### PR TITLE
feat(identity): control-plane API to configure LDAP/Kerberos providers (#1311)

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/marmos91/dittofs/internal/controlplane/api/handlers"
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/internal/sysinfo"
 	"github.com/marmos91/dittofs/pkg/adapter/nfs"
@@ -22,6 +24,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
+	"github.com/marmos91/dittofs/pkg/identity/ldap"
 	badgerstore "github.com/marmos91/dittofs/pkg/metadata/store/badger"
 	"github.com/marmos91/dittofs/pkg/metrics"
 	"github.com/spf13/cobra"
@@ -261,17 +264,13 @@ func runStart(cmd *cobra.Command, args []string) error {
 	// machine SID is resolved before any adapter reads the SID mapper. Pinning
 	// the same SID on every node yields identical local UID->SID encoding.
 	rt.SetPinnedMachineSID(cfg.Identity.MachineSID)
-	rt.SetAdapterFactory(createAdapterFactory(&cfg.Kerberos))
 
-	// Thread the LDAP/AD identity provider config into the runtime so the
-	// adapters' BuildIdentityResolver can register the provider when enabled.
-	if cfg.LDAP.Enabled {
-		ldapCfg := cfg.LDAP
-		rt.SetLDAPConfig(&ldapCfg)
-		logger.Info("LDAP identity provider enabled",
-			"url", cfg.LDAP.URL, "base_dn", cfg.LDAP.BaseDN, "idmap", cfg.LDAP.Idmap,
-			"nested_groups", cfg.LDAP.NestedGroups)
-	}
+	// Resolve identity-provider config: a DB row (managed via the API) wins over
+	// the file/env config; on first boot the file/env config seeds the DB. This
+	// sets the runtime's LDAP config and returns the effective Kerberos config to
+	// hand to the adapter factory.
+	effectiveKerberos := resolveIdentityProviders(ctx, cpStore, rt, cfg)
+	rt.SetAdapterFactory(createAdapterFactory(&effectiveKerberos))
 
 	// Create and set API server
 	apiServer, err := api.NewServer(cfg.ControlPlane, rt, cpStore, cfg.Snapshot.RestoreHTTPTimeout)
@@ -402,6 +401,121 @@ func buildMetricsListener(cfg *config.MetricsConfig, m *metrics.Metrics) (*metri
 		return nil, fmt.Errorf("create metrics server: %w", err)
 	}
 	return srv, nil
+}
+
+// resolveIdentityProviders reconciles identity-provider configuration between
+// the file/env config and the control-plane database. A persisted row (managed
+// over the API) takes precedence; when no row exists the file/env config seeds
+// the database on first boot. It sets the runtime's LDAP config directly and
+// returns the effective Kerberos config for the adapter factory.
+//
+// Note: the API does not manage Kerberos static IdentityMapping entries, so a
+// DB-sourced Kerberos config carries none — those are configured via the
+// separate /api/v1/identity-mappings routes.
+func resolveIdentityProviders(ctx context.Context, cpStore store.Store, rt *runtime.Runtime, cfg *config.Config) config.KerberosConfig {
+	// LDAP: DB row wins; else seed from file/env when enabled.
+	if row, err := cpStore.GetIdentityProviderConfig(ctx, models.IdentityProviderTypeLDAP); err == nil {
+		if lc, derr := ldap.UnmarshalStored([]byte(row.Config)); derr == nil {
+			rt.SetLDAPConfig(lc)
+			logger.Info("LDAP identity provider loaded from control-plane store",
+				"enabled", lc.Enabled, "url", lc.URL, "base_dn", lc.BaseDN)
+		} else {
+			logger.Warn("failed to decode stored LDAP config; ignoring", "error", derr)
+		}
+	} else if errors.Is(err, models.ErrIdentityProviderConfigNotFound) {
+		if cfg.LDAP.Enabled {
+			lc := cfg.LDAP
+			rt.SetLDAPConfig(&lc)
+			if blob, merr := ldap.MarshalStored(&lc); merr != nil {
+				logger.Warn("failed to marshal LDAP config for seeding", "error", merr)
+			} else if perr := cpStore.PutIdentityProviderConfig(ctx, &models.IdentityProviderConfig{
+				Type: models.IdentityProviderTypeLDAP, Enabled: lc.Enabled, Config: string(blob),
+			}); perr != nil {
+				logger.Warn("failed to seed LDAP config into store", "error", perr)
+			}
+			logger.Info("LDAP identity provider enabled (seeded from config file/env)",
+				"url", lc.URL, "base_dn", lc.BaseDN, "idmap", lc.Idmap)
+		}
+	} else {
+		logger.Warn("failed to read stored LDAP config; falling back to file/env", "error", err)
+		if cfg.LDAP.Enabled {
+			lc := cfg.LDAP
+			rt.SetLDAPConfig(&lc)
+		}
+	}
+
+	// Kerberos: DB row wins; else seed from file/env when enabled.
+	kerberos := cfg.Kerberos
+	if row, err := cpStore.GetIdentityProviderConfig(ctx, models.IdentityProviderTypeKerberos); err == nil {
+		var dto handlers.KerberosConfigDTO
+		if json.Unmarshal([]byte(row.Config), &dto) == nil {
+			kerberos = kerberosDTOToConfig(dto)
+			logger.Info("Kerberos identity provider loaded from control-plane store",
+				"enabled", kerberos.Enabled, "service_principal", kerberos.ServicePrincipal)
+		} else {
+			logger.Warn("failed to decode stored Kerberos config; falling back to file/env")
+		}
+	} else if errors.Is(err, models.ErrIdentityProviderConfigNotFound) && cfg.Kerberos.Enabled {
+		if blob, merr := json.Marshal(kerberosConfigToDTO(cfg.Kerberos)); merr == nil {
+			if perr := cpStore.PutIdentityProviderConfig(ctx, &models.IdentityProviderConfig{
+				Type: models.IdentityProviderTypeKerberos, Enabled: cfg.Kerberos.Enabled, Config: string(blob),
+			}); perr != nil {
+				logger.Warn("failed to seed Kerberos config into store", "error", perr)
+			}
+		}
+	}
+	return kerberos
+}
+
+func kerberosConfigToDTO(c config.KerberosConfig) handlers.KerberosConfigDTO {
+	dto := handlers.KerberosConfigDTO{
+		Enabled:          c.Enabled,
+		KeytabPath:       c.KeytabPath,
+		ServicePrincipal: c.ServicePrincipal,
+		Realm:            c.Realm,
+		NetBIOSDomain:    c.NetBIOSDomain,
+		DNSDomain:        c.DNSDomain,
+		Krb5Conf:         c.Krb5Conf,
+		MaxContexts:      c.MaxContexts,
+	}
+	if c.MaxClockSkew > 0 {
+		dto.MaxClockSkew = c.MaxClockSkew.String()
+	}
+	if c.ContextTTL > 0 {
+		dto.ContextTTL = c.ContextTTL.String()
+	}
+	return dto
+}
+
+func kerberosDTOToConfig(dto handlers.KerberosConfigDTO) config.KerberosConfig {
+	c := config.KerberosConfig{
+		Enabled:          dto.Enabled,
+		KeytabPath:       dto.KeytabPath,
+		ServicePrincipal: dto.ServicePrincipal,
+		Realm:            dto.Realm,
+		NetBIOSDomain:    dto.NetBIOSDomain,
+		DNSDomain:        dto.DNSDomain,
+		Krb5Conf:         dto.Krb5Conf,
+		MaxContexts:      dto.MaxContexts,
+	}
+	if d, err := time.ParseDuration(dto.MaxClockSkew); err == nil {
+		c.MaxClockSkew = d
+	}
+	if d, err := time.ParseDuration(dto.ContextTTL); err == nil {
+		c.ContextTTL = d
+	}
+	// Restore the defaults config.MustLoad would have applied, since a
+	// DB-sourced config bypasses ApplyDefaults.
+	if c.MaxClockSkew == 0 {
+		c.MaxClockSkew = 5 * time.Minute
+	}
+	if c.ContextTTL == 0 {
+		c.ContextTTL = 8 * time.Hour
+	}
+	if c.MaxContexts == 0 {
+		c.MaxContexts = 10000
+	}
+	return c
 }
 
 // createAdapterFactory returns a factory function that creates protocol adapters

--- a/cmd/dfsctl/commands/identityprovider/identityprovider.go
+++ b/cmd/dfsctl/commands/identityprovider/identityprovider.go
@@ -1,0 +1,226 @@
+// Package identityprovider implements the `dfsctl identity-provider` command
+// group for managing LDAP/AD and Kerberos identity providers over the REST API.
+package identityprovider
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
+	"github.com/marmos91/dittofs/pkg/apiclient"
+	"github.com/spf13/cobra"
+)
+
+// Cmd is the parent `identity-provider` command.
+var Cmd = &cobra.Command{
+	Use:     "identity-provider",
+	Aliases: []string{"idp"},
+	Short:   "Identity provider (LDAP/AD, Kerberos) management",
+	Long: `Manage DittoFS identity providers (LDAP/AD and Kerberos) over the API.
+
+LDAP changes hot-reload the live identity resolver; Kerberos changes take
+effect on the next server restart. Secret material (bind password) is
+write-only and never displayed.`,
+}
+
+func init() {
+	Cmd.AddCommand(listCmd)
+	Cmd.AddCommand(getCmd)
+	Cmd.AddCommand(setCmd)
+	Cmd.AddCommand(testCmd)
+}
+
+// --- list ---
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List identity providers and their state",
+	RunE:  runList,
+}
+
+// ProviderList renders identity-provider summaries as a table.
+type ProviderList []apiclient.IdentityProviderSummary
+
+// Headers implements TableRenderer.
+func (pl ProviderList) Headers() []string { return []string{"TYPE", "CONFIGURED", "ENABLED"} }
+
+// Rows implements TableRenderer.
+func (pl ProviderList) Rows() [][]string {
+	rows := make([][]string, 0, len(pl))
+	for _, p := range pl {
+		rows = append(rows, []string{p.Type, cmdutil.BoolToYesNo(p.Configured), cmdutil.BoolToYesNo(p.Enabled)})
+	}
+	return rows
+}
+
+func runList(cmd *cobra.Command, args []string) error {
+	client, err := cmdutil.GetAuthenticatedClient()
+	if err != nil {
+		return err
+	}
+	providers, err := client.ListIdentityProviders()
+	if err != nil {
+		return fmt.Errorf("failed to list identity providers: %w", err)
+	}
+	return cmdutil.PrintOutput(os.Stdout, providers, len(providers) == 0, "No identity providers.", ProviderList(providers))
+}
+
+// --- get ---
+
+var getCmd = &cobra.Command{
+	Use:   "get <ldap|kerberos>",
+	Short: "Show an identity provider's configuration (secrets redacted)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runGet,
+}
+
+func runGet(cmd *cobra.Command, args []string) error {
+	client, err := cmdutil.GetAuthenticatedClient()
+	if err != nil {
+		return err
+	}
+	var cfg any
+	switch args[0] {
+	case "ldap":
+		cfg, err = client.GetLDAPConfig()
+	case "kerberos":
+		cfg, err = client.GetKerberosConfig()
+	default:
+		return fmt.Errorf("unknown provider type %q (want ldap or kerberos)", args[0])
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get %s config: %w", args[0], err)
+	}
+	return cmdutil.PrintResourceWithSuccess(os.Stdout, cfg,
+		fmt.Sprintf("Retrieved %s identity provider configuration (use -o json|yaml to view).", args[0]))
+}
+
+// --- set ---
+
+var setConfigJSON string
+
+var setCmd = &cobra.Command{
+	Use:   "set <ldap|kerberos> --config '<json>'",
+	Short: "Create or replace an identity provider's configuration",
+	Long: `Create or replace an identity provider's configuration from a JSON body.
+
+The JSON shape matches the API config schema. For LDAP, set "bind_password" to
+the real password (or "********" / omit to keep the stored one). LDAP changes
+apply live; Kerberos changes apply on the next server restart.
+
+Examples:
+  dfsctl identity-provider set ldap --config '{"enabled":true,"url":"ldaps://dc:636","base_dn":"DC=x,DC=y","bind_dn":"CN=svc,DC=x,DC=y","bind_password":"s3cret","idmap":"rfc2307"}'
+  dfsctl identity-provider set kerberos --config @/path/to/krb.json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSet,
+}
+
+func init() {
+	setCmd.Flags().StringVar(&setConfigJSON, "config", "", "configuration as a JSON string, or @file to read from a file (required)")
+	_ = setCmd.MarkFlagRequired("config")
+	testCmd.Flags().StringVar(&testConfigJSON, "config", "", "configuration to test as a JSON string, or @file (required)")
+	_ = testCmd.MarkFlagRequired("config")
+}
+
+func runSet(cmd *cobra.Command, args []string) error {
+	client, err := cmdutil.GetAuthenticatedClient()
+	if err != nil {
+		return err
+	}
+	body, err := readConfigArg(setConfigJSON)
+	if err != nil {
+		return err
+	}
+	switch args[0] {
+	case "ldap":
+		var cfg apiclient.LDAPProviderConfig
+		if err := json.Unmarshal(body, &cfg); err != nil {
+			return fmt.Errorf("invalid LDAP config JSON: %w", err)
+		}
+		out, err := client.PutLDAPConfig(&cfg)
+		if err != nil {
+			return fmt.Errorf("failed to set LDAP config: %w", err)
+		}
+		return cmdutil.PrintResourceWithSuccess(os.Stdout, out, "Updated LDAP identity provider configuration.")
+	case "kerberos":
+		var cfg apiclient.KerberosProviderConfig
+		if err := json.Unmarshal(body, &cfg); err != nil {
+			return fmt.Errorf("invalid Kerberos config JSON: %w", err)
+		}
+		out, err := client.PutKerberosConfig(&cfg)
+		if err != nil {
+			return fmt.Errorf("failed to set Kerberos config: %w", err)
+		}
+		if _, perr := fmt.Fprintln(os.Stderr, "Kerberos configuration saved; it will take effect on the next server restart."); perr != nil {
+			return perr
+		}
+		return cmdutil.PrintResourceWithSuccess(os.Stdout, out, "Saved Kerberos identity provider configuration (applies on next server restart).")
+	default:
+		return fmt.Errorf("unknown provider type %q (want ldap or kerberos)", args[0])
+	}
+}
+
+// --- test ---
+
+var testConfigJSON string
+
+var testCmd = &cobra.Command{
+	Use:   "test <ldap|kerberos> --config '<json>'",
+	Short: "Test an identity provider's configuration without persisting it",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runTest,
+}
+
+func runTest(cmd *cobra.Command, args []string) error {
+	client, err := cmdutil.GetAuthenticatedClient()
+	if err != nil {
+		return err
+	}
+	body, err := readConfigArg(testConfigJSON)
+	if err != nil {
+		return err
+	}
+	var result *apiclient.IdentityProviderTestResult
+	switch args[0] {
+	case "ldap":
+		var cfg apiclient.LDAPProviderConfig
+		if err := json.Unmarshal(body, &cfg); err != nil {
+			return fmt.Errorf("invalid LDAP config JSON: %w", err)
+		}
+		result, err = client.TestLDAPConfig(&cfg)
+	case "kerberos":
+		var cfg apiclient.KerberosProviderConfig
+		if err := json.Unmarshal(body, &cfg); err != nil {
+			return fmt.Errorf("invalid Kerberos config JSON: %w", err)
+		}
+		result, err = client.TestKerberosConfig(&cfg)
+	default:
+		return fmt.Errorf("unknown provider type %q (want ldap or kerberos)", args[0])
+	}
+	if err != nil {
+		return fmt.Errorf("failed to test %s config: %w", args[0], err)
+	}
+	if perr := cmdutil.PrintResourceWithSuccess(os.Stdout, result, fmt.Sprintf("Test result: ok=%t %s", result.OK, result.Message)); perr != nil {
+		return perr
+	}
+	if !result.OK {
+		return fmt.Errorf("provider test failed at stage %q: %s", result.Stage, result.Message)
+	}
+	return nil
+}
+
+// --- helpers ---
+
+// readConfigArg returns the raw config bytes from a JSON string, or from a file
+// when the argument is prefixed with '@'.
+func readConfigArg(arg string) ([]byte, error) {
+	if len(arg) > 1 && arg[0] == '@' {
+		data, err := os.ReadFile(arg[1:])
+		if err != nil {
+			return nil, fmt.Errorf("read config file: %w", err)
+		}
+		return data, nil
+	}
+	return []byte(arg), nil
+}

--- a/cmd/dfsctl/commands/root.go
+++ b/cmd/dfsctl/commands/root.go
@@ -11,6 +11,7 @@ import (
 	ctxcmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/context"
 	gracecmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/grace"
 	groupcmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/group"
+	idpcmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/identityprovider"
 	idmapcmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/idmap"
 	netgroupcmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/netgroup"
 	quotacmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/quota"
@@ -98,6 +99,7 @@ func init() {
 	rootCmd.AddCommand(gracecmd.Cmd)
 	rootCmd.AddCommand(netgroupcmd.Cmd)
 	rootCmd.AddCommand(idmapcmd.Cmd)
+	rootCmd.AddCommand(idpcmd.Cmd)
 	rootCmd.AddCommand(settingscmd.Cmd)
 	rootCmd.AddCommand(switchUserCmd)
 	rootCmd.AddCommand(systemcmd.Cmd)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -582,6 +582,11 @@ dfsctl
     get            Get group details
     list           List all groups
     remove-user    Remove a user from a group
+  identity-provider Identity provider (LDAP/AD, Kerberos) management
+    get            Show an identity provider's configuration (secrets redacted)
+    list           List identity providers and their state
+    set            Create or replace an identity provider's configuration
+    test           Test an identity provider's configuration without persisting it
   idmap          Manage identity mappings
     add            Add an identity mapping
     list           List identity mappings
@@ -2279,6 +2284,140 @@ Examples:
 
 ```
 dfsctl group remove-user <group> <username>
+```
+
+Global flags:
+
+```
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
+```
+
+### `dfsctl identity-provider`
+
+Identity provider (LDAP/AD, Kerberos) management
+
+Manage DittoFS identity providers (LDAP/AD and Kerberos) over the API.
+
+LDAP changes hot-reload the live identity resolver; Kerberos changes take
+effect on the next server restart. Secret material (bind password) is
+write-only and never displayed.
+
+Global flags:
+
+```
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
+```
+
+### `dfsctl identity-provider get`
+
+Show an identity provider's configuration (secrets redacted)
+
+```
+dfsctl identity-provider get <ldap|kerberos>
+```
+
+Global flags:
+
+```
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
+```
+
+### `dfsctl identity-provider list`
+
+List identity providers and their state
+
+```
+dfsctl identity-provider list
+```
+
+Global flags:
+
+```
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
+```
+
+### `dfsctl identity-provider set`
+
+Create or replace an identity provider's configuration
+
+Create or replace an identity provider's configuration from a JSON body.
+
+The JSON shape matches the API config schema. For LDAP, set "bind_password" to
+the real password (or "********" / omit to keep the stored one). LDAP changes
+apply live; Kerberos changes apply on the next server restart.
+
+Examples:
+  dfsctl identity-provider set ldap --config '{"enabled":true,"url":"ldaps://dc:636","base_dn":"DC=x,DC=y","bind_dn":"CN=svc,DC=x,DC=y","bind_password":"s3cret","idmap":"rfc2307"}'
+  dfsctl identity-provider set kerberos --config @/path/to/krb.json
+
+```
+dfsctl identity-provider set <ldap|kerberos> --config '<json>' [flags]
+```
+
+Flags:
+
+```
+      --config string   configuration as a JSON string, or @file to read from a file (required)
+```
+
+Global flags:
+
+```
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
+```
+
+### `dfsctl identity-provider test`
+
+Test an identity provider's configuration without persisting it
+
+```
+dfsctl identity-provider test <ldap|kerberos> --config '<json>' [flags]
+```
+
+Flags:
+
+```
+      --config string   configuration to test as a JSON string, or @file (required)
 ```
 
 Global flags:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1613,6 +1613,26 @@ default Samba AD-DC works out of the box. For production directories, prefer a
 properly-issued DC certificate (the Go toggle is slated for removal in a future
 release).
 
+**Managing identity providers over the API (no restart).** The `ldap.*` and
+`kerberos.*` keys above seed the configuration on first boot. After that, both
+providers can be read, updated, and tested over the control-plane API without
+editing files:
+
+| Method & path | Purpose |
+|---|---|
+| `GET /api/v1/identity-providers` | List providers + enabled state (no secrets). |
+| `GET /api/v1/identity-providers/{type}/config` | Read config (bind password redacted to `********`). |
+| `PUT /api/v1/identity-providers/{type}/config` | Create/replace config (validated). |
+| `POST /api/v1/identity-providers/{type}/test` | Dry-run dial+bind (LDAP) / keytab check (Kerberos); never persists. |
+
+`{type}` is `ldap` or `kerberos`; all routes are admin-only. A persisted config
+**takes precedence over the file/env config** on subsequent boots. **LDAP
+changes hot-reload the live resolver**; **Kerberos changes take effect on the
+next server restart** (the NFS/SMB adapters bind it at startup). The bind
+password is write-only — submit `********` (or omit it) on `PUT` to keep the
+stored secret. Equivalent CLI: `dfsctl identity-provider {list,get,set,test}`
+(see [CLI.md](CLI.md)).
+
 ## Migration
 
 ### Required when upgrading from v0.15.x or earlier

--- a/docs/SMB.md
+++ b/docs/SMB.md
@@ -630,6 +630,19 @@ DittoFS implements NTLMv2 authentication with SPNEGO negotiation:
 3. Client sends SESSION_SETUP with NTLM response
 4. Server validates credentials and creates session
 
+> **NTLM authenticates local DittoFS users only.** The NTLMv2 response is
+> validated against the NT hash in the control-plane user store. An **AD domain
+> user** has no local account and no local NT hash, so NTLM logon for domain
+> users fails with `STATUS_LOGON_FAILURE`. Validating a domain user's NTLM
+> response would require a NETLOGON secure-channel passthrough to the DC
+> (`NetrLogonSamLogon`), which is **not implemented** (tracked in issue #1314,
+> tied to the deferred online-join work).
+>
+> **For AD domain users, use Kerberos** (below): the DC issues the ticket and
+> DittoFS validates it with its service keytab — no passthrough needed. The
+> LDAP/AD directory integration resolves *identity* (UID/GID, groups); it does
+> **not** authenticate NTLM.
+
 ### Kerberos Authentication
 
 DittoFS supports Kerberos authentication via SPNEGO alongside NTLM. When a client presents a Kerberos AP-REQ token in the SPNEGO negotiation, the server validates the ticket using the configured service keytab and maps the Kerberos principal to a control plane user.
@@ -638,7 +651,8 @@ Key details:
 
 - **Single round-trip**: Unlike NTLM's multi-step handshake, Kerberos authentication completes in one exchange (AP-REQ/AP-REP)
 - **Shared keytab**: The SMB adapter shares the Kerberos keytab with the NFS adapter; the server automatically derives the `cifs/` service principal from the configured `nfs/` principal
-- **Principal-to-user mapping**: The client principal name (without realm) is looked up in the control plane user store
+- **Principal-to-user mapping**: The client principal is resolved through the centralized identity resolver. A **local** DittoFS account matching the principal wins. When no local account exists but the **LDAP/AD directory** resolves the principal (RFC2307 UID/GID + groups), the session is built from that directory identity — an AD domain user does **not** need a pre-created local account (this mirrors the NFS `sec=krb5` path, so the same user maps to the same UID/GID across both protocols). A valid ticket whose principal resolves to neither a local account nor the directory is rejected (it is not treated as guest).
+  - **Authorization keys on group SIDs, not POSIX supplementary GIDs.** A directory-resolved SMB session carries the user's UID + primary GID + SID + the PAC's transitive group SIDs (Windows ACL checks use the SIDs). It does not carry the resolver's full nested/supplementary GID list — SMB authorization never used POSIX supplementary GIDs. Practical effect: a POSIX-mode file group-owned by one of the user's *nested* AD groups is granted over NFS (`sec=krb5`, via supplementary GIDs) but over SMB only when a matching group-SID ACE is present.
 - **SPNEGO negotiation**: The server advertises both NTLM and Kerberos OIDs; clients choose based on their configuration
 
 See `test/e2e/smb_kerberos_test.go` for end-to-end Kerberos authentication tests.

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -208,10 +208,15 @@ type Handler struct {
 	// Deprecated: use IdentityResolver for DB-backed resolution.
 	IdentityConfig *kerberos.IdentityConfig
 
-	// IdentityResolver resolves Kerberos principals to DittoFS users via
+	// identityResolver resolves Kerberos principals to DittoFS users via
 	// the centralized identity provider chain. When set, takes precedence
 	// over IdentityConfig. When nil, falls back to IdentityConfig.
-	IdentityResolver *pkgidentity.Resolver
+	//
+	// It is held in an atomic.Pointer because the identity-provider config can
+	// be hot-reloaded over the API (which rebuilds and re-injects a fresh
+	// resolver via SetIdentityResolver) while session-setup goroutines read it
+	// concurrently. Access only through SetIdentityResolver / IdentityResolver.
+	identityResolver atomic.Pointer[pkgidentity.Resolver]
 
 	// SMBServicePrincipal overrides the auto-derived CIFS service principal.
 	// When empty, derived from the NFS principal ("nfs/host@REALM" -> "cifs/host@REALM").
@@ -909,6 +914,19 @@ func (h *Handler) sessionDomain(fallback string) string {
 		return h.NetBIOSDomain
 	}
 	return fallback
+}
+
+// SetIdentityResolver atomically installs the centralized identity resolver.
+// Safe to call while session-setup goroutines read it (used for API-driven
+// identity-provider config hot-reload). Pass nil to clear.
+func (h *Handler) SetIdentityResolver(r *pkgidentity.Resolver) {
+	h.identityResolver.Store(r)
+}
+
+// IdentityResolver returns the current centralized identity resolver, or nil
+// when none is installed.
+func (h *Handler) IdentityResolver() *pkgidentity.Resolver {
+	return h.identityResolver.Load()
 }
 
 // GetSession retrieves a session by ID.

--- a/internal/adapter/smb/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/handlers/kerberos_auth.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -75,9 +76,9 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 	// smb2.session.encryption-aes-256-{ccm,gcm} under Kerberos (#686).
 	sessionKey := authResult.SessionKey.KeyValue
 
-	// Resolve principal to DittoFS username via centralized identity resolver
-	// (DB-backed mapping + convention fallback), or legacy IdentityConfig.
-	username := h.resolveKerberosPrincipal(ctx, authResult.Principal, authResult.Realm)
+	// Resolve principal to a DittoFS identity via the centralized resolver
+	// (DB-backed mapping + LDAP/AD directory + convention fallback).
+	resolved, username := h.resolveKerberosIdentity(ctx, authResult.Principal, authResult.Realm)
 
 	logger.Debug("Kerberos authentication succeeded",
 		"principal", authResult.Principal,
@@ -94,12 +95,19 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 		return NewErrorResult(types.StatusLogonFailure), nil
 	}
 
-	user, err := userStore.GetUser(ctx.Context, username)
-	if err != nil || user == nil || !user.Enabled {
+	localUser, err := userStore.GetUser(ctx.Context, username)
+	user, ok := resolveSessionUser(localUser, err, resolved)
+	if !ok {
 		logger.Info("Kerberos auth: user lookup failed",
 			"username", username, "principal", authResult.Principal,
-			"found", user != nil, "error", err)
+			"found", localUser != nil, "resolverFound", resolved != nil && resolved.Found, "error", err)
 		return NewErrorResult(types.StatusLogonFailure), nil
+	}
+	if localUser == nil {
+		// Directory-resolved AD/LDAP user with no local account (mirrors NFS GSS).
+		logger.Info("Kerberos auth: using directory-resolved identity (no local account)",
+			"username", user.Username, "uid", resolved.UID, "gid", resolved.GID,
+			"principal", authResult.Principal)
 	}
 
 	// Kerberos ticket end-time becomes the session expiry. prepareDispatch
@@ -359,17 +367,19 @@ func (h *Handler) completeKerberosBind(ctx *SMBHandlerContext, sess *session.Ses
 	// for the signing key, and a future AES-256 cipher derivation would use the
 	// full key. See handleKerberosAuth for the rationale (#686).
 	sessionKey := authResult.SessionKey.KeyValue
-	username := h.resolveKerberosPrincipal(ctx, authResult.Principal, authResult.Realm)
+	resolved, username := h.resolveKerberosIdentity(ctx, authResult.Principal, authResult.Realm)
 
 	userStore := h.Registry.GetUserStore()
 	if userStore == nil {
 		logger.Debug("Kerberos bind: no UserStore configured")
 		return NewErrorResult(types.StatusLogonFailure), nil
 	}
-	user, err := userStore.GetUser(ctx.Context, username)
-	if err != nil || user == nil || !user.Enabled {
+	localUser, err := userStore.GetUser(ctx.Context, username)
+	user, ok := resolveSessionUser(localUser, err, resolved)
+	if !ok {
 		logger.Info("Kerberos bind: user lookup failed",
-			"username", username, "principal", authResult.Principal, "found", user != nil, "error", err)
+			"username", username, "principal", authResult.Principal, "found", localUser != nil,
+			"resolverFound", resolved != nil && resolved.Found, "error", err)
 		return NewErrorResult(types.StatusLogonFailure), nil
 	}
 
@@ -501,22 +511,68 @@ func clientKerberosOID(parsedToken *auth.ParsedToken) asn1.ObjectIdentifier {
 	return auth.OIDKerberosV5
 }
 
-// resolveKerberosPrincipal resolves a Kerberos principal to a DittoFS username.
-// Uses the centralized identity resolver when available, falling back to the
-// legacy IdentityConfig-based resolution for backward compatibility.
-func (h *Handler) resolveKerberosPrincipal(ctx *SMBHandlerContext, principal, realm string) string {
-	if h.IdentityResolver != nil {
+// resolveKerberosIdentity resolves a Kerberos principal via the centralized
+// identity resolver, returning the full resolved identity and the username.
+//
+// When the resolver (including the LDAP/AD provider) matches, the returned
+// *identity.ResolvedIdentity carries the directory UID/GID/SIDs and Found=true,
+// so the caller can build a session for an AD/LDAP user that has no local dfs
+// account — mirroring the NFS GSS path. When the resolver is absent or misses,
+// it falls back to legacy IdentityConfig name resolution and returns a nil
+// identity (the caller then requires a local account).
+func (h *Handler) resolveKerberosIdentity(ctx *SMBHandlerContext, principal, realm string) (*identity.ResolvedIdentity, string) {
+	if resolver := h.IdentityResolver(); resolver != nil {
 		cred := &identity.Credential{
 			Provider:   "kerberos",
 			ExternalID: principal + "@" + realm,
 			Attributes: map[string]string{"realm": realm},
 		}
-		resolved, err := h.IdentityResolver.Resolve(ctx.Context, cred)
+		resolved, err := resolver.Resolve(ctx.Context, cred)
 		if err == nil && resolved.Found {
-			return resolved.Username
+			return resolved, resolved.Username
 		}
 	}
-	return pkgkerberos.ResolvePrincipal(principal, realm, h.IdentityConfig)
+	return nil, pkgkerberos.ResolvePrincipal(principal, realm, h.IdentityConfig)
+}
+
+// synthUserFromResolved builds a transient, non-persisted *models.User from a
+// directory-resolved identity so an AD/LDAP user with no local control-plane
+// account can still establish an SMB session. getUserIdentity derives the
+// primary GID from the first group, so the resolved primary GID is exposed
+// that way; SID/GroupSIDs flow into the SMB authorization context.
+func synthUserFromResolved(r *identity.ResolvedIdentity) *models.User {
+	uid := r.UID
+	gid := r.GID
+	return &models.User{
+		Username:  r.Username,
+		UID:       &uid,
+		Groups:    []models.Group{{GID: &gid}},
+		SID:       r.SID,
+		GroupSIDs: r.GroupSIDs,
+		Enabled:   true,
+	}
+}
+
+// resolveSessionUser picks the user to back a Kerberos session after a ticket
+// has been validated. A local, enabled control-plane account wins. Otherwise,
+// when the principal was resolved by the directory (LDAP/AD), a transient user
+// is synthesized from that identity so an AD user with no local account can log
+// in. A disabled local account or an unresolved principal yields ok=false (the
+// caller returns STATUS_LOGON_FAILURE — a valid ticket from an unknown/blocked
+// principal is not a guest).
+//
+// The directory fallback fires ONLY on an explicit "user not found" — a
+// transient store error (DB down) must not let a session through, and a
+// disabled local account (returned with no error) must not be bypassed.
+func resolveSessionUser(localUser *models.User, localErr error, resolved *identity.ResolvedIdentity) (*models.User, bool) {
+	switch {
+	case localErr == nil && localUser != nil && localUser.Enabled:
+		return localUser, true
+	case errors.Is(localErr, models.ErrUserNotFound) && resolved != nil && resolved.Found:
+		return synthUserFromResolved(resolved), true
+	default:
+		return nil, false
+	}
 }
 
 func extractAPReqFromGSSToken(token []byte) ([]byte, error) {

--- a/internal/adapter/smb/handlers/kerberos_identity_test.go
+++ b/internal/adapter/smb/handlers/kerberos_identity_test.go
@@ -1,0 +1,69 @@
+package handlers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/identity"
+)
+
+// Regression tests for #1317: SMB Kerberos must accept an AD/LDAP user that the
+// identity resolver matched even when no local control-plane account exists,
+// while still failing closed for disabled local accounts and unresolved
+// principals.
+
+func TestResolveSessionUser_LocalEnabledWins(t *testing.T) {
+	uid := uint32(1000)
+	local := &models.User{Username: "alice", UID: &uid, Enabled: true}
+	resolved := &identity.ResolvedIdentity{Username: "alice", UID: 10001, GID: 10000, Found: true}
+
+	got, ok := resolveSessionUser(local, nil, resolved)
+	if !ok || got != local {
+		t.Fatalf("local enabled account must win: ok=%v got=%v", ok, got)
+	}
+}
+
+func TestResolveSessionUser_DirectoryResolvedWhenNoLocalAccount(t *testing.T) {
+	resolved := &identity.ResolvedIdentity{
+		Username: "alice", UID: 10001, GID: 10000,
+		SID: "S-1-5-21-1-2-3-1104", GroupSIDs: []string{"S-1-5-21-1-2-3-513"}, Found: true,
+	}
+
+	got, ok := resolveSessionUser(nil, models.ErrUserNotFound, resolved)
+	if !ok {
+		t.Fatal("expected directory-resolved identity to be accepted")
+	}
+	if got.Username != "alice" || got.UID == nil || *got.UID != 10001 {
+		t.Fatalf("synthesized user wrong: %+v", got)
+	}
+	// getUserIdentity must derive the resolved UID + primary GID.
+	uid, gid := getUserIdentity(got)
+	if uid != 10001 || gid != 10000 {
+		t.Fatalf("getUserIdentity = %d/%d, want 10001/10000", uid, gid)
+	}
+	if got.SID != "S-1-5-21-1-2-3-1104" || len(got.GroupSIDs) != 1 {
+		t.Fatalf("SID/GroupSIDs not carried: %+v", got)
+	}
+}
+
+func TestResolveSessionUser_DisabledLocalAccountFailsClosed(t *testing.T) {
+	uid := uint32(1000)
+	disabled := &models.User{Username: "alice", UID: &uid, Enabled: false}
+	resolved := &identity.ResolvedIdentity{Username: "alice", UID: 10001, GID: 10000, Found: true}
+
+	// A disabled local account is an explicit block and must NOT be overridden
+	// by the directory identity.
+	if _, ok := resolveSessionUser(disabled, nil, resolved); ok {
+		t.Fatal("disabled local account must fail closed")
+	}
+}
+
+func TestResolveSessionUser_UnresolvedPrincipalFailsClosed(t *testing.T) {
+	if _, ok := resolveSessionUser(nil, models.ErrUserNotFound, &identity.ResolvedIdentity{Found: false}); ok {
+		t.Fatal("unresolved principal must fail closed (not guest)")
+	}
+	if _, ok := resolveSessionUser(nil, errors.New("store down"), nil); ok {
+		t.Fatal("nil resolver + no local user must fail closed")
+	}
+}

--- a/internal/controlplane/api/handlers/identity_providers.go
+++ b/internal/controlplane/api/handlers/identity_providers.go
@@ -1,0 +1,448 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	krb5config "github.com/jcmturner/gokrb5/v8/config"
+	"github.com/jcmturner/gokrb5/v8/keytab"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/controlplane/store"
+	"github.com/marmos91/dittofs/pkg/identity/ldap"
+)
+
+// IdentityProviderHandler serves the admin-only identity-provider configuration
+// API (LDAP/AD and Kerberos). Configuration is persisted in the control-plane
+// database so it can be managed without editing config files or restarting the
+// server; LDAP changes additionally hot-reload the live identity resolver.
+type IdentityProviderHandler struct {
+	store   store.IdentityProviderConfigStore
+	runtime *runtime.Runtime
+}
+
+// NewIdentityProviderHandler constructs an IdentityProviderHandler.
+func NewIdentityProviderHandler(s store.IdentityProviderConfigStore, rt *runtime.Runtime) *IdentityProviderHandler {
+	return &IdentityProviderHandler{store: s, runtime: rt}
+}
+
+// --- Wire DTOs (snake_case; secrets are write-only) ---
+
+type ldapTLSDTO struct {
+	CACertFile         string `json:"ca_cert_file"`
+	ClientCertFile     string `json:"client_cert_file"`
+	ClientKeyFile      string `json:"client_key_file"`
+	InsecureSkipVerify bool   `json:"insecure_skip_verify"`
+	MinVersion         string `json:"min_version"`
+}
+
+type ldapConfigDTO struct {
+	Enabled         bool       `json:"enabled"`
+	URL             string     `json:"url"`
+	StartTLS        bool       `json:"start_tls"`
+	AllowPlaintext  bool       `json:"allow_plaintext"`
+	BaseDN          string     `json:"base_dn"`
+	BindDN          string     `json:"bind_dn"`
+	BindPassword    string     `json:"bind_password,omitempty"`
+	UserAttr        string     `json:"user_attr"`
+	Realm           string     `json:"realm"`
+	Idmap           string     `json:"idmap"`
+	NestedGroups    bool       `json:"nested_groups"`
+	Timeout         string     `json:"timeout"`
+	MaxGroupResults int        `json:"max_group_results"`
+	TLS             ldapTLSDTO `json:"tls"`
+}
+
+// KerberosConfigDTO is the wire/persistence shape for Kerberos identity
+// provider configuration. It is exported so cmd/dfs can decode the persisted
+// row at startup and map it onto config.KerberosConfig — the handler cannot
+// import pkg/config (which imports the control-plane API package, creating a
+// cycle), so the config mapping lives in cmd. Durations are strings
+// (Go time.Duration syntax, e.g. "5m", "8h").
+type KerberosConfigDTO struct {
+	Enabled          bool   `json:"enabled"`
+	KeytabPath       string `json:"keytab_path"`
+	ServicePrincipal string `json:"service_principal"`
+	Realm            string `json:"realm"`
+	NetBIOSDomain    string `json:"netbios_domain"`
+	DNSDomain        string `json:"dns_domain"`
+	Krb5Conf         string `json:"krb5_conf"`
+	MaxClockSkew     string `json:"max_clock_skew"`
+	ContextTTL       string `json:"context_ttl"`
+	MaxContexts      int    `json:"max_contexts"`
+}
+
+type identityProviderSummary struct {
+	Type       string `json:"type"`
+	Enabled    bool   `json:"enabled"`
+	Configured bool   `json:"configured"`
+}
+
+type testResult struct {
+	OK        bool   `json:"ok"`
+	Stage     string `json:"stage,omitempty"`
+	Message   string `json:"message,omitempty"`
+	LatencyMS int64  `json:"latency_ms,omitempty"`
+}
+
+// List reports the configured/enabled state of each identity provider type
+// without exposing any secrets.
+func (h *IdentityProviderHandler) List(w http.ResponseWriter, r *http.Request) {
+	out := make([]identityProviderSummary, 0, 2)
+	for _, t := range []string{models.IdentityProviderTypeLDAP, models.IdentityProviderTypeKerberos} {
+		s := identityProviderSummary{Type: t}
+		row, err := h.store.GetIdentityProviderConfig(r.Context(), t)
+		switch {
+		case err == nil:
+			s.Configured = true
+			s.Enabled = row.Enabled
+		case errors.Is(err, models.ErrIdentityProviderConfigNotFound):
+			// leave Configured=false
+		default:
+			InternalServerError(w, "Failed to list identity providers")
+			return
+		}
+		out = append(out, s)
+	}
+	WriteJSONOK(w, out)
+}
+
+// GetConfig returns the stored configuration for a provider type with all
+// secret material redacted. Returns 404 when the provider is not configured.
+func (h *IdentityProviderHandler) GetConfig(w http.ResponseWriter, r *http.Request) {
+	providerType := chi.URLParam(r, "type")
+	row := h.loadRow(w, r, providerType)
+	if row == nil {
+		return // loadRow wrote the error/response
+	}
+
+	switch providerType {
+	case models.IdentityProviderTypeLDAP:
+		cfg, derr := ldap.UnmarshalStored([]byte(row.Config))
+		if derr != nil {
+			InternalServerError(w, "Failed to decode stored LDAP config")
+			return
+		}
+		WriteJSONOK(w, ldapConfigToDTO(cfg))
+	case models.IdentityProviderTypeKerberos:
+		var dto KerberosConfigDTO
+		if jerr := json.Unmarshal([]byte(row.Config), &dto); jerr != nil {
+			InternalServerError(w, "Failed to decode stored Kerberos config")
+			return
+		}
+		WriteJSONOK(w, dto) // Kerberos DTO carries no inline secret field
+	}
+}
+
+// PutConfig creates or replaces the configuration for a provider type. The body
+// is validated, persisted, and (for LDAP) hot-reloaded into the live resolver.
+func (h *IdentityProviderHandler) PutConfig(w http.ResponseWriter, r *http.Request) {
+	providerType := chi.URLParam(r, "type")
+	switch providerType {
+	case models.IdentityProviderTypeLDAP:
+		h.putLDAP(w, r)
+	case models.IdentityProviderTypeKerberos:
+		h.putKerberos(w, r)
+	default:
+		NotFound(w, "Unknown identity provider type")
+	}
+}
+
+// Test performs a non-persisting reachability/validity check for a provider.
+func (h *IdentityProviderHandler) Test(w http.ResponseWriter, r *http.Request) {
+	providerType := chi.URLParam(r, "type")
+	switch providerType {
+	case models.IdentityProviderTypeLDAP:
+		h.testLDAP(w, r)
+	case models.IdentityProviderTypeKerberos:
+		h.testKerberos(w, r)
+	default:
+		NotFound(w, "Unknown identity provider type")
+	}
+}
+
+// --- LDAP ---
+
+func (h *IdentityProviderHandler) putLDAP(w http.ResponseWriter, r *http.Request) {
+	var dto ldapConfigDTO
+	if !decodeJSONBody(w, r, &dto) {
+		return
+	}
+	cfg, err := h.ldapConfigFromDTO(r, &dto)
+	if err != nil {
+		BadRequest(w, err.Error())
+		return
+	}
+	cfg.ApplyDefaults()
+	if verr := cfg.Validate(); verr != nil {
+		BadRequest(w, verr.Error())
+		return
+	}
+
+	blob, err := ldap.MarshalStored(cfg)
+	if err != nil {
+		InternalServerError(w, "Failed to encode LDAP config")
+		return
+	}
+	if err := h.store.PutIdentityProviderConfig(r.Context(), &models.IdentityProviderConfig{
+		Type:    models.IdentityProviderTypeLDAP,
+		Enabled: cfg.Enabled,
+		Config:  string(blob),
+	}); err != nil {
+		InternalServerError(w, "Failed to persist LDAP config")
+		return
+	}
+
+	// Hot-reload: update the runtime's live config and rebuild the resolver in
+	// every adapter so the change takes effect without a restart.
+	if h.runtime != nil {
+		h.runtime.SetLDAPConfig(cfg)
+		h.runtime.NotifyIdentityProviderConfigChange()
+	}
+
+	WriteJSONOK(w, ldapConfigToDTO(cfg))
+}
+
+func (h *IdentityProviderHandler) testLDAP(w http.ResponseWriter, r *http.Request) {
+	var dto ldapConfigDTO
+	if !decodeJSONBody(w, r, &dto) {
+		return
+	}
+	cfg, err := h.ldapConfigFromDTO(r, &dto)
+	if err != nil {
+		WriteJSON(w, http.StatusOK, testResult{OK: false, Stage: "validate", Message: err.Error()})
+		return
+	}
+	// Validate up front so config errors are reported with Stage="validate";
+	// only an actual dial/bind failure then surfaces as Stage="connect".
+	cfg.ApplyDefaults()
+	if verr := cfg.Validate(); verr != nil {
+		WriteJSON(w, http.StatusOK, testResult{OK: false, Stage: "validate", Message: verr.Error()})
+		return
+	}
+	start := time.Now()
+	if terr := ldap.TestConnection(r.Context(), cfg); terr != nil {
+		WriteJSON(w, http.StatusOK, testResult{OK: false, Stage: "connect", Message: terr.Error()})
+		return
+	}
+	WriteJSON(w, http.StatusOK, testResult{OK: true, Message: "dial + bind succeeded", LatencyMS: time.Since(start).Milliseconds()})
+}
+
+// ldapConfigFromDTO maps a wire DTO to a domain ldap.Config, resolving the
+// write-only bind password: an empty or redacted-placeholder password means
+// "keep the currently stored password" so a read-modify-write round trip does
+// not wipe the secret.
+func (h *IdentityProviderHandler) ldapConfigFromDTO(r *http.Request, dto *ldapConfigDTO) (*ldap.Config, error) {
+	cfg := &ldap.Config{
+		Enabled:         dto.Enabled,
+		URL:             dto.URL,
+		StartTLS:        dto.StartTLS,
+		AllowPlaintext:  dto.AllowPlaintext,
+		BaseDN:          dto.BaseDN,
+		BindDN:          dto.BindDN,
+		BindPassword:    dto.BindPassword,
+		UserAttr:        dto.UserAttr,
+		Realm:           dto.Realm,
+		Idmap:           ldap.IdmapMode(dto.Idmap),
+		NestedGroups:    dto.NestedGroups,
+		MaxGroupResults: dto.MaxGroupResults,
+		TLS: ldap.TLSConfig{
+			CACertFile:         dto.TLS.CACertFile,
+			ClientCertFile:     dto.TLS.ClientCertFile,
+			ClientKeyFile:      dto.TLS.ClientKeyFile,
+			InsecureSkipVerify: dto.TLS.InsecureSkipVerify,
+			MinVersion:         dto.TLS.MinVersion,
+		},
+	}
+	if dto.Timeout != "" {
+		d, err := time.ParseDuration(dto.Timeout)
+		if err != nil {
+			return nil, fmt.Errorf("invalid timeout %q: %w", dto.Timeout, err)
+		}
+		cfg.Timeout = d
+	}
+	if dto.BindPassword == "" || dto.BindPassword == redactedSecret {
+		cfg.BindPassword = h.existingLDAPPassword(r)
+	}
+	return cfg, nil
+}
+
+// existingLDAPPassword returns the currently stored bind password, or "" if
+// none/undecodable. Used to preserve the secret on read-modify-write.
+func (h *IdentityProviderHandler) existingLDAPPassword(r *http.Request) string {
+	row, err := h.store.GetIdentityProviderConfig(r.Context(), models.IdentityProviderTypeLDAP)
+	if err != nil {
+		return ""
+	}
+	cfg, err := ldap.UnmarshalStored([]byte(row.Config))
+	if err != nil {
+		return ""
+	}
+	return cfg.BindPassword
+}
+
+func ldapConfigToDTO(cfg *ldap.Config) ldapConfigDTO {
+	dto := ldapConfigDTO{
+		Enabled:         cfg.Enabled,
+		URL:             cfg.URL,
+		StartTLS:        cfg.StartTLS,
+		AllowPlaintext:  cfg.AllowPlaintext,
+		BaseDN:          cfg.BaseDN,
+		BindDN:          cfg.BindDN,
+		UserAttr:        cfg.UserAttr,
+		Realm:           cfg.Realm,
+		Idmap:           string(cfg.Idmap),
+		NestedGroups:    cfg.NestedGroups,
+		MaxGroupResults: cfg.MaxGroupResults,
+		TLS: ldapTLSDTO{
+			CACertFile:         cfg.TLS.CACertFile,
+			ClientCertFile:     cfg.TLS.ClientCertFile,
+			ClientKeyFile:      cfg.TLS.ClientKeyFile,
+			InsecureSkipVerify: cfg.TLS.InsecureSkipVerify,
+			MinVersion:         cfg.TLS.MinVersion,
+		},
+	}
+	if cfg.Timeout > 0 {
+		dto.Timeout = cfg.Timeout.String()
+	}
+	// Write-only secret: report a placeholder when set, empty when unset.
+	if cfg.BindPassword != "" {
+		dto.BindPassword = redactedSecret
+	}
+	return dto
+}
+
+// --- Kerberos ---
+//
+// Kerberos config cannot reuse pkg/config here: pkg/config imports the
+// control-plane API package, so importing it into a handler would create an
+// import cycle. The handler therefore owns a plain DTO and validates inline;
+// cmd/dfs maps the persisted DTO onto config.KerberosConfig at startup. A
+// Kerberos config change applies on the next server restart (the NFS/SMB
+// adapters consume it at startup), so PutConfig persists but does not
+// hot-reload.
+
+func (h *IdentityProviderHandler) putKerberos(w http.ResponseWriter, r *http.Request) {
+	var dto KerberosConfigDTO
+	if !decodeJSONBody(w, r, &dto) {
+		return
+	}
+	if err := validateKerberosDTO(&dto); err != nil {
+		BadRequest(w, err.Error())
+		return
+	}
+	blob, err := json.Marshal(dto)
+	if err != nil {
+		InternalServerError(w, "Failed to encode Kerberos config")
+		return
+	}
+	if err := h.store.PutIdentityProviderConfig(r.Context(), &models.IdentityProviderConfig{
+		Type:    models.IdentityProviderTypeKerberos,
+		Enabled: dto.Enabled,
+		Config:  string(blob),
+	}); err != nil {
+		InternalServerError(w, "Failed to persist Kerberos config")
+		return
+	}
+	// No hot-reload: Kerberos is bound by the adapters at startup. Surface that
+	// the change takes effect on the next restart via a header note.
+	w.Header().Set("X-DittoFS-Apply", "restart-required")
+	WriteJSONOK(w, dto)
+}
+
+func (h *IdentityProviderHandler) testKerberos(w http.ResponseWriter, r *http.Request) {
+	var dto KerberosConfigDTO
+	if !decodeJSONBody(w, r, &dto) {
+		return
+	}
+	if err := validateKerberosDTO(&dto); err != nil {
+		WriteJSON(w, http.StatusOK, testResult{OK: false, Stage: "validate", Message: err.Error()})
+		return
+	}
+	if dto.KeytabPath == "" {
+		WriteJSON(w, http.StatusOK, testResult{OK: false, Stage: "validate", Message: "keytab_path is required"})
+		return
+	}
+	kt, err := keytab.Load(dto.KeytabPath)
+	if err != nil {
+		WriteJSON(w, http.StatusOK, testResult{OK: false, Stage: "keytab", Message: fmt.Sprintf("load keytab: %v", err)})
+		return
+	}
+	if len(kt.Entries) == 0 {
+		WriteJSON(w, http.StatusOK, testResult{OK: false, Stage: "keytab", Message: "keytab contains no entries"})
+		return
+	}
+	if dto.Krb5Conf != "" {
+		if _, cerr := krb5config.Load(dto.Krb5Conf); cerr != nil {
+			WriteJSON(w, http.StatusOK, testResult{OK: false, Stage: "krb5conf", Message: fmt.Sprintf("load krb5.conf: %v", cerr)})
+			return
+		}
+	}
+	WriteJSON(w, http.StatusOK, testResult{OK: true, Message: fmt.Sprintf("keytab loaded (%d entries)", len(kt.Entries))})
+}
+
+// validateKerberosDTO mirrors the shape checks in config.KerberosConfig.Validate
+// without importing pkg/config (which would create an import cycle).
+func validateKerberosDTO(dto *KerberosConfigDTO) error {
+	if dto.Enabled {
+		if dto.KeytabPath == "" {
+			return fmt.Errorf("keytab_path is required when kerberos is enabled")
+		}
+		if dto.ServicePrincipal == "" {
+			return fmt.Errorf("service_principal is required when kerberos is enabled")
+		}
+	}
+	if strings.ContainsAny(dto.Realm, "@/ ") {
+		return fmt.Errorf("realm %q must not contain '@', '/', or spaces", dto.Realm)
+	}
+	if strings.ContainsAny(dto.NetBIOSDomain, ".@/ ") {
+		return fmt.Errorf("netbios_domain %q must be a single label (no '.', '@', '/', or spaces)", dto.NetBIOSDomain)
+	}
+	if strings.ContainsAny(dto.DNSDomain, "@/ ") {
+		return fmt.Errorf("dns_domain %q must not contain '@', '/', or spaces", dto.DNSDomain)
+	}
+	for name, v := range map[string]string{"max_clock_skew": dto.MaxClockSkew, "context_ttl": dto.ContextTTL} {
+		if v == "" {
+			continue
+		}
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return fmt.Errorf("invalid %s %q: %w", name, v, err)
+		}
+		// Match config.KerberosConfig.Validate, which rejects negatives.
+		if d < 0 {
+			return fmt.Errorf("%s must not be negative", name)
+		}
+	}
+	if dto.MaxContexts < 0 {
+		return fmt.Errorf("max_contexts must be >= 0")
+	}
+	return nil
+}
+
+// --- shared ---
+
+// loadRow fetches the config row for providerType, writing the appropriate
+// error response and returning nil on miss/unknown-type/error.
+func (h *IdentityProviderHandler) loadRow(w http.ResponseWriter, r *http.Request, providerType string) *models.IdentityProviderConfig {
+	if providerType != models.IdentityProviderTypeLDAP && providerType != models.IdentityProviderTypeKerberos {
+		NotFound(w, "Unknown identity provider type")
+		return nil
+	}
+	row, err := h.store.GetIdentityProviderConfig(r.Context(), providerType)
+	if err != nil {
+		if errors.Is(err, models.ErrIdentityProviderConfigNotFound) {
+			NotFound(w, "Identity provider not configured")
+			return nil
+		}
+		InternalServerError(w, "Failed to read identity provider config")
+		return nil
+	}
+	return row
+}

--- a/internal/controlplane/api/handlers/identity_providers_test.go
+++ b/internal/controlplane/api/handlers/identity_providers_test.go
@@ -1,0 +1,238 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// fakeIDPStore is an in-memory IdentityProviderConfigStore for handler tests.
+type fakeIDPStore struct {
+	rows     map[string]*models.IdentityProviderConfig
+	putCalls int
+}
+
+func newFakeIDPStore() *fakeIDPStore {
+	return &fakeIDPStore{rows: map[string]*models.IdentityProviderConfig{}}
+}
+
+func (s *fakeIDPStore) GetIdentityProviderConfig(_ context.Context, t string) (*models.IdentityProviderConfig, error) {
+	if row, ok := s.rows[t]; ok {
+		return row, nil
+	}
+	return nil, models.ErrIdentityProviderConfigNotFound
+}
+
+func (s *fakeIDPStore) ListIdentityProviderConfigs(context.Context) ([]*models.IdentityProviderConfig, error) {
+	out := make([]*models.IdentityProviderConfig, 0, len(s.rows))
+	for _, r := range s.rows {
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+func (s *fakeIDPStore) PutIdentityProviderConfig(_ context.Context, cfg *models.IdentityProviderConfig) error {
+	s.putCalls++
+	cp := *cfg
+	s.rows[cfg.Type] = &cp
+	return nil
+}
+
+func (s *fakeIDPStore) DeleteIdentityProviderConfig(_ context.Context, t string) error {
+	if _, ok := s.rows[t]; !ok {
+		return models.ErrIdentityProviderConfigNotFound
+	}
+	delete(s.rows, t)
+	return nil
+}
+
+func withType(r *http.Request, t string) *http.Request {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("type", t)
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}
+
+func doReq(t *testing.T, h func(http.ResponseWriter, *http.Request), method, body, providerType string) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest(method, "/", strings.NewReader(body))
+	r = withType(r, providerType)
+	w := httptest.NewRecorder()
+	h(w, r)
+	return w
+}
+
+const validLDAPBody = `{
+	"enabled": true,
+	"url": "ldaps://dc.example.com:636",
+	"base_dn": "DC=example,DC=com",
+	"bind_dn": "CN=svc,DC=example,DC=com",
+	"bind_password": "secret",
+	"idmap": "rfc2307"
+}`
+
+func TestIDP_PutLDAP_PersistsAndRedacts(t *testing.T) {
+	st := newFakeIDPStore()
+	h := NewIdentityProviderHandler(st, nil) // nil runtime: PutLDAP guards on it
+
+	w := doReq(t, h.PutConfig, http.MethodPut, validLDAPBody, models.IdentityProviderTypeLDAP)
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var resp ldapConfigDTO
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.BindPassword != redactedSecret {
+		t.Fatalf("response password = %q, want redacted", resp.BindPassword)
+	}
+	// Stored blob must contain the real password (usable after restart).
+	row := st.rows[models.IdentityProviderTypeLDAP]
+	if row == nil || !strings.Contains(row.Config, "secret") {
+		t.Fatalf("stored config must retain real password, got %+v", row)
+	}
+}
+
+func TestIDP_PutLDAP_InvalidConfigIs400(t *testing.T) {
+	st := newFakeIDPStore()
+	h := NewIdentityProviderHandler(st, nil)
+
+	// enabled + plaintext ldap:// without StartTLS/AllowPlaintext → rejected.
+	body := `{"enabled":true,"url":"ldap://dc","base_dn":"DC=x","bind_dn":"CN=s","bind_password":"p"}`
+	w := doReq(t, h.PutConfig, http.MethodPut, body, models.IdentityProviderTypeLDAP)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	if st.putCalls != 0 {
+		t.Fatalf("invalid config must not persist (putCalls=%d)", st.putCalls)
+	}
+}
+
+func TestIDP_GetLDAP_RedactsPassword(t *testing.T) {
+	st := newFakeIDPStore()
+	h := NewIdentityProviderHandler(st, nil)
+	doReq(t, h.PutConfig, http.MethodPut, validLDAPBody, models.IdentityProviderTypeLDAP)
+
+	w := doReq(t, h.GetConfig, http.MethodGet, "", models.IdentityProviderTypeLDAP)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET status = %d", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "secret") {
+		t.Fatalf("GET leaked password: %s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), redactedSecret) {
+		t.Fatalf("GET should report redacted placeholder: %s", w.Body.String())
+	}
+}
+
+func TestIDP_PutLDAP_PreservesPasswordOnRedactedResubmit(t *testing.T) {
+	st := newFakeIDPStore()
+	h := NewIdentityProviderHandler(st, nil)
+	doReq(t, h.PutConfig, http.MethodPut, validLDAPBody, models.IdentityProviderTypeLDAP)
+
+	// Re-submit with the redacted placeholder (as a GET-then-PUT round trip would).
+	body := `{"enabled":true,"url":"ldaps://dc2","base_dn":"DC=example,DC=com","bind_dn":"CN=svc,DC=example,DC=com","bind_password":"********","idmap":"rfc2307"}`
+	w := doReq(t, h.PutConfig, http.MethodPut, body, models.IdentityProviderTypeLDAP)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", w.Code, w.Body.String())
+	}
+	row := st.rows[models.IdentityProviderTypeLDAP]
+	if !strings.Contains(row.Config, "secret") {
+		t.Fatalf("password must be preserved on redacted resubmit, got %s", row.Config)
+	}
+}
+
+func TestIDP_GetLDAP_NotConfiguredIs404(t *testing.T) {
+	h := NewIdentityProviderHandler(newFakeIDPStore(), nil)
+	w := doReq(t, h.GetConfig, http.MethodGet, "", models.IdentityProviderTypeLDAP)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestIDP_UnknownTypeIs404(t *testing.T) {
+	h := NewIdentityProviderHandler(newFakeIDPStore(), nil)
+	w := doReq(t, h.GetConfig, http.MethodGet, "", "saml")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestIDP_List(t *testing.T) {
+	st := newFakeIDPStore()
+	h := NewIdentityProviderHandler(st, nil)
+	doReq(t, h.PutConfig, http.MethodPut, validLDAPBody, models.IdentityProviderTypeLDAP)
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	h.List(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var got []identityProviderSummary
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 providers, got %d", len(got))
+	}
+	byType := map[string]identityProviderSummary{}
+	for _, s := range got {
+		byType[s.Type] = s
+	}
+	if !byType["ldap"].Configured || !byType["ldap"].Enabled {
+		t.Errorf("ldap should be configured+enabled: %+v", byType["ldap"])
+	}
+	if byType["kerberos"].Configured {
+		t.Errorf("kerberos should be unconfigured: %+v", byType["kerberos"])
+	}
+}
+
+func TestIDP_PutKerberos_ValidatesAndPersists(t *testing.T) {
+	st := newFakeIDPStore()
+	h := NewIdentityProviderHandler(st, nil)
+
+	// Invalid realm shape → 400.
+	bad := `{"enabled":false,"realm":"BAD/REALM"}`
+	if w := doReq(t, h.PutConfig, http.MethodPut, bad, models.IdentityProviderTypeKerberos); w.Code != http.StatusBadRequest {
+		t.Fatalf("bad realm status = %d, want 400", w.Code)
+	}
+
+	good := `{"enabled":false,"realm":"EXAMPLE.COM","netbios_domain":"EXAMPLE","dns_domain":"example.com","max_clock_skew":"5m"}`
+	w := doReq(t, h.PutConfig, http.MethodPut, good, models.IdentityProviderTypeKerberos)
+	if w.Code != http.StatusOK {
+		t.Fatalf("good status = %d; body=%s", w.Code, w.Body.String())
+	}
+	if w.Header().Get("X-DittoFS-Apply") != "restart-required" {
+		t.Errorf("expected restart-required apply header")
+	}
+	if st.rows[models.IdentityProviderTypeKerberos] == nil {
+		t.Fatalf("kerberos config not persisted")
+	}
+}
+
+func TestIDP_TestLDAP_DoesNotPersist(t *testing.T) {
+	st := newFakeIDPStore()
+	h := NewIdentityProviderHandler(st, nil)
+
+	// Points at an unreachable host: the test must return ok=false but never persist.
+	body := `{"enabled":true,"url":"ldaps://127.0.0.1:1","base_dn":"DC=x","bind_dn":"CN=s","bind_password":"p","idmap":"rfc2307"}`
+	w := doReq(t, h.Test, http.MethodPost, body, models.IdentityProviderTypeLDAP)
+	if w.Code != http.StatusOK {
+		t.Fatalf("test status = %d", w.Code)
+	}
+	var res testResult
+	_ = json.Unmarshal(w.Body.Bytes(), &res)
+	if res.OK {
+		t.Errorf("expected ok=false for unreachable host")
+	}
+	if st.putCalls != 0 {
+		t.Errorf("test must not persist (putCalls=%d)", st.putCalls)
+	}
+}

--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -116,6 +116,20 @@ type NFSAdapter struct {
 	// nil when Kerberos is not enabled.
 	kerberosConfig *config.KerberosConfig
 
+	// identityUnsub unsubscribes the OnIdentityMappingChange callback registered
+	// when the centralized resolver is wired. Re-set on each resolver rebuild so
+	// a hot-reload does not accumulate stale cache-invalidation callbacks.
+	identityUnsub func()
+
+	// identityProviderUnsub unsubscribes the OnIdentityProviderConfigChange
+	// callback. Registered once so an API-driven identity-provider config change
+	// rebuilds and re-injects the resolver without a restart.
+	identityProviderUnsub func()
+
+	// resolverMu serializes wireIdentityResolver so concurrent identity-provider
+	// config changes cannot race on identityUnsub/identityProviderUnsub.
+	resolverMu sync.Mutex
+
 	// portmapServer is the embedded portmapper server (RFC 1057).
 	// nil when portmapper is disabled.
 	portmapServer *portmap.Server

--- a/pkg/adapter/nfs/nlm.go
+++ b/pkg/adapter/nfs/nlm.go
@@ -677,10 +677,17 @@ func (s *NFSAdapter) initGSSProcessor(rt *runtime.Runtime) {
 	// Wire centralized identity resolver (DB-backed mapping + convention fallback).
 	// This takes precedence over the legacy StaticMapper when resolving principals.
 	if rt != nil {
-		realm := adapter.ExtractRealm(s.kerberosConfig.ServicePrincipal)
-		resolver := adapter.BuildIdentityResolver(rt, realm)
-		s.gssProcessor.SetResolver(resolver)
-		rt.OnIdentityMappingChange(resolver.InvalidateCache)
+		s.wireIdentityResolver(rt)
+
+		// Rebuild and re-inject the resolver when an identity provider's config
+		// is changed over the API (e.g. LDAP directory settings) so it takes
+		// effect without a restart. Registered once; the GSSProcessor guards the
+		// resolver with a lock, so the live swap is safe.
+		if s.identityProviderUnsub == nil {
+			s.identityProviderUnsub = rt.OnIdentityProviderConfigChange(func() {
+				s.wireIdentityResolver(rt)
+			})
+		}
 	}
 
 	logger.Info("RPCSEC_GSS (Kerberos) authentication enabled",
@@ -688,4 +695,27 @@ func (s *NFSAdapter) initGSSProcessor(rt *runtime.Runtime) {
 		"max_contexts", s.kerberosConfig.MaxContexts,
 		"context_ttl", s.kerberosConfig.ContextTTL,
 	)
+}
+
+// wireIdentityResolver builds the centralized identity resolver from the
+// current runtime config and injects it into the GSS processor. It is called
+// at GSS setup and again on every identity-provider config change so an
+// API-driven LDAP reconfiguration takes effect without a restart. The prior
+// OnIdentityMappingChange subscription is cancelled before re-subscribing so
+// reloads do not accumulate stale cache-invalidation callbacks.
+func (s *NFSAdapter) wireIdentityResolver(rt *runtime.Runtime) {
+	// Serialize: called from startup AND the OnIdentityProviderConfigChange
+	// callback (HTTP handler goroutines); concurrent config changes would
+	// otherwise race on identityUnsub and leak mapping-change subscriptions.
+	s.resolverMu.Lock()
+	defer s.resolverMu.Unlock()
+
+	realm := adapter.ExtractRealm(s.kerberosConfig.ServicePrincipal)
+	resolver := adapter.BuildIdentityResolver(rt, realm)
+	s.gssProcessor.SetResolver(resolver)
+
+	if s.identityUnsub != nil {
+		s.identityUnsub()
+	}
+	s.identityUnsub = rt.OnIdentityMappingChange(resolver.InvalidateCache)
 }

--- a/pkg/adapter/nfs/shutdown.go
+++ b/pkg/adapter/nfs/shutdown.go
@@ -30,6 +30,16 @@ func (s *NFSAdapter) Stop(ctx context.Context) error {
 	}
 	s.shareUnsubscribers = nil
 
+	// Unsubscribe identity resolver callbacks registered by wireIdentityResolver.
+	if s.identityUnsub != nil {
+		s.identityUnsub()
+		s.identityUnsub = nil
+	}
+	if s.identityProviderUnsub != nil {
+		s.identityProviderUnsub()
+		s.identityProviderUnsub = nil
+	}
+
 	// Stop portmapper first (stops accepting new queries before NFS stops)
 	s.stopPortmapper()
 

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -86,6 +86,16 @@ type Adapter struct {
 	// invalidations.
 	identityUnsub func()
 
+	// identityProviderUnsub is the unsubscribe function for the
+	// OnIdentityProviderConfigChange subscription. Registered once (guarded by
+	// nil) by wireIdentityResolver so an API-driven identity-provider config
+	// change rebuilds and re-injects the resolver without a restart.
+	identityProviderUnsub func()
+
+	// resolverMu serializes wireIdentityResolver so concurrent identity-provider
+	// config changes cannot race on identityUnsub/identityProviderUnsub.
+	resolverMu sync.Mutex
+
 	// kerberosProvider is retained for lifecycle management. It owns a
 	// background keytab-reload goroutine that must be stopped in Stop().
 	kerberosProvider *kerberos.Provider
@@ -541,12 +551,19 @@ func (s *Adapter) SetKerberosProvider(provider *kerberos.Provider) {
 // on initialization order. The method is a no-op when either the Kerberos
 // provider or the runtime is not yet available.
 func (s *Adapter) wireIdentityResolver(rt *runtime.Runtime) {
+	// Serialize: this is invoked from startup AND from the
+	// OnIdentityProviderConfigChange callback (HTTP handler goroutines), so
+	// concurrent PUTs would otherwise race on identityUnsub/identityProviderUnsub
+	// and leak OnIdentityMappingChange subscriptions.
+	s.resolverMu.Lock()
+	defer s.resolverMu.Unlock()
+
 	if s.handler.KerberosProvider == nil || rt == nil {
 		return
 	}
 	realm := adapter.ExtractRealm(s.handler.KerberosProvider.ServicePrincipal())
 	resolver := adapter.BuildIdentityResolver(rt, realm)
-	s.handler.IdentityResolver = resolver
+	s.handler.SetIdentityResolver(resolver)
 
 	// Cancel any prior subscription before registering a new one.
 	// wireIdentityResolver is called from both SetRuntime and SetKerberosProvider
@@ -556,6 +573,17 @@ func (s *Adapter) wireIdentityResolver(rt *runtime.Runtime) {
 		s.identityUnsub()
 	}
 	s.identityUnsub = rt.OnIdentityMappingChange(resolver.InvalidateCache)
+
+	// Rebuild and re-inject the resolver when an identity provider's config is
+	// changed over the API (e.g. LDAP directory settings) so it takes effect
+	// without a restart. Registered once — the rebuild re-runs this method,
+	// which picks up the new rt.LDAPConfig() and re-subscribes the mapping
+	// callback above.
+	if s.identityProviderUnsub == nil {
+		s.identityProviderUnsub = rt.OnIdentityProviderConfigChange(func() {
+			s.wireIdentityResolver(rt)
+		})
+	}
 }
 
 const (
@@ -621,6 +649,10 @@ func (s *Adapter) Stop(ctx context.Context) error {
 	if s.identityUnsub != nil {
 		s.identityUnsub()
 		s.identityUnsub = nil
+	}
+	if s.identityProviderUnsub != nil {
+		s.identityProviderUnsub()
+		s.identityProviderUnsub = nil
 	}
 
 	// Unsubscribe from share change notifications to prevent stale callbacks

--- a/pkg/apiclient/identity_providers.go
+++ b/pkg/apiclient/identity_providers.go
@@ -1,0 +1,129 @@
+package apiclient
+
+import "fmt"
+
+// IdentityProviderSummary reports the configured/enabled state of an identity
+// provider type as returned by ListIdentityProviders.
+type IdentityProviderSummary struct {
+	Type       string `json:"type"`
+	Enabled    bool   `json:"enabled"`
+	Configured bool   `json:"configured"`
+}
+
+// LDAPTLSConfig is the TLS sub-config of an LDAP identity provider.
+type LDAPTLSConfig struct {
+	CACertFile         string `json:"ca_cert_file"`
+	ClientCertFile     string `json:"client_cert_file"`
+	ClientKeyFile      string `json:"client_key_file"`
+	InsecureSkipVerify bool   `json:"insecure_skip_verify"`
+	MinVersion         string `json:"min_version"`
+}
+
+// LDAPProviderConfig mirrors the server's LDAP identity-provider config. The
+// bind password is write-only: it is accepted on Put/Test and returned as
+// "********" (or "") on Get — submitting the placeholder back preserves the
+// stored secret.
+type LDAPProviderConfig struct {
+	Enabled         bool          `json:"enabled"`
+	URL             string        `json:"url"`
+	StartTLS        bool          `json:"start_tls"`
+	AllowPlaintext  bool          `json:"allow_plaintext"`
+	BaseDN          string        `json:"base_dn"`
+	BindDN          string        `json:"bind_dn"`
+	BindPassword    string        `json:"bind_password,omitempty"`
+	UserAttr        string        `json:"user_attr"`
+	Realm           string        `json:"realm"`
+	Idmap           string        `json:"idmap"`
+	NestedGroups    bool          `json:"nested_groups"`
+	Timeout         string        `json:"timeout"`
+	MaxGroupResults int           `json:"max_group_results"`
+	TLS             LDAPTLSConfig `json:"tls"`
+}
+
+// KerberosProviderConfig mirrors the server's Kerberos identity-provider config.
+// A change takes effect on the next server restart.
+type KerberosProviderConfig struct {
+	Enabled          bool   `json:"enabled"`
+	KeytabPath       string `json:"keytab_path"`
+	ServicePrincipal string `json:"service_principal"`
+	Realm            string `json:"realm"`
+	NetBIOSDomain    string `json:"netbios_domain"`
+	DNSDomain        string `json:"dns_domain"`
+	Krb5Conf         string `json:"krb5_conf"`
+	MaxClockSkew     string `json:"max_clock_skew"`
+	ContextTTL       string `json:"context_ttl"`
+	MaxContexts      int    `json:"max_contexts"`
+}
+
+// IdentityProviderTestResult is the result of a non-persisting provider test.
+type IdentityProviderTestResult struct {
+	OK        bool   `json:"ok"`
+	Stage     string `json:"stage,omitempty"`
+	Message   string `json:"message,omitempty"`
+	LatencyMS int64  `json:"latency_ms,omitempty"`
+}
+
+// ListIdentityProviders returns the configured/enabled state of each identity
+// provider type (no secrets).
+func (c *Client) ListIdentityProviders() ([]IdentityProviderSummary, error) {
+	var out []IdentityProviderSummary
+	if err := c.get("/api/v1/identity-providers", &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// GetLDAPConfig returns the current LDAP provider config (bind password redacted).
+func (c *Client) GetLDAPConfig() (*LDAPProviderConfig, error) {
+	return getIdentityProviderConfig[LDAPProviderConfig](c, "ldap")
+}
+
+// PutLDAPConfig creates or replaces the LDAP provider config and hot-reloads it.
+func (c *Client) PutLDAPConfig(cfg *LDAPProviderConfig) (*LDAPProviderConfig, error) {
+	return putIdentityProviderConfig(c, "ldap", cfg)
+}
+
+// TestLDAPConfig dials+binds using cfg without persisting it.
+func (c *Client) TestLDAPConfig(cfg *LDAPProviderConfig) (*IdentityProviderTestResult, error) {
+	return testIdentityProvider(c, "ldap", cfg)
+}
+
+// GetKerberosConfig returns the current Kerberos provider config.
+func (c *Client) GetKerberosConfig() (*KerberosProviderConfig, error) {
+	return getIdentityProviderConfig[KerberosProviderConfig](c, "kerberos")
+}
+
+// PutKerberosConfig creates or replaces the Kerberos provider config (applied on
+// the next server restart).
+func (c *Client) PutKerberosConfig(cfg *KerberosProviderConfig) (*KerberosProviderConfig, error) {
+	return putIdentityProviderConfig(c, "kerberos", cfg)
+}
+
+// TestKerberosConfig validates cfg and loads its keytab without persisting.
+func (c *Client) TestKerberosConfig(cfg *KerberosProviderConfig) (*IdentityProviderTestResult, error) {
+	return testIdentityProvider(c, "kerberos", cfg)
+}
+
+func getIdentityProviderConfig[T any](c *Client, providerType string) (*T, error) {
+	var out T
+	if err := c.get(fmt.Sprintf("/api/v1/identity-providers/%s/config", providerType), &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func putIdentityProviderConfig[T any](c *Client, providerType string, cfg *T) (*T, error) {
+	var out T
+	if err := c.put(fmt.Sprintf("/api/v1/identity-providers/%s/config", providerType), cfg, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func testIdentityProvider[T any](c *Client, providerType string, cfg *T) (*IdentityProviderTestResult, error) {
+	var out IdentityProviderTestResult
+	if err := c.post(fmt.Sprintf("/api/v1/identity-providers/%s/test", providerType), cfg, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -480,6 +480,17 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 				r.Delete("/{key}", settingsHandler.Delete)
 			})
 
+			// Identity provider configuration (LDAP/AD, Kerberos) — admin only.
+			r.Route("/identity-providers", func(r chi.Router) {
+				r.Use(apiMiddleware.RequireAdmin())
+
+				idpHandler := handlers.NewIdentityProviderHandler(cpStore, rt)
+				r.Get("/", idpHandler.List)
+				r.Get("/{type}/config", idpHandler.GetConfig)
+				r.Put("/{type}/config", idpHandler.PutConfig)
+				r.Post("/{type}/test", idpHandler.Test)
+			})
+
 			// Unified client listing and disconnect (admin only) - all protocols
 			if clientHandler := handlers.NewClientHandler(rt); clientHandler != nil {
 				r.Route("/clients", func(r chi.Router) {

--- a/pkg/controlplane/models/identity_provider.go
+++ b/pkg/controlplane/models/identity_provider.go
@@ -1,0 +1,55 @@
+package models
+
+import (
+	"errors"
+	"time"
+)
+
+// Identity provider type discriminators. These are the {type} path segment of
+// the /api/v1/identity-providers/{type}/... routes and the primary key of the
+// IdentityProviderConfig table.
+const (
+	IdentityProviderTypeLDAP     = "ldap"
+	IdentityProviderTypeKerberos = "kerberos"
+)
+
+// IdentityProviderConfig persists the configuration of a single identity
+// provider (LDAP/AD or Kerberos) in the control-plane database so it can be
+// managed over the REST API without editing config files or restarting the
+// server.
+//
+// Config holds the JSON-serialized domain configuration (ldap.Config or
+// config.KerberosConfig) INCLUDING secret material (bind password / keytab
+// path). It is serialized with the secret intact — the redacting marshaler on
+// the domain types is deliberately bypassed for storage — so the persisted
+// config is usable after a restart. The column is never returned over the API:
+// the REST layer marshals a redacted DTO instead, so `json:"-"` here guards
+// against accidental serialization. Secrets are stored in plaintext, matching
+// the existing posture for block-store/S3 credentials in this same database.
+type IdentityProviderConfig struct {
+	// Type is the provider discriminator: "ldap" or "kerberos". Primary key —
+	// there is exactly one configuration row per provider type.
+	Type string `gorm:"column:type;primaryKey;type:varchar(32)" json:"type"`
+
+	// Enabled mirrors the domain config's Enabled flag, surfaced as a column so
+	// the list endpoint can report enabled state without deserializing Config.
+	Enabled bool `gorm:"not null" json:"enabled"`
+
+	// Config is the JSON-serialized domain configuration including secrets.
+	// Never serialized to the API (see type doc).
+	Config string `gorm:"type:text" json:"-"`
+
+	CreatedAt time.Time `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+}
+
+// TableName returns the table name for IdentityProviderConfig.
+func (IdentityProviderConfig) TableName() string {
+	return "identity_provider_configs"
+}
+
+var (
+	// ErrIdentityProviderConfigNotFound is returned when no configuration row
+	// exists for a provider type.
+	ErrIdentityProviderConfigNotFound = errors.New("identity provider config not found")
+)

--- a/pkg/controlplane/models/models.go
+++ b/pkg/controlplane/models/models.go
@@ -21,6 +21,7 @@ func AllModels() []any {
 		&Setting{},
 		&IdentityMapping{},
 		&SIDMapping{},
+		&IdentityProviderConfig{},
 		&NFSAdapterSettings{},
 		&SMBAdapterSettings{},
 		&Netgroup{},

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -140,6 +140,12 @@ type Runtime struct {
 
 	identityChangeCallbacks []func()
 
+	// identityProviderChangeCallbacks fire when an identity provider's
+	// configuration (LDAP/Kerberos) is changed via the API. Adapters register a
+	// closure that rebuilds and re-injects their identity resolver so a new
+	// directory config takes effect without a restart. Guarded by mu.
+	identityProviderChangeCallbacks []func()
+
 	// ldapConfig is the optional LDAP/AD identity provider configuration set at
 	// startup from the server config. When present and Enabled, BuildIdentityResolver
 	// registers an LDAP provider in the identity resolution chain. Guarded by mu.
@@ -907,6 +913,38 @@ func (r *Runtime) NotifyIdentityMappingChange() {
 	r.mu.RLock()
 	cbs := make([]func(), len(r.identityChangeCallbacks))
 	copy(cbs, r.identityChangeCallbacks)
+	r.mu.RUnlock()
+	for _, fn := range cbs {
+		if fn != nil {
+			fn()
+		}
+	}
+}
+
+// OnIdentityProviderConfigChange registers a callback invoked when an identity
+// provider's configuration is changed via the API. Adapters use this to rebuild
+// and re-inject their identity resolver so a new LDAP directory config takes
+// effect without a restart. Returns an unsubscribe function.
+func (r *Runtime) OnIdentityProviderConfigChange(fn func()) func() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.identityProviderChangeCallbacks = append(r.identityProviderChangeCallbacks, fn)
+	idx := len(r.identityProviderChangeCallbacks) - 1
+	return func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		if idx < len(r.identityProviderChangeCallbacks) {
+			r.identityProviderChangeCallbacks[idx] = nil
+		}
+	}
+}
+
+// NotifyIdentityProviderConfigChange fires all registered identity-provider
+// config change callbacks.
+func (r *Runtime) NotifyIdentityProviderConfigChange() {
+	r.mu.RLock()
+	cbs := make([]func(), len(r.identityProviderChangeCallbacks))
+	copy(cbs, r.identityProviderChangeCallbacks)
 	r.mu.RUnlock()
 	for _, fn := range cbs {
 		if fn != nil {

--- a/pkg/controlplane/store/identity_provider.go
+++ b/pkg/controlplane/store/identity_provider.go
@@ -1,0 +1,46 @@
+package store
+
+import (
+	"context"
+
+	"gorm.io/gorm/clause"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// GetIdentityProviderConfig returns the configuration row for a provider type.
+// Returns models.ErrIdentityProviderConfigNotFound when no row exists.
+func (s *GORMStore) GetIdentityProviderConfig(ctx context.Context, providerType string) (*models.IdentityProviderConfig, error) {
+	var cfg models.IdentityProviderConfig
+	err := s.db.WithContext(ctx).Where("type = ?", providerType).First(&cfg).Error
+	if err != nil {
+		return nil, convertNotFoundError(err, models.ErrIdentityProviderConfigNotFound)
+	}
+	return &cfg, nil
+}
+
+// ListIdentityProviderConfigs returns all configured provider rows.
+func (s *GORMStore) ListIdentityProviderConfigs(ctx context.Context) ([]*models.IdentityProviderConfig, error) {
+	return listAll[models.IdentityProviderConfig](s.db, ctx)
+}
+
+// PutIdentityProviderConfig creates or replaces the configuration row for
+// cfg.Type. The upsert is keyed on the type primary key and overwrites the
+// enabled flag and config blob.
+func (s *GORMStore) PutIdentityProviderConfig(ctx context.Context, cfg *models.IdentityProviderConfig) error {
+	return s.db.WithContext(ctx).
+		Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "type"}},
+			DoUpdates: clause.AssignmentColumns([]string{"enabled", "config", "updated_at"}),
+		}).
+		Create(cfg).Error
+}
+
+// DeleteIdentityProviderConfig removes the configuration row for a provider
+// type. Returns models.ErrIdentityProviderConfigNotFound when no row exists.
+func (s *GORMStore) DeleteIdentityProviderConfig(ctx context.Context, providerType string) error {
+	return deleteByField[models.IdentityProviderConfig](s.db, ctx, "type", providerType, models.ErrIdentityProviderConfigNotFound)
+}
+
+// Compile-time assertion that GORMStore satisfies IdentityProviderConfigStore.
+var _ IdentityProviderConfigStore = (*GORMStore)(nil)

--- a/pkg/controlplane/store/identity_provider_test.go
+++ b/pkg/controlplane/store/identity_provider_test.go
@@ -1,0 +1,83 @@
+//go:build integration
+
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+func TestIdentityProviderConfig_RoundTrip(t *testing.T) {
+	s := createTestStore(t)
+	ctx := context.Background()
+
+	// Not-found before any write.
+	if _, err := s.GetIdentityProviderConfig(ctx, models.IdentityProviderTypeLDAP); !errors.Is(err, models.ErrIdentityProviderConfigNotFound) {
+		t.Fatalf("expected ErrIdentityProviderConfigNotFound, got %v", err)
+	}
+
+	// Put with a secret-bearing config blob.
+	const blob = `{"BindPassword":"s3cret","URL":"ldaps://dc"}`
+	if err := s.PutIdentityProviderConfig(ctx, &models.IdentityProviderConfig{
+		Type:    models.IdentityProviderTypeLDAP,
+		Enabled: true,
+		Config:  blob,
+	}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	got, err := s.GetIdentityProviderConfig(ctx, models.IdentityProviderTypeLDAP)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.Enabled || got.Config != blob {
+		t.Fatalf("round-trip mismatch: enabled=%v config=%q", got.Enabled, got.Config)
+	}
+
+	// Upsert replaces enabled + config on the same type (no duplicate row).
+	const blob2 = `{"BindPassword":"new","URL":"ldaps://dc2"}`
+	if err := s.PutIdentityProviderConfig(ctx, &models.IdentityProviderConfig{
+		Type:    models.IdentityProviderTypeLDAP,
+		Enabled: false,
+		Config:  blob2,
+	}); err != nil {
+		t.Fatalf("Put upsert: %v", err)
+	}
+	got, err = s.GetIdentityProviderConfig(ctx, models.IdentityProviderTypeLDAP)
+	if err != nil {
+		t.Fatalf("Get after upsert: %v", err)
+	}
+	if got.Enabled || got.Config != blob2 {
+		t.Fatalf("upsert mismatch: enabled=%v config=%q", got.Enabled, got.Config)
+	}
+
+	// Second provider type coexists.
+	if err := s.PutIdentityProviderConfig(ctx, &models.IdentityProviderConfig{
+		Type:    models.IdentityProviderTypeKerberos,
+		Enabled: true,
+		Config:  `{"KeytabPath":"/etc/x.keytab"}`,
+	}); err != nil {
+		t.Fatalf("Put kerberos: %v", err)
+	}
+	list, err := s.ListIdentityProviderConfigs(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(list))
+	}
+
+	// Delete + not-found afterwards.
+	if err := s.DeleteIdentityProviderConfig(ctx, models.IdentityProviderTypeLDAP); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := s.GetIdentityProviderConfig(ctx, models.IdentityProviderTypeLDAP); !errors.Is(err, models.ErrIdentityProviderConfigNotFound) {
+		t.Fatalf("expected not-found after delete, got %v", err)
+	}
+	if err := s.DeleteIdentityProviderConfig(ctx, models.IdentityProviderTypeLDAP); !errors.Is(err, models.ErrIdentityProviderConfigNotFound) {
+		t.Fatalf("expected not-found deleting missing row, got %v", err)
+	}
+}

--- a/pkg/controlplane/store/interface.go
+++ b/pkg/controlplane/store/interface.go
@@ -749,6 +749,31 @@ type SIDMappingStore interface {
 	DeleteSIDMapping(ctx context.Context, sid string) error
 }
 
+// IdentityProviderConfigStore persists identity-provider (LDAP/AD, Kerberos)
+// configuration so it can be managed over the REST API instead of via config
+// files + restart. There is at most one row per provider type.
+//
+// The stored Config blob carries secret material (bind password / keytab path)
+// in plaintext; callers must never surface it over the API (the REST layer
+// returns a redacted DTO).
+type IdentityProviderConfigStore interface {
+	// GetIdentityProviderConfig returns the configuration row for a provider
+	// type ("ldap" | "kerberos"). Returns models.ErrIdentityProviderConfigNotFound
+	// when no row exists.
+	GetIdentityProviderConfig(ctx context.Context, providerType string) (*models.IdentityProviderConfig, error)
+
+	// ListIdentityProviderConfigs returns all configured provider rows.
+	ListIdentityProviderConfigs(ctx context.Context) ([]*models.IdentityProviderConfig, error)
+
+	// PutIdentityProviderConfig creates or replaces the configuration row for
+	// cfg.Type (upsert keyed on Type).
+	PutIdentityProviderConfig(ctx context.Context, cfg *models.IdentityProviderConfig) error
+
+	// DeleteIdentityProviderConfig removes the configuration row for a provider
+	// type. Returns models.ErrIdentityProviderConfigNotFound when no row exists.
+	DeleteIdentityProviderConfig(ctx context.Context, providerType string) error
+}
+
 // Store is the composite control plane persistence interface.
 //
 // It embeds all sub-interfaces to provide the full set of operations.
@@ -775,4 +800,5 @@ type Store interface {
 	RestoreMarkerStore
 	HealthStore
 	SIDMappingStore
+	IdentityProviderConfigStore
 }

--- a/pkg/identity/ldap/test.go
+++ b/pkg/identity/ldap/test.go
@@ -1,0 +1,62 @@
+package ldap
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// MarshalStored serializes a Config for trusted server-side persistence,
+// INCLUDING the bind password. It deliberately bypasses Config.MarshalJSON
+// (which redacts the password) so the persisted configuration is usable after
+// a restart. Never use this for anything client-facing — use the redacting
+// Config.MarshalJSON / the API DTO layer for that.
+func MarshalStored(cfg *Config) ([]byte, error) {
+	type alias Config
+	return json.Marshal((*alias)(cfg))
+}
+
+// UnmarshalStored is the inverse of MarshalStored: it decodes a stored config
+// blob (with the bind password intact) back into a Config.
+func UnmarshalStored(data []byte) (*Config, error) {
+	type alias Config
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return nil, err
+	}
+	c := Config(a)
+	return &c, nil
+}
+
+// TestConnection performs a dry-run reachability check against the directory
+// described by cfg: it applies defaults, validates, dials, and binds as the
+// service account, then closes the connection. Nothing is persisted and no
+// user is resolved.
+//
+// It backs the control-plane "test identity provider" endpoint. Returned
+// errors describe the failing stage (validation, dial, or bind) and never
+// include the bind password — the underlying go-ldap bind error reports only
+// the LDAP result code, not the credential.
+func TestConnection(ctx context.Context, cfg *Config) error {
+	return testConnection(ctx, cfg, dialAndBind)
+}
+
+// testConnection is the connect-injectable core of TestConnection so the
+// dial+bind path can be exercised in unit tests with a fake connection.
+func testConnection(ctx context.Context, cfg *Config, connect connectFunc) error {
+	if cfg == nil {
+		return fmt.Errorf("ldap: nil config")
+	}
+	// Copy so ApplyDefaults/Validate never mutate the caller's config (the
+	// handler reuses the same struct to persist after a successful test).
+	c := *cfg
+	c.ApplyDefaults()
+	if err := c.Validate(); err != nil {
+		return err
+	}
+	conn, err := connect(ctx, &c)
+	if err != nil {
+		return fmt.Errorf("ldap: connect/bind: %w", err)
+	}
+	return conn.Close()
+}

--- a/pkg/identity/ldap/test_connection_test.go
+++ b/pkg/identity/ldap/test_connection_test.go
@@ -1,0 +1,96 @@
+package ldap
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestTestConnection_DialsAndBinds(t *testing.T) {
+	called := false
+	connect := func(context.Context, *Config) (conn, error) {
+		called = true
+		return &fakeConn{}, nil
+	}
+	if err := testConnection(context.Background(), baseCfg(), connect); err != nil {
+		t.Fatalf("testConnection: %v", err)
+	}
+	if !called {
+		t.Fatal("expected connect to be called")
+	}
+}
+
+func TestTestConnection_ValidationFailsBeforeDial(t *testing.T) {
+	cfg := baseCfg()
+	cfg.URL = "" // enabled but no URL → Validate must reject
+	called := false
+	connect := func(context.Context, *Config) (conn, error) {
+		called = true
+		return &fakeConn{}, nil
+	}
+	if err := testConnection(context.Background(), cfg, connect); err == nil {
+		t.Fatal("expected validation error")
+	}
+	if called {
+		t.Fatal("connect must not be called when validation fails")
+	}
+}
+
+func TestTestConnection_ConnectError(t *testing.T) {
+	wantErr := errors.New("dial refused")
+	connect := func(context.Context, *Config) (conn, error) { return nil, wantErr }
+	err := testConnection(context.Background(), baseCfg(), connect)
+	if err == nil || !errors.Is(err, wantErr) {
+		t.Fatalf("expected wrapped connect error, got %v", err)
+	}
+}
+
+func TestTestConnection_DoesNotMutateCaller(t *testing.T) {
+	cfg := baseCfg()
+	cfg.UserAttr = "" // ApplyDefaults would set this on a copy, not the caller
+	connect := func(context.Context, *Config) (conn, error) { return &fakeConn{}, nil }
+	if err := testConnection(context.Background(), cfg, connect); err != nil {
+		t.Fatalf("testConnection: %v", err)
+	}
+	if cfg.UserAttr != "" {
+		t.Errorf("caller config mutated: UserAttr = %q", cfg.UserAttr)
+	}
+}
+
+func TestTestConnection_NilConfig(t *testing.T) {
+	if err := TestConnection(context.Background(), nil); err == nil {
+		t.Fatal("expected error for nil config")
+	}
+}
+
+func TestMarshalStored_PreservesPasswordRoundTrip(t *testing.T) {
+	cfg := baseCfg()
+	cfg.BindPassword = "s3cret"
+
+	data, err := MarshalStored(cfg)
+	if err != nil {
+		t.Fatalf("MarshalStored: %v", err)
+	}
+	if !strings.Contains(string(data), "s3cret") {
+		t.Fatalf("stored blob must contain the real password, got %s", data)
+	}
+
+	got, err := UnmarshalStored(data)
+	if err != nil {
+		t.Fatalf("UnmarshalStored: %v", err)
+	}
+	if got.BindPassword != "s3cret" || got.URL != cfg.URL || got.BaseDN != cfg.BaseDN {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+
+	// The redacting marshaler must NOT leak the password (contrast with stored).
+	redacted, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(redacted), "s3cret") {
+		t.Fatalf("redacting marshaler leaked password: %s", redacted)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an admin-only control-plane API (and `dfsctl` commands) to configure **LDAP/AD and Kerberos identity providers** without editing config files or restarting — completing config-management parity with shares/stores/adapters/settings. Also fixes two AD/LDAP auth gaps found alongside it.

Closes #1311. Fixes #1317. Addresses the docs ask in #1314 (the NETLOGON-passthrough feature stays tracked there).

## #1311 — identity-provider configuration API

- Routes (admin-only, `{type}` ∈ `ldap` | `kerberos`):
  - `GET /api/v1/identity-providers` — list + enabled state (no secrets)
  - `GET /api/v1/identity-providers/{type}/config` — read (bind password redacted to `********`)
  - `PUT /api/v1/identity-providers/{type}/config` — create/replace (validated)
  - `POST /api/v1/identity-providers/{type}/test` — dry-run dial+bind (LDAP) / keytab check (Kerberos); never persists
- **Persistence**: new `IdentityProviderConfig` GORM model + store. The `ldap.*`/`kerberos.*` file/env config **seeds** the DB on first boot; a stored row then **takes precedence**.
- **Hot-reload**: LDAP changes rebuild and re-inject the live identity resolver in the NFS/SMB adapters (new runtime change notification; SMB resolver swap made race-safe via `atomic.Pointer`). Kerberos changes apply on the next restart (adapters bind it at startup).
- **Secrets**: bind password is write-only — redacted on read, preserved when the placeholder is resubmitted, stored unredacted for use after restart.
- `pkg/apiclient` typed methods + `dfsctl identity-provider {list,get,set,test}` + regenerated `docs/CLI.md` + `docs/CONFIGURATION.md` note.

## #1317 — SMB Kerberos accepts directory-resolved AD users

After a ticket validates, if no local control-plane account exists **but** the identity resolver matched the principal (LDAP/AD), the session is now built from the resolved identity instead of failing with `STATUS_LOGON_FAILURE`. This mirrors the NFS GSS path, so the same AD user maps to the same UID/GID across protocols. Disabled local accounts and unresolved principals still fail closed.

## #1314 — docs

Documented in `docs/SMB.md`: SMB NTLM authenticates **local** DittoFS users only; AD domain users must use **Kerberos** (NETLOGON passthrough is not implemented — tracked in #1314). LDAP idmap resolves identity, not NTLM auth.

## Notes

- `pkg/config` imports the control-plane API package, so the handler cannot import `pkg/config`/`pkg/auth/kerberos` (import cycle). The handler therefore owns a plain Kerberos DTO + validates inline + tests the keytab via gokrb5 directly; `cmd/dfs` maps the persisted DTO onto `config.KerberosConfig` at startup.
- Secrets are stored plaintext in the control-plane DB, matching the existing posture for S3/block-store credentials. At-rest encryption can be a follow-up.

## Tests

- LDAP `TestConnection` + storage codec (password preserved vs. redacting marshaler)
- Store round-trip (upsert, secret survives, list, delete)
- Handler: validate→400, GET redaction, password preservation on resubmit, 404 unconfigured, list, Kerberos validation, test-does-not-persist
- `#1317` regression: `resolveSessionUser` (local wins / directory-resolved / disabled fails closed / unresolved fails closed)
