### PR TITLE
AD-3: core durable identity + idmap layer (#1235)

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -235,6 +235,10 @@ func runStart(cmd *cobra.Command, args []string) error {
 
 	// Configure runtime
 	rt.SetShutdownTimeout(cfg.ShutdownTimeout)
+	// Seed an operator-pinned machine SID (if configured) BEFORE Serve so the
+	// machine SID is resolved before any adapter reads the SID mapper. Pinning
+	// the same SID on every node yields identical local UID->SID encoding.
+	rt.SetPinnedMachineSID(cfg.Identity.MachineSID)
 	rt.SetAdapterFactory(createAdapterFactory(&cfg.Kerberos))
 
 	// Create and set API server

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1269,6 +1269,20 @@ adapters:
 
 ```yaml
 identity:
+  # Pin this node's machine SID (Windows S-1-5-21-{a}-{b}-{c}).
+  #
+  # When unset, the machine SID is generated once on first boot and
+  # persisted, staying stable across restarts. Local/algorithmic SIDs are
+  # derived purely from the machine SID + the Samba RID formula
+  # (user RID = uid*2+1000, group RID = gid*2+1001), so pinning the SAME
+  # value on every node in a cluster makes them compute IDENTICAL SIDs for
+  # the same Unix UID/GID — required for cross-node identity parity.
+  # Foreign (Active Directory / LDAP) domain SIDs are NOT derived this way;
+  # they are bound to stable UID/GIDs durably in the control-plane store.
+  #
+  # Env override: DITTOFS_IDENTITY_MACHINE_SID
+  machine_sid: "S-1-5-21-1111111111-2222222222-3333333333"
+
   # Identity mapping for NFSv4
   idmap:
     domain: example.com

--- a/pkg/adapter/identity.go
+++ b/pkg/adapter/identity.go
@@ -27,6 +27,11 @@ func ExtractRealm(principal string) string {
 func BuildIdentityResolver(rt *runtime.Runtime, realm string) *identity.Resolver {
 	cpStore := rt.Store()
 
+	// sidMappingStore, when the control-plane store supports it, resolves
+	// foreign (AD/LDAP) group SIDs to their durable GIDs so a user's Windows
+	// group SIDs contribute Unix supplementary GIDs (AD-3 #1235).
+	sidMappingStore, _ := cpStore.(store.SIDMappingStore)
+
 	userLookup := func(ctx context.Context, username string) (*identity.ResolvedIdentity, error) {
 		user, err := cpStore.GetUser(ctx, username)
 		if err != nil {
@@ -49,12 +54,34 @@ func BuildIdentityResolver(rt *runtime.Runtime, realm string) *identity.Resolver
 				gids = append(gids, *g.GID)
 			}
 		}
+
+		// Resolve persisted foreign group SIDs to durable GIDs and fold them
+		// into the supplementary group set. A SID with no durable mapping is
+		// skipped (the LDAP provider in AD-2 allocates the mapping at login);
+		// never-remap guarantees a stable GID once allocated.
+		if sidMappingStore != nil {
+			for _, gsid := range user.GroupSIDs {
+				m, err := sidMappingStore.GetSIDMapping(ctx, gsid)
+				if err != nil {
+					if errors.Is(err, models.ErrSIDMappingNotFound) {
+						continue
+					}
+					return nil, err
+				}
+				if m.IsGroup {
+					gids = append(gids, m.UnixID)
+				}
+			}
+		}
+
 		return &identity.ResolvedIdentity{
-			Username: user.Username,
-			UID:      uid,
-			GID:      gid,
-			GIDs:     gids,
-			Found:    true,
+			Username:  user.Username,
+			UID:       uid,
+			GID:       gid,
+			GIDs:      gids,
+			Found:     true,
+			SID:       user.SID,
+			GroupSIDs: user.GroupSIDs,
 		}, nil
 	}
 

--- a/pkg/adapter/identity.go
+++ b/pkg/adapter/identity.go
@@ -59,16 +59,13 @@ func BuildIdentityResolver(rt *runtime.Runtime, realm string) *identity.Resolver
 		// into the supplementary group set. A SID with no durable mapping is
 		// skipped (the LDAP provider in AD-2 allocates the mapping at login);
 		// never-remap guarantees a stable GID once allocated.
-		if sidMappingStore != nil {
+		if sidMappingStore != nil && len(user.GroupSIDs) > 0 {
+			mappings, err := sidMappingStore.GetSIDMappingsByIDs(ctx, user.GroupSIDs)
+			if err != nil {
+				return nil, err
+			}
 			for _, gsid := range user.GroupSIDs {
-				m, err := sidMappingStore.GetSIDMapping(ctx, gsid)
-				if err != nil {
-					if errors.Is(err, models.ErrSIDMappingNotFound) {
-						continue
-					}
-					return nil, err
-				}
-				if m.IsGroup {
+				if m, ok := mappings[gsid]; ok && m.IsGroup {
 					gids = append(gids, m.UnixID)
 				}
 			}

--- a/pkg/auth/sid/mapper.go
+++ b/pkg/auth/sid/mapper.go
@@ -17,7 +17,20 @@ import (
 // This guarantees UserSID(n) != GroupSID(n) for all n.
 //
 // The machine SID is of the form S-1-5-21-{a}-{b}-{c} where a, b, c are
-// randomly generated 32-bit values persisted in the control plane store.
+// 32-bit values. On a single node they are generated once and persisted in the
+// control-plane SettingsStore (key "machine_sid"), staying stable across
+// restarts.
+//
+// LOCKED, NODE-SHARED INVARIANT: the machine SID + the RID formula above are
+// the ONLY inputs to a local UID/GID's SID. Given the same machine SID, every
+// node computes the IDENTICAL SID for the same Unix UID/GID — no per-node
+// state is involved. Two nodes that want matching local/algorithmic SIDs MUST
+// therefore share the same machine SID; pin it via config (identity.machine_sid
+// / DITTOFS_IDENTITY_MACHINE_SID). Do NOT change the RID offsets (+1000 user /
+// +1001 group) or the machine-SID shape: doing so would re-encode every
+// already-issued local SID and break cross-node parity and persisted ACLs.
+// FOREIGN (AD/LDAP) domain SIDs are out of scope here — they are not derivable
+// from a local UID and are persisted durably in models.SIDMapping instead.
 type SIDMapper struct {
 	machineSID [3]uint32 // The three sub-authorities of the domain SID
 }

--- a/pkg/auth/sid/sid_test.go
+++ b/pkg/auth/sid/sid_test.go
@@ -546,3 +546,45 @@ func TestPrincipalToSID_HashFallback_RoundTrips(t *testing.T) {
 func hasSIDPrefix(s string) bool {
 	return len(s) >= 4 && s[:4] == "sid:"
 }
+
+// TestMachineSID_NodeParity is the AD-3 determinism acceptance: two mappers
+// built from the SAME machine SID produce IDENTICAL SIDs/RIDs for the same
+// UID/GID. This guarantees cross-node parity when operators pin one machine
+// SID across a cluster — no per-node state contributes to a local SID.
+func TestMachineSID_NodeParity(t *testing.T) {
+	const machine = "S-1-5-21-3141592-2718281-1618033"
+
+	// Build two independent mappers from the same pinned machine SID, as two
+	// cluster nodes would from the same config.
+	nodeA, err := NewSIDMapperFromString(machine)
+	if err != nil {
+		t.Fatalf("nodeA: %v", err)
+	}
+	nodeB, err := NewSIDMapperFromString(machine)
+	if err != nil {
+		t.Fatalf("nodeB: %v", err)
+	}
+
+	if nodeA.MachineSIDString() != machine || nodeB.MachineSIDString() != machine {
+		t.Fatalf("machine SID not round-tripped: A=%q B=%q want %q",
+			nodeA.MachineSIDString(), nodeB.MachineSIDString(), machine)
+	}
+
+	for _, id := range []uint32{1, 1000, 1001, 65534, 4294967} {
+		if a, b := FormatSID(nodeA.UserSID(id)), FormatSID(nodeB.UserSID(id)); a != b {
+			t.Errorf("UserSID(%d) differs across nodes: %s != %s", id, a, b)
+		}
+		if a, b := FormatSID(nodeA.GroupSID(id)), FormatSID(nodeB.GroupSID(id)); a != b {
+			t.Errorf("GroupSID(%d) differs across nodes: %s != %s", id, a, b)
+		}
+		// And the reverse decode must agree too.
+		ua, oka := nodeA.UIDFromSID(nodeB.UserSID(id))
+		if !oka || ua != id {
+			t.Errorf("cross-node UID decode failed for %d: got (%d,%v)", id, ua, oka)
+		}
+		ga, okg := nodeA.GIDFromSID(nodeB.GroupSID(id))
+		if !okg || ga != id {
+			t.Errorf("cross-node GID decode failed for %d: got (%d,%v)", id, ga, okg)
+		}
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/marmos91/dittofs/internal/bytesize"
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/adapter/nfs/identity"
+	"github.com/marmos91/dittofs/pkg/auth/sid"
 	"github.com/marmos91/dittofs/pkg/controlplane/api"
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
 	"github.com/mitchellh/mapstructure"
@@ -81,6 +82,37 @@ type Config struct {
 	// Metrics configures the Prometheus metrics endpoint (opt-in, disabled by
 	// default). See MetricsConfig.
 	Metrics MetricsConfig `mapstructure:"metrics" yaml:"metrics"`
+
+	// Identity configures Windows/SID identity mapping. See IdentityConfig.
+	Identity IdentityConfig `mapstructure:"identity" yaml:"identity"`
+}
+
+// IdentityConfig configures Windows/SID identity behavior shared across NFS,
+// SMB, and the control plane.
+//
+// Environment variable override:
+//
+//	DITTOFS_IDENTITY_MACHINE_SID pins the machine SID.
+type IdentityConfig struct {
+	// MachineSID, when set, pins this node's machine SID to a fixed
+	// "S-1-5-21-{a}-{b}-{c}" value instead of generating a random one on
+	// first boot. Pin the SAME value on every node in a cluster so they
+	// derive IDENTICAL local/algorithmic SIDs from the same Unix UID/GID
+	// (the RID formula in pkg/auth/sid/mapper.go is a LOCKED, node-shared
+	// invariant). Leave empty for a single node — the SID is then generated
+	// once and persisted, staying stable across restarts.
+	MachineSID string `mapstructure:"machine_sid" yaml:"machine_sid"`
+}
+
+// Validate returns an error if the IdentityConfig has invalid values.
+func (c *IdentityConfig) Validate() error {
+	if c.MachineSID == "" {
+		return nil
+	}
+	if _, err := sid.NewSIDMapperFromString(c.MachineSID); err != nil {
+		return fmt.Errorf("identity.machine_sid %q is invalid: %w", c.MachineSID, err)
+	}
+	return nil
 }
 
 // GCConfig configures the engine.CollectGarbage mark-sweep run. Knobs

--- a/pkg/config/env_binding_test.go
+++ b/pkg/config/env_binding_test.go
@@ -360,3 +360,44 @@ func TestLoad_NoFileNoEnv_StillDefaults(t *testing.T) {
 		t.Errorf("default database.type: got %q want sqlite", cfg.Database.Type)
 	}
 }
+
+// TestLoad_IdentityMachineSIDFromEnv verifies the machine-SID pin resolves from
+// env (DITTOFS_IDENTITY_MACHINE_SID) and via the config file (AD-3 #1235).
+func TestLoad_IdentityMachineSIDFromEnv(t *testing.T) {
+	content := `
+database:
+  type: sqlite
+controlplane:
+  jwt:
+    secret: "test-secret-key-for-testing-minimum-32-chars"
+`
+	path := writeConfigFile(t, content)
+
+	t.Setenv("DITTOFS_IDENTITY_MACHINE_SID", "S-1-5-21-10-20-30")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Identity.MachineSID != "S-1-5-21-10-20-30" {
+		t.Errorf("identity.machine_sid env override dropped, got %q", cfg.Identity.MachineSID)
+	}
+}
+
+// TestLoad_IdentityMachineSIDInvalidRejected verifies validation rejects a
+// malformed pinned machine SID.
+func TestLoad_IdentityMachineSIDInvalidRejected(t *testing.T) {
+	content := `
+database:
+  type: sqlite
+controlplane:
+  jwt:
+    secret: "test-secret-key-for-testing-minimum-32-chars"
+identity:
+  machine_sid: "not-a-sid"
+`
+	path := writeConfigFile(t, content)
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected Load to reject invalid identity.machine_sid")
+	}
+}

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -51,6 +51,10 @@ func Validate(cfg *Config) error {
 		return err
 	}
 
+	if err := cfg.Identity.Validate(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/controlplane/models/models.go
+++ b/pkg/controlplane/models/models.go
@@ -20,6 +20,7 @@ func AllModels() []any {
 		&AdapterConfig{},
 		&Setting{},
 		&IdentityMapping{},
+		&SIDMapping{},
 		&NFSAdapterSettings{},
 		&SMBAdapterSettings{},
 		&Netgroup{},

--- a/pkg/controlplane/models/sid_mapping.go
+++ b/pkg/controlplane/models/sid_mapping.go
@@ -1,0 +1,53 @@
+package models
+
+import (
+	"errors"
+	"time"
+)
+
+// SIDMapping is a durable binding between a foreign (Active Directory / LDAP)
+// domain SID and a stable DittoFS Unix UID/GID.
+//
+// Local/algorithmic SIDs (this machine's domain SID + an RID derived from the
+// local UID via the Samba formula — see pkg/auth/sid/mapper.go) are NOT stored
+// here: they are deterministically reproducible from the machine SID alone.
+// Only FOREIGN SIDs of the form S-1-5-21-<ad-domain>-<rid>, which are not
+// derivable from a local UID, require durable allocation.
+//
+// The mapping is keyed on the full domain SID and is allocated exactly once.
+// Re-resolving an existing foreign SID MUST return the same UID/GID — never
+// remap — because a remap would silently re-attribute files owned by the old
+// UID to a different principal (a data-exposure / data-loss invariant).
+//
+// IsGroup distinguishes a group SID (→ GID) from a user SID (→ UID); a SID is
+// allocated as one or the other based on the resolution context.
+type SIDMapping struct {
+	// SID is the canonical foreign domain SID string (e.g.
+	// "S-1-5-21-111-222-333-1107"). Primary key — uniqueness is the
+	// never-remap guarantee.
+	SID string `gorm:"primaryKey;type:varchar(184)" json:"sid"`
+
+	// UnixID is the allocated Unix identifier: a UID when IsGroup is false,
+	// a GID when IsGroup is true.
+	UnixID uint32 `gorm:"not null;index:idx_sid_mapping_unixid" json:"unix_id"`
+
+	// IsGroup reports whether UnixID is a GID (true) or a UID (false).
+	IsGroup bool `gorm:"not null;index:idx_sid_mapping_unixid" json:"is_group"`
+
+	// DisplayName is an optional human-readable label (e.g. the AD
+	// sAMAccountName) captured at allocation time for diagnostics.
+	DisplayName string `gorm:"type:varchar(255)" json:"display_name,omitempty"`
+
+	CreatedAt time.Time `gorm:"autoCreateTime" json:"created_at"`
+}
+
+// TableName returns the table name for SIDMapping.
+func (SIDMapping) TableName() string {
+	return "sid_mappings"
+}
+
+// Error types for SID mapping operations.
+var (
+	// ErrSIDMappingNotFound is returned when no mapping exists for a SID.
+	ErrSIDMappingNotFound = errors.New("sid mapping not found")
+)

--- a/pkg/controlplane/models/sid_mapping.go
+++ b/pkg/controlplane/models/sid_mapping.go
@@ -25,7 +25,7 @@ type SIDMapping struct {
 	// SID is the canonical foreign domain SID string (e.g.
 	// "S-1-5-21-111-222-333-1107"). Primary key — uniqueness is the
 	// never-remap guarantee.
-	SID string `gorm:"primaryKey;type:varchar(184)" json:"sid"`
+	SID string `gorm:"column:sid;primaryKey;type:varchar(184)" json:"sid"`
 
 	// UnixID is the allocated Unix identifier: a UID when IsGroup is false,
 	// a GID when IsGroup is true.

--- a/pkg/controlplane/models/user.go
+++ b/pkg/controlplane/models/user.go
@@ -44,15 +44,16 @@ type User struct {
 	LastLogin          *time.Time `json:"last_login,omitempty"`
 
 	// SID is the user's Windows Security Identifier, populated from
-	// Kerberos PAC, NTLMSSP session info, or local ID resolution.
-	// Empty when no source is wired. In-memory only for now — persistent
-	// storage of Windows identity is a follow-up.
-	SID string `gorm:"-" json:"sid,omitempty"`
+	// Kerberos PAC, NTLMSSP session info, or local ID resolution. Empty when
+	// no source is wired. Persisted as a plain column so the resolver can
+	// populate ResolvedIdentity.SID for a user authenticated over any
+	// protocol (AD-3 #1235).
+	SID string `gorm:"size:184" json:"sid,omitempty"`
 
 	// GroupSIDs is the list of Windows group SIDs for the user, populated
-	// alongside SID. In-memory only for now — gorm-excluded until a
-	// persistence strategy (JSON column or join table) is chosen.
-	GroupSIDs []string `gorm:"-" json:"group_sids,omitempty"`
+	// alongside SID. Persisted as a JSON-encoded text column via GORM's
+	// built-in json serializer (AD-3 #1235).
+	GroupSIDs []string `gorm:"serializer:json" json:"group_sids,omitempty"`
 
 	// Many-to-many relationship with groups
 	Groups []Group `gorm:"many2many:user_groups;" json:"groups,omitempty"`

--- a/pkg/controlplane/models/user.go
+++ b/pkg/controlplane/models/user.go
@@ -48,12 +48,12 @@ type User struct {
 	// no source is wired. Persisted as a plain column so the resolver can
 	// populate ResolvedIdentity.SID for a user authenticated over any
 	// protocol (AD-3 #1235).
-	SID string `gorm:"size:184" json:"sid,omitempty"`
+	SID string `gorm:"column:sid;size:184" json:"sid,omitempty"`
 
 	// GroupSIDs is the list of Windows group SIDs for the user, populated
 	// alongside SID. Persisted as a JSON-encoded text column via GORM's
 	// built-in json serializer (AD-3 #1235).
-	GroupSIDs []string `gorm:"serializer:json" json:"group_sids,omitempty"`
+	GroupSIDs []string `gorm:"column:group_sids;serializer:json" json:"group_sids,omitempty"`
 
 	// Many-to-many relationship with groups
 	Groups []Group `gorm:"many2many:user_groups;" json:"groups,omitempty"`

--- a/pkg/controlplane/runtime/lifecycle/service.go
+++ b/pkg/controlplane/runtime/lifecycle/service.go
@@ -68,6 +68,13 @@ type Service struct {
 	// sidMapper is the machine SID mapper, initialized on first Serve().
 	// It is exposed via SIDMapper() for adapters to use.
 	sidMapper *sid.SIDMapper
+
+	// pinnedMachineSID, when non-empty, is an operator-supplied machine SID
+	// (config/env) that initMachineSID seeds in preference to any random
+	// generation. Pinning the machine SID lets multiple cluster nodes derive
+	// IDENTICAL local/algorithmic SIDs from the same Unix UID/GID — see
+	// pkg/auth/sid/mapper.go for the LOCKED RID formula.
+	pinnedMachineSID string
 }
 
 func New(shutdownTimeout time.Duration) *Service {
@@ -92,19 +99,65 @@ func (s *Service) SIDMapper() *sid.SIDMapper {
 	return s.sidMapper
 }
 
-// initMachineSID loads or generates the machine SID from the settings store.
-// On first boot (no stored SID), a new random SID is generated and persisted.
-// On subsequent boots, the stored SID is loaded to ensure consistent mapping.
+// SetPinnedMachineSID records an operator-supplied machine SID to seed during
+// Serve(). Must be called before Serve(). An empty string is a no-op (the
+// machine SID is then loaded-or-generated as before). The value is validated
+// and applied by initMachineSID.
+func (s *Service) SetPinnedMachineSID(machineSID string) {
+	if s.served {
+		panic("cannot set pinned machine SID after Serve() has been called")
+	}
+	s.pinnedMachineSID = machineSID
+}
+
+// initMachineSID resolves the machine SID with the following precedence:
+//
+//  1. An operator-pinned machine SID (SetPinnedMachineSID, from config/env)
+//     is validated and applied; it is persisted to the settings store so it
+//     is authoritative and survives a later boot without the pin. Pinning the
+//     same SID on every node makes their local/algorithmic SIDs identical —
+//     required for cross-node identity parity (see pkg/auth/sid/mapper.go).
+//  2. Otherwise the stored SID (first boot generated + persisted) is loaded,
+//     keeping mapping stable across restarts.
+//  3. Otherwise a new random SID is generated and persisted.
+//
 // This MUST be called before any adapters are started.
 func (s *Service) initMachineSID(ctx context.Context, store MachineSIDStore) {
+	const machineSIDKey = "machine_sid"
+
+	// Operator pin takes precedence and is honored even without a settings
+	// store (ephemeral / test runtimes) so two nodes still derive identical
+	// SIDs from the same config.
+	if s.pinnedMachineSID != "" {
+		mapper, err := sid.NewSIDMapperFromString(s.pinnedMachineSID)
+		if err != nil {
+			logger.Error("Invalid pinned machine SID, ignoring and falling back",
+				"pinned", s.pinnedMachineSID, "error", err)
+		} else {
+			s.sidMapper = mapper
+			if store != nil {
+				prior, _ := store.GetSetting(ctx, machineSIDKey)
+				if prior != "" && prior != s.pinnedMachineSID {
+					logger.Warn("Pinned machine SID overrides a different stored value; foreign-SID mappings keyed on the old domain remain unaffected, but local UID->SID encoding changes",
+						"pinned", s.pinnedMachineSID, "stored", prior)
+				}
+				if prior != s.pinnedMachineSID {
+					if err := store.SetSetting(ctx, machineSIDKey, s.pinnedMachineSID); err != nil {
+						logger.Error("Failed to persist pinned machine SID", "sid", s.pinnedMachineSID, "error", err)
+					}
+				}
+			}
+			logger.Info("Using pinned machine SID", "sid", s.pinnedMachineSID)
+			return
+		}
+	}
+
 	if store == nil {
 		logger.Warn("No settings store available, generating ephemeral machine SID")
 		s.sidMapper = sid.GenerateMachineSID()
 		logger.Info("Generated ephemeral machine SID", "sid", s.sidMapper.MachineSIDString())
 		return
 	}
-
-	const machineSIDKey = "machine_sid"
 
 	stored, err := store.GetSetting(ctx, machineSIDKey)
 	if err != nil {

--- a/pkg/controlplane/runtime/lifecycle/service.go
+++ b/pkg/controlplane/runtime/lifecycle/service.go
@@ -140,12 +140,11 @@ func (s *Service) initMachineSID(ctx context.Context, store MachineSIDStore) err
 		}
 		s.sidMapper = mapper
 		if store != nil {
-			prior, _ := store.GetSetting(ctx, machineSIDKey)
-			if prior != "" && prior != s.pinnedMachineSID {
-				logger.Warn("Pinned machine SID overrides a different stored value; foreign-SID mappings keyed on the old domain remain unaffected, but local UID->SID encoding changes",
-					"pinned", s.pinnedMachineSID, "stored", prior)
-			}
-			if prior != s.pinnedMachineSID {
+			if prior, _ := store.GetSetting(ctx, machineSIDKey); prior != s.pinnedMachineSID {
+				if prior != "" {
+					logger.Warn("Pinned machine SID overrides a different stored value; foreign-SID mappings keyed on the old domain remain unaffected, but local UID->SID encoding changes",
+						"pinned", s.pinnedMachineSID, "stored", prior)
+				}
 				if err := store.SetSetting(ctx, machineSIDKey, s.pinnedMachineSID); err != nil {
 					logger.Error("Failed to persist pinned machine SID", "sid", s.pinnedMachineSID, "error", err)
 				}

--- a/pkg/controlplane/runtime/lifecycle/service.go
+++ b/pkg/controlplane/runtime/lifecycle/service.go
@@ -122,7 +122,7 @@ func (s *Service) SetPinnedMachineSID(machineSID string) {
 //  3. Otherwise a new random SID is generated and persisted.
 //
 // This MUST be called before any adapters are started.
-func (s *Service) initMachineSID(ctx context.Context, store MachineSIDStore) {
+func (s *Service) initMachineSID(ctx context.Context, store MachineSIDStore) error {
 	const machineSIDKey = "machine_sid"
 
 	// Operator pin takes precedence and is honored even without a settings
@@ -131,32 +131,35 @@ func (s *Service) initMachineSID(ctx context.Context, store MachineSIDStore) {
 	if s.pinnedMachineSID != "" {
 		mapper, err := sid.NewSIDMapperFromString(s.pinnedMachineSID)
 		if err != nil {
-			logger.Error("Invalid pinned machine SID, ignoring and falling back",
-				"pinned", s.pinnedMachineSID, "error", err)
-		} else {
-			s.sidMapper = mapper
-			if store != nil {
-				prior, _ := store.GetSetting(ctx, machineSIDKey)
-				if prior != "" && prior != s.pinnedMachineSID {
-					logger.Warn("Pinned machine SID overrides a different stored value; foreign-SID mappings keyed on the old domain remain unaffected, but local UID->SID encoding changes",
-						"pinned", s.pinnedMachineSID, "stored", prior)
-				}
-				if prior != s.pinnedMachineSID {
-					if err := store.SetSetting(ctx, machineSIDKey, s.pinnedMachineSID); err != nil {
-						logger.Error("Failed to persist pinned machine SID", "sid", s.pinnedMachineSID, "error", err)
-					}
+			// A pin is an explicit operator intent for cross-node parity.
+			// Silently falling back to a random SID would diverge this node's
+			// local UID->SID encoding from the rest of the cluster, so abort
+			// instead. The config layer normally rejects this earlier
+			// (IdentityConfig.Validate); this guards programmatic misuse.
+			return fmt.Errorf("invalid pinned machine SID %q: %w", s.pinnedMachineSID, err)
+		}
+		s.sidMapper = mapper
+		if store != nil {
+			prior, _ := store.GetSetting(ctx, machineSIDKey)
+			if prior != "" && prior != s.pinnedMachineSID {
+				logger.Warn("Pinned machine SID overrides a different stored value; foreign-SID mappings keyed on the old domain remain unaffected, but local UID->SID encoding changes",
+					"pinned", s.pinnedMachineSID, "stored", prior)
+			}
+			if prior != s.pinnedMachineSID {
+				if err := store.SetSetting(ctx, machineSIDKey, s.pinnedMachineSID); err != nil {
+					logger.Error("Failed to persist pinned machine SID", "sid", s.pinnedMachineSID, "error", err)
 				}
 			}
-			logger.Info("Using pinned machine SID", "sid", s.pinnedMachineSID)
-			return
 		}
+		logger.Info("Using pinned machine SID", "sid", s.pinnedMachineSID)
+		return nil
 	}
 
 	if store == nil {
 		logger.Warn("No settings store available, generating ephemeral machine SID")
 		s.sidMapper = sid.GenerateMachineSID()
 		logger.Info("Generated ephemeral machine SID", "sid", s.sidMapper.MachineSIDString())
-		return
+		return nil
 	}
 
 	stored, err := store.GetSetting(ctx, machineSIDKey)
@@ -174,7 +177,7 @@ func (s *Service) initMachineSID(ctx context.Context, store MachineSIDStore) {
 		} else {
 			s.sidMapper = mapper
 			logger.Info("Loaded machine SID from store", "sid", stored)
-			return
+			return nil
 		}
 	}
 
@@ -187,6 +190,7 @@ func (s *Service) initMachineSID(ctx context.Context, store MachineSIDStore) {
 	} else {
 		logger.Info("Generated and persisted machine SID", "sid", sidStr)
 	}
+	return nil
 }
 
 // SetAPIServer must be called before Serve().
@@ -243,7 +247,9 @@ func (s *Service) serve(
 
 	// Initialize machine SID BEFORE any adapters start.
 	// This ensures consistent identity mapping for all connections.
-	s.initMachineSID(ctx, machineSIDStore)
+	if err := s.initMachineSID(ctx, machineSIDStore); err != nil {
+		return fmt.Errorf("failed to initialize machine SID: %w", err)
+	}
 
 	if settings != nil {
 		if err := settings.LoadInitial(ctx); err != nil {

--- a/pkg/controlplane/runtime/lifecycle/service_test.go
+++ b/pkg/controlplane/runtime/lifecycle/service_test.go
@@ -298,3 +298,68 @@ func TestInitMachineSIDReadErrorGenerates(t *testing.T) {
 		t.Error("SID mapper should still be generated despite read error")
 	}
 }
+
+// A pinned machine SID is applied in preference to generation and persisted so
+// it is authoritative (AD-3 #1235).
+func TestInitMachineSIDPinnedApplied(t *testing.T) {
+	const pinned = "S-1-5-21-10-20-30"
+	s := New(0)
+	s.SetPinnedMachineSID(pinned)
+	store := &fakeSIDStore{vals: map[string]string{}}
+	s.initMachineSID(context.Background(), store)
+	if s.SIDMapper() == nil {
+		t.Fatal("SID mapper nil after pin")
+	}
+	if s.SIDMapper().MachineSIDString() != pinned {
+		t.Errorf("mapper SID = %q, want pinned %q", s.SIDMapper().MachineSIDString(), pinned)
+	}
+	if store.vals["machine_sid"] != pinned {
+		t.Errorf("pinned SID not persisted: got %q", store.vals["machine_sid"])
+	}
+}
+
+// A pinned SID overrides a different stored value (operator intent wins).
+func TestInitMachineSIDPinnedOverridesStored(t *testing.T) {
+	const pinned = "S-1-5-21-1-1-1"
+	s := New(0)
+	s.SetPinnedMachineSID(pinned)
+	store := &fakeSIDStore{vals: map[string]string{"machine_sid": "S-1-5-21-9-9-9"}}
+	s.initMachineSID(context.Background(), store)
+	if s.SIDMapper().MachineSIDString() != pinned {
+		t.Errorf("pinned SID did not override stored value: got %q", s.SIDMapper().MachineSIDString())
+	}
+	if store.vals["machine_sid"] != pinned {
+		t.Errorf("override not persisted: got %q", store.vals["machine_sid"])
+	}
+}
+
+// An invalid pinned SID is ignored and the normal generate/load path runs.
+func TestInitMachineSIDPinnedInvalidFallsBack(t *testing.T) {
+	s := New(0)
+	s.SetPinnedMachineSID("garbage")
+	store := &fakeSIDStore{vals: map[string]string{}}
+	s.initMachineSID(context.Background(), store)
+	if s.SIDMapper() == nil {
+		t.Fatal("SID mapper nil after invalid pin")
+	}
+	if s.SIDMapper().MachineSIDString() == "garbage" {
+		t.Error("invalid pin was applied verbatim")
+	}
+	if !store.setHit {
+		t.Error("fallback path should generate + persist")
+	}
+}
+
+// Two services pinned to the same SID produce identical mappers (node parity).
+func TestInitMachineSIDPinnedNodeParity(t *testing.T) {
+	const pinned = "S-1-5-21-7-7-7"
+	a, b := New(0), New(0)
+	a.SetPinnedMachineSID(pinned)
+	b.SetPinnedMachineSID(pinned)
+	a.initMachineSID(context.Background(), nil)
+	b.initMachineSID(context.Background(), nil)
+	if a.SIDMapper().MachineSIDString() != b.SIDMapper().MachineSIDString() {
+		t.Errorf("pinned nodes diverge: %q vs %q",
+			a.SIDMapper().MachineSIDString(), b.SIDMapper().MachineSIDString())
+	}
+}

--- a/pkg/controlplane/runtime/lifecycle/service_test.go
+++ b/pkg/controlplane/runtime/lifecycle/service_test.go
@@ -240,12 +240,12 @@ func TestServeOnlyRunsOnce(t *testing.T) {
 // one when a valid value is stored.
 func TestInitMachineSIDLoadsStored(t *testing.T) {
 	gen := New(0)
-	gen.initMachineSID(context.Background(), nil)
+	mustInitMachineSID(t, gen, nil)
 	stored := gen.SIDMapper().MachineSIDString()
 
 	s := New(0)
 	store := &fakeSIDStore{vals: map[string]string{"machine_sid": stored}}
-	s.initMachineSID(context.Background(), store)
+	mustInitMachineSID(t, s, store)
 	if s.SIDMapper() == nil {
 		t.Fatal("SID mapper nil after load")
 	}
@@ -261,7 +261,7 @@ func TestInitMachineSIDLoadsStored(t *testing.T) {
 func TestInitMachineSIDFirstBootPersists(t *testing.T) {
 	s := New(0)
 	store := &fakeSIDStore{vals: map[string]string{}}
-	s.initMachineSID(context.Background(), store)
+	mustInitMachineSID(t, s, store)
 	if s.SIDMapper() == nil {
 		t.Fatal("SID mapper nil")
 	}
@@ -277,7 +277,7 @@ func TestInitMachineSIDFirstBootPersists(t *testing.T) {
 func TestInitMachineSIDInvalidStoredRegenerates(t *testing.T) {
 	s := New(0)
 	store := &fakeSIDStore{vals: map[string]string{"machine_sid": "not-a-valid-sid"}}
-	s.initMachineSID(context.Background(), store)
+	mustInitMachineSID(t, s, store)
 	if s.SIDMapper() == nil {
 		t.Fatal("SID mapper nil after invalid stored value")
 	}
@@ -293,7 +293,7 @@ func TestInitMachineSIDInvalidStoredRegenerates(t *testing.T) {
 func TestInitMachineSIDReadErrorGenerates(t *testing.T) {
 	s := New(0)
 	store := &fakeSIDStore{getErr: errors.New("db down")}
-	s.initMachineSID(context.Background(), store)
+	mustInitMachineSID(t, s, store)
 	if s.SIDMapper() == nil {
 		t.Error("SID mapper should still be generated despite read error")
 	}
@@ -306,7 +306,7 @@ func TestInitMachineSIDPinnedApplied(t *testing.T) {
 	s := New(0)
 	s.SetPinnedMachineSID(pinned)
 	store := &fakeSIDStore{vals: map[string]string{}}
-	s.initMachineSID(context.Background(), store)
+	mustInitMachineSID(t, s, store)
 	if s.SIDMapper() == nil {
 		t.Fatal("SID mapper nil after pin")
 	}
@@ -324,7 +324,7 @@ func TestInitMachineSIDPinnedOverridesStored(t *testing.T) {
 	s := New(0)
 	s.SetPinnedMachineSID(pinned)
 	store := &fakeSIDStore{vals: map[string]string{"machine_sid": "S-1-5-21-9-9-9"}}
-	s.initMachineSID(context.Background(), store)
+	mustInitMachineSID(t, s, store)
 	if s.SIDMapper().MachineSIDString() != pinned {
 		t.Errorf("pinned SID did not override stored value: got %q", s.SIDMapper().MachineSIDString())
 	}
@@ -358,10 +358,19 @@ func TestInitMachineSIDPinnedNodeParity(t *testing.T) {
 	a, b := New(0), New(0)
 	a.SetPinnedMachineSID(pinned)
 	b.SetPinnedMachineSID(pinned)
-	a.initMachineSID(context.Background(), nil)
-	b.initMachineSID(context.Background(), nil)
+	mustInitMachineSID(t, a, nil)
+	mustInitMachineSID(t, b, nil)
 	if a.SIDMapper().MachineSIDString() != b.SIDMapper().MachineSIDString() {
 		t.Errorf("pinned nodes diverge: %q vs %q",
 			a.SIDMapper().MachineSIDString(), b.SIDMapper().MachineSIDString())
+	}
+}
+
+// mustInitMachineSID runs initMachineSID and fails the test on the error path,
+// for the success-path cases where a returned error is unexpected.
+func mustInitMachineSID(t *testing.T, s *Service, store MachineSIDStore) {
+	t.Helper()
+	if err := s.initMachineSID(context.Background(), store); err != nil {
+		t.Fatalf("initMachineSID: %v", err)
 	}
 }

--- a/pkg/controlplane/runtime/lifecycle/service_test.go
+++ b/pkg/controlplane/runtime/lifecycle/service_test.go
@@ -333,20 +333,22 @@ func TestInitMachineSIDPinnedOverridesStored(t *testing.T) {
 	}
 }
 
-// An invalid pinned SID is ignored and the normal generate/load path runs.
-func TestInitMachineSIDPinnedInvalidFallsBack(t *testing.T) {
+// An invalid pinned SID aborts initialization rather than silently falling
+// back to a random SID — a bad pin is an explicit operator error that would
+// otherwise diverge this node's local UID->SID encoding from the cluster.
+func TestInitMachineSIDPinnedInvalidFails(t *testing.T) {
 	s := New(0)
 	s.SetPinnedMachineSID("garbage")
 	store := &fakeSIDStore{vals: map[string]string{}}
-	s.initMachineSID(context.Background(), store)
-	if s.SIDMapper() == nil {
-		t.Fatal("SID mapper nil after invalid pin")
+	err := s.initMachineSID(context.Background(), store)
+	if err == nil {
+		t.Fatal("invalid pin must return an error, not fall back")
 	}
-	if s.SIDMapper().MachineSIDString() == "garbage" {
-		t.Error("invalid pin was applied verbatim")
+	if s.SIDMapper() != nil {
+		t.Error("no SID mapper should be set when the pin is invalid")
 	}
-	if !store.setHit {
-		t.Error("fallback path should generate + persist")
+	if store.setHit {
+		t.Error("invalid pin must not generate + persist a fallback SID")
 	}
 }
 

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -746,6 +746,14 @@ func (r *Runtime) GetMetadataService() *metadata.Service { return r.metadataServ
 // Returns nil if the runtime has not been started yet (Serve not called).
 func (r *Runtime) SIDMapper() *sid.SIDMapper { return r.lifecycleSvc.SIDMapper() }
 
+// SetPinnedMachineSID seeds an operator-supplied machine SID (config/env) used
+// during Serve(). Must be called before Serve(). Empty string is a no-op.
+// Pinning the same SID on every node makes their local UID->SID mapping
+// identical (cross-node identity parity).
+func (r *Runtime) SetPinnedMachineSID(machineSID string) {
+	r.lifecycleSvc.SetPinnedMachineSID(machineSID)
+}
+
 // SetLocalStoreDefaults sets the default sizing for per-share local stores.
 func (r *Runtime) SetLocalStoreDefaults(cfg *shares.LocalStoreDefaults) {
 	r.mu.Lock()

--- a/pkg/controlplane/store/interface.go
+++ b/pkg/controlplane/store/interface.go
@@ -57,6 +57,11 @@ type UserStore interface {
 	// Returns models.ErrUserNotFound if the user doesn't exist.
 	UpdateUser(ctx context.Context, user *models.User) error
 
+	// UpdateUserSIDInfo persists only the Windows identity (SID + group SIDs)
+	// resolved by a login flow, without touching other profile fields.
+	// Returns models.ErrUserNotFound if the user doesn't exist.
+	UpdateUserSIDInfo(ctx context.Context, username, sid string, groupSIDs []string) error
+
 	// DeleteUser deletes a user by username.
 	// Returns models.ErrUserNotFound if the user doesn't exist.
 	// Also deletes all share permissions for the user.
@@ -758,4 +763,5 @@ type Store interface {
 	SnapshotPolicyStore
 	RestoreMarkerStore
 	HealthStore
+	SIDMappingStore
 }

--- a/pkg/controlplane/store/interface.go
+++ b/pkg/controlplane/store/interface.go
@@ -728,6 +728,12 @@ type SIDMappingStore interface {
 	// ListSIDMappings returns all durable foreign-SID mappings.
 	ListSIDMappings(ctx context.Context) ([]*models.SIDMapping, error)
 
+	// GetSIDMappingsByIDs returns the durable mappings for the given SIDs in a
+	// single query, keyed by SID. SIDs without a mapping are simply absent from
+	// the result (no error) — avoids an N+1 lookup when enriching a user with
+	// many group SIDs.
+	GetSIDMappingsByIDs(ctx context.Context, sids []string) (map[string]*models.SIDMapping, error)
+
 	// AllocateSIDMapping idempotently binds a foreign SID to a Unix UID/GID.
 	// If a mapping already exists, the existing one is returned unchanged
 	// (never remapped). The first caller wins under concurrency.

--- a/pkg/controlplane/store/interface.go
+++ b/pkg/controlplane/store/interface.go
@@ -709,6 +709,30 @@ type IdentityMappingStore interface {
 	ListIdentityMappingsForUser(ctx context.Context, username string) ([]*models.IdentityMapping, error)
 }
 
+// SIDMappingStore provides durable foreign-SID -> Unix UID/GID allocation.
+//
+// It is a separate interface from Store (mirroring IdentityMappingStore) so
+// only identity-aware components depend on it. Local/algorithmic SIDs are not
+// stored here — only foreign AD/LDAP domain SIDs that cannot be derived from a
+// local UID. Allocation is idempotent and never remaps an existing SID.
+type SIDMappingStore interface {
+	// GetSIDMapping returns the durable mapping for a foreign domain SID.
+	// Returns models.ErrSIDMappingNotFound if none exists.
+	GetSIDMapping(ctx context.Context, sid string) (*models.SIDMapping, error)
+
+	// ListSIDMappings returns all durable foreign-SID mappings.
+	ListSIDMappings(ctx context.Context) ([]*models.SIDMapping, error)
+
+	// AllocateSIDMapping idempotently binds a foreign SID to a Unix UID/GID.
+	// If a mapping already exists, the existing one is returned unchanged
+	// (never remapped). The first caller wins under concurrency.
+	AllocateSIDMapping(ctx context.Context, sid string, unixID uint32, isGroup bool, displayName string) (*models.SIDMapping, error)
+
+	// DeleteSIDMapping removes a mapping (administrative cleanup only).
+	// Returns models.ErrSIDMappingNotFound if none exists.
+	DeleteSIDMapping(ctx context.Context, sid string) error
+}
+
 // Store is the composite control plane persistence interface.
 //
 // It embeds all sub-interfaces to provide the full set of operations.

--- a/pkg/controlplane/store/sid_mapping.go
+++ b/pkg/controlplane/store/sid_mapping.go
@@ -23,6 +23,24 @@ func (s *GORMStore) ListSIDMappings(ctx context.Context) ([]*models.SIDMapping, 
 	return listAll[models.SIDMapping](s.db, ctx)
 }
 
+// GetSIDMappingsByIDs returns the durable mappings for the given SIDs in a
+// single `WHERE sid IN (...)` query, keyed by SID. Unmapped SIDs are absent
+// from the result.
+func (s *GORMStore) GetSIDMappingsByIDs(ctx context.Context, sids []string) (map[string]*models.SIDMapping, error) {
+	out := make(map[string]*models.SIDMapping, len(sids))
+	if len(sids) == 0 {
+		return out, nil
+	}
+	var rows []models.SIDMapping
+	if err := s.db.WithContext(ctx).Where("sid IN ?", sids).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	for i := range rows {
+		out[rows[i].SID] = &rows[i]
+	}
+	return out, nil
+}
+
 // AllocateSIDMapping idempotently binds a foreign domain SID to a stable Unix
 // UID/GID and returns the durable mapping.
 //

--- a/pkg/controlplane/store/sid_mapping.go
+++ b/pkg/controlplane/store/sid_mapping.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"context"
-	"errors"
 
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"gorm.io/gorm/clause"
@@ -38,11 +37,13 @@ func (s *GORMStore) ListSIDMappings(ctx context.Context) ([]*models.SIDMapping, 
 // ON CONFLICT DO NOTHING and the row is re-read, so a racing caller observes
 // the winner's allocation rather than overwriting it.
 func (s *GORMStore) AllocateSIDMapping(ctx context.Context, sid string, unixID uint32, isGroup bool, displayName string) (*models.SIDMapping, error) {
-	// Fast path: return any existing binding without touching it.
+	// Fast path: return any existing binding without touching it. A transient
+	// read error here is deliberately non-fatal — the authoritative
+	// insert(ON CONFLICT DO NOTHING)+re-read below resolves the binding either
+	// way, so a flaky read must not fail an allocation that would otherwise
+	// succeed (this path is on the LDAP/PAC login hot path).
 	if existing, err := s.GetSIDMapping(ctx, sid); err == nil {
 		return existing, nil
-	} else if !errors.Is(err, models.ErrSIDMappingNotFound) {
-		return nil, err
 	}
 
 	row := &models.SIDMapping{

--- a/pkg/controlplane/store/sid_mapping.go
+++ b/pkg/controlplane/store/sid_mapping.go
@@ -1,0 +1,77 @@
+package store
+
+import (
+	"context"
+	"errors"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"gorm.io/gorm/clause"
+)
+
+// GetSIDMapping returns the durable mapping for a foreign domain SID.
+// Returns models.ErrSIDMappingNotFound when no mapping exists.
+func (s *GORMStore) GetSIDMapping(ctx context.Context, sid string) (*models.SIDMapping, error) {
+	var m models.SIDMapping
+	err := s.db.WithContext(ctx).Where("sid = ?", sid).First(&m).Error
+	if err != nil {
+		return nil, convertNotFoundError(err, models.ErrSIDMappingNotFound)
+	}
+	return &m, nil
+}
+
+// ListSIDMappings returns all durable foreign-SID mappings.
+func (s *GORMStore) ListSIDMappings(ctx context.Context) ([]*models.SIDMapping, error) {
+	return listAll[models.SIDMapping](s.db, ctx)
+}
+
+// AllocateSIDMapping idempotently binds a foreign domain SID to a stable Unix
+// UID/GID and returns the durable mapping.
+//
+// The binding is keyed on the full SID and is allocated EXACTLY ONCE: if a
+// mapping already exists for the SID, the existing UnixID/IsGroup is returned
+// unchanged regardless of the requested value. This enforces the never-remap
+// invariant — re-resolving a foreign SID always yields the same identity, so a
+// principal can never be silently re-attributed to files owned by a different
+// UID/GID.
+//
+// The first caller for a given SID wins under concurrency: the insert uses
+// ON CONFLICT DO NOTHING and the row is re-read, so a racing caller observes
+// the winner's allocation rather than overwriting it.
+func (s *GORMStore) AllocateSIDMapping(ctx context.Context, sid string, unixID uint32, isGroup bool, displayName string) (*models.SIDMapping, error) {
+	// Fast path: return any existing binding without touching it.
+	if existing, err := s.GetSIDMapping(ctx, sid); err == nil {
+		return existing, nil
+	} else if !errors.Is(err, models.ErrSIDMappingNotFound) {
+		return nil, err
+	}
+
+	row := &models.SIDMapping{
+		SID:         sid,
+		UnixID:      unixID,
+		IsGroup:     isGroup,
+		DisplayName: displayName,
+	}
+
+	// ON CONFLICT DO NOTHING: if a concurrent caller inserted the same SID
+	// between our read and this write, we do NOT overwrite their allocation.
+	res := s.db.WithContext(ctx).
+		Clauses(clause.OnConflict{Columns: []clause.Column{{Name: "sid"}}, DoNothing: true}).
+		Create(row)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+
+	// Re-read so that on a conflict (RowsAffected == 0) we return the winner's
+	// durable mapping, not the rejected candidate.
+	return s.GetSIDMapping(ctx, sid)
+}
+
+// DeleteSIDMapping removes a foreign-SID mapping. Intended for administrative
+// cleanup only — normal resolution never deletes mappings (never-remap).
+// Returns models.ErrSIDMappingNotFound when no mapping exists.
+func (s *GORMStore) DeleteSIDMapping(ctx context.Context, sid string) error {
+	return deleteByField[models.SIDMapping](s.db, ctx, "sid", sid, models.ErrSIDMappingNotFound)
+}
+
+// Compile-time assertion that GORMStore satisfies SIDMappingStore.
+var _ SIDMappingStore = (*GORMStore)(nil)

--- a/pkg/controlplane/store/sid_mapping_test.go
+++ b/pkg/controlplane/store/sid_mapping_test.go
@@ -5,17 +5,14 @@ package store
 import (
 	"context"
 	"errors"
-	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 )
 
 // sidBackend names a control-plane store backend the conformance test runs
-// against. SQLite always runs; postgres runs only when the DSN is present.
+// against.
 type sidBackend struct {
 	name string
 	// open returns a freshly-opened store pointing at the SAME durable
@@ -24,11 +21,15 @@ type sidBackend struct {
 	open func(t *testing.T) *GORMStore
 }
 
-// sidBackends returns the backends to exercise. SQLite uses a file (NOT
-// :memory:, which is wiped on close) so reopen tests observe durable state.
+// sidBackends returns the backends to exercise. The control-plane store is
+// tested on SQLite — the same dialect every other store_test in this package
+// uses — with a file-backed DB (NOT :memory:, which is wiped on close) so the
+// reopen tests observe durable state. Postgres parity for the GORM models is
+// covered by the production AutoMigrate path; this package has no isolated
+// postgres harness (the shared CI database is contended by other suites).
 func sidBackends(t *testing.T) []sidBackend {
 	t.Helper()
-	backends := []sidBackend{
+	return []sidBackend{
 		{
 			name: "sqlite",
 			open: func(t *testing.T) *GORMStore {
@@ -36,31 +37,6 @@ func sidBackends(t *testing.T) []sidBackend {
 			},
 		},
 	}
-
-	if dsn := os.Getenv("DITTOFS_TEST_POSTGRES_DSN"); dsn != "" {
-		cfg := postgresConfigFromDSN(t, dsn)
-		// Clean the SID/identity tables once so a prior run can't leak rows.
-		// Fail fast on cleanup errors rather than letting leftover rows cause
-		// confusing downstream flakes.
-		cleanup := openPostgresStore(t, cfg)
-		if err := cleanup.db.Exec("DELETE FROM sid_mappings").Error; err != nil {
-			t.Fatalf("cleanup sid_mappings: %v", err)
-		}
-		if err := cleanup.db.Exec("DELETE FROM users").Error; err != nil {
-			t.Fatalf("cleanup users: %v", err)
-		}
-		if err := cleanup.Close(); err != nil {
-			t.Fatalf("close cleanup store: %v", err)
-		}
-		backends = append(backends, sidBackend{
-			name: "postgres",
-			open: func(t *testing.T) *GORMStore {
-				return openPostgresStore(t, cfg)
-			},
-		})
-	}
-
-	return backends
 }
 
 // openSQLiteFileStore opens a file-backed SQLite store under t.TempDir() so the
@@ -93,49 +69,6 @@ func sqliteDirForTest(t *testing.T) string {
 	sqliteDirs[t] = d
 	t.Cleanup(func() { delete(sqliteDirs, t) })
 	return d
-}
-
-func openPostgresStore(t *testing.T, cfg *Config) *GORMStore {
-	t.Helper()
-	st, err := New(cfg)
-	if err != nil {
-		t.Fatalf("open postgres store: %v", err)
-	}
-	return st
-}
-
-// postgresConfigFromDSN parses a libpq key=value DSN into a store Config.
-func postgresConfigFromDSN(t *testing.T, dsn string) *Config {
-	t.Helper()
-	pc := PostgresConfig{Host: "localhost", Port: 5432, SSLMode: "disable"}
-	for _, field := range strings.Fields(dsn) {
-		kv := strings.SplitN(field, "=", 2)
-		if len(kv) != 2 {
-			continue
-		}
-		switch kv[0] {
-		case "host":
-			pc.Host = kv[1]
-		case "port":
-			p, err := strconv.Atoi(kv[1])
-			if err != nil {
-				t.Fatalf("parse DSN port %q: %v", kv[1], err)
-			}
-			pc.Port = p
-		case "dbname", "database":
-			pc.Database = kv[1]
-		case "user":
-			pc.User = kv[1]
-		case "password":
-			pc.Password = kv[1]
-		case "sslmode", "ssl_mode":
-			pc.SSLMode = kv[1]
-		}
-	}
-	if pc.Database == "" {
-		t.Fatalf("DITTOFS_TEST_POSTGRES_DSN %q has no dbname", dsn)
-	}
-	return &Config{Type: DatabaseTypePostgres, Postgres: pc}
 }
 
 // TestSIDMapping_RoundTripAndRestart covers the AD-3 acceptance: a foreign SID

--- a/pkg/controlplane/store/sid_mapping_test.go
+++ b/pkg/controlplane/store/sid_mapping_test.go
@@ -1,0 +1,313 @@
+//go:build integration
+
+package store
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// sidBackend names a control-plane store backend the conformance test runs
+// against. SQLite always runs; postgres runs only when the DSN is present.
+type sidBackend struct {
+	name string
+	// open returns a freshly-opened store pointing at the SAME durable
+	// database each time it is called, so a re-open simulates a process
+	// restart. Callers must Close the returned store.
+	open func(t *testing.T) *GORMStore
+}
+
+// sidBackends returns the backends to exercise. SQLite uses a file (NOT
+// :memory:, which is wiped on close) so reopen tests observe durable state.
+func sidBackends(t *testing.T) []sidBackend {
+	t.Helper()
+	backends := []sidBackend{
+		{
+			name: "sqlite",
+			open: func(t *testing.T) *GORMStore {
+				return openSQLiteFileStore(t)
+			},
+		},
+	}
+
+	if dsn := os.Getenv("DITTOFS_TEST_POSTGRES_DSN"); dsn != "" {
+		cfg := postgresConfigFromDSN(t, dsn)
+		// Clean the SID/identity tables once so a prior run can't leak rows.
+		cleanup := openPostgresStore(t, cfg)
+		_ = cleanup.db.Exec("DELETE FROM sid_mappings").Error
+		_ = cleanup.db.Exec("DELETE FROM users").Error
+		_ = cleanup.Close()
+		backends = append(backends, sidBackend{
+			name: "postgres",
+			open: func(t *testing.T) *GORMStore {
+				return openPostgresStore(t, cfg)
+			},
+		})
+	}
+
+	return backends
+}
+
+// openSQLiteFileStore opens a file-backed SQLite store under t.TempDir() so the
+// same path can be reopened to simulate a restart. The file path is stashed on
+// the test so repeated open() calls in one subtest hit the same DB.
+func openSQLiteFileStore(t *testing.T) *GORMStore {
+	t.Helper()
+	dir := sqliteDirForTest(t)
+	st, err := New(&Config{
+		Type:   DatabaseTypeSQLite,
+		SQLite: SQLiteConfig{Path: filepath.Join(dir, "controlplane.db")},
+	})
+	if err != nil {
+		t.Fatalf("open sqlite file store: %v", err)
+	}
+	return st
+}
+
+// sqliteDirForTest returns a per-subtest stable temp dir. t.TempDir() returns a
+// fresh dir per call, so cache the first one on a closure-scoped map keyed by
+// the test pointer via a sub-helper.
+var sqliteDirs = map[*testing.T]string{}
+
+func sqliteDirForTest(t *testing.T) string {
+	t.Helper()
+	if d, ok := sqliteDirs[t]; ok {
+		return d
+	}
+	d := t.TempDir()
+	sqliteDirs[t] = d
+	t.Cleanup(func() { delete(sqliteDirs, t) })
+	return d
+}
+
+func openPostgresStore(t *testing.T, cfg *Config) *GORMStore {
+	t.Helper()
+	st, err := New(cfg)
+	if err != nil {
+		t.Fatalf("open postgres store: %v", err)
+	}
+	return st
+}
+
+// postgresConfigFromDSN parses a libpq key=value DSN into a store Config.
+func postgresConfigFromDSN(t *testing.T, dsn string) *Config {
+	t.Helper()
+	pc := PostgresConfig{Host: "localhost", Port: 5432, SSLMode: "disable"}
+	for _, field := range strings.Fields(dsn) {
+		kv := strings.SplitN(field, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		switch kv[0] {
+		case "host":
+			pc.Host = kv[1]
+		case "port":
+			p, err := strconv.Atoi(kv[1])
+			if err != nil {
+				t.Fatalf("parse DSN port %q: %v", kv[1], err)
+			}
+			pc.Port = p
+		case "dbname", "database":
+			pc.Database = kv[1]
+		case "user":
+			pc.User = kv[1]
+		case "password":
+			pc.Password = kv[1]
+		case "sslmode", "ssl_mode":
+			pc.SSLMode = kv[1]
+		}
+	}
+	if pc.Database == "" {
+		t.Fatalf("DITTOFS_TEST_POSTGRES_DSN %q has no dbname", dsn)
+	}
+	return &Config{Type: DatabaseTypePostgres, Postgres: pc}
+}
+
+// TestSIDMapping_RoundTripAndRestart covers the AD-3 acceptance: a foreign SID
+// binds to a stable UID/GID, round-trips, and survives a store reopen.
+func TestSIDMapping_RoundTripAndRestart(t *testing.T) {
+	ctx := context.Background()
+	for _, be := range sidBackends(t) {
+		t.Run(be.name, func(t *testing.T) {
+			st := be.open(t)
+
+			const userSID = "S-1-5-21-111-222-333-1107"
+			const groupSID = "S-1-5-21-111-222-333-2050"
+
+			uMap, err := st.AllocateSIDMapping(ctx, userSID, 7001, false, "alice")
+			if err != nil {
+				t.Fatalf("allocate user SID: %v", err)
+			}
+			if uMap.UnixID != 7001 || uMap.IsGroup {
+				t.Fatalf("user mapping wrong: %+v", uMap)
+			}
+
+			gMap, err := st.AllocateSIDMapping(ctx, groupSID, 8001, true, "eng")
+			if err != nil {
+				t.Fatalf("allocate group SID: %v", err)
+			}
+			if gMap.UnixID != 8001 || !gMap.IsGroup {
+				t.Fatalf("group mapping wrong: %+v", gMap)
+			}
+
+			// Reopen the SAME durable store: mappings must reload unchanged.
+			if err := st.Close(); err != nil {
+				t.Fatalf("close: %v", err)
+			}
+			st2 := be.open(t)
+			defer st2.Close()
+
+			got, err := st2.GetSIDMapping(ctx, userSID)
+			if err != nil {
+				t.Fatalf("get user SID after restart: %v", err)
+			}
+			if got.UnixID != 7001 || got.IsGroup {
+				t.Errorf("user mapping changed after restart: %+v", got)
+			}
+
+			gotG, err := st2.GetSIDMapping(ctx, groupSID)
+			if err != nil {
+				t.Fatalf("get group SID after restart: %v", err)
+			}
+			if gotG.UnixID != 8001 || !gotG.IsGroup {
+				t.Errorf("group mapping changed after restart: %+v", gotG)
+			}
+		})
+	}
+}
+
+// TestSIDMapping_NeverRemap is the data-exposure invariant: re-allocating an
+// existing foreign SID with a DIFFERENT UID returns the original, never remaps.
+func TestSIDMapping_NeverRemap(t *testing.T) {
+	ctx := context.Background()
+	for _, be := range sidBackends(t) {
+		t.Run(be.name, func(t *testing.T) {
+			st := be.open(t)
+			defer st.Close()
+
+			const sid = "S-1-5-21-9-8-7-1500"
+			first, err := st.AllocateSIDMapping(ctx, sid, 5000, false, "")
+			if err != nil {
+				t.Fatalf("first allocate: %v", err)
+			}
+
+			// Attempt a remap to a different UID and to group=true.
+			second, err := st.AllocateSIDMapping(ctx, sid, 6000, true, "evil")
+			if err != nil {
+				t.Fatalf("second allocate: %v", err)
+			}
+			if second.UnixID != first.UnixID {
+				t.Errorf("SID remapped: first UID=%d second UID=%d (must be equal)", first.UnixID, second.UnixID)
+			}
+			if second.IsGroup != first.IsGroup {
+				t.Errorf("SID class flipped: first IsGroup=%v second=%v", first.IsGroup, second.IsGroup)
+			}
+
+			got, err := st.GetSIDMapping(ctx, sid)
+			if err != nil {
+				t.Fatalf("get after remap attempt: %v", err)
+			}
+			if got.UnixID != 5000 || got.IsGroup {
+				t.Errorf("stored mapping mutated: %+v (want UID=5000, group=false)", got)
+			}
+		})
+	}
+}
+
+// TestSIDMapping_NotFoundAndDelete covers the sentinel + admin delete path.
+func TestSIDMapping_NotFoundAndDelete(t *testing.T) {
+	ctx := context.Background()
+	for _, be := range sidBackends(t) {
+		t.Run(be.name, func(t *testing.T) {
+			st := be.open(t)
+			defer st.Close()
+
+			if _, err := st.GetSIDMapping(ctx, "S-1-5-21-0-0-0-9999"); !errors.Is(err, models.ErrSIDMappingNotFound) {
+				t.Errorf("missing SID err = %v, want ErrSIDMappingNotFound", err)
+			}
+			if err := st.DeleteSIDMapping(ctx, "S-1-5-21-0-0-0-9999"); !errors.Is(err, models.ErrSIDMappingNotFound) {
+				t.Errorf("delete missing SID err = %v, want ErrSIDMappingNotFound", err)
+			}
+
+			const sid = "S-1-5-21-1-2-3-2200"
+			if _, err := st.AllocateSIDMapping(ctx, sid, 4242, true, ""); err != nil {
+				t.Fatalf("allocate: %v", err)
+			}
+			if err := st.DeleteSIDMapping(ctx, sid); err != nil {
+				t.Fatalf("delete: %v", err)
+			}
+			if _, err := st.GetSIDMapping(ctx, sid); !errors.Is(err, models.ErrSIDMappingNotFound) {
+				t.Errorf("after delete err = %v, want ErrSIDMappingNotFound", err)
+			}
+		})
+	}
+}
+
+// TestUserSIDPersistence covers the User.SID / User.GroupSIDs persistence
+// acceptance: both survive create, update, and a store reopen.
+func TestUserSIDPersistence(t *testing.T) {
+	ctx := context.Background()
+	for _, be := range sidBackends(t) {
+		t.Run(be.name, func(t *testing.T) {
+			st := be.open(t)
+
+			uid := uint32(4000)
+			gid := uint32(4000)
+			user := &models.User{
+				Username:     "winuser",
+				PasswordHash: "x",
+				UID:          &uid,
+				GID:          &gid,
+				SID:          "S-1-5-21-50-60-70-9001",
+				GroupSIDs:    []string{"S-1-5-21-50-60-70-9100", "S-1-5-21-50-60-70-9101"},
+			}
+			if _, err := st.CreateUser(ctx, user); err != nil {
+				t.Fatalf("create user: %v", err)
+			}
+
+			// Reload after a restart and confirm SID/GroupSIDs persisted.
+			if err := st.Close(); err != nil {
+				t.Fatalf("close: %v", err)
+			}
+			st2 := be.open(t)
+			defer st2.Close()
+
+			got, err := st2.GetUser(ctx, "winuser")
+			if err != nil {
+				t.Fatalf("get user after restart: %v", err)
+			}
+			if got.SID != "S-1-5-21-50-60-70-9001" {
+				t.Errorf("SID not persisted: got %q", got.SID)
+			}
+			if len(got.GroupSIDs) != 2 ||
+				got.GroupSIDs[0] != "S-1-5-21-50-60-70-9100" ||
+				got.GroupSIDs[1] != "S-1-5-21-50-60-70-9101" {
+				t.Errorf("GroupSIDs not persisted: got %v", got.GroupSIDs)
+			}
+
+			// UpdateUser must also persist a changed SID/GroupSIDs.
+			got.SID = "S-1-5-21-50-60-70-9999"
+			got.GroupSIDs = []string{"S-1-5-21-50-60-70-9200"}
+			if err := st2.UpdateUser(ctx, got); err != nil {
+				t.Fatalf("update user: %v", err)
+			}
+			reloaded, err := st2.GetUser(ctx, "winuser")
+			if err != nil {
+				t.Fatalf("get user after update: %v", err)
+			}
+			if reloaded.SID != "S-1-5-21-50-60-70-9999" {
+				t.Errorf("updated SID not persisted: got %q", reloaded.SID)
+			}
+			if len(reloaded.GroupSIDs) != 1 || reloaded.GroupSIDs[0] != "S-1-5-21-50-60-70-9200" {
+				t.Errorf("updated GroupSIDs not persisted: got %v", reloaded.GroupSIDs)
+			}
+		})
+	}
+}

--- a/pkg/controlplane/store/sid_mapping_test.go
+++ b/pkg/controlplane/store/sid_mapping_test.go
@@ -292,11 +292,11 @@ func TestUserSIDPersistence(t *testing.T) {
 				t.Errorf("GroupSIDs not persisted: got %v", got.GroupSIDs)
 			}
 
-			// UpdateUser must also persist a changed SID/GroupSIDs.
-			got.SID = "S-1-5-21-50-60-70-9999"
-			got.GroupSIDs = []string{"S-1-5-21-50-60-70-9200"}
-			if err := st2.UpdateUser(ctx, got); err != nil {
-				t.Fatalf("update user: %v", err)
+			// UpdateUserSIDInfo persists a changed SID/GroupSIDs without
+			// reloading or touching the rest of the user.
+			if err := st2.UpdateUserSIDInfo(ctx, "winuser",
+				"S-1-5-21-50-60-70-9999", []string{"S-1-5-21-50-60-70-9200"}); err != nil {
+				t.Fatalf("update user SID info: %v", err)
 			}
 			reloaded, err := st2.GetUser(ctx, "winuser")
 			if err != nil {
@@ -307,6 +307,29 @@ func TestUserSIDPersistence(t *testing.T) {
 			}
 			if len(reloaded.GroupSIDs) != 1 || reloaded.GroupSIDs[0] != "S-1-5-21-50-60-70-9200" {
 				t.Errorf("updated GroupSIDs not persisted: got %v", reloaded.GroupSIDs)
+			}
+
+			// A general UpdateUser with a partial user (no GroupSIDs) must NOT
+			// erase the persisted Windows identity (F4 regression guard).
+			profile, err := st2.GetUser(ctx, "winuser")
+			if err != nil {
+				t.Fatalf("get user before profile update: %v", err)
+			}
+			profile.GroupSIDs = nil
+			profile.SID = ""
+			profile.DisplayName = "Win User"
+			if err := st2.UpdateUser(ctx, profile); err != nil {
+				t.Fatalf("update user profile: %v", err)
+			}
+			afterProfile, err := st2.GetUser(ctx, "winuser")
+			if err != nil {
+				t.Fatalf("get user after profile update: %v", err)
+			}
+			if afterProfile.SID != "S-1-5-21-50-60-70-9999" {
+				t.Errorf("profile UpdateUser clobbered SID: got %q", afterProfile.SID)
+			}
+			if len(afterProfile.GroupSIDs) != 1 {
+				t.Errorf("profile UpdateUser clobbered GroupSIDs: got %v", afterProfile.GroupSIDs)
 			}
 		})
 	}

--- a/pkg/controlplane/store/sid_mapping_test.go
+++ b/pkg/controlplane/store/sid_mapping_test.go
@@ -40,10 +40,18 @@ func sidBackends(t *testing.T) []sidBackend {
 	if dsn := os.Getenv("DITTOFS_TEST_POSTGRES_DSN"); dsn != "" {
 		cfg := postgresConfigFromDSN(t, dsn)
 		// Clean the SID/identity tables once so a prior run can't leak rows.
+		// Fail fast on cleanup errors rather than letting leftover rows cause
+		// confusing downstream flakes.
 		cleanup := openPostgresStore(t, cfg)
-		_ = cleanup.db.Exec("DELETE FROM sid_mappings").Error
-		_ = cleanup.db.Exec("DELETE FROM users").Error
-		_ = cleanup.Close()
+		if err := cleanup.db.Exec("DELETE FROM sid_mappings").Error; err != nil {
+			t.Fatalf("cleanup sid_mappings: %v", err)
+		}
+		if err := cleanup.db.Exec("DELETE FROM users").Error; err != nil {
+			t.Fatalf("cleanup users: %v", err)
+		}
+		if err := cleanup.Close(); err != nil {
+			t.Fatalf("close cleanup store: %v", err)
+		}
 		backends = append(backends, sidBackend{
 			name: "postgres",
 			open: func(t *testing.T) *GORMStore {

--- a/pkg/controlplane/store/users.go
+++ b/pkg/controlplane/store/users.go
@@ -93,12 +93,35 @@ func (s *GORMStore) UpdateUser(ctx context.Context, user *models.User) error {
 	}
 
 	// Update specific fields using Select to handle pointers properly.
-	// SID/GroupSIDs are included so a login flow that enriches the user with
-	// Windows identity (PAC/NTLMSSP/LDAP) persists it (AD-3 #1235).
+	// SID/GroupSIDs are deliberately NOT in this set: an explicit Select forces
+	// the column write even for a zero value, so a caller passing a partial
+	// user (GroupSIDs == nil) would silently erase persisted Windows identity.
+	// Identity columns are written only through UpdateUserSIDInfo, whose
+	// contract is to set exactly those columns.
 	return s.db.WithContext(ctx).
 		Model(&existing).
-		Select("Username", "Enabled", "MustChangePassword", "Role", "UID", "GID", "DisplayName", "Email", "SID", "GroupSIDs").
+		Select("Username", "Enabled", "MustChangePassword", "Role", "UID", "GID", "DisplayName", "Email").
 		Updates(user).Error
+}
+
+// UpdateUserSIDInfo persists the Windows identity (SID + group SIDs) for a user,
+// as resolved by a login flow (Kerberos PAC / NTLMSSP / LDAP, AD-3 #1235).
+// It writes only the sid and group_sids columns, so it can never clobber other
+// profile fields, and is safe to call with the freshly resolved values without
+// first reloading the rest of the user.
+func (s *GORMStore) UpdateUserSIDInfo(ctx context.Context, username, sid string, groupSIDs []string) error {
+	res := s.db.WithContext(ctx).
+		Model(&models.User{}).
+		Where("username = ?", username).
+		Select("SID", "GroupSIDs").
+		Updates(&models.User{SID: sid, GroupSIDs: groupSIDs})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return models.ErrUserNotFound
+	}
+	return nil
 }
 
 func (s *GORMStore) DeleteUser(ctx context.Context, username string) error {

--- a/pkg/controlplane/store/users.go
+++ b/pkg/controlplane/store/users.go
@@ -92,10 +92,12 @@ func (s *GORMStore) UpdateUser(ctx context.Context, user *models.User) error {
 		return convertNotFoundError(err, models.ErrUserNotFound)
 	}
 
-	// Update specific fields using Select to handle pointers properly
+	// Update specific fields using Select to handle pointers properly.
+	// SID/GroupSIDs are included so a login flow that enriches the user with
+	// Windows identity (PAC/NTLMSSP/LDAP) persists it (AD-3 #1235).
 	return s.db.WithContext(ctx).
 		Model(&existing).
-		Select("Username", "Enabled", "MustChangePassword", "Role", "UID", "GID", "DisplayName", "Email").
+		Select("Username", "Enabled", "MustChangePassword", "Role", "UID", "GID", "DisplayName", "Email", "SID", "GroupSIDs").
 		Updates(user).Error
 }
 

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -44,6 +44,15 @@ type ResolvedIdentity struct {
 	GIDs     []uint32
 	Domain   string
 	Found    bool
+
+	// SID is the user's Windows Security Identifier, when known. Empty when
+	// no Windows identity is associated with the user. Populated from the
+	// persisted control-plane user record so the same identity surfaces
+	// regardless of which protocol (NFS/SMB) or provider resolved it.
+	SID string
+
+	// GroupSIDs is the list of Windows group SIDs for the user, when known.
+	GroupSIDs []string
 }
 
 // IdentityProvider resolves external credentials to DittoFS users.


### PR DESCRIPTION
Part of #1231 (AD/LDAP enterprise integration umbrella).
Closes #1235.

## Summary

Adds the core durable identity + idmap layer for foreign (AD/LDAP) SIDs and makes local Windows identity reproducible across cluster nodes.

### Two SID classes
- **Local / algorithmic** (machine SID + RID from local UID, Samba formula `user=uid*2+1000`, `group=gid*2+1001`): already deterministic. This PR makes the **machine SID operator-pinnable** so two nodes derive identical local SIDs:
  - new `identity.machine_sid` config (env: `DITTOFS_IDENTITY_MACHINE_SID`), validated at load;
  - threaded through `Runtime.SetPinnedMachineSID` → `lifecycle.initMachineSID`, which now prefers a validated pin over generate/load and persists it as authoritative;
  - the RID formula + machine SID are documented as a **LOCKED, node-shared invariant** in `pkg/auth/sid/mapper.go`.
  - No clustering machinery is built — only pinnability + documentation.
- **Foreign / AD domain SIDs** (`S-1-5-21-<ad-domain>-<rid>`, not derivable from a local UID): persisted durably in the new `models.SIDMapping` table.

### Durable foreign-SID idmap (control-plane GORM home)
- `models.SIDMapping` (PK = full SID) registered in `AllModels()` (GORM AutoMigrate — no numbered SQL migration, matching the control-plane convention).
- `store.SIDMappingStore` interface + `GORMStore` CRUD. `AllocateSIDMapping` is **idempotent and never-remaps**: re-resolving an existing foreign SID returns the same UID/GID (ON CONFLICT DO NOTHING + re-read; first writer wins). This is the data-exposure invariant — a remap would silently re-attribute files owned by the old UID.

### Persist Windows identity on the user
- `User.SID` (plain `sid` column) and `User.GroupSIDs` (json-serialized `group_sids` column) — dropped the in-memory-only `gorm:"-"`. `UpdateUser` now selects these so a login enrichment flow persists them. (Explicit `column:` tags so GORM maps the all-caps acronym to `sid`/`group_sids`, not `s_id`/`group_si_ds`.)

### Resolver unification
- Added `SID`/`GroupSIDs` to `identity.ResolvedIdentity` and enriched `BuildIdentityResolver`'s `userLookup` (only that region) to populate them from the persisted user and fold durable foreign group-SID → GID mappings into the supplementary group set. The fields flow verbatim through the kerberos provider + resolver, so the same Windows identity surfaces regardless of provider/protocol.

## storetest interpretation
The acceptance text mentions "memory/badger/postgres storetest". Identity is the **control-plane's** domain — memory/badger are *metadata* backends that do not store users/SIDs. Conformance is therefore implemented as a **control-plane store_test** (`//go:build integration`): file-backed **sqlite** (reopened to simulate restart) always runs, and **postgres** runs when `DITTOFS_TEST_POSTGRES_DSN` is set (CI provides it), mirroring the existing `pkg/controlplane/store/*_test.go` pattern.

## Tests
- `store` (integration): foreign-SID round-trip + **restart-stable across store reopen**; **never-remap** (re-allocate with different UID returns original); not-found/delete sentinels; `User.SID`/`GroupSIDs` persist across create, **UpdateUser**, and reopen.
- `auth/sid`: node-parity determinism — two mappers from the same machine SID produce identical SID/RID for the same UID/GID (+ cross-node reverse decode).
- `lifecycle`: pinned-SID applied/persisted, overrides a different stored value, invalid pin falls back, two pinned services agree.
- `config`: `identity.machine_sid` env override + invalid-value rejection.

## Verification (all green)
```
go build ./...                                  # clean
go vet ./...                                     # clean
go vet -tags integration ./pkg/controlplane/store/...   # clean
gofmt -l <touched dirs>                          # clean
go test ./pkg/auth/sid/... ./pkg/controlplane/... ./pkg/config/... ./pkg/identity/... ./pkg/adapter/...   # ok
go test -tags integration -run 'TestSIDMapping|TestUserSIDPersistence' ./pkg/controlplane/store/...        # ok (sqlite; postgres skipped, no local DSN)
```

## Deferred / out of scope
- LDAP provider + resolver chain wiring (AD-2 #1234) owns provider registration and `pkg/identity/ldap/`; this PR only populates `ResolvedIdentity` and provides the durable store it will call to allocate foreign SIDs.
- No REST/dfsctl surface or operator CRD field for `identity.machine_sid` (config/env only here).
- The downstream conversion of `ResolvedIdentity.SID/GroupSIDs` into `metadata.Identity` lives in the protocol consumers (AD-0/AD-1 wired PAC group-SIDs there already); this PR keeps the resolver fields flowing verbatim.
