### PR TITLE
fix(smb): reclassify decorrelated handle-strip break as sharing violation (#1331)

### DIFF
--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -274,6 +274,11 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 	// initialConflict is consumed at most once by the wait closure; every
 	// subsequent poll must re-scan because a holder CLOSE/ACK can clear the
 	// conflict. conflictComputed records whether the scan actually ran.
+	var waitExceptKey [16]byte
+	if d.excludeOwner != nil {
+		waitExceptKey = d.excludeOwner.ExcludeLeaseKey
+	}
+
 	var initialConflict, conflictComputed bool
 	reason := lock.BreakReasonDefault
 	switch {
@@ -286,12 +291,47 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 		conflictComputed = true
 		if initialConflict {
 			reason = lock.BreakReasonSharingViolation
+		} else if newOpenIsShareRestrictive(d.req.DesiredAccess, d.req.ShareAccess) &&
+			h.LeaseManager.AnyHolderHasLeaseBits(lockFileHandle, shareName, waitExceptKey, lock.LeaseStateHandle) {
+			// Decorrelation race (#1331): checkShareModeConflict scans only live
+			// h.files opens, but a Handle-caching lease record can outlive its
+			// OpenFile by a few microseconds during the holder's close /
+			// durable-reconnect teardown. When the live-open scan misses that
+			// holder, a share-restrictive new open (one whose own ShareAccess
+			// would deny a co-located data holder — e.g. FILE_SHARE_NONE) is
+			// still a sharing-violation Handle-strip break, NOT a Default
+			// Write-flush break. Classifying it as Default picks the wrong break
+			// target (RWH→RH instead of RWH→RW) AND routes through the 5 s
+			// force-complete path, which tombstones the holder's lease; the
+			// holder's subsequent (late) LEASE_BREAK_ACK then fails
+			// STATUS_UNSUCCESSFUL (the #1322 replay flake).
+			//
+			// Routing it as a sharing violation uses the deferred-open park
+			// (WaitForShareConflictClear), which never force-completes, so a late
+			// ACK still succeeds (the same mechanism #749 introduced for the
+			// live-holder share-violation park).
+			//
+			// Why this does not regress the force-complete-reliant break tests
+			// (breaking3 / batch22 / timeout-disconnect): this branch is only
+			// reachable when checkShareModeConflict already returned false. Any
+			// holder with a LIVE OpenFile and a conflicting share mode — lease OR
+			// traditional oplock — is caught by that scan first and takes the
+			// initialConflict path above, so it never reaches here. (Note
+			// AnyHolderHasLeaseBits also matches traditional oplocks, which are
+			// stored with their RWH caching bits set; the gate is not lease-only.)
+			// The only holder that slips past the live-open scan is one whose
+			// OpenFile is already gone — the decorrelation window — and there the
+			// post-break recheckExistingFileGates re-evaluates the true share-mode
+			// outcome, with WaitForShareConflictClear's conflictPresent() seeing
+			// no live conflict and exiting immediately. The share-restrictiveness
+			// gate additionally keeps a share-permissive caching break (the
+			// genuine Default/Write-flush case) on the Default path.
+			reason = lock.BreakReasonSharingViolation
+			logger.Debug("CREATE: reclassified Default→SharingViolation (decorrelated handle-caching holder, #1331)",
+				"file", d.filename,
+				"desiredAccess", fmt.Sprintf("0x%x", d.req.DesiredAccess),
+				"shareAccess", fmt.Sprintf("0x%x", d.req.ShareAccess))
 		}
-	}
-
-	var waitExceptKey [16]byte
-	if d.excludeOwner != nil {
-		waitExceptKey = d.excludeOwner.ExcludeLeaseKey
 	}
 
 	// Snapshot the per-reason delay-mask intersection BEFORE dispatching.

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -2498,6 +2498,33 @@ func hasDeleteAccess(access uint32) bool {
 		m&types.MaximumAllowed != 0
 }
 
+// newOpenIsShareRestrictive reports whether an open, by virtue of its OWN
+// access + share masks alone, would deny a co-located data-bearing holder —
+// i.e. it requests a given data access but does NOT share that mode with
+// others. FILE_SHARE_NONE + any data access is the maximally restrictive case.
+//
+// Unlike checkShareModeConflict this needs no second party: it is the
+// holder-independent half of the share-mode test (the "new opener's share mask
+// denies others" direction). It is stable across the brief window where a
+// holder's OpenFile has been torn down but its lease record lingers, which is
+// exactly why the #1331 break-reason reclassification keys on it rather than on
+// the racy live-open scan. Stat-only opens impose no share constraint.
+func newOpenIsShareRestrictive(desiredAccess, shareAccess uint32) bool {
+	if isStatOnlyOpen(desiredAccess) {
+		return false
+	}
+	if hasReadAccess(desiredAccess) && shareAccess&smbShareRead == 0 {
+		return true
+	}
+	if hasWriteAccess(desiredAccess) && shareAccess&smbShareWrite == 0 {
+		return true
+	}
+	if hasDeleteAccess(desiredAccess) && shareAccess&smbShareDelete == 0 {
+		return true
+	}
+	return false
+}
+
 // getCachedShares returns the cached share list, rebuilding if invalidated.
 // Thread-safe via RWMutex (concurrent reads allowed, exclusive write for rebuild).
 func (h *Handler) getCachedShares() []rpc.ShareInfo1 {

--- a/internal/adapter/smb/handlers/handler_test.go
+++ b/internal/adapter/smb/handlers/handler_test.go
@@ -1064,3 +1064,51 @@ func TestAdsBasePath(t *testing.T) {
 		})
 	}
 }
+
+// TestNewOpenIsShareRestrictive pins the holder-independent discriminator that
+// the #1331 break-reason reclassification keys on. It must distinguish a
+// share-restrictive open (denies a co-located data holder → sharing-violation
+// Handle-strip break, deferred park, NO force-complete) from a share-permissive
+// caching break (the genuine Default/Write-flush case that breaking3 / batch22
+// rely on force-complete for).
+func TestNewOpenIsShareRestrictive(t *testing.T) {
+	const (
+		fileReadData    = uint32(0x00000001)
+		fileWriteData   = uint32(0x00000002)
+		deleteAccess    = uint32(0x00010000)
+		readControlOnly = uint32(0x00020000) // stat-only (READ_CONTROL)
+		fileShareRead   = uint32(0x01)
+		fileShareWrite  = uint32(0x02)
+		fileShareDelete = uint32(0x04)
+		fileShareAll    = fileShareRead | fileShareWrite | fileShareDelete
+	)
+	cases := []struct {
+		name          string
+		desiredAccess uint32
+		shareAccess   uint32
+		want          bool
+	}{
+		// The #1322/#1331 replay open: read with FILE_SHARE_NONE → restrictive.
+		{"read_shareNone", fileReadData, 0x0, true},
+		// breaking3-style caching break: read with full sharing → permissive.
+		{"read_shareAll", fileReadData, fileShareAll, false},
+		{"read_shareRead", fileReadData, fileShareRead, false},
+		// Write not shared even though read is → restrictive (write half).
+		{"readwrite_shareReadOnly", fileReadData | fileWriteData, fileShareRead, true},
+		{"write_shareNone", fileWriteData, 0x0, true},
+		{"write_shareWrite", fileWriteData, fileShareWrite, false},
+		// Delete not shared → restrictive.
+		{"delete_shareReadWrite", deleteAccess, fileShareRead | fileShareWrite, true},
+		{"delete_shareAll", deleteAccess, fileShareAll, false},
+		// Stat-only opens impose no share constraint regardless of share mask.
+		{"statOnly_shareNone", readControlOnly, 0x0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := newOpenIsShareRestrictive(tc.desiredAccess, tc.shareAccess); got != tc.want {
+				t.Errorf("newOpenIsShareRestrictive(0x%x, 0x%x) = %v, want %v",
+					tc.desiredAccess, tc.shareAccess, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Root-cause fix for the flaky `smb2.replay.dhv2-pending1n-vs-violation-lease-ack-sane` (#1322), tracked in #1331.

When a CREATE must break an existing holder's lease, `enforceShareModeBreak` classifies the break reason (`create_post_break.go`). That classification calls `checkShareModeConflict`, which scans **only live opens in `h.files`**. A Handle-caching lease *record* in the lock manager can briefly outlive its `OpenFile` during the holder's close / durable-reconnect teardown. In that window the live-open scan misses the holder, so the break is classified `BreakReasonDefault` instead of `BreakReasonSharingViolation`.

`reason=Default` is wrong here in two ways:

1. **Wrong break target** — `ComputeLeaseBreakTo` strips WRITE for Default (RWH→RH) but HANDLE for SharingViolation (RWH→RW).
2. **Wrong wait strategy** — Default routes through the 5 s force-complete path (`WaitForBreakCompletion` → `forceCompleteBreaks`), which **tombstones** the holder's lease. The holder's subsequent (late) `LEASE_BREAK_ACK` then fails `STATUS_UNSUCCESSFUL` — the #1322 flake.

A sharing violation instead routes to the deferred-open park (`WaitForShareConflictClear`), which **never force-completes**, so a late ACK still succeeds — the same mechanism #749 introduced for the live-holder share-violation park.

## Fix

- **`newOpenIsShareRestrictive(desiredAccess, shareAccess)`** (handler.go) — holder-independent: true when the new open requests a data access it does not share (e.g. `FILE_SHARE_NONE` + read). This signal is **stable across the decorrelation race** because it depends only on the new open's own masks, not on the racy live-open scan. Stat-only opens return false.
- In the classification's `default` branch: when `checkShareModeConflict` returns false **but** `newOpenIsShareRestrictive(...)` **and** `AnyHolderHasLeaseBits(…, LeaseStateHandle)` are true → reclassify to `BreakReasonSharingViolation`.
- Table test pinning the discriminator.

### Why it's safe / tightly scoped

- This branch is only reachable when `checkShareModeConflict` already returned false. Any holder with a **live `OpenFile`** and a conflicting share mode — lease *or* traditional oplock — is caught by that scan first (the `initialConflict` path), so it never reaches here. The only holder that slips past is one whose `OpenFile` is already gone (the decorrelation window), where the post-break recheck backstops and `WaitForShareConflictClear` exits immediately on no live conflict. So the force-complete-reliant tests (`breaking3` / `batch22` / `timeout-disconnect`) are untouched. (Note: `AnyHolderHasLeaseBits` also matches traditional oplocks — it is not lease-only — but that does not widen the effect, per the above.)
- Gated on share-restrictiveness — a share-permissive caching break (the genuine `Default`/Write-flush case) is untouched.
- Reclassifying to SharingViolation only changes the break target + wait strategy; the post-break `recheckExistingFileGates` re-evaluates the final client outcome regardless.

## How root cause was established

Instrumented the classification and ran the target test in a loop. In passing runs the break-reason and the lock-manager lease signal are correlated (both see the holder at the first CREATE, both clear by the replay). The flake is the rare timing where they **decorrelate**: an active Handle-bearing lease record with no live `OpenFile`, so the live-open scan reads no conflict while a break is still needed. The fix targets exactly that window.

## Validation

- Unit tests green (`handlers`, `lock`).
- Head-to-head vs `develop`: `smb2.lease` (42 pass), `smb2.oplock`, `smb2.durable-v2-open` (32 pass, 0 fail) — **zero new failures**. The three pre-existing failures (`lease.timeout`, `lease.v2_complex1`, `oplock.batch22b`) reproduce identically on `develop` and are unrelated.
- Target test passed 26/26 with the fix.

## Relationship to #1330

#1330 (widen the late-ACK-after-timeout branch to return OK) is **defense-in-depth** for the symptom. This PR removes the *cause* — the break never force-completes a still-ackable lease in the first place. The two are complementary and independent.

Refs #1331, #1322.
