### PR TITLE
fix(tls): review follow-ups for #1196 / #1214

### DIFF
--- a/cmd/dfsctl/cmdutil/util.go
+++ b/cmd/dfsctl/cmdutil/util.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/marmos91/dittofs/internal/cli/credentials"
 	"github.com/marmos91/dittofs/internal/cli/output"
@@ -65,9 +66,15 @@ type GlobalFlags struct {
 	TLSSkipVerifySet bool
 }
 
+// skipVerifyWarnOnce ensures the man-in-the-middle warning is printed at most
+// once per process, even though TLSClientOptions may be called several times
+// per command (e.g. token refresh followed by the final client build).
+var skipVerifyWarnOnce sync.Once
+
 // TLSClientOptions translates resolved TLS parameters into apiclient options.
-// It also emits the man-in-the-middle warning once when verification is
-// disabled. Empty parameters produce no options (default transport behavior).
+// It also emits the man-in-the-middle warning (once per process) when
+// verification is disabled. Empty parameters produce no options (default
+// transport behavior).
 func TLSClientOptions(caCert, clientCert, clientKey string, skipVerify bool) []apiclient.ClientOption {
 	var opts []apiclient.ClientOption
 	if caCert != "" {
@@ -77,9 +84,11 @@ func TLSClientOptions(caCert, clientCert, clientKey string, skipVerify bool) []a
 		opts = append(opts, apiclient.WithClientCert(clientCert, clientKey))
 	}
 	if skipVerify {
-		_, _ = fmt.Fprintln(os.Stderr,
-			"WARNING: TLS certificate verification disabled (--tls-skip-verify); "+
-				"the connection is vulnerable to man-in-the-middle attacks")
+		skipVerifyWarnOnce.Do(func() {
+			_, _ = fmt.Fprintln(os.Stderr,
+				"WARNING: TLS certificate verification disabled (--tls-skip-verify); "+
+					"the connection is vulnerable to man-in-the-middle attacks")
+		})
 		opts = append(opts, apiclient.WithInsecureSkipVerify(true))
 	}
 	return opts

--- a/cmd/dfsctl/commands/login.go
+++ b/cmd/dfsctl/commands/login.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"net/url"
+	"path/filepath"
 
 	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
 	"github.com/marmos91/dittofs/internal/cli/credentials"
@@ -54,6 +55,15 @@ func init() {
 	loginCmd.Flags().BoolVar(&loginTLSSkipVerify, "tls-skip-verify", false, "Disable TLS certificate verification (insecure)")
 }
 
+// absPath resolves p to an absolute path so it can be persisted and re-read
+// from a different working directory. An empty path stays empty (unset).
+func absPath(p string) (string, error) {
+	if p == "" {
+		return "", nil
+	}
+	return filepath.Abs(p)
+}
+
 func runLogin(cmd *cobra.Command, args []string) error {
 	// Load credential store
 	store, err := credentials.NewStore()
@@ -90,6 +100,20 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return cmdutil.HandleAbort(err)
 		}
+	}
+
+	// Normalize TLS cert paths to absolute before they are captured and
+	// persisted. The stored paths are re-read by later commands from a
+	// potentially different working directory, so a relative path supplied here
+	// (e.g. --cacert ca.pem) would otherwise resolve against the wrong cwd.
+	if loginCACert, err = absPath(loginCACert); err != nil {
+		return fmt.Errorf("resolve --cacert: %w", err)
+	}
+	if loginClientCert, err = absPath(loginClientCert); err != nil {
+		return fmt.Errorf("resolve --client-cert: %w", err)
+	}
+	if loginClientKey, err = absPath(loginClientKey); err != nil {
+		return fmt.Errorf("resolve --client-key: %w", err)
 	}
 
 	// Create API client. TLS material is captured here and persisted into the

--- a/internal/tlsconfig/tlsconfig.go
+++ b/internal/tlsconfig/tlsconfig.go
@@ -185,6 +185,12 @@ func (r *CertReloader) changed() bool {
 // plaintext. The returned config uses GetCertificate for hot-reload and, when
 // a client CA is set, requires and verifies client certificates (mTLS).
 func ServerConfig(cfg Config) (*tls.Config, error) {
+	// Validate first so an inconsistent partial config (e.g. cert_file without
+	// key_file, or a client CA without a server cert) is reported loudly rather
+	// than silently treated as "TLS disabled" by the Enabled() check below.
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
 	if !cfg.Enabled() {
 		return nil, nil
 	}

--- a/internal/tlsconfig/tlsconfig_test.go
+++ b/internal/tlsconfig/tlsconfig_test.go
@@ -175,6 +175,12 @@ func TestServerConfig(t *testing.T) {
 	if _, err := ServerConfig(Config{CertFile: "/nonexistent/c", KeyFile: "/nonexistent/k"}); err == nil {
 		t.Fatal("expected error for missing cert files")
 	}
+
+	// Inconsistent partial config must error loudly, not silently fall back to
+	// nil (plaintext) via Enabled()==false.
+	if _, err := ServerConfig(Config{CertFile: "/c"}); err == nil {
+		t.Fatal("expected error for cert_file without key_file, got nil (silent plaintext fallback)")
+	}
 }
 
 func TestCertReloader_HotSwap(t *testing.T) {

--- a/pkg/apiclient/client.go
+++ b/pkg/apiclient/client.go
@@ -109,14 +109,14 @@ func (c *Client) applyTLS() error {
 	if c.caCertPath != "" {
 		caPEM, err := os.ReadFile(c.caCertPath)
 		if err != nil {
-			return fmt.Errorf("read CA cert %s: %w", c.caCertPath, err)
+			return fmt.Errorf("read CA cert %q: %w", c.caCertPath, err)
 		}
 		pool, err := x509.SystemCertPool()
 		if err != nil || pool == nil {
 			pool = x509.NewCertPool()
 		}
 		if !pool.AppendCertsFromPEM(caPEM) {
-			return fmt.Errorf("CA cert %s contains no valid PEM certificate", c.caCertPath)
+			return fmt.Errorf("CA cert %q contains no valid PEM certificate", c.caCertPath)
 		}
 		tlsCfg.RootCAs = pool
 	}
@@ -124,7 +124,7 @@ func (c *Client) applyTLS() error {
 	if c.clientCertPath != "" {
 		cert, err := tls.LoadX509KeyPair(c.clientCertPath, c.clientKeyPath)
 		if err != nil {
-			return fmt.Errorf("load client key pair (cert=%s key=%s): %w", c.clientCertPath, c.clientKeyPath, err)
+			return fmt.Errorf("load client key pair (cert=%q key=%q): %w", c.clientCertPath, c.clientKeyPath, err)
 		}
 		tlsCfg.Certificates = []tls.Certificate{cert}
 	}


### PR DESCRIPTION
Addresses post-merge Copilot review comments on #1216 (dfsctl client TLS) and #1214 (shared internal/tlsconfig).

- **login (relative cert paths):** `--cacert`/`--client-cert`/`--client-key` are now normalized to absolute paths before being persisted in the credential context. Previously a relative path (e.g. `--cacert ca.pem`) was stored verbatim and later resolved against each command's working directory — which can differ from where `login` ran — causing surprising failures.
- **MITM warning printed once:** `TLSClientOptions` may be called more than once per command (token refresh + final client), so the `--tls-skip-verify` warning printed multiple times. Gated behind `sync.Once` (once per process).
- **Quoted paths in errors:** apiclient TLS load errors use `%q` so paths with spaces are unambiguous.
- **`tlsconfig.ServerConfig` validates first:** an inconsistent partial config (cert without key, client CA without server cert) now errors loudly instead of silently falling back to plaintext via `Enabled()==false`. Both current callers (control-plane API, NFS adapter) already validate; this is defense-in-depth for future callers.

## Test

```
go test ./pkg/apiclient/ ./cmd/dfsctl/... ./internal/tlsconfig/ ./internal/cli/credentials/
```
New: `ServerConfig` partial-config regression case.