### PR TITLE
fix(identity): resolve Kerberos domain users via LDAP directory fallback (#1246)

### DIFF
--- a/pkg/identity/ldap/provider.go
+++ b/pkg/identity/ldap/provider.go
@@ -88,14 +88,21 @@ func (p *Provider) Name() string { return ProviderName }
 // It claims AD SIDs (S-1-...) and "user@REALM" principals matching the
 // configured realm. The NFSv4 special principals are never claimed.
 func (p *Provider) CanResolve(cred *identity.Credential) bool {
-	if cred.Provider != "" {
-		return cred.Provider == ProviderName
+	// Explicitly addressed to the LDAP provider.
+	if cred.Provider == ProviderName {
+		return true
 	}
+	// An AD object SID is always ours, whatever auth source produced it.
 	if strings.HasPrefix(cred.ExternalID, "S-1-") {
 		return true
 	}
-	// splitPrincipal already rejects the NFSv4 special principals
-	// (OWNER@/GROUP@/EVERYONE@) by returning empty name/realm.
+	// A Kerberos/AD principal "user@REALM" in our realm: claim it as the
+	// directory backing even when the credential carries a different auth-source
+	// tag (e.g. Provider="kerberos" from the NFS/SMB GSS path). The Kerberos
+	// provider resolves principals that map to a local DittoFS user; a domain
+	// principal with no local account falls through to here so it still resolves
+	// to its RFC2307 UID/GID. splitPrincipal rejects the NFSv4 special
+	// principals (OWNER@/GROUP@/EVERYONE@) by returning empty name/realm.
 	name, realm := splitPrincipal(cred.ExternalID)
 	if name == "" || realm == "" {
 		return false

--- a/pkg/identity/ldap/provider_test.go
+++ b/pkg/identity/ldap/provider_test.go
@@ -242,6 +242,28 @@ func TestCanResolve(t *testing.T) {
 	if !p.CanResolve(&identity.Credential{Provider: ProviderName, ExternalID: "x"}) {
 		t.Error("explicit provider routing should be claimed")
 	}
+
+	// A credential tagged with a DIFFERENT auth source (e.g. Provider="kerberos"
+	// from the NFS/SMB GSS path) must still be claimed by shape: an in-realm
+	// principal or an AD SID is resolved against the directory as the fallback,
+	// while a foreign-realm principal is left for another provider. This is the
+	// fix for the bug where Kerberos-authenticated domain users never reached
+	// the directory and resolved to nobody.
+	taggedCases := []struct {
+		id   string
+		want bool
+	}{
+		{"alice@DITTOFS.AD", true},    // in-realm principal -> claimed
+		{"S-1-5-21-1-2-3-1104", true}, // AD SID -> claimed
+		{"alice@OTHER.REALM", false},  // foreign realm -> not ours
+		{"OWNER@", false},             // NFSv4 special principal -> never
+	}
+	for _, tc := range taggedCases {
+		got := p.CanResolve(&identity.Credential{Provider: "kerberos", ExternalID: tc.id})
+		if got != tc.want {
+			t.Errorf("CanResolve(kerberos-tagged %q) = %v, want %v", tc.id, got, tc.want)
+		}
+	}
 }
 
 func TestNew_RejectsInvalidConfig(t *testing.T) {

--- a/pkg/identity/resolver.go
+++ b/pkg/identity/resolver.go
@@ -102,16 +102,38 @@ type cacheResult struct {
 }
 
 func (r *Resolver) resolveUncached(ctx context.Context, cred *Credential) (*ResolvedIdentity, error) {
+	// A credential tagged with an explicit Provider names the PREFERRED provider
+	// (the auth source that produced it, e.g. "kerberos" for an RPCSEC_GSS /
+	// SPNEGO principal). Try it first — but treat Found=false as "try the rest
+	// of the chain", not a terminal answer. This is what realizes the documented
+	// fallback design in BuildIdentityResolver: the Kerberos provider resolves a
+	// principal that maps to a LOCAL DittoFS user, and a domain principal with no
+	// local account falls through to the LDAP/AD directory provider (RFC2307
+	// UID/GID + nested groups). Previously this branch returned the preferred
+	// provider's Found=false directly, so every domain user authenticating over
+	// Kerberos resolved to nobody and the directory was never consulted.
+	preferred := -1
 	if cred.Provider != "" {
-		for _, p := range r.providers {
+		for i, p := range r.providers {
 			if p.Name() == cred.Provider {
-				return p.Resolve(ctx, cred)
+				result, err := p.Resolve(ctx, cred)
+				if err != nil {
+					return nil, err
+				}
+				if result.Found {
+					return result, nil
+				}
+				preferred = i
+				break
 			}
 		}
-		return &ResolvedIdentity{Found: false}, nil
 	}
 
-	for _, p := range r.providers {
+	// Fall through to every other provider that claims the credential by shape.
+	for i, p := range r.providers {
+		if i == preferred {
+			continue // already tried above
+		}
 		if !p.CanResolve(cred) {
 			continue
 		}

--- a/pkg/identity/resolver_test.go
+++ b/pkg/identity/resolver_test.go
@@ -3,6 +3,7 @@ package identity
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -94,6 +95,58 @@ func TestResolver_ChainFirstMatchWins(t *testing.T) {
 	}
 	if second.callCount() != 0 {
 		t.Fatal("second provider should not have been called")
+	}
+}
+
+// TestResolver_PreferredProviderFallsThroughOnNotFound models the production
+// Kerberos→LDAP chain: a credential tagged Provider="kerberos" is tried against
+// the Kerberos provider first, but when that returns Found=false (the principal
+// is not a local DittoFS user) resolution must FALL THROUGH to the directory
+// provider that claims the principal by shape — not stop at the preferred
+// provider. Before the fix a Provider-tagged not-found ended resolution, so
+// every domain user authenticating over Kerberos resolved to nobody.
+func TestResolver_PreferredProviderFallsThroughOnNotFound(t *testing.T) {
+	krb := &mockProvider{name: "kerberos", results: map[string]*ResolvedIdentity{}}
+	dir := &mockProvider{
+		name:     "ldap",
+		canCheck: func(c *Credential) bool { return strings.HasSuffix(c.ExternalID, "@AD") },
+		results:  map[string]*ResolvedIdentity{"alice@AD": {Username: "alice", UID: 10001, GID: 10000, Found: true}},
+	}
+
+	r := NewResolver(WithProvider(krb), WithProvider(dir))
+	result, err := r.Resolve(context.Background(), &Credential{Provider: "kerberos", ExternalID: "alice@AD"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Found || result.UID != 10001 || result.GID != 10000 {
+		t.Fatalf("expected directory fall-through to resolve alice@AD to 10001:10000, got %+v", result)
+	}
+	if krb.callCount() != 1 {
+		t.Fatalf("preferred kerberos provider should be tried exactly once, got %d", krb.callCount())
+	}
+	if dir.callCount() != 1 {
+		t.Fatalf("directory provider should be tried once on fall-through, got %d", dir.callCount())
+	}
+}
+
+// TestResolver_PreferredProviderErrorDoesNotFallThrough pins that an
+// infrastructure error from the preferred provider is surfaced, not masked by
+// falling through to other providers (a transient KDC/DB error must not be
+// silently treated as "unmapped").
+func TestResolver_PreferredProviderErrorDoesNotFallThrough(t *testing.T) {
+	krb := &mockProvider{name: "kerberos", err: errors.New("kdc unreachable")}
+	dir := &mockProvider{
+		name:    "ldap",
+		results: map[string]*ResolvedIdentity{"alice@AD": {Username: "alice", UID: 10001, Found: true}},
+	}
+
+	r := NewResolver(WithProvider(krb), WithProvider(dir))
+	_, err := r.Resolve(context.Background(), &Credential{Provider: "kerberos", ExternalID: "alice@AD"})
+	if err == nil {
+		t.Fatal("expected preferred-provider error to be surfaced, got nil")
+	}
+	if dir.callCount() != 0 {
+		t.Fatalf("directory provider must not be tried after a preferred-provider error, got %d", dir.callCount())
 	}
 }
 


### PR DESCRIPTION
## Problem (found via live AD validation)

A credential tagged with an explicit `Provider` (the auth source that produced it — `"kerberos"` for an RPCSEC_GSS / SPNEGO principal) was dispatched **only** to the provider whose `Name()` matched, and that provider returning `Found=false` ended resolution. The identity chain registers the Kerberos provider *before* the LDAP/AD provider precisely so a domain principal with no local DittoFS account falls through to the directory (RFC2307 UID/GID + nested groups) — but the short-circuit in `resolveUncached` defeated that design.

**Result:** every domain user authenticating over NFS or SMB Kerberos resolved to **nobody (65534)**; the AD/LDAP directory was never queried. The Kerberos provider strips the realm and looks up the bare name as a *local* DittoFS user (`alice` → not found), so a real domain user never got its UID/GID.

## Live evidence (Samba AD-DC + real Linux NFSv4.1 `sec=krb5`)

| | Before | After |
|---|--------|-------|
| `alice` writes a file over `sec=krb5` | owned `65534:65534` (nobody) | owned **`10001:10000`** (alice's RFC2307 uid/gid via LDAP) |

POSIX semantics verified under the AD identity: `chmod 0640`→`0600` enforced, `mkdir` owned `10001:10000`, read-back OK (#1246 acceptance).

## Fix

- **resolver**: an explicit `Provider` is the *preferred* provider (tried first); on `Found=false` resolution **falls through** to the `CanResolve` chain. An infrastructure **error** from the preferred provider is still surfaced (not masked).
- **ldap `CanResolve`**: claims an in-realm principal / AD SID **by shape** even when the credential carries a different auth-source tag (e.g. `Provider="kerberos"`), so it serves as the directory fallback. Foreign-realm principals and NFSv4 special principals are left alone.

Unit tests for both (resolver fall-through + error-not-masked; ldap claims kerberos-tagged realm principal). Part of #1231. Closes #1246.

> Note: a separate Samba-AD-DC LDAPS interop snag surfaced during validation — Samba's self-signed cert has a negative serial that Go's x509 parser rejects even with `insecure_skip_verify` (worked around live with `GODEBUG=x509negativeserial=1`). Filed as a follow-up.