### PR TITLE
feat(netlogon): online-join machine credential provider (#1323)

### DIFF
--- a/cmd/dfs/commands/netlogon.go
+++ b/cmd/dfs/commands/netlogon.go
@@ -1,46 +1,73 @@
 package commands
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"strings"
 
 	"github.com/marmos91/dittofs/internal/auth/netlogon"
 	"github.com/marmos91/dittofs/pkg/config"
+	"github.com/marmos91/dittofs/pkg/controlplane/store"
 )
+
+// machineSecretKey is the control-plane settings key under which the online-join
+// provider persists the (rotated) machine-account password.
+const machineSecretKey = "netlogon.machine_account.secret"
+
+// machineSecretStore adapts the control-plane SettingsStore to the
+// netlogon.SecretStore interface, scoping all reads/writes to machineSecretKey.
+// This keeps the netlogon package free of any control-plane dependency.
+type machineSecretStore struct {
+	settings store.SettingsStore
+}
+
+// newMachineSecretStore wraps the control-plane store for machine-secret
+// persistence. Returns nil when s is nil so the offline path passes nil through.
+func newMachineSecretStore(s store.SettingsStore) netlogon.SecretStore {
+	if s == nil {
+		return nil
+	}
+	return &machineSecretStore{settings: s}
+}
+
+func (m *machineSecretStore) GetMachineSecret(ctx context.Context) (string, error) {
+	return m.settings.GetSetting(ctx, machineSecretKey)
+}
+
+func (m *machineSecretStore) SetMachineSecret(ctx context.Context, secret string) error {
+	return m.settings.SetSetting(ctx, machineSecretKey, secret)
+}
 
 // buildNetlogonAuthenticator creates a NetlogonAuthenticator from the Kerberos
 // machine-account configuration. Returns nil (typed-nil-safe: an untyped nil
 // interface value) when MachineAccount.Enabled is false, so the SMB handler
 // falls back to local NTLM authentication without a domain controller.
 //
+// It also returns a *netlogon.RotationManager when the online-join provider is
+// active and rotation is configured (nil otherwise); the caller starts it and
+// stops it on shutdown. Returning (nil, nil) is the disabled case.
+//
+// secret is the persistence backend for the online-join machine password; it
+// may be nil for the offline path (which never persists anything new).
+//
 // Typed-nil-interface safety: the disabled path returns the bare nil literal so
 // callers can safely test `auth == nil` without hitting the typed-nil-interface
 // trap (a (*netlogon.Authenticator)(nil) wrapped in the interface would not
 // equal nil).
-func buildNetlogonAuthenticator(k config.KerberosConfig) netlogon.NetlogonAuthenticator {
+func buildNetlogonAuthenticator(k config.KerberosConfig, secret netlogon.SecretStore) (netlogon.NetlogonAuthenticator, *netlogon.RotationManager) {
 	if !k.MachineAccount.Enabled {
-		return nil
+		return nil, nil
 	}
 
-	// Validate required fields before constructing a doomed authenticator.
 	ma := k.MachineAccount
 	if ma.AccountName == "" {
 		slog.Warn("NETLOGON machine account is enabled but AccountName is not set; NTLM passthrough disabled")
-		return nil
-	}
-	if ma.Secret == "" {
-		if ma.KeytabPath != "" {
-			slog.Warn("NETLOGON machine account: keytab-based credentials are not yet supported (tracked separately); NTLM passthrough disabled",
-				"keytab_path", ma.KeytabPath)
-		} else {
-			slog.Warn("NETLOGON machine account is enabled but Secret is not set; NTLM passthrough disabled")
-		}
-		return nil
+		return nil, nil
 	}
 	if k.NetBIOSDomain == "" {
 		slog.Warn("NETLOGON machine account is enabled but kerberos.netbios_domain (DomainName) is not set; NTLM passthrough disabled")
-		return nil
+		return nil, nil
 	}
 	// The realm is mandatory: the secure channel authenticates to the DC over a
 	// Kerberos SMB session, and when no dc_address is set the realm also drives
@@ -48,12 +75,59 @@ func buildNetlogonAuthenticator(k config.KerberosConfig) netlogon.NetlogonAuthen
 	// from the realm via _ldap._tcp.dc._msdcs.<realm> (#1324).
 	if k.Realm == "" {
 		slog.Warn("NETLOGON machine account is enabled but kerberos.realm is not set (required for the Kerberos SMB session to the DC and for DNS SRV discovery); NTLM passthrough disabled")
-		return nil
+		return nil, nil
 	}
 
 	// Derive the NetBIOS workstation name.  MS-NRPC §3.1.4.1 requires the
 	// short host name without the trailing '$' machine-account marker.
 	workstation := netbiosWorkstation(k)
+
+	// Online-join (opt-in): the provider creates the computer object and owns the
+	// machine-password lifecycle. Otherwise the offline provider uses the
+	// admin-supplied static secret.
+	if ma.OnlineJoin.Enabled {
+		oj := ma.OnlineJoin
+		cfg := netlogon.OnlineConfig{
+			AccountName:      ma.AccountName,
+			Workstation:      workstation,
+			DomainName:       k.NetBIOSDomain,
+			Realm:            k.Realm,
+			DCAddresses:      ma.DCAddresses,
+			RotationInterval: oj.RotationInterval,
+			Join: netlogon.JoinConfig{
+				LDAPURL:      oj.LDAPURL,
+				StartTLS:     oj.StartTLS,
+				BindDN:       oj.BindDN,
+				BindPassword: oj.BindPassword,
+				BaseDN:       oj.BaseDN,
+				OU:           oj.OU,
+				MachineName:  workstation,
+				DNSHostName:  oj.DNSHostName,
+				SPNs:         oj.SPNs,
+				TLS: netlogon.JoinTLSConfig{
+					CACertFile:         oj.CACertFile,
+					InsecureSkipVerify: oj.InsecureSkipVerify,
+				},
+			},
+		}
+		provider := netlogon.NewOnlineProvider(cfg, secret)
+		auth := netlogon.NewAuthenticator(provider)
+		rot := netlogon.NewRotationManager(provider, auth, oj.RotationInterval)
+		slog.Info("NETLOGON machine account: online-join provider active",
+			"account", ma.AccountName, "ldap_url", oj.LDAPURL, "rotation_interval", oj.RotationInterval)
+		return auth, rot
+	}
+
+	// Offline path: a static admin-supplied secret is required.
+	if ma.Secret == "" {
+		if ma.KeytabPath != "" {
+			slog.Warn("NETLOGON machine account: keytab-based credentials are not yet supported (tracked separately); NTLM passthrough disabled",
+				"keytab_path", ma.KeytabPath)
+		} else {
+			slog.Warn("NETLOGON machine account is enabled but Secret is not set (and online_join is off); NTLM passthrough disabled")
+		}
+		return nil, nil
+	}
 
 	cred := netlogon.MachineCredential{
 		AccountName: ma.AccountName,
@@ -63,7 +137,7 @@ func buildNetlogonAuthenticator(k config.KerberosConfig) netlogon.NetlogonAuthen
 		Realm:       k.Realm,
 		DCAddresses: ma.DCAddresses,
 	}
-	return netlogon.NewAuthenticator(netlogon.NewOfflineProvider(cred))
+	return netlogon.NewAuthenticator(netlogon.NewOfflineProvider(cred)), nil
 }
 
 // netbiosWorkstation derives the short workstation name used in NETLOGON RPC

--- a/cmd/dfs/commands/netlogon_test.go
+++ b/cmd/dfs/commands/netlogon_test.go
@@ -1,8 +1,10 @@
 package commands
 
 import (
+	"context"
 	"testing"
 
+	"github.com/marmos91/dittofs/internal/auth/netlogon"
 	"github.com/marmos91/dittofs/pkg/config"
 )
 
@@ -10,7 +12,7 @@ func TestBuildNetlogonAuthenticator_Disabled(t *testing.T) {
 	k := config.KerberosConfig{
 		MachineAccount: config.MachineAccountConfig{Enabled: false},
 	}
-	got := buildNetlogonAuthenticator(k)
+	got, _ := buildNetlogonAuthenticator(k, nil)
 	if got != nil {
 		t.Fatalf("expected nil for disabled machine account, got %v", got)
 	}
@@ -27,7 +29,7 @@ func TestBuildNetlogonAuthenticator_Enabled(t *testing.T) {
 			DCAddresses: []string{"192.168.1.1"},
 		},
 	}
-	got := buildNetlogonAuthenticator(k)
+	got, _ := buildNetlogonAuthenticator(k, nil)
 	if got == nil {
 		t.Fatal("expected non-nil authenticator for enabled machine account")
 	}
@@ -44,7 +46,7 @@ func TestBuildNetlogonAuthenticator_EnabledMissingSecret(t *testing.T) {
 			DCAddresses: []string{"192.168.1.1"},
 		},
 	}
-	got := buildNetlogonAuthenticator(k)
+	got, _ := buildNetlogonAuthenticator(k, nil)
 	if got != nil {
 		t.Fatal("expected nil when Secret is missing")
 	}
@@ -62,7 +64,7 @@ func TestBuildNetlogonAuthenticator_EnabledKeytabOnly(t *testing.T) {
 			DCAddresses: []string{"192.168.1.1"},
 		},
 	}
-	got := buildNetlogonAuthenticator(k)
+	got, _ := buildNetlogonAuthenticator(k, nil)
 	if got != nil {
 		t.Fatal("expected nil when only KeytabPath is set (not yet supported)")
 	}
@@ -79,7 +81,7 @@ func TestBuildNetlogonAuthenticator_EnabledMissingDomain(t *testing.T) {
 			DCAddresses: []string{"192.168.1.1"},
 		},
 	}
-	got := buildNetlogonAuthenticator(k)
+	got, _ := buildNetlogonAuthenticator(k, nil)
 	if got != nil {
 		t.Fatal("expected nil when NetBIOSDomain is missing")
 	}
@@ -98,7 +100,7 @@ func TestBuildNetlogonAuthenticator_EnabledMissingDCAddressesUsesDiscovery(t *te
 			// DCAddresses intentionally empty — located from the realm.
 		},
 	}
-	got := buildNetlogonAuthenticator(k)
+	got, _ := buildNetlogonAuthenticator(k, nil)
 	if got == nil {
 		t.Fatal("expected non-nil authenticator when realm is set (DC located via DNS SRV)")
 	}
@@ -117,11 +119,53 @@ func TestBuildNetlogonAuthenticator_EnabledMissingRealm(t *testing.T) {
 			DCAddresses: []string{"192.168.1.1"},
 		},
 	}
-	got := buildNetlogonAuthenticator(k)
+	got, _ := buildNetlogonAuthenticator(k, nil)
 	if got != nil {
 		t.Fatal("expected nil when realm is missing")
 	}
 }
+
+// TestBuildNetlogonAuthenticator_OnlineJoinNoSecretNeeded verifies the
+// online-join path builds an authenticator + rotation manager without a static
+// Secret (the provider owns the password). The provider is lazy, so no DC I/O
+// happens at construction.
+func TestBuildNetlogonAuthenticator_OnlineJoinNoSecretNeeded(t *testing.T) {
+	k := config.KerberosConfig{
+		Realm:         "EXAMPLE.COM",
+		NetBIOSDomain: "EXAMPLE",
+		MachineAccount: config.MachineAccountConfig{
+			Enabled:     true,
+			AccountName: "DITTOFS$",
+			// Secret intentionally empty — online join generates it.
+			OnlineJoin: config.OnlineJoinConfig{
+				Enabled:          true,
+				LDAPURL:          "ldaps://dc.example.com",
+				BindDN:           "CN=Administrator,CN=Users,DC=example,DC=com",
+				BindPassword:     "joinpass",
+				BaseDN:           "DC=example,DC=com",
+				RotationInterval: 0, // disabled → nil rotation manager
+			},
+		},
+	}
+	got, rot := buildNetlogonAuthenticator(k, &fakeSecretStore{})
+	if got == nil {
+		t.Fatal("expected non-nil authenticator for online-join (no static secret required)")
+	}
+	if rot != nil {
+		t.Fatal("expected nil rotation manager when rotation_interval is 0")
+	}
+}
+
+// fakeSecretStore is an in-memory netlogon.SecretStore for wiring tests.
+type fakeSecretStore struct{ v string }
+
+func (f *fakeSecretStore) GetMachineSecret(context.Context) (string, error) { return f.v, nil }
+func (f *fakeSecretStore) SetMachineSecret(_ context.Context, s string) error {
+	f.v = s
+	return nil
+}
+
+var _ netlogon.SecretStore = (*fakeSecretStore)(nil)
 
 func TestKerberosRoundTrip_MachineAccount(t *testing.T) {
 	orig := config.KerberosConfig{

--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/marmos91/dittofs/internal/auth/netlogon"
 	"github.com/marmos91/dittofs/internal/controlplane/api/handlers"
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/internal/sysinfo"
@@ -271,7 +272,21 @@ func runStart(cmd *cobra.Command, args []string) error {
 	// sets the runtime's LDAP config and returns the effective Kerberos config to
 	// hand to the adapter factory.
 	effectiveKerberos := resolveIdentityProviders(ctx, cpStore, rt, cfg)
-	rt.SetAdapterFactory(createAdapterFactory(&effectiveKerberos))
+
+	// Build the single, process-wide NETLOGON authenticator before the adapter
+	// factory so every SMB adapter instance shares it (one machine account per
+	// process). The online-join provider persists its rotated secret in the
+	// control-plane settings store, so it survives restarts. nlAuth is nil when
+	// machine_account is disabled. nlRotation drives periodic password rotation
+	// and is started below / stopped on shutdown.
+	nlAuth, nlRotation := buildNetlogonAuthenticator(effectiveKerberos, newMachineSecretStore(cpStore))
+	nlRotation.Start()
+	defer nlRotation.Stop()
+	if closer, ok := nlAuth.(interface{ Close(context.Context) }); ok && nlAuth != nil {
+		defer closer.Close(context.Background())
+	}
+
+	rt.SetAdapterFactory(createAdapterFactory(&effectiveKerberos, nlAuth))
 
 	// Create and set API server
 	apiServer, err := api.NewServer(cfg.ControlPlane, rt, cpStore, cfg.Snapshot.RestoreHTTPTimeout)
@@ -574,13 +589,19 @@ func kerberosDTOToConfig(dto handlers.KerberosConfigDTO) config.KerberosConfig {
 // createAdapterFactory returns a factory function that creates protocol adapters
 // from configuration. This factory is used by Runtime to create adapters
 // dynamically when loading from store or when created via API.
-func createAdapterFactory(kerberosConfig *config.KerberosConfig) runtime.AdapterFactory {
+//
+// nlAuth is the shared, process-wide NETLOGON authenticator (one machine
+// account per process). It is built once by the caller — so the online-join
+// provider joins / loads the persisted secret exactly once regardless of how
+// many SMB adapter instances the runtime spins up — and injected here. It is
+// nil when machine_account is disabled.
+func createAdapterFactory(kerberosConfig *config.KerberosConfig, nlAuth netlogon.NetlogonAuthenticator) runtime.AdapterFactory {
 	return func(cfg *models.AdapterConfig) (runtime.ProtocolAdapter, error) {
 		switch cfg.Type {
 		case "nfs":
 			return createNFSAdapter(cfg, kerberosConfig)
 		case "smb":
-			return createSMBAdapter(cfg, kerberosConfig)
+			return createSMBAdapter(cfg, kerberosConfig, nlAuth)
 		default:
 			return nil, fmt.Errorf("unknown adapter type: %s", cfg.Type)
 		}
@@ -624,7 +645,7 @@ func createNFSAdapter(cfg *models.AdapterConfig, kerberosConfig *config.Kerberos
 	return adapter, nil
 }
 
-func createSMBAdapter(cfg *models.AdapterConfig, kerberosConfig *config.KerberosConfig) (runtime.ProtocolAdapter, error) {
+func createSMBAdapter(cfg *models.AdapterConfig, kerberosConfig *config.KerberosConfig, nlAuth netlogon.NetlogonAuthenticator) (runtime.ProtocolAdapter, error) {
 	port := cfg.Port
 	if port == 0 {
 		port = 12445
@@ -663,15 +684,13 @@ func createSMBAdapter(cfg *models.AdapterConfig, kerberosConfig *config.Kerberos
 		smbAdapter.SetKerberosProvider(provider)
 	}
 
-	// Wire NETLOGON authenticator for domain-controller NTLM pass-through.
-	// This runs whenever kerberosConfig is present (machine_account lives on
-	// the kerberos config), regardless of kerberosConfig.Enabled.  An
-	// NTLM-only / legacy deployment sets kerberos.enabled=false but still
-	// needs NETLOGON passthrough when machine_account.enabled=true.
-	// buildNetlogonAuthenticator returns nil when MachineAccount.Enabled is
-	// false, so SetNetlogonAuthenticator no-ops in that case.
+	// Wire the shared NETLOGON authenticator for domain-controller NTLM
+	// pass-through. It is built once by the caller (one machine account per
+	// process) and injected, regardless of kerberosConfig.Enabled — an NTLM-only
+	// / legacy deployment sets kerberos.enabled=false but still needs NETLOGON
+	// passthrough when machine_account.enabled=true. nlAuth is nil when
+	// MachineAccount.Enabled is false, so SetNetlogonAuthenticator no-ops then.
 	if kerberosConfig != nil {
-		nlAuth := buildNetlogonAuthenticator(*kerberosConfig)
 		// When NTLM pass-through is active, the SMB handler must advertise, in its
 		// NTLM CHALLENGE TargetInfo, both the AD NetBIOS/DNS domain AND the AD
 		// machine-account computer name. Domain clients echo these into their

--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -281,10 +281,15 @@ func runStart(cmd *cobra.Command, args []string) error {
 	// and is started below / stopped on shutdown.
 	nlAuth, nlRotation := buildNetlogonAuthenticator(effectiveKerberos, newMachineSecretStore(cpStore))
 	nlRotation.Start()
-	defer nlRotation.Stop()
-	if closer, ok := nlAuth.(interface{ Close(context.Context) }); ok && nlAuth != nil {
-		defer closer.Close(context.Background())
-	}
+	// Single defer with deterministic ordering: stop the rotation loop FIRST so
+	// no rotation can re-establish (and leak) the secure channel after Close, then
+	// close the authenticator's cached channel.
+	defer func() {
+		nlRotation.Stop()
+		if closer, ok := nlAuth.(interface{ Close(context.Context) }); ok && nlAuth != nil {
+			closer.Close(context.Background())
+		}
+	}()
 
 	rt.SetAdapterFactory(createAdapterFactory(&effectiveKerberos, nlAuth))
 
@@ -518,6 +523,13 @@ func resolveIdentityProviders(ctx context.Context, cpStore store.Store, rt *runt
 			}
 		}
 	}
+
+	// Online-join is a server-bootstrap concern carrying privileged LDAP join
+	// credentials, so it is intentionally NOT part of the API-managed Kerberos
+	// DTO (which would persist the bind password in the DB and expose it over
+	// REST). Always source it from the file/env config and overlay it onto the
+	// effective config, so a DB-sourced Kerberos row never silently drops it.
+	kerberos.MachineAccount.OnlineJoin = cfg.Kerberos.MachineAccount.OnlineJoin
 	return kerberos
 }
 

--- a/internal/auth/netlogon/authenticator.go
+++ b/internal/auth/netlogon/authenticator.go
@@ -69,6 +69,33 @@ func (a *Authenticator) NetworkLogon(ctx context.Context, req NetworkLogonReques
 	return res, nil
 }
 
+// RotatePassword changes the machine account's password on the DC to
+// newPassword via NetrServerPasswordSet2 over the established secure channel,
+// using the CURRENT credential to authenticate the channel. On success the DC
+// holds newPassword; the caller is responsible for persisting it and switching
+// the provider's credential so the NEXT channel (re)connects with it.
+//
+// The channel is reset afterward unconditionally: the session key was derived
+// from the old password, and the next call must reconnect so a fresh key is
+// negotiated against whatever credential the provider now returns.
+func (a *Authenticator) RotatePassword(ctx context.Context, newPassword string) error {
+	mc, err := a.provider.Credential(ctx)
+	if err != nil {
+		return err
+	}
+	sc, err := a.ensureChannel(ctx, mc)
+	if err != nil {
+		return err
+	}
+	if err := sc.setPassword(ctx, *mc, newPassword); err != nil {
+		// A failed set may have torn the channel; drop it so the next op reconnects.
+		a.reset(ctx)
+		return err
+	}
+	a.reset(ctx)
+	return nil
+}
+
 // Close shuts down the cached secure channel connection.
 func (a *Authenticator) Close(ctx context.Context) {
 	a.mu.Lock()

--- a/internal/auth/netlogon/authenticator.go
+++ b/internal/auth/netlogon/authenticator.go
@@ -87,13 +87,23 @@ func (a *Authenticator) RotatePassword(ctx context.Context, newPassword string) 
 	if err != nil {
 		return err
 	}
-	if err := sc.setPassword(ctx, *mc, newPassword); err != nil {
-		// A failed set may have torn the channel; drop it so the next op reconnects.
+	err = sc.setPassword(ctx, *mc, newPassword)
+	if err != nil {
+		// ensureChannel released sc.mu before returning, so a concurrent
+		// NetworkLogon RPC failure could have reset the channel in the window
+		// before setPassword re-acquired it ("channel not connected"), or the set
+		// itself tore the channel. Either way, reconnect once and retry, mirroring
+		// NetworkLogon's single-retry policy.
 		a.reset(ctx)
-		return err
+		if sc, err = a.ensureChannel(ctx, mc); err != nil {
+			return err
+		}
+		err = sc.setPassword(ctx, *mc, newPassword)
 	}
+	// The session key was derived from the OLD password; drop the channel so the
+	// next call reconnects and negotiates a fresh key against the new credential.
 	a.reset(ctx)
-	return nil
+	return err
 }
 
 // Close shuts down the cached secure channel connection.

--- a/internal/auth/netlogon/join.go
+++ b/internal/auth/netlogon/join.go
@@ -1,0 +1,315 @@
+package netlogon
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"unicode/utf16"
+
+	ldapv3 "github.com/go-ldap/ldap/v3"
+)
+
+// userAccountControl flags (MS-ADTS 2.2.16). A computer (workstation trust)
+// account is created with WORKSTATION_TRUST_ACCOUNT set. PASSWD_NOTREQD is NOT
+// set: the account always carries a strong password we generate.
+const (
+	uacWorkstationTrustAccount = 0x1000
+)
+
+// JoinConfig configures the online creation of the machine (computer) account
+// in Active Directory over LDAP. The directory write requires a privileged
+// "join" credential (a Domain Admin or a delegated account with Create Computer
+// Objects rights on the target OU).
+//
+// LDAPS (or StartTLS) is mandatory: AD refuses to write unicodePwd over an
+// unencrypted connection, so the initial machine password can only be set on a
+// confidential channel. Validate() enforces this.
+type JoinConfig struct {
+	// LDAPURL is the directory URL, "ldaps://dc.example.com" (preferred) or
+	// "ldap://dc.example.com" combined with StartTLS.
+	LDAPURL string
+	// StartTLS upgrades a plaintext ldap:// connection before binding. Ignored
+	// for ldaps://.
+	StartTLS bool
+	// BindDN / BindPassword are the privileged join credentials.
+	BindDN       string
+	BindPassword string
+	// BaseDN is the domain naming context, e.g. "DC=dittofs,DC=ad". The computer
+	// object is created under OU (if set) or directly under CN=Computers,<BaseDN>.
+	BaseDN string
+	// OU is the optional container DN for the computer object, e.g.
+	// "OU=Servers,DC=dittofs,DC=ad". When empty the default CN=Computers
+	// container is used.
+	OU string
+	// MachineName is the short computer name without the trailing '$'
+	// (e.g. "DITTOFS"). The sAMAccountName becomes "<MachineName>$".
+	MachineName string
+	// DNSHostName is the FQDN stamped on the computer object (e.g.
+	// "dittofs.dittofs.ad"). Optional but recommended; AD uses it for SPN
+	// validation. When empty it is left unset.
+	DNSHostName string
+	// SPNs are the servicePrincipalName values to register on the account
+	// (e.g. "cifs/dittofs.dittofs.ad"). Optional.
+	SPNs []string
+	// TLS holds client TLS settings for the LDAPS/StartTLS connection.
+	TLS JoinTLSConfig
+}
+
+// JoinTLSConfig mirrors the LDAP provider's TLS knobs for the join connection.
+type JoinTLSConfig struct {
+	CACertFile         string
+	InsecureSkipVerify bool
+}
+
+// Validate checks the join configuration before any network I/O.
+func (c *JoinConfig) Validate() error {
+	if strings.TrimSpace(c.LDAPURL) == "" {
+		return fmt.Errorf("netlogon join: ldap_url is required")
+	}
+	scheme := strings.ToLower(strings.TrimSpace(c.LDAPURL))
+	switch {
+	case strings.HasPrefix(scheme, "ldaps://"):
+		// Implicit TLS — confidential, AD will accept the unicodePwd write.
+	case strings.HasPrefix(scheme, "ldap://"):
+		// Plaintext: AD rejects a unicodePwd write unless the channel is
+		// encrypted, so StartTLS is mandatory here (there is no allow_plaintext
+		// escape hatch for a join — a cleartext password write is never valid).
+		if !c.StartTLS {
+			return fmt.Errorf("netlogon join: ldap:// requires start_tls=true (AD refuses to set a machine password over an unencrypted connection)")
+		}
+	default:
+		return fmt.Errorf("netlogon join: ldap_url must use ldap:// or ldaps:// (got %q)", c.LDAPURL)
+	}
+	if strings.TrimSpace(c.BindDN) == "" {
+		return fmt.Errorf("netlogon join: bind_dn is required (a privileged account that can create computer objects)")
+	}
+	if c.BindPassword == "" {
+		return fmt.Errorf("netlogon join: bind_password is required")
+	}
+	if strings.TrimSpace(c.BaseDN) == "" {
+		return fmt.Errorf("netlogon join: base_dn is required")
+	}
+	if strings.TrimSpace(c.MachineName) == "" {
+		return fmt.Errorf("netlogon join: machine_name is required")
+	}
+	if strings.ContainsAny(c.MachineName, "$ ,=\\/") {
+		return fmt.Errorf("netlogon join: machine_name %q must be a bare NetBIOS label (no '$', spaces, or DN separators)", c.MachineName)
+	}
+	return nil
+}
+
+// ldapConn is the subset of *ldapv3.Conn the join uses. It is an interface so
+// unit tests can supply a fake directory without a live DC.
+type ldapConn interface {
+	Bind(username, password string) error
+	Search(req *ldapv3.SearchRequest) (*ldapv3.SearchResult, error)
+	Add(req *ldapv3.AddRequest) error
+	Modify(req *ldapv3.ModifyRequest) error
+	Close() error
+}
+
+// ldapDialer opens a bound connection. Swapped in tests.
+type ldapDialer func(ctx context.Context, cfg *JoinConfig) (ldapConn, error)
+
+// computerDN returns the distinguished name of the computer object.
+func (c *JoinConfig) computerDN() string {
+	container := c.OU
+	if strings.TrimSpace(container) == "" {
+		container = "CN=Computers," + c.BaseDN
+	}
+	return "CN=" + c.MachineName + "," + container
+}
+
+// samAccountName returns the "<MachineName>$" machine-account name.
+func (c *JoinConfig) samAccountName() string {
+	return strings.ToUpper(c.MachineName) + "$"
+}
+
+// joinDirectory creates (or reconciles) the computer object and sets its
+// password to newPassword, returning nothing on success. It is idempotent: if
+// the object already exists, only the password (and any drifted SPNs) are reset,
+// which is exactly what a re-join after a lost secret needs.
+//
+// The flow mirrors `net ads join`:
+//  1. Bind as the privileged join account.
+//  2. Search for an existing computer object by sAMAccountName.
+//  3. Create it (objectClass=computer, sAMAccountName, userAccountControl,
+//     dNSHostName, servicePrincipalName) if absent.
+//  4. Set unicodePwd (AD requires the password as a UTF-16LE string wrapped in
+//     double quotes, sent over the confidential connection).
+func joinDirectory(ctx context.Context, dial ldapDialer, cfg *JoinConfig, newPassword string) error {
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+	conn, err := dial(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("netlogon join: connect/bind: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	dn := cfg.computerDN()
+	sam := cfg.samAccountName()
+
+	exists, err := computerExists(conn, cfg, sam)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		if err := addComputerObject(conn, cfg, dn, sam); err != nil {
+			return fmt.Errorf("netlogon join: create computer %q: %w", dn, err)
+		}
+	}
+
+	if err := setUnicodePwd(conn, dn, newPassword); err != nil {
+		return fmt.Errorf("netlogon join: set machine password on %q: %w", dn, err)
+	}
+
+	// Ensure the account is enabled with the workstation-trust UAC. A freshly
+	// created object created without the password may be disabled until the
+	// password is set; reasserting UAC here makes the join converge regardless of
+	// the create path.
+	if err := setUserAccountControl(conn, dn, uacWorkstationTrustAccount); err != nil {
+		return fmt.Errorf("netlogon join: enable computer %q: %w", dn, err)
+	}
+	return nil
+}
+
+// computerExists reports whether a computer object with the given
+// sAMAccountName already lives under BaseDN.
+func computerExists(conn ldapConn, cfg *JoinConfig, sam string) (bool, error) {
+	req := ldapv3.NewSearchRequest(
+		cfg.BaseDN,
+		ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 2, 0, false,
+		fmt.Sprintf("(&(objectClass=computer)(sAMAccountName=%s))", ldapv3.EscapeFilter(sam)),
+		[]string{"distinguishedName"}, nil,
+	)
+	res, err := conn.Search(req)
+	if err != nil {
+		return false, fmt.Errorf("netlogon join: search computer %q: %w", sam, err)
+	}
+	return len(res.Entries) > 0, nil
+}
+
+// addComputerObject creates the computer object with the workstation-trust UAC
+// and optional dNSHostName / SPNs.
+func addComputerObject(conn ldapConn, cfg *JoinConfig, dn, sam string) error {
+	add := ldapv3.NewAddRequest(dn, nil)
+	add.Attribute("objectClass", []string{"top", "person", "organizationalPerson", "user", "computer"})
+	add.Attribute("sAMAccountName", []string{sam})
+	add.Attribute("userAccountControl", []string{fmt.Sprintf("%d", uacWorkstationTrustAccount)})
+	if cfg.DNSHostName != "" {
+		add.Attribute("dNSHostName", []string{cfg.DNSHostName})
+	}
+	if len(cfg.SPNs) > 0 {
+		add.Attribute("servicePrincipalName", cfg.SPNs)
+	}
+	return conn.Add(add)
+}
+
+// setUnicodePwd sets the account password via the AD unicodePwd attribute. AD
+// requires the value to be the password wrapped in double quotes and encoded as
+// UTF-16LE, sent over a confidential (TLS) connection.
+func setUnicodePwd(conn ldapConn, dn, password string) error {
+	mod := ldapv3.NewModifyRequest(dn, nil)
+	mod.Replace("unicodePwd", []string{encodeADPassword(password)})
+	return conn.Modify(mod)
+}
+
+// setUserAccountControl replaces the userAccountControl attribute.
+func setUserAccountControl(conn ldapConn, dn string, uac int) error {
+	mod := ldapv3.NewModifyRequest(dn, nil)
+	mod.Replace("userAccountControl", []string{fmt.Sprintf("%d", uac)})
+	return conn.Modify(mod)
+}
+
+// encodeADPassword renders a password as the byte string AD expects for
+// unicodePwd: the cleartext wrapped in double quotes, encoded UTF-16LE. The
+// go-ldap library marshals the string's raw bytes as the attribute value, so
+// the UTF-16LE bytes must be packed into a Go string here.
+func encodeADPassword(password string) string {
+	quoted := `"` + password + `"`
+	codes := utf16.Encode([]rune(quoted))
+	buf := make([]byte, 0, len(codes)*2)
+	for _, c := range codes {
+		buf = append(buf, byte(c), byte(c>>8))
+	}
+	return string(buf)
+}
+
+// dialAndBindJoin opens an encrypted LDAP connection and binds the join account.
+// LDAPS connects with implicit TLS; ldap:// upgrades via StartTLS (required —
+// Validate rejects plaintext joins).
+func dialAndBindJoin(ctx context.Context, cfg *JoinConfig) (ldapConn, error) {
+	host, err := joinHostFromURL(cfg.LDAPURL)
+	if err != nil {
+		return nil, err
+	}
+	isLDAPS := strings.HasPrefix(strings.ToLower(strings.TrimSpace(cfg.LDAPURL)), "ldaps://")
+
+	var opts []ldapv3.DialOpt
+	if isLDAPS {
+		tlsCfg, err := cfg.tlsClientConfig(host)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, ldapv3.DialWithTLSConfig(tlsCfg))
+	}
+
+	l, err := ldapv3.DialURL(cfg.LDAPURL, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("dial %s: %w", cfg.LDAPURL, err)
+	}
+
+	if !isLDAPS && cfg.StartTLS {
+		tlsCfg, err := cfg.tlsClientConfig(host)
+		if err != nil {
+			_ = l.Close()
+			return nil, err
+		}
+		if err := l.StartTLS(tlsCfg); err != nil {
+			_ = l.Close()
+			return nil, fmt.Errorf("ldap StartTLS upgrade failed: %w", err)
+		}
+	}
+
+	if err := l.Bind(cfg.BindDN, cfg.BindPassword); err != nil {
+		_ = l.Close()
+		return nil, fmt.Errorf("bind as %s: %w", cfg.BindDN, err)
+	}
+	return l, nil
+}
+
+// tlsClientConfig builds a *tls.Config for the join connection.
+func (c *JoinConfig) tlsClientConfig(serverName string) (*tls.Config, error) {
+	out := &tls.Config{
+		ServerName:         serverName,
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: c.TLS.InsecureSkipVerify, //nolint:gosec // opt-in lab escape hatch, off by default
+	}
+	if c.TLS.CACertFile != "" {
+		pem, err := os.ReadFile(c.TLS.CACertFile)
+		if err != nil {
+			return nil, fmt.Errorf("read join CA cert file %s: %w", c.TLS.CACertFile, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("join CA cert file %s contains no valid PEM certificate", c.TLS.CACertFile)
+		}
+		out.RootCAs = pool
+	}
+	return out, nil
+}
+
+// joinHostFromURL extracts the host (no port) for TLS ServerName verification.
+func joinHostFromURL(raw string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", fmt.Errorf("netlogon join: parse url %q: %w", raw, err)
+	}
+	return u.Hostname(), nil
+}

--- a/internal/auth/netlogon/join.go
+++ b/internal/auth/netlogon/join.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 	"strings"
@@ -18,6 +19,15 @@ import (
 // set: the account always carries a strong password we generate.
 const (
 	uacWorkstationTrustAccount = 0x1000
+
+	// supportedEncTypes advertises the Kerberos enctypes the machine account
+	// supports via msDS-SupportedEncryptionTypes (MS-KILE 2.2.7). 0x1F =
+	// DES-CBC-CRC | DES-CBC-MD5 | RC4-HMAC | AES128-CTS | AES256-CTS. Setting it
+	// is what `net ads join` does so the NETLOGON secure channel negotiates AES
+	// (CapAES_SHA2); without it a Samba DC may negotiate a weaker channel and
+	// reject the SamLogon passthrough. AES is also required for the password
+	// rotation path (see password.go buildTrustPassword).
+	supportedEncTypes = 0x1F
 )
 
 // JoinConfig configures the online creation of the machine (computer) account
@@ -70,11 +80,11 @@ func (c *JoinConfig) Validate() error {
 	if strings.TrimSpace(c.LDAPURL) == "" {
 		return fmt.Errorf("netlogon join: ldap_url is required")
 	}
-	scheme := strings.ToLower(strings.TrimSpace(c.LDAPURL))
+	lower := strings.ToLower(strings.TrimSpace(c.LDAPURL))
 	switch {
-	case strings.HasPrefix(scheme, "ldaps://"):
+	case strings.HasPrefix(lower, "ldaps://"):
 		// Implicit TLS — confidential, AD will accept the unicodePwd write.
-	case strings.HasPrefix(scheme, "ldap://"):
+	case strings.HasPrefix(lower, "ldap://"):
 		// Plaintext: AD rejects a unicodePwd write unless the channel is
 		// encrypted, so StartTLS is mandatory here (there is no allow_plaintext
 		// escape hatch for a join — a cleartext password write is never valid).
@@ -129,6 +139,11 @@ func (c *JoinConfig) samAccountName() string {
 	return strings.ToUpper(c.MachineName) + "$"
 }
 
+// isLDAPS reports whether the configured URL uses implicit TLS (ldaps://).
+func (c *JoinConfig) isLDAPS() bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(c.LDAPURL)), "ldaps://")
+}
+
 // joinDirectory creates (or reconciles) the computer object and sets its
 // password to newPassword, returning nothing on success. It is idempotent: if
 // the object already exists, only the password (and any drifted SPNs) are reset,
@@ -169,12 +184,16 @@ func joinDirectory(ctx context.Context, dial ldapDialer, cfg *JoinConfig, newPas
 		return fmt.Errorf("netlogon join: set machine password on %q: %w", dn, err)
 	}
 
-	// Ensure the account is enabled with the workstation-trust UAC. A freshly
-	// created object created without the password may be disabled until the
-	// password is set; reasserting UAC here makes the join converge regardless of
-	// the create path.
-	if err := setUserAccountControl(conn, dn, uacWorkstationTrustAccount); err != nil {
-		return fmt.Errorf("netlogon join: enable computer %q: %w", dn, err)
+	// Ensure the account is enabled with the workstation-trust UAC and advertises
+	// AES enctypes. A freshly created object may be disabled until the password is
+	// set, and an existing object from a prior (pre-AES) join may lack the enctype
+	// attribute; reasserting both here makes the join converge regardless of the
+	// create path, so the NETLOGON channel negotiates AES.
+	mod := ldapv3.NewModifyRequest(dn, nil)
+	mod.Replace("userAccountControl", []string{fmt.Sprintf("%d", uacWorkstationTrustAccount)})
+	mod.Replace("msDS-SupportedEncryptionTypes", []string{fmt.Sprintf("%d", supportedEncTypes)})
+	if err := conn.Modify(mod); err != nil {
+		return fmt.Errorf("netlogon join: enable computer %q (uac + enctypes): %w", dn, err)
 	}
 	return nil
 }
@@ -202,6 +221,7 @@ func addComputerObject(conn ldapConn, cfg *JoinConfig, dn, sam string) error {
 	add.Attribute("objectClass", []string{"top", "person", "organizationalPerson", "user", "computer"})
 	add.Attribute("sAMAccountName", []string{sam})
 	add.Attribute("userAccountControl", []string{fmt.Sprintf("%d", uacWorkstationTrustAccount)})
+	add.Attribute("msDS-SupportedEncryptionTypes", []string{fmt.Sprintf("%d", supportedEncTypes)})
 	if cfg.DNSHostName != "" {
 		add.Attribute("dNSHostName", []string{cfg.DNSHostName})
 	}
@@ -217,13 +237,6 @@ func addComputerObject(conn ldapConn, cfg *JoinConfig, dn, sam string) error {
 func setUnicodePwd(conn ldapConn, dn, password string) error {
 	mod := ldapv3.NewModifyRequest(dn, nil)
 	mod.Replace("unicodePwd", []string{encodeADPassword(password)})
-	return conn.Modify(mod)
-}
-
-// setUserAccountControl replaces the userAccountControl attribute.
-func setUserAccountControl(conn ldapConn, dn string, uac int) error {
-	mod := ldapv3.NewModifyRequest(dn, nil)
-	mod.Replace("userAccountControl", []string{fmt.Sprintf("%d", uac)})
 	return conn.Modify(mod)
 }
 
@@ -249,7 +262,16 @@ func dialAndBindJoin(ctx context.Context, cfg *JoinConfig) (ldapConn, error) {
 	if err != nil {
 		return nil, err
 	}
-	isLDAPS := strings.HasPrefix(strings.ToLower(strings.TrimSpace(cfg.LDAPURL)), "ldaps://")
+	isLDAPS := cfg.isLDAPS()
+
+	if cfg.TLS.InsecureSkipVerify {
+		// The machine password is written as unicodePwd over this connection. With
+		// certificate verification disabled the channel is encrypted but the DC
+		// identity is unverified, so a MITM could capture the cleartext password.
+		// Acceptable only as a lab escape hatch — never in production.
+		slog.Default().Warn("netlogon join: TLS certificate verification is DISABLED (insecure_skip_verify); the machine password is written over an unauthenticated TLS channel and is exposed to a man-in-the-middle. Use a pinned CA (ca_cert_file) in production.",
+			"ldap_url", cfg.LDAPURL)
+	}
 
 	var opts []ldapv3.DialOpt
 	if isLDAPS {

--- a/internal/auth/netlogon/join_test.go
+++ b/internal/auth/netlogon/join_test.go
@@ -1,0 +1,192 @@
+package netlogon
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"unicode/utf16"
+
+	ldapv3 "github.com/go-ldap/ldap/v3"
+)
+
+// fakeLDAP is an in-memory ldapConn that records the operations the join
+// performs so tests can assert on the computer object and password write.
+type fakeLDAP struct {
+	existing  bool // computer already present on Search
+	adds      []*ldapv3.AddRequest
+	modifies  []*ldapv3.ModifyRequest
+	bindErr   error
+	addErr    error
+	modifyErr error
+	closed    bool
+}
+
+func (f *fakeLDAP) Bind(string, string) error { return f.bindErr }
+func (f *fakeLDAP) Search(*ldapv3.SearchRequest) (*ldapv3.SearchResult, error) {
+	res := &ldapv3.SearchResult{}
+	if f.existing {
+		res.Entries = []*ldapv3.Entry{{DN: "CN=DITTOFS,CN=Computers,DC=dittofs,DC=ad"}}
+	}
+	return res, nil
+}
+func (f *fakeLDAP) Add(r *ldapv3.AddRequest) error {
+	if f.addErr != nil {
+		return f.addErr
+	}
+	f.adds = append(f.adds, r)
+	return nil
+}
+func (f *fakeLDAP) Modify(r *ldapv3.ModifyRequest) error {
+	if f.modifyErr != nil {
+		return f.modifyErr
+	}
+	f.modifies = append(f.modifies, r)
+	return nil
+}
+func (f *fakeLDAP) Close() error { f.closed = true; return nil }
+
+func baseJoinConfig() *JoinConfig {
+	return &JoinConfig{
+		LDAPURL:      "ldaps://dc.dittofs.ad",
+		BindDN:       "CN=Administrator,CN=Users,DC=dittofs,DC=ad",
+		BindPassword: "Passw0rd!2024",
+		BaseDN:       "DC=dittofs,DC=ad",
+		MachineName:  "DITTOFS",
+	}
+}
+
+func TestJoinDirectory_CreatesComputerAndSetsPassword(t *testing.T) {
+	fake := &fakeLDAP{existing: false}
+	dial := func(context.Context, *JoinConfig) (ldapConn, error) { return fake, nil }
+
+	if err := joinDirectory(context.Background(), dial, baseJoinConfig(), "Sup3rSecret!"); err != nil {
+		t.Fatalf("joinDirectory: %v", err)
+	}
+
+	if len(fake.adds) != 1 {
+		t.Fatalf("expected 1 Add (create computer), got %d", len(fake.adds))
+	}
+	add := fake.adds[0]
+	if add.DN != "CN=DITTOFS,CN=Computers,DC=dittofs,DC=ad" {
+		t.Errorf("computer DN = %q", add.DN)
+	}
+	if !hasAttr(add, "sAMAccountName", "DITTOFS$") {
+		t.Errorf("sAMAccountName not set to DITTOFS$: %+v", add.Attributes)
+	}
+	if !hasAttr(add, "userAccountControl", "4096") {
+		t.Errorf("userAccountControl not WORKSTATION_TRUST_ACCOUNT (4096): %+v", add.Attributes)
+	}
+
+	// Two modifies: unicodePwd + userAccountControl reassertion.
+	if len(fake.modifies) != 2 {
+		t.Fatalf("expected 2 Modify (unicodePwd + uac), got %d", len(fake.modifies))
+	}
+	assertUnicodePwd(t, fake.modifies[0], "Sup3rSecret!")
+	if !fake.closed {
+		t.Error("expected connection to be closed")
+	}
+}
+
+func TestJoinDirectory_IdempotentWhenComputerExists(t *testing.T) {
+	fake := &fakeLDAP{existing: true}
+	dial := func(context.Context, *JoinConfig) (ldapConn, error) { return fake, nil }
+
+	if err := joinDirectory(context.Background(), dial, baseJoinConfig(), "NewPass1!"); err != nil {
+		t.Fatalf("joinDirectory: %v", err)
+	}
+	if len(fake.adds) != 0 {
+		t.Errorf("expected no Add when computer exists, got %d", len(fake.adds))
+	}
+	// Still resets the password (re-join after lost secret) + reasserts uac.
+	if len(fake.modifies) != 2 {
+		t.Fatalf("expected 2 Modify on existing computer, got %d", len(fake.modifies))
+	}
+	assertUnicodePwd(t, fake.modifies[0], "NewPass1!")
+}
+
+func TestJoinDirectory_UsesOUWhenSet(t *testing.T) {
+	cfg := baseJoinConfig()
+	cfg.OU = "OU=Servers,DC=dittofs,DC=ad"
+	fake := &fakeLDAP{}
+	dial := func(context.Context, *JoinConfig) (ldapConn, error) { return fake, nil }
+
+	if err := joinDirectory(context.Background(), dial, cfg, "x"); err != nil {
+		t.Fatalf("joinDirectory: %v", err)
+	}
+	if fake.adds[0].DN != "CN=DITTOFS,OU=Servers,DC=dittofs,DC=ad" {
+		t.Errorf("OU placement wrong: %q", fake.adds[0].DN)
+	}
+}
+
+func TestJoinConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*JoinConfig)
+		wantErr bool
+	}{
+		{"valid ldaps", func(*JoinConfig) {}, false},
+		{"plaintext without starttls", func(c *JoinConfig) { c.LDAPURL = "ldap://dc.dittofs.ad" }, true},
+		{"plaintext with starttls", func(c *JoinConfig) { c.LDAPURL = "ldap://dc.dittofs.ad"; c.StartTLS = true }, false},
+		{"bad scheme", func(c *JoinConfig) { c.LDAPURL = "http://dc" }, true},
+		{"empty url", func(c *JoinConfig) { c.LDAPURL = "" }, true},
+		{"empty bind dn", func(c *JoinConfig) { c.BindDN = "" }, true},
+		{"empty bind pw", func(c *JoinConfig) { c.BindPassword = "" }, true},
+		{"empty base dn", func(c *JoinConfig) { c.BaseDN = "" }, true},
+		{"empty machine name", func(c *JoinConfig) { c.MachineName = "" }, true},
+		{"machine name with dollar", func(c *JoinConfig) { c.MachineName = "DITTOFS$" }, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := baseJoinConfig()
+			tt.mutate(cfg)
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() err=%v, wantErr=%v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestEncodeADPassword(t *testing.T) {
+	got := encodeADPassword("ab")
+	// Expect UTF-16LE of "ab" (quotes wrapped): " a b " → 4 code units, 8 bytes.
+	want := []rune{'"', 'a', 'b', '"'}
+	codes := utf16.Encode(want)
+	var sb strings.Builder
+	for _, c := range codes {
+		sb.WriteByte(byte(c))
+		sb.WriteByte(byte(c >> 8))
+	}
+	if got != sb.String() {
+		t.Errorf("encodeADPassword mismatch:\n got %x\nwant %x", got, sb.String())
+	}
+}
+
+func hasAttr(add *ldapv3.AddRequest, name, value string) bool {
+	for _, a := range add.Attributes {
+		if a.Type == name {
+			for _, v := range a.Vals {
+				if v == value {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func assertUnicodePwd(t *testing.T, mod *ldapv3.ModifyRequest, password string) {
+	t.Helper()
+	for _, ch := range mod.Changes {
+		if ch.Modification.Type == "unicodePwd" {
+			if len(ch.Modification.Vals) != 1 {
+				t.Fatalf("unicodePwd should have 1 value, got %d", len(ch.Modification.Vals))
+			}
+			if ch.Modification.Vals[0] != encodeADPassword(password) {
+				t.Errorf("unicodePwd value is not the UTF-16LE quoted password")
+			}
+			return
+		}
+	}
+	t.Fatalf("no unicodePwd modification found in %+v", mod.Changes)
+}

--- a/internal/auth/netlogon/online.go
+++ b/internal/auth/netlogon/online.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -180,7 +181,10 @@ type RotationManager struct {
 
 	stop chan struct{}
 	done chan struct{}
-	once sync.Once
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+	started   atomic.Bool
 }
 
 // NewRotationManager wires an online provider to its authenticator for periodic
@@ -201,12 +205,15 @@ func NewRotationManager(prov MachineCredentialProvider, auth *Authenticator, int
 }
 
 // Start launches the rotation loop in a goroutine. Safe to call on a nil
-// receiver (no-op), so callers need not branch.
+// receiver (no-op) and idempotent (a second call does not spawn a second loop).
 func (m *RotationManager) Start() {
 	if m == nil {
 		return
 	}
-	go m.run()
+	m.startOnce.Do(func() {
+		m.started.Store(true)
+		go m.run()
+	})
 }
 
 func (m *RotationManager) run() {
@@ -229,11 +236,16 @@ func (m *RotationManager) run() {
 }
 
 // Stop halts the rotation loop and waits for the goroutine to exit. Safe on a
-// nil receiver and idempotent.
+// nil receiver, idempotent, and non-blocking when Start was never called (no
+// goroutine to wait for) — so `m := NewRotationManager(...); defer m.Stop()`
+// with an early return before Start does not deadlock.
 func (m *RotationManager) Stop() {
 	if m == nil {
 		return
 	}
-	m.once.Do(func() { close(m.stop) })
+	m.stopOnce.Do(func() { close(m.stop) })
+	if !m.started.Load() {
+		return
+	}
 	<-m.done
 }

--- a/internal/auth/netlogon/online.go
+++ b/internal/auth/netlogon/online.go
@@ -1,0 +1,231 @@
+package netlogon
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// OnlineConfig configures the online-join machine credential provider.
+type OnlineConfig struct {
+	// AccountName is the machine-account sAMAccountName (e.g. "DITTOFS$").
+	AccountName string
+	// Workstation is the short NetBIOS workstation name (e.g. "DITTOFS").
+	Workstation string
+	// DomainName is the NetBIOS domain (e.g. "DITTOFS").
+	DomainName string
+	// Realm is the Kerberos realm (e.g. "DITTOFS.AD").
+	Realm string
+	// DCAddresses are optional DC addresses for the NETLOGON secure channel;
+	// when empty the DC is discovered from the realm via DNS SRV.
+	DCAddresses []string
+	// Join holds the LDAP join configuration (how to create the computer object).
+	Join JoinConfig
+	// RotationInterval is how often the machine password is rotated. Zero
+	// disables automatic rotation. AD's default machine-password max age is 30
+	// days; a value around 7 days is a safe default the caller may set.
+	RotationInterval time.Duration
+}
+
+// onlineProvider implements MachineCredentialProvider by creating the machine
+// account in AD on first use (online join) and owning the machine-password
+// lifecycle: it generates the initial password, persists it, and rotates it on
+// a schedule via NetrServerPasswordSet2.
+//
+// It is the opt-in alternative to offlineProvider. The secure channel and
+// Authenticator are unchanged — they consume whatever Credential() returns.
+type onlineProvider struct {
+	cfg    OnlineConfig
+	secret SecretStore
+	dial   ldapDialer // swapped in tests; defaults to dialAndBindJoin
+
+	mu       sync.Mutex
+	password string // current machine password (loaded or generated)
+	joined   bool   // true once the account is provisioned + password persisted
+}
+
+// NewOnlineProvider creates an online-join provider. The provider is lazy: no
+// directory I/O happens until the first Credential() call, so construction
+// cannot fail on a transient DC outage.
+func NewOnlineProvider(cfg OnlineConfig, secret SecretStore) MachineCredentialProvider {
+	return &onlineProvider{
+		cfg:    cfg,
+		secret: secret,
+		dial:   dialAndBindJoin,
+	}
+}
+
+// Credential returns the machine credential, performing the online join on the
+// first call when no password has been persisted yet.
+//
+// First-call resolution:
+//  1. Load the persisted password from the SecretStore. If present, the account
+//     was joined on a prior run — reuse it (survives restarts).
+//  2. Otherwise generate a strong password, create/reset the computer object in
+//     AD (idempotent), persist the password, and use it.
+func (p *onlineProvider) Credential(ctx context.Context) (*MachineCredential, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !p.joined {
+		if err := p.ensureJoinedLocked(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	if p.cfg.AccountName == "" || p.cfg.DomainName == "" || p.cfg.Realm == "" {
+		return nil, fmt.Errorf("netlogon: incomplete online machine config (account/domain/realm required)")
+	}
+
+	return &MachineCredential{
+		AccountName: p.cfg.AccountName,
+		Password:    p.password,
+		Workstation: p.cfg.Workstation,
+		DomainName:  p.cfg.DomainName,
+		Realm:       p.cfg.Realm,
+		DCAddresses: p.cfg.DCAddresses,
+	}, nil
+}
+
+// ensureJoinedLocked performs the one-time join (or reload). Must hold p.mu.
+func (p *onlineProvider) ensureJoinedLocked(ctx context.Context) error {
+	// 1. Reuse a previously persisted password (restart path).
+	if p.secret != nil {
+		stored, err := p.secret.GetMachineSecret(ctx)
+		if err != nil {
+			return fmt.Errorf("netlogon: load persisted machine secret: %w", err)
+		}
+		if stored != "" {
+			p.password = stored
+			p.joined = true
+			slog.Default().Info("netlogon: reusing persisted machine-account password (already joined)",
+				"account", p.cfg.AccountName)
+			return nil
+		}
+	}
+
+	// 2. First join: generate a password and create the computer object.
+	newPassword, err := generateMachinePassword()
+	if err != nil {
+		return err
+	}
+	if err := joinDirectory(ctx, p.dial, &p.cfg.Join, newPassword); err != nil {
+		return err
+	}
+
+	// Persist BEFORE marking joined: if persistence fails we must not treat the
+	// account as joined (the DC has the new password but we'd lose it on restart).
+	if p.secret != nil {
+		if err := p.secret.SetMachineSecret(ctx, newPassword); err != nil {
+			return fmt.Errorf("netlogon: persist machine secret after join: %w", err)
+		}
+	}
+	p.password = newPassword
+	p.joined = true
+	slog.Default().Info("netlogon: online join complete; machine account provisioned and password persisted",
+		"account", p.cfg.AccountName)
+	return nil
+}
+
+// rotate generates a new password, sets it on the DC via the authenticator's
+// established secure channel (authenticated with the CURRENT password), and on
+// success persists it and switches the in-memory credential. The order matters:
+// the DC must accept the new password before we persist/switch, or a crash
+// between steps would leave the persisted secret out of sync with the DC.
+func (p *onlineProvider) rotate(ctx context.Context, auth *Authenticator) error {
+	newPassword, err := generateMachinePassword()
+	if err != nil {
+		return err
+	}
+
+	// PasswordSet2 over the channel authenticated with the current password.
+	if err := auth.RotatePassword(ctx, newPassword); err != nil {
+		return err
+	}
+
+	// DC now holds newPassword. Persist then switch the credential so the next
+	// channel reconnect authenticates with it.
+	if p.secret != nil {
+		if err := p.secret.SetMachineSecret(ctx, newPassword); err != nil {
+			// The DC already switched; surface loudly. On restart the persisted
+			// (old) secret would be stale, but the rotation loop retries and a
+			// re-join reconciles via setUnicodePwd over LDAP.
+			return fmt.Errorf("netlogon: persist rotated machine secret (DC already switched!): %w", err)
+		}
+	}
+
+	p.mu.Lock()
+	p.password = newPassword
+	p.mu.Unlock()
+	slog.Default().Info("netlogon: machine-account password rotated", "account", p.cfg.AccountName)
+	return nil
+}
+
+// RotationManager drives periodic machine-password rotation for an online
+// provider. It is started by the wiring layer and stopped on shutdown.
+type RotationManager struct {
+	provider *onlineProvider
+	auth     *Authenticator
+	interval time.Duration
+
+	stop chan struct{}
+	done chan struct{}
+	once sync.Once
+}
+
+// NewRotationManager wires an online provider to its authenticator for periodic
+// rotation. Returns nil when prov is not an online provider or interval <= 0,
+// so the caller can unconditionally call Start/Stop on the result.
+func NewRotationManager(prov MachineCredentialProvider, auth *Authenticator, interval time.Duration) *RotationManager {
+	op, ok := prov.(*onlineProvider)
+	if !ok || interval <= 0 || auth == nil {
+		return nil
+	}
+	return &RotationManager{
+		provider: op,
+		auth:     auth,
+		interval: interval,
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+}
+
+// Start launches the rotation loop in a goroutine. Safe to call on a nil
+// receiver (no-op), so callers need not branch.
+func (m *RotationManager) Start() {
+	if m == nil {
+		return
+	}
+	go m.run()
+}
+
+func (m *RotationManager) run() {
+	defer close(m.done)
+	ticker := time.NewTicker(m.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.stop:
+			return
+		case <-ticker.C:
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			if err := m.provider.rotate(ctx, m.auth); err != nil {
+				slog.Default().Error("netlogon: machine-password rotation failed (will retry next interval)",
+					"account", m.provider.cfg.AccountName, "error", err)
+			}
+			cancel()
+		}
+	}
+}
+
+// Stop halts the rotation loop and waits for the goroutine to exit. Safe on a
+// nil receiver and idempotent.
+func (m *RotationManager) Stop() {
+	if m == nil {
+		return
+	}
+	m.once.Do(func() { close(m.stop) })
+	<-m.done
+}

--- a/internal/auth/netlogon/online.go
+++ b/internal/auth/netlogon/online.go
@@ -145,20 +145,28 @@ func (p *onlineProvider) rotate(ctx context.Context, auth *Authenticator) error 
 		return err
 	}
 
-	// DC now holds newPassword. Persist then switch the credential so the next
-	// channel reconnect authenticates with it.
-	if p.secret != nil {
-		if err := p.secret.SetMachineSecret(ctx, newPassword); err != nil {
-			// The DC already switched; surface loudly. On restart the persisted
-			// (old) secret would be stale, but the rotation loop retries and a
-			// re-join reconciles via setUnicodePwd over LDAP.
-			return fmt.Errorf("netlogon: persist rotated machine secret (DC already switched!): %w", err)
-		}
-	}
-
+	// The DC now holds newPassword. Update the in-memory credential FIRST so the
+	// running process keeps working regardless of the persistence outcome (the
+	// next channel reconnect must authenticate with the new password the DC now
+	// expects — keeping the old one would break all NTLM passthrough).
 	p.mu.Lock()
 	p.password = newPassword
 	p.mu.Unlock()
+
+	// Then persist so the new secret survives a restart.
+	if p.secret != nil {
+		if err := p.secret.SetMachineSecret(ctx, newPassword); err != nil {
+			// In-memory is already consistent with the DC, so the live process is
+			// fine. But the persisted secret is now stale: after a restart it would
+			// no longer match the DC. Surface loudly so an operator can intervene
+			// (a re-join with a fresh password reconciles the account). Online join
+			// itself remains the recovery path — see ensureJoinedLocked.
+			slog.Default().Error("netlogon: rotated machine password set on DC but FAILED to persist; a restart before the next successful rotation will require a re-join",
+				"account", p.cfg.AccountName, "error", err)
+			return fmt.Errorf("netlogon: persist rotated machine secret (DC already switched): %w", err)
+		}
+	}
+
 	slog.Default().Info("netlogon: machine-account password rotated", "account", p.cfg.AccountName)
 	return nil
 }

--- a/internal/auth/netlogon/online_test.go
+++ b/internal/auth/netlogon/online_test.go
@@ -1,0 +1,171 @@
+package netlogon
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	ldapv3 "github.com/go-ldap/ldap/v3"
+)
+
+// memSecretStore is an in-memory SecretStore for online-provider tests.
+type memSecretStore struct {
+	mu     sync.Mutex
+	val    string
+	setN   int
+	setErr error
+	getErr error
+}
+
+func (m *memSecretStore) GetMachineSecret(context.Context) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.val, m.getErr
+}
+func (m *memSecretStore) SetMachineSecret(_ context.Context, s string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.setErr != nil {
+		return m.setErr
+	}
+	m.val = s
+	m.setN++
+	return nil
+}
+
+func onlineCfg() OnlineConfig {
+	return OnlineConfig{
+		AccountName: "DITTOFS$",
+		Workstation: "DITTOFS",
+		DomainName:  "DITTOFS",
+		Realm:       "DITTOFS.AD",
+		Join: JoinConfig{
+			LDAPURL:      "ldaps://dc.dittofs.ad",
+			BindDN:       "CN=Administrator,CN=Users,DC=dittofs,DC=ad",
+			BindPassword: "Passw0rd!2024",
+			BaseDN:       "DC=dittofs,DC=ad",
+			MachineName:  "DITTOFS",
+		},
+	}
+}
+
+// countingDial returns a dialer that records how many times it is invoked and
+// the fake conn it returns.
+func countingDial(fake *fakeLDAP, count *int) ldapDialer {
+	return func(context.Context, *JoinConfig) (ldapConn, error) {
+		*count++
+		return fake, nil
+	}
+}
+
+func TestOnlineProvider_FirstCallJoinsAndPersists(t *testing.T) {
+	fake := &fakeLDAP{}
+	secret := &memSecretStore{}
+	var dialN int
+
+	p := &onlineProvider{cfg: onlineCfg(), secret: secret, dial: countingDial(fake, &dialN)}
+
+	cred, err := p.Credential(context.Background())
+	if err != nil {
+		t.Fatalf("Credential: %v", err)
+	}
+	if cred.AccountName != "DITTOFS$" || cred.Realm != "DITTOFS.AD" {
+		t.Errorf("unexpected credential: %+v", cred)
+	}
+	if cred.Password == "" {
+		t.Fatal("expected a generated password")
+	}
+	if dialN != 1 {
+		t.Errorf("expected 1 join dial, got %d", dialN)
+	}
+	if secret.val != cred.Password {
+		t.Errorf("persisted secret %q != credential password %q", secret.val, cred.Password)
+	}
+	if len(fake.adds) != 1 {
+		t.Errorf("expected computer Add on first join, got %d", len(fake.adds))
+	}
+}
+
+func TestOnlineProvider_SecondCallDoesNotRejoin(t *testing.T) {
+	fake := &fakeLDAP{}
+	secret := &memSecretStore{}
+	var dialN int
+	p := &onlineProvider{cfg: onlineCfg(), secret: secret, dial: countingDial(fake, &dialN)}
+
+	first, _ := p.Credential(context.Background())
+	second, err := p.Credential(context.Background())
+	if err != nil {
+		t.Fatalf("second Credential: %v", err)
+	}
+	if dialN != 1 {
+		t.Errorf("expected join to run only once, dialed %d times", dialN)
+	}
+	if first.Password != second.Password {
+		t.Error("password changed between calls without rotation")
+	}
+}
+
+func TestOnlineProvider_ReusesPersistedSecretAcrossRestart(t *testing.T) {
+	// Simulate a restart: a fresh provider with a pre-populated secret store must
+	// NOT re-join — it reuses the persisted password.
+	secret := &memSecretStore{val: "PersistedPass1!"}
+	fake := &fakeLDAP{}
+	var dialN int
+	p := &onlineProvider{cfg: onlineCfg(), secret: secret, dial: countingDial(fake, &dialN)}
+
+	cred, err := p.Credential(context.Background())
+	if err != nil {
+		t.Fatalf("Credential: %v", err)
+	}
+	if cred.Password != "PersistedPass1!" {
+		t.Errorf("expected persisted password, got %q", cred.Password)
+	}
+	if dialN != 0 {
+		t.Errorf("expected no join dial on restart with persisted secret, got %d", dialN)
+	}
+	if len(fake.adds) != 0 {
+		t.Errorf("expected no computer Add on restart, got %d", len(fake.adds))
+	}
+}
+
+func TestOnlineProvider_DoesNotMarkJoinedWhenPersistFails(t *testing.T) {
+	fake := &fakeLDAP{}
+	secret := &memSecretStore{setErr: errors.New("db down")}
+	var dialN int
+	p := &onlineProvider{cfg: onlineCfg(), secret: secret, dial: countingDial(fake, &dialN)}
+
+	if _, err := p.Credential(context.Background()); err == nil {
+		t.Fatal("expected error when persistence fails")
+	}
+	// A second attempt must retry the join (not silently treat it as joined).
+	secret.setErr = nil
+	if _, err := p.Credential(context.Background()); err != nil {
+		t.Fatalf("retry Credential: %v", err)
+	}
+	if dialN != 2 {
+		t.Errorf("expected join retried after persistence failure, dialed %d times", dialN)
+	}
+}
+
+func TestNewRotationManager_NilForOfflineOrZeroInterval(t *testing.T) {
+	offline := NewOfflineProvider(MachineCredential{AccountName: "X$", Password: "p", DomainName: "D", Realm: "R"})
+	auth := NewAuthenticator(offline)
+	if m := NewRotationManager(offline, auth, 1); m != nil {
+		t.Error("expected nil rotation manager for offline provider")
+	}
+
+	online := NewOnlineProvider(onlineCfg(), &memSecretStore{})
+	if m := NewRotationManager(online, NewAuthenticator(online), 0); m != nil {
+		t.Error("expected nil rotation manager for zero interval")
+	}
+}
+
+func TestRotationManager_NilSafe(t *testing.T) {
+	var m *RotationManager
+	m.Start() // must not panic
+	m.Stop()  // must not panic
+}
+
+// ensure fakeLDAP search returns an empty (non-nil) result for the no-OU path.
+var _ = ldapv3.NewSearchRequest

--- a/internal/auth/netlogon/online_test.go
+++ b/internal/auth/netlogon/online_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	ldapv3 "github.com/go-ldap/ldap/v3"
 )
@@ -54,7 +55,7 @@ func onlineCfg() OnlineConfig {
 // the fake conn it returns.
 func countingDial(fake *fakeLDAP, count *int) ldapDialer {
 	return func(context.Context, *JoinConfig) (ldapConn, error) {
-		*count++
+		(*count)++
 		return fake, nil
 	}
 }
@@ -165,6 +166,44 @@ func TestRotationManager_NilSafe(t *testing.T) {
 	var m *RotationManager
 	m.Start() // must not panic
 	m.Stop()  // must not panic
+}
+
+// Stop must not block when Start was never called: the run goroutine never
+// launched, so there is no `done` close to wait for. Guards the
+// `m := NewRotationManager(...); defer m.Stop(); if err != nil { return }`
+// pattern where an early return skips Start.
+func TestRotationManager_StopWithoutStart(t *testing.T) {
+	m := &RotationManager{
+		interval: time.Hour,
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+	done := make(chan struct{})
+	go func() { m.Stop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() blocked when Start() was never called")
+	}
+}
+
+// Stop after Start halts the loop and returns promptly. Also exercises Stop
+// idempotency (a second call must not panic on the already-closed channel).
+func TestRotationManager_StartThenStop(t *testing.T) {
+	m := &RotationManager{
+		interval: time.Hour,
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+	m.Start()
+	m.Start() // idempotent: must not spawn a second loop
+	done := make(chan struct{})
+	go func() { m.Stop(); m.Stop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() blocked after Start()")
+	}
 }
 
 // ensure fakeLDAP search returns an empty (non-nil) result for the no-OU path.

--- a/internal/auth/netlogon/password.go
+++ b/internal/auth/netlogon/password.go
@@ -1,0 +1,116 @@
+package netlogon
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"unicode/utf16"
+
+	logon "github.com/oiweiwei/go-msrpc/msrpc/nrpc/logon/v1"
+)
+
+// machinePasswordLen is the length of a generated machine-account password.
+// AD machine accounts use a 120-character random password by default; we use a
+// comfortably-long 64 to stay well under the 127-UTF16-char NL_TRUST_PASSWORD
+// limit while remaining brute-force-infeasible.
+const machinePasswordLen = 64
+
+// machinePasswordAlphabet is the character set for generated machine passwords.
+// It deliberately excludes characters that complicate shell/config round-trips
+// while keeping >90 bits of entropy at the configured length.
+const machinePasswordAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.@#%+=:"
+
+// trustPasswordBufferRunes is the fixed NL_TRUST_PASSWORD buffer size in UTF-16
+// code units (512 bytes). MS-NRPC §2.2.1.3.7: the password occupies the END of
+// the buffer; the leading bytes are random filler.
+const trustPasswordBufferRunes = 256
+
+// generateMachinePassword returns a cryptographically random machine-account
+// password of machinePasswordLen characters drawn from machinePasswordAlphabet.
+func generateMachinePassword() (string, error) {
+	out := make([]byte, machinePasswordLen)
+	max := big.NewInt(int64(len(machinePasswordAlphabet)))
+	for i := range out {
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return "", fmt.Errorf("netlogon: generate machine password: %w", err)
+		}
+		out[i] = machinePasswordAlphabet[n.Int64()]
+	}
+	return string(out), nil
+}
+
+// encryptor is the subset of the go-msrpc secure-channel client used to build a
+// NetrServerPasswordSet2 request: it encrypts bytes with the negotiated session
+// key (AES-CFB for AES_SHA2 channels, else DES) and sequences the per-call
+// NETLOGON authenticators. *xxx_SecureChannelClient satisfies it via its
+// exported Encrypt/SetAuthenticators/VerifyAuthenticator methods (which are not
+// part of the LogonSecureChannelClient interface, so we type-assert to this).
+type encryptor interface {
+	Encrypt(ctx context.Context, b []byte) ([]byte, error)
+	SetAuthenticators(ctx context.Context, a, ra **logon.Authenticator) error
+	VerifyAuthenticator(ctx context.Context, ra *logon.Authenticator) error
+}
+
+// buildTrustPassword constructs an NL_TRUST_PASSWORD for the given cleartext
+// password, then encrypts it with the secure channel's session key as
+// NetrServerPasswordSet2 requires (MS-NRPC §3.4.5.2.6).
+//
+// The cleartext buffer layout (NL_TRUST_PASSWORD, §2.2.1.3.7):
+//   - Buffer: 256 UTF-16 code units (512 bytes). The password's UTF-16LE bytes
+//     occupy the tail; the leading bytes are random filler.
+//   - Length: the password length in BYTES (UTF-16LE), placed in the trailing
+//     uint32 of the encrypted structure.
+//
+// The whole 516-byte structure (512-byte buffer + 4-byte length) is encrypted
+// with the session key. go-msrpc marshals Buffer ([]uint16) then Length
+// (uint32), and the secure channel's Encrypt covers exactly those bytes, so we
+// encrypt the marshalled bytes ourselves and hand the cipher back as the
+// TrustPassword.
+func buildTrustPassword(ctx context.Context, enc encryptor, password string) (*logon.TrustPassword, error) {
+	codes := utf16.Encode([]rune(password))
+	pwBytes := len(codes) * 2
+	if len(codes) > trustPasswordBufferRunes {
+		return nil, fmt.Errorf("netlogon: machine password too long (%d > %d UTF-16 chars)", len(codes), trustPasswordBufferRunes)
+	}
+
+	// 512-byte cleartext buffer: random filler at the front, password UTF-16LE
+	// at the tail.
+	clear := make([]byte, trustPasswordBufferRunes*2+4)
+	if _, err := rand.Read(clear[:trustPasswordBufferRunes*2]); err != nil {
+		return nil, fmt.Errorf("netlogon: trust password filler: %w", err)
+	}
+	off := trustPasswordBufferRunes*2 - pwBytes
+	for i, c := range codes {
+		clear[off+i*2] = byte(c)
+		clear[off+i*2+1] = byte(c >> 8)
+	}
+	// Trailing length (bytes) little-endian.
+	l := uint32(pwBytes)
+	clear[trustPasswordBufferRunes*2+0] = byte(l)
+	clear[trustPasswordBufferRunes*2+1] = byte(l >> 8)
+	clear[trustPasswordBufferRunes*2+2] = byte(l >> 16)
+	clear[trustPasswordBufferRunes*2+3] = byte(l >> 24)
+
+	cipher, err := enc.Encrypt(ctx, clear)
+	if err != nil {
+		return nil, fmt.Errorf("netlogon: encrypt trust password: %w", err)
+	}
+	if len(cipher) != len(clear) {
+		return nil, fmt.Errorf("netlogon: encrypted trust password length %d != %d", len(cipher), len(clear))
+	}
+
+	// Re-split the ciphertext into the Buffer ([]uint16) + Length (uint32) the
+	// marshaller expects.
+	buf := make([]uint16, trustPasswordBufferRunes)
+	for i := 0; i < trustPasswordBufferRunes; i++ {
+		buf[i] = uint16(cipher[i*2]) | uint16(cipher[i*2+1])<<8
+	}
+	encLen := uint32(cipher[trustPasswordBufferRunes*2]) |
+		uint32(cipher[trustPasswordBufferRunes*2+1])<<8 |
+		uint32(cipher[trustPasswordBufferRunes*2+2])<<16 |
+		uint32(cipher[trustPasswordBufferRunes*2+3])<<24
+
+	return &logon.TrustPassword{Buffer: buf, Length: encLen}, nil
+}

--- a/internal/auth/netlogon/password.go
+++ b/internal/auth/netlogon/password.go
@@ -3,6 +3,7 @@ package netlogon
 import (
 	"context"
 	"crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"math/big"
 	"unicode/utf16"
@@ -87,18 +88,20 @@ func buildTrustPassword(ctx context.Context, enc encryptor, password string) (*l
 		clear[off+i*2+1] = byte(c >> 8)
 	}
 	// Trailing length (bytes) little-endian.
-	l := uint32(pwBytes)
-	clear[trustPasswordBufferRunes*2+0] = byte(l)
-	clear[trustPasswordBufferRunes*2+1] = byte(l >> 8)
-	clear[trustPasswordBufferRunes*2+2] = byte(l >> 16)
-	clear[trustPasswordBufferRunes*2+3] = byte(l >> 24)
+	binary.LittleEndian.PutUint32(clear[trustPasswordBufferRunes*2:], uint32(pwBytes))
 
 	cipher, err := enc.Encrypt(ctx, clear)
 	if err != nil {
 		return nil, fmt.Errorf("netlogon: encrypt trust password: %w", err)
 	}
 	if len(cipher) != len(clear) {
-		return nil, fmt.Errorf("netlogon: encrypted trust password length %d != %d", len(cipher), len(clear))
+		// The secure channel's Encrypt is length-preserving only for the AES-CFB
+		// path (CapAES_SHA2). On a legacy DES/RC4-negotiated channel go-msrpc's
+		// Encrypt returns a truncated block, which cannot carry the 512-byte
+		// password buffer — rotation is unsupported there. Modern AD/Samba always
+		// negotiate AES_SHA2, so fail fast with an actionable message rather than
+		// sending a malformed NL_TRUST_PASSWORD.
+		return nil, fmt.Errorf("netlogon: trust-password encryption is not length-preserving (%d != %d); the secure channel did not negotiate AES (CapAES_SHA2), so NetrServerPasswordSet2 rotation is unsupported on this channel", len(cipher), len(clear))
 	}
 
 	// Re-split the ciphertext into the Buffer ([]uint16) + Length (uint32) the
@@ -107,10 +110,7 @@ func buildTrustPassword(ctx context.Context, enc encryptor, password string) (*l
 	for i := 0; i < trustPasswordBufferRunes; i++ {
 		buf[i] = uint16(cipher[i*2]) | uint16(cipher[i*2+1])<<8
 	}
-	encLen := uint32(cipher[trustPasswordBufferRunes*2]) |
-		uint32(cipher[trustPasswordBufferRunes*2+1])<<8 |
-		uint32(cipher[trustPasswordBufferRunes*2+2])<<16 |
-		uint32(cipher[trustPasswordBufferRunes*2+3])<<24
+	encLen := binary.LittleEndian.Uint32(cipher[trustPasswordBufferRunes*2:])
 
 	return &logon.TrustPassword{Buffer: buf, Length: encLen}, nil
 }

--- a/internal/auth/netlogon/password_test.go
+++ b/internal/auth/netlogon/password_test.go
@@ -1,0 +1,94 @@
+package netlogon
+
+import (
+	"context"
+	"testing"
+	"unicode/utf16"
+
+	logon "github.com/oiweiwei/go-msrpc/msrpc/nrpc/logon/v1"
+)
+
+func TestGenerateMachinePassword(t *testing.T) {
+	seen := map[string]struct{}{}
+	for i := 0; i < 100; i++ {
+		p, err := generateMachinePassword()
+		if err != nil {
+			t.Fatalf("generate: %v", err)
+		}
+		if len(p) != machinePasswordLen {
+			t.Fatalf("length = %d, want %d", len(p), machinePasswordLen)
+		}
+		for _, c := range p {
+			if !containsRune(machinePasswordAlphabet, c) {
+				t.Fatalf("password contains out-of-alphabet rune %q", c)
+			}
+		}
+		if _, dup := seen[p]; dup {
+			t.Fatalf("generated a duplicate password in %d tries (not random)", i)
+		}
+		seen[p] = struct{}{}
+	}
+}
+
+// identityEncryptor is a no-op encryptor: Encrypt returns the cleartext
+// unchanged so the test can decode the NL_TRUST_PASSWORD buffer back to the
+// original password and verify the byte layout.
+type identityEncryptor struct{}
+
+func (identityEncryptor) Encrypt(_ context.Context, b []byte) ([]byte, error) {
+	out := make([]byte, len(b))
+	copy(out, b)
+	return out, nil
+}
+func (identityEncryptor) SetAuthenticators(context.Context, **logon.Authenticator, **logon.Authenticator) error {
+	return nil
+}
+func (identityEncryptor) VerifyAuthenticator(context.Context, *logon.Authenticator) error { return nil }
+
+func TestBuildTrustPassword_Layout(t *testing.T) {
+	const pw = "Hello-World_123"
+	tp, err := buildTrustPassword(context.Background(), identityEncryptor{}, pw)
+	if err != nil {
+		t.Fatalf("buildTrustPassword: %v", err)
+	}
+
+	wantLen := uint32(len([]rune(pw)) * 2)
+	if tp.Length != wantLen {
+		t.Fatalf("Length = %d, want %d (UTF-16 bytes)", tp.Length, wantLen)
+	}
+	if len(tp.Buffer) != trustPasswordBufferRunes {
+		t.Fatalf("Buffer len = %d, want %d", len(tp.Buffer), trustPasswordBufferRunes)
+	}
+
+	// The password sits at the TAIL of the buffer; decode it back.
+	pwRunes := utf16.Encode([]rune(pw))
+	off := trustPasswordBufferRunes - len(pwRunes)
+	for i, want := range pwRunes {
+		if tp.Buffer[off+i] != want {
+			t.Fatalf("buffer[%d] = %04x, want %04x", off+i, tp.Buffer[off+i], want)
+		}
+	}
+	decoded := string(utf16.Decode(tp.Buffer[off:]))
+	if decoded != pw {
+		t.Fatalf("decoded tail = %q, want %q", decoded, pw)
+	}
+}
+
+func TestBuildTrustPassword_TooLong(t *testing.T) {
+	long := make([]rune, trustPasswordBufferRunes+1)
+	for i := range long {
+		long[i] = 'a'
+	}
+	if _, err := buildTrustPassword(context.Background(), identityEncryptor{}, string(long)); err == nil {
+		t.Fatal("expected error for over-long password")
+	}
+}
+
+func containsRune(s string, r rune) bool {
+	for _, c := range s {
+		if c == r {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/auth/netlogon/secretstore.go
+++ b/internal/auth/netlogon/secretstore.go
@@ -1,0 +1,20 @@
+package netlogon
+
+import "context"
+
+// SecretStore persists the machine-account password across restarts for the
+// online-join provider. It is a deliberately tiny surface (a scoped key/value
+// pair) so the netlogon package never imports the control-plane store directly;
+// cmd/dfs adapts the GORM-backed SettingsStore to this interface.
+//
+// The stored value is the machine-account password in cleartext. It is no more
+// sensitive than the offline provider's config-supplied secret (which lives in
+// the same DB / config), and it MUST round-trip byte-for-byte: NETLOGON derives
+// the session key from it, so any transformation would break the secure channel.
+type SecretStore interface {
+	// GetMachineSecret returns the persisted machine password, or "" (no error)
+	// when none has been stored yet (first boot before a join).
+	GetMachineSecret(ctx context.Context) (string, error)
+	// SetMachineSecret persists the machine password, overwriting any prior value.
+	SetMachineSecret(ctx context.Context, secret string) error
+}

--- a/internal/auth/netlogon/securechannel.go
+++ b/internal/auth/netlogon/securechannel.go
@@ -208,8 +208,16 @@ func (sc *SecureChannel) setPassword(ctx context.Context, mc MachineCredential, 
 		return err
 	}
 
+	// PrimaryName is the DC's UNC name. Mirror samLogon's fallback so a failed
+	// GetDCName in connect() (which leaves sc.dcName empty) does not send an empty
+	// PrimaryName that the DC would reject.
+	primaryName := sc.dcName
+	if primaryName == "" {
+		primaryName = "\\\\" + mc.DomainName
+	}
+
 	req := &logon.PasswordSet2Request{
-		PrimaryName:       sc.dcName,
+		PrimaryName:       primaryName,
 		AccountName:       mc.AccountName,
 		SecureChannelType: logon.SecureChannelTypeWorkstationSecureChannel,
 		ComputerName:      mc.Workstation,

--- a/internal/auth/netlogon/securechannel.go
+++ b/internal/auth/netlogon/securechannel.go
@@ -178,6 +178,67 @@ func (sc *SecureChannel) connect(ctx context.Context, mc MachineCredential) erro
 	return nil
 }
 
+// setPassword changes the machine account's password on the DC via
+// NetrServerPasswordSet2 (MS-NRPC §3.5.4.4.6), reusing the already-established
+// sealed secure channel. sc.mu is held for the full RPC so it serializes with
+// samLogon and close/reset, exactly like samLogon.
+//
+// PasswordSet2 is NOT one of the methods the go-msrpc secure-channel client
+// auto-wraps with the per-call NETLOGON authenticator dance, so we drive it
+// manually: type-assert the client to the exported Encrypt/SetAuthenticators/
+// VerifyAuthenticator method set, build the encrypted NL_TRUST_PASSWORD, fill
+// the request authenticator, call, and verify the return authenticator.
+func (sc *SecureChannel) setPassword(ctx context.Context, mc MachineCredential, newPassword string) error {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	if sc.cli == nil {
+		return fmt.Errorf("netlogon: channel not connected")
+	}
+
+	enc, ok := sc.cli.(encryptor)
+	if !ok {
+		// Defensive: the concrete go-msrpc secure-channel client always exposes
+		// these methods; a future refactor that hides them would land here.
+		return fmt.Errorf("netlogon: secure channel client does not expose authenticator/encrypt methods required for PasswordSet2")
+	}
+
+	trustPwd, err := buildTrustPassword(ctx, enc, newPassword)
+	if err != nil {
+		return err
+	}
+
+	req := &logon.PasswordSet2Request{
+		PrimaryName:       sc.dcName,
+		AccountName:       mc.AccountName,
+		SecureChannelType: logon.SecureChannelTypeWorkstationSecureChannel,
+		ComputerName:      mc.Workstation,
+		ClearNewPassword:  trustPwd,
+	}
+	// Fill req.Authenticator (and allocate the holder for the return authenticator).
+	var ret *logon.Authenticator
+	if err := enc.SetAuthenticators(ctx, &req.Authenticator, &ret); err != nil {
+		return fmt.Errorf("netlogon: PasswordSet2 authenticator: %w", err)
+	}
+
+	out, err := sc.cli.PasswordSet2(ctx, req)
+	if err != nil {
+		return fmt.Errorf("netlogon: PasswordSet2: %w", err)
+	}
+	if out.Return != 0 {
+		return fmt.Errorf("netlogon: PasswordSet2 returned 0x%08x", uint32(out.Return))
+	}
+	// Verify the server's return authenticator to confirm the DC, not a MITM,
+	// processed the call with our session key.
+	if out.ReturnAuthenticator == nil || out.ReturnAuthenticator.Credential == nil {
+		return fmt.Errorf("netlogon: PasswordSet2 missing return authenticator")
+	}
+	if err := enc.VerifyAuthenticator(ctx, out.ReturnAuthenticator); err != nil {
+		return fmt.Errorf("netlogon: PasswordSet2 return authenticator verify: %w", err)
+	}
+	return nil
+}
+
 // close tears down the cached connection.  Must be called with sc.mu held.
 func (sc *SecureChannel) close(ctx context.Context) {
 	if sc.cc != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -334,6 +334,88 @@ type MachineAccountConfig struct {
 
 	// DCAddresses is a list of domain controller addresses.
 	DCAddresses []string `mapstructure:"dc_address" yaml:"dc_address"`
+
+	// OnlineJoin configures online creation + rotation of the machine account.
+	// Opt-in: when disabled (the default), the machine credential is supplied
+	// offline via AccountName+Secret as before.
+	OnlineJoin OnlineJoinConfig `mapstructure:"online_join" yaml:"online_join"`
+}
+
+// OnlineJoinConfig configures the online-join machine-credential provider, which
+// creates the computer object in Active Directory over LDAP, owns the
+// machine-password lifecycle (initial set + periodic rotation via
+// NetrServerPasswordSet2), and persists the rotated secret in the control-plane
+// DB so it survives restarts.
+//
+// Online join is OPT-IN. When Enabled is false the offline provider is used:
+// an admin pre-provisions the computer account and supplies Secret/KeytabPath.
+type OnlineJoinConfig struct {
+	// Enabled turns on the online-join provider. When false the offline provider
+	// (static AccountName+Secret) is used.
+	Enabled bool `mapstructure:"enabled" yaml:"enabled"`
+
+	// LDAPURL is the directory URL used to write the computer object, e.g.
+	// "ldaps://dc.dittofs.ad" (preferred) or "ldap://dc.dittofs.ad" with
+	// StartTLS. AD refuses the machine-password write over an unencrypted
+	// connection, so one of LDAPS or StartTLS is required.
+	LDAPURL string `mapstructure:"ldap_url" yaml:"ldap_url"`
+
+	// StartTLS upgrades a plaintext ldap:// join connection to TLS before
+	// binding. Ignored for ldaps://.
+	StartTLS bool `mapstructure:"start_tls" yaml:"start_tls"`
+
+	// BindDN / BindPassword are the privileged "join" credentials: an account
+	// permitted to create computer objects in the target OU (a Domain Admin, or
+	// a delegated account). Used only at join time, never persisted.
+	BindDN       string `mapstructure:"bind_dn" yaml:"bind_dn"`
+	BindPassword string `mapstructure:"bind_password" yaml:"bind_password"`
+
+	// BaseDN is the domain naming context, e.g. "DC=dittofs,DC=ad".
+	BaseDN string `mapstructure:"base_dn" yaml:"base_dn"`
+
+	// OU is the optional container DN for the computer object, e.g.
+	// "OU=Servers,DC=dittofs,DC=ad". When empty, CN=Computers,<BaseDN> is used.
+	OU string `mapstructure:"ou" yaml:"ou"`
+
+	// DNSHostName is the FQDN stamped on the computer object (e.g.
+	// "dittofs.dittofs.ad"). Optional.
+	DNSHostName string `mapstructure:"dns_host_name" yaml:"dns_host_name"`
+
+	// SPNs are optional servicePrincipalName values to register on the account
+	// (e.g. "cifs/dittofs.dittofs.ad").
+	SPNs []string `mapstructure:"spns" yaml:"spns"`
+
+	// RotationInterval is how often the machine password is rotated. Zero
+	// disables rotation. AD's default machine-password max age is 30 days.
+	RotationInterval time.Duration `mapstructure:"rotation_interval" yaml:"rotation_interval"`
+
+	// CACertFile is an optional PEM CA bundle used to verify the LDAP server
+	// certificate for the join connection.
+	CACertFile string `mapstructure:"ca_cert_file" yaml:"ca_cert_file"`
+
+	// InsecureSkipVerify disables LDAP server-certificate verification for the
+	// join connection. Lab use only.
+	InsecureSkipVerify bool `mapstructure:"insecure_skip_verify" yaml:"insecure_skip_verify"`
+}
+
+// MarshalYAML redacts the join bind password when serialized for display.
+func (c OnlineJoinConfig) MarshalYAML() (interface{}, error) {
+	type alias OnlineJoinConfig
+	out := alias(c)
+	if out.BindPassword != "" {
+		out.BindPassword = redactedSecret
+	}
+	return out, nil
+}
+
+// MarshalJSON redacts the join bind password when serialized for display.
+func (c OnlineJoinConfig) MarshalJSON() ([]byte, error) {
+	type alias OnlineJoinConfig
+	out := alias(c)
+	if out.BindPassword != "" {
+		out.BindPassword = redactedSecret
+	}
+	return json.Marshal(out)
 }
 
 // MarshalYAML redacts the machine account secret when the config is serialized
@@ -490,6 +572,42 @@ func (c *KerberosConfig) Validate() error {
 		if strings.ContainsAny(c.DNSDomain, "@/ ") {
 			return fmt.Errorf("kerberos.dns_domain %q is invalid (must not contain '@', '/', or spaces; e.g. contoso.com)", c.DNSDomain)
 		}
+	}
+	if err := c.MachineAccount.OnlineJoin.Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Validate checks the online-join configuration for internal consistency
+// (fail-fast, no network I/O). Only enforced when Enabled.
+func (c *OnlineJoinConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	scheme := strings.ToLower(strings.TrimSpace(c.LDAPURL))
+	switch {
+	case scheme == "":
+		return fmt.Errorf("kerberos.machine_account.online_join.ldap_url is required when online_join is enabled")
+	case strings.HasPrefix(scheme, "ldaps://"):
+	case strings.HasPrefix(scheme, "ldap://"):
+		if !c.StartTLS {
+			return fmt.Errorf("kerberos.machine_account.online_join.ldap_url uses plaintext ldap://; set start_tls=true (AD refuses to set a machine password over an unencrypted connection)")
+		}
+	default:
+		return fmt.Errorf("kerberos.machine_account.online_join.ldap_url must use ldap:// or ldaps:// (got %q)", c.LDAPURL)
+	}
+	if strings.TrimSpace(c.BindDN) == "" {
+		return fmt.Errorf("kerberos.machine_account.online_join.bind_dn is required (a privileged account that can create computer objects)")
+	}
+	if c.BindPassword == "" {
+		return fmt.Errorf("kerberos.machine_account.online_join.bind_password is required")
+	}
+	if strings.TrimSpace(c.BaseDN) == "" {
+		return fmt.Errorf("kerberos.machine_account.online_join.base_dn is required")
+	}
+	if c.RotationInterval < 0 {
+		return fmt.Errorf("kerberos.machine_account.online_join.rotation_interval must be >= 0 (got %v; 0 disables rotation)", c.RotationInterval)
 	}
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -585,12 +585,12 @@ func (c *OnlineJoinConfig) Validate() error {
 	if !c.Enabled {
 		return nil
 	}
-	scheme := strings.ToLower(strings.TrimSpace(c.LDAPURL))
+	lower := strings.ToLower(strings.TrimSpace(c.LDAPURL))
 	switch {
-	case scheme == "":
+	case lower == "":
 		return fmt.Errorf("kerberos.machine_account.online_join.ldap_url is required when online_join is enabled")
-	case strings.HasPrefix(scheme, "ldaps://"):
-	case strings.HasPrefix(scheme, "ldap://"):
+	case strings.HasPrefix(lower, "ldaps://"):
+	case strings.HasPrefix(lower, "ldap://"):
 		if !c.StartTLS {
 			return fmt.Errorf("kerberos.machine_account.online_join.ldap_url uses plaintext ldap://; set start_tls=true (AD refuses to set a machine password over an unencrypted connection)")
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -573,6 +573,13 @@ func (c *KerberosConfig) Validate() error {
 			return fmt.Errorf("kerberos.dns_domain %q is invalid (must not contain '@', '/', or spaces; e.g. contoso.com)", c.DNSDomain)
 		}
 	}
+	// Fail fast on a misconfiguration that would otherwise be silently ignored:
+	// online-join lives under the machine_account block, so it has no effect
+	// unless the parent is enabled (buildNetlogonAuthenticator returns nil when
+	// machine_account.enabled=false).
+	if c.MachineAccount.OnlineJoin.Enabled && !c.MachineAccount.Enabled {
+		return fmt.Errorf("kerberos.machine_account.online_join.enabled=true requires kerberos.machine_account.enabled=true (online join has no effect while the machine account is disabled)")
+	}
 	if err := c.MachineAccount.OnlineJoin.Validate(); err != nil {
 		return err
 	}

--- a/test/integration/ad-dc/online_join_test.go
+++ b/test/integration/ad-dc/online_join_test.go
@@ -51,6 +51,34 @@ func (m *memSecret) SetMachineSecret(_ context.Context, s string) error {
 	return nil
 }
 
+// waitForDCStable blocks until the DC's NETLOGON/LDAP/KDC stack has been
+// continuously serving for a short streak, riding out the entrypoint's
+// provisioning-samba -> foreground-samba re-exec. It requires several
+// consecutive successful `samba-tool processes` calls AND a reachable DNS (53)
+// + SMB (445), since the secure channel and DC discovery use both.
+func waitForDCStable(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	const needStreak = 4
+	deadline := time.Now().Add(timeout)
+	streak := 0
+	for time.Now().Before(deadline) {
+		ok := exec.Command("docker", "exec", adContainerName, "samba-tool", "processes").Run() == nil
+		if ok {
+			streak++
+			if streak >= needStreak {
+				t.Logf("AD-DC stable (%d consecutive readiness checks)", streak)
+				time.Sleep(2 * time.Second) // small extra settle
+				return
+			}
+		} else {
+			streak = 0
+		}
+		time.Sleep(2 * time.Second)
+	}
+	dumpADLogs(t)
+	t.Fatalf("AD-DC did not stabilize within %s", timeout)
+}
+
 // TestOnlineJoinAndMemberLogon proves the full online-join lifecycle live:
 //  1. The online provider creates the DITTOJOIN$ computer object over LDAP
 //     (StartTLS) using the Administrator join credentials and sets its password.
@@ -76,6 +104,16 @@ func TestOnlineJoinAndMemberLogon(t *testing.T) {
 	waitForTCPAddr(t, dcIP+":135", 90*time.Second)
 	waitForTCPAddr(t, dcIP+":445", 90*time.Second)
 	waitForTCPAddr(t, dcIP+":389", 90*time.Second)
+
+	// The fixture entrypoint provisions the domain, exports the keytab, then
+	// STOPS the provisioning samba and re-execs it in the foreground. setupADDC
+	// returns as soon as the keytab exists — i.e. right at that restart. Driving a
+	// NETLOGON SamLogon through the just-joined account during that window yields
+	// transient DNS/SMB failures (connection refused on :53, "logon is invalid"
+	// on the SMB bind). Gate on the DC being CONTINUOUSLY ready (samba-tool
+	// processes succeeds several times in a row) so join + logon run against a
+	// stable DC, not the restart window.
+	waitForDCStable(t, 4*time.Minute)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
@@ -134,13 +172,21 @@ func TestOnlineJoinAndMemberLogon(t *testing.T) {
 		t.Fatal("persisted secret does not match the credential password")
 	}
 
-	// Confirm the computer object now exists in AD.
-	out, lerr := exec.Command("docker", "exec", adContainerName,
-		"samba-tool", "computer", "list").CombinedOutput()
-	if lerr != nil {
-		t.Fatalf("samba-tool computer list: %v\n%s", lerr, out)
+	// Confirm the computer object now exists in AD (best-effort: the entrypoint
+	// re-execs samba into the foreground shortly after provisioning, so a
+	// concurrent `docker exec` can be SIGTERM'd — that is informational only and
+	// must not fail the test, which proves the join via the live logon below).
+	if out, lerr := exec.Command("docker", "exec", adContainerName,
+		"samba-tool", "computer", "list").CombinedOutput(); lerr != nil {
+		t.Logf("samba-tool computer list (non-fatal): %v\n%s", lerr, out)
+	} else {
+		t.Logf("AD computer list after join:\n%s", out)
 	}
-	t.Logf("AD computer list after join:\n%s", out)
+
+	// Give the DC a moment to settle the freshly-set machine credential before
+	// driving a NETLOGON SamLogon through it (Samba caches credentials briefly
+	// after a password change).
+	time.Sleep(5 * time.Second)
 
 	// Now prove a member logon through the freshly-joined account: validate
 	// alice's NTLMv2 response over the NETLOGON secure channel authenticated with
@@ -148,12 +194,21 @@ func TestOnlineJoinAndMemberLogon(t *testing.T) {
 	serverChallenge := [8]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88}
 	clientNonce := []byte{0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB}
 
+	// MsvAvNbComputerName MUST equal the NETLOGON secure-channel's NetBIOS
+	// computer name (= the joined workstation, "DITTOJOIN"), NOT the domain name.
+	// Samba's CVE-2022-38023 mitigation (NTLMv2_RESPONSE_verify_netlogon_creds,
+	// MS-NRPC §3.5.4.5.1) parses this AV-pair out of the NTLMv2 NT-response blob
+	// and rejects the SamLogon with STATUS_LOGON_FAILURE *before* authenticating
+	// the user when it does not match the channel computer. In production DittoFS
+	// advertises exactly this name in its NTLM Type-2 (SetADDomain → the
+	// netbiosWorkstation name, the #1357 invariant), so a real domain client's
+	// response always carries the matching value; the test must mirror that.
 	v2 := &ntlm.V2{Config: &ntlm.Config{}}
 	cm := &ntlm.ChallengeMessage{
 		ServerChallenge: serverChallenge[:],
 		TargetInfo: ntlm.AttrValues{
 			ntlm.AttrNetBIOSDomainName:   &ntlm.Value{NetBIOSDomainName: adDomain},
-			ntlm.AttrNetBIOSComputerName: &ntlm.Value{NetBIOSComputerName: adDomain},
+			ntlm.AttrNetBIOSComputerName: &ntlm.Value{NetBIOSComputerName: onlineJoinMachineName},
 		},
 	}
 	aliceCred := credential.NewFromPassword(adDomain+"\\"+adUserAlice, adUserPass)
@@ -163,7 +218,7 @@ func TestOnlineJoinAndMemberLogon(t *testing.T) {
 	}
 
 	var res *netlogon.LogonResult
-	for attempt := 1; attempt <= 5; attempt++ {
+	for attempt := 1; attempt <= 10; attempt++ {
 		res, err = auth.NetworkLogon(ctx, netlogon.NetworkLogonRequest{
 			Username:        adUserAlice,
 			Domain:          adDomain,
@@ -174,8 +229,8 @@ func TestOnlineJoinAndMemberLogon(t *testing.T) {
 		if err == nil {
 			break
 		}
-		t.Logf("NetworkLogon attempt %d/5 via online-joined account: %v", attempt, err)
-		time.Sleep(2 * time.Second)
+		t.Logf("NetworkLogon attempt %d/10 via online-joined account: %v", attempt, err)
+		time.Sleep(3 * time.Second)
 	}
 	if err != nil {
 		dumpADLogs(t)

--- a/test/integration/ad-dc/online_join_test.go
+++ b/test/integration/ad-dc/online_join_test.go
@@ -1,0 +1,193 @@
+//go:build ad_dc
+
+// Online-join integration test (#1323): the online MachineCredentialProvider
+// creates a FRESH computer account in the Samba AD-DC over LDAP (no admin
+// pre-provisioning), owns its machine password, and the NETLOGON secure channel
+// authenticated with that just-created account validates a real domain user's
+// NTLMv2 logon (member logon through the online-joined account).
+//
+// This is the online counterpart to TestNetlogonPassthroughAlice, which uses the
+// admin-pre-provisioned DITTOFS$ account (offline provider). Here nothing is
+// pre-provisioned: the provider does the `net ads join` equivalent itself.
+//
+// Run with: go test -tags=ad_dc -v -timeout 20m -run TestOnlineJoin ./test/integration/ad-dc/
+// Requires Docker + host-routable container IP (CI Linux), like the other
+// NETLOGON tests (EPM port 135 + dynamic RPC + 445 must be reachable without NAT).
+package ad_dc_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/auth/netlogon"
+	"github.com/oiweiwei/go-msrpc/ssp/credential"
+	"github.com/oiweiwei/go-msrpc/ssp/ntlm"
+
+	"os/exec"
+)
+
+// onlineJoinMachineName is a DISTINCT computer name from the fixture's
+// pre-provisioned DITTOFS$, so the online join creates a genuinely new account.
+const onlineJoinMachineName = "DITTOJOIN"
+
+// memSecret is an in-memory netlogon.SecretStore for the integration test.
+type memSecret struct {
+	mu  sync.Mutex
+	val string
+}
+
+func (m *memSecret) GetMachineSecret(context.Context) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.val, nil
+}
+func (m *memSecret) SetMachineSecret(_ context.Context, s string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.val = s
+	return nil
+}
+
+// TestOnlineJoinAndMemberLogon proves the full online-join lifecycle live:
+//  1. The online provider creates the DITTOJOIN$ computer object over LDAP
+//     (StartTLS) using the Administrator join credentials and sets its password.
+//  2. The credential is persisted in the in-memory secret store.
+//  3. A NETLOGON secure channel authenticated with the freshly-joined account
+//     validates alice's NTLMv2 network logon and returns her SID + groups.
+func TestOnlineJoinAndMemberLogon(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping online-join integration test in short mode")
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not found, skipping online-join test")
+	}
+
+	// Start the AD-DC fixture (reuses setupADDC from ad_dc_integration_test.go).
+	_, _, _, cleanup := setupADDC(t)
+	defer cleanup()
+
+	dcIP := getContainerIP(t)
+	t.Logf("AD-DC container IP: %s", dcIP)
+
+	// NETLOGON needs EPM (135) + SMB (445); LDAP join needs 389 (StartTLS).
+	waitForTCPAddr(t, dcIP+":135", 90*time.Second)
+	waitForTCPAddr(t, dcIP+":445", 90*time.Second)
+	waitForTCPAddr(t, dcIP+":389", 90*time.Second)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	secret := &memSecret{}
+
+	// Online-join config: create DITTOJOIN$ over StartTLS against the DC's LDAP,
+	// binding as the domain Administrator (which can create computer objects).
+	// The DC's self-signed cert is accepted via InsecureSkipVerify (lab fixture).
+	cfg := netlogon.OnlineConfig{
+		AccountName: onlineJoinMachineName + "$",
+		Workstation: onlineJoinMachineName,
+		DomainName:  adDomain,
+		Realm:       adRealm,
+		DCAddresses: []string{dcIP},
+		Join: netlogon.JoinConfig{
+			LDAPURL:      fmt.Sprintf("ldap://%s:389", dcIP),
+			StartTLS:     true,
+			BindDN:       adBindDN,
+			BindPassword: adAdminPassword,
+			BaseDN:       adBaseDN,
+			MachineName:  onlineJoinMachineName,
+			DNSHostName:  fmt.Sprintf("%s.%s", onlineJoinMachineName, "dittofs.ad"),
+			SPNs:         []string{"HOST/" + onlineJoinMachineName + ".dittofs.ad"},
+			TLS:          netlogon.JoinTLSConfig{InsecureSkipVerify: true},
+		},
+	}
+
+	provider := netlogon.NewOnlineProvider(cfg, secret)
+	auth := netlogon.NewAuthenticator(provider)
+	defer auth.Close(ctx)
+
+	// First Credential() triggers the online join (create computer + set pwd +
+	// persist). Retry: the DC re-execs samba into the foreground shortly after
+	// provisioning, so LDAP/SMB have a brief down window.
+	var cred *netlogon.MachineCredential
+	var err error
+	for attempt := 1; attempt <= 15; attempt++ {
+		cred, err = provider.Credential(ctx)
+		if err == nil {
+			break
+		}
+		t.Logf("online join attempt %d/15 not ready: %v", attempt, err)
+		time.Sleep(3 * time.Second)
+	}
+	if err != nil {
+		dumpADLogs(t)
+		t.Fatalf("online join failed after retries: %v", err)
+	}
+	t.Logf("online join complete: account=%q password_len=%d", cred.AccountName, len(cred.Password))
+
+	if secret.val == "" {
+		t.Fatal("expected machine password to be persisted after join")
+	}
+	if secret.val != cred.Password {
+		t.Fatal("persisted secret does not match the credential password")
+	}
+
+	// Confirm the computer object now exists in AD.
+	out, lerr := exec.Command("docker", "exec", adContainerName,
+		"samba-tool", "computer", "list").CombinedOutput()
+	if lerr != nil {
+		t.Fatalf("samba-tool computer list: %v\n%s", lerr, out)
+	}
+	t.Logf("AD computer list after join:\n%s", out)
+
+	// Now prove a member logon through the freshly-joined account: validate
+	// alice's NTLMv2 response over the NETLOGON secure channel authenticated with
+	// DITTOJOIN$.
+	serverChallenge := [8]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88}
+	clientNonce := []byte{0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB}
+
+	v2 := &ntlm.V2{Config: &ntlm.Config{}}
+	cm := &ntlm.ChallengeMessage{
+		ServerChallenge: serverChallenge[:],
+		TargetInfo: ntlm.AttrValues{
+			ntlm.AttrNetBIOSDomainName:   &ntlm.Value{NetBIOSDomainName: adDomain},
+			ntlm.AttrNetBIOSComputerName: &ntlm.Value{NetBIOSComputerName: adDomain},
+		},
+	}
+	aliceCred := credential.NewFromPassword(adDomain+"\\"+adUserAlice, adUserPass)
+	resp, cerr := v2.ChallengeResponse(ctx, aliceCred, cm, clientNonce)
+	if cerr != nil {
+		t.Fatalf("compute alice NTLMv2 response: %v", cerr)
+	}
+
+	var res *netlogon.LogonResult
+	for attempt := 1; attempt <= 5; attempt++ {
+		res, err = auth.NetworkLogon(ctx, netlogon.NetworkLogonRequest{
+			Username:        adUserAlice,
+			Domain:          adDomain,
+			ServerChallenge: serverChallenge,
+			NTResponse:      resp.NT,
+			LMResponse:      resp.LM,
+		})
+		if err == nil {
+			break
+		}
+		t.Logf("NetworkLogon attempt %d/5 via online-joined account: %v", attempt, err)
+		time.Sleep(2 * time.Second)
+	}
+	if err != nil {
+		dumpADLogs(t)
+		t.Fatalf("member logon via online-joined account failed: %v", err)
+	}
+
+	t.Logf("member logon via online-joined account succeeded: user=%q user_sid=%q groups=%v",
+		res.Username, res.UserSID, res.GroupSIDs)
+	if res.UserSID == "" {
+		t.Error("expected non-empty UserSID from DC")
+	}
+	if len(res.GroupSIDs) == 0 {
+		t.Error("expected at least one GroupSID from DC")
+	}
+}

--- a/test/integration/ad-dc/online_join_test.go
+++ b/test/integration/ad-dc/online_join_test.go
@@ -18,6 +18,7 @@ package ad_dc_test
 import (
 	"context"
 	"fmt"
+	"os/exec"
 	"sync"
 	"testing"
 	"time"
@@ -25,8 +26,6 @@ import (
 	"github.com/marmos91/dittofs/internal/auth/netlogon"
 	"github.com/oiweiwei/go-msrpc/ssp/credential"
 	"github.com/oiweiwei/go-msrpc/ssp/ntlm"
-
-	"os/exec"
 )
 
 // onlineJoinMachineName is a DISTINCT computer name from the fixture's


### PR DESCRIPTION
## Summary

Implements the **online-join** `MachineCredentialProvider` for NETLOGON NTLM passthrough (the follow-up to #1314). The offline provider stays the **default**; online-join is **opt-in** via `kerberos.machine_account.online_join.enabled`. `SecureChannel` / `Authenticator` contracts are unchanged — the new provider slots in as a second implementation exactly as the interface was designed for.

Closes #1323.

## What it does

- **Creates the machine account in AD** (`net ads join` equivalent) over LDAP: binds with privileged join credentials (LDAPS or StartTLS — AD refuses an unencrypted `unicodePwd` write), creates the `computer` object under the configured OU (or `CN=Computers`), sets `userAccountControl=WORKSTATION_TRUST_ACCOUNT` + `msDS-SupportedEncryptionTypes` (so the NETLOGON channel negotiates AES), optional `dNSHostName`/SPNs, and sets the initial password via `unicodePwd`. Idempotent: an existing object is reconciled (password reset) — the re-join path after a lost secret.
- **Owns the machine-password lifecycle**: generates a strong random initial password; rotates periodically via MS-NRPC `NetrServerPasswordSet2` (`RotationManager`). The NL_TRUST_PASSWORD buffer is built per MS-NRPC §3.4.5.2.6 and encrypted with the secure channel's session key.
- **Persists the rotated secret** in the control-plane settings store (`netlogon.SecretStore` adapter over the GORM `SettingsStore`), so the account survives restarts without re-joining. Join credentials are sourced from file/env only and are never written to the DB or exposed over REST.

## Key files
- `internal/auth/netlogon/online.go` — `onlineProvider` + `RotationManager`
- `internal/auth/netlogon/join.go` — LDAP computer-object create + `unicodePwd`
- `internal/auth/netlogon/password.go` — password gen + NL_TRUST_PASSWORD buffer
- `internal/auth/netlogon/securechannel.go` — `setPassword` (PasswordSet2 over the schannel)
- `internal/auth/netlogon/authenticator.go` — `RotatePassword`
- `internal/auth/netlogon/secretstore.go` — `SecretStore` interface
- `pkg/config/config.go` — `OnlineJoinConfig` (+ validation, secret redaction)
- `cmd/dfs/commands/{netlogon,start}.go` — wiring + DB-backed secret store

## Testing

`go build ./... && go vet ./... && go test ./...` clean. New unit tests cover the join (mocked LDAP), the NL_TRUST_PASSWORD layout (no-op encryptor), password generation, and the provider lifecycle (join / reuse-on-restart / persist-failure / rotation-manager nil-safety).

### Live AD-DC integration test (PASS)

`TestOnlineJoinAndMemberLogon` (`ad_dc` build tag) against the dockerized Samba AD-DC: it JOINS a fresh `DITTOJOIN$` computer account online over LDAP, persists the secret, then proves a **member logon** for the AD user `alice` through the just-joined account's NETLOGON secure channel.

```
online_join_test.go:166: online join complete: account="DITTOJOIN$" password_len=64
online_join_test.go:240: member logon via online-joined account succeeded: user="alice" user_sid="S-1-5-21-3183869514-2930680146-759475578-1105" groups=[...513 ...1104 ...1103]
--- PASS: TestOnlineJoinAndMemberLogon (40.89s)
ok  	github.com/marmos91/dittofs/test/integration/ad-dc	40.923s
```

(`TestNetlogonPassthroughAlice` continues to PASS in the same run.)

> Note: the test sets the NTLMv2 `MsvAvNbComputerName` to the joined workstation name, mirroring DittoFS's production SMB Type-2 invariant (#1357) — Samba's CVE-2022-38023 mitigation rejects a passthrough SamLogon whose blob computer name diverges from the secure-channel workstation. No production-code change was needed for this; it was a test-harness detail.
