### PR TITLE
fix(block): CopyPayload must create dst FileBlock rows — clone read-back corruption (#1384)

### DIFF
--- a/pkg/block/engine/api_blockref_test.go
+++ b/pkg/block/engine/api_blockref_test.go
@@ -58,6 +58,96 @@ func TestCopyPayload_O1_IncrementsRefCountPerUniqueHash(t *testing.T) {
 	}
 }
 
+// TestCopyPayload_ToleratesPendingBlocks pins the #1384 fix: on a CAS share
+// every source block is Pending, so the Remote-gated GetByHash behind
+// IncrementRefCount resolves to "no FileBlock row" and returns
+// ErrFileBlockNotFound. That must NOT fail the copy — NFSv4.2 CLONE and SMB
+// server-side-copy route through CopyPayload, and the cloned blocks are kept
+// alive by the destination's manifest via the GC mark phase, not by RefCount.
+// (The pre-fix code returned the error and CLONE failed with EREMOTEIO on any
+// rolled-up source; the original test masked it with a fake that never gated.)
+func TestCopyPayload_ToleratesPendingBlocks(t *testing.T) {
+	fc := &fakeCoordinator{incAllNotFound: true}
+	bs := newTestEngineWithCoordinator(t, fc)
+	ctx := context.Background()
+
+	src := []block.BlockRef{
+		{Hash: block.ContentHash{0x01}, Offset: 0, Size: 1024},
+		{Hash: block.ContentHash{0x02}, Offset: 1024, Size: 1024},
+		{Hash: block.ContentHash{0x03}, Offset: 2048, Size: 1024},
+	}
+
+	dst, err := bs.CopyPayload(ctx, "src", "dst", src)
+	if err != nil {
+		t.Fatalf("CopyPayload must tolerate ErrFileBlockNotFound (pending CAS blocks), got: %v", err)
+	}
+	if len(dst) != len(src) {
+		t.Fatalf("dst len = %d, want %d (manifest must be copied even when refcount bump is a no-op)", len(dst), len(src))
+	}
+	for i := range src {
+		if dst[i] != src[i] {
+			t.Errorf("dst[%d] = %+v, want %+v", i, dst[i], src[i])
+		}
+	}
+}
+
+// TestCopyPayload_CreatesDstFileBlockRows is the #1384 corruption regression:
+// CopyPayload MUST create one per-(dstPayloadID/offset) FileBlock row for every
+// source block. The cold-read path resolves a payload's bytes via
+// ListFileBlocks(dstPayloadID), NOT via FileAttr.Blocks — so without dst rows a
+// read of the clone hits the sparse-block branch and zero-fills (silent
+// corruption). This test fails before the row-creation fix (no dst rows) and
+// passes after (one row per source block, same offset + hash + DataSize).
+func TestCopyPayload_CreatesDstFileBlockRows(t *testing.T) {
+	fc := &fakeCoordinator{incAllNotFound: true} // CAS share: every source block Pending.
+	bs := newTestEngineWithCoordinator(t, fc)
+	ctx := context.Background()
+
+	const dst = "dst"
+	src := []block.BlockRef{
+		{Hash: block.ContentHash{0x01}, Offset: 0, Size: 1024},
+		{Hash: block.ContentHash{0x02}, Offset: 1024, Size: 2048},
+		{Hash: block.ContentHash{0x03}, Offset: 3072, Size: 512},
+	}
+
+	if _, err := bs.CopyPayload(ctx, "src", dst, src); err != nil {
+		t.Fatalf("CopyPayload: %v", err)
+	}
+
+	rows, err := bs.fileBlockStore.ListFileBlocks(ctx, dst)
+	if err != nil {
+		t.Fatalf("ListFileBlocks(%s): %v", dst, err)
+	}
+	if len(rows) != len(src) {
+		t.Fatalf("dst FileBlock rows = %d, want %d (one per source block) — clone would zero-fill without rows (#1384)", len(rows), len(src))
+	}
+
+	// Index the created rows by offset and assert each mirrors its source block.
+	byOffset := make(map[uint64]*block.FileBlock, len(rows))
+	for _, fb := range rows {
+		off, ok := block.ParseChunkOffset(fb.ID)
+		if !ok {
+			t.Fatalf("dst row ID %q does not parse as {payloadID}/{offset}", fb.ID)
+		}
+		byOffset[off] = fb
+	}
+	for _, b := range src {
+		fb, ok := byOffset[b.Offset]
+		if !ok {
+			t.Fatalf("no dst FileBlock row at offset %d", b.Offset)
+		}
+		if fb.Hash != b.Hash {
+			t.Errorf("dst row offset %d hash = %s, want %s (must point at the shared CAS chunk)", b.Offset, fb.Hash.String(), b.Hash.String())
+		}
+		if fb.DataSize != b.Size {
+			t.Errorf("dst row offset %d DataSize = %d, want %d", b.Offset, fb.DataSize, b.Size)
+		}
+		if fb.State != block.BlockStatePending {
+			t.Errorf("dst row offset %d State = %v, want Pending", b.Offset, fb.State)
+		}
+	}
+}
+
 // TestCopyPayload_FailureRollsBack pins the mid-failure
 // contract: any IncrementRefCount error is surfaced immediately and no
 // further increments are attempted (caller's metadata txn rolls back

--- a/pkg/block/engine/coordinator_test.go
+++ b/pkg/block/engine/coordinator_test.go
@@ -33,6 +33,12 @@ type fakeCoordinator struct {
 	// whose Remote-gated GetByHash resolves to no FileBlock row (#1245 Bug A).
 	incErr error
 
+	// Optional: incAllNotFound makes EVERY IncrementRefCount return
+	// block.ErrFileBlockNotFound, modelling the real coordinator on a CAS
+	// share where all source blocks are Pending and the Remote-gated
+	// GetByHash never resolves them (#1384 CLONE / SMB server-side-copy).
+	incAllNotFound bool
+
 	// Optional: failOnNthDecrement returns an error on the Nth (1-based)
 	// DecrementRefCount call. Zero disables.
 	failOnNthDecrement int
@@ -98,6 +104,9 @@ func (f *fakeCoordinator) IncrementRefCount(_ context.Context, hash block.Conten
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.incCallCount++
+	if f.incAllNotFound {
+		return block.ErrFileBlockNotFound
+	}
 	if f.failOnNthIncrement > 0 && f.incCallCount == f.failOnNthIncrement {
 		if f.incErr != nil {
 			return f.incErr

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -511,26 +511,40 @@ func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID str
 	// rows and the FileAttr.Blocks manifest stay consistent. With no bound txn
 	// (e.g. unit tests wiring the engine directly) fall back to the store-level
 	// Put, matching the rollup ObjectIDPersister which runs outside any txn.
-	putRow := func(ctx context.Context, fb *block.FileBlock) error {
-		if tx := metadata.TxFromContext(ctx); tx != nil {
-			return tx.Put(ctx, fb)
-		}
-		return bs.fileBlockStore.Put(ctx, fb)
+	// Persist dst rows through the txn bound in ctx when present, else the
+	// store directly. The bound txn writes under the lock WithTransaction
+	// already holds — a separate store-level Put would re-enter the memory
+	// backend's non-reentrant mutex and self-deadlock. The store fallback
+	// covers the no-txn path (unit tests wiring the engine directly), matching
+	// the rollup ObjectIDPersister. The row write does NOT depend on
+	// bs.fileBlockStore being non-nil when a txn is bound.
+	tx := metadata.TxFromContext(ctx)
+	var putRow func(context.Context, *block.FileBlock) error
+	switch {
+	case tx != nil:
+		putRow = tx.Put
+	case bs.fileBlockStore != nil:
+		putRow = bs.fileBlockStore.Put
 	}
-	if bs.fileBlockStore != nil {
-		for _, b := range srcBlocks {
-			if b.Hash.IsZero() {
-				continue
-			}
-			fb := &block.FileBlock{
-				ID:       fmt.Sprintf("%s/%d", dstPayloadID, b.Offset),
-				Hash:     b.Hash,
-				DataSize: b.Size,
-				State:    block.BlockStatePending,
-			}
-			if err := putRow(ctx, fb); err != nil {
-				return nil, fmt.Errorf("CopyPayload: FileBlock.Put(%s): %w", fb.ID, err)
-			}
+	for _, b := range srcBlocks {
+		if b.Hash.IsZero() {
+			continue
+		}
+		// Refuse to produce an unreadable clone: if there are blocks to
+		// materialize but no way to persist the dst rows, fail loudly rather
+		// than copy only the manifest (whose blocks the cold-read path can't
+		// resolve without rows → zero-fill, #1384).
+		if putRow == nil {
+			return nil, fmt.Errorf("CopyPayload: no transaction or file-block store to persist dst rows for %s", dstPayloadID)
+		}
+		fb := &block.FileBlock{
+			ID:       fmt.Sprintf("%s/%d", dstPayloadID, b.Offset),
+			Hash:     b.Hash,
+			DataSize: b.Size,
+			State:    block.BlockStatePending,
+		}
+		if err := putRow(ctx, fb); err != nil {
+			return nil, fmt.Errorf("CopyPayload: FileBlock.Put(%s): %w", fb.ID, err)
 		}
 	}
 

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
 // ReadAt reads data from storage at the given offset into dest.
@@ -409,11 +410,27 @@ func (bs *Store) Delete(ctx context.Context, payloadID string, blocks []block.Bl
 	return coordErr
 }
 
-// CopyPayload duplicates a file's BlockRef list with O(1) cost.
-// Increments the RefCount of each unique source-hash via the
-// coordinator (no per-block data copy); returns a deep copy of
-// srcBlocks as the destination's BlockRef list. The caller's metadata
-// txn rolls back all increments on any error.
+// CopyPayload duplicates a file's content by referencing the source's
+// content-addressed blocks — no data movement, O(blocks) metadata puts.
+// It does two things for the destination:
+//
+//  1. Creates one per-(dstPayloadID/offset) FileBlock row for every source
+//     block, keyed by the SAME offset + hash + DataSize, in BlockStatePending.
+//     This is the load-bearing step for read correctness: the cold-read path
+//     resolves a payload's bytes via ListFileBlocks(dstPayloadID) (the per-file
+//     FileBlock rows), NOT via FileAttr.Blocks. Without dst rows a read of the
+//     clone hits the sparse-block branch and zero-fills — silent corruption
+//     (#1384). Because every row carries the source hash and the chunks are
+//     content-addressed, the dst rows resolve to the SAME shared CAS chunks and
+//     the clone reads back byte-identical to the source.
+//  2. Bumps each unique source-hash RefCount via the coordinator. This is now
+//     belt-and-suspenders: block keep-alive (and GC safety) is by-hash over the
+//     manifest live set in the GC mark phase, which enumerates the dst rows too.
+//
+// It returns a deep copy of srcBlocks as the destination's BlockRef list, which
+// the caller persists as dst's FileAttr.Blocks in the same metadata txn — so the
+// per-file rows and the FileAttr.Blocks manifest reference the same hashes and
+// offsets.
 //
 // Empty srcBlocks => nil-safe legacy path: copies nothing (legacy
 // CopyPayload data-copy semantics are removed in; the legacy
@@ -421,15 +438,17 @@ func (bs *Store) Delete(ctx context.Context, payloadID string, blocks []block.Bl
 // directly during the dual-read window). Production callers always
 // supply a snapshot of the source file's FileAttr.Blocks.
 //
-// Failure semantics: on any IncrementRefCount error, returns the error
-// immediately without further increments. Already-bumped counts are
-// the caller's metadata txn's responsibility to roll back (the engine
-// owns no txn).
+// Failure semantics: a genuine IncrementRefCount backend fault is surfaced
+// immediately without further increments (the caller's metadata txn rolls back).
+// A missing-row increment (ErrFileBlockNotFound) is tolerated — see the loop.
 //
 // Dedup: a single hash present multiple times in srcBlocks bumps the
 // RefCount only once per CopyPayload call (per-call seen-hash set).
 // The destination's []BlockRef preserves the original sequence so
-// subsequent reads still resolve every offset correctly.
+// subsequent reads still resolve every offset correctly. Dst rows are
+// created per source block (one row per offset) — two BlockRefs sharing a
+// hash are two distinct dst rows, mirroring the per-offset row model used by
+// the rollup ObjectIDPersister and the Delete/Truncate by-ID reap contract.
 func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID string, srcBlocks []block.BlockRef) ([]block.BlockRef, error) {
 	if err := bs.enter(); err != nil {
 		return nil, err
@@ -454,20 +473,76 @@ func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID str
 		}
 		seen[b.Hash] = struct{}{}
 		if err := bs.coordinator.IncrementRefCount(ctx, b.Hash); err != nil {
+			// A CAS block is content-addressed and lives in BlockStatePending
+			// for the life of the payload (it never transitions to Remote), so
+			// the Remote-gated GetByHash that IncrementRefCount relies on
+			// resolves it to "no FileBlock row" and returns ErrFileBlockNotFound.
+			// That is NOT a clone failure: the destination's BlockRef manifest
+			// (dst, below) references the same hashes, and block keep-alive is
+			// by-hash over the manifest live set in the GC mark phase
+			// (EnumerateFileBlocks / reapSupersededFileBlocks), not via RefCount.
+			// So a missing-row increment is a no-op to be skipped, mirroring how
+			// DecrementRefCount already tolerates the same miss. Without this,
+			// NFSv4.2 CLONE and SMB server-side-copy fail with EREMOTEIO on any
+			// rolled-up source (#1384). A genuine backend fault still aborts.
+			if errors.Is(err, block.ErrFileBlockNotFound) {
+				continue
+			}
 			return nil, fmt.Errorf("CopyPayload: increment refcount on %s: %w", b.Hash.String(), err)
 		}
 	}
 
+	// Create the destination's per-file FileBlock rows. The cold-read path
+	// resolves bytes via ListFileBlocks(dstPayloadID), not FileAttr.Blocks, so
+	// without these rows reads of the clone zero-fill (silent corruption,
+	// #1384). One row per source block keyed by dstPayloadID + the SAME offset,
+	// hash and DataSize, in BlockStatePending — mirroring the rollup
+	// ObjectIDPersister (engine.go) so the dst rows resolve to the shared CAS
+	// chunks (content-addressed by hash). Skip zero-hash blocks (sparse holes
+	// carry no chunk). No data is moved; this is O(blocks) metadata puts.
+	//
+	// Route the Put through the txn bound in ctx when present. The clone
+	// callers (common.CopyPayload / common.CloneWholeFile) invoke us inside
+	// metadataStore.WithTransaction, which on the memory backend holds the
+	// store mutex for the life of fn; the store-level fileBlockStore.Put would
+	// re-acquire that same (non-reentrant) mutex and self-deadlock. The
+	// tx-bound Put writes under the already-held lock and commits/rolls back
+	// atomically with the caller's dst FileAttr.Blocks PutFile — so the per-file
+	// rows and the FileAttr.Blocks manifest stay consistent. With no bound txn
+	// (e.g. unit tests wiring the engine directly) fall back to the store-level
+	// Put, matching the rollup ObjectIDPersister which runs outside any txn.
+	putRow := func(ctx context.Context, fb *block.FileBlock) error {
+		if tx := metadata.TxFromContext(ctx); tx != nil {
+			return tx.Put(ctx, fb)
+		}
+		return bs.fileBlockStore.Put(ctx, fb)
+	}
+	if bs.fileBlockStore != nil {
+		for _, b := range srcBlocks {
+			if b.Hash.IsZero() {
+				continue
+			}
+			fb := &block.FileBlock{
+				ID:       fmt.Sprintf("%s/%d", dstPayloadID, b.Offset),
+				Hash:     b.Hash,
+				DataSize: b.Size,
+				State:    block.BlockStatePending,
+			}
+			if err := putRow(ctx, fb); err != nil {
+				return nil, fmt.Errorf("CopyPayload: FileBlock.Put(%s): %w", fb.ID, err)
+			}
+		}
+	}
+
 	// Deep-copy the slice (BlockRef is a value type — append over nil
-	// produces a fresh backing array independent of srcBlocks).
+	// produces a fresh backing array independent of srcBlocks). The caller
+	// persists this as dst's FileAttr.Blocks in the same metadata txn, so the
+	// rows above and this manifest stay consistent (same hashes + offsets).
 	dst := append([]block.BlockRef(nil), srcBlocks...)
 
-	// Note: src/dst payloadIDs are kept in the signature for future use
-	// (cache prefetch hints, identity-based dedup) and to match the
-	// public Writer interface; the O(1) implementation does not need
-	// them for the refcount-only fast path.
+	// srcPayloadID is retained in the signature for future use (cache prefetch
+	// hints, identity-based dedup) and to match the public Writer interface.
 	_ = srcPayloadID
-	_ = dstPayloadID
 
 	return dst, nil
 }


### PR DESCRIPTION
## Severity: silent data corruption (found via #1374 follow-up audit)

NFSv4.2 CLONE and SMB server-side-copy route through `engine.CopyPayload`. For any **rolled-up** source file, the clone produced a destination that **reads back as all zeros** — verified on a live VM (NFSv4.2 + badger + S3).

### Root cause (two layers)
1. **EREMOTEIO failure:** `CopyPayload` calls `IncrementRefCount` per source hash and returns the error on failure. CAS blocks are `Pending` and never resolve behind the Remote-gated `GetByHash`, so `IncrementRefCount` returns `ErrFileBlockNotFound` → clone failed loudly.
2. **The corruption:** once that's unblocked, `CopyPayload` only copied the source's `BlockRef` manifest into the destination's `FileAttr.Blocks` and explicitly skipped row creation (`_ = dstPayloadID`). But the cold-read path resolves bytes via `ListFileBlocks(dstPayloadID)` (per-payload FileBlock rows), **not** `FileAttr.Blocks`. No dst rows → zero-fill.

The #1384 unit test missed both because its fake coordinator always succeeds at `IncrementRefCount` and doesn't model the FileBlock store.

### Fix
- Create one dst `FileBlock` row per source block (same hash/offset/size, `Pending`), mirroring `ObjectIDPersister`, so clone reads resolve the shared CAS chunks.
- The row `Put` uses the **context-bound metadata txn** (`TxFromContext`) when present: a store-level `Put` re-enters the memory backend's non-reentrant mutex held by `WithTransaction` and self-deadlocks; the tx-bound `Put` also commits atomically with the caller's dst-manifest persist.
- Tolerate `ErrFileBlockNotFound` from `IncrementRefCount` (the per-hash bump is a no-op in CAS — blocks are kept alive by the manifest + GC mark-sweep, not RefCount). A genuine backend fault still aborts.

### Verification
- **Live VM:** cloned a rolled-up 16 MiB file; after `echo 3 > drop_caches`, `md5(dst) == md5(src)` (real block reads). `Files` went 1→2, dst payload now has its rows.
- Regression test `TestCopyPayload_CreatesDstFileBlockRows` (real FileBlock store) asserts dst rows exist per source block — fails before, passes after. Existing CopyPayload + `CloneWholeFile` tests stay green (the latter previously **hung** without the tx-bound Put).

Refs #1384.