### PR TITLE
refactor(postgres): drop legacy link_counts table; inodes.nlink is sole source (PR-4 of #1166)

### DIFF
--- a/pkg/metadata/store/postgres/backup.go
+++ b/pkg/metadata/store/postgres/backup.go
@@ -28,12 +28,14 @@ const (
 	// framing, etc.) and add a migration path in Restore.
 	// v2 adds the v4_client_recovery table section.
 	// v3 renames the files table to inodes and drops the path/path_hash
-	// columns (#1166). The payload layout changed (the inode section name and
-	// its column set), so restore rejects older streams with
-	// ErrSchemaVersionMismatch — consistent with the v1->v2 bump, which added
-	// a table with no cross-version restore shim. Pre-1.0 backups are not
-	// forward-portable across schema versions.
-	postgresSchemaVersion = uint32(3)
+	// columns (#1166). v4 drops the legacy link_counts table; the hard-link
+	// count is consolidated onto inodes.nlink as the sole source of truth
+	// (#1166, part 4), so the backup table set no longer includes link_counts.
+	// The payload layout changed (one fewer table section), so restore rejects
+	// pre-v4 streams with ErrSchemaVersionMismatch — consistent with the prior
+	// bumps, which added/removed tables with no cross-version restore shim.
+	// Pre-1.0 backups are not forward-portable across schema versions.
+	postgresSchemaVersion = uint32(4)
 )
 
 // backupTables lists every metadata table in FK-safe dependency order
@@ -49,7 +51,6 @@ var backupTables = []string{
 	"inodes",
 	"shares",
 	"parent_child_map",
-	"link_counts",
 	"pending_writes",
 	"file_block_refs",
 	"file_blocks",

--- a/pkg/metadata/store/postgres/encoding.go
+++ b/pkg/metadata/store/postgres/encoding.go
@@ -60,7 +60,7 @@ func pgNanosToTime(n int64) time.Time {
 
 // fileRowToFileWithNlink converts a database row to a File struct, including link count.
 // Expected columns: id, share_name, path, file_type, mode, uid, gid, size,
-// atime, mtime, ctime, creation_time, content_id, link_target, device_major, device_minor, hidden, acl, object_id, deleted_at, original_path, deleted_by, link_count
+// atime, mtime, ctime, creation_time, content_id, link_target, device_major, device_minor, hidden, acl, eas, object_id, deleted_at, original_path, deleted_by, nlink
 //
 // The `path` column is no longer stored on the inode (#1166); callers supply it
 // as a reconstructed expression (inodePathExpr) walking parent_child_map up to
@@ -103,7 +103,7 @@ func fileRowToFileWithNlinkAndBlocks(row pgx.Row, withBlocks bool) (*metadata.Fi
 		deletedAt    sql.NullInt64
 		originalPath string
 		deletedBy    string
-		linkCount    sql.NullInt32
+		nlink        int32
 		blocksJSON   []byte
 	)
 
@@ -131,7 +131,7 @@ func fileRowToFileWithNlinkAndBlocks(row pgx.Row, withBlocks bool) (*metadata.Fi
 		&deletedAt,
 		&originalPath,
 		&deletedBy,
-		&linkCount,
+		&nlink,
 	}
 	if withBlocks {
 		dest = append(dest, &blocksJSON)
@@ -139,12 +139,6 @@ func fileRowToFileWithNlinkAndBlocks(row pgx.Row, withBlocks bool) (*metadata.Fi
 
 	if err := row.Scan(dest...); err != nil {
 		return nil, err
-	}
-
-	// Default to 1 if link count is not found
-	nlink := uint32(1)
-	if linkCount.Valid {
-		nlink = uint32(linkCount.Int32)
 	}
 
 	file := &metadata.File{
@@ -156,7 +150,7 @@ func fileRowToFileWithNlinkAndBlocks(row pgx.Row, withBlocks bool) (*metadata.Fi
 			Mode:         uint32(mode),
 			UID:          uint32(uid),
 			GID:          uint32(gid),
-			Nlink:        nlink,
+			Nlink:        uint32(nlink),
 			Size:         uint64(size),
 			Atime:        pgNanosToTime(atime),
 			Mtime:        pgNanosToTime(mtime),

--- a/pkg/metadata/store/postgres/files.go
+++ b/pkg/metadata/store/postgres/files.go
@@ -50,10 +50,9 @@ func (s *PostgresMetadataStore) GetFile(ctx context.Context, handle metadata.Fil
 			f.atime, f.mtime, f.ctime, f.creation_time,
 			f.content_id, f.link_target, f.device_major, f.device_minor,
 			f.hidden, f.acl, f.eas, f.object_id,
-			f.deleted_at, f.original_path, f.deleted_by, lc.link_count,
+			f.deleted_at, f.original_path, f.deleted_by, f.nlink,
 			` + blockRefsAggExpr + `
 		FROM inodes f
-		LEFT JOIN link_counts lc ON f.id = lc.file_id
 		WHERE f.id = $1 AND f.share_name = $2
 	`
 
@@ -166,7 +165,7 @@ func (s *PostgresMetadataStore) SetParent(ctx context.Context, handle metadata.F
 
 // GetLinkCount returns the hard link count for a file.
 // Uses direct pool query without transaction for better performance.
-// Returns 0 if the file doesn't track link counts or doesn't exist.
+// Returns 0 if the file doesn't exist. nlink is the sole source of truth (#1166).
 func (s *PostgresMetadataStore) GetLinkCount(ctx context.Context, handle metadata.FileHandle) (uint32, error) {
 	if err := ctx.Err(); err != nil {
 		return 0, err
@@ -181,7 +180,7 @@ func (s *PostgresMetadataStore) GetLinkCount(ctx context.Context, handle metadat
 	}
 
 	var count uint32
-	err = s.queryRow(ctx, `SELECT link_count FROM link_counts WHERE file_id = $1`, fileID).Scan(&count)
+	err = s.queryRow(ctx, `SELECT nlink FROM inodes WHERE id = $1`, fileID).Scan(&count)
 	if err != nil {
 		// Not found means count is 0
 		return 0, nil
@@ -226,10 +225,9 @@ func (s *PostgresMetadataStore) ListChildren(ctx context.Context, dirHandle meta
 	query := `
 		SELECT dc.child_name, dc.child_id, f.file_type, f.mode, f.uid, f.gid, f.size,
 		       f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.acl, f.eas, f.object_id,
-		       f.deleted_at, f.original_path, f.deleted_by, lc.link_count
+		       f.deleted_at, f.original_path, f.deleted_by, f.nlink
 		FROM parent_child_map dc
 		LEFT JOIN inodes f ON dc.child_id = f.id
-		LEFT JOIN link_counts lc ON dc.child_id = lc.file_id
 		WHERE dc.parent_id = $1 AND dc.child_name > $2
 		ORDER BY dc.child_name
 		LIMIT $3
@@ -462,9 +460,8 @@ func (s *PostgresMetadataStore) GetFileByPayloadID(ctx context.Context, payloadI
 			f.atime, f.mtime, f.ctime, f.creation_time,
 			f.content_id, f.link_target, f.device_major, f.device_minor,
 			f.hidden, f.acl, f.eas, f.object_id,
-			f.deleted_at, f.original_path, f.deleted_by, lc.link_count
+			f.deleted_at, f.original_path, f.deleted_by, f.nlink
 		FROM inodes f
-		LEFT JOIN link_counts lc ON f.id = lc.file_id
 		WHERE f.content_id_hash = md5($1)
 		LIMIT 1
 	`

--- a/pkg/metadata/store/postgres/migrations/000034_drop_link_counts.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000034_drop_link_counts.down.sql
@@ -1,0 +1,18 @@
+-- Rollback: recreate the legacy link_counts table and repopulate it from
+-- inodes.nlink (the authoritative column after 000034).
+
+-- Same DDL as 000001, except the FK now references inodes(id) (post-000032
+-- rename) instead of files(id).
+CREATE TABLE link_counts (
+    file_id     UUID PRIMARY KEY REFERENCES inodes(id) ON DELETE CASCADE,
+    link_count  INTEGER NOT NULL DEFAULT 1,
+
+    CONSTRAINT valid_link_count CHECK (link_count >= 0)
+);
+
+CREATE INDEX idx_link_counts_file_id ON link_counts(file_id);
+
+-- Repopulate from the authoritative inode column so a re-applied old code path
+-- that reads link_counts sees the correct values.
+INSERT INTO link_counts (file_id, link_count)
+SELECT id, nlink FROM inodes;

--- a/pkg/metadata/store/postgres/migrations/000034_drop_link_counts.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000034_drop_link_counts.up.sql
@@ -1,0 +1,23 @@
+-- Drop the legacy link_counts table; inodes.nlink is the sole source of truth
+-- for hard-link counts (#1166, part 4).
+--
+-- link_counts duplicated the count already carried by inodes.nlink (an existing
+-- NOT NULL DEFAULT 1 column). SetLinkCount dual-wrote both, and every read path
+-- (GetFile / ListChildren / CreateRootDirectory) LEFT JOINed link_counts purely
+-- to recover a value that nlink already held. Consolidating onto inodes.nlink
+-- removes the redundant table, the dual-write, and one join from the #1176
+-- single-round-trip GetFile.
+--
+-- 000032 renamed files -> inodes; link_counts' FK followed the rename and still
+-- references inodes(id) ON DELETE CASCADE. This migration is the first to touch
+-- link_counts since; nothing earlier dropped or altered it.
+
+-- Defensively reconcile any divergence into the authoritative column before the
+-- table goes away. nlink and link_count were kept in sync by SetLinkCount, but
+-- backfilling guarantees correctness for any row where they drifted.
+UPDATE inodes i SET nlink = lc.link_count
+FROM link_counts lc
+WHERE lc.file_id = i.id;
+
+DROP INDEX IF EXISTS idx_link_counts_file_id;
+DROP TABLE link_counts;

--- a/pkg/metadata/store/postgres/reset_audit_test.go
+++ b/pkg/metadata/store/postgres/reset_audit_test.go
@@ -33,6 +33,9 @@ func TestBackupTablesCoversAllMigrations(t *testing.T) {
 	// ALTER TABLE [IF EXISTS] <old> RENAME TO <new> — a rename retires <old>
 	// and introduces <new> (e.g. files -> inodes in 000032).
 	renameTableRE := regexp.MustCompile(`(?im)^\s*ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?([A-Za-z_][A-Za-z0-9_]*)\s+RENAME\s+TO\s+([A-Za-z_][A-Za-z0-9_]*)`)
+	// DROP TABLE [IF EXISTS] <name> — retires a table (e.g. link_counts in
+	// 000034). A dropped table must NOT remain in backupTables.
+	dropTableRE := regexp.MustCompile(`(?im)^\s*DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?([A-Za-z_][A-Za-z0-9_]*)`)
 
 	// Migrations apply in lexical filename order; process them that way so a
 	// later RENAME correctly supersedes an earlier CREATE.
@@ -73,6 +76,11 @@ func TestBackupTablesCoversAllMigrations(t *testing.T) {
 			if _, exists := seen[newName]; !exists {
 				seen[newName] = src
 			}
+		}
+		// Apply drops last: a dropped table is no longer live and must not be
+		// expected in backupTables.
+		for _, m := range dropTableRE.FindAllStringSubmatch(string(data), -1) {
+			delete(seen, m[1])
 		}
 	}
 

--- a/pkg/metadata/store/postgres/shares.go
+++ b/pkg/metadata/store/postgres/shares.go
@@ -349,18 +349,20 @@ func (s *PostgresMetadataStore) CreateRootDirectory(
 
 	now := time.Now()
 
-	// Insert root directory inode
+	// Insert root directory inode. Directories start with nlink = 2 ("." and the
+	// parent's entry). nlink is the sole source of truth for the hard-link count
+	// (#1166).
 	insertFileQuery := `
 		INSERT INTO inodes (
 			id, share_name,
 			file_type, mode, uid, gid, size,
 			atime, mtime, ctime, creation_time,
-			content_id, link_target, device_major, device_minor
+			content_id, link_target, device_major, device_minor, nlink
 		) VALUES (
 			$1, $2,
 			$3, $4, $5, $6, $7,
 			$8, $9, $10, $11,
-			$12, $13, $14, $15
+			$12, $13, $14, $15, 2
 		)
 	`
 
@@ -381,17 +383,6 @@ func (s *PostgresMetadataStore) CreateRootDirectory(
 		nil,                               // device_major (NULL)
 		nil,                               // device_minor (NULL)
 	)
-	if err != nil {
-		return nil, mapPgError(err, "CreateRootDirectory", shareName)
-	}
-
-	// Insert into link_counts (directories start with link count = 2: "." and parent reference)
-	insertLinkCountQuery := `
-		INSERT INTO link_counts (file_id, link_count)
-		VALUES ($1, $2)
-	`
-
-	_, err = tx.Exec(ctx, insertLinkCountQuery, rootID, 2)
 	if err != nil {
 		return nil, mapPgError(err, "CreateRootDirectory", shareName)
 	}
@@ -427,6 +418,7 @@ func (s *PostgresMetadataStore) CreateRootDirectory(
 		FileAttr: metadata.FileAttr{
 			Type:         metadata.FileTypeDirectory,
 			Mode:         mode,
+			Nlink:        2, // Root directories have 2 links ("." and parent's entry)
 			UID:          uid,
 			GID:          gid,
 			Size:         0,
@@ -447,7 +439,7 @@ func (s *PostgresMetadataStore) getExistingRootDirectory(ctx context.Context, sh
 	// authoritative pointer to its root) now that the path column is gone (#1166).
 	query := `
 		SELECT f.id, f.file_type, f.mode, f.uid, f.gid, f.size,
-			   f.atime, f.mtime, f.ctime, f.creation_time, f.hidden
+			   f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.nlink
 		FROM inodes f
 		WHERE f.id = (SELECT root_file_id FROM shares WHERE share_name = $1)
 	`
@@ -464,6 +456,7 @@ func (s *PostgresMetadataStore) getExistingRootDirectory(ctx context.Context, sh
 		ctime        int64
 		creationTime int64
 		hidden       bool
+		nlink        int32
 	)
 
 	err := s.queryRow(ctx, query, shareName).Scan(
@@ -478,6 +471,7 @@ func (s *PostgresMetadataStore) getExistingRootDirectory(ctx context.Context, sh
 		&ctime,
 		&creationTime,
 		&hidden,
+		&nlink,
 	)
 
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -494,6 +488,7 @@ func (s *PostgresMetadataStore) getExistingRootDirectory(ctx context.Context, sh
 		FileAttr: metadata.FileAttr{
 			Type:         metadata.FileType(fileType),
 			Mode:         uint32(mode),
+			Nlink:        uint32(nlink),
 			UID:          uint32(uid),
 			GID:          uint32(gid),
 			Size:         uint64(size),

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -203,10 +203,9 @@ func (tx *postgresTransaction) GetFile(ctx context.Context, handle metadata.File
 			f.atime, f.mtime, f.ctime, f.creation_time,
 			f.content_id, f.link_target, f.device_major, f.device_minor,
 			f.hidden, f.acl, f.eas, f.object_id,
-			f.deleted_at, f.original_path, f.deleted_by, lc.link_count,
+			f.deleted_at, f.original_path, f.deleted_by, f.nlink,
 			` + blockRefsAggExpr + `
 		FROM inodes f
-		LEFT JOIN link_counts lc ON f.id = lc.file_id
 		WHERE f.id = $1 AND f.share_name = $2
 	`
 
@@ -472,10 +471,11 @@ func (tx *postgresTransaction) DeleteFile(ctx context.Context, handle metadata.F
 		id, shareName,
 	).Scan(&fileType, &fileSize, &fileUID, &fileGID)
 
-	// Delete the file. link_counts.file_id and parent_child_map.parent_id both
-	// declare ON DELETE CASCADE against inodes(id), so deleting the inode row
-	// reaps this node's link-count and (if it is a directory) its child-map
-	// rows automatically. We do NOT delete this file from its parent's children
+	// Delete the file. parent_child_map.parent_id declares ON DELETE CASCADE
+	// against inodes(id), so deleting the inode row reaps (if it is a directory)
+	// its child-map rows automatically. The hard-link count lives on the inode
+	// row itself (inodes.nlink), so it is removed with the row. We do NOT delete
+	// this file from its parent's children
 	// map here — that is the responsibility of DeleteChild, which the service
 	// layer calls separately. This matches the memory and badger stores.
 	result, err := tx.tx.Exec(ctx, `DELETE FROM inodes WHERE id = $1 AND share_name = $2`, id, shareName)
@@ -618,10 +618,9 @@ func (tx *postgresTransaction) ListChildren(ctx context.Context, dirHandle metad
 	query := `
 		SELECT dc.child_name, dc.child_id, f.file_type, f.mode, f.uid, f.gid, f.size,
 		       f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.acl, f.eas, f.object_id,
-		       f.deleted_at, f.original_path, f.deleted_by, lc.link_count
+		       f.deleted_at, f.original_path, f.deleted_by, f.nlink
 		FROM parent_child_map dc
 		LEFT JOIN inodes f ON dc.child_id = f.id
-		LEFT JOIN link_counts lc ON dc.child_id = lc.file_id
 		WHERE dc.parent_id = $1 AND dc.child_name > $2
 		ORDER BY dc.child_name
 		LIMIT $3
@@ -796,7 +795,7 @@ func (tx *postgresTransaction) GetLinkCount(ctx context.Context, handle metadata
 	}
 
 	var count uint32
-	err = tx.tx.QueryRow(ctx, `SELECT link_count FROM link_counts WHERE file_id = $1`, fileID).Scan(&count)
+	err = tx.tx.QueryRow(ctx, `SELECT nlink FROM inodes WHERE id = $1`, fileID).Scan(&count)
 	if err != nil {
 		// Not found means count is 0
 		return 0, nil
@@ -818,24 +817,11 @@ func (tx *postgresTransaction) SetLinkCount(ctx context.Context, handle metadata
 		}
 	}
 
-	// Update link_counts table
-	query := `
-		INSERT INTO link_counts (file_id, link_count)
-		VALUES ($1, $2)
-		ON CONFLICT (file_id) DO UPDATE SET link_count = EXCLUDED.link_count
-	`
-
-	_, err = tx.tx.Exec(ctx, query, fileID, count)
+	// inodes.nlink is the sole source of truth for the hard-link count (#1166);
+	// GETATTR reads it straight off the inode row without a join.
+	_, err = tx.tx.Exec(ctx, `UPDATE inodes SET nlink = $1 WHERE id = $2`, count, fileID)
 	if err != nil {
 		return mapPgError(err, "SetLinkCount", "")
-	}
-
-	// Also keep the inodes.nlink column in sync with the link_counts table so
-	// GETATTR can read the link count straight off the inode row without a join.
-	nlinkQuery := `UPDATE inodes SET nlink = $1 WHERE id = $2`
-	_, err = tx.tx.Exec(ctx, nlinkQuery, count, fileID)
-	if err != nil {
-		return mapPgError(err, "SetLinkCount (nlink update)", "")
 	}
 
 	return nil
@@ -1055,9 +1041,8 @@ func (tx *postgresTransaction) DeleteShare(ctx context.Context, shareName string
 
 	// Delete all inode rows for the share. The store.go:161 contract is
 	// "removes a share and all its metadata"; dropping only the share row
-	// orphans every inodes/parent_child_map/link_counts/file_block_refs row.
-	// parent_child_map, link_counts, and file_block_refs all cascade from
-	// inodes(id).
+	// orphans every inodes/parent_child_map/file_block_refs row.
+	// parent_child_map and file_block_refs both cascade from inodes(id).
 	if _, err := tx.tx.Exec(ctx, `DELETE FROM inodes WHERE share_name = $1`, shareName); err != nil {
 		return mapPgError(err, "DeleteShare", shareName)
 	}
@@ -1154,9 +1139,8 @@ func (tx *postgresTransaction) CreateRootDirectory(ctx context.Context, shareNam
 	// share row is the authoritative pointer to its root inode.
 	checkQuery := `
 		SELECT f.id, f.file_type, f.mode, f.uid, f.gid, f.size,
-			   f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, lc.link_count
+			   f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.nlink
 		FROM inodes f
-		LEFT JOIN link_counts lc ON f.id = lc.file_id
 		WHERE f.id = (SELECT root_file_id FROM shares WHERE share_name = $1)
 	`
 
@@ -1172,24 +1156,15 @@ func (tx *postgresTransaction) CreateRootDirectory(ctx context.Context, shareNam
 		ctime        int64
 		creationTime int64
 		hidden       bool
-		linkCount    sql.NullInt32
+		nlink        int32
 	)
 
 	err := tx.tx.QueryRow(ctx, checkQuery, shareName).Scan(
 		&id, &fileType, &existingMode, &existingUID, &existingGID, &size,
-		&atime, &mtime, &ctime, &creationTime, &hidden, &linkCount,
+		&atime, &mtime, &ctime, &creationTime, &hidden, &nlink,
 	)
 
 	if err == nil {
-		// Determine Nlink value
-		var nlink uint32
-		if linkCount.Valid {
-			nlink = uint32(linkCount.Int32)
-		} else {
-			// Root directories always have at least 2 links
-			nlink = 2
-		}
-
 		// Root exists - return it
 		return &metadata.File{
 			ID:        uuid.MustParse(id),
@@ -1198,7 +1173,7 @@ func (tx *postgresTransaction) CreateRootDirectory(ctx context.Context, shareNam
 			FileAttr: metadata.FileAttr{
 				Type:         metadata.FileType(fileType),
 				Mode:         uint32(existingMode),
-				Nlink:        nlink,
+				Nlink:        uint32(nlink),
 				UID:          uint32(existingUID),
 				GID:          uint32(existingGID),
 				Size:         uint64(size),
@@ -1218,17 +1193,19 @@ func (tx *postgresTransaction) CreateRootDirectory(ctx context.Context, shareNam
 	rootID := uuid.New()
 	now := time.Now()
 
+	// Directories start with nlink = 2 ("." and the parent's entry). nlink is
+	// the sole source of truth for the hard-link count (#1166).
 	insertFileQuery := `
 		INSERT INTO inodes (
 			id, share_name,
 			file_type, mode, uid, gid, size,
 			atime, mtime, ctime, creation_time,
-			content_id, link_target, device_major, device_minor
+			content_id, link_target, device_major, device_minor, nlink
 		) VALUES (
 			$1, $2,
 			$3, $4, $5, $6, $7,
 			$8, $9, $10, $11,
-			$12, $13, $14, $15
+			$12, $13, $14, $15, 2
 		)
 	`
 
@@ -1249,17 +1226,6 @@ func (tx *postgresTransaction) CreateRootDirectory(ctx context.Context, shareNam
 		nil,                               // device_major (NULL)
 		nil,                               // device_minor (NULL)
 	)
-	if err != nil {
-		return nil, mapPgError(err, "CreateRootDirectory", shareName)
-	}
-
-	// Insert into link_counts
-	insertLinkCountQuery := `
-		INSERT INTO link_counts (file_id, link_count)
-		VALUES ($1, $2)
-	`
-
-	_, err = tx.tx.Exec(ctx, insertLinkCountQuery, rootID, 2)
 	if err != nil {
 		return nil, mapPgError(err, "CreateRootDirectory", shareName)
 	}
@@ -1404,9 +1370,8 @@ func (tx *postgresTransaction) GetFileByPayloadID(ctx context.Context, payloadID
 			f.atime, f.mtime, f.ctime, f.creation_time,
 			f.content_id, f.link_target, f.device_major, f.device_minor,
 			f.hidden, f.acl, f.eas, f.object_id,
-			f.deleted_at, f.original_path, f.deleted_by, lc.link_count
+			f.deleted_at, f.original_path, f.deleted_by, f.nlink
 		FROM inodes f
-		LEFT JOIN link_counts lc ON f.id = lc.file_id
 		WHERE f.content_id_hash = md5($1)
 		LIMIT 1
 	`

--- a/test/e2e/framework/containers.go
+++ b/test/e2e/framework/containers.go
@@ -426,11 +426,12 @@ func (ph *PostgresHelper) TruncateTables() error {
 	}
 	defer pool.Close()
 
+	// inodes is the post-000032 name for the former files table; link_counts
+	// was dropped in 000034 (hard-link count consolidated onto inodes.nlink).
 	_, err = pool.Exec(ctx, `
 		TRUNCATE TABLE
 			parent_child_map,
-			link_counts,
-			files,
+			inodes,
 			shares
 		CASCADE
 	`)


### PR DESCRIPTION
PR-4 of #1166. Consolidates hard-link count storage on the postgres backend: `inodes.nlink` (the existing `NOT NULL DEFAULT 1` column) becomes the single source of truth, and the redundant legacy `link_counts` table is dropped. Postgres-only; memory/badger backends are untouched and still pass the conformance suite unchanged.

## What
- **Removes dual-write redundancy.** `SetLinkCount` previously wrote BOTH `link_counts` (INSERT ... ON CONFLICT) AND `inodes.nlink`; now it keeps only `UPDATE inodes SET nlink`.
- **Migration `000034_drop_link_counts`.** up: defensively backfills `inodes.nlink` from `link_counts` (reconciles any divergence into the authoritative column), then drops the index and table. down: recreates the table (FK → `inodes(id)`, post-000032 rename) and repopulates from `inodes.nlink`.
- **One fewer join on the #1176 path.** `GetFile` / `GetFileByPayloadID` / `CreateRootDirectory` now select `f.nlink` directly instead of `LEFT JOIN link_counts`. The folded `blockRefsAggExpr` single-round-trip GetFile is preserved.
- **Schema v3 → v4.** `backup.go` drops `link_counts` from `backupTables` (used for both the COPY backup and the Reset TRUNCATE). Pre-v4 backups are rejected with `ErrSchemaVersionMismatch`, consistent with prior bumps — no cross-version shim.
- Directory inode INSERTs (root-dir create in `shares.go` + `transaction.go`) set `nlink = 2` directly.
- E2E `TruncateTables` helper updated to `inodes` (post-000032) and no longer references the dropped `link_counts`.
- `TestBackupTablesCoversAllMigrations` audit extended to honour `DROP TABLE` so a dropped table is no longer expected in `backupTables`.

## Behaviour parity
`PutFile` does not persist `File.Nlink` (nlink stays at its DEFAULT/SetLinkCount value) — this matches memory and badger, which maintain their link count separately from the inode struct and rely on the service always calling `SetLinkCount` after `PutFile`.

## Testing
- `go build ./...`, `go vet ./...` clean.
- `go test ./pkg/metadata/...` (memory + badger) green.
- Postgres integration conformance suite run against a FRESH db (migration applied at schema version 34): all subtests green, including hard-link, link-rename, backup-coverage, object_id-conflict (exercises SetLinkCount), and reset-then-restore. Verified `link_counts` table is gone and `inodes` remains. Validated the 000034 down→up roundtrip SQL end to end.

Refs #1166 (PR-5 closes it).