### PR TITLE
fix(netlogon): don't fail logon on local channel-teardown race under concurrent reload

### DIFF
--- a/internal/auth/netlogon/authenticator.go
+++ b/internal/auth/netlogon/authenticator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"sync"
 	"time"
 )
@@ -58,10 +59,27 @@ func isTransientChannelError(err error) bool {
 }
 
 // maxReloadRetries bounds how many times NetworkLogon rebuilds the channel and
-// retries after a transient secure-channel error (a concurrent reload tearing
-// down / rebuilding the channel), so it can never live-lock. In practice a
-// reload is a rare admin action and the first rebuild succeeds.
+// retries after a DC-side transient rejection (STATUS_ACCESS_DENIED while a
+// freshly rebuilt credential chain settles), so it can never live-lock. In
+// practice a reload is a rare admin action and the first rebuild succeeds.
+//
+// It does NOT bound the purely-local teardown race (errChannelNotConnected): see
+// maxTeardownRetries.
 const maxReloadRetries = 8
+
+// maxTeardownRetries bounds retries of the purely-local teardown race
+// (errChannelNotConnected): a concurrent reload closed the cached channel after
+// this logon read the pointer but before/while its RPC ran. Unlike a DC-side
+// rejection this never touches the DC (so it can never amplify toward account
+// lockout) and clears as soon as the logon grabs the freshly rebuilt channel.
+//
+// It therefore must NOT consume the small maxReloadRetries budget: under a burst
+// of admin reloads a single logon can legitimately lose this race many times in
+// a row, and failing the user's logon for an internal teardown race is wrong (it
+// was the flake behind #1383). The bound here exists only as a live-lock guard
+// and is generous; each losing attempt yields the P so a reload can make
+// progress instead of being starved by a tight retry spin.
+const maxTeardownRetries = 1024
 
 // reloadRetryBackoff is the pause between rebuild attempts after a DC-side
 // failure, giving a freshly rebuilt channel's MS-NRPC credential chain a moment
@@ -162,15 +180,50 @@ func (a *Authenticator) NetworkLogon(ctx context.Context, req NetworkLogonReques
 		return nil, err
 	}
 
-	// Transient: rebuild against the latest credential and retry, bounded so we can
-	// never live-lock, with a short backoff to let the rebuilt channel's credential
-	// chain settle.
+	// Transient: rebuild against the latest credential and retry. Two transient
+	// cases are bounded SEPARATELY:
+	//
+	//   - The purely-local teardown race (errChannelNotConnected): a concurrent
+	//     reload closed the cached channel out from under this logon. It never
+	//     reached the DC, so retrying it can never amplify toward account lockout,
+	//     and it clears the instant the logon grabs the freshly rebuilt channel.
+	//     It must NOT consume the small DC-retry budget — under a burst of admin
+	//     reloads one logon can lose this race many times in a row, and failing the
+	//     user's logon for an internal race is wrong (#1383). It is bounded only by
+	//     the generous maxTeardownRetries live-lock guard, with a Gosched yield so a
+	//     reload can make progress instead of being starved by a tight spin.
+	//
+	//   - A DC-side transient rejection (STATUS_ACCESS_DENIED while a freshly
+	//     rebuilt credential chain settles): bounded by the small maxReloadRetries,
+	//     with a short backoff between attempts.
 	//
 	// A credential-provider error is NOT retried: when passthrough is disabled the
 	// provider returns a validation error, so the loop returns immediately and the
 	// logon fails closed (it never silently keeps authenticating with a stale
 	// credential).
-	for attempt := 0; attempt < maxReloadRetries; attempt++ {
+	dcAttempts, teardownAttempts := 0, 0
+	for {
+		if errors.Is(err, errChannelNotConnected) {
+			if teardownAttempts++; teardownAttempts > maxTeardownRetries {
+				return nil, err
+			}
+			// Purely local: no backoff (no DC involved), just yield so an in-flight
+			// reload can finish swapping the channel before we grab it again.
+			runtime.Gosched()
+		} else {
+			// DC-side transient rejection: consume the bounded budget and back off so
+			// a just-rebuilt channel is not torn down again before its credential
+			// chain settles.
+			if dcAttempts++; dcAttempts > maxReloadRetries {
+				return nil, err
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(reloadRetryBackoff):
+			}
+		}
+
 		a.reset(ctx)
 		mc, err = a.provider.Credential(ctx)
 		if err != nil {
@@ -184,22 +237,11 @@ func (a *Authenticator) NetworkLogon(ctx context.Context, req NetworkLogonReques
 			return res, nil
 		}
 		// A non-transient failure on the rebuilt channel (e.g. the user's password
-		// really is wrong) must fail fast too — stop retrying immediately.
+		// really is wrong) must fail fast — stop retrying immediately.
 		if !isTransientChannelError(err) {
 			return nil, err
 		}
-		// Brief backoff before the next rebuild so a just-rebuilt channel is not
-		// immediately torn down again by a still-in-flight reload. Skipped for the
-		// purely-local "channel not connected" race, which needs no settle time.
-		if !errors.Is(err, errChannelNotConnected) {
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(reloadRetryBackoff):
-			}
-		}
 	}
-	return nil, err
 }
 
 // Reload tears down the cached channel so the next NetworkLogon rebuilds it

--- a/internal/auth/netlogon/authenticator.go
+++ b/internal/auth/netlogon/authenticator.go
@@ -181,9 +181,12 @@ func (a *Authenticator) NetworkLogon(ctx context.Context, req NetworkLogonReques
 	}
 
 	// Transient: rebuild against the latest credential and retry. Two transient
-	// cases are bounded SEPARATELY:
+	// cases are bounded SEPARATELY, discriminated by whether the error is the BARE
+	// errChannelNotConnected sentinel or merely WRAPS it:
 	//
-	//   - The purely-local teardown race (errChannelNotConnected): a concurrent
+	//   - The purely-local teardown race: samLogon found the channel already torn
+	//     down (cli == nil) before it acquired the lock and returned the BARE
+	//     sentinel (errChannelNotConnected, identity-compared with ==). A concurrent
 	//     reload closed the cached channel out from under this logon. It never
 	//     reached the DC, so retrying it can never amplify toward account lockout,
 	//     and it clears the instant the logon grabs the freshly rebuilt channel.
@@ -191,11 +194,18 @@ func (a *Authenticator) NetworkLogon(ctx context.Context, req NetworkLogonReques
 	//     reloads one logon can lose this race many times in a row, and failing the
 	//     user's logon for an internal race is wrong (#1383). It is bounded only by
 	//     the generous maxTeardownRetries live-lock guard, with a Gosched yield so a
-	//     reload can make progress instead of being starved by a tight spin.
+	//     reload can make progress instead of being starved by a tight spin, and an
+	//     explicit ctx check so a canceled/deadline-exceeded caller returns promptly
+	//     instead of spinning under that large budget.
 	//
-	//   - A DC-side transient rejection (STATUS_ACCESS_DENIED while a freshly
-	//     rebuilt credential chain settles): bounded by the small maxReloadRetries,
-	//     with a short backoff between attempts.
+	//   - Every OTHER transient case takes the bounded DC budget (maxReloadRetries)
+	//     with a backoff: a DC-side STATUS_ACCESS_DENIED (a freshly rebuilt
+	//     credential chain settling) AND a transport-level RPC failure, which
+	//     samLogon returns WRAPPING the sentinel (fmt.Errorf("...%w...", err)). The
+	//     wrapped case includes a real cli.SAMLogon failure such as a broken pipe or
+	//     a context.Canceled/DeadlineExceeded; it touched (or tried to touch) the DC
+	//     and so must be retried under a small, backed-off budget, NOT the local
+	//     teardown budget. The select on ctx.Done() below makes cancellation prompt.
 	//
 	// A credential-provider error is NOT retried: when passthrough is disabled the
 	// provider returns a validation error, so the loop returns immediately and the
@@ -203,7 +213,15 @@ func (a *Authenticator) NetworkLogon(ctx context.Context, req NetworkLogonReques
 	// credential).
 	dcAttempts, teardownAttempts := 0, 0
 	for {
-		if errors.Is(err, errChannelNotConnected) {
+		// Bare-sentinel identity comparison (NOT errors.Is): only the purely-local
+		// teardown race returns the unwrapped sentinel; wrapped transport errors fall
+		// through to the bounded DC branch.
+		if err == errChannelNotConnected {
+			// Honor cancellation even on the local-race path so a canceled or
+			// deadline-exceeded caller never spins under the large teardown budget.
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			if teardownAttempts++; teardownAttempts > maxTeardownRetries {
 				return nil, err
 			}
@@ -211,9 +229,9 @@ func (a *Authenticator) NetworkLogon(ctx context.Context, req NetworkLogonReques
 			// reload can finish swapping the channel before we grab it again.
 			runtime.Gosched()
 		} else {
-			// DC-side transient rejection: consume the bounded budget and back off so
-			// a just-rebuilt channel is not torn down again before its credential
-			// chain settles.
+			// DC-side transient rejection or wrapped transport failure: consume the
+			// bounded budget and back off so a just-rebuilt channel is not torn down
+			// again before its credential chain settles.
 			if dcAttempts++; dcAttempts > maxReloadRetries {
 				return nil, err
 			}

--- a/internal/auth/netlogon/reload_test.go
+++ b/internal/auth/netlogon/reload_test.go
@@ -64,6 +64,10 @@ type fakeState struct {
 	// samLogonCalls counts every samLogon invocation (including failures), so a
 	// test can assert NetworkLogon made exactly one call on a fast-fail.
 	samLogonCalls int32
+	// alwaysTornDown, when 1, makes every samLogon return the BARE
+	// errChannelNotConnected sentinel (the purely-local teardown race), so a test
+	// can drive NetworkLogon's high-budget teardown-retry path deterministically.
+	alwaysTornDown int32
 }
 
 // errDCRejected stands in for a TRANSIENT DC-side SamLogon rejection
@@ -100,6 +104,11 @@ func (c *fakeChannel) samLogon(ctx context.Context, mc MachineCredential, req Ne
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	atomic.AddInt32(&c.state.samLogonCalls, 1)
+	if atomic.LoadInt32(&c.state.alwaysTornDown) == 1 {
+		// Always surface the BARE local-teardown sentinel (not the wrapped transport
+		// variant), exercising NetworkLogon's high-budget teardown-retry path.
+		return nil, errChannelNotConnected
+	}
 	if !c.connected || c.closed {
 		// Mirror SecureChannel.samLogon's torn-down path so the Authenticator's
 		// reload-race retry/rebuild logic is exercised. Uses the same sentinel the
@@ -335,6 +344,34 @@ func TestNetworkLogon_RetriesTransportDrop(t *testing.T) {
 	}
 	if got := completedLogons(st); got != 1 {
 		t.Fatalf("expected exactly 1 successful logon, got %d", got)
+	}
+}
+
+// TestNetworkLogon_CanceledContextStopsTeardownRetry proves a canceled context
+// short-circuits the high-budget local-teardown retry loop: NetworkLogon returns
+// ctx.Err() promptly instead of spinning up to maxTeardownRetries (1024). The
+// teardown path is purely local (no DC backoff), so without an explicit ctx check
+// a canceled caller could otherwise burn the entire budget before returning
+// (#1383 Copilot follow-up).
+func TestNetworkLogon_CanceledContextStopsTeardownRetry(t *testing.T) {
+	st := &fakeState{alwaysTornDown: 1} // every samLogon returns the BARE teardown sentinel
+	withFakeChannels(t, st)
+
+	a := NewAuthenticator(NewMutableProvider(validCred("DITTOFS$")))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already canceled before the call
+
+	_, err := a.NetworkLogon(ctx, NetworkLogonRequest{Username: "alice", Domain: "DITTOFS"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled from a canceled-context logon, got: %v", err)
+	}
+	// The first samLogon runs (the ctx check guards the RETRY loop, not the initial
+	// attempt), then the teardown branch's ctx check returns immediately — so the
+	// total call count must be far below the 1024 teardown budget. A handful proves
+	// the loop did not spin the budget away.
+	if got := atomic.LoadInt32(&st.samLogonCalls); got > 4 {
+		t.Fatalf("expected the canceled context to stop the teardown retry promptly "+
+			"(<=4 samLogon calls), got %d — the loop spun the teardown budget", got)
 	}
 }
 


### PR DESCRIPTION
## What

Fixes the ~50% flake in `TestReloadCredential_ConcurrentLogons` (#1383), which intermittently failed with `expected zero logon errors under concurrent reload, got 1` and blocked unrelated PRs.

This is a **production concurrency bug**, not a test-only issue — the test was correctly asserting an invariant the code violated. (No data race: all shared state is already guarded by the credential `RWMutex` and the `a.mu` channel-pointer swap, so the race detector would not have flagged it; the flake surfaces deterministically under `-count`.)

## Why (root cause)

`NetworkLogon`'s retry loop bounded **all** transient secure-channel retries by a single small budget, `maxReloadRetries = 8`. Two very different conditions shared that budget:

1. **Local teardown race** (`errChannelNotConnected`) — a concurrent `ReloadCredential` closed the cached channel *after* a logon read the channel pointer but *before/while* its RPC ran. This never reaches the DC.
2. **DC-side transient rejection** (`STATUS_ACCESS_DENIED`) — a freshly rebuilt channel's MS-NRPC credential chain is still settling.

The retry of case (1) also ran with **no backoff and no yield**, in a tight spin against 4 reload goroutines spinning equally tightly. Under that burst, a single logon could lose the purely-local race 8 times in a row, exhaust the shared budget, and return `errChannelNotConnected` to the caller — a spurious logon failure caused entirely by an internal channel swap.

## Fix

Split the two transient cases into separate budgets:

- **Local teardown race**: retried under a separate, generous live-lock guard (`maxTeardownRetries = 1024`) with a `runtime.Gosched()` yield, so an in-flight reload makes progress instead of being starved by a tight retry spin. It no longer consumes the DC-retry budget. Safe to retry freely: it never touches the DC, so it can never amplify failed logons toward AD account lockout, and it clears the instant the logon grabs the freshly rebuilt channel.
- **DC-side rejection**: unchanged behaviour — still bounded by `maxReloadRetries` with `reloadRetryBackoff` between attempts.

A credential-provider error (passthrough disabled) still fails closed, and a hard auth failure still fails fast after one call — both preserved.

## Verification

- `go test -run TestReloadCredential_ConcurrentLogons -count=500 ./internal/auth/netlogon` — clean (was ~50% failure before)
- `go test -count=5 ./internal/auth/netlogon` — clean
- `go build ./...` and `go vet ./internal/auth/netlogon/` — clean

(`-race` is unsupported on this windows/arm64 host; the flake is a deterministic assertion failure exercised by `-count`, and the underlying shared state was already correctly synchronized.)

Fixes #1383.