### PR TITLE
fix(snapshot): open held manifests with Windows share-delete + ride out AV scans (#1332)

### DIFF
--- a/pkg/controlplane/runtime/snapshot_hold.go
+++ b/pkg/controlplane/runtime/snapshot_hold.go
@@ -146,20 +146,31 @@ func streamManifest(path string, fn func(block.ContentHash) error) (int, error) 
 	return hs.Len(), nil
 }
 
-// openManifestWithRetry opens path, retrying briefly on a Windows sharing
-// violation. The GC mark phase RLocks out concurrent snapshot deletes, but a
-// concurrent create's atomic rename — or, on real Windows deployments, an
-// antivirus / search-indexer momentarily holding the file — can surface
-// ERROR_SHARING_VIOLATION on open. That is transient: a short bounded retry
-// lets it clear rather than aborting the whole GC pass (which would skip
-// every later share's holds and risk deleting a still-held block).
-// fs.ErrNotExist is returned immediately (a TOCTOU delete is the caller's to
-// interpret, and is not resolved by waiting).
+// openManifestWithRetry opens path via openManifestShared (which on Windows
+// grants FILE_SHARE_DELETE so this read handle never blocks a concurrent unlink
+// of the manifest — see snapshot_open_windows.go). The retry handles the
+// remaining Windows sharing-violation source the share mode cannot: an
+// on-access antivirus / search-indexer scan that momentarily opens the
+// freshly written manifest WITHOUT sharing, so this open trips
+// ERROR_SHARING_VIOLATION until the scan releases it. A bounded retry rides out
+// the scan rather than aborting the whole GC pass (which would skip every later
+// share's holds and risk deleting a still-held block). fs.ErrNotExist is
+// returned immediately (a TOCTOU delete is the caller's to interpret, and is
+// not resolved by waiting).
 func openManifestWithRetry(path string) (*os.File, error) {
-	const maxAttempts = 5
+	// ~1.3s total budget over 10 attempts (capped exponential backoff). An
+	// on-access AV/indexer scan of a freshly written manifest can hold the file
+	// for longer than the original 100ms budget under heavy snapshot churn,
+	// which red-failed the GC pass (#1332); this rides out the scan instead.
+	const (
+		maxAttempts = 10
+		baseBackoff = 10 * time.Millisecond
+		maxBackoff  = 200 * time.Millisecond
+	)
 	var lastErr error
+	backoff := baseBackoff
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		f, err := os.Open(path)
+		f, err := openManifestShared(path)
 		if err == nil {
 			return f, nil
 		}
@@ -167,7 +178,8 @@ func openManifestWithRetry(path string) (*os.File, error) {
 			return nil, err
 		}
 		lastErr = err
-		time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
+		time.Sleep(backoff)
+		backoff = min(backoff*2, maxBackoff)
 	}
 	return nil, lastErr
 }

--- a/pkg/controlplane/runtime/snapshot_open_other.go
+++ b/pkg/controlplane/runtime/snapshot_open_other.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package runtime
+
+import "os"
+
+// openManifestShared is plain os.Open everywhere but Windows: POSIX already
+// lets a file be renamed or unlinked while held open for read, so there is no
+// sharing-violation class to guard against (see the Windows variant for the
+// rationale behind the explicit share mode there).
+func openManifestShared(path string) (*os.File, error) {
+	return os.Open(path)
+}

--- a/pkg/controlplane/runtime/snapshot_open_windows.go
+++ b/pkg/controlplane/runtime/snapshot_open_windows.go
@@ -1,0 +1,41 @@
+//go:build windows
+
+package runtime
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// openManifestShared opens path read-only with the full Windows sharing set
+// (FILE_SHARE_READ|WRITE|DELETE). Bare os.Open omits FILE_SHARE_DELETE, so a
+// read handle held over a manifest blocks — and collides with — a concurrent
+// snapshot create's atomic rename (MoveFileEx replace) or a delete's RemoveAll
+// on the same path, surfacing ERROR_SHARING_VIOLATION (#1332). Granting
+// FILE_SHARE_DELETE lets the rename/unlink proceed against the open handle
+// (POSIX-like semantics: the reader keeps reading the now-detached file),
+// eliminating the collision class instead of merely retrying through it.
+//
+// fs.ErrNotExist still propagates unchanged: CreateFile maps a missing path to
+// ERROR_FILE_NOT_FOUND/ERROR_PATH_NOT_FOUND, which windows.Errno (a
+// syscall.Errno) reports as os.ErrNotExist via errors.Is.
+func openManifestShared(path string) (*os.File, error) {
+	p, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	h, err := windows.CreateFile(
+		p,
+		windows.GENERIC_READ,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	return os.NewFile(uintptr(h), path), nil
+}

--- a/pkg/controlplane/runtime/snapshot_open_windows_test.go
+++ b/pkg/controlplane/runtime/snapshot_open_windows_test.go
@@ -1,0 +1,49 @@
+//go:build windows
+
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestOpenManifestShared_DoesNotBlockDelete is the deterministic Windows
+// regression for #1332. The GC mark phase streams manifest.hashes while the
+// snapshot lifecycle unlinks it. With bare os.Open the read handle omits
+// FILE_SHARE_DELETE, so a concurrent unlink raises ERROR_SHARING_VIOLATION;
+// openManifestShared grants the full sharing set so the unlink proceeds against
+// the open handle (POSIX-like: the reader keeps reading the detached file).
+func TestOpenManifestShared_DoesNotBlockDelete(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manifest.hashes")
+	require.NoError(t, os.WriteFile(path, []byte("hash-a\n"), 0o600))
+
+	// A held read handle (the mark side streaming the manifest) must NOT block
+	// a concurrent snapshot delete removing the file.
+	f, err := openManifestShared(path)
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+	require.NoError(t, os.Remove(path),
+		"shared read handle must not block manifest delete (#1332)")
+
+	// Baseline contrast: a bare os.Open (the pre-fix path) DOES block the same
+	// delete, proving the explicit share mode is what fixes #1332.
+	require.NoError(t, os.WriteFile(path, []byte("hash-b\n"), 0o600))
+	bare, err := os.Open(path)
+	require.NoError(t, err)
+	require.Error(t, os.Remove(path),
+		"baseline: bare os.Open omits FILE_SHARE_DELETE and blocks delete on Windows")
+	require.NoError(t, bare.Close())
+	require.NoError(t, os.Remove(path)) // leave dir clean for t.TempDir cleanup
+}
+
+// TestOpenManifestShared_MissingPathIsErrNotExist guards that the Windows
+// CreateFile path preserves fs.ErrNotExist semantics so streamManifest's TOCTOU
+// short-circuit (manifest deleted between Stat and open) still triggers.
+func TestOpenManifestShared_MissingPathIsErrNotExist(t *testing.T) {
+	_, err := openManifestShared(filepath.Join(t.TempDir(), "does-not-exist.hashes"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}


### PR DESCRIPTION
## Problem (#1332)

`go test ./pkg/controlplane/runtime/` on Windows intermittently failed:

```
TestSnapshotHoldProvider_StressGCvsDeleteUnderChurn: HeldHashes error:
... open ...\manifest.hashes: The process cannot access the file because it is
being used by another process.   (ERROR_SHARING_VIOLATION, 32)
```

The GC mark phase streams each held snapshot's `manifest.hashes` while the
snapshot lifecycle renames/unlinks it.

## Root cause (two distinct sources)

1. **Reader handle blocked unlink.** Bare `os.Open` omits `FILE_SHARE_DELETE`,
   so the read handle blocked / collided with a concurrent unlink of the manifest
   (POSIX allows unlink-while-open; Windows does not by default).
2. **AV/indexer scan.** An on-access antivirus / search-indexer momentarily opens
   the freshly written manifest *without* sharing — which the reader's own share
   mode cannot influence. The pre-existing retry's ~100ms budget could exhaust
   under heavy churn.

## Fix

- New platform shim `openManifestShared`: on Windows opens via
  `windows.CreateFile` with `FILE_SHARE_READ|WRITE|DELETE` (POSIX-like detach
  semantics); a plain `os.Open` everywhere else. Eliminates collision class (1).
- Widened the retry to a ~1.3s capped-exponential budget to ride out an AV scan
  (2) instead of red-failing the whole GC pass.
- `fs.ErrNotExist` still propagates unchanged for the TOCTOU short-circuit.

## Verification

- New deterministic Windows regression `TestOpenManifestShared_DoesNotBlockDelete`
  (shared handle does not block delete; bare `os.Open` baseline contrast proves
  the share mode is what fixes it) + `..._MissingPathIsErrNotExist`.
- `TestSnapshotHoldProvider_StressGCvsDeleteUnderChurn` green (count=20, 135s) on
  Windows arm64; full `pkg/controlplane/runtime` suite green.
- `GOOS=linux` and `windows` both build.

Note: `-race` is unavailable on windows/arm64, so the stress repro relies on the
deterministic unit test for the mechanism proof.