### PR TITLE
fix(metadata): make pool-path CreateShare atomic (#1368)

### DIFF
--- a/pkg/metadata/store/postgres/shares.go
+++ b/pkg/metadata/store/postgres/shares.go
@@ -148,19 +148,22 @@ func (s *PostgresMetadataStore) CreateShare(ctx context.Context, share *metadata
 		Type: metadata.FileTypeDirectory,
 		Mode: 0o755,
 	}
-	if _, err := s.CreateRootDirectory(ctx, share.Name, rootAttr); err != nil {
-		return fmt.Errorf("create share %q root directory: %w", share.Name, err)
-	}
 
-	// Persist the requested options + block layout on the freshly-inserted
-	// row (CreateRootDirectory seeds only share_name + root_file_id, leaving
-	// options/block_layout at their column defaults). UpdateShareOptions
-	// applies the same ParseBlockLayout normalization the old INSERT did.
-	if err := s.UpdateShareOptions(ctx, share.Name, &share.Options); err != nil {
-		return fmt.Errorf("create share %q options: %w", share.Name, err)
-	}
-
-	return nil
+	// Root-inode insert and options write run in ONE transaction so the share
+	// can never be left half-created (root materialized but options stuck at
+	// their column defaults) if the second step fails or the process crashes
+	// between them. UpdateShareOptions applies the same ParseBlockLayout
+	// normalization the old INSERT did; CreateRootDirectory seeds only
+	// share_name + root_file_id, so the options UPDATE finishes the row.
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		if _, err := tx.CreateRootDirectory(ctx, share.Name, rootAttr); err != nil {
+			return fmt.Errorf("create share %q root directory: %w", share.Name, err)
+		}
+		if err := tx.UpdateShareOptions(ctx, share.Name, &share.Options); err != nil {
+			return fmt.Errorf("create share %q options: %w", share.Name, err)
+		}
+		return nil
+	})
 }
 
 // UpdateShareOptions updates the share configuration options.

--- a/pkg/metadata/store/sqlite/shares.go
+++ b/pkg/metadata/store/sqlite/shares.go
@@ -148,19 +148,22 @@ func (s *SQLiteMetadataStore) CreateShare(ctx context.Context, share *metadata.S
 		Type: metadata.FileTypeDirectory,
 		Mode: 0o755,
 	}
-	if _, err := s.CreateRootDirectory(ctx, share.Name, rootAttr); err != nil {
-		return fmt.Errorf("create share %q root directory: %w", share.Name, err)
-	}
 
-	// Persist the requested options + block layout on the freshly-inserted
-	// row (CreateRootDirectory seeds only share_name + root_file_id, leaving
-	// options/block_layout at their column defaults). UpdateShareOptions
-	// applies the same ParseBlockLayout normalization the old INSERT did.
-	if err := s.UpdateShareOptions(ctx, share.Name, &share.Options); err != nil {
-		return fmt.Errorf("create share %q options: %w", share.Name, err)
-	}
-
-	return nil
+	// Root-inode insert and options write run in ONE transaction so the share
+	// can never be left half-created (root materialized but options stuck at
+	// their column defaults) if the second step fails or the process crashes
+	// between them. UpdateShareOptions applies the same ParseBlockLayout
+	// normalization the old INSERT did; CreateRootDirectory seeds only
+	// share_name + root_file_id, so the options UPDATE finishes the row.
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		if _, err := tx.CreateRootDirectory(ctx, share.Name, rootAttr); err != nil {
+			return fmt.Errorf("create share %q root directory: %w", share.Name, err)
+		}
+		if err := tx.UpdateShareOptions(ctx, share.Name, &share.Options); err != nil {
+			return fmt.Errorf("create share %q options: %w", share.Name, err)
+		}
+		return nil
+	})
 }
 
 // UpdateShareOptions updates the share configuration options.


### PR DESCRIPTION
## Summary

Closes #1368.

Pool-path `CreateShare` (sqlite + postgres) created the share in two non-atomic steps:

1. `s.CreateRootDirectory` — inserts the root inode + `shares` row in its **own** transaction (commits).
2. `s.UpdateShareOptions` — a **separate** exec persisting the caller's options/block-layout.

A failure or crash between them left a share **half-created**: root inode materialized and the `shares` row present, but `options`/`block_layout` stuck at their column defaults. SQLite's `SetMaxOpenConns(1)` serializes connections but does **not** make the two statements atomic.

## Fix

Wrap both steps in a single `WithTransaction`, calling the transaction-path `tx.CreateRootDirectory` + `tx.UpdateShareOptions` so they commit or roll back together. The block-layout validation and the duplicate-detection fast-path stay before the transaction (the latter is a fast path, not the integrity authority — the `shares` PRIMARY KEY is). Mirrors the existing `DeleteShare` transaction pattern; identical change in both stores.

## Verification

- `go build ./pkg/metadata/...`, `gofmt -s`, `go vet`, `golangci-lint` — clean
- `go test ./pkg/metadata/...` (incl. sqlite + postgres store conformance) — pass
- Behavior preserved: same call order, same error-wrap strings, same `ParseBlockLayout` normalization; only the transaction boundary changed
- code-simplifier + code-reviewer: no issues (executor isolation, retry idempotency, no nested-tx hazard all verified)