### PR TITLE
feat(nfs): enforce min_kerberos_level GSS protection floor (#1283)

### DIFF
--- a/docs/NFS.md
+++ b/docs/NFS.md
@@ -318,16 +318,19 @@ accepts (set via `dfsctl adapter edit nfs` / the share's `NFSExportOptions`):
 |--------|---------|--------|
 | `allow_auth_sys` | `true` | When `false`, AUTH_SYS (AUTH_UNIX) mounts/operations are refused. (Set `require_kerberos` to also refuse AUTH_NULL and mandate RPCSEC_GSS — `allow_auth_sys=false` alone only gates AUTH_SYS.) |
 | `require_kerberos` | `false` | When `true`, every mount/operation must use RPCSEC_GSS; AUTH_SYS and AUTH_NULL are refused. |
-| `min_kerberos_level` | `krb5` | Intended minimum GSS protection level (`krb5` / `krb5i` / `krb5p`). **Not yet enforced** — see note below. |
+| `min_kerberos_level` | `krb5` | Minimum GSS protection level a Kerberos session must negotiate (`krb5` = authentication, `krb5i` = + integrity, `krb5p` = + privacy). A session below the floor is refused. |
 
-`allow_auth_sys` and `require_kerberos` are enforced identically on **NFSv3**
-(at MOUNT) and on **NFSv4.0/4.1** (at the first operation that resolves the
-export handle — v4 has no MOUNT call). A refusal surfaces as `NFS4ERR_WRONGSEC`,
-prompting the client to retry with the correct flavor.
+`allow_auth_sys`, `require_kerberos`, and `min_kerberos_level` are enforced
+identically on **NFSv3** (at MOUNT) and on **NFSv4.0/4.1** (at the first
+operation that resolves the export handle — v4 has no MOUNT call). A refusal
+surfaces as `NFS4ERR_WRONGSEC` (v4) / `MNT3ERR_ACCES` (v3), prompting the client
+to retry with the correct flavor.
 
-`min_kerberos_level` is stored and surfaced but **not currently enforced** at the
-NFS layer (neither v3 nor v4): a share set to `krb5p` still accepts a `krb5`
-(integrity/privacy-less) session. Wire-protection enforcement is a known gap.
+`min_kerberos_level` only constrains RPCSEC_GSS sessions: it rejects a Kerberos
+session whose negotiated service level is below the floor (e.g. a plain `krb5`
+authentication-only session on a `krb5p` privacy share). Non-GSS flavors are
+governed by `allow_auth_sys` / `require_kerberos`; pair `min_kerberos_level`
+with `require_kerberos=true` to mandate a protection floor for *all* access.
 
 **Principal → identity mapping (the "access denied after EXCHANGE_ID" case).**
 A successful `sec=krb5` mount has two stages, and they fail differently:

--- a/internal/adapter/nfs/auth/kerberos_level.go
+++ b/internal/adapter/nfs/auth/kerberos_level.go
@@ -1,0 +1,45 @@
+package auth
+
+import (
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc/gss"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// requiredGSSServiceForLevel maps a share's min_kerberos_level to the minimum
+// RPCSEC_GSS service level (RFC 2203 §5.2.3) it requires. hasFloor is false for
+// an empty or unrecognised level, in which case no floor is enforced.
+func requiredGSSServiceForLevel(minLevel string) (svc uint32, hasFloor bool) {
+	switch minLevel {
+	case models.KerberosLevelKrb5:
+		return gss.RPCGSSSvcNone, true
+	case models.KerberosLevelKrb5i:
+		return gss.RPCGSSSvcIntegrity, true
+	case models.KerberosLevelKrb5p:
+		return gss.RPCGSSSvcPrivacy, true
+	default:
+		return 0, false
+	}
+}
+
+// MeetsMinKerberosLevel reports whether an RPCSEC_GSS request that negotiated
+// the `negotiated` service level (one of gss.RPCGSSSvc*) satisfies the share's
+// configured min_kerberos_level floor.
+//
+// The RPCSEC_GSS service levels are ordered none(1) < integrity(2) <
+// privacy(3), so a numeric >= comparison enforces the floor. An empty or
+// unrecognised min_kerberos_level means no floor is configured and the request
+// is allowed.
+//
+// This is the wire-protection counterpart to RequireKerberos: RequireKerberos
+// rejects non-GSS auth flavors, MeetsMinKerberosLevel rejects GSS sessions
+// negotiated below the requested protection level (e.g. a plain `krb5`
+// authentication-only session on a share that demands `krb5p` privacy). It is
+// only meaningful for RPCSEC_GSS requests; non-GSS flavors are governed by
+// AllowAuthSys / RequireKerberos.
+func MeetsMinKerberosLevel(minLevel string, negotiated uint32) bool {
+	required, hasFloor := requiredGSSServiceForLevel(minLevel)
+	if !hasFloor {
+		return true
+	}
+	return negotiated >= required
+}

--- a/internal/adapter/nfs/auth/kerberos_level_test.go
+++ b/internal/adapter/nfs/auth/kerberos_level_test.go
@@ -1,0 +1,50 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc/gss"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+func TestMeetsMinKerberosLevel(t *testing.T) {
+	tests := []struct {
+		name       string
+		minLevel   string
+		negotiated uint32
+		want       bool
+	}{
+		// No floor: any service level (including a non-GSS 0) is allowed.
+		{"empty floor / auth-only", "", gss.RPCGSSSvcNone, true},
+		{"empty floor / privacy", "", gss.RPCGSSSvcPrivacy, true},
+		{"unknown level treated as no floor", "krb5x", gss.RPCGSSSvcNone, true},
+
+		// krb5 floor = authentication only: every GSS service satisfies it.
+		{"krb5 floor / auth-only", models.KerberosLevelKrb5, gss.RPCGSSSvcNone, true},
+		{"krb5 floor / integrity", models.KerberosLevelKrb5, gss.RPCGSSSvcIntegrity, true},
+		{"krb5 floor / privacy", models.KerberosLevelKrb5, gss.RPCGSSSvcPrivacy, true},
+
+		// krb5i floor = integrity: auth-only is rejected, integrity/privacy pass.
+		{"krb5i floor / auth-only rejected", models.KerberosLevelKrb5i, gss.RPCGSSSvcNone, false},
+		{"krb5i floor / integrity", models.KerberosLevelKrb5i, gss.RPCGSSSvcIntegrity, true},
+		{"krb5i floor / privacy", models.KerberosLevelKrb5i, gss.RPCGSSSvcPrivacy, true},
+
+		// krb5p floor = privacy: only privacy passes.
+		{"krb5p floor / auth-only rejected", models.KerberosLevelKrb5p, gss.RPCGSSSvcNone, false},
+		{"krb5p floor / integrity rejected", models.KerberosLevelKrb5p, gss.RPCGSSSvcIntegrity, false},
+		{"krb5p floor / privacy", models.KerberosLevelKrb5p, gss.RPCGSSSvcPrivacy, true},
+
+		// Fail-closed: a floor above krb5 with a missing/zero service level
+		// (no GSS session info) is rejected.
+		{"krb5i floor / zero service fails closed", models.KerberosLevelKrb5i, 0, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MeetsMinKerberosLevel(tc.minLevel, tc.negotiated); got != tc.want {
+				t.Fatalf("MeetsMinKerberosLevel(%q, %d) = %v, want %v",
+					tc.minLevel, tc.negotiated, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/adapter/nfs/mount/handlers/mount.go
+++ b/internal/adapter/nfs/mount/handlers/mount.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/marmos91/dittofs/internal/adapter/nfs/auth"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc/gss"
 	internalxdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr"
@@ -129,6 +130,24 @@ func (h *Handler) Mount(
 		logger.Warn("Mount denied: Kerberos required but client uses non-GSS auth",
 			"path", req.DirPath, "client_ip", clientIP, "auth_flavor", ctx.AuthFlavor)
 		return &MountResponse{MountResponseBase: MountResponseBase{Status: MountErrAccess}}, nil
+	}
+	// Enforce the per-share GSS protection floor (min_kerberos_level): a krb5i /
+	// krb5p export must reject a Kerberos mount negotiated at a weaker service
+	// level. The negotiated RPCSEC_GSS service level rides in the request context
+	// from the GSS DATA dispatch, set for every processed RPCSEC_GSS request. We
+	// enforce only when that session info is present: a real GSS mount always
+	// carries it, so its absence means the request was not processed as GSS
+	// (e.g. Kerberos not configured), where applying the default "krb5" floor
+	// would spuriously deny. Non-GSS flavors are gated by the checks above.
+	if ctx.AuthFlavor == rpc.AuthRPCSECGSS {
+		if si := gss.SessionInfoFromContext(ctx.Context); si != nil {
+			if !auth.MeetsMinKerberosLevel(share.MinKerberosLevel, si.Service) {
+				logger.Warn("Mount denied: GSS protection level below share floor",
+					"path", req.DirPath, "client_ip", clientIP,
+					"min_kerberos_level", share.MinKerberosLevel, "negotiated_service", si.Service)
+				return &MountResponse{MountResponseBase: MountResponseBase{Status: MountErrAccess}}, nil
+			}
+		}
 	}
 
 	// Netgroup IP access check: reject mount if client IP is not in allowed netgroup.

--- a/internal/adapter/nfs/mount/handlers/mount_test.go
+++ b/internal/adapter/nfs/mount/handlers/mount_test.go
@@ -10,6 +10,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc/gss"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
@@ -63,6 +66,59 @@ func newMountCtx(reqCtx context.Context) *MountHandlerContext {
 		UID:        &uid,
 		GID:        &gid,
 		GIDs:       []uint32{gid},
+	}
+}
+
+// newGSSMountCtx builds a MountHandlerContext for an RPCSEC_GSS mount carrying
+// the given negotiated service level (gss.RPCGSSSvc*) in the request context,
+// matching how the GSS DATA dispatch threads it through.
+func newGSSMountCtx(reqCtx context.Context, service uint32) *MountHandlerContext {
+	uid := uint32(1000)
+	gid := uint32(1000)
+	return &MountHandlerContext{
+		Context:    gss.ContextWithSessionInfo(reqCtx, &gss.GSSSessionInfo{Service: service}),
+		ClientAddr: "127.0.0.1:12345",
+		AuthFlavor: rpc.AuthRPCSECGSS,
+		UID:        &uid,
+		GID:        &gid,
+		GIDs:       []uint32{gid},
+	}
+}
+
+// TestMount_MinKerberosLevel_RejectsBelowFloor verifies a krb5p share refuses a
+// plain krb5 (authentication-only) GSS mount with MountErrAccess (#1283).
+func TestMount_MinKerberosLevel_RejectsBelowFloor(t *testing.T) {
+	h, ctx := newTestMountHandler(t, "/export", true)
+	if err := h.Registry.(*runtime.Runtime).SetMinKerberosLevelForTesting("/export", models.KerberosLevelKrb5p); err != nil {
+		t.Fatalf("SetMinKerberosLevelForTesting: %v", err)
+	}
+
+	resp, err := h.Mount(newGSSMountCtx(ctx, gss.RPCGSSSvcNone), &MountRequest{DirPath: "/export"})
+	if err != nil {
+		t.Fatalf("Mount returned unexpected error: %v", err)
+	}
+	if resp.Status != MountErrAccess {
+		t.Fatalf("Status = %d, want MountErrAccess (%d)", resp.Status, MountErrAccess)
+	}
+	if len(resp.FileHandle) != 0 {
+		t.Errorf("FileHandle = %x, want empty on access-denied response", resp.FileHandle)
+	}
+}
+
+// TestMount_MinKerberosLevel_AllowsAtFloor verifies a krb5p share accepts a
+// privacy-level GSS mount.
+func TestMount_MinKerberosLevel_AllowsAtFloor(t *testing.T) {
+	h, ctx := newTestMountHandler(t, "/export", true)
+	if err := h.Registry.(*runtime.Runtime).SetMinKerberosLevelForTesting("/export", models.KerberosLevelKrb5p); err != nil {
+		t.Fatalf("SetMinKerberosLevelForTesting: %v", err)
+	}
+
+	resp, err := h.Mount(newGSSMountCtx(ctx, gss.RPCGSSSvcPrivacy), &MountRequest{DirPath: "/export"})
+	if err != nil {
+		t.Fatalf("Mount returned unexpected error: %v", err)
+	}
+	if resp.Status != MountOK {
+		t.Fatalf("Status = %d, want MountOK (%d)", resp.Status, MountOK)
 	}
 }
 

--- a/internal/adapter/nfs/v4/handlers/auth_policy_test.go
+++ b/internal/adapter/nfs/v4/handlers/auth_policy_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc/gss"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/attrs"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
@@ -140,5 +142,116 @@ func TestExportAuthPolicy_DefaultPermissionNoneMapsToAccess(t *testing.T) {
 	if status := getAttrStatusForFile(fx, fileHandle); status != types.NFS4ERR_ACCESS {
 		t.Fatalf("default_permission=none AUTH_UNIX GETATTR status = %d, want NFS4ERR_ACCESS (%d)",
 			status, types.NFS4ERR_ACCESS)
+	}
+}
+
+// ============================================================================
+// min_kerberos_level GSS protection floor (#1283)
+// ============================================================================
+//
+// min_kerberos_level was stored and surfaced but never enforced: a share
+// configured krb5i/krb5p still accepted a weaker GSS session. buildV4AuthContext
+// now compares the negotiated RPCSEC_GSS service level against the floor and
+// rejects below-floor sessions with NFS4ERR_WRONGSEC.
+
+// getAttrStatusForFileGSS builds an RPCSEC_GSS GETATTR carrying the given
+// negotiated service level (gss.RPCGSSSvc*) and returns the result status.
+func getAttrStatusForFileGSS(fx *realFSTestFixture, fileHandle metadata.FileHandle, service uint32) uint32 {
+	uid, gid := uint32(1000), uint32(1000)
+	ctx := &types.CompoundContext{
+		Context:    gss.ContextWithSessionInfo(context.Background(), &gss.GSSSessionInfo{Service: service}),
+		ClientAddr: "192.168.1.100:9999",
+		AuthFlavor: rpc.AuthRPCSECGSS,
+		UID:        &uid,
+		GID:        &gid,
+	}
+	ctx.CurrentFH = make([]byte, len(fileHandle))
+	copy(ctx.CurrentFH, fileHandle)
+
+	var requested []uint32
+	attrs.SetBit(&requested, attrs.FATTR4_TYPE)
+	return fx.handler.getAttrRealFS(ctx, requested).Status
+}
+
+// TestMinKerberosLevel_PrivacyShareAcceptsPrivacy is the floor-met sanity case:
+// a krb5p share accepts a privacy-level GSS session.
+func TestMinKerberosLevel_PrivacyShareAcceptsPrivacy(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	fileHandle := fx.createTestFile(t, fx.rootHandle, "f.txt", metadata.FileTypeRegular, 0o644, 1000, 1000)
+
+	if err := fx.rt.SetMinKerberosLevelForTesting("/export", models.KerberosLevelKrb5p); err != nil {
+		t.Fatalf("SetMinKerberosLevelForTesting: %v", err)
+	}
+
+	if status := getAttrStatusForFileGSS(fx, fileHandle, gss.RPCGSSSvcPrivacy); status != types.NFS4_OK {
+		t.Fatalf("krb5p share + privacy GSS GETATTR status = %d, want NFS4_OK (%d)", status, types.NFS4_OK)
+	}
+}
+
+// TestMinKerberosLevel_PrivacyShareRejectsAuthOnly verifies a krb5p share
+// rejects a plain krb5 (authentication-only) session with NFS4ERR_WRONGSEC.
+func TestMinKerberosLevel_PrivacyShareRejectsAuthOnly(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	fileHandle := fx.createTestFile(t, fx.rootHandle, "f.txt", metadata.FileTypeRegular, 0o644, 1000, 1000)
+
+	if err := fx.rt.SetMinKerberosLevelForTesting("/export", models.KerberosLevelKrb5p); err != nil {
+		t.Fatalf("SetMinKerberosLevelForTesting: %v", err)
+	}
+
+	if status := getAttrStatusForFileGSS(fx, fileHandle, gss.RPCGSSSvcNone); status != types.NFS4ERR_WRONGSEC {
+		t.Fatalf("krb5p share + auth-only GSS GETATTR status = %d, want NFS4ERR_WRONGSEC (%d)",
+			status, types.NFS4ERR_WRONGSEC)
+	}
+}
+
+// TestMinKerberosLevel_IntegrityShareRejectsAuthOnly verifies a krb5i share
+// rejects an authentication-only session but accepts integrity.
+func TestMinKerberosLevel_IntegrityShareRejectsAuthOnly(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	fileHandle := fx.createTestFile(t, fx.rootHandle, "f.txt", metadata.FileTypeRegular, 0o644, 1000, 1000)
+
+	if err := fx.rt.SetMinKerberosLevelForTesting("/export", models.KerberosLevelKrb5i); err != nil {
+		t.Fatalf("SetMinKerberosLevelForTesting: %v", err)
+	}
+
+	if status := getAttrStatusForFileGSS(fx, fileHandle, gss.RPCGSSSvcNone); status != types.NFS4ERR_WRONGSEC {
+		t.Fatalf("krb5i share + auth-only GSS GETATTR status = %d, want NFS4ERR_WRONGSEC (%d)",
+			status, types.NFS4ERR_WRONGSEC)
+	}
+	if status := getAttrStatusForFileGSS(fx, fileHandle, gss.RPCGSSSvcIntegrity); status != types.NFS4_OK {
+		t.Fatalf("krb5i share + integrity GSS GETATTR status = %d, want NFS4_OK (%d)", status, types.NFS4_OK)
+	}
+}
+
+// TestMinKerberosLevel_NoSessionInfoSkipsFloor guards the fail-open path: when a
+// request is RPCSEC_GSS flavored but carries NO GSS session info (the request
+// was not processed as GSS — e.g. Kerberos is not configured on the server), the
+// floor must NOT fire. Otherwise the factory-default "krb5" floor (set on every
+// DB-loaded share) would deny with negotiated service 0. The share keeps the
+// default krb5 floor; the context has no GSSSessionInfo.
+func TestMinKerberosLevel_NoSessionInfoSkipsFloor(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	fileHandle := fx.createTestFile(t, fx.rootHandle, "f.txt", metadata.FileTypeRegular, 0o644, 1000, 1000)
+
+	if err := fx.rt.SetMinKerberosLevelForTesting("/export", models.KerberosLevelKrb5); err != nil {
+		t.Fatalf("SetMinKerberosLevelForTesting: %v", err)
+	}
+
+	uid, gid := uint32(1000), uint32(1000)
+	ctx := &types.CompoundContext{
+		Context:    context.Background(), // no GSSSessionInfo
+		ClientAddr: "192.168.1.100:9999",
+		AuthFlavor: rpc.AuthRPCSECGSS,
+		UID:        &uid,
+		GID:        &gid,
+	}
+	ctx.CurrentFH = make([]byte, len(fileHandle))
+	copy(ctx.CurrentFH, fileHandle)
+	var requested []uint32
+	attrs.SetBit(&requested, attrs.FATTR4_TYPE)
+
+	if status := fx.handler.getAttrRealFS(ctx, requested).Status; status != types.NFS4_OK {
+		t.Fatalf("GSS flavor without session info GETATTR status = %d, want NFS4_OK (%d) — floor must not fire",
+			status, types.NFS4_OK)
 	}
 }

--- a/internal/adapter/nfs/v4/handlers/helpers.go
+++ b/internal/adapter/nfs/v4/handlers/helpers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/auth"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc/gss"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
 	"github.com/marmos91/dittofs/internal/logger"
@@ -112,6 +113,28 @@ func (h *Handler) buildV4AuthContext(ctx *types.CompoundContext, handle []byte) 
 			return nil, "", &authStatusError{
 				status: types.NFS4ERR_WRONGSEC,
 				err:    fmt.Errorf("share %q requires Kerberos", shareName),
+			}
+		}
+		// Enforce the per-share GSS protection floor (min_kerberos_level). A
+		// share configured krb5i/krb5p must reject a GSS session negotiated at a
+		// weaker service level (e.g. plain krb5 authentication-only on a krb5p
+		// privacy share). The negotiated RPCSEC_GSS service level is carried in
+		// the request context by the GSS DATA dispatch, which sets the session
+		// info for every processed RPCSEC_GSS request. We enforce the floor only
+		// when that session info is present: a real GSS session always carries
+		// it, so its absence means the request was not processed as GSS (e.g.
+		// Kerberos is not configured on the server) — applying the default
+		// "krb5" floor there would spuriously deny. Non-GSS flavors are gated
+		// above by AllowAuthSys / RequireKerberos.
+		if ctx.AuthFlavor == rpc.AuthRPCSECGSS {
+			if si := gss.SessionInfoFromContext(ctx.Context); si != nil {
+				if !auth.MeetsMinKerberosLevel(share.MinKerberosLevel, si.Service) {
+					return nil, "", &authStatusError{
+						status: types.NFS4ERR_WRONGSEC,
+						err: fmt.Errorf("share %q requires min kerberos level %q (negotiated service %d)",
+							shareName, share.MinKerberosLevel, si.Service),
+					}
+				}
 			}
 		}
 	}

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -847,6 +847,12 @@ func (r *Runtime) SetExportAuthPolicyForTesting(name string, allowAuthSys, requi
 	return r.sharesSvc.SetExportAuthPolicyForTesting(name, allowAuthSys, requireKerberos)
 }
 
+// SetMinKerberosLevelForTesting overrides a registered share's MinKerberosLevel
+// GSS protection floor ("", "krb5", "krb5i", "krb5p"). Test-only.
+func (r *Runtime) SetMinKerberosLevelForTesting(name, minLevel string) error {
+	return r.sharesSvc.SetMinKerberosLevelForTesting(name, minLevel)
+}
+
 // GetIdentityMappingStore returns the identity mapping store if supported.
 // Returns nil if the underlying store does not implement IdentityMappingStore.
 func (r *Runtime) GetIdentityMappingStore() store.IdentityMappingStore {

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1513,6 +1513,22 @@ func (s *Service) SetExportAuthPolicyForTesting(name string, allowAuthSys, requi
 	return nil
 }
 
+// SetMinKerberosLevelForTesting overrides a share's MinKerberosLevel (the GSS
+// protection floor: "", "krb5", "krb5i", "krb5p") in the registry under lock.
+// Test-only — lets NFS auth tests exercise the min_kerberos_level floor
+// (NFS4ERR_WRONGSEC / MOUNT refusal) without a full AddShare flow. Returns
+// ErrShareNotFound if the share is not registered.
+func (s *Service) SetMinKerberosLevelForTesting(name, minLevel string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	share, ok := s.registry[name]
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrShareNotFound, name)
+	}
+	share.MinKerberosLevel = minLevel
+	return nil
+}
+
 func (s *Service) GetRootHandle(shareName string) (metadata.FileHandle, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()


### PR DESCRIPTION
## What

`min_kerberos_level` (per-share `NFSExportOptions`) was stored, surfaced via REST/dfsctl, and documented, but **never enforced** in the NFS adapter — a share configured `krb5i`/`krb5p` still accepted a weaker GSS session (e.g. a plain `krb5` authentication-only session on a `krb5p` privacy share). Split out from the #1253 review.

## Change

- Enforce the GSS protection floor on both **NFSv3** (MOUNT) and **NFSv4.0/4.1** (`buildV4AuthContext`, the export-policy gate that already mirrors `RequireKerberos`/`AllowAuthSys`).
- The negotiated RPCSEC_GSS service level (none/integrity/privacy) is read from the request context threaded by the GSS DATA dispatch (`gss.SessionInfoFromContext`).
- Below-floor sessions refused with `NFS4ERR_WRONGSEC` (v4) / `MNT3ERR_ACCES` (v3). Only RPCSEC_GSS requests are subject to the floor; non-GSS flavors stay governed by `allow_auth_sys`/`require_kerberos`.
- New `auth.MeetsMinKerberosLevel` helper (`krb5 < krb5i < krb5p` ordered compare, fail-closed when no GSS session info present).

## Tests

- Unit table test for `MeetsMinKerberosLevel` (mapping + ordering + fail-closed).
- v4 integration: krb5p accepts privacy, rejects auth-only (WRONGSEC); krb5i rejects auth-only, accepts integrity.
- v3 MOUNT integration: krb5p rejects auth-only (MNT3ERR_ACCES), accepts privacy.
- `docs/NFS.md` updated (the field is now enforced; semantics documented).

Closes #1283.