### PR TITLE
test(config): make no-config fallback test hermetic across dev boxes (#1333)

### DIFF
--- a/pkg/config/mustload_defaults_test.go
+++ b/pkg/config/mustload_defaults_test.go
@@ -8,14 +8,18 @@ import (
 // TestMustLoad_NoConfigFileFallsBackToDefaults verifies the #1245 fix: when no
 // config file exists at the default location, MustLoad with an empty path must
 // NOT hard-fail (which made systemd crash-loop). Instead it falls back to
-// built-in defaults so the server boots. The empty XDG_CONFIG_HOME tmp dir
+// built-in defaults so the server boots. The empty temp config dir
 // guarantees DefaultConfigExists() is false.
 func TestMustLoad_NoConfigFileFallsBackToDefaults(t *testing.T) {
-	// Point the default config location at an empty temp dir (no config.yaml).
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	// Point the default config location at an empty temp dir (no config.yaml),
+	// so DefaultConfigExists() is false even on a dev box that actually runs
+	// dfs and has a real config at the default location (#1333).
+	setConfigDirEnv(t, t.TempDir())
 
 	if DefaultConfigExists() {
-		t.Fatal("precondition failed: a config file unexpectedly exists at the default location")
+		// Redirect didn't take (unusual env, e.g. APPDATA unset and HOME holds
+		// a config): this host can't host the test, so skip rather than fail.
+		t.Skip("a config file exists at the default location; cannot exercise the no-config fallback here")
 	}
 
 	cfg, err := MustLoad("")


### PR DESCRIPTION
## Problem (#1333)

`go test ./pkg/config/` hard-failed on any dev box / Windows workstation that has
actually run `dfs` (which writes a default config):

```
TestMustLoad_NoConfigFileFallsBackToDefaults:
  precondition failed: a config file unexpectedly exists at the default location
```

## Cause

The test only redirected `XDG_CONFIG_HOME`, which `getConfigDir()` ignores on
Windows (it reads `APPDATA`). So the real default config remained visible and the
precondition tripped `t.Fatal`.

## Fix

- Redirect the OS-appropriate base env var via the existing `setConfigDirEnv`
  helper (`APPDATA` on Windows, `XDG_CONFIG_HOME` on Unix) so the test is hermetic
  everywhere.
- Downgrade the residual precondition from `t.Fatal` to `t.Skip`: a host that
  still has a config at the default location simply can't exercise the no-config
  path — an environment limitation, not a product failure.

## Verification

`go test ./pkg/config/ -run TestMustLoad` passes on Windows (previously fataled).