### PR TITLE
fix(runtime): resolve share block stores by name-or-ID so shares load after restart (#1312)

### DIFF
--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -600,10 +600,35 @@ func (h *ShareHandler) Update(w http.ResponseWriter, r *http.Request) {
 		share.MetadataStoreID = *req.MetadataStoreID
 	}
 	if req.LocalBlockStoreID != nil {
-		share.LocalBlockStoreID = *req.LocalBlockStoreID
+		// Resolve to the canonical UUID, accepting either a name or a UUID
+		// (mirrors CreateShare). Persisting a raw name here was the root cause
+		// of #1312: on restart GetBlockStoreByID(name) failed and the share
+		// never loaded.
+		localBlockStore, err := h.store.GetBlockStore(r.Context(), *req.LocalBlockStoreID, models.BlockStoreKindLocal)
+		if err != nil {
+			localBlockStore, err = h.store.GetBlockStoreByID(r.Context(), *req.LocalBlockStoreID)
+		}
+		if err != nil {
+			BadRequest(w, "Local block store not found: "+*req.LocalBlockStoreID)
+			return
+		}
+		share.LocalBlockStoreID = localBlockStore.ID
 	}
 	if req.RemoteBlockStoreID != nil {
-		share.RemoteBlockStoreID = req.RemoteBlockStoreID
+		if *req.RemoteBlockStoreID == "" {
+			// Explicit clear of the remote tier.
+			share.RemoteBlockStoreID = nil
+		} else {
+			remoteBlockStore, err := h.store.GetBlockStore(r.Context(), *req.RemoteBlockStoreID, models.BlockStoreKindRemote)
+			if err != nil {
+				remoteBlockStore, err = h.store.GetBlockStoreByID(r.Context(), *req.RemoteBlockStoreID)
+			}
+			if err != nil {
+				BadRequest(w, "Remote block store not found: "+*req.RemoteBlockStoreID)
+				return
+			}
+			share.RemoteBlockStoreID = &remoteBlockStore.ID
+		}
 	}
 	if req.ReadOnly != nil {
 		share.ReadOnly = *req.ReadOnly

--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -61,6 +62,27 @@ type ShareHandler struct {
 // NewShareHandler creates a new ShareHandler.
 func NewShareHandler(s ShareHandlerStore, rt *runtime.Runtime) *ShareHandler {
 	return &ShareHandler{store: s, runtime: rt}
+}
+
+// resolveBlockStoreRef resolves a block-store reference — a name or a canonical
+// UUID — to its config, scoped to the expected kind. It tries the kind-scoped
+// name lookup first, then a UUID lookup, rejecting a UUID that resolves to the
+// wrong kind. This mirrors the runtime's resolveBlockStoreConfig so the API
+// never persists an id the share can't load at startup (#1312): a remote-store
+// UUID handed to local_block_store_id (or vice versa) is refused up front
+// instead of silently breaking the share on the next restart.
+func (h *ShareHandler) resolveBlockStoreRef(ctx context.Context, ref string, kind models.BlockStoreKind) (*models.BlockStoreConfig, error) {
+	if cfg, err := h.store.GetBlockStore(ctx, ref, kind); err == nil {
+		return cfg, nil
+	}
+	cfg, err := h.store.GetBlockStoreByID(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Kind != kind {
+		return nil, fmt.Errorf("block store %q has kind %q, expected %q", ref, cfg.Kind, kind)
+	}
+	return cfg, nil
 }
 
 // CreateShareRequest is the request body for POST /api/v1/shares.
@@ -244,11 +266,8 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate that local block store exists (try by name first, then by ID)
-	localBlockStore, err := h.store.GetBlockStore(r.Context(), req.LocalBlockStore, models.BlockStoreKindLocal)
-	if err != nil {
-		localBlockStore, err = h.store.GetBlockStoreByID(r.Context(), req.LocalBlockStore)
-	}
+	// Validate that local block store exists (accepts a name or a UUID).
+	localBlockStore, err := h.resolveBlockStoreRef(r.Context(), req.LocalBlockStore, models.BlockStoreKindLocal)
 	if err != nil {
 		BadRequest(w, "Local block store not found: "+req.LocalBlockStore)
 		return
@@ -257,10 +276,7 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 	// Validate optional remote block store
 	var remoteBlockStoreID *string
 	if req.RemoteBlockStore != nil && *req.RemoteBlockStore != "" {
-		remoteStore, remoteErr := h.store.GetBlockStore(r.Context(), *req.RemoteBlockStore, models.BlockStoreKindRemote)
-		if remoteErr != nil {
-			remoteStore, remoteErr = h.store.GetBlockStoreByID(r.Context(), *req.RemoteBlockStore)
-		}
+		remoteStore, remoteErr := h.resolveBlockStoreRef(r.Context(), *req.RemoteBlockStore, models.BlockStoreKindRemote)
 		if remoteErr != nil {
 			BadRequest(w, "Remote block store not found: "+*req.RemoteBlockStore)
 			return
@@ -604,10 +620,7 @@ func (h *ShareHandler) Update(w http.ResponseWriter, r *http.Request) {
 		// (mirrors CreateShare). Persisting a raw name here was the root cause
 		// of #1312: on restart GetBlockStoreByID(name) failed and the share
 		// never loaded.
-		localBlockStore, err := h.store.GetBlockStore(r.Context(), *req.LocalBlockStoreID, models.BlockStoreKindLocal)
-		if err != nil {
-			localBlockStore, err = h.store.GetBlockStoreByID(r.Context(), *req.LocalBlockStoreID)
-		}
+		localBlockStore, err := h.resolveBlockStoreRef(r.Context(), *req.LocalBlockStoreID, models.BlockStoreKindLocal)
 		if err != nil {
 			BadRequest(w, "Local block store not found: "+*req.LocalBlockStoreID)
 			return
@@ -619,10 +632,7 @@ func (h *ShareHandler) Update(w http.ResponseWriter, r *http.Request) {
 			// Explicit clear of the remote tier.
 			share.RemoteBlockStoreID = nil
 		} else {
-			remoteBlockStore, err := h.store.GetBlockStore(r.Context(), *req.RemoteBlockStoreID, models.BlockStoreKindRemote)
-			if err != nil {
-				remoteBlockStore, err = h.store.GetBlockStoreByID(r.Context(), *req.RemoteBlockStoreID)
-			}
+			remoteBlockStore, err := h.resolveBlockStoreRef(r.Context(), *req.RemoteBlockStoreID, models.BlockStoreKindRemote)
 			if err != nil {
 				BadRequest(w, "Remote block store not found: "+*req.RemoteBlockStoreID)
 				return

--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -64,6 +64,11 @@ func NewShareHandler(s ShareHandlerStore, rt *runtime.Runtime) *ShareHandler {
 	return &ShareHandler{store: s, runtime: rt}
 }
 
+// errWrongBlockStoreKind is returned by resolveBlockStoreRef when a reference
+// resolves to a store of an unexpected kind. It is a client error (a bad
+// reference), distinct from a missing store or an operational failure.
+var errWrongBlockStoreKind = errors.New("block store has unexpected kind")
+
 // resolveBlockStoreRef resolves a block-store reference — a name or a canonical
 // UUID — to its config, scoped to the expected kind. It tries the kind-scoped
 // name lookup first, then a UUID lookup, rejecting a UUID that resolves to the
@@ -71,18 +76,40 @@ func NewShareHandler(s ShareHandlerStore, rt *runtime.Runtime) *ShareHandler {
 // never persists an id the share can't load at startup (#1312): a remote-store
 // UUID handed to local_block_store_id (or vice versa) is refused up front
 // instead of silently breaking the share on the next restart.
+//
+// Only a genuine not-found on the name lookup falls through to the UUID lookup;
+// an operational error (DB/context) is returned as-is so callers can surface it
+// as a 500 rather than masking it as an unknown reference.
 func (h *ShareHandler) resolveBlockStoreRef(ctx context.Context, ref string, kind models.BlockStoreKind) (*models.BlockStoreConfig, error) {
-	if cfg, err := h.store.GetBlockStore(ctx, ref, kind); err == nil {
+	cfg, err := h.store.GetBlockStore(ctx, ref, kind)
+	if err == nil {
 		return cfg, nil
 	}
-	cfg, err := h.store.GetBlockStoreByID(ctx, ref)
+	if !errors.Is(err, models.ErrStoreNotFound) {
+		return nil, err
+	}
+	cfg, err = h.store.GetBlockStoreByID(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
 	if cfg.Kind != kind {
-		return nil, fmt.Errorf("block store %q has kind %q, expected %q", ref, cfg.Kind, kind)
+		return nil, fmt.Errorf("%w: %q is %q, expected %q", errWrongBlockStoreKind, ref, cfg.Kind, kind)
 	}
 	return cfg, nil
+}
+
+// writeBlockStoreRefError maps a resolveBlockStoreRef failure to an HTTP
+// response: a missing or wrong-kind reference is the client's fault (400),
+// anything else is an operational failure (500). tier is "Local" or "Remote".
+func writeBlockStoreRefError(w http.ResponseWriter, tier, ref string, err error) {
+	switch {
+	case errors.Is(err, models.ErrStoreNotFound):
+		BadRequest(w, tier+" block store not found: "+ref)
+	case errors.Is(err, errWrongBlockStoreKind):
+		BadRequest(w, tier+" block store has the wrong kind: "+ref)
+	default:
+		InternalServerError(w, "Failed to resolve "+tier+" block store "+ref+": "+err.Error())
+	}
 }
 
 // CreateShareRequest is the request body for POST /api/v1/shares.
@@ -269,7 +296,7 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 	// Validate that local block store exists (accepts a name or a UUID).
 	localBlockStore, err := h.resolveBlockStoreRef(r.Context(), req.LocalBlockStore, models.BlockStoreKindLocal)
 	if err != nil {
-		BadRequest(w, "Local block store not found: "+req.LocalBlockStore)
+		writeBlockStoreRefError(w, "Local", req.LocalBlockStore, err)
 		return
 	}
 
@@ -278,7 +305,7 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 	if req.RemoteBlockStore != nil && *req.RemoteBlockStore != "" {
 		remoteStore, remoteErr := h.resolveBlockStoreRef(r.Context(), *req.RemoteBlockStore, models.BlockStoreKindRemote)
 		if remoteErr != nil {
-			BadRequest(w, "Remote block store not found: "+*req.RemoteBlockStore)
+			writeBlockStoreRefError(w, "Remote", *req.RemoteBlockStore, remoteErr)
 			return
 		}
 		remoteBlockStoreID = &remoteStore.ID
@@ -622,7 +649,7 @@ func (h *ShareHandler) Update(w http.ResponseWriter, r *http.Request) {
 		// never loaded.
 		localBlockStore, err := h.resolveBlockStoreRef(r.Context(), *req.LocalBlockStoreID, models.BlockStoreKindLocal)
 		if err != nil {
-			BadRequest(w, "Local block store not found: "+*req.LocalBlockStoreID)
+			writeBlockStoreRefError(w, "Local", *req.LocalBlockStoreID, err)
 			return
 		}
 		share.LocalBlockStoreID = localBlockStore.ID
@@ -634,7 +661,7 @@ func (h *ShareHandler) Update(w http.ResponseWriter, r *http.Request) {
 		} else {
 			remoteBlockStore, err := h.resolveBlockStoreRef(r.Context(), *req.RemoteBlockStoreID, models.BlockStoreKindRemote)
 			if err != nil {
-				BadRequest(w, "Remote block store not found: "+*req.RemoteBlockStoreID)
+				writeBlockStoreRefError(w, "Remote", *req.RemoteBlockStoreID, err)
 				return
 			}
 			share.RemoteBlockStoreID = &remoteBlockStore.ID

--- a/internal/controlplane/api/handlers/shares_test.go
+++ b/internal/controlplane/api/handlers/shares_test.go
@@ -275,6 +275,71 @@ func TestShareHandler_Update_TrashRejectsNegative(t *testing.T) {
 	}
 }
 
+// TestShareHandler_Update_ResolvesBlockStoreNameToID verifies the root-cause
+// fix for #1312: PUT /shares with a local/remote block store *name* must
+// persist the canonical UUID, not the raw name. Previously the name was
+// stored verbatim, so on restart GetBlockStoreByID(name) failed and the share
+// never loaded.
+func TestShareHandler_Update_ResolvesBlockStoreNameToID(t *testing.T) {
+	cpStore, _, handler := setupShareTestWithRuntime(t)
+	seedShare(t, cpStore, "s-bsname")
+	ctx := context.Background()
+
+	// Create a new local + remote block store referenced by NAME below.
+	newLocal := &models.BlockStoreConfig{
+		ID: uuid.New().String(), Name: "fresh-local", Kind: models.BlockStoreKindLocal, Type: "memory", CreatedAt: time.Now(),
+	}
+	if _, err := cpStore.CreateBlockStore(ctx, newLocal); err != nil {
+		t.Fatalf("CreateBlockStore(local): %v", err)
+	}
+	newRemote := &models.BlockStoreConfig{
+		ID: uuid.New().String(), Name: "fresh-remote", Kind: models.BlockStoreKindRemote, Type: "memory", CreatedAt: time.Now(),
+	}
+	if _, err := cpStore.CreateBlockStore(ctx, newRemote); err != nil {
+		t.Fatalf("CreateBlockStore(remote): %v", err)
+	}
+
+	body := []byte(`{"local_block_store_id":"fresh-local","remote_block_store_id":"fresh-remote"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/shares/s-bsname", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withShareName(req, "s-bsname")
+	w := httptest.NewRecorder()
+
+	handler.Update(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("Update = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	got, err := cpStore.GetShare(ctx, "/s-bsname")
+	if err != nil {
+		t.Fatalf("GetShare: %v", err)
+	}
+	if got.LocalBlockStoreID != newLocal.ID {
+		t.Errorf("LocalBlockStoreID = %q, want canonical UUID %q (not the name)", got.LocalBlockStoreID, newLocal.ID)
+	}
+	if got.RemoteBlockStoreID == nil || *got.RemoteBlockStoreID != newRemote.ID {
+		t.Errorf("RemoteBlockStoreID = %v, want canonical UUID %q (not the name)", got.RemoteBlockStoreID, newRemote.ID)
+	}
+}
+
+// TestShareHandler_Update_RejectsUnknownBlockStore verifies an unknown block
+// store name/UUID is rejected with 400 rather than silently persisted.
+func TestShareHandler_Update_RejectsUnknownBlockStore(t *testing.T) {
+	cpStore, _, handler := setupShareTestWithRuntime(t)
+	seedShare(t, cpStore, "s-bsunknown")
+
+	body := []byte(`{"local_block_store_id":"does-not-exist"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/shares/s-bsunknown", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withShareName(req, "s-bsunknown")
+	w := httptest.NewRecorder()
+
+	handler.Update(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("Update(unknown block store) = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}
+
 // seedStores creates a metadata store + local block store (no share) and
 // returns their names, so a Create request can reference real stores and reach
 // the default_permission validation rather than failing the store-existence

--- a/internal/controlplane/api/handlers/shares_test.go
+++ b/internal/controlplane/api/handlers/shares_test.go
@@ -340,6 +340,35 @@ func TestShareHandler_Update_RejectsUnknownBlockStore(t *testing.T) {
 	}
 }
 
+// TestShareHandler_Update_RejectsWrongKindBlockStore verifies a UUID that
+// resolves to the wrong kind (a remote store handed to local_block_store_id) is
+// rejected with 400 rather than persisted — otherwise the share would fail to
+// load at the next restart (#1312).
+func TestShareHandler_Update_RejectsWrongKindBlockStore(t *testing.T) {
+	cpStore, _, handler := setupShareTestWithRuntime(t)
+	seedShare(t, cpStore, "s-bskind")
+	ctx := context.Background()
+
+	remote := &models.BlockStoreConfig{
+		ID: uuid.New().String(), Name: "kind-remote", Kind: models.BlockStoreKindRemote, Type: "memory", CreatedAt: time.Now(),
+	}
+	if _, err := cpStore.CreateBlockStore(ctx, remote); err != nil {
+		t.Fatalf("CreateBlockStore(remote): %v", err)
+	}
+
+	// Hand the remote store's UUID to the local tier — must be refused.
+	body := []byte(`{"local_block_store_id":"` + remote.ID + `"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/shares/s-bskind", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withShareName(req, "s-bskind")
+	w := httptest.NewRecorder()
+
+	handler.Update(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("Update(wrong-kind block store) = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}
+
 // seedStores creates a metadata store + local block store (no share) and
 // returns their names, so a Create request can reference real stores and reach
 // the default_permission validation rather than failing the store-existence

--- a/pkg/controlplane/runtime/init_test.go
+++ b/pkg/controlplane/runtime/init_test.go
@@ -138,6 +138,72 @@ func TestPerShareBlockStoreLocalOnly(t *testing.T) {
 	}
 }
 
+// TestLoadSharesResolvesBlockStoreByName reproduces #1312: a share whose
+// local_block_store_id (and remote_block_store_id) column holds the block
+// store *name* rather than its UUID — the shape persisted by the
+// `dfsctl share edit --local/--remote <name>` REST UpdateShare path, which
+// (unlike CreateShare) wrote the raw name into the DB. On a fresh runtime
+// over that persisted DB the share must still load and its per-share
+// BlockStore (local + remote) must resolve. Before the fix, resolution went
+// strictly through GetBlockStoreByID(name) and failed with "store not found",
+// so AddShare warn-skipped the share and every mount was denied.
+func TestLoadSharesResolvesBlockStoreByName(t *testing.T) {
+	rt, s := setupTestRuntime(t)
+	ctx := context.Background()
+
+	// Block store configs created via the API carry a UUID id and a
+	// human-friendly name. We deliberately ignore the returned UUIDs and
+	// reference the stores by NAME from the share, mirroring the corrupted
+	// rows produced by `share edit`.
+	const localName = "local-fs"
+	const remoteName = "remote-s3"
+	_ = createLocalBlockStoreConfig(t, s, localName)
+	_ = createRemoteBlockStoreConfig(t, s, remoteName)
+
+	metaStores, _ := s.ListMetadataStores(ctx)
+	metaID := metaStores[0].ID
+
+	remoteRef := remoteName
+	share := &models.Share{
+		Name:               "/demo",
+		MetadataStoreID:    metaID,
+		LocalBlockStoreID:  localName,  // NAME, not UUID (#1312 repro)
+		RemoteBlockStoreID: &remoteRef, // NAME, not UUID (#1312 repro)
+	}
+	if _, err := s.CreateShare(ctx, share); err != nil {
+		t.Fatalf("failed to create share: %v", err)
+	}
+
+	// Simulate a fresh server startup over the persisted DB.
+	if err := LoadSharesFromStore(ctx, rt, s); err != nil {
+		t.Fatalf("LoadSharesFromStore failed: %v", err)
+	}
+
+	shareObj, err := rt.GetShare("/demo")
+	if err != nil {
+		t.Fatalf("share /demo did not load after restart (block store not resolved by name): %v", err)
+	}
+	if shareObj.BlockStore == nil {
+		t.Fatal("expected non-nil BlockStore for share referencing block stores by name")
+	}
+	if shareObj.BlockStore.RemoteStore() == nil {
+		t.Fatal("expected non-nil remote store for share referencing remote block store by name")
+	}
+
+	// Sanity: the resolved local store is usable.
+	data := []byte("by-name resolution works")
+	if _, err := shareObj.BlockStore.WriteAt(ctx, "payload", nil, data, 0); err != nil {
+		t.Fatalf("WriteAt on name-resolved block store failed: %v", err)
+	}
+	buf := make([]byte, len(data))
+	if _, err := shareObj.BlockStore.ReadAt(ctx, "payload", nil, buf, 0); err != nil {
+		t.Fatalf("ReadAt on name-resolved block store failed: %v", err)
+	}
+	if string(buf) != string(data) {
+		t.Errorf("expected %q, got %q", data, buf)
+	}
+}
+
 func TestPerShareBlockStoreIsolation(t *testing.T) {
 	rt, s := setupTestRuntime(t)
 	ctx := context.Background()

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -292,8 +292,13 @@ func resolveBlockStoreConfig(
 	// Fall back to name resolution for legacy rows that stored the name.
 	byName, nameErr := provider.GetBlockStore(ctx, ref, kind)
 	if nameErr != nil {
-		// Surface the original ID-lookup error so the message stays familiar.
-		return nil, err
+		// A real operational error (DB/context) on the name path must not be
+		// masked as "not found"; only collapse to the familiar ID-lookup error
+		// when the name is genuinely absent too.
+		if errors.Is(nameErr, models.ErrStoreNotFound) {
+			return nil, err
+		}
+		return nil, nameErr
 	}
 	return byName, nil
 }
@@ -953,7 +958,13 @@ func (s *Service) acquireRemoteStore(ctx context.Context, ref string, provider B
 	if sr, ok := s.remoteStores[configID]; ok {
 		sr.refCount++
 		s.mu.Unlock()
-		_ = newStore.Close()
+		// We lost the race; discard our now-redundant store. newStore is the
+		// fully-decorated (encryption/compression) stack, so a Close failure
+		// here could leak a key provider — surface it rather than swallow it.
+		if err := newStore.Close(); err != nil {
+			logger.Warn("acquireRemoteStore: failed to close duplicate remote store",
+				"config_id", configID, "error", err)
+		}
 		return sr.store, configID, nil
 	}
 

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -260,8 +260,42 @@ type MetadataServiceDeregistrar interface {
 }
 
 // BlockStoreConfigProvider resolves block store configurations from the control plane DB.
+//
+// A share's LocalBlockStoreID/RemoteBlockStoreID normally hold the block store
+// row's UUID, but the REST UpdateShare path historically persisted the raw
+// *name* instead (#1312). Resolution therefore tries the UUID first and falls
+// back to a kind-scoped name lookup so shares whose rows hold a name still load
+// after a restart.
 type BlockStoreConfigProvider interface {
 	GetBlockStoreByID(ctx context.Context, id string) (*models.BlockStoreConfig, error)
+	GetBlockStore(ctx context.Context, name string, kind models.BlockStoreKind) (*models.BlockStoreConfig, error)
+}
+
+// resolveBlockStoreConfig resolves a block store reference that may be either a
+// UUID (the canonical form) or a name (#1312 legacy rows). It tries the UUID
+// lookup first; on not-found it falls back to a name lookup scoped to the
+// expected kind. The kind scope keeps a local name from accidentally resolving
+// to a same-named remote store and vice versa.
+func resolveBlockStoreConfig(
+	ctx context.Context,
+	provider BlockStoreConfigProvider,
+	ref string,
+	kind models.BlockStoreKind,
+) (*models.BlockStoreConfig, error) {
+	cfg, err := provider.GetBlockStoreByID(ctx, ref)
+	if err == nil {
+		return cfg, nil
+	}
+	if !errors.Is(err, models.ErrStoreNotFound) {
+		return nil, err
+	}
+	// Fall back to name resolution for legacy rows that stored the name.
+	byName, nameErr := provider.GetBlockStore(ctx, ref, kind)
+	if nameErr != nil {
+		// Surface the original ID-lookup error so the message stays familiar.
+		return nil, err
+	}
+	return byName, nil
 }
 
 // ShareStore is the narrow subset of pkg/controlplane/store.ShareStore that
@@ -702,8 +736,9 @@ func (s *Service) createBlockStoreForShare(
 	localStoreDefaults *LocalStoreDefaults,
 	syncerDefaults *SyncerDefaults,
 ) error {
-	// Resolve local block store config from DB.
-	localCfg, err := blockStoreProvider.GetBlockStoreByID(ctx, config.LocalBlockStoreID)
+	// Resolve local block store config from DB (by UUID, or by name for #1312
+	// legacy rows).
+	localCfg, err := resolveBlockStoreConfig(ctx, blockStoreProvider, config.LocalBlockStoreID, models.BlockStoreKindLocal)
 	if err != nil {
 		return fmt.Errorf("failed to resolve local block store config %q: %w", config.LocalBlockStoreID, err)
 	}
@@ -865,7 +900,20 @@ func (s *Service) createBlockStoreForShare(
 // Uses double-checked locking to avoid holding s.mu during potentially slow
 // network/DB I/O (config resolution, S3 client initialization).
 // Returns the store, its config ID, and any error.
-func (s *Service) acquireRemoteStore(ctx context.Context, configID string, provider BlockStoreConfigProvider) (remote.RemoteStore, string, error) {
+func (s *Service) acquireRemoteStore(ctx context.Context, ref string, provider BlockStoreConfigProvider) (remote.RemoteStore, string, error) {
+	// Resolve config first (by UUID, or by name for #1312 legacy rows) so the
+	// ref-count map is always keyed by the canonical store UUID. Two shares
+	// referencing the same remote — one by UUID, one by legacy name — must
+	// share the single ref-counted store.
+	remoteCfg, err := resolveBlockStoreConfig(ctx, provider, ref, models.BlockStoreKindRemote)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to resolve remote block store config %q: %w", ref, err)
+	}
+	if remoteCfg.Kind != models.BlockStoreKindRemote {
+		return nil, "", fmt.Errorf("block store config %q has kind %q, expected %q", ref, remoteCfg.Kind, models.BlockStoreKindRemote)
+	}
+	configID := remoteCfg.ID
+
 	s.mu.Lock()
 	if sr, ok := s.remoteStores[configID]; ok {
 		sr.refCount++
@@ -873,15 +921,6 @@ func (s *Service) acquireRemoteStore(ctx context.Context, configID string, provi
 		return sr.store, configID, nil
 	}
 	s.mu.Unlock()
-
-	// Resolve config and create store without holding the lock.
-	remoteCfg, err := provider.GetBlockStoreByID(ctx, configID)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to resolve remote block store config %q: %w", configID, err)
-	}
-	if remoteCfg.Kind != models.BlockStoreKindRemote {
-		return nil, "", fmt.Errorf("block store config %q has kind %q, expected %q", configID, remoteCfg.Kind, models.BlockStoreKindRemote)
-	}
 
 	newStore, err := CreateRemoteStoreFromConfig(ctx, remoteCfg.Type, remoteCfg)
 	if err != nil {

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -906,7 +906,19 @@ func (s *Service) createBlockStoreForShare(
 // network/DB I/O (config resolution, S3 client initialization).
 // Returns the store, its config ID, and any error.
 func (s *Service) acquireRemoteStore(ctx context.Context, ref string, provider BlockStoreConfigProvider) (remote.RemoteStore, string, error) {
-	// Resolve config first (by UUID, or by name for #1312 legacy rows) so the
+	// Fast path: when the share already persists the canonical UUID (the common
+	// case) and the store is live, take it without a config-resolution DB read.
+	// Legacy name refs (#1312) miss here — the map is keyed by UUID — and fall
+	// through to full resolution below.
+	s.mu.Lock()
+	if sr, ok := s.remoteStores[ref]; ok {
+		sr.refCount++
+		s.mu.Unlock()
+		return sr.store, ref, nil
+	}
+	s.mu.Unlock()
+
+	// Resolve config (by UUID, or by name for #1312 legacy rows) so the
 	// ref-count map is always keyed by the canonical store UUID. Two shares
 	// referencing the same remote — one by UUID, one by legacy name — must
 	// share the single ref-counted store.


### PR DESCRIPTION
## Problem

On `dfs` server restart, shares that reference an API-created block store fail to load and every mount is denied:

```
WARN  Failed to add share to runtime  share=/demo
      error="failed to create block store for share \"/demo\": failed to resolve local block store config \"local-fs\": store not found"
```

## Root cause

`dfsctl share edit --local/--remote <name>` sends the block store **name**. The REST `CreateShare` handler resolves a block store name/UUID to its canonical UUID before persisting, but the **`UpdateShare` handler did not** — it wrote `req.LocalBlockStoreID` / `req.RemoteBlockStoreID` verbatim into the share's `local_block_store_id` / `remote_block_store_id` columns.

On restart, `LoadSharesFromStore → AddShare → createBlockStoreForShare` resolved the reference strictly via `GetBlockStoreByID(name)`, which returns `store not found` (a UUID column lookup against a name). The share was warn-skipped, so all mounts were denied. A later `UpdateShare` then also failed with `share not found` because the share never came up.

Block store config persistence itself was never the gap — the control-plane DB *is* the source of truth and is read at startup. The gap was a **name-vs-UUID asymmetry** between create and update, plus strict ID-only resolution at load time.

## Fix

1. **Resilient resolution (recovers existing bad data).** `resolveBlockStoreConfig` resolves a reference by UUID first, then falls back to a **kind-scoped** name lookup. So shares whose rows already hold a name (e.g. the demo deployment) load after a restart without manual DB repair. `acquireRemoteStore` now keys the remote ref-count map by the canonical store UUID regardless of how the share referenced it, so two shares pointing at the same remote — one by UUID, one by legacy name — still share a single ref-counted store.

2. **Root-cause fix (stops new bad data).** The `UpdateShare` REST handler now resolves the local/remote block store name→UUID (mirroring `CreateShare`) and returns `400` for an unknown store. An empty `remote_block_store_id` explicitly clears the remote tier.

Respects architecture invariant #4 (block stores per-share; remote stores ref-counted by canonical config UUID; local dirs isolated).

## Tests

- `TestLoadSharesResolvesBlockStoreByName` (pkg/controlplane/runtime) — reproduces the exact live `store not found` boot symptom for a share referencing **local + remote** block stores by name; fails before the fix, passes after.
- `TestShareHandler_Update_ResolvesBlockStoreNameToID` — `PUT /shares` with block store **names** persists canonical UUIDs.
- `TestShareHandler_Update_RejectsUnknownBlockStore` — unknown store → `400`, not silently persisted.

## Verification

- `go build ./...` — clean
- `go test ./pkg/controlplane/...` — pass
- `go test -tags integration ./internal/controlplane/api/handlers/` — pass
- `go test -race ./pkg/controlplane/runtime/ -run '...block store...'` — pass
- `go vet` + `gofmt -l` on changed files — clean

Refs #1312