### PR TITLE
feat(dfsctl): idmap sid list/delete admin surface (#1243)

### DIFF
--- a/cmd/dfsctl/commands/idmap/sid.go
+++ b/cmd/dfsctl/commands/idmap/sid.go
@@ -11,9 +11,9 @@ var sidCmd = &cobra.Command{
 	Long: `Manage durable foreign-SID to Unix UID/GID allocations.
 
 When DittoFS resolves Active Directory / LDAP principals, foreign domain SIDs
-(of the form S-1-5-21-<domain>-<rid>) are durably bound to stable Unix UIDs and
-GIDs. These bindings are allocated exactly once and never remapped, so a foreign
-SID always resolves to the same identity.
+(of the form ` + "`S-1-5-21-<domain>-<rid>`" + `) are durably bound to stable Unix
+UIDs and GIDs. These bindings are allocated exactly once and never remapped, so a
+foreign SID always resolves to the same identity.
 
 This command surfaces that allocation table for administrative inspection and
 cleanup. It is distinct from "dfsctl idmap add/list/remove", which manages the

--- a/cmd/dfsctl/commands/idmap/sid.go
+++ b/cmd/dfsctl/commands/idmap/sid.go
@@ -1,0 +1,38 @@
+package idmap
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// sidCmd is the parent command for foreign-SID idmap allocation management.
+var sidCmd = &cobra.Command{
+	Use:   "sid",
+	Short: "Manage foreign-SID UID/GID allocations",
+	Long: `Manage durable foreign-SID to Unix UID/GID allocations.
+
+When DittoFS resolves Active Directory / LDAP principals, foreign domain SIDs
+(of the form S-1-5-21-<domain>-<rid>) are durably bound to stable Unix UIDs and
+GIDs. These bindings are allocated exactly once and never remapped, so a foreign
+SID always resolves to the same identity.
+
+This command surfaces that allocation table for administrative inspection and
+cleanup. It is distinct from "dfsctl idmap add/list/remove", which manages the
+authentication-principal to DittoFS-user mappings.
+
+Deletion is an administrative escape hatch: removing a mapping allows a foreign
+SID to be re-allocated to a different UID/GID on its next resolution, which can
+re-attribute files owned by the old UID. Use with care.
+
+Examples:
+  # List all foreign-SID allocations
+  dfsctl idmap sid list
+
+  # Delete a foreign-SID allocation
+  dfsctl idmap sid delete S-1-5-21-111-222-333-1107`,
+}
+
+func init() {
+	sidCmd.AddCommand(sidListCmd)
+	sidCmd.AddCommand(sidDeleteCmd)
+	Cmd.AddCommand(sidCmd)
+}

--- a/cmd/dfsctl/commands/idmap/sid_delete.go
+++ b/cmd/dfsctl/commands/idmap/sid_delete.go
@@ -1,0 +1,50 @@
+package idmap
+
+import (
+	"fmt"
+
+	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+var sidDeleteForce bool
+
+var sidDeleteCmd = &cobra.Command{
+	Use:   "delete <sid>",
+	Short: "Delete a foreign-SID UID/GID allocation",
+	Long: `Delete a durable foreign-SID to Unix UID/GID allocation.
+
+This is an administrative escape hatch. Removing a mapping allows the foreign SID
+to be re-allocated to a different UID/GID on its next resolution, which can
+re-attribute files owned by the old UID. This action is irreversible. You will be
+prompted for confirmation unless --force is specified.
+
+Examples:
+  # Delete with confirmation
+  dfsctl idmap sid delete S-1-5-21-111-222-333-1107
+
+  # Delete without confirmation
+  dfsctl idmap sid delete S-1-5-21-111-222-333-1107 --force`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSidDelete,
+}
+
+func init() {
+	sidDeleteCmd.Flags().BoolVarP(&sidDeleteForce, "force", "f", false, "Skip confirmation prompt")
+}
+
+func runSidDelete(cmd *cobra.Command, args []string) error {
+	sid := args[0]
+
+	client, err := cmdutil.GetAuthenticatedClient()
+	if err != nil {
+		return err
+	}
+
+	return cmdutil.RunDeleteWithConfirmation("SID mapping", sid, sidDeleteForce, func() error {
+		if err := client.DeleteSIDMapping(sid); err != nil {
+			return fmt.Errorf("failed to delete SID mapping: %w", err)
+		}
+		return nil
+	})
+}

--- a/cmd/dfsctl/commands/idmap/sid_list.go
+++ b/cmd/dfsctl/commands/idmap/sid_list.go
@@ -1,0 +1,68 @@
+package idmap
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
+	"github.com/marmos91/dittofs/pkg/apiclient"
+	"github.com/spf13/cobra"
+)
+
+var sidListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List foreign-SID UID/GID allocations",
+	Long: `List durable foreign-SID to Unix UID/GID allocations on the DittoFS server.
+
+Examples:
+  # List all foreign-SID allocations
+  dfsctl idmap sid list
+
+  # List as JSON
+  dfsctl idmap sid list -o json`,
+	RunE: runSidList,
+}
+
+// SIDMappingList is a list of SID mappings for table rendering.
+type SIDMappingList []apiclient.SIDMapping
+
+// Headers implements TableRenderer.
+func (sl SIDMappingList) Headers() []string {
+	return []string{"SID", "KIND", "UNIX_ID", "DISPLAY_NAME", "CREATED"}
+}
+
+// Rows implements TableRenderer.
+func (sl SIDMappingList) Rows() [][]string {
+	rows := make([][]string, 0, len(sl))
+	for _, m := range sl {
+		kind := "user"
+		if m.IsGroup {
+			kind = "group"
+		}
+		created := cmdutil.EmptyOr(m.CreatedAt, "-")
+		display := cmdutil.EmptyOr(m.DisplayName, "-")
+		rows = append(rows, []string{
+			m.SID,
+			kind,
+			strconv.FormatUint(uint64(m.UnixID), 10),
+			display,
+			created,
+		})
+	}
+	return rows
+}
+
+func runSidList(cmd *cobra.Command, args []string) error {
+	client, err := cmdutil.GetAuthenticatedClient()
+	if err != nil {
+		return err
+	}
+
+	mappings, err := client.ListSIDMappings()
+	if err != nil {
+		return fmt.Errorf("failed to list SID mappings: %w", err)
+	}
+
+	return cmdutil.PrintOutput(os.Stdout, mappings, len(mappings) == 0, "No SID mappings found.", SIDMappingList(mappings))
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -2473,9 +2473,9 @@ Manage foreign-SID UID/GID allocations
 Manage durable foreign-SID to Unix UID/GID allocations.
 
 When DittoFS resolves Active Directory / LDAP principals, foreign domain SIDs
-(of the form S-1-5-21-<domain>-<rid>) are durably bound to stable Unix UIDs and
-GIDs. These bindings are allocated exactly once and never remapped, so a foreign
-SID always resolves to the same identity.
+(of the form `S-1-5-21-<domain>-<rid>`) are durably bound to stable Unix
+UIDs and GIDs. These bindings are allocated exactly once and never remapped, so a
+foreign SID always resolves to the same identity.
 
 This command surfaces that allocation table for administrative inspection and
 cleanup. It is distinct from "dfsctl idmap add/list/remove", which manages the

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -587,6 +587,9 @@ dfsctl
     add            Add an identity mapping
     list           List identity mappings
     remove         Remove an identity mapping
+    sid            Manage foreign-SID UID/GID allocations
+      delete         Delete a foreign-SID UID/GID allocation
+      list           List foreign-SID UID/GID allocations
   login          Authenticate with DittoFS server
   logout         Clear stored credentials
   netgroup       Manage netgroups (IP access control)
@@ -2447,6 +2450,119 @@ Flags:
   -f, --force              Skip confirmation prompt
       --principal string   External identity to remove
       --provider string    Identity provider (e.g., kerberos, oidc, ad) (default "kerberos")
+```
+
+Global flags:
+
+```
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
+```
+
+### `dfsctl idmap sid`
+
+Manage foreign-SID UID/GID allocations
+
+Manage durable foreign-SID to Unix UID/GID allocations.
+
+When DittoFS resolves Active Directory / LDAP principals, foreign domain SIDs
+(of the form S-1-5-21-<domain>-<rid>) are durably bound to stable Unix UIDs and
+GIDs. These bindings are allocated exactly once and never remapped, so a foreign
+SID always resolves to the same identity.
+
+This command surfaces that allocation table for administrative inspection and
+cleanup. It is distinct from "dfsctl idmap add/list/remove", which manages the
+authentication-principal to DittoFS-user mappings.
+
+Deletion is an administrative escape hatch: removing a mapping allows a foreign
+SID to be re-allocated to a different UID/GID on its next resolution, which can
+re-attribute files owned by the old UID. Use with care.
+
+Examples:
+  # List all foreign-SID allocations
+  dfsctl idmap sid list
+
+  # Delete a foreign-SID allocation
+  dfsctl idmap sid delete S-1-5-21-111-222-333-1107
+
+Global flags:
+
+```
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
+```
+
+### `dfsctl idmap sid delete`
+
+Delete a foreign-SID UID/GID allocation
+
+Delete a durable foreign-SID to Unix UID/GID allocation.
+
+This is an administrative escape hatch. Removing a mapping allows the foreign SID
+to be re-allocated to a different UID/GID on its next resolution, which can
+re-attribute files owned by the old UID. This action is irreversible. You will be
+prompted for confirmation unless --force is specified.
+
+Examples:
+  # Delete with confirmation
+  dfsctl idmap sid delete S-1-5-21-111-222-333-1107
+
+  # Delete without confirmation
+  dfsctl idmap sid delete S-1-5-21-111-222-333-1107 --force
+
+```
+dfsctl idmap sid delete <sid> [flags]
+```
+
+Flags:
+
+```
+  -f, --force   Skip confirmation prompt
+```
+
+Global flags:
+
+```
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
+```
+
+### `dfsctl idmap sid list`
+
+List foreign-SID UID/GID allocations
+
+List durable foreign-SID to Unix UID/GID allocations on the DittoFS server.
+
+Examples:
+  # List all foreign-SID allocations
+  dfsctl idmap sid list
+
+  # List as JSON
+  dfsctl idmap sid list -o json
+
+```
+dfsctl idmap sid list
 ```
 
 Global flags:

--- a/internal/controlplane/api/handlers/sid_mappings.go
+++ b/internal/controlplane/api/handlers/sid_mappings.go
@@ -1,0 +1,89 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/store"
+)
+
+// SIDMappingHandler handles foreign-SID idmap admin API endpoints.
+//
+// These endpoints expose the durable foreign-SID -> Unix UID/GID allocation
+// table for administrative inspection and cleanup. The never-remap invariant
+// lives on the allocation path; deletion here is the admin escape hatch.
+type SIDMappingHandler struct {
+	store store.SIDMappingStore
+}
+
+// NewSIDMappingHandler creates a new SIDMappingHandler.
+func NewSIDMappingHandler(cpStore store.SIDMappingStore) *SIDMappingHandler {
+	return &SIDMappingHandler{store: cpStore}
+}
+
+// SIDMappingResponse is the response body for SID mapping operations.
+type SIDMappingResponse struct {
+	SID         string `json:"sid"`
+	UnixID      uint32 `json:"unix_id"`
+	IsGroup     bool   `json:"is_group"`
+	DisplayName string `json:"display_name,omitempty"`
+	CreatedAt   string `json:"created_at"`
+}
+
+// List handles GET /api/v1/sid-mappings.
+func (h *SIDMappingHandler) List(w http.ResponseWriter, r *http.Request) {
+	mappings, err := h.store.ListSIDMappings(r.Context())
+	if err != nil {
+		InternalServerError(w, "Failed to list SID mappings")
+		return
+	}
+
+	WriteJSONOK(w, sidMappingsToResponse(mappings))
+}
+
+// Delete handles DELETE /api/v1/sid-mappings/{sid}.
+func (h *SIDMappingHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	sid := chi.URLParam(r, "sid")
+	if sid == "" {
+		BadRequest(w, "SID is required")
+		return
+	}
+
+	decodedSID, err := url.PathUnescape(sid)
+	if err != nil {
+		BadRequest(w, "Invalid SID format")
+		return
+	}
+
+	if err := h.store.DeleteSIDMapping(r.Context(), decodedSID); err != nil {
+		if errors.Is(err, models.ErrSIDMappingNotFound) {
+			NotFound(w, "SID mapping not found")
+			return
+		}
+		InternalServerError(w, "Failed to delete SID mapping")
+		return
+	}
+
+	WriteNoContent(w)
+}
+
+func sidMappingsToResponse(mappings []*models.SIDMapping) []SIDMappingResponse {
+	response := make([]SIDMappingResponse, len(mappings))
+	for i, m := range mappings {
+		response[i] = sidMappingToResponse(m)
+	}
+	return response
+}
+
+func sidMappingToResponse(m *models.SIDMapping) SIDMappingResponse {
+	return SIDMappingResponse{
+		SID:         m.SID,
+		UnixID:      m.UnixID,
+		IsGroup:     m.IsGroup,
+		DisplayName: m.DisplayName,
+		CreatedAt:   m.CreatedAt.Format("2006-01-02T15:04:05Z"),
+	}
+}

--- a/internal/controlplane/api/handlers/sid_mappings_test.go
+++ b/internal/controlplane/api/handlers/sid_mappings_test.go
@@ -1,0 +1,132 @@
+//go:build integration
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/marmos91/dittofs/pkg/controlplane/store"
+)
+
+func setupSIDMappingTest(t *testing.T) (*store.GORMStore, *SIDMappingHandler) {
+	t.Helper()
+
+	dbConfig := store.Config{
+		Type: "sqlite",
+		SQLite: store.SQLiteConfig{
+			Path: ":memory:",
+		},
+	}
+	cpStore, err := store.New(&dbConfig)
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+
+	handler := NewSIDMappingHandler(cpStore)
+	return cpStore, handler
+}
+
+func TestListSIDMappings_Handler(t *testing.T) {
+	cpStore, handler := setupSIDMappingTest(t)
+	ctx := context.Background()
+
+	if _, err := cpStore.AllocateSIDMapping(ctx, "S-1-5-21-1-2-3-1107", 70001, false, "alice"); err != nil {
+		t.Fatalf("AllocateSIDMapping: %v", err)
+	}
+	if _, err := cpStore.AllocateSIDMapping(ctx, "S-1-5-21-1-2-3-1108", 80001, true, "engineers"); err != nil {
+		t.Fatalf("AllocateSIDMapping: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sid-mappings", nil)
+	w := httptest.NewRecorder()
+
+	handler.List(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("List() status = %d, want %d, body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp []SIDMappingResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+	if len(resp) != 2 {
+		t.Fatalf("List() returned %d mappings, want 2", len(resp))
+	}
+
+	byID := map[string]SIDMappingResponse{}
+	for _, m := range resp {
+		byID[m.SID] = m
+	}
+	if u := byID["S-1-5-21-1-2-3-1107"]; u.UnixID != 70001 || u.IsGroup || u.DisplayName != "alice" {
+		t.Errorf("user mapping = %+v, want unix=70001 group=false name=alice", u)
+	}
+	if g := byID["S-1-5-21-1-2-3-1108"]; g.UnixID != 80001 || !g.IsGroup || g.DisplayName != "engineers" {
+		t.Errorf("group mapping = %+v, want unix=80001 group=true name=engineers", g)
+	}
+}
+
+func TestListSIDMappings_Empty(t *testing.T) {
+	_, handler := setupSIDMappingTest(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sid-mappings", nil)
+	w := httptest.NewRecorder()
+
+	handler.List(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("List() status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp []SIDMappingResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+	if len(resp) != 0 {
+		t.Errorf("List() returned %d mappings, want 0", len(resp))
+	}
+}
+
+func deleteSIDRequest(t *testing.T, handler *SIDMappingHandler, sid string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/sid-mappings/"+sid, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("sid", sid)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+	handler.Delete(w, req)
+	return w
+}
+
+func TestDeleteSIDMapping_OK(t *testing.T) {
+	cpStore, handler := setupSIDMappingTest(t)
+	ctx := context.Background()
+
+	const sid = "S-1-5-21-1-2-3-1107"
+	if _, err := cpStore.AllocateSIDMapping(ctx, sid, 70001, false, "alice"); err != nil {
+		t.Fatalf("AllocateSIDMapping: %v", err)
+	}
+
+	w := deleteSIDRequest(t, handler, sid)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Delete() status = %d, want %d, body = %s", w.Code, http.StatusNoContent, w.Body.String())
+	}
+
+	if _, err := cpStore.GetSIDMapping(ctx, sid); err == nil {
+		t.Errorf("expected SID mapping to be deleted, but it still exists")
+	}
+}
+
+func TestDeleteSIDMapping_NotFound(t *testing.T) {
+	_, handler := setupSIDMappingTest(t)
+
+	w := deleteSIDRequest(t, handler, "S-1-5-21-9-9-9-9999")
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Delete(missing) status = %d, want %d, body = %s", w.Code, http.StatusNotFound, w.Body.String())
+	}
+}

--- a/pkg/apiclient/sid_mappings.go
+++ b/pkg/apiclient/sid_mappings.go
@@ -1,0 +1,22 @@
+package apiclient
+
+import "net/url"
+
+// SIDMapping represents a durable foreign-SID -> Unix UID/GID allocation.
+type SIDMapping struct {
+	SID         string `json:"sid"`
+	UnixID      uint32 `json:"unix_id"`
+	IsGroup     bool   `json:"is_group"`
+	DisplayName string `json:"display_name,omitempty"`
+	CreatedAt   string `json:"created_at"`
+}
+
+// ListSIDMappings returns all durable foreign-SID mappings.
+func (c *Client) ListSIDMappings() ([]SIDMapping, error) {
+	return listResources[SIDMapping](c, "/api/v1/sid-mappings")
+}
+
+// DeleteSIDMapping removes a foreign-SID mapping by SID.
+func (c *Client) DeleteSIDMapping(sid string) error {
+	return deleteResource(c, resourcePath("/api/v1/sid-mappings/%s", url.PathEscape(sid)))
+}

--- a/pkg/apiclient/sid_mappings_test.go
+++ b/pkg/apiclient/sid_mappings_test.go
@@ -1,0 +1,78 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListSIDMappings_RoundTrip verifies ListSIDMappings hits GET /sid-mappings
+// and decodes the mapping array, including user/group distinction.
+func TestListSIDMappings_RoundTrip(t *testing.T) {
+	s := newStubServer(t)
+	defer s.Close()
+	s.reset()
+
+	body, err := json.Marshal([]SIDMapping{
+		{SID: "S-1-5-21-1-2-3-1107", UnixID: 70001, IsGroup: false, DisplayName: "alice", CreatedAt: "2026-06-20T10:00:00Z"},
+		{SID: "S-1-5-21-1-2-3-1108", UnixID: 80001, IsGroup: true, DisplayName: "engineers", CreatedAt: "2026-06-20T11:00:00Z"},
+	})
+	require.NoError(t, err)
+	s.body = body
+
+	client := newTestClient(s).WithToken("test-token")
+	got, err := client.ListSIDMappings()
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	calls := s.observedCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, http.MethodGet, calls[0].Method)
+	assert.Equal(t, "/api/v1/sid-mappings", calls[0].Path)
+
+	assert.Equal(t, "S-1-5-21-1-2-3-1107", got[0].SID)
+	assert.Equal(t, uint32(70001), got[0].UnixID)
+	assert.False(t, got[0].IsGroup)
+	assert.Equal(t, "alice", got[0].DisplayName)
+	assert.True(t, got[1].IsGroup)
+	assert.Equal(t, uint32(80001), got[1].UnixID)
+}
+
+// TestDeleteSIDMapping_RoundTrip verifies DeleteSIDMapping issues a DELETE to the
+// path-escaped SID endpoint and treats success as no error.
+func TestDeleteSIDMapping_RoundTrip(t *testing.T) {
+	s := newStubServer(t)
+	defer s.Close()
+	s.reset()
+	s.status = http.StatusNoContent
+
+	client := newTestClient(s).WithToken("test-token")
+	err := client.DeleteSIDMapping("S-1-5-21-1-2-3-1107")
+	require.NoError(t, err)
+
+	calls := s.observedCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, http.MethodDelete, calls[0].Method)
+	assert.Equal(t, "/api/v1/sid-mappings/S-1-5-21-1-2-3-1107", calls[0].Path)
+}
+
+// TestDeleteSIDMapping_NotFound maps a 404 to a not-found APIError.
+func TestDeleteSIDMapping_NotFound(t *testing.T) {
+	s := newStubServer(t)
+	defer s.Close()
+	s.reset()
+	s.status = http.StatusNotFound
+	s.contentType = "application/problem+json"
+	s.body = []byte(`{"type":"about:blank","title":"Not Found","status":404,"detail":"SID mapping not found"}`)
+
+	client := newTestClient(s).WithToken("test-token")
+	err := client.DeleteSIDMapping("S-1-5-21-9-9-9-9999")
+	require.Error(t, err)
+
+	apiErr, ok := err.(*APIError)
+	require.True(t, ok, "expected *APIError, got %T", err)
+	assert.True(t, apiErr.IsNotFound(), "404 must surface as IsNotFound()")
+}

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -453,14 +453,14 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 
 			// Foreign-SID idmap allocations — durable AD/LDAP SID -> Unix UID/GID
 			// table for administrative inspection and cleanup (admin only).
-			if sms, ok := cpStore.(store.SIDMappingStore); ok {
-				r.Route("/sid-mappings", func(r chi.Router) {
-					r.Use(apiMiddleware.RequireAdmin())
-					sidmapHandler := handlers.NewSIDMappingHandler(sms)
-					r.Get("/", sidmapHandler.List)
-					r.Delete("/{sid}", sidmapHandler.Delete)
-				})
-			}
+			// store.Store embeds store.SIDMappingStore, so cpStore always
+			// satisfies it; register unconditionally.
+			r.Route("/sid-mappings", func(r chi.Router) {
+				r.Use(apiMiddleware.RequireAdmin())
+				sidmapHandler := handlers.NewSIDMappingHandler(cpStore)
+				r.Get("/", sidmapHandler.List)
+				r.Delete("/{sid}", sidmapHandler.Delete)
+			})
 
 			// System operations (admin only)
 			r.Route("/system", func(r chi.Router) {

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -451,6 +451,17 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 				})
 			}
 
+			// Foreign-SID idmap allocations — durable AD/LDAP SID -> Unix UID/GID
+			// table for administrative inspection and cleanup (admin only).
+			if sms, ok := cpStore.(store.SIDMappingStore); ok {
+				r.Route("/sid-mappings", func(r chi.Router) {
+					r.Use(apiMiddleware.RequireAdmin())
+					sidmapHandler := handlers.NewSIDMappingHandler(sms)
+					r.Get("/", sidmapHandler.List)
+					r.Delete("/{sid}", sidmapHandler.Delete)
+				})
+			}
+
 			// System operations (admin only)
 			r.Route("/system", func(r chi.Router) {
 				r.Use(apiMiddleware.RequireAdmin())


### PR DESCRIPTION
## Summary

Exposes the durable foreign-SID -> Unix UID/GID allocation table for administrative inspection and cleanup. The control-plane store layer (`SIDMappingStore`) already existed — this PR only adds the admin REST surface, the apiclient methods, and the `dfsctl` subcommands. Per the never-remap invariant (enforced on the allocation path), only **list** and **delete** are exposed; deletion is the documented admin escape hatch.

## REST (admin-only)

- `GET /api/v1/sid-mappings` — list all foreign-SID -> UID/GID allocations.
- `DELETE /api/v1/sid-mappings/{sid}` — remove one; returns `404` via the RFC7807 contract on `models.ErrSIDMappingNotFound`.

Handlers live alongside the existing identity/idmap handlers in `internal/controlplane/api/handlers/sid_mappings.go`; routes are registered next to the other idmap routes in `pkg/controlplane/api/router.go`, gated by `apiMiddleware.RequireAdmin()` exactly like the existing admin endpoints.

## apiclient

- `Client.ListSIDMappings()` and `Client.DeleteSIDMapping(sid)`, mirroring the existing `IdentityMapping` methods and error mapping.

## dfsctl

- New `idmap sid` subgroup with `list` (table output: SID / KIND / UNIX_ID / DISPLAY_NAME / CREATED) and `delete <sid>` (confirmation prompt with `--force`).
- Distinct from the existing `idmap add`/`list`/`remove`, which manage the provider->username `IdentityMapping` table.

## Docs & tests

- `docs/CLI.md` regenerated via `go run ./cmd/gendocs` (not hand-edited).
- Handler integration tests (`//go:build integration`) for list (incl. user/group distinction) + delete OK/404.
- apiclient round-trip tests for list, delete, and 404 mapping.

`go build ./...`, `go vet`, and `gofmt -l` are clean; touched-package tests pass.

Closes #1243
