### PR TITLE
feat(nfs): NFS-over-TLS (RFC 9289) — opportunistic AUTH_TLS + mTLS (#1197)

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -390,7 +390,31 @@ func createNFSAdapter(cfg *models.AdapterConfig, kerberosConfig *config.Kerberos
 		port = 12049
 	}
 
-	adapter := nfs.New(nfs.NFSConfig{Enabled: true, Port: port})
+	nfsCfg := nfs.NFSConfig{Enabled: true, Port: port}
+
+	parsedConfig, err := cfg.GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse adapter config: %w", err)
+	}
+	if tlsCfg, ok := parsedConfig["tls"].(map[string]any); ok {
+		if v, ok := tlsCfg["cert_file"].(string); ok {
+			nfsCfg.TLS.CertFile = v
+		}
+		if v, ok := tlsCfg["key_file"].(string); ok {
+			nfsCfg.TLS.KeyFile = v
+		}
+		if v, ok := tlsCfg["client_ca"].(string); ok {
+			nfsCfg.TLS.ClientCA = v
+		}
+		if v, ok := tlsCfg["min_version"].(string); ok {
+			nfsCfg.TLS.MinVersion = v
+		}
+		if v, ok := tlsCfg["mode"].(string); ok {
+			nfsCfg.TLS.Mode = v
+		}
+	}
+
+	adapter := nfs.New(nfsCfg)
 	if kerberosConfig != nil && kerberosConfig.Enabled {
 		adapter.SetKerberosConfig(kerberosConfig)
 	}

--- a/docs/NFS.md
+++ b/docs/NFS.md
@@ -287,10 +287,36 @@ NFS uses RPC authentication flavors:
 | AUTH_UNIX | 1 | Unix UID/GID credentials |
 | AUTH_SHORT | 2 | Short-hand credential |
 | RPCSEC_GSS | 6 | Kerberos/GSS-API (NFSv4) |
+| AUTH_TLS | 7 | RFC 9289 STARTTLS probe (transport upgrade, not a data flavor) |
 
 **AUTH_UNIX format:** Stamp (4 bytes), machine name (string), UID (4 bytes), GID (4 bytes), supplementary GIDs (array, max 16).
 
-**Security note:** AUTH_UNIX credentials are not cryptographically secured and can be spoofed. NFSv4 adds RPCSEC_GSS for Kerberos-based authentication. For production deployments, consider running on trusted networks, enabling Kerberos (NFSv4/v4.1), or using VPN/network-level encryption.
+**Security note:** AUTH_UNIX credentials are not cryptographically secured and can be spoofed. NFSv4 adds RPCSEC_GSS for Kerberos-based authentication. For production deployments, consider running on trusted networks, enabling Kerberos (NFSv4/v4.1), or using NFS-over-TLS (below) / VPN / network-level encryption.
+
+### NFS-over-TLS (RFC 9289)
+
+DittoFS can encrypt NFS wire traffic with TLS 1.3, using the opportunistic `AUTH_TLS` STARTTLS mechanism from RFC 9289. A client opens TCP and sends a `NULL` RPC with `auth_flavor = AUTH_TLS (7)`; the server replies with the 8-octet `"STARTTLS"` verifier, then both perform a TLS 1.3 handshake on the **same** connection. All subsequent RPC traffic is encrypted. Because Go performs the handshake and crypto in userspace, no kernel TLS (`kTLS`) or `tlshd` daemon is needed on the server.
+
+DittoFS only loads cert files — issuance/renewal/rotation is the platform's job; rotated files are hot-reloaded with no restart (shared with the control-plane TLS path via `internal/tlsconfig`).
+
+```yaml
+adapters:
+  nfs:
+    tls:
+      cert_file: /etc/dittofs/tls/tls.crt
+      key_file:  /etc/dittofs/tls/tls.key
+      client_ca: /etc/dittofs/tls/ca.crt   # optional → mutual TLS (client-cert auth)
+      min_version: "1.3"                    # RFC 9289 floor is TLS 1.3
+      mode: opportunistic                   # "opportunistic" (default) | "require"
+```
+
+- **`opportunistic`** (default): clients that send the `AUTH_TLS` probe are upgraded; clients that do not are still served in plaintext. Lets a TLS rollout proceed without breaking existing mounts.
+- **`require`**: a connection must upgrade via `AUTH_TLS` before any other RPC; plaintext requests are rejected (connection dropped).
+
+**Client interop:**
+
+- **Linux:** `mount -o vers=4.1,xprtsec=tls …` — requires `tlshd` (ktls-utils) and `CONFIG_NET_HANDSHAKE` (RHEL 9.x / upstream kernel 6.7+).
+- **macOS:** no NFS-over-TLS client — use Kerberos or a network-level tunnel instead.
 
 ### Error Handling
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -61,11 +61,12 @@
 - Identity mapping (root squash, all squash)
 - AUTH_UNIX support for trusted-network deployments
 - Native, file-based TLS (and optional mutual TLS) for the control plane API, with on-disk certificate hot-reload; loopback-only bind by default ([Control Plane API: TLS and Bind Address](#control-plane-api-tls-and-bind-address))
+- NFS-over-TLS (RFC 9289): opportunistic `AUTH_TLS` STARTTLS upgrade to TLS 1.3, with optional mutual TLS, sharing the control-plane cert hot-reload path ([NFS-over-TLS](#nfs-over-tls-rfc-9289))
 
 ### Remaining Limitations
 
 - No formal security audit performed
-- No built-in encryption in transit for NFS (use VPN or network-level encryption)
+- NFS-over-TLS requires a client that supports RFC 9289 (`xprtsec=tls`); macOS has no such client (use Kerberos or a network tunnel)
 - No built-in encryption at rest
 - No audit logging for file operations
 
@@ -373,12 +374,30 @@ shares:
 
 ### Encryption in Transit
 
-DittoFS does not currently provide built-in TLS encryption for NFS or SMB wire traffic. While Kerberos provides authentication and message integrity, file data is transmitted in cleartext over TCP unless network-level encryption is used.
+DittoFS supports in-transit encryption for both data-plane protocols: **SMB3** encrypts in-protocol (AES-GCM/CCM, see [SMB3 Encryption](#smb3-encryption)), and **NFS** can use **NFS-over-TLS (RFC 9289)** to wrap RPC traffic in TLS 1.3 (below). Without one of these — or network-level encryption — file data and AUTH_UNIX credentials travel in cleartext over TCP.
 
 **Implications:**
-- File data can be intercepted without network-level encryption
-- Use VPN, IPsec, or WireGuard to protect data in transit
-- SMB message signing protects integrity but not confidentiality
+- Plaintext NFS data can be intercepted without TLS or network-level encryption
+- Prefer NFS-over-TLS or SMB3 encryption; otherwise use VPN, IPsec, or WireGuard
+- SMB message signing protects integrity but not confidentiality (use encryption for that)
+
+#### NFS-over-TLS (RFC 9289)
+
+DittoFS implements the opportunistic `AUTH_TLS` STARTTLS upgrade from RFC 9289: a client sends a `NULL` RPC with `auth_flavor = AUTH_TLS`, the server replies with the `"STARTTLS"` verifier, and both perform a TLS 1.3 handshake on the same connection — all subsequent traffic is encrypted. The handshake runs in userspace (no kernel TLS / `tlshd` on the server). Setting `client_ca` requires and verifies a client certificate (mutual TLS).
+
+```yaml
+adapters:
+  nfs:
+    tls:
+      cert_file: /etc/dittofs/tls/tls.crt
+      key_file:  /etc/dittofs/tls/tls.key
+      client_ca: /etc/dittofs/tls/ca.crt   # optional → mutual TLS
+      mode: opportunistic                   # "opportunistic" (default) | "require"
+```
+
+- **`opportunistic`** still serves non-TLS clients in plaintext (smooth rollout); **`require`** rejects plaintext until a connection upgrades.
+- As with the control-plane API, DittoFS only loads cert files and hot-reloads them on rotation; issuance/renewal is the platform's responsibility.
+- Client support: Linux `mount -o vers=4.1,xprtsec=tls` needs `tlshd` + `CONFIG_NET_HANDSHAKE` (RHEL 9.x / kernel 6.7+); macOS has no NFS-over-TLS client. See [docs/NFS.md](NFS.md#nfs-over-tls-rfc-9289).
 
 ### Control Plane API: TLS and Bind Address
 

--- a/internal/adapter/nfs/rpc/auth.go
+++ b/internal/adapter/nfs/rpc/auth.go
@@ -38,7 +38,18 @@ const (
 	// Provides Kerberos-based authentication with optional integrity
 	// and privacy protection. Defined in RFC 2203.
 	AuthRPCSECGSS uint32 = 6
+
+	// AuthTLS indicates an RPC-with-TLS STARTTLS probe (RFC 9289 §5.1). A
+	// client sends a NULL procedure call with this credential flavor to ask
+	// the server to begin a TLS handshake on the same connection. It is never
+	// a real authentication flavor for data operations — only the NULL probe.
+	AuthTLS uint32 = 7
 )
+
+// StartTLSVerifier is the 8-octet ASCII string a server returns in the reply
+// verifier of an AUTH_TLS NULL probe to advertise that it is willing to start
+// TLS on the connection (RFC 9289 §5.1).
+const StartTLSVerifier = "STARTTLS"
 
 // UnixAuth represents Unix-style authentication credentials (AUTH_UNIX)
 // as defined in RFC 1831 Section 9.2.

--- a/internal/adapter/nfs/rpc/parser.go
+++ b/internal/adapter/nfs/rpc/parser.go
@@ -478,6 +478,18 @@ func MakeProgMismatchReply(xid uint32, low uint32, high uint32) ([]byte, error) 
 	return result, nil
 }
 
+// MakeStartTLSReply constructs the server's reply to an AUTH_TLS NULL probe
+// (RFC 9289 §5.1). It is an ordinary MSG_ACCEPTED/SUCCESS NULL reply whose
+// reply verifier carries the flavor AUTH_NONE and the 8-octet ASCII body
+// "STARTTLS"; the client reads that body as the signal to begin the TLS
+// handshake on the same connection.
+func MakeStartTLSReply(xid uint32) ([]byte, error) {
+	return MakeGSSSuccessReply(xid, nil, OpaqueAuth{
+		Flavor: AuthNull,
+		Body:   []byte(StartTLSVerifier),
+	})
+}
+
 // MakeGSSSuccessReply constructs an RPC success reply with a GSS verifier.
 //
 // This is identical to MakeSuccessReply except it uses the provided verifier

--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -265,7 +265,10 @@ type NFSTLSConfig struct {
 	// client certificate (mutual TLS).
 	ClientCA string `mapstructure:"client_ca"`
 
-	// MinVersion is the minimum TLS version: "1.2" or "1.3" (default "1.2").
+	// MinVersion is the configured minimum TLS version: "1.2" or "1.3". RFC 9289
+	// mandates TLS 1.3, so the effective floor is always raised to 1.3 even when
+	// "1.2" is set; the knob exists only for forward-compatibility symmetry with
+	// the control-plane TLS config.
 	MinVersion string `mapstructure:"min_version"`
 
 	// Mode selects the upgrade policy:
@@ -276,9 +279,26 @@ type NFSTLSConfig struct {
 	Mode string `mapstructure:"mode"`
 }
 
-// NFSTLSModeRequire is the Mode value that rejects plaintext RPC until a
-// connection has upgraded via AUTH_TLS.
-const NFSTLSModeRequire = "require"
+// NFS TLS Mode values. An empty Mode is treated as opportunistic.
+const (
+	// NFSTLSModeOpportunistic upgrades clients that send the AUTH_TLS probe but
+	// still serves non-TLS clients in plaintext.
+	NFSTLSModeOpportunistic = "opportunistic"
+	// NFSTLSModeRequire rejects plaintext RPC until a connection has upgraded
+	// via AUTH_TLS.
+	NFSTLSModeRequire = "require"
+)
+
+// validateMode rejects an unknown TLS Mode so a typo (e.g. "required") does not
+// silently fall back to opportunistic. An empty Mode is allowed (opportunistic).
+func (t NFSTLSConfig) validateMode() error {
+	switch t.Mode {
+	case "", NFSTLSModeOpportunistic, NFSTLSModeRequire:
+		return nil
+	default:
+		return fmt.Errorf("invalid mode %q (use %q or %q)", t.Mode, NFSTLSModeOpportunistic, NFSTLSModeRequire)
+	}
+}
 
 // shared converts the wire config into the backend-agnostic tlsconfig.Config.
 func (t NFSTLSConfig) shared() tlsconfig.Config {
@@ -641,6 +661,9 @@ func (s *NFSAdapter) Serve(ctx context.Context) error {
 	if err := s.config.TLS.shared().Validate(); err != nil {
 		return fmt.Errorf("adapters.nfs.tls.%w", err)
 	}
+	if err := s.config.TLS.validateMode(); err != nil {
+		return fmt.Errorf("adapters.nfs.tls.%w", err)
+	}
 	tlsCfg, err := tlsconfig.ServerConfig(s.config.TLS.shared())
 	if err != nil {
 		return fmt.Errorf("configure NFS TLS: %w", err)
@@ -653,7 +676,7 @@ func (s *NFSAdapter) Serve(ctx context.Context) error {
 			tlsCfg.MinVersion = tls.VersionTLS13
 		}
 		logger.Info("NFS-over-TLS enabled (RFC 9289)",
-			"mode", map[bool]string{true: NFSTLSModeRequire, false: "opportunistic"}[s.tlsRequire],
+			"mode", map[bool]string{true: NFSTLSModeRequire, false: NFSTLSModeOpportunistic}[s.tlsRequire],
 			"mtls", s.config.TLS.ClientCA != "")
 	}
 

--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -2,11 +2,14 @@ package nfs
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/marmos91/dittofs/internal/tlsconfig"
 
 	mount "github.com/marmos91/dittofs/internal/adapter/nfs/mount/handlers"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/blocking"
@@ -151,6 +154,15 @@ type NFSAdapter struct {
 	// (isOperationBlocked) does a single map lookup instead of a per-RPC JSON
 	// unmarshal + linear scan.
 	v3BlockedOps map[string]bool
+
+	// tlsConfig is the server TLS config used to upgrade connections that send
+	// an AUTH_TLS STARTTLS probe (RFC 9289). nil when TLS is not configured, in
+	// which case connections stay plaintext. Built once in Serve.
+	tlsConfig *tls.Config
+
+	// tlsRequire mirrors NFSTLSConfig.Mode == "require": when true, a connection
+	// must upgrade via AUTH_TLS before any other RPC is served.
+	tlsRequire bool
 }
 
 // NFSTimeoutsConfig groups all timeout-related configuration.
@@ -232,6 +244,55 @@ type NFSConfig struct {
 	// via rpcinfo/showmount without requiring a system-level rpcbind daemon.
 	// Default: enabled on port 10111.
 	Portmapper PortmapConfig `mapstructure:"portmapper"`
+
+	// TLS configures opportunistic NFS-over-TLS (RFC 9289). When the cert/key
+	// files are set, the server answers an AUTH_TLS STARTTLS probe and upgrades
+	// the connection to TLS 1.3. Unset = plaintext only (back-compat).
+	TLS NFSTLSConfig `mapstructure:"tls"`
+}
+
+// NFSTLSConfig configures NFS-over-TLS (RFC 9289). It mirrors the control
+// plane's file-based TLS config and reuses internal/tlsconfig for cert loading
+// and hot-reload. DittoFS only consumes cert files; lifecycle (issuance,
+// renewal, rotation) is the platform's responsibility.
+type NFSTLSConfig struct {
+	// CertFile / KeyFile are the PEM server certificate and private key. Both
+	// must be set to enable TLS; setting one without the other is an error.
+	CertFile string `mapstructure:"cert_file"`
+	KeyFile  string `mapstructure:"key_file"`
+
+	// ClientCA is a PEM CA bundle. When set, the server requires and verifies a
+	// client certificate (mutual TLS).
+	ClientCA string `mapstructure:"client_ca"`
+
+	// MinVersion is the minimum TLS version: "1.2" or "1.3" (default "1.2").
+	MinVersion string `mapstructure:"min_version"`
+
+	// Mode selects the upgrade policy:
+	//   - "opportunistic" (default): non-TLS clients are still served in
+	//     plaintext; only clients that send the AUTH_TLS probe are upgraded.
+	//   - "require": every connection must upgrade via AUTH_TLS before any
+	//     other RPC; plaintext requests are rejected.
+	Mode string `mapstructure:"mode"`
+}
+
+// NFSTLSModeRequire is the Mode value that rejects plaintext RPC until a
+// connection has upgraded via AUTH_TLS.
+const NFSTLSModeRequire = "require"
+
+// shared converts the wire config into the backend-agnostic tlsconfig.Config.
+func (t NFSTLSConfig) shared() tlsconfig.Config {
+	return tlsconfig.Config{
+		CertFile:   t.CertFile,
+		KeyFile:    t.KeyFile,
+		ClientCA:   t.ClientCA,
+		MinVersion: t.MinVersion,
+	}
+}
+
+// Enabled reports whether TLS is configured (both cert and key set).
+func (t NFSTLSConfig) Enabled() bool {
+	return t.shared().Enabled()
 }
 
 // PortmapConfig holds configuration for the embedded portmapper.
@@ -573,6 +634,28 @@ func (s *NFSAdapter) SetRuntime(rtAny any) {
 // Serve() should only be called once per NFSAdapter instance.
 func (s *NFSAdapter) Serve(ctx context.Context) error {
 	logger.Debug("NFS config", "max_connections", s.config.MaxConnections, "read_timeout", s.config.Timeouts.Read, "write_timeout", s.config.Timeouts.Write, "idle_timeout", s.config.Timeouts.Idle)
+
+	// Build the server TLS config (loads + parses the cert files now, so a bad
+	// cert path fails at startup rather than on the first STARTTLS probe). nil
+	// when TLS is not configured, in which case connections stay plaintext.
+	if err := s.config.TLS.shared().Validate(); err != nil {
+		return fmt.Errorf("adapters.nfs.tls.%w", err)
+	}
+	tlsCfg, err := tlsconfig.ServerConfig(s.config.TLS.shared())
+	if err != nil {
+		return fmt.Errorf("configure NFS TLS: %w", err)
+	}
+	s.tlsConfig = tlsCfg
+	s.tlsRequire = s.config.TLS.Enabled() && s.config.TLS.Mode == NFSTLSModeRequire
+	if tlsCfg != nil {
+		// TLS 1.3 is the RFC 9289 floor; raise the configured minimum if needed.
+		if tlsCfg.MinVersion < tls.VersionTLS13 {
+			tlsCfg.MinVersion = tls.VersionTLS13
+		}
+		logger.Info("NFS-over-TLS enabled (RFC 9289)",
+			"mode", map[bool]string{true: NFSTLSModeRequire, false: "opportunistic"}[s.tlsRequire],
+			"mtls", s.config.TLS.ClientCA != "")
+	}
 
 	// Start embedded portmapper (RFC 1057) for NFS service discovery.
 	// This allows clients to query rpcinfo/showmount without needing

--- a/pkg/adapter/nfs/connection.go
+++ b/pkg/adapter/nfs/connection.go
@@ -2,6 +2,7 @@ package nfs
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -55,6 +56,12 @@ type NFSConnection struct {
 	// pendingCBReplies routes NFSv4.1 backchannel REPLY messages.
 	// nil unless the connection is bound for back-channel.
 	pendingCBReplies *state.PendingCBReplies
+
+	// tlsUpgraded records whether this connection has completed an RFC 9289
+	// STARTTLS upgrade. Once true, c.conn is a *tls.Conn and all traffic is
+	// encrypted. Only touched from the single Serve read loop (the upgrade is
+	// handled synchronously before any request is dispatched concurrently).
+	tlsUpgraded bool
 }
 
 func NewNFSConnection(server *NFSAdapter, conn net.Conn, connectionID uint64) *NFSConnection {
@@ -107,9 +114,82 @@ func (c *NFSConnection) Serve(ctx context.Context) {
 			return
 		}
 
+		// RFC 9289 gate: when TLS is configured and this connection has not yet
+		// upgraded, intercept the AUTH_TLS STARTTLS probe (and, in require mode,
+		// reject plaintext) before dispatching the request concurrently.
+		if c.server.tlsConfig != nil && !c.tlsUpgraded {
+			handled, gateErr := c.handleTLSGate(ctx, call, rawMessage, clientAddr)
+			if gateErr != nil {
+				logger.Debug("NFS TLS gate closed connection", "address", clientAddr, "error", gateErr)
+				return
+			}
+			if handled {
+				c.resetIdleTimeout(clientAddr)
+				continue
+			}
+		}
+
 		c.dispatchRequest(ctx, clientAddr, call, rawMessage)
 		c.resetIdleTimeout(clientAddr)
 	}
+}
+
+// handleTLSGate enforces the RFC 9289 STARTTLS policy on a not-yet-upgraded
+// connection. It returns handled=true when it has consumed the request (a
+// successful upgrade, or a require-mode rejection that closes the connection);
+// handled=false means the caller should dispatch the request normally
+// (opportunistic mode, non-probe request). A non-nil error means the read loop
+// must terminate. On every handled/error path the pooled rawMessage is
+// released here, since the request is not forwarded to dispatchRequest.
+func (c *NFSConnection) handleTLSGate(ctx context.Context, call *rpc.RPCCallMessage, rawMessage []byte, clientAddr string) (bool, error) {
+	// A STARTTLS probe is a NULL procedure call carrying the AUTH_TLS flavor.
+	if call.Procedure == 0 && call.GetAuthFlavor() == rpc.AuthTLS {
+		pool.Put(rawMessage)
+		if err := c.startTLS(ctx, call.XID, clientAddr); err != nil {
+			return true, fmt.Errorf("STARTTLS upgrade: %w", err)
+		}
+		return true, nil
+	}
+
+	// Not a probe. In require mode, plaintext RPC is not allowed before the
+	// upgrade — drop the connection. In opportunistic mode, serve it normally.
+	if c.server.tlsRequire {
+		pool.Put(rawMessage)
+		return true, fmt.Errorf("require-TLS: rejecting plaintext request (program=%d procedure=%d flavor=%d) from %s",
+			call.Program, call.Procedure, call.GetAuthFlavor(), clientAddr)
+	}
+	return false, nil
+}
+
+// startTLS answers an AUTH_TLS probe with the "STARTTLS" verifier and performs
+// the TLS 1.3 handshake on the same TCP connection, swapping c.conn for the
+// resulting *tls.Conn (RFC 9289 §5.1). Because tls.Conn satisfies net.Conn, the
+// RPC framing and dispatch paths are unchanged after the swap. It runs
+// synchronously in the Serve read loop, before any request is dispatched, so no
+// concurrent goroutine touches c.conn during the handshake.
+func (c *NFSConnection) startTLS(ctx context.Context, xid uint32, clientAddr string) error {
+	reply, err := rpc.MakeStartTLSReply(xid)
+	if err != nil {
+		return fmt.Errorf("build STARTTLS reply: %w", err)
+	}
+	if err := c.writeReply(xid, reply); err != nil {
+		return fmt.Errorf("write STARTTLS verifier: %w", err)
+	}
+
+	// Clear the idle/read deadline for the handshake; the read loop re-arms it
+	// after the upgrade via resetIdleTimeout.
+	_ = c.conn.SetDeadline(time.Time{})
+
+	tlsConn := tls.Server(c.conn, c.server.tlsConfig)
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		return fmt.Errorf("TLS handshake: %w", err)
+	}
+
+	c.conn = tlsConn
+	c.tlsUpgraded = true
+	logger.Info("NFS connection upgraded to TLS", "address", clientAddr,
+		"version", tls.VersionName(tlsConn.ConnectionState().Version))
+	return nil
 }
 
 // isShuttingDown checks if the connection should close due to context

--- a/pkg/adapter/nfs/connection.go
+++ b/pkg/adapter/nfs/connection.go
@@ -62,7 +62,19 @@ type NFSConnection struct {
 	// encrypted. Only touched from the single Serve read loop (the upgrade is
 	// handled synchronously before any request is dispatched concurrently).
 	tlsUpgraded bool
+
+	// startedDispatch records whether any request has been dispatched
+	// concurrently on this connection. A STARTTLS upgrade is only honored
+	// before the first dispatch (RFC 9289: the AUTH_TLS NULL is the first RPC),
+	// so the synchronous handshake can never race an in-flight plaintext reply.
+	// Only touched from the single Serve read loop.
+	startedDispatch bool
 }
+
+// tlsHandshakeTimeout bounds the STARTTLS handshake so a client that sends the
+// AUTH_TLS probe but never completes the TLS handshake cannot pin a connection
+// (and, in require mode, exhaust connection slots) indefinitely.
+const tlsHandshakeTimeout = 30 * time.Second
 
 func NewNFSConnection(server *NFSAdapter, conn net.Conn, connectionID uint64) *NFSConnection {
 	return &NFSConnection{
@@ -114,10 +126,13 @@ func (c *NFSConnection) Serve(ctx context.Context) {
 			return
 		}
 
-		// RFC 9289 gate: when TLS is configured and this connection has not yet
-		// upgraded, intercept the AUTH_TLS STARTTLS probe (and, in require mode,
-		// reject plaintext) before dispatching the request concurrently.
-		if c.server.tlsConfig != nil && !c.tlsUpgraded {
+		// RFC 9289 gate: when TLS is configured and this connection has neither
+		// upgraded nor dispatched a request yet, intercept the AUTH_TLS STARTTLS
+		// probe (and, in require mode, reject plaintext) before any concurrent
+		// dispatch. Gating on !startedDispatch means the synchronous handshake
+		// can never race an in-flight plaintext reply; a probe arriving after
+		// plaintext traffic (opportunistic) is treated as an ordinary NULL.
+		if c.server.tlsConfig != nil && !c.tlsUpgraded && !c.startedDispatch {
 			handled, gateErr := c.handleTLSGate(ctx, call, rawMessage, clientAddr)
 			if gateErr != nil {
 				logger.Debug("NFS TLS gate closed connection", "address", clientAddr, "error", gateErr)
@@ -130,6 +145,7 @@ func (c *NFSConnection) Serve(ctx context.Context) {
 		}
 
 		c.dispatchRequest(ctx, clientAddr, call, rawMessage)
+		c.startedDispatch = true
 		c.resetIdleTimeout(clientAddr)
 	}
 }
@@ -176,9 +192,10 @@ func (c *NFSConnection) startTLS(ctx context.Context, xid uint32, clientAddr str
 		return fmt.Errorf("write STARTTLS verifier: %w", err)
 	}
 
-	// Clear the idle/read deadline for the handshake; the read loop re-arms it
-	// after the upgrade via resetIdleTimeout.
-	_ = c.conn.SetDeadline(time.Time{})
+	// Bound the handshake with a fresh deadline so a client that probes but
+	// never completes the TLS handshake cannot pin the connection. The read
+	// loop re-arms the idle deadline after the upgrade via resetIdleTimeout.
+	_ = c.conn.SetDeadline(time.Now().Add(tlsHandshakeTimeout))
 
 	tlsConn := tls.Server(c.conn, c.server.tlsConfig)
 	if err := tlsConn.HandshakeContext(ctx); err != nil {

--- a/pkg/adapter/nfs/tls_test.go
+++ b/pkg/adapter/nfs/tls_test.go
@@ -37,7 +37,10 @@ func mkCert(t *testing.T, cn string, isCA bool, parent *tlsTestCert) tlsTestCert
 	if err != nil {
 		t.Fatal(err)
 	}
-	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatal(err)
+	}
 	tmpl := &x509.Certificate{
 		SerialNumber:          serial,
 		Subject:               pkix.Name{CommonName: cn},
@@ -61,9 +64,15 @@ func mkCert(t *testing.T, cn string, isCA bool, parent *tlsTestCert) tlsTestCert
 	if err != nil {
 		t.Fatal(err)
 	}
-	parsed, _ := x509.ParseCertificate(der)
+	parsed, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
 	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
-	keyDER, _ := x509.MarshalECPrivateKey(key)
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
 	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
 	return tlsTestCert{certPEM: certPEM, keyPEM: keyPEM, cert: parsed, key: key}
 }
@@ -120,6 +129,7 @@ func runStartTLSServer(ln net.Listener, srv *NFSAdapter, errc chan<- error) {
 		errc <- err
 		return
 	}
+	defer func() { _ = conn.Close() }()
 	c := &NFSConnection{server: srv, conn: conn}
 	if err := c.startTLS(context.Background(), 1, "test"); err != nil {
 		errc <- err
@@ -202,7 +212,10 @@ func TestNFSConnection_StartTLS_MTLS(t *testing.T) {
 
 	// Case 1: client presents a valid cert → handshake succeeds.
 	t.Run("valid client cert accepted", func(t *testing.T) {
-		ln, _ := net.Listen("tcp", "127.0.0.1:0")
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
 		defer func() { _ = ln.Close() }()
 		errc := make(chan error, 1)
 		go runStartTLSServer(ln, newSrv(), errc)
@@ -234,7 +247,10 @@ func TestNFSConnection_StartTLS_MTLS(t *testing.T) {
 
 	// Case 2: no client cert → server rejects at handshake.
 	t.Run("missing client cert rejected", func(t *testing.T) {
-		ln, _ := net.Listen("tcp", "127.0.0.1:0")
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
 		defer func() { _ = ln.Close() }()
 		errc := make(chan error, 1)
 		go runStartTLSServer(ln, newSrv(), errc)
@@ -280,5 +296,18 @@ func TestNFSConnection_HandleTLSGate(t *testing.T) {
 	// just confirm detection does not fall through to the plaintext path.
 	if nullProbe.Procedure != 0 || nullProbe.GetAuthFlavor() != rpc.AuthTLS {
 		t.Fatal("probe detection predicate is wrong")
+	}
+}
+
+func TestNFSTLSConfig_ValidateMode(t *testing.T) {
+	for _, m := range []string{"", NFSTLSModeOpportunistic, NFSTLSModeRequire} {
+		if err := (NFSTLSConfig{Mode: m}).validateMode(); err != nil {
+			t.Errorf("mode %q: unexpected error %v", m, err)
+		}
+	}
+	for _, m := range []string{"required", "opportunistc", "tls", "REQUIRE"} {
+		if err := (NFSTLSConfig{Mode: m}).validateMode(); err == nil {
+			t.Errorf("mode %q: expected error, got nil", m)
+		}
 	}
 }

--- a/pkg/adapter/nfs/tls_test.go
+++ b/pkg/adapter/nfs/tls_test.go
@@ -1,0 +1,284 @@
+package nfs
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/binary"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
+	"github.com/marmos91/dittofs/internal/adapter/pool"
+	"github.com/marmos91/dittofs/internal/tlsconfig"
+)
+
+type tlsTestCert struct {
+	certPEM []byte
+	keyPEM  []byte
+	cert    *x509.Certificate
+	key     *ecdsa.PrivateKey
+}
+
+func mkCert(t *testing.T, cn string, isCA bool, parent *tlsTestCert) tlsTestCert {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	if isCA {
+		tmpl.IsCA = true
+		tmpl.KeyUsage |= x509.KeyUsageCertSign
+	}
+	signerCert, signerKey := tmpl, key
+	if parent != nil {
+		signerCert, signerKey = parent.cert, parent.key
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, signerCert, &key.PublicKey, signerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, _ := x509.ParseCertificate(der)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, _ := x509.MarshalECPrivateKey(key)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return tlsTestCert{certPEM: certPEM, keyPEM: keyPEM, cert: parsed, key: key}
+}
+
+func writeFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// serverTLS builds a server *tls.Config from a fresh cert (optionally requiring
+// a client cert signed by ca for mTLS).
+func serverTLS(t *testing.T, server tlsTestCert, ca *tlsTestCert) *tls.Config {
+	t.Helper()
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "tls.crt")
+	keyPath := filepath.Join(dir, "tls.key")
+	writeFile(t, certPath, server.certPEM)
+	writeFile(t, keyPath, server.keyPEM)
+	cfg := tlsconfig.Config{CertFile: certPath, KeyFile: keyPath, MinVersion: "1.3"}
+	if ca != nil {
+		caPath := filepath.Join(dir, "ca.crt")
+		writeFile(t, caPath, ca.certPEM)
+		cfg.ClientCA = caPath
+	}
+	tc, err := tlsconfig.ServerConfig(cfg)
+	if err != nil {
+		t.Fatalf("ServerConfig: %v", err)
+	}
+	return tc
+}
+
+// readRPCRecord reads one RFC 5531 record-marked message and returns its body.
+func readRPCRecord(t *testing.T, r io.Reader) []byte {
+	t.Helper()
+	var hdr [4]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		t.Fatalf("read fragment header: %v", err)
+	}
+	n := binary.BigEndian.Uint32(hdr[:]) &^ 0x80000000
+	body := make([]byte, n)
+	if _, err := io.ReadFull(r, body); err != nil {
+		t.Fatalf("read fragment body: %v", err)
+	}
+	return body
+}
+
+// runStartTLSServer accepts one connection, runs c.startTLS, then echoes 5
+// bytes over the upgraded connection. The handshake error (if any) is returned.
+func runStartTLSServer(ln net.Listener, srv *NFSAdapter, errc chan<- error) {
+	conn, err := ln.Accept()
+	if err != nil {
+		errc <- err
+		return
+	}
+	c := &NFSConnection{server: srv, conn: conn}
+	if err := c.startTLS(context.Background(), 1, "test"); err != nil {
+		errc <- err
+		return
+	}
+	buf := make([]byte, 5)
+	if _, err := io.ReadFull(c.conn, buf); err != nil {
+		errc <- err
+		return
+	}
+	_, _ = c.conn.Write(buf)
+	errc <- nil
+}
+
+func TestNFSConnection_StartTLS_OpportunisticHandshake(t *testing.T) {
+	serverCert := mkCert(t, "localhost", false, nil)
+	srv := &NFSAdapter{
+		config:    NFSConfig{Timeouts: NFSTimeoutsConfig{Write: 5 * time.Second}},
+		tlsConfig: serverTLS(t, serverCert, nil),
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	errc := make(chan error, 1)
+	go runStartTLSServer(ln, srv, errc)
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// The server writes the STARTTLS verifier first (we invoke startTLS directly,
+	// which assumes the probe has already been consumed).
+	record := readRPCRecord(t, conn)
+	if !bytes.Contains(record, []byte(rpc.StartTLSVerifier)) {
+		t.Fatalf("reply does not contain STARTTLS verifier: %x", record)
+	}
+
+	pool := x509.NewCertPool()
+	pool.AddCert(serverCert.cert)
+	tc := tls.Client(conn, &tls.Config{RootCAs: pool, ServerName: "localhost", MinVersion: tls.VersionTLS13})
+	if err := tc.HandshakeContext(context.Background()); err != nil {
+		t.Fatalf("client handshake: %v", err)
+	}
+	if _, err := tc.Write([]byte("hello")); err != nil {
+		t.Fatalf("encrypted write: %v", err)
+	}
+	got := make([]byte, 5)
+	if _, err := io.ReadFull(tc, got); err != nil {
+		t.Fatalf("encrypted read: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("echo = %q, want hello", got)
+	}
+	if err := <-errc; err != nil {
+		t.Fatalf("server: %v", err)
+	}
+}
+
+func TestNFSConnection_StartTLS_MTLS(t *testing.T) {
+	ca := mkCert(t, "test-ca", true, nil)
+	serverCert := mkCert(t, "localhost", false, &ca)
+	clientCert := mkCert(t, "client", false, &ca)
+
+	rootPool := x509.NewCertPool()
+	rootPool.AddCert(ca.cert)
+	clientTLSCert := tls.Certificate{Certificate: [][]byte{clientCert.cert.Raw}, PrivateKey: clientCert.key}
+
+	newSrv := func() *NFSAdapter {
+		return &NFSAdapter{
+			config:    NFSConfig{Timeouts: NFSTimeoutsConfig{Write: 5 * time.Second}},
+			tlsConfig: serverTLS(t, serverCert, &ca),
+		}
+	}
+
+	// Case 1: client presents a valid cert → handshake succeeds.
+	t.Run("valid client cert accepted", func(t *testing.T) {
+		ln, _ := net.Listen("tcp", "127.0.0.1:0")
+		defer func() { _ = ln.Close() }()
+		errc := make(chan error, 1)
+		go runStartTLSServer(ln, newSrv(), errc)
+
+		conn, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = conn.Close() }()
+		_ = readRPCRecord(t, conn)
+		tc := tls.Client(conn, &tls.Config{
+			RootCAs:      rootPool,
+			ServerName:   "localhost",
+			Certificates: []tls.Certificate{clientTLSCert},
+			MinVersion:   tls.VersionTLS13,
+		})
+		if err := tc.HandshakeContext(context.Background()); err != nil {
+			t.Fatalf("handshake with client cert: %v", err)
+		}
+		_, _ = tc.Write([]byte("hello"))
+		got := make([]byte, 5)
+		if _, err := io.ReadFull(tc, got); err != nil {
+			t.Fatalf("encrypted read: %v", err)
+		}
+		if err := <-errc; err != nil {
+			t.Fatalf("server: %v", err)
+		}
+	})
+
+	// Case 2: no client cert → server rejects at handshake.
+	t.Run("missing client cert rejected", func(t *testing.T) {
+		ln, _ := net.Listen("tcp", "127.0.0.1:0")
+		defer func() { _ = ln.Close() }()
+		errc := make(chan error, 1)
+		go runStartTLSServer(ln, newSrv(), errc)
+
+		conn, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = conn.Close() }()
+		_ = readRPCRecord(t, conn)
+		tc := tls.Client(conn, &tls.Config{RootCAs: rootPool, ServerName: "localhost", MinVersion: tls.VersionTLS13})
+		// The client handshake completes its flight, then fails when the server
+		// rejects the missing cert; the server's startTLS must report an error.
+		_ = tc.HandshakeContext(context.Background())
+		if err := <-errc; err == nil {
+			t.Fatal("expected server STARTTLS handshake to fail without a client cert")
+		}
+	})
+}
+
+func TestNFSConnection_HandleTLSGate(t *testing.T) {
+	nullProbe := &rpc.RPCCallMessage{Procedure: 0, Cred: rpc.OpaqueAuth{Flavor: rpc.AuthTLS}}
+	plainGetattr := &rpc.RPCCallMessage{Procedure: 1, Cred: rpc.OpaqueAuth{Flavor: rpc.AuthUnix}}
+
+	t.Run("require mode rejects plaintext", func(t *testing.T) {
+		c := &NFSConnection{server: &NFSAdapter{tlsConfig: &tls.Config{}, tlsRequire: true}}
+		handled, err := c.handleTLSGate(context.Background(), plainGetattr, pool.Get(0), "x")
+		if !handled || err == nil {
+			t.Fatalf("require/plaintext = (handled=%v, err=%v), want (true, error)", handled, err)
+		}
+	})
+
+	t.Run("opportunistic passes plaintext through", func(t *testing.T) {
+		c := &NFSConnection{server: &NFSAdapter{tlsConfig: &tls.Config{}, tlsRequire: false}}
+		handled, err := c.handleTLSGate(context.Background(), plainGetattr, pool.Get(0), "x")
+		if handled || err != nil {
+			t.Fatalf("opportunistic/plaintext = (handled=%v, err=%v), want (false, nil)", handled, err)
+		}
+	})
+
+	// Sanity: the probe is recognized as a probe (Procedure 0 + AUTH_TLS). We
+	// don't drive the full upgrade here (covered by the handshake tests); we
+	// just confirm detection does not fall through to the plaintext path.
+	if nullProbe.Procedure != 0 || nullProbe.GetAuthFlavor() != rpc.AuthTLS {
+		t.Fatal("probe detection predicate is wrong")
+	}
+}


### PR DESCRIPTION
Closes #1197. Builds on #1214 (shared `internal/tlsconfig`, already merged).

## What

NFS wire traffic was plaintext. This adds **RFC 9289** STARTTLS: a client opens TCP and sends a `NULL` RPC with `auth_flavor = AUTH_TLS (7)`; the server replies with the 8-octet `"STARTTLS"` verifier, then both perform a **TLS 1.3 handshake on the same connection** and all later RPC is encrypted. The handshake + crypto run in **userspace Go** — no kTLS / `tlshd` on the server. `tls.Conn` satisfies `net.Conn`, so RPC framing and dispatch are unchanged after the swap.

## Change

- **`internal/adapter/nfs/rpc`**: `AuthTLS = 7`, `StartTLSVerifier` ("STARTTLS"), `MakeStartTLSReply` (accepted NULL reply whose verifier carries the STARTTLS body).
- **`pkg/adapter/nfs/adapter.go`**: `NFSConfig.TLS` (`cert_file`/`key_file`/`client_ca`/`min_version`/`mode`) mirroring `controlplane.tls.*`. Server `*tls.Config` built once in `Serve` via the shared `internal/tlsconfig` (cert hot-reload for free); min raised to TLS 1.3 (the RFC floor).
- **`pkg/adapter/nfs/connection.go`**: per-conn `tlsUpgraded` flag + `handleTLSGate` hook before concurrent dispatch. Probe → write verifier, `tls.Server` handshake, swap `c.conn`. **Opportunistic** (default) still serves non-TLS clients in plaintext; **require** mode drops plaintext until upgrade. mTLS is free when `client_ca` is set (`RequireAndVerifyClientCert`).
- **`cmd/dfs/commands/start.go`**: parse `adapters.nfs.tls.*` from the adapter config map.

## Cert rotation

No NFS-specific watcher: it reuses the control-plane `CertReloader` (lifted to `internal/tlsconfig` in #1214), so rotated cert files are hot-reloaded with no restart, same as the API server.

## Test

`pkg/adapter/nfs`: full STARTTLS handshake + encrypted echo; mTLS (valid client cert accepted / missing rejected); gate decisions (require rejects plaintext / opportunistic passes through). `-race` clean.

```
go test -race ./pkg/adapter/nfs/ ./internal/adapter/nfs/rpc/
```

## Interop (documented)

- **Linux**: `mount -o vers=4.1,xprtsec=tls` — needs `tlshd` (ktls-utils) + `CONFIG_NET_HANDSHAKE` (RHEL 9.x / kernel 6.7+).
- **macOS**: no NFS-over-TLS client — Kerberos or a tunnel instead.

Docs: `docs/NFS.md` + `docs/SECURITY.md`.

## Out of scope

SMB (already SMB3-encrypted), kTLS offload, ACME/issuance, operator NFS-TLS rendering (follow-up).