### PR TITLE
docs(s3): document S3-compatible backend presets + MinIO e2e

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -673,6 +673,114 @@ The passphrase that unlocks a local key file is read from the
 `DITTOFS_ENCRYPTION_PASSPHRASE` environment variable — never the config
 file or command line.
 
+#### S3-compatible backend presets
+
+The `s3` remote store talks the AWS S3 API, so any S3-compatible object
+store works — set a custom `endpoint` (and credentials) and DittoFS connects
+to it instead of AWS. The store reads exactly these config keys (see
+`pkg/block/remote/s3/store.go` and the factory in
+`pkg/controlplane/runtime/shares/service.go`):
+
+| Key | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `bucket` | yes | — | Bucket name. Must already exist; DittoFS does not create it. |
+| `access_key_id` | yes | — | S3 access key. For GCS use an **HMAC** key, not a service-account JSON. |
+| `secret_access_key` | yes | — | S3 secret key. |
+| `region` | no | `us-east-1` | Some providers ignore it but the SDK still requires a value; the default is sent when omitted. |
+| `endpoint` | no (AWS) / yes (others) | AWS | Service URL. Scheme optional — `https://` is prepended when absent. |
+| `force_path_style` | no | auto | **Auto-enabled whenever `endpoint` is set.** Set explicitly to `false` to opt back into virtual-hosted-style for providers that require it (e.g. GCS). |
+| `prefix` | no | — | Key prefix prepended to every block (e.g. `dittofs/`). End it with `/`. |
+
+> Path-style addressing (`endpoint.example.com/bucket/key`) is the safe
+> default for non-AWS providers because virtual-hosted style
+> (`bucket.endpoint.example.com/key`) needs wildcard DNS and TLS SANs that
+> most S3-compatible gateways do not provide. DittoFS therefore flips
+> `force_path_style` on automatically the moment you set a custom `endpoint`;
+> the only providers below that need it turned back **off** are those that
+> require virtual-hosted style (GCS).
+
+Credentials can be passed inline in `--config` (as below) or read from the
+environment via the standard `DITTOFS_*` precedence; inline values are shown
+here for clarity. Each recipe is a `dfsctl store block remote add` invocation;
+attach the resulting store to a share with `dfsctl share create … --remote <name>`.
+
+##### Verified providers
+
+These run against an emulator (or a documented public endpoint) and are
+exercised by the e2e suite where an emulator exists:
+
+| Provider | Verified by | Endpoint | Region | `force_path_style` | Notes |
+| --- | --- | --- | --- | --- | --- |
+| AWS S3 | unit + prod use | _(omit — SDK default)_ | your bucket region | unset (virtual-hosted) | The native case; no `endpoint`. |
+| MinIO | **e2e emulator** | `http://minio.example:9000` | `us-east-1` | auto-on | Self-hosted; HTTP fine on a trusted network. |
+| LocalStack | **e2e emulator** | `http://localstack:4566` | `us-east-1` | auto-on | Test/CI only; not a production target. |
+| Ceph RGW | documented | `https://rgw.example:7480` | `us-east-1` | auto-on | RGW ignores region; any non-empty value is accepted. |
+
+```bash
+# MinIO  (verified by e2e emulator)
+dfsctl store block remote add --name minio-store --type s3 \
+  --config '{"endpoint":"http://minio.example:9000","bucket":"dittofs","region":"us-east-1","access_key_id":"minioadmin","secret_access_key":"minioadmin"}'
+
+# Ceph RGW (RADOS Gateway)
+dfsctl store block remote add --name ceph-store --type s3 \
+  --config '{"endpoint":"https://rgw.example:7480","bucket":"dittofs","region":"us-east-1","access_key_id":"ACCESS","secret_access_key":"SECRET"}'
+```
+
+##### Documented-only providers
+
+These are configured exactly like the verified ones but have **not** been run
+against a live account in CI — they are documented from each provider's S3
+compatibility guide. The per-provider column flags the one gotcha that bites.
+
+| Provider | Endpoint | Region | `force_path_style` | Gotcha |
+| --- | --- | --- | --- | --- |
+| Google Cloud Storage (XML/HMAC) | `https://storage.googleapis.com` | `us-east-1` | **set `false`** | Use an **HMAC** key (`access_key_id`/`secret_access_key`), not a service-account JSON. GCS ignores `region` (any non-empty value works), so send the `us-east-1` default. GCS wants virtual-hosted style, so override the auto path-style default to `false`. |
+| Backblaze B2 | `https://s3.us-west-004.backblazeb2.com` | `us-west-004` | auto-on | Endpoint embeds the region (`s3.<region>.backblazeb2.com`); `region` must match it. Use an **application key**, not the master key. |
+| Wasabi | `https://s3.us-east-1.wasabisys.com` | `us-east-1` | auto-on | Region is in the hostname; mismatched `region` causes auth failures. |
+| DigitalOcean Spaces | `https://nyc3.digitaloceanspaces.com` | `us-east-1` | auto-on | Endpoint is the datacenter (`<region>.digitaloceanspaces.com`); send `region: us-east-1` (Spaces ignores it but the SDK requires a value). |
+| Alibaba Cloud OSS | `https://oss-us-west-1.aliyuncs.com` | `us-west-1` | auto-on | Region is encoded in the endpoint host; use the matching OSS region. |
+| Tencent Cloud COS | `https://cos.ap-guangzhou.myqcloud.com` | `ap-guangzhou` | auto-on | Bucket name must include the AppID suffix (`name-1250000000`); endpoint carries the region. |
+| Oracle Cloud (OCI) Object Storage | `https://<namespace>.compat.objectstorage.us-ashburn-1.oraclecloud.com` | `us-ashburn-1` | auto-on | Endpoint contains your tenancy **namespace**; generate a **Customer Secret Key** for S3 compat. |
+| Storj (S3 gateway) | `https://gateway.storjshare.io` | `us-east-1` | auto-on | Use S3-gateway access keys (`uplink share --register`), not the API access grant. |
+
+```bash
+# Google Cloud Storage — note force_path_style:false (GCS wants virtual-hosted)
+dfsctl store block remote add --name gcs-store --type s3 \
+  --config '{"endpoint":"https://storage.googleapis.com","bucket":"dittofs","region":"us-east-1","access_key_id":"GOOG_HMAC_KEY","secret_access_key":"GOOG_HMAC_SECRET","force_path_style":false}'
+
+# Backblaze B2 — region is baked into the endpoint host
+dfsctl store block remote add --name b2-store --type s3 \
+  --config '{"endpoint":"https://s3.us-west-004.backblazeb2.com","bucket":"dittofs","region":"us-west-004","access_key_id":"B2_KEY_ID","secret_access_key":"B2_APP_KEY"}'
+
+# Wasabi
+dfsctl store block remote add --name wasabi-store --type s3 \
+  --config '{"endpoint":"https://s3.us-east-1.wasabisys.com","bucket":"dittofs","region":"us-east-1","access_key_id":"ACCESS","secret_access_key":"SECRET"}'
+
+# DigitalOcean Spaces
+dfsctl store block remote add --name spaces-store --type s3 \
+  --config '{"endpoint":"https://nyc3.digitaloceanspaces.com","bucket":"dittofs","region":"us-east-1","access_key_id":"SPACES_KEY","secret_access_key":"SPACES_SECRET"}'
+
+# Alibaba Cloud OSS
+dfsctl store block remote add --name oss-store --type s3 \
+  --config '{"endpoint":"https://oss-us-west-1.aliyuncs.com","bucket":"dittofs","region":"us-west-1","access_key_id":"ACCESS","secret_access_key":"SECRET"}'
+
+# Tencent Cloud COS — bucket name carries the AppID suffix
+dfsctl store block remote add --name cos-store --type s3 \
+  --config '{"endpoint":"https://cos.ap-guangzhou.myqcloud.com","bucket":"dittofs-1250000000","region":"ap-guangzhou","access_key_id":"SECRET_ID","secret_access_key":"SECRET_KEY"}'
+
+# Oracle Cloud (OCI) Object Storage — endpoint embeds your namespace
+dfsctl store block remote add --name oci-store --type s3 \
+  --config '{"endpoint":"https://my-namespace.compat.objectstorage.us-ashburn-1.oraclecloud.com","bucket":"dittofs","region":"us-ashburn-1","access_key_id":"OCI_ACCESS","secret_access_key":"OCI_SECRET"}'
+
+# Storj (S3-compatible gateway)
+dfsctl store block remote add --name storj-store --type s3 \
+  --config '{"endpoint":"https://gateway.storjshare.io","bucket":"dittofs","region":"us-east-1","access_key_id":"STORJ_ACCESS","secret_access_key":"STORJ_SECRET"}'
+```
+
+All of the above accept the same optional knobs as AWS S3 —
+`prefix`, `compression`, `encryption`, and `durable` (see the preceding
+subsections) — because they share the single `s3` store implementation.
+
 ### 7. Metadata Configuration
 
 Metadata configuration has two parts: filesystem capabilities (server config file) and store instances (managed via CLI).

--- a/test/e2e/framework/containers.go
+++ b/test/e2e/framework/containers.go
@@ -35,13 +35,21 @@ func (pc *PostgresConfig) ConnectionString() string {
 		pc.User, pc.Password, pc.Host, pc.Port, pc.Database)
 }
 
-// LocalstackHelper manages Localstack S3 integration for tests.
+// LocalstackHelper manages an S3-compatible emulator (Localstack or MinIO)
+// for tests. The bucket/list/cleanup helpers below are emulator-agnostic — they
+// only need Endpoint, Client, and the per-emulator credentials.
 type LocalstackHelper struct {
 	T         *testing.T
 	Container testcontainers.Container
 	Endpoint  string
 	Client    *s3.Client
 	Buckets   []string
+
+	// AccessKey/SecretKey are the static credentials the emulator accepts.
+	// They default to "test"/"test" (Localstack) when empty; MinIO overrides
+	// them. DittoFS shares are configured with these same values.
+	AccessKey string
+	SecretKey string
 }
 
 // Shared Localstack container for E2E tests (started once per test run)
@@ -130,10 +138,15 @@ func (lh *LocalstackHelper) createClient() {
 
 	ctx := context.Background()
 
+	accessKey, secretKey := lh.AccessKey, lh.SecretKey
+	if accessKey == "" || secretKey == "" {
+		accessKey, secretKey = "test", "test"
+	}
+
 	cfg, err := awsConfig.LoadDefaultConfig(ctx,
 		awsConfig.WithRegion("us-east-1"),
 		awsConfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
+			accessKey, secretKey, "",
 		)),
 	)
 	if err != nil {
@@ -292,6 +305,115 @@ func CheckLocalstackAvailable(t *testing.T) bool {
 	}
 
 	// With testcontainers, we can always start the container on demand
+	return true
+}
+
+// MinIO credentials used by the emulator and the DittoFS share that targets it.
+const (
+	minioAccessKey = "minioadmin"
+	minioSecretKey = "minioadmin"
+)
+
+// sharedMinioHelper is the MinIO container reused across the test run, mirroring
+// sharedLocalstackHelper.
+var sharedMinioHelper *LocalstackHelper
+
+// NewMinioHelper creates or returns a shared MinIO emulator helper. MinIO is a
+// distinct S3-compatible backend (vs Localstack) used to exercise the
+// custom-endpoint + auto-path-style preset path documented in
+// docs/CONFIGURATION.md. The returned helper reuses every LocalstackHelper
+// bucket/list/cleanup method.
+func NewMinioHelper(t *testing.T) *LocalstackHelper {
+	t.Helper()
+
+	if sharedMinioHelper != nil {
+		return sharedMinioHelper
+	}
+
+	ctx := context.Background()
+
+	// Honor an external MinIO when configured, like the Localstack path.
+	if endpoint := os.Getenv("MINIO_ENDPOINT"); endpoint != "" {
+		helper := &LocalstackHelper{
+			T:         t,
+			Endpoint:  endpoint,
+			Buckets:   make([]string, 0),
+			AccessKey: minioAccessKey,
+			SecretKey: minioSecretKey,
+		}
+		helper.createClient()
+		sharedMinioHelper = helper
+		return helper
+	}
+
+	req := testcontainers.ContainerRequest{
+		Image:        "minio/minio:RELEASE.2024-09-13T20-26-02Z",
+		ExposedPorts: []string{"9000/tcp"},
+		Env: map[string]string{
+			"MINIO_ROOT_USER":     minioAccessKey,
+			"MINIO_ROOT_PASSWORD": minioSecretKey,
+		},
+		Cmd: []string{"server", "/data"},
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort("9000/tcp"),
+			wait.ForHTTP("/minio/health/live").WithPort("9000/tcp"),
+		).WithDeadline(3 * time.Minute),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		t.Fatalf("failed to start minio container: %v", err)
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		_ = container.Terminate(ctx)
+		t.Fatalf("failed to get minio host: %v", err)
+	}
+
+	port, err := container.MappedPort(ctx, "9000")
+	if err != nil {
+		_ = container.Terminate(ctx)
+		t.Fatalf("failed to get minio port: %v", err)
+	}
+
+	helper := &LocalstackHelper{
+		T:         t,
+		Container: container,
+		Endpoint:  fmt.Sprintf("http://%s:%s", host, port.Port()),
+		Buckets:   make([]string, 0),
+		AccessKey: minioAccessKey,
+		SecretKey: minioSecretKey,
+	}
+	helper.createClient()
+	sharedMinioHelper = helper
+
+	return helper
+}
+
+// CheckMinioAvailable reports whether MinIO can be used (external instance
+// reachable, or testcontainers available to start one on demand).
+func CheckMinioAvailable(t *testing.T) bool {
+	t.Helper()
+
+	if endpoint := os.Getenv("MINIO_ENDPOINT"); endpoint != "" {
+		helper := &LocalstackHelper{
+			T:         t,
+			Endpoint:  endpoint,
+			Buckets:   make([]string, 0),
+			AccessKey: minioAccessKey,
+			SecretKey: minioSecretKey,
+		}
+		helper.createClient()
+
+		ctx := context.Background()
+		_, err := helper.Client.ListBuckets(ctx, &s3.ListBucketsInput{})
+		return err == nil
+	}
+
 	return true
 }
 
@@ -507,5 +629,11 @@ func CleanupSharedContainers() {
 	if sharedLocalstackHelper != nil && sharedLocalstackHelper.Container != nil {
 		_ = sharedLocalstackHelper.Container.Terminate(ctx)
 		sharedLocalstackHelper = nil
+	}
+
+	// Cleanup MinIO container
+	if sharedMinioHelper != nil && sharedMinioHelper.Container != nil {
+		_ = sharedMinioHelper.Container.Terminate(ctx)
+		sharedMinioHelper = nil
 	}
 }

--- a/test/e2e/helpers/matrix.go
+++ b/test/e2e/helpers/matrix.go
@@ -35,6 +35,63 @@ func (c MatrixSetupConfig) HasRemote() bool {
 	return c.RemoteType != "none"
 }
 
+// s3HelperCreds returns the credentials an S3-emulator helper (Localstack or
+// MinIO) accepts, defaulting to Localstack's "test"/"test" when unset.
+func s3HelperCreds(h *framework.LocalstackHelper) (accessKey, secretKey string) {
+	if h.AccessKey != "" && h.SecretKey != "" {
+		return h.AccessKey, h.SecretKey
+	}
+	return "test", "test"
+}
+
+// SetupS3CompatibleShare provisions a badger-metadata + fs-local + s3-remote
+// share whose remote points at the given S3-compatible emulator (Localstack or
+// MinIO). It is the e2e fixture for the S3-compatible backend presets
+// documented in docs/CONFIGURATION.md: a custom endpoint that auto-enables
+// path-style addressing in the s3 store factory. All resources are registered
+// for cleanup via t.Cleanup. Returns the share name.
+func SetupS3CompatibleShare(
+	t *testing.T,
+	runner *CLIRunner,
+	shareName string,
+	s3Helper *framework.LocalstackHelper,
+) string {
+	t.Helper()
+
+	metaName := UniqueTestName("meta")
+	localName := UniqueTestName("local")
+	remoteName := UniqueTestName("remote")
+
+	_, err := runner.CreateMetadataStore(metaName, "badger",
+		WithMetaDBPath(filepath.Join(t.TempDir(), "badger")))
+	require.NoError(t, err, "Should create badger metadata store")
+	t.Cleanup(func() { _ = runner.DeleteMetadataStore(metaName) })
+
+	_, err = runner.CreateLocalBlockStore(localName, "fs",
+		WithBlockRawConfig(fmt.Sprintf(`{"path":"%s"}`,
+			filepath.Join(t.TempDir(), "local-blocks"))))
+	require.NoError(t, err, "Should create fs local block store")
+	t.Cleanup(func() { _ = runner.DeleteLocalBlockStore(localName) })
+
+	bucketName := strings.ReplaceAll(
+		fmt.Sprintf("dittofs-s3c-%s", UniqueTestName("bkt")), "_", "-")
+	require.NoError(t, s3Helper.CreateBucket(context.Background(), bucketName),
+		"Should create S3 bucket on emulator")
+	t.Cleanup(func() { s3Helper.CleanupBucket(context.Background(), bucketName) })
+
+	accessKey, secretKey := s3HelperCreds(s3Helper)
+	_, err = runner.CreateRemoteBlockStore(remoteName, "s3",
+		WithBlockS3Config(bucketName, "us-east-1", s3Helper.Endpoint, accessKey, secretKey))
+	require.NoError(t, err, "Should create s3 remote block store")
+	t.Cleanup(func() { _ = runner.DeleteRemoteBlockStore(remoteName) })
+
+	_, err = runner.CreateShare(shareName, metaName, localName, WithShareRemote(remoteName))
+	require.NoError(t, err, "Should create share")
+	t.Cleanup(func() { _ = runner.DeleteShare(shareName) })
+
+	return shareName
+}
+
 // SetupStoreMatrix creates metadata, local block, and (optionally) remote block
 // stores for a 3D store matrix test, then creates a share referencing them.
 // All resources are registered for cleanup via t.Cleanup.
@@ -106,8 +163,9 @@ func SetupStoreMatrix(
 			require.NoError(t, err, "Should create S3 bucket")
 			t.Cleanup(func() { lsHelper.CleanupBucket(context.Background(), bucketName) })
 
+			accessKey, secretKey := s3HelperCreds(lsHelper)
 			remoteOpts = append(remoteOpts, WithBlockS3Config(
-				bucketName, "us-east-1", lsHelper.Endpoint, "test", "test"))
+				bucketName, "us-east-1", lsHelper.Endpoint, accessKey, secretKey))
 		}
 
 		_, err = runner.CreateRemoteBlockStore(setup.RemoteStoreName, sc.RemoteType, remoteOpts...)

--- a/test/e2e/run-e2e.sh
+++ b/test/e2e/run-e2e.sh
@@ -3,15 +3,18 @@
 # DittoFS E2E Test Runner
 # =============================================================================
 #
-# Runs E2E tests with optional features: S3 (Localstack), stress tests,
-# coverage profiling, NFS version selection, and specific test patterns.
+# Runs E2E tests with optional features: S3 (Localstack), MinIO
+# (S3-compatible presets), stress tests, coverage profiling, NFS version
+# selection, and specific test patterns.
 #
 # Usage:
 #   sudo ./run-e2e.sh [options]
 #
 # Options:
 #   --s3                 Start Localstack for S3 tests (stop after tests)
+#   --minio              Start MinIO for S3-compatible preset tests (stop after)
 #   --keep-localstack    Keep Localstack running after tests (for repeated runs)
+#   --keep-minio         Keep MinIO running after tests (for repeated runs)
 #   --test PATTERN       Run specific test pattern (-run PATTERN)
 #   --verbose            Enable verbose test output (-v)
 #   --coverage           Generate coverage profile (-coverprofile=coverage-e2e.out)
@@ -45,7 +48,9 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # Default options
 # =============================================================================
 USE_S3=false
+USE_MINIO=false
 KEEP_LOCALSTACK=false
+KEEP_MINIO=false
 TEST_PATTERN=""
 VERBOSE=false
 COVERAGE=false
@@ -75,7 +80,9 @@ Usage: sudo ./run-e2e.sh [options]
 
 Options:
   --s3                 Start Localstack for S3 tests (stop after tests)
+  --minio              Start MinIO for S3-compatible preset tests (stop after)
   --keep-localstack    Keep Localstack running after tests (for repeated runs)
+  --keep-minio         Keep MinIO running after tests (for repeated runs)
   --test PATTERN       Run specific test pattern (-run PATTERN)
   --verbose            Enable verbose test output (-v)
   --coverage           Generate coverage profile (-coverprofile=coverage-e2e.out)
@@ -93,6 +100,7 @@ Examples:
   sudo ./run-e2e.sh --verbose                        # Run with verbose output
   sudo ./run-e2e.sh --test TestNFSv4BasicOperations  # Run specific test
   sudo ./run-e2e.sh --s3                             # Include S3 tests
+  sudo ./run-e2e.sh --minio                          # Include S3-compatible preset tests (MinIO)
   sudo ./run-e2e.sh --portmap                        # Run portmapper tests only
   sudo ./run-e2e.sh --nfs-version 4                  # Set NFS version for tests
   sudo ./run-e2e.sh --local-only                     # Skip remote store combos
@@ -108,8 +116,16 @@ while [[ $# -gt 0 ]]; do
             USE_S3=true
             shift
             ;;
+        --minio)
+            USE_MINIO=true
+            shift
+            ;;
         --keep-localstack)
             KEEP_LOCALSTACK=true
+            shift
+            ;;
+        --keep-minio)
+            KEEP_MINIO=true
             shift
             ;;
         --test)
@@ -295,6 +311,56 @@ stop_localstack() {
 }
 
 # =============================================================================
+# MinIO management (S3-compatible backend preset tests)
+# =============================================================================
+MINIO_CONTAINER=""
+
+start_minio() {
+    log_step "Starting MinIO for S3-compatible preset tests..."
+
+    if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "dittofs-minio"; then
+        log_info "MinIO already running (dittofs-minio)"
+        MINIO_CONTAINER="dittofs-minio"
+        export MINIO_ENDPOINT="http://localhost:9000"
+        return
+    fi
+
+    docker run -d \
+        --name dittofs-minio \
+        -p 9000:9000 \
+        -e MINIO_ROOT_USER=minioadmin \
+        -e MINIO_ROOT_PASSWORD=minioadmin \
+        minio/minio:RELEASE.2024-09-13T20-26-02Z server /data
+
+    MINIO_CONTAINER="dittofs-minio"
+
+    log_info "Waiting for MinIO to be ready..."
+    local max_attempts=30
+    local attempt=1
+    while [[ $attempt -le $max_attempts ]]; do
+        if curl -sf http://localhost:9000/minio/health/live >/dev/null 2>&1; then
+            log_info "MinIO is ready"
+            export MINIO_ENDPOINT="http://localhost:9000"
+            return
+        fi
+        sleep 1
+        ((attempt++))
+    done
+
+    log_error "MinIO failed to start within $max_attempts seconds"
+    exit 1
+}
+
+stop_minio() {
+    if [[ -n "$MINIO_CONTAINER" ]] && [[ "$KEEP_MINIO" == "false" ]]; then
+        log_step "Stopping MinIO..."
+        docker rm -f "$MINIO_CONTAINER" 2>/dev/null || true
+    elif [[ "$KEEP_MINIO" == "true" ]]; then
+        log_info "Keeping MinIO running (--keep-minio)"
+    fi
+}
+
+# =============================================================================
 # Run tests
 # =============================================================================
 log_info "DittoFS E2E Test Runner"
@@ -305,6 +371,7 @@ log_info "Verbose:       ${VERBOSE}"
 log_info "Coverage:      ${COVERAGE}"
 log_info "Stress:        ${STRESS}"
 log_info "S3:            ${USE_S3}"
+log_info "MinIO:         ${USE_MINIO}"
 log_info "Race:          ${RACE}"
 log_info "Portmap:       ${PORTMAP}"
 log_info "Local only:    ${LOCAL_ONLY}"
@@ -320,6 +387,11 @@ echo ""
 # Start Localstack if needed
 if [[ "$USE_S3" == "true" ]]; then
     start_localstack
+fi
+
+# Start MinIO if needed
+if [[ "$USE_MINIO" == "true" ]]; then
+    start_minio
 fi
 
 # Run the tests
@@ -354,6 +426,11 @@ fi
 # Stop Localstack if needed
 if [[ "$USE_S3" == "true" ]]; then
     stop_localstack
+fi
+
+# Stop MinIO if needed
+if [[ "$USE_MINIO" == "true" ]]; then
+    stop_minio
 fi
 
 exit $TEST_EXIT_CODE

--- a/test/e2e/s3_compatible_presets_test.go
+++ b/test/e2e/s3_compatible_presets_test.go
@@ -1,0 +1,92 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/test/e2e/framework"
+	"github.com/marmos91/dittofs/test/e2e/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestS3CompatiblePresets exercises the S3-compatible backend preset path
+// documented in docs/CONFIGURATION.md against real emulators (MinIO and
+// LocalStack). Both are wired exactly as a non-AWS provider would be: a custom
+// `endpoint`, which makes the s3 store factory auto-enable path-style
+// addressing (force_path_style). A full NFS read/write/overwrite round-trip
+// through a share whose remote tier is the emulator proves the preset works
+// end-to-end, not just that the config parses.
+//
+// MinIO is the headline verified provider here (LocalStack is already covered
+// by the store matrix); running both confirms the single s3 implementation
+// serves distinct S3-compatible backends.
+func TestS3CompatiblePresets(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping S3-compatible preset tests in short mode")
+	}
+
+	emulators := []struct {
+		name      string
+		available func(*testing.T) bool
+		helper    func(*testing.T) *framework.LocalstackHelper
+	}{
+		{"minio", framework.CheckMinioAvailable, framework.NewMinioHelper},
+		{"localstack", framework.CheckLocalstackAvailable, framework.NewLocalstackHelper},
+	}
+
+	for _, em := range emulators {
+		t.Run(em.name, func(t *testing.T) {
+			if !em.available(t) {
+				t.Skipf("Skipping: %s emulator not available", em.name)
+			}
+			runS3CompatiblePresetTest(t, em.helper(t))
+		})
+	}
+}
+
+func runS3CompatiblePresetTest(t *testing.T, s3Helper *framework.LocalstackHelper) {
+	t.Helper()
+
+	sp := helpers.StartServerProcess(t, "")
+	t.Cleanup(sp.ForceKill)
+
+	runner := helpers.LoginAsAdmin(t, sp.APIURL())
+
+	shareName := "/export-s3c"
+	helpers.SetupS3CompatibleShare(t, runner, shareName, s3Helper)
+
+	nfsPort := helpers.FindFreePort(t)
+	_, err := runner.EnableAdapter("nfs", helpers.WithAdapterPort(nfsPort))
+	require.NoError(t, err, "Should enable NFS adapter")
+	t.Cleanup(func() { _, _ = runner.DisableAdapter("nfs") })
+
+	require.NoError(t,
+		helpers.WaitForAdapterStatus(t, runner, "nfs", true, 5*time.Second),
+		"NFS adapter should become enabled")
+
+	framework.WaitForServer(t, nfsPort, 10*time.Second)
+
+	mount := mountNFSExport(t, nfsPort, shareName)
+	t.Cleanup(mount.Cleanup)
+
+	// Write, read back, overwrite, read back — covers the create + remote-sync
+	// path through the S3-compatible backend.
+	content := []byte("DittoFS over an S3-compatible backend.")
+	file := mount.FilePath("s3c.txt")
+	framework.WriteFile(t, file, content)
+	t.Cleanup(func() { _ = os.Remove(file) })
+
+	assert.True(t, framework.FileExists(file), "File should exist after creation")
+	assert.True(t, bytes.Equal(content, framework.ReadFile(t, file)),
+		"Read content should match written content")
+
+	updated := []byte("Overwritten via S3-compatible remote.")
+	framework.WriteFile(t, file, updated)
+	assert.True(t, bytes.Equal(updated, framework.ReadFile(t, file)),
+		"Overwritten content should match")
+}


### PR DESCRIPTION
## What

Implements #1222 (T0: Document + test S3-compatible backend presets). **No production code changes** — the `s3` block store already serves any S3-compatible cloud via a custom `endpoint` + auto path-style (`pkg/block/remote/s3/store.go`, factory in `pkg/controlplane/runtime/shares/service.go`). This makes the multi-cloud claim concrete via docs + tests.

### Docs (`docs/CONFIGURATION.md`)
New "S3-compatible backend presets" subsection under Block Store Configuration:
- Config-key reference table grounded in the actual factory keys: `bucket`, `region` (default `us-east-1`), `endpoint`, `prefix`, `access_key_id`, `secret_access_key`, `force_path_style` (auto-enabled when `endpoint` is set; explicit `false` honored).
- **Verified providers** table (AWS, MinIO, LocalStack, Ceph RGW) vs **documented-only** table (GCS, Backblaze B2, Wasabi, DigitalOcean Spaces, Alibaba OSS, Tencent COS, Oracle OCI, Storj) — honest about what is emulator-verified vs documented from each provider's compat guide.
- A `dfsctl store block remote add … --type s3` recipe per provider, plus per-provider gotchas (GCS HMAC keys + `force_path_style:false`; B2/Wasabi region baked into endpoint host; COS AppID-suffixed bucket; OCI namespace in endpoint; Storj gateway keys).

### e2e (`test/e2e/`)
- `framework/containers.go`: `NewMinioHelper`/`CheckMinioAvailable` reuse the existing `LocalstackHelper` struct (added `AccessKey`/`SecretKey` fields); MinIO container cleaned up in `CleanupSharedContainers`.
- `helpers/matrix.go`: `SetupS3CompatibleShare` provisions a badger+fs+s3 share pointed at the emulator (custom endpoint → auto path-style — the exact preset path); `s3HelperCreds` threads creds (replaces a hardcoded `test/test`).
- `s3_compatible_presets_test.go`: `TestS3CompatiblePresets` runs an NFS write/read/overwrite round-trip against **MinIO and LocalStack**.
- `run-e2e.sh`: `--minio` / `--keep-minio` flags mirroring `--s3` / `--keep-localstack`.

## Why

Issue #1222: "Done when docs list verified providers and at least the emulator-backed ones run in e2e." The s3 store is generic; the gap was documentation + emulator coverage proving distinct S3-compatible backends work.

## Test evidence

- `go build ./...`, `go vet ./...`, `go vet -tags=e2e ./test/e2e/...` — clean; `gofmt -l` — clean; `bash -n run-e2e.sh` — clean.
- `go test ./pkg/block/remote/s3/ ./pkg/controlplane/runtime/shares/` — pass.
- **Real MinIO verification**: ran the existing env-driven S3 conformance suite against a live MinIO container via the preset config (custom endpoint + path-style) — `TestStore_BlockStoreConformance` **passed**, exercising the full block-store contract over an S3-compatible backend.
- `code-simplifier` (no changes needed) and `code-reviewer` run on the diff; reviewer findings addressed (dropped the inaccurate `encrypt_data` block-store knob, fixed GCS `region: auto` → `us-east-1`, added `--keep-minio` for symmetry).

Verified-by-emulator in e2e: **MinIO, LocalStack** (Ceph RGW documented). All others documented-only (need real accounts).

Closes #1222