### PR TITLE
feat(metrics): adapter RED + connection + NFS auth instruments (PR-2 of #1188)

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -248,10 +248,17 @@ func runStart(cmd *cobra.Command, args []string) error {
 		"port", cfg.ControlPlane.Port,
 		"tls", apiServer.TLSEnabled())
 
+	// Build the metrics registry unconditionally so inline instruments (adapter
+	// RED, connection, auth counters) always record; only the /metrics listener
+	// is gated by config. The runtime carries the handle to every adapter.
+	m := metrics.New(Version, Commit)
+	m.RegisterProvider(rt)
+	rt.SetMetrics(m)
+
 	// Configure the Prometheus metrics endpoint (opt-in). It runs on its own
 	// listener, separate from the API server, so scrapers reach it without API
 	// auth and the two surfaces have independent lifecycles.
-	metricsServer, err := buildMetricsServer(&cfg.Metrics, rt)
+	metricsServer, err := buildMetricsListener(&cfg.Metrics, m)
 	if err != nil {
 		return err
 	}
@@ -326,15 +333,13 @@ func getConfigSource(configFile string) string {
 	return "defaults"
 }
 
-// buildMetricsServer constructs the Prometheus metrics listener when enabled,
-// wiring the runtime as the read-through metrics provider. Returns (nil, nil)
-// when metrics are disabled.
-func buildMetricsServer(cfg *config.MetricsConfig, rt *runtime.Runtime) (*metrics.Server, error) {
+// buildMetricsListener constructs the Prometheus metrics HTTP listener for the
+// given registry when the endpoint is enabled. Returns (nil, nil) when metrics
+// serving is disabled (the registry still exists and records inline metrics).
+func buildMetricsListener(cfg *config.MetricsConfig, m *metrics.Metrics) (*metrics.Server, error) {
 	if !cfg.Enabled {
 		return nil, nil
 	}
-	m := metrics.New(Version, Commit)
-	m.RegisterProvider(rt)
 
 	var token string
 	if cfg.Auth == "token" {

--- a/pkg/adapter/base.go
+++ b/pkg/adapter/base.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -288,6 +289,7 @@ func (b *BaseAdapter) ServeWithFactory(
 		// Track connection for graceful shutdown
 		b.activeConns.Add(1)
 		b.ConnCount.Add(1)
+		b.Registry.Metrics().RecordConnAccepted(strings.ToLower(b.protocolName))
 
 		// Register connection for forced closure capability
 		connAddr := tcpConn.RemoteAddr().String()
@@ -315,6 +317,7 @@ func (b *BaseAdapter) ServeWithFactory(
 				// Cleanup on connection close
 				b.activeConns.Done()
 				b.ConnCount.Add(-1)
+				b.Registry.Metrics().RecordConnClosed(strings.ToLower(b.protocolName))
 				if b.connSemaphore != nil {
 					<-b.connSemaphore
 				}

--- a/pkg/adapter/nfs/dispatch.go
+++ b/pkg/adapter/nfs/dispatch.go
@@ -64,6 +64,12 @@ func (c *NFSConnection) handleRPCCall(ctx context.Context, call *rpc.RPCCallMess
 		}
 		gssResult := c.server.gssProcessor.Process(ctx, call.GetAuthBody(), call.GetVerifierBody(), headerPreimage, procedureData)
 
+		// Record the Kerberos/RPCSEC_GSS auth outcome (skip silent discards,
+		// which are sequence drops rather than credential decisions).
+		if !gssResult.SilentDiscard {
+			c.server.Registry.Metrics().RecordAuth("nfs", "krb5", gssResult.Err == nil)
+		}
+
 		// Handle GSS processing errors (CREDPROBLEM / CTXPROBLEM)
 		if gssResult.Err != nil {
 			// Determine the auth_stat from the structured result field

--- a/pkg/adapter/nfs/handlers.go
+++ b/pkg/adapter/nfs/handlers.go
@@ -32,7 +32,10 @@ import (
 //
 // Returns the reply data or an error if the handler fails.
 // recordOp records one NFS operation for the RED metrics (rate, errors,
-// duration). ok is the protocol-level success of the operation.
+// duration). status is intentionally a bounded ok|error rather than the precise
+// NFS status code: labelling by raw status would multiply series by op ×
+// ~20 codes. The ok bit is derived accurately from the handler's NFSStatus (v3)
+// so it reflects protocol-level failures, not just transport errors.
 func (c *NFSConnection) recordOp(op string, start time.Time, ok bool) {
 	status := "ok"
 	if !ok {

--- a/pkg/adapter/nfs/handlers.go
+++ b/pkg/adapter/nfs/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"time"
 
 	nfs "github.com/marmos91/dittofs/internal/adapter/nfs"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/middleware"
@@ -30,6 +31,16 @@ import (
 // - Support graceful server shutdown
 //
 // Returns the reply data or an error if the handler fails.
+// recordOp records one NFS operation for the RED metrics (rate, errors,
+// duration). ok is the protocol-level success of the operation.
+func (c *NFSConnection) recordOp(op string, start time.Time, ok bool) {
+	status := "ok"
+	if !ok {
+		status = "error"
+	}
+	c.server.Registry.Metrics().RecordRequest("nfs", op, status, time.Since(start))
+}
+
 func (c *NFSConnection) handleNFSProcedure(ctx context.Context, call *rpc.RPCCallMessage, data []byte, clientAddr string) ([]byte, error) {
 	// Log first v3 call per server lifetime
 	c.server.logV3FirstUse()
@@ -115,12 +126,14 @@ func (c *NFSConnection) handleNFSProcedure(ctx context.Context, call *rpc.RPCCal
 	}
 
 	// Dispatch to handler
+	start := time.Now()
 	result, err := procedure.Handler(
 		handlerCtx,
 		c.server.nfsHandler,
 		c.server.Registry,
 		data,
 	)
+	c.recordOp(procedure.Name, start, err == nil && (result == nil || result.NFSStatus == 0))
 
 	if result == nil {
 		if useDRC {
@@ -172,12 +185,14 @@ func (c *NFSConnection) handleMountProcedure(ctx context.Context, call *rpc.RPCC
 	}
 
 	// Dispatch to handler
+	start := time.Now()
 	result, err := procedure.Handler(
 		handlerCtx,
 		c.server.mountHandler,
 		c.server.Registry,
 		data,
 	)
+	c.recordOp("MOUNT_"+procedure.Name, start, err == nil)
 
 	if result == nil {
 		return nil, err
@@ -238,12 +253,14 @@ func (c *NFSConnection) handleNLMProcedure(ctx context.Context, call *rpc.RPCCal
 	}
 
 	// Dispatch to handler
+	start := time.Now()
 	result, err := procedure.Handler(
 		handlerCtx,
 		c.server.nlmHandler,
 		c.server.Registry,
 		data,
 	)
+	c.recordOp("NLM_"+procedure.Name, start, err == nil)
 
 	if result == nil {
 		return nil, err
@@ -305,11 +322,13 @@ func (c *NFSConnection) handleNSMProcedure(ctx context.Context, call *rpc.RPCCal
 	}
 
 	// Dispatch to handler
+	start := time.Now()
 	result, err := procedure.Handler(
 		handlerCtx,
 		c.server.nsmHandler,
 		data,
 	)
+	c.recordOp("NSM_"+procedure.Name, start, err == nil)
 
 	if result == nil {
 		return nil, err
@@ -330,7 +349,10 @@ func (c *NFSConnection) handleNFSv4Procedure(ctx context.Context, call *rpc.RPCC
 
 	switch call.Procedure {
 	case v4types.NFSPROC4_NULL:
-		return c.server.v4Handler.HandleNull(data)
+		start := time.Now()
+		reply, err := c.server.v4Handler.HandleNull(data)
+		c.recordOp("NULL", start, err == nil)
+		return reply, err
 
 	case v4types.NFSPROC4_COMPOUND:
 		// Extract CompoundContext with auth credentials
@@ -350,7 +372,13 @@ func (c *NFSConnection) handleNFSv4Procedure(ctx context.Context, call *rpc.RPCC
 		}
 		compCtx.ConnectionID = c.connectionID
 
+		// COMPOUND status here is coarse: per-op NFS4ERR codes are encoded inside
+		// the XDR result and the RPC always succeeds, so err only reflects
+		// wire/decode failures. Per-op v4 RED needs ProcessCompound to surface a
+		// status (follow-up); this records traffic + latency + transport errors.
+		start := time.Now()
 		result, err := c.server.v4Handler.ProcessCompound(compCtx, data)
+		c.recordOp("COMPOUND", start, err == nil)
 
 		// After COMPOUND completes, check if this connection was bound for
 		// back-channel. If so, register a ConnWriter and PendingCBReplies

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -20,6 +20,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
 	"github.com/marmos91/dittofs/pkg/health"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metrics"
 )
 
 // DefaultShutdownTimeout is the default timeout for graceful shutdown.
@@ -71,6 +72,12 @@ type Runtime struct {
 	identitySvc    *identity.Service
 	mountTracker   *MountTracker
 	clientRegistry *ClientRegistry
+
+	// metrics is the Prometheus metrics handle, set at startup. It is the
+	// carrier for inline adapter instruments (RED, connection, auth counters):
+	// adapters reach it via Runtime so no per-adapter plumbing is needed. May
+	// be nil; all metrics.Metrics Record* methods are nil-safe.
+	metrics *metrics.Metrics
 
 	// trashSvc is the recycle-bin service (list/restore/empty + reaper),
 	// constructed lazily by Trash() and started/stopped by the lifecycle
@@ -566,6 +573,21 @@ func (r *Runtime) GetBlockStoreForHandle(ctx context.Context, handle metadata.Fi
 
 func (r *Runtime) SetAPIServer(server AuxiliaryServer) {
 	r.lifecycleSvc.SetAPIServer(server)
+}
+
+// SetMetrics installs the Prometheus metrics handle. Call once at startup
+// before Serve. Passing nil disables inline instrument recording.
+func (r *Runtime) SetMetrics(m *metrics.Metrics) {
+	r.metrics = m
+}
+
+// Metrics returns the Prometheus metrics handle (may be nil). All Record*
+// methods on the returned value are nil-safe, so callers need not check.
+func (r *Runtime) Metrics() *metrics.Metrics {
+	if r == nil {
+		return nil
+	}
+	return r.metrics
 }
 
 func (r *Runtime) Serve(ctx context.Context) error {

--- a/pkg/metrics/instruments.go
+++ b/pkg/metrics/instruments.go
@@ -11,8 +11,10 @@ import (
 // emits existing state at scrape time. They are registered on the owned
 // registry in New.
 //
-// All Record* methods are nil-receiver safe: when metrics are disabled no
-// *Metrics is constructed, so call sites can invoke them unconditionally.
+// All Record* methods are nil-receiver safe so call sites can invoke them
+// unconditionally: a call site that holds no metrics handle (a nil *Metrics)
+// simply no-ops. (The server itself builds the registry unconditionally and
+// gates only the /metrics listener, but other callers/tests may pass nil.)
 type instruments struct {
 	requests     *prometheus.CounterVec   // {protocol,op,status}
 	reqDuration  *prometheus.HistogramVec // {protocol,op}

--- a/pkg/metrics/instruments.go
+++ b/pkg/metrics/instruments.go
@@ -1,0 +1,93 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// instruments holds the inline, event-driven metrics (counters/histograms)
+// incremented at call sites — distinct from the read-through collector, which
+// emits existing state at scrape time. They are registered on the owned
+// registry in New.
+//
+// All Record* methods are nil-receiver safe: when metrics are disabled no
+// *Metrics is constructed, so call sites can invoke them unconditionally.
+type instruments struct {
+	requests     *prometheus.CounterVec   // {protocol,op,status}
+	reqDuration  *prometheus.HistogramVec // {protocol,op}
+	connsTotal   *prometheus.CounterVec   // {protocol}
+	connsClosed  *prometheus.CounterVec   // {protocol}
+	authAttempts *prometheus.CounterVec   // {protocol,mechanism}
+	authFailures *prometheus.CounterVec   // {protocol,mechanism}
+}
+
+func newInstruments(reg *prometheus.Registry) *instruments {
+	factory := prometheus.NewCounterVec
+	in := &instruments{
+		requests: factory(prometheus.CounterOpts{
+			Namespace: Namespace, Subsystem: "adapter", Name: "requests_total",
+			Help: "Protocol requests handled, by protocol, operation, and status (ok|error).",
+		}, []string{"protocol", "op", "status"}),
+		reqDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: Namespace, Subsystem: "adapter", Name: "request_duration_seconds",
+			Help:    "Protocol request handling latency in seconds, by protocol and operation.",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"protocol", "op"}),
+		connsTotal: factory(prometheus.CounterOpts{
+			Namespace: Namespace, Subsystem: "adapter", Name: "connections_total",
+			Help: "Connections accepted since process start, by protocol.",
+		}, []string{"protocol"}),
+		connsClosed: factory(prometheus.CounterOpts{
+			Namespace: Namespace, Subsystem: "adapter", Name: "connections_closed_total",
+			Help: "Connections closed since process start, by protocol. Active = total - closed.",
+		}, []string{"protocol"}),
+		authAttempts: factory(prometheus.CounterOpts{
+			Namespace: Namespace, Subsystem: "auth", Name: "attempts_total",
+			Help: "Authentication attempts, by protocol and mechanism (sys|krb5|ntlm).",
+		}, []string{"protocol", "mechanism"}),
+		authFailures: factory(prometheus.CounterOpts{
+			Namespace: Namespace, Subsystem: "auth", Name: "failures_total",
+			Help: "Failed authentication attempts, by protocol and mechanism (sys|krb5|ntlm).",
+		}, []string{"protocol", "mechanism"}),
+	}
+	reg.MustRegister(in.requests, in.reqDuration, in.connsTotal, in.connsClosed, in.authAttempts, in.authFailures)
+	return in
+}
+
+// RecordRequest records one handled protocol request: its count (by status) and
+// its latency. status should be "ok" or "error".
+func (m *Metrics) RecordRequest(protocol, op, status string, d time.Duration) {
+	if m == nil {
+		return
+	}
+	m.in.requests.WithLabelValues(protocol, op, status).Inc()
+	m.in.reqDuration.WithLabelValues(protocol, op).Observe(d.Seconds())
+}
+
+// RecordConnAccepted counts an accepted connection.
+func (m *Metrics) RecordConnAccepted(protocol string) {
+	if m == nil {
+		return
+	}
+	m.in.connsTotal.WithLabelValues(protocol).Inc()
+}
+
+// RecordConnClosed counts a closed connection.
+func (m *Metrics) RecordConnClosed(protocol string) {
+	if m == nil {
+		return
+	}
+	m.in.connsClosed.WithLabelValues(protocol).Inc()
+}
+
+// RecordAuth records an authentication attempt and, when ok is false, a failure.
+func (m *Metrics) RecordAuth(protocol, mechanism string, ok bool) {
+	if m == nil {
+		return
+	}
+	m.in.authAttempts.WithLabelValues(protocol, mechanism).Inc()
+	if !ok {
+		m.in.authFailures.WithLabelValues(protocol, mechanism).Inc()
+	}
+}

--- a/pkg/metrics/instruments_test.go
+++ b/pkg/metrics/instruments_test.go
@@ -1,0 +1,64 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestInstruments_RecordRequest(t *testing.T) {
+	m := New("t", "c")
+	m.RecordRequest("nfs", "READ", "ok", 5*time.Millisecond)
+	m.RecordRequest("nfs", "READ", "error", time.Millisecond)
+	m.RecordRequest("smb", "Create", "ok", time.Millisecond)
+
+	expected := `
+# HELP dittofs_adapter_requests_total Protocol requests handled, by protocol, operation, and status (ok|error).
+# TYPE dittofs_adapter_requests_total counter
+dittofs_adapter_requests_total{op="Create",protocol="smb",status="ok"} 1
+dittofs_adapter_requests_total{op="READ",protocol="nfs",status="error"} 1
+dittofs_adapter_requests_total{op="READ",protocol="nfs",status="ok"} 1
+`
+	if err := testutil.GatherAndCompare(m.Registry(), strings.NewReader(expected), "dittofs_adapter_requests_total"); err != nil {
+		t.Fatalf("requests_total mismatch: %v", err)
+	}
+	if got := testutil.CollectAndCount(m.Registry(), "dittofs_adapter_request_duration_seconds"); got == 0 {
+		t.Fatal("expected request_duration_seconds series")
+	}
+}
+
+func TestInstruments_ConnAndAuth(t *testing.T) {
+	m := New("t", "c")
+	m.RecordConnAccepted("nfs")
+	m.RecordConnAccepted("nfs")
+	m.RecordConnClosed("nfs")
+	m.RecordAuth("smb", "ntlm", false)
+	m.RecordAuth("smb", "ntlm", true)
+
+	expected := `
+# HELP dittofs_adapter_connections_total Connections accepted since process start, by protocol.
+# TYPE dittofs_adapter_connections_total counter
+dittofs_adapter_connections_total{protocol="nfs"} 2
+# HELP dittofs_auth_attempts_total Authentication attempts, by protocol and mechanism (sys|krb5|ntlm).
+# TYPE dittofs_auth_attempts_total counter
+dittofs_auth_attempts_total{mechanism="ntlm",protocol="smb"} 2
+# HELP dittofs_auth_failures_total Failed authentication attempts, by protocol and mechanism (sys|krb5|ntlm).
+# TYPE dittofs_auth_failures_total counter
+dittofs_auth_failures_total{mechanism="ntlm",protocol="smb"} 1
+`
+	if err := testutil.GatherAndCompare(m.Registry(), strings.NewReader(expected),
+		"dittofs_adapter_connections_total", "dittofs_auth_attempts_total", "dittofs_auth_failures_total"); err != nil {
+		t.Fatalf("conn/auth mismatch: %v", err)
+	}
+}
+
+func TestInstruments_NilSafe(t *testing.T) {
+	var m *Metrics
+	// Must not panic on nil receiver.
+	m.RecordRequest("nfs", "READ", "ok", time.Millisecond)
+	m.RecordConnAccepted("nfs")
+	m.RecordConnClosed("nfs")
+	m.RecordAuth("nfs", "krb5", false)
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -17,6 +17,7 @@ const Namespace = "dittofs"
 // testable and isolated.
 type Metrics struct {
 	registry *prometheus.Registry
+	in       *instruments
 }
 
 // New creates a Metrics with an owned registry pre-populated with the Go
@@ -38,7 +39,7 @@ func New(version, commit string) *Metrics {
 	buildInfo.Set(1)
 	reg.MustRegister(buildInfo)
 
-	return &Metrics{registry: reg}
+	return &Metrics{registry: reg, in: newInstruments(reg)}
 }
 
 // RegisterProvider wires a read-through collector backed by p. The collector


### PR DESCRIPTION
## Summary

PR-2 of #1188 — inline Prometheus instruments at the protocol-adapter chokepoints. Builds on the `pkg/metrics` registry from PR-1 (#1201). Additive; the registry is now built unconditionally so instruments always record, with only the `/metrics` listener gated by config.

### Instruments (owned by `pkg/metrics`, nil-safe `Record*` methods)
- `dittofs_adapter_requests_total{protocol,op,status}` + `dittofs_adapter_request_duration_seconds{protocol,op}` — RED. Wired for **NFS**: v3 uses precise `NFSStatus`; mount/nlm/nsm/v4 use coarse (err-based) status. v4 COMPOUND status is RPC-level only (per-op `NFS4ERR` lives inside the XDR result — documented; true per-op v4 RED is a follow-up).
- `dittofs_adapter_connections_total{protocol}` + `dittofs_adapter_connections_closed_total{protocol}` — recorded at the **shared** `base.go` accept/close points, so this covers **both NFS and SMB**. Active = total − closed.
- `dittofs_auth_attempts_total{protocol,mechanism}` + `dittofs_auth_failures_total{protocol,mechanism}` — at the NFS `rpcsec_gss` boundary (`mechanism="krb5"`).

### Wiring
The runtime carries the `*metrics.Metrics` handle (`SetMetrics`/`Metrics()`); adapters reach it via `Runtime` (`b.Registry.Metrics()`), so there's no per-adapter or AdapterFactory plumbing. `Metrics()` is nil-safe even on a nil `*Runtime`, and every `Record*` method guards a nil receiver — so call sites are unconditional and test adapters without a registry are safe.

### Cardinality
`op` values come from the fixed dispatch tables (bounded); labels are `protocol`/`op`/`status`/`mechanism` only.

### Verification
`go build ./...` clean; `pkg/metrics` (incl. new instrument tests: requests/conn/auth + nil-safe receiver), `pkg/adapter`, `pkg/adapter/nfs` all green. Reviewer pass addressed (added NSM + v4 NULL recording; documented v4 COMPOUND coarse status).

### Deferred to PR-2b
SMB per-command RED + SMB session auth-failure counters — the internal SMB dispatch deliberately avoids `pkg/` imports, so threading metrics through `ConnInfo`/`ProcessSingleRequest` is a separate, more invasive change. (SMB connection counts are already covered here via `base.go`.)

Refs #1188.
