### PR TITLE
fix(perms): enforce per-user read-only share ceiling on NFS write path

### DIFF
--- a/pkg/metadata/auth_identity.go
+++ b/pkg/metadata/auth_identity.go
@@ -31,9 +31,14 @@ type AuthContext struct {
 	// Format: "IP:port" or just "IP"
 	ClientAddr string
 
-	// ShareReadOnly indicates whether the user has read-only access to the share
-	// This is determined by share-level user permissions (identity.SharePermission)
-	// When true, all write operations to this share should be denied
+	// ShareReadOnly indicates whether the user has read-only access to the share.
+	// This is the PER-USER share permission, resolved from the user's share grant
+	// (NFS auth_helper / SMB tree-connect), and is independent of the store-level
+	// ShareOptions.ReadOnly enforced inside calculatePermissions — a user can be
+	// read-only on a share whose stored options are read-write. When true the
+	// metadata permission funnel (checkFilePermissions / CheckParentCreateAccess /
+	// checkDeletePermission) strips write+delete so the ceiling applies uniformly
+	// to NFS and SMB, regardless of the file's POSIX mode or ACL grant (#1276).
 	ShareReadOnly bool
 
 	// WriteAuthorizedByHandle indicates that the SMB open handle driving this

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -274,9 +274,15 @@ func (s *Service) checkFilePermissions(ctx *AuthContext, handle FileHandle, requ
 	// NFS leaves WriteAuthorizedByHandle false (it has no handle), so NFS writes
 	// continue through the normal calculatePermissions path below.
 	//
-	// Note: ShareReadOnly takes precedence — if the share is read-only for this
-	// user, write permission is denied regardless of this flag.
-	if ctx.WriteAuthorizedByHandle && !ctx.ShareReadOnly && !acl.HasExplicitDeny(file.ACL) {
+	// Note: both read-only ceilings take precedence over the handle bypass —
+	// the per-user ctx.ShareReadOnly and the store-level shareOpts.ReadOnly (the
+	// share's configured read-only flag). If share options are toggled to
+	// read-only while a client still holds a previously write-authorized handle,
+	// the bypass must not let that handle keep writing past the share ceiling;
+	// the write falls through to calculatePermissions, which strips write for a
+	// read-only share.
+	shareReadOnly := shareOpts != nil && shareOpts.ReadOnly
+	if ctx.WriteAuthorizedByHandle && !ctx.ShareReadOnly && !shareReadOnly && !acl.HasExplicitDeny(file.ACL) {
 		// Only grant write-related permissions via the handle authorization.
 		// Read permissions still go through normal calculatePermissions checks.
 		writePerms := requested & (PermissionWrite | PermissionDelete)

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -287,7 +287,19 @@ func (s *Service) checkFilePermissions(ctx *AuthContext, handle FileHandle, requ
 		// For non-write requests (read-only), fall through to normal permission check
 	}
 
-	return calculatePermissions(file, ctx.Identity, shareOpts, requested), nil
+	granted := calculatePermissions(file, ctx.Identity, shareOpts, requested)
+
+	// Per-user read-only ceiling. ctx.ShareReadOnly is the user's resolved share
+	// permission and is independent of the store-level shareOpts.ReadOnly already
+	// applied inside calculatePermissions: a user can be read-only on a share
+	// whose stored options are read-write. Strip write+delete here so the ceiling
+	// is enforced at the single metadata funnel both protocols traverse — NFS
+	// write handlers have no compensating gate of their own, and the SMB
+	// handle-based bypass above is unreachable when ShareReadOnly is set. #1276.
+	if ctx.ShareReadOnly {
+		granted &^= PermissionWrite | PermissionDelete
+	}
+	return granted, nil
 }
 
 // calculatePermissions computes granted permissions based on file attributes and identity.
@@ -538,8 +550,11 @@ func (s *Service) CheckParentCreateAccess(ctx *AuthContext, parentHandle FileHan
 
 	shareOpts, _ := store.GetShareOptions(ctx.Context, file.ShareName)
 
-	// Share-level read-only beats any ACL grant.
-	if shareOpts != nil && shareOpts.ReadOnly {
+	// Read-only beats any ACL grant — both the per-user share permission
+	// (ctx.ShareReadOnly) and the store-level share option. Without the
+	// ctx.ShareReadOnly arm a read-only user could create entries under an
+	// ALLOW-granting parent DACL on an otherwise read-write share. #1276.
+	if ctx.ShareReadOnly || (shareOpts != nil && shareOpts.ReadOnly) {
 		return &StoreError{Code: ErrAccessDenied, Message: "write permission denied"}
 	}
 

--- a/pkg/metadata/auth_permissions_readonly_share_test.go
+++ b/pkg/metadata/auth_permissions_readonly_share_test.go
@@ -1,0 +1,112 @@
+package metadata_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckPermissions_PerUserReadOnlyStripsWrite asserts the #1276 fix: when a
+// user's PER-USER share permission is read-only (AuthContext.ShareReadOnly), the
+// metadata permission funnel strips write+delete even on a share whose stored
+// ShareOptions.ReadOnly is false and whose POSIX mode would grant write. This is
+// the NFS path (no handle flag); SMB shares the same funnel.
+func TestCheckPermissions_PerUserReadOnlyStripsWrite(t *testing.T) {
+	f := newTestFixture(t)
+
+	uid, gid := uint32(1000), uint32(1000)
+
+	// mode 0o666 owned by the requester — POSIX grants read+write.
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "rw.txt",
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o666, UID: uid, GID: gid})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(f.shareName, created.ID)
+	require.NoError(t, err)
+
+	// Baseline (read-write user): write granted.
+	rw := f.authContext(uid, gid)
+	got, err := f.service.CheckPermissions(rw, handle, metadata.PermissionWrite)
+	require.NoError(t, err)
+	require.NotZero(t, got&metadata.PermissionWrite, "precondition: write should be granted for read-write user")
+
+	// Read-only user: read granted, write+delete denied.
+	ro := f.authContext(uid, gid)
+	ro.ShareReadOnly = true
+
+	gotRead, err := f.service.CheckPermissions(ro, handle, metadata.PermissionRead)
+	require.NoError(t, err)
+	require.NotZero(t, gotRead&metadata.PermissionRead, "read must stay allowed on a read-only share")
+
+	gotWrite, err := f.service.CheckPermissions(ro, handle, metadata.PermissionWrite|metadata.PermissionDelete)
+	require.NoError(t, err)
+	if gotWrite&(metadata.PermissionWrite|metadata.PermissionDelete) != 0 {
+		t.Errorf("per-user read-only must strip write+delete, got 0x%x", gotWrite)
+	}
+}
+
+// TestCheckPermissions_PerUserReadOnlyStripsWriteWithACL asserts the ceiling
+// also beats an ALLOW ACL that would grant write — the per-user read-only flag
+// is enforced after ACL evaluation.
+func TestCheckPermissions_PerUserReadOnlyStripsWriteWithACL(t *testing.T) {
+	f := newTestFixture(t)
+
+	uid, gid := uint32(1001), uint32(1001)
+	allowAll := &acl.ACL{
+		ACEs: []acl.ACE{
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, Who: acl.SpecialEveryone, AccessMask: 0xFFFFFFFF},
+		},
+	}
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "acl.txt",
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o600, UID: uid, GID: gid, ACL: allowAll})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(f.shareName, created.ID)
+	require.NoError(t, err)
+
+	ro := f.authContext(uid, gid)
+	ro.ShareReadOnly = true
+
+	gotWrite, err := f.service.CheckPermissions(ro, handle, metadata.PermissionWrite)
+	require.NoError(t, err)
+	if gotWrite&metadata.PermissionWrite != 0 {
+		t.Errorf("per-user read-only must beat an ALLOW ACL write grant, got 0x%x", gotWrite)
+	}
+}
+
+// TestCheckParentCreateAccess_PerUserReadOnlyDenies asserts the create-path
+// ceiling: a read-only user cannot create an entry under an ALLOW-granting
+// parent DACL on an otherwise read-write share.
+func TestCheckParentCreateAccess_PerUserReadOnlyDenies(t *testing.T) {
+	f := newTestFixture(t)
+
+	uid, gid := uint32(1002), uint32(1002)
+	allowAll := &acl.ACL{
+		ACEs: []acl.ACE{
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, Who: acl.SpecialEveryone, AccessMask: 0xFFFFFFFF},
+		},
+	}
+	dir, _, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "rodir",
+		&metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o777, UID: uid, GID: gid, ACL: allowAll})
+	require.NoError(t, err)
+	dirHandle, err := metadata.EncodeShareHandle(f.shareName, dir.ID)
+	require.NoError(t, err)
+
+	ro := f.authContext(uid, gid)
+	ro.ShareReadOnly = true
+
+	err = f.service.CheckParentCreateAccess(ro, dirHandle, false)
+	if err == nil {
+		t.Fatal("CheckParentCreateAccess returned nil for read-only user, want ErrAccessDenied")
+	}
+	var storeErr *metadata.StoreError
+	if !errors.As(err, &storeErr) || storeErr.Code != metadata.ErrAccessDenied {
+		t.Fatalf("CheckParentCreateAccess err = %v, want StoreError{Code: ErrAccessDenied}", err)
+	}
+
+	// And the POSIX-only parent-write path (no ACL) must deny too.
+	if err := f.service.CheckParentWriteAccess(ro, f.rootHandle); err == nil {
+		t.Fatal("CheckParentWriteAccess returned nil for read-only user on POSIX-writable parent, want denied")
+	}
+}

--- a/pkg/metadata/auth_permissions_readonly_share_test.go
+++ b/pkg/metadata/auth_permissions_readonly_share_test.go
@@ -1,6 +1,7 @@
 package metadata_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -8,6 +9,44 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/acl"
 	"github.com/stretchr/testify/require"
 )
+
+// TestCheckPermissions_StoreReadOnlyShareBlocksHandleBypass asserts the
+// store-level read-only ceiling (ShareOptions.ReadOnly) also beats the SMB
+// handle-based write bypass: if a share is toggled read-only while a client
+// still holds a previously write-authorized handle (WriteAuthorizedByHandle),
+// the per-op check must not let that handle keep writing, even though the
+// per-user ctx.ShareReadOnly is false.
+func TestCheckPermissions_StoreReadOnlyShareBlocksHandleBypass(t *testing.T) {
+	f := newTestFixture(t)
+
+	uid, gid := uint32(1000), uint32(1000)
+	// Create the file BEFORE the share is read-only (a read-only share denies
+	// creation).
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "rw.txt",
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: uid, GID: gid})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(f.shareName, created.ID)
+	require.NoError(t, err)
+
+	// Register the share options entry (the fixture's CreateRootDirectory builds
+	// the file tree but not the share-options record) and toggle it read-only at
+	// the store level. CreateShare is a no-op-on-exists guard so the test is
+	// robust to either fixture shape.
+	_ = f.store.CreateShare(context.Background(), &metadata.Share{Name: f.shareName})
+	require.NoError(t, f.store.UpdateShareOptions(context.Background(), f.shareName,
+		&metadata.ShareOptions{ReadOnly: true}))
+
+	// SMB handle granted write at open; per-user ShareReadOnly is false.
+	authCtx := f.authContext(uid, gid)
+	authCtx.WriteAuthorizedByHandle = true
+	authCtx.ShareReadOnly = false
+
+	got, err := f.service.CheckPermissions(authCtx, handle, metadata.PermissionWrite)
+	require.NoError(t, err)
+	if got&metadata.PermissionWrite != 0 {
+		t.Errorf("store-level read-only share must block the handle write bypass, got 0x%x", got)
+	}
+}
 
 // TestCheckPermissions_PerUserReadOnlyStripsWrite asserts the #1276 fix: when a
 // user's PER-USER share permission is read-only (AuthContext.ShareReadOnly), the

--- a/pkg/metadata/auth_permissions_readonly_share_test.go
+++ b/pkg/metadata/auth_permissions_readonly_share_test.go
@@ -110,3 +110,80 @@ func TestCheckParentCreateAccess_PerUserReadOnlyDenies(t *testing.T) {
 		t.Fatal("CheckParentWriteAccess returned nil for read-only user on POSIX-writable parent, want denied")
 	}
 }
+
+// TestSetFileAttributes_PerUserReadOnlyDeniesOwnerMutation asserts the SETATTR
+// ceiling: a read-only user may not mutate even a file they OWN — chmod, chown,
+// and (most importantly) installing a permissive ACL must all be denied. Without
+// the ceiling the owner-bypass in SetFileAttributes would let a read-only owner
+// escalate access on their own file.
+func TestSetFileAttributes_PerUserReadOnlyDeniesOwnerMutation(t *testing.T) {
+	f := newTestFixture(t)
+
+	uid, gid := uint32(1500), uint32(1500)
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "owned.txt",
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: uid, GID: gid})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(f.shareName, created.ID)
+	require.NoError(t, err)
+
+	ro := f.authContext(uid, gid) // the OWNER
+	ro.ShareReadOnly = true
+
+	newMode := uint32(0o777)
+	openACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, Who: acl.SpecialEveryone, AccessMask: 0xFFFFFFFF},
+		},
+	}
+	cases := map[string]*metadata.SetAttrs{
+		"chmod": {Mode: &newMode},
+		"acl":   {ACL: openACL},
+		"chown": {UID: metadata.Uint32Ptr(2000)},
+		"utime": {MtimeNow: true},
+	}
+	for name, attrs := range cases {
+		_, err := f.service.SetFileAttributes(ro, handle, attrs)
+		if err == nil {
+			t.Errorf("%s: SetFileAttributes returned nil for read-only owner, want denied", name)
+			continue
+		}
+		var storeErr *metadata.StoreError
+		if !errors.As(err, &storeErr) || storeErr.Code != metadata.ErrAccessDenied {
+			t.Errorf("%s: err = %v, want StoreError{Code: ErrAccessDenied}", name, err)
+		}
+	}
+
+	// Sanity: the same owner on a read-write share CAN chmod.
+	rw := f.authContext(uid, gid)
+	if _, err := f.service.SetFileAttributes(rw, handle, &metadata.SetAttrs{Mode: &newMode}); err != nil {
+		t.Fatalf("precondition: owner chmod on read-write share should succeed, got %v", err)
+	}
+}
+
+// TestLockFile_PerUserReadOnlyDeniesExclusiveLock asserts a read-only user
+// cannot acquire an exclusive (write) byte-range lock, while a shared (read)
+// lock is still allowed.
+func TestLockFile_PerUserReadOnlyDeniesExclusiveLock(t *testing.T) {
+	f := newTestFixture(t)
+
+	uid, gid := uint32(1600), uint32(1600)
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "lockme.txt",
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o666, UID: uid, GID: gid})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(f.shareName, created.ID)
+	require.NoError(t, err)
+
+	ro := f.authContext(uid, gid)
+	ro.ShareReadOnly = true
+
+	// Exclusive (write) lock: denied.
+	err = f.service.LockFile(ro, handle, metadata.FileLock{SessionID: 1, Offset: 0, Length: 100, Exclusive: true})
+	if err == nil {
+		t.Error("LockFile(exclusive) returned nil for read-only user, want denied")
+	}
+
+	// Shared (read) lock: allowed.
+	if err := f.service.LockFile(ro, handle, metadata.FileLock{SessionID: 2, Offset: 0, Length: 100, Exclusive: false}); err != nil {
+		t.Errorf("LockFile(shared) for read-only user err = %v, want nil", err)
+	}
+}

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -229,6 +229,21 @@ func (s *Service) SetFileAttributes(ctx *AuthContext, handle FileHandle, attrs *
 	isOwner := identity != nil && identity.UID != nil && *identity.UID == file.UID
 	isRoot := identity != nil && identity.UID != nil && *identity.UID == 0
 
+	// Per-user read-only share ceiling (#1276). Every SETATTR mutation —
+	// chmod, chown/chgrp, ACL replace, explicit/utime-now timestamps, truncate —
+	// is a write, so a read-only user may perform none of them. This guard sits
+	// BEFORE the owner/root bypass below: without it, the isOwner short-circuit
+	// would let a read-only user mutate their own file (most dangerously, install
+	// a permissive DACL on it). Mirrors the write/delete strip in
+	// checkFilePermissions for the data path.
+	if ctx.ShareReadOnly {
+		return nil, &StoreError{
+			Code:    ErrAccessDenied,
+			Message: "read-only share: attribute change denied",
+			Path:    file.Path,
+		}
+	}
+
 	noOwnershipAttrs := attrs.Mode == nil && attrs.UID == nil && attrs.GID == nil
 
 	// POSIX: For utimensat() with UTIME_NOW, write permission is sufficient.

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -1046,13 +1046,15 @@ func (s *Service) LockFile(ctx *AuthContext, handle FileHandle, lock FileLock) e
 		requiredPerm = PermissionRead
 	}
 
-	// Get share options for permission check
-	shareOpts, err := store.GetShareOptions(ctx.Context, file.ShareName)
+	// Route through the shared permission funnel rather than calling
+	// calculatePermissions directly: checkFilePermissions applies the per-user
+	// read-only ceiling (#1276 — a read-only user must not take an exclusive
+	// write lock) and the SMB handle-based write authorization, keeping lock
+	// authorization consistent with every other write path.
+	granted, err := s.checkFilePermissions(ctx, handle, requiredPerm)
 	if err != nil {
-		shareOpts = nil // Continue without share options if unavailable
+		return err
 	}
-
-	granted := calculatePermissions(file, ctx.Identity, shareOpts, requiredPerm)
 	if granted&requiredPerm == 0 {
 		return NewPermissionDeniedError("")
 	}

--- a/pkg/metadata/storetest/cross_protocol_permissions.go
+++ b/pkg/metadata/storetest/cross_protocol_permissions.go
@@ -33,6 +33,7 @@ func RunCrossProtocolPermissionMatrix(t *testing.T, factory StoreFactory) {
 	t.Run("SIDOnlyGrant", func(t *testing.T) { testCrossProtocolSIDOnlyGrant(t, factory) })
 	t.Run("SIDOnlyDeny", func(t *testing.T) { testCrossProtocolSIDOnlyDeny(t, factory) })
 	t.Run("HandleWriteAuthorization", func(t *testing.T) { testCrossProtocolHandleWriteAuthorization(t, factory) })
+	t.Run("PerUserReadOnlyShare", func(t *testing.T) { testCrossProtocolPerUserReadOnlyShare(t, factory) })
 }
 
 // canonOp is a backend-neutral operation the matrix probes through every
@@ -485,4 +486,54 @@ func testCrossProtocolHandleWriteAuthorization(t *testing.T, factory StoreFactor
 	granted := f.userCtx(6600, 6600, grantSID)
 	assertLanesAgree(t, f, allowH, allowFile, granted, opRead, true)
 	assertLanesAgree(t, f, allowH, allowFile, granted, opWrite, true)
+}
+
+// testCrossProtocolPerUserReadOnlyShare pins the #1276 ceiling: when the
+// requester's PER-USER share permission is read-only (AuthContext.ShareReadOnly),
+// write is denied on every protocol even though the file's POSIX mode or ACL
+// would otherwise grant it — while read stays allowed. This is the restriction
+// direction complementing the handle/ACL grant cases above.
+//
+// ShareReadOnly is the per-user grant (set by NFS auth_helper / SMB tree-connect
+// from the resolved share permission); it is independent of the store-level
+// ShareOptions.ReadOnly. The share here is stored read-write, so only the
+// per-user flag forces the denial. The SMB lane's open-time gate (CheckFileAccess)
+// does not consult ShareReadOnly, so for a DACL-granting file it still mints a
+// write-authorized handle — but the operation-level metadata funnel (gate 2,
+// shared with NFS) strips write under ShareReadOnly, so both protocols agree.
+func testCrossProtocolPerUserReadOnlyShare(t *testing.T, factory StoreFactory) {
+	f := newCrossProtocolFixture(t, factory)
+
+	ownerUID, ownerGID := uint32(1300), uint32(1300)
+
+	// Case 1: no-ACL file, mode 0o666 — POSIX would grant write to everyone.
+	posixFile, posixH := f.createFile(t, "ro_user_posix.txt", &metadata.FileAttr{
+		Mode: 0o666, UID: ownerUID, GID: ownerGID,
+	})
+
+	// Read-write user: baseline write allowed (sanity that the file/grant is real).
+	rw := f.userCtx(ownerUID, ownerGID, "")
+	assertLanesAgree(t, f, posixH, posixFile, rw, opWrite, true)
+
+	// Read-only user (same identity, ShareReadOnly set): read allowed, write denied.
+	ro := f.userCtx(ownerUID, ownerGID, "")
+	ro.ShareReadOnly = true
+	assertLanesAgree(t, f, posixH, posixFile, ro, opRead, true)
+	assertLanesAgree(t, f, posixH, posixFile, ro, opWrite, false)
+
+	// Case 2: DACL granting EVERYONE@ full access — the ACL would grant write,
+	// but the per-user read-only ceiling must still deny it on every protocol.
+	allowAll := &acl.ACL{
+		ACEs: []acl.ACE{
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, Who: acl.SpecialEveryone, AccessMask: 0xFFFFFFFF},
+		},
+	}
+	aclFile, aclH := f.createFile(t, "ro_user_acl.txt", &metadata.FileAttr{
+		Mode: 0o600, UID: ownerUID, GID: ownerGID, ACL: allowAll,
+	})
+
+	roACL := f.userCtx(7700, 7700, "S-1-5-21-1-3-0-7700")
+	roACL.ShareReadOnly = true
+	assertLanesAgree(t, f, aclH, aclFile, roACL, opRead, true)
+	assertLanesAgree(t, f, aclH, aclFile, roACL, opWrite, false)
 }


### PR DESCRIPTION
## Problem

`AuthContext.ShareReadOnly` — the **per-user** share permission resolved by NFS `auth_helper`/`helpers` (from `permResult.ReadOnly`) and by SMB tree-connect — was consumed **only** in `checkDeletePermission` (as a guard on the `HasDeleteAccess` bypass). The actual write ceiling enforced in `calculatePermissions`/`evaluateWithACL` came from the **store-level** `ShareOptions.ReadOnly`, read fresh per request.

Consequence: a user whose *per-user* permission resolved to read-only (`ctx.ShareReadOnly=true`) but whose share's stored `ShareOptions.ReadOnly` was false could still write over **NFS** — `calculatePermissions` never saw the per-user flag. SMB had a compensating `HasWritePermission` gate in the WRITE/CREATE handlers; NFS write handlers had no equivalent. Pre-existing; surfaced by review of #1240.

## Fix

Enforce the per-user ceiling at the single metadata permission funnel both protocols traverse:

- **`checkFilePermissions`** — strip `PermissionWrite|PermissionDelete` from the computed grant when `ctx.ShareReadOnly`. Covers file write/read/execute and parent-write (`CheckParentWriteAccess`). The SMB handle-based bypass already required `!ShareReadOnly`, so it is unreachable when the flag is set.
- **`CheckParentCreateAccess`** — extend the read-only short-circuit to `ctx.ShareReadOnly || shareOpts.ReadOnly` so a read-only user can't create entries under an ALLOW-granting parent DACL.

Read stays allowed; only write/delete are stripped. NFS and SMB now reach the same decision at the shared choke point.

## Tests

- New `PerUserReadOnlyShare` case in the cross-protocol conformance matrix (`storetest`) — NFSv3/4.0/4.1/SMB all agree: write denied, read allowed, on both a POSIX-writable (mode 0o666) file and an ALLOW-ACL file, on a **read-write** share (only the per-user flag forces denial). Runs on memory/badger/postgres.
- Focused `pkg/metadata` unit tests for the NFS path (no handle flag): write+delete stripped on no-ACL and ALLOW-ACL files; `CheckParentCreateAccess`/`CheckParentWriteAccess` denied.

Closes #1276