### PR TITLE
fix(smb): LSARPC opnum 6 + SE_DACL_PROTECTED on default DACL (#1291)

### DIFF
--- a/internal/adapter/smb/handlers/security_test.go
+++ b/internal/adapter/smb/handlers/security_test.go
@@ -160,6 +160,16 @@ func TestBuildSD_NilACL_SynthesizesWindowsDefault(t *testing.T) {
 	if got, want := parsedACL.ACEs[1].Who, "sid:S-1-5-18"; got != want {
 		t.Errorf("ACE[1].Who = %q, want %q (SYSTEM SID round-trip)", got, want)
 	}
+
+	// The synthesized default is non-inherited, so SE_DACL_PROTECTED (0x1000)
+	// must be set — control 0x9004, matching standalone Samba (not 0x8004). The
+	// wire Control word is at offset 2; bit 0x1000 surfaces as parsedACL.Protected.
+	if control := binary.LittleEndian.Uint16(data[2:4]); control&seDACLProtected == 0 {
+		t.Errorf("SD control = 0x%04x, missing SE_DACL_PROTECTED (0x1000) on synthesized default (#1291)", control)
+	}
+	if !parsedACL.Protected {
+		t.Error("parsedACL.Protected = false, want true (synthesized default DACL is protected)")
+	}
 }
 
 // TestBuildSD_ZeroSecInfo_ReturnsEmptySD verifies that additionalSecInfo==0

--- a/internal/adapter/smb/rpc/lsarpc.go
+++ b/internal/adapter/smb/rpc/lsarpc.go
@@ -35,9 +35,17 @@ var LSAInterfaceUUID = [16]byte{
 // LSA Operation Numbers [MS-LSAT/MS-LSAD]
 const (
 	OpLsarClose       uint16 = 0  // LsarClose
+	OpLsarOpenPolicy  uint16 = 6  // LsarOpenPolicy (legacy; smbcacls/older clients use this)
 	OpLsarOpenPolicy2 uint16 = 44 // LsarOpenPolicy2
 	OpLsarLookupSids2 uint16 = 57 // LsarLookupSids2
 	OpLsarLookupSids3 uint16 = 76 // LsarLookupSids3
+)
+
+// DCE/RPC reject status codes [C706 §14.6 / MS-RPCE]. Returned in a FAULT PDU.
+const (
+	// ncaSOpRngError is nca_s_op_rng_error — the requested operation number is
+	// outside the range supported by the interface (unimplemented opnum).
+	ncaSOpRngError uint32 = 0x1C010002
 )
 
 // SID Name Types [MS-LSAT Section 2.2.13]
@@ -118,14 +126,14 @@ func (h *LSARPCHandler) HandleRequest(req *Request) []byte {
 	switch req.OpNum {
 	case OpLsarClose:
 		return h.handleClose(req)
-	case OpLsarOpenPolicy2:
-		return h.handleOpenPolicy2(req)
+	case OpLsarOpenPolicy, OpLsarOpenPolicy2:
+		return h.handleOpenPolicy(req)
 	case OpLsarLookupSids2:
 		return h.handleLookupSids(req)
 	case OpLsarLookupSids3:
 		return h.handleLookupSids(req) // Same logic, no policy handle needed
 	default:
-		return h.buildFault(req.Header.CallID, 0x1C010003) // nca_op_rng_error
+		return h.buildFault(req.Header.CallID, ncaSOpRngError)
 	}
 }
 
@@ -148,9 +156,12 @@ func (h *LSARPCHandler) handleClose(req *Request) []byte {
 	return resp.Encode(req.Header.CallID)
 }
 
-// handleOpenPolicy2 handles LsarOpenPolicy2 (opnum 44).
-// Returns a stub policy handle (required before LookupSids2).
-func (h *LSARPCHandler) handleOpenPolicy2(req *Request) []byte {
+// handleOpenPolicy handles both LsarOpenPolicy (opnum 6) and LsarOpenPolicy2
+// (opnum 44). Both return a policy handle required before LookupSids; the
+// request stubs differ only in the system-name argument, which we ignore.
+// smbcacls and older clients call the legacy opnum 6 first — without this,
+// they receive a fault and fall back to displaying raw SIDs.
+func (h *LSARPCHandler) handleOpenPolicy(req *Request) []byte {
 	// Response: policy handle (20 bytes) + status (4 bytes)
 	stubData := make([]byte, 24)
 	// Set a non-zero policy handle (fixed value)

--- a/internal/adapter/smb/rpc/lsarpc_test.go
+++ b/internal/adapter/smb/rpc/lsarpc_test.go
@@ -156,6 +156,42 @@ func TestLSARPC_OpenPolicy2(t *testing.T) {
 	}
 }
 
+// TestLSARPC_OpenPolicy verifies the legacy LsarOpenPolicy (opnum 6) returns a
+// success policy handle, not a fault. smbcacls and older clients call opnum 6
+// before LookupSids; faulting it makes them fall back to raw SIDs (#1291).
+func TestLSARPC_OpenPolicy(t *testing.T) {
+	h := newTestLSAHandler()
+
+	// LsarOpenPolicy stub data (minimal - handler ignores it).
+	stubData := make([]byte, 48)
+	reqData := buildTestRequest(2, OpLsarOpenPolicy, stubData)
+
+	req, err := ParseRequest(reqData)
+	if err != nil {
+		t.Fatalf("ParseRequest: %v", err)
+	}
+
+	response := h.HandleRequest(req)
+
+	hdr, err := ParseHeader(response)
+	if err != nil {
+		t.Fatalf("ParseHeader: %v", err)
+	}
+	if hdr.PacketType != PDUResponse {
+		t.Fatalf("LsarOpenPolicy (opnum 6) returned PDU type %d, want %d (Response) — clients fall back to raw SIDs on a fault", hdr.PacketType, PDUResponse)
+	}
+
+	// Status is at offset 20 within stub data (after 20-byte policy handle).
+	if len(response) < 24+24 {
+		t.Fatalf("Response stub data too short for OpenPolicy response")
+	}
+	stubStart := 24
+	status := binary.LittleEndian.Uint32(response[stubStart+20 : stubStart+24])
+	if status != statusSuccess {
+		t.Errorf("LsarOpenPolicy status = 0x%08x, want 0x%08x (success)", status, statusSuccess)
+	}
+}
+
 func TestLSARPC_Close(t *testing.T) {
 	h := newTestLSAHandler()
 

--- a/internal/adapter/smb/rpc/srvsvc.go
+++ b/internal/adapter/smb/rpc/srvsvc.go
@@ -118,7 +118,7 @@ func (h *SRVSVCHandler) HandleRequest(req *Request) []byte {
 		return h.handleNetrShareEnum(req)
 	default:
 		// Return fault for unsupported operations
-		return h.buildFault(req.Header.CallID, 0x1C010003) // nca_op_rng_error
+		return h.buildFault(req.Header.CallID, ncaSOpRngError)
 	}
 }
 

--- a/pkg/metadata/acl/synthesize.go
+++ b/pkg/metadata/acl/synthesize.go
@@ -108,6 +108,14 @@ func SynthesizeFromMode(mode uint32, ownerUID, ownerGID uint32, isDirectory bool
 // Flags are 0 (no inheritance) because this default is itself non-inheritable:
 // it represents "what a file should show when nothing else applies."
 //
+// Protected is true: this default is only used when no inheritable ACEs
+// applied from the parent (see the doc above), so the resulting DACL is
+// non-inherited and therefore protected (SE_DACL_PROTECTED, 0x1000). Files
+// that DO inherit carry a stored ACL with Protected=false (see
+// ComputeInheritedACL) and never reach this path. This matches what a
+// standalone Samba file server reports for such a file (SD control 0x9004,
+// not 0x8004).
+//
 // This is the SMB read-side default. NFS callers should not use this — NFS
 // surfaces file.ACL as-is and synthesizes nothing.
 func SynthesizeWindowsDefault() *ACL {
@@ -126,7 +134,8 @@ func SynthesizeWindowsDefault() *ACL {
 				Who:        SpecialSystem,
 			},
 		},
-		Source: ACLSourceWindowsDefault,
+		Source:    ACLSourceWindowsDefault,
+		Protected: true,
 	}
 }
 

--- a/pkg/metadata/acl/synthesize_test.go
+++ b/pkg/metadata/acl/synthesize_test.go
@@ -510,4 +510,11 @@ func TestSynthesizeWindowsDefault(t *testing.T) {
 			t.Errorf("ACE[%d].Flag = 0x%x carries inheritance bits; Windows default is flat", i, ace.Flag)
 		}
 	}
+
+	// The default is used only when no inheritable ACEs applied, so the DACL is
+	// non-inherited and must be marked protected — this drives SE_DACL_PROTECTED
+	// (0x1000) on the wire, matching standalone Samba (control 0x9004). See #1291.
+	if !acl.Protected {
+		t.Error("Protected = false, want true (synthesized default DACL is non-inherited)")
+	}
 }

--- a/test/pcap-corpus/smb-sd/CAPTURE.md
+++ b/test/pcap-corpus/smb-sd/CAPTURE.md
@@ -49,3 +49,18 @@ The harness surfaced two concrete divergences in the SD *values*:
 Both are tracked as a follow-up (see the issue referenced from #1237). Neither
 blocks the SD wire contract — they are fidelity gaps the corpus is designed to
 catch.
+
+## Update — both divergences fixed (#1291)
+
+1. **`SE_DACL_PROTECTED`** is now set on DittoFS's synthesized default DACL
+   (`acl.SynthesizeWindowsDefault`), so a file with no explicit/inherited ACL
+   reports control `0x9004` to match standalone Samba.
+2. **LSARPC SID→name** now works: the root cause was *not* a missing pipe (the
+   LSA interface and `LsarLookupSids2/3` were already implemented). `smbcacls`
+   calls the legacy `LsarOpenPolicy` (opnum 6) *before* the lookup, which
+   DittoFS did not handle — it returned a fault that the client read as
+   `DCERPC_NCA_S_UNKNOWN_IF` and gave up. Opnum 6 is now routed to the same
+   policy-handle handler as `LsarOpenPolicy2` (opnum 44).
+
+`dittofs-sample.pcap` above predates the fix; regenerate it on the next live
+capture against a patched DittoFS to refresh the corpus.


### PR DESCRIPTION
Two SMB `SECURITY_DESCRIPTOR` fidelity gaps surfaced by the #1237 SD corpus (smbcacls vs Samba 4.19). Both root-caused from the captured wire, not the issue text.

## 1. `SE_DACL_PROTECTED` (0x1000) omitted
Samba returns control `0x9004` (self-relative + DACL-protected + present); DittoFS returned `0x8004`.

DittoFS *does* do parent→child DACL inheritance (`ComputeInheritedACL`/`PropagateACL`). The synthesized Windows-default DACL is used **only when no inheritable ACEs applied**, so that DACL is non-inherited and must be protected. Set `Protected` on `acl.SynthesizeWindowsDefault()` → existing control-flag code ORs in `0x1000` → `0x9004`. Files that genuinely inherit keep `Protected=false` (inherited ACLs report `0x8004`, correctly).

## 2. `smbcacls` SID→name returned `DCERPC_NCA_S_UNKNOWN_IF`
The issue premise ("DittoFS does not implement the LSARPC pipe") is **stale** — `LsarLookupSids2/3` shipped in #251, three months before the corpus capture. Decoding `dittofs-sample.pcap` by hand showed the real cause: 4× (BIND → **opnum 6** → FAULT). smbcacls calls the **legacy `LsarOpenPolicy` (opnum 6)** before the lookup; DittoFS only implemented `LsarOpenPolicy2` (44), so opnum 6 hit the default branch and faulted — the lookup opnums were never reached.

Fix: route opnum 6 to the same policy-handle handler as opnum 44 (the handler ignores the request stub anyway). Also corrected the unknown-opnum fault code: `0x1C010003` is actually `nca_s_unk_if`; the right code for an unimplemented operation is `nca_s_op_rng_error` = `0x1C010002`.

## Tests
- `TestLSARPC_OpenPolicy` — opnum 6 returns a success policy handle, not a fault.
- `TestSynthesizeWindowsDefault` — default DACL is `Protected`.
- `TestBuildSD_NilACL_SynthesizesWindowsDefault` — asserts wire control carries `SE_DACL_PROTECTED`.

`dittofs-sample.pcap` predates the fix (regenerating needs a live capture); `CAPTURE.md` notes this.

Closes #1291. Part of #1231.