### PR TITLE
fix(block): bound the read-through cache and stop re-uploading fetched chunks

### DIFF
--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -218,6 +218,9 @@ func (m *Syncer) fetchBlock(ctx context.Context, payloadID string, blockIdx uint
 	if err := m.local.Put(ctx, fb.Hash, data); err != nil {
 		return nil, fmt.Errorf("store downloaded block %s locally: %w", storeKey, err)
 	}
+	// The bytes came from remote, so the chunk is already durable there:
+	// cancel its redundant re-upload and make it immediately evictable (#1362).
+	m.markFetchedSynced(ctx, fb.Hash)
 
 	return data, nil
 }
@@ -406,6 +409,9 @@ func (m *Syncer) inlineFetchOrWait(ctx context.Context, payloadID string, blockI
 		completionErr = fmt.Errorf("inline fetch: persist locally %s: %w", key, writeErr)
 		return nil, false, completionErr
 	}
+	// The bytes came from remote, so the chunk is already durable there:
+	// cancel its redundant re-upload and make it immediately evictable (#1362).
+	m.markFetchedSynced(ctx, fb.Hash)
 	completed = true
 	m.completeInFlight(key, result, nil)
 

--- a/pkg/block/engine/read_cache_bench_test.go
+++ b/pkg/block/engine/read_cache_bench_test.go
@@ -1,0 +1,360 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	localfs "github.com/marmos91/dittofs/pkg/block/local/fs"
+	memorylocal "github.com/marmos91/dittofs/pkg/block/local/memory"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	metastore "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+	"lukechampine.com/blake3"
+)
+
+// latencyRemote wraps a remotememory.Store and (a) injects a fixed per-Get
+// WAN latency into the verified-read path the engine fetch code actually
+// calls (dispatchRemoteFetch → ReadBlockVerified), and (b) counts Get and Put
+// calls atomically. It models a high-latency remote tier (S3 / object store)
+// so a benchmark can show the warm (all-local) read path avoiding the injected
+// round-trip, and an invariant test can assert that a read-only workload
+// issues zero re-uploads (Put count 0) after the #1362 fix.
+//
+// The counters and latency are wrapped around ReadBlockVerified rather than
+// Get because dispatchRemoteFetch routes every block fetch through the
+// verified-read CAS path; Get is wrapped too for completeness.
+type latencyRemote struct {
+	*remotememory.Store
+	getLatency time.Duration
+	gets       atomic.Int64
+	puts       atomic.Int64
+}
+
+func newLatencyRemote(getLatency time.Duration) *latencyRemote {
+	return &latencyRemote{Store: remotememory.New(), getLatency: getLatency}
+}
+
+func (r *latencyRemote) ReadBlockVerified(ctx context.Context, hash, expected block.ContentHash) ([]byte, error) {
+	r.gets.Add(1)
+	if r.getLatency > 0 {
+		time.Sleep(r.getLatency)
+	}
+	return r.Store.ReadBlockVerified(ctx, hash, expected)
+}
+
+func (r *latencyRemote) Get(ctx context.Context, hash block.ContentHash) ([]byte, error) {
+	r.gets.Add(1)
+	if r.getLatency > 0 {
+		time.Sleep(r.getLatency)
+	}
+	return r.Store.Get(ctx, hash)
+}
+
+func (r *latencyRemote) Put(ctx context.Context, hash block.ContentHash, data []byte) error {
+	r.puts.Add(1)
+	return r.Store.Put(ctx, hash, data)
+}
+
+// Compile-time assertion that the latency wrapper still satisfies the full
+// remote contract the syncer depends on.
+var _ remote.RemoteStore = (*latencyRemote)(nil)
+
+// seedRemoteOnlyBlock seeds a single FileBlock row in BlockStateRemote and the
+// matching CAS bytes in the (latency) remote, WITHOUT placing the chunk in any
+// local store. A subsequent read of (payloadID, blockIdx 0) therefore misses
+// locally and fetches from the remote tier — the exact cold-read path #1362
+// bounds. Returns the chunk hash.
+func seedRemoteOnlyBlock(t testing.TB, fbs *stubFileBlockStore, rs interface {
+	Put(context.Context, block.ContentHash, []byte) error
+}, payloadID string, data []byte) block.ContentHash {
+	t.Helper()
+	hash := block.ContentHash(blake3.Sum256(data))
+	if err := rs.Put(context.Background(), hash, data); err != nil {
+		t.Fatalf("seed remote Put: %v", err)
+	}
+	fb := &block.FileBlock{
+		ID:       fmt.Sprintf("%s/%d", payloadID, 0),
+		Hash:     hash,
+		DataSize: uint32(len(data)),
+		State:    block.BlockStateRemote,
+	}
+	if err := fbs.Put(context.Background(), fb); err != nil {
+		t.Fatalf("seed FileBlock Put: %v", err)
+	}
+	return hash
+}
+
+// BenchmarkReadThroughCache_ColdVsWarm quantifies the benefit of the
+// read-through cache by comparing two regimes against a latency-injecting
+// remote:
+//
+//   - cold: every iteration reads a fresh, remote-only working set. Each block
+//     misses locally and pays the injected WAN round-trip (fetchBlock →
+//     ReadBlockVerified → time.Sleep).
+//   - warm: the working set is fetched ONCE up front, so every benchmarked read
+//     is served from the local store with no remote latency and no Get.
+//
+// The benchmark exercises the syncer's fetch+persist path (fetchBlock) — the
+// exact code that persists fetched chunks into the local CAS store and, after
+// #1362, marks them synced + bounds them. Reported MB/s (via b.SetBytes) shows
+// the warm path's throughput is dominated by local I/O, not the WAN latency.
+func BenchmarkReadThroughCache_ColdVsWarm(b *testing.B) {
+	const (
+		chunkSize  = 64 * 1024            // 64 KiB working-set chunk
+		wanLatency = 1 * time.Millisecond // injected per-Get round-trip
+	)
+	ctx := context.Background()
+
+	b.Run("cold", func(b *testing.B) {
+		b.SetBytes(chunkSize)
+		b.ReportAllocs()
+		for i := 0; b.Loop(); i++ {
+			// Fresh remote-only working set every iteration so each read is a
+			// genuine miss that pays the WAN latency.
+			loc := memorylocal.New()
+			rs := newLatencyRemote(wanLatency)
+			fbs := newStubFileBlockStore()
+			payloadID := fmt.Sprintf("cold-%d", i)
+			data := makeChunk(chunkSize, byte(i))
+			seedRemoteOnlyBlock(b, fbs, rs, payloadID, data)
+
+			m := newFetchSyncer(loc, rs.Store, fbs)
+			m.remoteStore = rs // route through the latency wrapper
+
+			got, err := m.fetchBlock(ctx, payloadID, 0)
+			if err != nil {
+				b.Fatalf("cold fetchBlock: %v", err)
+			}
+			if len(got) != chunkSize {
+				b.Fatalf("cold read len=%d, want %d", len(got), chunkSize)
+			}
+		}
+	})
+
+	b.Run("warm", func(b *testing.B) {
+		// Build the working set ONCE and prime the local store so every
+		// benchmarked read is served from disk with no remote latency.
+		loc := memorylocal.New()
+		rs := newLatencyRemote(wanLatency)
+		fbs := newStubFileBlockStore()
+		payloadID := "warm"
+		data := makeChunk(chunkSize, 0x5A)
+		hash := seedRemoteOnlyBlock(b, fbs, rs, payloadID, data)
+
+		m := newFetchSyncer(loc, rs.Store, fbs)
+		m.remoteStore = rs
+
+		// Prime: one cold fetch persists the chunk locally.
+		if _, err := m.fetchBlock(ctx, payloadID, 0); err != nil {
+			b.Fatalf("warm prime fetchBlock: %v", err)
+		}
+		if has, _ := loc.Has(ctx, hash); !has {
+			b.Fatalf("warm prime did not persist chunk locally")
+		}
+		getsAfterPrime := rs.gets.Load()
+
+		b.SetBytes(chunkSize)
+		b.ReportAllocs()
+		for b.Loop() {
+			// Local-served read: ReadChunk hits the warm local store; no Get,
+			// no WAN latency. This is the read the cache exists to accelerate.
+			got, err := loc.Get(ctx, hash)
+			if err != nil {
+				b.Fatalf("warm local read: %v", err)
+			}
+			if len(got) != chunkSize {
+				b.Fatalf("warm read len=%d, want %d", len(got), chunkSize)
+			}
+		}
+		// Sanity: the warm loop issued no further remote Gets.
+		if extra := rs.gets.Load() - getsAfterPrime; extra != 0 {
+			b.Fatalf("warm loop issued %d remote Gets; want 0 (served from cache)", extra)
+		}
+	})
+}
+
+// makeChunk returns a deterministic chunkSize-byte slice seeded by fill so
+// distinct working-set members hash to distinct CAS keys.
+func makeChunk(n int, fill byte) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = fill ^ byte(i)
+	}
+	return b
+}
+
+// TestReadThroughCache_NoReuploadOnReadOnlyWorkload pins the #1362 read→write
+// de-amplification: fetching verbatim remote content on a read miss must NOT
+// schedule that content for re-upload. The chunk is already durable on the
+// remote, so re-uploading it turns a read-only workload into a write-heavy one
+// (read-amplification → write-amplification).
+//
+// The test seeds a remote-only working set, reads the whole set through the
+// real syncer fetch path (fetchBlock, which persists via local.Put then calls
+// markFetchedSynced), and asserts the mock remote's Put count is 0. It also
+// asserts the pending-upload set is fully drained (unsyncedBytes == 0) — the
+// precondition that makes the mirror loop a guaranteed no-op, so the assertion
+// does not depend on mirror-loop timing.
+func TestReadThroughCache_NoReuploadOnReadOnlyWorkload(t *testing.T) {
+	const (
+		setSize   = 8
+		chunkSize = 4 * 1024
+	)
+	ctx := context.Background()
+
+	loc := memorylocal.New()
+	rs := newLatencyRemote(0)
+	fbs := newStubFileBlockStore()
+	mds := metastore.NewMemoryMetadataStoreWithDefaults()
+
+	m := newFetchSyncer(loc, rs.Store, fbs)
+	m.remoteStore = rs      // count Puts through the wrapper
+	m.syncedHashStore = mds // so markFetchedSynced can mark synced
+	hashes := make([]block.ContentHash, 0, setSize)
+
+	for i := 0; i < setSize; i++ {
+		payloadID := fmt.Sprintf("ro-%d", i)
+		data := makeChunk(chunkSize, byte(i))
+		h := seedRemoteOnlyBlock(t, fbs, rs, payloadID, data)
+		hashes = append(hashes, h)
+
+		// Model the real read-fetch path: StoreChunk's onChunkComplete callback
+		// (wired by engine.New in production) registers the freshly-persisted
+		// chunk as pending upload. The memory local store does not fire that
+		// callback, so register it explicitly; markFetchedSynced inside
+		// fetchBlock must then cancel it.
+		m.addPendingHash(h, int64(chunkSize))
+	}
+	if got := m.UnsyncedBytes(); got != int64(setSize*chunkSize) {
+		t.Fatalf("precondition unsyncedBytes=%d, want %d", got, setSize*chunkSize)
+	}
+
+	// Reset the Put counter: the remote-seed Puts above are fixture setup, not
+	// re-uploads. We only care about Puts the READ path issues.
+	rs.puts.Store(0)
+
+	// Read the entire working set through the fetch+persist path.
+	for i := 0; i < setSize; i++ {
+		payloadID := fmt.Sprintf("ro-%d", i)
+		got, err := m.fetchBlock(ctx, payloadID, 0)
+		if err != nil {
+			t.Fatalf("fetchBlock %s: %v", payloadID, err)
+		}
+		if len(got) != chunkSize {
+			t.Fatalf("read %s len=%d, want %d", payloadID, len(got), chunkSize)
+		}
+	}
+
+	// Invariant 1: the read-only workload issued zero re-uploads.
+	if got := rs.puts.Load(); got != 0 {
+		t.Errorf("remote Put count=%d after read-only workload; want 0 (#1362 read→write amplification eliminated)", got)
+	}
+
+	// Invariant 2: the pending-upload set is fully drained, so the mirror loop
+	// is a guaranteed no-op regardless of its timing.
+	if got := m.UnsyncedBytes(); got != 0 {
+		t.Errorf("unsyncedBytes=%d after reads; want 0 (every fetched chunk canceled its pending upload)", got)
+	}
+	m.pendingMu.Lock()
+	pending := len(m.pendingHashes)
+	m.pendingMu.Unlock()
+	if pending != 0 {
+		t.Errorf("pendingHashes has %d entries; want 0", pending)
+	}
+
+	// And each fetched chunk is marked synced so eviction can reclaim it on a
+	// read-only workload.
+	for _, h := range hashes {
+		synced, err := mds.IsSynced(ctx, h)
+		if err != nil {
+			t.Fatalf("IsSynced: %v", err)
+		}
+		if !synced {
+			t.Errorf("chunk %s not marked synced; eviction would stall on a read-only workload", h.String())
+		}
+	}
+}
+
+// TestReadThroughCache_BoundedByMaxDisk is the headline #1362 invariant: a
+// read-only workload over a remote tier must NOT grow the local CAS store
+// without bound. It drives many distinct fetched chunks through the real
+// syncer fetch path into an FSStore configured with a small maxDisk, reading a
+// working set several times larger than the cap, and asserts diskUsed stays
+// <= maxDisk throughout and at the end.
+//
+// Before the fix, FSStore.Put (the read-through cache's write entry) delegated
+// straight to StoreChunk and never reserved capacity, so the cache grew
+// unbounded on a read-only workload (eviction only ran on the write/append
+// path). The fetch path here persists through FSStore.Put → ensureSpace, which
+// now evicts to honor the bound. The FSStore is wired with no SyncedHashStore,
+// so every chunk is evictable and the bound is enforced purely by Put's
+// capacity reservation.
+func TestReadThroughCache_BoundedByMaxDisk(t *testing.T) {
+	const (
+		chunkSize = 4 * 1024
+		// Cap at 5 chunks; the working set is 40 chunks (8x the cap).
+		maxDisk = 5 * chunkSize
+		setSize = 40
+	)
+	ctx := context.Background()
+
+	dir := t.TempDir()
+	// No SyncedHashStore: every fetched chunk is immediately evictable, so the
+	// bound is enforced by Put's ensureSpace alone.
+	loc, err := localfs.NewWithOptions(dir, maxDisk, newStubFileBlockStore(), localfs.FSStoreOptions{})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	startCtx, cancel := context.WithCancel(ctx)
+	loc.Start(startCtx)
+	t.Cleanup(func() {
+		cancel()
+		_ = loc.Close()
+	})
+
+	rs := newLatencyRemote(0)
+	fbs := newStubFileBlockStore()
+	m := newFetchSyncer(loc, rs.Store, fbs)
+	m.remoteStore = rs
+
+	for i := 0; i < setSize; i++ {
+		payloadID := fmt.Sprintf("bound-%d", i)
+		data := makeChunk(chunkSize, byte(i))
+		seedRemoteOnlyBlock(t, fbs, rs, payloadID, data)
+
+		got, err := m.fetchBlock(ctx, payloadID, 0)
+		if err != nil {
+			t.Fatalf("fetchBlock %s: %v", payloadID, err)
+		}
+		if len(got) != chunkSize {
+			t.Fatalf("read %s len=%d, want %d", payloadID, len(got), chunkSize)
+		}
+
+		// Invariant: after every fetched chunk lands, the local CAS store stays
+		// within its disk budget.
+		if used := loc.Stats().DiskUsed; used > maxDisk {
+			t.Fatalf("after fetch %d diskUsed=%d exceeds maxDisk=%d — read-through cache unbounded (#1362)", i, used, maxDisk)
+		}
+	}
+
+	// Read the set a second time (several times larger than the cap, total) to
+	// confirm the bound holds steady across re-fetches of evicted chunks.
+	for i := 0; i < setSize; i++ {
+		payloadID := fmt.Sprintf("bound-%d", i)
+		if _, err := m.fetchBlock(ctx, payloadID, 0); err != nil {
+			t.Fatalf("re-read fetchBlock %s: %v", payloadID, err)
+		}
+		if used := loc.Stats().DiskUsed; used > maxDisk {
+			t.Fatalf("re-read fetch %d diskUsed=%d exceeds maxDisk=%d (#1362)", i, used, maxDisk)
+		}
+	}
+
+	if used := loc.Stats().DiskUsed; used > maxDisk {
+		t.Fatalf("final diskUsed=%d exceeds maxDisk=%d after reading %d chunks into a %d-chunk cache (#1362)",
+			used, maxDisk, setSize, maxDisk/chunkSize)
+	}
+}

--- a/pkg/block/engine/read_cache_sync_test.go
+++ b/pkg/block/engine/read_cache_sync_test.go
@@ -1,0 +1,83 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	memorylocal "github.com/marmos91/dittofs/pkg/block/local/memory"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestInlineFetch_MarksFetchedChunkSyncedAndCancelsReupload pins the #1362
+// fix for read-fetch sync accounting. A chunk pulled from the remote tier on a
+// read miss is verbatim remote content, so the syncer must NOT schedule it for
+// re-upload (which turns a read-heavy workload into a write-heavy one) and must
+// mark it synced so eviction can reclaim it immediately rather than after a
+// mirror pass. inlineFetchOrWait persists via local.Put then calls
+// markFetchedSynced, which (1) cancels the pending-upload entry StoreChunk's
+// onChunkComplete callback registers and (2) marks the hash synced.
+func TestInlineFetch_MarksFetchedChunkSyncedAndCancelsReupload(t *testing.T) {
+	ctx := context.Background()
+	payloadID := "payload-readcache"
+	data := []byte("verbatim-remote-bytes-fetched-on-a-read-miss-0123456789")
+
+	loc := memorylocal.New()
+	rs := remotememory.New()
+	fbs := newStubFileBlockStore()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	hash, _ := seedFileBlock(t, fbs, rs, payloadID, data)
+
+	m := &Syncer{
+		local:           loc,
+		remoteStore:     rs,
+		fileBlockStore:  fbs,
+		inFlight:        make(map[string]*fetchResult),
+		stopCh:          make(chan struct{}),
+		config:          DefaultConfig(),
+		pendingHashes:   make(map[block.ContentHash]int64),
+		syncedHashStore: mds,
+	}
+
+	// The memory LocalStore used here does not fire StoreChunk's
+	// onChunkComplete callback, so register the pending-upload entry
+	// explicitly to model the real read-fetch path that markFetchedSynced
+	// must undo.
+	m.addPendingHash(hash, int64(len(data)))
+	if got := m.UnsyncedBytes(); got != int64(len(data)) {
+		t.Fatalf("precondition unsyncedBytes=%d, want %d", got, len(data))
+	}
+
+	rows, err := m.listFileBlocksSnapshot(ctx, payloadID)
+	if err != nil {
+		t.Fatalf("listFileBlocksSnapshot: %v", err)
+	}
+	gotData, downloaded, err := m.inlineFetchOrWait(ctx, payloadID, 0, rows)
+	if err != nil {
+		t.Fatalf("inlineFetchOrWait: %v", err)
+	}
+	if !downloaded || gotData == nil {
+		t.Fatalf("inlineFetchOrWait downloaded=%v data=%v; want a successful inline fetch", downloaded, gotData)
+	}
+
+	// (1) Re-upload canceled: nothing left pending, so mirrorOnce uploads nothing.
+	m.pendingMu.Lock()
+	_, stillPending := m.pendingHashes[hash]
+	m.pendingMu.Unlock()
+	if stillPending {
+		t.Errorf("fetched chunk still pending upload; the mirror loop would re-upload remote bytes (#1362)")
+	}
+	if got := m.UnsyncedBytes(); got != 0 {
+		t.Errorf("unsyncedBytes=%d after fetch, want 0 (pending entry must be canceled)", got)
+	}
+
+	// (2) Marked synced: eviction's IsSynced gate can reclaim it immediately.
+	synced, err := mds.IsSynced(ctx, hash)
+	if err != nil {
+		t.Fatalf("IsSynced: %v", err)
+	}
+	if !synced {
+		t.Errorf("fetched chunk not marked synced; eviction would skip it on a read-only workload (#1362)")
+	}
+}

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -132,6 +132,48 @@ func (m *Syncer) addPendingHash(h block.ContentHash, size int64) {
 	m.pendingMu.Unlock()
 }
 
+// markFetchedSynced records a chunk that was just downloaded from the remote
+// store as already mirrored. The bytes are verbatim remote content, so the
+// chunk is provably durable on remote, and we must treat it differently from a
+// locally-written chunk:
+//
+//  1. Cancel the pending-upload entry that StoreChunk's onChunkComplete
+//     callback registered for it, so the mirror loop does not waste a redundant
+//     remote.Put re-uploading data that is already there. Without this, reading
+//     an N-byte archive over a remote tier re-uploads N bytes back to remote
+//     (read-amplification → write-amplification, #1362).
+//  2. Mark it synced so eviction's IsSynced gate can reclaim it immediately
+//     rather than waiting for a mirror pass; otherwise the first eviction on a
+//     read-only workload finds zero synced candidates and stalls.
+//
+// Nil-safe for test fixtures with no SyncedHashStore wired.
+func (m *Syncer) markFetchedSynced(ctx context.Context, h block.ContentHash) {
+	if h.IsZero() {
+		return
+	}
+	m.mu.RLock()
+	hashStore := m.syncedHashStore
+	m.mu.RUnlock()
+	if hashStore != nil {
+		if err := hashStore.MarkSynced(ctx, h); err != nil {
+			// Non-fatal: leave the chunk pending so the mirror loop re-uploads
+			// and marks it synced on the next tick (remote.Put is idempotent).
+			logger.Warn("markFetchedSynced: MarkSynced failed; chunk will be re-mirrored",
+				"hash", h.String(), "error", err)
+			return
+		}
+	}
+	// Drop the pending-upload entry StoreChunk's callback just registered so
+	// the mirror loop skips it. A concurrent mirrorOnce tick that already
+	// snapshotted this hash may still re-upload it once — harmless and rare.
+	m.pendingMu.Lock()
+	if size, ok := m.pendingHashes[h]; ok {
+		delete(m.pendingHashes, h)
+		m.unsyncedBytes.Add(-size)
+	}
+	m.pendingMu.Unlock()
+}
+
 // UnsyncedBytes returns the running total on-disk size of CAS chunks present
 // locally but not yet mirrored to remote. This is the backpressure signal
 // the local store consults: a non-zero value with a healthy remote means a

--- a/pkg/block/local/fs/blockstore_methods.go
+++ b/pkg/block/local/fs/blockstore_methods.go
@@ -29,6 +29,25 @@ func (bc *FSStore) Put(ctx context.Context, hash block.ContentHash, data []byte)
 	if hash.IsZero() {
 		return fmt.Errorf("blockstore.fs: Put with zero hash")
 	}
+	// Put is the read-through cache's write entry: its production engine
+	// callers are the syncer's inline fetch + prefetch in engine/fetch.go (the
+	// offline CAS-migration tool and the conformance suite also call it, both
+	// with maxDisk == 0, where ensureSpace is a no-op). Unlike the
+	// append/rollup write path it does not flow through ensureSpace, so
+	// without this a read-only workload over a remote tier grows the local
+	// CAS store without bound, past maxDisk, because eviction is never
+	// triggered (#1362). Reserve capacity for genuinely new chunks only:
+	// StoreChunk is idempotent, and reserving for an already-present chunk
+	// would over-evict to make room for bytes that are never written.
+	exists, err := bc.Has(ctx, hash)
+	if err != nil {
+		return fmt.Errorf("blockstore.fs: Put: %w", err)
+	}
+	if !exists {
+		if err := bc.ensureSpace(ctx, int64(len(data))); err != nil {
+			return fmt.Errorf("blockstore.fs: Put: %w", err)
+		}
+	}
 	return bc.StoreChunk(ctx, hash, data)
 }
 

--- a/pkg/block/local/fs/read_cache_eviction_test.go
+++ b/pkg/block/local/fs/read_cache_eviction_test.go
@@ -1,0 +1,76 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+)
+
+// TestPut_BoundsReadThroughCache asserts that FSStore.Put — the read-through
+// cache's write entry, whose only production callers are the syncer's
+// remote-fetch paths in engine/fetch.go — reserves capacity via ensureSpace
+// before storing. Before #1362's fix, Put delegated straight to StoreChunk,
+// which never calls ensureSpace, so a read-only workload over a remote tier
+// grew the local CAS store without bound past maxDisk (eviction only ran on
+// the write/append path). This test fails without the Put-side ensureSpace.
+func TestPut_BoundsReadThroughCache(t *testing.T) {
+	const chunk = 200
+	const maxDisk = 3 * chunk // exactly three chunks fit; a fourth must evict
+	bc := newTestCacheWithDiskLimit(t, maxDisk)
+	ctx := context.Background()
+
+	// Seed three chunks via the canonical write path, then add a fourth via
+	// the read-cache Put. With a nil SyncedHashStore every chunk is evictable.
+	h1 := storeChunk(t, bc, bytes.Repeat([]byte{0x01}, chunk))
+	_ = storeChunk(t, bc, bytes.Repeat([]byte{0x02}, chunk))
+	_ = storeChunk(t, bc, bytes.Repeat([]byte{0x03}, chunk))
+	if got := bc.diskUsed.Load(); got != maxDisk {
+		t.Fatalf("seed diskUsed=%d, want %d", got, maxDisk)
+	}
+
+	fetched := bytes.Repeat([]byte{0x04}, chunk)
+	hFetched := hashBytes(fetched)
+	if err := bc.Put(ctx, hFetched, fetched); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	if got := bc.diskUsed.Load(); got > maxDisk {
+		t.Fatalf("after read-cache Put diskUsed=%d exceeds maxDisk=%d — cache unbounded (#1362)", got, maxDisk)
+	}
+	if _, err := os.Stat(bc.chunkPath(hFetched)); err != nil {
+		t.Fatalf("freshly fetched chunk must be present after Put: %v", err)
+	}
+	if _, err := os.Stat(bc.chunkPath(h1)); !os.IsNotExist(err) {
+		t.Errorf("LRU-oldest chunk should have been evicted to make room; stat err=%v", err)
+	}
+}
+
+// TestPut_IdempotentRePutDoesNotEvict guards the !exists gate: re-Putting a
+// chunk that is already present must not reserve capacity, because StoreChunk
+// is idempotent and writes nothing. Reserving unconditionally would evict
+// other live chunks to make room for bytes that are never added.
+func TestPut_IdempotentRePutDoesNotEvict(t *testing.T) {
+	const chunk = 200
+	const maxDisk = 2 * chunk
+	bc := newTestCacheWithDiskLimit(t, maxDisk)
+	ctx := context.Background()
+
+	a := bytes.Repeat([]byte{0xAA}, chunk)
+	hA := hashBytes(a)
+	if err := bc.Put(ctx, hA, a); err != nil {
+		t.Fatalf("Put A: %v", err)
+	}
+	hB := storeChunk(t, bc, bytes.Repeat([]byte{0xBB}, chunk))
+
+	// Re-Put A (already present): must be a capacity no-op so B survives.
+	if err := bc.Put(ctx, hA, a); err != nil {
+		t.Fatalf("re-Put A: %v", err)
+	}
+	if _, err := os.Stat(bc.chunkPath(hB)); err != nil {
+		t.Errorf("re-Put of an existing chunk must not evict others; B missing: %v", err)
+	}
+	if got := bc.diskUsed.Load(); got != maxDisk {
+		t.Errorf("diskUsed=%d, want %d (no growth on idempotent re-Put)", got, maxDisk)
+	}
+}


### PR DESCRIPTION
## What & why

Part of #1362. Deep investigation showed the issue's premise ("fetched blocks never persist") is largely already fixed on `develop` — read-through caching persists durably via `inlineFetchOrWait` → `local.Put`. The real bugs underneath are different:

**Bug 1 — read-through cache is unbounded on a read-only workload.** `FSStore.Put` (the read-fetch write entry; its only callers are the syncer's remote-fetch paths in `engine/fetch.go`) delegated straight to `StoreChunk`, which increments `diskUsed` and LRU-touches but **never calls `ensureSpace`**. `ensureSpace` — the sole eviction driver — only runs on the write/append path. So with no writes (archive/read workload), `diskUsed` grows past `maxDisk` forever. This is the "`du` shows tens of GB on a 1.9 GiB-limit host."

**Bug 2 — fetched chunks get re-uploaded and are temporarily un-evictable.** A chunk fetched from remote is verbatim remote content, yet `StoreChunk`'s `onChunkComplete` callback scheduled it for re-upload via the mirror loop, and `lruEvictOne` refuses to evict anything failing `IsSynced` until that mirror pass completes. Net: reading an N-byte archive re-PUTs N bytes back to S3 (read-amplification → write-amplification), and the first eviction finds zero synced candidates and stalls.

## Changes

- `FSStore.Put`: reserve capacity via `ensureSpace` for genuinely **new** chunks (idempotent re-Puts skip it, so they can't over-evict). `ensureSpace` already honors pin / eviction-disabled and is a no-op when `maxDisk == 0`, so the write path and conformance fixtures are unaffected.
- `Syncer.markFetchedSynced`: called after each read-fetch `local.Put`, it cancels the pending-upload entry and marks the hash synced immediately — killing the redundant re-upload and making the chunk instantly evictable.

## Tests (TDD — verified red before the fix)

- `TestPut_BoundsReadThroughCache` — read-cache `Put` past `maxDisk` evicts (fails red: `diskUsed=800 > maxDisk=600`).
- `TestPut_IdempotentRePutDoesNotEvict` — re-Put of an existing chunk reserves nothing, evicts nothing.
- `TestInlineFetch_MarksFetchedChunkSyncedAndCancelsReupload` — after an inline fetch the pending-upload entry is canceled (`unsyncedBytes == 0`) and the hash is marked synced.

`go test -race ./pkg/block/local/fs/ ./pkg/block/engine/` green; `go vet` clean.

## Follow-ups (same issue)

- PR2: fix stats so read-cached blocks show as local (`Blocks Local: 0` while `du` is huge).
- PR3: `dfsctl share warm` (async) to proactively materialize a share; pin + warm = permanent local mirror.
- Benchmarks quantifying cold-vs-warm throughput and the eliminated S3 re-upload.

Refs #1362