### PR TITLE
fix(smb): NTLM NETLOGON pass-through — advertise AD identity + idmap_rid (#1357)

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -672,6 +672,18 @@ func createSMBAdapter(cfg *models.AdapterConfig, kerberosConfig *config.Kerberos
 	// false, so SetNetlogonAuthenticator no-ops in that case.
 	if kerberosConfig != nil {
 		nlAuth := buildNetlogonAuthenticator(*kerberosConfig)
+		// When NTLM pass-through is active, the SMB handler must advertise, in its
+		// NTLM CHALLENGE TargetInfo, both the AD NetBIOS/DNS domain AND the AD
+		// machine-account computer name. Domain clients echo these into their
+		// NTLMv2 response; if the advertised domain is WORKGROUP or the computer
+		// name is the bare OS hostname (not the machine account), Samba's NETLOGON
+		// SamLogon rejects the otherwise-valid response (#1357). SetKerberosProvider
+		// covers the SPNEGO-enabled path, but NTLM-only members (kerberos.enabled
+		// =false) never reach it, so set it explicitly here. The computer name is
+		// the same workstation name the NETLOGON secure channel authenticates as.
+		if nlAuth != nil {
+			smbAdapter.SetADDomain(kerberosConfig.NetBIOSDomain, kerberosConfig.DNSDomain, netbiosWorkstation(*kerberosConfig))
+		}
 		smbAdapter.SetNetlogonAuthenticator(nlAuth)
 	}
 

--- a/internal/adapter/smb/auth/ntlm.go
+++ b/internal/adapter/smb/auth/ntlm.go
@@ -348,7 +348,16 @@ func GetMessageType(buf []byte) MessageType {
 // the server's configured AD domain to make the challenge domain-aware; pass
 // empty strings for a standalone server (TargetInfo then advertises
 // WORKGROUP / "local" exactly as before AD-4).
-func BuildChallenge(netbiosDomain, dnsDomain string) (message []byte, serverChallenge [8]byte) {
+//
+// netbiosComputer is the server's own NetBIOS computer name, advertised as the
+// MsvAvNbComputerName AV_PAIR. When NETLOGON pass-through is active this MUST be
+// the AD machine-account name (e.g. "DITTOFS"), not the OS hostname: a domain
+// client echoes MsvAvNbComputerName into its NTLMv2 response, and Samba's
+// NETLOGON SamLogon rejects the response when that name does not match the
+// machine account the secure channel authenticated as — even though the proof
+// is otherwise valid (#1357). Pass "" to fall back to the OS hostname (the
+// standalone / non-domain behavior).
+func BuildChallenge(netbiosDomain, dnsDomain, netbiosComputer string) (message []byte, serverChallenge [8]byte) {
 	// Generate random 8-byte challenge.
 	// This challenge is used to validate the client's NTLMv2 response
 	// and derive the session key for message signing.
@@ -364,7 +373,10 @@ func BuildChallenge(netbiosDomain, dnsDomain string) (message []byte, serverChal
 	// to validate against the wrong store and fail / mis-derive the NTLMv2 hash.
 	// Windows clients also require a non-empty TargetName when FlagRequestTarget
 	// is set.
-	hostname, _ := os.Hostname()
+	hostname := netbiosComputer
+	if hostname == "" {
+		hostname, _ = os.Hostname()
+	}
 	if hostname == "" {
 		hostname = "DITTOFS"
 	}

--- a/internal/adapter/smb/auth/ntlm_test.go
+++ b/internal/adapter/smb/auth/ntlm_test.go
@@ -128,7 +128,7 @@ func TestGetMessageType(t *testing.T) {
 // =============================================================================
 
 func TestBuildChallenge(t *testing.T) {
-	msg, serverChallenge := BuildChallenge("", "")
+	msg, serverChallenge := BuildChallenge("", "", "")
 
 	t.Run("HasCorrectSignature", func(t *testing.T) {
 		if !bytes.Equal(msg[0:8], Signature) {
@@ -176,7 +176,7 @@ func TestBuildChallenge(t *testing.T) {
 	})
 
 	t.Run("GeneratesUniqueChallenge", func(t *testing.T) {
-		msg2, serverChallenge2 := BuildChallenge("", "")
+		msg2, serverChallenge2 := BuildChallenge("", "", "")
 		challenge1 := msg[24:32]
 		challenge2 := msg2[24:32]
 
@@ -840,7 +840,7 @@ func TestBuildChallenge_TargetTypeFlag(t *testing.T) {
 	}
 
 	t.Run("standalone", func(t *testing.T) {
-		msg, _ := BuildChallenge("", "")
+		msg, _ := BuildChallenge("", "", "")
 		f := flagsOf(msg)
 		if f&FlagTargetTypeServer == 0 {
 			t.Error("standalone challenge must set FlagTargetTypeServer")
@@ -851,7 +851,7 @@ func TestBuildChallenge_TargetTypeFlag(t *testing.T) {
 	})
 
 	t.Run("domain-joined", func(t *testing.T) {
-		msg, _ := BuildChallenge("CONTOSO", "contoso.com")
+		msg, _ := BuildChallenge("CONTOSO", "contoso.com", "")
 		f := flagsOf(msg)
 		if f&FlagTargetTypeDomain == 0 {
 			t.Error("domain-joined challenge must set FlagTargetTypeDomain")

--- a/internal/adapter/smb/auth/ntlmv2_crossvalidation_test.go
+++ b/internal/adapter/smb/auth/ntlmv2_crossvalidation_test.go
@@ -20,7 +20,7 @@ func TestNTLMv2CrossValidation(t *testing.T) {
 	clientDomain := "" // go-smb2 typically sends empty domain
 
 	// Step 1: Server builds challenge (as our code does)
-	challengeMsg, serverChallenge := BuildChallenge("", "")
+	challengeMsg, serverChallenge := BuildChallenge("", "", "")
 
 	// Step 2: Extract TargetName and TargetInfo from challenge (as go-smb2 does)
 	targetNameLen := binary.LittleEndian.Uint16(challengeMsg[12:14])

--- a/internal/adapter/smb/auth/spnego_roundtrip_test.go
+++ b/internal/adapter/smb/auth/spnego_roundtrip_test.go
@@ -41,7 +41,7 @@ func TestSPNEGORoundTrip(t *testing.T) {
 	// =====================================================
 	// Step 2: Server sends Challenge wrapped in NegTokenResp
 	// =====================================================
-	challengeMsg, serverChallenge := BuildChallenge("", "")
+	challengeMsg, serverChallenge := BuildChallenge("", "", "")
 	t.Logf("Step 2: Server challenge: %x", serverChallenge)
 
 	spnegoChallengeResp, err := BuildAcceptIncomplete(OIDNTLMSSP, challengeMsg)

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -236,6 +236,25 @@ type Handler struct {
 	// ("local") is advertised. Set by the adapter from the Kerberos provider.
 	DNSDomain string
 
+	// NetBIOSName is the server's own NetBIOS computer name advertised in the
+	// NTLM Type-2 TargetInfo (MsvAvNbComputerName). When NETLOGON pass-through is
+	// active this MUST be the AD machine-account name (e.g. "DITTOFS"), because a
+	// domain client echoes it into its NTLMv2 response and Samba's NETLOGON
+	// SamLogon rejects a response whose computer name does not match the machine
+	// account the secure channel authenticated as (#1357). When empty the OS
+	// hostname is used (standalone / non-domain behavior). Set by the adapter
+	// from the NETLOGON machine-account workstation name.
+	NetBIOSName string
+
+	// NetlogonIdmapRID enables the idmap_rid fallback for NETLOGON pass-through:
+	// when a DC-validated domain user's SID is not mapped by any configured
+	// identity provider, derive a stable POSIX UID/GID algorithmically from the
+	// SID's RID (Samba idmap_rid model) so the user still gets a usable session
+	// without RFC2307 attributes or a directory lookup (#1357). Last resort —
+	// configured LDAP/local mappings always take precedence. Enabled by the
+	// adapter whenever a NETLOGON authenticator is injected.
+	NetlogonIdmapRID bool
+
 	// NtlmEnabled controls whether NTLM authentication is allowed.
 	// When false, NTLM tokens in SESSION_SETUP are rejected with STATUS_LOGON_FAILURE.
 	// Default: true.

--- a/internal/adapter/smb/handlers/netlogon_idmap_rid_test.go
+++ b/internal/adapter/smb/handlers/netlogon_idmap_rid_test.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/auth/netlogon"
+)
+
+func TestRIDFromSID(t *testing.T) {
+	cases := []struct {
+		sid     string
+		wantRID uint32
+		wantOK  bool
+	}{
+		{"S-1-5-21-1937300967-2839264751-453550700-1105", 1105, true},
+		{"S-1-5-21-1937300967-2839264751-453550700-513", 513, true},
+		{"S-1-5-18", 18, true}, // well-known LocalSystem (last component is the RID/sub-authority)
+		{"", 0, false},
+		{"notasid", 0, false},
+		{"S-1-5-21-1-2-3-", 0, false},    // trailing dash, empty RID
+		{"S-1-5-21-1-2-3-abc", 0, false}, // non-numeric RID
+		{"S-1-5-21-1-2-3-99999999999999999999", 0, false}, // overflows uint32
+	}
+	for _, c := range cases {
+		gotRID, gotOK := ridFromSID(c.sid)
+		if gotOK != c.wantOK || (gotOK && gotRID != c.wantRID) {
+			t.Errorf("ridFromSID(%q) = (%d,%v), want (%d,%v)", c.sid, gotRID, gotOK, c.wantRID, c.wantOK)
+		}
+	}
+}
+
+func TestSynthesizeRIDIdentity(t *testing.T) {
+	res := &netlogon.LogonResult{
+		Username:   "alice",
+		DomainName: "DITTOFS",
+		UserSID:    "S-1-5-21-1-2-3-1105",
+		GroupSIDs: []string{
+			"S-1-5-21-1-2-3-513",  // Domain Users → 513
+			"S-1-5-21-1-2-3-1104", // a group → 1104
+			"malformed-group-sid", // skipped
+		},
+	}
+	got := synthesizeRIDIdentity(res)
+	if got == nil {
+		t.Fatal("expected a synthesized identity, got nil")
+	}
+	if !got.Found {
+		t.Error("expected Found=true")
+	}
+	if got.UID != 1105 || got.GID != 1105 {
+		t.Errorf("UID/GID = %d/%d, want 1105/1105", got.UID, got.GID)
+	}
+	if got.Username != "alice" || got.Domain != "DITTOFS" || got.SID != "S-1-5-21-1-2-3-1105" {
+		t.Errorf("identity fields not propagated: %+v", got)
+	}
+	// Only the two well-formed group SIDs contribute GIDs; the malformed one is skipped.
+	wantGIDs := map[uint32]bool{513: true, 1104: true}
+	if len(got.GIDs) != len(wantGIDs) {
+		t.Fatalf("GIDs = %v, want exactly %v", got.GIDs, wantGIDs)
+	}
+	for _, g := range got.GIDs {
+		if !wantGIDs[g] {
+			t.Errorf("unexpected GID %d in %v", g, got.GIDs)
+		}
+	}
+}
+
+func TestSynthesizeRIDIdentity_BadUserSID(t *testing.T) {
+	if got := synthesizeRIDIdentity(&netlogon.LogonResult{UserSID: "not-a-sid"}); got != nil {
+		t.Errorf("expected nil for unparseable user SID, got %+v", got)
+	}
+}

--- a/internal/adapter/smb/handlers/netlogon_idmap_rid_test.go
+++ b/internal/adapter/smb/handlers/netlogon_idmap_rid_test.go
@@ -17,8 +17,8 @@ func TestRIDFromSID(t *testing.T) {
 		{"S-1-5-18", 18, true}, // well-known LocalSystem (last component is the RID/sub-authority)
 		{"", 0, false},
 		{"notasid", 0, false},
-		{"S-1-5-21-1-2-3-", 0, false},    // trailing dash, empty RID
-		{"S-1-5-21-1-2-3-abc", 0, false}, // non-numeric RID
+		{"S-1-5-21-1-2-3-", 0, false},                     // trailing dash, empty RID
+		{"S-1-5-21-1-2-3-abc", 0, false},                  // non-numeric RID
 		{"S-1-5-21-1-2-3-99999999999999999999", 0, false}, // overflows uint32
 	}
 	for _, c := range cases {

--- a/internal/adapter/smb/handlers/session_setup.go
+++ b/internal/adapter/smb/handlers/session_setup.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -727,7 +728,7 @@ func (h *Handler) handleNTLMNegotiateBinding(ctx *SMBHandlerContext, req *Sessio
 	}
 
 	// Build TYPE_2 CHALLENGE
-	challengeMsg, serverChallenge := auth.BuildChallenge(h.NetBIOSDomain, h.DNSDomain)
+	challengeMsg, serverChallenge := auth.BuildChallenge(h.NetBIOSDomain, h.DNSDomain, h.NetBIOSName)
 
 	pending := &PendingAuth{
 		SessionID:        ctx.SessionID, // bound session's ID
@@ -963,7 +964,7 @@ func (h *Handler) handleNTLMNegotiate(ctx *SMBHandlerContext, usedSPNEGO bool, m
 
 	// Build NTLM Type 2 (CHALLENGE) response
 	// This also returns the server challenge for later validation
-	challengeMsg, serverChallenge := auth.BuildChallenge(h.NetBIOSDomain, h.DNSDomain)
+	challengeMsg, serverChallenge := auth.BuildChallenge(h.NetBIOSDomain, h.DNSDomain, h.NetBIOSName)
 
 	// Store pending auth to track handshake state
 	// Include the server challenge for NTLMv2 validation in completeNTLMAuth
@@ -1422,26 +1423,76 @@ func (h *Handler) tryNetlogonFallback(ctx *SMBHandlerContext, pending *PendingAu
 // caller fails closed. Mirrors resolveKerberosIdentity, but the credential is a
 // validated Windows SID rather than a Kerberos principal.
 func (h *Handler) resolveNetlogonIdentity(ctx *SMBHandlerContext, res *netlogon.LogonResult) *pkgidentity.ResolvedIdentity {
-	resolver := h.IdentityResolver()
-	if resolver == nil {
+	if resolver := h.IdentityResolver(); resolver != nil {
+		// Provider is deliberately left unset (unlike the Kerberos path which
+		// stamps Provider: "kerberos"): SID-based resolution matches on ExternalID
+		// via the provider's CanResolve. Stamping a Provider here would narrow
+		// matching — do not "fix" this by adding one.
+		cred := &pkgidentity.Credential{
+			ExternalID: res.UserSID,
+			Attributes: map[string]string{
+				"username": res.Username,
+				"domain":   res.DomainName,
+			},
+		}
+		if resolved, err := resolver.Resolve(ctx.Context, cred); err == nil && resolved != nil && resolved.Found {
+			return resolved
+		}
+	}
+
+	// idmap_rid fallback: when no provider maps the DC-returned SID (e.g. no LDAP
+	// directory is configured), derive a stable POSIX identity algorithmically
+	// from the SID RIDs — Samba's idmap_rid model, where UID == the account's RID.
+	// This lets a NETLOGON-authenticated domain user obtain a usable session
+	// without RFC2307 attributes or a directory lookup. It is a last resort:
+	// any configured LDAP/local mapping above always takes precedence (#1357).
+	if h.NetlogonIdmapRID {
+		return synthesizeRIDIdentity(res)
+	}
+	return nil
+}
+
+// synthesizeRIDIdentity builds a ResolvedIdentity from an AD logon's SIDs using
+// the idmap_rid convention (UID/GID == RID). Returns nil if the user SID has no
+// parseable RID. Group SIDs with unparseable RIDs are skipped.
+func synthesizeRIDIdentity(res *netlogon.LogonResult) *pkgidentity.ResolvedIdentity {
+	uid, ok := ridFromSID(res.UserSID)
+	if !ok {
 		return nil
 	}
-	// Provider is deliberately left unset (unlike the Kerberos path which stamps
-	// Provider: "kerberos"): SID-based resolution matches on ExternalID via the
-	// provider's CanResolve. Stamping a Provider here would narrow matching — do
-	// not "fix" this by adding one.
-	cred := &pkgidentity.Credential{
-		ExternalID: res.UserSID,
-		Attributes: map[string]string{
-			"username": res.Username,
-			"domain":   res.DomainName,
-		},
+	gids := make([]uint32, 0, len(res.GroupSIDs))
+	for _, g := range res.GroupSIDs {
+		if gid, ok := ridFromSID(g); ok {
+			gids = append(gids, gid)
+		}
 	}
-	resolved, err := resolver.Resolve(ctx.Context, cred)
-	if err != nil || resolved == nil || !resolved.Found {
-		return nil
+	return &pkgidentity.ResolvedIdentity{
+		Username:  res.Username,
+		UID:       uid,
+		GID:       uid,
+		GIDs:      gids,
+		Domain:    res.DomainName,
+		Found:     true,
+		SID:       res.UserSID,
+		GroupSIDs: res.GroupSIDs,
 	}
-	return resolved
+}
+
+// ridFromSID returns the RID (last sub-authority) of a Windows SID string such
+// as "S-1-5-21-...-1105" → 1105. Returns false for a non-SID or unparseable RID.
+func ridFromSID(sid string) (uint32, bool) {
+	if !strings.HasPrefix(sid, "S-1-") {
+		return 0, false
+	}
+	i := strings.LastIndexByte(sid, '-')
+	if i < 0 || i+1 >= len(sid) {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(sid[i+1:], 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return uint32(v), true
 }
 
 // destroySessionOnReauthFailure tears down an existing session after its

--- a/internal/adapter/smb/handlers/session_setup.go
+++ b/internal/adapter/smb/handlers/session_setup.go
@@ -1417,11 +1417,20 @@ func (h *Handler) tryNetlogonFallback(ctx *SMBHandlerContext, pending *PendingAu
 	return h.buildAuthenticatedResponse(pending, signingKey[:], authMsg.NegotiateFlags, sess.ShouldEncrypt()), true
 }
 
-// resolveNetlogonIdentity maps a NETLOGON LogonResult to a DittoFS identity via
-// the centralized resolver, keyed on the DC-returned user SID. Returns nil when
-// no resolver is installed or the SID does not resolve (Found=false), so the
-// caller fails closed. Mirrors resolveKerberosIdentity, but the credential is a
-// validated Windows SID rather than a Kerberos principal.
+// resolveNetlogonIdentity maps a NETLOGON LogonResult to a DittoFS identity,
+// keyed on the DC-returned user SID. Resolution order:
+//  1. The centralized resolver (e.g. LDAP/local link), if installed. A configured
+//     directory mapping always wins.
+//  2. idmap_rid fallback (when NetlogonIdmapRID is set): a stable POSIX identity
+//     derived algorithmically from the SID RIDs (Samba idmap_rid, UID == RID), so
+//     a NETLOGON-authenticated domain user gets a usable session without RFC2307
+//     attributes or a directory lookup.
+//
+// Fails closed (returns nil) when neither path produces a mapping. A resolver
+// *error* is treated as an infrastructure failure: we fail closed and do NOT use
+// the RID fallback, since silently switching to algorithmic UIDs could mask a
+// directory outage and hand a user a different UID/GID than the configured
+// mapping (#1357). Mirrors resolveKerberosIdentity, keyed on a validated SID.
 func (h *Handler) resolveNetlogonIdentity(ctx *SMBHandlerContext, res *netlogon.LogonResult) *pkgidentity.ResolvedIdentity {
 	if resolver := h.IdentityResolver(); resolver != nil {
 		// Provider is deliberately left unset (unlike the Kerberos path which
@@ -1435,17 +1444,23 @@ func (h *Handler) resolveNetlogonIdentity(ctx *SMBHandlerContext, res *netlogon.
 				"domain":   res.DomainName,
 			},
 		}
-		if resolved, err := resolver.Resolve(ctx.Context, cred); err == nil && resolved != nil && resolved.Found {
+		resolved, err := resolver.Resolve(ctx.Context, cred)
+		if err != nil {
+			// Infrastructure failure (per pkg/identity.IdentityProvider: errors
+			// signal infra problems, not "unmapped"). Fail closed — do not fall
+			// back to RID idmap, which would mask the outage and could change the
+			// UID/GID relative to the configured directory mapping.
+			logger.Debug("NETLOGON identity resolve failed (infra error); failing closed",
+				"username", res.Username, "userSID", res.UserSID, "error", err)
+			return nil
+		}
+		if resolved != nil && resolved.Found {
 			return resolved
 		}
+		// Resolver present but no mapping for this SID (Found=false): fall through
+		// to the idmap_rid fallback below.
 	}
 
-	// idmap_rid fallback: when no provider maps the DC-returned SID (e.g. no LDAP
-	// directory is configured), derive a stable POSIX identity algorithmically
-	// from the SID RIDs — Samba's idmap_rid model, where UID == the account's RID.
-	// This lets a NETLOGON-authenticated domain user obtain a usable session
-	// without RFC2307 attributes or a directory lookup. It is a last resort:
-	// any configured LDAP/local mapping above always takes precedence (#1357).
 	if h.NetlogonIdmapRID {
 		return synthesizeRIDIdentity(res)
 	}

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -572,7 +572,47 @@ func (s *Adapter) SetNetlogonAuthenticator(nlAuth netlogon.NetlogonAuthenticator
 		return
 	}
 	s.handler.NetlogonAuth = nlAuth
+	// Enable the idmap_rid fallback so a DC-validated domain user with no LDAP/
+	// local mapping still resolves to a stable POSIX identity (UID == SID RID)
+	// and gets a usable session (#1357). A configured directory mapping always
+	// takes precedence; this only fires when nothing else resolves the SID.
+	s.handler.NetlogonIdmapRID = true
 	logger.Debug("SMB adapter: NETLOGON authenticator configured")
+}
+
+// SetADDomain makes the SMB handler domain-aware without requiring a Kerberos
+// SPNEGO provider. SetKerberosProvider already populates these names, but it is
+// only invoked when Kerberos (SPNEGO) is enabled. An NTLM-only domain member
+// (kerberos.enabled=false, machine_account.enabled=true) must still advertise
+// the AD NetBIOS/DNS domain — with FlagTargetTypeDomain — in the NTLM CHALLENGE
+// TargetInfo. Otherwise the server presents as standalone WORKGROUP, the domain
+// client embeds MsvAvNbDomainName="WORKGROUP" in its NTLMv2 response, and that
+// disagreement with the LogonDomainName DittoFS forwards makes the DC reject an
+// otherwise-valid response with STATUS_LOGON_FAILURE (#1357).
+//
+// netbiosComputer is the server's own NetBIOS computer name (MsvAvNbComputerName).
+// Under NETLOGON pass-through it MUST be the AD machine-account name (e.g.
+// "DITTOFS"), not the OS hostname: the DC rejects a forwarded NTLMv2 response
+// whose computer name does not match the machine account the secure channel
+// authenticated as (#1357).
+//
+// Idempotent and safe to call alongside SetKerberosProvider; the names come from
+// the same Kerberos config. Empty arguments are ignored so a later/earlier
+// SetKerberosProvider is never clobbered. Must be called before Serve().
+func (s *Adapter) SetADDomain(netbiosDomain, dnsDomain, netbiosComputer string) {
+	if netbiosDomain != "" {
+		s.handler.NetBIOSDomain = netbiosDomain
+	}
+	if dnsDomain != "" {
+		s.handler.DNSDomain = dnsDomain
+	}
+	if netbiosComputer != "" {
+		s.handler.NetBIOSName = netbiosComputer
+	}
+	if netbiosDomain != "" || dnsDomain != "" || netbiosComputer != "" {
+		logger.Info("SMB adapter: domain-aware NTLM CHALLENGE enabled",
+			"netbios_domain", netbiosDomain, "dns_domain", dnsDomain, "netbios_computer", netbiosComputer)
+	}
 }
 
 // wireIdentityResolver creates and wires a centralized identity resolver for

--- a/test/integration/ad-dc/ad_dc_keytab_test.go
+++ b/test/integration/ad-dc/ad_dc_keytab_test.go
@@ -138,7 +138,7 @@ func TestADCombinedKeytabAndDomainAwareSMB(t *testing.T) {
 		NetBIOSDomain: provider.NetBIOSDomain(),
 		DNSDomain:     provider.DNSDomain(),
 	}
-	challenge, _ := smbauth.BuildChallenge(h.NetBIOSDomain, h.DNSDomain)
+	challenge, _ := smbauth.BuildChallenge(h.NetBIOSDomain, h.DNSDomain, "")
 	pairs := parseChallengeTargetInfo(t, challenge)
 
 	if got := pairs[smbauth.AvNbDomainName]; got != adDomain {

--- a/test/integration/ad-dc/netlogon_smbclient_test.go
+++ b/test/integration/ad-dc/netlogon_smbclient_test.go
@@ -36,12 +36,6 @@ import (
 // configured, then confirms that smbclient can authenticate as the AD
 // domain user alice via NTLM (NETLOGON passthrough).
 func TestSMBNTLMNetlogonPassthrough(t *testing.T) {
-	// The NETLOGON schannel itself works (see TestNetlogonPassthroughAlice), but
-	// the full smbclient->DittoFS->SAMLogon path returns LOGON_FAILURE: a DittoFS
-	// SMB NTLM challenge-threading / SPNEGO NegTokenResp parse bug, not a schannel
-	// issue. Tracked in #1357. Un-skip once that is fixed.
-	t.Skip("SMB NTLM passthrough e2e blocked on DittoFS challenge threading — see #1357")
-
 	if testing.Short() {
 		t.Skip("skipping NETLOGON smbclient e2e test in short mode")
 	}


### PR DESCRIPTION
## What

Makes a **domain user authenticating over NTLM** (no Kerberos) work end-to-end via NETLOGON pass-through. Previously `smbclient -U 'DITTOFS\alice'` failed with `STATUS_LOGON_FAILURE` even though the secure channel was healthy (#1345).

## Root cause (two layers, isolated by replaying captured smbclient bytes against a live Samba AD-DC + bisecting the NTLMv2 AV_PAIRs)

1. **Wrong NTLM CHALLENGE TargetInfo.** DittoFS advertised `MsvAvNbDomainName=WORKGROUP` and `MsvAvNbComputerName=<OS hostname>`. A domain client echoes both into its NTLMv2 response; Samba's NETLOGON SamLogon rejects the (otherwise cryptographically valid) response when they don't match the AD NetBIOS domain and the machine-account name the channel authenticated as. The proof itself was always valid — verified by offline NTProofStr recompute.
2. **No POSIX mapping for the DC-returned SID.** Once SamLogon succeeded, the session failed closed because alice's SID had no UID/GID.

## Fix

- **Advertise the real AD identity** in the NTLM CHALLENGE: configured NetBIOS domain + machine-account NetBIOS computer name. `BuildChallenge` now takes the computer name; the adapter wires both from the machine-account config — covering the NTLM-only (`kerberos.enabled=false`) path that never reached `SetKerberosProvider`.
- **idmap_rid fallback** (`resolveNetlogonIdentity`): when no configured provider maps the SID, derive a stable UID/GID from the SID's RID (Samba `idmap_rid` model). Last resort — LDAP/local mappings always take precedence.

## Test

`TestSMBNTLMNetlogonPassthrough` (was skipped) now **passes** against the Samba AD-DC fixture: `smbclient` over NTLM authenticates and lists the share. Affected unit suites (`smb/auth`, `smb/handlers`, `pkg/adapter/smb`, `cmd/dfs/commands`) green; `BuildChallenge` callers updated for the new arg.

Closes #1357.