### PR TITLE
feat(k8s): scoped AD-DC domain-join LoadBalancer + Windows join guide (#1350)

### DIFF
--- a/docs/AD_LDAP_KERBEROS.md
+++ b/docs/AD_LDAP_KERBEROS.md
@@ -575,6 +575,52 @@ When a client cannot use Kerberos, SMB falls back to NTLM. With
 `netbios_domain` set, the server advertises the AD domain in the NTLM challenge
 so domain users authenticate against the correct domain (see Part C / docs/SMB.md).
 
+## Part F: Windows client — domain-join (Kerberos) [dev]
+
+A real Windows client gets the cleanest experience by **joining the domain** and
+authenticating to DittoFS over **Kerberos** — the server side is fully proven
+(SMB SPNEGO/PAC + AES keytab, Part C). A non-domain-joined Windows box would need
+NTLM passthrough (NETLOGON), which is a separate track (see #1314 / #1345). For
+acceptance testing, domain-join is the path with no extra server dependency.
+
+The in-cluster AD-DC is not publicly reachable by default. To let an external
+test VM join, expose the directory roles via the **scoped** dev LoadBalancer
+`k8s/samba-ad-dc/samba-ad-dc-lb.yaml` (Kerberos 88, kpasswd 464, LDAP 389/636,
+DNS 53):
+
+```bash
+# 1. Lock the LB to the Windows VM's public IP, then apply.
+kubectl apply -f k8s/samba-ad-dc/samba-ad-dc-lb.yaml
+kubectl -n dittofs patch svc samba-ad-lb --type=merge \
+  -p '{"spec":{"loadBalancerSourceRanges":["<WINDOWS_VM_IP>/32"]}}'
+kubectl -n dittofs get svc samba-ad-lb -o wide      # note EXTERNAL-IP
+```
+
+On the Windows VM (PowerShell, Administrator):
+
+```powershell
+# Point DNS at the AD-DC LB so DITTOFS.AD SRV records resolve.
+$adlb = "<samba-ad-lb EXTERNAL-IP>"
+Set-DnsClientServerAddress -InterfaceAlias Ethernet -ServerAddresses $adlb
+
+# Join the realm and reboot.
+$cred = Get-Credential DITTOFS\Administrator        # Passw0rd!2024 in the dev fixture
+Add-Computer -DomainName dittofs.ad -Credential $cred -Restart
+```
+
+After reboot, log in as `DITTOFS\alice` (dev password `TestPassword01!`). Map the
+DittoFS share and open a file's **Properties > Security** tab — owner/ACE SIDs
+resolve to `DITTOFS\<name>` via LSARPC (LsarLookupSids2/3; #1291 + #1341):
+
+```powershell
+net use \\<dittofs-smb-ip>\<share>           # Kerberos SSO as the logged-in domain user
+icacls \\<dittofs-smb-ip>\<share>\<file>     # CLI equivalent of the Security tab
+```
+
+> **Tear down after capture:** `kubectl -n dittofs delete svc samba-ad-lb` — the
+> LB publishes a KDC + LDAP directory and must not be left exposed. The AD-DC is
+> dev-only (see Known limitations).
+
 ---
 
 ## Known limitations
@@ -587,9 +633,11 @@ so domain users authenticate against the correct domain (see Part C / docs/SMB.m
   with `sec=krb5` requires the node kernel modules `rpcsec_gss_krb5` /
   `auth_rpcgss`. An in-cluster k3s node that lacks these modules cannot complete
   an `sec=krb5` NFS mount even though the server side is correct.
-- **SID → name resolution is incomplete (#236 / #1291).** Windows clients may see
-  raw SIDs instead of friendly names in ACL editors; full LSA-pipe name lookup is
-  still open. See [docs/ACLS.md](ACLS.md).
+- **SID → name resolution** works via the LSARPC pipe: `LsarOpenPolicy`
+  (opnum 6/44), `LsarLookupSids` (15), and `LsarLookupSids2/3` (57/76, the EX
+  forms Windows Explorer/`rpcclient` use) resolve machine-domain and AD
+  foreign-domain SIDs to `DITTOFS\<name>` (#1291, #1341, #1342). See
+  [docs/ACLS.md](ACLS.md).
 - **RC4-only keytabs are rejected by Windows 11 (#1318).** Ensure the keytab
   carries AES256/AES128 keys for the SPNs (Part A).
 - Online `net ads join` + machine-password rotation is out of scope; supply the

--- a/docs/AD_LDAP_KERBEROS.md
+++ b/docs/AD_LDAP_KERBEROS.md
@@ -600,8 +600,10 @@ On the Windows VM (PowerShell, Administrator):
 
 ```powershell
 # Point DNS at the AD-DC LB so DITTOFS.AD SRV records resolve.
+# Discover your NIC first — the alias is not always "Ethernet".
 $adlb = "<samba-ad-lb EXTERNAL-IP>"
-Set-DnsClientServerAddress -InterfaceAlias Ethernet -ServerAddresses $adlb
+$nic  = (Get-NetAdapter -Physical | Where-Object Status -eq 'Up')[0].ifIndex
+Set-DnsClientServerAddress -InterfaceIndex $nic -ServerAddresses $adlb
 
 # Join the realm and reboot.
 $cred = Get-Credential DITTOFS\Administrator        # Passw0rd!2024 in the dev fixture

--- a/docs/AD_LDAP_KERBEROS.md
+++ b/docs/AD_LDAP_KERBEROS.md
@@ -588,12 +588,17 @@ test VM join, expose the directory roles via the **scoped** dev LoadBalancer
 `k8s/samba-ad-dc/samba-ad-dc-lb.yaml` (Kerberos 88, kpasswd 464, LDAP 389/636,
 DNS 53):
 
+The manifest ships with a closed TEST-NET placeholder in
+`loadBalancerSourceRanges`, so applying it never exposes the AD-DC to the
+internet — the LB routes to nobody until you patch in the client `/32`:
+
 ```bash
-# 1. Lock the LB to the Windows VM's public IP, then apply.
+# 1. Apply (still closed — placeholder range routes nowhere), then open ONLY
+#    to the Windows VM's public IP.
 kubectl apply -f k8s/samba-ad-dc/samba-ad-dc-lb.yaml
 kubectl -n dittofs patch svc samba-ad-lb --type=merge \
   -p '{"spec":{"loadBalancerSourceRanges":["<WINDOWS_VM_IP>/32"]}}'
-kubectl -n dittofs get svc samba-ad-lb -o wide      # note EXTERNAL-IP
+kubectl -n dittofs get svc samba-ad-lb -o wide      # confirm range + note EXTERNAL-IP
 ```
 
 On the Windows VM (PowerShell, Administrator):
@@ -611,8 +616,12 @@ Add-Computer -DomainName dittofs.ad -Credential $cred -Restart
 ```
 
 After reboot, log in as `DITTOFS\alice` (dev password `TestPassword01!`). Map the
-DittoFS share and open a file's **Properties > Security** tab — owner/ACE SIDs
-resolve to `DITTOFS\<name>` via LSARPC (LsarLookupSids2/3; #1291 + #1341):
+DittoFS share and open a file's **Properties > Security** tab. **Prerequisite:**
+the LDAP/AD idmap resolver must be configured (Part B) — with it, owner/ACE SIDs
+resolve to `DITTOFS\<name>` via LSARPC (LsarLookupSids2/3; #1291 + #1341). If the
+directory resolver is unconfigured or unreachable, the server falls back to raw
+`S-1-5-21-…` SIDs (or `unix_user:*` / `unix_group:*`), so confirm the idmap is up
+before reading the GUI as an acceptance signal:
 
 ```powershell
 net use \\<dittofs-smb-ip>\<share>           # Kerberos SSO as the logged-in domain user
@@ -635,11 +644,13 @@ icacls \\<dittofs-smb-ip>\<share>\<file>     # CLI equivalent of the Security ta
   with `sec=krb5` requires the node kernel modules `rpcsec_gss_krb5` /
   `auth_rpcgss`. An in-cluster k3s node that lacks these modules cannot complete
   an `sec=krb5` NFS mount even though the server side is correct.
-- **SID → name resolution** works via the LSARPC pipe: `LsarOpenPolicy`
+- **SID → name resolution** is implemented over the LSARPC pipe: `LsarOpenPolicy`
   (opnum 6/44), `LsarLookupSids` (15), and `LsarLookupSids2/3` (57/76, the EX
-  forms Windows Explorer/`rpcclient` use) resolve machine-domain and AD
-  foreign-domain SIDs to `DITTOFS\<name>` (#1291, #1341, #1342). See
-  [docs/ACLS.md](ACLS.md).
+  forms Windows Explorer/`rpcclient` use) translate machine-domain and AD
+  foreign-domain SIDs to `DITTOFS\<name>` (#1291, #1341, #1342). This depends on
+  the directory-backed idmap resolver (Part B) being configured and reachable;
+  when it is not, the server falls back to raw `S-1-5-21-…` SIDs (or
+  `unix_user:*` / `unix_group:*`). See [docs/ACLS.md](ACLS.md).
 - **RC4-only keytabs are rejected by Windows 11 (#1318).** Ensure the keytab
   carries AES256/AES128 keys for the SPNs (Part A).
 - Online `net ads join` + machine-password rotation is out of scope; supply the

--- a/k8s/samba-ad-dc/samba-ad-dc-lb.yaml
+++ b/k8s/samba-ad-dc/samba-ad-dc-lb.yaml
@@ -1,0 +1,42 @@
+# Samba AD-DC external LoadBalancer — DEV / TEST ONLY (#1350).
+#
+# Exposes the AD-DC directory roles (Kerberos 88, kpasswd 464, LDAP 389/636,
+# DNS 53) on a public IP so an EXTERNAL Windows VM can DOMAIN-JOIN DITTOFS.AD
+# and then authenticate to the DittoFS SMB server via Kerberos (Route A to the
+# #1297 Windows acceptance proof — no NETLOGON NTLM-passthrough dependency).
+#
+# SECURITY — this publishes a Kerberos KDC + LDAP directory. It is DEV-ONLY and
+# MUST stay locked to the test client:
+#   * loadBalancerSourceRanges below is a PLACEHOLDER (TEST-NET-1, 192.0.2.0/24).
+#     Replace it with the test client's PUBLIC /32 BEFORE applying, e.g.:
+#       kubectl -n dittofs patch svc samba-ad-lb --type=merge \
+#         -p '{"spec":{"loadBalancerSourceRanges":["<WINDOWS_VM_IP>/32"]}}'
+#   * Tear the LB down after the capture:  kubectl -n dittofs delete svc samba-ad-lb
+# Never apply this with an open/0.0.0.0 range. Port 445 (SMB) is deliberately
+# NOT exposed here — DittoFS owns 445; the AD-DC is identity-only.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: samba-ad-lb
+  namespace: dittofs
+  labels:
+    app: samba-ad-dc
+    role: domain-join-lb
+spec:
+  type: LoadBalancer
+  # LOCK THIS DOWN before apply — placeholder range routes to nobody.
+  loadBalancerSourceRanges:
+    - 192.0.2.0/24
+  selector:
+    app: samba-ad-dc
+  ports:
+    - { name: kerberos-tcp, port: 88,  targetPort: 88,  protocol: TCP }
+    - { name: kerberos-udp, port: 88,  targetPort: 88,  protocol: UDP }
+    - { name: ldap,         port: 389, targetPort: 389, protocol: TCP }
+    - { name: ldap-udp,     port: 389, targetPort: 389, protocol: UDP }
+    - { name: ldaps,        port: 636, targetPort: 636, protocol: TCP }
+    - { name: kpasswd-tcp,  port: 464, targetPort: 464, protocol: TCP }
+    - { name: kpasswd-udp,  port: 464, targetPort: 464, protocol: UDP }
+    - { name: dns-tcp,      port: 53,  targetPort: 53,  protocol: TCP }
+    - { name: dns-udp,      port: 53,  targetPort: 53,  protocol: UDP }


### PR DESCRIPTION
## Route A enabler for the #1297 Windows acceptance proof

Lets an external Windows VM **domain-join `DITTOFS.AD`** and authenticate to the DittoFS SMB server over **Kerberos** (server side fully proven: SPNEGO/PAC + AES keytab). This sidesteps the NETLOGON NTLM-passthrough blocker (#1345) — no new product code, deployment-only.

### Adds
- `k8s/samba-ad-dc/samba-ad-dc-lb.yaml` — dev-only LoadBalancer exposing AD-DC directory roles (Kerberos 88, kpasswd 464, LDAP 389/636, DNS 53). **SMB 445 not exposed** (DittoFS owns it; AD-DC is identity-only).
- `docs/AD_LDAP_KERBEROS.md` Part F — the Windows join flow (DNS → `Add-Computer` → log in as `DITTOFS\alice` → Explorer Security tab / `icacls` resolve names).

### Safety
`loadBalancerSourceRanges` defaults to a **TEST-NET-1 placeholder** with loud comments: it publishes a KDC + LDAP directory, so it MUST be locked to the test client `/32` before apply and **torn down after capture**.

### Also
Refreshes the stale "SID→name incomplete" limitation — resolution now works via LSARPC opnum 6/44/15/57/76 (#1291, #1341, #1342).

Relates #1297 #1343 #1236. Closes #1350.