### PR TITLE
feat(metadata): unified xattr resolver over EAs + named streams (#1285)

### DIFF
--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -182,6 +182,12 @@ func New(s store.Store) *Runtime {
 	// take effect immediately.
 	rt.metadataService.SetTrashPolicy(&trashPolicy{sharesSvc: rt.sharesSvc})
 
+	// Wire the block-store-backed reader so the unified xattr resolver can
+	// surface named-stream-backed xattr values (the read half of cross-protocol
+	// parity for SMB-created streams). The shares service owns block-store
+	// resolution; the metadata Service stays block-engine-agnostic.
+	rt.metadataService.SetXattrStreamReader(rt.sharesSvc.XattrStreamReader())
+
 	// Persist quota grace-timer transitions back to the control-plane DB so the
 	// soft->grace->hard state survives restart. Only when a store is present.
 	if s != nil {

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"net/url"
 	"os"
@@ -1660,6 +1661,37 @@ func (s *Service) GetBlockStoreForHandle(ctx context.Context, handle metadata.Fi
 		return nil, fmt.Errorf("share %q has no block store configured", shareName)
 	}
 	return share.BlockStore, nil
+}
+
+// XattrStreamReader returns a metadata.StreamContentReader that materialises a
+// named-stream child's content as an xattr value via the per-share block store.
+// It is wired into metadata.Service.SetXattrStreamReader so the unified xattr
+// resolver can surface stream-entity-backed xattrs (the read half of
+// cross-protocol parity for SMB-created named streams). The metadata layer
+// stays block-engine-agnostic; this wrapper is the single seam where xattr
+// resolution reaches the block store (GetBlockStoreForHandle + ReadAt).
+//
+// A zero-size stream yields an empty value. Streams large enough to exceed an
+// int slice are rejected; named-stream xattr values are expected to be small.
+func (s *Service) XattrStreamReader() metadata.StreamContentReader {
+	return func(ctx context.Context, streamHandle metadata.FileHandle, attr *metadata.FileAttr) ([]byte, error) {
+		if attr == nil || attr.Size == 0 || attr.PayloadID == "" {
+			return []byte{}, nil
+		}
+		if attr.Size > math.MaxInt32 {
+			return nil, fmt.Errorf("stream-backed xattr too large: %d bytes", attr.Size)
+		}
+		bs, err := s.GetBlockStoreForHandle(ctx, streamHandle)
+		if err != nil {
+			return nil, err
+		}
+		buf := make([]byte, int(attr.Size))
+		n, rerr := bs.ReadAt(ctx, string(attr.PayloadID), nil, buf, 0)
+		if rerr != nil && rerr != io.EOF && rerr != io.ErrUnexpectedEOF {
+			return nil, rerr
+		}
+		return buf[:n], nil
+	}
 }
 
 // GetBlockStoreForShare returns the BlockStore for a named share.

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -91,6 +91,15 @@ type Service struct {
 	// on delete. Nil (the default) disables trash entirely: deletes destroy
 	// content as before. Installed via SetTrashPolicy.
 	trashPolicy TrashPolicy
+
+	// xattrStreamReader, if set, reads the content of a named-stream child File
+	// so the xattr resolver can surface stream-backed xattr values (the
+	// stream-entity backing). It is wired by the runtime layer, which has
+	// block-store access (GetBlockStoreForHandle + engine.Store.ReadAt); the
+	// metadata Service stays block-engine-agnostic. Nil (the default) leaves
+	// stream NAMES enumerable via ListXattr but makes GetXattr report a
+	// stream-only name as absent. Installed via SetXattrStreamReader.
+	xattrStreamReader StreamContentReader
 }
 
 // GraceCoordinator couples the lock-manager grace period with another grace

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -69,6 +69,37 @@ type Files interface {
 	ListChildren(ctx context.Context, dirHandle FileHandle, cursor string, limit int) ([]DirEntry, string, error)
 
 	// ========================================================================
+	// Extended Attribute (xattr) Operations
+	// ========================================================================
+	//
+	// These present a SINGLE xattr namespace over the two physical backings
+	// DittoFS maintains — inline K/V (FileAttr.EAs) and named-stream child
+	// entities — so every protocol family reads/writes the same data. The
+	// resolution logic is shared across all backends in xattr.go; each backend
+	// delegates to the Resolve* free functions. Precedence is
+	// stream-entity-wins-else-inline. See xattr.go for the full contract.
+
+	// GetXattr returns the value of the named xattr and whether it is present,
+	// merged across both backings (stream wins). Names resolve case-
+	// insensitively. Stream-backed values require block-store access and are
+	// surfaced by the Service-level wrapper; the bare store method cannot read
+	// stream content (no block store at this tier) and reports a
+	// stream-only name as absent.
+	GetXattr(ctx context.Context, handle FileHandle, name string) ([]byte, bool, error)
+
+	// SetXattr writes the xattr value into the inline backing when it fits
+	// (<= XattrInlineMaxBytes); a larger value returns ErrXattrTooLarge.
+	SetXattr(ctx context.Context, handle FileHandle, name string, value []byte) error
+
+	// RemoveXattr removes the named xattr from the inline backing. Returns
+	// ErrNotFound when the name is absent from the inline backing.
+	RemoveXattr(ctx context.Context, handle FileHandle, name string) error
+
+	// ListXattr returns all xattr names on the file, merged from both backings
+	// and de-duplicated case-insensitively, sorted for determinism.
+	ListXattr(ctx context.Context, handle FileHandle) ([]string, error)
+
+	// ========================================================================
 	// Parent Tracking Operations
 	// ========================================================================
 

--- a/pkg/metadata/store/badger/xattr.go
+++ b/pkg/metadata/store/badger/xattr.go
@@ -1,0 +1,51 @@
+package badger
+
+import (
+	"context"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// Extended-attribute (xattr) operations delegate to the shared resolver in
+// pkg/metadata/xattr.go over the Files interface. Both the Badger store and its
+// transaction satisfy metadata.Files, so the same Resolve* helpers serve both.
+
+// GetXattr implements metadata.Files.
+func (s *BadgerMetadataStore) GetXattr(ctx context.Context, handle metadata.FileHandle, name string) ([]byte, bool, error) {
+	return metadata.ResolveGetXattr(ctx, s, handle, name, nil)
+}
+
+// SetXattr implements metadata.Files.
+func (s *BadgerMetadataStore) SetXattr(ctx context.Context, handle metadata.FileHandle, name string, value []byte) error {
+	return metadata.ResolveSetXattr(ctx, s, handle, name, value)
+}
+
+// RemoveXattr implements metadata.Files.
+func (s *BadgerMetadataStore) RemoveXattr(ctx context.Context, handle metadata.FileHandle, name string) error {
+	return metadata.ResolveRemoveXattr(ctx, s, handle, name)
+}
+
+// ListXattr implements metadata.Files.
+func (s *BadgerMetadataStore) ListXattr(ctx context.Context, handle metadata.FileHandle) ([]string, error) {
+	return metadata.ResolveListXattr(ctx, s, handle)
+}
+
+// GetXattr implements metadata.Files for the transaction receiver.
+func (tx *badgerTransaction) GetXattr(ctx context.Context, handle metadata.FileHandle, name string) ([]byte, bool, error) {
+	return metadata.ResolveGetXattr(ctx, tx, handle, name, nil)
+}
+
+// SetXattr implements metadata.Files for the transaction receiver.
+func (tx *badgerTransaction) SetXattr(ctx context.Context, handle metadata.FileHandle, name string, value []byte) error {
+	return metadata.ResolveSetXattr(ctx, tx, handle, name, value)
+}
+
+// RemoveXattr implements metadata.Files for the transaction receiver.
+func (tx *badgerTransaction) RemoveXattr(ctx context.Context, handle metadata.FileHandle, name string) error {
+	return metadata.ResolveRemoveXattr(ctx, tx, handle, name)
+}
+
+// ListXattr implements metadata.Files for the transaction receiver.
+func (tx *badgerTransaction) ListXattr(ctx context.Context, handle metadata.FileHandle) ([]string, error) {
+	return metadata.ResolveListXattr(ctx, tx, handle)
+}

--- a/pkg/metadata/store/memory/xattr.go
+++ b/pkg/metadata/store/memory/xattr.go
@@ -1,0 +1,55 @@
+package memory
+
+import (
+	"context"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// Extended-attribute (xattr) operations delegate to the shared resolver in
+// pkg/metadata/xattr.go, which unifies the inline EA backing with named-stream
+// child entities over the Files interface. The memory store and its
+// transaction both satisfy metadata.Files, so the same Resolve* helpers serve
+// both. The bare store layer has no block-store reader wired, so stream-backed
+// values are surfaced by the Service tier; here the inline backing is
+// authoritative for Get.
+
+// GetXattr implements metadata.Files.
+func (store *MemoryMetadataStore) GetXattr(ctx context.Context, handle metadata.FileHandle, name string) ([]byte, bool, error) {
+	return metadata.ResolveGetXattr(ctx, store, handle, name, nil)
+}
+
+// SetXattr implements metadata.Files.
+func (store *MemoryMetadataStore) SetXattr(ctx context.Context, handle metadata.FileHandle, name string, value []byte) error {
+	return metadata.ResolveSetXattr(ctx, store, handle, name, value)
+}
+
+// RemoveXattr implements metadata.Files.
+func (store *MemoryMetadataStore) RemoveXattr(ctx context.Context, handle metadata.FileHandle, name string) error {
+	return metadata.ResolveRemoveXattr(ctx, store, handle, name)
+}
+
+// ListXattr implements metadata.Files.
+func (store *MemoryMetadataStore) ListXattr(ctx context.Context, handle metadata.FileHandle) ([]string, error) {
+	return metadata.ResolveListXattr(ctx, store, handle)
+}
+
+// GetXattr implements metadata.Files for the transaction receiver.
+func (tx *memoryTransaction) GetXattr(ctx context.Context, handle metadata.FileHandle, name string) ([]byte, bool, error) {
+	return metadata.ResolveGetXattr(ctx, tx, handle, name, nil)
+}
+
+// SetXattr implements metadata.Files for the transaction receiver.
+func (tx *memoryTransaction) SetXattr(ctx context.Context, handle metadata.FileHandle, name string, value []byte) error {
+	return metadata.ResolveSetXattr(ctx, tx, handle, name, value)
+}
+
+// RemoveXattr implements metadata.Files for the transaction receiver.
+func (tx *memoryTransaction) RemoveXattr(ctx context.Context, handle metadata.FileHandle, name string) error {
+	return metadata.ResolveRemoveXattr(ctx, tx, handle, name)
+}
+
+// ListXattr implements metadata.Files for the transaction receiver.
+func (tx *memoryTransaction) ListXattr(ctx context.Context, handle metadata.FileHandle) ([]string, error) {
+	return metadata.ResolveListXattr(ctx, tx, handle)
+}

--- a/pkg/metadata/store/postgres/xattr.go
+++ b/pkg/metadata/store/postgres/xattr.go
@@ -1,0 +1,52 @@
+package postgres
+
+import (
+	"context"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// Extended-attribute (xattr) operations delegate to the shared resolver in
+// pkg/metadata/xattr.go over the Files interface. Both the Postgres store and
+// its transaction satisfy metadata.Files, so the same Resolve* helpers serve
+// both. Inline values ride the existing eas JSONB column.
+
+// GetXattr implements metadata.Files.
+func (s *PostgresMetadataStore) GetXattr(ctx context.Context, handle metadata.FileHandle, name string) ([]byte, bool, error) {
+	return metadata.ResolveGetXattr(ctx, s, handle, name, nil)
+}
+
+// SetXattr implements metadata.Files.
+func (s *PostgresMetadataStore) SetXattr(ctx context.Context, handle metadata.FileHandle, name string, value []byte) error {
+	return metadata.ResolveSetXattr(ctx, s, handle, name, value)
+}
+
+// RemoveXattr implements metadata.Files.
+func (s *PostgresMetadataStore) RemoveXattr(ctx context.Context, handle metadata.FileHandle, name string) error {
+	return metadata.ResolveRemoveXattr(ctx, s, handle, name)
+}
+
+// ListXattr implements metadata.Files.
+func (s *PostgresMetadataStore) ListXattr(ctx context.Context, handle metadata.FileHandle) ([]string, error) {
+	return metadata.ResolveListXattr(ctx, s, handle)
+}
+
+// GetXattr implements metadata.Files for the transaction receiver.
+func (tx *postgresTransaction) GetXattr(ctx context.Context, handle metadata.FileHandle, name string) ([]byte, bool, error) {
+	return metadata.ResolveGetXattr(ctx, tx, handle, name, nil)
+}
+
+// SetXattr implements metadata.Files for the transaction receiver.
+func (tx *postgresTransaction) SetXattr(ctx context.Context, handle metadata.FileHandle, name string, value []byte) error {
+	return metadata.ResolveSetXattr(ctx, tx, handle, name, value)
+}
+
+// RemoveXattr implements metadata.Files for the transaction receiver.
+func (tx *postgresTransaction) RemoveXattr(ctx context.Context, handle metadata.FileHandle, name string) error {
+	return metadata.ResolveRemoveXattr(ctx, tx, handle, name)
+}
+
+// ListXattr implements metadata.Files for the transaction receiver.
+func (tx *postgresTransaction) ListXattr(ctx context.Context, handle metadata.FileHandle) ([]string, error) {
+	return metadata.ResolveListXattr(ctx, tx, handle)
+}

--- a/pkg/metadata/storetest/suite.go
+++ b/pkg/metadata/storetest/suite.go
@@ -94,6 +94,18 @@ func RunConformanceSuite(t *testing.T, factory StoreFactory) {
 		runEAOpsTests(t, factory)
 	})
 
+	// XattrOps covers the unified xattr resolver (pkg/metadata/xattr.go) that
+	// presents a single xattr namespace over the inline EA backing and named-
+	// stream child entities: inline get/set/delete/list, case-insensitive
+	// resolution, zero-length values, the >64 KiB ErrXattrTooLarge ceiling,
+	// merged listing (inline + a manually-created stream sibling), stream-
+	// content reads through a test reader, and stream-wins precedence. Pins
+	// cross-backend parity for the resolver the same way EAOps does for the
+	// raw EA map.
+	t.Run("XattrOps", func(t *testing.T) {
+		runXattrOpsTests(t, factory)
+	})
+
 	t.Run("FileBlockOps", func(t *testing.T) {
 		runFileBlockOpsTests(t, factory)
 	})

--- a/pkg/metadata/storetest/xattr_ops.go
+++ b/pkg/metadata/storetest/xattr_ops.go
@@ -1,0 +1,311 @@
+package storetest
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// runXattrOpsTests asserts cross-backend parity for the unified xattr resolver
+// (pkg/metadata/xattr.go), which presents ONE xattr namespace over the two
+// physical backings DittoFS maintains:
+//
+//   - Inline K/V  — FileAttr.EAs (the SMB EA backing).
+//   - Named-stream child entities — "<base>:<stream>" siblings (the SMB ADS
+//     backing), enumerated via ListChildren and read through the block store.
+//
+// Precedence is stream-entity-wins-else-inline. The bare store methods cover
+// the inline backing and stream-name enumeration; stream-content reads (which
+// require a block store) are exercised through the exported resolver with a
+// test StreamContentReader so this metadata-only suite proves the read path
+// without a block engine. Pins the same cross-backend parity contract EAOps
+// pins for the raw EA map.
+func runXattrOpsTests(t *testing.T, factory StoreFactory) {
+	t.Run("InlineSetGetDelete", func(t *testing.T) { testXattrInlineSetGetDelete(t, factory) })
+	t.Run("ZeroLengthValue", func(t *testing.T) { testXattrZeroLength(t, factory) })
+	t.Run("CaseInsensitiveResolution", func(t *testing.T) { testXattrCaseInsensitive(t, factory) })
+	t.Run("TooLarge", func(t *testing.T) { testXattrTooLarge(t, factory) })
+	t.Run("RemoveMissing", func(t *testing.T) { testXattrRemoveMissing(t, factory) })
+	t.Run("InlineList", func(t *testing.T) { testXattrInlineList(t, factory) })
+	t.Run("MergedListInlinePlusStream", func(t *testing.T) { testXattrMergedList(t, factory) })
+	t.Run("StreamBackedGet", func(t *testing.T) { testXattrStreamBackedGet(t, factory) })
+	t.Run("StreamWinsPrecedence", func(t *testing.T) { testXattrStreamPrecedence(t, factory) })
+}
+
+// testReader builds a StreamContentReader serving a fixed value for the given
+// stream handle, so content-backed resolution can be exercised without a block
+// store. It reads attr.Size bytes of the supplied payload.
+func testReader(payload []byte) metadata.StreamContentReader {
+	return func(_ context.Context, _ metadata.FileHandle, attr *metadata.FileAttr) ([]byte, error) {
+		if attr == nil {
+			return nil, nil
+		}
+		out := make([]byte, len(payload))
+		copy(out, payload)
+		return out, nil
+	}
+}
+
+// createStreamChild creates a "<base>:<stream>" child of parentHandle with the
+// given size/payload so the resolver's colon-prefix scan finds it as a named
+// stream of base. Returns the stream child's handle.
+func createStreamChild(t *testing.T, store metadata.Store, shareName string, parentHandle metadata.FileHandle, base, stream string, size uint64) metadata.FileHandle {
+	t.Helper()
+	name := base + ":" + stream
+	handle := createTestFile(t, store, shareName, parentHandle, name, 0o600)
+	// Stamp size + payload so a stream-content reader can materialise a value.
+	file, err := store.GetFile(t.Context(), handle)
+	if err != nil {
+		t.Fatalf("GetFile(stream child): %v", err)
+	}
+	file.Size = size
+	file.PayloadID = metadata.PayloadID(metadata.BuildPayloadID(shareName, file.Path))
+	if err := store.PutFile(t.Context(), file); err != nil {
+		t.Fatalf("PutFile(stream child): %v", err)
+	}
+	return handle
+}
+
+func testXattrInlineSetGetDelete(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+	root := createTestShare(t, store, "/xattr-inline")
+	handle := createTestFile(t, store, "/xattr-inline", root, "f.txt", 0o600)
+
+	if err := store.SetXattr(ctx, handle, "user.color", []byte("blue")); err != nil {
+		t.Fatalf("SetXattr: %v", err)
+	}
+	val, found, err := store.GetXattr(ctx, handle, "user.color")
+	if err != nil {
+		t.Fatalf("GetXattr: %v", err)
+	}
+	if !found || !bytes.Equal(val, []byte("blue")) {
+		t.Fatalf("GetXattr = (%q, %v), want (blue, true)", val, found)
+	}
+
+	if err := store.RemoveXattr(ctx, handle, "user.color"); err != nil {
+		t.Fatalf("RemoveXattr: %v", err)
+	}
+	_, found, err = store.GetXattr(ctx, handle, "user.color")
+	if err != nil {
+		t.Fatalf("GetXattr after remove: %v", err)
+	}
+	if found {
+		t.Fatal("xattr still present after RemoveXattr")
+	}
+}
+
+func testXattrZeroLength(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+	root := createTestShare(t, store, "/xattr-zero")
+	handle := createTestFile(t, store, "/xattr-zero", root, "f.txt", 0o600)
+
+	if err := store.SetXattr(ctx, handle, "user.empty", []byte{}); err != nil {
+		t.Fatalf("SetXattr(zero): %v", err)
+	}
+	val, found, err := store.GetXattr(ctx, handle, "user.empty")
+	if err != nil {
+		t.Fatalf("GetXattr(zero): %v", err)
+	}
+	if !found {
+		t.Fatal("zero-length xattr must round-trip as present, not absent")
+	}
+	if len(val) != 0 {
+		t.Fatalf("zero-length xattr value = %q, want empty", val)
+	}
+}
+
+func testXattrCaseInsensitive(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+	root := createTestShare(t, store, "/xattr-case")
+	handle := createTestFile(t, store, "/xattr-case", root, "f.txt", 0o600)
+
+	if err := store.SetXattr(ctx, handle, "User.MixedCase", []byte("v")); err != nil {
+		t.Fatalf("SetXattr: %v", err)
+	}
+	for _, probe := range []string{"User.MixedCase", "user.mixedcase", "USER.MIXEDCASE"} {
+		val, found, err := store.GetXattr(ctx, handle, probe)
+		if err != nil {
+			t.Fatalf("GetXattr(%q): %v", probe, err)
+		}
+		if !found || !bytes.Equal(val, []byte("v")) {
+			t.Fatalf("GetXattr(%q) = (%q, %v), want (v, true) — names must resolve case-insensitively", probe, val, found)
+		}
+	}
+
+	// An upsert under a different casing must not create a duplicate.
+	if err := store.SetXattr(ctx, handle, "USER.MIXEDCASE", []byte("v2")); err != nil {
+		t.Fatalf("SetXattr(case-diff upsert): %v", err)
+	}
+	names, err := store.ListXattr(ctx, handle)
+	if err != nil {
+		t.Fatalf("ListXattr: %v", err)
+	}
+	if len(names) != 1 {
+		t.Fatalf("case-different upsert created a duplicate: %v", names)
+	}
+}
+
+func testXattrTooLarge(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+	root := createTestShare(t, store, "/xattr-big")
+	handle := createTestFile(t, store, "/xattr-big", root, "f.txt", 0o600)
+
+	big := make([]byte, metadata.XattrInlineMaxBytes+1)
+	err := store.SetXattr(ctx, handle, "user.big", big)
+	if !errors.Is(err, metadata.ErrXattrTooLarge) {
+		t.Fatalf("SetXattr(oversized) err = %v, want ErrXattrTooLarge", err)
+	}
+
+	// A value exactly at the limit must succeed (boundary).
+	atLimit := make([]byte, metadata.XattrInlineMaxBytes)
+	if err := store.SetXattr(ctx, handle, "user.atlimit", atLimit); err != nil {
+		t.Fatalf("SetXattr(at-limit) err = %v, want nil", err)
+	}
+}
+
+func testXattrRemoveMissing(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+	root := createTestShare(t, store, "/xattr-rm")
+	handle := createTestFile(t, store, "/xattr-rm", root, "f.txt", 0o600)
+
+	err := store.RemoveXattr(ctx, handle, "user.absent")
+	if !metadata.IsNotFoundError(err) {
+		t.Fatalf("RemoveXattr(absent) err = %v, want ErrNotFound", err)
+	}
+}
+
+func testXattrInlineList(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+	root := createTestShare(t, store, "/xattr-list")
+	handle := createTestFile(t, store, "/xattr-list", root, "f.txt", 0o600)
+
+	for _, n := range []string{"user.a", "user.b", "user.c"} {
+		if err := store.SetXattr(ctx, handle, n, []byte("x")); err != nil {
+			t.Fatalf("SetXattr(%q): %v", n, err)
+		}
+	}
+	names, err := store.ListXattr(ctx, handle)
+	if err != nil {
+		t.Fatalf("ListXattr: %v", err)
+	}
+	want := []string{"user.a", "user.b", "user.c"}
+	if !equalNames(names, want) {
+		t.Fatalf("ListXattr = %v, want %v", names, want)
+	}
+}
+
+func testXattrMergedList(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+	root := createTestShare(t, store, "/xattr-merge")
+	handle := createTestFile(t, store, "/xattr-merge", root, "doc.txt", 0o600)
+
+	// Inline xattr on the file.
+	if err := store.SetXattr(ctx, handle, "user.inline", []byte("i")); err != nil {
+		t.Fatalf("SetXattr: %v", err)
+	}
+	// Manually-created named stream sibling "doc.txt:streamx".
+	createStreamChild(t, store, "/xattr-merge", root, "doc.txt", "streamx", 3)
+
+	names, err := store.ListXattr(ctx, handle)
+	if err != nil {
+		t.Fatalf("ListXattr: %v", err)
+	}
+	want := []string{"streamx", "user.inline"}
+	if !equalNames(names, want) {
+		t.Fatalf("merged ListXattr = %v, want %v (inline + stream names merged)", names, want)
+	}
+}
+
+func testXattrStreamBackedGet(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+	root := createTestShare(t, store, "/xattr-stream")
+	handle := createTestFile(t, store, "/xattr-stream", root, "doc.txt", 0o600)
+
+	content := []byte("STREAMVAL")
+	createStreamChild(t, store, "/xattr-stream", root, "doc.txt", "sv", uint64(len(content)))
+
+	// The bare store method has no reader -> stream-only name reports absent.
+	_, found, err := store.GetXattr(ctx, handle, "sv")
+	if err != nil {
+		t.Fatalf("store.GetXattr(stream): %v", err)
+	}
+	if found {
+		t.Fatal("bare store GetXattr surfaced a stream value without a reader")
+	}
+
+	// With a reader, the resolver returns the stream's content as the value.
+	val, found, err := metadata.ResolveGetXattr(ctx, store, handle, "sv", testReader(content))
+	if err != nil {
+		t.Fatalf("ResolveGetXattr(stream, reader): %v", err)
+	}
+	if !found || !bytes.Equal(val, content) {
+		t.Fatalf("stream-backed Get = (%q, %v), want (%q, true)", val, found, content)
+	}
+}
+
+func testXattrStreamPrecedence(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+	root := createTestShare(t, store, "/xattr-prec")
+	handle := createTestFile(t, store, "/xattr-prec", root, "doc.txt", 0o600)
+
+	// Same name in BOTH backings: inline + stream.
+	if err := store.SetXattr(ctx, handle, "dup", []byte("INLINE")); err != nil {
+		t.Fatalf("SetXattr: %v", err)
+	}
+	streamContent := []byte("STREAM")
+	createStreamChild(t, store, "/xattr-prec", root, "doc.txt", "dup", uint64(len(streamContent)))
+
+	// Stream wins: Get returns the stream content.
+	val, found, err := metadata.ResolveGetXattr(ctx, store, handle, "dup", testReader(streamContent))
+	if err != nil {
+		t.Fatalf("ResolveGetXattr(dup): %v", err)
+	}
+	if !found || !bytes.Equal(val, streamContent) {
+		t.Fatalf("precedence Get = (%q, %v), want stream content %q", val, found, streamContent)
+	}
+
+	// List de-dupes the colliding name to a single entry.
+	names, err := store.ListXattr(ctx, handle)
+	if err != nil {
+		t.Fatalf("ListXattr: %v", err)
+	}
+	count := 0
+	for _, n := range names {
+		if n == "dup" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("collision name appears %d times in ListXattr, want 1: %v", count, names)
+	}
+}
+
+// equalNames compares two name slices order-insensitively.
+func equalNames(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	g := append([]string(nil), got...)
+	w := append([]string(nil), want...)
+	sort.Strings(g)
+	sort.Strings(w)
+	for i := range g {
+		if g[i] != w[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/metadata/xattr.go
+++ b/pkg/metadata/xattr.go
@@ -1,0 +1,294 @@
+package metadata
+
+import (
+	"context"
+	"path"
+	"sort"
+	"strings"
+
+	metaerrors "github.com/marmos91/dittofs/pkg/metadata/errors"
+)
+
+// ============================================================================
+// Unified xattr resolver
+// ============================================================================
+//
+// This file implements a single extended-attribute (xattr) namespace over the
+// TWO physical backings DittoFS already maintains, so every protocol family
+// (SMB EA, SMB named streams, NFSv4.2 GETXATTR/SETXATTR/…) reads and writes the
+// SAME data and therefore sees each other. No protocol handler changes are
+// required: the resolver only reads the backings the SMB layer already writes.
+//
+// The two backings are:
+//
+//  1. Inline K/V — FileAttr.EAs (small values, <= XattrInlineMaxBytes). This is
+//     the default home for new xattrs. Names resolve case-insensitively with
+//     set-casing preservation, reusing LookupEA / ApplyEAMutations / findEAKey.
+//     Storage rides the existing EA JSON/JSONB column (see FileAttr.EAs).
+//
+//  2. Named-stream entities — colon-named "<base>:<name>" child Files of the
+//     base file's PARENT directory (block-backed, full file identity). These
+//     are enumerated with a colon-prefix scan over ListChildren, mirroring
+//     internal/adapter/smb/handlers/query_info.go:buildFileStreamInformation.
+//     A stream's content is the xattr value and is read through the block store
+//     (engine.Store.ReadAt) via an injected StreamContentReader — the metadata
+//     layer never imports the block engine directly.
+//
+// Precedence: STREAM-ENTITY-WINS-ELSE-INLINE. When both a same-named stream
+// child and an inline EA exist, Get/List surface the stream's content/name.
+//
+// SetXattr: a value <= XattrInlineMaxBytes is written inline via
+// ApplyEAMutations. A larger value returns the sentinel ErrXattrTooLarge (the
+// NFS adapter maps it to NFS4ERR_XATTR2BIG). Spilling oversized values into a
+// freshly-created named-stream entity from the store layer requires
+// block-store coordination that does not exist at this tier; it is a
+// documented PR2 follow-up (issue #1285). The READ path is complete in PR1:
+// List/Get already surface stream-backed xattrs created by SMB so
+// cross-protocol parity holds for existing streams.
+//
+// All resolution logic lives here as free functions over the Files interface
+// so every backend (memory / badger / postgres, store + transaction receivers)
+// shares one implementation; the per-backend Files methods are thin
+// delegations.
+
+// XattrInlineMaxBytes is the maximum value size stored inline in FileAttr.EAs.
+// Values larger than this exceed the inline backing and SetXattr returns
+// ErrXattrTooLarge (mapped to NFS4ERR_XATTR2BIG by the NFS adapter).
+const XattrInlineMaxBytes = 64 * 1024
+
+// ErrXattrTooLarge is returned by SetXattr (and ResolveSetXattr) when the value
+// exceeds XattrInlineMaxBytes and therefore cannot be stored inline. The NFS
+// adapter maps it to NFS4ERR_XATTR2BIG.
+var ErrXattrTooLarge = &StoreError{
+	Code:    metaerrors.ErrInvalidArgument,
+	Message: "xattr value too large for inline storage",
+}
+
+// StreamContentReader reads the full content of a named-stream child File so
+// the resolver can surface a stream-backed xattr value. It is injected by the
+// caller that has block-store access (the runtime/adapter layer); the metadata
+// layer stays block-engine-agnostic. A nil reader disables stream-content
+// reads: stream NAMES are still enumerated by ListXattr, but GetXattr on a
+// stream-backed name reports it as not found (callers without a reader cannot
+// materialise the value).
+type StreamContentReader func(ctx context.Context, streamHandle FileHandle, attr *FileAttr) ([]byte, error)
+
+// streamSeparator separates a base file name from its stream name in the colon
+// child-naming convention ("<base>:<stream>"). Mirrors the SMB ADS layout.
+const streamSeparator = ":"
+
+// streamChildPrefix returns the "<base>:" prefix used to scan a parent
+// directory's children for the base file's named streams.
+func streamChildPrefix(baseName string) string {
+	return baseName + streamSeparator
+}
+
+// streamNameFromChild extracts the stream-name portion of a colon child
+// ("<base>:<stream>" -> "<stream>") when it matches the base, case-insensitively.
+// Returns ("", false) when childName is not a stream of baseName.
+func streamNameFromChild(baseName, childName string) (string, bool) {
+	prefix := streamChildPrefix(baseName)
+	if len(childName) <= len(prefix) {
+		return "", false
+	}
+	if !strings.EqualFold(childName[:len(prefix)], prefix) {
+		return "", false
+	}
+	return childName[len(prefix):], true
+}
+
+// baseNameForHandle returns the file's own base name (final path component) and
+// its parent handle, used to scan for named-stream siblings. A file with no
+// recoverable parent (root, or a backend that does not track the parent) has no
+// named streams; (nil parent, "", nil) is returned and stream resolution is
+// skipped gracefully.
+func baseNameForHandle(ctx context.Context, files Files, handle FileHandle, file *File) (FileHandle, string, error) {
+	parent, err := files.GetParent(ctx, handle)
+	if err != nil {
+		// No parent (root) or backend without parent tracking: no streams.
+		if IsNotFoundError(err) {
+			return nil, "", nil
+		}
+		return nil, "", err
+	}
+	base := path.Base(file.Path)
+	if base == "." || base == "/" || base == "" {
+		return nil, "", nil
+	}
+	return parent, base, nil
+}
+
+// findStreamChild scans the parent directory for a "<base>:<name>" child whose
+// stream name matches name case-insensitively, returning its handle, attrs, and
+// whether a match was found. parent may be nil (no streams).
+func findStreamChild(ctx context.Context, files Files, parent FileHandle, baseName, name string) (FileHandle, *FileAttr, bool, error) {
+	if parent == nil || baseName == "" {
+		return nil, nil, false, nil
+	}
+	cursor := ""
+	for {
+		entries, next, err := files.ListChildren(ctx, parent, cursor, 0)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		for i := range entries {
+			streamName, ok := streamNameFromChild(baseName, entries[i].Name)
+			if !ok {
+				continue
+			}
+			if strings.EqualFold(streamName, name) {
+				return entries[i].Handle, entries[i].Attr, true, nil
+			}
+		}
+		if next == "" {
+			return nil, nil, false, nil
+		}
+		cursor = next
+	}
+}
+
+// ============================================================================
+// Resolver free functions (shared by all backends)
+// ============================================================================
+
+// ResolveGetXattr resolves a single xattr name against both backings with
+// stream-entity-wins precedence. A stream-backed value is materialised through
+// reader; when reader is nil, a stream-backed name reports not-found because the
+// value cannot be read without block-store access (the inline backing is still
+// consulted). Returns (value, found, error).
+func ResolveGetXattr(ctx context.Context, files Files, handle FileHandle, name string, reader StreamContentReader) ([]byte, bool, error) {
+	file, err := files.GetFile(ctx, handle)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Stream-entity-wins: look for a named-stream child first.
+	parent, baseName, err := baseNameForHandle(ctx, files, handle, file)
+	if err != nil {
+		return nil, false, err
+	}
+	streamHandle, streamAttr, ok, err := findStreamChild(ctx, files, parent, baseName, name)
+	if err != nil {
+		return nil, false, err
+	}
+	if ok {
+		if reader == nil {
+			// Stream exists but no block-store reader is wired at this tier.
+			return nil, false, nil
+		}
+		val, rerr := reader(ctx, streamHandle, streamAttr)
+		if rerr != nil {
+			return nil, false, rerr
+		}
+		return val, true, nil
+	}
+
+	// Fall back to the inline EA backing.
+	if val, found := file.LookupEA(name); found {
+		// Return a defensive copy so callers cannot mutate the (already
+		// deep-copied) GetFile result's backing array in surprising ways.
+		out := make([]byte, len(val))
+		copy(out, val)
+		return out, true, nil
+	}
+	return nil, false, nil
+}
+
+// ResolveSetXattr writes an xattr value into the inline backing when it fits
+// (<= XattrInlineMaxBytes), reusing ApplyEAMutations for case-insensitive,
+// casing-preserving upsert. Oversized values return ErrXattrTooLarge (PR1 does
+// not spill to a named-stream entity; see file header / issue #1285).
+func ResolveSetXattr(ctx context.Context, files Files, handle FileHandle, name string, value []byte) error {
+	if len(value) > XattrInlineMaxBytes {
+		return ErrXattrTooLarge
+	}
+	file, err := files.GetFile(ctx, handle)
+	if err != nil {
+		return err
+	}
+	file.ApplyEAMutations([]EAMutation{{Name: name, Value: value}})
+	return files.PutFile(ctx, file)
+}
+
+// ResolveRemoveXattr removes an xattr from the inline backing. Removing a name
+// that is only stream-backed (or absent) returns ErrNotFound: PR1 does not
+// delete named-stream entities from the store layer (that is a CREATE/DELETE
+// of a full file entity, owned by the protocol layer). A name present in BOTH
+// backings removes only the inline copy (the stream entity is untouched), which
+// then makes the stream copy visible per the stream-wins precedence.
+func ResolveRemoveXattr(ctx context.Context, files Files, handle FileHandle, name string) error {
+	file, err := files.GetFile(ctx, handle)
+	if err != nil {
+		return err
+	}
+	if _, found := file.LookupEA(name); !found {
+		return &StoreError{Code: metaerrors.ErrNotFound, Message: "xattr not found"}
+	}
+	file.ApplyEAMutations([]EAMutation{{Name: name, Delete: true}})
+	return files.PutFile(ctx, file)
+}
+
+// ResolveListXattr returns every xattr name on the file, merged from both
+// backings and de-duplicated case-insensitively (a name present in both backings
+// appears once, in the stream's casing per the stream-wins precedence). Names
+// are returned sorted for a stable, deterministic ordering across backends.
+func ResolveListXattr(ctx context.Context, files Files, handle FileHandle) ([]string, error) {
+	file, err := files.GetFile(ctx, handle)
+	if err != nil {
+		return nil, err
+	}
+
+	// Collect names case-insensitively, preferring stream casing on collision.
+	type entry struct {
+		name     string
+		isStream bool
+	}
+	seen := make(map[string]entry)
+	add := func(name string, isStream bool) {
+		key := strings.ToLower(name)
+		if existing, ok := seen[key]; ok {
+			// Stream wins the casing/identity on collision.
+			if isStream && !existing.isStream {
+				seen[key] = entry{name: name, isStream: true}
+			}
+			return
+		}
+		seen[key] = entry{name: name, isStream: isStream}
+	}
+
+	// Stream-backed names from the parent directory scan.
+	parent, baseName, err := baseNameForHandle(ctx, files, handle, file)
+	if err != nil {
+		return nil, err
+	}
+	if parent != nil && baseName != "" {
+		cursor := ""
+		for {
+			entries, next, lerr := files.ListChildren(ctx, parent, cursor, 0)
+			if lerr != nil {
+				return nil, lerr
+			}
+			for i := range entries {
+				if streamName, ok := streamNameFromChild(baseName, entries[i].Name); ok {
+					add(streamName, true)
+				}
+			}
+			if next == "" {
+				break
+			}
+			cursor = next
+		}
+	}
+
+	// Inline EA names.
+	for k := range file.EAs {
+		add(k, false)
+	}
+
+	names := make([]string, 0, len(seen))
+	for _, e := range seen {
+		names = append(names, e.name)
+	}
+	sort.Strings(names)
+	return names, nil
+}

--- a/pkg/metadata/xattr_service.go
+++ b/pkg/metadata/xattr_service.go
@@ -1,0 +1,89 @@
+package metadata
+
+import (
+	"github.com/marmos91/dittofs/internal/logger"
+)
+
+// ============================================================================
+// Service-level xattr operations (auth-context aware)
+// ============================================================================
+//
+// These are the protocol-facing entry points: NFSv4.2 GETXATTR/SETXATTR/
+// LISTXATTRS/REMOVEXATTR handlers (PR2) call these, mirroring how SMB EA writes
+// flow through SetFileAttributes. Each applies a permission check consistent
+// with the read/write data path, then delegates to the shared resolver in
+// xattr.go which unifies the inline EA backing with named-stream child
+// entities (precedence: stream-entity-wins-else-inline).
+//
+// Stream-backed VALUES are read through s.xattrStreamReader, wired by the
+// runtime layer (which has block-store access). When unset, stream NAMES are
+// still enumerable via ListXattr; GetXattr on a stream-only name reports
+// not-found.
+
+// SetXattrStreamReader installs the block-store-backed reader used to surface
+// stream-backed xattr values. Wired once at startup by the runtime layer.
+func (s *Service) SetXattrStreamReader(r StreamContentReader) { s.xattrStreamReader = r }
+
+// GetXattr returns the value of the named xattr and whether it is present,
+// resolved across both backings (stream wins) after a READ permission check.
+func (s *Service) GetXattr(ctx *AuthContext, handle FileHandle, name string) ([]byte, bool, error) {
+	store, err := s.storeForHandle(handle)
+	if err != nil {
+		return nil, false, err
+	}
+	if err := s.checkReadPermission(ctx, handle); err != nil {
+		logger.Debug("GetXattr: read permission denied", "name", name, "error", err)
+		return nil, false, err
+	}
+	return ResolveGetXattr(ctx.Context, store, handle, name, s.xattrStreamReader)
+}
+
+// SetXattr writes the xattr value into the inline backing when it fits
+// (<= XattrInlineMaxBytes); a larger value returns ErrXattrTooLarge. Requires
+// WRITE permission and is denied on a read-only share (per-user ceiling).
+func (s *Service) SetXattr(ctx *AuthContext, handle FileHandle, name string, value []byte) error {
+	store, err := s.storeForHandle(handle)
+	if err != nil {
+		return err
+	}
+	if ctx.ShareReadOnly {
+		return &StoreError{Code: ErrAccessDenied, Message: "read-only share: xattr write denied"}
+	}
+	if err := s.checkWritePermission(ctx, handle); err != nil {
+		logger.Debug("SetXattr: write permission denied", "name", name, "error", err)
+		return err
+	}
+	return ResolveSetXattr(ctx.Context, store, handle, name, value)
+}
+
+// RemoveXattr removes the named xattr from the inline backing. Requires WRITE
+// permission and is denied on a read-only share. Returns ErrNotFound when the
+// name is absent from the inline backing.
+func (s *Service) RemoveXattr(ctx *AuthContext, handle FileHandle, name string) error {
+	store, err := s.storeForHandle(handle)
+	if err != nil {
+		return err
+	}
+	if ctx.ShareReadOnly {
+		return &StoreError{Code: ErrAccessDenied, Message: "read-only share: xattr remove denied"}
+	}
+	if err := s.checkWritePermission(ctx, handle); err != nil {
+		logger.Debug("RemoveXattr: write permission denied", "name", name, "error", err)
+		return err
+	}
+	return ResolveRemoveXattr(ctx.Context, store, handle, name)
+}
+
+// ListXattr returns all xattr names on the file, merged from both backings,
+// after a READ permission check.
+func (s *Service) ListXattr(ctx *AuthContext, handle FileHandle) ([]string, error) {
+	store, err := s.storeForHandle(handle)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.checkReadPermission(ctx, handle); err != nil {
+		logger.Debug("ListXattr: read permission denied", "error", err)
+		return nil, err
+	}
+	return ResolveListXattr(ctx.Context, store, handle)
+}


### PR DESCRIPTION
## PR1 of #1285 — unified xattr resolver in the metadata layer

A single extended-attribute namespace over the **two physical backings** DittoFS already maintains, so every protocol family (SMB EA, SMB named streams, NFSv4.2 — PR2) reads/writes the same data and sees each other. **No SMB handler changes** — the resolver only reads the backings SMB already writes.

### Backings & precedence
1. **Inline K/V** = `FileAttr.EAs` (≤64 KiB) — reuses `LookupEA`/`ApplyEAMutations`/`findEAKey` (case-insensitive, casing-preserving). Rides the existing eas JSON/JSONB column.
2. **Named-stream entities** = colon-named `base:name` child Files (block-backed), enumerated via `ListChildren` colon-prefix scan (mirrors `query_info.go:buildFileStreamInformation`); content read through the block store.

Precedence: **stream-entity-wins-else-inline**.

### What's here
- **`Files` interface** (`pkg/metadata/store.go`): `GetXattr`/`SetXattr`/`RemoveXattr`/`ListXattr`, implemented on memory/badger/postgres (store + transaction receivers) as thin delegations to shared resolver free functions.
- **`pkg/metadata/xattr.go`** — `ResolveGetXattr`/`ResolveSetXattr`/`ResolveRemoveXattr`/`ResolveListXattr` over the `Files` interface; one implementation, all backends. `SetXattr` writes ≤64 KiB inline; larger → `ErrXattrTooLarge` (NFS adapter will map to `NFS4ERR_XATTR2BIG`).
- **Service-level methods** (`pkg/metadata/xattr_service.go`) taking `*metadata.AuthContext`, with read/write permission checks and the read-only-share ceiling — what the NFS adapter (PR2) calls.
- **Runtime wrapper** (`pkg/controlplane/runtime/shares/service.go`): `XattrStreamReader()` materialises stream content via `GetBlockStoreForHandle` + `engine.Store.ReadAt`, wired into the metadata Service at startup (`runtime.go`). The metadata layer stays block-engine-agnostic.
- **Conformance** (`pkg/metadata/storetest/xattr_ops.go`): inline get/set/delete/list, case-insensitive resolution, zero-length, >64 KiB ceiling, merged list (inline + manual stream sibling), stream-backed Get, stream-wins precedence — green on memory/badger/postgres.

### Service method signatures (for the NFS adapter PR to match)
```go
func (s *Service) GetXattr(ctx *AuthContext, handle FileHandle, name string) ([]byte, bool, error)
func (s *Service) SetXattr(ctx *AuthContext, handle FileHandle, name string, value []byte) error
func (s *Service) RemoveXattr(ctx *AuthContext, handle FileHandle, name string) error
func (s *Service) ListXattr(ctx *AuthContext, handle FileHandle) ([]string, error)
```

### Deferred (documented in `xattr.go` header / #1285 PR2)
- **Oversized-value spill into a named-stream entity**: PR1 returns `ErrXattrTooLarge` instead. Stream **read** (List/Get of existing SMB-created streams) is complete now, so cross-protocol parity holds for existing streams.
- `RemoveXattr` removes only the inline copy; deleting a named-stream **entity** is a full-file CREATE/DELETE owned by the protocol layer (out of scope for the store-tier resolver).

### Tests
- `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- `go test ./pkg/metadata/...` green; XattrOps passes on memory + badger locally. Postgres conformance is gated on `DITTOFS_TEST_POSTGRES_DSN` (not set locally → CI-verified); the resolver is backend-agnostic and rides the existing eas JSONB.

Refs #1285.
