### PR TITLE
AD-4a: domain-aware SMB session + offline-keytab Kerberos config (#1236)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1260,10 +1260,52 @@ adapters:
     # Kerberos (RPCSEC_GSS) settings
     kerberos:
       enabled: true
-      keytab: /etc/krb5.keytab
-      realm: EXAMPLE.COM
+      keytab_path: /etc/dittofs/dittofs.keytab
       service_principal: nfs/server.example.com@EXAMPLE.COM
+      krb5_conf: /etc/krb5.conf
+
+      # AD domain identity (optional; for an Active-Directory-joined server).
+      # When all three are unset the server is standalone and advertises the
+      # NetBIOS workgroup "WORKGROUP" exactly as a non-domain server does —
+      # leaving these empty is fully backward-compatible.
+      realm: EXAMPLE.COM            # Kerberos realm; defaults to the @REALM of service_principal
+      netbios_domain: EXAMPLE       # NetBIOS short name; NOT derivable, must be set to enable domain-aware SMB
+      dns_domain: example.com       # defaults to the lowercased realm
 ```
+
+| Key | Env var | Default |
+|---|---|---|
+| `kerberos.realm` | `DITTOFS_KERBEROS_REALM` | `@REALM` of `service_principal` |
+| `kerberos.netbios_domain` | `DITTOFS_KERBEROS_NETBIOS_DOMAIN` | (empty → standalone `WORKGROUP`) |
+| `kerberos.dns_domain` | `DITTOFS_KERBEROS_DNS_DOMAIN` | lowercased `realm` |
+
+#### Domain-aware SMB
+
+When `netbios_domain` is set, the SMB server advertises the AD domain in the
+NTLM challenge (`MsvAvNbDomainName` / `MsvAvDnsDomainName`) and stamps it on
+authenticated sessions, so domain users authenticate against the correct domain.
+Unset → the server advertises `WORKGROUP` / `local` (pre-AD-4 standalone
+behavior).
+
+#### Offline keytab import (one keytab, both protocols)
+
+A keytab can hold multiple service principals, so a single file serves SMB and
+NFS. Pre-create the computer/service account in AD and export a keytab
+containing **both** `cifs/<host>@REALM` (SMB) and `nfs/<host>@REALM` (NFS):
+
+```bash
+# On a domain-joined admin host (samba-tool / adcli / Windows ktpass):
+samba-tool domain exportkeytab /etc/dittofs/dittofs.keytab \
+    --principal=cifs/server.example.com@EXAMPLE.COM
+samba-tool domain exportkeytab /etc/dittofs/dittofs.keytab \
+    --principal=nfs/server.example.com@EXAMPLE.COM
+```
+
+Point `kerberos.keytab_path` at the combined keytab. The SMB handler selects
+the `cifs/` principal (deriving it from the NFS `service_principal`, or via an
+explicit override); NFS RPCSEC_GSS uses the `nfs/` principal. Online
+`net ads join` + machine-password rotation is out of scope (deferred — see
+#1231).
 
 ### 13. Identity Mapping Configuration
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1254,23 +1254,24 @@ adapters:
 
 ### 12. Kerberos Configuration
 
-```yaml
-adapters:
-  nfs:
-    # Kerberos (RPCSEC_GSS) settings
-    kerberos:
-      enabled: true
-      keytab_path: /etc/dittofs/dittofs.keytab
-      service_principal: nfs/server.example.com@EXAMPLE.COM
-      krb5_conf: /etc/krb5.conf
+`kerberos` is a top-level config block (it backs both NFS RPCSEC_GSS and SMB
+SPNEGO — not nested under `adapters`):
 
-      # AD domain identity (optional; for an Active-Directory-joined server).
-      # When all three are unset the server is standalone and advertises the
-      # NetBIOS workgroup "WORKGROUP" exactly as a non-domain server does —
-      # leaving these empty is fully backward-compatible.
-      realm: EXAMPLE.COM            # Kerberos realm; defaults to the @REALM of service_principal
-      netbios_domain: EXAMPLE       # NetBIOS short name; NOT derivable, must be set to enable domain-aware SMB
-      dns_domain: example.com       # defaults to the lowercased realm
+```yaml
+# Kerberos (RPCSEC_GSS + SMB SPNEGO) settings — top-level block
+kerberos:
+  enabled: true
+  keytab_path: /etc/dittofs/dittofs.keytab
+  service_principal: nfs/server.example.com@EXAMPLE.COM
+  krb5_conf: /etc/krb5.conf
+
+  # AD domain identity (optional; for an Active-Directory-joined server).
+  # When all three are unset the server is standalone and advertises the
+  # NetBIOS workgroup "WORKGROUP" exactly as a non-domain server does —
+  # leaving these empty is fully backward-compatible.
+  realm: EXAMPLE.COM            # Kerberos realm; defaults to the @REALM of service_principal
+  netbios_domain: EXAMPLE       # NetBIOS short name; NOT derivable, must be set to enable domain-aware SMB
+  dns_domain: example.com       # defaults to the lowercased realm
 ```
 
 | Key | Env var | Default |

--- a/internal/adapter/smb/auth/ntlm.go
+++ b/internal/adapter/smb/auth/ntlm.go
@@ -344,7 +344,11 @@ func GetMessageType(buf []byte) MessageType {
 //	56      var   Payload            TargetInfo terminator
 //
 // [MS-NLMP] Section 2.2.1.2
-func BuildChallenge() (message []byte, serverChallenge [8]byte) {
+// netbiosDomain and dnsDomain are advertised in the TargetInfo AV_PAIRs. Pass
+// the server's configured AD domain to make the challenge domain-aware; pass
+// empty strings for a standalone server (TargetInfo then advertises
+// WORKGROUP / "local" exactly as before AD-4).
+func BuildChallenge(netbiosDomain, dnsDomain string) (message []byte, serverChallenge [8]byte) {
 	// Generate random 8-byte challenge.
 	// This challenge is used to validate the client's NTLMv2 response
 	// and derive the session key for message signing.
@@ -393,7 +397,7 @@ func BuildChallenge() (message []byte, serverChallenge [8]byte) {
 	// Build target info with required AV_PAIRs for Windows compatibility.
 	// Windows clients need at minimum: NbDomainName, NbComputerName,
 	// DnsComputerName, and Timestamp (for NTLMv2 replay protection).
-	targetInfo := buildTargetInfo(hostname)
+	targetInfo := buildTargetInfo(hostname, netbiosDomain, dnsDomain)
 
 	// Calculate payload offsets
 	// Payload starts immediately after the fixed fields (56 bytes)
@@ -484,8 +488,22 @@ func BuildChallenge() (message []byte, serverChallenge [8]byte) {
 // disconnect immediately after receiving the Type 2 message.
 //
 // [MS-NLMP] Section 2.2.2.1
-func buildTargetInfo(hostname string) []byte {
-	domain := "WORKGROUP"
+// netbiosDomain is the NetBIOS short domain advertised in MsvAvNbDomainName
+// and dnsDomain is advertised in MsvAvDnsDomainName. Either may be empty: an
+// empty netbiosDomain falls back to "WORKGROUP" (standalone server) and an
+// empty dnsDomain falls back to "local". This keeps a standalone (non
+// domain-joined) server advertising exactly what it did before AD-4, while a
+// domain-joined server advertises its real AD domain so Windows clients send
+// NTLMv2 responses computed against the right domain.
+func buildTargetInfo(hostname, netbiosDomain, dnsDomain string) []byte {
+	domain := netbiosDomain
+	if domain == "" {
+		domain = "WORKGROUP"
+	}
+	dnsDom := dnsDomain
+	if dnsDom == "" {
+		dnsDom = "local"
+	}
 	nbName := strings.ToUpper(hostname)
 	dnsName := strings.ToLower(hostname)
 
@@ -493,7 +511,7 @@ func buildTargetInfo(hostname string) []byte {
 	nbDomainBytes := encodeUTF16LE(domain)
 	nbComputerBytes := encodeUTF16LE(nbName)
 	dnsComputerBytes := encodeUTF16LE(dnsName)
-	dnsDomainBytes := encodeUTF16LE("local")
+	dnsDomainBytes := encodeUTF16LE(dnsDom)
 
 	// Timestamp: Windows FILETIME (100-nanosecond intervals since 1601-01-01)
 	// Go epoch is 1970-01-01, offset is 116444736000000000 (100ns intervals)

--- a/internal/adapter/smb/auth/ntlm.go
+++ b/internal/adapter/smb/auth/ntlm.go
@@ -354,13 +354,28 @@ func BuildChallenge(netbiosDomain, dnsDomain string) (message []byte, serverChal
 	// and derive the session key for message signing.
 	_, _ = rand.Read(serverChallenge[:])
 
-	// Target name: server hostname for client identification.
-	// Windows clients require a non-empty TargetName when FlagRequestTarget is set.
+	// Target name + target-type flag. Per MS-NLMP §2.2.1.2 / §3.1.5.1.1 the two
+	// TargetType flags are mutually exclusive and the TargetName must match the
+	// one that is set: a DOMAIN-joined server advertises the NetBIOS domain as
+	// TargetName with FlagTargetTypeDomain, while a standalone server advertises
+	// its hostname with FlagTargetTypeServer. Windows clients select their
+	// credential store (domain vault vs local SAM) from this flag, so a
+	// domain-joined server that advertised TargetTypeServer would drive clients
+	// to validate against the wrong store and fail / mis-derive the NTLMv2 hash.
+	// Windows clients also require a non-empty TargetName when FlagRequestTarget
+	// is set.
 	hostname, _ := os.Hostname()
 	if hostname == "" {
 		hostname = "DITTOFS"
 	}
-	targetName := encodeUTF16LE(strings.ToUpper(hostname))
+	var targetName []byte
+	targetTypeFlag := FlagTargetTypeServer
+	if netbiosDomain != "" {
+		targetName = encodeUTF16LE(netbiosDomain)
+		targetTypeFlag = FlagTargetTypeDomain
+	} else {
+		targetName = encodeUTF16LE(strings.ToUpper(hostname))
+	}
 
 	// Flags for server capabilities.
 	//
@@ -386,7 +401,7 @@ func BuildChallenge(netbiosDomain, dnsDomain string) (message []byte, serverChal
 		FlagNTLM | // Support NTLM authentication
 		FlagSign | // Support message integrity (signing)
 		FlagAlwaysSign | // Include signature (even if dummy)
-		FlagTargetTypeServer | // We are a server (not domain controller)
+		targetTypeFlag | // TargetTypeDomain (domain-joined) or TargetTypeServer (standalone)
 		FlagExtendedSecurity | // Support NTLMv2 session security
 		FlagTargetInfo | // Include AV_PAIR list
 		Flag128 | // 128-bit session key strength (required by Linux CIFS client)

--- a/internal/adapter/smb/auth/ntlm_test.go
+++ b/internal/adapter/smb/auth/ntlm_test.go
@@ -128,7 +128,7 @@ func TestGetMessageType(t *testing.T) {
 // =============================================================================
 
 func TestBuildChallenge(t *testing.T) {
-	msg, serverChallenge := BuildChallenge()
+	msg, serverChallenge := BuildChallenge("", "")
 
 	t.Run("HasCorrectSignature", func(t *testing.T) {
 		if !bytes.Equal(msg[0:8], Signature) {
@@ -176,7 +176,7 @@ func TestBuildChallenge(t *testing.T) {
 	})
 
 	t.Run("GeneratesUniqueChallenge", func(t *testing.T) {
-		msg2, serverChallenge2 := BuildChallenge()
+		msg2, serverChallenge2 := BuildChallenge("", "")
 		challenge1 := msg[24:32]
 		challenge2 := msg2[24:32]
 
@@ -757,4 +757,87 @@ func rc4Encrypt(key, data []byte) []byte {
 	}
 
 	return result
+}
+
+// =============================================================================
+// Domain-aware TargetInfo Tests (AD-4)
+// =============================================================================
+
+// parseAvPairs walks an AV_PAIR list and returns a map of AvID -> decoded
+// UTF-16LE string value. It stops at the MsvAvEOL terminator.
+func parseAvPairs(t *testing.T, buf []byte) map[AvID]string {
+	t.Helper()
+	out := make(map[AvID]string)
+	for len(buf) >= 4 {
+		id := AvID(binary.LittleEndian.Uint16(buf[0:2]))
+		ln := int(binary.LittleEndian.Uint16(buf[2:4]))
+		if id == AvEOL {
+			break
+		}
+		if 4+ln > len(buf) {
+			t.Fatalf("AV_PAIR id=0x%x length %d overruns buffer (%d remaining)", id, ln, len(buf)-4)
+		}
+		val := buf[4 : 4+ln]
+		// Decode UTF-16LE (timestamp is raw bytes, but we only read string AVs).
+		runes := make([]uint16, ln/2)
+		for i := 0; i < ln/2; i++ {
+			runes[i] = binary.LittleEndian.Uint16(val[i*2:])
+		}
+		out[id] = string(utf16Decode(runes))
+		buf = buf[4+ln:]
+	}
+	return out
+}
+
+func utf16Decode(u []uint16) []rune {
+	r := make([]rune, len(u))
+	for i, c := range u {
+		r[i] = rune(c)
+	}
+	return r
+}
+
+// TestBuildTargetInfo_StandaloneDefault asserts the critical backward-compat
+// guarantee: with no domain configured, the TargetInfo advertises WORKGROUP as
+// the NetBIOS domain (and "local" as the DNS domain) exactly as before AD-4.
+func TestBuildTargetInfo_StandaloneDefault(t *testing.T) {
+	info := buildTargetInfo("FILESERVER", "", "")
+	pairs := parseAvPairs(t, info)
+
+	if got := pairs[AvNbDomainName]; got != "WORKGROUP" {
+		t.Errorf("standalone NbDomainName = %q, want %q", got, "WORKGROUP")
+	}
+	if got := pairs[AvDnsDomainName]; got != "local" {
+		t.Errorf("standalone DnsDomainName = %q, want %q", got, "local")
+	}
+	if got := pairs[AvNbComputerName]; got != "FILESERVER" {
+		t.Errorf("NbComputerName = %q, want %q", got, "FILESERVER")
+	}
+}
+
+// TestBuildTargetInfo_DomainAware asserts the AD-4 path: a configured NetBIOS +
+// DNS domain is advertised in the TargetInfo instead of WORKGROUP/local.
+func TestBuildTargetInfo_DomainAware(t *testing.T) {
+	info := buildTargetInfo("FILESERVER", "CONTOSO", "contoso.com")
+	pairs := parseAvPairs(t, info)
+
+	if got := pairs[AvNbDomainName]; got != "CONTOSO" {
+		t.Errorf("domain NbDomainName = %q, want %q", got, "CONTOSO")
+	}
+	if got := pairs[AvDnsDomainName]; got != "contoso.com" {
+		t.Errorf("domain DnsDomainName = %q, want %q", got, "contoso.com")
+	}
+}
+
+// TestBuildTargetInfo_PartialDomain asserts that an empty DNS domain still
+// falls back to "local" even when the NetBIOS domain is set, and vice versa.
+func TestBuildTargetInfo_PartialDomain(t *testing.T) {
+	info := buildTargetInfo("FILESERVER", "CONTOSO", "")
+	pairs := parseAvPairs(t, info)
+	if got := pairs[AvNbDomainName]; got != "CONTOSO" {
+		t.Errorf("NbDomainName = %q, want %q", got, "CONTOSO")
+	}
+	if got := pairs[AvDnsDomainName]; got != "local" {
+		t.Errorf("DnsDomainName = %q, want %q (empty dns falls back)", got, "local")
+	}
 }

--- a/internal/adapter/smb/auth/ntlm_test.go
+++ b/internal/adapter/smb/auth/ntlm_test.go
@@ -829,6 +829,39 @@ func TestBuildTargetInfo_DomainAware(t *testing.T) {
 	}
 }
 
+// TestBuildChallenge_TargetTypeFlag pins MS-NLMP §2.2.1.2/§3.1.5.1.1: the
+// CHALLENGE must set FlagTargetTypeDomain (mutually exclusive with
+// FlagTargetTypeServer) when domain-joined, and FlagTargetTypeServer when
+// standalone. A domain-joined server advertising TargetTypeServer drives
+// Windows clients to the wrong credential store.
+func TestBuildChallenge_TargetTypeFlag(t *testing.T) {
+	flagsOf := func(msg []byte) NegotiateFlag {
+		return NegotiateFlag(binary.LittleEndian.Uint32(msg[challengeFlagsOffset : challengeFlagsOffset+4]))
+	}
+
+	t.Run("standalone", func(t *testing.T) {
+		msg, _ := BuildChallenge("", "")
+		f := flagsOf(msg)
+		if f&FlagTargetTypeServer == 0 {
+			t.Error("standalone challenge must set FlagTargetTypeServer")
+		}
+		if f&FlagTargetTypeDomain != 0 {
+			t.Error("standalone challenge must NOT set FlagTargetTypeDomain")
+		}
+	})
+
+	t.Run("domain-joined", func(t *testing.T) {
+		msg, _ := BuildChallenge("CONTOSO", "contoso.com")
+		f := flagsOf(msg)
+		if f&FlagTargetTypeDomain == 0 {
+			t.Error("domain-joined challenge must set FlagTargetTypeDomain")
+		}
+		if f&FlagTargetTypeServer != 0 {
+			t.Error("domain-joined challenge must NOT set FlagTargetTypeServer")
+		}
+	})
+}
+
 // TestBuildTargetInfo_PartialDomain asserts that an empty DNS domain still
 // falls back to "local" even when the NetBIOS domain is set, and vice versa.
 func TestBuildTargetInfo_PartialDomain(t *testing.T) {

--- a/internal/adapter/smb/auth/ntlmv2_crossvalidation_test.go
+++ b/internal/adapter/smb/auth/ntlmv2_crossvalidation_test.go
@@ -20,7 +20,7 @@ func TestNTLMv2CrossValidation(t *testing.T) {
 	clientDomain := "" // go-smb2 typically sends empty domain
 
 	// Step 1: Server builds challenge (as our code does)
-	challengeMsg, serverChallenge := BuildChallenge()
+	challengeMsg, serverChallenge := BuildChallenge("", "")
 
 	// Step 2: Extract TargetName and TargetInfo from challenge (as go-smb2 does)
 	targetNameLen := binary.LittleEndian.Uint16(challengeMsg[12:14])

--- a/internal/adapter/smb/auth/spnego_roundtrip_test.go
+++ b/internal/adapter/smb/auth/spnego_roundtrip_test.go
@@ -41,7 +41,7 @@ func TestSPNEGORoundTrip(t *testing.T) {
 	// =====================================================
 	// Step 2: Server sends Challenge wrapped in NegTokenResp
 	// =====================================================
-	challengeMsg, serverChallenge := BuildChallenge()
+	challengeMsg, serverChallenge := BuildChallenge("", "")
 	t.Logf("Step 2: Server challenge: %x", serverChallenge)
 
 	spnegoChallengeResp, err := BuildAcceptIncomplete(OIDNTLMSSP, challengeMsg)

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -872,6 +872,19 @@ func NewHandlerWithSessionManager(sessionManager *session.Manager) *Handler {
 	return h
 }
 
+// sessionDomain returns the domain to stamp on an authenticated SMB session.
+// When the server is domain-joined (NetBIOSDomain configured) it returns the
+// AD NetBIOS short domain (e.g. CONTOSO) so the session reflects the server's
+// domain rather than the realm or whatever the client supplied. When standalone
+// (NetBIOSDomain empty) it returns the caller-provided fallback (the Kerberos
+// realm or the client-supplied NTLM domain), preserving pre-AD-4 behavior.
+func (h *Handler) sessionDomain(fallback string) string {
+	if h.NetBIOSDomain != "" {
+		return h.NetBIOSDomain
+	}
+	return fallback
+}
+
 // GetSession retrieves a session by ID.
 // Delegates to SessionManager for unified session/credit management.
 func (h *Handler) GetSession(sessionID uint64) (*session.Session, bool) {

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -191,6 +191,19 @@ type Handler struct {
 	// When empty, derived from the NFS principal ("nfs/host@REALM" -> "cifs/host@REALM").
 	SMBServicePrincipal string
 
+	// NetBIOSDomain is the AD NetBIOS short domain (e.g. CONTOSO) the server is
+	// joined to. It is advertised in the NTLM Type-2 TargetInfo
+	// (MsvAvNbDomainName), added to the NTLMv2 domain-try list, and stamped on a
+	// domain user's SMB Session. When empty the server is standalone and
+	// advertises/uses "WORKGROUP" exactly as before AD-4. Set by the adapter
+	// from the Kerberos provider's configured domain.
+	NetBIOSDomain string
+
+	// DNSDomain is the AD DNS domain (e.g. contoso.com) advertised in the NTLM
+	// Type-2 TargetInfo (MsvAvDnsDomainName). When empty the standalone default
+	// ("local") is advertised. Set by the adapter from the Kerberos provider.
+	DNSDomain string
+
 	// NtlmEnabled controls whether NTLM authentication is allowed.
 	// When false, NTLM tokens in SESSION_SETUP are rejected with STATUS_LOGON_FAILURE.
 	// Default: true.

--- a/internal/adapter/smb/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/handlers/kerberos_auth.go
@@ -130,19 +130,14 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 	// could observe a zero ExpiresAt on the published session and skip the
 	// per-request expiry check in prepareDispatch (see #341 A1).
 	// Domain-aware session (AD-4): stamp the configured AD NetBIOS short domain
-	// (e.g. CONTOSO) on the session when the server is domain-joined, rather
-	// than the Kerberos realm (e.g. CONTOSO.COM). When NetBIOSDomain is unset
-	// (standalone) fall back to the realm, preserving pre-AD-4 behavior.
-	sessionDomain := authResult.Realm
-	if h.NetBIOSDomain != "" {
-		sessionDomain = h.NetBIOSDomain
-	}
+	// (e.g. CONTOSO) when domain-joined, else fall back to the Kerberos realm
+	// (e.g. CONTOSO.COM), preserving pre-AD-4 behavior.
 	sessionID := h.GenerateSessionID()
 	sess := h.CreateSessionWithUserAndExpiry(
 		sessionID,
 		ctx.ClientAddr,
 		user,
-		sessionDomain,
+		h.sessionDomain(authResult.Realm),
 		ticketEndTime,
 	)
 	sess.OriginConnID = ctx.ConnID
@@ -219,11 +214,7 @@ func (h *Handler) reauthKerberosSession(
 	sess.Username = user.Username
 	// Domain-aware session (AD-4): keep the NetBIOS short domain on reauth when
 	// domain-joined; otherwise fall back to the realm (pre-AD-4 behavior).
-	if h.NetBIOSDomain != "" {
-		sess.Domain = h.NetBIOSDomain
-	} else {
-		sess.Domain = authResult.Realm
-	}
+	sess.Domain = h.sessionDomain(authResult.Realm)
 	sess.IsGuest = false
 	sess.IsNull = false
 	sess.ExpiresAt = ticketEndTime

--- a/internal/adapter/smb/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/handlers/kerberos_auth.go
@@ -129,12 +129,20 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 	// StoreSession to avoid a data race window where a concurrent reader
 	// could observe a zero ExpiresAt on the published session and skip the
 	// per-request expiry check in prepareDispatch (see #341 A1).
+	// Domain-aware session (AD-4): stamp the configured AD NetBIOS short domain
+	// (e.g. CONTOSO) on the session when the server is domain-joined, rather
+	// than the Kerberos realm (e.g. CONTOSO.COM). When NetBIOSDomain is unset
+	// (standalone) fall back to the realm, preserving pre-AD-4 behavior.
+	sessionDomain := authResult.Realm
+	if h.NetBIOSDomain != "" {
+		sessionDomain = h.NetBIOSDomain
+	}
 	sessionID := h.GenerateSessionID()
 	sess := h.CreateSessionWithUserAndExpiry(
 		sessionID,
 		ctx.ClientAddr,
 		user,
-		authResult.Realm,
+		sessionDomain,
 		ticketEndTime,
 	)
 	sess.OriginConnID = ctx.ConnID
@@ -209,7 +217,13 @@ func (h *Handler) reauthKerberosSession(
 	// requests through again (expire1/2 recovery).
 	sess.User = user
 	sess.Username = user.Username
-	sess.Domain = authResult.Realm
+	// Domain-aware session (AD-4): keep the NetBIOS short domain on reauth when
+	// domain-joined; otherwise fall back to the realm (pre-AD-4 behavior).
+	if h.NetBIOSDomain != "" {
+		sess.Domain = h.NetBIOSDomain
+	} else {
+		sess.Domain = authResult.Realm
+	}
 	sess.IsGuest = false
 	sess.IsNull = false
 	sess.ExpiresAt = ticketEndTime

--- a/internal/adapter/smb/handlers/session_setup.go
+++ b/internal/adapter/smb/handlers/session_setup.go
@@ -1222,11 +1222,7 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 				// message (which may be empty, the hostname, or "WORKGROUP"). When
 				// standalone (NetBIOSDomain empty) the client-supplied domain is
 				// retained, preserving pre-AD-4 behavior.
-				sessionDomain := authMsg.Domain
-				if h.NetBIOSDomain != "" {
-					sessionDomain = h.NetBIOSDomain
-				}
-				sess := h.CreateSessionWithUser(pending.SessionID, pending.ClientAddr, user, sessionDomain)
+				sess := h.CreateSessionWithUser(pending.SessionID, pending.ClientAddr, user, h.sessionDomain(authMsg.Domain))
 				sess.OriginConnID = ctx.ConnID
 				recordSessionBindIdentity(sess, ctx)
 

--- a/internal/adapter/smb/handlers/session_setup.go
+++ b/internal/adapter/smb/handlers/session_setup.go
@@ -725,7 +725,7 @@ func (h *Handler) handleNTLMNegotiateBinding(ctx *SMBHandlerContext, req *Sessio
 	}
 
 	// Build TYPE_2 CHALLENGE
-	challengeMsg, serverChallenge := auth.BuildChallenge()
+	challengeMsg, serverChallenge := auth.BuildChallenge(h.NetBIOSDomain, h.DNSDomain)
 
 	pending := &PendingAuth{
 		SessionID:        ctx.SessionID, // bound session's ID
@@ -961,7 +961,7 @@ func (h *Handler) handleNTLMNegotiate(ctx *SMBHandlerContext, usedSPNEGO bool, m
 
 	// Build NTLM Type 2 (CHALLENGE) response
 	// This also returns the server challenge for later validation
-	challengeMsg, serverChallenge := auth.BuildChallenge()
+	challengeMsg, serverChallenge := auth.BuildChallenge(h.NetBIOSDomain, h.DNSDomain)
 
 	// Store pending auth to track handshake state
 	// Include the server challenge for NTLMv2 validation in completeNTLMAuth
@@ -1117,7 +1117,8 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 					authMsg.Domain,            // Domain from AUTHENTICATE message
 					"",                        // Empty domain
 					strings.ToUpper(hostname), // Server hostname (TargetName)
-					"WORKGROUP",               // Default workgroup
+					h.NetBIOSDomain,           // Configured AD NetBIOS domain (AD-4; "" when standalone)
+					"WORKGROUP",               // Default workgroup (standalone)
 				})
 
 				logger.Debug("NTLMv2 validation attempt",
@@ -1215,7 +1216,17 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 					// Fallthrough: session disappeared between negotiate and auth (unlikely)
 				}
 
-				sess := h.CreateSessionWithUser(pending.SessionID, pending.ClientAddr, user, authMsg.Domain)
+				// Domain-aware session (AD-4): when the server is joined to an AD
+				// domain (NetBIOSDomain configured) the session reflects that
+				// domain rather than whatever the client put in the AUTHENTICATE
+				// message (which may be empty, the hostname, or "WORKGROUP"). When
+				// standalone (NetBIOSDomain empty) the client-supplied domain is
+				// retained, preserving pre-AD-4 behavior.
+				sessionDomain := authMsg.Domain
+				if h.NetBIOSDomain != "" {
+					sessionDomain = h.NetBIOSDomain
+				}
+				sess := h.CreateSessionWithUser(pending.SessionID, pending.ClientAddr, user, sessionDomain)
 				sess.OriginConnID = ctx.ConnID
 				recordSessionBindIdentity(sess, ctx)
 

--- a/internal/adapter/smb/handlers/session_setup.go
+++ b/internal/adapter/smb/handlers/session_setup.go
@@ -1198,7 +1198,7 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 				// Samba reference: smb2_sesssetup.c:633-637 passes
 				// session_info->session_key from the bind's GENSEC context.
 				if pending.IsBinding {
-					return h.completeSessionBind(ctx, pending, user, authMsg.Domain, signingKey[:], authMsg.NegotiateFlags), nil
+					return h.completeSessionBind(ctx, pending, user, h.sessionDomain(authMsg.Domain), signingKey[:], authMsg.NegotiateFlags), nil
 				}
 
 				if pending.IsReauth {
@@ -1210,7 +1210,7 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 					// them here makes the SUCCESS response's signature diverge
 					// from what the client computes with the unchanged key
 					// (smb2.session.reauth1-5 reject the response).
-					if result := h.tryReauthUpdate(pending, resolvedUsername, authMsg.Domain, user, false); result != nil {
+					if result := h.tryReauthUpdate(pending, resolvedUsername, h.sessionDomain(authMsg.Domain), user, false); result != nil {
 						return result, nil
 					}
 					// Fallthrough: session disappeared between negotiate and auth (unlikely)

--- a/internal/adapter/smb/handlers/session_setup_reauth_test.go
+++ b/internal/adapter/smb/handlers/session_setup_reauth_test.go
@@ -457,3 +457,28 @@ func TestTryReauthUpdate_ClearsKerberosPACIdentity(t *testing.T) {
 		t.Errorf("PACUserSID not cleared after NTLM reauth: %q", gotUserSID)
 	}
 }
+
+// TestHandler_sessionDomain pins the domain-aware selection used at every
+// session-create/reauth/bind site: a domain-joined server (NetBIOSDomain set)
+// always reports its AD domain; a standalone server falls back to the
+// client-supplied value (pre-AD-4 behavior). The reauth/bind paths route the
+// client domain through this helper so a successful re-auth cannot reset
+// Session.Domain back to an empty/WORKGROUP value on a domain-joined server.
+func TestHandler_sessionDomain(t *testing.T) {
+	t.Run("domain-joined overrides client value", func(t *testing.T) {
+		h := &Handler{NetBIOSDomain: "DITTOFS"}
+		for _, client := range []string{"", "WORKGROUP", "SOMEHOST"} {
+			if got := h.sessionDomain(client); got != "DITTOFS" {
+				t.Errorf("sessionDomain(%q) = %q, want DITTOFS", client, got)
+			}
+		}
+	})
+	t.Run("standalone keeps client value", func(t *testing.T) {
+		h := &Handler{}
+		for _, client := range []string{"", "WORKGROUP", "CORP"} {
+			if got := h.sessionDomain(client); got != client {
+				t.Errorf("sessionDomain(%q) = %q, want %q (standalone)", client, got, client)
+			}
+		}
+	})
+}

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -500,6 +500,20 @@ func (s *Adapter) SetKerberosProvider(provider *kerberos.Provider) {
 	s.kerberosProvider = provider
 	s.handler.KerberosProvider = provider
 
+	// Make the SMB handler domain-aware (AD-4): advertise the AD NetBIOS/DNS
+	// domain in the NTLM challenge TargetInfo, add it to the NTLMv2 domain-try
+	// list, and stamp it on authenticated domain sessions. When the provider was
+	// not configured with a domain these stay empty and the handler falls back
+	// to standalone WORKGROUP behavior.
+	s.handler.NetBIOSDomain = provider.NetBIOSDomain()
+	s.handler.DNSDomain = provider.DNSDomain()
+	if provider.NetBIOSDomain() != "" {
+		logger.Info("SMB adapter: domain-aware session enabled",
+			"netbios_domain", provider.NetBIOSDomain(),
+			"dns_domain", provider.DNSDomain(),
+			"realm", provider.Realm())
+	}
+
 	// Create KerberosService from the provider for AP-REQ verification,
 	// replay detection, and mutual auth token construction.
 	s.handler.KerberosService = authkerberos.NewKerberosService(provider)

--- a/pkg/auth/kerberos/provider.go
+++ b/pkg/auth/kerberos/provider.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -32,7 +33,16 @@ type Provider struct {
 	maxClockSkew     time.Duration
 	keytabPath       string
 	keytabManager    *KeytabManager
-	mu               sync.RWMutex
+
+	// AD domain identity (AD-4). All optional: empty values mean the server
+	// behaves as a standalone server (the SMB layer falls back to WORKGROUP).
+	// These are immutable after construction (derived from config once) and so
+	// are not guarded by mu.
+	realm         string // Kerberos realm, e.g. CONTOSO.COM
+	netbiosDomain string // NetBIOS short domain, e.g. CONTOSO ("" => standalone)
+	dnsDomain     string // DNS domain, e.g. contoso.com
+
+	mu sync.RWMutex
 }
 
 // NewProvider creates a new Kerberos provider from configuration.
@@ -71,12 +81,30 @@ func NewProvider(cfg *dconfig.KerberosConfig) (*Provider, error) {
 		return nil, fmt.Errorf("load krb5.conf %s: %w", krb5ConfPath, err)
 	}
 
+	// Resolve the AD domain identity. Realm defaults to the principal's
+	// "@REALM" suffix; DNSDomain defaults to the lowercased realm. NetBIOSDomain
+	// is never derived — when empty the SMB layer uses WORKGROUP (standalone).
+	// ApplyDefaults already fills these when the config flows through it, but
+	// resolve them here too so direct NewProvider callers (e.g. tests) and any
+	// path that bypasses ApplyDefaults still get consistent values.
+	realm := cfg.Realm
+	if realm == "" {
+		realm = extractRealm(servicePrincipal)
+	}
+	dnsDomain := cfg.DNSDomain
+	if dnsDomain == "" && realm != "" {
+		dnsDomain = strings.ToLower(realm)
+	}
+
 	p := &Provider{
 		keytab:           kt,
 		krb5Conf:         krbCfg,
 		servicePrincipal: servicePrincipal,
 		maxClockSkew:     cfg.MaxClockSkew,
 		keytabPath:       keytabPath,
+		realm:            realm,
+		netbiosDomain:    cfg.NetBIOSDomain,
+		dnsDomain:        dnsDomain,
 	}
 
 	// Create and start keytab manager for hot-reload
@@ -102,6 +130,35 @@ func (p *Provider) Keytab() *keytab.Keytab {
 // ServicePrincipal returns the configured service principal name.
 func (p *Provider) ServicePrincipal() string {
 	return p.servicePrincipal
+}
+
+// Realm returns the Kerberos realm the server is joined to (e.g. CONTOSO.COM),
+// or "" if it could not be determined. Immutable after construction.
+func (p *Provider) Realm() string {
+	return p.realm
+}
+
+// NetBIOSDomain returns the configured NetBIOS short domain (e.g. CONTOSO), or
+// "" when the server is standalone (in which case the SMB layer advertises and
+// uses WORKGROUP). Immutable after construction.
+func (p *Provider) NetBIOSDomain() string {
+	return p.netbiosDomain
+}
+
+// DNSDomain returns the DNS domain (e.g. contoso.com), defaulting to the
+// lowercased realm, or "" if neither was configured/derivable. Immutable after
+// construction.
+func (p *Provider) DNSDomain() string {
+	return p.dnsDomain
+}
+
+// extractRealm returns the "@REALM" suffix of a service principal
+// (e.g. "nfs/host@CONTOSO.COM" -> "CONTOSO.COM"), or "" if absent.
+func extractRealm(principal string) string {
+	if idx := strings.LastIndex(principal, "@"); idx >= 0 && idx < len(principal)-1 {
+		return principal[idx+1:]
+	}
+	return ""
 }
 
 // MaxClockSkew returns the maximum allowed clock skew.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -424,7 +424,7 @@ func (c *KerberosConfig) Validate() error {
 	// TargetInfo at session-setup time.
 	if c.Realm != "" {
 		if strings.ContainsAny(c.Realm, "@/ ") {
-			return fmt.Errorf("kerberos.realm %q is invalid (must not contain '@', '/', or spaces; e.g. CONTOSO.COM)", c.Realm)
+			return fmt.Errorf("kerberos realm %q is invalid (must not contain '@', '/', or spaces; e.g. CONTOSO.COM) — set kerberos.realm/DITTOFS_KERBEROS_REALM explicitly, or check the @REALM suffix of kerberos.service_principal it is derived from", c.Realm)
 		}
 	}
 	if c.NetBIOSDomain != "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -335,6 +335,41 @@ type KerberosConfig struct {
 	// Override: DITTOFS_KERBEROS_PRINCIPAL (primary), DITTOFS_KERBEROS_SERVICE_PRINCIPAL (compat)
 	ServicePrincipal string `mapstructure:"service_principal" yaml:"service_principal"`
 
+	// Realm is the Kerberos realm the server is joined to (e.g. CONTOSO.COM).
+	//
+	// When empty it is derived from the "@REALM" suffix of ServicePrincipal
+	// (applied in ApplyDefaults). It is used to make the SMB session
+	// domain-aware: it backs the DNS-domain default (lowercased Realm) when
+	// DNSDomain is not set explicitly.
+	//
+	// Optional and back-compatible: when neither Realm nor NetBIOSDomain is
+	// configured, the SMB server behaves exactly as a standalone server
+	// (advertising WORKGROUP), which is today's default.
+	// Override: DITTOFS_KERBEROS_REALM
+	Realm string `mapstructure:"realm" yaml:"realm"`
+
+	// NetBIOSDomain is the short NetBIOS domain name (e.g. CONTOSO).
+	//
+	// This is the domain the SMB server advertises in the NTLM Type-2
+	// TargetInfo (MsvAvNbDomainName) and stamps on a domain user's SMB
+	// session. It CANNOT be reliably derived from the realm (CONTOSO.COM may
+	// have a NetBIOS name unrelated to "CONTOSO"), so it must be set
+	// explicitly to make the server domain-aware.
+	//
+	// Optional and back-compatible: when empty the server advertises and uses
+	// "WORKGROUP" exactly as a standalone server does today.
+	// Override: DITTOFS_KERBEROS_NETBIOS_DOMAIN
+	NetBIOSDomain string `mapstructure:"netbios_domain" yaml:"netbios_domain"`
+
+	// DNSDomain is the DNS domain name (e.g. contoso.com) advertised in the
+	// NTLM Type-2 TargetInfo (MsvAvDnsDomainName).
+	//
+	// When empty it defaults to the lowercased Realm (applied in
+	// ApplyDefaults). When neither is set the server uses its standalone
+	// default DNS domain.
+	// Override: DITTOFS_KERBEROS_DNS_DOMAIN
+	DNSDomain string `mapstructure:"dns_domain" yaml:"dns_domain"`
+
 	// Krb5Conf is the path to the Kerberos configuration file.
 	// Default: /etc/krb5.conf
 	Krb5Conf string `mapstructure:"krb5_conf" yaml:"krb5_conf"`
@@ -382,6 +417,28 @@ func (c *KerberosConfig) Validate() error {
 		// "" is normalized to "static" in ApplyDefaults.
 	default:
 		return fmt.Errorf("kerberos.identity_mapping.strategy %q is not supported (only \"static\")", c.IdentityMapping.Strategy)
+	}
+	// AD domain identity fields are all optional (empty => standalone WORKGROUP
+	// behavior). When set, sanity-check their shape so a transposed realm vs
+	// NetBIOS name is caught at startup rather than producing a malformed NTLM
+	// TargetInfo at session-setup time.
+	if c.Realm != "" {
+		if strings.ContainsAny(c.Realm, "@/ ") {
+			return fmt.Errorf("kerberos.realm %q is invalid (must not contain '@', '/', or spaces; e.g. CONTOSO.COM)", c.Realm)
+		}
+	}
+	if c.NetBIOSDomain != "" {
+		// A NetBIOS short name is a single label: no dots, no '@'/'/' and no
+		// spaces. A dotted value almost always means a DNS/realm name was
+		// placed in the NetBIOS field.
+		if strings.ContainsAny(c.NetBIOSDomain, ".@/ ") {
+			return fmt.Errorf("kerberos.netbios_domain %q is invalid (must be a single NetBIOS label without '.', '@', '/', or spaces; e.g. CONTOSO)", c.NetBIOSDomain)
+		}
+	}
+	if c.DNSDomain != "" {
+		if strings.ContainsAny(c.DNSDomain, "@/ ") {
+			return fmt.Errorf("kerberos.dns_domain %q is invalid (must not contain '@', '/', or spaces; e.g. contoso.com)", c.DNSDomain)
+		}
 	}
 	return nil
 }

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -99,6 +99,23 @@ func applyKerberosDefaults(cfg *KerberosConfig) {
 		cfg.Krb5Conf = "/etc/krb5.conf"
 	}
 
+	// AD domain identity (AD-4): all optional and back-compatible.
+	//
+	// Realm defaults to the "@REALM" suffix of the service principal so an
+	// operator who already set service_principal=nfs/host@CONTOSO.COM gets a
+	// realm without restating it. NetBIOSDomain is intentionally NOT derived
+	// (it cannot be inferred from the realm) — leaving it empty keeps the
+	// standalone WORKGROUP behavior. DNSDomain defaults to the lowercased
+	// realm, the conventional AD mapping (CONTOSO.COM -> contoso.com).
+	if cfg.Realm == "" {
+		if idx := strings.LastIndex(cfg.ServicePrincipal, "@"); idx >= 0 && idx < len(cfg.ServicePrincipal)-1 {
+			cfg.Realm = cfg.ServicePrincipal[idx+1:]
+		}
+	}
+	if cfg.DNSDomain == "" && cfg.Realm != "" {
+		cfg.DNSDomain = strings.ToLower(cfg.Realm)
+	}
+
 	// Default max clock skew: 5 minutes (standard Kerberos default)
 	if cfg.MaxClockSkew == 0 {
 		cfg.MaxClockSkew = 5 * time.Minute

--- a/pkg/config/env_binding_test.go
+++ b/pkg/config/env_binding_test.go
@@ -294,6 +294,9 @@ func TestConfigEnvKeys_CoversKnownKeys(t *testing.T) {
 		"controlplane.require_initial_password_change",
 		"admin.username",
 		"kerberos.enabled",
+		"kerberos.realm",
+		"kerberos.netbios_domain",
+		"kerberos.dns_domain",
 		"gc.grace_period",
 		"snapshot.restore_http_timeout",
 	}
@@ -337,6 +340,105 @@ func TestLoad_EnvOnly_NoConfigFile(t *testing.T) {
 	}
 	if cfg.ControlPlane.JWT.Secret != "env-only-secret-key-minimum-32-characters!" {
 		t.Errorf("controlplane.jwt.secret: env override dropped on no-file path, got %q", cfg.ControlPlane.JWT.Secret)
+	}
+}
+
+// TestLoad_KerberosDomainFromEnv verifies the AD-4 domain identity env
+// overrides flow through the reflective env binding (no explicit BindEnv).
+func TestLoad_KerberosDomainFromEnv(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+
+	t.Setenv("DITTOFS_KERBEROS_REALM", "CONTOSO.COM")
+	t.Setenv("DITTOFS_KERBEROS_NETBIOS_DOMAIN", "CONTOSO")
+	t.Setenv("DITTOFS_KERBEROS_DNS_DOMAIN", "ad.contoso.com")
+
+	cfg, err := Load(missing)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Kerberos.Realm != "CONTOSO.COM" {
+		t.Errorf("kerberos.realm from env: got %q want CONTOSO.COM", cfg.Kerberos.Realm)
+	}
+	if cfg.Kerberos.NetBIOSDomain != "CONTOSO" {
+		t.Errorf("kerberos.netbios_domain from env: got %q want CONTOSO", cfg.Kerberos.NetBIOSDomain)
+	}
+	if cfg.Kerberos.DNSDomain != "ad.contoso.com" {
+		t.Errorf("kerberos.dns_domain from env (explicit, not derived): got %q want ad.contoso.com", cfg.Kerberos.DNSDomain)
+	}
+}
+
+// TestApplyDefaults_KerberosDomainDerivation verifies realm derives from the
+// service principal and dns_domain derives from the realm, while netbios_domain
+// is never derived. Crucially, an empty config stays empty (standalone).
+func TestApplyDefaults_KerberosDomainDerivation(t *testing.T) {
+	t.Run("derive realm and dns from principal", func(t *testing.T) {
+		cfg := &KerberosConfig{ServicePrincipal: "nfs/host.contoso.com@CONTOSO.COM"}
+		applyKerberosDefaults(cfg)
+		if cfg.Realm != "CONTOSO.COM" {
+			t.Errorf("derived realm: got %q want CONTOSO.COM", cfg.Realm)
+		}
+		if cfg.DNSDomain != "contoso.com" {
+			t.Errorf("derived dns_domain: got %q want contoso.com", cfg.DNSDomain)
+		}
+		if cfg.NetBIOSDomain != "" {
+			t.Errorf("netbios_domain must NOT be derived, got %q", cfg.NetBIOSDomain)
+		}
+	})
+
+	t.Run("explicit values preserved", func(t *testing.T) {
+		cfg := &KerberosConfig{
+			ServicePrincipal: "nfs/host@CONTOSO.COM",
+			Realm:            "OTHER.REALM",
+			DNSDomain:        "explicit.example.com",
+			NetBIOSDomain:    "SHORT",
+		}
+		applyKerberosDefaults(cfg)
+		if cfg.Realm != "OTHER.REALM" {
+			t.Errorf("explicit realm overwritten: got %q", cfg.Realm)
+		}
+		if cfg.DNSDomain != "explicit.example.com" {
+			t.Errorf("explicit dns_domain overwritten: got %q", cfg.DNSDomain)
+		}
+		if cfg.NetBIOSDomain != "SHORT" {
+			t.Errorf("explicit netbios_domain overwritten: got %q", cfg.NetBIOSDomain)
+		}
+	})
+
+	t.Run("standalone stays empty", func(t *testing.T) {
+		// No principal, no domain fields: must remain empty so the SMB layer
+		// falls back to WORKGROUP (backward compatibility).
+		cfg := &KerberosConfig{}
+		applyKerberosDefaults(cfg)
+		if cfg.Realm != "" || cfg.NetBIOSDomain != "" || cfg.DNSDomain != "" {
+			t.Errorf("standalone config should stay empty, got realm=%q netbios=%q dns=%q",
+				cfg.Realm, cfg.NetBIOSDomain, cfg.DNSDomain)
+		}
+	})
+}
+
+// TestKerberosConfig_ValidateDomainShape checks the field-shape validation.
+func TestKerberosConfig_ValidateDomainShape(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     KerberosConfig
+		wantErr bool
+	}{
+		{"empty ok (standalone)", KerberosConfig{}, false},
+		{"valid domain", KerberosConfig{Realm: "CONTOSO.COM", NetBIOSDomain: "CONTOSO", DNSDomain: "contoso.com"}, false},
+		{"netbios with dot rejected", KerberosConfig{NetBIOSDomain: "contoso.com"}, true},
+		{"realm with @ rejected", KerberosConfig{Realm: "host@CONTOSO.COM"}, true},
+		{"dns with space rejected", KerberosConfig{DNSDomain: "contoso com"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if tc.wantErr && err == nil {
+				t.Errorf("expected validation error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected validation error: %v", err)
+			}
+		})
 	}
 }
 

--- a/test/integration/ad-dc/ad_dc_keytab_test.go
+++ b/test/integration/ad-dc/ad_dc_keytab_test.go
@@ -1,0 +1,243 @@
+//go:build ad_dc
+
+// AD-4 integration test: ONE combined keytab serves both the SMB (cifs/) and
+// NFS (nfs/) service principals, and the SMB layer is domain-aware.
+//
+// This builds on the same Samba AD-DC fixture as AD-1 (TestADGroupSIDsFromPAC):
+// the fixture now registers BOTH cifs/ and nfs/ SPNs on the service account and
+// exports their keys into a single dittofs.keytab. This test asserts, against
+// that real fixture:
+//
+//  1. The combined keytab file actually contains BOTH a cifs/ and an nfs/
+//     principal entry (so one keytab serves both protocols).
+//  2. A Kerberos Provider built over that keytab and configured with the AD
+//     domain identity (Realm/NetBIOSDomain) surfaces Realm()/NetBIOSDomain()/
+//     DNSDomain() as configured/derived.
+//  3. An SMB Handler with NetBIOSDomain set produces an NTLM Type-2 challenge
+//     whose TargetInfo advertises the AD NetBIOS domain (MsvAvNbDomainName ==
+//     "DITTOFS"), not the standalone "WORKGROUP" — exercising the exact
+//     BuildChallenge call the handler's negotiate path makes.
+//  4. As a real end-to-end SMB SPNEGO-Kerberos accept, alice's cifs/ service
+//     ticket (obtained from the fixture KDC) is decrypted and validated by the
+//     KerberosService built over the COMBINED keytab — proving the cifs/ key in
+//     the shared keytab works for an SMB accept.
+//
+// The full live SMB+NFS krb5 session over the wire (real mount / smbclient with
+// the same combined keytab serving both protocols simultaneously) is covered by
+// AD-4b (scw / Windows acceptance); here we assert at the
+// keytab + provider + challenge + krb5-accept level, which is deterministic in CI.
+//
+// Run with: go test -tags=ad_dc -v -timeout 20m ./test/integration/ad-dc/
+package ad_dc_test
+
+import (
+	"encoding/binary"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	smbauth "github.com/marmos91/dittofs/internal/adapter/smb/auth"
+	"github.com/marmos91/dittofs/internal/adapter/smb/handlers"
+	kerbauth "github.com/marmos91/dittofs/internal/auth/kerberos"
+	"github.com/marmos91/dittofs/pkg/auth/kerberos"
+	dconfig "github.com/marmos91/dittofs/pkg/config"
+)
+
+// The combined keytab also carries nfs/dittofs.dittofs.ad@DITTOFS.AD (the NFS
+// SPN) alongside adSMBSPNFull (cifs/...), defined in ad_dc_integration_test.go.
+// Its presence is asserted at the keytab-byte level in (1); its live use is the
+// NFS krb5 path / AD-4b.
+
+// TestADCombinedKeytabAndDomainAwareSMB exercises the AD-4 wiring end to end
+// against the Samba AD-DC fixture.
+func TestADCombinedKeytabAndDomainAwareSMB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping AD-DC integration test in short mode")
+	}
+	if !dockerAvailable() {
+		t.Skip("docker not found, skipping AD-DC integration test")
+	}
+
+	// Bring up the fixture (shared helper from ad_dc_integration_test.go). It
+	// builds the image, provisions the domain, and copies out the COMBINED
+	// keytab + a host-side krb5.conf pointing at the mapped KDC port.
+	_, keytabPath, krb5ConfPath, cleanup := setupADDC(t)
+	defer cleanup()
+
+	// --- (1) Combined keytab carries BOTH cifs/ and nfs/ principals ---------
+	// The keytab v2 on-disk format stores each principal's name components as
+	// length-prefixed ASCII, so the component label ("cifs" / "nfs") appears
+	// verbatim in the file bytes. Asserting on the raw file (rather than poking
+	// the keytab with a specific enctype) is robust to whatever enctypes the DC
+	// happens to hold for the SPNs.
+	ktBytes, err := os.ReadFile(keytabPath)
+	if err != nil {
+		t.Fatalf("read combined keytab %s: %v", keytabPath, err)
+	}
+	if !keytabHasComponent(ktBytes, "cifs") {
+		t.Errorf("combined keytab missing cifs/ principal component (file %d bytes)", len(ktBytes))
+	}
+	if !keytabHasComponent(ktBytes, "nfs") {
+		t.Errorf("combined keytab missing nfs/ principal component (file %d bytes)", len(ktBytes))
+	}
+	t.Logf("combined keytab (%d bytes) carries both cifs/ and nfs/ principals ✓", len(ktBytes))
+
+	// --- (2) Provider surfaces the configured/derived AD domain identity ----
+	// Configure Realm + NetBIOSDomain explicitly (the short name is never
+	// derived). DNSDomain is left unset so the provider derives it from the
+	// lowercased realm.
+	cfg := &dconfig.KerberosConfig{
+		Enabled:          true,
+		KeytabPath:       keytabPath,
+		ServicePrincipal: adSMBSPNFull, // cifs/...@DITTOFS.AD
+		Krb5Conf:         krb5ConfPath,
+		Realm:            adRealm,  // DITTOFS.AD
+		NetBIOSDomain:    adDomain, // DITTOFS (short)
+		MaxClockSkew:     5 * time.Minute,
+		ContextTTL:       10 * time.Minute,
+		MaxContexts:      100,
+	}
+	provider, err := kerberos.NewProvider(cfg)
+	if err != nil {
+		t.Fatalf("create kerberos provider over combined keytab: %v", err)
+	}
+	defer provider.Close()
+
+	if got := provider.Realm(); got != adRealm {
+		t.Errorf("Provider.Realm() = %q, want %q", got, adRealm)
+	}
+	if got := provider.NetBIOSDomain(); got != adDomain {
+		t.Errorf("Provider.NetBIOSDomain() = %q, want %q", got, adDomain)
+	}
+	// DNSDomain was unset -> derived from the lowercased realm.
+	wantDNS := strings.ToLower(adRealm) // dittofs.ad
+	if got := provider.DNSDomain(); got != wantDNS {
+		t.Errorf("Provider.DNSDomain() = %q, want derived %q", got, wantDNS)
+	}
+	t.Logf("Provider domain identity: realm=%q netbios=%q dns=%q ✓",
+		provider.Realm(), provider.NetBIOSDomain(), provider.DNSDomain())
+
+	// --- (3) Domain-aware SMB challenge advertises the AD NetBIOS domain ----
+	// Build a Handler wired with the domain from the provider (the same wiring
+	// the adapter performs), then make the exact BuildChallenge call its
+	// negotiate path makes. The Type-2 TargetInfo must advertise the AD NetBIOS
+	// domain, not the standalone "WORKGROUP".
+	h := &handlers.Handler{
+		NetBIOSDomain: provider.NetBIOSDomain(),
+		DNSDomain:     provider.DNSDomain(),
+	}
+	challenge, _ := smbauth.BuildChallenge(h.NetBIOSDomain, h.DNSDomain)
+	pairs := parseChallengeTargetInfo(t, challenge)
+
+	if got := pairs[smbauth.AvNbDomainName]; got != adDomain {
+		t.Errorf("Type-2 MsvAvNbDomainName = %q, want %q (domain-aware, not WORKGROUP)", got, adDomain)
+	}
+	if got := pairs[smbauth.AvDnsDomainName]; got != wantDNS {
+		t.Errorf("Type-2 MsvAvDnsDomainName = %q, want %q", got, wantDNS)
+	}
+	t.Logf("SMB Type-2 challenge advertises NbDomain=%q DnsDomain=%q ✓",
+		pairs[smbauth.AvNbDomainName], pairs[smbauth.AvDnsDomainName])
+
+	// --- (4) Real SMB SPNEGO-Kerberos accept with the combined keytab -------
+	// alice obtains a cifs/ service ticket from the fixture KDC; the
+	// KerberosService built over the COMBINED keytab must decrypt + validate it.
+	// This proves the cifs/ key inside the shared keytab actually serves SMB
+	// accepts (the nfs/ key is exercised by the NFS krb5 path / AD-4b).
+	service := kerbauth.NewKerberosService(provider)
+	apReqBytes := getADAPREQ(t, krb5ConfPath) // alice -> cifs/ AP-REQ
+
+	result, err := service.Authenticate(apReqBytes, adSMBSPNFull)
+	if err != nil {
+		t.Fatalf("SMB krb5 accept with combined keytab failed: %v", err)
+	}
+	if result.Principal == "" {
+		t.Error("expected non-empty principal from SMB krb5 accept")
+	}
+	if !strings.EqualFold(result.Realm, adRealm) {
+		t.Errorf("accepted realm = %q, want %q", result.Realm, adRealm)
+	}
+	t.Logf("SMB krb5 accept via combined keytab: principal=%q realm=%q ✓",
+		result.Principal, result.Realm)
+}
+
+// dockerAvailable reports whether a docker binary is on PATH (mirrors the
+// skip-if-docker-absent guard in ad_dc_integration_test.go).
+func dockerAvailable() bool {
+	_, err := exec.LookPath("docker")
+	return err == nil
+}
+
+// keytabHasComponent reports whether the raw keytab file contains a principal
+// name component equal to want. In the MIT keytab v2 format a name component is
+// serialized as a uint16 length (big-endian) followed by that many ASCII bytes;
+// scanning for the length-prefixed token avoids false positives from substrings
+// embedded in other fields (e.g. the realm or a longer hostname).
+func keytabHasComponent(buf []byte, want string) bool {
+	w := []byte(want)
+	n := len(w)
+	if n == 0 || n > 0xFFFF {
+		return false
+	}
+	for i := 0; i+2+n <= len(buf); i++ {
+		if int(binary.BigEndian.Uint16(buf[i:i+2])) != n {
+			continue
+		}
+		if string(buf[i+2:i+2+n]) == want {
+			return true
+		}
+	}
+	return false
+}
+
+// parseChallengeTargetInfo extracts the TargetInfo AV_PAIR blob from a Type-2
+// CHALLENGE message and decodes it into AvID -> UTF-16LE string. The TargetInfo
+// fields live at offset 40 of the Type-2 message: len(uint16)@40, off(uint32)@44.
+func parseChallengeTargetInfo(t *testing.T, msg []byte) map[smbauth.AvID]string {
+	t.Helper()
+	const tiLenOff = 40
+	const tiOffOff = 44
+	if len(msg) < tiOffOff+4 {
+		t.Fatalf("challenge too short (%d bytes) to hold TargetInfo fields", len(msg))
+	}
+	tiLen := int(binary.LittleEndian.Uint16(msg[tiLenOff : tiLenOff+2]))
+	tiOff := int(binary.LittleEndian.Uint32(msg[tiOffOff : tiOffOff+4]))
+	if tiOff+tiLen > len(msg) {
+		t.Fatalf("TargetInfo off=%d len=%d overruns message (%d bytes)", tiOff, tiLen, len(msg))
+	}
+	return decodeAvPairs(t, msg[tiOff:tiOff+tiLen])
+}
+
+// decodeAvPairs walks an AV_PAIR list returning AvID -> decoded UTF-16LE string
+// (string-valued pairs only; it stops at AvEOL).
+func decodeAvPairs(t *testing.T, buf []byte) map[smbauth.AvID]string {
+	t.Helper()
+	out := make(map[smbauth.AvID]string)
+	for len(buf) >= 4 {
+		id := smbauth.AvID(binary.LittleEndian.Uint16(buf[0:2]))
+		ln := int(binary.LittleEndian.Uint16(buf[2:4]))
+		if id == smbauth.AvEOL {
+			break
+		}
+		if 4+ln > len(buf) {
+			t.Fatalf("AV_PAIR id=0x%x len %d overruns (%d remaining)", id, ln, len(buf)-4)
+		}
+		val := buf[4 : 4+ln]
+		runes := make([]uint16, ln/2)
+		for i := 0; i < ln/2; i++ {
+			runes[i] = binary.LittleEndian.Uint16(val[i*2:])
+		}
+		out[id] = string(utf16Runes(runes))
+		buf = buf[4+ln:]
+	}
+	return out
+}
+
+func utf16Runes(u []uint16) []rune {
+	r := make([]rune, len(u))
+	for i, c := range u {
+		r[i] = rune(c)
+	}
+	return r
+}

--- a/test/integration/ad-dc/entrypoint.sh
+++ b/test/integration/ad-dc/entrypoint.sh
@@ -130,20 +130,48 @@ samba-tool group addmembers devs "$USER_ALICE" >/dev/null 2>&1 || true
 create_user_if_absent "$USER_BOB"
 samba-tool group addmembers engineering "$USER_BOB" >/dev/null 2>&1 || true
 
-# --- Service keytab -------------------------------------------------------
-# Register the DittoFS SMB + NFS service principals on the Administrator account
-# and export their keys so the server can decrypt client AP-REQs. The PAC is
-# signed with the same key, so a correct keytab is required for PAC validation.
+# --- Combined service keytab ----------------------------------------------
+# Register BOTH the DittoFS SMB (cifs/) AND NFS (nfs/) service principals on the
+# Administrator account and export their keys into ONE keytab. A single keytab
+# serving both protocols is what AD-4 exercises: the dittofs server loads one
+# keytab and decrypts client AP-REQs for either the SMB or the NFS SPN with it.
+#
+# `samba-tool domain exportkeytab <file> --principal=...` APPENDS the principal's
+# keys to <file> when it already exists, so two successive invocations into the
+# same path produce a combined keytab containing both SPNs (each with all the
+# enctypes the DC holds). AD-1's PAC test consumes the cifs/ entry of this same
+# keytab, so keeping both in one file keeps AD-1 working unchanged.
 keytab="$KEYTAB_DIR/dittofs.keytab"
 if [ ! -f "$keytab" ]; then
-    log "Exporting service keytab to $keytab ($SMB_SPN, $NFS_SPN)"
+    log "Registering SPNs and exporting COMBINED keytab to $keytab ($SMB_SPN + $NFS_SPN)"
+
+    # Register both SPNs on Administrator. `spn add` is idempotent-ish: it errors
+    # if the SPN already exists, which is fine on a re-provisioned fixture.
     samba-tool spn add "$SMB_SPN" "$DOMAIN\\Administrator" >/dev/null 2>&1 || true
     samba-tool spn add "$NFS_SPN" "$DOMAIN\\Administrator" >/dev/null 2>&1 || true
+
+    # Export cifs/ then APPEND nfs/ into the same keytab file.
     samba-tool domain exportkeytab "$keytab" \
-        --principal="$SMB_SPN@$REALM" >/dev/null 2>&1 || true
+        --principal="$SMB_SPN@$REALM"
     samba-tool domain exportkeytab "$keytab" \
-        --principal="$NFS_SPN@$REALM" >/dev/null 2>&1 || true
-    # Also export Administrator's key so tests that need a TGT via keytab can.
+        --principal="$NFS_SPN@$REALM"
+
+    # Verify the combined keytab actually carries BOTH principals before we hand
+    # it off. klist -k lists keytab entries; fail loudly here rather than letting
+    # the Go test discover a half-exported keytab much later.
+    if klist -k "$keytab" >/dev/null 2>&1; then
+        if ! klist -k "$keytab" 2>/dev/null | grep -qi "cifs/"; then
+            log "ERROR: combined keytab missing cifs/ principal"; klist -k "$keytab" || true; exit 1
+        fi
+        if ! klist -k "$keytab" 2>/dev/null | grep -qi "nfs/"; then
+            log "ERROR: combined keytab missing nfs/ principal"; klist -k "$keytab" || true; exit 1
+        fi
+        log "Combined keytab verified: carries both cifs/ and nfs/ principals"
+    else
+        log "klist unavailable; skipping in-container keytab verification (Go test re-checks)"
+    fi
+
+    # The dittofs container runs as a non-root uid; make the keytab readable there.
     chown "$DITTOFS_UID:$DITTOFS_GID" "$keytab" 2>/dev/null || true
     chmod 0400 "$keytab" 2>/dev/null || true
 fi


### PR DESCRIPTION
Part of #1231. Part of **#1236** — the CODE half of AD-4; live scw-VM + real-Windows acceptance is AD-4b (follow-up).

## What
- **KerberosConfig** gains optional `realm` / `netbios_domain` / `dns_domain` (+ `DITTOFS_KERBEROS_{REALM,NETBIOS_DOMAIN,DNS_DOMAIN}`). Realm derives from the service principal's `@REALM`; DNS domain defaults to lowercased realm; NetBIOS is never derived. Provider exposes `Realm()/NetBIOSDomain()/DNSDomain()`.
- **Domain-aware SMB**: `buildTargetInfo`/`BuildChallenge` advertise the AD NetBIOS+DNS domain in the NTLM Type-2 TargetInfo; the NTLMv2 domain-try list + authenticated `Session.Domain` reflect it. Adapter wires the domain from the Kerberos provider.
- **Docs**: domain-aware fields + the offline combined-keytab import flow (one keytab holding `cifs/`+`nfs/` SPNs); `docs/CLI.md` regenerated.

SMB Kerberos accept + SPNEGO/NTLM-fallback already exist from AD-1 (not rebuilt).

## Backward-compatible (ships without breaking existing installs)
Every new field is optional. Unconfigured → the server advertises `WORKGROUP`/`local` and NTLM behaves exactly as before AD-4. Unit test pins this (`buildTargetInfo("FILESERVER","","")` → `WORKGROUP`).

## Verification
`go build ./...`, `go vet ./...`, `gofmt`, full-repo compile-check, `go vet -tags=ad_dc ./test/integration/ad-dc/`, and smb/auth + smb/handlers + config + kerberos package tests — all green.

A CI-repeatable `ad_dc` integration test (real SMB SPNEGO-Kerberos session-setup + NFS krb5 from a combined keytab) is being added on top of this branch.