### PR TITLE
feat(block): async share warm + pin startup warning (#1362)

### DIFF
--- a/cmd/dfsctl/commands/share/share.go
+++ b/cmd/dfsctl/commands/share/share.go
@@ -65,6 +65,7 @@ func init() {
 
 	Cmd.AddCommand(disableCmd)
 	Cmd.AddCommand(enableCmd)
+	Cmd.AddCommand(warmCmd)
 
 	Cmd.AddCommand(nfsConfigCmd) // per-share NFS adapter config (squash, netgroup, auth)
 }

--- a/cmd/dfsctl/commands/share/warm.go
+++ b/cmd/dfsctl/commands/share/warm.go
@@ -1,0 +1,111 @@
+package share
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
+	"github.com/marmos91/dittofs/internal/bytesize"
+	"github.com/marmos91/dittofs/internal/cli/output"
+	"github.com/marmos91/dittofs/pkg/apiclient"
+	"github.com/spf13/cobra"
+)
+
+// Terminal warm-job states (mirror shares.WarmState*).
+const (
+	warmStateDone     = "done"
+	warmStateFailed   = "failed"
+	warmStateCanceled = "canceled"
+)
+
+var warmCmd = &cobra.Command{
+	Use:   "warm <name>",
+	Short: "Warm a share's local block cache",
+	Long: `Proactively materialize a share's blocks onto the local disk tier.
+
+Starts an asynchronous job that downloads every remote block of the share into
+the local cache so subsequent reads are served locally. The command prints the
+job id and exits; use --watch to poll until the job completes.
+
+The share must have a remote tier configured. A pinned share with a bounded
+local tier may fail with a disk-full error if its working set exceeds the tier.
+
+Examples:
+  # Start a warm job and exit
+  dfsctl share warm /archive
+
+  # Start and follow progress until done
+  dfsctl share warm --watch /archive`,
+	Args: cobra.ExactArgs(1),
+	RunE: runShareWarm,
+}
+
+func init() {
+	warmCmd.Flags().Bool("watch", false, "Poll the job until it reaches a terminal state")
+}
+
+func runShareWarm(cmd *cobra.Command, args []string) error {
+	client, err := cmdutil.GetAuthenticatedClient()
+	if err != nil {
+		return err
+	}
+
+	shareName := args[0]
+	watch, _ := cmd.Flags().GetBool("watch")
+
+	jobID, err := client.StartShareWarm(shareName)
+	if err != nil {
+		return fmt.Errorf("failed to start warm job: %w", err)
+	}
+
+	if !watch {
+		format, ferr := cmdutil.GetOutputFormatParsed()
+		if ferr != nil {
+			return ferr
+		}
+		switch format {
+		case output.FormatJSON:
+			return output.PrintJSON(os.Stdout, map[string]string{"job_id": jobID})
+		case output.FormatYAML:
+			return output.PrintYAML(os.Stdout, map[string]string{"job_id": jobID})
+		default:
+			fmt.Printf("Warm job started: %s\n", jobID)
+		}
+		return nil
+	}
+
+	return watchWarm(client, shareName, jobID)
+}
+
+// watchWarm polls the warm job every second, rendering progress until a
+// terminal state. It returns a non-nil error on failed/canceled jobs so the
+// process exits non-zero.
+func watchWarm(client *apiclient.Client, shareName, jobID string) error {
+	for {
+		status, err := client.GetShareWarm(shareName, jobID)
+		if err != nil {
+			return fmt.Errorf("failed to poll warm job: %w", err)
+		}
+
+		fmt.Printf("\rfetched %d/%d blocks (%s)        ",
+			status.BlocksDone, status.BlocksTotal,
+			bytesize.ByteSize(status.BytesDone).String())
+
+		switch status.State {
+		case warmStateDone:
+			fmt.Printf("\rfetched %d/%d blocks (%s) — done\n",
+				status.BlocksDone, status.BlocksTotal,
+				bytesize.ByteSize(status.BytesDone).String())
+			return nil
+		case warmStateFailed:
+			fmt.Println()
+			return fmt.Errorf("warm job failed: %s", status.Error)
+		case warmStateCanceled:
+			fmt.Println()
+			return fmt.Errorf("warm job canceled: %s", status.Error)
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -642,6 +642,7 @@ dfsctl
       set            Create or update a share's snapshot policy
       show           Show a share's snapshot policy
     unmount        Unmount a mounted share
+    warm           Warm a share's local block cache
   status         Show server status
   store          Store management
     block          Block store management
@@ -4602,6 +4603,50 @@ Flags:
 
 ```
   -f, --force   Force unmount even if busy
+```
+
+Global flags:
+
+```
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
+```
+
+### `dfsctl share warm`
+
+Warm a share's local block cache
+
+Proactively materialize a share's blocks onto the local disk tier.
+
+Starts an asynchronous job that downloads every remote block of the share into
+the local cache so subsequent reads are served locally. The command prints the
+job id and exits; use --watch to poll until the job completes.
+
+The share must have a remote tier configured. A pinned share with a bounded
+local tier may fail with a disk-full error if its working set exceeds the tier.
+
+Examples:
+  # Start a warm job and exit
+  dfsctl share warm /archive
+
+  # Start and follow progress until done
+  dfsctl share warm --watch /archive
+
+```
+dfsctl share warm <name> [flags]
+```
+
+Flags:
+
+```
+      --watch   Poll the job until it reaches a terminal state
 ```
 
 Global flags:

--- a/internal/controlplane/api/handlers/blockstore.go
+++ b/internal/controlplane/api/handlers/blockstore.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -20,6 +21,8 @@ import (
 type BlockStoreRuntime interface {
 	GetBlockStoreStats(shareName string) (*shares.BlockStoreStatsResponse, error)
 	EvictBlockStore(ctx context.Context, shareName string, opts shares.EvictOptions) (*shares.EvictResult, error)
+	StartWarmBlockStore(ctx context.Context, shareName string) (*shares.WarmJob, error)
+	GetWarmStatus(jobID string) (*shares.WarmJob, bool)
 }
 
 // BlockStoreStatsHandler handles block store stats and eviction endpoints.
@@ -104,4 +107,91 @@ func (h *BlockStoreStatsHandler) Evict(w http.ResponseWriter, r *http.Request) {
 	}
 
 	WriteJSONOK(w, result)
+}
+
+// WarmJobStatusResponse is the JSON status body for a warm job, returned by
+// both Warm (202) and WarmStatus (200). Mirrors shares.WarmJob's wire shape.
+type WarmJobStatusResponse struct {
+	ID          string `json:"id"`
+	Share       string `json:"share"`
+	State       string `json:"state"`
+	BlocksTotal int64  `json:"blocks_total"`
+	BlocksDone  int64  `json:"blocks_done"`
+	BytesDone   int64  `json:"bytes_done"`
+	StartedAt   string `json:"started_at,omitempty"`
+	FinishedAt  string `json:"finished_at,omitempty"`
+	Error       string `json:"error,omitempty"`
+}
+
+func warmJobToResponse(j *shares.WarmJob) WarmJobStatusResponse {
+	resp := WarmJobStatusResponse{
+		ID:          j.ID,
+		Share:       j.Share,
+		State:       j.State,
+		BlocksTotal: j.BlocksTotal,
+		BlocksDone:  j.BlocksDone,
+		BytesDone:   j.BytesDone,
+		Error:       j.Err,
+	}
+	if !j.StartedAt.IsZero() {
+		resp.StartedAt = j.StartedAt.UTC().Format(time.RFC3339)
+	}
+	if !j.FinishedAt.IsZero() {
+		resp.FinishedAt = j.FinishedAt.UTC().Format(time.RFC3339)
+	}
+	return resp
+}
+
+// Warm handles POST /api/v1/shares/{name}/blockstore/warm. It starts (or
+// returns the already-running) async warm job that materializes the share's
+// blocks onto the local tier and responds 202 with the job id + initial status.
+func (h *BlockStoreStatsHandler) Warm(w http.ResponseWriter, r *http.Request) {
+	if h.runtime == nil {
+		InternalServerError(w, "runtime not initialized")
+		return
+	}
+
+	shareName := chi.URLParam(r, "name")
+	if shareName == "" {
+		BadRequest(w, "share name required")
+		return
+	}
+	shareName = normalizeShareName(shareName)
+
+	job, err := h.runtime.StartWarmBlockStore(r.Context(), shareName)
+	if err != nil {
+		logger.Debug("block store warm start error", "share", shareName, "error", err)
+		BadRequest(w, "warm failed")
+		return
+	}
+
+	WriteJSON(w, http.StatusAccepted, map[string]any{
+		"job_id": job.ID,
+		"status": warmJobToResponse(job),
+	})
+}
+
+// WarmStatus handles GET /api/v1/shares/{name}/blockstore/warm/{job_id}. It
+// returns the current status of a warm job. The {name} segment is accepted for
+// route symmetry with the start endpoint but the job id alone identifies the
+// job.
+func (h *BlockStoreStatsHandler) WarmStatus(w http.ResponseWriter, r *http.Request) {
+	if h.runtime == nil {
+		InternalServerError(w, "runtime not initialized")
+		return
+	}
+
+	jobID := chi.URLParam(r, "job_id")
+	if jobID == "" {
+		BadRequest(w, "job id required")
+		return
+	}
+
+	job, ok := h.runtime.GetWarmStatus(jobID)
+	if !ok {
+		NotFound(w, "warm job not found")
+		return
+	}
+
+	WriteJSONOK(w, warmJobToResponse(job))
 }

--- a/internal/controlplane/api/handlers/blockstore.go
+++ b/internal/controlplane/api/handlers/blockstore.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"time"
@@ -161,6 +162,10 @@ func (h *BlockStoreStatsHandler) Warm(w http.ResponseWriter, r *http.Request) {
 	job, err := h.runtime.StartWarmBlockStore(r.Context(), shareName)
 	if err != nil {
 		logger.Debug("block store warm start error", "share", shareName, "error", err)
+		if errors.Is(err, shares.ErrShareNotFound) {
+			NotFound(w, "share not found")
+			return
+		}
 		BadRequest(w, "warm failed")
 		return
 	}

--- a/internal/controlplane/api/handlers/blockstore_test.go
+++ b/internal/controlplane/api/handlers/blockstore_test.go
@@ -231,11 +231,15 @@ func TestBlockStoreHandler_Evict_SafetyError(t *testing.T) {
 // fakeBlockStoreRuntime implements BlockStoreRuntime for exercising the real
 // BlockStoreStatsHandler (as opposed to the testBlockStoreHandler shim above).
 type fakeBlockStoreRuntime struct {
-	stats     *shares.BlockStoreStatsResponse
-	statsErr  error
-	evict     *shares.EvictResult
-	evictErr  error
-	lastShare string
+	stats      *shares.BlockStoreStatsResponse
+	statsErr   error
+	evict      *shares.EvictResult
+	evictErr   error
+	lastShare  string
+	warmJob    *shares.WarmJob
+	warmErr    error
+	warmStatus *shares.WarmJob
+	warmFound  bool
 }
 
 func (f *fakeBlockStoreRuntime) GetBlockStoreStats(shareName string) (*shares.BlockStoreStatsResponse, error) {
@@ -246,6 +250,15 @@ func (f *fakeBlockStoreRuntime) GetBlockStoreStats(shareName string) (*shares.Bl
 func (f *fakeBlockStoreRuntime) EvictBlockStore(_ context.Context, shareName string, _ shares.EvictOptions) (*shares.EvictResult, error) {
 	f.lastShare = shareName
 	return f.evict, f.evictErr
+}
+
+func (f *fakeBlockStoreRuntime) StartWarmBlockStore(_ context.Context, shareName string) (*shares.WarmJob, error) {
+	f.lastShare = shareName
+	return f.warmJob, f.warmErr
+}
+
+func (f *fakeBlockStoreRuntime) GetWarmStatus(_ string) (*shares.WarmJob, bool) {
+	return f.warmStatus, f.warmFound
 }
 
 // TestBlockStoreStatsHandler_NormalizesShareName verifies the real handler
@@ -294,6 +307,87 @@ func TestBlockStoreStatsHandler_NormalizesShareName(t *testing.T) {
 		h.Evict(httptest.NewRecorder(), req)
 		if fake.lastShare != "" {
 			t.Fatalf("Evict (global): runtime got %q, want empty (all shares)", fake.lastShare)
+		}
+	})
+}
+
+// TestBlockStoreStatsHandler_Warm covers the async warm start (202 + job id)
+// and the status poll, including share-name normalization and the 404 for an
+// unknown job.
+func TestBlockStoreStatsHandler_Warm(t *testing.T) {
+	t.Run("start_returns_202_and_job_id", func(t *testing.T) {
+		fake := &fakeBlockStoreRuntime{warmJob: &shares.WarmJob{ID: "warm-/myshare-1", Share: "/myshare", State: shares.WarmStateRunning}}
+		h := NewBlockStoreStatsHandler(fake)
+		req := newChiRequestForBlockStore(http.MethodPost,
+			"/api/v1/shares/myshare/blockstore/warm", nil, "name", "myshare")
+		w := httptest.NewRecorder()
+		h.Warm(w, req)
+
+		if w.Code != http.StatusAccepted {
+			t.Fatalf("Warm status = %d, want 202", w.Code)
+		}
+		if fake.lastShare != "/myshare" {
+			t.Fatalf("Warm: runtime got %q, want /myshare", fake.lastShare)
+		}
+		var body struct {
+			JobID string `json:"job_id"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if body.JobID != "warm-/myshare-1" {
+			t.Fatalf("job_id = %q, want warm-/myshare-1", body.JobID)
+		}
+	})
+
+	t.Run("start_error_not_leaked", func(t *testing.T) {
+		fake := &fakeBlockStoreRuntime{warmErr: errors.New(`share "/secret" has no remote tier`)}
+		h := NewBlockStoreStatsHandler(fake)
+		req := newChiRequestForBlockStore(http.MethodPost,
+			"/api/v1/shares/secret/blockstore/warm", nil, "name", "secret")
+		w := httptest.NewRecorder()
+		h.Warm(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("Warm error status = %d, want 400", w.Code)
+		}
+		var p Problem
+		_ = json.NewDecoder(w.Body).Decode(&p)
+		if strings.Contains(p.Detail, "secret") {
+			t.Errorf("Detail leaks share name: %q", p.Detail)
+		}
+	})
+
+	t.Run("status_found", func(t *testing.T) {
+		fake := &fakeBlockStoreRuntime{
+			warmStatus: &shares.WarmJob{ID: "warm-/myshare-1", Share: "/myshare", State: shares.WarmStateDone, BlocksTotal: 5, BlocksDone: 5, BytesDone: 100},
+			warmFound:  true,
+		}
+		h := NewBlockStoreStatsHandler(fake)
+		req := newChiRequestForBlockStore(http.MethodGet,
+			"/api/v1/shares/myshare/blockstore/warm/warm-/myshare-1", nil, "name", "myshare", "job_id", "warm-/myshare-1")
+		w := httptest.NewRecorder()
+		h.WarmStatus(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("WarmStatus = %d, want 200", w.Code)
+		}
+		var resp WarmJobStatusResponse
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp.State != shares.WarmStateDone || resp.BlocksDone != 5 || resp.BytesDone != 100 {
+			t.Fatalf("unexpected status: %+v", resp)
+		}
+	})
+
+	t.Run("status_unknown_404", func(t *testing.T) {
+		fake := &fakeBlockStoreRuntime{warmFound: false}
+		h := NewBlockStoreStatsHandler(fake)
+		req := newChiRequestForBlockStore(http.MethodGet,
+			"/api/v1/shares/myshare/blockstore/warm/nope", nil, "name", "myshare", "job_id", "nope")
+		w := httptest.NewRecorder()
+		h.WarmStatus(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("WarmStatus unknown = %d, want 404", w.Code)
 		}
 	})
 }

--- a/pkg/apiclient/blockstore.go
+++ b/pkg/apiclient/blockstore.go
@@ -59,6 +59,51 @@ func (c *Client) BlockStoreEvictForShare(shareName string, req *BlockStoreEvictO
 	return createResource[BlockStoreEvictResult](c, fmt.Sprintf("/api/v1/shares/%s/blockstore/evict", url.PathEscape(normalizeShareNameForAPI(shareName))), req)
 }
 
+// WarmJobStatus is the wire-shape for an async share-warm job, returned by
+// GetShareWarm and embedded in StartShareWarm's response.
+type WarmJobStatus struct {
+	ID          string `json:"id"`
+	Share       string `json:"share"`
+	State       string `json:"state"`
+	BlocksTotal int64  `json:"blocks_total"`
+	BlocksDone  int64  `json:"blocks_done"`
+	BytesDone   int64  `json:"bytes_done"`
+	StartedAt   string `json:"started_at,omitempty"`
+	FinishedAt  string `json:"finished_at,omitempty"`
+	Error       string `json:"error,omitempty"`
+}
+
+// warmStartResponse is the 202 body from POST .../blockstore/warm.
+type warmStartResponse struct {
+	JobID  string        `json:"job_id"`
+	Status WarmJobStatus `json:"status"`
+}
+
+// StartShareWarm starts (or returns the already-running) async warm job that
+// materializes the named share's blocks onto its local tier. Returns the job
+// id to poll via GetShareWarm.
+func (c *Client) StartShareWarm(name string) (string, error) {
+	resp, err := createResource[warmStartResponse](
+		c,
+		fmt.Sprintf("/api/v1/shares/%s/blockstore/warm", url.PathEscape(normalizeShareNameForAPI(name))),
+		struct{}{},
+	)
+	if err != nil {
+		return "", err
+	}
+	return resp.JobID, nil
+}
+
+// GetShareWarm returns the current status of warm job jobID for the named
+// share.
+func (c *Client) GetShareWarm(name, jobID string) (*WarmJobStatus, error) {
+	return getResource[WarmJobStatus](
+		c,
+		fmt.Sprintf("/api/v1/shares/%s/blockstore/warm/%s",
+			url.PathEscape(normalizeShareNameForAPI(name)), url.PathEscape(jobID)),
+	)
+}
+
 // BlockStoreGCOptions is the request body for
 // POST /api/v1/shares/{name}/blockstore/gc. DryRun maps to
 // engine.Options.DryRun: mark + sweep enumeration runs but no DELETEs

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -755,6 +755,20 @@ func (bs *Store) EvictLocal(ctx context.Context, payloadID string) error {
 	return bs.local.DeleteAppendLog(ctx, payloadID)
 }
 
+// WarmAll proactively fetches every remote block of every payload in this
+// share onto the local CAS tier, delegating to the syncer's WarmAll under the
+// store's close-gate so a concurrent Close drains the run instead of racing
+// the local/syncer/remote teardown. See (*Syncer).WarmAll for semantics
+// (bounded by ParallelDownloads, errors on a missing remote, terminal on
+// ErrDiskFull, honors ctx cancellation). progress may be nil.
+func (bs *Store) WarmAll(ctx context.Context, progress func(done, total int64)) (WarmResult, error) {
+	if err := bs.enter(); err != nil {
+		return WarmResult{}, err
+	}
+	defer bs.closeMu.RUnlock()
+	return bs.syncer.WarmAll(ctx, progress)
+}
+
 // loadCache returns the current cache under cacheMu. Always non-nil (Null
 // Object pattern). Callers invoke the returned interface's methods OUTSIDE
 // the lock — cacheMu only guards the field read.

--- a/pkg/block/engine/warm.go
+++ b/pkg/block/engine/warm.go
@@ -1,0 +1,154 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/local/fs"
+)
+
+// WarmResult summarizes a WarmAll run: how many blocks were fetched from the
+// remote tier, how many bytes that fetch moved, and how many blocks were
+// already physically present locally (skipped without a remote round-trip).
+type WarmResult struct {
+	BlocksFetched      int64 `json:"blocks_fetched"`
+	BytesFetched       int64 `json:"bytes_fetched"`
+	BlocksAlreadyLocal int64 `json:"blocks_already_local"`
+}
+
+// warmTarget identifies one (payloadID, blockIdx) pair that must be fetched.
+type warmTarget struct {
+	payloadID string
+	blockIdx  uint64
+}
+
+// WarmAll proactively materializes every block of every payload in this share
+// onto the local CAS tier by reusing the per-block fetch primitive
+// (fetchBlock). It enumerates payloads via the local store's ListFiles and the
+// per-payload FileBlock rows, skips any block already present locally, and
+// fetches the rest with bounded concurrency (SyncerConfig.ParallelDownloads).
+//
+// progress (may be nil) is invoked after each block is processed with the
+// running (done, total) counts so callers can drive a poll/UI. total is the
+// number of NOT-already-local blocks (the blocks this run will actually fetch).
+//
+// A nil remote tier is an error: there is nothing to warm from. A fetch that
+// fails with fs.ErrDiskFull is terminal — the bounded local tier cannot hold
+// the working set — so the whole run is cancelled and the error surfaced.
+// Context cancellation stops the run promptly.
+func (m *Syncer) WarmAll(ctx context.Context, progress func(done, total int64)) (WarmResult, error) {
+	if err := m.checkReady(ctx); err != nil {
+		return WarmResult{}, err
+	}
+	if m.remoteStore == nil {
+		return WarmResult{}, errors.New("warm: share has no remote tier to warm from")
+	}
+
+	// Enumerate all (payloadID, blockIdx) pairs and split into already-local
+	// (counted, skipped) and to-fetch (the work list). The enumeration walks
+	// the same surface as populateBlockCounts: local.ListFiles -> per-payload
+	// ListFileBlocks. blockIdx is derived from the chunk's absolute offset the
+	// same way the read path does (resolveFileBlockFromRows / blockRange).
+	var (
+		targets      []warmTarget
+		alreadyLocal int64
+	)
+	for _, payloadID := range m.local.ListFiles() {
+		if err := ctx.Err(); err != nil {
+			return WarmResult{}, err
+		}
+		rows, err := m.listFileBlocksSnapshot(ctx, payloadID)
+		if err != nil {
+			return WarmResult{}, fmt.Errorf("warm: list blocks for %s: %w", payloadID, err)
+		}
+		for _, fb := range rows {
+			if fb == nil {
+				continue
+			}
+			abs, ok := block.ParseChunkOffset(fb.ID)
+			if !ok {
+				continue
+			}
+			blockIdx := abs / uint64(BlockSize)
+			if m.blockIsLocalFromRow(ctx, fb) {
+				alreadyLocal++
+				continue
+			}
+			targets = append(targets, warmTarget{payloadID: payloadID, blockIdx: blockIdx})
+		}
+	}
+
+	total := int64(len(targets))
+	if progress != nil {
+		progress(0, total)
+	}
+	if total == 0 {
+		return WarmResult{BlocksAlreadyLocal: alreadyLocal}, nil
+	}
+
+	parallel := m.config.ParallelDownloads
+	if parallel < 1 {
+		parallel = 1
+	}
+
+	var (
+		blocksFetched atomic.Int64
+		bytesFetched  atomic.Int64
+		done          atomic.Int64
+	)
+
+	g, gctx := errgroup.WithContext(ctx)
+	sem := make(chan struct{}, parallel)
+
+	for _, t := range targets {
+		t := t
+		// Block for a slot, but stop dispatching the moment the group is
+		// failing/cancelled (a fetch returned an error or ctx was cancelled).
+		select {
+		case <-gctx.Done():
+		case sem <- struct{}{}:
+		}
+		if gctx.Err() != nil {
+			break
+		}
+		g.Go(func() error {
+			defer func() { <-sem }()
+			data, err := m.fetchBlock(gctx, t.payloadID, t.blockIdx)
+			if err != nil {
+				if errors.Is(err, fs.ErrDiskFull) {
+					return fmt.Errorf("warm: local tier full while fetching %s/%d (raise local_store_size or evict): %w",
+						t.payloadID, t.blockIdx, err)
+				}
+				return fmt.Errorf("warm: fetch %s/%d: %w", t.payloadID, t.blockIdx, err)
+			}
+			if data != nil {
+				blocksFetched.Add(1)
+				bytesFetched.Add(int64(len(data)))
+			}
+			cur := done.Add(1)
+			if progress != nil {
+				progress(cur, total)
+			}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return WarmResult{
+			BlocksFetched:      blocksFetched.Load(),
+			BytesFetched:       bytesFetched.Load(),
+			BlocksAlreadyLocal: alreadyLocal,
+		}, err
+	}
+
+	return WarmResult{
+		BlocksFetched:      blocksFetched.Load(),
+		BytesFetched:       bytesFetched.Load(),
+		BlocksAlreadyLocal: alreadyLocal,
+	}, nil
+}

--- a/pkg/block/engine/warm_test.go
+++ b/pkg/block/engine/warm_test.go
@@ -1,0 +1,161 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	memorylocal "github.com/marmos91/dittofs/pkg/block/local/memory"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	"lukechampine.com/blake3"
+)
+
+// listFilesLocal wraps a memory LocalStore and overrides ListFiles to return a
+// fixed payload set. The memory store only tracks files that were written
+// through its append path; the warm tests seed blocks straight into the CAS +
+// FileBlock store, so this lets WarmAll enumerate them without a write loop.
+type listFilesLocal struct {
+	*memorylocal.MemoryStore
+	files []string
+}
+
+func (l *listFilesLocal) ListFiles() []string { return append([]string(nil), l.files...) }
+
+// seedFileBlockAt installs a FileBlock row covering [offset, offset+len(data))
+// under payloadID and seeds the remote CAS with the matching bytes. Unlike
+// seedFileBlock it lets the test place a row at a non-zero chunk offset so a
+// single payload can carry multiple blocks.
+func seedFileBlockAt(t *testing.T, fbs *stubFileBlockStore, rs *remotememory.Store, payloadID string, offset uint64, data []byte) block.ContentHash {
+	t.Helper()
+	hash := block.ContentHash(blake3.Sum256(data))
+	if err := rs.Put(context.Background(), hash, data); err != nil {
+		t.Fatalf("seed remote Put: %v", err)
+	}
+	fb := &block.FileBlock{
+		ID:       payloadIDChunkID(payloadID, offset),
+		Hash:     hash,
+		DataSize: uint32(len(data)),
+		State:    block.BlockStateRemote,
+	}
+	if err := fbs.Put(context.Background(), fb); err != nil {
+		t.Fatalf("seed FileBlock at offset %d: %v", offset, err)
+	}
+	return hash
+}
+
+func payloadIDChunkID(payloadID string, offset uint64) string {
+	return payloadID + "/" + itoa(offset)
+}
+
+func itoa(n uint64) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}
+
+// warmHarness wires a Syncer over a list-aware memory local store, a memory
+// remote, and a stub FileBlock store.
+func warmHarness(payloads []string) (*Syncer, *listFilesLocal, *remotememory.Store, *stubFileBlockStore) {
+	loc := &listFilesLocal{MemoryStore: memorylocal.New(), files: payloads}
+	rs := remotememory.New()
+	fbs := newStubFileBlockStore()
+	m := newFetchSyncer(loc, rs, fbs)
+	return m, loc, rs, fbs
+}
+
+func TestWarmAll_FetchesMissingSkipsLocal(t *testing.T) {
+	ctx := context.Background()
+	m, loc, rs, fbs := warmHarness([]string{"payA", "payB"})
+
+	// payA: two remote blocks at offsets 0 and BlockSize.
+	hA0 := seedFileBlockAt(t, fbs, rs, "payA", 0, []byte("payA-block-zero-bytes"))
+	hA1 := seedFileBlockAt(t, fbs, rs, "payA", uint64(BlockSize), []byte("payA-block-one-bytes"))
+	// payB: one remote block at offset 0.
+	hB0 := seedFileBlockAt(t, fbs, rs, "payB", 0, []byte("payB-block-zero-bytes"))
+
+	// Pre-place payA/0 locally so WarmAll must skip it.
+	dataA0, err := rs.Get(ctx, hA0)
+	if err != nil {
+		t.Fatalf("remote Get hA0: %v", err)
+	}
+	if err := loc.Put(ctx, hA0, dataA0); err != nil {
+		t.Fatalf("pre-seed local hA0: %v", err)
+	}
+
+	// The progress callback is invoked concurrently from each fetch goroutine,
+	// so guard the captured counters (mirrors how the shares registry callback
+	// takes its mutex).
+	var (
+		progMu              sync.Mutex
+		lastDone, lastTotal int64
+	)
+	res, err := m.WarmAll(ctx, func(done, total int64) {
+		progMu.Lock()
+		lastDone, lastTotal = done, total
+		progMu.Unlock()
+	})
+	if err != nil {
+		t.Fatalf("WarmAll: %v", err)
+	}
+
+	if res.BlocksAlreadyLocal != 1 {
+		t.Errorf("BlocksAlreadyLocal = %d; want 1", res.BlocksAlreadyLocal)
+	}
+	if res.BlocksFetched != 2 {
+		t.Errorf("BlocksFetched = %d; want 2", res.BlocksFetched)
+	}
+	if res.BytesFetched <= 0 {
+		t.Errorf("BytesFetched = %d; want > 0", res.BytesFetched)
+	}
+	if lastTotal != 2 || lastDone != 2 {
+		t.Errorf("progress final = (%d/%d); want (2/2)", lastDone, lastTotal)
+	}
+
+	// Every block must now be present in the local CAS tier.
+	for _, h := range []block.ContentHash{hA0, hA1, hB0} {
+		has, err := loc.Has(ctx, h)
+		if err != nil {
+			t.Fatalf("local Has: %v", err)
+		}
+		if !has {
+			t.Errorf("block %s not local after WarmAll", h.String())
+		}
+	}
+}
+
+func TestWarmAll_NoRemote(t *testing.T) {
+	m, _, _, _ := warmHarness([]string{"payA"})
+	m.remoteStore = nil
+	if _, err := m.WarmAll(context.Background(), nil); err == nil {
+		t.Fatal("WarmAll with nil remote: want error, got nil")
+	}
+}
+
+func TestWarmAll_Cancellation(t *testing.T) {
+	m, _, rs, fbs := warmHarness([]string{"payA"})
+	// Seed several remote blocks so there is work to cancel.
+	for i := uint64(0); i < 8; i++ {
+		seedFileBlockAt(t, fbs, rs, "payA", i*uint64(BlockSize), []byte("payA-block-bytes-"+itoa(i)))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before the run starts
+
+	_, err := m.WarmAll(ctx, nil)
+	if err == nil {
+		t.Fatal("WarmAll with cancelled context: want error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v; want context.Canceled", err)
+	}
+}

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -288,6 +288,10 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 				// Per-share block store management
 				r.Get("/{name}/blockstore/stats", blockStoreHandler.Stats)
 				r.Post("/{name}/blockstore/evict", blockStoreHandler.Evict)
+				// Per-share async warm: start a job that materializes the
+				// share's blocks onto the local tier, then poll its status.
+				r.Post("/{name}/blockstore/warm", blockStoreHandler.Warm)
+				r.Get("/{name}/blockstore/warm/{job_id}", blockStoreHandler.WarmStatus)
 				// Per-share GC trigger + last-run summary.
 				// Mounted under /shares/{name}/blockstore/... so the route
 				// pattern stays consistent with stats/evict and avoids the

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -832,6 +832,18 @@ func (r *Runtime) EvictBlockStore(ctx context.Context, shareName string, opts sh
 	return r.sharesSvc.EvictBlockStore(ctx, shareName, opts)
 }
 
+// StartWarmBlockStore starts (or returns the already-running) async warm job
+// that materializes the named share's blocks onto its local tier.
+func (r *Runtime) StartWarmBlockStore(ctx context.Context, shareName string) (*shares.WarmJob, error) {
+	return r.sharesSvc.StartWarm(ctx, shareName)
+}
+
+// GetWarmStatus returns a snapshot of a warm job by ID, or (nil, false) if the
+// job is unknown.
+func (r *Runtime) GetWarmStatus(jobID string) (*shares.WarmJob, bool) {
+	return r.sharesSvc.GetWarm(jobID)
+}
+
 func (r *Runtime) GetUserStore() models.UserStore { return r.store }
 
 func (r *Runtime) GetIdentityStore() models.IdentityStore {

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -2066,7 +2066,7 @@ func (s *Service) StartWarm(_ context.Context, shareName string) (*WarmJob, erro
 	share, exists := s.registry[shareName]
 	if !exists {
 		s.mu.RUnlock()
-		return nil, fmt.Errorf("share %q not found", shareName)
+		return nil, fmt.Errorf("%w: %q", ErrShareNotFound, shareName)
 	}
 	if share.BlockStore == nil {
 		s.mu.RUnlock()

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -412,6 +412,11 @@ type Service struct {
 	// ForShare applies it to shares added later. Guarded by mu. Nil disables
 	// inline recording.
 	metricsRec local.MetricsRecorder
+
+	// warmJobs tracks in-flight/completed async share-warm jobs (one active per
+	// share). Self-guarded; runs warm runs on detached contexts cancelled on
+	// RemoveShare. See warm.go.
+	warmJobs *warmRegistry
 }
 
 func New() *Service {
@@ -420,6 +425,7 @@ func New() *Service {
 		reservations:    make(map[string]struct{}),
 		remoteStores:    make(map[string]*sharedRemote),
 		changeCallbacks: make(map[int]func(shares []string)),
+		warmJobs:        newWarmRegistry(),
 	}
 }
 
@@ -891,6 +897,16 @@ func (s *Service) createBlockStoreForShare(
 	// backends produce "" so the status handler can short-circuit.
 	share.localStoreDir = deriveLocalStoreDir(localCfg, config.Name)
 
+	// A pinned share never evicts, so a bounded local tier can fill and then
+	// fail reads with ErrDiskFull once the working set exceeds it. Warn the
+	// operator at startup (no behavior change) so the misconfiguration is
+	// visible before it bites a client.
+	if config.RetentionPolicy == block.RetentionPin && remoteStore != nil && bs.LocalStats().MaxDisk > 0 {
+		logger.Warn("pinned share with a bounded local tier: reads will fail with ErrDiskFull once the working set exceeds the local tier — raise local_store_size or drop the pin",
+			"share", config.Name,
+			"local_store_size", bs.LocalStats().MaxDisk)
+	}
+
 	logger.Info("Per-share BlockStore initialized",
 		"share", config.Name,
 		"mode", modeLabel(remoteStore != nil),
@@ -1101,6 +1117,10 @@ func (s *Service) RemoveShare(name string) error {
 	localStoreDir := share.localStoreDir
 	delete(s.registry, name)
 	s.mu.Unlock()
+
+	// Cancel any in-flight warm job for this share so it cannot keep fetching
+	// into a block store that is about to be closed.
+	s.warmJobs.cancelForShare(name)
 
 	var errs []error
 
@@ -2033,6 +2053,42 @@ func (s *Service) EvictBlockStore(ctx context.Context, shareName string, opts Ev
 	}
 
 	return &result, nil
+}
+
+// StartWarm starts (or returns the already-running) async warm job for
+// shareName. The job proactively materializes every remote block of the share
+// onto the local tier (engine.Store.WarmAll) on a DETACHED context so it
+// outlives the request that triggered it; RemoveShare cancels it. Returns an
+// error if the share is unknown or has no block store. The returned WarmJob is
+// a snapshot taken under the registry lock.
+func (s *Service) StartWarm(_ context.Context, shareName string) (*WarmJob, error) {
+	s.mu.RLock()
+	share, exists := s.registry[shareName]
+	if !exists {
+		s.mu.RUnlock()
+		return nil, fmt.Errorf("share %q not found", shareName)
+	}
+	if share.BlockStore == nil {
+		s.mu.RUnlock()
+		return nil, fmt.Errorf("share %q has no block store configured", shareName)
+	}
+	bs := share.BlockStore
+	s.mu.RUnlock()
+
+	job := s.warmJobs.start(shareName, func(ctx context.Context, progress func(done, total int64)) (warmAllResult, error) {
+		res, err := bs.WarmAll(ctx, progress)
+		return warmAllResult{
+			BlocksFetched:      res.BlocksFetched,
+			BytesFetched:       res.BytesFetched,
+			BlocksAlreadyLocal: res.BlocksAlreadyLocal,
+		}, err
+	})
+	return job, nil
+}
+
+// GetWarm returns a snapshot of the warm job by ID, or (nil, false) if unknown.
+func (s *Service) GetWarm(jobID string) (*WarmJob, bool) {
+	return s.warmJobs.get(jobID)
 }
 
 // deriveGCStateRoot returns the per-share gc-state directory used by the

--- a/pkg/controlplane/runtime/shares/warm.go
+++ b/pkg/controlplane/runtime/shares/warm.go
@@ -17,6 +17,12 @@ const (
 	WarmStateCanceled = "canceled"
 )
 
+// maxRetainedJobs bounds the number of terminal (done/failed/canceled) jobs the
+// registry keeps so clients can still poll a recently-finished job, without the
+// jobs map growing without bound on a long-running server that warms repeatedly.
+// Running jobs are never evicted.
+const maxRetainedJobs = 32
+
 // WarmJob is the process-local record of an async share-warm operation
 // (proactively materializing a share's blocks onto the local tier). It is
 // in-memory only: jobs do not survive a restart. All fields are read/written
@@ -44,11 +50,24 @@ func (j *WarmJob) clone() *WarmJob {
 // share. It is process-local and mutex-guarded; the cancel funcs let
 // RemoveShare tear down a running warm so it does not outlive its block store.
 type warmRegistry struct {
-	mu      sync.Mutex
-	jobs    map[string]*WarmJob           // jobID -> job
-	active  map[string]string             // shareName -> active jobID (running only)
-	cancels map[string]context.CancelFunc // jobID -> detached-context cancel
-	counter int64                         // monotonic, for deterministic job IDs
+	mu        sync.Mutex
+	jobs      map[string]*WarmJob           // jobID -> job
+	active    map[string]string             // shareName -> active jobID (running only)
+	cancels   map[string]context.CancelFunc // jobID -> detached-context cancel
+	counter   int64                         // monotonic, for deterministic job IDs
+	completed []string                      // FIFO of terminal jobIDs, bounded by maxRetainedJobs
+}
+
+// retire records a job that has reached a terminal state and evicts the oldest
+// retained terminal jobs once the window exceeds maxRetainedJobs, so the jobs
+// map cannot grow without bound. Caller must hold r.mu.
+func (r *warmRegistry) retire(jobID string) {
+	r.completed = append(r.completed, jobID)
+	for len(r.completed) > maxRetainedJobs {
+		oldest := r.completed[0]
+		r.completed = r.completed[1:]
+		delete(r.jobs, oldest)
+	}
 }
 
 func newWarmRegistry() *warmRegistry {
@@ -140,6 +159,8 @@ func (r *warmRegistry) start(shareName string, run func(ctx context.Context, pro
 			j.State = WarmStateFailed
 			j.Err = err.Error()
 		}
+		// Bound retained terminal jobs so the jobs map cannot grow without limit.
+		r.retire(jobID)
 		logger.Debug("warm job finished",
 			"job", jobID, "share", shareName, "state", j.State,
 			"blocks_done", j.BlocksDone, "bytes_done", j.BytesDone, "error", j.Err)

--- a/pkg/controlplane/runtime/shares/warm.go
+++ b/pkg/controlplane/runtime/shares/warm.go
@@ -1,0 +1,175 @@
+package shares
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/logger"
+)
+
+// Warm job states.
+const (
+	WarmStateRunning  = "running"
+	WarmStateDone     = "done"
+	WarmStateFailed   = "failed"
+	WarmStateCanceled = "canceled"
+)
+
+// WarmJob is the process-local record of an async share-warm operation
+// (proactively materializing a share's blocks onto the local tier). It is
+// in-memory only: jobs do not survive a restart. All fields are read/written
+// under the warmRegistry mutex.
+type WarmJob struct {
+	ID    string `json:"id"`
+	Share string `json:"share"`
+	// State is one of WarmState{Running,Done,Failed,Canceled}.
+	State       string    `json:"state"`
+	BlocksTotal int64     `json:"blocks_total"`
+	BlocksDone  int64     `json:"blocks_done"`
+	BytesDone   int64     `json:"bytes_done"`
+	StartedAt   time.Time `json:"started_at"`
+	FinishedAt  time.Time `json:"finished_at"`
+	Err         string    `json:"error,omitempty"`
+}
+
+// clone returns a copy safe to hand outside the registry lock.
+func (j *WarmJob) clone() *WarmJob {
+	cp := *j
+	return &cp
+}
+
+// warmRegistry tracks in-flight and completed warm jobs, one active job per
+// share. It is process-local and mutex-guarded; the cancel funcs let
+// RemoveShare tear down a running warm so it does not outlive its block store.
+type warmRegistry struct {
+	mu      sync.Mutex
+	jobs    map[string]*WarmJob           // jobID -> job
+	active  map[string]string             // shareName -> active jobID (running only)
+	cancels map[string]context.CancelFunc // jobID -> detached-context cancel
+	counter int64                         // monotonic, for deterministic job IDs
+}
+
+func newWarmRegistry() *warmRegistry {
+	return &warmRegistry{
+		jobs:    make(map[string]*WarmJob),
+		active:  make(map[string]string),
+		cancels: make(map[string]context.CancelFunc),
+	}
+}
+
+// warmAllResult mirrors engine.WarmResult without coupling the registry to the
+// engine package. The adapter in StartWarm bridges the two.
+type warmAllResult struct {
+	BlocksFetched      int64
+	BytesFetched       int64
+	BlocksAlreadyLocal int64
+}
+
+// start launches a warm run for shareName against run on a DETACHED context
+// (derived from context.Background(), not the request ctx) so the job outlives
+// the HTTP request that triggered it. If a job is already running for the
+// share, the existing job is returned and run is not invoked.
+func (r *warmRegistry) start(shareName string, run func(ctx context.Context, progress func(done, total int64)) (warmAllResult, error)) *WarmJob {
+	r.mu.Lock()
+	if existingID, ok := r.active[shareName]; ok {
+		job := r.jobs[existingID].clone()
+		r.mu.Unlock()
+		return job
+	}
+
+	r.counter++
+	jobID := fmt.Sprintf("warm-%s-%d", shareName, r.counter)
+	job := &WarmJob{
+		ID:        jobID,
+		Share:     shareName,
+		State:     WarmStateRunning,
+		StartedAt: time.Now(),
+	}
+	r.jobs[jobID] = job
+	r.active[shareName] = jobID
+
+	ctx, cancel := context.WithCancel(context.Background())
+	r.cancels[jobID] = cancel
+
+	snapshot := job.clone()
+	r.mu.Unlock()
+
+	go func() {
+		progress := func(done, total int64) {
+			r.mu.Lock()
+			if j, ok := r.jobs[jobID]; ok {
+				j.BlocksDone = done
+				j.BlocksTotal = total
+			}
+			r.mu.Unlock()
+		}
+
+		res, err := run(ctx, progress)
+
+		// Classify BEFORE clearing the cancel func: cancelling here would set
+		// ctx.Err() and misclassify a plain failure as canceled.
+		canceled := ctx.Err() != nil
+
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		j, ok := r.jobs[jobID]
+		// Active mapping/cancel are cleared regardless of outcome so a later
+		// StartWarm for the same share can launch a fresh job.
+		if r.active[shareName] == jobID {
+			delete(r.active, shareName)
+		}
+		if c, ok := r.cancels[jobID]; ok {
+			c()
+			delete(r.cancels, jobID)
+		}
+		if !ok {
+			return
+		}
+		j.FinishedAt = time.Now()
+		j.BytesDone = res.BytesFetched
+		switch {
+		case err == nil:
+			j.State = WarmStateDone
+			j.BlocksDone = j.BlocksTotal
+		case canceled:
+			j.State = WarmStateCanceled
+			j.Err = err.Error()
+		default:
+			j.State = WarmStateFailed
+			j.Err = err.Error()
+		}
+		logger.Debug("warm job finished",
+			"job", jobID, "share", shareName, "state", j.State,
+			"blocks_done", j.BlocksDone, "bytes_done", j.BytesDone, "error", j.Err)
+	}()
+
+	return snapshot
+}
+
+// get returns a copy of the job by ID.
+func (r *warmRegistry) get(jobID string) (*WarmJob, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	job, ok := r.jobs[jobID]
+	if !ok {
+		return nil, false
+	}
+	return job.clone(), true
+}
+
+// cancelForShare cancels any running warm job for shareName. Called from
+// RemoveShare so a warm run cannot outlive the block store it materializes
+// into.
+func (r *warmRegistry) cancelForShare(shareName string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	jobID, ok := r.active[shareName]
+	if !ok {
+		return
+	}
+	if c, ok := r.cancels[jobID]; ok {
+		c()
+	}
+}

--- a/pkg/controlplane/runtime/shares/warm_retire_test.go
+++ b/pkg/controlplane/runtime/shares/warm_retire_test.go
@@ -1,0 +1,32 @@
+package shares
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestWarmRegistry_RetireBoundsJobsMap verifies that terminal jobs are evicted
+// once the retained window exceeds maxRetainedJobs, so a long-running server
+// that warms repeatedly cannot leak the jobs map without bound.
+func TestWarmRegistry_RetireBoundsJobsMap(t *testing.T) {
+	r := newWarmRegistry()
+
+	total := maxRetainedJobs + 10
+	for i := 0; i < total; i++ {
+		id := fmt.Sprintf("job-%d", i)
+		r.jobs[id] = &WarmJob{ID: id, State: WarmStateDone}
+		r.retire(id)
+	}
+
+	if got := len(r.jobs); got > maxRetainedJobs {
+		t.Errorf("jobs map size = %d, want <= %d", got, maxRetainedJobs)
+	}
+	// The oldest jobs are evicted; the most recent maxRetainedJobs are retained.
+	if _, ok := r.jobs["job-0"]; ok {
+		t.Errorf("oldest job (job-0) should have been evicted")
+	}
+	newest := fmt.Sprintf("job-%d", total-1)
+	if _, ok := r.jobs[newest]; !ok {
+		t.Errorf("newest job (%s) should still be retained for polling", newest)
+	}
+}

--- a/pkg/controlplane/runtime/shares/warm_test.go
+++ b/pkg/controlplane/runtime/shares/warm_test.go
@@ -1,0 +1,139 @@
+package shares
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// waitFor polls cond up to 2s; fails the test if it never becomes true.
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition not met within deadline")
+}
+
+func TestWarmRegistry_DeterministicIDsAndSuccess(t *testing.T) {
+	r := newWarmRegistry()
+
+	run := func(ctx context.Context, progress func(done, total int64)) (warmAllResult, error) {
+		progress(0, 2)
+		progress(1, 2)
+		progress(2, 2)
+		return warmAllResult{BlocksFetched: 2, BytesFetched: 42}, nil
+	}
+
+	job := r.start("/share", run)
+	if job.ID != "warm-/share-1" {
+		t.Fatalf("job ID = %q, want warm-/share-1", job.ID)
+	}
+	if job.State != WarmStateRunning {
+		t.Fatalf("initial state = %q, want running", job.State)
+	}
+
+	waitFor(t, func() bool {
+		j, _ := r.get(job.ID)
+		return j.State == WarmStateDone
+	})
+
+	j, ok := r.get(job.ID)
+	if !ok {
+		t.Fatal("job not found after completion")
+	}
+	if j.BlocksDone != 2 || j.BlocksTotal != 2 || j.BytesDone != 42 {
+		t.Fatalf("final job = %+v", j)
+	}
+	if j.FinishedAt.IsZero() {
+		t.Error("FinishedAt not set")
+	}
+
+	// A second start for the same share gets a fresh, monotonic ID.
+	job2 := r.start("/share", func(_ context.Context, _ func(done, total int64)) (warmAllResult, error) {
+		return warmAllResult{}, nil
+	})
+	if job2.ID != "warm-/share-2" {
+		t.Fatalf("second job ID = %q, want warm-/share-2", job2.ID)
+	}
+}
+
+func TestWarmRegistry_OneActivePerShare(t *testing.T) {
+	r := newWarmRegistry()
+
+	release := make(chan struct{})
+	var calls int
+	var mu sync.Mutex
+	run := func(_ context.Context, _ func(done, total int64)) (warmAllResult, error) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		<-release
+		return warmAllResult{}, nil
+	}
+
+	job1 := r.start("/share", run)
+	job2 := r.start("/share", run) // should return the running job, not start a new one
+	if job1.ID != job2.ID {
+		t.Fatalf("second start got a different job: %q vs %q", job1.ID, job2.ID)
+	}
+
+	close(release)
+	waitFor(t, func() bool {
+		j, _ := r.get(job1.ID)
+		return j.State == WarmStateDone
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("run invoked %d times, want 1", calls)
+	}
+}
+
+func TestWarmRegistry_CancelForShare(t *testing.T) {
+	r := newWarmRegistry()
+
+	started := make(chan struct{})
+	run := func(ctx context.Context, _ func(done, total int64)) (warmAllResult, error) {
+		close(started)
+		<-ctx.Done()
+		return warmAllResult{}, ctx.Err()
+	}
+
+	job := r.start("/share", run)
+	<-started
+	r.cancelForShare("/share")
+
+	waitFor(t, func() bool {
+		j, _ := r.get(job.ID)
+		return j.State == WarmStateCanceled
+	})
+
+	j, _ := r.get(job.ID)
+	if j.Err == "" {
+		t.Fatalf("canceled job missing error: %+v", j)
+	}
+}
+
+func TestWarmRegistry_Failure(t *testing.T) {
+	r := newWarmRegistry()
+	boom := errors.New("boom")
+	job := r.start("/share", func(_ context.Context, _ func(done, total int64)) (warmAllResult, error) {
+		return warmAllResult{}, boom
+	})
+	waitFor(t, func() bool {
+		j, _ := r.get(job.ID)
+		return j.State == WarmStateFailed
+	})
+	j, _ := r.get(job.ID)
+	if j.Err != "boom" {
+		t.Fatalf("failed job error = %q, want boom", j.Err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a per-share **warm** operation that proactively materializes a whole share's blocks onto the local disk tier, asynchronously (start a job, poll its status). It reuses the existing per-block remote-fetch primitive (`(*Syncer).fetchBlock`) — no parallel downloader — and is bounded by the per-share `ParallelDownloads` knob.

Also adds a one-line startup warning for a misconfiguration: a **pinned** share with a **bounded** local tier and a remote will fail reads with `ErrDiskFull` once its working set exceeds the tier.

Stacks logically on #1371 (the cache-bounding / marks-synced fix) — warm relies on `fetchBlock` being bounded and idempotent.

## Design

Async job model (no long-lived HTTP request):
- `POST /api/v1/shares/{name}/blockstore/warm` → `202` with `{ "job_id": ... }`, then
- `GET  /api/v1/shares/{name}/blockstore/warm/{job_id}` polls status.

`WarmAll` enumerates every payload (`local.ListFiles`) and its `FileBlock` rows (`ListFileBlocks`, the same surface as `populateBlockCounts`), skips blocks already physically local (`local.Has` via the existing `blockIsLocalFromRow` helper), and fetches the rest with an `errgroup` + semaphore sized to `ParallelDownloads`. A nil remote is an error; an `ErrDiskFull` fetch is terminal (cancels the group); context cancellation stops promptly.

The job registry is process-local, in-memory, mutex-guarded — one active job per share, deterministic monotonic IDs (`warm-<share>-<n>`). Each run executes on a **detached** context (from `context.Background()`), updated from the progress callback under the mutex. `RemoveShare` cancels any in-flight warm so it cannot outlive its block store.

Plumbed end to end mirroring `EvictBlockStore` at every layer (engine → shares service → runtime → REST → apiclient → dfsctl).

## Public API added

**Engine**
- `(*Syncer).WarmAll(ctx, progress func(done, total int64)) (WarmResult, error)`
- `(*Store).WarmAll(ctx, progress) (WarmResult, error)` (under the close-gate)
- `WarmResult { BlocksFetched, BytesFetched, BlocksAlreadyLocal int64 }`

**Runtime**
- `StartWarmBlockStore(ctx, shareName) (*shares.WarmJob, error)`
- `GetWarmStatus(jobID) (*shares.WarmJob, bool)`

**REST**
- `POST /api/v1/shares/{name}/blockstore/warm` → 202 `{ job_id, status }`
- `GET  /api/v1/shares/{name}/blockstore/warm/{job_id}` → `{ id, share, state, blocks_total, blocks_done, bytes_done, started_at, finished_at, error }`

**apiclient**
- `StartShareWarm(name) (jobID string, err error)`
- `GetShareWarm(name, jobID) (*WarmJobStatus, err)`

**dfsctl**
- `dfsctl share warm <name>` — start the job, print the id
- `dfsctl share warm --watch <name>` — poll ~1s, render `fetched X/Y blocks (Z)`, non-zero exit on failed/canceled

## Pin warning

In `createBlockStoreForShare`: when `RetentionPolicy == pin` AND the share has a remote AND the local tier has a non-zero max size, log one `Warn` suggesting raising `local_store_size` or dropping the pin. No behavior change.

## Tests

- engine `warm_test.go`: fetches missing / skips already-local / all-local afterward; nil-remote error; cancellation.
- shares `warm_test.go`: deterministic IDs, one-active-per-share, cancel-for-share, failure classification.
- handler `Warm` / `WarmStatus`: 202 + job id, error-detail-not-leaked, status found, unknown → 404.

`go vet`, `go build ./...`, `go test ./pkg/block/... ./pkg/controlplane/... ./pkg/apiclient/...`, `-race ./pkg/block/engine`, and `golangci-lint` all green. `docs/CLI.md` regenerated.

Refs #1362