### PR TITLE
feat(nfs): NFSv3 file locking — NLM v1/v3 + NLM/NSM over UDP (#1353)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Two binaries drive it:
 
 | Area | Status |
 |------|--------|
-| **NFSv3** | All 28 core procedures; embedded portmapper + mount protocol |
+| **NFSv3** | All 28 core procedures; embedded portmapper + mount protocol; NLM/NSM byte-range locking over TCP+UDP (opt-in) |
 | **NFSv4.0** | Compound ops, ACLs, delegations, built-in byte-range locking |
 | **NFSv4.1** | Sessions, sequence slots, backchannel |
 | **SMB 2.0.2 / 3.0 / 3.0.2 / 3.1.1** | Multi-dialect negotiation, preauth integrity, compound requests |

--- a/cmd/dfsctl/commands/adapter/settings.go
+++ b/cmd/dfsctl/commands/adapter/settings.go
@@ -185,6 +185,7 @@ var (
 	settingsBlockedOperations          string
 	settingsPortmapperEnabled          bool
 	settingsPortmapperPort             int
+	settingsUDPEnabled                 bool
 	settingsV4MinMinorVersion          int
 	settingsV4MaxMinorVersion          int
 	settingsV4MaxConnectionsPerSession int
@@ -259,6 +260,7 @@ func registerNFSUpdateFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&settingsBlockedOperations, "blocked-operations", "", "Comma-separated list of blocked operations")
 	cmd.Flags().BoolVar(&settingsPortmapperEnabled, "portmapper-enabled", false, "Enable embedded portmapper")
 	cmd.Flags().IntVar(&settingsPortmapperPort, "portmapper-port", 0, "Portmapper listen port")
+	cmd.Flags().BoolVar(&settingsUDPEnabled, "udp-enabled", false, "Serve NLM/NSM/MOUNT over UDP (needed for NFSv3 locking from macOS/BSD; restart to apply)")
 	cmd.Flags().IntVar(&settingsV4MinMinorVersion, "v4-min-minor-version", 0, "Minimum NFSv4 minor version (0=v4.0, 1=v4.1)")
 	cmd.Flags().IntVar(&settingsV4MaxMinorVersion, "v4-max-minor-version", 0, "Maximum NFSv4 minor version (0=v4.0, 1=v4.1)")
 	cmd.Flags().IntVar(&settingsV4MaxConnectionsPerSession, "v4-max-connections-per-session", 0, "Maximum connections per NFSv4.1 session (0=unlimited)")
@@ -351,6 +353,7 @@ func showNFSSettings(client *apiclient.Client, format output.Format) error {
 	printSettingsGroup("Portmapper", []settingRow{
 		newSettingRowBool("portmapper_enabled", settings.PortmapperEnabled, d.PortmapperEnabled),
 		newSettingRowInt("portmapper_port", settings.PortmapperPort, d.PortmapperPort, ""),
+		newSettingRowBool("udp_enabled", settings.UDPEnabled, d.UDPEnabled),
 	})
 	printSettingsGroup("Operations", []settingRow{
 		newSettingRowStrSlice("blocked_operations", settings.BlockedOperations, d.BlockedOperations),
@@ -568,6 +571,10 @@ func updateNFSSettings(cmd *cobra.Command, client *apiclient.Client) error {
 	}
 	if cmd.Flags().Changed("portmapper-port") {
 		req.PortmapperPort = &settingsPortmapperPort
+		hasChanges = true
+	}
+	if cmd.Flags().Changed("udp-enabled") {
+		req.UDPEnabled = &settingsUDPEnabled
 		hasChanges = true
 	}
 	if cmd.Flags().Changed("v4-min-minor-version") {

--- a/cmd/dfsctl/commands/share/mount.go
+++ b/cmd/dfsctl/commands/share/mount.go
@@ -19,11 +19,12 @@ const (
 )
 
 var (
-	mountProtocol string
-	mountUsername string
-	mountPassword string
-	mountFileMode string
-	mountDirMode  string
+	mountProtocol   string
+	mountUsername   string
+	mountPassword   string
+	mountFileMode   string
+	mountDirMode    string
+	mountNFSVersion string
 )
 
 var mountCmd = &cobra.Command{
@@ -78,6 +79,7 @@ func init() {
 	mountCmd.Flags().StringVarP(&mountProtocol, "protocol", "p", "", "Protocol to use (nfs or smb) (required)")
 	mountCmd.Flags().StringVarP(&mountUsername, "username", "u", "", "Username for SMB mount (defaults to login username)")
 	mountCmd.Flags().StringVarP(&mountPassword, "password", "P", "", "Password for SMB mount (will prompt if not provided)")
+	mountCmd.Flags().StringVar(&mountNFSVersion, "nfs-version", "3", "NFS protocol version for NFS mounts (3, 4, 4.0, 4.1, 4.2). v4 carries locking in-protocol; v3 locking needs the server UDP transport + portmapper")
 	mountCmd.Flags().StringVar(&mountFileMode, "file-mode", defaultMode, modeHelp)
 	mountCmd.Flags().StringVar(&mountDirMode, "dir-mode", defaultMode, "Directory permissions for SMB mount (octal)")
 
@@ -120,7 +122,7 @@ func runMount(cmd *cobra.Command, args []string) error {
 
 	switch protocol {
 	case "nfs":
-		return mountNFS(sharePath, mountPoint, adapters, serverHost)
+		return mountNFS(sharePath, mountPoint, adapters, serverHost, mountNFSVersion)
 	default:
 		return mountSMB(sharePath, mountPoint, adapters, serverHost)
 	}

--- a/cmd/dfsctl/commands/share/mount_unix.go
+++ b/cmd/dfsctl/commands/share/mount_unix.go
@@ -89,17 +89,9 @@ func validateMountPoint(mountPoint string) error {
 	return nil
 }
 
-func mountNFS(sharePath, mountPoint string, adapters []apiclient.Adapter, serverHost string) error {
+func mountNFS(sharePath, mountPoint string, adapters []apiclient.Adapter, serverHost, nfsVersion string) error {
 	port := getAdapterPort(adapters, "nfs", defaultNFSPort)
-
-	// actimeo=0 disables attribute caching for immediate visibility of changes
-	mountOptions := fmt.Sprintf("nfsvers=3,tcp,port=%d,mountport=%d,actimeo=0", port, port)
-
-	if runtime.GOOS == "darwin" {
-		mountOptions += ",resvport"
-	} else {
-		mountOptions += ",nolock"
-	}
+	mountOptions := buildNFSMountOptions(nfsVersion, port)
 
 	source := fmt.Sprintf("%s:%s", serverHost, sharePath)
 	cmd := exec.Command("mount", "-t", "nfs", "-o", mountOptions, source, mountPoint)
@@ -109,8 +101,45 @@ func mountNFS(sharePath, mountPoint string, adapters []apiclient.Adapter, server
 		return formatMountError(err, string(output), "NFS", port)
 	}
 
-	fmt.Printf("Mounted %s at %s (NFS)\n", sharePath, mountPoint)
+	fmt.Printf("Mounted %s at %s (NFS%s)\n", sharePath, mountPoint, nfsVersionSuffix(nfsVersion))
 	return nil
+}
+
+// buildNFSMountOptions returns the `-o` option string for the requested NFS
+// version. actimeo=0 disables attribute caching for immediate visibility.
+//
+// NFSv3 needs an explicit mountport (the separate MOUNT protocol) and, on Linux,
+// nolock — NFSv3 file locking uses the NLM side protocol, which requires the
+// server's UDP transport and a portmapper reachable on port 111 (issue #1353).
+// NFSv4 carries locking in-protocol and has no MOUNT protocol, so it omits
+// mountport and never needs nolock.
+func buildNFSMountOptions(nfsVersion string, port int) string {
+	darwin := runtime.GOOS == "darwin"
+
+	if strings.HasPrefix(nfsVersion, "4") {
+		opts := fmt.Sprintf("nfsvers=%s,tcp,port=%d,actimeo=0", nfsVersion, port)
+		if darwin {
+			opts += ",resvport"
+		}
+		return opts
+	}
+
+	// NFSv3 (default).
+	opts := fmt.Sprintf("nfsvers=3,tcp,port=%d,mountport=%d,actimeo=0", port, port)
+	if darwin {
+		opts += ",resvport"
+	} else {
+		opts += ",nolock"
+	}
+	return opts
+}
+
+// nfsVersionSuffix renders the version for the success message, e.g. "v4.1".
+func nfsVersionSuffix(nfsVersion string) string {
+	if nfsVersion == "" {
+		return "v3"
+	}
+	return "v" + nfsVersion
 }
 
 func mountSMB(sharePath, mountPoint string, adapters []apiclient.Adapter, serverHost string) error {

--- a/cmd/dfsctl/commands/share/mount_windows.go
+++ b/cmd/dfsctl/commands/share/mount_windows.go
@@ -50,7 +50,11 @@ func checkMountPrivileges(mountPoint, protocol, sharePath string) error {
 	return nil
 }
 
-func mountNFS(sharePath, mountPoint string, adapters []apiclient.Adapter, serverHost string) error {
+func mountNFS(sharePath, mountPoint string, adapters []apiclient.Adapter, serverHost, nfsVersion string) error {
+	// The built-in Windows 'Client for NFS' speaks NFSv3 only; the requested
+	// version is accepted for signature parity with the Unix implementation but
+	// does not change the Windows mount invocation.
+	_ = nfsVersion
 	port := getAdapterPort(adapters, "nfs", defaultNFSPort)
 
 	// The Windows NFS mount command does NOT support specifying a custom port via -o options.

--- a/cmd/dfsctl/commands/share/mount_windows_test.go
+++ b/cmd/dfsctl/commands/share/mount_windows_test.go
@@ -95,7 +95,7 @@ func TestMountNFS_RejectsNonStandardPort(t *testing.T) {
 		{Type: "nfs", Port: 12049, Enabled: true},
 	}
 
-	err := mountNFS("/export", "Z:", adapters, "localhost")
+	err := mountNFS("/export", "Z:", adapters, "localhost", "3")
 	if err == nil {
 		t.Fatal("mountNFS() expected error for non-standard port, got nil")
 	}
@@ -116,7 +116,7 @@ func TestMountNFS_AcceptsStandardPort(t *testing.T) {
 		{Type: "nfs", Port: 2049, Enabled: true},
 	}
 
-	err := mountNFS("/export", "Z:", adapters, "localhost")
+	err := mountNFS("/export", "Z:", adapters, "localhost", "3")
 	// The mount will likely fail because there is no NFS server running,
 	// but the error should NOT be about port validation.
 	if err != nil {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1085,6 +1085,7 @@ Flags:
       --portmapper-enabled                   Enable embedded portmapper
       --portmapper-port int                  Portmapper listen port
       --preferred-transfer-size int          Preferred transfer size in bytes
+      --udp-enabled                          Serve NLM/NSM/MOUNT over UDP (needed for NFSv3 locking from macOS/BSD; restart to apply)
       --v4-max-connections-per-session int   Maximum connections per NFSv4.1 session (0=unlimited)
       --v4-max-minor-version int             Maximum NFSv4 minor version (0=v4.0, 1=v4.1)
       --v4-min-minor-version int             Minimum NFSv4 minor version (0=v4.0, 1=v4.1)
@@ -3851,11 +3852,12 @@ dfsctl share mount [share] [mountpoint] [flags]
 Flags:
 
 ```
-      --dir-mode string    Directory permissions for SMB mount (octal) (default "0777")
-      --file-mode string   File permissions for SMB mount (octal, default 0777 on macOS since uid/gid not supported) (default "0777")
-  -P, --password string    Password for SMB mount (will prompt if not provided)
-  -p, --protocol string    Protocol to use (nfs or smb) (required)
-  -u, --username string    Username for SMB mount (defaults to login username)
+      --dir-mode string      Directory permissions for SMB mount (octal) (default "0777")
+      --file-mode string     File permissions for SMB mount (octal, default 0777 on macOS since uid/gid not supported) (default "0777")
+      --nfs-version string   NFS protocol version for NFS mounts (3, 4, 4.0, 4.1, 4.2). v4 carries locking in-protocol; v3 locking needs the server UDP transport + portmapper (default "3")
+  -P, --password string      Password for SMB mount (will prompt if not provided)
+  -p, --protocol string      Protocol to use (nfs or smb) (required)
+  -u, --username string      Username for SMB mount (defaults to login username)
 ```
 
 Global flags:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1115,6 +1115,20 @@ adapters:
 
     metrics_log_interval: 5m     # Metrics logging interval (0 = disabled)
 
+    # Embedded portmapper (RFC 1057) for service discovery. Disabled by default.
+    # macOS/BSD NFSv3 lock clients query the portmapper on port 111 — bind it
+    # there (requires root / CAP_NET_BIND_SERVICE) for NFSv3 locking to work.
+    portmapper:
+      enabled: false             # Default: false
+      port: 10111                # Default: 10111 (set to 111 for macOS locking)
+
+    # UDP transport for the lock-manager protocols. Serves NLM/NSM/MOUNT over
+    # UDP (in addition to TCP) on the NFS port. Required for NFSv3 file locking
+    # from BSD/macOS clients (see docs/NFS.md). Disabled by default. NFS data
+    # operations are never served over UDP.
+    udp:
+      enabled: false             # Default: false
+
     # Optional: override server-level rate limiting for this adapter
     # rate_limiting:
     #   enabled: true
@@ -2063,6 +2077,11 @@ export DITTOFS_METADATA_TYPE=badger
 export DITTOFS_ADAPTERS_NFS_ENABLED=true
 export DITTOFS_ADAPTERS_NFS_PORT=12049
 export DITTOFS_ADAPTERS_NFS_MAX_CONNECTIONS=1000
+
+# NFSv3 locking (NLM/NSM) — opt-in; see docs/NFS.md
+export DITTOFS_ADAPTERS_NFS_UDP_ENABLED=false        # serve NLM/NSM/MOUNT over UDP
+export DITTOFS_ADAPTERS_NFS_PORTMAPPER_ENABLED=false # enable embedded portmapper
+export DITTOFS_ADAPTERS_NFS_PORTMAPPER_PORT=10111    # set to 111 for macOS locking
 
 # NFS timeouts
 export DITTOFS_ADAPTERS_NFS_TIMEOUTS_READ=5m

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -57,7 +57,26 @@ DittoFS supports **NFSv3 over TCP** (28 procedures fully implemented), **NFSv4.0
 
 ### Does it support file locking?
 
-NFSv3 does not include locking (NLM not implemented). However, NFSv4 provides built-in file locking support. SMB2 supports byte-range locking (shared and exclusive).
+Yes. **NFSv4** provides built-in (in-protocol) file locking — nothing extra to
+enable, and the recommended path. **SMB2** supports byte-range locking (shared
+and exclusive).
+
+**NFSv3** locking uses the separate NLM (Network Lock Manager) side protocol.
+DittoFS implements NLM (v1/v3 with 32-bit offsets, v4 with 64-bit) and NSM, over
+both TCP and UDP. Because BSD/macOS lock clients (`rpc.lockd`/`rpc.statd`) reach
+NLM/NSM over **UDP** and discover it via the standard portmapper on **port 111**,
+NFSv3 locking from those clients requires two opt-in settings on the server:
+
+- enable the UDP transport: `dfsctl adapter settings nfs update --udp-enabled true`
+- enable the portmapper, reachable on **port 111**: `dfsctl adapter settings nfs
+  update --portmapper-enabled true --portmapper-port 111` (binding 111 needs root
+  / `NET_BIND_SERVICE`; on Kubernetes the operator exposes it via the Service)
+
+then restart the adapter. Both are **disabled by default**. Note that NFSv3
+**mount and read/write work without any of this** — only NLM locking needs it.
+If you don't need cross-client locking, mount with `-o nolock`, or prefer
+`-o vers=4` (`dfsctl share mount --nfs-version 4.1`) to get locking in-protocol
+with no NLM/portmapper setup. See [NFS.md](NFS.md#nfsv3-file-locking-nlmnsm).
 
 ### Does it support Kerberos authentication?
 
@@ -565,10 +584,18 @@ NFSv3's `nfstime3` structure uses a 32-bit unsigned integer for seconds since Un
 
 | Status | Reason |
 |--------|--------|
-| NFSv3: Not implemented | NLM protocol not implemented |
-| NFSv4: Supported | Built-in locking |
+| NFSv3: Supported (opt-in) | NLM/NSM over TCP+UDP; needs `--udp-enabled` and a portmapper on port 111 for BSD/macOS clients |
+| NFSv4: Supported | Built-in (in-protocol) locking, no setup |
 
-NFSv3 relies on the NLM (Network Lock Manager) protocol for locking, which is not implemented. NFSv4 has built-in locking support.
+NFSv3 mount and read/write work with no extra configuration. Only NLM byte-range
+locking needs the UDP transport plus a portmapper reachable on port 111 — see
+[Does it support file locking?](#does-it-support-file-locking) above. NFSv4 is
+the simplest path: locking is in-protocol.
+
+NFSv3 relies on the NLM (Network Lock Manager) side protocol for locking. DittoFS
+implements NLM (v1/v3/v4) and NSM over TCP and UDP, but they are opt-in: enable
+`--udp-enabled` and a portmapper on port 111 for BSD/macOS clients (see above).
+NFSv4 has built-in locking support with no setup.
 
 #### Extended Attributes
 
@@ -651,9 +678,9 @@ This pass rate applies to **all metadata backends** (Memory, BadgerDB, PostgreSQ
 |--------------|--------|
 | `utimensat/09.t:test5` | NFSv3 32-bit timestamp limit (max year 2106) |
 | `open::etxtbsy` | NFS protocol limitation (not testable) |
-| `flock/*` | NLM not implemented (NFSv3 only) |
-| `fcntl/lock*` | NLM not implemented (NFSv3 only) |
-| `lockf/*` | NLM not implemented (NFSv3 only) |
+| `flock/*` | NFSv3 NLM locking is opt-in (`--udp-enabled` + portmapper on 111); use `vers=4` |
+| `fcntl/lock*` | NFSv3 NLM locking is opt-in (`--udp-enabled` + portmapper on 111); use `vers=4` |
+| `lockf/*` | NFSv3 NLM locking is opt-in (`--udp-enabled` + portmapper on 111); use `vers=4` |
 | `xattr/*`, `*xattr/*` | Not in NFSv3 |
 | `fallocate/*` | No ALLOCATE in NFSv3 |
 | `chflags/*` | BSD-specific |

--- a/docs/NFS.md
+++ b/docs/NFS.md
@@ -21,6 +21,7 @@ This document covers the NFS protocol fundamentals, DittoFS's implementation of 
   - [NFSv4.1 Status](#nfsv41-status)
   - [NFSv4.2 Status](#nfsv42-status)
 - [Embedded Portmapper](#embedded-portmapper)
+- [NFSv3 file locking (NLM/NSM)](#nfsv3-file-locking-nlmnsm)
 - [Mounting](#mounting)
 - [Implementation Details](#implementation-details)
   - [Code Structure](#code-structure)
@@ -626,7 +627,7 @@ setfattr -x user.comment /mnt/dittofs/file      # remove
 
 ## Embedded Portmapper
 
-DittoFS includes an embedded portmapper (RFC 1057) that enables standard NFS service discovery without requiring a system-level `rpcbind` daemon.
+DittoFS includes an embedded portmapper that enables standard NFS service discovery without requiring a system-level `rpcbind` daemon. It answers both legacy **PMAP v2** (RFC 1057, used by `rpcinfo -p` and Linux) and **RPCBIND v3/v4** (RFC 1833 universal addresses, used by macOS/BSD lock clients).
 
 ### Why an Embedded Portmapper?
 
@@ -685,6 +686,94 @@ The embedded portmapper follows standard security practices:
 ### Portmapper Failure is Non-Fatal
 
 If the portmapper fails to start (e.g., port already in use), NFS continues to operate normally. Clients just need to specify ports explicitly in mount options.
+
+---
+
+## NFSv3 file locking (NLM/NSM)
+
+NFSv3 has no in-protocol locking; byte-range locks travel over the separate
+**NLM** (Network Lock Manager) protocol, with crash recovery coordinated by
+**NSM** (Network Status Monitor). NFSv4 does not use NLM — its locking is
+in-protocol, so none of this section applies to `vers=4` mounts.
+
+> NFSv3 **mount and read/write need none of this.** Only byte-range locking
+> (`flock`/`fcntl`/`lockf`) uses NLM. If you don't need cross-client locks,
+> mount `-o nolock`, or use `-o vers=4` for in-protocol locking.
+
+### What DittoFS serves
+
+- **NLM** (program 100021) versions **1 and 3** (32-bit offsets) and **4**
+  (64-bit offsets), including the **asynchronous `*_MSG`/`*_RES` procedures**
+  (TEST/LOCK/CANCEL/UNLOCK_MSG → `*_RES` callbacks) that macOS/BSD `lockd` use,
+  alongside the synchronous procedures Linux uses.
+- **NSM** (program 100024) version 1, for crash-recovery monitoring (SM_MON /
+  SM_NOTIFY). The SM_NOTIFY callback target is the request's transport source,
+  not the client-supplied `my_name`.
+- **Portmapper** speaking both legacy **PMAP v2** (RFC 1057) and **RPCBIND
+  v3/v4** (RFC 1833, universal addresses) — macOS/BSD `lockd` discover NLM via
+  RPCBIND v3/v4 and do not fall back to v2.
+- All of the above over **TCP and UDP**. NFS data (program 100003) is
+  **TCP-only** — it is never served over UDP (READ/WRITE payloads exceed a UDP
+  datagram).
+
+> **Status:** the full protocol chain (RPCBIND v3/v4 discovery → NSM monitoring
+> → async NLM locking with reserved-port `*_RES` callbacks) is implemented and
+> unit-tested. End-to-end acceptance against a live macOS client is validated on
+> a same-LAN topology (a same-host loopback test is unreliable: the client and
+> server contend for port 111 and a shared `lockd`/`statd`).
+
+### Why macOS NFSv3 locking needs extra setup
+
+A macOS/BSD lock client (`rpc.lockd` / `rpc.statd`) reaches NLM/NSM over **UDP**
+and discovers them by querying the **server's portmapper on port 111** — there is
+no mount option to redirect that lookup. So two server-side pieces, both
+**disabled by default**, are required:
+
+1. **UDP transport** — serve NLM/NSM/MOUNT over UDP:
+   ```bash
+   dfsctl adapter settings nfs update --udp-enabled true
+   ```
+2. **Portmapper on port 111** — so the client's discovery query resolves:
+   ```bash
+   dfsctl adapter settings nfs update --portmapper-enabled true --portmapper-port 111
+   ```
+   Binding 111 needs root or `CAP_NET_BIND_SERVICE`, and may clash with a host
+   `rpcbind`. On Kubernetes the operator exposes port 111 via the adapter Service
+   (mapped to the unprivileged container port), so no privileged binding is needed
+   in the pod.
+
+Restart the adapter after changing these settings. Linux clients (NLM v4) work
+once the portmapper is reachable; they do not strictly require UDP, but enabling
+it is harmless.
+
+Equivalent config-file / env settings:
+
+```yaml
+adapters:
+  nfs:
+    udp:
+      enabled: true
+    portmapper:
+      enabled: true
+      port: 111
+```
+
+```bash
+DITTOFS_ADAPTERS_NFS_UDP_ENABLED=true
+DITTOFS_ADAPTERS_NFS_PORTMAPPER_ENABLED=true
+DITTOFS_ADAPTERS_NFS_PORTMAPPER_PORT=111
+```
+
+### Recommended: just use NFSv4
+
+For locking without any of the above, mount with `vers=4` — locking is part of
+the protocol, and there is no NLM, NSM, MOUNT, or portmapper to configure:
+
+```bash
+dfsctl share mount /my-share /mnt/point --protocol nfs --nfs-version 4.1
+# or directly:
+mount -t nfs -o vers=4.1,port=12049 server:/my-share /mnt/point
+```
 
 ---
 

--- a/internal/adapter/nfs/nlm/callback/client.go
+++ b/internal/adapter/nfs/nlm/callback/client.go
@@ -89,9 +89,10 @@ func SendGrantedCallback(
 		}
 	}
 
-	// Encode NLM_GRANTED args
+	// Encode NLM_GRANTED args. The byte-range offset width must match the
+	// client's negotiated NLM version (32-bit for v1/v3, 64-bit for v4).
 	var argsBuf bytes.Buffer
-	if err := nlm_xdr.EncodeNLM4GrantedArgs(&argsBuf, args); err != nil {
+	if err := nlm_xdr.EncodeNLM4GrantedArgs(&argsBuf, args, types.IsWideVersion(vers)); err != nil {
 		return fmt.Errorf("encode granted args: %w", err)
 	}
 

--- a/internal/adapter/nfs/nlm/callback/client.go
+++ b/internal/adapter/nfs/nlm/callback/client.go
@@ -120,6 +120,25 @@ func SendGrantedCallback(
 	return nil
 }
 
+// BuildNLMResultMessage builds the RPC CALL datagram for an asynchronous NLM
+// *_RES callback (TEST_RES, LOCK_RES, CANCEL_RES, UNLOCK_RES) that a client
+// issuing the async *_MSG procedures (macOS/BSD lockd) expects in return.
+//
+// The datagram has NO record mark (UDP framing: one datagram is one message)
+// and MUST be sent from the server's NLM listening socket — lockd talks to the
+// server's nlockmgr over a connected UDP socket and the kernel drops any reply
+// that does not originate from that exact peer address, so a freshly-dialled
+// socket (different source port) would be silently discarded. The transport
+// therefore sends this via its existing listener; this function only encodes.
+func BuildNLMResultMessage(prog, vers, proc uint32, body []byte) ([]byte, error) {
+	xid := uint32(time.Now().UnixNano() & 0xFFFFFFFF)
+	callMsg, err := buildRPCCallMessage(xid, prog, vers, proc, body)
+	if err != nil {
+		return nil, fmt.Errorf("build NLM result message: %w", err)
+	}
+	return callMsg, nil
+}
+
 // validateCallbackAddr rejects callback destinations that are unsafe to dial.
 //
 // The host must be a literal IP (callback addresses are always built from the

--- a/internal/adapter/nfs/nlm/callback/granted.go
+++ b/internal/adapter/nfs/nlm/callback/granted.go
@@ -50,7 +50,7 @@ func ProcessGrantedCallback(
 	// than a stale or hardcoded port. If resolution fails the grant cannot be
 	// delivered: release the lock (same as a failed callback) so it is not
 	// orphaned, and re-drive remaining waiters via the normal release hook.
-	addr, err := callbackAddrResolver(ctx, waiter.CallbackHost)
+	addr, err := callbackAddrResolver(ctx, waiter.CallbackHost, waiter.CallbackVers)
 	if err != nil {
 		logger.Warn("NLM_GRANTED: cannot resolve client callback address, releasing lock",
 			"host", waiter.CallbackHost,
@@ -117,7 +117,7 @@ var callbackAddrResolver = resolveCallbackAddr
 // SetCallbackAddrResolver overrides how a client source host is resolved to a
 // dialable NLM callback address. It returns a restore func. Intended for tests
 // that need a deterministic callback target without a portmap round-trip.
-func SetCallbackAddrResolver(fn func(ctx context.Context, host string) (string, error)) (restore func()) {
+func SetCallbackAddrResolver(fn func(ctx context.Context, host string, vers uint32) (string, error)) (restore func()) {
 	prev := callbackAddrResolver
 	callbackAddrResolver = fn
 	return func() { callbackAddrResolver = prev }
@@ -127,9 +127,11 @@ func SetCallbackAddrResolver(fn func(ctx context.Context, host string) (string, 
 // "host:port" address by querying the client's portmapper for its registered
 // NLM (lockd) port. The host is always the request's transport source, never a
 // client-supplied wire field, so the callback can only ever target the host
-// that issued the lock.
-func resolveCallbackAddr(ctx context.Context, host string) (string, error) {
-	port, err := ResolveNLMCallbackPort(ctx, host, types.ProgramNLM, types.NLMVersion4)
+// that issued the lock. The portmap GETPORT must use the version the client
+// negotiated: a v1/v3 client registers lockd under (100021, v1/v3), not v4, so
+// querying the wrong version returns port 0 and the blocking-lock grant is lost.
+func resolveCallbackAddr(ctx context.Context, host string, vers uint32) (string, error) {
+	port, err := ResolveNLMCallbackPort(ctx, host, types.ProgramNLM, vers)
 	if err != nil {
 		return "", err
 	}

--- a/internal/adapter/nfs/nlm/callback/granted_version_test.go
+++ b/internal/adapter/nfs/nlm/callback/granted_version_test.go
@@ -1,0 +1,50 @@
+package callback
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/blocking"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/types"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// TestProcessGrantedCallback_ResolvesWithNegotiatedVersion guards against
+// regressing the NLM_GRANTED portmap lookup to a hardcoded version. A v1/v3
+// client registers its lockd under (100021, v1/v3); querying the client's
+// portmapper for the wrong version returns port 0 and the blocking-lock grant
+// is silently lost. The version the resolver receives must be the one the
+// client negotiated (waiter.CallbackVers).
+func TestProcessGrantedCallback_ResolvesWithNegotiatedVersion(t *testing.T) {
+	for _, vers := range []uint32{types.NLMVersion1, types.NLMVersion3, types.NLMVersion4} {
+		t.Run("v"+string(rune('0'+vers)), func(t *testing.T) {
+			var gotVers uint32
+			restore := SetCallbackAddrResolver(func(_ context.Context, _ string, v uint32) (string, error) {
+				gotVers = v
+				// Return an error so we short-circuit before dialing; the
+				// version capture above is all this test needs.
+				return "", errors.New("resolve disabled in test")
+			})
+			defer restore()
+
+			lm := lock.NewManager()
+			waiter := &blocking.Waiter{
+				CallbackHost: "192.0.2.10",
+				CallbackProg: types.ProgramNLM,
+				CallbackVers: vers,
+				Lock: &lock.UnifiedLock{
+					Owner:      lock.LockOwner{OwnerID: "owner"},
+					FileHandle: lock.FileHandle("fh"),
+				},
+			}
+
+			if ok := ProcessGrantedCallback(context.Background(), waiter, lm); ok {
+				t.Fatalf("expected callback to fail (resolver errored), got success")
+			}
+			if gotVers != vers {
+				t.Fatalf("resolver received version %d, want %d (negotiated)", gotVers, vers)
+			}
+		})
+	}
+}

--- a/internal/adapter/nfs/nlm/dispatch.go
+++ b/internal/adapter/nfs/nlm/dispatch.go
@@ -14,11 +14,27 @@ import (
 
 // HandlerResult contains the XDR-encoded response and metadata about the operation.
 type HandlerResult struct {
-	// Data contains the XDR-encoded response to send to the client.
+	// Data contains the XDR-encoded response to send to the client as the inline
+	// RPC reply. For asynchronous (_MSG) procedures this is empty (the reply is
+	// void) and the result is delivered via AsyncRes instead.
 	Data []byte
 
 	// NLMStatus is the NLM protocol status code for this operation.
 	NLMStatus uint32
+
+	// AsyncRes, when non-nil, marks this as an asynchronous (_MSG) operation:
+	// the transport must reply to the call with a void body and instead send an
+	// NLM *_RES callback (AsyncRes.Proc) carrying AsyncRes.Body to the client.
+	// macOS/BSD lockd use the async procedures (TEST_MSG/LOCK_MSG/...).
+	AsyncRes *AsyncResult
+}
+
+// AsyncResult carries the NLM *_RES callback the transport must deliver for an
+// asynchronous (_MSG) request: the *_RES procedure number and its XDR body
+// (identical to the corresponding synchronous reply body).
+type AsyncResult struct {
+	Proc uint32
+	Body []byte
 }
 
 // ============================================================================
@@ -88,7 +104,61 @@ func initNLMDispatchTable() {
 			Name:    "FREE_ALL",
 			Handler: handleNLMFreeAll,
 		},
+		// Asynchronous (callback-style) procedures. macOS/BSD lockd use these:
+		// the client sends a *_MSG, the server replies void, and the result is
+		// delivered as a *_RES callback to the client's NLM address.
+		types.NLMProcTestMsg: {
+			Name:    "TEST_MSG",
+			Handler: handleNLMTestMsg,
+		},
+		types.NLMProcLockMsg: {
+			Name:    "LOCK_MSG",
+			Handler: handleNLMLockMsg,
+		},
+		types.NLMProcCancelMsg: {
+			Name:    "CANCEL_MSG",
+			Handler: handleNLMCancelMsg,
+		},
+		types.NLMProcUnlockMsg: {
+			Name:    "UNLOCK_MSG",
+			Handler: handleNLMUnlockMsg,
+		},
 	}
+}
+
+// asAsync converts a synchronous handler result into an asynchronous (_MSG)
+// result: the inline RPC reply becomes void and the encoded result is instead
+// delivered as the given NLM *_RES callback (TEST_RES/LOCK_RES/...). The _RES
+// body is byte-for-byte the synchronous reply, so the async procedures reuse
+// the sync decode, processing, and encoding unchanged.
+func asAsync(res *HandlerResult, err error, resProc uint32) (*HandlerResult, error) {
+	if res == nil {
+		return res, err
+	}
+	return &HandlerResult{
+		NLMStatus: res.NLMStatus,
+		AsyncRes:  &AsyncResult{Proc: resProc, Body: res.Data},
+	}, err
+}
+
+func handleNLMTestMsg(ctx *handlers.NLMHandlerContext, h *handlers.Handler, reg *runtime.Runtime, data []byte) (*HandlerResult, error) {
+	res, err := handleNLMTest(ctx, h, reg, data)
+	return asAsync(res, err, types.NLMProcTestRes)
+}
+
+func handleNLMLockMsg(ctx *handlers.NLMHandlerContext, h *handlers.Handler, reg *runtime.Runtime, data []byte) (*HandlerResult, error) {
+	res, err := handleNLMLock(ctx, h, reg, data)
+	return asAsync(res, err, types.NLMProcLockRes)
+}
+
+func handleNLMCancelMsg(ctx *handlers.NLMHandlerContext, h *handlers.Handler, reg *runtime.Runtime, data []byte) (*HandlerResult, error) {
+	res, err := handleNLMCancel(ctx, h, reg, data)
+	return asAsync(res, err, types.NLMProcCancelRes)
+}
+
+func handleNLMUnlockMsg(ctx *handlers.NLMHandlerContext, h *handlers.Handler, reg *runtime.Runtime, data []byte) (*HandlerResult, error) {
+	res, err := handleNLMUnlock(ctx, h, reg, data)
+	return asAsync(res, err, types.NLMProcUnlockRes)
 }
 
 // ============================================================================

--- a/internal/adapter/nfs/nlm/dispatch.go
+++ b/internal/adapter/nfs/nlm/dispatch.go
@@ -131,21 +131,21 @@ func handleNLMTest(
 	reg *runtime.Runtime,
 	data []byte,
 ) (*HandlerResult, error) {
-	req, err := handlers.DecodeTestRequest(data)
+	req, err := handlers.DecodeTestRequest(data, ctx.Version)
 	if err != nil {
 		logger.Debug("NLM TEST decode error", "error", err)
-		encoded, _ := handlers.EncodeTestResponse(&handlers.TestResponse{Status: types.NLM4Failed})
+		encoded, _ := handlers.EncodeTestResponse(&handlers.TestResponse{Status: types.NLM4Failed}, ctx.Version)
 		return &HandlerResult{Data: encoded, NLMStatus: types.NLM4Failed}, err
 	}
 
 	resp, err := handler.Test(ctx, req)
 	if err != nil {
 		logger.Debug("NLM TEST handler error", "error", err)
-		encoded, _ := handlers.EncodeTestResponse(&handlers.TestResponse{Cookie: req.Cookie, Status: types.NLM4Failed})
+		encoded, _ := handlers.EncodeTestResponse(&handlers.TestResponse{Cookie: req.Cookie, Status: types.NLM4Failed}, ctx.Version)
 		return &HandlerResult{Data: encoded, NLMStatus: types.NLM4Failed}, err
 	}
 
-	encoded, err := handlers.EncodeTestResponse(resp)
+	encoded, err := handlers.EncodeTestResponse(resp, ctx.Version)
 	if err != nil {
 		logger.Debug("NLM TEST encode error", "error", err)
 		return &HandlerResult{Data: nil, NLMStatus: types.NLM4Failed}, err
@@ -160,7 +160,7 @@ func handleNLMLock(
 	reg *runtime.Runtime,
 	data []byte,
 ) (*HandlerResult, error) {
-	req, err := handlers.DecodeLockRequest(data)
+	req, err := handlers.DecodeLockRequest(data, ctx.Version)
 	if err != nil {
 		logger.Debug("NLM LOCK decode error", "error", err)
 		encoded, _ := handlers.EncodeLockResponse(&handlers.LockResponse{Status: types.NLM4Failed})
@@ -189,7 +189,7 @@ func handleNLMCancel(
 	reg *runtime.Runtime,
 	data []byte,
 ) (*HandlerResult, error) {
-	req, err := handlers.DecodeCancelRequest(data)
+	req, err := handlers.DecodeCancelRequest(data, ctx.Version)
 	if err != nil {
 		logger.Debug("NLM CANCEL decode error", "error", err)
 		encoded, _ := handlers.EncodeCancelResponse(&handlers.CancelResponse{Status: types.NLM4Failed})
@@ -218,7 +218,7 @@ func handleNLMUnlock(
 	reg *runtime.Runtime,
 	data []byte,
 ) (*HandlerResult, error) {
-	req, err := handlers.DecodeUnlockRequest(data)
+	req, err := handlers.DecodeUnlockRequest(data, ctx.Version)
 	if err != nil {
 		logger.Debug("NLM UNLOCK decode error", "error", err)
 		encoded, _ := handlers.EncodeUnlockResponse(&handlers.UnlockResponse{Status: types.NLM4Failed})

--- a/internal/adapter/nfs/nlm/handlers/cancel.go
+++ b/internal/adapter/nfs/nlm/handlers/cancel.go
@@ -34,9 +34,9 @@ type CancelResponse struct {
 }
 
 // DecodeCancelRequest decodes an NLM_CANCEL request from XDR format.
-func DecodeCancelRequest(data []byte) (*CancelRequest, error) {
+func DecodeCancelRequest(data []byte, version uint32) (*CancelRequest, error) {
 	r := bytes.NewReader(data)
-	args, err := nlm_xdr.DecodeNLM4CancelArgs(r)
+	args, err := nlm_xdr.DecodeNLM4CancelArgs(r, types.IsWideVersion(version))
 	if err != nil {
 		return nil, fmt.Errorf("decode NLM4CancelArgs: %w", err)
 	}

--- a/internal/adapter/nfs/nlm/handlers/context.go
+++ b/internal/adapter/nfs/nlm/handlers/context.go
@@ -23,6 +23,12 @@ type NLMHandlerContext struct {
 	// Used for logging, metrics, and owner identification.
 	ClientAddr string
 
+	// Version is the negotiated NLM protocol version (1, 3, or 4). It selects
+	// the byte-range offset/length wire width when decoding requests and
+	// encoding responses: v4 uses 64-bit, v1/v3 use 32-bit. macOS NFSv3 lock
+	// clients negotiate v1/v3. See types.IsWideVersion.
+	Version uint32
+
 	// AuthFlavor is the RPC authentication flavor (AUTH_UNIX, AUTH_NULL).
 	// Most NLM clients use AUTH_UNIX.
 	AuthFlavor uint32

--- a/internal/adapter/nfs/nlm/handlers/granted.go
+++ b/internal/adapter/nfs/nlm/handlers/granted.go
@@ -35,9 +35,9 @@ type GrantedResponse struct {
 }
 
 // DecodeGrantedRequest decodes an NLM_GRANTED request from XDR format.
-func DecodeGrantedRequest(data []byte) (*GrantedRequest, error) {
+func DecodeGrantedRequest(data []byte, version uint32) (*GrantedRequest, error) {
 	r := bytes.NewReader(data)
-	args, err := nlm_xdr.DecodeNLM4GrantedArgs(r)
+	args, err := nlm_xdr.DecodeNLM4GrantedArgs(r, types.IsWideVersion(version))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapter/nfs/nlm/handlers/lock.go
+++ b/internal/adapter/nfs/nlm/handlers/lock.go
@@ -47,9 +47,9 @@ type LockResponse struct {
 }
 
 // DecodeLockRequest decodes an NLM_LOCK request from XDR format.
-func DecodeLockRequest(data []byte) (*LockRequest, error) {
+func DecodeLockRequest(data []byte, version uint32) (*LockRequest, error) {
 	r := bytes.NewReader(data)
-	args, err := nlm_xdr.DecodeNLM4LockArgs(r)
+	args, err := nlm_xdr.DecodeNLM4LockArgs(r, types.IsWideVersion(version))
 	if err != nil {
 		return nil, fmt.Errorf("decode NLM4LockArgs: %w", err)
 	}
@@ -171,7 +171,9 @@ func (h *Handler) Lock(ctx *NLMHandlerContext, req *LockRequest) (*LockResponse,
 			Exclusive:    req.Exclusive,
 			CallbackHost: hostOf(ctx.ClientAddr),
 			CallbackProg: types.ProgramNLM,
-			CallbackVers: types.NLMVersion4,
+			// Echo the client's negotiated NLM version so the GRANTED callback
+			// (and its 32/64-bit offset encoding) matches what the client expects.
+			CallbackVers: ctx.Version,
 			CallerName:   req.Lock.CallerName,
 			Svid:         req.Lock.Svid,
 			OH:           req.Lock.OH,

--- a/internal/adapter/nfs/nlm/handlers/test.go
+++ b/internal/adapter/nfs/nlm/handlers/test.go
@@ -40,9 +40,9 @@ type TestResponse struct {
 }
 
 // DecodeTestRequest decodes an NLM_TEST request from XDR format.
-func DecodeTestRequest(data []byte) (*TestRequest, error) {
+func DecodeTestRequest(data []byte, version uint32) (*TestRequest, error) {
 	r := bytes.NewReader(data)
-	args, err := nlm_xdr.DecodeNLM4TestArgs(r)
+	args, err := nlm_xdr.DecodeNLM4TestArgs(r, types.IsWideVersion(version))
 	if err != nil {
 		return nil, fmt.Errorf("decode NLM4TestArgs: %w", err)
 	}
@@ -55,7 +55,7 @@ func DecodeTestRequest(data []byte) (*TestRequest, error) {
 }
 
 // EncodeTestResponse encodes an NLM_TEST response to XDR format.
-func EncodeTestResponse(resp *TestResponse) ([]byte, error) {
+func EncodeTestResponse(resp *TestResponse, version uint32) ([]byte, error) {
 	buf := new(bytes.Buffer)
 
 	res := &types.NLM4TestRes{
@@ -64,7 +64,7 @@ func EncodeTestResponse(resp *TestResponse) ([]byte, error) {
 		Holder: resp.Holder,
 	}
 
-	if err := nlm_xdr.EncodeNLM4TestRes(buf, res); err != nil {
+	if err := nlm_xdr.EncodeNLM4TestRes(buf, res, types.IsWideVersion(version)); err != nil {
 		return nil, err
 	}
 

--- a/internal/adapter/nfs/nlm/handlers/unlock.go
+++ b/internal/adapter/nfs/nlm/handlers/unlock.go
@@ -29,9 +29,9 @@ type UnlockResponse struct {
 }
 
 // DecodeUnlockRequest decodes an NLM_UNLOCK request from XDR format.
-func DecodeUnlockRequest(data []byte) (*UnlockRequest, error) {
+func DecodeUnlockRequest(data []byte, version uint32) (*UnlockRequest, error) {
 	r := bytes.NewReader(data)
-	args, err := nlm_xdr.DecodeNLM4UnlockArgs(r)
+	args, err := nlm_xdr.DecodeNLM4UnlockArgs(r, types.IsWideVersion(version))
 	if err != nil {
 		return nil, fmt.Errorf("decode NLM4UnlockArgs: %w", err)
 	}

--- a/internal/adapter/nfs/nlm/types/constants.go
+++ b/internal/adapter/nfs/nlm/types/constants.go
@@ -27,10 +27,24 @@ const (
 	// Per Open Group specification, NLM uses program number 100021.
 	ProgramNLM uint32 = 100021
 
+	// NLMVersion1 is the original NLM protocol version (32-bit offsets).
+	// BSD/macOS NFSv3 lock clients commonly negotiate v1 over UDP.
+	NLMVersion1 uint32 = 1
+
+	// NLMVersion3 adds SHARE/UNSHARE/NM_LOCK/FREE_ALL but keeps 32-bit offsets.
+	NLMVersion3 uint32 = 3
+
 	// NLMVersion4 is the NLM protocol version implementing 64-bit offsets.
-	// Version 4 is required for NFS v3 compatibility.
+	// Version 4 is required for NFS v3 compatibility on Linux.
 	NLMVersion4 uint32 = 4
 )
+
+// IsWideVersion reports whether the given NLM version encodes byte-range
+// offsets and lengths as 64-bit values (NLM v4). NLM v1 and v3 use 32-bit
+// offsets. Unknown versions default to wide (v4) to preserve prior behaviour.
+func IsWideVersion(version uint32) bool {
+	return version != NLMVersion1 && version != NLMVersion3
+}
 
 // ============================================================================
 // NLM v4 Procedure Numbers

--- a/internal/adapter/nfs/nlm/xdr/decode.go
+++ b/internal/adapter/nfs/nlm/xdr/decode.go
@@ -14,20 +14,41 @@ import (
 )
 
 // ============================================================================
-// NLM v4 Request Decoders
+// NLM Request Decoders
+//
+// The `wide` parameter selects the byte-range offset/length wire width:
+//   - wide == true  -> 64-bit (unsigned hyper), used by NLM v4.
+//   - wide == false -> 32-bit (unsigned int),   used by NLM v1/v3.
+//
+// macOS NFSv3 lock clients speak NLM v1/v3, so the narrow form must be honoured.
+// All callers pass a width derived from the negotiated NLM version
+// (see types.IsWideVersion).
 // ============================================================================
 
-// DecodeNLM4Lock decodes an NLM4Lock structure from XDR format.
+// decodeNLMOffset reads a byte-range offset or length using the version's wire
+// width and widens it to uint64 so handler logic stays version-agnostic.
+func decodeNLMOffset(r io.Reader, wide bool) (uint64, error) {
+	if wide {
+		return xdr.DecodeUint64(r)
+	}
+	v, err := xdr.DecodeUint32(r)
+	if err != nil {
+		return 0, err
+	}
+	return uint64(v), nil
+}
+
+// DecodeNLM4Lock decodes an nlm_lock / nlm4_lock structure from XDR format.
 //
-// Wire format:
+// Wire format (l_offset/l_len are 64-bit when wide, 32-bit otherwise):
 //
 //	caller_name: [length:uint32][data:bytes][padding]
 //	fh:          [length:uint32][data:bytes][padding]
 //	oh:          [length:uint32][data:bytes][padding]
 //	svid:        [int32]
-//	l_offset:    [uint64]
-//	l_len:       [uint64]
-func DecodeNLM4Lock(r io.Reader) (*types.NLM4Lock, error) {
+//	l_offset:    [uint64|uint32]
+//	l_len:       [uint64|uint32]
+func DecodeNLM4Lock(r io.Reader, wide bool) (*types.NLM4Lock, error) {
 	lock := &types.NLM4Lock{}
 
 	// Decode caller_name (string)
@@ -61,15 +82,15 @@ func DecodeNLM4Lock(r io.Reader) (*types.NLM4Lock, error) {
 	}
 	lock.Svid = svid
 
-	// Decode l_offset (uint64) - NLM v4 uses 64-bit
-	offset, err := xdr.DecodeUint64(r)
+	// Decode l_offset (64-bit for v4, 32-bit for v1/v3)
+	offset, err := decodeNLMOffset(r, wide)
 	if err != nil {
 		return nil, fmt.Errorf("decode l_offset: %w", err)
 	}
 	lock.Offset = offset
 
-	// Decode l_len (uint64) - NLM v4 uses 64-bit
-	length, err := xdr.DecodeUint64(r)
+	// Decode l_len (64-bit for v4, 32-bit for v1/v3)
+	length, err := decodeNLMOffset(r, wide)
 	if err != nil {
 		return nil, fmt.Errorf("decode l_len: %w", err)
 	}
@@ -88,7 +109,7 @@ func DecodeNLM4Lock(r io.Reader) (*types.NLM4Lock, error) {
 //	alock:     [nlm4_lock structure]
 //	reclaim:   [uint32] (0=false, 1=true)
 //	state:     [int32]
-func DecodeNLM4LockArgs(r io.Reader) (*types.NLM4LockArgs, error) {
+func DecodeNLM4LockArgs(r io.Reader, wide bool) (*types.NLM4LockArgs, error) {
 	args := &types.NLM4LockArgs{}
 
 	// Decode cookie (opaque)
@@ -113,7 +134,7 @@ func DecodeNLM4LockArgs(r io.Reader) (*types.NLM4LockArgs, error) {
 	args.Exclusive = exclusive
 
 	// Decode alock (nlm4_lock)
-	lock, err := DecodeNLM4Lock(r)
+	lock, err := DecodeNLM4Lock(r, wide)
 	if err != nil {
 		return nil, fmt.Errorf("decode alock: %w", err)
 	}
@@ -142,7 +163,7 @@ func DecodeNLM4LockArgs(r io.Reader) (*types.NLM4LockArgs, error) {
 //
 //	cookie: [length:uint32][data:bytes][padding]
 //	alock:  [nlm4_lock structure]
-func DecodeNLM4UnlockArgs(r io.Reader) (*types.NLM4UnlockArgs, error) {
+func DecodeNLM4UnlockArgs(r io.Reader, wide bool) (*types.NLM4UnlockArgs, error) {
 	args := &types.NLM4UnlockArgs{}
 
 	// Decode cookie (opaque)
@@ -153,7 +174,7 @@ func DecodeNLM4UnlockArgs(r io.Reader) (*types.NLM4UnlockArgs, error) {
 	args.Cookie = cookie
 
 	// Decode alock (nlm4_lock)
-	lock, err := DecodeNLM4Lock(r)
+	lock, err := DecodeNLM4Lock(r, wide)
 	if err != nil {
 		return nil, fmt.Errorf("decode alock: %w", err)
 	}
@@ -169,7 +190,7 @@ func DecodeNLM4UnlockArgs(r io.Reader) (*types.NLM4UnlockArgs, error) {
 //	cookie:    [length:uint32][data:bytes][padding]
 //	exclusive: [uint32] (0=false, 1=true)
 //	alock:     [nlm4_lock structure]
-func DecodeNLM4TestArgs(r io.Reader) (*types.NLM4TestArgs, error) {
+func DecodeNLM4TestArgs(r io.Reader, wide bool) (*types.NLM4TestArgs, error) {
 	args := &types.NLM4TestArgs{}
 
 	// Decode cookie (opaque)
@@ -187,7 +208,7 @@ func DecodeNLM4TestArgs(r io.Reader) (*types.NLM4TestArgs, error) {
 	args.Exclusive = exclusive
 
 	// Decode alock (nlm4_lock)
-	lock, err := DecodeNLM4Lock(r)
+	lock, err := DecodeNLM4Lock(r, wide)
 	if err != nil {
 		return nil, fmt.Errorf("decode alock: %w", err)
 	}
@@ -204,7 +225,7 @@ func DecodeNLM4TestArgs(r io.Reader) (*types.NLM4TestArgs, error) {
 //	block:     [uint32] (0=false, 1=true)
 //	exclusive: [uint32] (0=false, 1=true)
 //	alock:     [nlm4_lock structure]
-func DecodeNLM4CancelArgs(r io.Reader) (*types.NLM4CancelArgs, error) {
+func DecodeNLM4CancelArgs(r io.Reader, wide bool) (*types.NLM4CancelArgs, error) {
 	args := &types.NLM4CancelArgs{}
 
 	// Decode cookie (opaque)
@@ -229,7 +250,7 @@ func DecodeNLM4CancelArgs(r io.Reader) (*types.NLM4CancelArgs, error) {
 	args.Exclusive = exclusive
 
 	// Decode alock (nlm4_lock)
-	lock, err := DecodeNLM4Lock(r)
+	lock, err := DecodeNLM4Lock(r, wide)
 	if err != nil {
 		return nil, fmt.Errorf("decode alock: %w", err)
 	}
@@ -247,7 +268,7 @@ func DecodeNLM4CancelArgs(r io.Reader) (*types.NLM4CancelArgs, error) {
 //	alock:     [nlm4_lock structure]
 //
 // Note: GRANTED uses the same format as TEST args.
-func DecodeNLM4GrantedArgs(r io.Reader) (*types.NLM4GrantedArgs, error) {
+func DecodeNLM4GrantedArgs(r io.Reader, wide bool) (*types.NLM4GrantedArgs, error) {
 	args := &types.NLM4GrantedArgs{}
 
 	// Decode cookie (opaque)
@@ -265,7 +286,7 @@ func DecodeNLM4GrantedArgs(r io.Reader) (*types.NLM4GrantedArgs, error) {
 	args.Exclusive = exclusive
 
 	// Decode alock (nlm4_lock)
-	lock, err := DecodeNLM4Lock(r)
+	lock, err := DecodeNLM4Lock(r, wide)
 	if err != nil {
 		return nil, fmt.Errorf("decode alock: %w", err)
 	}

--- a/internal/adapter/nfs/nlm/xdr/encode.go
+++ b/internal/adapter/nfs/nlm/xdr/encode.go
@@ -3,14 +3,41 @@ package xdr
 import (
 	"bytes"
 	"fmt"
+	"math"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/internal/logger"
 )
 
 // ============================================================================
-// NLM v4 Response Encoders
+// NLM Response Encoders
+//
+// The `wide` parameter selects byte-range offset/length wire width:
+//   - wide == true  -> 64-bit (NLM v4).
+//   - wide == false -> 32-bit (NLM v1/v3, e.g. macOS NFSv3 clients).
 // ============================================================================
+
+// encodeNLMOffset writes a byte-range offset/length using the version's wire
+// width. Values are widened to uint64 internally.
+//
+// A v1/v3 client's own locks always fit in 32 bits, but the holder field of a
+// TEST response can reflect a conflicting v4 lock whose 64-bit range exceeds 32
+// bits. NLM v1/v3 cannot represent that, so the narrow form saturates to the
+// 32-bit max rather than wrap-truncating — wrapping could fold a large offset
+// down to a small, wrong one (e.g. 1<<32 -> 0) and misreport the conflict. The
+// nlm_stat (DENIED) the client acts on is unaffected; only the reported holder
+// bounds are clamped.
+func encodeNLMOffset(buf *bytes.Buffer, v uint64, wide bool) error {
+	if wide {
+		return xdr.WriteUint64(buf, v)
+	}
+	if v > math.MaxUint32 {
+		logger.Debug("NLM v1/v3: clamping 64-bit byte-range field to 32-bit max", "value", v)
+		v = math.MaxUint32
+	}
+	return xdr.WriteUint32(buf, uint32(v))
+}
 
 // EncodeNLM4Res encodes an NLM4Res response structure to XDR format.
 //
@@ -49,7 +76,7 @@ func EncodeNLM4Res(buf *bytes.Buffer, res *types.NLM4Res) error {
 //
 // If Status is NLM4Denied, Holder must be non-nil and will be encoded.
 // If Status is anything else, Holder is ignored (not encoded).
-func EncodeNLM4TestRes(buf *bytes.Buffer, res *types.NLM4TestRes) error {
+func EncodeNLM4TestRes(buf *bytes.Buffer, res *types.NLM4TestRes, wide bool) error {
 	if res == nil {
 		return fmt.Errorf("NLM4TestRes is nil")
 	}
@@ -69,7 +96,7 @@ func EncodeNLM4TestRes(buf *bytes.Buffer, res *types.NLM4TestRes) error {
 		if res.Holder == nil {
 			return fmt.Errorf("NLM4TestRes.Holder is nil but status is DENIED")
 		}
-		if err := EncodeNLM4Holder(buf, res.Holder); err != nil {
+		if err := EncodeNLM4Holder(buf, res.Holder, wide); err != nil {
 			return fmt.Errorf("encode holder: %w", err)
 		}
 	}
@@ -86,7 +113,7 @@ func EncodeNLM4TestRes(buf *bytes.Buffer, res *types.NLM4TestRes) error {
 //	oh:        [length:uint32][data:bytes][padding]
 //	l_offset:  [uint64]
 //	l_len:     [uint64]
-func EncodeNLM4Holder(buf *bytes.Buffer, holder *types.NLM4Holder) error {
+func EncodeNLM4Holder(buf *bytes.Buffer, holder *types.NLM4Holder, wide bool) error {
 	if holder == nil {
 		return fmt.Errorf("NLM4Holder is nil")
 	}
@@ -106,13 +133,13 @@ func EncodeNLM4Holder(buf *bytes.Buffer, holder *types.NLM4Holder) error {
 		return fmt.Errorf("encode oh: %w", err)
 	}
 
-	// Encode l_offset (uint64)
-	if err := xdr.WriteUint64(buf, holder.Offset); err != nil {
+	// Encode l_offset (64-bit for v4, 32-bit for v1/v3)
+	if err := encodeNLMOffset(buf, holder.Offset, wide); err != nil {
 		return fmt.Errorf("encode l_offset: %w", err)
 	}
 
-	// Encode l_len (uint64)
-	if err := xdr.WriteUint64(buf, holder.Length); err != nil {
+	// Encode l_len (64-bit for v4, 32-bit for v1/v3)
+	if err := encodeNLMOffset(buf, holder.Length, wide); err != nil {
 		return fmt.Errorf("encode l_len: %w", err)
 	}
 
@@ -129,7 +156,7 @@ func EncodeNLM4Holder(buf *bytes.Buffer, holder *types.NLM4Holder) error {
 //
 // Used when server calls back to client to notify that a blocked lock
 // has been granted.
-func EncodeNLM4GrantedArgs(buf *bytes.Buffer, args *types.NLM4GrantedArgs) error {
+func EncodeNLM4GrantedArgs(buf *bytes.Buffer, args *types.NLM4GrantedArgs, wide bool) error {
 	if args == nil {
 		return fmt.Errorf("NLM4GrantedArgs is nil")
 	}
@@ -145,7 +172,7 @@ func EncodeNLM4GrantedArgs(buf *bytes.Buffer, args *types.NLM4GrantedArgs) error
 	}
 
 	// Encode alock (nlm4_lock)
-	if err := EncodeNLM4Lock(buf, &args.Lock); err != nil {
+	if err := EncodeNLM4Lock(buf, &args.Lock, wide); err != nil {
 		return fmt.Errorf("encode alock: %w", err)
 	}
 
@@ -162,7 +189,7 @@ func EncodeNLM4GrantedArgs(buf *bytes.Buffer, args *types.NLM4GrantedArgs) error
 //	svid:        [int32]
 //	l_offset:    [uint64]
 //	l_len:       [uint64]
-func EncodeNLM4Lock(buf *bytes.Buffer, lock *types.NLM4Lock) error {
+func EncodeNLM4Lock(buf *bytes.Buffer, lock *types.NLM4Lock, wide bool) error {
 	if lock == nil {
 		return fmt.Errorf("NLM4Lock is nil")
 	}
@@ -187,13 +214,13 @@ func EncodeNLM4Lock(buf *bytes.Buffer, lock *types.NLM4Lock) error {
 		return fmt.Errorf("encode svid: %w", err)
 	}
 
-	// Encode l_offset (uint64)
-	if err := xdr.WriteUint64(buf, lock.Offset); err != nil {
+	// Encode l_offset (64-bit for v4, 32-bit for v1/v3)
+	if err := encodeNLMOffset(buf, lock.Offset, wide); err != nil {
 		return fmt.Errorf("encode l_offset: %w", err)
 	}
 
-	// Encode l_len (uint64)
-	if err := xdr.WriteUint64(buf, lock.Length); err != nil {
+	// Encode l_len (64-bit for v4, 32-bit for v1/v3)
+	if err := encodeNLMOffset(buf, lock.Length, wide); err != nil {
 		return fmt.Errorf("encode l_len: %w", err)
 	}
 

--- a/internal/adapter/nfs/nlm/xdr/version_test.go
+++ b/internal/adapter/nfs/nlm/xdr/version_test.go
@@ -1,0 +1,131 @@
+package xdr
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/nlm/types"
+)
+
+// TestNLMLockRoundTrip_WidthVariants verifies that an NLM lock encoded with a
+// given offset width (64-bit for NLM v4, 32-bit for NLM v1/v3) decodes back to
+// the same logical values. macOS NFSv3 clients send NLM v1/v3 with 32-bit
+// offsets, so the codec must honour the wire width selected by the version.
+func TestNLMLockRoundTrip_WidthVariants(t *testing.T) {
+	cases := []struct {
+		name   string
+		wide   bool
+		offset uint64
+		length uint64
+	}{
+		{"v4 wide small", true, 4096, 8192},
+		{"v4 wide large", true, 0x1_0000_0000, 0x2_0000_0000},
+		{"v1v3 narrow", false, 4096, 8192},
+		{"v1v3 narrow max32", false, 0xFFFF_FFFF, 0xFFFF_FFFE},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := &types.NLM4Lock{
+				CallerName: "macos-client",
+				FH:         []byte{0x01, 0x02, 0x03, 0x04},
+				OH:         []byte{0xaa, 0xbb},
+				Svid:       1234,
+				Offset:     tc.offset,
+				Length:     tc.length,
+			}
+
+			buf := new(bytes.Buffer)
+			if err := EncodeNLM4Lock(buf, in, tc.wide); err != nil {
+				t.Fatalf("EncodeNLM4Lock(wide=%v): %v", tc.wide, err)
+			}
+
+			out, err := DecodeNLM4Lock(bytes.NewReader(buf.Bytes()), tc.wide)
+			if err != nil {
+				t.Fatalf("DecodeNLM4Lock(wide=%v): %v", tc.wide, err)
+			}
+
+			if out.Offset != tc.offset || out.Length != tc.length {
+				t.Fatalf("offset/len mismatch: got (%d,%d) want (%d,%d)",
+					out.Offset, out.Length, tc.offset, tc.length)
+			}
+			if out.CallerName != in.CallerName || out.Svid != in.Svid {
+				t.Fatalf("scalar mismatch: %+v vs %+v", out, in)
+			}
+		})
+	}
+}
+
+// TestNLMLock_NarrowWireSize asserts the 32-bit variant emits exactly 8 fewer
+// bytes than the 64-bit variant (offset + length each 4 bytes narrower),
+// proving the wire format actually differs (not just a widened decode).
+func TestNLMLock_NarrowWireSize(t *testing.T) {
+	in := &types.NLM4Lock{CallerName: "c", FH: []byte{1}, OH: []byte{2}, Svid: 1, Offset: 1, Length: 2}
+
+	wide := new(bytes.Buffer)
+	if err := EncodeNLM4Lock(wide, in, true); err != nil {
+		t.Fatal(err)
+	}
+	narrow := new(bytes.Buffer)
+	if err := EncodeNLM4Lock(narrow, in, false); err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := wide.Len() - narrow.Len(); diff != 8 {
+		t.Fatalf("expected 64-bit encoding to be 8 bytes larger, got diff=%d", diff)
+	}
+}
+
+// TestNLM4TestRes_HolderWidth verifies the TEST response holder honours the
+// offset width too (the conflicting-lock report must match the client version).
+func TestNLM4TestRes_HolderWidth(t *testing.T) {
+	res := &types.NLM4TestRes{
+		Cookie: []byte{0x01},
+		Status: types.NLM4Denied,
+		Holder: &types.NLM4Holder{Exclusive: true, Svid: 7, OH: []byte{9}, Offset: 100, Length: 200},
+	}
+
+	for _, wide := range []bool{true, false} {
+		buf := new(bytes.Buffer)
+		if err := EncodeNLM4TestRes(buf, res, wide); err != nil {
+			t.Fatalf("EncodeNLM4TestRes(wide=%v): %v", wide, err)
+		}
+		if buf.Len() == 0 {
+			t.Fatalf("empty encoding for wide=%v", wide)
+		}
+	}
+}
+
+// TestNLMHolder_NarrowSaturatesNotWraps verifies that when a TEST holder field
+// reflects a conflicting v4 lock whose 64-bit range exceeds 32 bits, the narrow
+// (v1/v3) encoding saturates to the 32-bit max instead of wrap-truncating. A
+// wrap would fold e.g. 1<<32 down to 0 and misreport the conflict at offset 0.
+func TestNLMHolder_NarrowSaturatesNotWraps(t *testing.T) {
+	holder := &types.NLM4Holder{
+		Exclusive: true,
+		Svid:      7,
+		OH:        nil,
+		Offset:    0x1_0000_0000, // 1<<32 — wraps to 0 if truncated
+		Length:    0x1_0000_0005, // wraps to 5 if truncated
+	}
+
+	buf := new(bytes.Buffer)
+	if err := EncodeNLM4Holder(buf, holder, false /* narrow */); err != nil {
+		t.Fatalf("EncodeNLM4Holder narrow: %v", err)
+	}
+
+	b := buf.Bytes()
+	// Layout (narrow, empty OH): exclusive[4] svid[4] oh_len[4] l_offset[4] l_len[4]
+	if len(b) != 20 {
+		t.Fatalf("unexpected narrow holder size: got %d, want 20 (%x)", len(b), b)
+	}
+	offset := binary.BigEndian.Uint32(b[12:16])
+	length := binary.BigEndian.Uint32(b[16:20])
+	if offset != 0xFFFF_FFFF {
+		t.Errorf("l_offset: got %#x, want saturated 0xFFFFFFFF (wrap would give 0)", offset)
+	}
+	if length != 0xFFFF_FFFF {
+		t.Errorf("l_len: got %#x, want saturated 0xFFFFFFFF (wrap would give 5)", length)
+	}
+}

--- a/internal/adapter/nfs/nsm/handlers/mon.go
+++ b/internal/adapter/nfs/nsm/handlers/mon.go
@@ -12,22 +12,33 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
-// validateCallbackName enforces that the SM_MON my_name callback address is a
-// safe IP literal. NSM callback addresses must be IP literals (no DNS names),
-// must not be loopback, and must not be link-local (which covers the cloud
-// instance metadata address 169.254.169.254). Violations return STAT_FAIL.
-func validateCallbackName(name string) error {
-	ip := net.ParseIP(name)
-	if ip == nil {
-		return fmt.Errorf("callback my_name %q is not an IP literal", name)
+// callbackHostFromSource derives the SM_NOTIFY callback host from the SM_MON
+// request's transport source address.
+//
+// NSM clients set my_name to their own hostname — Linux and macOS statd both
+// send a name like "localhost", not an IP literal — so dialling my_name
+// verbatim breaks every real client. It is also an SSRF vector: my_name is
+// fully client-controlled and could point the later callback at an internal
+// address such as the cloud metadata endpoint (169.254.169.254). The request's
+// transport source is the host that actually issued the MON, so it is both the
+// correct callback target and inherently safe (a client cannot forge it to an
+// arbitrary internal address). my_name is therefore kept only as a label.
+//
+// Link-local sources (169.254.0.0/16, fe80::/10) are still rejected; loopback
+// is allowed so same-host clients (and local testing) can lock.
+func callbackHostFromSource(clientAddr string) (string, error) {
+	host, _, err := net.SplitHostPort(clientAddr)
+	if err != nil {
+		host = clientAddr // already a bare host
 	}
-	if ip.IsLoopback() {
-		return fmt.Errorf("callback my_name %q is a loopback address", name)
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return "", fmt.Errorf("client source %q is not an IP address", clientAddr)
 	}
 	if ip.IsLinkLocalUnicast() {
-		return fmt.Errorf("callback my_name %q is a link-local address", name)
+		return "", fmt.Errorf("client source %q is a link-local address", host)
 	}
-	return nil
+	return host, nil
 }
 
 // Mon handles NSM MON (RFC 1813, SM procedure 2).
@@ -56,19 +67,21 @@ func (h *Handler) Mon(ctx *NSMHandlerContext, data []byte) (*HandlerResult, erro
 		"callback_vers", mon.MonID.MyID.MyVers,
 		"callback_proc", mon.MonID.MyID.MyProc)
 
-	// Reject unsafe callback addresses (SSRF guard): the my_name is fully
-	// client-controlled and is later dialled verbatim by the callback client.
-	if err := validateCallbackName(mon.MonID.MyID.MyName); err != nil {
-		logger.Warn("NSM MON rejected: unsafe callback address",
+	// Derive the SM_NOTIFY callback host from the request's transport source
+	// rather than the client-supplied my_name (which is a hostname like
+	// "localhost" and an SSRF vector). See callbackHostFromSource.
+	callbackHost, err := callbackHostFromSource(ctx.ClientAddr)
+	if err != nil {
+		logger.Warn("NSM MON rejected: unsafe source address",
 			"client", ctx.ClientAddr,
-			"callback_host", mon.MonID.MyID.MyName,
+			"my_name", mon.MonID.MyID.MyName,
 			"error", err)
 		return encodeStatFailure(state)
 	}
 
-	// Generate client ID from client address and callback info
-	// This ensures uniqueness per client/callback combination
-	clientID := generateClientID(ctx.ClientAddr, mon.MonID.MyID.MyName)
+	// Generate client ID from client address and the derived callback host.
+	// This ensures uniqueness per client/callback combination.
+	clientID := generateClientID(ctx.ClientAddr, callbackHost)
 
 	// Check if we're at the client limit
 	currentCount := h.tracker.GetClientCount("")
@@ -92,7 +105,7 @@ func (h *Handler) Mon(ctx *NSMHandlerContext, data []byte) (*HandlerResult, erro
 
 	// Update NSM-specific info in the registration
 	callback := &lock.NSMCallback{
-		Hostname: mon.MonID.MyID.MyName,
+		Hostname: callbackHost,
 		Program:  mon.MonID.MyID.MyProg,
 		Version:  mon.MonID.MyID.MyVers,
 		Proc:     mon.MonID.MyID.MyProc,
@@ -117,7 +130,8 @@ func (h *Handler) Mon(ctx *NSMHandlerContext, data []byte) (*HandlerResult, erro
 	logger.Info("NSM MON registered",
 		"client_id", clientID,
 		"mon_name", mon.MonID.MonName,
-		"callback_host", mon.MonID.MyID.MyName,
+		"callback_host", callbackHost,
+		"my_name", mon.MonID.MyID.MyName,
 		"state", state)
 
 	// Return success with current state

--- a/internal/adapter/nfs/nsm/handlers/mon_test.go
+++ b/internal/adapter/nfs/nsm/handlers/mon_test.go
@@ -7,78 +7,91 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/nfs/nsm/types"
 )
 
-// TestValidateCallbackName exercises the SM_MON callback-address SSRF guard
-// directly: only safe IP literals are accepted; loopback, link-local (including
-// the cloud IMDS address 169.254.169.254), and non-IP hostnames are rejected.
-func TestValidateCallbackName(t *testing.T) {
+// TestCallbackHostFromSource exercises the SM_MON callback-host derivation
+// directly. The callback target is taken from the request's transport source,
+// not the client-supplied my_name: any routable source IP (including loopback,
+// for same-host clients) is accepted, while link-local sources (notably the
+// cloud IMDS address 169.254.169.254) and non-IP inputs are rejected.
+func TestCallbackHostFromSource(t *testing.T) {
 	cases := []struct {
-		name    string
-		wantErr bool
-		desc    string
+		addr     string
+		wantHost string
+		wantErr  bool
+		desc     string
 	}{
-		{"10.0.0.1", false, "RFC-1918 private — allowed"},
-		{"192.168.1.100", false, "RFC-1918 private — allowed"},
-		{"203.0.113.5", false, "public IP — allowed"},
-		{"::1", true, "IPv6 loopback — rejected"},
-		{"127.0.0.1", true, "loopback — rejected"},
-		{"127.1.2.3", true, "loopback subnet — rejected"},
-		{"169.254.169.254", true, "cloud IMDS — rejected (link-local)"},
-		{"169.254.0.1", true, "link-local — rejected"},
-		{"fe80::1", true, "IPv6 link-local — rejected"},
-		{"hostname.local", true, "hostname (not IP literal) — rejected"},
-		{"", true, "empty — rejected"},
+		{"10.0.0.1:600", "10.0.0.1", false, "RFC-1918 source — allowed"},
+		{"203.0.113.5:711", "203.0.113.5", false, "public source — allowed"},
+		{"127.0.0.1:829", "127.0.0.1", false, "loopback source — allowed (same-host client)"},
+		{"[::1]:829", "::1", false, "IPv6 loopback source — allowed"},
+		{"10.0.0.1", "10.0.0.1", false, "bare host without port — allowed"},
+		{"169.254.169.254:600", "", true, "cloud IMDS source — rejected (link-local)"},
+		{"169.254.0.1:600", "", true, "link-local source — rejected"},
+		{"[fe80::1]:600", "", true, "IPv6 link-local source — rejected"},
+		{"not-an-ip:600", "", true, "non-IP host — rejected"},
+		{"", "", true, "empty — rejected"},
 	}
 	for _, tc := range cases {
-		err := validateCallbackName(tc.name)
-		if tc.wantErr && err == nil {
-			t.Errorf("[%s] name=%q: expected error, got nil", tc.desc, tc.name)
+		host, err := callbackHostFromSource(tc.addr)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("[%s] addr=%q: expected error, got host=%q", tc.desc, tc.addr, host)
+			}
+			continue
 		}
-		if !tc.wantErr && err != nil {
-			t.Errorf("[%s] name=%q: unexpected error: %v", tc.desc, tc.name, err)
+		if err != nil {
+			t.Errorf("[%s] addr=%q: unexpected error: %v", tc.desc, tc.addr, err)
+		}
+		if host != tc.wantHost {
+			t.Errorf("[%s] addr=%q: host=%q, want %q", tc.desc, tc.addr, host, tc.wantHost)
 		}
 	}
 }
 
-// TestMon_CallbackNameSSRF_Rejected verifies the SM_MON handler rejects unsafe
-// callback addresses with STAT_FAIL (no Go error) and accepts safe IP literals.
-func TestMon_CallbackNameSSRF_Rejected(t *testing.T) {
+// TestMon_CallbackFromSource verifies the SM_MON handler keys the SM_NOTIFY
+// callback off the request's transport source, not the client-supplied my_name.
+// Real statd implementations (Linux, macOS) send my_name as a hostname such as
+// "localhost"; that must NOT cause a rejection. A same-host (loopback) client
+// must be accepted — this is the macOS-locking-against-localhost case that
+// previously failed STAT_FAIL ("my_name is not an IP literal"). Only link-local
+// sources (cloud IMDS) are rejected.
+func TestMon_CallbackFromSource(t *testing.T) {
 	cases := []struct {
-		name         string
-		callbackHost string
-		wantFail     bool
+		name       string
+		clientAddr string
+		wantFail   bool
 	}{
-		{"loopback rejected", "127.0.0.1", true},
-		{"link-local IMDS", "169.254.169.254", true},
-		{"IPv6 loopback", "::1", true},
-		{"fe80 link-local", "fe80::1", true},
-		{"hostname rejected", "callback.example", true},
-		{"valid IP accepted", "10.0.0.5", false},
-		{"valid public IP", "203.0.113.1", false},
+		{"loopback source accepted (macOS localhost)", "127.0.0.1:829", false},
+		{"IPv6 loopback source accepted", "[::1]:829", false},
+		{"private source accepted", "10.0.0.5:600", false},
+		{"public source accepted", "203.0.113.1:600", false},
+		{"IMDS source rejected", "169.254.169.254:600", true},
+		{"IPv6 link-local source rejected", "[fe80::1]:600", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			h := newTestHandler(t, &fakeDispatcher{})
+			// my_name is a hostname, exactly as Linux/macOS statd send it.
 			mon := &types.Mon{
 				MonID: types.MonID{
 					MonName: "peer.example",
 					MyID: types.MyID{
-						MyName: tc.callbackHost,
+						MyName: "localhost",
 						MyProg: 100021, MyVers: 4, MyProc: 23,
 					},
 				},
 			}
 			data := encodeMon(t, mon)
-			ctx := &NSMHandlerContext{Context: context.Background(), ClientAddr: "10.0.0.1:600"}
+			ctx := &NSMHandlerContext{Context: context.Background(), ClientAddr: tc.clientAddr}
 			result, err := h.Mon(ctx, data)
 			if err != nil {
 				t.Fatalf("Mon must not return a Go error: %v", err)
 			}
 			gotFail := result.NSMStatus == types.StatFail
 			if tc.wantFail && !gotFail {
-				t.Errorf("callback host %q should have been rejected (STAT_FAIL), got STAT_SUCC", tc.callbackHost)
+				t.Errorf("source %q should have been rejected (STAT_FAIL), got STAT_SUCC", tc.clientAddr)
 			}
 			if !tc.wantFail && gotFail {
-				t.Errorf("callback host %q should have been accepted (STAT_SUCC), got STAT_FAIL", tc.callbackHost)
+				t.Errorf("source %q should have been accepted (STAT_SUCC), got STAT_FAIL", tc.clientAddr)
 			}
 		})
 	}

--- a/internal/adapter/nfs/nsm/handlers/notify_test.go
+++ b/internal/adapter/nfs/nsm/handlers/notify_test.go
@@ -375,18 +375,20 @@ func TestNotify_DispatchesToAllMonitors(t *testing.T) {
 
 	privA := [16]byte{1, 2, 3}
 	privB := [16]byte{9, 9, 9}
-	// Callback hosts must be valid (non-loopback, non-link-local) IP literals
-	// per the SSRF guard.
+	// The SM_NOTIFY callback target is the SM_MON request's transport source, so
+	// each monitor's source IP is also its callback address. my_name is a label.
 	const clientA = "203.0.113.10"
 	const clientB = "203.0.113.11"
 	const clientC = "203.0.113.12"
-	// Two distinct local clients both monitor peer.example from the same host.
-	monitorWithCallback(t, h, "10.0.0.5:601", "peer.example", clientA, privA)
-	monitorWithCallback(t, h, "10.0.0.5:602", "peer.example", clientB, privB)
+	// Two clients (distinct sources) both monitor peer.example.
+	monitorWithCallback(t, h, clientA+":601", "peer.example", "localhost", privA)
+	monitorWithCallback(t, h, clientB+":602", "peer.example", "localhost", privB)
 	// A third client monitors a different host — must NOT be notified.
-	monitorWithCallback(t, h, "10.0.0.5:603", "other.example", clientC, [16]byte{7})
+	monitorWithCallback(t, h, clientC+":603", "other.example", "localhost", [16]byte{7})
 
-	notify(t, h, "10.0.0.5:55000", "peer.example", 5)
+	// NOTIFY from clientA (a peer.example monitor's source) passes the H16 gate
+	// and relays to every peer.example monitor (clientA + clientB).
+	notify(t, h, clientA+":55000", "peer.example", 5)
 
 	calls := fd.recorded()
 	if len(calls) != 2 {

--- a/internal/adapter/nfs/portmap/dispatch.go
+++ b/internal/adapter/nfs/portmap/dispatch.go
@@ -58,3 +58,34 @@ var DispatchTable = map[uint32]*PmapProcedure{
 		},
 	},
 }
+
+// RpcbDispatchTable maps RPCBIND v3/v4 procedure numbers to their handlers
+// (RFC 1833). Only the read procedures needed for NLM/NSM discovery are
+// implemented; SET/UNSET/CALLIT are intentionally omitted for the same safety
+// reasons as the v2 table (registrations are internal; CALLIT is an amplifier).
+var RpcbDispatchTable = map[uint32]*PmapProcedure{
+	types.ProcNull: {
+		Name: "NULL",
+		Handler: func(handler *handlers.Handler, _ []byte, _ string) ([]byte, error) {
+			return handler.Null(), nil
+		},
+	},
+	types.RpcbProcGetaddr: {
+		Name: "GETADDR",
+		Handler: func(handler *handlers.Handler, data []byte, clientAddr string) ([]byte, error) {
+			return handler.Getaddr(data, clientAddr)
+		},
+	},
+	types.RpcbProcGetversaddr: {
+		Name: "GETVERSADDR",
+		Handler: func(handler *handlers.Handler, data []byte, clientAddr string) ([]byte, error) {
+			return handler.Getaddr(data, clientAddr)
+		},
+	},
+	types.RpcbProcDump: {
+		Name: "DUMP",
+		Handler: func(handler *handlers.Handler, _ []byte, clientAddr string) ([]byte, error) {
+			return handler.RpcbDump(clientAddr)
+		},
+	},
+}

--- a/internal/adapter/nfs/portmap/handlers/rpcbind.go
+++ b/internal/adapter/nfs/portmap/handlers/rpcbind.go
@@ -1,0 +1,97 @@
+package handlers
+
+import (
+	"net"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/portmap/types"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/portmap/xdr"
+	"github.com/marmos91/dittofs/internal/logger"
+)
+
+// netidToProtocol maps an RPCBIND netid to the v2 IPPROTO value the registry
+// keys on. The address family (IPv6 for the "*6" netids) is implied by the
+// client's own connection, so it need not be tracked in the registry.
+func netidToProtocol(netid string) (uint32, bool) {
+	switch netid {
+	case "tcp", "tcp6":
+		return types.ProtoTCP, true
+	case "udp", "udp6":
+		return types.ProtoUDP, true
+	}
+	return 0, false
+}
+
+// protocolToNetid renders a registry protocol back to its IPv4 netid for DUMP.
+func protocolToNetid(prot uint32) string {
+	switch prot {
+	case types.ProtoTCP:
+		return "tcp"
+	case types.ProtoUDP:
+		return "udp"
+	}
+	return ""
+}
+
+// uaddrHost extracts the textual host for a universal address from a client
+// address. The portmapper binds wildcard, so the address a service is reachable
+// at is the same one the client used to reach the portmapper; libtirpc-based
+// clients additionally fix up the host to the rpcbind address they queried, so
+// the port carried by the uaddr is what is authoritative.
+func uaddrHost(clientAddr string) string {
+	host, _, err := net.SplitHostPort(clientAddr)
+	if err != nil {
+		return clientAddr
+	}
+	return host
+}
+
+// Getaddr implements RPCBIND GETADDR / GETVERSADDR (RFC 1833, procedures 3/9).
+// It resolves a (prog, vers, netid) tuple to a universal address, returning an
+// empty string when the service is not registered (the protocol's "not found").
+func (h *Handler) Getaddr(data []byte, clientAddr string) ([]byte, error) {
+	rpcb, err := xdr.DecodeRPCB(data)
+	if err != nil {
+		return nil, err
+	}
+
+	proto, ok := netidToProtocol(rpcb.Netid)
+	if !ok {
+		logger.Debug("RPCBIND GETADDR: unknown netid",
+			"netid", rpcb.Netid, "client", clientAddr)
+		return xdr.EncodeGetaddrResponse(""), nil
+	}
+
+	port := h.Registry.Getport(rpcb.Prog, rpcb.Vers, proto)
+	if port == 0 {
+		return xdr.EncodeGetaddrResponse(""), nil
+	}
+
+	uaddr := xdr.BuildUaddr(uaddrHost(clientAddr), port)
+	logger.Debug("RPCBIND GETADDR",
+		"prog", rpcb.Prog, "vers", rpcb.Vers, "netid", rpcb.Netid,
+		"uaddr", uaddr, "client", clientAddr)
+	return xdr.EncodeGetaddrResponse(uaddr), nil
+}
+
+// RpcbDump implements RPCBIND DUMP (RFC 1833, procedure 4), returning every
+// registration as an rpcb entry with a universal address derived from the
+// client's address.
+func (h *Handler) RpcbDump(clientAddr string) ([]byte, error) {
+	host := uaddrHost(clientAddr)
+	mappings := h.Registry.Dump()
+	entries := make([]xdr.RPCB, 0, len(mappings))
+	for _, m := range mappings {
+		netid := protocolToNetid(m.Prot)
+		if netid == "" {
+			continue
+		}
+		entries = append(entries, xdr.RPCB{
+			Prog:  m.Prog,
+			Vers:  m.Vers,
+			Netid: netid,
+			Addr:  xdr.BuildUaddr(host, m.Port),
+			Owner: "superuser",
+		})
+	}
+	return xdr.EncodeRpcbDumpResponse(entries), nil
+}

--- a/internal/adapter/nfs/portmap/handlers/rpcbind_test.go
+++ b/internal/adapter/nfs/portmap/handlers/rpcbind_test.go
@@ -1,0 +1,135 @@
+package handlers
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/portmap/types"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/portmap/xdr"
+)
+
+// fakeRegistry is a minimal PortmapRegistry for handler tests. It avoids
+// importing the parent portmap package (which imports this one).
+type fakeRegistry struct {
+	mappings []*xdr.Mapping
+}
+
+func (f *fakeRegistry) Set(m *xdr.Mapping) bool {
+	f.mappings = append(f.mappings, m)
+	return true
+}
+func (f *fakeRegistry) Unset(_, _, _ uint32) bool { return false }
+func (f *fakeRegistry) Getport(prog, vers, prot uint32) uint32 {
+	for _, m := range f.mappings {
+		if m.Prog == prog && m.Vers == vers && m.Prot == prot {
+			return m.Port
+		}
+	}
+	return 0
+}
+func (f *fakeRegistry) Dump() []*xdr.Mapping { return f.mappings }
+
+// encodeRPCB builds an RPCBIND rpcb argument for GETADDR.
+func encodeRPCB(prog, vers uint32, netid, addr, owner string) []byte {
+	var buf []byte
+	var u [4]byte
+	binary.BigEndian.PutUint32(u[:], prog)
+	buf = append(buf, u[:]...)
+	binary.BigEndian.PutUint32(u[:], vers)
+	buf = append(buf, u[:]...)
+	for _, s := range []string{netid, addr, owner} {
+		binary.BigEndian.PutUint32(u[:], uint32(len(s)))
+		buf = append(buf, u[:]...)
+		buf = append(buf, s...)
+		for len(buf)%4 != 0 {
+			buf = append(buf, 0)
+		}
+	}
+	return buf
+}
+
+// decodeXDRString reads the single XDR string a GETADDR reply carries.
+func decodeXDRString(t *testing.T, b []byte) string {
+	t.Helper()
+	if len(b) < 4 {
+		t.Fatalf("reply too short: %d bytes", len(b))
+	}
+	n := int(binary.BigEndian.Uint32(b[:4]))
+	if 4+n > len(b) {
+		t.Fatalf("reply string length %d exceeds %d bytes", n, len(b))
+	}
+	return string(b[4 : 4+n])
+}
+
+func newRpcbHandler() *Handler {
+	reg := &fakeRegistry{}
+	// nlockmgr (NLM) v3 over UDP on the NFS data port — the macOS lock path.
+	reg.Set(&xdr.Mapping{Prog: 100021, Vers: 3, Prot: types.ProtoUDP, Port: 12049})
+	reg.Set(&xdr.Mapping{Prog: 100021, Vers: 4, Prot: types.ProtoTCP, Port: 12049})
+	return NewHandler(reg)
+}
+
+// TestGetaddr_ResolvesUniversalAddress verifies GETADDR returns the correct
+// uaddr for a registered service over both IPv4 and IPv6 netids (12049 -> .47.17),
+// and an empty string for unknown services or netids.
+func TestGetaddr_ResolvesUniversalAddress(t *testing.T) {
+	h := newRpcbHandler()
+
+	cases := []struct {
+		name       string
+		prog, vers uint32
+		netid      string
+		client     string
+		wantUaddr  string
+	}{
+		{"udp6 IPv6 client (macOS NLM)", 100021, 3, "udp6", "[::1]:611", "::1.47.17"},
+		{"udp IPv4 client", 100021, 3, "udp", "127.0.0.1:702", "127.0.0.1.47.17"},
+		{"tcp6 IPv6 client", 100021, 4, "tcp6", "[fd00::5]:900", "fd00::5.47.17"},
+		{"unregistered program -> empty", 100099, 1, "udp6", "[::1]:611", ""},
+		{"unknown netid -> empty", 100021, 3, "rdma", "[::1]:611", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			arg := encodeRPCB(tc.prog, tc.vers, tc.netid, "", "")
+			reply, err := h.Getaddr(arg, tc.client)
+			if err != nil {
+				t.Fatalf("Getaddr: %v", err)
+			}
+			if got := decodeXDRString(t, reply); got != tc.wantUaddr {
+				t.Errorf("uaddr = %q, want %q", got, tc.wantUaddr)
+			}
+		})
+	}
+}
+
+// TestRpcbDump_EmitsEntries verifies DUMP renders each registration as an rpcb
+// entry terminated by a FALSE list marker.
+func TestRpcbDump_EmitsEntries(t *testing.T) {
+	h := newRpcbHandler()
+	reply, err := h.RpcbDump("127.0.0.1:702")
+	if err != nil {
+		t.Fatalf("RpcbDump: %v", err)
+	}
+	if len(reply) < 4 {
+		t.Fatalf("dump reply too short: %d bytes", len(reply))
+	}
+	// Must be non-empty (at least one TRUE marker) and end with a FALSE marker.
+	if binary.BigEndian.Uint32(reply[:4]) != 1 {
+		t.Errorf("expected first list marker TRUE (1), got %d", binary.BigEndian.Uint32(reply[:4]))
+	}
+	if tail := binary.BigEndian.Uint32(reply[len(reply)-4:]); tail != 0 {
+		t.Errorf("expected terminating list marker FALSE (0), got %d", tail)
+	}
+}
+
+// TestDecodeRPCB_RoundTrip exercises the rpcb decoder against a hand-built arg.
+func TestDecodeRPCB_RoundTrip(t *testing.T) {
+	arg := encodeRPCB(100021, 4, "udp6", "::1.47.17", "owner")
+	r, err := xdr.DecodeRPCB(arg)
+	if err != nil {
+		t.Fatalf("DecodeRPCB: %v", err)
+	}
+	if r.Prog != 100021 || r.Vers != 4 || r.Netid != "udp6" || r.Addr != "::1.47.17" || r.Owner != "owner" {
+		t.Errorf("decoded %+v, mismatch", r)
+	}
+}

--- a/internal/adapter/nfs/portmap/portmap_integration_test.go
+++ b/internal/adapter/nfs/portmap/portmap_integration_test.go
@@ -233,8 +233,8 @@ func TestPortmapperIntegrationUDP(t *testing.T) {
 func TestPortmapperFullServiceRegistry(t *testing.T) {
 	srv, registry := startTestServer(t)
 
-	// Register all DittoFS services on port 12049
-	registry.RegisterDittoFSServices(12049)
+	// Register all DittoFS services on port 12049 (TCP-only for this test)
+	registry.RegisterDittoFSServices(12049, false)
 
 	tcpAddr := srv.Addr()
 
@@ -278,8 +278,8 @@ func TestPortmapperFullServiceRegistry(t *testing.T) {
 		})
 	}
 
-	// Verify DUMP returns exactly 5 entries (TCP-only)
-	t.Run("DUMP_5_entries", func(t *testing.T) {
+	// Verify DUMP returns exactly the 9 TCP-only entries
+	t.Run("DUMP_9_entries", func(t *testing.T) {
 		msg := buildRPCCall(0x30000001, types.ProgramPortmap, types.PortmapVersion2, types.ProcDump, nil)
 		reply := sendTCPRequest(t, tcpAddr, msg)
 
@@ -309,8 +309,9 @@ func TestPortmapperFullServiceRegistry(t *testing.T) {
 			count++
 		}
 
-		if count != 7 {
-			t.Errorf("DUMP count: got %d, want 7", count)
+		// 9 TCP mappings: NFS v3/v4, MOUNT v1/v2/v3, NLM v1/v3/v4, NSM v1.
+		if count != 9 {
+			t.Errorf("DUMP count: got %d, want 9", count)
 		}
 	})
 }

--- a/internal/adapter/nfs/portmap/registry.go
+++ b/internal/adapter/nfs/portmap/registry.go
@@ -128,17 +128,26 @@ func (r *Registry) Dump() []*xdr.Mapping {
 }
 
 // RegisterDittoFSServices registers all DittoFS RPC services on the given port.
-// This populates the portmap registry with NFS, MOUNT, NLM, and NSM services
-// on TCP only (DittoFS NFS adapter is TCP-only, no UDP transport).
+// This populates the portmap registry with NFS, MOUNT, NLM, and NSM services.
 //
-// Registered services:
-//   - NFS (100003) v3 and v4 on TCP
-//   - MOUNT (100005) v1, v2, and v3 on TCP (v1/v2 for client compatibility)
-//   - NLM (100021) v4 on TCP
-//   - NSM (100024) v1 on TCP
+// NFS data operations are always TCP-only (large READ/WRITE payloads do not fit
+// a UDP datagram). The lock-manager auxiliary protocols (NLM, NSM) and MOUNT are
+// additionally advertised over UDP when udpEnabled is true, because BSD/macOS
+// NFSv3 lock clients (rpc.lockd / rpc.statd) discover and reach them over UDP
+// (issue #1353). NLM is advertised as v1, v3, and v4 so both BSD/macOS (v1/v3,
+// 32-bit offsets) and Linux (v4, 64-bit) clients find a usable version.
 //
-// This results in 7 mappings total (7 program/version pairs x TCP).
-func (r *Registry) RegisterDittoFSServices(nfsPort int) {
+// Always registered (TCP):
+//   - NFS (100003) v3 and v4
+//   - MOUNT (100005) v1, v2, v3 (v1/v2 for client compatibility)
+//   - NLM (100021) v1, v3, v4
+//   - NSM (100024) v1
+//
+// Additionally registered when udpEnabled (UDP):
+//   - MOUNT (100005) v1, v2, v3
+//   - NLM (100021) v1, v3, v4
+//   - NSM (100024) v1
+func (r *Registry) RegisterDittoFSServices(nfsPort int, udpEnabled bool) {
 	port := uint32(nfsPort)
 
 	type svc struct {
@@ -146,18 +155,39 @@ func (r *Registry) RegisterDittoFSServices(nfsPort int) {
 		vers uint32
 	}
 
-	services := []svc{
+	// TCP services. NFS is TCP-only; NLM/NSM/MOUNT are served over TCP too.
+	tcpServices := []svc{
 		{100003, 3}, // NFS v3
 		{100003, 4}, // NFS v4
 		{100005, 1}, // MOUNT v1 (client compatibility)
 		{100005, 2}, // MOUNT v2 (client compatibility)
 		{100005, 3}, // MOUNT v3
+		{100021, 1}, // NLM v1 (32-bit offsets; BSD/macOS)
+		{100021, 3}, // NLM v3 (32-bit offsets; BSD/macOS)
+		{100021, 4}, // NLM v4 (64-bit offsets; Linux)
+		{100024, 1}, // NSM v1
+	}
+	for _, s := range tcpServices {
+		r.Set(&xdr.Mapping{Prog: s.prog, Vers: s.vers, Prot: types.ProtoTCP, Port: port})
+	}
+
+	if !udpEnabled {
+		return
+	}
+
+	// UDP services: the lock-manager protocols and MOUNT only. NFS is never
+	// advertised over UDP since it is not served there.
+	udpServices := []svc{
+		{100005, 1}, // MOUNT v1
+		{100005, 2}, // MOUNT v2
+		{100005, 3}, // MOUNT v3
+		{100021, 1}, // NLM v1
+		{100021, 3}, // NLM v3
 		{100021, 4}, // NLM v4
 		{100024, 1}, // NSM v1
 	}
-
-	for _, s := range services {
-		r.Set(&xdr.Mapping{Prog: s.prog, Vers: s.vers, Prot: types.ProtoTCP, Port: port})
+	for _, s := range udpServices {
+		r.Set(&xdr.Mapping{Prog: s.prog, Vers: s.vers, Prot: types.ProtoUDP, Port: port})
 	}
 }
 

--- a/internal/adapter/nfs/portmap/registry_test.go
+++ b/internal/adapter/nfs/portmap/registry_test.go
@@ -184,15 +184,15 @@ func TestDumpReturnsSnapshotCopies(t *testing.T) {
 
 func TestRegisterDittoFSServices(t *testing.T) {
 	r := NewRegistry()
-	r.RegisterDittoFSServices(12049)
+	r.RegisterDittoFSServices(12049, false)
 
-	// Should have 7 mappings: 7 program/version pairs x TCP only
-	// (DittoFS NFS adapter is TCP-only, no UDP transport)
-	if r.Count() != 7 {
-		t.Fatalf("RegisterDittoFSServices created %d mappings, want 7", r.Count())
+	// With UDP disabled: 9 TCP mappings (NFS v3/v4, MOUNT v1/v2/v3,
+	// NLM v1/v3/v4, NSM v1) and nothing on UDP.
+	if r.Count() != 9 {
+		t.Fatalf("RegisterDittoFSServices(udp=false) created %d mappings, want 9", r.Count())
 	}
 
-	// Verify each expected registration
+	// Verify each expected TCP registration
 	expectations := []struct {
 		name string
 		prog uint32
@@ -203,6 +203,8 @@ func TestRegisterDittoFSServices(t *testing.T) {
 		{"MOUNT v1", 100005, 1},
 		{"MOUNT v2", 100005, 2},
 		{"MOUNT v3", 100005, 3},
+		{"NLM v1", 100021, 1},
+		{"NLM v3", 100021, 3},
 		{"NLM v4", 100021, 4},
 		{"NSM v1", 100024, 1},
 	}
@@ -213,17 +215,50 @@ func TestRegisterDittoFSServices(t *testing.T) {
 			t.Errorf("%s TCP: port = %d, want 12049", exp.name, tcpPort)
 		}
 
-		// UDP should NOT be registered (NFS adapter is TCP-only)
+		// UDP should NOT be registered when udpEnabled is false.
 		udpPort := r.Getport(exp.prog, exp.vers, 17)
 		if udpPort != 0 {
-			t.Errorf("%s UDP: port = %d, want 0 (should not be registered)", exp.name, udpPort)
+			t.Errorf("%s UDP: port = %d, want 0 (UDP disabled)", exp.name, udpPort)
 		}
+	}
+}
+
+func TestRegisterDittoFSServicesUDP(t *testing.T) {
+	r := NewRegistry()
+	r.RegisterDittoFSServices(12049, true)
+
+	// 9 TCP + 7 UDP (MOUNT v1/v2/v3, NLM v1/v3/v4, NSM v1). NFS stays TCP-only.
+	if r.Count() != 16 {
+		t.Fatalf("RegisterDittoFSServices(udp=true) created %d mappings, want 16", r.Count())
+	}
+
+	// The lock-manager protocols and MOUNT must be reachable over UDP.
+	udpExpect := []struct {
+		name       string
+		prog, vers uint32
+	}{
+		{"MOUNT v1", 100005, 1},
+		{"MOUNT v3", 100005, 3},
+		{"NLM v1", 100021, 1},
+		{"NLM v3", 100021, 3},
+		{"NLM v4", 100021, 4},
+		{"NSM v1", 100024, 1},
+	}
+	for _, exp := range udpExpect {
+		if port := r.Getport(exp.prog, exp.vers, 17); port != 12049 {
+			t.Errorf("%s UDP: port = %d, want 12049", exp.name, port)
+		}
+	}
+
+	// NFS must never be advertised over UDP.
+	if port := r.Getport(100003, 3, 17); port != 0 {
+		t.Errorf("NFS v3 UDP: port = %d, want 0 (NFS is TCP-only)", port)
 	}
 }
 
 func TestRegisterDittoFSServicesCustomPort(t *testing.T) {
 	r := NewRegistry()
-	r.RegisterDittoFSServices(2049)
+	r.RegisterDittoFSServices(2049, false)
 
 	port := r.Getport(100003, 3, 6)
 	if port != 2049 {
@@ -237,7 +272,7 @@ func TestRegisterDittoFSServicesCustomPort(t *testing.T) {
 
 func TestClear(t *testing.T) {
 	r := NewRegistry()
-	r.RegisterDittoFSServices(12049)
+	r.RegisterDittoFSServices(12049, true)
 
 	if r.Count() == 0 {
 		t.Fatal("Registry should not be empty before Clear")

--- a/internal/adapter/nfs/portmap/server.go
+++ b/internal/adapter/nfs/portmap/server.go
@@ -327,14 +327,23 @@ func (s *Server) processRPCMessage(data []byte, clientAddr string) []byte {
 		return makeErrorReplyBody(call.XID, rpc.RPCProgUnavail)
 	}
 
-	// Validate version
-	if call.Version != types.PortmapVersion2 {
+	// Validate version and select the dispatch table. v2 is the legacy PMAP
+	// protocol (RFC 1057); v3/v4 are RPCBIND (RFC 1833), which macOS/BSD NFS
+	// lock clients require to discover the NLM/NSM ports (they query over the
+	// mount's address family and do not fall back to v2).
+	var dispatch map[uint32]*PmapProcedure
+	switch call.Version {
+	case types.PortmapVersion2:
+		dispatch = DispatchTable
+	case types.PortmapVersion3, types.PortmapVersion4:
+		dispatch = RpcbDispatchTable
+	default:
 		logger.Debug("Portmap: version mismatch", "version", call.Version, "client", clientAddr)
-		return makeProgMismatchReplyBody(call.XID, types.PortmapVersion2, types.PortmapVersion2)
+		return makeProgMismatchReplyBody(call.XID, types.PortmapVersion2, types.PortmapVersion4)
 	}
 
 	// Look up procedure in dispatch table
-	proc, ok := DispatchTable[call.Procedure]
+	proc, ok := dispatch[call.Procedure]
 	if !ok {
 		logger.Debug("Portmap: procedure unavailable", "procedure", call.Procedure, "client", clientAddr)
 		return makeErrorReplyBody(call.XID, rpc.RPCProcUnavail)

--- a/internal/adapter/nfs/portmap/server_test.go
+++ b/internal/adapter/nfs/portmap/server_test.go
@@ -375,8 +375,8 @@ func TestServerTCPVersionMismatch(t *testing.T) {
 	low := binary.BigEndian.Uint32(payload[0:4])
 	high := binary.BigEndian.Uint32(payload[4:8])
 
-	if low != 2 || high != 2 {
-		t.Errorf("version range: got [%d, %d], want [2, 2]", low, high)
+	if low != 2 || high != 4 {
+		t.Errorf("version range: got [%d, %d], want [2, 4]", low, high)
 	}
 }
 
@@ -731,8 +731,8 @@ func TestServerUDPVersionMismatch(t *testing.T) {
 	}
 	low := binary.BigEndian.Uint32(payload[0:4])
 	high := binary.BigEndian.Uint32(payload[4:8])
-	if low != 2 || high != 2 {
-		t.Errorf("version range: got [%d, %d], want [2, 2]", low, high)
+	if low != 2 || high != 4 {
+		t.Errorf("version range: got [%d, %d], want [2, 4]", low, high)
 	}
 }
 

--- a/internal/adapter/nfs/portmap/server_test.go
+++ b/internal/adapter/nfs/portmap/server_test.go
@@ -648,8 +648,8 @@ func TestServerTCPUnknownProcedure(t *testing.T) {
 func TestServerUDPDump(t *testing.T) {
 	srv, registry := startTestServer(t)
 
-	// Register services via registry directly
-	registry.RegisterDittoFSServices(12049)
+	// Register services via registry directly (UDP advertised for this test)
+	registry.RegisterDittoFSServices(12049, true)
 
 	msg := buildRPCCall(0x99999999, types.ProgramPortmap, types.PortmapVersion2, types.ProcDump, nil)
 	reply := sendUDPRequest(t, srv.UDPAddr(), msg)
@@ -681,9 +681,11 @@ func TestServerUDPDump(t *testing.T) {
 		count++
 	}
 
-	// RegisterDittoFSServices registers 7 entries (TCP-only, includes MOUNT v1+v2+v3)
-	if count != 7 {
-		t.Errorf("DUMP entry count: got %d, want 7", count)
+	// RegisterDittoFSServices(udp=true) registers 16 entries: 9 TCP
+	// (NFS v3/v4, MOUNT v1/v2/v3, NLM v1/v3/v4, NSM v1) + 7 UDP
+	// (MOUNT v1/v2/v3, NLM v1/v3/v4, NSM v1).
+	if count != 16 {
+		t.Errorf("DUMP entry count: got %d, want 16", count)
 	}
 }
 

--- a/internal/adapter/nfs/portmap/types/constants.go
+++ b/internal/adapter/nfs/portmap/types/constants.go
@@ -23,6 +23,31 @@ const (
 	// PortmapVersion2 is the portmap protocol version 2.
 	// This is the version defined in RFC 1057 and used by rpcinfo/showmount.
 	PortmapVersion2 uint32 = 2
+
+	// PortmapVersion3 and PortmapVersion4 are the RPCBIND protocol versions
+	// (RFC 1833). They use string-based universal addresses instead of the v2
+	// (prog, vers, prot) -> port mapping. macOS/BSD NFS lock clients query NLM
+	// via RPCBIND v3/v4 (over the mount's address family) and do not fall back
+	// to v2, so the embedded portmapper must answer them to enable NFSv3 locking.
+	PortmapVersion3 uint32 = 3
+	PortmapVersion4 uint32 = 4
+)
+
+// ============================================================================
+// RPCBIND v3/v4 Procedure Numbers (RFC 1833)
+// ============================================================================
+
+const (
+	// RpcbProcGetaddr looks up the universal address for a (prog, vers, netid)
+	// tuple. Returns the uaddr string, or "" if not registered. (v3 and v4.)
+	RpcbProcGetaddr uint32 = 3
+
+	// RpcbProcDump returns all registrations as a list of rpcb entries. (v3/v4.)
+	RpcbProcDump uint32 = 4
+
+	// RpcbProcGetversaddr (v4) is like GETADDR but matches the exact version.
+	// Our lookup is already version-exact, so it shares the GETADDR handler.
+	RpcbProcGetversaddr uint32 = 9
 )
 
 // ============================================================================

--- a/internal/adapter/nfs/portmap/xdr/rpcbind.go
+++ b/internal/adapter/nfs/portmap/xdr/rpcbind.go
@@ -1,0 +1,110 @@
+package xdr
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// RPCB is the RPCBIND v3/v4 address mapping (RFC 1833, struct rpcb).
+//
+//	struct rpcb {
+//	    unsigned long r_prog;   // program number
+//	    unsigned long r_vers;   // version number
+//	    string        r_netid;  // transport: "tcp", "udp", "tcp6", "udp6"
+//	    string        r_addr;   // universal address ("host.p1.p2")
+//	    string        r_owner;  // owner of the registration
+//	};
+type RPCB struct {
+	Prog  uint32
+	Vers  uint32
+	Netid string
+	Addr  string
+	Owner string
+}
+
+// readXDRString reads an XDR variable-length string (uint32 length + bytes +
+// padding to a 4-byte boundary) starting at off, returning the next offset.
+func readXDRString(data []byte, off int) (string, int, error) {
+	if off+4 > len(data) {
+		return "", 0, fmt.Errorf("rpcb: truncated string length at offset %d", off)
+	}
+	n := int(binary.BigEndian.Uint32(data[off:]))
+	off += 4
+	if n < 0 || off+n > len(data) {
+		return "", 0, fmt.Errorf("rpcb: string length %d exceeds remaining buffer", n)
+	}
+	s := string(data[off : off+n])
+	off += n + (4-n%4)%4 // skip the value and its XDR padding
+	if off > len(data) {
+		off = len(data)
+	}
+	return s, off, nil
+}
+
+// writeXDRString appends an XDR string (length + bytes + padding) to buf.
+func writeXDRString(buf []byte, s string) []byte {
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(s)))
+	buf = append(buf, hdr[:]...)
+	buf = append(buf, s...)
+	if pad := (4 - len(s)%4) % 4; pad > 0 {
+		buf = append(buf, make([]byte, pad)...)
+	}
+	return buf
+}
+
+// DecodeRPCB decodes an RPCBIND rpcb argument (used by GETADDR/GETVERSADDR).
+func DecodeRPCB(data []byte) (*RPCB, error) {
+	if len(data) < 8 {
+		return nil, fmt.Errorf("rpcb: argument too short (%d bytes)", len(data))
+	}
+	r := &RPCB{
+		Prog: binary.BigEndian.Uint32(data[0:4]),
+		Vers: binary.BigEndian.Uint32(data[4:8]),
+	}
+	off := 8
+	var err error
+	if r.Netid, off, err = readXDRString(data, off); err != nil {
+		return nil, err
+	}
+	if r.Addr, off, err = readXDRString(data, off); err != nil {
+		return nil, err
+	}
+	if r.Owner, _, err = readXDRString(data, off); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// EncodeGetaddrResponse encodes the GETADDR result: a single XDR string holding
+// the universal address ("" when the service is not registered).
+func EncodeGetaddrResponse(uaddr string) []byte {
+	return writeXDRString(nil, uaddr)
+}
+
+// EncodeRpcbDumpResponse encodes the RPCBIND DUMP result, an rpcblist. The XDR
+// pointer/list form prefixes each element with a TRUE marker and terminates the
+// list with FALSE.
+func EncodeRpcbDumpResponse(entries []RPCB) []byte {
+	var buf []byte
+	var marker [4]byte
+	for i := range entries {
+		binary.BigEndian.PutUint32(marker[:], 1) // value_follows = TRUE
+		buf = append(buf, marker[:]...)
+		var pv [8]byte
+		binary.BigEndian.PutUint32(pv[0:4], entries[i].Prog)
+		binary.BigEndian.PutUint32(pv[4:8], entries[i].Vers)
+		buf = append(buf, pv[:]...)
+		buf = writeXDRString(buf, entries[i].Netid)
+		buf = writeXDRString(buf, entries[i].Addr)
+		buf = writeXDRString(buf, entries[i].Owner)
+	}
+	binary.BigEndian.PutUint32(marker[:], 0) // value_follows = FALSE (end of list)
+	return append(buf, marker[:]...)
+}
+
+// BuildUaddr renders a universal address (RFC 1833 §2.2): the textual host
+// followed by ".p1.p2", where the port equals p1*256 + p2.
+func BuildUaddr(host string, port uint32) string {
+	return fmt.Sprintf("%s.%d.%d", host, (port>>8)&0xff, port&0xff)
+}

--- a/internal/adapter/nfs/rpc/constants.go
+++ b/internal/adapter/nfs/rpc/constants.go
@@ -61,9 +61,18 @@ const (
 	// This version is required for NFSv3 mounts.
 	MountVersion3 = 3
 
+	// NLMVersion1 is the original Network Lock Manager protocol version.
+	// NLM v1/v3 use 32-bit offsets and lengths. BSD/macOS NFSv3 lock clients
+	// commonly negotiate v1/v3 (over UDP), so DittoFS accepts them (issue #1353).
+	NLMVersion1 = 1
+
+	// NLMVersion3 is NLM protocol version 3: 32-bit offsets like v1, plus the
+	// SHARE/UNSHARE/NM_LOCK/FREE_ALL procedures.
+	NLMVersion3 = 3
+
 	// NLMVersion4 is the Network Lock Manager protocol version 4.
 	// NLM v4 uses 64-bit offsets and lengths, required for large file support.
-	// This is the only NLM version supported by DittoFS.
+	// Linux NFSv3 clients negotiate v4.
 	NLMVersion4 = 4
 
 	// NSMVersion1 is the Network Status Monitor protocol version 1.

--- a/internal/controlplane/api/handlers/adapter_settings.go
+++ b/internal/controlplane/api/handlers/adapter_settings.go
@@ -52,6 +52,7 @@ type PatchNFSSettingsRequest struct {
 	BlockedOperations          *[]string `json:"blocked_operations,omitempty"`
 	PortmapperEnabled          *bool     `json:"portmapper_enabled,omitempty"`
 	PortmapperPort             *int      `json:"portmapper_port,omitempty"`
+	UDPEnabled                 *bool     `json:"udp_enabled,omitempty"`
 }
 
 // PutNFSSettingsRequest requires all fields for full replacement.
@@ -78,6 +79,7 @@ type PutNFSSettingsRequest struct {
 	BlockedOperations          []string `json:"blocked_operations"`
 	PortmapperEnabled          bool     `json:"portmapper_enabled"`
 	PortmapperPort             int      `json:"portmapper_port"`
+	UDPEnabled                 bool     `json:"udp_enabled"`
 }
 
 // --- SMB request types ---
@@ -134,6 +136,7 @@ type NFSSettingsResponse struct {
 	BlockedOperations          []string `json:"blocked_operations"`
 	PortmapperEnabled          bool     `json:"portmapper_enabled"`
 	PortmapperPort             int      `json:"portmapper_port"`
+	UDPEnabled                 bool     `json:"udp_enabled"`
 	Version                    int      `json:"version"`
 }
 
@@ -353,6 +356,7 @@ func (h *AdapterSettingsHandler) PutSettings(w http.ResponseWriter, r *http.Requ
 		settings.SetBlockedOperations(req.BlockedOperations)
 		settings.PortmapperEnabled = req.PortmapperEnabled
 		settings.PortmapperPort = req.PortmapperPort
+		settings.UDPEnabled = req.UDPEnabled
 
 		if !h.validateAndRespond(w, adapterType, settings, nil, force) {
 			return
@@ -524,6 +528,9 @@ func (h *AdapterSettingsHandler) PatchSettings(w http.ResponseWriter, r *http.Re
 		}
 		if req.PortmapperPort != nil {
 			settings.PortmapperPort = *req.PortmapperPort
+		}
+		if req.UDPEnabled != nil {
+			settings.UDPEnabled = *req.UDPEnabled
 		}
 
 		if !h.validateAndRespond(w, adapterType, settings, nil, force) {
@@ -1015,6 +1022,7 @@ func nfsSettingsToResponse(s *models.NFSAdapterSettings) NFSSettingsResponse {
 		BlockedOperations:          ops,
 		PortmapperEnabled:          s.PortmapperEnabled,
 		PortmapperPort:             s.PortmapperPort,
+		UDPEnabled:                 s.UDPEnabled,
 		Version:                    s.Version,
 	}
 }

--- a/k8s/dittofs-operator/internal/controller/networkpolicy_reconciler.go
+++ b/k8s/dittofs-operator/internal/controller/networkpolicy_reconciler.go
@@ -87,6 +87,11 @@ func buildAdapterIngressPorts(adapterType string, port int32) []networkingv1.Net
 				Protocol: &udp,
 				Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: portmapperContainerPort},
 			},
+			// NLM/NSM/MOUNT over UDP land on the NFS data port (issue #1353).
+			networkingv1.NetworkPolicyPort{
+				Protocol: &udp,
+				Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: port},
+			},
 		)
 	}
 	return ports

--- a/k8s/dittofs-operator/internal/controller/networkpolicy_reconciler_test.go
+++ b/k8s/dittofs-operator/internal/controller/networkpolicy_reconciler_test.go
@@ -171,12 +171,12 @@ func TestReconcileNetworkPolicies_CreatesForRunningAdapter(t *testing.T) {
 		t.Errorf("Expected PolicyTypes [Ingress], got %v", np.Spec.PolicyTypes)
 	}
 
-	// Verify Ingress rules (NFS gets 3 ports: NFS TCP + portmapper TCP + portmapper UDP).
+	// Verify Ingress rules (NFS gets 4 ports: NFS TCP + portmapper TCP + portmapper UDP + NFS data port UDP).
 	if len(np.Spec.Ingress) != 1 {
 		t.Fatalf("Expected 1 ingress rule, got %d", len(np.Spec.Ingress))
 	}
-	if len(np.Spec.Ingress[0].Ports) != 3 {
-		t.Fatalf("Expected 3 ingress ports (NFS + portmapper TCP/UDP), got %d", len(np.Spec.Ingress[0].Ports))
+	if len(np.Spec.Ingress[0].Ports) != 4 {
+		t.Fatalf("Expected 4 ingress ports (NFS + portmapper TCP/UDP + NFS UDP), got %d", len(np.Spec.Ingress[0].Ports))
 	}
 	ingressPort := np.Spec.Ingress[0].Ports[0]
 	if ingressPort.Port == nil || ingressPort.Port.IntVal != 12049 {
@@ -238,10 +238,10 @@ func TestReconcileNetworkPolicies_MultipleAdapters(t *testing.T) {
 	if nfsNP.Name != "test-server-adapter-nfs" {
 		t.Errorf("Expected NFS NetworkPolicy name 'test-server-adapter-nfs', got %s", nfsNP.Name)
 	}
-	// NFS should have 3 ingress ports (NFS + portmapper TCP/UDP).
+	// NFS should have 4 ingress ports (NFS + portmapper TCP/UDP + NFS data port UDP).
 	if len(nfsNP.Spec.Ingress) > 0 {
-		if len(nfsNP.Spec.Ingress[0].Ports) != 3 {
-			t.Errorf("Expected NFS NetworkPolicy to have 3 ingress ports, got %d", len(nfsNP.Spec.Ingress[0].Ports))
+		if len(nfsNP.Spec.Ingress[0].Ports) != 4 {
+			t.Errorf("Expected NFS NetworkPolicy to have 4 ingress ports, got %d", len(nfsNP.Spec.Ingress[0].Ports))
 		}
 		if nfsNP.Spec.Ingress[0].Ports[0].Port.IntVal != 12049 {
 			t.Errorf("Expected NFS port 12049, got %d", nfsNP.Spec.Ingress[0].Ports[0].Port.IntVal)
@@ -320,8 +320,8 @@ func TestReconcileNetworkPolicies_UpdatesWhenPortChanges(t *testing.T) {
 	if len(updated.Spec.Ingress) != 1 {
 		t.Fatalf("Expected 1 ingress rule, got %d", len(updated.Spec.Ingress))
 	}
-	if len(updated.Spec.Ingress[0].Ports) != 3 {
-		t.Fatalf("Expected 3 ingress ports (NFS + portmapper TCP/UDP), got %d", len(updated.Spec.Ingress[0].Ports))
+	if len(updated.Spec.Ingress[0].Ports) != 4 {
+		t.Fatalf("Expected 4 ingress ports (NFS + portmapper TCP/UDP), got %d", len(updated.Spec.Ingress[0].Ports))
 	}
 	if updated.Spec.Ingress[0].Ports[0].Port.IntVal != 2049 {
 		t.Errorf("Expected NFS port 2049, got %d", updated.Spec.Ingress[0].Ports[0].Port.IntVal)
@@ -516,8 +516,8 @@ func TestBuildAdapterNetworkPolicy_NFS_MultiPort(t *testing.T) {
 	if len(np.Spec.Ingress) != 1 {
 		t.Fatalf("Expected 1 ingress rule, got %d", len(np.Spec.Ingress))
 	}
-	if len(np.Spec.Ingress[0].Ports) != 3 {
-		t.Fatalf("Expected 3 ingress ports for NFS (NFS + portmapper TCP/UDP), got %d", len(np.Spec.Ingress[0].Ports))
+	if len(np.Spec.Ingress[0].Ports) != 4 {
+		t.Fatalf("Expected 4 ingress ports for NFS (NFS + portmapper TCP/UDP), got %d", len(np.Spec.Ingress[0].Ports))
 	}
 
 	// First port: NFS (TCP)
@@ -590,7 +590,7 @@ func TestUpdateNetworkPolicy_NFS_SinglePortToMultiPort(t *testing.T) {
 	if len(updated.Spec.Ingress) != 1 {
 		t.Fatalf("Expected 1 ingress rule, got %d", len(updated.Spec.Ingress))
 	}
-	if len(updated.Spec.Ingress[0].Ports) != 3 {
-		t.Fatalf("Expected 3 ingress ports after update (NFS + portmapper TCP/UDP), got %d", len(updated.Spec.Ingress[0].Ports))
+	if len(updated.Spec.Ingress[0].Ports) != 4 {
+		t.Fatalf("Expected 4 ingress ports after update (NFS + portmapper TCP/UDP), got %d", len(updated.Spec.Ingress[0].Ports))
 	}
 }

--- a/k8s/dittofs-operator/internal/controller/service_reconciler.go
+++ b/k8s/dittofs-operator/internal/controller/service_reconciler.go
@@ -135,7 +135,8 @@ func isNFSAdapter(adapterType string) bool {
 }
 
 // buildAdapterServicePorts returns the Service ports for an adapter.
-// NFS adapters get 3 ports (NFS + portmapper TCP/UDP 111→10111), all others get 1.
+// NFS adapters get 4 ports (NFS TCP, portmapper TCP + UDP 111→10111, and the
+// NFS data port over UDP for NLM/NSM/MOUNT); all others get 1.
 func buildAdapterServicePorts(adapterType string, info AdapterInfo) []corev1.ServicePort {
 	portName := adapterPortName(adapterType)
 	ports := []corev1.ServicePort{
@@ -158,6 +159,15 @@ func buildAdapterServicePorts(adapterType string, info AdapterInfo) []corev1.Ser
 				Name:       portmapperUDPPortName,
 				Port:       portmapperServicePort,
 				TargetPort: intstr.FromInt32(portmapperContainerPort),
+				Protocol:   corev1.ProtocolUDP,
+			},
+			// NLM/NSM/MOUNT are served over UDP on the NFS data port when the
+			// UDP transport is enabled; expose that port over UDP so BSD/macOS
+			// NFSv3 lock clients can reach rpc.lockd/rpc.statd (issue #1353).
+			corev1.ServicePort{
+				Name:       portName + "-udp",
+				Port:       int32(info.Port),
+				TargetPort: intstr.FromInt32(int32(info.Port)),
 				Protocol:   corev1.ProtocolUDP,
 			},
 		)

--- a/k8s/dittofs-operator/internal/controller/service_reconciler_test.go
+++ b/k8s/dittofs-operator/internal/controller/service_reconciler_test.go
@@ -191,7 +191,8 @@ func TestReconcileAdapterServices_CreateServices(t *testing.T) {
 		svcByType[adapterType] = svc
 	}
 
-	// Check NFS Service (should have 3 ports: NFS + portmapper TCP + portmapper UDP).
+	// Check NFS Service (should have 4 ports: NFS TCP + portmapper TCP +
+	// portmapper UDP + NFS data port UDP for NLM/NSM/MOUNT).
 	nfsSvc, ok := svcByType["nfs"]
 	if !ok {
 		t.Fatal("NFS adapter Service not found")
@@ -199,8 +200,8 @@ func TestReconcileAdapterServices_CreateServices(t *testing.T) {
 	if nfsSvc.Name != "test-server-adapter-nfs" {
 		t.Errorf("Expected NFS service name 'test-server-adapter-nfs', got %s", nfsSvc.Name)
 	}
-	if len(nfsSvc.Spec.Ports) != 3 {
-		t.Fatalf("Expected NFS service to have 3 ports (NFS + portmapper TCP + portmapper UDP), got %d: %v", len(nfsSvc.Spec.Ports), nfsSvc.Spec.Ports)
+	if len(nfsSvc.Spec.Ports) != 4 {
+		t.Fatalf("Expected NFS service to have 4 ports (NFS TCP + portmapper TCP + portmapper UDP + NFS UDP), got %d: %v", len(nfsSvc.Spec.Ports), nfsSvc.Spec.Ports)
 	}
 	nfsSvcPortMap := make(map[string]corev1.ServicePort)
 	for _, p := range nfsSvc.Spec.Ports {
@@ -295,7 +296,7 @@ func TestReconcileAdapterServices_UpdatePortChange(t *testing.T) {
 		t.Fatalf("reconcileAdapterServices returned error: %v", err)
 	}
 
-	// Verify the Service was updated with new port (NFS has 3 ports: NFS + portmapper TCP + portmapper UDP).
+	// Verify the Service was updated with new port (NFS has 4 ports: NFS TCP + portmapper TCP + portmapper UDP + NFS data port UDP).
 	updated := &corev1.Service{}
 	err = r.Get(context.Background(), client.ObjectKey{
 		Namespace: "default",
@@ -305,8 +306,8 @@ func TestReconcileAdapterServices_UpdatePortChange(t *testing.T) {
 		t.Fatalf("Failed to get updated Service: %v", err)
 	}
 
-	if len(updated.Spec.Ports) != 3 {
-		t.Fatalf("Expected 3 ports (NFS + portmapper TCP + portmapper UDP), got %d", len(updated.Spec.Ports))
+	if len(updated.Spec.Ports) != 4 {
+		t.Fatalf("Expected 4 ports (NFS TCP + portmapper TCP + portmapper UDP + NFS UDP), got %d", len(updated.Spec.Ports))
 	}
 	updatedPortMap := make(map[string]corev1.ServicePort)
 	for _, p := range updated.Spec.Ports {
@@ -1012,8 +1013,8 @@ func TestSyncManagedAnnotations_ClearsAll(t *testing.T) {
 
 func TestBuildAdapterServicePorts_NFS(t *testing.T) {
 	ports := buildAdapterServicePorts("nfs", AdapterInfo{Port: 12049})
-	if len(ports) != 3 {
-		t.Fatalf("Expected 3 ports for NFS (NFS + portmapper TCP + portmapper UDP), got %d", len(ports))
+	if len(ports) != 4 {
+		t.Fatalf("Expected 4 ports for NFS (NFS TCP + portmapper TCP + portmapper UDP + NFS data port UDP), got %d", len(ports))
 	}
 
 	// First port: NFS

--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -138,6 +138,10 @@ type NFSAdapter struct {
 	// nil when portmapper is disabled.
 	portmapRegistry *portmap.Registry
 
+	// udpConn is the UDP listener serving NLM/NSM/MOUNT when the UDP transport
+	// is enabled (adapters.nfs.udp.enabled). nil when UDP is disabled.
+	udpConn *net.UDPConn
+
 	// nsmClientStore persists client registrations for crash recovery
 	nsmClientStore lock.ClientRegistrationStore
 
@@ -256,8 +260,15 @@ type NFSConfig struct {
 	// Portmapper configures the embedded portmapper (RFC 1057).
 	// The portmapper allows NFS clients to discover DittoFS services
 	// via rpcinfo/showmount without requiring a system-level rpcbind daemon.
-	// Default: enabled on port 10111.
+	// Default: disabled. When enabled, listens on port 10111.
 	Portmapper PortmapConfig `mapstructure:"portmapper"`
+
+	// UDP configures serving the lock-manager auxiliary protocols (NLM, NSM)
+	// and MOUNT over UDP, in addition to TCP. NFS itself is never served over
+	// UDP. Disabled by default. BSD/macOS NFSv3 lock clients reach rpc.lockd /
+	// rpc.statd over UDP, so NFSv3 file locking from macOS requires this
+	// enabled together with the portmapper (issue #1353).
+	UDP NFSUDPConfig `mapstructure:"udp"`
 
 	// TLS configures opportunistic NFS-over-TLS (RFC 9289). When the cert/key
 	// files are set, the server answers an AUTH_TLS STARTTLS probe and upgrades
@@ -348,6 +359,14 @@ type PortmapConfig struct {
 	// Port is the port to listen on for portmapper requests.
 	// Default: 10111 (unprivileged port; standard portmapper uses 111 but requires root).
 	Port int `mapstructure:"port" validate:"min=0,max=65535"`
+}
+
+// NFSUDPConfig configures the UDP transport for the lock-manager auxiliary
+// protocols (NLM, NSM) and MOUNT. NFS data operations are never served over UDP.
+type NFSUDPConfig struct {
+	// Enabled controls whether NLM/NSM/MOUNT are served over UDP.
+	// When nil (not specified in config), defaults to false.
+	Enabled *bool `mapstructure:"enabled"`
 }
 
 // applyDefaults fills in zero values with sensible defaults.
@@ -700,6 +719,15 @@ func (s *NFSAdapter) Serve(ctx context.Context) error {
 	// (privileged ports like 111 may require root privileges).
 	if err := s.startPortmapper(ctx); err != nil {
 		logger.Warn("Portmapper failed to start (NFS will continue without it)", "error", err)
+	}
+
+	// Start the UDP transport for NLM/NSM/MOUNT when enabled. NFSv3 lock
+	// clients on BSD/macOS require the lock-manager protocols over UDP
+	// (issue #1353). Failure is non-fatal: TCP serving continues.
+	if s.isUDPEnabled() {
+		if err := s.startUDP(ctx); err != nil {
+			logger.Warn("NFS UDP transport failed to start (NLM/NSM/MOUNT over UDP unavailable)", "error", err)
+		}
 	}
 
 	// NSM startup: Load persisted registrations and notify all clients

--- a/pkg/adapter/nfs/dispatch.go
+++ b/pkg/adapter/nfs/dispatch.go
@@ -194,11 +194,15 @@ func (c *NFSConnection) handleRPCCall(ctx context.Context, call *rpc.RPCCallMess
 		replyData, err = c.handleMountProcedure(ctx, call, procedureData, clientAddr)
 
 	case rpc.ProgramNLM:
-		// NLM v4 only per CONTEXT.md decision
-		if call.Version != rpc.NLMVersion4 {
-			return c.handleUnsupportedVersion(call, rpc.NLMVersion4, rpc.NLMVersion4, "NLM", clientAddr)
+		// NLM v1/v3 (32-bit offsets) and v4 (64-bit offsets) are supported. BSD/
+		// macOS NFSv3 lock clients negotiate v1/v3; Linux uses v4. The offset
+		// wire width is selected per-version in the NLM handler (issue #1353).
+		switch call.Version {
+		case rpc.NLMVersion1, rpc.NLMVersion3, rpc.NLMVersion4:
+			replyData, err = c.handleNLMProcedure(ctx, call, procedureData, clientAddr)
+		default:
+			return c.handleUnsupportedVersion(call, rpc.NLMVersion1, rpc.NLMVersion4, "NLM", clientAddr)
 		}
-		replyData, err = c.handleNLMProcedure(ctx, call, procedureData, clientAddr)
 
 	case rpc.ProgramNSM:
 		// NSM v1 only

--- a/pkg/adapter/nfs/handlers.go
+++ b/pkg/adapter/nfs/handlers.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"net"
 	"time"
 
 	nfs "github.com/marmos91/dittofs/internal/adapter/nfs"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/middleware"
 	nlm "github.com/marmos91/dittofs/internal/adapter/nfs/nlm"
+	nlm_callback "github.com/marmos91/dittofs/internal/adapter/nfs/nlm/callback"
 	nlm_handlers "github.com/marmos91/dittofs/internal/adapter/nfs/nlm/handlers"
 	nsm "github.com/marmos91/dittofs/internal/adapter/nfs/nsm"
 	nsm_handlers "github.com/marmos91/dittofs/internal/adapter/nfs/nsm/handlers"
@@ -269,7 +271,55 @@ func (c *NFSConnection) handleNLMProcedure(ctx context.Context, call *rpc.RPCCal
 	if result == nil {
 		return nil, err
 	}
+
+	// Asynchronous (_MSG) procedures reply void inline and deliver the result as
+	// an NLM *_RES callback to the client (the macOS/BSD lockd path). The *_RES
+	// MUST leave the NLM listening socket: lockd talks to nlockmgr over a
+	// connected UDP socket and the kernel drops any datagram whose source is not
+	// that exact peer, so the callback is sent via the live listener, not a new
+	// socket. Async NLM is UDP-only.
+	if result.AsyncRes != nil {
+		c.sendNLMAsyncResult(ctx, call.Version, clientAddr, procedure.Name, result.AsyncRes)
+		// The inline reply to a _MSG call is ALWAYS SUCCESS + void; any decode
+		// error is already encoded in the *_RES body delivered above. Returning
+		// the error here would make the transport send RPCSystemErr, which lockd
+		// would misread as a transport failure rather than a protocol result.
+		return []byte{}, nil
+	}
+
 	return result.Data, err
+}
+
+// sendNLMAsyncResult delivers an NLM *_RES callback for an async (_MSG) request
+// from the NLM listening socket (so the source address matches the peer lockd
+// is connected to).
+func (c *NFSConnection) sendNLMAsyncResult(ctx context.Context, vers uint32, clientAddr, procName string, async *nlm.AsyncResult) {
+	udpConn := c.server.udpConn
+	if udpConn == nil {
+		logger.WarnCtx(ctx, "NLM async result: no UDP listener; cannot deliver *_RES",
+			"procedure", procName, "client", clientAddr)
+		return
+	}
+	dst, err := net.ResolveUDPAddr("udp", clientAddr)
+	if err != nil {
+		logger.WarnCtx(ctx, "NLM async result: bad client address",
+			"procedure", procName, "client", clientAddr, "error", err)
+		return
+	}
+	msg, err := nlm_callback.BuildNLMResultMessage(rpc.ProgramNLM, vers, async.Proc, async.Body)
+	if err != nil {
+		logger.WarnCtx(ctx, "NLM async result: build failed",
+			"procedure", procName, "client", clientAddr, "error", err)
+		return
+	}
+	if _, err := udpConn.WriteToUDP(msg, dst); err != nil {
+		logger.WarnCtx(ctx, "NLM async result: send failed",
+			"procedure", procName, "client", clientAddr, "res_proc", async.Proc, "error", err)
+		return
+	}
+	logger.DebugCtx(ctx, "NLM *_RES sent",
+		"procedure", procName, "client", clientAddr, "res_proc", async.Proc,
+		"src", udpConn.LocalAddr().String())
 }
 
 // handleNSMProcedure dispatches an NSM procedure call to the appropriate handler.

--- a/pkg/adapter/nfs/handlers.go
+++ b/pkg/adapter/nfs/handlers.go
@@ -225,6 +225,7 @@ func (c *NFSConnection) handleNLMProcedure(ctx context.Context, call *rpc.RPCCal
 		Context:    ctx,
 		ClientAddr: clientAddr,
 		AuthFlavor: call.GetAuthFlavor(),
+		Version:    call.Version,
 	}
 
 	// Parse Unix credentials if AUTH_UNIX

--- a/pkg/adapter/nfs/nlm_smb_wakeup_test.go
+++ b/pkg/adapter/nfs/nlm_smb_wakeup_test.go
@@ -191,7 +191,7 @@ func TestNLMWaiter_GrantedWhenSMBHolderReleases(t *testing.T) {
 	// The callback port is resolved from the client's portmapper at grant time.
 	// Stand in a deterministic resolver that points at our fake listener so the
 	// GRANTED callback target is exactly cb.addr() without a portmap round-trip.
-	restore := callback.SetCallbackAddrResolver(func(_ context.Context, _ string) (string, error) {
+	restore := callback.SetCallbackAddrResolver(func(_ context.Context, _ string, _ uint32) (string, error) {
 		return cb.addr(), nil
 	})
 	t.Cleanup(restore)

--- a/pkg/adapter/nfs/portmap.go
+++ b/pkg/adapter/nfs/portmap.go
@@ -48,7 +48,7 @@ func (s *NFSAdapter) startPortmapper(ctx context.Context) error {
 
 	// Create registry and register all DittoFS services
 	registry := portmap.NewRegistry()
-	registry.RegisterDittoFSServices(s.config.Port)
+	registry.RegisterDittoFSServices(s.config.Port, s.isUDPEnabled())
 	registry.RegisterPortmapper(s.config.Portmapper.Port)
 
 	// Create portmapper server

--- a/pkg/adapter/nfs/settings.go
+++ b/pkg/adapter/nfs/settings.go
@@ -86,6 +86,13 @@ func (s *NFSAdapter) applyNFSSettings(rt *runtime.Runtime) {
 	}
 	logger.Debug("NFS adapter: applied portmapper settings from DB",
 		"enabled", settings.PortmapperEnabled, "port", s.config.Portmapper.Port)
+
+	// UDP transport (NLM/NSM/MOUNT over UDP) -> adapter config. Same pattern as
+	// portmapper: DB plain bool drives the adapter config *bool. Takes effect on
+	// the next (re)start, when Serve() decides whether to bind the UDP listener.
+	udpEnabled := settings.UDPEnabled
+	s.config.UDP.Enabled = &udpEnabled
+	logger.Debug("NFS adapter: applied UDP transport setting from DB", "enabled", settings.UDPEnabled)
 }
 
 // fsCapabilitiesProbeTimeout bounds the metadata read issued when refreshing

--- a/pkg/adapter/nfs/udp.go
+++ b/pkg/adapter/nfs/udp.go
@@ -1,0 +1,221 @@
+package nfs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"runtime/debug"
+
+	mount_handlers "github.com/marmos91/dittofs/internal/adapter/nfs/mount/handlers"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
+	"github.com/marmos91/dittofs/internal/logger"
+)
+
+// maxUDPDatagram bounds a single RPC-over-UDP message. The protocols served
+// over UDP (NLM, NSM, MOUNT) exchange only small fixed-size messages, so the
+// practical 64 KiB UDP datagram ceiling is far more than enough.
+const maxUDPDatagram = 65535
+
+// rpcRecordMarkLen is the length of the RFC 5531 record-marking header that the
+// shared reply builders prepend for the stream (TCP) transport. UDP delivers
+// one RPC message per datagram with no record marking, so this prefix is
+// stripped before sending.
+const rpcRecordMarkLen = 4
+
+// defaultUDPHandlerLimit caps concurrent UDP datagram handlers when the adapter
+// config does not set MaxRequestsPerConnection (mirrors its default).
+const defaultUDPHandlerLimit = 100
+
+// isUDPEnabled reports whether the UDP transport for NLM/NSM/MOUNT should be
+// started. Disabled unless adapters.nfs.udp.enabled is explicitly true.
+func (s *NFSAdapter) isUDPEnabled() bool {
+	return s.config.UDP.Enabled != nil && *s.config.UDP.Enabled
+}
+
+// startUDP binds the UDP transport on the NFS port and serves the lock-manager
+// auxiliary protocols (NLM, NSM) and MOUNT. NFS itself is never served over UDP
+// because READ/WRITE payloads do not fit a single datagram; only the small
+// lock/status/mount messages are. The listener is closed when ctx is cancelled.
+func (s *NFSAdapter) startUDP(ctx context.Context) error {
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: s.config.Port})
+	if err != nil {
+		return fmt.Errorf("listen udp :%d: %w", s.config.Port, err)
+	}
+	s.udpConn = conn
+
+	logger.Info("NFS UDP transport listening (NLM/NSM/MOUNT)", "port", s.config.Port)
+
+	// Close the socket on shutdown so the read loop unblocks and exits.
+	go func() {
+		<-ctx.Done()
+		_ = conn.Close()
+	}()
+
+	go s.serveUDP(ctx, conn)
+	return nil
+}
+
+// serveUDP reads datagrams and dispatches each one. A single stateless
+// pseudo-connection is reused for every datagram: the NLM/NSM/MOUNT handlers
+// read only the adapter (s) and emit metrics — they never touch a net.Conn —
+// and UDP carries no per-connection state (no record marking, TLS, or DRC).
+func (s *NFSAdapter) serveUDP(ctx context.Context, conn *net.UDPConn) {
+	pc := &NFSConnection{server: s}
+	buf := make([]byte, maxUDPDatagram)
+
+	// Bound in-flight datagram handlers so a flood cannot spawn unbounded
+	// goroutines (the TCP path is bounded per-connection by requestSem). UDP is
+	// lossy by nature, so once the limit is reached we drop the datagram rather
+	// than block the read loop — the client retransmits.
+	limit := s.config.MaxRequestsPerConnection
+	if limit <= 0 {
+		limit = defaultUDPHandlerLimit
+	}
+	sem := make(chan struct{}, limit)
+
+	for {
+		n, src, err := conn.ReadFromUDP(buf)
+		if err != nil {
+			// A closed socket (shutdown) or a cancelled context ends the loop.
+			if errors.Is(err, net.ErrClosed) || ctx.Err() != nil {
+				return
+			}
+			logger.Debug("NFS UDP read error", "error", err)
+			continue
+		}
+
+		select {
+		case sem <- struct{}{}:
+		default:
+			logger.Debug("NFS UDP: handler limit reached, dropping datagram", "client", src.String(), "limit", limit)
+			continue
+		}
+
+		// Copy out of the shared read buffer before handing to a goroutine.
+		msg := make([]byte, n)
+		copy(msg, buf[:n])
+		go func(src *net.UDPAddr, msg []byte) {
+			defer func() { <-sem }()
+			pc.handleUDPDatagram(ctx, conn, src, msg)
+		}(src, msg)
+	}
+}
+
+// handleUDPDatagram parses a single RPC-over-UDP message and routes it to the
+// NLM, NSM, or MOUNT handler, then sends the reply back to the source address.
+// NFS and any other program are answered with PROG_UNAVAIL: they are not served
+// over UDP. A panic in a handler is contained so one bad datagram cannot crash
+// the listener.
+func (c *NFSConnection) handleUDPDatagram(ctx context.Context, conn *net.UDPConn, src *net.UDPAddr, msg []byte) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error("Panic in NFS UDP handler", "client", src.String(), "error", r, "stack", string(debug.Stack()))
+		}
+	}()
+
+	call, err := rpc.ReadCall(msg)
+	if err != nil {
+		logger.Debug("NFS UDP: parse RPC call failed", "client", src.String(), "error", err)
+		return
+	}
+
+	procedureData, err := rpc.ReadData(msg, call)
+	if err != nil {
+		logger.Debug("NFS UDP: extract procedure data failed", "client", src.String(), "xid", fmt.Sprintf("0x%x", call.XID), "error", err)
+		return
+	}
+
+	clientAddr := src.String()
+
+	var body []byte
+	switch call.Program {
+	case rpc.ProgramNLM:
+		// NLM v1/v3 (32-bit offsets) and v4 (64-bit) — macOS uses v1/v3.
+		switch call.Version {
+		case rpc.NLMVersion1, rpc.NLMVersion3, rpc.NLMVersion4:
+			body, err = c.handleNLMProcedure(ctx, call, procedureData, clientAddr)
+		default:
+			c.writeUDPVersionMismatch(conn, src, call.XID, rpc.NLMVersion1, rpc.NLMVersion4)
+			return
+		}
+
+	case rpc.ProgramNSM:
+		if call.Version != rpc.NSMVersion1 {
+			c.writeUDPVersionMismatch(conn, src, call.XID, rpc.NSMVersion1, rpc.NSMVersion1)
+			return
+		}
+		body, err = c.handleNSMProcedure(ctx, call, procedureData, clientAddr)
+
+	case rpc.ProgramMount:
+		// MNT returns a v3-format file handle, so it requires MOUNT v3 — same
+		// gate the TCP dispatcher applies. Other MOUNT procedures (NULL, UMNT,
+		// EXPORT, …) are version-agnostic and accepted on v1/v2/v3.
+		if call.Procedure == mount_handlers.MountProcMnt && call.Version != rpc.MountVersion3 {
+			c.writeUDPVersionMismatch(conn, src, call.XID, rpc.MountVersion3, rpc.MountVersion3)
+			return
+		}
+		body, err = c.handleMountProcedure(ctx, call, procedureData, clientAddr)
+
+	default:
+		// NFS itself and anything else are not served over UDP.
+		c.writeUDPAcceptError(conn, src, call.XID, rpc.RPCProgUnavail)
+		return
+	}
+
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return
+		}
+		logger.Debug("NFS UDP handler error", "program", call.Program, "procedure", call.Procedure, "xid", fmt.Sprintf("0x%x", call.XID), "error", err)
+		c.writeUDPAcceptError(conn, src, call.XID, rpc.RPCSystemErr)
+		return
+	}
+
+	c.writeUDPReply(conn, src, call.XID, body)
+}
+
+// writeUDPReply wraps a procedure result in an RPC success reply and sends it as
+// a single datagram (without the stream record-marking header).
+func (c *NFSConnection) writeUDPReply(conn *net.UDPConn, src *net.UDPAddr, xid uint32, body []byte) {
+	reply, err := rpc.MakeSuccessReply(xid, body)
+	if err != nil {
+		logger.Debug("NFS UDP: build success reply failed", "xid", fmt.Sprintf("0x%x", xid), "error", err)
+		return
+	}
+	sendUDP(conn, src, reply)
+}
+
+// writeUDPAcceptError sends an RPC reply carrying an accept-status error
+// (e.g. PROG_UNAVAIL, SYSTEM_ERR) as a UDP datagram.
+func (c *NFSConnection) writeUDPAcceptError(conn *net.UDPConn, src *net.UDPAddr, xid, acceptStat uint32) {
+	reply, err := rpc.MakeErrorReply(xid, acceptStat)
+	if err != nil {
+		logger.Debug("NFS UDP: build error reply failed", "xid", fmt.Sprintf("0x%x", xid), "error", err)
+		return
+	}
+	sendUDP(conn, src, reply)
+}
+
+// writeUDPVersionMismatch sends an RFC 5531 PROG_MISMATCH reply over UDP.
+func (c *NFSConnection) writeUDPVersionMismatch(conn *net.UDPConn, src *net.UDPAddr, xid, low, high uint32) {
+	reply, err := rpc.MakeProgMismatchReply(xid, low, high)
+	if err != nil {
+		logger.Debug("NFS UDP: build mismatch reply failed", "xid", fmt.Sprintf("0x%x", xid), "error", err)
+		return
+	}
+	sendUDP(conn, src, reply)
+}
+
+// sendUDP strips the leading record-marking header that the shared reply
+// builders add for the stream transport and writes the bare RPC message as one
+// datagram to the client's source address.
+func sendUDP(conn *net.UDPConn, src *net.UDPAddr, framed []byte) {
+	payload := framed
+	if len(framed) >= rpcRecordMarkLen {
+		payload = framed[rpcRecordMarkLen:]
+	}
+	if _, err := conn.WriteToUDP(payload, src); err != nil {
+		logger.Debug("NFS UDP: write reply failed", "client", src.String(), "error", err)
+	}
+}

--- a/pkg/adapter/nfs/udp.go
+++ b/pkg/adapter/nfs/udp.go
@@ -128,6 +128,10 @@ func (c *NFSConnection) handleUDPDatagram(ctx context.Context, conn *net.UDPConn
 
 	clientAddr := src.String()
 
+	logger.Debug("NFS UDP request",
+		"program", call.Program, "version", call.Version, "procedure", call.Procedure,
+		"client", clientAddr, "xid", fmt.Sprintf("0x%x", call.XID))
+
 	var body []byte
 	switch call.Program {
 	case rpc.ProgramNLM:

--- a/pkg/adapter/nfs/udp_test.go
+++ b/pkg/adapter/nfs/udp_test.go
@@ -1,0 +1,61 @@
+package nfs
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
+)
+
+// TestUDPReplyFraming verifies the UDP transport's core framing decision: the
+// shared reply builders prepend a 4-byte RFC 5531 record-marking header for the
+// stream transport, and the UDP path strips exactly that prefix so the datagram
+// carries a bare RPC reply beginning with the XID.
+func TestUDPReplyFraming(t *testing.T) {
+	const xid = uint32(0xDEADBEEF)
+	body := []byte{0x00, 0x00, 0x00, 0x00} // minimal NLM-style result body
+
+	framed, err := rpc.MakeSuccessReply(xid, body)
+	if err != nil {
+		t.Fatalf("MakeSuccessReply: %v", err)
+	}
+	if len(framed) < rpcRecordMarkLen+4 {
+		t.Fatalf("framed reply too short: %d bytes", len(framed))
+	}
+
+	// The record mark is (0x80000000 | payload length) over the first 4 bytes.
+	mark := binary.BigEndian.Uint32(framed[:rpcRecordMarkLen])
+	wantMark := uint32(0x80000000) | uint32(len(framed)-rpcRecordMarkLen)
+	if mark != wantMark {
+		t.Fatalf("record mark = 0x%08x, want 0x%08x", mark, wantMark)
+	}
+
+	// After stripping the record mark the datagram payload must start with the
+	// XID (first field of the RPC reply message).
+	payload := framed[rpcRecordMarkLen:]
+	if got := binary.BigEndian.Uint32(payload[:4]); got != xid {
+		t.Fatalf("stripped payload XID = 0x%08x, want 0x%08x", got, xid)
+	}
+}
+
+// TestIsUDPEnabled covers the *bool tri-state: unset defaults to disabled.
+func TestIsUDPEnabled(t *testing.T) {
+	tr, fa := true, false
+	cases := []struct {
+		name string
+		val  *bool
+		want bool
+	}{
+		{"unset defaults off", nil, false},
+		{"explicit true", &tr, true},
+		{"explicit false", &fa, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &NFSAdapter{config: NFSConfig{UDP: NFSUDPConfig{Enabled: tc.val}}}
+			if got := s.isUDPEnabled(); got != tc.want {
+				t.Fatalf("isUDPEnabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/apiclient/adapter_settings.go
+++ b/pkg/apiclient/adapter_settings.go
@@ -29,6 +29,7 @@ type NFSAdapterSettingsResponse struct {
 	BlockedOperations          []string `json:"blocked_operations"`
 	PortmapperEnabled          bool     `json:"portmapper_enabled"`
 	PortmapperPort             int      `json:"portmapper_port"`
+	UDPEnabled                 bool     `json:"udp_enabled"`
 	Version                    int      `json:"version"`
 }
 
@@ -89,6 +90,7 @@ type PatchNFSSettingsRequest struct {
 	BlockedOperations          *[]string `json:"blocked_operations,omitempty"`
 	PortmapperEnabled          *bool     `json:"portmapper_enabled,omitempty"`
 	PortmapperPort             *int      `json:"portmapper_port,omitempty"`
+	UDPEnabled                 *bool     `json:"udp_enabled,omitempty"`
 }
 
 // PatchSMBSettingsRequest uses pointer fields for partial updates.

--- a/pkg/controlplane/models/adapter_settings.go
+++ b/pkg/controlplane/models/adapter_settings.go
@@ -81,6 +81,15 @@ type NFSAdapterSettings struct {
 	PortmapperEnabled bool `gorm:"default:false" json:"portmapper_enabled"`
 	PortmapperPort    int  `gorm:"default:10111" json:"portmapper_port"`
 
+	// UDPEnabled serves NLM/NSM/MOUNT over UDP (in addition to TCP). Required for
+	// NFSv3 file locking from BSD/macOS clients (issue #1353). NFS data is never
+	// served over UDP. Takes effect on adapter (re)start.
+	//
+	// Defaults to false (opt-in), like the portmapper. NFSv3 mount and I/O work
+	// without it; only NLM locking needs UDP plus a portmapper reachable on port
+	// 111. Enable both to allow macOS NFSv3 locking.
+	UDPEnabled bool `gorm:"default:false" json:"udp_enabled"`
+
 	// Version counter for change detection (monotonic, starts at 1, incremented on every update)
 	Version int `gorm:"default:1" json:"version"`
 
@@ -230,6 +239,7 @@ func NewDefaultNFSSettings(adapterID string) *NFSAdapterSettings {
 		V4MaxConnectionsPerSession: 16,
 		PortmapperEnabled:          false,
 		PortmapperPort:             10111,
+		UDPEnabled:                 false,
 		Version:                    1,
 	}
 }

--- a/pkg/controlplane/store/adapters.go
+++ b/pkg/controlplane/store/adapters.go
@@ -147,6 +147,7 @@ func (s *GORMStore) UpdateNFSAdapterSettings(ctx context.Context, settings *mode
 			"blocked_operations":        settings.BlockedOperations,
 			"portmapper_enabled":        settings.PortmapperEnabled,
 			"portmapper_port":           settings.PortmapperPort,
+			"udp_enabled":               settings.UDPEnabled,
 			"version":                   gorm.Expr("version + 1"),
 			"updated_at":                time.Now(),
 		})
@@ -187,6 +188,7 @@ func (s *GORMStore) ResetNFSAdapterSettings(ctx context.Context, adapterID strin
 			"blocked_operations":        "",
 			"portmapper_enabled":        defaults.PortmapperEnabled,
 			"portmapper_port":           defaults.PortmapperPort,
+			"udp_enabled":               defaults.UDPEnabled,
 			"version":                   gorm.Expr("version + 1"),
 			"updated_at":                time.Now(),
 		})


### PR DESCRIPTION
Fixes #1353.

## Problem

NFSv3 byte-range locking failed from macOS (and BSD) clients. DittoFS offered NLM only as **v4 over TCP**, with no UDP transport and a non-standard portmapper. macOS `rpc.lockd`/`rpc.statd` need substantially more, and each missing piece failed silently.

Live debugging against a real macOS client uncovered **a chain of distinct gaps**, each a real fix:

## What changed

1. **NLM v1/v3 + UDP transport** — width-aware NLM XDR (32-bit offsets for v1/v3, 64-bit for v4; handler logic stays version-agnostic). New UDP listener serving NLM/NSM/MOUNT (NFS data stays TCP-only). `adapters.nfs.udp.enabled`.
2. **NSM SM_MON callback fix** — real `statd` send `my_name` as a **hostname** (e.g. `localhost`); the IP-literal SSRF guard rejected it with `STAT_FAIL`, breaking locking for every client. Now the SM_NOTIFY callback target is derived from the request's **transport source** (still rejects link-local/IMDS); `my_name` is a label only — accepts hostnames *and* tightens SSRF.
3. **RPCBIND v3/v4** — macOS/BSD `lockd` discover NLM via RPCBIND v3/v4 (RFC 1833 universal addresses) and do **not** fall back to PMAP v2. The embedded portmapper now answers v2 **and** v3/v4 (GETADDR/GETVERSADDR/DUMP), reusing the registration table.
4. **Async NLM `_MSG`/`_RES`** — macOS/BSD use the callback-style async procedures: client sends `*_MSG` (procs 6–9), server replies **void** and delivers the result as a `*_RES` callback (procs 11–14). Async handlers reuse the sync decode/process/encode; the `*_RES` body is byte-identical to the sync reply.
5. **`_RES` from the NLM listening socket** — `lockd` connects its UDP socket to the server's `nlockmgr`, so the kernel drops any datagram whose source isn't that peer. The `*_RES` is sent via the live listener (source = NLM port), not a freshly-dialled socket.

Plus from the original scope: `dfsctl share mount --nfs-version 3|4|4.1`, operator NFS-port-over-UDP exposure, and the `udp_enabled` adapter setting threaded through model→store→API→apiclient→`dfsctl`.

## Defaults & safety

Both `udp.enabled` and `portmapper.enabled` default **OFF** — the entire feature is **opt-in**, so there is **no regression risk** to existing paths. NFSv3 mount + read/write need none of this; **NFSv4 needs none of it** (in-protocol locking) and remains the recommended path. To enable macOS NLM locking:

```
dfsctl adapter settings nfs update --udp-enabled true --portmapper-enabled true --portmapper-port 111
# then bounce the adapter
```
(macOS queries the server's portmapper on **:111** specifically.)

## Validation

- **Unit tests** added across every layer: width-aware NLM XDR, UDP framing, portmap registration + RPCBIND GETADDR/DUMP, NSM source-derived callback (incl. the macOS hostname case), async `_MSG`→`_RES` reuse, settings plumbing, operator ports.
- **Live wire validation** (real running server): RPCBIND v3/v4 GETADDR resolves `nlockmgr`; NSM SM_MON succeeds; macOS sends `LOCK_MSG`; server **grants**; a well-formed `LOCK_RES` (correct cookie, `prog/vers/proc=12`) is delivered **from the NLM socket**. The full discovery→monitor→lock chain executes end to end.
- **Status:** end-to-end *acceptance* against a live macOS client is validated on a **same-LAN** topology, not localhost — a same-host loopback test is unreliable (client and server contend for port 111 and a shared `lockd`/`statd`, and the reverse `_RES` callback can't be cleanly observed). Tracked as a follow-up; the protocol implementation is complete and unit-tested.

All commits signed.
