### PR TITLE
docs(smb-acl): SID→name (#236) and foreign-AD-SID (#1231) are shipped, not Unsupported

### DIFF
--- a/docs/guide/smb-acl-fidelity.md
+++ b/docs/guide/smb-acl-fidelity.md
@@ -114,9 +114,9 @@ Tracked alongside the broader cross-protocol SACL gap in
 
 | Aspect | State | Notes |
 |--------|-------|-------|
-| Foreign domain SID on write | Unsupported / out of scope | A SID not in this machine's domain is not decodable to a local UID/GID. As an owner/group it is ignored; inside a DACL ACE it round-trips as the `sid:<canonical>` principal form (preserved verbatim by `SIDToPrincipal`/`PrincipalToSID`), so the ACE is kept but the SID maps to no local identity. Real AD integration is tracked by [#1231](https://github.com/marmos91/dittofs/issues/1231). |
+| Foreign domain SID → local UID/GID (write) | Unsupported / out of scope | A SID outside the joined domain is not decodable to a local UID/GID. As an owner/group it is ignored; inside a DACL ACE it round-trips as the `sid:<canonical>` principal form (preserved verbatim by `SIDToPrincipal`/`PrincipalToSID`), so the ACE is kept but the SID maps to no local UID/GID. AD integration shipped under [#1231](https://github.com/marmos91/dittofs/issues/1231) (Kerberos/NTLM logon, NETLOGON machine credential, `idmap_rid` for the *joined* domain); mapping a *foreign* (non-joined) domain SID to a local UID/GID remains out of scope. Foreign-SID → **name** display does resolve — see below. |
 | Named NFS principal → SID (e.g. `alice@EXAMPLE.COM`) | Partial (lossy) | `PrincipalToSID` synthesizes a hash-based fallback SID (full 32-bit hash as a 6th sub-authority) so it is NOT decodable back to a numeric UID and round-trips through `sid:`. Deterministic but not a real AD SID. |
-| SID → name resolution (display) | Unsupported | Raw SIDs are shown by Windows when no LSA name lookup is available; tracked by [#236](https://github.com/marmos91/dittofs/issues/236). |
+| SID → name resolution (display) | Works | LSA `\pipe\lsarpc` is implemented (`internal/adapter/smb/rpc/lsarpc.go`, all 7 ops incl. `LsarLookupSids2/3`, `LsarOpenPolicy3`). Windows Explorer's Security tab resolves machine-domain user/group SIDs and well-known SIDs to names; foreign AD-domain SIDs resolve via the foreign resolver (`pkg/adapter/smb/lsarpc_foreign.go`). Shipped under [#236](https://github.com/marmos91/dittofs/issues/236) / [#1341](https://github.com/marmos91/dittofs/issues/1341). |
 
 ## Unmappable-SID-on-write behavior
 
@@ -151,9 +151,10 @@ project memory):
   the Phase 31/32 Windows integration work: explicit-Deny synthesis was removed
   in favor of Allow-only DACLs (Samba convention) so Explorer no longer shows
   spurious "Write: Deny"; CREATE-context (MxAc) parsing and SET_INFO attribute
-  persistence (Hidden/ReadOnly) were fixed. SID-to-name resolution is still
-  open ([#236](https://github.com/marmos91/dittofs/issues/236)), so Explorer can
-  display raw SIDs instead of names.
+  persistence (Hidden/ReadOnly) were fixed. SID-to-name resolution is
+  implemented (LSA `lsarpc` pipe, [#236](https://github.com/marmos91/dittofs/issues/236)),
+  so Explorer resolves user/group and well-known SIDs to names; raw SIDs appear
+  only for principals with no directory entry.
 - **AD / Kerberos SMB.** `alice@REALM` → uid 10001 verified live against an
   AD-DC over Kerberos-bound SMB (idmap_rid SID→UID), confirming the
   domain-SID derivation in `mapper.go` end-to-end for the local-domain case.
@@ -170,14 +171,20 @@ project memory):
    (empty SACL on QUERY_INFO; SACL offset skipped on SET_INFO). AUDIT ACEs can
    be stored in the model but never reach a SMB client; ALARM ACEs have no
    Windows mapping and are dropped.
-2. **Foreign AD/LDAP SIDs are not mapped to local identities.** They round-trip
+2. **Foreign AD/LDAP SIDs are not mapped to local UID/GID.** They round-trip
    as opaque `sid:<canonical>` principals (so the ACE survives) but resolve to
-   no UID/GID. Full AD interop is [#1231](https://github.com/marmos91/dittofs/issues/1231).
+   no local UID/GID. AD interop shipped under [#1231](https://github.com/marmos91/dittofs/issues/1231)
+   (logon + `idmap_rid` for the joined domain); foreign-SID → local-UID idmap
+   specifically stays out of scope. Foreign-SID → **name** display does resolve
+   via `lsarpc` (see limitation 4).
 3. **Hash-based fallback SIDs for named principals are lossy.** Deterministic
    but not real AD SIDs; collisions are vanishingly rare but theoretically
    possible.
-4. **No LSA SID→name pipe.** Windows Explorer may show raw SIDs
-   ([#236](https://github.com/marmos91/dittofs/issues/236)).
+4. **LSA SID→name pipe is implemented** ([#236](https://github.com/marmos91/dittofs/issues/236),
+   `internal/adapter/smb/rpc/lsarpc.go`). Explorer resolves machine-domain and
+   well-known SIDs — and foreign AD-domain SIDs via the foreign resolver
+   (`pkg/adapter/smb/lsarpc_foreign.go`) — to names. Raw SIDs appear only for
+   principals with no directory entry.
 5. **nil-ACL access enforcement uses POSIX mode, not the synthesized DACL.**
    The `SynthesizeWindowsDefault` DACL shown to SMB clients for nil-ACL files is
    display-only; server-side access checks fall back to Unix mode bits, which
@@ -188,8 +195,8 @@ project memory):
 ## References
 
 - [#1228](https://github.com/marmos91/dittofs/issues/1228) — Windows-ACL / stable-handle fidelity (this matrix).
-- [#1231](https://github.com/marmos91/dittofs/issues/1231) — foreign AD/LDAP SID mapping.
-- [#236](https://github.com/marmos91/dittofs/issues/236) — SID-to-name (LSA) resolution.
+- [#1231](https://github.com/marmos91/dittofs/issues/1231) — AD/LDAP enterprise integration (shipped).
+- [#236](https://github.com/marmos91/dittofs/issues/236) — SID-to-name (LSA) resolution (shipped).
 - [Access Control](access-control.md) — cross-protocol ACL model and tradeoff analysis.
 - [MS-DTYP §2.4.4–2.4.6](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/) — SID / ACE / ACL / Security Descriptor formats.
 - [RFC 7530 §6](https://www.rfc-editor.org/rfc/rfc7530#section-6) — NFSv4 ACL model.


### PR DESCRIPTION
The SMB ACL fidelity matrix (`docs/guide/smb-acl-fidelity.md`) still listed **SID→name resolution (#236)** and **foreign-AD-domain SID mapping (#1231)** as *Unsupported / open*, but both shipped:

- LSA `\pipe\lsarpc` is fully implemented (`internal/adapter/smb/rpc/lsarpc.go`, all 7 ops incl. `LsarLookupSids2/3`, `LsarOpenPolicy3`).
- Foreign-AD-domain SIDs resolve via `pkg/adapter/smb/lsarpc_foreign.go`.

Verified live: `rpcclient lookupsids` against a running server resolves a machine-domain owner SID to `DOMAIN\user` via the reverse-UID→LDAP path.

Changes:
- Flip the SID→name and foreign-SID rows from Unsupported → Works, with code references.
- Keep foreign-SID → **local-UID idmap** (owner/group *write*) as out of scope — only **name display** resolves.
- Update the "Client-tested", "Known limitations", and "References" sections accordingly.

Doc-only.