### PR TITLE
fix(metrics): don't mount bearer-token Secret when metrics disabled

### DIFF
--- a/k8s/dittofs-operator/api/v1alpha1/helpers.go
+++ b/k8s/dittofs-operator/api/v1alpha1/helpers.go
@@ -156,9 +156,11 @@ func (ds *DittoServer) MetricsPath() string {
 }
 
 // MetricsBearerTokenSecret returns the configured bearer-token Secret selector,
-// or nil when the endpoint is unauthenticated.
+// or nil when the endpoint is unauthenticated OR metrics are disabled. Gating on
+// MetricsEnabled ensures the token Secret is never mounted/projected into the pod
+// when the /metrics listener is off (avoids needlessly exposing the token).
 func (ds *DittoServer) MetricsBearerTokenSecret() *corev1.SecretKeySelector {
-	if ds.Spec.Metrics != nil {
+	if ds.MetricsEnabled() {
 		return ds.Spec.Metrics.BearerTokenSecret
 	}
 	return nil

--- a/k8s/dittofs-operator/internal/controller/metrics_reconciler_test.go
+++ b/k8s/dittofs-operator/internal/controller/metrics_reconciler_test.go
@@ -305,6 +305,26 @@ func TestServiceMonitorCRDPresent_Gate(t *testing.T) {
 	}
 }
 
+// TestMetricsBearerTokenSecret_GatedOnEnabled verifies the bearer-token Secret
+// is only surfaced (and thus only mounted/projected into the pod) when metrics
+// are enabled, so the token is never exposed while the listener is off.
+func TestMetricsBearerTokenSecret_GatedOnEnabled(t *testing.T) {
+	ref := &corev1.SecretKeySelector{Key: "token"}
+	ref.Name = "tok"
+
+	enabled := newTestDittoServer("s", "default")
+	enabled.Spec.Metrics = &dittoiov1alpha1.MetricsSpec{Enabled: true, BearerTokenSecret: ref}
+	if got := enabled.MetricsBearerTokenSecret(); got == nil {
+		t.Errorf("expected token secret when metrics enabled")
+	}
+
+	disabled := newTestDittoServer("s", "default")
+	disabled.Spec.Metrics = &dittoiov1alpha1.MetricsSpec{Enabled: false, BearerTokenSecret: ref}
+	if got := disabled.MetricsBearerTokenSecret(); got != nil {
+		t.Errorf("token secret must be nil when metrics disabled, got %+v", got)
+	}
+}
+
 func TestBuildContainerPorts_MetricsPort(t *testing.T) {
 	ds := metricsEnabledDittoServer("test-server", "default", nil)
 	ports := buildContainerPorts(ds, nil)


### PR DESCRIPTION
Follow-up to #1210 (PR-4 of #1188) addressing the one actionable Copilot review finding.

`MetricsBearerTokenSecret()` returned the configured Secret selector whenever `spec.metrics.bearerTokenSecret` was set, even with `spec.metrics.enabled: false`. That caused the token Secret volume + mount to be projected into the pod while the `/metrics` listener was off — needlessly placing the token on the pod filesystem.

Fix: gate the helper on `MetricsEnabled()` so the volume/mount (which both source from it) are only created when metrics are actually on. Adds a regression test.

The other Copilot comments (metric label docs, snapshot-stale alert) were already correct in what merged in #1210 — Copilot reviewed an interim diff snapshot.