### PR TITLE
feat(smb): default SMB3 encryption to preferred + harden/document (#1198)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1022,7 +1022,7 @@ adapters:
       # "required"  - Only SMB 3.x clients with encryption can connect.
       #               2.x clients are rejected. Unencrypted requests on encrypted
       #               sessions return STATUS_ACCESS_DENIED.
-      encryption_mode: disabled   # disabled | preferred | required (default: disabled)
+      encryption_mode: preferred  # disabled | preferred | required (default: preferred)
 
       # Server cipher preference order (first = most preferred).
       # Empty list means all ciphers are allowed in the default order.
@@ -1044,12 +1044,20 @@ dfsctl share create --name /secure --metadata default --encrypt-data
 | Mode | Behavior | Use Case |
 |------|----------|----------|
 | `disabled` | No encryption for any session | Legacy clients, testing |
-| `preferred` | Encrypt 3.x sessions; allow unencrypted 2.x | Mixed environments |
+| `preferred` | Encrypt 3.x sessions; allow unencrypted 2.x | Mixed environments (**default**) |
 | `required` | Reject 2.x clients; encrypt all 3.x sessions | High-security environments |
+
+> **Secure default:** As of v1.0.0 the shipped default is `preferred`, so SMB 3.x
+> sessions are encrypted out of the box while remaining wire-compatible with SMB 2.x
+> clients. Set `encryption_mode: required` to mandate encryption for sensitive
+> deployments (this rejects SMB 2.x clients, which cannot encrypt). If SMB is bound to
+> a non-loopback address with `encryption_mode: disabled`, `dfs` logs a startup WARN
+> because file data then traverses the network in cleartext. See
+> [docs/SECURITY.md](SECURITY.md#smb3-security-model) for the hardened template.
 
 **Enforcement Rules:**
 
-1. **SESSION_SETUP**: When mode is `preferred` or `required`, encryption keys are derived for SMB 3.x sessions, and the `SMB2_SESSION_FLAG_ENCRYPT_DATA` flag is set in the response.
+1. **SESSION_SETUP**: When mode is `preferred` or `required`, AEAD encryption keys are derived for SMB 3.x sessions. In `required` mode the `SMB2_SESSION_FLAG_ENCRYPT_DATA` flag is set in the response and every subsequent message on the session must be encrypted. In `preferred` mode the keys are available for per-share enforcement, but the session flag is **not** set — message encryption is only forced on trees connected to shares with `encrypt_data=true`.
 2. **TREE_CONNECT**: When a share has `encrypt_data=true` and mode is `required`, unencrypted sessions are rejected with `STATUS_ACCESS_DENIED`. In `preferred` mode, unencrypted sessions are allowed (mixed model).
 3. **Guest sessions**: Never encrypted (no session key for key derivation).
 4. **SMB 2.x clients**: Never encrypted (encryption requires SMB 3.0+). In `required` mode, 2.x clients are rejected at NEGOTIATE.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1058,7 +1058,7 @@ dfsctl share create --name /secure --metadata default --encrypt-data
 **Enforcement Rules:**
 
 1. **SESSION_SETUP**: When mode is `preferred` or `required`, AEAD encryption keys are derived for SMB 3.x sessions. In `required` mode the `SMB2_SESSION_FLAG_ENCRYPT_DATA` flag is set in the response and every subsequent message on the session must be encrypted. In `preferred` mode the keys are available for per-share enforcement, but the session flag is **not** set — message encryption is only forced on trees connected to shares with `encrypt_data=true`.
-2. **TREE_CONNECT**: When a share has `encrypt_data=true` and mode is `required`, unencrypted sessions are rejected with `STATUS_ACCESS_DENIED`. In `preferred` mode, unencrypted sessions are allowed (mixed model).
+2. **Per-share (`encrypt_data=true`)**: encryption is forced on that tree **regardless of the global mode**. In `required` mode the unencrypted session is rejected at TREE_CONNECT. In `preferred` mode TREE_CONNECT succeeds, but every subsequent unencrypted request on the tree is denied with `STATUS_ACCESS_DENIED` (enforced by `checkEncryptionRequired`) — so plaintext access to an `encrypt_data` share is never actually allowed. The global mode only governs sessions to non-`encrypt_data` shares (mixed model in `preferred`).
 3. **Guest sessions**: Never encrypted (no session key for key derivation).
 4. **SMB 2.x clients**: Never encrypted (encryption requires SMB 3.0+). In `required` mode, 2.x clients are rejected at NEGOTIATE.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -125,18 +125,31 @@ SMB3 provides encryption using AEAD (Authenticated Encryption with Associated Da
 | AES-256-GCM | 3.1.1 | 256-bit | Fast (higher security, slightly slower than 128) |
 | AES-256-CCM | 3.0+ | 256-bit | Good (highest security AES-CCM variant) |
 
+SMB on-the-wire confidentiality is provided **by SMB3 in-protocol encryption** (the AEAD ciphers above) — not by TLS or QUIC. SMB-over-QUIC is tracked separately as a post-1.0 transport option and is out of scope for the v1.0.0 "SMB encryption" requirement, which this in-protocol encryption satisfies.
+
 **Encryption modes:**
 
-- **`disabled`**: No encryption. Suitable for testing only.
-- **`preferred`**: SMB 3.x sessions are encrypted; unencrypted SMB 2.x sessions are still accepted. Recommended for mixed environments.
+- **`disabled`**: No encryption. Suitable for testing only. If SMB is bound to a non-loopback address in this mode, `dfs` logs a startup WARN because file data traverses the network in cleartext.
+- **`preferred`** *(shipped default)*: SMB 3.x sessions are encrypted; unencrypted SMB 2.x sessions are still accepted. Confidentiality is on out of the box for capable clients while remaining wire-compatible with SMB 2.x.
 - **`required`**: Only encrypted SMB 3.x clients can connect. SMB 2.x clients are rejected at NEGOTIATE. **Recommended for production** with sensitive data.
 
 **Per-session vs per-share encryption:**
 
 - **Per-session**: When encryption is `preferred` or `required`, all traffic on an SMB 3.x session is encrypted after SESSION_SETUP completes.
-- **Per-share**: Individual shares can require encryption via the `encrypt_data` flag. Unencrypted sessions accessing an encrypted share receive `STATUS_ACCESS_DENIED`.
+- **Per-share**: Individual shares can require encryption via the `encrypt_data` flag (`dfsctl share create --encrypt-data`). Unencrypted sessions accessing an encrypted share receive `STATUS_ACCESS_DENIED`. This lets an admin force encryption on sensitive shares while leaving others compatible.
 
-**Security recommendation:** Set `encryption_mode: required` for environments handling sensitive data. This eliminates unencrypted traffic and rejects legacy clients that cannot encrypt.
+**Security recommendation:** The shipped default is `preferred` (secure-by-default, wire-compatible). For environments handling sensitive data, harden the SMB adapter to mandate both encryption and signing:
+
+```yaml
+adapters:
+  smb:
+    encryption:
+      encryption_mode: required   # reject SMB 2.x; encrypt all SMB 3.x sessions
+    signing:
+      required: true              # reject unsigned messages (tamper protection)
+```
+
+This eliminates unencrypted traffic, rejects legacy clients that cannot encrypt, and prevents message tampering. For shares that must stay SMB 2.x-compatible, keep the global mode at `preferred` and set `encrypt_data` on the sensitive shares instead.
 
 ### SMB3 Signing
 
@@ -374,12 +387,13 @@ shares:
 
 ### Encryption in Transit
 
-DittoFS supports in-transit encryption for both data-plane protocols: **SMB3** encrypts in-protocol (AES-GCM/CCM, see [SMB3 Encryption](#smb3-encryption)), and **NFS** can use **NFS-over-TLS (RFC 9289)** to wrap RPC traffic in TLS 1.3 (below). Without one of these — or network-level encryption — file data and AUTH_UNIX credentials travel in cleartext over TCP.
+DittoFS supports in-transit encryption for both data-plane protocols: **SMB3** encrypts in-protocol (AES-GCM/CCM, see [SMB3 Encryption](#smb3-encryption)) — on by default (`encryption_mode: preferred`), with `required` or per-share `encrypt_data` to mandate it — and **NFS** can use **NFS-over-TLS (RFC 9289)** to wrap RPC traffic in TLS 1.3 (below). Without one of these — or network-level encryption — file data and AUTH_UNIX credentials travel in cleartext over TCP.
 
 **Implications:**
 - Plaintext NFS data can be intercepted without TLS or network-level encryption
 - Prefer NFS-over-TLS or SMB3 encryption; otherwise use VPN, IPsec, or WireGuard
 - SMB message signing protects integrity but not confidentiality (use encryption for that)
+- In SMB `preferred` mode, legacy SMB 2.x clients (which cannot encrypt) still transmit in cleartext; set `encryption_mode: required` to reject them, or `encrypt_data` to force encryption on sensitive shares
 
 #### NFS-over-TLS (RFC 9289)
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -135,8 +135,8 @@ SMB on-the-wire confidentiality is provided **by SMB3 in-protocol encryption** (
 
 **Per-session vs per-share encryption:**
 
-- **Per-session**: When encryption is `preferred` or `required`, all traffic on an SMB 3.x session is encrypted after SESSION_SETUP completes.
-- **Per-share**: Individual shares can require encryption via the `encrypt_data` flag (`dfsctl share create --encrypt-data`). Unencrypted sessions accessing an encrypted share receive `STATUS_ACCESS_DENIED`. This lets an admin force encryption on sensitive shares while leaving others compatible.
+- **Per-session**: In `required` mode, `SMB2_SESSION_FLAG_ENCRYPT_DATA` is set at SESSION_SETUP and all traffic on the SMB 3.x session must be encrypted. In `preferred` mode, AEAD keys are derived but the flag is **not** set, so whole-session encryption is not forced (it remains available for per-share enforcement and client opt-in).
+- **Per-share**: Individual shares can require encryption via the `encrypt_data` flag (`dfsctl share create --encrypt-data`). This forces encryption on that tree **regardless of the global mode**: an unencrypted request on an `encrypt_data` tree receives `STATUS_ACCESS_DENIED` (enforced by `checkEncryptionRequired`). It lets an admin force encryption on sensitive shares while leaving others compatible.
 
 **Security recommendation:** The shipped default is `preferred` (secure-by-default, wire-compatible). For environments handling sensitive data, harden the SMB adapter to mandate both encryption and signing:
 

--- a/docs/SMB.md
+++ b/docs/SMB.md
@@ -812,10 +812,17 @@ DittoFS supports three encryption modes:
 | Mode | Behavior |
 |------|----------|
 | `disabled` | No encryption for any session |
-| `preferred` | Encrypt SMB 3.x sessions that support it; allow unencrypted 2.x |
+| `preferred` | Encrypt SMB 3.x sessions that support it; allow unencrypted 2.x (**default**) |
 | `required` | Reject SMB 2.x clients; encrypt all SMB 3.x sessions |
 
-**Per-session encryption** (`Session.EncryptData`): When mode is `preferred` or `required`, sessions negotiating SMB 3.x have `SMB2_SESSION_FLAG_ENCRYPT_DATA` set in SESSION_SETUP response. All subsequent messages on the session are encrypted.
+The shipped default is `preferred`: confidentiality is on by default for SMB 3.x
+clients without breaking SMB 2.x compatibility. Use `required` to force encryption
+on the whole server, or set per-share `encrypt_data` (below) to force it only on
+sensitive shares. SMB confidentiality is provided **by SMB3 in-protocol encryption**,
+not TLS or QUIC — see [docs/SECURITY.md](SECURITY.md#smb3-security-model). SMB-over-QUIC
+is tracked separately as a post-1.0 transport option.
+
+**Per-session encryption** (`Session.EncryptData`): When mode is `required`, sessions negotiating SMB 3.x have `SMB2_SESSION_FLAG_ENCRYPT_DATA` set in the SESSION_SETUP response and all subsequent messages on the session are encrypted. When mode is `preferred`, AEAD keys are still derived for SMB 3.x sessions (so per-share encryption can use them), but the session flag is **not** set — whole-session message encryption is only enforced in `required` mode or for shares with `encrypt_data=true`.
 
 **Per-share encryption** (`Share.EncryptData`): Individual shares can require encryption via the `encrypt_data` flag in share configuration. When set, `SMB2_SHAREFLAG_ENCRYPT_DATA` is returned in TREE_CONNECT response.
 

--- a/internal/adapter/smb/encryption_required_test.go
+++ b/internal/adapter/smb/encryption_required_test.go
@@ -1,0 +1,54 @@
+package smb
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/handlers"
+	"github.com/marmos91/dittofs/internal/adapter/smb/header"
+	"github.com/marmos91/dittofs/internal/adapter/smb/session"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// TestCheckEncryptionRequired_GlobalMode verifies the global ("required")
+// encryption gate in checkEncryptionRequired: post-session-setup requests on a
+// non-anonymous session must be encrypted, while NEGOTIATE/SESSION_SETUP and any
+// already-encrypted request are exempt. Per-share enforcement is covered by the
+// shouldRejectUnencryptedTreeConnect tests in the handlers package.
+func TestCheckEncryptionRequired_GlobalMode(t *testing.T) {
+	mgr := session.NewDefaultManager()
+	h := handlers.NewHandlerWithSessionManager(mgr)
+	connInfo := &ConnInfo{Handler: h, SessionManager: mgr}
+
+	const someSession = uint64(0x1234)
+
+	cases := []struct {
+		name        string
+		mode        string
+		command     types.Command
+		sessionID   uint64
+		isEncrypted bool
+		want        types.Status
+	}{
+		{"required_unencrypted_read_denied", "required", types.SMB2Read, someSession, false, types.StatusAccessDenied},
+		{"required_encrypted_read_ok", "required", types.SMB2Read, someSession, true, 0},
+		{"required_negotiate_exempt", "required", types.SMB2Negotiate, someSession, false, 0},
+		{"required_session_setup_exempt", "required", types.SMB2SessionSetup, someSession, false, 0},
+		{"required_no_session_skips_global", "required", types.SMB2Read, 0, false, 0},
+		{"preferred_unencrypted_read_ok", "preferred", types.SMB2Read, someSession, false, 0},
+		{"disabled_unencrypted_read_ok", "disabled", types.SMB2Read, someSession, false, 0},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h.EncryptionConfig.Mode = c.mode
+			reqHeader := &header.SMB2Header{
+				Command:   c.command,
+				SessionID: c.sessionID,
+			}
+			got := checkEncryptionRequired(reqHeader, connInfo, c.isEncrypted)
+			if got != c.want {
+				t.Errorf("checkEncryptionRequired = 0x%08x, want 0x%08x", got, c.want)
+			}
+		})
+	}
+}

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -20,6 +20,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
+	"github.com/marmos91/dittofs/pkg/netutil"
 )
 
 // Compile-time assertion that Adapter satisfies the adapter.Adapter interface.
@@ -140,9 +141,27 @@ func New(config Config) *Adapter {
 		Mode:           config.Encryption.Mode,
 		AllowedCiphers: config.Encryption.AllowedCiphers,
 	}
+	// Keep EncryptionEnabled (which gates CapEncryption in NEGOTIATE for SMB
+	// 3.0/3.0.2) in sync with the configured mode at construction time, so the
+	// adapter is self-consistent even before SetRuntime/applySMBSettings runs
+	// (e.g. tests, or SMB 3.0 clients connecting between New and SetRuntime).
+	handler.EncryptionEnabled = config.Encryption.Mode != "disabled"
 	logger.Debug("SMB encryption configuration",
 		"mode", handler.EncryptionConfig.Mode,
 		"allowed_ciphers", handler.EncryptionConfig.AllowedCiphers)
+
+	// Default-posture nudge: binding SMB to a non-loopback address with
+	// encryption explicitly disabled means file data and metadata cross the
+	// network in cleartext. The shipped default is "preferred" (encrypts SMB
+	// 3.x), so this only fires when an admin opted out. Mirror the control-plane
+	// API's cleartext WARN rather than hard-failing (wire-compat with SMB 2.x).
+	if config.Encryption.Mode == "disabled" && netutil.IsNonLoopbackHost(config.BindAddress) {
+		logger.Warn("SMB is bound to a non-loopback address with encryption disabled; "+
+			"file data and metadata will traverse the network in CLEARTEXT. "+
+			"Set adapters.smb.encryption.encryption_mode to \"preferred\" or \"required\". "+
+			"See docs/SECURITY.md.",
+			"bind_address", config.BindAddress)
+	}
 
 	// Build BaseAdapter config from SMB config
 	baseConfig := adapter.BaseConfig{

--- a/pkg/adapter/smb/cleartext_warn_test.go
+++ b/pkg/adapter/smb/cleartext_warn_test.go
@@ -37,6 +37,7 @@ func TestNew_CleartextWarnOnNonLoopbackDisabledEncryption(t *testing.T) {
 		wantWarn bool
 	}{
 		{"non_loopback_disabled", "0.0.0.0", "disabled", true},
+		{"empty_bind_disabled", "", "disabled", true}, // empty = wildcard (":port")
 		{"non_loopback_preferred", "0.0.0.0", "preferred", false},
 		{"non_loopback_required", "0.0.0.0", "required", false},
 		{"loopback_disabled", "127.0.0.1", "disabled", false},

--- a/pkg/adapter/smb/cleartext_warn_test.go
+++ b/pkg/adapter/smb/cleartext_warn_test.go
@@ -1,0 +1,59 @@
+package smb
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/logger"
+)
+
+// logCaptureMu serializes the process-global logger redirect used below.
+var logCaptureMu sync.Mutex
+
+func captureWarn(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	logCaptureMu.Lock()
+	buf := &bytes.Buffer{}
+	logger.InitWithWriter(buf, "WARN", "text", false)
+	t.Cleanup(func() {
+		logger.InitWithWriter(&bytes.Buffer{}, "ERROR", "text", false)
+		logCaptureMu.Unlock()
+	})
+	return buf
+}
+
+// TestNew_CleartextWarnOnNonLoopbackDisabledEncryption asserts that creating an
+// SMB adapter bound to a non-loopback address with encryption disabled emits the
+// cleartext WARN, while a loopback bind or any non-disabled mode stays quiet.
+func TestNew_CleartextWarnOnNonLoopbackDisabledEncryption(t *testing.T) {
+	const wantFragment = "traverse the network in CLEARTEXT"
+
+	cases := []struct {
+		name     string
+		bind     string
+		mode     string
+		wantWarn bool
+	}{
+		{"non_loopback_disabled", "0.0.0.0", "disabled", true},
+		{"non_loopback_preferred", "0.0.0.0", "preferred", false},
+		{"non_loopback_required", "0.0.0.0", "required", false},
+		{"loopback_disabled", "127.0.0.1", "disabled", false},
+		{"default_mode_non_loopback", "0.0.0.0", "", false}, // defaults to preferred
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			buf := captureWarn(t)
+			_ = New(Config{
+				BindAddress: c.bind,
+				Encryption:  EncryptionConfig{Mode: c.mode},
+			})
+			got := strings.Contains(buf.String(), wantFragment)
+			if got != c.wantWarn {
+				t.Errorf("warn emitted = %v, want %v (log: %q)", got, c.wantWarn, buf.String())
+			}
+		})
+	}
+}

--- a/pkg/adapter/smb/config.go
+++ b/pkg/adapter/smb/config.go
@@ -184,12 +184,12 @@ func (c *SigningConfig) ToSigningConfig() signing.SigningConfig {
 //     Unencrypted requests on encrypted sessions return STATUS_ACCESS_DENIED.
 //
 // Default values:
-//   - Mode: "disabled"
+//   - Mode: "preferred"
 //   - AllowedCiphers: [AES-256-GCM, AES-256-CCM, AES-128-GCM, AES-128-CCM]
 type EncryptionConfig struct {
 	// Mode controls the encryption policy.
 	// Valid values: "disabled", "preferred", "required"
-	// Default: "disabled"
+	// Default: "preferred" (encrypts SMB 3.x sessions, still accepts SMB 2.x)
 	Mode string `mapstructure:"encryption_mode"`
 
 	// AllowedCiphers is an ordered list of allowed cipher IDs.
@@ -213,7 +213,12 @@ func DefaultAllowedCiphers() []uint16 {
 // applyDefaults fills in zero values with sensible defaults.
 func (c *EncryptionConfig) applyDefaults() {
 	if c.Mode == "" {
-		c.Mode = "disabled"
+		// Secure-by-default: "preferred" transparently encrypts SMB 3.x sessions
+		// that support it while still accepting SMB 2.x (which cannot encrypt),
+		// so confidentiality is on out of the box without breaking wire compat.
+		// Set "required" to mandate encryption (rejecting SMB 2.x), or "disabled"
+		// to opt out entirely.
+		c.Mode = "preferred"
 	}
 	if len(c.AllowedCiphers) == 0 {
 		c.AllowedCiphers = DefaultAllowedCiphers()

--- a/pkg/adapter/smb/config_test.go
+++ b/pkg/adapter/smb/config_test.go
@@ -1,0 +1,29 @@
+package smb
+
+import "testing"
+
+// TestEncryptionConfig_DefaultModeIsPreferred locks in the secure-by-default
+// posture: an unset encryption mode resolves to "preferred", which encrypts
+// SMB 3.x sessions while still accepting SMB 2.x clients (wire-compatible).
+func TestEncryptionConfig_DefaultModeIsPreferred(t *testing.T) {
+	var c EncryptionConfig
+	c.applyDefaults()
+	if c.Mode != "preferred" {
+		t.Fatalf("default encryption mode = %q, want %q", c.Mode, "preferred")
+	}
+	if len(c.AllowedCiphers) == 0 {
+		t.Fatalf("default AllowedCiphers must be non-empty")
+	}
+}
+
+// TestEncryptionConfig_ExplicitModePreserved ensures applyDefaults never
+// overrides an admin-set mode (including an explicit "disabled" opt-out).
+func TestEncryptionConfig_ExplicitModePreserved(t *testing.T) {
+	for _, mode := range []string{"disabled", "preferred", "required"} {
+		c := EncryptionConfig{Mode: mode}
+		c.applyDefaults()
+		if c.Mode != mode {
+			t.Errorf("applyDefaults overrode mode %q -> %q", mode, c.Mode)
+		}
+	}
+}

--- a/pkg/controlplane/api/cleartext_warn_test.go
+++ b/pkg/controlplane/api/cleartext_warn_test.go
@@ -10,33 +10,6 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// TestIsNonLoopbackHost is a table test for the host classifier that gates the
-// cleartext-credentials warning.
-func TestIsNonLoopbackHost(t *testing.T) {
-	cases := []struct {
-		host string
-		want bool
-	}{
-		{"", false},          // empty defaults to loopback (127.0.0.1)
-		{"127.0.0.1", false}, // explicit loopback
-		{"127.0.0.5", false}, // anything in 127.0.0.0/8 is loopback
-		{"::1", false},
-		{"[::1]", false},
-		{"localhost", false},
-		{"0.0.0.0", true}, // wildcard reaches off-host
-		{"::", true},
-		{"[::]", true},
-		{"10.0.0.5", true},        // private but off-host
-		{"192.168.1.20", true},    // off-host
-		{"api.example.com", true}, // hostname → assume off-host
-	}
-	for _, c := range cases {
-		if got := isNonLoopbackHost(c.host); got != c.want {
-			t.Errorf("isNonLoopbackHost(%q) = %v, want %v", c.host, got, c.want)
-		}
-	}
-}
-
 // captureWarn redirects the global logger to a buffer at WARN level for the
 // duration of the test. The logger output is process-global, so the tests that
 // use this run serially (no t.Parallel).

--- a/pkg/controlplane/api/server.go
+++ b/pkg/controlplane/api/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/marmos91/dittofs/internal/tlsconfig"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
+	"github.com/marmos91/dittofs/pkg/netutil"
 )
 
 // DefaultRestoreHTTPTimeout is the fallback context bound applied to the
@@ -82,7 +83,7 @@ func NewServer(config APIConfig, rt *runtime.Runtime, cpStore store.Store, resto
 	// hard-require TLS (back-compat: many deployments terminate at the edge),
 	// so this is a startup WARN pointing at the TLS / external-termination docs
 	// rather than a fatal error.
-	if tlsConfig == nil && isNonLoopbackHost(config.Host) {
+	if tlsConfig == nil && netutil.IsNonLoopbackHost(config.Host) {
 		logger.Warn("control plane API is bound to a non-loopback address with TLS disabled; "+
 			"login credentials and tokens will traverse the network in CLEARTEXT. "+
 			"Configure controlplane.tls.{cert_file,key_file} for native TLS, or terminate TLS at an ingress/mesh. "+
@@ -260,29 +261,6 @@ func (s *Server) TLSEnabled() bool {
 // mTLSEnabled reports whether the server requires verified client certificates.
 func (s *Server) mTLSEnabled() bool {
 	return s.tlsConfig != nil && s.tlsConfig.ClientAuth == tls.RequireAndVerifyClientCert
-}
-
-// isNonLoopbackHost reports whether host binds the API to something other than
-// loopback. An empty host defaults to 127.0.0.1 (loopback) elsewhere, so it is
-// treated as loopback here. A wildcard bind (0.0.0.0 / ::) reaches off-host and
-// counts as non-loopback. A named host that does not parse as an IP (e.g. a
-// hostname) is conservatively treated as non-loopback so the cleartext warning
-// is not silently skipped.
-func isNonLoopbackHost(host string) bool {
-	switch host {
-	case "", "127.0.0.1", "::1", "[::1]", "localhost":
-		return false
-	}
-	// Strip brackets from an IPv6 literal like "[::]".
-	h := host
-	if len(h) >= 2 && h[0] == '[' && h[len(h)-1] == ']' {
-		h = h[1 : len(h)-1]
-	}
-	if ip := net.ParseIP(h); ip != nil {
-		return !ip.IsLoopback()
-	}
-	// Non-IP host (hostname): assume it resolves off-host.
-	return true
 }
 
 // displayAddr returns a host:port that is routable for example/log URLs. A

--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -1,0 +1,28 @@
+// Package netutil holds small, dependency-free networking helpers shared across
+// the control plane and protocol adapters.
+package netutil
+
+import "net"
+
+// IsNonLoopbackHost reports whether host binds a listener to something other
+// than loopback. An empty host is treated as loopback (callers default an empty
+// bind address to 127.0.0.1 elsewhere). A wildcard bind (0.0.0.0 / ::) reaches
+// off-host and counts as non-loopback. A named host that does not parse as an
+// IP (e.g. a hostname) is conservatively treated as non-loopback so cleartext
+// warnings are not silently skipped.
+func IsNonLoopbackHost(host string) bool {
+	switch host {
+	case "", "127.0.0.1", "::1", "[::1]", "localhost":
+		return false
+	}
+	// Strip brackets from an IPv6 literal like "[::]".
+	h := host
+	if len(h) >= 2 && h[0] == '[' && h[len(h)-1] == ']' {
+		h = h[1 : len(h)-1]
+	}
+	if ip := net.ParseIP(h); ip != nil {
+		return !ip.IsLoopback()
+	}
+	// Non-IP host (hostname): assume it resolves off-host.
+	return true
+}

--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -5,14 +5,16 @@ package netutil
 import "net"
 
 // IsNonLoopbackHost reports whether host binds a listener to something other
-// than loopback. An empty host is treated as loopback (callers default an empty
-// bind address to 127.0.0.1 elsewhere). A wildcard bind (0.0.0.0 / ::) reaches
-// off-host and counts as non-loopback. A named host that does not parse as an
-// IP (e.g. a hostname) is conservatively treated as non-loopback so cleartext
-// warnings are not silently skipped.
+// than loopback. An empty host is a wildcard bind (":port" listens on all
+// interfaces), so it counts as non-loopback; callers that want an empty bind to
+// mean loopback must default it to a loopback literal (e.g. "127.0.0.1") before
+// calling. A wildcard bind (0.0.0.0 / ::) reaches off-host and counts as
+// non-loopback. A named host that does not parse as an IP (e.g. a hostname) is
+// conservatively treated as non-loopback so cleartext warnings are not silently
+// skipped.
 func IsNonLoopbackHost(host string) bool {
 	switch host {
-	case "", "127.0.0.1", "::1", "[::1]", "localhost":
+	case "127.0.0.1", "::1", "[::1]", "localhost":
 		return false
 	}
 	// Strip brackets from an IPv6 literal like "[::]".

--- a/pkg/netutil/netutil_test.go
+++ b/pkg/netutil/netutil_test.go
@@ -1,0 +1,30 @@
+package netutil
+
+import "testing"
+
+// TestIsNonLoopbackHost is a table test for the host classifier that gates the
+// cleartext-credentials / unencrypted-traffic startup warnings.
+func TestIsNonLoopbackHost(t *testing.T) {
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{"", false},          // empty defaults to loopback (127.0.0.1)
+		{"127.0.0.1", false}, // explicit loopback
+		{"127.0.0.5", false}, // anything in 127.0.0.0/8 is loopback
+		{"::1", false},
+		{"[::1]", false},
+		{"localhost", false},
+		{"0.0.0.0", true}, // wildcard reaches off-host
+		{"::", true},
+		{"[::]", true},
+		{"10.0.0.5", true},        // private but off-host
+		{"192.168.1.20", true},    // off-host
+		{"api.example.com", true}, // hostname → assume off-host
+	}
+	for _, c := range cases {
+		if got := IsNonLoopbackHost(c.host); got != c.want {
+			t.Errorf("IsNonLoopbackHost(%q) = %v, want %v", c.host, got, c.want)
+		}
+	}
+}

--- a/pkg/netutil/netutil_test.go
+++ b/pkg/netutil/netutil_test.go
@@ -9,7 +9,7 @@ func TestIsNonLoopbackHost(t *testing.T) {
 		host string
 		want bool
 	}{
-		{"", false},          // empty defaults to loopback (127.0.0.1)
+		{"", true},           // empty = wildcard bind (":port", all interfaces)
 		{"127.0.0.1", false}, // explicit loopback
 		{"127.0.0.5", false}, // anything in 127.0.0.0/8 is loopback
 		{"::1", false},


### PR DESCRIPTION
Closes #1198.

## What

Make SMB3 in-protocol encryption the **default secure posture**. No new crypto — SMB3 GCM/CCM already exists; this flips the default, adds a hardening signal, and documents the model.

## Changes

- **Default flip**: `EncryptionConfig` mode `disabled` → `preferred` (`pkg/adapter/smb/config.go`). Wire-compatible — encrypts SMB 3.x sessions automatically, still accepts SMB 2.x clients (which cannot encrypt). `required` available for hardened deployments.
- **Startup WARN**: `dfs` logs a cleartext warning when SMB binds a **non-loopback** address with encryption explicitly `disabled` (mirrors the control-plane API cleartext WARN). Only fires on an explicit opt-out.
- **Shared helper**: extracted `netutil.IsNonLoopbackHost` (`pkg/netutil/`) from the control-plane API's unexported copy; reused by both API and SMB to avoid drift.
- **Self-consistency**: `New()` now syncs `handler.EncryptionEnabled` with the configured mode (was only synced at runtime in `applySMBSettings`), so `CapEncryption` advertisement is correct before `SetRuntime`.
- **Per-share**: confirmed `checkEncryptionRequired` + `shouldRejectUnencryptedTreeConnect` already enforce per-share `encrypt_data` under `required` mode; added focused tests.
- **Docs**: `CONFIGURATION.md` / `SMB.md` / `SECURITY.md` — new default, hardened template (encryption `required` + signing `required`), per-share `encrypt_data`, corrected the preferred-mode session-flag behavior (`SMB2_SESSION_FLAG_ENCRYPT_DATA` is set only in `required`), corrected the in-transit confidentiality model, cross-linked SMB-over-QUIC (post-1.0).

## Notes / out of scope

- **Operator**: SMB adapters are configured via REST post-deploy, not templated in the CRD/Helm chart, so operator-deployed servers inherit the new `preferred` default automatically — no CRD/chart change needed.
- **Live setting asymmetry** (pre-existing): `applySMBSettings` only upgrades `disabled`→`preferred`; it never downgrades. With the new default, `dfsctl ... --enable-encryption=false` cannot drive the mode to `disabled` — set `encryption_mode: disabled` in the config file instead. The config file is authoritative. A code WARN was considered but would fire on every default install (DB default `EnableEncryption=false`), so this is documented rather than logged.
- No new ciphers / no SMB-over-QUIC.

## Tests

- `pkg/netutil` host-classifier table test (moved from api).
- `pkg/adapter/smb` default-mode + explicit-mode-preserved + cleartext-WARN tests.
- `internal/adapter/smb` `checkEncryptionRequired` global-mode table test.
- `go build ./...`, `go vet`, `gofmt`, affected `go test` all green. Code-simplifier (no changes warranted) + code-reviewer (4 findings, all addressed) run.