### PR TITLE
test(ad-dc): make getContainerIP work on modern Docker engines (#1345)

### DIFF
--- a/test/integration/ad-dc/netlogon_passthrough_test.go
+++ b/test/integration/ad-dc/netlogon_passthrough_test.go
@@ -4,7 +4,6 @@ package ad_dc_test
 
 import (
 	"context"
-	"encoding/json"
 	"net"
 	"os/exec"
 	"strings"
@@ -32,25 +31,19 @@ const (
 // (it does not skip) — run this only in CI (Linux) or inside a Linux VM.
 func getContainerIP(t *testing.T) string {
 	t.Helper()
+	// Newer Docker engines drop the legacy top-level .NetworkSettings.IPAddress
+	// field, so a {{json .NetworkSettings.IPAddress}} template errors out; use the
+	// per-network Networks map, which is populated on the default bridge on both
+	// old and new engines. In CI (Linux) this bridge IP is host-reachable, which
+	// NETLOGON requires (EPM port 135 + the dynamic RPC port, no NAT).
 	out, err := exec.Command("docker", "inspect",
-		"--format", "{{json .NetworkSettings.IPAddress}}",
+		"--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}",
 		adContainerName,
 	).Output()
 	if err != nil {
-		t.Fatalf("docker inspect container IP: %v", err)
+		t.Fatalf("docker inspect network IP: %v", err)
 	}
-	var ip string
-	if err := json.Unmarshal([]byte(strings.TrimSpace(string(out))), &ip); err != nil || ip == "" {
-		// Try Networks map (newer Docker / custom network).
-		out2, err := exec.Command("docker", "inspect",
-			"--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}",
-			adContainerName,
-		).Output()
-		if err != nil {
-			t.Fatalf("docker inspect network IP: %v", err)
-		}
-		ip = strings.TrimSpace(string(out2))
-	}
+	ip := strings.TrimSpace(string(out))
 	if ip == "" {
 		t.Fatal("could not determine container IP address from docker inspect")
 	}

--- a/test/integration/ad-dc/netlogon_passthrough_test.go
+++ b/test/integration/ad-dc/netlogon_passthrough_test.go
@@ -36,18 +36,23 @@ func getContainerIP(t *testing.T) string {
 	// per-network Networks map, which is populated on the default bridge on both
 	// old and new engines. In CI (Linux) this bridge IP is host-reachable, which
 	// NETLOGON requires (EPM port 135 + the dynamic RPC port, no NAT).
+	// Emit one IP per line so multiple attached networks don't concatenate into
+	// a single invalid address; the AD-DC fixture uses only the default bridge,
+	// so the first non-empty line is the bridge IP we want.
 	out, err := exec.Command("docker", "inspect",
-		"--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}",
+		"--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}\n{{end}}",
 		adContainerName,
 	).Output()
 	if err != nil {
 		t.Fatalf("docker inspect network IP: %v", err)
 	}
-	ip := strings.TrimSpace(string(out))
-	if ip == "" {
-		t.Fatal("could not determine container IP address from docker inspect")
+	for _, line := range strings.Split(string(out), "\n") {
+		if ip := strings.TrimSpace(line); ip != "" {
+			return ip
+		}
 	}
-	return ip
+	t.Fatal("could not determine container IP address from docker inspect")
+	return ""
 }
 
 // TestNetlogonPassthroughAlice validates the full NETLOGON passthrough path:


### PR DESCRIPTION
## What

The `ad_dc` NETLOGON integration tests (`TestNetlogonPassthroughAlice`) failed at infrastructure setup with:

```
netlogon_passthrough_test.go: docker inspect container IP: exit status 1
```

Newer Docker engines drop the legacy top-level `.NetworkSettings.IPAddress` field, so the `{{json .NetworkSettings.IPAddress}}` template errors (exit 1). `getContainerIP` bailed on that first error via `t.Fatalf` instead of falling through to the `.NetworkSettings.Networks` map — so the test died before ever reaching the secure channel under test.

## Fix

Use the `.NetworkSettings.Networks` form directly. It's populated on the default bridge on both old and new engines.

## Verification

Ran live against a real Samba AD-DC (golang container, host network, native amd64). `getContainerIP` now resolves `172.17.0.2` and the test proceeds all the way to the NETLOGON transport bind — unblocking the harness for the remaining schannel interop work (#1345).

This is the test-infra fix only; it does **not** resolve the underlying go-msrpc↔Samba schannel interop (see #1345 for the two confirmed transport failure modes). The tests remain `t.Skip`-gated on #1345.

Refs #1345