### PR TITLE
fix(kerberos): omit acceptor subkey from AP-REP for SPNEGO MIC interop

### DIFF
--- a/internal/auth/kerberos/service.go
+++ b/internal/auth/kerberos/service.go
@@ -309,9 +309,10 @@ func extractPACIdentity(creds *credentials.Credentials) (userSID string, groupSI
 //     MIT krb5_gss and Heimdal reject raw AP-REPs with GSS_S_DEFECTIVE_TOKEN
 //     (see #337). Do not skip the wrap.
 //
-// Per RFC 4120 Section 5.5.2, the EncAPRepPart contains:
-//   - ctime/cusec copied from the authenticator (proves we decrypted the ticket)
-//   - subkey (optional): echoed if the client sent a subkey in the authenticator
+// Per RFC 4120 Section 5.5.2, the EncAPRepPart contains ctime/cusec copied from
+// the authenticator (proving we decrypted the ticket). It deliberately carries
+// NO subkey even when the client sent one — see the body for the SPNEGO
+// mechListMIC interop rationale.
 //
 // The EncAPRepPart is encrypted with the session key using key usage 12
 // (AP-REP encrypted part, per RFC 4120 Section 7.5.1).
@@ -322,16 +323,21 @@ func (s *KerberosService) BuildMutualAuth(apReq *messages.APReq, sessionKey type
 		Cusec: apReq.Authenticator.Cusec,
 	}
 
-	// If client sent a subkey, include it in the AP-REP.
-	// This tells the client we've accepted the subkey and will use it
-	// for subsequent operations (MIC computation, wrap/unwrap).
-	if HasSubkey(apReq) {
-		encAPRepPart.Subkey = apReq.Authenticator.SubKey
-		logger.Debug("Including subkey in EncAPRepPart",
-			"etype", apReq.Authenticator.SubKey.KeyType,
-			"key_len", len(apReq.Authenticator.SubKey.KeyValue),
-		)
-	}
+	// The AP-REP intentionally carries NO subkey, even when the client sent one
+	// in its authenticator. Per RFC 4121 Section 4.2.6 the GSS per-message
+	// protocol key is the initiator's authenticator subkey when present; an
+	// acceptor includes an AP-REP subkey only to assert a NEW, acceptor-chosen
+	// key, which then obliges every per-message token to set the AcceptorSubkey
+	// flag (0x04) and key its checksum from that subkey (RFC 4121 Section
+	// 4.2.6.1). Echoing the initiator's own subkey back as an "acceptor subkey"
+	// would put the context into that acceptor-subkey regime while our MIC/Wrap
+	// tokens are still emitted as plain SentByAcceptor (0x01) tokens — a real
+	// Windows/Samba client then verifies the server mechListMIC under the
+	// acceptor-subkey rules and rejects it (NT_STATUS_ACCESS_DENIED, "failed to
+	// verify mechListMIC"). Omitting the AP-REP subkey keeps the context on the
+	// initiator subkey, consistent with the SentByAcceptor-only tokens we emit,
+	// and interoperates with both real clients and the smbtorture battery. Our
+	// own context key is already the initiator subkey (set in Authenticate).
 
 	// Marshal the EncAPRepPart inner SEQUENCE (without APPLICATION tag)
 	encAPRepPartInner, err := asn1.Marshal(encAPRepPart)

--- a/internal/auth/kerberos/service_test.go
+++ b/internal/auth/kerberos/service_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jcmturner/gokrb5/v8/crypto"
 	"github.com/jcmturner/gokrb5/v8/iana/etypeID"
 	"github.com/jcmturner/gokrb5/v8/messages"
 	"github.com/jcmturner/gokrb5/v8/types"
@@ -80,6 +81,56 @@ func TestBuildMutualAuth(t *testing.T) {
 				t.Fatalf("expected APPLICATION 15 tag (0x6F), got 0x%02X", apRepBytes[0])
 			}
 		})
+	}
+}
+
+// TestBuildMutualAuth_OmitsAcceptorSubkey is the #1250 regression guard: even
+// when the client authenticator carries a subkey, the AP-REP must NOT echo it as
+// an acceptor subkey. An asserted AP-REP subkey puts the GSS context into the
+// acceptor-subkey regime (RFC 4121 Section 4.2.6.1), obliging every per-message
+// token to set the AcceptorSubkey flag (0x04) — which our SentByAcceptor-only
+// MIC/Wrap tokens do not — so a real Windows/Samba client rejects the server
+// mechListMIC with NT_STATUS_ACCESS_DENIED.
+func TestBuildMutualAuth_OmitsAcceptorSubkey(t *testing.T) {
+	svc := &KerberosService{replayCache: NewReplayCache(5 * time.Minute)}
+	sessionKey := types.EncryptionKey{
+		KeyType:  etypeID.AES128_CTS_HMAC_SHA1_96,
+		KeyValue: make([]byte, 16),
+	}
+	apReq := &messages.APReq{
+		Authenticator: types.Authenticator{
+			CTime: time.Now().UTC(),
+			Cusec: 7,
+			SubKey: types.EncryptionKey{
+				KeyType:  etypeID.AES256_CTS_HMAC_SHA1_96,
+				KeyValue: make([]byte, 32),
+			},
+		},
+	}
+
+	apRepBytes, err := svc.BuildMutualAuth(apReq, sessionKey)
+	if err != nil {
+		t.Fatalf("BuildMutualAuth failed: %v", err)
+	}
+
+	var apRep messages.APRep
+	if err := apRep.Unmarshal(apRepBytes); err != nil {
+		t.Fatalf("unmarshal AP-REP: %v", err)
+	}
+
+	decrypted, err := crypto.DecryptEncPart(apRep.EncPart, sessionKey, keyUsageAPRepEncPart)
+	if err != nil {
+		t.Fatalf("decrypt EncAPRepPart: %v", err)
+	}
+
+	var encPart messages.EncAPRepPart
+	if err := encPart.Unmarshal(decrypted); err != nil {
+		t.Fatalf("unmarshal EncAPRepPart: %v", err)
+	}
+
+	if encPart.Subkey.KeyType != 0 || len(encPart.Subkey.KeyValue) != 0 {
+		t.Errorf("AP-REP must not echo an acceptor subkey, got KeyType=%d KeyLen=%d",
+			encPart.Subkey.KeyType, len(encPart.Subkey.KeyValue))
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes Kerberos SMB session setup against **real Windows/Samba clients**: smbclient (and Windows redirectors) rejected DittoFS with `NT_STATUS_ACCESS_DENIED` ("failed to verify mechListMIC") whenever the client sent a subkey in its AP-REQ authenticator — the normal AES256 case against an AD DC.

## Root cause

`BuildMutualAuth` echoed the client's authenticator subkey back into the AP-REP `EncAPRepPart`. Per **RFC 4121 §4.2.6.1**, asserting an AP-REP subkey moves the GSS context into the *acceptor-subkey* regime, which requires every per-message token to set the **AcceptorSubkey flag (0x04)** and key its checksum from that subkey. DittoFS still emits plain `SentByAcceptor` (0x01) MIC/Wrap tokens, so the client computed a different mechListMIC checksum and rejected the response.

The MIT KDC path the smbtorture battery uses did not exercise the subkey echo, which is why SMB conformance stayed green (68/71) while real clients failed — matching the prior investigation under #1250.

## Fix

Do not echo the initiator subkey into the AP-REP. The GSS per-message key is the initiator authenticator subkey when present (already DittoFS's context key via `VerifyAPREQ`), so the `SentByAcceptor`-only tokens we emit verify correctly.

## Validation — live, real client

Reproduced and fixed end-to-end on a Scaleway VM running a **Samba AD DC** (realm `DITTOFS.AD`) + DittoFS on SMB 445, with **smbclient 4.19** over `--use-kerberos=required` (AES256):

Before:
```
gssapi_check_packet(...) failed: NT_STATUS_ACCESS_DENIED
gensec_spnego_client_negTokenTarg_finish: failed to verify mechListMIC: NT_STATUS_ACCESS_DENIED
session setup failed: NT_STATUS_ACCESS_DENIED
```
After:
```
  ..                                 DH        0  Sun Jun 21 13:48:38 2026
		274877906944 blocks of size 4096. 274877906944 blocks available
```

Plus a unit regression test (`TestBuildMutualAuth_OmitsAcceptorSubkey`) that decrypts the AP-REP and asserts no acceptor subkey is echoed even when the authenticator carries one.

Closes #1250