### PR TITLE
feat(metadata): UUID-based PayloadID for new files (PR-3 of #1166)

### DIFF
--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -1343,13 +1343,16 @@ func (h *Handler) closeFilesWithFilter(
 }
 
 // purgeBlockStorePayload best-effort deletes a deleted file's block-store
-// payload. PayloadIDs are path-derived (metadata.buildPayloadID), so a later
-// create at the same path reuses the same PayloadID; without this purge the
-// recreated file would read stale bytes from the prior file's append log
-// (e.g. a sparse hole would surface non-zero bytes —
-// smb2.ioctl.copy_chunk_sparse_dest). Callers invoke this only AFTER the
-// metadata removal succeeds, so a block-store miss is harmless and GC reclaims
-// any straggler CAS chunks; all errors are logged at Debug and swallowed.
+// payload using that file's own stored PayloadID. Files created after #1166
+// PR-3 get a UUID-based PayloadID (metadata.buildPayloadID), so a recreate at
+// the same path now gets a fresh content_id and cannot collide with this
+// file's bytes. This purge is still required to reclaim the deleted file's
+// append-log/CAS state (otherwise its append log and tracked size would leak;
+// historically a path-derived recreate could even read its stale bytes —
+// e.g. a sparse hole surfacing non-zero bytes, smb2.ioctl.copy_chunk_sparse_dest).
+// Callers invoke this only AFTER the metadata removal succeeds, so a block-store
+// miss is harmless and GC reclaims any straggler CAS chunks; all errors are
+// logged at Debug and swallowed.
 func (h *Handler) purgeBlockStorePayload(ctx context.Context, handle metadata.FileHandle, payloadID metadata.PayloadID, path, caller string) {
 	if payloadID == "" || len(handle) == 0 {
 		return

--- a/internal/adapter/smb/handlers/ioctl_copychunk_sparse_integration_test.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk_sparse_integration_test.go
@@ -249,15 +249,16 @@ func TestCopyChunk_SparseDest_LeadingGapReadsZeros(t *testing.T) {
 // TestCopyChunk_SparseDest_SurvivesPriorPayloadReuse reproduces the
 // full-battery pollution that broke smb2.ioctl.copy_chunk_sparse_dest at
 // ioctl.c:1772 ("sparse did not pass class") even though the standalone run
-// passed. PayloadIDs are path-derived, so an earlier copychunk test
-// (copy_chunk_src_exceed_multi) writes a NON-ZERO pattern into the dest path's
-// leading region, then the dest is unlinked and recreated at the SAME path —
-// reusing the same PayloadID. If the unlink does not purge the block-store
-// append log, the recreated 0-byte dest's sparse hole reads the prior file's
-// stale non-zero bytes.
+// passed. An earlier copychunk test (copy_chunk_src_exceed_multi) writes a
+// NON-ZERO pattern into the dest path's leading region, then the dest is
+// unlinked and recreated at the SAME path.
 //
-// This drives the REAL delete-on-close path (Handler.Close with DeletePending),
-// which must purge the block-store payload so the recreate reads zeros.
+// Since #1166 PR-3 a recreated file gets a FRESH UUID-based PayloadID, so the
+// new dest reads its sparse hole as zeros by construction — it never aliases
+// the prior file's append log. This test still drives the REAL delete-on-close
+// path (Handler.Close with DeletePending), which purges the deleted file's own
+// payload to reclaim its append-log/CAS state; it asserts both that the recreate
+// gets a fresh PayloadID and that the sparse hole reads zeros.
 func TestCopyChunk_SparseDest_SurvivesPriorPayloadReuse(t *testing.T) {
 	ctx := context.Background()
 
@@ -375,8 +376,10 @@ func TestCopyChunk_SparseDest_SurvivesPriorPayloadReuse(t *testing.T) {
 	}
 
 	// openDst creates "dst" at the share root and returns a wired OpenFile
-	// for it. The PayloadID is path-derived, so every call returns the SAME
-	// PayloadID — exactly the reuse the smbtorture battery exercises.
+	// for it. Since #1166 PR-3 each create gets a fresh UUID-based PayloadID,
+	// so successive calls return DIFFERENT PayloadIDs even at the same path —
+	// the recreate the smbtorture battery exercises no longer aliases the
+	// prior file's content.
 	openDst := func(fileID [16]byte) (*OpenFile, metadata.FileHandle) {
 		t.Helper()
 		dstFile, _, err := metaSvc.CreateFile(authCtx, rootHandle, "dst", &metadata.FileAttr{
@@ -431,13 +434,13 @@ func TestCopyChunk_SparseDest_SurvivesPriorPayloadReuse(t *testing.T) {
 		t.Fatalf("round1 Close (delete-on-close): %v", err)
 	}
 
-	// --- Round 2: recreate dest at the same path (same PayloadID), then
-	// the sparse_dest copy into [4096,8192). The leading [0,4096) hole MUST
-	// read zeros — not the stale round-1 pattern. ---
+	// --- Round 2: recreate dest at the same path, then the sparse_dest copy
+	// into [4096,8192). The leading [0,4096) hole MUST read zeros — not the
+	// stale round-1 pattern. ---
 	dst2, _ := openDst([16]byte{3})
-	if dst2.PayloadID != dst1.PayloadID {
-		t.Fatalf("test invariant: recreated dest should reuse the path-derived PayloadID (got %q vs %q)",
-			dst2.PayloadID, dst1.PayloadID)
+	if dst2.PayloadID == dst1.PayloadID {
+		t.Fatalf("test invariant: recreated dest should get a fresh UUID-based PayloadID, not reuse %q",
+			dst1.PayloadID)
 	}
 	chunks2 := []copyChunk{{SourceOffset: 0, TargetOffset: 4096, Length: 4096}}
 	res2, err := h.executeCopyChunks(smbCtx, FsctlSrvCopyChunk, dst2.FileID, srcOpen, dst2, chunks2)

--- a/pkg/block/blockstore.go
+++ b/pkg/block/blockstore.go
@@ -189,12 +189,13 @@ type BlockStoreAppend interface {
 	// payload (no-op return nil). After DeleteAppendLog returns, the
 	// payload's append-log state is fully reset; a subsequent
 	// AppendWrite for the same payloadID MUST succeed and start a
-	// fresh log (recreate semantics). This is required by DittoFS's
-	// path-based PayloadID lifecycle (metadata/file_helpers.go
-	// buildPayloadID derives PayloadID from shareName + path, so
-	// 'unlink + create at same path' reuses the same PayloadID).
-	// Backends that maintain a tombstone for race-safety reasons MUST
-	// clear it before DeleteAppendLog returns.
+	// fresh log (recreate semantics). Files created after #1166 PR-3
+	// get a UUID-based PayloadID (metadata/file_helpers.go
+	// buildPayloadID), so 'unlink + create at same path' allocates a
+	// fresh content_id rather than reusing one; this method is still
+	// invoked on delete with the deleted file's own PayloadID to reclaim
+	// its append-log state. Backends that maintain a tombstone for
+	// race-safety reasons MUST clear it before DeleteAppendLog returns.
 	//
 	// Orphan content-addressed chunks already emitted by a prior
 	// rollup are NOT removed here — they are swept by the mark-sweep

--- a/pkg/block/blockstoretest/appendlog.go
+++ b/pkg/block/blockstoretest/appendlog.go
@@ -96,11 +96,10 @@ func testAppendLogRoundTrip(t *testing.T, factory AppendFactory) {
 	}
 
 	// DeleteAppendLog resets the per-file append log. After it returns, a
-	// subsequent AppendWrite for the same payloadID must succeed
-	// (per BlockStoreAppend.DeleteAppendLog godoc — recreate semantics
-	// required by DittoFS's path-based PayloadID lifecycle). The
-	// already-rolled-up chunks remain in the store (orphan-chunk
-	// sweep is GC's job, not DeleteAppendLog's).
+	// subsequent AppendWrite for the same payloadID must succeed (per
+	// BlockStoreAppend.DeleteAppendLog godoc — this resurrect path runs
+	// on delete to reclaim the deleted file's log). The already-rolled-up
+	// chunks remain (orphan-chunk sweep is GC's job, not DeleteAppendLog's).
 	if err := bs.DeleteAppendLog(ctx, payloadID); err != nil {
 		t.Fatalf("DeleteAppendLog: %v", err)
 	}
@@ -121,10 +120,12 @@ func testAppendLogRoundTrip(t *testing.T, factory AppendFactory) {
 // testRecreateAfterDeleteAppendLog asserts that DeleteAppendLog does NOT
 // permanently tombstone a payloadID: a subsequent AppendWrite for the
 // same payloadID must succeed and start a fresh log. This is required
-// by DittoFS's path-based PayloadID lifecycle (an unlink-then-create
-// at the same path reuses the same PayloadID and must work — POSIX
-// recreate semantics surfaced via NFSv3 / pjdfstest chmod/12.t
-// unlink/14.t, open/00.t).
+// on delete: DeleteAppendLog must reclaim the deleted file's log and
+// leave the store ready for a fresh one. Files created after #1166
+// PR-3 get UUID-based PayloadIDs, so recreate-at-same-path uses a
+// fresh content_id (historically a path-derived recreate reused the
+// id — POSIX recreate via NFSv3, pjdfstest chmod/12.t, unlink/14.t,
+// open/00.t).
 //
 // The scenario writes once, deletes the log, then writes again at the
 // same payloadID and asserts the second write returns nil.
@@ -143,7 +144,7 @@ func testRecreateAfterDeleteAppendLog(t *testing.T, factory AppendFactory) {
 		t.Fatalf("DeleteAppendLog: %v", err)
 	}
 	if err := bs.AppendWrite(ctx, payloadID, payload, 0); err != nil {
-		t.Fatalf("AppendWrite after DeleteAppendLog (recreate semantics required by path-based PayloadID lifecycle): %v", err)
+		t.Fatalf("AppendWrite after DeleteAppendLog (store must accept a fresh log after delete): %v", err)
 	}
 }
 

--- a/pkg/block/engine/drain_persist_test.go
+++ b/pkg/block/engine/drain_persist_test.go
@@ -201,10 +201,10 @@ func newEngineOverStore(t *testing.T, ms metadata.Store) *engine.Store {
 }
 
 // createRealFile creates a file row through the metadata store the way the
-// production CreateFile path does — crucially setting PayloadID =
-// buildPayloadID(share, path) so the rollup-persist GetFileByPayloadID
-// lookup resolves to THIS row. It does NOT pre-populate Blocks (doing so
-// would mask the rollup-persist bug under test).
+// production CreateFile path does — crucially setting a UUID-based PayloadID
+// (buildPayloadID(share, id), see #1166 PR-3) so the rollup-persist
+// GetFileByPayloadID lookup resolves to THIS row. It does NOT pre-populate
+// Blocks (doing so would mask the rollup-persist bug under test).
 func createRealFile(t *testing.T, store metadata.Store, shareName, name string, rootHandle metadata.FileHandle) (string, metadata.FileHandle) {
 	t.Helper()
 	ctx := context.Background()
@@ -217,7 +217,7 @@ func createRealFile(t *testing.T, store metadata.Store, shareName, name string, 
 	if err != nil {
 		t.Fatalf("DecodeFileHandle: %v", err)
 	}
-	payloadID := strings.TrimPrefix(shareName, "/") + "/" + strings.TrimPrefix(path, "/")
+	payloadID := strings.TrimPrefix(shareName, "/") + "/" + id.String()
 	file := &metadata.File{
 		ID:        id,
 		ShareName: shareName,

--- a/pkg/block/local/fs/appendwrite.go
+++ b/pkg/block/local/fs/appendwrite.go
@@ -503,20 +503,22 @@ func (bc *FSStore) AppendWrite(ctx context.Context, payloadID string, data []byt
 //     tombstone, on-disk state and in-memory state for this payloadID
 //     are fully reset. Any AppendWrite that arrives AFTER step 5
 //     fresh-creates state via getOrCreateLog as if the payload never
-//     existed, which is exactly the desired semantics for the
-//     "unlink + create at same path" workflow DittoFS's path-based
-//     PayloadID strategy requires (see
-//     metadata/file_helpers.go:buildPayloadID — PayloadID is derived
-//     from shareName + path, so recreating a file at the same path
-//     reuses the same PayloadID).
+//     existed. Files created after #1166 PR-3 get a UUID-based
+//     PayloadID (metadata/file_helpers.go:buildPayloadID), so a
+//     recreate-at-same-path uses a fresh content_id; this reset path
+//     is still exercised on delete to reclaim the deleted file's own
+//     append-log state and must leave the store ready for a
+//     subsequent fresh log.
 //
 // This reverses the FIX-8 invariant (which kept the tombstone for the
 // FSStore lifetime to eliminate a clear-on-success resurrection race).
-// FIX-8 assumed callers would allocate a fresh PayloadID on recreate
-// DittoFS's path-based PayloadID strategy violates that assumption
-// breaking POSIX recreate-at-same-name workflows over NFSv3 (which
-// has no silly-rename masking — see pjdfstest chmod/12.t, unlink/14.t
-// open/00.t).
+// FIX-8 assumed callers would allocate a fresh PayloadID on recreate;
+// the older path-based PayloadID scheme violated that assumption,
+// breaking POSIX recreate-at-same-name workflows over NFSv3 (which has
+// no silly-rename masking — see pjdfstest chmod/12.t, unlink/14.t,
+// open/00.t). With UUID-based PayloadIDs recreates get a fresh id by
+// construction, but the FSStore reset on delete must still leave state
+// ready for the next fresh log.
 //
 // Ordering (Blocker 3 fix)
 //  1. Set tombstone under the shard lock so new AppendWrites and new rollupFile
@@ -634,10 +636,11 @@ func (bc *FSStore) DeleteAppendLog(ctx context.Context, payloadID string) error 
 	// before step 1, so it is safe to allow fresh recreates from this
 	// point on. This reverses the original FIX-8 invariant (which kept
 	// the tombstone for the FSStore lifetime to eliminate a
-	// clear-on-success resurrection race) — DittoFS's PayloadID is
-	// derived from the file's path (metadata/file_helpers.go
-	// buildPayloadID), so 'unlink + create at same path' must reuse
-	// the PayloadID and must therefore succeed.
+	// clear-on-success resurrection race). Files created after #1166 PR-3
+	// get a UUID-based PayloadID (metadata/file_helpers.go buildPayloadID),
+	// so a recreate-at-same-path gets a fresh content_id; this reset still
+	// runs on delete to reclaim the deleted file's own state and must
+	// leave the store ready for a subsequent fresh log.
 	sh.mu.Lock()
 	// C3: release the pressure budget for any record still live in this
 	// payload's logIndex. AppendWrite reserved recordFrameOverhead+payloadLen

--- a/pkg/block/local/fs/delete_truncate_test.go
+++ b/pkg/block/local/fs/delete_truncate_test.go
@@ -41,9 +41,11 @@ func TestDelete_FreshPayload_UnlinksLog(t *testing.T) {
 
 	// Per-file state cleared. The tombstone is also cleared on success
 	// so subsequent AppendWrites at the same PayloadID resurrect a
-	// fresh log (DittoFS's path-based PayloadID lifecycle — see the
-	// BlockStoreAppend.DeleteLog godoc and FSStore.DeleteAppendLog
-	// tombstone-lifecycle comment for why FIX-8 was reverted).
+	// fresh log. Files created after #1166 PR-3 get a UUID-based
+	// PayloadID, so recreates get a fresh id; this resurrect path still
+	// runs on delete (see the BlockStoreAppend.DeleteLog godoc and the
+	// FSStore.DeleteAppendLog tombstone-lifecycle comment for why FIX-8
+	// was reverted).
 	bcSh := bc.shardFor("file1")
 	bcSh.mu.RLock()
 	_, hasFD := bcSh.logFDs["file1"]
@@ -521,11 +523,13 @@ func TestTruncate_Rollup_SkipsBeyondBoundary(t *testing.T) {
 
 // TestDelete_Then_Write_ResurrectsLog verifies the post-Phase-18
 // invariant: a DeleteAppendLog followed by an AppendWrite on the SAME
-// payloadID must succeed and create a fresh log. This is required by
-// DittoFS's path-based PayloadID lifecycle — metadata.buildPayloadID
-// derives PayloadID from shareName + path, so 'unlink + create at
-// same path' reuses the PayloadID. Exposed by pjdfstest chmod/12.t
-// unlink/14.t, open/00.t on NFSv3 (NFSv4 silly-rename masks it).
+// payloadID must succeed and create a fresh log. Files created after
+// #1166 PR-3 get a UUID-based PayloadID, so the common case is a fresh
+// id on recreate; this same-id resurrect contract still matters because
+// DeleteAppendLog runs on delete and the store must remain usable for
+// any subsequent log on that id. Historically a path-derived recreate
+// reused the id (exposed by pjdfstest chmod/12.t, unlink/14.t,
+// open/00.t on NFSv3; NFSv4 silly-rename masks it).
 //
 // Reverses the prior FIX-8 invariant (tombstone permanent for the
 // process lifetime) — the drain barrier in DeleteAppendLog step 2

--- a/pkg/block/local/memory/memory.go
+++ b/pkg/block/local/memory/memory.go
@@ -323,10 +323,11 @@ func (s *MemoryStore) ListUnsynced(ctx context.Context) iter.Seq2[block.ContentH
 // A prior DeleteAppendLog on the same payloadID does NOT permanently
 // block subsequent AppendWrites: the memory store's rollup is
 // synchronous under the same write lock as DeleteAppendLog, so there is no
-// async-rollup-completion race to guard against. Recreate-at-same-id
-// is supported (DittoFS's metadata layer derives PayloadID from
-// shareName + path, so 'unlink + create at same path' reuses the
-// same payloadID — see metadata/file_helpers.go buildPayloadID).
+// async-rollup-completion race to guard against. Recreate-at-same-id is
+// supported. Files created after #1166 PR-3 get a UUID-based PayloadID
+// (metadata/file_helpers.go buildPayloadID), so 'unlink + create at same
+// path' yields a fresh content_id; DeleteAppendLog still runs on delete
+// with the deleted file's own PayloadID to reclaim its append-log state.
 //
 // Implements block.BlockStoreAppend.
 func (s *MemoryStore) AppendWrite(_ context.Context, payloadID string, data []byte, offset uint64) error {
@@ -438,8 +439,9 @@ func (s *MemoryStore) ReadPayloadAt(_ context.Context, payloadID string, dest []
 // the tracked file-size entry. Already-rolled-up CAS chunks remain in
 // the store — orphan-chunk cleanup is GC's responsibility per the
 // contract. Subsequent AppendWrites for the same payloadID resurrect
-// a fresh log (required by DittoFS's path-based PayloadID lifecycle
-// unlink + create at the same path reuses the same PayloadID).
+// a fresh log. Files created after #1166 PR-3 get a UUID-based
+// PayloadID, so this runs on delete to reclaim the deleted file's own
+// log; a recreate-at-same-path gets a fresh content_id.
 //
 // Implements block.BlockStoreAppend.
 func (s *MemoryStore) DeleteAppendLog(_ context.Context, payloadID string) error {

--- a/pkg/controlplane/runtime/snapshot_byteverify_test.go
+++ b/pkg/controlplane/runtime/snapshot_byteverify_test.go
@@ -222,9 +222,11 @@ func (f *byteVerifyFixture) close() {
 	}
 }
 
-// createEmptyFile creates a regular file inode under the share root with its
-// Path + PayloadID set the way the production create path does. It does NOT
-// set FileAttr.Blocks — the engine's post-flush coordinator owns that.
+// createEmptyFile creates a regular file inode under the share root. It sets a
+// deterministic path-based PayloadID via metadata.BuildPayloadID purely for
+// test self-consistency (the fixture both stores and queries the same value);
+// the production create path now derives a UUID-based PayloadID (#1166 PR-3).
+// It does NOT set FileAttr.Blocks — the engine's post-flush coordinator owns that.
 func (f *byteVerifyFixture) createEmptyFile(ctx context.Context, name string) metadata.PayloadID {
 	f.t.Helper()
 	root, err := f.meta.GetRootHandle(ctx, f.shareName)

--- a/pkg/metadata/file_create.go
+++ b/pkg/metadata/file_create.go
@@ -297,7 +297,7 @@ func (s *Service) createEntry(
 
 	// Set content ID for regular files
 	if fileType == FileTypeRegular {
-		newAttr.PayloadID = PayloadID(buildPayloadID(parent.ShareName, fullPath))
+		newAttr.PayloadID = PayloadID(buildPayloadID(parent.ShareName, id))
 	}
 
 	// Set device numbers for block/char devices

--- a/pkg/metadata/file_helpers.go
+++ b/pkg/metadata/file_helpers.go
@@ -1,6 +1,10 @@
 package metadata
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/google/uuid"
+)
 
 // buildPath constructs a full path from parent path and child name.
 func buildPath(parentPath, childName string) string {
@@ -10,9 +14,14 @@ func buildPath(parentPath, childName string) string {
 	return parentPath + "/" + childName
 }
 
-// buildPayloadID constructs a content ID from share name and path.
-func buildPayloadID(shareName, path string) string {
-	return strings.TrimPrefix(shareName, "/") + "/" + strings.TrimPrefix(path, "/")
+// buildPayloadID constructs a content ID from share name and the inode UUID.
+// UUID-based (not path-based) so the content_id is stable across rename/relink:
+// renaming changes the path but not the inode's UUID, so GetFileByPayloadID
+// keeps resolving (issue #1166). Existing path-based content_ids written before
+// this change continue to work — PayloadID is stored at create time and read
+// back from the inode field, never recomputed from path.
+func buildPayloadID(shareName string, id uuid.UUID) string {
+	return strings.TrimPrefix(shareName, "/") + "/" + id.String()
 }
 
 // MakeRdev encodes major and minor device numbers into a single Rdev value.

--- a/pkg/metadata/store/postgres/postgres_blockref_test.go
+++ b/pkg/metadata/store/postgres/postgres_blockref_test.go
@@ -378,8 +378,9 @@ func TestPostgres_Restore_ReconcilesNullHashFileBlocks(t *testing.T) {
 		t.Fatalf("GetFile: %v", err)
 	}
 	// content_id (PayloadID) is the prefix of the file_blocks row ID. The
-	// engine derives it from share + path; set it explicitly here so the
-	// reconcile join (file_blocks.id = content_id || '/' || offset) lands.
+	// production engine now derives it from share + inode UUID (#1166 PR-3);
+	// here we set a fixed value explicitly so the reconcile join
+	// (file_blocks.id = content_id || '/' || offset) lands deterministically.
 	payloadID := "restore-reconcile/vm.img"
 	file.PayloadID = metadata.PayloadID(payloadID)
 	file.Blocks = []block.BlockRef{

--- a/pkg/metadata/storetest/file_ops.go
+++ b/pkg/metadata/storetest/file_ops.go
@@ -13,6 +13,7 @@ func runFileOpsTests(t *testing.T, factory StoreFactory) {
 	t.Run("GetFile", func(t *testing.T) { testGetFile(t, factory) })
 	t.Run("DeleteFile", func(t *testing.T) { testDeleteFile(t, factory) })
 	t.Run("CreateHardLink", func(t *testing.T) { testCreateHardLink(t, factory) })
+	t.Run("ContentIdStableAcrossRename", func(t *testing.T) { testContentIdStableAcrossRename(t, factory) })
 	t.Run("HardLinkRenameKeepsOtherName", func(t *testing.T) { testHardLinkRenameKeepsOtherName(t, factory) })
 	t.Run("DerivedPathReflectsParentRename", func(t *testing.T) { testDerivedPathReflectsParentRename(t, factory) })
 	t.Run("SetFileAttributes", func(t *testing.T) { testSetFileAttributes(t, factory) })
@@ -389,6 +390,72 @@ func testDerivedPathReflectsParentRename(t *testing.T, factory StoreFactory) {
 	}
 	if child.Path != "/newdir/child.txt" {
 		t.Errorf("derived child path = %q, want /newdir/child.txt", child.Path)
+	}
+}
+
+// testContentIdStableAcrossRename verifies that a regular file's PayloadID
+// (block-store content_id) is independent of its path: it survives a rename to
+// a different directory unchanged, and GetFileByPayloadID still resolves to the
+// same inode afterwards. UUID-based PayloadIDs (#1166 PR-3) make content_id
+// stable across rename — a path-derived content_id would have gone stale and
+// broken the flusher's GetFileByPayloadID lookup after the move.
+func testContentIdStableAcrossRename(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	rootHandle := createTestShare(t, store, "/test")
+	ctx := t.Context()
+
+	dirHandle := createTestDir(t, store, "/test", rootHandle, "src")
+	handle := createTestFile(t, store, "/test", dirHandle, "blob.dat", 0o644)
+
+	// Stamp a PayloadID the way the service does at create time, then capture
+	// it. The store-level harness bypasses the service, so set it explicitly.
+	file, err := store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile() failed: %v", err)
+	}
+	const payloadID = metadata.PayloadID("test/blob-content-id")
+	file.PayloadID = payloadID
+	if err := store.PutFile(ctx, file); err != nil {
+		t.Fatalf("PutFile() with PayloadID failed: %v", err)
+	}
+
+	// Rename across directories: drop the old edge, add a new one under root.
+	if err := store.DeleteChild(ctx, dirHandle, "blob.dat"); err != nil {
+		t.Fatalf("DeleteChild(src/blob.dat) failed: %v", err)
+	}
+	if err := store.SetChild(ctx, rootHandle, "renamed.dat", handle); err != nil {
+		t.Fatalf("SetChild(renamed.dat) failed: %v", err)
+	}
+	if err := store.SetParent(ctx, handle, rootHandle); err != nil {
+		t.Fatalf("SetParent(root) failed: %v", err)
+	}
+
+	// The derived path changed, but the PayloadID must not.
+	moved, err := store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile() after rename failed: %v", err)
+	}
+	if moved.Path != "/renamed.dat" {
+		t.Errorf("derived path after rename = %q, want /renamed.dat", moved.Path)
+	}
+	if moved.PayloadID != payloadID {
+		t.Errorf("PayloadID changed across rename: got %q, want %q", moved.PayloadID, payloadID)
+	}
+
+	// And the content-id lookup must still resolve after the move, returning
+	// the same inode's content_id and its new derived path.
+	got, err := store.GetFileByPayloadID(ctx, payloadID)
+	if err != nil {
+		t.Fatalf("GetFileByPayloadID() after rename failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetFileByPayloadID() after rename returned nil file")
+	}
+	if got.PayloadID != payloadID {
+		t.Errorf("GetFileByPayloadID returned PayloadID %q, want %q", got.PayloadID, payloadID)
+	}
+	if got.Path != "/renamed.dat" {
+		t.Errorf("GetFileByPayloadID returned path %q, want /renamed.dat", got.Path)
 	}
 }
 

--- a/test/e2e/dedup_objectid_population_test.go
+++ b/test/e2e/dedup_objectid_population_test.go
@@ -177,15 +177,27 @@ func TestObjectIDPopulation_NFSWriteQuiesce(t *testing.T) {
 	require.NoError(t, err, "open second Postgres handle for verification")
 	t.Cleanup(func() { _ = mds.Close() })
 
-	// ---- Resolve the file row by PayloadID ----
+	// ---- Resolve the file row ----
 	//
-	// PayloadID format is path-based: BuildPayloadID(shareName, fullPath) ->
-	// "objid-pop/test.bin" (leading slashes stripped per
-	// pkg/metadata/validation.go BuildPayloadID).
-	payloadID := metadata.PayloadID(metadata.BuildPayloadID(shareName, "/test.bin"))
-	file, err := mds.GetFileByPayloadID(t.Context(), payloadID)
-	require.NoErrorf(t, err, "GetFileByPayloadID(%s)", string(payloadID))
-	require.NotNilf(t, file, "GetFileByPayloadID(%s) returned nil file", string(payloadID))
+	// Files created after #1166 PR-3 get a UUID-based PayloadID, so we cannot
+	// reconstruct the content_id from the path. Walk the namespace from the
+	// share root to the file, then read its stored attributes (including the
+	// PayloadID the server assigned at create time).
+	rootHandle, err := mds.GetRootHandle(t.Context(), shareName)
+	require.NoErrorf(t, err, "GetRootHandle(%s)", shareName)
+	fileHandle, err := mds.GetChild(t.Context(), rootHandle, "test.bin")
+	require.NoError(t, err, "GetChild(root, test.bin)")
+	file, err := mds.GetFile(t.Context(), fileHandle)
+	require.NoError(t, err, "GetFile(test.bin)")
+	require.NotNil(t, file, "GetFile(test.bin) returned nil file")
+
+	// The stored PayloadID must round-trip through GetFileByPayloadID, and
+	// resolve to the SAME inode we walked to above.
+	byPayload, err := mds.GetFileByPayloadID(t.Context(), file.PayloadID)
+	require.NoErrorf(t, err, "GetFileByPayloadID(%s)", string(file.PayloadID))
+	require.NotNilf(t, byPayload, "GetFileByPayloadID(%s) returned nil file", string(file.PayloadID))
+	require.Equalf(t, file.ID, byPayload.ID,
+		"GetFileByPayloadID(%s) resolved to a different inode", string(file.PayloadID))
 
 	// ---- REQUIRED RED ASSERT (must-have #1, 13-VERIFICATION.md:257-266) ----
 	require.Falsef(t, file.FileAttr.ObjectID.IsZero(),
@@ -204,7 +216,7 @@ func TestObjectIDPopulation_NFSWriteQuiesce(t *testing.T) {
 
 	// ---- Telemetry parity: emit at slog INFO for trend tracking ----
 	slog.Info("DEDUP-04 objectid populated",
-		"payload_id", string(payloadID),
+		"payload_id", string(file.PayloadID),
 		"object_id", file.FileAttr.ObjectID.String(),
 		"blocks", len(file.FileAttr.Blocks),
 		"size", objectIDPopulationPayloadSize)


### PR DESCRIPTION
PR-3 of #1166 (inode/path decoupling).

## What
New regular files derive their block-store `PayloadID` (content_id) from the **inode UUID** instead of the canonical path. `buildPayloadID(shareName, id uuid.UUID)` replaces the old path-based form; the sole production caller is `file_create.go` (using the UUID already decoded from the freshly generated handle).

## Why
content_id is now **stable across rename/relink**: a rename changes the path but not the inode's UUID, so `GetFileByPayloadID` keeps resolving after a move. The old path-derived content_id went stale on rename and broke the flusher's lookup — #1166 structural issue #5.

## Co-existence with old path-based content_ids
`PayloadID` is **stored** at create time (postgres `inodes.content_id`; memory/badger File struct) and **read back from the stored field**, never recomputed from path. So this only affects newly created files — existing path-based content_ids keep working unchanged. No migration.

## Recreate is now strictly safer
The block-store "unlink + create at same path" machinery (append-log/tombstone reset, `purgeBlockStorePayload`, `DeleteAppendLog`) existed because a path-derived recreate collided on the same content_id and could read stale bytes (pjdfstest open/00, unlink/14, chmod/12; smb2.ioctl.copy_chunk_sparse_dest). With UUID-based ids a recreate gets a **fresh** content_id by construction, so there is no stale-byte collision. The machinery is **kept** — purge-on-delete still fires using the deleted file's own stored PayloadID to reclaim its append-log/CAS state. Stale comments that claimed "PayloadID is path-derived so recreate reuses it" are reworded across `pkg/block/*`, the SMB handler, and the relevant block-store tests.

## Tests
- New conformance subtest `ContentIdStableAcrossRename` in `pkg/metadata/storetest/file_ops.go`: create a regular file, capture its PayloadID, rename it across directories, assert the PayloadID is unchanged and `GetFileByPayloadID` still resolves to the moved inode. Runs on **memory + badger + postgres** via the conformance harness.
- Fixed the e2e `TestObjectIDPopulation` test to resolve the NFS-created file by namespace walk (`GetRootHandle` → `GetChild` → `GetFile`) rather than reconstructing a path-based PayloadID, which would now miss.

Verified locally: build + vet + `go test ./pkg/metadata/...` (memory/badger) + full postgres conformance suite (local pg, including the new subtest) green.

References #1166. Does not close it (PR-5 closes #1166).