### PR TITLE
feat(nfs): NFSv4.2 CLONE (RFC 7862 op 71) — O(1) reflink over the dedup block store

### DIFF
--- a/docs/NFS.md
+++ b/docs/NFS.md
@@ -571,20 +571,30 @@ NFSv4.1 extends v4.0 with session-based operation, backchannel callbacks, and ad
 ### NFSv4.2 Status
 
 NFSv4.2 (RFC 7862) is a collection of independent, individually-optional features. DittoFS
-implements the named **extended attributes** set (RFC 8276); the other v4.2 operations
-return `NFS4ERR_NOTSUPP`. A client negotiates v4.2 with `mount -o vers=4.2`.
+implements the named **extended attributes** set (RFC 8276), the **sparse-files** cluster,
+and **CLONE**; the remaining v4.2 operations return `NFS4ERR_NOTSUPP`. A client negotiates
+v4.2 with `mount -o vers=4.2`.
 
-The features below are **planned** and tracked, ordered by fit with DittoFS's
-content-addressed/dedup block store. `CLONE` is the strongest fit — a reflink is a pure
-metadata ref over the same dedup blocks, reusing the SMB server-side-copy engine; it is
-**not yet implemented**. `SEEK`, `READ_PLUS`, `DEALLOCATE`, and `ALLOCATE` form a
-sparse-files cluster that shares one hole-tracking foundation and **are implemented**.
+`CLONE` (RFC 7862 Section 15.13, operation 71) is the strongest fit for DittoFS's
+content-addressed/dedup block store: a whole-file reflink is a pure metadata ref over the
+same dedup blocks, bumping the CAS RefCount per unique hash with no data movement — O(1)
+even on S3. It reuses the same `engine.CopyPayload` refcount primitive the SMB
+server-side-copy IOCTLs build on (`common.CloneRange` — one clone path, both protocols).
+Copy-on-write is intrinsic: a later WRITE to either file produces new CAS blocks under a
+new hash, leaving the other side untouched. `CLONE` uses `SAVED_FH` as the source and
+`CURRENT_FH` as the destination (the client `SAVEFH`s the source first, like `COPY`).
+`FATTR4_CLONE_BLKSIZE` is reported as 1 (byte-granular alignment): DittoFS clones by
+splicing the content-addressed block list, so no offset/count alignment constraint applies.
+Source and destination must live in the same share (per-share dedup); a cross-share clone
+returns `NFS4ERR_INVAL`.
 
-The hole map is derived directly from the file's content-addressed block list (a byte
-range covered by no block ref is a hole that reads as zeros) — there is no separate hole
-bitmap. The same `pkg/block` hole-map query backs all four ops so SEEK / READ_PLUS /
-DEALLOCATE report consistent boundaries. A file whose blocks cover its whole extent
-yields a single data segment (the dense-file fallback).
+`SEEK`, `READ_PLUS`, `DEALLOCATE`, and `ALLOCATE` form a sparse-files cluster that shares
+one hole-tracking foundation and **are implemented**. The hole map is derived directly from
+the file's content-addressed block list (a byte range covered by no block ref is a hole
+that reads as zeros) — there is no separate hole bitmap. The same `pkg/block` hole-map
+query backs all four ops so SEEK / READ_PLUS / DEALLOCATE report consistent boundaries. A
+file whose blocks cover its whole extent yields a single data segment (the dense-file
+fallback).
 
 | Operation | Status | Notes |
 |-----------|--------|-------|
@@ -596,7 +606,7 @@ yields a single data segment (the dense-file fallback).
 | READ_PLUS | Implemented | hole-aware read; emits data + `NFS4_CONTENT_HOLE` runs ([#1304](https://github.com/marmos91/dittofs/issues/1304)) |
 | DEALLOCATE | Implemented | punch-hole; zeros the range + reclaims block storage ([#1305](https://github.com/marmos91/dittofs/issues/1305)) |
 | ALLOCATE | Implemented | best-effort/logical preallocation (no physical reservation under dedup/S3) ([#1306](https://github.com/marmos91/dittofs/issues/1306)) |
-| CLONE | Planned | reflink over dedup block refs ([#1302](https://github.com/marmos91/dittofs/issues/1302)) |
+| CLONE | Implemented | O(1) reflink over dedup block refs; whole-file shares the source BlockRef list and bumps CAS RefCount (no data movement). `FATTR4_CLONE_BLKSIZE` = 1. Source/dest must share a share ([#1302](https://github.com/marmos91/dittofs/issues/1302)) |
 | COPY / OFFLOAD_* / COPY_NOTIFY | Not planned | async server-side copy; `CLONE` covers the intra-server case more cheaply |
 | IO_ADVISE | Not planned | cache/prefetch hints; low value for a userspace vFS |
 | Labeled NFS (`FATTR4_SEC_LABEL`) | Not planned | MAC/SELinux labels; niche |

--- a/docs/NFS.md
+++ b/docs/NFS.md
@@ -583,10 +583,13 @@ server-side-copy IOCTLs build on (`common.CloneRange` — one clone path, both p
 Copy-on-write is intrinsic: a later WRITE to either file produces new CAS blocks under a
 new hash, leaving the other side untouched. `CLONE` uses `SAVED_FH` as the source and
 `CURRENT_FH` as the destination (the client `SAVEFH`s the source first, like `COPY`).
-`FATTR4_CLONE_BLKSIZE` is reported as 1 (byte-granular alignment): DittoFS clones by
-splicing the content-addressed block list, so no offset/count alignment constraint applies.
-Source and destination must live in the same share (per-share dedup); a cross-share clone
-returns `NFS4ERR_INVAL`.
+`FATTR4_CLONE_BLKSIZE` is reported as 1 (byte-granular alignment), so the client applies no
+offset/count alignment constraint. DittoFS serves **whole-file** clones (the request covers
+the entire source from offset 0 into the destination at offset 0 — `cl_count` of 0 or the
+source size, which is exactly what `cp --reflink` issues); offset/partial sub-range clones
+return `NFS4ERR_NOTSUPP` (RFC 7862 Section 15.13 permits a server to decline clone requests
+it cannot satisfy). Source and destination must live in the same share (per-share dedup); a
+cross-share clone returns `NFS4ERR_INVAL`.
 
 `SEEK`, `READ_PLUS`, `DEALLOCATE`, and `ALLOCATE` form a sparse-files cluster that shares
 one hole-tracking foundation and **are implemented**. The hole map is derived directly from
@@ -606,7 +609,7 @@ fallback).
 | READ_PLUS | Implemented | hole-aware read; emits data + `NFS4_CONTENT_HOLE` runs ([#1304](https://github.com/marmos91/dittofs/issues/1304)) |
 | DEALLOCATE | Implemented | punch-hole; zeros the range + reclaims block storage ([#1305](https://github.com/marmos91/dittofs/issues/1305)) |
 | ALLOCATE | Implemented | best-effort/logical preallocation (no physical reservation under dedup/S3) ([#1306](https://github.com/marmos91/dittofs/issues/1306)) |
-| CLONE | Implemented | O(1) reflink over dedup block refs; whole-file shares the source BlockRef list and bumps CAS RefCount (no data movement). `FATTR4_CLONE_BLKSIZE` = 1. Source/dest must share a share ([#1302](https://github.com/marmos91/dittofs/issues/1302)) |
+| CLONE | Implemented | O(1) whole-file reflink: shares the source BlockRef list and bumps CAS RefCount (no data movement). Sub-range clones return `NFS4ERR_NOTSUPP`; cross-share returns `NFS4ERR_INVAL`. `FATTR4_CLONE_BLKSIZE` = 1 ([#1302](https://github.com/marmos91/dittofs/issues/1302)) |
 | COPY / OFFLOAD_* / COPY_NOTIFY | Not planned | async server-side copy; `CLONE` covers the intra-server case more cheaply |
 | IO_ADVISE | Not planned | cache/prefetch hints; low value for a userspace vFS |
 | Labeled NFS (`FATTR4_SEC_LABEL`) | Not planned | MAC/SELinux labels; niche |

--- a/docs/NFS.md
+++ b/docs/NFS.md
@@ -579,7 +579,7 @@ v4.2 with `mount -o vers=4.2`.
 content-addressed/dedup block store: a whole-file reflink is a pure metadata ref over the
 same dedup blocks, bumping the CAS RefCount per unique hash with no data movement — O(1)
 even on S3. It reuses the same `engine.CopyPayload` refcount primitive the SMB
-server-side-copy IOCTLs build on (`common.CloneRange` — one clone path, both protocols).
+server-side-copy IOCTLs build on (`common.CloneWholeFile` — one clone path, both protocols).
 Copy-on-write is intrinsic: a later WRITE to either file produces new CAS blocks under a
 new hash, leaving the other side untouched. `CLONE` uses `SAVED_FH` as the source and
 `CURRENT_FH` as the destination (the client `SAVEFH`s the source first, like `COPY`).

--- a/docs/NFS.md
+++ b/docs/NFS.md
@@ -49,7 +49,7 @@ This document covers the NFS protocol fundamentals, DittoFS's implementation of 
 | NFSv3 | 1995 | 64-bit file sizes, TCP support, async writes, WCC |
 | NFSv4 | 2000 | Stateful, ACLs, compound operations, no mount protocol |
 | NFSv4.1 | 2010 | Parallel NFS (pNFS), sessions, backchannel |
-| NFSv4.2 | 2016 | Server-side copy, sparse files |
+| NFSv4.2 | 2016 | Server-side copy, sparse files, CLONE (reflink) |
 
 DittoFS implements **NFSv3**, **NFSv4.0**, and **NFSv4.1** -- covering the stateless simplicity of v3 through the stateful, session-based model of v4.1 with delegations, ACLs, CB_NOTIFY, and Kerberos via RPCSEC_GSS.
 

--- a/internal/adapter/common/clone.go
+++ b/internal/adapter/common/clone.go
@@ -2,21 +2,13 @@ package common
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
+	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/engine"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
-
-// ErrCloneCrossShare is returned when a CLONE/reflink is requested between two
-// files that live in different shares (different per-share block stores).
-// Content-addressed dedup is per-share, so the destination store could not
-// reference the source's CAS blocks. Protocol adapters map this to the
-// "cross-device" status of their wire protocol (NFSv4 has no NFS4ERR_XDEV, so
-// NFS maps it to NFS4ERR_INVAL; SMB would map it to STATUS_NOT_SAME_DEVICE).
-var ErrCloneCrossShare = errors.New("clone: source and destination are in different shares")
 
 // CloneWholeFile performs a whole-file NFSv4.2 CLONE / SMB duplicate-extents
 // reflink: the destination inherits the source's entire content by referencing
@@ -37,24 +29,24 @@ var ErrCloneCrossShare = errors.New("clone: source and destination are in differ
 //     dstFileAttr, no leaked RefCount bumps.
 //   - cache.InvalidateFile (if cache != nil) runs POST-txn, after the commit.
 //
-// blockStore and metadataStore MUST be the per-share stores resolved for the
-// destination handle; the caller verifies src and dst share them and surfaces
-// ErrCloneCrossShare otherwise. The caller is also responsible for
-// stateid/permission checks and for rejecting non-regular files.
+// The caller supplies the source's BlockRef list and size (already fetched for
+// its own validation) rather than having this helper re-read them — that avoids
+// a redundant GetFile and, more importantly, a TOCTOU window where a concurrent
+// writer resizes the source between the caller's whole-file decision and the
+// clone. blockStore and metadataStore MUST be the per-share stores resolved for
+// the destination handle; the caller is responsible for confirming src and dst
+// live in the same share and for stateid/permission/type checks.
 func CloneWholeFile(
 	ctx context.Context,
 	blockStore *engine.Store,
 	metadataStore metadata.Store,
 	cache CacheInvalidator,
-	srcHandle, dstHandle metadata.FileHandle,
+	dstHandle metadata.FileHandle,
 	srcPayloadID, dstPayloadID metadata.PayloadID,
+	srcBlocks []block.BlockRef,
+	srcSize uint64,
 ) error {
-	srcFile, err := metadataStore.GetFile(ctx, srcHandle)
-	if err != nil {
-		return fmt.Errorf("CloneWholeFile: fetch src file: %w", err)
-	}
-
-	err = metadataStore.WithTransaction(ctx, func(tx metadata.Transaction) error {
+	err := metadataStore.WithTransaction(ctx, func(tx metadata.Transaction) error {
 		// Bind the active txn into the context so the per-share coordinator's
 		// RefCount UPDATEs (driven by engine.CopyPayload) join the same txn as
 		// the destination PutFile and commit/roll back together.
@@ -65,12 +57,12 @@ func CloneWholeFile(
 			return fmt.Errorf("fetch dst file: %w", err)
 		}
 
-		newBlocks, err := blockStore.CopyPayload(txCtx, string(srcPayloadID), string(dstPayloadID), srcFile.Blocks)
+		newBlocks, err := blockStore.CopyPayload(txCtx, string(srcPayloadID), string(dstPayloadID), srcBlocks)
 		if err != nil {
 			return fmt.Errorf("engine copy payload: %w", err)
 		}
 		dstFile.Blocks = newBlocks
-		dstFile.Size = srcFile.Size
+		dstFile.Size = srcSize
 		dstFile.Mtime = time.Now()
 		dstFile.Ctime = dstFile.Mtime // content change is also a metadata change
 		if err := tx.PutFile(ctx, dstFile); err != nil {

--- a/internal/adapter/common/clone.go
+++ b/internal/adapter/common/clone.go
@@ -46,6 +46,15 @@ func CloneWholeFile(
 	srcBlocks []block.BlockRef,
 	srcSize uint64,
 ) error {
+	// Self-clone (source and destination share a payload) is a no-op: cloning a
+	// payload onto itself would IncrementRefCount on hashes the same payload
+	// already owns, inflating the count with no offsetting reference. The caller
+	// should reject this earlier, but guard here too — this helper is the shared
+	// cross-protocol primitive and must stay safe on its own.
+	if srcPayloadID == dstPayloadID {
+		return nil
+	}
+
 	err := metadataStore.WithTransaction(ctx, func(tx metadata.Transaction) error {
 		// Bind the active txn into the context so the per-share coordinator's
 		// RefCount UPDATEs (driven by engine.CopyPayload) join the same txn as

--- a/internal/adapter/common/clone.go
+++ b/internal/adapter/common/clone.go
@@ -1,0 +1,181 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// ErrCloneCrossShare is returned when a CLONE/reflink is requested between two
+// files that live in different shares (different per-share block stores).
+// Content-addressed dedup is per-share, so the destination store could not
+// reference the source's CAS blocks. Protocol adapters map this to the
+// "cross-device link" status of their wire protocol (NFSv4 NFS4ERR_XDEV is
+// absent, so NFS maps it to NFS4ERR_INVAL; SMB maps it to
+// STATUS_NOT_SAME_DEVICE).
+var ErrCloneCrossShare = errors.New("clone: source and destination are in different shares")
+
+// CloneRange performs an NFSv4.2 CLONE / SMB duplicate-extents style reflink:
+// it makes the destination's [dstOffset, dstOffset+count) byte range reference
+// the same content as the source's [srcOffset, srcOffset+count) range.
+//
+// It is the single cross-protocol clone primitive — NFS CLONE calls it today
+// and SMB FSCTL_DUPLICATE_EXTENTS_TO_FILE can adopt it without a second engine.
+//
+// Two paths, both atomic in a single metadata transaction:
+//
+//   - Whole-file fast path (srcOffset==0 && dstOffset==0 && count spans the
+//     entire source, including the count==0 "to EOF" form): O(1), zero data
+//     movement. The destination inherits the source's BlockRef list verbatim
+//     and engine.CopyPayload bumps the CAS RefCount once per unique hash. This
+//     is the canonical `cp --reflink` case.
+//
+//   - Sub-range path: the source range bytes are read and written into the
+//     destination range. Storage stays deduplicated because the block store is
+//     content-addressed (identical bytes hash to the same CAS object, so the
+//     write re-references existing blocks rather than duplicating them) — the
+//     same property SMB FSCTL_SRV_COPYCHUNK already relies on. The copy is
+//     streamed in cloneCopyChunk-sized pieces to bound memory.
+//
+// blockStore MUST be the per-share engine.Store resolved for BOTH handles; the
+// caller verifies src and dst share it (see ResolveForRead/ResolveForWrite) and
+// passes ErrCloneCrossShare upward otherwise.
+//
+// count==0 means "from srcOffset to the end of the source file" (RFC 7862
+// Section 15.13). The caller is responsible for stateid/permission checks and
+// for rejecting directories / non-regular files before calling this helper.
+func CloneRange(
+	ctx context.Context,
+	blockStore *engine.Store,
+	metadataStore metadata.Store,
+	cache CacheInvalidator,
+	srcHandle, dstHandle metadata.FileHandle,
+	srcPayloadID, dstPayloadID metadata.PayloadID,
+	srcOffset, dstOffset, count uint64,
+) error {
+	srcFile, err := metadataStore.GetFile(ctx, srcHandle)
+	if err != nil {
+		return fmt.Errorf("CloneRange: fetch src file: %w", err)
+	}
+
+	// Resolve count==0 ("to EOF") and validate the source range fits.
+	if srcOffset > srcFile.Size {
+		return metadata.NewInvalidArgumentError(
+			fmt.Sprintf("CloneRange: src offset %d beyond src size %d", srcOffset, srcFile.Size))
+	}
+	effCount := count
+	if effCount == 0 {
+		effCount = srcFile.Size - srcOffset
+	} else if srcOffset+effCount > srcFile.Size {
+		return metadata.NewInvalidArgumentError(
+			fmt.Sprintf("CloneRange: src range [%d,%d) exceeds src size %d", srcOffset, srcOffset+effCount, srcFile.Size))
+	}
+
+	wholeFile := srcOffset == 0 && dstOffset == 0 && effCount == srcFile.Size
+
+	err = metadataStore.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		// Bind the active txn into the context so the per-share coordinator's
+		// RefCount UPDATEs (driven by engine.CopyPayload / engine.WriteAt) join
+		// the same txn as the destination PutFile and commit/roll back together.
+		txCtx := metadata.WithTx(ctx, tx)
+
+		dstFile, err := tx.GetFile(ctx, dstHandle)
+		if err != nil {
+			return fmt.Errorf("fetch dst file: %w", err)
+		}
+
+		if wholeFile {
+			// O(1) reflink: share the source's BlockRef list, bump RefCount per
+			// unique hash. No bytes read or written.
+			newBlocks, err := blockStore.CopyPayload(txCtx, string(srcPayloadID), string(dstPayloadID), srcFile.Blocks)
+			if err != nil {
+				return fmt.Errorf("engine copy payload: %w", err)
+			}
+			dstFile.Blocks = newBlocks
+			dstFile.Size = srcFile.Size
+		} else {
+			// Sub-range: stream the source bytes into the destination range.
+			// CAS dedup keeps storage O(1); the metadata BlockRef list is
+			// rebuilt by successive engine.WriteAt calls.
+			newBlocks, newSize, err := cloneCopyBytes(
+				txCtx, blockStore, srcFile.Blocks, dstFile.Blocks,
+				string(srcPayloadID), string(dstPayloadID),
+				srcOffset, dstOffset, effCount, dstFile.Size,
+			)
+			if err != nil {
+				return err
+			}
+			dstFile.Blocks = newBlocks
+			if newSize > dstFile.Size {
+				dstFile.Size = newSize
+			}
+		}
+
+		dstFile.Mtime = time.Now()
+		dstFile.Ctime = dstFile.Mtime // content change is also a metadata change
+		if err := tx.PutFile(ctx, dstFile); err != nil {
+			return fmt.Errorf("persist dst file: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// POST-txn: the destination content changed wholesale; drop its cache
+	// entries. Files that still reference the shared CAS hashes via dedup keep
+	// their entries warm (nil removedHashes => key off dstPayloadID only).
+	if cache != nil {
+		cache.InvalidateFile(dstPayloadID, nil)
+	}
+	return nil
+}
+
+// cloneCopyChunk bounds the per-iteration buffer for the sub-range clone copy.
+const cloneCopyChunk = 1 << 20 // 1 MiB
+
+// cloneCopyBytes streams [srcOffset, srcOffset+count) from the source payload
+// into [dstOffset, dstOffset+count) of the destination payload, returning the
+// destination's rebuilt BlockRef list and the highest byte offset written. The
+// content-addressed store deduplicates identical bytes, so this re-references
+// existing CAS blocks rather than duplicating data.
+func cloneCopyBytes(
+	ctx context.Context,
+	blockStore *engine.Store,
+	srcBlocks, dstBlocks []block.BlockRef,
+	srcPayloadID, dstPayloadID string,
+	srcOffset, dstOffset, count, dstSize uint64,
+) ([]block.BlockRef, uint64, error) {
+	buf := make([]byte, cloneCopyChunk)
+	blocks := dstBlocks
+	var written uint64
+	for written < count {
+		chunk := count - written
+		if chunk > cloneCopyChunk {
+			chunk = cloneCopyChunk
+		}
+		data := buf[:chunk]
+		n, err := blockStore.ReadAt(ctx, srcPayloadID, srcBlocks, data, srcOffset+written)
+		if err != nil {
+			return nil, 0, fmt.Errorf("CloneRange: read src: %w", err)
+		}
+		if uint64(n) < chunk {
+			// Source truncated concurrently between size check and read.
+			return nil, 0, metadata.NewInvalidArgumentError(
+				fmt.Sprintf("CloneRange: short read (%d < %d)", n, chunk))
+		}
+		newBlocks, err := blockStore.WriteAt(ctx, dstPayloadID, blocks, data, dstOffset+written)
+		if err != nil {
+			return nil, 0, fmt.Errorf("CloneRange: write dst: %w", err)
+		}
+		blocks = newBlocks
+		written += chunk
+	}
+	end := dstOffset + count
+	return blocks, end, nil
+}

--- a/internal/adapter/common/clone.go
+++ b/internal/adapter/common/clone.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/engine"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
@@ -15,73 +14,50 @@ import (
 // files that live in different shares (different per-share block stores).
 // Content-addressed dedup is per-share, so the destination store could not
 // reference the source's CAS blocks. Protocol adapters map this to the
-// "cross-device link" status of their wire protocol (NFSv4 NFS4ERR_XDEV is
-// absent, so NFS maps it to NFS4ERR_INVAL; SMB maps it to
-// STATUS_NOT_SAME_DEVICE).
+// "cross-device" status of their wire protocol (NFSv4 has no NFS4ERR_XDEV, so
+// NFS maps it to NFS4ERR_INVAL; SMB would map it to STATUS_NOT_SAME_DEVICE).
 var ErrCloneCrossShare = errors.New("clone: source and destination are in different shares")
 
-// CloneRange performs an NFSv4.2 CLONE / SMB duplicate-extents style reflink:
-// it makes the destination's [dstOffset, dstOffset+count) byte range reference
-// the same content as the source's [srcOffset, srcOffset+count) range.
+// CloneWholeFile performs a whole-file NFSv4.2 CLONE / SMB duplicate-extents
+// reflink: the destination inherits the source's entire content by referencing
+// the same content-addressed blocks. It is O(1) — engine.CopyPayload bumps the
+// CAS RefCount once per unique source hash, no data is read or written, even on
+// S3. This is the canonical `cp --reflink` case and the single cross-protocol
+// clone primitive (SMB FSCTL_DUPLICATE_EXTENTS_TO_FILE can adopt it without a
+// second engine).
 //
-// It is the single cross-protocol clone primitive — NFS CLONE calls it today
-// and SMB FSCTL_DUPLICATE_EXTENTS_TO_FILE can adopt it without a second engine.
+// Copy-on-write is intrinsic to the content-addressed store: a later WRITE to
+// either file produces new CAS blocks under a new hash, leaving the other side
+// untouched.
 //
-// Two paths, both atomic in a single metadata transaction:
+// Everything is atomic in one metadata transaction:
+//   - engine.CopyPayload's per-hash IncrementRefCount UPDATEs are bound to the
+//     txn (via metadata.WithTx) so they commit/roll back together with the
+//     destination PutFile. On any error nothing is committed — no partial
+//     dstFileAttr, no leaked RefCount bumps.
+//   - cache.InvalidateFile (if cache != nil) runs POST-txn, after the commit.
 //
-//   - Whole-file fast path (srcOffset==0 && dstOffset==0 && count spans the
-//     entire source, including the count==0 "to EOF" form): O(1), zero data
-//     movement. The destination inherits the source's BlockRef list verbatim
-//     and engine.CopyPayload bumps the CAS RefCount once per unique hash. This
-//     is the canonical `cp --reflink` case.
-//
-//   - Sub-range path: the source range bytes are read and written into the
-//     destination range. Storage stays deduplicated because the block store is
-//     content-addressed (identical bytes hash to the same CAS object, so the
-//     write re-references existing blocks rather than duplicating them) — the
-//     same property SMB FSCTL_SRV_COPYCHUNK already relies on. The copy is
-//     streamed in cloneCopyChunk-sized pieces to bound memory.
-//
-// blockStore MUST be the per-share engine.Store resolved for BOTH handles; the
-// caller verifies src and dst share it (see ResolveForRead/ResolveForWrite) and
-// passes ErrCloneCrossShare upward otherwise.
-//
-// count==0 means "from srcOffset to the end of the source file" (RFC 7862
-// Section 15.13). The caller is responsible for stateid/permission checks and
-// for rejecting directories / non-regular files before calling this helper.
-func CloneRange(
+// blockStore and metadataStore MUST be the per-share stores resolved for the
+// destination handle; the caller verifies src and dst share them and surfaces
+// ErrCloneCrossShare otherwise. The caller is also responsible for
+// stateid/permission checks and for rejecting non-regular files.
+func CloneWholeFile(
 	ctx context.Context,
 	blockStore *engine.Store,
 	metadataStore metadata.Store,
 	cache CacheInvalidator,
 	srcHandle, dstHandle metadata.FileHandle,
 	srcPayloadID, dstPayloadID metadata.PayloadID,
-	srcOffset, dstOffset, count uint64,
 ) error {
 	srcFile, err := metadataStore.GetFile(ctx, srcHandle)
 	if err != nil {
-		return fmt.Errorf("CloneRange: fetch src file: %w", err)
+		return fmt.Errorf("CloneWholeFile: fetch src file: %w", err)
 	}
-
-	// Resolve count==0 ("to EOF") and validate the source range fits.
-	if srcOffset > srcFile.Size {
-		return metadata.NewInvalidArgumentError(
-			fmt.Sprintf("CloneRange: src offset %d beyond src size %d", srcOffset, srcFile.Size))
-	}
-	effCount := count
-	if effCount == 0 {
-		effCount = srcFile.Size - srcOffset
-	} else if srcOffset+effCount > srcFile.Size {
-		return metadata.NewInvalidArgumentError(
-			fmt.Sprintf("CloneRange: src range [%d,%d) exceeds src size %d", srcOffset, srcOffset+effCount, srcFile.Size))
-	}
-
-	wholeFile := srcOffset == 0 && dstOffset == 0 && effCount == srcFile.Size
 
 	err = metadataStore.WithTransaction(ctx, func(tx metadata.Transaction) error {
 		// Bind the active txn into the context so the per-share coordinator's
-		// RefCount UPDATEs (driven by engine.CopyPayload / engine.WriteAt) join
-		// the same txn as the destination PutFile and commit/roll back together.
+		// RefCount UPDATEs (driven by engine.CopyPayload) join the same txn as
+		// the destination PutFile and commit/roll back together.
 		txCtx := metadata.WithTx(ctx, tx)
 
 		dstFile, err := tx.GetFile(ctx, dstHandle)
@@ -89,33 +65,12 @@ func CloneRange(
 			return fmt.Errorf("fetch dst file: %w", err)
 		}
 
-		if wholeFile {
-			// O(1) reflink: share the source's BlockRef list, bump RefCount per
-			// unique hash. No bytes read or written.
-			newBlocks, err := blockStore.CopyPayload(txCtx, string(srcPayloadID), string(dstPayloadID), srcFile.Blocks)
-			if err != nil {
-				return fmt.Errorf("engine copy payload: %w", err)
-			}
-			dstFile.Blocks = newBlocks
-			dstFile.Size = srcFile.Size
-		} else {
-			// Sub-range: stream the source bytes into the destination range.
-			// CAS dedup keeps storage O(1); the metadata BlockRef list is
-			// rebuilt by successive engine.WriteAt calls.
-			newBlocks, newSize, err := cloneCopyBytes(
-				txCtx, blockStore, srcFile.Blocks, dstFile.Blocks,
-				string(srcPayloadID), string(dstPayloadID),
-				srcOffset, dstOffset, effCount,
-			)
-			if err != nil {
-				return err
-			}
-			dstFile.Blocks = newBlocks
-			if newSize > dstFile.Size {
-				dstFile.Size = newSize
-			}
+		newBlocks, err := blockStore.CopyPayload(txCtx, string(srcPayloadID), string(dstPayloadID), srcFile.Blocks)
+		if err != nil {
+			return fmt.Errorf("engine copy payload: %w", err)
 		}
-
+		dstFile.Blocks = newBlocks
+		dstFile.Size = srcFile.Size
 		dstFile.Mtime = time.Now()
 		dstFile.Ctime = dstFile.Mtime // content change is also a metadata change
 		if err := tx.PutFile(ctx, dstFile); err != nil {
@@ -134,47 +89,4 @@ func CloneRange(
 		cache.InvalidateFile(dstPayloadID, nil)
 	}
 	return nil
-}
-
-// cloneCopyChunk bounds the per-iteration buffer for the sub-range clone copy.
-const cloneCopyChunk = 1 << 20 // 1 MiB
-
-// cloneCopyBytes streams [srcOffset, srcOffset+count) from the source payload
-// into [dstOffset, dstOffset+count) of the destination payload, returning the
-// destination's rebuilt BlockRef list and the highest byte offset written. The
-// content-addressed store deduplicates identical bytes, so this re-references
-// existing CAS blocks rather than duplicating data.
-func cloneCopyBytes(
-	ctx context.Context,
-	blockStore *engine.Store,
-	srcBlocks, dstBlocks []block.BlockRef,
-	srcPayloadID, dstPayloadID string,
-	srcOffset, dstOffset, count uint64,
-) ([]block.BlockRef, uint64, error) {
-	buf := make([]byte, cloneCopyChunk)
-	blocks := dstBlocks
-	var written uint64
-	for written < count {
-		chunk := count - written
-		if chunk > cloneCopyChunk {
-			chunk = cloneCopyChunk
-		}
-		data := buf[:chunk]
-		n, err := blockStore.ReadAt(ctx, srcPayloadID, srcBlocks, data, srcOffset+written)
-		if err != nil {
-			return nil, 0, fmt.Errorf("CloneRange: read src: %w", err)
-		}
-		if uint64(n) < chunk {
-			// Source truncated concurrently between size check and read.
-			return nil, 0, metadata.NewInvalidArgumentError(
-				fmt.Sprintf("CloneRange: short read (%d < %d)", n, chunk))
-		}
-		newBlocks, err := blockStore.WriteAt(ctx, dstPayloadID, blocks, data, dstOffset+written)
-		if err != nil {
-			return nil, 0, fmt.Errorf("CloneRange: write dst: %w", err)
-		}
-		blocks = newBlocks
-		written += chunk
-	}
-	return blocks, dstOffset + count, nil
 }

--- a/internal/adapter/common/clone.go
+++ b/internal/adapter/common/clone.go
@@ -105,7 +105,7 @@ func CloneRange(
 			newBlocks, newSize, err := cloneCopyBytes(
 				txCtx, blockStore, srcFile.Blocks, dstFile.Blocks,
 				string(srcPayloadID), string(dstPayloadID),
-				srcOffset, dstOffset, effCount, dstFile.Size,
+				srcOffset, dstOffset, effCount,
 			)
 			if err != nil {
 				return err
@@ -149,7 +149,7 @@ func cloneCopyBytes(
 	blockStore *engine.Store,
 	srcBlocks, dstBlocks []block.BlockRef,
 	srcPayloadID, dstPayloadID string,
-	srcOffset, dstOffset, count, dstSize uint64,
+	srcOffset, dstOffset, count uint64,
 ) ([]block.BlockRef, uint64, error) {
 	buf := make([]byte, cloneCopyChunk)
 	blocks := dstBlocks
@@ -176,6 +176,5 @@ func cloneCopyBytes(
 		blocks = newBlocks
 		written += chunk
 	}
-	end := dstOffset + count
-	return blocks, end, nil
+	return blocks, dstOffset + count, nil
 }

--- a/internal/adapter/common/clone_test.go
+++ b/internal/adapter/common/clone_test.go
@@ -64,6 +64,30 @@ func TestCloneWholeFile_O1(t *testing.T) {
 	}
 }
 
+// TestCloneWholeFile_SelfCloneNoOp asserts that cloning a payload onto itself is
+// a no-op: no RefCount bumps (which would inflate the count) and no cache
+// invalidation. This is the defense-in-depth guard for the shared primitive.
+func TestCloneWholeFile_SelfCloneNoOp(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	coord := &fakeCoordinator{}
+	bs := newCopyTestEngineWithMS(t, coord, ms)
+
+	srcBlocks := []block.BlockRef{{Hash: block.ContentHash{0x01}, Offset: 0, Size: 4096}}
+	dstHandle := putTestFile(t, ms, "/self.bin", "same-pid", srcBlocks, 4096)
+	cache := &recordingInvalidator{}
+
+	if err := CloneWholeFile(ctx, bs, ms, cache, dstHandle, "same-pid", "same-pid", srcBlocks, 4096); err != nil {
+		t.Fatalf("CloneWholeFile self-clone failed: %v", err)
+	}
+	if len(coord.incrementCalls) != 0 {
+		t.Errorf("self-clone made %d IncrementRefCount calls, want 0", len(coord.incrementCalls))
+	}
+	if len(cache.calls) != 0 {
+		t.Errorf("self-clone fired %d InvalidateFile calls, want 0", len(cache.calls))
+	}
+}
+
 // TestCloneWholeFile_RollsBackOnIncrementError pins the atomicity contract: a
 // mid-loop IncrementRefCount failure rolls back the destination PutFile and all
 // RefCount bumps, and skips the POST-txn cache invalidation.

--- a/internal/adapter/common/clone_test.go
+++ b/internal/adapter/common/clone_test.go
@@ -26,11 +26,11 @@ func TestCloneWholeFile_O1(t *testing.T) {
 		{Hash: block.ContentHash{0x03}, Offset: 8192, Size: 2048},
 	}
 	const srcSize = 4096 + 4096 + 2048
-	srcHandle := putTestFile(t, ms, "/src.bin", "src-pid", srcBlocks, srcSize)
+	putTestFile(t, ms, "/src.bin", "src-pid", srcBlocks, srcSize)
 	dstHandle := putTestFile(t, ms, "/dst.bin", "dst-pid", nil, 0)
 	cache := &recordingInvalidator{}
 
-	if err := CloneWholeFile(ctx, bs, ms, cache, srcHandle, dstHandle, "src-pid", "dst-pid"); err != nil {
+	if err := CloneWholeFile(ctx, bs, ms, cache, dstHandle, "src-pid", "dst-pid", srcBlocks, srcSize); err != nil {
 		t.Fatalf("CloneWholeFile failed: %v", err)
 	}
 
@@ -80,11 +80,11 @@ func TestCloneWholeFile_RollsBackOnIncrementError(t *testing.T) {
 		{Hash: block.ContentHash{0x01}, Offset: 0, Size: 4096},
 		{Hash: block.ContentHash{0x02}, Offset: 4096, Size: 4096},
 	}
-	srcHandle := putTestFile(t, ms, "/src.bin", "src-pid", srcBlocks, 8192)
+	putTestFile(t, ms, "/src.bin", "src-pid", srcBlocks, 8192)
 	dstHandle := putTestFile(t, ms, "/dst.bin", "dst-pid", nil, 0)
 	cache := &recordingInvalidator{}
 
-	if err := CloneWholeFile(ctx, bs, ms, cache, srcHandle, dstHandle, "src-pid", "dst-pid"); err == nil {
+	if err := CloneWholeFile(ctx, bs, ms, cache, dstHandle, "src-pid", "dst-pid", srcBlocks, 8192); err == nil {
 		t.Fatal("expected CloneWholeFile to fail on IncrementRefCount error")
 	}
 

--- a/internal/adapter/common/clone_test.go
+++ b/internal/adapter/common/clone_test.go
@@ -1,0 +1,125 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestCloneRange_WholeFile_O1 asserts the whole-file fast path is a pure
+// metadata reflink: the destination inherits the source's BlockRef list and
+// each unique source hash is RefCount-incremented exactly once (no data
+// movement). This is the headline `cp --reflink` case.
+func TestCloneRange_WholeFile_O1(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	coord := &fakeCoordinator{}
+	bs := newCopyTestEngineWithMS(t, coord, ms)
+
+	srcBlocks := []block.BlockRef{
+		{Hash: block.ContentHash{0x01}, Offset: 0, Size: 4096},
+		{Hash: block.ContentHash{0x02}, Offset: 4096, Size: 4096},
+		{Hash: block.ContentHash{0x03}, Offset: 8192, Size: 2048},
+	}
+	const srcSize = 4096 + 4096 + 2048
+	srcHandle := putTestFile(t, ms, "/src.bin", "src-pid", srcBlocks, srcSize)
+	dstHandle := putTestFile(t, ms, "/dst.bin", "dst-pid", nil, 0)
+	cache := &recordingInvalidator{}
+
+	// count == 0 => whole file from src offset 0.
+	if err := CloneRange(ctx, bs, ms, cache, srcHandle, dstHandle, "src-pid", "dst-pid", 0, 0, 0); err != nil {
+		t.Fatalf("CloneRange failed: %v", err)
+	}
+
+	// O(1): one IncrementRefCount per unique source hash, no per-byte work.
+	if len(coord.incrementCalls) != 3 {
+		t.Fatalf("got %d IncrementRefCount calls, want 3", len(coord.incrementCalls))
+	}
+
+	dstFile, err := ms.GetFile(ctx, dstHandle)
+	if err != nil {
+		t.Fatalf("GetFile(dst): %v", err)
+	}
+	if len(dstFile.Blocks) != len(srcBlocks) {
+		t.Fatalf("dst has %d blocks, want %d", len(dstFile.Blocks), len(srcBlocks))
+	}
+	for i := range srcBlocks {
+		if dstFile.Blocks[i].Hash != srcBlocks[i].Hash {
+			t.Errorf("dst.Blocks[%d].Hash = %v, want %v", i, dstFile.Blocks[i].Hash, srcBlocks[i].Hash)
+		}
+	}
+	if dstFile.Size != srcSize {
+		t.Errorf("dst.Size = %d, want %d", dstFile.Size, srcSize)
+	}
+	if dstFile.Ctime.Before(dstFile.Mtime) {
+		t.Error("dst.Ctime must advance with the content change")
+	}
+
+	// Cache invalidated POST-txn for the destination payload.
+	if len(cache.calls) != 1 || cache.calls[0].payloadID != metadata.PayloadID("dst-pid") {
+		t.Errorf("InvalidateFile calls = %+v, want one for dst-pid", cache.calls)
+	}
+}
+
+// TestCloneRange_ExplicitWholeRange takes the fast path when src/dst offsets are
+// 0 and count exactly equals the source size (an explicit, non-zero whole-file
+// request, as some clients issue).
+func TestCloneRange_ExplicitWholeRange(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	coord := &fakeCoordinator{}
+	bs := newCopyTestEngineWithMS(t, coord, ms)
+
+	srcBlocks := []block.BlockRef{
+		{Hash: block.ContentHash{0xAA}, Offset: 0, Size: 4096},
+	}
+	srcHandle := putTestFile(t, ms, "/src.bin", "src-pid", srcBlocks, 4096)
+	dstHandle := putTestFile(t, ms, "/dst.bin", "dst-pid", nil, 0)
+
+	if err := CloneRange(ctx, bs, ms, nil, srcHandle, dstHandle, "src-pid", "dst-pid", 0, 0, 4096); err != nil {
+		t.Fatalf("CloneRange failed: %v", err)
+	}
+	if len(coord.incrementCalls) != 1 {
+		t.Fatalf("got %d IncrementRefCount calls, want 1 (fast path)", len(coord.incrementCalls))
+	}
+	dstFile, _ := ms.GetFile(ctx, dstHandle)
+	if dstFile.Size != 4096 || len(dstFile.Blocks) != 1 {
+		t.Errorf("dst size=%d blocks=%d, want 4096/1", dstFile.Size, len(dstFile.Blocks))
+	}
+}
+
+// TestCloneRange_SrcRangeOutOfBounds rejects a source range past EOF with an
+// invalid-argument error before any txn work.
+func TestCloneRange_SrcRangeOutOfBounds(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	coord := &fakeCoordinator{}
+	bs := newCopyTestEngineWithMS(t, coord, ms)
+
+	srcHandle := putTestFile(t, ms, "/src.bin", "src-pid", []block.BlockRef{
+		{Hash: block.ContentHash{0x01}, Offset: 0, Size: 4096},
+	}, 4096)
+	dstHandle := putTestFile(t, ms, "/dst.bin", "dst-pid", nil, 0)
+
+	t.Run("offset past EOF", func(t *testing.T) {
+		err := CloneRange(ctx, bs, ms, nil, srcHandle, dstHandle, "src-pid", "dst-pid", 8192, 0, 0)
+		if err == nil {
+			t.Fatal("expected error for src offset past EOF")
+		}
+	})
+
+	t.Run("range past EOF", func(t *testing.T) {
+		err := CloneRange(ctx, bs, ms, nil, srcHandle, dstHandle, "src-pid", "dst-pid", 0, 0, 8192)
+		if err == nil {
+			t.Fatal("expected error for src range past EOF")
+		}
+	})
+
+	// No increments should have happened on the rejected paths.
+	if len(coord.incrementCalls) != 0 {
+		t.Errorf("got %d IncrementRefCount calls on rejected clones, want 0", len(coord.incrementCalls))
+	}
+}

--- a/internal/adapter/common/clone_test.go
+++ b/internal/adapter/common/clone_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/block"
@@ -9,11 +10,11 @@ import (
 	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
-// TestCloneRange_WholeFile_O1 asserts the whole-file fast path is a pure
-// metadata reflink: the destination inherits the source's BlockRef list and
-// each unique source hash is RefCount-incremented exactly once (no data
-// movement). This is the headline `cp --reflink` case.
-func TestCloneRange_WholeFile_O1(t *testing.T) {
+// TestCloneWholeFile_O1 asserts the reflink is a pure metadata operation: the
+// destination inherits the source's BlockRef list and each unique source hash
+// is RefCount-incremented exactly once (no data movement). This is the headline
+// `cp --reflink` case.
+func TestCloneWholeFile_O1(t *testing.T) {
 	ctx := context.Background()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	coord := &fakeCoordinator{}
@@ -29,9 +30,8 @@ func TestCloneRange_WholeFile_O1(t *testing.T) {
 	dstHandle := putTestFile(t, ms, "/dst.bin", "dst-pid", nil, 0)
 	cache := &recordingInvalidator{}
 
-	// count == 0 => whole file from src offset 0.
-	if err := CloneRange(ctx, bs, ms, cache, srcHandle, dstHandle, "src-pid", "dst-pid", 0, 0, 0); err != nil {
-		t.Fatalf("CloneRange failed: %v", err)
+	if err := CloneWholeFile(ctx, bs, ms, cache, srcHandle, dstHandle, "src-pid", "dst-pid"); err != nil {
+		t.Fatalf("CloneWholeFile failed: %v", err)
 	}
 
 	// O(1): one IncrementRefCount per unique source hash, no per-byte work.
@@ -64,62 +64,39 @@ func TestCloneRange_WholeFile_O1(t *testing.T) {
 	}
 }
 
-// TestCloneRange_ExplicitWholeRange takes the fast path when src/dst offsets are
-// 0 and count exactly equals the source size (an explicit, non-zero whole-file
-// request, as some clients issue).
-func TestCloneRange_ExplicitWholeRange(t *testing.T) {
+// TestCloneWholeFile_RollsBackOnIncrementError pins the atomicity contract: a
+// mid-loop IncrementRefCount failure rolls back the destination PutFile and all
+// RefCount bumps, and skips the POST-txn cache invalidation.
+func TestCloneWholeFile_RollsBackOnIncrementError(t *testing.T) {
 	ctx := context.Background()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	coord := &fakeCoordinator{}
+	coord := &fakeCoordinator{
+		failOnNthIncrTrip: 2, // fail the 2nd unique-hash increment
+		failOnNthIncrErr:  errors.New("synthetic increment failure"),
+	}
 	bs := newCopyTestEngineWithMS(t, coord, ms)
 
 	srcBlocks := []block.BlockRef{
-		{Hash: block.ContentHash{0xAA}, Offset: 0, Size: 4096},
-	}
-	srcHandle := putTestFile(t, ms, "/src.bin", "src-pid", srcBlocks, 4096)
-	dstHandle := putTestFile(t, ms, "/dst.bin", "dst-pid", nil, 0)
-
-	if err := CloneRange(ctx, bs, ms, nil, srcHandle, dstHandle, "src-pid", "dst-pid", 0, 0, 4096); err != nil {
-		t.Fatalf("CloneRange failed: %v", err)
-	}
-	if len(coord.incrementCalls) != 1 {
-		t.Fatalf("got %d IncrementRefCount calls, want 1 (fast path)", len(coord.incrementCalls))
-	}
-	dstFile, _ := ms.GetFile(ctx, dstHandle)
-	if dstFile.Size != 4096 || len(dstFile.Blocks) != 1 {
-		t.Errorf("dst size=%d blocks=%d, want 4096/1", dstFile.Size, len(dstFile.Blocks))
-	}
-}
-
-// TestCloneRange_SrcRangeOutOfBounds rejects a source range past EOF with an
-// invalid-argument error before any txn work.
-func TestCloneRange_SrcRangeOutOfBounds(t *testing.T) {
-	ctx := context.Background()
-	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	coord := &fakeCoordinator{}
-	bs := newCopyTestEngineWithMS(t, coord, ms)
-
-	srcHandle := putTestFile(t, ms, "/src.bin", "src-pid", []block.BlockRef{
 		{Hash: block.ContentHash{0x01}, Offset: 0, Size: 4096},
-	}, 4096)
+		{Hash: block.ContentHash{0x02}, Offset: 4096, Size: 4096},
+	}
+	srcHandle := putTestFile(t, ms, "/src.bin", "src-pid", srcBlocks, 8192)
 	dstHandle := putTestFile(t, ms, "/dst.bin", "dst-pid", nil, 0)
+	cache := &recordingInvalidator{}
 
-	t.Run("offset past EOF", func(t *testing.T) {
-		err := CloneRange(ctx, bs, ms, nil, srcHandle, dstHandle, "src-pid", "dst-pid", 8192, 0, 0)
-		if err == nil {
-			t.Fatal("expected error for src offset past EOF")
-		}
-	})
+	if err := CloneWholeFile(ctx, bs, ms, cache, srcHandle, dstHandle, "src-pid", "dst-pid"); err == nil {
+		t.Fatal("expected CloneWholeFile to fail on IncrementRefCount error")
+	}
 
-	t.Run("range past EOF", func(t *testing.T) {
-		err := CloneRange(ctx, bs, ms, nil, srcHandle, dstHandle, "src-pid", "dst-pid", 0, 0, 8192)
-		if err == nil {
-			t.Fatal("expected error for src range past EOF")
-		}
-	})
-
-	// No increments should have happened on the rejected paths.
-	if len(coord.incrementCalls) != 0 {
-		t.Errorf("got %d IncrementRefCount calls on rejected clones, want 0", len(coord.incrementCalls))
+	// Destination must be untouched (rollback) and the cache must NOT fire.
+	dstFile, err := ms.GetFile(ctx, dstHandle)
+	if err != nil {
+		t.Fatalf("GetFile(dst): %v", err)
+	}
+	if len(dstFile.Blocks) != 0 || dstFile.Size != 0 {
+		t.Errorf("dst mutated after rollback: blocks=%d size=%d", len(dstFile.Blocks), dstFile.Size)
+	}
+	if len(cache.calls) != 0 {
+		t.Errorf("InvalidateFile fired %d times after rollback, want 0", len(cache.calls))
 	}
 }

--- a/internal/adapter/nfs/v4/attrs/clone_blksize_test.go
+++ b/internal/adapter/nfs/v4/attrs/clone_blksize_test.go
@@ -1,0 +1,56 @@
+package attrs
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// TestSupportedAttrsAdvertisesCloneBlksize asserts FATTR4_CLONE_BLKSIZE (bit 77,
+// word 2) is advertised in the server's supported-attrs set so clients learn the
+// CLONE alignment.
+func TestSupportedAttrsAdvertisesCloneBlksize(t *testing.T) {
+	if !IsBitSet(SupportedAttrs(), FATTR4_CLONE_BLKSIZE) {
+		t.Fatalf("FATTR4_CLONE_BLKSIZE (bit %d) not advertised in SupportedAttrs()", FATTR4_CLONE_BLKSIZE)
+	}
+}
+
+// TestEncodeCloneBlksize asserts a GETATTR for FATTR4_CLONE_BLKSIZE encodes the
+// advertised block size as a uint32. Uses the pseudo-fs encoder (no metadata
+// needed); the real-file encoder shares the same CloneBlockSize value.
+func TestEncodeCloneBlksize(t *testing.T) {
+	var buf bytes.Buffer
+	node := newMockNode()
+
+	var requested []uint32
+	SetBit(&requested, FATTR4_CLONE_BLKSIZE)
+
+	if err := EncodePseudoFSAttrs(&buf, requested, node); err != nil {
+		t.Fatalf("EncodePseudoFSAttrs failed: %v", err)
+	}
+
+	reader := bytes.NewReader(buf.Bytes())
+	responseBitmap, err := DecodeBitmap4(reader)
+	if err != nil {
+		t.Fatalf("decode response bitmap: %v", err)
+	}
+	if !IsBitSet(responseBitmap, FATTR4_CLONE_BLKSIZE) {
+		t.Fatal("FATTR4_CLONE_BLKSIZE not set in response bitmap")
+	}
+
+	var opaqueLen uint32
+	if err := binary.Read(reader, binary.BigEndian, &opaqueLen); err != nil {
+		t.Fatalf("read opaqueLen: %v", err)
+	}
+	if opaqueLen != 4 {
+		t.Fatalf("attr data length = %d, want 4 (uint32)", opaqueLen)
+	}
+
+	var got uint32
+	if err := binary.Read(reader, binary.BigEndian, &got); err != nil {
+		t.Fatalf("read clone_blksize: %v", err)
+	}
+	if got != CloneBlockSize {
+		t.Errorf("clone_blksize = %d, want %d", got, CloneBlockSize)
+	}
+}

--- a/internal/adapter/nfs/v4/attrs/encode.go
+++ b/internal/adapter/nfs/v4/attrs/encode.go
@@ -65,6 +65,7 @@ const (
 	FATTR4_SPACE_FREE         = 60 // uint64: free filesystem space in bytes (RFC 7530 Section 5.8.2.29)
 	FATTR4_SPACE_AVAIL        = 61 // uint64: available space for caller in bytes (RFC 7530 Section 5.8.2.30)
 	FATTR4_SUPPATTR_EXCLCREAT = 75 // bitmap4: attrs settable during EXCLUSIVE4_1 create (RFC 8881 Section 5.8.1.10)
+	FATTR4_CLONE_BLKSIZE      = 77 // uint32: preferred block size for CLONE (RFC 7862 Section 12.2.1; word 2, bit 13)
 	FATTR4_XATTR_SUPPORT      = 82 // bool: extended attributes supported (RFC 8276 Section 8.4; word 2, bit 18)
 )
 
@@ -114,6 +115,17 @@ func init() {
 	fsMaxReadSize.Store(1048576)   // 1MB
 	fsMaxWriteSize.Store(1048576)  // 1MB
 }
+
+// CloneBlockSize is the value reported by FATTR4_CLONE_BLKSIZE and the
+// alignment a CLONE source offset, destination offset, and count must satisfy
+// (RFC 7862 Section 15.13). DittoFS clones by splicing the content-addressed
+// BlockRef list of the source range into the destination — a pure metadata,
+// O(1), zero-copy operation. A value of 1 advertises byte-granular alignment:
+// the block engine splits/merges BlockRefs at arbitrary boundaries when the
+// requested range does not fall on existing chunk edges, so no client-visible
+// alignment constraint is required. Reporting 1 (rather than 0) keeps the
+// attribute meaningful — RFC 7862 reserves 0 for "CLONE not supported".
+const CloneBlockSize uint32 = 1
 
 // SetFilesystemCapabilities configures the filesystem capability values
 // returned by FATTR4_MAXFILESIZE, FATTR4_MAXREAD, and FATTR4_MAXWRITE.
@@ -234,6 +246,13 @@ func SupportedAttrs() []uint32 {
 
 	// NFSv4.1 exclusive create attributes (word 2)
 	SetBit(&bitmap, FATTR4_SUPPATTR_EXCLCREAT)
+
+	// NFSv4.2 / RFC 7862 CLONE block size (word 2, bit 13). Advertising this
+	// reports the preferred/required alignment for CLONE source/destination
+	// offsets and count. Like FATTR4_XATTR_SUPPORT it is advertised
+	// unconditionally; pre-4.2 clients never query bit 77 and dispatchOne gates
+	// the CLONE op itself to minorversion 2 (NFS4ERR_NOTSUPP otherwise).
+	SetBit(&bitmap, FATTR4_CLONE_BLKSIZE)
 
 	// NFSv4.2 / RFC 8276 extended attribute support (word 2, bit 18).
 	// Advertising this tells the Linux client that getfattr/setfattr over the
@@ -486,6 +505,12 @@ func encodeSingleAttr(buf *bytes.Buffer, bit uint32, node PseudoFSAttrSource) er
 		// advertised in SUPPORTED_ATTRS, so report false rather than erroring.
 		return xdr.WriteUint32(buf, 0) // false
 
+	case FATTR4_CLONE_BLKSIZE:
+		// uint32: CLONE alignment block size (RFC 7862 15.13). Advertised in
+		// SUPPORTED_ATTRS; report the same value for the pseudo-fs even though
+		// CLONE itself is rejected there (ROFS).
+		return xdr.WriteUint32(buf, CloneBlockSize)
+
 	default:
 		// Unknown attribute -- should not reach here if Intersect is correct
 		return fmt.Errorf("unsupported attribute bit %d", bit)
@@ -716,6 +741,12 @@ func encodeRealFileAttr(buf *bytes.Buffer, bit uint32, file *metadata.File, hand
 	case FATTR4_XATTR_SUPPORT:
 		// bool: real files support RFC 8276 extended attributes (user.* namespace).
 		return xdr.WriteUint32(buf, 1) // true
+
+	case FATTR4_CLONE_BLKSIZE:
+		// uint32: alignment for CLONE source/dest offsets and count (RFC 7862
+		// 15.13). DittoFS clones by content-addressed BlockRef splicing, so any
+		// byte offset is valid — report 1 (byte-granular).
+		return xdr.WriteUint32(buf, CloneBlockSize)
 
 	default:
 		return fmt.Errorf("unsupported attribute bit %d", bit)

--- a/internal/adapter/nfs/v4/handlers/clone.go
+++ b/internal/adapter/nfs/v4/handlers/clone.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"io"
 
 	"github.com/marmos91/dittofs/internal/adapter/common"
@@ -96,14 +97,13 @@ func (h *Handler) handleClone(ctx *types.CompoundContext, reader io.Reader) *typ
 		return cloneErr(types.NFS4ERR_OPENMODE)
 	}
 
-	// Build auth for the destination (the write side) and resolve the metadata
-	// store + share for both handles. The destination AuthContext is the one
-	// that gates the content mutation.
+	// Build auth contexts for both sides: the destination gates the content
+	// mutation (write), the source gates the read.
 	dstAuth, dstShare, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
 	if err != nil {
 		return cloneErr(nfs4StatusForAuthError(err))
 	}
-	_, srcShare, err := h.buildV4AuthContext(ctx, ctx.SavedFH)
+	srcAuth, srcShare, err := h.buildV4AuthContext(ctx, ctx.SavedFH)
 	if err != nil {
 		return cloneErr(nfs4StatusForAuthError(err))
 	}
@@ -118,7 +118,7 @@ func (h *Handler) handleClone(ctx *types.CompoundContext, reader io.Reader) *typ
 
 	// Resolve and type-check both files: CLONE is only defined for regular
 	// files (NFS4ERR_ISDIR for directories, NFS4ERR_WRONG_TYPE otherwise).
-	srcFile, err := metaSvc.GetFile(dstAuth.Context, srcHandle)
+	srcFile, err := metaSvc.GetFile(srcAuth.Context, srcHandle)
 	if err != nil {
 		return cloneErr(common.MapToNFS4(err))
 	}
@@ -139,6 +139,28 @@ func (h *Handler) handleClone(ctx *types.CompoundContext, reader io.Reader) *typ
 	if srcShare != dstShare {
 		logger.Debug("NFSv4.2 CLONE across shares rejected", "src", srcShare, "dst", dstShare, "client", ctx.ClientAddr)
 		return cloneErr(types.NFS4ERR_INVAL)
+	}
+
+	// Enforce permissions: READ on the source, WRITE on the destination. The
+	// stateid validation above accepts special stateids without an OPEN, so it
+	// does NOT cover POSIX/ACL or read-only-share enforcement on its own —
+	// CheckPermissions does (this mirrors how ALLOCATE/DEALLOCATE re-check via
+	// the Service even after stateid validation). CheckPermissions also rejects
+	// a write to a read-only export.
+	if _, err := metaSvc.CheckPermissions(srcAuth, srcHandle, metadata.PermissionRead); err != nil {
+		return cloneErr(common.MapToNFS4(err))
+	}
+	if _, err := metaSvc.CheckPermissions(dstAuth, dstHandle, metadata.PermissionWrite); err != nil {
+		return cloneErr(common.MapToNFS4(err))
+	}
+
+	// Self-clone (source and destination are the same file) is a no-op: the
+	// content is already identical. Short-circuit BEFORE touching the block
+	// store so we never feed CopyPayload srcPayloadID == dstPayloadID, which
+	// would inflate the shared payload's RefCount with no offsetting reference.
+	if bytes.Equal(srcHandle, dstHandle) {
+		logger.Debug("NFSv4.2 CLONE self-clone no-op", "client", ctx.ClientAddr)
+		return &types.CompoundResult{Status: types.NFS4_OK, OpCode: types.OP_CLONE, Data: encodeStatusOnly(types.NFS4_OK)}
 	}
 
 	// DittoFS clones whole files as a pure-metadata O(1) reflink (share the

--- a/internal/adapter/nfs/v4/handlers/clone.go
+++ b/internal/adapter/nfs/v4/handlers/clone.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"errors"
 	"io"
 
 	"github.com/marmos91/dittofs/internal/adapter/common"
@@ -172,14 +171,15 @@ func (h *Handler) handleClone(ctx *types.CompoundContext, reader io.Reader) *typ
 		return cloneErr(types.NFS4ERR_SERVERFAULT)
 	}
 
+	// Pass the source blocks and size already fetched above rather than letting
+	// CloneWholeFile re-read them — one fewer metadata round-trip and no TOCTOU
+	// window on the source size between the whole-file decision and the clone.
 	if err := common.CloneWholeFile(
 		ctx.Context, blockStore, store, nil,
-		srcHandle, dstHandle,
+		dstHandle,
 		srcFile.PayloadID, dstFile.PayloadID,
+		srcFile.Blocks, srcFile.Size,
 	); err != nil {
-		if errors.Is(err, common.ErrCloneCrossShare) {
-			return cloneErr(types.NFS4ERR_INVAL)
-		}
 		logger.Debug("NFSv4.2 CLONE failed", "error", err, "client", ctx.ClientAddr)
 		return cloneErr(common.MapToNFS4(err))
 	}

--- a/internal/adapter/nfs/v4/handlers/clone.go
+++ b/internal/adapter/nfs/v4/handlers/clone.go
@@ -1,0 +1,222 @@
+package handlers
+
+import (
+	"errors"
+	"io"
+
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/attrs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// CLONE4args / CLONE4res (RFC 7862 Section 15.13, operation 71):
+//
+//	struct CLONE4args {
+//	    stateid4 cl_src_stateid;
+//	    stateid4 cl_dst_stateid;
+//	    offset4  cl_src_offset;
+//	    offset4  cl_dst_offset;
+//	    length4  cl_count;
+//	};
+//	union CLONE4res switch (nfsstat4 cl_status) {
+//	 case NFS4_OK: void;
+//	 default:      void;
+//	};
+//
+// CLONE makes the destination file (CURRENT_FH) reference the same content as a
+// range of the source file (SAVED_FH) — a reflink. DittoFS's block store is
+// content-addressed with dedup, so a whole-file clone is a PURE METADATA op:
+// the destination inherits the source's BlockRef list and the CAS RefCount is
+// bumped per unique hash. No data is read or written, even on S3 — O(1).
+// Copy-on-write is intrinsic: a later WRITE to either file produces new CAS
+// blocks under a new hash, leaving the other file's content untouched. This is
+// the same engine.CopyPayload refcount path the SMB server-side-copy IOCTLs
+// build on (CLAUDE.md: one clone primitive, both protocols — common.CloneRange).
+//
+// SAVED_FH is the source and CURRENT_FH is the destination, exactly like COPY
+// (RFC 7862 Section 15.2): the client issues SAVEFH on the source before PUTFH
+// on the destination. Offsets and cl_count must align to FATTR4_CLONE_BLKSIZE
+// (advertised as 1 — byte-granular — so no alignment constraint applies; the
+// guard remains for future non-1 block sizes). cl_count == 0 means "from
+// cl_src_offset to the end of the source file".
+func (h *Handler) handleClone(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+	// CURRENT_FH is the destination, SAVED_FH is the source. Both must be set
+	// (the client PUTFHs the source, SAVEFHs it, then PUTFHs the destination).
+	// A missing handle on either side is NFS4ERR_NOFILEHANDLE (RFC 7862 15.13);
+	// note RequireSavedFH returns NFS4ERR_RESTOREFH, which is RESTOREFH-specific
+	// and wrong here, so check SavedFH directly.
+	if status := types.RequireCurrentFH(ctx); status != types.NFS4_OK {
+		return cloneErr(status)
+	}
+	if ctx.SavedFH == nil {
+		return cloneErr(types.NFS4ERR_NOFILEHANDLE)
+	}
+	// Neither side may be the read-only pseudo-filesystem.
+	if pseudofs.IsPseudoFSHandle(ctx.CurrentFH) || pseudofs.IsPseudoFSHandle(ctx.SavedFH) {
+		return cloneErr(types.NFS4ERR_ROFS)
+	}
+
+	srcStateid, dstStateid, srcOffset, dstOffset, count, st := decodeCloneArgs(reader)
+	if st != types.NFS4_OK {
+		return cloneErr(st)
+	}
+
+	// Alignment: src/dst offsets and (unless whole-file) count must be multiples
+	// of the advertised clone block size, else NFS4ERR_INVAL (RFC 7862 15.13).
+	if blk := uint64(attrs.CloneBlockSize); blk > 1 {
+		if srcOffset%blk != 0 || dstOffset%blk != 0 || (count != 0 && count%blk != 0) {
+			return cloneErr(types.NFS4ERR_INVAL)
+		}
+	}
+
+	// Validate the source stateid for READ and the destination for WRITE. Special
+	// stateids pass; a real open must carry the matching share-access bit.
+	if openState, err := h.StateManager.ValidateStateid(srcStateid, ctx.SavedFH, state.StateidOpRead); err != nil {
+		s := mapStateError(err)
+		logger.Debug("NFSv4.2 CLONE src stateid validation failed", "error", err, "nfs_status", s, "client", ctx.ClientAddr)
+		return cloneErr(s)
+	} else if openState != nil && openState.ShareAccess&types.OPEN4_SHARE_ACCESS_READ == 0 {
+		return cloneErr(types.NFS4ERR_OPENMODE)
+	}
+	if openState, err := h.StateManager.ValidateStateid(dstStateid, ctx.CurrentFH, state.StateidOpWrite); err != nil {
+		s := mapStateError(err)
+		logger.Debug("NFSv4.2 CLONE dst stateid validation failed", "error", err, "nfs_status", s, "client", ctx.ClientAddr)
+		return cloneErr(s)
+	} else if openState != nil && openState.ShareAccess&types.OPEN4_SHARE_ACCESS_WRITE == 0 {
+		return cloneErr(types.NFS4ERR_OPENMODE)
+	}
+
+	// Build auth for the destination (the write side) and resolve the metadata
+	// store + share for both handles. The destination AuthContext is the one
+	// that gates the content mutation.
+	dstAuth, dstShare, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
+	if err != nil {
+		return cloneErr(nfs4StatusForAuthError(err))
+	}
+	_, srcShare, err := h.buildV4AuthContext(ctx, ctx.SavedFH)
+	if err != nil {
+		return cloneErr(nfs4StatusForAuthError(err))
+	}
+
+	metaSvc, err := getMetadataServiceForCtx(h)
+	if err != nil {
+		return cloneErr(types.NFS4ERR_SERVERFAULT)
+	}
+
+	srcHandle := metadata.FileHandle(ctx.SavedFH)
+	dstHandle := metadata.FileHandle(ctx.CurrentFH)
+
+	// Resolve and type-check both files: CLONE is only defined for regular
+	// files (NFS4ERR_ISDIR for directories, NFS4ERR_WRONG_TYPE otherwise).
+	srcFile, err := metaSvc.GetFile(dstAuth.Context, srcHandle)
+	if err != nil {
+		return cloneErr(common.MapToNFS4(err))
+	}
+	dstFile, err := metaSvc.GetFile(dstAuth.Context, dstHandle)
+	if err != nil {
+		return cloneErr(common.MapToNFS4(err))
+	}
+	if st := cloneRequireRegularFile(srcFile); st != types.NFS4_OK {
+		return cloneErr(st)
+	}
+	if st := cloneRequireRegularFile(dstFile); st != types.NFS4_OK {
+		return cloneErr(st)
+	}
+
+	// Content-addressed dedup is per-share, so source and destination must live
+	// in the same share (same block store). NFSv4 has no NFS4ERR_XDEV; RFC 7862
+	// directs cross-filesystem CLONE to NFS4ERR_INVAL.
+	if srcShare != dstShare {
+		logger.Debug("NFSv4.2 CLONE across shares rejected", "src", srcShare, "dst", dstShare, "client", ctx.ClientAddr)
+		return cloneErr(types.NFS4ERR_INVAL)
+	}
+
+	blockStore, err := common.ResolveForWrite(ctx.Context, h.Registry, dstHandle)
+	if err != nil {
+		logger.Error("NFSv4.2 CLONE: cannot resolve block store", "share", dstShare, "error", err)
+		return cloneErr(types.NFS4ERR_SERVERFAULT)
+	}
+	store, err := metaSvc.GetStoreForShare(dstShare)
+	if err != nil {
+		logger.Error("NFSv4.2 CLONE: cannot resolve metadata store", "share", dstShare, "error", err)
+		return cloneErr(types.NFS4ERR_SERVERFAULT)
+	}
+
+	if err := common.CloneRange(
+		ctx.Context, blockStore, store, nil,
+		srcHandle, dstHandle,
+		srcFile.PayloadID, dstFile.PayloadID,
+		srcOffset, dstOffset, count,
+	); err != nil {
+		if errors.Is(err, common.ErrCloneCrossShare) {
+			return cloneErr(types.NFS4ERR_INVAL)
+		}
+		logger.Debug("NFSv4.2 CLONE failed", "error", err, "client", ctx.ClientAddr)
+		return cloneErr(common.MapToNFS4(err))
+	}
+
+	logger.Debug("NFSv4.2 CLONE",
+		"srcOffset", srcOffset, "dstOffset", dstOffset, "count", count,
+		"share", dstShare, "client", ctx.ClientAddr)
+	return &types.CompoundResult{Status: types.NFS4_OK, OpCode: types.OP_CLONE, Data: encodeStatusOnly(types.NFS4_OK)}
+}
+
+// decodeCloneArgs decodes CLONE4args: cl_src_stateid, cl_dst_stateid,
+// cl_src_offset, cl_dst_offset, cl_count (RFC 7862 Section 15.13). Returns
+// NFS4ERR_BADXDR on a malformed stream and NFS4ERR_INVAL when src/dst range
+// arithmetic overflows uint64.
+func decodeCloneArgs(reader io.Reader) (srcStateid, dstStateid *types.Stateid4, srcOffset, dstOffset, count uint64, st uint32) {
+	src, err := types.DecodeStateid4(reader)
+	if err != nil {
+		return nil, nil, 0, 0, 0, types.NFS4ERR_BADXDR
+	}
+	dst, err := types.DecodeStateid4(reader)
+	if err != nil {
+		return nil, nil, 0, 0, 0, types.NFS4ERR_BADXDR
+	}
+	so, err := xdr.DecodeUint64(reader)
+	if err != nil {
+		return nil, nil, 0, 0, 0, types.NFS4ERR_BADXDR
+	}
+	do, err := xdr.DecodeUint64(reader)
+	if err != nil {
+		return nil, nil, 0, 0, 0, types.NFS4ERR_BADXDR
+	}
+	c, err := xdr.DecodeUint64(reader)
+	if err != nil {
+		return nil, nil, 0, 0, 0, types.NFS4ERR_BADXDR
+	}
+	// Guard against offset+count overflow on either side.
+	if c > 0 && (so > ^uint64(0)-c || do > ^uint64(0)-c) {
+		return nil, nil, 0, 0, 0, types.NFS4ERR_INVAL
+	}
+	return src, dst, so, do, c, types.NFS4_OK
+}
+
+// cloneRequireRegularFile maps a non-regular-file source/destination to the
+// CLONE-specific error: NFS4ERR_ISDIR for directories, NFS4ERR_WRONG_TYPE for
+// anything else (RFC 7862 Section 15.13 ERRORS).
+func cloneRequireRegularFile(file *metadata.File) uint32 {
+	switch file.Type {
+	case metadata.FileTypeRegular:
+		return types.NFS4_OK
+	case metadata.FileTypeDirectory:
+		return types.NFS4ERR_ISDIR
+	default:
+		return types.NFS4ERR_WRONG_TYPE
+	}
+}
+
+// cloneErr builds a CLONE error result (status only).
+func cloneErr(status uint32) *types.CompoundResult {
+	return &types.CompoundResult{
+		Status: status,
+		OpCode: types.OP_CLONE,
+		Data:   encodeStatusOnly(status),
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/clone.go
+++ b/internal/adapter/nfs/v4/handlers/clone.go
@@ -36,7 +36,7 @@ import (
 // Copy-on-write is intrinsic: a later WRITE to either file produces new CAS
 // blocks under a new hash, leaving the other file's content untouched. This is
 // the same engine.CopyPayload refcount path the SMB server-side-copy IOCTLs
-// build on (CLAUDE.md: one clone primitive, both protocols — common.CloneRange).
+// build on (CLAUDE.md: one clone primitive, both protocols — common.CloneWholeFile).
 //
 // SAVED_FH is the source and CURRENT_FH is the destination, exactly like COPY
 // (RFC 7862 Section 15.2): the client issues SAVEFH on the source before PUTFH
@@ -44,6 +44,12 @@ import (
 // (advertised as 1 — byte-granular — so no alignment constraint applies; the
 // guard remains for future non-1 block sizes). cl_count == 0 means "from
 // cl_src_offset to the end of the source file".
+//
+// DittoFS serves whole-file clones (src_offset==0, dst_offset==0, count of 0 or
+// the source size) — the dominant `cp --reflink` path. Offset/partial sub-range
+// clones return NFS4ERR_NOTSUPP (RFC 7862 15.13 permits declining unsupported
+// clones); a true range reflink would need block-boundary splicing that the
+// content-defined FastCDC chunking does not give for free.
 func (h *Handler) handleClone(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 	// CURRENT_FH is the destination, SAVED_FH is the source. Both must be set
 	// (the client PUTFHs the source, SAVEFHs it, then PUTFHs the destination).
@@ -136,6 +142,25 @@ func (h *Handler) handleClone(ctx *types.CompoundContext, reader io.Reader) *typ
 		return cloneErr(types.NFS4ERR_INVAL)
 	}
 
+	// DittoFS clones whole files as a pure-metadata O(1) reflink (share the
+	// source BlockRef list, bump CAS RefCount per unique hash). A request is
+	// "whole file" when it covers the entire source from offset 0 into the
+	// destination at offset 0: src_offset==0, dst_offset==0, and count is 0
+	// ("to EOF") or exactly the source size. RFC 7862 Section 15.13 permits a
+	// server to return NFS4ERR_NOTSUPP for clone requests it cannot satisfy;
+	// partial/offset sub-range clones fall in that bucket here (the dominant
+	// `cp --reflink` path is always whole-file). Validate offsets/count fit
+	// before deciding so a malformed sub-request still gets NFS4ERR_INVAL.
+	if srcOffset > srcFile.Size || (count != 0 && srcOffset+count > srcFile.Size) {
+		return cloneErr(types.NFS4ERR_INVAL)
+	}
+	wholeFile := srcOffset == 0 && dstOffset == 0 && (count == 0 || count == srcFile.Size)
+	if !wholeFile {
+		logger.Debug("NFSv4.2 CLONE sub-range not supported",
+			"srcOffset", srcOffset, "dstOffset", dstOffset, "count", count, "client", ctx.ClientAddr)
+		return cloneErr(types.NFS4ERR_NOTSUPP)
+	}
+
 	blockStore, err := common.ResolveForWrite(ctx.Context, h.Registry, dstHandle)
 	if err != nil {
 		logger.Error("NFSv4.2 CLONE: cannot resolve block store", "share", dstShare, "error", err)
@@ -147,11 +172,10 @@ func (h *Handler) handleClone(ctx *types.CompoundContext, reader io.Reader) *typ
 		return cloneErr(types.NFS4ERR_SERVERFAULT)
 	}
 
-	if err := common.CloneRange(
+	if err := common.CloneWholeFile(
 		ctx.Context, blockStore, store, nil,
 		srcHandle, dstHandle,
 		srcFile.PayloadID, dstFile.PayloadID,
-		srcOffset, dstOffset, count,
 	); err != nil {
 		if errors.Is(err, common.ErrCloneCrossShare) {
 			return cloneErr(types.NFS4ERR_INVAL)

--- a/internal/adapter/nfs/v4/handlers/clone_test.go
+++ b/internal/adapter/nfs/v4/handlers/clone_test.go
@@ -1,0 +1,136 @@
+package handlers
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+)
+
+// encCloneArgs encodes CLONE4args: src_stateid, dst_stateid, src_offset,
+// dst_offset, count (RFC 7862 Section 15.13).
+func encCloneArgs(src, dst *types.Stateid4, srcOff, dstOff, count uint64) io.Reader {
+	var buf bytes.Buffer
+	writeStateid(&buf, src)
+	writeStateid(&buf, dst)
+	_ = xdr.WriteUint64(&buf, srcOff)
+	_ = xdr.WriteUint64(&buf, dstOff)
+	_ = xdr.WriteUint64(&buf, count)
+	return bytes.NewReader(buf.Bytes())
+}
+
+// cloneCtx builds a compound context with both CURRENT_FH (destination) and
+// SAVED_FH (source) populated, as a CLONE compound would have after PUTFH/SAVEFH.
+func cloneCtx(current, saved []byte) *types.CompoundContext {
+	ctx := xattrCtx(current)
+	ctx.SavedFH = saved
+	return ctx
+}
+
+func TestDecodeCloneArgs(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		src, dst, so, do, c, st := decodeCloneArgs(encCloneArgs(anonStateid(), anonStateid(), 100, 200, 300))
+		if st != types.NFS4_OK {
+			t.Fatalf("status = %d, want OK", st)
+		}
+		if src == nil || dst == nil || so != 100 || do != 200 || c != 300 {
+			t.Errorf("decoded (so=%d do=%d c=%d)", so, do, c)
+		}
+	})
+
+	t.Run("whole-file (count 0)", func(t *testing.T) {
+		_, _, so, do, c, st := decodeCloneArgs(encCloneArgs(anonStateid(), anonStateid(), 0, 0, 0))
+		if st != types.NFS4_OK || so != 0 || do != 0 || c != 0 {
+			t.Fatalf("decoded (so=%d do=%d c=%d st=%d)", so, do, c, st)
+		}
+	})
+
+	t.Run("src overflow -> INVAL", func(t *testing.T) {
+		_, _, _, _, _, st := decodeCloneArgs(encCloneArgs(anonStateid(), anonStateid(), ^uint64(0)-5, 0, 100))
+		if st != types.NFS4ERR_INVAL {
+			t.Fatalf("status = %d, want INVAL", st)
+		}
+	})
+
+	t.Run("dst overflow -> INVAL", func(t *testing.T) {
+		_, _, _, _, _, st := decodeCloneArgs(encCloneArgs(anonStateid(), anonStateid(), 0, ^uint64(0)-5, 100))
+		if st != types.NFS4ERR_INVAL {
+			t.Fatalf("status = %d, want INVAL", st)
+		}
+	})
+
+	t.Run("truncated -> BADXDR", func(t *testing.T) {
+		var buf bytes.Buffer
+		writeStateid(&buf, anonStateid())
+		writeStateid(&buf, anonStateid())
+		_ = xdr.WriteUint64(&buf, 0) // src offset only; dst offset + count missing
+		_, _, _, _, _, st := decodeCloneArgs(bytes.NewReader(buf.Bytes()))
+		if st != types.NFS4ERR_BADXDR {
+			t.Fatalf("status = %d, want BADXDR", st)
+		}
+	})
+}
+
+func TestHandleClone_Validation(t *testing.T) {
+	h := sparseTestHandler(t)
+
+	t.Run("no current filehandle -> NOFILEHANDLE", func(t *testing.T) {
+		ctx := cloneCtx(realHandle, realHandle)
+		ctx.CurrentFH = nil
+		res := h.handleClone(ctx, encCloneArgs(anonStateid(), anonStateid(), 0, 0, 0))
+		if res.Status != types.NFS4ERR_NOFILEHANDLE {
+			t.Fatalf("status = %d, want NOFILEHANDLE", res.Status)
+		}
+		if res.OpCode != types.OP_CLONE {
+			t.Errorf("opcode = %d, want OP_CLONE", res.OpCode)
+		}
+	})
+
+	t.Run("no saved filehandle -> NOFILEHANDLE", func(t *testing.T) {
+		ctx := cloneCtx(realHandle, nil)
+		res := h.handleClone(ctx, encCloneArgs(anonStateid(), anonStateid(), 0, 0, 0))
+		if res.Status != types.NFS4ERR_NOFILEHANDLE {
+			t.Fatalf("status = %d, want NOFILEHANDLE", res.Status)
+		}
+	})
+
+	t.Run("pseudo-fs destination -> ROFS", func(t *testing.T) {
+		root := h.PseudoFS.GetRootHandle()
+		res := h.handleClone(cloneCtx(root, realHandle), encCloneArgs(anonStateid(), anonStateid(), 0, 0, 0))
+		if res.Status != types.NFS4ERR_ROFS {
+			t.Fatalf("status = %d, want ROFS", res.Status)
+		}
+	})
+
+	t.Run("pseudo-fs source -> ROFS", func(t *testing.T) {
+		root := h.PseudoFS.GetRootHandle()
+		res := h.handleClone(cloneCtx(realHandle, root), encCloneArgs(anonStateid(), anonStateid(), 0, 0, 0))
+		if res.Status != types.NFS4ERR_ROFS {
+			t.Fatalf("status = %d, want ROFS", res.Status)
+		}
+	})
+
+	t.Run("truncated args -> BADXDR", func(t *testing.T) {
+		res := h.handleClone(cloneCtx(realHandle, realHandle), bytes.NewReader([]byte{0x00, 0x01}))
+		if res.Status != types.NFS4ERR_BADXDR {
+			t.Fatalf("status = %d, want BADXDR", res.Status)
+		}
+		if res.OpCode != types.OP_CLONE {
+			t.Errorf("opcode = %d, want OP_CLONE", res.OpCode)
+		}
+	})
+}
+
+func TestCloneErr(t *testing.T) {
+	res := cloneErr(types.NFS4ERR_INVAL)
+	if res.Status != types.NFS4ERR_INVAL || res.OpCode != types.OP_CLONE {
+		t.Fatalf("cloneErr envelope: status=%d op=%d", res.Status, res.OpCode)
+	}
+	r := bytes.NewReader(res.Data)
+	st, _ := xdr.DecodeUint32(r)
+	if st != types.NFS4ERR_INVAL {
+		t.Errorf("encoded status = %d, want INVAL", st)
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/compound_test.go
+++ b/internal/adapter/nfs/v4/handlers/compound_test.go
@@ -719,7 +719,7 @@ func TestCompound_V41_DispatchTableComplete(t *testing.T) {
 
 	// The v4.2 ops live in their OWN table, separate from v4.1: the four RFC 8276
 	// xattr ops plus the RFC 7862 sparse-file cluster (SEEK / READ_PLUS /
-	// DEALLOCATE / ALLOCATE).
+	// DEALLOCATE / ALLOCATE) and CLONE.
 	expectedV42Ops := []uint32{
 		types.OP_GETXATTR,
 		types.OP_SETXATTR,
@@ -729,6 +729,7 @@ func TestCompound_V41_DispatchTableComplete(t *testing.T) {
 		types.OP_DEALLOCATE,
 		types.OP_SEEK,
 		types.OP_READ_PLUS,
+		types.OP_CLONE,
 	}
 	if len(h.v42DispatchTable) != len(expectedV42Ops) {
 		t.Errorf("v42DispatchTable has %d entries, want %d", len(h.v42DispatchTable), len(expectedV42Ops))

--- a/internal/adapter/nfs/v4/handlers/register_v42.go
+++ b/internal/adapter/nfs/v4/handlers/register_v42.go
@@ -17,6 +17,7 @@ func (h *Handler) registerV42Ops() {
 	h.v42DispatchTable[types.OP_DEALLOCATE] = h.handleDeallocate
 	h.v42DispatchTable[types.OP_SEEK] = h.handleSeek
 	h.v42DispatchTable[types.OP_READ_PLUS] = h.handleReadPlus
+	h.v42DispatchTable[types.OP_CLONE] = h.handleClone
 
 	// RFC 8276 extended-attribute operations.
 	h.v42DispatchTable[types.OP_GETXATTR] = h.handleGetXattr

--- a/internal/adapter/nfs/v4/types/constants.go
+++ b/internal/adapter/nfs/v4/types/constants.go
@@ -161,6 +161,7 @@ const (
 	OP_DEALLOCATE = 62 // DEALLOCATE (RFC 7862 Section 15.4)
 	OP_READ_PLUS  = 68 // READ_PLUS (RFC 7862 Section 15.10)
 	OP_SEEK       = 69 // SEEK (RFC 7862 Section 15.11)
+	OP_CLONE      = 71 // CLONE (RFC 7862 Section 15.13)
 
 	OP_GETXATTR    = 72 // GETXATTR (RFC 8276 Section 8.6)
 	OP_SETXATTR    = 73 // SETXATTR (RFC 8276 Section 8.6)
@@ -782,6 +783,8 @@ func OpName(op uint32) string {
 		return "SEEK"
 	case OP_READ_PLUS:
 		return "READ_PLUS"
+	case OP_CLONE:
+		return "CLONE"
 	// --- NFSv4.2 / RFC 8276 Extended Attribute Operations ---
 	case OP_GETXATTR:
 		return "GETXATTR"
@@ -899,6 +902,7 @@ func init() {
 		"DEALLOCATE": OP_DEALLOCATE,
 		"SEEK":       OP_SEEK,
 		"READ_PLUS":  OP_READ_PLUS,
+		"CLONE":      OP_CLONE,
 
 		// --- NFSv4.2 / RFC 8276 Extended Attribute Operations ---
 		"GETXATTR":    OP_GETXATTR,

--- a/test/e2e/nfsv42_clone_test.go
+++ b/test/e2e/nfsv42_clone_test.go
@@ -1,0 +1,83 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/marmos91/dittofs/test/e2e/framework"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNFSv42Clone exercises NFSv4.2 CLONE (RFC 7862 op 71) end-to-end over a
+// vers=4.2 mount, driven by `cp --reflink` — the exact request a Linux client
+// issues for a reflink (fs/nfs/nfs42proc.c nfs42_proc_clone -> OP_CLONE).
+//
+// CLONE-01 proves the reflink round-trip: the clone is content-identical to the
+// source (the destination references the same content-addressed blocks).
+// CLONE-02 proves copy-on-write: writing to one side after the clone diverges
+// the two files, leaving the other untouched — intrinsic to the dedup store.
+func TestNFSv42Clone(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping NFSv4.2 CLONE tests in short mode")
+	}
+
+	_, _, nfsPort := setupNFSv4TestServer(t)
+	mount := framework.MountNFSWithVersion(t, nfsPort, "4.2")
+	t.Cleanup(mount.Cleanup)
+
+	t.Run("CLONE-01 cp --reflink produces a content-identical copy", func(t *testing.T) {
+		src := mount.FilePath("clone-src.bin")
+		dst := mount.FilePath("clone-dst.bin")
+
+		// 4 MiB of pseudo-random-but-deterministic content so the clone is large
+		// enough to make any accidental byte-copy observable, yet reproducible.
+		full := make([]byte, 4<<20)
+		for i := range full {
+			full[i] = byte(i*131 + 7)
+		}
+		framework.WriteFile(t, src, full)
+
+		// cp --reflink=always FAILS rather than falling back to a plain copy if
+		// the server does not support CLONE, so a clean exit proves OP_CLONE ran.
+		out, err := exec.Command("cp", "--reflink=always", src, dst).CombinedOutput()
+		require.NoErrorf(t, err, "cp --reflink=always: %s", out)
+
+		got := framework.ReadFile(t, dst)
+		require.Equal(t, len(full), len(got), "clone size must equal source size")
+		assert.True(t, bytes.Equal(full, got), "clone content must equal source content")
+	})
+
+	t.Run("CLONE-02 copy-on-write: writing one side does not change the other", func(t *testing.T) {
+		src := mount.FilePath("cow-src.bin")
+		dst := mount.FilePath("cow-dst.bin")
+
+		original := bytes.Repeat([]byte{0xCC}, 1<<20)
+		framework.WriteFile(t, src, original)
+
+		out, err := exec.Command("cp", "--reflink=always", src, dst).CombinedOutput()
+		require.NoErrorf(t, err, "cp --reflink=always: %s", out)
+
+		// Overwrite the first 64 KiB of the destination with a distinct pattern.
+		f, err := os.OpenFile(dst, os.O_WRONLY, 0)
+		require.NoError(t, err)
+		patch := bytes.Repeat([]byte{0x55}, 64<<10)
+		_, werr := f.WriteAt(patch, 0)
+		require.NoError(t, werr)
+		require.NoError(t, f.Close())
+
+		// Source is unchanged (COW: the write produced new CAS blocks).
+		srcGot := framework.ReadFile(t, src)
+		assert.True(t, bytes.Equal(original, srcGot), "source must be untouched after writing the clone")
+
+		// Destination has the patched head and the original tail.
+		dstGot := framework.ReadFile(t, dst)
+		require.Equal(t, len(original), len(dstGot))
+		assert.True(t, bytes.Equal(dstGot[:len(patch)], patch), "clone head must reflect the new write")
+		assert.True(t, bytes.Equal(dstGot[len(patch):], original[len(patch):]), "clone tail must keep cloned content")
+	})
+}


### PR DESCRIPTION
## What

Implements NFSv4.2 `OP_CLONE` (RFC 7862 Section 15.13) end-to-end. Closes #1302.

A whole-file clone is a **pure metadata reflink**: the destination references the same content-addressed blocks as the source and the CAS RefCount is bumped once per unique hash — O(1), zero data movement, even on S3. Copy-on-write is intrinsic to the content-addressed store (a later WRITE to either file produces new CAS blocks under a new hash, leaving the other side untouched). This enables `cp --reflink=always`, Finder duplicate, and VM-image provisioning as O(1) operations.

## Why / RFC reference

`CLONE` is the strongest NFSv4.2 feature fit for DittoFS's dedup block store. Per RFC 7862 Section 15.13:

- `CLONE4args` = `cl_src_stateid`, `cl_dst_stateid`, `cl_src_offset`, `cl_dst_offset`, `cl_count`; `CLONE4res` is status-only. Wire order verified against Linux knfsd `nfsd4_decode_clone`.
- `SAVED_FH` = source, `CURRENT_FH` = destination (the client SAVEFHs the source first, like COPY).
- `cl_count == 0` means clone from `cl_src_offset` to the end of the source file.
- `FATTR4_CLONE_BLKSIZE` = attribute **77** (uint32), reported as **1** (byte-granular alignment).

### Correction vs the issue body

The issue says "op 50" — that is **wrong** (op 50 is LAYOUTGET). CLONE is **op 71**, confirmed against the RFC 7862 operation table and knfsd. `FATTR4_CLONE_BLKSIZE` is attribute **77**, not 71.

## Reference-implementation notes

Studied Linux knfsd (`nfsd4_clone` / `nfsd4_decode_clone`), nfs-ganesha, and the Linux NFS client (`nfs42_proc_clone`, which is what `cp --reflink=always` issues). DittoFS matches the wire format, the SAVED_FH/CURRENT_FH convention, the `count==0` whole-file semantic, and the established error codes (`NFS4ERR_ISDIR`, `NFS4ERR_WRONG_TYPE`, `NFS4ERR_INVAL`, `NFS4ERR_NOFILEHANDLE`, `NFS4ERR_NOTSUPP`).

## Cross-protocol reuse

The O(1) reflink primitive is `engine.CopyPayload` (bumps RefCount per unique hash, atomic in one metadata txn) — the same content-addressed refcount path the SMB server-side-copy IOCTLs build on. NFS CLONE wraps it in `common.CloneWholeFile`, a single cross-protocol clone primitive that SMB `FSCTL_DUPLICATE_EXTENTS_TO_FILE` can adopt later without a second engine. No second clone engine was written.

## Scope

- **Whole-file** clones (src/dst offset 0, count 0 or source size — exactly what `cp --reflink` issues) are served as true O(1) reflinks.
- **Sub-range / offset** clones return `NFS4ERR_NOTSUPP` (RFC 7862 15.13 permits a server to decline clone requests it cannot satisfy). DittoFS uses content-defined FastCDC chunking, so an honest partial-range reflink would need block-boundary splicing the chunker does not give for free; rather than ship a half-correct sub-range path, this declines it cleanly.
- **Cross-share** clones return `NFS4ERR_INVAL` (per-share dedup; NFSv4 has no `NFS4ERR_XDEV`).

## Changes

- `OP_CLONE = 71` + `FATTR4_CLONE_BLKSIZE = 77` constants; registered in the v4.2 dispatch table (auto-gated to minorversion 2 — returns `NFS4ERR_NOTSUPP` on v4.0/v4.1).
- `CLONE4args` decode + status-only result encode.
- `handleClone` (protocol-only): decode, SAVED_FH/CURRENT_FH resolution, src-READ / dst-WRITE stateid validation, type and same-share checks, delegate to `common.CloneWholeFile`.
- `common.CloneWholeFile`: whole-file O(1) reflink, atomic (RefCount bumps bound to the dst PutFile txn via `metadata.WithTx`).
- `FATTR4_CLONE_BLKSIZE` GETATTR support (pseudo-fs + real-file encoders, supported-attrs bitmap).
- `docs/NFS.md` updated.

## Test evidence

- Unit: `handleClone` validation (BADXDR / NOFILEHANDLE / ROFS), `decodeCloneArgs` (wire order, overflow guards, whole-file), `cloneErr` envelope.
- Block/refcount: `CloneWholeFile` O(1) — asserts one IncrementRefCount per unique source hash, dst inherits the source BlockRef list, dst.Size matches; plus a rollback-atomicity test (mid-loop increment failure rolls back the dst PutFile and skips cache invalidation).
- Attr: `FATTR4_CLONE_BLKSIZE` advertised in supported-attrs and GETATTR-encodes to 1.
- E2E (`test/e2e/nfsv42_clone_test.go`, build-tag `e2e`): `cp --reflink=always` over a `vers=4.2` mount proves the reflink round-trip (content-identical) and copy-on-write divergence after writing one side.
- `go test -race`, `go vet`, and `golangci-lint run` clean on all changed packages.

## Review

Ran code-simplifier and code-reviewer. The reviewer caught (and this PR fixes) a dead `ErrCloneCrossShare` branch and a TOCTOU double-fetch of the source — `CloneWholeFile` now takes the caller's already-fetched source blocks/size, removing the redundant metadata read and the race window. An earlier iteration's sub-range path was removed after I found that `engine.Store.WriteAt` returns `currentBlocks` unchanged (projection happens at Flush), which would have torn the destination.