### PR TITLE
fix(engine): dedup against not-yet-Remote donor returns MISS, not EIO (#1245 Bug A)

### DIFF
--- a/pkg/block/engine/coordinator_test.go
+++ b/pkg/block/engine/coordinator_test.go
@@ -27,6 +27,12 @@ type fakeCoordinator struct {
 	failOnNthIncrement int
 	incCallCount       int
 
+	// Optional: incErr overrides the error returned by failOnNthIncrement.
+	// When nil the generic induced-failure error is used. Set to
+	// block.ErrFileBlockNotFound to simulate a Pending (non-durable) donor
+	// whose Remote-gated GetByHash resolves to no FileBlock row (#1245 Bug A).
+	incErr error
+
 	// Optional: failOnNthDecrement returns an error on the Nth (1-based)
 	// DecrementRefCount call. Zero disables.
 	failOnNthDecrement int
@@ -93,6 +99,9 @@ func (f *fakeCoordinator) IncrementRefCount(_ context.Context, hash block.Conten
 	defer f.mu.Unlock()
 	f.incCallCount++
 	if f.failOnNthIncrement > 0 && f.incCallCount == f.failOnNthIncrement {
+		if f.incErr != nil {
+			return f.incErr
+		}
 		return errors.New("fakeCoordinator: induced IncrementRefCount failure")
 	}
 	f.incHashes = append(f.incHashes, hash)

--- a/pkg/block/engine/dedup.go
+++ b/pkg/block/engine/dedup.go
@@ -257,15 +257,50 @@ func (m *Syncer) applyFileLevelDedupHit(
 	isRetry bool,
 ) (bool, error) {
 	// 1. Increment RefCount on every distinct hash in target.
+	//
+	// `seen` tracks the hashes whose RefCount THIS call has already
+	// successfully incremented, so any early exit can roll them back
+	// and leave no leak. The hash currently being incremented is added
+	// to `seen` only AFTER a successful increment — a failed increment
+	// did NOT bump that hash, so it must be excluded from rollback.
 	seen := make(map[block.ContentHash]struct{}, len(targetBlocks))
 	for _, br := range targetBlocks {
 		if _, ok := seen[br.Hash]; ok {
 			continue
 		}
-		seen[br.Hash] = struct{}{}
 		if err := m.coordinator.IncrementRefCount(ctx, br.Hash); err != nil {
+			// Pending / non-durable donor: the coordinator's
+			// Remote-gated GetByHash resolves a not-yet-durable target
+			// block to "no FileBlock row" and surfaces
+			// metadata.ErrFileBlockNotFound. Deduping onto a target whose
+			// CAS blocks have not reached Remote is genuinely unsafe (the
+			// Remote-gate is correct — issue #1245 Bug A), so this is a
+			// dedup MISS, not a hard error: roll back the increments this
+			// call already made (excluding br.Hash, which was NOT
+			// incremented) and return (false, nil) so the caller falls
+			// through to the normal per-block upload of the file's own
+			// blocks. Dedup collapses later once the donor reaches Remote.
+			if errors.Is(err, block.ErrFileBlockNotFound) {
+				if rbErr := m.rollbackIncrements(ctx, seen, "file-level dedup pending-donor miss rollback"); rbErr != nil {
+					// A failed rollback decrement leaves a permanent +1
+					// RefCount on a CAS chunk; surface it rather than
+					// swallowing the leak, even though the not-found
+					// signal itself is benign.
+					return false, fmt.Errorf("file-level dedup pending-donor miss (refcount rollback also failed): %w", rbErr)
+				}
+				return false, nil
+			}
+			// Any other increment error is a real backend fault: roll
+			// back the increments already made on this call (excluding
+			// br.Hash) before propagating, so a mid-loop failure never
+			// leaks a partial set of RefCount bumps.
+			if rbErr := m.rollbackIncrements(ctx, seen, "file-level dedup increment-error rollback"); rbErr != nil {
+				return false, fmt.Errorf("file-level dedup: increment refcount on target hash %s (refcount rollback also failed): %w",
+					br.Hash.String(), errors.Join(err, rbErr))
+			}
 			return false, fmt.Errorf("file-level dedup: increment refcount on target hash %s: %w", br.Hash.String(), err)
 		}
+		seen[br.Hash] = struct{}{}
 	}
 
 	// 2. Persist target.Blocks + provisional ObjectID (single metadata

--- a/pkg/block/engine/dedup_pending_donor_test.go
+++ b/pkg/block/engine/dedup_pending_donor_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/engine"
 	"github.com/marmos91/dittofs/pkg/block/local/memory"
@@ -170,8 +169,11 @@ func runPendingDonorEagerDedup(t *testing.T, ms metadata.Store, sharePrefix stri
 	_ = objectID
 	_ = donorHash
 
-	// File B: identical content. Write then Flush — the eager path fires.
-	pidB := shareNamePrefix(shareName) + "/" + uuid.NewString()
+	// File B: identical content, backed by a REAL metadata File row (so the
+	// pending-donor MISS falls through to a faithful per-block upload +
+	// PersistFileBlocks against B's own row). Write then Flush — the eager
+	// path fires.
+	pidB, _ := createRealFile(t, ms, shareName, "clone.bin", rootHandle)
 	if _, err := bs.WriteAt(ctx, pidB, nil, content, 0); err != nil {
 		t.Fatalf("WriteAt clone: %v", err)
 	}

--- a/pkg/block/engine/dedup_pending_donor_test.go
+++ b/pkg/block/engine/dedup_pending_donor_test.go
@@ -1,0 +1,218 @@
+package engine_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/block/local/memory"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatabadger "github.com/marmos91/dittofs/pkg/metadata/store/badger"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+	"lukechampine.com/blake3"
+)
+
+// newEngineOverMetadataStore builds an engine.Store with a MEMORY local store
+// (so the eager small-file dedup path's bs.local.GetFileSize gate works after a
+// plain WriteAt — the fs local store only refreshes that size during recovery)
+// wired to the supplied REAL metadata store as the FileBlockStore, plus the
+// faithful testCoordinator. This lets the eager dedup hit route through the real
+// Remote-gated GetByHash, which is what triggers issue #1245 Bug A on a Pending
+// donor.
+func newEngineOverMetadataStore(t *testing.T, ms metadata.Store) *engine.Store {
+	t.Helper()
+	localStore := memory.New()
+	coord := &testCoordinator{store: ms}
+	syncer := engine.NewSyncer(localStore, nil, ms, engine.DefaultConfig())
+	bs, err := engine.New(engine.BlockStoreConfig{
+		Local:          localStore,
+		Remote:         nil,
+		Syncer:         syncer,
+		FileBlockStore: ms,
+		Coordinator:    coord,
+	})
+	if err != nil {
+		t.Fatalf("engine.New: %v", err)
+	}
+	if err := bs.Start(context.Background()); err != nil {
+		t.Fatalf("engine.Start: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+	return bs
+}
+
+// seedPendingDonor installs a donor file into the metadata store that mimics the
+// real rollup-persister's intermediate state for a single-chunk small file:
+//
+//   - A per-chunk FileBlock row in BlockStatePending (so the Remote-gated
+//     GetByHash returns nil — the donor is not yet durable).
+//   - A File row whose FileAttr.ObjectID is the single-block Merkle root, so the
+//     object-id index is published and FindByObjectID HITS.
+//
+// This is exactly the window the rollup persister leaves open: engine.go writes
+// the FileBlock rows as Pending and PersistFileBlocks publishes the ObjectID in
+// the same pass, and over a slow remote those rows stay Pending for seconds or
+// minutes. Returns the published ObjectID and the donor's content hash.
+func seedPendingDonor(t *testing.T, ms metadata.Store, shareName, name string, rootHandle metadata.FileHandle, content []byte) (block.ObjectID, block.ContentHash) {
+	t.Helper()
+	ctx := context.Background()
+
+	var hash block.ContentHash
+	sum := blake3.Sum256(content)
+	copy(hash[:], sum[:])
+	blockRef := block.BlockRef{Hash: hash, Offset: 0, Size: uint32(len(content))}
+	objectID := block.ComputeObjectID([]block.BlockRef{blockRef})
+
+	path := "/" + name
+	handle, err := ms.GenerateHandle(ctx, shareName, path)
+	if err != nil {
+		t.Fatalf("GenerateHandle donor: %v", err)
+	}
+	_, id, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		t.Fatalf("DecodeFileHandle donor: %v", err)
+	}
+	payloadID := shareNamePrefix(shareName) + "/" + id.String()
+
+	// FileBlock row in Pending state — GetByHash is Remote-gated, so this row
+	// will NOT resolve via the coordinator's IncrementRefCount path.
+	fb := &block.FileBlock{
+		ID:       payloadID + "/0",
+		Hash:     hash,
+		DataSize: uint32(len(content)),
+		State:    block.BlockStatePending,
+		RefCount: 1,
+	}
+	if err := ms.Put(ctx, fb); err != nil {
+		t.Fatalf("Put donor FileBlock: %v", err)
+	}
+
+	// File row with the published ObjectID + Blocks manifest so FindByObjectID
+	// resolves to this donor.
+	file := &metadata.File{
+		ID:        id,
+		ShareName: shareName,
+		Path:      path,
+		FileAttr: metadata.FileAttr{
+			Type:      metadata.FileTypeRegular,
+			Mode:      0o644,
+			UID:       1000,
+			GID:       1000,
+			Size:      uint64(len(content)),
+			PayloadID: metadata.PayloadID(payloadID),
+			ObjectID:  objectID,
+			Blocks:    []block.BlockRef{blockRef},
+		},
+	}
+	if err := ms.PutFile(ctx, file); err != nil {
+		t.Fatalf("PutFile donor: %v", err)
+	}
+	if err := ms.SetParent(ctx, handle, rootHandle); err != nil {
+		t.Fatalf("SetParent donor: %v", err)
+	}
+	if err := ms.SetChild(ctx, rootHandle, name, handle); err != nil {
+		t.Fatalf("SetChild donor: %v", err)
+	}
+	if err := ms.SetLinkCount(ctx, handle, 1); err != nil {
+		t.Fatalf("SetLinkCount donor: %v", err)
+	}
+
+	// Sanity: FindByObjectID must hit, and GetByHash must be gated to nil
+	// (Pending donor). If either of these breaks the repro is invalid.
+	if got, err := ms.FindByObjectID(ctx, objectID); err != nil || len(got) == 0 {
+		t.Fatalf("seedPendingDonor: FindByObjectID must hit (err=%v, blocks=%d)", err, len(got))
+	}
+	if fbGot, err := ms.GetByHash(ctx, hash); err != nil || fbGot != nil {
+		t.Fatalf("seedPendingDonor: GetByHash must be Remote-gated to nil for a Pending donor (err=%v, fb=%v)", err, fbGot)
+	}
+	return objectID, hash
+}
+
+func shareNamePrefix(shareName string) string {
+	if len(shareName) > 0 && shareName[0] == '/' {
+		return shareName[1:]
+	}
+	return shareName
+}
+
+// runPendingDonorEagerDedup is the shared body for issue #1245 Bug A through the
+// EAGER small-file dedup path.
+//
+// A donor with a published ObjectID but Pending (non-durable) FileBlock rows is
+// seeded. A second, byte-identical small file B is written and Flushed: the
+// eager small-file dedup fast-path computes the same single-block ObjectID,
+// FindByObjectID HITS the Pending donor, and applyFileLevelDedupHit tries to
+// IncrementRefCount on it.
+//
+// BEFORE the fix: IncrementRefCount → GetByHash (Remote-gated) → nil →
+// metadata.ErrFileBlockNotFound → applyFileLevelDedupHit returns an error →
+// Flush returns "eager small-file dedup: …no FileBlock…" → EIO, wedging the
+// SMB/NFS session on CLOSE/COMMIT.
+//
+// AFTER the fix: the Pending donor is treated as a clean MISS — Flush succeeds,
+// falls through to the normal per-block upload of B's own blocks, and B is
+// fully readable.
+func runPendingDonorEagerDedup(t *testing.T, ms metadata.Store, sharePrefix string) {
+	t.Helper()
+	ctx := context.Background()
+
+	shareName := sharePrefix + "-pending-donor"
+	rootHandle := createShare(t, ms, shareName)
+	bs := newEngineOverMetadataStore(t, ms)
+
+	// <= chunker.MinChunkSize so a single chunk drives the eager fast-path.
+	content := distinctContent(0x42, 64*1024)
+
+	// Seed donor A: published ObjectID + Pending FileBlock row.
+	objectID, donorHash := seedPendingDonor(t, ms, shareName, "donor.bin", rootHandle, content)
+	_ = objectID
+	_ = donorHash
+
+	// File B: identical content. Write then Flush — the eager path fires.
+	pidB := shareNamePrefix(shareName) + "/" + uuid.NewString()
+	if _, err := bs.WriteAt(ctx, pidB, nil, content, 0); err != nil {
+		t.Fatalf("WriteAt clone: %v", err)
+	}
+
+	// THE failing assertion before the fix: Flush must NOT error on a Pending
+	// donor — it must treat the eager hit as a miss and fall through.
+	if _, err := bs.Flush(ctx, pidB); err != nil {
+		t.Fatalf("Flush clone against Pending donor returned error (Bug A — should be a clean MISS): %v", err)
+	}
+
+	// After the miss, B must be fully readable from its own (locally rolled-up)
+	// blocks — no partial / wedged state.
+	readBack := make([]byte, len(content))
+	n, err := bs.ReadAt(ctx, pidB, nil, readBack, 0)
+	if err != nil {
+		t.Fatalf("ReadAt clone after Pending-donor miss: %v", err)
+	}
+	if n != len(content) {
+		t.Fatalf("ReadAt clone short read: got %d, want %d", n, len(content))
+	}
+	for i := range content {
+		if readBack[i] != content[i] {
+			t.Fatalf("clone content mismatch at byte %d after Pending-donor miss", i)
+		}
+	}
+}
+
+// TestMemoryDedup_PendingDonor_TreatedAsMiss locks in issue #1245 Bug A on the
+// in-memory metadata backend through the REAL engine eager-dedup Flush path.
+func TestMemoryDedup_PendingDonor_TreatedAsMiss(t *testing.T) {
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	runPendingDonorEagerDedup(t, ms, "mem")
+}
+
+// TestBadgerDedup_PendingDonor_TreatedAsMiss locks in issue #1245 Bug A on the
+// Badger metadata backend through the REAL engine eager-dedup Flush path.
+func TestBadgerDedup_PendingDonor_TreatedAsMiss(t *testing.T) {
+	ms, err := metadatabadger.NewBadgerMetadataStoreWithDefaults(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
+	}
+	t.Cleanup(func() { _ = ms.Close() })
+	runPendingDonorEagerDedup(t, ms, "badger")
+}

--- a/pkg/block/engine/dedup_test.go
+++ b/pkg/block/engine/dedup_test.go
@@ -475,6 +475,149 @@ func TestDedup_ConcurrentRace(t *testing.T) {
 	}
 }
 
+// TestApplyFileLevelDedupHit_PendingDonor_TreatedAsMiss encodes issue #1245
+// Bug A at the helper level: a target (donor) whose FileBlock rows are still
+// Pending (non-durable) makes the coordinator's Remote-gated GetByHash resolve
+// to no row, so IncrementRefCount returns block.ErrFileBlockNotFound. The helper
+// MUST treat this as a dedup MISS — return (false, nil), NOT an error — and roll
+// back any increments already made on prior target hashes so no RefCount leaks.
+// PersistFileBlocks MUST NOT be called (the caller falls through to the normal
+// per-block upload).
+func TestApplyFileLevelDedupHit_PendingDonor_TreatedAsMiss(t *testing.T) {
+	ctx := context.Background()
+	m, fc := dedupTestSetup(t)
+
+	speculative := makeSpeculativeBlocks(0xA1, 0xA2)
+	// Target has two distinct hashes; the FIRST increment succeeds, the
+	// SECOND returns ErrFileBlockNotFound (the Pending-donor signal).
+	target := makeSpeculativeBlocks(0xB1, 0xB2)
+	provisional := block.ComputeObjectID(speculative)
+	fc.objectIDHits[provisional] = target
+
+	fc.failOnNthIncrement = 2
+	fc.incErr = block.ErrFileBlockNotFound
+
+	hit, err := m.applyFileLevelDedupHit(ctx, "pid", speculative, target, provisional, false /*isRetry*/)
+	if err != nil {
+		t.Fatalf("err=%v; want nil (Pending donor must be a clean MISS, not an error)", err)
+	}
+	if hit {
+		t.Fatalf("hit=true; want false (Pending donor → MISS)")
+	}
+
+	// The first increment (on B1) must have been rolled back: exactly one
+	// DecrementRefCount, on the hash that was successfully incremented.
+	if got := len(fc.decHashes); got != 1 {
+		t.Fatalf("DecrementRefCount calls=%d; want 1 (roll back the one successful increment; no leak)", got)
+	}
+	if fc.decHashes[0][0] != 0xB1 {
+		t.Errorf("rolled-back hash=0x%02X; want 0xB1 (the only successfully-incremented target hash)", fc.decHashes[0][0])
+	}
+
+	// PersistFileBlocks MUST NOT fire on a miss.
+	if got := len(fc.persistCalls); got != 0 {
+		t.Errorf("PersistFileBlocks calls=%d on Pending-donor miss; want 0 (caller falls through to per-block path)", got)
+	}
+}
+
+// TestApplyFileLevelDedupHit_PendingDonor_FirstHash_NoLeak covers the
+// edge where the VERY FIRST target hash is the Pending one: no prior
+// increment was made, so there is nothing to roll back (zero
+// DecrementRefCount calls), and the helper still returns a clean miss.
+func TestApplyFileLevelDedupHit_PendingDonor_FirstHash_NoLeak(t *testing.T) {
+	ctx := context.Background()
+	m, fc := dedupTestSetup(t)
+
+	speculative := makeSpeculativeBlocks(0xA1)
+	target := makeSpeculativeBlocks(0xB1, 0xB2)
+	provisional := block.ComputeObjectID(speculative)
+	fc.objectIDHits[provisional] = target
+
+	fc.failOnNthIncrement = 1
+	fc.incErr = block.ErrFileBlockNotFound
+
+	hit, err := m.applyFileLevelDedupHit(ctx, "pid", speculative, target, provisional, false /*isRetry*/)
+	if err != nil {
+		t.Fatalf("err=%v; want nil (Pending donor MISS)", err)
+	}
+	if hit {
+		t.Fatalf("hit=true; want false")
+	}
+	if got := len(fc.decHashes); got != 0 {
+		t.Errorf("DecrementRefCount calls=%d; want 0 (first hash failed → nothing was incremented)", got)
+	}
+	if got := len(fc.persistCalls); got != 0 {
+		t.Errorf("PersistFileBlocks calls=%d; want 0", got)
+	}
+}
+
+// TestApplyFileLevelDedupHit_IncrementError_NonNotFound_RollsBack covers the
+// pre-existing refcount-leak fix: a NON-not-found IncrementRefCount error on a
+// later target hash must still roll back the earlier successful increment(s)
+// and then propagate the error (the call does NOT retry on this branch).
+func TestApplyFileLevelDedupHit_IncrementError_NonNotFound_RollsBack(t *testing.T) {
+	ctx := context.Background()
+	m, fc := dedupTestSetup(t)
+
+	speculative := makeSpeculativeBlocks(0xA1, 0xA2)
+	target := makeSpeculativeBlocks(0xB1, 0xB2)
+	provisional := block.ComputeObjectID(speculative)
+	fc.objectIDHits[provisional] = target
+
+	// Generic (non-not-found) failure on the second increment.
+	fc.failOnNthIncrement = 2
+	// incErr left nil → the generic induced-failure error is returned.
+
+	hit, err := m.applyFileLevelDedupHit(ctx, "pid", speculative, target, provisional, false /*isRetry*/)
+	if hit {
+		t.Fatalf("hit=true on increment error; want false")
+	}
+	if err == nil {
+		t.Fatalf("err=nil; want the increment failure propagated")
+	}
+	// Prior successful increment (B1) must be rolled back — no leak.
+	if got := len(fc.decHashes); got != 1 {
+		t.Fatalf("DecrementRefCount calls=%d; want 1 (roll back prior increment before propagating)", got)
+	}
+	if fc.decHashes[0][0] != 0xB1 {
+		t.Errorf("rolled-back hash=0x%02X; want 0xB1", fc.decHashes[0][0])
+	}
+	if got := len(fc.persistCalls); got != 0 {
+		t.Errorf("PersistFileBlocks calls=%d on increment error; want 0", got)
+	}
+}
+
+// TestTryEagerSmallFileDedup_PendingDonor_TreatedAsMiss verifies the eager
+// small-file path inherits the fix: a seeded ObjectID hit whose target is a
+// Pending donor (IncrementRefCount → ErrFileBlockNotFound) returns a clean
+// (false, nil) miss so engine.Flush falls through to the normal upload path.
+func TestTryEagerSmallFileDedup_PendingDonor_TreatedAsMiss(t *testing.T) {
+	ctx := context.Background()
+	m, fc := dedupTestSetup(t)
+
+	data := []byte("small file content for pending donor")
+	provisional := singleBlockObjectID(data)
+	contentHash := hashContent(data)
+	fc.objectIDHits[provisional] = []block.BlockRef{
+		{Hash: contentHash, Offset: 0, Size: uint32(len(data))},
+	}
+
+	// The single target hash is a Pending donor.
+	fc.failOnNthIncrement = 1
+	fc.incErr = block.ErrFileBlockNotFound
+
+	hit, err := m.tryEagerSmallFileDedup(ctx, "pid", data)
+	if err != nil {
+		t.Fatalf("err=%v; want nil (eager path must inherit the Pending-donor MISS)", err)
+	}
+	if hit {
+		t.Fatalf("hit=true; want false (Pending donor → MISS → fall through to normal Flush)")
+	}
+	if got := len(fc.persistCalls); got != 0 {
+		t.Errorf("PersistFileBlocks calls=%d on eager Pending-donor miss; want 0", got)
+	}
+}
+
 // Compile-time check: keep errors import live even if reshapes
 // the error-handling path. Tests that need errors.Is can adopt this.
 var _ = errors.Is


### PR DESCRIPTION
Part of #1245 (Bug A — blocking).

## Problem
Bulk same-content writes over SMB/NFS hit EIO on CLOSE/COMMIT (`increment refcount on target hash X: no FileBlock with hash X`), wedging the session. File-level dedup found a donor via `FindByObjectID` (object_id index published by the rollup persister) whose FileBlock rows were still `BlockStatePending` — `GetByHash` is Remote-gated, so it returned nil → `ErrFileBlockNotFound` → wrapped to error → EIO. Protocol-agnostic (reproduces over NFSv3 too).

## Fix
In `applyFileLevelDedupHit` step-1 increment loop:
- On `ErrFileBlockNotFound` (donor not yet durable): roll back already-incremented hashes and return **(false, nil) = MISS** → caller falls through to normal per-block upload. Dedup collapses later once the donor reaches Remote. Deduping onto a non-durable donor is genuinely unsafe (data loss if donor upload fails), so the Remote-gate stays; only the disposition changes.
- Also fixes a pre-existing refcount **leak**: any step-1 increment failure now rolls back prior increments before returning.

## Tests
Real-engine repro on memory + badger backends (`TestMemoryDedup_PendingDonor_TreatedAsMiss`, `TestBadgerDedup_PendingDonor_TreatedAsMiss`) — RED before fix (the exact EIO), GREEN after. Plus focused helper tests for rollback/no-leak and the eager path.

Scope: only `pkg/block/engine/dedup.go` (+ tests).