### PR TITLE
fix(nfs): validate xattr component4 names + correct namespace doc (#1285 follow-up)

### DIFF
--- a/internal/adapter/nfs/v4/handlers/getxattr.go
+++ b/internal/adapter/nfs/v4/handlers/getxattr.go
@@ -36,6 +36,11 @@ func (h *Handler) handleGetXattr(ctx *types.CompoundContext, reader io.Reader) *
 	if err != nil {
 		return xattrErr(types.OP_GETXATTR, types.NFS4ERR_BADXDR)
 	}
+	// gxa_name is a component4: reject invalid UTF-8 / NUL / '/' before it
+	// reaches canonicalization and the backend (matches LOOKUP/CREATE/REMOVE).
+	if status := types.ValidateUTF8Filename(name); status != types.NFS4_OK {
+		return xattrErr(types.OP_GETXATTR, status)
+	}
 
 	if pseudofs.IsPseudoFSHandle(ctx.CurrentFH) {
 		return xattrErr(types.OP_GETXATTR, types.NFS4ERR_NOTSUPP)

--- a/internal/adapter/nfs/v4/handlers/removexattr.go
+++ b/internal/adapter/nfs/v4/handlers/removexattr.go
@@ -37,6 +37,11 @@ func (h *Handler) handleRemoveXattr(ctx *types.CompoundContext, reader io.Reader
 	if err != nil {
 		return xattrErr(types.OP_REMOVEXATTR, types.NFS4ERR_BADXDR)
 	}
+	// rxa_name is a component4: reject invalid UTF-8 / NUL / '/' before
+	// canonicalization (matches LOOKUP/CREATE/REMOVE).
+	if status := types.ValidateUTF8Filename(name); status != types.NFS4_OK {
+		return xattrErr(types.OP_REMOVEXATTR, status)
+	}
 
 	if pseudofs.IsPseudoFSHandle(ctx.CurrentFH) {
 		return xattrErr(types.OP_REMOVEXATTR, types.NFS4ERR_ROFS)

--- a/internal/adapter/nfs/v4/handlers/setxattr.go
+++ b/internal/adapter/nfs/v4/handlers/setxattr.go
@@ -50,6 +50,11 @@ func (h *Handler) handleSetXattr(ctx *types.CompoundContext, reader io.Reader) *
 	if err != nil {
 		return xattrErr(types.OP_SETXATTR, types.NFS4ERR_BADXDR)
 	}
+	// sxa_key is a component4: reject invalid UTF-8 / NUL / '/' before any
+	// canonicalization or backing-store write (matches LOOKUP/CREATE/REMOVE).
+	if status := types.ValidateUTF8Filename(name); status != types.NFS4_OK {
+		return xattrErr(types.OP_SETXATTR, status)
+	}
 	// DecodeOpaque enforces a generic 1 MiB XDR cap. A value over our 64 KiB
 	// inline ceiling but within that cap decodes here and the store returns
 	// ErrXattrTooLarge -> NFS4ERR_XATTR2BIG below. A value over 1 MiB is

--- a/internal/adapter/nfs/v4/handlers/xattr_backend.go
+++ b/internal/adapter/nfs/v4/handlers/xattr_backend.go
@@ -60,13 +60,15 @@ func xattrBackendForHandler(h *Handler) (XattrBackend, error) {
 const xattrUserPrefix = "user."
 
 // canonicalizeXattrName maps a wire xattr name to its store-canonical form
-// ("user.<name>"). It returns ok=false when the name is in an unsupported
-// namespace (a name containing a "." that is not "user."), which the caller
-// maps to NFS4ERR_NOXATTR.
+// ("user.<name>"). It returns ok=false (caller → NFS4ERR_NOXATTR) only for a
+// name in a reserved non-user namespace — one whose first dot-segment is
+// "system", "trusted", or "security". Any other bare name is placed in the
+// user namespace, INCLUDING dotted names like "foo.bar" (a valid user xattr,
+// e.g. "com.apple.metadata:…"), which become "user.foo.bar".
 //
 // The Linux client strips "user." so names usually arrive bare; a name that
-// already carries the "user." prefix (other clients, or a name literally
-// containing a dot) is accepted as-is.
+// already carries the "user." prefix is accepted as-is (the bare prefix
+// "user." with no key is rejected).
 func canonicalizeXattrName(name string) (canonical string, ok bool) {
 	if name == "" {
 		return "", false

--- a/internal/adapter/nfs/v4/handlers/xattr_test.go
+++ b/internal/adapter/nfs/v4/handlers/xattr_test.go
@@ -171,6 +171,14 @@ func TestHandleGetXattr(t *testing.T) {
 		}
 	})
 
+	t.Run("invalid component4 name ('/') -> BADNAME", func(t *testing.T) {
+		h := xattrTestHandler(t, newFakeXattrBackend())
+		res := h.handleGetXattr(xattrCtx(realHandle), encGetXattrArgs("bad/name"))
+		if res.Status != types.NFS4ERR_BADNAME {
+			t.Fatalf("status = %d, want BADNAME", res.Status)
+		}
+	})
+
 	t.Run("pseudo-fs -> NOTSUPP", func(t *testing.T) {
 		h := xattrTestHandler(t, newFakeXattrBackend())
 		ctx := xattrCtx(h.PseudoFS.GetRootHandle())
@@ -465,7 +473,9 @@ func TestCanonicalizeXattrName(t *testing.T) {
 	}{
 		{"foo", "user.foo", true},
 		{"user.foo", "user.foo", true},
-		{"user.", "", false}, // bare prefix, no key -> invalid
+		{"user.", "", false},              // bare prefix, no key -> invalid
+		{"foo.bar", "user.foo.bar", true}, // dotted non-reserved name -> user.*
+		{"com.apple.x", "user.com.apple.x", true},
 		{"system.posix_acl_access", "", false},
 		{"trusted.x", "", false},
 		{"security.NTACL", "", false},


### PR DESCRIPTION
Follow-up to #1295 (merged) addressing the second Copilot review round, which landed after #1295 was merged so its fixes were not included.

## Changes
- **component4 validation**: GETXATTR/SETXATTR/REMOVEXATTR now run `types.ValidateUTF8Filename` on the decoded xattr name before canonicalization, rejecting invalid UTF-8 / NUL / `/` with BADCHAR/BADNAME/INVAL — consistent with LOOKUP/CREATE/REMOVE — instead of passing them to the backend.
- **doc/impl alignment**: corrected `canonicalizeXattrName` doc to match the implementation. Only the reserved `system`/`trusted`/`security` namespaces are rejected; other dotted names (e.g. `com.apple.x`) are valid user xattrs → `user.<name>`.
- tests: component4 `/` → BADNAME; dotted-name canonicalization (`foo.bar`→`user.foo.bar`, `com.apple.x`→`user.com.apple.x`).

Pure NFSv4.2 xattr-handler hardening; no behavior change for valid names.