### PR TITLE
test(lsarpc): lock opnum-76 EX domain-index linkage (#1342)

### DIFF
--- a/internal/adapter/smb/rpc/lsarpc_test.go
+++ b/internal/adapter/smb/rpc/lsarpc_test.go
@@ -1305,6 +1305,19 @@ func TestLSARPC_LookupSids3_Opnum76_RoundTrip(t *testing.T) {
 	if res.mappedCount != 2 {
 		t.Errorf("mappedCount = %d, want 2", res.mappedCount)
 	}
+
+	// The opnum-76 EX entry must link name[0] to its referenced domain via a
+	// valid DomainIndex (default machine domain "DITTOFS"). A wrong index here
+	// is what makes a client render a bare "bob" instead of "DITTOFS\bob" — the
+	// EX-path domain-linkage regression behind #1342/#1343. (57 and 76 share the
+	// builder, so this also covers the Windows Explorer opnum-57 path.)
+	di := res.names[0].domainIdx
+	if di < 0 || int(di) >= len(res.domains) {
+		t.Fatalf("name[0] domainIdx %d out of range (domains=%v)", di, res.domains)
+	}
+	if res.domains[di] != "DITTOFS" {
+		t.Errorf("name[0] -> domain %q, want DITTOFS", res.domains[di])
+	}
 }
 
 // TestLSARPC_LookupSids_PerOpnumLayout_ByteDiff proves the per-opnum layout


### PR DESCRIPTION
## #1342 — verified fixed, regression hardened

**Live verification** (demo, `dev-c08780bb`): `rpcclient lookupsids3` on alice's SID `S-1-5-21-…-21002` no longer faults — the `NT_STATUS_ARRAY_BOUNDS_EXCEEDED` of #1342 is **gone** and the name resolves (`alice (1)`). The framing fix landed in the #1341 NDR off-by-one work (un-terminated conformant+varying arrays); opnum 76 shares the response builder with opnum 57.

**This PR** hardens the opnum-76 regression test: it now asserts the EX translated-name entry links to its referenced domain via a valid `DomainIndex` (default machine domain `DITTOFS`). A wrong index is exactly what makes a client render a bare `bob` instead of `DITTOFS\bob` — the EX-path domain-linkage class behind #1342/#1343. Since opnum 57 (Windows Explorer) and 76 share the builder, locking 76 also covers 57.

Reviewed by code-simplifier (no changes — block already idiomatic) and code-reviewer (no issues — assertion correct, no out-of-range risk, tests what it claims).

Closes #1342.

> Note: rpcclient's `lookupsids3` prints the bare name (`alice`) where `lookupsids` prints `DITTOFS\alice` — that is an rpcclient display difference, not a wire bug. `TestLookupSids_MixedBatch_MultiDomain` + this assertion prove the EX wire carries correct `DomainIndex` → domain linkage, so real Windows Explorer (opnum 57) renders `DITTOFS\name`. The live Explorer GUI screenshot is tracked under #1297 (gated on domain-join #1350).