### PR TITLE
feat(nfs): NFSv4.2 sparse-file cluster — SEEK, READ_PLUS, ALLOCATE, DEALLOCATE

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -615,9 +615,29 @@ streams, so a value set over one protocol is readable over the other. See
 
 | Status | Reason |
 |--------|--------|
-| Not supported | No ALLOCATE procedure in NFSv3 |
+| NFSv3: not supported | No ALLOCATE procedure in NFSv3 |
+| NFSv4.2: supported (best-effort) | In-protocol ALLOCATE / DEALLOCATE (RFC 7862) |
 
-NFSv3 has no procedure for pre-allocating disk space. Space is allocated on actual write.
+NFSv3 has no procedure for pre-allocating disk space, so `fallocate` over a
+v3 mount is unsupported (space is allocated on actual write).
+
+Over a **NFSv4.2** mount DittoFS implements the RFC 7862 sparse-file cluster —
+`ALLOCATE`, `DEALLOCATE`, `SEEK` (SEEK_HOLE/SEEK_DATA) and `READ_PLUS`:
+
+- `fallocate <file>` (ALLOCATE) extends the file's logical size; the
+  newly-covered range reads back as zeros.
+- `fallocate -p <file>` (DEALLOCATE / punch hole) marks a byte range as a hole
+  that reads as zeros and reclaims the backing block storage.
+- `lseek(SEEK_HOLE)` / `lseek(SEEK_DATA)` report the next hole/data boundary.
+
+**ALLOCATE is best-effort, not a physical reservation.** DittoFS is
+thin-provisioned over a content-addressed/deduplicating block store (and
+optionally S3), so a true up-front physical reservation is neither possible nor
+meaningful. RFC 7862 permits a server to satisfy ALLOCATE without a physical
+reservation: DittoFS guarantees the requested range is readable (as a sparse
+hole until written) and grows the file size, but does **not** pre-reserve space
+— an out-of-space condition surfaces on the eventual write, exactly as for an
+ordinary sparse file.
 
 ### SMB Client Limitations
 
@@ -682,7 +702,7 @@ This pass rate applies to **all metadata backends** (Memory, BadgerDB, PostgreSQ
 | `fcntl/lock*` | NFSv3 NLM locking is opt-in (`--udp-enabled` + portmapper on 111); use `vers=4` |
 | `lockf/*` | NFSv3 NLM locking is opt-in (`--udp-enabled` + portmapper on 111); use `vers=4` |
 | `xattr/*`, `*xattr/*` | Not in NFSv3 |
-| `fallocate/*` | No ALLOCATE in NFSv3 |
+| `fallocate/*` | No ALLOCATE in NFSv3 (supported over NFSv4.2 — see above) |
 | `chflags/*` | BSD-specific |
 
 **Note**: Only `utimensat/09.t:test5` actually fails in current pjdfstest runs. Other patterns either don't have tests in the suite or the tests are skipped.

--- a/docs/NFS.md
+++ b/docs/NFS.md
@@ -576,9 +576,15 @@ return `NFS4ERR_NOTSUPP`. A client negotiates v4.2 with `mount -o vers=4.2`.
 
 The features below are **planned** and tracked, ordered by fit with DittoFS's
 content-addressed/dedup block store. `CLONE` is the strongest fit — a reflink is a pure
-metadata ref over the same dedup blocks, reusing the SMB server-side-copy engine. `SEEK`,
-`READ_PLUS`, and `DEALLOCATE` form a sparse-files cluster that shares hole-tracking
-plumbing. They are **not yet implemented**.
+metadata ref over the same dedup blocks, reusing the SMB server-side-copy engine; it is
+**not yet implemented**. `SEEK`, `READ_PLUS`, `DEALLOCATE`, and `ALLOCATE` form a
+sparse-files cluster that shares one hole-tracking foundation and **are implemented**.
+
+The hole map is derived directly from the file's content-addressed block list (a byte
+range covered by no block ref is a hole that reads as zeros) — there is no separate hole
+bitmap. The same `pkg/block` hole-map query backs all four ops so SEEK / READ_PLUS /
+DEALLOCATE report consistent boundaries. A file whose blocks cover its whole extent
+yields a single data segment (the dense-file fallback).
 
 | Operation | Status | Notes |
 |-----------|--------|-------|
@@ -586,11 +592,11 @@ plumbing. They are **not yet implemented**.
 | SETXATTR | Implemented | RFC 8276; `CREATE` / `REPLACE` / `EITHER` options honored |
 | LISTXATTRS | Implemented | RFC 8276; cookie-based pagination |
 | REMOVEXATTR | Implemented | RFC 8276 |
+| SEEK | Implemented | SEEK_HOLE / SEEK_DATA over the block-list hole map ([#1303](https://github.com/marmos91/dittofs/issues/1303)) |
+| READ_PLUS | Implemented | hole-aware read; emits data + `NFS4_CONTENT_HOLE` runs ([#1304](https://github.com/marmos91/dittofs/issues/1304)) |
+| DEALLOCATE | Implemented | punch-hole; zeros the range + reclaims block storage ([#1305](https://github.com/marmos91/dittofs/issues/1305)) |
+| ALLOCATE | Implemented | best-effort/logical preallocation (no physical reservation under dedup/S3) ([#1306](https://github.com/marmos91/dittofs/issues/1306)) |
 | CLONE | Planned | reflink over dedup block refs ([#1302](https://github.com/marmos91/dittofs/issues/1302)) |
-| SEEK | Planned | SEEK_HOLE / SEEK_DATA ([#1303](https://github.com/marmos91/dittofs/issues/1303)) |
-| READ_PLUS | Planned | hole-aware read ([#1304](https://github.com/marmos91/dittofs/issues/1304)) |
-| DEALLOCATE | Planned | punch-hole + storage reclaim ([#1305](https://github.com/marmos91/dittofs/issues/1305)) |
-| ALLOCATE | Planned | `fallocate` preallocation ([#1306](https://github.com/marmos91/dittofs/issues/1306)) |
 | COPY / OFFLOAD_* / COPY_NOTIFY | Not planned | async server-side copy; `CLONE` covers the intra-server case more cheaply |
 | IO_ADVISE | Not planned | cache/prefetch hints; low value for a userspace vFS |
 | Labeled NFS (`FATTR4_SEC_LABEL`) | Not planned | MAC/SELinux labels; niche |

--- a/internal/adapter/nfs/v4/handlers/allocate.go
+++ b/internal/adapter/nfs/v4/handlers/allocate.go
@@ -1,0 +1,85 @@
+package handlers
+
+import (
+	"io"
+
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// ALLOCATE4args / ALLOCATE4res (RFC 7862 Section 15.1):
+//
+//	struct ALLOCATE4args {
+//	    stateid4 aa_stateid;
+//	    offset4  aa_offset;
+//	    length4  aa_length;
+//	};
+//	union ALLOCATE4res switch (nfsstat4 ar_status) {
+//	 case NFS4_OK: void;
+//	 default:      void;
+//	};
+//
+// ALLOCATE guarantees [aa_offset, aa_offset+aa_length) is readable, growing the
+// file's logical size when the range extends past EOF.
+//
+// Reservation semantics (DECISION): DittoFS is thin-provisioned over a
+// content-addressed/dedup block store and optional S3 backend, so true physical
+// space reservation is not possible (and would be meaningless under dedup). RFC
+// 7862 permits a server to satisfy ALLOCATE without a physical reservation, so
+// DittoFS provides BEST-EFFORT / LOGICAL preallocation: the requested range is
+// guaranteed readable (newly covered bytes are a sparse hole that reads as
+// zeros) and the file size grows to cover it. No NFS4ERR_NOSPC pre-reservation
+// is attempted; out-of-space surfaces on the eventual WRITE, exactly as for an
+// ordinary sparse file. This is documented in docs/FAQ.md and docs/NFS.md.
+func (h *Handler) handleAllocate(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+	if status := types.RequireCurrentFH(ctx); status != types.NFS4_OK {
+		return allocErr(status)
+	}
+	if pseudofs.IsPseudoFSHandle(ctx.CurrentFH) {
+		return allocErr(types.NFS4ERR_ROFS)
+	}
+
+	stateid, offset, length, st := decodeAllocArgs(reader)
+	if st != types.NFS4_OK {
+		return allocErr(st)
+	}
+
+	// ALLOCATE may change the file size: validate the stateid as a write op and
+	// require WRITE share-access on a real open stateid (special stateids pass).
+	if openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, state.StateidOpWrite); stateErr != nil {
+		s := mapStateError(stateErr)
+		logger.Debug("NFSv4.2 ALLOCATE stateid validation failed", "error", stateErr, "nfs_status", s, "client", ctx.ClientAddr)
+		return allocErr(s)
+	} else if openState != nil && openState.ShareAccess&types.OPEN4_SHARE_ACCESS_WRITE == 0 {
+		return allocErr(types.NFS4ERR_OPENMODE)
+	}
+
+	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
+	if err != nil {
+		return allocErr(nfs4StatusForAuthError(err))
+	}
+	metaSvc, err := getMetadataServiceForCtx(h)
+	if err != nil {
+		return allocErr(types.NFS4ERR_SERVERFAULT)
+	}
+
+	if _, err := metaSvc.Allocate(authCtx, metadata.FileHandle(ctx.CurrentFH), offset, length); err != nil {
+		return allocErr(common.MapToNFS4(err))
+	}
+
+	logger.Debug("NFSv4.2 ALLOCATE", "offset", offset, "length", length, "client", ctx.ClientAddr)
+	return &types.CompoundResult{Status: types.NFS4_OK, OpCode: types.OP_ALLOCATE, Data: encodeStatusOnly(types.NFS4_OK)}
+}
+
+// allocErr builds an ALLOCATE error result (status only).
+func allocErr(status uint32) *types.CompoundResult {
+	return &types.CompoundResult{
+		Status: status,
+		OpCode: types.OP_ALLOCATE,
+		Data:   encodeStatusOnly(status),
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/compound.go
+++ b/internal/adapter/nfs/v4/handlers/compound.go
@@ -149,12 +149,12 @@ func (h *Handler) dispatchOne(compCtx *types.CompoundContext, v41ctx *types.V41R
 		result = h.v42DispatchTable[opCode](compCtx, reader)
 
 	case h.v42DispatchTable[opCode] != nil:
-		// v4.2-only op (RFC 8276 xattr) seen under v4.0/v4.1: it is a valid op
-		// number but unsupported → NOTSUPP, which stops the COMPOUND (RFC 7530
-		// §16.2). Unlike rejectV40OnlyOp, the op's args are NOT consumed from
-		// the reader; that is safe because NOTSUPP stops the COMPOUND, so no
-		// later op parses the reader.
-		logger.Debug("NFSv4 COMPOUND xattr op requires minorversion 2",
+		// v4.2-only op (RFC 8276 xattr or RFC 7862 sparse-file op) seen under
+		// v4.0/v4.1: it is a valid op number but unsupported → NOTSUPP, which
+		// stops the COMPOUND (RFC 7530 §16.2). Unlike rejectV40OnlyOp, the op's
+		// args are NOT consumed from the reader; that is safe because NOTSUPP
+		// stops the COMPOUND, so no later op parses the reader.
+		logger.Debug("NFSv4 COMPOUND v4.2-only op requires minorversion 2",
 			"opcode", opCode, "op_name", types.OpName(opCode), "client", compCtx.ClientAddr)
 		result = notSuppHandler(opCode)
 

--- a/internal/adapter/nfs/v4/handlers/compound_test.go
+++ b/internal/adapter/nfs/v4/handlers/compound_test.go
@@ -717,15 +717,21 @@ func TestCompound_V41_DispatchTableComplete(t *testing.T) {
 		}
 	}
 
-	// The RFC 8276 xattr ops (v4.2) live in their OWN table, separate from v4.1.
+	// The v4.2 ops live in their OWN table, separate from v4.1: the four RFC 8276
+	// xattr ops plus the RFC 7862 sparse-file cluster (SEEK / READ_PLUS /
+	// DEALLOCATE / ALLOCATE).
 	expectedV42Ops := []uint32{
 		types.OP_GETXATTR,
 		types.OP_SETXATTR,
 		types.OP_LISTXATTRS,
 		types.OP_REMOVEXATTR,
+		types.OP_ALLOCATE,
+		types.OP_DEALLOCATE,
+		types.OP_SEEK,
+		types.OP_READ_PLUS,
 	}
-	if len(h.v42DispatchTable) != 4 {
-		t.Errorf("v42DispatchTable has %d entries, want 4", len(h.v42DispatchTable))
+	if len(h.v42DispatchTable) != len(expectedV42Ops) {
+		t.Errorf("v42DispatchTable has %d entries, want %d", len(h.v42DispatchTable), len(expectedV42Ops))
 	}
 	for _, opCode := range expectedV42Ops {
 		if _, ok := h.v42DispatchTable[opCode]; !ok {

--- a/internal/adapter/nfs/v4/handlers/deallocate.go
+++ b/internal/adapter/nfs/v4/handlers/deallocate.go
@@ -1,0 +1,133 @@
+package handlers
+
+import (
+	"io"
+
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// DEALLOCATE4args / DEALLOCATE4res (RFC 7862 Section 15.4):
+//
+//	struct DEALLOCATE4args {
+//	    stateid4 da_stateid;
+//	    offset4  da_offset;
+//	    length4  da_length;
+//	};
+//	union DEALLOCATE4res switch (nfsstat4 dr_status) {
+//	 case NFS4_OK: void;
+//	 default:      void;
+//	};
+//
+// DEALLOCATE punches a hole in [da_offset, da_offset+da_length): the range is
+// marked as unbacked (reads back as zeros) and its block-store space is
+// reclaimed. The file's logical size is unchanged. The metadata mutation
+// (block-ref pruning) is done by metadata.Service.PunchHole; the physical
+// reclaim (dedup refcount decrement, remote sweep, GC eligibility) is driven
+// here via BlockStore.Truncate with the pre-op block snapshot — the same
+// reclaim seam SETATTR-truncate uses (CLAUDE.md invariants #1/#5).
+func (h *Handler) handleDeallocate(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+	if status := types.RequireCurrentFH(ctx); status != types.NFS4_OK {
+		return deallocErr(status)
+	}
+	if pseudofs.IsPseudoFSHandle(ctx.CurrentFH) {
+		return deallocErr(types.NFS4ERR_ROFS)
+	}
+
+	stateid, offset, length, st := decodeAllocArgs(reader)
+	if st != types.NFS4_OK {
+		return deallocErr(st)
+	}
+
+	// DEALLOCATE modifies file content: validate the stateid as a write op and
+	// require WRITE share-access on a real open stateid (special stateids pass).
+	if openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, state.StateidOpWrite); stateErr != nil {
+		s := mapStateError(stateErr)
+		logger.Debug("NFSv4.2 DEALLOCATE stateid validation failed", "error", stateErr, "nfs_status", s, "client", ctx.ClientAddr)
+		return deallocErr(s)
+	} else if openState != nil && openState.ShareAccess&types.OPEN4_SHARE_ACCESS_WRITE == 0 {
+		return deallocErr(types.NFS4ERR_OPENMODE)
+	}
+
+	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
+	if err != nil {
+		return deallocErr(nfs4StatusForAuthError(err))
+	}
+	metaSvc, err := getMetadataServiceForCtx(h)
+	if err != nil {
+		return deallocErr(types.NFS4ERR_SERVERFAULT)
+	}
+
+	handle := metadata.FileHandle(ctx.CurrentFH)
+	res, err := metaSvc.PunchHole(authCtx, handle, offset, length)
+	if err != nil {
+		return deallocErr(common.MapToNFS4(err))
+	}
+
+	// Reclaim block-store space and guarantee the punched range reads as zeros.
+	// Best-effort: the metadata mutation is authoritative and already committed,
+	// so a reclaim failure is logged but not surfaced (mirrors SETATTR-truncate).
+	// engine.PunchHole reaps CAS blocks fully inside the range and zero-writes
+	// the range so both the pre-rollup and CAS read paths return zeros.
+	if res.PayloadID != "" && length > 0 && offset < res.File.Size && h.Registry != nil {
+		if blockStore, bsErr := common.ResolveForWrite(ctx.Context, h.Registry, handle); bsErr != nil {
+			logger.Warn("NFSv4.2 DEALLOCATE reclaim: cannot resolve block store",
+				"handle", string(handle), "error", bsErr)
+		} else if _, pErr := blockStore.PunchHole(ctx.Context, string(res.PayloadID), res.PreOpBlocks, offset, punchLen(offset, length, res.File.Size)); pErr != nil {
+			logger.Warn("NFSv4.2 DEALLOCATE reclaim: block store punch failed",
+				"handle", string(handle), "error", pErr)
+		}
+	}
+
+	logger.Debug("NFSv4.2 DEALLOCATE", "offset", offset, "length", length,
+		"size", res.File.Size, "client", ctx.ClientAddr)
+
+	return &types.CompoundResult{Status: types.NFS4_OK, OpCode: types.OP_DEALLOCATE, Data: encodeStatusOnly(types.NFS4_OK)}
+}
+
+// decodeAllocArgs decodes the shared (stateid, offset, length) argument tuple of
+// ALLOCATE and DEALLOCATE. Returns NFS4ERR_BADXDR on a malformed stream and
+// NFS4ERR_INVAL when offset+length overflows uint64.
+func decodeAllocArgs(reader io.Reader) (*types.Stateid4, uint64, uint64, uint32) {
+	stateid, err := types.DecodeStateid4(reader)
+	if err != nil {
+		return nil, 0, 0, types.NFS4ERR_BADXDR
+	}
+	offset, err := xdr.DecodeUint64(reader)
+	if err != nil {
+		return nil, 0, 0, types.NFS4ERR_BADXDR
+	}
+	length, err := xdr.DecodeUint64(reader)
+	if err != nil {
+		return nil, 0, 0, types.NFS4ERR_BADXDR
+	}
+	if length > 0 && offset > ^uint64(0)-length {
+		return nil, 0, 0, types.NFS4ERR_INVAL
+	}
+	return stateid, offset, length, types.NFS4_OK
+}
+
+// punchLen clamps a DEALLOCATE length so the zero-overwrite never extends past
+// EOF (zeroing beyond the logical size would needlessly grow the payload). The
+// caller guarantees offset < size.
+func punchLen(offset, length, size uint64) uint64 {
+	end := offset + length
+	if end > size {
+		end = size
+	}
+	return end - offset
+}
+
+// deallocErr builds a DEALLOCATE error result (status only).
+func deallocErr(status uint32) *types.CompoundResult {
+	return &types.CompoundResult{
+		Status: status,
+		OpCode: types.OP_DEALLOCATE,
+		Data:   encodeStatusOnly(status),
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/deallocate.go
+++ b/internal/adapter/nfs/v4/handlers/deallocate.go
@@ -69,18 +69,29 @@ func (h *Handler) handleDeallocate(ctx *types.CompoundContext, reader io.Reader)
 		return deallocErr(common.MapToNFS4(err))
 	}
 
-	// Reclaim block-store space and guarantee the punched range reads as zeros.
-	// Best-effort: the metadata mutation is authoritative and already committed,
-	// so a reclaim failure is logged but not surfaced (mirrors SETATTR-truncate).
-	// engine.PunchHole reaps CAS blocks fully inside the range and zero-writes
-	// the range so both the pre-rollup and CAS read paths return zeros.
-	if res.PayloadID != "" && length > 0 && offset < res.File.Size && h.Registry != nil {
-		if blockStore, bsErr := common.ResolveForWrite(ctx.Context, h.Registry, handle); bsErr != nil {
-			logger.Warn("NFSv4.2 DEALLOCATE reclaim: cannot resolve block store",
+	// The engine punch is correctness-critical, not just reclaim: the read path
+	// resolves bytes with an empty BlockRef list (the dual-read shim), so pruning
+	// the metadata block list alone does NOT guarantee zero reads — only the
+	// block-store zero-overwrite does. Therefore a failure here must FAIL the op
+	// (rather than log-and-succeed), or stale bytes could remain readable in the
+	// punched range while the client is told NFS4_OK. engine.PunchHole reaps CAS
+	// blocks fully inside the range and zero-writes [offset, offset+length) so
+	// both the pre-rollup and CAS read paths return zeros.
+	if res.PayloadID != "" && length > 0 && offset < res.File.Size {
+		if h.Registry == nil {
+			logger.Error("NFSv4.2 DEALLOCATE: no registry configured", "handle", string(handle))
+			return deallocErr(types.NFS4ERR_SERVERFAULT)
+		}
+		blockStore, bsErr := common.ResolveForWrite(ctx.Context, h.Registry, handle)
+		if bsErr != nil {
+			logger.Error("NFSv4.2 DEALLOCATE: cannot resolve block store",
 				"handle", string(handle), "error", bsErr)
-		} else if _, pErr := blockStore.PunchHole(ctx.Context, string(res.PayloadID), res.PreOpBlocks, offset, punchLen(offset, length, res.File.Size)); pErr != nil {
-			logger.Warn("NFSv4.2 DEALLOCATE reclaim: block store punch failed",
+			return deallocErr(types.NFS4ERR_SERVERFAULT)
+		}
+		if _, pErr := blockStore.PunchHole(ctx.Context, string(res.PayloadID), res.PreOpBlocks, offset, punchLen(offset, length, res.File.Size)); pErr != nil {
+			logger.Error("NFSv4.2 DEALLOCATE: block store punch failed",
 				"handle", string(handle), "error", pErr)
+			return deallocErr(types.NFS4ERR_IO)
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/read_plus.go
+++ b/internal/adapter/nfs/v4/handlers/read_plus.go
@@ -109,6 +109,12 @@ func (h *Handler) handleReadPlus(ctx *types.CompoundContext, reader io.Reader) *
 	contents, err := h.buildReadPlusContents(ctx, file, offset, readEnd)
 	if err != nil {
 		logger.Debug("NFSv4.2 READ_PLUS content build failed", "error", err, "client", ctx.ClientAddr)
+		// A missing registry is a server misconfiguration, not an I/O fault —
+		// mirror READ's nil-Registry guard (NFS4ERR_SERVERFAULT). All other
+		// failures are block-store read errors → NFS4ERR_IO.
+		if errors.Is(err, errNoRegistry) {
+			return readPlusErr(types.NFS4ERR_SERVERFAULT)
+		}
 		return readPlusErr(types.NFS4ERR_IO)
 	}
 	eof := readEnd >= file.Size

--- a/internal/adapter/nfs/v4/handlers/read_plus.go
+++ b/internal/adapter/nfs/v4/handlers/read_plus.go
@@ -1,0 +1,219 @@
+package handlers
+
+import (
+	"bytes"
+	"errors"
+	"io"
+
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// errNoRegistry signals READ_PLUS could not resolve a block store because no
+// runtime registry is configured (mirrors the READ handler's nil-Registry guard).
+var errNoRegistry = errors.New("no registry configured")
+
+// READ_PLUS4args / READ_PLUS4res (RFC 7862 Section 15.10):
+//
+//	struct READ_PLUS4args {
+//	    stateid4 rpa_stateid;
+//	    offset4  rpa_offset;
+//	    count4   rpa_count;
+//	};
+//	union read_plus_content switch (data_content4 rpc_content) {
+//	 case NFS4_CONTENT_DATA: data4   rpc_data;   // offset4 + opaque<>
+//	 case NFS4_CONTENT_HOLE: data_info4 rpc_hole; // offset4 + length4
+//	};
+//	struct read_plus_res4 {
+//	    bool                rpr_eof;
+//	    read_plus_content   rpr_contents<>;
+//	};
+//	union READ_PLUS4res switch (nfsstat4 rp_status) {
+//	 case NFS4_OK: read_plus_res4 rp_resok4;
+//	 default:      void;
+//	};
+//
+// READ_PLUS is READ that may report holes compactly: the reply is an array of
+// data segments and NFS4_CONTENT_HOLE runs. Bytes-on-wire for a sparse file are
+// less than its logical size because hole runs carry only (offset, length).
+//
+// DittoFS derives the segmentation from the file's content-addressed block list
+// (block.Segments). The always-correct fallback — a dense file or a file with
+// no tracked holes — yields a single data segment, matching plain READ.
+func (h *Handler) handleReadPlus(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+	if status := types.RequireCurrentFH(ctx); status != types.NFS4_OK {
+		return readPlusErr(status)
+	}
+	if pseudofs.IsPseudoFSHandle(ctx.CurrentFH) {
+		return readPlusErr(types.NFS4ERR_ISDIR)
+	}
+
+	stateid, err := types.DecodeStateid4(reader)
+	if err != nil {
+		return readPlusErr(types.NFS4ERR_BADXDR)
+	}
+	offset, err := xdr.DecodeUint64(reader)
+	if err != nil {
+		return readPlusErr(types.NFS4ERR_BADXDR)
+	}
+	count, err := xdr.DecodeUint32(reader)
+	if err != nil {
+		return readPlusErr(types.NFS4ERR_BADXDR)
+	}
+
+	// READ_PLUS shares READ's stateid semantics: special stateids are allowed,
+	// a real open stateid must carry READ access.
+	if openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, state.StateidOpRead); stateErr != nil {
+		st := mapStateError(stateErr)
+		logger.Debug("NFSv4.2 READ_PLUS stateid validation failed", "error", stateErr, "nfs_status", st, "client", ctx.ClientAddr)
+		return readPlusErr(st)
+	} else if openState != nil && openState.ShareAccess&types.OPEN4_SHARE_ACCESS_READ == 0 {
+		return readPlusErr(types.NFS4ERR_OPENMODE)
+	}
+
+	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
+	if err != nil {
+		return readPlusErr(nfs4StatusForAuthError(err))
+	}
+	metaSvc, err := getMetadataServiceForCtx(h)
+	if err != nil {
+		return readPlusErr(types.NFS4ERR_SERVERFAULT)
+	}
+
+	file, err := metaSvc.GetFile(authCtx.Context, metadata.FileHandle(ctx.CurrentFH))
+	if err != nil {
+		return readPlusErr(common.MapToNFS4(err))
+	}
+	if file.Type != metadata.FileTypeRegular {
+		return readPlusErr(types.NFS4ERR_ISDIR)
+	}
+
+	// Empty file or read entirely past EOF: an empty content array with EOF set.
+	if file.Size == 0 || offset >= file.Size {
+		return encodeReadPlusResok(true, nil)
+	}
+
+	// Clamp the read window to EOF.
+	readEnd := offset + uint64(count)
+	if readEnd > file.Size || readEnd < offset /* overflow */ {
+		readEnd = file.Size
+	}
+
+	contents, err := h.buildReadPlusContents(ctx, file, offset, readEnd)
+	if err != nil {
+		logger.Debug("NFSv4.2 READ_PLUS content build failed", "error", err, "client", ctx.ClientAddr)
+		return readPlusErr(types.NFS4ERR_IO)
+	}
+	eof := readEnd >= file.Size
+
+	logger.Debug("NFSv4.2 READ_PLUS", "offset", offset, "count", count,
+		"end", readEnd, "segments", len(contents), "eof", eof, "client", ctx.ClientAddr)
+
+	return encodeReadPlusResok(eof, contents)
+}
+
+// readPlusContent is one encoded read_plus_content union member: either a data
+// segment (Hole=false, Data carries the bytes) or a hole run (Hole=true).
+type readPlusContent struct {
+	Hole   bool
+	Offset uint64
+	Length uint64 // hole length (Hole=true only)
+	Data   []byte // data bytes (Hole=false only)
+}
+
+// buildReadPlusContents segments [offset, readEnd) of the file into data and
+// hole runs using the shared hole map, reading the data runs from the block
+// store. Each segment is clipped to the requested window. Returned data byte
+// slices are copies (the pooled read buffers are released here), so the caller
+// may retain them past encoding.
+func (h *Handler) buildReadPlusContents(ctx *types.CompoundContext, file *metadata.File, offset, readEnd uint64) ([]readPlusContent, error) {
+	// No backing payload: the whole window is a single hole (reads as zeros).
+	if file.PayloadID == "" {
+		return []readPlusContent{{Hole: true, Offset: offset, Length: readEnd - offset}}, nil
+	}
+
+	segs := block.Segments(file.Blocks, file.Size)
+	var contents []readPlusContent
+	var blockStore *engine.Store
+
+	for _, seg := range segs {
+		// Intersect the segment with the requested window.
+		segStart := seg.Start
+		if segStart < offset {
+			segStart = offset
+		}
+		segEnd := seg.End
+		if segEnd > readEnd {
+			segEnd = readEnd
+		}
+		if segStart >= segEnd {
+			continue
+		}
+
+		if seg.Kind == block.SegmentHole {
+			contents = append(contents, readPlusContent{Hole: true, Offset: segStart, Length: segEnd - segStart})
+			continue
+		}
+
+		// Data segment: read the bytes from the block store (lazily resolved on
+		// the first data run so an all-hole window touches no block store).
+		if blockStore == nil {
+			if h.Registry == nil {
+				return nil, errNoRegistry
+			}
+			bs, err := common.ResolveForRead(ctx.Context, h.Registry, metadata.FileHandle(ctx.CurrentFH))
+			if err != nil {
+				return nil, err
+			}
+			blockStore = bs
+		}
+		res, err := common.ReadFromBlockStore(ctx.Context, blockStore, file.PayloadID, segStart, uint32(segEnd-segStart))
+		if err != nil {
+			return nil, err
+		}
+		// Copy out of the pooled buffer so it can be released immediately; the
+		// content array outlives this loop and is encoded later.
+		data := append([]byte(nil), res.Data...)
+		res.Release()
+		contents = append(contents, readPlusContent{Hole: false, Offset: segStart, Data: data})
+	}
+	return contents, nil
+}
+
+// encodeReadPlusResok encodes a successful READ_PLUS reply: status, eof, and the
+// content array (each member tagged NFS4_CONTENT_DATA or NFS4_CONTENT_HOLE).
+func encodeReadPlusResok(eof bool, contents []readPlusContent) *types.CompoundResult {
+	var buf bytes.Buffer
+	_ = xdr.WriteUint32(&buf, types.NFS4_OK)
+	_ = xdr.WriteBool(&buf, eof)
+	_ = xdr.WriteUint32(&buf, uint32(len(contents)))
+	for i := range contents {
+		c := &contents[i]
+		if c.Hole {
+			_ = xdr.WriteUint32(&buf, types.NFS4_CONTENT_HOLE)
+			_ = xdr.WriteUint64(&buf, c.Offset)
+			_ = xdr.WriteUint64(&buf, c.Length)
+			continue
+		}
+		_ = xdr.WriteUint32(&buf, types.NFS4_CONTENT_DATA)
+		_ = xdr.WriteUint64(&buf, c.Offset)
+		_ = xdr.WriteXDROpaque(&buf, c.Data)
+	}
+	return &types.CompoundResult{Status: types.NFS4_OK, OpCode: types.OP_READ_PLUS, Data: buf.Bytes()}
+}
+
+// readPlusErr builds a READ_PLUS error result (status only).
+func readPlusErr(status uint32) *types.CompoundResult {
+	return &types.CompoundResult{
+		Status: status,
+		OpCode: types.OP_READ_PLUS,
+		Data:   encodeStatusOnly(status),
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/register_v42.go
+++ b/internal/adapter/nfs/v4/handlers/register_v42.go
@@ -3,11 +3,22 @@ package handlers
 
 import "github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 
-// registerV42Ops registers the four RFC 8276 extended-attribute operations
-// (op numbers 72-75) into v42DispatchTable, kept separate from v4.0/v4.1 so the
-// minor-version boundary is explicit. dispatchOne gates these to minorversion 2:
-// a v4.0/v4.1 COMPOUND carrying one of these opcodes gets NFS4ERR_NOTSUPP.
+// registerV42Ops registers the NFSv4.2 operations into v42DispatchTable, kept
+// separate from v4.0/v4.1 so the minor-version boundary is explicit:
+//   - the four RFC 8276 extended-attribute operations (op numbers 72-75), and
+//   - the RFC 7862 sparse-file cluster SEEK / READ_PLUS / DEALLOCATE / ALLOCATE,
+//     which share one hole-tracking foundation (pkg/block hole map).
+//
+// dispatchOne gates these to minorversion 2: a v4.0/v4.1 COMPOUND carrying one
+// of these opcodes gets NFS4ERR_NOTSUPP.
 func (h *Handler) registerV42Ops() {
+	// RFC 7862 sparse-file operations.
+	h.v42DispatchTable[types.OP_ALLOCATE] = h.handleAllocate
+	h.v42DispatchTable[types.OP_DEALLOCATE] = h.handleDeallocate
+	h.v42DispatchTable[types.OP_SEEK] = h.handleSeek
+	h.v42DispatchTable[types.OP_READ_PLUS] = h.handleReadPlus
+
+	// RFC 8276 extended-attribute operations.
 	h.v42DispatchTable[types.OP_GETXATTR] = h.handleGetXattr
 	h.v42DispatchTable[types.OP_SETXATTR] = h.handleSetXattr
 	h.v42DispatchTable[types.OP_LISTXATTRS] = h.handleListXattrs

--- a/internal/adapter/nfs/v4/handlers/seek.go
+++ b/internal/adapter/nfs/v4/handlers/seek.go
@@ -1,0 +1,132 @@
+package handlers
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// SEEK4args / SEEK4res (RFC 7862 Section 15.11):
+//
+//	struct SEEK4args {
+//	    stateid4        sa_stateid;
+//	    offset4         sa_offset;
+//	    data_content4   sa_what;     // NFS4_CONTENT_DATA | NFS4_CONTENT_HOLE
+//	};
+//	struct seek_res4 {
+//	    bool            sr_eof;
+//	    offset4         sr_offset;
+//	};
+//	union SEEK4res switch (nfsstat4 sa_status) {
+//	 case NFS4_OK: seek_res4 resok4;
+//	 default:      void;
+//	};
+//
+// SEEK reports the next data (SEEK_DATA) or hole (SEEK_HOLE) boundary at or
+// after sa_offset. The hole map is derived from the file's content-addressed
+// block list (a byte range with no covering block ref is a hole). Per
+// RFC 7862, sa_offset >= file size returns NFS4ERR_NXIO, and SEEK_DATA past the
+// last data extent also returns NFS4ERR_NXIO (no more data). SEEK_HOLE always
+// finds a (virtual) hole at EOF.
+func (h *Handler) handleSeek(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+	if status := types.RequireCurrentFH(ctx); status != types.NFS4_OK {
+		return seekErr(status)
+	}
+	if pseudofs.IsPseudoFSHandle(ctx.CurrentFH) {
+		return seekErr(types.NFS4ERR_ISDIR)
+	}
+
+	stateid, err := types.DecodeStateid4(reader)
+	if err != nil {
+		return seekErr(types.NFS4ERR_BADXDR)
+	}
+	offset, err := xdr.DecodeUint64(reader)
+	if err != nil {
+		return seekErr(types.NFS4ERR_BADXDR)
+	}
+	what, err := xdr.DecodeUint32(reader)
+	if err != nil {
+		return seekErr(types.NFS4ERR_BADXDR)
+	}
+	if what != types.NFS4_CONTENT_DATA && what != types.NFS4_CONTENT_HOLE {
+		return seekErr(types.NFS4ERR_INVAL)
+	}
+
+	// SEEK is a read-family operation: validate the stateid for read access
+	// (special stateids permitted), mirroring READ.
+	if openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, state.StateidOpRead); stateErr != nil {
+		st := mapStateError(stateErr)
+		logger.Debug("NFSv4.2 SEEK stateid validation failed", "error", stateErr, "nfs_status", st, "client", ctx.ClientAddr)
+		return seekErr(st)
+	} else if openState != nil && openState.ShareAccess&types.OPEN4_SHARE_ACCESS_READ == 0 {
+		return seekErr(types.NFS4ERR_OPENMODE)
+	}
+
+	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
+	if err != nil {
+		return seekErr(nfs4StatusForAuthError(err))
+	}
+	metaSvc, err := getMetadataServiceForCtx(h)
+	if err != nil {
+		return seekErr(types.NFS4ERR_SERVERFAULT)
+	}
+
+	file, err := metaSvc.GetFile(authCtx.Context, metadata.FileHandle(ctx.CurrentFH))
+	if err != nil {
+		return seekErr(common.MapToNFS4(err))
+	}
+	if file.Type != metadata.FileTypeRegular {
+		return seekErr(types.NFS4ERR_ISDIR)
+	}
+
+	// sa_offset at or beyond EOF: no data and no in-file hole remain.
+	if offset >= file.Size {
+		return seekErr(types.NFS4ERR_NXIO)
+	}
+
+	var (
+		nextOffset uint64
+		found      bool
+	)
+	if what == types.NFS4_CONTENT_DATA {
+		nextOffset, found = block.NextDataOffset(file.Blocks, file.Size, offset)
+	} else {
+		nextOffset, found = block.NextHoleOffset(file.Blocks, file.Size, offset)
+	}
+	if !found {
+		// SEEK_DATA found no further data — the tail is a hole. NFS4ERR_NXIO is
+		// the RFC-mandated "no matching content" status.
+		return seekErr(types.NFS4ERR_NXIO)
+	}
+
+	// sr_eof is set when the reported offset coincides with EOF (the boundary
+	// is the end of the file). For SEEK_HOLE this is the common "hole at EOF"
+	// case; SEEK_DATA never returns EOF here because data offsets are < size.
+	eof := nextOffset >= file.Size
+
+	logger.Debug("NFSv4.2 SEEK", "what", what, "from", offset, "next", nextOffset,
+		"eof", eof, "size", file.Size, "client", ctx.ClientAddr)
+
+	var buf bytes.Buffer
+	_ = xdr.WriteUint32(&buf, types.NFS4_OK)
+	_ = xdr.WriteBool(&buf, eof)
+	_ = xdr.WriteUint64(&buf, nextOffset)
+	return &types.CompoundResult{Status: types.NFS4_OK, OpCode: types.OP_SEEK, Data: buf.Bytes()}
+}
+
+// seekErr builds a SEEK error result (status only).
+func seekErr(status uint32) *types.CompoundResult {
+	return &types.CompoundResult{
+		Status: status,
+		OpCode: types.OP_SEEK,
+		Data:   encodeStatusOnly(status),
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/sparse_test.go
+++ b/internal/adapter/nfs/v4/handlers/sparse_test.go
@@ -1,0 +1,217 @@
+package handlers
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+)
+
+// sparseTestHandler builds a Handler with no runtime registry. That is enough to
+// exercise the protocol-layer concerns of the RFC 7862 sparse ops (XDR decode,
+// pseudo-fs rejection, stateid validation, arg validation); the data path
+// (segment computation, zero reads, reclaim) is covered by the pkg/block hole
+// map unit tests and the test/e2e sparse suite.
+func sparseTestHandler(t *testing.T) *Handler {
+	t.Helper()
+	pfs := pseudofs.New()
+	pfs.Rebuild([]string{"/export"})
+	return NewHandler(nil, pfs)
+}
+
+// anonStateid returns the all-zeros (anonymous) special stateid, which
+// ValidateStateid accepts on both read and write families.
+func anonStateid() *types.Stateid4 { return &types.Stateid4{} }
+
+func writeStateid(buf *bytes.Buffer, sid *types.Stateid4) {
+	_ = xdr.WriteUint32(buf, sid.Seqid)
+	_, _ = buf.Write(sid.Other[:])
+}
+
+func encSeekArgs(sid *types.Stateid4, offset uint64, what uint32) io.Reader {
+	var buf bytes.Buffer
+	writeStateid(&buf, sid)
+	_ = xdr.WriteUint64(&buf, offset)
+	_ = xdr.WriteUint32(&buf, what)
+	return bytes.NewReader(buf.Bytes())
+}
+
+func encAllocArgs(sid *types.Stateid4, offset, length uint64) io.Reader {
+	var buf bytes.Buffer
+	writeStateid(&buf, sid)
+	_ = xdr.WriteUint64(&buf, offset)
+	_ = xdr.WriteUint64(&buf, length)
+	return bytes.NewReader(buf.Bytes())
+}
+
+// --- SEEK ---
+
+func TestHandleSeek_Validation(t *testing.T) {
+	h := sparseTestHandler(t)
+
+	t.Run("truncated args -> BADXDR", func(t *testing.T) {
+		res := h.handleSeek(xattrCtx(realHandle), bytes.NewReader([]byte{0x00, 0x01}))
+		if res.Status != types.NFS4ERR_BADXDR {
+			t.Fatalf("status = %d, want BADXDR", res.Status)
+		}
+		if res.OpCode != types.OP_SEEK {
+			t.Errorf("opcode = %d, want OP_SEEK", res.OpCode)
+		}
+	})
+
+	t.Run("invalid sa_what -> INVAL", func(t *testing.T) {
+		res := h.handleSeek(xattrCtx(realHandle), encSeekArgs(anonStateid(), 0, 99))
+		if res.Status != types.NFS4ERR_INVAL {
+			t.Fatalf("status = %d, want INVAL", res.Status)
+		}
+	})
+
+	t.Run("pseudo-fs handle -> ISDIR", func(t *testing.T) {
+		root := h.PseudoFS.GetRootHandle()
+		res := h.handleSeek(xattrCtx(root), encSeekArgs(anonStateid(), 0, types.NFS4_CONTENT_DATA))
+		if res.Status != types.NFS4ERR_ISDIR {
+			t.Fatalf("status = %d, want ISDIR", res.Status)
+		}
+	})
+
+	t.Run("no current filehandle -> NOFILEHANDLE", func(t *testing.T) {
+		ctx := xattrCtx(realHandle)
+		ctx.CurrentFH = nil
+		res := h.handleSeek(ctx, encSeekArgs(anonStateid(), 0, types.NFS4_CONTENT_DATA))
+		if res.Status != types.NFS4ERR_NOFILEHANDLE {
+			t.Fatalf("status = %d, want NOFILEHANDLE", res.Status)
+		}
+	})
+}
+
+// --- READ_PLUS ---
+
+func TestHandleReadPlus_Validation(t *testing.T) {
+	h := sparseTestHandler(t)
+
+	t.Run("truncated args -> BADXDR", func(t *testing.T) {
+		res := h.handleReadPlus(xattrCtx(realHandle), bytes.NewReader([]byte{0x00}))
+		if res.Status != types.NFS4ERR_BADXDR {
+			t.Fatalf("status = %d, want BADXDR", res.Status)
+		}
+		if res.OpCode != types.OP_READ_PLUS {
+			t.Errorf("opcode = %d, want OP_READ_PLUS", res.OpCode)
+		}
+	})
+
+	t.Run("pseudo-fs handle -> ISDIR", func(t *testing.T) {
+		root := h.PseudoFS.GetRootHandle()
+		var buf bytes.Buffer
+		writeStateid(&buf, anonStateid())
+		_ = xdr.WriteUint64(&buf, 0)
+		_ = xdr.WriteUint32(&buf, 4096)
+		res := h.handleReadPlus(xattrCtx(root), bytes.NewReader(buf.Bytes()))
+		if res.Status != types.NFS4ERR_ISDIR {
+			t.Fatalf("status = %d, want ISDIR", res.Status)
+		}
+	})
+}
+
+// encodeReadPlusResok / hole encoding shape check (no runtime needed).
+func TestEncodeReadPlusResok(t *testing.T) {
+	contents := []readPlusContent{
+		{Hole: false, Offset: 0, Data: []byte("abcd")},
+		{Hole: true, Offset: 4, Length: 12},
+	}
+	res := encodeReadPlusResok(false, contents)
+	if res.Status != types.NFS4_OK || res.OpCode != types.OP_READ_PLUS {
+		t.Fatalf("unexpected result envelope: status=%d op=%d", res.Status, res.OpCode)
+	}
+	r := bytes.NewReader(res.Data)
+	st, _ := xdr.DecodeUint32(r)
+	if st != types.NFS4_OK {
+		t.Fatalf("encoded status = %d", st)
+	}
+	eof, _ := xdr.DecodeBool(r)
+	if eof {
+		t.Errorf("eof = true, want false")
+	}
+	n, _ := xdr.DecodeUint32(r)
+	if n != 2 {
+		t.Fatalf("content count = %d, want 2", n)
+	}
+	// First member: data.
+	kind, _ := xdr.DecodeUint32(r)
+	if kind != types.NFS4_CONTENT_DATA {
+		t.Fatalf("member 0 kind = %d, want DATA", kind)
+	}
+	off, _ := xdr.DecodeUint64(r)
+	data, _ := xdr.DecodeOpaque(r)
+	if off != 0 || string(data) != "abcd" {
+		t.Errorf("member 0 = (off=%d data=%q)", off, data)
+	}
+	// Second member: hole.
+	kind, _ = xdr.DecodeUint32(r)
+	if kind != types.NFS4_CONTENT_HOLE {
+		t.Fatalf("member 1 kind = %d, want HOLE", kind)
+	}
+	hoff, _ := xdr.DecodeUint64(r)
+	hlen, _ := xdr.DecodeUint64(r)
+	if hoff != 4 || hlen != 12 {
+		t.Errorf("member 1 hole = (off=%d len=%d), want (4,12)", hoff, hlen)
+	}
+}
+
+// --- ALLOCATE / DEALLOCATE arg decoding ---
+
+func TestDecodeAllocArgs(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		sid, off, length, st := decodeAllocArgs(encAllocArgs(anonStateid(), 100, 200))
+		if st != types.NFS4_OK {
+			t.Fatalf("status = %d, want OK", st)
+		}
+		if sid == nil || off != 100 || length != 200 {
+			t.Errorf("decoded (off=%d len=%d)", off, length)
+		}
+	})
+
+	t.Run("overflow -> INVAL", func(t *testing.T) {
+		_, _, _, st := decodeAllocArgs(encAllocArgs(anonStateid(), ^uint64(0)-5, 100))
+		if st != types.NFS4ERR_INVAL {
+			t.Fatalf("status = %d, want INVAL", st)
+		}
+	})
+
+	t.Run("truncated -> BADXDR", func(t *testing.T) {
+		var buf bytes.Buffer
+		writeStateid(&buf, anonStateid())
+		_ = xdr.WriteUint64(&buf, 0) // offset only, missing length
+		_, _, _, st := decodeAllocArgs(bytes.NewReader(buf.Bytes()))
+		if st != types.NFS4ERR_BADXDR {
+			t.Fatalf("status = %d, want BADXDR", st)
+		}
+	})
+}
+
+func TestHandleAllocateDeallocate_PseudoFS(t *testing.T) {
+	h := sparseTestHandler(t)
+	root := h.PseudoFS.GetRootHandle()
+
+	if res := h.handleAllocate(xattrCtx(root), encAllocArgs(anonStateid(), 0, 4096)); res.Status != types.NFS4ERR_ROFS {
+		t.Errorf("ALLOCATE on pseudo-fs status = %d, want ROFS", res.Status)
+	}
+	if res := h.handleDeallocate(xattrCtx(root), encAllocArgs(anonStateid(), 0, 4096)); res.Status != types.NFS4ERR_ROFS {
+		t.Errorf("DEALLOCATE on pseudo-fs status = %d, want ROFS", res.Status)
+	}
+}
+
+func TestPunchLen(t *testing.T) {
+	cases := []struct{ off, length, size, want uint64 }{
+		{0, 100, 200, 100}, // within file
+		{50, 100, 120, 70}, // clamped to EOF
+		{0, 200, 200, 200}, // exactly to EOF
+	}
+	for _, c := range cases {
+		if got := punchLen(c.off, c.length, c.size); got != c.want {
+			t.Errorf("punchLen(%d,%d,%d) = %d, want %d", c.off, c.length, c.size, got, c.want)
+		}
+	}
+}

--- a/internal/adapter/nfs/v4/types/constants.go
+++ b/internal/adapter/nfs/v4/types/constants.go
@@ -153,10 +153,37 @@ const (
 // implements only the four RFC 8276 xattr operations from the v4.2 op range.
 
 const (
+	// Sparse-file / preallocation operations (RFC 7862). DittoFS implements the
+	// SEEK / READ_PLUS / DEALLOCATE / ALLOCATE cluster, which share one
+	// hole-tracking foundation derived from the file's content-addressed block
+	// list (a hole is any byte range covered by no block ref).
+	OP_ALLOCATE   = 59 // ALLOCATE (RFC 7862 Section 15.1)
+	OP_DEALLOCATE = 62 // DEALLOCATE (RFC 7862 Section 15.4)
+	OP_READ_PLUS  = 68 // READ_PLUS (RFC 7862 Section 15.10)
+	OP_SEEK       = 69 // SEEK (RFC 7862 Section 15.11)
+
 	OP_GETXATTR    = 72 // GETXATTR (RFC 8276 Section 8.6)
 	OP_SETXATTR    = 73 // SETXATTR (RFC 8276 Section 8.6)
 	OP_LISTXATTRS  = 74 // LISTXATTRS (RFC 8276 Section 8.6)
 	OP_REMOVEXATTR = 75 // REMOVEXATTR (RFC 8276 Section 8.6)
+)
+
+// ============================================================================
+// NFSv4.2 SEEK what (data_content4) and READ_PLUS content type (RFC 7862)
+// ============================================================================
+//
+// SEEK and READ_PLUS share the data_content4 enum to distinguish the data and
+// hole portions of a sparse file.
+
+const (
+	// NFS4_CONTENT_DATA marks a byte range backed by stored content; used as
+	// SEEK's sa_what (SEEK_DATA) and as a READ_PLUS data segment discriminator.
+	NFS4_CONTENT_DATA = 0
+
+	// NFS4_CONTENT_HOLE marks a byte range with no backing content (reads as
+	// zeros); used as SEEK's sa_what (SEEK_HOLE) and as a READ_PLUS hole segment
+	// discriminator.
+	NFS4_CONTENT_HOLE = 1
 )
 
 // ============================================================================
@@ -746,6 +773,15 @@ func OpName(op uint32) string {
 		return "DESTROY_CLIENTID"
 	case OP_RECLAIM_COMPLETE:
 		return "RECLAIM_COMPLETE"
+	// --- NFSv4.2 / RFC 7862 Sparse-file Operations ---
+	case OP_ALLOCATE:
+		return "ALLOCATE"
+	case OP_DEALLOCATE:
+		return "DEALLOCATE"
+	case OP_SEEK:
+		return "SEEK"
+	case OP_READ_PLUS:
+		return "READ_PLUS"
 	// --- NFSv4.2 / RFC 8276 Extended Attribute Operations ---
 	case OP_GETXATTR:
 		return "GETXATTR"
@@ -857,6 +893,12 @@ func init() {
 		"WANT_DELEGATION":      OP_WANT_DELEGATION,
 		"DESTROY_CLIENTID":     OP_DESTROY_CLIENTID,
 		"RECLAIM_COMPLETE":     OP_RECLAIM_COMPLETE,
+
+		// --- NFSv4.2 / RFC 7862 Sparse-file Operations ---
+		"ALLOCATE":   OP_ALLOCATE,
+		"DEALLOCATE": OP_DEALLOCATE,
+		"SEEK":       OP_SEEK,
+		"READ_PLUS":  OP_READ_PLUS,
 
 		// --- NFSv4.2 / RFC 8276 Extended Attribute Operations ---
 		"GETXATTR":    OP_GETXATTR,

--- a/pkg/block/engine/api_blockref_test.go
+++ b/pkg/block/engine/api_blockref_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"testing"
@@ -169,6 +170,92 @@ func TestTruncate_DropsBlocksPastNewSize(t *testing.T) {
 	}
 	if len(fc.reapIDs) != 2 {
 		t.Errorf("DecrementRefCountAndReap calls = %d, want 2 (one per dropped block)", len(fc.reapIDs))
+	}
+}
+
+// TestPunchHole_ReapsBlocksFullyInsideRange asserts the DEALLOCATE contract:
+// blocks lying entirely within [offset, offset+length) are dropped from the
+// returned BlockRef list and reaped via DecrementRefCountAndReap, while blocks
+// outside (or only partially overlapping) the range are kept.
+func TestPunchHole_ReapsBlocksFullyInsideRange(t *testing.T) {
+	fc := &fakeCoordinator{}
+	bs := newTestEngineWithCoordinator(t, fc)
+	ctx := context.Background()
+
+	blocks := []block.BlockRef{
+		{Hash: block.ContentHash{0x01}, Offset: 0, Size: 4096},     // kept (outside)
+		{Hash: block.ContentHash{0x02}, Offset: 4096, Size: 4096},  // dropped (inside [4096,12288))
+		{Hash: block.ContentHash{0x03}, Offset: 8192, Size: 4096},  // dropped (inside)
+		{Hash: block.ContentHash{0x04}, Offset: 12288, Size: 4096}, // kept (outside)
+	}
+
+	kept, err := bs.PunchHole(ctx, "punch-test", blocks, 4096, 8192) // range [4096,12288)
+	if err != nil {
+		t.Fatalf("PunchHole: %v", err)
+	}
+	if len(kept) != 2 {
+		t.Errorf("kept = %d blocks, want 2", len(kept))
+	}
+	if len(fc.reapIDs) != 2 {
+		t.Errorf("DecrementRefCountAndReap calls = %d, want 2 (one per fully-inside block)", len(fc.reapIDs))
+	}
+}
+
+// TestPunchHole_ReadsBackAsZeros asserts that after a punch the range reads back
+// as zeros via the engine read path (the zero-overwrite guarantees this even
+// pre-rollup), while surrounding bytes are untouched.
+func TestPunchHole_ReadsBackAsZeros(t *testing.T) {
+	bs := newTestEngine(t, 64*1024*1024, 0)
+	ctx := context.Background()
+	payloadID := "punch-zeros"
+
+	data := bytes.Repeat([]byte{0xAB}, 300)
+	if _, err := bs.WriteAt(ctx, payloadID, nil, data, 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+
+	if _, err := bs.PunchHole(ctx, payloadID, nil, 100, 100); err != nil {
+		t.Fatalf("PunchHole: %v", err)
+	}
+
+	buf := make([]byte, 300)
+	if _, err := bs.ReadAt(ctx, payloadID, nil, buf, 0); err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	for i := 0; i < 100; i++ {
+		if buf[i] != 0xAB {
+			t.Fatalf("byte %d = %#x, want 0xAB (head untouched)", i, buf[i])
+		}
+	}
+	for i := 100; i < 200; i++ {
+		if buf[i] != 0 {
+			t.Fatalf("byte %d = %#x, want 0 (punched)", i, buf[i])
+		}
+	}
+	for i := 200; i < 300; i++ {
+		if buf[i] != 0xAB {
+			t.Fatalf("byte %d = %#x, want 0xAB (tail untouched)", i, buf[i])
+		}
+	}
+}
+
+// TestPunchHole_ZeroLengthNoOp asserts that a zero-length punch returns the
+// input block list unchanged and performs no reap.
+func TestPunchHole_ZeroLengthNoOp(t *testing.T) {
+	fc := &fakeCoordinator{}
+	bs := newTestEngineWithCoordinator(t, fc)
+	ctx := context.Background()
+
+	blocks := []block.BlockRef{{Hash: block.ContentHash{0x01}, Offset: 0, Size: 4096}}
+	kept, err := bs.PunchHole(ctx, "punch-noop", blocks, 100, 0)
+	if err != nil {
+		t.Fatalf("PunchHole: %v", err)
+	}
+	if len(kept) != 1 {
+		t.Errorf("kept = %d, want 1 (unchanged)", len(kept))
+	}
+	if len(fc.reapIDs) != 0 {
+		t.Errorf("reap calls = %d, want 0", len(fc.reapIDs))
 	}
 }
 

--- a/pkg/block/engine/api_blockref_test.go
+++ b/pkg/block/engine/api_blockref_test.go
@@ -259,6 +259,17 @@ func TestPunchHole_ZeroLengthNoOp(t *testing.T) {
 	}
 }
 
+// TestPunchHole_OverflowRejected asserts that a range whose offset+length wraps
+// uint64 is rejected rather than silently operating on a wrapped (smaller) range.
+func TestPunchHole_OverflowRejected(t *testing.T) {
+	bs := newTestEngine(t, 64*1024*1024, 0)
+	ctx := context.Background()
+	blocks := []block.BlockRef{{Hash: block.ContentHash{0x01}, Offset: 0, Size: 4096}}
+	if _, err := bs.PunchHole(ctx, "punch-overflow", blocks, ^uint64(0)-5, 100); err == nil {
+		t.Fatal("PunchHole with overflowing range should return an error")
+	}
+}
+
 // TestTruncate_EmptyBlocksLegacyPath asserts that nil currentBlocks
 // runs the legacy local+remote truncate without coordinator side effects.
 func TestTruncate_EmptyBlocksLegacyPath(t *testing.T) {

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -210,6 +210,87 @@ func (bs *Store) Truncate(ctx context.Context, payloadID string, currentBlocks [
 	return kept, nil
 }
 
+// PunchHole implements the block-store side of NFSv4.2 DEALLOCATE (RFC 7862):
+// it makes [offset, offset+length) of payloadID read back as zeros and reclaims
+// the storage of any whole CAS block that falls entirely inside the range.
+//
+// currentBlocks is the file's pre-op block list. Blocks fully inside the
+// punched range are dropped and their dedup refcounts decremented (so the GC
+// sweep can reclaim the remote chunk, mirroring Truncate's by-ID reap); a block
+// only partially overlapping the range is KEPT, because its content hash still
+// addresses the surviving bytes — the partially-overlapped bytes are zeroed by
+// the overwrite below. The returned []BlockRef is the pruned list (whole-block
+// drops removed) for the caller to persist; an empty input returns nil
+// (dual-read shim semantics).
+//
+// To guarantee zeros on the read path regardless of rollup state, the range is
+// overwritten with zeros via the local append log (the same hot path WriteAt
+// uses). Zero chunks dedup to a single CAS object, so this does not defeat
+// space reclaim in aggregate. length == 0, or a payload with no blocks, is a
+// no-op success.
+func (bs *Store) PunchHole(ctx context.Context, payloadID string, currentBlocks []block.BlockRef, offset, length uint64) ([]block.BlockRef, error) {
+	if err := bs.enter(); err != nil {
+		return currentBlocks, err
+	}
+	defer bs.closeMu.RUnlock()
+	if length == 0 {
+		return currentBlocks, nil
+	}
+	end := offset + length
+
+	// Reap blocks lying ENTIRELY within [offset, end). Partially-overlapping
+	// blocks are kept (their hash still addresses surviving bytes); the zero
+	// overwrite below masks the punched portion on read.
+	kept := currentBlocks
+	if len(currentBlocks) > 0 {
+		kept = make([]block.BlockRef, 0, len(currentBlocks))
+		var dropped []block.BlockRef
+		for _, b := range currentBlocks {
+			bEnd := b.Offset + uint64(b.Size)
+			if b.Offset >= offset && bEnd <= end {
+				dropped = append(dropped, b)
+				continue
+			}
+			kept = append(kept, b)
+		}
+		if bs.coordinator != nil {
+			reaped := make(map[uint64]struct{}, len(dropped))
+			for _, b := range dropped {
+				if _, done := reaped[b.Offset]; done {
+					continue
+				}
+				reaped[b.Offset] = struct{}{}
+				if _, err := bs.coordinator.DecrementRefCountAndReap(ctx, payloadID, b.Offset); err != nil {
+					return currentBlocks, fmt.Errorf("reap block on punch %s/%d: %w", payloadID, b.Offset, err)
+				}
+			}
+		}
+	}
+
+	// Overwrite the range with zeros so both the pre-rollup append-log read path
+	// and the post-rollup CAS path return zeros. Chunked to bound the transient
+	// buffer for large deallocations.
+	const zeroChunk = 1 << 20 // 1 MiB
+	zeros := make([]byte, zeroChunk)
+	for pos := offset; pos < end; {
+		n := end - pos
+		if n > zeroChunk {
+			n = zeroChunk
+		}
+		if err := bs.local.AppendWrite(ctx, payloadID, zeros[:n], pos); err != nil {
+			return currentBlocks, fmt.Errorf("zero punched range %s [%d,%d): %w", payloadID, pos, pos+n, err)
+		}
+		pos += n
+	}
+
+	bs.loadCache().OnRead(payloadID, nil, 0)
+
+	if len(currentBlocks) == 0 {
+		return nil, nil
+	}
+	return kept, nil
+}
+
 // Delete removes all data for a payload from local store and remote store.
 // Invalidates all read buffer entries for the file and resets prefetcher state.
 //

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -236,6 +236,13 @@ func (bs *Store) PunchHole(ctx context.Context, payloadID string, currentBlocks 
 	if length == 0 {
 		return currentBlocks, nil
 	}
+	// Reject a range whose offset+length wraps uint64: a wrapped end would make
+	// the reap predicate and the zero-overwrite loop operate on an unintended
+	// (smaller) range, silently violating DEALLOCATE semantics. Adapters already
+	// validate this, but guard at the store boundary too.
+	if offset > ^uint64(0)-length {
+		return currentBlocks, fmt.Errorf("punch range overflow: offset=%d length=%d", offset, length)
+	}
 	end := offset + length
 
 	// Reap blocks lying ENTIRELY within [offset, end). Partially-overlapping

--- a/pkg/block/holemap.go
+++ b/pkg/block/holemap.go
@@ -182,7 +182,14 @@ func PunchHole(refs []BlockRef, offset, length uint64) []BlockRef {
 	if length == 0 || len(refs) == 0 {
 		return refs
 	}
+	// Defensive overflow guard: if offset+length would wrap uint64, clamp end to
+	// the max so the containment check never uses a wrapped (smaller) end and
+	// silently drops the wrong refs. Current callers validate ranges up front;
+	// this keeps the function safe if new call sites appear.
 	end := offset + length
+	if end < offset {
+		end = ^uint64(0)
+	}
 	out := make([]BlockRef, 0, len(refs))
 	for _, r := range refs {
 		rEnd := r.Offset + uint64(r.Size)

--- a/pkg/block/holemap.go
+++ b/pkg/block/holemap.go
@@ -1,0 +1,199 @@
+package block
+
+import "sort"
+
+// holemap.go is the shared hole-tracking foundation for the NFSv4.2 sparse-file
+// operations (SEEK, READ_PLUS, DEALLOCATE, ALLOCATE; RFC 7862).
+//
+// DittoFS does not store an explicit hole bitmap. The authoritative hole map is
+// the file's content-addressed block list (FileAttr.Blocks, sorted by Offset):
+// any byte in [0, fileSize) that no BlockRef covers is a hole and reads back as
+// zeros. The functions here derive data/hole boundaries from that list so SEEK,
+// READ_PLUS and DEALLOCATE all report consistent results from one source of
+// truth.
+//
+// Always-correct fallback: a file whose blocks contiguously cover [0, fileSize)
+// (or one with no block list at all but where the caller treats the extent as
+// data) yields a single data segment — the dense-file behavior. Conversely a
+// file with size > 0 and no covering blocks is entirely a hole. Both follow
+// from the same gap analysis below.
+
+// SegmentKind classifies a byte range of a file as data or hole.
+type SegmentKind uint8
+
+const (
+	// SegmentData is a range backed by stored content.
+	SegmentData SegmentKind = iota
+	// SegmentHole is a range with no backing content (reads as zeros).
+	SegmentHole
+)
+
+// Segment is a maximal contiguous run of one kind within [0, fileSize).
+// Start is inclusive, End is exclusive (End > Start for every emitted segment).
+type Segment struct {
+	Kind  SegmentKind
+	Start uint64
+	End   uint64
+}
+
+// Len returns the segment length in bytes.
+func (s Segment) Len() uint64 { return s.End - s.Start }
+
+// normalizedExtents returns the block-covered byte ranges within [0, fileSize),
+// sorted by start and merged across touching/overlapping refs. A ref straddling
+// fileSize is clamped to fileSize; refs entirely at/after fileSize are dropped.
+// The result is the data coverage from which holes are the complement.
+func normalizedExtents(refs []BlockRef, fileSize uint64) [][2]uint64 {
+	if fileSize == 0 || len(refs) == 0 {
+		return nil
+	}
+	ext := make([][2]uint64, 0, len(refs))
+	for _, r := range refs {
+		start := r.Offset
+		if start >= fileSize {
+			continue
+		}
+		end := r.Offset + uint64(r.Size)
+		if end > fileSize {
+			end = fileSize
+		}
+		if end <= start {
+			continue
+		}
+		ext = append(ext, [2]uint64{start, end})
+	}
+	if len(ext) == 0 {
+		return nil
+	}
+	// Caller invariant is sorted-by-offset, but DEALLOCATE splits and the
+	// dual-read shim can produce unsorted input, so sort defensively (cheap;
+	// block lists are small).
+	sort.Slice(ext, func(i, j int) bool { return ext[i][0] < ext[j][0] })
+
+	merged := ext[:1]
+	for _, e := range ext[1:] {
+		last := &merged[len(merged)-1]
+		if e[0] <= last[1] { // touching or overlapping -> extend
+			if e[1] > last[1] {
+				last[1] = e[1]
+			}
+			continue
+		}
+		merged = append(merged, e)
+	}
+	return merged
+}
+
+// Segments returns the ordered data/hole segmentation of [0, fileSize) derived
+// from refs. Segments tile the whole extent with no gaps or overlaps; an empty
+// file (fileSize == 0) returns nil. A file with no covering blocks returns a
+// single hole segment; a file fully covered by blocks returns a single data
+// segment. Used by READ_PLUS to emit data and NFS4_CONTENT_HOLE runs.
+func Segments(refs []BlockRef, fileSize uint64) []Segment {
+	if fileSize == 0 {
+		return nil
+	}
+	extents := normalizedExtents(refs, fileSize)
+	if len(extents) == 0 {
+		return []Segment{{Kind: SegmentHole, Start: 0, End: fileSize}}
+	}
+
+	segs := make([]Segment, 0, len(extents)*2+1)
+	var pos uint64
+	for _, e := range extents {
+		if e[0] > pos {
+			segs = append(segs, Segment{Kind: SegmentHole, Start: pos, End: e[0]})
+		}
+		segs = append(segs, Segment{Kind: SegmentData, Start: e[0], End: e[1]})
+		pos = e[1]
+	}
+	if pos < fileSize {
+		segs = append(segs, Segment{Kind: SegmentHole, Start: pos, End: fileSize})
+	}
+	return segs
+}
+
+// NextDataOffset implements SEEK_DATA: it returns the offset of the next byte
+// at or after `from` that is backed by data, and true. If there is no data at
+// or after `from` (the rest of the file is a hole, or `from` is at/after
+// fileSize), it returns (0, false) — the caller maps this to NFS4ERR_NXIO per
+// RFC 7862 Section 15.11.
+func NextDataOffset(refs []BlockRef, fileSize, from uint64) (uint64, bool) {
+	if from >= fileSize {
+		return 0, false
+	}
+	for _, e := range normalizedExtents(refs, fileSize) {
+		if e[1] <= from { // extent entirely before `from`
+			continue
+		}
+		if e[0] <= from { // `from` is inside a data extent
+			return from, true
+		}
+		return e[0], true // next data extent starts after `from`
+	}
+	return 0, false
+}
+
+// NextHoleOffset implements SEEK_HOLE: it returns the offset of the next byte
+// at or after `from` that is not backed by data. Because the implicit region at
+// and beyond EOF is always a (virtual) hole, a hole is always found for any
+// `from <= fileSize`: when `from` sits inside the file's final data extent the
+// returned offset is fileSize itself (RFC 7862 Section 15.11). For `from >=
+// fileSize` it returns (0, false) so the caller can map it to NFS4ERR_NXIO.
+func NextHoleOffset(refs []BlockRef, fileSize, from uint64) (uint64, bool) {
+	if from >= fileSize {
+		return 0, false
+	}
+	for _, e := range normalizedExtents(refs, fileSize) {
+		if e[1] <= from { // extent entirely before `from`
+			continue
+		}
+		if e[0] <= from {
+			// `from` is inside this data extent; the hole begins where it ends.
+			return e[1], true
+		}
+		// `from` is in a hole that precedes this extent.
+		return from, true
+	}
+	// No data extent covers or follows `from`: `from` is already in a hole.
+	return from, true
+}
+
+// PunchHole removes the byte range [offset, offset+length) from refs, returning
+// the resulting block list (sorted by Offset). It is the metadata side of
+// DEALLOCATE: a ref lying ENTIRELY within [offset, offset+length) is dropped (it
+// is wholly consumed by the hole); every other ref — including one that only
+// partially overlaps the range at its head or tail — is KEPT unchanged.
+// length == 0 is a no-op.
+//
+// Why partial-overlap refs are kept (not clipped): a BlockRef is content
+// addressed — its Hash covers exactly the original [Offset, Offset+Size) bytes,
+// so it cannot be split or shortened without invalidating the hash. Crucially,
+// the bytes of a partially-overlapping ref that fall OUTSIDE the punch range are
+// real data that must survive the DEALLOCATE; clipping the ref would turn them
+// into a (zero-reading) hole and lose data. Keeping the whole ref preserves
+// those bytes. The punched sub-range itself is made to read as zeros by the
+// block store (engine.PunchHole zero-overwrites exactly [offset, offset+length))
+// — so the hole semantics hold without touching the surrounding data.
+//
+// This "drop only fully-contained refs" predicate matches engine.PunchHole's
+// reap predicate, keeping the metadata and block-store views consistent.
+func PunchHole(refs []BlockRef, offset, length uint64) []BlockRef {
+	if length == 0 || len(refs) == 0 {
+		return refs
+	}
+	end := offset + length
+	out := make([]BlockRef, 0, len(refs))
+	for _, r := range refs {
+		rEnd := r.Offset + uint64(r.Size)
+		// Drop only refs entirely inside the punched range; keep everything else
+		// (non-overlapping and partially-overlapping) untouched so out-of-range
+		// data bytes survive.
+		if r.Offset >= offset && rEnd <= end {
+			continue
+		}
+		out = append(out, r)
+	}
+	sortBlockRefsByOffset(out)
+	return out
+}

--- a/pkg/block/holemap_test.go
+++ b/pkg/block/holemap_test.go
@@ -1,0 +1,214 @@
+package block
+
+import (
+	"reflect"
+	"testing"
+)
+
+// ref builds a BlockRef at offset with the given size (hash left zero — the
+// hole map only reads Offset/Size).
+func ref(offset uint64, size uint32) BlockRef {
+	return BlockRef{Offset: offset, Size: size}
+}
+
+func TestSegments(t *testing.T) {
+	tests := []struct {
+		name string
+		refs []BlockRef
+		size uint64
+		want []Segment
+	}{
+		{
+			name: "empty file",
+			size: 0,
+			want: nil,
+		},
+		{
+			name: "no blocks is all hole",
+			size: 100,
+			want: []Segment{{SegmentHole, 0, 100}},
+		},
+		{
+			name: "fully covered is single data segment",
+			refs: []BlockRef{ref(0, 100)},
+			size: 100,
+			want: []Segment{{SegmentData, 0, 100}},
+		},
+		{
+			name: "leading hole then data",
+			refs: []BlockRef{ref(50, 50)},
+			size: 100,
+			want: []Segment{{SegmentHole, 0, 50}, {SegmentData, 50, 100}},
+		},
+		{
+			name: "data then trailing hole",
+			refs: []BlockRef{ref(0, 40)},
+			size: 100,
+			want: []Segment{{SegmentData, 0, 40}, {SegmentHole, 40, 100}},
+		},
+		{
+			name: "hole in the middle",
+			refs: []BlockRef{ref(0, 20), ref(60, 40)},
+			size: 100,
+			want: []Segment{{SegmentData, 0, 20}, {SegmentHole, 20, 60}, {SegmentData, 60, 100}},
+		},
+		{
+			name: "adjacent blocks merge into one data segment",
+			refs: []BlockRef{ref(0, 20), ref(20, 20)},
+			size: 40,
+			want: []Segment{{SegmentData, 0, 40}},
+		},
+		{
+			name: "block straddling EOF is clamped",
+			refs: []BlockRef{ref(0, 200)},
+			size: 100,
+			want: []Segment{{SegmentData, 0, 100}},
+		},
+		{
+			name: "unsorted overlapping input is normalized",
+			refs: []BlockRef{ref(60, 40), ref(0, 70)},
+			size: 100,
+			want: []Segment{{SegmentData, 0, 100}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Segments(tt.refs, tt.size)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("Segments() = %+v, want %+v", got, tt.want)
+			}
+			// Invariant: segments tile [0,size) with no gaps/overlaps.
+			var pos uint64
+			for _, s := range got {
+				if s.Start != pos {
+					t.Fatalf("segment gap/overlap: start %d, want %d", s.Start, pos)
+				}
+				if s.End <= s.Start {
+					t.Fatalf("empty/negative segment %+v", s)
+				}
+				pos = s.End
+			}
+			if pos != tt.size {
+				t.Fatalf("segments cover [0,%d), want [0,%d)", pos, tt.size)
+			}
+		})
+	}
+}
+
+func TestNextDataOffset(t *testing.T) {
+	refs := []BlockRef{ref(0, 20), ref(60, 40)} // data [0,20) [60,100), hole [20,60)
+	size := uint64(100)
+	tests := []struct {
+		from      uint64
+		wantOff   uint64
+		wantFound bool
+	}{
+		{0, 0, true},    // inside first data extent
+		{10, 10, true},  // inside first data extent
+		{20, 60, true},  // start of hole -> next data at 60
+		{40, 60, true},  // inside hole -> next data at 60
+		{60, 60, true},  // inside second data extent
+		{99, 99, true},  // last data byte
+		{100, 0, false}, // at EOF -> NXIO
+		{200, 0, false}, // past EOF -> NXIO
+	}
+	for _, tt := range tests {
+		off, found := NextDataOffset(refs, size, tt.from)
+		if off != tt.wantOff || found != tt.wantFound {
+			t.Errorf("NextDataOffset(from=%d) = (%d,%v), want (%d,%v)", tt.from, off, found, tt.wantOff, tt.wantFound)
+		}
+	}
+
+	// A file whose tail is a hole: SEEK_DATA past the last data returns NXIO.
+	tailHole := []BlockRef{ref(0, 20)}
+	if off, found := NextDataOffset(tailHole, 100, 50); found {
+		t.Errorf("NextDataOffset in trailing hole = (%d,true), want not found", off)
+	}
+}
+
+func TestNextHoleOffset(t *testing.T) {
+	refs := []BlockRef{ref(0, 20), ref(60, 40)} // data [0,20) [60,100), hole [20,60)
+	size := uint64(100)
+	tests := []struct {
+		from      uint64
+		wantOff   uint64
+		wantFound bool
+	}{
+		{0, 20, true},   // inside data -> hole begins at 20
+		{19, 20, true},  // last data byte before hole
+		{20, 20, true},  // inside hole already
+		{40, 40, true},  // inside hole already
+		{60, 100, true}, // inside trailing data -> virtual hole at EOF
+		{99, 100, true}, // last data byte -> hole at EOF
+		{100, 0, false}, // at EOF -> NXIO
+	}
+	for _, tt := range tests {
+		off, found := NextHoleOffset(refs, size, tt.from)
+		if off != tt.wantOff || found != tt.wantFound {
+			t.Errorf("NextHoleOffset(from=%d) = (%d,%v), want (%d,%v)", tt.from, off, found, tt.wantOff, tt.wantFound)
+		}
+	}
+
+	// Fully dense file: the only hole is the virtual one at EOF.
+	dense := []BlockRef{ref(0, 100)}
+	if off, found := NextHoleOffset(dense, 100, 0); !found || off != 100 {
+		t.Errorf("NextHoleOffset dense = (%d,%v), want (100,true)", off, found)
+	}
+}
+
+func TestPunchHole(t *testing.T) {
+	tests := []struct {
+		name           string
+		refs           []BlockRef
+		offset, length uint64
+		want           []BlockRef
+	}{
+		{
+			name:   "zero length is no-op",
+			refs:   []BlockRef{ref(0, 100)},
+			offset: 10, length: 0,
+			want: []BlockRef{ref(0, 100)},
+		},
+		{
+			name:   "drop block fully inside range",
+			refs:   []BlockRef{ref(0, 20), ref(40, 20), ref(80, 20)},
+			offset: 40, length: 20,
+			want: []BlockRef{ref(0, 20), ref(80, 20)},
+		},
+		{
+			name:   "head-overlapping block is kept (out-of-range tail data survives)",
+			refs:   []BlockRef{ref(0, 100)},
+			offset: 50, length: 50,
+			want: []BlockRef{ref(0, 100)},
+		},
+		{
+			name:   "tail-overlapping block is kept (out-of-range head data survives)",
+			refs:   []BlockRef{ref(50, 50)},
+			offset: 0, length: 70,
+			want: []BlockRef{ref(50, 50)},
+		},
+		{
+			name:   "block straddling both ends is kept (head+tail data survive)",
+			refs:   []BlockRef{ref(0, 100)},
+			offset: 30, length: 40,
+			want: []BlockRef{ref(0, 100)},
+		},
+		{
+			name:   "no overlap leaves blocks untouched",
+			refs:   []BlockRef{ref(0, 20), ref(80, 20)},
+			offset: 40, length: 20,
+			want: []BlockRef{ref(0, 20), ref(80, 20)},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PunchHole(tt.refs, tt.offset, tt.length)
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("PunchHole() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/metadata/sparse.go
+++ b/pkg/metadata/sparse.go
@@ -1,0 +1,174 @@
+package metadata
+
+import (
+	"time"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+// sparse.go holds the metadata side of the NFSv4.2 sparse-file operations
+// (RFC 7862): DEALLOCATE (PunchHole) and ALLOCATE (Allocate). Both mutate the
+// authoritative content-addressed block list (FileAttr.Blocks) and/or the
+// logical size, then persist atomically. The block-store reclaim of the
+// physical bytes a DEALLOCATE frees is driven by the protocol adapter using the
+// pre-op block snapshot these methods return, mirroring the truncate-reclaim
+// split already used by SETATTR (CLAUDE.md invariants #1/#5: handlers
+// coordinate, the store owns the metadata mutation).
+
+// SparseResult reports the outcome of a PunchHole / Allocate so the adapter can
+// reclaim block-store space for the freed range and update WCC/quota state.
+type SparseResult struct {
+	// File is the file as it stands after the mutation (post-op attrs).
+	File *File
+	// PreOpBlocks is the file's block list BEFORE the mutation. The adapter
+	// passes this to BlockStore.Truncate so dropped/clipped tail chunks have
+	// their dedup refcounts decremented and remote bytes reclaimed.
+	PreOpBlocks []block.BlockRef
+	// PayloadID identifies the block-store payload for the reclaim call. Empty
+	// when the file has no backing payload (nothing to reclaim).
+	PayloadID PayloadID
+	// ReclaimFrom is the lowest offset whose backing bytes may now be
+	// unreferenced; the adapter reclaims storage at/after this offset.
+	ReclaimFrom uint64
+}
+
+// PunchHole implements DEALLOCATE (RFC 7862 Section 15.4): it marks the byte
+// range [offset, offset+length) of a regular file as a hole. Block refs lying
+// entirely within the range are dropped from the hole map (block.PunchHole);
+// the file's logical size is unchanged. Punching at or beyond EOF, or a zero
+// length, is a no-op success. The returned SparseResult.PreOpBlocks lets the
+// caller (the block store) reap the freed chunks and zero-overwrite the exact
+// punched range so it reads back as zeros — including any sub-range still
+// covered by a partially-overlapping block that PunchHole intentionally keeps
+// to preserve that block's out-of-range data.
+//
+// Requires write permission. Returns ErrIsDirectory for non-regular files and
+// ErrInvalidArgument when offset+length overflows uint64.
+func (s *Service) PunchHole(ctx *AuthContext, handle FileHandle, offset, length uint64) (*SparseResult, error) {
+	store, err := s.storeForHandle(handle)
+	if err != nil {
+		return nil, err
+	}
+
+	// Commit any pending write metadata first so file.Blocks/Size reflect the
+	// latest state before we mutate the block list.
+	if _, err := s.FlushPendingWriteForFile(ctx, handle); err != nil {
+		return nil, err
+	}
+
+	file, err := store.GetFile(ctx.Context, handle)
+	if err != nil {
+		return nil, err
+	}
+	if file.Type != FileTypeRegular {
+		return nil, &StoreError{Code: ErrIsDirectory, Message: "DEALLOCATE on non-regular file", Path: file.Path}
+	}
+	if rangeOverflows(offset, length) {
+		return nil, &StoreError{Code: ErrInvalidArgument, Message: "DEALLOCATE range overflow", Path: file.Path}
+	}
+	if err := s.checkWritePermission(ctx, handle); err != nil {
+		return nil, err
+	}
+
+	res := &SparseResult{File: file, PayloadID: file.PayloadID, ReclaimFrom: offset}
+
+	// No-op cases: zero length, nothing past offset to free, or no block list.
+	if length == 0 || offset >= file.Size || len(file.Blocks) == 0 {
+		return res, nil
+	}
+
+	res.PreOpBlocks = file.Blocks
+	newBlocks := block.PunchHole(file.Blocks, offset, length)
+	file.Blocks = newBlocks
+	if !file.ObjectID.IsZero() {
+		if len(newBlocks) == 0 {
+			file.ObjectID = block.ObjectID{}
+		} else {
+			file.ObjectID = block.ComputeObjectID(newBlocks)
+		}
+	}
+
+	now := time.Now()
+	file.Mtime = now
+	file.Ctime = now
+
+	if err := store.PutFile(ctx.Context, file); err != nil {
+		return nil, err
+	}
+
+	logger.Debug("metadata DEALLOCATE (punch hole)",
+		"path", file.Path, "offset", offset, "length", length,
+		"blocks_before", len(res.PreOpBlocks), "blocks_after", len(newBlocks))
+
+	return res, nil
+}
+
+// Allocate implements ALLOCATE (RFC 7862 Section 15.1): it guarantees the byte
+// range [offset, offset+length) is readable, extending the file's logical size
+// to offset+length when that is larger than the current size. DittoFS is
+// thin-provisioned over a content-addressed/dedup block store (and optionally
+// S3), so ALLOCATE does NOT physically reserve space — it provides
+// best-effort/logical preallocation: the range reads back as zeros (sparse
+// hole) until written, and the size grows so subsequent reads see the extent.
+// This matches the RFC, which permits a server to return success without a true
+// physical reservation. A range that lies entirely within the current size is a
+// success no-op (the file already covers it).
+//
+// Requires write permission. Returns ErrIsDirectory for non-regular files and
+// ErrInvalidArgument when offset+length overflows uint64.
+func (s *Service) Allocate(ctx *AuthContext, handle FileHandle, offset, length uint64) (*File, error) {
+	store, err := s.storeForHandle(handle)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := s.FlushPendingWriteForFile(ctx, handle); err != nil {
+		return nil, err
+	}
+
+	file, err := store.GetFile(ctx.Context, handle)
+	if err != nil {
+		return nil, err
+	}
+	if file.Type != FileTypeRegular {
+		return nil, &StoreError{Code: ErrIsDirectory, Message: "ALLOCATE on non-regular file", Path: file.Path}
+	}
+	if rangeOverflows(offset, length) {
+		return nil, &StoreError{Code: ErrInvalidArgument, Message: "ALLOCATE range overflow", Path: file.Path}
+	}
+	if err := s.checkWritePermission(ctx, handle); err != nil {
+		return nil, err
+	}
+
+	newEnd := offset + length
+	if length == 0 || newEnd <= file.Size {
+		// Range already within the file: nothing to grow. The bytes are already
+		// readable (data or hole), satisfying the allocation guarantee.
+		return file, nil
+	}
+
+	// Grow the logical size. The newly covered [oldSize, newEnd) region has no
+	// block refs, so it is a hole that reads as zeros — exactly the allocation
+	// contract for a thin-provisioned store. No block-store write is performed.
+	file.Size = newEnd
+	now := time.Now()
+	file.Mtime = now
+	file.Ctime = now
+
+	if err := store.PutFile(ctx.Context, file); err != nil {
+		return nil, err
+	}
+
+	logger.Debug("metadata ALLOCATE (logical preallocation)",
+		"path", file.Path, "offset", offset, "length", length, "new_size", newEnd)
+
+	return file, nil
+}
+
+// rangeOverflows reports whether the byte range [offset, offset+length) would
+// overflow uint64 (a malformed ALLOCATE/DEALLOCATE range). A zero length never
+// overflows.
+func rangeOverflows(offset, length uint64) bool {
+	return length > 0 && offset > ^uint64(0)-length
+}

--- a/pkg/metadata/sparse_test.go
+++ b/pkg/metadata/sparse_test.go
@@ -1,0 +1,116 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeSparseFile creates a regular file under the fixture root, then stamps it
+// with the given size and block list directly via the store so PunchHole /
+// Allocate have a realistic sparse layout to operate on. Returns the handle.
+func makeSparseFile(t *testing.T, fx *testFixture, name string, size uint64, blocks []block.BlockRef) metadata.FileHandle {
+	t.Helper()
+	file, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, name, &metadata.FileAttr{Mode: 0644})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(fx.shareName, file.ID)
+	require.NoError(t, err)
+
+	stored, err := fx.store.GetFile(fx.rootContext().Context, handle)
+	require.NoError(t, err)
+	stored.Size = size
+	stored.Blocks = blocks
+	stored.PayloadID = metadata.PayloadID("payload-" + name)
+	require.NoError(t, fx.store.PutFile(fx.rootContext().Context, stored))
+	return handle
+}
+
+func bref(offset uint64, size uint32) block.BlockRef {
+	return block.BlockRef{Offset: offset, Size: size}
+}
+
+func TestService_PunchHole(t *testing.T) {
+	t.Run("drops blocks inside the range and keeps size", func(t *testing.T) {
+		fx := newTestFixture(t)
+		// Dense file [0,300): blocks at 0,100,200 each 100 bytes.
+		handle := makeSparseFile(t, fx, "punch.bin", 300, []block.BlockRef{bref(0, 100), bref(100, 100), bref(200, 100)})
+
+		res, err := fx.service.PunchHole(fx.rootContext(), handle, 100, 100)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		assert.Equal(t, uint64(300), res.File.Size, "size must be unchanged by DEALLOCATE")
+		assert.Len(t, res.PreOpBlocks, 3, "pre-op snapshot for reclaim")
+
+		got, err := fx.store.GetFile(fx.rootContext().Context, handle)
+		require.NoError(t, err)
+		require.Len(t, got.Blocks, 2, "middle block dropped")
+		assert.Equal(t, uint64(0), got.Blocks[0].Offset)
+		assert.Equal(t, uint64(200), got.Blocks[1].Offset)
+
+		// The punched range is now a hole the hole map reports.
+		holeAt, found := block.NextHoleOffset(got.Blocks, got.Size, 0)
+		require.True(t, found)
+		assert.Equal(t, uint64(100), holeAt)
+	})
+
+	t.Run("zero length is a no-op success", func(t *testing.T) {
+		fx := newTestFixture(t)
+		handle := makeSparseFile(t, fx, "noop.bin", 100, []block.BlockRef{bref(0, 100)})
+		res, err := fx.service.PunchHole(fx.rootContext(), handle, 10, 0)
+		require.NoError(t, err)
+		assert.Nil(t, res.PreOpBlocks)
+		got, _ := fx.store.GetFile(fx.rootContext().Context, handle)
+		assert.Len(t, got.Blocks, 1)
+	})
+
+	t.Run("punch at EOF is a no-op success", func(t *testing.T) {
+		fx := newTestFixture(t)
+		handle := makeSparseFile(t, fx, "eof.bin", 100, []block.BlockRef{bref(0, 100)})
+		res, err := fx.service.PunchHole(fx.rootContext(), handle, 200, 50)
+		require.NoError(t, err)
+		assert.Nil(t, res.PreOpBlocks)
+	})
+
+	t.Run("directory rejected", func(t *testing.T) {
+		fx := newTestFixture(t)
+		_, err := fx.service.PunchHole(fx.rootContext(), fx.rootHandle, 0, 10)
+		require.Error(t, err)
+	})
+}
+
+func TestService_Allocate(t *testing.T) {
+	t.Run("extends size past EOF", func(t *testing.T) {
+		fx := newTestFixture(t)
+		handle := makeSparseFile(t, fx, "alloc.bin", 100, []block.BlockRef{bref(0, 100)})
+
+		f, err := fx.service.Allocate(fx.rootContext(), handle, 50, 500) // 50+500 = 550 > 100
+		require.NoError(t, err)
+		assert.Equal(t, uint64(550), f.Size)
+
+		got, _ := fx.store.GetFile(fx.rootContext().Context, handle)
+		assert.Equal(t, uint64(550), got.Size)
+		// The extended region is a hole (no block refs beyond 100).
+		segs := block.Segments(got.Blocks, got.Size)
+		require.GreaterOrEqual(t, len(segs), 2)
+		last := segs[len(segs)-1]
+		assert.Equal(t, block.SegmentHole, last.Kind)
+		assert.Equal(t, uint64(550), last.End)
+	})
+
+	t.Run("range within current size is a no-op", func(t *testing.T) {
+		fx := newTestFixture(t)
+		handle := makeSparseFile(t, fx, "within.bin", 1000, []block.BlockRef{bref(0, 1000)})
+		f, err := fx.service.Allocate(fx.rootContext(), handle, 100, 200)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(1000), f.Size, "size unchanged when range fits")
+	})
+
+	t.Run("directory rejected", func(t *testing.T) {
+		fx := newTestFixture(t)
+		_, err := fx.service.Allocate(fx.rootContext(), fx.rootHandle, 0, 10)
+		require.Error(t, err)
+	})
+}

--- a/test/e2e/nfsv42_sparse_test.go
+++ b/test/e2e/nfsv42_sparse_test.go
@@ -1,0 +1,151 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/marmos91/dittofs/test/e2e/framework"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// NFSv4.2 sparse-file operations (RFC 7862): SEEK, READ_PLUS, DEALLOCATE,
+// ALLOCATE. These mount with vers=4.2 and drive the operations through the
+// Linux kernel client:
+//   - fallocate -p  -> DEALLOCATE (punch hole)
+//   - fallocate     -> ALLOCATE
+//   - lseek SEEK_HOLE/SEEK_DATA -> SEEK (the kernel also uses READ_PLUS for
+//     buffered reads of sparse files on a v4.2 mount)
+// They require a Linux kernel client with NFSv4.2 (>= 4.x); MountNFSWithVersion
+// skips on macOS.
+// =============================================================================
+
+// Linux lseek whence values for sparse seeks (stable kernel ABI).
+const (
+	seekData = 3 // SEEK_DATA
+	seekHole = 4 // SEEK_HOLE
+)
+
+// seekTo opens path and returns the offset of the next data/hole at or after
+// `from`, plus any error (ENXIO when no such region exists).
+func seekTo(t *testing.T, path string, from int64, whence int) (int64, error) {
+	t.Helper()
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+	return syscall.Seek(int(f.Fd()), from, whence)
+}
+
+// blocks512 returns the number of 512-byte blocks the file occupies on the
+// server (st_blocks), used to confirm DEALLOCATE actually frees storage.
+func blocks512(t *testing.T, path string) int64 {
+	t.Helper()
+	var st syscall.Stat_t
+	require.NoError(t, syscall.Stat(path, &st))
+	return st.Blocks
+}
+
+// TestNFSv42Sparse exercises the SEEK / READ_PLUS / DEALLOCATE / ALLOCATE
+// cluster over a vers=4.2 mount (SPARSE-01..04).
+func TestNFSv42Sparse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping NFSv4.2 sparse tests in short mode")
+	}
+
+	_, _, nfsPort := setupNFSv4TestServer(t)
+	mount := framework.MountNFSWithVersion(t, nfsPort, "4.2")
+	t.Cleanup(mount.Cleanup)
+
+	t.Run("SPARSE-04 ALLOCATE extends size and reads back zeros", func(t *testing.T) {
+		path := mount.FilePath("alloc.bin")
+		framework.WriteFile(t, path, []byte{}) // create empty
+
+		// fallocate offset 0 length 64KiB -> file grows, range reads as zeros.
+		out, err := exec.Command("fallocate", "-o", "0", "-l", "65536", path).CombinedOutput()
+		require.NoErrorf(t, err, "fallocate: %s", out)
+
+		fi, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.Equal(t, int64(65536), fi.Size(), "ALLOCATE must extend logical size")
+
+		got := framework.ReadFile(t, path)
+		assert.Equal(t, 65536, len(got))
+		assert.True(t, bytes.Equal(got, make([]byte, 65536)), "allocated range must read back as zeros")
+	})
+
+	t.Run("SPARSE-03 DEALLOCATE punches a hole readable as zeros", func(t *testing.T) {
+		path := mount.FilePath("dealloc.bin")
+		// 1 MiB of 0xAB so the punch is observable in st_blocks.
+		full := bytes.Repeat([]byte{0xAB}, 1<<20)
+		framework.WriteFile(t, path, full)
+
+		before := blocks512(t, path)
+
+		// Punch a 512 KiB hole at offset 256 KiB.
+		out, err := exec.Command("fallocate", "-p", "-o", "262144", "-l", "524288", path).CombinedOutput()
+		require.NoErrorf(t, err, "fallocate -p: %s", out)
+
+		got := framework.ReadFile(t, path)
+		require.Equal(t, len(full), len(got), "size unchanged by DEALLOCATE")
+		// Punched region reads as zeros; surrounding bytes preserved.
+		assert.True(t, bytes.Equal(got[:262144], full[:262144]), "head preserved")
+		assert.True(t, bytes.Equal(got[262144:262144+524288], make([]byte, 524288)), "punched region zeroed")
+		assert.True(t, bytes.Equal(got[262144+524288:], full[262144+524288:]), "tail preserved")
+
+		// Storage usage should drop (best-effort: allow equal on backends that
+		// defer reclaim, but never grow).
+		after := blocks512(t, path)
+		assert.LessOrEqual(t, after, before, "DEALLOCATE should not increase storage")
+	})
+
+	t.Run("SPARSE-01 SEEK_HOLE / SEEK_DATA report punched boundaries", func(t *testing.T) {
+		path := mount.FilePath("seek.bin")
+		full := bytes.Repeat([]byte{0xCD}, 1<<20)
+		framework.WriteFile(t, path, full)
+
+		// Punch [256KiB, 768KiB).
+		out, err := exec.Command("fallocate", "-p", "-o", "262144", "-l", "524288", path).CombinedOutput()
+		require.NoErrorf(t, err, "fallocate -p: %s", out)
+
+		// SEEK_HOLE from 0 -> the start of the punched hole. The exact boundary
+		// depends on FastCDC chunk alignment (only whole chunks fully inside the
+		// punch become a hole in the block-list hole map), so assert the hole
+		// begins within the punched region rather than pinning the byte. It must
+		// be a real boundary before EOF, not the file size ("no hole found").
+		holeOff, err := seekTo(t, path, 0, seekHole)
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, holeOff, int64(262144), "hole should not start before the punch")
+		assert.Less(t, holeOff, int64(262144+524288), "hole should start within the punched region")
+
+		// SEEK_DATA from the middle of the punched region -> data resumes by the
+		// end of the punch, and never goes backwards.
+		dataOff, err := seekTo(t, path, 262144+262144, seekData)
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, dataOff, int64(262144+262144), "SEEK_DATA must not go backwards")
+		assert.LessOrEqual(t, dataOff, int64(262144+524288), "data should resume by the end of the punched region")
+	})
+
+	t.Run("SPARSE-02 READ_PLUS over a sparse file returns correct bytes", func(t *testing.T) {
+		// On a v4.2 mount the kernel issues READ_PLUS for buffered reads; the
+		// logical content must round-trip exactly regardless of hole encoding.
+		path := mount.FilePath("readplus.bin")
+		full := bytes.Repeat([]byte{0xEE}, 512<<10)
+		framework.WriteFile(t, path, full)
+
+		out, err := exec.Command("fallocate", "-p", "-o", "131072", "-l", "131072", path).CombinedOutput()
+		require.NoErrorf(t, err, "fallocate -p: %s", out)
+
+		want := append([]byte(nil), full...)
+		for i := 131072; i < 131072+131072; i++ {
+			want[i] = 0
+		}
+		got := framework.ReadFile(t, path)
+		assert.True(t, bytes.Equal(got, want), "READ_PLUS reconstructed content must match data+hole layout")
+	})
+}


### PR DESCRIPTION
Implements the NFSv4.2 sparse-file operation cluster (RFC 7862) on a single shared hole-tracking foundation, as the four issues requested.

## Shared foundation

There is **no separate hole bitmap**. The authoritative hole map is a file's content-addressed block list (`FileAttr.Blocks`, sorted by offset): any byte range covered by no `BlockRef` is a hole that reads as zeros. `pkg/block/holemap.go` derives all boundaries from that single source so SEEK, READ_PLUS, and DEALLOCATE stay consistent:

- `Segments()` — ordered data/hole segmentation (READ_PLUS).
- `NextDataOffset()` / `NextHoleOffset()` — SEEK_DATA / SEEK_HOLE boundaries.
- `PunchHole()` — drop block refs fully inside a punched range (DEALLOCATE).

Always-correct fallback: a file whose blocks cover its whole extent yields a single data segment (dense-file behavior).

## The four operations

| Op | # | Behavior |
|----|---|----------|
| **SEEK** (#1303) | 69 | SEEK_DATA / SEEK_HOLE over the block-list hole map. `offset >= size` or no-more-data → `NFS4ERR_NXIO`. |
| **READ_PLUS** (#1304) | 68 | Emits `read_plus` content arrays: data segments + `NFS4_CONTENT_HOLE` runs. Bytes-on-wire < logical size for sparse files; single data segment fallback for dense files. |
| **ALLOCATE** (#1306) | 59 | Extends logical size; the range reads back as zeros. |
| **DEALLOCATE** (#1305) | 62 | Punch a hole (reads as zeros) + reclaim block storage. |

Handlers do protocol concerns only (XDR, stateid validation, dispatch); the hole-map query and block-ref manipulation live in `pkg/block` and `pkg/metadata`. SEEK/READ_PLUS validate the stateid as read-family; ALLOCATE/DEALLOCATE as write-family. Every op threads `*metadata.AuthContext`. Registered into the existing `v42DispatchTable` (gated to minorversion 2).

## ALLOCATE semantics (decision)

DittoFS is thin-provisioned over a content-addressed/deduplicating block store (and optionally S3), so a true up-front **physical reservation is not possible or meaningful**. RFC 7862 permits a server to satisfy ALLOCATE without a physical reservation, so DittoFS provides **best-effort / logical** preallocation: the requested range is guaranteed readable (a sparse hole that reads as zeros until written) and the file size grows to cover it — but no space is pre-reserved. Out-of-space surfaces on the eventual WRITE, exactly as for an ordinary sparse file. Documented in `docs/FAQ.md` and `docs/NFS.md`.

DEALLOCATE reclaim: the engine reaps CAS blocks fully inside the punched range (dedup refcount decrement → GC eligibility) and zero-overwrites the exact range so both the pre-rollup append-log and CAS read paths return zeros. Partially-overlapping blocks are intentionally kept so their out-of-range data survives (a content-addressed block can't be split without invalidating its hash); the zero-overwrite masks the punched sub-range.

## Tests

- **Unit** — `pkg/block/holemap_test.go` (Segments / NextData / NextHole / PunchHole), `pkg/block/engine` PunchHole reap + zero-read, `pkg/metadata/sparse_test.go` (PunchHole/Allocate), handler XDR/validation in `internal/adapter/nfs/v4/handlers/sparse_test.go`.
- **E2E** (`test/e2e/nfsv42_sparse_test.go`, `//go:build e2e`, vers=4.2, Linux-only via `MountNFSWithVersion`): ALLOCATE extends size + reads zeros; DEALLOCATE punch reads zeros + storage does not grow; SEEK_HOLE/SEEK_DATA report punched boundaries; READ_PLUS content round-trips.
- `go build ./...`, `go vet`, `gofmt -l`, `go test -race` on all touched packages: green. (Pre-existing unrelated failures in `pkg/config` / `controlplane/api` confirmed present on clean develop.)

Reviewed by code-simplifier + code-reviewer; the reviewer's one HIGH finding (PunchHole tail-overlap data loss) was fixed by keeping partially-overlapping blocks.

Closes #1303
Closes #1304
Closes #1305
Closes #1306

🤖 Generated with [Claude Code](https://claude.com/claude-code)
