### PR TITLE
feat(dfsctl): add --gid/--host-gid to user create and edit (#1249)

### DIFF
--- a/cmd/dfsctl/commands/user/create.go
+++ b/cmd/dfsctl/commands/user/create.go
@@ -17,6 +17,8 @@ var (
 	createRole     string
 	createUID      uint32
 	createHostUID  bool
+	createGID      uint32
+	createHostGID  bool
 	createGroups   string
 	createEnabled  bool
 )
@@ -42,11 +44,11 @@ Examples:
   # Create user with email and groups
   dfsctl user create --username bob --password secret --email bob@example.com --groups editors,viewers
 
-  # Create user with specific UID
-  dfsctl user create --username bob --password secret --uid 1001
+  # Create user with specific UID and primary GID
+  dfsctl user create --username bob --password secret --uid 1001 --gid 1001
 
-  # Create user with your current host UID (for NFS access)
-  dfsctl user create --username bob --password secret --host-uid`,
+  # Create user with your current host UID and GID (for NFS access)
+  dfsctl user create --username bob --password secret --host-uid --host-gid`,
 	RunE: runCreate,
 }
 
@@ -57,9 +59,12 @@ func init() {
 	createCmd.Flags().StringVar(&createRole, "role", "user", "Role (user|admin)")
 	createCmd.Flags().Uint32Var(&createUID, "uid", 0, "Unix user ID (auto-assigned if not specified)")
 	createCmd.Flags().BoolVar(&createHostUID, "host-uid", false, "Use current host user's UID (for NFS access)")
+	createCmd.Flags().Uint32Var(&createGID, "gid", 0, "Unix primary group ID (auto-assigned if not specified)")
+	createCmd.Flags().BoolVar(&createHostGID, "host-gid", false, "Use current host user's GID (for NFS access)")
 	createCmd.Flags().StringVar(&createGroups, "groups", "", "Comma-separated list of groups")
 	// MarkFlagsMutuallyExclusive panics if flag names don't exist (see Cobra source)
 	createCmd.MarkFlagsMutuallyExclusive("uid", "host-uid")
+	createCmd.MarkFlagsMutuallyExclusive("gid", "host-gid")
 	createCmd.Flags().BoolVar(&createEnabled, "enabled", true, "Enable account")
 }
 
@@ -140,12 +145,37 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// GID - use host-gid, explicit gid, or prompt if interactive (mirrors UID).
+	var gid *uint32
+	if createHostGID {
+		hostGID := os.Getgid()
+		if hostGID < 0 {
+			return fmt.Errorf("--host-gid is not supported on this platform")
+		}
+		hostGIDUint32 := uint32(hostGID)
+		gid = &hostGIDUint32
+	} else if cmd.Flags().Changed("gid") {
+		gid = &createGID
+	} else if interactive {
+		gidInput, err := prompt.InputOptional("GID (leave empty for auto-assign, or use --host-gid)")
+		if err != nil {
+			return cmdutil.HandleAbort(err)
+		}
+		if gidInput != "" {
+			var gidVal uint32
+			if _, err := fmt.Sscanf(gidInput, "%d", &gidVal); err == nil {
+				gid = &gidVal
+			}
+		}
+	}
+
 	req := &apiclient.CreateUserRequest{
 		Username: username,
 		Password: password,
 		Email:    email,
 		Role:     role,
 		UID:      uid,
+		GID:      gid,
 		Groups:   cmdutil.ParseCommaSeparatedList(groups),
 		Enabled:  &createEnabled,
 	}

--- a/cmd/dfsctl/commands/user/edit.go
+++ b/cmd/dfsctl/commands/user/edit.go
@@ -16,6 +16,7 @@ var (
 	editDisplayName string
 	editRole        string
 	editUID         uint32
+	editGID         uint32
 	editGroups      string
 	editEnabled     string // "true", "false", or "" for unchanged
 )
@@ -44,8 +45,8 @@ Examples:
   # Update multiple fields
   dfsctl user edit alice --email alice@example.com --groups editors,admins
 
-  # Update UID
-  dfsctl user edit alice --uid 1001`,
+  # Update UID and primary GID
+  dfsctl user edit alice --uid 1001 --gid 1001`,
 	Args: cobra.ExactArgs(1),
 	RunE: runEdit,
 }
@@ -55,6 +56,7 @@ func init() {
 	editCmd.Flags().StringVar(&editDisplayName, "display-name", "", "Display name")
 	editCmd.Flags().StringVar(&editRole, "role", "", "Role (user|admin)")
 	editCmd.Flags().Uint32Var(&editUID, "uid", 0, "Unix user ID")
+	editCmd.Flags().Uint32Var(&editGID, "gid", 0, "Unix primary group ID")
 	editCmd.Flags().StringVar(&editGroups, "groups", "", "Comma-separated list of groups")
 	editCmd.Flags().StringVar(&editEnabled, "enabled", "", "Enable/disable account (true|false)")
 }
@@ -70,6 +72,7 @@ func runEdit(cmd *cobra.Command, args []string) error {
 	// Check if any flags were provided
 	hasFlags := cmd.Flags().Changed("email") || cmd.Flags().Changed("display-name") ||
 		cmd.Flags().Changed("role") || cmd.Flags().Changed("uid") ||
+		cmd.Flags().Changed("gid") ||
 		cmd.Flags().Changed("groups") || cmd.Flags().Changed("enabled")
 
 	// If no flags provided, run interactive mode
@@ -100,6 +103,11 @@ func runEdit(cmd *cobra.Command, args []string) error {
 		hasUpdate = true
 	}
 
+	if cmd.Flags().Changed("gid") {
+		req.GID = &editGID
+		hasUpdate = true
+	}
+
 	if editGroups != "" {
 		groups := cmdutil.ParseCommaSeparatedList(editGroups)
 		req.Groups = &groups
@@ -113,7 +121,7 @@ func runEdit(cmd *cobra.Command, args []string) error {
 	}
 
 	if !hasUpdate {
-		return fmt.Errorf("no fields specified. Use --email, --role, --uid, --groups, or --enabled")
+		return fmt.Errorf("no fields specified. Use --email, --role, --uid, --gid, --groups, or --enabled")
 	}
 
 	user, err := client.UpdateUser(username, req)
@@ -177,6 +185,23 @@ func runEditInteractive(client *apiclient.Client, username string) error {
 		var newUID uint32
 		if _, err := fmt.Sscanf(newUIDStr, "%d", &newUID); err == nil {
 			req.UID = &newUID
+			hasUpdate = true
+		}
+	}
+
+	// GID
+	currentGIDStr := ""
+	if current.GID != nil {
+		currentGIDStr = fmt.Sprintf("%d", *current.GID)
+	}
+	newGIDStr, err := prompt.Input("GID (leave empty to keep current)", currentGIDStr)
+	if err != nil {
+		return cmdutil.HandleAbort(err)
+	}
+	if newGIDStr != currentGIDStr && newGIDStr != "" {
+		var newGID uint32
+		if _, err := fmt.Sscanf(newGIDStr, "%d", &newGID); err == nil {
+			req.GID = &newGID
 			hasUpdate = true
 		}
 	}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -5740,11 +5740,11 @@ Examples:
   # Create user with email and groups
   dfsctl user create --username bob --password secret --email bob@example.com --groups editors,viewers
 
-  # Create user with specific UID
-  dfsctl user create --username bob --password secret --uid 1001
+  # Create user with specific UID and primary GID
+  dfsctl user create --username bob --password secret --uid 1001 --gid 1001
 
-  # Create user with your current host UID (for NFS access)
-  dfsctl user create --username bob --password secret --host-uid
+  # Create user with your current host UID and GID (for NFS access)
+  dfsctl user create --username bob --password secret --host-uid --host-gid
 
 ```
 dfsctl user create [flags]
@@ -5755,7 +5755,9 @@ Flags:
 ```
       --email string      Email address
       --enabled           Enable account (default true)
+      --gid uint32        Unix primary group ID (auto-assigned if not specified)
       --groups string     Comma-separated list of groups
+      --host-gid          Use current host user's GID (for NFS access)
       --host-uid          Use current host user's UID (for NFS access)
   -p, --password string   Password (prompts if not provided)
       --role string       Role (user|admin) (default "user")
@@ -5842,8 +5844,8 @@ Examples:
   # Update multiple fields
   dfsctl user edit alice --email alice@example.com --groups editors,admins
 
-  # Update UID
-  dfsctl user edit alice --uid 1001
+  # Update UID and primary GID
+  dfsctl user edit alice --uid 1001 --gid 1001
 
 ```
 dfsctl user edit <username> [flags]
@@ -5855,6 +5857,7 @@ Flags:
       --display-name string   Display name
       --email string          Email address
       --enabled string        Enable/disable account (true|false)
+      --gid uint32            Unix primary group ID
       --groups string         Comma-separated list of groups
       --role string           Role (user|admin)
       --uid uint32            Unix user ID

--- a/internal/controlplane/api/handlers/auth.go
+++ b/internal/controlplane/api/handlers/auth.go
@@ -50,6 +50,7 @@ type UserResponse struct {
 	Email              string     `json:"email,omitempty"`
 	Role               string     `json:"role"`
 	UID                *uint32    `json:"uid,omitempty"`
+	GID                *uint32    `json:"gid,omitempty"`
 	Groups             []string   `json:"groups,omitempty"`
 	Enabled            bool       `json:"enabled"`
 	MustChangePassword bool       `json:"must_change_password"`
@@ -211,6 +212,7 @@ func userToResponse(user *models.User) UserResponse {
 		Email:              user.Email,
 		Role:               string(user.Role),
 		UID:                user.UID,
+		GID:                user.GID,
 		Groups:             user.GetGroupNames(),
 		Enabled:            user.Enabled,
 		MustChangePassword: user.MustChangePassword,

--- a/internal/controlplane/api/handlers/users.go
+++ b/internal/controlplane/api/handlers/users.go
@@ -46,6 +46,7 @@ type CreateUserRequest struct {
 	DisplayName string                            `json:"display_name,omitempty"`
 	Role        string                            `json:"role,omitempty"`
 	UID         *uint32                           `json:"uid,omitempty"`
+	GID         *uint32                           `json:"gid,omitempty"`
 	Groups      []string                          `json:"groups,omitempty"`
 	Enabled     *bool                             `json:"enabled,omitempty"`
 	SharePerms  map[string]models.SharePermission `json:"share_permissions,omitempty"`
@@ -57,6 +58,7 @@ type UpdateUserRequest struct {
 	DisplayName *string                            `json:"display_name,omitempty"`
 	Role        *string                            `json:"role,omitempty"`
 	UID         *uint32                            `json:"uid,omitempty"`
+	GID         *uint32                            `json:"gid,omitempty"`
 	Groups      *[]string                          `json:"groups,omitempty"`
 	Enabled     *bool                              `json:"enabled,omitempty"`
 	SharePerms  *map[string]models.SharePermission `json:"share_permissions,omitempty"`
@@ -115,6 +117,7 @@ func (h *UserHandler) Create(w http.ResponseWriter, r *http.Request) {
 		MustChangePassword: role == models.RoleAdmin,
 		Role:               string(role),
 		UID:                req.UID,
+		GID:                req.GID,
 		DisplayName:        req.DisplayName,
 		Email:              req.Email,
 	}
@@ -238,6 +241,9 @@ func (h *UserHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.UID != nil {
 		user.UID = req.UID
+	}
+	if req.GID != nil {
+		user.GID = req.GID
 	}
 
 	if err := h.store.UpdateUser(r.Context(), user); err != nil {

--- a/internal/controlplane/api/handlers/users_test.go
+++ b/internal/controlplane/api/handlers/users_test.go
@@ -189,6 +189,47 @@ func TestUserHandler_Create_WithGroups(t *testing.T) {
 	})
 }
 
+// TestUserHandler_Create_WithGID covers #1249: an explicit primary GID set at
+// create time round-trips through the response and is persisted on the user.
+func TestUserHandler_Create_WithGID(t *testing.T) {
+	cpStore, _, handler := setupUserTest(t)
+	ctx := context.Background()
+
+	uid := uint32(1500)
+	gid := uint32(1600)
+	body, _ := json.Marshal(CreateUserRequest{
+		Username: "giduser",
+		Password: "password123",
+		UID:      &uid,
+		GID:      &gid,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.Create(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Create() status = %d, want %d, body = %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+
+	var resp UserResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+	if resp.GID == nil || *resp.GID != gid {
+		t.Errorf("response GID = %v, want %d", resp.GID, gid)
+	}
+
+	stored, err := cpStore.GetUser(ctx, "giduser")
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+	if stored.GID == nil || *stored.GID != gid {
+		t.Errorf("persisted GID = %v, want %d", stored.GID, gid)
+	}
+}
+
 func TestUserHandler_Create_Duplicate(t *testing.T) {
 	cpStore, _, handler := setupUserTest(t)
 	ctx := context.Background()

--- a/pkg/apiclient/users.go
+++ b/pkg/apiclient/users.go
@@ -13,6 +13,7 @@ type User struct {
 	Email              string            `json:"email,omitempty"`
 	Role               string            `json:"role"`
 	UID                *uint32           `json:"uid,omitempty"`
+	GID                *uint32           `json:"gid,omitempty"`
 	Groups             []string          `json:"groups,omitempty"`
 	Enabled            bool              `json:"enabled"`
 	MustChangePassword bool              `json:"must_change_password"`
@@ -29,6 +30,7 @@ type CreateUserRequest struct {
 	DisplayName      string            `json:"display_name,omitempty"`
 	Role             string            `json:"role,omitempty"`
 	UID              *uint32           `json:"uid,omitempty"`
+	GID              *uint32           `json:"gid,omitempty"`
 	Groups           []string          `json:"groups,omitempty"`
 	Enabled          *bool             `json:"enabled,omitempty"`
 	SharePermissions map[string]string `json:"share_permissions,omitempty"`
@@ -40,6 +42,7 @@ type UpdateUserRequest struct {
 	DisplayName      *string            `json:"display_name,omitempty"`
 	Role             *string            `json:"role,omitempty"`
 	UID              *uint32            `json:"uid,omitempty"`
+	GID              *uint32            `json:"gid,omitempty"`
 	Groups           *[]string          `json:"groups,omitempty"`
 	Enabled          *bool              `json:"enabled,omitempty"`
 	SharePermissions *map[string]string `json:"share_permissions,omitempty"`


### PR DESCRIPTION
Closes #1249. Part of #1231 Wave 3 (UX gap found during AD-4b acceptance).

A user's primary GID (`User.GID`) had no API/CLI surface — it could only be set by editing the control-plane database directly. The dfs SMB CREATE path logs `User has no group with GID configured, using default` for users created without one.

## Change

End-to-end wiring, mirroring the existing UID handling:

- **`dfsctl user create`**: `--gid` and `--host-gid` (mutually exclusive, like `--uid`/`--host-uid`) + interactive prompt.
- **`dfsctl user edit`**: `--gid` + interactive prompt.
- **apiclient**: `GID *uint32` on `CreateUserRequest`, `UpdateUserRequest`, and `User`.
- **REST handler**: `GID` on the request structs, set on the user model in Create/Update, and surfaced in `UserResponse`.
- Regenerated `docs/CLI.md`.

The control-plane GORM store already persists `User.GID` (it is in `UpdateUser`'s `Select` list and in `Create`), so no store change was needed.

## Tests

`TestUserHandler_Create_WithGID` (integration tag): an explicit GID round-trips through the create response and is persisted on the user. Existing user-handler + dfsctl command tests stay green; `go vet` clean; docs regenerated.

Additive only — no behavior change for users created without a GID.