### PR TITLE
feat(metrics): SMB RED + auth instruments (PR-2b of #1188)

### DIFF
--- a/internal/adapter/smb/conn_types.go
+++ b/internal/adapter/smb/conn_types.go
@@ -19,6 +19,17 @@ type LockedWriter struct {
 	sync.Mutex
 }
 
+// MetricsRecorder is the minimal sink the SMB dispatch path uses to emit
+// protocol RED (rate/errors/duration) and authentication metrics. It is
+// satisfied by *metrics.Metrics (whose methods are all nil-receiver safe), and
+// declared here so internal/ dispatch does not depend on pkg/metrics. All
+// implementations MUST tolerate being called on a nil/absent backend; callers
+// still guard for a nil ConnInfo.Metrics to avoid a nil-interface deref.
+type MetricsRecorder interface {
+	RecordRequest(protocol, op, status string, d time.Duration)
+	RecordAuth(protocol, mechanism string, ok bool)
+}
+
 // ConnInfo provides the connection context needed by dispatch and compound
 // request processing functions. This decouples internal/ protocol logic from
 // the Connection struct in pkg/adapter/smb/.
@@ -42,6 +53,11 @@ type ConnInfo struct {
 
 	// SessionManager provides session and credit management.
 	SessionManager *session.Manager
+
+	// Metrics records per-request RED (rate/errors/duration) and is consulted
+	// on the SMB dispatch path. Nil when the server runs without a metrics
+	// backend; every call site guards for nil. See MetricsRecorder.
+	Metrics MetricsRecorder
 
 	// WriteMu serializes writes to the connection.
 	WriteMu *LockedWriter

--- a/internal/adapter/smb/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/handlers/kerberos_auth.go
@@ -22,7 +22,16 @@ import (
 // Validates the AP-REQ, normalizes the session key to 16 bytes for SMB3 KDF,
 // resolves the principal to a DittoFS username, and creates an authenticated session.
 // [MS-SMB2] Section 3.3.5.5.3
-func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, parsedToken *auth.ParsedToken) (*HandlerResult, error) {
+func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, parsedToken *auth.ParsedToken) (result *HandlerResult, retErr error) {
+	// Record the terminal Kerberos auth verdict exactly once. The AP-REQ both
+	// negotiates and completes (single-shot), so every return from this function
+	// is a final verdict: success is any non-error result; AP-REQ verification
+	// failures, unknown principals, and missing config all return LOGON_FAILURE
+	// and count as failed krb5 attempts.
+	defer func() {
+		h.recordAuth("krb5", result != nil && !result.Status.IsError())
+	}()
+
 	// Check that KerberosService is configured (not just the provider).
 	// KerberosService encapsulates AP-REQ verification, replay detection,
 	// and subkey preference logic shared across NFS and SMB.
@@ -298,7 +307,17 @@ func (h *Handler) buildKerberosAcceptResponse(
 // registration. The caller (handleSessionBind) has already validated the bind
 // matrix (dialect / signing-algo / cipher) and seeded the per-channel preauth
 // hash. smbtorture smb2.session.bind1 / bind2 / bind_invalid_auth.
-func (h *Handler) completeKerberosBind(ctx *SMBHandlerContext, sess *session.Session, parsedToken *auth.ParsedToken) (*HandlerResult, error) {
+func (h *Handler) completeKerberosBind(ctx *SMBHandlerContext, sess *session.Session, parsedToken *auth.ParsedToken) (result *HandlerResult, retErr error) {
+	// Record the terminal Kerberos bind verdict exactly once. Like
+	// handleKerberosAuth this path is single-shot (the AP-REQ both authenticates
+	// and completes the bind), so every return is a final verdict — success is
+	// any non-error result; LOGON_FAILURE / ACCESS_DENIED count as failed krb5
+	// attempts. NTLM bind verdicts are already recorded in completeNTLMAuth via
+	// its pending.IsBinding branch.
+	defer func() {
+		h.recordAuth("krb5", result != nil && !result.Status.IsError())
+	}()
+
 	if h.KerberosService == nil {
 		logger.Debug("Kerberos bind attempted but no KerberosService configured")
 		return NewErrorResult(types.StatusLogonFailure), nil
@@ -432,7 +451,7 @@ func (h *Handler) completeKerberosBind(ctx *SMBHandlerContext, sess *session.Ses
 
 	// Binding response matches the existing session's encrypt-data state per
 	// §3.3.5.5; the BINDING flag is request-only and not echoed.
-	result := h.buildSessionSetupResponse(types.StatusSuccess, sessionEncryptFlag(sess), spnegoResp)
+	result = h.buildSessionSetupResponse(types.StatusSuccess, sessionEncryptFlag(sess), spnegoResp)
 	result.IsBinding = true
 	return result, nil
 }

--- a/internal/adapter/smb/handlers/runtime_iface.go
+++ b/internal/adapter/smb/handlers/runtime_iface.go
@@ -6,6 +6,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metrics"
 )
 
 // smbRuntime is the consumer-defined role interface for the SMB handlers.
@@ -32,6 +33,10 @@ type smbRuntime interface {
 	// Identity / auth backends.
 	GetUserStore() models.UserStore
 	GetIdentityMappingStore() store.IdentityMappingStore
+
+	// Metrics returns the inline metrics sink (may be nil; all Record* methods
+	// are nil-receiver safe). SESSION_SETUP uses it to record SMB auth attempts.
+	Metrics() *metrics.Metrics
 }
 
 var _ smbRuntime = (*runtime.Runtime)(nil)

--- a/internal/adapter/smb/handlers/session_setup.go
+++ b/internal/adapter/smb/handlers/session_setup.go
@@ -19,6 +19,16 @@ import (
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 )
 
+// recordAuth emits one SMB authentication-attempt metric (and a failure when
+// ok is false) for the given mechanism (ntlm|krb5). No-op when no runtime or no
+// metrics backend is wired; Metrics().RecordAuth is itself nil-receiver safe.
+func (h *Handler) recordAuth(mechanism string, ok bool) {
+	if h == nil || h.Registry == nil {
+		return
+	}
+	h.Registry.Metrics().RecordAuth("smb", mechanism, ok)
+}
+
 // SESSION_SETUP request structure offsets [MS-SMB2] 2.2.5
 const (
 	sessionSetupStructureSizeOffset     = 0  // 2 bytes: Always 25
@@ -1012,18 +1022,28 @@ func (h *Handler) handleNTLMNegotiate(ctx *SMBHandlerContext, usedSPNEGO bool, m
 //  6. Creating an authenticated or guest session
 //  7. Configuring session signing with the derived key
 //  8. Cleaning up the pending authentication state
-func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte) (*HandlerResult, error) {
+func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte) (result *HandlerResult, retErr error) {
 	// Get and validate pending auth
 	pending, ok := h.GetPendingAuth(ctx.SessionID, ctx.ConnID)
 	if !ok {
 		logger.Debug("No pending auth for session",
 			"sessionID", ctx.SessionID,
 			"connID", ctx.ConnID)
+		// No pending handshake: a stray TYPE_3 is a protocol error, not a
+		// credential verdict — not counted as an NTLM auth attempt.
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
 
 	// Remove pending auth (handshake complete)
 	h.DeletePendingAuth(ctx.SessionID, ctx.ConnID)
+
+	// Record the terminal NTLM auth verdict: this is the TYPE_3 (AUTHENTICATE)
+	// completion, so exactly one attempt is counted per handshake. Success is any
+	// non-error result (StatusSuccess for validated/anonymous/guest sessions);
+	// LOGON_FAILURE / INVALID_PARAMETER count as failures.
+	defer func() {
+		h.recordAuth("ntlm", result != nil && !result.Status.IsError())
+	}()
 
 	// Extract NTLM token (unwrap SPNEGO if needed)
 	ntlmToken, _, _ := extractNTLMToken(securityBuffer)

--- a/internal/adapter/smb/handlers/session_setup_metrics_test.go
+++ b/internal/adapter/smb/handlers/session_setup_metrics_test.go
@@ -1,0 +1,134 @@
+package handlers
+
+// Tests for SMB authentication metrics (PR-2b of #1188): SESSION_SETUP records
+// one dittofs_auth_attempts_total{protocol=smb,mechanism} per terminal verdict,
+// plus a dittofs_auth_failures_total on failure. Mechanism is bounded to
+// {ntlm,krb5}.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/auth"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/metrics"
+)
+
+// newMetricsHandler builds a Handler whose Registry is a runtime with a real,
+// owned metrics registry the test can scrape, backed by an in-memory store.
+func newMetricsHandler(t *testing.T) (*Handler, *metrics.Metrics) {
+	t.Helper()
+	h := NewHandler()
+	h.NtlmEnabled = true
+	rt := runtime.New(newInMemoryStoreForTest(t))
+	m := metrics.New("test", "test")
+	rt.SetMetrics(m)
+	h.Registry = rt
+	return h, m
+}
+
+func TestSessionSetup_RecordsKerberosFailure(t *testing.T) {
+	h, m := newMetricsHandler(t)
+	// No KerberosService configured: handleKerberosAuth returns LOGON_FAILURE,
+	// which the auth recorder counts as one failed krb5 attempt.
+	ctx := NewSMBHandlerContext(context.Background(), "127.0.0.1:1", 0, 0, 1)
+	res, err := h.handleKerberosAuth(ctx, []byte{0x01, 0x02}, &auth.ParsedToken{})
+	if err != nil {
+		t.Fatalf("handleKerberosAuth returned error: %v", err)
+	}
+	if res == nil || res.Status != types.StatusLogonFailure {
+		t.Fatalf("expected LOGON_FAILURE result, got %+v", res)
+	}
+
+	if got := counterValue(t, m, "dittofs_auth_attempts_total", "smb", "krb5"); got != 1 {
+		t.Fatalf("krb5 attempts = %v, want 1", got)
+	}
+	if got := counterValue(t, m, "dittofs_auth_failures_total", "smb", "krb5"); got != 1 {
+		t.Fatalf("krb5 failures = %v, want 1", got)
+	}
+}
+
+func TestSessionSetup_RecordsKerberosBindFailure(t *testing.T) {
+	h, m := newMetricsHandler(t)
+	// completeKerberosBind is the single-shot Kerberos channel-bind verdict. With
+	// no KerberosService it returns LOGON_FAILURE, recorded as one failed krb5
+	// attempt — the bind path must be instrumented just like handleKerberosAuth.
+	const sessionID = uint64(0xabc)
+	sess := h.CreateSessionWithUser(sessionID, "127.0.0.1:1", &models.User{Username: "alice", Enabled: true}, "")
+	ctx := NewSMBHandlerContext(context.Background(), "127.0.0.1:1", sessionID, 0, 1)
+
+	res, err := h.completeKerberosBind(ctx, sess, &auth.ParsedToken{})
+	if err != nil {
+		t.Fatalf("completeKerberosBind returned error: %v", err)
+	}
+	if res == nil || res.Status != types.StatusLogonFailure {
+		t.Fatalf("expected LOGON_FAILURE result, got %+v", res)
+	}
+
+	if got := counterValue(t, m, "dittofs_auth_attempts_total", "smb", "krb5"); got != 1 {
+		t.Fatalf("krb5 bind attempts = %v, want 1", got)
+	}
+	if got := counterValue(t, m, "dittofs_auth_failures_total", "smb", "krb5"); got != 1 {
+		t.Fatalf("krb5 bind failures = %v, want 1", got)
+	}
+}
+
+func TestSessionSetup_RecordsNTLMFailure(t *testing.T) {
+	h, m := newMetricsHandler(t)
+	// Seed a pending NTLM handshake so completeNTLMAuth treats this as a
+	// terminal TYPE_3 verdict. The user does not exist in the store → the
+	// userStore lookup fails → LOGON_FAILURE → one failed ntlm attempt.
+	const sessionID, connID = uint64(7), uint64(3)
+	h.StorePendingAuth(&PendingAuth{SessionID: sessionID, ConnID: connID})
+
+	ctx := NewSMBHandlerContext(context.Background(), "127.0.0.1:1", sessionID, 0, 1)
+	ctx.ConnID = connID
+
+	authMsg := buildNTLMAuthenticateForTest("ghost", "", nil)
+	res, err := h.completeNTLMAuth(ctx, authMsg)
+	if err != nil {
+		t.Fatalf("completeNTLMAuth returned error: %v", err)
+	}
+	if res == nil || res.Status != types.StatusLogonFailure {
+		t.Fatalf("expected LOGON_FAILURE result, got %+v", res)
+	}
+
+	if got := counterValue(t, m, "dittofs_auth_attempts_total", "smb", "ntlm"); got != 1 {
+		t.Fatalf("ntlm attempts = %v, want 1", got)
+	}
+	if got := counterValue(t, m, "dittofs_auth_failures_total", "smb", "ntlm"); got != 1 {
+		t.Fatalf("ntlm failures = %v, want 1", got)
+	}
+}
+
+// counterValue scrapes the named counter and returns the value of the sample
+// matching {protocol,mechanism}, or -1 when no such sample exists.
+func counterValue(t *testing.T, m *metrics.Metrics, name, protocol, mechanism string) float64 {
+	t.Helper()
+	mfs, err := m.Registry().Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, mc := range mf.GetMetric() {
+			var p, mech string
+			for _, l := range mc.GetLabel() {
+				switch l.GetName() {
+				case "protocol":
+					p = l.GetValue()
+				case "mechanism":
+					mech = l.GetValue()
+				}
+			}
+			if p == protocol && mech == mechanism {
+				return mc.GetCounter().GetValue()
+			}
+		}
+	}
+	return -1
+}

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/handlers"
@@ -12,6 +13,36 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/internal/logger"
 )
+
+// recordRequest emits one SMB RED sample (rate/errors/duration) for op. status
+// is the bounded ok|error label; SMB carries a precise per-command NTSTATUS, so
+// callers derive it from the result/error rather than collapsing every failure
+// into "error" only on transport faults. No-op when connInfo carries no metrics
+// backend. op is lower-cased to keep the {protocol,op} label set bounded and
+// stable regardless of the dispatch table's casing.
+func recordRequest(connInfo *ConnInfo, op string, isError bool, start time.Time) {
+	if connInfo == nil || connInfo.Metrics == nil {
+		return
+	}
+	status := "ok"
+	if isError {
+		status = "error"
+	}
+	connInfo.Metrics.RecordRequest("smb", strings.ToLower(op), status, time.Since(start))
+}
+
+// commandName resolves a bounded operation label for an SMB2 command code.
+// Commands absent from the dispatch table collapse to the single label
+// types.Command.String() yields for unmapped codes ("UNKNOWN", lower-cased to
+// "unknown" by recordRequest) — deliberately a constant rather than the numeric
+// code so an unrecognised-command flood cannot blow up {protocol,op}
+// cardinality. Used on the pre-dispatch error path where no *Command exists.
+func commandName(cmd types.Command) string {
+	if c, ok := DispatchTable[cmd]; ok {
+		return c.Name
+	}
+	return cmd.String()
+}
 
 // ProcessSingleRequest dispatches an SMB2 request to the appropriate handler.
 // This is used for non-compound (single) requests with full credit tracking.
@@ -39,6 +70,19 @@ func ProcessSingleRequest(
 		return ctx.Err()
 	default:
 	}
+
+	// RED metrics: one sample per handled request via a single deferred emit.
+	// metricOp defaults to the request's command name and is refined to the
+	// dispatch-table name once the command resolves; metricErr is flipped on
+	// every protocol-level failure (credit/sequence rejects, pre-dispatch gate
+	// errors, handler errors, and error-class NTSTATUS results). CANCEL (nil
+	// result, no response) leaves metricErr false and records as ok.
+	start := time.Now()
+	metricOp := commandName(reqHeader.Command)
+	metricErr := false
+	defer func() {
+		recordRequest(connInfo, metricOp, metricErr, start)
+	}()
 
 	// Track request for adaptive credit management
 	connInfo.SessionManager.RequestStarted(reqHeader.SessionID)
@@ -73,6 +117,7 @@ func ProcessSingleRequest(
 				"command", reqHeader.Command.String(),
 				"creditCharge", reqHeader.CreditCharge,
 				"error", err)
+			metricErr = true
 			return SendErrorResponse(reqHeader, types.StatusInvalidParameter, connInfo)
 		}
 	}
@@ -84,6 +129,7 @@ func ProcessSingleRequest(
 				"messageID", reqHeader.MessageID,
 				"creditCharge", charge,
 				"exempt", exempt)
+			metricErr = true
 			return SendErrorResponse(reqHeader, types.StatusInvalidParameter, connInfo)
 		}
 	}
@@ -99,6 +145,7 @@ func ProcessSingleRequest(
 		// session/expiry gate so it always dispatches to its handler, which
 		// cancels the pending op and returns nil (no response), per MS-SMB2
 		// §3.3.5.16.
+		metricErr = true
 		return sendDispatchError(reqHeader, errStatus, connInfo, isEncrypted)
 	}
 
@@ -119,6 +166,7 @@ func ProcessSingleRequest(
 
 	// Per MS-SMB2 3.3.5.2.1: enforce encryption requirements.
 	if errStatus := checkEncryptionRequired(reqHeader, connInfo, isEncrypted); errStatus != 0 {
+		metricErr = true
 		return sendDispatchError(reqHeader, errStatus, connInfo, isEncrypted)
 	}
 
@@ -129,6 +177,7 @@ func ProcessSingleRequest(
 		logger.Debug("Channel-sequence verification rejected request",
 			"command", reqHeader.Command.String(),
 			"messageID", reqHeader.MessageID)
+		metricErr = true
 		return sendDispatchError(reqHeader, errStatus, connInfo, isEncrypted)
 	}
 
@@ -181,6 +230,9 @@ func ProcessSingleRequest(
 		handlerCtx.RequestAsyncId = reqHeader.AsyncId
 	}
 
+	// Refine the RED op label now that the dispatch table resolved the command.
+	metricOp = cmd.Name
+
 	logger.Debug("Dispatching SMB2 command",
 		"command", cmd.Name,
 		"messageID", reqHeader.MessageID,
@@ -190,6 +242,7 @@ func ProcessSingleRequest(
 	result, err := cmd.Handler(handlerCtx, connInfo.Handler, body)
 	if err != nil {
 		logger.Debug("Handler error", "command", cmd.Name, "error", err)
+		metricErr = true
 		return SendErrorResponse(reqHeader, types.StatusInternalError, connInfo)
 	}
 
@@ -201,8 +254,15 @@ func ProcessSingleRequest(
 			logger.Warn("Handler returned nil result for non-CANCEL command",
 				"command", cmd.Name, "client", handlerCtx.ClientAddr)
 		}
+		// A nil result means no response was sent (CANCEL per §3.3.5.16). The
+		// request was still handled successfully — record it as ok via the defer.
 		return nil
 	}
+
+	// Derive the precise ok|error status from the handler's NTSTATUS — SMB
+	// returns a precise per-command status, so use it rather than collapsing
+	// every non-transport failure into ok (unlike NFSv4's coarse compound).
+	metricErr = result.Status.IsError()
 
 	// DropConnection: close TCP without sending a response.
 	// Used for fatal protocol violations (e.g., VALIDATE_NEGOTIATE failure).
@@ -422,8 +482,19 @@ func prepareDispatch(ctx context.Context, reqHeader *header.SMB2Header, connInfo
 // [MS-SMB2] 3.3.5.5). Callers on the compound path MUST thread per-subcommand
 // wire bytes here; the first-command caller can pass the concatenation of
 // firstHeader.Encode() and firstBody when no sliced buffer is available.
-func ProcessRequestWithFileIDAndCallback(ctx context.Context, reqHeader *header.SMB2Header, body []byte, rawMessage []byte, connInfo *ConnInfo, isEncrypted bool, asyncNotifyCallback handlers.AsyncResponseCallback) (*HandlerResult, [16]byte, *handlers.SMBHandlerContext) {
+func ProcessRequestWithFileIDAndCallback(ctx context.Context, reqHeader *header.SMB2Header, body []byte, rawMessage []byte, connInfo *ConnInfo, isEncrypted bool, asyncNotifyCallback handlers.AsyncResponseCallback) (retResult *HandlerResult, retFileID [16]byte, retCtx *handlers.SMBHandlerContext) {
 	var fileID [16]byte
+
+	// RED metrics: one sample per compound subcommand. SMB carries a precise
+	// per-command NTSTATUS, so each subcommand is recorded with its own
+	// op/status rather than collapsed into a single compound sample. The defer
+	// reads the named result so it records whatever status the handler (or a
+	// pre-dispatch gate) produced; a nil result (CANCEL, no response) records ok.
+	start := time.Now()
+	metricOp := commandName(reqHeader.Command)
+	defer func() {
+		recordRequest(connInfo, metricOp, retResult != nil && retResult.Status.IsError(), start)
+	}()
 
 	cmd, handlerCtx, errStatus := prepareDispatch(ctx, reqHeader, connInfo)
 	if errStatus != 0 {
@@ -500,6 +571,9 @@ func ProcessRequestWithFileIDAndCallback(ctx context.Context, reqHeader *header.
 	if reqHeader.Command == types.SMB2Cancel && reqHeader.Flags.IsAsync() {
 		handlerCtx.RequestAsyncId = reqHeader.AsyncId
 	}
+
+	// Refine the RED op label now that the dispatch table resolved the command.
+	metricOp = cmd.Name
 
 	logger.Debug("Dispatching SMB2 command",
 		"command", cmd.Name,

--- a/internal/adapter/smb/response_metrics_test.go
+++ b/internal/adapter/smb/response_metrics_test.go
@@ -1,0 +1,123 @@
+package smb
+
+// Tests for the SMB RED (rate/errors/duration) metrics wired into the dispatch
+// path (PR-2b of #1188). They drive ProcessSingleRequest with a real
+// *metrics.Metrics sink on the ConnInfo and assert the emitted series carry
+// bounded labels (protocol=smb, lower-cased op, ok|error status).
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/handlers"
+	"github.com/marmos91/dittofs/internal/adapter/smb/header"
+	"github.com/marmos91/dittofs/internal/adapter/smb/session"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/metrics"
+)
+
+// newMetricsConnInfo builds a ConnInfo whose send path routes through
+// WriteNetBIOSFrame (SessionID 0 keeps the plain-wire branch) and whose Metrics
+// sink is a real, owned registry the test can scrape.
+func newMetricsConnInfo(t *testing.T, conn net.Conn) (*ConnInfo, *metrics.Metrics) {
+	t.Helper()
+	m := metrics.New("test", "test")
+	mgr := session.NewDefaultManager()
+	return &ConnInfo{
+		Conn:           conn,
+		Handler:        handlers.NewHandlerWithSessionManager(mgr),
+		SessionManager: mgr,
+		WriteMu:        &LockedWriter{},
+		WriteTimeout:   2 * time.Second,
+		SequenceWindow: NewSequenceWindowForConnection(mgr),
+		Metrics:        m,
+	}, m
+}
+
+// echoBody is the minimal valid SMB2 ECHO request body (StructureSize=4).
+func echoBody() []byte { return []byte{0x04, 0x00, 0x00, 0x00} }
+
+func echoHeader(messageID uint64) *header.SMB2Header {
+	return &header.SMB2Header{
+		StructureSize: header.HeaderSize,
+		Command:       types.SMB2Echo,
+		Credits:       1,
+		CreditCharge:  1,
+		MessageID:     messageID,
+		SessionID:     0,
+		TreeID:        0,
+	}
+}
+
+func TestProcessSingleRequest_RecordsRedOnSuccess(t *testing.T) {
+	serverConn, cleanup := newTestConnPair(t)
+	t.Cleanup(cleanup)
+
+	ci, m := newMetricsConnInfo(t, serverConn)
+
+	if err := ProcessSingleRequest(context.Background(), echoHeader(1), echoBody(), nil, ci, false, nil); err != nil {
+		t.Fatalf("ProcessSingleRequest(ECHO) returned error: %v", err)
+	}
+
+	expected := `
+# HELP dittofs_adapter_requests_total Protocol requests handled, by protocol, operation, and status (ok|error).
+# TYPE dittofs_adapter_requests_total counter
+dittofs_adapter_requests_total{op="echo",protocol="smb",status="ok"} 1
+`
+	if err := testutil.GatherAndCompare(m.Registry(), strings.NewReader(expected), "dittofs_adapter_requests_total"); err != nil {
+		t.Fatalf("requests_total mismatch: %v", err)
+	}
+	if got := testutil.CollectAndCount(m.Registry(), "dittofs_adapter_request_duration_seconds"); got == 0 {
+		t.Fatal("expected request_duration_seconds series for smb echo")
+	}
+}
+
+func TestProcessSingleRequest_RecordsErrorOnUnknownCommand(t *testing.T) {
+	serverConn, cleanup := newTestConnPair(t)
+	t.Cleanup(cleanup)
+
+	ci, m := newMetricsConnInfo(t, serverConn)
+	// An unmapped command code makes prepareDispatch return STATUS_INVALID_PARAMETER
+	// before any handler runs; the dispatch-error path records status="error".
+	reqHeader := echoHeader(1)
+	reqHeader.Command = types.Command(0x7000) // not in DispatchTable
+
+	if err := ProcessSingleRequest(context.Background(), reqHeader, nil, nil, ci, false, nil); err != nil {
+		t.Fatalf("ProcessSingleRequest(unknown) returned error: %v", err)
+	}
+
+	// Unmapped codes collapse to the single bounded op="unknown" label (not the
+	// numeric code) so an unrecognised-command flood cannot blow up cardinality.
+	expected := `
+# HELP dittofs_adapter_requests_total Protocol requests handled, by protocol, operation, and status (ok|error).
+# TYPE dittofs_adapter_requests_total counter
+dittofs_adapter_requests_total{op="unknown",protocol="smb",status="error"} 1
+`
+	if err := testutil.GatherAndCompare(m.Registry(), strings.NewReader(expected), "dittofs_adapter_requests_total"); err != nil {
+		t.Fatalf("requests_total mismatch: %v", err)
+	}
+}
+
+func TestProcessSingleRequest_NilMetricsNoPanic(t *testing.T) {
+	serverConn, cleanup := newTestConnPair(t)
+	t.Cleanup(cleanup)
+
+	mgr := session.NewDefaultManager()
+	ci := &ConnInfo{
+		Conn:           serverConn,
+		Handler:        handlers.NewHandlerWithSessionManager(mgr),
+		SessionManager: mgr,
+		WriteMu:        &LockedWriter{},
+		WriteTimeout:   2 * time.Second,
+		SequenceWindow: NewSequenceWindowForConnection(mgr),
+		Metrics:        nil,
+	}
+	if err := ProcessSingleRequest(context.Background(), echoHeader(1), echoBody(), nil, ci, false, nil); err != nil {
+		t.Fatalf("ProcessSingleRequest with nil Metrics returned error: %v", err)
+	}
+}

--- a/pkg/adapter/smb/connection.go
+++ b/pkg/adapter/smb/connection.go
@@ -189,6 +189,11 @@ func (c *Connection) connInfo() *smb.ConnInfo {
 		// Max size = 2 * MaxSessionCredits to allow generous window growth.
 		SequenceWindow: smb.NewSequenceWindowForConnection(c.server.sessionManager),
 	}
+	// Source the metrics sink from the runtime (nil-safe Record* methods). Left
+	// nil when the server runs without a metrics backend; dispatch guards for it.
+	if rt := c.server.Registry; rt != nil {
+		ci.Metrics = rt.Metrics()
+	}
 	// Wrap the session tracker so that session creation/deletion also
 	// registers/deregisters the ConnInfo in the adapter's session→connection
 	// map. This enables lease break notifications to be routed to the correct


### PR DESCRIPTION
## What

Wires the SMB protocol path into the existing nil-safe Prometheus instruments in `pkg/metrics` (introduced in PR-2). **No new instruments are defined** — only SMB call sites are connected. This completes the SMB half deferred from PR-2 (#1204); NFS already had RED + auth.

### RED (rate / errors / duration)
- `internal/adapter/smb/response.go`: `ProcessSingleRequest` and the compound `ProcessRequestWithFileIDAndCallback` (covers both inherited- and fresh-FileID sub-paths) emit one sample per (sub)command via a single deferred record:
  - `dittofs_adapter_requests_total{protocol="smb",op,status}`
  - `dittofs_adapter_request_duration_seconds{protocol="smb",op}`
- `status` is derived from the precise per-command NTSTATUS (`result.Status.IsError()`), not just transport faults — SMB carries an exact status, unlike NFSv4 compound. Credit/sequence rejects, pre-dispatch gate errors, and handler errors all record `status="error"`. CANCEL (nil result, no response) records `ok`.
- `op` is lower-cased and bounded to the SMB command set; unmapped command codes collapse to a single `unknown` label (not the numeric code) so an unrecognised-command flood cannot blow up cardinality.

### Auth
- SESSION_SETUP records `dittofs_auth_attempts_total` / `_failures_total{protocol="smb",mechanism}` once per **terminal** verdict (not on the intermediate NTLM `MORE_PROCESSING_REQUIRED` challenge round):
  - NTLM: `completeNTLMAuth` (covers the bind TYPE_3 via its `IsBinding` branch)
  - Kerberos: `handleKerberosAuth` (primary) and `completeKerberosBind` (single-shot channel bind)
- `mechanism` bounded to `{ntlm,krb5}`.

### Wiring
- `ConnInfo` gains a `MetricsRecorder` field (satisfied by `*metrics.Metrics`), populated in `connInfo()` from the runtime's nil-safe `Metrics()` handle.
- `smbRuntime` exposes `Metrics()` so handlers reach the sink. Every call site is nil-guarded.

## Label discipline
`protocol="smb"` constant; `op` ∈ SMB command set; `status` ∈ `{ok,error}`; `mechanism` ∈ `{ntlm,krb5}`. **No** per-file / handle / session / client / uid labels — cardinality stays bounded.

## Tests
- `response_metrics_test.go`: drives `ProcessSingleRequest` with a real registry; asserts the RED series with bounded labels (success ECHO → `op=echo,status=ok`; unknown command → `status=error`; nil-metrics → no panic).
- `session_setup_metrics_test.go`: asserts one `attempts_total` + one `failures_total` per verdict for NTLM, Kerberos, and Kerberos bind.
- `go build ./...`, `go vet ./...`, full `go test ./...` green.

Part of #1188.