### PR TITLE
test(ad-dc): make Samba AD-DC fixture portable to fresh Debian Bookworm (#1252)

### DIFF
--- a/test/integration/ad-dc/Dockerfile
+++ b/test/integration/ad-dc/Dockerfile
@@ -19,11 +19,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 # samba-ad-dc pulls in the AD-DC role (provisioning + KDC + LDAP). winbind and
 # krb5-user give us kadmin-style tooling and samba-tool dependencies. ldb-tools
 # (ldbadd/ldbmodify) lets entrypoint.sh stamp RFC2307 attributes directly.
+# samba-ad-provision ships the AD schema LDIFs (AD_DS_*.ldf) that
+# `samba-tool domain provision` needs; current debian:bookworm-slim split these
+# out of samba-ad-dc, so provisioning fails without it (issue #1252).
 RUN set -eu; \
     for i in 1 2 3; do \
         apt-get update \
           && apt-get install -y --no-install-recommends \
-               samba samba-ad-dc samba-common-bin winbind \
+               samba samba-ad-dc samba-ad-provision samba-common-bin winbind \
                krb5-user ldb-tools ldap-utils procps \
           && rm -rf /var/lib/apt/lists/* \
           && exit 0; \

--- a/test/integration/ad-dc/ad_dc_integration_test.go
+++ b/test/integration/ad-dc/ad_dc_integration_test.go
@@ -162,8 +162,14 @@ func setupADDC(t *testing.T) (kdcHostPort int, keytabPath, krb5ConfPath string, 
 	// Run the container with the AD-DC entrypoint (it provisions the domain,
 	// creates users/groups, and exports the keytab to /keytabs on its own).
 	t.Log("Starting AD-DC container...")
+	// --privileged is required for `samba-tool domain provision`: setting the NT
+	// ACL on the sysvol share (smbd.set_nt_acl) is denied on an overlayfs-backed
+	// container filesystem (e.g. Docker Desktop on macOS), aborting provisioning.
+	// CI's overlay2-on-ext4 happens to allow it unprivileged, but requiring it
+	// keeps the fixture portable across developer machines (issue #1252).
 	runOut, err := exec.Command("docker", "run", "-d",
 		"--platform", "linux/amd64",
+		"--privileged",
 		"--name", adContainerName,
 		"-p", "0:88/tcp",
 		adImageName,
@@ -334,9 +340,23 @@ func getADAPREQ(t *testing.T, krb5ConfPath string) []byte {
 	}
 
 	// kinit equivalent. DisablePAFXFAST avoids an unnecessary preauth round.
+	// Retry on transient KDC errors: the entrypoint exports the keytab (which
+	// setupADDC waits for) and only THEN stops the provisioning samba and
+	// re-execs it in the foreground, so the KDC has a brief down window right
+	// when the test first reaches kinit ("connection reset by peer"). A short
+	// retry loop rides that restart gap out.
 	cl := client.NewWithPassword(adUserAlice, adRealm, adUserPass, cfg, client.DisablePAFXFAST(true))
-	if err := cl.Login(); err != nil {
-		t.Fatalf("kinit as alice failed: %v", err)
+	var loginErr error
+	for attempt := 1; attempt <= 15; attempt++ {
+		if loginErr = cl.Login(); loginErr == nil {
+			break
+		}
+		t.Logf("kinit attempt %d/15 not ready yet: %v", attempt, loginErr)
+		time.Sleep(2 * time.Second)
+	}
+	if loginErr != nil {
+		dumpADLogs(t)
+		t.Fatalf("kinit as alice failed after retries: %v", loginErr)
 	}
 	defer cl.Destroy()
 	t.Log("alice obtained a TGT from the AD-DC")

--- a/test/integration/ad-dc/ad_dc_ldap_test.go
+++ b/test/integration/ad-dc/ad_dc_ldap_test.go
@@ -82,10 +82,21 @@ func TestLDAPResolveDomainUser(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	res, err := provider.Resolve(ctx, &identity.Credential{ExternalID: "alice@" + adRealm})
+	// Retry on transient connect errors: the entrypoint re-execs samba into the
+	// foreground shortly after provisioning, so LDAP (389) has a brief down
+	// window right when the test first connects ("connection reset by peer").
+	var res *identity.ResolvedIdentity
+	for attempt := 1; attempt <= 15; attempt++ {
+		res, err = provider.Resolve(ctx, &identity.Credential{ExternalID: "alice@" + adRealm})
+		if err == nil {
+			break
+		}
+		t.Logf("Resolve(alice) attempt %d/15 not ready yet: %v", attempt, err)
+		time.Sleep(2 * time.Second)
+	}
 	if err != nil {
 		dumpADLogs(t)
-		t.Fatalf("Resolve(alice): %v", err)
+		t.Fatalf("Resolve(alice) failed after retries: %v", err)
 	}
 	t.Logf("Resolved alice: %+v", res)
 
@@ -156,8 +167,12 @@ func setupADDCForLDAP(t *testing.T) (ldapPort int, cleanup func()) {
 	}
 
 	t.Log("Starting AD-DC container (LDAP)...")
+	// --privileged: domain provision sets the sysvol NT ACL (smbd.set_nt_acl),
+	// which is denied on an overlayfs-backed container FS (e.g. Docker Desktop on
+	// macOS). Keeps the fixture portable across developer machines (issue #1252).
 	runOut, err := exec.Command("docker", "run", "-d",
 		"--platform", "linux/amd64",
+		"--privileged",
 		"--name", adContainerName,
 		"-p", "0:389/tcp",
 		adImageName,

--- a/test/integration/ad-dc/ad_dc_ldap_test.go
+++ b/test/integration/ad-dc/ad_dc_ldap_test.go
@@ -79,7 +79,11 @@ func TestLDAPResolveDomainUser(t *testing.T) {
 		t.Fatalf("ldap.New: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	// The deadline must exceed the whole retry window below (up to 15 attempts ×
+	// (15s per-attempt LDAP timeout + 2s backoff)), otherwise the context would
+	// expire mid-loop and the remaining attempts would fail with a misleading
+	// "context deadline exceeded" instead of the real connectivity error.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	// Retry on transient connect errors: the entrypoint re-execs samba into the
@@ -87,6 +91,9 @@ func TestLDAPResolveDomainUser(t *testing.T) {
 	// window right when the test first connects ("connection reset by peer").
 	var res *identity.ResolvedIdentity
 	for attempt := 1; attempt <= 15; attempt++ {
+		if ctx.Err() != nil {
+			break
+		}
 		res, err = provider.Resolve(ctx, &identity.Credential{ExternalID: "alice@" + adRealm})
 		if err == nil {
 			break

--- a/test/integration/ad-dc/entrypoint.sh
+++ b/test/integration/ad-dc/entrypoint.sh
@@ -64,14 +64,20 @@ if [ ! -f /var/lib/samba/.provisioned ]; then
     # Provision the domain controller. SAMBA_INTERNAL DNS keeps the fixture
     # self-contained (no bind9 dependency). --use-rfc2307 enables the RFC2307
     # POSIX attribute schema so we can stamp uidNumber/gidNumber on some objects.
+    #
+    # The DC functional level is intentionally left at samba's default: the
+    # "ad dc functional level" smb.conf parameter (and a fixed 2016 level) is not
+    # accepted across all samba versions in debian:bookworm-slim, and the fixture
+    # needs none of it — PAC group SIDs, RFC2307 attrs, and Kerberos all work at
+    # the default level. Pinning it broke provisioning on a freshly rebuilt image
+    # (issue #1252).
     samba-tool domain provision \
         --use-rfc2307 \
         --realm="$REALM" \
         --domain="$DOMAIN" \
         --server-role=dc \
         --dns-backend=SAMBA_INTERNAL \
-        --adminpass="$ADMIN_PASSWORD" \
-        --option="ad dc functional level = 2016"
+        --adminpass="$ADMIN_PASSWORD"
 
     # Samba writes its own krb5.conf during provision; expose it to other
     # containers / the Go test on the shared volume.


### PR DESCRIPTION
Closes #1252. Part of #1231 Wave 3.

A fresh build of the Samba AD-DC test fixture on `debian:bookworm-slim` no longer provisions — three independent breakages, each aborting `samba-tool domain provision`:

1. **Functional-level option rejected.** `--option="ad dc functional level = 2016"` is no longer an accepted smb.conf parameter on the provision command line (`Unknown parameter encountered`). Dropped the pin — the default functional level is fine for PAC group SIDs, RFC2307 attrs, and Kerberos.
2. **AD schema package split out.** The AD schema LDIFs (`AD_DS_*.ldf`) moved from `samba-ad-dc` into `samba-ad-provision` (`File [...] not found. Please install samba-ad-provision package`). Added it to the image.
3. **sysvol NT-ACL denied on overlayfs.** `smbd.set_nt_acl` on the sysvol share fails on an overlayfs-backed container FS (Docker Desktop on macOS). Run the fixture container `--privileged` so provisioning works across developer machines. (CI's overlay2-on-ext4 happened to allow it unprivileged, masking this.)

Also made the tests resilient to a pre-existing timing race: the entrypoint re-execs samba into the foreground shortly after exporting the keytab, so the KDC (88) and LDAP (389) have a brief down window right when the tests first connect (`connection reset by peer`). Added short retry loops around `kinit` and the LDAP `Resolve`.

## Validation

Full suite green on a fresh image build (macOS / Docker Desktop, linux/amd64):
```
ok  github.com/marmos91/dittofs/test/integration/ad-dc  44.9s
```
covering `TestADGroupSIDsFromPAC` (AD-1), `TestADCombinedKeytabAndDomainAwareSMB` (AD-4), and the LDAP resolve test (AD-2).

Test-only / fixture-only change; no production code touched.