### PR TITLE
feat(nfs): NFSv4.2 minorversion + RFC 8276 xattr ops (#1285)

### DIFF
--- a/internal/adapter/nfs/v4/attrs/encode.go
+++ b/internal/adapter/nfs/v4/attrs/encode.go
@@ -65,6 +65,7 @@ const (
 	FATTR4_SPACE_FREE         = 60 // uint64: free filesystem space in bytes (RFC 7530 Section 5.8.2.29)
 	FATTR4_SPACE_AVAIL        = 61 // uint64: available space for caller in bytes (RFC 7530 Section 5.8.2.30)
 	FATTR4_SUPPATTR_EXCLCREAT = 75 // bitmap4: attrs settable during EXCLUSIVE4_1 create (RFC 8881 Section 5.8.1.10)
+	FATTR4_XATTR_SUPPORT      = 82 // bool: extended attributes supported (RFC 8276 Section 8.4; word 2, bit 18)
 )
 
 // time_how4 constants for SETATTR timestamp setting (RFC 7530 Section 5.7)
@@ -233,6 +234,11 @@ func SupportedAttrs() []uint32 {
 
 	// NFSv4.1 exclusive create attributes (word 2)
 	SetBit(&bitmap, FATTR4_SUPPATTR_EXCLCREAT)
+
+	// NFSv4.2 / RFC 8276 extended attribute support (word 2, bit 18).
+	// Advertising this tells the Linux client that getfattr/setfattr over the
+	// user.* namespace is available, so it issues the RFC 8276 xattr ops.
+	SetBit(&bitmap, FATTR4_XATTR_SUPPORT)
 
 	return bitmap
 }
@@ -468,6 +474,11 @@ func encodeSingleAttr(buf *bytes.Buffer, bit uint32, node PseudoFSAttrSource) er
 		// of EXCLUSIVE4_1, rather than requiring a follow-up SETATTR.
 		return EncodeBitmap4(buf, exclcreatAttrs())
 
+	case FATTR4_XATTR_SUPPORT:
+		// bool: the pseudo-fs carries no named attributes, but the attribute is
+		// advertised in SUPPORTED_ATTRS, so report false rather than erroring.
+		return xdr.WriteUint32(buf, 0) // false
+
 	default:
 		// Unknown attribute -- should not reach here if Intersect is correct
 		return fmt.Errorf("unsupported attribute bit %d", bit)
@@ -694,6 +705,10 @@ func encodeRealFileAttr(buf *bytes.Buffer, bit uint32, file *metadata.File, hand
 
 	case FATTR4_SUPPATTR_EXCLCREAT:
 		return EncodeBitmap4(buf, exclcreatAttrs())
+
+	case FATTR4_XATTR_SUPPORT:
+		// bool: real files support RFC 8276 extended attributes (user.* namespace).
+		return xdr.WriteUint32(buf, 1) // true
 
 	default:
 		return fmt.Errorf("unsupported attribute bit %d", bit)

--- a/internal/adapter/nfs/v4/attrs/encode.go
+++ b/internal/adapter/nfs/v4/attrs/encode.go
@@ -238,6 +238,13 @@ func SupportedAttrs() []uint32 {
 	// NFSv4.2 / RFC 8276 extended attribute support (word 2, bit 18).
 	// Advertising this tells the Linux client that getfattr/setfattr over the
 	// user.* namespace is available, so it issues the RFC 8276 xattr ops.
+	//
+	// This bit is advertised unconditionally (independent of the COMPOUND's
+	// minor version). Per RFC 8276 §8.4 FATTR4_XATTR_SUPPORT is only meaningful
+	// to minorversion-2 clients, and v4.0/v4.1 clients do not query bit 82, so a
+	// constant supported-attrs bitmap is harmless. dispatchOne still gates the
+	// xattr ops themselves to minorversion 2 (NFS4ERR_NOTSUPP otherwise), so a
+	// pre-4.2 client can never act on this bit.
 	SetBit(&bitmap, FATTR4_XATTR_SUPPORT)
 
 	return bitmap

--- a/internal/adapter/nfs/v4/attrs/encode_test.go
+++ b/internal/adapter/nfs/v4/attrs/encode_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	v4types "github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
 // ============================================================================
@@ -591,5 +592,30 @@ func TestWritableAndExclcreatStillIncludeTimeSet(t *testing.T) {
 		if !IsBitSet(exclcreatAttrs(), bit) {
 			t.Errorf("exclcreatAttrs() missing write-only bit %d", bit)
 		}
+	}
+}
+
+// TestXattrSupportAttr verifies the RFC 8276 FATTR4_XATTR_SUPPORT (bit 82,
+// word 2) is advertised in SUPPORTED_ATTRS and encodes as bool true for real
+// files. 82/32 = word 2, 82%32 = 18.
+func TestXattrSupportAttr(t *testing.T) {
+	if FATTR4_XATTR_SUPPORT != 82 {
+		t.Fatalf("FATTR4_XATTR_SUPPORT = %d, want 82", FATTR4_XATTR_SUPPORT)
+	}
+	if FATTR4_XATTR_SUPPORT/32 != 2 || FATTR4_XATTR_SUPPORT%32 != 18 {
+		t.Fatalf("FATTR4_XATTR_SUPPORT word/offset = %d/%d, want 2/18",
+			FATTR4_XATTR_SUPPORT/32, FATTR4_XATTR_SUPPORT%32)
+	}
+	if !IsBitSet(SupportedAttrs(), FATTR4_XATTR_SUPPORT) {
+		t.Error("SupportedAttrs() missing FATTR4_XATTR_SUPPORT")
+	}
+
+	// Real-file encode: bool true (uint32 1).
+	var buf bytes.Buffer
+	if err := encodeRealFileAttr(&buf, FATTR4_XATTR_SUPPORT, &metadata.File{}, metadata.FileHandle("/s:id"), nil); err != nil {
+		t.Fatalf("encodeRealFileAttr(XATTR_SUPPORT): %v", err)
+	}
+	if got := binary.BigEndian.Uint32(buf.Bytes()); got != 1 {
+		t.Errorf("real-file FATTR4_XATTR_SUPPORT encoded = %d, want 1 (true)", got)
 	}
 }

--- a/internal/adapter/nfs/v4/handlers/compound.go
+++ b/internal/adapter/nfs/v4/handlers/compound.go
@@ -125,7 +125,7 @@ func rejectV40OnlyOp(opCode uint32, reader io.Reader, clientAddr string) *types.
 //
 // The returned result always has OpCode set (defaulting to the dispatched
 // opCode when a handler left it zero).
-func (h *Handler) dispatchOne(compCtx *types.CompoundContext, v41ctx *types.V41RequestContext, opCode uint32, reader io.Reader, isV41 bool) *types.CompoundResult {
+func (h *Handler) dispatchOne(compCtx *types.CompoundContext, v41ctx *types.V41RequestContext, opCode uint32, reader io.Reader, isV41, isV42 bool) *types.CompoundResult {
 	// Adapter-level operation blocklist: blocked ops return NOTSUPP.
 	if h.IsOperationBlocked(opCode) {
 		logger.Debug("NFSv4 COMPOUND op blocked by adapter settings",
@@ -140,13 +140,25 @@ func (h *Handler) dispatchOne(compCtx *types.CompoundContext, v41ctx *types.V41R
 	case isV41 && v40OnlyOps[opCode]:
 		result = rejectV40OnlyOp(opCode, reader, compCtx.ClientAddr)
 
-	case isV41 && h.v41DispatchTable[opCode] != nil:
+	case !isV42 && xattrOps[opCode]:
+		// RFC 8276 xattr ops are valid only under v4.2; reject (NOTSUPP) in
+		// v4.0/v4.1. The opcode is a valid v4.2 op number, so no args are
+		// consumed here — the loop stops on the non-OK status, matching how
+		// rejectV40OnlyOp short-circuits the COMPOUND (RFC 7530 §16.2).
+		logger.Debug("NFSv4 COMPOUND xattr op requires minorversion 2",
+			"opcode", opCode, "op_name", types.OpName(opCode), "client", compCtx.ClientAddr)
+		result = notSuppHandler(opCode)
+
+	case isV42 && xattrOps[opCode]:
+		result = h.v41DispatchTable[opCode](compCtx, v41ctx, reader)
+
+	case isV41 && h.v41DispatchTable[opCode] != nil && !xattrOps[opCode]:
 		result = h.v41DispatchTable[opCode](compCtx, v41ctx, reader)
 
 	case h.opDispatchTable[opCode] != nil:
 		result = h.opDispatchTable[opCode](compCtx, reader)
 
-	case opCode >= 3 && opCode <= h.maxValidOpCode(isV41):
+	case opCode >= 3 && opCode <= h.maxValidOpCode(isV41, isV42):
 		// Valid operation number for this minor version but not implemented.
 		result = notSuppHandler(opCode)
 
@@ -168,17 +180,29 @@ func (h *Handler) dispatchOne(compCtx *types.CompoundContext, v41ctx *types.V41R
 // maxValidOpCode returns the highest opcode that is a valid operation number
 // for the active minor version (used to distinguish "valid but unimplemented"
 // from "illegal opcode").
-func (h *Handler) maxValidOpCode(isV41 bool) uint32 {
-	if isV41 {
+//
+// Under v4.2 the range extends through OP_REMOVEXATTR (75) so that the RFC 8276
+// xattr ops are recognised. v4.1 stops at OP_RECLAIM_COMPLETE (58) and v4.0 at
+// OP_RELEASE_LOCKOWNER (39), unchanged from before.
+func (h *Handler) maxValidOpCode(isV41, isV42 bool) uint32 {
+	switch {
+	case isV42:
+		return types.OP_REMOVEXATTR
+	case isV41:
 		return types.OP_RECLAIM_COMPLETE
+	default:
+		return types.OP_RELEASE_LOCKOWNER
 	}
-	return types.OP_RELEASE_LOCKOWNER
 }
 
 // compoundLoopParams configures runCompoundOps for a specific COMPOUND variant.
 type compoundLoopParams struct {
-	// isV41 selects v4.1 dispatch semantics in dispatchOne.
+	// isV41 selects v4.1 dispatch semantics in dispatchOne (SEQUENCE gating,
+	// v4.0-only op rejection). v4.2 is a superset and also sets isV41.
 	isV41 bool
+	// isV42 enables the RFC 8276 xattr ops (72-75) and extends the valid-opcode
+	// ceiling to OP_REMOVEXATTR. Always implies isV41.
+	isV42 bool
 	// v41ctx is the per-request v4.1 session context (nil for v4.0 and for the
 	// v4.1 exempt-op path).
 	v41ctx *types.V41RequestContext
@@ -234,7 +258,7 @@ func (h *Handler) runCompoundOps(compCtx *types.CompoundContext, numOps uint32, 
 			}
 		}
 
-		result := h.dispatchOne(compCtx, p.v41ctx, opCode, reader, p.isV41)
+		result := h.dispatchOne(compCtx, p.v41ctx, opCode, reader, p.isV41, p.isV42)
 		results = append(results, *result)
 		lastStatus = result.Status
 
@@ -260,10 +284,11 @@ func (h *Handler) runCompoundOps(compCtx *types.CompoundContext, numOps uint32, 
 // Execution stops on the first error, and the response includes results up to
 // and including the failed operation.
 //
-// Minorversion routing (per RFC 8881):
+// Minorversion routing (per RFC 8881 / RFC 7862 / RFC 8276):
 //   - 0: NFSv4.0 dispatch table (OpHandler signature)
 //   - 1: NFSv4.1 dispatch table (V41OpHandler), with fallback to v4.0 table
-//   - 2+: NFS4ERR_MINOR_VERS_MISMATCH
+//   - 2: NFSv4.1 dispatch table plus the RFC 8276 xattr ops (72-75)
+//   - 3+: NFS4ERR_MINOR_VERS_MISMATCH
 //
 // COMPOUND4args wire format:
 //
@@ -327,7 +352,13 @@ func (h *Handler) ProcessCompound(compCtx *types.CompoundContext, data []byte) (
 		return h.dispatchV40(compCtx, tag, numOps, reader)
 
 	case types.NFS4_MINOR_VERSION_1:
-		return h.dispatchV41(compCtx, tag, numOps, reader)
+		return h.dispatchV41(compCtx, tag, numOps, reader, false)
+
+	case types.NFS4_MINOR_VERSION_2:
+		// v4.2 reuses the entire v4.1 SEQUENCE/session machinery (RFC 7862
+		// builds on RFC 8881); the only delta is that the RFC 8276 xattr ops
+		// become valid, which the isV42 flag enables in dispatchOne.
+		return h.dispatchV41(compCtx, tag, numOps, reader, true)
 
 	default:
 		logger.Debug("NFSv4 minor version mismatch",
@@ -379,7 +410,7 @@ func (h *Handler) dispatchV40(compCtx *types.CompoundContext, tag []byte, numOps
 //
 // On SEQUENCE replay (duplicate slot+seqid), returns the cached COMPOUND
 // response bytes directly without re-executing any operations.
-func (h *Handler) dispatchV41(compCtx *types.CompoundContext, tag []byte, numOps uint32, reader io.Reader) ([]byte, error) {
+func (h *Handler) dispatchV41(compCtx *types.CompoundContext, tag []byte, numOps uint32, reader io.Reader, isV42 bool) ([]byte, error) {
 	// Validate operation count limit
 	if numOps > types.MaxCompoundOps {
 		logger.Debug("NFSv4.1 COMPOUND op count exceeds limit",
@@ -406,7 +437,7 @@ func (h *Handler) dispatchV41(compCtx *types.CompoundContext, tag []byte, numOps
 			"op_name", types.OpName(firstOpCode),
 			"num_ops", numOps,
 			"client", compCtx.ClientAddr)
-		return h.dispatchV41Ops(compCtx, tag, firstOpCode, numOps, nil, reader)
+		return h.dispatchV41Ops(compCtx, tag, firstOpCode, numOps, nil, reader, isV42)
 	}
 
 	// Non-exempt: first op MUST be SEQUENCE
@@ -479,6 +510,7 @@ func (h *Handler) dispatchV41(compCtx *types.CompoundContext, tag []byte, numOps
 	// response, preserving replay semantics for the ops that did complete.
 	opResults, lastStatus, _ := h.runCompoundOps(compCtx, numOps, reader, compoundLoopParams{
 		isV41:                true,
+		isV42:                isV42,
 		v41ctx:               v41ctx,
 		startIndex:           1,
 		hardErrOnDecodeError: false,
@@ -504,9 +536,10 @@ func (h *Handler) dispatchV41(compCtx *types.CompoundContext, tag []byte, numOps
 // read from the reader). Used for the exempt-op path, where the first op is not
 // SEQUENCE (e.g. EXCHANGE_ID) and so v41ctx is nil. Decode errors encode a
 // partial reply rather than dropping it (matching the SEQUENCE-bearing path).
-func (h *Handler) dispatchV41Ops(compCtx *types.CompoundContext, tag []byte, firstOpCode uint32, numOps uint32, v41ctx *types.V41RequestContext, reader io.Reader) ([]byte, error) {
+func (h *Handler) dispatchV41Ops(compCtx *types.CompoundContext, tag []byte, firstOpCode uint32, numOps uint32, v41ctx *types.V41RequestContext, reader io.Reader, isV42 bool) ([]byte, error) {
 	results, lastStatus, _ := h.runCompoundOps(compCtx, numOps, reader, compoundLoopParams{
 		isV41:                true,
+		isV42:                isV42,
 		v41ctx:               v41ctx,
 		firstOpCode:          firstOpCode,
 		hasFirstOpCode:       true,

--- a/internal/adapter/nfs/v4/handlers/compound.go
+++ b/internal/adapter/nfs/v4/handlers/compound.go
@@ -135,28 +135,34 @@ func (h *Handler) dispatchOne(compCtx *types.CompoundContext, v41ctx *types.V41R
 		return result
 	}
 
+	// Dispatch precedence is by minor version, highest first: a v4.2 op (the
+	// RFC 8276 xattr ops) is recognised only under minorversion 2; otherwise
+	// fall through to the v4.1 then v4.0 tables (the later minor versions are
+	// supersets). Each table's membership defines its version's op set, so no
+	// per-op allowlists are needed here.
 	var result *types.CompoundResult
 	switch {
 	case isV41 && v40OnlyOps[opCode]:
 		result = rejectV40OnlyOp(opCode, reader, compCtx.ClientAddr)
 
-	case !isV42 && xattrOps[opCode]:
-		// RFC 8276 xattr ops are valid only under v4.2; reject (NOTSUPP) in
-		// v4.0/v4.1. The opcode is a valid v4.2 op number, so no args are
-		// consumed here — the loop stops on the non-OK status, matching how
-		// rejectV40OnlyOp short-circuits the COMPOUND (RFC 7530 §16.2).
+	case isV42 && h.v42DispatchTable[opCode] != nil:
+		result = h.v42DispatchTable[opCode](compCtx, reader)
+
+	case h.v42DispatchTable[opCode] != nil:
+		// v4.2-only op (RFC 8276 xattr) seen under v4.0/v4.1: it is a valid op
+		// number but unsupported → NOTSUPP, which stops the COMPOUND (RFC 7530
+		// §16.2). Unlike rejectV40OnlyOp, the op's args are NOT consumed from
+		// the reader; that is safe because NOTSUPP stops the COMPOUND, so no
+		// later op parses the reader.
 		logger.Debug("NFSv4 COMPOUND xattr op requires minorversion 2",
 			"opcode", opCode, "op_name", types.OpName(opCode), "client", compCtx.ClientAddr)
 		result = notSuppHandler(opCode)
 
-	case isV42 && xattrOps[opCode]:
+	case isV41 && h.v41DispatchTable[opCode] != nil:
 		result = h.v41DispatchTable[opCode](compCtx, v41ctx, reader)
 
-	case isV41 && h.v41DispatchTable[opCode] != nil && !xattrOps[opCode]:
-		result = h.v41DispatchTable[opCode](compCtx, v41ctx, reader)
-
-	case h.opDispatchTable[opCode] != nil:
-		result = h.opDispatchTable[opCode](compCtx, reader)
+	case h.v40DispatchTable[opCode] != nil:
+		result = h.v40DispatchTable[opCode](compCtx, reader)
 
 	case opCode >= 3 && opCode <= h.maxValidOpCode(isV41, isV42):
 		// Valid operation number for this minor version but not implemented.
@@ -285,7 +291,7 @@ func (h *Handler) runCompoundOps(compCtx *types.CompoundContext, numOps uint32, 
 // and including the failed operation.
 //
 // Minorversion routing (per RFC 8881 / RFC 7862 / RFC 8276):
-//   - 0: NFSv4.0 dispatch table (OpHandler signature)
+//   - 0: NFSv4.0 dispatch table (V40OpHandler signature)
 //   - 1: NFSv4.1 dispatch table (V41OpHandler), with fallback to v4.0 table
 //   - 2: NFSv4.1 dispatch table plus the RFC 8276 xattr ops (72-75)
 //   - 3+: NFS4ERR_MINOR_VERS_MISMATCH
@@ -369,7 +375,7 @@ func (h *Handler) ProcessCompound(compCtx *types.CompoundContext, data []byte) (
 }
 
 // dispatchV40 executes the v4.0 COMPOUND dispatch loop.
-// Operations are dispatched through opDispatchTable.
+// Operations are dispatched through v40DispatchTable.
 func (h *Handler) dispatchV40(compCtx *types.CompoundContext, tag []byte, numOps uint32, reader io.Reader) ([]byte, error) {
 	// Validate operation count limit
 	if numOps > types.MaxCompoundOps {

--- a/internal/adapter/nfs/v4/handlers/compound_test.go
+++ b/internal/adapter/nfs/v4/handlers/compound_test.go
@@ -386,12 +386,14 @@ func TestNullHandler(t *testing.T) {
 	}
 }
 
-func TestCompoundMinorVersion2(t *testing.T) {
+// TestCompoundMinorVersion3 verifies that minorversion 3 (unsupported) is
+// rejected with NFS4ERR_MINOR_VERS_MISMATCH. v4.2 is now supported (RFC 8276
+// xattr ops), so the unsupported-version boundary moved from 2 to 3.
+func TestCompoundMinorVersion3(t *testing.T) {
 	h := newTestHandler()
 	ctx := newTestCompoundContext()
 
-	// Minor version 2 should also fail (only 0 supported)
-	data := buildCompoundArgs([]byte("v4.2"), 2, []uint32{types.OP_GETATTR})
+	data := buildCompoundArgs([]byte("v4.3"), 3, []uint32{types.OP_GETATTR})
 	resp, err := h.ProcessCompound(ctx, data)
 	if err != nil {
 		t.Fatalf("ProcessCompound error: %v", err)
@@ -543,11 +545,14 @@ func TestCompound_MinorVersion1_V41Op_NOTSUPP(t *testing.T) {
 	}
 }
 
-func TestCompound_MinorVersion2_Rejected(t *testing.T) {
+// TestCompound_MinorVersion2_RequiresSequence verifies that v4.2 is accepted and
+// routed through the v4.1 session machinery: a non-exempt first op (GETATTR)
+// without a leading SEQUENCE returns NFS4ERR_OP_NOT_IN_SESSION (not a
+// minor-version mismatch), exactly like v4.1.
+func TestCompound_MinorVersion2_RequiresSequence(t *testing.T) {
 	h := newTestHandler()
 	ctx := newTestCompoundContext()
 
-	// minorversion=2 should return NFS4ERR_MINOR_VERS_MISMATCH
 	data := buildCompoundArgs([]byte("v4.2"), 2, []uint32{types.OP_GETATTR})
 	resp, err := h.ProcessCompound(ctx, data)
 	if err != nil {
@@ -559,12 +564,9 @@ func TestCompound_MinorVersion2_Rejected(t *testing.T) {
 		t.Fatalf("decode response error: %v", err)
 	}
 
-	if decoded.Status != types.NFS4ERR_MINOR_VERS_MISMATCH {
-		t.Errorf("status = %d, want NFS4ERR_MINOR_VERS_MISMATCH (%d)",
-			decoded.Status, types.NFS4ERR_MINOR_VERS_MISMATCH)
-	}
-	if decoded.NumResults != 0 {
-		t.Errorf("numResults = %d, want 0", decoded.NumResults)
+	if decoded.Status != types.NFS4ERR_OP_NOT_IN_SESSION {
+		t.Errorf("status = %d, want NFS4ERR_OP_NOT_IN_SESSION (%d)",
+			decoded.Status, types.NFS4ERR_OP_NOT_IN_SESSION)
 	}
 	if string(decoded.Tag) != "v4.2" {
 		t.Errorf("tag = %q, want %q", string(decoded.Tag), "v4.2")
@@ -677,8 +679,9 @@ func TestCompound_V41_AllStubOps(t *testing.T) {
 }
 
 func TestCompound_V41_DispatchTableComplete(t *testing.T) {
-	// Verify all 19 v4.1 operation numbers (40-58) are registered in the
-	// v41DispatchTable. This ensures no operation was missed during setup.
+	// Verify all 19 v4.1 operation numbers (40-58) plus the 4 RFC 8276 xattr
+	// ops (72-75, which share the v41DispatchTable) are registered. This ensures
+	// no operation was missed during setup.
 	h := newTestHandler()
 
 	expectedOps := []uint32{
@@ -701,10 +704,15 @@ func TestCompound_V41_DispatchTableComplete(t *testing.T) {
 		types.OP_WANT_DELEGATION,
 		types.OP_DESTROY_CLIENTID,
 		types.OP_RECLAIM_COMPLETE,
+		// RFC 8276 xattr ops (v4.2) ride the v41DispatchTable.
+		types.OP_GETXATTR,
+		types.OP_SETXATTR,
+		types.OP_LISTXATTRS,
+		types.OP_REMOVEXATTR,
 	}
 
-	if len(h.v41DispatchTable) != 19 {
-		t.Errorf("v41DispatchTable has %d entries, want 19", len(h.v41DispatchTable))
+	if len(h.v41DispatchTable) != 23 {
+		t.Errorf("v41DispatchTable has %d entries, want 23", len(h.v41DispatchTable))
 	}
 
 	for _, opCode := range expectedOps {
@@ -1404,11 +1412,11 @@ func TestCompound_VersionRangeGating(t *testing.T) {
 	})
 
 	t.Run("OutOfRange_Both", func(t *testing.T) {
-		// minorversion=2 should always be rejected regardless of range
+		// minorversion=3 is above the default max (2) and must be rejected.
 		h := newTestHandler()
 		ctx := newTestCompoundContext()
 
-		data := buildCompoundArgs([]byte("v42"), 2, []uint32{types.OP_GETATTR})
+		data := buildCompoundArgs([]byte("v43"), 3, []uint32{types.OP_GETATTR})
 		resp, err := h.ProcessCompound(ctx, data)
 		if err != nil {
 			t.Fatalf("ProcessCompound error: %v", err)
@@ -1419,11 +1427,11 @@ func TestCompound_VersionRangeGating(t *testing.T) {
 			t.Fatalf("decode response error: %v", err)
 		}
 		if decoded.Status != types.NFS4ERR_MINOR_VERS_MISMATCH {
-			t.Errorf("v4.2 status = %d, want NFS4ERR_MINOR_VERS_MISMATCH", decoded.Status)
+			t.Errorf("v4.3 status = %d, want NFS4ERR_MINOR_VERS_MISMATCH", decoded.Status)
 		}
 		// Tag should still be echoed
-		if string(decoded.Tag) != "v42" {
-			t.Errorf("tag = %q, want %q", string(decoded.Tag), "v42")
+		if string(decoded.Tag) != "v43" {
+			t.Errorf("tag = %q, want %q", string(decoded.Tag), "v43")
 		}
 	})
 }
@@ -2537,12 +2545,12 @@ func TestCompound_DispatchOne_MinorVersionRouting(t *testing.T) {
 
 		// Under v4.0 the op dispatches to the registered handler.
 		args := encodeSetClientIDArgsForReject()
-		if res := h.dispatchOne(ctx, nil, types.OP_SETCLIENTID, bytes.NewReader(args), false); res.Status != types.NFS4_OK {
+		if res := h.dispatchOne(ctx, nil, types.OP_SETCLIENTID, bytes.NewReader(args), false, false); res.Status != types.NFS4_OK {
 			t.Errorf("v4.0 SETCLIENTID status = %d, want NFS4_OK", res.Status)
 		}
 
 		// Under v4.1 the same op is rejected with NOTSUPP (args consumed).
-		if res := h.dispatchOne(ctx, nil, types.OP_SETCLIENTID, bytes.NewReader(args), true); res.Status != types.NFS4ERR_NOTSUPP {
+		if res := h.dispatchOne(ctx, nil, types.OP_SETCLIENTID, bytes.NewReader(args), true, false); res.Status != types.NFS4ERR_NOTSUPP {
 			t.Errorf("v4.1 SETCLIENTID status = %d, want NFS4ERR_NOTSUPP (%d)", res.Status, types.NFS4ERR_NOTSUPP)
 		}
 	})
@@ -2561,13 +2569,13 @@ func TestCompound_DispatchOne_MinorVersionRouting(t *testing.T) {
 
 		// Under v4.0 the v4.1 table is not consulted → handler not reached.
 		reached = false
-		if res := h.dispatchOne(ctx, nil, probeOp, bytes.NewReader(nil), false); reached {
+		if res := h.dispatchOne(ctx, nil, probeOp, bytes.NewReader(nil), false, false); reached {
 			t.Errorf("v4.0 must not reach v4.1 handler (status=%d)", res.Status)
 		}
 
 		// Under v4.1 the handler is reached.
 		reached = false
-		if res := h.dispatchOne(ctx, nil, probeOp, bytes.NewReader(nil), true); !reached || res.Status != types.NFS4_OK {
+		if res := h.dispatchOne(ctx, nil, probeOp, bytes.NewReader(nil), true, false); !reached || res.Status != types.NFS4_OK {
 			t.Errorf("v4.1 must reach v4.1 handler: reached=%v status=%d", reached, res.Status)
 		}
 	})

--- a/internal/adapter/nfs/v4/handlers/compound_test.go
+++ b/internal/adapter/nfs/v4/handlers/compound_test.go
@@ -266,7 +266,7 @@ func TestCompoundMultipleOpsStopOnError(t *testing.T) {
 
 	// Register a test handler that succeeds for a specific op
 	testOp := uint32(types.OP_PUTROOTFH) // Use a known op number
-	h.opDispatchTable[testOp] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+	h.v40DispatchTable[testOp] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 		return &types.CompoundResult{
 			Status: types.NFS4_OK,
 			OpCode: testOp,
@@ -415,7 +415,7 @@ func TestCompoundExactlyMaxOps(t *testing.T) {
 
 	// Register a succeeding handler for testing
 	testOp := uint32(types.OP_PUTROOTFH)
-	h.opDispatchTable[testOp] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+	h.v40DispatchTable[testOp] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 		return &types.CompoundResult{
 			Status: types.NFS4_OK,
 			OpCode: testOp,
@@ -679,9 +679,9 @@ func TestCompound_V41_AllStubOps(t *testing.T) {
 }
 
 func TestCompound_V41_DispatchTableComplete(t *testing.T) {
-	// Verify all 19 v4.1 operation numbers (40-58) plus the 4 RFC 8276 xattr
-	// ops (72-75, which share the v41DispatchTable) are registered. This ensures
-	// no operation was missed during setup.
+	// Verify all 19 v4.1 operation numbers (40-58) are registered in the v4.1
+	// table, and that the 4 RFC 8276 xattr ops (72-75) are registered separately
+	// in the v4.2 table (asserted below). This ensures no op was missed in setup.
 	h := newTestHandler()
 
 	expectedOps := []uint32{
@@ -704,20 +704,32 @@ func TestCompound_V41_DispatchTableComplete(t *testing.T) {
 		types.OP_WANT_DELEGATION,
 		types.OP_DESTROY_CLIENTID,
 		types.OP_RECLAIM_COMPLETE,
-		// RFC 8276 xattr ops (v4.2) ride the v41DispatchTable.
-		types.OP_GETXATTR,
-		types.OP_SETXATTR,
-		types.OP_LISTXATTRS,
-		types.OP_REMOVEXATTR,
 	}
 
-	if len(h.v41DispatchTable) != 23 {
-		t.Errorf("v41DispatchTable has %d entries, want 23", len(h.v41DispatchTable))
+	if len(h.v41DispatchTable) != 19 {
+		t.Errorf("v41DispatchTable has %d entries, want 19", len(h.v41DispatchTable))
 	}
 
 	for _, opCode := range expectedOps {
 		if _, ok := h.v41DispatchTable[opCode]; !ok {
 			t.Errorf("v41DispatchTable missing entry for %s (%d)",
+				types.OpName(opCode), opCode)
+		}
+	}
+
+	// The RFC 8276 xattr ops (v4.2) live in their OWN table, separate from v4.1.
+	expectedV42Ops := []uint32{
+		types.OP_GETXATTR,
+		types.OP_SETXATTR,
+		types.OP_LISTXATTRS,
+		types.OP_REMOVEXATTR,
+	}
+	if len(h.v42DispatchTable) != 4 {
+		t.Errorf("v42DispatchTable has %d entries, want 4", len(h.v42DispatchTable))
+	}
+	for _, opCode := range expectedV42Ops {
+		if _, ok := h.v42DispatchTable[opCode]; !ok {
+			t.Errorf("v42DispatchTable missing entry for %s (%d)",
 				types.OpName(opCode), opCode)
 		}
 	}
@@ -791,14 +803,14 @@ func TestCompound_V40_Regression(t *testing.T) {
 		h := newTestHandler()
 
 		// Register succeeding handlers
-		h.opDispatchTable[types.OP_PUTROOTFH] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+		h.v40DispatchTable[types.OP_PUTROOTFH] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 			return &types.CompoundResult{
 				Status: types.NFS4_OK,
 				OpCode: types.OP_PUTROOTFH,
 				Data:   encodeStatusOnly(types.NFS4_OK),
 			}
 		}
-		h.opDispatchTable[types.OP_GETATTR] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+		h.v40DispatchTable[types.OP_GETATTR] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 			// Consume args (bitmap)
 			_, _ = xdr.DecodeUint32(reader) // bitmap length
 			return &types.CompoundResult{
@@ -839,7 +851,7 @@ func TestCompound_V40_Regression(t *testing.T) {
 		h := newTestHandler()
 
 		var sawSkipOwnerSeqid bool
-		h.opDispatchTable[types.OP_PUTROOTFH] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+		h.v40DispatchTable[types.OP_PUTROOTFH] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 			sawSkipOwnerSeqid = ctx.SkipOwnerSeqid
 			return &types.CompoundResult{
 				Status: types.NFS4_OK,
@@ -958,7 +970,7 @@ func TestCompound_V40_Regression(t *testing.T) {
 		// v4.0 multi-op still stops on error
 		h := newTestHandler()
 
-		h.opDispatchTable[types.OP_PUTROOTFH] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+		h.v40DispatchTable[types.OP_PUTROOTFH] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 			return &types.CompoundResult{
 				Status: types.NFS4_OK,
 				OpCode: types.OP_PUTROOTFH,
@@ -1115,7 +1127,7 @@ func TestCompound_V40_V41_Coexistence(t *testing.T) {
 		h, sessionID := createTestSession(t)
 
 		var sawSkipOwnerSeqid bool
-		h.opDispatchTable[types.OP_PUTROOTFH] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+		h.v40DispatchTable[types.OP_PUTROOTFH] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 			sawSkipOwnerSeqid = ctx.SkipOwnerSeqid
 			return &types.CompoundResult{
 				Status: types.NFS4_OK,
@@ -2481,7 +2493,7 @@ func TestCompound_V40_CancelledContext_EncodesPartialReply(t *testing.T) {
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	// op0 succeeds and cancels the context; the cancel is then observed at the
 	// op1 boundary (before GETATTR dispatches), so op0's result is preserved.
-	h.opDispatchTable[types.OP_PUTROOTFH] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+	h.v40DispatchTable[types.OP_PUTROOTFH] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 		cancel()
 		return &types.CompoundResult{Status: types.NFS4_OK, OpCode: types.OP_PUTROOTFH, Data: encodeStatusOnly(types.NFS4_OK)}
 	}
@@ -2538,7 +2550,7 @@ func TestCompound_DispatchOne_MinorVersionRouting(t *testing.T) {
 	t.Run("v4.0-only op rejected under v4.1", func(t *testing.T) {
 		h := newTestHandler()
 		// Register a v4.0 SETCLIENTID handler that, if reached, would succeed.
-		h.opDispatchTable[types.OP_SETCLIENTID] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+		h.v40DispatchTable[types.OP_SETCLIENTID] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 			return &types.CompoundResult{Status: types.NFS4_OK, OpCode: types.OP_SETCLIENTID, Data: encodeStatusOnly(types.NFS4_OK)}
 		}
 		ctx := newTestCompoundContext()
@@ -2564,7 +2576,7 @@ func TestCompound_DispatchOne_MinorVersionRouting(t *testing.T) {
 			return &types.CompoundResult{Status: types.NFS4_OK, OpCode: probeOp, Data: encodeStatusOnly(types.NFS4_OK)}
 		}
 		// Ensure no v4.0 table entry shadows it.
-		delete(h.opDispatchTable, probeOp)
+		delete(h.v40DispatchTable, probeOp)
 		ctx := newTestCompoundContext()
 
 		// Under v4.0 the v4.1 table is not consulted → handler not reached.

--- a/internal/adapter/nfs/v4/handlers/delegreturn_test.go
+++ b/internal/adapter/nfs/v4/handlers/delegreturn_test.go
@@ -167,7 +167,7 @@ func TestHandleDelegReturn_Registered(t *testing.T) {
 	h := NewHandler(nil, pfs)
 
 	// Verify DELEGRETURN is registered in the dispatch table
-	if _, exists := h.opDispatchTable[types.OP_DELEGRETURN]; !exists {
+	if _, exists := h.v40DispatchTable[types.OP_DELEGRETURN]; !exists {
 		t.Error("OP_DELEGRETURN should be registered in dispatch table")
 	}
 }

--- a/internal/adapter/nfs/v4/handlers/getxattr.go
+++ b/internal/adapter/nfs/v4/handlers/getxattr.go
@@ -1,0 +1,90 @@
+package handlers
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// GETXATTR4args / GETXATTR4res (RFC 8276 Section 8.6):
+//
+//	struct GETXATTR4args {
+//	    xattrkey4   gxa_name;   // component4 (utf8str_cs)
+//	};
+//	struct GETXATTR4resok {
+//	    xattrvalue4 gxr_value;  // opaque<>
+//	};
+//	union GETXATTR4res switch (nfsstat4 status) {
+//	 case NFS4_OK:  GETXATTR4resok;
+//	 default:       void;
+//	};
+//
+// A missing xattr returns NFS4ERR_NOXATTR. Pseudo-fs handles return
+// NFS4ERR_NOTSUPP (the virtual namespace carries no named attributes).
+func (h *Handler) handleGetXattr(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+	if status := types.RequireCurrentFH(ctx); status != types.NFS4_OK {
+		return xattrErr(types.OP_GETXATTR, status)
+	}
+
+	name, err := xdr.DecodeString(reader)
+	if err != nil {
+		return xattrErr(types.OP_GETXATTR, types.NFS4ERR_BADXDR)
+	}
+
+	if pseudofs.IsPseudoFSHandle(ctx.CurrentFH) {
+		return xattrErr(types.OP_GETXATTR, types.NFS4ERR_NOTSUPP)
+	}
+
+	canonical, ok := canonicalizeXattrName(name)
+	if !ok {
+		// Unsupported namespace: no such attribute (RFC 8276 §8.1).
+		return xattrErr(types.OP_GETXATTR, types.NFS4ERR_NOXATTR)
+	}
+
+	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
+	if err != nil {
+		return xattrErr(types.OP_GETXATTR, types.NFS4ERR_SERVERFAULT)
+	}
+
+	backend, err := xattrBackendForHandler(h)
+	if err != nil {
+		return xattrErr(types.OP_GETXATTR, types.NFS4ERR_SERVERFAULT)
+	}
+
+	handle := metadata.FileHandle(ctx.CurrentFH)
+	value, found, err := backend.GetXattr(authCtx, handle, canonical)
+	if err != nil {
+		status := common.MapToNFS4(err)
+		return xattrErr(types.OP_GETXATTR, status)
+	}
+	if !found {
+		return xattrErr(types.OP_GETXATTR, types.NFS4ERR_NOXATTR)
+	}
+
+	logger.Debug("NFSv4.2 GETXATTR", "name", canonical, "len", len(value), "client", ctx.ClientAddr)
+
+	var buf bytes.Buffer
+	_ = xdr.WriteUint32(&buf, types.NFS4_OK)
+	_ = xdr.WriteXDROpaque(&buf, value)
+
+	return &types.CompoundResult{
+		Status: types.NFS4_OK,
+		OpCode: types.OP_GETXATTR,
+		Data:   buf.Bytes(),
+	}
+}
+
+// xattrErr builds a status-only CompoundResult for an xattr op error.
+func xattrErr(opCode, status uint32) *types.CompoundResult {
+	return &types.CompoundResult{
+		Status: status,
+		OpCode: opCode,
+		Data:   encodeStatusOnly(status),
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/handler.go
+++ b/internal/adapter/nfs/v4/handlers/handler.go
@@ -11,24 +11,31 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	v41handlers "github.com/marmos91/dittofs/internal/adapter/nfs/v4/v41/handlers"
-	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/adapter/nfs/identity"
 )
 
-// OpHandler is the type signature for individual NFSv4 operation handlers.
+// V40OpHandler is the type signature for individual NFSv4 operation handlers.
 // Each handler receives the mutable compound context and an io.Reader
 // positioned at the operation's arguments. It returns a CompoundResult
 // with the operation's status and XDR-encoded response data.
-type OpHandler func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult
+type V40OpHandler func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult
 
 // V41OpHandler is the type signature for NFSv4.1 operation handlers.
-// Unlike v4.0 OpHandler, it receives a V41RequestContext with session/slot info
+// Unlike v4.0 V40OpHandler, it receives a V41RequestContext with session/slot info
 // populated by SEQUENCE processing. For stub handlers, the context is nil.
 type V41OpHandler func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult
 
+// V42OpHandler is the type signature for NFSv4.2 operation handlers (RFC 8276
+// extended-attribute ops). v4.2 ops run inside the v4.1 session machinery
+// (SEQUENCE is processed by the COMPOUND loop before dispatch), but the xattr
+// ops themselves are session-state-agnostic, so — like V40OpHandler — the
+// signature omits the V41RequestContext. The distinct named type keeps the
+// v4.2 op set visibly separate from v4.0/v4.1.
+type V42OpHandler func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult
+
 // Handler is the concrete implementation for NFSv4 protocol handlers.
 // It processes COMPOUND RPCs by dispatching operations through
-// the opDispatchTable (v4.0) and v41DispatchTable (v4.1).
+// the v40DispatchTable (v4.0) and v41DispatchTable (v4.1).
 type Handler struct {
 	// Registry provides access to all stores and shares.
 	Registry nfsRuntime
@@ -58,13 +65,20 @@ type Handler struct {
 	// If an operation is in this set, COMPOUND returns NFS4ERR_NOTSUPP for it.
 	blockedOps map[uint32]bool
 
-	// opDispatchTable maps v4.0 operation numbers to handler functions.
-	opDispatchTable map[uint32]OpHandler
+	// v40DispatchTable maps v4.0 operation numbers to handler functions.
+	v40DispatchTable map[uint32]V40OpHandler
 
 	// v41DispatchTable maps v4.1 operation numbers (40-58) to handler functions.
 	// v4.0 operations (3-39) are accessible from v4.1 compounds via fallback
-	// to opDispatchTable.
+	// to v40DispatchTable.
 	v41DispatchTable map[uint32]V41OpHandler
+
+	// v42DispatchTable maps v4.2 operation numbers (RFC 8276 xattr ops 72-75) to
+	// handler functions, kept SEPARATE from v41DispatchTable so the minor-version
+	// boundary is explicit: an op in this table is v4.2-only and is gated to
+	// minorversion 2 in dispatchOne. v4.0/v4.1 ops remain reachable from a v4.2
+	// COMPOUND via the v41/v40 tables (v4.2 is a superset).
+	v42DispatchTable map[uint32]V42OpHandler
 
 	// v41Deps holds shared dependencies for v4.1 operation handlers.
 	v41Deps *v41handlers.Deps
@@ -103,8 +117,9 @@ func NewHandler(registry nfsRuntime, pfs *pseudofs.PseudoFS, stateManager ...*st
 		Registry:         registry,
 		PseudoFS:         pfs,
 		StateManager:     sm,
-		opDispatchTable:  make(map[uint32]OpHandler),
+		v40DispatchTable: make(map[uint32]V40OpHandler),
 		v41DispatchTable: make(map[uint32]V41OpHandler),
+		v42DispatchTable: make(map[uint32]V42OpHandler),
 		maxMinorVersion:  2, // default: accept v4.0, v4.1, and v4.2 (RFC 8276 xattr ops)
 	}
 
@@ -114,201 +129,15 @@ func NewHandler(registry nfsRuntime, pfs *pseudofs.PseudoFS, stateManager ...*st
 	}
 	h.v41Deps = v41d
 
-	// Register all implemented operation handlers.
-	// Filehandle management
-	h.opDispatchTable[types.OP_PUTFH] = h.handlePutFH
-	h.opDispatchTable[types.OP_PUTROOTFH] = h.handlePutRootFH
-	h.opDispatchTable[types.OP_PUTPUBFH] = h.handlePutPubFH
-	h.opDispatchTable[types.OP_GETFH] = h.handleGetFH
-	h.opDispatchTable[types.OP_SAVEFH] = h.handleSaveFH
-	h.opDispatchTable[types.OP_RESTOREFH] = h.handleRestoreFH
-
-	// Pseudo-fs traversal and attributes
-	h.opDispatchTable[types.OP_LOOKUP] = h.handleLookup
-	h.opDispatchTable[types.OP_LOOKUPP] = h.handleLookupP
-	h.opDispatchTable[types.OP_GETATTR] = h.handleGetAttr
-	h.opDispatchTable[types.OP_READDIR] = h.handleReadDir
-	h.opDispatchTable[types.OP_ACCESS] = h.handleAccess
-
-	// Symlink operations
-	h.opDispatchTable[types.OP_READLINK] = h.handleReadLink
-
-	// Create/Remove operations
-	h.opDispatchTable[types.OP_CREATE] = h.handleCreate
-	h.opDispatchTable[types.OP_REMOVE] = h.handleRemove
-
-	// Link and rename operations
-	h.opDispatchTable[types.OP_LINK] = h.handleLink
-	h.opDispatchTable[types.OP_RENAME] = h.handleRename
-
-	// Attribute operations
-	h.opDispatchTable[types.OP_SETATTR] = h.handleSetAttr
-
-	// Protocol operations
-	h.opDispatchTable[types.OP_ILLEGAL] = h.handleIllegal
-
-	// Stateful I/O operations
-	h.opDispatchTable[types.OP_OPEN] = h.handleOpen
-	h.opDispatchTable[types.OP_OPEN_CONFIRM] = h.handleOpenConfirm
-	h.opDispatchTable[types.OP_CLOSE] = h.handleClose
-
-	// Data I/O operations
-	h.opDispatchTable[types.OP_READ] = h.handleRead
-	h.opDispatchTable[types.OP_WRITE] = h.handleWrite
-	h.opDispatchTable[types.OP_COMMIT] = h.handleCommit
-
-	// Conditional verification
-	h.opDispatchTable[types.OP_VERIFY] = h.handleVerify
-	h.opDispatchTable[types.OP_NVERIFY] = h.handleNVerify
-
-	// Security negotiation
-	h.opDispatchTable[types.OP_SECINFO] = h.handleSecInfo
-
-	// Client setup operations
-	h.opDispatchTable[types.OP_SETCLIENTID] = h.handleSetClientID
-	h.opDispatchTable[types.OP_SETCLIENTID_CONFIRM] = h.handleSetClientIDConfirm
-	h.opDispatchTable[types.OP_RENEW] = h.handleRenew
-
-	// Lock operations (, 10-02)
-	h.opDispatchTable[types.OP_LOCK] = h.handleLock
-	h.opDispatchTable[types.OP_LOCKT] = h.handleLockT
-	h.opDispatchTable[types.OP_LOCKU] = h.handleLockU
-
-	// Delegation operations (, 11-03)
-	h.opDispatchTable[types.OP_DELEGRETURN] = h.handleDelegReturn
-	h.opDispatchTable[types.OP_DELEGPURGE] = h.handleDelegPurge
-
-	// Stub operations (deferred to later phases)
-	h.opDispatchTable[types.OP_OPENATTR] = h.handleOpenAttr
-	h.opDispatchTable[types.OP_OPEN_DOWNGRADE] = h.handleOpenDowngrade
-	h.opDispatchTable[types.OP_RELEASE_LOCKOWNER] = h.handleReleaseLockOwner
-
-	// Grace period lifecycle :
-	// On server startup (if previous clients exist):
-	//   handler.StateManager.StartGracePeriod(previousClientIDs)
-	// On graceful shutdown:
-	//   snapshots := handler.StateManager.SaveClientState()
-	//   // serialize snapshots to disk
-	//   handler.StateManager.Shutdown()
-
-	// NFSv4.1 dispatch table (stub handlers for all 19 v4.1 operations)
-	//
-	// Each stub decodes its operation's XDR args (to prevent stream desync)
-	// and returns NFS4ERR_NOTSUPP.
-
-	// BACKCHANNEL_CTL: update callback program and security params (RFC 8881 Section 18.33)
-	h.v41DispatchTable[types.OP_BACKCHANNEL_CTL] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
-		return v41handlers.HandleBackchannelCtl(h.v41Deps, ctx, v41ctx, reader)
-	}
-	// BIND_CONN_TO_SESSION: connection binding (RFC 8881 Section 18.34)
-	h.v41DispatchTable[types.OP_BIND_CONN_TO_SESSION] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
-		return v41handlers.HandleBindConnToSession(h.v41Deps, ctx, v41ctx, reader)
-	}
-	// EXCHANGE_ID: client identity registration (RFC 8881 Section 18.35)
-	h.v41DispatchTable[types.OP_EXCHANGE_ID] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
-		return v41handlers.HandleExchangeID(h.v41Deps, ctx, v41ctx, reader)
-	}
-	// CREATE_SESSION: session lifecycle (RFC 8881 Section 18.36)
-	h.v41DispatchTable[types.OP_CREATE_SESSION] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
-		return v41handlers.HandleCreateSession(h.v41Deps, ctx, v41ctx, reader)
-	}
-	// DESTROY_SESSION: session teardown (RFC 8881 Section 18.37)
-	h.v41DispatchTable[types.OP_DESTROY_SESSION] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
-		return v41handlers.HandleDestroySession(h.v41Deps, ctx, v41ctx, reader)
-	}
-	h.v41DispatchTable[types.OP_FREE_STATEID] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
-		return v41handlers.HandleFreeStateid(h.v41Deps, ctx, v41ctx, reader)
-	}
-	h.v41DispatchTable[types.OP_GET_DIR_DELEGATION] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
-		return v41handlers.HandleGetDirDelegation(h.v41Deps, ctx, v41ctx, reader)
-	}
-	h.v41DispatchTable[types.OP_GETDEVICEINFO] = v41StubHandler(types.OP_GETDEVICEINFO, func(r io.Reader) error {
-		var args types.GetDeviceInfoArgs
-		return args.Decode(r)
-	})
-	h.v41DispatchTable[types.OP_GETDEVICELIST] = v41StubHandler(types.OP_GETDEVICELIST, func(r io.Reader) error {
-		var args types.GetDeviceListArgs
-		return args.Decode(r)
-	})
-	h.v41DispatchTable[types.OP_LAYOUTCOMMIT] = v41StubHandler(types.OP_LAYOUTCOMMIT, func(r io.Reader) error {
-		var args types.LayoutCommitArgs
-		return args.Decode(r)
-	})
-	h.v41DispatchTable[types.OP_LAYOUTGET] = v41StubHandler(types.OP_LAYOUTGET, func(r io.Reader) error {
-		var args types.LayoutGetArgs
-		return args.Decode(r)
-	})
-	h.v41DispatchTable[types.OP_LAYOUTRETURN] = v41StubHandler(types.OP_LAYOUTRETURN, func(r io.Reader) error {
-		var args types.LayoutReturnArgs
-		return args.Decode(r)
-	})
-	h.v41DispatchTable[types.OP_SECINFO_NO_NAME] = v41StubHandler(types.OP_SECINFO_NO_NAME, func(r io.Reader) error {
-		var args types.SecinfoNoNameArgs
-		return args.Decode(r)
-	})
-	// SEQUENCE at position > 0 returns NFS4ERR_SEQUENCE_POS per RFC 8881.
-	// SEQUENCE at position 0 is handled specially in dispatchV41 before the op loop.
-	h.v41DispatchTable[types.OP_SEQUENCE] = func(ctx *types.CompoundContext, _ *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
-		var args types.SequenceArgs
-		if err := args.Decode(reader); err != nil {
-			return &types.CompoundResult{
-				Status: types.NFS4ERR_BADXDR,
-				OpCode: types.OP_SEQUENCE,
-				Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
-			}
-		}
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_SEQUENCE_POS,
-			OpCode: types.OP_SEQUENCE,
-			Data:   encodeStatusOnly(types.NFS4ERR_SEQUENCE_POS),
-		}
-	}
-	h.v41DispatchTable[types.OP_SET_SSV] = v41StubHandler(types.OP_SET_SSV, func(r io.Reader) error {
-		var args types.SetSsvArgs
-		return args.Decode(r)
-	})
-	h.v41DispatchTable[types.OP_TEST_STATEID] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
-		return v41handlers.HandleTestStateid(h.v41Deps, ctx, v41ctx, reader)
-	}
-	h.v41DispatchTable[types.OP_WANT_DELEGATION] = v41StubHandler(types.OP_WANT_DELEGATION, func(r io.Reader) error {
-		var args types.WantDelegationArgs
-		return args.Decode(r)
-	})
-	h.v41DispatchTable[types.OP_DESTROY_CLIENTID] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
-		return v41handlers.HandleDestroyClientID(h.v41Deps, ctx, v41ctx, reader)
-	}
-	h.v41DispatchTable[types.OP_RECLAIM_COMPLETE] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
-		return v41handlers.HandleReclaimComplete(h.v41Deps, ctx, v41ctx, reader)
-	}
-
-	// NFSv4.2 / RFC 8276 extended-attribute operations. These share the v4.1
-	// session/SEQUENCE machinery (RFC 7862 builds on RFC 8881), so they ride the
-	// v41DispatchTable. They are gated to v4.2-only in dispatchOne: a v4.0/v4.1
-	// COMPOUND carrying one of these opcodes gets NFS4ERR_NOTSUPP.
-	h.v41DispatchTable[types.OP_GETXATTR] = func(ctx *types.CompoundContext, _ *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
-		return h.handleGetXattr(ctx, reader)
-	}
-	h.v41DispatchTable[types.OP_SETXATTR] = func(ctx *types.CompoundContext, _ *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
-		return h.handleSetXattr(ctx, reader)
-	}
-	h.v41DispatchTable[types.OP_LISTXATTRS] = func(ctx *types.CompoundContext, _ *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
-		return h.handleListXattrs(ctx, reader)
-	}
-	h.v41DispatchTable[types.OP_REMOVEXATTR] = func(ctx *types.CompoundContext, _ *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
-		return h.handleRemoveXattr(ctx, reader)
-	}
+	// Register operation handlers grouped by NFS minor version. Each
+	// registerV4xOps method lives in its own register_v4x.go file so the
+	// version boundary is explicit: RFC 7530 (v4.0), RFC 8881 (v4.1),
+	// RFC 8276 xattr ops (v4.2).
+	h.registerV40Ops()
+	h.registerV41Ops()
+	h.registerV42Ops()
 
 	return h
-}
-
-// xattrOps is the set of RFC 8276 extended-attribute operation numbers, which
-// are valid only in NFSv4.2 COMPOUNDs. In v4.0/v4.1 COMPOUNDs they must return
-// NFS4ERR_NOTSUPP (mirroring the v40OnlyOps gating in the opposite direction).
-var xattrOps = map[uint32]bool{
-	types.OP_GETXATTR:    true, // op 72
-	types.OP_SETXATTR:    true, // op 73
-	types.OP_LISTXATTRS:  true, // op 74
-	types.OP_REMOVEXATTR: true, // op 75
 }
 
 // SetXattrBackend overrides the extended-attribute backend used by the RFC 8276
@@ -317,30 +146,6 @@ var xattrOps = map[uint32]bool{
 // tests to inject a fake backend.
 func (h *Handler) SetXattrBackend(b XattrBackend) {
 	h.xattrBackend = b
-}
-
-// v41StubHandler creates a v4.1 stub handler that decodes args and returns NOTSUPP.
-// The decoder parameter consumes the operation's XDR args from the reader to
-// prevent stream desync (the CRITICAL invariant for COMPOUND processing).
-func v41StubHandler(opCode uint32, decoder func(io.Reader) error) V41OpHandler {
-	return func(ctx *types.CompoundContext, _ *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
-		if err := decoder(reader); err != nil {
-			logger.Debug("NFSv4.1 stub decode error",
-				"op", types.OpName(opCode), "error", err, "client", ctx.ClientAddr)
-			return &types.CompoundResult{
-				Status: types.NFS4ERR_BADXDR,
-				OpCode: opCode,
-				Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
-			}
-		}
-		logger.Debug("NFSv4.1 operation not yet implemented",
-			"op", types.OpName(opCode), "client", ctx.ClientAddr)
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_NOTSUPP,
-			OpCode: opCode,
-			Data:   encodeStatusOnly(types.NFS4ERR_NOTSUPP),
-		}
-	}
 }
 
 // handleIllegal handles the OP_ILLEGAL operation (RFC 7530 Section 16.14).

--- a/internal/adapter/nfs/v4/handlers/handler.go
+++ b/internal/adapter/nfs/v4/handlers/handler.go
@@ -73,9 +73,16 @@ type Handler struct {
 	// Compounds with minorversion < minMinorVersion get NFS4ERR_MINOR_VERS_MISMATCH.
 	minMinorVersion uint32
 
-	// maxMinorVersion is the maximum accepted NFSv4 minor version (default 1).
+	// maxMinorVersion is the maximum accepted NFSv4 minor version (default 2).
 	// Compounds with minorversion > maxMinorVersion get NFS4ERR_MINOR_VERS_MISMATCH.
+	// v4.2 support is limited to the RFC 8276 extended-attribute operations.
 	maxMinorVersion uint32
+
+	// xattrBackend resolves named (extended) attribute operations for the four
+	// RFC 8276 xattr handlers. It is satisfied structurally by *metadata.Service.
+	// Depending on this interface (rather than concrete Service methods) keeps
+	// PR2 decoupled from the unified xattr resolver landing in PR1 (#1285).
+	xattrBackend XattrBackend
 }
 
 // NewHandler creates a new NFSv4 handler with the given runtime, pseudo-fs,
@@ -98,7 +105,7 @@ func NewHandler(registry nfsRuntime, pfs *pseudofs.PseudoFS, stateManager ...*st
 		StateManager:     sm,
 		opDispatchTable:  make(map[uint32]OpHandler),
 		v41DispatchTable: make(map[uint32]V41OpHandler),
-		maxMinorVersion:  1, // default: accept v4.0 and v4.1
+		maxMinorVersion:  2, // default: accept v4.0, v4.1, and v4.2 (RFC 8276 xattr ops)
 	}
 
 	// Initialize v4.1 handler dependencies
@@ -274,7 +281,42 @@ func NewHandler(registry nfsRuntime, pfs *pseudofs.PseudoFS, stateManager ...*st
 		return v41handlers.HandleReclaimComplete(h.v41Deps, ctx, v41ctx, reader)
 	}
 
+	// NFSv4.2 / RFC 8276 extended-attribute operations. These share the v4.1
+	// session/SEQUENCE machinery (RFC 7862 builds on RFC 8881), so they ride the
+	// v41DispatchTable. They are gated to v4.2-only in dispatchOne: a v4.0/v4.1
+	// COMPOUND carrying one of these opcodes gets NFS4ERR_NOTSUPP.
+	h.v41DispatchTable[types.OP_GETXATTR] = func(ctx *types.CompoundContext, _ *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
+		return h.handleGetXattr(ctx, reader)
+	}
+	h.v41DispatchTable[types.OP_SETXATTR] = func(ctx *types.CompoundContext, _ *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
+		return h.handleSetXattr(ctx, reader)
+	}
+	h.v41DispatchTable[types.OP_LISTXATTRS] = func(ctx *types.CompoundContext, _ *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
+		return h.handleListXattrs(ctx, reader)
+	}
+	h.v41DispatchTable[types.OP_REMOVEXATTR] = func(ctx *types.CompoundContext, _ *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
+		return h.handleRemoveXattr(ctx, reader)
+	}
+
 	return h
+}
+
+// xattrOps is the set of RFC 8276 extended-attribute operation numbers, which
+// are valid only in NFSv4.2 COMPOUNDs. In v4.0/v4.1 COMPOUNDs they must return
+// NFS4ERR_NOTSUPP (mirroring the v40OnlyOps gating in the opposite direction).
+var xattrOps = map[uint32]bool{
+	types.OP_GETXATTR:    true, // op 72
+	types.OP_SETXATTR:    true, // op 73
+	types.OP_LISTXATTRS:  true, // op 74
+	types.OP_REMOVEXATTR: true, // op 75
+}
+
+// SetXattrBackend overrides the extended-attribute backend used by the RFC 8276
+// xattr handlers. When unset, the handlers resolve the backend from the
+// registry's metadata service (see xattrBackendForHandler). Primarily used by
+// tests to inject a fake backend.
+func (h *Handler) SetXattrBackend(b XattrBackend) {
+	h.xattrBackend = b
 }
 
 // v41StubHandler creates a v4.1 stub handler that decodes args and returns NOTSUPP.
@@ -362,7 +404,7 @@ func (h *Handler) IsOperationBlocked(opNum uint32) bool {
 
 // SetMinorVersionRange sets the accepted minor version range for COMPOUND requests.
 // Compounds with minorversion outside [min, max] get NFS4ERR_MINOR_VERS_MISMATCH.
-// Default: min=0, max=1 (both v4.0 and v4.1 enabled).
+// Default: min=0, max=2 (v4.0, v4.1, and v4.2 xattr ops enabled).
 func (h *Handler) SetMinorVersionRange(min, max uint32) {
 	h.minMinorVersion = min
 	h.maxMinorVersion = max

--- a/internal/adapter/nfs/v4/handlers/listxattrs.go
+++ b/internal/adapter/nfs/v4/handlers/listxattrs.go
@@ -142,5 +142,10 @@ func wireXattrName(canonical string) (string, bool) {
 		// No "user." prefix: a non-user-namespace name; hide it from the wire.
 		return "", false
 	}
+	if stripped == "" {
+		// A bare "user." with no key (unexpected backend data): emitting it would
+		// put an empty, invalid name on the wire. Hide it defensively.
+		return "", false
+	}
 	return stripped, true
 }

--- a/internal/adapter/nfs/v4/handlers/listxattrs.go
+++ b/internal/adapter/nfs/v4/handlers/listxattrs.go
@@ -1,0 +1,146 @@
+package handlers
+
+import (
+	"bytes"
+	"io"
+	"sort"
+
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// LISTXATTRS4args / LISTXATTRS4res (RFC 8276 Section 8.6):
+//
+//	struct LISTXATTRS4args {
+//	    nfs_cookie4 lxa_cookie;    // uint64
+//	    count4      lxa_maxcount;  // uint32
+//	};
+//	struct LISTXATTRS4resok {
+//	    nfs_cookie4 lxr_cookie;    // uint64
+//	    xattrkey4   lxr_names<>;   // component4<>
+//	    bool        lxr_eof;
+//	};
+//	union LISTXATTRS4res switch (nfsstat4 status) {
+//	 case NFS4_OK: LISTXATTRS4resok;
+//	 default:      void;
+//	};
+//
+// LISTXATTRS carries NO stateid. Names are returned in the wire ("user."-
+// stripped) form so they match what a setfattr/getfattr client expects. The
+// cookie is the count of names already returned by prior calls; paging is over
+// a stable (sorted) name order. Pseudo-fs handles return NFS4ERR_NOTSUPP.
+func (h *Handler) handleListXattrs(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+	if status := types.RequireCurrentFH(ctx); status != types.NFS4_OK {
+		return xattrErr(types.OP_LISTXATTRS, status)
+	}
+
+	cookie, err := xdr.DecodeUint64(reader)
+	if err != nil {
+		return xattrErr(types.OP_LISTXATTRS, types.NFS4ERR_BADXDR)
+	}
+	maxcount, err := xdr.DecodeUint32(reader)
+	if err != nil {
+		return xattrErr(types.OP_LISTXATTRS, types.NFS4ERR_BADXDR)
+	}
+
+	if pseudofs.IsPseudoFSHandle(ctx.CurrentFH) {
+		return xattrErr(types.OP_LISTXATTRS, types.NFS4ERR_NOTSUPP)
+	}
+
+	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
+	if err != nil {
+		return xattrErr(types.OP_LISTXATTRS, types.NFS4ERR_SERVERFAULT)
+	}
+	backend, err := xattrBackendForHandler(h)
+	if err != nil {
+		return xattrErr(types.OP_LISTXATTRS, types.NFS4ERR_SERVERFAULT)
+	}
+
+	handle := metadata.FileHandle(ctx.CurrentFH)
+	rawNames, err := backend.ListXattr(authCtx, handle)
+	if err != nil {
+		return xattrErr(types.OP_LISTXATTRS, common.MapToNFS4(err))
+	}
+
+	// Strip the "user." prefix and keep only user-namespace names (the only
+	// namespace exposed over the wire), then sort for a stable cookie order.
+	names := make([]string, 0, len(rawNames))
+	for _, n := range rawNames {
+		if wire, ok := wireXattrName(n); ok {
+			names = append(names, wire)
+		}
+	}
+	sort.Strings(names)
+
+	if cookie > uint64(len(names)) {
+		// A cookie past the end is stale/invalid.
+		return xattrErr(types.OP_LISTXATTRS, types.NFS4ERR_BAD_COOKIE)
+	}
+
+	// Budget the reply to maxcount bytes: cookie(8) + array-count(4) + eof(4)
+	// is the fixed overhead; each name costs len(4) + utf8 + XDR pad.
+	const fixedOverhead = 8 + 4 + 4
+	budget := int(maxcount)
+	if budget < fixedOverhead {
+		// maxcount must at least hold the empty reply; RFC 8276 returns
+		// NFS4ERR_TOOSMALL when it cannot.
+		return xattrErr(types.OP_LISTXATTRS, types.NFS4ERR_TOOSMALL)
+	}
+	used := fixedOverhead
+
+	var out []string
+	i := int(cookie)
+	for ; i < len(names); i++ {
+		entryLen := 4 + len(names[i])
+		if pad := (4 - (len(names[i]) % 4)) % 4; pad != 0 {
+			entryLen += pad
+		}
+		if used+entryLen > budget {
+			break
+		}
+		used += entryLen
+		out = append(out, names[i])
+	}
+
+	if len(out) == 0 && i < len(names) {
+		// The very first remaining name does not fit in maxcount.
+		return xattrErr(types.OP_LISTXATTRS, types.NFS4ERR_TOOSMALL)
+	}
+
+	newCookie := cookie + uint64(len(out))
+	eof := int(newCookie) >= len(names)
+
+	logger.Debug("NFSv4.2 LISTXATTRS", "total", len(names), "returned", len(out),
+		"cookie", cookie, "new_cookie", newCookie, "eof", eof, "client", ctx.ClientAddr)
+
+	var buf bytes.Buffer
+	_ = xdr.WriteUint32(&buf, types.NFS4_OK)
+	_ = xdr.WriteUint64(&buf, newCookie)
+	_ = xdr.WriteUint32(&buf, uint32(len(out))) // names<> array length
+	for _, n := range out {
+		_ = xdr.WriteXDRString(&buf, n)
+	}
+	_ = xdr.WriteBool(&buf, eof)
+
+	return &types.CompoundResult{
+		Status: types.NFS4_OK,
+		OpCode: types.OP_LISTXATTRS,
+		Data:   buf.Bytes(),
+	}
+}
+
+// wireXattrName converts a store-canonical xattr name to its wire form (drop the
+// "user." prefix). ok is false for names outside the user namespace, which are
+// hidden from LISTXATTRS (e.g. the reserved SMB security.NTACL name).
+func wireXattrName(canonical string) (string, bool) {
+	stripped := stripXattrPrefix(canonical)
+	if stripped == canonical {
+		// No "user." prefix: a non-user-namespace name; hide it from the wire.
+		return "", false
+	}
+	return stripped, true
+}

--- a/internal/adapter/nfs/v4/handlers/lock_test.go
+++ b/internal/adapter/nfs/v4/handlers/lock_test.go
@@ -303,7 +303,7 @@ func TestHandleLock_Dispatched(t *testing.T) {
 	pfs.Rebuild([]string{"/export"})
 	h := NewHandler(nil, pfs)
 
-	if _, exists := h.opDispatchTable[types.OP_LOCK]; !exists {
+	if _, exists := h.v40DispatchTable[types.OP_LOCK]; !exists {
 		t.Fatal("OP_LOCK not registered in dispatch table")
 	}
 }
@@ -551,7 +551,7 @@ func TestHandleLockT_Dispatched(t *testing.T) {
 	pfs.Rebuild([]string{"/export"})
 	h := NewHandler(nil, pfs)
 
-	if _, exists := h.opDispatchTable[types.OP_LOCKT]; !exists {
+	if _, exists := h.v40DispatchTable[types.OP_LOCKT]; !exists {
 		t.Fatal("OP_LOCKT not registered in dispatch table")
 	}
 }
@@ -801,7 +801,7 @@ func TestHandleLockU_Dispatched(t *testing.T) {
 	pfs.Rebuild([]string{"/export"})
 	h := NewHandler(nil, pfs)
 
-	if _, exists := h.opDispatchTable[types.OP_LOCKU]; !exists {
+	if _, exists := h.v40DispatchTable[types.OP_LOCKU]; !exists {
 		t.Fatal("OP_LOCKU not registered in dispatch table")
 	}
 }

--- a/internal/adapter/nfs/v4/handlers/register_v40.go
+++ b/internal/adapter/nfs/v4/handlers/register_v40.go
@@ -1,0 +1,85 @@
+// register_v40.go — NFSv4.0 (RFC 7530) operation handler registration.
+package handlers
+
+import "github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+
+// registerV40Ops registers every implemented NFSv4.0 operation (op numbers
+// 3-39) into v40DispatchTable. These are reachable from v4.0, v4.1 and v4.2
+// COMPOUNDs (the later minor versions are supersets).
+func (h *Handler) registerV40Ops() {
+	// Filehandle management
+	h.v40DispatchTable[types.OP_PUTFH] = h.handlePutFH
+	h.v40DispatchTable[types.OP_PUTROOTFH] = h.handlePutRootFH
+	h.v40DispatchTable[types.OP_PUTPUBFH] = h.handlePutPubFH
+	h.v40DispatchTable[types.OP_GETFH] = h.handleGetFH
+	h.v40DispatchTable[types.OP_SAVEFH] = h.handleSaveFH
+	h.v40DispatchTable[types.OP_RESTOREFH] = h.handleRestoreFH
+
+	// Pseudo-fs traversal and attributes
+	h.v40DispatchTable[types.OP_LOOKUP] = h.handleLookup
+	h.v40DispatchTable[types.OP_LOOKUPP] = h.handleLookupP
+	h.v40DispatchTable[types.OP_GETATTR] = h.handleGetAttr
+	h.v40DispatchTable[types.OP_READDIR] = h.handleReadDir
+	h.v40DispatchTable[types.OP_ACCESS] = h.handleAccess
+
+	// Symlink operations
+	h.v40DispatchTable[types.OP_READLINK] = h.handleReadLink
+
+	// Create/Remove operations
+	h.v40DispatchTable[types.OP_CREATE] = h.handleCreate
+	h.v40DispatchTable[types.OP_REMOVE] = h.handleRemove
+
+	// Link and rename operations
+	h.v40DispatchTable[types.OP_LINK] = h.handleLink
+	h.v40DispatchTable[types.OP_RENAME] = h.handleRename
+
+	// Attribute operations
+	h.v40DispatchTable[types.OP_SETATTR] = h.handleSetAttr
+
+	// Protocol operations
+	h.v40DispatchTable[types.OP_ILLEGAL] = h.handleIllegal
+
+	// Stateful I/O operations
+	h.v40DispatchTable[types.OP_OPEN] = h.handleOpen
+	h.v40DispatchTable[types.OP_OPEN_CONFIRM] = h.handleOpenConfirm
+	h.v40DispatchTable[types.OP_CLOSE] = h.handleClose
+
+	// Data I/O operations
+	h.v40DispatchTable[types.OP_READ] = h.handleRead
+	h.v40DispatchTable[types.OP_WRITE] = h.handleWrite
+	h.v40DispatchTable[types.OP_COMMIT] = h.handleCommit
+
+	// Conditional verification
+	h.v40DispatchTable[types.OP_VERIFY] = h.handleVerify
+	h.v40DispatchTable[types.OP_NVERIFY] = h.handleNVerify
+
+	// Security negotiation
+	h.v40DispatchTable[types.OP_SECINFO] = h.handleSecInfo
+
+	// Client setup operations
+	h.v40DispatchTable[types.OP_SETCLIENTID] = h.handleSetClientID
+	h.v40DispatchTable[types.OP_SETCLIENTID_CONFIRM] = h.handleSetClientIDConfirm
+	h.v40DispatchTable[types.OP_RENEW] = h.handleRenew
+
+	// Lock operations (, 10-02)
+	h.v40DispatchTable[types.OP_LOCK] = h.handleLock
+	h.v40DispatchTable[types.OP_LOCKT] = h.handleLockT
+	h.v40DispatchTable[types.OP_LOCKU] = h.handleLockU
+
+	// Delegation operations (, 11-03)
+	h.v40DispatchTable[types.OP_DELEGRETURN] = h.handleDelegReturn
+	h.v40DispatchTable[types.OP_DELEGPURGE] = h.handleDelegPurge
+
+	// Stub operations (deferred to later phases)
+	h.v40DispatchTable[types.OP_OPENATTR] = h.handleOpenAttr
+	h.v40DispatchTable[types.OP_OPEN_DOWNGRADE] = h.handleOpenDowngrade
+	h.v40DispatchTable[types.OP_RELEASE_LOCKOWNER] = h.handleReleaseLockOwner
+
+	// Grace period lifecycle :
+	// On server startup (if previous clients exist):
+	//   handler.StateManager.StartGracePeriod(previousClientIDs)
+	// On graceful shutdown:
+	//   snapshots := handler.StateManager.SaveClientState()
+	//   // serialize snapshots to disk
+	//   handler.StateManager.Shutdown()
+}

--- a/internal/adapter/nfs/v4/handlers/register_v41.go
+++ b/internal/adapter/nfs/v4/handlers/register_v41.go
@@ -1,0 +1,123 @@
+// register_v41.go — NFSv4.1 (RFC 8881) operation handler registration.
+package handlers
+
+import (
+	"io"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	v41handlers "github.com/marmos91/dittofs/internal/adapter/nfs/v4/v41/handlers"
+	"github.com/marmos91/dittofs/internal/logger"
+)
+
+// registerV41Ops registers the 19 NFSv4.1 operations (op numbers 40-58) into
+// v41DispatchTable. Most are stubs that decode their args and return NOTSUPP.
+func (h *Handler) registerV41Ops() {
+	// BACKCHANNEL_CTL: update callback program and security params (RFC 8881 Section 18.33)
+	h.v41DispatchTable[types.OP_BACKCHANNEL_CTL] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
+		return v41handlers.HandleBackchannelCtl(h.v41Deps, ctx, v41ctx, reader)
+	}
+	// BIND_CONN_TO_SESSION: connection binding (RFC 8881 Section 18.34)
+	h.v41DispatchTable[types.OP_BIND_CONN_TO_SESSION] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
+		return v41handlers.HandleBindConnToSession(h.v41Deps, ctx, v41ctx, reader)
+	}
+	// EXCHANGE_ID: client identity registration (RFC 8881 Section 18.35)
+	h.v41DispatchTable[types.OP_EXCHANGE_ID] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
+		return v41handlers.HandleExchangeID(h.v41Deps, ctx, v41ctx, reader)
+	}
+	// CREATE_SESSION: session lifecycle (RFC 8881 Section 18.36)
+	h.v41DispatchTable[types.OP_CREATE_SESSION] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
+		return v41handlers.HandleCreateSession(h.v41Deps, ctx, v41ctx, reader)
+	}
+	// DESTROY_SESSION: session teardown (RFC 8881 Section 18.37)
+	h.v41DispatchTable[types.OP_DESTROY_SESSION] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
+		return v41handlers.HandleDestroySession(h.v41Deps, ctx, v41ctx, reader)
+	}
+	h.v41DispatchTable[types.OP_FREE_STATEID] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
+		return v41handlers.HandleFreeStateid(h.v41Deps, ctx, v41ctx, reader)
+	}
+	h.v41DispatchTable[types.OP_GET_DIR_DELEGATION] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
+		return v41handlers.HandleGetDirDelegation(h.v41Deps, ctx, v41ctx, reader)
+	}
+	h.v41DispatchTable[types.OP_GETDEVICEINFO] = v41StubHandler(types.OP_GETDEVICEINFO, func(r io.Reader) error {
+		var args types.GetDeviceInfoArgs
+		return args.Decode(r)
+	})
+	h.v41DispatchTable[types.OP_GETDEVICELIST] = v41StubHandler(types.OP_GETDEVICELIST, func(r io.Reader) error {
+		var args types.GetDeviceListArgs
+		return args.Decode(r)
+	})
+	h.v41DispatchTable[types.OP_LAYOUTCOMMIT] = v41StubHandler(types.OP_LAYOUTCOMMIT, func(r io.Reader) error {
+		var args types.LayoutCommitArgs
+		return args.Decode(r)
+	})
+	h.v41DispatchTable[types.OP_LAYOUTGET] = v41StubHandler(types.OP_LAYOUTGET, func(r io.Reader) error {
+		var args types.LayoutGetArgs
+		return args.Decode(r)
+	})
+	h.v41DispatchTable[types.OP_LAYOUTRETURN] = v41StubHandler(types.OP_LAYOUTRETURN, func(r io.Reader) error {
+		var args types.LayoutReturnArgs
+		return args.Decode(r)
+	})
+	h.v41DispatchTable[types.OP_SECINFO_NO_NAME] = v41StubHandler(types.OP_SECINFO_NO_NAME, func(r io.Reader) error {
+		var args types.SecinfoNoNameArgs
+		return args.Decode(r)
+	})
+	// SEQUENCE at position > 0 returns NFS4ERR_SEQUENCE_POS per RFC 8881.
+	// SEQUENCE at position 0 is handled specially in dispatchV41 before the op loop.
+	h.v41DispatchTable[types.OP_SEQUENCE] = func(ctx *types.CompoundContext, _ *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
+		var args types.SequenceArgs
+		if err := args.Decode(reader); err != nil {
+			return &types.CompoundResult{
+				Status: types.NFS4ERR_BADXDR,
+				OpCode: types.OP_SEQUENCE,
+				Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
+			}
+		}
+		return &types.CompoundResult{
+			Status: types.NFS4ERR_SEQUENCE_POS,
+			OpCode: types.OP_SEQUENCE,
+			Data:   encodeStatusOnly(types.NFS4ERR_SEQUENCE_POS),
+		}
+	}
+	h.v41DispatchTable[types.OP_SET_SSV] = v41StubHandler(types.OP_SET_SSV, func(r io.Reader) error {
+		var args types.SetSsvArgs
+		return args.Decode(r)
+	})
+	h.v41DispatchTable[types.OP_TEST_STATEID] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
+		return v41handlers.HandleTestStateid(h.v41Deps, ctx, v41ctx, reader)
+	}
+	h.v41DispatchTable[types.OP_WANT_DELEGATION] = v41StubHandler(types.OP_WANT_DELEGATION, func(r io.Reader) error {
+		var args types.WantDelegationArgs
+		return args.Decode(r)
+	})
+	h.v41DispatchTable[types.OP_DESTROY_CLIENTID] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
+		return v41handlers.HandleDestroyClientID(h.v41Deps, ctx, v41ctx, reader)
+	}
+	h.v41DispatchTable[types.OP_RECLAIM_COMPLETE] = func(ctx *types.CompoundContext, v41ctx *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
+		return v41handlers.HandleReclaimComplete(h.v41Deps, ctx, v41ctx, reader)
+	}
+}
+
+// v41StubHandler creates a v4.1 stub handler that decodes args and returns NOTSUPP.
+// The decoder parameter consumes the operation's XDR args from the reader to
+// prevent stream desync (the CRITICAL invariant for COMPOUND processing).
+func v41StubHandler(opCode uint32, decoder func(io.Reader) error) V41OpHandler {
+	return func(ctx *types.CompoundContext, _ *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
+		if err := decoder(reader); err != nil {
+			logger.Debug("NFSv4.1 stub decode error",
+				"op", types.OpName(opCode), "error", err, "client", ctx.ClientAddr)
+			return &types.CompoundResult{
+				Status: types.NFS4ERR_BADXDR,
+				OpCode: opCode,
+				Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
+			}
+		}
+		logger.Debug("NFSv4.1 operation not yet implemented",
+			"op", types.OpName(opCode), "client", ctx.ClientAddr)
+		return &types.CompoundResult{
+			Status: types.NFS4ERR_NOTSUPP,
+			OpCode: opCode,
+			Data:   encodeStatusOnly(types.NFS4ERR_NOTSUPP),
+		}
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/register_v42.go
+++ b/internal/adapter/nfs/v4/handlers/register_v42.go
@@ -1,0 +1,15 @@
+// register_v42.go — NFSv4.2 (RFC 8276) extended-attribute operation registration.
+package handlers
+
+import "github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+
+// registerV42Ops registers the four RFC 8276 extended-attribute operations
+// (op numbers 72-75) into v42DispatchTable, kept separate from v4.0/v4.1 so the
+// minor-version boundary is explicit. dispatchOne gates these to minorversion 2:
+// a v4.0/v4.1 COMPOUND carrying one of these opcodes gets NFS4ERR_NOTSUPP.
+func (h *Handler) registerV42Ops() {
+	h.v42DispatchTable[types.OP_GETXATTR] = h.handleGetXattr
+	h.v42DispatchTable[types.OP_SETXATTR] = h.handleSetXattr
+	h.v42DispatchTable[types.OP_LISTXATTRS] = h.handleListXattrs
+	h.v42DispatchTable[types.OP_REMOVEXATTR] = h.handleRemoveXattr
+}

--- a/internal/adapter/nfs/v4/handlers/removexattr.go
+++ b/internal/adapter/nfs/v4/handlers/removexattr.go
@@ -72,7 +72,15 @@ func (h *Handler) handleRemoveXattr(ctx *types.CompoundContext, reader io.Reader
 	}
 
 	if err := backend.RemoveXattr(authCtx, handle, canonical); err != nil {
-		return xattrErr(types.OP_REMOVEXATTR, common.MapToNFS4(err))
+		// A "not found" here means the name is only stream-backed (PR1 does not
+		// delete stream entities) or lost a TOCTOU race after the pre-check. Per
+		// RFC 8276 §11.2 a missing xattr is NOXATTR, not the generic NOENT the
+		// store error otherwise maps to.
+		status := common.MapToNFS4(err)
+		if status == types.NFS4ERR_NOENT {
+			status = types.NFS4ERR_NOXATTR
+		}
+		return xattrErr(types.OP_REMOVEXATTR, status)
 	}
 
 	after := h.xattrChangeID(ctx, handle)

--- a/internal/adapter/nfs/v4/handlers/removexattr.go
+++ b/internal/adapter/nfs/v4/handlers/removexattr.go
@@ -1,0 +1,94 @@
+package handlers
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// REMOVEXATTR4args / REMOVEXATTR4res (RFC 8276 Section 8.6):
+//
+//	struct REMOVEXATTR4args {
+//	    xattrkey4    rxa_name;   // component4 (utf8str_cs)
+//	};
+//	struct REMOVEXATTR4resok {
+//	    change_info4 rxr_info;
+//	};
+//	union REMOVEXATTR4res switch (nfsstat4 status) {
+//	 case NFS4_OK: REMOVEXATTR4resok;
+//	 default:      void;
+//	};
+//
+// REMOVEXATTR carries NO stateid. Removing a missing xattr returns
+// NFS4ERR_NOXATTR. The change_info4 reflects the file's change attribute
+// (ctime) before/after. Pseudo-fs handles return NFS4ERR_ROFS.
+func (h *Handler) handleRemoveXattr(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+	if status := types.RequireCurrentFH(ctx); status != types.NFS4_OK {
+		return xattrErr(types.OP_REMOVEXATTR, status)
+	}
+
+	name, err := xdr.DecodeString(reader)
+	if err != nil {
+		return xattrErr(types.OP_REMOVEXATTR, types.NFS4ERR_BADXDR)
+	}
+
+	if pseudofs.IsPseudoFSHandle(ctx.CurrentFH) {
+		return xattrErr(types.OP_REMOVEXATTR, types.NFS4ERR_ROFS)
+	}
+
+	canonical, ok := canonicalizeXattrName(name)
+	if !ok {
+		return xattrErr(types.OP_REMOVEXATTR, types.NFS4ERR_NOXATTR)
+	}
+
+	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
+	if err != nil {
+		return xattrErr(types.OP_REMOVEXATTR, types.NFS4ERR_SERVERFAULT)
+	}
+	backend, err := xattrBackendForHandler(h)
+	if err != nil {
+		return xattrErr(types.OP_REMOVEXATTR, types.NFS4ERR_SERVERFAULT)
+	}
+
+	handle := metadata.FileHandle(ctx.CurrentFH)
+
+	// change_info4 "before" (best-effort; advisory WCC data).
+	before := h.xattrChangeID(ctx, handle)
+
+	// Missing xattr -> NFS4ERR_NOXATTR (the backend RemoveXattr is a no-op on a
+	// missing name, so probe existence first).
+	_, exists, gerr := backend.GetXattr(authCtx, handle, canonical)
+	if gerr != nil {
+		return xattrErr(types.OP_REMOVEXATTR, common.MapToNFS4(gerr))
+	}
+	if !exists {
+		return xattrErr(types.OP_REMOVEXATTR, types.NFS4ERR_NOXATTR)
+	}
+
+	if err := backend.RemoveXattr(authCtx, handle, canonical); err != nil {
+		return xattrErr(types.OP_REMOVEXATTR, common.MapToNFS4(err))
+	}
+
+	after := h.xattrChangeID(ctx, handle)
+	if after == 0 {
+		after = before
+	}
+
+	logger.Debug("NFSv4.2 REMOVEXATTR", "name", canonical, "client", ctx.ClientAddr)
+
+	var buf bytes.Buffer
+	_ = xdr.WriteUint32(&buf, types.NFS4_OK)
+	encodeChangeInfo4(&buf, true, before, after)
+
+	return &types.CompoundResult{
+		Status: types.NFS4_OK,
+		OpCode: types.OP_REMOVEXATTR,
+		Data:   buf.Bytes(),
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/sequence_handler_test.go
+++ b/internal/adapter/nfs/v4/handlers/sequence_handler_test.go
@@ -714,7 +714,7 @@ func TestCompound_V41_SkipOwnerSeqid(t *testing.T) {
 
 	// Install a test v4.0 handler that checks SkipOwnerSeqid
 	var sawSkipOwnerSeqid bool
-	h.opDispatchTable[types.OP_PUTROOTFH] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+	h.v40DispatchTable[types.OP_PUTROOTFH] = func(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 		sawSkipOwnerSeqid = ctx.SkipOwnerSeqid
 		return &types.CompoundResult{
 			Status: types.NFS4_OK,

--- a/internal/adapter/nfs/v4/handlers/setxattr.go
+++ b/internal/adapter/nfs/v4/handlers/setxattr.go
@@ -50,6 +50,11 @@ func (h *Handler) handleSetXattr(ctx *types.CompoundContext, reader io.Reader) *
 	if err != nil {
 		return xattrErr(types.OP_SETXATTR, types.NFS4ERR_BADXDR)
 	}
+	// DecodeOpaque enforces a generic 1 MiB XDR cap. A value over our 64 KiB
+	// inline ceiling but within that cap decodes here and the store returns
+	// ErrXattrTooLarge -> NFS4ERR_XATTR2BIG below. A value over 1 MiB is
+	// unreachable from a conformant client (Linux XATTR_SIZE_MAX is 64 KiB) and
+	// surfaces as NFS4ERR_BADXDR — acceptable for malformed input.
 	value, err := xdr.DecodeOpaque(reader)
 	if err != nil {
 		return xattrErr(types.OP_SETXATTR, types.NFS4ERR_BADXDR)

--- a/internal/adapter/nfs/v4/handlers/setxattr.go
+++ b/internal/adapter/nfs/v4/handlers/setxattr.go
@@ -1,0 +1,144 @@
+package handlers
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// SETXATTR4args / SETXATTR4res (RFC 8276 Section 8.6):
+//
+//	enum setxattr_option4 {
+//	    SETXATTR4_EITHER  = 0,
+//	    SETXATTR4_CREATE  = 1,
+//	    SETXATTR4_REPLACE = 2
+//	};
+//	struct SETXATTR4args {
+//	    setxattr_option4 sxa_option;
+//	    xattrkey4        sxa_key;    // component4 (utf8str_cs)
+//	    xattrvalue4      sxa_value;  // opaque<>
+//	};
+//	struct SETXATTR4resok {
+//	    change_info4 sxr_info;
+//	};
+//	union SETXATTR4res switch (nfsstat4 status) {
+//	 case NFS4_OK: SETXATTR4resok;
+//	 default:      void;
+//	};
+//
+// SETXATTR carries NO stateid. CREATE on an existing xattr returns
+// NFS4ERR_EXIST; REPLACE on a missing xattr returns NFS4ERR_NOXATTR. The
+// change_info4 reflects the file's change attribute (ctime) before/after.
+// Pseudo-fs handles return NFS4ERR_ROFS (the virtual namespace is read-only).
+func (h *Handler) handleSetXattr(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+	if status := types.RequireCurrentFH(ctx); status != types.NFS4_OK {
+		return xattrErr(types.OP_SETXATTR, status)
+	}
+
+	option, err := xdr.DecodeUint32(reader)
+	if err != nil {
+		return xattrErr(types.OP_SETXATTR, types.NFS4ERR_BADXDR)
+	}
+	name, err := xdr.DecodeString(reader)
+	if err != nil {
+		return xattrErr(types.OP_SETXATTR, types.NFS4ERR_BADXDR)
+	}
+	value, err := xdr.DecodeOpaque(reader)
+	if err != nil {
+		return xattrErr(types.OP_SETXATTR, types.NFS4ERR_BADXDR)
+	}
+
+	if option != types.SETXATTR4_EITHER &&
+		option != types.SETXATTR4_CREATE &&
+		option != types.SETXATTR4_REPLACE {
+		return xattrErr(types.OP_SETXATTR, types.NFS4ERR_INVAL)
+	}
+
+	if pseudofs.IsPseudoFSHandle(ctx.CurrentFH) {
+		return xattrErr(types.OP_SETXATTR, types.NFS4ERR_ROFS)
+	}
+
+	canonical, ok := canonicalizeXattrName(name)
+	if !ok {
+		// Unsupported namespace: there is no place to create such an xattr,
+		// and REPLACE of a non-existent one is NOXATTR.
+		return xattrErr(types.OP_SETXATTR, types.NFS4ERR_NOXATTR)
+	}
+
+	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
+	if err != nil {
+		return xattrErr(types.OP_SETXATTR, types.NFS4ERR_SERVERFAULT)
+	}
+	backend, err := xattrBackendForHandler(h)
+	if err != nil {
+		return xattrErr(types.OP_SETXATTR, types.NFS4ERR_SERVERFAULT)
+	}
+
+	handle := metadata.FileHandle(ctx.CurrentFH)
+
+	// change_info4 "before". Best-effort: the change attribute is advisory WCC
+	// data, so a lookup failure falls back to 0 rather than failing the op.
+	before := h.xattrChangeID(ctx, handle)
+
+	if option != types.SETXATTR4_EITHER {
+		_, exists, gerr := backend.GetXattr(authCtx, handle, canonical)
+		if gerr != nil {
+			return xattrErr(types.OP_SETXATTR, common.MapToNFS4(gerr))
+		}
+		if option == types.SETXATTR4_CREATE && exists {
+			return xattrErr(types.OP_SETXATTR, types.NFS4ERR_EXIST)
+		}
+		if option == types.SETXATTR4_REPLACE && !exists {
+			return xattrErr(types.OP_SETXATTR, types.NFS4ERR_NOXATTR)
+		}
+	}
+
+	if err := backend.SetXattr(authCtx, handle, canonical, value); err != nil {
+		return xattrErr(types.OP_SETXATTR, common.MapToNFS4(err))
+	}
+
+	after := h.xattrChangeID(ctx, handle)
+	if after == 0 {
+		// The set succeeded but the post-op changeid was unavailable; fall back
+		// to the pre-op changeid so before/after stay coherent.
+		after = before
+	}
+
+	logger.Debug("NFSv4.2 SETXATTR", "name", canonical, "option", option,
+		"len", len(value), "client", ctx.ClientAddr)
+
+	var buf bytes.Buffer
+	_ = xdr.WriteUint32(&buf, types.NFS4_OK)
+	encodeChangeInfo4(&buf, true, before, after)
+
+	return &types.CompoundResult{
+		Status: types.NFS4_OK,
+		OpCode: types.OP_SETXATTR,
+		Data:   buf.Bytes(),
+	}
+}
+
+// xattrChangeID returns the current change attribute (changeid4) of the file,
+// derived from its ctime in nanoseconds — the same source GETATTR uses for
+// FATTR4_CHANGE — for use in the change_info4 of SETXATTR/REMOVEXATTR.
+//
+// It is best-effort: the change attribute is advisory WCC data, so when no
+// metadata service is available (e.g. a fake-backend unit test) or the lookup
+// fails it returns 0 rather than failing the operation.
+func (h *Handler) xattrChangeID(ctx *types.CompoundContext, handle metadata.FileHandle) uint64 {
+	metaSvc, err := getMetadataServiceForCtx(h)
+	if err != nil || metaSvc == nil {
+		return 0
+	}
+	file, err := metaSvc.GetFile(ctx.Context, handle)
+	if err != nil {
+		return 0
+	}
+	return uint64(file.Ctime.UnixNano())
+}

--- a/internal/adapter/nfs/v4/handlers/setxattr.go
+++ b/internal/adapter/nfs/v4/handlers/setxattr.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"errors"
 	"io"
 
 	"github.com/marmos91/dittofs/internal/adapter/common"
@@ -100,6 +101,12 @@ func (h *Handler) handleSetXattr(ctx *types.CompoundContext, reader io.Reader) *
 	}
 
 	if err := backend.SetXattr(authCtx, handle, canonical, value); err != nil {
+		// RFC 8276 §11.2: a value exceeding the server's limit is XATTR2BIG.
+		// ErrXattrTooLarge is a metadata sentinel (ErrInvalidArgument-coded), so
+		// it would otherwise coarsen to NFS4ERR_INVAL via the generic map.
+		if errors.Is(err, metadata.ErrXattrTooLarge) {
+			return xattrErr(types.OP_SETXATTR, types.NFS4ERR_XATTR2BIG)
+		}
 		return xattrErr(types.OP_SETXATTR, common.MapToNFS4(err))
 	}
 

--- a/internal/adapter/nfs/v4/handlers/xattr_backend.go
+++ b/internal/adapter/nfs/v4/handlers/xattr_backend.go
@@ -14,8 +14,10 @@ import (
 // and PR1's unified resolver will swap in transparently.
 //
 // All names passed across this interface are canonical store names (the
-// "user."-prefixed form — see xattr.go canonicalization), shared with the SMB
-// EA namespace so both protocols observe one set of attributes.
+// "user."-prefixed form — see canonicalizeXattrName). This is the namespace
+// the unified resolver (pkg/metadata/xattr.go) reads and writes; end-to-end
+// cross-protocol name parity with SMB EAs/streams is exercised in PR3, not
+// asserted here.
 type XattrBackend interface {
 	// GetXattr returns the value of the named xattr and whether it is present.
 	GetXattr(ctx *metadata.AuthContext, h metadata.FileHandle, name string) ([]byte, bool, error)
@@ -69,8 +71,12 @@ func canonicalizeXattrName(name string) (canonical string, ok bool) {
 	if name == "" {
 		return "", false
 	}
-	// Already namespaced as user.*: accept verbatim.
+	// Already namespaced as user.*: accept verbatim, but reject the bare prefix
+	// with no key component ("user.") — that would be an empty on-wire name.
 	if strings.HasPrefix(name, xattrUserPrefix) {
+		if name == xattrUserPrefix {
+			return "", false
+		}
 		return name, true
 	}
 	// A bare name in another namespace (system.*, trusted.*, security.*, …) is

--- a/internal/adapter/nfs/v4/handlers/xattr_backend.go
+++ b/internal/adapter/nfs/v4/handlers/xattr_backend.go
@@ -1,0 +1,93 @@
+package handlers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// XattrBackend resolves named (extended) attribute operations for the RFC 8276
+// NFSv4.2 xattr handlers. It is deliberately a small interface owned by this
+// package (dependency inversion) so PR2 does not depend on the concrete xattr
+// methods landing in PR1 (#1285): *metadata.Service satisfies it structurally,
+// and PR1's unified resolver will swap in transparently.
+//
+// All names passed across this interface are canonical store names (the
+// "user."-prefixed form — see xattr.go canonicalization), shared with the SMB
+// EA namespace so both protocols observe one set of attributes.
+type XattrBackend interface {
+	// GetXattr returns the value of the named xattr and whether it is present.
+	GetXattr(ctx *metadata.AuthContext, h metadata.FileHandle, name string) ([]byte, bool, error)
+	// SetXattr creates or replaces the named xattr (unconditional upsert;
+	// create/replace semantics are enforced by the handler).
+	SetXattr(ctx *metadata.AuthContext, h metadata.FileHandle, name string, value []byte) error
+	// RemoveXattr deletes the named xattr.
+	RemoveXattr(ctx *metadata.AuthContext, h metadata.FileHandle, name string) error
+	// ListXattr returns the names of all xattrs on the file (store-canonical
+	// form, i.e. including the "user." prefix).
+	ListXattr(ctx *metadata.AuthContext, h metadata.FileHandle) ([]string, error)
+}
+
+// xattrBackendForHandler returns the xattr backend the handler should use. An
+// explicitly injected backend (SetXattrBackend, used by tests) wins; otherwise
+// the registry's *metadata.Service is used, which satisfies XattrBackend.
+func xattrBackendForHandler(h *Handler) (XattrBackend, error) {
+	if h.xattrBackend != nil {
+		return h.xattrBackend, nil
+	}
+	svc, err := getMetadataServiceForCtx(h)
+	if err != nil {
+		return nil, err
+	}
+	if svc == nil {
+		return nil, fmt.Errorf("no metadata service configured for xattr backend")
+	}
+	return svc, nil
+}
+
+// xattrUserPrefix is the only xattr namespace DittoFS exposes over NFSv4.2.
+//
+// The Linux NFS client carries only the "user." namespace on the wire and
+// strips the prefix before sending the name (so a client setfattr -n user.foo
+// arrives as "foo"). To keep names aligned with the SMB EA namespace, NFS
+// canonicalizes incoming names to "user.<name>" before the backend and strips
+// the prefix on the way out. Requests for any other namespace (system., trusted.,
+// security., …) are rejected with NFS4ERR_NOXATTR (RFC 8276 §8.1: a server may
+// reject names it does not support).
+const xattrUserPrefix = "user."
+
+// canonicalizeXattrName maps a wire xattr name to its store-canonical form
+// ("user.<name>"). It returns ok=false when the name is in an unsupported
+// namespace (a name containing a "." that is not "user."), which the caller
+// maps to NFS4ERR_NOXATTR.
+//
+// The Linux client strips "user." so names usually arrive bare; a name that
+// already carries the "user." prefix (other clients, or a name literally
+// containing a dot) is accepted as-is.
+func canonicalizeXattrName(name string) (canonical string, ok bool) {
+	if name == "" {
+		return "", false
+	}
+	// Already namespaced as user.*: accept verbatim.
+	if strings.HasPrefix(name, xattrUserPrefix) {
+		return name, true
+	}
+	// A bare name in another namespace (system.*, trusted.*, security.*, …) is
+	// rejected. We treat any dotted name whose first segment is a known reserved
+	// namespace as unsupported; a bare name with no namespace defaults to user.
+	if i := strings.IndexByte(name, '.'); i >= 0 {
+		switch name[:i] {
+		case "system", "trusted", "security":
+			return "", false
+		}
+	}
+	return xattrUserPrefix + name, true
+}
+
+// stripXattrPrefix reverses canonicalizeXattrName for names returned to the
+// client: it drops the "user." prefix so the wire name matches what the Linux
+// client sent. Names without the prefix are returned unchanged.
+func stripXattrPrefix(name string) string {
+	return strings.TrimPrefix(name, xattrUserPrefix)
+}

--- a/internal/adapter/nfs/v4/handlers/xattr_test.go
+++ b/internal/adapter/nfs/v4/handlers/xattr_test.go
@@ -23,6 +23,10 @@ type fakeXattrBackend struct {
 	store map[string][]byte
 	// forceErr, when set, is returned by every method (to exercise error mapping).
 	forceErr error
+	// setErr / removeErr, when set, are returned only by SetXattr / RemoveXattr
+	// (to exercise per-op error mapping without tripping the GetXattr pre-check).
+	setErr    error
+	removeErr error
 }
 
 func newFakeXattrBackend() *fakeXattrBackend {
@@ -41,6 +45,9 @@ func (f *fakeXattrBackend) SetXattr(_ *metadata.AuthContext, _ metadata.FileHand
 	if f.forceErr != nil {
 		return f.forceErr
 	}
+	if f.setErr != nil {
+		return f.setErr
+	}
 	f.store[name] = value
 	return nil
 }
@@ -48,6 +55,9 @@ func (f *fakeXattrBackend) SetXattr(_ *metadata.AuthContext, _ metadata.FileHand
 func (f *fakeXattrBackend) RemoveXattr(_ *metadata.AuthContext, _ metadata.FileHandle, name string) error {
 	if f.forceErr != nil {
 		return f.forceErr
+	}
+	if f.removeErr != nil {
+		return f.removeErr
 	}
 	delete(f.store, name)
 	return nil
@@ -255,6 +265,17 @@ func TestHandleSetXattr(t *testing.T) {
 			t.Fatalf("status = %d, want ROFS on pseudo-fs", res.Status)
 		}
 	})
+
+	t.Run("oversized value -> XATTR2BIG (RFC 8276 §11.2)", func(t *testing.T) {
+		b := newFakeXattrBackend()
+		// EITHER skips the GetXattr pre-check, so setErr surfaces directly.
+		b.setErr = metadata.ErrXattrTooLarge
+		h := xattrTestHandler(t, b)
+		res := h.handleSetXattr(xattrCtx(realHandle), encSetXattrArgs(types.SETXATTR4_EITHER, "foo", []byte("big")))
+		if res.Status != types.NFS4ERR_XATTR2BIG {
+			t.Fatalf("status = %d, want XATTR2BIG (not the generic INVAL)", res.Status)
+		}
+	})
 }
 
 // --- LISTXATTRS ---
@@ -406,6 +427,21 @@ func TestHandleRemoveXattr(t *testing.T) {
 		res := h.handleRemoveXattr(xattrCtx(realHandle), encRemoveXattrArgs("trusted.foo"))
 		if res.Status != types.NFS4ERR_NOXATTR {
 			t.Fatalf("status = %d, want NOXATTR", res.Status)
+		}
+	})
+
+	t.Run("stream-backed (pre-check passes, remove not-found) -> NOXATTR", func(t *testing.T) {
+		// Models a name that exists via the stream backing (GetXattr pre-check
+		// finds it) but whose RemoveXattr returns ErrNotFound because PR1 does
+		// not delete stream entities. RFC 8276 §11.2: surface NOXATTR, not the
+		// generic NOENT the store error maps to.
+		b := newFakeXattrBackend()
+		b.store["user.foo"] = []byte("v") // pre-check sees it
+		b.removeErr = &metadata.StoreError{Code: metadata.ErrNotFound, Message: "xattr not found"}
+		h := xattrTestHandler(t, b)
+		res := h.handleRemoveXattr(xattrCtx(realHandle), encRemoveXattrArgs("foo"))
+		if res.Status != types.NFS4ERR_NOXATTR {
+			t.Fatalf("status = %d, want NOXATTR (not NOENT)", res.Status)
 		}
 	})
 

--- a/internal/adapter/nfs/v4/handlers/xattr_test.go
+++ b/internal/adapter/nfs/v4/handlers/xattr_test.go
@@ -1,0 +1,490 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// realHandle is a valid-format real-FS handle ("shareName:uuid") accepted by
+// buildV4AuthContext with a nil registry (basic auth context).
+var realHandle = []byte("/export:00000000-0000-0000-0000-000000000001")
+
+// fakeXattrBackend is an in-memory XattrBackend for the NFSv4.2 xattr handler
+// tests. It keys on the store-canonical (user.-prefixed) name.
+type fakeXattrBackend struct {
+	store map[string][]byte
+	// forceErr, when set, is returned by every method (to exercise error mapping).
+	forceErr error
+}
+
+func newFakeXattrBackend() *fakeXattrBackend {
+	return &fakeXattrBackend{store: make(map[string][]byte)}
+}
+
+func (f *fakeXattrBackend) GetXattr(_ *metadata.AuthContext, _ metadata.FileHandle, name string) ([]byte, bool, error) {
+	if f.forceErr != nil {
+		return nil, false, f.forceErr
+	}
+	v, ok := f.store[name]
+	return v, ok, nil
+}
+
+func (f *fakeXattrBackend) SetXattr(_ *metadata.AuthContext, _ metadata.FileHandle, name string, value []byte) error {
+	if f.forceErr != nil {
+		return f.forceErr
+	}
+	f.store[name] = value
+	return nil
+}
+
+func (f *fakeXattrBackend) RemoveXattr(_ *metadata.AuthContext, _ metadata.FileHandle, name string) error {
+	if f.forceErr != nil {
+		return f.forceErr
+	}
+	delete(f.store, name)
+	return nil
+}
+
+func (f *fakeXattrBackend) ListXattr(_ *metadata.AuthContext, _ metadata.FileHandle) ([]string, error) {
+	if f.forceErr != nil {
+		return nil, f.forceErr
+	}
+	names := make([]string, 0, len(f.store))
+	for k := range f.store {
+		names = append(names, k)
+	}
+	return names, nil
+}
+
+// xattrTestHandler builds a handler wired with the given fake backend and a
+// pseudo-fs containing /export. Registry is nil, so buildV4AuthContext returns
+// a basic auth context and xattrChangeID is a best-effort no-op.
+func xattrTestHandler(t *testing.T, backend XattrBackend) *Handler {
+	t.Helper()
+	pfs := pseudofs.New()
+	pfs.Rebuild([]string{"/export"})
+	h := NewHandler(nil, pfs)
+	h.SetXattrBackend(backend)
+	return h
+}
+
+func xattrCtx(handle []byte) *types.CompoundContext {
+	uid := uint32(1000)
+	gid := uint32(1000)
+	return &types.CompoundContext{
+		Context:    context.Background(),
+		ClientAddr: "10.0.0.1:1234",
+		AuthFlavor: 1, // AUTH_UNIX
+		UID:        &uid,
+		GID:        &gid,
+		CurrentFH:  handle,
+	}
+}
+
+// --- arg encoders (mirror the RFC 8276 wire formats) ---
+
+func encGetXattrArgs(name string) io.Reader {
+	var buf bytes.Buffer
+	_ = xdr.WriteXDRString(&buf, name)
+	return bytes.NewReader(buf.Bytes())
+}
+
+func encSetXattrArgs(option uint32, name string, value []byte) io.Reader {
+	var buf bytes.Buffer
+	_ = xdr.WriteUint32(&buf, option)
+	_ = xdr.WriteXDRString(&buf, name)
+	_ = xdr.WriteXDROpaque(&buf, value)
+	return bytes.NewReader(buf.Bytes())
+}
+
+func encListXattrsArgs(cookie uint64, maxcount uint32) io.Reader {
+	var buf bytes.Buffer
+	_ = xdr.WriteUint64(&buf, cookie)
+	_ = xdr.WriteUint32(&buf, maxcount)
+	return bytes.NewReader(buf.Bytes())
+}
+
+func encRemoveXattrArgs(name string) io.Reader {
+	var buf bytes.Buffer
+	_ = xdr.WriteXDRString(&buf, name)
+	return bytes.NewReader(buf.Bytes())
+}
+
+// --- GETXATTR ---
+
+func TestHandleGetXattr(t *testing.T) {
+	t.Run("success strips and round-trips value", func(t *testing.T) {
+		b := newFakeXattrBackend()
+		b.store["user.foo"] = []byte("bar")
+		h := xattrTestHandler(t, b)
+
+		res := h.handleGetXattr(xattrCtx(realHandle), encGetXattrArgs("foo"))
+		if res.Status != types.NFS4_OK {
+			t.Fatalf("status = %d, want NFS4_OK", res.Status)
+		}
+		// res.Data = status(4) + opaque value
+		r := bytes.NewReader(res.Data)
+		st, _ := xdr.DecodeUint32(r)
+		if st != types.NFS4_OK {
+			t.Fatalf("encoded status = %d", st)
+		}
+		val, err := xdr.DecodeOpaque(r)
+		if err != nil {
+			t.Fatalf("decode value: %v", err)
+		}
+		if string(val) != "bar" {
+			t.Errorf("value = %q, want %q", val, "bar")
+		}
+	})
+
+	t.Run("missing -> NOXATTR", func(t *testing.T) {
+		h := xattrTestHandler(t, newFakeXattrBackend())
+		res := h.handleGetXattr(xattrCtx(realHandle), encGetXattrArgs("nope"))
+		if res.Status != types.NFS4ERR_NOXATTR {
+			t.Fatalf("status = %d, want NOXATTR", res.Status)
+		}
+	})
+
+	t.Run("non-user namespace rejected -> NOXATTR", func(t *testing.T) {
+		h := xattrTestHandler(t, newFakeXattrBackend())
+		res := h.handleGetXattr(xattrCtx(realHandle), encGetXattrArgs("system.posix_acl_access"))
+		if res.Status != types.NFS4ERR_NOXATTR {
+			t.Fatalf("status = %d, want NOXATTR for system.* namespace", res.Status)
+		}
+	})
+
+	t.Run("pseudo-fs -> NOTSUPP", func(t *testing.T) {
+		h := xattrTestHandler(t, newFakeXattrBackend())
+		ctx := xattrCtx(h.PseudoFS.GetRootHandle())
+		res := h.handleGetXattr(ctx, encGetXattrArgs("foo"))
+		if res.Status != types.NFS4ERR_NOTSUPP {
+			t.Fatalf("status = %d, want NOTSUPP on pseudo-fs", res.Status)
+		}
+	})
+
+	t.Run("no current FH -> NOFILEHANDLE", func(t *testing.T) {
+		h := xattrTestHandler(t, newFakeXattrBackend())
+		ctx := xattrCtx(nil)
+		res := h.handleGetXattr(ctx, encGetXattrArgs("foo"))
+		if res.Status != types.NFS4ERR_NOFILEHANDLE {
+			t.Fatalf("status = %d, want NOFILEHANDLE", res.Status)
+		}
+	})
+}
+
+// --- SETXATTR ---
+
+func TestHandleSetXattr(t *testing.T) {
+	t.Run("EITHER creates and canonicalizes to user.", func(t *testing.T) {
+		b := newFakeXattrBackend()
+		h := xattrTestHandler(t, b)
+		res := h.handleSetXattr(xattrCtx(realHandle), encSetXattrArgs(types.SETXATTR4_EITHER, "foo", []byte("v1")))
+		if res.Status != types.NFS4_OK {
+			t.Fatalf("status = %d, want NFS4_OK", res.Status)
+		}
+		if got := string(b.store["user.foo"]); got != "v1" {
+			t.Errorf("store[user.foo] = %q, want v1", got)
+		}
+		// res.Data = status(4) + change_info4 (20 bytes)
+		if len(res.Data) != 4+20 {
+			t.Errorf("res.Data len = %d, want 24", len(res.Data))
+		}
+	})
+
+	t.Run("CREATE on existing -> EXIST", func(t *testing.T) {
+		b := newFakeXattrBackend()
+		b.store["user.foo"] = []byte("x")
+		h := xattrTestHandler(t, b)
+		res := h.handleSetXattr(xattrCtx(realHandle), encSetXattrArgs(types.SETXATTR4_CREATE, "foo", []byte("y")))
+		if res.Status != types.NFS4ERR_EXIST {
+			t.Fatalf("status = %d, want EXIST", res.Status)
+		}
+	})
+
+	t.Run("REPLACE on missing -> NOXATTR", func(t *testing.T) {
+		h := xattrTestHandler(t, newFakeXattrBackend())
+		res := h.handleSetXattr(xattrCtx(realHandle), encSetXattrArgs(types.SETXATTR4_REPLACE, "foo", []byte("y")))
+		if res.Status != types.NFS4ERR_NOXATTR {
+			t.Fatalf("status = %d, want NOXATTR", res.Status)
+		}
+	})
+
+	t.Run("CREATE on missing succeeds", func(t *testing.T) {
+		b := newFakeXattrBackend()
+		h := xattrTestHandler(t, b)
+		res := h.handleSetXattr(xattrCtx(realHandle), encSetXattrArgs(types.SETXATTR4_CREATE, "foo", []byte("y")))
+		if res.Status != types.NFS4_OK {
+			t.Fatalf("status = %d, want NFS4_OK", res.Status)
+		}
+	})
+
+	t.Run("REPLACE on existing succeeds", func(t *testing.T) {
+		b := newFakeXattrBackend()
+		b.store["user.foo"] = []byte("x")
+		h := xattrTestHandler(t, b)
+		res := h.handleSetXattr(xattrCtx(realHandle), encSetXattrArgs(types.SETXATTR4_REPLACE, "foo", []byte("y")))
+		if res.Status != types.NFS4_OK {
+			t.Fatalf("status = %d, want NFS4_OK", res.Status)
+		}
+		if got := string(b.store["user.foo"]); got != "y" {
+			t.Errorf("store[user.foo] = %q, want y", got)
+		}
+	})
+
+	t.Run("invalid option -> INVAL", func(t *testing.T) {
+		h := xattrTestHandler(t, newFakeXattrBackend())
+		res := h.handleSetXattr(xattrCtx(realHandle), encSetXattrArgs(99, "foo", []byte("y")))
+		if res.Status != types.NFS4ERR_INVAL {
+			t.Fatalf("status = %d, want INVAL", res.Status)
+		}
+	})
+
+	t.Run("pseudo-fs -> ROFS", func(t *testing.T) {
+		h := xattrTestHandler(t, newFakeXattrBackend())
+		ctx := xattrCtx(h.PseudoFS.GetRootHandle())
+		res := h.handleSetXattr(ctx, encSetXattrArgs(types.SETXATTR4_EITHER, "foo", []byte("y")))
+		if res.Status != types.NFS4ERR_ROFS {
+			t.Fatalf("status = %d, want ROFS on pseudo-fs", res.Status)
+		}
+	})
+}
+
+// --- LISTXATTRS ---
+
+func TestHandleListXattrs(t *testing.T) {
+	t.Run("lists user names stripped, sorted, eof", func(t *testing.T) {
+		b := newFakeXattrBackend()
+		b.store["user.bbb"] = []byte("1")
+		b.store["user.aaa"] = []byte("2")
+		b.store["security.NTACL"] = []byte("hidden") // non-user: must be hidden
+		h := xattrTestHandler(t, b)
+
+		res := h.handleListXattrs(xattrCtx(realHandle), encListXattrsArgs(0, 1<<16))
+		if res.Status != types.NFS4_OK {
+			t.Fatalf("status = %d, want NFS4_OK", res.Status)
+		}
+		r := bytes.NewReader(res.Data)
+		_, _ = xdr.DecodeUint32(r) // status
+		cookie, _ := xdr.DecodeUint64(r)
+		count, _ := xdr.DecodeUint32(r)
+		if count != 2 {
+			t.Fatalf("name count = %d, want 2 (security.* hidden)", count)
+		}
+		names := make([]string, count)
+		for i := range names {
+			s, _ := xdr.DecodeString(r)
+			names[i] = s
+		}
+		eof, _ := xdr.DecodeBool(r)
+		if names[0] != "aaa" || names[1] != "bbb" {
+			t.Errorf("names = %v, want [aaa bbb]", names)
+		}
+		if cookie != 2 {
+			t.Errorf("cookie = %d, want 2", cookie)
+		}
+		if !eof {
+			t.Error("eof = false, want true")
+		}
+	})
+
+	t.Run("empty list eof true", func(t *testing.T) {
+		h := xattrTestHandler(t, newFakeXattrBackend())
+		res := h.handleListXattrs(xattrCtx(realHandle), encListXattrsArgs(0, 1<<16))
+		if res.Status != types.NFS4_OK {
+			t.Fatalf("status = %d, want NFS4_OK", res.Status)
+		}
+		r := bytes.NewReader(res.Data)
+		_, _ = xdr.DecodeUint32(r)
+		_, _ = xdr.DecodeUint64(r)
+		count, _ := xdr.DecodeUint32(r)
+		eof, _ := xdr.DecodeBool(r)
+		if count != 0 || !eof {
+			t.Errorf("count=%d eof=%v, want 0/true", count, eof)
+		}
+	})
+
+	t.Run("paging via cookie", func(t *testing.T) {
+		b := newFakeXattrBackend()
+		b.store["user.a"] = []byte("1")
+		b.store["user.b"] = []byte("2")
+		b.store["user.c"] = []byte("3")
+		h := xattrTestHandler(t, b)
+
+		// maxcount budget for exactly one short name per call:
+		// fixed 16 + one entry (4 + 1 byte name + 3 pad = 8) = 24.
+		res := h.handleListXattrs(xattrCtx(realHandle), encListXattrsArgs(0, 24))
+		r := bytes.NewReader(res.Data)
+		_, _ = xdr.DecodeUint32(r)
+		cookie, _ := xdr.DecodeUint64(r)
+		count, _ := xdr.DecodeUint32(r)
+		if count != 1 {
+			t.Fatalf("first page count = %d, want 1", count)
+		}
+		name0, _ := xdr.DecodeString(r)
+		eof, _ := xdr.DecodeBool(r)
+		if name0 != "a" || cookie != 1 || eof {
+			t.Fatalf("page1: name=%q cookie=%d eof=%v", name0, cookie, eof)
+		}
+
+		// Second page from cookie=1.
+		res2 := h.handleListXattrs(xattrCtx(realHandle), encListXattrsArgs(cookie, 24))
+		r2 := bytes.NewReader(res2.Data)
+		_, _ = xdr.DecodeUint32(r2)
+		_, _ = xdr.DecodeUint64(r2)
+		c2, _ := xdr.DecodeUint32(r2)
+		n2, _ := xdr.DecodeString(r2)
+		if c2 != 1 || n2 != "b" {
+			t.Fatalf("page2: count=%d name=%q", c2, n2)
+		}
+	})
+
+	t.Run("stale cookie -> BAD_COOKIE", func(t *testing.T) {
+		h := xattrTestHandler(t, newFakeXattrBackend())
+		res := h.handleListXattrs(xattrCtx(realHandle), encListXattrsArgs(5, 1<<16))
+		if res.Status != types.NFS4ERR_BAD_COOKIE {
+			t.Fatalf("status = %d, want BAD_COOKIE", res.Status)
+		}
+	})
+
+	t.Run("maxcount too small -> TOOSMALL", func(t *testing.T) {
+		b := newFakeXattrBackend()
+		b.store["user.longname"] = []byte("1")
+		h := xattrTestHandler(t, b)
+		res := h.handleListXattrs(xattrCtx(realHandle), encListXattrsArgs(0, 16))
+		if res.Status != types.NFS4ERR_TOOSMALL {
+			t.Fatalf("status = %d, want TOOSMALL", res.Status)
+		}
+	})
+
+	t.Run("pseudo-fs -> NOTSUPP", func(t *testing.T) {
+		h := xattrTestHandler(t, newFakeXattrBackend())
+		ctx := xattrCtx(h.PseudoFS.GetRootHandle())
+		res := h.handleListXattrs(ctx, encListXattrsArgs(0, 1<<16))
+		if res.Status != types.NFS4ERR_NOTSUPP {
+			t.Fatalf("status = %d, want NOTSUPP on pseudo-fs", res.Status)
+		}
+	})
+}
+
+// --- REMOVEXATTR ---
+
+func TestHandleRemoveXattr(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		b := newFakeXattrBackend()
+		b.store["user.foo"] = []byte("v")
+		h := xattrTestHandler(t, b)
+		res := h.handleRemoveXattr(xattrCtx(realHandle), encRemoveXattrArgs("foo"))
+		if res.Status != types.NFS4_OK {
+			t.Fatalf("status = %d, want NFS4_OK", res.Status)
+		}
+		if _, ok := b.store["user.foo"]; ok {
+			t.Error("user.foo still present after remove")
+		}
+		if len(res.Data) != 4+20 {
+			t.Errorf("res.Data len = %d, want 24 (status + change_info4)", len(res.Data))
+		}
+	})
+
+	t.Run("missing -> NOXATTR", func(t *testing.T) {
+		h := xattrTestHandler(t, newFakeXattrBackend())
+		res := h.handleRemoveXattr(xattrCtx(realHandle), encRemoveXattrArgs("foo"))
+		if res.Status != types.NFS4ERR_NOXATTR {
+			t.Fatalf("status = %d, want NOXATTR", res.Status)
+		}
+	})
+
+	t.Run("non-user namespace -> NOXATTR", func(t *testing.T) {
+		h := xattrTestHandler(t, newFakeXattrBackend())
+		res := h.handleRemoveXattr(xattrCtx(realHandle), encRemoveXattrArgs("trusted.foo"))
+		if res.Status != types.NFS4ERR_NOXATTR {
+			t.Fatalf("status = %d, want NOXATTR", res.Status)
+		}
+	})
+
+	t.Run("pseudo-fs -> ROFS", func(t *testing.T) {
+		h := xattrTestHandler(t, newFakeXattrBackend())
+		ctx := xattrCtx(h.PseudoFS.GetRootHandle())
+		res := h.handleRemoveXattr(ctx, encRemoveXattrArgs("foo"))
+		if res.Status != types.NFS4ERR_ROFS {
+			t.Fatalf("status = %d, want ROFS on pseudo-fs", res.Status)
+		}
+	})
+}
+
+// --- name canonicalization ---
+
+func TestCanonicalizeXattrName(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantName string
+		wantOK   bool
+	}{
+		{"foo", "user.foo", true},
+		{"user.foo", "user.foo", true},
+		{"system.posix_acl_access", "", false},
+		{"trusted.x", "", false},
+		{"security.NTACL", "", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		got, ok := canonicalizeXattrName(c.in)
+		if ok != c.wantOK || got != c.wantName {
+			t.Errorf("canonicalizeXattrName(%q) = (%q,%v), want (%q,%v)", c.in, got, ok, c.wantName, c.wantOK)
+		}
+	}
+}
+
+func TestStripXattrPrefix(t *testing.T) {
+	if got := stripXattrPrefix("user.foo"); got != "foo" {
+		t.Errorf("stripXattrPrefix(user.foo) = %q, want foo", got)
+	}
+	if got := stripXattrPrefix("foo"); got != "foo" {
+		t.Errorf("stripXattrPrefix(foo) = %q, want foo", got)
+	}
+}
+
+// --- v4.2 op gating in dispatchOne ---
+
+// TestXattrOpsGatedToV42 verifies that the RFC 8276 xattr ops are dispatched
+// only under v4.2 (isV42=true) and return NFS4ERR_NOTSUPP under v4.0/v4.1.
+func TestXattrOpsGatedToV42(t *testing.T) {
+	b := newFakeXattrBackend()
+	b.store["user.foo"] = []byte("bar")
+	h := xattrTestHandler(t, b)
+
+	for _, op := range []uint32{types.OP_GETXATTR, types.OP_SETXATTR, types.OP_LISTXATTRS, types.OP_REMOVEXATTR} {
+		// Under v4.1 (isV42=false): NOTSUPP, args not consumed.
+		ctx := xattrCtx(realHandle)
+		res := h.dispatchOne(ctx, nil, op, bytes.NewReader(nil), true, false)
+		if res.Status != types.NFS4ERR_NOTSUPP {
+			t.Errorf("%s under v4.1: status = %d, want NOTSUPP", types.OpName(op), res.Status)
+		}
+	}
+
+	// Under v4.2 (isV42=true): GETXATTR with valid args reaches the handler.
+	ctx := xattrCtx(realHandle)
+	res := h.dispatchOne(ctx, nil, types.OP_GETXATTR, encGetXattrArgs("foo"), true, true)
+	if res.Status != types.NFS4_OK {
+		t.Errorf("GETXATTR under v4.2: status = %d, want NFS4_OK", res.Status)
+	}
+}
+
+// --- backend error mapping ---
+
+func TestXattrBackendErrorMapping(t *testing.T) {
+	b := newFakeXattrBackend()
+	b.forceErr = errors.New("boom")
+	h := xattrTestHandler(t, b)
+	res := h.handleGetXattr(xattrCtx(realHandle), encGetXattrArgs("foo"))
+	if res.Status == types.NFS4_OK {
+		t.Fatalf("expected non-OK status on backend error, got OK")
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/xattr_test.go
+++ b/internal/adapter/nfs/v4/handlers/xattr_test.go
@@ -465,6 +465,7 @@ func TestCanonicalizeXattrName(t *testing.T) {
 	}{
 		{"foo", "user.foo", true},
 		{"user.foo", "user.foo", true},
+		{"user.", "", false}, // bare prefix, no key -> invalid
 		{"system.posix_acl_access", "", false},
 		{"trusted.x", "", false},
 		{"security.NTACL", "", false},

--- a/internal/adapter/nfs/v4/types/constants.go
+++ b/internal/adapter/nfs/v4/types/constants.go
@@ -146,6 +146,20 @@ const (
 )
 
 // ============================================================================
+// NFSv4.2 Operation Numbers (nfs_opnum4)
+// ============================================================================
+//
+// Per RFC 8276 Section 8.6 (extended attributes for NFSv4.2). DittoFS
+// implements only the four RFC 8276 xattr operations from the v4.2 op range.
+
+const (
+	OP_GETXATTR    = 72 // GETXATTR (RFC 8276 Section 8.6)
+	OP_SETXATTR    = 73 // SETXATTR (RFC 8276 Section 8.6)
+	OP_LISTXATTRS  = 74 // LISTXATTRS (RFC 8276 Section 8.6)
+	OP_REMOVEXATTR = 75 // REMOVEXATTR (RFC 8276 Section 8.6)
+)
+
+// ============================================================================
 // NFSv4 Error Codes (nfsstat4)
 // ============================================================================
 //
@@ -267,6 +281,19 @@ const (
 	NFS4ERR_REJECT_DELEG     = 10085 // Reject delegation
 	NFS4ERR_RETURNCONFLICT   = 10086 // Return conflict
 	NFS4ERR_DELEG_REVOKED    = 10087 // Delegation revoked
+)
+
+// --- NFSv4.2 / RFC 8276 Extended Attribute Error Codes ---
+
+const (
+	// NFS4ERR_NOXATTR indicates the named extended attribute does not exist
+	// (RFC 8276 Section 11.2). Returned by GETXATTR/REMOVEXATTR for a missing
+	// xattr and by SETXATTR with SETXATTR4_REPLACE on a missing xattr.
+	NFS4ERR_NOXATTR = 10095
+
+	// NFS4ERR_XATTR2BIG indicates the xattr value (or, for LISTXATTRS, the
+	// reply) exceeds an implementation limit (RFC 8276 Section 11.2).
+	NFS4ERR_XATTR2BIG = 10096
 )
 
 // ============================================================================
@@ -455,6 +482,35 @@ const (
 const (
 	// NFS4_MINOR_VERSION_1 indicates NFSv4.1 per RFC 8881.
 	NFS4_MINOR_VERSION_1 = 1
+
+	// NFS4_MINOR_VERSION_2 indicates NFSv4.2 per RFC 7862. DittoFS implements
+	// only the RFC 8276 extended-attribute operations from this minor version.
+	NFS4_MINOR_VERSION_2 = 2
+)
+
+// ============================================================================
+// NFSv4.2 Extended Attribute ACCESS Bits (RFC 8276 Section 8.1)
+// ============================================================================
+//
+// These augment the RFC 7530 ACCESS4_* bits and describe access to a file's
+// named (extended) attributes rather than its data.
+
+const (
+	ACCESS4_XAREAD  = 0x00000040 // read extended attributes
+	ACCESS4_XAWRITE = 0x00000080 // write/create/remove extended attributes
+	ACCESS4_XALIST  = 0x00000100 // list extended attribute names
+)
+
+// ============================================================================
+// NFSv4.2 SETXATTR option (setxattr_option4) (RFC 8276 Section 8.6)
+// ============================================================================
+//
+// Controls create-vs-replace semantics for the SETXATTR operation.
+
+const (
+	SETXATTR4_EITHER  = 0 // create the xattr or replace an existing one
+	SETXATTR4_CREATE  = 1 // create only; NFS4ERR_EXIST if it already exists
+	SETXATTR4_REPLACE = 2 // replace only; NFS4ERR_NOXATTR if it is missing
 )
 
 // ============================================================================
@@ -690,6 +746,15 @@ func OpName(op uint32) string {
 		return "DESTROY_CLIENTID"
 	case OP_RECLAIM_COMPLETE:
 		return "RECLAIM_COMPLETE"
+	// --- NFSv4.2 / RFC 8276 Extended Attribute Operations ---
+	case OP_GETXATTR:
+		return "GETXATTR"
+	case OP_SETXATTR:
+		return "SETXATTR"
+	case OP_LISTXATTRS:
+		return "LISTXATTRS"
+	case OP_REMOVEXATTR:
+		return "REMOVEXATTR"
 	default:
 		return "UNKNOWN"
 	}
@@ -792,6 +857,12 @@ func init() {
 		"WANT_DELEGATION":      OP_WANT_DELEGATION,
 		"DESTROY_CLIENTID":     OP_DESTROY_CLIENTID,
 		"RECLAIM_COMPLETE":     OP_RECLAIM_COMPLETE,
+
+		// --- NFSv4.2 / RFC 8276 Extended Attribute Operations ---
+		"GETXATTR":    OP_GETXATTR,
+		"SETXATTR":    OP_SETXATTR,
+		"LISTXATTRS":  OP_LISTXATTRS,
+		"REMOVEXATTR": OP_REMOVEXATTR,
 	}
 }
 

--- a/internal/controlplane/api/handlers/adapter_settings.go
+++ b/internal/controlplane/api/handlers/adapter_settings.go
@@ -272,8 +272,8 @@ func (h *AdapterSettingsHandler) GetDefaults(w http.ResponseWriter, r *http.Requ
 				"preferred_transfer_size":        {Min: ranges.PreferredTransferSizeMin, Max: ranges.PreferredTransferSizeMax},
 				"max_delegations":                {Min: 0, Max: 1000000},
 				"dir_deleg_batch_window_ms":      {Min: 0, Max: 5000},
-				"v4_min_minor_version":           {Min: 0, Max: 1},
-				"v4_max_minor_version":           {Min: 0, Max: 1},
+				"v4_min_minor_version":           {Min: 0, Max: 2},
+				"v4_max_minor_version":           {Min: 0, Max: 2},
 				"v4_max_connections_per_session": {Min: 0, Max: 1024},
 				"portmapper_port":                {Min: ranges.PortmapperPortMin, Max: ranges.PortmapperPortMax},
 			},
@@ -756,8 +756,8 @@ func validateNFSSettings(s *models.NFSAdapterSettings) map[string]string {
 	validateIntRange(errs, "portmapper_port", s.PortmapperPort, ranges.PortmapperPortMin, ranges.PortmapperPortMax)
 	validateIntRange(errs, "max_delegations", s.MaxDelegations, 0, 1000000)
 	validateIntRange(errs, "dir_deleg_batch_window_ms", s.DirDelegBatchWindowMs, 0, 5000)
-	validateIntRange(errs, "v4_min_minor_version", s.V4MinMinorVersion, 0, 1)
-	validateIntRange(errs, "v4_max_minor_version", s.V4MaxMinorVersion, 0, 1)
+	validateIntRange(errs, "v4_min_minor_version", s.V4MinMinorVersion, 0, 2)
+	validateIntRange(errs, "v4_max_minor_version", s.V4MaxMinorVersion, 0, 2)
 	if s.V4MinMinorVersion > s.V4MaxMinorVersion {
 		errs["v4_min_minor_version"] = "must be <= v4_max_minor_version"
 	}

--- a/pkg/controlplane/models/adapter_settings.go
+++ b/pkg/controlplane/models/adapter_settings.go
@@ -65,9 +65,9 @@ type NFSAdapterSettings struct {
 	MaxDelegations        int  `gorm:"default:10000" json:"max_delegations"`        // max total outstanding delegations (file + directory combined)
 	DirDelegBatchWindowMs int  `gorm:"default:50" json:"dir_deleg_batch_window_ms"` // notification batching window in milliseconds
 
-	// NFSv4 minor version range (0=v4.0, 1=v4.1)
+	// NFSv4 minor version range (0=v4.0, 1=v4.1, 2=v4.2 RFC 8276 xattr ops)
 	V4MinMinorVersion int `gorm:"default:0" json:"v4_min_minor_version"` // minimum NFSv4 minor version
-	V4MaxMinorVersion int `gorm:"default:1" json:"v4_max_minor_version"` // maximum NFSv4 minor version
+	V4MaxMinorVersion int `gorm:"default:2" json:"v4_max_minor_version"` // maximum NFSv4 minor version
 
 	// TODO: Wire NFSv4.1 session limits into StateManager (these fields are not yet active; future: settings watcher).
 	V4MaxSessionSlots          int `gorm:"default:64" json:"v4_max_session_slots"`           // fore channel max slots per session
@@ -224,7 +224,7 @@ func NewDefaultNFSSettings(adapterID string) *NFSAdapterSettings {
 		MaxDelegations:             10000,
 		DirDelegBatchWindowMs:      50,
 		V4MinMinorVersion:          0,
-		V4MaxMinorVersion:          1,
+		V4MaxMinorVersion:          2,
 		V4MaxSessionSlots:          64,
 		V4MaxSessionsPerClient:     16,
 		V4MaxConnectionsPerSession: 16,

--- a/pkg/metadata/xattr_service.go
+++ b/pkg/metadata/xattr_service.go
@@ -47,7 +47,10 @@ func (s *Service) SetXattr(ctx *AuthContext, handle FileHandle, name string, val
 		return err
 	}
 	if ctx.ShareReadOnly {
-		return &StoreError{Code: ErrAccessDenied, Message: "read-only share: xattr write denied"}
+		// ErrReadOnly (→ NFS4ERR_ROFS / EROFS), not ErrAccessDenied, so a
+		// read-only share surfaces "read-only file system" rather than
+		// "permission denied" — matching the pseudo-fs NFS4ERR_ROFS path.
+		return &StoreError{Code: ErrReadOnly, Message: "read-only share: xattr write denied"}
 	}
 	if err := s.checkWritePermission(ctx, handle); err != nil {
 		logger.Debug("SetXattr: write permission denied", "name", name, "error", err)
@@ -65,7 +68,8 @@ func (s *Service) RemoveXattr(ctx *AuthContext, handle FileHandle, name string) 
 		return err
 	}
 	if ctx.ShareReadOnly {
-		return &StoreError{Code: ErrAccessDenied, Message: "read-only share: xattr remove denied"}
+		// ErrReadOnly (→ NFS4ERR_ROFS / EROFS); see SetXattr.
+		return &StoreError{Code: ErrReadOnly, Message: "read-only share: xattr remove denied"}
 	}
 	if err := s.checkWritePermission(ctx, handle); err != nil {
 		logger.Debug("RemoveXattr: write permission denied", "name", name, "error", err)

--- a/pkg/metadata/xattr_test.go
+++ b/pkg/metadata/xattr_test.go
@@ -1,0 +1,81 @@
+package metadata_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/stretchr/testify/require"
+)
+
+// TestServiceXattrRoundTrip exercises the metadata Service xattr accessors
+// (the scaffolding backing the NFSv4.2 / RFC 8276 handlers) against a real
+// memory store: set, get, list, remove. EA storage is shared with SMB, so names
+// round-trip case-insensitively.
+func TestServiceXattrRoundTrip(t *testing.T) {
+	fx := newTestFixture(t)
+	ctx := fx.rootContext()
+
+	file, _, err := fx.service.CreateFile(ctx, fx.rootHandle, "x.txt", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular,
+		Mode: 0o644,
+	})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeFileHandle(file)
+	require.NoError(t, err)
+
+	// Missing xattr.
+	_, found, err := fx.service.GetXattr(ctx, handle, "user.foo")
+	require.NoError(t, err)
+	require.False(t, found)
+
+	// Set + get.
+	require.NoError(t, fx.service.SetXattr(ctx, handle, "user.foo", []byte("bar")))
+	val, found, err := fx.service.GetXattr(ctx, handle, "user.foo")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "bar", string(val))
+
+	// Returned value is a copy (mutating it must not corrupt the store).
+	val[0] = 'X'
+	val2, _, err := fx.service.GetXattr(ctx, handle, "user.foo")
+	require.NoError(t, err)
+	require.Equal(t, "bar", string(val2))
+
+	// Second name + list.
+	require.NoError(t, fx.service.SetXattr(ctx, handle, "user.baz", []byte("qux")))
+	names, err := fx.service.ListXattr(ctx, handle)
+	require.NoError(t, err)
+	sort.Strings(names)
+	require.Equal(t, []string{"user.baz", "user.foo"}, names)
+
+	// Remove.
+	require.NoError(t, fx.service.RemoveXattr(ctx, handle, "user.foo"))
+	_, found, err = fx.service.GetXattr(ctx, handle, "user.foo")
+	require.NoError(t, err)
+	require.False(t, found)
+
+	names, err = fx.service.ListXattr(ctx, handle)
+	require.NoError(t, err)
+	require.Equal(t, []string{"user.baz"}, names)
+}
+
+// TestServiceXattrCaseInsensitive verifies the EA-name case-insensitivity
+// (MS-FSCC §2.4.15) shared with SMB carries over to the xattr accessors.
+func TestServiceXattrCaseInsensitive(t *testing.T) {
+	fx := newTestFixture(t)
+	ctx := fx.rootContext()
+
+	file, _, err := fx.service.CreateFile(ctx, fx.rootHandle, "ci.txt", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular,
+		Mode: 0o644,
+	})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeFileHandle(file)
+	require.NoError(t, err)
+
+	require.NoError(t, fx.service.SetXattr(ctx, handle, "user.Foo", []byte("v")))
+	_, found, err := fx.service.GetXattr(ctx, handle, "user.foo")
+	require.NoError(t, err)
+	require.True(t, found, "GetXattr must resolve case-insensitively")
+}


### PR DESCRIPTION
## PR2 of #1285 — NFSv4.2 minorversion + the four RFC 8276 xattr ops

Adds NFSv4.2 minorversion negotiation and the four RFC 8276 extended-attribute operations (GETXATTR, SETXATTR, LISTXATTRS, REMOVEXATTR) to the NFSv4 server.

Runs **in parallel with the metadata-resolver PR (PR1)** and is decoupled via dependency inversion: the handlers depend on a small `XattrBackend` interface owned by the nfs handlers package, which `*metadata.Service` satisfies structurally. PR1's unified resolver swaps in transparently.

### What's here

**Constants** (`v4/types/constants.go`)
- Op numbers `OP_GETXATTR=72`, `OP_SETXATTR=73`, `OP_LISTXATTRS=74`, `OP_REMOVEXATTR=75`
- `NFS4_MINOR_VERSION_2=2`
- Errors `NFS4ERR_NOXATTR=10095`, `NFS4ERR_XATTR2BIG=10096`
- ACCESS bits `ACCESS4_XAREAD=0x40 / XAWRITE=0x80 / XALIST=0x100`
- `setxattr_option4` (EITHER/CREATE/REPLACE)
- `OpName` + `OpNameToNum` cases

All numbers verified against **RFC 8276 §8.6 / §11** — every value in the spec matched the task; nothing needed correcting.

**Minorversion negotiation** (`v4/handlers/{compound,handler}.go`)
- Default `maxMinorVersion=2`; settings validation range `[0,2]` (both sites in `adapter_settings.go`); model default bumped 1→2.
- v4.2 reuses the entire v4.1 SEQUENCE/session machinery (RFC 7862 builds on RFC 8881) via an `isV42` flag threaded through `dispatchOne`/`runCompoundOps`.
- Ops 72-75 gated to v4.2-only (NOTSUPP under v4.0/v4.1), mirroring the existing `v40OnlyOps` pattern; `maxValidOpCode` extends to 75 under v4.2.

**Handlers** (`v4/handlers/{getxattr,setxattr,listxattrs,removexattr}.go`)
- Exact RFC 8276 wire formats. SETXATTR/LISTXATTRS/REMOVEXATTR carry **no stateid**.
- CREATE-on-existing → `NFS4ERR_EXIST`; REPLACE-on-missing / GET / REMOVE-missing → `NFS4ERR_NOXATTR`.
- `change_info4` from the file's change attribute (ctime) via `encodeChangeInfo4`.
- Pseudo-fs → `NFS4ERR_NOTSUPP` (get/list) / `NFS4ERR_ROFS` (set/remove).

**Namespace**: Linux carries only `user.` (prefix stripped on wire). Canonicalized to `user.<name>` before the backend, stripped on read (so names match SMB EAs); non-`user.` namespaces rejected with `NFS4ERR_NOXATTR`.

**Capability** (`v4/attrs/encode.go`): `FATTR4_XATTR_SUPPORT` (bit 82 → word 2, offset 18) advertised in `SupportedAttrs()` and encoded (true for real files, false for pseudo-fs).

**PR1 dependency handling**: compiles standalone. The 4 `XattrBackend` methods are added to `*metadata.Service` (`pkg/metadata/xattr.go`) as a thin, **functional** implementation backed by the existing per-file EA map (`File.EAs` / `SetAttrs.EAMutations` — the same storage SMB FILE_FULL_EA_INFORMATION uses, so NFS and SMB share one namespace), clearly marked `TODO(#1285 PR1)` for replacement by the unified resolver. Unit tests use a fake `XattrBackend`.

### Tests
- Per-op XDR + handler behavior with a fake backend (success, missing→NOXATTR, CREATE/REPLACE/EITHER semantics, namespace reject, pseudo-fs, LISTXATTRS paging/cookie/eof/TOOSMALL, backend error mapping, v4.2-only gating).
- `metadata` Service xattr round-trip (set/get/list/remove + case-insensitivity + value-copy) against a real memory store.
- attrs FATTR4_XATTR_SUPPORT bit/word math + encode.
- Updated existing compound tests that assumed v4.2 was unsupported.

`go build ./...`, `go vet ./...`, `gofmt -l` all clean; full `./internal/adapter/nfs/...` + `./pkg/metadata/` + controlplane settings tests green (incl. `-race`).