### PR TITLE
feat(dfsctl): client-side TLS — custom CA, mTLS client cert, skip-verify (#1196)

### DIFF
--- a/cmd/dfsctl/cmdutil/util.go
+++ b/cmd/dfsctl/cmdutil/util.go
@@ -52,6 +52,37 @@ type GlobalFlags struct {
 	Output    string
 	NoColor   bool
 	Verbose   bool
+
+	// TLS escape-hatch overrides. When set they take precedence over the TLS
+	// material stored in the active login context. TLSSkipVerifySet records
+	// whether --tls-skip-verify was explicitly passed, so the stored value is
+	// only overridden on an explicit flag (a bare false flag would otherwise
+	// silently re-enable verification).
+	CACert           string
+	ClientCert       string
+	ClientKey        string
+	TLSSkipVerify    bool
+	TLSSkipVerifySet bool
+}
+
+// TLSClientOptions translates resolved TLS parameters into apiclient options.
+// It also emits the man-in-the-middle warning once when verification is
+// disabled. Empty parameters produce no options (default transport behavior).
+func TLSClientOptions(caCert, clientCert, clientKey string, skipVerify bool) []apiclient.ClientOption {
+	var opts []apiclient.ClientOption
+	if caCert != "" {
+		opts = append(opts, apiclient.WithCACert(caCert))
+	}
+	if clientCert != "" || clientKey != "" {
+		opts = append(opts, apiclient.WithClientCert(clientCert, clientKey))
+	}
+	if skipVerify {
+		_, _ = fmt.Fprintln(os.Stderr,
+			"WARNING: TLS certificate verification disabled (--tls-skip-verify); "+
+				"the connection is vulnerable to man-in-the-middle attacks")
+		opts = append(opts, apiclient.WithInsecureSkipVerify(true))
+	}
+	return opts
 }
 
 // GetAuthenticatedClient returns an API client configured from the current context.
@@ -60,7 +91,8 @@ type GlobalFlags struct {
 func GetAuthenticatedClient() (*apiclient.Client, error) {
 	// Check for explicit flags first
 	if Flags.ServerURL != "" && Flags.Token != "" {
-		return apiclient.New(Flags.ServerURL).WithToken(Flags.Token), nil
+		opts := TLSClientOptions(Flags.CACert, Flags.ClientCert, Flags.ClientKey, Flags.TLSSkipVerify)
+		return apiclient.New(Flags.ServerURL, opts...).WithToken(Flags.Token), nil
 	}
 
 	// Load credential store
@@ -90,9 +122,29 @@ func GetAuthenticatedClient() (*apiclient.Client, error) {
 		tok = Flags.Token
 	}
 
+	// Resolve TLS material: stored context is the baseline; root override flags
+	// take precedence when present.
+	caCert := ctx.CACert
+	if Flags.CACert != "" {
+		caCert = Flags.CACert
+	}
+	clientCert := ctx.ClientCert
+	if Flags.ClientCert != "" {
+		clientCert = Flags.ClientCert
+	}
+	clientKey := ctx.ClientKey
+	if Flags.ClientKey != "" {
+		clientKey = Flags.ClientKey
+	}
+	skipVerify := ctx.TLSSkipVerify
+	if Flags.TLSSkipVerifySet {
+		skipVerify = Flags.TLSSkipVerify
+	}
+	tlsOpts := TLSClientOptions(caCert, clientCert, clientKey, skipVerify)
+
 	// Check if token is expired and try to refresh
 	if ctx.IsExpired() && ctx.HasRefreshToken() {
-		client := apiclient.New(url)
+		client := apiclient.New(url, tlsOpts...)
 		newTokens, err := client.RefreshToken(ctx.RefreshToken)
 		if err != nil {
 			// Refresh failed, user needs to re-login
@@ -117,7 +169,7 @@ func GetAuthenticatedClient() (*apiclient.Client, error) {
 		return nil, fmt.Errorf("no access token. Run 'dfsctl login' first")
 	}
 
-	return apiclient.New(url).WithToken(tok), nil
+	return apiclient.New(url, tlsOpts...).WithToken(tok), nil
 }
 
 // GetOutputFormatParsed returns the parsed output format.

--- a/cmd/dfsctl/commands/login.go
+++ b/cmd/dfsctl/commands/login.go
@@ -16,6 +16,11 @@ var (
 	loginUsername    string
 	loginPassword    string
 	loginContextName string
+
+	loginCACert        string
+	loginClientCert    string
+	loginClientKey     string
+	loginTLSSkipVerify bool
 )
 
 var loginCmd = &cobra.Command{
@@ -43,6 +48,10 @@ func init() {
 	loginCmd.Flags().StringVarP(&loginUsername, "username", "u", "", "Username")
 	loginCmd.Flags().StringVarP(&loginPassword, "password", "p", "", "Password")
 	loginCmd.Flags().StringVarP(&loginContextName, "context", "c", "", "Context name (defaults to current or auto-generated)")
+	loginCmd.Flags().StringVar(&loginCACert, "cacert", "", "Path to a PEM CA bundle trusted for the server certificate")
+	loginCmd.Flags().StringVar(&loginClientCert, "client-cert", "", "Path to a PEM client certificate for mutual TLS")
+	loginCmd.Flags().StringVar(&loginClientKey, "client-key", "", "Path to the PEM client private key for mutual TLS")
+	loginCmd.Flags().BoolVar(&loginTLSSkipVerify, "tls-skip-verify", false, "Disable TLS certificate verification (insecure)")
 }
 
 func runLogin(cmd *cobra.Command, args []string) error {
@@ -83,8 +92,10 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Create API client
-	client := apiclient.New(serverURLStr)
+	// Create API client. TLS material is captured here and persisted into the
+	// context below so later commands reuse it without re-specifying flags.
+	tlsOpts := cmdutil.TLSClientOptions(loginCACert, loginClientCert, loginClientKey, loginTLSSkipVerify)
+	client := apiclient.New(serverURLStr, tlsOpts...)
 
 	// Attempt login
 	fmt.Printf("Logging in to %s as %s...\n", serverURLStr, username)
@@ -117,11 +128,15 @@ func runLogin(cmd *cobra.Command, args []string) error {
 
 	// Save credentials
 	ctx := &credentials.Context{
-		ServerURL:    serverURLStr,
-		Username:     username,
-		AccessToken:  tokens.AccessToken,
-		RefreshToken: tokens.RefreshToken,
-		ExpiresAt:    tokens.ExpiresAt,
+		ServerURL:     serverURLStr,
+		Username:      username,
+		AccessToken:   tokens.AccessToken,
+		RefreshToken:  tokens.RefreshToken,
+		ExpiresAt:     tokens.ExpiresAt,
+		CACert:        loginCACert,
+		ClientCert:    loginClientCert,
+		ClientKey:     loginClientKey,
+		TLSSkipVerify: loginTLSSkipVerify,
 	}
 
 	if err := store.SetContext(contextName, ctx); err != nil {

--- a/cmd/dfsctl/commands/root.go
+++ b/cmd/dfsctl/commands/root.go
@@ -49,6 +49,11 @@ Use "dfsctl [command] --help" for more information about a command.`,
 		cmdutil.Flags.Output, _ = cmd.Flags().GetString("output")
 		cmdutil.Flags.NoColor, _ = cmd.Flags().GetBool("no-color")
 		cmdutil.Flags.Verbose, _ = cmd.Flags().GetBool("verbose")
+		cmdutil.Flags.CACert, _ = cmd.Flags().GetString("cacert")
+		cmdutil.Flags.ClientCert, _ = cmd.Flags().GetString("client-cert")
+		cmdutil.Flags.ClientKey, _ = cmd.Flags().GetString("client-key")
+		cmdutil.Flags.TLSSkipVerify, _ = cmd.Flags().GetBool("tls-skip-verify")
+		cmdutil.Flags.TLSSkipVerifySet = cmd.Flags().Changed("tls-skip-verify")
 	},
 }
 
@@ -69,6 +74,13 @@ func init() {
 	rootCmd.PersistentFlags().StringP("output", "o", "table", "Output format (table|json|yaml)")
 	rootCmd.PersistentFlags().Bool("no-color", false, "Disable colored output")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
+
+	// TLS escape-hatch overrides (login-time flags persist into the context;
+	// these override the stored material for a single invocation).
+	rootCmd.PersistentFlags().String("cacert", "", "Path to a PEM CA bundle trusted for the server certificate (overrides stored)")
+	rootCmd.PersistentFlags().String("client-cert", "", "Path to a PEM client certificate for mutual TLS (overrides stored)")
+	rootCmd.PersistentFlags().String("client-key", "", "Path to the PEM client private key for mutual TLS (overrides stored)")
+	rootCmd.PersistentFlags().Bool("tls-skip-verify", false, "Disable TLS certificate verification (insecure; overrides stored)")
 
 	// Add subcommands
 	rootCmd.AddCommand(versionCmd)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -692,11 +692,15 @@ Use "dfsctl [command] --help" for more information about a command.
 Flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl adapter`
@@ -727,11 +731,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl adapter disable`
@@ -754,11 +762,15 @@ dfsctl adapter disable <type>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl adapter edit`
@@ -798,11 +810,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl adapter enable`
@@ -836,11 +852,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl adapter list`
@@ -863,11 +883,15 @@ dfsctl adapter list
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl adapter settings`
@@ -898,11 +922,15 @@ dfsctl adapter settings <type>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl adapter settings nfs`
@@ -918,11 +946,15 @@ dfsctl adapter settings nfs
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl adapter settings nfs reset`
@@ -955,11 +987,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl adapter settings nfs show`
@@ -984,11 +1020,15 @@ dfsctl adapter settings nfs show
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl adapter settings nfs update`
@@ -1045,11 +1085,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl adapter settings smb`
@@ -1065,11 +1109,15 @@ dfsctl adapter settings smb
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl adapter settings smb reset`
@@ -1102,11 +1150,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl adapter settings smb show`
@@ -1131,11 +1183,15 @@ dfsctl adapter settings smb show
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl adapter settings smb update`
@@ -1178,11 +1234,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl bench`
@@ -1210,11 +1270,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl bench compare`
@@ -1237,11 +1301,15 @@ dfsctl bench compare FILE [FILE...]
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl bench run`
@@ -1284,11 +1352,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl bench storage-tiers`
@@ -1335,11 +1407,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl client`
@@ -1367,11 +1443,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl client disconnect`
@@ -1404,11 +1484,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl client list`
@@ -1447,11 +1531,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl client sessions`
@@ -1473,11 +1561,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl client sessions destroy`
@@ -1509,11 +1601,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl client sessions list`
@@ -1536,11 +1632,15 @@ dfsctl client sessions list <client-id>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl completion`
@@ -1588,11 +1688,15 @@ dfsctl completion [bash|zsh|fish|powershell]
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl context`
@@ -1614,11 +1718,15 @@ Subcommands:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl context current`
@@ -1647,10 +1755,14 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl context delete`
@@ -1681,11 +1793,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl context list`
@@ -1711,11 +1827,15 @@ dfsctl context list
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl context rename`
@@ -1735,11 +1855,15 @@ dfsctl context rename <old-name> <new-name>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl context use`
@@ -1761,11 +1885,15 @@ dfsctl context use <name>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl grace`
@@ -1791,11 +1919,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl grace end`
@@ -1819,11 +1951,15 @@ dfsctl grace end
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl grace status`
@@ -1853,11 +1989,15 @@ dfsctl grace status
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl group`
@@ -1895,11 +2035,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl group add-user`
@@ -1919,11 +2063,15 @@ dfsctl group add-user <group> <username>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl group create`
@@ -1957,11 +2105,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl group delete`
@@ -1993,11 +2145,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl group edit`
@@ -2033,11 +2189,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl group get`
@@ -2060,11 +2220,15 @@ dfsctl group get <name>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl group list`
@@ -2090,11 +2254,15 @@ dfsctl group list
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl group remove-user`
@@ -2114,11 +2282,15 @@ dfsctl group remove-user <group> <username>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl idmap`
@@ -2153,11 +2325,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl idmap add`
@@ -2191,11 +2367,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl idmap list`
@@ -2227,11 +2407,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl idmap remove`
@@ -2268,11 +2452,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl login`
@@ -2301,10 +2489,14 @@ dfsctl login [flags]
 Flags:
 
 ```
-  -c, --context string    Context name (defaults to current or auto-generated)
-  -p, --password string   Password
-      --server string     Server URL (default "http://localhost:8080")
-  -u, --username string   Username
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate
+      --client-cert string   Path to a PEM client certificate for mutual TLS
+      --client-key string    Path to the PEM client private key for mutual TLS
+  -c, --context string       Context name (defaults to current or auto-generated)
+  -p, --password string      Password
+      --server string        Server URL (default "http://localhost:8080")
+      --tls-skip-verify      Disable TLS certificate verification (insecure)
+  -u, --username string      Username
 ```
 
 Global flags:
@@ -2336,11 +2528,15 @@ dfsctl logout
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl netgroup`
@@ -2374,11 +2570,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl netgroup add-member`
@@ -2411,11 +2611,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl netgroup create`
@@ -2444,11 +2648,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl netgroup delete`
@@ -2483,11 +2691,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl netgroup list`
@@ -2510,11 +2722,15 @@ dfsctl netgroup list
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl netgroup remove-member`
@@ -2542,11 +2758,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl netgroup show`
@@ -2569,11 +2789,15 @@ dfsctl netgroup show <name>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl quota`
@@ -2605,11 +2829,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl quota list`
@@ -2632,11 +2860,15 @@ dfsctl quota list <share>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl quota rm`
@@ -2673,11 +2905,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl quota set`
@@ -2721,11 +2957,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl settings`
@@ -2750,11 +2990,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl settings get`
@@ -2777,11 +3021,15 @@ dfsctl settings get <key>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl settings list`
@@ -2804,11 +3052,15 @@ dfsctl settings list
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl settings set`
@@ -2831,11 +3083,15 @@ dfsctl settings set <key> <value>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share`
@@ -2879,11 +3135,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share create`
@@ -2959,11 +3219,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share delete`
@@ -2995,11 +3259,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share disable`
@@ -3031,11 +3299,15 @@ dfsctl share disable <name>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share edit`
@@ -3117,11 +3389,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share enable`
@@ -3148,11 +3424,15 @@ dfsctl share enable <name>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share list`
@@ -3178,11 +3458,15 @@ dfsctl share list
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share list-mounts`
@@ -3211,11 +3495,15 @@ dfsctl share list-mounts [share]
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share mount`
@@ -3271,11 +3559,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share nfs-config`
@@ -3302,11 +3594,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share nfs-config set`
@@ -3329,11 +3625,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share nfs-config show`
@@ -3347,11 +3647,15 @@ dfsctl share nfs-config show <name>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share permission`
@@ -3379,11 +3683,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share permission grant`
@@ -3420,11 +3728,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share permission list`
@@ -3447,11 +3759,15 @@ dfsctl share permission list <share>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share permission revoke`
@@ -3481,11 +3797,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share show`
@@ -3508,11 +3828,15 @@ dfsctl share show <name>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share snapshot`
@@ -3544,11 +3868,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share snapshot create`
@@ -3590,11 +3918,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share snapshot delete`
@@ -3623,11 +3955,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share snapshot list`
@@ -3664,11 +4000,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share snapshot restore`
@@ -3707,11 +4047,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share snapshot show`
@@ -3725,11 +4069,15 @@ dfsctl share snapshot show <share> <id>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share snapshot-policy`
@@ -3761,11 +4109,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share snapshot-policy delete`
@@ -3788,11 +4140,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share snapshot-policy list`
@@ -3806,11 +4162,15 @@ dfsctl share snapshot-policy list
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share snapshot-policy run`
@@ -3830,11 +4190,15 @@ dfsctl share snapshot-policy run <share>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share snapshot-policy set`
@@ -3872,11 +4236,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share snapshot-policy show`
@@ -3890,11 +4258,15 @@ dfsctl share snapshot-policy show <share>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl share unmount`
@@ -3931,11 +4303,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl status`
@@ -3964,11 +4340,15 @@ dfsctl status
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store`
@@ -4002,11 +4382,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store block`
@@ -4035,11 +4419,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store block audit-refcounts`
@@ -4068,11 +4456,15 @@ dfsctl store block audit-refcounts <share>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store block evict`
@@ -4120,11 +4512,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store block gc`
@@ -4164,11 +4560,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store block gc-status`
@@ -4193,11 +4593,15 @@ dfsctl store block gc-status <share>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store block health`
@@ -4235,11 +4639,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store block local`
@@ -4264,11 +4672,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store block local add`
@@ -4314,11 +4726,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store block local edit`
@@ -4355,11 +4771,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store block local list`
@@ -4382,11 +4802,15 @@ dfsctl store block local list
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store block local remove`
@@ -4417,11 +4841,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store block remote`
@@ -4446,11 +4874,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store block remote add`
@@ -4518,11 +4950,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store block remote edit`
@@ -4563,11 +4999,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store block remote list`
@@ -4590,11 +5030,15 @@ dfsctl store block remote list
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store block remote remove`
@@ -4625,11 +5069,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store block stats`
@@ -4664,11 +5112,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store metadata`
@@ -4693,11 +5145,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store metadata add`
@@ -4750,11 +5206,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store metadata edit`
@@ -4794,11 +5254,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store metadata health`
@@ -4830,11 +5294,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store metadata list`
@@ -4857,11 +5325,15 @@ dfsctl store metadata list
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl store metadata remove`
@@ -4892,11 +5364,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl switch-user`
@@ -4931,11 +5407,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl system`
@@ -4947,11 +5427,15 @@ System-level operations for managing the DittoFS server.
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl system drain-uploads`
@@ -4978,11 +5462,15 @@ dfsctl system drain-uploads
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl trash`
@@ -5004,11 +5492,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl trash empty`
@@ -5036,11 +5528,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl trash list`
@@ -5064,11 +5560,15 @@ dfsctl trash list <share>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl trash restore`
@@ -5098,11 +5598,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl trash status`
@@ -5123,11 +5627,15 @@ dfsctl trash status <share>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl user`
@@ -5158,11 +5666,15 @@ Examples:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl user change-password`
@@ -5195,11 +5707,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl user create`
@@ -5250,11 +5766,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl user delete`
@@ -5286,11 +5806,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl user edit`
@@ -5339,11 +5863,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl user get`
@@ -5366,11 +5894,15 @@ dfsctl user get <username>
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl user list`
@@ -5396,11 +5928,15 @@ dfsctl user list
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl user password`
@@ -5432,11 +5968,15 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 
 ### `dfsctl version`
@@ -5458,10 +5998,14 @@ Flags:
 Global flags:
 
 ```
-      --no-color        Disable colored output
-  -o, --output string   Output format (table|json|yaml) (default "table")
-      --server string   Server URL (overrides stored credential)
-      --token string    Bearer token (overrides stored credential)
-  -v, --verbose         Enable verbose output
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
 ```
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -408,6 +408,21 @@ This TLS support is deliberately thin and follows the etcd/MinIO/Vault-client no
 
 See [docs/CONFIGURATION.md](CONFIGURATION.md#tls-and-bind-address) for the full option reference and [docs/DEPLOYMENT.md](DEPLOYMENT.md) for deployment topologies. Note this covers the **control plane API only** — NFS/SMB data-plane traffic still relies on network-level encryption (below).
 
+**`dfsctl` client-side TLS.** When the API is served behind a private CA or mutual TLS, the `dfsctl` client needs the matching trust material. It is captured **once at login** and reused by every later command — TLS is a property of the login context, not a per-request flag:
+
+```bash
+# Private CA: trust the server certificate
+dfsctl login --server https://host:port --cacert /etc/dittofs/tls/ca.crt -u admin
+
+# Mutual TLS: also present a client certificate
+dfsctl login --server https://host:port --cacert ca.crt \
+    --client-cert client.crt --client-key client.key -u admin
+
+dfsctl share list   # reuses the stored CA / client cert — no flags needed
+```
+
+The login stores the certificate **file paths** (not their contents) in the per-context credential file. Each command re-reads the files, so certbot / cert-manager rotation is picked up automatically on the next invocation — the paths must stay readable. The same flags exist as root-level escape hatches (`dfsctl --cacert … share list`) and take precedence over the stored context for a single command. `--tls-skip-verify` disables certificate verification and is **insecure** (vulnerable to man-in-the-middle); it prints a warning and is intended only for development against self-signed certs. Setting `--client-cert` without `--client-key` is rejected.
+
 ### Network-Level Protection
 
 **Use VPN or encrypted tunnels:**

--- a/internal/cli/credentials/store.go
+++ b/internal/cli/credentials/store.go
@@ -38,6 +38,14 @@ type Context struct {
 	AccessToken  string    `json:"access_token,omitempty"`
 	RefreshToken string    `json:"refresh_token,omitempty"`
 	ExpiresAt    time.Time `json:"expires_at,omitempty"`
+
+	// TLS material captured at login and reused by every later command. Paths
+	// are stored (not contents) so the files are re-read each run and survive
+	// certbot/cert-manager rotation; the paths must stay readable.
+	CACert        string `json:"ca_cert,omitempty"`
+	ClientCert    string `json:"client_cert,omitempty"`
+	ClientKey     string `json:"client_key,omitempty"`
+	TLSSkipVerify bool   `json:"tls_skip_verify,omitempty"`
 }
 
 // IsExpired returns true if the access token has expired.

--- a/pkg/apiclient/client.go
+++ b/pkg/apiclient/client.go
@@ -4,10 +4,13 @@ package apiclient
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"time"
 )
 
@@ -17,6 +20,16 @@ type Client struct {
 	httpClient         *http.Client
 	token              string
 	restoreHTTPTimeout time.Duration
+
+	// TLS intent captured by the With* options and resolved once in New.
+	caCertPath         string
+	clientCertPath     string
+	clientKeyPath      string
+	insecureSkipVerify bool
+	// tlsErr holds a deferred TLS-configuration failure (bad CA file, missing
+	// client key, etc.). New does not return an error, so the failure is
+	// surfaced on the first request instead of being silently dropped.
+	tlsErr error
 }
 
 // ClientOption configures a Client at construction time.
@@ -27,6 +40,30 @@ type ClientOption func(*Client)
 // default 30 second client timeout.
 func WithRestoreTimeout(d time.Duration) ClientOption {
 	return func(c *Client) { c.restoreHTTPTimeout = d }
+}
+
+// WithCACert trusts the PEM-encoded CA bundle at path (in addition to the
+// system roots) when verifying the server certificate. Use it to reach a
+// server that presents a certificate signed by a private CA.
+func WithCACert(path string) ClientOption {
+	return func(c *Client) { c.caCertPath = path }
+}
+
+// WithClientCert presents the PEM-encoded client certificate/key pair for
+// mutual TLS. Both paths are required together; supplying one without the
+// other is a configuration error surfaced on the first request.
+func WithClientCert(certPath, keyPath string) ClientOption {
+	return func(c *Client) {
+		c.clientCertPath = certPath
+		c.clientKeyPath = keyPath
+	}
+}
+
+// WithInsecureSkipVerify disables server certificate verification. This is
+// insecure (vulnerable to man-in-the-middle) and intended only for
+// development against self-signed certs; the CLI emits a warning when set.
+func WithInsecureSkipVerify(skip bool) ClientOption {
+	return func(c *Client) { c.insecureSkipVerify = skip }
 }
 
 // defaultRestoreHTTPTimeout is the timeout applied to the restore HTTP call
@@ -47,7 +84,59 @@ func New(baseURL string, opts ...ClientOption) *Client {
 	for _, opt := range opts {
 		opt(c)
 	}
+	// Resolve TLS material once. Only build a custom transport when a TLS
+	// option was set, so the default behavior (system-root trust over the
+	// shared default transport) is preserved for plain HTTP / public-CA TLS.
+	if c.caCertPath != "" || c.clientCertPath != "" || c.clientKeyPath != "" || c.insecureSkipVerify {
+		if err := c.applyTLS(); err != nil {
+			c.tlsErr = err
+		}
+	}
 	return c
+}
+
+// applyTLS builds a *tls.Config from the captured options and installs it on a
+// cloned default transport (preserving proxy/keep-alive defaults). It is the
+// single place client TLS material is read from disk.
+func (c *Client) applyTLS() error {
+	if (c.clientCertPath == "") != (c.clientKeyPath == "") {
+		return fmt.Errorf("client certificate and key must be provided together (got cert=%q key=%q)", c.clientCertPath, c.clientKeyPath)
+	}
+
+	tlsCfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	tlsCfg.InsecureSkipVerify = c.insecureSkipVerify //nolint:gosec // opt-in via --tls-skip-verify; the CLI warns when enabled
+
+	if c.caCertPath != "" {
+		caPEM, err := os.ReadFile(c.caCertPath)
+		if err != nil {
+			return fmt.Errorf("read CA cert %s: %w", c.caCertPath, err)
+		}
+		pool, err := x509.SystemCertPool()
+		if err != nil || pool == nil {
+			pool = x509.NewCertPool()
+		}
+		if !pool.AppendCertsFromPEM(caPEM) {
+			return fmt.Errorf("CA cert %s contains no valid PEM certificate", c.caCertPath)
+		}
+		tlsCfg.RootCAs = pool
+	}
+
+	if c.clientCertPath != "" {
+		cert, err := tls.LoadX509KeyPair(c.clientCertPath, c.clientKeyPath)
+		if err != nil {
+			return fmt.Errorf("load client key pair (cert=%s key=%s): %w", c.clientCertPath, c.clientKeyPath, err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
+
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return fmt.Errorf("unexpected default HTTP transport type %T", http.DefaultTransport)
+	}
+	tr := base.Clone()
+	tr.TLSClientConfig = tlsCfg
+	c.httpClient.Transport = tr
+	return nil
 }
 
 // WithToken returns a new client with the given token.
@@ -57,6 +146,11 @@ func (c *Client) WithToken(token string) *Client {
 		httpClient:         c.httpClient,
 		token:              token,
 		restoreHTTPTimeout: c.restoreHTTPTimeout,
+		caCertPath:         c.caCertPath,
+		clientCertPath:     c.clientCertPath,
+		clientKeyPath:      c.clientKeyPath,
+		insecureSkipVerify: c.insecureSkipVerify,
+		tlsErr:             c.tlsErr,
 	}
 }
 
@@ -93,6 +187,13 @@ func (c *Client) doCtx(ctx context.Context, method, path string, body, result an
 // cancellation and overall deadline; the http.Client's Timeout still acts
 // as an upper bound.
 func (c *Client) doVia(ctx context.Context, hc *http.Client, method, path string, body, result any) error {
+	// Surface a deferred TLS-configuration failure (captured in New) before
+	// attempting any I/O, so the user gets a precise error instead of an
+	// opaque transport failure.
+	if c.tlsErr != nil {
+		return c.tlsErr
+	}
+
 	var bodyReader io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)

--- a/pkg/apiclient/client_tls_test.go
+++ b/pkg/apiclient/client_tls_test.go
@@ -1,0 +1,151 @@
+package apiclient
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// genKeyPair mints a self-signed ECDSA cert/key pair, writes them to dir, and
+// returns their paths plus the leaf cert (for trust-pool assembly).
+func genKeyPair(t *testing.T, dir, cn string) (certPath, keyPath string, leaf *x509.Certificate) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{cn},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	parsed, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	certPath = filepath.Join(dir, cn+".crt")
+	keyPath = filepath.Join(dir, cn+".key")
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	require.NoError(t, os.WriteFile(certPath, certPEM, 0o600))
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600))
+	return certPath, keyPath, parsed
+}
+
+// writeCAFile writes a leaf cert as a PEM CA bundle and returns the path.
+func writeCAFile(t *testing.T, dir string, leaf *x509.Certificate) string {
+	t.Helper()
+	caPath := filepath.Join(dir, "ca.crt")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leaf.Raw})
+	require.NoError(t, os.WriteFile(caPath, pemBytes, 0o600))
+	return caPath
+}
+
+func TestClient_CustomCA_TrustsPrivateCert(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	caPath := writeCAFile(t, t.TempDir(), ts.Certificate())
+
+	// Without the CA the self-signed server cert is untrusted → request fails.
+	noCA := New(ts.URL)
+	assert.Error(t, noCA.do(http.MethodGet, "/", nil, nil),
+		"expected untrusted cert to fail without --cacert")
+
+	// With the CA trusted the request succeeds.
+	withCA := New(ts.URL, WithCACert(caPath))
+	require.NoError(t, withCA.tlsErr)
+	assert.NoError(t, withCA.do(http.MethodGet, "/", nil, nil))
+}
+
+func TestClient_InsecureSkipVerify(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, WithInsecureSkipVerify(true))
+	require.NoError(t, c.tlsErr)
+	assert.NoError(t, c.do(http.MethodGet, "/", nil, nil))
+}
+
+func TestClient_BadCAFile(t *testing.T) {
+	c := New("https://example.invalid", WithCACert("/nonexistent/ca.pem"))
+	err := c.do(http.MethodGet, "/", nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read CA cert")
+}
+
+func TestClient_ClientCertWithoutKey_Errors(t *testing.T) {
+	certPath, _, _ := genKeyPair(t, t.TempDir(), "client")
+	c := New("https://example.invalid", WithClientCert(certPath, ""))
+	err := c.do(http.MethodGet, "/", nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be provided together")
+}
+
+func TestClient_MTLS_PresentsClientCert(t *testing.T) {
+	dir := t.TempDir()
+	clientCertPath, clientKeyPath, clientLeaf := genKeyPair(t, dir, "client")
+
+	clientPool := x509.NewCertPool()
+	clientPool.AddCert(clientLeaf)
+
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	ts.TLS = &tls.Config{
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  clientPool,
+		MinVersion: tls.VersionTLS12,
+	}
+	ts.StartTLS()
+	defer ts.Close()
+
+	caPath := writeCAFile(t, dir, ts.Certificate())
+
+	// CA-only (no client cert) → server rejects at handshake.
+	noCert := New(ts.URL, WithCACert(caPath))
+	require.NoError(t, noCert.tlsErr)
+	assert.Error(t, noCert.do(http.MethodGet, "/", nil, nil),
+		"mTLS server should reject a client presenting no certificate")
+
+	// CA + client cert → accepted.
+	withCert := New(ts.URL, WithCACert(caPath), WithClientCert(clientCertPath, clientKeyPath))
+	require.NoError(t, withCert.tlsErr)
+	assert.NoError(t, withCert.do(http.MethodGet, "/", nil, nil))
+}
+
+func TestClient_NoTLSOptions_UsesDefaultTransport(t *testing.T) {
+	// With no TLS option set, the client must not install a custom transport,
+	// preserving the shared default-transport behavior.
+	c := New("http://example.invalid")
+	assert.Nil(t, c.httpClient.Transport)
+	assert.NoError(t, c.tlsErr)
+}


### PR DESCRIPTION
Closes #1196.

## Problem

The control-plane **server** already supports native TLS + mTLS, but the `dfsctl` **client** used the default HTTP transport — it trusted only system-root CAs and could not present a client certificate or skip verification. A server behind a private CA or mTLS was unreachable.

## Change

**`pkg/apiclient`** — new `ClientOption`s `WithCACert(path)`, `WithClientCert(certPath, keyPath)`, `WithInsecureSkipVerify(bool)`. When any is set, `New()` builds a cloned `http.DefaultTransport` with a custom `*tls.Config` (private-CA trust on top of system roots, client keypair for mTLS, MinVersion 1.2). With no TLS option the shared default transport is left untouched (back-compat). A deferred build failure (bad CA file, client-cert-without-key) is captured and surfaced on the **first request** instead of being dropped (keeps `New`'s no-error signature). `WithToken` carries the TLS state through.

**UX — capture at login, reuse after.** TLS is a property of the login context, not a per-request flag:
```
dfsctl login --server https://host:port --cacert ca.pem -u admin
dfsctl share list                       # reuses stored CA, no flags
dfsctl login ... --client-cert c.pem --client-key c.key   # mTLS
```
Stored as file **paths** (not contents) in the per-context credential file → re-read each run → certbot/cert-manager rotation absorbed on the next invocation. Root-level `--cacert/--client-cert/--client-key/--tls-skip-verify` flags override the stored context for a single command. `--tls-skip-verify` prints a MITM warning; `--client-cert` without `--client-key` errors.

Touches: `pkg/apiclient/client.go`, `internal/cli/credentials/store.go` (new `Context` fields), `cmd/dfsctl/commands/login.go`, `cmd/dfsctl/cmdutil/util.go` (`TLSClientOptions` + `GetAuthenticatedClient`), `cmd/dfsctl/commands/root.go`.

## Note on cert watching

No client-side watcher: `dfsctl` is a fresh process per command and re-reads the cert paths at `New()`, so rotation is handled by construction. The hot-reload watcher belongs to the long-lived **servers** — the control plane today, and the NFS server via #1197 (which reuses the lifted `internal/tlsconfig` reloader).

## Test

`pkg/apiclient` tests vs `httptest.NewTLSServer` — private-CA trust (+ untrusted control), skip-verify, bad-CA-file, client-cert-without-key error, mTLS handshake (present/absent client cert), no-TLS-options-keeps-default-transport. Credential round-trip + login persistence covered by existing suites.

```
go test ./pkg/apiclient/ ./internal/cli/credentials/ ./cmd/dfsctl/...
```

Docs: SECURITY.md client-TLS section; regenerated CLI.md.