### PR TITLE
fix(smb): surface block-store flush failure on CLOSE (#1267)

### DIFF
--- a/internal/adapter/common/content_errmap_test.go
+++ b/internal/adapter/common/content_errmap_test.go
@@ -8,6 +8,7 @@ import (
 	nfs4types "github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	smbtypes "github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/local/fs"
 )
 
 // TestContentErrMap_CASMismatch verifies that a wrapped
@@ -159,5 +160,41 @@ func TestContentErrMap_NonCAS_NoRegression(t *testing.T) {
 	other := fmt.Errorf("opaque storage failure")
 	if got := MapContentToNFS3(other); got != nfs3types.NFS3ErrIO {
 		t.Errorf("regression: MapContentToNFS3(unknown) = %d, want NFS3ErrIO", got)
+	}
+}
+
+// TestContentErrMap_PressureTimeout_SurfacedNonSuccess locks in #1267: the
+// append-log backpressure sentinel fs.ErrPressureTimeout (returned when a
+// wedged rollup pool cannot admit a write, and the durability-point flush the
+// NFS COMMIT / SMB CLOSE handlers run cannot make forward progress) must map to
+// a non-success, I/O-class status in every protocol arm. Surfacing it is what
+// lets the handler fail the COMMIT/CLOSE loudly instead of acknowledging a
+// payload that never durably flushed.
+func TestContentErrMap_PressureTimeout_SurfacedNonSuccess(t *testing.T) {
+	// Direct sentinel and a wrapped form (handlers receive the engine-wrapped
+	// error) must both resolve to the same non-success codes via errors.Is.
+	cases := []error{
+		fs.ErrPressureTimeout,
+		fmt.Errorf("engine flush payload p1: %w", fs.ErrPressureTimeout),
+	}
+	for _, err := range cases {
+		if got := MapContentToNFS3(err); got != nfs3types.NFS3ErrIO {
+			t.Errorf("MapContentToNFS3(%v) = %d, want NFS3ErrIO (%d)", err, got, nfs3types.NFS3ErrIO)
+		}
+		if got := MapContentToNFS3(err); got == nfs3types.NFS3OK {
+			t.Errorf("MapContentToNFS3(%v) = NFS3OK — #1267: pressure-timeout flush must not look successful", err)
+		}
+		if got := MapContentToNFS4(err); got != nfs4types.NFS4ERR_IO {
+			t.Errorf("MapContentToNFS4(%v) = %d, want NFS4ERR_IO (%d)", err, got, nfs4types.NFS4ERR_IO)
+		}
+		if got := MapContentToNFS4(err); got == nfs4types.NFS4_OK {
+			t.Errorf("MapContentToNFS4(%v) = NFS4_OK — #1267: pressure-timeout flush must not look successful", err)
+		}
+		if got := MapContentToSMB(err); got != smbtypes.StatusUnexpectedIOError {
+			t.Errorf("MapContentToSMB(%v) = %v, want StatusUnexpectedIOError", err, got)
+		}
+		if got := MapContentToSMB(err); got == smbtypes.StatusSuccess {
+			t.Errorf("MapContentToSMB(%v) = StatusSuccess — #1267: pressure-timeout flush must not look successful", err)
+		}
 	}
 }

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -529,7 +529,14 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 				}
 
 				if deleteErr != nil {
-					resp.Status = common.MapToSMB(deleteErr)
+					// Surface the delete-on-close failure (#388) — but only when
+					// no durable-flush failure was already recorded in Step 6. A
+					// failed block-store flush is a data-loss signal and takes
+					// precedence: if both fail, the client must see the flush
+					// (data-integrity) status, not the delete error (#1267).
+					if resp.Status == types.StatusSuccess {
+						resp.Status = common.MapToSMB(deleteErr)
+					}
 					logger.Debug("CLOSE: failed to delete",
 						"path", openFile.Path,
 						"isDir", openFile.IsDirectory,

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -212,8 +212,14 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	if !openFile.IsDirectory && openFile.PayloadID != "" {
 		blockStore, bsErr := common.ResolveForWrite(ctx.Context, h.Registry, openFile.MetadataHandle)
 		if bsErr != nil {
+			// A ResolveForWrite failure is NOT a block-store content/durability
+			// error — it surfaces handle-decode / share-registry / config
+			// problems. Map it through the generic mapper (StatusInternalError
+			// etc.), mirroring READ/WRITE/FLUSH which map their resolve/handle
+			// errors via common.MapToSMB. Only the CommitBlockStore failure
+			// below is a true content error (MapContentToSMB).
 			logger.Warn("CLOSE: block store not available for handle", "path", openFile.Path, "error", bsErr)
-			flushFailStatus = common.MapContentToSMB(bsErr)
+			flushFailStatus = common.MapToSMB(bsErr)
 		} else if flushErr := common.CommitBlockStore(ctx.Context, blockStore, openFile.PayloadID); flushErr != nil {
 			logger.Warn("CLOSE: flush failed", "path", openFile.Path, "error", flushErr)
 			flushFailStatus = common.MapContentToSMB(flushErr)

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -284,16 +284,13 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// ========================================================================
 
 	// Seed the response status with the durable-flush outcome. If the block
-	// store flush above failed, the CLOSE is reported as a failure
-	// (data-integrity, #1267); otherwise it starts as StatusSuccess. The
-	// delete-on-close path below may override this with its own error status,
-	// but it never resets a recorded failure back to success.
-	closeStatus := types.StatusSuccess
-	if flushFailStatus != types.StatusSuccess {
-		closeStatus = flushFailStatus
-	}
+	// store (or pending-metadata) flush above failed, the CLOSE is reported as
+	// a failure (data-integrity, #1267); otherwise flushFailStatus is still its
+	// zero value, StatusSuccess. The delete-on-close path below may override
+	// this with its own error status, but it never resets a recorded failure
+	// back to success.
 	resp := &CloseResponse{
-		SMBResponseBase: SMBResponseBase{Status: closeStatus},
+		SMBResponseBase: SMBResponseBase{Status: flushFailStatus},
 		Flags:           req.Flags,
 	}
 

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -133,10 +133,13 @@ func (resp *CloseResponse) Encode() ([]byte, error) {
 // conversion (SMB-to-NFS symlink interop), handles delete-on-close, releases
 // byte-range locks and oplocks, and unregisters any pending CHANGE_NOTIFY watches.
 //
-// Flush errors are logged but do not fail the CLOSE. Delete-on-close unlink
-// failures are surfaced to the client per MS-SMB2 3.3.5.10 / MS-FSA 2.1.5.4
-// (#388) — the client must know the file was not removed. The handle itself
-// is always released regardless, to prevent resource leaks.
+// Flush errors fail the CLOSE: CLOSE is a durability point (MS-SMB2 3.3.5.10),
+// so a failed block-store (or pending-metadata) flush is mapped to a non-success
+// status rather than silently acknowledged — otherwise the client treats data
+// that never persisted as committed (#1267). Delete-on-close unlink failures are
+// likewise surfaced per MS-SMB2 3.3.5.10 / MS-FSA 2.1.5.4 (#388) — the client
+// must know the file was not removed. The handle itself is always released
+// regardless of any flush/delete failure, to prevent resource leaks.
 func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseResponse, error) {
 	logger.Debug("CLOSE request",
 		"fileID", fmt.Sprintf("%x", req.FileID),
@@ -195,12 +198,25 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// Unlike NFS COMMIT which is non-blocking, SMB CLOSE requires immediate durability.
 	// Routed through common.CommitBlockStore so any future []BlockRef
 	// plumbing lands in one place (see common/doc.go).
+	//
+	// CLOSE is a durability point (MS-SMB2 3.3.5.10): the client treats a
+	// successful CLOSE as a guarantee that its writes reached stable storage.
+	// If the durable flush fails (e.g. append-log backpressure surfaces
+	// fs.ErrPressureTimeout when the rollup pool is wedged), we MUST surface
+	// the failure as a non-success status rather than silently ack the close —
+	// otherwise the client believes data it never persisted is committed
+	// (silent write truncation, #1267). The mapped status is recorded and
+	// applied to the response below; handle teardown still runs unconditionally
+	// so the failed flush does not leak the open-file/lease state.
+	var flushFailStatus types.Status
 	if !openFile.IsDirectory && openFile.PayloadID != "" {
 		blockStore, bsErr := common.ResolveForWrite(ctx.Context, h.Registry, openFile.MetadataHandle)
 		if bsErr != nil {
 			logger.Warn("CLOSE: block store not available for handle", "path", openFile.Path, "error", bsErr)
+			flushFailStatus = common.MapContentToSMB(bsErr)
 		} else if flushErr := common.CommitBlockStore(ctx.Context, blockStore, openFile.PayloadID); flushErr != nil {
 			logger.Warn("CLOSE: flush failed", "path", openFile.Path, "error", flushErr)
+			flushFailStatus = common.MapContentToSMB(flushErr)
 		} else {
 			logger.Debug("CLOSE: flushed", "path", openFile.Path, "payloadID", openFile.PayloadID)
 		}
@@ -224,7 +240,15 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 			flushed, metaErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle)
 			if metaErr != nil {
 				logger.Warn("CLOSE: metadata flush failed", "path", openFile.Path, "error", metaErr)
-				// Continue with close even if metadata flush fails
+				// Surface the metadata-flush failure too (#1267): if the
+				// deferred size/mtime never persisted, the client must not be
+				// told the CLOSE succeeded. Lower severity than the byte-data
+				// flush above, but still a durability gap. Only record it when
+				// no block-store flush failure was already captured, so the
+				// data-loss signal (block flush) takes precedence in the status.
+				if flushFailStatus == types.StatusSuccess {
+					flushFailStatus = common.MapToSMB(metaErr)
+				}
 			} else if flushed {
 				logger.Debug("CLOSE: metadata flushed", "path", openFile.Path)
 			}
@@ -259,8 +283,17 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// Step 6: Build response with optional attributes
 	// ========================================================================
 
+	// Seed the response status with the durable-flush outcome. If the block
+	// store flush above failed, the CLOSE is reported as a failure
+	// (data-integrity, #1267); otherwise it starts as StatusSuccess. The
+	// delete-on-close path below may override this with its own error status,
+	// but it never resets a recorded failure back to success.
+	closeStatus := types.StatusSuccess
+	if flushFailStatus != types.StatusSuccess {
+		closeStatus = flushFailStatus
+	}
 	resp := &CloseResponse{
-		SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},
+		SMBResponseBase: SMBResponseBase{Status: closeStatus},
 		Flags:           req.Flags,
 	}
 

--- a/internal/adapter/smb/handlers/close_flush_error_test.go
+++ b/internal/adapter/smb/handlers/close_flush_error_test.go
@@ -1,0 +1,211 @@
+// Regression coverage for #1267: SMB CLOSE must surface a block-store flush
+// failure instead of silently acknowledging the close with STATUS_SUCCESS.
+//
+// CLOSE is a durability point (MS-SMB2 3.3.5.10): the client treats a
+// successful CLOSE as proof that its writes reached stable storage. Before the
+// fix, Close() logged the flush error at WARN and returned StatusSuccess
+// anyway, so a payload that never durably flushed (e.g. append-log
+// backpressure surfacing fs.ErrPressureTimeout, or the share's block store
+// going away mid-close → engine.ErrStoreClosed) was reported as committed —
+// silent write truncation.
+//
+// The handler-level test drives h.Close end-to-end against a memory metadata +
+// block store (the same backends every smb-conformance profile uses) but
+// closes the underlying engine.Store first, so the flush deterministically
+// returns engine.ErrStoreClosed. That sentinel maps to STATUS_FILE_CLOSED via
+// common.MapContentToSMB — any non-success status proves the swallow is fixed.
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	cpstore "github.com/marmos91/dittofs/pkg/controlplane/store"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// setupFlushErrorShare wires a handler + runtime + memory metadata + memory
+// block store with a single read-write share, writes a small payload to a file
+// named "data" under the share root, and registers an OpenFile for it. Returns
+// the handler, a primed SMBHandlerContext, the file's metadata handle, and the
+// FileID of the registered OpenFile.
+func setupFlushErrorShare(t *testing.T) (*Handler, *SMBHandlerContext, metadata.FileHandle, [16]byte) {
+	t.Helper()
+	ctx := context.Background()
+
+	cps, err := cpstore.New(&cpstore.Config{
+		Type:   cpstore.DatabaseTypeSQLite,
+		SQLite: cpstore.SQLiteConfig{Path: ":memory:"},
+	})
+	if err != nil {
+		t.Fatalf("cpstore.New: %v", err)
+	}
+	rt := runtime.New(cps)
+
+	if _, err := cps.CreateMetadataStore(ctx, &models.MetadataStoreConfig{Name: "flushmeta", Type: "memory"}); err != nil {
+		t.Fatalf("CreateMetadataStore: %v", err)
+	}
+	metaStore := metamemory.NewMemoryMetadataStoreWithDefaults()
+	if err := rt.RegisterMetadataStore("flushmeta", metaStore); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+
+	localBSID, err := cps.CreateBlockStore(ctx, &models.BlockStoreConfig{
+		Name: "flushbs", Kind: models.BlockStoreKindLocal, Type: "memory",
+	})
+	if err != nil {
+		t.Fatalf("CreateBlockStore: %v", err)
+	}
+
+	const shareName = "/flush"
+	if err := rt.AddShare(ctx, &runtime.ShareConfig{
+		Name:              shareName,
+		MetadataStore:     "flushmeta",
+		Enabled:           true,
+		LocalBlockStoreID: localBSID,
+		RootAttr: &metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o777,
+		},
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+
+	rootHandle, err := rt.GetRootHandle(shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+
+	uid, gid := uint32(0), uint32(0)
+	authCtx := &metadata.AuthContext{
+		Context:  ctx,
+		Identity: &metadata.Identity{UID: &uid, GID: &gid},
+	}
+	metaSvc := rt.GetMetadataService()
+
+	const fileName = "data"
+	file, _, err := metaSvc.CreateFile(authCtx, rootHandle, fileName, &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0o644,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+	fileHandle, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+
+	payload := []byte("payload-that-must-flush")
+	bs, err := rt.GetBlockStoreForHandle(ctx, fileHandle)
+	if err != nil {
+		t.Fatalf("GetBlockStoreForHandle: %v", err)
+	}
+	writeOp, err := metaSvc.PrepareWrite(authCtx, fileHandle, uint64(len(payload)))
+	if err != nil {
+		t.Fatalf("PrepareWrite: %v", err)
+	}
+	if _, err := bs.WriteAt(ctx, string(writeOp.PayloadID), nil, payload, 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if _, err := metaSvc.CommitWrite(authCtx, writeOp); err != nil {
+		t.Fatalf("CommitWrite: %v", err)
+	}
+
+	committed, err := metaSvc.GetFile(ctx, fileHandle)
+	if err != nil {
+		t.Fatalf("GetFile post-write: %v", err)
+	}
+
+	h := NewHandler()
+	h.Registry = rt
+
+	const callerUID, callerGID uint32 = 1000, 1000
+	suid, sgid := callerUID, callerGID
+	sess := h.CreateSession("127.0.0.1:12345", false, "test-user", "")
+	sess.User = &models.User{
+		Username: "test-user",
+		UID:      &suid,
+		Groups:   []models.Group{{GID: &sgid}},
+	}
+
+	const treeID uint32 = 1
+	h.StoreTree(&TreeConnection{
+		TreeID:     treeID,
+		SessionID:  sess.SessionID,
+		ShareName:  shareName,
+		Permission: models.PermissionReadWrite,
+	})
+
+	fileID := [16]byte{7}
+	openFile := &OpenFile{
+		FileID:         fileID,
+		TreeID:         treeID,
+		SessionID:      sess.SessionID,
+		Path:           fileName,
+		ShareName:      shareName,
+		DesiredAccess:  uint32(types.FileReadData | types.FileWriteData),
+		GrantedAccess:  uint32(types.FileReadData | types.FileWriteData),
+		MetadataHandle: fileHandle,
+		PayloadID:      committed.PayloadID,
+		ParentHandle:   rootHandle,
+		FileName:       fileName,
+	}
+	h.StoreOpenFile(openFile)
+
+	smbCtx := &SMBHandlerContext{
+		Context:   ctx,
+		SessionID: sess.SessionID,
+		TreeID:    treeID,
+		ShareName: shareName,
+	}
+
+	return h, smbCtx, fileHandle, fileID
+}
+
+// TestClose_FlushFailure_SurfacedAsNonSuccess proves that when the block-store
+// flush fails during CLOSE, the handler returns a non-success NTSTATUS rather
+// than the pre-#1267 silent StatusSuccess. The flush is forced to fail by
+// closing the underlying engine.Store first, so engine.Flush returns
+// engine.ErrStoreClosed (the same mapping seam fs.ErrPressureTimeout and the
+// other block-store content errors travel through).
+func TestClose_FlushFailure_SurfacedAsNonSuccess(t *testing.T) {
+	h, smbCtx, fileHandle, fileID := setupFlushErrorShare(t)
+
+	// Force the durable flush to fail: close the share's block store so the
+	// CLOSE-time engine.Flush short-circuits with engine.ErrStoreClosed.
+	bs, err := h.Registry.GetBlockStoreForHandle(smbCtx.Context, fileHandle)
+	if err != nil {
+		t.Fatalf("GetBlockStoreForHandle: %v", err)
+	}
+	if err := bs.Close(); err != nil {
+		t.Fatalf("close block store: %v", err)
+	}
+
+	resp, err := h.Close(smbCtx, &CloseRequest{FileID: fileID})
+	if err != nil {
+		t.Fatalf("Close: unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("Close: nil response")
+	}
+	if resp.Status == types.StatusSuccess {
+		t.Fatalf("Close: status = STATUS_SUCCESS, but the durable flush failed — "+
+			"#1267 regression: a non-flushed payload was acknowledged as committed (resp=%+v)", resp)
+	}
+	// engine.ErrStoreClosed maps to STATUS_FILE_CLOSED via MapContentToSMB; pin
+	// it so the test also guards the chosen mapping, not merely "any non-zero".
+	if resp.Status != types.StatusFileClosed {
+		t.Fatalf("Close: status = 0x%08x, expected STATUS_FILE_CLOSED (0x%08x) for a closed-store flush failure",
+			uint32(resp.Status), uint32(types.StatusFileClosed))
+	}
+
+	// The handle must still be released even though the flush failed — a failed
+	// durability point must not leak the open-file entry.
+	if _, ok := h.GetOpenFile(fileID); ok {
+		t.Fatal("Close: open file handle still registered after CLOSE; failed flush leaked the handle")
+	}
+}

--- a/internal/adapter/smb/handlers/close_flush_error_test.go
+++ b/internal/adapter/smb/handlers/close_flush_error_test.go
@@ -209,3 +209,70 @@ func TestClose_FlushFailure_SurfacedAsNonSuccess(t *testing.T) {
 		t.Fatal("Close: open file handle still registered after CLOSE; failed flush leaked the handle")
 	}
 }
+
+// TestClose_FlushFailure_WinsOverDeleteFailure proves the status precedence in
+// the delete-on-close path: when BOTH the durable block-store flush AND the
+// delete-on-close unlink fail during the same CLOSE, the handler reports the
+// FLUSH (data-loss) status, not the delete error. The block flush failure is a
+// data-integrity signal — silently overwriting it with the delete error would
+// hide from the client that its writes never reached stable storage (#1267
+// precedence regression).
+//
+// The flush is forced to fail by closing the underlying engine.Store (→
+// engine.ErrStoreClosed → STATUS_FILE_CLOSED). The delete-on-close is forced to
+// fail by unlinking the file out-of-band before CLOSE, so the DOC RemoveFile
+// returns ErrNoEntity → STATUS_OBJECT_NAME_NOT_FOUND. The two map to distinct
+// statuses, so the assertion proves which one wins.
+func TestClose_FlushFailure_WinsOverDeleteFailure(t *testing.T) {
+	h, smbCtx, fileHandle, fileID := setupFlushErrorShare(t)
+
+	// Arm delete-on-close on the registered handle so the CLOSE delete path runs.
+	openFile, ok := h.GetOpenFile(fileID)
+	if !ok {
+		t.Fatal("setup: open file not registered")
+	}
+	openFile.InitialDeleteOnClose = true
+	h.StoreOpenFile(openFile)
+
+	// Force the delete-on-close unlink to fail: remove the file out-of-band so
+	// the DOC RemoveFile finds no such child (→ ErrNoEntity).
+	metaSvc := h.Registry.GetMetadataService()
+	uid, gid := uint32(0), uint32(0)
+	authCtx := &metadata.AuthContext{
+		Context:         smbCtx.Context,
+		Identity:        &metadata.Identity{UID: &uid, GID: &gid},
+		HasDeleteAccess: true,
+	}
+	if _, _, err := metaSvc.RemoveFile(authCtx, openFile.ParentHandle, openFile.FileName); err != nil {
+		t.Fatalf("out-of-band RemoveFile: %v", err)
+	}
+
+	// Force the durable flush to fail too: close the share's block store.
+	bs, err := h.Registry.GetBlockStoreForHandle(smbCtx.Context, fileHandle)
+	if err != nil {
+		t.Fatalf("GetBlockStoreForHandle: %v", err)
+	}
+	if err := bs.Close(); err != nil {
+		t.Fatalf("close block store: %v", err)
+	}
+
+	resp, err := h.Close(smbCtx, &CloseRequest{FileID: fileID})
+	if err != nil {
+		t.Fatalf("Close: unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("Close: nil response")
+	}
+
+	// Precedence guard: the flush (data-loss) status must win over the delete
+	// error. STATUS_OBJECT_NAME_NOT_FOUND is the delete error — seeing it means
+	// the delete clobbered the more-important flush failure (#1267 regression).
+	if resp.Status == types.StatusObjectNameNotFound {
+		t.Fatalf("Close: status = STATUS_OBJECT_NAME_NOT_FOUND — the delete error " +
+			"clobbered the block-flush (data-loss) status (#1267 precedence regression)")
+	}
+	if resp.Status != types.StatusFileClosed {
+		t.Fatalf("Close: status = 0x%08x, expected the flush failure STATUS_FILE_CLOSED (0x%08x) to win over the delete failure",
+			uint32(resp.Status), uint32(types.StatusFileClosed))
+	}
+}


### PR DESCRIPTION
Fixes #1267 — a data-integrity bug where SMB CLOSE acknowledged success even when the durable block-store flush failed, causing silent write truncation.

## Root cause
`internal/adapter/smb/handlers/close.go` ran the CLOSE-time durability flush via `common.CommitBlockStore` (→ `engine.Flush`), but on a non-nil error it only logged at WARN and **continued, returning `StatusSuccess`**. CLOSE is a durability point (MS-SMB2 3.3.5.10): the client treats a successful CLOSE as proof its writes reached stable storage. So a payload that never durably flushed (append-log backpressure surfacing `fs.ErrPressureTimeout`, a closed store mid-CLOSE → `engine.ErrStoreClosed`, a rollup/dedup error, etc.) was reported as committed.

## Fix
- SMB CLOSE now maps the flush error via `common.MapContentToSMB` and returns it as the CLOSE response status instead of `StatusSuccess`. Handle teardown (open-file removal, lease/oplock release) still runs unconditionally so a failed flush never leaks state.
- The pending-metadata flush failure in CLOSE is surfaced too (lower priority — the byte-data flush wins the status when both fail).

## Audit of the other swallow candidates
- **SMB WRITE** (`write.go`): already correct — a `WriteToBlockStore` error is mapped via `common.MapContentToSMB` and returned (no silent success). The WRITE-time deferred-metadata `FlushPendingWriteForFile` stays DEBUG-only (re-attempted and now surfaced at CLOSE).
- **NFSv3 COMMIT** (`nfs/v3/handlers/commit.go`): already correct — flush error → `NFS3ErrIO`.
- **NFSv4 COMMIT** (`nfs/v4/handlers/commit.go`): already correct — flush error → `NFS4ERR_IO`.

Only SMB CLOSE swallowed the error.

## Tests
- `close_flush_error_test.go`: drives `h.Close` end-to-end (memory metadata + block store) with the underlying `engine.Store` closed first, so the flush deterministically returns `ErrStoreClosed`; asserts CLOSE returns a non-success status (`STATUS_FILE_CLOSED`) and that the handle is still released. Verified it fails against the unfixed handler (negative control).
- `content_errmap_test.go`: pins `fs.ErrPressureTimeout` (direct + wrapped) to a non-success I/O-class status in NFSv3/NFSv4/SMB.

`go build ./...`, `go vet`, and the SMB/NFS handler + common test suites all pass.