### PR TITLE
fix(netlogon): don't let a DB Kerberos row drop the operator/env machine account or pin stale mount paths (#1392)

### DIFF
--- a/cmd/dfs/commands/netlogon.go
+++ b/cmd/dfs/commands/netlogon.go
@@ -123,6 +123,8 @@ func buildNetlogonAuthenticator(k config.KerberosConfig, secret netlogon.SecretS
 	if !ok {
 		return nil, nil
 	}
+	slog.Info("NETLOGON machine account: offline provider active",
+		"account", ma.AccountName, "dc_addresses", ma.DCAddresses)
 	return netlogon.NewAuthenticator(netlogon.NewMutableProvider(cred)), nil
 }
 

--- a/cmd/dfs/commands/netlogon_test.go
+++ b/cmd/dfs/commands/netlogon_test.go
@@ -201,3 +201,80 @@ func TestKerberosRoundTrip_MachineAccount(t *testing.T) {
 		t.Errorf("DCAddresses: got %v, want %v", ma.DCAddresses, orig.MachineAccount.DCAddresses)
 	}
 }
+
+// TestMergeMachineAccountFromFile_OverlaysOfflineWhenDBLacksIt covers #1392: a
+// DB-sourced Kerberos config with no machine account must inherit the file/env
+// offline credential the operator injected, rather than silently dropping it.
+func TestMergeMachineAccountFromFile_OverlaysOfflineWhenDBLacksIt(t *testing.T) {
+	db := config.KerberosConfig{ // DB row seeded before passthrough was configured
+		Enabled:       true,
+		NetBIOSDomain: "EXAMPLE",
+		Realm:         "EXAMPLE.COM",
+	}
+	file := config.KerberosConfig{
+		MachineAccount: config.MachineAccountConfig{
+			Enabled:     true,
+			AccountName: "DITTOFS$",
+			Secret:      "s3cr3t",
+			DCAddresses: []string{"dc.example.com"},
+		},
+	}
+	got := mergeMachineAccountFromFile(db, file)
+	if !got.MachineAccount.Enabled || got.MachineAccount.AccountName != "DITTOFS$" || got.MachineAccount.Secret != "s3cr3t" {
+		t.Fatalf("offline machine account not overlaid from file: %+v", got.MachineAccount)
+	}
+	// The DB-sourced top-level fields must be preserved.
+	if got.NetBIOSDomain != "EXAMPLE" || got.Realm != "EXAMPLE.COM" {
+		t.Fatalf("DB-sourced fields clobbered: %+v", got)
+	}
+}
+
+// TestMergeMachineAccountFromFile_DBMachineAccountWins verifies an API-configured
+// machine account (present and enabled in the DB row) is NOT overwritten by the
+// file/env credential.
+func TestMergeMachineAccountFromFile_DBMachineAccountWins(t *testing.T) {
+	db := config.KerberosConfig{
+		MachineAccount: config.MachineAccountConfig{
+			Enabled:     true,
+			AccountName: "DBACCOUNT$",
+			Secret:      "db-secret",
+		},
+	}
+	file := config.KerberosConfig{
+		MachineAccount: config.MachineAccountConfig{
+			Enabled:     true,
+			AccountName: "FILEACCOUNT$",
+			Secret:      "file-secret",
+		},
+	}
+	got := mergeMachineAccountFromFile(db, file)
+	if got.MachineAccount.AccountName != "DBACCOUNT$" || got.MachineAccount.Secret != "db-secret" {
+		t.Fatalf("DB machine account should win, got: %+v", got.MachineAccount)
+	}
+}
+
+// TestMergeMachineAccountFromFile_OnlineJoinAlwaysFromFile verifies online-join
+// (privileged, never persisted in the DB DTO) is always sourced from file/env,
+// even when the DB row carries its own offline machine account.
+func TestMergeMachineAccountFromFile_OnlineJoinAlwaysFromFile(t *testing.T) {
+	db := config.KerberosConfig{
+		MachineAccount: config.MachineAccountConfig{
+			Enabled:     true,
+			AccountName: "DBACCOUNT$",
+			Secret:      "db-secret",
+		},
+	}
+	file := config.KerberosConfig{
+		MachineAccount: config.MachineAccountConfig{
+			OnlineJoin: config.OnlineJoinConfig{Enabled: true, LDAPURL: "ldaps://dc.example.com"},
+		},
+	}
+	got := mergeMachineAccountFromFile(db, file)
+	if !got.MachineAccount.OnlineJoin.Enabled || got.MachineAccount.OnlineJoin.LDAPURL != "ldaps://dc.example.com" {
+		t.Fatalf("online-join not overlaid from file: %+v", got.MachineAccount.OnlineJoin)
+	}
+	// DB offline account still wins for the non-online-join fields.
+	if got.MachineAccount.AccountName != "DBACCOUNT$" {
+		t.Fatalf("DB offline account clobbered: %+v", got.MachineAccount)
+	}
+}

--- a/cmd/dfs/commands/netlogon_test.go
+++ b/cmd/dfs/commands/netlogon_test.go
@@ -278,3 +278,56 @@ func TestMergeMachineAccountFromFile_OnlineJoinAlwaysFromFile(t *testing.T) {
 		t.Fatalf("DB offline account clobbered: %+v", got.MachineAccount)
 	}
 }
+
+// TestOverlayDeploymentPaths_FileWinsWhenSet verifies a file/env keytab,
+// krb5.conf, or machine-account keytab path overrides the stale value carried
+// in a DB-sourced Kerberos row. This is the deployment-relocation case: an
+// operator moves the mount and the DB row must not pin the old absolute path.
+func TestOverlayDeploymentPaths_FileWinsWhenSet(t *testing.T) {
+	db := config.KerberosConfig{
+		KeytabPath: "/etc/dittofs/krb5.keytab",
+		Krb5Conf:   "/etc/krb5.conf",
+		MachineAccount: config.MachineAccountConfig{
+			KeytabPath: "/etc/dittofs/machine.keytab",
+		},
+	}
+	file := config.KerberosConfig{
+		KeytabPath: "/kerberos/dittofs.keytab",
+		Krb5Conf:   "/kerberos-krb5/krb5.conf",
+		MachineAccount: config.MachineAccountConfig{
+			KeytabPath: "/kerberos/machine.keytab",
+		},
+	}
+	got := overlayDeploymentPaths(db, file)
+	if got.KeytabPath != "/kerberos/dittofs.keytab" {
+		t.Fatalf("KeytabPath not overlaid: %q", got.KeytabPath)
+	}
+	if got.Krb5Conf != "/kerberos-krb5/krb5.conf" {
+		t.Fatalf("Krb5Conf not overlaid: %q", got.Krb5Conf)
+	}
+	if got.MachineAccount.KeytabPath != "/kerberos/machine.keytab" {
+		t.Fatalf("MachineAccount.KeytabPath not overlaid: %q", got.MachineAccount.KeytabPath)
+	}
+}
+
+// TestOverlayDeploymentPaths_EmptyFileKeepsDB verifies a pure-API deployment
+// (no path in file/env) is unaffected: the DB row's paths are preserved.
+func TestOverlayDeploymentPaths_EmptyFileKeepsDB(t *testing.T) {
+	db := config.KerberosConfig{
+		KeytabPath: "/etc/dittofs/krb5.keytab",
+		Krb5Conf:   "/etc/krb5.conf",
+		MachineAccount: config.MachineAccountConfig{
+			KeytabPath: "/etc/dittofs/machine.keytab",
+		},
+	}
+	got := overlayDeploymentPaths(db, config.KerberosConfig{})
+	if got.KeytabPath != "/etc/dittofs/krb5.keytab" {
+		t.Fatalf("KeytabPath clobbered by empty file: %q", got.KeytabPath)
+	}
+	if got.Krb5Conf != "/etc/krb5.conf" {
+		t.Fatalf("Krb5Conf clobbered by empty file: %q", got.Krb5Conf)
+	}
+	if got.MachineAccount.KeytabPath != "/etc/dittofs/machine.keytab" {
+		t.Fatalf("MachineAccount.KeytabPath clobbered by empty file: %q", got.MachineAccount.KeytabPath)
+	}
+}

--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -529,6 +529,13 @@ func resolveIdentityProviders(ctx context.Context, cpStore store.Store, rt *runt
 	// for the precedence rules (#1392).
 	kerberos = mergeMachineAccountFromFile(kerberos, cfg.Kerberos)
 
+	// Overlay deployment-path fields (keytab / krb5.conf mount paths) from
+	// file/env. These are filesystem-mount concerns the operator controls, not
+	// API-managed identity policy: when a volume mount moves (e.g. an operator
+	// upgrade relocating the keytab), the stale DB-row path must not win and
+	// crash the server on a missing file. See overlayDeploymentPaths.
+	kerberos = overlayDeploymentPaths(kerberos, cfg.Kerberos)
+
 	// Seed the runtime's hot-reloadable NETLOGON machine credential from the
 	// effective Kerberos machine-account config (#1325). nil disables passthrough.
 	// The SMB adapter reads this on an identity-provider config change to rebuild
@@ -569,6 +576,31 @@ func mergeMachineAccountFromFile(effective, file config.KerberosConfig) config.K
 		onlineJoin := effective.MachineAccount.OnlineJoin
 		effective.MachineAccount = file.MachineAccount
 		effective.MachineAccount.OnlineJoin = onlineJoin
+	}
+	return effective
+}
+
+// overlayDeploymentPaths lets the file/env config override the keytab and
+// krb5.conf paths carried in a DB-sourced Kerberos config.
+//
+// Unlike realm / service principal / NetBIOS domain (API-managed identity
+// policy, where the DB row is authoritative), these are filesystem-mount
+// concerns owned by the deployment: where the orchestrator mounts the keytab
+// and krb5.conf volumes. Persisting them as policy means a DB row seeded under
+// one layout pins a stale absolute path; when an operator upgrade relocates the
+// mount (e.g. /etc/dittofs/krb5.keytab -> /kerberos/dittofs.keytab) the server
+// would crashloop on "open ...: no such file". So a non-empty file/env path
+// always wins; an empty one leaves the DB value intact (pure-API deployments
+// that never set a path are unaffected).
+func overlayDeploymentPaths(effective, file config.KerberosConfig) config.KerberosConfig {
+	if file.KeytabPath != "" {
+		effective.KeytabPath = file.KeytabPath
+	}
+	if file.Krb5Conf != "" {
+		effective.Krb5Conf = file.Krb5Conf
+	}
+	if file.MachineAccount.KeytabPath != "" {
+		effective.MachineAccount.KeytabPath = file.MachineAccount.KeytabPath
 	}
 	return effective
 }

--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -524,12 +524,10 @@ func resolveIdentityProviders(ctx context.Context, cpStore store.Store, rt *runt
 		}
 	}
 
-	// Online-join is a server-bootstrap concern carrying privileged LDAP join
-	// credentials, so it is intentionally NOT part of the API-managed Kerberos
-	// DTO (which would persist the bind password in the DB and expose it over
-	// REST). Always source it from the file/env config and overlay it onto the
-	// effective config, so a DB-sourced Kerberos row never silently drops it.
-	kerberos.MachineAccount.OnlineJoin = cfg.Kerberos.MachineAccount.OnlineJoin
+	// Overlay the operator/env-injected machine-account config onto the
+	// effective (DB-sourced) Kerberos config. See mergeMachineAccountFromFile
+	// for the precedence rules (#1392).
+	kerberos = mergeMachineAccountFromFile(kerberos, cfg.Kerberos)
 
 	// Seed the runtime's hot-reloadable NETLOGON machine credential from the
 	// effective Kerberos machine-account config (#1325). nil disables passthrough.
@@ -544,6 +542,35 @@ func resolveIdentityProviders(ctx context.Context, cpStore store.Store, rt *runt
 	}
 
 	return kerberos
+}
+
+// mergeMachineAccountFromFile overlays the operator/env-injected machine-account
+// configuration onto the effective Kerberos config (which is DB-sourced when a
+// control-plane row exists, else the file/env config itself).
+//
+// Two precedence rules, both rooted in the fact that machine-account credentials
+// arrive out-of-band (the online-join bind password and the offline machine
+// secret are injected via the config file / DITTOFS_KERBEROS_MACHINE_ACCOUNT_*
+// env), NOT through the API-managed Kerberos DTO that backs the DB row:
+//
+//   - Online-join carries a privileged LDAP bind password and is intentionally
+//     never persisted in the DB DTO, so it is ALWAYS sourced from file/env.
+//   - The offline machine account (account name + secret) is overlaid from
+//     file/env only when the effective config does not already enable one. This
+//     fixes #1392: a DB Kerberos row seeded before NTLM passthrough was
+//     configured carries no machine_account and would otherwise overwrite (drop)
+//     the file/env credential the operator injected, silently disabling
+//     passthrough. A machine account configured explicitly via the API (present
+//     and enabled in the DB row) still wins.
+func mergeMachineAccountFromFile(effective, file config.KerberosConfig) config.KerberosConfig {
+	effective.MachineAccount.OnlineJoin = file.MachineAccount.OnlineJoin
+
+	if !effective.MachineAccount.Enabled && file.MachineAccount.Enabled {
+		onlineJoin := effective.MachineAccount.OnlineJoin
+		effective.MachineAccount = file.MachineAccount
+		effective.MachineAccount.OnlineJoin = onlineJoin
+	}
+	return effective
 }
 
 func kerberosConfigToDTO(c config.KerberosConfig) handlers.KerberosConfigDTO {


### PR DESCRIPTION
Fixes #1392.

`resolveIdentityProviders` (start.go) lets a DB-sourced Kerberos identity-provider row overwrite the file/env config wholesale. Two real footguns follow, both surfaced live on demo.dittofs.io during the v0.22.0 upgrade. This PR closes both.

## Bug 1 — operator/env machine account silently dropped

A DB row seeded before NTLM passthrough was configured carries no `machine_account`. The wholesale overwrite overlaid **only** `MachineAccount.OnlineJoin` back, so the operator's file/env offline credential (`identity.kerberos.machineAccount` → config file + `DITTOFS_KERBEROS_MACHINE_ACCOUNT_SECRET`) was silently dropped — `buildNetlogonAuthenticator` returned nil, passthrough stayed off, and domain-user NTLM logon failed with `STATUS_LOGON_FAILURE` and **no diagnostic** (the offline build path was silent).

**Fix:** new pure helper `mergeMachineAccountFromFile(effective, file)`:
- online-join is **always** sourced from file/env (privileged LDAP bind password, never persisted in the API DTO) — unchanged behavior.
- the **offline** machine account is overlaid from file/env **only when the effective config doesn't already enable one**, so an API-configured machine account in the DB still wins.
- `buildNetlogonAuthenticator` now logs `NETLOGON machine account: offline provider active` (previously silent).

## Bug 2 — stale keytab / krb5.conf mount paths pinned by the DB row

`KeytabPath`, `Krb5Conf`, and `MachineAccount.KeytabPath` are filesystem-deployment concerns the orchestrator owns, not API-managed identity policy — but they were persisted in the DB row like policy. When an operator upgrade relocates a mount (e.g. `/etc/dittofs/krb5.keytab` → `/kerberos/dittofs.keytab`), the stale DB path wins and the server **crashloops** on `open ...: no such file`. Same root cause as Bug 1: DB row clobbers file/env.

**Fix:** `overlayDeploymentPaths(effective, file)` lets a non-empty file/env keytab / krb5.conf path override the DB value; an empty one leaves the DB value intact (pure-API deployments unaffected).

## Tests

`go test ./cmd/dfs/commands/` green; `go vet` + `gofmt` clean.
- `mergeMachineAccountFromFile`: offline overlaid when DB lacks it (Bug 1), DB machine account wins when present, online-join always from file.
- `overlayDeploymentPaths`: file path wins when set (Bug 2 relocation case), empty file keeps DB value.