### PR TITLE
fix(block): warm + stats enumerate from metadata, not local store (#1374)

### DIFF
--- a/cmd/dfs/commands/migrate_to_cas.go
+++ b/cmd/dfs/commands/migrate_to_cas.go
@@ -403,3 +403,6 @@ func (nopFileBlockStore) GetFileBlock(_ context.Context, _ string) (*block.FileB
 func (nopFileBlockStore) ListFileBlocks(_ context.Context, _ string) ([]*block.FileBlock, error) {
 	return nil, nil
 }
+func (nopFileBlockStore) EnumeratePayloads(_ context.Context, _ func(payloadID string) error) error {
+	return nil
+}

--- a/internal/bench/phase19_test.go
+++ b/internal/bench/phase19_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"math/rand"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -269,4 +270,23 @@ func (s *aggregateStubFileBlockStore) ListFileBlocks(_ context.Context, payloadI
 		}
 	}
 	return out, nil
+}
+func (s *aggregateStubFileBlockStore) EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error {
+	s.mu.Lock()
+	seen := make(map[string]struct{})
+	for id := range s.blocks {
+		if i := strings.Index(id, "/"); i >= 0 {
+			seen[id[:i]] = struct{}{}
+		}
+	}
+	s.mu.Unlock()
+	for payloadID := range seen {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := fn(payloadID); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -737,6 +737,10 @@ func (bs *Store) SetRequireDurableCommit(v bool) {
 func (bs *Store) RemoteStore() remote.RemoteStore { return bs.remote }
 
 // ListFiles returns the payloadIDs of all files tracked in the local store.
+// This reflects only locally-present payloads (those with a live append log);
+// it goes empty after rollup. Callers needing every payload (including
+// rolled-up ones) should enumerate the authoritative metadata via the
+// fileBlock store's EnumeratePayloads instead.
 func (bs *Store) ListFiles() []string { return bs.local.ListFiles() }
 
 // EvictLocal removes all local per-file state (memory tracking, files

--- a/pkg/block/engine/engine_test.go
+++ b/pkg/block/engine/engine_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -103,6 +104,25 @@ func (s *stubFileBlockStore) ListFileBlocks(_ context.Context, payloadID string)
 		}
 	}
 	return out, nil
+}
+func (s *stubFileBlockStore) EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error {
+	s.mu.Lock()
+	seen := make(map[string]struct{})
+	for id := range s.blocks {
+		if i := strings.Index(id, "/"); i >= 0 {
+			seen[id[:i]] = struct{}{}
+		}
+	}
+	s.mu.Unlock()
+	for payloadID := range seen {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := fn(payloadID); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // newTestEngine creates an engine.Store with memory local store, nil remote

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -184,6 +184,22 @@ func (m *Syncer) fetchBlock(ctx context.Context, payloadID string, blockIdx uint
 		return nil, nil
 	}
 
+	return m.fetchResolvedBlock(ctx, fb)
+}
+
+// fetchResolvedBlock downloads the already-resolved FileBlock row from the
+// remote store, persists it to the local CAS tier, and marks it
+// fetched-synced. It is the post-resolve body shared by fetchBlock (which
+// resolves by blockIdx round-trip) and WarmAll (which already holds the row
+// from enumeration, so it must NOT re-resolve by blockIdx — FastCDC chunks
+// start at arbitrary, non-BlockSize-aligned offsets, and a blockIdx lookup
+// would miss every non-aligned chunk and silently skip it). Returns nil data
+// when the row has no actionable remote key (sparse / never-uploaded).
+func (m *Syncer) fetchResolvedBlock(ctx context.Context, fb *block.FileBlock) ([]byte, error) {
+	if fb == nil {
+		return nil, nil
+	}
+
 	storeKey, data, err := m.dispatchRemoteFetch(ctx, fb)
 	if err != nil {
 		if errors.Is(err, block.ErrChunkNotFound) {

--- a/pkg/block/engine/stats.go
+++ b/pkg/block/engine/stats.go
@@ -123,7 +123,6 @@ func (bs *Store) getStats(withBlockCounts bool) BlockStoreStats {
 	}
 
 	localStats := bs.local.Stats()
-	files := bs.local.ListFiles()
 
 	cacheStats := bs.loadCache().Stats()
 
@@ -134,7 +133,10 @@ func (bs *Store) getStats(withBlockCounts bool) BlockStoreStats {
 	outageDuration := bs.syncer.RemoteOutageDuration()
 
 	stats := BlockStoreStats{
-		FileCount:           len(files),
+		// FileCount is the cheap local-only count here; the full-stats path
+		// (withBlockCounts) overwrites it with the authoritative distinct-payload
+		// count from the metadata so it reflects rolled-up files too (#1374).
+		FileCount:           len(bs.local.ListFiles()),
 		LocalDiskUsed:       localStats.DiskUsed,
 		LocalDiskMax:        localStats.MaxDisk,
 		LocalMemUsed:        localStats.MemUsed,
@@ -159,14 +161,18 @@ func (bs *Store) getStats(withBlockCounts bool) BlockStoreStats {
 	}
 
 	if withBlockCounts {
-		bs.populateBlockCounts(&stats, files)
+		bs.populateBlockCounts(&stats)
 	}
 
 	return stats
 }
 
-// populateBlockCounts fills block count fields from the metadata store.
-func (bs *Store) populateBlockCounts(stats *BlockStoreStats, files []string) {
+// populateBlockCounts fills block count fields and FileCount from the
+// authoritative metadata. It enumerates payloads via
+// fileBlockStore.EnumeratePayloads (which survives rollup) rather than the
+// local store's ListFiles, so a rolled-up share whose append logs are gone
+// still reports its blocks and files instead of zero (#1374).
+func (bs *Store) populateBlockCounts(stats *BlockStoreStats) {
 	if bs.fileBlockStore == nil {
 		return
 	}
@@ -174,45 +180,59 @@ func (bs *Store) populateBlockCounts(stats *BlockStoreStats, files []string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	for _, payloadID := range files {
+	var payloadCount int
+	if err := bs.fileBlockStore.EnumeratePayloads(ctx, func(payloadID string) error {
+		payloadCount++
 		blocks, err := bs.fileBlockStore.ListFileBlocks(ctx, payloadID)
 		if err != nil {
-			continue
+			return nil // skip this payload, keep going
 		}
-		for _, b := range blocks {
-			stats.BlocksTotal++
-			// Classify by PHYSICAL presence in the local CAS store, not by sync
-			// state. A block fetched from remote keeps a BlockStateRemote row
-			// even though its CAS chunk now sits on local disk; classifying by
-			// state alone reported it as remote, so a fully read-cached share
-			// showed "Blocks Local: 0" while du showed the cache was full
-			// (#1362). A zero hash means the block is genuinely dirty/in-flight
-			// (rollup not yet complete) and cannot be present.
-			if !b.Hash.IsZero() {
-				if present, herr := bs.local.Has(ctx, b.Hash); herr == nil && present {
-					stats.BlocksLocal++
-					if b.State == block.BlockStateRemote {
-						// On disk yet the row says remote: read-through-cached.
-						stats.BlocksCached++
-					}
-					continue
+		bs.classifyBlocks(ctx, stats, blocks)
+		return nil
+	}); err != nil {
+		return
+	}
+	// Authoritative distinct-payload count (reflects rolled-up files too).
+	stats.FileCount = payloadCount
+}
+
+// classifyBlocks tallies a payload's FileBlock rows into the per-state stats
+// counters. Split out of populateBlockCounts so the EnumeratePayloads callback
+// stays readable; the classification logic is unchanged.
+func (bs *Store) classifyBlocks(ctx context.Context, stats *BlockStoreStats, blocks []*block.FileBlock) {
+	for _, b := range blocks {
+		stats.BlocksTotal++
+		// Classify by PHYSICAL presence in the local CAS store, not by sync
+		// state. A block fetched from remote keeps a BlockStateRemote row
+		// even though its CAS chunk now sits on local disk; classifying by
+		// state alone reported it as remote, so a fully read-cached share
+		// showed "Blocks Local: 0" while du showed the cache was full
+		// (#1362). A zero hash means the block is genuinely dirty/in-flight
+		// (rollup not yet complete) and cannot be present.
+		if !b.Hash.IsZero() {
+			if present, herr := bs.local.Has(ctx, b.Hash); herr == nil && present {
+				stats.BlocksLocal++
+				if b.State == block.BlockStateRemote {
+					// On disk yet the row says remote: read-through-cached.
+					stats.BlocksCached++
 				}
+				continue
 			}
-			// Not physically present (or zero hash): fall back to sync state.
-			switch b.State {
-			case block.BlockStatePending:
-				if b.Hash.IsZero() {
-					stats.BlocksDirty++
-				} else {
-					// Rollup-committed but absent from disk (evicted): the
-					// remote copy is authoritative; a read will refetch it.
-					stats.BlocksRemote++
-				}
-			case block.BlockStateSyncing:
-				stats.BlocksRemote++
-			case block.BlockStateRemote:
+		}
+		// Not physically present (or zero hash): fall back to sync state.
+		switch b.State {
+		case block.BlockStatePending:
+			if b.Hash.IsZero() {
+				stats.BlocksDirty++
+			} else {
+				// Rollup-committed but absent from disk (evicted): the
+				// remote copy is authoritative; a read will refetch it.
 				stats.BlocksRemote++
 			}
+		case block.BlockStateSyncing:
+			stats.BlocksRemote++
+		case block.BlockStateRemote:
+			stats.BlocksRemote++
 		}
 	}
 }

--- a/pkg/block/engine/stats_cached_test.go
+++ b/pkg/block/engine/stats_cached_test.go
@@ -41,7 +41,7 @@ func TestPopulateBlockCounts_ClassifiesByPhysicalPresence(t *testing.T) {
 	mustPutFB(t, fbs, &block.FileBlock{ID: payloadID + "/2", Hash: block.ContentHash{}, DataSize: 4, State: block.BlockStatePending})
 
 	var stats BlockStoreStats
-	bs.populateBlockCounts(&stats, []string{payloadID})
+	bs.populateBlockCounts(&stats)
 
 	if stats.BlocksTotal != 3 {
 		t.Errorf("BlocksTotal=%d, want 3", stats.BlocksTotal)

--- a/pkg/block/engine/syncer_test.go
+++ b/pkg/block/engine/syncer_test.go
@@ -9,6 +9,7 @@ import (
 	"iter"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -396,6 +397,25 @@ func (s *stubFBS) ListFileBlocks(_ context.Context, payloadID string) ([]*block.
 		}
 	}
 	return out, nil
+}
+func (s *stubFBS) EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error {
+	s.mu.Lock()
+	seen := make(map[string]struct{})
+	for id := range s.blocks {
+		if i := strings.Index(id, "/"); i >= 0 {
+			seen[id[:i]] = struct{}{}
+		}
+	}
+	s.mu.Unlock()
+	for payloadID := range seen {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := fn(payloadID); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // integrationFixture bundles every component the four mirror-loop

--- a/pkg/block/engine/warm.go
+++ b/pkg/block/engine/warm.go
@@ -29,9 +29,14 @@ type warmTarget struct {
 
 // WarmAll proactively materializes every block of every payload in this share
 // onto the local CAS tier by reusing the per-block fetch primitive
-// (fetchBlock). It enumerates payloads via the local store's ListFiles and the
-// per-payload FileBlock rows, skips any block already present locally, and
-// fetches the rest with bounded concurrency (SyncerConfig.ParallelDownloads).
+// (fetchBlock). It enumerates payloads from the authoritative metadata
+// (fileBlockStore.EnumeratePayloads) and the per-payload FileBlock rows, skips
+// any block already present locally, and fetches the rest with bounded
+// concurrency (SyncerConfig.ParallelDownloads). Enumerating the metadata rather
+// than the local store's ListFiles is what lets warm materialize payloads whose
+// append log was discarded after rollup — their FileBlock rows survive, but
+// local.ListFiles no longer reports them, so the old surface made warm a silent
+// no-op on rolled-up shares (#1374).
 //
 // progress (may be nil) is invoked after each block is processed with the
 // running (done, total) counts so callers can drive a poll/UI. total is the
@@ -51,14 +56,23 @@ func (m *Syncer) WarmAll(ctx context.Context, progress func(done, total int64)) 
 
 	// Enumerate all (payloadID, blockIdx) pairs and split into already-local
 	// (counted, skipped) and to-fetch (the work list). The enumeration walks
-	// the same surface as populateBlockCounts: local.ListFiles -> per-payload
-	// ListFileBlocks. blockIdx is derived from the chunk's absolute offset the
-	// same way the read path does (resolveFileBlockFromRows / blockRange).
+	// the same surface as populateBlockCounts: fileBlockStore.EnumeratePayloads
+	// -> per-payload ListFileBlocks (the authoritative metadata, which survives
+	// rollup). blockIdx is derived from the chunk's absolute offset the same way
+	// the read path does (resolveFileBlockFromRows / blockRange).
+	var payloadIDs []string
+	if err := m.fileBlockStore.EnumeratePayloads(ctx, func(payloadID string) error {
+		payloadIDs = append(payloadIDs, payloadID)
+		return nil
+	}); err != nil {
+		return WarmResult{}, fmt.Errorf("warm: enumerate payloads: %w", err)
+	}
+
 	var (
 		targets      []warmTarget
 		alreadyLocal int64
 	)
-	for _, payloadID := range m.local.ListFiles() {
+	for _, payloadID := range payloadIDs {
 		if err := ctx.Err(); err != nil {
 			return WarmResult{}, err
 		}

--- a/pkg/block/engine/warm.go
+++ b/pkg/block/engine/warm.go
@@ -21,15 +21,19 @@ type WarmResult struct {
 	BlocksAlreadyLocal int64 `json:"blocks_already_local"`
 }
 
-// warmTarget identifies one (payloadID, blockIdx) pair that must be fetched.
+// warmTarget identifies one FileBlock row that must be fetched. It carries the
+// resolved *block.FileBlock from enumeration so the worker fetches by the row
+// in hand rather than round-tripping through a blockIdx lookup — FastCDC chunks
+// start at arbitrary, non-BlockSize-aligned offsets, so a blockIdx lookup would
+// miss every non-aligned chunk and silently skip it (#1374).
 type warmTarget struct {
 	payloadID string
-	blockIdx  uint64
+	fb        *block.FileBlock
 }
 
 // WarmAll proactively materializes every block of every payload in this share
 // onto the local CAS tier by reusing the per-block fetch primitive
-// (fetchBlock). It enumerates payloads from the authoritative metadata
+// (fetchResolvedBlock). It enumerates payloads from the authoritative metadata
 // (fileBlockStore.EnumeratePayloads) and the per-payload FileBlock rows, skips
 // any block already present locally, and fetches the rest with bounded
 // concurrency (SyncerConfig.ParallelDownloads). Enumerating the metadata rather
@@ -54,12 +58,14 @@ func (m *Syncer) WarmAll(ctx context.Context, progress func(done, total int64)) 
 		return WarmResult{}, errors.New("warm: share has no remote tier to warm from")
 	}
 
-	// Enumerate all (payloadID, blockIdx) pairs and split into already-local
-	// (counted, skipped) and to-fetch (the work list). The enumeration walks
-	// the same surface as populateBlockCounts: fileBlockStore.EnumeratePayloads
-	// -> per-payload ListFileBlocks (the authoritative metadata, which survives
-	// rollup). blockIdx is derived from the chunk's absolute offset the same way
-	// the read path does (resolveFileBlockFromRows / blockRange).
+	// Enumerate all FileBlock rows and split into already-local (counted,
+	// skipped) and to-fetch (the work list). The enumeration walks the same
+	// surface as populateBlockCounts: fileBlockStore.EnumeratePayloads ->
+	// per-payload ListFileBlocks (the authoritative metadata, which survives
+	// rollup). Each to-fetch target carries the resolved row so the worker
+	// fetches by the row in hand (fetchResolvedBlock) instead of round-tripping
+	// through a BlockSize-aligned blockIdx lookup, which would miss every
+	// non-aligned FastCDC chunk (#1374).
 	var payloadIDs []string
 	if err := m.fileBlockStore.EnumeratePayloads(ctx, func(payloadID string) error {
 		payloadIDs = append(payloadIDs, payloadID)
@@ -84,16 +90,14 @@ func (m *Syncer) WarmAll(ctx context.Context, progress func(done, total int64)) 
 			if fb == nil {
 				continue
 			}
-			abs, ok := block.ParseChunkOffset(fb.ID)
-			if !ok {
+			if _, ok := block.ParseChunkOffset(fb.ID); !ok {
 				continue
 			}
-			blockIdx := abs / uint64(BlockSize)
 			if m.blockIsLocalFromRow(ctx, fb) {
 				alreadyLocal++
 				continue
 			}
-			targets = append(targets, warmTarget{payloadID: payloadID, blockIdx: blockIdx})
+			targets = append(targets, warmTarget{payloadID: payloadID, fb: fb})
 		}
 	}
 
@@ -132,13 +136,13 @@ func (m *Syncer) WarmAll(ctx context.Context, progress func(done, total int64)) 
 		}
 		g.Go(func() error {
 			defer func() { <-sem }()
-			data, err := m.fetchBlock(gctx, t.payloadID, t.blockIdx)
+			data, err := m.fetchResolvedBlock(gctx, t.fb)
 			if err != nil {
 				if errors.Is(err, fs.ErrDiskFull) {
-					return fmt.Errorf("warm: local tier full while fetching %s/%d (raise local_store_size or evict): %w",
-						t.payloadID, t.blockIdx, err)
+					return fmt.Errorf("warm: local tier full while fetching %s (raise local_store_size or evict): %w",
+						t.fb.ID, err)
 				}
-				return fmt.Errorf("warm: fetch %s/%d: %w", t.payloadID, t.blockIdx, err)
+				return fmt.Errorf("warm: fetch %s: %w", t.fb.ID, err)
 			}
 			if data != nil {
 				blocksFetched.Add(1)

--- a/pkg/block/engine/warm_test.go
+++ b/pkg/block/engine/warm_test.go
@@ -133,6 +133,41 @@ func TestWarmAll_FetchesMissingSkipsLocal(t *testing.T) {
 	}
 }
 
+// TestWarmAll_FetchesNonAlignedChunk guards #1374: FastCDC chunks start at
+// arbitrary byte offsets that do NOT align to BlockSize. The old WarmAll
+// fetched via fetchBlock(payloadID, blockIdx), and fetchBlock resolves the row
+// covering byte blockIdx*BlockSize — so a chunk whose offset is not a multiple
+// of BlockSize was never resolved and was silently skipped (WarmAll reported
+// success but fetched nothing). WarmAll now fetches the enumerated row directly
+// (fetchResolvedBlock), so the non-aligned chunk must land locally.
+func TestWarmAll_FetchesNonAlignedChunk(t *testing.T) {
+	ctx := context.Background()
+	m, _, rs, fbs := warmHarness([]string{"payA"})
+
+	// A remote-only chunk at a deliberately non-BlockSize-aligned offset.
+	offset := uint64(BlockSize) + 12345
+	hash := seedFileBlockAt(t, fbs, rs, "payA", offset, []byte("non-aligned-fastcdc-chunk-bytes"))
+
+	res, err := m.WarmAll(ctx, nil)
+	if err != nil {
+		t.Fatalf("WarmAll: %v", err)
+	}
+	if res.BlocksFetched != 1 {
+		t.Errorf("BlocksFetched = %d; want 1 (non-aligned chunk must be fetched)", res.BlocksFetched)
+	}
+	if res.BytesFetched <= 0 {
+		t.Errorf("BytesFetched = %d; want > 0", res.BytesFetched)
+	}
+
+	has, err := m.local.Has(ctx, hash)
+	if err != nil {
+		t.Fatalf("local Has: %v", err)
+	}
+	if !has {
+		t.Errorf("non-aligned chunk %s not present locally after WarmAll", hash.String())
+	}
+}
+
 func TestWarmAll_NoRemote(t *testing.T) {
 	m, _, _, _ := warmHarness([]string{"payA"})
 	m.remoteStore = nil

--- a/pkg/block/fileblock.go
+++ b/pkg/block/fileblock.go
@@ -160,6 +160,17 @@ type EngineFileBlockStore interface {
 	// "{payloadID}/", sorted by parsed numeric block index. Returns
 	// an empty (non-nil) slice when no blocks match.
 	ListFileBlocks(ctx context.Context, payloadID string) ([]*FileBlock, error)
+
+	// EnumeratePayloads streams every distinct payloadID that has at
+	// least one FileBlock row in this (share-scoped) store through fn,
+	// in no guaranteed order. It is the authoritative enumeration of a
+	// share's files: unlike the local block store's ListFiles (which
+	// tracks only payloads with a live append-log and goes empty once a
+	// payload rolls up), the FileBlock rows persist across rollup, so
+	// this also surfaces rolled-up and remote-only payloads. warm and
+	// stats drive off this rather than local.ListFiles. A non-nil error
+	// from fn aborts the enumeration and is returned.
+	EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error
 }
 
 // Reader defines read operations on the block store.

--- a/pkg/block/local/fs/appendlog_testhelpers_test.go
+++ b/pkg/block/local/fs/appendlog_testhelpers_test.go
@@ -51,6 +51,9 @@ func (nopFBS) GetFileBlock(_ context.Context, _ string) (*block.FileBlock, error
 func (nopFBS) ListFileBlocks(_ context.Context, _ string) ([]*block.FileBlock, error) {
 	return nil, nil
 }
+func (nopFBS) EnumeratePayloads(_ context.Context, _ func(payloadID string) error) error {
+	return nil
+}
 
 // newFSStoreForTest constructs an FSStore in t.TempDir with the given
 // options and a nopFBS backing store. Registers t.Cleanup to Close the

--- a/pkg/block/local/fs/drain_reset_testhelpers_test.go
+++ b/pkg/block/local/fs/drain_reset_testhelpers_test.go
@@ -63,6 +63,24 @@ func (m *memFBS) ListFileBlocks(_ context.Context, payloadID string) ([]*block.F
 	return out, nil
 }
 
+func (m *memFBS) EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error {
+	m.mu.Lock()
+	ids := make([]string, 0, len(m.rows))
+	for payloadID := range m.rows {
+		ids = append(ids, payloadID)
+	}
+	m.mu.Unlock()
+	for _, payloadID := range ids {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := fn(payloadID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (m *memFBS) GetFileBlock(_ context.Context, blockID string) (*block.FileBlock, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/pkg/block/local/fs/eviction_lsl08_conformance_test.go
+++ b/pkg/block/local/fs/eviction_lsl08_conformance_test.go
@@ -243,3 +243,7 @@ func (c *countingFBSWrapper) ListFileBlocks(ctx context.Context, payloadID strin
 	c.counter++
 	return c.inner.ListFileBlocks(ctx, payloadID)
 }
+func (c *countingFBSWrapper) EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error {
+	c.counter++
+	return c.inner.EnumeratePayloads(ctx, fn)
+}

--- a/pkg/block/local/fs/fs_test.go
+++ b/pkg/block/local/fs/fs_test.go
@@ -91,6 +91,9 @@ func (c *countingFileBlockStore) ListFileBlocks(ctx context.Context, payloadID s
 	c.listFileBlocks.Add(1)
 	return c.inner.ListFileBlocks(ctx, payloadID)
 }
+func (c *countingFileBlockStore) EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error {
+	return c.inner.EnumeratePayloads(ctx, fn)
+}
 
 // snapshot captures the current call counts for comparison.
 type fbsCallSnapshot struct {

--- a/pkg/block/local/fs/rollup_test.go
+++ b/pkg/block/local/fs/rollup_test.go
@@ -654,6 +654,9 @@ func (p *programmableFBS) GetFileBlock(ctx context.Context, id string) (*block.F
 func (p *programmableFBS) ListFileBlocks(ctx context.Context, payloadID string) ([]*block.FileBlock, error) {
 	return p.inner.ListFileBlocks(ctx, payloadID)
 }
+func (p *programmableFBS) EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error {
+	return p.inner.EnumeratePayloads(ctx, fn)
+}
 
 // newFSStoreForRollupLRUTest constructs an FSStore backed by a
 // programmableFBS wrapping a memory metadata store. The same store

--- a/pkg/block/local/fs/test_hooks.go
+++ b/pkg/block/local/fs/test_hooks.go
@@ -263,3 +263,6 @@ func (nopFBSForTest) GetFileBlock(_ context.Context, _ string) (*block.FileBlock
 func (nopFBSForTest) ListFileBlocks(_ context.Context, _ string) ([]*block.FileBlock, error) {
 	return nil, nil
 }
+func (nopFBSForTest) EnumeratePayloads(_ context.Context, _ func(payloadID string) error) error {
+	return nil
+}

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -398,6 +398,15 @@ type Store interface {
 	// as GetFileBlock above.
 	ListFileBlocks(ctx context.Context, payloadID string) ([]*block.FileBlock, error)
 
+	// EnumeratePayloads streams every distinct payloadID that has at least one
+	// FileBlock row through fn (deduped, order-independent). Unlike the local
+	// block store's ListFiles, this enumerates the authoritative metadata, so
+	// it still yields payloads whose append log was discarded after rollup.
+	// Used by `share warm` and block-store stats to enumerate the full payload
+	// set rather than only locally-present payloads. See
+	// block.EngineFileBlockStore.
+	EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error
+
 	// ========================================================================
 	// Usage Tracking
 	// ========================================================================

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -439,6 +439,56 @@ func (s *BadgerMetadataStore) ListFileBlocks(_ context.Context, payloadID string
 	return result, nil
 }
 
+// EnumeratePayloads streams every distinct payloadID that has at least one
+// FileBlock row through fn. It iterates the fb-file:{payloadID}:{blockIdx}
+// secondary index, extracts the payloadID (the substring before the LAST ':')
+// from each key, dedupes via a set, and calls fn once per distinct payloadID.
+// Unlike the local store's ListFiles, this enumerates the authoritative
+// metadata, so it still yields rolled-up payloads whose append log is gone.
+func (s *BadgerMetadataStore) EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error {
+	seen := make(map[string]struct{})
+	err := s.db.View(func(txn *badger.Txn) error {
+		prefix := []byte(fileBlockFilePrefix)
+		opts := badger.DefaultIteratorOptions
+		opts.Prefix = prefix
+		opts.PrefetchValues = false // Keys only — payloadID lives in the key
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			// Key form: fb-file:{payloadID}:{blockIdx}. payloadIDs do not
+			// contain ':', but split on the LAST ':' to be safe since blockIdx
+			// is the trailing numeric segment.
+			key := string(it.Item().Key()[len(prefix):])
+			i := strings.LastIndex(key, ":")
+			if i < 0 {
+				continue
+			}
+			payloadID := key[:i]
+			if _, ok := seen[payloadID]; ok {
+				continue
+			}
+			seen[payloadID] = struct{}{}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	for payloadID := range seen {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := fn(payloadID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // EnumerateFileBlocks streams every FileBlock's ContentHash through fn using
 // a Badger prefix iterator over fb:. The iterator yields one row per block
 // (no allocation of a full slice in application memory)..

--- a/pkg/metadata/store/memory/objects.go
+++ b/pkg/metadata/store/memory/objects.go
@@ -152,6 +152,36 @@ func (s *MemoryMetadataStore) ListFileBlocks(ctx context.Context, payloadID stri
 	return s.listFileBlocksLocked(ctx, payloadID)
 }
 
+// EnumeratePayloads streams every distinct payloadID that has at least one
+// FileBlock row through fn. It collects distinct payloadIDs under the read
+// lock (splitting each block.ID on the FIRST '/' to recover the payloadID),
+// releases the lock, then calls fn per payloadID so callers can issue further
+// metadata operations. Unlike the local store's ListFiles, this enumerates the
+// authoritative metadata, so it still yields rolled-up payloads.
+func (s *MemoryMetadataStore) EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error {
+	seen := make(map[string]struct{})
+	s.mu.RLock()
+	if s.fileBlockData != nil {
+		for id := range s.fileBlockData.blocks {
+			i := strings.Index(id, "/")
+			if i < 0 {
+				continue
+			}
+			seen[id[:i]] = struct{}{}
+		}
+	}
+	s.mu.RUnlock()
+	for payloadID := range seen {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := fn(payloadID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // EnumerateFileBlocks streams every FileBlock's ContentHash through fn.
 // The memory backend snapshots hashes under the read lock then releases
 // the lock before invoking fn so callers can issue further metadata

--- a/pkg/metadata/store/memory/objects.go
+++ b/pkg/metadata/store/memory/objects.go
@@ -154,16 +154,18 @@ func (s *MemoryMetadataStore) ListFileBlocks(ctx context.Context, payloadID stri
 
 // EnumeratePayloads streams every distinct payloadID that has at least one
 // FileBlock row through fn. It collects distinct payloadIDs under the read
-// lock (splitting each block.ID on the FIRST '/' to recover the payloadID),
-// releases the lock, then calls fn per payloadID so callers can issue further
-// metadata operations. Unlike the local store's ListFiles, this enumerates the
+// lock (splitting each block.ID on the LAST '/' to recover the payloadID —
+// payloadIDs are BuildPayloadID(shareName, filePath) and themselves contain
+// slashes, while the trailing component is the chunk offset), releases the
+// lock, then calls fn per payloadID so callers can issue further metadata
+// operations. Unlike the local store's ListFiles, this enumerates the
 // authoritative metadata, so it still yields rolled-up payloads.
 func (s *MemoryMetadataStore) EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error {
 	seen := make(map[string]struct{})
 	s.mu.RLock()
 	if s.fileBlockData != nil {
 		for id := range s.fileBlockData.blocks {
-			i := strings.Index(id, "/")
+			i := strings.LastIndex(id, "/")
 			if i < 0 {
 				continue
 			}

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -363,33 +363,64 @@ SELECT encode(hash, 'hex') FROM file_block_refs`
 
 // EnumeratePayloads streams every distinct payloadID that has at least one
 // FileBlock row through fn. FileBlock row IDs have the form
-// {payloadID}/{blockIdx}; the query recovers the payloadID with
-// split_part(id, '/', 1) and DISTINCT dedupes. Unlike the local store's
-// ListFiles, this enumerates the authoritative metadata, so it still yields
-// rolled-up payloads.
+// {payloadID}/{chunkOffset}; the payloadID is everything BEFORE THE LAST '/'
+// (payloadIDs are BuildPayloadID(shareName, filePath) and themselves contain
+// slashes, so a split_part on the FIRST slash would truncate every
+// subdirectory file to its share name). We therefore parse the payloadID in
+// Go on the last slash rather than in SQL.
+//
+// The rows cursor is fully drained and CLOSED before any fn callback runs:
+// fn may issue further reads, so we collect first then call — matching the
+// sqlite/badger/memory backends. (The pgx pool is multi-connection, so this
+// is for correctness/consistency rather than deadlock avoidance.)
 func (s *PostgresMetadataStore) EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error {
-	const query = `SELECT DISTINCT split_part(id, '/', 1) FROM file_blocks WHERE position('/' in id) > 0`
-	rows, err := s.query(ctx, query)
+	const query = `SELECT DISTINCT id FROM file_blocks`
+	ids, err := s.collectFileBlockIDs(ctx, query)
 	if err != nil {
-		return fmt.Errorf("enumerate payloads: query: %w", err)
+		return err
 	}
-	defer rows.Close()
-	for rows.Next() {
+
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("enumerate payloads: %w", err)
 		}
-		var payloadID string
-		if err := rows.Scan(&payloadID); err != nil {
-			return fmt.Errorf("enumerate payloads: scan: %w", err)
+		i := strings.LastIndex(id, "/")
+		if i < 0 {
+			continue
 		}
+		payloadID := id[:i]
+		if _, ok := seen[payloadID]; ok {
+			continue
+		}
+		seen[payloadID] = struct{}{}
 		if err := fn(payloadID); err != nil {
 			return err
 		}
 	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("enumerate payloads: rows: %w", err)
-	}
 	return nil
+}
+
+// collectFileBlockIDs runs query (which must SELECT a single TEXT id column),
+// scans every id into a slice, and closes the rows cursor before returning.
+func (s *PostgresMetadataStore) collectFileBlockIDs(ctx context.Context, query string) ([]string, error) {
+	rows, err := s.query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("enumerate payloads: query: %w", err)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("enumerate payloads: scan: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("enumerate payloads: rows: %w", err)
+	}
+	return ids, nil
 }
 
 // EnumerateFileBlocks streams every live-set ContentHash through fn, unioning

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -361,6 +361,37 @@ const enumerateHashesQuery = `SELECT hash FROM file_blocks
 UNION ALL
 SELECT encode(hash, 'hex') FROM file_block_refs`
 
+// EnumeratePayloads streams every distinct payloadID that has at least one
+// FileBlock row through fn. FileBlock row IDs have the form
+// {payloadID}/{blockIdx}; the query recovers the payloadID with
+// split_part(id, '/', 1) and DISTINCT dedupes. Unlike the local store's
+// ListFiles, this enumerates the authoritative metadata, so it still yields
+// rolled-up payloads.
+func (s *PostgresMetadataStore) EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error {
+	const query = `SELECT DISTINCT split_part(id, '/', 1) FROM file_blocks WHERE position('/' in id) > 0`
+	rows, err := s.query(ctx, query)
+	if err != nil {
+		return fmt.Errorf("enumerate payloads: query: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("enumerate payloads: %w", err)
+		}
+		var payloadID string
+		if err := rows.Scan(&payloadID); err != nil {
+			return fmt.Errorf("enumerate payloads: scan: %w", err)
+		}
+		if err := fn(payloadID); err != nil {
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("enumerate payloads: rows: %w", err)
+	}
+	return nil
+}
+
 // EnumerateFileBlocks streams every live-set ContentHash through fn, unioning
 // the CAS index with the per-file manifest (see enumerateHashesQuery).
 func (s *PostgresMetadataStore) EnumerateFileBlocks(ctx context.Context, fn func(block.ContentHash) error) error {

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -360,6 +360,37 @@ const enumerateHashesQuery = `SELECT hash FROM file_blocks
 UNION ALL
 SELECT lower(hex(hash)) FROM file_block_refs`
 
+// EnumeratePayloads streams every distinct payloadID that has at least one
+// FileBlock row through fn. FileBlock row IDs have the form
+// {payloadID}/{blockIdx}; the query recovers the payloadID with
+// substr(id, 1, instr(id, '/') - 1) and DISTINCT dedupes. Unlike the local
+// store's ListFiles, this enumerates the authoritative metadata, so it still
+// yields rolled-up payloads.
+func (s *SQLiteMetadataStore) EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error {
+	const query = `SELECT DISTINCT substr(id, 1, instr(id, '/') - 1) FROM file_blocks WHERE instr(id, '/') > 0`
+	rows, err := s.query(ctx, query)
+	if err != nil {
+		return fmt.Errorf("enumerate payloads: query: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("enumerate payloads: %w", err)
+		}
+		var payloadID string
+		if err := rows.Scan(&payloadID); err != nil {
+			return fmt.Errorf("enumerate payloads: scan: %w", err)
+		}
+		if err := fn(payloadID); err != nil {
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("enumerate payloads: rows: %w", err)
+	}
+	return nil
+}
+
 // EnumerateFileBlocks streams every live-set ContentHash through fn, unioning
 // the CAS index with the per-file manifest (see enumerateHashesQuery).
 func (s *SQLiteMetadataStore) EnumerateFileBlocks(ctx context.Context, fn func(block.ContentHash) error) error {

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -362,33 +362,66 @@ SELECT lower(hex(hash)) FROM file_block_refs`
 
 // EnumeratePayloads streams every distinct payloadID that has at least one
 // FileBlock row through fn. FileBlock row IDs have the form
-// {payloadID}/{blockIdx}; the query recovers the payloadID with
-// substr(id, 1, instr(id, '/') - 1) and DISTINCT dedupes. Unlike the local
-// store's ListFiles, this enumerates the authoritative metadata, so it still
-// yields rolled-up payloads.
+// {payloadID}/{chunkOffset}; the payloadID is everything BEFORE THE LAST '/'
+// (payloadIDs are BuildPayloadID(shareName, filePath) and themselves contain
+// slashes, so a substr/split on the FIRST slash would truncate every
+// subdirectory file to its share name). We therefore parse the payloadID in
+// Go on the last slash rather than in SQL.
+//
+// The rows cursor is fully drained and CLOSED before any fn callback runs.
+// The SQLite pool is MaxOpenConns(1), and warm/stats fn callbacks issue
+// further reads (ListFileBlocks) that need that single connection — calling fn
+// while the cursor is still open would deadlock. This collect-then-call shape
+// also matches the badger/memory backends.
 func (s *SQLiteMetadataStore) EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error {
-	const query = `SELECT DISTINCT substr(id, 1, instr(id, '/') - 1) FROM file_blocks WHERE instr(id, '/') > 0`
-	rows, err := s.query(ctx, query)
+	const query = `SELECT DISTINCT id FROM file_blocks`
+	ids, err := s.collectFileBlockIDs(ctx, query)
 	if err != nil {
-		return fmt.Errorf("enumerate payloads: query: %w", err)
+		return err
 	}
-	defer rows.Close()
-	for rows.Next() {
+
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("enumerate payloads: %w", err)
 		}
-		var payloadID string
-		if err := rows.Scan(&payloadID); err != nil {
-			return fmt.Errorf("enumerate payloads: scan: %w", err)
+		i := strings.LastIndex(id, "/")
+		if i < 0 {
+			continue
 		}
+		payloadID := id[:i]
+		if _, ok := seen[payloadID]; ok {
+			continue
+		}
+		seen[payloadID] = struct{}{}
 		if err := fn(payloadID); err != nil {
 			return err
 		}
 	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("enumerate payloads: rows: %w", err)
-	}
 	return nil
+}
+
+// collectFileBlockIDs runs query (which must SELECT a single TEXT id column),
+// scans every id into a slice, and closes the rows cursor before returning so
+// the caller may safely issue further queries on the single-connection pool.
+func (s *SQLiteMetadataStore) collectFileBlockIDs(ctx context.Context, query string) ([]string, error) {
+	rows, err := s.query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("enumerate payloads: query: %w", err)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("enumerate payloads: scan: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("enumerate payloads: rows: %w", err)
+	}
+	return ids, nil
 }
 
 // EnumerateFileBlocks streams every live-set ContentHash through fn, unioning

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -613,19 +613,26 @@ func testListFileBlocksEmptyStore(t *testing.T, factory StoreFactory) {
 // (#1374).
 // ============================================================================
 
-// testEnumeratePayloads seeds blocks for three distinct payloads (multiple
-// blocks each, including a multi-digit block index to exercise the last-colon /
-// first-slash split) and asserts EnumeratePayloads yields exactly the three
-// distinct payloadIDs, deduped and order-independent.
+// testEnumeratePayloads seeds blocks for several distinct payloads (multiple
+// blocks each, including a multi-digit block index to exercise numeric suffix
+// handling, AND payloadIDs that themselves CONTAIN slashes — the production
+// shape, BuildPayloadID(shareName, filePath), where the trailing "/{offset}"
+// component is the chunk offset and the payloadID is everything before the
+// LAST slash) and asserts EnumeratePayloads yields exactly those distinct
+// payloadIDs, deduped and order-independent. A backend that split on the FIRST
+// slash would truncate "myshare/dir/sub/file.bin" to "myshare" and fail here.
 func testEnumeratePayloads(t *testing.T, factory StoreFactory) {
 	store := factory(t)
 	ctx := t.Context()
 
-	// payload -> number of blocks.
+	// payload -> number of blocks. The slash-containing payloadIDs are the
+	// normal case for any file in a subdirectory.
 	want := map[string]int{
-		"payload-alpha": 3,
-		"payload-beta":  1,
-		"payload-gamma": 12, // exercises a multi-digit block index suffix
+		"payload-alpha":            3,
+		"payload-beta":             1,
+		"payload-gamma":            12, // exercises a multi-digit block index suffix
+		"myshare/dir/sub/file.bin": 2,  // payloadID itself contains slashes
+		"export/docs/report.pdf":   1,  // single-block subdirectory file
 	}
 	for payloadID, n := range want {
 		for i := 0; i < n; i++ {

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -135,6 +135,19 @@ func runFileBlockOpsTests(t *testing.T, factory StoreFactory) {
 		testEnumerateFileBlocks_CorruptHashFailsClosed(t, factory)
 	})
 
+	// `share warm` and block-store stats enumerate payloads from the
+	// authoritative metadata (EnumeratePayloads) rather than the local block
+	// store's ListFiles, which goes empty after rollup. Every backend MUST
+	// yield exactly the distinct payloadIDs derived from the FileBlock row IDs
+	// ({payloadID}/{blockIdx}), deduped and order-independent (#1374).
+	t.Run("EnumeratePayloads", func(t *testing.T) {
+		testEnumeratePayloads(t, factory)
+	})
+
+	t.Run("EnumeratePayloads_Empty", func(t *testing.T) {
+		testEnumeratePayloads_Empty(t, factory)
+	})
+
 	// IncrementRefCount / DecrementRefCount called via a
 	// metadata.Transaction MUST roll back when the wrapping WithTransaction
 	// returns an error. All backends — memory, badger, postgres — honor the
@@ -586,6 +599,93 @@ func testListFileBlocksEmptyStore(t *testing.T, factory StoreFactory) {
 	}
 	if len(result) != 0 {
 		t.Errorf("ListFileBlocks(empty) returned %d blocks, want 0", len(result))
+	}
+}
+
+// ============================================================================
+// EnumeratePayloads Tests
+//
+// EnumeratePayloads streams every DISTINCT payloadID that has at least one
+// FileBlock row. It is the rollup-durable enumeration surface used by
+// `share warm` and block-store stats: unlike the local block store's
+// ListFiles, the FileBlock metadata rows survive after an append log rolls up,
+// so this still reports payloads whose local payload tracking has gone empty
+// (#1374).
+// ============================================================================
+
+// testEnumeratePayloads seeds blocks for three distinct payloads (multiple
+// blocks each, including a multi-digit block index to exercise the last-colon /
+// first-slash split) and asserts EnumeratePayloads yields exactly the three
+// distinct payloadIDs, deduped and order-independent.
+func testEnumeratePayloads(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	// payload -> number of blocks.
+	want := map[string]int{
+		"payload-alpha": 3,
+		"payload-beta":  1,
+		"payload-gamma": 12, // exercises a multi-digit block index suffix
+	}
+	for payloadID, n := range want {
+		for i := 0; i < n; i++ {
+			b := &block.FileBlock{
+				ID:         fmt.Sprintf("%s/%d", payloadID, i),
+				State:      block.BlockStatePending,
+				LocalPath:  fmt.Sprintf("/cache/%s-%d", payloadID, i),
+				DataSize:   128,
+				RefCount:   1,
+				LastAccess: time.Now(),
+				CreatedAt:  time.Now(),
+			}
+			if err := store.Put(ctx, b); err != nil {
+				t.Fatalf("Put(%s) failed: %v", b.ID, err)
+			}
+		}
+	}
+
+	got := make(map[string]int)
+	err := store.EnumeratePayloads(ctx, func(payloadID string) error {
+		got[payloadID]++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("EnumeratePayloads error: %v", err)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("EnumeratePayloads yielded %d distinct payloads %v, want %d %v",
+			len(got), got, len(want), want)
+	}
+	for payloadID := range want {
+		switch got[payloadID] {
+		case 0:
+			t.Errorf("EnumeratePayloads missing payload %q", payloadID)
+		case 1:
+			// exactly once — correct
+		default:
+			t.Errorf("EnumeratePayloads yielded payload %q %d times, want exactly 1 (must dedupe)",
+				payloadID, got[payloadID])
+		}
+	}
+}
+
+// testEnumeratePayloads_Empty asserts EnumeratePayloads invokes fn zero times
+// on an empty store.
+func testEnumeratePayloads_Empty(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	count := 0
+	err := store.EnumeratePayloads(ctx, func(_ string) error {
+		count++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("EnumeratePayloads(empty) error: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("EnumeratePayloads(empty): fn invoked %d times, want 0", count)
 	}
 }
 


### PR DESCRIPTION
## Problem (#1374)

`dfsctl share warm` is a silent no-op and `dfsctl store block stats` reports `Blocks Total=0` (while `Local Disk Used` shows real bytes) on any share whose files have **rolled up**.

Root cause: both enumerate payloads via the **local block store** (`FSStore.ListFiles`), which only tracks payloads with a live append-log. Once a file rolls up, its CAS chunks and FileBlock metadata rows persist, but the payload drops out of `ListFiles` — so warm finds nothing to fetch and stats count nothing. This is independent of the refcount index the issue suspected.

## Fix

- Add `EnumeratePayloads(ctx, fn)` to the FileBlock store — streams every distinct payloadID from the **rollup-durable metadata** (`fb-file:` index / `file_blocks` table). Implemented for badger, memory, postgres, sqlite + conformance test.
- `WarmAll` and `populateBlockCounts`/`FileCount` now enumerate via `EnumeratePayloads` instead of `local.ListFiles()`. Per-block classification and fetch logic are unchanged. `GetStatsLite` stays O(1) and does not enumerate.

## Verification (live, SCW VM, badger + S3 remote)

After writing a 100 MiB file and rolling it up:
- **Before:** `Files=0, Blocks Total=0, Blocks Local=0` while disk held 100 MB; `warm` returned a job that fetched nothing.
- **After:** `Files=1, Blocks Total=100, Blocks Local=100`; `warm` enumerates all 100 blocks.

`go build ./...`, `go vet`, and `go test ./pkg/block/... ./pkg/metadata/...` (incl. the new `EnumeratePayloads` conformance across all 4 backends) pass.

Part of a larger #1374 cleanup (CAS-honest audit, warm job-id, legacy-refcount removal) landing in follow-up PRs.