### PR TITLE
fix(rollup): converge object_id conflict instead of looping forever (#1245 Bug B)

### DIFF
--- a/pkg/block/engine/concurrent_identical_drain_test.go
+++ b/pkg/block/engine/concurrent_identical_drain_test.go
@@ -1,0 +1,137 @@
+package engine_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatabadger "github.com/marmos91/dittofs/pkg/metadata/store/badger"
+)
+
+// TestBadgerConcurrentIdenticalContent_Converges drives N concurrent rollups
+// of BYTE-IDENTICAL content through the real engine over the badger metadata
+// backend and asserts ALL converge: a concurrent Flush of every file's
+// identical content provokes badger SSI optimistic-concurrency aborts on the
+// hot dedup keys (the obj:<hash> object_id index + the content-hash FileBlock
+// rows), exactly the bulk-same-content (zero/padding tar block) pattern from
+// #1245-B.
+//
+// Before the fix, badger's WithTransaction leaked the raw badgerdb.ErrConflict
+// sentinel on the SSI hot-key path; the rollup persister's conflict handler
+// could not recognize it as an object_id conflict, so the duplicate's blocks
+// never fell back to the zero-objectID write and the Flush surfaced the raw
+// conflict (and the background ticker would re-run the same payloadID forever).
+// After the fix, every file converges:
+//   - Flush succeeds for all files,
+//   - every file has a complete, restorable block list,
+//   - exactly one file owns the canonical object_id (the rest are zero).
+func TestBadgerConcurrentIdenticalContent_Converges(t *testing.T) {
+	// Shrink the badger SSI retry budget to 1 so any overlapping write-write on
+	// the hot dedup keys surfaces an exhausted-retry conflict immediately
+	// (instead of being absorbed by the default 20-retry backoff). This makes
+	// the #1245-B livelock path deterministic: the rollup persister MUST
+	// recognize the (now-wrapped) conflict and converge to the zero-objectID
+	// write for every duplicate rather than bubbling the raw conflict back to
+	// the drain/ticker.
+	restore := metadatabadger.SetMaxTransactionRetriesForTest(1)
+	t.Cleanup(restore)
+
+	ms, err := metadatabadger.NewBadgerMetadataStoreWithDefaults(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
+	}
+	t.Cleanup(func() { _ = ms.Close() })
+
+	ctx := context.Background()
+	shareName := "badger-conc-dup"
+	rootHandle := createShare(t, ms, shareName)
+	bs := newEngineOverStore(t, ms)
+
+	const nFiles = 12
+	// Byte-identical 3MB content across every file → all share the same
+	// Merkle-root object_id and the same per-chunk content hashes → maximal
+	// dedup-key contention under concurrent rollup.
+	content := distinctContent(0x42, 3*1024*1024)
+
+	pids := make([]string, nFiles)
+	handles := make([]metadata.FileHandle, nFiles)
+	for i := 0; i < nFiles; i++ {
+		pid, h := createRealFile(t, ms, shareName, fmt.Sprintf("dup-%02d.bin", i), rootHandle)
+		pids[i] = pid
+		handles[i] = h
+		if _, werr := bs.WriteAt(ctx, pid, nil, content, 0); werr != nil {
+			t.Fatalf("WriteAt file %d: %v", i, werr)
+		}
+	}
+
+	// Concurrently drive rollup-to-CAS+manifest from many goroutines. Each
+	// DrainRollups iterates the whole dirty set; the per-file mutex inside
+	// rollupFile serializes same-file passes but lets DIFFERENT identical-
+	// content files roll up in parallel, so their ObjectIDPersister calls
+	// concurrently contend on the same hot badger dedup keys (the obj:<hash>
+	// object_id index + the content-hash FileBlock rows) → SSI conflicts.
+	const drainers = 8
+	errs := make([]error, drainers)
+	var wg sync.WaitGroup
+	wg.Add(drainers)
+	for d := 0; d < drainers; d++ {
+		go func(idx int) {
+			defer wg.Done()
+			errs[idx] = bs.DrainRollups(ctx)
+		}(d)
+	}
+	wg.Wait()
+
+	for i, e := range errs {
+		if e != nil {
+			t.Fatalf("concurrent DrainRollups %d must converge (no looping/leaked conflict): %v", i, e)
+		}
+	}
+
+	// A final serial DrainRollups must also be clean (no residual conflict
+	// wedged, all dirty intervals fully drained).
+	if derr := bs.DrainRollups(ctx); derr != nil {
+		t.Fatalf("final DrainRollups must converge: %v", derr)
+	}
+
+	// Every file must have a complete, restorable block list; exactly one owns
+	// the canonical object_id.
+	owners := 0
+	want := block.NewHashSet(0)
+	for i := 0; i < nFiles; i++ {
+		f, gerr := ms.GetFile(ctx, handles[i])
+		if gerr != nil {
+			t.Fatalf("GetFile file %d: %v", i, gerr)
+		}
+		if len(f.Blocks) == 0 {
+			t.Fatalf("file %d has empty FileAttr.Blocks after convergence (unrestorable)", i)
+		}
+		for _, b := range f.Blocks {
+			want.Add(b.Hash)
+		}
+		if !f.ObjectID.IsZero() {
+			owners++
+		}
+	}
+
+	if owners != 1 {
+		t.Fatalf("expected exactly one object_id owner, got %d", owners)
+	}
+
+	// The Backup manifest must reference every block hash (all files
+	// restorable).
+	got, bufLen := manifestHashes(t, ms)
+	missing := 0
+	for _, h := range want.Sorted() {
+		if !got.Contains(h) {
+			missing++
+		}
+	}
+	if missing > 0 {
+		t.Fatalf("Backup manifest missing %d/%d referenced hashes (manifest len=%d, buf=%d bytes)",
+			missing, want.Len(), got.Len(), bufLen)
+	}
+}

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -441,12 +441,10 @@ func (bs *Store) persistRollupBlocksConverging(ctx context.Context, payloadID st
 	// write loop, which re-surfaces any real fault. The actual write still goes
 	// through the bounded backoff below so a concurrent SSI abort on the
 	// (still-hot) file row / content-hash rows converges instead of failing.
-	if !persistObjID.IsZero() {
-		if owner, ferr := bs.coordinator.FindByObjectID(ctx, persistObjID); ferr == nil && owner != nil {
-			logger.Debug("rollup persist: canonical object_id owner already exists; persisting duplicate's blocks with zero object_id (pre-check)",
-				"payloadID", payloadID, "objectID", persistObjID.String())
-			wantObjID = zeroObjectID
-		}
+	if !persistObjID.IsZero() && bs.canonicalOwnerExists(ctx, persistObjID) {
+		logger.Debug("rollup persist: canonical object_id owner already exists; persisting duplicate's blocks with zero object_id (pre-check)",
+			"payloadID", payloadID, "objectID", persistObjID.String())
+		wantObjID = zeroObjectID
 	}
 
 	// (2) Bounded converging backoff around the claim. The first successful
@@ -477,12 +475,10 @@ func (bs *Store) persistRollupBlocksConverging(ctx context.Context, payloadID st
 		// a still-hot non-object_id key (SSI abort on the file row / content-
 		// hash rows under bulk identical content) — back off and retry the
 		// same zero-objectID write until it commits.
-		if !wantObjID.IsZero() {
-			if owner, ferr := bs.coordinator.FindByObjectID(ctx, wantObjID); ferr == nil && owner != nil {
-				logger.Debug("rollup persist: object_id now owned by another file; converging to zero-objectID write",
-					"payloadID", payloadID, "objectID", wantObjID.String(), "attempt", attempt)
-				wantObjID = zeroObjectID
-			}
+		if !wantObjID.IsZero() && bs.canonicalOwnerExists(ctx, wantObjID) {
+			logger.Debug("rollup persist: object_id now owned by another file; converging to zero-objectID write",
+				"payloadID", payloadID, "objectID", wantObjID.String(), "attempt", attempt)
+			wantObjID = zeroObjectID
 		}
 
 		time.Sleep(backoff)
@@ -492,6 +488,15 @@ func (bs *Store) persistRollupBlocksConverging(ctx context.Context, payloadID st
 	}
 	return fmt.Errorf("rollup persist: did not converge after %d attempts (payloadID=%s): %w",
 		rollupPersistMaxAttempts, payloadID, lastErr)
+}
+
+// canonicalOwnerExists reports whether a file already owns objectID as its
+// canonical Merkle-root pointer. A lookup error is treated as "unknown owner"
+// (non-fatal): the caller falls through to the bounded write loop, which
+// re-surfaces any real fault. Callers must guard against a zero objectID.
+func (bs *Store) canonicalOwnerExists(ctx context.Context, objectID block.ObjectID) bool {
+	owner, err := bs.coordinator.FindByObjectID(ctx, objectID)
+	return err == nil && owner != nil
 }
 
 // Start initializes the store and starts background goroutines.

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -481,7 +481,16 @@ func (bs *Store) persistRollupBlocksConverging(ctx context.Context, payloadID st
 			wantObjID = zeroObjectID
 		}
 
-		time.Sleep(backoff)
+		// Back off, but stay responsive to cancellation: a plain time.Sleep would
+		// let a canceled rollup linger for the full remaining backoff window. On
+		// cancellation during backoff, fail rather than silently succeed,
+		// preferring the ctx error but reporting the last conflict for context.
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return fmt.Errorf("rollup persist: canceled during backoff (payloadID=%s, lastErr=%v): %w",
+				payloadID, lastErr, ctx.Err())
+		}
 		if backoff < 50*time.Millisecond {
 			backoff *= 2
 		}

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/local"
 	"github.com/marmos91/dittofs/pkg/block/remote"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	mderrors "github.com/marmos91/dittofs/pkg/metadata/errors"
 )
 
 // Compile-time interface satisfaction check.
@@ -280,34 +282,7 @@ func New(cfg BlockStoreConfig) (*Store, error) {
 				persistBlocks = block.MergeBlockRefsByOffset(existing, blocks)
 				persistObjID = block.ComputeObjectID(persistBlocks)
 			}
-			if err := bs.coordinator.PersistFileBlocks(ctx, payloadID, persistBlocks, persistObjID); err != nil {
-				// File-level dedup: another file already owns this
-				// Merkle-root ObjectID (byte-identical content). The
-				// object_id index enforces "one ObjectID -> one file", so
-				// this duplicate cannot claim the canonical pointer. It
-				// MUST still persist its own block list (so the file is
-				// restorable and its FileBlock manifest is complete) — it
-				// simply does so WITHOUT owning the object_id (left zero =
-				// "not the canonical dedup target"). Retrying with a zero
-				// ObjectID writes object_id NULL, which the partial unique
-				// index skips, so the per-file blocks land cleanly.
-				//
-				// Propagating the raw conflict instead would (a) fail an
-				// explicit DrainRollups, (b) wedge the background rollup
-				// worker into retrying the same conflict forever, and (c)
-				// leave the duplicate with an empty block list →
-				// unrestorable. The block hashes themselves are content-
-				// addressed and already durable in CAS from StoreChunk.
-				if isObjectIDConflict(err) {
-					logger.Debug("rollup persist: object_id already mapped to another file; persisting duplicate's blocks without claiming the dedup pointer",
-						"payloadID", payloadID,
-						"objectID", persistObjID.String())
-					var zeroObjectID block.ObjectID
-					if rerr := bs.coordinator.PersistFileBlocks(ctx, payloadID, persistBlocks, zeroObjectID); rerr != nil {
-						return fmt.Errorf("rollup persist: retry without object_id after dedup conflict: %w", rerr)
-					}
-					return bs.reapSupersededFileBlocks(ctx, payloadID, priorOffsets, blocks)
-				}
+			if err := bs.persistRollupBlocksConverging(ctx, payloadID, persistBlocks, persistObjID); err != nil {
 				return err
 			}
 			return bs.reapSupersededFileBlocks(ctx, payloadID, priorOffsets, blocks)
@@ -386,6 +361,137 @@ func New(cfg BlockStoreConfig) (*Store, error) {
 	// invalidation — mirrors the TestClose_ClosesCache pattern.
 	cfg.Syncer.bs = bs
 	return bs, nil
+}
+
+// rollupPersistMaxAttempts bounds the converging retry loop in
+// persistRollupBlocksConverging. Each attempt re-resolves the canonical
+// object_id owner and, on a recognized conflict, converges toward the
+// zero-objectID write. The cap guarantees termination so a genuinely
+// pathological metadata-store fault surfaces a clear error instead of looping
+// forever (#1245-B).
+const rollupPersistMaxAttempts = 8
+
+// isRollupPersistConflict reports whether err is a conflict the rollup
+// persister can converge past by falling back to the zero-objectID write. It
+// recognizes BOTH:
+//
+//   - isObjectIDConflict(err) — the deterministic first-committer-wins
+//     object_id conflict the coordinator maps to engine.ErrObjectIDConflict
+//     (Postgres 23505 on files_object_id_idx, the in-closure PutFile conflict
+//     on Memory/Badger); and
+//
+//   - mderrors.IsConflictError(err) — a raw store-level ErrConflict that
+//     bypasses the coordinator's in-closure mapObjectIDConflict because it is
+//     raised at COMMIT time, not by the PutFile call. Badger's SSI
+//     optimistic-concurrency abort under bulk same-content rollup is the
+//     canonical case (#1245-B): WithTransaction now returns a wrapped
+//     mderrors.StoreError{Code: ErrConflict} when its retry budget is
+//     exhausted, which surfaces here through the WithTransaction return value
+//     rather than through PutFile.
+//
+// Recognizing both keeps the converging fallback uniform across the
+// deterministic object_id conflict and the SSI hot-key conflict without
+// altering isObjectIDConflict (whose dedup-retry callers must keep their
+// narrower semantics).
+func isRollupPersistConflict(err error) bool {
+	return isObjectIDConflict(err) || mderrors.IsConflictError(err)
+}
+
+// persistRollupBlocksConverging persists a rollup pass's block list + ObjectID
+// for payloadID, guaranteeing convergence under the bulk same-content
+// (file-level dedup) race (#1245-B).
+//
+// Two cooperating mechanisms remove the livelock the naive single-fallback had:
+//
+//  1. Read-only pre-check. BEFORE attempting to claim the object_id, ask the
+//     coordinator whether a canonical owner already exists for this Merkle root
+//     (FindByObjectID). If so, this file is a duplicate-but-not-the-first; it
+//     persists its blocks with a ZERO object_id immediately and never enters
+//     the obj-key write/probe race at all. This eliminates the write-write
+//     contention for every identical file after the first, which is what
+//     turned a transient SSI abort into a sustained hot-key livelock.
+//
+//  2. Bounded converging backoff. The genuine first-committer race (two files
+//     reach PersistFileBlocks before either has committed, so FindByObjectID
+//     missed for both) is still possible. On a recognized conflict
+//     (isRollupPersistConflict — uniform across the deterministic object_id
+//     conflict and Badger's wrapped commit-time SSI abort) the loop backs off,
+//     re-resolves FindByObjectID (a peer may have just become canonical), and
+//     retries — converging to the zero-objectID write. The attempt count is
+//     capped so a real fault terminates with a clear error rather than spinning
+//     the rollup ticker on the same payloadID forever.
+//
+// A duplicate's blocks are content-addressed and already durable in CAS; the
+// only thing it forfeits is ownership of the canonical object_id pointer (left
+// zero = "not the dedup target"), which the partial unique index skips so the
+// per-file block list lands cleanly and the file stays restorable.
+func (bs *Store) persistRollupBlocksConverging(ctx context.Context, payloadID string, persistBlocks []block.BlockRef, persistObjID block.ObjectID) error {
+	var zeroObjectID block.ObjectID
+
+	// wantObjID is the object_id this file will TRY to claim. The pre-check and
+	// the conflict handler both narrow it to zero once a canonical owner is
+	// known to exist, after which the file persists its blocks as a benign
+	// duplicate.
+	wantObjID := persistObjID
+
+	// (1) Read-only pre-check: if a canonical owner already exists for this
+	// Merkle root, target the zero object_id from the start so this file never
+	// races on the obj-key write. Skip on a zero objectID (nothing to dedup
+	// against) and treat a lookup error as non-fatal — fall through to the
+	// write loop, which re-surfaces any real fault. The actual write still goes
+	// through the bounded backoff below so a concurrent SSI abort on the
+	// (still-hot) file row / content-hash rows converges instead of failing.
+	if !persistObjID.IsZero() {
+		if owner, ferr := bs.coordinator.FindByObjectID(ctx, persistObjID); ferr == nil && owner != nil {
+			logger.Debug("rollup persist: canonical object_id owner already exists; persisting duplicate's blocks with zero object_id (pre-check)",
+				"payloadID", payloadID, "objectID", persistObjID.String())
+			wantObjID = zeroObjectID
+		}
+	}
+
+	// (2) Bounded converging backoff around the claim. The first successful
+	// committer wins the object_id; every subsequent committer recognizes the
+	// conflict, re-resolves, and converges to the zero-objectID write. A
+	// zero-objectID write that itself aborts (SSI on a still-hot file row /
+	// content-hash row under bulk identical content) is retried until it
+	// commits.
+	backoff := time.Millisecond
+	var lastErr error
+	for attempt := 0; attempt < rollupPersistMaxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		err := bs.coordinator.PersistFileBlocks(ctx, payloadID, persistBlocks, wantObjID)
+		if err == nil {
+			return nil
+		}
+		if !isRollupPersistConflict(err) {
+			return err
+		}
+		lastErr = err
+
+		// Conflict recognized. If we were still trying to claim the canonical
+		// object_id, re-resolve: a peer may have just committed and become the
+		// canonical owner, in which case we converge to the zero-objectID write
+		// on the next attempt. If we already targeted zero, the conflict is on
+		// a still-hot non-object_id key (SSI abort on the file row / content-
+		// hash rows under bulk identical content) — back off and retry the
+		// same zero-objectID write until it commits.
+		if !wantObjID.IsZero() {
+			if owner, ferr := bs.coordinator.FindByObjectID(ctx, wantObjID); ferr == nil && owner != nil {
+				logger.Debug("rollup persist: object_id now owned by another file; converging to zero-objectID write",
+					"payloadID", payloadID, "objectID", wantObjID.String(), "attempt", attempt)
+				wantObjID = zeroObjectID
+			}
+		}
+
+		time.Sleep(backoff)
+		if backoff < 50*time.Millisecond {
+			backoff *= 2
+		}
+	}
+	return fmt.Errorf("rollup persist: did not converge after %d attempts (payloadID=%s): %w",
+		rollupPersistMaxAttempts, payloadID, lastErr)
 }
 
 // Start initializes the store and starts background goroutines.

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -168,7 +168,7 @@ func (s *BadgerMetadataStore) Delete(ctx context.Context, id string) error {
 // errors short-circuit.
 func (s *BadgerMetadataStore) updateWithConflictRetry(ctx context.Context, fn func(*badger.Txn) error) error {
 	var lastErr error
-	for attempt := 0; attempt < maxTransactionRetries; attempt++ {
+	for attempt := 0; attempt < int(maxTransactionRetries.Load()); attempt++ {
 		if err := ctx.Err(); err != nil {
 			return err
 		}

--- a/pkg/metadata/store/badger/testhooks.go
+++ b/pkg/metadata/store/badger/testhooks.go
@@ -1,0 +1,13 @@
+package badger
+
+// SetMaxTransactionRetriesForTest overrides the SSI conflict retry budget and
+// returns a function that restores the previous value. It exists solely so
+// cross-package tests (e.g. the block/engine rollup-convergence suite) can
+// shrink the budget to deterministically drive WithTransaction into its
+// retry-exhausted conflict path without spinning thousands of contending
+// goroutines. Production code never calls it.
+func SetMaxTransactionRetriesForTest(n int) func() {
+	prev := maxTransactionRetries
+	maxTransactionRetries = n
+	return func() { maxTransactionRetries = prev }
+}

--- a/pkg/metadata/store/badger/testhooks.go
+++ b/pkg/metadata/store/badger/testhooks.go
@@ -7,7 +7,7 @@ package badger
 // retry-exhausted conflict path without spinning thousands of contending
 // goroutines. Production code never calls it.
 func SetMaxTransactionRetriesForTest(n int) func() {
-	prev := maxTransactionRetries
-	maxTransactionRetries = n
-	return func() { maxTransactionRetries = prev }
+	prev := maxTransactionRetries.Load()
+	maxTransactionRetries.Store(int32(n))
+	return func() { maxTransactionRetries.Store(prev) }
 }

--- a/pkg/metadata/store/badger/testhooks.go
+++ b/pkg/metadata/store/badger/testhooks.go
@@ -8,6 +8,12 @@ package badger
 // goroutines. Production code never calls it.
 func SetMaxTransactionRetriesForTest(n int) func() {
 	prev := maxTransactionRetries.Load()
+	// Clamp to at least 1: a value <= 0 would make WithTransaction run zero
+	// attempts and return nil without ever executing the closure (lastErr stays
+	// nil), silently swallowing the work.
+	if n < 1 {
+		n = 1
+	}
 	maxTransactionRetries.Store(int32(n))
 	return func() { maxTransactionRetries.Store(prev) }
 }

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -6,6 +6,7 @@ import (
 	goerrors "errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	badgerdb "github.com/dgraph-io/badger/v4"
@@ -81,9 +82,15 @@ func (tx *badgerTransaction) addQuota2(k badgerQuotaKey, d metadata.UsageStat) {
 
 // Maximum number of retries for conflict errors.
 // Set high because concurrent writes to the same file can cause many
-// conflicts. A package var (not a const) so tests can lower it to
-// deterministically exercise the retry-exhausted path.
-var maxTransactionRetries = 20
+// conflicts. An atomic (not a const) so tests can lower it via
+// SetMaxTransactionRetriesForTest to deterministically exercise the
+// retry-exhausted path without racing the concurrent reads in
+// WithTransaction / updateWithConflictRetry under `go test -race`.
+var maxTransactionRetries = func() *atomic.Int32 {
+	v := &atomic.Int32{}
+	v.Store(20)
+	return v
+}()
 
 // WithTransaction executes fn within a BadgerDB transaction.
 //
@@ -96,7 +103,7 @@ func (s *BadgerMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 	}
 
 	var lastErr error
-	for attempt := 0; attempt < maxTransactionRetries; attempt++ {
+	for attempt := 0; attempt < int(maxTransactionRetries.Load()); attempt++ {
 		// pendingDelta is captured outside db.Update so it is read after a
 		// successful commit and reset per attempt (a retried attempt starts
 		// from zero, so a conflict-retry cannot double-count usedBytes).

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -79,9 +79,11 @@ func (tx *badgerTransaction) addQuota2(k badgerQuotaKey, d metadata.UsageStat) {
 	tx.quotaDelta[k] = cur
 }
 
-// Maximum number of retries for conflict errors
-// Set high because concurrent writes to the same file can cause many conflicts
-const maxTransactionRetries = 20
+// Maximum number of retries for conflict errors.
+// Set high because concurrent writes to the same file can cause many
+// conflicts. A package var (not a const) so tests can lower it to
+// deterministically exercise the retry-exhausted path.
+var maxTransactionRetries = 20
 
 // WithTransaction executes fn within a BadgerDB transaction.
 //
@@ -135,7 +137,25 @@ func (s *BadgerMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 		return err
 	}
 
-	// All retries exhausted
+	// All retries exhausted. Wrap the raw badgerdb.ErrConflict sentinel into a
+	// recognizable mderrors.StoreError{Code: ErrConflict} (#1245-B). The raw
+	// badger sentinel is badger's SSI optimistic-concurrency abort
+	// ("Transaction Conflict. Please retry"); leaking it bare meant
+	// codebase-wide conflict detection (errors.As(*StoreError) /
+	// mderrors.IsConflictError, the runtime coordinator's mapObjectIDConflict,
+	// and the rollup persister's isObjectIDConflict) could not classify a
+	// hot-key SSI abort as a conflict — so a bulk same-content rollup never
+	// converged to the zero-objectID dedup write and the ticker re-ran the same
+	// payloadID forever. Wrapping (with the raw sentinel reachable via Unwrap
+	// for diagnostics) makes the exhausted SSI conflict recognizable uniformly
+	// with Postgres' 23505 and Memory's StoreError conflict.
+	if goerrors.Is(lastErr, badgerdb.ErrConflict) {
+		return &mderrors.StoreError{
+			Code:    mderrors.ErrConflict,
+			Message: "badger WithTransaction: transaction conflict (SSI) after exhausting retries",
+			Cause:   lastErr,
+		}
+	}
 	return lastErr
 }
 

--- a/pkg/metadata/store/badger/transaction_conflict_test.go
+++ b/pkg/metadata/store/badger/transaction_conflict_test.go
@@ -1,0 +1,86 @@
+package badger
+
+import (
+	goerrors "errors"
+	"path/filepath"
+	"testing"
+
+	badgerdb "github.com/dgraph-io/badger/v4"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	mderrors "github.com/marmos91/dittofs/pkg/metadata/errors"
+)
+
+// TestWithTransaction_RetryExhaustedConflictIsWrapped asserts that when the
+// SSI optimistic-concurrency retry budget is exhausted, WithTransaction
+// returns the conflict WRAPPED into an mderrors.StoreError{Code: ErrConflict}
+// (recognizable codebase-wide via mderrors.IsConflictError /
+// errors.As(*StoreError)) rather than leaking the raw badgerdb.ErrConflict
+// sentinel.
+//
+// Bug #1245-B: the raw sentinel leaked through, so the rollup persister's
+// mapObjectIDConflict (which only recognizes *StoreError{Code:ErrConflict}
+// or postgres 23505) could not classify the badger SSI hot-key abort as a
+// benign object_id conflict → the rollup ticker re-ran the same payloadID
+// forever (151 retries/24h) without converging.
+func TestWithTransaction_RetryExhaustedConflictIsWrapped(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "metadata.db")
+	store, err := NewBadgerMetadataStoreWithDefaults(t.Context(), dbPath)
+	if err != nil {
+		t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	ctx := t.Context()
+	hotKey := []byte("itest:hotkey")
+
+	// Seed the contended key so every attempt reads then writes it.
+	if uerr := store.db.Update(func(txn *badgerdb.Txn) error {
+		return txn.Set(hotKey, []byte("v0"))
+	}); uerr != nil {
+		t.Fatalf("seed hot key: %v", uerr)
+	}
+
+	// fn reads the hot key (recording a read-conflict dependency) and writes
+	// it. After the read but before the closure returns, an out-of-band
+	// committed write mutates the same key, guaranteeing the in-flight txn's
+	// commit aborts with ErrConflict on EVERY attempt — so the retry budget is
+	// exhausted and WithTransaction must surface a wrapped conflict.
+	gen := 0
+	txErr := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		bt := tx.(*badgerTransaction)
+		// Read to establish the SSI read dependency on hotKey.
+		if _, gerr := bt.txn.Get(hotKey); gerr != nil {
+			return gerr
+		}
+		// Write the key inside the txn (so the commit actually conflicts).
+		if serr := bt.txn.Set(hotKey, []byte("inflight")); serr != nil {
+			return serr
+		}
+		// Out-of-band committed write to the same key, forcing this attempt's
+		// commit to abort. Use a fresh value each attempt.
+		gen++
+		val := []byte{byte('a' + gen)}
+		return store.db.Update(func(txn *badgerdb.Txn) error {
+			return txn.Set(hotKey, val)
+		})
+	})
+
+	if txErr == nil {
+		t.Fatalf("expected a retry-exhausted conflict error, got nil")
+	}
+
+	// MUST be recognizable as an mderrors conflict (this is what
+	// mapObjectIDConflict / isObjectIDConflict rely on).
+	if !mderrors.IsConflictError(txErr) {
+		t.Fatalf("retry-exhausted conflict not recognized as mderrors conflict: %v", txErr)
+	}
+
+	// The raw badger sentinel MUST still be reachable through the unwrap chain
+	// for diagnostics, but it MUST NOT be the top-level returned value.
+	if txErr == badgerdb.ErrConflict { //nolint:errorlint // intentional identity check: the raw sentinel must not be returned bare
+		t.Fatalf("WithTransaction leaked the raw badgerdb.ErrConflict sentinel; want a wrapped *StoreError")
+	}
+	if !goerrors.Is(txErr, badgerdb.ErrConflict) {
+		t.Fatalf("wrapped conflict lost the underlying badgerdb.ErrConflict cause: %v", txErr)
+	}
+}


### PR DESCRIPTION
Part of #1245 (Bug B — non-converging rollup retry-loop).

## Problem
Under bulk same-content writes the rollup ticker logged `rollup: ObjectIDPersister: Transaction Conflict. Please retry` on the same payloadID indefinitely (151×/24h, never converging). Two root causes:
1. Badger's `WithTransaction` returned the **raw `badgerdb.ErrConflict` sentinel** (an SSI optimistic-concurrency abort) after exhausting its retry budget — never wrapped into `mderrors.StoreError{Code:ErrConflict}`. None of the conflict recognizers matched it, so the persister could not fall back to the zero-objectID dedup write.
2. The badger SSI abort fires at **commit time** inside `WithTransaction`, bypassing the coordinator's in-closure `mapObjectIDConflict(PutFile)` — so the engine recognizer also needed `mderrors.IsConflictError`.

## Fix
- **badger** `WithTransaction`: on retry-exhaustion, wrap the conflict into `mderrors.StoreError{Code:ErrConflict, Cause: badgerdb.ErrConflict}` (raw reachable via `Unwrap`). Kills the unwrapped-sentinel leak codebase-wide.
- **engine** ObjectIDPersister → `persistRollupBlocksConverging`: read-only `FindByObjectID` pre-check targets a zero object_id for known duplicates (skips the obj-key write race); bounded converging backoff (`rollupPersistMaxAttempts=8`) re-resolves and converges to the zero-objectID write on a recognized conflict, capped so a real fault terminates with a clear error. `isRollupPersistConflict = isObjectIDConflict || mderrors.IsConflictError`.

`isObjectIDConflict` signature/body untouched; `dedup.go`/`coordinator.go` untouched.

## Tests
`TestWithTransaction_RetryExhaustedConflictIsWrapped` (RED→GREEN) and `TestBadgerConcurrentIdenticalContent_Converges` (N=12 identical 3MB files, 8 concurrent DrainRollups, retry budget shrunk to 1 to make the livelock deterministic — reproduces the exact production symptom, RED→GREEN, `-race` + 15× clean). Existing identical-content drain tests stay green.