### PR TITLE
fix(smb): carry supplementary/nested GIDs into auth context (#1327)

### DIFF
--- a/internal/adapter/smb/handlers/auth_helper.go
+++ b/internal/adapter/smb/handlers/auth_helper.go
@@ -159,6 +159,22 @@ func BuildAuthContextFromUser(ctx *SMBHandlerContext, user *models.User) *metada
 		authCtx.Identity.UID = &uid
 		authCtx.Identity.GID = &gid
 		authCtx.Identity.Username = user.Username
+		// Supplementary group IDs: populate Identity.GIDs from every group the
+		// user belongs to so POSIX-mode permission checks (Identity.HasGID)
+		// honor secondary / nested-AD-group membership, not just the primary
+		// GID. Without this an AD user resolved over Kerberos — or any local
+		// user in multiple groups — was granted group access over NFS (which
+		// carries the full set) but denied over SMB. Mirrors the NFS GSS path
+		// (#1327).
+		if len(user.Groups) > 0 {
+			gids := make([]uint32, 0, len(user.Groups))
+			for _, group := range user.Groups {
+				if group.GID != nil {
+					gids = append(gids, *group.GID)
+				}
+			}
+			authCtx.Identity.GIDs = gids
+		}
 		if user.SID != "" {
 			userSID := user.SID
 			authCtx.Identity.SID = &userSID

--- a/internal/adapter/smb/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/handlers/kerberos_auth.go
@@ -538,15 +538,26 @@ func (h *Handler) resolveKerberosIdentity(ctx *SMBHandlerContext, principal, rea
 // synthUserFromResolved builds a transient, non-persisted *models.User from a
 // directory-resolved identity so an AD/LDAP user with no local control-plane
 // account can still establish an SMB session. getUserIdentity derives the
-// primary GID from the first group, so the resolved primary GID is exposed
-// that way; SID/GroupSIDs flow into the SMB authorization context.
+// primary GID from the first group, so the resolved primary GID is listed
+// first; the full resolved supplementary set follows so the SMB auth context
+// carries nested AD group GIDs for POSIX-mode group checks, mirroring the NFS
+// GSS path (#1327). SID/GroupSIDs flow into the SMB authorization context.
 func synthUserFromResolved(r *identity.ResolvedIdentity) *models.User {
 	uid := r.UID
 	gid := r.GID
+	groups := make([]models.Group, 0, 1+len(r.GIDs))
+	groups = append(groups, models.Group{GID: &gid})
+	for _, g := range r.GIDs {
+		if g == r.GID {
+			continue // primary already listed first
+		}
+		sg := g
+		groups = append(groups, models.Group{GID: &sg})
+	}
 	return &models.User{
 		Username:  r.Username,
 		UID:       &uid,
-		Groups:    []models.Group{{GID: &gid}},
+		Groups:    groups,
 		SID:       r.SID,
 		GroupSIDs: r.GroupSIDs,
 		Enabled:   true,

--- a/internal/adapter/smb/handlers/kerberos_identity_test.go
+++ b/internal/adapter/smb/handlers/kerberos_identity_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -44,6 +45,65 @@ func TestResolveSessionUser_DirectoryResolvedWhenNoLocalAccount(t *testing.T) {
 	}
 	if got.SID != "S-1-5-21-1-2-3-1104" || len(got.GroupSIDs) != 1 {
 		t.Fatalf("SID/GroupSIDs not carried: %+v", got)
+	}
+}
+
+// TestSynthUserFromResolved_CarriesSupplementaryGIDs verifies the synthesized
+// user lists the primary GID first (so getUserIdentity picks it) and also
+// carries the full resolved supplementary set, deduplicating the primary
+// (#1327).
+func TestSynthUserFromResolved_CarriesSupplementaryGIDs(t *testing.T) {
+	resolved := &identity.ResolvedIdentity{
+		Username: "alice", UID: 10001, GID: 10000,
+		GIDs:  []uint32{10000, 10007, 10042}, // includes primary + two nested groups
+		Found: true,
+	}
+
+	got := synthUserFromResolved(resolved)
+
+	// Primary GID must be first for getUserIdentity.
+	uid, gid := getUserIdentity(got)
+	if uid != 10001 || gid != 10000 {
+		t.Fatalf("getUserIdentity = %d/%d, want 10001/10000", uid, gid)
+	}
+	// All distinct GIDs present exactly once (primary not duplicated).
+	gotGIDs := map[uint32]int{}
+	for _, g := range got.Groups {
+		if g.GID != nil {
+			gotGIDs[*g.GID]++
+		}
+	}
+	for _, want := range []uint32{10000, 10007, 10042} {
+		if gotGIDs[want] != 1 {
+			t.Fatalf("GID %d appears %d times, want 1: %+v", want, gotGIDs[want], gotGIDs)
+		}
+	}
+	if len(gotGIDs) != 3 {
+		t.Fatalf("expected 3 distinct GIDs, got %d: %+v", len(gotGIDs), gotGIDs)
+	}
+}
+
+// TestBuildAuthContextFromUser_PopulatesSupplementaryGIDs verifies the SMB auth
+// context carries Identity.GIDs from the user's full group set so POSIX-mode
+// group checks (HasGID) honor secondary / nested-AD groups, matching NFS (#1327).
+func TestBuildAuthContextFromUser_PopulatesSupplementaryGIDs(t *testing.T) {
+	user := synthUserFromResolved(&identity.ResolvedIdentity{
+		Username: "alice", UID: 10001, GID: 10000,
+		GIDs: []uint32{10000, 10007, 10042}, Found: true,
+	})
+
+	authCtx := BuildAuthContextFromUser(&SMBHandlerContext{Context: context.Background()}, user)
+
+	if authCtx.Identity.GID == nil || *authCtx.Identity.GID != 10000 {
+		t.Fatalf("primary GID = %v, want 10000", authCtx.Identity.GID)
+	}
+	for _, g := range []uint32{10007, 10042} {
+		if !authCtx.Identity.HasGID(g) {
+			t.Fatalf("HasGID(%d) = false, want true (supplementary group dropped)", g)
+		}
+	}
+	if authCtx.Identity.HasGID(99999) {
+		t.Fatal("HasGID(99999) = true, want false")
 	}
 }
 


### PR DESCRIPTION
Closes #1327.

## Problem

SMB built the auth context with only the **primary** GID, so POSIX-mode group permission checks (`Identity.HasGID`, `auth_permissions.go`) never saw a user's secondary or nested-AD groups. The same identity was granted group access over **NFS** — whose GSS path (`framework.go` `resolveIdentity`) carries the full `resolved.GIDs` set — but **denied over SMB**. Surfaced after #1320 let AD users with rich nested-group membership authenticate over SMB.

ACL/SD-mode shares were unaffected: SMB authorization there keys on `GroupSIDs` (the PAC delivers the transitive group-SID set under Kerberos), which #1320 already carried. This is specifically a POSIX-mode group-membership gap.

## Fix

- `BuildAuthContextFromUser` now populates `Identity.GIDs` from **every** group the user belongs to — so `HasGID` honors supplementary membership for local users too, not only directory-resolved ones.
- `synthUserFromResolved` lists the resolved primary GID first (so `getUserIdentity` still derives the correct primary) followed by the full resolved supplementary set, deduplicating the primary.

Mirrors the NFS GSS path so the same AD identity resolves to the same effective group set on both protocols.

## Tests

- `TestSynthUserFromResolved_CarriesSupplementaryGIDs` — primary listed first, full set carried, primary not duplicated.
- `TestBuildAuthContextFromUser_PopulatesSupplementaryGIDs` — `Identity.HasGID` returns true for nested groups, false for non-members.
- Existing #1317 `resolveSessionUser` regression suite still passes.

## Verification

```
go build ./...                                   # clean
go vet ./internal/adapter/smb/handlers/          # clean
go test ./internal/adapter/smb/handlers/         # ok
```

Refs #1317 #1231