### PR TITLE
feat(controlplane): honor admin.password_hash for first-run bootstrap (#1251)

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -116,10 +116,13 @@ func runStart(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize control plane store: %w", err)
 	}
 
-	// Ensure admin user exists (generates random password on first run).
-	// Whether the first-login password change is forced is operator-configurable
-	// (controlplane.require_initial_password_change, default true).
-	adminPassword, err := cpStore.EnsureAdminUser(ctx, cfg.ControlPlane.RequiresInitialPasswordChange())
+	// Ensure admin user exists. On first run the password is taken from
+	// admin.password_hash (config), DITTOFS_ADMIN_INITIAL_PASSWORD (env,
+	// plaintext, also enables SMB admin), or a generated random password — in
+	// that precedence. Whether the first-login password change is forced is
+	// operator-configurable (controlplane.require_initial_password_change,
+	// default true) and is skipped when the operator supplied the password.
+	adminPassword, err := cpStore.EnsureAdminUser(ctx, cfg.ControlPlane.RequiresInitialPasswordChange(), cfg.Admin.PasswordHash)
 	if err != nil {
 		return fmt.Errorf("failed to ensure admin user: %w", err)
 	}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1780,6 +1780,23 @@ export DITTOFS_ADMIN_INITIAL_PASSWORD=my-secure-password
 
 > **Note**: `DITTOFS_ADMIN_INITIAL_PASSWORD` is only used during the very first server start when the admin user is created. It has no effect on subsequent starts. When set, the admin account's `MustChangePassword` flag is not enabled.
 
+#### Bootstrap admin password
+
+On the **first** start (when no `admin` user exists yet) the initial admin password is chosen in this precedence:
+
+1. **`DITTOFS_ADMIN_INITIAL_PASSWORD`** (env, plaintext) — sets a known password and also derives the NT hash, so the admin can authenticate over **SMB** as well as the REST/control-plane API.
+2. **`admin.password_hash`** (config, bcrypt `$2a$`/`$2b$`/`$2y$`) — sets a known credential without writing a plaintext secret to disk. No NT hash is derivable from a bcrypt hash, so an admin bootstrapped this way works for the **control-plane/REST API only, not SMB** (use option 1 for SMB). A value that is not a valid bcrypt hash is rejected at startup.
+3. **Auto-generated** — a random password is generated and printed once to the terminal (and, in daemon mode, a warning notes it is not logged; reset it with `dfsctl user passwd admin`).
+
+Options 1 and 2 also skip the forced first-login password change (the operator already chose the password). All three apply only on first start; later starts never change an existing admin's password.
+
+```yaml
+admin:
+  username: admin
+  # bcrypt hash, e.g. from `htpasswd -bnBC 10 "" 'my-secure-password' | tr -d ':\n'`
+  password_hash: "$2b$10$..."
+```
+
 **Examples**:
 
 ```bash

--- a/pkg/controlplane/controlplane.go
+++ b/pkg/controlplane/controlplane.go
@@ -129,8 +129,8 @@ func (cp *ControlPlane) APIServer() *api.Server {
 //
 // requireInitialPasswordChange controls whether a freshly created admin is
 // forced to change its password on first login (see APIConfig.RequiresInitialPasswordChange).
-func (cp *ControlPlane) EnsureAdminUser(ctx context.Context, requireInitialPasswordChange bool) (string, error) {
-	return cp.store.EnsureAdminUser(ctx, requireInitialPasswordChange)
+func (cp *ControlPlane) EnsureAdminUser(ctx context.Context, requireInitialPasswordChange bool, configuredPasswordHash string) (string, error) {
+	return cp.store.EnsureAdminUser(ctx, requireInitialPasswordChange, configuredPasswordHash)
 }
 
 // IdentityStore returns the store as an IdentityStore interface.

--- a/pkg/controlplane/controlplane_test.go
+++ b/pkg/controlplane/controlplane_test.go
@@ -122,7 +122,7 @@ func TestEnsureAdminUser(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	pw, err := cp.EnsureAdminUser(ctx, true)
+	pw, err := cp.EnsureAdminUser(ctx, true, "")
 	if err != nil {
 		t.Fatalf("EnsureAdminUser: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestEnsureAdminUser(t *testing.T) {
 		t.Error("expected a generated password on first creation")
 	}
 	// Idempotent: second call returns empty password (user already exists).
-	pw2, err := cp.EnsureAdminUser(ctx, true)
+	pw2, err := cp.EnsureAdminUser(ctx, true, "")
 	if err != nil {
 		t.Fatalf("EnsureAdminUser (2nd): %v", err)
 	}

--- a/pkg/controlplane/store/interface.go
+++ b/pkg/controlplane/store/interface.go
@@ -491,7 +491,12 @@ type AdminStore interface {
 	// flagged to change its password on first login. When false (or when the
 	// password was supplied via DITTOFS_ADMIN_INITIAL_PASSWORD) the admin is
 	// created without the forced change.
-	EnsureAdminUser(ctx context.Context, requireInitialPasswordChange bool) (initialPassword string, err error)
+	//
+	// configuredPasswordHash, when non-empty and no plaintext env override is
+	// set, is used as the admin's bcrypt password hash directly (a known
+	// control-plane credential with no generated password). It must be a valid
+	// $2a$/$2b$ bcrypt hash. Returns an empty initialPassword in that case.
+	EnsureAdminUser(ctx context.Context, requireInitialPasswordChange bool, configuredPasswordHash string) (initialPassword string, err error)
 
 	// IsAdminInitialized returns whether the admin user has been initialized.
 	IsAdminInitialized(ctx context.Context) (bool, error)

--- a/pkg/controlplane/store/store_test.go
+++ b/pkg/controlplane/store/store_test.go
@@ -1284,7 +1284,7 @@ func TestEnsureAdminUser(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("creates admin if not exists", func(t *testing.T) {
-		password, err := store.EnsureAdminUser(ctx, true)
+		password, err := store.EnsureAdminUser(ctx, true, "")
 		if err != nil {
 			t.Fatalf("failed to ensure admin user: %v", err)
 		}
@@ -1307,7 +1307,7 @@ func TestEnsureAdminUser(t *testing.T) {
 	})
 
 	t.Run("second call returns empty password", func(t *testing.T) {
-		password, err := store.EnsureAdminUser(ctx, true)
+		password, err := store.EnsureAdminUser(ctx, true, "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1327,6 +1327,55 @@ func TestEnsureAdminUser(t *testing.T) {
 	})
 }
 
+// TestEnsureAdminUser_ConfiguredHash covers #1251: a bcrypt hash supplied via
+// admin.password_hash bootstraps a known admin credential (no generated
+// password, no forced change), and a non-bcrypt hash is rejected up front.
+func TestEnsureAdminUser_ConfiguredHash(t *testing.T) {
+	t.Setenv(models.EnvAdminInitialPassword, "")
+	ctx := context.Background()
+
+	hash, _, err := models.HashPasswordWithNT("knownadminpw")
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+
+	t.Run("uses configured bcrypt hash without generating a password", func(t *testing.T) {
+		store := createTestStore(t)
+		defer store.Close()
+
+		password, err := store.EnsureAdminUser(ctx, true, hash)
+		if err != nil {
+			t.Fatalf("EnsureAdminUser: %v", err)
+		}
+		if password != "" {
+			t.Errorf("expected empty initial password when hash is configured, got %q", password)
+		}
+
+		user, err := store.GetUser(ctx, "admin")
+		if err != nil {
+			t.Fatalf("admin should exist: %v", err)
+		}
+		if user.MustChangePassword {
+			t.Error("operator-supplied password must not force a first-login change")
+		}
+		// The configured credential must actually authenticate.
+		if _, err := store.ValidateCredentials(ctx, "admin", "knownadminpw"); err != nil {
+			t.Errorf("configured admin password should authenticate: %v", err)
+		}
+	})
+
+	t.Run("rejects a non-bcrypt hash", func(t *testing.T) {
+		store := createTestStore(t)
+		defer store.Close()
+
+		// A plaintext/garbage value (a common mistake — putting the password
+		// itself in password_hash) must fail fast, not bootstrap a broken admin.
+		if _, err := store.EnsureAdminUser(ctx, true, "not-a-bcrypt-hash"); err == nil {
+			t.Fatal("expected EnsureAdminUser to reject a non-bcrypt admin.password_hash")
+		}
+	})
+}
+
 // TestEnsureAdminUser_OptOutForcedChange verifies that the
 // require_initial_password_change knob, when disabled, provisions the bootstrap
 // admin without the forced first-login password change.
@@ -1338,7 +1387,7 @@ func TestEnsureAdminUser_OptOutForcedChange(t *testing.T) {
 	defer store.Close()
 	ctx := context.Background()
 
-	password, err := store.EnsureAdminUser(ctx, false)
+	password, err := store.EnsureAdminUser(ctx, false, "")
 	if err != nil {
 		t.Fatalf("failed to ensure admin user: %v", err)
 	}
@@ -1401,7 +1450,7 @@ func TestEnsureDefaultGroups(t *testing.T) {
 
 	t.Run("adds admin user to admins group", func(t *testing.T) {
 		// Create admin user first
-		_, err := store.EnsureAdminUser(ctx, true)
+		_, err := store.EnsureAdminUser(ctx, true, "")
 		if err != nil {
 			t.Fatalf("failed to ensure admin user: %v", err)
 		}

--- a/pkg/controlplane/store/users.go
+++ b/pkg/controlplane/store/users.go
@@ -222,7 +222,7 @@ func (s *GORMStore) ValidateCredentials(ctx context.Context, username, password 
 	return user, nil
 }
 
-func (s *GORMStore) EnsureAdminUser(ctx context.Context, requireInitialPasswordChange bool) (string, error) {
+func (s *GORMStore) EnsureAdminUser(ctx context.Context, requireInitialPasswordChange bool, configuredPasswordHash string) (string, error) {
 	// Check if admin exists
 	_, err := s.GetUser(ctx, models.AdminUsername)
 	if err == nil {
@@ -234,6 +234,31 @@ func (s *GORMStore) EnsureAdminUser(ctx context.Context, requireInitialPasswordC
 
 	// Check if password was explicitly set via environment variable
 	passwordFromEnv := os.Getenv(models.EnvAdminInitialPassword) != ""
+
+	// A bcrypt hash supplied via config (admin.password_hash) gives operators a
+	// known admin credential without a generated password and without writing a
+	// plaintext secret to disk. The plaintext env var takes precedence because
+	// it can also derive the NT hash for SMB; a bcrypt hash cannot, so an
+	// admin bootstrapped this way can authenticate to the control plane / REST
+	// API but not over SMB (use the env var for that).
+	if configuredPasswordHash != "" && !passwordFromEnv {
+		// Fail fast on a non-bcrypt / malformed hash rather than letting every
+		// admin login fail later with an opaque error. bcrypt.Cost parses the
+		// hash structure and version ($2a$/$2b$/$2y$ are all accepted).
+		if _, err := bcrypt.Cost([]byte(configuredPasswordHash)); err != nil {
+			return "", fmt.Errorf("admin.password_hash is not a valid bcrypt hash (%w); "+
+				"expected a $2a$/$2b$/$2y$ hash, e.g. from `dfsctl` or `htpasswd -bnBC 10 \"\" <pw>`", err)
+		}
+		// No NT hash is derivable from a bcrypt hash (SMB admin needs the
+		// plaintext env var path). Operator chose the password, so do not force
+		// a first-login change.
+		admin := models.DefaultAdminUser(configuredPasswordHash, "")
+		admin.MustChangePassword = false
+		if _, err := s.CreateUser(ctx, admin); err != nil {
+			return "", fmt.Errorf("failed to create admin user: %w", err)
+		}
+		return "", nil
+	}
 
 	// Generate or get password from environment
 	password, err := models.GetOrGenerateAdminPassword()


### PR DESCRIPTION
Closes #1251. Part of #1231 Wave 3 (operability gap found during AD-4b acceptance).

## Problem

The documented `admin.password_hash` config field was never consumed by `dfs start`. On first run the admin was always created with a **generated** password — printed once to the terminal interactively, but **unretrievable in daemon mode** — unless `DITTOFS_ADMIN_INITIAL_PASSWORD` (plaintext, env) was set. So there was no on-disk/config way to bootstrap a known admin credential.

## Change

`EnsureAdminUser` now takes the configured bcrypt hash. On first run (no admin yet, no plaintext env override) it creates the admin with that hash directly — a known control-plane credential, no generated password, no plaintext secret on disk, and no forced first-login change.

Precedence on first start:
1. `DITTOFS_ADMIN_INITIAL_PASSWORD` (plaintext, env) — also derives the NT hash → admin can use **SMB**.
2. `admin.password_hash` (bcrypt `$2a$`/`$2b$`/`$2y$`) — **control-plane/REST only** (no NT hash derivable from a bcrypt hash).
3. Auto-generated (existing behavior).

A configured value that is not a valid bcrypt hash is **rejected at startup** with an actionable error (e.g. a plaintext password mistakenly placed in `password_hash`).

Threaded through `ControlPlane` and the `AdminStore` interface; documented the precedence + SMB caveat in `docs/CONFIGURATION.md`.

## Tests

`TestEnsureAdminUser_ConfiguredHash` (integration): configured hash bootstraps an admin that authenticates with the chosen password and is not forced to change it; a non-bcrypt hash is rejected. Existing `EnsureAdminUser` tests updated for the new signature; `go vet`/gofmt clean.

## Backward compatibility

Additive. With `admin.password_hash` unset (the default), behavior is unchanged: env var, else generated password. No change for existing installs.