### PR TITLE
test(ad-dc): AD-1 PAC group-SID integration test + fixture + CI (#1233)

### DIFF
--- a/.github/workflows/ad-dc.yml
+++ b/.github/workflows/ad-dc.yml
@@ -1,0 +1,56 @@
+# AD-DC PAC Integration Test (AD-1, #1233)
+#
+# Validates that an Active Directory ticket's Kerberos PAC group SIDs flow
+# through the shared KerberosService into the AuthResult — the property AD-1
+# delivers (DecodePAC + group-SID threading). Uses a real Samba AD-DC in
+# Docker (test/integration/ad-dc), which issues PAC-bearing tickets that a
+# plain MIT KDC cannot.
+#
+# Tiered by EVENT, matching the smbtorture-kerberos job:
+#   postsubmit (push develop) + nightly cron + manual dispatch only.
+# OFF presubmit: building + provisioning a fresh Samba AD domain is expensive
+# (minutes) and AD is rarely the regressing surface on an ordinary PR.
+
+name: AD-DC PAC Test
+
+on:
+  push:
+    branches: [develop]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '**.png'
+      - '**.jpg'
+      - '**.svg'
+  schedule:
+    - cron: '0 4 * * *'  # Nightly 4 AM UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ad-dc-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ad-dc:
+    name: AD PAC group SIDs
+    runs-on: ubuntu-latest
+    # The samba-ad-dc image build + domain provision dominates the wall clock.
+    timeout-minutes: 40
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.x"
+          cache: true
+
+      - name: Run AD-DC PAC integration test
+        run: |
+          cd test/integration/ad-dc
+          chmod +x run.sh
+          ./run.sh -v

--- a/internal/adapter/smb/handlers/auth_helper.go
+++ b/internal/adapter/smb/handlers/auth_helper.go
@@ -247,7 +247,9 @@ func (h *Handler) primeAuthContext(ctx *SMBHandlerContext, treeID uint32, sessio
 		// so BuildAuthContextFromUser can merge them into the identity. Follow-up
 		// ops (CREATE/READ/WRITE/QUERY_DIRECTORY) arrive keyed only by FileID and
 		// would otherwise lose the AD group set that was resolved at SESSION_SETUP.
-		ctx.PACGroupSIDs = sess.PACGroupSIDs
+		// PACIdentity copies under the session lock — safe against a concurrent
+		// re-auth refreshing the set.
+		ctx.PACGroupSIDs, _ = sess.PACIdentity()
 	}
 }
 

--- a/internal/adapter/smb/handlers/auth_helper.go
+++ b/internal/adapter/smb/handlers/auth_helper.go
@@ -161,7 +161,16 @@ func BuildAuthContextFromUser(ctx *SMBHandlerContext, user *models.User) *metada
 			userSID := user.SID
 			authCtx.Identity.SID = &userSID
 		}
-		authCtx.Identity.GroupSIDs = mergeImplicitAuthSIDs(user.GroupSIDs)
+		// Merge the user's persisted named group SIDs with any Kerberos PAC
+		// group SIDs carried on this request's session. For an AD-issued ticket
+		// the PAC delivers the DC-resolved transitive group set, so a DACL ACE
+		// keyed on an AD group matches even when the local user model never
+		// enumerated it. mergeImplicitAuthSIDs dedups (first occurrence wins).
+		groupSIDs := user.GroupSIDs
+		if len(ctx.PACGroupSIDs) > 0 {
+			groupSIDs = append(append([]string(nil), user.GroupSIDs...), ctx.PACGroupSIDs...)
+		}
+		authCtx.Identity.GroupSIDs = mergeImplicitAuthSIDs(groupSIDs)
 	}
 
 	// Set share-level permission flags
@@ -235,6 +244,11 @@ func (h *Handler) primeAuthContext(ctx *SMBHandlerContext, treeID uint32, sessio
 		if sess.User != nil {
 			ctx.User = sess.User
 		}
+		// Carry the session's Kerberos PAC group SIDs onto the request context
+		// so BuildAuthContextFromUser can merge them into the identity. Follow-up
+		// ops (CREATE/READ/WRITE/QUERY_DIRECTORY) arrive keyed only by FileID and
+		// would otherwise lose the AD group set that was resolved at SESSION_SETUP.
+		ctx.PACGroupSIDs = sess.PACGroupSIDs
 	}
 }
 

--- a/internal/adapter/smb/handlers/auth_helper.go
+++ b/internal/adapter/smb/handlers/auth_helper.go
@@ -165,12 +165,11 @@ func BuildAuthContextFromUser(ctx *SMBHandlerContext, user *models.User) *metada
 		// group SIDs carried on this request's session. For an AD-issued ticket
 		// the PAC delivers the DC-resolved transitive group set, so a DACL ACE
 		// keyed on an AD group matches even when the local user model never
-		// enumerated it. mergeImplicitAuthSIDs dedups (first occurrence wins).
-		groupSIDs := user.GroupSIDs
-		if len(ctx.PACGroupSIDs) > 0 {
-			groupSIDs = append(append([]string(nil), user.GroupSIDs...), ctx.PACGroupSIDs...)
-		}
-		authCtx.Identity.GroupSIDs = mergeImplicitAuthSIDs(groupSIDs)
+		// enumerated it. slices.Concat allocates a fresh slice (no aliasing of
+		// user.GroupSIDs); mergeImplicitAuthSIDs then dedups (first occurrence wins).
+		authCtx.Identity.GroupSIDs = mergeImplicitAuthSIDs(
+			slices.Concat(user.GroupSIDs, ctx.PACGroupSIDs),
+		)
 	}
 
 	// Set share-level permission flags

--- a/internal/adapter/smb/handlers/context.go
+++ b/internal/adapter/smb/handlers/context.go
@@ -149,6 +149,13 @@ type SMBHandlerContext struct {
 	// This is set from the session during request handling.
 	User *models.User
 
+	// PACGroupSIDs carries the Kerberos PAC group SIDs of the request's
+	// session (when it authenticated via Kerberos against AD). Populated from
+	// Session.PACGroupSIDs by primeAuthContext and the Kerberos SESSION_SETUP
+	// path, then merged into AuthContext.Identity.GroupSIDs by
+	// BuildAuthContextFromUser. Empty for NTLM/guest/anonymous requests.
+	PACGroupSIDs []string
+
 	// Permission is the user's permission level for the current share
 	// This is resolved during TREE_CONNECT and used for access control.
 	Permission models.SharePermission

--- a/internal/adapter/smb/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/handlers/kerberos_auth.go
@@ -143,8 +143,7 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 	// the DC and delivered in the ticket) onto the session so every subsequent
 	// request on it can merge them into AuthContext.Identity.GroupSIDs. Also set
 	// them on this SESSION_SETUP request's context for any immediate use.
-	sess.PACGroupSIDs = authResult.GroupSIDs
-	sess.PACUserSID = authResult.UserSID
+	sess.SetPACIdentity(authResult.GroupSIDs, authResult.UserSID)
 	ctx.PACGroupSIDs = authResult.GroupSIDs
 	ctx.SessionID = sessionID
 	ctx.IsGuest = false
@@ -216,8 +215,7 @@ func (h *Handler) reauthKerberosSession(
 	sess.ExpiresAt = ticketEndTime
 	// Refresh the PAC group/user SIDs from the new ticket — group membership may
 	// have changed between the original logon and this re-authentication.
-	sess.PACGroupSIDs = authResult.GroupSIDs
-	sess.PACUserSID = authResult.UserSID
+	sess.SetPACIdentity(authResult.GroupSIDs, authResult.UserSID)
 	ctx.PACGroupSIDs = authResult.GroupSIDs
 	ctx.IsGuest = false
 

--- a/internal/adapter/smb/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/handlers/kerberos_auth.go
@@ -139,6 +139,13 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 	)
 	sess.OriginConnID = ctx.ConnID
 	recordSessionBindIdentity(sess, ctx)
+	// Capture the Kerberos PAC group/user SIDs (AD nested-group set, resolved by
+	// the DC and delivered in the ticket) onto the session so every subsequent
+	// request on it can merge them into AuthContext.Identity.GroupSIDs. Also set
+	// them on this SESSION_SETUP request's context for any immediate use.
+	sess.PACGroupSIDs = authResult.GroupSIDs
+	sess.PACUserSID = authResult.UserSID
+	ctx.PACGroupSIDs = authResult.GroupSIDs
 	ctx.SessionID = sessionID
 	ctx.IsGuest = false
 
@@ -207,6 +214,11 @@ func (h *Handler) reauthKerberosSession(
 	sess.IsGuest = false
 	sess.IsNull = false
 	sess.ExpiresAt = ticketEndTime
+	// Refresh the PAC group/user SIDs from the new ticket — group membership may
+	// have changed between the original logon and this re-authentication.
+	sess.PACGroupSIDs = authResult.GroupSIDs
+	sess.PACUserSID = authResult.UserSID
+	ctx.PACGroupSIDs = authResult.GroupSIDs
 	ctx.IsGuest = false
 
 	logger.Info("Kerberos session re-authenticated (identity updated, keys retained)",

--- a/internal/adapter/smb/handlers/session_setup.go
+++ b/internal/adapter/smb/handlers/session_setup.go
@@ -1746,8 +1746,7 @@ func (h *Handler) tryReauthUpdate(pending *PendingAuth, username, domain string,
 	// (PAC group SIDs, possibly privileged) and then reauthenticated via NTLM as
 	// a lower-privileged or anonymous user would retain the original AD group
 	// SIDs, granting access on SID-keyed ACLs it should no longer have.
-	existingSess.PACGroupSIDs = nil
-	existingSess.PACUserSID = ""
+	existingSess.SetPACIdentity(nil, "")
 
 	logger.Info("Session re-authenticated (identity updated, keys retained)",
 		"sessionID", existingSess.SessionID,

--- a/internal/adapter/smb/handlers/session_setup.go
+++ b/internal/adapter/smb/handlers/session_setup.go
@@ -1739,6 +1739,16 @@ func (h *Handler) tryReauthUpdate(pending *PendingAuth, username, domain string,
 	existingSess.IsGuest = isGuest
 	existingSess.IsNull = username == "" && !isGuest
 
+	// Clear any Kerberos PAC identity carried from a prior auth on this session.
+	// tryReauthUpdate handles the NTLM reauth path, which carries no in-band PAC;
+	// the Kerberos reauth path (reauthKerberosSession) sets these from the new
+	// ticket. Without this, a session that first authenticated via Kerberos
+	// (PAC group SIDs, possibly privileged) and then reauthenticated via NTLM as
+	// a lower-privileged or anonymous user would retain the original AD group
+	// SIDs, granting access on SID-keyed ACLs it should no longer have.
+	existingSess.PACGroupSIDs = nil
+	existingSess.PACUserSID = ""
+
 	logger.Info("Session re-authenticated (identity updated, keys retained)",
 		"sessionID", existingSess.SessionID,
 		"username", existingSess.Username,

--- a/internal/adapter/smb/handlers/session_setup_reauth_test.go
+++ b/internal/adapter/smb/handlers/session_setup_reauth_test.go
@@ -414,3 +414,46 @@ func TestSessionSetup_UserWithoutNTHash_Rejected(t *testing.T) {
 			sess.Username, sess.User)
 	}
 }
+
+// TestTryReauthUpdate_ClearsKerberosPACIdentity is the regression net for the
+// privilege-escalation class where a session first authenticates via Kerberos
+// (its PAC carries AD group SIDs, possibly privileged) and is then re-
+// authenticated via NTLM as a lower-privileged or anonymous user. The NTLM
+// reauth carries no in-band PAC, so the session's AD credential set MUST revert
+// to empty — otherwise the new identity would inherit the prior principal's PAC
+// group SIDs and gain access on SID-keyed ACLs it should no longer have.
+func TestTryReauthUpdate_ClearsKerberosPACIdentity(t *testing.T) {
+	h := NewHandler()
+
+	const sessionID = uint64(0xc0ffee)
+	kerbUser := &models.User{Username: "alice", Enabled: true}
+	sess := h.CreateSessionWithUser(sessionID, "127.0.0.1:1", kerbUser, "DITTOFS")
+
+	// Simulate the prior Kerberos auth having stamped PAC identity on the session.
+	sess.PACGroupSIDs = []string{
+		"S-1-5-21-1111111111-2222222222-3333333333-512", // Domain Admins
+		"S-1-5-21-1111111111-2222222222-3333333333-513", // Domain Users
+	}
+	sess.PACUserSID = "S-1-5-21-1111111111-2222222222-3333333333-1001"
+
+	// Drive an NTLM reauth onto the same session as a different, lower-priv user.
+	ntlmUser := &models.User{Username: "bob", Enabled: true}
+	pending := &PendingAuth{SessionID: sessionID, IsReauth: true}
+	if res := h.tryReauthUpdate(pending, "bob", "DITTOFS", ntlmUser, false); res == nil {
+		t.Fatal("tryReauthUpdate returned nil for an existing session")
+	}
+
+	got, ok := h.GetSession(sessionID)
+	if !ok {
+		t.Fatal("session disappeared after reauth update")
+	}
+	if got.Username != "bob" {
+		t.Errorf("Username = %q, want bob", got.Username)
+	}
+	if len(got.PACGroupSIDs) != 0 {
+		t.Errorf("PACGroupSIDs not cleared after NTLM reauth: %v — stale AD groups leak privilege", got.PACGroupSIDs)
+	}
+	if got.PACUserSID != "" {
+		t.Errorf("PACUserSID not cleared after NTLM reauth: %q", got.PACUserSID)
+	}
+}

--- a/internal/adapter/smb/handlers/session_setup_reauth_test.go
+++ b/internal/adapter/smb/handlers/session_setup_reauth_test.go
@@ -430,11 +430,10 @@ func TestTryReauthUpdate_ClearsKerberosPACIdentity(t *testing.T) {
 	sess := h.CreateSessionWithUser(sessionID, "127.0.0.1:1", kerbUser, "DITTOFS")
 
 	// Simulate the prior Kerberos auth having stamped PAC identity on the session.
-	sess.PACGroupSIDs = []string{
+	sess.SetPACIdentity([]string{
 		"S-1-5-21-1111111111-2222222222-3333333333-512", // Domain Admins
 		"S-1-5-21-1111111111-2222222222-3333333333-513", // Domain Users
-	}
-	sess.PACUserSID = "S-1-5-21-1111111111-2222222222-3333333333-1001"
+	}, "S-1-5-21-1111111111-2222222222-3333333333-1001")
 
 	// Drive an NTLM reauth onto the same session as a different, lower-priv user.
 	ntlmUser := &models.User{Username: "bob", Enabled: true}
@@ -450,10 +449,11 @@ func TestTryReauthUpdate_ClearsKerberosPACIdentity(t *testing.T) {
 	if got.Username != "bob" {
 		t.Errorf("Username = %q, want bob", got.Username)
 	}
-	if len(got.PACGroupSIDs) != 0 {
-		t.Errorf("PACGroupSIDs not cleared after NTLM reauth: %v — stale AD groups leak privilege", got.PACGroupSIDs)
+	gotGroupSIDs, gotUserSID := got.PACIdentity()
+	if len(gotGroupSIDs) != 0 {
+		t.Errorf("PACGroupSIDs not cleared after NTLM reauth: %v — stale AD groups leak privilege", gotGroupSIDs)
 	}
-	if got.PACUserSID != "" {
-		t.Errorf("PACUserSID not cleared after NTLM reauth: %q", got.PACUserSID)
+	if gotUserSID != "" {
+		t.Errorf("PACUserSID not cleared after NTLM reauth: %q", gotUserSID)
 	}
 }

--- a/internal/adapter/smb/session/session.go
+++ b/internal/adapter/smb/session/session.go
@@ -74,6 +74,20 @@ type Session struct {
 	// for permission checking and share access control.
 	User *models.User
 
+	// PACGroupSIDs are the Windows group SIDs delivered in the client's
+	// Kerberos PAC (MS-PAC). For an AD-issued ticket these are the DC-resolved
+	// transitive group memberships. They are captured once at SESSION_SETUP
+	// (Kerberos path) and merged into every per-request AuthContext.Identity
+	// .GroupSIDs so SID-based ACL ACEs keyed on AD groups match — without an
+	// LDAP group-walk. Empty for NTLM/guest/anonymous sessions and for tickets
+	// without a PAC. Read-only after session creation.
+	PACGroupSIDs []string
+
+	// PACUserSID is the client's Windows user SID from the Kerberos PAC, when
+	// present. Captured alongside PACGroupSIDs. Resolution to a local UID/GID
+	// is the durable idmap layer's concern (AD-3 / #1235).
+	PACUserSID string
+
 	// cryptoState holds per-session cryptographic state (signing keys, signer,
 	// encryption/decryption keys). Replaces the old Signing field.
 	// For 2.x: HMAC-SHA256 signer. For 3.x: CMAC/GMAC signer + KDF-derived keys.

--- a/internal/adapter/smb/session/session.go
+++ b/internal/adapter/smb/session/session.go
@@ -74,19 +74,22 @@ type Session struct {
 	// for permission checking and share access control.
 	User *models.User
 
-	// PACGroupSIDs are the Windows group SIDs delivered in the client's
-	// Kerberos PAC (MS-PAC). For an AD-issued ticket these are the DC-resolved
-	// transitive group memberships. They are captured once at SESSION_SETUP
-	// (Kerberos path) and merged into every per-request AuthContext.Identity
-	// .GroupSIDs so SID-based ACL ACEs keyed on AD groups match — without an
-	// LDAP group-walk. Empty for NTLM/guest/anonymous sessions and for tickets
-	// without a PAC. Read-only after session creation.
-	PACGroupSIDs []string
-
-	// PACUserSID is the client's Windows user SID from the Kerberos PAC, when
-	// present. Captured alongside PACGroupSIDs. Resolution to a local UID/GID
-	// is the durable idmap layer's concern (AD-3 / #1235).
-	PACUserSID string
+	// pacGroupSIDs / pacUserSID hold the Windows identity delivered in the
+	// client's Kerberos PAC (MS-PAC). For an AD-issued ticket the group SIDs are
+	// the DC-resolved transitive group memberships, merged into every per-request
+	// AuthContext.Identity.GroupSIDs so SID-based ACL ACEs keyed on AD groups
+	// match without an LDAP group-walk. Empty for NTLM/guest/anonymous sessions
+	// and tickets without a PAC. Resolution of these SIDs to a local UID/GID is
+	// the durable idmap layer's concern (AD-3 / #1235).
+	//
+	// Unlike the scalar identity fields above, these are written on SESSION_SETUP
+	// AND refreshed/cleared on re-authentication (Kerberos reauth refreshes,
+	// NTLM reauth clears) while request goroutines read them concurrently. A
+	// slice header is three words, so a torn read is memory-unsafe — not merely
+	// stale. They are therefore private and guarded by mu; access only via
+	// SetPACIdentity / PACIdentity, which copy in and out.
+	pacGroupSIDs []string
+	pacUserSID   string
 
 	// cryptoState holds per-session cryptographic state (signing keys, signer,
 	// encryption/decryption keys). Replaces the old Signing field.
@@ -182,7 +185,8 @@ type Session struct {
 	// Credit tracking
 	credits Credits
 
-	// mu protects credit mutation operations
+	// mu protects credit mutation operations and the mutable PAC identity
+	// (pacGroupSIDs/pacUserSID, via SetPACIdentity/PACIdentity).
 	mu sync.Mutex
 
 	// channels holds TCP connections explicitly bound to this session, keyed
@@ -198,6 +202,36 @@ type Session struct {
 	// insert" — is atomic under concurrent binds.
 	channelsMu sync.RWMutex
 	channels   map[uint64]*Channel
+}
+
+// SetPACIdentity stores the Kerberos PAC group SIDs and user SID for the
+// session, replacing any previous set. Called on SESSION_SETUP and on
+// re-authentication (Kerberos reauth refreshes, NTLM reauth clears with a nil
+// slice and empty string). The group SIDs are copied so the caller's slice is
+// never aliased and a concurrent PACIdentity reader can never observe a torn
+// header. Safe for concurrent use.
+func (s *Session) SetPACIdentity(groupSIDs []string, userSID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(groupSIDs) == 0 {
+		s.pacGroupSIDs = nil
+	} else {
+		s.pacGroupSIDs = append([]string(nil), groupSIDs...)
+	}
+	s.pacUserSID = userSID
+}
+
+// PACIdentity returns a copy of the session's Kerberos PAC group SIDs and the
+// user SID. The slice is copied so the caller cannot mutate session state and
+// never shares a backing array with a concurrent SetPACIdentity. Returns
+// (nil, "") for sessions without PAC identity. Safe for concurrent use.
+func (s *Session) PACIdentity() (groupSIDs []string, userSID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.pacGroupSIDs) > 0 {
+		groupSIDs = append([]string(nil), s.pacGroupSIDs...)
+	}
+	return groupSIDs, s.pacUserSID
 }
 
 // Credits tracks credit accounting for a session.

--- a/internal/auth/kerberos/service.go
+++ b/internal/auth/kerberos/service.go
@@ -221,7 +221,15 @@ func extractPACIdentity(creds *credentials.Credentials) (userSID string, groupSI
 	if ad.LogonDomainID != "" && ad.UserID != 0 {
 		userSID = fmt.Sprintf("%s-%d", ad.LogonDomainID, ad.UserID)
 	}
-	return userSID, ad.GroupMembershipSIDs
+	// Copy the slice: GetADCredentials returns ADCredentials by value, but the
+	// GroupMembershipSIDs header still aliases gokrb5's internal backing array.
+	// Returning it directly would let a future gokrb5 mutation corrupt the SIDs
+	// we persist on the session. Own our copy.
+	if len(ad.GroupMembershipSIDs) > 0 {
+		groupSIDs = make([]string, len(ad.GroupMembershipSIDs))
+		copy(groupSIDs, ad.GroupMembershipSIDs)
+	}
+	return userSID, groupSIDs
 }
 
 // BuildMutualAuth constructs a raw AP-REP token for mutual authentication.

--- a/internal/auth/kerberos/service.go
+++ b/internal/auth/kerberos/service.go
@@ -10,6 +10,7 @@ import (
 	// reject as malformed. See issue #335.
 	"github.com/jcmturner/gofork/encoding/asn1"
 	"github.com/jcmturner/gokrb5/v8/asn1tools"
+	"github.com/jcmturner/gokrb5/v8/credentials"
 	"github.com/jcmturner/gokrb5/v8/crypto"
 	"github.com/jcmturner/gokrb5/v8/messages"
 	"github.com/jcmturner/gokrb5/v8/service"
@@ -50,6 +51,24 @@ type AuthResult struct {
 
 	// APReq is the parsed AP-REQ message, preserved for AP-REP construction.
 	APReq messages.APReq
+
+	// UserSID is the client's Windows Security Identifier as carried in the
+	// Kerberos PAC (MS-PAC §2.5 KERB_VALIDATION_INFO): the logon domain SID
+	// joined with the user's RID. Empty when the ticket carries no PAC (e.g.
+	// an MIT KDC, or a Samba/AD ticket whose PAC could not be decoded).
+	UserSID string
+
+	// GroupSIDs are the Windows group Security Identifiers delivered in the
+	// Kerberos PAC. Active Directory resolves nested group membership at the
+	// DC and stamps the full transitive set into the ticket, so no LDAP
+	// group-walk is required at authentication time. Empty when the ticket
+	// carries no PAC. These flow into AuthContext.Identity.GroupSIDs for
+	// SID-based ACL evaluation.
+	//
+	// Resolution of these (possibly foreign) SIDs to local UID/GID is the
+	// concern of the durable idmap layer (AD-3 / #1235); AD-1 only makes the
+	// SIDs flow into the live identity.
+	GroupSIDs []string
 }
 
 // KerberosService provides shared Kerberos authentication used by both
@@ -107,16 +126,24 @@ func (s *KerberosService) Authenticate(apReqBytes []byte, servicePrincipal strin
 		return nil, fmt.Errorf("unmarshal AP-REQ: %w", err)
 	}
 
-	// Build gokrb5 service settings from provider
+	// Build gokrb5 service settings from provider.
+	//
+	// DecodePAC is enabled so AD-issued tickets surface their PAC
+	// (MS-PAC) authorization data — specifically the transitive group SIDs the
+	// DC stamped into the ticket. gokrb5 verifies the PAC server signature with
+	// the same keytab key used for the ticket, so a tampered PAC fails
+	// VerifyAPREQ. Tickets without a PAC (e.g. from a plain MIT KDC) verify
+	// exactly as before — creds simply carry no AD attributes.
 	settings := service.NewSettings(
 		s.provider.Keytab(),
 		service.MaxClockSkew(s.provider.MaxClockSkew()),
-		service.DecodePAC(false),
+		service.DecodePAC(true),
 		service.KeytabPrincipal(servicePrincipal),
 	)
 
-	// Verify the AP-REQ
-	ok, _, err := service.VerifyAPREQ(&apReq, settings)
+	// Verify the AP-REQ. On success creds carries the decoded PAC attributes
+	// (when DecodePAC is on and the ticket contained a PAC).
+	ok, creds, err := service.VerifyAPREQ(&apReq, settings)
 	if err != nil {
 		return nil, fmt.Errorf("verify AP-REQ: %w", err)
 	}
@@ -153,10 +180,16 @@ func (s *KerberosService) Authenticate(apReqBytes []byte, servicePrincipal strin
 	clientPrincipal := apReq.Ticket.DecryptedEncPart.CName.PrincipalNameString()
 	clientRealm := apReq.Ticket.DecryptedEncPart.CRealm
 
+	// Extract PAC authorization data (AD group SIDs + user SID) when the ticket
+	// carried a verified PAC. creds is nil for callers/tickets without a PAC.
+	userSID, groupSIDs := extractPACIdentity(creds)
+
 	logger.Debug("Kerberos authentication successful",
 		"principal", clientPrincipal,
 		"realm", clientRealm,
 		"has_subkey", HasSubkey(&apReq),
+		"pac_user_sid", userSID,
+		"pac_group_sid_count", len(groupSIDs),
 	)
 
 	return &AuthResult{
@@ -164,7 +197,31 @@ func (s *KerberosService) Authenticate(apReqBytes []byte, servicePrincipal strin
 		Realm:      clientRealm,
 		SessionKey: contextKey,
 		APReq:      apReq,
+		UserSID:    userSID,
+		GroupSIDs:  groupSIDs,
 	}, nil
+}
+
+// extractPACIdentity pulls the Windows user SID and group SIDs out of the
+// decoded Kerberos PAC. gokrb5 exposes the decoded KERB_VALIDATION_INFO via
+// credentials.ADCredentials (populated by VerifyAPREQ when DecodePAC is on and
+// the ticket contained a PAC). It returns empty values when creds is nil or
+// the ticket carried no AD attributes — i.e. a non-AD KDC — so the rest of the
+// pipeline behaves exactly as it did before PAC decoding was enabled.
+//
+// The user SID is reconstructed from the logon domain SID + the user's RID per
+// MS-PAC §2.5; the group SIDs come straight from
+// KERB_VALIDATION_INFO.GetGroupMembershipSIDs (domain groups, extra SIDs, and
+// resource groups), already formatted as full SID strings.
+func extractPACIdentity(creds *credentials.Credentials) (userSID string, groupSIDs []string) {
+	if creds == nil {
+		return "", nil
+	}
+	ad := creds.GetADCredentials()
+	if ad.LogonDomainID != "" && ad.UserID != 0 {
+		userSID = fmt.Sprintf("%s-%d", ad.LogonDomainID, ad.UserID)
+	}
+	return userSID, ad.GroupMembershipSIDs
 }
 
 // BuildMutualAuth constructs a raw AP-REP token for mutual authentication.

--- a/pkg/block/local/fs/compaction_test.go
+++ b/pkg/block/local/fs/compaction_test.go
@@ -29,6 +29,15 @@ func logFileSize(t *testing.T, bc *FSStore, payloadID string) int64 {
 // fence is frozen by monotonicity at the pre-compaction
 // high-water mark — only the in-memory budget continues to drop as
 // records are consumed.
+// compactionDrainTimeout bounds how long the steady-state compaction tests
+// wait for the rollup workers to drain the on-disk log. The work is fsync-heavy
+// (256 AppendWrites, each durably appended), and Windows CI runners fsync an
+// order of magnitude slower than Linux — a 10s budget intermittently expired
+// there while the log was still draining (logBytesTotal=~640 KiB, mid-drop).
+// The poll returns the instant the bound is met, so a generous ceiling costs
+// no wall-clock on success (≈1-2s on Linux) and only adds headroom on slow I/O.
+const compactionDrainTimeout = 60 * time.Second
+
 func waitForLogBytesBelow(t *testing.T, bc *FSStore, max int64, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
@@ -88,7 +97,7 @@ func TestCompaction_BoundedLogSize(t *testing.T) {
 	// is frozen at the pre-compaction high-water mark by
 	// monotonicity — only the in-memory fence and on-disk header
 	// continue to advance.
-	waitForLogBytesBelow(t, bc, 64*1024, 10*time.Second)
+	waitForLogBytesBelow(t, bc, 64*1024, compactionDrainTimeout)
 	// Give the compaction pass a moment to fire after the SetRollupOffset
 	// that advanced the fence past the threshold.
 	time.Sleep(300 * time.Millisecond)
@@ -131,7 +140,7 @@ func TestCompaction_DisabledByNegativeThreshold(t *testing.T) {
 		}
 	}
 	totalBytes := uint64(writes) * uint64(len(chunk))
-	waitForLogBytesBelow(t, bc, 64*1024, 10*time.Second)
+	waitForLogBytesBelow(t, bc, 64*1024, compactionDrainTimeout)
 	// Allow a final rollup tick to settle on disk.
 	time.Sleep(200 * time.Millisecond)
 
@@ -175,7 +184,7 @@ func TestCompaction_RecoveryRebuildsAfterCompact(t *testing.T) {
 		}
 	}
 	phase1Bytes := uint64(phase1Writes) * uint64(len(chunk))
-	waitForLogBytesBelow(t, bc, 32*1024, 10*time.Second)
+	waitForLogBytesBelow(t, bc, 32*1024, compactionDrainTimeout)
 
 	// close the store BEFORE measuring size. Close() joins rollup
 	// and compaction workers, guaranteeing no in-flight compaction can leave

--- a/test/integration/ad-dc/Dockerfile
+++ b/test/integration/ad-dc/Dockerfile
@@ -1,0 +1,42 @@
+# Samba Active Directory Domain Controller fixture.
+#
+# Unlike the MIT KDC in test/integration/kerberos (auth only, no PAC), a Samba
+# AD-DC issues Kerberos tickets carrying a Microsoft PAC (MS-PAC) with the
+# user's transitive group SIDs — exactly what AD-1 needs to validate PAC
+# decoding (DecodePAC) end to end against a real domain controller.
+#
+# The container provisions a fresh domain on first start via entrypoint.sh,
+# creates test users + groups (some with RFC2307 uidNumber/gidNumber, some
+# without, to exercise the AD-3 idmap fallback later), and exports a service
+# keytab. It runs linux/amd64 so it works on Apple Silicon under emulation,
+# mirroring the other docker harnesses.
+FROM debian:bookworm-slim
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Retry apt-get to handle transient network/mirror failures (exit code 100).
+# See: https://forums.docker.com/t/docker-build-returns-exit-code-100/119303
+#
+# samba-ad-dc pulls in the AD-DC role (provisioning + KDC + LDAP). winbind and
+# krb5-user give us kadmin-style tooling and samba-tool dependencies. ldb-tools
+# (ldbadd/ldbmodify) lets entrypoint.sh stamp RFC2307 attributes directly.
+RUN set -eu; \
+    for i in 1 2 3; do \
+        apt-get update \
+          && apt-get install -y --no-install-recommends \
+               samba samba-ad-dc samba-common-bin winbind \
+               krb5-user ldb-tools ldap-utils procps \
+          && rm -rf /var/lib/apt/lists/* \
+          && exit 0; \
+        echo "apt-get attempt $i failed, retrying in 5s..." >&2; \
+        sleep 5; \
+    done; \
+    echo "ERROR: failed to install samba packages after 3 attempts" >&2; \
+    exit 1
+
+COPY --chmod=0755 entrypoint.sh /entrypoint.sh
+
+# 88 = Kerberos KDC, 389 = LDAP, 464 = kpasswd. The test maps 88 to a random
+# host port for the Go Kerberos client to reach.
+EXPOSE 88/tcp 88/udp 389/tcp 464/tcp 464/udp
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/test/integration/ad-dc/ad_dc_integration_test.go
+++ b/test/integration/ad-dc/ad_dc_integration_test.go
@@ -67,7 +67,9 @@ func TestADGroupSIDsFromPAC(t *testing.T) {
 		t.Skip("docker not found, skipping AD-DC integration test")
 	}
 
-	kdcPort, keytabPath, krb5ConfPath, cleanup := setupADDC(t)
+	// krb5ConfPath already encodes the mapped KDC port, so the gokrb5 client
+	// reaches the DC without a separate port argument.
+	_, keytabPath, krb5ConfPath, cleanup := setupADDC(t)
 	defer cleanup()
 
 	// Build the shared KerberosService from a provider backed by the exported
@@ -92,7 +94,7 @@ func TestADGroupSIDsFromPAC(t *testing.T) {
 	// alice authenticates against the DC and obtains a service ticket for the
 	// SMB SPN, then we build the raw AP-REQ (Authenticate expects the raw
 	// AP-REQ, not a GSS-wrapped token).
-	apReqBytes := getADAPREQ(t, krb5ConfPath, kdcPort)
+	apReqBytes := getADAPREQ(t, krb5ConfPath)
 
 	result, err := service.Authenticate(apReqBytes, adSMBSPNFull)
 	if err != nil {
@@ -323,7 +325,7 @@ func dumpADLogs(t *testing.T) {
 // getADAPREQ logs in as alice against the AD-DC and returns the raw AP-REQ
 // bytes for the SMB SPN (NOT GSS-wrapped — KerberosService.Authenticate
 // expects the raw AP-REQ).
-func getADAPREQ(t *testing.T, krb5ConfPath string, _ int) []byte {
+func getADAPREQ(t *testing.T, krb5ConfPath string) []byte {
 	t.Helper()
 
 	cfg, err := krb5config.Load(krb5ConfPath)

--- a/test/integration/ad-dc/ad_dc_integration_test.go
+++ b/test/integration/ad-dc/ad_dc_integration_test.go
@@ -1,0 +1,384 @@
+//go:build ad_dc
+
+// Package ad_dc_test provides an integration test for AD-1 (#1233): decoding
+// the Kerberos PAC of an Active Directory ticket and surfacing the user's
+// transitive group SIDs through the shared KerberosService.AuthResult.
+//
+// Unlike test/integration/kerberos (an MIT KDC, auth only, no PAC), this test
+// stands up a real Samba Active Directory Domain Controller in Docker. The DC
+// issues service tickets carrying a Microsoft PAC (MS-PAC) whose
+// GroupMembershipSIDs include the user's full transitive group set — AD
+// resolves nested membership at the DC. The test logs in as alice (a member of
+// devs, which is nested under engineering), obtains a service ticket for the
+// SMB SPN, builds the AP-REQ, and asserts that KerberosService.Authenticate
+// returns a non-empty GroupSIDs containing BOTH the devs and engineering
+// domain group SIDs plus a populated UserSID.
+//
+// Run with: go test -tags=ad_dc -v -timeout 20m ./test/integration/ad-dc/
+// Requires: Docker (the samba-ad-dc image builds + provisions under linux/amd64
+// emulation on Apple Silicon, which is slow — hence the generous timeout).
+package ad_dc_test
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jcmturner/gokrb5/v8/client"
+	krb5config "github.com/jcmturner/gokrb5/v8/config"
+	"github.com/jcmturner/gokrb5/v8/messages"
+	"github.com/jcmturner/gokrb5/v8/types"
+
+	kerbauth "github.com/marmos91/dittofs/internal/auth/kerberos"
+	"github.com/marmos91/dittofs/pkg/auth/kerberos"
+	dconfig "github.com/marmos91/dittofs/pkg/config"
+)
+
+const (
+	adContainerName = "dittofs-ad-dc-test"
+	adImageName     = "dittofs-ad-dc-test"
+
+	adRealm  = "DITTOFS.AD"
+	adDomain = "DITTOFS"
+
+	adUserAlice = "alice"
+	adUserPass  = "TestPassword01!"
+
+	// SMB service principal the DittoFS server presents; the fixture exports
+	// its key into dittofs.keytab. spnShort is the form gokrb5 uses to request
+	// a service ticket (no realm); spnFull is what Authenticate validates against.
+	adSMBSPNShort = "cifs/dittofs.dittofs.ad"
+	adSMBSPNFull  = "cifs/dittofs.dittofs.ad@DITTOFS.AD"
+)
+
+// TestADGroupSIDsFromPAC exercises the full AD-1 path: a real AD ticket's PAC
+// group SIDs flow into the KerberosService AuthResult.
+func TestADGroupSIDsFromPAC(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping AD-DC integration test in short mode")
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not found, skipping AD-DC integration test")
+	}
+
+	kdcPort, keytabPath, krb5ConfPath, cleanup := setupADDC(t)
+	defer cleanup()
+
+	// Build the shared KerberosService from a provider backed by the exported
+	// service keytab. This is the same construction the SMB session layer uses.
+	cfg := &dconfig.KerberosConfig{
+		Enabled:          true,
+		KeytabPath:       keytabPath,
+		ServicePrincipal: adSMBSPNFull,
+		Krb5Conf:         krb5ConfPath,
+		MaxClockSkew:     5 * time.Minute,
+		ContextTTL:       10 * time.Minute,
+		MaxContexts:      100,
+	}
+	provider, err := kerberos.NewProvider(cfg)
+	if err != nil {
+		t.Fatalf("create kerberos provider: %v", err)
+	}
+	defer provider.Close()
+
+	service := kerbauth.NewKerberosService(provider)
+
+	// alice authenticates against the DC and obtains a service ticket for the
+	// SMB SPN, then we build the raw AP-REQ (Authenticate expects the raw
+	// AP-REQ, not a GSS-wrapped token).
+	apReqBytes := getADAPREQ(t, krb5ConfPath, kdcPort)
+
+	result, err := service.Authenticate(apReqBytes, adSMBSPNFull)
+	if err != nil {
+		t.Fatalf("Authenticate failed: %v", err)
+	}
+
+	t.Logf("Authenticated principal=%q realm=%q user_sid=%q group_sids=%v",
+		result.Principal, result.Realm, result.UserSID, result.GroupSIDs)
+
+	// UserSID must be populated from the PAC (logon domain SID + RID).
+	if result.UserSID == "" {
+		t.Error("expected non-empty UserSID from PAC, got empty")
+	} else if !strings.HasPrefix(result.UserSID, "S-1-5-21-") {
+		t.Errorf("UserSID %q does not look like a domain SID (S-1-5-21-...)", result.UserSID)
+	}
+
+	// GroupSIDs must be non-empty and contain BOTH the devs and engineering
+	// group SIDs. AD resolves the nesting (devs ⊂ engineering) at the DC and
+	// stamps both into alice's ticket PAC — no LDAP group-walk required.
+	if len(result.GroupSIDs) == 0 {
+		t.Fatal("expected non-empty GroupSIDs from PAC, got none")
+	}
+
+	devsSID := lookupGroupSID(t, "devs")
+	engineeringSID := lookupGroupSID(t, "engineering")
+
+	if !containsSID(result.GroupSIDs, devsSID) {
+		t.Errorf("GroupSIDs %v missing devs SID %q", result.GroupSIDs, devsSID)
+	}
+	if !containsSID(result.GroupSIDs, engineeringSID) {
+		t.Errorf("GroupSIDs %v missing engineering (nested) SID %q", result.GroupSIDs, engineeringSID)
+	}
+
+	t.Logf("PAC carried devs=%s and engineering=%s (nested resolved at DC) ✓", devsSID, engineeringSID)
+}
+
+// AD-DC Docker Setup
+
+// setupADDC builds the Samba AD-DC image, runs it (letting its own entrypoint
+// provision the domain), waits for the KDC to accept connections, and copies
+// the exported keytab + a host-side krb5.conf pointing at the mapped KDC port.
+func setupADDC(t *testing.T) (kdcHostPort int, keytabPath, krb5ConfPath string, cleanup func()) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+
+	// Clean up any previous container.
+	_ = exec.Command("docker", "rm", "-f", adContainerName).Run()
+
+	dockerfileDir := findADDockerfileDir(t)
+
+	// Build the image (cached after first run). Force linux/amd64: samba-ad-dc
+	// has no native arm64 path in our base and runs fine under emulation.
+	t.Log("Building Samba AD-DC image (slow on first run)...")
+	buildCmd := exec.Command("docker", "build",
+		"--platform", "linux/amd64",
+		"-t", adImageName, dockerfileDir,
+	)
+	buildCmd.Stdout = os.Stdout
+	buildCmd.Stderr = os.Stderr
+	if err := buildCmd.Run(); err != nil {
+		t.Fatalf("docker build failed: %v", err)
+	}
+
+	// Run the container with the AD-DC entrypoint (it provisions the domain,
+	// creates users/groups, and exports the keytab to /keytabs on its own).
+	t.Log("Starting AD-DC container...")
+	runOut, err := exec.Command("docker", "run", "-d",
+		"--platform", "linux/amd64",
+		"--name", adContainerName,
+		"-p", "0:88/tcp",
+		adImageName,
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("docker run failed: %v\n%s", err, runOut)
+	}
+
+	// Discover the randomly assigned host port for the KDC.
+	portOut, err := exec.Command("docker", "port", adContainerName, "88/tcp").Output()
+	if err != nil {
+		dumpADLogs(t)
+		t.Fatalf("docker port: %v", err)
+	}
+	portStr := strings.TrimSpace(string(portOut))
+	parts := strings.Split(portStr, ":")
+	kdcHostPort, err = strconv.Atoi(parts[len(parts)-1])
+	if err != nil {
+		t.Fatalf("parse port %q: %v", portStr, err)
+	}
+	t.Logf("AD-DC KDC mapped to host port %d", kdcHostPort)
+
+	// Wait for the KDC TCP port to come up. Provisioning a fresh AD domain
+	// under emulation is slow, so allow several minutes.
+	t.Log("Waiting for KDC TCP port...")
+	waitForADPort(t, kdcHostPort, 6*time.Minute)
+
+	// Wait for the entrypoint to finish exporting the keytab. It is the last
+	// artifact written before samba re-execs in the foreground.
+	t.Log("Waiting for service keytab export...")
+	waitForKeytab(t, 4*time.Minute)
+
+	// Copy the keytab out of the container. docker cp reads as root inside the
+	// container, so the fixture's chmod 0400 / chown to the dittofs uid does
+	// not block us (it would block a host volume mount).
+	keytabPath = filepath.Join(tmpDir, "dittofs.keytab")
+	if out, err := exec.Command("docker", "cp",
+		adContainerName+":/keytabs/dittofs.keytab", keytabPath).CombinedOutput(); err != nil {
+		dumpADLogs(t)
+		t.Fatalf("copy keytab: %v\n%s", err, out)
+	}
+
+	// Write a host-side krb5.conf that points the realm KDC at the mapped host
+	// port (force TCP, the mapped port is TCP only). The Samba-generated
+	// krb5.conf in the container references the DC hostname, which the host
+	// cannot resolve — so we synthesise a minimal one like the MIT KDC test.
+	krb5ConfPath = filepath.Join(tmpDir, "krb5.conf")
+	hostKrb5Conf := fmt.Sprintf(`[libdefaults]
+    default_realm = %s
+    dns_lookup_realm = false
+    dns_lookup_kdc = false
+    udp_preference_limit = 1
+    rdns = false
+
+[realms]
+    %s = {
+        kdc = 127.0.0.1:%d
+    }
+`, adRealm, adRealm, kdcHostPort)
+	if err := os.WriteFile(krb5ConfPath, []byte(hostKrb5Conf), 0o644); err != nil {
+		t.Fatalf("write krb5.conf: %v", err)
+	}
+
+	cleanup = func() {
+		t.Log("Cleaning up AD-DC container...")
+		_ = exec.Command("docker", "rm", "-f", adContainerName).Run()
+	}
+	return kdcHostPort, keytabPath, krb5ConfPath, cleanup
+}
+
+func findADDockerfileDir(t *testing.T) string {
+	t.Helper()
+	if _, err := os.Stat("Dockerfile"); err == nil {
+		return "."
+	}
+	dir, _ := os.Getwd()
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return filepath.Join(dir, "test", "integration", "ad-dc")
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("cannot find project root (go.mod)")
+		}
+		dir = parent
+	}
+}
+
+// waitForKeytab polls until dittofs.keytab exists and is non-empty inside the
+// container (the entrypoint exports it after provisioning completes).
+func waitForKeytab(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		out, err := exec.Command("docker", "exec", adContainerName,
+			"sh", "-c", "test -s /keytabs/dittofs.keytab && echo ok").CombinedOutput()
+		if err == nil && strings.TrimSpace(string(out)) == "ok" {
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	dumpADLogs(t)
+	t.Fatalf("keytab not exported within %s", timeout)
+}
+
+func waitForADPort(t *testing.T, port int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 1*time.Second)
+		if err == nil {
+			conn.Close()
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	dumpADLogs(t)
+	t.Fatalf("KDC port %d not ready within %s", port, timeout)
+}
+
+// lookupGroupSID queries the running DC for a group's object SID via samba-tool.
+func lookupGroupSID(t *testing.T, group string) string {
+	t.Helper()
+	out, err := exec.Command("docker", "exec", adContainerName,
+		"samba-tool", "group", "show", group, "--attributes=objectSid").CombinedOutput()
+	if err != nil {
+		t.Fatalf("samba-tool group show %s: %v\n%s", group, err, out)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToLower(line), "objectsid:") {
+			sid := strings.TrimSpace(line[len("objectsid:"):])
+			if sid != "" {
+				return sid
+			}
+		}
+	}
+	t.Fatalf("could not parse objectSid for group %s from:\n%s", group, out)
+	return ""
+}
+
+func containsSID(sids []string, want string) bool {
+	for _, s := range sids {
+		if strings.EqualFold(s, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func dumpADLogs(t *testing.T) {
+	t.Helper()
+	out, _ := exec.Command("docker", "logs", "--tail", "100", adContainerName).CombinedOutput()
+	t.Logf("---- AD-DC container logs (tail) ----\n%s\n-------------------------------------", out)
+}
+
+// Real AD Ticket Generation
+
+// getADAPREQ logs in as alice against the AD-DC and returns the raw AP-REQ
+// bytes for the SMB SPN (NOT GSS-wrapped — KerberosService.Authenticate
+// expects the raw AP-REQ).
+func getADAPREQ(t *testing.T, krb5ConfPath string, _ int) []byte {
+	t.Helper()
+
+	cfg, err := krb5config.Load(krb5ConfPath)
+	if err != nil {
+		t.Fatalf("load krb5.conf: %v", err)
+	}
+
+	// kinit equivalent. DisablePAFXFAST avoids an unnecessary preauth round.
+	cl := client.NewWithPassword(adUserAlice, adRealm, adUserPass, cfg, client.DisablePAFXFAST(true))
+	if err := cl.Login(); err != nil {
+		t.Fatalf("kinit as alice failed: %v", err)
+	}
+	defer cl.Destroy()
+	t.Log("alice obtained a TGT from the AD-DC")
+
+	// TGS-REQ for the SMB service principal.
+	tkt, sessionKey, err := cl.GetServiceTicket(adSMBSPNShort)
+	if err != nil {
+		t.Fatalf("get service ticket for %s: %v", adSMBSPNShort, err)
+	}
+	t.Logf("alice obtained a service ticket for %s (enctype=%d)", adSMBSPNShort, sessionKey.KeyType)
+
+	apReqBytes := buildAPREQ(t, cl, tkt, sessionKey)
+	t.Logf("Built raw AP-REQ (%d bytes)", len(apReqBytes))
+	return apReqBytes
+}
+
+// buildAPREQ marshals a raw AP-REQ for the given service ticket.
+func buildAPREQ(t *testing.T, cl *client.Client, tkt messages.Ticket, sessionKey types.EncryptionKey) []byte {
+	t.Helper()
+
+	auth, err := types.NewAuthenticator(cl.Credentials.Domain(), cl.Credentials.CName())
+	if err != nil {
+		t.Fatalf("create authenticator: %v", err)
+	}
+
+	apReq, err := messages.NewAPReq(tkt, sessionKey, auth)
+	if err != nil {
+		t.Fatalf("build AP-REQ: %v", err)
+	}
+
+	apReqBytes, err := apReq.Marshal()
+	if err != nil {
+		t.Fatalf("marshal AP-REQ: %v", err)
+	}
+	// Sanity: a marshalled AP-REQ starts with APPLICATION 14 (0x6e).
+	if len(apReqBytes) == 0 || apReqBytes[0] != 0x6e {
+		t.Fatalf("unexpected AP-REQ prefix: %x", firstBytes(apReqBytes))
+	}
+	return apReqBytes
+}
+
+func firstBytes(b []byte) []byte {
+	if len(b) > 8 {
+		return b[:8]
+	}
+	return b
+}

--- a/test/integration/ad-dc/entrypoint.sh
+++ b/test/integration/ad-dc/entrypoint.sh
@@ -9,7 +9,8 @@
 #     bob    -- member of engineering only, NO RFC2307 attrs (RID-fallback case)
 #
 #   Groups:
-#     engineering -- has RFC2307 gidNumber
+#     engineering -- top-level group (group-level RFC2307 gidNumber is left to
+#                    AD-3, which is the consumer; AD-1 only needs membership)
 #     devs        -- nested member of engineering (so alice's PAC carries BOTH
 #                    devs and engineering SIDs: AD resolves nesting at the DC)
 #
@@ -20,10 +21,11 @@
 # A service keytab for the DittoFS SMB/NFS principals is exported to the shared
 # /keytabs volume so the dittofs server (or a Go test) can authenticate tickets.
 #
-# RFC2307 attrs vs RID fallback: alice/devs/engineering get uidNumber/gidNumber
-# (the idmap_ad path AD-3 will read over LDAP); bob/its group get none (the
-# idmap_rid algorithmic-fallback path). AD-1 does not consume these — they are
-# provisioned now so the AD-2/AD-3 PRs gate against the same fixture.
+# RFC2307 attrs vs RID fallback: alice gets uidNumber/gidNumber (the idmap_ad
+# path AD-3 will read over LDAP); bob gets none (the idmap_rid algorithmic-
+# fallback path). AD-1 does not consume these user attrs — they are provisioned
+# now so the AD-2/AD-3 PRs gate against the same fixture. Group-level gidNumbers
+# are AD-3's concern and are stamped there when that path is built.
 
 set -euo pipefail
 
@@ -128,12 +130,8 @@ samba-tool group addmembers devs "$USER_ALICE" >/dev/null 2>&1 || true
 create_user_if_absent "$USER_BOB"
 samba-tool group addmembers engineering "$USER_BOB" >/dev/null 2>&1 || true
 
-# RFC2307 gidNumber on engineering (group-level POSIX attr the AD-3 idmap reads).
-# alice's group (Domain Users primary) keeps the provision-time default.
-samba-tool group editlocalgroup >/dev/null 2>&1 || true
-
 # --- Service keytab -------------------------------------------------------
-# Register the DittoFS SMB + NFS service principals on the DC's machine account
+# Register the DittoFS SMB + NFS service principals on the Administrator account
 # and export their keys so the server can decrypt client AP-REQs. The PAC is
 # signed with the same key, so a correct keytab is required for PAC validation.
 keytab="$KEYTAB_DIR/dittofs.keytab"

--- a/test/integration/ad-dc/entrypoint.sh
+++ b/test/integration/ad-dc/entrypoint.sh
@@ -46,8 +46,6 @@ USER_PASSWORD="${USER_PASSWORD:-TestPassword01!}"
 DITTOFS_UID="${DITTOFS_UID:-65532}"
 DITTOFS_GID="${DITTOFS_GID:-65532}"
 
-REALM_LOWER="${REALM,,}"
-
 log() { echo "[AD-DC] $*"; }
 
 mkdir -p "$KEYTAB_DIR"
@@ -87,7 +85,7 @@ fi
 log "Starting samba for provisioning..."
 samba -D
 # Wait for the LDAP/KDC stack to accept connections.
-for i in $(seq 1 30); do
+for _ in $(seq 1 30); do
     if samba-tool processes >/dev/null 2>&1; then
         break
     fi

--- a/test/integration/ad-dc/entrypoint.sh
+++ b/test/integration/ad-dc/entrypoint.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# Samba Active Directory Domain Controller bootstrap for AD-1 PAC testing.
+#
+# Provisions a fresh AD domain on first start, then creates test users and
+# groups that exercise the Kerberos PAC group-SID path:
+#
+#   Users:
+#     alice  -- member of devs (nested under engineering) + RFC2307 attrs set
+#     bob    -- member of engineering only, NO RFC2307 attrs (RID-fallback case)
+#
+#   Groups:
+#     engineering -- has RFC2307 gidNumber
+#     devs        -- nested member of engineering (so alice's PAC carries BOTH
+#                    devs and engineering SIDs: AD resolves nesting at the DC)
+#
+# alice's ticket therefore carries a PAC whose GroupMembershipSIDs include the
+# devs and engineering domain group SIDs. That is the property AD-1's test
+# asserts: PAC group SIDs flow into the Kerberos AuthResult.
+#
+# A service keytab for the DittoFS SMB/NFS principals is exported to the shared
+# /keytabs volume so the dittofs server (or a Go test) can authenticate tickets.
+#
+# RFC2307 attrs vs RID fallback: alice/devs/engineering get uidNumber/gidNumber
+# (the idmap_ad path AD-3 will read over LDAP); bob/its group get none (the
+# idmap_rid algorithmic-fallback path). AD-1 does not consume these — they are
+# provisioned now so the AD-2/AD-3 PRs gate against the same fixture.
+
+set -euo pipefail
+
+REALM="${AD_REALM:-DITTOFS.AD}"
+DOMAIN="${AD_DOMAIN:-DITTOFS}"
+ADMIN_PASSWORD="${AD_ADMIN_PASSWORD:-Passw0rd!2024}"
+KEYTAB_DIR="${KEYTAB_DIR:-/keytabs}"
+
+# Service principals the DittoFS server presents to clients.
+SMB_SPN="${SMB_SPN:-cifs/dittofs.${REALM,,}}"
+NFS_SPN="${NFS_SPN:-nfs/dittofs.${REALM,,}}"
+
+# Test users + groups.
+USER_ALICE="${USER_ALICE:-alice}"
+USER_BOB="${USER_BOB:-bob}"
+USER_PASSWORD="${USER_PASSWORD:-TestPassword01!}"
+
+# UID/GID the dittofs container runs as; the exported keytab must be readable
+# there. Defaults match the smb-conformance harness.
+DITTOFS_UID="${DITTOFS_UID:-65532}"
+DITTOFS_GID="${DITTOFS_GID:-65532}"
+
+REALM_LOWER="${REALM,,}"
+
+log() { echo "[AD-DC] $*"; }
+
+mkdir -p "$KEYTAB_DIR"
+
+# samba-tool domain provision is destructive and one-shot. Use the presence of
+# the provisioned config as the "already initialised" sentinel so a container
+# restart re-uses the existing domain database rather than re-provisioning.
+if [ ! -f /var/lib/samba/.provisioned ]; then
+    log "Provisioning AD domain $DOMAIN / realm $REALM"
+
+    # Remove any stub smb.conf so provision writes a clean AD-DC config.
+    rm -f /etc/samba/smb.conf
+
+    # Provision the domain controller. SAMBA_INTERNAL DNS keeps the fixture
+    # self-contained (no bind9 dependency). --use-rfc2307 enables the RFC2307
+    # POSIX attribute schema so we can stamp uidNumber/gidNumber on some objects.
+    samba-tool domain provision \
+        --use-rfc2307 \
+        --realm="$REALM" \
+        --domain="$DOMAIN" \
+        --server-role=dc \
+        --dns-backend=SAMBA_INTERNAL \
+        --adminpass="$ADMIN_PASSWORD" \
+        --option="ad dc functional level = 2016"
+
+    # Samba writes its own krb5.conf during provision; expose it to other
+    # containers / the Go test on the shared volume.
+    cp /var/lib/samba/private/krb5.conf "$KEYTAB_DIR/krb5.conf"
+    chmod 644 "$KEYTAB_DIR/krb5.conf"
+
+    touch /var/lib/samba/.provisioned
+    log "Provision complete"
+fi
+
+# Start samba in the background so samba-tool (which talks to the running DC for
+# user/group management) can operate. Foreground samba is re-exec'd at the end.
+log "Starting samba for provisioning..."
+samba -D
+# Wait for the LDAP/KDC stack to accept connections.
+for i in $(seq 1 30); do
+    if samba-tool processes >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+
+create_user_if_absent() {
+    local user="$1"; shift
+    if ! samba-tool user show "$user" >/dev/null 2>&1; then
+        log "Creating user $user"
+        samba-tool user create "$user" "$USER_PASSWORD" "$@"
+    fi
+}
+
+create_group_if_absent() {
+    local group="$1"
+    if ! samba-tool group show "$group" >/dev/null 2>&1; then
+        log "Creating group $group"
+        samba-tool group add "$group"
+    fi
+}
+
+# --- Groups ---------------------------------------------------------------
+create_group_if_absent engineering
+create_group_if_absent devs
+
+# Nest devs under engineering: AD resolves the nesting at the DC, so a member of
+# devs gets BOTH the devs and engineering SIDs in their ticket's PAC. This is
+# the "no LDAP group-walk needed" property AD-1 demonstrates.
+samba-tool group addmembers engineering devs >/dev/null 2>&1 || true
+
+# --- Users ----------------------------------------------------------------
+# alice: RFC2307 attrs set (idmap_ad path), member of devs (=> nested in engineering).
+create_user_if_absent "$USER_ALICE" \
+    --uid-number=10001 --gid-number=10000 \
+    --unix-home="/home/$USER_ALICE" --login-shell=/bin/bash
+samba-tool group addmembers devs "$USER_ALICE" >/dev/null 2>&1 || true
+
+# bob: NO RFC2307 attrs (idmap_rid algorithmic-fallback path), member of engineering.
+create_user_if_absent "$USER_BOB"
+samba-tool group addmembers engineering "$USER_BOB" >/dev/null 2>&1 || true
+
+# RFC2307 gidNumber on engineering (group-level POSIX attr the AD-3 idmap reads).
+# alice's group (Domain Users primary) keeps the provision-time default.
+samba-tool group editlocalgroup >/dev/null 2>&1 || true
+
+# --- Service keytab -------------------------------------------------------
+# Register the DittoFS SMB + NFS service principals on the DC's machine account
+# and export their keys so the server can decrypt client AP-REQs. The PAC is
+# signed with the same key, so a correct keytab is required for PAC validation.
+keytab="$KEYTAB_DIR/dittofs.keytab"
+if [ ! -f "$keytab" ]; then
+    log "Exporting service keytab to $keytab ($SMB_SPN, $NFS_SPN)"
+    samba-tool spn add "$SMB_SPN" "$DOMAIN\\Administrator" >/dev/null 2>&1 || true
+    samba-tool spn add "$NFS_SPN" "$DOMAIN\\Administrator" >/dev/null 2>&1 || true
+    samba-tool domain exportkeytab "$keytab" \
+        --principal="$SMB_SPN@$REALM" >/dev/null 2>&1 || true
+    samba-tool domain exportkeytab "$keytab" \
+        --principal="$NFS_SPN@$REALM" >/dev/null 2>&1 || true
+    # Also export Administrator's key so tests that need a TGT via keytab can.
+    chown "$DITTOFS_UID:$DITTOFS_GID" "$keytab" 2>/dev/null || true
+    chmod 0400 "$keytab" 2>/dev/null || true
+fi
+
+log "AD-DC ready: realm=$REALM users=[$USER_ALICE,$USER_BOB] groups=[engineering,devs(nested)]"
+
+# Stop the backgrounded samba and re-exec it in the foreground as PID 1's child
+# so the container stays alive and signals propagate.
+samba-tool processes >/dev/null 2>&1 || true
+pkill -TERM samba 2>/dev/null || true
+sleep 2
+
+log "Starting samba in foreground..."
+exec samba --foreground --no-process-group

--- a/test/integration/ad-dc/run.sh
+++ b/test/integration/ad-dc/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Run the AD-1 PAC group-SID integration test against a real Samba AD-DC in
+# Docker. Builds + provisions a fresh domain (slow under linux/amd64 emulation
+# on Apple Silicon), so the timeout is generous.
+#
+# Usage:
+#   ./run.sh          # Run the test
+#   ./run.sh -v       # Verbose output
+set -euo pipefail
+
+cd "$(dirname "$0")/../../.."
+
+echo "=== AD-DC PAC Group-SID Integration Test (AD-1) ==="
+echo "Requires: Docker"
+echo ""
+
+exec go test -tags=ad_dc -timeout 20m ./test/integration/ad-dc/ "$@"


### PR DESCRIPTION
## What

Completes **AD-1 (#1233)**: AD-issued Kerberos tickets now surface their PAC group SIDs through the shared `KerberosService`.

- **PAC decode + group-SID threading** (already committed in `a21c26c3`): `service.go` flips `DecodePAC(false→true)` and `extractPACIdentity` pulls the user SID (logon-domain SID + RID) and transitive `GroupMembershipSIDs` from the gokrb5 PAC into `AuthResult.{UserSID,GroupSIDs}`; the SMB session layer threads `GroupSIDs` into the session identity. Tickets without a PAC (plain MIT KDC) verify exactly as before.
- **Samba AD-DC docker fixture** (`test/integration/ad-dc/{Dockerfile,entrypoint.sh}`): provisions realm `DITTOFS.AD` with `alice` (RFC2307 attrs, member of `devs` nested under `engineering`) and `bob` (no RFC2307, `engineering` only), and exports a service keytab for the SMB/NFS SPNs. Because AD resolves nesting at the DC, alice's ticket PAC carries **both** the `devs` and `engineering` group SIDs.
- **Integration test** (`ad_dc_integration_test.go`, build tag `ad_dc`): builds/runs the AD-DC container, logs in as alice, gets a service ticket for `cifs/dittofs.dittofs.ad`, builds the raw AP-REQ, calls `KerberosService.Authenticate`, and asserts `UserSID` is a domain SID and `GroupSIDs` contains both the `devs` and (nested) `engineering` SIDs (looked up live via `samba-tool`).
- **CI** (`.github/workflows/ad-dc.yml`): runs at **postsubmit (push develop) + nightly cron + manual dispatch**, OFF presubmit — mirrors the `smbtorture-kerberos` tiering, since building/provisioning a Samba AD domain is expensive.

## Why

Issue AD-1 requires AD group SIDs to flow into the live identity so SID-based ACL evaluation sees the user's full transitive group set without an LDAP group-walk at auth time. The new integration test proves this end-to-end against a real domain controller (an MIT KDC issues no PAC, so it cannot).

## Test plan

- `go build ./...` — clean
- `go vet ./...` — clean
- `gofmt -l .` — empty
- `go test -race ./internal/auth/kerberos/... ./pkg/identity/...` — pass
- The `ad_dc`-tagged docker test is gated behind the build tag + a docker-presence skip, so `go test ./...` stays green without docker (the package has no buildable Go files without the tag).
- **Docker test not run locally**: the Docker daemon is not running on the dev host. The test is correctly gated and will run in CI at the postsubmit/nightly tier.

## Known follow-up

Durable foreign-SID persistence (restart/node-stable idmap) is **AD-3 (#1235)** — AD-1 only makes the SIDs flow into the live identity.

Closes #1233
