### PR TITLE
fix(test): export AES keytab from AD-DC fixture (#1318)

### DIFF
--- a/test/integration/ad-dc/ad_dc_keytab_test.go
+++ b/test/integration/ad-dc/ad_dc_keytab_test.go
@@ -38,6 +38,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jcmturner/gokrb5/v8/keytab"
+
 	smbauth "github.com/marmos91/dittofs/internal/adapter/smb/auth"
 	"github.com/marmos91/dittofs/internal/adapter/smb/handlers"
 	kerbauth "github.com/marmos91/dittofs/internal/auth/kerberos"
@@ -83,6 +85,14 @@ func TestADCombinedKeytabAndDomainAwareSMB(t *testing.T) {
 		t.Errorf("combined keytab missing nfs/ principal component (file %d bytes)", len(ktBytes))
 	}
 	t.Logf("combined keytab (%d bytes) carries both cifs/ and nfs/ principals ✓", len(ktBytes))
+
+	// --- (1b) Each service principal carries AES256 + AES128 keys (#1318) ----
+	// Windows 11 refuses RC4 (arcfour-hmac, etype 23) service tickets, so the
+	// exported keytab MUST carry aes256-cts (etype 18) and aes128-cts (etype 17)
+	// keys for each SPN. Parse the keytab with gokrb5 and assert both enctypes
+	// are present per service-principal component — not merely that the file is
+	// non-empty or that some AES key exists somewhere.
+	assertKeytabHasAESPerSPN(t, ktBytes)
 
 	// --- (2) Provider surfaces the configured/derived AD domain identity ----
 	// Configure Realm + NetBIOSDomain explicitly (the short name is never
@@ -189,6 +199,56 @@ func keytabHasComponent(buf []byte, want string) bool {
 		}
 	}
 	return false
+}
+
+// Kerberos enctype numbers (RFC 3961 / RFC 8009).
+const (
+	etypeAES128CTS = 17 // aes128-cts-hmac-sha1-96
+	etypeAES256CTS = 18 // aes256-cts-hmac-sha1-96
+)
+
+// assertKeytabHasAESPerSPN parses the raw keytab with gokrb5 and asserts that
+// each service principal ("cifs/..." and "nfs/...") has BOTH an aes256-cts
+// (etype 18) and an aes128-cts (etype 17) key entry. This guards against the
+// #1318 regression where the AD-DC exported an RC4-only (arcfour-hmac, etype 23)
+// keytab that Windows 11 refuses for service tickets.
+func assertKeytabHasAESPerSPN(t *testing.T, ktBytes []byte) {
+	t.Helper()
+
+	var kt keytab.Keytab
+	if err := kt.Unmarshal(ktBytes); err != nil {
+		t.Fatalf("parse combined keytab with gokrb5: %v", err)
+	}
+
+	// service -> set of enctypes seen for that service's principal.
+	have := map[string]map[int32]bool{
+		"cifs": {},
+		"nfs":  {},
+	}
+	for _, e := range kt.Entries {
+		if len(e.Principal.Components) == 0 {
+			continue
+		}
+		svc := e.Principal.Components[0] // "cifs" or "nfs"
+		if seen, ok := have[svc]; ok {
+			seen[e.Key.KeyType] = true
+		}
+		t.Logf("keytab entry: principal=%s realm=%s etype=%d kvno=%d",
+			strings.Join(e.Principal.Components, "/"), e.Principal.Realm, e.Key.KeyType, e.KVNO)
+	}
+
+	for _, svc := range []string{"cifs", "nfs"} {
+		seen := have[svc]
+		if !seen[etypeAES256CTS] {
+			t.Errorf("keytab %s/ principal missing aes256-cts key (etype %d); Windows 11 rejects RC4-only service tickets", svc, etypeAES256CTS)
+		}
+		if !seen[etypeAES128CTS] {
+			t.Errorf("keytab %s/ principal missing aes128-cts key (etype %d); Windows 11 rejects RC4-only service tickets", svc, etypeAES128CTS)
+		}
+		if seen[etypeAES256CTS] && seen[etypeAES128CTS] {
+			t.Logf("keytab %s/ principal carries aes256-cts + aes128-cts keys ✓", svc)
+		}
+	}
 }
 
 // parseChallengeTargetInfo extracts the TargetInfo AV_PAIR blob from a Type-2

--- a/test/integration/ad-dc/entrypoint.sh
+++ b/test/integration/ad-dc/entrypoint.sh
@@ -156,6 +156,47 @@ if [ ! -f "$keytab" ]; then
     samba-tool spn add "$SMB_SPN" "$DOMAIN\\Administrator" >/dev/null 2>&1 || true
     samba-tool spn add "$NFS_SPN" "$DOMAIN\\Administrator" >/dev/null 2>&1 || true
 
+    # Force AES kerberos keys on the SPN-holding account (issue #1318).
+    #
+    # By default the Administrator account that holds the cifs/ + nfs/ SPNs may
+    # carry only the arcfour-hmac (RC4) kerberos key, so `exportkeytab` emits an
+    # RC4-only keytab. Windows 11 refuses RC4 (arcfour-hmac) service tickets, so
+    # the exported keytab must carry AES256/AES128 keys for the SPNs.
+    #
+    # Two steps are required, in order:
+    #   1. Advertise AES support on the account by setting
+    #      msDS-SupportedEncryptionTypes. 0x1F (31) = DES-CBC-CRC + DES-CBC-MD5 +
+    #      RC4-HMAC + AES128-CTS + AES256-CTS; keeping the legacy bits set avoids
+    #      breaking any RC4/DES client while adding AES. (0x18 / 24 would be
+    #      AES-only.)
+    #   2. Regenerate the kerberos keys. AES keys are derived from the account
+    #      password + salt, so they only materialise on a password change. Reset
+    #      the Administrator password to itself to force key regeneration without
+    #      changing the credential the rest of the fixture relies on.
+    #
+    # exportkeytab (below) then emits the full key set the DC now holds — AES256,
+    # AES128, and RC4 — because we never restrict it to a single --enctype.
+    admin_dn="$(samba-tool user show Administrator --attributes=distinguishedName 2>/dev/null \
+        | sed -n 's/^distinguishedName: //p' | head -n1)"
+    if [ -n "$admin_dn" ]; then
+        log "Enabling AES enctypes on $admin_dn (msDS-SupportedEncryptionTypes=31)"
+        ldbmodify -H /var/lib/samba/private/sam.ldb <<EOF || \
+            log "WARN: failed to set msDS-SupportedEncryptionTypes (continuing)"
+dn: $admin_dn
+changetype: modify
+replace: msDS-SupportedEncryptionTypes
+msDS-SupportedEncryptionTypes: 31
+EOF
+    else
+        log "WARN: could not resolve Administrator DN; skipping enctype attribute set"
+    fi
+
+    # Reset the password to itself to regenerate kerberos keys (incl. AES) now
+    # that AES enctypes are advertised on the account.
+    log "Regenerating kerberos keys for Administrator (password reset to force AES)"
+    samba-tool user setpassword Administrator --newpassword="$ADMIN_PASSWORD" \
+        >/dev/null 2>&1 || log "WARN: setpassword failed (continuing)"
+
     # Export cifs/ then APPEND nfs/ into the same keytab file.
     samba-tool domain exportkeytab "$keytab" \
         --principal="$SMB_SPN@$REALM"
@@ -172,7 +213,22 @@ if [ ! -f "$keytab" ]; then
         if ! klist -k "$keytab" 2>/dev/null | grep -qi "nfs/"; then
             log "ERROR: combined keytab missing nfs/ principal"; klist -k "$keytab" || true; exit 1
         fi
-        log "Combined keytab verified: carries both cifs/ and nfs/ principals"
+        # Fast-fail if AES keys are missing (issue #1318). `klist -ke` prints the
+        # enctype per entry; require at least one aes256-cts and one aes128-cts so
+        # the Windows-11-incompatible RC4-only regression cannot slip through.
+        if klist -ke "$keytab" >/dev/null 2>&1; then
+            if ! klist -ke "$keytab" 2>/dev/null | grep -qi "aes256-cts"; then
+                log "ERROR: combined keytab missing aes256-cts key (Win11 rejects RC4-only)"
+                klist -ke "$keytab" || true; exit 1
+            fi
+            if ! klist -ke "$keytab" 2>/dev/null | grep -qi "aes128-cts"; then
+                log "ERROR: combined keytab missing aes128-cts key (Win11 rejects RC4-only)"
+                klist -ke "$keytab" || true; exit 1
+            fi
+            log "Combined keytab verified: carries cifs/ + nfs/ with aes256-cts and aes128-cts keys"
+        else
+            log "Combined keytab verified: carries both cifs/ and nfs/ principals (enctype check skipped)"
+        fi
     else
         log "klist unavailable; skipping in-container keytab verification (Go test re-checks)"
     fi


### PR DESCRIPTION
Closes #1318.

## Problem

The dockerized Samba AD-DC test fixture exported an **RC4-only** service keytab. The Administrator account holding the `cifs/` + `nfs/` SPNs carried only an arcfour-hmac (RC4) Kerberos key, so `samba-tool domain exportkeytab` (which never restricts enctype) emitted RC4 only. **Windows 11 refuses RC4/arcfour-hmac service tickets**, so a Win11 client cannot authenticate against a DittoFS server using this keytab. (Linux `smbclient` tolerates RC4, which is why earlier in-cluster SMB-Kerberos testing passed despite this.)

The fixture's krb5.conf/smb.conf were not forcing arcfour — the only missing piece was AES keys on the account.

## Fix (`test/integration/ad-dc/entrypoint.sh`)

After registering the SPNs, before `exportkeytab`:
1. `ldbmodify` the account's `msDS-SupportedEncryptionTypes = 31` (0x1F = DES + RC4 + AES128 + AES256 — keeps legacy bits so no existing client breaks while adding AES).
2. `samba-tool user setpassword Administrator --newpassword=<same>` to regenerate the Kerberos keys (AES keys derive from password+salt, so they only materialize on a password change). Resetting to the same password avoids disturbing the rest of the fixture.

`exportkeytab` then emits the full key set (AES256 + AES128 + RC4). Added an in-container `klist -ke` fast-fail that requires both `aes256-cts` and `aes128-cts` so an RC4-only regression can't slip through.

## Test (`ad_dc_keytab_test.go`)

New assertion parses the exported keytab with gokrb5 and verifies **each** SPN (`cifs/`, `nfs/`) carries etype 18 (aes256-cts) **and** etype 17 (aes128-cts) — not merely that the keytab is non-empty.

## Verification

Local (Windows): `go build ./...`, `go vet -tags=ad_dc ./test/integration/ad-dc/...`, `gofmt -l` clean, package compiles under the `ad_dc` build tag.

The `ad_dc` integration test needs Docker + the Samba image and does not run on Windows — end-to-end keytab-enctype verification runs on the Linux VM fixture. (Mechanism validated live against the running Samba AD-DC — see issue.)