### PR TITLE
feat(shutdown): bound graceful-shutdown wait + adapter drain regression tests (Refs #1313)

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -340,10 +340,11 @@ func runStart(cmd *cobra.Command, args []string) error {
 		cancel()
 
 		// Wait for the runtime to drain (snapshots -> StopAllAdapters -> flush
-		// -> close stores -> stop API). The drain runs these stages serially,
-		// each bounded by the configured shutdown timeout, but a wedged stage
-		// (e.g. a stuck store flush) could otherwise block the process
-		// indefinitely. Under Kubernetes that means the pod hangs until SIGKILL
+		// -> close stores -> stop API). The drain runs these stages serially
+		// and most are individually bounded by the configured shutdown timeout,
+		// but a wedged stage (e.g. a stuck store flush or an unbounded store
+		// close) could otherwise block the process indefinitely. Under
+		// Kubernetes that means the pod hangs until SIGKILL
 		// at the end of its terminationGracePeriod, dropping clients abruptly —
 		// exactly what #1313 is about. Cap the overall wait so the process
 		// always exits on its own first.

--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -339,16 +339,21 @@ func runStart(cmd *cobra.Command, args []string) error {
 		logger.Info("Shutdown signal received, initiating graceful shutdown")
 		cancel()
 
-		// Wait for the runtime to drain (StopAllAdapters -> flush -> close
-		// stores -> stop API). The drain is itself bounded by the configured
-		// shutdown timeout at each stage, but a wedged stage (e.g. a stuck
-		// store flush) could otherwise block the process indefinitely. Under
-		// Kubernetes that means the pod hangs until SIGKILL at the end of its
-		// terminationGracePeriod, dropping clients abruptly — exactly what
-		// #1313 is about. Cap the overall wait so the process always exits on
-		// its own within the grace window; the extra margin over a single
-		// shutdownTimeout accommodates the sequential drain stages.
-		shutdownDeadline := 2*cfg.ShutdownTimeout + 10*time.Second
+		// Wait for the runtime to drain (snapshots -> StopAllAdapters -> flush
+		// -> close stores -> stop API). The drain runs these stages serially,
+		// each bounded by the configured shutdown timeout, but a wedged stage
+		// (e.g. a stuck store flush) could otherwise block the process
+		// indefinitely. Under Kubernetes that means the pod hangs until SIGKILL
+		// at the end of its terminationGracePeriod, dropping clients abruptly —
+		// exactly what #1313 is about. Cap the overall wait so the process
+		// always exits on its own first.
+		//
+		// The factor mirrors the operator's shutdownStageMultiplier=3, which
+		// sizes terminationGracePeriodSeconds as preStop(5) + 3*shutdownTimeout
+		// + 10s. After SIGTERM the process therefore has 3*shutdownTimeout + 10s
+		// before SIGKILL, so 3*shutdownTimeout + 5s self-exits just inside that
+		// window while still letting the common multi-stage drain finish.
+		shutdownDeadline := 3*cfg.ShutdownTimeout + 5*time.Second
 		select {
 		case err := <-serverDone:
 			if err != nil {

--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -355,6 +355,8 @@ func runStart(cmd *cobra.Command, args []string) error {
 		// before SIGKILL, so 3*shutdownTimeout + 5s self-exits just inside that
 		// window while still letting the common multi-stage drain finish.
 		shutdownDeadline := 3*cfg.ShutdownTimeout + 5*time.Second
+		timer := time.NewTimer(shutdownDeadline)
+		defer timer.Stop()
 		select {
 		case err := <-serverDone:
 			if err != nil {
@@ -362,7 +364,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 				return err
 			}
 			logger.Info("Server stopped gracefully")
-		case <-time.After(shutdownDeadline):
+		case <-timer.C:
 			logger.Error("Graceful shutdown exceeded deadline; forcing exit",
 				"deadline", shutdownDeadline)
 			return fmt.Errorf("graceful shutdown timed out after %s", shutdownDeadline)

--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -339,12 +339,28 @@ func runStart(cmd *cobra.Command, args []string) error {
 		logger.Info("Shutdown signal received, initiating graceful shutdown")
 		cancel()
 
-		// Wait for server to shut down gracefully
-		if err := <-serverDone; err != nil {
-			logger.Error("Server shutdown error", "error", err)
-			return err
+		// Wait for the runtime to drain (StopAllAdapters -> flush -> close
+		// stores -> stop API). The drain is itself bounded by the configured
+		// shutdown timeout at each stage, but a wedged stage (e.g. a stuck
+		// store flush) could otherwise block the process indefinitely. Under
+		// Kubernetes that means the pod hangs until SIGKILL at the end of its
+		// terminationGracePeriod, dropping clients abruptly — exactly what
+		// #1313 is about. Cap the overall wait so the process always exits on
+		// its own within the grace window; the extra margin over a single
+		// shutdownTimeout accommodates the sequential drain stages.
+		shutdownDeadline := 2*cfg.ShutdownTimeout + 10*time.Second
+		select {
+		case err := <-serverDone:
+			if err != nil {
+				logger.Error("Server shutdown error", "error", err)
+				return err
+			}
+			logger.Info("Server stopped gracefully")
+		case <-time.After(shutdownDeadline):
+			logger.Error("Graceful shutdown exceeded deadline; forcing exit",
+				"deadline", shutdownDeadline)
+			return fmt.Errorf("graceful shutdown timed out after %s", shutdownDeadline)
 		}
-		logger.Info("Server stopped gracefully")
 
 	case err := <-serverDone:
 		signal.Stop(sigChan)

--- a/pkg/adapter/base_stop_test.go
+++ b/pkg/adapter/base_stop_test.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"context"
 	"net"
+	"sync"
 	"testing"
 	"time"
 )
@@ -39,5 +40,123 @@ func TestBaseAdapter_Stop_CtxDone_ForceClosesConnections(t *testing.T) {
 	_ = srv.SetWriteDeadline(time.Now().Add(50 * time.Millisecond))
 	if _, writeErr := srv.Write([]byte("probe")); writeErr == nil {
 		t.Fatal("Stop with cancelled context did not force-close the active connection")
+	}
+}
+
+// TestBaseAdapter_Stop_ClosesListener verifies that Stop closes the TCP
+// listener so the adapter stops accepting new connections. This is the first
+// step of a graceful SIGTERM shutdown (issue #1313): a restarting server must
+// stop admitting clients before it drains in-flight work.
+func TestBaseAdapter_Stop_ClosesListener(t *testing.T) {
+	b := NewBaseAdapter(BaseConfig{ShutdownTimeout: 5 * time.Second}, "TEST")
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to bind listener: %v", err)
+	}
+	addr := ln.Addr().String()
+
+	// Wire the listener into the adapter the way ServeWithFactory does and mark
+	// readiness so any concurrent probe observes a started adapter.
+	b.listenerMu.Lock()
+	b.listener = ln
+	b.listenerMu.Unlock()
+	b.started.Store(true)
+	close(b.ListenerReady)
+
+	// Sanity: the listener accepts before Stop.
+	c, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		t.Fatalf("pre-Stop dial should succeed: %v", err)
+	}
+	_ = c.Close()
+
+	if err := b.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop with no active connections should return nil, got %v", err)
+	}
+
+	// After Stop the listener is closed: a fresh accept must fail.
+	if _, err := ln.Accept(); err == nil {
+		t.Fatal("listener still accepting after Stop; Stop did not close it")
+	}
+}
+
+// TestBaseAdapter_Stop_DrainsActiveConnection verifies the graceful happy path:
+// Stop waits for an in-flight connection to finish (within the timeout) and
+// returns nil rather than force-closing it. The complementary force-close path
+// (timeout exceeded) is covered by TestBaseAdapter_Stop_CtxDone_ForceClosesConnections.
+func TestBaseAdapter_Stop_DrainsActiveConnection(t *testing.T) {
+	b := NewBaseAdapter(BaseConfig{ShutdownTimeout: 5 * time.Second}, "TEST")
+
+	// Model one in-flight connection that completes shortly after Stop begins,
+	// mirroring a request handler finishing its work during shutdown.
+	b.activeConns.Add(1)
+	b.ConnCount.Store(1)
+
+	var once sync.Once
+	finish := func() {
+		once.Do(func() {
+			b.ConnCount.Add(-1)
+			b.activeConns.Done()
+		})
+	}
+	defer finish() // safety net if the test fails before the goroutine runs
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		finish()
+	}()
+
+	start := time.Now()
+	if err := b.Stop(context.Background()); err != nil {
+		t.Fatalf("graceful Stop should return nil once the connection drains, got %v", err)
+	}
+	elapsed := time.Since(start)
+
+	// Stop must have actually waited for the drain (~100ms), not returned
+	// instantly, and must not have run to the full timeout.
+	if elapsed < 50*time.Millisecond {
+		t.Fatalf("Stop returned too quickly (%v); it did not wait for the connection to drain", elapsed)
+	}
+	if elapsed >= b.Config.ShutdownTimeout {
+		t.Fatalf("Stop took %v (>= timeout); it did not drain gracefully", elapsed)
+	}
+	if remaining := b.ConnCount.Load(); remaining != 0 {
+		t.Fatalf("expected 0 active connections after graceful drain, got %d", remaining)
+	}
+}
+
+// TestBaseAdapter_InitiateShutdown_InterruptsBlockingReads verifies that
+// shutdown sets a read deadline on active connections so a goroutine blocked
+// in Read unblocks promptly instead of hanging until SIGKILL. This is what
+// lets the SMB/NFS read loops notice shutdown and run their clean
+// per-connection teardown (session cleanup, TCP FIN) within the drain window.
+func TestBaseAdapter_InitiateShutdown_InterruptsBlockingReads(t *testing.T) {
+	b := NewBaseAdapter(BaseConfig{ShutdownTimeout: 5 * time.Second}, "TEST")
+
+	srv, cli := net.Pipe()
+	defer func() { _ = srv.Close() }()
+	defer func() { _ = cli.Close() }()
+	b.ActiveConnections.Store("127.0.0.1:9999", srv)
+
+	readErr := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 1)
+		_, err := srv.Read(buf) // blocks until a deadline is set
+		readErr <- err
+	}()
+
+	// Give the goroutine a moment to enter the blocking Read.
+	time.Sleep(20 * time.Millisecond)
+
+	b.initiateShutdown()
+
+	select {
+	case err := <-readErr:
+		if err == nil {
+			t.Fatal("blocked Read returned without error after shutdown; expected a deadline-exceeded error")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("blocked Read was not interrupted by initiateShutdown within 1s")
 	}
 }

--- a/pkg/adapter/base_stop_test.go
+++ b/pkg/adapter/base_stop_test.go
@@ -74,8 +74,11 @@ func TestBaseAdapter_Stop_ClosesListener(t *testing.T) {
 		t.Fatalf("Stop with no active connections should return nil, got %v", err)
 	}
 
-	// After Stop the listener is closed: a fresh accept must fail.
-	if _, err := ln.Accept(); err == nil {
+	// After Stop the listener is closed: a fresh dial must fail. Probe with
+	// DialTimeout rather than ln.Accept() so a regression where Stop leaves the
+	// listener open surfaces as a fast failure instead of a hung Accept.
+	if c, err := net.DialTimeout("tcp", addr, time.Second); err == nil {
+		_ = c.Close()
 		t.Fatal("listener still accepting after Stop; Stop did not close it")
 	}
 }

--- a/pkg/adapter/base_stop_test.go
+++ b/pkg/adapter/base_stop_test.go
@@ -3,7 +3,6 @@ package adapter
 import (
 	"context"
 	"net"
-	"sync"
 	"testing"
 	"time"
 )
@@ -89,22 +88,16 @@ func TestBaseAdapter_Stop_DrainsActiveConnection(t *testing.T) {
 	b := NewBaseAdapter(BaseConfig{ShutdownTimeout: 5 * time.Second}, "TEST")
 
 	// Model one in-flight connection that completes shortly after Stop begins,
-	// mirroring a request handler finishing its work during shutdown.
+	// mirroring a request handler finishing its work during shutdown. Stop
+	// blocks on activeConns.Wait(), so it cannot return until this goroutine
+	// calls Done().
 	b.activeConns.Add(1)
 	b.ConnCount.Store(1)
 
-	var once sync.Once
-	finish := func() {
-		once.Do(func() {
-			b.ConnCount.Add(-1)
-			b.activeConns.Done()
-		})
-	}
-	defer finish() // safety net if the test fails before the goroutine runs
-
 	go func() {
 		time.Sleep(100 * time.Millisecond)
-		finish()
+		b.ConnCount.Add(-1)
+		b.activeConns.Done()
 	}()
 
 	start := time.Now()

--- a/pkg/adapter/base_stop_test.go
+++ b/pkg/adapter/base_stop_test.go
@@ -90,7 +90,7 @@ func TestBaseAdapter_Stop_ClosesListener(t *testing.T) {
 // TestBaseAdapter_Stop_DrainsActiveConnection verifies the graceful happy path:
 // Stop waits for an in-flight connection to finish (within the timeout) and
 // returns nil rather than force-closing it. The complementary force-close path
-// (timeout exceeded) is covered by TestBaseAdapter_Stop_CtxDone_ForceClosesConnections.
+// (context cancelled) is covered by TestBaseAdapter_Stop_CtxDone_ForceClosesConnections.
 func TestBaseAdapter_Stop_DrainsActiveConnection(t *testing.T) {
 	b := NewBaseAdapter(BaseConfig{ShutdownTimeout: 5 * time.Second}, "TEST")
 

--- a/pkg/adapter/base_stop_test.go
+++ b/pkg/adapter/base_stop_test.go
@@ -70,7 +70,11 @@ func TestBaseAdapter_Stop_ClosesListener(t *testing.T) {
 	}
 	_ = c.Close()
 
-	if err := b.Stop(context.Background()); err != nil {
+	// Bound the call so a regression where Stop never returns fails fast at the
+	// deadline instead of hanging until the global test timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), b.Config.ShutdownTimeout)
+	defer cancel()
+	if err := b.Stop(ctx); err != nil {
 		t.Fatalf("Stop with no active connections should return nil, got %v", err)
 	}
 
@@ -103,8 +107,14 @@ func TestBaseAdapter_Stop_DrainsActiveConnection(t *testing.T) {
 		b.activeConns.Done()
 	}()
 
+	// Bound the call so a regression that never drains fails at the deadline
+	// rather than hanging until the global test timeout; the in-flight
+	// connection drains well within ShutdownTimeout, so the graceful path
+	// (done before ctx) still wins on the happy path.
+	ctx, cancel := context.WithTimeout(context.Background(), b.Config.ShutdownTimeout)
+	defer cancel()
 	start := time.Now()
-	if err := b.Stop(context.Background()); err != nil {
+	if err := b.Stop(ctx); err != nil {
 		t.Fatalf("graceful Stop should return nil once the connection drains, got %v", err)
 	}
 	elapsed := time.Since(start)


### PR DESCRIPTION
## Summary

Addresses the tractable slice of #1313 (clients dropped abruptly on server restart). On investigating the shutdown path, **most of the graceful-teardown machinery already exists on develop** — this PR adds the one missing safety net (a bounded process-level shutdown wait), strengthens regression coverage, and documents honestly what remains.

## What I found already implemented (and verified)

The restart-resilience surface is substantially built already:

- **Signal handling + graceful drain** (`cmd/dfs/commands/start.go`, `pkg/controlplane/runtime/lifecycle/service.go`): SIGINT/SIGTERM cancels the root context; `lifecycle.shutdown` runs an ordered drain — stop settings watcher → drain snapshot goroutines → `StopAllAdapters` → flush pending metadata writes → close metadata stores → stop API/metrics servers. The process waits for `rt.Serve` to fully return before exiting.
- **Adapter `Stop`** (`pkg/adapter/base.go`, embedded by NFS and SMB): closes the listener (stops accepting), interrupts blocking reads via a short read deadline, cancels in-flight request contexts, waits for active connections to drain within `ShutdownTimeout`, then force-closes survivors. NFS/SMB add protocol-specific teardown (portmapper/GSS/Kerberos; SMB session cleanup).
- **SMB session teardown on disconnect** (`internal/adapter/smb/handlers/handler.go`): connection close runs `CleanupSession(..., isDisconnect=true)` → closes files (flushing caches), releases leases, deletes trees/sessions, then TCP FIN.
- **Operator termination grace** (`k8s/dittofs-operator/.../dittoserver_controller.go`): the StatefulSet pod **already** sets `terminationGracePeriodSeconds` (derived from `shutdown_timeout`, default ~105s, overridable via `spec.terminationGracePeriodSeconds`) **and** a `preStop` sleep hook. Covered by controller tests.
- **SMB durable handles + Continuous Availability** (`internal/adapter/smb/handlers/durable_context.go`, `tree_connect.go`, `pkg/metadata/lock/durable_store.go`): `--continuous-availability` share flag is advertised in TREE_CONNECT (`SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY`); CREATE handles DHnQ/DH2Q (incl. CA-gated persistent), and DHnC/DH2C reconnect; durable-handle state is persisted to the metadata store on transport disconnect and **survives a process restart** when backed by a persistent `DurableStore` (badger/postgres). All with existing test coverage (`durable_context_test.go`, `durable_scavenger_test.go`, `reopen2_e2e_test.go`).

In short, a CA-share client holding a (persistent) durable handle, on a persistent metadata backend, already has the mechanism to ride through a restart, and a graceful SIGTERM already triggers clean per-connection teardown rather than mid-session SIGKILL.

## What this PR changes

1. **Bounded process-level shutdown wait** (`cmd/dfs/commands/start.go`): previously the process waited on the runtime drain with **no upper bound**. A wedged stage (e.g. a stuck store flush) would hang the process until Kubernetes SIGKILLs it at the end of `terminationGracePeriod` — dropping clients abruptly, the exact failure #1313 describes. Now the wait is capped at `3*shutdown_timeout + 5s` (95s at the default) — matching the operator's `shutdownStageMultiplier=3` so it stays just inside the operator-derived grace period (`preStop(5) + 3*shutdown_timeout + 10s`) before SIGKILL, so the process always exits on its own within the window and logs the offending timeout.
2. **Adapter graceful-shutdown regression tests** (`pkg/adapter/base_stop_test.go`):
   - `Stop` closes the listener (stops accepting new connections).
   - `Stop` drains an in-flight connection to completion within the timeout and returns nil (the graceful happy path — the pre-existing test only covered force-close on an already-cancelled context).
   - `initiateShutdown` interrupts a goroutine blocked in `Read` (what lets the SMB/NFS read loops notice shutdown and run clean teardown).

## Deliberately deferred (documented per #1313 scope)

- **NFSv4 reboot-grace / RECLAIM coupling.** NLM/NFSv4 grace coordination exists, but a full server-restart grace window that lets clients reclaim NFSv4 state across a process restart (persisting client/lease records and honoring RECLAIM) is a larger, separate effort. Not built here.
- **SMB CA ride-through guarantees beyond the current mechanism.** Durable/persistent handles work, but verifying end-to-end ride-through against real Windows/macOS clients across a restart (and any remaining edge cases in lease/epoch restoration) is acceptance work, not a code change. Left as follow-up.
- **No proactive SMB2 LOGOFF broadcast on shutdown.** The server closes connections cleanly (FIN) and tears down sessions, but does not proactively push a disconnect indication to each client. This is intentional — durable-handle reconnect, not a graceful logoff, is the correct ride-through path.

## Prerequisite

End-to-end resilience is also blocked by **#1312** (a reconnecting client lands on a dead share until that is fixed), which is a separate PR by another agent. The graceful-shutdown and operator-grace work here is independent of #1312 code-wise.

## Verification

```
$ go build ./...                              # clean
$ go test -race ./pkg/adapter/                # ok  github.com/marmos91/dittofs/pkg/adapter  1.791s
$ go vet ./pkg/adapter/ ./cmd/dfs/...         # clean
$ gofmt -l pkg/adapter/base_stop_test.go cmd/dfs/commands/start.go   # no output
```

Operator module was not modified, so its envtest suite was not run.

Refs #1313