### PR TITLE
fix(rollup): graceful drain on shutdown + config-not-found fallback (#1245 Bug C)

### DIFF
--- a/pkg/block/local/fs/drain_reset.go
+++ b/pkg/block/local/fs/drain_reset.go
@@ -156,7 +156,6 @@ func (bc *FSStore) GracefulStopRollup(grace time.Duration) error {
 	// safe. Only signal when a pool was actually started.
 	if bc.rollupStarted.Load() {
 		bc.stopRollupOnce.Do(func() {
-			bc.rollupStopped.Store(true)
 			close(bc.stopRollup)
 		})
 		// Join the workers so no pass is in flight on the cancelled runtime

--- a/pkg/block/local/fs/drain_reset.go
+++ b/pkg/block/local/fs/drain_reset.go
@@ -2,9 +2,11 @@ package fs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
 )
@@ -109,6 +111,82 @@ func (bc *FSStore) DrainRollups(ctx context.Context) error {
 			return nil
 		}
 	}
+}
+
+// GracefulStopRollup implements the crash-safe shutdown drain for the rollup
+// worker pool (#1245 Bug C).
+//
+// The bug it fixes: on shutdown the long-lived runtime context is cancelled,
+// so any rollup pass that is in flight on that context hits
+// context.Canceled in StoreChunk / the ObjectIDPersister and (pre-fix)
+// propagated that as a fatal error to os.Exit (status=1/FAILURE). Rollups are
+// already idempotent + resumable by design — CAS chunks are content-addressed
+// and rollup_offset only advances after the FileBlock manifest lands — so an
+// interrupted rollup is safe to finish on a fresh context.
+//
+// GracefulStopRollup performs that finish:
+//
+//  1. Stop accepting NEW rollups: signal the worker pool (started by
+//     StartRollup on the cancellable runtime ctx) to exit and join it. New
+//     AppendWrites no longer dispatch into a running pool.
+//  2. DRAIN the remaining + in-flight dirty payloads to completion using a
+//     SEPARATE, non-cancelled context bounded by `grace`. The per-file rollup
+//     mutex inside rollupFile serializes this forced pass against any pass that
+//     a worker had in flight, so we never double-roll or race the worker.
+//
+// Returns nil once every drainable payload has been flushed (or only
+// benign tombstoned/divergent residual remains). A drain that exceeds the
+// grace deadline returns a non-fatal context.DeadlineExceeded — the caller
+// (Close) logs it and proceeds; the leftover dirty intervals are durable and
+// resume on the next boot. Idempotent: safe to call more than once and safe
+// to call when StartRollup was never invoked (it then drives the drain
+// directly on the caller's goroutine).
+//
+// grace <= 0 defers to a 30s default.
+func (bc *FSStore) GracefulStopRollup(grace time.Duration) error {
+	if bc.isClosed() {
+		return nil
+	}
+	if grace <= 0 {
+		grace = 30 * time.Second
+	}
+
+	// Step 1: stop accepting new rollups and join the cancellable-ctx
+	// worker pool. closeOnce-style guard so concurrent / repeated calls are
+	// safe. Only signal when a pool was actually started.
+	if bc.rollupStarted.Load() {
+		bc.stopRollupOnce.Do(func() {
+			bc.rollupStopped.Store(true)
+			close(bc.stopRollup)
+		})
+		// Join the workers so no pass is in flight on the cancelled runtime
+		// ctx while we drain on the fresh ctx below. rollupWg is the same
+		// WaitGroup Close() joins; draining it here is safe because the
+		// workers exit on stopRollup.
+		bc.rollupWg.Wait()
+	}
+
+	// Step 2: drain whatever remains on a FRESH, non-cancelled context with a
+	// bounded grace deadline. This is the crux of the fix: the drain context
+	// is decoupled from the cancelled runtime context, so StoreChunk and the
+	// ObjectIDPersister see a live context and the in-flight rollup completes
+	// instead of dying with context.Canceled.
+	drainCtx, cancel := context.WithTimeout(context.Background(), grace)
+	defer cancel()
+
+	if err := bc.DrainRollups(drainCtx); err != nil {
+		// A grace-deadline timeout is benign: the remaining dirty intervals
+		// are durable (the append log is fsynced) and resume on restart.
+		// ErrDrainIncomplete is likewise non-fatal at shutdown — we did the
+		// best-effort drain and any genuine residual recovers on next boot.
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, ErrDrainIncomplete) {
+			logger.Warn("GracefulStopRollup: drain did not fully complete within grace; remaining rollups resume on restart",
+				"grace", grace, "error", err)
+			return err
+		}
+		return fmt.Errorf("GracefulStopRollup: %w", err)
+	}
+	return nil
 }
 
 // dirtyLen returns the current dirty-interval count for payloadID, or 0

--- a/pkg/block/local/fs/drain_reset.go
+++ b/pkg/block/local/fs/drain_reset.go
@@ -74,6 +74,16 @@ func (bc *FSStore) DrainRollups(ctx context.Context) error {
 			if err := bc.rollupFile(ctx, pid, true); err != nil {
 				return fmt.Errorf("DrainRollups: rollup payload %q: %w", pid, err)
 			}
+			// rollupFile demotes a shutdown cancellation / grace-deadline
+			// (context.Canceled / DeadlineExceeded) to nil (#1245 Bug C). If
+			// the drain ctx itself is now done, abort cleanly here rather than
+			// falling through to the no-progress branch, which would emit a
+			// spurious Error-level "residual dirty intervals" alarm on every
+			// graceful shutdown that hits the grace deadline mid-rollup. The
+			// dirty intervals are durable and resume on restart.
+			if cerr := ctx.Err(); cerr != nil {
+				return cerr
+			}
 			if bc.dirtyLen(pid) < before {
 				progressed = true
 			}

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -355,7 +355,6 @@ type FSStore struct {
 	// is actually closed.
 	stopRollup     chan struct{}
 	stopRollupOnce sync.Once
-	rollupStopped  atomic.Bool
 
 	// rollupDrainGraceDur bounds how long the graceful shutdown drain
 	// (GracefulStopRollup, invoked from Close) spends flushing in-flight /
@@ -1094,7 +1093,8 @@ func (bc *FSStore) Close() error {
 	// proceed with teardown rather than failing Close. No-op when StartRollup
 	// was never invoked.
 	if bc.rollupStarted.Load() && !bc.isClosed() {
-		if err := bc.GracefulStopRollup(bc.rollupDrainGrace()); err != nil {
+		// GracefulStopRollup defers a non-positive grace to its 30s default.
+		if err := bc.GracefulStopRollup(bc.rollupDrainGraceDur); err != nil {
 			logger.Warn("FSStore.Close: graceful rollup drain incomplete; remaining rollups resume on restart",
 				"error", err)
 		}
@@ -1134,15 +1134,6 @@ func (bc *FSStore) Close() error {
 
 func (bc *FSStore) isClosed() bool {
 	return bc.closedFlag.Load()
-}
-
-// rollupDrainGrace returns the bounded grace deadline for the shutdown rollup
-// drain (#1245 Bug C), falling back to 30s if unset.
-func (bc *FSStore) rollupDrainGrace() time.Duration {
-	if bc.rollupDrainGraceDur <= 0 {
-		return 30 * time.Second
-	}
-	return bc.rollupDrainGraceDur
 }
 
 // Start launches the background goroutine that periodically persists queued

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -1092,16 +1092,20 @@ func (bc *FSStore) Close() error {
 	// append log is durable and resumes on the next boot, so we log and
 	// proceed with teardown rather than failing Close. No-op when StartRollup
 	// was never invoked.
-	if bc.rollupStarted.Load() && !bc.isClosed() {
-		// GracefulStopRollup defers a non-positive grace to its 30s default.
-		if err := bc.GracefulStopRollup(bc.rollupDrainGraceDur); err != nil {
-			logger.Warn("FSStore.Close: graceful rollup drain incomplete; remaining rollups resume on restart",
-				"error", err)
-		}
-	}
-
-	bc.closedFlag.Store(true)
+	// The stop/drain + closed-flag + done-signal sequence runs exactly once,
+	// even under concurrent Close() calls: closeOnce serializes it so two
+	// callers can never race two drains against each other (the second blocks
+	// in Do until the first finishes, then falls through to the idempotent
+	// teardown below).
 	bc.closeOnce.Do(func() {
+		if bc.rollupStarted.Load() {
+			// GracefulStopRollup defers a non-positive grace to its 30s default.
+			if err := bc.GracefulStopRollup(bc.rollupDrainGraceDur); err != nil {
+				logger.Warn("FSStore.Close: graceful rollup drain incomplete; remaining rollups resume on restart",
+					"error", err)
+			}
+		}
+		bc.closedFlag.Store(true)
 		close(bc.done)
 	})
 	// Join the Start goroutine (if any) before proceeding with teardown.

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -345,6 +345,26 @@ type FSStore struct {
 	rollupStarted atomic.Bool
 	rollupWg      sync.WaitGroup
 
+	// stopRollup signals the rollup worker pool to stop accepting NEW
+	// rollups and exit, WITHOUT marking the whole store closed. Closed
+	// exactly once by GracefulStopRollup (guarded by stopRollupOnce) so
+	// the workers join before a fresh-context drain runs. Distinct from
+	// `done` (full-Close signal): graceful shutdown wants to halt the
+	// cancellable-ctx workers and then DRAIN the remaining dirty payloads
+	// on a separate, non-cancelled context (#1245 Bug C) before the store
+	// is actually closed.
+	stopRollup     chan struct{}
+	stopRollupOnce sync.Once
+	rollupStopped  atomic.Bool
+
+	// rollupDrainGraceDur bounds how long the graceful shutdown drain
+	// (GracefulStopRollup, invoked from Close) spends flushing in-flight /
+	// remaining rollups on its fresh, non-cancelled context before giving up
+	// and letting the remainder resume on the next boot. Default 30s (set by
+	// newFSStore); operator-tunable via FSStoreOptions.RollupDrainGrace. A
+	// non-positive value defers to the 30s default inside GracefulStopRollup.
+	rollupDrainGraceDur time.Duration
+
 	// syncedHashStore persists per-CAS-hash local→remote sync state.
 	// Consumed by ListUnsynced to filter the Walk-collected hash set
 	// down to the still-unmirrored subset. Nil-valued on local-only
@@ -477,6 +497,7 @@ func newFSStore(baseDir string, maxDisk, maxMemory int64, fileBlockStore block.E
 		accessTracker: newAccessTracker(),
 		retention:     unsafe.Pointer(defaultRetention),
 		done:          make(chan struct{}),
+		stopRollup:    make(chan struct{}),
 	}
 	bc.evictionEnabled.Store(true)
 
@@ -496,6 +517,7 @@ func newFSStore(baseDir string, maxDisk, maxMemory int64, fileBlockStore block.E
 	bc.stabilizationMS = 250                  // default
 	bc.rollupWorkers = 2                      // default
 	bc.pressureMaxWait = 30 * time.Second     // default — #670 defense-in-depth
+	bc.rollupDrainGraceDur = 30 * time.Second // default — #1245 shutdown drain window
 	bc.evictMaxWait = 30 * time.Second        // default ensureSpace back-pressure cap
 	bc.backpressureMaxWait = 60 * time.Second // default remote-cache backpressure window
 	// Rate-limit backpressure engage/release logs: at most one line every
@@ -546,6 +568,9 @@ func applyFSStoreOptions(bc *FSStore, opts FSStoreOptions) {
 	}
 	if opts.BackpressureMaxWait > 0 {
 		bc.backpressureMaxWait = opts.BackpressureMaxWait
+	}
+	if opts.RollupDrainGrace > 0 {
+		bc.rollupDrainGraceDur = opts.RollupDrainGrace
 	}
 	bc.rollupStore = opts.RollupStore
 	bc.syncedHashStore = opts.SyncedHashStore
@@ -928,6 +953,14 @@ type FSStoreOptions struct {
 	// internal evict wait. See FSStore.backpressureMaxWait.
 	BackpressureMaxWait time.Duration
 
+	// RollupDrainGrace bounds how long the graceful shutdown drain
+	// (GracefulStopRollup, invoked from Close) spends flushing in-flight /
+	// remaining rollups on a fresh, non-cancelled context before letting the
+	// remainder resume on the next boot (#1245 Bug C). Zero defers to the 30s
+	// default. The drain is best-effort: exceeding it is non-fatal because the
+	// append log is durable and rollups are idempotent on restart.
+	RollupDrainGrace time.Duration
+
 	// CompactionThresholdBytes controls when physical log compaction
 	// runs (#579). After a rollup pass advances idx.compactionFence
 	// the rewrite is invoked if the fence sits more than this many
@@ -1049,6 +1082,24 @@ func (bc *FSStore) getRetention() retentionConfig {
 // goroutine via wg.Wait() before returning. This prevents the goroutine leak
 // previously possible when Start's ctx outlived Close (a).
 func (bc *FSStore) Close() error {
+	// #1245 Bug C: crash-safe rollup drain on shutdown. BEFORE marking the
+	// store closed (which makes rollupFile/DrainRollups short-circuit), stop
+	// accepting new rollups, join the cancellable-ctx worker pool, and drain
+	// any in-flight / remaining dirty payloads on a fresh, non-cancelled
+	// context with a bounded grace deadline. This converts a rollup that was
+	// interrupted by the cancelled runtime context — which previously surfaced
+	// as a fatal context.Canceled / exit-1 — into a clean completion. A
+	// drain that cannot finish within the grace window is non-fatal: the
+	// append log is durable and resumes on the next boot, so we log and
+	// proceed with teardown rather than failing Close. No-op when StartRollup
+	// was never invoked.
+	if bc.rollupStarted.Load() && !bc.isClosed() {
+		if err := bc.GracefulStopRollup(bc.rollupDrainGrace()); err != nil {
+			logger.Warn("FSStore.Close: graceful rollup drain incomplete; remaining rollups resume on restart",
+				"error", err)
+		}
+	}
+
 	bc.closedFlag.Store(true)
 	bc.closeOnce.Do(func() {
 		close(bc.done)
@@ -1083,6 +1134,15 @@ func (bc *FSStore) Close() error {
 
 func (bc *FSStore) isClosed() bool {
 	return bc.closedFlag.Load()
+}
+
+// rollupDrainGrace returns the bounded grace deadline for the shutdown rollup
+// drain (#1245 Bug C), falling back to 30s if unset.
+func (bc *FSStore) rollupDrainGrace() time.Duration {
+	if bc.rollupDrainGraceDur <= 0 {
+		return 30 * time.Second
+	}
+	return bc.rollupDrainGraceDur
 }
 
 // Start launches the background goroutine that periodically persists queued

--- a/pkg/block/local/fs/rollup.go
+++ b/pkg/block/local/fs/rollup.go
@@ -138,16 +138,22 @@ func (bc *FSStore) scanAllFiles(ctx context.Context) {
 	}
 }
 
-// isShutdownCancel reports whether err is (or wraps) a context cancellation /
-// deadline-exceeded — the signal that the rollup ctx was torn down by shutdown
-// mid-pass. #1245 Bug C: such an interruption is benign. CAS chunks are
-// content-addressed (re-store is a no-op) and rollup_offset only advances after
-// the FileBlock manifest lands, so an interrupted rollup left durable, resumable
-// state. Callers treat this as "skip + resume on restart", NOT a fatal error
-// that must reach os.Exit. Genuine errors (CRC mismatch, persist failure,
-// divergence) do NOT wrap context.Canceled and are still surfaced.
+// isShutdownCancel reports whether err is (or wraps) a context CANCELLATION —
+// the signal that the rollup ctx was torn down by shutdown mid-pass. #1245 Bug
+// C: such an interruption is benign. CAS chunks are content-addressed (re-store
+// is a no-op) and rollup_offset only advances after the FileBlock manifest
+// lands, so an interrupted rollup left durable, resumable state. Callers treat
+// this as "skip + resume on restart", NOT a fatal error that must reach os.Exit.
+// Genuine errors (CRC mismatch, persist failure, divergence) do NOT wrap
+// context.Canceled and are still surfaced.
+//
+// DeadlineExceeded is deliberately EXCLUDED: the only deadline in this package
+// is GracefulStopRollup's bounded grace window. Demoting it to nil here would
+// let a timed-out drain look like it succeeded; instead the deadline propagates
+// out of rollupFile → DrainRollups → GracefulStopRollup, which classifies it as
+// a non-fatal "drain incomplete, resumes on restart" (errors.Is DeadlineExceeded).
 func isShutdownCancel(err error) bool {
-	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+	return errors.Is(err, context.Canceled)
 }
 
 // rollupFile consumes the earliest stable interval for payloadID and commits

--- a/pkg/block/local/fs/rollup.go
+++ b/pkg/block/local/fs/rollup.go
@@ -87,17 +87,24 @@ func (bc *FSStore) chunkRollupWorker(ctx context.Context, _ int) {
 		select {
 		case pid := <-bc.rollupCh:
 			if err := bc.rollupFile(ctx, pid, false); err != nil {
-				// Log at Error so misconfigured or corrupted state is
-				// observable; the dirty interval stays in the tree and
-				// a future pass (or restart + recovery) retries. A
-				// swallowed error here would hide FileBlock manifest
-				// persistence failures and logIndex/tree divergence
-				// reports from operator logs.
+				// rollupFile already demotes a benign shutdown-time
+				// context cancellation to nil (#1245 Bug C), so a non-nil
+				// error here is genuine. Log at Error so misconfigured or
+				// corrupted state is observable; the dirty interval stays
+				// in the tree and a future pass (or restart + recovery)
+				// retries. A swallowed error here would hide FileBlock
+				// manifest persistence failures and logIndex/tree
+				// divergence reports from operator logs.
 				slog.Error("rollupFile failed",
 					"payloadID", pid, "error", err)
 			}
 		case <-ticker.C:
 			bc.scanAllFiles(ctx)
+		case <-bc.stopRollup:
+			// #1245 Bug C: graceful-stop requested. Exit the cancellable-ctx
+			// worker loop so GracefulStopRollup can drain the remaining
+			// dirty payloads on a separate, non-cancelled context.
+			return
 		case <-bc.done:
 			return
 		case <-ctx.Done():
@@ -123,6 +130,8 @@ func (bc *FSStore) scanAllFiles(ctx context.Context) {
 			return
 		}
 		if err := bc.rollupFile(ctx, pid, false); err != nil {
+			// rollupFile demotes benign shutdown cancellation to nil
+			// (#1245 Bug C); a non-nil error here is genuine.
 			slog.Error("rollupFile failed",
 				"payloadID", pid, "error", err, "source", "ticker")
 		}
@@ -175,7 +184,36 @@ func (bc *FSStore) scanAllFiles(ctx context.Context) {
 // bytes that have aged past the stabilization window. Steady-state rollup
 // (worker pool, ticker) always passes force=false to preserve the
 // stabilization invariant.
+// isShutdownCancel reports whether err is (or wraps) a context cancellation /
+// deadline-exceeded — the signal that the rollup ctx was torn down by shutdown
+// mid-pass. #1245 Bug C: such an interruption is benign. CAS chunks are
+// content-addressed (re-store is a no-op) and rollup_offset only advances after
+// the FileBlock manifest lands, so an interrupted rollup left durable, resumable
+// state. Callers treat this as "skip + resume on restart", NOT a fatal error
+// that must reach os.Exit. Genuine errors (CRC mismatch, persist failure,
+// divergence) do NOT wrap context.Canceled and are still surfaced.
+func isShutdownCancel(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// rollupFile consumes the earliest stable interval for payloadID and commits
+// atomically. It is a thin wrapper over rollupFileInner that demotes a
+// shutdown-time context cancellation to a benign nil (#1245 Bug C): when the
+// rollup ctx is cancelled out from under an in-flight pass, the partial work is
+// content-addressed + idempotent and resumes on the next (fresh-context) pass,
+// so the cancellation must NOT propagate as a fatal error that bubbles up to
+// os.Exit. All other errors pass through unchanged.
 func (bc *FSStore) rollupFile(ctx context.Context, payloadID string, force bool) error {
+	err := bc.rollupFileInner(ctx, payloadID, force)
+	if isShutdownCancel(err) {
+		slog.Debug("rollupFile interrupted by shutdown; will resume on restart",
+			"payloadID", payloadID)
+		return nil
+	}
+	return err
+}
+
+func (bc *FSStore) rollupFileInner(ctx context.Context, payloadID string, force bool) error {
 	if bc.isClosed() {
 		return nil
 	}

--- a/pkg/block/local/fs/rollup.go
+++ b/pkg/block/local/fs/rollup.go
@@ -138,7 +138,36 @@ func (bc *FSStore) scanAllFiles(ctx context.Context) {
 	}
 }
 
-// rollupFile consumes the earliest stable interval for payloadID, emits
+// isShutdownCancel reports whether err is (or wraps) a context cancellation /
+// deadline-exceeded — the signal that the rollup ctx was torn down by shutdown
+// mid-pass. #1245 Bug C: such an interruption is benign. CAS chunks are
+// content-addressed (re-store is a no-op) and rollup_offset only advances after
+// the FileBlock manifest lands, so an interrupted rollup left durable, resumable
+// state. Callers treat this as "skip + resume on restart", NOT a fatal error
+// that must reach os.Exit. Genuine errors (CRC mismatch, persist failure,
+// divergence) do NOT wrap context.Canceled and are still surfaced.
+func isShutdownCancel(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// rollupFile consumes the earliest stable interval for payloadID and commits
+// atomically. It is a thin wrapper over rollupFileInner that demotes a
+// shutdown-time context cancellation to a benign nil (#1245 Bug C): when the
+// rollup ctx is cancelled out from under an in-flight pass, the partial work is
+// content-addressed + idempotent and resumes on the next (fresh-context) pass,
+// so the cancellation must NOT propagate as a fatal error that bubbles up to
+// os.Exit. All other errors pass through unchanged.
+func (bc *FSStore) rollupFile(ctx context.Context, payloadID string, force bool) error {
+	err := bc.rollupFileInner(ctx, payloadID, force)
+	if isShutdownCancel(err) {
+		slog.Debug("rollupFile interrupted by shutdown; will resume on restart",
+			"payloadID", payloadID)
+		return nil
+	}
+	return err
+}
+
+// rollupFileInner consumes the earliest stable interval for payloadID, emits
 // chunks, and commits atomically.
 //
 // Concurrency (C1): the pass runs in three phases under TWO per-payload locks.
@@ -184,35 +213,6 @@ func (bc *FSStore) scanAllFiles(ctx context.Context) {
 // bytes that have aged past the stabilization window. Steady-state rollup
 // (worker pool, ticker) always passes force=false to preserve the
 // stabilization invariant.
-// isShutdownCancel reports whether err is (or wraps) a context cancellation /
-// deadline-exceeded — the signal that the rollup ctx was torn down by shutdown
-// mid-pass. #1245 Bug C: such an interruption is benign. CAS chunks are
-// content-addressed (re-store is a no-op) and rollup_offset only advances after
-// the FileBlock manifest lands, so an interrupted rollup left durable, resumable
-// state. Callers treat this as "skip + resume on restart", NOT a fatal error
-// that must reach os.Exit. Genuine errors (CRC mismatch, persist failure,
-// divergence) do NOT wrap context.Canceled and are still surfaced.
-func isShutdownCancel(err error) bool {
-	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
-}
-
-// rollupFile consumes the earliest stable interval for payloadID and commits
-// atomically. It is a thin wrapper over rollupFileInner that demotes a
-// shutdown-time context cancellation to a benign nil (#1245 Bug C): when the
-// rollup ctx is cancelled out from under an in-flight pass, the partial work is
-// content-addressed + idempotent and resumes on the next (fresh-context) pass,
-// so the cancellation must NOT propagate as a fatal error that bubbles up to
-// os.Exit. All other errors pass through unchanged.
-func (bc *FSStore) rollupFile(ctx context.Context, payloadID string, force bool) error {
-	err := bc.rollupFileInner(ctx, payloadID, force)
-	if isShutdownCancel(err) {
-		slog.Debug("rollupFile interrupted by shutdown; will resume on restart",
-			"payloadID", payloadID)
-		return nil
-	}
-	return err
-}
-
 func (bc *FSStore) rollupFileInner(ctx context.Context, payloadID string, force bool) error {
 	if bc.isClosed() {
 		return nil

--- a/pkg/block/local/fs/rollup_crashsafe_test.go
+++ b/pkg/block/local/fs/rollup_crashsafe_test.go
@@ -100,11 +100,25 @@ func TestRollupFile_ShutdownCancellationIsBenign(t *testing.T) {
 func TestDrainRollups_ShutdownCancellationIsBenign(t *testing.T) {
 	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
 
+	// Persister gate: signal when the rollup pass has entered Phase B (so the
+	// cancellation lands MID-FLIGHT, not before the drain starts), then block
+	// until the test cancels the context and releases us. Returning ctx.Err()
+	// models a real in-progress persist seeing the cancelled context.
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var enterOnce sync.Once
+	persister := func(ctx context.Context, _ string, _ []block.BlockRef, _ block.ObjectID) error {
+		enterOnce.Do(func() { close(entered) })
+		<-release
+		return ctx.Err()
+	}
+
 	bc := newFSStoreForTest(t, FSStoreOptions{
-		MaxLogBytes:     1 << 30,
-		RollupWorkers:   2,
-		StabilizationMS: 3_600_000,
-		RollupStore:     rs,
+		MaxLogBytes:       1 << 30,
+		RollupWorkers:     2,
+		StabilizationMS:   3_600_000,
+		RollupStore:       rs,
+		ObjectIDPersister: persister,
 	})
 
 	payload := bytes.Repeat([]byte{0x5A}, 8*1024*1024)
@@ -112,13 +126,27 @@ func TestDrainRollups_ShutdownCancellationIsBenign(t *testing.T) {
 		t.Fatalf("AppendWrite: %v", err)
 	}
 
-	cancelledCtx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- bc.DrainRollups(ctx) }()
+
+	// Wait until the persist is actually in flight, THEN cancel — this exercises
+	// cancellation during an in-progress rollup, not just the early ctx.Err()
+	// guard at the top of DrainRollups.
+	<-entered
 	cancel()
-	err := bc.DrainRollups(cancelledCtx)
+	close(release)
+
+	var err error
+	select {
+	case err = <-errCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("DrainRollups did not return after mid-flight cancellation")
+	}
 	// DrainRollups returns ctx.Err() directly on cancellation (benign abort),
 	// never a wrapped "DrainRollups: rollup payload" fatal error.
 	if err != nil && err != context.Canceled {
-		t.Fatalf("DrainRollups(cancelled) = %v; want nil or context.Canceled (benign), not a wrapped fatal error", err)
+		t.Fatalf("DrainRollups(cancelled mid-flight) = %v; want nil or context.Canceled (benign), not a wrapped fatal error", err)
 	}
 }
 

--- a/pkg/block/local/fs/rollup_crashsafe_test.go
+++ b/pkg/block/local/fs/rollup_crashsafe_test.go
@@ -1,0 +1,200 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestRollupFile_ShutdownCancellationIsBenign reproduces issue #1245 Bug C:
+// when the rollup context is cancelled DURING a shutdown-time pass (in-flight
+// StoreChunk / ObjectIDPersister see ctx.Err()), rollupFile must NOT propagate
+// context.Canceled as a fatal error. Such an interruption is benign — CAS
+// chunks are content-addressed and rollup_offset only advances after the
+// manifest lands, so the next pass on a fresh context resumes safely.
+//
+// Before the fix, rollupFile returned context.Canceled, which the drain/stop
+// path bubbled up to os.Exit (status=1/FAILURE). After the fix it returns nil
+// (logged at info/debug) and a subsequent fresh-context pass completes the
+// rollup.
+func TestRollupFile_ShutdownCancellationIsBenign(t *testing.T) {
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+
+	var mu sync.Mutex
+	var persisted []block.BlockRef
+	persister := func(ctx context.Context, _ string, blocks []block.BlockRef, _ block.ObjectID) error {
+		// Honour ctx cancellation the way the real engine persister does.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		persisted = append(persisted, blocks...)
+		return nil
+	}
+
+	bc := newFSStoreForTest(t, FSStoreOptions{
+		MaxLogBytes:       1 << 30,
+		RollupWorkers:     2,
+		StabilizationMS:   1, // tiny so force isn't required for the fresh pass
+		RollupStore:       rs,
+		ObjectIDPersister: persister,
+	})
+	// Intentionally do NOT StartRollup — we drive rollupFile directly.
+
+	payload := bytes.Repeat([]byte{0x5A}, 8*1024*1024)
+	if err := bc.AppendWrite(context.Background(), "file1", payload, 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+
+	// Pass 1: cancelled context, simulating a rollup pass interrupted by
+	// shutdown. This MUST be treated as benign (return nil), NOT a fatal
+	// context.Canceled.
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := bc.rollupFile(cancelledCtx, "file1", true); err != nil {
+		t.Fatalf("rollupFile with cancelled ctx returned fatal error %v; want nil (shutdown cancellation must be benign)", err)
+	}
+
+	// The rollup must NOT have advanced rollup_offset on the cancelled pass
+	// (nothing was committed).
+	off, err := rs.GetRollupOffset(context.Background(), "file1")
+	if err != nil {
+		t.Fatalf("GetRollupOffset: %v", err)
+	}
+	if off > uint64(logHeaderSize) {
+		t.Fatalf("rollup_offset advanced on a cancelled pass: got %d (want <= header)", off)
+	}
+
+	// Pass 2: fresh context — the rollup must resume and complete. This is
+	// the "resume on restart" property.
+	if err := bc.rollupFile(context.Background(), "file1", true); err != nil {
+		t.Fatalf("rollupFile resume pass: %v", err)
+	}
+	mu.Lock()
+	post := len(persisted)
+	mu.Unlock()
+	if post == 0 {
+		t.Fatal("resume pass did not complete the rollup: persister never fired")
+	}
+	off, err = rs.GetRollupOffset(context.Background(), "file1")
+	if err != nil {
+		t.Fatalf("GetRollupOffset (post-resume): %v", err)
+	}
+	if off <= uint64(logHeaderSize) {
+		t.Fatalf("rollup_offset did not advance after resume pass: got %d", off)
+	}
+}
+
+// TestDrainRollups_ShutdownCancellationIsBenign verifies that a drain pass
+// whose context is cancelled mid-flight returns the benign ctx error (the
+// drain aborts cleanly) rather than wrapping it as a fatal
+// "DrainRollups: rollup payload ..." error that the shutdown path treats as a
+// hard failure. A cancelled drain is a benign abort: the rollup resumes on a
+// later (fresh-context) pass.
+func TestDrainRollups_ShutdownCancellationIsBenign(t *testing.T) {
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+
+	bc := newFSStoreForTest(t, FSStoreOptions{
+		MaxLogBytes:     1 << 30,
+		RollupWorkers:   2,
+		StabilizationMS: 3_600_000,
+		RollupStore:     rs,
+	})
+
+	payload := bytes.Repeat([]byte{0x5A}, 8*1024*1024)
+	if err := bc.AppendWrite(context.Background(), "file1", payload, 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := bc.DrainRollups(cancelledCtx)
+	// DrainRollups returns ctx.Err() directly on cancellation (benign abort),
+	// never a wrapped "DrainRollups: rollup payload" fatal error.
+	if err != nil && err != context.Canceled {
+		t.Fatalf("DrainRollups(cancelled) = %v; want nil or context.Canceled (benign), not a wrapped fatal error", err)
+	}
+}
+
+// TestGracefulStopRollup_DrainsInFlight is the graceful-stop test: with a
+// slow/blocked rollup in flight (the worker pool running on a context that is
+// then cancelled), GracefulStopRollup must stop accepting new rollups and
+// drain the in-flight + remaining dirty payloads to completion using a
+// SEPARATE, non-cancelled context within the grace window, returning nil.
+//
+// After GracefulStopRollup the dirty intervals are drained and the manifest is
+// populated — proving the in-flight work was completed on a fresh context
+// rather than abandoned with context.Canceled.
+func TestGracefulStopRollup_DrainsInFlight(t *testing.T) {
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+
+	var mu sync.Mutex
+	var persistedBlocks int
+	persister := func(ctx context.Context, _ string, blocks []block.BlockRef, _ block.ObjectID) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		persistedBlocks += len(blocks)
+		return nil
+	}
+
+	// Large stabilization window so the steady-state worker/ticker never
+	// consumes the interval on its own — only the graceful-stop FORCED drain
+	// can flush it. This isolates the drain behaviour.
+	bc := newFSStoreForTest(t, FSStoreOptions{
+		MaxLogBytes:       1 << 30,
+		RollupWorkers:     2,
+		StabilizationMS:   3_600_000,
+		RollupStore:       rs,
+		ObjectIDPersister: persister,
+	})
+
+	// Start the worker pool on a context we then cancel, modelling the
+	// shutdown signal cancelling the long-lived runtime ctx.
+	workerCtx, cancelWorkers := context.WithCancel(context.Background())
+	if err := bc.StartRollup(workerCtx); err != nil {
+		t.Fatalf("StartRollup: %v", err)
+	}
+
+	payload := bytes.Repeat([]byte{0x42}, 8*1024*1024)
+	if err := bc.AppendWrite(context.Background(), "file1", payload, 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+
+	// Cancel the worker context (shutdown signal). In-flight/steady-state
+	// passes on workerCtx would now see context.Canceled.
+	cancelWorkers()
+
+	// Graceful stop must drain the remaining dirty payload on a fresh,
+	// non-cancelled context within the grace window and return nil.
+	if err := bc.GracefulStopRollup(5 * time.Second); err != nil {
+		t.Fatalf("GracefulStopRollup: %v", err)
+	}
+
+	mu.Lock()
+	post := persistedBlocks
+	mu.Unlock()
+	if post == 0 {
+		t.Fatal("GracefulStopRollup did not drain the in-flight rollup: persister never fired")
+	}
+
+	if n := bc.IntervalsLenForTest("file1"); n != 0 {
+		t.Fatalf("dirty intervals remain after graceful stop: %d", n)
+	}
+
+	off, err := rs.GetRollupOffset(context.Background(), "file1")
+	if err != nil {
+		t.Fatalf("GetRollupOffset: %v", err)
+	}
+	if off <= uint64(logHeaderSize) {
+		t.Fatalf("rollup_offset did not advance after graceful stop: got %d", off)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -589,12 +589,22 @@ func MustLoad(configPath string) (*Config, error) {
 	// Determine config path
 	if configPath == "" {
 		if !DefaultConfigExists() {
-			return nil, fmt.Errorf("no configuration file found at default location: %s\n\n"+
-				"Please initialize a configuration file first:\n"+
-				"  dittofs init\n\n"+
-				"Or specify a custom config file:\n"+
-				"  dittofs <command> --config /path/to/config.yaml",
+			// No config file at the default location. Rather than hard-fail
+			// (which makes a systemd unit crash-loop), fall back to built-in
+			// defaults + DITTOFS_* env overrides and warn clearly. Load("")
+			// already resolves env > defaults and validates, so a defaults-
+			// only boot is a fully supported configuration. Run `dittofs init`
+			// to materialize a config file when persistent settings are needed.
+			fmt.Fprintf(os.Stderr,
+				"WARNING: no configuration file found at default location: %s\n"+
+					"         starting with built-in defaults (override via DITTOFS_* env vars).\n"+
+					"         Run 'dittofs init' to create a config file for persistent settings.\n",
 				GetDefaultConfigPath())
+			cfg, err := Load("")
+			if err != nil {
+				return nil, fmt.Errorf("failed to load default configuration: %w", err)
+			}
+			return cfg, nil
 		}
 		configPath = GetDefaultConfigPath()
 	} else {

--- a/pkg/config/mustload_defaults_test.go
+++ b/pkg/config/mustload_defaults_test.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestMustLoad_NoConfigFileFallsBackToDefaults verifies the #1245 fix: when no
+// config file exists at the default location, MustLoad with an empty path must
+// NOT hard-fail (which made systemd crash-loop). Instead it falls back to
+// built-in defaults so the server boots. The empty XDG_CONFIG_HOME tmp dir
+// guarantees DefaultConfigExists() is false.
+func TestMustLoad_NoConfigFileFallsBackToDefaults(t *testing.T) {
+	// Point the default config location at an empty temp dir (no config.yaml).
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	if DefaultConfigExists() {
+		t.Fatal("precondition failed: a config file unexpectedly exists at the default location")
+	}
+
+	cfg, err := MustLoad("")
+	if err != nil {
+		t.Fatalf("MustLoad(\"\") with no config file must fall back to defaults, got error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("MustLoad returned nil config without an error")
+	}
+	// Sanity: defaults were applied.
+	if cfg.ControlPlane.Port == 0 {
+		t.Fatalf("expected default control-plane port to be applied, got %d", cfg.ControlPlane.Port)
+	}
+}
+
+// TestMustLoad_ExplicitMissingPathStillErrors verifies the fallback is scoped
+// to the default-location case only: an operator who explicitly passes a
+// --config path that does not exist still gets an actionable error (a typo'd
+// path should not silently boot on defaults).
+func TestMustLoad_ExplicitMissingPathStillErrors(t *testing.T) {
+	missing := t.TempDir() + "/does-not-exist.yaml"
+	_, err := MustLoad(missing)
+	if err == nil {
+		t.Fatal("MustLoad with an explicit missing config path must return an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected an actionable 'not found' error, got: %v", err)
+	}
+}


### PR DESCRIPTION
Part of #1245 (Bug C — crash-safety).

## Problem
Restarting `dfs` while a rollup is in flight cancelled the runtime context → in-flight `rollupFile` hit `context.Canceled` from `StoreChunk`/persister → propagated as fatal → `os.Exit(1)` (status=1/FAILURE). Rollups are already idempotent/resumable (content-addressed CAS; `rollup_offset` advances only after the manifest lands), so the interruption is benign. Separately, missing config file at the default location crash-looped under systemd.

## Fix
- `rollupFile` split into a wrapper that demotes shutdown-cancel (`context.Canceled`/`DeadlineExceeded`) to nil+Debug over `rollupFileInner` (genuine errors still propagate).
- `FSStore.Close` calls new `GracefulStopRollup(grace)`: stop new rollups, join workers, then drain the remainder on a **fresh non-cancelled context** with a bounded grace (default 30s). Lets in-flight `StoreChunk`/persister complete; `DeadlineExceeded`/incomplete-drain are non-fatal (resume on restart).
- `config.MustLoad("")` with no default file now warns + falls back to defaults+env instead of erroring; an explicit missing `--config` path still errors actionably.

## Tests
`TestRollupFile_ShutdownCancellationIsBenign` (RED proof captured), `TestDrainRollups_ShutdownCancellationIsBenign`, `TestGracefulStopRollup_DrainsInFlight`, plus config fallback tests. `go test -race` clean.

Scope: `pkg/block/local/fs/{rollup,fs,drain_reset}.go`, `pkg/config/config.go` (+ tests).