### PR TITLE
fix(kerberos): best-effort PAC decode so non-AD KDCs authenticate (#1259)

### DIFF
--- a/internal/auth/kerberos/pac_test.go
+++ b/internal/auth/kerberos/pac_test.go
@@ -1,0 +1,62 @@
+package kerberos
+
+import (
+	"testing"
+
+	"github.com/jcmturner/gofork/encoding/asn1"
+	"github.com/jcmturner/gokrb5/v8/iana/adtype"
+	"github.com/jcmturner/gokrb5/v8/keytab"
+	"github.com/jcmturner/gokrb5/v8/messages"
+	"github.com/jcmturner/gokrb5/v8/types"
+)
+
+// Regression coverage for #1259: PAC decoding must be best-effort and must NOT
+// fail Kerberos authentication for tickets without a (full) PAC. gokrb5's
+// VerifyAPREQ couples PAC decoding to AP-REQ verification — a ticket from a
+// plain MIT/Heimdal KDC carries a PAC with no KerbValidationInfo buffer, which
+// hard-failed authentication. Authenticate now verifies the AP-REQ with PAC
+// decoding disabled and decodes the PAC separately via decodePACBestEffort.
+
+// TestDecodePACBestEffort_NoPAC: a ticket with no authorization data (the
+// typical non-AD KDC case) must yield no AD credentials and no error, so the
+// caller proceeds with a plain authenticated identity.
+func TestDecodePACBestEffort_NoPAC(t *testing.T) {
+	apReq := &messages.APReq{} // empty ticket => no AuthorizationData
+
+	ad, err := decodePACBestEffort(apReq, &keytab.Keytab{})
+	if err != nil {
+		t.Fatalf("no-PAC ticket must not error, got: %v", err)
+	}
+	if ad != nil {
+		t.Fatalf("no-PAC ticket must yield nil AD credentials, got: %+v", ad)
+	}
+}
+
+// TestDecodePACBestEffort_MalformedPAC: a ticket that DOES carry a PAC the
+// library cannot decode must return an error (so the caller skips AD attrs)
+// rather than panicking. The key regression property is that the caller treats
+// this as "no AD attributes", never as an authentication failure.
+func TestDecodePACBestEffort_MalformedPAC(t *testing.T) {
+	// Inner AD-WIN2K-PAC entry carrying bytes that fail pac.PACType.Unmarshal
+	// (claims 16 buffers but provides none).
+	innerAD := types.AuthorizationData{
+		{ADType: adtype.ADWin2KPAC, ADData: []byte{0x10, 0, 0, 0, 0, 0, 0, 0}},
+	}
+	innerBytes, err := asn1.Marshal(innerAD)
+	if err != nil {
+		t.Fatalf("marshal inner AuthorizationData: %v", err)
+	}
+
+	apReq := &messages.APReq{}
+	apReq.Ticket.DecryptedEncPart.AuthorizationData = types.AuthorizationData{
+		{ADType: adtype.ADIfRelevant, ADData: innerBytes},
+	}
+
+	ad, err := decodePACBestEffort(apReq, &keytab.Keytab{})
+	if err == nil {
+		t.Fatal("malformed PAC must return an error so the caller skips AD attrs")
+	}
+	if ad != nil {
+		t.Fatalf("malformed PAC must yield nil AD credentials, got: %+v", ad)
+	}
+}

--- a/internal/auth/kerberos/pac_test.go
+++ b/internal/auth/kerberos/pac_test.go
@@ -33,9 +33,10 @@ func TestDecodePACBestEffort_NoPAC(t *testing.T) {
 }
 
 // TestDecodePACBestEffort_MalformedPAC: a ticket that DOES carry a PAC the
-// library cannot decode must return an error (so the caller skips AD attrs)
-// rather than panicking. The key regression property is that the caller treats
-// this as "no AD attributes", never as an authentication failure.
+// library cannot decode (here the PAC blob fails pac.PACType.Unmarshal) must
+// return an error so the caller skips AD attrs rather than panicking. The key
+// regression property is that the caller treats this as "no AD attributes",
+// never as an authentication failure.
 func TestDecodePACBestEffort_MalformedPAC(t *testing.T) {
 	// Inner AD-WIN2K-PAC entry carrying bytes that fail pac.PACType.Unmarshal
 	// (claims 16 buffers but provides none).

--- a/internal/auth/kerberos/service.go
+++ b/internal/auth/kerberos/service.go
@@ -245,6 +245,10 @@ func decodePACBestEffort(apReq *messages.APReq, kt *keytab.Keytab) (*credentials
 	if err != nil {
 		return nil, err
 	}
+	// Defensive: GetPACType -> ProcessPACInfoBuffers already returns an error
+	// when KerbValidationInfo is absent, so a nil here with err==nil should be
+	// impossible. Guard anyway rather than risk a nil deref (panic in an auth
+	// path) if that gokrb5 contract ever changes.
 	if p.KerbValidationInfo == nil {
 		return nil, fmt.Errorf("PAC carried no KerbValidationInfo")
 	}

--- a/internal/auth/kerberos/service.go
+++ b/internal/auth/kerberos/service.go
@@ -2,6 +2,8 @@ package kerberos
 
 import (
 	"fmt"
+	"io"
+	"log"
 
 	// gokrb5 uses gofork's asn1 package, not the Go stdlib, because stdlib's
 	// encoding/asn1 has known bugs with Kerberos types (GeneralizedTime
@@ -12,6 +14,7 @@ import (
 	"github.com/jcmturner/gokrb5/v8/asn1tools"
 	"github.com/jcmturner/gokrb5/v8/credentials"
 	"github.com/jcmturner/gokrb5/v8/crypto"
+	"github.com/jcmturner/gokrb5/v8/keytab"
 	"github.com/jcmturner/gokrb5/v8/messages"
 	"github.com/jcmturner/gokrb5/v8/service"
 	"github.com/jcmturner/gokrb5/v8/types"
@@ -128,27 +131,43 @@ func (s *KerberosService) Authenticate(apReqBytes []byte, servicePrincipal strin
 
 	// Build gokrb5 service settings from provider.
 	//
-	// DecodePAC is enabled so AD-issued tickets surface their PAC
-	// (MS-PAC) authorization data — specifically the transitive group SIDs the
-	// DC stamped into the ticket. gokrb5 verifies the PAC server signature with
-	// the same keytab key used for the ticket, so a tampered PAC fails
-	// VerifyAPREQ. Tickets without a PAC (e.g. from a plain MIT KDC) verify
-	// exactly as before — creds simply carry no AD attributes.
+	// PAC decoding is intentionally DISABLED inside VerifyAPREQ and performed
+	// separately, best-effort, below. gokrb5's VerifyAPREQ couples PAC decoding
+	// to AP-REQ verification: if a ticket carries a PAC it cannot fully decode
+	// (e.g. a plain MIT KDC stamps a PAC with no KerbValidationInfo buffer), it
+	// returns an error and the whole authentication fails. That would break
+	// Kerberos for every non-AD deployment. Decoupling keeps authentication
+	// working for any KDC while still surfacing AD group SIDs when a real
+	// AD-DC ticket carries them.
 	settings := service.NewSettings(
 		s.provider.Keytab(),
 		service.MaxClockSkew(s.provider.MaxClockSkew()),
-		service.DecodePAC(true),
+		service.DecodePAC(false),
 		service.KeytabPrincipal(servicePrincipal),
 	)
 
-	// Verify the AP-REQ. On success creds carries the decoded PAC attributes
-	// (when DecodePAC is on and the ticket contained a PAC).
+	// Verify the AP-REQ (ticket decryption, authenticator check, clock skew).
 	ok, creds, err := service.VerifyAPREQ(&apReq, settings)
 	if err != nil {
 		return nil, fmt.Errorf("verify AP-REQ: %w", err)
 	}
 	if !ok {
 		return nil, fmt.Errorf("AP-REQ verification failed")
+	}
+
+	// Best-effort PAC decode for AD authorization data (transitive group SIDs +
+	// user SID). The PAC server signature is verified with the same keytab key
+	// (GetPACType), so a tampered PAC is rejected. On ANY PAC problem — absent,
+	// partial (MIT KDC), or signature failure — we proceed WITHOUT AD
+	// attributes rather than failing authentication. This is fail-closed for
+	// authorization: a missing/invalid PAC yields no group SIDs (less access),
+	// never elevated access.
+	if ad, perr := decodePACBestEffort(&apReq, s.provider.Keytab()); perr != nil {
+		logger.Debug("PAC decode skipped; proceeding without AD authorization data",
+			"error", perr,
+		)
+	} else if ad != nil {
+		creds.SetADCredentials(*ad)
 	}
 
 	// Extract session key from the decrypted ticket
@@ -202,10 +221,53 @@ func (s *KerberosService) Authenticate(apReqBytes []byte, servicePrincipal strin
 	}, nil
 }
 
+// decodePACBestEffort decodes the MS-PAC carried in a verified AP-REQ ticket
+// and returns the AD authorization attributes, WITHOUT letting a PAC problem
+// fail authentication. It mirrors the credential population gokrb5's
+// VerifyAPREQ does internally, but as a separate, fallible step:
+//
+//   - no PAC in the ticket (typical non-AD KDC)  -> (nil, nil)
+//   - PAC present but undecodable / signature bad -> (nil, err)  [caller skips]
+//   - PAC present and valid                       -> (*ADCredentials, nil)
+//
+// GetPACType verifies the PAC server signature with the keytab key for the
+// ticket's own service principal (sname=nil selects it), so a forged PAC is
+// rejected here and the caller proceeds without AD attributes — fail-closed.
+func decodePACBestEffort(apReq *messages.APReq, kt *keytab.Keytab) (*credentials.ADCredentials, error) {
+	// sname=nil -> GetPACType uses the ticket's own SName to pick the keytab key
+	// (correct for a combined cifs/+nfs/ keytab). The logger is required by the
+	// gokrb5 signature; route it to io.Discard since we surface outcomes via our
+	// own structured logger at the call site.
+	isPAC, p, err := apReq.Ticket.GetPACType(kt, nil, log.New(io.Discard, "", 0))
+	if !isPAC {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if p.KerbValidationInfo == nil {
+		return nil, fmt.Errorf("PAC carried no KerbValidationInfo")
+	}
+	ki := p.KerbValidationInfo
+	return &credentials.ADCredentials{
+		GroupMembershipSIDs: ki.GetGroupMembershipSIDs(),
+		LogOnTime:           ki.LogOnTime.Time(),
+		LogOffTime:          ki.LogOffTime.Time(),
+		PasswordLastSet:     ki.PasswordLastSet.Time(),
+		EffectiveName:       ki.EffectiveName.Value,
+		FullName:            ki.FullName.Value,
+		UserID:              int(ki.UserID),
+		PrimaryGroupID:      int(ki.PrimaryGroupID),
+		LogonServer:         ki.LogonServer.Value,
+		LogonDomainName:     ki.LogonDomainName.Value,
+		LogonDomainID:       ki.LogonDomainID.String(),
+	}, nil
+}
+
 // extractPACIdentity pulls the Windows user SID and group SIDs out of the
 // decoded Kerberos PAC. gokrb5 exposes the decoded KERB_VALIDATION_INFO via
-// credentials.ADCredentials (populated by VerifyAPREQ when DecodePAC is on and
-// the ticket contained a PAC). It returns empty values when creds is nil or
+// credentials.ADCredentials (populated by decodePACBestEffort when the ticket
+// carried a valid PAC). It returns empty values when creds is nil or
 // the ticket carried no AD attributes — i.e. a non-AD KDC — so the rest of the
 // pipeline behaves exactly as it did before PAC decoding was enabled.
 //


### PR DESCRIPTION
Closes #1259. Part of #1231 Wave 3 (found while investigating #1250).

## Problem

AD-1 (#1233) enabled `service.DecodePAC(true)` in `internal/auth/kerberos/service.go` — the shared Kerberos accept path for **both SMB and NFS** (`sec=krb5`). gokrb5's `VerifyAPREQ` couples PAC decoding to AP-REQ verification:

```go
isPAC, pac, err := APReq.Ticket.GetPACType(...)
if isPAC && err != nil {
    return false, creds, err   // hard auth failure
}
```

A plain **MIT/Heimdal KDC** stamps a PAC that has no `KerbValidationInfo` (LOGON_INFO) buffer, so `ProcessPACInfoBuffers` returns `PAC Info Buffers does not contain a KerbValidationInfo` → the entire authentication fails (`verify AP-REQ: ...`). Every **non-AD** Kerberos deployment broke: SMB session setup and NFS `sec=krb5` both return `LOGON_FAILURE`. The smb-conformance Kerberos suite (`smb2.session`) went from passing to **0/71**.

The previous in-code comment ("Tickets without a PAC … verify exactly as before") was wrong: the MIT ticket *does* carry a PAC (`isPAC=true`), just an incomplete one — exactly the hard-fail case.

## Fix

Decouple PAC decoding from authentication:

1. Call `VerifyAPREQ` with `DecodePAC(false)` (ticket decryption / authenticator / clock-skew only).
2. Decode the PAC **best-effort** via `Ticket.GetPACType`, which still verifies the PAC server signature with the keytab key.
3. On **any** PAC problem — absent, partial (MIT), or forged — proceed *without* AD attributes instead of failing auth.

This is **fail-closed for authorization**: a missing/invalid PAC yields no group SIDs (less access), never elevated access. AD-issued tickets with a full PAC still surface their transitive group SIDs unchanged.

## Validation

- New unit tests (`pac_test.go`): no-PAC ticket → no error / no AD creds; malformed PAC → error (caller skips), no panic.
- smb-conformance `smb2.session` Kerberos: **0 → 68 passing** (`krbOK=145`, best-effort PAC skip firing for MIT tickets); the AD PAC group-SID path is unaffected.
- `go test ./internal/auth/kerberos/... ./internal/adapter/smb/...` green; `go vet` clean.

## Backward compatibility

Additive/robustness-only. AD deployments keep full PAC group SIDs; non-AD deployments (the previously-broken case) work again. Addresses the "ship without breaking existing installations" gate.