### PR TITLE
feat(netlogon): locate DC via DNS SRV when no address configured (#1324)

### DIFF
--- a/cmd/dfs/commands/netlogon.go
+++ b/cmd/dfs/commands/netlogon.go
@@ -42,8 +42,12 @@ func buildNetlogonAuthenticator(k config.KerberosConfig) netlogon.NetlogonAuthen
 		slog.Warn("NETLOGON machine account is enabled but kerberos.netbios_domain (DomainName) is not set; NTLM passthrough disabled")
 		return nil
 	}
-	if len(ma.DCAddresses) == 0 {
-		slog.Warn("NETLOGON machine account is enabled but no DCAddresses are configured; NTLM passthrough disabled")
+	// A DC address is optional: with none configured the secure channel locates
+	// one from the realm via the AD DNS SRV record (_ldap._tcp.dc._msdcs.<realm>).
+	// That fallback needs the realm, so only disable passthrough when both are
+	// absent (#1324).
+	if len(ma.DCAddresses) == 0 && k.Realm == "" {
+		slog.Warn("NETLOGON machine account is enabled but neither dc_address nor kerberos.realm is set (no way to locate a DC); NTLM passthrough disabled")
 		return nil
 	}
 

--- a/cmd/dfs/commands/netlogon.go
+++ b/cmd/dfs/commands/netlogon.go
@@ -42,12 +42,12 @@ func buildNetlogonAuthenticator(k config.KerberosConfig) netlogon.NetlogonAuthen
 		slog.Warn("NETLOGON machine account is enabled but kerberos.netbios_domain (DomainName) is not set; NTLM passthrough disabled")
 		return nil
 	}
-	// A DC address is optional: with none configured the secure channel locates
-	// one from the realm via the AD DNS SRV record (_ldap._tcp.dc._msdcs.<realm>).
-	// That fallback needs the realm, so only disable passthrough when both are
-	// absent (#1324).
-	if len(ma.DCAddresses) == 0 && k.Realm == "" {
-		slog.Warn("NETLOGON machine account is enabled but neither dc_address nor kerberos.realm is set (no way to locate a DC); NTLM passthrough disabled")
+	// The realm is mandatory: the secure channel authenticates to the DC over a
+	// Kerberos SMB session, and when no dc_address is set the realm also drives
+	// DNS SRV discovery. A dc_address is optional — absent one, the DC is located
+	// from the realm via _ldap._tcp.dc._msdcs.<realm> (#1324).
+	if k.Realm == "" {
+		slog.Warn("NETLOGON machine account is enabled but kerberos.realm is not set (required for the Kerberos SMB session to the DC and for DNS SRV discovery); NTLM passthrough disabled")
 		return nil
 	}
 

--- a/cmd/dfs/commands/netlogon_test.go
+++ b/cmd/dfs/commands/netlogon_test.go
@@ -85,7 +85,9 @@ func TestBuildNetlogonAuthenticator_EnabledMissingDomain(t *testing.T) {
 	}
 }
 
-func TestBuildNetlogonAuthenticator_EnabledMissingDCAddresses(t *testing.T) {
+func TestBuildNetlogonAuthenticator_EnabledMissingDCAddressesUsesDiscovery(t *testing.T) {
+	// No dc_address is valid: the realm drives DNS SRV discovery of the DC at
+	// connect time, so passthrough stays enabled (#1324).
 	k := config.KerberosConfig{
 		Realm:         "EXAMPLE.COM",
 		NetBIOSDomain: "EXAMPLE",
@@ -93,12 +95,31 @@ func TestBuildNetlogonAuthenticator_EnabledMissingDCAddresses(t *testing.T) {
 			Enabled:     true,
 			AccountName: "DITTOFS$",
 			Secret:      "s3cr3t",
-			// DCAddresses intentionally empty
+			// DCAddresses intentionally empty — located from the realm.
+		},
+	}
+	got := buildNetlogonAuthenticator(k)
+	if got == nil {
+		t.Fatal("expected non-nil authenticator when realm is set (DC located via DNS SRV)")
+	}
+}
+
+func TestBuildNetlogonAuthenticator_EnabledMissingRealm(t *testing.T) {
+	// Realm is mandatory: the Kerberos SMB session to the DC and DNS SRV
+	// discovery both require it. Without it, passthrough must be disabled (#1324).
+	k := config.KerberosConfig{
+		// Realm intentionally empty
+		NetBIOSDomain: "EXAMPLE",
+		MachineAccount: config.MachineAccountConfig{
+			Enabled:     true,
+			AccountName: "DITTOFS$",
+			Secret:      "s3cr3t",
+			DCAddresses: []string{"192.168.1.1"},
 		},
 	}
 	got := buildNetlogonAuthenticator(k)
 	if got != nil {
-		t.Fatal("expected nil when DCAddresses is empty")
+		t.Fatal("expected nil when realm is missing")
 	}
 }
 

--- a/internal/auth/netlogon/credential.go
+++ b/internal/auth/netlogon/credential.go
@@ -36,8 +36,12 @@ func (p *offlineProvider) Credential(ctx context.Context) (*MachineCredential, e
 	if p.cred.AccountName == "" || p.cred.Password == "" || p.cred.DomainName == "" {
 		return nil, fmt.Errorf("netlogon: incomplete machine credential (account/password/domain required)")
 	}
-	if len(p.cred.DCAddresses) == 0 {
-		return nil, fmt.Errorf("netlogon: no DC address configured")
+	// A DC address is optional: when none is configured the secure channel
+	// locates one via the AD DNS SRV record (_ldap._tcp.dc._msdcs.<realm>),
+	// which requires the Kerberos realm. Require at least one of the two so we
+	// never build an authenticator that can neither dial nor discover a DC (#1324).
+	if len(p.cred.DCAddresses) == 0 && p.cred.Realm == "" {
+		return nil, fmt.Errorf("netlogon: no DC address configured and no realm for DNS SRV discovery")
 	}
 	cp := p.cred
 	return &cp, nil

--- a/internal/auth/netlogon/credential.go
+++ b/internal/auth/netlogon/credential.go
@@ -36,12 +36,13 @@ func (p *offlineProvider) Credential(ctx context.Context) (*MachineCredential, e
 	if p.cred.AccountName == "" || p.cred.Password == "" || p.cred.DomainName == "" {
 		return nil, fmt.Errorf("netlogon: incomplete machine credential (account/password/domain required)")
 	}
-	// A DC address is optional: when none is configured the secure channel
-	// locates one via the AD DNS SRV record (_ldap._tcp.dc._msdcs.<realm>),
-	// which requires the Kerberos realm. Require at least one of the two so we
-	// never build an authenticator that can neither dial nor discover a DC (#1324).
-	if len(p.cred.DCAddresses) == 0 && p.cred.Realm == "" {
-		return nil, fmt.Errorf("netlogon: no DC address configured and no realm for DNS SRV discovery")
+	// The realm is mandatory regardless of how the DC is located: the secure
+	// channel rides a Kerberos-authenticated SMB session (buildKRB5Config needs
+	// the realm) and, when no DC address is configured, the realm also drives
+	// DNS SRV discovery. A DC address itself is optional — absent one, the secure
+	// channel locates a DC from the realm via _ldap._tcp.dc._msdcs.<realm> (#1324).
+	if p.cred.Realm == "" {
+		return nil, fmt.Errorf("netlogon: realm is required (Kerberos SMB session to the DC and DNS SRV discovery both need it)")
 	}
 	cp := p.cred
 	return &cp, nil

--- a/internal/auth/netlogon/credential_test.go
+++ b/internal/auth/netlogon/credential_test.go
@@ -26,3 +26,34 @@ func TestOfflineProviderValidates(t *testing.T) {
 		t.Fatal("expected validation error for incomplete credential")
 	}
 }
+
+// TestOfflineProviderRealmDiscoveryFallback verifies a credential with no DC
+// address is accepted when a realm is present, since the secure channel can
+// then locate a DC via DNS SRV discovery (#1324).
+func TestOfflineProviderRealmDiscoveryFallback(t *testing.T) {
+	p := NewOfflineProvider(MachineCredential{
+		AccountName: "DITTOFS$", Password: "secret",
+		Workstation: "DITTOFS", DomainName: "DITTOFS", Realm: "DITTOFS.AD",
+		// DCAddresses intentionally empty: discovery resolves it from the realm.
+	})
+	got, err := p.Credential(context.Background())
+	if err != nil {
+		t.Fatalf("expected realm-only credential to validate, got error: %v", err)
+	}
+	if len(got.DCAddresses) != 0 || got.Realm != "DITTOFS.AD" {
+		t.Fatalf("unexpected credential: %+v", got)
+	}
+}
+
+// TestOfflineProviderRejectsNoDCNoRealm verifies a credential with neither a DC
+// address nor a realm is rejected: nothing can locate a DC (#1324).
+func TestOfflineProviderRejectsNoDCNoRealm(t *testing.T) {
+	p := NewOfflineProvider(MachineCredential{
+		AccountName: "DITTOFS$", Password: "secret",
+		Workstation: "DITTOFS", DomainName: "DITTOFS",
+		// No DCAddresses, no Realm.
+	})
+	if _, err := p.Credential(context.Background()); err == nil {
+		t.Fatal("expected validation error when neither DC address nor realm is set")
+	}
+}

--- a/internal/auth/netlogon/discovery.go
+++ b/internal/auth/netlogon/discovery.go
@@ -80,3 +80,82 @@ func DiscoverDCs(ctx context.Context, realm, dnsServer string) ([]DCInfo, error)
 	}
 	return dcs, nil
 }
+
+// resolveDialTarget returns the address to dial for the NETLOGON SMB session and
+// the Kerberos service principal (cifs/<fqdn>) of that exact host. The SPN must
+// name the dialed host: a ticket for a different DC would not authenticate the
+// SMB session, so the SPN is always tied to the dial target rather than to an
+// arbitrary SRV result (#1324). Three cases:
+//
+//   - No dc_address configured: locate a DC from the realm via DNS SRV (the host
+//     resolver, since a domain-joined host's resolv.conf points at a DC) and dial
+//     it by name.
+//   - dc_address is a hostname: it already names the DC — dial it and derive the
+//     SPN directly, no SRV round-trip needed.
+//   - dc_address is an IP: query the SRV locator (the DC is its own DNS server)
+//     and pick the DC whose address matches the dialed IP. A single-DC domain is
+//     unambiguous; if no SRV target matches, fall back to the first SRV result.
+func resolveDialTarget(ctx context.Context, mc MachineCredential) (dialServer, spn string, err error) {
+	if len(mc.DCAddresses) == 0 {
+		dcs, derr := DiscoverDCs(ctx, mc.Realm, "")
+		if derr != nil {
+			return "", "", fmt.Errorf("discover DC: %w", derr)
+		}
+		if len(dcs) == 0 {
+			return "", "", fmt.Errorf("no DC discovered for realm %q and none configured", mc.Realm)
+		}
+		return dcs[0].FQDN, dcs[0].SPN(), nil
+	}
+
+	dial := mc.DCAddresses[0]
+	host := dial
+	if h, _, splitErr := net.SplitHostPort(dial); splitErr == nil {
+		host = h
+	}
+	if net.ParseIP(host) == nil {
+		// Hostname dial target already names the DC.
+		return dial, "cifs/" + host, nil
+	}
+
+	// IP dial target: resolve a name for the SPN via the DC's own DNS.
+	dcs, derr := DiscoverDCs(ctx, mc.Realm, host)
+	if derr != nil {
+		return "", "", fmt.Errorf("discover DC: %w", derr)
+	}
+	if len(dcs) == 0 {
+		return "", "", fmt.Errorf("no DC discovered for realm %q", mc.Realm)
+	}
+	chosen := dcs[0]
+	if len(dcs) > 1 {
+		if m := matchDCByIP(ctx, dcs, host); m != nil {
+			chosen = *m
+		}
+		// else: ambiguous multi-DC IP — fall back to the first SRV result.
+	}
+	return dial, chosen.SPN(), nil
+}
+
+// matchDCByIP returns the discovered DC whose FQDN resolves (via the DC's own
+// DNS server at dnsServer) to dnsServer, or nil if none match. Used to bind the
+// Kerberos SPN to the configured dial IP in a multi-DC domain.
+func matchDCByIP(ctx context.Context, dcs []DCInfo, dnsServer string) *DCInfo {
+	resolver := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			d := net.Dialer{Timeout: 5 * time.Second}
+			return d.DialContext(ctx, network, net.JoinHostPort(dnsServer, "53"))
+		},
+	}
+	for i := range dcs {
+		addrs, lerr := resolver.LookupHost(ctx, dcs[i].FQDN)
+		if lerr != nil {
+			continue
+		}
+		for _, a := range addrs {
+			if a == dnsServer {
+				return &dcs[i]
+			}
+		}
+	}
+	return nil
+}

--- a/internal/auth/netlogon/securechannel.go
+++ b/internal/auth/netlogon/securechannel.go
@@ -113,18 +113,32 @@ func (sc *SecureChannel) connect(ctx context.Context, mc MachineCredential) erro
 		return nil
 	}
 
-	if len(mc.DCAddresses) == 0 {
-		return fmt.Errorf("netlogon: no DC address configured")
+	// Resolve which DC to connect to and its canonical FQDN (for the cifs/<fqdn>
+	// SMB service principal) via the AD DNS SRV locator. Two modes (#1324):
+	//
+	//   - DC address configured: connectivity uses that address, and we point the
+	//     SRV lookup at it (the DC is the domain's authoritative DNS server) purely
+	//     to learn the FQDN for the SPN. The IP stays the dial target.
+	//   - No DC address configured: locate a DC entirely from the realm using the
+	//     host resolver (a domain-joined host's resolv.conf points at a DC), then
+	//     dial the discovered FQDN directly.
+	var server string
+	var dcs []DCInfo
+	var err error
+	if len(mc.DCAddresses) > 0 {
+		server = mc.DCAddresses[0]
+		dcs, err = DiscoverDCs(ctx, mc.Realm, server)
+	} else {
+		dcs, err = DiscoverDCs(ctx, mc.Realm, "")
+		if err == nil && len(dcs) > 0 {
+			server = dcs[0].FQDN
+		}
 	}
-	server := mc.DCAddresses[0]
-
-	// Discover the DC's canonical FQDN via the AD DNS SRV locator so we can name
-	// the SMB Kerberos service principal (cifs/<fqdn>). The DC is the domain's
-	// DNS server, so we query it directly at the address we already hold (#1324).
-	// Connectivity still uses `server` (the IP) — only the SPN needs the name.
-	dcs, err := DiscoverDCs(ctx, mc.Realm, server)
 	if err != nil {
 		return fmt.Errorf("netlogon: discover DC: %w", err)
+	}
+	if len(dcs) == 0 || server == "" {
+		return fmt.Errorf("netlogon: no DC discovered for realm %q and none configured", mc.Realm)
 	}
 	spn := dcs[0].SPN()
 

--- a/internal/auth/netlogon/securechannel.go
+++ b/internal/auth/netlogon/securechannel.go
@@ -113,34 +113,13 @@ func (sc *SecureChannel) connect(ctx context.Context, mc MachineCredential) erro
 		return nil
 	}
 
-	// Resolve which DC to connect to and its canonical FQDN (for the cifs/<fqdn>
-	// SMB service principal) via the AD DNS SRV locator. Two modes (#1324):
-	//
-	//   - DC address configured: connectivity uses that address, and we point the
-	//     SRV lookup at it (the DC is the domain's authoritative DNS server) purely
-	//     to learn the FQDN for the SPN. The IP stays the dial target.
-	//   - No DC address configured: locate a DC entirely from the realm using the
-	//     host resolver (a domain-joined host's resolv.conf points at a DC), then
-	//     dial the discovered FQDN directly.
-	var server string
-	var dcs []DCInfo
-	var err error
-	if len(mc.DCAddresses) > 0 {
-		server = mc.DCAddresses[0]
-		dcs, err = DiscoverDCs(ctx, mc.Realm, server)
-	} else {
-		dcs, err = DiscoverDCs(ctx, mc.Realm, "")
-		if err == nil && len(dcs) > 0 {
-			server = dcs[0].FQDN
-		}
-	}
+	// Resolve the dial target and the Kerberos SMB service principal (cifs/<fqdn>)
+	// for the DC we will actually connect to. The SPN must name the dialed host —
+	// a cifs/<other-dc> ticket would not authenticate the SMB session (#1324).
+	server, spn, err := resolveDialTarget(ctx, mc)
 	if err != nil {
-		return fmt.Errorf("netlogon: discover DC: %w", err)
+		return fmt.Errorf("netlogon: %w", err)
 	}
-	if len(dcs) == 0 || server == "" {
-		return fmt.Errorf("netlogon: no DC discovered for realm %q and none configured", mc.Realm)
-	}
-	spn := dcs[0].SPN()
 
 	// Register the machine credential and the SPNEGO/NTLM/KRB5/Netlogon mechanisms
 	// (once, process-global) BEFORE creating the security context, which captures


### PR DESCRIPTION
## What

Wires DNS SRV DC discovery (`_ldap._tcp.dc._msdcs.<realm>`) as a full fallback for NETLOGON, so a machine-account config no longer **requires** an explicit `dc_address`.

Previously `DiscoverDCs` (landed in #1358) was used only to resolve the DC **FQDN** for the SMB Kerberos service principal — connectivity still needed a hardcoded `dc_address`. Now:

- **No `dc_address` configured** → locate a DC entirely from the realm via the host resolver (a domain-joined host's `resolv.conf` points at a DC) and dial the discovered FQDN.
- **`dc_address` configured** → unchanged: that address is the dial target, and the SRV lookup against it only resolves the FQDN for the SPN.

## Changes

- `credential.go`: accept a realm-only credential — require **either** a DC address **or** a realm (so we never build an authenticator that can neither dial nor discover).
- `securechannel.go connect()`: discover the DC address from the realm when none configured.
- `cmd/dfs/commands/netlogon.go`: keep NTLM passthrough enabled when only the realm is set (disable only when **both** `dc_address` and `kerberos.realm` are absent).
- Tests: realm-only credential validates; neither-set is rejected.

## Test

`go test ./internal/auth/netlogon/...` green. The discovery→dial path is exercised by the `ad_dc` integration suite.

Closes #1324.