### PR TITLE
fix(smb): late lease-break ACK after timeout force-complete returns OK (#1322)

### DIFF
--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -892,24 +892,36 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(ctx context.Context, leaseKey [16]b
 
 	if !lock.Lease.Breaking {
 		// Late ACK after server-side timeout: forceCompleteBreaks already
-		// auto-revoked the lease to None and tagged BrokenViaTimeout. If
-		// the client now ACKs that same None state, the wire-visible
-		// outcome matches the desired final state — return STATUS_OK
-		// silently. BrokenViaTimeout is left untouched so the downstream
-		// grant-coercion path (OnlyTimeoutTombstoneRecords) still treats
-		// the record as a tombstone for smbtorture batch22b semantics.
+		// auto-revoked the lease to None and tagged BrokenViaTimeout. The
+		// client's late ACK is then a benign acknowledgment of a break the
+		// server has already completed — return STATUS_OK silently,
+		// regardless of which (subset) state the client names. We do NOT
+		// resurrect any bits: LeaseState stays None. BrokenViaTimeout is
+		// left untouched so the downstream grant-coercion path
+		// (OnlyTimeoutTombstoneRecords) still treats the record as a
+		// tombstone for smbtorture batch22b semantics.
 		//
-		// Required by WPTS BVT_DirectoryLeasing_ReadWriteHandleCaching
-		// (#454) where the SUT controller's synchronous CreateFile holds
-		// the test client past the 5 s parent-break timeout, so the ACK
-		// can only be sent post-force-complete. smbtorture breaking2 /
-		// breaking5 ACK within the breaking window, so their post-ack
-		// duplicate has BrokenViaTimeout=false and still surfaces as
-		// STATUS_UNSUCCESSFUL via the fall-through below.
-		if lock.Lease.BrokenViaTimeout && acknowledgedState == LeaseStateNone &&
-			lock.Lease.LeaseState == LeaseStateNone {
-			logger.Debug("AcknowledgeLeaseBreak: late ACK matches post-timeout state, treating as success",
-				"leaseKey", fmt.Sprintf("%x", leaseKey))
+		// The acknowledgedState is intentionally NOT constrained to None:
+		// a parked share-violation CREATE that force-completes the holder's
+		// RWH lease (revoking to None) races the holder's deferred Handle-
+		// strip ACK (break-to RW). When the 5 s force-complete wins under CI
+		// jitter, the holder ACKs RW post-timeout and must still succeed —
+		// smbtorture dhv2-pending1n-vs-violation-lease-ack-sane (#1322).
+		// forceCompleteBreaks zeroes BreakToState, so there is no surviving
+		// break-to to validate the subset against; the tombstoned None is
+		// the authoritative outcome either way.
+		//
+		// Also required by WPTS BVT_DirectoryLeasing_ReadWriteHandleCaching
+		// (#454) where the SUT controller's synchronous CreateFile holds the
+		// test client past the 5 s parent-break timeout, so the ACK can only
+		// be sent post-force-complete. smbtorture breaking2 / breaking5 ACK
+		// within the breaking window, so their post-ack duplicate has
+		// BrokenViaTimeout=false and still surfaces as STATUS_UNSUCCESSFUL
+		// via the fall-through below.
+		if lock.Lease.BrokenViaTimeout && lock.Lease.LeaseState == LeaseStateNone {
+			logger.Debug("AcknowledgeLeaseBreak: late ACK after timeout force-complete, treating as success",
+				"leaseKey", fmt.Sprintf("%x", leaseKey),
+				"acknowledgedState", LeaseStateToString(acknowledgedState))
 			return nil
 		}
 		return ErrLeaseAckNotBreaking

--- a/pkg/metadata/lock/leases_test.go
+++ b/pkg/metadata/lock/leases_test.go
@@ -1097,6 +1097,60 @@ func TestAcknowledgeLeaseBreak_AckToNone_KeepsRecordAtNone(t *testing.T) {
 	assert.False(t, found, "lease should be gone after CLOSE")
 }
 
+// TestAcknowledgeLeaseBreak_LateAckNonNoneAfterTimeout_Succeeds pins the
+// smbtorture dhv2-pending1n-vs-violation-lease-ack-sane "sane" contract (#1322):
+// when a parked CREATE force-completes the holder's breaking lease on the
+// break-wait timeout (revoking RWH→None, BrokenViaTimeout), a holder that ACKs
+// LATE with its intended handle-strip state (RW, a non-None subset of the
+// original break-to) must still get STATUS_OK — not STATUS_UNSUCCESSFUL. The
+// pre-#1322 success branch forgave only a None==None late ACK, so an RW late
+// ACK fell through to ErrLeaseAckNotBreaking and flaked the test whenever CI
+// jitter let the 5 s force-complete win the race against the holder's ACK.
+//
+// The ACK must NOT resurrect any lease bits: the force-completed None stands.
+func TestAcknowledgeLeaseBreak_LateAckNonNoneAfterTimeout_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	key1 := [16]byte{1, 0, 0, 0}
+
+	// Holder takes an RWH lease, then is broken (Handle strip, break-to RW) by a
+	// conflicting open.
+	_, _, err := mgr.RequestLease(ctx, FileHandle("file1"), key1, [16]byte{}, "owner1", "client1", "/share",
+		LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+	mgr.mu.Lock()
+	for _, locks := range mgr.unifiedLocks {
+		for _, lock := range locks {
+			if lock.Lease != nil && lock.Lease.LeaseKey == key1 {
+				lock.Lease.Breaking = true
+				lock.Lease.BreakToState = LeaseStateRead | LeaseStateWrite
+				lock.Lease.BreakingToRequired = LeaseStateRead | LeaseStateWrite
+				lock.Lease.BreakStarted = time.Now()
+			}
+		}
+	}
+	mgr.mu.Unlock()
+
+	// The parked CREATE's break-wait timer fires first (CI jitter): force-complete
+	// tombstones the lease to None and tags BrokenViaTimeout.
+	mgr.forceCompleteBreaks("file1")
+	state, _, found := mgr.GetLeaseState(ctx, key1)
+	require.True(t, found, "force-completed record persists at None")
+	require.Equal(t, LeaseStateNone, state, "force-complete revoked to None")
+
+	// Holder ACKs late with RW (its handle-strip break-to, a non-None state).
+	// Must succeed — the break the server already completed is benignly ack'd.
+	err = mgr.AcknowledgeLeaseBreak(ctx, key1, LeaseStateRead|LeaseStateWrite, 0)
+	require.NoError(t, err, "late non-None ACK after timeout force-complete must succeed (ack-sane)")
+
+	// The ACK must not resurrect bits: the forced None stands.
+	state, _, found = mgr.GetLeaseState(ctx, key1)
+	assert.True(t, found, "record still present after late ACK")
+	assert.Equal(t, LeaseStateNone, state, "late ACK must not resurrect lease bits")
+}
+
 // ============================================================================
 // ReleaseLease Tests
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes the intermittent `STATUS_UNSUCCESSFUL` on the holder's deferred `LEASE_BREAK_ACK` in `smb2.replay.dhv2-pending1n-vs-violation-lease-ack-sane` (#1322). The test was flipped green by #749 and is now re-flaking under CI scheduling jitter.

## Root cause (of the flake surface)

A parked share-violation CREATE can force-complete the holder's breaking lease on the break-wait timeout, revoking `RWH→None` and tagging `BrokenViaTimeout`. The holder then ACKs **late** with its Handle-strip break-to state (`RW`). The post-timeout success branch in `acknowledgeLeaseBreakImpl` only forgave a `None==None` late ACK:

```go
if lock.Lease.BrokenViaTimeout && acknowledgedState == LeaseStateNone &&
    lock.Lease.LeaseState == LeaseStateNone { return nil }
return ErrLeaseAckNotBreaking   // RW late ACK lands here → STATUS_UNSUCCESSFUL
```

So whenever the 5 s force-complete won the race against the holder's ACK, the `RW` ACK fell through to `ErrLeaseAckNotBreaking`.

## Fix

Widen the branch: **any** late ACK on a `BrokenViaTimeout` record already tombstoned to `None` returns OK, without resurrecting bits. `forceCompleteBreaks` zeroes `BreakToState`, so the tombstoned `None` is the authoritative outcome regardless of which (subset) state the client names.

Unaffected:
- `breaking2` / `breaking5` duplicate-ACK — these ACK within the breaking window, so `BrokenViaTimeout=false` and still surface `STATUS_UNSUCCESSFUL` via the fall-through.
- `batch22b` grant-coercion — `BrokenViaTimeout` tombstone is preserved.

## Note — follow-up

This is a robust backstop, not the deepest fix. The *correct* fix (matching Samba `defer_open`) is to stop the parked share-violation CREATE from force-completing at all — #749 already does this for the `SharingViolation` path; the residual flake is the break **misclassifying as `reason=Default`** under jitter. Tracked separately for proper root-cause (needs smbtorture repro).

## Test

`TestAcknowledgeLeaseBreak_LateAckNonNoneAfterTimeout_Succeeds` — RW late ACK after timeout force-complete returns OK, and asserts the forced `None` is not resurrected. Full `pkg/metadata/lock`, `internal/adapter/smb/lease`, and `internal/adapter/smb/handlers` suites green.
