### PR TITLE
feat(blockstore): expose max_log_bytes append-log pressure budget; remove inert max_pending_size/MaxMemory

### DIFF
--- a/bench/blockstore/fixture.go
+++ b/bench/blockstore/fixture.go
@@ -28,7 +28,7 @@ const (
 // returned cleanup closes the engine, which also closes the remote.
 func NewEngine(baseDir string, remoteStore remote.RemoteStore) (*engine.Store, func(), error) {
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	local, err := fs.NewWithOptions(baseDir, 0, MemBudget, ms, fs.FSStoreOptions{
+	local, err := fs.NewWithOptions(baseDir, 0, ms, fs.FSStoreOptions{
 		MaxLogBytes:     LogBudget,
 		RollupWorkers:   RollupWorkers,
 		StabilizationMS: StabilizationMS,

--- a/bench/blockstore/workloads_extra.go
+++ b/bench/blockstore/workloads_extra.go
@@ -34,7 +34,7 @@ const (
 // chunk removal without engine overhead.
 func NewLocalStore(baseDir string) (*fs.FSStore, func(), error) {
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	local, err := fs.NewWithOptions(baseDir, 0, MemBudget, ms, fs.FSStoreOptions{
+	local, err := fs.NewWithOptions(baseDir, 0, ms, fs.FSStoreOptions{
 		MaxLogBytes:     LogBudget,
 		RollupWorkers:   1,
 		StabilizationMS: StabilizationMS,

--- a/cmd/dfs/commands/config/show.go
+++ b/cmd/dfs/commands/config/show.go
@@ -47,7 +47,8 @@ func init() {
 
 func runConfigShow(cmd *cobra.Command, args []string) error {
 	if showDeduced {
-		return runShowDeduced()
+		configPath, _ := cmd.Flags().GetString("config")
+		return runShowDeduced(configPath)
 	}
 
 	// Get config path from parent's persistent flag
@@ -101,11 +102,24 @@ func yamlKeyedView(cfg *config.Config) (interface{}, error) {
 }
 
 // runShowDeduced displays auto-deduced block store defaults with system info.
-func runShowDeduced() error {
+// The append-log budget (max_log_bytes) reflects the effective value: a global
+// blockstore.local.max_log_bytes override (from the config file or DITTOFS_*
+// env) takes precedence over the system-deduced default.
+func runShowDeduced(configPath string) error {
 	detector := sysinfo.NewDetector()
 	deduced := block.DeduceDefaults(detector)
 
 	mem := block.FormatBytes(detector.AvailableMemory())
+
+	// Quiet, env-aware load (Load, not MustLoad): resolves env > file >
+	// defaults without emitting the "no config file" warning, so we can show
+	// the effective max_log_bytes (global override applied if any).
+	effectiveMaxLogBytes := deduced.MaxLogBytes
+	maxLogBytesSource := "25% of " + mem + ", floor 1 GiB"
+	if cfg, err := config.Load(configPath); err == nil && cfg.Blockstore.Local.MaxLogBytes > 0 {
+		effectiveMaxLogBytes = cfg.Blockstore.Local.MaxLogBytes
+		maxLogBytesSource = "blockstore.local.max_log_bytes override"
+	}
 
 	fmt.Printf("# System Resources\n")
 	fmt.Printf("# CPUs: %d (source: runtime.GOMAXPROCS)\n", detector.AvailableCPUs())
@@ -118,8 +132,8 @@ func runShowDeduced() error {
 		block.FormatBytes(deduced.LocalStoreSize), mem)
 	fmt.Printf("read_buffer_size: %s  # 12.5%% of %s\n",
 		block.FormatBytes(uint64(deduced.ReadBufferSize)), mem)
-	fmt.Printf("max_pending_size: %s  # 50%% of local_store_size\n",
-		block.FormatBytes(deduced.MaxPendingSize))
+	fmt.Printf("max_log_bytes: %s  # %s; overridable globally (blockstore.local.max_log_bytes) and per-store\n",
+		block.FormatBytes(effectiveMaxLogBytes), maxLogBytesSource)
 	fmt.Printf("parallel_syncs: %d  # max(4, %d CPUs)\n",
 		deduced.ParallelSyncs, detector.AvailableCPUs())
 	fmt.Printf("parallel_fetches: %d  # max(8, %d CPUs * 2)\n",

--- a/cmd/dfs/commands/migrate_to_cas.go
+++ b/cmd/dfs/commands/migrate_to_cas.go
@@ -44,7 +44,6 @@ var (
 	migrateDryRun      bool
 	migrateJSON        bool
 	migrateMaxDisk     int64
-	migrateMaxMemory   int64
 )
 
 var migrateToCASCmd = &cobra.Command{
@@ -90,8 +89,6 @@ func init() {
 		"Emit one JSON object per second of progress to stdout (machine-parseable)")
 	migrateToCASCmd.Flags().Int64Var(&migrateMaxDisk, "max-disk", 0,
 		"Per-share max-disk budget for the destination FSStore (0 = unlimited)")
-	migrateToCASCmd.Flags().Int64Var(&migrateMaxMemory, "max-memory", 0,
-		"Per-share max-memory budget for the destination FSStore (0 = 256 MiB default)")
 	migrateToCASCmd.Flags().StringVar(&migrateMetadataDir, "metadata-dir", "",
 		"Path to the badger metadata database directory (REQUIRED; the directory passed to the metadata store's 'path' config)")
 }
@@ -174,7 +171,7 @@ func runMigrateToCAS(cmd *cobra.Command, args []string) error {
 		// sub-path). FSStore internally creates `blocks/` (CAS) + `logs/`
 		// (append log) as siblings under baseDir.
 		bs, openErr := fs.NewFSStoreForMigration(shareDir,
-			migrateMaxDisk, migrateMaxMemory, nopFileBlockStore{},
+			migrateMaxDisk, nopFileBlockStore{},
 			fs.FSStoreOptions{})
 		if openErr != nil {
 			return fmt.Errorf("open destination store for share %q: %w", name, openErr)

--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -180,7 +180,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 	logger.Info("Auto-deduced block store defaults",
 		"local_store_size", block.FormatBytes(deduced.LocalStoreSize),
 		"read_buffer_size", block.FormatBytes(uint64(deduced.ReadBufferSize)),
-		"max_pending_size", block.FormatBytes(deduced.MaxPendingSize),
+		"max_log_bytes", block.FormatBytes(deduced.MaxLogBytes),
 		"parallel_syncs", deduced.ParallelSyncs,
 		"parallel_fetches", deduced.ParallelFetches,
 		"prefetch_workers", deduced.PrefetchWorkers,
@@ -194,11 +194,20 @@ func runStart(cmd *cobra.Command, args []string) error {
 		)
 	}
 
+	// Resolve the effective append-log pressure budget default: the global
+	// config blockstore.local.max_log_bytes wins when set, otherwise the
+	// system-deduced default. A per-share block store config max_log_bytes
+	// still overrides this inside CreateLocalStoreFromConfig.
+	effectiveMaxLogBytes := deduced.MaxLogBytes
+	if cfg.Blockstore.Local.MaxLogBytes > 0 {
+		effectiveMaxLogBytes = cfg.Blockstore.Local.MaxLogBytes
+	}
+
 	// Set per-share defaults BEFORE loading shares (AddShare creates BlockStores).
 	rt.SetLocalStoreDefaults(&shares.LocalStoreDefaults{
 		MaxSize:                deduced.LocalStoreSize,
-		MaxMemory:              block.ClampToInt64(deduced.MaxPendingSize),
 		ReadBufferBytes:        deduced.ReadBufferSize,
+		MaxLogBytes:            block.ClampToInt64(effectiveMaxLogBytes),
 		DedupLRUSize:           cfg.Blockstore.Local.DedupLRUSize,
 		DefaultRemoteCacheSize: cfg.Blockstore.Local.DefaultRemoteCacheSize,
 		BackpressureMaxWait:    cfg.Blockstore.Local.BackpressureMaxWait,

--- a/cmd/dfsctl/commands/store/block/stats.go
+++ b/cmd/dfsctl/commands/store/block/stats.go
@@ -78,7 +78,7 @@ func printBlockStoreStatsTable(resp *apiclient.BlockStoreStatsResponse) error {
 		{"Local Disk Used", formatBytes(t.LocalDiskUsed)},
 		{"Local Disk Max", formatBytes(t.LocalDiskMax)},
 		{"Local Mem Used", formatBytes(t.LocalMemUsed)},
-		{"Local Mem Max", formatBytes(t.LocalMemMax)},
+		{"Append-Log Limit", formatBytes(t.AppendLogLimitBytes)},
 		{"Read Buffer Entries", fmt.Sprintf("%d", t.ReadBufferEntries)},
 		{"Read Buffer Used", formatBytes(t.ReadBufferUsed)},
 		{"Read Buffer Max", formatBytes(t.ReadBufferMax)},

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -380,7 +380,6 @@ Flags:
       --dry-run               Walk + sample only; report file count, bytes, estimated dedup ratio, ETA. Writes nothing.
       --json                  Emit one JSON object per second of progress to stdout (machine-parseable)
       --max-disk int          Per-share max-disk budget for the destination FSStore (0 = unlimited)
-      --max-memory int        Per-share max-memory budget for the destination FSStore (0 = 256 MiB default)
       --metadata-dir string   Path to the badger metadata database directory (REQUIRED; the directory passed to the metadata store's 'path' config)
       --share string          Scope migration to one share (default: all shares discovered under <storage-dir>/shares/)
       --storage-dir string    Storage root (REQUIRED; expects <root>/shares/<name>/blocks layout)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -338,7 +338,7 @@ logs a startup warning.)
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `max_log_bytes` | int | `1073741824` (1 GiB) | Per-share total-log-bytes budget; writers block on pressure when exceeded. Values above 2^53 (~9 PiB) lose precision through JSON parsing. |
+| `max_log_bytes` | int | deduced (25% of RAM, floor 1 GiB) | **Per-share** append-log pressure budget; writers block (`ErrPressureTimeout`) when the buffered log exceeds it. This per-store value takes **precedence** over the global `blockstore.local.max_log_bytes` and the system-deduced default. Values above 2^53 (~9 PiB) lose precision through JSON parsing. |
 | `rollup_workers` | int | `2` | Number of rollup goroutines (BLAKE3 + FastCDC) per share. |
 | `stabilization_ms` | int | `250` | Dirty-interval stabilization window in milliseconds before rollup. |
 | `orphan_log_min_age_seconds` | int | `3600` (1h) | Minimum log-file mtime age before the boot-time orphan sweep may unlink it. Prevents fresh (not-yet-rolled-up) logs from being swept when metadata is absent. |
@@ -352,6 +352,38 @@ Env-var mapping follows the dot-path convention:
 The local `fs` store requires a metadata backend that implements
 `metadata.RollupStore` to persist each log's `rollup_offset`; memory, badger,
 and postgres all qualify.
+
+##### Append-log pressure budget (`max_log_bytes`)
+
+`max_log_bytes` is **THE** append-log backpressure lever. The on-disk append
+log buffers freshly-written bytes before the async rollup folds them into CAS
+chunks; once the buffered total exceeds this budget, `AppendWrite` stalls and
+eventually returns `ErrPressureTimeout` (surfaced as disk-full to the
+protocol). It is sized **relative to available memory** — the disk-backed
+pre-flush working set scales with how fast the host absorbs writes — at 25% of
+RAM with a 1 GiB floor (the historical fixed default becomes the minimum on
+small machines). Run `dfs config show --deduced` to see the effective value.
+
+The effective budget resolves with the following **precedence** (highest
+first):
+
+1. **Per-store** block-store `config["max_log_bytes"]` — set per share via
+   `dfsctl store block local edit <share> --config '{"max_log_bytes": 2147483648}'`.
+2. **Global** server-config `blockstore.local.max_log_bytes` — applies to every
+   share that does not set the per-store key.
+3. **System-deduced** default (25% of RAM, floor 1 GiB).
+
+The global knob lives in the top-level server-config `blockstore.local` block
+and binds to the env var `DITTOFS_BLOCKSTORE_LOCAL_MAX_LOG_BYTES`:
+
+```yaml
+blockstore:
+  local:
+    max_log_bytes: 2147483648   # 2 GiB global append-log pressure budget.
+                                # 0 / unset = system-deduced default
+                                # (25% of RAM, floor 1 GiB). A per-store
+                                # config max_log_bytes overrides this.
+```
 
 #### GC knobs
 
@@ -450,6 +482,8 @@ blockstore:
     backpressure_max_wait: 60s               # Max time a write stalls for the
                                              # syncer to drain before disk-full.
     dedup_lru_size: 4096                      # In-memory dedup LRU slot count.
+    max_log_bytes: 2147483648                # Global append-log pressure budget
+                                             # (see above). 0/unset = deduced.
 ```
 
 Env-var mapping (dot-path convention):

--- a/internal/adapter/common/copy_payload_test.go
+++ b/internal/adapter/common/copy_payload_test.go
@@ -361,7 +361,7 @@ func newCopyTestEngineWithMS(t *testing.T, coord *fakeCoordinator, ms *metadatam
 	t.Helper()
 
 	tmpDir := t.TempDir()
-	localStore, err := fs.NewWithOptions(tmpDir, 100*1024*1024, 16*1024*1024, ms, fs.FSStoreOptions{})
+	localStore, err := fs.NewWithOptions(tmpDir, 100*1024*1024, ms, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions failed: %v", err)
 	}

--- a/internal/adapter/common/write_payload_test.go
+++ b/internal/adapter/common/write_payload_test.go
@@ -26,7 +26,7 @@ func newTestEngine(t *testing.T) *engine.Store {
 
 	tmpDir := t.TempDir()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	localStore, err := fs.NewWithOptions(tmpDir, 100*1024*1024, 16*1024*1024, ms, fs.FSStoreOptions{
+	localStore, err := fs.NewWithOptions(tmpDir, 100*1024*1024, ms, fs.FSStoreOptions{
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 50,

--- a/internal/adapter/nfs/v3/handlers/testing/fixtures.go
+++ b/internal/adapter/nfs/v3/handlers/testing/fixtures.go
@@ -102,7 +102,7 @@ func NewHandlerFixtureWithStore(
 
 	// Create local store, syncer, and block store engine
 	tmpDir := t.TempDir()
-	localStore, err := fs.NewWithOptions(tmpDir, 0, 0, metaStore, fs.FSStoreOptions{})
+	localStore, err := fs.NewWithOptions(tmpDir, 0, metaStore, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("Failed to create local store: %v", err)
 	}

--- a/internal/adapter/nfs/v4/handlers/io_test.go
+++ b/internal/adapter/nfs/v4/handlers/io_test.go
@@ -41,7 +41,7 @@ func newIOTestFixture(t *testing.T, shareName string) *ioTestFixture {
 
 	// Create local store, syncer, and block store engine
 	tmpDir := t.TempDir()
-	localStore, err := fs.NewWithOptions(tmpDir, 0, 0, metaStore, fs.FSStoreOptions{})
+	localStore, err := fs.NewWithOptions(tmpDir, 0, metaStore, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("create local store: %v", err)
 	}

--- a/pkg/block/defaults.go
+++ b/pkg/block/defaults.go
@@ -18,6 +18,7 @@ type SystemDetector interface {
 const (
 	MinLocalStoreSize      uint64 = 256 << 20 // 256 MiB
 	MinReadBufferSize      int64  = 64 << 20  // 64 MiB
+	MinMaxLogBytes         uint64 = 1 << 30   // 1 GiB
 	MinParallelSyncs              = 4
 	MinParallelFetches            = 8
 	DefaultPrefetchWorkers        = 4
@@ -27,7 +28,7 @@ const (
 type DeducedDefaults struct {
 	LocalStoreSize  uint64 // 25% of memory, floor 256 MiB
 	ReadBufferSize  int64  // 12.5% of memory, floor 64 MiB
-	MaxPendingSize  uint64 // 50% of LocalStoreSize
+	MaxLogBytes     uint64 // 25% of memory, floor 1 GiB (append-log pressure budget)
 	ParallelSyncs   int    // max(4, cpus)
 	ParallelFetches int    // max(8, cpus*2)
 	PrefetchWorkers int    // fixed at DefaultPrefetchWorkers
@@ -35,6 +36,7 @@ type DeducedDefaults struct {
 	// Internal: track whether clamping actually occurred.
 	localStoreClamped      bool
 	readBufferClamped      bool
+	maxLogBytesClamped     bool
 	parallelSyncsClamped   bool
 	parallelFetchesClamped bool
 }
@@ -60,7 +62,21 @@ func DeduceDefaults(d SystemDetector) *DeducedDefaults {
 		readBufferSize = MinReadBufferSize
 	}
 
-	maxPendingSize := localStoreSize / 2
+	// MaxLogBytes is the per-share append-log pressure budget: the on-disk
+	// append log buffers freshly-written bytes before the async rollup folds
+	// them into CAS chunks, and AppendWrite stalls (ErrPressureTimeout) once
+	// logBytesTotal exceeds this budget. Because the log is disk-backed
+	// pre-flush write data whose in-flight working set is bounded by how fast
+	// the host can absorb writes, we size it relative to available memory —
+	// 25% of RAM, the same fraction used for the local store — with a 1 GiB
+	// floor so the budget never drops below the historical fixed default on
+	// small machines. Reporters on large-RAM hosts get a proportionally larger
+	// budget instead of a hardcoded 1 GiB ceiling.
+	maxLogBytes := mem / 4
+	maxLogBytesClamped := maxLogBytes < MinMaxLogBytes
+	if maxLogBytesClamped {
+		maxLogBytes = MinMaxLogBytes
+	}
 
 	parallelSyncs := cpus
 	parallelSyncsClamped := parallelSyncs < MinParallelSyncs
@@ -77,12 +93,13 @@ func DeduceDefaults(d SystemDetector) *DeducedDefaults {
 	return &DeducedDefaults{
 		LocalStoreSize:         localStoreSize,
 		ReadBufferSize:         readBufferSize,
-		MaxPendingSize:         maxPendingSize,
+		MaxLogBytes:            maxLogBytes,
 		ParallelSyncs:          parallelSyncs,
 		ParallelFetches:        parallelFetches,
 		PrefetchWorkers:        DefaultPrefetchWorkers,
 		localStoreClamped:      localStoreClamped,
 		readBufferClamped:      readBufferClamped,
+		maxLogBytesClamped:     maxLogBytesClamped,
 		parallelSyncsClamped:   parallelSyncsClamped,
 		parallelFetchesClamped: parallelFetchesClamped,
 	}
@@ -100,6 +117,9 @@ func (d *DeducedDefaults) HitFloors() []string {
 	if d.readBufferClamped {
 		floors = append(floors, fmt.Sprintf("read_buffer_size floored at %s", FormatBytes(uint64(MinReadBufferSize))))
 	}
+	if d.maxLogBytesClamped {
+		floors = append(floors, fmt.Sprintf("max_log_bytes floored at %s", FormatBytes(MinMaxLogBytes)))
+	}
 	if d.parallelSyncsClamped {
 		floors = append(floors, fmt.Sprintf("parallel_syncs floored at %d", MinParallelSyncs))
 	}
@@ -112,12 +132,12 @@ func (d *DeducedDefaults) HitFloors() []string {
 // String returns a human-readable summary of deduced defaults.
 func (d *DeducedDefaults) String() string {
 	return fmt.Sprintf(
-		"LocalStoreSize=%s, ReadBufferSize=%s, ParallelSyncs=%d, ParallelFetches=%d, MaxPendingSize=%s, PrefetchWorkers=%d",
+		"LocalStoreSize=%s, ReadBufferSize=%s, ParallelSyncs=%d, ParallelFetches=%d, MaxLogBytes=%s, PrefetchWorkers=%d",
 		FormatBytes(d.LocalStoreSize),
 		FormatBytes(uint64(d.ReadBufferSize)),
 		d.ParallelSyncs,
 		d.ParallelFetches,
-		FormatBytes(d.MaxPendingSize),
+		FormatBytes(d.MaxLogBytes),
 		d.PrefetchWorkers,
 	)
 }

--- a/pkg/block/defaults_test.go
+++ b/pkg/block/defaults_test.go
@@ -21,7 +21,7 @@ func TestDeduceDefaults(t *testing.T) {
 		cpus           int
 		wantLocalStore uint64
 		wantReadBuffer int64
-		wantPending    uint64
+		wantLogBytes   uint64
 		wantSyncs      int
 		wantFetches    int
 		wantPrefetch   int
@@ -32,7 +32,7 @@ func TestDeduceDefaults(t *testing.T) {
 			cpus:           8,
 			wantLocalStore: 2 * gib, // 25% of 8GiB
 			wantReadBuffer: 1 * gib, // 12.5% of 8GiB
-			wantPending:    1 * gib, // 50% of 2GiB
+			wantLogBytes:   2 * gib, // 25% of 8GiB
 			wantSyncs:      8,       // max(4, 8)
 			wantFetches:    16,      // max(8, 8*2)
 			wantPrefetch:   DefaultPrefetchWorkers,
@@ -43,7 +43,7 @@ func TestDeduceDefaults(t *testing.T) {
 			cpus:           1,
 			wantLocalStore: 256 * mib, // 25% of 512MiB = 128MiB, floor 256MiB
 			wantReadBuffer: 64 * mib,  // 12.5% of 512MiB = 64MiB, exactly at floor
-			wantPending:    128 * mib, // 50% of 256MiB
+			wantLogBytes:   1 * gib,   // 25% of 512MiB = 128MiB, floor 1 GiB
 			wantSyncs:      4,         // max(4, 1) = floor
 			wantFetches:    8,         // max(8, 2) = floor
 			wantPrefetch:   DefaultPrefetchWorkers,
@@ -54,7 +54,7 @@ func TestDeduceDefaults(t *testing.T) {
 			cpus:           1,
 			wantLocalStore: 256 * mib, // 25% of 256MiB = 64MiB, floor 256MiB
 			wantReadBuffer: 64 * mib,  // 12.5% of 256MiB = 32MiB, floor 64MiB
-			wantPending:    128 * mib, // 50% of 256MiB
+			wantLogBytes:   1 * gib,   // 25% of 256MiB = 64MiB, floor 1 GiB
 			wantSyncs:      4,         // floor
 			wantFetches:    8,         // floor
 			wantPrefetch:   DefaultPrefetchWorkers,
@@ -65,7 +65,7 @@ func TestDeduceDefaults(t *testing.T) {
 			cpus:           64,
 			wantLocalStore: 64 * gib, // 25% of 256GiB
 			wantReadBuffer: 32 * gib, // 12.5% of 256GiB
-			wantPending:    32 * gib, // 50% of 64GiB
+			wantLogBytes:   64 * gib, // 25% of 256GiB
 			wantSyncs:      64,       // max(4, 64)
 			wantFetches:    128,      // max(8, 128)
 			wantPrefetch:   DefaultPrefetchWorkers,
@@ -76,7 +76,7 @@ func TestDeduceDefaults(t *testing.T) {
 			cpus:           4,
 			wantLocalStore: 1 * gib,   // 25% of 4GiB
 			wantReadBuffer: 512 * mib, // 12.5% of 4GiB
-			wantPending:    512 * mib, // 50% of 1GiB
+			wantLogBytes:   1 * gib,   // 25% of 4GiB = 1 GiB, exactly at floor
 			wantSyncs:      4,         // max(4, 4)
 			wantFetches:    8,         // max(8, 8)
 			wantPrefetch:   DefaultPrefetchWorkers,
@@ -87,7 +87,7 @@ func TestDeduceDefaults(t *testing.T) {
 			cpus:           32,
 			wantLocalStore: 512 * mib, // 25% of 2GiB
 			wantReadBuffer: 256 * mib, // 12.5% of 2GiB
-			wantPending:    256 * mib, // 50% of 512MiB
+			wantLogBytes:   1 * gib,   // 25% of 2GiB = 512MiB, floor 1 GiB
 			wantSyncs:      32,        // max(4, 32)
 			wantFetches:    64,        // max(8, 64)
 			wantPrefetch:   DefaultPrefetchWorkers,
@@ -105,8 +105,8 @@ func TestDeduceDefaults(t *testing.T) {
 			if got.ReadBufferSize != tt.wantReadBuffer {
 				t.Errorf("ReadBufferSize = %d, want %d", got.ReadBufferSize, tt.wantReadBuffer)
 			}
-			if got.MaxPendingSize != tt.wantPending {
-				t.Errorf("MaxPendingSize = %d, want %d", got.MaxPendingSize, tt.wantPending)
+			if got.MaxLogBytes != tt.wantLogBytes {
+				t.Errorf("MaxLogBytes = %d, want %d", got.MaxLogBytes, tt.wantLogBytes)
 			}
 			if got.ParallelSyncs != tt.wantSyncs {
 				t.Errorf("ParallelSyncs = %d, want %d", got.ParallelSyncs, tt.wantSyncs)
@@ -142,7 +142,7 @@ func TestDeduceDefaults_String(t *testing.T) {
 	}
 	t.Logf("String() = %s", s)
 
-	for _, want := range []string{"LocalStoreSize", "ReadBufferSize", "ParallelSyncs", "ParallelFetches", "MaxPendingSize"} {
+	for _, want := range []string{"LocalStoreSize", "ReadBufferSize", "ParallelSyncs", "ParallelFetches", "MaxLogBytes"} {
 		if !strings.Contains(s, want) {
 			t.Errorf("String() missing %q: %s", want, s)
 		}
@@ -159,12 +159,13 @@ func TestHitFloors_OnlyReportsClamped(t *testing.T) {
 		t.Errorf("expected no floors on 4GiB/4CPU, got %v", floors)
 	}
 
-	// 256MiB/1CPU: everything is clamped.
+	// 256MiB/1CPU: everything is clamped (local_store, read_buffer,
+	// max_log_bytes, parallel_syncs, parallel_fetches).
 	d2 := &mockDetector{memory: 256 * mib, cpus: 1}
 	got2 := DeduceDefaults(d2)
 	floors2 := got2.HitFloors()
-	if len(floors2) != 4 {
-		t.Errorf("expected 4 floors on 256MiB/1CPU, got %d: %v", len(floors2), floors2)
+	if len(floors2) != 5 {
+		t.Errorf("expected 5 floors on 256MiB/1CPU, got %d: %v", len(floors2), floors2)
 	}
 }
 

--- a/pkg/block/engine/cache_populated_on_rollup_test.go
+++ b/pkg/block/engine/cache_populated_on_rollup_test.go
@@ -38,7 +38,7 @@ import (
 func newRollupCacheFixture(t *testing.T) (*Store, *fs.FSStore, *recordingPutCache) {
 	t.Helper()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, 16*1024*1024, ms, fs.FSStoreOptions{
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 5,

--- a/pkg/block/engine/drain_persist_test.go
+++ b/pkg/block/engine/drain_persist_test.go
@@ -170,7 +170,7 @@ func newEngineOverStore(t *testing.T, ms metadata.Store) *engine.Store {
 	if !ok {
 		t.Fatalf("metadata store %T does not implement metadata.SyncedHashStore", ms)
 	}
-	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, 16*1024*1024, ms, fs.FSStoreOptions{
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 3_600_000, // 1h — async/ticker rollup can never fire

--- a/pkg/block/engine/drain_reset_test.go
+++ b/pkg/block/engine/drain_reset_test.go
@@ -18,7 +18,7 @@ import (
 func newDrainResetFixture(t *testing.T) (*Store, *fs.FSStore) {
 	t.Helper()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, 16*1024*1024, ms, fs.FSStoreOptions{
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 3_600_000, // 1h — async/ticker rollup can never fire

--- a/pkg/block/engine/engine_dualread_test.go
+++ b/pkg/block/engine/engine_dualread_test.go
@@ -63,7 +63,7 @@ func newDualReadEnv(t *testing.T) *dualReadEnv {
 	t.Helper()
 	tmp := t.TempDir()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	bc, err := fs.NewWithOptions(tmp, 0, 0, ms, fs.FSStoreOptions{})
+	bc, err := fs.NewWithOptions(tmp, 0, ms, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)
 	}

--- a/pkg/block/engine/engine_health_test.go
+++ b/pkg/block/engine/engine_health_test.go
@@ -63,7 +63,7 @@ func buildHealthTestEngine(t *testing.T) (*Store, *fakeRemoteStore) {
 
 	tmpDir := t.TempDir()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	localStore, err := fs.NewWithOptions(tmpDir, 100*1024*1024, 16*1024*1024, ms, fs.FSStoreOptions{
+	localStore, err := fs.NewWithOptions(tmpDir, 100*1024*1024, ms, fs.FSStoreOptions{
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 50,

--- a/pkg/block/engine/engine_offline_test.go
+++ b/pkg/block/engine/engine_offline_test.go
@@ -160,7 +160,7 @@ func TestPrefetchSuppressedWhenUnhealthy(t *testing.T) {
 	// Create engine with prefetch enabled.
 	tmpDir := t.TempDir()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	localStore, err := fs.NewWithOptions(tmpDir, 100*1024*1024, 16*1024*1024, ms, fs.FSStoreOptions{
+	localStore, err := fs.NewWithOptions(tmpDir, 100*1024*1024, ms, fs.FSStoreOptions{
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 50,

--- a/pkg/block/engine/loadbyhash_test.go
+++ b/pkg/block/engine/loadbyhash_test.go
@@ -18,7 +18,7 @@ import (
 func newLoadByHashFixture(t *testing.T) (*Store, *fs.FSStore) {
 	t.Helper()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, 16*1024*1024, ms, fs.FSStoreOptions{})
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)
 	}

--- a/pkg/block/engine/nil_remotestore_test.go
+++ b/pkg/block/engine/nil_remotestore_test.go
@@ -16,7 +16,7 @@ func newNilRemoteStoreEnv(t *testing.T) (*Syncer, local.LocalStore, func()) {
 	t.Helper()
 	tmpDir := t.TempDir()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	bc, err := fs.NewWithOptions(tmpDir, 0, 0, ms, fs.FSStoreOptions{})
+	bc, err := fs.NewWithOptions(tmpDir, 0, ms, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions() error = %v", err)
 	}

--- a/pkg/block/engine/onchunkcomplete_test.go
+++ b/pkg/block/engine/onchunkcomplete_test.go
@@ -19,7 +19,7 @@ import (
 func newOnChunkCompleteFixture(t *testing.T, readBufferBytes int64) (*Store, *fs.FSStore) {
 	t.Helper()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, 16*1024*1024, ms, fs.FSStoreOptions{})
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)
 	}

--- a/pkg/block/engine/pending_set_test.go
+++ b/pkg/block/engine/pending_set_test.go
@@ -17,7 +17,7 @@ import (
 func newPendingSetFixture(t *testing.T) (*Store, *fs.FSStore, *metadatamemory.MemoryMetadataStore) {
 	t.Helper()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, 16*1024*1024, ms, fs.FSStoreOptions{
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 5,

--- a/pkg/block/engine/stats.go
+++ b/pkg/block/engine/stats.go
@@ -22,8 +22,15 @@ type BlockStoreStats struct {
 	// LocalMemMax is retained for wire/JSON compatibility but is always 0:
 	// the FSStore no longer tracks a configurable dirty-buffer memory budget
 	// (the former MaxMemory knob was never enforced and was removed). The real
-	// append-log pressure budget is max_log_bytes; see GetStats notes.
+	// append-log pressure budget is AppendLogLimitBytes below.
 	LocalMemMax int64 `json:"local_mem_max"`
+
+	// AppendLogLimitBytes is the effective append-log pressure budget
+	// (resolved max_log_bytes: per-store > global > deduced). AppendWrite
+	// blocks once the on-disk append log exceeds this ceiling and ultimately
+	// returns ErrPressureTimeout if the rollup cannot drain. This is the real
+	// write-pressure ceiling that replaced the inert MaxMemory knob.
+	AppendLogLimitBytes int64 `json:"append_log_limit_bytes"`
 
 	ReadBufferEntries int   `json:"read_buffer_entries"`
 	ReadBufferUsed    int64 `json:"read_buffer_used"`
@@ -111,11 +118,12 @@ func (bs *Store) getStats(withBlockCounts bool) BlockStoreStats {
 	outageDuration := bs.syncer.RemoteOutageDuration()
 
 	stats := BlockStoreStats{
-		FileCount:     len(files),
-		LocalDiskUsed: localStats.DiskUsed,
-		LocalDiskMax:  localStats.MaxDisk,
-		LocalMemUsed:  localStats.MemUsed,
-		LocalMemMax:   0, // retained for compatibility; FSStore no longer tracks a mem budget
+		FileCount:           len(files),
+		LocalDiskUsed:       localStats.DiskUsed,
+		LocalDiskMax:        localStats.MaxDisk,
+		LocalMemUsed:        localStats.MemUsed,
+		LocalMemMax:         0, // retained for compatibility; FSStore no longer tracks a mem budget
+		AppendLogLimitBytes: localStats.MaxLogBytes,
 
 		ReadBufferEntries:   cacheStats.Entries,
 		ReadBufferUsed:      cacheStats.CurBytes,

--- a/pkg/block/engine/stats.go
+++ b/pkg/block/engine/stats.go
@@ -19,7 +19,11 @@ type BlockStoreStats struct {
 	LocalDiskUsed int64 `json:"local_disk_used"`
 	LocalDiskMax  int64 `json:"local_disk_max"`
 	LocalMemUsed  int64 `json:"local_mem_used"`
-	LocalMemMax   int64 `json:"local_mem_max"`
+	// LocalMemMax is retained for wire/JSON compatibility but is always 0:
+	// the FSStore no longer tracks a configurable dirty-buffer memory budget
+	// (the former MaxMemory knob was never enforced and was removed). The real
+	// append-log pressure budget is max_log_bytes; see GetStats notes.
+	LocalMemMax int64 `json:"local_mem_max"`
 
 	ReadBufferEntries int   `json:"read_buffer_entries"`
 	ReadBufferUsed    int64 `json:"read_buffer_used"`
@@ -107,11 +111,12 @@ func (bs *Store) getStats(withBlockCounts bool) BlockStoreStats {
 	outageDuration := bs.syncer.RemoteOutageDuration()
 
 	stats := BlockStoreStats{
-		FileCount:           len(files),
-		LocalDiskUsed:       localStats.DiskUsed,
-		LocalDiskMax:        localStats.MaxDisk,
-		LocalMemUsed:        localStats.MemUsed,
-		LocalMemMax:         localStats.MaxMemory,
+		FileCount:     len(files),
+		LocalDiskUsed: localStats.DiskUsed,
+		LocalDiskMax:  localStats.MaxDisk,
+		LocalMemUsed:  localStats.MemUsed,
+		LocalMemMax:   0, // retained for compatibility; FSStore no longer tracks a mem budget
+
 		ReadBufferEntries:   cacheStats.Entries,
 		ReadBufferUsed:      cacheStats.CurBytes,
 		ReadBufferMax:       cacheStats.MaxBytes,

--- a/pkg/block/engine/sync_health_integration_test.go
+++ b/pkg/block/engine/sync_health_integration_test.go
@@ -99,7 +99,7 @@ func newHealthTestEnv(t *testing.T) *healthTestEnv {
 	t.Helper()
 	tmpDir := t.TempDir()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	bc, err := fs.NewWithOptions(tmpDir, 0, 0, ms, fs.FSStoreOptions{
+	bc, err := fs.NewWithOptions(tmpDir, 0, ms, fs.FSStoreOptions{
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 50,
@@ -334,7 +334,7 @@ func TestHealthCallbackInvocation(t *testing.T) {
 func TestHealthMonitorNilRemoteStore(t *testing.T) {
 	tmpDir := t.TempDir()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	bc, err := fs.NewWithOptions(tmpDir, 0, 0, ms, fs.FSStoreOptions{})
+	bc, err := fs.NewWithOptions(tmpDir, 0, ms, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions() error = %v", err)
 	}

--- a/pkg/block/engine/syncer_evict_unsynced_test.go
+++ b/pkg/block/engine/syncer_evict_unsynced_test.go
@@ -24,7 +24,7 @@ func TestMirrorOnce_EvictedUnsyncedHash_NotSilentlyDropped(t *testing.T) {
 	ctx := context.Background()
 
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, 16*1024*1024, ms, fs.FSStoreOptions{
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
 		SyncedHashStore: ms,
 	})
 	if err != nil {

--- a/pkg/block/local/fs/appendlog_budget_c3_test.go
+++ b/pkg/block/local/fs/appendlog_budget_c3_test.go
@@ -15,7 +15,7 @@ import (
 func newC3BudgetStore(t *testing.T, maxLogBytes int64) *FSStore {
 	t.Helper()
 	mem := memmeta.NewMemoryMetadataStoreWithDefaults()
-	bc, err := NewWithOptions(t.TempDir(), 1<<30, 1<<30, mem, FSStoreOptions{
+	bc, err := NewWithOptions(t.TempDir(), 1<<30, mem, FSStoreOptions{
 		MaxLogBytes:     maxLogBytes,
 		RollupWorkers:   1,
 		StabilizationMS: 1,

--- a/pkg/block/local/fs/appendlog_internals_test.go
+++ b/pkg/block/local/fs/appendlog_internals_test.go
@@ -35,7 +35,7 @@ func appendlogFactory(t *testing.T) *fs.FSStore {
 	t.Helper()
 	dir := t.TempDir()
 	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
-	bc, err := fs.NewWithOptions(dir, 1<<30, 1<<30, nil, fs.FSStoreOptions{
+	bc, err := fs.NewWithOptions(dir, 1<<30, nil, fs.FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 50,

--- a/pkg/block/local/fs/appendlog_testhelpers_test.go
+++ b/pkg/block/local/fs/appendlog_testhelpers_test.go
@@ -61,7 +61,7 @@ func newFSStoreForTest(t *testing.T, opts FSStoreOptions) *FSStore {
 	if err != nil {
 		t.Fatalf("MkdirTemp: %v", err)
 	}
-	bc, err := NewWithOptions(dir, 1<<30, 1<<30, nopFBS{}, opts)
+	bc, err := NewWithOptions(dir, 1<<30, nopFBS{}, opts)
 	if err != nil {
 		_ = os.RemoveAll(dir)
 		t.Fatalf("NewWithOptions: %v", err)

--- a/pkg/block/local/fs/appendwrite_group_commit_bench_test.go
+++ b/pkg/block/local/fs/appendwrite_group_commit_bench_test.go
@@ -137,7 +137,7 @@ func BenchmarkAppendWrite_GroupCommit(b *testing.B) {
 func newBenchFSStore(b *testing.B, opts FSStoreOptions) *FSStore {
 	b.Helper()
 	dir := b.TempDir()
-	bc, err := NewWithOptions(dir, 1<<30, 1<<30, nopFBS{}, opts)
+	bc, err := NewWithOptions(dir, 1<<30, nopFBS{}, opts)
 	if err != nil {
 		b.Fatalf("NewWithOptions: %v", err)
 	}

--- a/pkg/block/local/fs/backpressure_test.go
+++ b/pkg/block/local/fs/backpressure_test.go
@@ -37,7 +37,7 @@ func newBackpressureStore(t *testing.T, maxDisk int64) (*FSStore, *memory.Memory
 	t.Helper()
 	dir := t.TempDir()
 	mds := memory.NewMemoryMetadataStoreWithDefaults()
-	bc, err := NewWithOptions(dir, maxDisk, 256*1024*1024, mds, FSStoreOptions{
+	bc, err := NewWithOptions(dir, maxDisk, mds, FSStoreOptions{
 		SyncedHashStore: mds,
 	})
 	if err != nil {

--- a/pkg/block/local/fs/compaction_test.go
+++ b/pkg/block/local/fs/compaction_test.go
@@ -207,7 +207,7 @@ func TestCompaction_RecoveryRebuildsAfterCompact(t *testing.T) {
 		t.Fatalf("compaction did not trim log: size=%d cumulative writes=%d",
 			preReopenSize, phase1Bytes)
 	}
-	bc2, err := NewWithOptions(baseDir, 1<<30, 1<<30, nopFBS{}, opts)
+	bc2, err := NewWithOptions(baseDir, 1<<30, nopFBS{}, opts)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
@@ -364,7 +364,7 @@ func TestCompaction_StaleTempCleanedUpOnRecovery(t *testing.T) {
 	}
 
 	// Reopen and run recovery.
-	bc2, err := NewWithOptions(baseDir, 1<<30, 1<<30, nopFBS{}, FSStoreOptions{
+	bc2, err := NewWithOptions(baseDir, 1<<30, nopFBS{}, FSStoreOptions{
 		MaxLogBytes:     1 << 20,
 		RollupWorkers:   2,
 		StabilizationMS: 10,

--- a/pkg/block/local/fs/delete_truncate_test.go
+++ b/pkg/block/local/fs/delete_truncate_test.go
@@ -308,7 +308,7 @@ func TestDelete_CrashBetweenMetadataAndUnlink_OrphanSwept(t *testing.T) {
 
 	// First, create an FSStore with append-log on, write one record so
 	// a log file exists, then close.
-	bc1, err := NewWithOptions(dir, 1<<30, 1<<30, nopFBS{}, FSStoreOptions{
+	bc1, err := NewWithOptions(dir, 1<<30, nopFBS{}, FSStoreOptions{
 		MaxLogBytes:            1 << 30,
 		RollupWorkers:          2,
 		StabilizationMS:        10,
@@ -336,7 +336,7 @@ func TestDelete_CrashBetweenMetadataAndUnlink_OrphanSwept(t *testing.T) {
 	// Crash-recovery pass on a fresh FSStore with the same RollupStore.
 	// rs has no entry for "crashed" (metadata step never committed) and
 	// nopFBS has no block-0 entry — so it qualifies as orphan.
-	bc2, err := NewWithOptions(dir, 1<<30, 1<<30, nopFBS{}, FSStoreOptions{
+	bc2, err := NewWithOptions(dir, 1<<30, nopFBS{}, FSStoreOptions{
 		MaxLogBytes:            1 << 30,
 		RollupWorkers:          2,
 		StabilizationMS:        10,

--- a/pkg/block/local/fs/drain_reset_testhelpers_test.go
+++ b/pkg/block/local/fs/drain_reset_testhelpers_test.go
@@ -103,7 +103,7 @@ func newFSStoreForTestWithFBS(t *testing.T, fbs block.EngineFileBlockStore, opts
 	if err != nil {
 		t.Fatalf("MkdirTemp: %v", err)
 	}
-	bc, err := NewWithOptions(dir, 1<<30, 1<<30, fbs, opts)
+	bc, err := NewWithOptions(dir, 1<<30, fbs, opts)
 	if err != nil {
 		_ = os.RemoveAll(dir)
 		t.Fatalf("NewWithOptions: %v", err)

--- a/pkg/block/local/fs/eviction_lsl08_conformance_test.go
+++ b/pkg/block/local/fs/eviction_lsl08_conformance_test.go
@@ -41,7 +41,7 @@ func lsl08Factory(t *testing.T) *fs.FSStore {
 	dir := t.TempDir()
 	mds := memmeta.NewMemoryMetadataStoreWithDefaults()
 	spy := &countingFBSWrapper{inner: mds}
-	bc, err := fs.NewWithOptions(dir, 600, 1<<30, spy, fs.FSStoreOptions{})
+	bc, err := fs.NewWithOptions(dir, 600, spy, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("NewWithOptions: %v", err)
 	}

--- a/pkg/block/local/fs/eviction_test.go
+++ b/pkg/block/local/fs/eviction_test.go
@@ -19,7 +19,7 @@ func newTestCacheWithDiskLimit(t *testing.T, maxDisk int64) *FSStore {
 	t.Helper()
 	dir := t.TempDir()
 	blockStore := memory.NewMemoryMetadataStoreWithDefaults()
-	bc, err := NewWithOptions(dir, maxDisk, 256*1024*1024, blockStore, FSStoreOptions{})
+	bc, err := NewWithOptions(dir, maxDisk, blockStore, FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("failed to create local store: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestLSL08_NoFileBlockStoreCallsDuringEviction(t *testing.T) {
 	dir := t.TempDir()
 	inner := memory.NewMemoryMetadataStoreWithDefaults()
 	spy := newCountingFileBlockStore(inner)
-	bc, err := NewWithOptions(dir, 1500, 256*1024*1024, spy, FSStoreOptions{})
+	bc, err := NewWithOptions(dir, 1500, spy, FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -194,7 +194,7 @@ func TestLSL08_LRUSeededOnStartup(t *testing.T) {
 	mds := memory.NewMemoryMetadataStoreWithDefaults()
 
 	// Create a first store, store a chunk, close.
-	bc1, err := NewWithOptions(dir, 1<<30, 256*1024*1024, mds, FSStoreOptions{})
+	bc1, err := NewWithOptions(dir, 1<<30, mds, FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("New 1: %v", err)
 	}
@@ -202,7 +202,7 @@ func TestLSL08_LRUSeededOnStartup(t *testing.T) {
 	_ = bc1.Close()
 
 	// Reopen: New() should seed the LRU from disk so hPersist is evictable.
-	bc2, err := NewWithOptions(dir, 600, 256*1024*1024, mds, FSStoreOptions{})
+	bc2, err := NewWithOptions(dir, 600, mds, FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("New 2: %v", err)
 	}

--- a/pkg/block/local/fs/eviction_unsynced_protection_test.go
+++ b/pkg/block/local/fs/eviction_unsynced_protection_test.go
@@ -21,7 +21,7 @@ func newCacheWithSyncedStore(t *testing.T, maxDisk int64) (*FSStore, *memory.Mem
 	t.Helper()
 	dir := t.TempDir()
 	mds := memory.NewMemoryMetadataStoreWithDefaults()
-	bc, err := NewWithOptions(dir, maxDisk, 256*1024*1024, mds, FSStoreOptions{
+	bc, err := NewWithOptions(dir, maxDisk, mds, FSStoreOptions{
 		SyncedHashStore: mds,
 	})
 	if err != nil {
@@ -164,7 +164,7 @@ func (s *slowSyncedHashStore) DeleteSynced(ctx context.Context, h block.ContentH
 func TestLRU_EvictTouchRace(t *testing.T) {
 	dir := t.TempDir()
 	mds := memory.NewMemoryMetadataStoreWithDefaults()
-	bc, err := NewWithOptions(dir, 1<<30, 256*1024*1024, mds, FSStoreOptions{
+	bc, err := NewWithOptions(dir, 1<<30, mds, FSStoreOptions{
 		SyncedHashStore: &slowSyncedHashStore{inner: mds, delay: 200 * time.Microsecond},
 	})
 	if err != nil {

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -147,9 +147,8 @@ type ObjectIDPersister func(ctx context.Context, payloadID string, blocks []bloc
 // In flushBlock, the map entry is deleted while holding mb.mu to prevent a race
 // where a concurrent writer gets a stale memBlock with nil data.
 type FSStore struct {
-	baseDir   string
-	maxDisk   int64
-	maxMemory int64
+	baseDir string
+	maxDisk int64
 	// the local store is one of the engine-
 	// internal callers that still uses the wider EngineFileBlockStore
 	// surface (GetFileBlock, ListFileBlocks) on top of the narrowed
@@ -468,7 +467,7 @@ type FSStore struct {
 //   - sentinel PRESENT, .blk files PRESENT  → success (sentinel is ground truth)
 //   - sentinel MISSING, no .blk files       → success (fresh install)
 //   - sentinel MISSING, .blk files PRESENT  → block.ErrLegacyLayoutDetected
-func newFSStore(baseDir string, maxDisk, maxMemory int64, fileBlockStore block.EngineFileBlockStore, opts FSStoreOptions, skipSentinelCheck bool) (*FSStore, error) {
+func newFSStore(baseDir string, maxDisk int64, fileBlockStore block.EngineFileBlockStore, opts FSStoreOptions, skipSentinelCheck bool) (*FSStore, error) {
 	if !skipSentinelCheck {
 		if err := checkLegacyLayoutSentinel(baseDir); err != nil {
 			return nil, err
@@ -478,15 +477,10 @@ func newFSStore(baseDir string, maxDisk, maxMemory int64, fileBlockStore block.E
 		return nil, fmt.Errorf("local store: create base dir: %w", err)
 	}
 
-	if maxMemory <= 0 {
-		maxMemory = 256 * 1024 * 1024 // 256MB default
-	}
-
 	defaultRetention := &retentionConfig{policy: block.RetentionLRU}
 	bc := &FSStore{
 		baseDir:       baseDir,
 		maxDisk:       maxDisk,
-		maxMemory:     maxMemory,
 		blockStore:    fileBlockStore,
 		memBlocks:     make(map[blockKey]*memBlock),
 		fileBlocks:    make(map[string]map[uint64]*memBlock),
@@ -975,7 +969,6 @@ type FSStoreOptions struct {
 // Parameters:
 //   - baseDir: directory for .blk block files, created if absent.
 //   - maxDisk: maximum total size of on-disk .blk files in bytes. 0 = unlimited.
-//   - maxMemory: memory budget for dirty write buffers in bytes. 0 defaults to 256MB.
 //   - fileBlockStore: persistent store for FileBlock metadata
 //     (local path, upload state, etc.).
 //   - opts: tunables for append-log sizing, rollup pool, dedup LRU,
@@ -985,8 +978,8 @@ type FSStoreOptions struct {
 // Runs the legacy-layout sentinel gate; returns
 // block.ErrLegacyLayoutDetected when the share holds the pre-CAS
 // `.blk` layout without a `.cas-migrated-v1` marker.
-func NewWithOptions(baseDir string, maxDisk, maxMemory int64, fileBlockStore block.EngineFileBlockStore, opts FSStoreOptions) (*FSStore, error) {
-	return newFSStore(baseDir, maxDisk, maxMemory, fileBlockStore, opts, false)
+func NewWithOptions(baseDir string, maxDisk int64, fileBlockStore block.EngineFileBlockStore, opts FSStoreOptions) (*FSStore, error) {
+	return newFSStore(baseDir, maxDisk, fileBlockStore, opts, false)
 }
 
 // NewFSStoreForMigration constructs an FSStore that skips the legacy-
@@ -1001,8 +994,8 @@ func NewWithOptions(baseDir string, maxDisk, maxMemory int64, fileBlockStore blo
 // the gate would otherwise refuse the open.
 //
 // Behavior is otherwise identical to NewWithOptions.
-func NewFSStoreForMigration(baseDir string, maxDisk, maxMemory int64, fileBlockStore block.EngineFileBlockStore, opts FSStoreOptions) (*FSStore, error) {
-	return newFSStore(baseDir, maxDisk, maxMemory, fileBlockStore, opts, true)
+func NewFSStoreForMigration(baseDir string, maxDisk int64, fileBlockStore block.EngineFileBlockStore, opts FSStoreOptions) (*FSStore, error) {
+	return newFSStore(baseDir, maxDisk, fileBlockStore, opts, true)
 }
 
 // SetObjectIDPersister installs the rollup-completion callback. Safe to
@@ -1227,7 +1220,6 @@ func (bc *FSStore) Stats() local.Stats {
 		DiskUsed:      bc.diskUsed.Load(),
 		MaxDisk:       bc.maxDisk,
 		MemUsed:       bc.memUsed.Load(),
-		MaxMemory:     bc.maxMemory,
 		FileCount:     fileCount,
 		MemBlockCount: memBlockCount,
 	}

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -1219,11 +1219,19 @@ func (bc *FSStore) Stats() local.Stats {
 	return local.Stats{
 		DiskUsed:      bc.diskUsed.Load(),
 		MaxDisk:       bc.maxDisk,
+		MaxLogBytes:   bc.maxLogBytes,
 		MemUsed:       bc.memUsed.Load(),
 		FileCount:     fileCount,
 		MemBlockCount: memBlockCount,
 	}
 }
+
+// MaxLogBytes returns the effective append-log pressure budget in bytes
+// (the resolved max_log_bytes: per-store > global > deduced default).
+// AppendWrite blocks once logBytesTotal exceeds this ceiling and ultimately
+// returns block.ErrPressureTimeout if the rollup cannot drain in time. The
+// value is immutable after construction, so it is read without a lock.
+func (bc *FSStore) MaxLogBytes() int64 { return bc.maxLogBytes }
 
 // updateFileSize updates the tracked file size if the new end offset is larger.
 // Uses double-checked locking: RLock fast path for existing files, Lock for creation.

--- a/pkg/block/local/fs/fs_conformance_test.go
+++ b/pkg/block/local/fs/fs_conformance_test.go
@@ -19,7 +19,7 @@ func newFSStoreForConformance(t *testing.T) *fs.FSStore {
 	t.Helper()
 	dir := t.TempDir()
 	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
-	bc, err := fs.NewWithOptions(dir, 1<<30, 1<<30, nil, fs.FSStoreOptions{
+	bc, err := fs.NewWithOptions(dir, 1<<30, nil, fs.FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 50,

--- a/pkg/block/local/fs/fs_test.go
+++ b/pkg/block/local/fs/fs_test.go
@@ -193,7 +193,7 @@ func TestFSStoreStartCloseNoGoroutineLeak(t *testing.T) {
 	for i := 0; i < cycles; i++ {
 		dir := t.TempDir()
 		blockStore := memory.NewMemoryMetadataStoreWithDefaults()
-		bc, err := NewWithOptions(dir, 0, 256*1024*1024, blockStore, FSStoreOptions{})
+		bc, err := NewWithOptions(dir, 0, blockStore, FSStoreOptions{})
 		if err != nil {
 			t.Fatalf("cycle %d: New failed: %v", i, err)
 		}
@@ -247,7 +247,7 @@ func TestNewFSStore_SentinelDetection(t *testing.T) {
 				writeLegacyBlkForTest(t, shareDir)
 			}
 			mds := memory.NewMemoryMetadataStoreWithDefaults()
-			bc, err := NewWithOptions(shareDir, 0, 256*1024*1024, mds, FSStoreOptions{})
+			bc, err := NewWithOptions(shareDir, 0, mds, FSStoreOptions{})
 			if tc.wantLegacy {
 				if err == nil {
 					_ = bc.Close()
@@ -287,7 +287,7 @@ func TestNewFSStore_DeepBlkFile(t *testing.T) {
 			t.Fatalf("write blk: %v", err)
 		}
 		mds := memory.NewMemoryMetadataStoreWithDefaults()
-		_, err := NewWithOptions(shareDir, 0, 256*1024*1024, mds, FSStoreOptions{})
+		_, err := NewWithOptions(shareDir, 0, mds, FSStoreOptions{})
 		if !errors.Is(err, block.ErrLegacyLayoutDetected) {
 			t.Fatalf("expected ErrLegacyLayoutDetected at legacy depth; got %v", err)
 		}
@@ -306,7 +306,7 @@ func TestNewFSStore_DeepBlkFile(t *testing.T) {
 			t.Fatalf("write blk: %v", err)
 		}
 		mds := memory.NewMemoryMetadataStoreWithDefaults()
-		bc, err := NewWithOptions(shareDir, 0, 256*1024*1024, mds, FSStoreOptions{})
+		bc, err := NewWithOptions(shareDir, 0, mds, FSStoreOptions{})
 		if err != nil {
 			t.Fatalf("expected success (depth>3 .blk not detected); got %v", err)
 		}
@@ -324,11 +324,11 @@ func TestNewFSStoreForMigration_BypassesSentinel(t *testing.T) {
 
 	// Confirm the production constructor refuses, so we know the
 	// bypass is actually being exercised by the next call.
-	if _, err := NewWithOptions(shareDir, 0, 256*1024*1024, memory.NewMemoryMetadataStoreWithDefaults(), FSStoreOptions{}); !errors.Is(err, block.ErrLegacyLayoutDetected) {
+	if _, err := NewWithOptions(shareDir, 0, memory.NewMemoryMetadataStoreWithDefaults(), FSStoreOptions{}); !errors.Is(err, block.ErrLegacyLayoutDetected) {
 		t.Fatalf("precondition: NewWithOptions should refuse legacy layout; got %v", err)
 	}
 
-	bc, err := NewFSStoreForMigration(shareDir, 0, 256*1024*1024,
+	bc, err := NewFSStoreForMigration(shareDir, 0,
 		memory.NewMemoryMetadataStoreWithDefaults(), FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("NewFSStoreForMigration: expected success on legacy layout; got %v", err)

--- a/pkg/block/local/fs/healthcheck_test.go
+++ b/pkg/block/local/fs/healthcheck_test.go
@@ -15,7 +15,7 @@ import (
 func newTestStore(t *testing.T) *FSStore {
 	t.Helper()
 	dir := t.TempDir()
-	bs, err := NewWithOptions(dir, 0, 0, nil, FSStoreOptions{})
+	bs, err := NewWithOptions(dir, 0, nil, FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("NewWithDefaults: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestFSStore_Healthcheck_UnhealthyAfterClose(t *testing.T) {
 
 func TestFSStore_Healthcheck_UnhealthyWhenBaseDirRemoved(t *testing.T) {
 	dir := t.TempDir()
-	bs, err := NewWithOptions(dir, 0, 0, nil, FSStoreOptions{})
+	bs, err := NewWithOptions(dir, 0, nil, FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("NewWithDefaults: %v", err)
 	}

--- a/pkg/block/local/fs/recovery_test.go
+++ b/pkg/block/local/fs/recovery_test.go
@@ -68,7 +68,7 @@ func reopenFSStore(t *testing.T, bc *FSStore, rs *memmeta.MemoryMetadataStore) *
 	t.Helper()
 	baseDir := bc.baseDir
 	_ = bc.Close()
-	bc2, err := NewWithOptions(baseDir, 1<<30, 1<<30, nopFBS{}, FSStoreOptions{
+	bc2, err := NewWithOptions(baseDir, 1<<30, nopFBS{}, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 10,
@@ -87,7 +87,7 @@ func reopenFSStore(t *testing.T, bc *FSStore, rs *memmeta.MemoryMetadataStore) *
 func newFSStoreWithRS(t *testing.T, rs *memmeta.MemoryMetadataStore) *FSStore {
 	t.Helper()
 	dir := t.TempDir()
-	bc, err := NewWithOptions(dir, 1<<30, 1<<30, nopFBS{}, FSStoreOptions{
+	bc, err := NewWithOptions(dir, 1<<30, nopFBS{}, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 10,
@@ -263,7 +263,7 @@ func TestRecovery_FreshLogNotSwept(t *testing.T) {
 func TestRecovery_OrphanSweep_UnlinksLog(t *testing.T) {
 	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
 	dir := t.TempDir()
-	bc, err := NewWithOptions(dir, 1<<30, 1<<30, nopFBS{}, FSStoreOptions{
+	bc, err := NewWithOptions(dir, 1<<30, nopFBS{}, FSStoreOptions{
 		MaxLogBytes:            1 << 30,
 		RollupWorkers:          2,
 		StabilizationMS:        10,
@@ -281,7 +281,7 @@ func TestRecovery_OrphanSweep_UnlinksLog(t *testing.T) {
 	// Wait out the configured 1s age gate.
 	time.Sleep(1100 * time.Millisecond)
 
-	bc2, err := NewWithOptions(dir, 1<<30, 1<<30, nopFBS{}, FSStoreOptions{
+	bc2, err := NewWithOptions(dir, 1<<30, nopFBS{}, FSStoreOptions{
 		MaxLogBytes:            1 << 30,
 		RollupWorkers:          2,
 		StabilizationMS:        10,
@@ -514,7 +514,7 @@ func TestRecovery_OrphanAgeFloor_WarnsOnNonPositive(t *testing.T) {
 
 	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
 	dir := t.TempDir()
-	bc, err := NewWithOptions(dir, 1<<30, 1<<30, nopFBS{}, FSStoreOptions{
+	bc, err := NewWithOptions(dir, 1<<30, nopFBS{}, FSStoreOptions{
 		MaxLogBytes:            1 << 30,
 		RollupWorkers:          2,
 		StabilizationMS:        10,
@@ -539,7 +539,7 @@ func TestRecovery_OrphanAgeFloor_WarnsOnNonPositive(t *testing.T) {
 	}
 	_ = bc.Close()
 
-	bc2, err := NewWithOptions(dir, 1<<30, 1<<30, nopFBS{}, FSStoreOptions{
+	bc2, err := NewWithOptions(dir, 1<<30, nopFBS{}, FSStoreOptions{
 		MaxLogBytes:            1 << 30,
 		RollupWorkers:          2,
 		StabilizationMS:        10,

--- a/pkg/block/local/fs/rollup_idempotent_dedup_bench_test.go
+++ b/pkg/block/local/fs/rollup_idempotent_dedup_bench_test.go
@@ -45,7 +45,7 @@ func newBenchFSStoreWithLRU(tb testing.TB) (*FSStore, *programmableFBS, *memmeta
 	mem := memmeta.NewMemoryMetadataStoreWithDefaults()
 	wrapped := newProgrammableFBS(mem)
 	dir := tb.TempDir()
-	bc, err := NewWithOptions(dir, 1<<30, 1<<30, wrapped, FSStoreOptions{
+	bc, err := NewWithOptions(dir, 1<<30, wrapped, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 1,

--- a/pkg/block/local/fs/rollup_test.go
+++ b/pkg/block/local/fs/rollup_test.go
@@ -666,7 +666,7 @@ func newFSStoreForRollupLRUTest(t *testing.T) (*FSStore, *programmableFBS, *memm
 	mem := memmeta.NewMemoryMetadataStoreWithDefaults()
 	wrapped := newProgrammableFBS(mem)
 	dir := t.TempDir()
-	bc, err := NewWithOptions(dir, 1<<30, 1<<30, wrapped, FSStoreOptions{
+	bc, err := NewWithOptions(dir, 1<<30, wrapped, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 1,

--- a/pkg/block/local/fs/test_hooks.go
+++ b/pkg/block/local/fs/test_hooks.go
@@ -128,7 +128,7 @@ func (bc *FSStore) ForceRollupForTest(ctx context.Context, payloadID string) err
 // metadata. Caller MUST have Close()'d any prior FSStore on the same
 // directory first (concurrent opens race on the log fds).
 func ReopenForTest(baseDir string, rs metadata.RollupStore) (*FSStore, error) {
-	bc, err := NewWithOptions(baseDir, 1<<30, 1<<30, nopFBSForTest{}, FSStoreOptions{
+	bc, err := NewWithOptions(baseDir, 1<<30, nopFBSForTest{}, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 50,

--- a/pkg/block/local/local.go
+++ b/pkg/block/local/local.go
@@ -14,7 +14,6 @@ type Stats struct {
 	DiskUsed      int64 // Current total size of on-disk block data in bytes
 	MaxDisk       int64 // Configured maximum disk size (0 = unlimited)
 	MemUsed       int64 // Current in-memory dirty buffer usage in bytes
-	MaxMemory     int64 // Configured memory budget for dirty buffers
 	FileCount     int   // Number of files with local data
 	MemBlockCount int   // Number of in-memory dirty blocks
 }

--- a/pkg/block/local/local.go
+++ b/pkg/block/local/local.go
@@ -13,6 +13,7 @@ import (
 type Stats struct {
 	DiskUsed      int64 // Current total size of on-disk block data in bytes
 	MaxDisk       int64 // Configured maximum disk size (0 = unlimited)
+	MaxLogBytes   int64 // Append-log pressure budget in bytes (max_log_bytes)
 	MemUsed       int64 // Current in-memory dirty buffer usage in bytes
 	FileCount     int   // Number of files with local data
 	MemBlockCount int   // Number of in-memory dirty blocks

--- a/pkg/config/blockstore.go
+++ b/pkg/config/blockstore.go
@@ -50,6 +50,16 @@ type BlockstoreLocalConfig struct {
 	// still unsynced. Default 60s when zero. Distinct from the internal LRU
 	// evict wait.
 	BackpressureMaxWait time.Duration `mapstructure:"backpressure_max_wait" yaml:"backpressure_max_wait"`
+
+	// MaxLogBytes is the per-share append-log pressure budget in bytes: the
+	// on-disk append log buffers freshly-written bytes before the async
+	// rollup folds them into CAS chunks, and AppendWrite stalls
+	// (ErrPressureTimeout) once the buffered total exceeds this budget. This
+	// is THE append-log backpressure lever. 0 means "use the system-deduced
+	// default" (DeduceDefaults: 25% of RAM, floor 1 GiB). A per-share block
+	// store config `max_log_bytes` overrides this global default for that
+	// share; this global default in turn overrides the deduced default.
+	MaxLogBytes uint64 `mapstructure:"max_log_bytes" yaml:"max_log_bytes"`
 }
 
 // ApplyDefaults fills any zero-valued field with the defaults.
@@ -72,10 +82,11 @@ func (c *BlockstoreLocalConfig) Validate() error {
 	if c.DedupLRUSize <= 0 {
 		return fmt.Errorf("blockstore.local.dedup_lru_size must be > 0 (got %d)", c.DedupLRUSize)
 	}
-	// DefaultRemoteCacheSize and BackpressureMaxWait treat zero as "apply
-	// the built-in default" (filled by ApplyDefaults), so Validate only
-	// rejects an explicitly negative backpressure wait — the one
-	// nonsensical value a duration can take.
+	// DefaultRemoteCacheSize, MaxLogBytes, and BackpressureMaxWait treat zero
+	// as "apply the built-in (or system-deduced) default", so Validate only
+	// rejects an explicitly negative backpressure wait — the one nonsensical
+	// value a duration can take. MaxLogBytes is uint64 and so cannot be
+	// negative; any positive value is honored as an explicit override.
 	if c.BackpressureMaxWait < 0 {
 		return fmt.Errorf("blockstore.local.backpressure_max_wait must be >= 0 (got %s)", c.BackpressureMaxWait)
 	}

--- a/pkg/config/blockstore_test.go
+++ b/pkg/config/blockstore_test.go
@@ -119,3 +119,65 @@ func TestConfig_YAMLRoundTrip_BlockstoreLocalDedupLRUSize(t *testing.T) {
 		t.Fatalf("YAML round-trip: got %d, want 2048", cfg.Blockstore.Local.DedupLRUSize)
 	}
 }
+
+// max_log_bytes is the append-log pressure budget. Zero means "use the
+// system-deduced default" (resolved at the runtime layer, since it depends on
+// system memory), so ApplyDefaults must NOT rewrite a zero value, Validate must
+// accept zero and any positive value, and the key must round-trip through YAML
+// and the DITTOFS_* reflective env binding.
+
+func TestBlockstoreLocalConfig_ApplyDefaults_LeavesMaxLogBytesZero(t *testing.T) {
+	c := BlockstoreLocalConfig{}
+	c.ApplyDefaults()
+	if c.MaxLogBytes != 0 {
+		t.Fatalf("MaxLogBytes: got %d, want 0 (zero defers to system-deduced default)", c.MaxLogBytes)
+	}
+}
+
+func TestBlockstoreLocalConfig_ApplyDefaults_PreservesMaxLogBytes(t *testing.T) {
+	c := BlockstoreLocalConfig{MaxLogBytes: 2 << 30}
+	c.ApplyDefaults()
+	if c.MaxLogBytes != 2<<30 {
+		t.Fatalf("MaxLogBytes: got %d, want %d (2 GiB) preserved", c.MaxLogBytes, 2<<30)
+	}
+}
+
+func TestBlockstoreLocalConfig_Validate_AcceptsMaxLogBytes(t *testing.T) {
+	// Zero (defer to default) and a positive override must both validate.
+	for _, v := range []uint64{0, 1 << 30, 8 << 30} {
+		c := BlockstoreLocalConfig{DedupLRUSize: 1024, MaxLogBytes: v}
+		if err := c.Validate(); err != nil {
+			t.Fatalf("Validate() with max_log_bytes=%d: got %v, want nil", v, err)
+		}
+	}
+}
+
+func TestConfig_YAMLRoundTrip_BlockstoreLocalMaxLogBytes(t *testing.T) {
+	yamlBody := []byte("blockstore:\n  local:\n    max_log_bytes: 3221225472\n") // 3 GiB
+	var cfg Config
+	if err := yaml.Unmarshal(yamlBody, &cfg); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if cfg.Blockstore.Local.MaxLogBytes != 3<<30 {
+		t.Fatalf("YAML round-trip: got %d, want %d (3 GiB)", cfg.Blockstore.Local.MaxLogBytes, 3<<30)
+	}
+}
+
+func TestLoad_BlockstoreLocalMaxLogBytesFromEnv(t *testing.T) {
+	content := `
+controlplane:
+  jwt:
+    secret: "test-secret-key-for-testing-minimum-32-chars"
+`
+	path := writeConfigFile(t, content)
+
+	t.Setenv("DITTOFS_BLOCKSTORE_LOCAL_MAX_LOG_BYTES", "4294967296") // 4 GiB
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Blockstore.Local.MaxLogBytes != 4<<30 {
+		t.Fatalf("max_log_bytes from env: got %d, want %d (4 GiB)", cfg.Blockstore.Local.MaxLogBytes, 4<<30)
+	}
+}

--- a/pkg/controlplane/runtime/metrics.go
+++ b/pkg/controlplane/runtime/metrics.go
@@ -31,6 +31,7 @@ func (r *Runtime) MetricsSnapshot(ctx context.Context) metrics.Snapshot {
 			DiskMaxBytes:        st.LocalDiskMax,
 			MemUsedBytes:        st.LocalMemUsed,
 			MemMaxBytes:         st.LocalMemMax,
+			AppendLogLimitBytes: st.AppendLogLimitBytes,
 			UnsyncedBytes:       st.UnsyncedBytes,
 			PendingUploads:      int64(st.PendingUploads),
 			CompletedSyncs:      int64(st.CompletedSyncs),

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1814,6 +1814,7 @@ func addBlockStoreStats(dst *engine.BlockStoreStats, src engine.BlockStoreStats)
 	dst.LocalDiskMax += src.LocalDiskMax
 	dst.LocalMemUsed += src.LocalMemUsed
 	dst.LocalMemMax += src.LocalMemMax
+	dst.AppendLogLimitBytes += src.AppendLogLimitBytes
 	dst.ReadBufferEntries += src.ReadBufferEntries
 	dst.ReadBufferUsed += src.ReadBufferUsed
 	dst.ReadBufferMax += src.ReadBufferMax

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -274,11 +274,19 @@ type ShareStore interface {
 
 // LocalStoreDefaults holds default sizing for per-share local stores.
 type LocalStoreDefaults struct {
-	MaxSize   uint64 // Maximum local store size per share (0 = unlimited)
-	MaxMemory int64  // Memory budget for dirty buffers per share (0 = 256MB)
+	MaxSize uint64 // Maximum local store size per share (0 = unlimited)
 
 	// ReadBufferBytes is the per-share read buffer budget in bytes (0 = disabled).
 	ReadBufferBytes int64
+
+	// MaxLogBytes is the effective append-log pressure budget (bytes) applied
+	// to a share when its per-share block store config does NOT carry an
+	// explicit `max_log_bytes`. It resolves the global config
+	// blockstore.local.max_log_bytes (when set) or, failing that, the
+	// system-deduced default (DeduceDefaults.MaxLogBytes). 0 leaves the
+	// FSStore's own internal default in force. Precedence at the share level
+	// is: per-store config["max_log_bytes"] > this global/deduced default.
+	MaxLogBytes int64
 
 	// DedupLRUSize is the slot count for the in-memory hash dedup LRU; the
 	// per-share block-store JSON config `dedup_lru_size` takes precedence
@@ -1956,10 +1964,8 @@ func CreateLocalStoreFromConfig(
 	}
 
 	var maxDisk int64
-	var maxMemory int64
 	if defaults != nil {
 		maxDisk = int64(defaults.MaxSize)
-		maxMemory = defaults.MaxMemory
 	}
 
 	// Remote-cache backpressure window (how long a write stalls for the
@@ -1985,6 +1991,14 @@ func CreateLocalStoreFromConfig(
 	// are warned and ignored.
 	var fsOpts fs.FSStoreOptions
 	fsOpts.BackpressureMaxWait = backpressureMaxWait
+	// Append-log pressure budget default. Precedence (lowest first):
+	// FSStore internal default < global/deduced default (plumbed via
+	// LocalStoreDefaults.MaxLogBytes) < per-store config["max_log_bytes"].
+	// Seed fsOpts.MaxLogBytes from the global/deduced default here; the
+	// per-store config branch below overrides it when present.
+	if defaults != nil && defaults.MaxLogBytes > 0 {
+		fsOpts.MaxLogBytes = defaults.MaxLogBytes
+	}
 	if _, ok := config["use_append_log"]; ok {
 		logger.Warn("block store config has use_append_log: append is mandatory in v0.16+, flag is ignored")
 	}
@@ -2098,7 +2112,7 @@ func CreateLocalStoreFromConfig(
 		if shs, ok := fileBlockStore.(metadata.SyncedHashStore); ok {
 			fsOpts.SyncedHashStore = shs
 		}
-		store, err := fs.NewWithOptions(shareDir, maxDisk, maxMemory, fileBlockStore, fsOpts)
+		store, err := fs.NewWithOptions(shareDir, maxDisk, fileBlockStore, fsOpts)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/metrics/collectors.go
+++ b/pkg/metrics/collectors.go
@@ -17,10 +17,11 @@ type runtimeCollector struct {
 	p Provider
 
 	// Per-share capacity.
-	diskUsed *prometheus.Desc
-	diskMax  *prometheus.Desc
-	memUsed  *prometheus.Desc
-	memMax   *prometheus.Desc
+	diskUsed       *prometheus.Desc
+	diskMax        *prometheus.Desc
+	memUsed        *prometheus.Desc
+	memMax         *prometheus.Desc
+	appendLogLimit *prometheus.Desc
 
 	// Per-share durability / sync.
 	syncPendingBytes   *prometheus.Desc
@@ -59,10 +60,11 @@ func newRuntimeCollector(p Provider) *runtimeCollector {
 	return &runtimeCollector{
 		p: p,
 
-		diskUsed: d(fqdn("localstore", "disk_used_bytes"), "Local block-store disk bytes in use.", share),
-		diskMax:  d(fqdn("localstore", "disk_limit_bytes"), "Local block-store disk byte ceiling (0 = unbounded).", share),
-		memUsed:  d(fqdn("localstore", "memory_used_bytes"), "Local block-store in-memory buffer bytes in use.", share),
-		memMax:   d(fqdn("localstore", "memory_limit_bytes"), "Local block-store in-memory buffer byte ceiling (0 = unbounded).", share),
+		diskUsed:       d(fqdn("localstore", "disk_used_bytes"), "Local block-store disk bytes in use.", share),
+		diskMax:        d(fqdn("localstore", "disk_limit_bytes"), "Local block-store disk byte ceiling (0 = unbounded).", share),
+		memUsed:        d(fqdn("localstore", "memory_used_bytes"), "Local block-store in-memory buffer bytes in use.", share),
+		memMax:         d(fqdn("localstore", "memory_limit_bytes"), "Deprecated: always 0; the in-memory budget was removed. See dittofs_localstore_append_log_limit_bytes.", share),
+		appendLogLimit: d(fqdn("localstore", "append_log_limit_bytes"), "Local block-store append-log pressure budget in bytes (max_log_bytes); writes block with ErrPressureTimeout above this.", share),
 
 		syncPendingBytes:   d(fqdn("sync", "pending_bytes"), "On-disk bytes present locally but not yet mirrored to the remote (data at risk).", share),
 		syncPendingUploads: d(fqdn("sync", "pending_uploads"), "Uploads currently queued to the remote.", share),
@@ -97,7 +99,7 @@ func (c *runtimeCollector) Describe(ch chan<- *prometheus.Desc) {
 
 func (c *runtimeCollector) allDescs() []*prometheus.Desc {
 	return []*prometheus.Desc{
-		c.diskUsed, c.diskMax, c.memUsed, c.memMax,
+		c.diskUsed, c.diskMax, c.memUsed, c.memMax, c.appendLogLimit,
 		c.syncPendingBytes, c.syncPendingUploads, c.syncUploadsTotal, c.syncFailuresTotal,
 		c.remoteUp, c.remoteOutage, c.remoteReadsBlocked,
 		c.logicalBytes, c.storeFiles,
@@ -125,6 +127,7 @@ func (c *runtimeCollector) Collect(ch chan<- prometheus.Metric) {
 		gauge(c.diskMax, float64(s.DiskMaxBytes), s.Name)
 		gauge(c.memUsed, float64(s.MemUsedBytes), s.Name)
 		gauge(c.memMax, float64(s.MemMaxBytes), s.Name)
+		gauge(c.appendLogLimit, float64(s.AppendLogLimitBytes), s.Name)
 		gauge(c.logicalBytes, float64(s.LogicalBytes), s.Name)
 		gauge(c.storeFiles, float64(s.FileCount), s.Name)
 		gauge(c.snapshotsActive, float64(s.SnapshotsHeld), s.Name)

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -73,6 +73,31 @@ dittofs_client_connections_active{protocol="smb"} 1
 	}
 }
 
+// The append-log pressure budget (max_log_bytes) is exposed as a gauge, and the
+// removed in-memory budget gauge keeps emitting 0 for back-compat.
+func TestRuntimeCollector_AppendLogLimitGauge(t *testing.T) {
+	m := newTestMetrics(t, Snapshot{Shares: []ShareSnapshot{{
+		Name:                "alpha",
+		AppendLogLimitBytes: 1 << 30,
+		MemMaxBytes:         0,
+	}}})
+
+	expected := `
+# HELP dittofs_localstore_append_log_limit_bytes Local block-store append-log pressure budget in bytes (max_log_bytes); writes block with ErrPressureTimeout above this.
+# TYPE dittofs_localstore_append_log_limit_bytes gauge
+dittofs_localstore_append_log_limit_bytes{share="alpha"} 1.073741824e+09
+# HELP dittofs_localstore_memory_limit_bytes Deprecated: always 0; the in-memory budget was removed. See dittofs_localstore_append_log_limit_bytes.
+# TYPE dittofs_localstore_memory_limit_bytes gauge
+dittofs_localstore_memory_limit_bytes{share="alpha"} 0
+`
+	if err := testutil.GatherAndCompare(m.Registry(), strings.NewReader(expected),
+		"dittofs_localstore_append_log_limit_bytes",
+		"dittofs_localstore_memory_limit_bytes",
+	); err != nil {
+		t.Fatalf("unexpected metrics: %v", err)
+	}
+}
+
 // Sync/remote series must be suppressed for local-only shares (no remote).
 func TestRuntimeCollector_LocalOnlyShareSkipsSyncSeries(t *testing.T) {
 	m := newTestMetrics(t, Snapshot{Shares: []ShareSnapshot{{

--- a/pkg/metrics/snapshot.go
+++ b/pkg/metrics/snapshot.go
@@ -42,6 +42,9 @@ type ShareSnapshot struct {
 	DiskMaxBytes  int64
 	MemUsedBytes  int64
 	MemMaxBytes   int64
+	// AppendLogLimitBytes is the append-log pressure budget (max_log_bytes):
+	// the real write-pressure ceiling that replaced the inert MemMaxBytes knob.
+	AppendLogLimitBytes int64
 
 	// Durability / sync backlog.
 	UnsyncedBytes       int64


### PR DESCRIPTION
## Summary

`max_pending_size` (which fed FSStore `MaxMemory`) was **inert**: `bc.maxMemory`
was stored, defaulted, and reported in `Status()`, but never compared or
enforced anywhere — no backpressure, no eviction. The real append-log pressure
gate is **`max_log_bytes`**, which stalls `AppendWrite` (`ErrPressureTimeout`)
once the buffered append log exceeds the budget.

This PR pivots #1269 to expose the lever that actually works and rips out the
dead plumbing.

## Changes

**Removed the inert MaxMemory / MaxPendingSize plumbing end to end:**
- `fs.NewWithOptions` / `fs.NewFSStoreForMigration` / `newFSStore` lose the
  `maxMemory` positional parameter (every call site updated, incl. tests,
  benches, migration, and the `test_hooks.go` reopen helper).
- Dropped `DeducedDefaults.MaxPendingSize`, `LocalStoreDefaults.MaxMemory`,
  `local.Stats.MaxMemory`, the `FSStore.maxMemory` field/default/assignment,
  and the `dfs migrate-to-cas --max-memory` flag (CLI.md regenerated).
- `engine.BlockStoreStats.LocalMemMax` is kept for wire/JSON compatibility but
  is now always `0` (documented) — the FSStore no longer tracks a mem budget.

**Made `max_log_bytes` the configurable lever:**
- New global `blockstore.local.max_log_bytes` config field (mapstructure/yaml),
  auto-bound to `DITTOFS_BLOCKSTORE_LOCAL_MAX_LOG_BYTES` via the reflective
  config walk. `0` = use the deduced default.
- New **RAM-relative deduced default**: `DeduceDefaults.MaxLogBytes` = 25% of
  available memory with a **1 GiB floor** (the old hardcoded 1 GiB becomes the
  minimum on small machines; large-RAM hosts get a proportionally bigger
  budget). Basis documented in the code.
- Effective precedence wired through: **per-store `config["max_log_bytes"]` >
  global `blockstore.local.max_log_bytes` > deduced default**. The FSStore no
  longer hardcodes 1 GiB when `opts.MaxLogBytes == 0`; the global/deduced
  default is applied in `CreateLocalStoreFromConfig` unless the per-store key is
  present.

**Surfaces & docs:**
- `dfs config show --deduced` now prints the effective `max_log_bytes` (env-aware
  quiet `config.Load`, showing whether a global override applies) instead of
  `max_pending_size`.
- `docs/CONFIGURATION.md` documents the append-log pressure budget, the
  precedence, the per-store override
  (`dfsctl store block local edit … --config '{"max_log_bytes":…}'`), and the
  `DITTOFS_*` env var. `max_pending_size` is gone.

## Tests
- Deduction test reworked for `MaxLogBytes` (floor + non-floor cases) and the
  `HitFloors` count.
- Config layer: `ApplyDefaults` leaves zero, `Validate` accepts zero/positive,
  YAML round-trip, and `DITTOFS_BLOCKSTORE_LOCAL_MAX_LOG_BYTES` env round-trip.
- `go build ./...`, `go vet ./...`, `gofmt`, and `go test ./...` all green.

Closes #1269