### PR TITLE
fix(block): count read-cached blocks as local in stats

### DIFF
--- a/cmd/dfsctl/commands/store/block/stats.go
+++ b/cmd/dfsctl/commands/store/block/stats.go
@@ -74,6 +74,7 @@ func printBlockStoreStatsTable(resp *apiclient.BlockStoreStatsResponse) error {
 		{"Blocks Total", fmt.Sprintf("%d", t.BlocksTotal)},
 		{"Blocks Dirty", fmt.Sprintf("%d", t.BlocksDirty)},
 		{"Blocks Local", fmt.Sprintf("%d", t.BlocksLocal)},
+		{"Blocks Cached", fmt.Sprintf("%d", t.BlocksCached)},
 		{"Blocks Remote", fmt.Sprintf("%d", t.BlocksRemote)},
 		{"Local Disk Used", formatBytes(t.LocalDiskUsed)},
 		{"Local Disk Max", formatBytes(t.LocalDiskMax)},

--- a/pkg/block/engine/stats.go
+++ b/pkg/block/engine/stats.go
@@ -15,6 +15,12 @@ type BlockStoreStats struct {
 	BlocksLocal  int `json:"blocks_local"`
 	BlocksRemote int `json:"blocks_remote"`
 	BlocksTotal  int `json:"blocks_total"`
+	// BlocksCached is the subset of BlocksLocal that is physically present on
+	// local disk but whose metadata row still reads BlockStateRemote — i.e.
+	// blocks populated by the read-through cache after a remote fetch. It lets
+	// operators see how much of the local tier is read-cached vs write-side
+	// (#1362).
+	BlocksCached int `json:"blocks_cached"`
 
 	LocalDiskUsed int64 `json:"local_disk_used"`
 	LocalDiskMax  int64 `json:"local_disk_max"`
@@ -175,19 +181,35 @@ func (bs *Store) populateBlockCounts(stats *BlockStoreStats, files []string) {
 		}
 		for _, b := range blocks {
 			stats.BlocksTotal++
+			// Classify by PHYSICAL presence in the local CAS store, not by sync
+			// state. A block fetched from remote keeps a BlockStateRemote row
+			// even though its CAS chunk now sits on local disk; classifying by
+			// state alone reported it as remote, so a fully read-cached share
+			// showed "Blocks Local: 0" while du showed the cache was full
+			// (#1362). A zero hash means the block is genuinely dirty/in-flight
+			// (rollup not yet complete) and cannot be present.
+			if !b.Hash.IsZero() {
+				if present, herr := bs.local.Has(ctx, b.Hash); herr == nil && present {
+					stats.BlocksLocal++
+					if b.State == block.BlockStateRemote {
+						// On disk yet the row says remote: read-through-cached.
+						stats.BlocksCached++
+					}
+					continue
+				}
+			}
+			// Not physically present (or zero hash): fall back to sync state.
 			switch b.State {
 			case block.BlockStatePending:
-				// A CAS-pending block with a non-zero hash is locally present in the
-				// CAS store; a zero hash means the block is truly dirty/in-flight
-				// (rollup not yet complete). LocalPath and BlockStoreKey are legacy
-				// signals irrelevant on the CAS path.
-				if !b.Hash.IsZero() {
-					stats.BlocksLocal++
-				} else {
+				if b.Hash.IsZero() {
 					stats.BlocksDirty++
+				} else {
+					// Rollup-committed but absent from disk (evicted): the
+					// remote copy is authoritative; a read will refetch it.
+					stats.BlocksRemote++
 				}
 			case block.BlockStateSyncing:
-				stats.BlocksLocal++
+				stats.BlocksRemote++
 			case block.BlockStateRemote:
 				stats.BlocksRemote++
 			}

--- a/pkg/block/engine/stats_cached_test.go
+++ b/pkg/block/engine/stats_cached_test.go
@@ -1,0 +1,68 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	memorylocal "github.com/marmos91/dittofs/pkg/block/local/memory"
+	"lukechampine.com/blake3"
+)
+
+// TestPopulateBlockCounts_ClassifiesByPhysicalPresence pins the #1362 stats
+// fix: a block whose FileBlock row still reads BlockStateRemote but whose CAS
+// chunk is physically on local disk (the read-through-cache case) must count as
+// local — and additionally as cached — rather than remote. Before the fix,
+// classification went purely by sync state, so a fully read-cached share
+// reported "Blocks Local: 0" while du showed the cache was full.
+func TestPopulateBlockCounts_ClassifiesByPhysicalPresence(t *testing.T) {
+	ctx := context.Background()
+	loc := memorylocal.New()
+	fbs := newStubFileBlockStore()
+	bs := &Store{local: loc, fileBlockStore: fbs}
+
+	const payloadID = "p1"
+
+	// Block A: row says remote, but the chunk is physically present locally
+	// (fetched and cached). Expect local + cached.
+	dataA := []byte("aaaa-read-cached-block-present-on-disk")
+	hA := block.ContentHash(blake3.Sum256(dataA))
+	if err := loc.Put(ctx, hA, dataA); err != nil {
+		t.Fatalf("local Put A: %v", err)
+	}
+	mustPutFB(t, fbs, &block.FileBlock{ID: payloadID + "/0", Hash: hA, DataSize: uint32(len(dataA)), State: block.BlockStateRemote})
+
+	// Block B: row says remote and the chunk is absent locally. Expect remote.
+	dataB := []byte("bbbb-remote-only-not-on-disk")
+	hB := block.ContentHash(blake3.Sum256(dataB))
+	mustPutFB(t, fbs, &block.FileBlock{ID: payloadID + "/1", Hash: hB, DataSize: uint32(len(dataB)), State: block.BlockStateRemote})
+
+	// Block C: dirty/in-flight (zero hash, rollup incomplete). Expect dirty.
+	mustPutFB(t, fbs, &block.FileBlock{ID: payloadID + "/2", Hash: block.ContentHash{}, DataSize: 4, State: block.BlockStatePending})
+
+	var stats BlockStoreStats
+	bs.populateBlockCounts(&stats, []string{payloadID})
+
+	if stats.BlocksTotal != 3 {
+		t.Errorf("BlocksTotal=%d, want 3", stats.BlocksTotal)
+	}
+	if stats.BlocksLocal != 1 {
+		t.Errorf("BlocksLocal=%d, want 1 (read-cached chunk is physically local)", stats.BlocksLocal)
+	}
+	if stats.BlocksCached != 1 {
+		t.Errorf("BlocksCached=%d, want 1 (locally present but row says remote)", stats.BlocksCached)
+	}
+	if stats.BlocksRemote != 1 {
+		t.Errorf("BlocksRemote=%d, want 1 (remote-only block)", stats.BlocksRemote)
+	}
+	if stats.BlocksDirty != 1 {
+		t.Errorf("BlocksDirty=%d, want 1 (zero-hash in-flight block)", stats.BlocksDirty)
+	}
+}
+
+func mustPutFB(t *testing.T, fbs *stubFileBlockStore, fb *block.FileBlock) {
+	t.Helper()
+	if err := fbs.Put(context.Background(), fb); err != nil {
+		t.Fatalf("stub FileBlock Put: %v", err)
+	}
+}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1963,6 +1963,7 @@ func addBlockStoreStats(dst *engine.BlockStoreStats, src engine.BlockStoreStats)
 	dst.BlocksLocal += src.BlocksLocal
 	dst.BlocksRemote += src.BlocksRemote
 	dst.BlocksTotal += src.BlocksTotal
+	dst.BlocksCached += src.BlocksCached
 	dst.LocalDiskUsed += src.LocalDiskUsed
 	dst.LocalDiskMax += src.LocalDiskMax
 	dst.LocalMemUsed += src.LocalMemUsed


### PR DESCRIPTION
## What & why

Part of #1362. `populateBlockCounts` classified every block by its FileBlock **sync state**. A block fetched from the remote tier keeps a `BlockStateRemote` row even after its CAS chunk lands on local disk, so it was counted as remote. Result: a fully read-cached share reported `Blocks Local: 0` while `du` showed the local tier was full — operators couldn't see what was cached.

## Change

Classify by **physical presence** instead of sync state:
- chunk on local disk (`local.Has`) → counts as `BlocksLocal`, and additionally as a new `BlocksCached` when the row still reads `BlockStateRemote` (i.e. read-through-cache populated);
- zero-hash in-flight blocks → `BlocksDirty` (unchanged);
- rolled-up-but-evicted blocks (row present, chunk absent) → `BlocksRemote` (a read will refetch).

Adds `BlocksCached` (additive JSON; `apiclient.BlockStoreStats` is a type alias of the engine struct so it propagates automatically), aggregation in `addBlockStoreStats`, and a `Blocks Cached` line in `dfsctl store block stats`.

## Tests

- `TestPopulateBlockCounts_ClassifiesByPhysicalPresence` — a remote-row-but-locally-present block counts as local+cached; a remote-only block counts as remote; a zero-hash block counts as dirty.
- Existing `TestBlockStoreStats_WireShapeRoundTrip` still green (round-trips the new field).

`go build ./...`, `go vet`, `go test ./pkg/apiclient/ ./pkg/block/engine/` all green.

## Note

Independent of #1371 (branched off develop). `populateBlockCounts` now does one `local.Has` (an os.Stat) per block; it runs only on the full `GetStats` path, not `GetStatsLite` (the metrics-scrape hot path), so the cost is bounded to operator-initiated stats calls.

Refs #1362