### PR TITLE
feat(adapter): log COMMIT/CLOSE durability decision at DEBUG (#1245)

### DIFF
--- a/internal/adapter/common/write_payload.go
+++ b/internal/adapter/common/write_payload.go
@@ -120,19 +120,24 @@ func CommitBlockStore(
 	// means the bytes already survive a restart regardless of Finalized. This
 	// single DEBUG line surfaces the exact (Finalized, local/remote durable)
 	// inputs so a saturated-CLOSE trace can confirm there is no silent window
-	// without adding a log line to the common (durable) hot path's behaviour.
+	// without adding a log line to the common (durable) hot path's behavior.
+	// The booleans below feed the decision logic regardless of log level, so
+	// only the DebugCtx call itself (the string conversion + variadic boxing)
+	// is guarded to keep the ack path allocation-free when DEBUG is disabled.
 	finalized := res != nil && res.Finalized
 	localDurable := blockStore.LocalDurable()
 	remoteDurable := blockStore.RemoteDurable()
 	requireDurable := blockStore.RequireDurableCommit()
-	logger.DebugCtx(ctx, "COMMIT/CLOSE flush decision",
-		"payloadID", string(payloadID),
-		"finalized", finalized,
-		"localDurable", localDurable,
-		"remoteDurable", remoteDurable,
-		"requireDurableCommit", requireDurable,
-		"durableAtAck", localDurable || (finalized && remoteDurable),
-	)
+	if logger.IsDebugEnabled() {
+		logger.DebugCtx(ctx, "COMMIT/CLOSE flush decision",
+			"payloadID", string(payloadID),
+			"finalized", finalized,
+			"localDurable", localDurable,
+			"remoteDurable", remoteDurable,
+			"requireDurableCommit", requireDurable,
+			"durableAtAck", localDurable || (finalized && remoteDurable),
+		)
+	}
 
 	// DEFAULT: strict durability enforcement is opt-in. A successful flush is
 	// enough to ack — the remote mirror stays async and observable.

--- a/internal/adapter/common/write_payload.go
+++ b/internal/adapter/common/write_payload.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block/engine"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
@@ -111,19 +112,41 @@ func CommitBlockStore(
 		// Hard error: unchanged behavior (mapped via the content errmap).
 		return err
 	}
+
+	// Observability (#1245): record the per-store durability decision at the
+	// ack point. engine.Flush returning nil only means the flush pump did not
+	// fault; in the DEFAULT (async) policy Finalized may still be false while
+	// the remote mirror catches up, and localDurable=true (fs local store)
+	// means the bytes already survive a restart regardless of Finalized. This
+	// single DEBUG line surfaces the exact (Finalized, local/remote durable)
+	// inputs so a saturated-CLOSE trace can confirm there is no silent window
+	// without adding a log line to the common (durable) hot path's behaviour.
+	finalized := res != nil && res.Finalized
+	localDurable := blockStore.LocalDurable()
+	remoteDurable := blockStore.RemoteDurable()
+	requireDurable := blockStore.RequireDurableCommit()
+	logger.DebugCtx(ctx, "COMMIT/CLOSE flush decision",
+		"payloadID", string(payloadID),
+		"finalized", finalized,
+		"localDurable", localDurable,
+		"remoteDurable", remoteDurable,
+		"requireDurableCommit", requireDurable,
+		"durableAtAck", localDurable || (finalized && remoteDurable),
+	)
+
 	// DEFAULT: strict durability enforcement is opt-in. A successful flush is
 	// enough to ack — the remote mirror stays async and observable.
-	if !blockStore.RequireDurableCommit() {
+	if !requireDurable {
 		return nil
 	}
 	// FAST path: a durable local store means the bytes already survive a
 	// restart; ack without waiting for the async remote mirror.
-	if blockStore.LocalDurable() {
+	if localDurable {
 		return nil
 	}
 	// Local store is volatile: success requires the data to have reached a
 	// durable remote (Finalized AND the remote is itself durable).
-	if res != nil && res.Finalized && blockStore.RemoteDurable() {
+	if finalized && remoteDurable {
 		return nil
 	}
 	// Not yet durable anywhere that survives a crash — report so the client


### PR DESCRIPTION
## What

Adds one `DebugCtx` line at the `CommitBlockStore` ack point (the seam shared by NFSv3 COMMIT, NFSv4 COMMIT, SMB CLOSE) recording the exact per-store durability inputs:

```
finalized, localDurable, remoteDurable, requireDurableCommit, durableAtAck
```

## Why

Follow-up to #1245. Reporter confirmed the silent-truncation fix (#1267 + #1274) round-trips **8/8 byte-perfect** on `develop`, but asked *"which log level surfaces the engine.Flush Finalized/err decision?"* so a deliberately-saturated-CLOSE trace can prove there is no residual silent window.

Answer today: **no line emits `res.Finalized`** — on hard error it's `WARN "CLOSE: flush failed"`, on success `DEBUG "CLOSE: flushed"` (which drops Finalized). This patch fills that gap.

## Behaviour

- **No ack-path change** — pure observability. The decision logic (`localDurable || (finalized && remoteDurable)`, gated on `require_durable_commit`) is unchanged; the booleans are just hoisted into locals and logged.
- DEBUG level only (per CLAUDE.md invariant #6: expected outcomes log at Debug), so the durable hot path stays quiet by default.
- Run with `DITTOFS_LOGGING_LEVEL=DEBUG` to capture the decision under a saturated CLOSE.

## Test

`go build` / `go vet` / `go test ./internal/adapter/common/` green; existing `commit_durability_test.go` covers the decision logic (unchanged).