### PR TITLE
fix(block): make audit-refcounts CAS-honest (#1374)

### DIFF
--- a/cmd/dfsctl/commands/store/block/audit.go
+++ b/cmd/dfsctl/commands/store/block/audit.go
@@ -11,22 +11,31 @@ import (
 	"github.com/marmos91/dittofs/pkg/apiclient"
 )
 
-// auditRefcountsCmd verifies the refcount invariant (∑ FileBlock.RefCount
-// == ∑ len(FileAttr.Blocks)) for the named share. Persists last-run
-// summary at <localStore>/audit-state/last-inv02.json.
+// auditRefcountsCmd verifies the CAS manifest-consistency invariant for
+// the named share: every block referenced by a file's manifest
+// (FileAttr.Blocks) must have a backing FileBlock row in the metadata
+// store. Persists last-run summary at <localStore>/audit-state/last-inv02.json.
 var auditRefcountsCmd = &cobra.Command{
 	Use:   "audit-refcounts <share>",
-	Short: "Verify FileBlock.RefCount matches FileAttr.Blocks references",
-	Long: `Run the INV-02 reconciliation audit for the named share.
+	Short: "Verify every manifest block reference has a backing FileBlock row",
+	Long: `Run the CAS manifest-consistency audit for the named share.
 
-Computes ∑ FileBlock.RefCount and compares against ∑ len(FileAttr.Blocks)
-across all files in the share. A non-zero delta indicates a refcount drift
-that may block GC reclamation (a leaked block survives the grace window)
-or signal a bug in the dedup short-circuit.
+Walks every file in the share and checks that each block referenced by the
+file's manifest (FileAttr.Blocks) has a backing FileBlock row in the
+metadata store. A manifest reference with no backing row is a genuine
+DANGLING reference — the file claims a chunk the store has no record of, so
+a read would return zeros or fail (the silent-data-loss class). The
+invariant is "dangling refs == 0"; a non-zero count is real corruption
+worth alerting on, so the command exits non-zero (use it as
+` + "`audit-refcounts <share> || alert`" + `).
+
+The legacy per-hash RefCount metric (∑ FileBlock.RefCount) was removed:
+RefCount is not maintained in the content-addressed-store model (CAS blocks
+are written Pending and never transition to Remote), so that sum was
+structurally always 0 and produced false-positive "delta" alarms.
 
 Persists last-run summary at <localStore>/audit-state/last-inv02.json
-analogously to GC's last-run.json. Operator-invokable; no periodic
-schedule in v0.15.0.
+analogously to GC's last-run.json. Operator-invokable; no periodic schedule.
 
 Examples:
   dfsctl store block audit-refcounts myshare
@@ -44,10 +53,10 @@ func runAuditRefcounts(_ *cobra.Command, args []string) error {
 
 	res, err := client.BlockStoreAuditRefcounts(share)
 	if err != nil {
-		return fmt.Errorf("failed to run INV-02 audit: %w", err)
+		return fmt.Errorf("failed to run manifest-consistency audit: %w", err)
 	}
 	if res == nil || res.Result == nil {
-		return fmt.Errorf("INV-02 audit: server returned empty response")
+		return fmt.Errorf("manifest-consistency audit: server returned empty response")
 	}
 
 	format, err := cmdutil.GetOutputFormatParsed()
@@ -55,10 +64,11 @@ func runAuditRefcounts(_ *cobra.Command, args []string) error {
 		return err
 	}
 	// Emit the audit body first so observability is identical across
-	// formats, then surface a detected refcount drift as a non-zero exit
+	// formats, then surface a detected dangling reference as a non-zero exit
 	// independently of the output format. A non-zero Delta is a real
-	// INV-02 violation (leaked block / dedup bug) — `audit-refcounts || alert`
-	// must fire in -o json/-o yaml too, not only the table branch.
+	// violation (a manifest ref with no backing FileBlock row — silent data
+	// loss) — `audit-refcounts || alert` must fire in -o json/-o yaml too,
+	// not only the table branch.
 	switch format {
 	case output.FormatJSON:
 		if err := output.PrintJSON(os.Stdout, res); err != nil {
@@ -75,14 +85,14 @@ func runAuditRefcounts(_ *cobra.Command, args []string) error {
 	}
 
 	if res.Result.Delta != 0 {
-		return fmt.Errorf("INV-02 violation: refcount delta=%d", res.Result.Delta)
+		return fmt.Errorf("manifest-consistency violation: dangling refs delta=%d", res.Result.Delta)
 	}
 	return nil
 }
 
 // printAuditTable renders the audit summary as a key/value table mirroring
-// printGCStatsTable's shape. Highlights the Delta field — operators read
-// that first to spot drift.
+// printGCStatsTable's shape. Highlights the Dangling refs field — operators
+// read that first to spot silent-data-loss corruption.
 func printAuditTable(res *apiclient.BlockStoreAuditResult) error {
 	r := res.Result
 	pairs := [][2]string{
@@ -91,16 +101,16 @@ func printAuditTable(res *apiclient.BlockStoreAuditResult) error {
 		{"Completed At", r.CompletedAt.Format("2006-01-02T15:04:05Z07:00")},
 		{"Duration", fmt.Sprintf("%dms", r.DurationMS)},
 		{"Total Files", fmt.Sprintf("%d", r.TotalFiles)},
-		{"Total Refs (Σ len(Blocks))", fmt.Sprintf("%d", r.TotalRefs)},
-		{"Total RefCount (Σ RefCount)", fmt.Sprintf("%d", r.TotalRefCount)},
-		{"Delta (refs - refcount)", fmt.Sprintf("%d", r.Delta)},
+		{"Manifest Refs (Σ len(Blocks))", fmt.Sprintf("%d", r.TotalRefs)},
+		{"Backed by FileBlock row", fmt.Sprintf("%d", r.BackedRefs)},
+		{"Dangling refs (missing row)", fmt.Sprintf("%d", r.DanglingRefs)},
 	}
 	if err := output.SimpleTable(os.Stdout, pairs); err != nil {
 		return err
 	}
 	if r.Delta != 0 {
 		fmt.Println()
-		fmt.Printf("INV-02 violation: delta=%d — refcount drift detected\n", r.Delta)
+		fmt.Printf("manifest-consistency violation: %d dangling reference(s) — manifest blocks with no backing FileBlock row\n", r.DanglingRefs)
 	}
 	return nil
 }

--- a/cmd/dfsctl/commands/store/block/audit_test.go
+++ b/cmd/dfsctl/commands/store/block/audit_test.go
@@ -90,14 +90,15 @@ func TestAuditCmd_CallsClient_AndPrintsSummary(t *testing.T) {
 	defer s.Close()
 	now := time.Now().UTC().Truncate(time.Second)
 	s.result = &engine.AuditRefcountsResult{
-		Share:         "myshare",
-		StartedAt:     now,
-		CompletedAt:   now.Add(time.Second),
-		DurationMS:    1000,
-		TotalFiles:    3,
-		TotalRefs:     10,
-		TotalRefCount: 10,
-		Delta:         0,
+		Share:        "myshare",
+		StartedAt:    now,
+		CompletedAt:  now.Add(time.Second),
+		DurationMS:   1000,
+		TotalFiles:   3,
+		TotalRefs:    10,
+		BackedRefs:   10,
+		DanglingRefs: 0,
+		Delta:        0,
 	}
 	withAuditTestServer(t, s.URL)
 
@@ -113,13 +114,13 @@ func TestAuditCmd_CallsClient_AndPrintsSummary(t *testing.T) {
 	if s.lastPath != "/api/v1/shares/myshare/audit/refcounts" {
 		t.Errorf("path = %q, want /api/v1/shares/myshare/audit/refcounts", s.lastPath)
 	}
-	for _, frag := range []string{"Share", "myshare", "Total Files", "3", "Total Refs", "10", "Delta", "0"} {
+	for _, frag := range []string{"Share", "myshare", "Total Files", "3", "Manifest Refs", "10", "Backed by FileBlock row", "Dangling refs", "0"} {
 		if !strings.Contains(out, frag) {
 			t.Errorf("stdout missing %q, got %q", frag, out)
 		}
 	}
-	if strings.Contains(out, "INV-02 violation") {
-		t.Errorf("delta=0 must not surface INV-02 violation banner; got %q", out)
+	if strings.Contains(out, "manifest-consistency violation") {
+		t.Errorf("dangling=0 must not surface violation banner; got %q", out)
 	}
 }
 
@@ -131,13 +132,14 @@ func TestAuditCmd_DriftSurfacesViolation(t *testing.T) {
 	defer s.Close()
 	now := time.Now().UTC().Truncate(time.Second)
 	s.result = &engine.AuditRefcountsResult{
-		Share:         "myshare",
-		StartedAt:     now,
-		CompletedAt:   now.Add(time.Second),
-		TotalFiles:    3,
-		TotalRefs:     10,
-		TotalRefCount: 15,
-		Delta:         -5,
+		Share:        "myshare",
+		StartedAt:    now,
+		CompletedAt:  now.Add(time.Second),
+		TotalFiles:   3,
+		TotalRefs:    10,
+		BackedRefs:   5,
+		DanglingRefs: 5,
+		Delta:        5,
 	}
 	withAuditTestServer(t, s.URL)
 
@@ -149,14 +151,14 @@ func TestAuditCmd_DriftSurfacesViolation(t *testing.T) {
 	if runErr == nil {
 		t.Fatal("non-zero delta must return a non-nil error (non-zero exit)")
 	}
-	if !strings.Contains(runErr.Error(), "delta=-5") {
+	if !strings.Contains(runErr.Error(), "delta=5") {
 		t.Errorf("error must include the delta value; got %v", runErr)
 	}
-	if !strings.Contains(out, "INV-02 violation") {
-		t.Errorf("non-zero delta must surface INV-02 violation banner; got %q", out)
+	if !strings.Contains(out, "manifest-consistency violation") {
+		t.Errorf("non-zero delta must surface violation banner; got %q", out)
 	}
-	if !strings.Contains(out, "delta=-5") {
-		t.Errorf("violation banner must include delta value; got %q", out)
+	if !strings.Contains(out, "5 dangling reference") {
+		t.Errorf("violation banner must include the dangling count; got %q", out)
 	}
 }
 
@@ -170,10 +172,11 @@ func TestAuditCmd_DriftExitsNonZeroAcrossFormats(t *testing.T) {
 			s := newAuditServer(t)
 			defer s.Close()
 			s.result = &engine.AuditRefcountsResult{
-				Share:         "myshare",
-				TotalRefs:     10,
-				TotalRefCount: 7,
-				Delta:         3,
+				Share:        "myshare",
+				TotalRefs:    10,
+				BackedRefs:   7,
+				DanglingRefs: 3,
+				Delta:        3,
 			}
 			withAuditTestServer(t, s.URL)
 			cmdutil.Flags.Output = format

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -646,7 +646,7 @@ dfsctl
   status         Show server status
   store          Store management
     block          Block store management
-      audit-refcounts Verify FileBlock.RefCount matches FileAttr.Blocks references
+      audit-refcounts Verify every manifest block reference has a backing FileBlock row
       evict          Evict block store data
       gc             Run garbage collection for a block store share
       gc-status      Show the last block-store GC run summary for a share
@@ -4781,18 +4781,26 @@ Global flags:
 
 ### `dfsctl store block audit-refcounts`
 
-Verify FileBlock.RefCount matches FileAttr.Blocks references
+Verify every manifest block reference has a backing FileBlock row
 
-Run the INV-02 reconciliation audit for the named share.
+Run the CAS manifest-consistency audit for the named share.
 
-Computes ∑ FileBlock.RefCount and compares against ∑ len(FileAttr.Blocks)
-across all files in the share. A non-zero delta indicates a refcount drift
-that may block GC reclamation (a leaked block survives the grace window)
-or signal a bug in the dedup short-circuit.
+Walks every file in the share and checks that each block referenced by the
+file's manifest (FileAttr.Blocks) has a backing FileBlock row in the
+metadata store. A manifest reference with no backing row is a genuine
+DANGLING reference — the file claims a chunk the store has no record of, so
+a read would return zeros or fail (the silent-data-loss class). The
+invariant is "dangling refs == 0"; a non-zero count is real corruption
+worth alerting on, so the command exits non-zero (use it as
+`audit-refcounts <share> || alert`).
+
+The legacy per-hash RefCount metric (∑ FileBlock.RefCount) was removed:
+RefCount is not maintained in the content-addressed-store model (CAS blocks
+are written Pending and never transition to Remote), so that sum was
+structurally always 0 and produced false-positive "delta" alarms.
 
 Persists last-run summary at <localStore>/audit-state/last-inv02.json
-analogously to GC's last-run.json. Operator-invokable; no periodic
-schedule in v0.15.0.
+analogously to GC's last-run.json. Operator-invokable; no periodic schedule.
 
 Examples:
   dfsctl store block audit-refcounts myshare

--- a/internal/controlplane/api/handlers/blockstore_audit.go
+++ b/internal/controlplane/api/handlers/blockstore_audit.go
@@ -46,10 +46,11 @@ type BlockStoreAuditResponse struct {
 // RunAudit handles POST /api/v1/shares/{name}/audit/refcounts.
 //
 // Behavior: invokes Runtime.AuditRefcounts with the URL share name.
-// The audit walks the share's metadata store, computing
-// ∑ FileBlock.RefCount and ∑ len(FileAttr.Blocks); a non-zero delta
-// indicates refcount drift. Last-run summary is persisted under
-// <localStoreRoot>/audit-state/last-inv02.json.
+// The audit walks the share's metadata store and verifies that every
+// manifest reference (FileAttr.Blocks) has a backing FileBlock row; a
+// non-zero delta (DanglingRefs) indicates a file references a chunk the
+// store has no record of (silent-data-loss class). Last-run summary is
+// persisted under <localStoreRoot>/audit-state/last-inv02.json.
 //
 // Status codes:
 //   - 200 OK with BlockStoreAuditResponse on success
@@ -84,12 +85,13 @@ func (h *BlockStoreAuditHandler) RunAudit(w http.ResponseWriter, r *http.Request
 	}
 
 	// Structured slog INFO for the audit result so operators can grep
-	// refcount violations without scraping HTTP logs.
+	// dangling-reference violations without scraping HTTP logs.
 	logger.Info("Block store INV-02 audit complete",
 		"share", name,
 		"total_files", res.TotalFiles,
 		"total_refs", res.TotalRefs,
-		"total_refcount", res.TotalRefCount,
+		"backed_refs", res.BackedRefs,
+		"dangling_refs", res.DanglingRefs,
 		"delta", res.Delta,
 		"duration_ms", res.DurationMS,
 	)

--- a/internal/controlplane/api/handlers/blockstore_audit_test.go
+++ b/internal/controlplane/api/handlers/blockstore_audit_test.go
@@ -42,12 +42,13 @@ func newAuditRequest(method, path, share string) *http.Request {
 func TestBlockStoreAuditHandler_RunAudit_Success(t *testing.T) {
 	fake := &fakeAuditRuntime{
 		res: &engine.AuditRefcountsResult{
-			Share:         "myshare",
-			TotalFiles:    3,
-			TotalRefs:     10,
-			TotalRefCount: 10,
-			Delta:         0,
-			DurationMS:    42,
+			Share:        "myshare",
+			TotalFiles:   3,
+			TotalRefs:    10,
+			BackedRefs:   10,
+			DanglingRefs: 0,
+			Delta:        0,
+			DurationMS:   42,
 		},
 	}
 	h := NewBlockStoreAuditHandler(fake)
@@ -72,7 +73,7 @@ func TestBlockStoreAuditHandler_RunAudit_Success(t *testing.T) {
 	if resp.Result == nil {
 		t.Fatal("RunAudit: nil Result in response")
 	}
-	if resp.Result.TotalFiles != 3 || resp.Result.TotalRefs != 10 || resp.Result.TotalRefCount != 10 || resp.Result.Delta != 0 {
+	if resp.Result.TotalFiles != 3 || resp.Result.TotalRefs != 10 || resp.Result.BackedRefs != 10 || resp.Result.DanglingRefs != 0 || resp.Result.Delta != 0 {
 		t.Fatalf("RunAudit: unexpected result: %+v", resp.Result)
 	}
 }
@@ -82,11 +83,12 @@ func TestBlockStoreAuditHandler_RunAudit_Success(t *testing.T) {
 func TestBlockStoreAuditHandler_RunAudit_Drift(t *testing.T) {
 	fake := &fakeAuditRuntime{
 		res: &engine.AuditRefcountsResult{
-			Share:         "myshare",
-			TotalFiles:    3,
-			TotalRefs:     10,
-			TotalRefCount: 15,
-			Delta:         -5,
+			Share:        "myshare",
+			TotalFiles:   3,
+			TotalRefs:    10,
+			BackedRefs:   5,
+			DanglingRefs: 5,
+			Delta:        5,
 		},
 	}
 	h := NewBlockStoreAuditHandler(fake)
@@ -102,8 +104,8 @@ func TestBlockStoreAuditHandler_RunAudit_Drift(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if resp.Result.Delta != -5 {
-		t.Fatalf("Delta = %d, want -5", resp.Result.Delta)
+	if resp.Result.Delta != 5 || resp.Result.DanglingRefs != 5 {
+		t.Fatalf("Delta/DanglingRefs = %d/%d, want 5/5", resp.Result.Delta, resp.Result.DanglingRefs)
 	}
 }
 

--- a/pkg/apiclient/blockstore.go
+++ b/pkg/apiclient/blockstore.go
@@ -158,19 +158,20 @@ func (c *Client) BlockStoreGCStatus(shareName string) (*engine.GCRunSummary, err
 
 // BlockStoreAuditResult is the response body for
 // POST /api/v1/shares/{name}/audit/refcounts. Wraps the
-// engine.AuditRefcountsResult value (refcount audit).
+// engine.AuditRefcountsResult value (CAS manifest-consistency audit).
 // Mirrors the server-side handlers.BlockStoreAuditResponse shape.
 type BlockStoreAuditResult struct {
 	Result *engine.AuditRefcountsResult `json:"result"`
 }
 
-// BlockStoreAuditRefcounts triggers the on-demand refcount reconciliation
-// audit for the named share. Server walks the share's metadata store
-// and computes ∑ FileBlock.RefCount vs ∑ len(FileAttr.Blocks); a
-// non-zero delta indicates drift. The audit persists last-inv02.json
-// under the share's audit-state directory; this client method returns
-// the same summary in the response body for direct consumption by
-// `dfsctl blockstore audit-refcounts`.
+// BlockStoreAuditRefcounts triggers the on-demand CAS manifest-consistency
+// audit for the named share. Server walks the share's metadata store and
+// verifies every manifest reference (FileAttr.Blocks) has a backing
+// FileBlock row; a non-zero delta (DanglingRefs) indicates a file
+// references a chunk the store has no record of. The audit persists
+// last-inv02.json under the share's audit-state directory; this client
+// method returns the same summary in the response body for direct
+// consumption by `dfsctl blockstore audit-refcounts`.
 //
 // Mirrors BlockStoreGC's URL/error pattern (per-share path, JSON body,
 // JWT auth via the underlying transport).

--- a/pkg/block/engine/audit_state.go
+++ b/pkg/block/engine/audit_state.go
@@ -1,15 +1,23 @@
 // Package engine — audit
 //
-// AuditRefcounts walks a share's metadata store and reconciles the global
-// invariant
+// AuditRefcounts walks a share's metadata store and verifies the CAS
+// manifest-consistency invariant:
 //
-//	∑ FileBlock.RefCount == ∑ len(FileAttr.Blocks)
+//	every block referenced by a file's manifest (FileAttr.Blocks) must
+//	have a backing FileBlock row in the metadata store.
 //
-// A non-zero delta indicates a refcount drift that may block GC reclamation
-// (a leaked block's CAS object survives the grace window) or signal a bug
-// in the dedup short-circuit (donor leak). The audit is operator-invoked
-// via `dfsctl blockstore audit-refcounts <share>`; there is no periodic
-// schedule.
+// A manifest reference with no backing FileBlock row is a genuine
+// DANGLING reference — the silent-data-loss class (cf. #583/#789): the
+// file claims a chunk that the store has no record of, so a read would
+// return zeros or fail. DanglingRefs > 0 is the real signal worth
+// alerting on; the invariant is DanglingRefs == 0.
+//
+// This replaces the legacy "∑ FileBlock.RefCount == ∑ len(FileAttr.Blocks)"
+// reconciliation. RefCount is not maintained in the CAS model (CAS blocks
+// are written State=Pending and never transition to Remote, GetByHash is
+// remote-gated, and reclamation is mark-sweep GC over the live set), so
+// the old metric was structurally always 0 and produced false-positive
+// "corruption" alarms. The audit no longer touches RefCount or GetByHash.
 //
 // Persistence: the last-run summary is written atomically (.tmp + rename)
 // to <localStoreRoot>/audit-state/last-inv02.json, mirroring GC's
@@ -25,14 +33,16 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
-	"github.com/marmos91/dittofs/pkg/block"
 	// justification: AuditRefcounts is the cross-file metadata-walk
 	// entrypoint for reconciliation. It MUST bind
 	// metadata.Store to enumerate FileAttr.Blocks across the share's
-	// directory tree (GetRootHandle, GetFile, ListChildren). Lifting these
-	// helpers into pkg/block would create a circular import.
+	// directory tree (GetRootHandle, GetFile, ListChildren) and to read
+	// the backing FileBlock rows (ListFileBlocks). Lifting these helpers
+	// into pkg/block would create a circular import.
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -61,24 +71,31 @@ type AuditRefcountsResult struct {
 	// TotalFiles is the number of regular files scanned.
 	TotalFiles uint64 `json:"total_files"`
 
-	// TotalRefs is ∑ len(FileAttr.Blocks) across every regular file in the share.
+	// TotalRefs is ∑ len(FileAttr.Blocks) across every regular file in the
+	// share — the manifest reference count.
 	TotalRefs uint64 `json:"total_refs"`
 
-	// TotalRefCount is ∑ FileBlock.RefCount summed across distinct hashes
-	// (the post- single-row-per-hash world; legacy multi-row data is
-	// dedup'd via GetByHash so cross-row hash duplicates don't double-count).
-	TotalRefCount uint64 `json:"total_refcount"`
+	// BackedRefs is the number of manifest references that have a matching
+	// FileBlock row in the metadata store (a row at the ref's offset with a
+	// non-zero hash).
+	BackedRefs uint64 `json:"backed_refs"`
 
-	// Delta is TotalRefs - TotalRefCount. Zero means holds; non-zero
-	// indicates drift (positive: file refs exceed RefCount; negative: leaked
-	// RefCount with no owning file).
+	// DanglingRefs is the number of manifest references with NO backing
+	// FileBlock row (== TotalRefs - BackedRefs). Each dangling ref is a
+	// silent-data-loss hazard: the file claims a chunk the store has no
+	// record of.
+	DanglingRefs uint64 `json:"dangling_refs"`
+
+	// Delta is the violation count, defined as DanglingRefs. Zero means the
+	// invariant holds (every manifest ref is backed); non-zero means at
+	// least one file references a chunk with no FileBlock row.
 	Delta int64 `json:"delta"`
 }
 
-// AuditRefcounts walks the metadata store and computes the
-// invariant for the named share. Persists last-run summary at
-// <localStoreRoot>/audit-state/last-inv02.json. Pass an empty
-// localStoreRoot to skip persistence (in-memory backend).
+// AuditRefcounts walks the metadata store and verifies the manifest↔
+// FileBlock-row consistency invariant for the named share. Persists
+// last-run summary at <localStoreRoot>/audit-state/last-inv02.json. Pass an
+// empty localStoreRoot to skip persistence (in-memory backend).
 //
 // per-share audit, slog-only observability
 // no Prometheus surface in this phase.
@@ -96,37 +113,24 @@ func AuditRefcounts(ctx context.Context, share string, store metadata.Store, loc
 		StartedAt: start,
 	}
 
-	// 1) ∑ FileBlock.RefCount across distinct ContentHashes via the
-	// cursor-bounded EnumerateFileBlocks (memory bound). Dedup
-	// by hash mirrors the post- single-row-per-hash world; legacy
-	//    multi-row data is collapsed because every row sharing a hash
-	//    carries the same RefCount semantics (GetByHash returns ANY one).
-	seen := make(map[block.ContentHash]struct{})
-	if err := store.EnumerateFileBlocks(ctx, func(h block.ContentHash) error {
-		if _, ok := seen[h]; ok {
-			return nil
-		}
-		seen[h] = struct{}{}
-		fb, err := store.GetByHash(ctx, h)
-		if err != nil {
-			return fmt.Errorf("get by hash %x: %w", h[:8], err)
-		}
-		if fb != nil {
-			result.TotalRefCount += uint64(fb.RefCount)
-		}
-		return nil
-	}); err != nil {
-		return nil, fmt.Errorf("audit-refcounts: enumerate file blocks: %w", err)
-	}
-
-	// 2) ∑ len(FileAttr.Blocks) across every regular file in the share.
+	// Walk every regular file in the share. For each file, read its
+	// manifest (FileAttr.Blocks) and the backing FileBlock rows
+	// (ListFileBlocks by payloadID). A manifest ref is BACKED iff a row
+	// exists at the ref's offset with a matching non-zero hash; otherwise
+	// it is DANGLING.
 	rootHandle, err := store.GetRootHandle(ctx, share)
 	if err != nil {
 		return nil, fmt.Errorf("audit-refcounts: get root handle for %q: %w", share, err)
 	}
 	if err := walkAuditShareFiles(ctx, store, rootHandle, func(f *metadata.File) error {
 		result.TotalFiles++
+		backed, dangling, err := auditFileManifest(ctx, store, f)
+		if err != nil {
+			return err
+		}
 		result.TotalRefs += uint64(len(f.Blocks))
+		result.BackedRefs += backed
+		result.DanglingRefs += dangling
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("audit-refcounts: walk share %q: %w", share, err)
@@ -134,12 +138,63 @@ func AuditRefcounts(ctx context.Context, share string, store metadata.Store, loc
 
 	result.CompletedAt = time.Now().UTC()
 	result.DurationMS = result.CompletedAt.Sub(result.StartedAt).Milliseconds()
-	result.Delta = int64(result.TotalRefs) - int64(result.TotalRefCount)
+	result.Delta = int64(result.DanglingRefs)
 
 	if err := persistAuditLastRun(localStoreRoot, result); err != nil {
 		return nil, fmt.Errorf("audit-refcounts: persist last-run: %w", err)
 	}
 	return result, nil
+}
+
+// auditFileManifest reconciles one file's manifest (FileAttr.Blocks)
+// against its backing FileBlock rows. Returns the count of backed vs
+// dangling manifest refs for the file.
+//
+// FileBlock IDs are "{payloadID}/{offset}" (the engine writes
+// fmt.Sprintf("%s/%d", payloadID, blockRef.Offset)); the manifest BlockRef
+// carries the same Offset. A ref is backed iff a row exists at its offset
+// with a non-zero hash. Matching by offset (not by hash equality) is the
+// right key: the manifest is the authority for which chunk lives at each
+// offset, and a present row with a non-zero hash means the store has a
+// record of that chunk.
+func auditFileManifest(ctx context.Context, store metadata.Store, f *metadata.File) (backed, dangling uint64, err error) {
+	if len(f.Blocks) == 0 {
+		return 0, 0, nil
+	}
+
+	payloadID := string(f.PayloadID)
+	rows, err := store.ListFileBlocks(ctx, payloadID)
+	if err != nil {
+		return 0, 0, fmt.Errorf("list file blocks for payload %q: %w", payloadID, err)
+	}
+
+	// Set of present rows keyed by parsed offset (the suffix of the
+	// FileBlock ID after "{payloadID}/"). A row with a zero hash does not
+	// back a manifest ref — treat it as absent.
+	present := make(map[uint64]struct{}, len(rows))
+	prefix := payloadID + "/"
+	for _, row := range rows {
+		if row == nil || row.Hash.IsZero() {
+			continue
+		}
+		suffix := strings.TrimPrefix(row.ID, prefix)
+		off, convErr := strconv.ParseUint(suffix, 10, 64)
+		if convErr != nil {
+			// Non-numeric suffix: not an offset-keyed CAS row. Skip it
+			// rather than crediting it to an offset.
+			continue
+		}
+		present[off] = struct{}{}
+	}
+
+	for _, ref := range f.Blocks {
+		if _, ok := present[ref.Offset]; ok {
+			backed++
+		} else {
+			dangling++
+		}
+	}
+	return backed, dangling, nil
 }
 
 // walkAuditShareFiles recursively walks the share rooted at dirHandle

--- a/pkg/block/engine/audit_state.go
+++ b/pkg/block/engine/audit_state.go
@@ -152,11 +152,13 @@ func AuditRefcounts(ctx context.Context, share string, store metadata.Store, loc
 //
 // FileBlock IDs are "{payloadID}/{offset}" (the engine writes
 // fmt.Sprintf("%s/%d", payloadID, blockRef.Offset)); the manifest BlockRef
-// carries the same Offset. A ref is backed iff a row exists at its offset
-// with a non-zero hash. Matching by offset (not by hash equality) is the
-// right key: the manifest is the authority for which chunk lives at each
-// offset, and a present row with a non-zero hash means the store has a
-// record of that chunk.
+// carries the same Offset and the expected content Hash. A ref is backed
+// iff a row exists at its offset AND that row's hash equals the manifest
+// ref's hash (and is non-zero). Matching by offset alone is not enough:
+// a row present at the right offset but carrying a DIFFERENT hash is
+// genuine corruption (the store holds a record of a different chunk than
+// the file claims), and crediting it as backed would silently hide that
+// mismatch. Such refs are counted as dangling.
 func auditFileManifest(ctx context.Context, store metadata.Store, f *metadata.File) (backed, dangling uint64, err error) {
 	if len(f.Blocks) == 0 {
 		return 0, 0, nil
@@ -168,10 +170,10 @@ func auditFileManifest(ctx context.Context, store metadata.Store, f *metadata.Fi
 		return 0, 0, fmt.Errorf("list file blocks for payload %q: %w", payloadID, err)
 	}
 
-	// Set of present rows keyed by parsed offset (the suffix of the
-	// FileBlock ID after "{payloadID}/"). A row with a zero hash does not
-	// back a manifest ref — treat it as absent.
-	present := make(map[uint64]struct{}, len(rows))
+	// Map of present rows keyed by parsed offset (the suffix of the
+	// FileBlock ID after "{payloadID}/") to the row's content hash. A row
+	// with a zero hash does not back a manifest ref — treat it as absent.
+	byOffset := make(map[uint64]metadata.ContentHash, len(rows))
 	prefix := payloadID + "/"
 	for _, row := range rows {
 		if row == nil || row.Hash.IsZero() {
@@ -184,11 +186,14 @@ func auditFileManifest(ctx context.Context, store metadata.Store, f *metadata.Fi
 			// rather than crediting it to an offset.
 			continue
 		}
-		present[off] = struct{}{}
+		byOffset[off] = row.Hash
 	}
 
 	for _, ref := range f.Blocks {
-		if _, ok := present[ref.Offset]; ok {
+		// Backed iff a row exists at the ref's offset whose hash matches the
+		// ref's hash (and is non-zero). A present-but-mismatched hash is
+		// corruption and counts as dangling — never silently backed.
+		if presentHash, ok := byOffset[ref.Offset]; ok && presentHash == ref.Hash && !presentHash.IsZero() {
 			backed++
 		} else {
 			dangling++

--- a/pkg/block/engine/audit_state_test.go
+++ b/pkg/block/engine/audit_state_test.go
@@ -14,16 +14,20 @@ import (
 )
 
 // seedAuditTestStore creates a memory metadata store with one share named
-// "audit-test" and three regular files. The first file has 5 BlockRefs
-// the second has 3, the third has 2. Each FileBlock is seeded with a
-// matching RefCount=1 so the pre-leak invariant ∑RefCount == ∑len(Blocks)
-// holds (3+5+2 = 10 refs, 10 blocks × RefCount=1). Used by all three
-// audit tests below.
-func seedAuditTestStore(t *testing.T) (*metadatamemory.MemoryMetadataStore, string, [][]string) {
+// "audit-test" and three regular files. The first file has 5 BlockRefs,
+// the second has 3, the third has 2 (10 manifest refs total). Each
+// manifest ref is backed by a FileBlock row whose ID is
+// "{payloadID}/{offset}" with a matching non-zero hash, so the
+// manifest↔FileBlock-row invariant holds (DanglingRefs == 0) pre-mutation.
+//
+// Returns the store, the share name, and per-file (payloadID, []offset)
+// so a test can delete a specific backing row to manufacture a dangling
+// manifest reference.
+func seedAuditTestStore(t *testing.T) (store *metadatamemory.MemoryMetadataStore, shareName string, payloadIDs []string, offsets [][]uint64) {
 	t.Helper()
-	store := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	store = metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	ctx := context.Background()
-	const shareName = "audit-test"
+	shareName = "audit-test"
 
 	// Create share + root.
 	if err := store.CreateShare(ctx, &metadata.Share{Name: shareName}); err != nil {
@@ -44,7 +48,8 @@ func seedAuditTestStore(t *testing.T) (*metadatamemory.MemoryMetadataStore, stri
 	// Three files with 5, 3, 2 BlockRefs respectively.
 	perFile := []int{5, 3, 2}
 	now := time.Now().UTC()
-	allBlockIDs := make([][]string, len(perFile))
+	payloadIDs = make([]string, len(perFile))
+	offsets = make([][]uint64, len(perFile))
 
 	for fi, n := range perFile {
 		name := fileNameFor(fi)
@@ -57,41 +62,46 @@ func seedAuditTestStore(t *testing.T) (*metadatamemory.MemoryMetadataStore, stri
 			t.Fatalf("DecodeFileHandle: %v", err)
 		}
 
-		blockIDs := make([]string, n)
+		// payloadID is the FileBlock-ID prefix; the engine keys blocks as
+		// "{payloadID}/{offset}". Use a stable per-file payload id.
+		payloadID := "payload-" + jstr(fi)
+		payloadIDs[fi] = payloadID
+		fileOffsets := make([]uint64, n)
 		refs := make([]block.BlockRef, n)
 		for bi := 0; bi < n; bi++ {
 			h := hashForFileBlock(fi, bi)
-			blockID := fileNameFor(fi) + "/" + jstr(bi)
+			off := uint64(bi) * 4096
+			blockID := payloadID + "/" + jstr(int(off))
 			fb := &block.FileBlock{
 				ID:            blockID,
 				Hash:          h,
-				State:         block.BlockStateRemote,
+				State:         block.BlockStatePending,
 				LocalPath:     "/cache/" + blockID,
 				BlockStoreKey: "cas/" + h.String()[0:2] + "/" + h.String()[2:4] + "/" + h.String(),
 				DataSize:      4096,
-				RefCount:      1,
 				LastAccess:    now,
 				CreatedAt:     now,
 			}
 			if err := store.Put(ctx, fb); err != nil {
 				t.Fatalf("Put block %s: %v", blockID, err)
 			}
-			blockIDs[bi] = blockID
-			refs[bi] = block.BlockRef{Hash: h, Offset: uint64(bi) * 4096, Size: 4096}
+			fileOffsets[bi] = off
+			refs[bi] = block.BlockRef{Hash: h, Offset: off, Size: 4096}
 		}
 
 		file := &metadata.File{
 			ID:        fileID,
 			ShareName: shareName,
 			FileAttr: metadata.FileAttr{
-				Type:   metadata.FileTypeRegular,
-				Mode:   0o644,
-				UID:    1000,
-				GID:    1000,
-				Mtime:  now,
-				Ctime:  now,
-				Atime:  now,
-				Blocks: refs,
+				Type:      metadata.FileTypeRegular,
+				Mode:      0o644,
+				UID:       1000,
+				GID:       1000,
+				Mtime:     now,
+				Ctime:     now,
+				Atime:     now,
+				PayloadID: metadata.PayloadID(payloadID),
+				Blocks:    refs,
 			},
 		}
 		if err := store.PutFile(ctx, file); err != nil {
@@ -106,9 +116,9 @@ func seedAuditTestStore(t *testing.T) (*metadatamemory.MemoryMetadataStore, stri
 		if err := store.SetLinkCount(ctx, handle, 1); err != nil {
 			t.Fatalf("SetLinkCount: %v", err)
 		}
-		allBlockIDs[fi] = blockIDs
+		offsets[fi] = fileOffsets
 	}
-	return store, shareName, allBlockIDs
+	return store, shareName, payloadIDs, offsets
 }
 
 func fileNameFor(i int) string {
@@ -145,9 +155,10 @@ func hashForFileBlock(fileIdx, blockIdx int) block.ContentHash {
 
 // TestAuditRefcounts_Computes asserts AuditRefcounts returns the expected
 // aggregate counts when the invariant holds. 3 files with 5+3+2=10
-// BlockRefs each carrying RefCount=1 yields delta=0.
+// manifest refs, each backed by a FileBlock row, yields DanglingRefs=0
+// (Delta=0).
 func TestAuditRefcounts_Computes(t *testing.T) {
-	store, shareName, _ := seedAuditTestStore(t)
+	store, shareName, _, _ := seedAuditTestStore(t)
 	tmpDir := t.TempDir()
 
 	res, err := AuditRefcounts(context.Background(), shareName, store, tmpDir)
@@ -163,11 +174,14 @@ func TestAuditRefcounts_Computes(t *testing.T) {
 	if res.TotalRefs != 10 {
 		t.Errorf("TotalRefs = %d, want 10", res.TotalRefs)
 	}
-	if res.TotalRefCount != 10 {
-		t.Errorf("TotalRefCount = %d, want 10", res.TotalRefCount)
+	if res.BackedRefs != 10 {
+		t.Errorf("BackedRefs = %d, want 10 (every manifest ref backed)", res.BackedRefs)
+	}
+	if res.DanglingRefs != 0 {
+		t.Errorf("DanglingRefs = %d, want 0 (invariant must hold)", res.DanglingRefs)
 	}
 	if res.Delta != 0 {
-		t.Errorf("Delta = %d, want 0 (invariant must hold pre-leak)", res.Delta)
+		t.Errorf("Delta = %d, want 0 (invariant must hold)", res.Delta)
 	}
 	if res.StartedAt.IsZero() || res.CompletedAt.IsZero() {
 		t.Errorf("timestamps not populated: %+v", res)
@@ -177,18 +191,21 @@ func TestAuditRefcounts_Computes(t *testing.T) {
 	}
 }
 
-// TestAuditRefcounts_DetectsDelta asserts that a known refcount leak
-// surfaces in the audit's Delta field. Bumping one block's RefCount by
-// 5 (without touching FileAttr.Blocks anywhere) yields TotalRefCount=15
-// vs TotalRefs=10 → Delta = -5.
+// TestAuditRefcounts_DetectsDelta asserts that a genuine dangling
+// reference surfaces in the audit's DanglingRefs/Delta fields. Deleting
+// one FileBlock row (without touching FileAttr.Blocks) leaves the manifest
+// entry pointing at a chunk the store no longer records — the
+// silent-data-loss class. TotalRefs stays 10 (manifest unchanged), but
+// BackedRefs drops to 9 and DanglingRefs == Delta == 1.
 func TestAuditRefcounts_DetectsDelta(t *testing.T) {
-	store, shareName, allBlockIDs := seedAuditTestStore(t)
+	store, shareName, payloadIDs, offsets := seedAuditTestStore(t)
 	tmpDir := t.TempDir()
 
-	// Bump RefCount by 5 on the first block of file 0.
-	const leak uint32 = 5
-	if err := store.InjectRefCountLeak(context.Background(), allBlockIDs[0][0], leak); err != nil {
-		t.Fatalf("InjectRefCountLeak: %v", err)
+	// Delete the FileBlock row backing file 0's first manifest ref, leaving
+	// the manifest entry in place → that ref becomes dangling.
+	danglingID := payloadIDs[0] + "/" + jstr(int(offsets[0][0]))
+	if err := store.Delete(context.Background(), danglingID); err != nil {
+		t.Fatalf("Delete backing row %q: %v", danglingID, err)
 	}
 
 	res, err := AuditRefcounts(context.Background(), shareName, store, tmpDir)
@@ -196,14 +213,16 @@ func TestAuditRefcounts_DetectsDelta(t *testing.T) {
 		t.Fatalf("AuditRefcounts: %v", err)
 	}
 	if res.TotalRefs != 10 {
-		t.Errorf("TotalRefs = %d, want 10 (leak does not change FileAttr.Blocks)", res.TotalRefs)
+		t.Errorf("TotalRefs = %d, want 10 (deleting a row does not change FileAttr.Blocks)", res.TotalRefs)
 	}
-	if res.TotalRefCount != 10+uint64(leak) {
-		t.Errorf("TotalRefCount = %d, want %d (leak adds to RefCount)", res.TotalRefCount, 10+leak)
+	if res.BackedRefs != 9 {
+		t.Errorf("BackedRefs = %d, want 9 (one backing row deleted)", res.BackedRefs)
 	}
-	wantDelta := -int64(leak)
-	if res.Delta != wantDelta {
-		t.Errorf("Delta = %d, want %d (refs - refcount)", res.Delta, wantDelta)
+	if res.DanglingRefs != 1 {
+		t.Errorf("DanglingRefs = %d, want 1 (the manifest ref with no backing row)", res.DanglingRefs)
+	}
+	if res.Delta != 1 {
+		t.Errorf("Delta = %d, want 1 (Delta == DanglingRefs)", res.Delta)
 	}
 }
 
@@ -211,7 +230,7 @@ func TestAuditRefcounts_DetectsDelta(t *testing.T) {
 // <localStoreRoot>/audit-state/last-inv02.json containing the
 // timestamps and counts. Subsequent runs OVERWRITE atomically.
 func TestAuditRefcounts_PersistsLastRun(t *testing.T) {
-	store, shareName, _ := seedAuditTestStore(t)
+	store, shareName, _, _ := seedAuditTestStore(t)
 	tmpDir := t.TempDir()
 
 	res, err := AuditRefcounts(context.Background(), shareName, store, tmpDir)
@@ -234,7 +253,7 @@ func TestAuditRefcounts_PersistsLastRun(t *testing.T) {
 	if got.Share != res.Share {
 		t.Errorf("persisted Share = %q, want %q", got.Share, res.Share)
 	}
-	if got.TotalFiles != res.TotalFiles || got.TotalRefs != res.TotalRefs || got.TotalRefCount != res.TotalRefCount || got.Delta != res.Delta {
+	if got.TotalFiles != res.TotalFiles || got.TotalRefs != res.TotalRefs || got.BackedRefs != res.BackedRefs || got.DanglingRefs != res.DanglingRefs || got.Delta != res.Delta {
 		t.Errorf("persisted counts mismatch: got %+v, want %+v", got, res)
 	}
 	if got.StartedAt.IsZero() || got.CompletedAt.IsZero() {
@@ -268,13 +287,13 @@ func TestAuditRefcounts_PersistsLastRun(t *testing.T) {
 // TestAuditRefcounts_EmptyLocalRoot asserts an empty localStoreRoot
 // (in-memory backend) skips persistence cleanly without error.
 func TestAuditRefcounts_EmptyLocalRoot(t *testing.T) {
-	store, shareName, _ := seedAuditTestStore(t)
+	store, shareName, _, _ := seedAuditTestStore(t)
 
 	res, err := AuditRefcounts(context.Background(), shareName, store, "")
 	if err != nil {
 		t.Fatalf("AuditRefcounts (empty root): %v", err)
 	}
-	if res.TotalRefs != 10 || res.TotalRefCount != 10 || res.Delta != 0 {
+	if res.TotalRefs != 10 || res.BackedRefs != 10 || res.DanglingRefs != 0 || res.Delta != 0 {
 		t.Errorf("counts mismatch on empty root: %+v", res)
 	}
 	if AuditLastRunPath("") != "" {

--- a/pkg/block/engine/audit_state_test.go
+++ b/pkg/block/engine/audit_state_test.go
@@ -226,6 +226,59 @@ func TestAuditRefcounts_DetectsDelta(t *testing.T) {
 	}
 }
 
+// TestAuditRefcounts_DetectsHashMismatch asserts that a backing row present
+// at the right offset but carrying a DIFFERENT (non-zero) hash than the
+// manifest ref is counted as DANGLING, not backed. This is genuine
+// corruption: the store records a different chunk than the file claims at
+// that offset, and crediting it as backed would silently hide the mismatch.
+// The manifest is unchanged (TotalRefs stays 10), but the tampered ref drops
+// BackedRefs to 9 and DanglingRefs == Delta == 1.
+func TestAuditRefcounts_DetectsHashMismatch(t *testing.T) {
+	store, shareName, payloadIDs, offsets := seedAuditTestStore(t)
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+
+	// Overwrite the FileBlock row backing file 0's first manifest ref with a
+	// row at the SAME id/offset but a different non-zero hash, leaving the
+	// manifest entry untouched → hash mismatch → that ref is dangling.
+	mismatchID := payloadIDs[0] + "/" + jstr(int(offsets[0][0]))
+	now := time.Now().UTC()
+	wrongHash := hashForFileBlock(99, 99) // distinct from any seeded ref hash
+	if wrongHash.IsZero() {
+		t.Fatal("wrongHash must be non-zero to exercise the mismatch path")
+	}
+	wrongRow := &block.FileBlock{
+		ID:            mismatchID,
+		Hash:          wrongHash,
+		State:         block.BlockStatePending,
+		LocalPath:     "/cache/" + mismatchID,
+		BlockStoreKey: "cas/" + wrongHash.String()[0:2] + "/" + wrongHash.String()[2:4] + "/" + wrongHash.String(),
+		DataSize:      4096,
+		LastAccess:    now,
+		CreatedAt:     now,
+	}
+	if err := store.Put(ctx, wrongRow); err != nil {
+		t.Fatalf("Put mismatched row %q: %v", mismatchID, err)
+	}
+
+	res, err := AuditRefcounts(ctx, shareName, store, tmpDir)
+	if err != nil {
+		t.Fatalf("AuditRefcounts: %v", err)
+	}
+	if res.TotalRefs != 10 {
+		t.Errorf("TotalRefs = %d, want 10 (overwriting a row does not change FileAttr.Blocks)", res.TotalRefs)
+	}
+	if res.BackedRefs != 9 {
+		t.Errorf("BackedRefs = %d, want 9 (the hash-mismatched ref is not backed)", res.BackedRefs)
+	}
+	if res.DanglingRefs != 1 {
+		t.Errorf("DanglingRefs = %d, want 1 (hash mismatch must be detected as dangling)", res.DanglingRefs)
+	}
+	if res.Delta != 1 {
+		t.Errorf("Delta = %d, want 1 (Delta == DanglingRefs)", res.Delta)
+	}
+}
+
 // TestAuditRefcounts_PersistsLastRun asserts the audit writes
 // <localStoreRoot>/audit-state/last-inv02.json containing the
 // timestamps and counts. Subsequent runs OVERWRITE atomically.

--- a/pkg/controlplane/runtime/blockaudit.go
+++ b/pkg/controlplane/runtime/blockaudit.go
@@ -8,14 +8,14 @@ import (
 	"github.com/marmos91/dittofs/pkg/block/engine"
 )
 
-// AuditRefcounts runs the refcount reconciliation audit for the named
+// AuditRefcounts runs the CAS manifest-consistency audit for the named
 // share. Resolves the share's metadata store and audit-state root, then
-// delegates to engine.AuditRefcounts which walks the metadata and
-// computes:
+// delegates to engine.AuditRefcounts which walks the metadata and verifies
+// that every manifest reference (FileAttr.Blocks) has a backing FileBlock
+// row in the store.
 //
-//	∑ FileBlock.RefCount   vs   ∑ len(FileAttr.Blocks)
-//
-// A non-zero delta indicates refcount drift (leak or missed decrement).
+// A non-zero delta (DanglingRefs) indicates at least one file references a
+// chunk the store has no record of — the silent-data-loss class.
 // Last-run summary is persisted under
 // <localStoreRoot>/audit-state/last-inv02.json — analogous to GC's
 // last-run.json under <gcStateRoot>/.
@@ -58,7 +58,8 @@ func (r *Runtime) AuditRefcounts(ctx context.Context, shareName string) (*engine
 		"share", shareName,
 		"totalFiles", res.TotalFiles,
 		"totalRefs", res.TotalRefs,
-		"totalRefCount", res.TotalRefCount,
+		"backedRefs", res.BackedRefs,
+		"danglingRefs", res.DanglingRefs,
 		"delta", res.Delta,
 		"durationMs", res.DurationMS,
 	)


### PR DESCRIPTION
## Problem (#1374)

`dfsctl store block audit-refcounts <share>` reports a huge, alarming `Delta` (e.g. `delta=24427`) that looks like index corruption but is a **false positive**. It computed `TotalRefCount = Σ GetByHash(hash).RefCount`. In the CAS model `FileBlock.RefCount` is vestigial (reclamation is mark-sweep GC; eviction keys off `IsSynced`; delete/truncate reap by block ID — none consult RefCount), and `GetByHash` is remote-gated so it never resolves pending CAS blocks. So `Σ RefCount` is structurally **always 0** → `Delta = TotalRefs` always. There is no desync to repair.

## Fix

Redefine the audit to the **meaningful CAS invariant**: every `FileAttr.Blocks` manifest reference must have a backing `FileBlock` row. A manifest ref with no row is a genuine dangling reference (the silent-data-loss class, cf. #583/#789).

- New fields: `Manifest Refs (Σ len(Blocks))`, `Backed by FileBlock row`, `Dangling refs (missing row)`. `Delta == DanglingRefs`; invariant is `DanglingRefs == 0`.
- Dropped `TotalRefCount` and all `GetByHash`/RefCount use from the audit path (the store methods remain for now; a later phase removes them).
- Non-zero exit still fires on `DanglingRefs > 0`, so `audit-refcounts <share> || alert` works on real corruption. `docs/CLI.md` regenerated.

Tests: healthy share → `DanglingRefs==0` (exit 0); deleting a backing FileBlock row while leaving the manifest entry → `DanglingRefs==1` (non-zero exit).

Part of the #1374 cleanup (companion to #1377 enumeration, #1380 job-id). RefCount/dedup machinery removal lands in a follow-up phase.