### PR TITLE
fix(controlplane): persist local_store_size/read_buffer_size/quota_bytes/encrypt_data in share edit

### DIFF
--- a/pkg/controlplane/store/shares.go
+++ b/pkg/controlplane/store/shares.go
@@ -97,6 +97,10 @@ func (s *GORMStore) UpdateShare(ctx context.Context, share *models.Share) error 
 		"trash_restrict_to_admin":             share.TrashRestrictToAdmin,
 		"trash_max_bytes":                     share.TrashMaxBytes,
 		"trash_exclude_patterns":              share.TrashExcludePatterns,
+		"encrypt_data":                        share.EncryptData,
+		"local_store_size":                    share.LocalStoreSize,
+		"read_buffer_size":                    share.ReadBufferSize,
+		"quota_bytes":                         share.QuotaBytes,
 		"updated_at":                          share.UpdatedAt,
 	}
 	// Handle remote_block_store_id explicitly: GORM map-based Updates may skip

--- a/pkg/controlplane/store/store_test.go
+++ b/pkg/controlplane/store/store_test.go
@@ -664,6 +664,69 @@ func TestShareOperations(t *testing.T) {
 		}
 	})
 
+	t.Run("update share persists local/buffer/quota/encrypt (#1268)", func(t *testing.T) {
+		// Refs #1268: UpdateShare builds an explicit map for .Updates and
+		// previously omitted these four columns, so `share edit` logged
+		// success while silently dropping them. Set all four to
+		// non-default values and assert each round-trips through GetShare.
+		share := &models.Share{
+			Name:              "/export-1268",
+			MetadataStoreID:   metaStoreID,
+			LocalBlockStoreID: localBlockStoreID,
+		}
+		if _, err := store.CreateShare(ctx, share); err != nil {
+			t.Fatalf("failed to create share: %v", err)
+		}
+
+		got, err := store.GetShare(ctx, "/export-1268")
+		if err != nil {
+			t.Fatalf("failed to get share: %v", err)
+		}
+		got.EncryptData = true
+		got.LocalStoreSize = 123456789
+		got.ReadBufferSize = 65536
+		got.QuotaBytes = 10737418240
+
+		if err := store.UpdateShare(ctx, got); err != nil {
+			t.Fatalf("failed to update share: %v", err)
+		}
+
+		reloaded, err := store.GetShare(ctx, "/export-1268")
+		if err != nil {
+			t.Fatalf("failed to reload share: %v", err)
+		}
+		if !reloaded.EncryptData {
+			t.Error("expected EncryptData to persist as true")
+		}
+		if reloaded.LocalStoreSize != 123456789 {
+			t.Errorf("expected LocalStoreSize 123456789, got %d", reloaded.LocalStoreSize)
+		}
+		if reloaded.ReadBufferSize != 65536 {
+			t.Errorf("expected ReadBufferSize 65536, got %d", reloaded.ReadBufferSize)
+		}
+		if reloaded.QuotaBytes != 10737418240 {
+			t.Errorf("expected QuotaBytes 10737418240, got %d", reloaded.QuotaBytes)
+		}
+
+		// Zero values must also be writable (e.g. disabling encryption,
+		// removing a quota) — map-based .Updates writes explicit zeros.
+		reloaded.EncryptData = false
+		reloaded.QuotaBytes = 0
+		if err := store.UpdateShare(ctx, reloaded); err != nil {
+			t.Fatalf("failed to update share (zeroing): %v", err)
+		}
+		zeroed, err := store.GetShare(ctx, "/export-1268")
+		if err != nil {
+			t.Fatalf("failed to reload share (zeroing): %v", err)
+		}
+		if zeroed.EncryptData {
+			t.Error("expected EncryptData to persist as false")
+		}
+		if zeroed.QuotaBytes != 0 {
+			t.Errorf("expected QuotaBytes 0, got %d", zeroed.QuotaBytes)
+		}
+	})
+
 	t.Run("new share defaults enabled=true", func(t *testing.T) {
 		share := &models.Share{
 			Name:              "/export-enabled-default",


### PR DESCRIPTION
Fixes #1268.

`UpdateShare` (pkg/controlplane/store/shares.go) builds an explicit `map[string]any` for GORM's `.Updates`, which only writes the keys present in the map. The map omitted four columns that the REST edit handler sets in-memory, so `share edit` logged success while silently dropping them:

- `local_store_size`  (Share.LocalStoreSize)
- `read_buffer_size`  (Share.ReadBufferSize)
- `quota_bytes`       (Share.QuotaBytes)
- `encrypt_data`      (Share.EncryptData)

## Fix
Add the four missing keys to the `updates` map (using the model's GORM column names — two are pinned via explicit `column:` tags). Map-based `.Updates` writes explicit zero values for present keys, so disabling encryption or removing a quota (set to 0) works correctly — consistent with the existing `trash_max_bytes` handling.

## Test
Extends `TestShareOperations` with a subtest that creates a share, sets all four fields to non-default values via `UpdateShare`, reloads via `GetShare`, and asserts each persisted — then re-zeroes `encrypt_data`/`quota_bytes` to confirm zero values are writable too.

`go vet`, `go build ./...`, and `go test ./pkg/controlplane/...` (incl. `-tags integration` store suite) all pass.