### PR TITLE
fix(metadata): configurable + RAM-relative badger cache sizing (#1245 Bug D)

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -22,6 +22,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
+	badgerstore "github.com/marmos91/dittofs/pkg/metadata/store/badger"
 	"github.com/marmos91/dittofs/pkg/metrics"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -145,6 +146,15 @@ func runStart(cmd *cobra.Command, args []string) error {
 	if adaptersCreated {
 		logger.Info("Default adapters created", "adapters", "nfs, smb")
 	}
+
+	// Wire operator-configured Badger metadata-cache defaults into the badger
+	// engine BEFORE any metadata store is opened (InitializeFromStore opens
+	// them). Zero values leave that dimension to RAM-relative auto-sizing
+	// inside the engine (#1245 Bug D).
+	badgerstore.SetGlobalBadgerCacheDefaults(
+		cfg.Metadata.Badger.BlockCacheSizeMB,
+		cfg.Metadata.Badger.IndexCacheSizeMB,
+	)
 
 	// Initialize runtime from database (loads metadata stores and shares)
 	rt, err := runtime.InitializeFromStore(ctx, cpStore)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -585,6 +585,69 @@ metadata:
     case_preserving: true
 ```
 
+#### BadgerDB cache sizing (config file)
+
+The BadgerDB metadata engine keeps two in-memory caches that dominate read
+performance under concurrent NFS/SMB load:
+
+- the **block cache** — decompressed LSM-tree data blocks, and
+- the **index cache** — the block-offset indices used to locate keys.
+
+Badger's own defaults are tiny (256 MiB block, index cache disabled), which
+thrashes on a busy server over a large directory tree. The symptom in the logs
+is `Block cache might be too small ... hit-ratio: 0.26 ... sets-rejected`; every
+cold lookup then walks the LSM tree from disk, which also widens the window for
+the dedup transaction-conflict race and the append-log "pressure wait timed out"
+stall.
+
+By default both sizes **auto-scale with the memory available to the process**,
+so no tuning is required:
+
+| Cache | Fraction of available RAM | Floor   | Ceiling |
+|-------|---------------------------|---------|---------|
+| block | 15 %                      | 512 MiB | 4 GiB   |
+| index | 7.5 %                     | 256 MiB | 2 GiB   |
+
+The fractions are deliberately conservative because the same process also holds
+the append-log, the metadata working set, and read buffers. The available-memory
+figure is the cgroup limit inside a container, or physical RAM otherwise (same
+detection used for block-store sizing). Examples:
+
+- **4 GiB host** → ~614 MiB block / ~307 MiB index (the floors don't bind).
+- **2 GiB host / 2 GiB cgroup** → 512 MiB block / 256 MiB index (floors bind).
+- **64 GiB host** → 4 GiB block / 2 GiB index (ceilings bind).
+
+To override the auto-sizing, set the sizes explicitly (in MiB) in the top-level
+`metadata.badger` block. Setting one dimension still auto-sizes the other:
+
+```yaml
+metadata:
+  badger:
+    block_cache_mb: 2048   # 0 (default) = auto-size from available RAM
+    index_cache_mb: 1024   # 0 (default) = auto-size from available RAM
+```
+
+Environment overrides: `DITTOFS_METADATA_BADGER_BLOCK_CACHE_MB`,
+`DITTOFS_METADATA_BADGER_INDEX_CACHE_MB`.
+
+**Recommended sizing vs. object/metadata count.** As a rule of thumb the block
+cache should hold the hot directory/inode working set. Each cached file/inode is
+on the order of a few hundred bytes of decompressed LSM data, so:
+
+| Hot metadata objects | Suggested `block_cache_mb` | Suggested `index_cache_mb` |
+|----------------------|----------------------------|----------------------------|
+| up to ~1 M           | auto (≥512)                | auto (≥256)                |
+| ~1–10 M              | 1024–2048                  | 512–1024                   |
+| ~10–50 M             | 2048–4096                  | 1024–2048                  |
+| > 50 M               | 4096+ (raise host RAM)     | 2048+                      |
+
+If you still see `hit-ratio` below ~0.8 or `sets-rejected` in the Badger logs,
+the cache is undersized for the working set — raise `block_cache_mb` first.
+
+These global sizes apply to every BadgerDB metadata store on the node. A single
+store can be overridden via its config-map keys when it is created (see below):
+`--config '{"path":"...","block_cache_mb":2048,"index_cache_mb":1024}'`.
+
 #### Metadata Store Instances (CLI)
 
 Metadata stores are managed at runtime via `dfsctl` and persisted in the control plane database:
@@ -596,6 +659,11 @@ Metadata stores are managed at runtime via `dfsctl` and persisted in the control
 # BadgerDB for persistent metadata
 ./dfsctl store metadata add --name badger-main --type badger \
   --config '{"path":"/tmp/dittofs-metadata-main"}'
+
+# BadgerDB with explicit per-store cache sizes (MiB). Omit either key (or set 0)
+# to auto-size that cache from available RAM. See "BadgerDB cache sizing" above.
+./dfsctl store metadata add --name badger-big --type badger \
+  --config '{"path":"/tmp/dittofs-metadata-big","block_cache_mb":2048,"index_cache_mb":1024}'
 
 # Separate BadgerDB instance for isolated shares
 ./dfsctl store metadata add --name badger-isolated --type badger \

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -98,6 +98,32 @@ The lack of FUSE overhead and optimized Go implementation provides competitive p
 - Low latency for metadata operations
 - Scales well with concurrent connections
 
+### My BadgerDB logs "Block cache might be too small ... hit-ratio: 0.26 ... sets-rejected" — what do I do?
+
+That message means the BadgerDB metadata engine's in-memory **block cache** is
+undersized for your working set, so it is thrashing: most lookups miss the cache
+and hit disk. A low hit-ratio also widens the window for the dedup
+transaction-conflict race and the append-log "pressure wait timed out" stall, so
+it is worth fixing.
+
+By default the block and index caches **auto-size from the memory available to
+the process** (≈15 % / ≈7.5 %, with 512/256 MiB floors and 4 GiB/2 GiB
+ceilings), so a 4 GiB host already gets ~614 MiB / ~307 MiB without tuning. If
+you still see the warning, your hot metadata set is larger than the auto-sized
+cache — raise it explicitly:
+
+```yaml
+metadata:
+  badger:
+    block_cache_mb: 2048   # raise first; 0 = auto-size
+    index_cache_mb: 1024
+```
+
+or via env (`DITTOFS_METADATA_BADGER_BLOCK_CACHE_MB=2048`). See
+[CONFIGURATION.md → BadgerDB cache sizing](CONFIGURATION.md#badgerdb-cache-sizing-config-file)
+for a sizing table keyed to object/metadata count. Aim for a hit-ratio above
+~0.8 with no `sets-rejected`.
+
 ### Does metadata persist across server restarts?
 
 It depends on the metadata store:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -72,6 +72,10 @@ type Config struct {
 	// Blockstore configures local/remote blockstore tunables.
 	Blockstore BlockstoreConfig `mapstructure:"blockstore" yaml:"blockstore"`
 
+	// Metadata configures global, engine-specific metadata-store tunables
+	// (e.g. the BadgerDB block/index cache sizes). See MetadataConfig.
+	Metadata MetadataConfig `mapstructure:"metadata" yaml:"metadata"`
+
 	// GC configures the engine.CollectGarbage mark-sweep run.
 	// These knobs apply globally to every block-store GC invocation.
 	GC GCConfig `mapstructure:"gc" yaml:"gc"`

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -26,6 +26,7 @@ func ApplyDefaults(cfg *Config) {
 	cfg.GC.ApplyDefaults()
 	cfg.Snapshot.ApplyDefaults()
 	cfg.Blockstore.ApplyDefaults()
+	cfg.Metadata.ApplyDefaults()
 	cfg.Metrics.ApplyDefaults()
 	cfg.LDAP.ApplyDefaults()
 }

--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -165,6 +165,17 @@ controlplane:
 # View current deduced values:
 #   dfs config show --deduced
 
+# Metadata engine tunables (optional)
+# BadgerDB block/index cache sizes (MiB). Both auto-size from available RAM
+# when unset (~15% / ~7.5%, floors 512/256 MiB, ceilings 4 GiB/2 GiB), so a
+# 4 GiB host gets ~614/~307 MiB automatically. Raise these if Badger logs
+# "Block cache might be too small ... hit-ratio ... sets-rejected".
+# See docs/CONFIGURATION.md -> "BadgerDB cache sizing".
+# metadata:
+#   badger:
+#     block_cache_mb: 2048
+#     index_cache_mb: 1024
+
 # Initial admin user configuration
 # This is used to bootstrap the first admin user
 admin:

--- a/pkg/config/metadata.go
+++ b/pkg/config/metadata.go
@@ -1,0 +1,72 @@
+package config
+
+import "fmt"
+
+// MetadataConfig configures global, engine-specific metadata-store tunables.
+// These apply to every metadata store of the matching engine opened by the
+// server (the per-store path/connection details still live in the control-plane
+// database; this section carries operational knobs that are the same for every
+// store of an engine on this node).
+type MetadataConfig struct {
+	// Badger configures the BadgerDB metadata engine's in-memory caches.
+	Badger BadgerMetadataConfig `mapstructure:"badger" yaml:"badger"`
+}
+
+// BadgerMetadataConfig configures the BadgerDB metadata engine's block- and
+// index-cache sizes (#1245 Bug D).
+//
+// BadgerDB's own defaults are tiny (256 MiB block, index cache disabled), which
+// thrashes on a busy server: Badger logs "Block cache might be too small ...
+// hit-ratio: 0.26 ... sets-rejected", every cold lookup hits disk, and the
+// stalls widen the window for the dedup transaction-conflict race and the
+// append-log "pressure wait timed out" path.
+//
+// Both sizes are in MiB. When a size is 0 (the default), it is NOT set to a
+// fixed number — instead the badger engine AUTO-SIZES that cache as a fraction
+// of the memory available to the process (≈15% for the block cache, ≈7.5% for
+// the index cache), clamped to sane floors (512 MiB block / 256 MiB index) and
+// ceilings (4 GiB block / 2 GiB index). So a 4 GiB host gets ≈614 MiB block /
+// ≈307 MiB index automatically, and operators only set these to override the
+// auto-sizing.
+//
+// Environment overrides follow the DITTOFS_METADATA_BADGER_* convention, e.g.
+// DITTOFS_METADATA_BADGER_BLOCK_CACHE_MB=2048.
+type BadgerMetadataConfig struct {
+	// BlockCacheSizeMB is BadgerDB's block cache size in MiB. 0 = auto-size
+	// from available RAM. Override: DITTOFS_METADATA_BADGER_BLOCK_CACHE_MB.
+	BlockCacheSizeMB int64 `mapstructure:"block_cache_mb" yaml:"block_cache_mb"`
+
+	// IndexCacheSizeMB is BadgerDB's index cache size in MiB. 0 = auto-size
+	// from available RAM. Override: DITTOFS_METADATA_BADGER_INDEX_CACHE_MB.
+	IndexCacheSizeMB int64 `mapstructure:"index_cache_mb" yaml:"index_cache_mb"`
+}
+
+// ApplyDefaults leaves both sizes at 0 by design: a zero value is the signal to
+// the badger engine to RAM-relative auto-size (see BadgerMetadataConfig). It is
+// present for symmetry with the other config sub-structs and so future fields
+// have a home.
+func (c *BadgerMetadataConfig) ApplyDefaults() {}
+
+// ApplyDefaults fans out to the badger sub-section.
+func (c *MetadataConfig) ApplyDefaults() {
+	c.Badger.ApplyDefaults()
+}
+
+// Validate rejects negative cache sizes. Zero is valid (auto-size); any
+// positive value is accepted (the badger engine applies its own floors when a
+// value is set explicitly only insofar as it never goes below Badger's own
+// minimums — operators are trusted with an explicit number).
+func (c *BadgerMetadataConfig) Validate() error {
+	if c.BlockCacheSizeMB < 0 {
+		return fmt.Errorf("metadata.badger.block_cache_mb must be >= 0 (got %d); 0 auto-sizes from available RAM", c.BlockCacheSizeMB)
+	}
+	if c.IndexCacheSizeMB < 0 {
+		return fmt.Errorf("metadata.badger.index_cache_mb must be >= 0 (got %d); 0 auto-sizes from available RAM", c.IndexCacheSizeMB)
+	}
+	return nil
+}
+
+// Validate fans out to the badger sub-section.
+func (c *MetadataConfig) Validate() error {
+	return c.Badger.Validate()
+}

--- a/pkg/config/metadata.go
+++ b/pkg/config/metadata.go
@@ -52,10 +52,9 @@ func (c *MetadataConfig) ApplyDefaults() {
 	c.Badger.ApplyDefaults()
 }
 
-// Validate rejects negative cache sizes. Zero is valid (auto-size); any
-// positive value is accepted (the badger engine applies its own floors when a
-// value is set explicitly only insofar as it never goes below Badger's own
-// minimums — operators are trusted with an explicit number).
+// Validate rejects negative cache sizes. Zero is valid (auto-size from
+// available RAM); any positive value is accepted verbatim — an operator who
+// sets an explicit size is trusted with the number.
 func (c *BadgerMetadataConfig) Validate() error {
 	if c.BlockCacheSizeMB < 0 {
 		return fmt.Errorf("metadata.badger.block_cache_mb must be >= 0 (got %d); 0 auto-sizes from available RAM", c.BlockCacheSizeMB)

--- a/pkg/config/metadata_test.go
+++ b/pkg/config/metadata_test.go
@@ -1,0 +1,171 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestBadgerMetadataConfig_DefaultsAreZero pins the design contract that an
+// unset cache size stays 0 — the signal that defers to RAM-relative auto-sizing
+// inside the badger engine (#1245 Bug D). ApplyDefaults must NOT substitute a
+// fixed number.
+func TestBadgerMetadataConfig_DefaultsAreZero(t *testing.T) {
+	c := BadgerMetadataConfig{}
+	c.ApplyDefaults()
+	if c.BlockCacheSizeMB != 0 {
+		t.Errorf("BlockCacheSizeMB default: got %d, want 0 (auto-size)", c.BlockCacheSizeMB)
+	}
+	if c.IndexCacheSizeMB != 0 {
+		t.Errorf("IndexCacheSizeMB default: got %d, want 0 (auto-size)", c.IndexCacheSizeMB)
+	}
+}
+
+func TestBadgerMetadataConfig_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     BadgerMetadataConfig
+		wantErr bool
+	}{
+		{"zero ok (auto-size)", BadgerMetadataConfig{}, false},
+		{"positive ok", BadgerMetadataConfig{BlockCacheSizeMB: 2048, IndexCacheSizeMB: 1024}, false},
+		{"negative block rejected", BadgerMetadataConfig{BlockCacheSizeMB: -1}, true},
+		{"negative index rejected", BadgerMetadataConfig{IndexCacheSizeMB: -1}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if tc.wantErr && err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected validation error: %v", err)
+			}
+		})
+	}
+}
+
+// TestBadgerMetadataConfig_Validate_ErrorMentionsDottedPath asserts the error
+// carries the canonical dotted config key so operators can pinpoint it.
+func TestBadgerMetadataConfig_Validate_ErrorMentionsDottedPath(t *testing.T) {
+	c := BadgerMetadataConfig{BlockCacheSizeMB: -5}
+	err := c.Validate()
+	if err == nil || !strings.Contains(err.Error(), "metadata.badger.block_cache_mb") {
+		t.Fatalf("error must mention metadata.badger.block_cache_mb, got %v", err)
+	}
+}
+
+// TestConfig_UmbrellaApplyDefaults_InvokesMetadata guards the ApplyDefaults
+// fan-out wires the metadata sub-section (no panic on a zero Config).
+func TestConfig_UmbrellaApplyDefaults_InvokesMetadata(t *testing.T) {
+	cfg := &Config{}
+	ApplyDefaults(cfg)
+	if cfg.Metadata.Badger.BlockCacheSizeMB != 0 {
+		t.Fatalf("metadata.badger.block_cache_mb default: got %d, want 0", cfg.Metadata.Badger.BlockCacheSizeMB)
+	}
+}
+
+// TestConfig_YAMLRoundTrip_MetadataBadger asserts the new keys parse from a YAML
+// body via the canonical loader pattern.
+func TestConfig_YAMLRoundTrip_MetadataBadger(t *testing.T) {
+	yamlBody := []byte("metadata:\n  badger:\n    block_cache_mb: 2048\n    index_cache_mb: 1024\n")
+	var cfg Config
+	if err := yaml.Unmarshal(yamlBody, &cfg); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if cfg.Metadata.Badger.BlockCacheSizeMB != 2048 {
+		t.Errorf("block_cache_mb: got %d, want 2048", cfg.Metadata.Badger.BlockCacheSizeMB)
+	}
+	if cfg.Metadata.Badger.IndexCacheSizeMB != 1024 {
+		t.Errorf("index_cache_mb: got %d, want 1024", cfg.Metadata.Badger.IndexCacheSizeMB)
+	}
+}
+
+// TestLoad_MetadataBadgerFromFile verifies the keys load through the full
+// viper-backed Load() path from a config file.
+func TestLoad_MetadataBadgerFromFile(t *testing.T) {
+	content := `
+database:
+  type: sqlite
+controlplane:
+  jwt:
+    secret: "test-secret-key-for-testing-minimum-32-chars"
+metadata:
+  badger:
+    block_cache_mb: 3072
+    index_cache_mb: 1536
+`
+	cfg, err := Load(writeConfigFile(t, content))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Metadata.Badger.BlockCacheSizeMB != 3072 {
+		t.Errorf("block_cache_mb from file: got %d, want 3072", cfg.Metadata.Badger.BlockCacheSizeMB)
+	}
+	if cfg.Metadata.Badger.IndexCacheSizeMB != 1536 {
+		t.Errorf("index_cache_mb from file: got %d, want 1536", cfg.Metadata.Badger.IndexCacheSizeMB)
+	}
+}
+
+// TestLoad_MetadataBadgerFromEnv verifies env overrides resolve through the
+// reflective env binding (DITTOFS_METADATA_BADGER_*), even when the key is
+// absent from the file.
+func TestLoad_MetadataBadgerFromEnv(t *testing.T) {
+	content := `
+database:
+  type: sqlite
+controlplane:
+  jwt:
+    secret: "test-secret-key-for-testing-minimum-32-chars"
+`
+	path := writeConfigFile(t, content)
+
+	t.Setenv("DITTOFS_METADATA_BADGER_BLOCK_CACHE_MB", "4096")
+	t.Setenv("DITTOFS_METADATA_BADGER_INDEX_CACHE_MB", "2048")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Metadata.Badger.BlockCacheSizeMB != 4096 {
+		t.Errorf("block_cache_mb from env: got %d, want 4096", cfg.Metadata.Badger.BlockCacheSizeMB)
+	}
+	if cfg.Metadata.Badger.IndexCacheSizeMB != 2048 {
+		t.Errorf("index_cache_mb from env: got %d, want 2048", cfg.Metadata.Badger.IndexCacheSizeMB)
+	}
+}
+
+// TestLoad_MetadataBadgerNegativeRejected verifies a negative size fails Load
+// validation.
+func TestLoad_MetadataBadgerNegativeRejected(t *testing.T) {
+	content := `
+database:
+  type: sqlite
+controlplane:
+  jwt:
+    secret: "test-secret-key-for-testing-minimum-32-chars"
+metadata:
+  badger:
+    block_cache_mb: -1
+`
+	if _, err := Load(writeConfigFile(t, content)); err == nil {
+		t.Fatal("expected Load to reject negative metadata.badger.block_cache_mb")
+	}
+}
+
+// TestConfigEnvKeys_CoversMetadataBadger guards that the reflective key walk
+// includes the new nested keys (so BindEnv binds them — otherwise the env
+// override would silently drop).
+func TestConfigEnvKeys_CoversMetadataBadger(t *testing.T) {
+	keys := configEnvKeys()
+	set := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		set[k] = true
+	}
+	for _, want := range []string{"metadata.badger.block_cache_mb", "metadata.badger.index_cache_mb"} {
+		if !set[want] {
+			t.Errorf("configEnvKeys() missing %q", want)
+		}
+	}
+}

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -31,6 +31,10 @@ func Validate(cfg *Config) error {
 		return err
 	}
 
+	if err := cfg.Metadata.Validate(); err != nil {
+		return err
+	}
+
 	if err := cfg.Kerberos.Validate(); err != nil {
 		return err
 	}

--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -73,7 +74,12 @@ func CreateMetadataStoreFromConfig(ctx context.Context, storeType string, cfg in
 		if err != nil {
 			return nil, fmt.Errorf("failed to expand path %q: %w", dbPath, err)
 		}
-		return badger.NewBadgerMetadataStoreWithDefaults(ctx, dbPath)
+		// Optional per-store Badger cache overrides (#1245 Bug D). When unset
+		// (0) the badger engine falls through to the global config and then
+		// RAM-relative auto-sizing.
+		blockCacheMB := configInt64(config, "block_cache_mb")
+		indexCacheMB := configInt64(config, "index_cache_mb")
+		return badger.NewBadgerMetadataStoreWithDefaultsAndCaches(ctx, dbPath, blockCacheMB, indexCacheMB)
 
 	case "postgres":
 		pgCfg := &postgres.PostgresMetadataStoreConfig{}
@@ -145,6 +151,29 @@ func CreateMetadataStoreFromConfig(ctx context.Context, storeType string, cfg in
 
 	default:
 		return nil, fmt.Errorf("unsupported metadata store type: %s", storeType)
+	}
+}
+
+// configInt64 extracts an integer value from a type-specific config map under
+// key, returning 0 when the key is absent or not a number. Config maps are
+// typically produced by json.Unmarshal (numbers decode to float64), but a
+// directly-set map may carry int/int64, so all are accepted.
+func configInt64(config map[string]any, key string) int64 {
+	switch v := config[key].(type) {
+	case float64:
+		return int64(v)
+	case int64:
+		return v
+	case int:
+		return int64(v)
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil {
+			return 0
+		}
+		return n
+	default:
+		return 0
 	}
 }
 

--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -74,11 +74,19 @@ func CreateMetadataStoreFromConfig(ctx context.Context, storeType string, cfg in
 		if err != nil {
 			return nil, fmt.Errorf("failed to expand path %q: %w", dbPath, err)
 		}
-		// Optional per-store Badger cache overrides (#1245 Bug D). When unset
-		// (0) the badger engine falls through to the global config and then
-		// RAM-relative auto-sizing.
+		// Optional per-store Badger cache overrides (#1245 Bug D). The docs
+		// define 0 = unset (fall through to global config then RAM-relative
+		// auto-sizing) and positive = explicit size in MiB. A negative value is
+		// a config error — reject it here rather than letting it silently fall
+		// through to auto-sizing as if it were unset.
 		blockCacheMB := configInt64(config, "block_cache_mb")
+		if blockCacheMB < 0 {
+			return nil, fmt.Errorf("badger metadata store block_cache_mb must be >= 0 (0 = auto), got %d", blockCacheMB)
+		}
 		indexCacheMB := configInt64(config, "index_cache_mb")
+		if indexCacheMB < 0 {
+			return nil, fmt.Errorf("badger metadata store index_cache_mb must be >= 0 (0 = auto), got %d", indexCacheMB)
+		}
 		return badger.NewBadgerMetadataStoreWithDefaultsAndCaches(ctx, dbPath, blockCacheMB, indexCacheMB)
 
 	case "postgres":

--- a/pkg/controlplane/runtime/metadata_cache_test.go
+++ b/pkg/controlplane/runtime/metadata_cache_test.go
@@ -1,0 +1,72 @@
+package runtime
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata/store/badger"
+)
+
+// TestConfigInt64 covers the per-store config-map integer extraction used to
+// read the optional badger cache overrides (block_cache_mb / index_cache_mb).
+// Config maps come from json.Unmarshal (numbers -> float64) but may also carry
+// int/int64/json.Number, all of which must be accepted; everything else -> 0.
+func TestConfigInt64(t *testing.T) {
+	cases := []struct {
+		name string
+		m    map[string]any
+		key  string
+		want int64
+	}{
+		{"float64 (json-decoded)", map[string]any{"block_cache_mb": float64(2048)}, "block_cache_mb", 2048},
+		{"int", map[string]any{"block_cache_mb": 1024}, "block_cache_mb", 1024},
+		{"int64", map[string]any{"block_cache_mb": int64(512)}, "block_cache_mb", 512},
+		{"json.Number", map[string]any{"block_cache_mb": json.Number("777")}, "block_cache_mb", 777},
+		{"absent key -> 0", map[string]any{}, "block_cache_mb", 0},
+		{"wrong type -> 0", map[string]any{"block_cache_mb": "nope"}, "block_cache_mb", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := configInt64(tc.m, tc.key); got != tc.want {
+				t.Fatalf("configInt64: got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCreateMetadataStoreFromConfig_BadgerCacheOverride asserts that the per-
+// store config-map cache keys are threaded into the opened badger store's live
+// options (#1245 Bug D).
+func TestCreateMetadataStoreFromConfig_BadgerCacheOverride(t *testing.T) {
+	// Ensure global defaults don't mask the per-store override.
+	badger.SetGlobalBadgerCacheDefaults(0, 0)
+
+	cfg := &fakeStoreConfig{cfg: map[string]any{
+		"path":           t.TempDir(),
+		"block_cache_mb": float64(640),
+		"index_cache_mb": float64(320),
+	}}
+
+	store, err := CreateMetadataStoreFromConfig(t.Context(), "badger", cfg)
+	if err != nil {
+		t.Fatalf("CreateMetadataStoreFromConfig: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	bs, ok := store.(*badger.BadgerMetadataStore)
+	if !ok {
+		t.Fatalf("expected *badger.BadgerMetadataStore, got %T", store)
+	}
+	const mib = int64(1) << 20
+	if got, want := bs.BadgerOptions().BlockCacheSize, 640*mib; got != want {
+		t.Errorf("BlockCacheSize: got %d, want %d (640 MiB)", got, want)
+	}
+	if got, want := bs.BadgerOptions().IndexCacheSize, 320*mib; got != want {
+		t.Errorf("IndexCacheSize: got %d, want %d (320 MiB)", got, want)
+	}
+}
+
+// fakeStoreConfig satisfies the GetConfig interface CreateMetadataStoreFromConfig expects.
+type fakeStoreConfig struct{ cfg map[string]any }
+
+func (f *fakeStoreConfig) GetConfig() (map[string]any, error) { return f.cfg, nil }

--- a/pkg/controlplane/runtime/metadata_cache_test.go
+++ b/pkg/controlplane/runtime/metadata_cache_test.go
@@ -66,6 +66,38 @@ func TestCreateMetadataStoreFromConfig_BadgerCacheOverride(t *testing.T) {
 	}
 }
 
+// TestCreateMetadataStoreFromConfig_BadgerNegativeCacheRejected asserts that a
+// negative per-store cache override is a config error rather than silently
+// falling through to auto-sizing. 0 = unset/auto, positive = explicit size;
+// negative is invalid (#1245 Bug D).
+func TestCreateMetadataStoreFromConfig_BadgerNegativeCacheRejected(t *testing.T) {
+	badger.SetGlobalBadgerCacheDefaults(0, 0)
+
+	cases := []struct {
+		name string
+		key  string
+	}{
+		{"negative block_cache_mb", "block_cache_mb"},
+		{"negative index_cache_mb", "index_cache_mb"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &fakeStoreConfig{cfg: map[string]any{
+				"path": t.TempDir(),
+				tc.key: float64(-1),
+			}}
+
+			store, err := CreateMetadataStoreFromConfig(t.Context(), "badger", cfg)
+			if err == nil {
+				if store != nil {
+					_ = store.Close()
+				}
+				t.Fatalf("expected error for negative %s, got nil", tc.key)
+			}
+		})
+	}
+}
+
 // fakeStoreConfig satisfies the GetConfig interface CreateMetadataStoreFromConfig expects.
 type fakeStoreConfig struct{ cfg map[string]any }
 

--- a/pkg/controlplane/runtime/stores/service.go
+++ b/pkg/controlplane/runtime/stores/service.go
@@ -182,6 +182,12 @@ func (s *Service) OpenMetadataStoreAtPath(
 		if err != nil {
 			return nil, fmt.Errorf("expand badger pathOverride %q: %w", pathOverride, err)
 		}
+		// Temp/snapshot/probe stores inherit the process-wide cache default
+		// (SetGlobalBadgerCacheDefaults) and RAM-relative auto-sizing via
+		// buildBadgerOptions, so they are not subject to the #1245 Bug D
+		// thrashing. Per-store cache overrides (block_cache_mb/index_cache_mb)
+		// are intentionally NOT threaded here — these are short-lived stores
+		// where a bespoke cache size has no practical value.
 		store, err := badger.NewBadgerMetadataStoreWithDefaults(ctx, dbPath)
 		if err != nil {
 			return nil, fmt.Errorf("open badger engine at %q: %w", dbPath, err)

--- a/pkg/metadata/store/badger/cache.go
+++ b/pkg/metadata/store/badger/cache.go
@@ -135,6 +135,15 @@ func clampMB(v, lo, hi int64) int64 {
 // Each dimension is resolved independently, so an operator can pin the block
 // cache while letting the index cache auto-scale (or vice versa). availMem is
 // the process-available memory in bytes (from sysinfo).
+//
+// A non-positive per-store value (0 or negative) is treated as "unset" and
+// falls through to the global default / auto-sizing — there is no way to
+// request a zero/disabled cache here, which is deliberate: Badger needs a
+// non-zero block cache under compression/encryption, and a thrashing tiny
+// cache is the very bug (#1245 Bug D) this resolution exists to prevent.
+// The config-file path additionally rejects negative values at load time
+// (BadgerMetadataConfig.Validate); the per-store config-map path tolerates
+// them as "unset" rather than erroring.
 func resolveCacheSizesMB(config BadgerMetadataStoreConfig, availMem uint64) (blockCacheMB, indexCacheMB int64) {
 	blockCacheMB = config.BlockCacheSizeMB
 	indexCacheMB = config.IndexCacheSizeMB
@@ -196,9 +205,11 @@ func buildBadgerOptions(config BadgerMetadataStoreConfig, availMem uint64) badge
 
 	// Resolve cache sizes with precedence: explicit > global config >
 	// RAM-relative auto-sizing (see resolveCacheSizesMB / #1245 Bug D). The
-	// resolved sizes are always > 0 (floors enforced), which also satisfies
-	// Badger's requirement that the block cache be non-zero under
-	// compression/encryption.
+	// resolved sizes are always > 0 — an explicit positive value is used
+	// verbatim, otherwise the auto-size path applies floors (>= minBlockCacheMB
+	// / minIndexCacheMB). Either way the block cache stays non-zero, satisfying
+	// Badger's requirement under compression/encryption. (Compression is None
+	// here, so this is currently belt-and-suspenders.)
 	blockCacheMB, indexCacheMB := resolveCacheSizesMB(config, availMem)
 
 	opts = opts.WithBlockCacheSize(blockCacheMB << 20) // MiB -> bytes

--- a/pkg/metadata/store/badger/cache.go
+++ b/pkg/metadata/store/badger/cache.go
@@ -1,0 +1,208 @@
+package badger
+
+import (
+	"sync"
+
+	badger "github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4/options"
+
+	"github.com/marmos91/dittofs/internal/sysinfo"
+)
+
+// Badger cache sizing (#1245 Bug D).
+//
+// BadgerDB keeps two in-memory caches that dominate metadata read performance:
+//
+//   - the BLOCK cache, holding decompressed/decrypted LSM-tree data blocks, and
+//   - the INDEX cache, holding the block-offset indices used to locate keys.
+//
+// Badger's own defaults are tiny (256 MiB block, 0 index — index cache disabled
+// by default). On a host serving hundreds of concurrent NFS/SMB operations over
+// a large directory tree this thrashes: Badger logs "Block cache might be too
+// small ... hit-ratio: 0.26 ... sets-rejected" and every cold lookup walks the
+// LSM tree from disk. The thrashing also widens the window for the dedup
+// transaction-conflict race and the append-log "pressure wait timed out" path,
+// because metadata operations stall on disk I/O instead of returning from cache.
+//
+// We fix this in two ways:
+//
+//  1. The sizes are CONFIGURABLE — explicitly via BadgerMetadataStoreConfig
+//     (sourced from the per-store config map and the global DITTOFS_* /
+//     config.yaml metadata.badger.* keys).
+//
+//  2. When NOT explicitly configured, the sizes AUTO-SCALE with the memory
+//     available to the process (autoSizeCacheMB), so a 4 GiB host gets a
+//     usefully large cache without any tuning, while a large host gets more.
+
+const (
+	// blockCacheMemFraction is the fraction of process-available memory
+	// allocated to Badger's block cache when no explicit size is set.
+	// Conservative: the process also holds the append-log, the working set,
+	// and (on metadata stores fronting remote block stores) read buffers.
+	blockCacheMemFraction = 0.15
+
+	// indexCacheMemFraction is the fraction of process-available memory
+	// allocated to Badger's index cache when no explicit size is set. Indices
+	// are smaller than data blocks, so this is half the block-cache fraction.
+	indexCacheMemFraction = 0.075
+
+	// minBlockCacheMB / minIndexCacheMB are absolute floors (in MiB). These sit
+	// well above Badger's own tiny default so even a memory-detection failure
+	// (which falls back to the 4 GiB sysinfo default) yields a usefully large
+	// cache. They also guarantee a non-zero block cache, which Badger REQUIRES
+	// whenever compression or encryption is enabled.
+	minBlockCacheMB int64 = 512
+	minIndexCacheMB int64 = 256
+
+	// maxBlockCacheMB / maxIndexCacheMB cap the auto-sized caches so a very
+	// large host does not hand an unbounded slice of RAM to a single metadata
+	// store. Operators who genuinely want more set the sizes explicitly.
+	maxBlockCacheMB int64 = 4096
+	maxIndexCacheMB int64 = 2048
+)
+
+// globalCacheDefaults holds operator-configured cache sizes (in MiB) sourced
+// from the global config (metadata.badger.*). They are applied by
+// NewBadgerMetadataStoreWithDefaults / the default-options path when the
+// per-store config does not set its own sizes. A zero value means "unset —
+// fall through to RAM-relative auto-sizing".
+var globalCacheDefaults struct {
+	mu           sync.RWMutex
+	blockCacheMB int64
+	indexCacheMB int64
+}
+
+// SetGlobalBadgerCacheDefaults records operator-configured Badger cache sizes
+// (in MiB) sourced from the global DITTOFS_* / config.yaml metadata.badger.*
+// keys. These become the default for every badger metadata store opened
+// afterwards that does not specify its own BlockCacheSizeMB / IndexCacheSizeMB.
+//
+// A zero value for either size means "not configured" — that dimension then
+// falls through to RAM-relative auto-sizing (autoSizeCacheMB). Safe for
+// concurrent use; call once at startup before opening stores.
+func SetGlobalBadgerCacheDefaults(blockCacheMB, indexCacheMB int64) {
+	globalCacheDefaults.mu.Lock()
+	globalCacheDefaults.blockCacheMB = blockCacheMB
+	globalCacheDefaults.indexCacheMB = indexCacheMB
+	globalCacheDefaults.mu.Unlock()
+}
+
+func getGlobalBadgerCacheDefaults() (blockCacheMB, indexCacheMB int64) {
+	globalCacheDefaults.mu.RLock()
+	defer globalCacheDefaults.mu.RUnlock()
+	return globalCacheDefaults.blockCacheMB, globalCacheDefaults.indexCacheMB
+}
+
+// autoSizeCacheMB returns RAM-relative Badger block- and index-cache sizes (in
+// MiB) for a host with availMem bytes of process-available memory.
+//
+// Formula: each cache is a fixed fraction of available memory
+// (blockCacheMemFraction / indexCacheMemFraction), then clamped to the
+// [min, max]MB bounds. The fractions are deliberately conservative because the
+// same process also holds the append-log, the metadata working set, and read
+// buffers. The floors keep small hosts (and the memory-detection fallback) well
+// above Badger's tiny default; the ceilings stop a very large host from handing
+// a single store an unbounded slice of RAM.
+//
+// Example: a 4 GiB host -> block 614 MiB clamped to floor 512? No: 4096*0.15 =
+// 614 MiB (> 512 floor) block, 4096*0.075 = 307 MiB (> 256 floor) index.
+func autoSizeCacheMB(availMem uint64) (blockCacheMB, indexCacheMB int64) {
+	availMB := int64(availMem >> 20)
+	blockCacheMB = clampMB(int64(float64(availMB)*blockCacheMemFraction), minBlockCacheMB, maxBlockCacheMB)
+	indexCacheMB = clampMB(int64(float64(availMB)*indexCacheMemFraction), minIndexCacheMB, maxIndexCacheMB)
+	return blockCacheMB, indexCacheMB
+}
+
+// clampMB clamps v to the inclusive [lo, hi] range.
+func clampMB(v, lo, hi int64) int64 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+// resolveCacheSizesMB resolves the effective Badger block- and index-cache
+// sizes (in MiB) for a store, applying the precedence:
+//
+//  1. explicit per-store config (config.BlockCacheSizeMB / IndexCacheSizeMB),
+//  2. operator global config (SetGlobalBadgerCacheDefaults),
+//  3. RAM-relative auto-sizing (autoSizeCacheMB) for whichever dimension is
+//     still zero.
+//
+// Each dimension is resolved independently, so an operator can pin the block
+// cache while letting the index cache auto-scale (or vice versa). availMem is
+// the process-available memory in bytes (from sysinfo).
+func resolveCacheSizesMB(config BadgerMetadataStoreConfig, availMem uint64) (blockCacheMB, indexCacheMB int64) {
+	blockCacheMB = config.BlockCacheSizeMB
+	indexCacheMB = config.IndexCacheSizeMB
+
+	if blockCacheMB <= 0 || indexCacheMB <= 0 {
+		gBlock, gIndex := getGlobalBadgerCacheDefaults()
+		if blockCacheMB <= 0 && gBlock > 0 {
+			blockCacheMB = gBlock
+		}
+		if indexCacheMB <= 0 && gIndex > 0 {
+			indexCacheMB = gIndex
+		}
+	}
+
+	if blockCacheMB <= 0 || indexCacheMB <= 0 {
+		autoBlock, autoIndex := autoSizeCacheMB(availMem)
+		if blockCacheMB <= 0 {
+			blockCacheMB = autoBlock
+		}
+		if indexCacheMB <= 0 {
+			indexCacheMB = autoIndex
+		}
+	}
+
+	return blockCacheMB, indexCacheMB
+}
+
+// detectAvailableMemory returns the memory available to this process in bytes.
+// Indirected through a package var so tests can pin a deterministic figure.
+var detectAvailableMemory = func() uint64 {
+	return sysinfo.NewDetector().AvailableMemory()
+}
+
+// buildBadgerOptions constructs the badger.Options used to open a metadata
+// store. It is a pure function of its inputs (the store config and the
+// process-available memory figure), which makes the option construction — in
+// particular the resolved BlockCacheSize / IndexCacheSize threading — directly
+// testable without opening a database.
+//
+// When config.BadgerOptions is non-nil it is used verbatim (the operator has
+// taken full control of Badger tuning); only the unconditional SyncWrites
+// override is layered on by the caller. Otherwise sensible metadata-workload
+// defaults are applied and the cache sizes are resolved via resolveCacheSizesMB.
+func buildBadgerOptions(config BadgerMetadataStoreConfig, availMem uint64) badger.Options {
+	if config.BadgerOptions != nil {
+		return *config.BadgerOptions
+	}
+
+	opts := badger.DefaultOptions(config.DBPath)
+
+	// Optimize for metadata workload:
+	// - Frequent small reads/writes (file attributes, directory entries)
+	// - Range scans for directory listings (READDIR operations)
+	// - Concurrent access from multiple NFS clients
+	// - Large working set from directory scanning (Finder, ls -R, etc.)
+	// - High cache hit ratio critical for performance
+	opts = opts.WithLoggingLevel(badger.WARNING) // Reduce log noise
+	opts = opts.WithCompression(options.None)    // Metadata is small, compression overhead not worth it
+
+	// Resolve cache sizes with precedence: explicit > global config >
+	// RAM-relative auto-sizing (see resolveCacheSizesMB / #1245 Bug D). The
+	// resolved sizes are always > 0 (floors enforced), which also satisfies
+	// Badger's requirement that the block cache be non-zero under
+	// compression/encryption.
+	blockCacheMB, indexCacheMB := resolveCacheSizesMB(config, availMem)
+
+	opts = opts.WithBlockCacheSize(blockCacheMB << 20) // MiB -> bytes
+	opts = opts.WithIndexCacheSize(indexCacheMB << 20) // MiB -> bytes
+
+	return opts
+}

--- a/pkg/metadata/store/badger/cache.go
+++ b/pkg/metadata/store/badger/cache.go
@@ -104,8 +104,8 @@ func getGlobalBadgerCacheDefaults() (blockCacheMB, indexCacheMB int64) {
 // above Badger's tiny default; the ceilings stop a very large host from handing
 // a single store an unbounded slice of RAM.
 //
-// Example: a 4 GiB host -> block 614 MiB clamped to floor 512? No: 4096*0.15 =
-// 614 MiB (> 512 floor) block, 4096*0.075 = 307 MiB (> 256 floor) index.
+// Example: on a 4 GiB host neither cache hits a bound — block = 4096*0.15 ≈
+// 614 MiB, index = 4096*0.075 ≈ 307 MiB.
 func autoSizeCacheMB(availMem uint64) (blockCacheMB, indexCacheMB int64) {
 	availMB := int64(availMem >> 20)
 	blockCacheMB = clampMB(int64(float64(availMB)*blockCacheMemFraction), minBlockCacheMB, maxBlockCacheMB)

--- a/pkg/metadata/store/badger/cache_test.go
+++ b/pkg/metadata/store/badger/cache_test.go
@@ -190,6 +190,37 @@ func TestBuildBadgerOptions_CustomOptionsPassthrough(t *testing.T) {
 	}
 }
 
+// TestNewBadgerStore_CustomOptionsSkipsMemoryProbe asserts that the
+// custom-options path does NOT call detectAvailableMemory: buildBadgerOptions
+// returns config.BadgerOptions verbatim and ignores availMem, so probing
+// sysinfo there is wasted work (#1245 Bug D review follow-up).
+func TestNewBadgerStore_CustomOptionsSkipsMemoryProbe(t *testing.T) {
+	orig := detectAvailableMemory
+	t.Cleanup(func() { detectAvailableMemory = orig })
+
+	probed := false
+	detectAvailableMemory = func() uint64 {
+		probed = true
+		return 4 << 30
+	}
+
+	custom := badger.DefaultOptions(t.TempDir()).
+		WithBlockCacheSize(123 * mib).
+		WithIndexCacheSize(45 * mib)
+
+	store, err := NewBadgerMetadataStore(t.Context(), BadgerMetadataStoreConfig{
+		BadgerOptions: &custom,
+	})
+	if err != nil {
+		t.Fatalf("NewBadgerMetadataStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	if probed {
+		t.Error("custom-options path must not probe available memory")
+	}
+}
+
 // TestNewBadgerStore_AppliesResolvedCacheSizes is an end-to-end assertion that
 // an opened store's live badger.DB carries the resolved (here: explicit) cache
 // sizes — i.e. the option-builder output actually reaches badger.Open.

--- a/pkg/metadata/store/badger/cache_test.go
+++ b/pkg/metadata/store/badger/cache_test.go
@@ -1,0 +1,216 @@
+package badger
+
+import (
+	"testing"
+
+	badger "github.com/dgraph-io/badger/v4"
+)
+
+const mib = int64(1) << 20
+
+// TestAutoSizeCacheMB_Bounds asserts the RAM-relative auto-sizing function
+// (#1245 Bug D): the caches scale with available memory and are clamped to the
+// documented [min, max] bounds. In particular a 4 GiB host must get a usefully
+// large cache (well above Badger's tiny default), not the floor.
+func TestAutoSizeCacheMB_Bounds(t *testing.T) {
+	gib := uint64(1) << 30
+
+	cases := []struct {
+		name        string
+		availMem    uint64
+		wantBlockMB int64
+		wantIndexMB int64
+	}{
+		{
+			// Tiny host: both dimensions clamp to the floor.
+			name:        "1GiB clamps to floor",
+			availMem:    1 * gib,
+			wantBlockMB: minBlockCacheMB, // 1024*0.15=153 -> floor 512
+			wantIndexMB: minIndexCacheMB, // 1024*0.075=76 -> floor 256
+		},
+		{
+			// 4 GiB host (the bug report's host): fractions exceed the floor,
+			// so the host gets a genuinely larger cache.
+			name:        "4GiB scales above floor",
+			availMem:    4 * gib,
+			wantBlockMB: 614, // 4096*0.15 = 614.4 -> 614
+			wantIndexMB: 307, // 4096*0.075 = 307.2 -> 307
+		},
+		{
+			// Huge host: both dimensions clamp to the ceiling.
+			name:        "256GiB clamps to ceiling",
+			availMem:    256 * gib,
+			wantBlockMB: maxBlockCacheMB,
+			wantIndexMB: maxIndexCacheMB,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotBlock, gotIndex := autoSizeCacheMB(tc.availMem)
+			if gotBlock != tc.wantBlockMB {
+				t.Errorf("block cache: got %d MiB, want %d MiB", gotBlock, tc.wantBlockMB)
+			}
+			if gotIndex != tc.wantIndexMB {
+				t.Errorf("index cache: got %d MiB, want %d MiB", gotIndex, tc.wantIndexMB)
+			}
+			// Invariants: both dimensions are always within bounds and > 0.
+			if gotBlock < minBlockCacheMB || gotBlock > maxBlockCacheMB {
+				t.Errorf("block cache %d MiB out of [%d,%d]", gotBlock, minBlockCacheMB, maxBlockCacheMB)
+			}
+			if gotIndex < minIndexCacheMB || gotIndex > maxIndexCacheMB {
+				t.Errorf("index cache %d MiB out of [%d,%d]", gotIndex, minIndexCacheMB, maxIndexCacheMB)
+			}
+		})
+	}
+}
+
+// TestAutoSizeCacheMB_BlockNonZero pins Badger's hard requirement that the
+// block cache be > 0 when compression/encryption is enabled — the auto-sizer
+// must never return zero regardless of how little memory is reported.
+func TestAutoSizeCacheMB_BlockNonZero(t *testing.T) {
+	gotBlock, gotIndex := autoSizeCacheMB(0)
+	if gotBlock <= 0 {
+		t.Fatalf("block cache must be > 0, got %d", gotBlock)
+	}
+	if gotIndex <= 0 {
+		t.Fatalf("index cache must be > 0, got %d", gotIndex)
+	}
+}
+
+// TestResolveCacheSizesMB_Precedence asserts the resolution precedence:
+// explicit per-store config > global config > RAM-relative auto-sizing, with
+// each dimension resolved independently.
+func TestResolveCacheSizesMB_Precedence(t *testing.T) {
+	// Pin a deterministic memory figure so auto-sizing is predictable.
+	availMem := uint64(4) << 30 // 4 GiB -> auto block 614, index 307
+	autoBlock, autoIndex := autoSizeCacheMB(availMem)
+
+	t.Run("explicit per-store wins", func(t *testing.T) {
+		SetGlobalBadgerCacheDefaults(2000, 1000)
+		t.Cleanup(func() { SetGlobalBadgerCacheDefaults(0, 0) })
+
+		block, index := resolveCacheSizesMB(BadgerMetadataStoreConfig{
+			BlockCacheSizeMB: 777,
+			IndexCacheSizeMB: 333,
+		}, availMem)
+		if block != 777 || index != 333 {
+			t.Fatalf("explicit config should win: got (%d,%d), want (777,333)", block, index)
+		}
+	})
+
+	t.Run("global config used when per-store unset", func(t *testing.T) {
+		SetGlobalBadgerCacheDefaults(2000, 1000)
+		t.Cleanup(func() { SetGlobalBadgerCacheDefaults(0, 0) })
+
+		block, index := resolveCacheSizesMB(BadgerMetadataStoreConfig{}, availMem)
+		if block != 2000 || index != 1000 {
+			t.Fatalf("global config should be used: got (%d,%d), want (2000,1000)", block, index)
+		}
+	})
+
+	t.Run("auto-size when nothing configured", func(t *testing.T) {
+		SetGlobalBadgerCacheDefaults(0, 0)
+
+		block, index := resolveCacheSizesMB(BadgerMetadataStoreConfig{}, availMem)
+		if block != autoBlock || index != autoIndex {
+			t.Fatalf("should auto-size: got (%d,%d), want (%d,%d)", block, index, autoBlock, autoIndex)
+		}
+	})
+
+	t.Run("independent dimensions: block explicit, index auto", func(t *testing.T) {
+		SetGlobalBadgerCacheDefaults(0, 0)
+
+		block, index := resolveCacheSizesMB(BadgerMetadataStoreConfig{
+			BlockCacheSizeMB: 1234,
+		}, availMem)
+		if block != 1234 {
+			t.Fatalf("explicit block should win: got %d, want 1234", block)
+		}
+		if index != autoIndex {
+			t.Fatalf("index should auto-size: got %d, want %d", index, autoIndex)
+		}
+	})
+}
+
+// TestBuildBadgerOptions_ThreadsCacheSizes asserts that the resolved cache
+// sizes are actually threaded into the badger.Options produced by the
+// option-builder — the core of the #1245 fix. We assert on the Options struct
+// directly (no DB open needed).
+func TestBuildBadgerOptions_ThreadsExplicitSizes(t *testing.T) {
+	SetGlobalBadgerCacheDefaults(0, 0)
+
+	opts := buildBadgerOptions(BadgerMetadataStoreConfig{
+		DBPath:           t.TempDir(),
+		BlockCacheSizeMB: 800,
+		IndexCacheSizeMB: 400,
+	}, 4<<30)
+
+	if got, want := opts.BlockCacheSize, 800*mib; got != want {
+		t.Errorf("BlockCacheSize: got %d bytes, want %d bytes (800 MiB)", got, want)
+	}
+	if got, want := opts.IndexCacheSize, 400*mib; got != want {
+		t.Errorf("IndexCacheSize: got %d bytes, want %d bytes (400 MiB)", got, want)
+	}
+}
+
+// TestBuildBadgerOptions_ThreadsAutoSizes asserts that, with nothing
+// configured, the RAM-relative auto-sized values land in the Options.
+func TestBuildBadgerOptions_ThreadsAutoSizes(t *testing.T) {
+	SetGlobalBadgerCacheDefaults(0, 0)
+
+	availMem := uint64(4) << 30
+	autoBlock, autoIndex := autoSizeCacheMB(availMem)
+
+	opts := buildBadgerOptions(BadgerMetadataStoreConfig{DBPath: t.TempDir()}, availMem)
+
+	if got, want := opts.BlockCacheSize, autoBlock*mib; got != want {
+		t.Errorf("BlockCacheSize: got %d bytes, want %d bytes (%d MiB auto)", got, want, autoBlock)
+	}
+	if got, want := opts.IndexCacheSize, autoIndex*mib; got != want {
+		t.Errorf("IndexCacheSize: got %d bytes, want %d bytes (%d MiB auto)", got, want, autoIndex)
+	}
+}
+
+// TestBuildBadgerOptions_CustomOptionsPassthrough asserts that an operator who
+// supplies BadgerOptions takes full control: the helper returns them verbatim
+// and does not override the caches.
+func TestBuildBadgerOptions_CustomOptionsPassthrough(t *testing.T) {
+	custom := badger.DefaultOptions(t.TempDir()).
+		WithBlockCacheSize(123 * mib).
+		WithIndexCacheSize(45 * mib)
+
+	opts := buildBadgerOptions(BadgerMetadataStoreConfig{BadgerOptions: &custom}, 4<<30)
+
+	if opts.BlockCacheSize != 123*mib {
+		t.Errorf("custom BlockCacheSize not preserved: got %d", opts.BlockCacheSize)
+	}
+	if opts.IndexCacheSize != 45*mib {
+		t.Errorf("custom IndexCacheSize not preserved: got %d", opts.IndexCacheSize)
+	}
+}
+
+// TestNewBadgerStore_AppliesResolvedCacheSizes is an end-to-end assertion that
+// an opened store's live badger.DB carries the resolved (here: explicit) cache
+// sizes — i.e. the option-builder output actually reaches badger.Open.
+func TestNewBadgerStore_AppliesResolvedCacheSizes(t *testing.T) {
+	SetGlobalBadgerCacheDefaults(0, 0)
+
+	store, err := NewBadgerMetadataStore(t.Context(), BadgerMetadataStoreConfig{
+		DBPath:           t.TempDir(),
+		BlockCacheSizeMB: 600,
+		IndexCacheSizeMB: 300,
+	})
+	if err != nil {
+		t.Fatalf("NewBadgerMetadataStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	opts := store.db.Opts()
+	if got, want := opts.BlockCacheSize, 600*mib; got != want {
+		t.Errorf("live BlockCacheSize: got %d, want %d", got, want)
+	}
+	if got, want := opts.IndexCacheSize, 300*mib; got != want {
+		t.Errorf("live IndexCacheSize: got %d, want %d", got, want)
+	}
+}

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	badger "github.com/dgraph-io/badger/v4"
-	"github.com/dgraph-io/badger/v4/options"
 	"github.com/oklog/ulid/v2"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
@@ -166,12 +165,17 @@ type BadgerMetadataStoreConfig struct {
 	// If nil, sensible defaults are used
 	BadgerOptions *badger.Options
 
-	// BlockCacheSizeMB is BadgerDB's block cache size in MB (default: 256)
-	// This caches LSM-tree data blocks for faster reads
+	// BlockCacheSizeMB is BadgerDB's block cache size in MiB. This caches
+	// decompressed LSM-tree data blocks for faster reads. When 0 (unset) the
+	// size is resolved from the global config (SetGlobalBadgerCacheDefaults)
+	// or, failing that, RAM-relative auto-sizing (autoSizeCacheMB). See
+	// cache.go / #1245 Bug D.
 	BlockCacheSizeMB int64
 
-	// IndexCacheSizeMB is BadgerDB's index cache size in MB (default: 128)
-	// This caches LSM-tree indices for faster lookups
+	// IndexCacheSizeMB is BadgerDB's index cache size in MiB. This caches
+	// LSM-tree block indices for faster key lookups. When 0 (unset) the size
+	// is resolved from the global config or RAM-relative auto-sizing — see
+	// BlockCacheSizeMB.
 	IndexCacheSizeMB int64
 }
 
@@ -214,40 +218,13 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 		return nil, err
 	}
 
-	// Prepare BadgerDB options
-	var opts badger.Options
-	customOpts := config.BadgerOptions != nil
-	if customOpts {
-		opts = *config.BadgerOptions
-	} else {
-		// Use sensible defaults for DittoFS metadata workload
-		opts = badger.DefaultOptions(config.DBPath)
-
-		// Optimize for metadata workload:
-		// - Frequent small reads/writes (file attributes, directory entries)
-		// - Range scans for directory listings (READDIR operations)
-		// - Concurrent access from multiple NFS clients
-		// - Large working set from directory scanning (Finder, ls -R, etc.)
-		// - High cache hit ratio critical for performance
-		opts = opts.WithLoggingLevel(badger.WARNING) // Reduce log noise
-		opts = opts.WithCompression(options.None)    // Metadata is small, compression overhead not worth it
-
-		// Configure cache sizes (with production-ready defaults if not specified)
-		// Production NFS workloads require larger caches to maintain high hit ratios:
-		// - With 256MB caches: ~8% hit ratio (cache thrashing, poor performance)
-		// - With 1GB+ caches: >80% hit ratio (good performance for 100s of concurrent operations)
-		blockCacheMB := config.BlockCacheSizeMB
-		if blockCacheMB == 0 {
-			blockCacheMB = 1024 // Default: 1GB for production NFS workloads
-		}
-		indexCacheMB := config.IndexCacheSizeMB
-		if indexCacheMB == 0 {
-			indexCacheMB = 512 // Default: 512MB for production workloads
-		}
-
-		opts = opts.WithBlockCacheSize(blockCacheMB << 20) // Convert MB to bytes
-		opts = opts.WithIndexCacheSize(indexCacheMB << 20) // Convert MB to bytes
-	}
+	// Prepare BadgerDB options. Option construction (including the resolved
+	// block/index cache sizing — #1245 Bug D) lives in the pure, testable
+	// buildBadgerOptions helper. When config.BadgerOptions is nil the helper
+	// applies metadata-workload defaults and resolves the cache sizes with
+	// precedence: explicit per-store config > global config > RAM-relative
+	// auto-sizing. detectAvailableMemory is indirected for testability.
+	opts := buildBadgerOptions(config, detectAvailableMemory())
 
 	// Crash-consistency (#583, enforced #588): force SyncWrites=true on
 	// every code path — default-options AND custom-options. Default
@@ -507,7 +484,26 @@ func (s *BadgerMetadataStore) GetQuotaUsage(scope metadata.QuotaScope, id uint32
 //   - *BadgerMetadataStore: A new store instance with default configuration
 //   - error: Error if database initialization fails
 func NewBadgerMetadataStoreWithDefaults(ctx context.Context, dbPath string) (*BadgerMetadataStore, error) {
-	return NewBadgerMetadataStore(ctx, BadgerMetadataStoreConfig{
+	return NewBadgerMetadataStore(ctx, defaultStoreConfig(dbPath))
+}
+
+// NewBadgerMetadataStoreWithDefaultsAndCaches is NewBadgerMetadataStoreWithDefaults
+// with explicit Badger block/index cache sizes (in MiB). A zero size for either
+// dimension defers that cache to the global config / RAM-relative auto-sizing
+// (see cache.go / #1245 Bug D). Used by the per-store config-map path so an
+// operator can pin caches on a single metadata store via its config keys
+// (block_cache_mb / index_cache_mb).
+func NewBadgerMetadataStoreWithDefaultsAndCaches(ctx context.Context, dbPath string, blockCacheMB, indexCacheMB int64) (*BadgerMetadataStore, error) {
+	cfg := defaultStoreConfig(dbPath)
+	cfg.BlockCacheSizeMB = blockCacheMB
+	cfg.IndexCacheSizeMB = indexCacheMB
+	return NewBadgerMetadataStore(ctx, cfg)
+}
+
+// defaultStoreConfig returns the standard BadgerMetadataStoreConfig (capabilities
+// and limits) for the given path, with cache sizes left at 0 (auto-sized).
+func defaultStoreConfig(dbPath string) BadgerMetadataStoreConfig {
+	return BadgerMetadataStoreConfig{
 		DBPath: dbPath,
 		Capabilities: metadata.FilesystemCapabilities{
 			// Transfer Sizes
@@ -537,7 +533,7 @@ func NewBadgerMetadataStoreWithDefaults(ctx context.Context, dbPath string) (*Ba
 		},
 		MaxStorageBytes: 0, // Unlimited (reported as available disk space)
 		MaxFiles:        0, // Unlimited (reported as 1 million)
-	})
+	}
 }
 
 // initializeSingletons initializes singleton keys if they don't exist.
@@ -636,6 +632,12 @@ func (s *BadgerMetadataStore) Close() error {
 
 	return s.closeErr
 }
+
+// BadgerOptions returns the badger.Options the underlying DB was opened with.
+// Exposed for diagnostics and tests (e.g. asserting the resolved block/index
+// cache sizes were threaded into the open — #1245 Bug D). The returned value is
+// a copy; mutating it does not affect the live DB.
+func (s *BadgerMetadataStore) BadgerOptions() badger.Options { return s.db.Opts() }
 
 // GetStoreID returns the Badger-persistent store identifier (stored at key
 // cfg:store_id). Stable across restarts — the ULID is written once on first

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -224,7 +224,16 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 	// applies metadata-workload defaults and resolves the cache sizes with
 	// precedence: explicit per-store config > global config > RAM-relative
 	// auto-sizing. detectAvailableMemory is indirected for testability.
-	opts := buildBadgerOptions(config, detectAvailableMemory())
+	//
+	// availMem is only consulted on the default-options path (the
+	// RAM-relative auto-sizing fallback). On the custom-options path
+	// buildBadgerOptions returns config.BadgerOptions verbatim and ignores
+	// availMem entirely, so skip the sysinfo probe there.
+	var availMem uint64
+	if config.BadgerOptions == nil {
+		availMem = detectAvailableMemory()
+	}
+	opts := buildBadgerOptions(config, availMem)
 
 	// Crash-consistency (#583, enforced #588): force SyncWrites=true on
 	// every code path — default-options AND custom-options. Default


### PR DESCRIPTION
Part of #1245 (Bug D — badger cache undersized/non-tunable).

## Problem
On a 4 GB host the metadata Badger cache thrashed (hit-ratio ~0.26, sets-rejected high), which also widened the dedup tx-conflict and append-log pressure-wait windows. Root cause (refined): the store opened Badger with a **fixed** 1 GiB block / 512 MiB index cache and **no config knob and no RAM-relative sizing** — over-committed on small hosts, un-tunable on large ones.

## Fix
- New `pkg/metadata/store/badger/cache.go`: pure, testable `buildBadgerOptions` / `resolveCacheSizesMB` / `autoSizeCacheMB`.
- **Configurable**: `metadata.badger.block_cache_mb` / `index_cache_mb` (config.yaml + `DITTOFS_METADATA_BADGER_*` env).
- **RAM-relative auto-sizing** when unset: block = 15% of process-available memory, index = 7.5%, clamped (floor 512/256 MiB, ceiling 4 GiB/2 GiB). Available memory = cgroup limit in a container else physical RAM (`internal/sysinfo`). Floors keep block cache > 0 (Badger requires it under compression/encryption). Precedence: explicit per-store > global config > auto-size, per-dimension.
- Docs: sizing tables + formula + tuning FAQ in `docs/CONFIGURATION.md` and `docs/FAQ.md`.

Other badger.Open site (`pkg/block/engine/gcstate.go`, transient GC-state DB) intentionally left as-is.

## Tests
Auto-size bounds/non-zero, precedence, options-threading, store-applies-resolved-sizes; config round-trip/env/validation; runtime per-store override. `go build/vet/gofmt` clean.