### PR TITLE
feat: scheduled wire field + name_prefix validation

### DIFF
--- a/internal/controlplane/api/handlers/snapshot.go
+++ b/internal/controlplane/api/handlers/snapshot.go
@@ -262,6 +262,7 @@ func (h *SnapshotHandler) toWire(s *models.Snapshot, includeDisk bool) dto.Snaps
 		Share:         s.ShareName,
 		State:         s.State,
 		RemoteDurable: s.RemoteDurable,
+		Scheduled:     s.Scheduled,
 		Error:         s.Error,
 		CreatedAt:     s.CreatedAt,
 		UpdatedAt:     s.UpdatedAt,

--- a/internal/controlplane/api/handlers/snapshot_policy.go
+++ b/internal/controlplane/api/handlers/snapshot_policy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -15,6 +16,12 @@ import (
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/schedule"
 )
+
+// snapshotNamePrefixRe is the authoritative charset/length rule for a snapshot
+// policy NamePrefix. The prefix is concatenated into a snapshot label
+// (prefix + "-" + timestamp), so it must reject path-traversal and other
+// injection characters. Empty is allowed (falls back to defaultNamePrefix).
+var snapshotNamePrefixRe = regexp.MustCompile(`^[A-Za-z0-9_-]{0,64}$`)
 
 // SnapshotPolicyRuntime is the narrow Runtime surface SnapshotPolicyHandler
 // depends on. Defined here so unit tests can substitute a fake.
@@ -75,6 +82,10 @@ func (h *SnapshotPolicyHandler) Upsert(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.KeepLast < 0 {
 		BadRequest(w, "keep_last must be >= 0")
+		return
+	}
+	if req.NamePrefix != "" && !snapshotNamePrefixRe.MatchString(req.NamePrefix) {
+		BadRequest(w, "invalid name_prefix: must match ^[A-Za-z0-9_-]{0,64}$")
 		return
 	}
 	enabled := true

--- a/internal/controlplane/api/handlers/snapshot_policy_test.go
+++ b/internal/controlplane/api/handlers/snapshot_policy_test.go
@@ -103,6 +103,18 @@ func TestSnapshotPolicyHandler_Upsert_InvalidInterval(t *testing.T) {
 	}
 }
 
+func TestSnapshotPolicyHandler_Upsert_InvalidNamePrefix(t *testing.T) {
+	h := NewSnapshotPolicyHandler(&fakeSnapshotPolicyRuntime{})
+	body, _ := json.Marshal(dto.UpsertSnapshotPolicyRequest{Interval: "24h", NamePrefix: "bad prefix!"})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/shares/data/snapshot-policy", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	newPolicyRouter(h).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+}
+
 func TestSnapshotPolicyHandler_Upsert_NegativeKeepLast(t *testing.T) {
 	h := NewSnapshotPolicyHandler(&fakeSnapshotPolicyRuntime{})
 	body, _ := json.Marshal(dto.UpsertSnapshotPolicyRequest{Interval: "24h", KeepLast: -1})

--- a/internal/controlplane/api/handlers/snapshot_test.go
+++ b/internal/controlplane/api/handlers/snapshot_test.go
@@ -310,6 +310,29 @@ func TestSnapshotHandler_Get_HappyPath(t *testing.T) {
 	}
 }
 
+func TestSnapshotHandler_Get_ScheduledRoundTrips(t *testing.T) {
+	fake := &fakeSnapshotRuntime{
+		getFn: func(_ context.Context, _, snapID string) (*models.Snapshot, error) {
+			return &models.Snapshot{ID: snapID, ShareName: "/data", State: models.StateReady, Scheduled: true}, nil
+		},
+	}
+	h := NewSnapshotHandler(fake, 30*time.Second, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/shares/data/snapshots/snap-1", nil)
+	rr := httptest.NewRecorder()
+	newSnapshotRouter(h).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var got dto.Snapshot
+	if err := json.NewDecoder(rr.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.Scheduled {
+		t.Fatalf("scheduled = false, want true (body=%+v)", got)
+	}
+}
+
 func TestSnapshotHandler_Get_NotFound(t *testing.T) {
 	fake := &fakeSnapshotRuntime{
 		getFn: func(_ context.Context, _, _ string) (*models.Snapshot, error) {

--- a/pkg/controlplane/api/dto/snapshot.go
+++ b/pkg/controlplane/api/dto/snapshot.go
@@ -12,6 +12,7 @@ type Snapshot struct {
 	Share         string    `json:"share"`
 	State         string    `json:"state"`
 	RemoteDurable bool      `json:"remote_durable"`
+	Scheduled     bool      `json:"scheduled"`
 	ManifestCount int       `json:"manifest_count,omitempty"`
 	DumpBytes     int64     `json:"dump_bytes,omitempty"`
 	RetryOf       string    `json:"retry_of,omitempty"`


### PR DESCRIPTION
Bundles the two upstream gaps tracked in #1213 into a single backward-compatible, additive change. Both are required by the DittoFS Pro snapshot-policies UI.

## Changes

### D-01 — `scheduled` wire field
`models.Snapshot.Scheduled` (set by the background snapshot scheduler) was never surfaced on the wire: `dto.Snapshot` had no `scheduled` field and `SnapshotHandler.toWire` dropped it. This PR adds `Scheduled bool \`json:"scheduled"\`` to `dto.Snapshot` and sets it unconditionally in `toWire` (it does not depend on `includeDisk`). API clients can now distinguish scheduler-created snapshots from manual ones exactly, rather than guessing from the name prefix.

### D-08 — `name_prefix` charset validation
The snapshot-policy `Upsert` handler validated interval / ttl / keep_last but passed `NamePrefix` straight through, where it is concatenated into a snapshot label (`prefix + "-" + timestamp`). This PR adds authoritative server-side validation against `^[A-Za-z0-9_-]{0,64}$` (alphanumeric + underscore + hyphen, max 64 chars), returning HTTP 400 on mismatch. Empty is still allowed and falls back to the scheduler's `defaultNamePrefix = "scheduled"`. This rejects path-traversal and other injection characters at the trust boundary; any downstream UI mirror is UX-only.

## Tests
- `TestSnapshotHandler_Get_ScheduledRoundTrips` — `scheduled: true` round-trips through `toWire`.
- `TestSnapshotPolicyHandler_Upsert_InvalidNamePrefix` — a malformed prefix returns 400.

`go test ./internal/controlplane/api/handlers/...` and `go build ./...` both green.

Both changes are additive and backward-compatible (optional field + new validation), suitable for a patch release.

Closes #1213