### PR TITLE
docs(smb): ACL/SD fidelity interop matrix + durable restart test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Two binaries: `dfs` (server, `cmd/dfs/`) and `dfsctl` (REST client, `cmd/dfsctl/
 - `docs/CONFIGURATION.md` — config file + env vars (`DITTOFS_*`)
 - `docs/CLI.md` — full `dfs` / `dfsctl` reference (**generated** — see below)
 - `docs/NFS.md`, `docs/SMB.md` — protocol details
+- `docs/SMB_ACL_FIDELITY.md` — SMB Windows-ACL/SD interop matrix (Works/Partial/Unsupported)
 - `docs/IMPLEMENTING_STORES.md` — metadata/block store contracts
 - `docs/DEBUGGING.md` — SMB/NFS pcap-diff interop playbook
 - `docs/FAQ.md` — known limitations (ETXTBSY, POSIX gaps, single-node)

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ an isolated local storage directory and its own caching tiers. See
 - [NFS](docs/NFS.md) — NFSv3/v4.0/v4.1 status, mounting, internals
 - [SMB](docs/SMB.md) — SMB2/3 status, encryption, signing, leases, durable handles
 - [ACLs](docs/ACLS.md) — the cross-protocol ACL model shared by NFS and SMB
+- [SMB ACL Fidelity](docs/SMB_ACL_FIDELITY.md) — what the SMB Security Descriptor path round-trips (Works/Partial/Unsupported)
 - [Encryption](docs/ENCRYPTION.md) — client-side per-remote envelope encryption
 - [Snapshots](docs/SNAPSHOTS.md) — reference-based share snapshots and restore
 - [Windows Testing](docs/WINDOWS_TESTING.md) — SMB conformance against Windows

--- a/docs/SMB_ACL_FIDELITY.md
+++ b/docs/SMB_ACL_FIDELITY.md
@@ -1,0 +1,195 @@
+# SMB Windows-ACL / Security-Descriptor Fidelity Matrix
+
+This is the interop reference for what the DittoFS SMB Security Descriptor (SD)
+path actually round-trips, derived from the code — not from the spec. It is the
+"documented interop matrix" required by [#1228](https://github.com/marmos91/dittofs/issues/1228).
+
+For the cross-protocol ACL *model* (why NFSv4 ACEs are the canonical form, the
+evaluation algorithm, mode sync), see [ACLS.md](ACLS.md). This document is
+narrower: it states, aspect by aspect, whether the SMB SD wire path is
+**Works**, **Partial**, or **Unsupported**, with the source of truth for each.
+
+## Legend
+
+- **Works** — round-trips faithfully through QUERY_INFO (read) → SET_INFO
+  (write) → QUERY_INFO with no semantic loss.
+- **Partial** — round-trips with a documented caveat or under conditions.
+- **Unsupported** — dropped, stubbed, or not implemented; behavior noted.
+
+Code paths referenced:
+
+| Path | Function(s) | File |
+|------|-------------|------|
+| SD read (build) | `BuildSecurityDescriptor`, `buildDACL`, `buildEmptySACL` | `internal/adapter/smb/handlers/security.go` |
+| Read-side DACL synthesis | `SynthesizeWindowsDefault`, `SynthesizeFromMode` | `pkg/metadata/acl/synthesize.go` |
+| SD write (parse) | `ParseSecurityDescriptorWithOptions`, `parseDACL` | `internal/adapter/smb/handlers/security.go` |
+| SET_INFO Security | `setSecurityInfo`, `checkSetInfoSecurityAccess` | `internal/adapter/smb/handlers/set_info.go` |
+| SID derivation | `UserSID`, `GroupSID`, `UIDFromSID`, `GIDFromSID`, `PrincipalToSID`, `SIDToPrincipal` | `pkg/auth/sid/mapper.go` |
+| Generic-mask expansion | `ExpandGenericMask` | `pkg/metadata/acl/generic.go` |
+| Inheritance | `ComputeInheritedACL`, `PropagateACL`, flag translation | `pkg/metadata/acl/inherit.go`, `pkg/metadata/acl/flags.go` |
+| Storage | `FileAttr.ACL` / `SetAttrs.ACL` | `pkg/metadata/file_types.go` |
+
+NFSv4 ACE mask bits and Windows `ACCESS_MASK` bits share identical positions by
+RFC 7530 design, so masks need no translation. Only the principal format differs
+(NFSv4 `who@domain` strings vs. binary SIDs) and the inheritance-flag bit for
+`INHERITED_ACE` (NFSv4 `0x80` vs. Windows `0x10`, translated in `flags.go`).
+
+## Owner / Group SID
+
+| Aspect | State | Notes |
+|--------|-------|-------|
+| Owner SID read | Works | `BuildSecurityDescriptor` emits `mapper.UserSID(file.UID)`. UID 0 → `BUILTIN\Administrators` (`S-1-5-32-544`); all other UIDs → domain SID `S-1-5-21-{machine}-{uid*2+1000}`. |
+| Group SID read | Works | `mapper.GroupSID(file.GID)` → `S-1-5-21-{machine}-{gid*2+1001}`. The `+1001` (vs `+1000`) offset guarantees `UserSID(n) != GroupSID(n)`. |
+| Owner SID write | Works (round-trips local) | Parsed only when `OwnerSecurityInformation` is requested AND `UIDFromSID` recognizes the SID (machine-domain, even RID offset ≥ 1000). Recognized → `SetAttrs.UID`. Unrecognized owner SID is silently ignored (UID unchanged). |
+| Group SID write | Works (round-trips local) | `GIDFromSID` (odd RID offset); falls back to `UIDFromSID` if the group SID actually encodes a user. Unrecognized → ignored. |
+| Owner/Group section gating | Works | Write requires `WRITE_OWNER` on the open's `GrantedAccess` (`checkSetInfoSecurityAccess`); both sections fold under one `WRITE_OWNER` gate per MS-DTYP §2.5.3.3. |
+
+Note: `OWNER@`/`GROUP@` *inside a DACL ACE* resolve to the file's current
+owner/group SID via `principalToSID` (`UserSID`/`GroupSID`) — NOT to
+`CREATOR_OWNER`/`CREATOR_GROUP`. The CREATOR placeholders (`S-1-3-0`/`S-1-3-1`)
+are distinct and only meaningful as inheritable placeholders (see Inheritance).
+
+## DACL — ACE count, type, mask
+
+| Aspect | State | Notes |
+|--------|-------|-------|
+| ALLOW ACE (type 0x00) | Works | `accessAllowedACEType` ↔ `ACE4_ACCESS_ALLOWED_ACE_TYPE`, both directions. |
+| DENY ACE (type 0x01) | Works | `accessDeniedACEType` ↔ `ACE4_ACCESS_DENIED_ACE_TYPE`. Stored and round-tripped; canonical ordering (deny before allow) is the ACL engine's concern. |
+| Access mask bits | Works | Identical bit positions; written/parsed verbatim. Generic bits are expanded on write (see below). |
+| ACE count | Partial | Capped at `acl.MaxACECount` (128). `parseDACL` rejects a DACL whose header AceCount exceeds the cap with an error → SET_INFO returns `STATUS_INVALID_PARAMETER`. DACL size cap is `acl.MaxDACLSize` (64 KiB). |
+| Unknown ACE types on write | Partial | `parseDACL` skips ACE types it cannot map (anything other than ALLOW/DENY/AUDIT) — the ACE is dropped, the rest of the DACL still parses. |
+| Empty DACL (0 ACEs) | Works | `file.ACL != nil, len(ACEs)==0` emits a 0-ACE DACL (deny-all) on read; no default is synthesized. |
+| nil ACL on read | Partial (synthesized) | `file.ACL == nil` → `SynthesizeWindowsDefault`: ALLOW `OWNER@` + ALLOW `SYSTEM@`, both FullControl, no inherit flags, `Protected=true` (SD control `0x9004`). This is a *display* default; server-side access enforcement still uses POSIX mode bits for nil-ACL files. `SynthesizeFromMode` (POSIX-mode → Allow-only DACL) exists but is currently only exercised by tests. |
+
+## Inheritance flags
+
+| Flag | Wire | NFSv4 | State | Notes |
+|------|------|-------|-------|-------|
+| OBJECT_INHERIT (OI) | 0x01 | `ACE4_FILE_INHERIT_ACE` 0x01 | Works | Translated by `flags.go`. |
+| CONTAINER_INHERIT (CI) | 0x02 | `ACE4_DIRECTORY_INHERIT_ACE` 0x02 | Works | |
+| NO_PROPAGATE (NP) | 0x04 | `ACE4_NO_PROPAGATE_INHERIT_ACE` 0x04 | Works | Stops propagation at first child; honored in `ComputeInheritedACL`. |
+| INHERIT_ONLY (IO) | 0x08 | `ACE4_INHERIT_ONLY_ACE` 0x08 | Works | IO ACEs skipped in evaluation, kept for children. |
+| INHERITED_ACE | 0x10 | `ACE4_INHERITED_ACE` 0x80 | Works | Bit position differs (0x10 ↔ 0x80) and is correctly remapped — a naive truncation would corrupt this. |
+| Inheritance computation at create | Works | — | Works | `ComputeInheritedACL` mirrors Samba `create_descriptor.c`; CREATOR_OWNER/CREATOR_GROUP (`S-1-3-0`/`S-1-3-1`) placeholders are substituted with the creator's frozen identity at create time. |
+| Recursive propagation on parent change | Works | — | Works | `PropagateACL` recomputes inherited ACEs while preserving explicit ones and child per-SD flags. |
+
+## SD control flags
+
+| Flag | State | Notes |
+|------|-------|-------|
+| SE_SELF_RELATIVE (0x8000) | Works | Always set; all SDs are self-relative. |
+| SE_DACL_PRESENT (0x0004) | Works | Set when `DACLSecurityInformation` requested. |
+| SE_DACL_PROTECTED (0x1000) | Works | Read from `ACL.Protected`; written from inbound Control. Blocks inheritance from ancestors; never itself inherited onto children. |
+| SE_DACL_AUTO_INHERITED (0x0400) | Works (canonicalized) | Round-trips via `ACL.AutoInherited`. Default canonicalization (MS-DTYP §2.5.3.4.2, mirrors Samba `canonicalize_inheritance_bits`): persisted only when SET_INFO carries BOTH `AUTO_INHERITED` and `AUTO_INHERIT_REQ` (0x0100). Per-share opt-out (`acl flag inherited canonicalization = no`) preserves it verbatim. |
+| SE_DACL_AUTO_INHERIT_REQ (0x0100) | Works (request-only) | Processed as a request flag; never echoed back on read. |
+| SE_SACL_PRESENT (0x0010) | Partial | Set when `SACLSecurityInformation` requested, but the SACL body is an empty stub — see SACL below. |
+
+## Null DACL
+
+| Aspect | State | Notes |
+|--------|-------|-------|
+| Read | Works | `ACL.NullDACL` → `SE_DACL_PRESENT` set with `daclOffset == 0` (no DACL body) = everyone-full-access semantics. |
+| Write | Works | SD with `SE_DACL_PRESENT` and zero DACL offset → `&acl.ACL{NullDACL: true}`. Also produced when `DACLSecurityInformation` is requested but the SD carries no DACL (`setSecurityInfo`). |
+
+## SACL (audit)
+
+| Aspect | State | Notes |
+|--------|-------|-------|
+| SACL read | Unsupported (empty stub) | `buildEmptySACL` emits a valid but zero-ACE SACL (revision 2, count 0, size 8) when `SACLSecurityInformation` is requested. No audit ACEs are ever surfaced. |
+| SACL write | Unsupported (dropped) | `ParseSecurityDescriptorWithOptions` skips the SACL offset entirely (`r.Skip(4)` with a "SACL parsing not implemented" comment). The write is access-gated (`AccessSystemSecurity` required) but the SACL content is discarded. |
+| AUDIT ACE storage | Partial | `ACE4_SYSTEM_AUDIT_ACE_TYPE` can be stored in the model and translated (`systemAuditACEType`), but is never placed in a DACL on read and never parsed from a SACL on write. ALARM ACEs have no Windows mapping (`nfsToWindowsACEType` returns false → dropped). |
+
+Tracked alongside the broader cross-protocol SACL gap in
+[ACLS.md "Known Limitations"](ACLS.md#known-limitations).
+
+## GENERIC_* mask expansion
+
+| Aspect | State | Notes |
+|--------|-------|-------|
+| GENERIC_READ / WRITE / EXECUTE / ALL on write | Works | `parseDACL` calls `ExpandGenericMask` on each ACE before storing, per MS-DTYP §2.5.3 / MS-FSA §2.1.5.1.2.1. Generic bits are expanded to file-object-specific rights and the generic bits stripped (e.g. `GENERIC_ALL 0x10000000` → `FILE_ALL_ACCESS 0x001F01FF`). |
+| Generic bits at inherit time | Works | `ComputeInheritedACL` expands generic bits on effective (non-INHERIT_ONLY) ACEs against the child object type; INHERIT_ONLY placeholders keep generic bits for the eventual leaf. |
+| Generic bits on read | n/a | Stored masks are already specific (expanded on write), so read emits specific rights. |
+
+## Foreign (AD/LDAP) SID mapping
+
+| Aspect | State | Notes |
+|--------|-------|-------|
+| Foreign domain SID on write | Unsupported / out of scope | A SID not in this machine's domain is not decodable to a local UID/GID. As an owner/group it is ignored; inside a DACL ACE it round-trips as the `sid:<canonical>` principal form (preserved verbatim by `SIDToPrincipal`/`PrincipalToSID`), so the ACE is kept but the SID maps to no local identity. Real AD integration is tracked by [#1231](https://github.com/marmos91/dittofs/issues/1231). |
+| Named NFS principal → SID (e.g. `alice@EXAMPLE.COM`) | Partial (lossy) | `PrincipalToSID` synthesizes a hash-based fallback SID (full 32-bit hash as a 6th sub-authority) so it is NOT decodable back to a numeric UID and round-trips through `sid:`. Deterministic but not a real AD SID. |
+| SID → name resolution (display) | Unsupported | Raw SIDs are shown by Windows when no LSA name lookup is available; tracked by [#236](https://github.com/marmos91/dittofs/issues/236). |
+
+## Unmappable-SID-on-write behavior
+
+| Scenario | Behavior |
+|----------|----------|
+| Owner/Group SID not recognized by `UIDFromSID`/`GIDFromSID` | Section silently ignored; UID/GID unchanged. No error returned. |
+| DACL ACE SID not a local domain SID | `SIDToPrincipal` returns `sid:<canonical>`; ACE stored with that `Who`. Preserved on subsequent reads via `PrincipalToSID`'s `sid:` round-trip. |
+| Well-known SIDs (Everyone `S-1-1-0`, SYSTEM `S-1-5-18`, BUILTIN\Administrators `S-1-5-32-544`, OWNER_RIGHTS `S-1-3-4`, CREATOR_OWNER `S-1-3-0`, CREATOR_GROUP `S-1-3-1`) | Mapped to/from their NFSv4 special principals (`EVERYONE@`, `SYSTEM@`, `ADMINISTRATORS@`, `OwnerRights@`, `CreatorOwner@`, `CreatorGroup@`). Works. |
+| DACL AceCount > 128 or DACL > 64 KiB | `parseDACL` errors → SET_INFO returns `STATUS_INVALID_PARAMETER`. |
+
+## Access gating on SET_INFO Security
+
+`checkSetInfoSecurityAccess` authorizes each requested section against the
+**open's** `GrantedAccess` (captured at CREATE, per MS-SMB2 §3.3.5.21.3), not
+the file's current DACL:
+
+| Requested section | Required right |
+|-------------------|----------------|
+| DACL (`0x04`) | `WRITE_DAC` |
+| OWNER / GROUP (`0x01` / `0x02`) | `WRITE_OWNER` |
+| SACL (`0x08`) | `ACCESS_SYSTEM_SECURITY` |
+
+Any requested section lacking its bit denies the whole request with
+`STATUS_ACCESS_DENIED`.
+
+## Client-tested
+
+Behaviors confirmed against real clients (per repo history, CLAUDE.md, and
+project memory):
+
+- **Windows 11 Explorer — Security tab.** SD read/build path verified through
+  the Phase 31/32 Windows integration work: explicit-Deny synthesis was removed
+  in favor of Allow-only DACLs (Samba convention) so Explorer no longer shows
+  spurious "Write: Deny"; CREATE-context (MxAc) parsing and SET_INFO attribute
+  persistence (Hidden/ReadOnly) were fixed. SID-to-name resolution is still
+  open ([#236](https://github.com/marmos91/dittofs/issues/236)), so Explorer can
+  display raw SIDs instead of names.
+- **AD / Kerberos SMB.** `alice@REALM` → uid 10001 verified live against an
+  AD-DC over Kerberos-bound SMB (idmap_rid SID→UID), confirming the
+  domain-SID derivation in `mapper.go` end-to-end for the local-domain case.
+- **smbtorture `smb2.acls`.** The SD build/parse, inheritance
+  (INHERITANCE/INHERITFLAGS), GENERIC expansion, and AUTO_INHERITED
+  canonicalization paths are exercised by the SMB conformance suite (see
+  inline references in `security.go`, `inherit.go`, `generic.go`).
+- **macOS Finder.** Not separately validated for the ACL Security path; treat
+  as untested for ACL fidelity.
+
+## Known limitations
+
+1. **SACL is a stub.** Audit ACEs are never read out and are dropped on write
+   (empty SACL on QUERY_INFO; SACL offset skipped on SET_INFO). AUDIT ACEs can
+   be stored in the model but never reach a SMB client; ALARM ACEs have no
+   Windows mapping and are dropped.
+2. **Foreign AD/LDAP SIDs are not mapped to local identities.** They round-trip
+   as opaque `sid:<canonical>` principals (so the ACE survives) but resolve to
+   no UID/GID. Full AD interop is [#1231](https://github.com/marmos91/dittofs/issues/1231).
+3. **Hash-based fallback SIDs for named principals are lossy.** Deterministic
+   but not real AD SIDs; collisions are vanishingly rare but theoretically
+   possible.
+4. **No LSA SID→name pipe.** Windows Explorer may show raw SIDs
+   ([#236](https://github.com/marmos91/dittofs/issues/236)).
+5. **nil-ACL access enforcement uses POSIX mode, not the synthesized DACL.**
+   The `SynthesizeWindowsDefault` DACL shown to SMB clients for nil-ACL files is
+   display-only; server-side access checks fall back to Unix mode bits, which
+   stay authoritative.
+6. **Owner/Group live in `FileAttr`, not in the ACL.** Changing owner/group
+   does not emit ACL-change events (see [ACLS.md](ACLS.md#known-limitations)).
+
+## References
+
+- [#1228](https://github.com/marmos91/dittofs/issues/1228) — Windows-ACL / stable-handle fidelity (this matrix).
+- [#1231](https://github.com/marmos91/dittofs/issues/1231) — foreign AD/LDAP SID mapping.
+- [#236](https://github.com/marmos91/dittofs/issues/236) — SID-to-name (LSA) resolution.
+- [ACLS.md](ACLS.md) — cross-protocol ACL model and tradeoff analysis.
+- [MS-DTYP §2.4.4–2.4.6](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/) — SID / ACE / ACL / Security Descriptor formats.
+- [RFC 7530 §6](https://www.rfc-editor.org/rfc/rfc7530#section-6) — NFSv4 ACL model.

--- a/internal/adapter/smb/handlers/durable_restart_survival_test.go
+++ b/internal/adapter/smb/handlers/durable_restart_survival_test.go
@@ -1,0 +1,151 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// fileIDPersistentHalf returns the persistent half (bytes 0-7) of a 16-byte
+// SMB2 FileID. The durable-handle store keys V1 handles on this half only
+// (see durable_context.go zeroVolatileHalf / buildPersistedDurableHandle),
+// and GenerateFileID packs the monotonic nextFileID counter into exactly these
+// eight bytes — so a counter that resets on restart can re-mint a persistent
+// half that already belongs to a disconnected durable handle.
+func fileIDPersistentHalf(id [16]byte) [8]byte {
+	return [8]byte(id[:8])
+}
+
+// TestDurableHandleSurvivesSimulatedRestart asserts the reconnect-resolution
+// invariant for durable handles across a simulated server restart, and proves
+// the FileID-counter collision hazard that motivates the startup reseed
+// (Fix A / #1376).
+//
+// Sequence:
+//  1. A durable handle is persisted with a known FileID. Its persistent half is
+//     deliberately set to the value GenerateFileID mints first on a freshly
+//     constructed Handler — so a naive restart re-mints a colliding persistent
+//     half.
+//  2. Restart is simulated by constructing a brand-new Handler (nextFileID
+//     resets to 1) wired to the SAME durable store. The persisted record
+//     survives the restart because it lives in the store, not in Handler state.
+//  3. The persisted handle is still reconnect-resolvable by its FileID via the
+//     store's persistent-half-keyed lookup (GetDurableHandleByFileID), which is
+//     exactly what processV2Reconnect / processV1Reconnect call.
+//  4. The collision hazard is demonstrated: the first FileID a fresh Handler
+//     mints reuses the persisted handle's persistent half. This is the bug a
+//     startup reseed of nextFileID (from the max persisted FileID) prevents.
+//
+// NOTE: the post-reseed assertion — that a freshly minted FileID does NOT
+// collide with any persisted handle's persistent half — depends on Fix A's
+// Handler.SeedFileIDFromDurableHandles, which is NOT yet on origin/develop
+// (tracked by PR #1376). That assertion lives in the guarded sub-test below and
+// is skipped until #1376 lands. We intentionally do NOT reimplement the seed
+// here.
+func TestDurableHandleSurvivesSimulatedRestart(t *testing.T) {
+	ctx := context.Background()
+
+	// FileID with persistent half == counter value 2 (little-endian in bytes
+	// 0-7, matching GenerateFileID's packing), volatile half arbitrary.
+	// A fresh Handler stores nextFileID=1, and GenerateFileID does Add(1)
+	// BEFORE packing, so the first FileID it mints carries persistent half 2 —
+	// the value chosen here so the collision hazard below is exact.
+	persistedFileID := [16]byte{
+		0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // persistent half = 2
+		0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x11, 0x22, 0x33, // volatile half
+	}
+
+	now := time.Now()
+	store := newMockDurableStore()
+
+	// --- Pre-restart: persist the durable handle. ---
+	if err := store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
+		ID:              "restart-survivor",
+		FileID:          persistedFileID,
+		OriginalFileID:  persistedFileID,
+		Path:            "/restart/file.txt",
+		ShareName:       "share1",
+		DisconnectedAt:  now,
+		TimeoutMs:       300000, // 5 min — well within timeout at "restart"
+		ServerStartTime: now,
+	}); err != nil {
+		t.Fatalf("PutDurableHandle: %v", err)
+	}
+
+	// --- Simulate restart: brand-new Handler, counter resets to 1. ---
+	h := NewHandler()
+	h.DurableStore = store
+
+	if got := h.nextFileID.Load(); got != 1 {
+		t.Fatalf("fresh Handler nextFileID = %d, want 1 (restart counter reset)", got)
+	}
+
+	// --- The persisted handle survives and is reconnect-resolvable by FileID. ---
+	// This is the lookup processV1Reconnect / processV2Reconnect perform for a
+	// V1-via-DH2C (zero CreateGuid) reconnect — keyed on the persistent half.
+	resolved, err := store.GetDurableHandleByFileID(ctx, persistedFileID)
+	if err != nil {
+		t.Fatalf("GetDurableHandleByFileID: %v", err)
+	}
+	if resolved == nil {
+		t.Fatal("persisted durable handle not resolvable by FileID after restart")
+	}
+	if resolved.ID != "restart-survivor" {
+		t.Fatalf("resolved wrong handle: ID=%q, want %q", resolved.ID, "restart-survivor")
+	}
+	if fileIDPersistentHalf(resolved.FileID) != fileIDPersistentHalf(persistedFileID) {
+		t.Fatalf("resolved FileID persistent half %x != persisted %x",
+			fileIDPersistentHalf(resolved.FileID), fileIDPersistentHalf(persistedFileID))
+	}
+
+	// --- Collision hazard (the bug Fix A / #1376 fixes). ---
+	// Without a startup reseed, the FIRST FileID a fresh Handler mints reuses
+	// the persisted handle's persistent half (both derive from counter value 2:
+	// nextFileID resets to 1, GenerateFileID does Add(1) first).
+	// A reconnect of the disconnected durable handle would then alias a live,
+	// freshly opened file. This assertion documents the hazard so a regression
+	// in GenerateFileID's packing (or the store's persistent-half keying) is
+	// caught here.
+	minted := h.GenerateFileID()
+	if fileIDPersistentHalf(minted) != fileIDPersistentHalf(persistedFileID) {
+		t.Fatalf("expected fresh-Handler first FileID to collide with persisted "+
+			"persistent half (the #1376 hazard); minted=%x persisted=%x",
+			fileIDPersistentHalf(minted), fileIDPersistentHalf(persistedFileID))
+	}
+}
+
+// TestDurableHandleNoCollisionAfterReseed is the post-Fix-A assertion: after a
+// fresh Handler runs the startup reseed of nextFileID from the persisted
+// durable handles, a freshly minted FileID's persistent half must NOT collide
+// with any persisted handle's persistent half — while the persisted handle
+// stays reconnect-resolvable.
+//
+// This depends on Handler.SeedFileIDFromDurableHandles (Fix A, PR #1376), which
+// is NOT on origin/develop at the time of writing. Enable this test once #1376
+// merges by removing the skip and the build-tag guard below.
+func TestDurableHandleNoCollisionAfterReseed(t *testing.T) {
+	t.Skip("blocked on Fix A / PR #1376: Handler.SeedFileIDFromDurableHandles " +
+		"not yet on origin/develop — see durable_restart_survival_test.go header")
+
+	// Intended assertions once #1376 lands (kept as documentation; the symbol
+	// SeedFileIDFromDurableHandles does not exist yet so this body must stay
+	// behind the t.Skip above and uncompiled references avoided):
+	//
+	//   ctx := context.Background()
+	//   store := newMockDurableStore()
+	//   _ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
+	//       ID: "seed-survivor", FileID: persistedFileID, ...})
+	//
+	//   h := NewHandler()
+	//   h.DurableStore = store
+	//   if err := h.SeedFileIDFromDurableHandles(ctx); err != nil { t.Fatal(err) }
+	//
+	//   minted := h.GenerateFileID()
+	//   if fileIDPersistentHalf(minted) == fileIDPersistentHalf(persistedFileID) {
+	//       t.Fatal("freshly minted FileID collides with persisted handle after reseed")
+	//   }
+	//   resolved, _ := store.GetDurableHandleByFileID(ctx, persistedFileID)
+	//   if resolved == nil { t.Fatal("persisted handle not resolvable after reseed") }
+}

--- a/internal/adapter/smb/handlers/durable_restart_survival_test.go
+++ b/internal/adapter/smb/handlers/durable_restart_survival_test.go
@@ -15,6 +15,9 @@ import (
 // and GenerateFileID packs the monotonic nextFileID counter into exactly these
 // eight bytes — so a counter that resets on restart can re-mint a persistent
 // half that already belongs to a disconnected durable handle.
+//
+// The slice→array conversion `[8]byte(id[:8])` is valid Go (≥ 1.20; this repo
+// is on Go 1.25); it copies the first eight bytes into a comparable array.
 func fileIDPersistentHalf(id [16]byte) [8]byte {
 	return [8]byte(id[:8])
 }
@@ -45,15 +48,25 @@ func fileIDPersistentHalf(id [16]byte) [8]byte {
 func TestDurableHandleSurvivesSimulatedRestart(t *testing.T) {
 	ctx := context.Background()
 
-	// FileID with persistent half == counter value 2 (little-endian in bytes
-	// 0-7, matching GenerateFileID's packing), volatile half arbitrary.
-	// A fresh Handler stores nextFileID=1, and GenerateFileID does Add(1)
-	// BEFORE packing, so the first FileID it mints carries persistent half 2 —
-	// the value chosen here so the collision hazard below is exact.
-	persistedFileID := [16]byte{
-		0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // persistent half = 2
-		0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x11, 0x22, 0x33, // volatile half
-	}
+	// Persistent half == counter value 2 (little-endian in bytes 0-7, matching
+	// GenerateFileID's packing). A fresh Handler stores nextFileID=1, and
+	// GenerateFileID does Add(1) BEFORE packing, so the first FileID it mints
+	// carries persistent half 2 — chosen here so the collision hazard below is
+	// exact.
+	//
+	// Production storage shape: the persisted FileID has its VOLATILE half
+	// (bytes 8-15) ZEROED — buildPersistedDurableHandle stores only the
+	// persistent half in FileID, and keeps the full original 16-byte value in
+	// OriginalFileID (see pkg/metadata/lock/durable_store.go). Mirror that here
+	// so the seed key matches what the store would actually hold.
+	const persistedCounter uint64 = 2
+	var persistedFileID [16]byte // volatile half stays zeroed (production shape)
+	binary.LittleEndian.PutUint64(persistedFileID[:8], persistedCounter)
+
+	// originalFileID is the full 16-byte value (persistent + volatile) as seen
+	// at the original CREATE — only OriginalFileID retains the volatile half.
+	originalFileID := persistedFileID
+	copy(originalFileID[8:], []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x11, 0x22, 0x33})
 
 	now := time.Now()
 	store := newMockDurableStore()
@@ -61,8 +74,8 @@ func TestDurableHandleSurvivesSimulatedRestart(t *testing.T) {
 	// --- Pre-restart: persist the durable handle. ---
 	if err := store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
 		ID:              "restart-survivor",
-		FileID:          persistedFileID,
-		OriginalFileID:  persistedFileID,
+		FileID:          persistedFileID, // volatile half zeroed, as in production
+		OriginalFileID:  originalFileID,  // full original value retained
 		Path:            "/restart/file.txt",
 		ShareName:       "share1",
 		DisconnectedAt:  now,
@@ -131,17 +144,25 @@ func TestDurableHandleNoCollisionAfterReseed(t *testing.T) {
 	// (counter value 5000, little-endian in bytes 0-7, matching GenerateFileID's
 	// packing). A fresh Handler's counter starts at 1, so without the reseed its
 	// minted FileIDs would walk 2,3,4,… and eventually collide with 5000.
+	//
+	// Production storage shape (pkg/metadata/lock/durable_store.go): the
+	// persisted FileID keeps only the persistent half — the volatile half
+	// (bytes 8-15) is zeroed, and the full original value lives in
+	// OriginalFileID. Mirror that here; the reseed reads bytes 0-7 only, so the
+	// zeroed volatile half does not affect the seed math.
 	const persistedCounter uint64 = 5000
-	var persistedFileID [16]byte
+	var persistedFileID [16]byte // volatile half stays zeroed (production shape)
 	binary.LittleEndian.PutUint64(persistedFileID[:8], persistedCounter)
-	copy(persistedFileID[8:], []byte{0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x01, 0x02, 0x03})
+
+	originalFileID := persistedFileID
+	copy(originalFileID[8:], []byte{0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x01, 0x02, 0x03})
 
 	now := time.Now()
 	store := newMockDurableStore()
 	if err := store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
 		ID:              "seed-survivor",
-		FileID:          persistedFileID,
-		OriginalFileID:  persistedFileID,
+		FileID:          persistedFileID, // volatile half zeroed, as in production
+		OriginalFileID:  originalFileID,  // full original value retained
 		Path:            "/reseed/file.txt",
 		ShareName:       "share1",
 		DisconnectedAt:  now,

--- a/internal/adapter/smb/handlers/durable_restart_survival_test.go
+++ b/internal/adapter/smb/handlers/durable_restart_survival_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/binary"
 	"testing"
 	"time"
 
@@ -38,12 +39,9 @@ func fileIDPersistentHalf(id [16]byte) [8]byte {
 //     mints reuses the persisted handle's persistent half. This is the bug a
 //     startup reseed of nextFileID (from the max persisted FileID) prevents.
 //
-// NOTE: the post-reseed assertion — that a freshly minted FileID does NOT
-// collide with any persisted handle's persistent half — depends on Fix A's
-// Handler.SeedFileIDFromDurableHandles, which is NOT yet on origin/develop
-// (tracked by PR #1376). That assertion lives in the guarded sub-test below and
-// is skipped until #1376 lands. We intentionally do NOT reimplement the seed
-// here.
+// The closed-loop counterpart — that after Handler.SeedFileIDFromDurableHandles
+// (Fix A, #1376) a freshly minted FileID does NOT collide — lives in
+// TestDurableHandleNoCollisionAfterReseed below.
 func TestDurableHandleSurvivesSimulatedRestart(t *testing.T) {
 	ctx := context.Background()
 
@@ -118,34 +116,79 @@ func TestDurableHandleSurvivesSimulatedRestart(t *testing.T) {
 
 // TestDurableHandleNoCollisionAfterReseed is the post-Fix-A assertion: after a
 // fresh Handler runs the startup reseed of nextFileID from the persisted
-// durable handles, a freshly minted FileID's persistent half must NOT collide
-// with any persisted handle's persistent half — while the persisted handle
-// stays reconnect-resolvable.
+// durable handles (Handler.SeedFileIDFromDurableHandles, #1376), a freshly
+// minted FileID's persistent half must NOT collide with the persisted handle's
+// persistent half — while the persisted handle stays reconnect-resolvable by
+// FileID.
 //
-// This depends on Handler.SeedFileIDFromDurableHandles (Fix A, PR #1376), which
-// is NOT on origin/develop at the time of writing. Enable this test once #1376
-// merges by removing the skip and the build-tag guard below.
+// This is the closed-loop counterpart to TestDurableHandleSurvivesSimulatedRestart,
+// which demonstrates the un-seeded collision hazard: SeedFileIDFromDurableHandles
+// is exactly what removes it.
 func TestDurableHandleNoCollisionAfterReseed(t *testing.T) {
-	t.Skip("blocked on Fix A / PR #1376: Handler.SeedFileIDFromDurableHandles " +
-		"not yet on origin/develop — see durable_restart_survival_test.go header")
+	ctx := context.Background()
 
-	// Intended assertions once #1376 lands (kept as documentation; the symbol
-	// SeedFileIDFromDurableHandles does not exist yet so this body must stay
-	// behind the t.Skip above and uncompiled references avoided):
-	//
-	//   ctx := context.Background()
-	//   store := newMockDurableStore()
-	//   _ = store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
-	//       ID: "seed-survivor", FileID: persistedFileID, ...})
-	//
-	//   h := NewHandler()
-	//   h.DurableStore = store
-	//   if err := h.SeedFileIDFromDurableHandles(ctx); err != nil { t.Fatal(err) }
-	//
-	//   minted := h.GenerateFileID()
-	//   if fileIDPersistentHalf(minted) == fileIDPersistentHalf(persistedFileID) {
-	//       t.Fatal("freshly minted FileID collides with persisted handle after reseed")
-	//   }
-	//   resolved, _ := store.GetDurableHandleByFileID(ctx, persistedFileID)
-	//   if resolved == nil { t.Fatal("persisted handle not resolvable after reseed") }
+	// A durable handle persisted with a deliberately HIGH persistent half
+	// (counter value 5000, little-endian in bytes 0-7, matching GenerateFileID's
+	// packing). A fresh Handler's counter starts at 1, so without the reseed its
+	// minted FileIDs would walk 2,3,4,… and eventually collide with 5000.
+	const persistedCounter uint64 = 5000
+	var persistedFileID [16]byte
+	binary.LittleEndian.PutUint64(persistedFileID[:8], persistedCounter)
+	copy(persistedFileID[8:], []byte{0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x01, 0x02, 0x03})
+
+	now := time.Now()
+	store := newMockDurableStore()
+	if err := store.PutDurableHandle(ctx, &lock.PersistedDurableHandle{
+		ID:              "seed-survivor",
+		FileID:          persistedFileID,
+		OriginalFileID:  persistedFileID,
+		Path:            "/reseed/file.txt",
+		ShareName:       "share1",
+		DisconnectedAt:  now,
+		TimeoutMs:       300000,
+		ServerStartTime: now,
+	}); err != nil {
+		t.Fatalf("PutDurableHandle: %v", err)
+	}
+
+	// --- Simulate restart + run the startup reseed (Fix A). ---
+	h := NewHandler()
+	h.DurableStore = store
+	if got := h.nextFileID.Load(); got != 1 {
+		t.Fatalf("fresh Handler nextFileID = %d, want 1 (restart counter reset)", got)
+	}
+
+	h.SeedFileIDFromDurableHandles(ctx, store)
+
+	// The reseed stores the max persisted persistent half (5000) as the
+	// last-issued value; GenerateFileID pre-increments, so the next minted
+	// persistent half is 5001 — strictly above every persisted handle.
+	if got := h.nextFileID.Load(); got != persistedCounter {
+		t.Fatalf("after reseed nextFileID = %d, want %d (max persisted persistent half)",
+			got, persistedCounter)
+	}
+
+	// --- A freshly minted FileID must NOT collide with the persisted handle. ---
+	minted := h.GenerateFileID()
+	if fileIDPersistentHalf(minted) == fileIDPersistentHalf(persistedFileID) {
+		t.Fatalf("freshly minted FileID collides with persisted handle after reseed: "+
+			"minted=%x persisted=%x",
+			fileIDPersistentHalf(minted), fileIDPersistentHalf(persistedFileID))
+	}
+	if mintedCounter := binary.LittleEndian.Uint64(minted[:8]); mintedCounter != persistedCounter+1 {
+		t.Fatalf("first post-reseed FileID persistent half = %d, want %d (max+1)",
+			mintedCounter, persistedCounter+1)
+	}
+
+	// --- The persisted handle is still reconnect-resolvable by FileID. ---
+	resolved, err := store.GetDurableHandleByFileID(ctx, persistedFileID)
+	if err != nil {
+		t.Fatalf("GetDurableHandleByFileID: %v", err)
+	}
+	if resolved == nil {
+		t.Fatal("persisted durable handle not resolvable by FileID after reseed")
+	}
+	if resolved.ID != "seed-survivor" {
+		t.Fatalf("resolved wrong handle: ID=%q, want %q", resolved.ID, "seed-survivor")
+	}
 }


### PR DESCRIPTION
**Fix D of #1228** — the documented interop matrix + a durable-handle restart-survival test.

## What

- **`docs/SMB_ACL_FIDELITY.md`** — a precise, evidence-based **Works / Partial / Unsupported** matrix for the SMB Windows-ACL + Security-Descriptor path, derived by reading the actual code (not the spec). Covers:
  - Owner/Group SID read+write (machine-SID + `uid*2+1000` / `gid*2+1001` RID derivation; UID0→Administrators).
  - DACL ACE count / type (allow+deny) / mask; ACE/DACL caps.
  - Inheritance flags OI/CI/NP/IO + the `INHERITED_ACE` 0x80↔0x10 remap; inherit-time + propagation.
  - SD control flags: `SE_DACL_PROTECTED`, `SE_DACL_AUTO_INHERITED` (+ canonicalization toggle), null DACL.
  - **SACL** — unsupported: empty stub on read, dropped on write; AUDIT stored-only, ALARM dropped.
  - `GENERIC_*` mask expansion on write and at inherit time.
  - Foreign AD/LDAP SID mapping (out of scope, #1231) and unmappable-SID-on-write behavior.
  - SET_INFO Security access gating table.
  - "Client-tested" (Win11 Explorer Security tab, AD/Kerberos SMB, smbtorture; macOS Finder noted untested) and "Known limitations".
  - Cross-references #1228, #1231, #236.
  - Linked from `README.md` and `CLAUDE.md`.

- **`internal/adapter/smb/handlers/durable_restart_survival_test.go`** — restart-survival tests for durable handles (match `durable_scavenger_test.go` style via `newMockDurableStore()`):
  - `TestDurableHandleSurvivesSimulatedRestart`: persists a durable handle, simulates restart with a fresh `Handler` (FileID counter resets), asserts it stays reconnect-resolvable by FileID (persistent-half-keyed `GetDurableHandleByFileID`, the lookup `processV*Reconnect` use), and demonstrates the un-seeded persistent-half collision hazard.
  - `TestDurableHandleNoCollisionAfterReseed`: the closed-loop counterpart — persists a handle with a high FileID, runs `Handler.SeedFileIDFromDurableHandles` (Fix A / #1376, now merged), then asserts the counter seeds to the max persisted persistent half, a freshly minted FileID mints `max+1` (no collision), and the persisted handle stays reconnect-resolvable.

## Why

#1228 explicitly demands a documented interop matrix for SMB Windows-ACL / stable-handle fidelity; it did not exist. There was also no test asserting durable-handle FileID identity survives a restart.

## Verify

`go build ./...` and `go test ./internal/adapter/smb/handlers/ ./pkg/adapter/smb/ -count=1` both pass.