### PR TITLE
fix(security): remove hardcoded S3 creds from demo script, add gitleaks CI

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,28 @@
+name: Secret Scan
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop, main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Full history so gitleaks scans every commit, not just the tip.
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -2,7 +2,7 @@ name: Secret Scan
 
 on:
   push:
-    branches: [develop]
+    branches: [develop, main]
   pull_request:
     branches: [develop, main]
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,14 @@
+# gitleaks config — extends the built-in ruleset.
+# https://github.com/gitleaks/gitleaks
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Known-safe placeholders and example values"
+regexes = [
+  # AWS's official documentation example key — not a real credential.
+  '''AKIAIOSFODNN7EXAMPLE''',
+  '''wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY''',
+  # Localstack / test fixtures use literal "test" credentials.
+  '''(?i)(access|secret)[_-]?key["'\s:=]+test["']''',
+]

--- a/scripts/setup-dittofs-demo.sh
+++ b/scripts/setup-dittofs-demo.sh
@@ -24,11 +24,13 @@ CONFIG_FILE="${CONFIG_DIR}/config.yaml"
 GO_VERSION="1.25.0"
 ADMIN_PASSWORD="$(openssl rand -base64 16)"
 
-# Cubbit DS3 S3 credentials
-S3_ENDPOINT="https://s3.cubbit.eu"
-S3_BUCKET="dittofs-demo"
-S3_ACCESS_KEY="dxp2eUyJ+fK307J+aqreAoy63rh4w4+B"
-S3_SECRET_KEY="6XxMNrcAXk/vvMzM11PTsZqfZ5jG3e8gkUVBnhi6g/k="
+# Cubbit DS3 S3 credentials — supplied via environment, never hardcoded.
+# Export these before running:
+#   export S3_ACCESS_KEY=... S3_SECRET_KEY=...
+S3_ENDPOINT="${S3_ENDPOINT:-https://s3.cubbit.eu}"
+S3_BUCKET="${S3_BUCKET:-dittofs-demo}"
+S3_ACCESS_KEY="${S3_ACCESS_KEY:?Set S3_ACCESS_KEY in the environment}"
+S3_SECRET_KEY="${S3_SECRET_KEY:?Set S3_SECRET_KEY in the environment}"
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/scripts/setup-dittofs-demo.sh
+++ b/scripts/setup-dittofs-demo.sh
@@ -7,7 +7,10 @@
 #   - Local SSD attached at /dev/sda1
 #
 # Usage:
-#   sudo ./setup-dittofs-demo.sh [tarball-path]
+#   sudo S3_ACCESS_KEY=... S3_SECRET_KEY=... ./setup-dittofs-demo.sh [tarball-path]
+#
+#   (Pass the S3 vars through sudo as shown — a plain `export` in your shell
+#   is stripped by sudo, and the script will then refuse to start.)
 
 set -euo pipefail
 


### PR DESCRIPTION
## What

The demo setup script `scripts/setup-dittofs-demo.sh` hardcoded **live Cubbit DS3 S3 access + secret keys** (committed since v0.9.3, public on `main`/`develop`).

## Changes

- **`scripts/setup-dittofs-demo.sh`** — read `S3_ACCESS_KEY` / `S3_SECRET_KEY` from the environment with `${VAR:?}` fail-fast checks; `S3_ENDPOINT` / `S3_BUCKET` keep sensible defaults. No credentials in the tree.
- **`.github/workflows/secret-scan.yml`** — gitleaks on push/PR to `develop`/`main`, `fetch-depth: 0` full-history scan.
- **`.gitleaks.toml`** — extends the default ruleset, allowlists known-safe placeholders (AWS `AKIAIOSFODNN7EXAMPLE`, localstack test creds).

## Status

- ✅ Leaked keys **rotated** — the old values are now dead.
- ✅ Full repo audit (two independent sweeps): this was the only real leak.
- ⏭️ git history **not** rewritten — keys rotated = inert; rewrite would touch 30 release tags + ~70 branches/active worktrees for cosmetic gain. Revisit only if compliance requires expungement.