### PR TITLE
fix(smb/lsarpc): implement LsarOpenPolicy3 (opnum 130) — Windows ACL editor SID→name (#1343)

### DIFF
--- a/internal/adapter/smb/rpc/lsarpc.go
+++ b/internal/adapter/smb/rpc/lsarpc.go
@@ -34,13 +34,13 @@ var LSAInterfaceUUID = [16]byte{
 
 // LSA Operation Numbers [MS-LSAT/MS-LSAD]
 const (
-	OpLsarClose       uint16 = 0  // LsarClose
-	OpLsarOpenPolicy  uint16 = 6  // LsarOpenPolicy (legacy; smbcacls/older clients use this)
-	OpLsarOpenPolicy2 uint16 = 44 // LsarOpenPolicy2
+	OpLsarClose       uint16 = 0   // LsarClose
+	OpLsarOpenPolicy  uint16 = 6   // LsarOpenPolicy (legacy; smbcacls/older clients use this)
+	OpLsarOpenPolicy2 uint16 = 44  // LsarOpenPolicy2
 	OpLsarOpenPolicy3 uint16 = 130 // LsarOpenPolicy3 (Windows 10/11 Explorer Security tab calls this FIRST)
-	OpLsarLookupSids  uint16 = 15 // LsarLookupSids  (legacy; smbcacls/rpcclient lookupsids)
-	OpLsarLookupSids2 uint16 = 57 // LsarLookupSids2 (Windows Explorer)
-	OpLsarLookupSids3 uint16 = 76 // LsarLookupSids3 (rpcclient lookupsids3)
+	OpLsarLookupSids  uint16 = 15  // LsarLookupSids  (legacy; smbcacls/rpcclient lookupsids)
+	OpLsarLookupSids2 uint16 = 57  // LsarLookupSids2 (Windows Explorer)
+	OpLsarLookupSids3 uint16 = 76  // LsarLookupSids3 (rpcclient lookupsids3)
 )
 
 // DCE/RPC reject status codes [C706 §14.6 / MS-RPCE]. Returned in a FAULT PDU.

--- a/internal/adapter/smb/rpc/lsarpc.go
+++ b/internal/adapter/smb/rpc/lsarpc.go
@@ -37,6 +37,7 @@ const (
 	OpLsarClose       uint16 = 0  // LsarClose
 	OpLsarOpenPolicy  uint16 = 6  // LsarOpenPolicy (legacy; smbcacls/older clients use this)
 	OpLsarOpenPolicy2 uint16 = 44 // LsarOpenPolicy2
+	OpLsarOpenPolicy3 uint16 = 130 // LsarOpenPolicy3 (Windows 10/11 Explorer Security tab calls this FIRST)
 	OpLsarLookupSids  uint16 = 15 // LsarLookupSids  (legacy; smbcacls/rpcclient lookupsids)
 	OpLsarLookupSids2 uint16 = 57 // LsarLookupSids2 (Windows Explorer)
 	OpLsarLookupSids3 uint16 = 76 // LsarLookupSids3 (rpcclient lookupsids3)
@@ -202,6 +203,8 @@ func (h *LSARPCHandler) HandleRequest(req *Request) []byte {
 		return h.handleClose(req)
 	case OpLsarOpenPolicy, OpLsarOpenPolicy2:
 		return h.handleOpenPolicy(req)
+	case OpLsarOpenPolicy3:
+		return h.handleOpenPolicy3(req)
 	case OpLsarLookupSids, OpLsarLookupSids2, OpLsarLookupSids3:
 		return h.handleLookupSids(req)
 	default:
@@ -249,6 +252,46 @@ func (h *LSARPCHandler) handleOpenPolicy(req *Request) []byte {
 		StubData:    stubData,
 	}
 
+	return resp.Encode(req.Header.CallID)
+}
+
+// handleOpenPolicy3 handles LsarOpenPolicy3 (opnum 130). Windows 10/11 Explorer's
+// Security tab (aclui.dll) calls this NEWER OpenPolicy variant FIRST; if it faults
+// the ACL editor fails to resolve ACE trustee SIDs (and the file's Properties
+// dialog can hang/fail outright for an AD-owned file) even though the legacy
+// owner-field path falls back to OpenPolicy2 — exactly the #1343 raw-SID symptom.
+//
+// Per MS-LSAD 3.1.4.4.1 the response adds two out-params BEFORE the policy handle:
+//
+//	OutVersion        ULONG                       (the negotiated revision)
+//	OutRevisionInfo   LSAPR_REVISION_INFO union   switch(OutVersion):
+//	                    case 1: { ULONG Revision; ULONG SupportedFeatures }
+//	PolicyHandle      20 bytes
+//	return            NTSTATUS
+//
+// Emitting only the OpenPolicy2 layout (handle+status) would misalign the handle
+// the client reads, so the extra out-params are required.
+func (h *LSARPCHandler) handleOpenPolicy3(req *Request) []byte {
+	var buf bytes.Buffer
+	appendUint32Buf(&buf, 1) // OutVersion = 1
+	// OutRevisionInfo union, switch(OutVersion=1) -> REVISION_INFO_V1
+	appendUint32Buf(&buf, 1) // union discriminant = 1
+	appendUint32Buf(&buf, 1) // V1.Revision
+	appendUint32Buf(&buf, 0) // V1.SupportedFeatures (none advertised)
+	// Policy handle (20 bytes), non-zero to mirror handleOpenPolicy.
+	handle := make([]byte, 20)
+	handle[0] = 0x01
+	handle[4] = 0x02
+	buf.Write(handle)
+	// Return status.
+	appendUint32Buf(&buf, statusSuccess)
+
+	resp := &Response{
+		AllocHint:   uint32(buf.Len()),
+		ContextID:   req.ContextID,
+		CancelCount: 0,
+		StubData:    buf.Bytes(),
+	}
 	return resp.Encode(req.Header.CallID)
 }
 

--- a/internal/adapter/smb/rpc/lsarpc_test.go
+++ b/internal/adapter/smb/rpc/lsarpc_test.go
@@ -192,6 +192,56 @@ func TestLSARPC_OpenPolicy(t *testing.T) {
 	}
 }
 
+// TestLSARPC_OpenPolicy3 verifies LsarOpenPolicy3 (opnum 130) returns a success
+// policy handle in the OpenPolicy3 layout, not a fault. Windows 10/11 Explorer's
+// Security tab (aclui.dll) calls opnum 130 FIRST; faulting it makes the ACL editor
+// show raw SIDs and can make the file Properties dialog fail to open for an
+// AD-owned file (#1343). Verified live: real Windows then resolves DITTOFS\alice.
+func TestLSARPC_OpenPolicy3(t *testing.T) {
+	h := newTestLSAHandler()
+
+	// LsarOpenPolicy3 request stub (handler ignores its contents).
+	reqData := buildTestRequest(2, OpLsarOpenPolicy3, make([]byte, 48))
+	req, err := ParseRequest(reqData)
+	if err != nil {
+		t.Fatalf("ParseRequest: %v", err)
+	}
+
+	response := h.HandleRequest(req)
+	hdr, err := ParseHeader(response)
+	if err != nil {
+		t.Fatalf("ParseHeader: %v", err)
+	}
+	if hdr.PacketType != PDUResponse {
+		t.Fatalf("LsarOpenPolicy3 (opnum 130) returned PDU type %d, want %d (Response) — Windows shows raw SIDs / Properties fails on a fault", hdr.PacketType, PDUResponse)
+	}
+
+	// OpenPolicy3 layout: OutVersion(4) + RevisionInfo{disc(4),Revision(4),
+	// SupportedFeatures(4)} + PolicyHandle(20) + status(4) = 40-byte stub.
+	stub := response[24:]
+	if len(stub) < 40 {
+		t.Fatalf("OpenPolicy3 stub = %d bytes, want >= 40 (out-params precede the handle)", len(stub))
+	}
+	if v := binary.LittleEndian.Uint32(stub[0:4]); v != 1 {
+		t.Errorf("OutVersion = %d, want 1", v)
+	}
+	// Handle must be non-zero so the client can use it for the follow-up LookupSids.
+	handle := stub[16:36]
+	allZero := true
+	for _, b := range handle {
+		if b != 0 {
+			allZero = false
+			break
+		}
+	}
+	if allZero {
+		t.Error("OpenPolicy3 returned a zero policy handle")
+	}
+	if status := binary.LittleEndian.Uint32(stub[36:40]); status != statusSuccess {
+		t.Errorf("OpenPolicy3 status = 0x%08x, want 0x%08x (success)", status, statusSuccess)
+	}
+}
+
 func TestLSARPC_Close(t *testing.T) {
 	h := newTestLSAHandler()
 


### PR DESCRIPTION
## Windows Explorer Security tab showed raw SID + Properties dialog failed for AD-owned files

**Root cause:** Windows 10/11 Explorer's Security tab (`aclui.dll`) calls **`LsarOpenPolicy3` (opnum 130)** FIRST when resolving ACE trustee SIDs. DittoFS faulted it (`nca_s_op_rng_error`). The legacy owner-field path falls back to `OpenPolicy2`+`LookupSids2` (so the Details→Owner field resolved `DITTOFS\alice`), but the **ACL-editor list does not fall back** → raw `S-1-5-21-…` SID, and the **Properties dialog failed to open entirely** for an AD-owned file. Same class as the opnum-6 gap fixed in #1291.

## Fix
Route opnum 130 to a new `handleOpenPolicy3` returning a valid policy handle in the MS-LSAD 3.1.4.4.1 layout — two out-params precede the 20-byte handle so the client reads it at the right offset:
```
OutVersion(uint32=1) + RevisionInfo_V1{disc=1, Revision=1, SupportedFeatures=0} + PolicyHandle(20) + NTSTATUS
```

## Verified live on real Windows 11
Demo `dev-06f66c02`. The `alice-smb.txt` Properties dialog opens, and the **Security tab shows `alice (DITTOFS\alice)`** (resolved), not the raw SID. Server: opnum 130 → success → 44 → 57 → resolved.

> The real-Explorer GUI test was essential: `LookupAccountSid(server,sid)` / `rpcclient` use OpenPolicy2 and resolved fine; only the Security tab hits the OpenPolicy3 path.

Reviewed by code-simplifier (clean) + code-reviewer (NDR framing correct, no issues). Adds `TestLSARPC_OpenPolicy3`.

Closes #1343.