### PR TITLE
fix(ldap): tolerate Samba AD-DC negative-serial TLS certs (#1289)

### DIFF
--- a/cmd/dfs/main.go
+++ b/cmd/dfs/main.go
@@ -1,3 +1,12 @@
+// Tolerate X.509 certificates with negative serial numbers. Samba AD-DC
+// auto-generates self-signed TLS certs that commonly have a negative serial,
+// which Go's crypto/x509 rejects at parse time (since Go 1.23) — before TLS
+// verification runs, so ldap.tls.insecure_skip_verify cannot bypass it. This
+// bakes the tolerance into the dfs binary so LDAPS against a default Samba
+// AD-DC works without a manual GODEBUG env var. See issue #1289. Production
+// directories should still use a properly-issued DC certificate.
+//
+//go:debug x509negativeserial=1
 package main
 
 import (

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1604,6 +1604,15 @@ Admin-configured identity links (`dfsctl idmap add`) take precedence over the
 directory query: a link for an `ldap` external ID resolves to the mapped local
 user before any LDAP search is issued.
 
+**Samba AD-DC self-signed certificates.** A default Samba AD-DC serves an
+auto-generated TLS certificate that commonly has a *negative serial number*.
+Go's `crypto/x509` rejects such certificates at parse time — before TLS
+verification runs — so `ldap.tls.insecure_skip_verify` does **not** bypass it.
+The `dfs` binary is built with `x509negativeserial=1` so `ldaps://` against a
+default Samba AD-DC works out of the box. For production directories, prefer a
+properly-issued DC certificate (the Go toggle is slated for removal in a future
+release).
+
 ## Migration
 
 ### Required when upgrading from v0.15.x or earlier


### PR DESCRIPTION
## Problem
`ldaps://` against a default Samba AD-DC fails:
```
tls: failed to parse certificate from server: x509: negative serial number
```
Go's `crypto/x509` rejects negative-serial certificates **at parse time** (since Go 1.23), *before* TLS verification — so `ldap.tls.insecure_skip_verify` cannot bypass it. Samba AD-DC auto-generated self-signed certs commonly carry a negative serial, so the AD/LDAP idmap can't resolve domain users over the directory out of the box.

## Fix
Bake `x509negativeserial=1` into the `dfs` binary via a `//go:debug` directive in `cmd/dfs/main.go`. No runtime `GODEBUG` env var, no custom dialer. Verified baked into the binary's `DefaultGODEBUG`.

Documented in `docs/CONFIGURATION.md`: production directories should still use a properly-issued DC cert (the Go toggle is slated for removal in a future release).

Closes #1289. Part of #1231.