### PR TITLE
fix(netlogon): Kerberos-bound ncacn_np schannel resolves Samba interop (#1345) + DC SRV discovery (#1324)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/oiweiwei/go-msrpc v1.4.3
+	github.com/oiweiwei/gokrb5.fork/v9 v9.0.6
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pierrec/lz4/v4 v4.1.26
@@ -104,7 +105,6 @@ require (
 	github.com/oiweiwei/go-math v1.0.0 // indirect
 	github.com/oiweiwei/go-oem v1.0.0 // indirect
 	github.com/oiweiwei/go-smb2.fork v1.0.1 // indirect
-	github.com/oiweiwei/gokrb5.fork/v9 v9.0.6 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/internal/auth/netlogon/discovery.go
+++ b/internal/auth/netlogon/discovery.go
@@ -1,0 +1,81 @@
+package netlogon
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+// DCInfo identifies a domain controller discovered via DNS SRV records.
+type DCInfo struct {
+	// FQDN is the DC's canonical DNS host name without the trailing dot,
+	// e.g. "dc01.dittofs.ad". It is the basis for the Kerberos service
+	// principal (cifs/<FQDN>) used to authenticate the NETLOGON SMB session.
+	FQDN string
+	// Port is the SRV record port (389 for the _ldap locator record).
+	Port uint16
+	// Priority/Weight are the SRV selection fields, lowest priority first.
+	Priority uint16
+	Weight   uint16
+}
+
+// SPN returns the SMB service principal name for the DC (cifs/<FQDN>).
+//
+// AD domain controllers register HOST/<fqdn> rather than an explicit
+// cifs/<fqdn>, but the default AD sPNMappings alias the host service class to
+// cifs (and a dozen others), so the KDC issues a cifs/<fqdn> ticket from the
+// HOST key. This is the same SPN a Windows client uses for an SMB session.
+func (d DCInfo) SPN() string { return "cifs/" + d.FQDN }
+
+// DiscoverDCs resolves the domain controllers for realm using the AD DNS
+// locator SRV record (_ldap._tcp.dc._msdcs.<realm>), returning them in SRV
+// priority/weight order. This is the discovery half of #1324.
+//
+// In an Active Directory domain the DC is itself the authoritative DNS server,
+// so dnsServer is normally a DC address (we already hold one for connectivity);
+// pointing the resolver at it both avoids a dependency on the host's resolv.conf
+// and guarantees the records resolve. If dnsServer is empty the system resolver
+// is used.
+func DiscoverDCs(ctx context.Context, realm, dnsServer string) ([]DCInfo, error) {
+	realm = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(realm)), ".")
+	if realm == "" {
+		return nil, fmt.Errorf("netlogon: discover DC: empty realm")
+	}
+
+	resolver := net.DefaultResolver
+	if dnsServer != "" {
+		resolver = &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
+				d := net.Dialer{Timeout: 5 * time.Second}
+				return d.DialContext(ctx, network, net.JoinHostPort(dnsServer, "53"))
+			},
+		}
+	}
+
+	// _ldap._tcp.dc._msdcs.<realm> is the AD "DC locator" record: every DC in
+	// the domain publishes it. LookupSRV already returns records sorted by
+	// priority then weight per RFC 2782.
+	const service, proto = "ldap", "tcp"
+	name := "dc._msdcs." + realm
+	_, srvs, err := resolver.LookupSRV(ctx, service, proto, name)
+	if err != nil {
+		return nil, fmt.Errorf("netlogon: SRV lookup _%s._%s.%s: %w", service, proto, name, err)
+	}
+	if len(srvs) == 0 {
+		return nil, fmt.Errorf("netlogon: no DC SRV records for realm %q", realm)
+	}
+
+	dcs := make([]DCInfo, 0, len(srvs))
+	for _, s := range srvs {
+		dcs = append(dcs, DCInfo{
+			FQDN:     strings.TrimSuffix(s.Target, "."),
+			Port:     s.Port,
+			Priority: s.Priority,
+			Weight:   s.Weight,
+		})
+	}
+	return dcs, nil
+}

--- a/internal/auth/netlogon/discovery.go
+++ b/internal/auth/netlogon/discovery.go
@@ -30,8 +30,9 @@ type DCInfo struct {
 func (d DCInfo) SPN() string { return "cifs/" + d.FQDN }
 
 // DiscoverDCs resolves the domain controllers for realm using the AD DNS
-// locator SRV record (_ldap._tcp.dc._msdcs.<realm>), returning them in SRV
-// priority/weight order. This is the discovery half of #1324.
+// locator SRV record (_ldap._tcp.dc._msdcs.<realm>). net.LookupSRV already
+// returns the records sorted by priority and randomized by weight per RFC 2782,
+// and that order is preserved here. This is the discovery half of #1324.
 //
 // In an Active Directory domain the DC is itself the authoritative DNS server,
 // so dnsServer is normally a DC address (we already hold one for connectivity);

--- a/internal/auth/netlogon/securechannel.go
+++ b/internal/auth/netlogon/securechannel.go
@@ -31,6 +31,11 @@ var gssapiRegister sync.Once
 // bind inside NewSecureChannelClient authenticates the machine account via
 // NTLM/SPNEGO (the netlogon schannel config does not exist yet at that point);
 // the Netlogon mechanism is used only for the sealed secure channel afterward.
+// registerGSSAPI is process-global and runs exactly once (sync.Once): it
+// captures the FIRST machine credential's account/password/workstation/realm.
+// DittoFS uses a single machine account (one realm) per process, so the locked
+// credential always matches the realm passed to buildKRB5Config on later calls;
+// a second, different realm in the same process is unsupported by design.
 func registerGSSAPI(mc MachineCredential) {
 	gssapiRegister.Do(func() {
 		// Domain must be set: the schannel NL_AUTH_MESSAGE carries it (Samba
@@ -60,6 +65,19 @@ func buildKRB5Config(realm, kdc string) (*krb5.Config, error) {
 	realm = strings.ToUpper(strings.TrimSuffix(strings.TrimSpace(realm), "."))
 	if realm == "" {
 		return nil, fmt.Errorf("netlogon: krb5 config: empty realm")
+	}
+	kdc = strings.TrimSpace(kdc)
+	if kdc == "" {
+		return nil, fmt.Errorf("netlogon: krb5 config: empty KDC address")
+	}
+	// realm and kdc are interpolated into the krb5 config text, so reject any
+	// whitespace/control characters that could inject additional config
+	// directives (e.g. a newline in a misconfigured dc_address).
+	if strings.ContainsAny(realm, " \t\r\n[]{}") {
+		return nil, fmt.Errorf("netlogon: krb5 config: invalid realm %q", realm)
+	}
+	if strings.ContainsAny(kdc, " \t\r\n[]{}") {
+		return nil, fmt.Errorf("netlogon: krb5 config: invalid KDC address %q", kdc)
 	}
 	conf := fmt.Sprintf(`[libdefaults]
   default_realm = %[1]s

--- a/internal/auth/netlogon/securechannel.go
+++ b/internal/auth/netlogon/securechannel.go
@@ -4,15 +4,20 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
+
+	krb5_config "github.com/oiweiwei/gokrb5.fork/v9/config"
 
 	"github.com/oiweiwei/go-msrpc/dcerpc"
 	"github.com/oiweiwei/go-msrpc/msrpc/dtyp"
 	epm "github.com/oiweiwei/go-msrpc/msrpc/epm/epm/v3"
 	logon "github.com/oiweiwei/go-msrpc/msrpc/nrpc/logon/v1"
+	"github.com/oiweiwei/go-msrpc/smb2"
 	"github.com/oiweiwei/go-msrpc/ssp"
 	"github.com/oiweiwei/go-msrpc/ssp/credential"
 	"github.com/oiweiwei/go-msrpc/ssp/gssapi"
+	"github.com/oiweiwei/go-msrpc/ssp/krb5"
 )
 
 // gssapiRegister guards the one-time, process-global registration of the
@@ -33,8 +38,40 @@ func registerGSSAPI(mc MachineCredential) {
 			mc.AccountName, mc.Password, credential.Workstation(mc.Workstation)))
 		gssapi.AddMechanism(ssp.SPNEGO)
 		gssapi.AddMechanism(ssp.NTLM)
+		// KRB5 authenticates the NETLOGON named-pipe SMB session: Samba rejects a
+		// machine-account NTLM SMB logon, so the schannel must ride a Kerberos
+		// SMB session over ncacn_np (#1345).
+		gssapi.AddMechanism(ssp.KRB5)
 		gssapi.AddMechanism(ssp.Netlogon)
 	})
+}
+
+// buildKRB5Config returns an in-memory krb5 config that maps realm to the given
+// KDC address, so the machine account can obtain its TGT and the cifs/ service
+// ticket for the NETLOGON SMB session without a krb5.conf file on disk. The KDC
+// is the DC we already connect to; DNS lookups are disabled since we point the
+// realm straight at it.
+func buildKRB5Config(realm, kdc string) (*krb5.Config, error) {
+	realm = strings.ToUpper(strings.TrimSuffix(strings.TrimSpace(realm), "."))
+	if realm == "" {
+		return nil, fmt.Errorf("netlogon: krb5 config: empty realm")
+	}
+	conf := fmt.Sprintf(`[libdefaults]
+  default_realm = %[1]s
+  dns_lookup_kdc = false
+  dns_lookup_realm = false
+  rdns = false
+[realms]
+  %[1]s = {
+    kdc = %[2]s
+    admin_server = %[2]s
+  }
+`, realm, kdc)
+	parsed, err := krb5_config.NewFromString(conf)
+	if err != nil {
+		return nil, fmt.Errorf("netlogon: krb5 config: %w", err)
+	}
+	return &krb5.Config{KRB5Config: parsed}, nil
 }
 
 // SecureChannel wraps a go-msrpc schannel client with a mutex-guarded cached
@@ -58,21 +95,47 @@ func (sc *SecureChannel) connect(ctx context.Context, mc MachineCredential) erro
 	}
 	server := mc.DCAddresses[0]
 
-	// Register the machine credential and the SPNEGO/NTLM/Netlogon mechanisms
+	// Discover the DC's canonical FQDN via the AD DNS SRV locator so we can name
+	// the SMB Kerberos service principal (cifs/<fqdn>). The DC is the domain's
+	// DNS server, so we query it directly at the address we already hold (#1324).
+	// Connectivity still uses `server` (the IP) — only the SPN needs the name.
+	dcs, err := DiscoverDCs(ctx, mc.Realm, server)
+	if err != nil {
+		return fmt.Errorf("netlogon: discover DC: %w", err)
+	}
+	spn := dcs[0].SPN()
+
+	// Register the machine credential and the SPNEGO/NTLM/KRB5/Netlogon mechanisms
 	// (once, process-global) BEFORE creating the security context, which captures
 	// the registered credential and mechanisms. NewSecureChannelClient then runs
-	// the full challenge handshake (the initial GetDCName/ReqChallenge bind uses
-	// NTLM/SPNEGO, then NetrServerAuthenticate3 + AlterContext apply the sealed
-	// schannel) internally — so we must NOT pre-seed a netlogon.Config.
+	// the full challenge handshake internally — so we must NOT pre-seed a
+	// netlogon.Config.
 	registerGSSAPI(mc)
-	gctx := gssapi.NewSecurityContext(ctx)
+
+	// Inline krb5 config (realm -> KDC = the DC) so the machine account can get a
+	// TGT + cifs/ service ticket without depending on a host krb5.conf file.
+	krb5Cfg, err := buildKRB5Config(mc.Realm, server)
+	if err != nil {
+		return err
+	}
+	gctx := gssapi.NewSecurityContext(ctx, ssp.WithKRB5(krb5Cfg))
 
 	cc, err := dcerpc.Dial(gctx, server, epm.EndpointMapper(gctx, server))
 	if err != nil {
 		return fmt.Errorf("netlogon: dial %s: %w", server, err)
 	}
 
-	cli, err := logon.NewSecureChannelClient(gctx, cc, dcerpc.WithSeal(), dcerpc.WithEndpoint("ncacn_ip_tcp:"))
+	// Samba rejects the sealed-schannel AlterContext over ncacn_ip_tcp with
+	// RPC_S_UNKNOWN_AUTHN_SERVICE (0x721); the named-pipe transport (\PIPE\netlogon
+	// over SMB) is the binding Samba accepts. That SMB session must authenticate
+	// the machine account with Kerberos (Samba refuses machine-account NTLM over
+	// SMB), targeting the DC's cifs/ SPN (#1345).
+	dialer := smb2.NewDialer(smb2.WithSecurity(gssapi.WithTargetName(spn)))
+	cli, err := logon.NewSecureChannelClient(gctx, cc,
+		dcerpc.WithSeal(),
+		dcerpc.WithEndpoint("ncacn_np:"),
+		dcerpc.WithSMBDialer(dialer),
+	)
 	if err != nil {
 		_ = cc.Close(gctx)
 		return fmt.Errorf("netlogon: secure channel client: %w", err)

--- a/internal/auth/netlogon/securechannel.go
+++ b/internal/auth/netlogon/securechannel.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/oiweiwei/go-msrpc/dcerpc"
 	"github.com/oiweiwei/go-msrpc/msrpc/dtyp"
-	epm "github.com/oiweiwei/go-msrpc/msrpc/epm/epm/v3"
 	logon "github.com/oiweiwei/go-msrpc/msrpc/nrpc/logon/v1"
 	"github.com/oiweiwei/go-msrpc/smb2"
 	"github.com/oiweiwei/go-msrpc/ssp"
@@ -120,22 +119,22 @@ func (sc *SecureChannel) connect(ctx context.Context, mc MachineCredential) erro
 	}
 	gctx := gssapi.NewSecurityContext(ctx, ssp.WithKRB5(krb5Cfg))
 
-	cc, err := dcerpc.Dial(gctx, server, epm.EndpointMapper(gctx, server))
+	// Samba rejects the sealed-schannel AlterContext over ncacn_ip_tcp with
+	// RPC_S_UNKNOWN_AUTHN_SERVICE (0x721); the named-pipe transport (\PIPE\NETLOGON
+	// over SMB) is the binding Samba accepts. That SMB session must authenticate
+	// the machine account with Kerberos (Samba refuses machine-account NTLM over
+	// SMB), targeting the DC's cifs/ SPN. Bind the netlogon pipe directly
+	// (ncacn_np:[netlogon]) rather than via the endpoint mapper (#1345).
+	dialer := smb2.NewDialer(smb2.WithSecurity(gssapi.WithTargetName(spn)))
+	cc, err := dcerpc.Dial(gctx, server,
+		dcerpc.WithEndpoint("ncacn_np:[netlogon]"),
+		dcerpc.WithSMBDialer(dialer),
+	)
 	if err != nil {
 		return fmt.Errorf("netlogon: dial %s: %w", server, err)
 	}
 
-	// Samba rejects the sealed-schannel AlterContext over ncacn_ip_tcp with
-	// RPC_S_UNKNOWN_AUTHN_SERVICE (0x721); the named-pipe transport (\PIPE\netlogon
-	// over SMB) is the binding Samba accepts. That SMB session must authenticate
-	// the machine account with Kerberos (Samba refuses machine-account NTLM over
-	// SMB), targeting the DC's cifs/ SPN (#1345).
-	dialer := smb2.NewDialer(smb2.WithSecurity(gssapi.WithTargetName(spn)))
-	cli, err := logon.NewSecureChannelClient(gctx, cc,
-		dcerpc.WithSeal(),
-		dcerpc.WithEndpoint("ncacn_np:"),
-		dcerpc.WithSMBDialer(dialer),
-	)
+	cli, err := logon.NewSecureChannelClient(gctx, cc, dcerpc.WithSeal())
 	if err != nil {
 		_ = cc.Close(gctx)
 		return fmt.Errorf("netlogon: secure channel client: %w", err)

--- a/internal/auth/netlogon/securechannel.go
+++ b/internal/auth/netlogon/securechannel.go
@@ -33,8 +33,14 @@ var gssapiRegister sync.Once
 // the Netlogon mechanism is used only for the sealed secure channel afterward.
 func registerGSSAPI(mc MachineCredential) {
 	gssapiRegister.Do(func() {
+		// Domain must be set: the schannel NL_AUTH_MESSAGE carries it (Samba
+		// rejects a schannel bind "without domain"), and the Kerberos SMB session
+		// uses it as the machine principal's realm. The realm (DNS form) satisfies
+		// both — go-msrpc sends it as the NL_AUTH DNSDomainName (#1345).
 		gssapi.AddCredential(credential.NewFromPassword(
-			mc.AccountName, mc.Password, credential.Workstation(mc.Workstation)))
+			mc.AccountName, mc.Password,
+			credential.Workstation(mc.Workstation),
+			credential.Domain(mc.Realm)))
 		gssapi.AddMechanism(ssp.SPNEGO)
 		gssapi.AddMechanism(ssp.NTLM)
 		// KRB5 authenticates the NETLOGON named-pipe SMB session: Samba rejects a

--- a/test/integration/ad-dc/entrypoint.sh
+++ b/test/integration/ad-dc/entrypoint.sh
@@ -136,12 +136,23 @@ samba-tool group addmembers devs "$USER_ALICE" >/dev/null 2>&1 || true
 create_user_if_absent "$USER_BOB"
 samba-tool group addmembers engineering "$USER_BOB" >/dev/null 2>&1 || true
 
-# --- Machine account for NETLOGON passthrough tests (#1314) ---------------
+# --- Machine account for NETLOGON passthrough tests (#1314, #1345) --------
 # Creates the DITTOFS$ computer account used by TestNetlogonPassthroughAlice.
 # samba-tool computer create yields a sAMAccountName of "dittofs$" (AD uppercases
-# it to DITTOFS$ on lookup). The || true prevents a re-run from aborting when the
-# account already exists.
-samba-tool computer create dittofs --computerpassword="MachinePass01!" >/dev/null 2>&1 || true
+# it to DITTOFS$ on lookup).
+#
+# NOTE (#1345): `samba-tool computer create --computerpassword=...` is NOT a
+# valid option on this samba (4.17.x) — it errors with "no such option", and the
+# old `|| true` SILENTLY SWALLOWED that, so the machine account was NEVER created
+# and every NETLOGON test ran against a nonexistent account. Create the computer
+# first, then set its password via `user setpassword` (which derives proper
+# Kerberos keys, making the account usable for both NETLOGON and Kerberos-SMB).
+MACHINE_PASSWORD="${MACHINE_PASSWORD:-MachinePass01!}"
+if ! samba-tool computer list 2>/dev/null | grep -qix 'dittofs\$'; then
+    log "Creating machine account dittofs\$ (NETLOGON passthrough)"
+    samba-tool computer create dittofs
+    samba-tool user setpassword 'dittofs$' --newpassword="$MACHINE_PASSWORD"
+fi
 
 # --- Combined service keytab ----------------------------------------------
 # Register BOTH the DittoFS SMB (cifs/) AND NFS (nfs/) service principals on the

--- a/test/integration/ad-dc/entrypoint.sh
+++ b/test/integration/ad-dc/entrypoint.sh
@@ -151,8 +151,11 @@ MACHINE_PASSWORD="${MACHINE_PASSWORD:-MachinePass01!}"
 if ! samba-tool computer list 2>/dev/null | grep -qix 'dittofs\$'; then
     log "Creating machine account dittofs\$ (NETLOGON passthrough)"
     samba-tool computer create dittofs
-    samba-tool user setpassword 'dittofs$' --newpassword="$MACHINE_PASSWORD"
 fi
+# Always (re)set the password so a reused domain DB (the .provisioned restart
+# path) or an account left by an earlier run reconciles to the expected
+# credential — and the AES/RC4 Kerberos keys regenerate from it each time.
+samba-tool user setpassword 'dittofs$' --newpassword="$MACHINE_PASSWORD"
 
 # --- Combined service keytab ----------------------------------------------
 # Register BOTH the DittoFS SMB (cifs/) AND NFS (nfs/) service principals on the

--- a/test/integration/ad-dc/netlogon_passthrough_test.go
+++ b/test/integration/ad-dc/netlogon_passthrough_test.go
@@ -83,10 +83,13 @@ func TestNetlogonPassthroughAlice(t *testing.T) {
 	dcIP := getContainerIP(t)
 	t.Logf("AD-DC container IP: %s", dcIP)
 
-	// Wait for the DC's DCE-RPC endpoint mapper (port 135) to accept connections.
-	// Samba's RPC stack comes up shortly after the KDC; dialing too early yields
-	// "connection refused" on the NETLOGON bind.
+	// Wait for the DC's DCE-RPC endpoint mapper (port 135) AND the SMB server
+	// (port 445) to accept connections. Samba's RPC stack comes up shortly after
+	// the KDC; dialing too early yields "connection refused" on the NETLOGON bind.
+	// The schannel rides a Kerberos SMB session over ncacn_np (\PIPE\netlogon), so
+	// 445 must be listening too — it can bind a beat after 135 (#1345).
 	waitForTCPAddr(t, dcIP+":135", 90*time.Second)
+	waitForTCPAddr(t, dcIP+":445", 90*time.Second)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()

--- a/test/integration/ad-dc/netlogon_passthrough_test.go
+++ b/test/integration/ad-dc/netlogon_passthrough_test.go
@@ -62,12 +62,6 @@ func getContainerIP(t *testing.T) string {
 //
 // This test requires the AD-DC fixture (ad_dc build tag) and Docker.
 func TestNetlogonPassthroughAlice(t *testing.T) {
-	// The NETLOGON secure channel negotiates (ReqChallenge + Authenticate3) but
-	// the sealed-schannel AlterContext is currently rejected by the Samba AD-DC
-	// with RPC_S_UNKNOWN_AUTHN_SERVICE (0x721) over ncacn_ip_tcp. Tracked in
-	// #1345 (go-msrpc<->Samba schannel interop). Un-skip once resolved.
-	t.Skip("NETLOGON schannel AlterContext interop with Samba AD-DC pending — see #1345")
-
 	if testing.Short() {
 		t.Skip("skipping NETLOGON passthrough integration test in short mode")
 	}

--- a/test/integration/ad-dc/netlogon_smbclient_test.go
+++ b/test/integration/ad-dc/netlogon_smbclient_test.go
@@ -36,11 +36,6 @@ import (
 // configured, then confirms that smbclient can authenticate as the AD
 // domain user alice via NTLM (NETLOGON passthrough).
 func TestSMBNTLMNetlogonPassthrough(t *testing.T) {
-	// Blocked on the same go-msrpc<->Samba schannel interop as the integration
-	// test: the sealed-schannel AlterContext is rejected by the DC
-	// (RPC_S_UNKNOWN_AUTHN_SERVICE 0x721). Tracked in #1345. Un-skip once resolved.
-	t.Skip("NETLOGON schannel AlterContext interop with Samba AD-DC pending — see #1345")
-
 	if testing.Short() {
 		t.Skip("skipping NETLOGON smbclient e2e test in short mode")
 	}

--- a/test/integration/ad-dc/netlogon_smbclient_test.go
+++ b/test/integration/ad-dc/netlogon_smbclient_test.go
@@ -36,6 +36,12 @@ import (
 // configured, then confirms that smbclient can authenticate as the AD
 // domain user alice via NTLM (NETLOGON passthrough).
 func TestSMBNTLMNetlogonPassthrough(t *testing.T) {
+	// The NETLOGON schannel itself works (see TestNetlogonPassthroughAlice), but
+	// the full smbclient->DittoFS->SAMLogon path returns LOGON_FAILURE: a DittoFS
+	// SMB NTLM challenge-threading / SPNEGO NegTokenResp parse bug, not a schannel
+	// issue. Tracked in #1357. Un-skip once that is fixed.
+	t.Skip("SMB NTLM passthrough e2e blocked on DittoFS challenge threading — see #1357")
+
 	if testing.Short() {
 		t.Skip("skipping NETLOGON smbclient e2e test in short mode")
 	}


### PR DESCRIPTION
## Summary
Resolves the NETLOGON schannel interop with Samba AD-DC (#1345). `TestNetlogonPassthroughAlice` now **PASSES** live against a real Samba AD-DC: alice's NTLMv2 is validated through a sealed Kerberos `ncacn_np` schannel and the DC returns her UserSID + GroupSIDs.

## Root causes found (live debugging against real Samba)
1. **The fixture never created the machine account.** `samba-tool computer create --computerpassword=...` is not a valid option on Samba 4.17; the `|| true` swallowed the error, so `DITTOFS$` never existed and every prior NETLOGON run was against a nonexistent account. Fixed: `computer create` + `user setpassword` (derives Kerberos keys).
2. **Samba rejects machine-account NTLM over SMB**, and rejects the schannel `AlterContext` over `ncacn_ip_tcp` (`0x721`). Fix: bind the schannel over a **Kerberos-authenticated** SMB session on `ncacn_np:[netlogon]`.
3. **`0x721` real cause** (Samba debug log): `Request for schannel to without domain → NT_STATUS_LOGON_FAILURE`. go-msrpc builds the schannel `NL_AUTH_MESSAGE` from the credential's domain, which we left empty. Fix: set the credential Domain to the realm — go-msrpc sends it as the NL_AUTH DNSDomainName and the Kerberos SMB session uses it as the principal realm.

## Changes
- `internal/auth/netlogon/discovery.go` — DNS SRV DC locator (`_ldap._tcp.dc._msdcs.<realm>`) → `cifs/<fqdn>` SPN. Implements the discovery core of **#1324** (queries the DC's own DNS; IP stays the connectivity path).
- `internal/auth/netlogon/securechannel.go` — register `ssp.KRB5`, inline krb5 config (realm→KDC), Kerberos SMB dialer targeting the DC `cifs/` SPN, direct `ncacn_np:[netlogon]` bind, credential Domain=realm.
- `test/integration/ad-dc/entrypoint.sh` — correct machine-account creation.
- tests — wait for DC :445; un-skip `TestNetlogonPassthroughAlice`.

## Verification
Live, real Samba AD-DC: `--- PASS: TestNetlogonPassthroughAlice`. Samba log confirms `netr_LogonSamLogon (opnum[2]) WITH SEALED schannel ... NT_STATUS_OK`. The `ad_dc` suite runs post-merge + nightly via `ad-dc.yml`.

## Follow-up
`TestSMBNTLMNetlogonPassthrough` (full smbclient e2e) stays `t.Skip`-gated on **#1357** — a separate DittoFS SMB NTLM challenge-threading bug, not a schannel issue.

Closes #1345