### PR TITLE
feat(smb): preserve SACL across SET_INFO/QUERY_INFO round-trip

### DIFF
--- a/internal/adapter/smb/handlers/security.go
+++ b/internal/adapter/smb/handlers/security.go
@@ -53,10 +53,12 @@ const (
 	accessAllowedACEType = 0x00
 	accessDeniedACEType  = 0x01
 	systemAuditACEType   = 0x02
+	systemAlarmACEType   = 0x03
 )
 
 // nfsToWindowsACEType maps an NFSv4 ACE type to a Windows ACE type.
-// Returns false for unrecognized types (e.g., ALARM).
+// Returns false for unrecognized types. Allow/Deny appear in DACLs;
+// Audit/Alarm appear in SACLs and round-trip via the SACL path.
 func nfsToWindowsACEType(nfsType uint32) (uint8, bool) {
 	switch nfsType {
 	case acl.ACE4_ACCESS_ALLOWED_ACE_TYPE:
@@ -65,6 +67,8 @@ func nfsToWindowsACEType(nfsType uint32) (uint8, bool) {
 		return accessDeniedACEType, true
 	case acl.ACE4_SYSTEM_AUDIT_ACE_TYPE:
 		return systemAuditACEType, true
+	case acl.ACE4_SYSTEM_ALARM_ACE_TYPE:
+		return systemAlarmACEType, true
 	default:
 		return 0, false
 	}
@@ -80,6 +84,8 @@ func windowsToNFSACEType(winType uint8) (uint32, bool) {
 		return acl.ACE4_ACCESS_DENIED_ACE_TYPE, true
 	case systemAuditACEType:
 		return acl.ACE4_SYSTEM_AUDIT_ACE_TYPE, true
+	case systemAlarmACEType:
+		return acl.ACE4_SYSTEM_ALARM_ACE_TYPE, true
 	default:
 		return 0, false
 	}
@@ -176,10 +182,15 @@ func BuildSecurityDescriptor(file *metadata.File, additionalSecInfo uint32) ([]b
 		fileACL = buildDACL(daclBuf, file)
 	}
 
-	// Build SACL (empty stub if requested)
+	// Build SACL. When the file has stored SACL ACEs, serialize them;
+	// otherwise emit a valid empty SACL stub (matching prior behavior).
 	saclBuf := smbenc.NewWriter(aclHeaderSize)
 	if includeSACL {
-		buildEmptySACL(saclBuf)
+		if file.ACL != nil && len(file.ACL.SACL) > 0 {
+			buildSACL(saclBuf, file, file.ACL.SACL)
+		} else {
+			buildEmptySACL(saclBuf)
+		}
 	}
 
 	// Compute SD control flags dynamically
@@ -380,6 +391,49 @@ func buildDACL(buf *smbenc.Writer, file *metadata.File) *acl.ACL {
 	return fileACL
 }
 
+// buildSACL constructs a SACL (System Access Control List) from the file's
+// stored SACL ACEs. The wire layout is identical to a DACL (MS-DTYP §2.4.5 +
+// §2.4.4.2) — only the audit/alarm ACE types and the SUCCESSFUL/FAILED audit
+// flags differ. ACEs whose type does not map to a Windows ACE type are skipped
+// (defensive — the parse side only stores mappable types).
+func buildSACL(buf *smbenc.Writer, file *metadata.File, saclACEs []acl.ACE) {
+	aces := make([]windowsACE, 0, len(saclACEs))
+	for _, ace := range saclACEs {
+		aceType, ok := nfsToWindowsACEType(ace.Type)
+		if !ok {
+			continue
+		}
+		aces = append(aces, windowsACE{
+			aceType:    aceType,
+			aceFlags:   acl.NFSv4FlagsToWindowsFlags(ace.Flag),
+			accessMask: ace.AccessMask,
+			sid:        principalToSID(ace.Who, file.UID, file.GID),
+		})
+	}
+
+	totalACLSize := aclHeaderSize
+	for i := range aces {
+		totalACLSize += aceHeaderSize + sid.SIDSize(aces[i].sid)
+	}
+
+	// ACL header (8 bytes) per MS-DTYP §2.4.5
+	buf.WriteUint8(2) // AclRevision (2 = standard)
+	buf.WriteUint8(0) // Sbz1
+	buf.WriteUint16(uint16(totalACLSize))
+	buf.WriteUint16(uint16(len(aces)))
+	buf.WriteUint16(0) // Sbz2
+
+	for i := range aces {
+		ace := &aces[i]
+		aceSize := uint16(aceHeaderSize + sid.SIDSize(ace.sid))
+		buf.WriteUint8(ace.aceType)
+		buf.WriteUint8(ace.aceFlags)
+		buf.WriteUint16(aceSize)
+		buf.WriteUint32(ace.accessMask)
+		encodeSID(buf, ace.sid)
+	}
+}
+
 // buildEmptySACL writes a valid empty SACL to buf.
 // The SACL has revision=2, count=0, and total size=8 bytes.
 func buildEmptySACL(buf *smbenc.Writer) {
@@ -439,7 +493,7 @@ func ParseSecurityDescriptorWithOptions(data []byte, opts ParseSDOptions) (owner
 	control := r.ReadUint16()
 	offsetOwner := r.ReadUint32()
 	offsetGroup := r.ReadUint32()
-	r.Skip(4) // offsetSACL (SACL parsing not implemented; preserve-on-write is future work)
+	offsetSACL := r.ReadUint32()
 	offsetDACL := r.ReadUint32()
 	if r.Err() != nil {
 		return nil, nil, nil, fmt.Errorf("failed to parse SD header: %w", r.Err())
@@ -512,14 +566,49 @@ func ParseSecurityDescriptorWithOptions(data []byte, opts ParseSDOptions) (owner
 		}
 	}
 
+	// Parse SACL (audit/alarm) when SE_SACL_PRESENT is set and a SACL body is
+	// present. The SACL is stored on the same ACL carrier (fileACL.SACL) so the
+	// SET_INFO handler can install it; on read it round-trips through
+	// BuildSecurityDescriptor. The SACL never participates in access checks.
+	if offsetSACL > 0 && int(offsetSACL)+aclHeaderSize <= len(data) && control&seSACLPresent != 0 {
+		saclACEs, serr := parseACEs(data[offsetSACL:])
+		if serr != nil {
+			return ownerUID, ownerGID, nil, fmt.Errorf("failed to parse SACL: %w", serr)
+		}
+		if fileACL == nil {
+			// Only the SACL section was present (no DACL). Use a carrier ACL
+			// with no DACL ACEs and Source unset — the SET_INFO handler gates
+			// DACL application on the DACL section flag, so this never installs
+			// an empty DACL on its own.
+			fileACL = &acl.ACL{}
+		}
+		fileACL.SACL = saclACEs
+	}
+
 	return ownerUID, ownerGID, fileACL, nil
 }
 
 // parseDACL parses a DACL and returns an NFSv4 ACL.
 // ACLs parsed from SET_INFO are marked with Source: ACLSourceSMBExplicit.
 func parseDACL(data []byte) (*acl.ACL, error) {
+	aces, err := parseACEs(data)
+	if err != nil {
+		return nil, err
+	}
+	return &acl.ACL{
+		ACEs:   aces,
+		Source: acl.ACLSourceSMBExplicit,
+	}, nil
+}
+
+// parseACEs decodes the ACE array from a binary ACL body (DACL or SACL),
+// returning the ACEs as NFSv4 ACEs. The DACL and SACL share an identical
+// on-wire layout (MS-DTYP §2.4.5 + §2.4.4.2); the only difference is the ACE
+// types they carry (allow/deny for DACL, audit/alarm for SACL), both handled
+// by windowsToNFSACEType. ACEs of unrecognized type are skipped.
+func parseACEs(data []byte) ([]acl.ACE, error) {
 	if len(data) < aclHeaderSize {
-		return nil, fmt.Errorf("DACL too short: %d bytes", len(data))
+		return nil, fmt.Errorf("ACL too short: %d bytes", len(data))
 	}
 
 	// Snapshot the atomic mapper pointer once for SID→principal resolution.
@@ -533,7 +622,7 @@ func parseDACL(data []byte) (*acl.ACL, error) {
 	// Sbz2 not needed
 
 	if aceCount > acl.MaxACECount {
-		return nil, fmt.Errorf("DACL has %d ACEs, exceeds maximum %d", aceCount, acl.MaxACECount)
+		return nil, fmt.Errorf("ACL has %d ACEs, exceeds maximum %d", aceCount, acl.MaxACECount)
 	}
 
 	aces := make([]acl.ACE, 0, aceCount)
@@ -541,7 +630,7 @@ func parseDACL(data []byte) (*acl.ACL, error) {
 
 	for i := 0; i < int(aceCount); i++ {
 		if offset+aceHeaderSize > len(data) {
-			return nil, fmt.Errorf("ACE %d extends beyond DACL data", i)
+			return nil, fmt.Errorf("ACE %d extends beyond ACL data", i)
 		}
 
 		aceR := smbenc.NewReader(data[offset:])
@@ -554,7 +643,7 @@ func parseDACL(data []byte) (*acl.ACL, error) {
 		}
 
 		if offset+int(aceSize) > len(data) {
-			return nil, fmt.Errorf("ACE %d size %d extends beyond DACL data", i, aceSize)
+			return nil, fmt.Errorf("ACE %d size %d extends beyond ACL data", i, aceSize)
 		}
 
 		// Parse SID from remaining ACE data
@@ -587,10 +676,7 @@ func parseDACL(data []byte) (*acl.ACL, error) {
 		offset += int(aceSize)
 	}
 
-	return &acl.ACL{
-		ACEs:   aces,
-		Source: acl.ACLSourceSMBExplicit,
-	}, nil
+	return aces, nil
 }
 
 // ============================================================================

--- a/internal/adapter/smb/handlers/security_sacl_test.go
+++ b/internal/adapter/smb/handlers/security_sacl_test.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
@@ -195,5 +197,85 @@ func TestMergeSecurityACL_PreservesUnrequestedSection(t *testing.T) {
 	}
 	if len(out.SACL) != 1 || out.SACL[0].AccessMask != acl.ACE4_READ_DATA {
 		t.Errorf("SACL-only merge: SACL not taken from parsed: %+v", out.SACL)
+	}
+}
+
+// TestMergeSecurityACL_DACLInfoSet_SACLOnlySD verifies that a request setting
+// DACLSecurityInformation while the parsed SD carried ONLY a SACL section (a
+// non-nil carrier ACL with no DACL body) does NOT install an empty deny-all
+// DACL. ParseSecurityDescriptorWithOptions returns &acl.ACL{} (no Source, no
+// NullDACL) with only SACL populated in that case; treating "non-nil" as "has
+// DACL" would have stamped a 0-ACE deny-all DACL. The DACL must fall back to
+// null-DACL (everyone) behavior instead.
+func TestMergeSecurityACL_DACLInfoSet_SACLOnlySD(t *testing.T) {
+	// A SACL-only carrier: no Source, no NullDACL, no DACL ACEs — exactly what
+	// the parser returns for an SD that carried only a SACL section.
+	parsed := &acl.ACL{
+		SACL: []acl.ACE{{Type: acl.ACE4_SYSTEM_AUDIT_ACE_TYPE, AccessMask: acl.ACE4_WRITE_DATA, Who: acl.SpecialEveryone}},
+	}
+
+	// Defensive sanity: the discriminator must classify this as "no DACL body".
+	if parsedHasDACLBody(parsed) {
+		t.Fatal("SACL-only carrier wrongly classified as having a DACL body")
+	}
+
+	out := mergeSecurityACL(parsed, nil, true /*wantDACL*/, false /*wantSACL*/)
+	if len(out.ACEs) != 0 {
+		t.Errorf("DACL-info SET with SACL-only SD must not synthesize DACL ACEs, got %d", len(out.ACEs))
+	}
+	if !out.NullDACL {
+		t.Error("DACL-info SET with SACL-only SD must fall back to null DACL, not an empty deny-all DACL")
+	}
+	if out.Source == acl.ACLSourceSMBExplicit {
+		t.Error("SACL-only carrier must not be promoted to an explicit (deny-all) DACL")
+	}
+
+	// A genuine explicit-empty DACL (Source set, 0 ACEs) MUST still be honored
+	// as a deny-all DACL — not coerced to null. This guards against the gate
+	// over-correcting.
+	explicitEmpty := &acl.ACL{Source: acl.ACLSourceSMBExplicit}
+	if !parsedHasDACLBody(explicitEmpty) {
+		t.Fatal("explicit-empty DACL must be classified as having a DACL body")
+	}
+	out = mergeSecurityACL(explicitEmpty, nil, true, false)
+	if out.NullDACL {
+		t.Error("explicit-empty DACL must remain a deny-all DACL, not be coerced to null")
+	}
+	if out.Source != acl.ACLSourceSMBExplicit {
+		t.Errorf("explicit-empty DACL Source lost: %q", out.Source)
+	}
+}
+
+// TestMergeSecurityACL_ClearSACL_StoresNil verifies that clearing the SACL
+// (SACL requested, but the SD carried an empty/absent SACL) stores a nil slice
+// — not a non-nil empty slice. json:"sacl,omitempty" only omits nil, so an
+// empty slice would persist as "sacl":[], making "clear" differ in stored
+// shape from "never set".
+func TestMergeSecurityACL_ClearSACL_StoresNil(t *testing.T) {
+	current := &acl.ACL{
+		ACEs:   []acl.ACE{{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: acl.ACE4_READ_DATA, Who: acl.SpecialOwner}},
+		Source: acl.ACLSourceSMBExplicit,
+		SACL:   []acl.ACE{{Type: acl.ACE4_SYSTEM_AUDIT_ACE_TYPE, AccessMask: acl.ACE4_WRITE_DATA, Who: acl.SpecialEveryone}},
+	}
+
+	// Parsed SD requested SACL but carried no SACL ACEs (empty, non-nil slice).
+	parsed := &acl.ACL{
+		ACEs:   current.ACEs,
+		Source: acl.ACLSourceSMBExplicit,
+		SACL:   []acl.ACE{}, // empty, non-nil
+	}
+
+	out := mergeSecurityACL(parsed, current, true /*wantDACL*/, true /*wantSACL*/)
+	if out.SACL != nil {
+		t.Errorf("clear-SACL must store a nil SACL slice, got %#v", out.SACL)
+	}
+
+	// And the JSON form must omit the key entirely.
+	data, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if bytes.Contains(data, []byte("sacl")) {
+		t.Errorf("cleared SACL must be omitted from JSON, got %s", data)
 	}
 }

--- a/internal/adapter/smb/handlers/security_sacl_test.go
+++ b/internal/adapter/smb/handlers/security_sacl_test.go
@@ -1,0 +1,199 @@
+package handlers
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+)
+
+// TestBuildSD_SACL_RoundTrip verifies that a stored SACL (audit ACEs) is
+// serialized on QUERY_INFO and parses back identically on SET_INFO — closing
+// the parsed-then-dropped gap (#1228 Fix C). The DACL is unaffected.
+func TestBuildSD_SACL_RoundTrip(t *testing.T) {
+	file := &metadata.File{
+		FileAttr: metadata.FileAttr{
+			UID:  1000,
+			GID:  1000,
+			Mode: 0o755,
+			ACL: &acl.ACL{
+				ACEs: []acl.ACE{
+					{
+						Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+						AccessMask: acl.ACE4_READ_DATA | acl.ACE4_EXECUTE,
+						Who:        acl.SpecialEveryone,
+					},
+				},
+				SACL: []acl.ACE{
+					{
+						Type:       acl.ACE4_SYSTEM_AUDIT_ACE_TYPE,
+						Flag:       acl.ACE4_SUCCESSFUL_ACCESS_ACE_FLAG | acl.ACE4_FAILED_ACCESS_ACE_FLAG,
+						AccessMask: acl.ACE4_WRITE_DATA,
+						Who:        acl.SpecialEveryone,
+					},
+				},
+			},
+		},
+	}
+
+	secInfo := uint32(DACLSecurityInformation | SACLSecurityInformation)
+	data, err := BuildSecurityDescriptor(file, secInfo)
+	if err != nil {
+		t.Fatalf("BuildSecurityDescriptor: %v", err)
+	}
+
+	// SE_SACL_PRESENT must be set and the SACL must carry exactly one ACE.
+	control := binary.LittleEndian.Uint16(data[2:4])
+	if control&seSACLPresent == 0 {
+		t.Error("SE_SACL_PRESENT not set")
+	}
+	saclOffset := binary.LittleEndian.Uint32(data[12:16])
+	if saclOffset == 0 {
+		t.Fatal("SACL offset is 0 when a SACL is stored")
+	}
+	saclCount := binary.LittleEndian.Uint16(data[saclOffset+4 : saclOffset+6])
+	if saclCount != 1 {
+		t.Fatalf("SACL ACE count = %d, want 1", saclCount)
+	}
+
+	// Round-trip: parse the SD back and confirm the SACL survives.
+	_, _, parsed, err := ParseSecurityDescriptor(data)
+	if err != nil {
+		t.Fatalf("ParseSecurityDescriptor: %v", err)
+	}
+	if parsed == nil {
+		t.Fatal("parsed ACL is nil")
+	}
+	if len(parsed.SACL) != 1 {
+		t.Fatalf("parsed SACL has %d ACEs, want 1", len(parsed.SACL))
+	}
+	got := parsed.SACL[0]
+	if got.Type != acl.ACE4_SYSTEM_AUDIT_ACE_TYPE {
+		t.Errorf("SACL ACE type = %d, want AUDIT(%d)", got.Type, acl.ACE4_SYSTEM_AUDIT_ACE_TYPE)
+	}
+	wantFlag := uint32(acl.ACE4_SUCCESSFUL_ACCESS_ACE_FLAG | acl.ACE4_FAILED_ACCESS_ACE_FLAG)
+	if got.Flag != wantFlag {
+		t.Errorf("SACL ACE flag = 0x%x, want 0x%x (success+failed audit flags must round-trip)", got.Flag, wantFlag)
+	}
+	if got.AccessMask != acl.ACE4_WRITE_DATA {
+		t.Errorf("SACL ACE mask = 0x%x, want 0x%x", got.AccessMask, acl.ACE4_WRITE_DATA)
+	}
+	if got.Who != acl.SpecialEveryone {
+		t.Errorf("SACL ACE who = %q, want %q", got.Who, acl.SpecialEveryone)
+	}
+
+	// DACL must still be present and unchanged.
+	if len(parsed.ACEs) != 1 {
+		t.Fatalf("parsed DACL has %d ACEs, want 1", len(parsed.ACEs))
+	}
+}
+
+// TestBuildSD_SACL_EmptyStub_WhenNoStoredSACL verifies the nil-SACL case still
+// emits the legacy empty stub (count=0, size=8) — behavior unchanged when no
+// SACL is stored.
+func TestBuildSD_SACL_EmptyStub_WhenNoStoredSACL(t *testing.T) {
+	file := &metadata.File{
+		FileAttr: metadata.FileAttr{
+			UID: 1000, GID: 1000, Mode: 0o755,
+			ACL: &acl.ACL{ACEs: []acl.ACE{{
+				Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: acl.ACE4_READ_DATA, Who: acl.SpecialOwner,
+			}}},
+		},
+	}
+
+	data, err := BuildSecurityDescriptor(file, uint32(DACLSecurityInformation|SACLSecurityInformation))
+	if err != nil {
+		t.Fatalf("BuildSecurityDescriptor: %v", err)
+	}
+	saclOffset := binary.LittleEndian.Uint32(data[12:16])
+	saclCount := binary.LittleEndian.Uint16(data[saclOffset+4 : saclOffset+6])
+	if saclCount != 0 {
+		t.Errorf("SACL ACE count = %d, want 0 (empty stub)", saclCount)
+	}
+	saclSize := binary.LittleEndian.Uint16(data[saclOffset+2 : saclOffset+4])
+	if saclSize != 8 {
+		t.Errorf("SACL size = %d, want 8 (empty stub)", saclSize)
+	}
+}
+
+// TestParseSD_SACLOnly_NoDACL verifies that an SD carrying only a SACL section
+// (SE_SACL_PRESENT, no SE_DACL_PRESENT) parses into a carrier ACL with the SACL
+// populated and no DACL ACEs — so a SACL-only SET_INFO does not fabricate a DACL.
+func TestParseSD_SACLOnly_NoDACL(t *testing.T) {
+	// Build an SD that has a SACL but no DACL by round-tripping a file whose
+	// ACL has only a SACL, requesting only the SACL section.
+	file := &metadata.File{
+		FileAttr: metadata.FileAttr{
+			UID: 1000, GID: 1000, Mode: 0o755,
+			ACL: &acl.ACL{
+				SACL: []acl.ACE{{
+					Type:       acl.ACE4_SYSTEM_AUDIT_ACE_TYPE,
+					Flag:       acl.ACE4_FAILED_ACCESS_ACE_FLAG,
+					AccessMask: acl.ACE4_WRITE_DATA,
+					Who:        acl.SpecialOwner,
+				}},
+			},
+		},
+	}
+	data, err := BuildSecurityDescriptor(file, uint32(SACLSecurityInformation))
+	if err != nil {
+		t.Fatalf("BuildSecurityDescriptor: %v", err)
+	}
+
+	_, _, parsed, err := ParseSecurityDescriptor(data)
+	if err != nil {
+		t.Fatalf("ParseSecurityDescriptor: %v", err)
+	}
+	if parsed == nil {
+		t.Fatal("expected a carrier ACL for the SACL, got nil")
+	}
+	if len(parsed.SACL) != 1 {
+		t.Fatalf("parsed SACL has %d ACEs, want 1", len(parsed.SACL))
+	}
+	if len(parsed.ACEs) != 0 {
+		t.Errorf("SACL-only SD produced %d DACL ACEs, want 0", len(parsed.ACEs))
+	}
+	if parsed.NullDACL {
+		t.Error("SACL-only SD must not be marked NullDACL")
+	}
+}
+
+// TestMergeSecurityACL_PreservesUnrequestedSection verifies the SET_INFO merge:
+// a DACL-only request preserves the current SACL, and a SACL-only request
+// preserves the current DACL.
+func TestMergeSecurityACL_PreservesUnrequestedSection(t *testing.T) {
+	current := &acl.ACL{
+		ACEs:   []acl.ACE{{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: acl.ACE4_READ_DATA, Who: acl.SpecialOwner}},
+		Source: acl.ACLSourceSMBExplicit,
+		SACL:   []acl.ACE{{Type: acl.ACE4_SYSTEM_AUDIT_ACE_TYPE, AccessMask: acl.ACE4_WRITE_DATA, Who: acl.SpecialEveryone}},
+	}
+
+	// DACL-only SET: new DACL replaces ACEs, SACL preserved from current.
+	parsedDACL := &acl.ACL{
+		ACEs:   []acl.ACE{{Type: acl.ACE4_ACCESS_DENIED_ACE_TYPE, AccessMask: acl.ACE4_WRITE_DATA, Who: acl.SpecialEveryone}},
+		Source: acl.ACLSourceSMBExplicit,
+	}
+	out := mergeSecurityACL(parsedDACL, current, true, false)
+	if len(out.ACEs) != 1 || out.ACEs[0].Type != acl.ACE4_ACCESS_DENIED_ACE_TYPE {
+		t.Errorf("DACL-only merge: DACL not taken from parsed: %+v", out.ACEs)
+	}
+	if len(out.SACL) != 1 || out.SACL[0].Type != acl.ACE4_SYSTEM_AUDIT_ACE_TYPE {
+		t.Errorf("DACL-only merge: SACL not preserved from current: %+v", out.SACL)
+	}
+
+	// SACL-only SET: new SACL replaces SACL, DACL preserved from current.
+	parsedSACL := &acl.ACL{
+		SACL: []acl.ACE{{Type: acl.ACE4_SYSTEM_AUDIT_ACE_TYPE, AccessMask: acl.ACE4_READ_DATA, Who: acl.SpecialOwner}},
+	}
+	out = mergeSecurityACL(parsedSACL, current, false, true)
+	if len(out.ACEs) != 1 || out.ACEs[0].Who != acl.SpecialOwner {
+		t.Errorf("SACL-only merge: DACL not preserved from current: %+v", out.ACEs)
+	}
+	if out.Source != acl.ACLSourceSMBExplicit {
+		t.Errorf("SACL-only merge: DACL Source not preserved, got %q", out.Source)
+	}
+	if len(out.SACL) != 1 || out.SACL[0].AccessMask != acl.ACE4_READ_DATA {
+		t.Errorf("SACL-only merge: SACL not taken from parsed: %+v", out.SACL)
+	}
+}

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1869,14 +1869,29 @@ func (h *Handler) setSecurityInfo(
 	return setInfoStatus(types.StatusSuccess), nil
 }
 
+// parsedHasDACLBody reports whether a parsed SD carried an actual DACL section.
+//
+// ParseSecurityDescriptorWithOptions returns a non-nil carrier ACL whenever it
+// found EITHER a DACL or a SACL, so "non-nil" alone does not imply a DACL is
+// present: a SACL-only SD yields &acl.ACL{} (no Source, no NullDACL) with only
+// the SACL slice populated. parseDACL always stamps Source=ACLSourceSMBExplicit
+// (even for a 0-ACE explicit-empty DACL), and a wire null DACL sets NullDACL —
+// those two markers are the only ways the DACL portion gets populated, so they
+// are the reliable discriminator. Without this gate a DACL-info SET carrying a
+// SACL-only SD would install an empty deny-all DACL instead of preserving the
+// prior (or null-DACL) behavior.
+func parsedHasDACLBody(parsed *acl.ACL) bool {
+	return parsed != nil && (parsed.Source == acl.ACLSourceSMBExplicit || parsed.NullDACL)
+}
+
 // mergeSecurityACL builds the acl.ACL to install on a SET_INFO Security,
 // combining the freshly-parsed SD (parsed) with the file's current ACL
 // (current) according to which sections the request carried.
 //
 //   - DACL requested: take the DACL (ACEs + DACL-level flags + Source) from
-//     parsed; if parsed is nil the request carried no DACL body → null DACL.
+//     parsed; if parsed carried no DACL body → null DACL.
 //   - DACL not requested: preserve the current DACL unchanged.
-//   - SACL requested: take the SACL from parsed (nil parsed → clear SACL).
+//   - SACL requested: take the SACL from parsed (no/empty SACL → clear it).
 //   - SACL not requested: preserve the current SACL unchanged.
 //
 // The result is a single carrier so the metadata store's whole-ACL replace
@@ -1886,7 +1901,7 @@ func mergeSecurityACL(parsed, current *acl.ACL, wantDACL, wantSACL bool) *acl.AC
 
 	// DACL portion (ACEs + DACL-scoped control flags + Source).
 	if wantDACL {
-		if parsed != nil {
+		if parsedHasDACLBody(parsed) {
 			out.ACEs = parsed.ACEs
 			out.Source = parsed.Source
 			out.Protected = parsed.Protected
@@ -1904,9 +1919,11 @@ func mergeSecurityACL(parsed, current *acl.ACL, wantDACL, wantSACL bool) *acl.AC
 		out.NullDACL = current.NullDACL
 	}
 
-	// SACL portion.
+	// SACL portion. Normalize an empty (non-nil) slice to nil so "clear SACL"
+	// stores the same shape as "no SACL" — json:"sacl,omitempty" only drops a
+	// nil slice, so an empty slice would otherwise persist as "sacl":[].
 	if wantSACL {
-		if parsed != nil {
+		if parsed != nil && len(parsed.SACL) > 0 {
 			out.SACL = parsed.SACL
 		}
 		// parsed nil or empty SACL → leave out.SACL nil (cleared).

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1824,15 +1824,28 @@ func (h *Handler) setSecurityInfo(
 		changed = true
 	}
 
-	if (additionalInfo & DACLSecurityInformation) != 0 {
-		if fileACL != nil {
-			setAttrs.ACL = fileACL
-			changed = true
-		} else {
-			// DACL section requested but no DACL in SD → null DACL
-			setAttrs.ACL = &acl.ACL{NullDACL: true}
-			changed = true
+	// DACL and SACL are stored on the same acl.ACL carrier (DACL in ACEs/flags,
+	// SACL in the SACL slice). A SET_INFO may request either or both sections,
+	// so build the installed ACL honoring exactly the requested sections while
+	// preserving the unrequested portion from the file's current ACL. Without
+	// this preserve step, a SACL-only SET would wipe the DACL (and vice versa).
+	wantDACL := (additionalInfo & DACLSecurityInformation) != 0
+	wantSACL := (additionalInfo & SACLSecurityInformation) != 0
+	if wantDACL || wantSACL {
+		// Fetch the current ACL so the unrequested section survives. A miss
+		// (or nil ACL) leaves the section empty, matching today's full-replace
+		// behavior for the requested section.
+		var current *acl.ACL
+		if !wantDACL || !wantSACL {
+			metaSvc := h.Registry.GetMetadataService()
+			if cur, gerr := metaSvc.GetFile(authCtx.Context, openFile.MetadataHandle); gerr == nil && cur != nil {
+				current = cur.ACL
+			}
 		}
+
+		merged := mergeSecurityACL(fileACL, current, wantDACL, wantSACL)
+		setAttrs.ACL = merged
+		changed = true
 	}
 
 	if !changed {
@@ -1854,6 +1867,54 @@ func (h *Handler) setSecurityInfo(
 	}
 
 	return setInfoStatus(types.StatusSuccess), nil
+}
+
+// mergeSecurityACL builds the acl.ACL to install on a SET_INFO Security,
+// combining the freshly-parsed SD (parsed) with the file's current ACL
+// (current) according to which sections the request carried.
+//
+//   - DACL requested: take the DACL (ACEs + DACL-level flags + Source) from
+//     parsed; if parsed is nil the request carried no DACL body → null DACL.
+//   - DACL not requested: preserve the current DACL unchanged.
+//   - SACL requested: take the SACL from parsed (nil parsed → clear SACL).
+//   - SACL not requested: preserve the current SACL unchanged.
+//
+// The result is a single carrier so the metadata store's whole-ACL replace
+// installs both sections atomically without dropping the unrequested one.
+func mergeSecurityACL(parsed, current *acl.ACL, wantDACL, wantSACL bool) *acl.ACL {
+	out := &acl.ACL{}
+
+	// DACL portion (ACEs + DACL-scoped control flags + Source).
+	if wantDACL {
+		if parsed != nil {
+			out.ACEs = parsed.ACEs
+			out.Source = parsed.Source
+			out.Protected = parsed.Protected
+			out.AutoInherited = parsed.AutoInherited
+			out.NullDACL = parsed.NullDACL
+		} else {
+			// DACL section requested but no DACL body in the SD → null DACL.
+			out.NullDACL = true
+		}
+	} else if current != nil {
+		out.ACEs = current.ACEs
+		out.Source = current.Source
+		out.Protected = current.Protected
+		out.AutoInherited = current.AutoInherited
+		out.NullDACL = current.NullDACL
+	}
+
+	// SACL portion.
+	if wantSACL {
+		if parsed != nil {
+			out.SACL = parsed.SACL
+		}
+		// parsed nil or empty SACL → leave out.SACL nil (cleared).
+	} else if current != nil {
+		out.SACL = current.SACL
+	}
+
+	return out
 }
 
 // checkSetInfoSecurityAccess maps requested SECURITY_INFORMATION sections to

--- a/pkg/metadata/acl/flags.go
+++ b/pkg/metadata/acl/flags.go
@@ -12,7 +12,12 @@ package acl
 //	NFSv4 0x02 (DIRECTORY_INHERIT_ACE)    -> Windows 0x02 (CI)
 //	NFSv4 0x04 (NO_PROPAGATE_INHERIT_ACE) -> Windows 0x04 (NP)
 //	NFSv4 0x08 (INHERIT_ONLY_ACE)         -> Windows 0x08 (IO)
+//	NFSv4 0x10 (SUCCESSFUL_ACCESS_ACE_FLAG)-> Windows 0x40 (SUCCESSFUL_ACCESS)
+//	NFSv4 0x20 (FAILED_ACCESS_ACE_FLAG)    -> Windows 0x80 (FAILED_ACCESS)
 //	NFSv4 0x80 (INHERITED_ACE)            -> Windows 0x10 (INHERITED)
+//
+// The SUCCESSFUL/FAILED audit flags are only meaningful on SACL audit/alarm
+// ACEs; DACL allow/deny ACEs never carry them, so DACL output is unchanged.
 func NFSv4FlagsToWindowsFlags(nfsFlags uint32) uint8 {
 	var winFlags uint8
 	if nfsFlags&ACE4_FILE_INHERIT_ACE != 0 {
@@ -26,6 +31,12 @@ func NFSv4FlagsToWindowsFlags(nfsFlags uint32) uint8 {
 	}
 	if nfsFlags&ACE4_INHERIT_ONLY_ACE != 0 {
 		winFlags |= 0x08 // INHERIT_ONLY_ACE
+	}
+	if nfsFlags&ACE4_SUCCESSFUL_ACCESS_ACE_FLAG != 0 {
+		winFlags |= 0x40 // SUCCESSFUL_ACCESS_ACE_FLAG (0x10 -> 0x40)
+	}
+	if nfsFlags&ACE4_FAILED_ACCESS_ACE_FLAG != 0 {
+		winFlags |= 0x80 // FAILED_ACCESS_ACE_FLAG (0x20 -> 0x80)
 	}
 	if nfsFlags&ACE4_INHERITED_ACE != 0 {
 		winFlags |= 0x10 // INHERITED_ACE (0x80 -> 0x10)
@@ -42,6 +53,8 @@ func NFSv4FlagsToWindowsFlags(nfsFlags uint32) uint8 {
 //	Windows 0x02 (CI)        -> NFSv4 0x02 (DIRECTORY_INHERIT_ACE)
 //	Windows 0x04 (NP)        -> NFSv4 0x04 (NO_PROPAGATE_INHERIT_ACE)
 //	Windows 0x08 (IO)        -> NFSv4 0x08 (INHERIT_ONLY_ACE)
+//	Windows 0x40 (SUCCESSFUL_ACCESS) -> NFSv4 0x10 (SUCCESSFUL_ACCESS_ACE_FLAG)
+//	Windows 0x80 (FAILED_ACCESS)     -> NFSv4 0x20 (FAILED_ACCESS_ACE_FLAG)
 //	Windows 0x10 (INHERITED) -> NFSv4 0x80 (INHERITED_ACE)
 func WindowsFlagsToNFSv4Flags(winFlags uint8) uint32 {
 	var nfsFlags uint32
@@ -56,6 +69,12 @@ func WindowsFlagsToNFSv4Flags(winFlags uint8) uint32 {
 	}
 	if winFlags&0x08 != 0 {
 		nfsFlags |= ACE4_INHERIT_ONLY_ACE
+	}
+	if winFlags&0x40 != 0 {
+		nfsFlags |= ACE4_SUCCESSFUL_ACCESS_ACE_FLAG // 0x40 -> 0x10
+	}
+	if winFlags&0x80 != 0 {
+		nfsFlags |= ACE4_FAILED_ACCESS_ACE_FLAG // 0x80 -> 0x20
 	}
 	if winFlags&0x10 != 0 {
 		nfsFlags |= ACE4_INHERITED_ACE // 0x10 -> 0x80

--- a/pkg/metadata/acl/mode.go
+++ b/pkg/metadata/acl/mode.go
@@ -68,6 +68,16 @@ func AdjustACLForMode(a *ACL, newMode uint32) *ACL {
 	newACEs := make([]ACE, len(a.ACEs))
 	copy(newACEs, a.ACEs)
 
+	// Deep-copy the SACL too. chmod never touches audit/alarm ACEs, but the
+	// "returns a new ACL; the original is not modified" contract requires a
+	// fresh backing array — aliasing a.SACL would let a later mutation of the
+	// returned ACL corrupt the caller's original.
+	var newSACL []ACE
+	if a.SACL != nil {
+		newSACL = make([]ACE, len(a.SACL))
+		copy(newSACL, a.SACL)
+	}
+
 	for i := range newACEs {
 		ace := &newACEs[i]
 
@@ -108,9 +118,10 @@ func AdjustACLForMode(a *ACL, newMode uint32) *ACL {
 		AutoInherited: a.AutoInherited,
 		NullDACL:      a.NullDACL,
 		// SACL (audit/alarm) is unaffected by chmod — RFC 7530 §6.4.1 only
-		// rewrites DACL special-identifier rwx bits. Carry it through so a
-		// chmod after a SET_INFO SACL does not silently drop the audit ACEs.
-		SACL: a.SACL,
+		// rewrites DACL special-identifier rwx bits. Carry the deep copy
+		// through so a chmod after a SET_INFO SACL does not silently drop the
+		// audit ACEs, without aliasing the caller's original backing array.
+		SACL: newSACL,
 	}
 }
 

--- a/pkg/metadata/acl/mode.go
+++ b/pkg/metadata/acl/mode.go
@@ -107,6 +107,10 @@ func AdjustACLForMode(a *ACL, newMode uint32) *ACL {
 		Protected:     a.Protected,
 		AutoInherited: a.AutoInherited,
 		NullDACL:      a.NullDACL,
+		// SACL (audit/alarm) is unaffected by chmod — RFC 7530 §6.4.1 only
+		// rewrites DACL special-identifier rwx bits. Carry it through so a
+		// chmod after a SET_INFO SACL does not silently drop the audit ACEs.
+		SACL: a.SACL,
 	}
 }
 

--- a/pkg/metadata/acl/sacl_test.go
+++ b/pkg/metadata/acl/sacl_test.go
@@ -1,0 +1,116 @@
+package acl
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestACL_SACL_JSONRoundTrip verifies the SACL field serializes and
+// deserializes through JSON — the storage path used by the postgres (JSONB),
+// badger, and sqlite backends. No migration is needed precisely because the
+// whole ACL struct is JSON-marshaled.
+func TestACL_SACL_JSONRoundTrip(t *testing.T) {
+	original := &ACL{
+		ACEs: []ACE{
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialOwner},
+		},
+		SACL: []ACE{
+			{
+				Type:       ACE4_SYSTEM_AUDIT_ACE_TYPE,
+				Flag:       ACE4_SUCCESSFUL_ACCESS_ACE_FLAG | ACE4_FAILED_ACCESS_ACE_FLAG,
+				AccessMask: ACE4_WRITE_DATA,
+				Who:        SpecialEveryone,
+			},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded ACL
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(decoded.SACL) != 1 {
+		t.Fatalf("decoded SACL len = %d, want 1", len(decoded.SACL))
+	}
+	got := decoded.SACL[0]
+	if got.Type != ACE4_SYSTEM_AUDIT_ACE_TYPE {
+		t.Errorf("SACL Type = %d, want AUDIT", got.Type)
+	}
+	if got.Flag != ACE4_SUCCESSFUL_ACCESS_ACE_FLAG|ACE4_FAILED_ACCESS_ACE_FLAG {
+		t.Errorf("SACL Flag = 0x%x", got.Flag)
+	}
+	if got.AccessMask != ACE4_WRITE_DATA || got.Who != SpecialEveryone {
+		t.Errorf("SACL ACE roundtrip mismatch: %+v", got)
+	}
+}
+
+// TestACL_SACL_JSONOmitEmpty verifies a nil SACL is omitted from the wire form,
+// keeping existing stored ACLs byte-identical (no spurious "sacl" key).
+func TestACL_SACL_JSONOmitEmpty(t *testing.T) {
+	a := &ACL{ACEs: []ACE{{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialOwner}}}
+	data, err := json.Marshal(a)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "sacl") {
+		t.Errorf("nil SACL should be omitted, got %s", data)
+	}
+}
+
+// TestAdjustACLForMode_PreservesSACL verifies chmod does not drop the SACL.
+func TestAdjustACLForMode_PreservesSACL(t *testing.T) {
+	in := &ACL{
+		ACEs: []ACE{{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: rwxMaskBits, Who: SpecialOwner}},
+		SACL: []ACE{{Type: ACE4_SYSTEM_AUDIT_ACE_TYPE, AccessMask: ACE4_WRITE_DATA, Who: SpecialEveryone}},
+	}
+	out := AdjustACLForMode(in, 0o755)
+	if len(out.SACL) != 1 {
+		t.Fatalf("AdjustACLForMode dropped SACL: got %d entries, want 1", len(out.SACL))
+	}
+	if out.SACL[0].Type != ACE4_SYSTEM_AUDIT_ACE_TYPE {
+		t.Errorf("SACL ACE type changed: %d", out.SACL[0].Type)
+	}
+}
+
+// TestValidateACL_SACLEntries verifies SACL entries are validated and a
+// malformed SACL ACE is rejected.
+func TestValidateACL_SACLEntries(t *testing.T) {
+	good := &ACL{
+		SACL: []ACE{{Type: ACE4_SYSTEM_AUDIT_ACE_TYPE, AccessMask: ACE4_WRITE_DATA, Who: SpecialEveryone}},
+	}
+	if err := ValidateACL(good); err != nil {
+		t.Errorf("valid SACL rejected: %v", err)
+	}
+
+	badWho := &ACL{
+		SACL: []ACE{{Type: ACE4_SYSTEM_AUDIT_ACE_TYPE, AccessMask: ACE4_WRITE_DATA, Who: ""}},
+	}
+	if err := ValidateACL(badWho); err == nil {
+		t.Error("SACL ACE with empty Who should be rejected")
+	}
+
+	badType := &ACL{
+		SACL: []ACE{{Type: 0xFF, AccessMask: ACE4_WRITE_DATA, Who: SpecialEveryone}},
+	}
+	if err := ValidateACL(badType); err == nil {
+		t.Error("SACL ACE with invalid type should be rejected")
+	}
+}
+
+// TestAuditFlags_RoundTrip verifies the SUCCESSFUL/FAILED audit ACE flags map
+// to/from their Windows bit positions (0x40 / 0x80) — required for SACL audit
+// ACEs to round-trip.
+func TestAuditFlags_RoundTrip(t *testing.T) {
+	nfs := uint32(ACE4_SUCCESSFUL_ACCESS_ACE_FLAG | ACE4_FAILED_ACCESS_ACE_FLAG)
+	win := NFSv4FlagsToWindowsFlags(nfs)
+	if win != 0x40|0x80 {
+		t.Fatalf("NFSv4->Windows audit flags = 0x%x, want 0xc0", win)
+	}
+	if back := WindowsFlagsToNFSv4Flags(win); back != nfs {
+		t.Errorf("Windows->NFSv4 audit flags = 0x%x, want 0x%x", back, nfs)
+	}
+}

--- a/pkg/metadata/acl/sacl_test.go
+++ b/pkg/metadata/acl/sacl_test.go
@@ -76,6 +76,39 @@ func TestAdjustACLForMode_PreservesSACL(t *testing.T) {
 	}
 }
 
+// TestAdjustACLForMode_SACLDeepCopy verifies the "returns a new ACL; the
+// original is not modified" contract extends to the SACL: mutating the returned
+// ACL's SACL must not corrupt the caller's original backing array.
+func TestAdjustACLForMode_SACLDeepCopy(t *testing.T) {
+	in := &ACL{
+		ACEs: []ACE{{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: rwxMaskBits, Who: SpecialOwner}},
+		SACL: []ACE{{Type: ACE4_SYSTEM_AUDIT_ACE_TYPE, AccessMask: ACE4_WRITE_DATA, Who: SpecialEveryone}},
+	}
+	out := AdjustACLForMode(in, 0o755)
+
+	// Mutate the returned SACL — the original must be untouched.
+	out.SACL[0].AccessMask = ACE4_READ_DATA
+	if in.SACL[0].AccessMask != ACE4_WRITE_DATA {
+		t.Errorf("AdjustACLForMode aliased SACL backing array: original mutated to 0x%x", in.SACL[0].AccessMask)
+	}
+}
+
+// TestValidateACL_SACLMaxSize verifies the 64KB serialized-size bound applies to
+// the SACL, not just the DACL — an oversized SACL (via an unbounded Who) must be
+// rejected.
+func TestValidateACL_SACLMaxSize(t *testing.T) {
+	huge := make([]byte, MaxDACLSize)
+	for i := range huge {
+		huge[i] = 'a'
+	}
+	a := &ACL{
+		SACL: []ACE{{Type: ACE4_SYSTEM_AUDIT_ACE_TYPE, AccessMask: ACE4_WRITE_DATA, Who: string(huge)}},
+	}
+	if err := ValidateACL(a); err == nil {
+		t.Error("oversized SACL must be rejected by the MaxDACLSize bound")
+	}
+}
+
 // TestValidateACL_SACLEntries verifies SACL entries are validated and a
 // malformed SACL ACE is rejected.
 func TestValidateACL_SACLEntries(t *testing.T) {

--- a/pkg/metadata/acl/types.go
+++ b/pkg/metadata/acl/types.go
@@ -155,12 +155,23 @@ const (
 )
 
 // ACL represents an NFSv4 Access Control List.
+//
+// The ACEs/Source/Protected/AutoInherited/NullDACL fields describe the
+// DACL (discretionary ACL) — the access-control portion that drives
+// permission evaluation. SACL holds the system ACL (audit/alarm ACEs)
+// which is never consulted for access decisions; it is preserved purely
+// for round-trip fidelity with Windows clients that SET and QUERY the
+// SACL_SECURITY_INFORMATION section (MS-DTYP §2.4.6). A nil SACL means
+// "no SACL stored" and is backward compatible with existing data — the
+// SMB read side emits an empty SACL stub in that case, matching prior
+// behavior exactly.
 type ACL struct {
 	ACEs          []ACE     `json:"aces"`
 	Source        ACLSource `json:"source,omitempty"`         // How this ACL was created
 	Protected     bool      `json:"protected,omitempty"`      // SE_DACL_PROTECTED - blocks inheritance
 	AutoInherited bool      `json:"auto_inherited,omitempty"` // SE_DACL_AUTO_INHERITED — DACL was auto-inherited from parent
 	NullDACL      bool      `json:"null_dacl,omitempty"`      // Windows null DACL — no DACL present (everyone full access)
+	SACL          []ACE     `json:"sacl,omitempty"`           // System ACL (audit/alarm ACEs); preserved for round-trip, not used for access checks
 }
 
 // isSpecialWho reports whether who is one of the special identifiers:

--- a/pkg/metadata/acl/validate.go
+++ b/pkg/metadata/acl/validate.go
@@ -80,6 +80,18 @@ func ValidateACL(a *ACL) error {
 		}
 	}
 
+	// Validate SACL (audit/alarm) entries with the same per-ACE and count
+	// limits. The SACL is stored for round-trip fidelity only and never drives
+	// access evaluation, but malformed entries must still be rejected.
+	if len(a.SACL) > MaxACECount {
+		return fmt.Errorf("%w: %d SACL ACEs (maximum %d)", ErrACETooMany, len(a.SACL), MaxACECount)
+	}
+	for i := range a.SACL {
+		if err := ValidateACE(&a.SACL[i]); err != nil {
+			return fmt.Errorf("SACL ACE %d: %w", i, err)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/metadata/acl/validate.go
+++ b/pkg/metadata/acl/validate.go
@@ -80,11 +80,20 @@ func ValidateACL(a *ACL) error {
 		}
 	}
 
-	// Validate SACL (audit/alarm) entries with the same per-ACE and count
-	// limits. The SACL is stored for round-trip fidelity only and never drives
-	// access evaluation, but malformed entries must still be rejected.
+	// Validate SACL (audit/alarm) entries with the same per-ACE, count, AND
+	// serialized-size limits applied to the DACL. The SACL is stored for
+	// round-trip fidelity only and never drives access evaluation, but its
+	// ACE.Who strings are equally unbounded, so the 64KB cap must apply here
+	// too — otherwise an oversized SACL bypasses the MaxDACLSize bound.
 	if len(a.SACL) > MaxACECount {
 		return fmt.Errorf("%w: %d SACL ACEs (maximum %d)", ErrACETooMany, len(a.SACL), MaxACECount)
+	}
+	saclSize := 4
+	for i := range a.SACL {
+		saclSize += aceWireOverhead + xdrPad(len(a.SACL[i].Who))
+		if saclSize > MaxDACLSize {
+			return fmt.Errorf("%w: SACL exceeds %d bytes", ErrACLTooLarge, MaxDACLSize)
+		}
 	}
 	for i := range a.SACL {
 		if err := ValidateACE(&a.SACL[i]); err != nil {

--- a/pkg/metadata/store/memory/files.go
+++ b/pkg/metadata/store/memory/files.go
@@ -27,10 +27,11 @@ func cloneBlocks(in []block.BlockRef) []block.BlockRef {
 	return out
 }
 
-// cloneACL returns a deep copy of a *acl.ACL, including a fresh copy of its
-// ACEs slice. acl.ACL holds a single reference-bearing field (the ACEs slice);
-// acl.ACE is a flat value type (uint32 fields + a string Who), so an
-// element-wise slice copy fully detaches the clone — no nested pointers remain.
+// cloneACL returns a deep copy of a *acl.ACL, including fresh copies of its
+// ACEs (DACL) and SACL slices. acl.ACL holds two reference-bearing fields (the
+// ACEs and SACL slices); acl.ACE is a flat value type (uint32 fields + a string
+// Who), so an element-wise slice copy fully detaches the clone — no nested
+// pointers remain.
 //
 // Used by PutFile/GetFile/ListChildren in the Memory backend to prevent ACL
 // aliasing between the caller's view and the stored view. Without this, an
@@ -48,6 +49,10 @@ func cloneACL(in *acl.ACL) *acl.ACL {
 	if in.ACEs != nil {
 		out.ACEs = make([]acl.ACE, len(in.ACEs))
 		copy(out.ACEs, in.ACEs)
+	}
+	if in.SACL != nil {
+		out.SACL = make([]acl.ACE, len(in.SACL))
+		copy(out.SACL, in.SACL)
 	}
 	return &out
 }

--- a/pkg/metadata/store/memory/files_sacl_test.go
+++ b/pkg/metadata/store/memory/files_sacl_test.go
@@ -1,0 +1,93 @@
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+)
+
+// putFileWithACL stamps a file carrying the given ACL through the public
+// Put/Get path on MemoryMetadataStore and returns (handle, file).
+func putFileWithACL(t *testing.T, store *MemoryMetadataStore, shareName, name string, a *acl.ACL) (metadata.FileHandle, *metadata.File) {
+	t.Helper()
+	ctx := context.Background()
+
+	require.NoError(t, store.CreateShare(ctx, &metadata.Share{Name: shareName}))
+	rootAttr := &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755}
+	rootFile, err := store.CreateRootDirectory(ctx, shareName, rootAttr)
+	require.NoError(t, err)
+	rootHandle, err := metadata.EncodeFileHandle(rootFile)
+	require.NoError(t, err)
+
+	handle, err := store.GenerateHandle(ctx, shareName, "/"+name)
+	require.NoError(t, err)
+	_, id, err := metadata.DecodeFileHandle(handle)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	file := &metadata.File{
+		ID:        id,
+		ShareName: shareName,
+		FileAttr: metadata.FileAttr{
+			Type: metadata.FileTypeRegular, Mode: 0o644, UID: 1000, GID: 1000,
+			Mtime: now, Ctime: now, Atime: now, CreationTime: now,
+			ACL: a,
+		},
+	}
+	require.NoError(t, store.PutFile(ctx, file))
+	require.NoError(t, store.SetParent(ctx, handle, rootHandle))
+	require.NoError(t, store.SetChild(ctx, rootHandle, name, handle))
+	return handle, file
+}
+
+// TestMemoryStore_SACL_RoundTrip verifies a stored SACL survives Put/Get in the
+// memory backend.
+func TestMemoryStore_SACL_RoundTrip(t *testing.T) {
+	store := NewMemoryMetadataStoreWithDefaults()
+	ctx := context.Background()
+
+	in := &acl.ACL{
+		ACEs: []acl.ACE{{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: acl.ACE4_READ_DATA, Who: acl.SpecialOwner}},
+		SACL: []acl.ACE{{
+			Type:       acl.ACE4_SYSTEM_AUDIT_ACE_TYPE,
+			Flag:       acl.ACE4_FAILED_ACCESS_ACE_FLAG,
+			AccessMask: acl.ACE4_WRITE_DATA,
+			Who:        acl.SpecialEveryone,
+		}},
+	}
+	handle, _ := putFileWithACL(t, store, "share-sacl", "f", in)
+
+	got, err := store.GetFile(ctx, handle)
+	require.NoError(t, err)
+	require.NotNil(t, got.ACL)
+	require.Len(t, got.ACL.SACL, 1, "stored SACL must survive Put/Get")
+	require.Equal(t, uint32(acl.ACE4_SYSTEM_AUDIT_ACE_TYPE), got.ACL.SACL[0].Type)
+	require.Equal(t, uint32(acl.ACE4_FAILED_ACCESS_ACE_FLAG), got.ACL.SACL[0].Flag)
+}
+
+// TestMemoryStore_SACL_DeepCopy verifies cloneACL deep-copies the SACL slice so
+// a caller-side mutation after PutFile does not leak into stored state.
+func TestMemoryStore_SACL_DeepCopy(t *testing.T) {
+	store := NewMemoryMetadataStoreWithDefaults()
+	ctx := context.Background()
+
+	in := &acl.ACL{
+		SACL: []acl.ACE{{Type: acl.ACE4_SYSTEM_AUDIT_ACE_TYPE, AccessMask: acl.ACE4_WRITE_DATA, Who: acl.SpecialEveryone}},
+	}
+	handle, file := putFileWithACL(t, store, "share-sacl-copy", "f", in)
+
+	// Mutate the caller-side SACL after PutFile returned.
+	file.ACL.SACL[0].AccessMask = acl.ACE4_READ_DATA
+
+	got, err := store.GetFile(ctx, handle)
+	require.NoError(t, err)
+	require.NotNil(t, got.ACL)
+	require.Len(t, got.ACL.SACL, 1)
+	require.Equal(t, uint32(acl.ACE4_WRITE_DATA), got.ACL.SACL[0].AccessMask,
+		"PutFile must deep-copy SACL: caller-side mutation leaked into stored state")
+}


### PR DESCRIPTION
## What

Preserve the SACL (System ACL — audit/alarm ACEs) across the SMB
`SET_INFO` / `QUERY_INFO` Security round-trip. **Fix C of #1228.**

## Why

The security-descriptor path parsed the SACL offset and then discarded it
on `SET_INFO` (TODO at `security.go` "SACL parsing not implemented") and
returned only an empty SACL stub on `QUERY_INFO`. Any audit/alarm ACEs a
Windows client set were silently lost on the next read.

## Fix

- `pkg/metadata/acl/types.go` — add `ACL.SACL []ACE` (`json:"sacl,omitempty"`).
  Nil/absent = "no SACL", so existing stored ACLs are byte-for-byte unchanged
  and the read side still emits the empty stub.
- `pkg/metadata/store/memory/files.go` — `cloneACL` now deep-copies the SACL
  slice (the only backend with an explicit field-by-field copy).
- `pkg/metadata/acl/mode.go` — `AdjustACLForMode` (chmod) carries the SACL
  through its struct rebuild instead of dropping it.
- `pkg/metadata/acl/validate.go` — `ValidateACL` validates SACL entries.
- `pkg/metadata/acl/flags.go` — map the SUCCESSFUL/FAILED audit ACE flags
  (NFSv4 `0x10`/`0x20` <-> Windows `0x40`/`0x80`). DACL ACEs never carry these,
  so DACL output is unchanged.
- `internal/adapter/smb/handlers/security.go` — parse the SACL body into
  `ACL.SACL` on `SET_INFO`; serialize the stored SACL (vs. empty stub) on
  `QUERY_INFO` with `SE_SACL_PRESENT`; add audit/alarm ACE-type mapping.
  DACL serialization is byte-for-byte unchanged.
- `internal/adapter/smb/handlers/set_info.go` — install the SACL when
  `SACL_SECURITY_INFORMATION` is requested (gated on `ACCESS_SYSTEM_SECURITY`,
  which already existed), merging with the current ACL so a SACL-only — or
  DACL-only — SET does not clobber the unrequested section.

DACL behavior is preserved exactly. When no SACL is stored, behavior matches
today (empty stub on read, nothing stored on write).

## Tests

- `acl`: SACL JSON round-trip + omitempty, `AdjustACLForMode` SACL
  preservation, `ValidateACL` SACL rejection, audit-flag round-trip.
- `smb/handlers`: SACL SD round-trip (audit ACE incl. success/failed flags),
  empty-stub when no SACL, SACL-only SD (no fabricated DACL), `SET_INFO` merge
  preserves the unrequested section.
- `store/memory`: SACL Put/Get round-trip + deep-copy isolation.

`go build ./... && go vet ./... && go test ./pkg/metadata/... ./internal/adapter/smb/handlers/ -count=1` all pass.

## Migration

**No DB migration needed.** Postgres (JSONB), Badger, and SQLite all marshal
the whole `acl.ACL` struct as JSON, so the new field persists transparently.
7 production files changed, 3 new test files; no schema changes.
