### PR TITLE
AD-0: permission-core consolidation + NFSv4 ACCESS fix + cross-protocol conformance matrix

### DIFF
--- a/internal/adapter/nfs/v4/handlers/access.go
+++ b/internal/adapter/nfs/v4/handlers/access.go
@@ -69,8 +69,12 @@ func (h *Handler) handleAccess(ctx *types.CompoundContext, reader io.Reader) *ty
 
 // accessRealFS handles ACCESS for real filesystem files.
 //
-// It checks Unix permission bits against the effective UID/GID from
-// the auth context. All 6 access bits are reported as supported.
+// It routes through the central metadata permission checker
+// (MetadataService.CheckPermissions) exactly like the NFSv3 ACCESS handler,
+// so ACLs, DENY ACEs, and SID-based grants are honored identically across
+// protocols. The handler only translates protocol access bits to and from the
+// canonical metadata.Permission vocabulary; all permission logic lives in the
+// metadata layer. All 6 access bits are reported as supported.
 func (h *Handler) accessRealFS(ctx *types.CompoundContext, accessReq uint32) *types.CompoundResult {
 	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
 	if err != nil {
@@ -90,7 +94,8 @@ func (h *Handler) accessRealFS(ctx *types.CompoundContext, accessReq uint32) *ty
 		}
 	}
 
-	file, err := metaSvc.GetFile(authCtx.Context, metadata.FileHandle(ctx.CurrentFH))
+	handle := metadata.FileHandle(ctx.CurrentFH)
+	file, err := metaSvc.GetFile(authCtx.Context, handle)
 	if err != nil {
 		status := common.MapToNFS4(err)
 		return &types.CompoundResult{
@@ -100,8 +105,29 @@ func (h *Handler) accessRealFS(ctx *types.CompoundContext, accessReq uint32) *ty
 		}
 	}
 
-	// Check Unix permission bits against UID/GID
-	granted := checkAccessBits(accessReq, file, authCtx)
+	// Translate the requested ACCESS4 bits to the canonical permission
+	// vocabulary, run the central checker, then translate the granted set
+	// back. This is the same path NFSv3 ACCESS uses (see
+	// internal/adapter/nfs/v3/handlers/access.go) — the metadata layer owns
+	// ACL / DENY-ACE / SID evaluation; the handler does protocol only.
+	requestedPerms := nfsAccessToPermissions(accessReq, file.Type)
+
+	grantedPerms, err := metaSvc.CheckPermissions(authCtx, handle, requestedPerms)
+	if err != nil {
+		status := common.MapToNFS4(err)
+		return &types.CompoundResult{
+			Status: status,
+			OpCode: types.OP_ACCESS,
+			Data:   encodeStatusOnly(status),
+		}
+	}
+
+	// Mask back to what the client actually asked for; CheckPermissions only
+	// ever returns a subset of the requested generic flags, but the
+	// permission<->access translation is not perfectly bijective for
+	// directories (LOOKUP and EXECUTE both map to Traverse), so re-AND with
+	// the requested ACCESS4 bits.
+	granted := permissionsToNFSAccess(grantedPerms, file.Type) & accessReq
 
 	// Report all ACCESS4 bits the server can evaluate
 	supported := uint32(ACCESS4_READ | ACCESS4_LOOKUP | ACCESS4_MODIFY |
@@ -141,90 +167,80 @@ func (h *Handler) accessRealFS(ctx *types.CompoundContext, accessReq uint32) *ty
 	}
 }
 
-// checkAccessBits checks requested ACCESS bits against file Unix permissions.
+// nfsAccessToPermissions translates NFSv4 ACCESS4 bits to the canonical
+// metadata.Permission vocabulary. NFSv4 ACCESS4 bits (RFC 7530 §6) share the
+// same numeric values and semantics as NFSv3 ACCESS bits (RFC 1813 §3.3.4), so
+// this mirrors internal/adapter/nfs/v3/handlers/access.go::nfsAccessToPermissions
+// to keep cross-protocol enforcement identical.
 //
-// Root (UID 0) gets all access. For other users, it checks the appropriate
-// owner/group/other permission bits based on the effective UID/GID.
-func checkAccessBits(requested uint32, file *metadata.File, authCtx *metadata.AuthContext) uint32 {
-	var granted uint32
+// The translation is context-sensitive on file type: for directories
+// ACCESS4_READ means list, ACCESS4_LOOKUP/EXECUTE mean traverse, and
+// MODIFY/EXTEND mean write; for files the mapping is direct.
+func nfsAccessToPermissions(accessReq uint32, fileType metadata.FileType) metadata.Permission {
+	var perms metadata.Permission
 
-	// Determine effective UID/GID
-	uid := ^uint32(0) // sentinel: invalid UID
-	gid := ^uint32(0)
-	var gids []uint32
-
-	if authCtx.Identity != nil {
-		if authCtx.Identity.UID != nil {
-			uid = *authCtx.Identity.UID
+	if fileType == metadata.FileTypeDirectory {
+		if accessReq&ACCESS4_READ != 0 {
+			perms |= metadata.PermissionListDirectory
 		}
-		if authCtx.Identity.GID != nil {
-			gid = *authCtx.Identity.GID
+		if accessReq&ACCESS4_LOOKUP != 0 {
+			perms |= metadata.PermissionTraverse
 		}
-		gids = authCtx.Identity.GIDs
-	}
-
-	// Root gets everything
-	if uid == 0 {
-		return requested
-	}
-
-	// Determine which permission triad applies
-	mode := file.Mode & 0o7777
-	var readBit, writeBit, execBit bool
-
-	if uid == file.UID {
-		// Owner bits
-		readBit = mode&0o400 != 0
-		writeBit = mode&0o200 != 0
-		execBit = mode&0o100 != 0
-	} else if isInGroup(gid, gids, file.GID) {
-		// Group bits
-		readBit = mode&0o040 != 0
-		writeBit = mode&0o020 != 0
-		execBit = mode&0o010 != 0
+		if accessReq&ACCESS4_EXECUTE != 0 {
+			perms |= metadata.PermissionTraverse
+		}
+		if accessReq&(ACCESS4_MODIFY|ACCESS4_EXTEND) != 0 {
+			perms |= metadata.PermissionWrite
+		}
 	} else {
-		// Other bits
-		readBit = mode&0o004 != 0
-		writeBit = mode&0o002 != 0
-		execBit = mode&0o001 != 0
-	}
-
-	// Map permission bits to ACCESS4 bits
-	if requested&ACCESS4_READ != 0 && readBit {
-		granted |= ACCESS4_READ
-	}
-	if requested&ACCESS4_LOOKUP != 0 {
-		// For directories: execute bit; for files: execute bit
-		if execBit {
-			granted |= ACCESS4_LOOKUP
+		if accessReq&ACCESS4_READ != 0 {
+			perms |= metadata.PermissionRead
+		}
+		if accessReq&(ACCESS4_MODIFY|ACCESS4_EXTEND) != 0 {
+			perms |= metadata.PermissionWrite
+		}
+		if accessReq&ACCESS4_EXECUTE != 0 {
+			perms |= metadata.PermissionExecute
 		}
 	}
-	if requested&ACCESS4_MODIFY != 0 && writeBit {
-		granted |= ACCESS4_MODIFY
-	}
-	if requested&ACCESS4_EXTEND != 0 && writeBit {
-		granted |= ACCESS4_EXTEND
-	}
-	if requested&ACCESS4_DELETE != 0 && writeBit {
-		// Simplified: grant DELETE if write permission on current
-		granted |= ACCESS4_DELETE
-	}
-	if requested&ACCESS4_EXECUTE != 0 && execBit {
-		granted |= ACCESS4_EXECUTE
+
+	if accessReq&ACCESS4_DELETE != 0 {
+		perms |= metadata.PermissionDelete
 	}
 
-	return granted
+	return perms
 }
 
-// isInGroup checks if the given gid or any supplementary gids match the target group.
-func isInGroup(gid uint32, gids []uint32, targetGID uint32) bool {
-	if gid == targetGID {
-		return true
-	}
-	for _, g := range gids {
-		if g == targetGID {
-			return true
+// permissionsToNFSAccess is the inverse of nfsAccessToPermissions, mirroring
+// internal/adapter/nfs/v3/handlers/access.go::permissionsToNFSAccess.
+func permissionsToNFSAccess(perms metadata.Permission, fileType metadata.FileType) uint32 {
+	var accessRes uint32
+
+	if fileType == metadata.FileTypeDirectory {
+		if perms&metadata.PermissionListDirectory != 0 {
+			accessRes |= ACCESS4_READ
+		}
+		if perms&metadata.PermissionTraverse != 0 {
+			accessRes |= ACCESS4_LOOKUP | ACCESS4_EXECUTE
+		}
+		if perms&metadata.PermissionWrite != 0 {
+			accessRes |= ACCESS4_MODIFY | ACCESS4_EXTEND
+		}
+	} else {
+		if perms&metadata.PermissionRead != 0 {
+			accessRes |= ACCESS4_READ
+		}
+		if perms&metadata.PermissionWrite != 0 {
+			accessRes |= ACCESS4_MODIFY | ACCESS4_EXTEND
+		}
+		if perms&metadata.PermissionExecute != 0 {
+			accessRes |= ACCESS4_EXECUTE
 		}
 	}
-	return false
+
+	if perms&metadata.PermissionDelete != 0 {
+		accessRes |= ACCESS4_DELETE
+	}
+
+	return accessRes
 }

--- a/internal/adapter/nfs/v4/handlers/realfs_test.go
+++ b/internal/adapter/nfs/v4/handlers/realfs_test.go
@@ -675,8 +675,16 @@ func TestAccess_RealFS_RootGetsAll(t *testing.T) {
 	if supported != allBits {
 		t.Errorf("supported = 0x%x, want 0x%x", supported, allBits)
 	}
-	if access != allBits {
-		t.Errorf("access = 0x%x, want 0x%x (root should get all)", access, allBits)
+
+	// Root gets every bit that is MEANINGFUL for the object type. ACCESS4_LOOKUP
+	// (0x02) is a directory-search right; on a regular file it has no canonical
+	// permission mapping (RFC 7530 §6 / RFC 1813 §3.3.4) and is correctly NOT
+	// granted. This matches the NFSv3 ACCESS handler, which uses the identical
+	// nfsAccessToPermissions / permissionsToNFSAccess translation — the whole
+	// point of routing NFSv4 ACCESS through the central checker.
+	wantRoot := allBits &^ uint32(ACCESS4_LOOKUP)
+	if access != wantRoot {
+		t.Errorf("access = 0x%x, want 0x%x (root gets all meaningful bits; LOOKUP is directory-only)", access, wantRoot)
 	}
 }
 

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -354,6 +354,29 @@ type OpenFile struct {
 	// and MS-FSCC §2.4.1, FileAccessInformation and QUERY_INFO open-level
 	// access gates consult this field, not DesiredAccess (smb2.acls.GENERIC
 	// at acls.c:440).
+	//
+	// Per-op gates are INTENTIONALLY frozen to this snapshot, not re-evaluated
+	// through the central FileAccessChecker on each request:
+	//
+	//   - The single access check happens once, at CREATE, through the central
+	//     metadata.FileAccessChecker (CheckFileAccess / CheckFileAccessWithParent).
+	//     Subsequent READ / WRITE / DELETE / SET_INFO / IOCTL (sparse, copychunk,
+	//     fsctl) handlers gate against this frozen GrantedAccess rather than
+	//     re-running the checker. This is the MS-SMB2 / MS-FSA handle model
+	//     (MS-FSA §2.1.5.2/§2.1.5.3 operate on Open.GrantedAccess; §2.1.5.4
+	//     delete-on-close honors the authorization frozen at open), and it is
+	//     deliberately spec-correct: an open's rights do NOT shrink or grow if
+	//     the DACL changes after the handle is granted. Re-evaluating per-op
+	//     would be a protocol bug, not a fix — a Windows client holding a valid
+	//     handle would start seeing STATUS_ACCESS_DENIED mid-stream.
+	//   - DELETE access verified at open (FILE_DELETE_ON_CLOSE / SET_INFO
+	//     FileDispositionInformation) is propagated to the unlink path via
+	//     AuthContext.HasDeleteAccess so the metadata delete check honors the
+	//     same frozen authorization (see metadata.checkDeletePermission, #388).
+	//
+	// So for SMB the central checker is the SOLE authorizer; per-op handlers
+	// only consult the mask it produced. Centralizing the per-op gates further
+	// would change spec-mandated semantics and is explicitly out of scope.
 	GrantedAccess       uint32
 	IsDirectory         bool
 	IsPipe              bool   // True if this is a named pipe (IPC$)

--- a/internal/adapter/smb/handlers/query_directory.go
+++ b/internal/adapter/smb/handlers/query_directory.go
@@ -420,7 +420,7 @@ func (h *Handler) QueryDirectory(ctx *SMBHandlerContext, req *QueryDirectoryRequ
 			}
 			return &file.FileAttr
 		}
-		filteredEntries = filterByAccess(filteredEntries, authCtx, hydrate)
+		filteredEntries = filterByAccess(metaSvc, filteredEntries, authCtx, hydrate)
 	}
 
 	// Sort entries by name (case-insensitive) for consistent enumeration order.
@@ -1129,36 +1129,49 @@ func (h *Handler) treeHasAccessBasedEnumeration(treeID uint32) bool {
 // inaccessible under ABE rather than leaking it.
 type attrHydrator func(entry *metadata.DirEntry) *metadata.FileAttr
 
+// abeReadMask is the set of read rights an access-based enumeration requires
+// the caller to hold on an entry for it to remain visible. Mirrors Samba
+// source3/smbd/dir.c::user_can_read_fsp: FILE_READ_DATA | FILE_READ_EA |
+// FILE_READ_ATTRIBUTES | READ_CONTROL. NFSv4 bits intentionally share positions
+// with Windows MS-DTYP rights (RFC 7530 §6.2.1) — READ_DATA == LIST_DIRECTORY
+// (0x1), READ_NAMED_ATTRS == READ_EA (0x8) — so the same mask applies to both
+// files and directories. smb2.acls.ACCESSBASED asserts a file granting only a
+// strict subset of these bits is hidden.
+const abeReadMask = acl.ACE4_READ_DATA |
+	acl.ACE4_READ_NAMED_ATTRS |
+	acl.ACE4_READ_ATTRIBUTES |
+	acl.ACE4_READ_ACL
+
 // filterByAccess returns the subset of entries the requester may read,
 // implementing MS-SRVS SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM semantics.
-// Files require ACE4_READ_DATA, directories require ACE4_LIST_DIRECTORY
-// (which share the same bit, 0x00000001). When the entry has an ACL attached,
-// the decision is made by acl.Evaluate using the requester's identity. When
-// the entry has no ACL but has attributes, we fall back to Unix mode-bit
-// checks — same convention as security.go's buildDACL (#525): the SD that
-// goes on the wire synthesizes a Windows default, but server-side decisions
-// stay POSIX so mode bits remain authoritative.
+// The per-entry read decision is delegated to the central permission checker
+// (metadata.FileAccessChecker.CheckAttrReadAccess), so ABE visibility honors
+// the same ACL / DENY-ACE / SID evaluation — over one EvaluateContext — that
+// CREATE-time access checks use. The handler does protocol only: it picks the
+// entries and the read mask; the metadata layer owns the decision.
 //
 // When DirEntry.Attr is nil (documented optional, refs #532 review):
 //   - If hydrate is non-nil it is called to look up the attributes; if it
 //     still returns nil the entry is hidden (fail-closed).
 //   - If hydrate is nil the entry is hidden directly. Returning true here
 //     would leak entries that ABE is supposed to suppress.
-func filterByAccess(entries []metadata.DirEntry, authCtx *metadata.AuthContext, hydrate attrHydrator) []metadata.DirEntry {
+func filterByAccess(checker metadata.FileAccessChecker, entries []metadata.DirEntry, authCtx *metadata.AuthContext, hydrate attrHydrator) []metadata.DirEntry {
 	if len(entries) == 0 {
 		return entries
 	}
 
-	// Root bypass mirrors the rest of the metadata layer: UID 0 sees
-	// everything regardless of per-file DACL / mode. Avoids hiding entries
-	// from admin tools that legitimately need a full listing.
+	// Root fast-path: UID 0 sees everything, so skip per-entry hydration and
+	// the checker round-trip entirely (admin tools need a full listing). The
+	// central checker would also grant root, but short-circuiting here avoids
+	// a GetFile per orphaned entry. This is an enumeration optimization, not a
+	// permission decision — the decision itself still lives in the checker.
 	if authCtx != nil && authCtx.Identity != nil && authCtx.Identity.UID != nil && *authCtx.Identity.UID == 0 {
 		return entries
 	}
 
 	out := entries[:0]
 	for i := range entries {
-		if canEnumerateEntry(&entries[i], authCtx, hydrate) {
+		if canEnumerateEntry(checker, &entries[i], authCtx, hydrate) {
 			out = append(out, entries[i])
 		}
 	}
@@ -1166,8 +1179,10 @@ func filterByAccess(entries []metadata.DirEntry, authCtx *metadata.AuthContext, 
 }
 
 // canEnumerateEntry reports whether the requester may see this entry in an
-// access-based enumeration. See filterByAccess for the policy contract.
-func canEnumerateEntry(entry *metadata.DirEntry, authCtx *metadata.AuthContext, hydrate attrHydrator) bool {
+// access-based enumeration. See filterByAccess for the policy contract. The
+// actual read evaluation (ACL when present, POSIX mode-bit fallback, root and
+// anonymous handling) lives in the central checker.
+func canEnumerateEntry(checker metadata.FileAccessChecker, entry *metadata.DirEntry, authCtx *metadata.AuthContext, hydrate attrHydrator) bool {
 	attr := entry.Attr
 	if attr == nil {
 		// Attr is documented optional on DirEntry (pkg/metadata/validation.go).
@@ -1184,85 +1199,5 @@ func canEnumerateEntry(entry *metadata.DirEntry, authCtx *metadata.AuthContext, 
 		}
 	}
 
-	// Mirror Samba source3/smbd/dir.c::user_can_read_fsp: ABE requires the
-	// caller to hold FILE_READ_DATA | FILE_READ_EA | FILE_READ_ATTRIBUTES |
-	// READ_CONTROL on the entry. NFSv4 bits intentionally share positions with
-	// Windows MS-DTYP rights (RFC 7530 §6.2.1) — READ_DATA == LIST_DIRECTORY
-	// (0x1), READ_NAMED_ATTRS == READ_EA (0x8), so the same mask applies to
-	// both files and directories. The smbtorture smb2.acls.ACCESSBASED test
-	// asserts a file granting only a strict subset of these bits is hidden.
-	const enumMask = acl.ACE4_READ_DATA |
-		acl.ACE4_READ_NAMED_ATTRS |
-		acl.ACE4_READ_ATTRIBUTES |
-		acl.ACE4_READ_ACL
-
-	if attr.ACL != nil {
-		evalCtx := buildEnumEvalContext(attr, authCtx)
-		return acl.Evaluate(attr.ACL, evalCtx, enumMask)
-	}
-
-	// POSIX fallback — same semantics as
-	// pkg/metadata/auth_permissions.go::calculatePermissions for read.
-	return posixCanRead(attr, authCtx)
-}
-
-// buildEnumEvalContext constructs an acl.EvaluateContext from an attr +
-// AuthContext pair for access-based enumeration decisions.
-func buildEnumEvalContext(attr *metadata.FileAttr, authCtx *metadata.AuthContext) *acl.EvaluateContext {
-	evalCtx := &acl.EvaluateContext{
-		FileOwnerUID: attr.UID,
-		FileOwnerGID: attr.GID,
-	}
-	// Anonymous (no Identity or no UID): force FileOwnerUID to the
-	// AnonymousFileOwnerUID sentinel so the requester's zero-valued UID
-	// cannot collapse onto a root-owned entry's owner and pick up OWNER@
-	// ACEs plus the MS-DTYP §2.5.3.2 owner-implicit grant during ABE
-	// visibility checks. See #540.
-	if authCtx == nil || authCtx.Identity == nil || authCtx.Identity.UID == nil {
-		evalCtx.FileOwnerUID = acl.AnonymousFileOwnerUID
-		return evalCtx
-	}
-	id := authCtx.Identity
-	if id.UID != nil {
-		evalCtx.UID = *id.UID
-	}
-	if id.GID != nil {
-		evalCtx.GID = *id.GID
-	}
-	evalCtx.GIDs = id.GIDs
-	switch {
-	case id.Username != "" && id.Domain != "":
-		evalCtx.Who = id.Username + "@" + id.Domain
-	case id.Username != "":
-		evalCtx.Who = id.Username
-	}
-	if id.SID != nil {
-		evalCtx.SID = *id.SID
-	}
-	evalCtx.GroupSIDs = id.GroupSIDs
-	// MS-DTYP §2.5.3.2: owner-implicit WRITE_OWNER requires
-	// SeTakeOwnershipPrivilege (admins only). See acl.Evaluate.
-	evalCtx.RequesterHasTakeOwnership = acl.HasTakeOwnershipPrivilege(evalCtx.SID, evalCtx.GroupSIDs)
-	return evalCtx
-}
-
-// posixCanRead implements the read-bit selection used for access-based
-// enumeration on files / directories without an ACL.
-func posixCanRead(attr *metadata.FileAttr, authCtx *metadata.AuthContext) bool {
-	if attr == nil {
-		return true
-	}
-	if authCtx == nil || authCtx.Identity == nil || authCtx.Identity.UID == nil {
-		// Anonymous → only the "other" read bit applies.
-		return attr.Mode&0o004 != 0
-	}
-	uid := *authCtx.Identity.UID
-	switch {
-	case uid == attr.UID:
-		return attr.Mode&0o400 != 0
-	case authCtx.Identity.HasGID(attr.GID):
-		return attr.Mode&0o040 != 0
-	default:
-		return attr.Mode&0o004 != 0
-	}
+	return checker.CheckAttrReadAccess(attr, authCtx, abeReadMask)
 }

--- a/internal/adapter/smb/handlers/query_directory_abe_test.go
+++ b/internal/adapter/smb/handlers/query_directory_abe_test.go
@@ -13,6 +13,12 @@ import (
 
 func uint32Ptr(v uint32) *uint32 { return &v }
 
+// abeChecker returns a metadata.FileAccessChecker for the access-based
+// enumeration filter under test. CheckAttrReadAccess evaluates purely from the
+// passed FileAttr + AuthContext and touches no store, so a bare service
+// instance is sufficient.
+func abeChecker() metadata.FileAccessChecker { return metadata.New() }
+
 // authForUID builds an AuthContext for the given UID with a single primary GID.
 // Context is wired to context.Background() so future hydrators that dereference
 // authCtx.Context don't panic.
@@ -85,13 +91,13 @@ func TestFilterByAccess_OwnerOnlyACL(t *testing.T) {
 
 	owner := authForUID(1000, 1000)
 	// Make a fresh copy each call since filterByAccess mutates in place.
-	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), owner, nil)
+	got := filterByAccess(abeChecker(), append([]metadata.DirEntry(nil), entries...), owner, nil)
 	if len(got) != 2 {
 		t.Fatalf("owner: want 2 entries, got %d (%v)", len(got), got)
 	}
 
 	other := authForUID(2000, 2000)
-	got = filterByAccess(append([]metadata.DirEntry(nil), entries...), other, nil)
+	got = filterByAccess(abeChecker(), append([]metadata.DirEntry(nil), entries...), other, nil)
 	if len(got) != 1 || got[0].Name != "public.txt" {
 		t.Fatalf("non-owner: want only public.txt, got %v", got)
 	}
@@ -121,7 +127,7 @@ func TestFilterByAccess_PartialReadMaskHidesFromOwner(t *testing.T) {
 				},
 			}
 			entries := []metadata.DirEntry{regularFileWithACL("smb2-testsd", 1000, 1000, 0o000, a)}
-			got := filterByAccess(append([]metadata.DirEntry(nil), entries...), owner, nil)
+			got := filterByAccess(abeChecker(), append([]metadata.DirEntry(nil), entries...), owner, nil)
 			if len(got) != 0 {
 				t.Fatalf("owner with partial mask %#x: want hidden, got %d entries", tc.mask, len(got))
 			}
@@ -143,13 +149,13 @@ func TestFilterByAccess_DirectoryListBit(t *testing.T) {
 	}
 
 	other := authForUID(2000, 2000)
-	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), other, nil)
+	got := filterByAccess(abeChecker(), append([]metadata.DirEntry(nil), entries...), other, nil)
 	if len(got) != 0 {
 		t.Fatalf("non-owner directory: want hidden, got %v", got)
 	}
 
 	owner := authForUID(1000, 1000)
-	got = filterByAccess(append([]metadata.DirEntry(nil), entries...), owner, nil)
+	got = filterByAccess(abeChecker(), append([]metadata.DirEntry(nil), entries...), owner, nil)
 	if len(got) != 1 {
 		t.Fatalf("owner directory: want 1 entry, got %d", len(got))
 	}
@@ -167,19 +173,19 @@ func TestFilterByAccess_POSIXFallback(t *testing.T) {
 	}
 
 	owner := authForUID(1000, 1000)
-	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), owner, nil)
+	got := filterByAccess(abeChecker(), append([]metadata.DirEntry(nil), entries...), owner, nil)
 	if len(got) != 3 {
 		t.Fatalf("owner: want all 3 entries, got %d (%v)", len(got), got)
 	}
 
 	groupMember := authForUID(2000, 1000) // not owner, in group
-	got = filterByAccess(append([]metadata.DirEntry(nil), entries...), groupMember, nil)
+	got = filterByAccess(abeChecker(), append([]metadata.DirEntry(nil), entries...), groupMember, nil)
 	if len(got) != 2 {
 		t.Fatalf("group member: want 2 entries (world.txt + group.txt), got %d (%v)", len(got), got)
 	}
 
 	stranger := authForUID(3000, 3000) // neither owner nor in group
-	got = filterByAccess(append([]metadata.DirEntry(nil), entries...), stranger, nil)
+	got = filterByAccess(abeChecker(), append([]metadata.DirEntry(nil), entries...), stranger, nil)
 	if len(got) != 1 || got[0].Name != "world.txt" {
 		t.Fatalf("stranger: want only world.txt, got %v", got)
 	}
@@ -199,7 +205,7 @@ func TestFilterByAccess_RootBypass(t *testing.T) {
 	}
 
 	root := authForUID(0, 0)
-	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), root, nil)
+	got := filterByAccess(abeChecker(), append([]metadata.DirEntry(nil), entries...), root, nil)
 	if len(got) != 2 {
 		t.Fatalf("root: want all 2 entries, got %d (%v)", len(got), got)
 	}
@@ -218,7 +224,7 @@ func TestFilterByAccess_HidesNonReadable(t *testing.T) {
 	entries := []metadata.DirEntry{
 		regularFileWithACL("secret.txt", 1000, 1000, 0o000, ownerOnly),
 	}
-	got := filterByAccess(entries, authForUID(2000, 2000), nil)
+	got := filterByAccess(abeChecker(), entries, authForUID(2000, 2000), nil)
 	if len(got) != 0 {
 		t.Fatalf("want 0 entries, got %d", len(got))
 	}
@@ -235,7 +241,7 @@ func TestFilterByAccess_NilAttrFailsClosed(t *testing.T) {
 		{Name: "noattr.txt", Attr: nil},
 	}
 
-	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), authForUID(2000, 2000), nil)
+	got := filterByAccess(abeChecker(), append([]metadata.DirEntry(nil), entries...), authForUID(2000, 2000), nil)
 	if len(got) != 0 {
 		t.Fatalf("nil-attr no-hydrator: want 0 entries (hidden), got %d (%v)", len(got), got)
 	}
@@ -250,7 +256,7 @@ func TestFilterByAccess_NilAttrHydratorMisses(t *testing.T) {
 	}
 
 	miss := func(_ *metadata.DirEntry) *metadata.FileAttr { return nil }
-	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), authForUID(2000, 2000), miss)
+	got := filterByAccess(abeChecker(), append([]metadata.DirEntry(nil), entries...), authForUID(2000, 2000), miss)
 	if len(got) != 0 {
 		t.Fatalf("nil-attr hydrator miss: want 0 entries, got %d", len(got))
 	}
@@ -281,13 +287,13 @@ func TestFilterByAccess_NilAttrHydratorHits(t *testing.T) {
 	}
 
 	// Owner with hydration: visible.
-	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), authForUID(1000, 1000), hydrate)
+	got := filterByAccess(abeChecker(), append([]metadata.DirEntry(nil), entries...), authForUID(1000, 1000), hydrate)
 	if len(got) != 1 {
 		t.Fatalf("owner via hydrate: want 1 entry, got %d (%v)", len(got), got)
 	}
 
 	// Non-owner with hydration: hidden by ACL.
-	got = filterByAccess(append([]metadata.DirEntry(nil), entries...), authForUID(2000, 2000), hydrate)
+	got = filterByAccess(abeChecker(), append([]metadata.DirEntry(nil), entries...), authForUID(2000, 2000), hydrate)
 	if len(got) != 0 {
 		t.Fatalf("non-owner via hydrate: want 0 entries, got %d (%v)", len(got), got)
 	}
@@ -306,7 +312,7 @@ func TestFilterByAccess_NilAttrRootBypass(t *testing.T) {
 		return nil
 	}
 
-	got := filterByAccess(append([]metadata.DirEntry(nil), entries...), authForUID(0, 0), hydrate)
+	got := filterByAccess(abeChecker(), append([]metadata.DirEntry(nil), entries...), authForUID(0, 0), hydrate)
 	if len(got) != 1 {
 		t.Fatalf("root: want 1 entry (bypass), got %d", len(got))
 	}

--- a/pkg/metadata/file_access_checker.go
+++ b/pkg/metadata/file_access_checker.go
@@ -1,0 +1,152 @@
+package metadata
+
+import "github.com/marmos91/dittofs/pkg/metadata/acl"
+
+// FileAccessChecker is the single protocol-agnostic entry point every protocol
+// adapter (NFSv3 / NFSv4.0 / NFSv4.1 / SMB2 / SMB3) funnels permission
+// decisions through. Consolidating the checks behind one interface keeps the
+// "handlers do protocol only" invariant: adapters translate their wire access
+// bits to and from the canonical vocabularies below and never evaluate ACLs,
+// DENY ACEs, or SID-based grants themselves.
+//
+// Two request vocabularies are supported because the two protocol families
+// arrive with different access-bit models, but both resolve to the same
+// underlying acl.Evaluate / acl.EvaluateGranted core over one EvaluateContext
+// (UID/GID/GIDs + SID/GroupSIDs):
+//
+//   - CheckPermissions takes the generic metadata.Permission flag set. NFSv3 /
+//     NFSv4 ACCESS and NFSv4 OPEN translate their RFC 1813 / RFC 7530 ACCESS
+//     bits into Permission flags and call this.
+//   - CheckFileAccess / CheckFileAccessWithParent take a raw MS-DTYP access
+//     mask. SMB CREATE evaluates DesiredAccess against the file's DACL through
+//     these and freezes the result onto the handle's GrantedAccess.
+//
+// CheckAttrReadAccess is the attr-based read probe used by SMB access-based
+// enumeration, where only a directory entry's FileAttr (not a full File with a
+// handle) is in scope. It centralizes the ACL+POSIX read evaluation the SMB
+// query_directory handler previously inlined via a direct acl.Evaluate call.
+//
+// *Service is the production implementation; the interface exists so the
+// permission core has one named contract and so the cross-protocol conformance
+// matrix can assert every protocol's translation lands on identical decisions.
+type FileAccessChecker interface {
+	// CheckPermissions evaluates a generic-flag request against a file handle
+	// and returns the granted subset (NFS path).
+	CheckPermissions(ctx *AuthContext, handle FileHandle, requested Permission) (Permission, error)
+
+	// CheckFileAccess evaluates an MS-DTYP DesiredAccess mask against a file's
+	// stored DACL and returns the granted mask (SMB CREATE path). Returns
+	// ErrAccessDenied as a *StoreError when a non-MAXIMUM_ALLOWED bit is denied.
+	CheckFileAccess(file *File, authCtx *AuthContext, desiredAccess uint32) (uint32, error)
+
+	// CheckFileAccessWithParent extends CheckFileAccess with the MS-FSA
+	// delete-via-parent override (FILE_DELETE_CHILD on the parent grants DELETE
+	// on the child even when the child's own DACL denies it).
+	CheckFileAccessWithParent(file *File, parent *File, authCtx *AuthContext, desiredAccess uint32) (uint32, error)
+
+	// CheckAttrReadAccess reports whether the requester may read the entry
+	// described by attr. Used by SMB access-based enumeration. requestedMask is
+	// the set of MS-DTYP / NFSv4 read rights the caller requires (these bit
+	// positions are shared between the two models per RFC 7530 §6.2.1).
+	CheckAttrReadAccess(attr *FileAttr, authCtx *AuthContext, requestedMask uint32) bool
+}
+
+// Static assertion that *Service satisfies the consolidated checker contract.
+var _ FileAccessChecker = (*Service)(nil)
+
+// CheckAttrReadAccess reports whether authCtx may read the entry described by
+// attr, evaluating its ACL when present and falling back to POSIX mode bits
+// otherwise. It is the centralized form of the access-based-enumeration read
+// probe SMB query_directory previously implemented with an inline acl.Evaluate
+// call, so the ABE visibility decision now shares the exact EvaluateContext
+// shape used by CheckFileAccess / CheckPermissions.
+//
+// requestedMask carries the MS-DTYP / NFSv4 read rights the caller requires
+// (e.g. READ_DATA | READ_NAMED_ATTRS | READ_ATTRIBUTES | READ_ACL for ABE).
+// The ACE bit positions are shared between the Windows and NFSv4 models per
+// RFC 7530 §6.2.1, so a single mask drives both files and directories.
+func (s *Service) CheckAttrReadAccess(attr *FileAttr, authCtx *AuthContext, requestedMask uint32) bool {
+	if attr == nil {
+		// No attributes resolved: fail closed. The caller (ABE) must not leak
+		// an entry it cannot prove the requester may read.
+		return false
+	}
+
+	// Root bypass mirrors the rest of the metadata layer: UID 0 reads
+	// everything regardless of per-file DACL / mode.
+	if authCtx != nil && authCtx.Identity != nil && authCtx.Identity.UID != nil && *authCtx.Identity.UID == 0 {
+		return true
+	}
+
+	if attr.ACL != nil {
+		evalCtx := buildAttrEvalContext(attr, authCtx)
+		return acl.Evaluate(attr.ACL, evalCtx, requestedMask)
+	}
+
+	// POSIX fallback — same read-bit selection as
+	// auth_permissions.go::calculatePermissions for read.
+	return attrPosixCanRead(attr, authCtx)
+}
+
+// buildAttrEvalContext constructs an acl.EvaluateContext from a FileAttr +
+// AuthContext pair. It mirrors buildFileAccessEvalContext but takes the bare
+// FileAttr (no enclosing File / handle), which is all an access-based
+// enumeration decision has in scope.
+func buildAttrEvalContext(attr *FileAttr, authCtx *AuthContext) *acl.EvaluateContext {
+	if authCtx == nil || authCtx.Identity == nil || authCtx.Identity.UID == nil {
+		// Anonymous: force FileOwnerUID to the AnonymousFileOwnerUID sentinel so
+		// the requester's zero-valued UID cannot collapse onto a root-owned
+		// entry's owner and pick up OWNER@ ACEs plus the MS-DTYP §2.5.3.2
+		// owner-implicit grant. See #540.
+		return &acl.EvaluateContext{
+			FileOwnerUID: acl.AnonymousFileOwnerUID,
+			FileOwnerGID: attr.GID,
+		}
+	}
+
+	identity := authCtx.Identity
+	evalCtx := &acl.EvaluateContext{
+		UID:          *identity.UID,
+		GIDs:         identity.GIDs,
+		FileOwnerUID: attr.UID,
+		FileOwnerGID: attr.GID,
+	}
+	if identity.GID != nil {
+		evalCtx.GID = *identity.GID
+	}
+
+	switch {
+	case identity.Username != "" && identity.Domain != "":
+		evalCtx.Who = identity.Username + "@" + identity.Domain
+	case identity.Username != "":
+		evalCtx.Who = identity.Username
+	}
+
+	if identity.SID != nil {
+		evalCtx.SID = *identity.SID
+	}
+	evalCtx.GroupSIDs = identity.GroupSIDs
+	// MS-DTYP §2.5.3.2: owner-implicit WRITE_OWNER requires
+	// SeTakeOwnershipPrivilege (admins only). See acl.Evaluate.
+	evalCtx.RequesterHasTakeOwnership = acl.HasTakeOwnershipPrivilege(evalCtx.SID, evalCtx.GroupSIDs)
+
+	return evalCtx
+}
+
+// attrPosixCanRead implements the read-bit selection used when an entry has no
+// ACL: owner/group/other read bit based on the requester's effective identity.
+func attrPosixCanRead(attr *FileAttr, authCtx *AuthContext) bool {
+	if authCtx == nil || authCtx.Identity == nil || authCtx.Identity.UID == nil {
+		// Anonymous → only the "other" read bit applies.
+		return attr.Mode&0o004 != 0
+	}
+	uid := *authCtx.Identity.UID
+	switch {
+	case uid == attr.UID:
+		return attr.Mode&0o400 != 0
+	case authCtx.Identity.HasGID(attr.GID):
+		return attr.Mode&0o040 != 0
+	default:
+		return attr.Mode&0o004 != 0
+	}
+}

--- a/pkg/metadata/storetest/cross_protocol_permissions.go
+++ b/pkg/metadata/storetest/cross_protocol_permissions.go
@@ -1,0 +1,401 @@
+package storetest
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+)
+
+// RunCrossProtocolPermissionMatrix is the cross-protocol permission conformance
+// suite (AD-0). It is the regression net guaranteeing that NFSv3, NFSv4.0,
+// NFSv4.1, and SMB all reach the SAME allow/deny decision for the SAME file +
+// ACL on the SAME metadata backend.
+//
+// AD identities are worthless if the two protocol families enforce a file's ACL
+// differently. The original NFSv4 ACCESS handler reimplemented a Unix-mode-only
+// check that ignored ACLs, DENY ACEs, and SID-based grants, so the same file
+// produced a different answer on NFSv4 than on NFSv3/SMB. This suite pins the
+// fix: every protocol "lane" below drives the SAME central
+// metadata.FileAccessChecker entry point its production adapter uses, and the
+// suite asserts every lane agrees with every other lane and with the expected
+// decision — including DENY ACEs and SID-only grants (the bug class).
+//
+// Run it from each backend's conformance test (memory / badger / postgres) so
+// the matrix is (memory|badger|postgres) x (NFSv3|NFSv4.0|NFSv4.1|SMB).
+func RunCrossProtocolPermissionMatrix(t *testing.T, factory StoreFactory) {
+	t.Helper()
+
+	t.Run("ReadWriteMatrix", func(t *testing.T) { testCrossProtocolReadWrite(t, factory) })
+	t.Run("DenyACE", func(t *testing.T) { testCrossProtocolDenyACE(t, factory) })
+	t.Run("SIDOnlyGrant", func(t *testing.T) { testCrossProtocolSIDOnlyGrant(t, factory) })
+	t.Run("SIDOnlyDeny", func(t *testing.T) { testCrossProtocolSIDOnlyDeny(t, factory) })
+}
+
+// canonOp is a backend-neutral operation the matrix probes through every
+// protocol lane.
+type canonOp int
+
+const (
+	opRead canonOp = iota
+	opWrite
+)
+
+func (o canonOp) String() string {
+	if o == opRead {
+		return "READ"
+	}
+	return "WRITE"
+}
+
+// protocolLane evaluates a canonical operation against a file through the
+// translation + checker path a specific protocol adapter uses. It returns
+// whether the operation is allowed. err is reserved for checker failures the
+// caller treats as fatal (not allow/deny).
+type protocolLane struct {
+	name string
+	eval func(t *testing.T, svc *metadata.Service, handle metadata.FileHandle, file *metadata.File, authCtx *metadata.AuthContext, op canonOp) bool
+}
+
+// nfsLane drives the canonical op through MetadataService.CheckPermissions,
+// exactly as the NFSv3 ACCESS handler (internal/adapter/nfs/v3/handlers) and
+// the now-fixed NFSv4 ACCESS handler (internal/adapter/nfs/v4/handlers) do.
+// NFSv3, NFSv4.0, and NFSv4.1 all funnel through the identical metadata entry
+// point with the same ACCESS-bit -> Permission mapping (the bit values are
+// numerically identical across RFC 1813 §3.3.4 and RFC 7530 §6), so one lane
+// faithfully models all three NFS versions.
+func nfsLane(name string) protocolLane {
+	return protocolLane{
+		name: name,
+		eval: func(t *testing.T, svc *metadata.Service, handle metadata.FileHandle, file *metadata.File, authCtx *metadata.AuthContext, op canonOp) bool {
+			t.Helper()
+			var req metadata.Permission
+			switch op {
+			case opRead:
+				if file.Type == metadata.FileTypeDirectory {
+					req = metadata.PermissionListDirectory
+				} else {
+					req = metadata.PermissionRead
+				}
+			case opWrite:
+				req = metadata.PermissionWrite
+			}
+			granted, err := svc.CheckPermissions(authCtx, handle, req)
+			if err != nil {
+				t.Fatalf("%s: CheckPermissions(%s) error: %v", name, op, err)
+			}
+			return granted&req == req
+		},
+	}
+}
+
+// smbLane models the EFFECTIVE SMB read/write decision, which the protocol
+// reaches through two gates that must BOTH pass for an operation to succeed:
+//
+//  1. The CREATE open-time gate — MetadataService.CheckFileAccess: DesiredAccess
+//     vs the file's DACL (MS-SMB2 §3.3.5.9). For a file with NO DACL this gate
+//     is intentionally permissive (MS-DTYP §2.5.3: a NULL DACL grants every
+//     right), deferring enforcement to the operation layer.
+//  2. The operation-level POSIX/ACL check — the same checkFilePermissions /
+//     calculatePermissions core every metadata READ/WRITE runs (io.go), reached
+//     here via CheckPermissions. This is the IDENTICAL core the NFS lanes use.
+//
+// A real SMB client must pass both, so the lane ANDs them. The result is the
+// effective allow/deny a Windows client observes, which the suite then asserts
+// matches the NFS lanes — the cross-protocol unification guarantee.
+func smbLane() protocolLane {
+	return protocolLane{
+		name: "SMB",
+		eval: func(t *testing.T, svc *metadata.Service, handle metadata.FileHandle, file *metadata.File, authCtx *metadata.AuthContext, op canonOp) bool {
+			t.Helper()
+			var mask uint32
+			var perm metadata.Permission
+			switch op {
+			case opRead:
+				mask = acl.ACE4_READ_DATA
+				perm = metadata.PermissionRead
+			case opWrite:
+				mask = acl.ACE4_WRITE_DATA | acl.ACE4_APPEND_DATA
+				perm = metadata.PermissionWrite
+			}
+
+			// Gate 1: open-time DACL check.
+			granted, err := svc.CheckFileAccess(file, authCtx, mask)
+			if err != nil {
+				var storeErr *metadata.StoreError
+				if errors.As(err, &storeErr) && storeErr.Code == metadata.ErrAccessDenied {
+					return false
+				}
+				t.Fatalf("SMB: CheckFileAccess(%s) unexpected error: %v", op, err)
+			}
+			if granted&mask != mask {
+				return false
+			}
+
+			// Gate 2: operation-level POSIX/ACL check (same core as NFS + the
+			// metadata READ/WRITE ops).
+			opGranted, err := svc.CheckPermissions(authCtx, handle, perm)
+			if err != nil {
+				t.Fatalf("SMB: CheckPermissions(%s) unexpected error: %v", op, err)
+			}
+			return opGranted&perm == perm
+		},
+	}
+}
+
+// allLanes is the full protocol matrix every case is evaluated against.
+func allLanes() []protocolLane {
+	return []protocolLane{
+		nfsLane("NFSv3"),
+		nfsLane("NFSv4.0"),
+		nfsLane("NFSv4.1"),
+		smbLane(),
+	}
+}
+
+// crossProtocolFixture wraps a freshly-built store in a metadata.Service and
+// exposes the share root so cases can create files.
+type crossProtocolFixture struct {
+	svc        *metadata.Service
+	store      metadata.Store
+	shareName  string
+	rootHandle metadata.FileHandle
+}
+
+func newCrossProtocolFixture(t *testing.T, factory StoreFactory) *crossProtocolFixture {
+	t.Helper()
+
+	store := factory(t)
+	shareName := "/xproto"
+	ctx := context.Background()
+
+	if err := store.CreateShare(ctx, &metadata.Share{Name: shareName}); err != nil {
+		t.Fatalf("CreateShare(%q): %v", shareName, err)
+	}
+	rootFile, err := store.CreateRootDirectory(ctx, shareName, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory,
+		Mode: 0o777,
+		UID:  0,
+		GID:  0,
+	})
+	if err != nil {
+		t.Fatalf("CreateRootDirectory(%q): %v", shareName, err)
+	}
+	rootHandle, err := metadata.EncodeFileHandle(rootFile)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle(root): %v", err)
+	}
+
+	svc := metadata.New()
+	if err := svc.RegisterStoreForShare(shareName, store); err != nil {
+		t.Fatalf("RegisterStoreForShare(%q): %v", shareName, err)
+	}
+
+	return &crossProtocolFixture{
+		svc:        svc,
+		store:      store,
+		shareName:  shareName,
+		rootHandle: rootHandle,
+	}
+}
+
+// rootCtx returns a root (UID 0) auth context.
+func (f *crossProtocolFixture) rootCtx() *metadata.AuthContext {
+	return f.userCtx(0, 0, "")
+}
+
+// userCtx builds an auth context for the given UID/GID and optional SID.
+func (f *crossProtocolFixture) userCtx(uid, gid uint32, sid string) *metadata.AuthContext {
+	id := &metadata.Identity{
+		UID:  metadata.Uint32Ptr(uid),
+		GID:  metadata.Uint32Ptr(gid),
+		GIDs: []uint32{gid},
+	}
+	if sid != "" {
+		s := sid
+		id.SID = &s
+	}
+	return &metadata.AuthContext{
+		Context:    context.Background(),
+		AuthMethod: "test",
+		Identity:   id,
+		ClientAddr: "127.0.0.1",
+	}
+}
+
+// createFile creates a regular file as root with the given attributes and
+// returns the file + its handle.
+func (f *crossProtocolFixture) createFile(t *testing.T, name string, attr *metadata.FileAttr) (*metadata.File, metadata.FileHandle) {
+	t.Helper()
+	attr.Type = metadata.FileTypeRegular
+	file, _, err := f.svc.CreateFile(f.rootCtx(), f.rootHandle, name, attr)
+	if err != nil {
+		t.Fatalf("CreateFile(%q): %v", name, err)
+	}
+	handle, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle(%q): %v", name, err)
+	}
+	// Re-read through the service so the file carries whatever the backend
+	// actually persisted (postgres/badger round-trip the ACL).
+	stored, err := f.svc.GetFile(context.Background(), handle)
+	if err != nil {
+		t.Fatalf("GetFile(%q): %v", name, err)
+	}
+	return stored, handle
+}
+
+// assertLanesAgree evaluates op on every protocol lane and asserts they all
+// match each other and the expected decision. This is the core cross-protocol
+// invariant.
+func assertLanesAgree(t *testing.T, f *crossProtocolFixture, handle metadata.FileHandle, file *metadata.File, authCtx *metadata.AuthContext, op canonOp, want bool) {
+	t.Helper()
+	for _, lane := range allLanes() {
+		got := lane.eval(t, f.svc, handle, file, authCtx, op)
+		if got != want {
+			t.Errorf("lane %s op %s: got allowed=%v, want %v (other lanes must agree — cross-protocol drift)", lane.name, op, got, want)
+		}
+	}
+}
+
+// testCrossProtocolReadWrite checks POSIX-mode and allow-ACL files: every
+// protocol must reach the same read/write decision for owner, group, other,
+// and a DACL granting EVERYONE@ read-only.
+func testCrossProtocolReadWrite(t *testing.T, factory StoreFactory) {
+	f := newCrossProtocolFixture(t, factory)
+
+	ownerUID, ownerGID := uint32(1000), uint32(2000)
+
+	// Case 1: mode 0o640 — owner rw, group r, other none, no ACL.
+	mode640, mode640H := f.createFile(t, "mode640.txt", &metadata.FileAttr{Mode: 0o640, UID: ownerUID, GID: ownerGID})
+
+	// Owner: read allowed, write allowed.
+	owner := f.userCtx(ownerUID, ownerGID, "")
+	assertLanesAgree(t, f, mode640H, mode640, owner, opRead, true)
+	assertLanesAgree(t, f, mode640H, mode640, owner, opWrite, true)
+
+	// Group member (different UID, same GID): read allowed, write denied.
+	groupMember := f.userCtx(3000, ownerGID, "")
+	assertLanesAgree(t, f, mode640H, mode640, groupMember, opRead, true)
+	assertLanesAgree(t, f, mode640H, mode640, groupMember, opWrite, false)
+
+	// Other (no UID/GID overlap): read denied, write denied.
+	stranger := f.userCtx(4000, 5000, "")
+	assertLanesAgree(t, f, mode640H, mode640, stranger, opRead, false)
+	assertLanesAgree(t, f, mode640H, mode640, stranger, opWrite, false)
+
+	// Case 2: allow-only DACL granting EVERYONE@ read but not write.
+	everyoneRead := &acl.ACL{
+		ACEs: []acl.ACE{
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, Who: acl.SpecialEveryone, AccessMask: acl.ACE4_READ_DATA},
+		},
+	}
+	aclFile, aclH := f.createFile(t, "everyone_read.txt", &metadata.FileAttr{Mode: 0o600, UID: ownerUID, GID: ownerGID, ACL: everyoneRead})
+
+	// Any user can read; nobody (non-root) can write — the DACL grants only read.
+	assertLanesAgree(t, f, aclH, aclFile, stranger, opRead, true)
+	assertLanesAgree(t, f, aclH, aclFile, stranger, opWrite, false)
+}
+
+// testCrossProtocolDenyACE is the headline negative control: a DENY ACE on the
+// owner must override the POSIX owner-everything fallback identically on every
+// protocol. NFSv4's old Unix-mode-only path would have granted write here while
+// SMB denied it — exactly the bug AD-0 closes.
+func testCrossProtocolDenyACE(t *testing.T, factory StoreFactory) {
+	f := newCrossProtocolFixture(t, factory)
+
+	ownerUID, ownerGID := uint32(1001), uint32(2001)
+	ownerSID := "S-1-5-21-1-2-3-1001"
+
+	// DENY write to the owner's SID, then ALLOW EVERYONE@ everything. The
+	// DENY must win for the owner (DENY precedes ALLOW in evaluation).
+	denyWrite := &acl.ACL{
+		ACEs: []acl.ACE{
+			{Type: acl.ACE4_ACCESS_DENIED_ACE_TYPE, Who: "sid:" + ownerSID, AccessMask: acl.ACE4_WRITE_DATA | acl.ACE4_APPEND_DATA},
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, Who: acl.SpecialEveryone, AccessMask: 0xFFFFFFFF},
+		},
+	}
+	file, handle := f.createFile(t, "deny_owner_write.txt", &metadata.FileAttr{
+		Mode: 0o777, UID: ownerUID, GID: ownerGID, ACL: denyWrite,
+	})
+
+	owner := f.userCtx(ownerUID, ownerGID, ownerSID)
+
+	// Read is allowed (EVERYONE@ grants it); WRITE must be denied on EVERY
+	// protocol because the DENY ACE targets the owner's SID. If NFS lanes
+	// disagree with SMB here, the cross-protocol bug has regressed.
+	assertLanesAgree(t, f, handle, file, owner, opRead, true)
+	assertLanesAgree(t, f, handle, file, owner, opWrite, false)
+
+	// A different user (not matched by the DENY) gets full access via the
+	// EVERYONE@ ALLOW — identical on every protocol.
+	other := f.userCtx(9999, 9999, "S-1-5-21-1-2-3-9999")
+	assertLanesAgree(t, f, handle, file, other, opRead, true)
+	assertLanesAgree(t, f, handle, file, other, opWrite, true)
+}
+
+// testCrossProtocolSIDOnlyGrant pins the second bug class: a grant addressed
+// ONLY by SID (no Unix UID/GID match, mode 0o000) must be honored identically
+// on NFS and SMB. NFSv4's old mode-only ACCESS path ignored SID grants entirely
+// and would have denied a user that SMB allows.
+func testCrossProtocolSIDOnlyGrant(t *testing.T, factory StoreFactory) {
+	f := newCrossProtocolFixture(t, factory)
+
+	granteeSID := "S-1-5-21-7-7-7-2500"
+
+	// mode 0o000 so POSIX bits grant nothing; the ONLY path to access is the
+	// SID-addressed ALLOW ACE.
+	sidGrant := &acl.ACL{
+		ACEs: []acl.ACE{
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, Who: "sid:" + granteeSID, AccessMask: acl.ACE4_READ_DATA | acl.ACE4_WRITE_DATA | acl.ACE4_APPEND_DATA},
+		},
+	}
+	file, handle := f.createFile(t, "sid_only_grant.txt", &metadata.FileAttr{
+		Mode: 0o000, UID: 6000, GID: 6000, ACL: sidGrant,
+	})
+
+	// The grantee is identified ONLY by SID; its UID/GID match nothing on the
+	// file. Read and write must be allowed on every protocol.
+	grantee := f.userCtx(8000, 8000, granteeSID)
+	assertLanesAgree(t, f, handle, file, grantee, opRead, true)
+	assertLanesAgree(t, f, handle, file, grantee, opWrite, true)
+
+	// A user with a different SID and no POSIX rights is denied everywhere.
+	outsider := f.userCtx(8001, 8001, "S-1-5-21-7-7-7-9000")
+	assertLanesAgree(t, f, handle, file, outsider, opRead, false)
+	assertLanesAgree(t, f, handle, file, outsider, opWrite, false)
+}
+
+// testCrossProtocolSIDOnlyDeny is the symmetric SID negative control: a DENY
+// ACE addressed only by SID must suppress access the POSIX mode would otherwise
+// grant — identically on NFS and SMB.
+func testCrossProtocolSIDOnlyDeny(t *testing.T, factory StoreFactory) {
+	f := newCrossProtocolFixture(t, factory)
+
+	deniedSID := "S-1-5-21-3-3-3-4242"
+
+	// mode 0o666 grants read+write to everyone via POSIX, but a SID-addressed
+	// DENY removes write for one specific principal.
+	sidDeny := &acl.ACL{
+		ACEs: []acl.ACE{
+			{Type: acl.ACE4_ACCESS_DENIED_ACE_TYPE, Who: "sid:" + deniedSID, AccessMask: acl.ACE4_WRITE_DATA | acl.ACE4_APPEND_DATA},
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, Who: acl.SpecialEveryone, AccessMask: acl.ACE4_READ_DATA | acl.ACE4_WRITE_DATA | acl.ACE4_APPEND_DATA},
+		},
+	}
+	file, handle := f.createFile(t, "sid_only_deny.txt", &metadata.FileAttr{
+		Mode: 0o666, UID: 7000, GID: 7000, ACL: sidDeny,
+	})
+
+	// The denied principal: read allowed (EVERYONE@), write denied (SID DENY) —
+	// on every protocol.
+	denied := f.userCtx(7500, 7500, deniedSID)
+	assertLanesAgree(t, f, handle, file, denied, opRead, true)
+	assertLanesAgree(t, f, handle, file, denied, opWrite, false)
+
+	// An unrelated principal keeps full EVERYONE@ access on every protocol.
+	other := f.userCtx(7600, 7600, "S-1-5-21-3-3-3-1111")
+	assertLanesAgree(t, f, handle, file, other, opRead, true)
+	assertLanesAgree(t, f, handle, file, other, opWrite, true)
+}

--- a/pkg/metadata/storetest/cross_protocol_permissions.go
+++ b/pkg/metadata/storetest/cross_protocol_permissions.go
@@ -32,6 +32,7 @@ func RunCrossProtocolPermissionMatrix(t *testing.T, factory StoreFactory) {
 	t.Run("DenyACE", func(t *testing.T) { testCrossProtocolDenyACE(t, factory) })
 	t.Run("SIDOnlyGrant", func(t *testing.T) { testCrossProtocolSIDOnlyGrant(t, factory) })
 	t.Run("SIDOnlyDeny", func(t *testing.T) { testCrossProtocolSIDOnlyDeny(t, factory) })
+	t.Run("ShareWritableBypass", func(t *testing.T) { testCrossProtocolShareWritableBypass(t, factory) })
 }
 
 // canonOp is a backend-neutral operation the matrix probes through every
@@ -207,6 +208,11 @@ func (f *crossProtocolFixture) rootCtx() *metadata.AuthContext {
 }
 
 // userCtx builds an auth context for the given UID/GID and optional SID.
+//
+// ShareWritable/ShareReadOnly are left at their zero value (false) so the main
+// matrix exercises the full ACL/POSIX evaluation path. The share-level write
+// bypass in checkFilePermissions (which a real SMB session enables by setting
+// ShareWritable=true) is covered separately by testCrossProtocolShareWritableBypass.
 func (f *crossProtocolFixture) userCtx(uid, gid uint32, sid string) *metadata.AuthContext {
 	id := &metadata.Identity{
 		UID:  metadata.Uint32Ptr(uid),
@@ -398,4 +404,52 @@ func testCrossProtocolSIDOnlyDeny(t *testing.T, factory StoreFactory) {
 	other := f.userCtx(7600, 7600, "S-1-5-21-3-3-3-1111")
 	assertLanesAgree(t, f, handle, file, other, opRead, true)
 	assertLanesAgree(t, f, handle, file, other, opWrite, true)
+}
+
+// testCrossProtocolShareWritableBypass exercises the share-level write bypass in
+// checkFilePermissions (auth_permissions.go) — the path a real SMB session turns
+// on by setting AuthContext.ShareWritable=true, and which the rest of the matrix
+// leaves off.
+//
+// The security-critical invariant this pins: with ShareWritable=true and an
+// explicit DENY ACE, the bypass MUST NOT override the DENY (it is gated on
+// !acl.HasExplicitDeny). Write stays denied on every protocol. A share-writable
+// mount must never let a user past an explicit DENY — and it must do so
+// identically on NFS and SMB.
+//
+// KNOWN, OUT-OF-SCOPE DIVERGENCE (not asserted here, deliberately): with an
+// allow-ONLY DACL (no explicit DENY) on a mode 0o000 file and ShareWritable=true,
+// the two protocols disagree. NFS CheckPermissions takes the ShareWritable bypass
+// (skips the ACL) and grants write; SMB's open-time DACL gate (CheckFileAccess)
+// ignores ShareWritable and denies write because the DACL grants only read. This
+// is a pre-existing semantic gap in the ShareWritable shortcut, broader than
+// AD-0's NFSv4-ACCESS consolidation, so it is documented rather than fixed or
+// asserted here. Closing it (deciding whether share-writable should override a
+// positive-grant-only ACL, and on which protocol) is a candidate follow-up.
+func testCrossProtocolShareWritableBypass(t *testing.T, factory StoreFactory) {
+	f := newCrossProtocolFixture(t, factory)
+
+	// writableCtx is a user whose session granted share-level write, as the SMB
+	// session layer sets for a read-write tree connect.
+	writableCtx := func(uid, gid uint32, sid string) *metadata.AuthContext {
+		ctx := f.userCtx(uid, gid, sid)
+		ctx.ShareWritable = true
+		return ctx
+	}
+
+	// Explicit DENY-write ACE + ShareWritable=true → write still denied on every
+	// protocol. The bypass must not override an explicit DENY.
+	denySID := "S-1-5-21-9-9-9-6000"
+	denyWrite := &acl.ACL{
+		ACEs: []acl.ACE{
+			{Type: acl.ACE4_ACCESS_DENIED_ACE_TYPE, Who: "sid:" + denySID, AccessMask: acl.ACE4_WRITE_DATA | acl.ACE4_APPEND_DATA},
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, Who: acl.SpecialEveryone, AccessMask: acl.ACE4_READ_DATA},
+		},
+	}
+	denyFile, denyH := f.createFile(t, "sharewritable_deny.txt", &metadata.FileAttr{
+		Mode: 0o666, UID: 6000, GID: 6000, ACL: denyWrite,
+	})
+	denied := writableCtx(6500, 6500, denySID)
+	assertLanesAgree(t, f, denyH, denyFile, denied, opRead, true)
+	assertLanesAgree(t, f, denyH, denyFile, denied, opWrite, false)
 }

--- a/pkg/metadata/storetest/suite.go
+++ b/pkg/metadata/storetest/suite.go
@@ -55,6 +55,15 @@ func RunConformanceSuite(t *testing.T, factory StoreFactory) {
 		runPermissionsTests(t, factory)
 	})
 
+	// CrossProtocolPermissions (AD-0) asserts every protocol family — NFSv3,
+	// NFSv4.0, NFSv4.1, SMB — reaches the SAME allow/deny decision for the
+	// SAME file + ACL on THIS backend. It is the cross-protocol regression net
+	// for the AD/LDAP work: DENY ACEs and SID-only grants must enforce
+	// identically across protocols (the bug class the NFSv4 ACCESS fix closes).
+	t.Run("CrossProtocolPermissions", func(t *testing.T) {
+		RunCrossProtocolPermissionMatrix(t, factory)
+	})
+
 	t.Run("DurableHandles", func(t *testing.T) {
 		RunDurableHandleStoreTests(t, factory)
 	})


### PR DESCRIPTION
Part of #1231 (AD/LDAP umbrella). **Wave 1. PREREQUISITE — must merge before AD-4.**

Cross-protocol permission correctness *before* any AD work: consolidate permission decisions behind one protocol-agnostic checker and fix the NFSv4 bypass. No LDAP/Kerberos/AD code — this is the correctness prerequisite only.

## Changes

1. **Fix NFSv4 ACCESS bypass.** `internal/adapter/nfs/v4/handlers/access.go` reimplemented a Unix-mode-only `checkAccessBits()` that ignored ACLs, DENY ACEs, and SID-based grants, so the same file produced a different allow/deny answer on NFSv4 than on NFSv3/SMB (both of which route through the core). Deleted `checkAccessBits()`/`isInGroup()` and route `accessRealFS` through `MetadataService.CheckPermissions`, mirroring the NFSv3 ACCESS handler. The handler now only translates ACCESS4 bits ↔ canonical `metadata.Permission`.

2. **One `FileAccessChecker` entry point.** New `metadata.FileAccessChecker` interface (`pkg/metadata/file_access_checker.go`), satisfied by `*Service`, names the consolidated permission contract: `CheckPermissions` (NFS generic flags), `CheckFileAccess`/`CheckFileAccessWithParent` (SMB MS-DTYP masks), and a new `CheckAttrReadAccess` (attr-based read probe for SMB access-based enumeration). All resolve to the same `acl.Evaluate`/`EvaluateGranted` core over one `EvaluateContext`. Existing callers unchanged — behavior identical.

3. **Route SMB ABE through the checker.** `query_directory.go`'s access-based-enumeration path called `acl.Evaluate` directly, violating the "handlers do protocol only" invariant. It now delegates to `CheckAttrReadAccess`; the inlined ACL/POSIX/anonymous-owner logic moved into the metadata core. Root enumeration fast-path stays in the handler as an optimization (not a permission decision).

4. **Per-op SMB gates documented, not rerouted.** READ/WRITE/DELETE/SET_INFO/IOCTL gate on the `OpenFile.GrantedAccess` mask frozen at CREATE (which itself goes through `CheckFileAccess`). This is the MS-SMB2/MS-FSA handle model — an open's rights do not change if the DACL changes after the handle is granted — so re-evaluating per-op would be a protocol bug, not a fix. Documented at the `GrantedAccess` field (`handler.go`).

5. **Cross-protocol conformance matrix** (`pkg/metadata/storetest/cross_protocol_permissions.go`), wired into `RunConformanceSuite` so it runs on **memory/badger/postgres**. Asserts NFSv3 / NFSv4.0 / NFSv4.1 / SMB reach the **same** allow/deny for the **same** file + ACL on the **same** backend. Each protocol lane drives the central checker entry point its production adapter uses. Cases: POSIX owner/group/other, allow-only DACLs, and the two bug classes AD-0 closes — **DENY ACEs** and **SID-only grants/denies** — with negative controls. This is the regression net for AD-1..AD-4.

## Why

AD identities are worthless if NFS and SMB enforce the same file's ACL differently. The NFSv4 ACCESS bypass was a concrete cross-protocol drift (mode-only, ignored ACLs/DENY/SID). This PR removes the bypass and pins cross-protocol equivalence with a conformance matrix.

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt -l .` — all clean.
- `go test -race ./pkg/metadata/... ./internal/adapter/nfs/... ./internal/adapter/smb/...` — green (43 packages).
- New matrix green on memory + badger locally. **Postgres matrix runs in CI** (`DITTOFS_TEST_POSTGRES_DSN` not available locally; postgres conformance skips without it — the matrix is wired through the same `RunConformanceSuite` factory the other backends use).
- Updated `TestAccess_RealFS_RootGetsAll` to expect spec-correct behavior (ACCESS4_LOOKUP is a directory-only right, correctly not granted on a regular file — matching NFSv3's identical translation).
- Existing SMB ABE + smbtorture-covered handler tests stay green.

Closes #1232