### PR TITLE
fix(smb): stable FileID across restart (#1228 Fix A)

### DIFF
--- a/internal/adapter/smb/handlers/fileid_seed_test.go
+++ b/internal/adapter/smb/handlers/fileid_seed_test.go
@@ -66,6 +66,26 @@ func TestSeedFileIDFromDurableHandles_NeverLowers(t *testing.T) {
 	}
 }
 
+// TestSeedFileIDFromDurableHandles_MaxUint64 verifies the overflow guard: a
+// persisted FileID holding the maximum uint64 must NOT seed the counter to it,
+// which would make the next GenerateFileID wrap to 0.
+func TestSeedFileIDFromDurableHandles_MaxUint64(t *testing.T) {
+	store := newMockDurableStore()
+	_ = store.PutDurableHandle(context.Background(), durableWithFileID("max", ^uint64(0)))
+
+	h := NewHandler()
+	start := h.nextFileID.Load()
+	h.SeedFileIDFromDurableHandles(context.Background(), store)
+
+	if got := h.nextFileID.Load(); got != start {
+		t.Fatalf("counter seeded to %d on max-uint64 handle; want left at %d (no wrap)", got, start)
+	}
+	// And the next minted FileID must not be 0 (wrap sentinel).
+	if id := persistentHalf(h.GenerateFileID()); id == 0 {
+		t.Fatalf("GenerateFileID wrapped to 0 after max-uint64 seed")
+	}
+}
+
 // TestSeedFileIDFromDurableHandles_EmptyAndNil verifies the no-op paths: an
 // empty store and a nil store both leave the default start intact and never
 // panic.

--- a/internal/adapter/smb/handlers/fileid_seed_test.go
+++ b/internal/adapter/smb/handlers/fileid_seed_test.go
@@ -1,0 +1,85 @@
+package handlers
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// persistentHalf decodes the little-endian uint64 the FileID counter writes
+// into bytes 0..7, mirroring GenerateFileID's encoding.
+func persistentHalf(fileID [16]byte) uint64 {
+	return binary.LittleEndian.Uint64(fileID[0:8])
+}
+
+// durableWithFileID builds a persisted durable handle whose FileID persistent
+// half equals id (volatile half zeroed, as real persisted records store it).
+func durableWithFileID(idStr string, id uint64) *lock.PersistedDurableHandle {
+	var fileID [16]byte
+	binary.LittleEndian.PutUint64(fileID[0:8], id)
+	return &lock.PersistedDurableHandle{ID: idStr, FileID: fileID}
+}
+
+// TestSeedFileIDFromDurableHandles verifies the post-restart FileID counter is
+// bumped past the highest persisted durable-handle FileID, so a fresh CREATE
+// cannot re-mint a FileID a V1 reconnect would match (MS-SMB2 §3.3.5.9.7).
+func TestSeedFileIDFromDurableHandles(t *testing.T) {
+	store := newMockDurableStore()
+	_ = store.PutDurableHandle(context.Background(), durableWithFileID("a", 5))
+	_ = store.PutDurableHandle(context.Background(), durableWithFileID("b", 42))
+	_ = store.PutDurableHandle(context.Background(), durableWithFileID("c", 17))
+
+	h := NewHandler() // starts nextFileID at 1
+	h.SeedFileIDFromDurableHandles(context.Background(), store)
+
+	// First CREATE after seeding must land strictly above the max persisted
+	// FileID (42), so it cannot collide with any reclaimable durable open.
+	got := persistentHalf(h.GenerateFileID())
+	if got <= 42 {
+		t.Fatalf("first FileID after seed = %d, want > 42 (max persisted)", got)
+	}
+	if got != 43 {
+		t.Fatalf("first FileID after seed = %d, want 43 (max+1)", got)
+	}
+}
+
+// TestSeedFileIDFromDurableHandles_NeverLowers verifies the counter is only
+// bumped upward: a store whose handles are all below the current counter
+// leaves it untouched.
+func TestSeedFileIDFromDurableHandles_NeverLowers(t *testing.T) {
+	store := newMockDurableStore()
+	_ = store.PutDurableHandle(context.Background(), durableWithFileID("a", 3))
+
+	h := NewHandler()
+	// Advance the counter well past the persisted max.
+	for i := 0; i < 100; i++ {
+		h.GenerateFileID()
+	}
+	before := h.nextFileID.Load()
+
+	h.SeedFileIDFromDurableHandles(context.Background(), store)
+
+	if after := h.nextFileID.Load(); after != before {
+		t.Fatalf("counter moved from %d to %d; seed must never lower it", before, after)
+	}
+}
+
+// TestSeedFileIDFromDurableHandles_EmptyAndNil verifies the no-op paths: an
+// empty store and a nil store both leave the default start intact and never
+// panic.
+func TestSeedFileIDFromDurableHandles_EmptyAndNil(t *testing.T) {
+	h := NewHandler()
+	start := h.nextFileID.Load()
+
+	h.SeedFileIDFromDurableHandles(context.Background(), newMockDurableStore())
+	if got := h.nextFileID.Load(); got != start {
+		t.Fatalf("empty store changed counter to %d, want %d", got, start)
+	}
+
+	h.SeedFileIDFromDurableHandles(context.Background(), nil)
+	if got := h.nextFileID.Load(); got != start {
+		t.Fatalf("nil store changed counter to %d, want %d", got, start)
+	}
+}

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -1970,12 +1970,14 @@ func (h *Handler) baseFileUUID(authCtx *metadata.AuthContext, parentHandle metad
 // after a server restart freshly minted FileIDs cannot collide with the
 // FileID of a still-reclaimable durable open.
 //
-// Without this, the counter restarts at 1 every process start (see NewHandler),
-// while durable-handle records in the metadata store retain persistent halves
-// 1,2,3,…. A post-restart CREATE would re-mint a persistent half equal to a
-// persisted handle's, and a V1 reconnect (DHnC) — which matches on the
-// persistent half alone, with no CreateGuid to disambiguate — could then
-// reconnect or consume the wrong file (MS-SMB2 §3.3.5.9.7).
+// Without this, the counter restarts at 1 every process start (see NewHandler;
+// the first issued persistent half is 2, since GenerateFileID pre-increments),
+// while durable-handle records in the metadata store retain the persistent
+// halves issued before the restart. A post-restart CREATE would re-mint a
+// persistent half equal to a persisted handle's, and a V1 reconnect (DHnC) —
+// which matches on the persistent half alone, with no CreateGuid to
+// disambiguate — could then reconnect or consume the wrong file
+// (MS-SMB2 §3.3.5.9.7).
 //
 // Called once during adapter startup after the DurableStore is wired in.
 // The persistent half is the little-endian uint64 in bytes 0..7 of FileID,
@@ -2000,6 +2002,15 @@ func (h *Handler) SeedFileIDFromDurableHandles(ctx context.Context, store lock.D
 		}
 	}
 	if maxID == 0 {
+		return
+	}
+	// Guard the overflow edge: if a persisted FileID already holds the maximum
+	// uint64, seeding to it would make the next GenerateFileID's Add(1) wrap to
+	// 0 (and the log line below wrap too), reintroducing collisions. Such a
+	// value can't be exceeded anyway, so skip seeding and surface it.
+	if maxID == ^uint64(0) {
+		logger.Warn("SMB: persisted durable handle holds max FileID; cannot seed counter safely",
+			"durable_handles", len(handles))
 		return
 	}
 	// The counter holds the *last issued* persistent half — GenerateFileID

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"strings"
 	"sync"
@@ -1962,6 +1963,61 @@ func (h *Handler) baseFileUUID(authCtx *metadata.AuthContext, parentHandle metad
 		}
 	}
 	return fallback
+}
+
+// SeedFileIDFromDurableHandles bumps the persistent-half FileID counter past
+// the highest value already recorded in persisted durable handles, so that
+// after a server restart freshly minted FileIDs cannot collide with the
+// FileID of a still-reclaimable durable open.
+//
+// Without this, the counter restarts at 1 every process start (see NewHandler),
+// while durable-handle records in the metadata store retain persistent halves
+// 1,2,3,…. A post-restart CREATE would re-mint a persistent half equal to a
+// persisted handle's, and a V1 reconnect (DHnC) — which matches on the
+// persistent half alone, with no CreateGuid to disambiguate — could then
+// reconnect or consume the wrong file (MS-SMB2 §3.3.5.9.7).
+//
+// Called once during adapter startup after the DurableStore is wired in.
+// The persistent half is the little-endian uint64 in bytes 0..7 of FileID,
+// matching the encoding GenerateFileID writes; the volatile half (bytes 8..15)
+// is zeroed in persisted records and ignored here.
+func (h *Handler) SeedFileIDFromDurableHandles(ctx context.Context, store lock.DurableHandleStore) {
+	if store == nil {
+		return
+	}
+	handles, err := store.ListDurableHandles(ctx)
+	if err != nil {
+		logger.Warn("SMB: could not seed FileID counter from durable handles; "+
+			"using default start (FileID collision possible across restart)",
+			"error", err)
+		return
+	}
+	var maxID uint64
+	for _, dh := range handles {
+		id := binary.LittleEndian.Uint64(dh.FileID[:8])
+		if id > maxID {
+			maxID = id
+		}
+	}
+	if maxID == 0 {
+		return
+	}
+	// The counter holds the *last issued* persistent half — GenerateFileID
+	// pre-increments via Add(1) — so storing maxID makes the next issued
+	// FileID maxID+1, strictly above every persisted handle. Bump only
+	// upward: a concurrent CREATE may already have advanced the counter at or
+	// past maxID, so never lower it.
+	for {
+		cur := h.nextFileID.Load()
+		if cur >= maxID {
+			return
+		}
+		if h.nextFileID.CompareAndSwap(cur, maxID) {
+			logger.Info("SMB: seeded FileID counter past persisted durable handles",
+				"next_file_id", maxID+1, "durable_handles", len(handles))
+			return
+		}
+	}
 }
 
 // GenerateFileID generates a new unique file ID

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -467,6 +467,11 @@ func (s *Adapter) Serve(ctx context.Context) error {
 	if durableStore := s.findDurableHandleStore(); durableStore != nil {
 		s.handler.DurableStore = durableStore
 
+		// Seed the FileID counter past any persisted durable handles so a
+		// post-restart CREATE cannot re-mint a FileID still owned by a
+		// reclaimable durable open (MS-SMB2 §3.3.5.9.7).
+		s.handler.SeedFileIDFromDurableHandles(ctx, durableStore)
+
 		durableTimeout := uint32(DefaultDurableHandleTimeout)
 		if s.handler.DurableTimeoutMs != 0 {
 			durableTimeout = s.handler.DurableTimeoutMs


### PR DESCRIPTION
## What

Seed the SMB2 FileId persistent-half counter past any persisted durable handles at adapter startup, so a post-restart `CREATE` cannot re-mint a FileID still owned by a reclaimable durable open.

## Why (the bug)

`GenerateFileID` mints the FileId persistent half from `nextFileID`, an in-memory counter that resets to `1` every server start (`handler.go` `NewHandler`). Durable-handle records, however, persist FileIDs in the metadata store across restart.

So after a restart, fresh `CREATE`s re-issue persistent halves `1,2,3,…` — the same values already held by persisted durable handles. A **V1 durable reconnect (DHnC)** matches on the persistent half **alone** (no CreateGuid to disambiguate), so it could reconnect or atomically consume the **wrong file** (MS-SMB2 §3.3.5.9.7). Low probability, real correctness bug.

## Fix

New `Handler.SeedFileIDFromDurableHandles(ctx, store)`:
- Lists persisted durable handles, finds the max persistent half (little-endian `FileID[:8]`, matching `GenerateFileID`'s encoding).
- Bumps the counter to that max via an **upward-only CAS loop** (never lowers — a concurrent `CREATE` may already have advanced it). Counter holds the *last-issued* value, so storing `maxID` makes the next issued FileID `maxID+1`.
- No-ops on nil store, list error (logged), or empty store.

Called once in `pkg/adapter/smb/adapter.go` `Serve`, right after `DurableStore` is wired in (same gate as the scavenger). Reuses the existing `ListDurableHandles` — no new per-backend store method.

## Tests

`fileid_seed_test.go`: seeds past max persisted; never lowers when counter already ahead; nil/empty store no-op.

## Scope

Fix A of #1228. Fix B (SET_INFO unmapped-SID silent no-op) + interop-matrix doc to follow in a separate PR. SACL preserve-on-write tracked separately.