### PR TITLE
feat(block): per-store durability + honest CLOSE/COMMIT (fixes #1274)

### DIFF
--- a/cmd/dfsctl/commands/store/block/stats.go
+++ b/cmd/dfsctl/commands/store/block/stats.go
@@ -83,8 +83,11 @@ func printBlockStoreStatsTable(resp *apiclient.BlockStoreStatsResponse) error {
 		{"Read Buffer Used", formatBytes(t.ReadBufferUsed)},
 		{"Read Buffer Max", formatBytes(t.ReadBufferMax)},
 		{"Has Remote", fmt.Sprintf("%v", t.HasRemote)},
+		{"Local Durable", fmt.Sprintf("%v", t.LocalDurable)},
+		{"Remote Durable", fmt.Sprintf("%v", t.RemoteDurable)},
 		{"Pending Syncs", fmt.Sprintf("%d", t.PendingSyncs)},
 		{"Pending Uploads", fmt.Sprintf("%d", t.PendingUploads)},
+		{"Pending Remote (bytes)", formatBytes(t.UnsyncedBytes)},
 		{"Completed Syncs", fmt.Sprintf("%d", t.CompletedSyncs)},
 		{"Failed Syncs", fmt.Sprintf("%d", t.FailedSyncs)},
 	}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -385,6 +385,63 @@ blockstore:
                                 # config max_log_bytes overrides this.
 ```
 
+#### Durability & the CLOSE/COMMIT contract (`durable`)
+
+Durability is a **per-store property**: whether bytes a store has accepted
+survive a daemon crash / restart. Each local and remote store resolves an
+effective `durable` flag at construction — a **type default** that an operator
+may override.
+
+| Store type | Kind | Default `durable` |
+|------------|------|-------------------|
+| `fs` | local | `true` — bytes are on disk; un-mirrored chunks are never evicted, survive restart, and re-mirror asynchronously |
+| `memory` | local | `false` — volatile, lost on restart |
+| `s3` | remote | `true` — durable object storage |
+| `memory` | remote | `false` — test/dev fixture, lost on restart |
+
+Override the default per store by adding a `durable` bool to the store's
+`config` JSON, e.g. for a local `fs` store on a volatile tmpfs mount:
+
+```sh
+dfsctl store block local edit <share> --config '{"durable": false}'
+```
+
+or to deliberately treat a memory store as durable in a test/dev setup:
+
+```sh
+dfsctl store block local edit <share> --config '{"durable": true}'
+```
+
+A non-bool `durable` value is ignored with a startup warning (the type default
+stands). The effective values are surfaced as `Local Durable` / `Remote
+Durable` in `dfsctl store block stats`.
+
+**CLOSE/COMMIT semantics.** SMB CLOSE and NFS COMMIT (and the NFSv3 stable-WRITE
+path) report success once data is on a **durable** store. The rule is:
+
+```
+committed := localDurable || (Finalized && remoteDurable)
+```
+
+- **Production (local `fs`):** `localDurable=true`, so CLOSE/COMMIT ack
+  immediately — there is **no wait** on the remote. The local→remote mirror
+  stays fully **asynchronous** (the syncer keeps draining in the background).
+  This is the fast path and is unchanged from prior releases.
+- **Volatile local (`memory`) + durable remote (`s3`):** the data is only safe
+  once it reaches the durable remote, so CLOSE/COMMIT succeeds only when the
+  flush is `Finalized`. While the remote is unhealthy or a mirror pass is
+  in-flight, CLOSE/COMMIT returns a transient I/O error (`NFS3ERR_IO` /
+  `NFS4ERR_IO` / SMB `STATUS_UNEXPECTED_IO_ERROR`) and the client re-drives —
+  the bytes remain in local CAS and the syncer keeps mirroring. (NFS *unstable*
+  WRITE is unaffected — it still returns `UNSTABLE` and defers durability to a
+  later COMMIT.)
+- **Volatile local with no remote (or a non-durable remote):** the data is never
+  durable, so CLOSE/COMMIT reports the same transient I/O error rather than
+  silently acknowledging a write that a crash would lose.
+
+`dfsctl store block stats` also shows `Pending Remote (bytes)` — the headline
+data-at-risk gauge (local CAS bytes not yet mirrored to the remote).
+
 #### GC knobs
 
 The CAS write path uses an async syncer and a fail-closed mark-sweep

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -417,16 +417,30 @@ stands). The effective values are surfaced as `Local Durable` / `Remote
 Durable` in `dfsctl store block stats`.
 
 **CLOSE/COMMIT semantics.** SMB CLOSE and NFS COMMIT (and the NFSv3 stable-WRITE
-path) report success once data is on a **durable** store. The rule is:
+path) call the engine flush. A **hard** flush error (I/O fault, remote rejection,
+metadata error) is **always** surfaced to the client regardless of the settings
+below. Beyond that, whether CLOSE/COMMIT waits for durability is governed by a
+per-share policy flag, `require_durable_commit` (default **false**):
 
+| `require_durable_commit` | CLOSE/COMMIT behavior |
+|--------------------------|-----------------------|
+| `false` (default) | Acknowledge once the flush succeeds — **regardless** of durability. The local→remote mirror stays fully **asynchronous** and observable via the unsynced-bytes metric / `Pending Remote (bytes)`. Ordinary NFS/POSIX writes **never** EIO. |
+| `true` (opt-in) | Acknowledge only when the data is on a **durable** store: `committed := localDurable \|\| (Finalized && remoteDurable)`. Trades latency for synchronous durability on non-fs-local stores. |
+
+Set it per share via the local block store config:
+
+```sh
+dfsctl store block local edit <share> --config '{"require_durable_commit": true}'
 ```
-committed := localDurable || (Finalized && remoteDurable)
-```
+
+A non-bool value is ignored with a startup warning (default `false` stands).
+
+When `require_durable_commit = true`, the strict rule resolves as follows:
 
 - **Production (local `fs`):** `localDurable=true`, so CLOSE/COMMIT ack
-  immediately — there is **no wait** on the remote. The local→remote mirror
-  stays fully **asynchronous** (the syncer keeps draining in the background).
-  This is the fast path and is unchanged from prior releases.
+  immediately — there is **no wait** on the remote, and the mirror stays fully
+  asynchronous. fs-local is always durable, so the flag is effectively a
+  **no-op** there (the fast path is identical to the default).
 - **Volatile local (`memory`) + durable remote (`s3`):** the data is only safe
   once it reaches the durable remote, so CLOSE/COMMIT succeeds only when the
   flush is `Finalized`. While the remote is unhealthy or a mirror pass is
@@ -439,8 +453,15 @@ committed := localDurable || (Finalized && remoteDurable)
   durable, so CLOSE/COMMIT reports the same transient I/O error rather than
   silently acknowledging a write that a crash would lose.
 
+In the **default** configuration none of the above transient errors occur —
+CLOSE/COMMIT acks on a successful flush and the syncer mirrors in the
+background. Use `require_durable_commit = true` only when you need synchronous
+durability guarantees on a volatile-local + durable-remote share and can accept
+the added latency.
+
 `dfsctl store block stats` also shows `Pending Remote (bytes)` — the headline
-data-at-risk gauge (local CAS bytes not yet mirrored to the remote).
+data-at-risk gauge (local CAS bytes not yet mirrored to the remote) — which is
+the way to observe the async mirror backlog under the default policy.
 
 #### GC knobs
 

--- a/internal/adapter/common/commit_durability_test.go
+++ b/internal/adapter/common/commit_durability_test.go
@@ -1,0 +1,153 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	localmemory "github.com/marmos91/dittofs/pkg/block/local/memory"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// newMemoryEngine builds an engine with an in-memory local store (NOT durable)
+// and the given remote (may be nil). The metadata memory store provides both
+// the FileBlockStore and SyncedHashStore so the syncer's mirror loop can run
+// and report Finalized=true after a write+flush.
+func newMemoryEngine(t *testing.T, remote *remotememory.Store, durableLocalOverride *bool) *engine.Store {
+	t.Helper()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	localStore := localmemory.New()
+	if durableLocalOverride != nil {
+		localStore.SetDurable(*durableLocalOverride)
+	}
+
+	cfg := engine.BlockStoreConfig{
+		Local:           localStore,
+		FileBlockStore:  ms,
+		SyncedHashStore: ms,
+	}
+	if remote != nil {
+		cfg.Remote = remote
+		cfg.Syncer = engine.NewSyncer(localStore, remote, ms, engine.DefaultConfig())
+	} else {
+		cfg.Syncer = engine.NewSyncer(localStore, nil, ms, engine.DefaultConfig())
+	}
+
+	bs, err := engine.New(cfg)
+	if err != nil {
+		t.Fatalf("engine.New: %v", err)
+	}
+	if err := bs.Start(context.Background()); err != nil {
+		t.Fatalf("engine.Start: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+	return bs
+}
+
+func writePayload(t *testing.T, bs *engine.Store, payloadID string) {
+	t.Helper()
+	data := []byte("durability-matrix-payload-bytes")
+	if err := WriteToBlockStore(context.Background(), bs, metadata.PayloadID(payloadID), data, 0); err != nil {
+		t.Fatalf("WriteToBlockStore: %v", err)
+	}
+}
+
+// TestCommitBlockStore_FSLocal_NoRemote_ReturnsNil asserts the FAST path: a
+// durable local (fs) store acks immediately regardless of remote state. This is
+// the production hot path — ErrNotDurableYet must NEVER occur.
+func TestCommitBlockStore_FSLocal_NoRemote_ReturnsNil(t *testing.T) {
+	bs := newTestEngine(t) // fs-backed local, nil remote
+	payloadID := "fs-local-no-remote"
+	writePayload(t, bs, payloadID)
+
+	if err := CommitBlockStore(context.Background(), bs, metadata.PayloadID(payloadID)); err != nil {
+		t.Fatalf("fs-local CommitBlockStore should return nil (durable, fast); got %v", err)
+	}
+	if !bs.LocalDurable() {
+		t.Fatal("fs local store must be durable")
+	}
+}
+
+// TestCommitBlockStore_MemoryLocal_HealthyDurableRemote_ReturnsNil asserts that
+// a volatile local store reaching a durable remote (Finalized=true) commits.
+func TestCommitBlockStore_MemoryLocal_HealthyDurableRemote_ReturnsNil(t *testing.T) {
+	remote := remotememory.New()
+	remote.SetDurable(true) // simulate a durable remote (s3 type-default)
+	bs := newMemoryEngine(t, remote, nil)
+	payloadID := "mem-local-durable-remote"
+	writePayload(t, bs, payloadID)
+
+	if !bs.RemoteDurable() {
+		t.Fatal("remote should report durable after SetDurable(true)")
+	}
+	if err := CommitBlockStore(context.Background(), bs, metadata.PayloadID(payloadID)); err != nil {
+		t.Fatalf("memory-local + durable remote (Finalized) should commit; got %v", err)
+	}
+}
+
+// TestCommitBlockStore_MemoryLocal_NonDurableRemote_NotDurableYet asserts that
+// even a Finalized flush to a NON-durable remote does not commit.
+func TestCommitBlockStore_MemoryLocal_NonDurableRemote_NotDurableYet(t *testing.T) {
+	remote := remotememory.New() // memory remote: NOT durable by default
+	bs := newMemoryEngine(t, remote, nil)
+	payloadID := "mem-local-nondurable-remote"
+	writePayload(t, bs, payloadID)
+
+	if bs.RemoteDurable() {
+		t.Fatal("memory remote should NOT be durable by default")
+	}
+	err := CommitBlockStore(context.Background(), bs, metadata.PayloadID(payloadID))
+	if !errors.Is(err, ErrNotDurableYet) {
+		t.Fatalf("memory-local + non-durable remote should be ErrNotDurableYet; got %v", err)
+	}
+}
+
+// TestCommitBlockStore_MemoryLocal_NoRemote_NotDurableYet asserts the honest
+// failure when nothing durable backs the data.
+func TestCommitBlockStore_MemoryLocal_NoRemote_NotDurableYet(t *testing.T) {
+	bs := newMemoryEngine(t, nil, nil)
+	payloadID := "mem-local-no-remote"
+	writePayload(t, bs, payloadID)
+
+	err := CommitBlockStore(context.Background(), bs, metadata.PayloadID(payloadID))
+	if !errors.Is(err, ErrNotDurableYet) {
+		t.Fatalf("memory-local + no remote should be ErrNotDurableYet; got %v", err)
+	}
+}
+
+// TestCommitBlockStore_ConfigOverride_FlipsBehavior asserts the per-store
+// durable override changes the commit decision: a memory local store marked
+// durable=true now acks on the fast path (no remote required).
+func TestCommitBlockStore_ConfigOverride_FlipsBehavior(t *testing.T) {
+	durable := true
+	bs := newMemoryEngine(t, nil, &durable) // memory local, FORCED durable, no remote
+	payloadID := "mem-local-override-durable"
+	writePayload(t, bs, payloadID)
+
+	if !bs.LocalDurable() {
+		t.Fatal("memory local store with override durable=true should report durable")
+	}
+	if err := CommitBlockStore(context.Background(), bs, metadata.PayloadID(payloadID)); err != nil {
+		t.Fatalf("override durable=true should commit on the fast path; got %v", err)
+	}
+
+	// And the inverse: fs local forced durable=false now requires a durable
+	// remote that it does not have → ErrNotDurableYet.
+	fsBS := newTestEngine(t)
+	if fsLocal := fsBS.LocalForTest(); fsLocal != nil {
+		if setter, ok := fsLocal.(interface{ SetDurable(bool) }); ok {
+			setter.SetDurable(false)
+		} else {
+			t.Fatal("fs local store must support SetDurable")
+		}
+	}
+	fsPayload := "fs-local-override-nondurable"
+	writePayload(t, fsBS, fsPayload)
+	err := CommitBlockStore(context.Background(), fsBS, metadata.PayloadID(fsPayload))
+	if !errors.Is(err, ErrNotDurableYet) {
+		t.Fatalf("fs local forced durable=false + no remote should be ErrNotDurableYet; got %v", err)
+	}
+}

--- a/internal/adapter/common/commit_durability_test.go
+++ b/internal/adapter/common/commit_durability_test.go
@@ -55,45 +55,96 @@ func writePayload(t *testing.T, bs *engine.Store, payloadID string) {
 	}
 }
 
-// TestCommitBlockStore_FSLocal_NoRemote_ReturnsNil asserts the FAST path: a
-// durable local (fs) store acks immediately regardless of remote state. This is
-// the production hot path — ErrNotDurableYet must NEVER occur.
-func TestCommitBlockStore_FSLocal_NoRemote_ReturnsNil(t *testing.T) {
-	bs := newTestEngine(t) // fs-backed local, nil remote
-	payloadID := "fs-local-no-remote"
+// --- Default policy (require_durable_commit = false) ---------------------
+//
+// This is the shipped default and the case that previously EIO'd pjdfstest:
+// strict durability enforcement is OPT-IN, so after a successful Flush the
+// commit seam acks unconditionally regardless of local/remote durability.
+
+// TestCommitBlockStore_Default_MemoryLocal_NoRemote_ReturnsNil is the exact
+// pjdfstest-breaking case: a volatile memory-local store with NO remote and
+// the default policy must return nil (NOT ErrNotDurableYet) from a CLOSE/
+// COMMIT after a successful flush.
+func TestCommitBlockStore_Default_MemoryLocal_NoRemote_ReturnsNil(t *testing.T) {
+	bs := newMemoryEngine(t, nil, nil) // memory local, no remote, default policy
+	payloadID := "default-mem-local-no-remote"
+	writePayload(t, bs, payloadID)
+
+	if bs.RequireDurableCommit() {
+		t.Fatal("default policy must be require_durable_commit=false")
+	}
+	if err := CommitBlockStore(context.Background(), bs, metadata.PayloadID(payloadID)); err != nil {
+		t.Fatalf("default policy: memory-local + no remote should ack (nil); got %v", err)
+	}
+}
+
+// TestCommitBlockStore_Default_MemoryLocal_NonDurableRemote_ReturnsNil asserts
+// that under the default policy even a non-durable remote does not block the
+// ack — the mirror stays async.
+func TestCommitBlockStore_Default_MemoryLocal_NonDurableRemote_ReturnsNil(t *testing.T) {
+	remote := remotememory.New() // memory remote: NOT durable by default
+	bs := newMemoryEngine(t, remote, nil)
+	payloadID := "default-mem-local-nondurable-remote"
 	writePayload(t, bs, payloadID)
 
 	if err := CommitBlockStore(context.Background(), bs, metadata.PayloadID(payloadID)); err != nil {
-		t.Fatalf("fs-local CommitBlockStore should return nil (durable, fast); got %v", err)
+		t.Fatalf("default policy: memory-local + non-durable remote should ack (nil); got %v", err)
+	}
+}
+
+// --- Strict policy (require_durable_commit = true) ------------------------
+//
+// Opt-in honest enforcement: CLOSE/COMMIT only succeeds when the data is on a
+// durable store (localDurable || (Finalized && remoteDurable)).
+
+// strict enables the opt-in honest-durability policy on bs and returns it.
+func strict(bs *engine.Store) *engine.Store {
+	bs.SetRequireDurableCommit(true)
+	return bs
+}
+
+// TestCommitBlockStore_Strict_FSLocal_NoRemote_ReturnsNil asserts the FAST
+// path under strict mode: a durable local (fs) store acks immediately
+// regardless of remote state. fs-local is always durable so the strict flag is
+// a no-op there.
+func TestCommitBlockStore_Strict_FSLocal_NoRemote_ReturnsNil(t *testing.T) {
+	bs := strict(newTestEngine(t)) // fs-backed local, nil remote
+	payloadID := "strict-fs-local-no-remote"
+	writePayload(t, bs, payloadID)
+
+	if err := CommitBlockStore(context.Background(), bs, metadata.PayloadID(payloadID)); err != nil {
+		t.Fatalf("strict fs-local CommitBlockStore should return nil (durable, fast); got %v", err)
 	}
 	if !bs.LocalDurable() {
 		t.Fatal("fs local store must be durable")
 	}
 }
 
-// TestCommitBlockStore_MemoryLocal_HealthyDurableRemote_ReturnsNil asserts that
-// a volatile local store reaching a durable remote (Finalized=true) commits.
-func TestCommitBlockStore_MemoryLocal_HealthyDurableRemote_ReturnsNil(t *testing.T) {
+// TestCommitBlockStore_Strict_MemoryLocal_HealthyDurableRemote_ReturnsNil
+// asserts that under strict mode a volatile local store reaching a durable
+// remote (Finalized=true) commits.
+func TestCommitBlockStore_Strict_MemoryLocal_HealthyDurableRemote_ReturnsNil(t *testing.T) {
 	remote := remotememory.New()
 	remote.SetDurable(true) // simulate a durable remote (s3 type-default)
-	bs := newMemoryEngine(t, remote, nil)
-	payloadID := "mem-local-durable-remote"
+	bs := strict(newMemoryEngine(t, remote, nil))
+	payloadID := "strict-mem-local-durable-remote"
 	writePayload(t, bs, payloadID)
 
 	if !bs.RemoteDurable() {
 		t.Fatal("remote should report durable after SetDurable(true)")
 	}
 	if err := CommitBlockStore(context.Background(), bs, metadata.PayloadID(payloadID)); err != nil {
-		t.Fatalf("memory-local + durable remote (Finalized) should commit; got %v", err)
+		t.Fatalf("strict memory-local + durable remote (Finalized) should commit; got %v", err)
 	}
 }
 
-// TestCommitBlockStore_MemoryLocal_NonDurableRemote_NotDurableYet asserts that
-// even a Finalized flush to a NON-durable remote does not commit.
-func TestCommitBlockStore_MemoryLocal_NonDurableRemote_NotDurableYet(t *testing.T) {
+// TestCommitBlockStore_Strict_MemoryLocal_NonDurableRemote_NotDurableYet
+// asserts that under strict mode even a Finalized flush to a NON-durable
+// remote does not commit.
+func TestCommitBlockStore_Strict_MemoryLocal_NonDurableRemote_NotDurableYet(t *testing.T) {
 	remote := remotememory.New() // memory remote: NOT durable by default
-	bs := newMemoryEngine(t, remote, nil)
-	payloadID := "mem-local-nondurable-remote"
+	bs := strict(newMemoryEngine(t, remote, nil))
+	payloadID := "strict-mem-local-nondurable-remote"
 	writePayload(t, bs, payloadID)
 
 	if bs.RemoteDurable() {
@@ -101,42 +152,43 @@ func TestCommitBlockStore_MemoryLocal_NonDurableRemote_NotDurableYet(t *testing.
 	}
 	err := CommitBlockStore(context.Background(), bs, metadata.PayloadID(payloadID))
 	if !errors.Is(err, ErrNotDurableYet) {
-		t.Fatalf("memory-local + non-durable remote should be ErrNotDurableYet; got %v", err)
+		t.Fatalf("strict memory-local + non-durable remote should be ErrNotDurableYet; got %v", err)
 	}
 }
 
-// TestCommitBlockStore_MemoryLocal_NoRemote_NotDurableYet asserts the honest
-// failure when nothing durable backs the data.
-func TestCommitBlockStore_MemoryLocal_NoRemote_NotDurableYet(t *testing.T) {
-	bs := newMemoryEngine(t, nil, nil)
-	payloadID := "mem-local-no-remote"
+// TestCommitBlockStore_Strict_MemoryLocal_NoRemote_NotDurableYet asserts the
+// honest failure under strict mode when nothing durable backs the data.
+func TestCommitBlockStore_Strict_MemoryLocal_NoRemote_NotDurableYet(t *testing.T) {
+	bs := strict(newMemoryEngine(t, nil, nil))
+	payloadID := "strict-mem-local-no-remote"
 	writePayload(t, bs, payloadID)
 
 	err := CommitBlockStore(context.Background(), bs, metadata.PayloadID(payloadID))
 	if !errors.Is(err, ErrNotDurableYet) {
-		t.Fatalf("memory-local + no remote should be ErrNotDurableYet; got %v", err)
+		t.Fatalf("strict memory-local + no remote should be ErrNotDurableYet; got %v", err)
 	}
 }
 
-// TestCommitBlockStore_ConfigOverride_FlipsBehavior asserts the per-store
-// durable override changes the commit decision: a memory local store marked
-// durable=true now acks on the fast path (no remote required).
-func TestCommitBlockStore_ConfigOverride_FlipsBehavior(t *testing.T) {
+// TestCommitBlockStore_Strict_ConfigOverride_FlipsBehavior asserts the
+// per-store durable override changes the commit decision under strict mode: a
+// memory local store marked durable=true now acks on the fast path (no remote
+// required).
+func TestCommitBlockStore_Strict_ConfigOverride_FlipsBehavior(t *testing.T) {
 	durable := true
-	bs := newMemoryEngine(t, nil, &durable) // memory local, FORCED durable, no remote
-	payloadID := "mem-local-override-durable"
+	bs := strict(newMemoryEngine(t, nil, &durable)) // memory local, FORCED durable, no remote
+	payloadID := "strict-mem-local-override-durable"
 	writePayload(t, bs, payloadID)
 
 	if !bs.LocalDurable() {
 		t.Fatal("memory local store with override durable=true should report durable")
 	}
 	if err := CommitBlockStore(context.Background(), bs, metadata.PayloadID(payloadID)); err != nil {
-		t.Fatalf("override durable=true should commit on the fast path; got %v", err)
+		t.Fatalf("strict override durable=true should commit on the fast path; got %v", err)
 	}
 
-	// And the inverse: fs local forced durable=false now requires a durable
-	// remote that it does not have → ErrNotDurableYet.
-	fsBS := newTestEngine(t)
+	// And the inverse: fs local forced durable=false under strict mode now
+	// requires a durable remote that it does not have → ErrNotDurableYet.
+	fsBS := strict(newTestEngine(t))
 	if fsLocal := fsBS.LocalForTest(); fsLocal != nil {
 		if setter, ok := fsLocal.(interface{ SetDurable(bool) }); ok {
 			setter.SetDurable(false)
@@ -144,10 +196,10 @@ func TestCommitBlockStore_ConfigOverride_FlipsBehavior(t *testing.T) {
 			t.Fatal("fs local store must support SetDurable")
 		}
 	}
-	fsPayload := "fs-local-override-nondurable"
+	fsPayload := "strict-fs-local-override-nondurable"
 	writePayload(t, fsBS, fsPayload)
 	err := CommitBlockStore(context.Background(), fsBS, metadata.PayloadID(fsPayload))
 	if !errors.Is(err, ErrNotDurableYet) {
-		t.Fatalf("fs local forced durable=false + no remote should be ErrNotDurableYet; got %v", err)
+		t.Fatalf("strict fs local forced durable=false + no remote should be ErrNotDurableYet; got %v", err)
 	}
 }

--- a/internal/adapter/common/content_errmap.go
+++ b/internal/adapter/common/content_errmap.go
@@ -56,6 +56,12 @@ func MapContentToNFS3(err error) uint32 {
 	if goerrors.Is(err, block.ErrRemoteUnavailable) {
 		return nfs3types.NFS3ErrIO
 	}
+	// Data committed locally but not yet durable (volatile local store, durable
+	// remote not reached) — transient I/O error so the client re-drives
+	// COMMIT/CLOSE (#1274). Never occurs on the fs-local production hot path.
+	if goerrors.Is(err, ErrNotDurableYet) {
+		return nfs3types.NFS3ErrIO
+	}
 	return nfs3types.NFS3ErrIO
 }
 
@@ -79,6 +85,11 @@ func MapContentToNFS4(err error) uint32 {
 		return nfs4types.NFS4ERR_IO
 	}
 	if goerrors.Is(err, block.ErrRemoteUnavailable) {
+		return nfs4types.NFS4ERR_IO
+	}
+	// Not yet durable (see MapContentToNFS3) — transient I/O so the client
+	// re-drives COMMIT/CLOSE (#1274).
+	if goerrors.Is(err, ErrNotDurableYet) {
 		return nfs4types.NFS4ERR_IO
 	}
 	return nfs4types.NFS4ERR_IO
@@ -112,6 +123,12 @@ func MapContentToSMB(err error) smbtypes.Status {
 		return smbtypes.StatusUnexpectedIOError
 	}
 	if goerrors.Is(err, block.ErrRemoteUnavailable) {
+		return smbtypes.StatusUnexpectedIOError
+	}
+	// Data committed locally but not yet durable (volatile local store, durable
+	// remote not reached) — STATUS_UNEXPECTED_IO_ERROR so the client re-drives
+	// CLOSE/flush (#1274). Never occurs on the fs-local production hot path.
+	if goerrors.Is(err, ErrNotDurableYet) {
 		return smbtypes.StatusUnexpectedIOError
 	}
 	return smbtypes.StatusUnexpectedIOError

--- a/internal/adapter/common/content_errmap_test.go
+++ b/internal/adapter/common/content_errmap_test.go
@@ -198,3 +198,29 @@ func TestContentErrMap_PressureTimeout_SurfacedNonSuccess(t *testing.T) {
 		}
 	}
 }
+
+// TestContentErrMap_NotDurableYet verifies the #1274 ErrNotDurableYet sentinel
+// (data committed locally but not yet on a durable store) maps to I/O-class
+// codes in every protocol arm so the client re-drives COMMIT/CLOSE, both as the
+// bare sentinel and wrapped.
+func TestContentErrMap_NotDurableYet(t *testing.T) {
+	cases := []error{
+		ErrNotDurableYet,
+		fmt.Errorf("commit payload p1: %w", ErrNotDurableYet),
+	}
+	for _, err := range cases {
+		if got := MapContentToNFS3(err); got != nfs3types.NFS3ErrIO {
+			t.Errorf("MapContentToNFS3(%v) = %d, want NFS3ErrIO", err, got)
+		}
+		if got := MapContentToNFS4(err); got != nfs4types.NFS4ERR_IO {
+			t.Errorf("MapContentToNFS4(%v) = %d, want NFS4ERR_IO", err, got)
+		}
+		if got := MapContentToSMB(err); got != smbtypes.StatusUnexpectedIOError {
+			t.Errorf("MapContentToSMB(%v) = %v, want StatusUnexpectedIOError", err, got)
+		}
+		// Must never look successful.
+		if MapContentToSMB(err) == smbtypes.StatusSuccess {
+			t.Errorf("ErrNotDurableYet must not map to StatusSuccess")
+		}
+	}
+}

--- a/internal/adapter/common/write_payload.go
+++ b/internal/adapter/common/write_payload.go
@@ -8,7 +8,9 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// ErrNotDurableYet is returned by CommitBlockStore when a CLOSE / COMMIT cannot
+// ErrNotDurableYet is returned by CommitBlockStore ONLY when a share has
+// opted into strict honest-durability enforcement
+// (config["require_durable_commit"] = true) and a CLOSE / COMMIT cannot
 // honestly report success: the share's local store is NOT durable (e.g. an
 // in-memory local store) AND the data has not yet reached a durable remote
 // (the engine FlushResult is not Finalized, or the remote is itself not
@@ -18,9 +20,12 @@ import (
 // a transient I/O error (NFS3ERR_IO / NFS4ERR_IO / SMB STATUS_UNEXPECTED_IO_ERROR)
 // and the client re-drives COMMIT/CLOSE.
 //
-// In the common production configuration (fs local store) this sentinel NEVER
-// occurs: CommitBlockStore returns nil on the fast local-durable path before it
-// is ever reached, and the remote mirror stays fully asynchronous. See #1274.
+// This sentinel is NEVER returned in the default configuration
+// (require_durable_commit = false): CommitBlockStore acks once engine.Flush
+// succeeds and the remote mirror stays fully asynchronous and observable via
+// the unsynced-bytes metric. Even when strict enforcement IS enabled, the
+// common production case (fs local store) returns nil on the fast
+// local-durable path before this is ever reached. See #1274.
 var ErrNotDurableYet = errors.New("block: data not yet durable (local store is volatile and durable remote not reached)")
 
 // WriteToBlockStore is the structural twin of ReadFromBlockStore. It is a
@@ -65,27 +70,37 @@ func WriteToBlockStore(
 // that call so a later refactor can add BlockRef-aware plumbing once,
 // keeping protocol-handler code unchanged.
 //
-// CommitBlockStore applies the honest per-store durability commit rule (#1274).
-// A payload is "committed" (CLOSE/COMMIT may report success) iff
-//
-//	localDurable || (Finalized && remoteDurable)
-//
-// where localDurable / remoteDurable come from the engine's per-store
-// DurabilityReporter and Finalized comes from the engine FlushResult:
-//
-//   - Production (fs local store): localDurable=true → ack immediately on the
-//     FAST path, with no remote wait. The remote mirror stays fully async (the
-//     syncer keeps draining in the background) and ErrNotDurableYet is never
-//     returned.
-//   - memory local + durable remote (s3): the bytes are only safe once they
-//     reach the durable remote, so success requires FlushResult.Finalized.
-//     A transient unhealthy-remote / uploader-gate-contention flush returns
-//     {Finalized:false} → ErrNotDurableYet so the client re-drives.
-//   - memory local with no remote / a non-durable remote: never durable →
-//     ErrNotDurableYet (honest failure rather than silent loss).
-//
 // A hard flush error (I/O fault, remote.Put rejection, metadata error) is
-// returned unchanged.
+// ALWAYS surfaced unchanged (the #1267 fix) — engine.Flush returning a non-nil
+// error propagates regardless of policy.
+//
+// Beyond that, durability acknowledgement is governed by the per-share policy
+// flag RequireDurableCommit (config["require_durable_commit"], default false):
+//
+//   - DEFAULT (RequireDurableCommit == false): once engine.Flush succeeds,
+//     CommitBlockStore returns nil unconditionally — CLOSE/COMMIT acknowledge
+//     regardless of local/remote durability. The remote mirror stays fully
+//     asynchronous and observable via the unsynced-bytes metric. This
+//     preserves the fast async design and the normal NFS/POSIX path (ordinary
+//     writes never EIO).
+//
+//   - STRICT (RequireDurableCommit == true): apply the honest per-store
+//     durability rule — a payload is "committed" iff
+//
+//     localDurable || (Finalized && remoteDurable)
+//
+//     where localDurable / remoteDurable come from the engine's per-store
+//     DurabilityReporter and Finalized comes from the engine FlushResult:
+//
+//   - fs local store: localDurable=true → ack immediately on the FAST
+//     path, no remote wait (the flag is a no-op for fs-local).
+//
+//   - memory local + durable remote (s3): success requires
+//     FlushResult.Finalized; a transient unhealthy-remote flush returns
+//     {Finalized:false} → ErrNotDurableYet so the client re-drives.
+//
+//   - memory local with no remote / a non-durable remote: never durable →
+//     ErrNotDurableYet (the operator opted into honest failure).
 func CommitBlockStore(
 	ctx context.Context,
 	blockStore *engine.Store,
@@ -95,6 +110,11 @@ func CommitBlockStore(
 	if err != nil {
 		// Hard error: unchanged behavior (mapped via the content errmap).
 		return err
+	}
+	// DEFAULT: strict durability enforcement is opt-in. A successful flush is
+	// enough to ack — the remote mirror stays async and observable.
+	if !blockStore.RequireDurableCommit() {
+		return nil
 	}
 	// FAST path: a durable local store means the bytes already survive a
 	// restart; ack without waiting for the async remote mirror.

--- a/internal/adapter/common/write_payload.go
+++ b/internal/adapter/common/write_payload.go
@@ -2,10 +2,26 @@ package common
 
 import (
 	"context"
+	"errors"
 
 	"github.com/marmos91/dittofs/pkg/block/engine"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
+
+// ErrNotDurableYet is returned by CommitBlockStore when a CLOSE / COMMIT cannot
+// honestly report success: the share's local store is NOT durable (e.g. an
+// in-memory local store) AND the data has not yet reached a durable remote
+// (the engine FlushResult is not Finalized, or the remote is itself not
+// durable). The bytes are still safe in local CAS and the background syncer
+// will keep re-driving the mirror, but a crash before that completes would lose
+// data the client was told CLOSE succeeded on — so the protocol adapter returns
+// a transient I/O error (NFS3ERR_IO / NFS4ERR_IO / SMB STATUS_UNEXPECTED_IO_ERROR)
+// and the client re-drives COMMIT/CLOSE.
+//
+// In the common production configuration (fs local store) this sentinel NEVER
+// occurs: CommitBlockStore returns nil on the fast local-durable path before it
+// is ever reached, and the remote mirror stays fully asynchronous. See #1274.
+var ErrNotDurableYet = errors.New("block: data not yet durable (local store is volatile and durable remote not reached)")
 
 // WriteToBlockStore is the structural twin of ReadFromBlockStore. It is a
 // direct passthrough to engine.WriteAt today — there is no FileAttr.Blocks
@@ -49,15 +65,48 @@ func WriteToBlockStore(
 // that call so a later refactor can add BlockRef-aware plumbing once,
 // keeping protocol-handler code unchanged.
 //
-// It is currently a direct passthrough; the *block.FlushResult from
-// the engine is dropped because every existing call site already ignores
-// it (only the error is acted on). If per-file flush telemetry becomes
-// needed, widen the signature then.
+// CommitBlockStore applies the honest per-store durability commit rule (#1274).
+// A payload is "committed" (CLOSE/COMMIT may report success) iff
+//
+//	localDurable || (Finalized && remoteDurable)
+//
+// where localDurable / remoteDurable come from the engine's per-store
+// DurabilityReporter and Finalized comes from the engine FlushResult:
+//
+//   - Production (fs local store): localDurable=true → ack immediately on the
+//     FAST path, with no remote wait. The remote mirror stays fully async (the
+//     syncer keeps draining in the background) and ErrNotDurableYet is never
+//     returned.
+//   - memory local + durable remote (s3): the bytes are only safe once they
+//     reach the durable remote, so success requires FlushResult.Finalized.
+//     A transient unhealthy-remote / uploader-gate-contention flush returns
+//     {Finalized:false} → ErrNotDurableYet so the client re-drives.
+//   - memory local with no remote / a non-durable remote: never durable →
+//     ErrNotDurableYet (honest failure rather than silent loss).
+//
+// A hard flush error (I/O fault, remote.Put rejection, metadata error) is
+// returned unchanged.
 func CommitBlockStore(
 	ctx context.Context,
 	blockStore *engine.Store,
 	payloadID metadata.PayloadID,
 ) error {
-	_, err := blockStore.Flush(ctx, string(payloadID))
-	return err
+	res, err := blockStore.Flush(ctx, string(payloadID))
+	if err != nil {
+		// Hard error: unchanged behavior (mapped via the content errmap).
+		return err
+	}
+	// FAST path: a durable local store means the bytes already survive a
+	// restart; ack without waiting for the async remote mirror.
+	if blockStore.LocalDurable() {
+		return nil
+	}
+	// Local store is volatile: success requires the data to have reached a
+	// durable remote (Finalized AND the remote is itself durable).
+	if res != nil && res.Finalized && blockStore.RemoteDurable() {
+		return nil
+	}
+	// Not yet durable anywhere that survives a crash — report so the client
+	// re-drives. The bytes remain in local CAS and the syncer keeps mirroring.
+	return ErrNotDurableYet
 }

--- a/internal/adapter/smb/handlers/close_mfsymlink_test.go
+++ b/internal/adapter/smb/handlers/close_mfsymlink_test.go
@@ -53,17 +53,12 @@ func setupMFsymlinkShare(t *testing.T, allowMFsymlink bool, target string) (*Han
 		t.Fatalf("RegisterMetadataStore: %v", err)
 	}
 
-	// #1274: mark this memory local store durable via the per-store config
-	// override so CLOSE acks SUCCESS (the honest commit rule otherwise reports
-	// ErrNotDurableYet for a volatile memory-local share). This test exercises
-	// MFsymlink conversion, not durability.
-	mfBlockCfg := &models.BlockStoreConfig{
+	// A plain memory local store suffices: require_durable_commit defaults to
+	// false, so CLOSE acks once the flush succeeds regardless of durability
+	// (#1274). This test exercises MFsymlink conversion, not durability.
+	localBSID, err := cps.CreateBlockStore(ctx, &models.BlockStoreConfig{
 		Name: "mfbs", Kind: models.BlockStoreKindLocal, Type: "memory",
-	}
-	if err := mfBlockCfg.SetConfig(map[string]any{"durable": true}); err != nil {
-		t.Fatalf("SetConfig durable: %v", err)
-	}
-	localBSID, err := cps.CreateBlockStore(ctx, mfBlockCfg)
+	})
 	if err != nil {
 		t.Fatalf("CreateBlockStore: %v", err)
 	}

--- a/internal/adapter/smb/handlers/close_mfsymlink_test.go
+++ b/internal/adapter/smb/handlers/close_mfsymlink_test.go
@@ -53,9 +53,17 @@ func setupMFsymlinkShare(t *testing.T, allowMFsymlink bool, target string) (*Han
 		t.Fatalf("RegisterMetadataStore: %v", err)
 	}
 
-	localBSID, err := cps.CreateBlockStore(ctx, &models.BlockStoreConfig{
+	// #1274: mark this memory local store durable via the per-store config
+	// override so CLOSE acks SUCCESS (the honest commit rule otherwise reports
+	// ErrNotDurableYet for a volatile memory-local share). This test exercises
+	// MFsymlink conversion, not durability.
+	mfBlockCfg := &models.BlockStoreConfig{
 		Name: "mfbs", Kind: models.BlockStoreKindLocal, Type: "memory",
-	})
+	}
+	if err := mfBlockCfg.SetConfig(map[string]any{"durable": true}); err != nil {
+		t.Fatalf("SetConfig durable: %v", err)
+	}
+	localBSID, err := cps.CreateBlockStore(ctx, mfBlockCfg)
 	if err != nil {
 		t.Fatalf("CreateBlockStore: %v", err)
 	}

--- a/pkg/block/blockstore.go
+++ b/pkg/block/blockstore.go
@@ -202,3 +202,38 @@ type BlockStoreAppend interface {
 	// GC.
 	DeleteAppendLog(ctx context.Context, payloadID string) error
 }
+
+// DurabilityReporter is an optional capability a block store (local or
+// remote) MAY implement to report whether data it has accepted survives a
+// process crash / restart.
+//
+// Durability is a per-store property and is the foundation of the honest
+// CLOSE/COMMIT contract (#1274). The commit rule used by the adapter flush
+// seam (internal/adapter/common.CommitBlockStore) is:
+//
+//	committed := localDurable || (Finalized && remoteDurable)
+//
+// where localDurable / remoteDurable are read from the local / remote store's
+// Durable() report and Finalized comes from the engine FlushResult.
+//
+// Type defaults (resolved at construction; an operator may override via the
+// per-store config["durable"] bool):
+//
+//   - local fs store        → true  (bytes are on disk, un-mirrored chunks are
+//     not evicted, survive restart, re-mirror async)
+//   - local memory store    → false (lost on crash/restart)
+//   - remote s3 store       → true  (durable object storage)
+//   - remote memory store   → false (test fixture, lost on restart)
+//
+// Stores that do NOT implement this interface are treated conservatively by
+// callers (assumed NOT durable) so a missing capability never lets the server
+// over-promise durability.
+//
+// Decorators (encryption, compression) MUST delegate Durable() to the wrapped
+// store: wrapping a durable backend does not change where the bytes ultimately
+// land.
+type DurabilityReporter interface {
+	// Durable reports whether data accepted by this store survives a
+	// process crash or restart of the daemon.
+	Durable() bool
+}

--- a/pkg/block/blockstore.go
+++ b/pkg/block/blockstore.go
@@ -237,3 +237,15 @@ type DurabilityReporter interface {
 	// process crash or restart of the daemon.
 	Durable() bool
 }
+
+// IsDurable reports the conservative durability of store. A store that
+// implements DurabilityReporter answers for itself; one that does not (or a nil
+// store) is treated as NOT durable so callers never over-promise durability.
+// This is the single place the missing-capability default lives — engine
+// accessors and the encryption / compression decorators all route through it.
+func IsDurable(store any) bool {
+	if r, ok := store.(DurabilityReporter); ok {
+		return r.Durable()
+	}
+	return false
+}

--- a/pkg/block/compression/decorator.go
+++ b/pkg/block/compression/decorator.go
@@ -246,8 +246,21 @@ func (d *Decorator) Healthcheck(ctx context.Context) health.Report {
 	return d.inner.Healthcheck(ctx)
 }
 
+// Durable delegates to the wrapped store (block.DurabilityReporter). Compressing
+// block bodies does not change where the bytes ultimately land, so a durable
+// inner store stays durable through the decorator. If the wrapped store does
+// not implement DurabilityReporter we fall back to the conservative default
+// (false) so the server never over-promises durability.
+func (d *Decorator) Durable() bool {
+	if r, ok := d.inner.(block.DurabilityReporter); ok {
+		return r.Durable()
+	}
+	return false
+}
+
 // Compile-time interface assertions.
 var (
-	_ block.Store        = (*Decorator)(nil)
-	_ remote.RemoteStore = (*Decorator)(nil)
+	_ block.Store              = (*Decorator)(nil)
+	_ remote.RemoteStore       = (*Decorator)(nil)
+	_ block.DurabilityReporter = (*Decorator)(nil)
 )

--- a/pkg/block/compression/decorator.go
+++ b/pkg/block/compression/decorator.go
@@ -246,16 +246,12 @@ func (d *Decorator) Healthcheck(ctx context.Context) health.Report {
 	return d.inner.Healthcheck(ctx)
 }
 
-// Durable delegates to the wrapped store (block.DurabilityReporter). Compressing
-// block bodies does not change where the bytes ultimately land, so a durable
-// inner store stays durable through the decorator. If the wrapped store does
-// not implement DurabilityReporter we fall back to the conservative default
-// (false) so the server never over-promises durability.
+// Durable delegates to the wrapped store via block.IsDurable. Compressing block
+// bodies does not change where the bytes ultimately land, so a durable inner
+// store stays durable through the decorator; a wrapped store that does not
+// report durability falls back to the conservative default (false).
 func (d *Decorator) Durable() bool {
-	if r, ok := d.inner.(block.DurabilityReporter); ok {
-		return r.Durable()
-	}
-	return false
+	return block.IsDurable(d.inner)
 }
 
 // Compile-time interface assertions.

--- a/pkg/block/compression/durability_test.go
+++ b/pkg/block/compression/durability_test.go
@@ -1,0 +1,30 @@
+package compression
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+)
+
+// TestDecorator_Durable_DelegatesToInner verifies the compression decorator
+// delegates Durable() to the wrapped store (#1274): wrapping a durable backend
+// keeps it durable; wrapping a non-durable one stays non-durable.
+func TestDecorator_Durable_DelegatesToInner(t *testing.T) {
+	inner := remotememory.New() // memory remote: NOT durable by default
+	d, err := NewRemote(inner, CompressionPolicy{Algo: AlgoZstd})
+	if err != nil {
+		t.Fatalf("NewRemote: %v", err)
+	}
+
+	var _ block.DurabilityReporter = d
+
+	if d.Durable() {
+		t.Fatal("compressing a non-durable inner store must stay NOT durable")
+	}
+
+	inner.SetDurable(true) // simulate a durable remote (e.g. s3)
+	if !d.Durable() {
+		t.Fatal("compressing a durable inner store must report durable (delegation)")
+	}
+}

--- a/pkg/block/encryption/decorator.go
+++ b/pkg/block/encryption/decorator.go
@@ -209,16 +209,12 @@ func (d *EncryptedRemote) Healthcheck(ctx context.Context) health.Report {
 	return d.inner.Healthcheck(ctx)
 }
 
-// Durable delegates to the wrapped store (block.DurabilityReporter). Encrypting
-// block bodies does not change where the bytes ultimately land, so a durable
-// inner store stays durable through the decorator. If the wrapped store does
-// not implement DurabilityReporter we fall back to the conservative default
-// (false) so the server never over-promises durability.
+// Durable delegates to the wrapped store via block.IsDurable. Encrypting block
+// bodies does not change where the bytes ultimately land, so a durable inner
+// store stays durable through the decorator; a wrapped store that does not
+// report durability falls back to the conservative default (false).
 func (d *EncryptedRemote) Durable() bool {
-	if r, ok := d.inner.(block.DurabilityReporter); ok {
-		return r.Durable()
-	}
-	return false
+	return block.IsDurable(d.inner)
 }
 
 // decrypt parses the frame, unwraps the block key, and authenticated-

--- a/pkg/block/encryption/decorator.go
+++ b/pkg/block/encryption/decorator.go
@@ -209,6 +209,18 @@ func (d *EncryptedRemote) Healthcheck(ctx context.Context) health.Report {
 	return d.inner.Healthcheck(ctx)
 }
 
+// Durable delegates to the wrapped store (block.DurabilityReporter). Encrypting
+// block bodies does not change where the bytes ultimately land, so a durable
+// inner store stays durable through the decorator. If the wrapped store does
+// not implement DurabilityReporter we fall back to the conservative default
+// (false) so the server never over-promises durability.
+func (d *EncryptedRemote) Durable() bool {
+	if r, ok := d.inner.(block.DurabilityReporter); ok {
+		return r.Durable()
+	}
+	return false
+}
+
 // decrypt parses the frame, unwraps the block key, and authenticated-
 // decrypts the ciphertext against hash as AAD. An unframed block on an
 // encryption-enabled share is rejected — it indicates external mutation
@@ -276,6 +288,7 @@ func newAEAD(algo AEAD, key []byte) (cipher.AEAD, error) {
 
 // Compile-time interface assertions.
 var (
-	_ block.Store        = (*EncryptedRemote)(nil)
-	_ remote.RemoteStore = (*EncryptedRemote)(nil)
+	_ block.Store              = (*EncryptedRemote)(nil)
+	_ remote.RemoteStore       = (*EncryptedRemote)(nil)
+	_ block.DurabilityReporter = (*EncryptedRemote)(nil)
 )

--- a/pkg/block/encryption/durability_test.go
+++ b/pkg/block/encryption/durability_test.go
@@ -1,0 +1,30 @@
+package encryption
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+)
+
+// TestEncryptedRemote_Durable_DelegatesToInner verifies the encryption decorator
+// delegates Durable() to the wrapped store (#1274): wrapping a durable backend
+// keeps it durable; wrapping a non-durable one stays non-durable.
+func TestEncryptedRemote_Durable_DelegatesToInner(t *testing.T) {
+	inner := remotememory.New() // memory remote: NOT durable by default
+	d, err := NewRemote(inner, EncryptionPolicy{AEAD: AEADAES256GCM}, newProvider(t))
+	if err != nil {
+		t.Fatalf("NewRemote: %v", err)
+	}
+
+	var _ block.DurabilityReporter = d
+
+	if d.Durable() {
+		t.Fatal("encrypting a non-durable inner store must stay NOT durable")
+	}
+
+	inner.SetDurable(true) // simulate a durable remote (e.g. s3)
+	if !d.Durable() {
+		t.Fatal("encrypting a durable inner store must report durable (delegation)")
+	}
+}

--- a/pkg/block/engine/durability_test.go
+++ b/pkg/block/engine/durability_test.go
@@ -1,0 +1,75 @@
+package engine
+
+import (
+	"testing"
+
+	localmemory "github.com/marmos91/dittofs/pkg/block/local/memory"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+)
+
+func TestEngine_LocalDurable_MemoryDefaultsFalse(t *testing.T) {
+	localStore := localmemory.New()
+	fbs := newStubFileBlockStore()
+	syncer := NewSyncer(localStore, nil, fbs, DefaultConfig())
+	bs, err := New(BlockStoreConfig{Local: localStore, Syncer: syncer, FileBlockStore: fbs})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+
+	if bs.LocalDurable() {
+		t.Fatal("memory local store should report NOT durable by default")
+	}
+	if bs.RemoteDurable() {
+		t.Fatal("nil remote must report NOT durable")
+	}
+}
+
+func TestEngine_LocalDurable_OverrideTrue(t *testing.T) {
+	localStore := localmemory.New()
+	localStore.SetDurable(true) // operator override
+	fbs := newStubFileBlockStore()
+	syncer := NewSyncer(localStore, nil, fbs, DefaultConfig())
+	bs, err := New(BlockStoreConfig{Local: localStore, Syncer: syncer, FileBlockStore: fbs})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+
+	if !bs.LocalDurable() {
+		t.Fatal("memory local store with SetDurable(true) should report durable")
+	}
+}
+
+func TestEngine_RemoteDurable_MemoryDefaultsFalse(t *testing.T) {
+	localStore := localmemory.New()
+	remoteStore := remotememory.New()
+	fbs := newStubFileBlockStore()
+	syncer := NewSyncer(localStore, remoteStore, fbs, DefaultConfig())
+	bs, err := New(BlockStoreConfig{Local: localStore, Remote: remoteStore, Syncer: syncer, FileBlockStore: fbs})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+
+	if bs.RemoteDurable() {
+		t.Fatal("memory remote store should report NOT durable by default")
+	}
+}
+
+func TestEngine_RemoteDurable_OverrideTrue(t *testing.T) {
+	localStore := localmemory.New()
+	remoteStore := remotememory.New()
+	remoteStore.SetDurable(true) // simulate a durable remote (s3 type-default)
+	fbs := newStubFileBlockStore()
+	syncer := NewSyncer(localStore, remoteStore, fbs, DefaultConfig())
+	bs, err := New(BlockStoreConfig{Local: localStore, Remote: remoteStore, Syncer: syncer, FileBlockStore: fbs})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+
+	if !bs.RemoteDurable() {
+		t.Fatal("remote store with SetDurable(true) should report durable")
+	}
+}

--- a/pkg/block/engine/durability_test.go
+++ b/pkg/block/engine/durability_test.go
@@ -73,3 +73,26 @@ func TestEngine_RemoteDurable_OverrideTrue(t *testing.T) {
 		t.Fatal("remote store with SetDurable(true) should report durable")
 	}
 }
+
+func TestEngine_RequireDurableCommit_DefaultsFalse(t *testing.T) {
+	localStore := localmemory.New()
+	fbs := newStubFileBlockStore()
+	syncer := NewSyncer(localStore, nil, fbs, DefaultConfig())
+	bs, err := New(BlockStoreConfig{Local: localStore, Syncer: syncer, FileBlockStore: fbs})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+
+	if bs.RequireDurableCommit() {
+		t.Fatal("require_durable_commit must default to false")
+	}
+	bs.SetRequireDurableCommit(true)
+	if !bs.RequireDurableCommit() {
+		t.Fatal("SetRequireDurableCommit(true) should flip the policy")
+	}
+	bs.SetRequireDurableCommit(false)
+	if bs.RequireDurableCommit() {
+		t.Fatal("SetRequireDurableCommit(false) should clear the policy")
+	}
+}

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -682,6 +682,35 @@ func (bs *Store) SetMetrics(rec local.MetricsRecorder) {
 // Do not use in production code.
 func (bs *Store) LocalForTest() local.LocalStore { return bs.local }
 
+// LocalDurable reports whether the engine's local store survives a process
+// crash / restart (block.DurabilityReporter). It is the localDurable input to
+// the honest CLOSE/COMMIT commit rule (#1274). When the local store does not
+// implement DurabilityReporter the conservative default (false) is returned so
+// the server never over-promises durability — every production local backend
+// (fs) implements it, so this only affects bare test fixtures.
+func (bs *Store) LocalDurable() bool {
+	if r, ok := bs.local.(block.DurabilityReporter); ok {
+		return r.Durable()
+	}
+	return false
+}
+
+// RemoteDurable reports whether the engine's remote store survives a process
+// crash / restart. A nil remote (local-only share) is not durable by
+// definition. A remote that does not implement DurabilityReporter falls back to
+// the conservative default (false). The type assertion sees through the
+// encryption / compression decorators because they delegate Durable() to the
+// store they wrap.
+func (bs *Store) RemoteDurable() bool {
+	if bs.remote == nil {
+		return false
+	}
+	if r, ok := bs.remote.(block.DurabilityReporter); ok {
+		return r.Durable()
+	}
+	return false
+}
+
 // RemoteStore returns the per-share remote object store, or nil if the
 // share is local-only. Used by the snapshot sync-gate verify step
 // to drive VerifyRemoteDurability after DrainAllUploads, and by

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -689,26 +689,16 @@ func (bs *Store) LocalForTest() local.LocalStore { return bs.local }
 // the server never over-promises durability — every production local backend
 // (fs) implements it, so this only affects bare test fixtures.
 func (bs *Store) LocalDurable() bool {
-	if r, ok := bs.local.(block.DurabilityReporter); ok {
-		return r.Durable()
-	}
-	return false
+	return block.IsDurable(bs.local)
 }
 
 // RemoteDurable reports whether the engine's remote store survives a process
-// crash / restart. A nil remote (local-only share) is not durable by
-// definition. A remote that does not implement DurabilityReporter falls back to
-// the conservative default (false). The type assertion sees through the
-// encryption / compression decorators because they delegate Durable() to the
-// store they wrap.
+// crash / restart. A nil remote (local-only share) and a remote that does not
+// implement DurabilityReporter both fall back to the conservative default
+// (false) via block.IsDurable. The report sees through the encryption /
+// compression decorators because they delegate Durable() to the store they wrap.
 func (bs *Store) RemoteDurable() bool {
-	if bs.remote == nil {
-		return false
-	}
-	if r, ok := bs.remote.(block.DurabilityReporter); ok {
-		return r.Durable()
-	}
-	return false
+	return block.IsDurable(bs.remote)
 }
 
 // RemoteStore returns the per-share remote object store, or nil if the

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -128,6 +128,19 @@ type Store struct {
 	closeMu  sync.RWMutex
 	closed   bool  // guarded by closeMu; true once teardown has run
 	closeErr error // memoized result of the first Close (idempotent)
+
+	// requireDurableCommit gates the strict honest-CLOSE/COMMIT rule (#1274).
+	// When false (the default), CommitBlockStore acks once engine.Flush
+	// succeeds regardless of local/remote durability — the remote mirror
+	// stays fully async and observable via the unsynced-bytes metric, so the
+	// fast path is preserved and ordinary NFS/POSIX writes never EIO. When
+	// true (opt-in per-share via config["require_durable_commit"]), CLOSE/
+	// COMMIT only succeed when the data is on a durable store
+	// (localDurable || (Finalized && remoteDurable)), trading latency for
+	// synchronous durability on non-fs-local stores. Set once at
+	// construction; read on the commit path. fs-local is always durable so
+	// the flag is a no-op there.
+	requireDurableCommit bool
 }
 
 // New creates a new Store from the given configuration.
@@ -699,6 +712,22 @@ func (bs *Store) LocalDurable() bool {
 // compression decorators because they delegate Durable() to the store they wrap.
 func (bs *Store) RemoteDurable() bool {
 	return block.IsDurable(bs.remote)
+}
+
+// RequireDurableCommit reports whether this share enforces the strict
+// honest-CLOSE/COMMIT durability rule (#1274). When false (the default), the
+// commit seam acks once engine.Flush succeeds and the remote mirror stays
+// async. When true, CLOSE/COMMIT only succeed once the data reaches a durable
+// store. Configured per-share via config["require_durable_commit"].
+func (bs *Store) RequireDurableCommit() bool {
+	return bs.requireDurableCommit
+}
+
+// SetRequireDurableCommit sets the strict honest-CLOSE/COMMIT durability
+// policy for this share. Called once at construction by the shares service
+// from the per-share config["require_durable_commit"] key (default false).
+func (bs *Store) SetRequireDurableCommit(v bool) {
+	bs.requireDurableCommit = v
 }
 
 // RemoteStore returns the per-share remote object store, or nil if the

--- a/pkg/block/engine/stats.go
+++ b/pkg/block/engine/stats.go
@@ -52,6 +52,16 @@ type BlockStoreStats struct {
 	EvictionSuspended   bool    `json:"eviction_suspended"`
 	OutageDurationSecs  float64 `json:"outage_duration_seconds"`
 	OfflineReadsBlocked int64   `json:"offline_reads_blocked"`
+
+	// LocalDurable / RemoteDurable expose the effective per-store durability
+	// (#1274): the type default (fs/s3 → true, memory → false) unless the
+	// operator overrode it via config["durable"]. They drive the honest
+	// CLOSE/COMMIT contract — a payload is committed iff
+	// LocalDurable || (Finalized && RemoteDurable). RemoteDurable is always
+	// false when HasRemote is false. Surfaced so operators can confirm whether
+	// CLOSE/COMMIT acks are crash-safe for a given share.
+	LocalDurable  bool `json:"local_durable"`
+	RemoteDurable bool `json:"remote_durable"`
 }
 
 // Stats returns storage statistics from the local store.
@@ -138,6 +148,8 @@ func (bs *Store) getStats(withBlockCounts bool) BlockStoreStats {
 		OutageDurationSecs:  outageDuration.Seconds(),
 		OfflineReadsBlocked: bs.syncer.OfflineReadsBlocked(),
 		UnsyncedBytes:       bs.syncer.UnsyncedBytes(),
+		LocalDurable:        bs.LocalDurable(),
+		RemoteDurable:       bs.RemoteDurable(),
 	}
 
 	if withBlockCounts {

--- a/pkg/block/local/fs/durability_test.go
+++ b/pkg/block/local/fs/durability_test.go
@@ -1,0 +1,37 @@
+package fs
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestFSStore_Durable verifies the fs local backend reports durable by default
+// (#1274) and that SetDurable overrides the type default.
+func TestFSStore_Durable(t *testing.T) {
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc, err := NewWithOptions(t.TempDir(), 0, mds, FSStoreOptions{})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	t.Cleanup(func() { _ = bc.Close() })
+
+	// Type default: fs is durable.
+	if !bc.Durable() {
+		t.Fatal("fs local store should report durable by default")
+	}
+
+	// Capability is wired.
+	var _ block.DurabilityReporter = bc
+
+	// Override flips it (e.g. a tmpfs-backed share).
+	bc.SetDurable(false)
+	if bc.Durable() {
+		t.Fatal("SetDurable(false) should make the fs store report NOT durable")
+	}
+	bc.SetDurable(true)
+	if !bc.Durable() {
+		t.Fatal("SetDurable(true) should restore durable")
+	}
+}

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -118,6 +118,7 @@ var (
 var (
 	_ local.LocalStore          = (*FSStore)(nil)
 	_ local.ChunkLifecycleHooks = (*FSStore)(nil)
+	_ block.DurabilityReporter  = (*FSStore)(nil)
 )
 
 // ObjectIDPersister is invoked after a rollup quiesces successfully.
@@ -214,6 +215,13 @@ type FSStore struct {
 	// evicting remote blocks. Used by local-only mode where there is no
 	// remote store to re-fetch evicted blocks from.
 	evictionEnabled atomic.Bool
+
+	// durable reports whether bytes accepted by this store survive a crash /
+	// restart (block.DurabilityReporter). The fs backend writes to disk and
+	// never evicts un-mirrored chunks, so the type default is true; an operator
+	// may override it via the per-store config["durable"] bool (SetDurable),
+	// e.g. for a tmpfs-backed share where the disk is volatile.
+	durable atomic.Bool
 
 	// retention holds the retention policy and TTL, accessed atomically
 	// to avoid data races between SetRetentionPolicy and concurrent eviction.
@@ -493,6 +501,9 @@ func newFSStore(baseDir string, maxDisk int64, fileBlockStore block.EngineFileBl
 		stopRollup:    make(chan struct{}),
 	}
 	bc.evictionEnabled.Store(true)
+	// Type default: fs-backed local storage is durable (#1274). Overridable
+	// post-construction via SetDurable from the controlplane config["durable"].
+	bc.durable.Store(true)
 
 	// in-process LRU for CAS chunks (see field comments).
 	bc.lruIndex = make(map[block.ContentHash]*list.Element)

--- a/pkg/block/local/fs/manage.go
+++ b/pkg/block/local/fs/manage.go
@@ -14,6 +14,20 @@ func (bc *FSStore) SetEvictionEnabled(enabled bool) {
 	bc.evictionEnabled.Store(enabled)
 }
 
+// Durable reports whether bytes accepted by this store survive a process crash
+// or restart (block.DurabilityReporter). The fs backend persists chunks to disk
+// and never evicts un-mirrored chunks, so the type default is true. An operator
+// may flip it off via SetDurable for a volatile-disk share (e.g. tmpfs).
+func (bc *FSStore) Durable() bool {
+	return bc.durable.Load()
+}
+
+// SetDurable overrides the type-default durability of this store. Called by the
+// controlplane when the per-store config carries an explicit "durable" bool.
+func (bc *FSStore) SetDurable(durable bool) {
+	bc.durable.Store(durable)
+}
+
 // GetStoredFileSize returns the total stored data size for a file by summing
 // the DataSize of all FileBlock records in the metadata store.
 // Returns 0 for unknown files (no error).

--- a/pkg/block/local/memory/durability_test.go
+++ b/pkg/block/local/memory/durability_test.go
@@ -1,0 +1,28 @@
+package memory_test
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/local/memory"
+)
+
+// TestMemoryStore_Durable verifies the in-memory local backend reports NOT
+// durable by default (#1274) and that SetDurable overrides the type default.
+func TestMemoryStore_Durable(t *testing.T) {
+	s := memory.New()
+
+	var _ block.DurabilityReporter = s
+
+	if s.Durable() {
+		t.Fatal("memory local store should report NOT durable by default")
+	}
+	s.SetDurable(true)
+	if !s.Durable() {
+		t.Fatal("SetDurable(true) should make the memory store report durable")
+	}
+	s.SetDurable(false)
+	if s.Durable() {
+		t.Fatal("SetDurable(false) should restore NOT durable")
+	}
+}

--- a/pkg/block/local/memory/memory.go
+++ b/pkg/block/local/memory/memory.go
@@ -7,6 +7,7 @@ import (
 	"iter"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"lukechampine.com/blake3"
@@ -22,6 +23,7 @@ import (
 var (
 	_ local.LocalStore          = (*MemoryStore)(nil)
 	_ local.ChunkLifecycleHooks = (*MemoryStore)(nil)
+	_ block.DurabilityReporter  = (*MemoryStore)(nil)
 )
 
 // ErrStoreClosed is an alias for block.ErrStoreClosed for backward compatibility.
@@ -73,6 +75,12 @@ type MemoryStore struct {
 	// rollup's chunk boundaries.
 	chunkEmitter ChunkEmitter
 
+	// durable reports whether accepted bytes survive a crash/restart
+	// (block.DurabilityReporter). In-memory storage is volatile, so the type
+	// default is false; an operator could override via SetDurable, though doing
+	// so for a memory store is almost always a misconfiguration.
+	durable atomic.Bool
+
 	closed bool
 }
 
@@ -122,6 +130,20 @@ func New() *MemoryStore {
 		cas:        make(map[block.ContentHash]casEntry),
 		appendLogs: make(map[string]*appendLog),
 	}
+}
+
+// Durable reports whether accepted bytes survive a crash/restart
+// (block.DurabilityReporter). In-memory storage is volatile, so the type
+// default is false. The zero value of the atomic field already encodes false.
+func (s *MemoryStore) Durable() bool {
+	return s.durable.Load()
+}
+
+// SetDurable overrides the type-default durability. Provided for symmetry with
+// the fs backend so the controlplane can apply config["durable"] uniformly;
+// marking a memory store durable is almost always a misconfiguration.
+func (s *MemoryStore) SetDurable(durable bool) {
+	s.durable.Store(durable)
 }
 
 // GetFileSize returns the tracked file size.

--- a/pkg/block/remote/memory/durability_test.go
+++ b/pkg/block/remote/memory/durability_test.go
@@ -1,0 +1,23 @@
+package memory
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+// TestStore_Durable verifies the in-memory remote backend reports NOT durable
+// by default (#1274) and that SetDurable overrides the type default.
+func TestStore_Durable(t *testing.T) {
+	s := New()
+
+	var _ block.DurabilityReporter = s
+
+	if s.Durable() {
+		t.Fatal("memory remote store should report NOT durable by default")
+	}
+	s.SetDurable(true)
+	if !s.Durable() {
+		t.Fatal("SetDurable(true) should make the memory remote store report durable")
+	}
+}

--- a/pkg/block/remote/memory/store.go
+++ b/pkg/block/remote/memory/store.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"lukechampine.com/blake3"
@@ -16,7 +17,10 @@ import (
 )
 
 // Compile-time interface satisfaction check.
-var _ remote.RemoteStore = (*Store)(nil)
+var (
+	_ remote.RemoteStore       = (*Store)(nil)
+	_ block.DurabilityReporter = (*Store)(nil)
+)
 
 // memBlock holds the per-object body plus metadata captured at Put time.
 type memBlock struct {
@@ -35,6 +39,11 @@ type Store struct {
 	// this to manipulate LastModified deterministically.
 	nowFn  func() time.Time
 	closed bool
+
+	// durable reports whether accepted bytes survive a crash/restart
+	// (block.DurabilityReporter). This is a test/dev fixture whose contents are
+	// volatile, so the type default is false.
+	durable atomic.Bool
 }
 
 // New creates a new in-memory remote block store.
@@ -43,6 +52,19 @@ func New() *Store {
 		blocks: make(map[block.ContentHash]*memBlock),
 		nowFn:  time.Now,
 	}
+}
+
+// Durable reports whether accepted bytes survive a crash/restart
+// (block.DurabilityReporter). The in-memory remote fixture is volatile, so the
+// type default is false (the zero value of the atomic field).
+func (s *Store) Durable() bool {
+	return s.durable.Load()
+}
+
+// SetDurable overrides the type-default durability, applied by the controlplane
+// when the per-store config carries an explicit "durable".
+func (s *Store) SetDurable(durable bool) {
+	s.durable.Store(durable)
 }
 
 // SetNowFnForTest overrides the time source used by Put to stamp

--- a/pkg/block/remote/s3/durability_test.go
+++ b/pkg/block/remote/s3/durability_test.go
@@ -1,0 +1,24 @@
+package s3
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+// TestStore_Durable verifies the s3 remote backend reports durable by default
+// (#1274) and that SetDurable overrides the type default. Durable() does not
+// touch the s3 client, so a nil client is fine here.
+func TestStore_Durable(t *testing.T) {
+	s := New(nil, Config{Bucket: "b"})
+
+	var _ block.DurabilityReporter = s
+
+	if !s.Durable() {
+		t.Fatal("s3 remote store should report durable by default")
+	}
+	s.SetDurable(false)
+	if s.Durable() {
+		t.Fatal("SetDurable(false) should make the s3 store report NOT durable")
+	}
+}

--- a/pkg/block/remote/s3/store.go
+++ b/pkg/block/remote/s3/store.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -43,7 +44,10 @@ const casPrefix = "cas/"
 const s3HTTPRequestTimeout = 2 * time.Minute
 
 // Compile-time interface satisfaction check.
-var _ remote.RemoteStore = (*Store)(nil)
+var (
+	_ remote.RemoteStore       = (*Store)(nil)
+	_ block.DurabilityReporter = (*Store)(nil)
+)
 
 // Config holds configuration for the S3 block store.
 type Config struct {
@@ -80,15 +84,35 @@ type Store struct {
 	keyPrefix string
 	closed    bool
 	mu        sync.RWMutex
+
+	// durable reports whether accepted bytes survive a crash/restart
+	// (block.DurabilityReporter). S3 object storage is durable, so the type
+	// default is true; set via SetDurable from the controlplane config.
+	durable atomic.Bool
 }
 
 // New creates a new S3 remote block store with an existing client.
 func New(client *s3.Client, config Config) *Store {
-	return &Store{
+	s := &Store{
 		client:    client,
 		bucket:    config.Bucket,
 		keyPrefix: config.KeyPrefix,
 	}
+	s.durable.Store(true)
+	return s
+}
+
+// Durable reports whether accepted bytes survive a crash/restart
+// (block.DurabilityReporter). S3 is durable object storage, so the type
+// default is true.
+func (s *Store) Durable() bool {
+	return s.durable.Load()
+}
+
+// SetDurable overrides the type-default durability of this store, applied by
+// the controlplane when the per-store config carries an explicit "durable".
+func (s *Store) SetDurable(durable bool) {
+	s.durable.Store(durable)
 }
 
 // NewFromConfig creates a new S3 remote block store by creating an S3 client from config.

--- a/pkg/controlplane/runtime/shares/non_closing_remote_durability_test.go
+++ b/pkg/controlplane/runtime/shares/non_closing_remote_durability_test.go
@@ -1,0 +1,105 @@
+package shares
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	adaptercommon "github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	localmemory "github.com/marmos91/dittofs/pkg/block/local/memory"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestNonClosingRemote_DelegatesDurable is the regression guard for #1274:
+// production wraps EVERY remote store in *nonClosingRemote before handing it to
+// the engine. Because nonClosingRemote embeds remote.RemoteStore (which has no
+// Durable method) and previously overrode only Close(), it silently dropped the
+// block.DurabilityReporter capability — so engine.Store.RemoteDurable() type-
+// asserted to DurabilityReporter, failed, and reported NOT durable for EVERY
+// production S3-remote share, yielding a spurious ErrNotDurableYet on every
+// COMMIT/CLOSE even though the data reached durable storage.
+//
+// The pre-existing engine durability tests passed the remote UNWRAPPED, which is
+// exactly why they missed this. This test wraps a durable remote in the real
+// production wrapper and asserts the capability survives.
+func TestNonClosingRemote_DelegatesDurable(t *testing.T) {
+	durableRemote := remotememory.New()
+	durableRemote.SetDurable(true) // simulate a durable remote (s3 type-default)
+
+	wrapped := &nonClosingRemote{durableRemote}
+
+	// 1. The wrapper itself must implement DurabilityReporter and report the
+	//    wrapped store's durability — without this it is not a DurabilityReporter
+	//    at all and block.IsDurable falls back to the conservative false.
+	if _, ok := interface{}(wrapped).(block.DurabilityReporter); !ok {
+		t.Fatal("*nonClosingRemote must implement block.DurabilityReporter")
+	}
+	if !wrapped.Durable() {
+		t.Fatal("nonClosingRemote.Durable() must delegate true through the wrapped durable remote")
+	}
+	if !block.IsDurable(wrapped) {
+		t.Fatal("block.IsDurable must see through *nonClosingRemote to the durable remote")
+	}
+
+	// Inverse: a non-durable remote must NOT be reported durable through the wrapper.
+	nonDurable := &nonClosingRemote{remotememory.New()} // memory remote: NOT durable by default
+	if nonDurable.Durable() {
+		t.Fatal("nonClosingRemote wrapping a non-durable remote must report NOT durable")
+	}
+}
+
+// TestNonClosingRemote_EngineRemoteDurableAndCommit builds the engine the way
+// production does — memory-local + the durable remote wrapped in the production
+// *nonClosingRemote — and asserts the honest-commit contract holds end to end:
+// RemoteDurable() is TRUE and CommitBlockStore returns nil (not ErrNotDurableYet)
+// for a Finalized write.
+func TestNonClosingRemote_EngineRemoteDurableAndCommit(t *testing.T) {
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	localStore := localmemory.New() // volatile local — durability must come from the remote
+	durableRemote := remotememory.New()
+	durableRemote.SetDurable(true)
+
+	// This is the production wrap: engine holds *nonClosingRemote, not the bare remote.
+	engineRemote := &nonClosingRemote{durableRemote}
+
+	syncer := engine.NewSyncer(localStore, engineRemote, ms, engine.DefaultConfig())
+	bs, err := engine.New(engine.BlockStoreConfig{
+		Local:           localStore,
+		Remote:          engineRemote,
+		Syncer:          syncer,
+		FileBlockStore:  ms,
+		SyncedHashStore: ms,
+	})
+	if err != nil {
+		t.Fatalf("engine.New: %v", err)
+	}
+	if err := bs.Start(context.Background()); err != nil {
+		t.Fatalf("engine.Start: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+
+	// The crux of #1274: with the wrapper in place, the engine must still see the
+	// remote as durable.
+	if !bs.RemoteDurable() {
+		t.Fatal("engine.RemoteDurable() must be TRUE through the production *nonClosingRemote wrapper (#1274)")
+	}
+	if bs.LocalDurable() {
+		t.Fatal("memory local store must report NOT durable (test premise: durability comes from the remote)")
+	}
+
+	// Write + commit: a Finalized flush to the durable wrapped remote must commit.
+	payloadID := metadata.PayloadID("nonclosing-durable-remote")
+	if err := adaptercommon.WriteToBlockStore(context.Background(), bs, payloadID, []byte("durable-via-wrapper"), 0); err != nil {
+		t.Fatalf("WriteToBlockStore: %v", err)
+	}
+	if err := adaptercommon.CommitBlockStore(context.Background(), bs, payloadID); err != nil {
+		if errors.Is(err, adaptercommon.ErrNotDurableYet) {
+			t.Fatalf("CommitBlockStore returned ErrNotDurableYet through the *nonClosingRemote wrapper — #1274 regression")
+		}
+		t.Fatalf("CommitBlockStore: %v", err)
+	}
+}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -808,6 +808,18 @@ func (s *Service) createBlockStoreForShare(
 		return fmt.Errorf("failed to create BlockStore: %w", err)
 	}
 
+	// Apply the per-share strict honest-CLOSE/COMMIT policy (#1274). Read the
+	// optional "require_durable_commit" bool from the local store config the
+	// same way config["durable"] is read; absent or non-bool → false (default:
+	// the commit seam acks once Flush succeeds and the remote mirror stays
+	// async). Set before Start so it governs the very first commit.
+	if localStoreCfg, cfgErr := localCfg.GetConfig(); cfgErr == nil {
+		applyRequireDurableCommit(bs, localStoreCfg, config.Name)
+	} else {
+		logger.Warn("failed to read local block store config for require_durable_commit; defaulting to false",
+			"share", config.Name, "error", cfgErr)
+	}
+
 	if err := bs.Start(ctx); err != nil {
 		cleanup()
 		return fmt.Errorf("failed to start BlockStore: %w", err)
@@ -2175,6 +2187,30 @@ func applyDurableOverride(store any, config map[string]any, label, shareName str
 	}
 	setter.SetDurable(b)
 	logger.Info("block store durability overridden by config", "store", label, "share", shareName, "durable", b)
+}
+
+// applyRequireDurableCommit reads the optional per-share
+// "require_durable_commit" bool from the local store config and sets the
+// strict honest-CLOSE/COMMIT policy on the engine Store (#1274). Read the same
+// conservative way as config["durable"]: absent or non-bool → false (default),
+// so the commit seam acks once Flush succeeds and the remote mirror stays
+// async — ordinary NFS/POSIX writes never EIO. When true, CLOSE/COMMIT only
+// succeed once the data is on a durable store.
+func applyRequireDurableCommit(bs *engine.Store, config map[string]any, shareName string) {
+	v, ok := config["require_durable_commit"]
+	if !ok {
+		return
+	}
+	b, ok := v.(bool)
+	if !ok {
+		logger.Warn("block store config has require_durable_commit but it is not a bool; ignoring",
+			"share", shareName, "value", v)
+		return
+	}
+	bs.SetRequireDurableCommit(b)
+	if b {
+		logger.Info("strict honest-CLOSE/COMMIT durability enabled by config", "share", shareName)
+	}
 }
 
 // CreateRemoteStoreFromConfig creates a remote store from type and dynamic config.

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -339,6 +339,15 @@ type nonClosingRemote struct {
 
 func (n *nonClosingRemote) Close() error { return nil }
 
+// Durable delegates to the wrapped remote chain so the no-op-Close wrapper
+// still implements block.DurabilityReporter. Without this, embedding
+// remote.RemoteStore (which has no Durable method) would silently drop the
+// capability, and engine.Store.RemoteDurable() would type-assert to
+// block.DurabilityReporter, fail, and report NOT durable for every production
+// S3-remote share — breaking the honest COMMIT/CLOSE contract (#1274) with a
+// spurious ErrNotDurableYet on every commit.
+func (n *nonClosingRemote) Durable() bool { return block.IsDurable(n.RemoteStore) }
+
 // Service manages share registration, lookup, and configuration.
 type Service struct {
 	mu       sync.RWMutex

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -2121,14 +2121,51 @@ func CreateLocalStoreFromConfig(
 			_ = store.Close()
 			return nil, fmt.Errorf("fs local store: StartRollup: %w", err)
 		}
+		applyDurableOverride(store, config, "local "+storeType, shareName)
 		return store, nil
 
 	case "memory":
-		return localmemory.New(), nil
+		store := localmemory.New()
+		applyDurableOverride(store, config, "local "+storeType, shareName)
+		return store, nil
 
 	default:
 		return nil, fmt.Errorf("unsupported local store type: %s", storeType)
 	}
+}
+
+// durableOverrideSetter is implemented by block stores (local and remote) that
+// expose a per-store durability override (block stores embed a
+// block.DurabilityReporter type-default; this lets an operator flip it).
+type durableOverrideSetter interface {
+	SetDurable(bool)
+}
+
+// applyDurableOverride reads an optional "durable" bool from the per-store
+// config and applies it to store when present, overriding the type-default
+// durability (#1274). A non-bool "durable" value is warned and ignored so the
+// type-default stands. label/shareName feed the diagnostic log line.
+func applyDurableOverride(store any, config map[string]any, label, shareName string) {
+	v, ok := config["durable"]
+	if !ok {
+		return
+	}
+	b, ok := v.(bool)
+	if !ok {
+		logger.Warn("block store config has durable but it is not a bool; ignoring",
+			"store", label, "share", shareName, "value", v)
+		return
+	}
+	setter, ok := store.(durableOverrideSetter)
+	if !ok {
+		// Every shipped store implements SetDurable; a store that does not is a
+		// programmer error, surface it instead of silently dropping the override.
+		logger.Warn("block store does not support a durable override; ignoring config[\"durable\"]",
+			"store", label, "share", shareName)
+		return
+	}
+	setter.SetDurable(b)
+	logger.Info("block store durability overridden by config", "store", label, "share", shareName, "durable", b)
 }
 
 // CreateRemoteStoreFromConfig creates a remote store from type and dynamic config.
@@ -2142,7 +2179,9 @@ func CreateRemoteStoreFromConfig(ctx context.Context, storeType string, cfg inte
 
 	switch storeType {
 	case "memory":
-		return remotememory.New(), nil
+		store := remotememory.New()
+		applyDurableOverride(store, config, "remote "+storeType, "")
+		return store, nil
 
 	case "filesystem":
 		return nil, errors.New("remote store type 'filesystem' removed in v4.0 -- use 'memory' or 's3'")
@@ -2174,7 +2213,7 @@ func CreateRemoteStoreFromConfig(ctx context.Context, storeType string, cfg inte
 			forcePathStyle = true
 		}
 
-		return remotes3.NewFromConfig(ctx, remotes3.Config{
+		store, err := remotes3.NewFromConfig(ctx, remotes3.Config{
 			Bucket:         bucket,
 			Region:         region,
 			Endpoint:       endpoint,
@@ -2183,6 +2222,11 @@ func CreateRemoteStoreFromConfig(ctx context.Context, storeType string, cfg inte
 			KeyPrefix:      prefix,
 			ForcePathStyle: forcePathStyle,
 		})
+		if err != nil {
+			return nil, err
+		}
+		applyDurableOverride(store, config, "remote "+storeType, "")
+		return store, nil
 
 	default:
 		return nil, fmt.Errorf("unsupported remote store type: %s", storeType)


### PR DESCRIPTION
Implements #1274 — per-store durability modeled explicitly, with honest CLOSE/COMMIT as an **opt-in** policy.

## What
- **`DurabilityReporter { Durable() bool }`** capability on all block stores. Type defaults: local fs = durable, local memory = not, remote s3 = durable, remote memory = not. Encryption/compression decorators delegate; `nonClosingRemote` delegates too (prod wrapper). Per-store override via `config["durable"]`.
- **`CommitBlockStore` rule** (NFSv3/v4 COMMIT, SMB CLOSE): hard flush errors always surface (#1267). Durability ack is governed by per-share **`require_durable_commit`** (default **false**):
  - default → a successful flush acks unconditionally; remote mirror stays **async + observable** (no behavior change, normal POSIX writes never EIO, fs-local fast path unchanged).
  - strict (opt-in) → `localDurable || (Finalized && remoteDurable)`, else `ErrNotDurableYet` → NFS3ERR_IO / NFS4ERR_IO / SMB error.
- **Observability**: `dittofs_localstore_unsynced_bytes` gauge (existing) + dfsctl Local/Remote Durable + Pending Remote rows + engine stats.

## Why opt-in
Strict-at-COMMIT is incompatible with normal NFS/POSIX operation and the fast+async design for any non-fs-local store (it EIOs ordinary writes). Default stays honest-but-non-blocking; operators who want synchronous durability on e.g. a memory-local+s3 share set `require_durable_commit: true` and accept the latency.

Closes #1274.