### PR TITLE
fix(smb): resolve AD foreign-domain SIDs to names in LSARPC (LsarLookupSids2/3)

### DIFF
--- a/internal/adapter/smb/rpc/lsarpc.go
+++ b/internal/adapter/smb/rpc/lsarpc.go
@@ -37,8 +37,9 @@ const (
 	OpLsarClose       uint16 = 0  // LsarClose
 	OpLsarOpenPolicy  uint16 = 6  // LsarOpenPolicy (legacy; smbcacls/older clients use this)
 	OpLsarOpenPolicy2 uint16 = 44 // LsarOpenPolicy2
-	OpLsarLookupSids2 uint16 = 57 // LsarLookupSids2
-	OpLsarLookupSids3 uint16 = 76 // LsarLookupSids3
+	OpLsarLookupSids  uint16 = 15 // LsarLookupSids  (legacy; smbcacls/rpcclient lookupsids)
+	OpLsarLookupSids2 uint16 = 57 // LsarLookupSids2 (Windows Explorer)
+	OpLsarLookupSids3 uint16 = 76 // LsarLookupSids3 (rpcclient lookupsids3)
 )
 
 // DCE/RPC reject status codes [C706 §14.6 / MS-RPCE]. Returned in a FAULT PDU.
@@ -94,6 +95,17 @@ type ForeignSIDResolver interface {
 	// constants (SidTypeUser / SidTypeGroup). ok=false means no directory
 	// object matched the SID.
 	LookupSID(sidString string) (name, domain string, sidType uint16, ok bool)
+
+	// LookupUID resolves a POSIX UID to its directory account name and NetBIOS
+	// domain. It backs the OWNER-SID display path for an AD-only user: the
+	// machine-domain (algorithmic) SID on a file decodes to a UID that has no
+	// local DittoFS account, so the name is recovered from the directory by its
+	// uidNumber. ok=false means no directory object matched the UID.
+	LookupUID(uid uint32) (name, domain string, ok bool)
+
+	// LookupGID resolves a POSIX GID to its directory group name and NetBIOS
+	// domain. Mirrors LookupUID for the GROUP SID on a file.
+	LookupGID(gid uint32) (name, domain string, ok bool)
 }
 
 // =============================================================================
@@ -190,10 +202,8 @@ func (h *LSARPCHandler) HandleRequest(req *Request) []byte {
 		return h.handleClose(req)
 	case OpLsarOpenPolicy, OpLsarOpenPolicy2:
 		return h.handleOpenPolicy(req)
-	case OpLsarLookupSids2:
+	case OpLsarLookupSids, OpLsarLookupSids2, OpLsarLookupSids3:
 		return h.handleLookupSids(req)
-	case OpLsarLookupSids3:
-		return h.handleLookupSids(req) // Same logic, no policy handle needed
 	default:
 		return h.buildFault(req.Header.CallID, ncaSOpRngError)
 	}
@@ -250,18 +260,6 @@ type resolvedSID struct {
 	domainSID  *sid.SID
 }
 
-// resolveNameOrFallback attempts to resolve a name via the lookup function.
-// If the resolver is nil or the lookup misses, the fallback is returned.
-func resolveNameOrFallback(fallback string, resolver IdentityResolver, lookup func(IdentityResolver) (string, bool)) string {
-	if resolver == nil {
-		return fallback
-	}
-	if resolved, ok := lookup(resolver); ok {
-		return resolved
-	}
-	return fallback
-}
-
 // resolveSID resolves a single SID to a display name and type.
 func (h *LSARPCHandler) resolveSID(s *sid.SID) resolvedSID {
 	// Check well-known SIDs
@@ -288,30 +286,67 @@ func (h *LSARPCHandler) resolveSID(s *sid.SID) resolvedSID {
 		return resolvedSID{name: name, sidType: sidType}
 	}
 
-	// Check machine domain SIDs (user)
+	// Check machine domain SIDs (user). The local control-plane store is tried
+	// first (LookupUsernameByUID). When it misses — the common AD case where the
+	// file owner is an AD-only user (e.g. alice, uid 10001) with no local DittoFS
+	// account — fall back to the directory by uidNumber so Explorer still shows
+	// "DOMAIN\alice" instead of a synthetic "unix_user:10001". The owner SID on
+	// the wire is the machine-domain algorithmic SID, NOT alice's real AD SID, so
+	// this reverse-UID path (not the foreign-SID path) is what names it.
 	if uid, ok := h.sidMapper.UIDFromSID(s); ok {
-		name := resolveNameOrFallback(
-			fmt.Sprintf("unix_user:%d", uid),
-			h.resolver,
-			func(r IdentityResolver) (string, bool) { return r.LookupUsernameByUID(uid) },
-		)
+		if h.resolver != nil {
+			if name, found := h.resolver.LookupUsernameByUID(uid); found {
+				return resolvedSID{
+					name:       name,
+					sidType:    SidTypeUser,
+					domainName: h.machineDomainNameOrDefault(),
+					domainSID:  h.machineDomainSID(),
+				}
+			}
+		}
+		if h.foreignResolver != nil {
+			if name, domain, found := h.foreignResolver.LookupUID(uid); found {
+				return resolvedSID{
+					name:       name,
+					sidType:    SidTypeUser,
+					domainName: domain,
+					domainSID:  h.machineDomainSID(),
+				}
+			}
+		}
 		return resolvedSID{
-			name:       name,
+			name:       fmt.Sprintf("unix_user:%d", uid),
 			sidType:    SidTypeUser,
 			domainName: h.machineDomainNameOrDefault(),
 			domainSID:  h.machineDomainSID(),
 		}
 	}
 
-	// Check machine domain SIDs (group)
+	// Check machine domain SIDs (group). Same local-then-directory fallback as
+	// the user branch above, by gidNumber.
 	if gid, ok := h.sidMapper.GIDFromSID(s); ok {
-		name := resolveNameOrFallback(
-			fmt.Sprintf("unix_group:%d", gid),
-			h.resolver,
-			func(r IdentityResolver) (string, bool) { return r.LookupGroupNameByGID(gid) },
-		)
+		if h.resolver != nil {
+			if name, found := h.resolver.LookupGroupNameByGID(gid); found {
+				return resolvedSID{
+					name:       name,
+					sidType:    SidTypeGroup,
+					domainName: h.machineDomainNameOrDefault(),
+					domainSID:  h.machineDomainSID(),
+				}
+			}
+		}
+		if h.foreignResolver != nil {
+			if name, domain, found := h.foreignResolver.LookupGID(gid); found {
+				return resolvedSID{
+					name:       name,
+					sidType:    SidTypeGroup,
+					domainName: domain,
+					domainSID:  h.machineDomainSID(),
+				}
+			}
+		}
 		return resolvedSID{
-			name:       name,
+			name:       fmt.Sprintf("unix_group:%d", gid),
 			sidType:    SidTypeGroup,
 			domainName: h.machineDomainNameOrDefault(),
 			domainSID:  h.machineDomainSID(),
@@ -378,13 +413,24 @@ func (h *LSARPCHandler) machineDomainSID() *sid.SID {
 	return fullSID
 }
 
-// handleLookupSids handles LsarLookupSids2 (opnum 57) and LsarLookupSids3 (opnum 76).
-// Parses the SID array, resolves each SID, and returns a response with
-// referenced domains and translated names.
+// handleLookupSids handles LsarLookupSids (opnum 15), LsarLookupSids2 (opnum
+// 57), and LsarLookupSids3 (opnum 76). It parses the SID array, resolves each
+// SID, and returns a response with referenced domains and translated names.
+//
+// Per MS-LSAT the response translated-names structure is per-opnum:
+//   - 15 (LsarLookupSids): LSAPR_TRANSLATED_NAMES — entries are
+//     LSAPR_TRANSLATED_NAME with NO Flags field.
+//   - 57/76 (LookupSids2/3): LSAPR_TRANSLATED_NAMES_EX — entries are
+//     LSAPR_TRANSLATED_NAME_EX with a trailing Flags (ULONG). The 57 and 76
+//     responses are byte-identical (they differ only in request-side params),
+//     so both share the EX builder.
+//
+// Emitting the EX layout for opnum 15 (or vice-versa) shifts every field after
+// the first entry by 4 bytes, which a real client parses as an out-of-bounds
+// array — the NT_STATUS_ARRAY_BOUNDS_EXCEEDED seen from rpcclient.
 func (h *LSARPCHandler) handleLookupSids(req *Request) []byte {
-	// Parse SIDs from the request stub data.
-	// The request format varies between opnum 57 (has policy handle) and 76 (no handle).
-	// For simplicity, we extract SIDs from the binary data.
+	// Parse SIDs from the request stub data. The leading bytes differ per opnum
+	// (policy handle for 15/57, none for 76) — parseSIDsFromRequest accounts for it.
 	sids := h.parseSIDsFromRequest(req.StubData, req.OpNum)
 
 	logger.Debug("LSA LookupSids", "numSids", len(sids))
@@ -414,8 +460,10 @@ func (h *LSARPCHandler) handleLookupSids(req *Request) []byte {
 		}
 	}
 
-	// Build response stub data
-	stubData := h.buildLookupSidsResponse(resolved, domains, domainMap, allMapped)
+	// Build response stub data. Opnum 15 uses the non-EX translated-name layout
+	// (no Flags); 57/76 use the EX layout.
+	withFlags := req.OpNum != OpLsarLookupSids
+	stubData := h.buildLookupSidsResponse(resolved, domains, domainMap, allMapped, withFlags)
 
 	resp := &Response{
 		AllocHint:   uint32(len(stubData)),
@@ -432,10 +480,12 @@ func (h *LSARPCHandler) handleLookupSids(req *Request) []byte {
 func (h *LSARPCHandler) parseSIDsFromRequest(data []byte, opnum uint16) []*sid.SID {
 	var sids []*sid.SID
 
-	// For opnum 57 (LookupSids2): skip policy handle (20 bytes) then SID array
-	// For opnum 76 (LookupSids3): SID array directly
+	// LsarLookupSids (15) and LsarLookupSids2 (57) both lead with a 20-byte
+	// LSAPR_HANDLE PolicyHandle before the SID_ENUM_BUFFER. LsarLookupSids3 (76)
+	// takes an RPC binding handle (handle_t) instead, which is never marshaled,
+	// so its SID_ENUM_BUFFER starts at offset 0.
 	offset := 0
-	if opnum == OpLsarLookupSids2 {
+	if opnum == OpLsarLookupSids || opnum == OpLsarLookupSids2 {
 		offset = 20 // Skip policy handle
 	}
 
@@ -506,12 +556,19 @@ type domainEntry struct {
 	sid  *sid.SID
 }
 
-// buildLookupSidsResponse builds the NDR-encoded response for LookupSids2.
+// buildLookupSidsResponse builds the NDR-encoded LookupSids response.
+//
+// The referenced-domain list, mapped count, and status are identical across
+// all three opnums. withFlags selects the translated-name entry layout: true
+// emits LSAPR_TRANSLATED_NAME_EX (Use + Name + DomainIndex + Flags) for
+// LookupSids2/3 (opnum 57/76); false emits LSAPR_TRANSLATED_NAME (no Flags)
+// for the legacy LookupSids (opnum 15).
 func (h *LSARPCHandler) buildLookupSidsResponse(
 	resolved []resolvedSID,
 	domains []domainEntry,
 	domainMap map[string]int,
 	allMapped bool,
+	withFlags bool,
 ) []byte {
 	var buf bytes.Buffer
 
@@ -599,8 +656,10 @@ func (h *LSARPCHandler) buildLookupSidsResponse(
 				}
 			}
 			_ = binary.Write(&buf, binary.LittleEndian, domIdx)
-			// Flags (uint32)
-			appendUint32Buf(&buf, 0)
+			// Flags (uint32) — present only in the _EX layout (opnum 57/76).
+			if withFlags {
+				appendUint32Buf(&buf, 0)
+			}
 		}
 
 		// Deferred string data for each name

--- a/internal/adapter/smb/rpc/lsarpc.go
+++ b/internal/adapter/smb/rpc/lsarpc.go
@@ -77,6 +77,25 @@ type IdentityResolver interface {
 	LookupGroupNameByGID(gid uint32) (string, bool)
 }
 
+// ForeignSIDResolver resolves a FOREIGN (AD/LDAP) domain SID — one that is
+// neither well-known nor an algorithmic machine-domain SID — to its account
+// name, NetBIOS domain, and SID type. It backs the directory side of the
+// LSARPC SID-to-name path so Windows Explorer's Security tab shows real AD
+// account names (e.g. CONTOSO\alice) instead of raw SIDs.
+//
+// Implementations consult the configured identity directory (the LDAP/AD
+// provider via the centralized identity.Resolver) and SHOULD cache. A miss
+// (ok=false) is expected and never an error: the SID stays unmapped and the
+// batch returns STATUS_SOME_NOT_MAPPED. When nil, the handler skips the
+// directory lookup entirely and foreign SIDs render as raw strings.
+type ForeignSIDResolver interface {
+	// LookupSID resolves a canonical SID string ("S-1-5-21-...") to its
+	// account name and NetBIOS domain. sidType is one of the SidType*
+	// constants (SidTypeUser / SidTypeGroup). ok=false means no directory
+	// object matched the SID.
+	LookupSID(sidString string) (name, domain string, sidType uint16, ok bool)
+}
+
 // =============================================================================
 // LSA Handler
 // =============================================================================
@@ -85,12 +104,55 @@ type IdentityResolver interface {
 type LSARPCHandler struct {
 	sidMapper *sid.SIDMapper
 	resolver  IdentityResolver
+
+	// machineDomainName is the NetBIOS name advertised for algorithmic
+	// machine-domain SIDs (the local user/group RIDs). Defaults to "DITTOFS"
+	// when empty so existing standalone behavior is preserved.
+	machineDomainName string
+
+	// foreignResolver resolves AD/LDAP domain SIDs that are neither well-known
+	// nor machine-domain. Optional; nil leaves foreign SIDs unmapped (raw).
+	foreignResolver ForeignSIDResolver
 }
+
+// defaultMachineDomainName is the NetBIOS domain reported for machine-domain
+// (algorithmic local UID/GID) SIDs when no explicit name is configured.
+const defaultMachineDomainName = "DITTOFS"
 
 // NewLSARPCHandler creates a new LSA RPC handler with the given SID mapper
 // and optional identity resolver for real name resolution.
 func NewLSARPCHandler(sidMapper *sid.SIDMapper, resolver IdentityResolver) *LSARPCHandler {
-	return &LSARPCHandler{sidMapper: sidMapper, resolver: resolver}
+	return &LSARPCHandler{
+		sidMapper:         sidMapper,
+		resolver:          resolver,
+		machineDomainName: defaultMachineDomainName,
+	}
+}
+
+// SetMachineDomainName overrides the NetBIOS domain name reported for
+// machine-domain SIDs. An empty value resets it to the default ("DITTOFS").
+func (h *LSARPCHandler) SetMachineDomainName(name string) {
+	if name == "" {
+		h.machineDomainName = defaultMachineDomainName
+		return
+	}
+	h.machineDomainName = name
+}
+
+// SetForeignSIDResolver wires the directory-backed resolver used for AD/LDAP
+// domain SIDs. Safe to leave unset; foreign SIDs then render as raw strings.
+func (h *LSARPCHandler) SetForeignSIDResolver(r ForeignSIDResolver) {
+	h.foreignResolver = r
+}
+
+// machineDomainNameOrDefault returns the configured machine NetBIOS name,
+// falling back to the default for a zero-valued handler (e.g. struct literals
+// in tests that bypass NewLSARPCHandler).
+func (h *LSARPCHandler) machineDomainNameOrDefault() string {
+	if h.machineDomainName == "" {
+		return defaultMachineDomainName
+	}
+	return h.machineDomainName
 }
 
 // HandleBind processes a BIND request and returns a BIND_ACK for the LSA interface.
@@ -236,7 +298,7 @@ func (h *LSARPCHandler) resolveSID(s *sid.SID) resolvedSID {
 		return resolvedSID{
 			name:       name,
 			sidType:    SidTypeUser,
-			domainName: "DITTOFS",
+			domainName: h.machineDomainNameOrDefault(),
 			domainSID:  h.machineDomainSID(),
 		}
 	}
@@ -251,8 +313,28 @@ func (h *LSARPCHandler) resolveSID(s *sid.SID) resolvedSID {
 		return resolvedSID{
 			name:       name,
 			sidType:    SidTypeGroup,
-			domainName: "DITTOFS",
+			domainName: h.machineDomainNameOrDefault(),
 			domainSID:  h.machineDomainSID(),
+		}
+	}
+
+	// Foreign (AD/LDAP) domain SID: not well-known, not machine-domain. Consult
+	// the directory-backed resolver. A hit yields the real AD account name + its
+	// NetBIOS domain; a miss falls through to the unknown branch below so the SID
+	// stays unmapped (STATUS_SOME_NOT_MAPPED) — never a fault.
+	if h.foreignResolver != nil {
+		sidStr := sid.FormatSID(s)
+		if name, domain, sidType, ok := h.foreignResolver.LookupSID(sidStr); ok {
+			if sidType != SidTypeUser && sidType != SidTypeGroup && sidType != SidTypeDomain &&
+				sidType != SidTypeAlias && sidType != SidTypeWellKnownGroup {
+				sidType = SidTypeUser
+			}
+			return resolvedSID{
+				name:       name,
+				sidType:    sidType,
+				domainName: domain,
+				domainSID:  foreignDomainSID(s),
+			}
 		}
 	}
 
@@ -260,6 +342,24 @@ func (h *LSARPCHandler) resolveSID(s *sid.SID) resolvedSID {
 	return resolvedSID{
 		name:    sid.FormatSID(s),
 		sidType: SidTypeUnknown,
+	}
+}
+
+// foreignDomainSID derives the domain SID (the account SID with its trailing
+// RID stripped) for a foreign account SID. For a standard 5-sub-authority
+// S-1-5-21-{a}-{b}-{c}-{RID} SID this yields S-1-5-21-{a}-{b}-{c}. SIDs without
+// a strippable RID are returned unchanged so the referenced-domain entry stays
+// well-formed.
+func foreignDomainSID(s *sid.SID) *sid.SID {
+	if s == nil || s.SubAuthorityCount < 1 {
+		return s
+	}
+	n := int(s.SubAuthorityCount) - 1
+	return &sid.SID{
+		Revision:            s.Revision,
+		SubAuthorityCount:   byte(n),
+		IdentifierAuthority: s.IdentifierAuthority,
+		SubAuthorities:      append([]uint32(nil), s.SubAuthorities[:n]...),
 	}
 }
 

--- a/internal/adapter/smb/rpc/lsarpc.go
+++ b/internal/adapter/smb/rpc/lsarpc.go
@@ -596,10 +596,13 @@ func (h *LSARPCHandler) buildLookupSidsResponse(
 		// Fixed-size domain entries: name (NDR string header = 12 bytes) + SID pointer (4 bytes) = 16 bytes each
 		refID := uint32(0x00020008)
 		for _, d := range domains {
+			// RPC_UNICODE_STRING: Length and MaximumLength are both the byte
+			// count of the name with NO terminator (2*char_count). The referenced
+			// buffer (writeNDRUnicodeString) is likewise un-terminated, so its
+			// ActualCount == Length/2 and Samba's array-length check holds.
 			nameUTF16Len := uint16(len(encodeUTF16LE(d.name)))
-			byteLen := nameUTF16Len + 2                               // include null terminator
-			_ = binary.Write(&buf, binary.LittleEndian, nameUTF16Len) // Length (excluding null terminator)
-			_ = binary.Write(&buf, binary.LittleEndian, byteLen)      // MaximumLength (including null terminator)
+			_ = binary.Write(&buf, binary.LittleEndian, nameUTF16Len) // Length (bytes, no NUL)
+			_ = binary.Write(&buf, binary.LittleEndian, nameUTF16Len) // MaximumLength (bytes, no NUL)
 			appendUint32Buf(&buf, refID)                              // pointer to string data
 			refID += 4
 			appendUint32Buf(&buf, refID) // pointer to SID data
@@ -642,10 +645,11 @@ func (h *LSARPCHandler) buildLookupSidsResponse(
 		for _, r := range resolved {
 			_ = binary.Write(&buf, binary.LittleEndian, r.sidType)
 			_ = binary.Write(&buf, binary.LittleEndian, uint16(0))
+			// RPC_UNICODE_STRING: Length == MaximumLength == 2*char_count, no NUL
+			// (matches the un-terminated referenced buffer below).
 			nameUTF16Len := uint16(len(encodeUTF16LE(r.name)))
-			byteLen := nameUTF16Len + 2
-			_ = binary.Write(&buf, binary.LittleEndian, nameUTF16Len) // Length (excluding null terminator)
-			_ = binary.Write(&buf, binary.LittleEndian, byteLen)      // MaximumLength (including null terminator)
+			_ = binary.Write(&buf, binary.LittleEndian, nameUTF16Len) // Length (bytes, no NUL)
+			_ = binary.Write(&buf, binary.LittleEndian, nameUTF16Len) // MaximumLength (bytes, no NUL)
 			appendUint32Buf(&buf, nameRefID)                          // unique pointer
 			nameRefID += 4
 			// Domain index (int32)
@@ -687,10 +691,20 @@ func (h *LSARPCHandler) buildLookupSidsResponse(
 	return buf.Bytes()
 }
 
-// writeNDRUnicodeString writes an NDR-conformant+varying unicode string.
+// writeNDRUnicodeString writes the UTF-16 buffer referenced by an
+// RPC_UNICODE_STRING as an NDR conformant+varying array.
+//
+// Per [MS-LSAT], the LSAPR_TRANSLATED_NAME[_EX].Name (and the referenced-domain
+// Name) buffers returned by the server are NOT NUL-terminated: MaxCount, Offset,
+// and ActualCount are all in CHARACTERS and equal the exact code-unit count
+// (2*char_count == the RPC_UNICODE_STRING Length in bytes). Appending a NUL — or
+// setting MaxCount/ActualCount to char_count+1 — makes the conformant array one
+// element longer than Length implies, which Samba rejects in
+// ndr_check_steal_array_length ("Bad array length - got N expected N-1") and
+// rpcclient surfaces as NT_STATUS_ARRAY_BOUNDS_EXCEEDED.
 func writeNDRUnicodeString(buf *bytes.Buffer, s string) {
 	utf16 := encodeUTF16LE(s)
-	charCount := uint32(len(utf16)/2 + 1) // UTF-16 code units + null terminator
+	charCount := uint32(len(utf16) / 2) // UTF-16 code units, NO null terminator
 
 	// Conformant: MaxCount
 	appendUint32Buf(buf, charCount)
@@ -699,10 +713,8 @@ func writeNDRUnicodeString(buf *bytes.Buffer, s string) {
 	// Varying: ActualCount
 	appendUint32Buf(buf, charCount)
 
-	// UTF-16LE string data
+	// UTF-16LE string data (no trailing NUL — these are counted strings).
 	buf.Write(utf16)
-	// Null terminator (2 bytes)
-	buf.Write([]byte{0, 0})
 
 	// Pad to 4-byte boundary
 	for buf.Len()%4 != 0 {

--- a/internal/adapter/smb/rpc/lsarpc_test.go
+++ b/internal/adapter/smb/rpc/lsarpc_test.go
@@ -674,9 +674,13 @@ func TestStoreIdentityResolver_NilFuncs(t *testing.T) {
 // Foreign (AD/LDAP) SID resolution
 // =============================================================================
 
-// mockForeignResolver is a test ForeignSIDResolver keyed by canonical SID string.
+// mockForeignResolver is a test ForeignSIDResolver. SID hits are keyed by
+// canonical SID string; reverse uid/gid hits (the AD-only owner path) are keyed
+// by numeric id.
 type mockForeignResolver struct {
-	hits map[string]foreignHit
+	hits    map[string]foreignHit
+	uidHits map[uint32]reverseHit
+	gidHits map[uint32]reverseHit
 }
 
 type foreignHit struct {
@@ -685,12 +689,33 @@ type foreignHit struct {
 	sidType uint16
 }
 
+type reverseHit struct {
+	name   string
+	domain string
+}
+
 func (m *mockForeignResolver) LookupSID(sidString string) (string, string, uint16, bool) {
 	h, ok := m.hits[sidString]
 	if !ok {
 		return "", "", 0, false
 	}
 	return h.name, h.domain, h.sidType, true
+}
+
+func (m *mockForeignResolver) LookupUID(uid uint32) (string, string, bool) {
+	h, ok := m.uidHits[uid]
+	if !ok {
+		return "", "", false
+	}
+	return h.name, h.domain, true
+}
+
+func (m *mockForeignResolver) LookupGID(gid uint32) (string, string, bool) {
+	h, ok := m.gidHits[gid]
+	if !ok {
+		return "", "", false
+	}
+	return h.name, h.domain, true
 }
 
 func TestResolveSID_ForeignAD_Hit(t *testing.T) {
@@ -784,8 +809,9 @@ type translatedName struct {
 
 // parseLookupSidsResponse decodes the stub data produced by
 // buildLookupSidsResponse. It mirrors that exact layout — it is a test-only
-// reader, not a general NDR parser.
-func parseLookupSidsResponse(t *testing.T, response []byte) lookupSidsResult {
+// reader, not a general NDR parser. withFlags selects the EX (opnum 57/76)
+// vs non-EX (opnum 15) translated-name entry layout.
+func parseLookupSidsResponse(t *testing.T, response []byte, withFlags bool) lookupSidsResult {
 	t.Helper()
 	if len(response) <= 24 {
 		t.Fatalf("response too short: %d bytes", len(response))
@@ -816,10 +842,10 @@ func parseLookupSidsResponse(t *testing.T, response []byte) lookupSidsResult {
 	if domCount > 0 {
 		_ = u32() // conformant max count
 		for range domCount {
-			length := u16()      // Length (excl null), in bytes
-			_ = u16()            // MaximumLength
-			_ = u32()            // string pointer
-			_ = u32()            // SID pointer
+			length := u16() // Length (excl null), in bytes
+			_ = u16()       // MaximumLength
+			_ = u32()       // string pointer
+			_ = u32()       // SID pointer
 			domFixeds = append(domFixeds, domFixed{nameUTF16Bytes: length})
 		}
 		// Deferred domain name strings.
@@ -846,7 +872,9 @@ func parseLookupSidsResponse(t *testing.T, response []byte) lookupSidsResult {
 			_ = u16() // MaximumLength
 			_ = u32() // name pointer
 			domIdx := int32(u32())
-			_ = u32() // flags
+			if withFlags {
+				_ = u32() // flags (EX layout only)
+			}
 			res.names = append(res.names, translatedName{sidType: st, domainIdx: domIdx})
 		}
 		// Deferred name strings.
@@ -949,7 +977,7 @@ func TestLookupSids_MixedBatch_MultiDomain(t *testing.T) {
 		t.Fatal("got fault for a partially-unmapped batch; must be a normal response")
 	}
 
-	res := parseLookupSidsResponse(t, response)
+	res := parseLookupSidsResponse(t, response, true) // opnum 57 → EX layout
 
 	if res.status != statusSomeNotMapped {
 		t.Errorf("status = 0x%08x, want STATUS_SOME_NOT_MAPPED (0x%08x)", res.status, statusSomeNotMapped)
@@ -1023,10 +1051,10 @@ func TestBuildLookupSidsResponse_TwoDomains(t *testing.T) {
 		}
 	}
 
-	stub := h.buildLookupSidsResponse(resolved, domains, domainMap, true)
+	stub := h.buildLookupSidsResponse(resolved, domains, domainMap, true, true)
 	// Prefix a fake 24-byte RPC header so the shared parser offset math holds.
 	response := append(make([]byte, 24), stub...)
-	res := parseLookupSidsResponse(t, response)
+	res := parseLookupSidsResponse(t, response, true)
 
 	if len(res.domains) != 2 {
 		t.Fatalf("domains = %v, want exactly 2 (deduped)", res.domains)
@@ -1043,5 +1071,310 @@ func TestBuildLookupSidsResponse_TwoDomains(t *testing.T) {
 	}
 	if res.status != statusSuccess {
 		t.Errorf("status = 0x%08x, want success", res.status)
+	}
+}
+
+// =============================================================================
+// Machine-domain SID → directory reverse uid/gid (GAP 1: AD-only owner)
+// =============================================================================
+
+// TestResolveSID_MachineDomainUser_DirectoryFallback covers the headline #1343
+// case: the file OWNER SID is the machine-domain (algorithmic) SID for an
+// AD-only user (alice, uid 10001), so it decodes via UIDFromSID. The local
+// control-plane resolver has no such user, so resolution must fall back to the
+// directory by uidNumber and present the real AD name + domain.
+func TestResolveSID_MachineDomainUser_DirectoryFallback(t *testing.T) {
+	mapper := sid.NewSIDMapper(0, 0, 0)
+	// Local resolver: deliberately empty for uid 10001 (no local account).
+	local := &mockResolver{users: map[uint32]string{}}
+	foreign := &mockForeignResolver{
+		uidHits: map[uint32]reverseHit{10001: {name: "alice", domain: "DITTOFS"}},
+	}
+	h := NewLSARPCHandler(mapper, local)
+	h.SetForeignSIDResolver(foreign)
+	h.SetMachineDomainName("FILER01")
+
+	ownerSID := mapper.UserSID(10001) // S-1-5-21-0-0-0-(10001*2+1000)
+	r := h.resolveSID(ownerSID)
+
+	if r.name != "alice" {
+		t.Errorf("name = %q, want alice (directory reverse-uid)", r.name)
+	}
+	if r.sidType != SidTypeUser {
+		t.Errorf("sidType = %d, want %d (User)", r.sidType, SidTypeUser)
+	}
+	// The directory-resolved domain (from the reverse lookup) takes precedence
+	// over the machine NetBIOS name for an AD-only account.
+	if r.domainName != "DITTOFS" {
+		t.Errorf("domainName = %q, want DITTOFS (from directory)", r.domainName)
+	}
+	if r.domainSID == nil {
+		t.Error("domainSID is nil; want the machine domain SID")
+	}
+}
+
+// TestResolveSID_MachineDomainUser_LocalWins ensures the local store still wins
+// when the user DOES have a local account — the directory fallback only fires
+// on a local miss, and the machine NetBIOS name is used for local accounts.
+func TestResolveSID_MachineDomainUser_LocalWins(t *testing.T) {
+	mapper := sid.NewSIDMapper(0, 0, 0)
+	local := &mockResolver{users: map[uint32]string{42: "localbob"}}
+	foreign := &mockForeignResolver{
+		uidHits: map[uint32]reverseHit{42: {name: "WRONG", domain: "WRONGDOM"}},
+	}
+	h := NewLSARPCHandler(mapper, local)
+	h.SetForeignSIDResolver(foreign)
+	h.SetMachineDomainName("FILER01")
+
+	r := h.resolveSID(mapper.UserSID(42))
+	if r.name != "localbob" {
+		t.Errorf("name = %q, want localbob (local store wins)", r.name)
+	}
+	if r.domainName != "FILER01" {
+		t.Errorf("domainName = %q, want FILER01 (machine domain for local account)", r.domainName)
+	}
+}
+
+// TestResolveSID_MachineDomainGroup_DirectoryFallback is the group analog: a
+// GROUP SID for an AD-only group falls back to the directory by gidNumber.
+func TestResolveSID_MachineDomainGroup_DirectoryFallback(t *testing.T) {
+	mapper := sid.NewSIDMapper(0, 0, 0)
+	local := &mockResolver{groups: map[uint32]string{}}
+	foreign := &mockForeignResolver{
+		gidHits: map[uint32]reverseHit{10000: {name: "domain users", domain: "DITTOFS"}},
+	}
+	h := NewLSARPCHandler(mapper, local)
+	h.SetForeignSIDResolver(foreign)
+
+	r := h.resolveSID(mapper.GroupSID(10000))
+	if r.name != "domain users" {
+		t.Errorf("name = %q, want \"domain users\"", r.name)
+	}
+	if r.sidType != SidTypeGroup {
+		t.Errorf("sidType = %d, want %d (Group)", r.sidType, SidTypeGroup)
+	}
+	if r.domainName != "DITTOFS" {
+		t.Errorf("domainName = %q, want DITTOFS", r.domainName)
+	}
+}
+
+// TestResolveSID_MachineDomainUser_BothMiss confirms that when neither the local
+// store nor the directory knows the uid, the SID still resolves (never faults) —
+// it shows the generic unix_user:N name under the machine domain.
+func TestResolveSID_MachineDomainUser_BothMiss(t *testing.T) {
+	mapper := sid.NewSIDMapper(0, 0, 0)
+	h := NewLSARPCHandler(mapper, &mockResolver{users: map[uint32]string{}})
+	h.SetForeignSIDResolver(&mockForeignResolver{uidHits: map[uint32]reverseHit{}})
+
+	r := h.resolveSID(mapper.UserSID(7))
+	if r.name != "unix_user:7" {
+		t.Errorf("name = %q, want unix_user:7", r.name)
+	}
+	if r.sidType != SidTypeUser {
+		t.Errorf("sidType = %d, want %d (User)", r.sidType, SidTypeUser)
+	}
+}
+
+// =============================================================================
+// Opnum 15 (LsarLookupSids) and opnum 76 (LsarLookupSids3) framing
+// =============================================================================
+
+// buildLookupSidsStubData builds a LookupSids request stub for the given opnum.
+// Opnum 15/57 lead with a 20-byte policy handle; opnum 76 does not.
+func buildLookupSidsStubData(opnum uint16, sids []*sid.SID) []byte {
+	var buf bytes.Buffer
+	if opnum == OpLsarLookupSids || opnum == OpLsarLookupSids2 {
+		policyHandle := make([]byte, 20)
+		policyHandle[0] = 0x01
+		buf.Write(policyHandle)
+	}
+	appendUint32Buf(&buf, uint32(len(sids))) // Count
+	appendUint32Buf(&buf, 0x00020000)        // pointer to array
+	appendUint32Buf(&buf, uint32(len(sids))) // conformant max count
+	for range sids {
+		appendUint32Buf(&buf, 0x00020004) // SID pointer
+	}
+	for _, s := range sids {
+		appendUint32Buf(&buf, uint32(s.SubAuthorityCount))
+		sid.EncodeSID(&buf, s)
+	}
+	return buf.Bytes()
+}
+
+// TestLSARPC_LookupSids_Opnum15_RoundTrip verifies opnum 15 dispatches (no
+// fault, no PROCNUM_OUT_OF_RANGE) and emits the NON-EX translated-name layout.
+// Decoding with withFlags=false must yield well-formed, in-range fields; the
+// well-known SID maps and the unknown SID does not.
+func TestLSARPC_LookupSids_Opnum15_RoundTrip(t *testing.T) {
+	mapper := sid.NewSIDMapper(0, 0, 0)
+	h := NewLSARPCHandler(mapper, &mockResolver{users: map[uint32]string{5: "alice"}})
+
+	sids := []*sid.SID{
+		sid.WellKnownAdministrators,   // BUILTIN\Administrators
+		mapper.UserSID(5),             // DITTOFS\alice
+		sid.ParseSIDMust("S-1-99-42"), // unknown
+	}
+	stub := buildLookupSidsStubData(OpLsarLookupSids, sids)
+	reqData := buildTestRequest(50, OpLsarLookupSids, stub)
+	req, err := ParseRequest(reqData)
+	if err != nil {
+		t.Fatalf("ParseRequest: %v", err)
+	}
+
+	response := h.HandleRequest(req)
+	hdr, err := ParseHeader(response)
+	if err != nil {
+		t.Fatalf("ParseHeader: %v", err)
+	}
+	if hdr.PacketType == PDUFault {
+		t.Fatal("opnum 15 faulted; smbcacls/rpcclient lookupsids must get a response")
+	}
+
+	res := parseLookupSidsResponse(t, response, false) // opnum 15 → non-EX layout
+	if len(res.names) != 3 {
+		t.Fatalf("translated names = %d, want 3", len(res.names))
+	}
+	wantTypes := []uint16{SidTypeAlias, SidTypeUser, SidTypeUnknown}
+	for i, wt := range wantTypes {
+		if res.names[i].sidType != wt {
+			t.Errorf("name[%d].sidType = %d, want %d", i, res.names[i].sidType, wt)
+		}
+	}
+	if res.status != statusSomeNotMapped {
+		t.Errorf("status = 0x%08x, want STATUS_SOME_NOT_MAPPED", res.status)
+	}
+	if res.mappedCount != 2 {
+		t.Errorf("mappedCount = %d, want 2", res.mappedCount)
+	}
+	// Every mapped domain index must be in range — the proof the non-EX layout
+	// is internally consistent (a stray Flags word would shift these).
+	for i, n := range res.names {
+		if n.sidType == SidTypeUnknown {
+			if n.domainIdx != -1 {
+				t.Errorf("unmapped name[%d] domainIdx = %d, want -1", i, n.domainIdx)
+			}
+			continue
+		}
+		if n.domainIdx < 0 || int(n.domainIdx) >= len(res.domains) {
+			t.Errorf("name[%d] domainIdx %d out of range (%d domains)", i, n.domainIdx, len(res.domains))
+		}
+	}
+}
+
+// TestLSARPC_LookupSids3_Opnum76_RoundTrip exercises opnum 76 (no policy handle
+// on the wire). It must parse the SID array from offset 0 and emit the EX
+// layout. A wrong leading-offset or wrong entry layout is exactly what produced
+// NT_STATUS_ARRAY_BOUNDS_EXCEEDED (#1342).
+func TestLSARPC_LookupSids3_Opnum76_RoundTrip(t *testing.T) {
+	mapper := sid.NewSIDMapper(0, 0, 0)
+	h := NewLSARPCHandler(mapper, &mockResolver{users: map[uint32]string{9: "bob"}})
+
+	sids := []*sid.SID{
+		mapper.UserSID(9),
+		sid.WellKnownEveryone,
+	}
+	stub := buildLookupSidsStubData(OpLsarLookupSids3, sids)
+	reqData := buildTestRequest(76, OpLsarLookupSids3, stub)
+	req, err := ParseRequest(reqData)
+	if err != nil {
+		t.Fatalf("ParseRequest: %v", err)
+	}
+
+	response := h.HandleRequest(req)
+	hdr, err := ParseHeader(response)
+	if err != nil {
+		t.Fatalf("ParseHeader: %v", err)
+	}
+	if hdr.PacketType == PDUFault {
+		t.Fatal("opnum 76 faulted")
+	}
+
+	res := parseLookupSidsResponse(t, response, true) // opnum 76 → EX layout
+	if len(res.names) != 2 {
+		t.Fatalf("translated names = %d, want 2 (offset-0 SID parse)", len(res.names))
+	}
+	if res.names[0].sidType != SidTypeUser {
+		t.Errorf("name[0].sidType = %d, want %d (User)", res.names[0].sidType, SidTypeUser)
+	}
+	if res.names[1].sidType != SidTypeWellKnownGroup {
+		t.Errorf("name[1].sidType = %d, want %d (WellKnownGroup)", res.names[1].sidType, SidTypeWellKnownGroup)
+	}
+	if res.status != statusSuccess {
+		t.Errorf("status = 0x%08x, want success (all mapped)", res.status)
+	}
+	if res.mappedCount != 2 {
+		t.Errorf("mappedCount = %d, want 2", res.mappedCount)
+	}
+}
+
+// TestLSARPC_LookupSids_PerOpnumLayout_ByteDiff proves the per-opnum layout
+// difference is real: for the SAME single mapped SID, the opnum-15 (non-EX)
+// stub is exactly 4 bytes shorter than the opnum-57 (EX) stub — the missing
+// Flags word. This is the framing fix for #1342.
+func TestLSARPC_LookupSids_PerOpnumLayout_ByteDiff(t *testing.T) {
+	mapper := sid.NewSIDMapper(0, 0, 0)
+	h := NewLSARPCHandler(mapper, &mockResolver{users: map[uint32]string{3: "carol"}})
+
+	resp15 := h.HandleRequest(mustParse(t, buildTestRequest(1, OpLsarLookupSids,
+		buildLookupSidsStubData(OpLsarLookupSids, []*sid.SID{mapper.UserSID(3)}))))
+	resp57 := h.HandleRequest(mustParse(t, buildTestRequest(2, OpLsarLookupSids2,
+		buildLookupSidsStubData(OpLsarLookupSids2, []*sid.SID{mapper.UserSID(3)}))))
+
+	if len(resp15) == 0 || len(resp57) == 0 {
+		t.Fatal("empty response")
+	}
+	diff := len(resp57) - len(resp15)
+	if diff != 4 {
+		t.Errorf("opnum57 stub - opnum15 stub = %d bytes, want 4 (one Flags ULONG per mapped name)", diff)
+	}
+}
+
+func mustParse(t *testing.T, reqData []byte) *Request {
+	t.Helper()
+	req, err := ParseRequest(reqData)
+	if err != nil {
+		t.Fatalf("ParseRequest: %v", err)
+	}
+	return req
+}
+
+// TestLSARPC_LookupSids_MixedBatch_PerOpnum runs the same mapped/unmapped batch
+// through all three opnums and asserts STATUS_SOME_NOT_MAPPED + the mapped count
+// hold regardless of layout.
+func TestLSARPC_LookupSids_MixedBatch_PerOpnum(t *testing.T) {
+	mapper := sid.NewSIDMapper(0, 0, 0)
+	h := NewLSARPCHandler(mapper, &mockResolver{users: map[uint32]string{2: "dave"}})
+
+	sids := []*sid.SID{
+		mapper.UserSID(2),            // mapped
+		sid.ParseSIDMust("S-1-99-7"), // unmapped
+		sid.WellKnownEveryone,        // mapped
+	}
+
+	cases := []struct {
+		opnum     uint16
+		withFlags bool
+	}{
+		{OpLsarLookupSids, false},
+		{OpLsarLookupSids2, true},
+		{OpLsarLookupSids3, true},
+	}
+	for _, c := range cases {
+		stub := buildLookupSidsStubData(c.opnum, sids)
+		req := mustParse(t, buildTestRequest(100, c.opnum, stub))
+		response := h.HandleRequest(req)
+		if hdr, _ := ParseHeader(response); hdr.PacketType == PDUFault {
+			t.Fatalf("opnum %d faulted on mixed batch", c.opnum)
+		}
+		res := parseLookupSidsResponse(t, response, c.withFlags)
+		if len(res.names) != 3 {
+			t.Errorf("opnum %d: names = %d, want 3", c.opnum, len(res.names))
+		}
+		if res.status != statusSomeNotMapped {
+			t.Errorf("opnum %d: status = 0x%08x, want STATUS_SOME_NOT_MAPPED", c.opnum, res.status)
+		}
+		if res.mappedCount != 2 {
+			t.Errorf("opnum %d: mappedCount = %d, want 2", c.opnum, res.mappedCount)
+		}
 	}
 }

--- a/internal/adapter/smb/rpc/lsarpc_test.go
+++ b/internal/adapter/smb/rpc/lsarpc_test.go
@@ -889,7 +889,8 @@ func parseLookupSidsResponse(t *testing.T, response []byte, withFlags bool) look
 }
 
 // readNDRUnicodeString decodes a writeNDRUnicodeString-encoded string and
-// advances off past the 4-byte padding.
+// advances off past the 4-byte padding. The buffer is an un-terminated
+// conformant+varying array: MaxCount == ActualCount == char_count (no NUL).
 func readNDRUnicodeString(t *testing.T, b []byte, off *int) string {
 	t.Helper()
 	maxCount := binary.LittleEndian.Uint32(b[*off : *off+4])
@@ -897,8 +898,10 @@ func readNDRUnicodeString(t *testing.T, b []byte, off *int) string {
 	*off += 4 // offset
 	actual := binary.LittleEndian.Uint32(b[*off : *off+4])
 	*off += 4
-	_ = maxCount
-	// actual includes the null terminator (charCount).
+	// MaxCount and ActualCount must agree and carry NO null terminator.
+	if maxCount != actual {
+		t.Fatalf("NDR string MaxCount=%d != ActualCount=%d", maxCount, actual)
+	}
 	chars := int(actual)
 	byteLen := chars * 2
 	data := b[*off : *off+byteLen]
@@ -907,13 +910,10 @@ func readNDRUnicodeString(t *testing.T, b []byte, off *int) string {
 	for *off%4 != 0 {
 		*off++
 	}
-	// Drop the trailing null code unit and decode UTF-16LE.
+	// Decode UTF-16LE; there is no trailing NUL to drop.
 	var sb []rune
 	for i := 0; i+1 < len(data); i += 2 {
 		c := binary.LittleEndian.Uint16(data[i : i+2])
-		if c == 0 {
-			break
-		}
 		sb = append(sb, rune(c))
 	}
 	return string(sb)
@@ -1376,5 +1376,190 @@ func TestLSARPC_LookupSids_MixedBatch_PerOpnum(t *testing.T) {
 		if res.mappedCount != 2 {
 			t.Errorf("opnum %d: mappedCount = %d, want 2", c.opnum, res.mappedCount)
 		}
+	}
+}
+
+// =============================================================================
+// Golden byte-count assertions for RPC_UNICODE_STRING / NDR array length
+//
+// These lock the #1342 off-by-one: a resolved name of N characters must be
+// framed with RPC_UNICODE_STRING Length == MaximumLength == 2*N (bytes, NO
+// terminator) and a referenced conformant+varying UTF-16 array whose
+// MaxCount == Offset+ActualCount == N (chars, NO trailing NUL). Samba's
+// ndr_check_steal_array_length cross-checks ActualCount against Length/2; the
+// old "+1 / +NUL" encoding made got==expected+1 ("got 8 expected 7") and
+// rpcclient returned NT_STATUS_ARRAY_BOUNDS_EXCEEDED.
+// =============================================================================
+
+// ndrString captures the exact wire fields of one RPC_UNICODE_STRING plus the
+// conformant+varying UTF-16 array it references, as decoded from a real
+// buildLookupSidsResponse stub.
+type ndrString struct {
+	length    uint16 // RPC_UNICODE_STRING.Length (bytes)
+	maxLength uint16 // RPC_UNICODE_STRING.MaximumLength (bytes)
+	maxCount  uint32 // array MaxCount (chars)
+	offset    uint32 // array Offset (chars)
+	actual    uint32 // array ActualCount (chars)
+	value     string // decoded name
+	utf16Len  int    // raw UTF-16 byte count actually written (no padding)
+}
+
+// decodeLookupSidsStrings walks a buildLookupSidsResponse stub and returns the
+// referenced-domain name strings and the translated-name strings with their
+// exact RPC_UNICODE_STRING + array length fields. It is intentionally a precise,
+// hand-rolled reader (not the lenient parseLookupSidsResponse) so the byte
+// counts are asserted, not inferred. withFlags selects EX (57/76) vs non-EX (15).
+func decodeLookupSidsStrings(t *testing.T, stub []byte, withFlags bool) (domains, names []ndrString) {
+	t.Helper()
+	off := 0
+	u16 := func() uint16 { v := binary.LittleEndian.Uint16(stub[off : off+2]); off += 2; return v }
+	u32 := func() uint32 { v := binary.LittleEndian.Uint32(stub[off : off+4]); off += 4; return v }
+
+	// Read an un-terminated conformant+varying UTF-16 array, capturing fields.
+	readArray := func() (maxCount, offset, actual uint32, value string, rawLen int) {
+		maxCount = u32()
+		offset = u32()
+		actual = u32()
+		rawLen = int(actual) * 2
+		data := stub[off : off+rawLen]
+		off += rawLen
+		for off%4 != 0 {
+			off++
+		}
+		var sb []rune
+		for i := 0; i+1 < len(data); i += 2 {
+			sb = append(sb, rune(binary.LittleEndian.Uint16(data[i:i+2])))
+		}
+		return maxCount, offset, actual, string(sb), rawLen
+	}
+
+	// --- Referenced domain list ---
+	_ = u32() // list pointer
+	domCount := u32()
+	_ = u32() // array pointer
+	_ = u32() // max entries
+	type domFixed struct{ length, maxLength uint16 }
+	var domFixeds []domFixed
+	if domCount > 0 {
+		_ = u32() // conformant max count
+		for range domCount {
+			length := u16()
+			maxLength := u16()
+			_ = u32() // string pointer
+			_ = u32() // SID pointer
+			domFixeds = append(domFixeds, domFixed{length, maxLength})
+		}
+		for _, d := range domFixeds {
+			mc, o, a, v, raw := readArray()
+			domains = append(domains, ndrString{d.length, d.maxLength, mc, o, a, v, raw})
+		}
+		for range domCount {
+			skipNDRSID(t, stub, &off)
+		}
+	}
+
+	// --- Translated names ---
+	nameCount := u32()
+	_ = u32() // array pointer
+	type nameFixed struct{ length, maxLength uint16 }
+	var nameFixeds []nameFixed
+	if nameCount > 0 {
+		_ = u32() // conformant max count
+		for range nameCount {
+			_ = u16() // Use
+			_ = u16() // pad/reserved
+			length := u16()
+			maxLength := u16()
+			_ = u32() // name pointer
+			_ = u32() // domain index
+			if withFlags {
+				_ = u32() // flags (EX only)
+			}
+			nameFixeds = append(nameFixeds, nameFixed{length, maxLength})
+		}
+		for _, n := range nameFixeds {
+			mc, o, a, v, raw := readArray()
+			names = append(names, ndrString{n.length, n.maxLength, mc, o, a, v, raw})
+		}
+	}
+	return domains, names
+}
+
+// assertExactName checks one ndrString against an expected name: Length and
+// MaximumLength are 2*N bytes, the array MaxCount/Offset+ActualCount are N
+// chars, and no NUL terminator was written.
+func assertExactName(t *testing.T, label string, got ndrString, want string) {
+	t.Helper()
+	n := len(encodeUTF16LE(want)) / 2 // UTF-16 code units
+	if got.value != want {
+		t.Errorf("%s: name = %q, want %q", label, got.value, want)
+	}
+	if int(got.length) != 2*n {
+		t.Errorf("%s: RPC_UNICODE_STRING.Length = %d, want %d (2*%d, no NUL)", label, got.length, 2*n, n)
+	}
+	if int(got.maxLength) != 2*n {
+		t.Errorf("%s: RPC_UNICODE_STRING.MaximumLength = %d, want %d (== Length, no NUL)", label, got.maxLength, 2*n)
+	}
+	if int(got.maxCount) != n {
+		t.Errorf("%s: array MaxCount = %d, want %d (chars, no NUL)", label, got.maxCount, n)
+	}
+	if got.offset != 0 {
+		t.Errorf("%s: array Offset = %d, want 0", label, got.offset)
+	}
+	if int(got.actual) != n {
+		t.Errorf("%s: array ActualCount = %d, want %d (chars, no NUL) — the #1342 off-by-one", label, got.actual, n)
+	}
+	if got.utf16Len != 2*n {
+		t.Errorf("%s: wrote %d UTF-16 bytes, want %d (a trailing NUL would add 2)", label, got.utf16Len, 2*n)
+	}
+}
+
+// TestLSARPC_TranslatedName_ExactLengths_AllOpnums is the regression lock for
+// #1342. A 12-character username ("abcdefghijkl") under the 7-character machine
+// domain ("DITTOFS") is resolved and the response stub is decoded with exact
+// byte counts. For EACH of opnum 15 (non-EX), 57 and 76 (EX) it asserts the
+// translated name frames as Length=24/MaxCount=12 and the domain as
+// Length=14/MaxCount=7 — both with no NUL. These are precisely the "got N+1
+// expected N" cases the live Samba client rejected (12->13, 7->8).
+func TestLSARPC_TranslatedName_ExactLengths_AllOpnums(t *testing.T) {
+	const userName = "abcdefghijkl" // 12 chars
+	const domainName = "DITTOFS"    // 7 chars (machine domain default)
+
+	mapper := sid.NewSIDMapper(0, 0, 0)
+
+	cases := []struct {
+		name      string
+		opnum     uint16
+		withFlags bool
+	}{
+		{"opnum15_nonEX", OpLsarLookupSids, false},
+		{"opnum57_EX", OpLsarLookupSids2, true},
+		{"opnum76_EX", OpLsarLookupSids3, true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h := NewLSARPCHandler(mapper, &mockResolver{users: map[uint32]string{1: userName}})
+			stub := buildLookupSidsStubData(c.opnum, []*sid.SID{mapper.UserSID(1)})
+			req := mustParse(t, buildTestRequest(1, c.opnum, stub))
+			response := h.HandleRequest(req)
+			if hdr, _ := ParseHeader(response); hdr.PacketType == PDUFault {
+				t.Fatalf("opnum %d faulted", c.opnum)
+			}
+			if len(response) <= 24 {
+				t.Fatalf("response too short: %d bytes", len(response))
+			}
+			domains, names := decodeLookupSidsStrings(t, response[24:], c.withFlags)
+
+			if len(names) != 1 {
+				t.Fatalf("translated names = %d, want 1", len(names))
+			}
+			assertExactName(t, "name[0]", names[0], userName)
+
+			if len(domains) != 1 {
+				t.Fatalf("referenced domains = %d, want 1", len(domains))
+			}
+			assertExactName(t, "domain[0]", domains[0], domainName)
+		})
 	}
 }

--- a/internal/adapter/smb/rpc/lsarpc_test.go
+++ b/internal/adapter/smb/rpc/lsarpc_test.go
@@ -669,3 +669,379 @@ func TestStoreIdentityResolver_NilFuncs(t *testing.T) {
 		t.Error("LookupGroupNameByGID should return false when LookupGroup is nil")
 	}
 }
+
+// =============================================================================
+// Foreign (AD/LDAP) SID resolution
+// =============================================================================
+
+// mockForeignResolver is a test ForeignSIDResolver keyed by canonical SID string.
+type mockForeignResolver struct {
+	hits map[string]foreignHit
+}
+
+type foreignHit struct {
+	name    string
+	domain  string
+	sidType uint16
+}
+
+func (m *mockForeignResolver) LookupSID(sidString string) (string, string, uint16, bool) {
+	h, ok := m.hits[sidString]
+	if !ok {
+		return "", "", 0, false
+	}
+	return h.name, h.domain, h.sidType, true
+}
+
+func TestResolveSID_ForeignAD_Hit(t *testing.T) {
+	mapper := sid.NewSIDMapper(0, 0, 0)
+	adSID := sid.ParseSIDMust("S-1-5-21-1111111111-2222222222-3333333333-1107")
+	resolver := &mockForeignResolver{
+		hits: map[string]foreignHit{
+			sid.FormatSID(adSID): {name: "alice", domain: "CONTOSO", sidType: SidTypeUser},
+		},
+	}
+	h := NewLSARPCHandler(mapper, nil)
+	h.SetForeignSIDResolver(resolver)
+
+	r := h.resolveSID(adSID)
+	if r.name != "alice" {
+		t.Errorf("name = %q, want alice", r.name)
+	}
+	if r.domainName != "CONTOSO" {
+		t.Errorf("domainName = %q, want CONTOSO", r.domainName)
+	}
+	if r.sidType != SidTypeUser {
+		t.Errorf("sidType = %d, want %d (User)", r.sidType, SidTypeUser)
+	}
+	// The referenced domain SID must be the account SID with its RID stripped.
+	wantDomSID := sid.FormatSID(sid.ParseSIDMust("S-1-5-21-1111111111-2222222222-3333333333"))
+	if r.domainSID == nil || sid.FormatSID(r.domainSID) != wantDomSID {
+		t.Errorf("domainSID = %v, want %s", r.domainSID, wantDomSID)
+	}
+}
+
+func TestResolveSID_ForeignAD_Miss(t *testing.T) {
+	mapper := sid.NewSIDMapper(0, 0, 0)
+	adSID := sid.ParseSIDMust("S-1-5-21-1111111111-2222222222-3333333333-1107")
+	resolver := &mockForeignResolver{hits: map[string]foreignHit{}} // empty: always misses
+	h := NewLSARPCHandler(mapper, nil)
+	h.SetForeignSIDResolver(resolver)
+
+	r := h.resolveSID(adSID)
+	if r.sidType != SidTypeUnknown {
+		t.Errorf("miss sidType = %d, want %d (Unknown)", r.sidType, SidTypeUnknown)
+	}
+	if r.name != sid.FormatSID(adSID) {
+		t.Errorf("miss name = %q, want raw SID %q", r.name, sid.FormatSID(adSID))
+	}
+}
+
+func TestResolveSID_ForeignAD_NilResolver(t *testing.T) {
+	// With no foreign resolver wired, a foreign SID is unknown (raw), never a panic.
+	h := newTestLSAHandler()
+	adSID := sid.ParseSIDMust("S-1-5-21-1111111111-2222222222-3333333333-1107")
+	r := h.resolveSID(adSID)
+	if r.sidType != SidTypeUnknown {
+		t.Errorf("sidType = %d, want %d (Unknown)", r.sidType, SidTypeUnknown)
+	}
+}
+
+func TestResolveSID_MachineDomainName_Configurable(t *testing.T) {
+	mapper := sid.NewSIDMapper(0, 0, 0)
+	h := NewLSARPCHandler(mapper, &mockResolver{users: map[uint32]string{7: "bob"}})
+
+	// Default machine domain name.
+	if got := h.resolveSID(mapper.UserSID(7)).domainName; got != "DITTOFS" {
+		t.Errorf("default domainName = %q, want DITTOFS", got)
+	}
+
+	// Overridden machine domain name applies to machine-domain SIDs only.
+	h.SetMachineDomainName("FILER01")
+	if got := h.resolveSID(mapper.UserSID(7)).domainName; got != "FILER01" {
+		t.Errorf("overridden domainName = %q, want FILER01", got)
+	}
+
+	// Resetting with empty restores the default.
+	h.SetMachineDomainName("")
+	if got := h.resolveSID(mapper.UserSID(7)).domainName; got != "DITTOFS" {
+		t.Errorf("reset domainName = %q, want DITTOFS", got)
+	}
+}
+
+// lookupSidsResult is a decoded LsarLookupSids response (the parts under test).
+type lookupSidsResult struct {
+	domains     []string // referenced-domain names, in list order
+	names       []translatedName
+	mappedCount uint32
+	status      uint32
+}
+
+type translatedName struct {
+	sidType   uint16
+	domainIdx int32
+}
+
+// parseLookupSidsResponse decodes the stub data produced by
+// buildLookupSidsResponse. It mirrors that exact layout — it is a test-only
+// reader, not a general NDR parser.
+func parseLookupSidsResponse(t *testing.T, response []byte) lookupSidsResult {
+	t.Helper()
+	if len(response) <= 24 {
+		t.Fatalf("response too short: %d bytes", len(response))
+	}
+	stub := response[24:]
+	off := 0
+	u32 := func() uint32 {
+		v := binary.LittleEndian.Uint32(stub[off : off+4])
+		off += 4
+		return v
+	}
+	u16 := func() uint16 {
+		v := binary.LittleEndian.Uint16(stub[off : off+2])
+		off += 2
+		return v
+	}
+
+	var res lookupSidsResult
+
+	// --- Referenced domain list ---
+	_ = u32() // list pointer
+	domCount := u32()
+	_ = u32() // array pointer
+	_ = u32() // max entries
+
+	type domFixed struct{ nameUTF16Bytes uint16 }
+	var domFixeds []domFixed
+	if domCount > 0 {
+		_ = u32() // conformant max count
+		for range domCount {
+			length := u16()      // Length (excl null), in bytes
+			_ = u16()            // MaximumLength
+			_ = u32()            // string pointer
+			_ = u32()            // SID pointer
+			domFixeds = append(domFixeds, domFixed{nameUTF16Bytes: length})
+		}
+		// Deferred domain name strings.
+		for _, d := range domFixeds {
+			name := readNDRUnicodeString(t, stub, &off)
+			_ = d
+			res.domains = append(res.domains, name)
+		}
+		// Deferred domain SIDs.
+		for range domCount {
+			skipNDRSID(t, stub, &off)
+		}
+	}
+
+	// --- Translated names ---
+	nameCount := u32()
+	_ = u32() // array pointer
+	if nameCount > 0 {
+		_ = u32() // conformant max count
+		for range nameCount {
+			st := u16()
+			_ = u16() // pad/reserved
+			_ = u16() // Length
+			_ = u16() // MaximumLength
+			_ = u32() // name pointer
+			domIdx := int32(u32())
+			_ = u32() // flags
+			res.names = append(res.names, translatedName{sidType: st, domainIdx: domIdx})
+		}
+		// Deferred name strings.
+		for range nameCount {
+			readNDRUnicodeString(t, stub, &off)
+		}
+	}
+
+	res.mappedCount = u32()
+	res.status = u32()
+	return res
+}
+
+// readNDRUnicodeString decodes a writeNDRUnicodeString-encoded string and
+// advances off past the 4-byte padding.
+func readNDRUnicodeString(t *testing.T, b []byte, off *int) string {
+	t.Helper()
+	maxCount := binary.LittleEndian.Uint32(b[*off : *off+4])
+	*off += 4
+	*off += 4 // offset
+	actual := binary.LittleEndian.Uint32(b[*off : *off+4])
+	*off += 4
+	_ = maxCount
+	// actual includes the null terminator (charCount).
+	chars := int(actual)
+	byteLen := chars * 2
+	data := b[*off : *off+byteLen]
+	*off += byteLen
+	// 4-byte align.
+	for *off%4 != 0 {
+		*off++
+	}
+	// Drop the trailing null code unit and decode UTF-16LE.
+	var sb []rune
+	for i := 0; i+1 < len(data); i += 2 {
+		c := binary.LittleEndian.Uint16(data[i : i+2])
+		if c == 0 {
+			break
+		}
+		sb = append(sb, rune(c))
+	}
+	return string(sb)
+}
+
+// skipNDRSID advances off past a writeNDRSID-encoded SID.
+func skipNDRSID(t *testing.T, b []byte, off *int) {
+	t.Helper()
+	_ = binary.LittleEndian.Uint32(b[*off : *off+4]) // conformant max count
+	*off += 4
+	// SID: revision(1) + subauthcount(1) + authority(6) + subauths(4*n)
+	subCount := int(b[*off+1])
+	*off += 8 + 4*subCount
+	for *off%4 != 0 {
+		*off++
+	}
+}
+
+// TestLookupSids_MixedBatch_MultiDomain exercises a batch containing a
+// well-known SID, a machine-domain user, a foreign AD hit, and a foreign AD
+// miss. It asserts STATUS_SOME_NOT_MAPPED, the correct MappedCount, per-SID
+// types, and that the referenced-domain list correctly carries BUILTIN/the
+// machine domain/the AD domain with the per-name domain index pointing at the
+// right entry.
+func TestLookupSids_MixedBatch_MultiDomain(t *testing.T) {
+	mapper := sid.NewSIDMapper(0, 0, 0)
+	localResolver := &mockResolver{users: map[uint32]string{5: "localuser"}}
+
+	adHit := sid.ParseSIDMust("S-1-5-21-1111111111-2222222222-3333333333-1107")
+	adMiss := sid.ParseSIDMust("S-1-5-21-999999999-888888888-777777777-1500")
+	foreign := &mockForeignResolver{
+		hits: map[string]foreignHit{
+			sid.FormatSID(adHit): {name: "alice", domain: "CONTOSO", sidType: SidTypeUser},
+		},
+	}
+
+	h := NewLSARPCHandler(mapper, localResolver)
+	h.SetForeignSIDResolver(foreign)
+	h.SetMachineDomainName("FILER01")
+
+	sids := []*sid.SID{
+		sid.WellKnownAdministrators, // BUILTIN\Administrators (alias)
+		mapper.UserSID(5),           // FILER01\localuser
+		adHit,                       // CONTOSO\alice
+		adMiss,                      // unmapped
+	}
+
+	stubData := buildLookupSids2StubData(sids)
+	reqData := buildTestRequest(42, OpLsarLookupSids2, stubData)
+	req, err := ParseRequest(reqData)
+	if err != nil {
+		t.Fatalf("ParseRequest: %v", err)
+	}
+	response := h.HandleRequest(req)
+
+	hdr, err := ParseHeader(response)
+	if err != nil {
+		t.Fatalf("ParseHeader: %v", err)
+	}
+	if hdr.PacketType == PDUFault {
+		t.Fatal("got fault for a partially-unmapped batch; must be a normal response")
+	}
+
+	res := parseLookupSidsResponse(t, response)
+
+	if res.status != statusSomeNotMapped {
+		t.Errorf("status = 0x%08x, want STATUS_SOME_NOT_MAPPED (0x%08x)", res.status, statusSomeNotMapped)
+	}
+	if res.mappedCount != 3 {
+		t.Errorf("mappedCount = %d, want 3", res.mappedCount)
+	}
+	if len(res.names) != 4 {
+		t.Fatalf("translated names = %d, want 4", len(res.names))
+	}
+
+	// Per-SID types.
+	wantTypes := []uint16{SidTypeAlias, SidTypeUser, SidTypeUser, SidTypeUnknown}
+	for i, wt := range wantTypes {
+		if res.names[i].sidType != wt {
+			t.Errorf("name[%d].sidType = %d, want %d", i, res.names[i].sidType, wt)
+		}
+	}
+
+	// The unmapped entry must carry domain index -1.
+	if res.names[3].domainIdx != -1 {
+		t.Errorf("unmapped name domainIdx = %d, want -1", res.names[3].domainIdx)
+	}
+
+	// Referenced domains: BUILTIN, FILER01, CONTOSO (in first-seen order).
+	wantDomains := []string{"BUILTIN", "FILER01", "CONTOSO"}
+	if len(res.domains) != len(wantDomains) {
+		t.Fatalf("referenced domains = %v, want %v", res.domains, wantDomains)
+	}
+	for i, wd := range wantDomains {
+		if res.domains[i] != wd {
+			t.Errorf("domain[%d] = %q, want %q", i, res.domains[i], wd)
+		}
+	}
+
+	// Each mapped name's domain index must point at the matching domain entry.
+	checkIdx := func(nameIdx int, wantDomain string) {
+		di := res.names[nameIdx].domainIdx
+		if di < 0 || int(di) >= len(res.domains) {
+			t.Errorf("name[%d] domainIdx %d out of range", nameIdx, di)
+			return
+		}
+		if res.domains[di] != wantDomain {
+			t.Errorf("name[%d] -> domain %q, want %q", nameIdx, res.domains[di], wantDomain)
+		}
+	}
+	checkIdx(0, "BUILTIN")
+	checkIdx(1, "FILER01")
+	checkIdx(2, "CONTOSO")
+}
+
+// TestBuildLookupSidsResponse_TwoDomains is a focused round-trip over the
+// referenced-domain list with exactly two distinct domains, verifying the
+// dedup/index bookkeeping in isolation from the request parser.
+func TestBuildLookupSidsResponse_TwoDomains(t *testing.T) {
+	h := newTestLSAHandler()
+
+	resolved := []resolvedSID{
+		{name: "alice", sidType: SidTypeUser, domainName: "CONTOSO", domainSID: sid.ParseSIDMust("S-1-5-21-1-2-3")},
+		{name: "bob", sidType: SidTypeUser, domainName: "FABRIKAM", domainSID: sid.ParseSIDMust("S-1-5-21-4-5-6")},
+		{name: "carol", sidType: SidTypeUser, domainName: "CONTOSO", domainSID: sid.ParseSIDMust("S-1-5-21-1-2-3")},
+	}
+
+	domainMap := make(map[string]int)
+	var domains []domainEntry
+	for i := range resolved {
+		r := &resolved[i]
+		if _, ok := domainMap[r.domainName]; !ok {
+			domainMap[r.domainName] = len(domains)
+			domains = append(domains, domainEntry{name: r.domainName, sid: r.domainSID})
+		}
+	}
+
+	stub := h.buildLookupSidsResponse(resolved, domains, domainMap, true)
+	// Prefix a fake 24-byte RPC header so the shared parser offset math holds.
+	response := append(make([]byte, 24), stub...)
+	res := parseLookupSidsResponse(t, response)
+
+	if len(res.domains) != 2 {
+		t.Fatalf("domains = %v, want exactly 2 (deduped)", res.domains)
+	}
+	if res.domains[0] != "CONTOSO" || res.domains[1] != "FABRIKAM" {
+		t.Errorf("domains = %v, want [CONTOSO FABRIKAM]", res.domains)
+	}
+	if res.names[0].domainIdx != 0 || res.names[1].domainIdx != 1 || res.names[2].domainIdx != 0 {
+		t.Errorf("domain indices = [%d %d %d], want [0 1 0]",
+			res.names[0].domainIdx, res.names[1].domainIdx, res.names[2].domainIdx)
+	}
+	if res.mappedCount != 3 {
+		t.Errorf("mappedCount = %d, want 3", res.mappedCount)
+	}
+	if res.status != statusSuccess {
+		t.Errorf("status = 0x%08x, want success", res.status)
+	}
+}

--- a/internal/adapter/smb/rpc/pipe.go
+++ b/internal/adapter/smb/rpc/pipe.go
@@ -157,11 +157,13 @@ func (p *PipeState) Transact(inputData []byte, maxOutput int) ([]byte, error) {
 
 // PipeManager manages named pipe instances
 type PipeManager struct {
-	mu               sync.RWMutex
-	pipes            map[[16]byte]*PipeState // Keyed by SMB FileID
-	shares           []ShareInfo1            // Available shares for enumeration
-	sidMapper        *sid.SIDMapper          // For lsarpc SID resolution
-	identityResolver IdentityResolver        // For lsarpc real name resolution
+	mu                sync.RWMutex
+	pipes             map[[16]byte]*PipeState // Keyed by SMB FileID
+	shares            []ShareInfo1            // Available shares for enumeration
+	sidMapper         *sid.SIDMapper          // For lsarpc SID resolution
+	identityResolver  IdentityResolver        // For lsarpc real name resolution
+	foreignResolver   ForeignSIDResolver      // For lsarpc AD/LDAP SID resolution
+	machineDomainName string                  // NetBIOS name for machine-domain SIDs
 }
 
 // NewPipeManager creates a new pipe manager
@@ -193,6 +195,22 @@ func (pm *PipeManager) SetIdentityResolver(resolver IdentityResolver) {
 	pm.identityResolver = resolver
 }
 
+// SetForeignSIDResolver sets the directory-backed resolver used by lsarpc to
+// translate foreign (AD/LDAP) domain SIDs to account names. May be nil.
+func (pm *PipeManager) SetForeignSIDResolver(resolver ForeignSIDResolver) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pm.foreignResolver = resolver
+}
+
+// SetMachineDomainName sets the NetBIOS domain name reported by lsarpc for
+// machine-domain (local UID/GID) SIDs. An empty value uses the default.
+func (pm *PipeManager) SetMachineDomainName(name string) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pm.machineDomainName = name
+}
+
 // CreatePipe creates a new named pipe instance.
 // The handler type is determined by the pipe name: "lsarpc" creates an
 // LSARPCHandler, all others create an SRVSVCHandler.
@@ -208,7 +226,10 @@ func (pm *PipeManager) CreatePipe(fileID [16]byte, pipeName string) *PipeState {
 		if mapper == nil {
 			mapper = sid.NewSIDMapper(0, 0, 0) // fallback
 		}
-		handler = NewLSARPCHandler(mapper, pm.identityResolver)
+		lsaHandler := NewLSARPCHandler(mapper, pm.identityResolver)
+		lsaHandler.SetForeignSIDResolver(pm.foreignResolver)
+		lsaHandler.SetMachineDomainName(pm.machineDomainName)
+		handler = lsaHandler
 	} else {
 		// Create SRVSVC handler for share enumeration
 		sharesCopy := make([]ShareInfo1, len(pm.shares))

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -96,6 +96,12 @@ type Adapter struct {
 	// config changes cannot race on identityUnsub/identityProviderUnsub.
 	resolverMu sync.Mutex
 
+	// foreignSIDProviderUnsub is the unsubscribe function for the
+	// OnIdentityProviderConfigChange subscription that rebuilds the LSARPC
+	// foreign-SID resolver. Registered once (guarded by nil) so an API-driven
+	// LDAP config change re-wires the resolver without a restart.
+	foreignSIDProviderUnsub func()
+
 	// kerberosProvider is retained for lifecycle management. It owns a
 	// background keytab-reload goroutine that must be stopped in Stop().
 	kerberosProvider *kerberos.Provider
@@ -299,6 +305,12 @@ func (s *Adapter) SetRuntime(rtAny any) {
 		})
 		logger.Debug("SMB adapter: identity resolver configured for LSARPC")
 	}
+
+	// Wire the directory-backed foreign-SID resolver for LSARPC so an AD/LDAP
+	// domain SID (neither well-known nor machine-domain) is translated to its
+	// real account name + NetBIOS domain in Explorer's Security tab. Independent
+	// of Kerberos: LDAP may be configured on its own.
+	s.wireForeignSIDResolver(rt)
 
 	// Wire centralized identity resolver for Kerberos principal → DittoFS user mapping.
 	// Uses DB-backed LinkStore + convention fallback, shared with the NFS adapter.
@@ -540,6 +552,11 @@ func (s *Adapter) SetKerberosProvider(provider *kerberos.Provider) {
 	// methods outside the handler's narrow smbRuntime role interface.
 	s.wireIdentityResolver(s.Registry)
 
+	// Re-wire the LSARPC foreign-SID resolver now that the AD NetBIOS domain is
+	// known (SetKerberosProvider may run after SetRuntime). Safe to call twice;
+	// it rebuilds and re-injects the resolver and guards the subscription.
+	s.wireForeignSIDResolver(s.Registry)
+
 	logger.Debug("SMB adapter Kerberos provider configured",
 		"principal", provider.ServicePrincipal(),
 		"stripRealm", s.handler.IdentityConfig.StripRealm)
@@ -584,6 +601,53 @@ func (s *Adapter) wireIdentityResolver(rt *runtime.Runtime) {
 			s.wireIdentityResolver(rt)
 		})
 	}
+}
+
+// wireForeignSIDResolver builds a directory-backed resolver for foreign
+// (AD/LDAP) domain SIDs and injects it into the LSARPC PipeManager. Unlike
+// wireIdentityResolver this does not require a Kerberos provider — an
+// LDAP-only deployment still resolves AD SIDs to names in Explorer's Security
+// tab. A no-op when the runtime or pipe manager is unavailable.
+//
+// The resolver is rebuilt (and re-injected) on an identity-provider config
+// change so enabling/disabling LDAP over the API takes effect without a
+// restart. When LDAP is not enabled the underlying resolver simply never
+// matches a foreign SID, so it degrades to the prior raw-SID behavior.
+func (s *Adapter) wireForeignSIDResolver(rt *runtime.Runtime) {
+	s.resolverMu.Lock()
+	defer s.resolverMu.Unlock()
+
+	if rt == nil || s.handler == nil || s.handler.PipeManager == nil {
+		return
+	}
+
+	// Build a resolver chain (Kerberos + LDAP/AD when configured). The realm is
+	// taken from the Kerberos provider when present; BuildIdentityResolver still
+	// registers the LDAP provider whenever rt.LDAPConfig() is enabled.
+	var realm string
+	if s.handler.KerberosProvider != nil {
+		realm = adapter.ExtractRealm(s.handler.KerberosProvider.ServicePrincipal())
+	}
+	resolver := adapter.BuildIdentityResolver(rt, realm)
+
+	// Prefer the explicitly configured AD NetBIOS domain (set on the handler by
+	// SetKerberosProvider). Empty leaves the resolver to derive it from the
+	// resolved realm. This is the AD DOMAIN's NetBIOS name, used only for
+	// foreign (directory) accounts — NOT the local machine-domain name. Local
+	// algorithmic UID/GID SIDs keep the standalone machine name ("DITTOFS")
+	// since they are the server's own identities, not AD-domain principals.
+	s.handler.PipeManager.SetForeignSIDResolver(
+		newIdentityForeignSIDResolver(resolver, s.handler.NetBIOSDomain),
+	)
+
+	if s.foreignSIDProviderUnsub == nil {
+		s.foreignSIDProviderUnsub = rt.OnIdentityProviderConfigChange(func() {
+			s.wireForeignSIDResolver(rt)
+		})
+	}
+
+	logger.Debug("SMB adapter: LSARPC foreign-SID resolver configured",
+		"ad_netbios_domain", s.handler.NetBIOSDomain)
 }
 
 const (
@@ -653,6 +717,10 @@ func (s *Adapter) Stop(ctx context.Context) error {
 	if s.identityProviderUnsub != nil {
 		s.identityProviderUnsub()
 		s.identityProviderUnsub = nil
+	}
+	if s.foreignSIDProviderUnsub != nil {
+		s.foreignSIDProviderUnsub()
+		s.foreignSIDProviderUnsub = nil
 	}
 
 	// Unsubscribe from share change notifications to prevent stale callbacks

--- a/pkg/adapter/smb/lsarpc_foreign.go
+++ b/pkg/adapter/smb/lsarpc_foreign.go
@@ -62,14 +62,49 @@ func (r *identityForeignSIDResolver) LookupSID(sidString string) (name, domain s
 		return "", "", 0, false
 	}
 
-	dom := r.netbiosDomain
-	if dom == "" {
-		dom = netbiosFromRealm(resolved.Domain)
-	}
-
 	// The forward directory resolve matches objectClass=user, so a hit is an
 	// account (user) rather than a group.
-	return resolved.Username, dom, smbrpc.SidTypeUser, true
+	return resolved.Username, r.netbiosOrDerive(resolved.Domain), smbrpc.SidTypeUser, true
+}
+
+// LookupUID resolves a POSIX UID to its directory account name + NetBIOS
+// domain. It backs the OWNER-SID display path: a file owned by an AD-only user
+// carries the machine-domain (algorithmic) SID, which the LSARPC handler
+// decodes to a UID. When that UID has no local DittoFS account the handler
+// calls here, and the resolver's LDAP provider matches it by uidNumber to
+// recover the real account name (e.g. alice). A miss returns ok=false so the
+// SID stays unmapped — never a fault.
+func (r *identityForeignSIDResolver) LookupUID(uid uint32) (name, domain string, ok bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
+	defer cancel()
+
+	n, dom, found := r.resolver.LookupUID(ctx, uid)
+	if !found || n == "" {
+		return "", "", false
+	}
+	return n, r.netbiosOrDerive(dom), true
+}
+
+// LookupGID resolves a POSIX GID to its directory group name + NetBIOS domain.
+// Mirrors LookupUID for the GROUP SID on a file (matched by gidNumber).
+func (r *identityForeignSIDResolver) LookupGID(gid uint32) (name, domain string, ok bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
+	defer cancel()
+
+	n, dom, found := r.resolver.LookupGID(ctx, gid)
+	if !found || n == "" {
+		return "", "", false
+	}
+	return n, r.netbiosOrDerive(dom), true
+}
+
+// netbiosOrDerive returns the configured AD NetBIOS short name, or derives one
+// from the resolved realm when none was configured.
+func (r *identityForeignSIDResolver) netbiosOrDerive(realm string) string {
+	if r.netbiosDomain != "" {
+		return r.netbiosDomain
+	}
+	return netbiosFromRealm(realm)
 }
 
 // netbiosFromRealm derives a NetBIOS short domain from a Kerberos realm / DNS

--- a/pkg/adapter/smb/lsarpc_foreign.go
+++ b/pkg/adapter/smb/lsarpc_foreign.go
@@ -1,0 +1,88 @@
+package smb
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	smbrpc "github.com/marmos91/dittofs/internal/adapter/smb/rpc"
+	"github.com/marmos91/dittofs/pkg/identity"
+)
+
+// identityForeignSIDResolver bridges the centralized identity.Resolver to the
+// LSARPC ForeignSIDResolver interface. It resolves a foreign (AD/LDAP) domain
+// SID to its account name + NetBIOS domain by issuing a SID-keyed credential
+// to the resolver, which routes it to the LDAP/AD provider's objectSid search.
+//
+// The resolver already caches forward lookups (positive + negative TTL), so a
+// repeated Explorer "Security tab" lookup of the same SID hits the cache rather
+// than re-querying the directory.
+type identityForeignSIDResolver struct {
+	resolver *identity.Resolver
+
+	// netbiosDomain is the AD short domain (e.g. CONTOSO) advertised for
+	// resolved foreign accounts. When empty, the domain is derived from the
+	// resolved identity's realm/Domain (first DNS label, upper-cased).
+	netbiosDomain string
+
+	timeout time.Duration
+}
+
+// lsarpcForeignLookupTimeout bounds a single directory round-trip triggered by
+// an Explorer Security-tab lookup. Generous for one LDAP search but short
+// enough that a hung directory never wedges the named-pipe handler.
+const lsarpcForeignLookupTimeout = 5 * time.Second
+
+// newIdentityForeignSIDResolver builds a ForeignSIDResolver backed by the given
+// identity.Resolver. netbiosDomain is the configured AD short name (may be
+// empty, in which case it is derived from the resolved realm). Returns nil when
+// the resolver is nil so callers can pass the result straight through.
+func newIdentityForeignSIDResolver(resolver *identity.Resolver, netbiosDomain string) smbrpc.ForeignSIDResolver {
+	if resolver == nil {
+		return nil
+	}
+	return &identityForeignSIDResolver{
+		resolver:      resolver,
+		netbiosDomain: netbiosDomain,
+		timeout:       lsarpcForeignLookupTimeout,
+	}
+}
+
+// LookupSID resolves a canonical SID string to an AD account name + NetBIOS
+// domain. The resolver's LDAP/AD provider matches the SID via objectSid and
+// returns the sAMAccountName. A miss (Found=false) or any infrastructure error
+// returns ok=false so the SID stays unmapped — Explorer then shows the raw SID
+// for that entry, never a fault.
+func (r *identityForeignSIDResolver) LookupSID(sidString string) (name, domain string, sidType uint16, ok bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
+	defer cancel()
+
+	resolved, err := r.resolver.Resolve(ctx, &identity.Credential{ExternalID: sidString})
+	if err != nil || resolved == nil || !resolved.Found || resolved.Username == "" {
+		return "", "", 0, false
+	}
+
+	dom := r.netbiosDomain
+	if dom == "" {
+		dom = netbiosFromRealm(resolved.Domain)
+	}
+
+	// The forward directory resolve matches objectClass=user, so a hit is an
+	// account (user) rather than a group.
+	return resolved.Username, dom, smbrpc.SidTypeUser, true
+}
+
+// netbiosFromRealm derives a NetBIOS short domain from a Kerberos realm / DNS
+// domain by taking the first label and upper-casing it (CONTOSO.COM -> CONTOSO).
+// This is the conventional Samba derivation used only as a fallback when no
+// NetBIOS name was configured explicitly; it returns "" for an empty realm.
+func netbiosFromRealm(realm string) string {
+	realm = strings.TrimSpace(realm)
+	if realm == "" {
+		return ""
+	}
+	if idx := strings.IndexByte(realm, '.'); idx > 0 {
+		realm = realm[:idx]
+	}
+	return strings.ToUpper(realm)
+}

--- a/pkg/identity/ldap/provider.go
+++ b/pkg/identity/ldap/provider.go
@@ -203,6 +203,68 @@ func (p *Provider) Resolve(ctx context.Context, cred *identity.Credential) (*ide
 	}, nil
 }
 
+// LookupUID resolves a POSIX UID to an AD account name + realm via an
+// RFC2307 reverse search (&(objectClass=user)(uidNumber=N)). It backs the
+// LSARPC owner-SID display path: the machine-domain SID decodes to a UID that
+// has no local DittoFS account (the owner is an AD-only user such as alice),
+// so the name is recovered from the directory instead.
+//
+// Returns ok=false (no error logged as fatal) when no object matches or the
+// directory is unreachable, so a miss degrades to a raw SID rather than a
+// fault. Only meaningful in the rfc2307 idmap mode; in rid mode the UID is the
+// RID and is matched on objectSid by the forward path instead, so this returns
+// ok=false.
+func (p *Provider) LookupUID(ctx context.Context, uid uint32) (name, domain string, ok bool) {
+	return p.reverseLookup(ctx, "user", "uidNumber", uid)
+}
+
+// LookupGID resolves a POSIX GID to an AD group name + realm via an RFC2307
+// reverse search (&(objectClass=group)(gidNumber=N)). Mirrors LookupUID for
+// the GROUP SID on a file. Returns ok=false on a miss or in rid mode.
+func (p *Provider) LookupGID(ctx context.Context, gid uint32) (name, domain string, ok bool) {
+	return p.reverseLookup(ctx, "group", "gidNumber", gid)
+}
+
+// reverseLookup performs a single RFC2307 reverse search for the given object
+// class and POSIX-number attribute, returning the object's sAMAccountName and
+// the configured realm. Infrastructure errors are logged at Debug and folded
+// into ok=false so a directory outage never faults the LSARPC pipe.
+func (p *Provider) reverseLookup(ctx context.Context, objectClass, numAttr string, id uint32) (string, string, bool) {
+	// Only RFC2307 stamps uidNumber/gidNumber. In rid mode the POSIX id is the
+	// object's RID; there is no number attribute to match on, so report a miss
+	// and let the caller fall back to the raw SID.
+	if p.cfg.Idmap != IdmapRFC2307 {
+		return "", "", false
+	}
+
+	c, err := p.connect(ctx, p.cfg)
+	if err != nil {
+		logger.Debug("ldap: reverse lookup connect/bind failed", "attr", numAttr, "id", id, "error", err)
+		return "", "", false
+	}
+	defer func() { _ = c.Close() }()
+
+	filter := fmt.Sprintf("(&(objectClass=%s)(%s=%d))", objectClass, numAttr, id)
+	req := ldapv3.NewSearchRequest(
+		p.cfg.BaseDN,
+		ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 2, int(p.cfg.Timeout.Seconds()), false,
+		filter, []string{"sAMAccountName"}, nil,
+	)
+	res, err := c.Search(req)
+	if err != nil {
+		logger.Debug("ldap: reverse lookup search failed", "filter", filter, "error", err)
+		return "", "", false
+	}
+	if len(res.Entries) == 0 {
+		return "", "", false
+	}
+	name := res.Entries[0].GetAttributeValue("sAMAccountName")
+	if name == "" {
+		return "", "", false
+	}
+	return name, p.cfg.Realm, true
+}
+
 // userFilter builds an LDAP filter matching the credential. SIDs are matched on
 // objectSid; principals on the configured user attribute (sAMAccountName).
 func (p *Provider) userFilter(cred *identity.Credential) (string, error) {

--- a/pkg/identity/ldap/provider_test.go
+++ b/pkg/identity/ldap/provider_test.go
@@ -285,3 +285,85 @@ func TestSIDToLDAPFilter_RoundTrips(t *testing.T) {
 		t.Errorf("unexpected filter prefix: %q", got)
 	}
 }
+
+// TestLookupUID_RFC2307 covers the reverse uid→name search that backs the
+// LSARPC owner-SID display path. The provider must issue a
+// (&(objectClass=user)(uidNumber=N)) filter and return the sAMAccountName +
+// realm. A miss returns ok=false.
+func TestLookupUID_RFC2307(t *testing.T) {
+	var sawFilter string
+	fc := &fakeConn{
+		search: func(req *ldapv3.SearchRequest) ([]*ldapv3.Entry, error) {
+			sawFilter = req.Filter
+			if strings.Contains(req.Filter, "uidNumber=10001") {
+				return []*ldapv3.Entry{entry("CN=alice,DC=dittofs,DC=ad",
+					map[string][]string{"sAMAccountName": {"alice"}}, nil)}, nil
+			}
+			return nil, nil
+		},
+	}
+	p := newTestProvider(t, baseCfg(), fc)
+
+	name, domain, ok := p.LookupUID(context.Background(), 10001)
+	if !ok {
+		t.Fatal("LookupUID(10001) ok=false, want true")
+	}
+	if name != "alice" {
+		t.Errorf("name = %q, want alice", name)
+	}
+	if domain != "DITTOFS.AD" {
+		t.Errorf("domain = %q, want DITTOFS.AD", domain)
+	}
+	if !strings.Contains(sawFilter, "objectClass=user") || !strings.Contains(sawFilter, "uidNumber=10001") {
+		t.Errorf("filter = %q, want objectClass=user + uidNumber=10001", sawFilter)
+	}
+
+	// Miss.
+	if _, _, ok := p.LookupUID(context.Background(), 99999); ok {
+		t.Error("LookupUID(99999) ok=true, want false (no match)")
+	}
+}
+
+// TestLookupGID_RFC2307 mirrors TestLookupUID_RFC2307 for the group path.
+func TestLookupGID_RFC2307(t *testing.T) {
+	var sawFilter string
+	fc := &fakeConn{
+		search: func(req *ldapv3.SearchRequest) ([]*ldapv3.Entry, error) {
+			sawFilter = req.Filter
+			if strings.Contains(req.Filter, "gidNumber=10000") {
+				return []*ldapv3.Entry{entry("CN=domain users,DC=dittofs,DC=ad",
+					map[string][]string{"sAMAccountName": {"domain users"}}, nil)}, nil
+			}
+			return nil, nil
+		},
+	}
+	p := newTestProvider(t, baseCfg(), fc)
+
+	name, domain, ok := p.LookupGID(context.Background(), 10000)
+	if !ok || name != "domain users" || domain != "DITTOFS.AD" {
+		t.Errorf("LookupGID(10000) = (%q, %q, %v), want (domain users, DITTOFS.AD, true)", name, domain, ok)
+	}
+	if !strings.Contains(sawFilter, "objectClass=group") || !strings.Contains(sawFilter, "gidNumber=10000") {
+		t.Errorf("filter = %q, want objectClass=group + gidNumber=10000", sawFilter)
+	}
+}
+
+// TestLookupUID_RIDMode confirms reverse lookup is a no-op (miss) in rid mode,
+// where the POSIX id is the RID and there is no uidNumber attribute to match.
+func TestLookupUID_RIDMode(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Idmap = IdmapRID
+	searched := false
+	fc := &fakeConn{search: func(*ldapv3.SearchRequest) ([]*ldapv3.Entry, error) {
+		searched = true
+		return nil, nil
+	}}
+	p := newTestProvider(t, cfg, fc)
+
+	if _, _, ok := p.LookupUID(context.Background(), 1234); ok {
+		t.Error("LookupUID in rid mode should miss")
+	}
+	if searched {
+		t.Error("rid mode must not issue a directory search for reverse uid lookup")
+	}
+}

--- a/pkg/identity/resolver.go
+++ b/pkg/identity/resolver.go
@@ -149,6 +149,71 @@ func (r *Resolver) resolveUncached(ctx context.Context, cred *Credential) (*Reso
 	return &ResolvedIdentity{Found: false}, nil
 }
 
+// ReverseResolver is an optional capability a Provider may implement to resolve
+// a POSIX UID/GID back to a directory account/group name. It backs the LSARPC
+// owner/group SID display path: a local algorithmic SID decodes to a UID/GID
+// that has no local DittoFS account (an AD-only user), so the name is recovered
+// from the directory instead.
+//
+// A miss returns ok=false and is never an error: the SID then stays unmapped
+// (raw) rather than faulting. Infrastructure failures are folded into ok=false
+// by the implementation.
+type ReverseResolver interface {
+	// LookupUID resolves a POSIX UID to an account name + domain/realm.
+	LookupUID(ctx context.Context, uid uint32) (name, domain string, ok bool)
+	// LookupGID resolves a POSIX GID to a group name + domain/realm.
+	LookupGID(ctx context.Context, gid uint32) (name, domain string, ok bool)
+}
+
+// reverseUIDKey / reverseGIDKey are synthetic cache keys for reverse lookups.
+// They share the Resolver's cache (positive + negative TTL) with forward
+// resolution but cannot collide with a forward key, which always embeds a
+// provider name and an ExternalID via cacheKey.
+func reverseUIDKey(uid uint32) string { return fmt.Sprintf("ruid:%d", uid) }
+func reverseGIDKey(gid uint32) string { return fmt.Sprintf("rgid:%d", gid) }
+
+// LookupUID resolves a POSIX UID to a directory account name + domain by
+// consulting every registered provider that implements ReverseResolver, in
+// registration order. The first hit wins. Results (hits and misses) are cached
+// with the same TTLs as forward resolution so a repeated Explorer Security-tab
+// lookup of the same owner does not re-query the directory each time.
+func (r *Resolver) LookupUID(ctx context.Context, uid uint32) (name, domain string, ok bool) {
+	return r.reverseLookup(ctx, reverseUIDKey(uid), func(rr ReverseResolver) (string, string, bool) {
+		return rr.LookupUID(ctx, uid)
+	})
+}
+
+// LookupGID resolves a POSIX GID to a directory group name + domain. Mirrors
+// LookupUID for the GROUP SID on a file.
+func (r *Resolver) LookupGID(ctx context.Context, gid uint32) (name, domain string, ok bool) {
+	return r.reverseLookup(ctx, reverseGIDKey(gid), func(rr ReverseResolver) (string, string, bool) {
+		return rr.LookupGID(ctx, gid)
+	})
+}
+
+// reverseLookup runs a cached reverse lookup against the provider chain. The
+// hit/miss is encoded into a ResolvedIdentity (Username/Domain/Found) so it can
+// ride the existing identity cache.
+func (r *Resolver) reverseLookup(ctx context.Context, key string, query func(ReverseResolver) (string, string, bool)) (string, string, bool) {
+	if cached, _, hit := r.cache.get(key); hit && cached != nil {
+		return cached.Username, cached.Domain, cached.Found
+	}
+
+	for _, p := range r.providers {
+		rr, capable := p.(ReverseResolver)
+		if !capable {
+			continue
+		}
+		if name, domain, ok := query(rr); ok {
+			r.cache.put(key, &ResolvedIdentity{Username: name, Domain: domain, Found: true}, nil)
+			return name, domain, true
+		}
+	}
+
+	r.cache.put(key, &ResolvedIdentity{Found: false}, nil)
+	return "", "", false
+}
+
 // InvalidateCache clears all cached entries.
 func (r *Resolver) InvalidateCache() {
 	r.cache.invalidateAll()

--- a/pkg/identity/resolver_test.go
+++ b/pkg/identity/resolver_test.go
@@ -346,3 +346,86 @@ func TestResolver_ConcurrentAccess(t *testing.T) {
 		t.Fatalf("expected at most ~5 provider calls with caching, got %d", p.callCount())
 	}
 }
+
+// reverseMockProvider is a mockProvider that also implements ReverseResolver,
+// used to exercise the resolver's reverse uid/gid lookup chain.
+type reverseMockProvider struct {
+	mockProvider
+	uids     map[uint32]string
+	gids     map[uint32]string
+	domain   string
+	uidCalls atomic.Int32
+}
+
+func (m *reverseMockProvider) LookupUID(_ context.Context, uid uint32) (string, string, bool) {
+	m.uidCalls.Add(1)
+	if n, ok := m.uids[uid]; ok {
+		return n, m.domain, true
+	}
+	return "", "", false
+}
+
+func (m *reverseMockProvider) LookupGID(_ context.Context, gid uint32) (string, string, bool) {
+	if n, ok := m.gids[gid]; ok {
+		return n, m.domain, true
+	}
+	return "", "", false
+}
+
+// TestResolver_ReverseLookup_Chain verifies LookupUID/LookupGID consult only
+// providers that implement ReverseResolver, first hit wins, and that a
+// non-reverse provider in the chain is skipped without panicking.
+func TestResolver_ReverseLookup_Chain(t *testing.T) {
+	plain := &mockProvider{name: "kerberos"} // no ReverseResolver
+	dir := &reverseMockProvider{
+		mockProvider: mockProvider{name: "ldap"},
+		uids:         map[uint32]string{10001: "alice"},
+		gids:         map[uint32]string{10000: "domain users"},
+		domain:       "DITTOFS.AD",
+	}
+	r := NewResolver(WithProvider(plain), WithProvider(dir))
+
+	name, domain, ok := r.LookupUID(context.Background(), 10001)
+	if !ok || name != "alice" || domain != "DITTOFS.AD" {
+		t.Fatalf("LookupUID = (%q, %q, %v), want (alice, DITTOFS.AD, true)", name, domain, ok)
+	}
+
+	gname, _, ok := r.LookupGID(context.Background(), 10000)
+	if !ok || gname != "domain users" {
+		t.Fatalf("LookupGID = (%q, %v), want (domain users, true)", gname, ok)
+	}
+
+	if _, _, ok := r.LookupUID(context.Background(), 99999); ok {
+		t.Error("LookupUID(99999) should miss")
+	}
+}
+
+// TestResolver_ReverseLookup_Cached verifies a repeated reverse lookup is served
+// from cache (the provider is queried once for a hit and once for a miss).
+func TestResolver_ReverseLookup_Cached(t *testing.T) {
+	dir := &reverseMockProvider{
+		mockProvider: mockProvider{name: "ldap"},
+		uids:         map[uint32]string{42: "bob"},
+		domain:       "AD",
+	}
+	r := NewResolver(WithProvider(dir))
+
+	for i := 0; i < 3; i++ {
+		if name, _, ok := r.LookupUID(context.Background(), 42); !ok || name != "bob" {
+			t.Fatalf("iter %d: LookupUID(42) = (%q, %v)", i, name, ok)
+		}
+	}
+	if got := dir.uidCalls.Load(); got != 1 {
+		t.Errorf("provider LookupUID called %d times, want 1 (cached)", got)
+	}
+
+	// A miss is also cached.
+	for i := 0; i < 3; i++ {
+		if _, _, ok := r.LookupUID(context.Background(), 7); ok {
+			t.Fatalf("iter %d: LookupUID(7) should miss", i)
+		}
+	}
+	if got := dir.uidCalls.Load(); got != 2 {
+		t.Errorf("provider LookupUID called %d times total, want 2 (one hit + one miss, both cached)", got)
+	}
+}


### PR DESCRIPTION
## What

Windows ACL editors (Explorer Security tab) showed **raw SIDs** (`S-1-5-21-…`) instead of `DOMAIN\user` for files owned by real **AD** users. #236/#1291 already resolve **local** users + well-known SIDs; this closes the remaining **AD foreign-domain** SID→name gap (tied to #1317).

## How

- `lsarpc.go`: new `ForeignSIDResolver` interface; `resolveSID` now consults it for any SID that is neither well-known nor machine-domain, returning the AD account name + NetBIOS domain + `SID_NAME_USE`; misses fall through to `SidTypeUnknown` (→ `STATUS_SOME_NOT_MAPPED`, never a fault). Hardcoded `"DITTOFS"` machine-domain label replaced by a configurable name; referenced-domain-list dedup handles multiple domains (BUILTIN / NT AUTHORITY / machine / AD).
- `pkg/adapter/smb/lsarpc_foreign.go` (new): bridges `identity.Resolver` → `ForeignSIDResolver` via `Resolve(&Credential{ExternalID: sid})`, which routes to the LDAP provider's existing `objectSid=` search (cached). Wired in `adapter.go` with hot-reload (`OnIdentityProviderConfigChange`).

## Tests

Unit tests added/green: foreign-AD hit (name+domain+type+stripped domain SID), miss, nil-resolver, configurable machine domain, mixed batch asserting `STATUS_SOME_NOT_MAPPED`/`MappedCount`/per-SID types + multi-domain referenced-list indexing, and a two-domain `buildLookupSidsResponse` round-trip. `go build ./...`, `go vet`, `go test ./internal/adapter/smb/... ./pkg/identity/... ./pkg/auth/sid/... ./pkg/adapter/...` green.

## Verification status (honest)

- **Live, server-side:** rolled onto the demo; confirmed the LSARPC pipe is reached and the directory resolver runs for AD users (`kinit alice` → server resolves `alice`/uid 10001 during a `LookupSids` call).
- **Pending real-Windows confirmation:** Windows Explorer uses **LsarLookupSids2 (opnum 57)**, which `rpcclient` can't drive directly, so end-to-end name display needs a real Windows client (being set up).
- **Follow-up (separate):** `rpcclient lookupsids3` (opnum 76) returns `NT_STATUS_ARRAY_BOUNDS_EXCEEDED` — a pre-existing **LookupSids3 wire-format** issue (the handler parses the request but the response envelope mis-frames for real clients). Filed separately; not introduced here.