### PR TITLE
feat(metadata): add pure-Go SQLite metadata store (#1224)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1294,7 +1294,8 @@ Backends maintain a secondary index:
 
 | Backend  | Index                                                                       |
 |----------|-----------------------------------------------------------------------------|
-| Postgres | Partial unique: `files_object_id_idx ON files(object_id) WHERE object_id IS NOT NULL` (migration `000013_object_id`) |
+| Postgres | Partial unique: `inodes_object_id_idx ON inodes(object_id) WHERE object_id IS NOT NULL` |
+| SQLite   | Partial unique: `inodes_object_id_idx ON inodes(object_id) WHERE object_id IS NOT NULL` (pure-Go `glebarez/go-sqlite`, mirrors the Postgres model) |
 | Badger   | Secondary key `obj:{hex} -> file_id`, maintained inside each `Put`/`Delete` write batch |
 | Memory   | `map[ContentHash]uuid`, guarded by the existing store mutex                 |
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -781,6 +781,12 @@ Metadata stores are managed at runtime via `dfsctl` and persisted in the control
 ./dfsctl store metadata add --name badger-isolated --type badger \
   --config '{"path":"/tmp/dittofs-metadata-isolated"}'
 
+# SQLite for a persistent single-binary / edge appliance (pure-Go, no cgo).
+# Reuses the PostgreSQL data model (parent_child_map hard links, nlink,
+# recursive-CTE path reconstruction, object_id dedup index).
+./dfsctl store metadata add --name sqlite-edge --type sqlite \
+  --config '{"path":"/var/lib/dittofs/metadata.db"}'
+
 # PostgreSQL for distributed, horizontally-scalable metadata
 # Set POSTGRES_PASSWORD in your environment
 ./dfsctl store metadata add --name postgres-production --type postgres \

--- a/flake.nix
+++ b/flake.nix
@@ -383,7 +383,7 @@
 
               # Auto-updated by .github/workflows/nix-update-hash.yml on go.mod/go.sum changes.
               # Manual: go run scripts/update-nix-hash.go
-              vendorHash = "sha256-SLizpE1e0YU7mJ9jOFi0lRu1uaKE+mggEJpcVFIBO/s=";
+              vendorHash = "sha256-ZkahN9xpL7tE+ENcyQu8XTJ98GTSxwC1HDmCSWc7zhE=";
 
               ldflags = [
                 "-s"

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/dgraph-io/badger/v4 v4.5.2
 	github.com/docker/go-connections v0.6.0
 	github.com/gemalto/kmip-go v0.1.0
+	github.com/glebarez/go-sqlite v1.21.2
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/go-ldap/ldap/v3 v3.4.13
@@ -67,7 +68,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/gemalto/flume v1.0.0 // indirect
 	github.com/geoffgarside/ber v1.1.0 // indirect
-	github.com/glebarez/go-sqlite v1.21.2 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -16,6 +16,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/store/badger"
 	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
 	"github.com/marmos91/dittofs/pkg/metadata/store/postgres"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
 )
 
 // InitializeFromStore creates a runtime and loads metadata stores from the database.
@@ -157,6 +158,45 @@ func CreateMetadataStoreFromConfig(ctx context.Context, storeType string, cfg in
 		}
 
 		return postgres.NewPostgresMetadataStore(ctx, pgCfg, capabilities)
+
+	case "sqlite":
+		dbPath, ok := config["path"].(string)
+		if !ok || dbPath == "" {
+			dbPath, ok = config["db_path"].(string) // accept legacy key
+			if !ok || dbPath == "" {
+				return nil, errors.New("sqlite metadata store requires path as string")
+			}
+		}
+		dbPath, err = pathutil.ExpandPath(dbPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to expand path %q: %w", dbPath, err)
+		}
+
+		sqliteCfg := &sqlite.SQLiteMetadataStoreConfig{
+			Path:        dbPath,
+			AutoMigrate: true,
+		}
+
+		capabilities := metadata.FilesystemCapabilities{
+			MaxReadSize:           1024 * 1024,
+			PreferredReadSize:     64 * 1024,
+			MaxWriteSize:          1024 * 1024,
+			PreferredWriteSize:    64 * 1024,
+			MaxFileSize:           1024 * 1024 * 1024 * 100, // 100 GB
+			MaxFilenameLen:        255,
+			MaxPathLen:            4096,
+			MaxHardLinkCount:      32767,
+			SupportsHardLinks:     true,
+			SupportsSymlinks:      true,
+			CaseSensitive:         true,
+			CasePreserving:        true,
+			SupportsACLs:          false,
+			SupportsExtendedAttrs: true, // EAs persist in the inodes.eas column.
+			// File timestamps are stored as INTEGER unix nanoseconds (lossless).
+			TimestampResolution: time.Nanosecond,
+		}
+
+		return sqlite.NewSQLiteMetadataStore(ctx, sqliteCfg, capabilities)
 
 	default:
 		return nil, fmt.Errorf("unsupported metadata store type: %s", storeType)

--- a/pkg/controlplane/runtime/stores/service.go
+++ b/pkg/controlplane/runtime/stores/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/store/badger"
 	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
 	"github.com/marmos91/dittofs/pkg/metadata/store/postgres"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
 )
 
 // Service manages named metadata store instances.
@@ -204,6 +205,25 @@ func (s *Service) OpenMetadataStoreAtPath(
 		}
 		return store, nil
 
+	case "sqlite":
+		// SQLite is filesystem-backed like badger: pathOverride is the backing
+		// database-file path. AutoMigrate creates the schema on open.
+		if pathOverride == "" {
+			return nil, fmt.Errorf("sqlite engine requires non-empty pathOverride")
+		}
+		dbPath, err := pathutil.ExpandPath(pathOverride)
+		if err != nil {
+			return nil, fmt.Errorf("expand sqlite pathOverride %q: %w", pathOverride, err)
+		}
+		store, err := sqlite.NewSQLiteMetadataStore(ctx, &sqlite.SQLiteMetadataStoreConfig{
+			Path:        dbPath,
+			AutoMigrate: true,
+		}, sqliteRestoreCapabilities())
+		if err != nil {
+			return nil, fmt.Errorf("open sqlite engine at %q: %w", dbPath, err)
+		}
+		return store, nil
+
 	default:
 		return nil, fmt.Errorf("unsupported metadata store type %q", cfg.Type)
 	}
@@ -333,4 +353,27 @@ func openPostgresAtSchema(
 	return nil, errors.New(
 		"postgres schema-scoped open is not supported: the postgres metadata " +
 			"engine does not yet accept a per-instance schema override")
+}
+
+// sqliteRestoreCapabilities returns the filesystem capabilities a SQLite store
+// is opened with for snapshot/restore-at-path. They mirror the primary SQLite
+// factory in runtime/init.go so a restored store advertises identical limits.
+func sqliteRestoreCapabilities() metadata.FilesystemCapabilities {
+	return metadata.FilesystemCapabilities{
+		MaxReadSize:           1024 * 1024,
+		PreferredReadSize:     64 * 1024,
+		MaxWriteSize:          1024 * 1024,
+		PreferredWriteSize:    64 * 1024,
+		MaxFileSize:           1024 * 1024 * 1024 * 100,
+		MaxFilenameLen:        255,
+		MaxPathLen:            4096,
+		MaxHardLinkCount:      32767,
+		SupportsHardLinks:     true,
+		SupportsSymlinks:      true,
+		CaseSensitive:         true,
+		CasePreserving:        true,
+		SupportsACLs:          false,
+		SupportsExtendedAttrs: true,
+		TimestampResolution:   time.Nanosecond,
+	}
 }

--- a/pkg/metadata/store/sqlite/backup.go
+++ b/pkg/metadata/store/sqlite/backup.go
@@ -1,0 +1,529 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/backup"
+)
+
+// sqliteEngineTag identifies SQLite-produced backup streams; Restore refuses a
+// stream tagged for a different engine.
+const sqliteEngineTag = "sqlite"
+
+// sqliteSchemaVersion is bumped whenever the on-disk schema changes in a way
+// that makes an older backup unrestorable. Restore rejects a mismatch.
+const sqliteSchemaVersion uint32 = 1
+
+// backupTables lists every table dumped by Backup and reloaded by Restore, in a
+// FK-safe order for restore (parents before children). inodes must precede
+// parent_child_map / file_block_refs / locks / durable_handles (all reference
+// inodes), and shares references inodes(root_file_id).
+var backupTables = []string{
+	"inodes",
+	"shares",
+	"filesystem_meta",
+	"parent_child_map",
+	"file_blocks",
+	"file_block_refs",
+	"locks",
+	"nsm_client_registrations",
+	"durable_handles",
+	"v4_client_recovery",
+	"rollup_offsets",
+	"synced_hashes",
+	"server_config",
+	"server_epoch",
+	"filesystem_capabilities",
+}
+
+// isKnownTable guards Restore against an unexpected table name in the stream.
+func isKnownTable(name string) bool {
+	for _, t := range backupTables {
+		if t == name {
+			return true
+		}
+	}
+	return false
+}
+
+// Cell value-kind tags for the self-describing per-row encoding.
+const (
+	cellNull  byte = 0
+	cellInt   byte = 1
+	cellFloat byte = 2
+	cellText  byte = 3
+	cellBlob  byte = 4
+)
+
+// Backup serializes the entire metadata database into a CRC-protected envelope
+// and returns the set of distinct content hashes referenced by file_block_refs
+// (so the caller can pin the corresponding blocks). It is a logical, row-based
+// export — portable across SQLite file formats and independent of the on-disk
+// page layout.
+func (s *SQLiteMetadataStore) Backup(ctx context.Context, w io.Writer) (*block.HashSet, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("%w: %v", metadata.ErrBackupAborted, err)
+	}
+
+	// A single read transaction gives a consistent snapshot across all tables.
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, fmt.Errorf("backup: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	envW, err := backup.NewWriter(w, sqliteEngineTag)
+	if err != nil {
+		return nil, fmt.Errorf("backup: create envelope: %w", err)
+	}
+
+	var verBuf [4]byte
+	binary.LittleEndian.PutUint32(verBuf[:], sqliteSchemaVersion)
+	if _, err := envW.Write(verBuf[:]); err != nil {
+		return nil, fmt.Errorf("backup: write schema version: %w", err)
+	}
+
+	var countBuf [4]byte
+	binary.LittleEndian.PutUint32(countBuf[:], uint32(len(backupTables)))
+	if _, err := envW.Write(countBuf[:]); err != nil {
+		return nil, fmt.Errorf("backup: write table count: %w", err)
+	}
+
+	for _, table := range backupTables {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("%w: %v", metadata.ErrBackupAborted, err)
+		}
+		if err := backupTable(ctx, tx, envW, table); err != nil {
+			return nil, fmt.Errorf("backup: table %s: %w", table, err)
+		}
+	}
+
+	hs, err := extractHashes(ctx, tx)
+	if err != nil {
+		return nil, fmt.Errorf("backup: extract hashes: %w", err)
+	}
+
+	if err := envW.Finish(); err != nil {
+		return nil, fmt.Errorf("backup: finish envelope: %w", err)
+	}
+	return hs, nil
+}
+
+// backupTable streams every row of one table as a self-describing section:
+//
+//	name_len(u16) name
+//	col_count(u16) [ col_name_len(u16) col_name ]*
+//	row_count(u32) [ row ]*    where each row is col_count tagged cells.
+func backupTable(ctx context.Context, tx *sql.Tx, w io.Writer, table string) error {
+	rows, err := tx.QueryContext(ctx, `SELECT * FROM `+table)
+	if err != nil {
+		return fmt.Errorf("select: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return fmt.Errorf("columns: %w", err)
+	}
+
+	if err := writeString(w, table); err != nil {
+		return err
+	}
+	if err := writeU16(w, uint16(len(cols))); err != nil {
+		return err
+	}
+	for _, c := range cols {
+		if err := writeString(w, c); err != nil {
+			return err
+		}
+	}
+
+	// Buffer the rows so the row count can be written before the rows. Metadata
+	// row counts are bounded by the share's inode count; this matches the
+	// Postgres backend buffering a table's COPY output in memory.
+	var rowBuf []byte
+	var n uint32
+	for rows.Next() {
+		cells := make([]any, len(cols))
+		ptrs := make([]any, len(cols))
+		for i := range cells {
+			ptrs[i] = &cells[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			return fmt.Errorf("scan: %w", err)
+		}
+		for _, v := range cells {
+			rowBuf = appendCell(rowBuf, v)
+		}
+		n++
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate: %w", err)
+	}
+
+	if err := writeU32(w, n); err != nil {
+		return err
+	}
+	if _, err := w.Write(rowBuf); err != nil {
+		return err
+	}
+	return nil
+}
+
+// extractHashes collects the distinct content hashes referenced by
+// file_block_refs so the caller can pin the corresponding blocks.
+func extractHashes(ctx context.Context, tx *sql.Tx) (*block.HashSet, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT DISTINCT hash FROM file_block_refs`)
+	if err != nil {
+		return nil, fmt.Errorf("query hashes: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	hs := block.NewHashSet(0)
+	for rows.Next() {
+		var raw []byte
+		if err := rows.Scan(&raw); err != nil {
+			return nil, fmt.Errorf("scan hash: %w", err)
+		}
+		if len(raw) != block.HashSize {
+			return nil, fmt.Errorf("hash has unexpected length %d (want %d)", len(raw), block.HashSize)
+		}
+		var ch block.ContentHash
+		copy(ch[:], raw)
+		hs.Add(ch)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate hashes: %w", err)
+	}
+	return hs, nil
+}
+
+// Restore replaces the (must-be-empty) database contents from a backup stream
+// produced by Backup. It verifies the envelope CRC before committing so a
+// truncated or corrupt stream never leaves a partial state.
+func (s *SQLiteMetadataStore) Restore(ctx context.Context, r io.Reader) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("restore cancelled: %w", err)
+	}
+
+	var hasShares bool
+	if err := s.db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM shares)`).Scan(&hasShares); err != nil {
+		return fmt.Errorf("restore: check empty: %w", err)
+	}
+	if hasShares {
+		return metadata.ErrRestoreDestinationNotEmpty
+	}
+
+	engineTag, payloadR, acc, err := backup.ReadHeader(r)
+	if err != nil {
+		return fmt.Errorf("%w: envelope: %v", metadata.ErrRestoreCorrupt, err)
+	}
+	if err := backup.VerifyEngine(engineTag, sqliteEngineTag); err != nil {
+		return fmt.Errorf("%w: %v", metadata.ErrRestoreCorrupt, err)
+	}
+
+	var verBuf [4]byte
+	if _, err := io.ReadFull(payloadR, verBuf[:]); err != nil {
+		return fmt.Errorf("%w: read schema version: %v", metadata.ErrRestoreCorrupt, err)
+	}
+	if v := binary.LittleEndian.Uint32(verBuf[:]); v != sqliteSchemaVersion {
+		return fmt.Errorf("%w: got %d, want %d", metadata.ErrSchemaVersionMismatch, v, sqliteSchemaVersion)
+	}
+
+	var countBuf [4]byte
+	if _, err := io.ReadFull(payloadR, countBuf[:]); err != nil {
+		return fmt.Errorf("%w: read table count: %v", metadata.ErrRestoreCorrupt, err)
+	}
+	tableCount := binary.LittleEndian.Uint32(countBuf[:])
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("restore: begin tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if err := truncateAllTables(ctx, tx); err != nil {
+		return fmt.Errorf("%w: truncate: %v", metadata.ErrRestoreCorrupt, err)
+	}
+
+	for i := uint32(0); i < tableCount; i++ {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("%w: %v", metadata.ErrRestoreCorrupt, err)
+		}
+		if err := restoreTable(ctx, tx, payloadR); err != nil {
+			return fmt.Errorf("%w: table %d: %v", metadata.ErrRestoreCorrupt, i, err)
+		}
+	}
+
+	// Verify the CRC BEFORE committing so a corrupt tail aborts the restore.
+	if err := backup.VerifyCRC(r, acc); err != nil {
+		return fmt.Errorf("%w: %v", metadata.ErrRestoreCorrupt, err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("restore: commit: %w", err)
+	}
+	committed = true
+
+	// Re-seed the in-memory used-bytes / quota counters from the restored rows.
+	if err := s.initUsedBytesCounter(ctx); err != nil {
+		return fmt.Errorf("restore: reinitialize used-bytes counter: %w", err)
+	}
+	// The cached store_id was read at open; the restored stream may carry a
+	// different one, so re-read it from server_config (the row Restore just
+	// reloaded) so GetStoreID reflects the restored database without a reopen.
+	sid, err := s.ensureStoreID(ctx)
+	if err != nil {
+		return fmt.Errorf("restore: re-read store_id: %w", err)
+	}
+	s.storeID = sid
+	return nil
+}
+
+// restoreTable reads one table section and re-inserts its rows.
+func restoreTable(ctx context.Context, tx *sql.Tx, r io.Reader) error {
+	table, err := readString(r)
+	if err != nil {
+		return fmt.Errorf("read name: %w", err)
+	}
+	if !isKnownTable(table) {
+		return fmt.Errorf("unknown table %q in backup stream", table)
+	}
+
+	colCount, err := readU16(r)
+	if err != nil {
+		return fmt.Errorf("read col count: %w", err)
+	}
+	cols := make([]string, colCount)
+	for i := range cols {
+		if cols[i], err = readString(r); err != nil {
+			return fmt.Errorf("read col name: %w", err)
+		}
+	}
+
+	rowCount, err := readU32(r)
+	if err != nil {
+		return fmt.Errorf("read row count: %w", err)
+	}
+	if rowCount == 0 {
+		return nil
+	}
+
+	insertSQL := buildInsert(table, cols)
+	for i := uint32(0); i < rowCount; i++ {
+		vals := make([]any, colCount)
+		for c := 0; c < int(colCount); c++ {
+			if vals[c], err = readCell(r); err != nil {
+				return fmt.Errorf("read cell: %w", err)
+			}
+		}
+		if _, err := tx.ExecContext(ctx, insertSQL, vals...); err != nil {
+			return fmt.Errorf("insert into %s: %w", table, err)
+		}
+	}
+	return nil
+}
+
+// truncateAllTables empties every table in reverse FK order. SQLite has no
+// TRUNCATE; a plain DELETE with foreign_keys enabled is sufficient and the
+// reverse order avoids tripping ON DELETE RESTRICT (shares.root_file_id).
+func truncateAllTables(ctx context.Context, tx *sql.Tx) error {
+	for i := len(backupTables) - 1; i >= 0; i-- {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM `+backupTables[i]); err != nil {
+			return fmt.Errorf("delete from %s: %w", backupTables[i], err)
+		}
+	}
+	return nil
+}
+
+// buildInsert renders `INSERT INTO t (c1,c2,...) VALUES (?,?,...)`.
+func buildInsert(table string, cols []string) string {
+	q := `INSERT INTO ` + quoteIdent(table) + ` (`
+	for i, c := range cols {
+		if i > 0 {
+			q += ", "
+		}
+		q += quoteIdent(c)
+	}
+	q += `) VALUES (`
+	for i := range cols {
+		if i > 0 {
+			q += ", "
+		}
+		q += "?"
+	}
+	q += `)`
+	return q
+}
+
+// quoteIdent double-quotes a SQL identifier, doubling embedded quotes. Table and
+// column names here come from the fixed backupTables list and the dumped
+// column metadata, never operator input.
+func quoteIdent(id string) string {
+	out := make([]byte, 0, len(id)+2)
+	out = append(out, '"')
+	for i := 0; i < len(id); i++ {
+		if id[i] == '"' {
+			out = append(out, '"')
+		}
+		out = append(out, id[i])
+	}
+	out = append(out, '"')
+	return string(out)
+}
+
+// --------------------------------------------------------------------------
+// Self-describing cell / primitive codec
+// --------------------------------------------------------------------------
+
+func appendCell(buf []byte, v any) []byte {
+	switch t := v.(type) {
+	case nil:
+		return append(buf, cellNull)
+	case int64:
+		buf = append(buf, cellInt)
+		var b [8]byte
+		binary.LittleEndian.PutUint64(b[:], uint64(t))
+		return append(buf, b[:]...)
+	case float64:
+		buf = append(buf, cellFloat)
+		var b [8]byte
+		binary.LittleEndian.PutUint64(b[:], math.Float64bits(t))
+		return append(buf, b[:]...)
+	case []byte:
+		buf = append(buf, cellBlob)
+		var b [4]byte
+		binary.LittleEndian.PutUint32(b[:], uint32(len(t)))
+		buf = append(buf, b[:]...)
+		return append(buf, t...)
+	case string:
+		buf = append(buf, cellText)
+		var b [4]byte
+		binary.LittleEndian.PutUint32(b[:], uint32(len(t)))
+		buf = append(buf, b[:]...)
+		return append(buf, []byte(t)...)
+	case bool:
+		buf = append(buf, cellInt)
+		var b [8]byte
+		if t {
+			binary.LittleEndian.PutUint64(b[:], 1)
+		}
+		return append(buf, b[:]...)
+	default:
+		// Should not happen: database/sql yields nil/int64/float64/[]byte/string
+		// for SQLite columns. Encode the fmt string as text for resilience.
+		s := fmt.Sprintf("%v", t)
+		buf = append(buf, cellText)
+		var b [4]byte
+		binary.LittleEndian.PutUint32(b[:], uint32(len(s)))
+		buf = append(buf, b[:]...)
+		return append(buf, []byte(s)...)
+	}
+}
+
+func readCell(r io.Reader) (any, error) {
+	var kind [1]byte
+	if _, err := io.ReadFull(r, kind[:]); err != nil {
+		return nil, err
+	}
+	switch kind[0] {
+	case cellNull:
+		return nil, nil
+	case cellInt:
+		var b [8]byte
+		if _, err := io.ReadFull(r, b[:]); err != nil {
+			return nil, err
+		}
+		return int64(binary.LittleEndian.Uint64(b[:])), nil
+	case cellFloat:
+		var b [8]byte
+		if _, err := io.ReadFull(r, b[:]); err != nil {
+			return nil, err
+		}
+		return math.Float64frombits(binary.LittleEndian.Uint64(b[:])), nil
+	case cellText:
+		n, err := readU32(r)
+		if err != nil {
+			return nil, err
+		}
+		buf := make([]byte, n)
+		if _, err := io.ReadFull(r, buf); err != nil {
+			return nil, err
+		}
+		return string(buf), nil
+	case cellBlob:
+		n, err := readU32(r)
+		if err != nil {
+			return nil, err
+		}
+		buf := make([]byte, n)
+		if _, err := io.ReadFull(r, buf); err != nil {
+			return nil, err
+		}
+		return buf, nil
+	default:
+		return nil, fmt.Errorf("unknown cell kind %d", kind[0])
+	}
+}
+
+func writeString(w io.Writer, s string) error {
+	if err := writeU16(w, uint16(len(s))); err != nil {
+		return err
+	}
+	_, err := w.Write([]byte(s))
+	return err
+}
+
+func readString(r io.Reader) (string, error) {
+	n, err := readU16(r)
+	if err != nil {
+		return "", err
+	}
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+func writeU16(w io.Writer, v uint16) error {
+	var b [2]byte
+	binary.LittleEndian.PutUint16(b[:], v)
+	_, err := w.Write(b[:])
+	return err
+}
+
+func readU16(r io.Reader) (uint16, error) {
+	var b [2]byte
+	if _, err := io.ReadFull(r, b[:]); err != nil {
+		return 0, err
+	}
+	return binary.LittleEndian.Uint16(b[:]), nil
+}
+
+func writeU32(w io.Writer, v uint32) error {
+	var b [4]byte
+	binary.LittleEndian.PutUint32(b[:], v)
+	_, err := w.Write(b[:])
+	return err
+}
+
+func readU32(r io.Reader) (uint32, error) {
+	var b [4]byte
+	if _, err := io.ReadFull(r, b[:]); err != nil {
+		return 0, err
+	}
+	return binary.LittleEndian.Uint32(b[:]), nil
+}

--- a/pkg/metadata/store/sqlite/client_recovery.go
+++ b/pkg/metadata/store/sqlite/client_recovery.go
@@ -1,0 +1,179 @@
+package sqlite
+
+import (
+	"context"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// ============================================================================
+// SQLite ClientRecoveryStore Implementation
+// ============================================================================
+
+// sqliteRecoveryStore implements lock.ClientRecoveryStore using SQLite.
+//
+// Storage Model:
+//   - v4_client_recovery table: stores V4ClientRecoveryRecord
+//   - keyed by clientid_string (server-global; share is not part of the key)
+//
+// Thread Safety:
+// All operations are single statements executed against the connection pool.
+type sqliteRecoveryStore struct {
+	pool execer
+}
+
+// newSQLiteRecoveryStore creates a new SQLite client recovery store.
+func newSQLiteRecoveryStore(pool execer) *sqliteRecoveryStore {
+	return &sqliteRecoveryStore{pool: pool}
+}
+
+// PutClientRecovery stores or replaces the record for a confirmed client using
+// an upsert keyed by clientid_string (latest wins, one row).
+//
+// Put REPLACES the full record, reclaim_complete included, to stay byte-for-byte
+// identical to the memory/badger backends (which overwrite the whole struct).
+// Semantically a re-confirm means the client's state is fresh, so reclaim starts
+// over; callers persist reclaim completion through RecordReclaimComplete, not
+// through Put.
+func (s *sqliteRecoveryStore) PutClientRecovery(ctx context.Context, rec *lock.V4ClientRecoveryRecord) error {
+	query := `
+		INSERT INTO v4_client_recovery (
+			clientid_string, clientid, boot_verifier, principal,
+			confirmed_at, server_epoch, reclaim_complete
+		)
+		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+		ON CONFLICT (clientid_string) DO UPDATE SET
+			clientid = EXCLUDED.clientid,
+			boot_verifier = EXCLUDED.boot_verifier,
+			principal = EXCLUDED.principal,
+			confirmed_at = EXCLUDED.confirmed_at,
+			server_epoch = EXCLUDED.server_epoch,
+			reclaim_complete = EXCLUDED.reclaim_complete
+	`
+
+	_, err := s.pool.Exec(ctx, query,
+		rec.ClientIDString,
+		int64(rec.ClientID),
+		rec.BootVerifier[:], // [8]byte -> BYTEA
+		rec.Principal,
+		rec.ConfirmedAt,
+		int64(rec.ServerEpoch),
+		rec.ReclaimComplete,
+	)
+	return err
+}
+
+// DeleteClientRecovery removes the record for a client.
+func (s *sqliteRecoveryStore) DeleteClientRecovery(ctx context.Context, clientIDString string) error {
+	query := `DELETE FROM v4_client_recovery WHERE clientid_string = ?1`
+	_, err := s.pool.Exec(ctx, query, clientIDString)
+	return err
+}
+
+// scanRecoveryRecord scans one row into a V4ClientRecoveryRecord, copying the
+// BYTEA boot_verifier into the fixed [8]byte array.
+func scanRecoveryRecord(row scanRow) (*lock.V4ClientRecoveryRecord, error) {
+	var rec lock.V4ClientRecoveryRecord
+	var clientID, serverEpoch int64
+	var bootVerifier []byte
+
+	err := row.Scan(
+		&rec.ClientIDString,
+		&clientID,
+		&bootVerifier,
+		&rec.Principal,
+		&rec.ConfirmedAt,
+		&serverEpoch,
+		&rec.ReclaimComplete,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	rec.ClientID = uint64(clientID)
+	rec.ServerEpoch = uint64(serverEpoch)
+	if len(bootVerifier) == 8 {
+		copy(rec.BootVerifier[:], bootVerifier)
+	}
+	return &rec, nil
+}
+
+// ListClientRecovery returns all stored records.
+func (s *sqliteRecoveryStore) ListClientRecovery(ctx context.Context) ([]*lock.V4ClientRecoveryRecord, error) {
+	query := `
+		SELECT clientid_string, clientid, boot_verifier, principal,
+		       confirmed_at, server_epoch, reclaim_complete
+		FROM v4_client_recovery
+		ORDER BY confirmed_at
+	`
+
+	rows, err := s.pool.Query(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make([]*lock.V4ClientRecoveryRecord, 0)
+	for rows.Next() {
+		rec, err := scanRecoveryRecord(rows)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// RecordReclaimComplete marks the client's record reclaim-complete. A missing
+// record is a no-op (RowsAffected == 0), not an error.
+func (s *sqliteRecoveryStore) RecordReclaimComplete(ctx context.Context, clientIDString string) error {
+	query := `UPDATE v4_client_recovery SET reclaim_complete = TRUE WHERE clientid_string = ?1`
+	_, err := s.pool.Exec(ctx, query, clientIDString)
+	return err
+}
+
+// ============================================================================
+// SQLiteMetadataStore ClientRecoveryStore Integration
+// ============================================================================
+
+// Ensure SQLiteMetadataStore implements ClientRecoveryStore.
+var _ lock.ClientRecoveryStore = (*SQLiteMetadataStore)(nil)
+
+// getRecoveryStore returns the recovery store, initializing if needed.
+func (s *SQLiteMetadataStore) getRecoveryStore() *sqliteRecoveryStore {
+	s.recoveryStoreMu.Lock()
+	defer s.recoveryStoreMu.Unlock()
+	if s.recoveryStore == nil {
+		s.recoveryStore = newSQLiteRecoveryStore(s.conn())
+	}
+	return s.recoveryStore
+}
+
+// PutClientRecovery stores or replaces a client recovery record.
+func (s *SQLiteMetadataStore) PutClientRecovery(ctx context.Context, rec *lock.V4ClientRecoveryRecord) error {
+	return s.getRecoveryStore().PutClientRecovery(ctx, rec)
+}
+
+// DeleteClientRecovery removes a client recovery record.
+func (s *SQLiteMetadataStore) DeleteClientRecovery(ctx context.Context, clientIDString string) error {
+	return s.getRecoveryStore().DeleteClientRecovery(ctx, clientIDString)
+}
+
+// ListClientRecovery returns all stored client recovery records.
+func (s *SQLiteMetadataStore) ListClientRecovery(ctx context.Context) ([]*lock.V4ClientRecoveryRecord, error) {
+	return s.getRecoveryStore().ListClientRecovery(ctx)
+}
+
+// RecordReclaimComplete marks a client's recovery record reclaim-complete.
+func (s *SQLiteMetadataStore) RecordReclaimComplete(ctx context.Context, clientIDString string) error {
+	return s.getRecoveryStore().RecordReclaimComplete(ctx, clientIDString)
+}
+
+// ClientRecoveryStore returns this store as a ClientRecoveryStore.
+// This allows direct access to the interface for handler initialization.
+func (s *SQLiteMetadataStore) ClientRecoveryStore() lock.ClientRecoveryStore {
+	return s
+}

--- a/pkg/metadata/store/sqlite/clients.go
+++ b/pkg/metadata/store/sqlite/clients.go
@@ -1,0 +1,235 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// ============================================================================
+// SQLite ClientRegistrationStore Implementation
+// ============================================================================
+
+// sqliteClientStore implements lock.ClientRegistrationStore using SQLite.
+//
+// It persists NSM registrations across restarts for crash recovery.
+//
+// Storage Model:
+//   - nsm_client_registrations table: stores PersistedClientRegistration
+//   - Indexes on callback_host, registered_at, mon_name
+//
+// Thread Safety:
+// All operations use database transactions for atomicity.
+type sqliteClientStore struct {
+	pool execer
+}
+
+// newSQLiteClientStore creates a new SQLite client registration store.
+func newSQLiteClientStore(pool execer) *sqliteClientStore {
+	return &sqliteClientStore{
+		pool: pool,
+	}
+}
+
+// PutClientRegistration stores or updates a client registration using upsert.
+func (s *sqliteClientStore) PutClientRegistration(ctx context.Context, reg *lock.PersistedClientRegistration) error {
+	query := `
+		INSERT INTO nsm_client_registrations (
+			client_id, mon_name, priv, callback_host, callback_prog,
+			callback_vers, callback_proc, registered_at, server_epoch
+		)
+		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+		ON CONFLICT (client_id) DO UPDATE SET
+			mon_name = EXCLUDED.mon_name,
+			priv = EXCLUDED.priv,
+			callback_host = EXCLUDED.callback_host,
+			callback_prog = EXCLUDED.callback_prog,
+			callback_vers = EXCLUDED.callback_vers,
+			callback_proc = EXCLUDED.callback_proc,
+			registered_at = EXCLUDED.registered_at,
+			server_epoch = EXCLUDED.server_epoch
+	`
+
+	_, err := s.pool.Exec(ctx, query,
+		reg.ClientID,
+		reg.MonName,
+		reg.Priv[:], // Convert [16]byte to slice
+		reg.CallbackHost,
+		reg.CallbackProg,
+		reg.CallbackVers,
+		reg.CallbackProc,
+		reg.RegisteredAt,
+		reg.ServerEpoch,
+	)
+	return err
+}
+
+// GetClientRegistration retrieves a registration by client ID.
+func (s *sqliteClientStore) GetClientRegistration(ctx context.Context, clientID string) (*lock.PersistedClientRegistration, error) {
+	query := `
+		SELECT client_id, mon_name, priv, callback_host, callback_prog,
+		       callback_vers, callback_proc, registered_at, server_epoch
+		FROM nsm_client_registrations
+		WHERE client_id = ?1
+	`
+
+	var reg lock.PersistedClientRegistration
+	var privBytes []byte
+
+	err := s.pool.QueryRow(ctx, query, clientID).Scan(
+		&reg.ClientID,
+		&reg.MonName,
+		&privBytes,
+		&reg.CallbackHost,
+		&reg.CallbackProg,
+		&reg.CallbackVers,
+		&reg.CallbackProc,
+		&reg.RegisteredAt,
+		&reg.ServerEpoch,
+	)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil // Not found returns nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Copy priv bytes to fixed array
+	if len(privBytes) == 16 {
+		copy(reg.Priv[:], privBytes)
+	}
+
+	return &reg, nil
+}
+
+// DeleteClientRegistration removes a registration by client ID.
+func (s *sqliteClientStore) DeleteClientRegistration(ctx context.Context, clientID string) error {
+	query := `DELETE FROM nsm_client_registrations WHERE client_id = ?1`
+	_, err := s.pool.Exec(ctx, query, clientID)
+	return err
+}
+
+// ListClientRegistrations returns all stored registrations.
+func (s *sqliteClientStore) ListClientRegistrations(ctx context.Context) ([]*lock.PersistedClientRegistration, error) {
+	query := `
+		SELECT client_id, mon_name, priv, callback_host, callback_prog,
+		       callback_vers, callback_proc, registered_at, server_epoch
+		FROM nsm_client_registrations
+		ORDER BY registered_at
+	`
+
+	rows, err := s.pool.Query(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []*lock.PersistedClientRegistration
+	for rows.Next() {
+		var reg lock.PersistedClientRegistration
+		var privBytes []byte
+
+		err := rows.Scan(
+			&reg.ClientID,
+			&reg.MonName,
+			&privBytes,
+			&reg.CallbackHost,
+			&reg.CallbackProg,
+			&reg.CallbackVers,
+			&reg.CallbackProc,
+			&reg.RegisteredAt,
+			&reg.ServerEpoch,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(privBytes) == 16 {
+			copy(reg.Priv[:], privBytes)
+		}
+
+		result = append(result, &reg)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// DeleteAllClientRegistrations removes all registrations.
+func (s *sqliteClientStore) DeleteAllClientRegistrations(ctx context.Context) (int, error) {
+	query := `DELETE FROM nsm_client_registrations`
+	result, err := s.pool.Exec(ctx, query)
+	if err != nil {
+		return 0, err
+	}
+	return int(result.RowsAffected()), nil
+}
+
+// DeleteClientRegistrationsByMonName removes all registrations monitoring a specific host.
+func (s *sqliteClientStore) DeleteClientRegistrationsByMonName(ctx context.Context, monName string) (int, error) {
+	query := `DELETE FROM nsm_client_registrations WHERE mon_name = ?1`
+	result, err := s.pool.Exec(ctx, query, monName)
+	if err != nil {
+		return 0, err
+	}
+	return int(result.RowsAffected()), nil
+}
+
+// ============================================================================
+// SQLiteMetadataStore ClientRegistrationStore Integration
+// ============================================================================
+
+// Ensure SQLiteMetadataStore implements ClientRegistrationStore
+var _ lock.ClientRegistrationStore = (*SQLiteMetadataStore)(nil)
+
+// getClientStore returns the client store, initializing if needed.
+func (s *SQLiteMetadataStore) getClientStore() *sqliteClientStore {
+	s.clientStoreMu.Lock()
+	defer s.clientStoreMu.Unlock()
+	if s.clientStore == nil {
+		s.clientStore = newSQLiteClientStore(s.conn())
+	}
+	return s.clientStore
+}
+
+// PutClientRegistration stores or updates a client registration.
+func (s *SQLiteMetadataStore) PutClientRegistration(ctx context.Context, reg *lock.PersistedClientRegistration) error {
+	return s.getClientStore().PutClientRegistration(ctx, reg)
+}
+
+// GetClientRegistration retrieves a registration by client ID.
+func (s *SQLiteMetadataStore) GetClientRegistration(ctx context.Context, clientID string) (*lock.PersistedClientRegistration, error) {
+	return s.getClientStore().GetClientRegistration(ctx, clientID)
+}
+
+// DeleteClientRegistration removes a registration by client ID.
+func (s *SQLiteMetadataStore) DeleteClientRegistration(ctx context.Context, clientID string) error {
+	return s.getClientStore().DeleteClientRegistration(ctx, clientID)
+}
+
+// ListClientRegistrations returns all stored registrations.
+func (s *SQLiteMetadataStore) ListClientRegistrations(ctx context.Context) ([]*lock.PersistedClientRegistration, error) {
+	return s.getClientStore().ListClientRegistrations(ctx)
+}
+
+// DeleteAllClientRegistrations removes all registrations.
+func (s *SQLiteMetadataStore) DeleteAllClientRegistrations(ctx context.Context) (int, error) {
+	return s.getClientStore().DeleteAllClientRegistrations(ctx)
+}
+
+// DeleteClientRegistrationsByMonName removes all registrations monitoring a specific host.
+func (s *SQLiteMetadataStore) DeleteClientRegistrationsByMonName(ctx context.Context, monName string) (int, error) {
+	return s.getClientStore().DeleteClientRegistrationsByMonName(ctx, monName)
+}
+
+// ClientRegistrationStore returns this store as a ClientRegistrationStore.
+// This allows direct access to the interface for handler initialization.
+func (s *SQLiteMetadataStore) ClientRegistrationStore() lock.ClientRegistrationStore {
+	return s
+}

--- a/pkg/metadata/store/sqlite/config.go
+++ b/pkg/metadata/store/sqlite/config.go
@@ -1,0 +1,88 @@
+package sqlite
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// SQLiteMetadataStoreConfig holds the configuration for the SQLite metadata
+// store. SQLite is an embedded, single-file engine, so there is no host/port/
+// credential surface — the only required parameter is the on-disk database
+// path.
+type SQLiteMetadataStoreConfig struct {
+	// Path is the on-disk location of the SQLite database file. The special
+	// value ":memory:" opens an ephemeral in-memory database (used by tests).
+	Path string `mapstructure:"path" validate:"required"`
+
+	// BusyTimeout bounds how long a statement waits for the write lock held by
+	// another connection before returning SQLITE_BUSY. SQLite serializes
+	// writers; a generous busy timeout lets concurrent operations queue rather
+	// than fail. Default: 5s.
+	BusyTimeout time.Duration `mapstructure:"busy_timeout"`
+
+	// QueryTimeout bounds an individual statement. Default: 30s.
+	QueryTimeout time.Duration `mapstructure:"query_timeout"`
+
+	// AutoMigrate runs embedded migrations on open when true. Default: false
+	// (the factory enables it explicitly, matching the Postgres backend).
+	AutoMigrate bool `mapstructure:"auto_migrate"`
+
+	// StatsCacheTTL is retained for parity with the Postgres config surface.
+	// Default: 5s.
+	StatsCacheTTL time.Duration `mapstructure:"stats_cache_ttl"`
+}
+
+// ApplyDefaults sets default values for unspecified configuration fields.
+func (c *SQLiteMetadataStoreConfig) ApplyDefaults() {
+	if c.BusyTimeout == 0 {
+		c.BusyTimeout = 5 * time.Second
+	}
+	if c.QueryTimeout == 0 {
+		c.QueryTimeout = 30 * time.Second
+	}
+	if c.StatsCacheTTL == 0 {
+		c.StatsCacheTTL = 5 * time.Second
+	}
+}
+
+// Validate checks the configuration for required fields and sane values.
+func (c *SQLiteMetadataStoreConfig) Validate() error {
+	if strings.TrimSpace(c.Path) == "" {
+		return fmt.Errorf("sqlite metadata store requires a non-empty path")
+	}
+	return nil
+}
+
+// DSN builds the database/sql data-source string for modernc.org/sqlite.
+//
+// Foreign-key enforcement is OFF by default in SQLite; the schema relies on
+// ON DELETE CASCADE (parent_child_map, file_block_refs), so it MUST be enabled
+// per connection. busy_timeout (milliseconds) lets writers queue behind the
+// single-writer lock instead of failing immediately. journal_mode=WAL improves
+// read/write concurrency for the embedded single-binary workload this store
+// targets. The pragmas are passed via the `_pragma` query parameters that
+// modernc.org/sqlite recognises, so they apply to every pooled connection.
+func (c *SQLiteMetadataStoreConfig) DSN() string {
+	// An in-memory database must be shared across the connection pool, otherwise
+	// each connection would see its own empty database. The "file::memory:" +
+	// cache=shared form gives all connections in the pool one shared in-memory
+	// database for the process lifetime.
+	path := c.Path
+	if path == ":memory:" {
+		path = "file::memory:?cache=shared"
+	}
+
+	sep := "?"
+	if strings.Contains(path, "?") {
+		sep = "&"
+	}
+	busyMS := c.BusyTimeout.Milliseconds()
+	if busyMS <= 0 {
+		busyMS = 5000
+	}
+	return fmt.Sprintf(
+		"%s%s_pragma=foreign_keys(1)&_pragma=busy_timeout(%d)&_pragma=journal_mode(WAL)",
+		path, sep, busyMS,
+	)
+}

--- a/pkg/metadata/store/sqlite/durable_handles.go
+++ b/pkg/metadata/store/sqlite/durable_handles.go
@@ -1,0 +1,448 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// sqliteDurableStore implements lock.DurableHandleStore using SQLite.
+type sqliteDurableStore struct {
+	pool execer
+}
+
+func newSQLiteDurableStore(pool execer) *sqliteDurableStore {
+	return &sqliteDurableStore{
+		pool: pool,
+	}
+}
+
+const durableHandleColumns = `
+	id, file_id, path, share_name, desired_access, granted_access, share_access,
+	create_options, metadata_handle, payload_id, oplock_level,
+	lease_key, lease_state, lease_epoch, create_guid, app_instance_id,
+	username, session_key_hash, is_v2, created_at, disconnected_at,
+	timeout_ms, server_start_time,
+	delete_pending, parent_handle, file_name, is_directory,
+	position_info, original_file_id, requested_alloc_size, is_persistent
+`
+
+func scanDurableHandle(row scanRow) (*lock.PersistedDurableHandle, error) {
+	var h lock.PersistedDurableHandle
+	var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes []byte
+	var positionInfoSigned, requestedAllocSizeSigned int64
+	var leaseEpochSigned int32
+
+	err := row.Scan(
+		&h.ID,
+		&fileIDBytes,
+		&h.Path,
+		&h.ShareName,
+		&h.DesiredAccess,
+		&h.GrantedAccess,
+		&h.ShareAccess,
+		&h.CreateOptions,
+		&h.MetadataHandle,
+		&h.PayloadID,
+		&h.OplockLevel,
+		&leaseKeyBytes,
+		&h.LeaseState,
+		&leaseEpochSigned,
+		&createGuidBytes,
+		&appInstanceIdBytes,
+		&h.Username,
+		&sessionKeyHashBytes,
+		&h.IsV2,
+		&h.CreatedAt,
+		&h.DisconnectedAt,
+		&h.TimeoutMs,
+		&h.ServerStartTime,
+		&h.DeletePending,
+		&h.ParentHandle,
+		&h.FileName,
+		&h.IsDirectory,
+		&positionInfoSigned,
+		&originalFileIDBytes,
+		&requestedAllocSizeSigned,
+		&h.IsPersistent,
+	)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	h.LeaseEpoch = uint16(leaseEpochSigned)
+	h.PositionInfo = uint64(positionInfoSigned)
+	h.RequestedAllocSize = uint64(requestedAllocSizeSigned)
+	copyFixedByteArrays(&h, fileIDBytes, leaseKeyBytes, createGuidBytes,
+		appInstanceIdBytes, sessionKeyHashBytes)
+	if len(originalFileIDBytes) == 16 {
+		copy(h.OriginalFileID[:], originalFileIDBytes)
+	}
+	return &h, nil
+}
+
+func scanDurableHandleRows(rows scanRows) ([]*lock.PersistedDurableHandle, error) {
+	defer rows.Close()
+
+	var result []*lock.PersistedDurableHandle
+	for rows.Next() {
+		var h lock.PersistedDurableHandle
+		var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes []byte
+		var positionInfoSigned, requestedAllocSizeSigned int64
+		var leaseEpochSigned int32
+
+		err := rows.Scan(
+			&h.ID,
+			&fileIDBytes,
+			&h.Path,
+			&h.ShareName,
+			&h.DesiredAccess,
+			&h.GrantedAccess,
+			&h.ShareAccess,
+			&h.CreateOptions,
+			&h.MetadataHandle,
+			&h.PayloadID,
+			&h.OplockLevel,
+			&leaseKeyBytes,
+			&h.LeaseState,
+			&leaseEpochSigned,
+			&createGuidBytes,
+			&appInstanceIdBytes,
+			&h.Username,
+			&sessionKeyHashBytes,
+			&h.IsV2,
+			&h.CreatedAt,
+			&h.DisconnectedAt,
+			&h.TimeoutMs,
+			&h.ServerStartTime,
+			&h.DeletePending,
+			&h.ParentHandle,
+			&h.FileName,
+			&h.IsDirectory,
+			&positionInfoSigned,
+			&originalFileIDBytes,
+			&requestedAllocSizeSigned,
+			&h.IsPersistent,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		h.LeaseEpoch = uint16(leaseEpochSigned)
+		h.PositionInfo = uint64(positionInfoSigned)
+		h.RequestedAllocSize = uint64(requestedAllocSizeSigned)
+		copyFixedByteArrays(&h, fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes)
+		if len(originalFileIDBytes) == 16 {
+			copy(h.OriginalFileID[:], originalFileIDBytes)
+		}
+		result = append(result, &h)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func copyFixedByteArrays(h *lock.PersistedDurableHandle, fileID, leaseKey, createGuid, appInstanceId, sessionKeyHash []byte) {
+	if len(fileID) == 16 {
+		copy(h.FileID[:], fileID)
+	}
+	if len(leaseKey) == 16 {
+		copy(h.LeaseKey[:], leaseKey)
+	}
+	if len(createGuid) == 16 {
+		copy(h.CreateGuid[:], createGuid)
+	}
+	if len(appInstanceId) == 16 {
+		copy(h.AppInstanceId[:], appInstanceId)
+	}
+	if len(sessionKeyHash) == 32 {
+		copy(h.SessionKeyHash[:], sessionKeyHash)
+	}
+}
+
+// nullableBytes16 returns nil for zero-value [16]byte arrays (stored as NULL).
+func nullableBytes16(b [16]byte) []byte {
+	var zero [16]byte
+	if b == zero {
+		return nil
+	}
+	return b[:]
+}
+
+func (s *sqliteDurableStore) PutDurableHandle(ctx context.Context, handle *lock.PersistedDurableHandle) error {
+	query := `
+		INSERT INTO durable_handles (
+			id, file_id, path, share_name, desired_access, granted_access, share_access,
+			create_options, metadata_handle, payload_id, oplock_level,
+			lease_key, lease_state, create_guid, app_instance_id,
+			username, session_key_hash, is_v2, created_at, disconnected_at,
+			timeout_ms, server_start_time,
+			delete_pending, parent_handle, file_name, is_directory,
+			position_info, original_file_id, requested_alloc_size,
+			lease_epoch, is_persistent
+		)
+		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31)
+		ON CONFLICT (id) DO UPDATE SET
+			file_id = EXCLUDED.file_id,
+			path = EXCLUDED.path,
+			share_name = EXCLUDED.share_name,
+			desired_access = EXCLUDED.desired_access,
+			granted_access = EXCLUDED.granted_access,
+			share_access = EXCLUDED.share_access,
+			create_options = EXCLUDED.create_options,
+			metadata_handle = EXCLUDED.metadata_handle,
+			payload_id = EXCLUDED.payload_id,
+			oplock_level = EXCLUDED.oplock_level,
+			lease_key = EXCLUDED.lease_key,
+			lease_state = EXCLUDED.lease_state,
+			create_guid = EXCLUDED.create_guid,
+			app_instance_id = EXCLUDED.app_instance_id,
+			username = EXCLUDED.username,
+			session_key_hash = EXCLUDED.session_key_hash,
+			is_v2 = EXCLUDED.is_v2,
+			created_at = EXCLUDED.created_at,
+			disconnected_at = EXCLUDED.disconnected_at,
+			timeout_ms = EXCLUDED.timeout_ms,
+			server_start_time = EXCLUDED.server_start_time,
+			delete_pending = EXCLUDED.delete_pending,
+			parent_handle = EXCLUDED.parent_handle,
+			file_name = EXCLUDED.file_name,
+			is_directory = EXCLUDED.is_directory,
+			position_info = EXCLUDED.position_info,
+			original_file_id = EXCLUDED.original_file_id,
+			requested_alloc_size = EXCLUDED.requested_alloc_size,
+			lease_epoch = EXCLUDED.lease_epoch,
+			is_persistent = EXCLUDED.is_persistent
+	`
+
+	_, err := s.pool.Exec(ctx, query,
+		handle.ID,
+		handle.FileID[:],
+		handle.Path,
+		handle.ShareName,
+		handle.DesiredAccess,
+		handle.GrantedAccess,
+		handle.ShareAccess,
+		handle.CreateOptions,
+		handle.MetadataHandle,
+		handle.PayloadID,
+		handle.OplockLevel,
+		nullableBytes16(handle.LeaseKey),
+		handle.LeaseState,
+		nullableBytes16(handle.CreateGuid),
+		nullableBytes16(handle.AppInstanceId),
+		handle.Username,
+		handle.SessionKeyHash[:],
+		handle.IsV2,
+		handle.CreatedAt,
+		handle.DisconnectedAt,
+		handle.TimeoutMs,
+		handle.ServerStartTime,
+		handle.DeletePending,
+		handle.ParentHandle,
+		handle.FileName,
+		handle.IsDirectory,
+		// PositionInfo is a file offset (FILE_POSITION_INFORMATION.CurrentByteOffset,
+		// MS-FSCC 2.4.32) stored as BIGINT (signed int64). File offsets fit in
+		// int64 in practice; reinterpret the bit pattern to preserve any high-bit
+		// value. The scan path mirrors this with uint64(int64) on read.
+		int64(handle.PositionInfo),
+		handle.OriginalFileID[:],
+		// RequestedAllocSize is a client-requested allocation reservation
+		// ([MS-SMB2] 2.2.13.2.2) stored as BIGINT (signed int64), reinterpreting
+		// the bit pattern like PositionInfo. The scan path mirrors this with
+		// uint64(int64) on read.
+		int64(handle.RequestedAllocSize),
+		// LeaseEpoch is the SMB3 lease-V2 epoch (uint16) stored as INTEGER.
+		// The scan path mirrors this with uint16(int32) on read.
+		int32(handle.LeaseEpoch),
+		// IsPersistent marks a persistent durable handle granted on a CA share
+		// (#739) so a reconnect re-echoes the DH2Q PERSISTENT flag.
+		handle.IsPersistent,
+	)
+	return err
+}
+
+func (s *sqliteDurableStore) GetDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
+	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE id = ?1`
+	return scanDurableHandle(s.pool.QueryRow(ctx, query, id))
+}
+
+func (s *sqliteDurableStore) GetDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
+	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE file_id = ?1 LIMIT 1`
+	return scanDurableHandle(s.pool.QueryRow(ctx, query, fileID[:]))
+}
+
+func (s *sqliteDurableStore) GetDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
+	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE create_guid = ?1 LIMIT 1`
+	return scanDurableHandle(s.pool.QueryRow(ctx, query, createGuid[:]))
+}
+
+// ConsumeDurableHandleByFileID atomically fetches and deletes via
+// `DELETE ... RETURNING`, closing the V1 reconnect TOCTOU window.
+func (s *sqliteDurableStore) ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
+	query := `DELETE FROM durable_handles WHERE file_id = ?1 RETURNING ` + durableHandleColumns
+	return scanDurableHandle(s.pool.QueryRow(ctx, query, fileID[:]))
+}
+
+// ConsumeDurableHandleByCreateGuid is the V2 counterpart.
+func (s *sqliteDurableStore) ConsumeDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
+	query := `DELETE FROM durable_handles WHERE create_guid = ?1 RETURNING ` + durableHandleColumns
+	return scanDurableHandle(s.pool.QueryRow(ctx, query, createGuid[:]))
+}
+
+func (s *sqliteDurableStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {
+	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE app_instance_id = ?1 ORDER BY created_at`
+	rows, err := s.pool.Query(ctx, query, appInstanceId[:])
+	if err != nil {
+		return nil, err
+	}
+	return scanDurableHandleRows(rows)
+}
+
+func (s *sqliteDurableStore) GetDurableHandlesByFileHandle(ctx context.Context, fileHandle []byte) ([]*lock.PersistedDurableHandle, error) {
+	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE metadata_handle = ?1 ORDER BY created_at`
+	rows, err := s.pool.Query(ctx, query, fileHandle)
+	if err != nil {
+		return nil, err
+	}
+	return scanDurableHandleRows(rows)
+}
+
+func (s *sqliteDurableStore) DeleteDurableHandle(ctx context.Context, id string) error {
+	query := `DELETE FROM durable_handles WHERE id = ?1`
+	_, err := s.pool.Exec(ctx, query, id)
+	return err
+}
+
+func (s *sqliteDurableStore) ListDurableHandles(ctx context.Context) ([]*lock.PersistedDurableHandle, error) {
+	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles ORDER BY created_at`
+	rows, err := s.pool.Query(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	return scanDurableHandleRows(rows)
+}
+
+func (s *sqliteDurableStore) ListDurableHandlesByShare(ctx context.Context, shareName string) ([]*lock.PersistedDurableHandle, error) {
+	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE share_name = ?1 ORDER BY created_at`
+	rows, err := s.pool.Query(ctx, query, shareName)
+	if err != nil {
+		return nil, err
+	}
+	return scanDurableHandleRows(rows)
+}
+
+func (s *sqliteDurableStore) DeleteExpiredDurableHandles(ctx context.Context, now time.Time) (int, error) {
+	// SQLite has no interval arithmetic, and modernc stores time.Time in a
+	// textual layout SQLite's date functions cannot parse. So compute expiry in
+	// Go: a handle is expired when disconnected_at + timeout_ms <= now. Read the
+	// candidate (id, disconnected_at, timeout_ms) tuples, then delete the
+	// expired ids. The two statements run on the same single-writer connection,
+	// so no handle can change its expiry in between.
+	rows, err := s.pool.Query(ctx,
+		`SELECT id, disconnected_at, timeout_ms FROM durable_handles`)
+	if err != nil {
+		return 0, err
+	}
+	var expired []string
+	for rows.Next() {
+		var id string
+		var disconnectedAt time.Time
+		var timeoutMS int64
+		if err := rows.Scan(&id, &disconnectedAt, &timeoutMS); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		if !disconnectedAt.Add(time.Duration(timeoutMS) * time.Millisecond).After(now) {
+			expired = append(expired, id)
+		}
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	for _, id := range expired {
+		if _, err := s.pool.Exec(ctx, `DELETE FROM durable_handles WHERE id = ?1`, id); err != nil {
+			return 0, err
+		}
+	}
+	return len(expired), nil
+}
+
+// SQLiteMetadataStore DurableHandleStore delegation
+
+var _ lock.DurableHandleStore = (*SQLiteMetadataStore)(nil)
+
+func (s *SQLiteMetadataStore) getDurableStore() *sqliteDurableStore {
+	s.durableStoreMu.Lock()
+	defer s.durableStoreMu.Unlock()
+	if s.durableStore == nil {
+		s.durableStore = newSQLiteDurableStore(s.conn())
+	}
+	return s.durableStore
+}
+
+func (s *SQLiteMetadataStore) PutDurableHandle(ctx context.Context, handle *lock.PersistedDurableHandle) error {
+	return s.getDurableStore().PutDurableHandle(ctx, handle)
+}
+
+func (s *SQLiteMetadataStore) GetDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
+	return s.getDurableStore().GetDurableHandle(ctx, id)
+}
+
+func (s *SQLiteMetadataStore) GetDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
+	return s.getDurableStore().GetDurableHandleByFileID(ctx, fileID)
+}
+
+func (s *SQLiteMetadataStore) GetDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
+	return s.getDurableStore().GetDurableHandleByCreateGuid(ctx, createGuid)
+}
+
+func (s *SQLiteMetadataStore) ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
+	return s.getDurableStore().ConsumeDurableHandleByFileID(ctx, fileID)
+}
+
+func (s *SQLiteMetadataStore) ConsumeDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
+	return s.getDurableStore().ConsumeDurableHandleByCreateGuid(ctx, createGuid)
+}
+
+func (s *SQLiteMetadataStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {
+	return s.getDurableStore().GetDurableHandlesByAppInstanceId(ctx, appInstanceId)
+}
+
+func (s *SQLiteMetadataStore) GetDurableHandlesByFileHandle(ctx context.Context, fileHandle []byte) ([]*lock.PersistedDurableHandle, error) {
+	return s.getDurableStore().GetDurableHandlesByFileHandle(ctx, fileHandle)
+}
+
+func (s *SQLiteMetadataStore) DeleteDurableHandle(ctx context.Context, id string) error {
+	return s.getDurableStore().DeleteDurableHandle(ctx, id)
+}
+
+func (s *SQLiteMetadataStore) ListDurableHandles(ctx context.Context) ([]*lock.PersistedDurableHandle, error) {
+	return s.getDurableStore().ListDurableHandles(ctx)
+}
+
+func (s *SQLiteMetadataStore) ListDurableHandlesByShare(ctx context.Context, shareName string) ([]*lock.PersistedDurableHandle, error) {
+	return s.getDurableStore().ListDurableHandlesByShare(ctx, shareName)
+}
+
+func (s *SQLiteMetadataStore) DeleteExpiredDurableHandles(ctx context.Context, now time.Time) (int, error) {
+	return s.getDurableStore().DeleteExpiredDurableHandles(ctx, now)
+}
+
+// DurableHandleStore returns this store as a DurableHandleStore.
+func (s *SQLiteMetadataStore) DurableHandleStore() lock.DurableHandleStore {
+	return s
+}

--- a/pkg/metadata/store/sqlite/encoding.go
+++ b/pkg/metadata/store/sqlite/encoding.go
@@ -1,0 +1,298 @@
+package sqlite
+
+import (
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+)
+
+// ============================================================================
+// File Handle Encoding/Decoding
+// ============================================================================
+
+// encodeFileHandle creates a file handle from share name and UUID string
+func encodeFileHandle(shareName string, idStr string) (metadata.FileHandle, error) {
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		return nil, err
+	}
+	return metadata.EncodeShareHandle(shareName, id)
+}
+
+// ============================================================================
+// Timestamp Encoding (INTEGER nanoseconds, lossless FILETIME parity)
+// ============================================================================
+//
+// File timestamps are stored as INTEGER unix nanoseconds so sub-microsecond
+// FILETIME values round-trip losslessly, on par with the memory/badger
+// backends (#882). A zero time.Time maps to 0 and back, matching the
+// zero-value semantics those backends use.
+
+// timeToNanos converts a time.Time to the INTEGER unix-nanosecond value stored
+// in the files timestamp columns. The zero time maps to 0.
+func timeToNanos(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.UnixNano()
+}
+
+// nanosToTime converts a stored INTEGER unix-nanosecond value back to a UTC
+// time.Time. 0 maps to the zero time.Time.
+func nanosToTime(n int64) time.Time {
+	if n == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, n).UTC()
+}
+
+// ============================================================================
+// Database Row Serialization
+// ============================================================================
+
+// fileRowToFileWithNlink converts a database row to a File struct, including link count.
+// Expected columns: id, share_name, path, file_type, mode, uid, gid, size,
+// atime, mtime, ctime, creation_time, content_id, link_target, device_major, device_minor, hidden, acl, eas, object_id, deleted_at, original_path, deleted_by, nlink
+//
+// The `path` column is no longer stored on the inode (#1166); callers supply it
+// as a reconstructed expression (inodePathExpr) walking parent_child_map up to
+// the share root. For a hard-linked inode this yields one of its paths.
+func fileRowToFileWithNlink(r scanRow) (*metadata.File, error) {
+	return fileRowToFileWithNlinkAndBlocks(r, false)
+}
+
+// fileRowToFileWithNlinkAndBlocks decodes a file row that optionally carries a
+// trailing blocks column. When withBlocks is true the SELECT list MUST append
+// blockRefsAggExpr as its final column; the row's FileAttr.Blocks is then
+// hydrated in the same round-trip rather than via a second loadFileBlockRefs
+// query (#1176). With withBlocks=false this is identical to the pre-#1176 read.
+//
+// The folded aggregate is ordered by "offset" ASC and decoded into the same
+// []block.BlockRef shape loadFileBlockRefs produces — an empty/absent set
+// (directories, symlinks, blockless regular files) yields a nil slice.
+func fileRowToFileWithNlinkAndBlocks(r scanRow, withBlocks bool) (*metadata.File, error) {
+	var (
+		id           uuid.UUID
+		shareName    string
+		path         string
+		fileType     int16
+		mode         int32
+		uid          int32
+		gid          int32
+		size         int64
+		atime        int64
+		mtime        int64
+		ctime        int64
+		creationTime int64
+		payloadID    sql.NullString
+		linkTarget   sql.NullString
+		deviceMajor  sql.NullInt32
+		deviceMinor  sql.NullInt32
+		hidden       bool
+		aclJSON      []byte
+		easJSON      []byte
+		objectIDRaw  []byte
+		deletedAt    sql.NullInt64
+		originalPath string
+		deletedBy    string
+		nlink        int32
+		blocksJSON   []byte
+	)
+
+	dest := []any{
+		&id,
+		&shareName,
+		&path,
+		&fileType,
+		&mode,
+		&uid,
+		&gid,
+		&size,
+		&atime,
+		&mtime,
+		&ctime,
+		&creationTime,
+		&payloadID,
+		&linkTarget,
+		&deviceMajor,
+		&deviceMinor,
+		&hidden,
+		&aclJSON,
+		&easJSON,
+		&objectIDRaw,
+		&deletedAt,
+		&originalPath,
+		&deletedBy,
+		&nlink,
+	}
+	if withBlocks {
+		dest = append(dest, &blocksJSON)
+	}
+
+	if err := r.Scan(dest...); err != nil {
+		return nil, err
+	}
+
+	file := &metadata.File{
+		ID:        id,
+		ShareName: shareName,
+		Path:      path,
+		FileAttr: metadata.FileAttr{
+			Type:         metadata.FileType(fileType),
+			Mode:         uint32(mode),
+			UID:          uint32(uid),
+			GID:          uint32(gid),
+			Nlink:        uint32(nlink),
+			Size:         uint64(size),
+			Atime:        nanosToTime(atime),
+			Mtime:        nanosToTime(mtime),
+			Ctime:        nanosToTime(ctime),
+			CreationTime: nanosToTime(creationTime),
+			Hidden:       hidden,
+		},
+	}
+
+	// Handle nullable fields
+	if payloadID.Valid {
+		file.PayloadID = metadata.PayloadID(payloadID.String)
+	}
+
+	if linkTarget.Valid {
+		file.LinkTarget = linkTarget.String
+	}
+
+	// Populate Rdev for device files
+	if deviceMajor.Valid && deviceMinor.Valid {
+		file.Rdev = metadata.MakeRdev(uint32(deviceMajor.Int32), uint32(deviceMinor.Int32))
+	}
+
+	// Unmarshal ACL from JSONB if present
+	if len(aclJSON) > 0 {
+		var fileACL acl.ACL
+		if err := json.Unmarshal(aclJSON, &fileACL); err == nil {
+			file.ACL = &fileACL
+		}
+	}
+
+	// Unmarshal extended attributes from JSONB if present. A malformed row is
+	// treated as "no EAs" rather than failing the whole read.
+	if len(easJSON) > 0 {
+		var eas map[string][]byte
+		if err := json.Unmarshal(easJSON, &eas); err == nil && len(eas) > 0 {
+			file.EAs = eas
+		}
+	}
+
+	// object_id BLOB -> FileAttr.ObjectID.
+	// NULL or empty -> ObjectID stays zero (sentinel: never quiesced).
+	if len(objectIDRaw) > 0 {
+		if len(objectIDRaw) != block.HashSize {
+			return nil, fmt.Errorf(
+				"fileRowToFileWithNlink: object_id has invalid length %d (want %d)",
+				len(objectIDRaw), block.HashSize,
+			)
+		}
+		copy(file.ObjectID[:], objectIDRaw)
+	}
+
+	// Recycle-bin metadata (#190). deleted_at is INTEGER unix-nanoseconds (like
+	// the other file timestamps): NULL -> live node (nil pointer); a valid value
+	// decodes via nanosToTime for lossless nanosecond round-trip.
+	// original_path / deleted_by default to '' for live nodes.
+	if deletedAt.Valid {
+		t := nanosToTime(deletedAt.Int64)
+		file.DeletedAt = &t
+	}
+	file.OriginalPath = originalPath
+	file.DeletedBy = deletedBy
+
+	// Folded block refs (#1176): when the SELECT appended blockRefsAggExpr,
+	// hydrate FileAttr.Blocks from that aggregate rather than a second query.
+	if withBlocks && len(blocksJSON) > 0 {
+		blocks, err := decodeBlockRefsJSON(blocksJSON)
+		if err != nil {
+			return nil, err
+		}
+		file.Blocks = blocks
+	}
+
+	return file, nil
+}
+
+// blockRefsAggExpr is a correlated scalar subquery aggregating a file's
+// file_block_refs rows into a single JSON array, ordered by "offset" ASC to
+// match loadFileBlockRefs. Splice it as the FINAL column of
+// a SELECT whose inode row is aliased `f` (it references f.id) and decode the
+// result with fileRowToFileWithNlinkAndBlocks(row, true).
+//
+// Each element is [offset, size, hash_hex]; hash is lower(hex(...)) so the
+// BLOB round-trips byte-for-byte. An inode with no refs yields a JSON empty
+// array '[]', which decodes to a nil slice (parity with loadFileBlockRefs on an
+// empty set).
+//
+// SQLite's json_group_array does not accept an inner ORDER BY, so the rows are
+// ordered by "offset" ASC in a derived subquery before aggregation.
+const blockRefsAggExpr = `(
+	SELECT json_group_array(json_array(fbr."offset", fbr.size, lower(hex(fbr.hash))))
+	FROM (
+		SELECT "offset", size, hash
+		FROM file_block_refs
+		WHERE file_id = f.id
+		ORDER BY "offset" ASC
+	) AS fbr
+)`
+
+// decodeBlockRefsJSON decodes the JSON array produced by blockRefsAggExpr into
+// []block.BlockRef, applying the same hash-length validation as
+// loadFileBlockRefs (a malformed hash is surfaced as an error, never coerced to
+// a half-decoded ref).
+func decodeBlockRefsJSON(raw []byte) ([]block.BlockRef, error) {
+	// Element shape: [offset(int64), size(int32), hash_hex(string)].
+	var rows [][3]json.RawMessage
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		return nil, fmt.Errorf("decode folded block refs: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	out := make([]block.BlockRef, 0, len(rows))
+	for _, r := range rows {
+		var (
+			off     int64
+			sz      int32
+			hashHex string
+		)
+		if err := json.Unmarshal(r[0], &off); err != nil {
+			return nil, fmt.Errorf("decode folded block ref offset: %w", err)
+		}
+		if err := json.Unmarshal(r[1], &sz); err != nil {
+			return nil, fmt.Errorf("decode folded block ref size: %w", err)
+		}
+		if err := json.Unmarshal(r[2], &hashHex); err != nil {
+			return nil, fmt.Errorf("decode folded block ref hash: %w", err)
+		}
+		rawHash, err := hex.DecodeString(hashHex)
+		if err != nil {
+			return nil, fmt.Errorf("decode folded block ref hash hex: %w", err)
+		}
+		if len(rawHash) != block.HashSize {
+			return nil, fmt.Errorf(
+				"folded block ref hash has unexpected length %d (want %d)",
+				len(rawHash), block.HashSize,
+			)
+		}
+		var br block.BlockRef
+		copy(br.Hash[:], rawHash)
+		br.Offset = uint64(off)
+		br.Size = uint32(sz)
+		out = append(out, br)
+	}
+	return out, nil
+}

--- a/pkg/metadata/store/sqlite/errors.go
+++ b/pkg/metadata/store/sqlite/errors.go
@@ -133,5 +133,8 @@ func isBusyError(err error) bool {
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "database is locked") ||
 		strings.Contains(msg, "database table is locked") ||
-		strings.Contains(msg, "sqlite_busy")
+		strings.Contains(msg, "sqlite_busy") ||
+		// mapDBError rewrites busy/locked driver errors to this message before
+		// they reach WithTransaction's retry check, so match it too.
+		strings.Contains(msg, "database busy")
 }

--- a/pkg/metadata/store/sqlite/errors.go
+++ b/pkg/metadata/store/sqlite/errors.go
@@ -1,0 +1,137 @@
+package sqlite
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// mapDBError maps SQLite/database errors to metadata store errors.
+//
+// modernc.org/sqlite surfaces constraint and busy conditions through the error
+// string, so classification is done by inspecting the message. The high-value
+// cases — not-found, unique violation (with the object_id dedup sub-case),
+// foreign-key violation, NOT NULL, and busy/locked — are mapped to the same
+// metadata.StoreError codes the Postgres backend emits, keeping the conformance
+// suite backend-agnostic.
+func mapDBError(err error, operation, path string) error {
+	if err == nil {
+		return nil
+	}
+
+	// Already a StoreError (e.g. from a validation helper): pass through.
+	var storeErr *metadata.StoreError
+	if errors.As(err, &storeErr) {
+		return storeErr
+	}
+
+	// Not found.
+	if errors.Is(err, sql.ErrNoRows) {
+		return &metadata.StoreError{
+			Code:    metadata.ErrNotFound,
+			Message: fmt.Sprintf("%s: not found", operation),
+			Path:    path,
+		}
+	}
+
+	msg := strings.ToLower(err.Error())
+
+	switch {
+	// UNIQUE / PRIMARY KEY constraint violation.
+	case strings.Contains(msg, "unique constraint") ||
+		strings.Contains(msg, "primary key constraint") ||
+		strings.Contains(msg, "constraint failed: unique"):
+		// The inodes_object_id_idx partial unique index enforces one ObjectID
+		// per file. A second byte-identical file trips it; the rollup persist
+		// path treats that as a BENIGN conflict (the duplicate's blocks are
+		// already covered by the canonical file's manifest), so surface it as
+		// ErrConflict rather than ErrAlreadyExists. The index name appears in
+		// the SQLite constraint error text.
+		if strings.Contains(msg, "object_id") || strings.Contains(msg, "inodes_object_id_idx") {
+			return &metadata.StoreError{
+				Code:    metadata.ErrConflict,
+				Message: fmt.Sprintf("%s: object_id already mapped to another file", operation),
+				Path:    path,
+			}
+		}
+		return &metadata.StoreError{
+			Code:    metadata.ErrAlreadyExists,
+			Message: fmt.Sprintf("%s: already exists", operation),
+			Path:    path,
+		}
+
+	// FOREIGN KEY constraint violation: a referenced row is missing.
+	case strings.Contains(msg, "foreign key constraint"):
+		return &metadata.StoreError{
+			Code:    metadata.ErrNotFound,
+			Message: fmt.Sprintf("%s: referenced item not found", operation),
+			Path:    path,
+		}
+
+	// CHECK constraint violation.
+	case strings.Contains(msg, "check constraint") || strings.Contains(msg, "constraint failed: check"):
+		if strings.Contains(msg, "non_empty") {
+			return &metadata.StoreError{
+				Code:    metadata.ErrNotEmpty,
+				Message: fmt.Sprintf("%s: directory not empty", operation),
+				Path:    path,
+			}
+		}
+		return &metadata.StoreError{
+			Code:    metadata.ErrInvalidArgument,
+			Message: fmt.Sprintf("%s: invalid value", operation),
+			Path:    path,
+		}
+
+	// NOT NULL constraint violation.
+	case strings.Contains(msg, "not null constraint"):
+		return &metadata.StoreError{
+			Code:    metadata.ErrInvalidArgument,
+			Message: fmt.Sprintf("%s: missing required field", operation),
+			Path:    path,
+		}
+
+	// Busy / locked: contention under the single-writer engine. Mapped to an
+	// I/O error and flagged retryable via Cause so WithTransaction retries.
+	case strings.Contains(msg, "database is locked") ||
+		strings.Contains(msg, "database table is locked") ||
+		strings.Contains(msg, "sqlite_busy"):
+		return &metadata.StoreError{
+			Code:    metadata.ErrIOError,
+			Message: fmt.Sprintf("%s: database busy, retry", operation),
+			Path:    path,
+			Cause:   err,
+		}
+
+	// Disk full.
+	case strings.Contains(msg, "database or disk is full"):
+		return &metadata.StoreError{
+			Code:    metadata.ErrNoSpace,
+			Message: fmt.Sprintf("%s: no space available", operation),
+			Path:    path,
+		}
+
+	default:
+		return &metadata.StoreError{
+			Code:    metadata.ErrIOError,
+			Message: fmt.Sprintf("%s: database error: %v", operation, err),
+			Path:    path,
+		}
+	}
+}
+
+// isBusyError reports whether err is a SQLite busy/locked condition that a
+// transaction can retry. Mirrors the Postgres isRetryableError (deadlock /
+// serialization-failure) role for the embedded engine.
+func isBusyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "database is locked") ||
+		strings.Contains(msg, "database table is locked") ||
+		strings.Contains(msg, "sqlite_busy")
+}

--- a/pkg/metadata/store/sqlite/file_block_refs.go
+++ b/pkg/metadata/store/sqlite/file_block_refs.go
@@ -1,0 +1,164 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+// ============================================================================
+// file_block_refs CRUD
+// ============================================================================
+//
+// Stores FileAttr.Blocks []block.BlockRef rows for files. Per
+// we use a separate table (not JSONB on files) to avoid TOAST write
+// amplification on the VM-primary workload.
+//
+// All helpers operate against a pgx.Tx so that PutFile's BlockRef replace
+// happens atomically with the files row UPDATE.
+//
+// Schema lives in migrations/000012_file_block_refs.up.sql.
+
+// putFileBlockRefs replaces all rows in file_block_refs for fileID with
+// the given blocks. Atomic when called inside a pgx.Tx (the caller's tx).
+//
+// Implementation: DELETE+INSERT. Engine-bug paths are defended by the
+// (file_id, "offset") PK — a duplicate offset would be rejected. The
+// DELETE first ensures stale offsets from a prior list are not left
+// behind when the new list is shorter.
+func putFileBlockRefs(ctx context.Context, tx execer, fileID uuid.UUID, blocks []block.BlockRef) error {
+	if _, err := tx.Exec(ctx, `DELETE FROM file_block_refs WHERE file_id = ?1`, fileID); err != nil {
+		return fmt.Errorf("delete file_block_refs for %s: %w", fileID, err)
+	}
+	if len(blocks) == 0 {
+		return nil
+	}
+	// SQLite has no batch protocol; insert each ref with a prepared-statement
+	// reuse via the same tx connection. The (file_id, "offset") PK rejects a
+	// duplicate offset.
+	for _, b := range blocks {
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO file_block_refs (file_id, "offset", size, hash) VALUES (?1, ?2, ?3, ?4)`,
+			fileID, int64(b.Offset), int32(b.Size), b.Hash[:],
+		); err != nil {
+			return fmt.Errorf("insert file_block_ref: %w", err)
+		}
+	}
+	return nil
+}
+
+// deleteFileBlockRefs removes all rows for fileID. The FK cascade
+// handles this automatically when the files row is deleted; this helper
+// is exposed for callers that pre-clear refs without dropping the row.
+//
+// the file-delete path today, but plan-defined future callers may need
+// pre-clear semantics.
+//
+//nolint:unused // exported as part of the API surface; FK cascade handles
+func deleteFileBlockRefs(ctx context.Context, tx execer, fileID uuid.UUID) error {
+	if _, err := tx.Exec(ctx, `DELETE FROM file_block_refs WHERE file_id = ?1`, fileID); err != nil {
+		return fmt.Errorf("delete file_block_refs for %s: %w", fileID, err)
+	}
+	return nil
+}
+
+// loadFileBlockRefs loads all rows for fileID via the pool (not a tx),
+// ordered by offset ASC; returns a nil slice when no rows exist.
+// Used by FindByObjectID. GetFile no longer calls this — it folds the same
+// rows into its metadata read via blockRefsAggExpr (#1176).
+func (s *SQLiteMetadataStore) loadFileBlockRefs(ctx context.Context, fileID uuid.UUID) ([]block.BlockRef, error) {
+	rows, err := s.query(ctx,
+		`SELECT "offset", size, hash FROM file_block_refs WHERE file_id = ?1 ORDER BY "offset" ASC`,
+		fileID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query file_block_refs for %s: %w", fileID, err)
+	}
+	defer rows.Close()
+
+	var out []block.BlockRef
+	for rows.Next() {
+		var off int64
+		var sz int32
+		var raw []byte
+		if err := rows.Scan(&off, &sz, &raw); err != nil {
+			return nil, fmt.Errorf("scan file_block_ref: %w", err)
+		}
+		if len(raw) != block.HashSize {
+			return nil, fmt.Errorf(
+				"file_block_refs.hash for %s/%d has unexpected length %d (want %d)",
+				fileID, off, len(raw), block.HashSize,
+			)
+		}
+		var br block.BlockRef
+		copy(br.Hash[:], raw)
+		br.Offset = uint64(off)
+		br.Size = uint32(sz)
+		out = append(out, br)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate file_block_refs: %w", err)
+	}
+	return out, nil
+}
+
+// ============================================================================
+// Test capability: RawSQLAccessor
+// ============================================================================
+
+// RawSQLAccessor is an optional capability backends may implement to expose
+// a small set of test-only direct-SQL helpers. Used by
+// postgres_blockref_test.go to assert FK cascade behavior.
+type RawSQLAccessor interface {
+	// CountFileBlockRefs returns the number of file_block_refs rows for
+	// fileID. Test-only — never call this from production code.
+	CountFileBlockRefs(ctx context.Context, fileID uuid.UUID) (int, error)
+
+	// InsertNullHashFileBlock inserts a file_blocks row with a NULL hash
+	// column, simulating a legacy backup produced before the Put
+	// hash-gate fix. Test-only — never call this from production code.
+	InsertNullHashFileBlock(ctx context.Context, id string, dataSize uint32) error
+
+	// FileBlockHashHex returns the hex hash string stored on the
+	// file_blocks row for id, or "" when the hash column is NULL.
+	// Test-only — never call this from production code.
+	FileBlockHashHex(ctx context.Context, id string) (string, error)
+}
+
+// CountFileBlockRefs implements RawSQLAccessor for *SQLiteMetadataStore.
+func (s *SQLiteMetadataStore) CountFileBlockRefs(ctx context.Context, fileID uuid.UUID) (int, error) {
+	var n int
+	err := s.queryRow(ctx, `SELECT COUNT(*) FROM file_block_refs WHERE file_id = ?1`, fileID).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count file_block_refs: %w", err)
+	}
+	return n, nil
+}
+
+// InsertNullHashFileBlock implements RawSQLAccessor for *SQLiteMetadataStore.
+func (s *SQLiteMetadataStore) InsertNullHashFileBlock(ctx context.Context, id string, dataSize uint32) error {
+	_, err := s.exec(ctx, `
+		INSERT INTO file_blocks (id, hash, data_size, ref_count, state)
+		VALUES (?1, NULL, ?2, 1, 0)
+		ON CONFLICT (id) DO UPDATE SET hash = NULL`,
+		id, int32(dataSize))
+	if err != nil {
+		return fmt.Errorf("insert null-hash file_block: %w", err)
+	}
+	return nil
+}
+
+// FileBlockHashHex implements RawSQLAccessor for *SQLiteMetadataStore.
+func (s *SQLiteMetadataStore) FileBlockHashHex(ctx context.Context, id string) (string, error) {
+	var hash *string
+	err := s.queryRow(ctx, `SELECT hash FROM file_blocks WHERE id = ?1`, id).Scan(&hash)
+	if err != nil {
+		return "", fmt.Errorf("read file_block hash: %w", err)
+	}
+	if hash == nil {
+		return "", nil
+	}
+	return *hash, nil
+}

--- a/pkg/metadata/store/sqlite/files.go
+++ b/pkg/metadata/store/sqlite/files.go
@@ -1,0 +1,497 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+)
+
+// ============================================================================
+// CRUD Operations
+// ============================================================================
+//
+// Read operations use direct pool queries for better performance (no transaction overhead).
+// Write operations use WithTransaction for atomicity.
+
+// GetFile retrieves file metadata by handle.
+// Uses direct pool query without transaction for better performance.
+// Returns ErrNotFound if handle doesn't exist.
+func (s *SQLiteMetadataStore) GetFile(ctx context.Context, handle metadata.FileHandle) (*metadata.File, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	shareName, id, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return nil, &metadata.StoreError{
+			Code:    metadata.ErrInvalidHandle,
+			Message: "invalid file handle",
+		}
+	}
+
+	// Fold FileAttr.Blocks into the metadata read via a correlated aggregate
+	// (#1176): one round-trip instead of the metadata SELECT plus a separate
+	// loadFileBlockRefs. blockRefsAggExpr yields NULL for directories,
+	// symlinks, and blockless files, so the decoded slice stays nil for them —
+	// byte-identical to the prior two-query behaviour.
+	query := `
+		SELECT
+			f.id, f.share_name, ` + inodePathExpr + `,
+			f.file_type, f.mode, f.uid, f.gid, f.size,
+			f.atime, f.mtime, f.ctime, f.creation_time,
+			f.content_id, f.link_target, f.device_major, f.device_minor,
+			f.hidden, f.acl, f.eas, f.object_id,
+			f.deleted_at, f.original_path, f.deleted_by, f.nlink,
+			` + blockRefsAggExpr + `
+		FROM inodes f
+		WHERE f.id = ?1 AND f.share_name = ?2
+	`
+
+	row := s.queryRow(ctx, query, id, shareName)
+	file, err := fileRowToFileWithNlinkAndBlocks(row, true)
+	if err != nil {
+		return nil, mapDBError(err, "GetFile", "")
+	}
+
+	return file, nil
+}
+
+// PutFile stores or updates file metadata.
+// Creates the entry if it doesn't exist.
+func (s *SQLiteMetadataStore) PutFile(ctx context.Context, file *metadata.File) error {
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.PutFile(ctx, file)
+	})
+}
+
+// DeleteFile removes file metadata by handle.
+// Returns ErrNotFound if handle doesn't exist.
+func (s *SQLiteMetadataStore) DeleteFile(ctx context.Context, handle metadata.FileHandle) error {
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.DeleteFile(ctx, handle)
+	})
+}
+
+// GetChild resolves a name in a directory to a file handle.
+// Uses direct pool query without transaction for better performance.
+// Returns ErrNotFound if name doesn't exist.
+func (s *SQLiteMetadataStore) GetChild(ctx context.Context, dirHandle metadata.FileHandle, name string) (metadata.FileHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	shareName, parentID, err := metadata.DecodeFileHandle(dirHandle)
+	if err != nil {
+		return nil, &metadata.StoreError{
+			Code:    metadata.ErrInvalidHandle,
+			Message: "invalid directory handle",
+		}
+	}
+
+	query := `
+		SELECT dc.child_id FROM parent_child_map dc
+		WHERE dc.parent_id = ?1 AND dc.child_name = ?2
+	`
+
+	var childID string
+	err = s.queryRow(ctx, query, parentID, name).Scan(&childID)
+	if err != nil {
+		return nil, mapDBError(err, "GetChild", name)
+	}
+
+	return encodeFileHandle(shareName, childID)
+}
+
+// SetChild adds or updates a child entry in a directory.
+func (s *SQLiteMetadataStore) SetChild(ctx context.Context, dirHandle metadata.FileHandle, name string, childHandle metadata.FileHandle) error {
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.SetChild(ctx, dirHandle, name, childHandle)
+	})
+}
+
+// DeleteChild removes a child entry from a directory.
+// Returns ErrNotFound if name doesn't exist.
+func (s *SQLiteMetadataStore) DeleteChild(ctx context.Context, dirHandle metadata.FileHandle, name string) error {
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.DeleteChild(ctx, dirHandle, name)
+	})
+}
+
+// GetParent returns the parent handle for a file/directory.
+// Uses direct pool query without transaction for better performance.
+// Returns ErrNotFound for root directories (no parent).
+func (s *SQLiteMetadataStore) GetParent(ctx context.Context, handle metadata.FileHandle) (metadata.FileHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	shareName, childID, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return nil, &metadata.StoreError{
+			Code:    metadata.ErrInvalidHandle,
+			Message: "invalid file handle",
+		}
+	}
+
+	query := `SELECT parent_id FROM parent_child_map WHERE child_id = ?1 LIMIT 1`
+
+	var parentIDStr string
+	err = s.queryRow(ctx, query, childID).Scan(&parentIDStr)
+	if err != nil {
+		return nil, mapDBError(err, "GetParent", "")
+	}
+
+	return encodeFileHandle(shareName, parentIDStr)
+}
+
+// SetParent sets the parent handle for a file/directory.
+//
+// Parent tracking is handled implicitly by parent_child_map via SetChild, so
+// this performs no write. It still honours context cancellation, matching the
+// prior WithTransaction-based implementation, while avoiding the cost of
+// opening an empty transaction.
+func (s *SQLiteMetadataStore) SetParent(ctx context.Context, handle metadata.FileHandle, parentHandle metadata.FileHandle) error {
+	return ctx.Err()
+}
+
+// GetLinkCount returns the hard link count for a file.
+// Uses direct pool query without transaction for better performance.
+// Returns 0 if the file doesn't exist. nlink is the sole source of truth (#1166).
+func (s *SQLiteMetadataStore) GetLinkCount(ctx context.Context, handle metadata.FileHandle) (uint32, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	_, fileID, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return 0, &metadata.StoreError{
+			Code:    metadata.ErrInvalidHandle,
+			Message: "invalid file handle",
+		}
+	}
+
+	var count uint32
+	err = s.queryRow(ctx, `SELECT nlink FROM inodes WHERE id = ?1`, fileID).Scan(&count)
+	if err != nil {
+		// Not found means count is 0
+		return 0, nil
+	}
+
+	return count, nil
+}
+
+// SetLinkCount sets the hard link count for a file.
+func (s *SQLiteMetadataStore) SetLinkCount(ctx context.Context, handle metadata.FileHandle, count uint32) error {
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.SetLinkCount(ctx, handle, count)
+	})
+}
+
+// ListChildren returns directory entries with pagination support.
+// Uses direct pool query without transaction for better performance.
+func (s *SQLiteMetadataStore) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, cursor string, limit int) ([]metadata.DirEntry, string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, "", err
+	}
+
+	shareName, parentID, err := metadata.DecodeFileHandle(dirHandle)
+	if err != nil {
+		return nil, "", &metadata.StoreError{
+			Code:    metadata.ErrInvalidHandle,
+			Message: "invalid directory handle",
+		}
+	}
+
+	if limit <= 0 {
+		limit = 1000
+	}
+
+	// Refs #532 (PR #536 review): hydrate f.acl so DirEntry.Attr.ACL is
+	// populated, matching the Memory/Badger backends. Without this column,
+	// access-based enumeration (and any other ACL-aware caller iterating
+	// DirEntry.Attr) silently degrades to POSIX mode bits even on files that
+	// have a DACL set. ACL JSONB rows are typically small relative to the
+	// listing row itself, so the extra column adds negligible per-row cost
+	// versus the per-entry GetFile() round trip it avoids.
+	query := `
+		SELECT dc.child_name, dc.child_id, f.file_type, f.mode, f.uid, f.gid, f.size,
+		       f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.acl, f.eas, f.object_id,
+		       f.deleted_at, f.original_path, f.deleted_by, f.nlink
+		FROM parent_child_map dc
+		LEFT JOIN inodes f ON dc.child_id = f.id
+		WHERE dc.parent_id = ?1 AND dc.child_name > ?2
+		ORDER BY dc.child_name
+		LIMIT ?3
+	`
+
+	rows, err := s.query(ctx, query, parentID, cursor, limit+1)
+	if err != nil {
+		return nil, "", mapDBError(err, "ListChildren", "")
+	}
+	defer rows.Close()
+
+	var entries []metadata.DirEntry
+	for rows.Next() && len(entries) < limit {
+		var name, childIDStr string
+		var fileType int16
+		var mode, uid, gid int32
+		var size int64
+		var atime, mtime, ctime, creationTime int64
+		var hidden bool
+		var aclJSON []byte
+		var easJSON []byte
+		var objectIDRaw []byte
+		var deletedAt sql.NullInt64
+		var originalPath string
+		var deletedBy string
+		var linkCount sql.NullInt32
+
+		err := rows.Scan(&name, &childIDStr, &fileType, &mode, &uid, &gid, &size,
+			&atime, &mtime, &ctime, &creationTime, &hidden, &aclJSON, &easJSON, &objectIDRaw,
+			&deletedAt, &originalPath, &deletedBy, &linkCount)
+		if err != nil {
+			return nil, "", err
+		}
+
+		childHandle, err := encodeFileHandle(shareName, childIDStr)
+		if err != nil {
+			return nil, "", err
+		}
+
+		// Determine Nlink value
+		var nlink uint32
+		if linkCount.Valid {
+			nlink = uint32(linkCount.Int32)
+		} else {
+			// Default based on file type
+			if metadata.FileType(fileType) == metadata.FileTypeDirectory {
+				nlink = 2
+			} else {
+				nlink = 1
+			}
+		}
+
+		// hydrate ObjectID for directory entries.
+		// NULL/empty -> zero (sentinel).
+		//
+		// (review iteration 1): the shape DOES NOT match
+		// GetFile in this backend. GetFile populates FileAttr.Blocks via
+		// loadFileBlockRefs; ListChildren intentionally does NOT (per-row
+		// BlockRef hydration would be a quadratic cost on directory
+		// listings). Memory and Badger backends include Blocks on
+		// DirEntry.Attr because their underlying serialisation already
+		// carries the slice — the relational model splits
+		// FileAttr.Blocks into a separate table (file_block_refs) and
+		// listing rows skip the join. Callers MUST treat
+		// DirEntry.Attr.Blocks as not-loaded for the SQLite store and re-read
+		// via GetFile if the BlockRef list is needed for hot-path
+		// resolution. Current short-circuit code (FindByObjectID-driven)
+		// never consults DirEntry.Attr.ObjectID, so this asymmetry is
+		// benign at the call surface.
+		attr := &metadata.FileAttr{
+			Type:         metadata.FileType(fileType),
+			Mode:         uint32(mode),
+			Nlink:        nlink,
+			UID:          uint32(uid),
+			GID:          uint32(gid),
+			Size:         uint64(size),
+			Atime:        nanosToTime(atime),
+			Mtime:        nanosToTime(mtime),
+			Ctime:        nanosToTime(ctime),
+			CreationTime: nanosToTime(creationTime),
+			Hidden:       hidden,
+		}
+		if len(objectIDRaw) > 0 {
+			if len(objectIDRaw) != block.HashSize {
+				return nil, "", fmt.Errorf(
+					"ListChildren: object_id has invalid length %d (want %d)",
+					len(objectIDRaw), block.HashSize,
+				)
+			}
+			copy(attr.ObjectID[:], objectIDRaw)
+		}
+
+		// Recycle-bin metadata (#190): carried on DirEntry.Attr so trash
+		// enumeration via listing reflects recycle state without a re-read.
+		// deleted_at is BIGINT unix-nanoseconds; decode via nanosToTime.
+		if deletedAt.Valid {
+			t := nanosToTime(deletedAt.Int64)
+			attr.DeletedAt = &t
+		}
+		attr.OriginalPath = originalPath
+		attr.DeletedBy = deletedBy
+
+		// Refs #532 (PR #536 review): mirror fileRowToFileWithNlink. A
+		// malformed ACL row is treated as "no ACL" rather than failing the
+		// whole listing — same lenient behaviour the GetFile path has had
+		// since the column was introduced.
+		if len(aclJSON) > 0 {
+			var fileACL acl.ACL
+			if err := json.Unmarshal(aclJSON, &fileACL); err == nil {
+				attr.ACL = &fileACL
+			}
+		}
+
+		// Hydrate EAs for directory entries (same lenient unmarshal as ACL).
+		if len(easJSON) > 0 {
+			var eas map[string][]byte
+			if err := json.Unmarshal(easJSON, &eas); err == nil && len(eas) > 0 {
+				attr.EAs = eas
+			}
+		}
+
+		entry := metadata.DirEntry{
+			ID:     metadata.HandleToINode(childHandle),
+			Name:   name,
+			Handle: childHandle,
+			Attr:   attr,
+		}
+
+		entries = append(entries, entry)
+	}
+
+	// Surface any error that terminated the iteration early (e.g. a network
+	// drop mid-stream). Without this check a partial result would be returned
+	// as a complete, successful listing.
+	if err := rows.Err(); err != nil {
+		return nil, "", mapDBError(err, "ListChildren", "")
+	}
+
+	nextCursor := ""
+	if len(entries) >= limit {
+		nextCursor = entries[len(entries)-1].Name
+	}
+
+	return entries, nextCursor, nil
+}
+
+// GetFilesystemMeta retrieves filesystem metadata for a share.
+// Uses direct pool query without transaction for better performance.
+func (s *SQLiteMetadataStore) GetFilesystemMeta(ctx context.Context, shareName string) (*metadata.FilesystemMeta, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	query := `SELECT meta FROM filesystem_meta WHERE share_name = ?1`
+
+	var data []byte
+	err := s.queryRow(ctx, query, shareName).Scan(&data)
+	if err != nil {
+		// Return defaults if not found
+		return &metadata.FilesystemMeta{
+			Capabilities: s.capabilities,
+		}, nil
+	}
+
+	var meta metadata.FilesystemMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, err
+	}
+
+	return &meta, nil
+}
+
+// PutFilesystemMeta stores filesystem metadata for a share.
+func (s *SQLiteMetadataStore) PutFilesystemMeta(ctx context.Context, shareName string, meta *metadata.FilesystemMeta) error {
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.PutFilesystemMeta(ctx, shareName, meta)
+	})
+}
+
+// ============================================================================
+// Payload ID Operations
+// ============================================================================
+
+// FindByObjectID looks up a file by its Merkle-root ObjectID and returns the
+// canonical BlockRef list of the matching row. Returns (nil, nil) on miss
+// (zero-valued input or no matching row).
+//
+// Uses the partial UNIQUE index files_object_id_idx; the LIMIT 1 is defensive
+// (the partial UNIQUE constraint already enforces single-row matches for
+// non-NULL object_id values).
+func (s *SQLiteMetadataStore) FindByObjectID(ctx context.Context, objectID block.ObjectID) ([]block.BlockRef, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if objectID.IsZero() {
+		return nil, nil
+	}
+
+	var fileID uuid.UUID
+	err := s.queryRow(ctx,
+		`SELECT id FROM inodes WHERE object_id = ?1 LIMIT 1`,
+		objectID[:],
+	).Scan(&fileID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, mapDBError(err, "FindByObjectID", objectID.String())
+	}
+
+	return s.loadFileBlockRefs(ctx, fileID)
+}
+
+// GetFileByPayloadID retrieves a file by its content ID (used by cache flusher)
+func (s *SQLiteMetadataStore) GetFileByPayloadID(ctx context.Context, payloadID metadata.PayloadID) (*metadata.File, error) {
+	if payloadID == "" {
+		return nil, &metadata.StoreError{
+			Code:    metadata.ErrInvalidArgument,
+			Message: "content ID cannot be empty",
+		}
+	}
+
+	query := `
+		SELECT
+			f.id, f.share_name, ` + inodePathExpr + `,
+			f.file_type, f.mode, f.uid, f.gid, f.size,
+			f.atime, f.mtime, f.ctime, f.creation_time,
+			f.content_id, f.link_target, f.device_major, f.device_minor,
+			f.hidden, f.acl, f.eas, f.object_id,
+			f.deleted_at, f.original_path, f.deleted_by, f.nlink
+		FROM inodes f
+		WHERE f.content_id = ?1
+		LIMIT 1
+	`
+
+	row := s.queryRow(ctx, query, string(payloadID))
+	file, err := fileRowToFileWithNlink(row)
+	if err != nil {
+		return nil, mapDBError(err, "GetFileByPayloadID", string(payloadID))
+	}
+
+	return file, nil
+}
+
+// CountObjectIDIndexRows implements the storetest.ObjectIDIndexAccessor
+// optional capability. Returns the number of files indexed under the
+// given objectID via the partial UNIQUE index files_object_id_idx.
+//
+// Test-only — never call from production code. Used by the
+// ConcurrentQuiesceRace scenario to assert exactly one row
+// survives the first-committer-wins resolution.
+//
+// Zero-valued objectID inputs short-circuit to (0, nil) without backend
+// access, mirroring FindByObjectID's partial/skip-zero discipline.
+func (s *SQLiteMetadataStore) CountObjectIDIndexRows(ctx context.Context, objectID block.ObjectID) (int, error) {
+	if objectID.IsZero() {
+		return 0, nil
+	}
+	var n int
+	err := s.queryRow(ctx,
+		`SELECT count(*) FROM inodes WHERE object_id = ?1`,
+		objectID[:],
+	).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count files.object_id: %w", err)
+	}
+	return n, nil
+}

--- a/pkg/metadata/store/sqlite/healthcheck.go
+++ b/pkg/metadata/store/sqlite/healthcheck.go
@@ -1,0 +1,35 @@
+package sqlite
+
+import (
+	"context"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/health"
+)
+
+// Healthcheck verifies the database is operational and returns a
+// structured [health.Report].
+//
+// The probe pings the database, which runs a trivial round-trip query.
+// This catches a closed pool or an unreadable/locked database file —
+// the failure modes a /status route operator would care about.
+//
+// Returns [health.StatusUnknown] when the caller's context is canceled
+// (the probe was indeterminate, not the store), [health.StatusUnhealthy]
+// when the ping itself returns an error, or [health.StatusHealthy] with
+// the measured probe latency on success.
+//
+// Thread-safe; designed to be called concurrently from /status routes
+// behind a [health.CachedChecker].
+func (s *SQLiteMetadataStore) Healthcheck(ctx context.Context) health.Report {
+	start := time.Now()
+	if err := ctx.Err(); err != nil {
+		return health.NewUnknownReport(err.Error(), time.Since(start))
+	}
+
+	if err := s.db.PingContext(ctx); err != nil {
+		return health.NewUnhealthyReport("sqlite ping: "+err.Error(), time.Since(start))
+	}
+
+	return health.NewHealthyReport(time.Since(start))
+}

--- a/pkg/metadata/store/sqlite/locks.go
+++ b/pkg/metadata/store/sqlite/locks.go
@@ -1,0 +1,750 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"strconv"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata/errors"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// ============================================================================
+// SQLite LockStore Implementation
+// ============================================================================
+
+// sqliteLockStore implements lock.LockStore using SQLite.
+//
+// It persists locks across restarts, so it is suitable for deployments
+// requiring lock persistence.
+//
+// Storage Model:
+//   - locks table: stores PersistedLock with indexed columns
+//   - server_epoch table: single row tracking server restarts
+//
+// Thread Safety:
+// All operations use database transactions for atomicity.
+type sqliteLockStore struct {
+	pool execer
+}
+
+// newSQLiteLockStore creates a new SQLite lock store.
+func newSQLiteLockStore(pool execer) *sqliteLockStore {
+	return &sqliteLockStore{
+		pool: pool,
+	}
+}
+
+// lockColumns is the full column list persisted for every PersistedLock. It
+// MUST list every field the suite (storetest.RunLockPersistenceSuite) asserts
+// is preserved — byte-range identity, lease, and delegation state alike.
+const lockColumns = `id, share_name, file_id, owner_id, client_id, lock_type,
+	byte_offset, byte_length, is_zero_byte, is_legacy_byte_range,
+	share_reservation, acquired_at, server_epoch,
+	lease_key, lease_state, lease_epoch, break_to_state, breaking_to_required,
+	breaking, parent_lease_key, is_directory, is_traditional_oplock,
+	delegation_id, deleg_type, deleg_breaking, deleg_recalled, deleg_revoked,
+	deleg_notification_mask, break_started`
+
+// putLockSQL is the upsert statement, parameterized ?1..?29 in lockColumns
+// order. The ON CONFLICT clause re-syncs every column so an overwrite never
+// leaves stale lease/delegation state behind.
+const putLockSQL = `
+	INSERT INTO locks (` + lockColumns + `)
+	VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13,
+	        ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22,
+	        ?23, ?24, ?25, ?26, ?27, ?28, ?29)
+	ON CONFLICT (id) DO UPDATE SET
+		share_name = EXCLUDED.share_name,
+		file_id = EXCLUDED.file_id,
+		owner_id = EXCLUDED.owner_id,
+		client_id = EXCLUDED.client_id,
+		lock_type = EXCLUDED.lock_type,
+		byte_offset = EXCLUDED.byte_offset,
+		byte_length = EXCLUDED.byte_length,
+		is_zero_byte = EXCLUDED.is_zero_byte,
+		is_legacy_byte_range = EXCLUDED.is_legacy_byte_range,
+		share_reservation = EXCLUDED.share_reservation,
+		acquired_at = EXCLUDED.acquired_at,
+		server_epoch = EXCLUDED.server_epoch,
+		lease_key = EXCLUDED.lease_key,
+		lease_state = EXCLUDED.lease_state,
+		lease_epoch = EXCLUDED.lease_epoch,
+		break_to_state = EXCLUDED.break_to_state,
+		breaking_to_required = EXCLUDED.breaking_to_required,
+		breaking = EXCLUDED.breaking,
+		parent_lease_key = EXCLUDED.parent_lease_key,
+		is_directory = EXCLUDED.is_directory,
+		is_traditional_oplock = EXCLUDED.is_traditional_oplock,
+		delegation_id = EXCLUDED.delegation_id,
+		deleg_type = EXCLUDED.deleg_type,
+		deleg_breaking = EXCLUDED.deleg_breaking,
+		deleg_recalled = EXCLUDED.deleg_recalled,
+		deleg_revoked = EXCLUDED.deleg_revoked,
+		deleg_notification_mask = EXCLUDED.deleg_notification_mask,
+		break_started = EXCLUDED.break_started
+`
+
+// putLockArgs returns the argument list for putLockSQL in lockColumns order.
+// lease_key/parent_lease_key are stored as NULL when empty so byte-range rows
+// don't carry phantom zero-length keys that IsLease() would misclassify.
+func putLockArgs(lk *lock.PersistedLock) []interface{} {
+	return []interface{}{
+		lk.ID,
+		lk.ShareName,
+		lk.FileID,
+		lk.OwnerID,
+		lk.ClientID,
+		lk.LockType,
+		// byte_offset/byte_length are TEXT decimal strings to hold the full
+		// uint64 range (NFSv4 unbounded = 0xFFFFFFFFFFFFFFFF > MaxInt64), which
+		// SQLite's signed 64-bit INTEGER cannot represent.
+		strconv.FormatUint(lk.Offset, 10),
+		strconv.FormatUint(lk.Length, 10),
+		lk.IsZeroByte,
+		lk.IsLegacyByteRange,
+		lk.AccessMode,
+		lk.AcquiredAt,
+		lk.ServerEpoch,
+		nilIfEmpty(lk.LeaseKey),
+		lk.LeaseState,
+		lk.LeaseEpoch,
+		lk.BreakToState,
+		lk.BreakingToRequired,
+		lk.Breaking,
+		nilIfEmpty(lk.ParentLeaseKey),
+		lk.IsDirectory,
+		lk.IsTraditionalOplock,
+		lk.DelegationID,
+		lk.DelegType,
+		lk.DelegBreaking,
+		lk.DelegRecalled,
+		lk.DelegRevoked,
+		lk.DelegNotificationMask,
+		// break_started is nullable: a zero BreakStarted (no in-flight break)
+		// stores as SQL NULL and scans back to the zero time, matching the
+		// memory/badger JSON round-trip.
+		nullTimeIfZero(lk.BreakStarted),
+	}
+}
+
+// nilIfEmpty maps an empty byte slice to a typed nil so it stores as SQL NULL.
+func nilIfEmpty(b []byte) []byte {
+	if len(b) == 0 {
+		return nil
+	}
+	return b
+}
+
+// nullTimeIfZero maps a zero time.Time to a NULL sql.NullTime so a zeroed
+// nullable timestamp column round-trips as the zero time rather than a driver
+// default, and a non-zero time stores faithfully.
+func nullTimeIfZero(t time.Time) sql.NullTime {
+	if t.IsZero() {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{Time: t, Valid: true}
+}
+
+// PutLock persists a lock using upsert.
+func (s *sqliteLockStore) PutLock(ctx context.Context, lk *lock.PersistedLock) error {
+	_, err := s.pool.Exec(ctx, putLockSQL, putLockArgs(lk)...)
+	return err
+}
+
+// putLockTx persists a lock within an existing transaction.
+func (s *sqliteLockStore) putLockTx(ctx context.Context, tx execer, lk *lock.PersistedLock) error {
+	_, err := tx.Exec(ctx, putLockSQL, putLockArgs(lk)...)
+	return err
+}
+
+// selectByID is the single-row select, columns in lockColumns order so it
+// shares the scanLock destination layout.
+const selectByID = `SELECT ` + lockColumns + ` FROM locks WHERE id = ?1`
+
+// scanLock scans one row into a PersistedLock. byte_offset/byte_length are
+// TEXT decimal strings (full uint64 range, see putLockTx) and are scanned as
+// strings, then parsed back into uint64.
+func scanLock(row scanRow) (*lock.PersistedLock, error) {
+	var lk lock.PersistedLock
+	var offsetStr, lengthStr string
+	var breakStarted sql.NullTime
+	if err := row.Scan(scanArgs(&lk, &offsetStr, &lengthStr, &breakStarted)...); err != nil {
+		return nil, err
+	}
+	off, err := strconv.ParseUint(offsetStr, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	length, err := strconv.ParseUint(lengthStr, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	lk.Offset = off
+	lk.Length = length
+	// break_started is nullable; a NULL leaves BreakStarted at its zero value.
+	if breakStarted.Valid {
+		lk.BreakStarted = breakStarted.Time
+	}
+	return &lk, nil
+}
+
+// scanArgs returns the Scan destination pointers in lockColumns order. The
+// byte_offset/byte_length NUMERIC columns scan into the caller's string holders
+// (offsetStr/lengthStr); scanLock parses them into lk.Offset/lk.Length. A new
+// column is wired in exactly one place here.
+func scanArgs(lk *lock.PersistedLock, offsetStr, lengthStr *string, breakStarted *sql.NullTime) []interface{} {
+	return []interface{}{
+		&lk.ID,
+		&lk.ShareName,
+		&lk.FileID,
+		&lk.OwnerID,
+		&lk.ClientID,
+		&lk.LockType,
+		offsetStr,
+		lengthStr,
+		&lk.IsZeroByte,
+		&lk.IsLegacyByteRange,
+		&lk.AccessMode,
+		&lk.AcquiredAt,
+		&lk.ServerEpoch,
+		&lk.LeaseKey,
+		&lk.LeaseState,
+		&lk.LeaseEpoch,
+		&lk.BreakToState,
+		&lk.BreakingToRequired,
+		&lk.Breaking,
+		&lk.ParentLeaseKey,
+		&lk.IsDirectory,
+		&lk.IsTraditionalOplock,
+		&lk.DelegationID,
+		&lk.DelegType,
+		&lk.DelegBreaking,
+		&lk.DelegRecalled,
+		&lk.DelegRevoked,
+		&lk.DelegNotificationMask,
+		breakStarted,
+	}
+}
+
+// GetLock retrieves a lock by ID.
+func (s *sqliteLockStore) GetLock(ctx context.Context, lockID string) (*lock.PersistedLock, error) {
+	lk, err := scanLock(s.pool.QueryRow(ctx, selectByID, lockID))
+	if err == sql.ErrNoRows {
+		return nil, &errors.StoreError{
+			Code:    errors.ErrLockNotFound,
+			Message: "lock not found",
+			Path:    lockID,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return lk, nil
+}
+
+// getLockTx retrieves a lock within an existing transaction.
+func (s *sqliteLockStore) getLockTx(ctx context.Context, tx execer, lockID string) (*lock.PersistedLock, error) {
+	lk, err := scanLock(tx.QueryRow(ctx, selectByID, lockID))
+	if err == sql.ErrNoRows {
+		return nil, &errors.StoreError{
+			Code:    errors.ErrLockNotFound,
+			Message: "lock not found",
+			Path:    lockID,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return lk, nil
+}
+
+// DeleteLock removes a lock by ID.
+func (s *sqliteLockStore) DeleteLock(ctx context.Context, lockID string) error {
+	query := `DELETE FROM locks WHERE id = ?1`
+	result, err := s.pool.Exec(ctx, query, lockID)
+	if err != nil {
+		return err
+	}
+
+	if result.RowsAffected() == 0 {
+		return &errors.StoreError{
+			Code:    errors.ErrLockNotFound,
+			Message: "lock not found",
+			Path:    lockID,
+		}
+	}
+
+	return nil
+}
+
+// deleteLockTx removes a lock within an existing transaction.
+func (s *sqliteLockStore) deleteLockTx(ctx context.Context, tx execer, lockID string) error {
+	query := `DELETE FROM locks WHERE id = ?1`
+	result, err := tx.Exec(ctx, query, lockID)
+	if err != nil {
+		return err
+	}
+
+	if result.RowsAffected() == 0 {
+		return &errors.StoreError{
+			Code:    errors.ErrLockNotFound,
+			Message: "lock not found",
+			Path:    lockID,
+		}
+	}
+
+	return nil
+}
+
+// buildListQuery assembles the dynamic SELECT + WHERE for a LockQuery, sharing
+// the lockColumns layout with scanArgs so reads stay in sync with the schema.
+func buildListQuery(query lock.LockQuery) (string, []interface{}) {
+	baseQuery := `SELECT ` + lockColumns + ` FROM locks WHERE 1=1`
+
+	var args []interface{}
+
+	// Anonymous `?` placeholders bind positionally in append order. (SQLite
+	// treats `$N` as a NAMED parameter, which database/sql's positional args
+	// never fill — it would silently compare against NULL and match nothing.)
+	if query.FileID != "" {
+		baseQuery += ` AND file_id = ?`
+		args = append(args, query.FileID)
+	}
+	if query.OwnerID != "" {
+		baseQuery += ` AND owner_id = ?`
+		args = append(args, query.OwnerID)
+	}
+	if query.ClientID != "" {
+		baseQuery += ` AND client_id = ?`
+		args = append(args, query.ClientID)
+	}
+	if query.ShareName != "" {
+		baseQuery += ` AND share_name = ?`
+		args = append(args, query.ShareName)
+	}
+
+	return baseQuery, args
+}
+
+// ListLocks returns locks matching the query.
+func (s *sqliteLockStore) ListLocks(ctx context.Context, query lock.LockQuery) ([]*lock.PersistedLock, error) {
+	baseQuery, args := buildListQuery(query)
+
+	rows, err := s.pool.Query(ctx, baseQuery, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var locks []*lock.PersistedLock
+	for rows.Next() {
+		lk, err := scanLock(rows)
+		if err != nil {
+			return nil, err
+		}
+		locks = append(locks, lk)
+	}
+
+	return locks, rows.Err()
+}
+
+// listLocksTx lists locks within an existing transaction.
+func (s *sqliteLockStore) listLocksTx(ctx context.Context, tx execer, query lock.LockQuery) ([]*lock.PersistedLock, error) {
+	baseQuery, args := buildListQuery(query)
+
+	rows, err := tx.Query(ctx, baseQuery, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var locks []*lock.PersistedLock
+	for rows.Next() {
+		lk, err := scanLock(rows)
+		if err != nil {
+			return nil, err
+		}
+		locks = append(locks, lk)
+	}
+
+	return locks, rows.Err()
+}
+
+// DeleteLocksByClient removes all locks for a client.
+func (s *sqliteLockStore) DeleteLocksByClient(ctx context.Context, clientID string) (int, error) {
+	query := `DELETE FROM locks WHERE client_id = ?1`
+	result, err := s.pool.Exec(ctx, query, clientID)
+	if err != nil {
+		return 0, err
+	}
+
+	return int(result.RowsAffected()), nil
+}
+
+// deleteLocksByClientTx removes locks within an existing transaction.
+func (s *sqliteLockStore) deleteLocksByClientTx(ctx context.Context, tx execer, clientID string) (int, error) {
+	query := `DELETE FROM locks WHERE client_id = ?1`
+	result, err := tx.Exec(ctx, query, clientID)
+	if err != nil {
+		return 0, err
+	}
+
+	return int(result.RowsAffected()), nil
+}
+
+// DeleteLocksByFile removes all locks for a file.
+func (s *sqliteLockStore) DeleteLocksByFile(ctx context.Context, fileID string) (int, error) {
+	query := `DELETE FROM locks WHERE file_id = ?1`
+	result, err := s.pool.Exec(ctx, query, fileID)
+	if err != nil {
+		return 0, err
+	}
+
+	return int(result.RowsAffected()), nil
+}
+
+// deleteLocksByFileTx removes locks within an existing transaction.
+func (s *sqliteLockStore) deleteLocksByFileTx(ctx context.Context, tx execer, fileID string) (int, error) {
+	query := `DELETE FROM locks WHERE file_id = ?1`
+	result, err := tx.Exec(ctx, query, fileID)
+	if err != nil {
+		return 0, err
+	}
+
+	return int(result.RowsAffected()), nil
+}
+
+// GetServerEpoch returns current server epoch.
+func (s *sqliteLockStore) GetServerEpoch(ctx context.Context) (uint64, error) {
+	query := `SELECT epoch FROM server_epoch WHERE id = 1`
+	var epoch uint64
+	err := s.pool.QueryRow(ctx, query).Scan(&epoch)
+	if err == sql.ErrNoRows {
+		return 0, nil // Fresh start
+	}
+	if err != nil {
+		return 0, err
+	}
+	return epoch, nil
+}
+
+// getServerEpochTx gets epoch within an existing transaction.
+func (s *sqliteLockStore) getServerEpochTx(ctx context.Context, tx execer) (uint64, error) {
+	query := `SELECT epoch FROM server_epoch WHERE id = 1`
+	var epoch uint64
+	err := tx.QueryRow(ctx, query).Scan(&epoch)
+	if err == sql.ErrNoRows {
+		return 0, nil // Fresh start
+	}
+	if err != nil {
+		return 0, err
+	}
+	return epoch, nil
+}
+
+// IncrementServerEpoch increments and returns new epoch.
+func (s *sqliteLockStore) IncrementServerEpoch(ctx context.Context) (uint64, error) {
+	query := `
+		INSERT INTO server_epoch (id, epoch, updated_at)
+		VALUES (1, 1, CURRENT_TIMESTAMP)
+		ON CONFLICT (id) DO UPDATE SET
+			epoch = server_epoch.epoch + 1,
+			updated_at = CURRENT_TIMESTAMP
+		RETURNING epoch
+	`
+	var newEpoch uint64
+	err := s.pool.QueryRow(ctx, query).Scan(&newEpoch)
+	return newEpoch, err
+}
+
+// incrementServerEpochTx increments epoch within an existing transaction.
+func (s *sqliteLockStore) incrementServerEpochTx(ctx context.Context, tx execer) (uint64, error) {
+	query := `
+		INSERT INTO server_epoch (id, epoch, updated_at)
+		VALUES (1, 1, CURRENT_TIMESTAMP)
+		ON CONFLICT (id) DO UPDATE SET
+			epoch = server_epoch.epoch + 1,
+			updated_at = CURRENT_TIMESTAMP
+		RETURNING epoch
+	`
+	var newEpoch uint64
+	err := tx.QueryRow(ctx, query).Scan(&newEpoch)
+	return newEpoch, err
+}
+
+// GetCleanShutdown reports whether the previous run shut down gracefully.
+// An absent singleton row (fresh store) is reported as false (unclean) — the
+// fail-safe default.
+func (s *sqliteLockStore) GetCleanShutdown(ctx context.Context) (bool, error) {
+	query := `SELECT clean_shutdown FROM server_epoch WHERE id = 1`
+	var clean bool
+	err := s.pool.QueryRow(ctx, query).Scan(&clean)
+	if err == sql.ErrNoRows {
+		return false, nil // fresh start -> unclean
+	}
+	if err != nil {
+		return false, err
+	}
+	return clean, nil
+}
+
+// SetCleanShutdown records the clean-shutdown marker on the server_epoch
+// singleton row. It upserts so the marker can be written before any
+// IncrementServerEpoch has created the row.
+func (s *sqliteLockStore) SetCleanShutdown(ctx context.Context, clean bool) error {
+	query := `
+		INSERT INTO server_epoch (id, epoch, clean_shutdown, updated_at)
+		VALUES (1, 0, ?1, CURRENT_TIMESTAMP)
+		ON CONFLICT (id) DO UPDATE SET
+			clean_shutdown = EXCLUDED.clean_shutdown,
+			updated_at = CURRENT_TIMESTAMP
+	`
+	_, err := s.pool.Exec(ctx, query, clean)
+	return err
+}
+
+// getCleanShutdownTx reads the marker within an existing transaction.
+func (s *sqliteLockStore) getCleanShutdownTx(ctx context.Context, tx execer) (bool, error) {
+	query := `SELECT clean_shutdown FROM server_epoch WHERE id = 1`
+	var clean bool
+	err := tx.QueryRow(ctx, query).Scan(&clean)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return clean, nil
+}
+
+// setCleanShutdownTx writes the marker within an existing transaction.
+func (s *sqliteLockStore) setCleanShutdownTx(ctx context.Context, tx execer, clean bool) error {
+	query := `
+		INSERT INTO server_epoch (id, epoch, clean_shutdown, updated_at)
+		VALUES (1, 0, ?1, CURRENT_TIMESTAMP)
+		ON CONFLICT (id) DO UPDATE SET
+			clean_shutdown = EXCLUDED.clean_shutdown,
+			updated_at = CURRENT_TIMESTAMP
+	`
+	_, err := tx.Exec(ctx, query, clean)
+	return err
+}
+
+// ReclaimLease reclaims an existing lease during grace period.
+// Searches for a persisted lease with matching file handle and lease key.
+func (s *sqliteLockStore) ReclaimLease(ctx context.Context, fileHandle lock.FileHandle, leaseKey [16]byte, _ string) (*lock.UnifiedLock, error) {
+	// Search for leases on this file with matching lease key
+	locks, err := s.ListLocks(ctx, lock.LockQuery{FileID: string(fileHandle)})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, lk := range locks {
+		// Must be a lease (has 16-byte key)
+		if len(lk.LeaseKey) != 16 {
+			continue
+		}
+		// Match lease key
+		var storedKey [16]byte
+		copy(storedKey[:], lk.LeaseKey)
+		if storedKey != leaseKey {
+			continue
+		}
+		// Found matching lease - convert to UnifiedLock
+		enhanced := lock.FromPersistedLock(lk)
+		if enhanced.Lease != nil {
+			enhanced.Lease.Reclaim = true
+		}
+		enhanced.Reclaim = true
+		return enhanced, nil
+	}
+
+	return nil, &errors.StoreError{
+		Code:    errors.ErrLockNotFound,
+		Message: "lease not found for reclaim",
+		Path:    string(fileHandle),
+	}
+}
+
+// reclaimLeaseTx reclaims a lease within an existing transaction.
+func (s *sqliteLockStore) reclaimLeaseTx(ctx context.Context, tx execer, fileHandle lock.FileHandle, leaseKey [16]byte, _ string) (*lock.UnifiedLock, error) {
+	// Search for leases on this file with matching lease key
+	locks, err := s.listLocksTx(ctx, tx, lock.LockQuery{FileID: string(fileHandle)})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, lk := range locks {
+		// Must be a lease (has 16-byte key)
+		if len(lk.LeaseKey) != 16 {
+			continue
+		}
+		// Match lease key
+		var storedKey [16]byte
+		copy(storedKey[:], lk.LeaseKey)
+		if storedKey != leaseKey {
+			continue
+		}
+		// Found matching lease - convert to UnifiedLock
+		enhanced := lock.FromPersistedLock(lk)
+		if enhanced.Lease != nil {
+			enhanced.Lease.Reclaim = true
+		}
+		enhanced.Reclaim = true
+		return enhanced, nil
+	}
+
+	return nil, &errors.StoreError{
+		Code:    errors.ErrLockNotFound,
+		Message: "lease not found for reclaim",
+		Path:    string(fileHandle),
+	}
+}
+
+// ============================================================================
+// SQLiteMetadataStore LockStore Integration
+// ============================================================================
+
+// Ensure SQLiteMetadataStore implements LockStore
+var _ lock.LockStore = (*SQLiteMetadataStore)(nil)
+
+// initLockStore ensures the lock store is initialized.
+func (s *SQLiteMetadataStore) initLockStore() {
+	s.lockStoreMu.Lock()
+	defer s.lockStoreMu.Unlock()
+	if s.lockStore == nil {
+		s.lockStore = newSQLiteLockStore(s.conn())
+	}
+}
+
+// PutLock persists a lock.
+func (s *SQLiteMetadataStore) PutLock(ctx context.Context, lk *lock.PersistedLock) error {
+	s.initLockStore()
+	return s.lockStore.PutLock(ctx, lk)
+}
+
+// GetLock retrieves a lock by ID.
+func (s *SQLiteMetadataStore) GetLock(ctx context.Context, lockID string) (*lock.PersistedLock, error) {
+	s.initLockStore()
+	return s.lockStore.GetLock(ctx, lockID)
+}
+
+// DeleteLock removes a lock by ID.
+func (s *SQLiteMetadataStore) DeleteLock(ctx context.Context, lockID string) error {
+	s.initLockStore()
+	return s.lockStore.DeleteLock(ctx, lockID)
+}
+
+// ListLocks returns locks matching the query.
+func (s *SQLiteMetadataStore) ListLocks(ctx context.Context, query lock.LockQuery) ([]*lock.PersistedLock, error) {
+	s.initLockStore()
+	return s.lockStore.ListLocks(ctx, query)
+}
+
+// DeleteLocksByClient removes all locks for a client.
+func (s *SQLiteMetadataStore) DeleteLocksByClient(ctx context.Context, clientID string) (int, error) {
+	s.initLockStore()
+	return s.lockStore.DeleteLocksByClient(ctx, clientID)
+}
+
+// DeleteLocksByFile removes all locks for a file.
+func (s *SQLiteMetadataStore) DeleteLocksByFile(ctx context.Context, fileID string) (int, error) {
+	s.initLockStore()
+	return s.lockStore.DeleteLocksByFile(ctx, fileID)
+}
+
+// GetServerEpoch returns current server epoch.
+func (s *SQLiteMetadataStore) GetServerEpoch(ctx context.Context) (uint64, error) {
+	s.initLockStore()
+	return s.lockStore.GetServerEpoch(ctx)
+}
+
+// IncrementServerEpoch increments and returns new epoch.
+func (s *SQLiteMetadataStore) IncrementServerEpoch(ctx context.Context) (uint64, error) {
+	s.initLockStore()
+	return s.lockStore.IncrementServerEpoch(ctx)
+}
+
+// GetCleanShutdown reports whether the previous run shut down gracefully.
+func (s *SQLiteMetadataStore) GetCleanShutdown(ctx context.Context) (bool, error) {
+	s.initLockStore()
+	return s.lockStore.GetCleanShutdown(ctx)
+}
+
+// SetCleanShutdown records the clean-shutdown marker durably.
+func (s *SQLiteMetadataStore) SetCleanShutdown(ctx context.Context, clean bool) error {
+	s.initLockStore()
+	return s.lockStore.SetCleanShutdown(ctx, clean)
+}
+
+// ReclaimLease reclaims an existing lease during grace period.
+func (s *SQLiteMetadataStore) ReclaimLease(ctx context.Context, fileHandle lock.FileHandle, leaseKey [16]byte, clientID string) (*lock.UnifiedLock, error) {
+	s.initLockStore()
+	return s.lockStore.ReclaimLease(ctx, fileHandle, leaseKey, clientID)
+}
+
+// ============================================================================
+// Transaction LockStore Support
+// ============================================================================
+
+// Ensure sqliteTransaction implements LockStore
+var _ lock.LockStore = (*sqliteTransaction)(nil)
+
+func (ptx *sqliteTransaction) PutLock(ctx context.Context, lk *lock.PersistedLock) error {
+	ptx.store.initLockStore()
+	return ptx.store.lockStore.putLockTx(ctx, ptx.tx, lk)
+}
+
+func (ptx *sqliteTransaction) GetLock(ctx context.Context, lockID string) (*lock.PersistedLock, error) {
+	ptx.store.initLockStore()
+	return ptx.store.lockStore.getLockTx(ctx, ptx.tx, lockID)
+}
+
+func (ptx *sqliteTransaction) DeleteLock(ctx context.Context, lockID string) error {
+	ptx.store.initLockStore()
+	return ptx.store.lockStore.deleteLockTx(ctx, ptx.tx, lockID)
+}
+
+func (ptx *sqliteTransaction) ListLocks(ctx context.Context, query lock.LockQuery) ([]*lock.PersistedLock, error) {
+	ptx.store.initLockStore()
+	return ptx.store.lockStore.listLocksTx(ctx, ptx.tx, query)
+}
+
+func (ptx *sqliteTransaction) DeleteLocksByClient(ctx context.Context, clientID string) (int, error) {
+	ptx.store.initLockStore()
+	return ptx.store.lockStore.deleteLocksByClientTx(ctx, ptx.tx, clientID)
+}
+
+func (ptx *sqliteTransaction) DeleteLocksByFile(ctx context.Context, fileID string) (int, error) {
+	ptx.store.initLockStore()
+	return ptx.store.lockStore.deleteLocksByFileTx(ctx, ptx.tx, fileID)
+}
+
+func (ptx *sqliteTransaction) GetServerEpoch(ctx context.Context) (uint64, error) {
+	ptx.store.initLockStore()
+	return ptx.store.lockStore.getServerEpochTx(ctx, ptx.tx)
+}
+
+func (ptx *sqliteTransaction) IncrementServerEpoch(ctx context.Context) (uint64, error) {
+	ptx.store.initLockStore()
+	return ptx.store.lockStore.incrementServerEpochTx(ctx, ptx.tx)
+}
+
+func (ptx *sqliteTransaction) GetCleanShutdown(ctx context.Context) (bool, error) {
+	ptx.store.initLockStore()
+	return ptx.store.lockStore.getCleanShutdownTx(ctx, ptx.tx)
+}
+
+func (ptx *sqliteTransaction) SetCleanShutdown(ctx context.Context, clean bool) error {
+	ptx.store.initLockStore()
+	return ptx.store.lockStore.setCleanShutdownTx(ctx, ptx.tx, clean)
+}
+
+func (ptx *sqliteTransaction) ReclaimLease(ctx context.Context, fileHandle lock.FileHandle, leaseKey [16]byte, clientID string) (*lock.UnifiedLock, error) {
+	ptx.store.initLockStore()
+	return ptx.store.lockStore.reclaimLeaseTx(ctx, ptx.tx, fileHandle, leaseKey, clientID)
+}

--- a/pkg/metadata/store/sqlite/migrate.go
+++ b/pkg/metadata/store/sqlite/migrate.go
@@ -1,0 +1,197 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite/migrations"
+)
+
+// runMigrations applies the embedded `*.up.sql` migrations in ascending numeric
+// order, tracking applied versions in a schema_migrations table.
+//
+// A bespoke runner (rather than golang-migrate) is used deliberately: the
+// golang-migrate sqlite driver blank-imports modernc.org/sqlite, which
+// registers the database/sql driver name "sqlite" a SECOND time alongside the
+// glebarez/go-sqlite driver the control-plane GORM layer registers — and two
+// registrations of the same name panic at init. Running the SQL ourselves over
+// the already-registered "sqlite" driver avoids pulling in that conflicting
+// registration while keeping the migrations file-based and versioned.
+func runMigrations(ctx context.Context, db *sql.DB, log *slog.Logger) error {
+	log.Info("Running database migrations...")
+
+	if _, err := db.ExecContext(ctx,
+		`CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER PRIMARY KEY)`,
+	); err != nil {
+		return fmt.Errorf("create schema_migrations: %w", err)
+	}
+
+	applied, err := appliedVersions(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	files, err := upMigrationFiles()
+	if err != nil {
+		return err
+	}
+
+	count := 0
+	for _, m := range files {
+		if applied[m.version] {
+			continue
+		}
+		body, rerr := migrations.FS.ReadFile(m.name)
+		if rerr != nil {
+			return fmt.Errorf("read migration %s: %w", m.name, rerr)
+		}
+		if err := applyMigration(ctx, db, m.version, string(body)); err != nil {
+			return fmt.Errorf("apply migration %s: %w", m.name, err)
+		}
+		count++
+	}
+
+	if count == 0 {
+		log.Info("No migrations to apply (database is up to date)")
+	} else {
+		log.Info("Migrations completed successfully", "applied", count)
+	}
+	return nil
+}
+
+// applyMigration runs one migration's SQL and records its version atomically.
+func applyMigration(ctx context.Context, db *sql.DB, version int, body string) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	for _, stmt := range splitStatements(body) {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("statement %q: %w", truncateForError(stmt), err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO schema_migrations (version) VALUES (?)`, version); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}
+
+func appliedVersions(ctx context.Context, db *sql.DB) (map[int]bool, error) {
+	rows, err := db.QueryContext(ctx, `SELECT version FROM schema_migrations`)
+	if err != nil {
+		return nil, fmt.Errorf("query schema_migrations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	applied := map[int]bool{}
+	for rows.Next() {
+		var v int
+		if err := rows.Scan(&v); err != nil {
+			return nil, err
+		}
+		applied[v] = true
+	}
+	return applied, rows.Err()
+}
+
+type migrationFile struct {
+	version int
+	name    string
+}
+
+// upMigrationFiles lists embedded `NNNNNN_*.up.sql` files in ascending version
+// order.
+func upMigrationFiles() ([]migrationFile, error) {
+	entries, err := migrations.FS.ReadDir(".")
+	if err != nil {
+		return nil, fmt.Errorf("read migrations dir: %w", err)
+	}
+	var out []migrationFile
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".up.sql") {
+			continue
+		}
+		idx := strings.IndexByte(name, '_')
+		if idx <= 0 {
+			continue
+		}
+		v, perr := strconv.Atoi(name[:idx])
+		if perr != nil {
+			continue
+		}
+		out = append(out, migrationFile{version: v, name: name})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].version < out[j].version })
+	return out, nil
+}
+
+// splitStatements splits a migration body into individual statements on the
+// `;` terminator. `--` line comments are stripped FIRST so a `;` inside a
+// comment (e.g. prose punctuation) never splits a statement. The schema uses no
+// triggers or stored procedures and no string literals containing `;`, so a
+// `;` split of the comment-free text is correct.
+func splitStatements(body string) []string {
+	var sb strings.Builder
+	for _, line := range strings.Split(body, "\n") {
+		if i := strings.Index(line, "--"); i >= 0 {
+			line = line[:i]
+		}
+		sb.WriteString(line)
+		sb.WriteByte('\n')
+	}
+	parts := strings.Split(sb.String(), ";")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if strings.TrimSpace(p) == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+func truncateForError(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > 80 {
+		return s[:80] + "..."
+	}
+	return s
+}
+
+// RunMigrations is a public wrapper for manual migration execution (e.g. CLI).
+func RunMigrations(ctx context.Context, cfg *SQLiteMetadataStoreConfig) error {
+	cfg.ApplyDefaults()
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	log := logger.With("component", "sqlite_migration")
+
+	db, err := sql.Open(sqliteDriverName, cfg.DSN())
+	if err != nil {
+		return fmt.Errorf("failed to open sqlite database: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.PingContext(ctx); err != nil {
+		return fmt.Errorf("failed to ping sqlite database: %w", err)
+	}
+	return runMigrations(ctx, db, log)
+}

--- a/pkg/metadata/store/sqlite/migrations/000001_initial_schema.down.sql
+++ b/pkg/metadata/store/sqlite/migrations/000001_initial_schema.down.sql
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS synced_hashes;
+DROP TABLE IF EXISTS rollup_offsets;
+DROP TABLE IF EXISTS v4_client_recovery;
+DROP TABLE IF EXISTS durable_handles;
+DROP TABLE IF EXISTS nsm_client_registrations;
+DROP TABLE IF EXISTS locks;
+DROP TABLE IF EXISTS file_block_refs;
+DROP TABLE IF EXISTS file_blocks;
+DROP TABLE IF EXISTS server_epoch;
+DROP TABLE IF EXISTS server_config;
+DROP TABLE IF EXISTS filesystem_capabilities;
+DROP TABLE IF EXISTS filesystem_meta;
+DROP TABLE IF EXISTS shares;
+DROP TABLE IF EXISTS parent_child_map;
+DROP TABLE IF EXISTS inodes;

--- a/pkg/metadata/store/sqlite/migrations/000001_initial_schema.up.sql
+++ b/pkg/metadata/store/sqlite/migrations/000001_initial_schema.up.sql
@@ -1,0 +1,330 @@
+-- SQLite metadata store schema.
+--
+-- This single consolidated migration produces the SAME logical schema the
+-- Postgres backend reaches after its 34 incremental migrations. SQLite has no
+-- existing deployments to migrate incrementally, so the final state is created
+-- in one step. Dialect adaptations vs Postgres:
+--   UUID      -> TEXT  (UUID stored as its canonical string form)
+--   BYTEA     -> BLOB
+--   JSONB     -> TEXT  (JSON stored as text/bytes)
+--   BOOLEAN   -> INTEGER 0/1 (the database/sql driver maps Go bool transparently)
+--   TIMESTAMPTZ NOW() -> TEXT CURRENT_TIMESTAMP for server-managed audit columns;
+--                        file timestamps remain BIGINT unix-nanoseconds (lossless).
+--   NUMERIC(20) lock offset/length -> INTEGER (uint64 fits SQLite's 64-bit int;
+--                        values are stored/read as int64 by the lock codec).
+-- ON DELETE CASCADE is honoured because every connection enables
+-- PRAGMA foreign_keys=ON (see config.DSN).
+
+-- ---------------------------------------------------------------------------
+-- inodes (Postgres "files", renamed in migration 000032; path/path_hash dropped
+-- in #1166 — namespace lives entirely in parent_child_map).
+-- ---------------------------------------------------------------------------
+CREATE TABLE inodes (
+    id              TEXT PRIMARY KEY,
+    share_name      TEXT NOT NULL,
+    file_type       INTEGER NOT NULL,
+    mode            INTEGER NOT NULL,
+    uid             INTEGER NOT NULL,
+    gid             INTEGER NOT NULL,
+    size            INTEGER NOT NULL DEFAULT 0,
+    nlink           INTEGER NOT NULL DEFAULT 1,
+    atime           INTEGER NOT NULL,
+    mtime           INTEGER NOT NULL,
+    ctime           INTEGER NOT NULL,
+    creation_time   INTEGER NOT NULL,
+    content_id      TEXT,
+    link_target     TEXT,
+    device_major    INTEGER,
+    device_minor    INTEGER,
+    hidden          INTEGER NOT NULL DEFAULT 0,
+    acl             TEXT,
+    eas             TEXT,
+    object_id       BLOB,
+    deleted_at      INTEGER,
+    original_path   TEXT NOT NULL DEFAULT '',
+    deleted_by      TEXT NOT NULL DEFAULT '',
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT valid_file_type CHECK (file_type BETWEEN 0 AND 6),
+    CONSTRAINT valid_uid CHECK (uid >= 0),
+    CONSTRAINT valid_gid CHECK (gid >= 0),
+    CONSTRAINT valid_size CHECK (size >= 0),
+    CONSTRAINT valid_nlink CHECK (nlink >= 0)
+);
+
+CREATE INDEX idx_inodes_share_name ON inodes(share_name);
+-- SQLite has no btree row-size limit, so content_id is indexed directly
+-- (the Postgres backend hashed it into content_id_hash to dodge the 2704-byte
+-- limit; that workaround is unnecessary here).
+CREATE INDEX idx_inodes_content_id ON inodes(content_id) WHERE content_id IS NOT NULL;
+CREATE INDEX idx_inodes_updated_at ON inodes(updated_at);
+CREATE INDEX idx_inodes_hidden ON inodes(hidden) WHERE hidden = 1;
+CREATE UNIQUE INDEX inodes_object_id_idx ON inodes(object_id) WHERE object_id IS NOT NULL;
+CREATE INDEX idx_inodes_uid ON inodes(uid) WHERE file_type = 0;
+CREATE INDEX idx_inodes_gid ON inodes(gid) WHERE file_type = 0;
+
+-- ---------------------------------------------------------------------------
+-- parent_child_map: the namespace. No unique constraint on child_id, so an
+-- inode may be referenced by many names (hard links).
+-- ---------------------------------------------------------------------------
+CREATE TABLE parent_child_map (
+    parent_id   TEXT NOT NULL REFERENCES inodes(id) ON DELETE CASCADE,
+    child_id    TEXT NOT NULL REFERENCES inodes(id) ON DELETE CASCADE,
+    child_name  TEXT NOT NULL,
+
+    PRIMARY KEY (parent_id, child_name),
+    CONSTRAINT non_empty_child_name CHECK (length(child_name) > 0)
+);
+
+CREATE INDEX idx_parent_child_map_parent ON parent_child_map(parent_id);
+CREATE INDEX idx_parent_child_map_child ON parent_child_map(child_id);
+
+-- ---------------------------------------------------------------------------
+-- shares
+-- ---------------------------------------------------------------------------
+CREATE TABLE shares (
+    share_name      TEXT PRIMARY KEY,
+    root_file_id    TEXT NOT NULL REFERENCES inodes(id),
+    options         TEXT NOT NULL DEFAULT '{}',
+    block_layout    TEXT NOT NULL DEFAULT 'legacy',
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT non_empty_share_name CHECK (length(share_name) > 0)
+);
+
+-- ---------------------------------------------------------------------------
+-- filesystem_meta
+-- ---------------------------------------------------------------------------
+CREATE TABLE filesystem_meta (
+    share_name TEXT PRIMARY KEY,
+    meta       TEXT NOT NULL DEFAULT '{}'
+);
+
+-- ---------------------------------------------------------------------------
+-- filesystem_capabilities (singleton)
+-- ---------------------------------------------------------------------------
+CREATE TABLE filesystem_capabilities (
+    id                   INTEGER PRIMARY KEY DEFAULT 1,
+    max_read_size        INTEGER NOT NULL,
+    preferred_read_size  INTEGER NOT NULL,
+    max_write_size       INTEGER NOT NULL,
+    preferred_write_size INTEGER NOT NULL,
+    max_file_size        INTEGER NOT NULL,
+    max_filename_len     INTEGER NOT NULL,
+    max_path_len         INTEGER NOT NULL,
+    max_hard_link_count  INTEGER NOT NULL,
+    supports_hard_links  INTEGER NOT NULL,
+    supports_symlinks    INTEGER NOT NULL,
+    case_sensitive       INTEGER NOT NULL,
+    case_preserving      INTEGER NOT NULL,
+    supports_acls        INTEGER NOT NULL,
+    time_resolution      INTEGER NOT NULL,
+
+    CONSTRAINT singleton_check CHECK (id = 1)
+);
+
+-- ---------------------------------------------------------------------------
+-- server_config (singleton): config JSON and the engine-persistent store_id.
+-- ---------------------------------------------------------------------------
+CREATE TABLE server_config (
+    id         INTEGER PRIMARY KEY DEFAULT 1,
+    config     TEXT NOT NULL DEFAULT '{}',
+    store_id   TEXT,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT singleton_check CHECK (id = 1)
+);
+
+-- ---------------------------------------------------------------------------
+-- server_epoch (singleton): NLM/SMB lock-generation counter PLUS the
+-- clean-shutdown marker. The row is created lazily by IncrementServerEpoch /
+-- SetCleanShutdown; an absent row reads as epoch 0 / unclean (the fail-safe
+-- default the boot-time lock recovery relies on after a Reset).
+-- ---------------------------------------------------------------------------
+CREATE TABLE server_epoch (
+    id             INTEGER PRIMARY KEY DEFAULT 1,
+    epoch          INTEGER NOT NULL DEFAULT 0,
+    clean_shutdown INTEGER NOT NULL DEFAULT 0,
+    updated_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT singleton_check CHECK (id = 1)
+);
+
+-- ---------------------------------------------------------------------------
+-- file_blocks: content-addressed block metadata.
+-- ---------------------------------------------------------------------------
+CREATE TABLE file_blocks (
+    id                   TEXT PRIMARY KEY,
+    hash                 TEXT,
+    data_size            INTEGER NOT NULL DEFAULT 0,
+    cache_path           TEXT,
+    block_store_key      TEXT,
+    ref_count            INTEGER NOT NULL DEFAULT 1,
+    last_access          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at           TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    state                INTEGER NOT NULL DEFAULT 0,
+    last_sync_attempt_at TIMESTAMP
+);
+
+CREATE INDEX idx_file_blocks_hash ON file_blocks(hash) WHERE hash IS NOT NULL;
+CREATE INDEX idx_file_blocks_pending ON file_blocks(created_at) WHERE state = 0 AND cache_path IS NOT NULL;
+CREATE INDEX idx_file_blocks_remote ON file_blocks(last_access) WHERE state = 2 AND cache_path IS NOT NULL;
+CREATE INDEX idx_file_blocks_unreferenced ON file_blocks(id) WHERE ref_count = 0;
+CREATE INDEX idx_file_blocks_syncing_age ON file_blocks(last_sync_attempt_at) WHERE state = 1;
+
+-- ---------------------------------------------------------------------------
+-- file_block_refs: per-file ordered block manifest.
+-- ---------------------------------------------------------------------------
+CREATE TABLE file_block_refs (
+    file_id  TEXT NOT NULL REFERENCES inodes(id) ON DELETE CASCADE,
+    "offset" INTEGER NOT NULL,
+    size     INTEGER NOT NULL,
+    hash     BLOB NOT NULL,
+
+    PRIMARY KEY (file_id, "offset")
+);
+
+CREATE INDEX idx_file_block_refs_file_id ON file_block_refs(file_id);
+
+-- ---------------------------------------------------------------------------
+-- locks: persisted NLM/SMB lock state.
+-- ---------------------------------------------------------------------------
+CREATE TABLE locks (
+    id                      TEXT PRIMARY KEY,
+    share_name              TEXT NOT NULL,
+    -- file_id is an opaque lock target (NFS/SMB file handle), NOT necessarily an
+    -- inodes.id, so it carries no foreign key (matching the Postgres schema).
+    file_id                 TEXT NOT NULL,
+    owner_id                TEXT NOT NULL DEFAULT '',
+    client_id               TEXT NOT NULL,
+    lock_type               INTEGER NOT NULL,
+    -- byte_offset/byte_length hold uint64 values up to 0xFFFFFFFFFFFFFFFF,
+    -- which exceeds SQLite's signed 64-bit INTEGER. The lock codec stores them
+    -- as decimal strings (strconv.FormatUint) and parses them back, so TEXT
+    -- affinity preserves the full unsigned range losslessly.
+    byte_offset             TEXT,
+    byte_length             TEXT,
+    is_zero_byte            INTEGER NOT NULL DEFAULT 0,
+    is_legacy_byte_range    INTEGER NOT NULL DEFAULT 0,
+    share_reservation       INTEGER NOT NULL DEFAULT 0,
+    acquired_at             TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    server_epoch            INTEGER NOT NULL DEFAULT 0,
+    lease_key               BLOB,
+    lease_state             INTEGER NOT NULL DEFAULT 0,
+    lease_epoch             INTEGER,
+    break_to_state          INTEGER,
+    breaking_to_required    INTEGER,
+    breaking                INTEGER,
+    parent_lease_key        BLOB,
+    is_directory            INTEGER,
+    is_traditional_oplock   INTEGER,
+    delegation_id           TEXT,
+    deleg_type              INTEGER,
+    deleg_breaking          INTEGER,
+    deleg_recalled          INTEGER,
+    deleg_revoked           INTEGER,
+    deleg_notification_mask INTEGER,
+    break_started           TIMESTAMP
+);
+
+CREATE INDEX idx_locks_client_id ON locks(client_id);
+CREATE INDEX idx_locks_file_id ON locks(file_id);
+CREATE INDEX idx_locks_share_name ON locks(share_name);
+
+-- ---------------------------------------------------------------------------
+-- nsm_client_registrations: NLM/NSM client persistence.
+-- ---------------------------------------------------------------------------
+CREATE TABLE nsm_client_registrations (
+    client_id     TEXT PRIMARY KEY,
+    mon_name      TEXT NOT NULL,
+    priv          BLOB NOT NULL,
+    callback_host TEXT NOT NULL,
+    callback_prog INTEGER NOT NULL,
+    callback_vers INTEGER NOT NULL,
+    callback_proc INTEGER NOT NULL,
+    registered_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    server_epoch  INTEGER NOT NULL,
+
+    CONSTRAINT valid_priv CHECK (length(priv) = 16),
+    CONSTRAINT valid_callback_prog CHECK (callback_prog >= 0),
+    CONSTRAINT valid_callback_vers CHECK (callback_vers >= 0),
+    CONSTRAINT valid_callback_proc CHECK (callback_proc >= 0)
+);
+
+CREATE INDEX idx_nsm_mon_name ON nsm_client_registrations(mon_name);
+
+-- ---------------------------------------------------------------------------
+-- durable_handles: SMB3 durable/persistent handle persistence.
+-- ---------------------------------------------------------------------------
+CREATE TABLE durable_handles (
+    id                   TEXT PRIMARY KEY,
+    file_id              BLOB NOT NULL,
+    path                 TEXT NOT NULL DEFAULT '',
+    share_name           TEXT NOT NULL,
+    desired_access       INTEGER NOT NULL DEFAULT 0,
+    share_access         INTEGER NOT NULL DEFAULT 0,
+    create_options       INTEGER NOT NULL DEFAULT 0,
+    metadata_handle      BLOB NOT NULL,
+    payload_id           TEXT,
+    oplock_level         INTEGER NOT NULL DEFAULT 0,
+    lease_key            BLOB,
+    lease_state          INTEGER NOT NULL DEFAULT 0,
+    create_guid          BLOB,
+    app_instance_id      BLOB,
+    username             TEXT NOT NULL DEFAULT '',
+    session_key_hash     BLOB NOT NULL,
+    is_v2                INTEGER NOT NULL DEFAULT 0,
+    created_at           TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    disconnected_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    timeout_ms           INTEGER NOT NULL DEFAULT 60000,
+    server_start_time    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    delete_pending       INTEGER NOT NULL DEFAULT 0,
+    parent_handle        BLOB,
+    file_name            TEXT,
+    is_directory         INTEGER NOT NULL DEFAULT 0,
+    granted_access       INTEGER,
+    position_info        INTEGER,
+    original_file_id     BLOB,
+    requested_alloc_size INTEGER,
+    lease_epoch          INTEGER,
+    is_persistent        INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE UNIQUE INDEX idx_durable_handles_create_guid ON durable_handles(create_guid) WHERE create_guid IS NOT NULL;
+CREATE INDEX idx_durable_handles_app_instance_id ON durable_handles(app_instance_id) WHERE app_instance_id IS NOT NULL;
+CREATE INDEX idx_durable_handles_file_id ON durable_handles(file_id);
+CREATE INDEX idx_durable_handles_share_name ON durable_handles(share_name);
+CREATE INDEX idx_durable_handles_metadata_handle ON durable_handles(metadata_handle);
+CREATE INDEX idx_durable_handles_disconnected_at ON durable_handles(disconnected_at);
+
+-- ---------------------------------------------------------------------------
+-- v4_client_recovery: NFSv4 client-recovery persistence.
+-- ---------------------------------------------------------------------------
+CREATE TABLE v4_client_recovery (
+    clientid_string  TEXT PRIMARY KEY,
+    clientid         INTEGER NOT NULL,
+    boot_verifier    BLOB NOT NULL,
+    principal        TEXT NOT NULL DEFAULT '',
+    confirmed_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    server_epoch     INTEGER NOT NULL,
+    reclaim_complete INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT valid_boot_verifier CHECK (length(boot_verifier) = 8)
+);
+
+-- ---------------------------------------------------------------------------
+-- rollup_offsets: per-payload append-log rollup position.
+-- ---------------------------------------------------------------------------
+CREATE TABLE rollup_offsets (
+    payload_id    TEXT PRIMARY KEY,
+    rollup_offset INTEGER NOT NULL DEFAULT 0
+);
+
+-- ---------------------------------------------------------------------------
+-- synced_hashes: content hashes confirmed durable in the remote store.
+-- ---------------------------------------------------------------------------
+CREATE TABLE synced_hashes (
+    hash      TEXT PRIMARY KEY,
+    synced_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/pkg/metadata/store/sqlite/migrations/embed.go
+++ b/pkg/metadata/store/sqlite/migrations/embed.go
@@ -1,0 +1,8 @@
+package migrations
+
+import "embed"
+
+// FS contains the embedded SQLite migration files.
+//
+//go:embed *.sql
+var FS embed.FS

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -1,0 +1,753 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// ============================================================================
+// FileBlockStore Implementation for SQLite Store
+// ============================================================================
+//
+// This file implements the FileBlockStore interface for the SQLite metadata store.
+// It provides content-addressed file block tracking for deduplication and caching.
+//
+// The FileBlockStore interface is narrowed to 6 methods. The backend
+// retains the legacy GetFileBlock + ListFileBlocks helpers as
+// concrete methods on the struct (not on the public interface) for
+// engine-internal callers.
+//
+// Table:
+//   - file_blocks: File block data with UUID as primary key and hash index
+//
+// Thread Safety: All operations use SQLite transactions for ACID guarantees.
+//
+// ============================================================================
+
+// Ensure SQLiteMetadataStore implements FileBlockStore
+var _ block.FileBlockStore = (*SQLiteMetadataStore)(nil)
+
+// ============================================================================
+// FileBlock Operations
+// ============================================================================
+
+// GetFileBlock retrieves a file block by its ID. Not on the narrowed
+// FileBlockStore interface; kept as a backend
+// method for engine-internal callers.
+func (s *SQLiteMetadataStore) GetFileBlock(ctx context.Context, id string) (*metadata.FileBlock, error) {
+	query := `SELECT id, hash, data_size, cache_path, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+		FROM file_blocks WHERE id = ?1`
+	row := s.queryRow(ctx, query, id)
+
+	block, err := scanFileBlock(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, metadata.ErrFileBlockNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get file block: %w", err)
+	}
+	return block, nil
+}
+
+// Put stores or updates a file block.
+//
+// The hash column is persisted whenever the block carries a non-zero
+// content hash, regardless of block state. The content hash is derived
+// at rollup time (long before the block reaches the remote) and is the
+// key the engine's CAS read path uses to resolve a chunk. Gating the
+// write on IsFinalized() left every Pending row with a NULL hash; reads
+// then survived only while the bytes stayed in the local append log or
+// RAM cache, and broke the moment local state went cold (restart +
+// cache eviction, or a snapshot restore's ResetLocalState). The memory
+// and badger backends always store the hash inline on the row, so this
+// matches their behavior.
+func (s *SQLiteMetadataStore) Put(ctx context.Context, block *metadata.FileBlock) error {
+	var hashStr *string
+	if !block.Hash.IsZero() {
+		h := block.Hash.String()
+		hashStr = &h
+	}
+	var blockStoreKey *string
+	if block.BlockStoreKey != "" {
+		blockStoreKey = &block.BlockStoreKey
+	}
+	var cachePath *string
+	if block.LocalPath != "" {
+		cachePath = &block.LocalPath
+	}
+	// persist LastSyncAttemptAt as NULL when zero so the
+	// janitor's WHERE last_sync_attempt_at < cutoff predicate excludes
+	// never-claimed rows naturally instead of matching every Pending row.
+	var lastSyncAttemptAt *time.Time
+	if !block.LastSyncAttemptAt.IsZero() {
+		t := block.LastSyncAttemptAt
+		lastSyncAttemptAt = &t
+	}
+
+	// Omit ref_count from the ON CONFLICT UPDATE list so concurrent
+	// IncrementRefCount / DecrementRefCount (which run as atomic SQL `+1` /
+	// `-1` UPDATEs) cannot be silently overwritten by a stale
+	// Put-with-in-memory-RefCount. RefCount on the INSERT path is still set
+	// verbatim from the caller's *FileBlock (matches the contract for new
+	// rows). For existing rows, RefCount mutates exclusively through
+	// Increment/Decrement. hash uses COALESCE so a zero-hash Put never NULLs
+	// a previously-persisted good hash.
+	query := `
+		INSERT INTO file_blocks (id, hash, data_size, cache_path, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at)
+		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+		ON CONFLICT (id) DO UPDATE SET
+			hash = COALESCE(EXCLUDED.hash, file_blocks.hash),
+			data_size = EXCLUDED.data_size,
+			cache_path = EXCLUDED.cache_path,
+			block_store_key = EXCLUDED.block_store_key,
+			last_access = EXCLUDED.last_access,
+			state = EXCLUDED.state,
+			last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`
+	_, err := s.exec(ctx, query,
+		block.ID, hashStr, block.DataSize, cachePath, blockStoreKey,
+		block.RefCount, block.LastAccess, block.CreatedAt, block.State, lastSyncAttemptAt)
+	if err != nil {
+		return fmt.Errorf("put file block: %w", err)
+	}
+	return nil
+}
+
+// Delete removes a file block by its ID. Renamed from DeleteFileBlock in
+func (s *SQLiteMetadataStore) Delete(ctx context.Context, id string) error {
+	result, err := s.exec(ctx, `DELETE FROM file_blocks WHERE id = ?1`, id)
+	if err != nil {
+		return fmt.Errorf("delete file block: %w", err)
+	}
+	rows := result.RowsAffected()
+	if rows == 0 {
+		return metadata.ErrFileBlockNotFound
+	}
+	return nil
+}
+
+// IncrementRefCount atomically increments a block's RefCount.
+func (s *SQLiteMetadataStore) IncrementRefCount(ctx context.Context, id string) error {
+	result, err := s.exec(ctx,
+		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE id = ?1`, id)
+	if err != nil {
+		return fmt.Errorf("increment ref count: %w", err)
+	}
+	rows := result.RowsAffected()
+	if rows == 0 {
+		return metadata.ErrFileBlockNotFound
+	}
+	return nil
+}
+
+// DecrementRefCount atomically decrements a block's RefCount.
+func (s *SQLiteMetadataStore) DecrementRefCount(ctx context.Context, id string) (uint32, error) {
+	query := `UPDATE file_blocks SET ref_count = MAX(ref_count - 1, 0) WHERE id = ?1 RETURNING ref_count`
+	var newCount uint32
+	err := s.queryRow(ctx, query, id).Scan(&newCount)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, metadata.ErrFileBlockNotFound
+	}
+	if err != nil {
+		return 0, fmt.Errorf("decrement ref count: %w", err)
+	}
+	return newCount, nil
+}
+
+// DecrementRefCountAndReap atomically decrements ref_count and, when it hits 0,
+// deletes the row — both statements run inside ONE transaction so the
+// decrement-and-reap is atomic and TOCTOU-free against a concurrent AddRef
+// (which takes the same row lock). The conditional `ref_count = 0` predicate on
+// the DELETE means a concurrent bump that landed between the two statements
+// (impossible within the row lock, but defended anyway) leaves the row alive.
+// Returns (0, nil) when the row is already absent — a swept row is not a caller
+// error.
+func (s *SQLiteMetadataStore) DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error) {
+	rawTx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("decrement-and-reap begin tx: %w", err)
+	}
+	defer func() { _ = rawTx.Rollback() }()
+
+	newCount, err := decrementAndReapTx(ctx, execer{e: rawTx, op: "DecrementRefCountAndReap"}, id)
+	if err != nil {
+		return 0, err
+	}
+	if err := rawTx.Commit(); err != nil {
+		return 0, fmt.Errorf("decrement-and-reap commit: %w", err)
+	}
+	return newCount, nil
+}
+
+// decrementAndReapTx runs the -1 UPDATE then a conditional DELETE on the given
+// pgx.Tx. Shared by the pool-backed store method and the sqliteTransaction
+// method so both surfaces behave identically. Returns ErrFileBlockNotFound
+// mapped to (0, nil) — i.e. a missing row is tolerated.
+func decrementAndReapTx(ctx context.Context, tx execer, id string) (uint32, error) {
+	var newCount uint32
+	err := tx.QueryRow(ctx,
+		`UPDATE file_blocks SET ref_count = MAX(ref_count - 1, 0) WHERE id = ?1 RETURNING ref_count`,
+		id).Scan(&newCount)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil // tolerate already-swept row
+	}
+	if err != nil {
+		return 0, fmt.Errorf("decrement ref count: %w", err)
+	}
+	if newCount == 0 {
+		if _, err := tx.Exec(ctx,
+			`DELETE FROM file_blocks WHERE id = ?1 AND ref_count = 0`, id); err != nil {
+			return 0, fmt.Errorf("reap zero-ref block: %w", err)
+		}
+	}
+	return newCount, nil
+}
+
+// AddRef atomically bumps RefCount on the FileBlock row(s) indexed by
+// the given content hash. Implements the FileBlockStore.AddRef contract
+// used by the in-memory hash dedup LRU hit path to
+// reference an already-stored block without creating a new row.
+//
+// Atomicity: a single UPDATE statement performs the bump — the SQLite
+// single-writer engine serializes contended updates against the same row,
+// so AddRef is TOCTOU-free against concurrent DecrementRefCount cascade
+// (matches the existing IncrementRefCount idiom).
+//
+// Returns metadata.ErrUnknownHash when RowsAffected == 0 (no row exists
+// for this hash). Callers (the LRU hit site) fall back to the full Put
+// path on this sentinel.
+//
+// Multi-row-per-hash tolerance:
+// the hash index on file_blocks is a NON-UNIQUE partial index (migration
+// 000011), so a single hash may match multiple rows in legacy data. The
+// UPDATE deliberately omits LIMIT — all matching rows are bumped
+// uniformly so refcount accounting stays correct regardless of which
+// row a later DecrementRefCount targets. The conformance test seeds a
+// single row, so RefCount goes from N to N+1 exactly.
+//
+// Only ref_count is mutated. block_state is never touched: AddRef
+// references an existing block, and the LRU hit path never creates
+// or transitions one.
+func (s *SQLiteMetadataStore) AddRef(ctx context.Context, hash block.ContentHash, _ string, _ block.BlockRef) error {
+	// payloadID + blockRef accepted for future GC traceability;
+	// postgres backend records ref count only — parameters intentionally
+	// blanked.
+	//
+	// state = 2 (Remote) scoping mirrors GetByHash and the memory/badger
+	// backends, whose AddRef resolves the hash only through the finalized
+	// hash index. The dedup hit path references a block already confirmed
+	// on the remote; a Pending row (which now also carries its hash) is
+	// not a valid dedup donor, so AddRef must miss it and return
+	// ErrUnknownHash exactly as before, letting the caller fall back to
+	// the full Put path.
+	result, err := s.exec(ctx,
+		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE hash = ?1 AND state = 2 /* Remote */`,
+		hash.String())
+	if err != nil {
+		return fmt.Errorf("add ref: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return metadata.ErrUnknownHash
+	}
+	return nil
+}
+
+// GetByHash looks up a finalized block by its content hash.
+// Returns nil without error if not found. Renamed from
+// FindFileBlockByHash. Dedup matches only Remote (state=2) blocks —
+// Pending or Syncing rows have not been confirmed on the remote and
+// are unsafe dedup targets.
+func (s *SQLiteMetadataStore) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileBlock, error) {
+	query := `SELECT id, hash, data_size, cache_path, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+		FROM file_blocks WHERE hash = ?1 AND state = 2 /* Remote */`
+	row := s.queryRow(ctx, query, hash.String())
+
+	block, err := scanFileBlock(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("find file block by hash: %w", err)
+	}
+	return block, nil
+}
+
+// ListPending returns blocks in Pending state (RefCount>=1, not yet
+// uploaded) older than the given duration. Renamed from
+// ListLocalBlocks; the underlying semantics already match ("Local"
+// was renamed Pending). If limit > 0, at most limit blocks are
+// returned.
+//
+// The legacy four-state machine collapsed to three; "Pending"
+// replaces both "Dirty" and "Local". The state literal here is 0,
+// matching block.BlockStatePending.
+func (s *SQLiteMetadataStore) ListPending(ctx context.Context, olderThan time.Duration, limit int) ([]*metadata.FileBlock, error) {
+	// olderThan <= 0 means "no age filter" — return every local block. The
+	// age predicate is omitted entirely in that case to avoid the corner
+	// where created_at ties or beats time.Now() under tight scheduling.
+	query := `SELECT id, hash, data_size, cache_path, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+		FROM file_blocks
+		WHERE state = 0 /* Pending */ AND cache_path IS NOT NULL`
+	args := make([]any, 0, 2)
+	if olderThan > 0 {
+		args = append(args, time.Now().Add(-olderThan))
+		query += fmt.Sprintf(" AND created_at < ?%d", len(args))
+	}
+	query += " ORDER BY created_at ASC"
+	if limit > 0 {
+		args = append(args, limit)
+		query += fmt.Sprintf(" LIMIT ?%d", len(args))
+	}
+	rows, err := s.query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list pending blocks: %w", err)
+	}
+	defer rows.Close()
+	return scanFileBlockRows(rows)
+}
+
+// ListFileBlocks returns all blocks belonging to a file, ordered by block index.
+// Uses LIKE query on block ID prefix, then sorts in Go for correct numeric ordering.
+// Not on the narrowed FileBlockStore interface;
+// kept as a backend method for engine-internal callers.
+func (s *SQLiteMetadataStore) ListFileBlocks(ctx context.Context, payloadID string) ([]*metadata.FileBlock, error) {
+	query := `SELECT id, hash, data_size, cache_path, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+		FROM file_blocks
+		WHERE id LIKE ?1
+		ORDER BY id ASC`
+	rows, err := s.query(ctx, query, payloadID+"/%")
+	if err != nil {
+		return nil, fmt.Errorf("list file blocks: %w", err)
+	}
+	defer rows.Close()
+	result, err := scanFileBlockRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	// SQL ORDER BY id ASC gives lexicographic order which is wrong for multi-digit
+	// block indices (e.g., "10" < "2"). Sort by parsed numeric index.
+	sort.Slice(result, func(i, j int) bool {
+		return pgParseBlockIdx(result[i].ID) < pgParseBlockIdx(result[j].ID)
+	})
+	if result == nil {
+		return []*metadata.FileBlock{}, nil
+	}
+	return result, nil
+}
+
+// enumerateHashesQuery is the GC mark live-set query. It UNIONs the CAS index
+// (file_blocks.hash, VARCHAR hex) with the per-file manifest
+// (file_block_refs.hash, BYTEA → encode hex) so the live set is a strict
+// SUPERSET of both structures. The snapshot Backup HashSet is built from
+// file_block_refs alone (File.Blocks); without the union a hash present only in
+// file_block_refs (e.g. a manifest row whose CAS index row was never written or
+// already reaped) would be absent from the live set and the GC sweep would reap
+// the still-live remote chunk once a snapshot hold lapsed (data loss). NULL
+// hashes (legacy pre-CAS file_blocks rows) are emitted as the zero ContentHash
+// and skipped by the mark phase; file_block_refs.hash is NOT NULL.
+//
+// UNION ALL, not UNION: the consumer (GC mark phase) dedupes hashes into a set,
+// so cross-source and intra-source duplicates are harmless. UNION would force an
+// expensive sort/hash-aggregate to dedupe at the query layer for no benefit.
+const enumerateHashesQuery = `SELECT hash FROM file_blocks
+UNION ALL
+SELECT lower(hex(hash)) FROM file_block_refs`
+
+// EnumerateFileBlocks streams every live-set ContentHash through fn, unioning
+// the CAS index with the per-file manifest (see enumerateHashesQuery).
+func (s *SQLiteMetadataStore) EnumerateFileBlocks(ctx context.Context, fn func(block.ContentHash) error) error {
+	rows, err := s.query(ctx, enumerateHashesQuery)
+	if err != nil {
+		return fmt.Errorf("enumerate file blocks: query: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("enumerate file blocks: %w", err)
+		}
+		var hashStr sql.NullString
+		if err := rows.Scan(&hashStr); err != nil {
+			return fmt.Errorf("enumerate file blocks: scan: %w", err)
+		}
+		var h block.ContentHash
+		if hashStr.Valid {
+			parsed, perr := metadata.ParseContentHash(hashStr.String)
+			if perr != nil {
+				// (mark fail-closed): a malformed hash row
+				// cannot be silently coerced to the zero hash — that would
+				// invite the GC mark phase to treat the row as a legacy
+				// pre-CAS entry and the sweep would reap a still-live CAS
+				// object once the grace TTL lapses. Surface the parse error
+				// so EnumerateFileBlocks aborts and the sweep is skipped.
+				return fmt.Errorf("enumerate file blocks: parse hash %q: %w",
+					hashStr.String, perr)
+			}
+			h = parsed
+		}
+		if err := fn(h); err != nil {
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("enumerate file blocks: rows: %w", err)
+	}
+	return nil
+}
+
+// pgParseBlockIdx extracts the numeric block index from a block ID ("{payloadID}/{blockIdx}").
+func pgParseBlockIdx(id string) int {
+	if idx := strings.LastIndex(id, "/"); idx >= 0 {
+		var v int
+		if _, err := fmt.Sscanf(id[idx+1:], "%d", &v); err == nil {
+			return v
+		}
+	}
+	return 0
+}
+
+// ============================================================================
+// Scan Helpers
+// ============================================================================
+
+// scanFileBlock scans a single row into a FileBlock.
+func scanFileBlock(row scanRow) (*metadata.FileBlock, error) {
+	var (
+		block             metadata.FileBlock
+		hashStr           sql.NullString
+		cachePath         sql.NullString
+		blockStoreKey     sql.NullString
+		lastSyncAttemptAt sql.NullTime
+	)
+	if err := row.Scan(&block.ID, &hashStr, &block.DataSize, &cachePath, &blockStoreKey,
+		&block.RefCount, &block.LastAccess, &block.CreatedAt, &block.State, &lastSyncAttemptAt); err != nil {
+		return nil, err
+	}
+	if hashStr.Valid {
+		// do not silently coerce malformed CAS hashes to the
+		// zero hash — see EnumerateFileBlocks for the data-loss scenario.
+		h, perr := metadata.ParseContentHash(hashStr.String)
+		if perr != nil {
+			return nil, fmt.Errorf("scan file block %s: parse hash %q: %w",
+				block.ID, hashStr.String, perr)
+		}
+		block.Hash = h
+	}
+	if cachePath.Valid {
+		block.LocalPath = cachePath.String
+	}
+	if blockStoreKey.Valid {
+		block.BlockStoreKey = blockStoreKey.String
+	}
+	if lastSyncAttemptAt.Valid {
+		block.LastSyncAttemptAt = lastSyncAttemptAt.Time
+	}
+	return &block, nil
+}
+
+// scanFileBlockRows scans multiple rows into FileBlock slices.
+func scanFileBlockRows(rows scanRows) ([]*metadata.FileBlock, error) {
+	var result []*metadata.FileBlock
+	for rows.Next() {
+		block, err := scanFileBlock(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan file block: %w", err)
+		}
+		result = append(result, block)
+	}
+	return result, rows.Err()
+}
+
+// ============================================================================
+// Transaction Support
+// ============================================================================
+
+// Ensure sqliteTransaction implements FileBlockStore
+var _ block.FileBlockStore = (*sqliteTransaction)(nil)
+
+// The FileBlockStore methods on
+// sqliteTransaction MUST execute against the txn's own pgx.Tx, not the
+// public store's connection-pool helpers. Previously every method just
+// called `tx.store.X(...)` which routed through the pool — defeating
+// rollback for any caller that bumped RefCount inside WithTransaction
+// then encountered a downstream PutFile failure (silent
+// leak). All proxies below are now tx-bound; non-mutating
+// helpers that don't support tx-binding here (ListPending, etc.) keep
+// the pool path because no caller mutates state through them.
+
+func (tx *sqliteTransaction) GetFileBlock(ctx context.Context, id string) (*metadata.FileBlock, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	query := `SELECT id, hash, data_size, cache_path, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+		FROM file_blocks WHERE id = ?1`
+	row := tx.tx.QueryRow(ctx, query, id)
+	block, err := scanFileBlock(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, metadata.ErrFileBlockNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get file block: %w", err)
+	}
+	return block, nil
+}
+
+func (tx *sqliteTransaction) Put(ctx context.Context, block *metadata.FileBlock) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	var hashStr *string
+	if !block.Hash.IsZero() {
+		h := block.Hash.String()
+		hashStr = &h
+	}
+	var blockStoreKey *string
+	if block.BlockStoreKey != "" {
+		blockStoreKey = &block.BlockStoreKey
+	}
+	var cachePath *string
+	if block.LocalPath != "" {
+		cachePath = &block.LocalPath
+	}
+	var lastSyncAttemptAt *time.Time
+	if !block.LastSyncAttemptAt.IsZero() {
+		t := block.LastSyncAttemptAt
+		lastSyncAttemptAt = &t
+	}
+	// Omit ref_count from the ON CONFLICT update list (matches the pool-path
+	// Put). RefCount mutates only via Increment/Decrement. hash uses COALESCE
+	// so a zero-hash Put never NULLs a previously-persisted good hash.
+	query := `
+		INSERT INTO file_blocks (id, hash, data_size, cache_path, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at)
+		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+		ON CONFLICT (id) DO UPDATE SET
+			hash = COALESCE(EXCLUDED.hash, file_blocks.hash),
+			data_size = EXCLUDED.data_size,
+			cache_path = EXCLUDED.cache_path,
+			block_store_key = EXCLUDED.block_store_key,
+			last_access = EXCLUDED.last_access,
+			state = EXCLUDED.state,
+			last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`
+	_, err := tx.tx.Exec(ctx, query,
+		block.ID, hashStr, block.DataSize, cachePath, blockStoreKey,
+		block.RefCount, block.LastAccess, block.CreatedAt, block.State, lastSyncAttemptAt)
+	if err != nil {
+		return fmt.Errorf("put file block: %w", err)
+	}
+	return nil
+}
+
+func (tx *sqliteTransaction) Delete(ctx context.Context, id string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	result, err := tx.tx.Exec(ctx, `DELETE FROM file_blocks WHERE id = ?1`, id)
+	if err != nil {
+		return fmt.Errorf("delete file block: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return metadata.ErrFileBlockNotFound
+	}
+	return nil
+}
+
+// IncrementRefCount runs the +1 UPDATE on the active pgx.Tx so a
+// subsequent rollback undoes the bump (fix). Production callers
+// route here through metadataCoordinator.IncrementRefCount when ctx
+// carries an active tx via metadata.WithTx.
+func (tx *sqliteTransaction) IncrementRefCount(ctx context.Context, id string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	result, err := tx.tx.Exec(ctx,
+		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE id = ?1`, id)
+	if err != nil {
+		return fmt.Errorf("increment ref count: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return metadata.ErrFileBlockNotFound
+	}
+	return nil
+}
+
+// DecrementRefCount runs the -1 UPDATE on the active pgx.Tx so a
+// subsequent rollback undoes the decrement (fix).
+func (tx *sqliteTransaction) DecrementRefCount(ctx context.Context, id string) (uint32, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	query := `UPDATE file_blocks SET ref_count = MAX(ref_count - 1, 0) WHERE id = ?1 RETURNING ref_count`
+	var newCount uint32
+	err := tx.tx.QueryRow(ctx, query, id).Scan(&newCount)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, metadata.ErrFileBlockNotFound
+	}
+	if err != nil {
+		return 0, fmt.Errorf("decrement ref count: %w", err)
+	}
+	return newCount, nil
+}
+
+// DecrementRefCountAndReap runs the -1 UPDATE + reap-at-zero DELETE on the
+// active pgx.Tx so a subsequent rollback undoes both. Returns (0, nil) when the
+// row is already absent.
+func (tx *sqliteTransaction) DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	return decrementAndReapTx(ctx, tx.tx, id)
+}
+
+// AddRef runs the +1 UPDATE keyed by hash on the active pgx.Tx so a
+// subsequent rollback undoes the bump (parity for the
+// LRU hit path). Returns metadata.ErrUnknownHash when no row matches.
+func (tx *sqliteTransaction) AddRef(ctx context.Context, hash block.ContentHash, _ string, _ block.BlockRef) error {
+	// payloadID + blockRef accepted for future GC traceability;
+	// postgres backend records ref count only — parameters intentionally
+	// blanked.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	// state = 2 (Remote) scoping mirrors the pool-path AddRef and the
+	// memory/badger backends — a Pending row is not a valid dedup donor.
+	result, err := tx.tx.Exec(ctx,
+		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE hash = ?1 AND state = 2 /* Remote */`,
+		hash.String())
+	if err != nil {
+		return fmt.Errorf("add ref: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return metadata.ErrUnknownHash
+	}
+	return nil
+}
+
+func (tx *sqliteTransaction) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileBlock, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	query := `SELECT id, hash, data_size, cache_path, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+		FROM file_blocks WHERE hash = ?1 AND state = 2 /* Remote */`
+	row := tx.tx.QueryRow(ctx, query, hash.String())
+	block, err := scanFileBlock(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("find file block by hash: %w", err)
+	}
+	return block, nil
+}
+
+// ListPending / ListFileBlocks / EnumerateFileBlocks run on the active
+// transaction (tx.tx), NOT the pool. Delegating to the pool opens a separate
+// connection that cannot see this transaction's uncommitted writes, so a Put
+// followed by a List in the same WithTransaction would miss the pending row
+// (read-after-write violation; the SQL is otherwise identical to the
+// store-level methods).
+func (tx *sqliteTransaction) ListPending(ctx context.Context, olderThan time.Duration, limit int) ([]*metadata.FileBlock, error) {
+	query := `SELECT id, hash, data_size, cache_path, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+		FROM file_blocks
+		WHERE state = 0 /* Pending */ AND cache_path IS NOT NULL`
+	args := make([]any, 0, 2)
+	if olderThan > 0 {
+		args = append(args, time.Now().Add(-olderThan))
+		query += fmt.Sprintf(" AND created_at < ?%d", len(args))
+	}
+	query += " ORDER BY created_at ASC"
+	if limit > 0 {
+		args = append(args, limit)
+		query += fmt.Sprintf(" LIMIT ?%d", len(args))
+	}
+	rows, err := tx.tx.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list pending blocks: %w", err)
+	}
+	defer rows.Close()
+	return scanFileBlockRows(rows)
+}
+
+func (tx *sqliteTransaction) ListFileBlocks(ctx context.Context, payloadID string) ([]*metadata.FileBlock, error) {
+	query := `SELECT id, hash, data_size, cache_path, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+		FROM file_blocks
+		WHERE id LIKE ?1
+		ORDER BY id ASC`
+	rows, err := tx.tx.Query(ctx, query, payloadID+"/%")
+	if err != nil {
+		return nil, fmt.Errorf("list file blocks: %w", err)
+	}
+	defer rows.Close()
+	result, err := scanFileBlockRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	// Lexicographic SQL order mis-sorts multi-digit indices ("10" < "2");
+	// sort by parsed numeric index, matching the store-level method.
+	sort.Slice(result, func(i, j int) bool {
+		return pgParseBlockIdx(result[i].ID) < pgParseBlockIdx(result[j].ID)
+	})
+	if result == nil {
+		return []*metadata.FileBlock{}, nil
+	}
+	return result, nil
+}
+
+func (tx *sqliteTransaction) EnumerateFileBlocks(ctx context.Context, fn func(block.ContentHash) error) error {
+	rows, err := tx.tx.Query(ctx, enumerateHashesQuery)
+	if err != nil {
+		return fmt.Errorf("enumerate file blocks: query: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("enumerate file blocks: %w", err)
+		}
+		var hashStr sql.NullString
+		if err := rows.Scan(&hashStr); err != nil {
+			return fmt.Errorf("enumerate file blocks: scan: %w", err)
+		}
+		var h block.ContentHash
+		if hashStr.Valid {
+			parsed, perr := metadata.ParseContentHash(hashStr.String)
+			if perr != nil {
+				return fmt.Errorf("enumerate file blocks: parse hash %q: %w", hashStr.String, perr)
+			}
+			h = parsed
+		}
+		if err := fn(h); err != nil {
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("enumerate file blocks: rows: %w", err)
+	}
+	return nil
+}
+
+// The file_blocks table schema lives in
+// pkg/metadata/store/postgres/migrations/000010_file_blocks.up.sql.
+
+// InjectCorruptHashRow stores a file_blocks row whose hash column holds a
+// syntactically malformed value. Test-only: implements the storetest
+// CorruptHashInjector capability so the conformance suite can exercise
+// fail-closed enumeration. The TEXT column lets us bypass the
+// Put contract that always serializes a valid ContentHash.String().
+func (s *SQLiteMetadataStore) InjectCorruptHashRow(ctx context.Context, blockID string, badHash string) error {
+	now := time.Now()
+	_, err := s.exec(ctx, `
+		INSERT INTO file_blocks (id, hash, data_size, cache_path, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at)
+		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+		ON CONFLICT (id) DO UPDATE SET hash = EXCLUDED.hash`,
+		blockID, badHash, uint32(64), nil, nil, uint32(1), now, now, int(block.BlockStateRemote), nil,
+	)
+	if err != nil {
+		return fmt.Errorf("inject corrupt hash row: %w", err)
+	}
+	return nil
+}

--- a/pkg/metadata/store/sqlite/paths.go
+++ b/pkg/metadata/store/sqlite/paths.go
@@ -1,0 +1,72 @@
+package sqlite
+
+// Path reconstruction (#1166).
+//
+// The inodes table no longer stores a canonical path: parent_child_map
+// (parent_id, child_name -> child_id) is the sole source of truth for the
+// namespace. metadata.File.Path is still populated by GetFile and the
+// payload-id lookup (callers and the conformance suite derive child paths from
+// a parent's Path), so it is reconstructed on read by walking parent_child_map
+// up to the share root.
+//
+// For a hard-linked inode (N names) the walk is deterministic but arbitrary:
+// at each level it follows a single edge ordered by (parent_id, child_name),
+// yielding ONE of the inode's paths. POSIX does not guarantee which path a
+// stat() reflects for a multiply-linked file, so returning any valid reachable
+// path is correct. An inode with no parent edge (a share root, or an
+// orphaned/unlinked-but-open inode) resolves to "/".
+//
+// inodePathExpr is a correlated scalar subquery that computes the path for the
+// row aliased `f` in the enclosing query (it references f.id). Splice it into a
+// SELECT list in place of the old f.path column. It is a single round-trip with
+// the rest of the row.
+//
+// SQLite has no LATERAL join, so the per-level "pick one edge" is done with a
+// correlated subquery on the row's implicit rowid: at each level the edge whose
+// rowid matches the minimum (parent_id, child_name) ordering for the current
+// child is selected, yielding exactly one deterministic parent edge.
+//
+// The `depth < 4096` guard bounds the walk: parent_child_map's schema permits a
+// directed cycle (only FK constraints to inodes(id), no acyclicity check) that
+// no filesystem operation can create but a bug or direct DB edit could. Without
+// the cap a cycle would make every GetFile for a node in it recurse forever.
+// 4096 is well above any real path-component depth (it matches the filesystem
+// MaxPathLen ceiling), so it never truncates a legitimate path while turning a
+// corrupt cycle into a bounded, finite result.
+//
+// Path component order is built INTO the recursive accumulator (`acc`) rather
+// than relying on group_concat honoring a subquery ORDER BY: the bundled SQLite
+// (3.41.x via glebarez/go-sqlite) predates the ordered-aggregate syntax
+// (`group_concat(x ORDER BY …)`, 3.44+), and an aggregate over a derived table
+// is not guaranteed to consume rows in the subquery's order. Each recursive
+// step PREPENDS the parent's name (`e.child_name || '/' || up.acc`), so the
+// deepest (root-most) row's `acc` already holds the full root-to-target path;
+// the final SELECT picks that single row (`ORDER BY depth DESC LIMIT 1`), which
+// is deterministic.
+const inodePathExpr = `(
+	WITH RECURSIVE up(parent_id, acc, depth) AS (
+		SELECT e.parent_id, e.child_name, 1
+		FROM parent_child_map e
+		WHERE e.child_id = f.id
+		  AND e.rowid = (
+			SELECT e2.rowid FROM parent_child_map e2
+			WHERE e2.child_id = f.id
+			ORDER BY e2.parent_id, e2.child_name
+			LIMIT 1
+		  )
+
+		UNION ALL
+
+		SELECT e.parent_id, e.child_name || '/' || up.acc, up.depth + 1
+		FROM parent_child_map e, up
+		WHERE e.child_id = up.parent_id
+		  AND e.rowid = (
+			SELECT e2.rowid FROM parent_child_map e2
+			WHERE e2.child_id = up.parent_id
+			ORDER BY e2.parent_id, e2.child_name
+			LIMIT 1
+		  )
+		  AND up.depth < 4096
+	)
+	SELECT COALESCE('/' || (SELECT acc FROM up ORDER BY depth DESC LIMIT 1), '/')
+)`

--- a/pkg/metadata/store/sqlite/pool_helpers.go
+++ b/pkg/metadata/store/sqlite/pool_helpers.go
@@ -3,16 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
-	"time"
 )
-
-// poolConnectionAcquireTimeout bounds how long a single statement waits for a
-// connection from the underlying *sql.DB pool. SQLite is an embedded,
-// single-writer engine, so contention is resolved by the busy_timeout pragma
-// rather than a large connection pool; this timeout is a defense-in-depth
-// ceiling that keeps an operation from blocking forever if the (size-limited)
-// pool is momentarily saturated.
-const poolConnectionAcquireTimeout = 10 * time.Second
 
 // ============================================================================
 // database/sql executor shim

--- a/pkg/metadata/store/sqlite/pool_helpers.go
+++ b/pkg/metadata/store/sqlite/pool_helpers.go
@@ -1,0 +1,141 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+// poolConnectionAcquireTimeout bounds how long a single statement waits for a
+// connection from the underlying *sql.DB pool. SQLite is an embedded,
+// single-writer engine, so contention is resolved by the busy_timeout pragma
+// rather than a large connection pool; this timeout is a defense-in-depth
+// ceiling that keeps an operation from blocking forever if the (size-limited)
+// pool is momentarily saturated.
+const poolConnectionAcquireTimeout = 10 * time.Second
+
+// ============================================================================
+// database/sql executor shim
+// ============================================================================
+//
+// The SQLite store is a near-verbatim port of the Postgres store, which was
+// written against pgx (pool.QueryRow(ctx, sql, args...) etc.). To keep the
+// query bodies unchanged, the helper methods below present the SAME surface
+// over database/sql: a single-row Row, a streaming Rows, and an Exec result —
+// each exposing only the handful of methods the store actually uses.
+//
+// SQL-dialect differences ($N placeholders -> ?, Postgres-only functions) are
+// adapted in the queries themselves; the API shape is preserved here.
+
+// sqlExecutor is satisfied by both *sql.DB and *sql.Tx. It is the lowest common
+// denominator the store needs.
+type sqlExecutor interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+// scanRow is the single-row scan surface used across the store (mirrors
+// pgx.Row).
+type scanRow interface {
+	Scan(dest ...any) error
+}
+
+// scanRows is the streaming surface used across the store (mirrors pgx.Rows,
+// minus the wire-format accessors only backup.go needed — backup is
+// reimplemented without them).
+type scanRows interface {
+	Next() bool
+	Scan(dest ...any) error
+	Close()
+	Err() error
+}
+
+// errorRow returns a deferred error from Scan (mirrors pgx's lazy error rows).
+type errorRow struct{ err error }
+
+func (r errorRow) Scan(dest ...any) error { return r.err }
+
+// cmdResult mirrors pgx's CommandTag.RowsAffected() (single int64 return) so
+// the ported bodies can write `result.RowsAffected()` without the (n, err)
+// shape of database/sql's sql.Result. The affected count is captured eagerly
+// from the sql.Result at Exec time; a RowsAffected error (never produced by
+// the SQLite driver) collapses to 0.
+type cmdResult struct{ affected int64 }
+
+func (c cmdResult) RowsAffected() int64 { return c.affected }
+
+// sqlRows adapts *sql.Rows to the rows interface. The only shape difference is
+// Close(): database/sql returns an error, pgx returns nothing. Close errors on
+// SQLite are not actionable, so they are swallowed (matching pgx semantics);
+// iteration errors are surfaced through Err().
+type sqlRows struct{ *sql.Rows }
+
+func (r sqlRows) Close()     { _ = r.Rows.Close() }
+func (r sqlRows) Err() error { return r.Rows.Err() }
+
+// execer wraps an sqlExecutor so its methods match the pgx pool/tx surface used
+// by the store: QueryRow/Query/Exec taking (ctx, sql, args...). Both the
+// store-level pool path and the per-transaction path use one of these.
+type execer struct {
+	e  sqlExecutor
+	op string // label for error mapping ("query", "exec", "tx", ...)
+}
+
+func (x execer) QueryRow(ctx context.Context, query string, args ...any) scanRow {
+	if err := ctx.Err(); err != nil {
+		return errorRow{err: err}
+	}
+	return x.e.QueryRowContext(ctx, query, args...)
+}
+
+func (x execer) Query(ctx context.Context, query string, args ...any) (scanRows, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	r, err := x.e.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, mapDBError(err, x.op, query)
+	}
+	return sqlRows{r}, nil
+}
+
+func (x execer) Exec(ctx context.Context, query string, args ...any) (cmdResult, error) {
+	if err := ctx.Err(); err != nil {
+		return cmdResult{}, err
+	}
+	res, err := x.e.ExecContext(ctx, query, args...)
+	if err != nil {
+		return cmdResult{}, mapDBError(err, x.op, query)
+	}
+	n, _ := res.RowsAffected()
+	return cmdResult{affected: n}, nil
+}
+
+// ============================================================================
+// Store-level (non-transactional) pool helpers
+// ============================================================================
+
+// queryRow executes a single-row query against the shared *sql.DB.
+func (s *SQLiteMetadataStore) queryRow(ctx context.Context, query string, args ...any) scanRow {
+	return execer{e: s.db, op: "queryRow"}.QueryRow(ctx, query, args...)
+}
+
+// query executes a multi-row query against the shared *sql.DB. The caller MUST
+// Close the returned rows.
+func (s *SQLiteMetadataStore) query(ctx context.Context, query string, args ...any) (scanRows, error) {
+	return execer{e: s.db, op: "query"}.Query(ctx, query, args...)
+}
+
+// exec executes a statement against the shared *sql.DB and returns the result
+// for RowsAffected inspection.
+func (s *SQLiteMetadataStore) exec(ctx context.Context, query string, args ...any) (cmdResult, error) {
+	return execer{e: s.db, op: "exec"}.Exec(ctx, query, args...)
+}
+
+// conn returns the pgx-shaped executor over the shared *sql.DB used by the lazy
+// sub-stores (locks/clients/durable/recovery). They were written against a pool
+// handle named `pool`; an execer presents the same QueryRow/Query/Exec surface.
+func (s *SQLiteMetadataStore) conn() execer {
+	return execer{e: s.db, op: "substore"}
+}

--- a/pkg/metadata/store/sqlite/reset.go
+++ b/pkg/metadata/store/sqlite/reset.go
@@ -1,0 +1,52 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+var _ metadata.Resetable = (*SQLiteMetadataStore)(nil)
+
+// Reset empties every metadata table in a single transaction. The table list is
+// the same backupTables slice used by Backup/Restore. While the tx holds, the
+// single-writer engine blocks concurrent writers; Reset assumes the runtime has
+// already verified the share is disabled.
+//
+// SQLite has no TRUNCATE; truncateAllTables issues an FK-safe sequence of
+// DELETEs (reverse dependency order). The in-memory used-bytes / quota counters
+// are reset to empty afterwards so a reused store handle reports zero usage.
+func (s *SQLiteMetadataStore) Reset(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("reset cancelled: %w", err)
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("reset: begin txn: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if err := truncateAllTables(ctx, tx); err != nil {
+		return fmt.Errorf("reset: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("reset: commit: %w", err)
+	}
+	committed = true
+
+	// Reset the in-memory counters to match the now-empty tables.
+	s.usedBytes.Store(0)
+	s.quotaMu.Lock()
+	s.userUsage = make(map[uint32]*metadata.UsageStat)
+	s.groupUsage = make(map[uint32]*metadata.UsageStat)
+	s.quotaMu.Unlock()
+	return nil
+}

--- a/pkg/metadata/store/sqlite/rollup.go
+++ b/pkg/metadata/store/sqlite/rollup.go
@@ -1,0 +1,163 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// ============================================================================
+// RollupStore Implementation for SQLite Store
+// ============================================================================
+//
+// Persists the per-file rollup_offset for the hybrid append-log tier. The
+// atomic-monotone contract is enforced by a conditional upsert that rejects a
+// strictly-lower offset in its WHERE predicate, rather than a prior read — so
+// a concurrent writer cannot regress the value (see SetRollupOffset / INV-03).
+//
+// The rollup_offsets table lives in the initial schema migration.
+// ============================================================================
+
+// Compile-time assertion: the SQLite engine implements RollupStore.
+var _ metadata.RollupStore = (*SQLiteMetadataStore)(nil)
+
+// validateStoredOffset converts a stored (signed int64) rollup offset to uint64,
+// rejecting negative values that can only arise from on-disk corruption
+// or out-of-band SQL writes (FIX-14: the write path bounds-checks against
+// MaxInt64 and uint64 inputs cannot produce a negative cast).
+func validateStoredOffset(v int64) (uint64, error) {
+	if v < 0 {
+		return 0, fmt.Errorf("sqlite rollup: stored offset %d is negative (corruption)", v)
+	}
+	return uint64(v), nil
+}
+
+// SetRollupOffset atomically advances payloadID -> newOffset iff
+// newOffset >= the currently-stored value. Returns the PREVIOUS stored
+// value on success.
+//
+// On monotone violation (newOffset < stored), returns (storedOffset,
+// metadata.ErrRollupOffsetRegression); the stored value is UNCHANGED.
+//
+// Atomicity: the monotone invariant (INV-03) is enforced by the conditional
+// WHERE predicate on the ON CONFLICT DO UPDATE branch — a regression performs
+// no write and reports RowsAffected()==0. This holds even for concurrent
+// first-inserts (no row to FOR UPDATE-lock): they converge under the
+// unique-key conflict and the WHERE guard rejects the lower offset.
+//
+// The prior value is read separately (FOR UPDATE) only to return `prev` on
+// success. It is NOT projected out of an
+// INSERT ... ON CONFLICT ... RETURNING (SELECT rollup_offset FROM cte): the
+// CTE and the conflict target are the same row, so that subquery resolves to
+// NULL and reported prev=0 on every update.
+func (s *SQLiteMetadataStore) SetRollupOffset(ctx context.Context, payloadID string, newOffset uint64) (uint64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	// FIX-14: rollup_offset is stored as a signed int64 (SQLite INTEGER). Reject
+	// any newOffset that does not fit so we never overflow the column with a
+	// silently-truncated cast. In practice no real file approaches 2^63 bytes,
+	// but the guard prevents a cast-induced negative-offset corruption from
+	// reaching the database.
+	if newOffset > math.MaxInt64 {
+		return 0, fmt.Errorf("rollup offset %d exceeds int64 range", newOffset)
+	}
+
+	rawTx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("sqlite rollup begin: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = rawTx.Rollback()
+		}
+	}()
+	tx := execer{e: rawTx, op: "SetRollupOffset"}
+
+	// Read the prior value for the returned `prev`. ErrNoRows means no row yet
+	// (prev == 0). This read is NOT the authority for the monotone invariant —
+	// two concurrent first-inserts both see no row. The conditional WHERE
+	// predicate on the upsert below is the authority (INV-03).
+	var prev uint64
+	var prevSigned int64
+	switch err := tx.QueryRow(ctx,
+		`SELECT rollup_offset FROM rollup_offsets WHERE payload_id = ?1`,
+		payloadID).Scan(&prevSigned); {
+	case errors.Is(err, sql.ErrNoRows):
+		// No prior row yet: prev stays 0.
+	case err != nil:
+		return 0, fmt.Errorf("sqlite rollup select: %w", err)
+	default:
+		v, verr := validateStoredOffset(prevSigned)
+		if verr != nil {
+			return 0, verr
+		}
+		prev = v
+	}
+
+	// Monotone upsert: the WHERE predicate rejects a strictly-lower offset on
+	// the conflict branch, so a regression performs no write and reports
+	// RowsAffected()==0. This is the single point that enforces INV-03 and is
+	// safe even when no row existed at the SELECT above (concurrent
+	// first-inserts converge here under the unique-key conflict).
+	tag, err := tx.Exec(ctx,
+		`INSERT INTO rollup_offsets (payload_id, rollup_offset)
+		 VALUES (?1, ?2)
+		 ON CONFLICT (payload_id) DO UPDATE SET rollup_offset = EXCLUDED.rollup_offset
+		 WHERE rollup_offsets.rollup_offset <= EXCLUDED.rollup_offset`,
+		payloadID, int64(newOffset))
+	if err != nil {
+		return 0, fmt.Errorf("sqlite rollup upsert: %w", err)
+	}
+
+	if tag.RowsAffected() == 0 {
+		// Regression: a row exists with a strictly-higher offset (this caller's
+		// newOffset < stored, possibly written by a racing first-insert). Read
+		// the committed value to report; the stored value is left UNCHANGED
+		// (deferred Rollback releases the lock without writing).
+		var stored int64
+		if err := tx.QueryRow(ctx,
+			`SELECT rollup_offset FROM rollup_offsets WHERE payload_id = ?1`,
+			payloadID).Scan(&stored); err != nil {
+			return 0, fmt.Errorf("sqlite rollup read after regression: %w", err)
+		}
+		v, verr := validateStoredOffset(stored)
+		if verr != nil {
+			return 0, verr
+		}
+		return v, metadata.ErrRollupOffsetRegression
+	}
+
+	if err := rawTx.Commit(); err != nil {
+		return 0, fmt.Errorf("sqlite rollup commit: %w", err)
+	}
+	committed = true
+	return prev, nil
+}
+
+// GetRollupOffset returns the persisted rollup_offset for payloadID, or
+// (0, nil) if unset. Matches the contract in metadata.RollupStore — a
+// fresh file is treated as rolled-up-to-0.
+func (s *SQLiteMetadataStore) GetRollupOffset(ctx context.Context, payloadID string) (uint64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	row := s.queryRow(ctx,
+		`SELECT rollup_offset FROM rollup_offsets WHERE payload_id = ?1`,
+		payloadID)
+	var v int64
+	if err := row.Scan(&v); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("sqlite rollup select: %w", err)
+	}
+	return validateStoredOffset(v)
+}

--- a/pkg/metadata/store/sqlite/server.go
+++ b/pkg/metadata/store/sqlite/server.go
@@ -1,0 +1,150 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// ============================================================================
+// Server Configuration
+// ============================================================================
+
+// GetServerConfig retrieves server-wide configuration
+func (s *SQLiteMetadataStore) GetServerConfig(ctx context.Context) (metadata.MetadataServerConfig, error) {
+	query := `SELECT config FROM server_config WHERE id = 1`
+
+	// config is stored as a JSON TEXT column; scan the raw bytes and unmarshal
+	// (SQLite, unlike Postgres JSONB, does not auto-decode into a Go map).
+	var raw []byte
+	err := s.queryRow(ctx, query).Scan(&raw)
+	if errors.Is(err, sql.ErrNoRows) {
+		// A fresh store has no persisted config row. Match the memory and
+		// badger backends: report an empty (non-nil) config, not a
+		// not-found error, so callers can write to CustomSettings.
+		return metadata.MetadataServerConfig{CustomSettings: map[string]any{}}, nil
+	}
+	if err != nil {
+		return metadata.MetadataServerConfig{}, mapDBError(err, "GetServerConfig", "")
+	}
+
+	customSettings := map[string]any{}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &customSettings); err != nil {
+			return metadata.MetadataServerConfig{}, mapDBError(err, "GetServerConfig", "")
+		}
+	}
+	return metadata.MetadataServerConfig{
+		CustomSettings: customSettings,
+	}, nil
+}
+
+// SetServerConfig updates server-wide configuration
+func (s *SQLiteMetadataStore) SetServerConfig(ctx context.Context, config metadata.MetadataServerConfig) error {
+	query := `
+		INSERT INTO server_config (id, config)
+		VALUES (1, ?1)
+		ON CONFLICT (id) DO UPDATE
+		SET config = EXCLUDED.config, updated_at = CURRENT_TIMESTAMP
+	`
+
+	settings := config.CustomSettings
+	if settings == nil {
+		settings = map[string]any{}
+	}
+	raw, err := json.Marshal(settings)
+	if err != nil {
+		return mapDBError(err, "SetServerConfig", "")
+	}
+	_, err = s.exec(ctx, query, raw)
+	return err
+}
+
+// ============================================================================
+// Filesystem Capabilities
+// ============================================================================
+
+// GetFilesystemCapabilities returns the filesystem capabilities
+func (s *SQLiteMetadataStore) GetFilesystemCapabilities(ctx context.Context, handle metadata.FileHandle) (*metadata.FilesystemCapabilities, error) {
+	// Return cached capabilities (set during initialization)
+	// Note: handle parameter not used as capabilities are share-level, not file-level
+	return &s.capabilities, nil
+}
+
+// SetFilesystemCapabilities updates the filesystem capabilities
+func (s *SQLiteMetadataStore) SetFilesystemCapabilities(capabilities metadata.FilesystemCapabilities) {
+	// Update cached capabilities
+	s.capabilities = capabilities
+
+	// Update database (best effort - don't fail if it errors)
+	// This is called during initialization, so database updates are non-critical
+	ctx := context.Background()
+	query := `
+		INSERT INTO filesystem_capabilities (
+			id, max_read_size, preferred_read_size, max_write_size, preferred_write_size,
+			max_file_size, max_filename_len, max_path_len, max_hard_link_count,
+			supports_hard_links, supports_symlinks, case_sensitive, case_preserving,
+			supports_acls, time_resolution
+		) VALUES (
+			1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14
+		)
+		ON CONFLICT (id) DO UPDATE SET
+			max_read_size = EXCLUDED.max_read_size,
+			preferred_read_size = EXCLUDED.preferred_read_size,
+			max_write_size = EXCLUDED.max_write_size,
+			preferred_write_size = EXCLUDED.preferred_write_size,
+			max_file_size = EXCLUDED.max_file_size,
+			max_filename_len = EXCLUDED.max_filename_len,
+			max_path_len = EXCLUDED.max_path_len,
+			max_hard_link_count = EXCLUDED.max_hard_link_count,
+			supports_hard_links = EXCLUDED.supports_hard_links,
+			supports_symlinks = EXCLUDED.supports_symlinks,
+			case_sensitive = EXCLUDED.case_sensitive,
+			case_preserving = EXCLUDED.case_preserving,
+			supports_acls = EXCLUDED.supports_acls,
+			time_resolution = EXCLUDED.time_resolution
+	`
+
+	_, err := s.exec(ctx, query,
+		capabilities.MaxReadSize,
+		capabilities.PreferredReadSize,
+		capabilities.MaxWriteSize,
+		capabilities.PreferredWriteSize,
+		capabilities.MaxFileSize,
+		capabilities.MaxFilenameLen,
+		capabilities.MaxPathLen,
+		capabilities.MaxHardLinkCount,
+		capabilities.SupportsHardLinks,
+		capabilities.SupportsSymlinks,
+		capabilities.CaseSensitive,
+		capabilities.CasePreserving,
+		capabilities.SupportsACLs,
+		capabilities.TimestampResolution,
+	)
+
+	// Log error but don't fail - capabilities are already cached
+	if err != nil {
+		s.logger.Warn("Failed to persist capabilities to database", "error", err)
+	}
+}
+
+// ============================================================================
+// Filesystem Statistics
+// ============================================================================
+
+// GetFilesystemStatistics returns filesystem statistics scoped to the share
+// encoded in the handle. The store-wide atomic usedBytes counter cannot answer
+// a per-share query, so a scoped SQL aggregate (statfsQuery) is used instead.
+// An undecodable handle falls back to the store-wide totals (single-share
+// compatible).
+func (s *SQLiteMetadataStore) GetFilesystemStatistics(ctx context.Context, handle metadata.FileHandle) (*metadata.FilesystemStatistics, error) {
+	sql, args := statfsQuery(handle)
+	var bytesUsed, filesUsed int64
+	if err := s.queryRow(ctx, sql, args...).Scan(&bytesUsed, &filesUsed); err != nil {
+		return nil, mapDBError(err, "GetFilesystemStatistics", "")
+	}
+	return buildFilesystemStatistics(bytesUsed, filesUsed), nil
+}

--- a/pkg/metadata/store/sqlite/shares.go
+++ b/pkg/metadata/store/sqlite/shares.go
@@ -1,0 +1,509 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// ============================================================================
+// Handle/Share Operations
+// ============================================================================
+
+// GenerateHandle creates a new unique file handle for a path in a share.
+func (s *SQLiteMetadataStore) GenerateHandle(ctx context.Context, shareName string, path string) (metadata.FileHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// Handles are UUID-based; the path is stored in the File struct.
+	return metadata.GenerateNewHandle(shareName)
+}
+
+// GetRootHandle returns the root handle for a share.
+// Returns ErrNotFound if the share doesn't exist.
+func (s *SQLiteMetadataStore) GetRootHandle(ctx context.Context, shareName string) (metadata.FileHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	query := `SELECT root_file_id FROM shares WHERE share_name = ?1`
+
+	var rootID uuid.UUID
+	err := s.queryRow(ctx, query, shareName).Scan(&rootID)
+	if err != nil {
+		return nil, mapDBError(err, "GetRootHandle", shareName)
+	}
+
+	return metadata.EncodeShareHandle(shareName, rootID)
+}
+
+// GetShareOptions returns the share configuration options.
+// Returns ErrNotFound if the share doesn't exist.
+//
+// The block_layout column is read alongside the legacy options JSON
+// blob and overrides whatever the JSON happens to contain — the
+// dedicated column is the authoritative source per
+// (D-A6). Empty / NULL values coerce to legacy via
+// ParseBlockLayout for forward-compat with pre-migration rows.
+func (s *SQLiteMetadataStore) GetShareOptions(ctx context.Context, shareName string) (*metadata.ShareOptions, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	query := `SELECT options, block_layout FROM shares WHERE share_name = ?1`
+
+	var (
+		optionsJSON     []byte
+		blockLayoutText string
+	)
+	err := s.queryRow(ctx, query, shareName).Scan(&optionsJSON, &blockLayoutText)
+	if err != nil {
+		return nil, mapDBError(err, "GetShareOptions", shareName)
+	}
+
+	var options metadata.ShareOptions
+	if len(optionsJSON) > 0 {
+		if err := json.Unmarshal(optionsJSON, &options); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal share options: %w", err)
+		}
+	}
+
+	// Authoritative: the dedicated block_layout column overrides any
+	// stale value embedded in the JSON blob. ParseBlockLayout coerces
+	// the empty-string default (DEFAULT 'legacy' in the schema, but
+	// also any pre-migration row with NULL→"" via the COALESCE-like
+	// behavior of TEXT NOT NULL DEFAULT) into BlockLayoutLegacy.
+	// Unknown values surface ErrInvalidBlockLayout.
+	layout, err := metadata.ParseBlockLayout(blockLayoutText)
+	if err != nil {
+		return nil, fmt.Errorf("share %q: %w", shareName, err)
+	}
+	options.BlockLayout = layout
+
+	return &options, nil
+}
+
+// ============================================================================
+// Share Lifecycle Operations
+// ============================================================================
+
+// CreateShare creates a new share with the given configuration.
+//
+// The block_layout column is populated from share.Options.BlockLayout;
+// an unset / zero-value field is normalized through ParseBlockLayout
+// (so it stores as 'legacy', matching the schema DEFAULT and D-A6
+// safe-default semantics).
+func (s *SQLiteMetadataStore) CreateShare(ctx context.Context, share *metadata.Share) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	// The shares.root_file_id column is NOT NULL with an FK to inodes(id), so
+	// a share row cannot exist before its root inode — a bare
+	// INSERT INTO shares (share_name, options, ...) is structurally
+	// impossible (it raises a not_null_violation on root_file_id) and never
+	// once succeeded. Honour the documented contract ("Also creates the root
+	// directory for the share", matching the memory/badger backends) by
+	// materializing a default root directory, which inserts the shares row
+	// via CreateRootDirectory's ON CONFLICT upsert, then persisting the
+	// caller's options. Callers wanting specific root attrs invoke
+	// CreateRootDirectory afterward; it is idempotent and updates the
+	// existing root in place (no orphaned inode).
+
+	// Validate the block layout BEFORE creating any rows so an invalid value
+	// can't leave a half-created share (root inode materialized, options
+	// rejected). UpdateShareOptions re-parses it; this is the early guard.
+	if _, err := metadata.ParseBlockLayout(string(share.Options.BlockLayout)); err != nil {
+		return fmt.Errorf("create share %q: %w", share.Name, err)
+	}
+
+	// Duplicate detection: a share is "created" once its root inode exists.
+	// This read is the common-case fast path; it is not the integrity
+	// authority. The shares table PRIMARY KEY(share_name) is the authority —
+	// two creators racing the same name both pass this check and reach
+	// CreateRootDirectory, but the second INSERT INTO shares conflicts on the
+	// primary key (the ON CONFLICT upsert just re-points root_file_id, leaving
+	// at most one root). (Production also serializes share creation upstream in
+	// the control plane.)
+	existing, err := s.getExistingRootDirectory(ctx, share.Name)
+	if err != nil {
+		return fmt.Errorf("create share %q: check existing: %w", share.Name, err)
+	}
+	if existing != nil {
+		return &metadata.StoreError{
+			Code:    metadata.ErrAlreadyExists,
+			Message: "share already exists",
+			Path:    share.Name,
+		}
+	}
+
+	rootAttr := &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory,
+		Mode: 0o755,
+	}
+	if _, err := s.CreateRootDirectory(ctx, share.Name, rootAttr); err != nil {
+		return fmt.Errorf("create share %q root directory: %w", share.Name, err)
+	}
+
+	// Persist the requested options + block layout on the freshly-inserted
+	// row (CreateRootDirectory seeds only share_name + root_file_id, leaving
+	// options/block_layout at their column defaults). UpdateShareOptions
+	// applies the same ParseBlockLayout normalization the old INSERT did.
+	if err := s.UpdateShareOptions(ctx, share.Name, &share.Options); err != nil {
+		return fmt.Errorf("create share %q options: %w", share.Name, err)
+	}
+
+	return nil
+}
+
+// UpdateShareOptions updates the share configuration options.
+//
+// The block_layout column is updated alongside the JSON options blob.
+// This is how `dfsctl blockstore migrate` flips a share from `legacy`
+// to `cas-only` once the integrity check passes (D-A7); the operation
+// is a single SQL UPDATE so the flip is atomic with whatever other
+// option changes the migration tool wants to bundle.
+func (s *SQLiteMetadataStore) UpdateShareOptions(ctx context.Context, shareName string, options *metadata.ShareOptions) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	optionsData, err := json.Marshal(options)
+	if err != nil {
+		return fmt.Errorf("failed to marshal share options: %w", err)
+	}
+
+	layout, err := metadata.ParseBlockLayout(string(options.BlockLayout))
+	if err != nil {
+		return fmt.Errorf("share %q: %w", shareName, err)
+	}
+
+	query := `UPDATE shares SET options = ?1, block_layout = ?2 WHERE share_name = ?3`
+	result, err := s.exec(ctx, query, optionsData, string(layout), shareName)
+	if err != nil {
+		return err
+	}
+
+	if result.RowsAffected() == 0 {
+		return &metadata.StoreError{
+			Code:    metadata.ErrNotFound,
+			Message: "share not found",
+			Path:    shareName,
+		}
+	}
+
+	return nil
+}
+
+// DeleteShare removes a share and all its metadata. Runs inside a
+// transaction so the share row and its file rows are dropped atomically
+// (see the tx-path for the cascade rationale).
+func (s *SQLiteMetadataStore) DeleteShare(ctx context.Context, shareName string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.DeleteShare(ctx, shareName)
+	})
+}
+
+// ListShares returns the names of all shares.
+func (s *SQLiteMetadataStore) ListShares(ctx context.Context) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	rows, err := s.query(ctx, `SELECT share_name FROM shares`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+	}
+
+	// Surface any error that terminated the iteration early so a partial
+	// share list is not returned as if it were complete.
+	if err := rows.Err(); err != nil {
+		return nil, mapDBError(err, "ListShares", "")
+	}
+
+	return names, nil
+}
+
+// ============================================================================
+// Root Directory Operations
+// ============================================================================
+
+// CreateRootDirectory creates the root directory for a share
+func (s *SQLiteMetadataStore) CreateRootDirectory(
+	ctx context.Context,
+	shareName string,
+	attr *metadata.FileAttr,
+) (*metadata.File, error) {
+	if shareName == "" {
+		return nil, &metadata.StoreError{
+			Code:    metadata.ErrInvalidArgument,
+			Message: "share name cannot be empty",
+		}
+	}
+
+	// Apply defaults
+	uid := attr.UID
+	gid := attr.GID
+	mode := attr.Mode
+	if mode == 0 {
+		mode = 0o755
+	}
+
+	s.logger.Info("Creating root directory",
+		"share", shareName,
+		"uid", uid,
+		"gid", gid,
+	)
+
+	// Check if root directory already exists (idempotent behavior)
+	existingRoot, err := s.getExistingRootDirectory(ctx, shareName)
+	if err == nil && existingRoot != nil {
+		// Check if root directory attributes need to be updated from config
+		// This handles the case where the config changed since the share was first created
+		needsUpdate := false
+		if mode != 0 && existingRoot.Mode != mode {
+			s.logger.Info("Updating root directory mode from config",
+				"share", shareName,
+				"oldMode", fmt.Sprintf("%o", existingRoot.Mode),
+				"newMode", fmt.Sprintf("%o", mode))
+			existingRoot.Mode = mode
+			needsUpdate = true
+		}
+		if existingRoot.UID != uid {
+			s.logger.Info("Updating root directory UID from config",
+				"share", shareName,
+				"oldUID", existingRoot.UID,
+				"newUID", uid)
+			existingRoot.UID = uid
+			needsUpdate = true
+		}
+		if existingRoot.GID != gid {
+			s.logger.Info("Updating root directory GID from config",
+				"share", shareName,
+				"oldGID", existingRoot.GID,
+				"newGID", gid)
+			existingRoot.GID = gid
+			needsUpdate = true
+		}
+
+		if needsUpdate {
+			now := time.Now()
+			updateQuery := `
+				UPDATE inodes
+				SET mode = ?1, uid = ?2, gid = ?3, ctime = ?4
+				WHERE id = ?5
+			`
+			_, err := s.exec(ctx, updateQuery,
+				int32(existingRoot.Mode),
+				int32(existingRoot.UID),
+				int32(existingRoot.GID),
+				timeToNanos(now),
+				existingRoot.ID,
+			)
+			if err != nil {
+				return nil, err
+			}
+			existingRoot.Ctime = now
+			s.logger.Info("Root directory attributes updated from config",
+				"share", shareName,
+				"root_id", existingRoot.ID)
+		} else {
+			s.logger.Info("Root directory already exists, returning existing",
+				"share", shareName,
+				"root_id", existingRoot.ID,
+			)
+		}
+		return existingRoot, nil
+	}
+
+	// Begin transaction.
+	rawTx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, mapDBError(err, "CreateRootDirectory", shareName)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = rawTx.Rollback()
+		}
+	}()
+	tx := execer{e: rawTx, op: "CreateRootDirectory"}
+
+	// Generate UUID for root directory
+	rootID := uuid.New()
+
+	now := time.Now()
+
+	// Insert root directory inode. Directories start with nlink = 2 ("." and the
+	// parent's entry). nlink is the sole source of truth for the hard-link count
+	// (#1166).
+	insertFileQuery := `
+		INSERT INTO inodes (
+			id, share_name,
+			file_type, mode, uid, gid, size,
+			atime, mtime, ctime, creation_time,
+			content_id, link_target, device_major, device_minor, nlink
+		) VALUES (
+			?1, ?2,
+			?3, ?4, ?5, ?6, ?7,
+			?8, ?9, ?10, ?11,
+			?12, ?13, ?14, ?15, 2
+		)
+	`
+
+	_, err = tx.Exec(ctx, insertFileQuery,
+		rootID,                            // id
+		shareName,                         // share_name
+		int16(metadata.FileTypeDirectory), // file_type
+		int32(mode),                       // mode
+		int32(uid),                        // uid
+		int32(gid),                        // gid
+		int64(0),                          // size
+		timeToNanos(now),                  // atime
+		timeToNanos(now),                  // mtime
+		timeToNanos(now),                  // ctime
+		timeToNanos(now),                  // creation_time
+		nil,                               // content_id (NULL for directories)
+		nil,                               // link_target (NULL)
+		nil,                               // device_major (NULL)
+		nil,                               // device_minor (NULL)
+	)
+	if err != nil {
+		return nil, mapDBError(err, "CreateRootDirectory", shareName)
+	}
+
+	// Insert into shares table
+	insertShareQuery := `
+		INSERT INTO shares (share_name, root_file_id)
+		VALUES (?1, ?2)
+		ON CONFLICT (share_name) DO UPDATE
+		SET root_file_id = EXCLUDED.root_file_id
+	`
+
+	_, err = tx.Exec(ctx, insertShareQuery, shareName, rootID)
+	if err != nil {
+		return nil, mapDBError(err, "CreateRootDirectory", shareName)
+	}
+
+	// Commit transaction
+	if err := rawTx.Commit(); err != nil {
+		return nil, mapDBError(err, "CreateRootDirectory", shareName)
+	}
+	committed = true
+
+	s.logger.Info("Root directory created successfully",
+		"share", shareName,
+		"root_id", rootID,
+	)
+
+	// Build File
+	file := &metadata.File{
+		ID:        rootID,
+		ShareName: shareName,
+		Path:      "/",
+		FileAttr: metadata.FileAttr{
+			Type:         metadata.FileTypeDirectory,
+			Mode:         mode,
+			Nlink:        2, // Root directories have 2 links ("." and parent's entry)
+			UID:          uid,
+			GID:          gid,
+			Size:         0,
+			Atime:        now,
+			Mtime:        now,
+			Ctime:        now,
+			CreationTime: now,
+		},
+	}
+
+	return file, nil
+}
+
+// getExistingRootDirectory checks if a root directory already exists for the share
+// and returns it if found. Returns nil, nil if not found.
+func (s *SQLiteMetadataStore) getExistingRootDirectory(ctx context.Context, shareName string) (*metadata.File, error) {
+	// Resolve the root inode via shares.root_file_id (the share row is the
+	// authoritative pointer to its root) now that the path column is gone (#1166).
+	query := `
+		SELECT f.id, f.file_type, f.mode, f.uid, f.gid, f.size,
+			   f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.nlink
+		FROM inodes f
+		WHERE f.id = (SELECT root_file_id FROM shares WHERE share_name = ?1)
+	`
+
+	var (
+		id           uuid.UUID
+		fileType     int16
+		mode         int32
+		uid          int32
+		gid          int32
+		size         int64
+		atime        int64
+		mtime        int64
+		ctime        int64
+		creationTime int64
+		hidden       bool
+		nlink        int32
+	)
+
+	err := s.queryRow(ctx, query, shareName).Scan(
+		&id,
+		&fileType,
+		&mode,
+		&uid,
+		&gid,
+		&size,
+		&atime,
+		&mtime,
+		&ctime,
+		&creationTime,
+		&hidden,
+		&nlink,
+	)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil // Not found, not an error
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &metadata.File{
+		ID:        id,
+		ShareName: shareName,
+		Path:      "/",
+		FileAttr: metadata.FileAttr{
+			Type:         metadata.FileType(fileType),
+			Mode:         uint32(mode),
+			Nlink:        uint32(nlink),
+			UID:          uint32(uid),
+			GID:          uint32(gid),
+			Size:         uint64(size),
+			Atime:        nanosToTime(atime),
+			Mtime:        nanosToTime(mtime),
+			Ctime:        nanosToTime(ctime),
+			CreationTime: nanosToTime(creationTime),
+			Hidden:       hidden,
+		},
+	}, nil
+}

--- a/pkg/metadata/store/sqlite/sqlite_conformance_test.go
+++ b/pkg/metadata/store/sqlite/sqlite_conformance_test.go
@@ -1,0 +1,157 @@
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
+	"github.com/marmos91/dittofs/pkg/metadata/storetest"
+)
+
+// sqliteTestCapabilities returns the capabilities every SQLite test store is
+// opened with. Mirrors the Postgres conformance capabilities so the shared
+// suite asserts identical behavior across backends.
+func sqliteTestCapabilities() metadata.FilesystemCapabilities {
+	return metadata.FilesystemCapabilities{
+		MaxReadSize:         1048576,
+		PreferredReadSize:   1048576,
+		MaxWriteSize:        1048576,
+		PreferredWriteSize:  1048576,
+		MaxFileSize:         9223372036854775807,
+		MaxFilenameLen:      255,
+		MaxPathLen:          4096,
+		MaxHardLinkCount:    32767,
+		SupportsHardLinks:   true,
+		SupportsSymlinks:    true,
+		CaseSensitive:       true,
+		CasePreserving:      true,
+		TimestampResolution: 1,
+	}
+}
+
+// newSQLiteStoreFactory returns a factory that hands each conformance subtest a
+// CLEAN store backed by its own on-disk database file in a per-subtest temp
+// directory. A fresh file per subtest guarantees isolation without any shared
+// state — sidestepping the shared-DB pollution traps the Postgres backend has
+// to defend against. AutoMigrate creates the schema on open. The store is
+// closed via t.Cleanup.
+func newSQLiteStoreFactory() func(t *testing.T) metadata.Store {
+	return func(t *testing.T) metadata.Store {
+		t.Helper()
+		dbPath := filepath.Join(t.TempDir(), "conformance.db")
+		cfg := &sqlite.SQLiteMetadataStoreConfig{
+			Path:        dbPath,
+			AutoMigrate: true,
+		}
+		store, err := sqlite.NewSQLiteMetadataStore(context.Background(), cfg, sqliteTestCapabilities())
+		if err != nil {
+			t.Fatalf("NewSQLiteMetadataStore() failed: %v", err)
+		}
+		t.Cleanup(func() { _ = store.Close() })
+		return store
+	}
+}
+
+func TestConformance(t *testing.T) {
+	storetest.RunConformanceSuite(t, newSQLiteStoreFactory())
+}
+
+func TestBackupConformance(t *testing.T) {
+	storetest.RunBackupConformanceSuite(t, newSQLiteStoreFactory())
+}
+
+func TestResetThenRestoreConformance(t *testing.T) {
+	storetest.ResetThenRestoreConformance(t, newSQLiteStoreFactory())
+}
+
+func TestLockPersistenceConformance(t *testing.T) {
+	factory := newSQLiteStoreFactory()
+	storetest.RunLockPersistenceSuite(t, func(t *testing.T) lock.LockStore {
+		return factory(t).(lock.LockStore)
+	})
+}
+
+// TestSQLite_TxServerConfigRoundTrip exercises the transaction-scoped
+// SetServerConfig / GetServerConfig path, which the shared conformance suite
+// does not cover (it only drives the pool path). The config column is JSON
+// TEXT, so the tx path must marshal/unmarshal explicitly rather than binding a
+// Go map directly to the driver.
+func TestSQLite_TxServerConfigRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := newSQLiteStoreFactory()(t)
+
+	want := metadata.MetadataServerConfig{
+		CustomSettings: map[string]any{"feature": "on", "n": float64(7)},
+	}
+	if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.SetServerConfig(ctx, want)
+	}); err != nil {
+		t.Fatalf("tx SetServerConfig failed: %v", err)
+	}
+
+	var got metadata.MetadataServerConfig
+	if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		var err error
+		got, err = tx.GetServerConfig(ctx)
+		return err
+	}); err != nil {
+		t.Fatalf("tx GetServerConfig failed: %v", err)
+	}
+	if got.CustomSettings["feature"] != "on" || got.CustomSettings["n"] != float64(7) {
+		t.Fatalf("tx server config round-trip mismatch: got %#v", got.CustomSettings)
+	}
+
+	// The pool path must observe the tx-written config too.
+	poolGot, err := store.GetServerConfig(ctx)
+	if err != nil {
+		t.Fatalf("pool GetServerConfig failed: %v", err)
+	}
+	if poolGot.CustomSettings["feature"] != "on" {
+		t.Fatalf("pool path did not observe tx-written config: %#v", poolGot.CustomSettings)
+	}
+}
+
+// TestSQLite_CleanShutdownMarkerDurable pins that a graceful Close records the
+// clean-shutdown marker durably across a close+reopen against the same database
+// file: a freshly-opened store defaults to unclean; a graceful Close records
+// clean=true; reopening a NEW store against the same file reads it back.
+func TestSQLite_CleanShutdownMarkerDurable(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "cleanshutdown.db")
+	cfg := &sqlite.SQLiteMetadataStoreConfig{Path: dbPath, AutoMigrate: true}
+
+	seed, err := sqlite.NewSQLiteMetadataStore(ctx, cfg, sqliteTestCapabilities())
+	if err != nil {
+		t.Fatalf("open seed: %v", err)
+	}
+	// A fresh store has no server_epoch row yet, so it must read unclean.
+	clean, err := seed.GetCleanShutdown(ctx)
+	if err != nil {
+		_ = seed.Close()
+		t.Fatalf("GetCleanShutdown (fresh): %v", err)
+	}
+	if clean {
+		_ = seed.Close()
+		t.Fatalf("fresh store reported clean=true; absent marker must read unclean")
+	}
+	// Graceful Close records clean=true.
+	if err := seed.Close(); err != nil {
+		t.Fatalf("seed Close: %v", err)
+	}
+
+	store, err := sqlite.NewSQLiteMetadataStore(ctx, cfg, sqliteTestCapabilities())
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	clean, err = store.GetCleanShutdown(ctx)
+	if err != nil {
+		t.Fatalf("GetCleanShutdown (reopen): %v", err)
+	}
+	if !clean {
+		t.Fatalf("graceful Close must durably record clean=true across reopen; got false")
+	}
+}

--- a/pkg/metadata/store/sqlite/statfs.go
+++ b/pkg/metadata/store/sqlite/statfs.go
@@ -1,0 +1,64 @@
+package sqlite
+
+import (
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// Sentinel capacity values reported by GetFilesystemStatistics. The Postgres
+// backend imposes no hard quota, so these are "effectively unlimited" ceilings.
+const (
+	statfsTotalBytes uint64 = 1 << 50 // 1 PB
+	statfsTotalFiles uint64 = 1 << 32 // 4 billion files
+)
+
+// statfsQuery builds the aggregate query (and its args) for
+// GetFilesystemStatistics. When the handle decodes to a share name the
+// aggregate is scoped to that share with a WHERE predicate; otherwise it falls
+// back to the store-wide aggregate (single-share compatible). An undecodable
+// handle is treated as the store-wide case rather than an error.
+//
+// The aggregate counts only regular files, matching the semantics of the
+// store-wide usedBytes counter (initUsedBytesCounter) it replaces: directories,
+// symlinks and other non-regular entries carry no logical bytes and must not
+// inflate UsedFiles (the share root directory would otherwise be counted).
+//
+// Both the pool and transaction implementations share this so the scoping rule
+// lives in exactly one place.
+func statfsQuery(handle metadata.FileHandle) (sql string, args []any) {
+	shareName, _, decodeErr := metadata.DecodeFileHandle(handle)
+	if decodeErr != nil {
+		shareName = ""
+	}
+	if shareName != "" {
+		return `SELECT COALESCE(SUM(size), 0), COUNT(*) FROM inodes WHERE share_name = ?1 AND file_type = ?2`,
+			[]any{shareName, int(metadata.FileTypeRegular)}
+	}
+	return `SELECT COALESCE(SUM(size), 0), COUNT(*) FROM inodes WHERE file_type = ?1`,
+		[]any{int(metadata.FileTypeRegular)}
+}
+
+// buildFilesystemStatistics assembles a FilesystemStatistics from the scanned
+// aggregate counts, clamping available space to zero if usage somehow exceeds
+// the (effectively unlimited) ceilings.
+func buildFilesystemStatistics(bytesUsed, filesUsed int64) *metadata.FilesystemStatistics {
+	used := uint64(bytesUsed)
+	usedFiles := uint64(filesUsed)
+
+	availableBytes := uint64(0)
+	if statfsTotalBytes > used {
+		availableBytes = statfsTotalBytes - used
+	}
+	availableFiles := uint64(0)
+	if statfsTotalFiles > usedFiles {
+		availableFiles = statfsTotalFiles - usedFiles
+	}
+
+	return &metadata.FilesystemStatistics{
+		TotalBytes:     statfsTotalBytes,
+		AvailableBytes: availableBytes,
+		UsedBytes:      used,
+		TotalFiles:     statfsTotalFiles,
+		AvailableFiles: availableFiles,
+		UsedFiles:      usedFiles,
+	}
+}

--- a/pkg/metadata/store/sqlite/store.go
+++ b/pkg/metadata/store/sqlite/store.go
@@ -1,0 +1,374 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	// glebarez/go-sqlite is a pure-Go (no cgo) SQLite driver — a fork of
+	// modernc.org/sqlite — that registers the database/sql driver name
+	// "sqlite". The control-plane GORM layer uses the same package, so a single
+	// registration serves both. Importing modernc.org/sqlite directly would
+	// register "sqlite" a SECOND time and panic at init.
+	_ "github.com/glebarez/go-sqlite"
+	"github.com/oklog/ulid/v2"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// sqliteDriverName is the database/sql driver name registered by the imported
+// pure-Go SQLite driver.
+const sqliteDriverName = "sqlite"
+
+// SQLiteMetadataStore implements the metadata.Store interface using an embedded
+// SQLite database (modernc.org/sqlite, pure Go, no cgo). It is a near-verbatim
+// port of the Postgres store: the schema, recursive-CTE path reconstruction,
+// hard-link model (parent_child_map + nlink), and object_id dedup index are all
+// preserved, with SQL adapted to the SQLite dialect.
+type SQLiteMetadataStore struct {
+	// db is the database/sql handle over the single SQLite file. SQLite is a
+	// single-writer engine; the pool is bounded to keep contention predictable.
+	db *sql.DB
+
+	// config holds the store configuration.
+	config *SQLiteMetadataStoreConfig
+
+	// capabilities holds the filesystem capabilities.
+	capabilities metadata.FilesystemCapabilities
+
+	// logger for structured logging.
+	logger *slog.Logger
+
+	// ctx is the store context (for graceful shutdown).
+	ctx context.Context
+
+	// cancel cancels the store context.
+	cancel context.CancelFunc
+
+	// usedBytes tracks the total logical bytes used by regular files. Updated
+	// atomically on every size-changing operation. Initialized from a SQL SUM
+	// query on startup.
+	usedBytes atomic.Int64
+
+	// userUsage / groupUsage track per-identity usage (bytes + file count) for
+	// regular files, keyed by owner uid / gid. Seeded from a GROUP BY query on
+	// startup and updated from each committed transaction's deltas. Guarded by
+	// quotaMu.
+	quotaMu    sync.Mutex
+	userUsage  map[uint32]*metadata.UsageStat
+	groupUsage map[uint32]*metadata.UsageStat
+
+	// storeID is the engine-persistent identifier, backed by
+	// server_config.store_id. Created on first open with a fresh ULID; read
+	// thereafter. Immutable for the life of the instance.
+	storeID string
+
+	// Lazily-initialized sub-stores for lock / client / durable-handle /
+	// NFSv4-recovery persistence. Each wraps the shared *sql.DB executor.
+	lockStore   *sqliteLockStore
+	lockStoreMu sync.Mutex
+
+	clientStore   *sqliteClientStore
+	clientStoreMu sync.Mutex
+
+	durableStore   *sqliteDurableStore
+	durableStoreMu sync.Mutex
+
+	recoveryStore   *sqliteRecoveryStore
+	recoveryStoreMu sync.Mutex
+}
+
+// NewSQLiteMetadataStore creates a new SQLite-backed metadata store.
+func NewSQLiteMetadataStore(
+	ctx context.Context,
+	cfg *SQLiteMetadataStoreConfig,
+	capabilities metadata.FilesystemCapabilities,
+) (*SQLiteMetadataStore, error) {
+	cfg.ApplyDefaults()
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	log := logger.With("component", "sqlite_metadata_store")
+
+	db, err := sql.Open(sqliteDriverName, cfg.DSN())
+	if err != nil {
+		return nil, fmt.Errorf("failed to open sqlite database: %w", err)
+	}
+
+	// SQLite is single-writer. Bounding the pool to one connection serializes
+	// access deterministically and keeps a warm connection alive — important
+	// for ":memory:" + cache=shared, where the database lives only as long as
+	// at least one connection is open.
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(0)
+
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("failed to ping sqlite database: %w", err)
+	}
+
+	if cfg.AutoMigrate {
+		log.Info("AutoMigrate is enabled, running migrations...")
+		if err := runMigrations(ctx, db, log); err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("failed to run migrations: %w", err)
+		}
+	} else {
+		log.Info("AutoMigrate is disabled, skipping migrations")
+	}
+
+	if err := initializeFilesystemCapabilities(ctx, db, capabilities); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("failed to initialize filesystem capabilities: %w", err)
+	}
+
+	storeCtx, cancel := context.WithCancel(context.Background())
+
+	store := &SQLiteMetadataStore{
+		db:           db,
+		config:       cfg,
+		capabilities: capabilities,
+		logger:       log,
+		ctx:          storeCtx,
+		cancel:       cancel,
+	}
+
+	if err := store.initUsedBytesCounter(ctx); err != nil {
+		_ = db.Close()
+		cancel()
+		return nil, fmt.Errorf("failed to initialize used bytes counter: %w", err)
+	}
+
+	sid, err := store.ensureStoreID(ctx)
+	if err != nil {
+		_ = db.Close()
+		cancel()
+		return nil, fmt.Errorf("ensure store_id: %w", err)
+	}
+	store.storeID = sid
+
+	log.Info("SQLite metadata store initialized successfully", "path", cfg.Path)
+
+	return store, nil
+}
+
+// GetUsedBytes returns the current total logical bytes used by regular files.
+func (s *SQLiteMetadataStore) GetUsedBytes() int64 {
+	return s.usedBytes.Load()
+}
+
+// initUsedBytesCounter initializes the store-wide atomic counter from a SQL SUM
+// query and seeds the per-identity usage cache from GROUP BY aggregates. Both
+// are reconstructed from the inodes table (the source of truth).
+func (s *SQLiteMetadataStore) initUsedBytesCounter(ctx context.Context) error {
+	query := `SELECT COALESCE(SUM(size), 0) FROM inodes WHERE file_type = ?`
+	var totalUsed int64
+	if err := s.db.QueryRowContext(ctx, query, int(metadata.FileTypeRegular)).Scan(&totalUsed); err != nil {
+		return fmt.Errorf("failed to query used bytes: %w", err)
+	}
+	s.usedBytes.Store(totalUsed)
+
+	userUsage, err := s.seedUsageByColumn(ctx, "uid")
+	if err != nil {
+		return err
+	}
+	groupUsage, err := s.seedUsageByColumn(ctx, "gid")
+	if err != nil {
+		return err
+	}
+	s.quotaMu.Lock()
+	s.userUsage = userUsage
+	s.groupUsage = groupUsage
+	s.quotaMu.Unlock()
+	return nil
+}
+
+// seedUsageByColumn aggregates per-identity usage (bytes + count) for regular
+// files grouped by the given owner column ("uid" or "gid"). The column name is
+// a fixed internal constant, never user input.
+func (s *SQLiteMetadataStore) seedUsageByColumn(ctx context.Context, col string) (map[uint32]*metadata.UsageStat, error) {
+	query := fmt.Sprintf(
+		`SELECT %s, COALESCE(SUM(size), 0), COUNT(*) FROM inodes WHERE file_type = ? GROUP BY %s`,
+		col, col,
+	)
+	rows, err := s.db.QueryContext(ctx, query, int(metadata.FileTypeRegular))
+	if err != nil {
+		return nil, fmt.Errorf("failed to seed %s usage: %w", col, err)
+	}
+	defer rows.Close()
+	out := make(map[uint32]*metadata.UsageStat)
+	for rows.Next() {
+		var id int64
+		var bytes, files int64
+		if err := rows.Scan(&id, &bytes, &files); err != nil {
+			return nil, fmt.Errorf("failed to scan %s usage: %w", col, err)
+		}
+		out[uint32(id)] = &metadata.UsageStat{Bytes: bytes, Files: files}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed iterating %s usage: %w", col, err)
+	}
+	return out, nil
+}
+
+// GetQuotaUsage returns per-identity usage for the given scope and id.
+func (s *SQLiteMetadataStore) GetQuotaUsage(scope metadata.QuotaScope, id uint32) (metadata.UsageStat, error) {
+	s.quotaMu.Lock()
+	defer s.quotaMu.Unlock()
+	m := s.userUsage
+	if scope == metadata.QuotaScopeGroup {
+		m = s.groupUsage
+	}
+	if u, ok := m[id]; ok {
+		return *u, nil
+	}
+	return metadata.UsageStat{}, nil
+}
+
+// applyQuotaDelta folds a per-identity usage delta into the in-memory usage
+// cache. Called post-commit (matching usedBytes).
+func (s *SQLiteMetadataStore) applyQuotaDelta(delta map[sqQuotaKey]metadata.UsageStat) {
+	if len(delta) == 0 {
+		return
+	}
+	s.quotaMu.Lock()
+	defer s.quotaMu.Unlock()
+	for k, d := range delta {
+		m := s.userUsage
+		if k.scope == metadata.QuotaScopeGroup {
+			m = s.groupUsage
+		}
+		cur := m[k.id]
+		if cur == nil {
+			cur = &metadata.UsageStat{}
+			m[k.id] = cur
+		}
+		cur.Bytes += d.Bytes
+		cur.Files += d.Files
+		if cur.Bytes < 0 {
+			cur.Bytes = 0
+		}
+		if cur.Files < 0 {
+			cur.Files = 0
+		}
+		if cur.Bytes == 0 && cur.Files == 0 {
+			delete(m, k.id)
+		}
+	}
+}
+
+// ensureStoreID reads the engine-persistent store_id from server_config; if the
+// row is missing or carries the empty sentinel, writes a fresh ULID atomically
+// and returns it. Idempotent after bootstrap.
+func (s *SQLiteMetadataStore) ensureStoreID(ctx context.Context) (string, error) {
+	fresh := ulid.Make().String()
+	var existing string
+	err := s.db.QueryRowContext(ctx, `
+		INSERT INTO server_config (id, store_id)
+		VALUES (1, ?)
+		ON CONFLICT (id) DO UPDATE
+		SET store_id = COALESCE(NULLIF(server_config.store_id, ''), excluded.store_id)
+		RETURNING store_id
+	`, fresh).Scan(&existing)
+	if err != nil {
+		return "", fmt.Errorf("upsert store_id row: %w", err)
+	}
+	return existing, nil
+}
+
+// GetStoreID returns the SQLite-persistent store identifier (stored in
+// server_config.store_id). Stable across restarts.
+func (s *SQLiteMetadataStore) GetStoreID() string { return s.storeID }
+
+// Compile-time assertion: the SQLite engine exposes GetStoreID.
+var _ interface{ GetStoreID() string } = (*SQLiteMetadataStore)(nil)
+
+// Close records the clean-shutdown marker and closes the database handle.
+func (s *SQLiteMetadataStore) Close() error {
+	s.logger.Info("Closing SQLite metadata store...")
+
+	// Record a clean-shutdown marker BEFORE closing so the lock-recovery boot
+	// path can distinguish a graceful drain from a crash. A persist failure is
+	// logged but does not block close.
+	markCtx, markCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	if err := s.SetCleanShutdown(markCtx, true); err != nil {
+		s.logger.Error("failed to persist clean-shutdown marker on close", "error", err)
+	}
+	markCancel()
+
+	s.cancel()
+
+	if s.db != nil {
+		if err := s.db.Close(); err != nil {
+			return err
+		}
+	}
+
+	s.logger.Info("SQLite metadata store closed")
+	return nil
+}
+
+// initializeFilesystemCapabilities inserts or updates filesystem capabilities.
+func initializeFilesystemCapabilities(ctx context.Context, db *sql.DB, caps metadata.FilesystemCapabilities) error {
+	query := `
+		INSERT INTO filesystem_capabilities (
+			id,
+			max_read_size,
+			preferred_read_size,
+			max_write_size,
+			preferred_write_size,
+			max_file_size,
+			max_filename_len,
+			max_path_len,
+			max_hard_link_count,
+			supports_hard_links,
+			supports_symlinks,
+			case_sensitive,
+			case_preserving,
+			supports_acls,
+			time_resolution
+		) VALUES (
+			1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+		)
+		ON CONFLICT (id) DO UPDATE SET
+			max_read_size = excluded.max_read_size,
+			preferred_read_size = excluded.preferred_read_size,
+			max_write_size = excluded.max_write_size,
+			preferred_write_size = excluded.preferred_write_size,
+			max_file_size = excluded.max_file_size,
+			max_filename_len = excluded.max_filename_len,
+			max_path_len = excluded.max_path_len,
+			max_hard_link_count = excluded.max_hard_link_count,
+			supports_hard_links = excluded.supports_hard_links,
+			supports_symlinks = excluded.supports_symlinks,
+			case_sensitive = excluded.case_sensitive,
+			case_preserving = excluded.case_preserving,
+			supports_acls = excluded.supports_acls,
+			time_resolution = excluded.time_resolution
+	`
+
+	_, err := db.ExecContext(ctx, query,
+		caps.MaxReadSize,
+		caps.PreferredReadSize,
+		caps.MaxWriteSize,
+		caps.PreferredWriteSize,
+		caps.MaxFileSize,
+		caps.MaxFilenameLen,
+		caps.MaxPathLen,
+		caps.MaxHardLinkCount,
+		caps.SupportsHardLinks,
+		caps.SupportsSymlinks,
+		caps.CaseSensitive,
+		caps.CasePreserving,
+		caps.SupportsACLs,
+		caps.TimestampResolution,
+	)
+	return err
+}

--- a/pkg/metadata/store/sqlite/store.go
+++ b/pkg/metadata/store/sqlite/store.go
@@ -202,7 +202,7 @@ func (s *SQLiteMetadataStore) seedUsageByColumn(ctx context.Context, col string)
 	if err != nil {
 		return nil, fmt.Errorf("failed to seed %s usage: %w", col, err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	out := make(map[uint32]*metadata.UsageStat)
 	for rows.Next() {
 		var id int64

--- a/pkg/metadata/store/sqlite/synced_hash_store.go
+++ b/pkg/metadata/store/sqlite/synced_hash_store.go
@@ -1,0 +1,74 @@
+// Per-CAS-hash idempotent presence marker backed by the synced_hashes
+// table. See metadata.SyncedHashStore for the contract; this backend
+// uses a tiny indexed table keyed by the raw 32-byte BLAKE3 hash, with
+// ON CONFLICT DO NOTHING for idempotent MarkSynced and unconditional
+// DELETE for idempotent DeleteSynced.
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// Compile-time assertion: the SQLite engine implements SyncedHashStore.
+var _ metadata.SyncedHashStore = (*SQLiteMetadataStore)(nil)
+
+// IsSynced reports whether hash has been MarkSynced'd at least once.
+// Returns (false, nil) when no row exists for hash — an absent hash is
+// treated as "not yet synced", not as an error.
+func (s *SQLiteMetadataStore) IsSynced(ctx context.Context, hash block.ContentHash) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
+	row := s.queryRow(ctx,
+		`SELECT 1 FROM synced_hashes WHERE hash = ?1`,
+		hash[:])
+	var dummy int
+	err := row.Scan(&dummy)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("sqlite synced get: %w", err)
+	}
+	return true, nil
+}
+
+// MarkSynced records that hash has been mirrored to remote. Idempotent
+// via ON CONFLICT (hash) DO NOTHING — re-applying the same hash is a
+// no-op.
+func (s *SQLiteMetadataStore) MarkSynced(ctx context.Context, hash block.ContentHash) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if _, err := s.exec(ctx,
+		`INSERT INTO synced_hashes (hash, synced_at) VALUES (?1, CURRENT_TIMESTAMP)
+			ON CONFLICT (hash) DO NOTHING`,
+		hash[:]); err != nil {
+		return fmt.Errorf("sqlite synced mark: %w", err)
+	}
+	return nil
+}
+
+// DeleteSynced removes the synced marker for hash. Idempotent: DELETE
+// returns no error when the row does not exist (zero rows affected is
+// not an error condition).
+func (s *SQLiteMetadataStore) DeleteSynced(ctx context.Context, hash block.ContentHash) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if _, err := s.exec(ctx,
+		`DELETE FROM synced_hashes WHERE hash = ?1`,
+		hash[:]); err != nil {
+		return fmt.Errorf("sqlite synced delete: %w", err)
+	}
+	return nil
+}

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -1,0 +1,1357 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+)
+
+// maxTransactionRetries bounds retries on a busy/locked condition.
+const maxTransactionRetries = 3
+
+// ============================================================================
+// Transaction Support
+// ============================================================================
+
+// sqliteTransaction wraps a SQLite transaction for the Transaction interface.
+//
+// pendingDelta accumulates the usedBytes change made by mutations inside the
+// closure. It is applied to the store's atomic counter exactly once after a
+// successful Commit (see WithTransaction). WithTransaction retries the closure
+// on a busy/locked condition; accumulating per-attempt and applying post-commit
+// prevents the counter from double-counting across retries.
+//
+// tx is the pgx-shaped executor (QueryRow/Query/Exec with (ctx, sql, args...))
+// over the underlying *sql.Tx, so the ported query bodies use it unchanged.
+type sqliteTransaction struct {
+	store        *SQLiteMetadataStore
+	tx           execer
+	pendingDelta int64
+	// quotaDelta accumulates per-identity usage changes (bytes + file count)
+	// keyed by (scope, id). Applied to the store's in-memory userUsage/
+	// groupUsage cache exactly once after a successful commit, identical to
+	// pendingDelta (so a serialization/deadlock retry never double-counts).
+	quotaDelta map[sqQuotaKey]metadata.UsageStat
+}
+
+// sqQuotaKey identifies a per-identity usage bucket inside a transaction's
+// accumulated delta.
+type sqQuotaKey struct {
+	scope metadata.QuotaScope
+	id    uint32
+}
+
+// addQuota records a usage delta for the file's owner identity (both user and
+// group scopes). See memory store addQuota for the create/resize/chown cases.
+func (tx *sqliteTransaction) addQuota(uid, gid uint32, bytes, files int64) {
+	if bytes == 0 && files == 0 {
+		return
+	}
+	if tx.quotaDelta == nil {
+		tx.quotaDelta = make(map[sqQuotaKey]metadata.UsageStat)
+	}
+	u := tx.quotaDelta[sqQuotaKey{metadata.QuotaScopeUser, uid}]
+	u.Bytes += bytes
+	u.Files += files
+	tx.quotaDelta[sqQuotaKey{metadata.QuotaScopeUser, uid}] = u
+	g := tx.quotaDelta[sqQuotaKey{metadata.QuotaScopeGroup, gid}]
+	g.Bytes += bytes
+	g.Files += files
+	tx.quotaDelta[sqQuotaKey{metadata.QuotaScopeGroup, gid}] = g
+}
+
+// addQuotaKeyed merges a single pre-keyed usage delta (used when folding the
+// per-identity totals freed by DeleteShare).
+func (tx *sqliteTransaction) addQuotaKeyed(k sqQuotaKey, d metadata.UsageStat) {
+	if d.Bytes == 0 && d.Files == 0 {
+		return
+	}
+	if tx.quotaDelta == nil {
+		tx.quotaDelta = make(map[sqQuotaKey]metadata.UsageStat)
+	}
+	cur := tx.quotaDelta[k]
+	cur.Bytes += d.Bytes
+	cur.Files += d.Files
+	tx.quotaDelta[k] = cur
+}
+
+// WithTransaction executes fn within a SQLite transaction.
+//
+// If fn returns an error, the transaction is rolled back. If fn returns nil,
+// the transaction is committed. Retries automatically on a busy/locked
+// condition. The accumulated usedBytes / per-identity quota deltas are applied
+// exactly once after a successful commit so a retry never double-counts.
+func (s *SQLiteMetadataStore) WithTransaction(ctx context.Context, fn func(tx metadata.Transaction) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxTransactionRetries; attempt++ {
+		rawTx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			if isBusyError(err) {
+				lastErr = err
+				time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
+				continue
+			}
+			return mapDBError(err, "WithTransaction", "")
+		}
+
+		ptx := &sqliteTransaction{store: s, tx: execer{e: rawTx, op: "tx"}}
+		if err := fn(ptx); err != nil {
+			_ = rawTx.Rollback()
+			if isBusyError(err) {
+				lastErr = err
+				time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
+				continue
+			}
+			return err
+		}
+
+		if err := rawTx.Commit(); err != nil {
+			if isBusyError(err) {
+				lastErr = err
+				time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
+				continue
+			}
+			return mapDBError(err, "WithTransaction", "")
+		}
+
+		// Apply the accumulated usedBytes delta exactly once, after commit.
+		if ptx.pendingDelta != 0 {
+			s.usedBytes.Add(ptx.pendingDelta)
+		}
+		// Apply per-identity usage deltas once, after commit.
+		s.applyQuotaDelta(ptx.quotaDelta)
+		return nil // Success
+	}
+
+	// All retries exhausted
+	return mapDBError(lastErr, "WithTransaction", "")
+}
+
+// ============================================================================
+// Transaction CRUD Operations
+// ============================================================================
+
+func (tx *sqliteTransaction) GetFile(ctx context.Context, handle metadata.FileHandle) (*metadata.File, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	shareName, id, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return nil, &metadata.StoreError{
+			Code:    metadata.ErrInvalidHandle,
+			Message: "invalid file handle",
+		}
+	}
+
+	// Fold FileAttr.Blocks into the metadata read (#1176): one round-trip
+	// instead of the SELECT plus a separate getFileBlockRefs. See GetFile
+	// (pool path) and blockRefsAggExpr for the equivalence rationale.
+	query := `
+		SELECT
+			f.id, f.share_name, ` + inodePathExpr + `,
+			f.file_type, f.mode, f.uid, f.gid, f.size,
+			f.atime, f.mtime, f.ctime, f.creation_time,
+			f.content_id, f.link_target, f.device_major, f.device_minor,
+			f.hidden, f.acl, f.eas, f.object_id,
+			f.deleted_at, f.original_path, f.deleted_by, f.nlink,
+			` + blockRefsAggExpr + `
+		FROM inodes f
+		WHERE f.id = ?1 AND f.share_name = ?2
+	`
+
+	row := tx.tx.QueryRow(ctx, query, id, shareName)
+	file, err := fileRowToFileWithNlinkAndBlocks(row, true)
+	if err != nil {
+		return nil, mapDBError(err, "GetFile", "")
+	}
+
+	// Debug logging to trace file type issues
+	tx.store.logger.Debug("GetFile retrieved",
+		"id", id.String(),
+		"share", shareName,
+		"path", file.Path,
+		"file_type", int(file.Type),
+		"size", file.Size)
+
+	return file, nil
+}
+
+func (tx *sqliteTransaction) PutFile(ctx context.Context, file *metadata.File) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	// For existing files (updates), use UPDATE directly to avoid unique constraint issues.
+	// This is more efficient and handles concurrent updates properly.
+	//
+	// Namespace uniqueness lives in parent_child_map(parent_id, child_name); the
+	// inodes row no longer carries a path/path_hash column (#1166), so a Move is
+	// just a parent_child_map re-link (SetChild/DeleteChild) — there is nothing
+	// path-related to update on the inode row here. content_id is still set:
+	// it keys file_blocks and is consumed by GetFileByPayloadID.
+	//
+	// SQLite is a single-writer engine: a transaction holds an exclusive write
+	// lock for its duration, so a SELECT-then-UPDATE inside the same tx has no
+	// interleaving window (unlike the multi-writer Postgres case the FROM/CTE
+	// FOR UPDATE form guarded against). Read the pre-update size/owner/type
+	// first, then UPDATE; a zero-row read means the file does not exist and we
+	// fall through to INSERT — the same not-found signal as before.
+	const selectOldQuery = `
+		SELECT size, uid, gid, file_type
+		FROM inodes
+		WHERE id = ?1 AND share_name = ?2
+	`
+	updateQuery := `
+		UPDATE inodes SET
+			file_type = ?1,
+			mode = ?2,
+			uid = ?3,
+			gid = ?4,
+			size = ?5,
+			atime = ?6,
+			mtime = ?7,
+			ctime = ?8,
+			creation_time = ?9,
+			content_id = ?10,
+			link_target = ?11,
+			device_major = ?12,
+			device_minor = ?13,
+			hidden = ?14,
+			acl = ?15,
+			eas = ?16,
+			object_id = ?17,
+			deleted_at = ?18,
+			original_path = ?19,
+			deleted_by = ?20
+		WHERE id = ?21 AND share_name = ?22
+	`
+
+	var deviceMajor, deviceMinor *int32
+	if file.Type == metadata.FileTypeBlockDevice || file.Type == metadata.FileTypeCharDevice {
+		major := int32(metadata.RdevMajor(file.Rdev))
+		minor := int32(metadata.RdevMinor(file.Rdev))
+		deviceMajor = &major
+		deviceMinor = &minor
+	}
+
+	var payloadIDPtr *string
+	if file.PayloadID != "" {
+		str := string(file.PayloadID)
+		payloadIDPtr = &str
+	}
+
+	var linkTargetPtr *string
+	if file.LinkTarget != "" {
+		linkTargetPtr = &file.LinkTarget
+	}
+
+	// Marshal ACL to JSON for JSONB storage
+	var aclJSON []byte
+	if file.ACL != nil {
+		var marshalErr error
+		aclJSON, marshalErr = json.Marshal(file.ACL)
+		if marshalErr != nil {
+			return mapDBError(marshalErr, "PutFile", "marshal ACL")
+		}
+	}
+
+	// Marshal extended attributes to JSON for JSONB storage. Empty/nil EAs
+	// write SQL NULL so a file that never had EAs stores nothing.
+	var easJSON []byte
+	if len(file.EAs) > 0 {
+		var marshalErr error
+		easJSON, marshalErr = json.Marshal(file.EAs)
+		if marshalErr != nil {
+			return mapDBError(marshalErr, "PutFile", "marshal EAs")
+		}
+	}
+
+	// object_id BYTEA argument.
+	// Zero-valued ObjectID writes SQL NULL so the partial unique index
+	// (files_object_id_idx WHERE object_id IS NOT NULL) skips the row —
+	// legacy / never-quiesced / partially-flushed files never collide on
+	// the all-zero sentinel.
+	var objectIDArg interface{}
+	if !file.ObjectID.IsZero() {
+		objectIDArg = file.ObjectID[:]
+	}
+
+	// deleted_at is a BIGINT unix-nanoseconds column (#190), nullable: NULL marks
+	// a live node, a value records the recycle instant losslessly (like the other
+	// file timestamps). Pass *int64 so a nil DeletedAt writes SQL NULL.
+	var deletedAtArg *int64
+	if file.DeletedAt != nil {
+		n := file.DeletedAt.UnixNano()
+		deletedAtArg = &n
+	}
+
+	// Read the pre-update size/owner/type, then UPDATE. Under SQLite's single
+	// writer there is no interleaving between the two statements inside this
+	// transaction. A missing row (sql.ErrNoRows) means the file does not exist,
+	// so we fall through to INSERT.
+	var oldSizeVal sql.NullInt64
+	var oldUIDVal, oldGIDVal, oldTypeVal sql.NullInt64
+	updated := true
+	scanErr := tx.tx.QueryRow(ctx, selectOldQuery, file.ID, file.ShareName).
+		Scan(&oldSizeVal, &oldUIDVal, &oldGIDVal, &oldTypeVal)
+	switch {
+	case scanErr == nil:
+		// Row exists; update it in place.
+		if _, err := tx.tx.Exec(ctx, updateQuery,
+			file.Type, file.Mode, file.UID, file.GID, file.Size,
+			timeToNanos(file.Atime), timeToNanos(file.Mtime),
+			timeToNanos(file.Ctime), timeToNanos(file.CreationTime),
+			payloadIDPtr, linkTargetPtr, deviceMajor, deviceMinor,
+			file.Hidden, aclJSON, easJSON, objectIDArg,
+			deletedAtArg, file.OriginalPath, file.DeletedBy,
+			file.ID, file.ShareName,
+		); err != nil {
+			return mapDBError(err, "PutFile", "")
+		}
+	case errors.Is(scanErr, sql.ErrNoRows):
+		updated = false
+	default:
+		return mapDBError(scanErr, "PutFile", "")
+	}
+
+	// Track size delta for regular files after a successful update.
+	// Accumulated on the tx and applied once after a successful commit so a
+	// serialization/deadlock retry never double-counts.
+	if updated && file.Type == metadata.FileTypeRegular {
+		var oldSize uint64
+		if oldSizeVal.Valid {
+			oldSize = uint64(oldSizeVal.Int64)
+		}
+		tx.pendingDelta += int64(file.Size) - int64(oldSize)
+
+		// Per-identity usage. The previous row may not have been a regular file
+		// (type change), in which case it contributed nothing before.
+		oldWasRegular := oldTypeVal.Valid && metadata.FileType(oldTypeVal.Int64) == metadata.FileTypeRegular
+		oldUID := uint32(oldUIDVal.Int64)
+		oldGID := uint32(oldGIDVal.Int64)
+		switch {
+		case !oldWasRegular:
+			tx.addQuota(file.UID, file.GID, int64(file.Size), 1)
+		case oldUID == file.UID && oldGID == file.GID:
+			tx.addQuota(file.UID, file.GID, int64(file.Size)-int64(oldSize), 0)
+		default:
+			// Chown: move bytes + inode from old owner to new owner.
+			tx.addQuota(oldUID, oldGID, -int64(oldSize), -1)
+			tx.addQuota(file.UID, file.GID, int64(file.Size), 1)
+		}
+	}
+
+	// If no rows were updated, the file doesn't exist - do an INSERT
+	if !updated {
+		insertQuery := `
+			INSERT INTO inodes (
+				id, share_name, file_type, mode, uid, gid, size,
+				atime, mtime, ctime, creation_time, content_id, link_target,
+				device_major, device_minor, hidden, acl, eas, object_id,
+				deleted_at, original_path, deleted_by
+			) VALUES (
+				?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18,
+				?19, ?20, ?21, ?22
+			)
+		`
+
+		if _, err := tx.tx.Exec(ctx, insertQuery,
+			file.ID, file.ShareName,
+			file.Type, file.Mode, file.UID, file.GID, file.Size,
+			timeToNanos(file.Atime), timeToNanos(file.Mtime),
+			timeToNanos(file.Ctime), timeToNanos(file.CreationTime),
+			payloadIDPtr, linkTargetPtr, deviceMajor, deviceMinor,
+			file.Hidden, aclJSON, easJSON, objectIDArg,
+			deletedAtArg, file.OriginalPath, file.DeletedBy,
+		); err != nil {
+			return mapDBError(err, "PutFile", "")
+		}
+
+		// Track new regular file size.
+		if file.Type == metadata.FileTypeRegular {
+			if file.Size > 0 {
+				tx.pendingDelta += int64(file.Size)
+			}
+			tx.addQuota(file.UID, file.GID, int64(file.Size), 1)
+		}
+
+		// Debug logging for new file inserts
+		tx.store.logger.Debug("PutFile inserted",
+			"id", file.ID.String(),
+			"share", file.ShareName,
+			"path", file.Path,
+			"file_type", int(file.Type),
+			"size", file.Size)
+	}
+
+	// persist FileAttr.Blocks into file_block_refs.
+	// Atomic with the files-row UPDATE/INSERT above (same tx). Only regular
+	// files carry BlockRef payloads. Empty/nil Blocks performs a DELETE-only
+	// pass, ensuring no stale rows survive a write that drops Blocks.
+	if file.Type == metadata.FileTypeRegular {
+		if err := putFileBlockRefs(ctx, tx.tx, file.ID, file.Blocks); err != nil {
+			return mapDBError(err, "PutFile", "blocks")
+		}
+	}
+
+	return nil
+}
+
+func (tx *sqliteTransaction) DeleteFile(ctx context.Context, handle metadata.FileHandle) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	shareName, id, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return &metadata.StoreError{
+			Code:    metadata.ErrInvalidHandle,
+			Message: "invalid file handle",
+		}
+	}
+
+	// Read size + owner before deletion for counter tracking.
+	var fileType int
+	var fileSize int64
+	var fileUID, fileGID int64
+	_ = tx.tx.QueryRow(ctx,
+		`SELECT file_type, size, uid, gid FROM inodes WHERE id = ?1 AND share_name = ?2`,
+		id, shareName,
+	).Scan(&fileType, &fileSize, &fileUID, &fileGID)
+
+	// Delete the file. parent_child_map.parent_id declares ON DELETE CASCADE
+	// against inodes(id), so deleting the inode row reaps (if it is a directory)
+	// its child-map rows automatically. The hard-link count lives on the inode
+	// row itself (inodes.nlink), so it is removed with the row. We do NOT delete
+	// this file from its parent's children
+	// map here — that is the responsibility of DeleteChild, which the service
+	// layer calls separately. This matches the memory and badger stores.
+	result, err := tx.tx.Exec(ctx, `DELETE FROM inodes WHERE id = ?1 AND share_name = ?2`, id, shareName)
+	if err != nil {
+		return mapDBError(err, "DeleteFile", "")
+	}
+
+	if result.RowsAffected() == 0 {
+		return &metadata.StoreError{
+			Code:    metadata.ErrNotFound,
+			Message: "file not found",
+		}
+	}
+
+	// Subtract size from the pending delta + per-identity usage for regular files.
+	if metadata.FileType(fileType) == metadata.FileTypeRegular {
+		if fileSize > 0 {
+			tx.pendingDelta -= fileSize
+		}
+		tx.addQuota(uint32(fileUID), uint32(fileGID), -fileSize, -1)
+	}
+
+	return nil
+}
+
+func (tx *sqliteTransaction) GetChild(ctx context.Context, dirHandle metadata.FileHandle, name string) (metadata.FileHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	shareName, parentID, err := metadata.DecodeFileHandle(dirHandle)
+	if err != nil {
+		return nil, &metadata.StoreError{
+			Code:    metadata.ErrInvalidHandle,
+			Message: "invalid directory handle",
+		}
+	}
+
+	query := `
+		SELECT dc.child_id FROM parent_child_map dc
+		WHERE dc.parent_id = ?1 AND dc.child_name = ?2
+	`
+
+	var childID string
+	err = tx.tx.QueryRow(ctx, query, parentID, name).Scan(&childID)
+	if err != nil {
+		return nil, mapDBError(err, "GetChild", name)
+	}
+
+	// Debug logging to trace child lookup
+	tx.store.logger.Debug("GetChild found",
+		"parent_id", parentID.String(),
+		"child_name", name,
+		"child_id", childID,
+		"share", shareName)
+
+	return encodeFileHandle(shareName, childID)
+}
+
+func (tx *sqliteTransaction) SetChild(ctx context.Context, dirHandle metadata.FileHandle, name string, childHandle metadata.FileHandle) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	_, parentID, err := metadata.DecodeFileHandle(dirHandle)
+	if err != nil {
+		return &metadata.StoreError{
+			Code:    metadata.ErrInvalidHandle,
+			Message: "invalid directory handle",
+		}
+	}
+
+	_, childID, err := metadata.DecodeFileHandle(childHandle)
+	if err != nil {
+		return &metadata.StoreError{
+			Code:    metadata.ErrInvalidHandle,
+			Message: "invalid child handle",
+		}
+	}
+
+	query := `
+		INSERT INTO parent_child_map (parent_id, child_name, child_id)
+		VALUES (?1, ?2, ?3)
+		ON CONFLICT (parent_id, child_name) DO UPDATE SET child_id = EXCLUDED.child_id
+	`
+
+	_, err = tx.tx.Exec(ctx, query, parentID, name, childID)
+	if err != nil {
+		return mapDBError(err, "SetChild", name)
+	}
+
+	return nil
+}
+
+func (tx *sqliteTransaction) DeleteChild(ctx context.Context, dirHandle metadata.FileHandle, name string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	_, parentID, err := metadata.DecodeFileHandle(dirHandle)
+	if err != nil {
+		return &metadata.StoreError{
+			Code:    metadata.ErrInvalidHandle,
+			Message: "invalid directory handle",
+		}
+	}
+
+	_, err = tx.tx.Exec(ctx, `DELETE FROM parent_child_map WHERE parent_id = ?1 AND child_name = ?2`, parentID, name)
+	if err != nil {
+		return mapDBError(err, "DeleteChild", name)
+	}
+
+	// Note: We don't check RowsAffected() here because the entry may have already
+	// been deleted by the CASCADE DELETE on the child_id foreign key when DeleteFile
+	// deleted the file from the files table. The desired outcome (child mapping
+	// no longer exists) is achieved either way.
+
+	return nil
+}
+
+func (tx *sqliteTransaction) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, cursor string, limit int) ([]metadata.DirEntry, string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, "", err
+	}
+
+	shareName, parentID, err := metadata.DecodeFileHandle(dirHandle)
+	if err != nil {
+		return nil, "", &metadata.StoreError{
+			Code:    metadata.ErrInvalidHandle,
+			Message: "invalid directory handle",
+		}
+	}
+
+	if limit <= 0 {
+		limit = 1000
+	}
+
+	// Refs #532 (PR #536 review): hydrate f.acl — keep parity with the
+	// pool-query ListChildren above. See files.go for rationale.
+	query := `
+		SELECT dc.child_name, dc.child_id, f.file_type, f.mode, f.uid, f.gid, f.size,
+		       f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.acl, f.eas, f.object_id,
+		       f.deleted_at, f.original_path, f.deleted_by, f.nlink
+		FROM parent_child_map dc
+		LEFT JOIN inodes f ON dc.child_id = f.id
+		WHERE dc.parent_id = ?1 AND dc.child_name > ?2
+		ORDER BY dc.child_name
+		LIMIT ?3
+	`
+
+	rows, err := tx.tx.Query(ctx, query, parentID, cursor, limit+1)
+	if err != nil {
+		return nil, "", mapDBError(err, "ListChildren", "")
+	}
+	defer rows.Close()
+
+	var entries []metadata.DirEntry
+	for rows.Next() && len(entries) < limit {
+		var name, childIDStr string
+		var fileType int16
+		var mode, uid, gid int32
+		var size int64
+		var atime, mtime, ctime, creationTime int64
+		var hidden bool
+		var aclJSON []byte
+		var easJSON []byte
+		var objectIDRaw []byte
+		var deletedAt sql.NullInt64
+		var originalPath string
+		var deletedBy string
+		var linkCount sql.NullInt32
+
+		err := rows.Scan(&name, &childIDStr, &fileType, &mode, &uid, &gid, &size,
+			&atime, &mtime, &ctime, &creationTime, &hidden, &aclJSON, &easJSON, &objectIDRaw,
+			&deletedAt, &originalPath, &deletedBy, &linkCount)
+		if err != nil {
+			return nil, "", err
+		}
+
+		childHandle, err := encodeFileHandle(shareName, childIDStr)
+		if err != nil {
+			return nil, "", err
+		}
+
+		// Determine Nlink value
+		var nlink uint32
+		if linkCount.Valid {
+			nlink = uint32(linkCount.Int32)
+		} else {
+			// Default based on file type
+			if metadata.FileType(fileType) == metadata.FileTypeDirectory {
+				nlink = 2
+			} else {
+				nlink = 1
+			}
+		}
+
+		// hydrate ObjectID for directory entries so the
+		// shape matches GetFile. NULL/empty -> zero (sentinel).
+		attr := &metadata.FileAttr{
+			Type:         metadata.FileType(fileType),
+			Mode:         uint32(mode),
+			Nlink:        nlink,
+			UID:          uint32(uid),
+			GID:          uint32(gid),
+			Size:         uint64(size),
+			Atime:        nanosToTime(atime),
+			Mtime:        nanosToTime(mtime),
+			Ctime:        nanosToTime(ctime),
+			CreationTime: nanosToTime(creationTime),
+			Hidden:       hidden,
+		}
+		if len(objectIDRaw) > 0 {
+			if len(objectIDRaw) != block.HashSize {
+				return nil, "", fmt.Errorf(
+					"ListChildren: object_id has invalid length %d (want %d)",
+					len(objectIDRaw), block.HashSize,
+				)
+			}
+			copy(attr.ObjectID[:], objectIDRaw)
+		}
+
+		// Recycle-bin metadata (#190): carried on DirEntry.Attr so trash
+		// enumeration via listing reflects recycle state without a re-read,
+		// matching the pool-query path. deleted_at is BIGINT unix-nanoseconds;
+		// decode via nanosToTime.
+		if deletedAt.Valid {
+			t := nanosToTime(deletedAt.Int64)
+			attr.DeletedAt = &t
+		}
+		attr.OriginalPath = originalPath
+		attr.DeletedBy = deletedBy
+
+		// Refs #532 (PR #536 review): mirror fileRowToFileWithNlink — soft
+		// failure on malformed ACL JSON, same as the pool-query path.
+		if len(aclJSON) > 0 {
+			var fileACL acl.ACL
+			if err := json.Unmarshal(aclJSON, &fileACL); err == nil {
+				attr.ACL = &fileACL
+			}
+		}
+
+		// Hydrate EAs for directory entries (same lenient unmarshal as ACL).
+		if len(easJSON) > 0 {
+			var eas map[string][]byte
+			if err := json.Unmarshal(easJSON, &eas); err == nil && len(eas) > 0 {
+				attr.EAs = eas
+			}
+		}
+
+		entry := metadata.DirEntry{
+			ID:     metadata.HandleToINode(childHandle),
+			Name:   name,
+			Handle: childHandle,
+			Attr:   attr,
+		}
+
+		entries = append(entries, entry)
+	}
+
+	// Surface any error that terminated the iteration early (e.g. a network
+	// drop mid-stream). Without this check a partial result would be returned
+	// as a complete, successful listing.
+	if err := rows.Err(); err != nil {
+		return nil, "", mapDBError(err, "ListChildren", "")
+	}
+
+	nextCursor := ""
+	if len(entries) >= limit {
+		nextCursor = entries[len(entries)-1].Name
+	}
+
+	return entries, nextCursor, nil
+}
+
+func (tx *sqliteTransaction) GetParent(ctx context.Context, handle metadata.FileHandle) (metadata.FileHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	shareName, childID, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return nil, &metadata.StoreError{
+			Code:    metadata.ErrInvalidHandle,
+			Message: "invalid file handle",
+		}
+	}
+
+	query := `SELECT parent_id FROM parent_child_map WHERE child_id = ?1 LIMIT 1`
+
+	var parentIDStr string
+	err = tx.tx.QueryRow(ctx, query, childID).Scan(&parentIDStr)
+	if err != nil {
+		return nil, mapDBError(err, "GetParent", "")
+	}
+
+	return encodeFileHandle(shareName, parentIDStr)
+}
+
+func (tx *sqliteTransaction) SetParent(ctx context.Context, handle metadata.FileHandle, parentHandle metadata.FileHandle) error {
+	// Parent is tracked via the parent_child_map table, already handled by SetChild.
+	return nil
+}
+
+func (tx *sqliteTransaction) GetLinkCount(ctx context.Context, handle metadata.FileHandle) (uint32, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	_, fileID, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return 0, &metadata.StoreError{
+			Code:    metadata.ErrInvalidHandle,
+			Message: "invalid file handle",
+		}
+	}
+
+	var count uint32
+	err = tx.tx.QueryRow(ctx, `SELECT nlink FROM inodes WHERE id = ?1`, fileID).Scan(&count)
+	if err != nil {
+		// Not found means count is 0
+		return 0, nil
+	}
+
+	return count, nil
+}
+
+func (tx *sqliteTransaction) SetLinkCount(ctx context.Context, handle metadata.FileHandle, count uint32) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	_, fileID, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return &metadata.StoreError{
+			Code:    metadata.ErrInvalidHandle,
+			Message: "invalid file handle",
+		}
+	}
+
+	// inodes.nlink is the sole source of truth for the hard-link count (#1166);
+	// GETATTR reads it straight off the inode row without a join.
+	_, err = tx.tx.Exec(ctx, `UPDATE inodes SET nlink = ?1 WHERE id = ?2`, count, fileID)
+	if err != nil {
+		return mapDBError(err, "SetLinkCount", "")
+	}
+
+	return nil
+}
+
+func (tx *sqliteTransaction) GetFilesystemMeta(ctx context.Context, shareName string) (*metadata.FilesystemMeta, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	query := `SELECT meta FROM filesystem_meta WHERE share_name = ?1`
+
+	var data []byte
+	err := tx.tx.QueryRow(ctx, query, shareName).Scan(&data)
+	if err != nil {
+		// Return defaults if not found
+		return &metadata.FilesystemMeta{
+			Capabilities: tx.store.capabilities,
+		}, nil
+	}
+
+	var meta metadata.FilesystemMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, err
+	}
+
+	return &meta, nil
+}
+
+func (tx *sqliteTransaction) PutFilesystemMeta(ctx context.Context, shareName string, meta *metadata.FilesystemMeta) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+
+	query := `
+		INSERT INTO filesystem_meta (share_name, meta)
+		VALUES (?1, ?2)
+		ON CONFLICT (share_name) DO UPDATE SET meta = EXCLUDED.meta
+	`
+
+	_, err = tx.tx.Exec(ctx, query, shareName, data)
+	if err != nil {
+		return mapDBError(err, "PutFilesystemMeta", shareName)
+	}
+
+	return nil
+}
+
+func (tx *sqliteTransaction) GenerateHandle(ctx context.Context, shareName string, path string) (metadata.FileHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// Handles are UUID-based; the path is stored in the File struct.
+	return metadata.GenerateNewHandle(shareName)
+}
+
+// ============================================================================
+// Transaction Shares Operations
+// ============================================================================
+
+func (tx *sqliteTransaction) GetRootHandle(ctx context.Context, shareName string) (metadata.FileHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	query := `SELECT root_file_id FROM shares WHERE share_name = ?1`
+
+	var rootID uuid.UUID
+	err := tx.tx.QueryRow(ctx, query, shareName).Scan(&rootID)
+	if err != nil {
+		return nil, mapDBError(err, "GetRootHandle", shareName)
+	}
+
+	return metadata.EncodeShareHandle(shareName, rootID)
+}
+
+func (tx *sqliteTransaction) GetShareOptions(ctx context.Context, shareName string) (*metadata.ShareOptions, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	query := `SELECT options, block_layout FROM shares WHERE share_name = ?1`
+
+	var (
+		optionsJSON     []byte
+		blockLayoutText string
+	)
+	err := tx.tx.QueryRow(ctx, query, shareName).Scan(&optionsJSON, &blockLayoutText)
+	if err != nil {
+		return nil, mapDBError(err, "GetShareOptions", shareName)
+	}
+
+	var options metadata.ShareOptions
+	if len(optionsJSON) > 0 {
+		if err := json.Unmarshal(optionsJSON, &options); err != nil {
+			return nil, mapDBError(err, "GetShareOptions", shareName)
+		}
+	}
+
+	// Authoritative: block_layout column overrides JSON blob (Phase
+	// 14 / D-A6). ParseBlockLayout coerces "" → legacy.
+	layout, err := metadata.ParseBlockLayout(blockLayoutText)
+	if err != nil {
+		return nil, fmt.Errorf("share %q: %w", shareName, err)
+	}
+	options.BlockLayout = layout
+
+	return &options, nil
+}
+
+func (tx *sqliteTransaction) CreateShare(ctx context.Context, share *metadata.Share) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	optionsData, err := json.Marshal(share.Options)
+	if err != nil {
+		return err
+	}
+
+	layout, err := metadata.ParseBlockLayout(string(share.Options.BlockLayout))
+	if err != nil {
+		return fmt.Errorf("share %q: %w", share.Name, err)
+	}
+
+	// Update options for existing share (created by CreateRootDirectory)
+	query := `UPDATE shares SET options = ?1, block_layout = ?2 WHERE share_name = ?3`
+	_, err = tx.tx.Exec(ctx, query, optionsData, string(layout), share.Name)
+	if err != nil {
+		return mapDBError(err, "CreateShare", share.Name)
+	}
+
+	return nil
+}
+
+func (tx *sqliteTransaction) UpdateShareOptions(ctx context.Context, shareName string, options *metadata.ShareOptions) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	optionsData, err := json.Marshal(options)
+	if err != nil {
+		return err
+	}
+
+	layout, err := metadata.ParseBlockLayout(string(options.BlockLayout))
+	if err != nil {
+		return fmt.Errorf("share %q: %w", shareName, err)
+	}
+
+	query := `UPDATE shares SET options = ?1, block_layout = ?2 WHERE share_name = ?3`
+	result, err := tx.tx.Exec(ctx, query, optionsData, string(layout), shareName)
+	if err != nil {
+		return mapDBError(err, "UpdateShareOptions", shareName)
+	}
+
+	if result.RowsAffected() == 0 {
+		return &metadata.StoreError{
+			Code:    metadata.ErrNotFound,
+			Message: "share not found",
+			Path:    shareName,
+		}
+	}
+
+	return nil
+}
+
+func (tx *sqliteTransaction) DeleteShare(ctx context.Context, shareName string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	// Sum the regular-file bytes about to be removed so the usedBytes
+	// counter stays accurate without a full recompute. A failed Scan must not
+	// be swallowed: silently proceeding with freedBytes=0 would delete the
+	// files but never decrement the counter, drifting statfs for the process
+	// lifetime.
+	var freedBytes int64
+	if err := tx.tx.QueryRow(ctx,
+		`SELECT COALESCE(SUM(size), 0) FROM inodes
+		 WHERE share_name = ?1 AND file_type = ?2 AND size > 0`,
+		shareName, int(metadata.FileTypeRegular),
+	).Scan(&freedBytes); err != nil {
+		return mapDBError(err, "DeleteShare", shareName)
+	}
+
+	// Capture per-identity usage about to be removed (uid + gid) so the
+	// in-memory usage cache stays accurate. Aggregated before the rows are
+	// deleted; applied to the tx quota delta (post-commit) below.
+	if err := tx.collectShareQuotaFreed(ctx, shareName, "uid", metadata.QuotaScopeUser); err != nil {
+		return err
+	}
+	if err := tx.collectShareQuotaFreed(ctx, shareName, "gid", metadata.QuotaScopeGroup); err != nil {
+		return err
+	}
+
+	// Drop the share row first: shares.root_file_id references inodes(id)
+	// WITHOUT ON DELETE CASCADE, so the inode rows cannot be removed while
+	// the share still points at the root inode.
+	result, err := tx.tx.Exec(ctx, `DELETE FROM shares WHERE share_name = ?1`, shareName)
+	if err != nil {
+		return mapDBError(err, "DeleteShare", shareName)
+	}
+	if result.RowsAffected() == 0 {
+		return &metadata.StoreError{
+			Code:    metadata.ErrNotFound,
+			Message: "share not found",
+			Path:    shareName,
+		}
+	}
+
+	// Delete all inode rows for the share. The store.go:161 contract is
+	// "removes a share and all its metadata"; dropping only the share row
+	// orphans every inodes/parent_child_map/file_block_refs row.
+	// parent_child_map and file_block_refs both cascade from inodes(id).
+	if _, err := tx.tx.Exec(ctx, `DELETE FROM inodes WHERE share_name = ?1`, shareName); err != nil {
+		return mapDBError(err, "DeleteShare", shareName)
+	}
+
+	// Accumulate the decrement on the tx and apply it once after a successful
+	// commit so a serialization/deadlock retry never double-counts. The
+	// counter is statfs-only, not quota-enforcing.
+	if freedBytes > 0 {
+		tx.pendingDelta -= freedBytes
+	}
+
+	return nil
+}
+
+// collectShareQuotaFreed aggregates per-identity usage for the regular files of
+// a share being deleted (grouped by uid or gid) and records the negative delta
+// on the tx so the in-memory usage cache is decremented post-commit. The column
+// is a fixed internal constant, never user input.
+func (tx *sqliteTransaction) collectShareQuotaFreed(ctx context.Context, shareName, col string, scope metadata.QuotaScope) error {
+	query := fmt.Sprintf(
+		`SELECT %s, COALESCE(SUM(size), 0), COUNT(*) FROM inodes
+		 WHERE share_name = ?1 AND file_type = ?2 GROUP BY %s`,
+		col, col,
+	)
+	rows, err := tx.tx.Query(ctx, query, shareName, int(metadata.FileTypeRegular))
+	if err != nil {
+		return mapDBError(err, "DeleteShare", shareName)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, bytes, files int64
+		if err := rows.Scan(&id, &bytes, &files); err != nil {
+			return mapDBError(err, "DeleteShare", shareName)
+		}
+		tx.addQuotaKeyed(sqQuotaKey{scope, uint32(id)}, metadata.UsageStat{Bytes: -bytes, Files: -files})
+	}
+	if err := rows.Err(); err != nil {
+		return mapDBError(err, "DeleteShare", shareName)
+	}
+	return nil
+}
+
+func (tx *sqliteTransaction) ListShares(ctx context.Context) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	rows, err := tx.tx.Query(ctx, `SELECT share_name FROM shares`)
+	if err != nil {
+		return nil, mapDBError(err, "ListShares", "")
+	}
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+	}
+
+	// Surface any error that terminated the iteration early so a partial
+	// share list is not returned as if it were complete.
+	if err := rows.Err(); err != nil {
+		return nil, mapDBError(err, "ListShares", "")
+	}
+
+	return names, nil
+}
+
+func (tx *sqliteTransaction) CreateRootDirectory(ctx context.Context, shareName string, attr *metadata.FileAttr) (*metadata.File, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	if shareName == "" {
+		return nil, &metadata.StoreError{
+			Code:    metadata.ErrInvalidArgument,
+			Message: "share name cannot be empty",
+		}
+	}
+
+	// Apply defaults
+	uid := attr.UID
+	gid := attr.GID
+	mode := attr.Mode
+	if mode == 0 {
+		mode = 0o755
+	}
+
+	// Check if root directory already exists (idempotent behavior). The root is
+	// resolved via shares.root_file_id — with the path column gone (#1166), the
+	// share row is the authoritative pointer to its root inode.
+	checkQuery := `
+		SELECT f.id, f.file_type, f.mode, f.uid, f.gid, f.size,
+			   f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.nlink
+		FROM inodes f
+		WHERE f.id = (SELECT root_file_id FROM shares WHERE share_name = ?1)
+	`
+
+	var (
+		id           string
+		fileType     int16
+		existingMode int32
+		existingUID  int32
+		existingGID  int32
+		size         int64
+		atime        int64
+		mtime        int64
+		ctime        int64
+		creationTime int64
+		hidden       bool
+		nlink        int32
+	)
+
+	err := tx.tx.QueryRow(ctx, checkQuery, shareName).Scan(
+		&id, &fileType, &existingMode, &existingUID, &existingGID, &size,
+		&atime, &mtime, &ctime, &creationTime, &hidden, &nlink,
+	)
+
+	if err == nil {
+		// Root exists - return it
+		return &metadata.File{
+			ID:        uuid.MustParse(id),
+			ShareName: shareName,
+			Path:      "/",
+			FileAttr: metadata.FileAttr{
+				Type:         metadata.FileType(fileType),
+				Mode:         uint32(existingMode),
+				Nlink:        uint32(nlink),
+				UID:          uint32(existingUID),
+				GID:          uint32(existingGID),
+				Size:         uint64(size),
+				Atime:        nanosToTime(atime),
+				Mtime:        nanosToTime(mtime),
+				Ctime:        nanosToTime(ctime),
+				CreationTime: nanosToTime(creationTime),
+				Hidden:       hidden,
+			},
+		}, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return nil, mapDBError(err, "CreateRootDirectory", shareName)
+	}
+
+	// Create new root directory
+	rootID := uuid.New()
+	now := time.Now()
+
+	// Directories start with nlink = 2 ("." and the parent's entry). nlink is
+	// the sole source of truth for the hard-link count (#1166).
+	insertFileQuery := `
+		INSERT INTO inodes (
+			id, share_name,
+			file_type, mode, uid, gid, size,
+			atime, mtime, ctime, creation_time,
+			content_id, link_target, device_major, device_minor, nlink
+		) VALUES (
+			?1, ?2,
+			?3, ?4, ?5, ?6, ?7,
+			?8, ?9, ?10, ?11,
+			?12, ?13, ?14, ?15, 2
+		)
+	`
+
+	_, err = tx.tx.Exec(ctx, insertFileQuery,
+		rootID,                            // id
+		shareName,                         // share_name
+		int16(metadata.FileTypeDirectory), // file_type
+		int32(mode),                       // mode
+		int32(uid),                        // uid
+		int32(gid),                        // gid
+		int64(0),                          // size
+		timeToNanos(now),                  // atime
+		timeToNanos(now),                  // mtime
+		timeToNanos(now),                  // ctime
+		timeToNanos(now),                  // creation_time
+		nil,                               // content_id (NULL for directories)
+		nil,                               // link_target (NULL)
+		nil,                               // device_major (NULL)
+		nil,                               // device_minor (NULL)
+	)
+	if err != nil {
+		return nil, mapDBError(err, "CreateRootDirectory", shareName)
+	}
+
+	// Insert into shares table
+	insertShareQuery := `
+		INSERT INTO shares (share_name, root_file_id)
+		VALUES (?1, ?2)
+		ON CONFLICT (share_name) DO UPDATE
+		SET root_file_id = EXCLUDED.root_file_id
+	`
+
+	_, err = tx.tx.Exec(ctx, insertShareQuery, shareName, rootID)
+	if err != nil {
+		return nil, mapDBError(err, "CreateRootDirectory", shareName)
+	}
+
+	return &metadata.File{
+		ID:        rootID,
+		ShareName: shareName,
+		Path:      "/",
+		FileAttr: metadata.FileAttr{
+			Type:         metadata.FileTypeDirectory,
+			Mode:         mode,
+			Nlink:        2, // Root directories have 2 links (. and parent's entry)
+			UID:          uid,
+			GID:          gid,
+			Size:         0,
+			Atime:        now,
+			Mtime:        now,
+			Ctime:        now,
+			CreationTime: now,
+		},
+	}, nil
+}
+
+// ============================================================================
+// Transaction ServerConfig Operations
+// ============================================================================
+
+func (tx *sqliteTransaction) SetServerConfig(ctx context.Context, config metadata.MetadataServerConfig) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	query := `
+		INSERT INTO server_config (id, config)
+		VALUES (1, ?1)
+		ON CONFLICT (id) DO UPDATE
+		SET config = EXCLUDED.config, updated_at = CURRENT_TIMESTAMP
+	`
+
+	// config is a JSON TEXT column; marshal explicitly (SQLite, unlike Postgres
+	// JSONB, does not serialize a Go map bind value).
+	settings := config.CustomSettings
+	if settings == nil {
+		settings = map[string]any{}
+	}
+	raw, err := json.Marshal(settings)
+	if err != nil {
+		return mapDBError(err, "SetServerConfig", "")
+	}
+	if _, err := tx.tx.Exec(ctx, query, raw); err != nil {
+		return mapDBError(err, "SetServerConfig", "")
+	}
+
+	return nil
+}
+
+func (tx *sqliteTransaction) GetServerConfig(ctx context.Context) (metadata.MetadataServerConfig, error) {
+	if err := ctx.Err(); err != nil {
+		return metadata.MetadataServerConfig{}, err
+	}
+
+	query := `SELECT config FROM server_config WHERE id = 1`
+
+	// config is a JSON TEXT column; scan raw bytes and unmarshal (parity with
+	// the pool-path GetServerConfig).
+	var raw []byte
+	err := tx.tx.QueryRow(ctx, query).Scan(&raw)
+	if errors.Is(err, sql.ErrNoRows) {
+		// Match the pool-path and the memory/badger backends: a missing
+		// config row is an empty (non-nil) config, not a not-found error.
+		return metadata.MetadataServerConfig{CustomSettings: map[string]any{}}, nil
+	}
+	if err != nil {
+		return metadata.MetadataServerConfig{}, mapDBError(err, "GetServerConfig", "")
+	}
+
+	customSettings := map[string]any{}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &customSettings); err != nil {
+			return metadata.MetadataServerConfig{}, mapDBError(err, "GetServerConfig", "")
+		}
+	}
+	return metadata.MetadataServerConfig{
+		CustomSettings: customSettings,
+	}, nil
+}
+
+func (tx *sqliteTransaction) GetFilesystemCapabilities(ctx context.Context, handle metadata.FileHandle) (*metadata.FilesystemCapabilities, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// Return cached capabilities
+	caps := tx.store.capabilities
+	return &caps, nil
+}
+
+func (tx *sqliteTransaction) SetFilesystemCapabilities(capabilities metadata.FilesystemCapabilities) {
+	tx.store.capabilities = capabilities
+}
+
+func (tx *sqliteTransaction) GetFilesystemStatistics(ctx context.Context, handle metadata.FileHandle) (*metadata.FilesystemStatistics, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// Scope the aggregate to the share encoded in the handle (statfsQuery).
+	// Without the WHERE predicate every share reports the store-wide total. An
+	// invalid handle falls back to the store-wide aggregate (single-share
+	// compatible).
+	sql, args := statfsQuery(handle)
+	var bytesUsed, filesUsed int64
+	if err := tx.tx.QueryRow(ctx, sql, args...).Scan(&bytesUsed, &filesUsed); err != nil {
+		return nil, mapDBError(err, "GetFilesystemStatistics", "")
+	}
+
+	return buildFilesystemStatistics(bytesUsed, filesUsed), nil
+}
+
+// ============================================================================
+// Transaction Files Operations (additional)
+// ============================================================================
+
+func (tx *sqliteTransaction) GetFileByPayloadID(ctx context.Context, payloadID metadata.PayloadID) (*metadata.File, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	if payloadID == "" {
+		return nil, &metadata.StoreError{
+			Code:    metadata.ErrInvalidArgument,
+			Message: "content ID cannot be empty",
+		}
+	}
+
+	query := `
+		SELECT
+			f.id, f.share_name, ` + inodePathExpr + `,
+			f.file_type, f.mode, f.uid, f.gid, f.size,
+			f.atime, f.mtime, f.ctime, f.creation_time,
+			f.content_id, f.link_target, f.device_major, f.device_minor,
+			f.hidden, f.acl, f.eas, f.object_id,
+			f.deleted_at, f.original_path, f.deleted_by, f.nlink
+		FROM inodes f
+		WHERE f.content_id = ?1
+		LIMIT 1
+	`
+
+	row := tx.tx.QueryRow(ctx, query, string(payloadID))
+	file, err := fileRowToFileWithNlink(row)
+	if err != nil {
+		return nil, mapDBError(err, "GetFileByPayloadID", string(payloadID))
+	}
+
+	return file, nil
+}

--- a/pkg/metadata/store/sqlite/xattr.go
+++ b/pkg/metadata/store/sqlite/xattr.go
@@ -1,0 +1,52 @@
+package sqlite
+
+import (
+	"context"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// Extended-attribute (xattr) operations delegate to the shared resolver in
+// pkg/metadata/xattr.go over the Files interface. Both the Postgres store and
+// its transaction satisfy metadata.Files, so the same Resolve* helpers serve
+// both. Inline values ride the existing eas JSONB column.
+
+// GetXattr implements metadata.Files.
+func (s *SQLiteMetadataStore) GetXattr(ctx context.Context, handle metadata.FileHandle, name string) ([]byte, bool, error) {
+	return metadata.ResolveGetXattr(ctx, s, handle, name, nil)
+}
+
+// SetXattr implements metadata.Files.
+func (s *SQLiteMetadataStore) SetXattr(ctx context.Context, handle metadata.FileHandle, name string, value []byte) error {
+	return metadata.ResolveSetXattr(ctx, s, handle, name, value)
+}
+
+// RemoveXattr implements metadata.Files.
+func (s *SQLiteMetadataStore) RemoveXattr(ctx context.Context, handle metadata.FileHandle, name string) error {
+	return metadata.ResolveRemoveXattr(ctx, s, handle, name)
+}
+
+// ListXattr implements metadata.Files.
+func (s *SQLiteMetadataStore) ListXattr(ctx context.Context, handle metadata.FileHandle) ([]string, error) {
+	return metadata.ResolveListXattr(ctx, s, handle)
+}
+
+// GetXattr implements metadata.Files for the transaction receiver.
+func (tx *sqliteTransaction) GetXattr(ctx context.Context, handle metadata.FileHandle, name string) ([]byte, bool, error) {
+	return metadata.ResolveGetXattr(ctx, tx, handle, name, nil)
+}
+
+// SetXattr implements metadata.Files for the transaction receiver.
+func (tx *sqliteTransaction) SetXattr(ctx context.Context, handle metadata.FileHandle, name string, value []byte) error {
+	return metadata.ResolveSetXattr(ctx, tx, handle, name, value)
+}
+
+// RemoveXattr implements metadata.Files for the transaction receiver.
+func (tx *sqliteTransaction) RemoveXattr(ctx context.Context, handle metadata.FileHandle, name string) error {
+	return metadata.ResolveRemoveXattr(ctx, tx, handle, name)
+}
+
+// ListXattr implements metadata.Files for the transaction receiver.
+func (tx *sqliteTransaction) ListXattr(ctx context.Context, handle metadata.FileHandle) ([]string, error) {
+	return metadata.ResolveListXattr(ctx, tx, handle)
+}


### PR DESCRIPTION
## What

Adds a new SQLite-backed metadata store at `pkg/metadata/store/sqlite/`, implementing the full ~110-method `metadata.Store` interface (plus the lock / durable-handle / NFSv4-recovery sub-stores, backup/restore, and reset). It uses the pure-Go `glebarez/go-sqlite` driver over `database/sql` — **no cgo**.

## Why

For single-binary appliance / edge deployments that want durable metadata without standing up PostgreSQL. SQLite reuses the same relational model as Postgres (recursive CTEs, partial-unique indexes), so it was the natural second persistent backend (badger is the embedded KV option; this is the embedded SQL option). Closes #1224.

## Design

The PostgreSQL store is the reference implementation; this is a faithful port with the SQL adapted to the SQLite dialect:

- **Same model:** `parent_child_map` with **no unique on `child_id`** (hard links), `nlink` as source of truth with the partial-unique-on-active index pattern, recursive-CTE path reconstruction, and the `object_id` partial-unique dedup index (`inodes_object_id_idx`).
- **Dialect adaptations:** `?N` indexed placeholders (preserves Postgres's out-of-order `$21/$22` in PutFile); `json_group_array`/`json_array`/`lower(hex())` for the block-ref manifest (vs `json_agg`/`encode`); `TIMESTAMP`-typed columns so the driver round-trips `time.Time`; `byte_offset`/`byte_length` stored as decimal **TEXT** to hold the full `uint64` range; no `LATERAL` (recursive CTE picks one parent edge via a correlated `rowid` subquery), no `FOR UPDATE`/`TRUNCATE`/`md5()` (SQLite has no btree row-size limit, so `content_id` is indexed directly).
- **Single consolidated migration** (mirrors the postgres `migrations/` layout) producing the final schema in one step — SQLite has no existing deployments to migrate incrementally. A small bespoke migration runner applies it; `golang-migrate`'s sqlite driver is intentionally avoided because it blank-imports `modernc.org/sqlite`, which would register the `database/sql` driver name `"sqlite"` a second time alongside the control-plane's `glebarez/go-sqlite` and panic at init.
- **Factory:** `case "sqlite"` in `CreateMetadataStoreFromConfig` (`runtime/init.go`) and a restore-at-path case in `runtime/stores/service.go`.

## Conformance

Passes the **full shared `storetest` conformance suite — 187/187 subtests, `-race` clean** (FileOps, DirOps, Permissions, CrossProtocolPermissions, DurableHandles, ClientRecovery, ACL/EA/Xattr, FileBlock/BlockRef/Truncate/ObjectID ops, StoreSurface, INV02 fuzz, Backup/ResetThenRestore/LockPersistence).

CI wiring mirrors **badger**, not postgres: the suite is self-contained (no external DB), so `pkg/metadata/store/sqlite/sqlite_conformance_test.go` has **no `//go:build integration` tag** and runs in the default `go test -race ./pkg/...` unit-test job — unlike the integration-gated postgres suite that needs a live DSN.

## Review

Ran the code-simplifier and code-reviewer over the diff before opening. Reviewer verified the high-risk areas (out-of-order `?N` binding, hard-link CTE determinism, `uint64`→TEXT, EXCLUDED casing, JSON/BLOB hash round-trip, TIMESTAMP scanning, single-connection pool, CRC-before-commit restore, error mapping) as correct; the one MEDIUM finding (stale cached `store_id` after `Restore`) is fixed in this branch.