### PR TITLE
feat(quota): durable default-user grace across restarts (#1200)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -698,6 +698,17 @@ bytes and inode count between identities. Limits live in the control-plane DB
 and are also manageable via the REST API
 (`/api/v1/shares/{name}/quotas[/{scope}/{id}]`).
 
+The **soft → grace → hard** state machine records when an identity first crosses
+its soft threshold and enforces the soft limit as hard once the grace window
+elapses. For an explicit user/group quota the grace timer lives on the quota
+row. For the **default-user** fallback the timer is inherently per-user (each
+user trips soft at a different time, and the single shared template row cannot
+hold per-user state), so it is recorded in a small side table keyed by
+`(share, uid)`, written the first time a default-user breaches soft and reaped
+when usage drops back under soft. This makes default-user grace **durable across
+a server restart** — a restart no longer hands every over-soft default user a
+fresh grace window.
+
 > **Note**: enforcement is best-effort (matching the per-share soft quota):
 > under high write concurrency a few operations may briefly exceed a limit until
 > usage catches up. This is standard for userspace NFS/SMB servers.

--- a/pkg/controlplane/models/models.go
+++ b/pkg/controlplane/models/models.go
@@ -9,6 +9,7 @@ func AllModels() []any {
 		&BlockStoreConfig{},
 		&Share{},
 		&Quota{},
+		&UserGrace{},
 		&Snapshot{},
 		&SnapshotPolicy{},
 		&RestoreMarker{},

--- a/pkg/controlplane/models/user_grace.go
+++ b/pkg/controlplane/models/user_grace.go
@@ -1,0 +1,41 @@
+package models
+
+import "time"
+
+// UserGrace is the durable per-real-user grace timer for a default-user quota
+// fallback. A default-user quota is a single shared template row (see Quota with
+// QuotaScopeDefaultUser) applied to every uid without an explicit quota, so its
+// grace state is inherently per-user: each user crosses the soft threshold at a
+// different time. That per-user state cannot live on the single shared Quota
+// row, so it is recorded here, keyed by (share_name, uid).
+//
+// Rows are written lazily the first time a default-user breaches their soft
+// threshold and reaped when usage drops back under soft, so growth is bounded by
+// the number of default-users currently in a grace window. Persisting these
+// makes default-user soft→grace→hard enforcement survive a server restart (the
+// multi-tenant common case where a default cap applies to everyone); without it
+// a restart hands every over-soft default user a fresh grace window.
+//
+// Explicit user/group quotas keep their own grace timer on the Quota row and do
+// not use this table.
+type UserGrace struct {
+	ID string `gorm:"primaryKey;size:36" json:"id"`
+
+	// ShareName is the share the grace timer belongs to.
+	ShareName string `gorm:"not null;size:255;uniqueIndex:idx_user_grace_identity" json:"share_name"`
+
+	// UID is the real user id whose default-user grace window this records.
+	UID uint32 `gorm:"not null;uniqueIndex:idx_user_grace_identity" json:"uid"`
+
+	// GraceStartedAt records when this user first crossed the default-user soft
+	// threshold. Always set for a stored row (the row is deleted to clear).
+	GraceStartedAt time.Time `gorm:"not null" json:"grace_started_at"`
+
+	CreatedAt time.Time `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+}
+
+// TableName returns the table name for UserGrace.
+func (UserGrace) TableName() string {
+	return "user_grace"
+}

--- a/pkg/controlplane/runtime/quota.go
+++ b/pkg/controlplane/runtime/quota.go
@@ -68,6 +68,40 @@ func (r *Runtime) LoadIdentityQuotasForShare(ctx context.Context, shareName stri
 	return nil
 }
 
+// LoadDefaultUserGraceForShare restores the durable per-real-user default-user
+// grace timers for a share from the control-plane DB into the metadata service.
+// Called during AddShare (after LoadIdentityQuotasForShare) so default-user
+// soft→grace→hard enforcement survives a restart.
+func (r *Runtime) LoadDefaultUserGraceForShare(ctx context.Context, shareName string) error {
+	// No control-plane store (test fixtures, embedded use): nothing to load.
+	if r.store == nil {
+		return nil
+	}
+	rows, err := r.store.ListUserGrace(ctx, shareName)
+	if err != nil {
+		return err
+	}
+	byUID := make(map[uint32]time.Time, len(rows))
+	for _, g := range rows {
+		byUID[g.UID] = g.GraceStartedAt
+	}
+	r.metadataService.SeedDefaultUserGrace(shareName, byUID)
+	return nil
+}
+
+// PurgeDefaultUserGrace removes all durable default-user grace timers for a
+// share. Called when the share is removed or its default-user quota is deleted,
+// so stale rows cannot accumulate once the fallback no longer applies.
+// Best-effort: failures are logged, not surfaced.
+func (r *Runtime) PurgeDefaultUserGrace(ctx context.Context, shareName string) {
+	if r.store == nil {
+		return
+	}
+	if err := r.store.DeleteUserGraceForShare(ctx, shareName); err != nil {
+		logger.Warn("failed to purge default-user grace timers", "share", shareName, "error", err)
+	}
+}
+
 // UpdateIdentityQuota hot-updates a single per-identity quota in the metadata
 // service from a persisted model row. Mirrors UpdateShareQuota.
 func (r *Runtime) UpdateIdentityQuota(q *models.Quota) {
@@ -84,6 +118,31 @@ func (r *Runtime) RemoveIdentityQuota(shareName, scope string, identityID *uint3
 		return
 	}
 	r.metadataService.RemoveIdentityQuota(shareName, mScope, id)
+	switch {
+	case scope == models.QuotaScopeDefaultUser:
+		// Removing the default-user quota retires the fallback entirely, so its
+		// per-real-user grace timers (durable + in-memory) are now dead state.
+		// Purge the durable rows and drop the in-memory map so nothing leaks.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		r.PurgeDefaultUserGrace(ctx, shareName)
+		r.metadataService.SeedDefaultUserGrace(shareName, nil)
+	case scope == models.QuotaScopeUser && identityID != nil:
+		// Removing an explicit user quota reverts this uid to the default-user
+		// fallback. Clear any stale default-user grace timer (in-memory +
+		// durable) so the uid starts a fresh window on its next soft breach
+		// rather than inheriting an expired one left from before the explicit
+		// quota was installed (which would wrongly block writes immediately).
+		r.metadataService.ClearDefaultUserGrace(shareName, *identityID)
+		if r.store != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := r.store.DeleteUserGrace(ctx, shareName, *identityID); err != nil {
+				logger.Warn("failed to reap default-user grace on explicit quota removal",
+					"share", shareName, "uid", *identityID, "error", err)
+			}
+		}
+	}
 }
 
 // GetIdentityQuotaUsage returns the live per-identity usage (bytes + file count)
@@ -169,5 +228,24 @@ func (p *quotaGracePersister) PersistQuotaGrace(shareName string, scope metadata
 	if err := p.rt.store.SetQuotaGraceStartedAt(ctx, shareName, modelScope, identityID, tp); err != nil {
 		logger.Warn("failed to persist quota grace timer",
 			"share", shareName, "scope", modelScope, "error", err)
+	}
+}
+
+// PersistDefaultUserGrace durably records (zero t reaps) the per-real-user grace
+// timer for a default-user quota fallback, keyed by (share, uid) in the
+// user_grace side table. Best-effort: errors are logged, not surfaced to the
+// write path.
+func (p *quotaGracePersister) PersistDefaultUserGrace(shareName string, uid uint32, t time.Time) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var err error
+	if t.IsZero() {
+		err = p.rt.store.DeleteUserGrace(ctx, shareName, uid)
+	} else {
+		err = p.rt.store.SetUserGrace(ctx, shareName, uid, t)
+	}
+	if err != nil {
+		logger.Warn("failed to persist default-user grace timer",
+			"share", shareName, "uid", uid, "error", err)
 	}
 }

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -416,6 +416,11 @@ func (r *Runtime) AddShare(ctx context.Context, config *ShareConfig) error {
 	if err := r.LoadIdentityQuotasForShare(ctx, config.Name); err != nil {
 		logger.Warn("failed to load identity quotas for share", "share", config.Name, "error", err)
 	}
+	// Restore durable default-user grace timers so default-user soft→grace→hard
+	// enforcement survives a restart. Best-effort, same as identity quotas.
+	if err := r.LoadDefaultUserGraceForShare(ctx, config.Name); err != nil {
+		logger.Warn("failed to load default-user grace timers for share", "share", config.Name, "error", err)
+	}
 	return nil
 }
 
@@ -452,6 +457,12 @@ func (r *Runtime) RemoveShare(name string) error {
 	// registration above. Without this the service maps grow unbounded across
 	// add/remove churn and a same-name re-add reuses the stale lock manager.
 	r.metadataService.RemoveStoreForShare(name)
+	// Purge durable default-user grace timers for the gone share so the
+	// user_grace side table cannot accumulate orphan rows across add/remove
+	// churn. Best-effort, off the critical path.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	r.PurgeDefaultUserGrace(ctx, name)
 	return rmErr
 }
 

--- a/pkg/controlplane/store/interface.go
+++ b/pkg/controlplane/store/interface.go
@@ -248,6 +248,21 @@ type QuotaStore interface {
 
 	// SetQuotaGraceStartedAt persists a grace-timer transition (nil clears it).
 	SetQuotaGraceStartedAt(ctx context.Context, shareName, scope string, identityID *uint32, t *time.Time) error
+
+	// ListUserGrace returns the durable per-real-user default-user grace timers
+	// for a share, used to reseed the in-memory map after a restart.
+	ListUserGrace(ctx context.Context, shareName string) ([]*models.UserGrace, error)
+
+	// SetUserGrace upserts the durable default-user grace timer for (share, uid).
+	SetUserGrace(ctx context.Context, shareName string, uid uint32, t time.Time) error
+
+	// DeleteUserGrace removes the durable default-user grace timer for
+	// (share, uid). A missing row is not an error.
+	DeleteUserGrace(ctx context.Context, shareName string, uid uint32) error
+
+	// DeleteUserGraceForShare removes all durable default-user grace timers for a
+	// share (on share removal or default-user quota deletion).
+	DeleteUserGraceForShare(ctx context.Context, shareName string) error
 }
 
 // PermissionStore provides user and group share permission operations.

--- a/pkg/controlplane/store/user_grace.go
+++ b/pkg/controlplane/store/user_grace.go
@@ -1,0 +1,60 @@
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm/clause"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// ListUserGrace returns all durable default-user grace timers for a share. Used
+// to reseed the metadata service's in-memory per-user grace map at share load so
+// default-user soft→grace→hard enforcement survives a restart.
+func (s *GORMStore) ListUserGrace(ctx context.Context, shareName string) ([]*models.UserGrace, error) {
+	var rows []*models.UserGrace
+	if err := s.db.WithContext(ctx).
+		Where("share_name = ?", shareName).
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// SetUserGrace upserts the durable default-user grace timer for (share, uid).
+// Written lazily the first time a default-user breaches their soft threshold.
+func (s *GORMStore) SetUserGrace(ctx context.Context, shareName string, uid uint32, t time.Time) error {
+	row := &models.UserGrace{
+		ID:             uuid.New().String(),
+		ShareName:      shareName,
+		UID:            uid,
+		GraceStartedAt: t,
+	}
+	// Upsert on the (share_name, uid) unique index: a concurrent enforce for the
+	// same user must not error, just refresh the timestamp.
+	return s.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "share_name"}, {Name: "uid"}},
+		DoUpdates: clause.AssignmentColumns([]string{"grace_started_at", "updated_at"}),
+	}).Create(row).Error
+}
+
+// DeleteUserGrace removes the durable default-user grace timer for (share, uid).
+// Called when usage drops back under the soft threshold (reap). A missing row is
+// not an error: clearing is best-effort from the enforcer hot path.
+func (s *GORMStore) DeleteUserGrace(ctx context.Context, shareName string, uid uint32) error {
+	return s.db.WithContext(ctx).
+		Where("share_name = ? AND uid = ?", shareName, uid).
+		Delete(&models.UserGrace{}).Error
+}
+
+// DeleteUserGraceForShare removes every durable default-user grace timer for a
+// share. Called when the share is removed or its default-user quota is deleted,
+// so stale rows cannot accumulate once the default-user fallback no longer
+// applies.
+func (s *GORMStore) DeleteUserGraceForShare(ctx context.Context, shareName string) error {
+	return s.db.WithContext(ctx).
+		Where("share_name = ?", shareName).
+		Delete(&models.UserGrace{}).Error
+}

--- a/pkg/controlplane/store/user_grace_test.go
+++ b/pkg/controlplane/store/user_grace_test.go
@@ -1,0 +1,126 @@
+//go:build integration
+
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestUserGrace_SetListDelete_RoundTrip(t *testing.T) {
+	store := createTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	t0 := time.Now().UTC().Truncate(time.Second)
+
+	if err := store.SetUserGrace(ctx, "alpha", 1000, t0); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if err := store.SetUserGrace(ctx, "alpha", 1001, t0.Add(time.Minute)); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	// A row for a different share must not bleed into alpha's listing.
+	if err := store.SetUserGrace(ctx, "beta", 1000, t0); err != nil {
+		t.Fatalf("set beta: %v", err)
+	}
+
+	rows, err := store.ListUserGrace(ctx, "alpha")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("alpha rows = %d, want 2", len(rows))
+	}
+	got := map[uint32]time.Time{}
+	for _, r := range rows {
+		got[r.UID] = r.GraceStartedAt.UTC().Truncate(time.Second)
+	}
+	if !got[1000].Equal(t0) {
+		t.Errorf("uid 1000 grace = %v, want %v", got[1000], t0)
+	}
+	if !got[1001].Equal(t0.Add(time.Minute)) {
+		t.Errorf("uid 1001 grace = %v, want %v", got[1001], t0.Add(time.Minute))
+	}
+
+	// Delete one row; the other survives.
+	if err := store.DeleteUserGrace(ctx, "alpha", 1000); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	rows, err = store.ListUserGrace(ctx, "alpha")
+	if err != nil {
+		t.Fatalf("list after delete: %v", err)
+	}
+	if len(rows) != 1 || rows[0].UID != 1001 {
+		t.Fatalf("after delete, rows = %+v, want only uid 1001", rows)
+	}
+
+	// Deleting a missing row is not an error (best-effort reap).
+	if err := store.DeleteUserGrace(ctx, "alpha", 999); err != nil {
+		t.Errorf("delete missing row: %v", err)
+	}
+}
+
+func TestUserGrace_SetIsUpsert(t *testing.T) {
+	store := createTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	t0 := time.Now().UTC().Truncate(time.Second)
+	if err := store.SetUserGrace(ctx, "alpha", 1000, t0); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	// Re-set the same (share, uid) with a later time: refreshes, no duplicate.
+	t1 := t0.Add(2 * time.Hour)
+	if err := store.SetUserGrace(ctx, "alpha", 1000, t1); err != nil {
+		t.Fatalf("re-set: %v", err)
+	}
+
+	rows, err := store.ListUserGrace(ctx, "alpha")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1 (upsert, not insert)", len(rows))
+	}
+	if !rows[0].GraceStartedAt.UTC().Truncate(time.Second).Equal(t1) {
+		t.Errorf("grace = %v, want refreshed %v", rows[0].GraceStartedAt, t1)
+	}
+}
+
+func TestUserGrace_DeleteForShare(t *testing.T) {
+	store := createTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	t0 := time.Now().UTC()
+	for _, uid := range []uint32{1000, 1001, 1002} {
+		if err := store.SetUserGrace(ctx, "alpha", uid, t0); err != nil {
+			t.Fatalf("set %d: %v", uid, err)
+		}
+	}
+	if err := store.SetUserGrace(ctx, "beta", 1000, t0); err != nil {
+		t.Fatalf("set beta: %v", err)
+	}
+
+	if err := store.DeleteUserGraceForShare(ctx, "alpha"); err != nil {
+		t.Fatalf("delete for share: %v", err)
+	}
+
+	rows, err := store.ListUserGrace(ctx, "alpha")
+	if err != nil {
+		t.Fatalf("list alpha: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("alpha rows after purge = %d, want 0", len(rows))
+	}
+	// beta is untouched.
+	rows, err = store.ListUserGrace(ctx, "beta")
+	if err != nil {
+		t.Fatalf("list beta: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("beta rows = %d, want 1", len(rows))
+	}
+}

--- a/pkg/metadata/quota_enforce.go
+++ b/pkg/metadata/quota_enforce.go
@@ -122,7 +122,12 @@ func (s *Service) liveGrace(shareName string, scope QuotaScope, usageID uint32, 
 
 func (s *Service) startGrace(shareName string, scope QuotaScope, usageID uint32, isDefaultUserFallback bool, rowID uint32, t time.Time) {
 	if isDefaultUserFallback {
-		s.identityQuotas.setDynGrace(shareName, scope, usageID, t)
+		// Per-real-user grace for a default-user fallback. Persist the durable
+		// side-table copy only when the in-memory timer actually changed, so it
+		// survives a restart without churning the DB on every write.
+		if s.identityQuotas.setDynGrace(shareName, scope, usageID, t) {
+			s.persistDefaultUserGrace(shareName, usageID, t)
+		}
 		return
 	}
 	if s.identityQuotas.updateGraceStartedAt(shareName, scope, rowID, t) {
@@ -132,7 +137,12 @@ func (s *Service) startGrace(shareName string, scope QuotaScope, usageID uint32,
 
 func (s *Service) clearGrace(shareName string, scope QuotaScope, usageID uint32, isDefaultUserFallback bool, rowID uint32) {
 	if isDefaultUserFallback {
-		s.identityQuotas.setDynGrace(shareName, scope, usageID, time.Time{})
+		// Reap the durable timer only when one was actually running: clearGrace
+		// fires on every under-soft op, so the changed-guard avoids a DB delete
+		// per write for users that were never in grace.
+		if s.identityQuotas.setDynGrace(shareName, scope, usageID, time.Time{}) {
+			s.persistDefaultUserGrace(shareName, usageID, time.Time{})
+		}
 		return
 	}
 	if s.identityQuotas.updateGraceStartedAt(shareName, scope, rowID, time.Time{}) {
@@ -146,5 +156,14 @@ func (s *Service) persistGrace(shareName string, scope QuotaScope, id uint32, t 
 	s.mu.RUnlock()
 	if p != nil {
 		p.PersistQuotaGrace(shareName, scope, id, t)
+	}
+}
+
+func (s *Service) persistDefaultUserGrace(shareName string, uid uint32, t time.Time) {
+	s.mu.RLock()
+	p := s.quotaGracePersist
+	s.mu.RUnlock()
+	if p != nil {
+		p.PersistDefaultUserGrace(shareName, uid, t)
 	}
 }

--- a/pkg/metadata/quota_grace_durable_test.go
+++ b/pkg/metadata/quota_grace_durable_test.go
@@ -1,0 +1,175 @@
+package metadata_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeGracePersister stands in for the control-plane durable grace store. It
+// captures the per-real-user default-user grace timers the enforcer persists, so
+// a test can simulate a restart by reseeding a fresh Service from the captured
+// state.
+type fakeGracePersister struct {
+	mu sync.Mutex
+	// dynamic maps real uid -> grace start for default-user fallbacks. A reap
+	// (zero t) deletes the entry, mirroring the user_grace side table.
+	dynamic map[uint32]time.Time
+}
+
+func newFakeGracePersister() *fakeGracePersister {
+	return &fakeGracePersister{dynamic: map[uint32]time.Time{}}
+}
+
+func (f *fakeGracePersister) PersistQuotaGrace(string, metadata.QuotaScope, uint32, time.Time) {
+}
+
+func (f *fakeGracePersister) PersistDefaultUserGrace(_ string, uid uint32, t time.Time) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if t.IsZero() {
+		delete(f.dynamic, uid)
+		return
+	}
+	f.dynamic[uid] = t
+}
+
+func (f *fakeGracePersister) snapshot() map[uint32]time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make(map[uint32]time.Time, len(f.dynamic))
+	for k, v := range f.dynamic {
+		out[k] = v
+	}
+	return out
+}
+
+// TestDefaultUserGrace_PersistsAndReaps verifies the enforcer durably records a
+// default-user grace timer on a soft breach and reaps it when projected usage
+// falls back under soft. The check is on PROJECTED usage (live counter + delta),
+// so two PrepareWrite calls on the same (still size-0) file drive the
+// start→clear transition without committing any writes.
+func TestDefaultUserGrace_PersistsAndReaps(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+	persist := newFakeGracePersister()
+	fx.service.SetQuotaGracePersister(persist)
+
+	fx.service.SetIdentityQuota(fx.shareName, metadata.IdentityQuota{
+		Scope:        metadata.QuotaScopeUser,
+		ID:           metadata.DefaultUserID,
+		SoftBytes:    100,
+		LimitBytes:   100000,
+		GraceSeconds: 3600,
+	})
+
+	user := fx.authContext(1000, 1000)
+	file, _, err := fx.service.CreateFile(user, fx.rootHandle, "f.bin", &metadata.FileAttr{Mode: 0o644})
+	require.NoError(t, err)
+	h := handleForFile(t, file)
+
+	// Projected 200 > soft 100 → grace starts and is persisted durably.
+	_, err = fx.service.PrepareWrite(user, h, 200)
+	require.NoError(t, err, "over-soft within grace must be allowed")
+	require.Contains(t, persist.snapshot(), uint32(1000), "soft breach must persist a durable grace timer")
+
+	// Projected 90 < soft 100 (file still size 0) → grace cleared and reaped.
+	_, err = fx.service.PrepareWrite(user, h, 90)
+	require.NoError(t, err)
+	require.NotContains(t, persist.snapshot(), uint32(1000), "drop under soft must reap the durable grace timer")
+}
+
+// TestDefaultUserGrace_SurvivesRestart verifies that a default-user's expired
+// grace, restored from the durable store after a restart, is enforced as hard —
+// rather than handing the user a fresh grace window (the #1200 gap). A user with
+// no seeded timer on the same restarted service still gets its own fresh grace,
+// proving the seed (not a blanket block) is what drives enforcement.
+func TestDefaultUserGrace_SurvivesRestart(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+
+	quota := metadata.IdentityQuota{
+		Scope:        metadata.QuotaScopeUser,
+		ID:           metadata.DefaultUserID,
+		SoftBytes:    100,
+		LimitBytes:   100000,
+		GraceSeconds: 3600, // 1h
+	}
+
+	// --- before restart: user 1000 breaches soft, starting a grace window. ---
+	persist := newFakeGracePersister()
+	fx.service.SetQuotaGracePersister(persist)
+	fx.service.SetIdentityQuota(fx.shareName, quota)
+
+	user := fx.authContext(1000, 1000)
+	file, _, err := fx.service.CreateFile(user, fx.rootHandle, "f.bin", &metadata.FileAttr{Mode: 0o644})
+	require.NoError(t, err)
+	h := handleForFile(t, file)
+	_, err = fx.service.PrepareWrite(user, h, 200)
+	require.NoError(t, err)
+	require.Contains(t, persist.snapshot(), uint32(1000))
+
+	// --- restart: fresh Service over the SAME store (usage survives). Seed the
+	// durable grace, backdated so the 1h window has already elapsed. ---
+	svc2 := metadata.New()
+	require.NoError(t, svc2.RegisterStoreForShare(fx.shareName, fx.store))
+	svc2.SetQuotaGracePersister(newFakeGracePersister())
+	svc2.SetIdentityQuota(fx.shareName, quota)
+	svc2.SeedDefaultUserGrace(fx.shareName, map[uint32]time.Time{
+		1000: time.Now().Add(-2 * time.Hour),
+	})
+
+	// User 1000's restored grace is expired → soft is enforced as hard.
+	_, err = svc2.PrepareWrite(user, h, 200)
+	require.Error(t, err, "expired grace restored across restart must block")
+	require.True(t, isQuotaErr(err), "want ErrQuotaExceeded, got %v", err)
+
+	// A different user with no seeded timer gets its own fresh grace window.
+	other := fx.authContext(1001, 1001)
+	ofile, _, err := svc2.CreateFile(other, fx.rootHandle, "g.bin", &metadata.FileAttr{Mode: 0o644})
+	require.NoError(t, err)
+	oh := handleForFile(t, ofile)
+	_, err = svc2.PrepareWrite(other, oh, 200)
+	require.NoError(t, err, "an unseen user's first breach must start a fresh grace, not inherit 1000's")
+}
+
+// TestDefaultUserGrace_ClearOnExplicitQuotaRemoval guards the edge case the
+// reviewer flagged: a uid that was in default-user grace, then got an explicit
+// quota, then had it removed, must NOT inherit the stale (possibly expired)
+// default-user timer when it reverts to the fallback — it should start fresh.
+// The runtime calls Service.ClearDefaultUserGrace on explicit-quota removal;
+// this test exercises that method directly.
+func TestDefaultUserGrace_ClearOnExplicitQuotaRemoval(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+	fx.service.SetIdentityQuota(fx.shareName, metadata.IdentityQuota{
+		Scope:        metadata.QuotaScopeUser,
+		ID:           metadata.DefaultUserID,
+		SoftBytes:    100,
+		LimitBytes:   100000,
+		GraceSeconds: 3600,
+	})
+
+	user := fx.authContext(1000, 1000)
+	file, _, err := fx.service.CreateFile(user, fx.rootHandle, "f.bin", &metadata.FileAttr{Mode: 0o644})
+	require.NoError(t, err)
+	h := handleForFile(t, file)
+
+	// Leftover stale default-user grace timer for uid 1000, already expired.
+	fx.service.SeedDefaultUserGrace(fx.shareName, map[uint32]time.Time{
+		1000: time.Now().Add(-2 * time.Hour),
+	})
+	// Sanity: while the stale timer is present, uid 1000 is wrongly blocked.
+	_, err = fx.service.PrepareWrite(user, h, 200)
+	require.True(t, isQuotaErr(err), "stale expired default-user grace should block until cleared, got %v", err)
+
+	// Clearing (what the runtime does on explicit-quota removal) drops the timer.
+	fx.service.ClearDefaultUserGrace(fx.shareName, 1000)
+
+	// uid 1000 now starts a fresh grace window instead of inheriting the expired one.
+	_, err = fx.service.PrepareWrite(user, h, 200)
+	require.NoError(t, err, "after clear, uid 1000 must start a fresh grace, not inherit the expired timer")
+}

--- a/pkg/metadata/quota_limits.go
+++ b/pkg/metadata/quota_limits.go
@@ -85,26 +85,58 @@ func (q *quotaLimits) dynGraceStartedAt(share string, scope QuotaScope, realID u
 	return time.Time{}
 }
 
-// setDynGrace sets (zero clears) the ephemeral default-user grace timer for a
-// real identity.
-func (q *quotaLimits) setDynGrace(share string, scope QuotaScope, realID uint32, t time.Time) {
+// setDynGrace sets (zero clears) the per-real-user default-user grace timer for
+// a real identity. It returns whether the stored value actually changed, so the
+// caller persists the durable copy only on a real transition (the clear path
+// runs on every under-soft write and must not churn the DB).
+func (q *quotaLimits) setDynGrace(share string, scope QuotaScope, realID uint32, t time.Time) bool {
 	q.mu.Lock()
 	defer q.mu.Unlock()
+	key := identityQuotaKey{scope, realID}
 	m := q.dynGrace[share]
 	if t.IsZero() {
-		if m != nil {
-			delete(m, identityQuotaKey{scope, realID})
-			if len(m) == 0 {
-				delete(q.dynGrace, share)
-			}
+		if m == nil {
+			return false
 		}
-		return
+		if _, ok := m[key]; !ok {
+			return false
+		}
+		delete(m, key)
+		if len(m) == 0 {
+			delete(q.dynGrace, share)
+		}
+		return true
 	}
 	if m == nil {
 		m = make(map[identityQuotaKey]time.Time)
 		q.dynGrace[share] = m
 	}
-	m[identityQuotaKey{scope, realID}] = t
+	if prev, ok := m[key]; ok && prev.Equal(t) {
+		return false
+	}
+	m[key] = t
+	return true
+}
+
+// seedDynGrace installs durable per-real-user default-user grace timers for a
+// share, replacing any existing ephemeral entries. Called at share load to
+// restore grace state persisted across a restart. Entries are keyed by real uid
+// under QuotaScopeUser (the only scope with a default-user fallback).
+func (q *quotaLimits) seedDynGrace(share string, byUID map[uint32]time.Time) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	m := make(map[identityQuotaKey]time.Time, len(byUID))
+	for uid, t := range byUID {
+		if t.IsZero() {
+			continue
+		}
+		m[identityQuotaKey{QuotaScopeUser, uid}] = t
+	}
+	if len(m) == 0 {
+		delete(q.dynGrace, share)
+		return
+	}
+	q.dynGrace[share] = m
 }
 
 // set installs or replaces a single identity quota for a share.

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -132,6 +132,16 @@ func New() *Service {
 // changes).
 type QuotaGracePersister interface {
 	PersistQuotaGrace(shareName string, scope QuotaScope, id uint32, t time.Time)
+
+	// PersistDefaultUserGrace durably records (zero t reaps) the per-real-user
+	// grace timer for a default-user quota fallback. uid is the REAL uid (not the
+	// DefaultUserID sentinel). Unlike an explicit quota — whose grace lives on its
+	// own row — a default-user quota is a single shared template row that cannot
+	// hold per-user grace, so the timer is stored in a side table keyed by
+	// (share, uid). Persisting it makes default-user soft→grace→hard enforcement
+	// survive a restart. Same best-effort, non-blocking contract as
+	// PersistQuotaGrace.
+	PersistDefaultUserGrace(shareName string, uid uint32, t time.Time)
 }
 
 // SetQuotaGracePersister installs the grace-timer persistence hook.
@@ -154,6 +164,24 @@ func (s *Service) RemoveIdentityQuota(shareName string, scope QuotaScope, id uin
 // ReplaceIdentityQuotas atomically replaces all per-identity quotas for a share.
 func (s *Service) ReplaceIdentityQuotas(shareName string, quotas []IdentityQuota) {
 	s.identityQuotas.replaceShare(shareName, quotas)
+}
+
+// SeedDefaultUserGrace restores the durable per-real-user default-user grace
+// timers for a share (keyed by real uid), replacing any existing ephemeral
+// entries. Called at share load so default-user soft→grace→hard enforcement
+// survives a restart.
+func (s *Service) SeedDefaultUserGrace(shareName string, byUID map[uint32]time.Time) {
+	s.identityQuotas.seedDynGrace(shareName, byUID)
+}
+
+// ClearDefaultUserGrace drops the in-memory per-real-user default-user grace
+// timer for a single uid on a share. Called when an explicit user quota is
+// removed and the uid reverts to the default-user fallback, so it does not
+// inherit a stale (possibly already-expired) grace window left over from before
+// the explicit quota was installed. The caller reaps the durable side-table row
+// separately.
+func (s *Service) ClearDefaultUserGrace(shareName string, uid uint32) {
+	s.identityQuotas.setDynGrace(shareName, QuotaScopeUser, uid, time.Time{})
 }
 
 // GetIdentityQuota returns the exact-keyed quota for (scope,id) on a share.


### PR DESCRIPTION
Closes #1200.

## Problem

The per-user/group quota soft→grace→hard state machine (#1151) persists the grace timer for **explicit** user/group quotas on their own DB row, but the **default-user** fallback is a single shared template row that cannot hold per-user grace. Its timer was kept in-memory only (`quotaLimits.dynGrace`, keyed by real uid) and **reset on restart** — so a restart handed every over-soft default user a fresh grace window, weakening soft enforcement in exactly the common multi-tenant case (a default cap on everyone, overrides for a few).

## Fix

Persist the per-`(share, uid)` default-user grace timer to a new control-plane table `user_grace`:

- **Lazy write** the first time a default-user breaches their soft threshold; **reap** when projected usage drops back under soft.
- **Seed** the in-memory map from the table at share load (`AddShare`), so soft→grace→hard survives a restart.
- `setDynGrace` now returns a *changed* bool so the durable copy is written only on a real transition — no DB write per under-soft write.
- **Bounded growth:** rows exist only for default-users currently in grace. Purged on share removal and default-user-quota deletion; and when a uid's explicit quota override is removed it reverts to the fallback, so its stale default-user timer (in-memory + durable) is cleared to avoid inheriting an expired window.

Explicit user/group quota behavior is unchanged.

## Design note

The durable state lives in the **control-plane GORM store** (new `UserGrace` model, AutoMigrate) — not a numbered metadata migration as the issue loosely suggested. This mirrors where quota *limits* and the existing explicit-grace persistence already live, and avoids the metadata 3-backend (memory/badger/postgres) conformance burden for what is control-plane policy state. Consistent with the `Quota` / `Snapshot` / `SnapshotPolicy` precedent.

## Tests

- `pkg/metadata/quota_grace_durable_test.go` — persist+reap on soft transitions; **expired grace restored across a simulated restart enforces as hard** while an unseen user still gets a fresh window; clear-on-explicit-quota-removal regression.
- `pkg/controlplane/store/user_grace_test.go` (integration) — Set/List/Delete round-trip, upsert (no duplicate), per-share isolation, purge-for-share.

`go build ./...`, `go vet ./...`, existing quota suite all green. No new CLI flags (no `gendocs` change).

## Review

code-simplifier: no changes needed. code-reviewer: found one real edge case (stale default-user timer inherited after an explicit quota override is added then removed) — fixed via `Service.ClearDefaultUserGrace` wired into `RemoveIdentityQuota`, with a regression test.