### PR TITLE
perf(nfs/v4): IsOperationBlocked consults prebuilt cache, not live settings

### DIFF
--- a/internal/adapter/nfs/v4/handlers/compound_test.go
+++ b/internal/adapter/nfs/v4/handlers/compound_test.go
@@ -2591,7 +2591,7 @@ func encodeSetClientIDArgsForReject() []byte {
 // cached blocked-ops set populated by SetBlockedOps (the hot-path optimization),
 // rather than re-parsing live settings on each call.
 func TestIsOperationBlocked_CacheHit(t *testing.T) {
-	h := newTestHandler() // Registry is nil -> purely cache-driven
+	h := newTestHandler() // IsOperationBlocked always consults the cache
 
 	// Nothing blocked initially.
 	if h.IsOperationBlocked(types.OP_READ) {

--- a/internal/adapter/nfs/v4/handlers/handler.go
+++ b/internal/adapter/nfs/v4/handlers/handler.go
@@ -346,24 +346,14 @@ func (h *Handler) SetBlockedOps(opNames []string) {
 // IsOperationBlocked returns true if the given operation number is blocked
 // at the adapter level. Per-share blocked operations are checked separately
 // in the COMPOUND dispatcher using the CompoundContext after PUTFH resolves.
-// Reads live settings from the SettingsWatcher when available, falling back
-// to the local blockedOps cache (used in tests or before settings load).
+//
+// This consults the pre-parsed blockedOps set, which is populated by
+// SetBlockedOps from the SettingsWatcher in applyNFSSettings (on startup and
+// on each settings-change event, with hot-reload support). Doing a single map
+// lookup here keeps the hot COMPOUND dispatch path free of the per-op JSON
+// unmarshal + linear name scan that reading live settings would incur — see
+// the NFSv3 isOperationBlocked path, which is structured the same way.
 func (h *Handler) IsOperationBlocked(opNum uint32) bool {
-	if h.Registry != nil {
-		settings := h.Registry.GetNFSSettings()
-		if settings != nil {
-			blockedOps := settings.GetBlockedOperations()
-			// Check if this operation is in the blocked list
-			for _, name := range blockedOps {
-				if num, ok := types.OpNameToNum(name); ok && num == opNum {
-					return true
-				}
-			}
-			return false
-		}
-	}
-
-	// Fall back to local cache (for tests or when settings not available)
 	h.blockedOpsMu.RLock()
 	blocked := h.blockedOps[opNum]
 	h.blockedOpsMu.RUnlock()

--- a/internal/adapter/nfs/v4/handlers/runtime_iface.go
+++ b/internal/adapter/nfs/v4/handlers/runtime_iface.go
@@ -33,9 +33,6 @@ type nfsRuntime interface {
 	// Identity / auth.
 	GetIdentityStore() models.IdentityStore
 	ApplyIdentityMapping(shareName string, ident *metadata.Identity) (*metadata.Identity, error)
-
-	// Live NFS adapter settings (blocked-operation gating).
-	GetNFSSettings() *models.NFSAdapterSettings
 }
 
 var _ nfsRuntime = (*runtime.Runtime)(nil)

--- a/internal/adapter/nfs/v4/handlers/runtime_iface.go
+++ b/internal/adapter/nfs/v4/handlers/runtime_iface.go
@@ -16,8 +16,8 @@ import (
 // implicitly (compile-time assertion below).
 //
 // It is kept separate from the NFSv3 interface because the two protocols use
-// overlapping but distinct method sets (v4 needs root-handle resolution,
-// handle→share routing and live settings; v3 needs the adapter-provider hook).
+// overlapping but distinct method sets (v4 needs root-handle resolution and
+// handle→share routing; v3 needs the adapter-provider hook).
 type nfsRuntime interface {
 	// Per-share block-store resolution (used via common.ResolveFor*).
 	common.BlockStoreRegistry


### PR DESCRIPTION
Closes #1212.

## Problem

`IsOperationBlocked` (`internal/adapter/nfs/v4/handlers/handler.go`) had a `Registry != nil` branch (the production path) that called `settings.GetBlockedOperations()` → `json.Unmarshal` on every COMPOUND op, plus a linear `OpNameToNum` scan per blocked name. PR #1108 added the `SetBlockedOps` `map[uint32]bool` cache and wired it for NFSv3 + the v4 `Registry == nil` fallback, but the v4 `Registry != nil` branch was never switched to consult it, so the optimization was bypassed in production.

## Fix

Drop the `Registry != nil` branch — `IsOperationBlocked` now always consults the prebuilt `h.blockedOps` map. The cache is already maintained by `applyNFSSettings` (`SetBlockedOps`) on startup and on every SettingsWatcher change (`OnNFSSettingsChange`), so production behavior is identical: the hot COMPOUND dispatch path is now a single map lookup with zero per-op JSON unmarshal — mirroring the NFSv3 `isOperationBlocked` path.

Also trimmed the now-unused `GetNFSSettings` from the `nfsRuntime` role interface (kept minimal per its stated invariant).

## Verification

- `go build ./...`, `go vet ./internal/adapter/nfs/...` clean
- `go test ./internal/adapter/nfs/v4/handlers/ ./pkg/adapter/nfs/` pass (incl. `TestIsOperationBlocked_CacheHit`)
- No correctness/security change; low-severity perf only.