### PR TITLE
fix(dfs): demote expected shutdown causes from ERROR to Info (#1329)

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
@@ -358,11 +359,12 @@ func runStart(cmd *cobra.Command, args []string) error {
 		defer timer.Stop()
 		select {
 		case err := <-serverDone:
-			if err != nil {
+			if isExpectedShutdownErr(err) {
+				logger.Info("Server stopped gracefully")
+			} else {
 				logger.Error("Server shutdown error", "error", err)
 				return err
 			}
-			logger.Info("Server stopped gracefully")
 		case <-timer.C:
 			logger.Error("Graceful shutdown exceeded deadline; forcing exit",
 				"deadline", shutdownDeadline)
@@ -379,6 +381,19 @@ func runStart(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// isExpectedShutdownErr reports whether err is the normal outcome of a
+// SIGTERM-initiated graceful shutdown rather than a real failure. We cancel the
+// root context on purpose, so context.Canceled — and the http.ErrServerClosed a
+// listener returns once Shutdown is called — are expected. Per the logging
+// convention (expected errors at Info/Debug, unexpected at Error), these must
+// not be logged at ERROR: a clean shutdown emitting ERROR on every restart
+// tripped alerting / log-based health checks (#1329).
+func isExpectedShutdownErr(err error) bool {
+	return err == nil ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, http.ErrServerClosed)
 }
 
 // getConfigSource returns a description of where the config was loaded from.

--- a/cmd/dfs/commands/start_shutdown_test.go
+++ b/cmd/dfs/commands/start_shutdown_test.go
@@ -1,0 +1,36 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// TestIsExpectedShutdownErr pins #1329: a SIGTERM-initiated graceful shutdown
+// returns context.Canceled (and listeners return http.ErrServerClosed), which
+// must be classified as expected so it logs at Info and exits zero — while a
+// genuine drain failure must still be treated as an error.
+func TestIsExpectedShutdownErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, true},
+		{"bare context.Canceled", context.Canceled, true},
+		{"wrapped context.Canceled", fmt.Errorf("runtime serve: %w", context.Canceled), true},
+		{"http.ErrServerClosed", http.ErrServerClosed, true},
+		{"wrapped http.ErrServerClosed", fmt.Errorf("api server: %w", http.ErrServerClosed), true},
+		{"real failure", errors.New("store flush failed"), false},
+		{"deadline exceeded is not canceled", context.DeadlineExceeded, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isExpectedShutdownErr(tc.err); got != tc.want {
+				t.Fatalf("isExpectedShutdownErr(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem (#1329)

A clean SIGTERM-initiated shutdown ended with:

```
ERROR  Server shutdown error  error="context canceled"
```

`context.Canceled` is the *expected* result of an intentional root-context
cancel, so logging it at ERROR (and returning non-zero) on every restart tripped
alerting / log-based health checks and muddied postmortems. CLAUDE.md rule 6:
expected errors log at Debug/Info, unexpected at Error.

## Fix

- New pure helper `isExpectedShutdownErr` treating `nil`, `context.Canceled`, and
  `http.ErrServerClosed` (incl. wrapped) as expected.
- In the SIGTERM drain branch: expected → log `Server stopped gracefully` at Info
  and exit zero; anything else → ERROR + return err (unchanged). The non-shutdown
  `serverDone` case and the deadline-timeout case are untouched.
- Table test covers bare/wrapped expected errors, a real failure, and
  `context.DeadlineExceeded` (must stay unexpected).

## Verification

**Unit:** `go test ./cmd/dfs/commands/ -run TestIsExpectedShutdownErr` — all subtests pass.

**Live (demo, k3s):** built `dittofs:dev-1329`, rolled `demo-0`, graceful SIGTERM. Final drain sequence:

```
INFO  snapshot lifecycle: no in-flight snapshots at shutdown
INFO  API server stopped gracefully
INFO  NFS graceful shutdown complete: all connections closed
INFO  SMB graceful shutdown complete: all connections closed
INFO  NFS shutdown signal received   error="context canceled"   <- now INFO, was the ERROR source
INFO  DittoFS runtime stopped
INFO  Server stopped gracefully
```

No `ERROR Server shutdown error` line — the pre-fix baseline documented in #1329
is gone; `context canceled` now surfaces only as INFO.