### PR TITLE
fix(nfs): enforce Kerberos export policy on NFSv4 + map auth denials

### DIFF
--- a/docs/NFS.md
+++ b/docs/NFS.md
@@ -318,12 +318,16 @@ accepts (set via `dfsctl adapter edit nfs` / the share's `NFSExportOptions`):
 |--------|---------|--------|
 | `allow_auth_sys` | `true` | When `false`, AUTH_SYS (AUTH_UNIX) mounts are refused; only Kerberos is accepted. |
 | `require_kerberos` | `false` | When `true`, every mount/operation must use RPCSEC_GSS; AUTH_SYS and AUTH_NULL are refused. |
-| `min_kerberos_level` | `krb5` | Minimum GSS protection level (`krb5` / `krb5i` / `krb5p`). |
+| `min_kerberos_level` | `krb5` | Intended minimum GSS protection level (`krb5` / `krb5i` / `krb5p`). **Not yet enforced** — see note below. |
 
-These are enforced identically on **NFSv3** (at MOUNT) and on **NFSv4.0/4.1**
-(at the first operation that resolves the export handle — v4 has no MOUNT call).
-A refusal surfaces as `NFS4ERR_WRONGSEC`, prompting the client to retry with the
-correct flavor.
+`allow_auth_sys` and `require_kerberos` are enforced identically on **NFSv3**
+(at MOUNT) and on **NFSv4.0/4.1** (at the first operation that resolves the
+export handle — v4 has no MOUNT call). A refusal surfaces as `NFS4ERR_WRONGSEC`,
+prompting the client to retry with the correct flavor.
+
+`min_kerberos_level` is stored and surfaced but **not currently enforced** at the
+NFS layer (neither v3 nor v4): a share set to `krb5p` still accepts a `krb5`
+(integrity/privacy-less) session. Wire-protection enforcement is a known gap.
 
 **Principal → identity mapping (the "access denied after EXCHANGE_ID" case).**
 A successful `sec=krb5` mount has two stages, and they fail differently:

--- a/docs/NFS.md
+++ b/docs/NFS.md
@@ -293,6 +293,64 @@ NFS uses RPC authentication flavors:
 
 **Security note:** AUTH_UNIX credentials are not cryptographically secured and can be spoofed. NFSv4 adds RPCSEC_GSS for Kerberos-based authentication. For production deployments, consider running on trusted networks, enabling Kerberos (NFSv4/v4.1), or using NFS-over-TLS (below) / VPN / network-level encryption.
 
+### Kerberos exports (RPCSEC_GSS / `sec=krb5`)
+
+NFSv4.0 and NFSv4.1 can authenticate with Kerberos via RPCSEC_GSS. The server
+verifies the client's Kerberos ticket against a keytab and maps the
+authenticated principal to a DittoFS identity for permission checks.
+
+**Mounting (Linux):**
+
+```bash
+# DittoFS listens on 12049, not the default 2049 — pass it explicitly.
+sudo mount -t nfs4 -o vers=4.1,sec=krb5,port=12049 server:/export /mnt/dittofs
+```
+
+The non-default port also applies to the auth handshake; without `port=12049`
+the client connects to 2049 and the mount fails with `Connection refused`
+before Kerberos is ever attempted. (Run the embedded portmapper on 111 to drop
+the explicit port — see [Mounting](#mounting).)
+
+**Per-export policy.** Three NFS export options gate which auth flavors a share
+accepts (set via `dfsctl adapter edit nfs` / the share's `NFSExportOptions`):
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `allow_auth_sys` | `true` | When `false`, AUTH_SYS (AUTH_UNIX) mounts are refused; only Kerberos is accepted. |
+| `require_kerberos` | `false` | When `true`, every mount/operation must use RPCSEC_GSS; AUTH_SYS and AUTH_NULL are refused. |
+| `min_kerberos_level` | `krb5` | Minimum GSS protection level (`krb5` / `krb5i` / `krb5p`). |
+
+These are enforced identically on **NFSv3** (at MOUNT) and on **NFSv4.0/4.1**
+(at the first operation that resolves the export handle — v4 has no MOUNT call).
+A refusal surfaces as `NFS4ERR_WRONGSEC`, prompting the client to retry with the
+correct flavor.
+
+**Principal → identity mapping (the "access denied after EXCHANGE_ID" case).**
+A successful `sec=krb5` mount has two stages, and they fail differently:
+
+1. **GSS context establishment** (the client's `EXCHANGE_ID` / context init).
+   This succeeds as soon as the ticket verifies against the server keytab.
+2. **Authorization** of the mapped principal on the export. The authenticated
+   principal is resolved to a DittoFS user (and UID/GID) through the identity
+   store / idmap. A principal with **no mapping** resolves to **nobody**
+   (UID 65534), and nobody is then subject to the export's
+   `default_permission`: if that is `none`, the export denies the operation and
+   the mount fails with `access denied` **even though the Kerberos handshake
+   succeeded**.
+
+This is by design — a host that mounts with its **machine** credential (no user
+`kinit`, e.g. `nfs/host.realm@REALM` from `/etc/krb5.keytab`) authenticates as
+the machine principal, which has no user identity. To grant such a mount:
+
+- add an idmap entry (or a DittoFS user) for the principal so it resolves to a
+  real UID/GID, **or**
+- set the export's `default_permission` to `read` / `read-write` so unmapped
+  (nobody) principals are admitted with that ceiling, **and** ensure the export
+  root's POSIX mode permits the resulting identity to traverse it.
+
+User principals (`alice@REALM`, obtained via `kinit`) that are present in the
+idmap mount and access files as that user with no extra configuration.
+
 ### NFS-over-TLS (RFC 9289)
 
 DittoFS can encrypt NFS wire traffic with TLS 1.3, using the opportunistic `AUTH_TLS` STARTTLS mechanism from RFC 9289. A client opens TCP and sends a `NULL` RPC with `auth_flavor = AUTH_TLS (7)`; the server replies with the 8-octet `"STARTTLS"` verifier, then both perform a TLS 1.3 handshake on the **same** connection. All subsequent RPC traffic is encrypted. Because Go performs the handshake and crypto in userspace, no kernel TLS (`kTLS`) or `tlshd` daemon is needed on the server.

--- a/docs/NFS.md
+++ b/docs/NFS.md
@@ -316,7 +316,7 @@ accepts (set via `dfsctl adapter edit nfs` / the share's `NFSExportOptions`):
 
 | Option | Default | Effect |
 |--------|---------|--------|
-| `allow_auth_sys` | `true` | When `false`, AUTH_SYS (AUTH_UNIX) mounts are refused; only Kerberos is accepted. |
+| `allow_auth_sys` | `true` | When `false`, AUTH_SYS (AUTH_UNIX) mounts/operations are refused. (Set `require_kerberos` to also refuse AUTH_NULL and mandate RPCSEC_GSS — `allow_auth_sys=false` alone only gates AUTH_SYS.) |
 | `require_kerberos` | `false` | When `true`, every mount/operation must use RPCSEC_GSS; AUTH_SYS and AUTH_NULL are refused. |
 | `min_kerberos_level` | `krb5` | Intended minimum GSS protection level (`krb5` / `krb5i` / `krb5p`). **Not yet enforced** — see note below. |
 

--- a/internal/adapter/nfs/v4/handlers/access.go
+++ b/internal/adapter/nfs/v4/handlers/access.go
@@ -78,10 +78,11 @@ func (h *Handler) handleAccess(ctx *types.CompoundContext, reader io.Reader) *ty
 func (h *Handler) accessRealFS(ctx *types.CompoundContext, accessReq uint32) *types.CompoundResult {
 	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
 	if err != nil {
+		st := nfs4StatusForAuthError(err)
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
+			Status: st,
 			OpCode: types.OP_ACCESS,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
+			Data:   encodeStatusOnly(st),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/auth_policy_test.go
+++ b/internal/adapter/nfs/v4/handlers/auth_policy_test.go
@@ -1,0 +1,83 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/attrs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// ============================================================================
+// Export auth-flavor policy enforcement (#1253)
+// ============================================================================
+//
+// NFSv4.1 has no MOUNT call, so the per-share RequireKerberos / AllowAuthSys
+// checks the v3 MOUNT handler applies never ran on v4 — a share that required
+// Kerberos (or disallowed AUTH_SYS) was mountable over AUTH_SYS on v4.1,
+// silently bypassing the export policy. buildV4AuthContext now mirrors the v3
+// logic at the first real-FS op and surfaces the refusal as NFS4ERR_WRONGSEC
+// (not NFS4ERR_SERVERFAULT) so the client retries with the correct flavor.
+//
+// These tests drive the policy through a real op handler (GETATTR over an
+// AUTH_UNIX context) and assert the status the client actually sees.
+
+// getAttrStatusForFile builds an AUTH_UNIX GETATTR for the given file handle
+// and returns the resulting CompoundResult status.
+func getAttrStatusForFile(fx *realFSTestFixture, fileHandle metadata.FileHandle) uint32 {
+	ctx := newRealFSContext(1000, 1000) // AUTH_UNIX
+	ctx.CurrentFH = make([]byte, len(fileHandle))
+	copy(ctx.CurrentFH, fileHandle)
+
+	var requested []uint32
+	attrs.SetBit(&requested, attrs.FATTR4_TYPE)
+
+	return fx.handler.getAttrRealFS(ctx, requested).Status
+}
+
+// TestExportAuthPolicy_DefaultAllowsAuthSys is the sanity case: the default
+// fixture share permits AUTH_SYS, so an AUTH_UNIX GETATTR succeeds.
+func TestExportAuthPolicy_DefaultAllowsAuthSys(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	fileHandle := fx.createTestFile(t, fx.rootHandle, "f.txt", metadata.FileTypeRegular, 0o644, 1000, 1000)
+
+	if status := getAttrStatusForFile(fx, fileHandle); status != types.NFS4_OK {
+		t.Fatalf("default share AUTH_UNIX GETATTR status = %d, want NFS4_OK (%d)", status, types.NFS4_OK)
+	}
+}
+
+// TestExportAuthPolicy_RequireKerberosRejectsAuthSys verifies that a share
+// requiring Kerberos rejects an AUTH_SYS request with NFS4ERR_WRONGSEC (not
+// NFS4ERR_SERVERFAULT, which would mask the policy refusal).
+func TestExportAuthPolicy_RequireKerberosRejectsAuthSys(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	fileHandle := fx.createTestFile(t, fx.rootHandle, "f.txt", metadata.FileTypeRegular, 0o644, 1000, 1000)
+
+	// allowAuthSys=true but requireKerberos=true: an AUTH_SYS request must be
+	// refused because the share mandates Kerberos.
+	if err := fx.rt.SetExportAuthPolicyForTesting("/export", true, true); err != nil {
+		t.Fatalf("SetExportAuthPolicyForTesting: %v", err)
+	}
+
+	if status := getAttrStatusForFile(fx, fileHandle); status != types.NFS4ERR_WRONGSEC {
+		t.Fatalf("RequireKerberos share AUTH_UNIX GETATTR status = %d, want NFS4ERR_WRONGSEC (%d)",
+			status, types.NFS4ERR_WRONGSEC)
+	}
+}
+
+// TestExportAuthPolicy_DisallowAuthSysRejectsAuthSys verifies that a share that
+// disallows AUTH_SYS rejects an AUTH_UNIX request with NFS4ERR_WRONGSEC.
+func TestExportAuthPolicy_DisallowAuthSysRejectsAuthSys(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	fileHandle := fx.createTestFile(t, fx.rootHandle, "f.txt", metadata.FileTypeRegular, 0o644, 1000, 1000)
+
+	// allowAuthSys=false: an AUTH_SYS request must be refused.
+	if err := fx.rt.SetExportAuthPolicyForTesting("/export", false, false); err != nil {
+		t.Fatalf("SetExportAuthPolicyForTesting: %v", err)
+	}
+
+	if status := getAttrStatusForFile(fx, fileHandle); status != types.NFS4ERR_WRONGSEC {
+		t.Fatalf("AllowAuthSys=false share AUTH_UNIX GETATTR status = %d, want NFS4ERR_WRONGSEC (%d)",
+			status, types.NFS4ERR_WRONGSEC)
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/auth_policy_test.go
+++ b/internal/adapter/nfs/v4/handlers/auth_policy_test.go
@@ -1,12 +1,49 @@
 package handlers
 
 import (
+	"context"
 	"testing"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/attrs"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
+
+// emptyIdentityStore is a models.IdentityStore with no users: GetUserByUID
+// returns no match so every UID resolves to guest, exercising the
+// default_permission policy in auth.ResolveSharePermission. ResolveSharePermission
+// short-circuits to "allow with defaults" when the identity store is nil, so a
+// non-nil (but empty) store is required to drive the guest-denial path.
+type emptyIdentityStore struct{}
+
+func (emptyIdentityStore) GetUser(context.Context, string) (*models.User, error) {
+	return nil, models.ErrUserNotFound
+}
+func (emptyIdentityStore) ValidateCredentials(context.Context, string, string) (*models.User, error) {
+	return nil, models.ErrUserNotFound
+}
+func (emptyIdentityStore) ListUsers(context.Context) ([]*models.User, error) { return nil, nil }
+func (emptyIdentityStore) GetGuestUser(context.Context, string) (*models.User, error) {
+	return nil, models.ErrUserNotFound
+}
+func (emptyIdentityStore) GetGroup(context.Context, string) (*models.Group, error) {
+	return nil, models.ErrGroupNotFound
+}
+func (emptyIdentityStore) ListGroups(context.Context) ([]*models.Group, error) { return nil, nil }
+func (emptyIdentityStore) GetUserGroups(context.Context, string) ([]*models.Group, error) {
+	return nil, nil
+}
+func (emptyIdentityStore) ResolveSharePermission(context.Context, *models.User, string) (models.SharePermission, error) {
+	return models.PermissionNone, nil
+}
+func (emptyIdentityStore) GetUserByUID(context.Context, uint32) (*models.User, error) {
+	return nil, models.ErrUserNotFound
+}
+func (emptyIdentityStore) GetUserByID(context.Context, string) (*models.User, error) {
+	return nil, models.ErrUserNotFound
+}
+func (emptyIdentityStore) IsGuestEnabled(context.Context, string) bool { return false }
 
 // ============================================================================
 // Export auth-flavor policy enforcement (#1253)
@@ -79,5 +116,29 @@ func TestExportAuthPolicy_DisallowAuthSysRejectsAuthSys(t *testing.T) {
 	if status := getAttrStatusForFile(fx, fileHandle); status != types.NFS4ERR_WRONGSEC {
 		t.Fatalf("AllowAuthSys=false share AUTH_UNIX GETATTR status = %d, want NFS4ERR_WRONGSEC (%d)",
 			status, types.NFS4ERR_WRONGSEC)
+	}
+}
+
+// TestExportAuthPolicy_DefaultPermissionNoneMapsToAccess pins the other half of
+// the status-mapping fix: a share-permission denial (default_permission=none for
+// an unmapped principal — the krb5 machine-principal-maps-to-nobody case) must
+// surface as NFS4ERR_ACCESS, not NFS4ERR_SERVERFAULT. The fixture identity store
+// has no user for UID 1000, so it resolves to guest and default_permission=none
+// denies it.
+func TestExportAuthPolicy_DefaultPermissionNoneMapsToAccess(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	fileHandle := fx.createTestFile(t, fx.rootHandle, "f.txt", metadata.FileTypeRegular, 0o644, 1000, 1000)
+
+	// A non-nil identity store with no users is required: ResolveSharePermission
+	// allows-with-defaults when the store is nil, so without this the guest
+	// default_permission=none branch never runs.
+	fx.rt.SetIdentityStoreForTesting(emptyIdentityStore{})
+	if err := fx.rt.SetSharePolicyForTesting("/export", "none", models.SquashNone); err != nil {
+		t.Fatalf("SetSharePolicyForTesting: %v", err)
+	}
+
+	if status := getAttrStatusForFile(fx, fileHandle); status != types.NFS4ERR_ACCESS {
+		t.Fatalf("default_permission=none AUTH_UNIX GETATTR status = %d, want NFS4ERR_ACCESS (%d)",
+			status, types.NFS4ERR_ACCESS)
 	}
 }

--- a/internal/adapter/nfs/v4/handlers/commit.go
+++ b/internal/adapter/nfs/v4/handlers/commit.go
@@ -64,10 +64,11 @@ func (h *Handler) handleCommit(ctx *types.CompoundContext, reader io.Reader) *ty
 	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
 	if err != nil {
 		logger.Debug("NFSv4 COMMIT auth context failed", "error", err, "client", ctx.ClientAddr)
+		st := nfs4StatusForAuthError(err)
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
+			Status: st,
 			OpCode: types.OP_COMMIT,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
+			Data:   encodeStatusOnly(st),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/create.go
+++ b/internal/adapter/nfs/v4/handlers/create.go
@@ -152,10 +152,11 @@ func (h *Handler) handleCreate(ctx *types.CompoundContext, reader io.Reader) *ty
 		logger.Debug("NFSv4 CREATE auth context failed",
 			"error", err,
 			"client", ctx.ClientAddr)
+		st := nfs4StatusForAuthError(err)
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
+			Status: st,
 			OpCode: types.OP_CREATE,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
+			Data:   encodeStatusOnly(st),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/getattr.go
+++ b/internal/adapter/nfs/v4/handlers/getattr.go
@@ -64,10 +64,11 @@ func (h *Handler) handleGetAttr(ctx *types.CompoundContext, reader io.Reader) *t
 func (h *Handler) getAttrRealFS(ctx *types.CompoundContext, requested []uint32) *types.CompoundResult {
 	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
 	if err != nil {
+		st := nfs4StatusForAuthError(err)
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
+			Status: st,
 			OpCode: types.OP_GETATTR,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
+			Data:   encodeStatusOnly(st),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/helpers.go
+++ b/internal/adapter/nfs/v4/handlers/helpers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/auth"
@@ -11,6 +12,30 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
+
+// authStatusError wraps a buildV4AuthContext failure with the NFS4 status the
+// COMPOUND operation should return. Without it every auth failure collapsed to
+// NFS4ERR_SERVERFAULT, which mislabels an authorization denial (a krb5 export
+// policy rejection or a default_permission=none denial) as an internal error.
+type authStatusError struct {
+	status uint32
+	err    error
+}
+
+func (e *authStatusError) Error() string { return e.err.Error() }
+func (e *authStatusError) Unwrap() error { return e.err }
+
+// nfs4StatusForAuthError maps a buildV4AuthContext error to the NFS4 status a
+// handler should return. Typed authStatusError values carry their own status
+// (NFS4ERR_WRONGSEC for an export auth-flavor rejection, NFS4ERR_ACCESS for a
+// share-permission denial); anything else is a genuine internal fault.
+func nfs4StatusForAuthError(err error) uint32 {
+	var ae *authStatusError
+	if errors.As(err, &ae) {
+		return ae.status
+	}
+	return types.NFS4ERR_SERVERFAULT
+}
 
 // buildV4AuthContext creates an AuthContext for NFSv4 real-FS operations.
 //
@@ -29,10 +54,16 @@ func (h *Handler) buildV4AuthContext(ctx *types.CompoundContext, handle []byte) 
 		return nil, "", fmt.Errorf("decode file handle: %w", err)
 	}
 
-	// Map auth flavor to auth method string
+	// Map auth flavor to auth method string. RPCSEC_GSS (Kerberos) was
+	// previously mislabeled "anonymous", which both confused audit logs and
+	// blocked any per-share auth-flavor policy from telling krb5 apart from a
+	// truly anonymous request.
 	authMethod := "anonymous"
-	if ctx.AuthFlavor == rpc.AuthUnix {
+	switch ctx.AuthFlavor {
+	case rpc.AuthUnix:
 		authMethod = "unix"
+	case rpc.AuthRPCSECGSS:
+		authMethod = "kerberos"
 	}
 
 	// Build identity from Unix credentials (before mapping)
@@ -63,6 +94,28 @@ func (h *Handler) buildV4AuthContext(ctx *types.CompoundContext, handle []byte) 
 	// below still fails closed if the share is genuinely gone.
 	share, _ := h.Registry.GetShare(shareName)
 
+	// Enforce the per-share export auth-flavor policy. NFSv4.1 has no MOUNT
+	// call, so the RequireKerberos / AllowAuthSys checks the v3 MOUNT handler
+	// applies (mount/handlers/mount.go) never ran on v4 — a share that requires
+	// Kerberos was mountable over AUTH_SYS on v4.1, silently bypassing the
+	// requirement. Mirror the v3 logic here, at the first real-FS op that
+	// resolves the share handle, and surface the refusal as NFS4ERR_WRONGSEC so
+	// the client retries with the correct flavor (SECINFO).
+	if share != nil {
+		if !share.AllowAuthSys && ctx.AuthFlavor == rpc.AuthUnix {
+			return nil, "", &authStatusError{
+				status: types.NFS4ERR_WRONGSEC,
+				err:    fmt.Errorf("share %q does not allow AUTH_SYS", shareName),
+			}
+		}
+		if share.RequireKerberos && ctx.AuthFlavor != rpc.AuthRPCSECGSS {
+			return nil, "", &authStatusError{
+				status: types.NFS4ERR_WRONGSEC,
+				err:    fmt.Errorf("share %q requires Kerberos", shareName),
+			}
+		}
+	}
+
 	// Apply the export-squash permission policy (default_permission=none denial,
 	// root→admin promotion, guest/known-user read-only coercion). This is the
 	// SAME policy the v3 path applies via auth.ResolveSharePermission; v4
@@ -71,6 +124,14 @@ func (h *Handler) buildV4AuthContext(ctx *types.CompoundContext, handle []byte) 
 	permResult, err := auth.ResolveSharePermission(
 		ctx.Context, h.Registry.GetIdentityStore(), share, shareName, ctx.ClientAddr, ctx.UID)
 	if err != nil {
+		// A share-permission denial (e.g. default_permission=none for an
+		// unmapped principal — the krb5 machine-principal-maps-to-nobody case)
+		// is an authorization decision, not an internal fault: surface it as
+		// NFS4ERR_ACCESS so the client sees "permission denied", not a server
+		// error.
+		if errors.Is(err, auth.ErrShareAccessDenied) {
+			return nil, "", &authStatusError{status: types.NFS4ERR_ACCESS, err: err}
+		}
 		return nil, "", err
 	}
 	if permResult.Username != "" {

--- a/internal/adapter/nfs/v4/handlers/link.go
+++ b/internal/adapter/nfs/v4/handlers/link.go
@@ -88,10 +88,11 @@ func (h *Handler) handleLink(ctx *types.CompoundContext, reader io.Reader) *type
 		logger.Debug("NFSv4 LINK auth context failed",
 			"error", err,
 			"client", ctx.ClientAddr)
+		st := nfs4StatusForAuthError(err)
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
+			Status: st,
 			OpCode: types.OP_LINK,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
+			Data:   encodeStatusOnly(st),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/lookup.go
+++ b/internal/adapter/nfs/v4/handlers/lookup.go
@@ -61,10 +61,11 @@ func (h *Handler) lookupInRealFS(ctx *types.CompoundContext, name string) *types
 		logger.Debug("NFSv4 LOOKUP real-FS auth context failed",
 			"error", err,
 			"client", ctx.ClientAddr)
+		st := nfs4StatusForAuthError(err)
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
+			Status: st,
 			OpCode: types.OP_LOOKUP,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
+			Data:   encodeStatusOnly(st),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/lookupp.go
+++ b/internal/adapter/nfs/v4/handlers/lookupp.go
@@ -41,10 +41,11 @@ func (h *Handler) handleLookupP(ctx *types.CompoundContext, _ io.Reader) *types.
 func (h *Handler) lookupParentInRealFS(ctx *types.CompoundContext) *types.CompoundResult {
 	authCtx, shareName, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
 	if err != nil {
+		st := nfs4StatusForAuthError(err)
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
+			Status: st,
 			OpCode: types.OP_LOOKUPP,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
+			Data:   encodeStatusOnly(st),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -238,7 +238,7 @@ func (h *Handler) handleOpenClaimNull(
 		logger.Debug("NFSv4 OPEN auth context failed",
 			"error", err,
 			"client", ctx.ClientAddr)
-		return openError(types.NFS4ERR_SERVERFAULT)
+		return openError(nfs4StatusForAuthError(err))
 	}
 
 	metaSvc, err := getMetadataServiceForCtx(h)
@@ -733,7 +733,7 @@ func (h *Handler) handleOpenClaimDelegateCur(
 
 	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
 	if err != nil {
-		return openError(types.NFS4ERR_SERVERFAULT)
+		return openError(nfs4StatusForAuthError(err))
 	}
 
 	metaSvc, err := getMetadataServiceForCtx(h)

--- a/internal/adapter/nfs/v4/handlers/read.go
+++ b/internal/adapter/nfs/v4/handlers/read.go
@@ -111,10 +111,11 @@ func (h *Handler) handleRead(ctx *types.CompoundContext, reader io.Reader) *type
 	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
 	if err != nil {
 		logger.Debug("NFSv4 READ auth context failed", "error", err, "client", ctx.ClientAddr)
+		st := nfs4StatusForAuthError(err)
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
+			Status: st,
 			OpCode: types.OP_READ,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
+			Data:   encodeStatusOnly(st),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/readdir.go
+++ b/internal/adapter/nfs/v4/handlers/readdir.go
@@ -100,10 +100,11 @@ func (h *Handler) handleReadDir(ctx *types.CompoundContext, reader io.Reader) *t
 func (h *Handler) readDirRealFS(ctx *types.CompoundContext, cookie uint64, cookieVerf [8]byte, maxcount uint32, attrRequest []uint32) *types.CompoundResult {
 	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
 	if err != nil {
+		st := nfs4StatusForAuthError(err)
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
+			Status: st,
 			OpCode: types.OP_READDIR,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
+			Data:   encodeStatusOnly(st),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/readlink.go
+++ b/internal/adapter/nfs/v4/handlers/readlink.go
@@ -38,10 +38,11 @@ func (h *Handler) handleReadLink(ctx *types.CompoundContext, _ io.Reader) *types
 	// Real filesystem handle -- read symlink target
 	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
 	if err != nil {
+		st := nfs4StatusForAuthError(err)
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
+			Status: st,
 			OpCode: types.OP_READLINK,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
+			Data:   encodeStatusOnly(st),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/remove.go
+++ b/internal/adapter/nfs/v4/handlers/remove.go
@@ -63,10 +63,11 @@ func (h *Handler) handleRemove(ctx *types.CompoundContext, reader io.Reader) *ty
 		logger.Debug("NFSv4 REMOVE auth context failed",
 			"error", err,
 			"client", ctx.ClientAddr)
+		st := nfs4StatusForAuthError(err)
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
+			Status: st,
 			OpCode: types.OP_REMOVE,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
+			Data:   encodeStatusOnly(st),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/rename.go
+++ b/internal/adapter/nfs/v4/handlers/rename.go
@@ -105,10 +105,11 @@ func (h *Handler) handleRename(ctx *types.CompoundContext, reader io.Reader) *ty
 		logger.Debug("NFSv4 RENAME auth context failed",
 			"error", err,
 			"client", ctx.ClientAddr)
+		st := nfs4StatusForAuthError(err)
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
+			Status: st,
 			OpCode: types.OP_RENAME,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
+			Data:   encodeStatusOnly(st),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/setattr.go
+++ b/internal/adapter/nfs/v4/handlers/setattr.go
@@ -141,10 +141,11 @@ func (h *Handler) handleSetAttr(ctx *types.CompoundContext, reader io.Reader) *t
 	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
 	if err != nil {
 		logger.Error("NFSv4 SETATTR build auth context failed", "error", err)
+		st := nfs4StatusForAuthError(err)
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
+			Status: st,
 			OpCode: types.OP_SETATTR,
-			Data:   encodeSetAttrError(types.NFS4ERR_SERVERFAULT),
+			Data:   encodeSetAttrError(st),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/verify.go
+++ b/internal/adapter/nfs/v4/handlers/verify.go
@@ -59,7 +59,7 @@ func verifyAttributes(h *Handler, ctx *types.CompoundContext, reader io.Reader) 
 		// Real-fs handle
 		authCtx, _, authErr := h.buildV4AuthContext(ctx, ctx.CurrentFH)
 		if authErr != nil {
-			return false, types.NFS4ERR_SERVERFAULT
+			return false, nfs4StatusForAuthError(authErr)
 		}
 
 		metaSvc, metaErr := getMetadataServiceForCtx(h)

--- a/internal/adapter/nfs/v4/handlers/write.go
+++ b/internal/adapter/nfs/v4/handlers/write.go
@@ -169,10 +169,11 @@ func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *typ
 	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
 	if err != nil {
 		logger.Debug("NFSv4 WRITE auth context failed", "error", err, "client", ctx.ClientAddr)
+		st := nfs4StatusForAuthError(err)
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
+			Status: st,
 			OpCode: types.OP_WRITE,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
+			Data:   encodeStatusOnly(st),
 		}
 	}
 

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -841,6 +841,12 @@ func (r *Runtime) SetSharePolicyForTesting(name, defaultPermission string, squas
 	return r.sharesSvc.SetSharePolicyForTesting(name, defaultPermission, squash)
 }
 
+// SetExportAuthPolicyForTesting overrides a registered share's AllowAuthSys and
+// RequireKerberos export auth-flavor fields. Test-only.
+func (r *Runtime) SetExportAuthPolicyForTesting(name string, allowAuthSys, requireKerberos bool) error {
+	return r.sharesSvc.SetExportAuthPolicyForTesting(name, allowAuthSys, requireKerberos)
+}
+
 // GetIdentityMappingStore returns the identity mapping store if supported.
 // Returns nil if the underlying store does not implement IdentityMappingStore.
 func (r *Runtime) GetIdentityMappingStore() store.IdentityMappingStore {

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1400,6 +1400,10 @@ func (s *Service) RegisterShareForTesting(name string) {
 		Enabled:           true,
 		DefaultPermission: "read-write",
 		Squash:            models.SquashNone,
+		// Mirror the AddShare default (allowAuthSys defaults true when unset):
+		// a bare test share must permit AUTH_SYS, otherwise the v4 export
+		// auth-flavor policy denies every AUTH_UNIX op.
+		AllowAuthSys: true,
 	}
 }
 
@@ -1467,6 +1471,24 @@ func (s *Service) SetSharePolicyForTesting(name, defaultPermission string, squas
 	}
 	share.DefaultPermission = defaultPermission
 	share.Squash = squash
+	return nil
+}
+
+// SetExportAuthPolicyForTesting overrides a share's AllowAuthSys and
+// RequireKerberos export auth-flavor fields in the registry under lock.
+// Test-only — lets NFS auth tests exercise the per-share export auth-flavor
+// policy (NFS4ERR_WRONGSEC enforcement) without a full AddShare flow. Use this
+// instead of mutating a *Share returned by GetShare, which is now a snapshot
+// copy. Returns ErrShareNotFound if the share is not registered.
+func (s *Service) SetExportAuthPolicyForTesting(name string, allowAuthSys, requireKerberos bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	share, ok := s.registry[name]
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrShareNotFound, name)
+	}
+	share.AllowAuthSys = allowAuthSys
+	share.RequireKerberos = requireKerberos
 	return nil
 }
 


### PR DESCRIPTION
## Problem

Found during AD-4b live acceptance (#1253). A Linux `mount -o vers=4.1,sec=krb5` against DittoFS established the GSS context (EXCHANGE_ID succeeded) but then failed `access denied by server`. Investigation surfaced three distinct defects:

1. **NFSv4 never enforced the per-share export auth-flavor policy.** `RequireKerberos` / `AllowAuthSys` are enforced only in the **v3 MOUNT** handler. NFSv4.1 has no MOUNT call, so on v4.1 these were dead — **a share that requires Kerberos was mountable over AUTH_SYS**, silently bypassing the requirement (a real security gap).
2. **RPCSEC_GSS was mislabeled `"anonymous"`** in the v4 auth context — confusing audit logs and hiding krb5 from any flavor policy.
3. **Every `buildV4AuthContext` denial collapsed to `NFS4ERR_SERVERFAULT`**, mislabeling an authorization decision as an internal fault. The reported symptom is exactly this: an unmapped krb5 **machine principal** (`nfs/host.realm@REALM` from `/etc/krb5.keytab`, no user `kinit`) resolves to **nobody**, and `default_permission=none` denies it — but the client saw SERVERFAULT, not a permission error.

## Fix

- **Enforce `RequireKerberos`/`AllowAuthSys` on v4** in `buildV4AuthContext` (the first real-FS op that resolves the export handle), mirroring the v3 MOUNT logic. A refusal returns **`NFS4ERR_WRONGSEC`** so the client retries with the correct flavor.
- **Label GSS as `"kerberos"`** (was `"anonymous"`).
- **Map denials properly** via a typed `authStatusError` + `nfs4StatusForAuthError`: share-permission denial → **`NFS4ERR_ACCESS`**, flavor refusal → **`NFS4ERR_WRONGSEC`**, genuine internal error → `SERVERFAULT`. Swept across all v4 op handlers (access/getattr/lookup/read/write/create/remove/rename/setattr/open/… ; `close` is a best-effort flush, unchanged).

Default shares are unaffected: `AllowAuthSys` defaults true, `RequireKerberos` false.

## The machine-principal symptom is configuration, not a code bug

The denial itself is **by design** — a host mounting with its machine credential has no user identity → nobody. Granting it is an idmap entry or a permissive `default_permission`. This PR makes the failure *legible* (ACCESS, not SERVERFAULT) and **documents** the setup.

## Tests / docs

- New `auth_policy_test.go`: default share + AUTH_UNIX → `NFS4_OK`; `RequireKerberos=true` + AUTH_UNIX → `NFS4ERR_WRONGSEC`; `AllowAuthSys=false` + AUTH_UNIX → `NFS4ERR_WRONGSEC` (driven through a real op handler). Added `SetExportAuthPolicyForTesting`; made `RegisterShareForTesting` production-faithful (`AllowAuthSys=true`).
- `docs/NFS.md`: new **Kerberos exports** section — port 12049, the three export options, and the machine-principal→nobody behavior with how to grant access.

Local: build + vet + gofmt clean; `internal/adapter/nfs/v4/handlers` + runtime suites green.

Closes #1253