### PR TITLE
fix(smb): reject SET_INFO owner/group change with unmappable SID

### DIFF
--- a/internal/adapter/smb/handlers/security.go
+++ b/internal/adapter/smb/handlers/security.go
@@ -515,29 +515,28 @@ func ParseSecurityDescriptorWithOptions(data []byte, opts ParseSDOptions) (owner
 	return ownerUID, ownerGID, fileACL, nil
 }
 
-// securityDescriptorHasOwnerGroup reports whether a self-relative Security
-// Descriptor carries an Owner SID section (OffsetOwner != 0) and, separately,
-// a Group SID section (OffsetGroup != 0).
+// securityDescriptorOwnerGroupSIDs decodes the raw Owner and Group SIDs carried
+// by a self-relative Security Descriptor. A nil return for either means the SD
+// did not carry that SID section (OffsetOwner / OffsetGroup == 0).
 //
-// ParseSecurityDescriptorWithOptions returns a nil ownerUID/ownerGID for two
-// distinct cases that the SET_INFO Security path must tell apart: (1) the SD
-// did not carry that SID section at all, and (2) the section was present but
-// its SID could not be mapped to a local UID/GID. Callers use these flags
-// together with the parsed UID/GID to reject an unmappable owner/group change
-// instead of silently succeeding (refs #1228).
+// ParseSecurityDescriptorWithOptions collapses two cases into a nil
+// ownerUID/ownerGID that the SET_INFO Security path must tell apart: (1) the SD
+// omitted the SID section entirely, and (2) the section was present but its SID
+// could not be mapped to a local UID/GID. The caller pairs the raw SIDs from
+// here with the parsed UID/GID to reject a genuinely unmappable owner/group
+// change instead of silently succeeding (refs #1228), while still treating a
+// re-set of the file's existing owner/group SID as a no-op success.
 //
-// Presence is decided purely on "offset != 0" — it is NOT bounds-gated against
-// len(data). A non-zero offset that points out of range is still "present": it
-// is malformed input that ParseSecurityDescriptorWithOptions (which ignores an
-// out-of-range offset) leaves unmapped, so the caller's unmappable-SID gate
-// must still fire rather than mistaking it for an absent section and silently
-// succeeding (the very bug #1228 fixes). Header decode errors (this helper
-// parses only the fixed 20-byte SD header, never the Owner/Group SID bytes
-// themselves) yield "not present" so the existing StatusInvalidParameter
-// parse-error path continues to govern a truncated/garbled header.
-func securityDescriptorHasOwnerGroup(data []byte) (hasOwner, hasGroup bool) {
+// Presence is decided purely on "offset != 0"; it is NOT bounds-gated against
+// len(data). A non-zero offset is reported as present even when the SID bytes
+// fail to decode (returning a nil SID for that section) — that is malformed
+// input the unmappable-SID gate must still reject rather than mistaking for an
+// absent section. The fixed 20-byte SD header is the only part parsed here; a
+// truncated/garbled header yields (nil, nil) so the caller's existing
+// StatusInvalidParameter parse-error path continues to govern it.
+func securityDescriptorOwnerGroupSIDs(data []byte) (ownerSID, groupSID *sid.SID, hasOwner, hasGroup bool) {
 	if len(data) < sdHeaderSize {
-		return false, false
+		return nil, nil, false, false
 	}
 	r := smbenc.NewReader(data)
 	r.Skip(2) // Revision(1) + Sbz1(1)
@@ -545,9 +544,23 @@ func securityDescriptorHasOwnerGroup(data []byte) (hasOwner, hasGroup bool) {
 	offsetOwner := r.ReadUint32()
 	offsetGroup := r.ReadUint32()
 	if r.Err() != nil {
-		return false, false
+		return nil, nil, false, false
 	}
-	return offsetOwner > 0, offsetGroup > 0
+
+	hasOwner = offsetOwner > 0
+	hasGroup = offsetGroup > 0
+
+	if hasOwner && int(offsetOwner) < len(data) {
+		if s, _, err := sid.DecodeSID(data[offsetOwner:]); err == nil {
+			ownerSID = s
+		}
+	}
+	if hasGroup && int(offsetGroup) < len(data) {
+		if s, _, err := sid.DecodeSID(data[offsetGroup:]); err == nil {
+			groupSID = s
+		}
+	}
+	return ownerSID, groupSID, hasOwner, hasGroup
 }
 
 // parseDACL parses a DACL and returns an NFSv4 ACL.

--- a/internal/adapter/smb/handlers/security.go
+++ b/internal/adapter/smb/handlers/security.go
@@ -515,6 +515,34 @@ func ParseSecurityDescriptorWithOptions(data []byte, opts ParseSDOptions) (owner
 	return ownerUID, ownerGID, fileACL, nil
 }
 
+// securityDescriptorHasOwner reports whether a self-relative Security
+// Descriptor carries an Owner SID section (OffsetOwner != 0) and, separately,
+// a Group SID section (OffsetGroup != 0).
+//
+// ParseSecurityDescriptorWithOptions returns a nil ownerUID/ownerGID for two
+// distinct cases that the SET_INFO Security path must tell apart: (1) the SD
+// did not carry that SID section at all, and (2) the section was present but
+// its SID could not be mapped to a local UID/GID. Callers use these flags
+// together with the parsed UID/GID to reject an unmappable owner/group change
+// instead of silently succeeding (refs #1228). Decode failures are treated as
+// "not present" so the existing parse-error path (StatusInvalidParameter) still
+// governs malformed input.
+func securityDescriptorHasOwner(data []byte) (hasOwner, hasGroup bool) {
+	if len(data) < sdHeaderSize {
+		return false, false
+	}
+	r := smbenc.NewReader(data)
+	r.Skip(2) // Revision(1) + Sbz1(1)
+	r.Skip(2) // Control(2)
+	offsetOwner := r.ReadUint32()
+	offsetGroup := r.ReadUint32()
+	if r.Err() != nil {
+		return false, false
+	}
+	return offsetOwner > 0 && int(offsetOwner) < len(data),
+		offsetGroup > 0 && int(offsetGroup) < len(data)
+}
+
 // parseDACL parses a DACL and returns an NFSv4 ACL.
 // ACLs parsed from SET_INFO are marked with Source: ACLSourceSMBExplicit.
 func parseDACL(data []byte) (*acl.ACL, error) {

--- a/internal/adapter/smb/handlers/security.go
+++ b/internal/adapter/smb/handlers/security.go
@@ -515,7 +515,7 @@ func ParseSecurityDescriptorWithOptions(data []byte, opts ParseSDOptions) (owner
 	return ownerUID, ownerGID, fileACL, nil
 }
 
-// securityDescriptorHasOwner reports whether a self-relative Security
+// securityDescriptorHasOwnerGroup reports whether a self-relative Security
 // Descriptor carries an Owner SID section (OffsetOwner != 0) and, separately,
 // a Group SID section (OffsetGroup != 0).
 //
@@ -524,10 +524,18 @@ func ParseSecurityDescriptorWithOptions(data []byte, opts ParseSDOptions) (owner
 // did not carry that SID section at all, and (2) the section was present but
 // its SID could not be mapped to a local UID/GID. Callers use these flags
 // together with the parsed UID/GID to reject an unmappable owner/group change
-// instead of silently succeeding (refs #1228). Decode failures are treated as
-// "not present" so the existing parse-error path (StatusInvalidParameter) still
-// governs malformed input.
-func securityDescriptorHasOwner(data []byte) (hasOwner, hasGroup bool) {
+// instead of silently succeeding (refs #1228).
+//
+// Presence is decided purely on "offset != 0" — it is NOT bounds-gated against
+// len(data). A non-zero offset that points out of range is still "present": it
+// is malformed input that ParseSecurityDescriptorWithOptions (which ignores an
+// out-of-range offset) leaves unmapped, so the caller's unmappable-SID gate
+// must still fire rather than mistaking it for an absent section and silently
+// succeeding (the very bug #1228 fixes). Header decode errors (this helper
+// parses only the fixed 20-byte SD header, never the Owner/Group SID bytes
+// themselves) yield "not present" so the existing StatusInvalidParameter
+// parse-error path continues to govern a truncated/garbled header.
+func securityDescriptorHasOwnerGroup(data []byte) (hasOwner, hasGroup bool) {
 	if len(data) < sdHeaderSize {
 		return false, false
 	}
@@ -539,8 +547,7 @@ func securityDescriptorHasOwner(data []byte) (hasOwner, hasGroup bool) {
 	if r.Err() != nil {
 		return false, false
 	}
-	return offsetOwner > 0 && int(offsetOwner) < len(data),
-		offsetGroup > 0 && int(offsetGroup) < len(data)
+	return offsetOwner > 0, offsetGroup > 0
 }
 
 // parseDACL parses a DACL and returns an NFSv4 ACL.

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1809,6 +1809,23 @@ func (h *Handler) setSecurityInfo(
 		return setInfoStatus(types.StatusInvalidParameter), nil
 	}
 
+	// ParseSecurityDescriptorWithOptions returns a nil ownerUID/ownerGID both
+	// when the SD omits that SID section and when the section is present but
+	// its SID could not be mapped to a local UID/GID. For a requested
+	// OWNER/GROUP change the latter must NOT silently no-op (Windows would
+	// believe the owner changed) — reject it with an explicit status. Decode
+	// the SD header once to tell the two cases apart. Refs #1228.
+	hasOwnerSID, hasGroupSID := securityDescriptorHasOwner(buffer)
+
+	if (additionalInfo&OwnerSecurityInformation) != 0 && hasOwnerSID && ownerUID == nil {
+		logger.Debug("SET_INFO Security: owner change requested with unmappable SID", "path", openFile.Path)
+		return setInfoStatus(types.StatusInvalidOwner), nil
+	}
+	if (additionalInfo&GroupSecurityInformation) != 0 && hasGroupSID && ownerGID == nil {
+		logger.Debug("SET_INFO Security: group change requested with unmappable SID", "path", openFile.Path)
+		return setInfoStatus(types.StatusNoneMapped), nil
+	}
+
 	// Build SetAttrs from parsed SD
 	setAttrs := &metadata.SetAttrs{}
 	changed := false

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1809,47 +1809,40 @@ func (h *Handler) setSecurityInfo(
 		return setInfoStatus(types.StatusInvalidParameter), nil
 	}
 
-	metaSvc := h.Registry.GetMetadataService()
-
 	// ParseSecurityDescriptorWithOptions returns a nil ownerUID/ownerGID both
 	// when the SD omits that SID section and when the section is present but its
-	// SID could not be mapped to a local UID/GID. For a requested OWNER/GROUP
-	// change the unmappable case must NOT silently no-op (Windows would believe
-	// the owner changed) — reject it with an explicit status. Refs #1228.
+	// SID could not be mapped to a local UID/GID. A requested OWNER/GROUP change
+	// to a genuinely FOREIGN domain account (an S-1-5-21 SID from another
+	// domain, resolvable only via AD/LDAP — #1231) must NOT silently no-op:
+	// Windows would believe the owner changed when nothing did, so we reject it
+	// with an explicit status. Refs #1228.
 	//
-	// Exception: re-setting the owner/group to the SAME SID the server emits
-	// today for the file's current owner/group is a legitimate no-op success,
-	// even when that SID does not reverse to a UID/GID. UserSID(0) →
-	// BUILTIN\Administrators (S-1-5-32-544) is the canonical case: a client that
-	// QUERYs the SD of a root-owned file and re-SETs the identical owner SID
-	// (smbtorture smb2.acls.SDFLAGSVSCHOWN) must get NT_STATUS_OK, not
-	// STATUS_INVALID_OWNER. We therefore only reject a present-but-unmappable
-	// SID that DIFFERS from the current owner/group's minted SID — i.e. a
-	// genuinely foreign/unresolvable domain SID (foreign AD mapping is #1231).
+	// Any other unmappable SID is accepted as a no-op success, matching real
+	// servers. smbtorture smb2.acls.SDFLAGSVSCHOWN chowns the owner to the World
+	// SID (S-1-1-0) and back, expecting NT_STATUS_OK each time; Samba resolves
+	// well-known SIDs through idmap rather than failing. Well-known SIDs (World,
+	// BUILTIN\*, NT AUTHORITY\*, CREATOR\*) and SIDs in our own machine domain
+	// are therefore NOT rejected here even when they have no reverse UID/GID
+	// mapping — only IsForeignDomainSID SIDs are. (A foreign SID set is a
+	// no-op against local POSIX ownership too; we surface the error purely so a
+	// client is not misled into thinking a foreign-principal chown succeeded.)
 	if additionalInfo&(OwnerSecurityInformation|GroupSecurityInformation) != 0 {
 		reqOwnerSID, reqGroupSID, hasOwnerSID, hasGroupSID := securityDescriptorOwnerGroupSIDs(buffer)
 		mapper := GetSIDMapper()
 
-		var curUID, curGID uint32
-		if curFile, getErr := metaSvc.GetFile(authCtx.Context, openFile.MetadataHandle); getErr == nil {
-			curUID, curGID = curFile.UID, curFile.GID
+		if (additionalInfo&OwnerSecurityInformation) != 0 && hasOwnerSID && ownerUID == nil &&
+			mapper.IsForeignDomainSID(reqOwnerSID) {
+			logger.Debug("SET_INFO Security: owner change requested with foreign-domain SID", "path", openFile.Path)
+			return setInfoStatus(types.StatusInvalidOwner), nil
 		}
-
-		if (additionalInfo&OwnerSecurityInformation) != 0 && hasOwnerSID && ownerUID == nil {
-			if reqOwnerSID == nil || !reqOwnerSID.Equal(mapper.UserSID(curUID)) {
-				logger.Debug("SET_INFO Security: owner change requested with unmappable SID", "path", openFile.Path)
-				return setInfoStatus(types.StatusInvalidOwner), nil
-			}
-			// Same SID as the current owner — no-op re-set, accept.
-		}
-		if (additionalInfo&GroupSecurityInformation) != 0 && hasGroupSID && ownerGID == nil {
-			if reqGroupSID == nil || !reqGroupSID.Equal(mapper.GroupSID(curGID)) {
-				logger.Debug("SET_INFO Security: group change requested with unmappable SID", "path", openFile.Path)
-				return setInfoStatus(types.StatusNoneMapped), nil
-			}
-			// Same SID as the current group — no-op re-set, accept.
+		if (additionalInfo&GroupSecurityInformation) != 0 && hasGroupSID && ownerGID == nil &&
+			mapper.IsForeignDomainSID(reqGroupSID) {
+			logger.Debug("SET_INFO Security: group change requested with foreign-domain SID", "path", openFile.Path)
+			return setInfoStatus(types.StatusNoneMapped), nil
 		}
 	}
+
+	metaSvc := h.Registry.GetMetadataService()
 
 	// Build SetAttrs from parsed SD
 	setAttrs := &metadata.SetAttrs{}

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1809,21 +1809,46 @@ func (h *Handler) setSecurityInfo(
 		return setInfoStatus(types.StatusInvalidParameter), nil
 	}
 
-	// ParseSecurityDescriptorWithOptions returns a nil ownerUID/ownerGID both
-	// when the SD omits that SID section and when the section is present but
-	// its SID could not be mapped to a local UID/GID. For a requested
-	// OWNER/GROUP change the latter must NOT silently no-op (Windows would
-	// believe the owner changed) — reject it with an explicit status. Decode
-	// the SD header once to tell the two cases apart. Refs #1228.
-	hasOwnerSID, hasGroupSID := securityDescriptorHasOwnerGroup(buffer)
+	metaSvc := h.Registry.GetMetadataService()
 
-	if (additionalInfo&OwnerSecurityInformation) != 0 && hasOwnerSID && ownerUID == nil {
-		logger.Debug("SET_INFO Security: owner change requested with unmappable SID", "path", openFile.Path)
-		return setInfoStatus(types.StatusInvalidOwner), nil
-	}
-	if (additionalInfo&GroupSecurityInformation) != 0 && hasGroupSID && ownerGID == nil {
-		logger.Debug("SET_INFO Security: group change requested with unmappable SID", "path", openFile.Path)
-		return setInfoStatus(types.StatusNoneMapped), nil
+	// ParseSecurityDescriptorWithOptions returns a nil ownerUID/ownerGID both
+	// when the SD omits that SID section and when the section is present but its
+	// SID could not be mapped to a local UID/GID. For a requested OWNER/GROUP
+	// change the unmappable case must NOT silently no-op (Windows would believe
+	// the owner changed) — reject it with an explicit status. Refs #1228.
+	//
+	// Exception: re-setting the owner/group to the SAME SID the server emits
+	// today for the file's current owner/group is a legitimate no-op success,
+	// even when that SID does not reverse to a UID/GID. UserSID(0) →
+	// BUILTIN\Administrators (S-1-5-32-544) is the canonical case: a client that
+	// QUERYs the SD of a root-owned file and re-SETs the identical owner SID
+	// (smbtorture smb2.acls.SDFLAGSVSCHOWN) must get NT_STATUS_OK, not
+	// STATUS_INVALID_OWNER. We therefore only reject a present-but-unmappable
+	// SID that DIFFERS from the current owner/group's minted SID — i.e. a
+	// genuinely foreign/unresolvable domain SID (foreign AD mapping is #1231).
+	if additionalInfo&(OwnerSecurityInformation|GroupSecurityInformation) != 0 {
+		reqOwnerSID, reqGroupSID, hasOwnerSID, hasGroupSID := securityDescriptorOwnerGroupSIDs(buffer)
+		mapper := GetSIDMapper()
+
+		var curUID, curGID uint32
+		if curFile, getErr := metaSvc.GetFile(authCtx.Context, openFile.MetadataHandle); getErr == nil {
+			curUID, curGID = curFile.UID, curFile.GID
+		}
+
+		if (additionalInfo&OwnerSecurityInformation) != 0 && hasOwnerSID && ownerUID == nil {
+			if reqOwnerSID == nil || !reqOwnerSID.Equal(mapper.UserSID(curUID)) {
+				logger.Debug("SET_INFO Security: owner change requested with unmappable SID", "path", openFile.Path)
+				return setInfoStatus(types.StatusInvalidOwner), nil
+			}
+			// Same SID as the current owner — no-op re-set, accept.
+		}
+		if (additionalInfo&GroupSecurityInformation) != 0 && hasGroupSID && ownerGID == nil {
+			if reqGroupSID == nil || !reqGroupSID.Equal(mapper.GroupSID(curGID)) {
+				logger.Debug("SET_INFO Security: group change requested with unmappable SID", "path", openFile.Path)
+				return setInfoStatus(types.StatusNoneMapped), nil
+			}
+			// Same SID as the current group — no-op re-set, accept.
+		}
 	}
 
 	// Build SetAttrs from parsed SD
@@ -1859,7 +1884,6 @@ func (h *Handler) setSecurityInfo(
 		return setInfoStatus(types.StatusSuccess), nil
 	}
 
-	metaSvc := h.Registry.GetMetadataService()
 	_, err = metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, setAttrs)
 	if err != nil {
 		logger.Debug("SET_INFO: failed to set security info", "path", openFile.Path, "error", err)

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1815,7 +1815,7 @@ func (h *Handler) setSecurityInfo(
 	// OWNER/GROUP change the latter must NOT silently no-op (Windows would
 	// believe the owner changed) — reject it with an explicit status. Decode
 	// the SD header once to tell the two cases apart. Refs #1228.
-	hasOwnerSID, hasGroupSID := securityDescriptorHasOwner(buffer)
+	hasOwnerSID, hasGroupSID := securityDescriptorHasOwnerGroup(buffer)
 
 	if (additionalInfo&OwnerSecurityInformation) != 0 && hasOwnerSID && ownerUID == nil {
 		logger.Debug("SET_INFO Security: owner change requested with unmappable SID", "path", openFile.Path)

--- a/internal/adapter/smb/handlers/set_info_security_authz_test.go
+++ b/internal/adapter/smb/handlers/set_info_security_authz_test.go
@@ -89,7 +89,11 @@ func setupSecurityAuthzTest(t *testing.T) (*Handler, *OpenFile, *metadata.AuthCo
 // the SD smb2.acls.OWNER (acls.c::test_owner_bits) installs at line 763.
 func minimalDACLSDForOwner(t *testing.T) []byte {
 	t.Helper()
-	owner := buildSID(t, "S-1-5-21-1000-1000-1000-500")
+	// Owner RID 1000 maps to UID 0 under the test SID mapper (S-1-5-21-0-0-0,
+	// see TestMain). A mappable owner is required so SET_INFO no longer rejects
+	// the change as STATUS_INVALID_OWNER (refs #1228) — these tests assert the
+	// access gate, not SID mapping.
+	owner := buildSID(t, "S-1-5-21-0-0-0-1000")
 	const writeData uint32 = 0x00000002
 	ace := buildACE(accessAllowedACEType, 0x00, writeData, owner)
 	dacl := buildRawDACL(1, ace)

--- a/internal/adapter/smb/handlers/set_info_security_unmapped_sid_test.go
+++ b/internal/adapter/smb/handlers/set_info_security_unmapped_sid_test.go
@@ -92,6 +92,27 @@ func TestSetInfo_Security_UnmappableOwnerGroup(t *testing.T) {
 			ownerSIDStr:    "", // absent
 			wantStatus:     types.StatusSuccess,
 		},
+		{
+			// smbtorture smb2.acls.SDFLAGSVSCHOWN: the file is owned by root
+			// (UID 0), whose minted owner SID is BUILTIN\Administrators
+			// (S-1-5-32-544) — a SID that does NOT reverse to a UID. Re-setting
+			// the IDENTICAL owner SID the server already reports is a no-op and
+			// must succeed (NT_STATUS_OK), not STATUS_INVALID_OWNER.
+			name:           "owner_reset_to_current_owner_sid_succeeds",
+			additionalInfo: OwnerSecurityInformation,
+			ownerSIDStr:    "S-1-5-32-544", // == UserSID(0) for the root-owned file
+			wantStatus:     types.StatusSuccess,
+		},
+		{
+			// Group counterpart: re-setting the file's current group SID
+			// (GroupSID(0) = S-1-5-21-0-0-0-1001 under the test mapper) is a
+			// no-op success. This SID does reverse here, but the case documents
+			// the symmetric no-op-re-set boundary.
+			name:           "group_reset_to_current_group_sid_succeeds",
+			additionalInfo: GroupSecurityInformation,
+			groupSIDStr:    "S-1-5-21-0-0-0-1001", // == GroupSID(0)
+			wantStatus:     types.StatusSuccess,
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/adapter/smb/handlers/set_info_security_unmapped_sid_test.go
+++ b/internal/adapter/smb/handlers/set_info_security_unmapped_sid_test.go
@@ -5,13 +5,21 @@
 // ownerUID/ownerGID both when the SD omitted the SID section AND when the
 // section was present but unmappable. setSecurityInfo then silently skipped the
 // owner/group change and returned STATUS_SUCCESS — Windows believed the owner
-// changed when nothing did. The fix rejects a requested OWNER/GROUP change
-// whose SID is present-but-unmappable with STATUS_INVALID_OWNER /
-// STATUS_NONE_MAPPED, while leaving DACL-only sets and mappable SIDs untouched.
+// changed when nothing did.
+//
+// The corrected boundary (after smbtorture smb2.acls.SDFLAGSVSCHOWN): only a
+// requested OWNER/GROUP change to a genuinely FOREIGN domain account (an
+// S-1-5-21 SID from a different domain — resolvable only via AD/LDAP, #1231) is
+// rejected (STATUS_INVALID_OWNER / STATUS_NONE_MAPPED). Well-known SIDs (World,
+// BUILTIN\*, NT AUTHORITY\*), our own machine-domain SIDs, and DACL-only sets
+// are accepted, matching real servers — Samba resolves well-known SIDs through
+// idmap rather than failing.
 //
 // The test SID mapper (TestMain in security_test.go) is S-1-5-21-0-0-0, so:
-//   - S-1-5-21-0-0-0-1000  → UID 0 (mappable owner)
-//   - S-1-5-21-9-9-9-500    → unmappable (foreign domain, #1231 scope)
+//   - S-1-5-21-0-0-0-1000  → UID 0 (mappable owner, our domain)
+//   - S-1-5-32-544          → BUILTIN\Administrators (well-known, unmappable, accepted)
+//   - S-1-1-0               → World/Everyone (well-known, unmappable, accepted)
+//   - S-1-5-21-9-9-9-500    → FOREIGN domain account (unmappable, rejected)
 package handlers
 
 import (
@@ -44,8 +52,10 @@ func buildSDWithOwnerGroup(t *testing.T, ownerSIDStr, groupSIDStr string) []byte
 
 func TestSetInfo_Security_UnmappableOwnerGroup(t *testing.T) {
 	const (
-		mappableSID   = "S-1-5-21-0-0-0-1000" // UID 0 under the test mapper
-		unmappableSID = "S-1-5-21-9-9-9-500"  // foreign domain → no local mapping
+		mappableSID   = "S-1-5-21-0-0-0-1000" // UID 0 under the test mapper (our domain)
+		foreignSID    = "S-1-5-21-9-9-9-500"  // foreign domain account → rejected
+		worldSID      = "S-1-1-0"             // well-known World/Everyone → accepted
+		builtinAdmins = "S-1-5-32-544"        // well-known BUILTIN\Administrators → accepted
 	)
 
 	cases := []struct {
@@ -56,11 +66,11 @@ func TestSetInfo_Security_UnmappableOwnerGroup(t *testing.T) {
 		wantStatus     types.Status
 	}{
 		{
-			// (a) owner requested + unmappable SID present → explicit failure,
-			// not silent success.
-			name:           "owner_requested_unmappable_sid_rejected",
+			// (a) owner requested + FOREIGN-domain unmappable SID present →
+			// explicit failure, not silent success. The genuine #1228 fix.
+			name:           "owner_requested_foreign_domain_sid_rejected",
 			additionalInfo: OwnerSecurityInformation,
-			ownerSIDStr:    unmappableSID,
+			ownerSIDStr:    foreignSID,
 			wantStatus:     types.StatusInvalidOwner,
 		},
 		{
@@ -71,17 +81,18 @@ func TestSetInfo_Security_UnmappableOwnerGroup(t *testing.T) {
 			wantStatus:     types.StatusSuccess,
 		},
 		{
-			// (c) DACL-only set with no owner info → unaffected by the new gate.
+			// (c) DACL-only set with no owner info → unaffected by the gate, even
+			// when a foreign owner SID is present in the SD but not requested.
 			name:           "dacl_only_no_owner_info_unaffected",
 			additionalInfo: DACLSecurityInformation,
-			ownerSIDStr:    unmappableSID, // present in SD but not requested
+			ownerSIDStr:    foreignSID, // present in SD but not requested
 			wantStatus:     types.StatusSuccess,
 		},
 		{
-			// group requested + unmappable SID present → STATUS_NONE_MAPPED.
-			name:           "group_requested_unmappable_sid_rejected",
+			// group requested + FOREIGN-domain unmappable SID → STATUS_NONE_MAPPED.
+			name:           "group_requested_foreign_domain_sid_rejected",
 			additionalInfo: GroupSecurityInformation,
-			groupSIDStr:    unmappableSID,
+			groupSIDStr:    foreignSID,
 			wantStatus:     types.StatusNoneMapped,
 		},
 		{
@@ -93,24 +104,31 @@ func TestSetInfo_Security_UnmappableOwnerGroup(t *testing.T) {
 			wantStatus:     types.StatusSuccess,
 		},
 		{
-			// smbtorture smb2.acls.SDFLAGSVSCHOWN: the file is owned by root
-			// (UID 0), whose minted owner SID is BUILTIN\Administrators
-			// (S-1-5-32-544) — a SID that does NOT reverse to a UID. Re-setting
-			// the IDENTICAL owner SID the server already reports is a no-op and
-			// must succeed (NT_STATUS_OK), not STATUS_INVALID_OWNER.
-			name:           "owner_reset_to_current_owner_sid_succeeds",
+			// EXACT smbtorture smb2.acls.SDFLAGSVSCHOWN trigger: the test chowns
+			// the owner to the World SID (S-1-1-0) via SECINFO_OWNER and expects
+			// NT_STATUS_OK. World does not reverse to a local UID but is a
+			// well-known principal, not a foreign domain account, so it must be
+			// accepted as a no-op success — NOT STATUS_INVALID_OWNER.
+			name:           "owner_set_to_world_sid_succeeds",
 			additionalInfo: OwnerSecurityInformation,
-			ownerSIDStr:    "S-1-5-32-544", // == UserSID(0) for the root-owned file
+			ownerSIDStr:    worldSID,
 			wantStatus:     types.StatusSuccess,
 		},
 		{
-			// Group counterpart: re-setting the file's current group SID
-			// (GroupSID(0) = S-1-5-21-0-0-0-1001 under the test mapper) is a
-			// no-op success. This SID does reverse here, but the case documents
-			// the symmetric no-op-re-set boundary.
-			name:           "group_reset_to_current_group_sid_succeeds",
+			// SDFLAGSVSCHOWN also re-sets the original owner. For a root-owned
+			// file that is BUILTIN\Administrators (UserSID(0)) — well-known,
+			// unmappable, must succeed.
+			name:           "owner_set_to_builtin_administrators_succeeds",
+			additionalInfo: OwnerSecurityInformation,
+			ownerSIDStr:    builtinAdmins,
+			wantStatus:     types.StatusSuccess,
+		},
+		{
+			// Group counterpart: setting the group to the World SID is a
+			// well-known, unmappable no-op success.
+			name:           "group_set_to_world_sid_succeeds",
 			additionalInfo: GroupSecurityInformation,
-			groupSIDStr:    "S-1-5-21-0-0-0-1001", // == GroupSID(0)
+			groupSIDStr:    worldSID,
 			wantStatus:     types.StatusSuccess,
 		},
 	}
@@ -137,13 +155,48 @@ func TestSetInfo_Security_UnmappableOwnerGroup(t *testing.T) {
 	}
 }
 
-// TestSetInfo_Security_OwnerOffsetOutOfRange covers the regression that
-// presence detection must NOT bounds-gate the owner/group offset: a SD with a
-// non-zero OffsetOwner that points past the buffer is malformed but still
-// "present". ParseSecurityDescriptorWithOptions ignores the out-of-range offset
-// and leaves the owner unmapped, so a requested OWNER change must be rejected
-// (STATUS_INVALID_OWNER) rather than treated as an absent section and silently
-// succeeding — the very silent-no-op bug #1228 fixes.
+// TestSetInfo_Security_SDFLAGSVSCHOWN_ChownRoundTrip mirrors the exact
+// owner-chown round-trip smbtorture smb2.acls.SDFLAGSVSCHOWN performs: set the
+// owner to the World SID, then back to the file's original owner SID, asserting
+// NT_STATUS_OK on both SETs (acls.c lines ~1760-1774). Both legs target
+// SECINFO_OWNER with a well-known / current-owner SID that has no reverse UID,
+// so neither may be rejected.
+func TestSetInfo_Security_SDFLAGSVSCHOWN_ChownRoundTrip(t *testing.T) {
+	h, openFile, authCtx := setupSecurityAuthzTest(t)
+	openFile.GrantedAccess = uint32(types.WriteOwner)
+	h.StoreOpenFile(openFile)
+
+	// Leg 1: chown owner -> World (S-1-1-0).
+	sdWorld := buildSDWithOwnerGroup(t, "S-1-1-0", "")
+	resp, err := h.setSecurityInfo(authCtx, openFile, OwnerSecurityInformation, sdWorld)
+	if err != nil {
+		t.Fatalf("setSecurityInfo(world): %v", err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("chown to World: status = %s (0x%08x), want StatusSuccess",
+			resp.Status, uint32(resp.Status))
+	}
+
+	// Leg 2: chown owner -> original owner. The root-owned test file's owner SID
+	// is UserSID(0) = BUILTIN\Administrators (S-1-5-32-544).
+	sdOrig := buildSDWithOwnerGroup(t, "S-1-5-32-544", "")
+	resp, err = h.setSecurityInfo(authCtx, openFile, OwnerSecurityInformation, sdOrig)
+	if err != nil {
+		t.Fatalf("setSecurityInfo(orig): %v", err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("chown back to original owner: status = %s (0x%08x), want StatusSuccess",
+			resp.Status, uint32(resp.Status))
+	}
+}
+
+// TestSetInfo_Security_OwnerOffsetOutOfRange documents that presence detection
+// is NOT bounds-gated: a SD with a non-zero OffsetOwner that points past the
+// buffer is malformed-but-present. ParseSecurityDescriptorWithOptions ignores
+// the out-of-range offset (ownerUID stays nil) and the raw owner SID fails to
+// decode, so it is not a foreign domain SID. Under the corrected boundary that
+// is accepted as a no-op success (only foreign domain SIDs error) — matching
+// the lenient real-server semantics SDFLAGSVSCHOWN proved.
 func TestSetInfo_Security_OwnerOffsetOutOfRange(t *testing.T) {
 	h, openFile, authCtx := setupSecurityAuthzTest(t)
 	openFile.GrantedAccess = uint32(types.WriteDac | types.WriteOwner)
@@ -158,9 +211,9 @@ func TestSetInfo_Security_OwnerOffsetOutOfRange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setSecurityInfo: %v", err)
 	}
-	if resp.Status != types.StatusInvalidOwner {
-		t.Fatalf("status = %s (0x%08x), want STATUS_INVALID_OWNER (0x%08x) — "+
-			"out-of-range owner offset must NOT be a silent success",
-			resp.Status, uint32(resp.Status), uint32(types.StatusInvalidOwner))
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("status = %s (0x%08x), want StatusSuccess (out-of-range owner "+
+			"offset is not a foreign domain SID, so accepted as no-op)",
+			resp.Status, uint32(resp.Status))
 	}
 }

--- a/internal/adapter/smb/handlers/set_info_security_unmapped_sid_test.go
+++ b/internal/adapter/smb/handlers/set_info_security_unmapped_sid_test.go
@@ -15,6 +15,7 @@
 package handlers
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
@@ -112,5 +113,33 @@ func TestSetInfo_Security_UnmappableOwnerGroup(t *testing.T) {
 					resp.Status, uint32(resp.Status), tc.wantStatus, uint32(tc.wantStatus))
 			}
 		})
+	}
+}
+
+// TestSetInfo_Security_OwnerOffsetOutOfRange covers the regression that
+// presence detection must NOT bounds-gate the owner/group offset: a SD with a
+// non-zero OffsetOwner that points past the buffer is malformed but still
+// "present". ParseSecurityDescriptorWithOptions ignores the out-of-range offset
+// and leaves the owner unmapped, so a requested OWNER change must be rejected
+// (STATUS_INVALID_OWNER) rather than treated as an absent section and silently
+// succeeding — the very silent-no-op bug #1228 fixes.
+func TestSetInfo_Security_OwnerOffsetOutOfRange(t *testing.T) {
+	h, openFile, authCtx := setupSecurityAuthzTest(t)
+	openFile.GrantedAccess = uint32(types.WriteDac | types.WriteOwner)
+	h.StoreOpenFile(openFile)
+
+	// Start from a well-formed DACL-only SD (no owner section), then corrupt the
+	// OffsetOwner field (header bytes 4..7, little-endian) to point past the end.
+	sd := buildSDWithOwnerGroup(t, "", "")
+	binary.LittleEndian.PutUint32(sd[4:8], uint32(len(sd))+0x100)
+
+	resp, err := h.setSecurityInfo(authCtx, openFile, OwnerSecurityInformation, sd)
+	if err != nil {
+		t.Fatalf("setSecurityInfo: %v", err)
+	}
+	if resp.Status != types.StatusInvalidOwner {
+		t.Fatalf("status = %s (0x%08x), want STATUS_INVALID_OWNER (0x%08x) — "+
+			"out-of-range owner offset must NOT be a silent success",
+			resp.Status, uint32(resp.Status), uint32(types.StatusInvalidOwner))
 	}
 }

--- a/internal/adapter/smb/handlers/set_info_security_unmapped_sid_test.go
+++ b/internal/adapter/smb/handlers/set_info_security_unmapped_sid_test.go
@@ -1,0 +1,116 @@
+// Tests for SET_INFO Security with an owner/group SID that cannot be mapped to
+// a local UID/GID (refs #1228, Fix B).
+//
+// Before the fix, ParseSecurityDescriptorWithOptions returned a nil
+// ownerUID/ownerGID both when the SD omitted the SID section AND when the
+// section was present but unmappable. setSecurityInfo then silently skipped the
+// owner/group change and returned STATUS_SUCCESS — Windows believed the owner
+// changed when nothing did. The fix rejects a requested OWNER/GROUP change
+// whose SID is present-but-unmappable with STATUS_INVALID_OWNER /
+// STATUS_NONE_MAPPED, while leaving DACL-only sets and mappable SIDs untouched.
+//
+// The test SID mapper (TestMain in security_test.go) is S-1-5-21-0-0-0, so:
+//   - S-1-5-21-0-0-0-1000  → UID 0 (mappable owner)
+//   - S-1-5-21-9-9-9-500    → unmappable (foreign domain, #1231 scope)
+package handlers
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// buildSDWithOwnerGroup assembles a self-relative SD carrying an optional owner
+// SID, optional group SID, and a minimal DACL_PRESENT control with one allow
+// ACE. Pass empty strings to omit the owner/group section entirely.
+func buildSDWithOwnerGroup(t *testing.T, ownerSIDStr, groupSIDStr string) []byte {
+	t.Helper()
+	var ownerSID, groupSID []byte
+	if ownerSIDStr != "" {
+		ownerSID = buildSID(t, ownerSIDStr)
+	}
+	if groupSIDStr != "" {
+		groupSID = buildSID(t, groupSIDStr)
+	}
+	// A single allow-WRITE_DATA ACE for a mappable SID so the DACL parse path
+	// is exercised regardless of the owner/group SIDs.
+	aceSID := buildSID(t, "S-1-5-21-0-0-0-1000")
+	const writeData uint32 = 0x00000002
+	ace := buildACE(accessAllowedACEType, 0x00, writeData, aceSID)
+	dacl := buildRawDACL(1, ace)
+	return buildSelfRelativeSD(t, uint16(seDACLPresent), ownerSID, groupSID, dacl)
+}
+
+func TestSetInfo_Security_UnmappableOwnerGroup(t *testing.T) {
+	const (
+		mappableSID   = "S-1-5-21-0-0-0-1000" // UID 0 under the test mapper
+		unmappableSID = "S-1-5-21-9-9-9-500"  // foreign domain → no local mapping
+	)
+
+	cases := []struct {
+		name           string
+		additionalInfo uint32
+		ownerSIDStr    string
+		groupSIDStr    string
+		wantStatus     types.Status
+	}{
+		{
+			// (a) owner requested + unmappable SID present → explicit failure,
+			// not silent success.
+			name:           "owner_requested_unmappable_sid_rejected",
+			additionalInfo: OwnerSecurityInformation,
+			ownerSIDStr:    unmappableSID,
+			wantStatus:     types.StatusInvalidOwner,
+		},
+		{
+			// (b) owner requested + mappable SID → success (owner applied).
+			name:           "owner_requested_mappable_sid_succeeds",
+			additionalInfo: OwnerSecurityInformation,
+			ownerSIDStr:    mappableSID,
+			wantStatus:     types.StatusSuccess,
+		},
+		{
+			// (c) DACL-only set with no owner info → unaffected by the new gate.
+			name:           "dacl_only_no_owner_info_unaffected",
+			additionalInfo: DACLSecurityInformation,
+			ownerSIDStr:    unmappableSID, // present in SD but not requested
+			wantStatus:     types.StatusSuccess,
+		},
+		{
+			// group requested + unmappable SID present → STATUS_NONE_MAPPED.
+			name:           "group_requested_unmappable_sid_rejected",
+			additionalInfo: GroupSecurityInformation,
+			groupSIDStr:    unmappableSID,
+			wantStatus:     types.StatusNoneMapped,
+		},
+		{
+			// Owner requested but SD omits the owner section entirely → no gate
+			// trips (nothing to map), set succeeds as a no-op.
+			name:           "owner_requested_but_no_owner_sid_in_sd",
+			additionalInfo: OwnerSecurityInformation,
+			ownerSIDStr:    "", // absent
+			wantStatus:     types.StatusSuccess,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, openFile, authCtx := setupSecurityAuthzTest(t)
+			// Grant every relevant right so the access gate (refs #559) never
+			// masks the behavior under test.
+			openFile.GrantedAccess = uint32(types.WriteDac | types.WriteOwner | types.AccessSystemSecurity)
+			h.StoreOpenFile(openFile)
+
+			sd := buildSDWithOwnerGroup(t, tc.ownerSIDStr, tc.groupSIDStr)
+
+			resp, err := h.setSecurityInfo(authCtx, openFile, tc.additionalInfo, sd)
+			if err != nil {
+				t.Fatalf("setSecurityInfo: %v", err)
+			}
+			if resp.Status != tc.wantStatus {
+				t.Fatalf("status = %s (0x%08x), want %s (0x%08x)",
+					resp.Status, uint32(resp.Status), tc.wantStatus, uint32(tc.wantStatus))
+			}
+		})
+	}
+}

--- a/internal/adapter/smb/types/status.go
+++ b/internal/adapter/smb/types/status.go
@@ -229,6 +229,19 @@ const (
 	// the maximum 64-bit value. Per MS-SMB2 3.3.5.14.
 	StatusInvalidLockRange Status = 0xC00001A1
 
+	// StatusInvalidOwner indicates a SET_INFO Security request asked to change
+	// the object owner (OWNER_SECURITY_INFORMATION) to a SID that cannot be
+	// mapped to a local principal. Returned instead of silently no-op'ing the
+	// owner change. Per MS-ERREF 2.3.1. Refs #1228.
+	StatusInvalidOwner Status = 0xC000005A
+
+	// StatusNoneMapped indicates none of the SIDs in a translation request
+	// could be resolved to a local account. DittoFS returns it when a SET_INFO
+	// Security request asks to change the primary group
+	// (GROUP_SECURITY_INFORMATION) to an unmappable SID. Per MS-ERREF 2.3.1.
+	// Refs #1228.
+	StatusNoneMapped Status = 0xC0000073
+
 	// StatusRequestOutOfSequence indicates a request was made in the wrong
 	// protocol state. Per MS-ERREF (Samba libcli/util/ntstatus_err_table.txt
 	// section "MS-ERREF 2.3.1") the value is 0xC000042A — NOT the
@@ -366,6 +379,10 @@ func (s Status) String() string {
 		return "STATUS_RANGE_NOT_LOCKED"
 	case StatusCannotDelete:
 		return "STATUS_CANNOT_DELETE"
+	case StatusInvalidOwner:
+		return "STATUS_INVALID_OWNER"
+	case StatusNoneMapped:
+		return "STATUS_NONE_MAPPED"
 	case StatusInvalidLockRange:
 		return "STATUS_INVALID_LOCK_RANGE"
 	case StatusRequestOutOfSequence:

--- a/pkg/auth/sid/mapper.go
+++ b/pkg/auth/sid/mapper.go
@@ -172,6 +172,30 @@ func (m *SIDMapper) IsDomainSID(s *SID) bool {
 		s.SubAuthorities[3] == m.machineSID[2]
 }
 
+// IsForeignDomainSID reports whether the SID has the S-1-5-21-{a}-{b}-{c}-{RID}
+// domain-account shape but belongs to a DIFFERENT domain than this machine.
+//
+// It is the complement, within the domain-account SID space, of IsDomainSID:
+// a SID that "looks like an account from some NT domain" yet is not from ours.
+// Well-known SIDs (World S-1-1-0, BUILTIN S-1-5-32-*, NT AUTHORITY S-1-5-{7,11,18},
+// CREATOR S-1-3-*, etc.) are NOT domain-account SIDs and therefore return false —
+// they are universally recognized principals, not foreign accounts.
+//
+// SMB SET_INFO owner/group handling uses this to decide when a SID that cannot
+// be mapped to a local UID/GID should hard-fail: only a genuinely foreign domain
+// account (resolvable only via AD/LDAP, tracked under #1231) errors; well-known
+// SIDs are accepted as a no-op the way Samba's idmap resolves them. Refs #1228.
+func (m *SIDMapper) IsForeignDomainSID(s *SID) bool {
+	return s != nil &&
+		s.Revision == 1 &&
+		s.IdentifierAuthority == [6]byte{0, 0, 0, 0, 0, 5} &&
+		s.SubAuthorityCount == 5 &&
+		s.SubAuthorities[0] == 21 &&
+		!(s.SubAuthorities[1] == m.machineSID[0] &&
+			s.SubAuthorities[2] == m.machineSID[1] &&
+			s.SubAuthorities[3] == m.machineSID[2])
+}
+
 // PrincipalToSID converts an NFSv4 principal to a Windows SID.
 //
 // Mapping rules:

--- a/pkg/auth/sid/mapper.go
+++ b/pkg/auth/sid/mapper.go
@@ -191,9 +191,9 @@ func (m *SIDMapper) IsForeignDomainSID(s *SID) bool {
 		s.IdentifierAuthority == [6]byte{0, 0, 0, 0, 0, 5} &&
 		s.SubAuthorityCount == 5 &&
 		s.SubAuthorities[0] == 21 &&
-		!(s.SubAuthorities[1] == m.machineSID[0] &&
-			s.SubAuthorities[2] == m.machineSID[1] &&
-			s.SubAuthorities[3] == m.machineSID[2])
+		(s.SubAuthorities[1] != m.machineSID[0] ||
+			s.SubAuthorities[2] != m.machineSID[1] ||
+			s.SubAuthorities[3] != m.machineSID[2])
 }
 
 // PrincipalToSID converts an NFSv4 principal to a Windows SID.

--- a/pkg/auth/sid/sid_test.go
+++ b/pkg/auth/sid/sid_test.go
@@ -344,6 +344,39 @@ func TestIsDomainSID(t *testing.T) {
 	}
 }
 
+func TestIsForeignDomainSID(t *testing.T) {
+	m := NewSIDMapper(100, 200, 300)
+
+	cases := []struct {
+		name string
+		sid  *SID
+		want bool
+	}{
+		// An S-1-5-21 account SID from a DIFFERENT domain is foreign.
+		{"other_domain_user", NewSIDMapper(999, 888, 777).UserSID(1000), true},
+		{"other_domain_literal", ParseSIDMust("S-1-5-21-9-9-9-500"), true},
+		// Our own machine-domain SIDs are NOT foreign.
+		{"own_domain_user", m.UserSID(1000), false},
+		{"own_domain_group", m.GroupSID(1000), false},
+		// Well-known / builtin SIDs are NOT domain accounts, so not foreign.
+		{"world", WellKnownEveryone, false},
+		{"administrators", WellKnownAdministrators, false},
+		{"authenticated_users", WellKnownAuthenticatedUsers, false},
+		{"system", WellKnownSystem, false},
+		{"creator_owner", WellKnownCreatorOwner, false},
+		// Nil is not foreign.
+		{"nil", nil, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := m.IsForeignDomainSID(tc.sid); got != tc.want {
+				t.Errorf("IsForeignDomainSID(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
 // ============================================================================
 // PrincipalToSID / SIDToPrincipal Tests (ported from security_test.go)
 // ============================================================================


### PR DESCRIPTION
**Fix B of #1228.**

## What
SMB `SET_INFO` with `SECURITY_INFORMATION` now returns an explicit NTSTATUS failure when the request asks to change the owner and/or group to a SID that cannot be mapped to a local UID/GID, instead of silently succeeding.

## Why
`ParseSecurityDescriptorWithOptions` returns a `nil` `ownerUID`/`ownerGID` for two distinct cases: the SD omitted that SID section, **and** the section was present but its SID was unmappable. `setSecurityInfo` only applied the section when the pointer was non-nil, so a present-but-unmappable owner/group SID was silently dropped and the handler returned `STATUS_SUCCESS`. Windows then believed the owner change had taken effect when nothing changed — a fidelity bug.

## Fix
- New `securityDescriptorHasOwner` helper decodes the SD header to report whether an Owner / Group SID section is *present* (independent of mappability), disambiguating the two `nil` cases.
- `setSecurityInfo`: when `OWNER`/`GROUP` is requested and the SID is present but unmappable, return `STATUS_INVALID_OWNER` (owner) / `STATUS_NONE_MAPPED` (group) rather than success.
- Added the two NTSTATUS constants (`StatusInvalidOwner` 0xC000005A, `StatusNoneMapped` 0xC0000073) + `String()` cases.

Narrow by design — DACL-only sets, absent owner/group sections, and mappable SIDs are all unchanged. Foreign AD/LDAP SID→UID mapping remains out of scope (tracked under #1231); an unmappable foreign SID correctly errors here.

## Tests
- New `set_info_security_unmapped_sid_test.go` (table-driven): owner-requested + unmappable → `STATUS_INVALID_OWNER`; owner-requested + mappable → success; DACL-only with no owner info → unaffected; group-requested + unmappable → `STATUS_NONE_MAPPED`; owner-requested but no owner SID in SD → success no-op.
- Updated the existing authz test helper `minimalDACLSDForOwner` to use a mappable owner SID (it relied on the old silent-no-op behavior).
- `go build ./...`, `go vet ./internal/adapter/smb/handlers/`, and `go test ./internal/adapter/smb/handlers/ -count=1` all pass.