### PR TITLE
docs(cli): fix garbled command-help rendering on the docs site

### DIFF
--- a/cmd/dfs/commands/completion.go
+++ b/cmd/dfs/commands/completion.go
@@ -11,37 +11,31 @@ var completionCmd = &cobra.Command{
 	Short: "Generate shell completion script",
 	Long: `Generate shell completion script for dfs.
 
-To load completions:
+The generated script enables tab-completion for dfs commands, subcommands, and
+flags in your shell. Pick the snippet for your shell and load it once.
 
-Bash:
-  # Linux:
-  $ dfs completion bash > /etc/bash_completion.d/dfs
-  # macOS:
-  $ dfs completion bash > $(brew --prefix)/etc/bash_completion.d/dfs
+Examples:
+  # Bash (Linux): install system-wide
+  dfs completion bash > /etc/bash_completion.d/dfs
 
-Zsh:
-  # If shell completion is not already enabled in your environment,
-  # you will need to enable it. You can execute the following once:
-  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+  # Bash (macOS, requires the Homebrew bash-completion package)
+  dfs completion bash > $(brew --prefix)/etc/bash_completion.d/dfs
 
-  # To load completions for each session, execute once:
-  # Linux:
-  $ dfs completion zsh > "${fpath[1]}/_dfs"
-  # macOS:
-  $ dfs completion zsh > $(brew --prefix)/share/zsh/site-functions/_dfs
+  # Zsh: enable completion once (if not already enabled), then install
+  echo "autoload -U compinit; compinit" >> ~/.zshrc
+  dfs completion zsh > "${fpath[1]}/_dfs"
 
-  # You will need to start a new shell for this setup to take effect.
+  # Zsh (macOS, Homebrew)
+  dfs completion zsh > $(brew --prefix)/share/zsh/site-functions/_dfs
 
-Fish:
-  $ dfs completion fish > ~/.config/fish/completions/dfs.fish
+  # Fish
+  dfs completion fish > ~/.config/fish/completions/dfs.fish
 
-PowerShell:
-  PS> dfs completion powershell | Out-String | Invoke-Expression
+  # PowerShell: load for the current session
+  dfs completion powershell | Out-String | Invoke-Expression
 
-  # To load completions for every new session, run:
-  PS> dfs completion powershell > dfs.ps1
-  # and source this file from your PowerShell profile.
-`,
+  # PowerShell: persist across sessions by sourcing from your profile
+  dfs completion powershell > dfs.ps1`,
 	DisableFlagsInUseLine: true,
 	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),

--- a/cmd/dfsctl/commands/completion.go
+++ b/cmd/dfsctl/commands/completion.go
@@ -11,37 +11,31 @@ var completionCmd = &cobra.Command{
 	Short: "Generate shell completion script",
 	Long: `Generate shell completion script for dfsctl.
 
-To load completions:
+The generated script enables tab-completion for dfsctl commands, subcommands,
+and flags in your shell. Pick the snippet for your shell and load it once.
 
-Bash:
-  # Linux:
-  $ dfsctl completion bash > /etc/bash_completion.d/dfsctl
-  # macOS:
-  $ dfsctl completion bash > $(brew --prefix)/etc/bash_completion.d/dfsctl
+Examples:
+  # Bash (Linux): install system-wide
+  dfsctl completion bash > /etc/bash_completion.d/dfsctl
 
-Zsh:
-  # If shell completion is not already enabled in your environment,
-  # you will need to enable it. You can execute the following once:
-  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+  # Bash (macOS, requires the Homebrew bash-completion package)
+  dfsctl completion bash > $(brew --prefix)/etc/bash_completion.d/dfsctl
 
-  # To load completions for each session, execute once:
-  # Linux:
-  $ dfsctl completion zsh > "${fpath[1]}/_dfsctl"
-  # macOS:
-  $ dfsctl completion zsh > $(brew --prefix)/share/zsh/site-functions/_dfsctl
+  # Zsh: enable completion once (if not already enabled), then install
+  echo "autoload -U compinit; compinit" >> ~/.zshrc
+  dfsctl completion zsh > "${fpath[1]}/_dfsctl"
 
-  # You will need to start a new shell for this setup to take effect.
+  # Zsh (macOS, Homebrew)
+  dfsctl completion zsh > $(brew --prefix)/share/zsh/site-functions/_dfsctl
 
-Fish:
-  $ dfsctl completion fish > ~/.config/fish/completions/dfsctl.fish
+  # Fish
+  dfsctl completion fish > ~/.config/fish/completions/dfsctl.fish
 
-PowerShell:
-  PS> dfsctl completion powershell | Out-String | Invoke-Expression
+  # PowerShell: load for the current session
+  dfsctl completion powershell | Out-String | Invoke-Expression
 
-  # To load completions for every new session, run:
-  PS> dfsctl completion powershell > dfsctl.ps1
-  # and source this file from your PowerShell profile.
-`,
+  # PowerShell: persist across sessions by sourcing from your profile
+  dfsctl completion powershell > dfsctl.ps1`,
 	DisableFlagsInUseLine: true,
 	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),

--- a/cmd/dfsctl/commands/share/mount.go
+++ b/cmd/dfsctl/commands/share/mount.go
@@ -33,10 +33,20 @@ var mountCmd = &cobra.Command{
 	Long: `Mount a DittoFS share at a local mount point using NFS or SMB protocol.
 
 For SMB mounts, credentials are resolved in order:
-  1. --username/--password flags
-  2. DITTOFS_PASSWORD environment variable (for password)
-  3. Current login context username
-  4. Interactive password prompt
+
+1. --username/--password flags
+2. DITTOFS_PASSWORD environment variable (for password)
+3. Current login context username
+4. Interactive password prompt
+
+Mount commands typically require sudo/root privileges on Unix systems.
+
+Platform differences for SMB with sudo:
+
+- Linux: mount owner set to your user via uid/gid options (default mode 0755)
+- macOS: mount owned by root (uid/gid removed in Catalina), default mode 0777
+- macOS alternative: mount to ~/mnt without sudo for a user-owned mount
+- Windows: uses 'net use' to map network drives (e.g. dfsctl share mount /export --protocol smb Z:)
 
 Examples:
   # Mount via NFS
@@ -52,15 +62,7 @@ Examples:
   DITTOFS_PASSWORD=secret dfsctl share mount /export --protocol smb /mnt/dittofs
 
   # Mount to user directory without sudo (macOS only, recommended)
-  mkdir -p ~/mnt/dittofs && dfsctl share mount /export --protocol smb ~/mnt/dittofs
-
-Note: Mount commands typically require sudo/root privileges on Unix systems.
-
-Platform differences for SMB with sudo:
-  - Linux: Mount owner set to your user via uid/gid options (default mode 0755)
-  - macOS: Mount owned by root (uid/gid removed in Catalina), default mode 0777
-  - macOS alternative: mount to ~/mnt without sudo for user-owned mount
-  - Windows: Uses 'net use' to map network drives (e.g., dfsctl share mount /export --protocol smb Z:)`,
+  mkdir -p ~/mnt/dittofs && dfsctl share mount /export --protocol smb ~/mnt/dittofs`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
 			return fmt.Errorf("requires share path and mount point\n\nUsage: dfsctl share mount [share] [mountpoint] --protocol <nfs|smb>\n\nExample: dfsctl share mount --protocol nfs /export /mnt/dittofs")

--- a/cmd/gendocs/main.go
+++ b/cmd/gendocs/main.go
@@ -116,6 +116,43 @@ func dedent(s string) string {
 	return strings.Join(lines, "\n")
 }
 
+// renderDesc emits a command description, fencing any indented, pre-formatted
+// run (aligned subcommand tables, option lists, numbered steps) that Cobra Long
+// strings conventionally use. Without fencing, Markdown/MDX collapses the
+// leading whitespace and runs every line together. Non-indented prose is left
+// as prose so it wraps and renders normally.
+func renderDesc(buf *bytes.Buffer, desc string) {
+	indented := func(s string) bool {
+		return strings.HasPrefix(s, "  ") || strings.HasPrefix(s, "\t")
+	}
+	lines := strings.Split(desc, "\n")
+	for i := 0; i < len(lines); {
+		if indented(lines[i]) {
+			// Extend the run over indented lines and any interior blank lines,
+			// trimming trailing blanks so they don't pad the fence.
+			j, last := i, i
+			for j < len(lines) && (indented(lines[j]) || strings.TrimSpace(lines[j]) == "") {
+				if indented(lines[j]) {
+					last = j
+				}
+				j++
+			}
+			fmt.Fprintf(buf, "```\n%s\n```\n\n", dedent(strings.Join(lines[i:last+1], "\n")))
+			i = last + 1
+			continue
+		}
+		// Gather a prose run up to the next indented line.
+		j := i
+		for j < len(lines) && !indented(lines[j]) {
+			j++
+		}
+		if prose := strings.TrimSpace(strings.Join(lines[i:j], "\n")); prose != "" {
+			fmt.Fprintf(buf, "%s\n\n", prose)
+		}
+		i = j
+	}
+}
+
 // anchor slugifies a command path the way GitHub-flavored Markdown anchors
 // section headers: lowercase, backticks dropped, spaces to hyphens.
 func anchor(path string) string {
@@ -140,8 +177,8 @@ func writeCommand(buf *bytes.Buffer, c *cobra.Command) {
 	// it out so the prose renders as prose and the commands render as a fenced,
 	// highlighted code block (instead of headings + smart-quoted dashes).
 	desc, embeddedExamples := splitExamples(c.Long)
-	if desc != "" && strings.TrimSpace(desc) != strings.TrimSpace(c.Short) {
-		fmt.Fprintf(buf, "%s\n\n", strings.TrimSpace(desc))
+	if d := strings.TrimSpace(desc); d != "" && d != strings.TrimSpace(c.Short) {
+		renderDesc(buf, desc)
 	}
 
 	if c.Runnable() {

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -48,39 +48,37 @@ Generate shell completion script
 
 Generate shell completion script for dfs.
 
-To load completions:
-
-Bash:
-  # Linux:
-  $ dfs completion bash > /etc/bash_completion.d/dfs
-  # macOS:
-  $ dfs completion bash > $(brew --prefix)/etc/bash_completion.d/dfs
-
-Zsh:
-  # If shell completion is not already enabled in your environment,
-  # you will need to enable it. You can execute the following once:
-  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
-
-  # To load completions for each session, execute once:
-  # Linux:
-  $ dfs completion zsh > "${fpath[1]}/_dfs"
-  # macOS:
-  $ dfs completion zsh > $(brew --prefix)/share/zsh/site-functions/_dfs
-
-  # You will need to start a new shell for this setup to take effect.
-
-Fish:
-  $ dfs completion fish > ~/.config/fish/completions/dfs.fish
-
-PowerShell:
-  PS> dfs completion powershell | Out-String | Invoke-Expression
-
-  # To load completions for every new session, run:
-  PS> dfs completion powershell > dfs.ps1
-  # and source this file from your PowerShell profile.
+The generated script enables tab-completion for dfs commands, subcommands, and
+flags in your shell. Pick the snippet for your shell and load it once.
 
 ```
 dfs completion [bash|zsh|fish|powershell]
+```
+
+**Examples:**
+
+```bash
+# Bash (Linux): install system-wide
+dfs completion bash > /etc/bash_completion.d/dfs
+
+# Bash (macOS, requires the Homebrew bash-completion package)
+dfs completion bash > $(brew --prefix)/etc/bash_completion.d/dfs
+
+# Zsh: enable completion once (if not already enabled), then install
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+dfs completion zsh > "${fpath[1]}/_dfs"
+
+# Zsh (macOS, Homebrew)
+dfs completion zsh > $(brew --prefix)/share/zsh/site-functions/_dfs
+
+# Fish
+dfs completion fish > ~/.config/fish/completions/dfs.fish
+
+# PowerShell: load for the current session
+dfs completion powershell | Out-String | Invoke-Expression
+
+# PowerShell: persist across sessions by sourcing from your profile
+dfs completion powershell > dfs.ps1
 ```
 
 Global flags:
@@ -1802,39 +1800,37 @@ Generate shell completion script
 
 Generate shell completion script for dfsctl.
 
-To load completions:
-
-Bash:
-  # Linux:
-  $ dfsctl completion bash > /etc/bash_completion.d/dfsctl
-  # macOS:
-  $ dfsctl completion bash > $(brew --prefix)/etc/bash_completion.d/dfsctl
-
-Zsh:
-  # If shell completion is not already enabled in your environment,
-  # you will need to enable it. You can execute the following once:
-  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
-
-  # To load completions for each session, execute once:
-  # Linux:
-  $ dfsctl completion zsh > "${fpath[1]}/_dfsctl"
-  # macOS:
-  $ dfsctl completion zsh > $(brew --prefix)/share/zsh/site-functions/_dfsctl
-
-  # You will need to start a new shell for this setup to take effect.
-
-Fish:
-  $ dfsctl completion fish > ~/.config/fish/completions/dfsctl.fish
-
-PowerShell:
-  PS> dfsctl completion powershell | Out-String | Invoke-Expression
-
-  # To load completions for every new session, run:
-  PS> dfsctl completion powershell > dfsctl.ps1
-  # and source this file from your PowerShell profile.
+The generated script enables tab-completion for dfsctl commands, subcommands,
+and flags in your shell. Pick the snippet for your shell and load it once.
 
 ```
 dfsctl completion [bash|zsh|fish|powershell]
+```
+
+**Examples:**
+
+```bash
+# Bash (Linux): install system-wide
+dfsctl completion bash > /etc/bash_completion.d/dfsctl
+
+# Bash (macOS, requires the Homebrew bash-completion package)
+dfsctl completion bash > $(brew --prefix)/etc/bash_completion.d/dfsctl
+
+# Zsh: enable completion once (if not already enabled), then install
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+dfsctl completion zsh > "${fpath[1]}/_dfsctl"
+
+# Zsh (macOS, Homebrew)
+dfsctl completion zsh > $(brew --prefix)/share/zsh/site-functions/_dfsctl
+
+# Fish
+dfsctl completion fish > ~/.config/fish/completions/dfsctl.fish
+
+# PowerShell: load for the current session
+dfsctl completion powershell | Out-String | Invoke-Expression
+
+# PowerShell: persist across sessions by sourcing from your profile
+dfsctl completion powershell > dfsctl.ps1
 ```
 
 Global flags:

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -96,10 +96,13 @@ Manage DittoFS configuration files.
 Use 'dfs init' to create a new configuration file.
 
 Subcommands:
-  edit      Open configuration in editor
-  validate  Validate configuration file
-  show      Display current configuration
-  schema    Generate JSON schema for IDE/validation
+
+```
+edit      Open configuration in editor
+validate  Validate configuration file
+show      Display current configuration
+schema    Generate JSON schema for IDE/validation
+```
 
 Global flags:
 
@@ -142,9 +145,12 @@ Generate JSON schema for configuration
 Generate a JSON schema for the DittoFS configuration file.
 
 The schema can be used for:
-  - IDE autocompletion (VS Code, IntelliJ, etc.)
-  - Configuration file validation
-  - Documentation generation
+
+```
+- IDE autocompletion (VS Code, IntelliJ, etc.)
+- Configuration file validation
+- Documentation generation
+```
 
 ```
 dfs config schema [flags]
@@ -1512,12 +1518,15 @@ Benchmark DittoFS storage tier performance by measuring read throughput at each 
 The workload writes a file through the NFS/SMB mount, then reads it back three times — evicting a different cache layer before each read — to isolate cold (remote store), warm (local + read buffer), and local-only performance. Admin authentication is required to call the eviction API between reads. The share must have a remote block store configured for cold-read testing.
 
 Steps executed per file size:
-  1. Write via mount
-  2. Evict all (read buffer + local store)
-  3. Cold read (data fetched from remote store)
-  4. Warm read (data in read buffer + local store)
-  5. Evict read buffer only
-  6. Local-only read (data served from local FS store)
+
+```
+1. Write via mount
+2. Evict all (read buffer + local store)
+3. Cold read (data fetched from remote store)
+4. Warm read (data in read buffer + local store)
+5. Evict read buffer only
+6. Local-only read (data served from local FS store)
+```
 
 ```
 dfsctl bench storage-tiers [flags]
@@ -2788,9 +2797,11 @@ local DittoFS user accounts. Mappings are shared across NFS and SMB, ensuring
 consistent uid/gid resolution in mixed-protocol deployments. Supported principal
 formats include:
 
-  NFS/Kerberos:  alice@EXAMPLE.COM
-  SMB/NTLM:      CORP\alice
-  SMB/Kerberos:  alice@CORP.COM
+```
+NFS/Kerberos:  alice@EXAMPLE.COM
+SMB/NTLM:      CORP\alice
+SMB/Kerberos:  alice@CORP.COM
+```
 
 Use "dfsctl idmap sid" to inspect the separate table of foreign-SID to
 Unix UID/GID allocations managed automatically by Active Directory resolution.
@@ -4290,10 +4301,20 @@ Mount a share via NFS or SMB
 Mount a DittoFS share at a local mount point using NFS or SMB protocol.
 
 For SMB mounts, credentials are resolved in order:
-  1. --username/--password flags
-  2. DITTOFS_PASSWORD environment variable (for password)
-  3. Current login context username
-  4. Interactive password prompt
+
+1. --username/--password flags
+2. DITTOFS_PASSWORD environment variable (for password)
+3. Current login context username
+4. Interactive password prompt
+
+Mount commands typically require sudo/root privileges on Unix systems.
+
+Platform differences for SMB with sudo:
+
+- Linux: mount owner set to your user via uid/gid options (default mode 0755)
+- macOS: mount owned by root (uid/gid removed in Catalina), default mode 0777
+- macOS alternative: mount to ~/mnt without sudo for a user-owned mount
+- Windows: uses 'net use' to map network drives (e.g. dfsctl share mount /export --protocol smb Z:)
 
 ```
 dfsctl share mount [share] [mountpoint] [flags]
@@ -4302,28 +4323,20 @@ dfsctl share mount [share] [mountpoint] [flags]
 **Examples:**
 
 ```bash
-  # Mount via NFS
-  dfsctl share mount /export --protocol nfs /mnt/dittofs
+# Mount via NFS
+dfsctl share mount /export --protocol nfs /mnt/dittofs
 
-  # Mount via SMB
-  dfsctl share mount /export --protocol smb /mnt/dittofs
+# Mount via SMB
+dfsctl share mount /export --protocol smb /mnt/dittofs
 
-  # Mount via SMB with explicit credentials
-  dfsctl share mount /export --protocol smb --username alice /mnt/dittofs
+# Mount via SMB with explicit credentials
+dfsctl share mount /export --protocol smb --username alice /mnt/dittofs
 
-  # Mount via SMB with password from environment
-  DITTOFS_PASSWORD=secret dfsctl share mount /export --protocol smb /mnt/dittofs
+# Mount via SMB with password from environment
+DITTOFS_PASSWORD=secret dfsctl share mount /export --protocol smb /mnt/dittofs
 
-  # Mount to user directory without sudo (macOS only, recommended)
-  mkdir -p ~/mnt/dittofs && dfsctl share mount /export --protocol smb ~/mnt/dittofs
-
-Note: Mount commands typically require sudo/root privileges on Unix systems.
-
-Platform differences for SMB with sudo:
-  - Linux: Mount owner set to your user via uid/gid options (default mode 0755)
-  - macOS: Mount owned by root (uid/gid removed in Catalina), default mode 0777
-  - macOS alternative: mount to ~/mnt without sudo for user-owned mount
-  - Windows: Uses 'net use' to map network drives (e.g., dfsctl share mount /export --protocol smb Z:)
+# Mount to user directory without sudo (macOS only, recommended)
+mkdir -p ~/mnt/dittofs && dfsctl share mount /export --protocol smb ~/mnt/dittofs
 ```
 
 Flags:
@@ -4529,10 +4542,13 @@ Grant a permission level to a user or group on a share.
 Specify exactly one of --user or --group together with --level. Re-running
 the command on a principal that already has a permission replaces the existing
 level. Permission levels in order of increasing access:
-  - none:       No access (explicitly blocks the principal)
-  - read:       Read-only access
-  - read-write: Read and write access
-  - admin:      Full administrative access including ACL management
+
+```
+- none:       No access (explicitly blocks the principal)
+- read:       Read-only access
+- read-write: Read and write access
+- admin:      Full administrative access including ACL management
+```
 
 ```
 dfsctl share permission grant <share> [flags]
@@ -5584,7 +5600,9 @@ whose LastModified is older than the configured grace period (default
 1h). The last-run.json summary is persisted under the share's gc-state
 directory and can be inspected with:
 
-  dfsctl store block gc-status <share>
+```
+dfsctl store block gc-status <share>
+```
 
 Use --dry-run to skip deletes and print up to dry_run_sample_size
 candidate keys (default 1000). Recommended for first-time deployment
@@ -5757,12 +5775,18 @@ Add a local block store
 Add a new local block store to the DittoFS server.
 
 Supported types:
-  - fs: Filesystem-backed block store (fast, persistent)
-  - memory: In-memory block store (fast, ephemeral, for testing)
+
+```
+- fs: Filesystem-backed block store (fast, persistent)
+- memory: In-memory block store (fast, ephemeral, for testing)
+```
 
 Type-specific options:
-  fs:
-    --path: Block directory path (or prompted interactively)
+
+```
+fs:
+  --path: Block directory path (or prompted interactively)
+```
 
 ```
 dfsctl store block local add [flags]
@@ -5987,17 +6011,23 @@ Add a remote block store
 Add a new remote block store to the DittoFS server.
 
 Supported types:
-  - s3: AWS S3 or S3-compatible store (durable, production)
-  - memory: In-memory store (fast, ephemeral, for testing)
+
+```
+- s3: AWS S3 or S3-compatible store (durable, production)
+- memory: In-memory store (fast, ephemeral, for testing)
+```
 
 Type-specific options:
-  s3:
-    --bucket: S3 bucket name (or prompted interactively)
-    --region: AWS region (default: us-east-1)
-    --endpoint: Custom endpoint for S3-compatible stores
-    --prefix: Key prefix within the bucket
-    --access-key: AWS access key ID
-    --secret-key: AWS secret access key
+
+```
+s3:
+  --bucket: S3 bucket name (or prompted interactively)
+  --region: AWS region (default: us-east-1)
+  --endpoint: Custom endpoint for S3-compatible stores
+  --prefix: Key prefix within the bucket
+  --access-key: AWS access key ID
+  --secret-key: AWS secret access key
+```
 
 ```
 dfsctl store block remote add [flags]
@@ -6289,16 +6319,22 @@ Add a metadata store
 Add a new metadata store to the DittoFS server.
 
 Supported types:
-  - memory: In-memory store (fast, ephemeral)
-  - badger: BadgerDB store (persistent, embedded)
-  - postgres: PostgreSQL store (persistent, distributed)
+
+```
+- memory: In-memory store (fast, ephemeral)
+- badger: BadgerDB store (persistent, embedded)
+- postgres: PostgreSQL store (persistent, distributed)
+```
 
 Type-specific options:
-  badger:
-    --db-path: Path to BadgerDB directory (or prompted interactively)
 
-  postgres:
-    --config: JSON with connection settings, or omit for interactive prompts
+```
+badger:
+  --db-path: Path to BadgerDB directory (or prompted interactively)
+
+postgres:
+  --config: JSON with connection settings, or omit for interactive prompts
+```
 
 ```
 dfsctl store metadata add [flags]


### PR DESCRIPTION
## Problem

On the docs site (`dittofs.io/docs/.../cli`) several command-help sections rendered as collapsed run-on text, e.g. `dfscompletionbash>/etc/bash_completion.d/dfs`.

Root cause: those commands embed **indented, pre-formatted blocks** — aligned subcommand tables, option lists, numbered steps, shell snippets — inside their Cobra `Long` descriptions. `cmd/gendocs` emitted `Long` as plain Markdown, so the static-site (MDX) renderer collapsed the leading whitespace and joined every line.

Affected: `dfs completion`, `dfsctl completion`, `dfs config`, `dfsctl idmap`, `dfsctl share mount`, `dfsctl bench storage-tiers`, and the `dfsctl store … add` family.

This survived #1390 — that PR only fenced embedded `Examples:` blocks; these used other pre-formatted formats.

## Fix

- **gendocs**: fence any indented pre-formatted run in a description, leaving non-indented prose as prose. One general fix covers every command (and future ones). Reuses the existing `dedent` helper.
- **completion** (`dfs` + `dfsctl`): restructured the `Long` into the conventional `Examples:` block, so the snippets render as a copy-pasteable fenced code block in both the website and terminal `--help`.
- **share mount**: reordered `Long` so its notes / platform list precede the `Examples:` block (they were being swept into the example fence) and turned them into proper Markdown lists.
- Regenerated `docs/guide/cli.md`.

## Verify

- `go build ./cmd/dfs ./cmd/dfsctl ./cmd/gendocs` ✅ · `go vet` ✅ · `gofmt` clean ✅
- Audit of regenerated `cli.md`: **0** collapse hazards remaining (was ~8 commands); no prose wrongly fenced.