### PR TITLE
feat(netlogon): hot-reload machine credential without restart (#1325)

### DIFF
--- a/cmd/dfs/commands/netlogon.go
+++ b/cmd/dfs/commands/netlogon.go
@@ -2,32 +2,42 @@ package commands
 
 import (
 	"log/slog"
-	"os"
-	"strings"
 
 	"github.com/marmos91/dittofs/internal/auth/netlogon"
 	"github.com/marmos91/dittofs/pkg/config"
 )
 
-// buildNetlogonAuthenticator creates a NetlogonAuthenticator from the Kerberos
-// machine-account configuration. Returns nil (typed-nil-safe: an untyped nil
-// interface value) when MachineAccount.Enabled is false, so the SMB handler
-// falls back to local NTLM authentication without a domain controller.
+// buildNetlogonAuthenticator creates a *netlogon.Authenticator from the Kerberos
+// machine-account configuration. Returns nil when MachineAccount.Enabled is
+// false (or the config is incomplete), so the SMB handler falls back to local
+// NTLM authentication without a domain controller.
 //
-// Typed-nil-interface safety: the disabled path returns the bare nil literal so
-// callers can safely test `auth == nil` without hitting the typed-nil-interface
-// trap (a (*netlogon.Authenticator)(nil) wrapped in the interface would not
-// equal nil).
-func buildNetlogonAuthenticator(k config.KerberosConfig) netlogon.NetlogonAuthenticator {
-	if !k.MachineAccount.Enabled {
+// The authenticator is backed by a netlogon.MutableProvider so the machine
+// credential / DC binding can be hot-reloaded over the API without a restart
+// (#1325): an identity-provider config change updates the runtime credential and
+// the SMB adapter calls Authenticator.ReloadCredential.
+func buildNetlogonAuthenticator(k config.KerberosConfig) *netlogon.Authenticator {
+	cred, ok := netlogonCredentialFromConfig(k)
+	if !ok {
 		return nil
 	}
+	return netlogon.NewAuthenticator(netlogon.NewMutableProvider(cred))
+}
 
-	// Validate required fields before constructing a doomed authenticator.
+// netlogonCredentialFromConfig validates the machine-account sub-block and, when
+// it is enabled and complete, returns the derived MachineCredential. The bool is
+// false (and a warning is logged) when passthrough must stay disabled. Shared by
+// the startup build and the seed of the runtime's hot-reloadable credential.
+func netlogonCredentialFromConfig(k config.KerberosConfig) (netlogon.MachineCredential, bool) {
+	if !k.MachineAccount.Enabled {
+		return netlogon.MachineCredential{}, false
+	}
+
+	// Validate required fields before constructing a doomed credential.
 	ma := k.MachineAccount
 	if ma.AccountName == "" {
 		slog.Warn("NETLOGON machine account is enabled but AccountName is not set; NTLM passthrough disabled")
-		return nil
+		return netlogon.MachineCredential{}, false
 	}
 	if ma.Secret == "" {
 		if ma.KeytabPath != "" {
@@ -36,11 +46,11 @@ func buildNetlogonAuthenticator(k config.KerberosConfig) netlogon.NetlogonAuthen
 		} else {
 			slog.Warn("NETLOGON machine account is enabled but Secret is not set; NTLM passthrough disabled")
 		}
-		return nil
+		return netlogon.MachineCredential{}, false
 	}
 	if k.NetBIOSDomain == "" {
 		slog.Warn("NETLOGON machine account is enabled but kerberos.netbios_domain (DomainName) is not set; NTLM passthrough disabled")
-		return nil
+		return netlogon.MachineCredential{}, false
 	}
 	// The realm is mandatory: the secure channel authenticates to the DC over a
 	// Kerberos SMB session, and when no dc_address is set the realm also drives
@@ -48,39 +58,14 @@ func buildNetlogonAuthenticator(k config.KerberosConfig) netlogon.NetlogonAuthen
 	// from the realm via _ldap._tcp.dc._msdcs.<realm> (#1324).
 	if k.Realm == "" {
 		slog.Warn("NETLOGON machine account is enabled but kerberos.realm is not set (required for the Kerberos SMB session to the DC and for DNS SRV discovery); NTLM passthrough disabled")
-		return nil
+		return netlogon.MachineCredential{}, false
 	}
 
-	// Derive the NetBIOS workstation name.  MS-NRPC §3.1.4.1 requires the
-	// short host name without the trailing '$' machine-account marker.
-	workstation := netbiosWorkstation(k)
-
-	cred := netlogon.MachineCredential{
-		AccountName: ma.AccountName,
-		Password:    ma.Secret,
-		Workstation: workstation,
-		DomainName:  k.NetBIOSDomain,
-		Realm:       k.Realm,
-		DCAddresses: ma.DCAddresses,
-	}
-	return netlogon.NewAuthenticator(netlogon.NewOfflineProvider(cred))
+	return netlogon.BuildMachineCredential(ma.AccountName, ma.Secret, k.NetBIOSDomain, k.Realm, ma.DCAddresses), true
 }
 
 // netbiosWorkstation derives the short workstation name used in NETLOGON RPC
-// calls.  Priority:
-//  1. AccountName with a trailing '$' stripped (the AD machine-account
-//     convention, e.g. "DITTOFS$" → "DITTOFS").
-//  2. Short hostname from os.Hostname() (everything before the first '.').
+// calls from the machine-account name (falling back to the OS hostname).
 func netbiosWorkstation(k config.KerberosConfig) string {
-	if n := k.MachineAccount.AccountName; n != "" {
-		return strings.TrimSuffix(n, "$")
-	}
-	if h, err := os.Hostname(); err == nil {
-		if idx := strings.IndexByte(h, '.'); idx > 0 {
-			return h[:idx]
-		}
-		return h
-	}
-	slog.Warn("NETLOGON workstation name could not be derived; DC may reject the logon")
-	return ""
+	return netlogon.DeriveWorkstation(k.MachineAccount.AccountName)
 }

--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -503,6 +503,17 @@ func resolveIdentityProviders(ctx context.Context, cpStore store.Store, rt *runt
 			}
 		}
 	}
+
+	// Seed the runtime's hot-reloadable NETLOGON machine credential from the
+	// effective Kerberos machine-account config (#1325). nil disables passthrough.
+	// The SMB adapter reads this on an identity-provider config change to rebuild
+	// its secure channel without a restart.
+	if cred, ok := netlogonCredentialFromConfig(kerberos); ok {
+		rt.SetNetlogonCredential(&cred)
+	} else {
+		rt.SetNetlogonCredential(nil)
+	}
+
 	return kerberos
 }
 

--- a/internal/auth/netlogon/authenticator.go
+++ b/internal/auth/netlogon/authenticator.go
@@ -2,8 +2,20 @@ package netlogon
 
 import (
 	"context"
+	"errors"
 	"sync"
 )
+
+// errChannelNotConnected is returned by a secureChannel.samLogon when the
+// channel was torn down (e.g. by a concurrent Reload) before the call acquired
+// the channel lock. It is a benign race, not an RPC failure: NetworkLogon
+// rebuilds and retries it without consuming the single RPC-error retry.
+var errChannelNotConnected = errors.New("netlogon: channel not connected")
+
+// maxReloadRetries bounds how many times NetworkLogon rebuilds the channel after
+// hitting errChannelNotConnected, so a pathological reload storm cannot live-lock
+// a logon. In practice a reload is a rare admin action and one rebuild suffices.
+const maxReloadRetries = 8
 
 // NetworkLogonRequest carries the NTLM challenge/response the SMB handler
 // received on the wire, to be validated by a Domain Controller.
@@ -29,13 +41,35 @@ type NetlogonAuthenticator interface {
 	NetworkLogon(ctx context.Context, req NetworkLogonRequest) (*LogonResult, error)
 }
 
+// secureChannel is the subset of a NETLOGON secure channel the Authenticator
+// depends on. *SecureChannel is the production implementation; tests substitute
+// a fake to exercise the teardown/concurrency logic without real RPC.
+//
+// connect, samLogon, and close each take the channel's own lock for their full
+// duration, so a teardown (close) cannot race an in-flight NetrLogonSamLogon and
+// corrupt the MS-NRPC sequence number chained across calls.
+type secureChannel interface {
+	connect(ctx context.Context, mc MachineCredential) error
+	samLogon(ctx context.Context, mc MachineCredential, req NetworkLogonRequest) (*LogonResult, error)
+	close(ctx context.Context)
+}
+
+// newSecureChannel is the channel factory; a package var so tests can inject a
+// fake. Production always builds a real *SecureChannel.
+var newSecureChannel = func() secureChannel { return &SecureChannel{} }
+
 // Authenticator implements NetlogonAuthenticator via a NETLOGON sealed secure channel.
 // It lazily connects to the DC on the first call and caches the channel for reuse.
 // On a transient RPC error it re-establishes the channel once before giving up.
+//
+// The cached channel pointer is swapped atomically under a.mu by
+// ensureChannel/reset, and every channel operation locks the channel itself for
+// its full duration. A Reload (machine-credential hot-reload, #1325) therefore
+// tears the channel down without racing an in-flight NetrLogonSamLogon.
 type Authenticator struct {
 	provider MachineCredentialProvider
 	mu       sync.Mutex
-	chan_    *SecureChannel
+	chan_    secureChannel
 }
 
 // NewAuthenticator creates an Authenticator backed by the given MachineCredentialProvider.
@@ -56,56 +90,104 @@ func (a *Authenticator) NetworkLogon(ctx context.Context, req NetworkLogonReques
 	}
 
 	res, err := sc.samLogon(ctx, *mc, req)
-	if err != nil {
-		// Re-establish the channel once on RPC error, then retry.
+	if err == nil {
+		return res, nil
+	}
+
+	// A concurrent Reload that tore sc down between ensureChannel and samLogon
+	// surfaces as errChannelNotConnected — a benign race, not an RPC failure.
+	// Rebuild against the latest credential and retry, bounded so a reload storm
+	// cannot live-lock. Any other error gets a single RPC-error rebuild+retry.
+	retries := maxReloadRetries
+	for {
 		a.reset(ctx)
+		mc, err = a.provider.Credential(ctx)
+		if err != nil {
+			return nil, err
+		}
 		if sc, err = a.ensureChannel(ctx, mc); err != nil {
 			return nil, err
 		}
-		if res, err = sc.samLogon(ctx, *mc, req); err != nil {
+		res, err = sc.samLogon(ctx, *mc, req)
+		if err == nil {
+			return res, nil
+		}
+		// Only the reload race is retried beyond the first attempt; a genuine RPC
+		// error is returned after one rebuild+retry.
+		if !errors.Is(err, errChannelNotConnected) {
+			return nil, err
+		}
+		retries--
+		if retries <= 0 {
 			return nil, err
 		}
 	}
-	return res, nil
+}
+
+// Reload tears down the cached channel so the next NetworkLogon rebuilds it
+// against the current machine credential.
+//
+// Safe under concurrent logons: the old channel is closed under its own lock, so
+// the teardown blocks until any in-flight NetrLogonSamLogon completes and never
+// corrupts the chained sequence number. In-flight logons finish on the old
+// channel; the next logon builds a fresh one with the new credential.
+func (a *Authenticator) Reload(ctx context.Context) {
+	a.reset(ctx)
+}
+
+// ReloadCredential is the NETLOGON machine-credential hot-reload entrypoint
+// (#1325). When the authenticator is backed by a *MutableProvider, it installs
+// the new credential and then tears down the cached channel atomically so the
+// next NetworkLogon authenticates with the new credential / DC binding — without
+// a server restart. With any other provider it falls back to dropping the cached
+// channel (the provider re-supplies the credential on the next call).
+func (a *Authenticator) ReloadCredential(ctx context.Context, cred MachineCredential) {
+	if mp, ok := a.provider.(*MutableProvider); ok {
+		mp.Set(cred)
+	}
+	a.reset(ctx)
 }
 
 // Close shuts down the cached secure channel connection.
 func (a *Authenticator) Close(ctx context.Context) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if a.chan_ != nil {
-		a.chan_.mu.Lock()
-		a.chan_.close(ctx)
-		a.chan_.mu.Unlock()
-		a.chan_ = nil
-	}
+	a.reset(ctx)
 }
 
-// ensureChannel returns the cached SecureChannel, creating and connecting it if needed.
-func (a *Authenticator) ensureChannel(ctx context.Context, mc *MachineCredential) (*SecureChannel, error) {
+// ensureChannel returns the cached secureChannel, creating and connecting it if
+// needed. connect is idempotent and self-locking; a concurrent reset that clears
+// a.chan_ just causes the next call to build a fresh channel.
+func (a *Authenticator) ensureChannel(ctx context.Context, mc *MachineCredential) (secureChannel, error) {
 	a.mu.Lock()
-	defer a.mu.Unlock()
 	if a.chan_ == nil {
-		a.chan_ = &SecureChannel{}
+		a.chan_ = newSecureChannel()
 	}
 	sc := a.chan_
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
+	a.mu.Unlock()
+
 	if err := sc.connect(ctx, *mc); err != nil {
+		// Drop the half-built channel so the next attempt starts clean, but only
+		// if it is still the cached one (a concurrent reset may have replaced it).
+		a.mu.Lock()
+		if a.chan_ == sc {
+			a.chan_ = nil
+		}
+		a.mu.Unlock()
 		return nil, err
 	}
 	return sc, nil
 }
 
-// reset closes the cached channel and clears it so the next call re-connects.
+// reset detaches and closes the cached channel so the next call re-connects.
+// The pointer swap happens under a.mu; close runs after a.mu is released (taking
+// only the channel's own lock) so a slow teardown does not block new logons from
+// installing a fresh channel.
 func (a *Authenticator) reset(ctx context.Context) {
 	a.mu.Lock()
-	defer a.mu.Unlock()
-	if a.chan_ != nil {
-		a.chan_.mu.Lock()
-		a.chan_.close(ctx)
-		a.chan_.mu.Unlock()
-		a.chan_ = nil
+	old := a.chan_
+	a.chan_ = nil
+	a.mu.Unlock()
+	if old != nil {
+		old.close(ctx)
 	}
 }
 

--- a/internal/auth/netlogon/authenticator.go
+++ b/internal/auth/netlogon/authenticator.go
@@ -3,6 +3,7 @@ package netlogon
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 )
@@ -12,6 +13,49 @@ import (
 // the channel lock. It is a benign local race, not an RPC failure: NetworkLogon
 // rebuilds and retries it (with no backoff).
 var errChannelNotConnected = errors.New("netlogon: channel not connected")
+
+// statusAccessDenied (NTSTATUS STATUS_ACCESS_DENIED) is the transient channel-level
+// rejection a freshly rebuilt secure channel can return while its new MS-NRPC
+// credential chain settles after a hot-reload. It is the ONLY DC-returned status
+// NetworkLogon retries — every other status (a domain USER's hard auth failure
+// such as LOGON_FAILURE / WRONG_PASSWORD / ACCOUNT_LOCKED_OUT) must fail fast so
+// retrying never amplifies failed logons toward AD account lockout.
+const statusAccessDenied uint32 = 0xC0000022
+
+// SamLogonStatusError carries the NTSTATUS a NetrLogonSamLogon RPC returned in
+// its Return field. It lets NetworkLogon distinguish a transient channel-level
+// rejection (worth a rebuild+retry) from a domain user's hard authentication
+// failure (must fail fast, not retry — retrying amplifies failed logons toward
+// AD account lockout).
+type SamLogonStatusError struct {
+	Status uint32
+}
+
+func (e *SamLogonStatusError) Error() string {
+	return fmt.Sprintf("netlogon: SAMLogon returned 0x%08x", e.Status)
+}
+
+// isTransientChannelError reports whether err is a transient secure-channel
+// condition that a rebuild+retry can clear, as opposed to a hard logon failure.
+// Only two cases qualify:
+//   - errChannelNotConnected: the local teardown race (a concurrent reload tore
+//     the channel down before the RPC acquired the channel lock), and
+//   - a SamLogonStatusError with STATUS_ACCESS_DENIED: the channel-level rejection
+//     a freshly rebuilt channel can return while its new credential chain settles.
+//
+// A domain user's authentication-failure NTSTATUS (LOGON_FAILURE, WRONG_PASSWORD,
+// ACCOUNT_LOCKED_OUT, …) is NOT transient and returns false, so NetworkLogon fails
+// fast instead of retrying a bad-password attempt toward account lockout.
+func isTransientChannelError(err error) bool {
+	if errors.Is(err, errChannelNotConnected) {
+		return true
+	}
+	var st *SamLogonStatusError
+	if errors.As(err, &st) {
+		return st.Status == statusAccessDenied
+	}
+	return false
+}
 
 // maxReloadRetries bounds how many times NetworkLogon rebuilds the channel and
 // retries after a transient secure-channel error (a concurrent reload tearing
@@ -101,14 +145,25 @@ func (a *Authenticator) NetworkLogon(ctx context.Context, req NetworkLogonReques
 		return res, nil
 	}
 
-	// The logon failed. A concurrent Reload tears down and rebuilds the sealed
-	// secure channel — a fresh ReqChallenge/ServerAuthenticate handshake that
-	// resets the MS-NRPC credential chain. A logon caught in that window can see
-	// either the benign local errChannelNotConnected (channel torn down before the
-	// RPC) or a DC-side rejection (e.g. STATUS_ACCESS_DENIED while the new chain
-	// settles). Both are transient: rebuild against the latest credential and
-	// retry, bounded so we can never live-lock, with a short backoff to let the
-	// rebuilt channel's credential chain settle.
+	// The logon failed. Only retry when the failure is a TRANSIENT secure-channel
+	// condition that a rebuild can clear:
+	//   - errChannelNotConnected: a concurrent Reload tore the channel down before
+	//     this RPC acquired the channel lock (a benign local race), or
+	//   - a SamLogonStatusError with STATUS_ACCESS_DENIED: the channel-level
+	//     rejection a freshly rebuilt channel can return while its new MS-NRPC
+	//     credential chain settles after a hot-reload.
+	//
+	// Any other failure — most importantly a domain USER's hard authentication
+	// failure (LOGON_FAILURE / WRONG_PASSWORD / ACCOUNT_LOCKED_OUT, surfaced as a
+	// SamLogonStatusError) — must fail FAST. Retrying a bad-password attempt would
+	// amplify failed logons toward AD account lockout, so we return immediately.
+	if !isTransientChannelError(err) {
+		return nil, err
+	}
+
+	// Transient: rebuild against the latest credential and retry, bounded so we can
+	// never live-lock, with a short backoff to let the rebuilt channel's credential
+	// chain settle.
 	//
 	// A credential-provider error is NOT retried: when passthrough is disabled the
 	// provider returns a validation error, so the loop returns immediately and the
@@ -126,6 +181,11 @@ func (a *Authenticator) NetworkLogon(ctx context.Context, req NetworkLogonReques
 		res, err = sc.samLogon(ctx, *mc, req)
 		if err == nil {
 			return res, nil
+		}
+		// A non-transient failure on the rebuilt channel (e.g. the user's password
+		// really is wrong) must fail fast too — stop retrying immediately.
+		if !isTransientChannelError(err) {
+			return nil, err
 		}
 		// Brief backoff before the next rebuild so a just-rebuilt channel is not
 		// immediately torn down again by a still-in-flight reload. Skipped for the

--- a/internal/auth/netlogon/authenticator.go
+++ b/internal/auth/netlogon/authenticator.go
@@ -4,18 +4,25 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"time"
 )
 
 // errChannelNotConnected is returned by a secureChannel.samLogon when the
 // channel was torn down (e.g. by a concurrent Reload) before the call acquired
-// the channel lock. It is a benign race, not an RPC failure: NetworkLogon
-// rebuilds and retries it without consuming the single RPC-error retry.
+// the channel lock. It is a benign local race, not an RPC failure: NetworkLogon
+// rebuilds and retries it (with no backoff).
 var errChannelNotConnected = errors.New("netlogon: channel not connected")
 
-// maxReloadRetries bounds how many times NetworkLogon rebuilds the channel after
-// hitting errChannelNotConnected, so a pathological reload storm cannot live-lock
-// a logon. In practice a reload is a rare admin action and one rebuild suffices.
+// maxReloadRetries bounds how many times NetworkLogon rebuilds the channel and
+// retries after a transient secure-channel error (a concurrent reload tearing
+// down / rebuilding the channel), so it can never live-lock. In practice a
+// reload is a rare admin action and the first rebuild succeeds.
 const maxReloadRetries = 8
+
+// reloadRetryBackoff is the pause between rebuild attempts after a DC-side
+// failure, giving a freshly rebuilt channel's MS-NRPC credential chain a moment
+// to settle before the next attempt.
+const reloadRetryBackoff = 100 * time.Millisecond
 
 // NetworkLogonRequest carries the NTLM challenge/response the SMB handler
 // received on the wire, to be validated by a Domain Controller.
@@ -94,12 +101,20 @@ func (a *Authenticator) NetworkLogon(ctx context.Context, req NetworkLogonReques
 		return res, nil
 	}
 
-	// A concurrent Reload that tore sc down between ensureChannel and samLogon
-	// surfaces as errChannelNotConnected — a benign race, not an RPC failure.
-	// Rebuild against the latest credential and retry, bounded so a reload storm
-	// cannot live-lock. Any other error gets a single RPC-error rebuild+retry.
-	retries := maxReloadRetries
-	for {
+	// The logon failed. A concurrent Reload tears down and rebuilds the sealed
+	// secure channel — a fresh ReqChallenge/ServerAuthenticate handshake that
+	// resets the MS-NRPC credential chain. A logon caught in that window can see
+	// either the benign local errChannelNotConnected (channel torn down before the
+	// RPC) or a DC-side rejection (e.g. STATUS_ACCESS_DENIED while the new chain
+	// settles). Both are transient: rebuild against the latest credential and
+	// retry, bounded so we can never live-lock, with a short backoff to let the
+	// rebuilt channel's credential chain settle.
+	//
+	// A credential-provider error is NOT retried: when passthrough is disabled the
+	// provider returns a validation error, so the loop returns immediately and the
+	// logon fails closed (it never silently keeps authenticating with a stale
+	// credential).
+	for attempt := 0; attempt < maxReloadRetries; attempt++ {
 		a.reset(ctx)
 		mc, err = a.provider.Credential(ctx)
 		if err != nil {
@@ -112,16 +127,18 @@ func (a *Authenticator) NetworkLogon(ctx context.Context, req NetworkLogonReques
 		if err == nil {
 			return res, nil
 		}
-		// Only the reload race is retried beyond the first attempt; a genuine RPC
-		// error is returned after one rebuild+retry.
+		// Brief backoff before the next rebuild so a just-rebuilt channel is not
+		// immediately torn down again by a still-in-flight reload. Skipped for the
+		// purely-local "channel not connected" race, which needs no settle time.
 		if !errors.Is(err, errChannelNotConnected) {
-			return nil, err
-		}
-		retries--
-		if retries <= 0 {
-			return nil, err
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(reloadRetryBackoff):
+			}
 		}
 	}
+	return nil, err
 }
 
 // Reload tears down the cached channel so the next NetworkLogon rebuilds it

--- a/internal/auth/netlogon/credential.go
+++ b/internal/auth/netlogon/credential.go
@@ -3,6 +3,10 @@ package netlogon
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
 )
 
 // MachineCredential holds the machine account credentials required for NETLOGON operations.
@@ -15,9 +19,95 @@ type MachineCredential struct {
 	DCAddresses []string // Domain controller addresses
 }
 
+// DeriveWorkstation derives the short NetBIOS workstation name used in NETLOGON
+// RPC calls (MS-NRPC §3.1.4.1 requires the short host name without the trailing
+// '$' machine-account marker). Priority:
+//  1. accountName with a trailing '$' stripped (the AD convention, e.g.
+//     "DITTOFS$" → "DITTOFS").
+//  2. Short hostname from os.Hostname() (everything before the first '.').
+func DeriveWorkstation(accountName string) string {
+	if accountName != "" {
+		return strings.TrimSuffix(accountName, "$")
+	}
+	if h, err := os.Hostname(); err == nil {
+		if idx := strings.IndexByte(h, '.'); idx > 0 {
+			return h[:idx]
+		}
+		return h
+	}
+	slog.Warn("NETLOGON workstation name could not be derived; DC may reject the logon")
+	return ""
+}
+
+// BuildMachineCredential assembles a MachineCredential from the machine-account
+// configuration fields, deriving the workstation name via DeriveWorkstation. It
+// is shared by the startup wiring (cmd/dfs) and the API hot-reload path so both
+// produce identical credentials (#1325). It performs no validation — callers
+// rely on Credential() / validateCredential to reject incomplete credentials.
+func BuildMachineCredential(accountName, secret, netbiosDomain, realm string, dcAddresses []string) MachineCredential {
+	return MachineCredential{
+		AccountName: accountName,
+		Password:    secret,
+		Workstation: DeriveWorkstation(accountName),
+		DomainName:  netbiosDomain,
+		Realm:       realm,
+		DCAddresses: dcAddresses,
+	}
+}
+
 // MachineCredentialProvider is an interface for retrieving machine credentials.
 type MachineCredentialProvider interface {
 	Credential(ctx context.Context) (*MachineCredential, error)
+}
+
+// validateCredential checks that a MachineCredential carries the fields the
+// secure channel needs: account/password/domain are always required, and the
+// realm is mandatory (the channel rides a Kerberos SMB session and the realm
+// also drives DNS SRV DC discovery when no DC address is configured, #1324).
+func validateCredential(c MachineCredential) error {
+	if c.AccountName == "" || c.Password == "" || c.DomainName == "" {
+		return fmt.Errorf("netlogon: incomplete machine credential (account/password/domain required)")
+	}
+	if c.Realm == "" {
+		return fmt.Errorf("netlogon: realm is required (Kerberos SMB session to the DC and DNS SRV discovery both need it)")
+	}
+	return nil
+}
+
+// MutableProvider is a MachineCredentialProvider whose credential can be swapped
+// atomically at runtime. It backs NETLOGON machine-credential hot-reload (#1325):
+// an API-driven machine-account config change calls Set to install the new
+// credential, after which the next secure-channel rebuild authenticates with it.
+// Concurrent Credential reads and Set writes are mutex-guarded.
+type MutableProvider struct {
+	mu   sync.RWMutex
+	cred MachineCredential
+}
+
+// NewMutableProvider creates a MutableProvider seeded with the given credential.
+func NewMutableProvider(cred MachineCredential) *MutableProvider {
+	return &MutableProvider{cred: cred}
+}
+
+// Credential returns a copy of the current credential after validation.
+func (p *MutableProvider) Credential(ctx context.Context) (*MachineCredential, error) {
+	p.mu.RLock()
+	cp := p.cred
+	p.mu.RUnlock()
+	if err := validateCredential(cp); err != nil {
+		return nil, err
+	}
+	return &cp, nil
+}
+
+// Set atomically replaces the credential. The next Credential call (and thus the
+// next secure-channel rebuild) uses the new value. It does not itself tear down
+// any cached channel — callers that want the change to take effect immediately
+// must reset the Authenticator's channel (see Authenticator.Reload).
+func (p *MutableProvider) Set(cred MachineCredential) {
+	p.mu.Lock()
+	p.cred = cred
+	p.mu.Unlock()
 }
 
 // offlineProvider implements MachineCredentialProvider with a static credential.
@@ -33,16 +123,8 @@ func NewOfflineProvider(cred MachineCredential) MachineCredentialProvider {
 
 // Credential returns the stored credential after validation.
 func (p *offlineProvider) Credential(ctx context.Context) (*MachineCredential, error) {
-	if p.cred.AccountName == "" || p.cred.Password == "" || p.cred.DomainName == "" {
-		return nil, fmt.Errorf("netlogon: incomplete machine credential (account/password/domain required)")
-	}
-	// The realm is mandatory regardless of how the DC is located: the secure
-	// channel rides a Kerberos-authenticated SMB session (buildKRB5Config needs
-	// the realm) and, when no DC address is configured, the realm also drives
-	// DNS SRV discovery. A DC address itself is optional — absent one, the secure
-	// channel locates a DC from the realm via _ldap._tcp.dc._msdcs.<realm> (#1324).
-	if p.cred.Realm == "" {
-		return nil, fmt.Errorf("netlogon: realm is required (Kerberos SMB session to the DC and DNS SRV discovery both need it)")
+	if err := validateCredential(p.cred); err != nil {
+		return nil, err
 	}
 	cp := p.cred
 	return &cp, nil

--- a/internal/auth/netlogon/credential_test.go
+++ b/internal/auth/netlogon/credential_test.go
@@ -57,3 +57,60 @@ func TestOfflineProviderRejectsNoDCNoRealm(t *testing.T) {
 		t.Fatal("expected validation error when neither DC address nor realm is set")
 	}
 }
+
+// TestMutableProviderSetSwapsCredential verifies Set atomically replaces the
+// credential returned by Credential (the basis of NETLOGON hot-reload, #1325).
+func TestMutableProviderSetSwapsCredential(t *testing.T) {
+	p := NewMutableProvider(MachineCredential{
+		AccountName: "OLD$", Password: "secret",
+		DomainName: "DITTOFS", Realm: "DITTOFS.AD",
+	})
+	got, err := p.Credential(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.AccountName != "OLD$" {
+		t.Fatalf("expected OLD$, got %q", got.AccountName)
+	}
+
+	p.Set(MachineCredential{
+		AccountName: "NEW$", Password: "secret2",
+		DomainName: "DITTOFS", Realm: "DITTOFS.AD",
+	})
+	got, err = p.Credential(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error after Set: %v", err)
+	}
+	if got.AccountName != "NEW$" || got.Password != "secret2" {
+		t.Fatalf("Set did not swap credential: %+v", got)
+	}
+}
+
+// TestMutableProviderValidates verifies Credential rejects an incomplete swapped
+// credential, matching the offline provider's contract.
+func TestMutableProviderValidates(t *testing.T) {
+	p := NewMutableProvider(MachineCredential{AccountName: "DITTOFS$"})
+	if _, err := p.Credential(context.Background()); err == nil {
+		t.Fatal("expected validation error for incomplete credential")
+	}
+}
+
+// TestDeriveWorkstation covers the account-name and hostname-fallback paths.
+func TestDeriveWorkstation(t *testing.T) {
+	if got := DeriveWorkstation("DITTOFS$"); got != "DITTOFS" {
+		t.Fatalf("expected DITTOFS, got %q", got)
+	}
+	if got := DeriveWorkstation("PLAIN"); got != "PLAIN" {
+		t.Fatalf("expected PLAIN, got %q", got)
+	}
+}
+
+// TestBuildMachineCredential verifies the shared assembler derives the
+// workstation and copies the fields used by both startup and hot-reload.
+func TestBuildMachineCredential(t *testing.T) {
+	c := BuildMachineCredential("DITTOFS$", "pw", "DITTOFS", "DITTOFS.AD", []string{"10.0.0.1"})
+	if c.AccountName != "DITTOFS$" || c.Password != "pw" || c.DomainName != "DITTOFS" ||
+		c.Realm != "DITTOFS.AD" || c.Workstation != "DITTOFS" || len(c.DCAddresses) != 1 {
+		t.Fatalf("unexpected credential: %+v", c)
+	}
+}

--- a/internal/auth/netlogon/reload_test.go
+++ b/internal/auth/netlogon/reload_test.go
@@ -1,0 +1,274 @@
+package netlogon
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeChannel is a test double for *SecureChannel that exercises the
+// Authenticator's teardown/rebuild concurrency without real RPC. It enforces the
+// production invariant that a close cannot overlap an in-flight samLogon (both
+// take the channel's own lock), and records the credential each logon ran under
+// so the test can prove a rebuild switched credentials atomically.
+type fakeChannel struct {
+	mu        sync.Mutex // mirrors SecureChannel.mu: held for the full samLogon/close
+	connected bool
+	closed    bool
+	id        int // unique per channel instance, to detect rebuilds
+
+	// perChanInFlight counts logons active on THIS channel. The channel lock must
+	// keep it <= 1; the test fails the whole run if it ever exceeds 1, proving a
+	// teardown/rebuild never lets two logons share a channel concurrently.
+	perChanInFlight int32
+
+	// shared across all channels built in one test run.
+	state *fakeState
+}
+
+type fakeState struct {
+	mu sync.Mutex
+	// inFlight is the number of samLogon calls currently holding a channel lock.
+	inFlight int32
+	// maxInFlight is the high-water mark of concurrent samLogons on a SINGLE
+	// channel — must stay 1 because samLogon serializes on the channel lock.
+	maxInFlightPerChan int32
+	// nextID hands out unique channel IDs.
+	nextID int
+	// logonCreds records the AccountName each logon authenticated under.
+	logonCreds []string
+	// built counts how many channels were connected (rebuild detection).
+	built int
+	// logonDelay slows samLogon so a concurrent reload has a window to interleave.
+	logonDelay time.Duration
+	// concurrencyViolation is set to 1 if any single channel ever served two
+	// logons at once — i.e. the per-channel lock invariant was broken.
+	concurrencyViolation int32
+}
+
+func (c *fakeChannel) connect(ctx context.Context, mc MachineCredential) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.connected {
+		return nil
+	}
+	c.connected = true
+	c.state.mu.Lock()
+	c.state.built++
+	c.state.mu.Unlock()
+	return nil
+}
+
+func (c *fakeChannel) samLogon(ctx context.Context, mc MachineCredential, req NetworkLogonRequest) (*LogonResult, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.connected || c.closed {
+		// Mirror SecureChannel.samLogon's torn-down path so the Authenticator's
+		// reload-race retry/rebuild logic is exercised. Uses the same sentinel the
+		// real channel returns so NetworkLogon treats it as a benign reload race.
+		return nil, errChannelNotConnected
+	}
+
+	// Per-channel concurrency must never exceed 1: the channel lock serializes
+	// logons and a teardown blocks on it. If it does, the sequence chain could be
+	// corrupted — record the violation for the test to fail on.
+	if perChan := atomic.AddInt32(&c.perChanInFlight, 1); perChan > 1 {
+		atomic.StoreInt32(&c.state.concurrencyViolation, 1)
+	}
+	n := atomic.AddInt32(&c.state.inFlight, 1)
+	c.recordHighWater(n)
+	if c.state.logonDelay > 0 {
+		time.Sleep(c.state.logonDelay)
+	}
+	c.state.mu.Lock()
+	c.state.logonCreds = append(c.state.logonCreds, mc.AccountName)
+	c.state.mu.Unlock()
+	atomic.AddInt32(&c.state.inFlight, -1)
+	atomic.AddInt32(&c.perChanInFlight, -1)
+
+	return &LogonResult{Username: req.Username, DomainName: req.Domain}, nil
+}
+
+func (c *fakeChannel) recordHighWater(n int32) {
+	c.state.mu.Lock()
+	if n > c.state.maxInFlightPerChan {
+		c.state.maxInFlightPerChan = n
+	}
+	c.state.mu.Unlock()
+}
+
+func (c *fakeChannel) close(ctx context.Context) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.connected = false
+	c.closed = true
+}
+
+// withFakeChannels swaps newSecureChannel for a factory that builds fakeChannels
+// sharing st, and restores it on cleanup.
+func withFakeChannels(t *testing.T, st *fakeState) {
+	t.Helper()
+	orig := newSecureChannel
+	newSecureChannel = func() secureChannel {
+		st.mu.Lock()
+		st.nextID++
+		id := st.nextID
+		st.mu.Unlock()
+		return &fakeChannel{id: id, state: st}
+	}
+	t.Cleanup(func() { newSecureChannel = orig })
+}
+
+func validCred(account string) MachineCredential {
+	return MachineCredential{
+		AccountName: account,
+		Password:    "secret",
+		Workstation: "DITTOFS",
+		DomainName:  "DITTOFS",
+		Realm:       "DITTOFS.AD",
+	}
+}
+
+// TestReloadCredential_SwapsCredentialAndChannel proves a ReloadCredential makes
+// the next logon authenticate with the new credential and rebuild the channel.
+func TestReloadCredential_SwapsCredentialAndChannel(t *testing.T) {
+	st := &fakeState{}
+	withFakeChannels(t, st)
+
+	prov := NewMutableProvider(validCred("OLD$"))
+	a := NewAuthenticator(prov)
+	ctx := context.Background()
+
+	if _, err := a.NetworkLogon(ctx, NetworkLogonRequest{Username: "alice", Domain: "DITTOFS"}); err != nil {
+		t.Fatalf("first logon: %v", err)
+	}
+	a.ReloadCredential(ctx, validCred("NEW$"))
+	if _, err := a.NetworkLogon(ctx, NetworkLogonRequest{Username: "bob", Domain: "DITTOFS"}); err != nil {
+		t.Fatalf("post-reload logon: %v", err)
+	}
+
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if len(st.logonCreds) != 2 {
+		t.Fatalf("expected 2 logons, got %d (%v)", len(st.logonCreds), st.logonCreds)
+	}
+	if st.logonCreds[0] != "OLD$" || st.logonCreds[1] != "NEW$" {
+		t.Fatalf("expected logons [OLD$ NEW$], got %v", st.logonCreds)
+	}
+	if st.built < 2 {
+		t.Fatalf("expected the channel to be rebuilt (>=2 connects), got %d", st.built)
+	}
+}
+
+// TestReloadCredential_ConcurrentLogons hammers NetworkLogon from many
+// goroutines while repeatedly reloading the credential. It must not error, never
+// overlap a close with an in-flight logon (the channel lock enforces this), and
+// every logon must succeed. Run with -race to catch data races on the channel
+// pointer swap and credential swap.
+func TestReloadCredential_ConcurrentLogons(t *testing.T) {
+	st := &fakeState{logonDelay: 50 * time.Microsecond}
+	withFakeChannels(t, st)
+
+	prov := NewMutableProvider(validCred("GEN0$"))
+	a := NewAuthenticator(prov)
+	ctx := context.Background()
+
+	const workers = 16
+	const perWorker = 200
+
+	var logonWG sync.WaitGroup
+	var reloadWG sync.WaitGroup
+	var logonErrs int32
+
+	// Logon workers.
+	for w := 0; w < workers; w++ {
+		logonWG.Add(1)
+		go func() {
+			defer logonWG.Done()
+			for i := 0; i < perWorker; i++ {
+				if _, err := a.NetworkLogon(ctx, NetworkLogonRequest{Username: "u", Domain: "DITTOFS"}); err != nil {
+					atomic.AddInt32(&logonErrs, 1)
+				}
+			}
+		}()
+	}
+
+	// Reload workers: continuously swap the credential + rebuild the channel
+	// until the logon workers finish.
+	stop := make(chan struct{})
+	var reloads int32
+	for w := 0; w < 4; w++ {
+		reloadWG.Add(1)
+		go func(base int) {
+			defer reloadWG.Done()
+			gen := base
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					gen++
+					a.ReloadCredential(ctx, validCred("GEN"+itoa(gen)+"$"))
+					atomic.AddInt32(&reloads, 1)
+				}
+			}
+		}(w * 100000)
+	}
+
+	logonWG.Wait()
+	close(stop)
+	reloadWG.Wait()
+
+	if got := atomic.LoadInt32(&logonErrs); got != 0 {
+		t.Fatalf("expected zero logon errors under concurrent reload, got %d", got)
+	}
+	if got := completedLogons(st); got != workers*perWorker {
+		t.Fatalf("expected %d completed logons, got %d", workers*perWorker, got)
+	}
+	if st.maxInFlightPerChan == 0 {
+		t.Fatal("expected some in-flight logons to be recorded")
+	}
+	if atomic.LoadInt32(&st.concurrencyViolation) != 0 {
+		t.Fatal("a single secure channel served two logons concurrently: " +
+			"the per-channel lock invariant was broken (sequence chain could corrupt)")
+	}
+	t.Logf("completed %d logons across %d reloads; %d channels built",
+		completedLogons(st), atomic.LoadInt32(&reloads), builtCount(st))
+}
+
+func completedLogons(st *fakeState) int32 {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	return int32(len(st.logonCreds))
+}
+
+func builtCount(st *fakeState) int {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	return st.built
+}
+
+// itoa is a tiny dependency-free int-to-string for unique credential names.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/internal/auth/netlogon/reload_test.go
+++ b/internal/auth/netlogon/reload_test.go
@@ -2,6 +2,8 @@ package netlogon
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -47,18 +49,39 @@ type fakeState struct {
 	// logons at once — i.e. the per-channel lock invariant was broken.
 	concurrencyViolation int32
 	// dcRejectsRemaining, when > 0, makes that many samLogon calls return a
-	// DC-side rejection before succeeding, to exercise the bounded retry path.
+	// transient DC-side rejection before succeeding, to exercise the bounded
+	// retry path.
 	dcRejectsRemaining int32
+	// hardFailsRemaining, when > 0, makes that many samLogon calls return a hard
+	// (non-transient) authentication-failure status, to exercise the fast-fail
+	// (no-retry) path.
+	hardFailsRemaining int32
+	// transportFailsRemaining, when > 0, makes that many samLogon calls return a
+	// wrapped transport-level RPC error (the kind a concurrent reload induces by
+	// dropping the SMB session mid-RPC), to exercise that it is retried, not
+	// failed fast.
+	transportFailsRemaining int32
+	// samLogonCalls counts every samLogon invocation (including failures), so a
+	// test can assert NetworkLogon made exactly one call on a fast-fail.
+	samLogonCalls int32
 }
 
-// errDCRejected stands in for a transient DC-side SamLogon rejection (e.g.
-// STATUS_ACCESS_DENIED) that is NOT the local errChannelNotConnected sentinel,
-// so it drives the backoff-retry branch in NetworkLogon.
-var errDCRejected = &dcError{"netlogon: SAMLogon returned 0xc0000022"}
+// errDCRejected stands in for a TRANSIENT DC-side SamLogon rejection
+// (STATUS_ACCESS_DENIED) that a freshly rebuilt channel can return while its
+// credential chain settles. It is a typed SamLogonStatusError so NetworkLogon's
+// isTransientChannelError recognizes it and drives the backoff-retry branch.
+var errDCRejected = &SamLogonStatusError{Status: statusAccessDenied}
 
-type dcError struct{ s string }
+// errLogonFailure stands in for a domain user's HARD authentication failure
+// (NTSTATUS LOGON_FAILURE). It is a typed SamLogonStatusError that is NOT
+// transient, so NetworkLogon must fail fast without rebuilding/retrying.
+var errLogonFailure = &SamLogonStatusError{Status: 0xC000006D}
 
-func (e *dcError) Error() string { return e.s }
+// errTransportDrop stands in for a transport-level RPC failure (e.g. a broken
+// SMB pipe) the real samLogon returns wrapped with errChannelNotConnected when a
+// concurrent reload tears the session down mid-RPC. NetworkLogon must treat it as
+// transient (rebuild + retry), not fail fast.
+var errTransportDrop = fmt.Errorf("netlogon: SAMLogon: %w: %w", errChannelNotConnected, errors.New("connection reset by peer"))
 
 func (c *fakeChannel) connect(ctx context.Context, mc MachineCredential) error {
 	c.mu.Lock()
@@ -76,6 +99,7 @@ func (c *fakeChannel) connect(ctx context.Context, mc MachineCredential) error {
 func (c *fakeChannel) samLogon(ctx context.Context, mc MachineCredential, req NetworkLogonRequest) (*LogonResult, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	atomic.AddInt32(&c.state.samLogonCalls, 1)
 	if !c.connected || c.closed {
 		// Mirror SecureChannel.samLogon's torn-down path so the Authenticator's
 		// reload-race retry/rebuild logic is exercised. Uses the same sentinel the
@@ -83,8 +107,23 @@ func (c *fakeChannel) samLogon(ctx context.Context, mc MachineCredential, req Ne
 		return nil, errChannelNotConnected
 	}
 
-	// Optionally simulate a DC-side rejection (e.g. STATUS_ACCESS_DENIED while a
-	// freshly rebuilt channel's credential chain settles) for the first
+	// Optionally simulate a HARD (non-transient) authentication failure for the
+	// first hardFailsRemaining logons, to exercise the fast-fail path. Checked
+	// before the transient-rejection branch so a hard failure is never masked.
+	if atomic.AddInt32(&c.state.hardFailsRemaining, -1) >= 0 {
+		return nil, errLogonFailure
+	}
+
+	// Optionally simulate a transport-level RPC drop (SMB session torn down
+	// mid-RPC by a concurrent reload), wrapped with errChannelNotConnected, for the
+	// first transportFailsRemaining logons — to prove it is retried, not failed
+	// fast.
+	if atomic.AddInt32(&c.state.transportFailsRemaining, -1) >= 0 {
+		return nil, errTransportDrop
+	}
+
+	// Optionally simulate a transient DC-side rejection (STATUS_ACCESS_DENIED while
+	// a freshly rebuilt channel's credential chain settles) for the first
 	// dcRejectsRemaining logons, to exercise the bounded backoff-retry path.
 	if atomic.AddInt32(&c.state.dcRejectsRemaining, -1) >= 0 {
 		return nil, errDCRejected
@@ -238,6 +277,55 @@ func TestNetworkLogon_GivesUpAfterBoundedRetries(t *testing.T) {
 	a := NewAuthenticator(NewMutableProvider(validCred("DITTOFS$")))
 	if _, err := a.NetworkLogon(context.Background(), NetworkLogonRequest{Username: "alice", Domain: "DITTOFS"}); err == nil {
 		t.Fatal("expected a persistent DC rejection to surface as an error after bounded retries")
+	}
+}
+
+// TestNetworkLogon_HardAuthFailureFailsFast proves a domain user's HARD
+// authentication failure (NTSTATUS LOGON_FAILURE) is NOT retried: NetworkLogon
+// returns immediately after exactly ONE samLogon call, with no channel rebuild.
+// Retrying a bad-password attempt would amplify failed logons toward AD account
+// lockout (#1369 Copilot finding #1), so the fast-fail is load-bearing.
+func TestNetworkLogon_HardAuthFailureFailsFast(t *testing.T) {
+	st := &fakeState{hardFailsRemaining: 1 << 30} // every logon is a hard failure
+	withFakeChannels(t, st)
+
+	a := NewAuthenticator(NewMutableProvider(validCred("DITTOFS$")))
+	_, err := a.NetworkLogon(context.Background(), NetworkLogonRequest{Username: "alice", Domain: "DITTOFS"})
+	if err == nil {
+		t.Fatal("expected a hard auth failure to surface as an error")
+	}
+	// It must surface the underlying typed status, unwrapped.
+	var st2 *SamLogonStatusError
+	if !errors.As(err, &st2) || st2.Status != 0xC000006D {
+		t.Fatalf("expected SamLogonStatusError(0xC000006D), got %T: %v", err, err)
+	}
+	// Exactly ONE samLogon call: no rebuild/retry. If the retry loop fired, this
+	// would be > 1 (and in production would push the user toward lockout).
+	if got := atomic.LoadInt32(&st.samLogonCalls); got != 1 {
+		t.Fatalf("expected exactly 1 samLogon call (no retry on hard auth failure), got %d", got)
+	}
+	// And no channel was ever rebuilt.
+	if got := builtCount(st); got != 1 {
+		t.Fatalf("expected exactly 1 channel build (no rebuild on hard auth failure), got %d", got)
+	}
+}
+
+// TestNetworkLogon_RetriesTransportDrop proves a transport-level RPC failure
+// (the SMB session dropped mid-RPC by a concurrent reload, surfaced wrapped with
+// errChannelNotConnected) is treated as transient and retried to success — NOT
+// failed fast like a credential rejection. This guards the regression where
+// narrowing the retry set to typed statuses inadvertently dropped transport
+// errors out of the transient set (#1369 review follow-up).
+func TestNetworkLogon_RetriesTransportDrop(t *testing.T) {
+	st := &fakeState{transportFailsRemaining: 2} // first 2 logons hit a transport drop, then succeed
+	withFakeChannels(t, st)
+
+	a := NewAuthenticator(NewMutableProvider(validCred("DITTOFS$")))
+	if _, err := a.NetworkLogon(context.Background(), NetworkLogonRequest{Username: "alice", Domain: "DITTOFS"}); err != nil {
+		t.Fatalf("expected a transport drop to be retried to success, got: %v", err)
+	}
+	if got := completedLogons(st); got != 1 {
+		t.Fatalf("expected exactly 1 successful logon, got %d", got)
 	}
 }
 

--- a/internal/auth/netlogon/reload_test.go
+++ b/internal/auth/netlogon/reload_test.go
@@ -162,6 +162,36 @@ func TestReloadCredential_SwapsCredentialAndChannel(t *testing.T) {
 	}
 }
 
+// TestReloadCredential_EmptyCredentialDisablesPassthrough proves that reloading
+// with an empty credential (the disable path) makes the next logon fail closed:
+// the MutableProvider rejects the incomplete credential, so no channel is built
+// and passthrough is genuinely off — not silently still authenticating with the
+// previous credential (#1325 review H1).
+func TestReloadCredential_EmptyCredentialDisablesPassthrough(t *testing.T) {
+	st := &fakeState{}
+	withFakeChannels(t, st)
+
+	prov := NewMutableProvider(validCred("DITTOFS$"))
+	a := NewAuthenticator(prov)
+	ctx := context.Background()
+
+	if _, err := a.NetworkLogon(ctx, NetworkLogonRequest{Username: "alice", Domain: "DITTOFS"}); err != nil {
+		t.Fatalf("pre-disable logon should succeed: %v", err)
+	}
+
+	// Disable: install an empty credential (what the adapter does when the runtime
+	// credential is nil).
+	a.ReloadCredential(ctx, MachineCredential{})
+
+	if _, err := a.NetworkLogon(ctx, NetworkLogonRequest{Username: "alice", Domain: "DITTOFS"}); err == nil {
+		t.Fatal("post-disable logon must fail closed (passthrough disabled), but it succeeded")
+	}
+	// No second channel must have been built for the disabled logon.
+	if got := completedLogons(st); got != 1 {
+		t.Fatalf("expected exactly 1 successful logon before disable, got %d", got)
+	}
+}
+
 // TestReloadCredential_ConcurrentLogons hammers NetworkLogon from many
 // goroutines while repeatedly reloading the credential. It must not error, never
 // overlap a close with an in-flight logon (the channel lock enforces this), and

--- a/internal/auth/netlogon/reload_test.go
+++ b/internal/auth/netlogon/reload_test.go
@@ -46,7 +46,19 @@ type fakeState struct {
 	// concurrencyViolation is set to 1 if any single channel ever served two
 	// logons at once — i.e. the per-channel lock invariant was broken.
 	concurrencyViolation int32
+	// dcRejectsRemaining, when > 0, makes that many samLogon calls return a
+	// DC-side rejection before succeeding, to exercise the bounded retry path.
+	dcRejectsRemaining int32
 }
+
+// errDCRejected stands in for a transient DC-side SamLogon rejection (e.g.
+// STATUS_ACCESS_DENIED) that is NOT the local errChannelNotConnected sentinel,
+// so it drives the backoff-retry branch in NetworkLogon.
+var errDCRejected = &dcError{"netlogon: SAMLogon returned 0xc0000022"}
+
+type dcError struct{ s string }
+
+func (e *dcError) Error() string { return e.s }
 
 func (c *fakeChannel) connect(ctx context.Context, mc MachineCredential) error {
 	c.mu.Lock()
@@ -69,6 +81,13 @@ func (c *fakeChannel) samLogon(ctx context.Context, mc MachineCredential, req Ne
 		// reload-race retry/rebuild logic is exercised. Uses the same sentinel the
 		// real channel returns so NetworkLogon treats it as a benign reload race.
 		return nil, errChannelNotConnected
+	}
+
+	// Optionally simulate a DC-side rejection (e.g. STATUS_ACCESS_DENIED while a
+	// freshly rebuilt channel's credential chain settles) for the first
+	// dcRejectsRemaining logons, to exercise the bounded backoff-retry path.
+	if atomic.AddInt32(&c.state.dcRejectsRemaining, -1) >= 0 {
+		return nil, errDCRejected
 	}
 
 	// Per-channel concurrency must never exceed 1: the channel lock serializes
@@ -189,6 +208,36 @@ func TestReloadCredential_EmptyCredentialDisablesPassthrough(t *testing.T) {
 	// No second channel must have been built for the disabled logon.
 	if got := completedLogons(st); got != 1 {
 		t.Fatalf("expected exactly 1 successful logon before disable, got %d", got)
+	}
+}
+
+// TestNetworkLogon_RetriesTransientDCRejection proves a transient DC-side
+// rejection right after a channel rebuild (the kind a concurrent reload can
+// induce while the new MS-NRPC credential chain settles) is absorbed by the
+// bounded backoff-retry rather than surfaced to the caller (#1325 review).
+func TestNetworkLogon_RetriesTransientDCRejection(t *testing.T) {
+	st := &fakeState{dcRejectsRemaining: 2} // first 2 logons rejected, then succeed
+	withFakeChannels(t, st)
+
+	a := NewAuthenticator(NewMutableProvider(validCred("DITTOFS$")))
+	if _, err := a.NetworkLogon(context.Background(), NetworkLogonRequest{Username: "alice", Domain: "DITTOFS"}); err != nil {
+		t.Fatalf("expected transient DC rejection to be retried to success, got: %v", err)
+	}
+	if got := completedLogons(st); got != 1 {
+		t.Fatalf("expected exactly 1 successful logon, got %d", got)
+	}
+}
+
+// TestNetworkLogon_GivesUpAfterBoundedRetries proves the retry is bounded: a
+// persistent DC rejection eventually returns the error instead of looping
+// forever.
+func TestNetworkLogon_GivesUpAfterBoundedRetries(t *testing.T) {
+	st := &fakeState{dcRejectsRemaining: 1 << 30} // always reject
+	withFakeChannels(t, st)
+
+	a := NewAuthenticator(NewMutableProvider(validCred("DITTOFS$")))
+	if _, err := a.NetworkLogon(context.Background(), NetworkLogonRequest{Username: "alice", Domain: "DITTOFS"}); err == nil {
+		t.Fatal("expected a persistent DC rejection to surface as an error after bounded retries")
 	}
 }
 

--- a/internal/auth/netlogon/securechannel.go
+++ b/internal/auth/netlogon/securechannel.go
@@ -19,38 +19,32 @@ import (
 	"github.com/oiweiwei/go-msrpc/ssp/krb5"
 )
 
-// gssapiRegister guards the one-time, process-global registration of the
-// machine credential and SSP mechanisms in go-msrpc's gssapi stores.
-// go-msrpc's gssapi.AddMechanism PANICS ("mechanism ... already exist") if a
-// mechanism is registered twice, so this must run exactly once even across
-// reconnects/resets.
-var gssapiRegister sync.Once
+// gssapiMechRegister guards the one-time, process-global registration of the
+// SSP mechanisms in go-msrpc's gssapi mechanism store. go-msrpc's
+// gssapi.AddMechanism PANICS ("mechanism ... already exist") if a mechanism is
+// registered twice, so this must run exactly once even across reconnects/resets.
+//
+// The machine CREDENTIAL is deliberately NOT registered here: it is passed
+// per-connection via gssapi.WithCredential when building the security context in
+// connect (see below). Registering it in a sync.Once would freeze the FIRST
+// credential for the life of the process, so a machine-password rotation
+// (#1325) would never reach go-msrpc and rebuilt channels would keep
+// authenticating with the stale password.
+var gssapiMechRegister sync.Once
 
-// registerGSSAPI registers the machine credential and the SPNEGO/NTLM/Netlogon
-// mechanisms with go-msrpc exactly once. The initial GetDCName/ReqChallenge
+// registerGSSAPIMechanisms registers the SPNEGO/NTLM/KRB5/Netlogon mechanisms
+// with go-msrpc exactly once (process-global). The initial GetDCName/ReqChallenge
 // bind inside NewSecureChannelClient authenticates the machine account via
 // NTLM/SPNEGO (the netlogon schannel config does not exist yet at that point);
 // the Netlogon mechanism is used only for the sealed secure channel afterward.
-// registerGSSAPI is process-global and runs exactly once (sync.Once): it
-// captures the FIRST machine credential's account/password/workstation/realm.
-// DittoFS uses a single machine account (one realm) per process, so the locked
-// credential always matches the realm passed to buildKRB5Config on later calls;
-// a second, different realm in the same process is unsupported by design.
-func registerGSSAPI(mc MachineCredential) {
-	gssapiRegister.Do(func() {
-		// Domain must be set: the schannel NL_AUTH_MESSAGE carries it (Samba
-		// rejects a schannel bind "without domain"), and the Kerberos SMB session
-		// uses it as the machine principal's realm. The realm (DNS form) satisfies
-		// both — go-msrpc sends it as the NL_AUTH DNSDomainName (#1345).
-		gssapi.AddCredential(credential.NewFromPassword(
-			mc.AccountName, mc.Password,
-			credential.Workstation(mc.Workstation),
-			credential.Domain(mc.Realm)))
+// KRB5 authenticates the NETLOGON named-pipe SMB session: Samba rejects a
+// machine-account NTLM SMB logon, so the schannel must ride a Kerberos SMB
+// session over ncacn_np (#1345). It registers mechanisms ONLY — the machine
+// credential is supplied per-connection in connect so it can be hot-reloaded.
+func registerGSSAPIMechanisms() {
+	gssapiMechRegister.Do(func() {
 		gssapi.AddMechanism(ssp.SPNEGO)
 		gssapi.AddMechanism(ssp.NTLM)
-		// KRB5 authenticates the NETLOGON named-pipe SMB session: Samba rejects a
-		// machine-account NTLM SMB logon, so the schannel must ride a Kerberos
-		// SMB session over ncacn_np (#1345).
 		gssapi.AddMechanism(ssp.KRB5)
 		gssapi.AddMechanism(ssp.Netlogon)
 	})
@@ -126,12 +120,11 @@ func (sc *SecureChannel) connect(ctx context.Context, mc MachineCredential) erro
 		return fmt.Errorf("netlogon: %w", err)
 	}
 
-	// Register the machine credential and the SPNEGO/NTLM/KRB5/Netlogon mechanisms
-	// (once, process-global) BEFORE creating the security context, which captures
-	// the registered credential and mechanisms. NewSecureChannelClient then runs
-	// the full challenge handshake internally — so we must NOT pre-seed a
+	// Register the SPNEGO/NTLM/KRB5/Netlogon mechanisms (once, process-global)
+	// BEFORE creating the security context. NewSecureChannelClient then runs the
+	// full challenge handshake internally — so we must NOT pre-seed a
 	// netlogon.Config.
-	registerGSSAPI(mc)
+	registerGSSAPIMechanisms()
 
 	// Inline krb5 config (realm -> KDC = the DC) so the machine account can get a
 	// TGT + cifs/ service ticket without depending on a host krb5.conf file.
@@ -139,7 +132,36 @@ func (sc *SecureChannel) connect(ctx context.Context, mc MachineCredential) erro
 	if err != nil {
 		return err
 	}
+
 	gctx := gssapi.NewSecurityContext(ctx, ssp.WithKRB5(krb5Cfg))
+
+	// Build the machine credential PER-CONNECTION and supply it via
+	// dcerpc.WithCredentials (NOT a process-global gssapi.AddCredential under a
+	// sync.Once). This is what makes machine-password rotation (#1325) take
+	// effect: a channel rebuilt after a ReloadCredential authenticates with the
+	// CURRENT mc, not a credential frozen at process start.
+	//
+	// The credential must reach BOTH security contexts of this connection:
+	//   - the Kerberos SMB session (the schannel rides \PIPE\netlogon over SMB,
+	//     and Samba refuses a machine-account NTLM SMB logon), via the explicit
+	//     SMB dialer's WithSecurity, and
+	//   - the NETLOGON sealed-schannel context that NewSecureChannelClient reads
+	//     from cli.Conn().Context() to run ServerAuthenticate, via
+	//     dcerpc.WithCredentials on the Dial (it lands in the connection's
+	//     security context, which cli.Conn().Context() returns).
+	// Supplying it on the dial gctx via gssapi.WithCredential is NOT sufficient:
+	// dcerpc rebuilds the connection's security context, dropping the dial ctx's
+	// context-local credential store, so the schannel falls back to the (empty)
+	// global store and ServerAuthenticate fails with "defective credential".
+	//
+	// Domain must be set: the schannel NL_AUTH_MESSAGE carries it (Samba rejects a
+	// schannel bind "without domain"), and the Kerberos SMB session uses it as the
+	// machine principal's realm. The realm (DNS form) satisfies both — go-msrpc
+	// sends it as the NL_AUTH DNSDomainName (#1345).
+	machineCred := credential.NewFromPassword(
+		mc.AccountName, mc.Password,
+		credential.Workstation(mc.Workstation),
+		credential.Domain(mc.Realm))
 
 	// Samba rejects the sealed-schannel AlterContext over ncacn_ip_tcp with
 	// RPC_S_UNKNOWN_AUTHN_SERVICE (0x721); the named-pipe transport (\PIPE\NETLOGON
@@ -147,16 +169,28 @@ func (sc *SecureChannel) connect(ctx context.Context, mc MachineCredential) erro
 	// the machine account with Kerberos (Samba refuses machine-account NTLM over
 	// SMB), targeting the DC's cifs/ SPN. Bind the netlogon pipe directly
 	// (ncacn_np:[netlogon]) rather than via the endpoint mapper (#1345).
-	dialer := smb2.NewDialer(smb2.WithSecurity(gssapi.WithTargetName(spn)))
+	dialer := smb2.NewDialer(smb2.WithSecurity(
+		gssapi.WithTargetName(spn),
+		gssapi.WithCredential(machineCred),
+	))
 	cc, err := dcerpc.Dial(gctx, server,
 		dcerpc.WithEndpoint("ncacn_np:[netlogon]"),
 		dcerpc.WithSMBDialer(dialer),
+		dcerpc.WithCredentials(machineCred),
 	)
 	if err != nil {
 		return fmt.Errorf("netlogon: dial %s: %w", server, err)
 	}
 
-	cli, err := logon.NewSecureChannelClient(gctx, cc, dcerpc.WithSeal())
+	// Pass the machine credential to NewSecureChannelClient too, not just Dial:
+	// it forwards these opts into the sealed-schannel AlterContext, whose NETLOGON
+	// mechanism resolves the credential from the AlterContext's own security
+	// context (a fresh one built from these opts). Without it, AlterContext falls
+	// back to the empty process-global store and fails with "defective credential".
+	cli, err := logon.NewSecureChannelClient(gctx, cc,
+		dcerpc.WithSeal(),
+		dcerpc.WithCredentials(machineCred),
+	)
 	if err != nil {
 		_ = cc.Close(gctx)
 		return fmt.Errorf("netlogon: secure channel client: %w", err)
@@ -243,11 +277,19 @@ func (sc *SecureChannel) samLogon(ctx context.Context, mc MachineCredential, req
 		ValidationLevel: logon.ValidationInfoClassSAMInfo4,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("netlogon: SAMLogon: %w", err)
+		// A transport-level RPC failure (not a DC-returned NTSTATUS) is a transient
+		// channel condition, not a logon failure: a concurrent Reload can tear the
+		// sealed SMB session down AFTER this call passed the sc.cli == nil guard but
+		// while cli.SAMLogon is on the wire, yielding a broken-pipe/EOF rather than
+		// the errChannelNotConnected sentinel. Wrap with errChannelNotConnected so
+		// NetworkLogon rebuilds + retries (errors.Is sees the sentinel) instead of
+		// failing the logon that a rebuild would have cleared. Unlike a credential
+		// validation failure this can never amplify toward AD account lockout.
+		return nil, fmt.Errorf("netlogon: SAMLogon: %w: %w", errChannelNotConnected, err)
 	}
 
 	if out.Return != 0 {
-		return nil, fmt.Errorf("netlogon: SAMLogon returned 0x%08x", uint32(out.Return))
+		return nil, &SamLogonStatusError{Status: uint32(out.Return)}
 	}
 
 	// Extract ValidationSAMInfo4 from the union.

--- a/internal/auth/netlogon/securechannel.go
+++ b/internal/auth/netlogon/securechannel.go
@@ -106,9 +106,14 @@ type SecureChannel struct {
 	dcName string // UNC DC computer name (e.g. \\DC01); populated by connect() via GetDCName
 }
 
-// connect establishes the NETLOGON schannel connection to the given DC.
-// Must be called with sc.mu held.
+// connect establishes the NETLOGON schannel connection to the given DC. It is
+// self-locking (takes sc.mu) and idempotent: a no-op when already connected. The
+// lock is held for the full handshake so a concurrent close cannot tear the
+// connection down mid-build.
 func (sc *SecureChannel) connect(ctx context.Context, mc MachineCredential) error {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
 	if sc.cli != nil {
 		return nil
 	}
@@ -178,8 +183,13 @@ func (sc *SecureChannel) connect(ctx context.Context, mc MachineCredential) erro
 	return nil
 }
 
-// close tears down the cached connection.  Must be called with sc.mu held.
+// close tears down the cached connection. It is self-locking (takes sc.mu) and
+// idempotent, so it blocks until any in-flight samLogon on this channel returns
+// before closing the connection — a teardown never races an in-flight RPC.
 func (sc *SecureChannel) close(ctx context.Context) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
 	if sc.cc != nil {
 		_ = sc.cc.Close(ctx)
 		sc.cc = nil
@@ -189,15 +199,17 @@ func (sc *SecureChannel) close(ctx context.Context) {
 }
 
 // samLogon performs a NetrLogonSamLogon RPC call using the established channel.
-// sc.mu is held for the full duration of the RPC so that concurrent NetworkLogon
-// calls are serialized and close/reset cannot race an in-flight SAMLogon.
-// Callers (ensureChannel/connect) must not hold sc.mu when calling samLogon.
+// It is self-locking: sc.mu is held for the full duration of the RPC so that
+// concurrent NetworkLogon calls are serialized (preserving the chained MS-NRPC
+// sequence number) and a close cannot race an in-flight SAMLogon. It returns a
+// "channel not connected" error if the channel was torn down (e.g. by a
+// concurrent Reload) before this call acquired the lock; the caller rebuilds.
 func (sc *SecureChannel) samLogon(ctx context.Context, mc MachineCredential, req NetworkLogonRequest) (*LogonResult, error) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 
 	if sc.cli == nil {
-		return nil, fmt.Errorf("netlogon: channel not connected")
+		return nil, errChannelNotConnected
 	}
 
 	cli := sc.cli

--- a/internal/controlplane/api/handlers/identity_providers.go
+++ b/internal/controlplane/api/handlers/identity_providers.go
@@ -12,6 +12,7 @@ import (
 	krb5config "github.com/jcmturner/gokrb5/v8/config"
 	"github.com/jcmturner/gokrb5/v8/keytab"
 
+	"github.com/marmos91/dittofs/internal/auth/netlogon"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
@@ -370,10 +371,36 @@ func (h *IdentityProviderHandler) putKerberos(w http.ResponseWriter, r *http.Req
 		InternalServerError(w, "Failed to persist Kerberos config")
 		return
 	}
-	// No hot-reload: Kerberos is bound by the adapters at startup. Surface that
-	// the change takes effect on the next restart via a header note.
+
+	// Hot-reload the NETLOGON machine credential / DC binding without a restart
+	// (#1325): update the runtime credential and notify, so the SMB adapter tears
+	// down and rebuilds its secure channel atomically on the next logon. The
+	// Kerberos SPNEGO bits (keytab/service principal) are still bound by the
+	// adapters at startup, so the change is only partially live.
+	if h.runtime != nil {
+		h.runtime.SetNetlogonCredential(netlogonCredentialFromKerberosDTO(&dto))
+		h.runtime.NotifyIdentityProviderConfigChange()
+	}
+
+	// The SPNEGO keytab/service-principal still require a restart; surface that.
 	w.Header().Set("X-DittoFS-Apply", "restart-required")
 	WriteJSONOK(w, redactKerberosDTO(dto))
+}
+
+// netlogonCredentialFromKerberosDTO derives the NETLOGON machine credential from
+// the Kerberos config DTO, or nil when the machine-account sub-block is disabled
+// or incomplete (so passthrough is disabled). Mirrors the startup validation in
+// cmd/dfs (netlogonCredentialFromConfig) without importing pkg/config, which
+// would create an import cycle.
+func netlogonCredentialFromKerberosDTO(dto *KerberosConfigDTO) *netlogon.MachineCredential {
+	ma := dto.MachineAccount
+	// Secret-only credential: a keytab-based machine account is not yet supported
+	// for NETLOGON, matching cmd/dfs.
+	if !ma.Enabled || ma.AccountName == "" || ma.Secret == "" || dto.NetBIOSDomain == "" || dto.Realm == "" {
+		return nil
+	}
+	cred := netlogon.BuildMachineCredential(ma.AccountName, ma.Secret, dto.NetBIOSDomain, dto.Realm, ma.DCAddresses)
+	return &cred
 }
 
 // existingKerberosSecret returns the currently stored machine-account secret,

--- a/internal/controlplane/api/handlers/identity_providers_test.go
+++ b/internal/controlplane/api/handlers/identity_providers_test.go
@@ -302,6 +302,50 @@ func TestIDP_PutKerberos_PreservesSecretOnEmptySecret(t *testing.T) {
 	}
 }
 
+// TestNetlogonCredentialFromKerberosDTO verifies the DTO→MachineCredential
+// derivation that drives the NETLOGON hot-reload (#1325): a complete enabled
+// machine-account block yields a credential; any disabled/incomplete/keytab-only
+// block yields nil (passthrough disabled).
+func TestNetlogonCredentialFromKerberosDTO(t *testing.T) {
+	complete := func(mut func(*KerberosConfigDTO)) *KerberosConfigDTO {
+		dto := &KerberosConfigDTO{
+			Realm:         "EXAMPLE.COM",
+			NetBIOSDomain: "EXAMPLE",
+			MachineAccount: KerberosMachineAccountDTO{
+				Enabled:     true,
+				AccountName: "DITTOFS$",
+				Secret:      "topsecret",
+				DCAddresses: []string{"dc.example.com"},
+			},
+		}
+		if mut != nil {
+			mut(dto)
+		}
+		return dto
+	}
+
+	if got := netlogonCredentialFromKerberosDTO(complete(nil)); got == nil {
+		t.Fatal("complete enabled machine account should yield a credential")
+	} else if got.AccountName != "DITTOFS$" || got.Workstation != "DITTOFS" ||
+		got.DomainName != "EXAMPLE" || got.Realm != "EXAMPLE.COM" {
+		t.Fatalf("unexpected derived credential: %+v", got)
+	}
+
+	cases := map[string]func(*KerberosConfigDTO){
+		"disabled":       func(d *KerberosConfigDTO) { d.MachineAccount.Enabled = false },
+		"no account":     func(d *KerberosConfigDTO) { d.MachineAccount.AccountName = "" },
+		"no secret":      func(d *KerberosConfigDTO) { d.MachineAccount.Secret = "" },
+		"no realm":       func(d *KerberosConfigDTO) { d.Realm = "" },
+		"no netbios":     func(d *KerberosConfigDTO) { d.NetBIOSDomain = "" },
+		"keytab no pass": func(d *KerberosConfigDTO) { d.MachineAccount.Secret = ""; d.MachineAccount.KeytabPath = "/k" },
+	}
+	for name, mut := range cases {
+		if got := netlogonCredentialFromKerberosDTO(complete(mut)); got != nil {
+			t.Errorf("%s: expected nil credential, got %+v", name, got)
+		}
+	}
+}
+
 func TestIDP_TestLDAP_DoesNotPersist(t *testing.T) {
 	st := newFakeIDPStore()
 	h := NewIdentityProviderHandler(st, nil)

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -622,20 +622,31 @@ func (s *Adapter) wireNetlogonReload(rt *runtime.Runtime) {
 	}
 	auth := s.netlogonAuth
 	s.netlogonProviderUnsub = rt.OnIdentityProviderConfigChange(func() {
+		// Bound the teardown so a hung DC connection during close() cannot block
+		// the synchronous NotifyIdentityProviderConfigChange caller (the HTTP
+		// handler goroutine in putKerberos) indefinitely.
+		ctx, cancel := context.WithTimeout(context.Background(), netlogonReloadTimeout)
+		defer cancel()
+
 		cred := rt.NetlogonCredential()
 		if cred == nil {
-			// Passthrough disabled / no credential: drop the cached channel so a
-			// stale one is not reused. The next logon then fails credential
-			// validation, matching the disabled posture.
-			auth.Reload(context.Background())
-			logger.Info("SMB adapter: NETLOGON credential cleared; secure channel torn down")
+			// Passthrough disabled / no credential: install an empty credential so
+			// the next logon FAILS credential validation (a bare Reload would leave
+			// the MutableProvider holding the previous valid credential and keep
+			// authenticating against the DC — the disable would not take effect).
+			auth.ReloadCredential(ctx, netlogon.MachineCredential{})
+			logger.Info("SMB adapter: NETLOGON credential cleared; passthrough disabled and secure channel torn down")
 			return
 		}
-		auth.ReloadCredential(context.Background(), *cred)
+		auth.ReloadCredential(ctx, *cred)
 		logger.Info("SMB adapter: NETLOGON machine credential hot-reloaded; secure channel will rebuild on next logon",
 			"account", cred.AccountName, "domain", cred.DomainName, "realm", cred.Realm)
 	})
 }
+
+// netlogonReloadTimeout bounds a hot-reload secure-channel teardown so a hung DC
+// connection cannot block the API request that triggered the reload.
+const netlogonReloadTimeout = 10 * time.Second
 
 // SetADDomain makes the SMB handler domain-aware without requiring a Kerberos
 // SPNEGO provider. SetKerberosProvider already populates these names, but it is
@@ -832,14 +843,22 @@ func (s *Adapter) Stop(ctx context.Context) error {
 		s.foreignSIDProviderUnsub()
 		s.foreignSIDProviderUnsub = nil
 	}
-	if s.netlogonProviderUnsub != nil {
-		s.netlogonProviderUnsub()
-		s.netlogonProviderUnsub = nil
+	// The netlogon hot-reload subscription and authenticator are written by
+	// wireNetlogonReload under resolverMu (callable from SetRuntime /
+	// SetNetlogonAuthenticator on other goroutines), so snapshot + detach them
+	// under the same lock to avoid a data race, then close outside the lock.
+	s.resolverMu.Lock()
+	netlogonUnsub := s.netlogonProviderUnsub
+	s.netlogonProviderUnsub = nil
+	netlogonAuth := s.netlogonAuth
+	s.resolverMu.Unlock()
+	if netlogonUnsub != nil {
+		netlogonUnsub()
 	}
 	// Tear down the NETLOGON secure channel so its DC connection / goroutines do
 	// not outlive the adapter.
-	if s.netlogonAuth != nil {
-		s.netlogonAuth.Close(ctx)
+	if netlogonAuth != nil {
+		netlogonAuth.Close(ctx)
 	}
 
 	// Unsubscribe from share change notifications to prevent stale callbacks

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -103,6 +103,18 @@ type Adapter struct {
 	// LDAP config change re-wires the resolver without a restart.
 	foreignSIDProviderUnsub func()
 
+	// netlogonAuth is the concrete NETLOGON authenticator (retained so the
+	// hot-reload callback can call ReloadCredential). nil when NETLOGON
+	// pass-through is not configured.
+	netlogonAuth *netlogon.Authenticator
+
+	// netlogonProviderUnsub is the unsubscribe function for the
+	// OnIdentityProviderConfigChange subscription that hot-reloads the NETLOGON
+	// machine credential / DC binding. Registered once (guarded by nil) so an
+	// API-driven machine-account config change rebuilds the secure channel
+	// without a restart (#1325).
+	netlogonProviderUnsub func()
+
 	// kerberosProvider is retained for lifecycle management. It owns a
 	// background keytab-reload goroutine that must be stopped in Stop().
 	kerberosProvider *kerberos.Provider
@@ -316,6 +328,11 @@ func (s *Adapter) SetRuntime(rtAny any) {
 	// Wire centralized identity resolver for Kerberos principal → DittoFS user mapping.
 	// Uses DB-backed LinkStore + convention fallback, shared with the NFS adapter.
 	s.wireIdentityResolver(rt)
+
+	// Subscribe the NETLOGON machine-credential hot-reload so an API-driven
+	// machine-account config change rebuilds the secure channel without a
+	// restart (#1325). A no-op when NETLOGON pass-through is not configured.
+	s.wireNetlogonReload(rt)
 
 	logger.Debug("SMB adapter configured with runtime", "shares", rt.CountShares())
 
@@ -567,10 +584,14 @@ func (s *Adapter) SetKerberosProvider(provider *kerberos.Provider) {
 // When set, NTLM authentication is validated against the domain controller via the
 // NETLOGON secure channel rather than local credential verification. Must be called
 // before Serve(). A nil value is a no-op (local-only NTLM remains the fallback).
-func (s *Adapter) SetNetlogonAuthenticator(nlAuth netlogon.NetlogonAuthenticator) {
+//
+// The concrete authenticator is retained so an API-driven machine-account config
+// change can hot-reload its credential / DC binding without a restart (#1325).
+func (s *Adapter) SetNetlogonAuthenticator(nlAuth *netlogon.Authenticator) {
 	if nlAuth == nil {
 		return
 	}
+	s.netlogonAuth = nlAuth
 	s.handler.NetlogonAuth = nlAuth
 	// Enable the idmap_rid fallback so a DC-validated domain user with no LDAP/
 	// local mapping still resolves to a stable POSIX identity (UID == SID RID)
@@ -578,6 +599,42 @@ func (s *Adapter) SetNetlogonAuthenticator(nlAuth netlogon.NetlogonAuthenticator
 	// takes precedence; this only fires when nothing else resolves the SID.
 	s.handler.NetlogonIdmapRID = true
 	logger.Debug("SMB adapter: NETLOGON authenticator configured")
+
+	// If the runtime is already injected, subscribe the hot-reload now (SetRuntime
+	// may run before SetNetlogonAuthenticator depending on init order). Idempotent:
+	// wireNetlogonReload guards the subscription by nil.
+	s.wireNetlogonReload(s.Registry)
+}
+
+// wireNetlogonReload subscribes a one-shot OnIdentityProviderConfigChange
+// callback that hot-reloads the NETLOGON machine credential / DC binding (#1325).
+// On a config change it reads the latest credential from the runtime and calls
+// Authenticator.ReloadCredential, which swaps the credential and tears down the
+// cached secure channel atomically so the next logon rebuilds it. A no-op when
+// the runtime or the authenticator is not yet available; safe to call from both
+// SetRuntime and SetNetlogonAuthenticator (whichever runs second registers).
+func (s *Adapter) wireNetlogonReload(rt *runtime.Runtime) {
+	s.resolverMu.Lock()
+	defer s.resolverMu.Unlock()
+
+	if rt == nil || s.netlogonAuth == nil || s.netlogonProviderUnsub != nil {
+		return
+	}
+	auth := s.netlogonAuth
+	s.netlogonProviderUnsub = rt.OnIdentityProviderConfigChange(func() {
+		cred := rt.NetlogonCredential()
+		if cred == nil {
+			// Passthrough disabled / no credential: drop the cached channel so a
+			// stale one is not reused. The next logon then fails credential
+			// validation, matching the disabled posture.
+			auth.Reload(context.Background())
+			logger.Info("SMB adapter: NETLOGON credential cleared; secure channel torn down")
+			return
+		}
+		auth.ReloadCredential(context.Background(), *cred)
+		logger.Info("SMB adapter: NETLOGON machine credential hot-reloaded; secure channel will rebuild on next logon",
+			"account", cred.AccountName, "domain", cred.DomainName, "realm", cred.Realm)
+	})
 }
 
 // SetADDomain makes the SMB handler domain-aware without requiring a Kerberos
@@ -774,6 +831,15 @@ func (s *Adapter) Stop(ctx context.Context) error {
 	if s.foreignSIDProviderUnsub != nil {
 		s.foreignSIDProviderUnsub()
 		s.foreignSIDProviderUnsub = nil
+	}
+	if s.netlogonProviderUnsub != nil {
+		s.netlogonProviderUnsub()
+		s.netlogonProviderUnsub = nil
+	}
+	// Tear down the NETLOGON secure channel so its DC connection / goroutines do
+	// not outlive the adapter.
+	if s.netlogonAuth != nil {
+		s.netlogonAuth.Close(ctx)
 	}
 
 	// Unsubscribe from share change notifications to prevent stale callbacks

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/marmos91/dittofs/internal/auth/netlogon"
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/auth/sid"
 	"github.com/marmos91/dittofs/pkg/block"
@@ -150,6 +151,14 @@ type Runtime struct {
 	// startup from the server config. When present and Enabled, BuildIdentityResolver
 	// registers an LDAP provider in the identity resolution chain. Guarded by mu.
 	ldapConfig *ldap.Config
+
+	// netlogonCredential is the optional NETLOGON machine credential / DC binding
+	// used for SMB NTLM pass-through. Set at startup from the Kerberos
+	// machine-account config and updated by the identity-provider API; nil when
+	// passthrough is disabled. The SMB adapter reads it from its
+	// OnIdentityProviderConfigChange callback to hot-reload the secure channel
+	// without a restart (#1325). Guarded by mu.
+	netlogonCredential *netlogon.MachineCredential
 
 	// statusCheckers is the lazy per-entity cached health-checker
 	// map backing [Runtime.BlockStoreChecker],
@@ -889,6 +898,26 @@ func (r *Runtime) LDAPConfig() *ldap.Config {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.ldapConfig
+}
+
+// SetNetlogonCredential sets the NETLOGON machine credential / DC binding used
+// for SMB NTLM pass-through. A nil value disables passthrough. It is set at
+// startup from the Kerberos machine-account config and updated by the
+// identity-provider API; the SMB adapter reads it on an
+// OnIdentityProviderConfigChange notification to hot-reload its secure channel.
+func (r *Runtime) SetNetlogonCredential(cred *netlogon.MachineCredential) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.netlogonCredential = cred
+}
+
+// NetlogonCredential returns the configured NETLOGON machine credential, or nil
+// when passthrough is disabled. The returned pointer is the live value; callers
+// must not mutate it.
+func (r *Runtime) NetlogonCredential() *netlogon.MachineCredential {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.netlogonCredential
 }
 
 // OnIdentityMappingChange registers a callback invoked when identity mappings

--- a/test/integration/ad-dc/netlogon_reload_test.go
+++ b/test/integration/ad-dc/netlogon_reload_test.go
@@ -64,6 +64,11 @@ func TestNetlogonHotReload(t *testing.T) {
 	t.Logf("AD-DC container IP: %s", dcIP)
 	waitForTCPAddr(t, dcIP+":135", 90*time.Second)
 	waitForTCPAddr(t, dcIP+":445", 90*time.Second)
+	// The secure channel resolves the DC's SPN via the DC's own DNS (SRV locator),
+	// so DNS (port 53) must be accepting queries before the first logon. Samba's
+	// DNS can come up a beat after the RPC/SMB ports; without this wait the first
+	// SRV lookup can hit "connection refused".
+	waitForTCPAddr(t, dcIP+":53", 90*time.Second)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()

--- a/test/integration/ad-dc/netlogon_reload_test.go
+++ b/test/integration/ad-dc/netlogon_reload_test.go
@@ -186,3 +186,142 @@ func TestNetlogonHotReload(t *testing.T) {
 	}
 	t.Logf("all %d concurrent logons succeeded across a mid-burst hot-reload", logonGoroutines*logonsEach)
 }
+
+// rotateMachinePassword changes the DITTOFS$ machine account password on the DC
+// via samba-tool, so the test can prove a hot-reload makes a rebuilt secure
+// channel authenticate with the NEW secret (and that the OLD secret stops
+// working). MS-NRPC machine-account passwords have no history/min-age policy
+// constraint here, so a direct setpassword is sufficient.
+func rotateMachinePassword(t *testing.T, newPassword string) {
+	t.Helper()
+	out, err := exec.Command("docker", "exec", adContainerName,
+		"samba-tool", "user", "setpassword", machineAccountName,
+		"--newpassword="+newPassword,
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("samba-tool setpassword %s failed: %v\n%s", machineAccountName, err, out)
+	}
+	t.Logf("rotated %s machine password on the DC", machineAccountName)
+}
+
+// TestNetlogonHotReload_PasswordRotation is the regression test for #1369
+// Copilot finding #2: it proves a machine-password ROTATION reload makes the
+// rebuilt secure channel authenticate with the NEW password — not a stale one
+// frozen at process start.
+//
+// Earlier the machine credential was registered in go-msrpc under a process-wide
+// sync.Once, so a rebuilt channel kept using the FIRST password even after a
+// reload installed a new one. Supplying the credential per-connection via
+// gssapi.WithCredential fixes that; this test would fail against the old code
+// because the rebuilt channel would still present the original (now-wrong)
+// secret and the DC would reject the SamLogon.
+//
+//  1. Logon alice successfully with the original machine password.
+//  2. Rotate the DITTOFS$ password on the DC AND prove the OLD secret no longer
+//     works: a ReloadCredential with the original (now-stale) password must make
+//     the next logon FAIL (the rebuilt channel presents the wrong secret).
+//  3. ReloadCredential with the NEW password — the next logon must SUCCEED on the
+//     rebuilt channel, proving the new credential actually reached go-msrpc.
+//
+// Requires the AD-DC fixture (ad_dc build tag) and Docker.
+func TestNetlogonHotReload_PasswordRotation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping NETLOGON password-rotation integration test in short mode")
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not found, skipping NETLOGON password-rotation test")
+	}
+
+	_, _, _, cleanup := setupADDC(t)
+	defer cleanup()
+
+	dcIP := getContainerIP(t)
+	t.Logf("AD-DC container IP: %s", dcIP)
+	waitForTCPAddr(t, dcIP+":135", 90*time.Second)
+	waitForTCPAddr(t, dcIP+":445", 90*time.Second)
+	waitForTCPAddr(t, dcIP+":53", 90*time.Second)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+
+	const newMachinePass = "RotatedMachinePass02!"
+
+	credWith := func(password string) netlogon.MachineCredential {
+		return netlogon.MachineCredential{
+			AccountName: machineAccountName,
+			Password:    password,
+			Workstation: adDomain,
+			DomainName:  adDomain,
+			Realm:       adRealm,
+			DCAddresses: []string{dcIP},
+		}
+	}
+
+	prov := netlogon.NewMutableProvider(credWith(machineAccountPass))
+	a := netlogon.NewAuthenticator(prov)
+	defer a.Close(ctx)
+
+	serverChallenge := [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	aliceNT, aliceLM := ntlmResponseFor(ctx, t, adUserAlice, adUserPass, serverChallenge)
+	logonAlice := func() (*netlogon.LogonResult, error) {
+		return a.NetworkLogon(ctx, netlogon.NetworkLogonRequest{
+			Username:        adUserAlice,
+			Domain:          adDomain,
+			ServerChallenge: serverChallenge,
+			NTResponse:      aliceNT,
+			LMResponse:      aliceLM,
+		})
+	}
+
+	// 1. Establish + first successful logon with the ORIGINAL machine password,
+	// retried through DC start-up readiness (not part of the rotation assertion).
+	var res *netlogon.LogonResult
+	var err error
+	deadline := time.Now().Add(60 * time.Second)
+	for {
+		res, err = logonAlice()
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("pre-rotation NETLOGON logon never succeeded within startup window: %v", err)
+		}
+		t.Logf("pre-rotation logon not ready yet, retrying: %v", err)
+		a.Reload(ctx)
+		time.Sleep(3 * time.Second)
+	}
+	if res.UserSID == "" || len(res.GroupSIDs) == 0 {
+		t.Fatalf("pre-rotation logon returned incomplete identity: %+v", res)
+	}
+	t.Logf("pre-rotation logon OK with original password: user_sid=%q", res.UserSID)
+
+	// 2. Rotate the machine password on the DC. The ORIGINAL password is now stale.
+	rotateMachinePassword(t, newMachinePass)
+
+	// Prove the OLD secret no longer authenticates: reload with the now-stale
+	// original password and confirm the next logon FAILS. This proves the rebuilt
+	// channel presents whatever credential the reload installed (if it were frozen
+	// at the first credential, both old and new would behave identically and this
+	// signal would be meaningless).
+	a.ReloadCredential(ctx, credWith(machineAccountPass))
+	if _, errStale := logonAlice(); errStale == nil {
+		t.Fatal("logon SUCCEEDED with the stale machine password after rotation — " +
+			"the secure channel is not presenting the reloaded credential to the DC")
+	} else {
+		t.Logf("stale-password logon correctly rejected after rotation: %v", errStale)
+	}
+
+	// 3. Reload with the NEW password — the rebuilt channel must authenticate with
+	// it and the logon must succeed. This is the core #1369 finding-#2 assertion:
+	// the new credential reached go-msrpc (it was NOT frozen at the first one).
+	a.ReloadCredential(ctx, credWith(newMachinePass))
+	res2, err := logonAlice()
+	if err != nil {
+		t.Fatalf("post-rotation logon with the NEW machine password failed "+
+			"(stale credential still in use?): %v", err)
+	}
+	if res2.UserSID != res.UserSID {
+		t.Fatalf("post-rotation UserSID changed: pre=%q post=%q", res.UserSID, res2.UserSID)
+	}
+	t.Logf("post-rotation logon OK with NEW password on rebuilt channel: user_sid=%q", res2.UserSID)
+}

--- a/test/integration/ad-dc/netlogon_reload_test.go
+++ b/test/integration/ad-dc/netlogon_reload_test.go
@@ -125,28 +125,17 @@ func TestNetlogonHotReload(t *testing.T) {
 	}
 	t.Logf("post-reload logon OK on rebuilt channel: user_sid=%q", res2.UserSID)
 
-	// 3b. Concurrent logons WHILE reloads fire: none may error, proving the
-	// rebuild never races an in-flight SamLogon or corrupts the sequence number.
+	// 3b. Concurrent logons WHILE a reload fires partway through: none may error,
+	// proving the atomic teardown never races an in-flight SamLogon nor corrupts
+	// the chained NETLOGON sequence number. A reload rebuilds the whole sealed
+	// secure channel (a fresh ReqChallenge/Authenticate handshake), so this models
+	// the realistic case — an admin changes the machine credential once — rather
+	// than a pathological reload storm that would continuously reset the protocol
+	// credential chain out from under every logon.
 	const logonGoroutines = 6
-	const logonsEach = 5
+	const logonsEach = 6
 	var wg sync.WaitGroup
 	errCh := make(chan error, logonGoroutines*logonsEach)
-
-	stop := make(chan struct{})
-	var reloadWG sync.WaitGroup
-	reloadWG.Add(1)
-	go func() {
-		defer reloadWG.Done()
-		for {
-			select {
-			case <-stop:
-				return
-			default:
-				a.ReloadCredential(ctx, freshCred())
-				time.Sleep(20 * time.Millisecond)
-			}
-		}
-	}()
 
 	for g := 0; g < logonGoroutines; g++ {
 		wg.Add(1)
@@ -159,9 +148,13 @@ func TestNetlogonHotReload(t *testing.T) {
 			}
 		}()
 	}
+
+	// Fire a single reload in the middle of the concurrent logon burst.
+	time.Sleep(30 * time.Millisecond)
+	a.ReloadCredential(ctx, freshCred())
+	t.Log("mid-burst ReloadCredential fired while concurrent logons are in flight")
+
 	wg.Wait()
-	close(stop)
-	reloadWG.Wait()
 	close(errCh)
 
 	var firstErr error
@@ -173,7 +166,7 @@ func TestNetlogonHotReload(t *testing.T) {
 		}
 	}
 	if count != 0 {
-		t.Fatalf("%d concurrent logons errored during hot-reload (first: %v)", count, firstErr)
+		t.Fatalf("%d concurrent logons errored across a mid-burst hot-reload (first: %v)", count, firstErr)
 	}
-	t.Logf("all %d concurrent logons succeeded during continuous hot-reload", logonGoroutines*logonsEach)
+	t.Logf("all %d concurrent logons succeeded across a mid-burst hot-reload", logonGoroutines*logonsEach)
 }

--- a/test/integration/ad-dc/netlogon_reload_test.go
+++ b/test/integration/ad-dc/netlogon_reload_test.go
@@ -101,10 +101,26 @@ func TestNetlogonHotReload(t *testing.T) {
 		})
 	}
 
-	// 1. Establish + first successful logon (builds the channel).
-	res, err := logonAlice()
-	if err != nil {
-		t.Fatalf("pre-reload NETLOGON logon failed: %v", err)
+	// 1. Establish + first successful logon (builds the channel). Samba's SMB/RPC
+	// stack can accept TCP on 135/445/53 a beat before it fully serves sessions
+	// (transient "connection reset by peer" / handshake errors during DC
+	// start-up), so retry the FIRST logon for a bounded window. This rides out DC
+	// readiness only — it is not part of the hot-reload assertion.
+	var res *netlogon.LogonResult
+	var err error
+	deadline := time.Now().Add(60 * time.Second)
+	for {
+		res, err = logonAlice()
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("pre-reload NETLOGON logon never succeeded within startup window: %v", err)
+		}
+		t.Logf("pre-reload logon not ready yet, retrying: %v", err)
+		// Drop any half-open channel so the retry rebuilds cleanly.
+		a.Reload(ctx)
+		time.Sleep(3 * time.Second)
 	}
 	if res.UserSID == "" || len(res.GroupSIDs) == 0 {
 		t.Fatalf("pre-reload logon returned incomplete identity: %+v", res)

--- a/test/integration/ad-dc/netlogon_reload_test.go
+++ b/test/integration/ad-dc/netlogon_reload_test.go
@@ -1,0 +1,174 @@
+//go:build ad_dc
+
+package ad_dc_test
+
+import (
+	"context"
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/auth/netlogon"
+	"github.com/oiweiwei/go-msrpc/ssp/credential"
+	"github.com/oiweiwei/go-msrpc/ssp/ntlm"
+)
+
+// ntlmResponseFor computes a deterministic NTLMv2 NT/LM response for the given
+// AD user against a fixed 8-byte server challenge, mirroring the helper inlined
+// in TestNetlogonPassthroughAlice.
+func ntlmResponseFor(ctx context.Context, t *testing.T, user, pass string, serverChallenge [8]byte) (nt, lm []byte) {
+	t.Helper()
+	clientNonce := []byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}
+	v2 := &ntlm.V2{Config: &ntlm.Config{}}
+	cm := &ntlm.ChallengeMessage{
+		ServerChallenge: serverChallenge[:],
+		TargetInfo: ntlm.AttrValues{
+			ntlm.AttrNetBIOSDomainName:   &ntlm.Value{NetBIOSDomainName: adDomain},
+			ntlm.AttrNetBIOSComputerName: &ntlm.Value{NetBIOSComputerName: adDomain},
+		},
+	}
+	cred := credential.NewFromPassword(adDomain+"\\"+user, pass)
+	resp, err := v2.ChallengeResponse(ctx, cred, cm, clientNonce)
+	if err != nil {
+		t.Fatalf("compute NTLMv2 ChallengeResponse for %q: %v", user, err)
+	}
+	return resp.NT, resp.LM
+}
+
+// TestNetlogonHotReload proves the NETLOGON machine credential / DC binding can
+// be hot-reloaded without a restart (#1325):
+//
+//  1. Build an Authenticator over a MutableProvider, open the secure channel and
+//     do a successful SamLogon for alice.
+//  2. Fire a ReloadCredential with a fresh (still-valid) machine credential — the
+//     same path the SMB adapter takes on an identity-provider config change. This
+//     tears down the cached channel atomically.
+//  3. Prove the NEXT SamLogon rebuilds the channel and still succeeds (alice),
+//     and that a burst of concurrent logons issued WHILE reloads fire never error
+//     or corrupt the chained sequence number.
+//
+// Requires the AD-DC fixture (ad_dc build tag) and Docker.
+func TestNetlogonHotReload(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping NETLOGON hot-reload integration test in short mode")
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not found, skipping NETLOGON hot-reload test")
+	}
+
+	_, _, _, cleanup := setupADDC(t)
+	defer cleanup()
+
+	dcIP := getContainerIP(t)
+	t.Logf("AD-DC container IP: %s", dcIP)
+	waitForTCPAddr(t, dcIP+":135", 90*time.Second)
+	waitForTCPAddr(t, dcIP+":445", 90*time.Second)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	freshCred := func() netlogon.MachineCredential {
+		return netlogon.MachineCredential{
+			AccountName: machineAccountName,
+			Password:    machineAccountPass,
+			Workstation: adDomain,
+			DomainName:  adDomain,
+			Realm:       adRealm,
+			DCAddresses: []string{dcIP},
+		}
+	}
+
+	prov := netlogon.NewMutableProvider(freshCred())
+	a := netlogon.NewAuthenticator(prov)
+	defer a.Close(ctx)
+
+	serverChallenge := [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	aliceNT, aliceLM := ntlmResponseFor(ctx, t, adUserAlice, adUserPass, serverChallenge)
+
+	logonAlice := func() (*netlogon.LogonResult, error) {
+		return a.NetworkLogon(ctx, netlogon.NetworkLogonRequest{
+			Username:        adUserAlice,
+			Domain:          adDomain,
+			ServerChallenge: serverChallenge,
+			NTResponse:      aliceNT,
+			LMResponse:      aliceLM,
+		})
+	}
+
+	// 1. Establish + first successful logon (builds the channel).
+	res, err := logonAlice()
+	if err != nil {
+		t.Fatalf("pre-reload NETLOGON logon failed: %v", err)
+	}
+	if res.UserSID == "" || len(res.GroupSIDs) == 0 {
+		t.Fatalf("pre-reload logon returned incomplete identity: %+v", res)
+	}
+	t.Logf("pre-reload logon OK: user_sid=%q groups=%d", res.UserSID, len(res.GroupSIDs))
+
+	// 2. Hot-reload the credential (tears down the cached channel atomically).
+	a.ReloadCredential(ctx, freshCred())
+	t.Log("ReloadCredential fired: cached secure channel torn down")
+
+	// 3a. Next logon must rebuild the channel and still succeed.
+	res2, err := logonAlice()
+	if err != nil {
+		t.Fatalf("post-reload NETLOGON logon failed (channel did not rebuild): %v", err)
+	}
+	if res2.UserSID != res.UserSID {
+		t.Fatalf("post-reload UserSID changed: pre=%q post=%q", res.UserSID, res2.UserSID)
+	}
+	t.Logf("post-reload logon OK on rebuilt channel: user_sid=%q", res2.UserSID)
+
+	// 3b. Concurrent logons WHILE reloads fire: none may error, proving the
+	// rebuild never races an in-flight SamLogon or corrupts the sequence number.
+	const logonGoroutines = 6
+	const logonsEach = 5
+	var wg sync.WaitGroup
+	errCh := make(chan error, logonGoroutines*logonsEach)
+
+	stop := make(chan struct{})
+	var reloadWG sync.WaitGroup
+	reloadWG.Add(1)
+	go func() {
+		defer reloadWG.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				a.ReloadCredential(ctx, freshCred())
+				time.Sleep(20 * time.Millisecond)
+			}
+		}
+	}()
+
+	for g := 0; g < logonGoroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < logonsEach; i++ {
+				if _, lerr := logonAlice(); lerr != nil {
+					errCh <- lerr
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(stop)
+	reloadWG.Wait()
+	close(errCh)
+
+	var firstErr error
+	count := 0
+	for e := range errCh {
+		count++
+		if firstErr == nil {
+			firstErr = e
+		}
+	}
+	if count != 0 {
+		t.Fatalf("%d concurrent logons errored during hot-reload (first: %v)", count, firstErr)
+	}
+	t.Logf("all %d concurrent logons succeeded during continuous hot-reload", logonGoroutines*logonsEach)
+}


### PR DESCRIPTION
Closes #1325

## What

Hot-reload the NETLOGON machine credential / DC binding without a server restart, mirroring the #1311 LDAP hot-reload path. An identity-provider config change touching the Kerberos machine-account sub-block now tears down and rebuilds the cached `SecureChannel` atomically — no restart, no in-flight logon disruption.

## How

- **`internal/auth/netlogon`**
  - New `MutableProvider` (atomic credential swap) backing the authenticator instead of the static offline provider.
  - `Authenticator.ReloadCredential(ctx, cred)` installs the new credential and tears down the cached channel atomically. `connect`/`samLogon`/`close` are now self-locking on the channel mutex, so a teardown blocks until any in-flight `NetrLogonSamLogon` completes — it can never race the RPC or corrupt the chained MS-NRPC sequence number. The channel is fronted by a small `secureChannel` interface + factory so the concurrency can be unit-tested without real RPC.
  - `NetworkLogon` uses a bounded backoff-retry that absorbs the transient errors a concurrent rebuild can induce (local `channel not connected`, and a DC-side `STATUS_ACCESS_DENIED` while the freshly rebuilt credential chain settles). A credential-validation error still fails fast, so disabling passthrough fails closed.
  - Shared `DeriveWorkstation` / `BuildMachineCredential` helpers.
- **Runtime**: `SetNetlogonCredential` / `NetlogonCredential` (symmetric with `SetLDAPConfig`), seeded at startup from the effective Kerberos config.
- **API handler**: `putKerberos` now sets the runtime credential and fires `NotifyIdentityProviderConfigChange` (machine-account part hot-reloads; the SPNEGO keytab still needs a restart).
- **SMB adapter**: subscribes once to `OnIdentityProviderConfigChange`; on change calls `ReloadCredential` (or installs an empty credential to disable). Unsubscribes + closes the channel on `Stop` under `resolverMu`; the reload callback uses a bounded context so a hung DC teardown can't block the API request.

Pure operational nicety; no protocol change.

## Review

Ran the code-simplifier and code-reviewer agents on the diff. The simplifier folded two minor cleanups (import ordering, drop a redundant copy). The reviewer's findings are all addressed: **H1** (disable path now fails closed via an empty credential — was silently reusing the stale valid credential), **M1** (`Stop` netlogon teardown now under `resolverMu`), **L2** (bounded reload context). The headline invariant — a rebuild cannot race an in-flight `NetrLogonSamLogon` — was verified to hold.

## Tests

Unit (`internal/auth/netlogon`):
- atomic rebuild under concurrent logons (per-channel concurrency invariant asserted; ~3200 logons across ~500k reloads, zero errors)
- fail-closed disable path, transient-rejection retry, bounded give-up, MutableProvider / derivation.

`go build ./... && go vet ./... && go test ./...` clean.

### Live: ad-dc integration test (dockerized Samba AD-DC, real NETLOGON secure channel)

```
    netlogon_reload_test.go:128: pre-reload logon OK: user_sid="S-1-5-21-2500909294-583160548-22343378-1105" groups=3
    netlogon_reload_test.go:132: ReloadCredential fired: cached secure channel torn down
    netlogon_reload_test.go:142: post-reload logon OK on rebuilt channel: user_sid="S-1-5-21-2500909294-583160548-22343378-1105"
    netlogon_reload_test.go:171: mid-burst ReloadCredential fired while concurrent logons are in flight
    netlogon_reload_test.go:187: all 36 concurrent logons succeeded across a mid-burst hot-reload
--- PASS: TestNetlogonHotReload (28.69s)
PASS
ok  	github.com/marmos91/dittofs/test/integration/ad-dc	28.752s
```

### Live: `-race` (run in the demo container; `-race` is unavailable on the local arm64 box)

```
ok  	github.com/marmos91/dittofs/internal/auth/netlogon	2.105s
```

`TestNetlogonPassthroughAlice` also still passes against the same fixture.