### PR TITLE
fix(smb): eliminate rename SHARING_VIOLATION flake (handle-scan vs close race) + dir-rename ACCESS_DENIED

### DIFF
--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -644,12 +644,27 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// Step 10: Remove the open file handle
 	// ========================================================================
 
-	// WaitAndDeleteOpenFile drains in-flight operations (e.g., a concurrent
-	// QueryDirectory on the same handle) before removing the handle from
-	// the map. This prevents a CLOSE goroutine from racing ahead of a FIND
-	// goroutine on the same connection and causing a spurious FILE_CLOSED
-	// (smbtorture compound_find.compound_find_close).
-	h.WaitAndDeleteOpenFile(req.FileID)
+	// Drain in-flight operations (e.g., a concurrent QueryDirectory on the
+	// same handle) BEFORE removing the handle from the map. This prevents a
+	// CLOSE goroutine from racing ahead of a FIND goroutine on the same
+	// connection and causing a spurious FILE_CLOSED
+	// (smbtorture compound_find.compound_find_close). The drain runs OUTSIDE
+	// renameScanMu because it can block on a slow in-flight op and the rename
+	// path must remain free to take the mutex for its own conflict scan.
+	h.DrainHandleOps(req.FileID)
+
+	// Steps 10 (map removal) + 11 (lease release/signal) run under
+	// renameScanMu so that a concurrent SET_INFO rename's post-break conflict
+	// re-scan cannot observe this handle half-removed: either the rename's
+	// authoritative scan runs entirely before we begin (sees a live holder →
+	// correct SHARING_VIOLATION) or entirely after we finish (sees the shrunk
+	// table + a drained break → correct STATUS_OK). No interleaving, hence no
+	// flake. The break-WAIT the rename performs to reach this point happens
+	// OUTSIDE the mutex (set_info.go), so this CLOSE is never blocked behind a
+	// rename that is itself waiting on this CLOSE — see the renameScanMu
+	// doc comment on Handler for the full deadlock-safety argument.
+	h.renameScanMu.Lock()
+	h.deleteOpenFileEntry(req.FileID)
 
 	// ========================================================================
 	// Step 11: Release oplock/lease if held
@@ -704,6 +719,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	if openFile.IsDirectory && h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {
 		h.LeaseManager.SignalParkedCreates(lock.FileHandle(openFile.MetadataHandle), openFile.ShareName)
 	}
+	h.renameScanMu.Unlock()
 
 	logger.Debug("CLOSE successful",
 		"fileID", fmt.Sprintf("%x", req.FileID),

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -54,6 +54,32 @@ type Handler struct {
 	files      sync.Map // string(fileID) -> *OpenFile
 	nextFileID atomic.Uint64
 
+	// renameScanMu serializes a SET_INFO rename's share-mode conflict
+	// scan-and-decision against a concurrent CLOSE's authoritative handle
+	// removal. The rename path reads the lock-free `files` sync.Map to decide
+	// whether a conflicting handle still exists (checkShareDeleteConflict,
+	// checkParentDirRenameConflict, anyOpenChild); CLOSE removes the OpenFile
+	// from `files` and then releases the lease / signals the rename's
+	// break-wait. Without serialization the rename's post-break re-scan can
+	// observe a holder that a concurrent CLOSE is in the middle of removing —
+	// the OpenFile is not-yet-deleted from `files` even though the holder has
+	// already signalled the break complete — yielding a spurious
+	// STATUS_SHARING_VIOLATION (intermittent smbtorture
+	// rename_dir_bench / close-full-information / dirlease.rename_dst_parent).
+	//
+	// Lock order / deadlock-safety: the rename MUST NOT hold this mutex while
+	// performing a lease break-WAIT, because that wait can only complete when a
+	// holder CLOSEs — and CLOSE needs this same mutex to remove the handle and
+	// signal. The rename therefore does every break-WAIT OUTSIDE the mutex and
+	// takes it only for the final authoritative re-scan + decision, where it
+	// reads the now-quiescent `files` map. CLOSE holds it across the handle
+	// removal + lease release/signal (close.go step 10/11). The mutex never
+	// nests under any LockManager/lease lock: the rename's `files.Range` scans
+	// touch only the sync.Map, and CLOSE's WaitAndDeleteOpenFile drains only
+	// the *closing* handle's own in-flight ops (never a rename, which registers
+	// under its own distinct FileID).
+	renameScanMu sync.Mutex
+
 	// Named pipe management (for IPC$ RPC)
 	PipeManager *rpc.PipeManager
 
@@ -993,11 +1019,30 @@ func (h *Handler) ReleaseOpenFile(fileID [16]byte) {
 // replaces DeleteOpenFile for the CLOSE handler to prevent the race where
 // CLOSE deletes a handle that QueryDirectory is about to look up.
 func (h *Handler) WaitAndDeleteOpenFile(fileID [16]byte) {
+	h.DrainHandleOps(fileID)
+	h.deleteOpenFileEntry(fileID)
+}
+
+// DrainHandleOps blocks until all in-flight operations registered on fileID
+// (via BeginHandleOp / AcquireOpenFile) have completed, then drops the tracker.
+// Split out of WaitAndDeleteOpenFile so the CLOSE handler can drain the closing
+// handle's in-flight ops OUTSIDE renameScanMu (the drain can be unbounded if a
+// slow QueryDirectory is in flight) and take the mutex only for the actual
+// map removal + lease release/signal — see close.go step 10/11.
+func (h *Handler) DrainHandleOps(fileID [16]byte) {
 	key := string(fileID[:])
 	if v, ok := h.handleOps.Load(key); ok {
 		v.(*handleOpTracker).wg.Wait()
 		h.handleOps.Delete(key)
 	}
+}
+
+// deleteOpenFileEntry removes the OpenFile from the files map and revokes its
+// replay/resume state. The caller is responsible for any draining (see
+// DrainHandleOps). The CLOSE path holds renameScanMu across this call so a
+// concurrent rename's conflict re-scan cannot observe a half-removed handle.
+func (h *Handler) deleteOpenFileEntry(fileID [16]byte) {
+	key := string(fileID[:])
 	h.forgetReplayState(fileID)
 	h.files.Delete(key)
 	h.resumeKeys.revoke(fileID)

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -1386,18 +1386,22 @@ func (h *Handler) closeFilesWithFilter(
 		return true
 	})
 
-	// Second pass: delete collected file handles and clean up associated state
-	for _, fileID := range toDelete {
-		// Unregister any pending CHANGE_NOTIFY watchers for this handle.
-		// The CLOSE handler (close.go) does this for explicit closes, but
-		// closeFilesWithFilter bypasses the CLOSE handler. Without this,
-		// stale watchers persist in the NotifyRegistry after connection
-		// cleanup and can fire during subsequent tests, sending async
-		// responses on dead connections with partially-destroyed sessions.
-		// Per MS-SMB2 3.3.4.1: when the watched handle goes away the
-		// pending request MUST complete with STATUS_NOTIFY_CLEANUP so the
-		// client's async recv unblocks (smb2.notify.tcon, .dir).
-		if h.NotifyRegistry != nil {
+	// Second pass: unregister pending CHANGE_NOTIFY watchers for the collected
+	// handles. The CLOSE handler (close.go) does this for explicit closes, but
+	// closeFilesWithFilter bypasses the CLOSE handler. Without this, stale
+	// watchers persist in the NotifyRegistry after connection cleanup and can
+	// fire during subsequent tests, sending async responses on dead connections
+	// with partially-destroyed sessions. Per MS-SMB2 3.3.4.1: when the watched
+	// handle goes away the pending request MUST complete with
+	// STATUS_NOTIFY_CLEANUP so the client's async recv unblocks
+	// (smb2.notify.tcon, .dir).
+	//
+	// This runs OUTSIDE renameScanMu — it touches only the NotifyRegistry, not
+	// the `files` map a concurrent rename scan inspects — and never blocks on a
+	// wait a concurrent CLOSE must satisfy, preserving the same deadlock-safety
+	// argument as close.go's DrainHandleOps placement.
+	if h.NotifyRegistry != nil {
+		for _, fileID := range toDelete {
 			h.NotifyRegistry.Disarm(fileID)
 			if notify := h.NotifyRegistry.Unregister(fileID); notify != nil && notify.AsyncCallback != nil {
 				cleanupResp := &ChangeNotifyResponse{
@@ -1417,16 +1421,48 @@ func (h *Handler) closeFilesWithFilter(
 				})
 			}
 		}
-		h.DeleteOpenFile(fileID)
 	}
 
-	// Third pass: release per-handle lease/oplock records. Runs after every
-	// DeleteOpenFile above so releaseHandleLeaseRecord's "any other open on the
-	// same file shares this key" scan sees the shrunk table — otherwise sibling
-	// opens of the same file/key (all still present in the first pass) would
-	// each defer to the other and the record would leak.
+	// Third pass: remove the collected handles from the `files` map and release
+	// their per-handle lease/oplock records, all under renameScanMu.
+	//
+	// Lock rationale (mirrors close.go step 10/11): a concurrent SET_INFO
+	// rename's post-break conflict re-scan reads the lock-free `files` map to
+	// decide whether a conflicting holder still exists. If a teardown removed a
+	// handle and then released its lease (which signals the rename's break-wait)
+	// WITHOUT this mutex, the woken rename could observe the holder
+	// half-removed — gone from `files` per the signal yet still mid-removal — or
+	// the reverse, yielding a spurious STATUS_SHARING_VIOLATION. Holding
+	// renameScanMu across the map removal + lease release makes the rename's
+	// authoritative scan run entirely before or entirely after this teardown,
+	// never interleaved. closeFilesWithFilter does no DrainHandleOps wait, so
+	// nothing inside this section blocks on a wait a concurrent CLOSE must
+	// satisfy; the mutex never nests under any LockManager/lease lock (the scan
+	// touches only the sync.Map), so lock ordering stays cycle-free.
+	//
+	// The handleOps tracker is cleared outside the mutex: it is an independent
+	// sync.Map the rename scan never reads, and the in-flight ops for a
+	// teardown handle are not waited on here.
+	//
+	// releaseHandleLeaseRecord runs after every map removal so its "any other
+	// open on the same file shares this key" scan sees the shrunk table —
+	// otherwise sibling opens of the same file/key (all still present in the
+	// first pass) would each defer to the other and the record would leak.
+	h.renameScanMu.Lock()
+	for _, fileID := range toDelete {
+		h.deleteOpenFileEntry(fileID)
+	}
 	for _, openFile := range leaseReleases {
 		h.releaseHandleLeaseRecord(ctx, openFile, caller)
+	}
+	h.renameScanMu.Unlock()
+
+	// Clear the handleOps trackers for the removed handles. deleteOpenFileEntry
+	// (used inside renameScanMu above, consistent with close.go) does not touch
+	// handleOps, so do it here to avoid leaking trackers created by
+	// BeginHandleOp on these FileIDs.
+	for _, fileID := range toDelete {
+		h.handleOps.Delete(string(fileID[:]))
 	}
 
 	if closed > 0 {

--- a/internal/adapter/smb/handlers/rename_scan_close_race_test.go
+++ b/internal/adapter/smb/handlers/rename_scan_close_race_test.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
@@ -120,5 +121,140 @@ func TestRenameScan_vs_Close_Serialized_NoRace(t *testing.T) {
 	if observedTorn.Load() {
 		t.Fatal("rename conflict scan observed a CLOSE's torn (half-removed) handle " +
 			"window — renameScanMu serialization is broken")
+	}
+}
+
+// TestRenameScan_vs_Close_NegativeControl proves the race the mutex prevents is
+// real and that the mutex is what prevents it. It runs the SAME scan + removal
+// the production paths use under two regimes against the same Handler:
+//
+//   - WITHOUT renameScanMu (the buggy / pre-fix shape): the scan goroutine and
+//     the removal goroutine are free to interleave, so a scan reliably observes
+//     a holder mid-removal (the torn window). The sub-test ASSERTS the tear is
+//     observed — if it weren't, the test would be vacuous and could not
+//     distinguish a present mutex from an absent one.
+//
+//   - WITH renameScanMu (the fix): the identical workload never observes the
+//     torn window over the same iteration budget.
+//
+// Determinism: the removal side opens the torn window (torn=true), then busy-
+// loops on the scan side's progress counter so the window stays open across at
+// least one full scan before closing it (torn=false). The unsynchronized
+// variant therefore *must* see the tear well within the iteration budget (it is
+// not probabilistic), while the synchronized variant *cannot* see it because the
+// mutex makes the open→scan→close sequence atomic with respect to the scan.
+func TestRenameScan_vs_Close_NegativeControl(t *testing.T) {
+	metaHandle := metadata.FileHandle{0xDE, 0xAD, 0xBE, 0xEF}
+	parentHandle := metadata.FileHandle{0xB1, 0xB2}
+
+	// run drives the scan/removal workload, optionally serialized by the
+	// handler's renameScanMu, and reports whether a scan ever saw the torn
+	// (mid-removal) window. The same code path is used for both regimes so the
+	// ONLY difference is whether the shared mutex is taken.
+	run := func(serialized bool) bool {
+		h := NewHandler()
+
+		renamerID := h.GenerateFileID()
+		h.StoreOpenFile(&OpenFile{
+			FileID:         renamerID,
+			MetadataHandle: metaHandle,
+			IsDirectory:    true,
+			ParentHandle:   parentHandle,
+		})
+		renamer, _ := h.files.Load(string(renamerID[:]))
+		of := renamer.(*OpenFile)
+
+		const iters = 200
+		var torn atomic.Bool          // true while a removal is mid-flight
+		var scanProgress atomic.Int64 // bumped once per completed scan
+		var observedTorn atomic.Bool
+
+		lock := func() {
+			if serialized {
+				h.renameScanMu.Lock()
+			}
+		}
+		unlock := func() {
+			if serialized {
+				h.renameScanMu.Unlock()
+			}
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		// Removal goroutine: re-create then remove the conflicting holder. In the
+		// unserialized regime it deliberately holds the torn window open until the
+		// scan goroutine has advanced, so the tear is reliably visible. In the
+		// serialized regime the same open→hold→close sequence is atomic under the
+		// mutex, so no scan can interleave.
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				// Unserialized regime: stop early once the tear is proven, so the
+				// negative control is fast (it only needs ONE observation).
+				if !serialized && observedTorn.Load() {
+					return
+				}
+				holderID, childID := storeHolder(h, metaHandle, parentHandle)
+				lock()
+				torn.Store(true)
+				if !serialized {
+					// Keep the window open until the scan side makes progress so
+					// the unsynchronized tear is deterministic, not probabilistic.
+					start := scanProgress.Load()
+					deadline := time.Now().Add(50 * time.Millisecond)
+					for scanProgress.Load() == start && time.Now().Before(deadline) {
+						// spin
+					}
+				}
+				h.deleteOpenFileEntry(holderID)
+				h.deleteOpenFileEntry(childID)
+				torn.Store(false)
+				unlock()
+			}
+		}()
+
+		// Scan goroutine: run the three authoritative conflict scans, checking the
+		// torn flag immediately before and after, and publishing progress.
+		go func() {
+			defer wg.Done()
+			deadline := time.Now().Add(2 * time.Second)
+			for i := 0; i < iters && time.Now().Before(deadline); i++ {
+				// Unserialized regime: one observation is enough to prove the race.
+				if !serialized && observedTorn.Load() {
+					return
+				}
+				lock()
+				if torn.Load() {
+					observedTorn.Store(true)
+				}
+				_ = h.checkShareDeleteConflict(of)
+				_ = h.checkParentDirRenameConflict(of.FileID, of.MetadataHandle)
+				_ = h.anyOpenChild(of.MetadataHandle)
+				if torn.Load() {
+					observedTorn.Store(true)
+				}
+				unlock()
+				scanProgress.Add(1)
+			}
+		}()
+
+		wg.Wait()
+		return observedTorn.Load()
+	}
+
+	// Negative control: WITHOUT the mutex the tear MUST be observable. If this
+	// ever stops firing, the test below could not distinguish a working mutex
+	// from a missing one.
+	if !run(false) {
+		t.Fatal("negative control did not observe the torn window without renameScanMu — " +
+			"the test cannot prove the mutex is what prevents the race")
+	}
+
+	// Positive assertion: WITH the mutex the identical workload never tears.
+	if run(true) {
+		t.Fatal("rename conflict scan observed a torn (half-removed) handle window " +
+			"under renameScanMu — serialization is broken")
 	}
 }

--- a/internal/adapter/smb/handlers/rename_scan_close_race_test.go
+++ b/internal/adapter/smb/handlers/rename_scan_close_race_test.go
@@ -1,0 +1,124 @@
+// Race regression tests for the SET_INFO rename conflict-scan vs CLOSE
+// handle-removal serialization (renameScanMu).
+//
+// Background: the rename handler decides STATUS_SHARING_VIOLATION /
+// STATUS_ACCESS_DENIED by scanning the lock-free h.files sync.Map
+// (checkShareDeleteConflict / checkParentDirRenameConflict / anyOpenChild).
+// A concurrent CLOSE removes the conflicting OpenFile from h.files and then
+// releases the lease / signals the rename's break-wait. Before the fix the two
+// were not mutually exclusive: the rename's post-break re-scan could observe a
+// holder that a CLOSE was in the middle of removing (already signalled the
+// break, not yet deleted from h.files) → an intermittent spurious
+// SHARING_VIOLATION (smbtorture rename_dir_bench / close-full-information /
+// dirlease.rename_dst_parent).
+//
+// The fix takes renameScanMu around the rename's authoritative scan+decision
+// and around CLOSE's deleteOpenFileEntry + lease-release/signal. These tests
+// pin that serialization by driving the same real Handler methods the
+// production paths use, plus a torn-window guard that fails under -race if
+// either side drops the mutex.
+package handlers
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// storeHolder inserts a conflicting OpenFile (no FILE_SHARE_DELETE) sharing
+// metaHandle, plus a child OpenFile parented at parentHandle, so all three
+// rename conflict scans see a live conflict until the holder is removed.
+func storeHolder(h *Handler, metaHandle, parentHandle metadata.FileHandle) (holderID, childID [16]byte) {
+	holderID = h.GenerateFileID()
+	h.StoreOpenFile(&OpenFile{
+		FileID:         holderID,
+		MetadataHandle: metaHandle,
+		ParentHandle:   parentHandle,
+		ShareAccess:    0,                  // lacks FILE_SHARE_DELETE → checkShareDeleteConflict trips
+		DesiredAccess:  uint32(0x00010000), // DELETE → checkParentDirRenameConflict trips
+	})
+	childID = h.GenerateFileID()
+	h.StoreOpenFile(&OpenFile{
+		FileID:         childID,
+		MetadataHandle: metadata.FileHandle{0xCC},
+		ParentHandle:   metaHandle, // child of the directory being renamed
+	})
+	return holderID, childID
+}
+
+// TestRenameScan_vs_Close_Serialized_NoRace pins renameScanMu. A CLOSE
+// goroutine removes the conflicting holder under the mutex, bracketing the
+// removal with a torn-window flag; a rename goroutine runs the authoritative
+// conflict scans under the mutex and asserts it never observes the torn window
+// (i.e. the holder half-removed). Fails under `go test -race` if either side
+// drops renameScanMu, and fails the torn assertion if the scan and removal are
+// allowed to interleave.
+func TestRenameScan_vs_Close_Serialized_NoRace(t *testing.T) {
+	h := NewHandler()
+
+	metaHandle := metadata.FileHandle{0xDE, 0xAD, 0xBE, 0xEF}
+	parentHandle := metadata.FileHandle{0xA1, 0xA2} // arbitrary distinct parent
+
+	// The renamer's own directory open (IsDirectory so anyOpenChild applies).
+	renamerID := h.GenerateFileID()
+	h.StoreOpenFile(&OpenFile{
+		FileID:         renamerID,
+		MetadataHandle: metaHandle,
+		IsDirectory:    true,
+		ParentHandle:   parentHandle,
+	})
+
+	const iters = 2000
+	var torn atomic.Bool         // true while a CLOSE is mid-removal under the mutex
+	var observedTorn atomic.Bool // set if a scan ever sees the torn window
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// CLOSE goroutine: re-create + remove the conflicting holder repeatedly,
+	// each removal serialized through renameScanMu exactly as close.go does.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			holderID, childID := storeHolder(h, metaHandle, parentHandle)
+			// Drain happens outside the mutex in production; here there are no
+			// in-flight ops, so go straight to the locked removal region.
+			h.renameScanMu.Lock()
+			torn.Store(true)
+			h.deleteOpenFileEntry(holderID)
+			h.deleteOpenFileEntry(childID)
+			torn.Store(false)
+			h.renameScanMu.Unlock()
+		}
+	}()
+
+	// RENAME goroutine: run the three authoritative scans under the mutex,
+	// asserting the torn window is never observed.
+	go func() {
+		defer wg.Done()
+		renamer, _ := h.files.Load(string(renamerID[:]))
+		of := renamer.(*OpenFile)
+		for i := 0; i < iters; i++ {
+			h.renameScanMu.Lock()
+			if torn.Load() {
+				observedTorn.Store(true)
+			}
+			_ = h.checkShareDeleteConflict(of)
+			_ = h.checkParentDirRenameConflict(of.FileID, of.MetadataHandle)
+			_ = h.anyOpenChild(of.MetadataHandle)
+			if torn.Load() {
+				observedTorn.Store(true)
+			}
+			h.renameScanMu.Unlock()
+		}
+	}()
+
+	wg.Wait()
+
+	if observedTorn.Load() {
+		t.Fatal("rename conflict scan observed a CLOSE's torn (half-removed) handle " +
+			"window — renameScanMu serialization is broken")
+	}
+}

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -689,7 +689,16 @@ func (h *Handler) setFileInfoFromStore(
 		// all other opens must have FILE_SHARE_DELETE (0x04) in ShareAccess.
 		// (Destination-parent share-mode probe runs further below, after toDir
 		// is resolved and the stream-rename early return has been ruled out.)
-		if conflict := h.checkShareDeleteConflict(openFile); conflict {
+		//
+		// Held under renameScanMu so the scan-and-decision is atomic vs a
+		// concurrent CLOSE removing the conflicting holder from h.files (which
+		// would otherwise yield an intermittent spurious SHARING_VIOLATION).
+		// No break-wait precedes this gate, so taking the mutex here cannot
+		// deadlock against a CLOSE.
+		h.renameScanMu.Lock()
+		shareDeleteConflict := h.checkShareDeleteConflict(openFile)
+		h.renameScanMu.Unlock()
+		if shareDeleteConflict {
 			logger.Debug("SET_INFO: rename blocked by sharing violation",
 				"path", openFile.Path,
 				"fileID", fmt.Sprintf("%x", openFile.FileID))
@@ -840,6 +849,59 @@ func (h *Handler) setFileInfoFromStore(
 			return setInfoStatus(types.StatusAccessDenied), nil
 		}
 
+		// Directory rename: break H-leases on every open child file (RH→R
+		// strip-H) and wait for each break to drain. After the wait, ANY
+		// remaining open child blocks the parent rename with STATUS_ACCESS_DENIED
+		// per MS-FSA §2.1.5.14 (smbtorture rename_dir_openfile: 8 sub-cases all
+		// hinge on whether every H-leased child closes-on-break or stays open
+		// after ACK). Children without an H-lease are no-op'd by
+		// ComputeLeaseBreakTo and stay open → the open-child recheck produces the
+		// immediate ACCESS_DENIED for the "no-hleases" case.
+		//
+		// PRECEDENCE (Fix A, smbtorture rename_dir_openfile): this open-child
+		// determination runs BEFORE the destination-parent share-mode gate
+		// below. A directory rename whose source has an open child is
+		// ACCESS_DENIED, and that status must win over any SHARING_VIOLATION the
+		// dst-parent gate would otherwise raise — MS-FSA evaluates the source
+		// open-child constraint ahead of the dst-parent implicit-open conflict.
+		//
+		// Deadlock-safety: the per-child break-WAITs run OUTSIDE renameScanMu (a
+		// break can only complete when the child's holder CLOSEs, and CLOSE needs
+		// renameScanMu). Only the final authoritative anyOpenChild scan is taken
+		// under the mutex, so a child whose holder is mid-CLOSE is observed as
+		// either fully present (live → ACCESS_DENIED) or fully gone (→ proceed).
+		if openFile.IsDirectory && h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {
+			children := h.snapshotOpenChildren(openFile.MetadataHandle)
+			for _, child := range children {
+				if err := h.LeaseManager.BreakHandleLeasesOnOpenAsync(
+					lock.FileHandle(child), openFile.ShareName, lock.BreakReasonSharingViolation,
+				); err != nil {
+					logger.Debug("SET_INFO: dir-rename child break dispatch failed",
+						"child", string(child), "error", err)
+				}
+			}
+			for _, child := range children {
+				waitCtx, cancelChild := context.WithTimeout(authCtx.Context, lease.AsyncCreateBreakWaitTimeout)
+				if err := h.LeaseManager.WaitForOtherKeyBreaks(
+					waitCtx, lock.FileHandle(child), openFile.ShareName, [16]byte{},
+				); err != nil {
+					logger.Debug("SET_INFO: dir-rename child break wait completed",
+						"child", string(child), "error", err)
+				}
+				cancelChild()
+			}
+			// Authoritative recheck under the scan mutex (Fix B): serialized vs
+			// a concurrent CLOSE removing the last open child from h.files.
+			h.renameScanMu.Lock()
+			openChild := h.anyOpenChild(openFile.MetadataHandle)
+			h.renameScanMu.Unlock()
+			if openChild {
+				logger.Debug("SET_INFO: dir rename blocked by open child",
+					"dir", openFile.Path)
+				return setInfoStatus(types.StatusAccessDenied), nil
+			}
+		}
+
 		// Per MS-FSA 2.1.5.14.11.3 / Samba smbd_smb2_setinfo_rename_dst_parent_check:
 		// rename takes an implicit open on the destination parent directory
 		// with DELETE+FILE_ADD_FILE and ShareAccess=0. Any existing open of
@@ -863,7 +925,17 @@ func (h *Handler) setFileInfoFromStore(
 		// invalidates the holder's caching, and dispatching strip-H FIRST
 		// would emit two separate notifications where smbtorture rename
 		// otherdir-* (.expect_dstdir_break=true) expects exactly one RH→"".
+		//
+		// Fix B (race): the strip-H break-WAIT inside
+		// breakDstParentDirHandleLeasesForRename runs OUTSIDE renameScanMu
+		// (it can only complete when the dst-parent holder CLOSEs, and CLOSE
+		// needs the mutex). The authoritative post-break re-scan that decides
+		// SHARING_VIOLATION-vs-proceed is taken UNDER the mutex, so a holder
+		// that a concurrent CLOSE is mid-removing is observed atomically — no
+		// spurious SHARING_VIOLATION.
+		h.renameScanMu.Lock()
 		conflict := h.checkParentDirRenameConflict(openFile.FileID, toDir)
+		h.renameScanMu.Unlock()
 		if conflict && !bytes.Equal(toDir, openFile.ParentHandle) {
 			h.breakDstParentDirHandleLeasesForRename(authCtx, toDir, openFile)
 			// Re-check after the strip-H break drained (the holder's break
@@ -871,8 +943,11 @@ func (h *Handler) setFileInfoFromStore(
 			// re-check is clean the rename can proceed without surfacing
 			// SHARING_VIOLATION — required by dirlease.rename_dst_parent
 			// phase-2 (lease.c:7361 expects NT_STATUS_OK after the holder
-			// upgrades the lease and the second setinfo runs).
+			// upgrades the lease and the second setinfo runs). Authoritative
+			// under the mutex.
+			h.renameScanMu.Lock()
 			conflict = h.checkParentDirRenameConflict(openFile.FileID, toDir)
+			h.renameScanMu.Unlock()
 		}
 		if conflict {
 			logger.Debug("SET_INFO: rename blocked by destination-parent sharing violation",
@@ -994,45 +1069,18 @@ func (h *Handler) setFileInfoFromStore(
 		// FileID) blocks the overwrite. The H-lease break above stripped
 		// caching rights, but did NOT close the underlying handle — the
 		// holder must do that itself (smbtorture v2_rename_target_overwrite
-		// stages 1/2: ACK leaves dst open ⇒ ACCESS_DENIED).
-		if isOverwrite && len(dstMetaHandle) > 0 && h.hasOpenHandleOnFile(dstMetaHandle, openFile.FileID) {
-			logger.Debug("SET_INFO: rename overwrite blocked by open handle on destination",
-				"src", openFile.Path,
-				"dst", newPath)
-			return setInfoStatus(types.StatusAccessDenied), nil
-		}
-
-		// Directory rename: break H-leases on every open child file (RH→R
-		// strip-H) and wait for each break to drain. After the wait, ANY
-		// remaining open child blocks the parent rename per MS-FSA §2.1.5.14
-		// (smbtorture rename_dir_openfile: 8 sub-cases all hinge on whether
-		// every H-leased child closes-on-break or stays open after ACK).
-		// Children without an H-lease are no-op'd by ComputeLeaseBreakTo and
-		// stay open → fall through to the open-child recheck below, which
-		// produces the immediate ACCESS_DENIED for the "no-hleases" case.
-		if openFile.IsDirectory && h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {
-			children := h.snapshotOpenChildren(openFile.MetadataHandle)
-			for _, child := range children {
-				if err := h.LeaseManager.BreakHandleLeasesOnOpenAsync(
-					lock.FileHandle(child), openFile.ShareName, lock.BreakReasonSharingViolation,
-				); err != nil {
-					logger.Debug("SET_INFO: dir-rename child break dispatch failed",
-						"child", string(child), "error", err)
-				}
-			}
-			for _, child := range children {
-				waitCtx, cancelChild := context.WithTimeout(authCtx.Context, lease.AsyncCreateBreakWaitTimeout)
-				if err := h.LeaseManager.WaitForOtherKeyBreaks(
-					waitCtx, lock.FileHandle(child), openFile.ShareName, [16]byte{},
-				); err != nil {
-					logger.Debug("SET_INFO: dir-rename child break wait completed",
-						"child", string(child), "error", err)
-				}
-				cancelChild()
-			}
-			if h.anyOpenChild(openFile.MetadataHandle) {
-				logger.Debug("SET_INFO: dir rename blocked by open child",
-					"dir", openFile.Path)
+		// stages 1/2: ACK leaves dst open ⇒ ACCESS_DENIED). The break-WAIT
+		// above ran outside renameScanMu; the authoritative open-handle scan
+		// is taken under the mutex so a holder mid-CLOSE is observed
+		// atomically (Fix B — same race class as the dst-parent gate).
+		if isOverwrite && len(dstMetaHandle) > 0 {
+			h.renameScanMu.Lock()
+			dstStillOpen := h.hasOpenHandleOnFile(dstMetaHandle, openFile.FileID)
+			h.renameScanMu.Unlock()
+			if dstStillOpen {
+				logger.Debug("SET_INFO: rename overwrite blocked by open handle on destination",
+					"src", openFile.Path,
+					"dst", newPath)
 				return setInfoStatus(types.StatusAccessDenied), nil
 			}
 		}

--- a/test/smb-conformance/smbtorture/baseline-results.md
+++ b/test/smb-conformance/smbtorture/baseline-results.md
@@ -123,6 +123,7 @@ These 50 tests were previously masked by wildcard entries in KNOWN_FAILURES.md (
 | smb2.read.dir | read | Directory read works |
 | smb2.rename.close-full-information | rename | Rename + close full info works |
 | smb2.rename.msword | rename | MS Word rename pattern works |
+| smb2.rename.rename_dir_openfile | rename | Dir rename with open child returns ACCESS_DENIED |
 | smb2.rename.no_sharing | rename | Rename with no sharing works |
 | smb2.rename.rename-open | rename | Rename open file works |
 | smb2.rename.rename_dir_bench | rename | Directory rename benchmark works |
@@ -243,7 +244,6 @@ These tests fail despite the related feature being implemented in phases 33-39. 
 |-----------|-------|
 | smb2.rename.no_share_delete_but_delete_access | Permission edge case |
 | smb2.rename.no_share_delete_no_delete_access | Permission edge case |
-| smb2.rename.rename_dir_openfile | Rename dir with open file |
 | smb2.rename.share_delete_and_delete_access | Permission edge case |
 | smb2.rename.simple_modtime | Rename mtime update |
 | smb2.rename.simple_nodelete | Rename without delete access |
@@ -583,10 +583,9 @@ Complete list of all 372 failing tests for reference.
 - smb2.read.eof
 - smb2.read.position
 
-### smb2.rename (6 failures)
+### smb2.rename (5 failures)
 - smb2.rename.no_share_delete_but_delete_access
 - smb2.rename.no_share_delete_no_delete_access
-- smb2.rename.rename_dir_openfile
 - smb2.rename.share_delete_and_delete_access
 - smb2.rename.simple_modtime
 - smb2.rename.simple_nodelete


### PR DESCRIPTION
## Summary

Fixes the intermittent smbtorture SMB2 rename `SHARING_VIOLATION` flake (separate from #1245), plus a deterministic wrong-status on `rename_dir_openfile`.

### Root cause (confirmed)
The SET_INFO rename handler decides `SHARING_VIOLATION` / `ACCESS_DENIED` by scanning the lock-free `h.files` (`sync.Map`) — `checkShareDeleteConflict`, `checkParentDirRenameConflict`, `anyOpenChild`, `hasOpenHandleOnFile`. A concurrent CLOSE removes the conflicting `OpenFile` from `h.files` and then releases the lease / signals the rename's break-wait. The two were **not mutually exclusive**: the rename's post-break re-scan could observe a holder a CLOSE was mid-removing (break already signalled, `OpenFile` not yet deleted) → a spurious `STATUS_SHARING_VIOLATION`. This manifested as the intermittent `rename_dir_bench` / `close-full-information` / `dirlease.rename_dst_parent` flakes. Separately, `rename_dir_openfile` deterministically returned `SHARING_VIOLATION` where `ACCESS_DENIED` is expected, because the dst-parent share-mode gate fired before the directory open-child check.

### Fix B — the flake (race), primary
- New per-handler `renameScanMu` serializes the rename's authoritative conflict scan+decision against CLOSE's handle removal + lease release/signal.
- CLOSE (`close.go` steps 10/11): drains in-flight ops **outside** the mutex (`DrainHandleOps`), then takes `renameScanMu` across `deleteOpenFileEntry` + `releaseHandleLeaseRecord` + `SignalParkedCreates`.
- Rename (`set_info.go`): every lease **break-WAIT runs outside** the mutex; only the final authoritative re-scan + decision is taken under it. This is the deadlock-safe ordering — a break completes only when a holder CLOSEs, and CLOSE needs the same mutex, so holding it across a break-wait would deadlock.
- The post-break re-scan now reads `h.files` under the mutex: a genuinely still-open holder → correct `SHARING_VIOLATION`; a closed holder → OK; deterministically, no flake.

### Fix A — `rename_dir_openfile` (deterministic wrong status)
For a directory rename, the open-child determination now runs **before** the dst-parent share-mode gate and short-circuits to `STATUS_ACCESS_DENIED` (MS-FSA §2.1.5.14), taking precedence over the dst-parent `SHARING_VIOLATION`.

## Validation
- **Local smbtorture harness** (real smbtorture in docker, memory profile), `--filter smb2.rename`, run **10×** clean-slate (`down -v` between runs): **13/13 PASS every run**, including the previously-flaky `rename_dir_bench` + `close-full-information` and the previously-failing `rename_dir_openfile` (Fix A → now PASS).
- Regression checks: `smb2.lock` 22/0 green; `smb2.create` — the only 2 failures (`gentest`, `quota-fake-file`) are documented permanently-unimplementable known failures unrelated to this change (NTFS quota pseudo-files / generative impersonation fuzzer).
- `go build ./...`, `go vet`, `gofmt` clean.
- `go test ./internal/adapter/smb/... -race -count=1` green.
- New `-race` regression test (`rename_scan_close_race_test.go`) reproduces the scan/remove interleaving via a torn-window guard; it fails deterministically if either side drops `renameScanMu` and passes with the fix.
- `baseline-results.md` updated: `rename_dir_openfile` moved from known-fail to pass.