### PR TITLE
fix(docs): allow_private_endpoint for self-hosted S3 presets (#1222)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -690,6 +690,7 @@ to it instead of AWS. The store reads exactly these config keys (see
 | `endpoint` | no (AWS) / yes (others) | AWS | Service URL. Scheme optional — `https://` is prepended when absent. |
 | `force_path_style` | no | auto | **Auto-enabled whenever `endpoint` is set.** Set explicitly to `false` to opt back into virtual-hosted-style for providers that require it (e.g. GCS). |
 | `prefix` | no | — | Key prefix prepended to every block (e.g. `dittofs/`). End it with `/`. |
+| `allow_private_endpoint` | no | `false` | Required to point `endpoint` at a loopback or private-network address (MinIO, LocalStack, self-hosted RGW). See the SSRF note below. |
 
 > Path-style addressing (`endpoint.example.com/bucket/key`) is the safe
 > default for non-AWS providers because virtual-hosted style
@@ -699,10 +700,19 @@ to it instead of AWS. The store reads exactly these config keys (see
 > the only providers below that need it turned back **off** are those that
 > require virtual-hosted style (GCS).
 
-Credentials can be passed inline in `--config` (as below) or read from the
-environment via the standard `DITTOFS_*` precedence; inline values are shown
-here for clarity. Each recipe is a `dfsctl store block remote add` invocation;
-attach the resulting store to a share with `dfsctl share create … --remote <name>`.
+> **Private endpoints (MinIO, LocalStack, self-hosted RGW).** DittoFS rejects
+> an `endpoint` that resolves to a loopback or private-network address
+> (`127.0.0.0/8`, `10/8`, `172.16/12`, `192.168/16`, link-local, ULA) as an
+> SSRF guard; the cloud metadata address (`169.254.169.254`) is always blocked.
+> Self-hosted gateways normally live on exactly those networks, so add
+> `"allow_private_endpoint": true` to their `--config` to permit them, as the
+> MinIO and Ceph recipes below do.
+
+Credentials live in the store's own config (the `--config` blob below, or the
+equivalent `--access-key` / `--secret-key` flags) — they are not read from the
+`DITTOFS_*` server-config environment. Each recipe is a
+`dfsctl store block remote add` invocation; attach the resulting store to a
+share with `dfsctl share create … --remote <name>`.
 
 ##### Verified providers
 
@@ -719,11 +729,15 @@ exercised by the e2e suite where an emulator exists:
 ```bash
 # MinIO  (verified by e2e emulator)
 dfsctl store block remote add --name minio-store --type s3 \
-  --config '{"endpoint":"http://minio.example:9000","bucket":"dittofs","region":"us-east-1","access_key_id":"minioadmin","secret_access_key":"minioadmin"}'
+  --config '{"endpoint":"http://minio.example:9000","bucket":"dittofs","region":"us-east-1","access_key_id":"minioadmin","secret_access_key":"minioadmin","allow_private_endpoint":true}'
+
+# LocalStack  (verified by e2e emulator)
+dfsctl store block remote add --name localstack-store --type s3 \
+  --config '{"endpoint":"http://localstack:4566","bucket":"dittofs","region":"us-east-1","access_key_id":"test","secret_access_key":"test","allow_private_endpoint":true}'
 
 # Ceph RGW (RADOS Gateway)
 dfsctl store block remote add --name ceph-store --type s3 \
-  --config '{"endpoint":"https://rgw.example:7480","bucket":"dittofs","region":"us-east-1","access_key_id":"ACCESS","secret_access_key":"SECRET"}'
+  --config '{"endpoint":"https://rgw.example:7480","bucket":"dittofs","region":"us-east-1","access_key_id":"ACCESS","secret_access_key":"SECRET","allow_private_endpoint":true}'
 ```
 
 ##### Documented-only providers

--- a/test/e2e/helpers/matrix.go
+++ b/test/e2e/helpers/matrix.go
@@ -81,7 +81,8 @@ func SetupS3CompatibleShare(
 
 	accessKey, secretKey := s3HelperCreds(s3Helper)
 	_, err = runner.CreateRemoteBlockStore(remoteName, "s3",
-		WithBlockS3Config(bucketName, "us-east-1", s3Helper.Endpoint, accessKey, secretKey))
+		WithBlockS3Config(bucketName, "us-east-1", s3Helper.Endpoint, accessKey, secretKey),
+		WithBlockAllowPrivateEndpoint())
 	require.NoError(t, err, "Should create s3 remote block store")
 	t.Cleanup(func() { _ = runner.DeleteRemoteBlockStore(remoteName) })
 
@@ -165,7 +166,8 @@ func SetupStoreMatrix(
 
 			accessKey, secretKey := s3HelperCreds(lsHelper)
 			remoteOpts = append(remoteOpts, WithBlockS3Config(
-				bucketName, "us-east-1", lsHelper.Endpoint, accessKey, secretKey))
+				bucketName, "us-east-1", lsHelper.Endpoint, accessKey, secretKey),
+				WithBlockAllowPrivateEndpoint())
 		}
 
 		_, err = runner.CreateRemoteBlockStore(setup.RemoteStoreName, sc.RemoteType, remoteOpts...)

--- a/test/e2e/helpers/stores.go
+++ b/test/e2e/helpers/stores.go
@@ -174,6 +174,11 @@ type blockStoreOptions struct {
 	endpoint  string
 	accessKey string
 	secretKey string
+	// allowPrivate permits a loopback/private-network endpoint (MinIO,
+	// LocalStack). The s3 store rejects such endpoints as an SSRF guard
+	// unless allow_private_endpoint=true, which only the --config JSON path
+	// can express, so setting this switches the S3 flags to a config blob.
+	allowPrivate bool
 	// Generic JSON config
 	rawConfig string
 }
@@ -196,6 +201,16 @@ func WithBlockRawConfig(config string) BlockStoreOption {
 	}
 }
 
+// WithBlockAllowPrivateEndpoint permits an S3 endpoint that resolves to a
+// loopback or private-network address (MinIO, LocalStack). Pair it with
+// WithBlockS3Config; it sends the S3 settings as a --config JSON blob carrying
+// allow_private_endpoint=true, since the typed S3 flags cannot express it.
+func WithBlockAllowPrivateEndpoint() BlockStoreOption {
+	return func(o *blockStoreOptions) {
+		o.allowPrivate = true
+	}
+}
+
 // =============================================================================
 // Block Store CRUD Methods
 // =============================================================================
@@ -206,20 +221,48 @@ func appendBlockStoreConfigArgs(args []string, options *blockStoreOptions) []str
 	if options.rawConfig != "" {
 		return append(args, "--config", options.rawConfig)
 	}
-	if options.bucket != "" {
-		args = append(args, "--bucket", options.bucket)
-		if options.region != "" {
-			args = append(args, "--region", options.region)
+	if options.bucket == "" {
+		return args
+	}
+
+	// allow_private_endpoint is only expressible via the --config JSON path, so
+	// emit the S3 settings as a blob when a private endpoint is needed (the
+	// typed --bucket/--endpoint flags cannot carry it).
+	if options.allowPrivate {
+		cfg := map[string]any{
+			"bucket":                 options.bucket,
+			"allow_private_endpoint": true,
 		}
-		if options.endpoint != "" {
-			args = append(args, "--endpoint", options.endpoint)
+		setIfNotEmpty(cfg, "region", options.region)
+		setIfNotEmpty(cfg, "endpoint", options.endpoint)
+		setIfNotEmpty(cfg, "access_key_id", options.accessKey)
+		setIfNotEmpty(cfg, "secret_access_key", options.secretKey)
+		blob, err := json.Marshal(cfg)
+		if err != nil {
+			panic(fmt.Sprintf("marshal block store config: %v", err))
 		}
-		if options.accessKey != "" {
-			args = append(args, "--access-key", options.accessKey)
-		}
-		if options.secretKey != "" {
-			args = append(args, "--secret-key", options.secretKey)
-		}
+		return append(args, "--config", string(blob))
+	}
+
+	args = append(args, "--bucket", options.bucket)
+	args = appendIfNotEmpty(args, "--region", options.region)
+	args = appendIfNotEmpty(args, "--endpoint", options.endpoint)
+	args = appendIfNotEmpty(args, "--access-key", options.accessKey)
+	args = appendIfNotEmpty(args, "--secret-key", options.secretKey)
+	return args
+}
+
+// setIfNotEmpty assigns value to cfg[key] only when value is non-empty.
+func setIfNotEmpty(cfg map[string]any, key, value string) {
+	if value != "" {
+		cfg[key] = value
+	}
+}
+
+// appendIfNotEmpty appends "flag value" to args only when value is non-empty.
+func appendIfNotEmpty(args []string, flag, value string) []string {
+	if value != "" {
+		return append(args, flag, value)
 	}
 	return args
 }

--- a/test/e2e/run-e2e.sh
+++ b/test/e2e/run-e2e.sh
@@ -271,6 +271,8 @@ start_localstack() {
     if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "dittofs-localstack"; then
         log_info "Localstack already running (dittofs-localstack)"
         LOCALSTACK_CONTAINER="dittofs-localstack"
+        # Mirror the fresh-start path so reused containers are still detected.
+        export LOCALSTACK_ENDPOINT="http://localhost:4566"
         return
     fi
 
@@ -291,6 +293,9 @@ start_localstack() {
     while [[ $attempt -le $max_attempts ]]; do
         if curl -s http://localhost:4566/_localstack/health 2>/dev/null | grep -q '"s3": "available"'; then
             log_info "Localstack is ready"
+            # Export the endpoint the Go helpers look for; without it the
+            # LocalStack-backed S3 tests silently skip (mirrors MINIO_ENDPOINT).
+            export LOCALSTACK_ENDPOINT="http://localhost:4566"
             return
         fi
         sleep 1


### PR DESCRIPTION
## What

Follow-up to #1361 (S3-compatible presets), addressing the 6 Copilot review comments that were not resolved before that PR merged.

The s3 block store rejects an `endpoint` resolving to a loopback/private address as an SSRF guard (`pkg/controlplane/runtime/blockstore_init.go` reads `config["allow_private_endpoint"]`). The merged recipes and e2e helpers omitted the key, so:
- the documented MinIO / LocalStack / self-hosted RGW recipes failed at `share create`;
- the new preset e2e test could only ever skip (emulator endpoint is private), giving false-green CI.

## Changes

- **docs/CONFIGURATION.md** — document `allow_private_endpoint` + the SSRF guard; add it to the MinIO and Ceph recipes; add a LocalStack recipe; correct the inaccurate claim that store credentials come from `DITTOFS_*` env.
- **test/e2e/helpers** — `WithBlockAllowPrivateEndpoint()` emits a `--config` JSON blob (the typed `--bucket/--endpoint` flags cannot carry the key); applied at both emulator call sites.
- **test/e2e/run-e2e.sh** — export `LOCALSTACK_ENDPOINT` in both the fresh-start and already-running paths (mirrors `MINIO_ENDPOINT`); without it the LocalStack-backed tests silently skip.

## Verification

- `go build -tags e2e ./...` + `go vet -tags e2e ./test/e2e/helpers/...` clean; gofmt clean.
- code-simplifier + code-reviewer run; reviewer-found bug (missing export in the reuse path) fixed.

Re-addresses #1222.