### PR TITLE
fix(block): slash-free warm job id + warn on empty enumeration (#1374)

### DIFF
--- a/cmd/dfsctl/commands/share/warm.go
+++ b/cmd/dfsctl/commands/share/warm.go
@@ -97,6 +97,9 @@ func watchWarm(client *apiclient.Client, shareName, jobID string) error {
 			fmt.Printf("\rfetched %d/%d blocks (%s) — done\n",
 				status.BlocksDone, status.BlocksTotal,
 				bytesize.ByteSize(status.BytesDone).String())
+			if status.Warning != "" {
+				fmt.Fprintf(os.Stderr, "warning: %s\n", status.Warning)
+			}
 			return nil
 		case warmStateFailed:
 			fmt.Println()

--- a/internal/controlplane/api/handlers/blockstore.go
+++ b/internal/controlplane/api/handlers/blockstore.go
@@ -122,6 +122,7 @@ type WarmJobStatusResponse struct {
 	StartedAt   string `json:"started_at,omitempty"`
 	FinishedAt  string `json:"finished_at,omitempty"`
 	Error       string `json:"error,omitempty"`
+	Warning     string `json:"warning,omitempty"`
 }
 
 func warmJobToResponse(j *shares.WarmJob) WarmJobStatusResponse {
@@ -133,6 +134,7 @@ func warmJobToResponse(j *shares.WarmJob) WarmJobStatusResponse {
 		BlocksDone:  j.BlocksDone,
 		BytesDone:   j.BytesDone,
 		Error:       j.Err,
+		Warning:     j.Warning,
 	}
 	if !j.StartedAt.IsZero() {
 		resp.StartedAt = j.StartedAt.UTC().Format(time.RFC3339)

--- a/internal/controlplane/api/handlers/blockstore_test.go
+++ b/internal/controlplane/api/handlers/blockstore_test.go
@@ -316,7 +316,7 @@ func TestBlockStoreStatsHandler_NormalizesShareName(t *testing.T) {
 // unknown job.
 func TestBlockStoreStatsHandler_Warm(t *testing.T) {
 	t.Run("start_returns_202_and_job_id", func(t *testing.T) {
-		fake := &fakeBlockStoreRuntime{warmJob: &shares.WarmJob{ID: "warm-/myshare-1", Share: "/myshare", State: shares.WarmStateRunning}}
+		fake := &fakeBlockStoreRuntime{warmJob: &shares.WarmJob{ID: "warm-1", Share: "/myshare", State: shares.WarmStateRunning}}
 		h := NewBlockStoreStatsHandler(fake)
 		req := newChiRequestForBlockStore(http.MethodPost,
 			"/api/v1/shares/myshare/blockstore/warm", nil, "name", "myshare")
@@ -335,8 +335,8 @@ func TestBlockStoreStatsHandler_Warm(t *testing.T) {
 		if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
-		if body.JobID != "warm-/myshare-1" {
-			t.Fatalf("job_id = %q, want warm-/myshare-1", body.JobID)
+		if body.JobID != "warm-1" {
+			t.Fatalf("job_id = %q, want warm-1", body.JobID)
 		}
 	})
 
@@ -359,12 +359,12 @@ func TestBlockStoreStatsHandler_Warm(t *testing.T) {
 
 	t.Run("status_found", func(t *testing.T) {
 		fake := &fakeBlockStoreRuntime{
-			warmStatus: &shares.WarmJob{ID: "warm-/myshare-1", Share: "/myshare", State: shares.WarmStateDone, BlocksTotal: 5, BlocksDone: 5, BytesDone: 100},
+			warmStatus: &shares.WarmJob{ID: "warm-1", Share: "/myshare", State: shares.WarmStateDone, BlocksTotal: 5, BlocksDone: 5, BytesDone: 100, Warning: "block metadata may be missing"},
 			warmFound:  true,
 		}
 		h := NewBlockStoreStatsHandler(fake)
 		req := newChiRequestForBlockStore(http.MethodGet,
-			"/api/v1/shares/myshare/blockstore/warm/warm-/myshare-1", nil, "name", "myshare", "job_id", "warm-/myshare-1")
+			"/api/v1/shares/myshare/blockstore/warm/warm-1", nil, "name", "myshare", "job_id", "warm-1")
 		w := httptest.NewRecorder()
 		h.WarmStatus(w, req)
 		if w.Code != http.StatusOK {
@@ -373,6 +373,9 @@ func TestBlockStoreStatsHandler_Warm(t *testing.T) {
 		var resp WarmJobStatusResponse
 		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 			t.Fatalf("decode: %v", err)
+		}
+		if resp.Warning != "block metadata may be missing" {
+			t.Fatalf("WarmStatus warning = %q, want passthrough", resp.Warning)
 		}
 		if resp.State != shares.WarmStateDone || resp.BlocksDone != 5 || resp.BytesDone != 100 {
 			t.Fatalf("unexpected status: %+v", resp)

--- a/pkg/apiclient/blockstore.go
+++ b/pkg/apiclient/blockstore.go
@@ -71,6 +71,7 @@ type WarmJobStatus struct {
 	StartedAt   string `json:"started_at,omitempty"`
 	FinishedAt  string `json:"finished_at,omitempty"`
 	Error       string `json:"error,omitempty"`
+	Warning     string `json:"warning,omitempty"`
 }
 
 // warmStartResponse is the 202 body from POST .../blockstore/warm.

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -2076,7 +2076,12 @@ func (s *Service) StartWarm(_ context.Context, shareName string) (*WarmJob, erro
 	bs := share.BlockStore
 	s.mu.RUnlock()
 
-	job := s.warmJobs.start(shareName, func(ctx context.Context, progress func(done, total int64)) (warmAllResult, error) {
+	// Capture the share's currently-stored byte count up front (O(1) lite
+	// stats, no per-file DB walk). The registry uses it to warn when a warm
+	// run enumerates zero blocks on a non-empty share (#1374).
+	usedBytes := bs.GetStatsLite().LocalDiskUsed
+
+	job := s.warmJobs.start(shareName, usedBytes, func(ctx context.Context, progress func(done, total int64)) (warmAllResult, error) {
 		res, err := bs.WarmAll(ctx, progress)
 		return warmAllResult{
 			BlocksFetched:      res.BlocksFetched,

--- a/pkg/controlplane/runtime/shares/warm.go
+++ b/pkg/controlplane/runtime/shares/warm.go
@@ -173,10 +173,10 @@ func (r *warmRegistry) start(shareName string, usedBytes int64, run func(ctx con
 			// (#1374) rather than a silent no-op success.
 			if res.BlocksFetched+res.BlocksAlreadyLocal == 0 && usedBytes > 0 {
 				j.Warning = fmt.Sprintf(
-					"warm found 0 enumerable blocks for share %s but it reports %d used bytes — block metadata may be missing",
+					"warm found 0 enumerable blocks for share %s but it has %d bytes on the local disk tier — block metadata may be missing",
 					shareName, usedBytes)
 				logger.Warn("warm found no enumerable blocks on non-empty share",
-					"share", shareName, "used_bytes", usedBytes)
+					"share", shareName, "local_disk_used_bytes", usedBytes)
 			}
 		case canceled:
 			j.State = WarmStateCanceled

--- a/pkg/controlplane/runtime/shares/warm.go
+++ b/pkg/controlplane/runtime/shares/warm.go
@@ -38,6 +38,11 @@ type WarmJob struct {
 	StartedAt   time.Time `json:"started_at"`
 	FinishedAt  time.Time `json:"finished_at"`
 	Err         string    `json:"error,omitempty"`
+	// Warning carries a non-fatal advisory surfaced to the operator on an
+	// otherwise-successful run. It is set when a warm run enumerated zero
+	// blocks to materialize for a share that nonetheless reports nonzero
+	// stored bytes — a strong hint that block metadata is missing (#1374).
+	Warning string `json:"warning,omitempty"`
 }
 
 // clone returns a copy safe to hand outside the registry lock.
@@ -90,7 +95,13 @@ type warmAllResult struct {
 // (derived from context.Background(), not the request ctx) so the job outlives
 // the HTTP request that triggered it. If a job is already running for the
 // share, the existing job is returned and run is not invoked.
-func (r *warmRegistry) start(shareName string, run func(ctx context.Context, progress func(done, total int64)) (warmAllResult, error)) *WarmJob {
+//
+// usedBytes is the share's currently-stored byte count (captured by the
+// caller before launching). When the run completes with zero enumerable
+// blocks (nothing fetched AND nothing already-local) but usedBytes > 0, the
+// job's Warning field is set: a non-empty share with no warmable blocks is a
+// strong hint that block metadata is missing (#1374).
+func (r *warmRegistry) start(shareName string, usedBytes int64, run func(ctx context.Context, progress func(done, total int64)) (warmAllResult, error)) *WarmJob {
 	r.mu.Lock()
 	if existingID, ok := r.active[shareName]; ok {
 		job := r.jobs[existingID].clone()
@@ -99,7 +110,11 @@ func (r *warmRegistry) start(shareName string, run func(ctx context.Context, pro
 	}
 
 	r.counter++
-	jobID := fmt.Sprintf("warm-%s-%d", shareName, r.counter)
+	// Opaque, slash-free id. The counter is global+monotonic so the id is
+	// unique across shares without embedding the (slash-bearing) share name,
+	// which previously broke the {job_id} poll route for shares like "/export"
+	// (#1374). Per-share dedup is still handled by the active map above.
+	jobID := fmt.Sprintf("warm-%d", r.counter)
 	job := &WarmJob{
 		ID:        jobID,
 		Share:     shareName,
@@ -152,6 +167,17 @@ func (r *warmRegistry) start(shareName string, run func(ctx context.Context, pro
 		case err == nil:
 			j.State = WarmStateDone
 			j.BlocksDone = j.BlocksTotal
+			// Total enumerable blocks for the run = fetched + already-local.
+			// If that is zero yet the share reports stored bytes, the warm
+			// found nothing to do on a non-empty share — surface a warning
+			// (#1374) rather than a silent no-op success.
+			if res.BlocksFetched+res.BlocksAlreadyLocal == 0 && usedBytes > 0 {
+				j.Warning = fmt.Sprintf(
+					"warm found 0 enumerable blocks for share %s but it reports %d used bytes — block metadata may be missing",
+					shareName, usedBytes)
+				logger.Warn("warm found no enumerable blocks on non-empty share",
+					"share", shareName, "used_bytes", usedBytes)
+			}
 		case canceled:
 			j.State = WarmStateCanceled
 			j.Err = err.Error()

--- a/pkg/controlplane/runtime/shares/warm_test.go
+++ b/pkg/controlplane/runtime/shares/warm_test.go
@@ -3,6 +3,7 @@ package shares
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -31,9 +32,12 @@ func TestWarmRegistry_DeterministicIDsAndSuccess(t *testing.T) {
 		return warmAllResult{BlocksFetched: 2, BytesFetched: 42}, nil
 	}
 
-	job := r.start("/share", run)
-	if job.ID != "warm-/share-1" {
-		t.Fatalf("job ID = %q, want warm-/share-1", job.ID)
+	job := r.start("/share", 0, run)
+	if job.ID != "warm-1" {
+		t.Fatalf("job ID = %q, want warm-1", job.ID)
+	}
+	if strings.Contains(job.ID, "/") {
+		t.Fatalf("job ID %q must not contain a slash (breaks poll route)", job.ID)
 	}
 	if job.State != WarmStateRunning {
 		t.Fatalf("initial state = %q, want running", job.State)
@@ -56,11 +60,74 @@ func TestWarmRegistry_DeterministicIDsAndSuccess(t *testing.T) {
 	}
 
 	// A second start for the same share gets a fresh, monotonic ID.
-	job2 := r.start("/share", func(_ context.Context, _ func(done, total int64)) (warmAllResult, error) {
+	job2 := r.start("/share", 0, func(_ context.Context, _ func(done, total int64)) (warmAllResult, error) {
 		return warmAllResult{}, nil
 	})
-	if job2.ID != "warm-/share-2" {
-		t.Fatalf("second job ID = %q, want warm-/share-2", job2.ID)
+	if job2.ID != "warm-2" {
+		t.Fatalf("second job ID = %q, want warm-2", job2.ID)
+	}
+
+	// The job is resolvable via the status lookup by id alone (the round-trip
+	// that the 404 bug broke for slash-bearing shares).
+	if _, ok := r.get(job2.ID); !ok {
+		t.Fatalf("started job %q not resolvable by id", job2.ID)
+	}
+}
+
+func TestWarmRegistry_SlashShareYieldsSlashFreeID(t *testing.T) {
+	r := newWarmRegistry()
+	job := r.start("/export", 0, func(_ context.Context, _ func(done, total int64)) (warmAllResult, error) {
+		return warmAllResult{}, nil
+	})
+	if strings.Contains(job.ID, "/") {
+		t.Fatalf("job ID %q for share /export must not contain a slash", job.ID)
+	}
+	if _, ok := r.get(job.ID); !ok {
+		t.Fatalf("job %q not resolvable by id", job.ID)
+	}
+}
+
+func TestWarmRegistry_WarnsOnEmptyEnumerationNonEmptyShare(t *testing.T) {
+	r := newWarmRegistry()
+
+	// Zero enumerable blocks (nothing fetched, nothing already-local) on a
+	// share that reports nonzero stored bytes must set the Warning (#1374).
+	job := r.start("/export", 4096, func(_ context.Context, _ func(done, total int64)) (warmAllResult, error) {
+		return warmAllResult{}, nil
+	})
+	waitFor(t, func() bool {
+		j, _ := r.get(job.ID)
+		return j.State == WarmStateDone
+	})
+	j, _ := r.get(job.ID)
+	if j.Warning == "" {
+		t.Fatalf("expected warning on 0-block warm of non-empty share, got none: %+v", j)
+	}
+
+	// A share that genuinely has no stored bytes must NOT warn.
+	jobEmpty := r.start("/empty", 0, func(_ context.Context, _ func(done, total int64)) (warmAllResult, error) {
+		return warmAllResult{}, nil
+	})
+	waitFor(t, func() bool {
+		j, _ := r.get(jobEmpty.ID)
+		return j.State == WarmStateDone
+	})
+	je, _ := r.get(jobEmpty.ID)
+	if je.Warning != "" {
+		t.Fatalf("empty share should not warn, got %q", je.Warning)
+	}
+
+	// A run that DID enumerate blocks must not warn even if used bytes > 0.
+	jobOK := r.start("/full", 4096, func(_ context.Context, _ func(done, total int64)) (warmAllResult, error) {
+		return warmAllResult{BlocksAlreadyLocal: 3}, nil
+	})
+	waitFor(t, func() bool {
+		j, _ := r.get(jobOK.ID)
+		return j.State == WarmStateDone
+	})
+	jo, _ := r.get(jobOK.ID)
+	if jo.Warning != "" {
+		t.Fatalf("share with enumerable blocks should not warn, got %q", jo.Warning)
 	}
 }
 
@@ -78,8 +145,8 @@ func TestWarmRegistry_OneActivePerShare(t *testing.T) {
 		return warmAllResult{}, nil
 	}
 
-	job1 := r.start("/share", run)
-	job2 := r.start("/share", run) // should return the running job, not start a new one
+	job1 := r.start("/share", 0, run)
+	job2 := r.start("/share", 0, run) // should return the running job, not start a new one
 	if job1.ID != job2.ID {
 		t.Fatalf("second start got a different job: %q vs %q", job1.ID, job2.ID)
 	}
@@ -107,7 +174,7 @@ func TestWarmRegistry_CancelForShare(t *testing.T) {
 		return warmAllResult{}, ctx.Err()
 	}
 
-	job := r.start("/share", run)
+	job := r.start("/share", 0, run)
 	<-started
 	r.cancelForShare("/share")
 
@@ -125,7 +192,7 @@ func TestWarmRegistry_CancelForShare(t *testing.T) {
 func TestWarmRegistry_Failure(t *testing.T) {
 	r := newWarmRegistry()
 	boom := errors.New("boom")
-	job := r.start("/share", func(_ context.Context, _ func(done, total int64)) (warmAllResult, error) {
+	job := r.start("/share", 0, func(_ context.Context, _ func(done, total int64)) (warmAllResult, error) {
 		return warmAllResult{}, boom
 	})
 	waitFor(t, func() bool {

--- a/pkg/controlplane/runtime/shares/warm_test.go
+++ b/pkg/controlplane/runtime/shares/warm_test.go
@@ -103,6 +103,9 @@ func TestWarmRegistry_WarnsOnEmptyEnumerationNonEmptyShare(t *testing.T) {
 	if j.Warning == "" {
 		t.Fatalf("expected warning on 0-block warm of non-empty share, got none: %+v", j)
 	}
+	if !strings.Contains(j.Warning, "local disk tier") {
+		t.Fatalf("warning should reference the local disk tier, got %q", j.Warning)
+	}
 
 	// A share that genuinely has no stored bytes must NOT warn.
 	jobEmpty := r.start("/empty", 0, func(_ context.Context, _ func(done, total int64)) (warmAllResult, error) {


### PR DESCRIPTION
## Problem (#1374)

`dfsctl share warm <share> --watch` immediately fails with `Error: failed to poll warm job: warm job not found` (HTTP 404). The warm job id embeds the share name including its slash — for `/export` it is `warm-/export-1` — and the slash breaks the poll route `.../warm/{job_id}`.

Separately, a warm run that enumerates nothing returns `202` + a job that fetches nothing, with no signal to the operator.

## Fix

- **Opaque job id:** `warm-%d` (monotonic counter) instead of `warm-{share}-{n}`. Per-share dedup still uses the registry's `active` map; nothing parses the id to recover the share. Poll route now resolves.
- **Empty-enumeration warning:** when a warm run finds 0 enumerable blocks but the share reports nonzero stored bytes, set `WarmJob.Warning` (surfaced in the status response, apiclient, and `--watch` output) and log at Warn. Used-bytes is read from the O(1) `GetStatsLite().LocalDiskUsed` at the shares layer.

Tests: job ids are slash-free and resolvable by id (incl. a `/`-named share); warning fires on empty enumeration of a non-empty share and stays quiet otherwise.

Companion to #1377 (warm/stats metadata enumeration). Part of the #1374 cleanup.