### PR TITLE
fix(perms): SMB handle-based write authorization (#1240)

### DIFF
--- a/internal/adapter/smb/handlers/auth_helper.go
+++ b/internal/adapter/smb/handlers/auth_helper.go
@@ -86,8 +86,9 @@ func BuildAuthContext(ctx *SMBHandlerContext) (*metadata.AuthContext, error) {
 	// (audit #1132).
 	setUnprivilegedIdentity(authCtx)
 
-	// Set share-level permission flags for guest/anonymous sessions
-	authCtx.ShareWritable = HasWritePermission(ctx)
+	// Set the share-level read-only ceiling for guest/anonymous sessions.
+	// Per-handle write authorization (WriteAuthorizedByHandle) is set by the
+	// WRITE / SET_INFO op handlers from OpenFile.GrantedAccess, not here.
 	authCtx.ShareReadOnly = ctx.Permission == models.PermissionRead
 
 	return authCtx, nil
@@ -140,9 +141,10 @@ func getUserIdentity(user *models.User) (uid, gid uint32) {
 // Falls back to defaults (1000/1000) if not configured.
 //
 // Share Permission:
-// ShareWritable is set based on the SMB context's share permission.
-// This allows users with share-level write permission to bypass file-level
-// Unix permission checks.
+// ShareReadOnly is set from the SMB context's share permission (the read-only
+// ceiling). Per-handle write authorization (WriteAuthorizedByHandle) is NOT set
+// here — it is set by the WRITE / SET_INFO op handlers from the open handle's
+// GrantedAccess, since SMB write authorization is handle-based.
 func BuildAuthContextFromUser(ctx *SMBHandlerContext, user *models.User) *metadata.AuthContext {
 	authCtx := &metadata.AuthContext{
 		Context:                ctx.Context,
@@ -172,9 +174,9 @@ func BuildAuthContextFromUser(ctx *SMBHandlerContext, user *models.User) *metada
 		)
 	}
 
-	// Set share-level permission flags
-	// ShareWritable allows bypassing file-level permission checks for write operations
-	authCtx.ShareWritable = HasWritePermission(ctx)
+	// Set the share-level read-only ceiling. Per-handle write authorization
+	// (WriteAuthorizedByHandle) is set by the WRITE / SET_INFO op handlers from
+	// OpenFile.GrantedAccess, not here — SMB write authorization is handle-based.
 	authCtx.ShareReadOnly = ctx.Permission == models.PermissionRead
 
 	return authCtx
@@ -348,7 +350,10 @@ func (h *Handler) buildOpenerAuthContext(ctx *SMBHandlerContext, openFile *OpenF
 	// nobody/nogroup identity, matching the BuildAuthContext User==nil arm.
 	// Never UID=0 — see nobodyUID for the root-bypass rationale.
 	setUnprivilegedIdentity(authCtx)
-	authCtx.ShareWritable = HasWritePermission(ctx)
+	// Only the read-only ceiling is share-derived. Per-handle write
+	// authorization (WriteAuthorizedByHandle) is set by the WRITE / SET_INFO op
+	// handlers from OpenFile.GrantedAccess; SET_INFO SecurityDescriptor (the only
+	// current caller of this helper) is WRITE_DAC-gated, not a data write.
 	authCtx.ShareReadOnly = ctx.Permission == models.PermissionRead
 	return authCtx
 }

--- a/internal/adapter/smb/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk.go
@@ -392,6 +392,12 @@ func (h *Handler) executeCopyChunks(
 		logger.Warn("COPYCHUNK: failed to build auth context", "error", err)
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
+	// COPYCHUNK writes data into the destination handle. Like WRITE, it is
+	// handle-based: the destination open already authorized write against the
+	// DACL ceiling at CREATE (verified above via dstOpen.GrantedAccess), so the
+	// metadata layer must not re-deny on the destination's POSIX mode /
+	// DOS-READONLY attribute (#1240).
+	authCtx.WriteAuthorizedByHandle = hasWriteAccess(dstOpen.GrantedAccess)
 
 	srcPayloadID := string(srcFile.PayloadID)
 	srcSize := srcFile.Size

--- a/internal/adapter/smb/handlers/ioctl_sparse.go
+++ b/internal/adapter/smb/handlers/ioctl_sparse.go
@@ -501,6 +501,11 @@ var errZeroFillCancelled = errors.New("zero-fill cancelled")
 // allocate more than zeroFillChunkSize regardless of how large the requested
 // range is — smbtorture's hole-punch tests exercise multi-MB ranges.
 func (h *Handler) zeroFillRange(authCtx *metadata.AuthContext, openFile *OpenFile, start, end uint64) error {
+	// SET_ZERO_DATA writes zeros through the handle's data stream; like WRITE it
+	// is handle-based (#1240). The open already authorized write against the DACL
+	// ceiling (the caller gated on FILE_WRITE_DATA), so the metadata layer must
+	// not re-deny on the file's POSIX mode / DOS-READONLY attribute.
+	authCtx.WriteAuthorizedByHandle = hasWriteAccess(openFile.GrantedAccess)
 	metaSvc := h.Registry.GetMetadataService()
 	blockStore, err := common.ResolveForWrite(authCtx.Context, h.Registry, openFile.MetadataHandle)
 	if err != nil {

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1302,6 +1302,13 @@ func (h *Handler) setFileInfoFromStore(
 			return setInfoStatus(types.StatusInvalidParameter), nil
 		}
 
+		// Setting EOF is a size-changing data write. SMB authorizes it from the
+		// open handle's GrantedAccess (post-DACL intersection at CREATE), not the
+		// file's current POSIX mode — so a handle opened with FILE_WRITE_DATA on a
+		// DOS-READONLY file may truncate it. Signal the metadata layer to
+		// authorize the size change from the handle rather than re-deny on mode.
+		authCtx.WriteAuthorizedByHandle = hasWriteAccess(openFile.GrantedAccess)
+
 		// Break Level II (Read) oplocks held by other clients.
 		// Per MS-SMB2 3.3.5.21.2 / MS-FSA 2.1.5.14.4: truncation is a
 		// data-modifying operation that invalidates read caches.
@@ -1431,6 +1438,10 @@ func (h *Handler) setFileInfoFromStore(
 				metaSvc := h.Registry.GetMetadataService()
 				if curFile, getErr := metaSvc.GetFile(authCtx.Context, openFile.MetadataHandle); getErr == nil &&
 					requested < curFile.Size {
+					// Allocation-driven truncate is a size-changing data write —
+					// authorize it from the open handle's GrantedAccess, not the
+					// file's POSIX mode (handle-based SMB write authorization).
+					authCtx.WriteAuthorizedByHandle = hasWriteAccess(openFile.GrantedAccess)
 					if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{
 						Size: &requested,
 					}); err != nil {

--- a/internal/adapter/smb/handlers/write.go
+++ b/internal/adapter/smb/handlers/write.go
@@ -324,6 +324,16 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}}, nil
 	}
 
+	// SMB write authorization is HANDLE-BASED: the open already enforced the
+	// DACL ceiling (Step 2b verified the handle carries FILE_WRITE_DATA /
+	// FILE_APPEND_DATA via OpenFile.GrantedAccess). Signal the metadata layer
+	// not to re-deny this WRITE on the file's POSIX mode / DOS-READONLY
+	// attribute (smbtorture smb2.durable-open.read-only writes through a handle
+	// opened on a FILE_ATTRIBUTE_READONLY file). An explicit DENY-write ACE
+	// would have stripped write at open, so this flag can only be set when the
+	// open legitimately granted write.
+	authCtx.WriteAuthorizedByHandle = hasWriteAccess(openFile.GrantedAccess)
+
 	// ========================================================================
 	// Step 8: Check for conflicting byte-range locks
 	// ========================================================================

--- a/pkg/metadata/auth_identity.go
+++ b/pkg/metadata/auth_identity.go
@@ -36,13 +36,26 @@ type AuthContext struct {
 	// When true, all write operations to this share should be denied
 	ShareReadOnly bool
 
-	// ShareWritable indicates whether the user has share-level write permission.
-	// When true, the user can write to files in the share regardless of file-level
-	// Unix permissions. This is used to implement share-based access control where
-	// authenticated users with share write permission bypass file-level permission checks.
-	// This is similar to how root bypass works, but applies to any user with share
-	// write permission.
-	ShareWritable bool
+	// WriteAuthorizedByHandle indicates that the SMB open handle driving this
+	// operation was granted write access (FILE_WRITE_DATA / FILE_APPEND_DATA) at
+	// CREATE time. When set, the metadata layer must NOT re-deny the write on the
+	// file's current POSIX mode / DOS-READONLY attribute: the DACL ceiling was
+	// already enforced at open by the DACL-honoring open-time gate
+	// (Service.CheckFileAccess), so an explicit DENY-write ACE would have denied
+	// FILE_WRITE_DATA at open and the handle would never carry write.
+	//
+	// SMB is HANDLE-BASED: a handle granted write must remain writable regardless
+	// of the file's mode (the smbtorture smb2.durable-open.read-only scenario
+	// CREATEs a FILE_ATTRIBUTE_READONLY file with full access, then writes through
+	// the handle). This flag is the precise per-handle replacement for the former
+	// coarse share-level ShareWritable floor.
+	//
+	// Set ONLY by SMB op handlers, derived from OpenFile.GrantedAccess. NFS is
+	// PATH-BASED — it has no handle and MUST leave this false so writes continue
+	// to re-check POSIX/ACL per operation. ShareReadOnly remains the ceiling:
+	// when the share is read-only for this user, the write is denied regardless
+	// of this flag.
+	WriteAuthorizedByHandle bool
 
 	// LockClientID is the lock-layer client identifier used for lease exclusion.
 	// This must match the LockOwner.ClientID format used when acquiring leases.
@@ -105,10 +118,15 @@ func NewSystemAuthContext(ctx context.Context) *AuthContext {
 	uid := uint32(0)
 	gid := uint32(0)
 	return &AuthContext{
-		Context:       ctx,
-		AuthMethod:    "system",
-		ClientAddr:    "internal",
-		ShareWritable: true,
+		Context:    ctx,
+		AuthMethod: "system",
+		ClientAddr: "internal",
+		// Internal/system operations run as UID 0 (root), which already
+		// bypasses file-level permission checks in calculatePermissions.
+		// Set WriteAuthorizedByHandle so any write-related metadata call also
+		// skips DOS-READONLY re-denial, matching the prior ShareWritable
+		// behavior for system contexts.
+		WriteAuthorizedByHandle: true,
 		Identity: &Identity{
 			UID:      &uid,
 			GID:      &gid,

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -250,29 +250,34 @@ func (s *Service) checkFilePermissions(ctx *AuthContext, handle FileHandle, requ
 		shareOpts = nil
 	}
 
-	// Share-level write permission bypass:
-	// If the user has share-level write permission (ctx.ShareWritable) and the
-	// file's ACL does not contain an explicit DENY ACE, grant write-related
-	// permissions, bypassing file-level Unix permission checks.
+	// Handle-based SMB write authorization:
+	// SMB is handle-based — a handle granted FILE_WRITE_DATA / FILE_APPEND_DATA
+	// at open (by the DACL-honoring open-time gate Service.CheckFileAccess) must
+	// be able to write regardless of the file's current POSIX mode or
+	// DOS-READONLY attribute. The smbtorture smb2.durable-open.read-only test
+	// CREATEs a FILE_ATTRIBUTE_READONLY file (granted full access at open under a
+	// NULL DACL) and then WRITEs through that handle. When ctx.WriteAuthorizedByHandle
+	// is set, the SMB op handler has confirmed the open carried write access
+	// (derived from OpenFile.GrantedAccess), so the metadata layer must not
+	// re-deny on file-level POSIX bits / DOS-READONLY.
 	//
-	// Bypass remains in effect when:
-	//   - the file has no ACL at all, or
-	//   - the file's ACL is allow-only (no DENY ACE present).
-	// Allow-only ACLs are additive: they only add grants on top of POSIX bits,
-	// so the share-level write grant should still apply. Concretely this keeps
-	// smbtorture stream-inherit-perms (which appends one ALLOW ACE to the
-	// synthesized DACL) and create.multi (which works against allow-only
-	// share-root SDs) passing.
-	//
-	// Bypass disabled only when an explicit DENY ACE is present: a DENY ACE
-	// encodes intent that POSIX bits / share-level grants cannot express and
-	// must take precedence (load-bearing for smbtorture acls.DENY1 and
+	// Defense-in-depth on explicit DENY: the open-time DACL gate already strips
+	// FILE_WRITE_DATA when an explicit DENY-write ACE is present, so a write-
+	// authorized handle can never be minted on such a file and this branch would
+	// not be reached for it in production. We nonetheless keep the
+	// !acl.HasExplicitDeny guard so that even a mis-set flag can never let a
+	// caller past an explicit DENY ACE at the metadata layer — a DENY ACE encodes
+	// intent POSIX bits cannot express and must always win (the same invariant
+	// the former share-level floor pinned for smbtorture acls.DENY1 /
 	// delete-on-close-perms.*).
 	//
-	// Note: ShareReadOnly takes precedence - if the share is read-only for this
-	// user, write permission is denied regardless of ShareWritable.
-	if ctx.ShareWritable && !ctx.ShareReadOnly && !acl.HasExplicitDeny(file.ACL) {
-		// Only grant write-related permissions via the share-level bypass.
+	// NFS leaves WriteAuthorizedByHandle false (it has no handle), so NFS writes
+	// continue through the normal calculatePermissions path below.
+	//
+	// Note: ShareReadOnly takes precedence — if the share is read-only for this
+	// user, write permission is denied regardless of this flag.
+	if ctx.WriteAuthorizedByHandle && !ctx.ShareReadOnly && !acl.HasExplicitDeny(file.ACL) {
+		// Only grant write-related permissions via the handle authorization.
 		// Read permissions still go through normal calculatePermissions checks.
 		writePerms := requested & (PermissionWrite | PermissionDelete)
 		if writePerms != 0 {
@@ -538,13 +543,14 @@ func (s *Service) CheckParentCreateAccess(ctx *AuthContext, parentHandle FileHan
 		return &StoreError{Code: ErrAccessDenied, Message: "write permission denied"}
 	}
 
-	// Share-level write bypass mirrors checkFilePermissions: an ALLOW-only
-	// DACL plus ctx.ShareWritable still permits writes (load-bearing for
-	// stream-inherit-perms and create.multi). Only an explicit DENY ACE
-	// disables the bypass.
-	if ctx.ShareWritable && !ctx.ShareReadOnly && !acl.HasExplicitDeny(file.ACL) {
-		return nil
-	}
+	// CREATE has no open handle yet, so the handle-based write authorization
+	// used for SMB WRITE/SET_INFO (ctx.WriteAuthorizedByHandle) does not apply
+	// here — the parent-create gate IS the open-time authorization boundary.
+	// We therefore evaluate the parent's DACL precisely below: an ALLOW-only
+	// DACL that grants the requesting principal ADD_FILE / ADD_SUBDIRECTORY
+	// (directly, or via GENERIC_WRITE / GENERIC_ALL expansion in acl.Evaluate)
+	// permits the create, keeping stream-inherit-perms and create.multi passing,
+	// while a parent DACL that does not grant the add bit correctly denies.
 
 	// Root bypass aligns with calculatePermissions/evaluateACLPermissions:
 	// UID 0 gets all permissions except on read-only shares (handled above).

--- a/pkg/metadata/auth_permissions_acl_short_circuit_test.go
+++ b/pkg/metadata/auth_permissions_acl_short_circuit_test.go
@@ -8,12 +8,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestCheckPermissions_ACLDenyOverridesShareWritable asserts that when a file
-// carries an explicit ACL with a SID-form deny-write ACE for the requester,
-// the share-level ShareWritable bypass does NOT grant write. Without this
-// gate, smbtorture acls.DENY1 + delete-on-close-perms.* fail because the
-// share short-circuit always wins over file-level intent.
-func TestCheckPermissions_ACLDenyOverridesShareWritable(t *testing.T) {
+// TestCheckPermissions_ACLDenyOverridesHandleWrite asserts that when a file
+// carries an explicit ACL with a SID-form deny-write ACE for the requester, the
+// handle-based write authorization (WriteAuthorizedByHandle) does NOT grant
+// write — the metadata layer keeps the explicit-DENY guard for defense-in-depth.
+//
+// In production this case cannot arise: the SMB open-time DACL gate strips
+// FILE_WRITE_DATA when a DENY-write ACE is present, so a write-authorized handle
+// is never minted and the WRITE handler never sets the flag. We set the flag
+// anyway here to prove the metadata-layer DENY guard holds even if the flag were
+// mis-set, preserving smbtorture acls.DENY1 + delete-on-close-perms.* behavior.
+func TestCheckPermissions_ACLDenyOverridesHandleWrite(t *testing.T) {
 	f := newTestFixture(t)
 
 	requesterUID := uint32(1001)
@@ -48,27 +53,122 @@ func TestCheckPermissions_ACLDenyOverridesShareWritable(t *testing.T) {
 	handle, err := metadata.EncodeShareHandle(f.shareName, created.ID)
 	require.NoError(t, err)
 
-	// Build an AuthContext with ShareWritable = true (smbtorture's typical
-	// session has a writable share permission). Identity carries the SID so
+	// Build an AuthContext with WriteAuthorizedByHandle = true (as an SMB WRITE
+	// handler would set from a write-granted handle). Identity carries the SID so
 	// SID-form ACE matching can fire.
 	authCtx := f.authContext(requesterUID, 1001)
 	authCtx.Identity.SID = strPtr(requesterSID)
-	authCtx.ShareWritable = true
+	authCtx.WriteAuthorizedByHandle = true
 	authCtx.ShareReadOnly = false
 
 	got, err := f.service.CheckPermissions(authCtx, handle, metadata.PermissionWrite|metadata.PermissionDelete)
 	require.NoError(t, err)
 	if got&metadata.PermissionWrite != 0 || got&metadata.PermissionDelete != 0 {
-		t.Errorf("expected write+delete denied via SID-form deny ACE on writable share, got 0x%x", got)
+		t.Errorf("expected write+delete denied via SID-form deny ACE despite WriteAuthorizedByHandle, got 0x%x", got)
 	}
 }
 
-// TestCheckPermissions_AllowOnlyACLKeepsShareWritableBypass asserts that when
-// a file carries an explicit ACL containing only ALLOW ACEs (no DENY), the
-// share-level ShareWritable bypass continues to grant write. This covers
+// TestCheckPermissions_HandleWriteGrantsOnReadonlyFile asserts the headline
+// #1240 scenario: a handle granted write at open (WriteAuthorizedByHandle=true)
+// writes through to a file the requester does NOT own and whose POSIX mode would
+// deny write — and, separately, a DOS-READONLY file — yet the write is granted
+// because the open already enforced the DACL ceiling.
+//
+// This is the smbtorture smb2.durable-open.read-only motivation: a
+// FILE_ATTRIBUTE_READONLY file opened with full access (NULL DACL) must remain
+// writable through the handle.
+func TestCheckPermissions_HandleWriteGrantsOnReadonlyFile(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterUID := uint32(1001)
+
+	// DOS-READONLY bit (mode 0x100000) plus a mode that grants nothing to the
+	// requester (owned by a different UID, 0o400 owner-read-only). No ACL — so
+	// the open-time gate was permissive and the handle carries write.
+	const dosReadonly = uint32(0x100000)
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "readonly.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o400 | dosReadonly,
+			UID:  2002, // not the requester
+			GID:  2002,
+		})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(f.shareName, created.ID)
+	require.NoError(t, err)
+
+	// Without the handle flag, the requester (non-owner, no write bit) is denied.
+	denyCtx := f.authContext(requesterUID, 1001)
+	denyCtx.ShareReadOnly = false
+	gotDeny, err := f.service.CheckPermissions(denyCtx, handle, metadata.PermissionWrite)
+	require.NoError(t, err)
+	if gotDeny&metadata.PermissionWrite != 0 {
+		t.Fatalf("precondition: expected write denied without handle authorization, got 0x%x", gotDeny)
+	}
+
+	// With WriteAuthorizedByHandle=true, the write is granted despite POSIX mode
+	// and the DOS-READONLY attribute — the open is the authorization boundary.
+	authCtx := f.authContext(requesterUID, 1001)
+	authCtx.WriteAuthorizedByHandle = true
+	authCtx.ShareReadOnly = false
+	got, err := f.service.CheckPermissions(authCtx, handle, metadata.PermissionWrite)
+	require.NoError(t, err)
+	if got&metadata.PermissionWrite == 0 {
+		t.Errorf("expected write granted via WriteAuthorizedByHandle on readonly/non-owner file, got 0x%x", got)
+	}
+}
+
+// TestCheckPermissions_HandleWriteSuppressedByReadOnlyShare asserts the
+// ShareReadOnly ceiling beats the handle authorization: when the share is
+// read-only for the user, the handle-based write bypass is suppressed and the
+// write falls through to the normal POSIX/ACL check, which denies a non-owner
+// who has no write bit. (ShareReadOnly gates the bypass; the share's ReadOnly
+// option is enforced inside calculatePermissions on the fallthrough.)
+func TestCheckPermissions_HandleWriteSuppressedByReadOnlyShare(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterUID := uint32(1001)
+	// Non-owner, owner-read-only: without the handle bypass the requester has no
+	// write bit, so suppression of the bypass must surface as a denial.
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "ro_share.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o400,
+			UID:  2002, // not the requester
+			GID:  2002,
+		})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(f.shareName, created.ID)
+	require.NoError(t, err)
+
+	// Sanity: with the handle bypass and a writable share, write is granted.
+	rwCtx := f.authContext(requesterUID, 1001)
+	rwCtx.WriteAuthorizedByHandle = true
+	rwCtx.ShareReadOnly = false
+	gotRW, err := f.service.CheckPermissions(rwCtx, handle, metadata.PermissionWrite)
+	require.NoError(t, err)
+	if gotRW&metadata.PermissionWrite == 0 {
+		t.Fatalf("precondition: expected write granted via handle on writable share, got 0x%x", gotRW)
+	}
+
+	// ShareReadOnly suppresses the bypass; the POSIX fallthrough then denies.
+	authCtx := f.authContext(requesterUID, 1001)
+	authCtx.WriteAuthorizedByHandle = true
+	authCtx.ShareReadOnly = true
+
+	got, err := f.service.CheckPermissions(authCtx, handle, metadata.PermissionWrite)
+	require.NoError(t, err)
+	if got&metadata.PermissionWrite != 0 {
+		t.Errorf("expected write denied on read-only share despite WriteAuthorizedByHandle, got 0x%x", got)
+	}
+}
+
+// TestCheckPermissions_AllowOnlyACLKeepsHandleWriteBypass asserts that when a
+// file carries an explicit ACL containing only ALLOW ACEs (no DENY), the
+// handle-based write authorization continues to grant write. This covers
 // smbtorture stream-inherit-perms (where SET_INFO Security appends one ALLOW
 // ACE to the synthesized DACL) and create.multi (allow-only SD on share root).
-func TestCheckPermissions_AllowOnlyACLKeepsShareWritableBypass(t *testing.T) {
+func TestCheckPermissions_AllowOnlyACLKeepsHandleWriteBypass(t *testing.T) {
 	f := newTestFixture(t)
 
 	requesterUID := uint32(1001)
@@ -101,14 +201,14 @@ func TestCheckPermissions_AllowOnlyACLKeepsShareWritableBypass(t *testing.T) {
 
 	authCtx := f.authContext(requesterUID, 1001)
 	authCtx.Identity.SID = strPtr(requesterSID)
-	authCtx.ShareWritable = true
+	authCtx.WriteAuthorizedByHandle = true
 	authCtx.ShareReadOnly = false
 
 	got, err := f.service.CheckPermissions(authCtx, handle, metadata.PermissionWrite|metadata.PermissionDelete)
 	require.NoError(t, err)
 	want := metadata.PermissionWrite | metadata.PermissionDelete
 	if got&want != want {
-		t.Errorf("expected share-level write+delete bypass on allow-only ACL, got 0x%x", got)
+		t.Errorf("expected handle-based write+delete bypass on allow-only ACL, got 0x%x", got)
 	}
 }
 

--- a/pkg/metadata/auth_permissions_parent_check_test.go
+++ b/pkg/metadata/auth_permissions_parent_check_test.go
@@ -51,7 +51,6 @@ func TestCheckParentWriteAccess_ACLDenyReturnsAccessDenied(t *testing.T) {
 	authCtx := f.authContext(requesterUID, 1001)
 	sid := requesterSID
 	authCtx.Identity.SID = &sid
-	authCtx.ShareWritable = true
 	authCtx.ShareReadOnly = false
 
 	err = f.service.CheckParentWriteAccess(authCtx, dirHandle)
@@ -65,14 +64,13 @@ func TestCheckParentWriteAccess_ACLDenyReturnsAccessDenied(t *testing.T) {
 }
 
 // TestCheckParentWriteAccess_NoACLAllowsAdd asserts the POSIX-only happy path
-// is unchanged (parent has no explicit ACL; ShareWritable bypass still
-// applies because the P1-1 gate only fires when an ACL is present).
+// is unchanged: a parent with no explicit ACL falls through to the POSIX write
+// check (the root dir is mode 0o777, so a non-owner gets write via "other").
 func TestCheckParentWriteAccess_NoACLAllowsAdd(t *testing.T) {
 	f := newTestFixture(t)
 	authCtx := f.authContext(1001, 1001)
-	authCtx.ShareWritable = true
 	if err := f.service.CheckParentWriteAccess(authCtx, f.rootHandle); err != nil {
-		t.Fatalf("CheckParentWriteAccess on POSIX-only writable parent err = %v, want nil", err)
+		t.Fatalf("CheckParentWriteAccess on POSIX-writable parent err = %v, want nil", err)
 	}
 }
 
@@ -117,9 +115,6 @@ func TestCheckParentCreateAccess_DenyAddFileBlocksFileAllowsDir(t *testing.T) {
 	authCtx := f.authContext(requesterUID, 1001)
 	sid := requesterSID
 	authCtx.Identity.SID = &sid
-	// Disable the share-level write bypass so the ACL is the sole gate
-	// (the bypass would short-circuit deny-ACL evaluation otherwise).
-	authCtx.ShareWritable = false
 
 	// File create: must be denied by the ADD_FILE deny ACE.
 	err = f.service.CheckParentCreateAccess(authCtx, dirHandle, false)
@@ -175,7 +170,6 @@ func TestCheckParentCreateAccess_DenyAddSubdirBlocksDirAllowsFile(t *testing.T) 
 	authCtx := f.authContext(requesterUID, 1001)
 	sid := requesterSID
 	authCtx.Identity.SID = &sid
-	authCtx.ShareWritable = false
 
 	// Directory create: must be denied by the ADD_SUBDIRECTORY deny ACE.
 	err = f.service.CheckParentCreateAccess(authCtx, dirHandle, true)
@@ -195,12 +189,11 @@ func TestCheckParentCreateAccess_DenyAddSubdirBlocksDirAllowsFile(t *testing.T) 
 
 // TestCheckParentCreateAccess_NoACLFallsBackToWriteCheck verifies the
 // POSIX fallback path: when the parent has no ACL, evaluation falls
-// through to the shared PermissionWrite check so mode bits and
-// share-level grants still govern.
+// through to the shared PermissionWrite check so mode bits govern (the root
+// dir is mode 0o777, so a non-owner gets write via "other").
 func TestCheckParentCreateAccess_NoACLFallsBackToWriteCheck(t *testing.T) {
 	f := newTestFixture(t)
 	authCtx := f.authContext(1001, 1001)
-	authCtx.ShareWritable = true
 
 	if err := f.service.CheckParentCreateAccess(authCtx, f.rootHandle, false); err != nil {
 		t.Fatalf("CheckParentCreateAccess(file, no-ACL) err = %v, want nil", err)

--- a/pkg/metadata/storetest/cross_protocol_permissions.go
+++ b/pkg/metadata/storetest/cross_protocol_permissions.go
@@ -32,7 +32,7 @@ func RunCrossProtocolPermissionMatrix(t *testing.T, factory StoreFactory) {
 	t.Run("DenyACE", func(t *testing.T) { testCrossProtocolDenyACE(t, factory) })
 	t.Run("SIDOnlyGrant", func(t *testing.T) { testCrossProtocolSIDOnlyGrant(t, factory) })
 	t.Run("SIDOnlyDeny", func(t *testing.T) { testCrossProtocolSIDOnlyDeny(t, factory) })
-	t.Run("ShareWritableBypass", func(t *testing.T) { testCrossProtocolShareWritableBypass(t, factory) })
+	t.Run("HandleWriteAuthorization", func(t *testing.T) { testCrossProtocolHandleWriteAuthorization(t, factory) })
 }
 
 // canonOp is a backend-neutral operation the matrix probes through every
@@ -103,9 +103,20 @@ func nfsLane(name string) protocolLane {
 //     calculatePermissions core every metadata READ/WRITE runs (io.go), reached
 //     here via CheckPermissions. This is the IDENTICAL core the NFS lanes use.
 //
-// A real SMB client must pass both, so the lane ANDs them. The result is the
-// effective allow/deny a Windows client observes, which the suite then asserts
-// matches the NFS lanes — the cross-protocol unification guarantee.
+// SMB write authorization is HANDLE-BASED for files that carry a DACL: gate 1
+// (CheckFileAccess) is the DACL ceiling enforced at open. When the file has a
+// DACL and gate 1 grants write, the production WRITE / SET_INFO handler sets
+// AuthContext.WriteAuthorizedByHandle from the open handle's GrantedAccess, and
+// gate 2 must then honor the handle rather than re-deny on the file's POSIX mode
+// (the smb2.durable-open.read-only scenario). An explicit DENY-write ACE strips
+// write at gate 1, so the handle never carries write and the op is denied — the
+// security invariant the matrix pins.
+//
+// For files with NO DACL, gate 1 is intentionally permissive (NULL DACL grants
+// everything, MS-DTYP §2.5.3) and is therefore not a real authorization — the
+// POSIX-mode per-op check is. The lane leaves WriteAuthorizedByHandle unset in
+// that case so SMB and NFS reach the SAME POSIX decision, preserving the
+// cross-protocol agreement on plain mode-bit files.
 func smbLane() protocolLane {
 	return protocolLane{
 		name: "SMB",
@@ -122,7 +133,9 @@ func smbLane() protocolLane {
 				perm = metadata.PermissionWrite
 			}
 
-			// Gate 1: open-time DACL check.
+			// Gate 1: open-time DACL check. This is the authorization boundary
+			// for SMB — an explicit DENY-write ACE or a DACL that omits write
+			// strips write from the handle here.
 			granted, err := svc.CheckFileAccess(file, authCtx, mask)
 			if err != nil {
 				var storeErr *metadata.StoreError
@@ -136,8 +149,21 @@ func smbLane() protocolLane {
 			}
 
 			// Gate 2: operation-level POSIX/ACL check (same core as NFS + the
-			// metadata READ/WRITE ops).
-			opGranted, err := svc.CheckPermissions(authCtx, handle, perm)
+			// metadata READ/WRITE ops). For writes to a DACL-bearing file, gate 1
+			// was the real DACL authorization and granted write, so the real
+			// handler sets WriteAuthorizedByHandle from OpenFile.GrantedAccess.
+			// Model that on a copy of the context so the shared authCtx the NFS
+			// lanes use stays unmutated. For no-DACL files gate 1 is a permissive
+			// freebie, so we leave the flag unset and SMB falls through to the
+			// same POSIX check NFS runs.
+			opCtx := authCtx
+			if op == opWrite && file.ACL != nil {
+				ctxCopy := *authCtx
+				ctxCopy.WriteAuthorizedByHandle = true
+				opCtx = &ctxCopy
+			}
+
+			opGranted, err := svc.CheckPermissions(opCtx, handle, perm)
 			if err != nil {
 				t.Fatalf("SMB: CheckPermissions(%s) unexpected error: %v", op, err)
 			}
@@ -209,10 +235,11 @@ func (f *crossProtocolFixture) rootCtx() *metadata.AuthContext {
 
 // userCtx builds an auth context for the given UID/GID and optional SID.
 //
-// ShareWritable/ShareReadOnly are left at their zero value (false) so the main
-// matrix exercises the full ACL/POSIX evaluation path. The share-level write
-// bypass in checkFilePermissions (which a real SMB session enables by setting
-// ShareWritable=true) is covered separately by testCrossProtocolShareWritableBypass.
+// WriteAuthorizedByHandle/ShareReadOnly are left at their zero value (false) so
+// the NFS lanes exercise the full ACL/POSIX evaluation path. The SMB lane stamps
+// WriteAuthorizedByHandle itself (handle-based write authorization) when gate 1
+// grants write on a DACL-bearing file — see smbLane and
+// testCrossProtocolHandleWriteAuthorization.
 func (f *crossProtocolFixture) userCtx(uid, gid uint32, sid string) *metadata.AuthContext {
 	id := &metadata.Identity{
 		UID:  metadata.Uint32Ptr(uid),
@@ -406,39 +433,27 @@ func testCrossProtocolSIDOnlyDeny(t *testing.T, factory StoreFactory) {
 	assertLanesAgree(t, f, handle, file, other, opWrite, true)
 }
 
-// testCrossProtocolShareWritableBypass exercises the share-level write bypass in
-// checkFilePermissions (auth_permissions.go) — the path a real SMB session turns
-// on by setting AuthContext.ShareWritable=true, and which the rest of the matrix
-// leaves off.
+// testCrossProtocolHandleWriteAuthorization models SMB's HANDLE-BASED write
+// authorization (#1240) and pins the security invariant against an explicit
+// DENY-write ACE.
 //
-// The security-critical invariant this pins: with ShareWritable=true and an
-// explicit DENY ACE, the bypass MUST NOT override the DENY (it is gated on
-// !acl.HasExplicitDeny). Write stays denied on every protocol. A share-writable
-// mount must never let a user past an explicit DENY — and it must do so
-// identically on NFS and SMB.
+// SMB is handle-based: a handle granted FILE_WRITE_DATA at open (the gate-1
+// CheckFileAccess DACL evaluation) may write regardless of the file's POSIX
+// mode. The smbLane reproduces this by stamping WriteAuthorizedByHandle on the
+// op context whenever gate 1 grants write on a DACL-bearing file. NFS has no
+// handle and re-checks the ACL/POSIX per op.
 //
-// KNOWN, OUT-OF-SCOPE DIVERGENCE (not asserted here, deliberately): with an
-// allow-ONLY DACL (no explicit DENY) on a mode 0o000 file and ShareWritable=true,
-// the two protocols disagree. NFS CheckPermissions takes the ShareWritable bypass
-// (skips the ACL) and grants write; SMB's open-time DACL gate (CheckFileAccess)
-// ignores ShareWritable and denies write because the DACL grants only read. This
-// is a pre-existing semantic gap in the ShareWritable shortcut, broader than
-// AD-0's NFSv4-ACCESS consolidation, so it is documented rather than fixed or
-// asserted here. Closing it (deciding whether share-writable should override a
-// positive-grant-only ACL, and on which protocol) is a candidate follow-up.
-func testCrossProtocolShareWritableBypass(t *testing.T, factory StoreFactory) {
+// The security-critical invariant: with an explicit DENY-write ACE, gate 1
+// strips FILE_WRITE_DATA from the open, so the handle never carries write and
+// the metadata layer is never told WriteAuthorizedByHandle. Write stays denied
+// on every protocol — a handle can never be minted past an explicit DENY, so
+// the metadata-layer handle bypass can never override one.
+func testCrossProtocolHandleWriteAuthorization(t *testing.T, factory StoreFactory) {
 	f := newCrossProtocolFixture(t, factory)
 
-	// writableCtx is a user whose session granted share-level write, as the SMB
-	// session layer sets for a read-write tree connect.
-	writableCtx := func(uid, gid uint32, sid string) *metadata.AuthContext {
-		ctx := f.userCtx(uid, gid, sid)
-		ctx.ShareWritable = true
-		return ctx
-	}
-
-	// Explicit DENY-write ACE + ShareWritable=true → write still denied on every
-	// protocol. The bypass must not override an explicit DENY.
+	// Explicit DENY-write ACE → write denied on every protocol. On SMB the open
+	// (gate 1) denies write, so no write-authorized handle is ever minted; the
+	// metadata-layer handle bypass therefore can never reach this file.
 	denySID := "S-1-5-21-9-9-9-6000"
 	denyWrite := &acl.ACL{
 		ACEs: []acl.ACE{
@@ -446,10 +461,28 @@ func testCrossProtocolShareWritableBypass(t *testing.T, factory StoreFactory) {
 			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, Who: acl.SpecialEveryone, AccessMask: acl.ACE4_READ_DATA},
 		},
 	}
-	denyFile, denyH := f.createFile(t, "sharewritable_deny.txt", &metadata.FileAttr{
+	denyFile, denyH := f.createFile(t, "handle_write_deny.txt", &metadata.FileAttr{
 		Mode: 0o666, UID: 6000, GID: 6000, ACL: denyWrite,
 	})
-	denied := writableCtx(6500, 6500, denySID)
+	denied := f.userCtx(6500, 6500, denySID)
 	assertLanesAgree(t, f, denyH, denyFile, denied, opRead, true)
 	assertLanesAgree(t, f, denyH, denyFile, denied, opWrite, false)
+
+	// Allow-write DACL on a mode 0o000 file: the SMB open grants write (DACL
+	// authorization), so the handle is write-authorized and the write succeeds
+	// despite the file mode granting nothing. NFS, which re-checks the ACL per
+	// op, also grants via the SID-addressed ALLOW. Both protocols agree: WRITE
+	// allowed even though POSIX mode is 0o000 — the handle/ACL is the authority.
+	grantSID := "S-1-5-21-9-9-9-7000"
+	allowWrite := &acl.ACL{
+		ACEs: []acl.ACE{
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, Who: "sid:" + grantSID, AccessMask: acl.ACE4_READ_DATA | acl.ACE4_WRITE_DATA | acl.ACE4_APPEND_DATA},
+		},
+	}
+	allowFile, allowH := f.createFile(t, "handle_write_allow.txt", &metadata.FileAttr{
+		Mode: 0o000, UID: 6000, GID: 6000, ACL: allowWrite,
+	})
+	granted := f.userCtx(6600, 6600, grantSID)
+	assertLanesAgree(t, f, allowH, allowFile, granted, opRead, true)
+	assertLanesAgree(t, f, allowH, allowFile, granted, opWrite, true)
 }


### PR DESCRIPTION
## The model

SMB is **handle-based**: a handle granted `FILE_WRITE_DATA` / `FILE_APPEND_DATA` at open (by the DACL-honoring open-time gate `Service.CheckFileAccess`) must be able to write **regardless of the file's current POSIX mode or DOS-READONLY attribute**. The DACL ceiling — including an explicit DENY-write ACE — is enforced **at open**: a DENY strips write from the handle, so a write-authorized handle can never be minted on a DENY'd file.

The metadata WRITE/SET_INFO authorization previously approximated this with a coarse **share-level** `AuthContext.ShareWritable` floor in `checkFilePermissions` (and `CheckParentCreateAccess`). That floor was a SHARE-wide approximation of per-handle authorization and didn't reflect what the actual open granted.

## What changed

- **`pkg/metadata/auth_identity.go`**: removed `AuthContext.ShareWritable`; added `AuthContext.WriteAuthorizedByHandle bool` — "the SMB open handle was granted write access; the metadata layer must not re-deny on POSIX mode / DOS-READONLY, the DACL ceiling was enforced at open. Set only by SMB op handlers; NFS leaves it false (path-based)."
- **`pkg/metadata/auth_permissions.go`**: `checkFilePermissions` now grants the requested write/delete bits when `WriteAuthorizedByHandle && !ShareReadOnly && !acl.HasExplicitDeny(file.ACL)`. `ShareReadOnly` stays the ceiling; the explicit-DENY guard is kept as **defense-in-depth** (production can't reach it because the open already denies, but a mis-set flag can never override a DENY ACE). `CheckParentCreateAccess` drops the share-level floor and evaluates the parent DACL precisely (CREATE has no handle; the parent-create gate IS the open-time authorization, and `acl.Evaluate` expands `GENERIC_WRITE`/`GENERIC_ALL` so allow-only DACLs still grant — `create.multi` / `stream-inherit-perms` preserved).
- **SMB handlers** (`auth_helper.go`): the 3 sites that set `ShareWritable` now only set the `ShareReadOnly` ceiling. The new flag is set in the op handlers:
  - `write.go` (WRITE): `authCtx.WriteAuthorizedByHandle = hasWriteAccess(openFile.GrantedAccess)` after building the AuthContext passed to `PrepareWrite`.
  - `set_info.go` (SET_INFO size-changing): same, on the `FileEndOfFileInformation` case and the allocation-driven truncate inside `FileAllocationInformation`, on the AuthContext passed to `SetFileAttributes(Size:...)`.
- **NFS**: unchanged. NFS adapters never set the flag (verified), so NFS writes stay path-based.
- **Tests**: reworked `storetest` cross-protocol matrix to model SMB as handle-based (gate-1 DACL open grant ⇒ flag set for the gate-2 op check on DACL-bearing files; no-DACL files fall through to the same POSIX check NFS runs, keeping the lanes in agreement). Renamed the bypass case to `HandleWriteAuthorization` and pinned the DENY invariant + an allow-write-on-mode-0o000 case. Updated the metadata unit tests and added regression tests: write granted through a write-authorized handle on a DOS-READONLY / non-owner file (the `smb2.durable-open.read-only` motivation), DENY-write still denies, and `ShareReadOnly` suppresses the bypass.

## Why the old floor was coarse

`ShareWritable` was true for any read-write SMB session and bypassed file-level POSIX for every file with no explicit DENY — a share-wide grant, not the precise "this handle was opened with write" signal. The new flag is derived per-handle from `OpenFile.GrantedAccess`, so authorization tracks the actual open.

## Motivation: smb2.durable-open.read-only

That test CREATEs a file with `FILE_ATTRIBUTE_READONLY` (granted full access at open under a NULL DACL), then WRITEs through the handle. With the old code this relied on the coarse `ShareWritable` floor not denying; now the handle's `GrantedAccess` precisely authorizes the write while the file's DOS-READONLY bit is correctly ignored for the already-opened handle.

**NFS is unchanged** (path-based; flag stays false).

## Local verification

`go build ./...`, `go vet ./...`, `gofmt -l` clean. Passing: `./pkg/metadata/...` (incl. memory/badger/postgres conformance + cross-protocol matrix), `./internal/adapter/smb/...`, `./internal/adapter/nfs/...`, `./pkg/controlplane/...`.

Closes #1240