### PR TITLE
fix(perms): enforce share permission as a ceiling, not a floor

### DIFF
--- a/internal/adapter/smb/handlers/auth_helper.go
+++ b/internal/adapter/smb/handlers/auth_helper.go
@@ -86,8 +86,9 @@ func BuildAuthContext(ctx *SMBHandlerContext) (*metadata.AuthContext, error) {
 	// (audit #1132).
 	setUnprivilegedIdentity(authCtx)
 
-	// Set share-level permission flags for guest/anonymous sessions
-	authCtx.ShareWritable = HasWritePermission(ctx)
+	// Share-level read-only ceiling for guest/anonymous sessions. A read-write
+	// tree connect grants nothing on its own; the file's ACL/POSIX decides. The
+	// share permission can only restrict, via ShareReadOnly.
 	authCtx.ShareReadOnly = ctx.Permission == models.PermissionRead
 
 	return authCtx, nil
@@ -140,9 +141,9 @@ func getUserIdentity(user *models.User) (uid, gid uint32) {
 // Falls back to defaults (1000/1000) if not configured.
 //
 // Share Permission:
-// ShareWritable is set based on the SMB context's share permission.
-// This allows users with share-level write permission to bypass file-level
-// Unix permission checks.
+// ShareReadOnly is set from the SMB tree-connect permission and acts as a
+// ceiling — a read-only share denies all writes regardless of the file ACL. A
+// read-write share grants nothing on its own; the file's ACL/POSIX decides.
 func BuildAuthContextFromUser(ctx *SMBHandlerContext, user *models.User) *metadata.AuthContext {
 	authCtx := &metadata.AuthContext{
 		Context:                ctx.Context,
@@ -172,9 +173,9 @@ func BuildAuthContextFromUser(ctx *SMBHandlerContext, user *models.User) *metada
 		)
 	}
 
-	// Set share-level permission flags
-	// ShareWritable allows bypassing file-level permission checks for write operations
-	authCtx.ShareWritable = HasWritePermission(ctx)
+	// Share-level read-only ceiling. A read-write tree connect grants nothing on
+	// its own; the file's ACL/POSIX decides. The share permission only restricts,
+	// via ShareReadOnly.
 	authCtx.ShareReadOnly = ctx.Permission == models.PermissionRead
 
 	return authCtx
@@ -348,7 +349,7 @@ func (h *Handler) buildOpenerAuthContext(ctx *SMBHandlerContext, openFile *OpenF
 	// nobody/nogroup identity, matching the BuildAuthContext User==nil arm.
 	// Never UID=0 — see nobodyUID for the root-bypass rationale.
 	setUnprivilegedIdentity(authCtx)
-	authCtx.ShareWritable = HasWritePermission(ctx)
+	// Read-only ceiling only; a read-write share grants nothing on its own.
 	authCtx.ShareReadOnly = ctx.Permission == models.PermissionRead
 	return authCtx
 }

--- a/pkg/metadata/auth_identity.go
+++ b/pkg/metadata/auth_identity.go
@@ -32,17 +32,13 @@ type AuthContext struct {
 	ClientAddr string
 
 	// ShareReadOnly indicates whether the user has read-only access to the share
-	// This is determined by share-level user permissions (identity.SharePermission)
-	// When true, all write operations to this share should be denied
+	// (the per-user share permission, identity.SharePermission). When true, all
+	// write operations to this share are denied. The share permission is a ceiling
+	// over the file's own ACL/POSIX rights: a read-only share restricts, while a
+	// read-write share grants nothing on its own — the file's ACL/POSIX decides.
+	// This matches the standard multiprotocol NAS model (Windows share ∧ NTFS,
+	// NetApp export Access_Type, NFS-Ganesha, Samba).
 	ShareReadOnly bool
-
-	// ShareWritable indicates whether the user has share-level write permission.
-	// When true, the user can write to files in the share regardless of file-level
-	// Unix permissions. This is used to implement share-based access control where
-	// authenticated users with share write permission bypass file-level permission checks.
-	// This is similar to how root bypass works, but applies to any user with share
-	// write permission.
-	ShareWritable bool
 
 	// LockClientID is the lock-layer client identifier used for lease exclusion.
 	// This must match the LockOwner.ClientID format used when acquiring leases.
@@ -105,10 +101,9 @@ func NewSystemAuthContext(ctx context.Context) *AuthContext {
 	uid := uint32(0)
 	gid := uint32(0)
 	return &AuthContext{
-		Context:       ctx,
-		AuthMethod:    "system",
-		ClientAddr:    "internal",
-		ShareWritable: true,
+		Context:    ctx,
+		AuthMethod: "system",
+		ClientAddr: "internal",
 		Identity: &Identity{
 			UID:      &uid,
 			GID:      &gid,

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -250,38 +250,12 @@ func (s *Service) checkFilePermissions(ctx *AuthContext, handle FileHandle, requ
 		shareOpts = nil
 	}
 
-	// Share-level write permission bypass:
-	// If the user has share-level write permission (ctx.ShareWritable) and the
-	// file's ACL does not contain an explicit DENY ACE, grant write-related
-	// permissions, bypassing file-level Unix permission checks.
-	//
-	// Bypass remains in effect when:
-	//   - the file has no ACL at all, or
-	//   - the file's ACL is allow-only (no DENY ACE present).
-	// Allow-only ACLs are additive: they only add grants on top of POSIX bits,
-	// so the share-level write grant should still apply. Concretely this keeps
-	// smbtorture stream-inherit-perms (which appends one ALLOW ACE to the
-	// synthesized DACL) and create.multi (which works against allow-only
-	// share-root SDs) passing.
-	//
-	// Bypass disabled only when an explicit DENY ACE is present: a DENY ACE
-	// encodes intent that POSIX bits / share-level grants cannot express and
-	// must take precedence (load-bearing for smbtorture acls.DENY1 and
-	// delete-on-close-perms.*).
-	//
-	// Note: ShareReadOnly takes precedence - if the share is read-only for this
-	// user, write permission is denied regardless of ShareWritable.
-	if ctx.ShareWritable && !ctx.ShareReadOnly && !acl.HasExplicitDeny(file.ACL) {
-		// Only grant write-related permissions via the share-level bypass.
-		// Read permissions still go through normal calculatePermissions checks.
-		writePerms := requested & (PermissionWrite | PermissionDelete)
-		if writePerms != 0 {
-			// For write requests, grant what was requested
-			return writePerms, nil
-		}
-		// For non-write requests (read-only), fall through to normal permission check
-	}
-
+	// The share permission is a ceiling, not a floor: a read-write share grants no
+	// write that the file's ACL/POSIX mode denies. Only a read-only share
+	// restricts, which calculatePermissions applies from the share's ReadOnly
+	// option (shareOpts.ReadOnly). Write authority is otherwise decided solely by
+	// the unified ACL/POSIX evaluation below, identically for NFS and SMB. See
+	// AuthContext.ShareReadOnly for the multiprotocol-NAS rationale.
 	return calculatePermissions(file, ctx.Identity, shareOpts, requested), nil
 }
 
@@ -526,7 +500,7 @@ func (s *Service) CheckParentCreateAccess(ctx *AuthContext, parentHandle FileHan
 	}
 
 	// Without an ACL there's nothing to refine — fall back to the generic
-	// POSIX-write check so mode bits / share-level grants apply uniformly.
+	// POSIX-write check so the parent's mode bits govern.
 	if file.ACL == nil {
 		return s.checkWritePermission(ctx, parentHandle)
 	}
@@ -538,13 +512,8 @@ func (s *Service) CheckParentCreateAccess(ctx *AuthContext, parentHandle FileHan
 		return &StoreError{Code: ErrAccessDenied, Message: "write permission denied"}
 	}
 
-	// Share-level write bypass mirrors checkFilePermissions: an ALLOW-only
-	// DACL plus ctx.ShareWritable still permits writes (load-bearing for
-	// stream-inherit-perms and create.multi). Only an explicit DENY ACE
-	// disables the bypass.
-	if ctx.ShareWritable && !ctx.ShareReadOnly && !acl.HasExplicitDeny(file.ACL) {
-		return nil
-	}
+	// On a read-write share the parent ACL evaluated below is the sole gate for
+	// ADD_FILE / ADD_SUBDIRECTORY; a read-only share already denied above.
 
 	// Root bypass aligns with calculatePermissions/evaluateACLPermissions:
 	// UID 0 gets all permissions except on read-only shares (handled above).

--- a/pkg/metadata/auth_permissions_acl_short_circuit_test.go
+++ b/pkg/metadata/auth_permissions_acl_short_circuit_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestCheckPermissions_ACLDenyOverridesShareWritable asserts that when a file
-// carries an explicit ACL with a SID-form deny-write ACE for the requester,
-// the share-level ShareWritable bypass does NOT grant write. Without this
-// gate, smbtorture acls.DENY1 + delete-on-close-perms.* fail because the
-// share short-circuit always wins over file-level intent.
-func TestCheckPermissions_ACLDenyOverridesShareWritable(t *testing.T) {
+// TestCheckPermissions_ACLDenyBeatsPosixWrite asserts that when a file carries
+// an explicit ACL with a SID-form deny-write ACE for the requester, write is
+// denied even though the POSIX mode (0o777) would grant it and the share is
+// read-write. The file's ACL is authoritative; the share grant is a ceiling,
+// not a floor. Covers smbtorture acls.DENY1 + delete-on-close-perms.*.
+func TestCheckPermissions_ACLDenyBeatsPosixWrite(t *testing.T) {
 	f := newTestFixture(t)
 
 	requesterUID := uint32(1001)
@@ -48,12 +48,10 @@ func TestCheckPermissions_ACLDenyOverridesShareWritable(t *testing.T) {
 	handle, err := metadata.EncodeShareHandle(f.shareName, created.ID)
 	require.NoError(t, err)
 
-	// Build an AuthContext with ShareWritable = true (smbtorture's typical
-	// session has a writable share permission). Identity carries the SID so
-	// SID-form ACE matching can fire.
+	// Read-write share (ShareReadOnly=false, the default). Identity carries the
+	// SID so SID-form ACE matching can fire.
 	authCtx := f.authContext(requesterUID, 1001)
 	authCtx.Identity.SID = strPtr(requesterSID)
-	authCtx.ShareWritable = true
 	authCtx.ShareReadOnly = false
 
 	got, err := f.service.CheckPermissions(authCtx, handle, metadata.PermissionWrite|metadata.PermissionDelete)
@@ -63,21 +61,20 @@ func TestCheckPermissions_ACLDenyOverridesShareWritable(t *testing.T) {
 	}
 }
 
-// TestCheckPermissions_AllowOnlyACLKeepsShareWritableBypass asserts that when
-// a file carries an explicit ACL containing only ALLOW ACEs (no DENY), the
-// share-level ShareWritable bypass continues to grant write. This covers
-// smbtorture stream-inherit-perms (where SET_INFO Security appends one ALLOW
-// ACE to the synthesized DACL) and create.multi (allow-only SD on share root).
-func TestCheckPermissions_AllowOnlyACLKeepsShareWritableBypass(t *testing.T) {
+// TestCheckPermissions_AllowOnlyACLGrantsWriteViaACL asserts that an allow-only
+// DACL that itself grants write yields write, sourced from the ACL. This is the
+// smbtorture stream-inherit-perms case (SET_INFO Security appends a broad ALLOW
+// ACE) and create.multi (allow-only SD on the share root): the ACL grants the
+// write directly.
+func TestCheckPermissions_AllowOnlyACLGrantsWriteViaACL(t *testing.T) {
 	f := newTestFixture(t)
 
 	requesterUID := uint32(1001)
 	requesterSID := "S-1-5-21-1-2-3-2001"
 
-	// Allow-only ACL: a single ALLOW ACE for EVERYONE@ with broad mask.
-	// This mirrors what smbtorture stream-inherit-perms ends up with after
-	// SET_INFO Security adds an explicit ALLOW ACE: a DACL flagged as
-	// SMB-explicit but containing zero DENY ACEs.
+	// Allow-only ACL: a single ALLOW ACE for EVERYONE@ with broad mask, mirroring
+	// what stream-inherit-perms ends up with — a DACL flagged SMB-explicit with
+	// zero DENY ACEs that grants WRITE_DATA|APPEND_DATA among the broad mask.
 	allowOnlyACL := &acl.ACL{
 		ACEs: []acl.ACE{
 			{
@@ -101,14 +98,61 @@ func TestCheckPermissions_AllowOnlyACLKeepsShareWritableBypass(t *testing.T) {
 
 	authCtx := f.authContext(requesterUID, 1001)
 	authCtx.Identity.SID = strPtr(requesterSID)
-	authCtx.ShareWritable = true
 	authCtx.ShareReadOnly = false
 
 	got, err := f.service.CheckPermissions(authCtx, handle, metadata.PermissionWrite|metadata.PermissionDelete)
 	require.NoError(t, err)
 	want := metadata.PermissionWrite | metadata.PermissionDelete
 	if got&want != want {
-		t.Errorf("expected share-level write+delete bypass on allow-only ACL, got 0x%x", got)
+		t.Errorf("expected write+delete granted by the allow-only ACL, got 0x%x", got)
+	}
+}
+
+// TestCheckPermissions_ShareDoesNotGrantBeyondACL guards the share-permission
+// ceiling: an allow-only DACL that grants only READ, on a mode 0o000 file, must
+// not yield write on a read-write share. The share permission is a ceiling, never
+// a floor — a read-write share grants nothing the file's ACL/POSIX denies.
+func TestCheckPermissions_ShareDoesNotGrantBeyondACL(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterUID := uint32(1001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+
+	// Allow-only DACL granting READ only; POSIX mode denies everyone.
+	readOnlyACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        acl.SpecialEveryone,
+				AccessMask: acl.ACE4_READ_DATA,
+			},
+		},
+	}
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "share_ceiling.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o000,
+			UID:  2000,
+			GID:  2000,
+			ACL:  readOnlyACL,
+		})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(f.shareName, created.ID)
+	require.NoError(t, err)
+
+	// Read-write share (ShareReadOnly=false). Requester is neither owner nor a
+	// grantee of write in the DACL.
+	authCtx := f.authContext(requesterUID, 1001)
+	authCtx.Identity.SID = strPtr(requesterSID)
+	authCtx.ShareReadOnly = false
+
+	got, err := f.service.CheckPermissions(authCtx, handle, metadata.PermissionRead|metadata.PermissionWrite|metadata.PermissionDelete)
+	require.NoError(t, err)
+	if got&metadata.PermissionRead == 0 {
+		t.Errorf("expected read granted by the allow-only ACL, got 0x%x", got)
+	}
+	if got&(metadata.PermissionWrite|metadata.PermissionDelete) != 0 {
+		t.Errorf("expected write+delete DENIED (share is a ceiling, not a floor), got 0x%x", got)
 	}
 }
 

--- a/pkg/metadata/auth_permissions_parent_check_test.go
+++ b/pkg/metadata/auth_permissions_parent_check_test.go
@@ -51,7 +51,6 @@ func TestCheckParentWriteAccess_ACLDenyReturnsAccessDenied(t *testing.T) {
 	authCtx := f.authContext(requesterUID, 1001)
 	sid := requesterSID
 	authCtx.Identity.SID = &sid
-	authCtx.ShareWritable = true
 	authCtx.ShareReadOnly = false
 
 	err = f.service.CheckParentWriteAccess(authCtx, dirHandle)
@@ -64,13 +63,12 @@ func TestCheckParentWriteAccess_ACLDenyReturnsAccessDenied(t *testing.T) {
 	}
 }
 
-// TestCheckParentWriteAccess_NoACLAllowsAdd asserts the POSIX-only happy path
-// is unchanged (parent has no explicit ACL; ShareWritable bypass still
-// applies because the P1-1 gate only fires when an ACL is present).
+// TestCheckParentWriteAccess_NoACLAllowsAdd asserts the POSIX-only happy path:
+// the parent has no explicit ACL and its mode (the fixture root is 0o777) grants
+// the requester write, so the create is permitted by POSIX alone.
 func TestCheckParentWriteAccess_NoACLAllowsAdd(t *testing.T) {
 	f := newTestFixture(t)
 	authCtx := f.authContext(1001, 1001)
-	authCtx.ShareWritable = true
 	if err := f.service.CheckParentWriteAccess(authCtx, f.rootHandle); err != nil {
 		t.Fatalf("CheckParentWriteAccess on POSIX-only writable parent err = %v, want nil", err)
 	}
@@ -117,9 +115,6 @@ func TestCheckParentCreateAccess_DenyAddFileBlocksFileAllowsDir(t *testing.T) {
 	authCtx := f.authContext(requesterUID, 1001)
 	sid := requesterSID
 	authCtx.Identity.SID = &sid
-	// Disable the share-level write bypass so the ACL is the sole gate
-	// (the bypass would short-circuit deny-ACL evaluation otherwise).
-	authCtx.ShareWritable = false
 
 	// File create: must be denied by the ADD_FILE deny ACE.
 	err = f.service.CheckParentCreateAccess(authCtx, dirHandle, false)
@@ -175,7 +170,6 @@ func TestCheckParentCreateAccess_DenyAddSubdirBlocksDirAllowsFile(t *testing.T) 
 	authCtx := f.authContext(requesterUID, 1001)
 	sid := requesterSID
 	authCtx.Identity.SID = &sid
-	authCtx.ShareWritable = false
 
 	// Directory create: must be denied by the ADD_SUBDIRECTORY deny ACE.
 	err = f.service.CheckParentCreateAccess(authCtx, dirHandle, true)
@@ -195,12 +189,11 @@ func TestCheckParentCreateAccess_DenyAddSubdirBlocksDirAllowsFile(t *testing.T) 
 
 // TestCheckParentCreateAccess_NoACLFallsBackToWriteCheck verifies the
 // POSIX fallback path: when the parent has no ACL, evaluation falls
-// through to the shared PermissionWrite check so mode bits and
-// share-level grants still govern.
+// through to the shared PermissionWrite check so the mode bits govern (the
+// fixture root is 0o777, so the requester is granted by POSIX alone).
 func TestCheckParentCreateAccess_NoACLFallsBackToWriteCheck(t *testing.T) {
 	f := newTestFixture(t)
 	authCtx := f.authContext(1001, 1001)
-	authCtx.ShareWritable = true
 
 	if err := f.service.CheckParentCreateAccess(authCtx, f.rootHandle, false); err != nil {
 		t.Fatalf("CheckParentCreateAccess(file, no-ACL) err = %v, want nil", err)

--- a/pkg/metadata/storetest/cross_protocol_permissions.go
+++ b/pkg/metadata/storetest/cross_protocol_permissions.go
@@ -32,7 +32,7 @@ func RunCrossProtocolPermissionMatrix(t *testing.T, factory StoreFactory) {
 	t.Run("DenyACE", func(t *testing.T) { testCrossProtocolDenyACE(t, factory) })
 	t.Run("SIDOnlyGrant", func(t *testing.T) { testCrossProtocolSIDOnlyGrant(t, factory) })
 	t.Run("SIDOnlyDeny", func(t *testing.T) { testCrossProtocolSIDOnlyDeny(t, factory) })
-	t.Run("ShareWritableBypass", func(t *testing.T) { testCrossProtocolShareWritableBypass(t, factory) })
+	t.Run("ShareCeiling", func(t *testing.T) { testCrossProtocolShareCeiling(t, factory) })
 }
 
 // canonOp is a backend-neutral operation the matrix probes through every
@@ -209,10 +209,10 @@ func (f *crossProtocolFixture) rootCtx() *metadata.AuthContext {
 
 // userCtx builds an auth context for the given UID/GID and optional SID.
 //
-// ShareWritable/ShareReadOnly are left at their zero value (false) so the main
-// matrix exercises the full ACL/POSIX evaluation path. The share-level write
-// bypass in checkFilePermissions (which a real SMB session enables by setting
-// ShareWritable=true) is covered separately by testCrossProtocolShareWritableBypass.
+// ShareReadOnly is left false so the matrix exercises the full ACL/POSIX
+// evaluation path. The share permission is a ceiling, never a floor, so a
+// read-write share is simply the absence of the ShareReadOnly restriction —
+// the file's ACL/POSIX alone decides write.
 func (f *crossProtocolFixture) userCtx(uid, gid uint32, sid string) *metadata.AuthContext {
 	id := &metadata.Identity{
 		UID:  metadata.Uint32Ptr(uid),
@@ -406,39 +406,19 @@ func testCrossProtocolSIDOnlyDeny(t *testing.T, factory StoreFactory) {
 	assertLanesAgree(t, f, handle, file, other, opWrite, true)
 }
 
-// testCrossProtocolShareWritableBypass exercises the share-level write bypass in
-// checkFilePermissions (auth_permissions.go) — the path a real SMB session turns
-// on by setting AuthContext.ShareWritable=true, and which the rest of the matrix
-// leaves off.
+// testCrossProtocolShareCeiling pins the share-permission model: the share grant
+// is a ceiling, never a floor. A read-write share grants no write that the file's
+// own ACL/POSIX denies — it can only restrict — so NFS and SMB reach the same
+// decision from the file's ACL for every case. Mirrors Windows (share ∧ NTFS),
+// NetApp export Access_Type, NFS-Ganesha, and Samba (whose "write list" cannot
+// grant beyond the underlying filesystem perms).
 //
-// The security-critical invariant this pins: with ShareWritable=true and an
-// explicit DENY ACE, the bypass MUST NOT override the DENY (it is gated on
-// !acl.HasExplicitDeny). Write stays denied on every protocol. A share-writable
-// mount must never let a user past an explicit DENY — and it must do so
-// identically on NFS and SMB.
-//
-// KNOWN, OUT-OF-SCOPE DIVERGENCE (not asserted here, deliberately): with an
-// allow-ONLY DACL (no explicit DENY) on a mode 0o000 file and ShareWritable=true,
-// the two protocols disagree. NFS CheckPermissions takes the ShareWritable bypass
-// (skips the ACL) and grants write; SMB's open-time DACL gate (CheckFileAccess)
-// ignores ShareWritable and denies write because the DACL grants only read. This
-// is a pre-existing semantic gap in the ShareWritable shortcut, broader than
-// AD-0's NFSv4-ACCESS consolidation, so it is documented rather than fixed or
-// asserted here. Closing it (deciding whether share-writable should override a
-// positive-grant-only ACL, and on which protocol) is a candidate follow-up.
-func testCrossProtocolShareWritableBypass(t *testing.T, factory StoreFactory) {
+// All cases run on a read-write share (ShareReadOnly=false, the userCtx default).
+func testCrossProtocolShareCeiling(t *testing.T, factory StoreFactory) {
 	f := newCrossProtocolFixture(t, factory)
 
-	// writableCtx is a user whose session granted share-level write, as the SMB
-	// session layer sets for a read-write tree connect.
-	writableCtx := func(uid, gid uint32, sid string) *metadata.AuthContext {
-		ctx := f.userCtx(uid, gid, sid)
-		ctx.ShareWritable = true
-		return ctx
-	}
-
-	// Explicit DENY-write ACE + ShareWritable=true → write still denied on every
-	// protocol. The bypass must not override an explicit DENY.
+	// (1) SECURITY — explicit DENY-write ACE → write denied on every protocol.
+	// A read-write share must never let a user past an explicit DENY.
 	denySID := "S-1-5-21-9-9-9-6000"
 	denyWrite := &acl.ACL{
 		ACEs: []acl.ACE{
@@ -446,10 +426,43 @@ func testCrossProtocolShareWritableBypass(t *testing.T, factory StoreFactory) {
 			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, Who: acl.SpecialEveryone, AccessMask: acl.ACE4_READ_DATA},
 		},
 	}
-	denyFile, denyH := f.createFile(t, "sharewritable_deny.txt", &metadata.FileAttr{
+	denyFile, denyH := f.createFile(t, "ceiling_deny.txt", &metadata.FileAttr{
 		Mode: 0o666, UID: 6000, GID: 6000, ACL: denyWrite,
 	})
-	denied := writableCtx(6500, 6500, denySID)
+	denied := f.userCtx(6500, 6500, denySID)
 	assertLanesAgree(t, f, denyH, denyFile, denied, opRead, true)
 	assertLanesAgree(t, f, denyH, denyFile, denied, opWrite, false)
+
+	// (2) CEILING — allow-ONLY DACL granting only READ, on a mode 0o000 file. The
+	// file grants the requester no write by either ACL or POSIX, so even on a
+	// read-write share write is denied on every protocol, while read stays granted
+	// (the DACL allows it). NFS and SMB agree.
+	allowOnly := &acl.ACL{
+		ACEs: []acl.ACE{
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, Who: acl.SpecialEveryone, AccessMask: acl.ACE4_READ_DATA},
+		},
+	}
+	allowFile, allowH := f.createFile(t, "ceiling_allow_only.txt", &metadata.FileAttr{
+		Mode: 0o000, UID: 7000, GID: 7000, ACL: allowOnly,
+	})
+	other := f.userCtx(7500, 7500, "S-1-5-21-9-9-9-7000")
+	assertLanesAgree(t, f, allowH, allowFile, other, opRead, true)
+	assertLanesAgree(t, f, allowH, allowFile, other, opWrite, false)
+
+	// (3) ADDITIVE GRANT — allow-only DACL that DOES grant the requester write.
+	// Write is granted on every protocol, sourced from the ACL itself: an allow
+	// ACE is additive over the POSIX mode, so a file whose mode denies everyone
+	// still grants write to a principal the DACL names.
+	grantSID := "S-1-5-21-9-9-9-8000"
+	allowWrite := &acl.ACL{
+		ACEs: []acl.ACE{
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, Who: "sid:" + grantSID, AccessMask: acl.ACE4_READ_DATA | acl.ACE4_WRITE_DATA | acl.ACE4_APPEND_DATA},
+		},
+	}
+	grantFile, grantH := f.createFile(t, "ceiling_allow_write.txt", &metadata.FileAttr{
+		Mode: 0o000, UID: 8000, GID: 8000, ACL: allowWrite,
+	})
+	grantee := f.userCtx(8500, 8500, grantSID)
+	assertLanesAgree(t, f, grantH, grantFile, grantee, opRead, true)
+	assertLanesAgree(t, f, grantH, grantFile, grantee, opWrite, true)
 }


### PR DESCRIPTION
## Summary

Aligns DittoFS's cross-protocol permission model with the standard multiprotocol NAS behaviour: the **share/export grant is a ceiling, not a floor** — it bounds access from above (ANDed with the file's own ACL/POSIX) and never expands it. A read-write share grants no write that the file's ACL or mode denies; only a read-only share restricts, via `ShareReadOnly`.

Reference implementations this matches:
- **Windows** — share permissions ∧ NTFS permissions, most-restrictive-wins.
- **NetApp ONTAP** — export `Access_Type` bounds the volume security style.
- **NFS-Ganesha** (userspace, FSAL — same shape as DittoFS) — export `Access_Type` over the FSAL `test_access`.
- **Samba** — a `write list` grant cannot exceed the underlying filesystem rights.

## The divergence this closes

A share-level write grant previously acted as a **floor** on the NFS evaluation path (`checkFilePermissions` / `CheckParentCreateAccess`): it granted write over an allow-only DACL regardless of the file's own permissions. The SMB open-time DACL gate did not honour it, so NFS and SMB disagreed on the same file + identity. Removing the floor converges both protocols on the file's ACL.

## Changes
- Remove the `ShareWritable` bypass at both sites; remove the now-unused `AuthContext.ShareWritable` field and its SMB session setters.
- Cross-protocol conformance matrix: assert NFS/SMB convergence for the explicit-DENY, allow-only-read (ceiling), and allow-only-write (additive) cases on memory/badger/postgres.
- Unit tests: pin that an explicit DENY and a read-only allow-only DACL both deny write on a read-write share, and that an ACL write grant still yields write.

## Validation
- Full `pkg/metadata` + SMB handler unit tests green.
- Local smbtorture `smb2.acls` (14/14), `smb2.stream-inherit-perms`, `smb2.create`: zero new failures vs develop.

Closes #1240