### PR TITLE
perf(block): parallelize CAS upload to remote (~15× large-file write) + datapath metrics + per-remote tunable (#1266)

### DIFF
--- a/cmd/dfsctl/commands/store/block/remote/add.go
+++ b/cmd/dfsctl/commands/store/block/remote/add.go
@@ -16,13 +16,14 @@ var (
 	addType   string
 	addConfig string
 	// S3 specific
-	addBucket      string
-	addRegion      string
-	addEndpoint    string
-	addPrefix      string
-	addAccessKey   string
-	addSecretKey   string
-	addCompression string
+	addBucket          string
+	addRegion          string
+	addEndpoint        string
+	addPrefix          string
+	addAccessKey       string
+	addSecretKey       string
+	addCompression     string
+	addParallelUploads int
 	// Encryption (client-side, optional)
 	addEncryptionAEAD       string
 	addEncryptionKeyKind    string
@@ -82,6 +83,7 @@ func init() {
 	addCmd.Flags().StringVar(&addAccessKey, "access-key", "", "AWS access key ID (for s3)")
 	addCmd.Flags().StringVar(&addSecretKey, "secret-key", "", "AWS secret access key (for s3)")
 	addCmd.Flags().StringVar(&addCompression, "compression", "", "Enable per-block compression: zstd, lz4 (default: off)")
+	addCmd.Flags().IntVar(&addParallelUploads, "parallel-uploads", 0, "Max parallel chunk uploads to this remote (0 = auto, scales with CPU count)")
 	// Encryption flags
 	addCmd.Flags().StringVar(&addEncryptionAEAD, "encryption-aead", "", "Enable client-side encryption with the given AEAD: aes-256-gcm, chacha20-poly1305, xchacha20-poly1305")
 	addCmd.Flags().StringVar(&addEncryptionKeyKind, "encryption-key-kind", "", "Key provider: local | kmip (required when --encryption-aead is set)")
@@ -100,7 +102,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	config, err := buildRemoteConfig(addType, addConfig, addBucket, addRegion, addEndpoint, addPrefix, addAccessKey, addSecretKey, addCompression, encryptionFlags{
+	config, err := buildRemoteConfig(addType, addConfig, addBucket, addRegion, addEndpoint, addPrefix, addAccessKey, addSecretKey, addCompression, addParallelUploads, encryptionFlags{
 		AEAD:       addEncryptionAEAD,
 		KeyKind:    addEncryptionKeyKind,
 		KeyFile:    addEncryptionKeyFile,
@@ -139,7 +141,7 @@ type encryptionFlags struct {
 	KMIPKeyUID string
 }
 
-func buildRemoteConfig(storeType, jsonConfig, bucket, region, endpoint, prefix, accessKey, secretKey, compression string, enc encryptionFlags) (any, error) {
+func buildRemoteConfig(storeType, jsonConfig, bucket, region, endpoint, prefix, accessKey, secretKey, compression string, parallelUploads int, enc encryptionFlags) (any, error) {
 	if jsonConfig != "" {
 		var config any
 		if err := json.Unmarshal([]byte(jsonConfig), &config); err != nil {
@@ -224,6 +226,9 @@ func buildRemoteConfig(storeType, jsonConfig, bucket, region, endpoint, prefix, 
 		}
 		if encryptionBlock != nil {
 			config["encryption"] = encryptionBlock
+		}
+		if parallelUploads > 0 {
+			config["parallel_uploads"] = parallelUploads
 		}
 		return config, nil
 

--- a/cmd/dfsctl/commands/store/block/remote/add_test.go
+++ b/cmd/dfsctl/commands/store/block/remote/add_test.go
@@ -44,7 +44,7 @@ func TestBuildCompressionBlock(t *testing.T) {
 }
 
 func TestBuildRemoteConfig_S3_CompressionMergesIn(t *testing.T) {
-	cfg, err := buildRemoteConfig("s3", "", "bucket", "us-east-1", "", "", "AK", "SK", "zstd", encryptionFlags{})
+	cfg, err := buildRemoteConfig("s3", "", "bucket", "us-east-1", "", "", "AK", "SK", "zstd", 0, encryptionFlags{})
 	if err != nil {
 		t.Fatalf("buildRemoteConfig: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestBuildRemoteConfig_S3_CompressionMergesIn(t *testing.T) {
 }
 
 func TestBuildRemoteConfig_S3_NoCompressionByDefault(t *testing.T) {
-	cfg, err := buildRemoteConfig("s3", "", "bucket", "us-east-1", "", "", "AK", "SK", "", encryptionFlags{})
+	cfg, err := buildRemoteConfig("s3", "", "bucket", "us-east-1", "", "", "AK", "SK", "", 0, encryptionFlags{})
 	if err != nil {
 		t.Fatalf("buildRemoteConfig: %v", err)
 	}
@@ -73,9 +73,34 @@ func TestBuildRemoteConfig_S3_NoCompressionByDefault(t *testing.T) {
 }
 
 func TestBuildRemoteConfig_S3_RejectsInvalidAlgo(t *testing.T) {
-	_, err := buildRemoteConfig("s3", "", "bucket", "us-east-1", "", "", "AK", "SK", "gzip", encryptionFlags{})
+	_, err := buildRemoteConfig("s3", "", "bucket", "us-east-1", "", "", "AK", "SK", "gzip", 0, encryptionFlags{})
 	if err == nil || !strings.Contains(err.Error(), "invalid --compression") {
 		t.Fatalf("err=%v, want invalid --compression error", err)
+	}
+}
+
+func TestBuildRemoteConfig_S3_ParallelUploadsMergesIn(t *testing.T) {
+	cfg, err := buildRemoteConfig("s3", "", "bucket", "us-east-1", "", "", "AK", "SK", "", 8, encryptionFlags{})
+	if err != nil {
+		t.Fatalf("buildRemoteConfig: %v", err)
+	}
+	m, ok := cfg.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", cfg)
+	}
+	if m["parallel_uploads"] != 8 {
+		t.Fatalf("parallel_uploads=%v, want 8", m["parallel_uploads"])
+	}
+}
+
+func TestBuildRemoteConfig_S3_NoParallelUploadsByDefault(t *testing.T) {
+	cfg, err := buildRemoteConfig("s3", "", "bucket", "us-east-1", "", "", "AK", "SK", "", 0, encryptionFlags{})
+	if err != nil {
+		t.Fatalf("buildRemoteConfig: %v", err)
+	}
+	m, _ := cfg.(map[string]any)
+	if _, present := m["parallel_uploads"]; present {
+		t.Fatalf("parallel_uploads key should be absent when flag is 0: %#v", m)
 	}
 }
 
@@ -153,7 +178,7 @@ func TestBuildEncryptionBlock_Rejects(t *testing.T) {
 }
 
 func TestBuildRemoteConfig_S3_EncryptionMergesIn(t *testing.T) {
-	cfg, err := buildRemoteConfig("s3", "", "bucket", "us-east-1", "", "", "AK", "SK", "", encryptionFlags{
+	cfg, err := buildRemoteConfig("s3", "", "bucket", "us-east-1", "", "", "AK", "SK", "", 0, encryptionFlags{
 		AEAD:    "aes-256-gcm",
 		KeyKind: "local",
 		KeyFile: "/etc/dittofs/share.key",
@@ -174,7 +199,7 @@ func TestBuildRemoteConfig_S3_EncryptionMergesIn(t *testing.T) {
 func TestBuildRemoteConfig_JSONConfigShortCircuitsFlag(t *testing.T) {
 	// --config takes the parsed JSON verbatim; --compression flag is
 	// ignored when --config is set (matches existing flag interaction).
-	cfg, err := buildRemoteConfig("s3", `{"bucket":"x"}`, "", "", "", "", "", "", "lz4", encryptionFlags{})
+	cfg, err := buildRemoteConfig("s3", `{"bucket":"x"}`, "", "", "", "", "", "", "lz4", 0, encryptionFlags{})
 	if err != nil {
 		t.Fatalf("buildRemoteConfig: %v", err)
 	}

--- a/cmd/dfsctl/commands/store/block/remote/edit.go
+++ b/cmd/dfsctl/commands/store/block/remote/edit.go
@@ -15,11 +15,12 @@ var (
 	editType   string
 	editConfig string
 	// S3 specific
-	editBucket    string
-	editRegion    string
-	editEndpoint  string
-	editAccessKey string
-	editSecretKey string
+	editBucket          string
+	editRegion          string
+	editEndpoint        string
+	editAccessKey       string
+	editSecretKey       string
+	editParallelUploads int
 )
 
 var editCmd = &cobra.Command{
@@ -51,6 +52,7 @@ func init() {
 	editCmd.Flags().StringVar(&editEndpoint, "endpoint", "", "Custom S3 endpoint")
 	editCmd.Flags().StringVar(&editAccessKey, "access-key", "", "AWS access key ID (for s3)")
 	editCmd.Flags().StringVar(&editSecretKey, "secret-key", "", "AWS secret access key (for s3)")
+	editCmd.Flags().IntVar(&editParallelUploads, "parallel-uploads", 0, "Max parallel chunk uploads to this remote (0 = auto, scales with CPU count)")
 }
 
 func runEdit(cmd *cobra.Command, args []string) error {
@@ -68,7 +70,8 @@ func runEdit(cmd *cobra.Command, args []string) error {
 
 	hasFlags := cmd.Flags().Changed("type") || cmd.Flags().Changed("config") ||
 		cmd.Flags().Changed("bucket") || cmd.Flags().Changed("region") || cmd.Flags().Changed("endpoint") ||
-		cmd.Flags().Changed("access-key") || cmd.Flags().Changed("secret-key")
+		cmd.Flags().Changed("access-key") || cmd.Flags().Changed("secret-key") ||
+		cmd.Flags().Changed("parallel-uploads")
 
 	if !hasFlags {
 		return runEditInteractive(client, name, current)
@@ -84,7 +87,7 @@ func runEdit(cmd *cobra.Command, args []string) error {
 		}
 		req.Config = config
 		hasUpdate = true
-	} else if editBucket != "" || editRegion != "" || editEndpoint != "" || editAccessKey != "" || editSecretKey != "" {
+	} else if editBucket != "" || editRegion != "" || editEndpoint != "" || editAccessKey != "" || editSecretKey != "" || cmd.Flags().Changed("parallel-uploads") {
 		var currentConfig map[string]any
 		if len(current.Config) > 0 {
 			_ = json.Unmarshal(current.Config, &currentConfig)
@@ -108,6 +111,16 @@ func runEdit(cmd *cobra.Command, args []string) error {
 		if editSecretKey != "" {
 			currentConfig["secret_access_key"] = editSecretKey
 		}
+		// parallel-uploads is an int where 0 is meaningful ("reset to auto"),
+		// so key off Changed rather than a zero-value check: set clears to
+		// auto-deduce, a positive value pins the per-remote cap.
+		if cmd.Flags().Changed("parallel-uploads") {
+			if editParallelUploads > 0 {
+				currentConfig["parallel_uploads"] = editParallelUploads
+			} else {
+				delete(currentConfig, "parallel_uploads")
+			}
+		}
 		req.Config = currentConfig
 		hasUpdate = true
 	}
@@ -118,7 +131,7 @@ func runEdit(cmd *cobra.Command, args []string) error {
 	}
 
 	if !hasUpdate {
-		return fmt.Errorf("no update fields specified. Use --type, --config, --bucket, --region, --endpoint, --access-key, or --secret-key")
+		return fmt.Errorf("no update fields specified. Use --type, --config, --bucket, --region, --endpoint, --access-key, --secret-key, or --parallel-uploads")
 	}
 
 	store, err := client.UpdateBlockStore("remote", name, req)
@@ -194,6 +207,11 @@ func runEditInteractive(client *apiclient.Client, name string, current *apiclien
 		}
 		if newSecretKey != "" {
 			newConfig["secret_access_key"] = newSecretKey
+		}
+		// Carry forward server-side tuning the interactive prompts don't
+		// cover, so an interactive edit doesn't silently reset it.
+		if v, ok := currentConfig["parallel_uploads"]; ok {
+			newConfig["parallel_uploads"] = v
 		}
 
 		req.Config = newConfig

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -5296,6 +5296,7 @@ Flags:
       --encryption-kmip-key-uid string    KMIP managed symmetric key UID (kind=kmip)
       --endpoint string                   Custom S3 endpoint (for S3-compatible stores)
       --name string                       Store name (required)
+      --parallel-uploads int              Max parallel chunk uploads to this remote (0 = auto, scales with CPU count)
       --prefix string                     Key prefix within the bucket (for s3)
       --region string                     AWS region (for s3) (default "us-east-1")
       --secret-key string                 AWS secret access key (for s3)
@@ -5342,13 +5343,14 @@ dfsctl store block remote edit <name> [flags]
 Flags:
 
 ```
-      --access-key string   AWS access key ID (for s3)
-      --bucket string       S3 bucket name (for s3)
-      --config string       Store configuration as JSON
-      --endpoint string     Custom S3 endpoint
-      --region string       AWS region (for s3)
-      --secret-key string   AWS secret access key (for s3)
-      --type string         Store type: s3, memory
+      --access-key string      AWS access key ID (for s3)
+      --bucket string          S3 bucket name (for s3)
+      --config string          Store configuration as JSON
+      --endpoint string        Custom S3 endpoint
+      --parallel-uploads int   Max parallel chunk uploads to this remote (0 = auto, scales with CPU count)
+      --region string          AWS region (for s3)
+      --secret-key string      AWS secret access key (for s3)
+      --type string            Store type: s3, memory
 ```
 
 Global flags:

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -74,6 +74,11 @@ type Store struct {
 	remote remote.RemoteStore
 	syncer *Syncer
 
+	// metrics is the engine-side data-plane metrics sink (mirror/upload
+	// path). Retained from SetMetrics when the injected recorder also
+	// satisfies DataplaneMetrics. May be nil in tests; call sites guard.
+	metrics DataplaneMetrics
+
 	// widened to EngineFileBlockStore so populateBlockCounts
 	// can call ListFileBlocks (engine-internal method not on the public
 	// FileBlockStore surface).
@@ -683,6 +688,11 @@ func (bs *Store) Close() error {
 func (bs *Store) SetMetrics(rec local.MetricsRecorder) {
 	if aware, ok := bs.local.(local.MetricsAware); ok {
 		aware.SetMetrics(rec)
+	}
+	// The injected recorder (*metrics.Metrics in production) also carries the
+	// data-plane upload instruments; retain it for the mirror/upload path.
+	if dm, ok := rec.(DataplaneMetrics); ok {
+		bs.metrics = dm
 	}
 }
 

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
@@ -76,8 +77,11 @@ type Store struct {
 
 	// metrics is the engine-side data-plane metrics sink (mirror/upload
 	// path). Retained from SetMetrics when the injected recorder also
-	// satisfies DataplaneMetrics. May be nil in tests; call sites guard.
-	metrics DataplaneMetrics
+	// satisfies DataplaneMetrics. Held as an atomic.Pointer because
+	// SetMetrics back-fills it on already-serving shares (the registry is
+	// built after shares load), racing the concurrent mirror goroutines that
+	// read it. Nil pointer (the zero value) until set; call sites guard.
+	metrics atomic.Pointer[DataplaneMetrics]
 
 	// widened to EngineFileBlockStore so populateBlockCounts
 	// can call ListFileBlocks (engine-internal method not on the public
@@ -692,7 +696,7 @@ func (bs *Store) SetMetrics(rec local.MetricsRecorder) {
 	// The injected recorder (*metrics.Metrics in production) also carries the
 	// data-plane upload instruments; retain it for the mirror/upload path.
 	if dm, ok := rec.(DataplaneMetrics); ok {
-		bs.metrics = dm
+		bs.metrics.Store(&dm)
 	}
 }
 

--- a/pkg/block/engine/metrics.go
+++ b/pkg/block/engine/metrics.go
@@ -1,0 +1,22 @@
+package engine
+
+import "time"
+
+// DataplaneMetrics is the engine-side metrics seam for the mirror/upload path.
+// It follows the nil-safe Record* convention of pkg/metrics, which *Metrics
+// satisfies. The engine depends on this interface rather than importing
+// pkg/metrics directly, keeping pkg/block free of the metrics dependency
+// (the same reason local.MetricsRecorder exists for the local store).
+type DataplaneMetrics interface {
+	// RecordUpload records one CAS chunk upload to remote: result is "ok" or
+	// "error", bytes is the chunk size, d is the remote Put latency.
+	RecordUpload(bytes int, result string, d time.Duration)
+	// UploadStarted/UploadFinished bracket one in-flight remote Put so the
+	// inflight gauge reflects the mirror loop's effective upload concurrency.
+	UploadStarted()
+	UploadFinished()
+	// SetUploadQueueDepth publishes pending-upload backlog at mirror-pass start.
+	SetUploadQueueDepth(n int)
+	// RecordRehash records pre-upload BLAKE3 re-hash latency for one chunk.
+	RecordRehash(d time.Duration)
+}

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -532,7 +532,10 @@ func (m *Syncer) dataplaneMetrics() DataplaneMetrics {
 	if m.bs == nil {
 		return nil
 	}
-	return m.bs.metrics
+	if p := m.bs.metrics.Load(); p != nil {
+		return *p
+	}
+	return nil
 }
 
 // mirrorChunk uploads one pending CAS chunk to the remote store and marks it

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -469,8 +469,8 @@ func (m *Syncer) mirrorOnce(ctx context.Context) error {
 	}
 	m.pendingMu.Unlock()
 
-	if m.bs != nil && m.bs.metrics != nil {
-		m.bs.metrics.SetUploadQueueDepth(len(snapshot))
+	if mx := m.dataplaneMetrics(); mx != nil {
+		mx.SetUploadQueueDepth(len(snapshot))
 	}
 
 	// Tracks whether at least one pending hash was retained-but-not-mirrored
@@ -525,6 +525,16 @@ func (m *Syncer) mirrorOnce(ctx context.Context) error {
 	return nil
 }
 
+// dataplaneMetrics returns the engine's data-plane metrics sink, or nil when
+// the syncer is detached from a Store or no recorder was injected. Call sites
+// must guard the result: it is a plain interface, not a nil-safe *Metrics.
+func (m *Syncer) dataplaneMetrics() DataplaneMetrics {
+	if m.bs == nil {
+		return nil
+	}
+	return m.bs.metrics
+}
+
 // mirrorChunk uploads one pending CAS chunk to the remote store and marks it
 // synced. It returns nil — recording lostBeforeMirror — when the local bytes
 // vanished before upload, so one missing chunk does not fail the whole pass.
@@ -551,10 +561,7 @@ func (m *Syncer) mirrorChunk(ctx context.Context, hashStore metadata.SyncedHashS
 		return fmt.Errorf("local get %s: %w", hash, err)
 	}
 
-	var mx DataplaneMetrics
-	if m.bs != nil {
-		mx = m.bs.metrics
-	}
+	mx := m.dataplaneMetrics()
 
 	// Re-hash fetched bytes before upload. Local bitrot, torn writes, or
 	// hardware errors between rollup-time hashing and this read would

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -468,6 +468,10 @@ func (m *Syncer) mirrorOnce(ctx context.Context) error {
 	}
 	m.pendingMu.Unlock()
 
+	if m.bs != nil && m.bs.metrics != nil {
+		m.bs.metrics.SetUploadQueueDepth(len(snapshot))
+	}
+
 	// Tracks whether at least one pending hash was retained-but-not-mirrored
 	// because its local bytes were gone. The loop continues draining the
 	// other hashes (one bad hash must not stall the rest), and reports this
@@ -506,7 +510,16 @@ func (m *Syncer) mirrorOnce(ctx context.Context) error {
 		// ReadBlockVerified is post-facto and useless once the local
 		// copy is evicted, so refuse the upload here and surface an
 		// error to the syncer loop.
+		var mx DataplaneMetrics
+		if m.bs != nil {
+			mx = m.bs.metrics
+		}
+
+		rehashStart := time.Now()
 		computed := block.ContentHash(blake3.Sum256(data))
+		if mx != nil {
+			mx.RecordRehash(time.Since(rehashStart))
+		}
 		if computed != hash {
 			logger.Error("local corruption detected before mirror upload — refusing to upload",
 				"hash", hash.String(),
@@ -514,7 +527,21 @@ func (m *Syncer) mirrorOnce(ctx context.Context) error {
 				"bytes", len(data))
 			return fmt.Errorf("%w on hash %s: computed %s (refusing upload)", block.ErrCASContentMismatch, hash.String(), computed.String())
 		}
-		if err := m.remoteStore.Put(ctx, hash, data); err != nil {
+
+		uploadStart := time.Now()
+		if mx != nil {
+			mx.UploadStarted()
+		}
+		err = m.remoteStore.Put(ctx, hash, data)
+		if mx != nil {
+			mx.UploadFinished()
+			result := "ok"
+			if err != nil {
+				result = "error"
+			}
+			mx.RecordUpload(len(data), result, time.Since(uploadStart))
+		}
+		if err != nil {
 			return fmt.Errorf("remote put %s: %w", hash, err)
 		}
 		if err := hashStore.MarkSynced(ctx, hash); err != nil {

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/block/local"
 	"github.com/marmos91/dittofs/pkg/block/remote"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"golang.org/x/sync/errgroup"
 	"lukechampine.com/blake3"
 )
 
@@ -473,94 +474,131 @@ func (m *Syncer) mirrorOnce(ctx context.Context) error {
 	}
 
 	// Tracks whether at least one pending hash was retained-but-not-mirrored
-	// because its local bytes were gone. The loop continues draining the
+	// because its local bytes were gone. The pass continues draining the
 	// other hashes (one bad hash must not stall the rest), and reports this
-	// via ErrChunkLostBeforeMirror AFTER the loop so Flush/SyncNow do not
+	// via ErrChunkLostBeforeMirror AFTER the pass so Flush/SyncNow do not
 	// claim durability while the periodic uploader can treat it as a
 	// non-fatal retry-next-tick condition.
-	var lostBeforeMirror bool
+	var lostBeforeMirror atomic.Bool
+
+	// Upload the snapshot concurrently, bounded by ParallelUploads. Each
+	// chunk is independent — a distinct CAS hash, an idempotent remote Put,
+	// and a per-hash MarkSynced — and the path is network-latency-bound, so
+	// a serial loop leaves the link idle (one in-flight S3 Put gave only
+	// ~2.7 MiB/s VM→fr-par; #1266). The first fatal error cancels the group
+	// via gctx; in-flight Puts observe the cancellation. Mirrors the bounded
+	// errgroup pattern used by warm().
+	parallel := m.config.ParallelUploads
+	if parallel < 1 {
+		parallel = 1
+	}
+	g, gctx := errgroup.WithContext(ctx)
+	sem := make(chan struct{}, parallel)
 
 	for _, hash := range snapshot {
-		data, err := m.local.Get(ctx, hash)
-		if errors.Is(err, block.ErrChunkNotFound) {
-			// The local chunk is gone before we could mirror it. Retain the
-			// hash for the next tick rather than dropping it — dropping
-			// silently destroyed the only copy of never-mirrored data. If
-			// the chunk is truly gone (e.g. an external delete), the next
-			// seedPendingFromDisk / ListUnsynced drift reconcile walks disk,
-			// finds the chunk absent, and stops re-seeding it, so the retry
-			// loop terminates naturally instead of spinning forever.
-			//
-			// Record the failure: this pass did NOT make the payload durable
-			// on remote, so an explicit Flush/SyncNow must not report
-			// success. The periodic uploader continues draining the rest of
-			// the snapshot and may swallow the resulting sentinel.
-			logger.Error("mirrorOnce: chunk lost locally before mirror — retained for retry",
-				"hash", hash.String())
-			lostBeforeMirror = true
-			continue
+		hash := hash
+		// Block for a slot, but stop dispatching the moment the group is
+		// failing/cancelled.
+		select {
+		case <-gctx.Done():
+		case sem <- struct{}{}:
 		}
-		if err != nil {
-			return fmt.Errorf("local get %s: %w", hash, err)
+		if gctx.Err() != nil {
+			break
 		}
-		// Re-hash fetched bytes before upload. Local bitrot, torn
-		// writes, or hardware errors between rollup-time hashing and
-		// this read would otherwise silently propagate corrupt bytes
-		// to remote and MarkSynced them. Downstream verification via
-		// ReadBlockVerified is post-facto and useless once the local
-		// copy is evicted, so refuse the upload here and surface an
-		// error to the syncer loop.
-		var mx DataplaneMetrics
-		if m.bs != nil {
-			mx = m.bs.metrics
-		}
-
-		rehashStart := time.Now()
-		computed := block.ContentHash(blake3.Sum256(data))
-		if mx != nil {
-			mx.RecordRehash(time.Since(rehashStart))
-		}
-		if computed != hash {
-			logger.Error("local corruption detected before mirror upload — refusing to upload",
-				"hash", hash.String(),
-				"computed", computed.String(),
-				"bytes", len(data))
-			return fmt.Errorf("%w on hash %s: computed %s (refusing upload)", block.ErrCASContentMismatch, hash.String(), computed.String())
-		}
-
-		uploadStart := time.Now()
-		if mx != nil {
-			mx.UploadStarted()
-		}
-		err = m.remoteStore.Put(ctx, hash, data)
-		if mx != nil {
-			mx.UploadFinished()
-			result := "ok"
-			if err != nil {
-				result = "error"
-			}
-			mx.RecordUpload(len(data), result, time.Since(uploadStart))
-		}
-		if err != nil {
-			return fmt.Errorf("remote put %s: %w", hash, err)
-		}
-		if err := hashStore.MarkSynced(ctx, hash); err != nil {
-			return fmt.Errorf("mark synced %s: %w", hash, err)
-		}
-		m.pendingMu.Lock()
-		if size, ok := m.pendingHashes[hash]; ok {
-			delete(m.pendingHashes, hash)
-			m.unsyncedBytes.Add(-size)
-		}
-		m.pendingMu.Unlock()
+		g.Go(func() error {
+			defer func() { <-sem }()
+			return m.mirrorChunk(gctx, hashStore, hash, &lostBeforeMirror)
+		})
 	}
-	if lostBeforeMirror {
+
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	if lostBeforeMirror.Load() {
 		// At least one pending hash was retained-but-not-mirrored: the
 		// payload is not durable on remote. Flush/SyncNow propagate this;
 		// the periodic uploader logs+swallows it (non-fatal, retry next
 		// tick — the good hashes were still drained above).
 		return block.ErrChunkLostBeforeMirror
 	}
+	return nil
+}
+
+// mirrorChunk uploads one pending CAS chunk to the remote store and marks it
+// synced. It returns nil — recording lostBeforeMirror — when the local bytes
+// vanished before upload, so one missing chunk does not fail the whole pass.
+// It returns an error on local read failure, local bitrot (hash mismatch),
+// remote Put failure, or MarkSynced failure. Safe for concurrent use:
+// pendingHashes mutation is guarded by pendingMu, the metrics sink and remote
+// store are concurrency-safe, and each call owns a distinct hash.
+func (m *Syncer) mirrorChunk(ctx context.Context, hashStore metadata.SyncedHashStore, hash block.ContentHash, lostBeforeMirror *atomic.Bool) error {
+	data, err := m.local.Get(ctx, hash)
+	if errors.Is(err, block.ErrChunkNotFound) {
+		// The local chunk is gone before we could mirror it. Retain the hash
+		// for the next tick rather than dropping it — dropping silently
+		// destroyed the only copy of never-mirrored data. If the chunk is
+		// truly gone (e.g. an external delete), the next seedPendingFromDisk
+		// / ListUnsynced drift reconcile walks disk, finds the chunk absent,
+		// and stops re-seeding it, so the retry loop terminates naturally
+		// instead of spinning forever.
+		logger.Error("mirrorOnce: chunk lost locally before mirror — retained for retry",
+			"hash", hash.String())
+		lostBeforeMirror.Store(true)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("local get %s: %w", hash, err)
+	}
+
+	var mx DataplaneMetrics
+	if m.bs != nil {
+		mx = m.bs.metrics
+	}
+
+	// Re-hash fetched bytes before upload. Local bitrot, torn writes, or
+	// hardware errors between rollup-time hashing and this read would
+	// otherwise silently propagate corrupt bytes to remote and MarkSynced
+	// them. Downstream verification via ReadBlockVerified is post-facto and
+	// useless once the local copy is evicted, so refuse the upload here.
+	rehashStart := time.Now()
+	computed := block.ContentHash(blake3.Sum256(data))
+	if mx != nil {
+		mx.RecordRehash(time.Since(rehashStart))
+	}
+	if computed != hash {
+		logger.Error("local corruption detected before mirror upload — refusing to upload",
+			"hash", hash.String(),
+			"computed", computed.String(),
+			"bytes", len(data))
+		return fmt.Errorf("%w on hash %s: computed %s (refusing upload)", block.ErrCASContentMismatch, hash.String(), computed.String())
+	}
+
+	uploadStart := time.Now()
+	if mx != nil {
+		mx.UploadStarted()
+	}
+	err = m.remoteStore.Put(ctx, hash, data)
+	if mx != nil {
+		mx.UploadFinished()
+		result := "ok"
+		if err != nil {
+			result = "error"
+		}
+		mx.RecordUpload(len(data), result, time.Since(uploadStart))
+	}
+	if err != nil {
+		return fmt.Errorf("remote put %s: %w", hash, err)
+	}
+	if err := hashStore.MarkSynced(ctx, hash); err != nil {
+		return fmt.Errorf("mark synced %s: %w", hash, err)
+	}
+	m.pendingMu.Lock()
+	if size, ok := m.pendingHashes[hash]; ok {
+		delete(m.pendingHashes, hash)
+		m.unsyncedBytes.Add(-size)
+	}
+	m.pendingMu.Unlock()
 	return nil
 }
 

--- a/pkg/controlplane/runtime/blockstore_init.go
+++ b/pkg/controlplane/runtime/blockstore_init.go
@@ -93,6 +93,9 @@ func ValidateBlockStoreConfig(kind models.BlockStoreKind, storeType string, cfg 
 			if err := validateCompressionSubconfig(config); err != nil {
 				return err
 			}
+			if err := validateParallelUploads(config); err != nil {
+				return err
+			}
 			return nil
 		default:
 			return fmt.Errorf("unsupported remote block store type: %s", storeType)
@@ -130,4 +133,30 @@ func validateCompressionSubconfig(config map[string]any) error {
 	default:
 		return fmt.Errorf("compression.algo: unsupported value %q (want zstd or lz4)", algoStr)
 	}
+}
+
+// maxParallelUploads bounds the per-remote parallel_uploads override. It is a
+// safety rail against FD/goroutine exhaustion, not a tuning target.
+const maxParallelUploads = 256
+
+// validateParallelUploads checks the optional per-remote parallel_uploads
+// override. 0 / absent means "use the server default" (CPU-deduced); a
+// positive value pins the per-remote upload concurrency. JSON numbers decode
+// as float64.
+func validateParallelUploads(config map[string]any) error {
+	raw, ok := config["parallel_uploads"]
+	if !ok {
+		return nil
+	}
+	n, ok := raw.(float64)
+	if !ok {
+		return fmt.Errorf("parallel_uploads: expected number, got %T", raw)
+	}
+	if n != float64(int(n)) {
+		return fmt.Errorf("parallel_uploads: expected integer, got %v", n)
+	}
+	if n < 0 || n > maxParallelUploads {
+		return fmt.Errorf("parallel_uploads: must be between 0 and %d (got %d)", maxParallelUploads, int(n))
+	}
+	return nil
 }

--- a/pkg/controlplane/runtime/blockstore_init_test.go
+++ b/pkg/controlplane/runtime/blockstore_init_test.go
@@ -83,3 +83,37 @@ func TestValidateCompressionSubconfig(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateParallelUploads(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     map[string]any
+		wantErr string // substring; "" means accept
+	}{
+		{"absent", map[string]any{}, ""},
+		{"zero_means_auto", map[string]any{"parallel_uploads": float64(0)}, ""},
+		{"valid", map[string]any{"parallel_uploads": float64(16)}, ""},
+		{"max_boundary", map[string]any{"parallel_uploads": float64(256)}, ""},
+		{"negative", map[string]any{"parallel_uploads": float64(-1)}, "between 0 and 256"},
+		{"over_max", map[string]any{"parallel_uploads": float64(257)}, "between 0 and 256"},
+		{"non_integer", map[string]any{"parallel_uploads": float64(2.5)}, "expected integer"},
+		{"wrong_type", map[string]any{"parallel_uploads": "8"}, "expected number"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateParallelUploads(tc.cfg)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -787,6 +787,21 @@ func (s *Service) createBlockStoreForShare(
 
 	syncerCfg := buildSyncerConfigFromDefaults(syncerDefaults)
 
+	// Apply the optional per-remote upload-concurrency override. Unset or 0
+	// keeps the server default (CPU-deduced); a positive value pins this
+	// remote's upload parallelism. Validated to [0,256] at config admission.
+	// The resolve hits the in-memory config cache (the remote was just
+	// acquired), so this is a cheap lookup, not a fresh DB round-trip.
+	if config.RemoteBlockStoreID != "" {
+		if remoteCfg, cfgErr := resolveBlockStoreConfig(ctx, blockStoreProvider, config.RemoteBlockStoreID, models.BlockStoreKindRemote); cfgErr == nil {
+			if parsed, pErr := remoteCfg.GetConfig(); pErr == nil {
+				if v, ok := parsed["parallel_uploads"].(float64); ok && v > 0 {
+					syncerCfg.ParallelUploads = int(v)
+				}
+			}
+		}
+	}
+
 	// Wrap shared remote in nonClosingRemote so engine.Close() doesn't close it;
 	// releaseRemoteStore handles actual closing via ref counting.
 	var engineRemote remote.RemoteStore

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -790,8 +790,9 @@ func (s *Service) createBlockStoreForShare(
 	// Apply the optional per-remote upload-concurrency override. Unset or 0
 	// keeps the server default (CPU-deduced); a positive value pins this
 	// remote's upload parallelism. Validated to [0,256] at config admission.
-	// The resolve hits the in-memory config cache (the remote was just
-	// acquired), so this is a cheap lookup, not a fresh DB round-trip.
+	// acquireRemoteStore caches only the instantiated store, not its config,
+	// so this re-resolves the BlockStoreConfig (a DB read). A failure here is
+	// non-fatal — fall back to the default and warn rather than fail attach.
 	if config.RemoteBlockStoreID != "" {
 		if remoteCfg, cfgErr := resolveBlockStoreConfig(ctx, blockStoreProvider, config.RemoteBlockStoreID, models.BlockStoreKindRemote); cfgErr == nil {
 			if parsed, pErr := remoteCfg.GetConfig(); pErr == nil {
@@ -799,6 +800,9 @@ func (s *Service) createBlockStoreForShare(
 					syncerCfg.ParallelUploads = int(v)
 				}
 			}
+		} else {
+			logger.Warn("failed to resolve remote config for parallel_uploads override; using server default",
+				"share", config.Name, "error", cfgErr)
 		}
 	}
 

--- a/pkg/metrics/instruments.go
+++ b/pkg/metrics/instruments.go
@@ -157,7 +157,7 @@ func newInstruments(reg *prometheus.Registry) *instruments {
 		}),
 		uploadsInflight: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: Namespace, Subsystem: "datapath", Name: "uploads_inflight",
-			Help: "CAS chunk uploads currently in flight to the remote store (mirror-loop concurrency; 1 today).",
+			Help: "CAS chunk uploads currently in flight to the remote store (the mirror loop's effective upload concurrency).",
 		}),
 		uploadQueueDepth: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: Namespace, Subsystem: "datapath", Name: "upload_queue_depth",
@@ -300,7 +300,7 @@ func (m *Metrics) RecordUpload(bytes int, result string, d time.Duration) {
 
 // UploadStarted and UploadFinished bracket one in-flight remote Put so that
 // datapath_uploads_inflight reflects the mirror loop's effective upload
-// concurrency (1 today; >1 once the upload loop is parallelized).
+// concurrency (the loop runs up to ParallelUploads Puts at once).
 func (m *Metrics) UploadStarted() {
 	if m == nil {
 		return

--- a/pkg/metrics/instruments.go
+++ b/pkg/metrics/instruments.go
@@ -45,6 +45,17 @@ type instruments struct {
 	// the same fqName would also fail registration).
 	snapOps      *prometheus.CounterVec   // {op,result}
 	snapDuration *prometheus.HistogramVec // {op}
+
+	// Data-plane upload pipeline (subsystem "datapath"). Instruments the
+	// engine mirror loop that copies CAS chunks local→remote, to attribute
+	// large-file write throughput across re-hash vs remote-Put and to expose
+	// the loop's effective upload concurrency and backlog.
+	uploadsTotal     *prometheus.CounterVec // {result}
+	uploadDuration   prometheus.Histogram
+	uploadBytes      prometheus.Histogram
+	uploadsInflight  prometheus.Gauge
+	uploadQueueDepth prometheus.Gauge
+	rehashDuration   prometheus.Histogram
 }
 
 func newInstruments(reg *prometheus.Registry) *instruments {
@@ -129,12 +140,42 @@ func newInstruments(reg *prometheus.Registry) *instruments {
 			Help:    "Snapshot operation duration in seconds, by op (create|delete|restore).",
 			Buckets: prometheus.DefBuckets,
 		}, []string{"op"}),
+
+		uploadsTotal: factory(prometheus.CounterOpts{
+			Namespace: Namespace, Subsystem: "datapath", Name: "uploads_total",
+			Help: "CAS chunk uploads to the remote store, by result (ok|error).",
+		}, []string{"result"}),
+		uploadDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: Namespace, Subsystem: "datapath", Name: "upload_duration_seconds",
+			Help:    "Remote-store Put latency per CAS chunk, in seconds.",
+			Buckets: prometheus.DefBuckets,
+		}),
+		uploadBytes: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: Namespace, Subsystem: "datapath", Name: "upload_bytes",
+			Help:    "Size of each CAS chunk uploaded to the remote store, in bytes.",
+			Buckets: prometheus.ExponentialBuckets(4096, 2, 12),
+		}),
+		uploadsInflight: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace, Subsystem: "datapath", Name: "uploads_inflight",
+			Help: "CAS chunk uploads currently in flight to the remote store (mirror-loop concurrency; 1 today).",
+		}),
+		uploadQueueDepth: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace, Subsystem: "datapath", Name: "upload_queue_depth",
+			Help: "CAS chunks pending upload, sampled at the start of each mirror pass.",
+		}),
+		rehashDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: Namespace, Subsystem: "datapath", Name: "rehash_duration_seconds",
+			Help:    "BLAKE3 re-hash (pre-upload bitrot verify) latency per CAS chunk, in seconds.",
+			Buckets: prometheus.DefBuckets,
+		}),
 	}
 	reg.MustRegister(
 		in.requests, in.reqDuration, in.connsTotal, in.connsClosed, in.authAttempts, in.authFailures,
 		in.backpressureTotal, in.backpressureWaitSeconds, in.evictionsTotal, in.evictedBytesTotal,
 		in.gcRuns, in.gcRunning, in.gcLastRunTime, in.gcSweptObjects, in.gcFreedBytes, in.gcDurationSecs,
 		in.snapOps, in.snapDuration,
+		in.uploadsTotal, in.uploadDuration, in.uploadBytes, in.uploadsInflight,
+		in.uploadQueueDepth, in.rehashDuration,
 	)
 	return in
 }
@@ -242,4 +283,52 @@ func (m *Metrics) RecordSnapshotOp(op, result string, d time.Duration) {
 	}
 	m.in.snapOps.WithLabelValues(op, result).Inc()
 	m.in.snapDuration.WithLabelValues(op).Observe(d.Seconds())
+}
+
+// RecordUpload records one CAS chunk upload to the remote store: its count (by
+// result "ok"|"error"), the bytes transferred, and the remote Put latency.
+func (m *Metrics) RecordUpload(bytes int, result string, d time.Duration) {
+	if m == nil {
+		return
+	}
+	m.in.uploadsTotal.WithLabelValues(result).Inc()
+	m.in.uploadDuration.Observe(d.Seconds())
+	if bytes > 0 {
+		m.in.uploadBytes.Observe(float64(bytes))
+	}
+}
+
+// UploadStarted and UploadFinished bracket one in-flight remote Put so that
+// datapath_uploads_inflight reflects the mirror loop's effective upload
+// concurrency (1 today; >1 once the upload loop is parallelized).
+func (m *Metrics) UploadStarted() {
+	if m == nil {
+		return
+	}
+	m.in.uploadsInflight.Inc()
+}
+
+func (m *Metrics) UploadFinished() {
+	if m == nil {
+		return
+	}
+	m.in.uploadsInflight.Dec()
+}
+
+// SetUploadQueueDepth publishes the number of CAS chunks pending upload,
+// sampled at the start of a mirror pass.
+func (m *Metrics) SetUploadQueueDepth(n int) {
+	if m == nil {
+		return
+	}
+	m.in.uploadQueueDepth.Set(float64(n))
+}
+
+// RecordRehash records the BLAKE3 re-hash (pre-upload bitrot verify) latency
+// for one CAS chunk.
+func (m *Metrics) RecordRehash(d time.Duration) {
+	if m == nil {
+		return
+	}
+	m.in.rehashDuration.Observe(d.Seconds())
 }


### PR DESCRIPTION
## What

Fixes the large-file write throughput bottleneck in #1266: CAS chunks were mirrored to the remote store **one at a time**. Since the path is network-latency-bound, the serial loop left the uplink almost entirely idle.

## Root cause (measured)

Benchmarked on a Scaleway VM → real Scaleway S3 (fr-par):
- Serial upload: **2.7 MiB/s**, `uploads_inflight` pinned at **1**, box 94% idle (5.5% CPU).
- A single 1 MiB S3 PUT takes ~0.36 s — inherent S3 latency, **not** DittoFS overhead (connection reuse already works: 1 TLS handshake/run; the S3 transport pool is fine).
- Raw S3 scales near-linearly with concurrency (N=16 → ~24–31 MiB/s, N=32 → ~44).
- The unused `SyncQueue` had `ParallelUploads=16` workers, but `EnqueueUpload` had **zero callers** — the live mirror loop ignored it.

## Changes

1. **Parallelize the mirror upload loop** (`pkg/block/engine/syncer.go`) — the per-pass snapshot now uploads concurrently via a bounded `errgroup` (`ParallelUploads`), mirroring `warm()`'s pattern. Each chunk is independent (distinct CAS hash, idempotent Put, per-hash `MarkSynced`); `pendingHashes` stays guarded; first fatal error cancels the group; lost-before-mirror still surfaces `ErrChunkLostBeforeMirror`.
2. **`datapath` Prometheus metrics** (`pkg/metrics`) — `upload_duration_seconds`, `upload_bytes`, `uploads_total{result}`, `uploads_inflight`, `upload_queue_depth`, `rehash_duration_seconds`. Wired via a new `engine.DataplaneMetrics` seam (held in an `atomic.Pointer`, since `SetMetrics` back-fills live shares concurrently with the mirror goroutines).
3. **Per-remote `--parallel-uploads` tunable** — `dfsctl store block remote add/edit --parallel-uploads N`. Stored in the remote's JSON config blob (no schema/migration), validated to [0,256], applied to the share's `SyncerConfig` at attach. `0`/unset falls back to the server default (`max(4, nCPU)`).

## Result

| | throughput | uploads_inflight |
|---|---|---|
| serial (before) | 2.7 MiB/s | 1 |
| **parallel (after)** | **40.0 MiB/s** | **16** |

**~15×.** Per-PUT latency unchanged — pure concurrency win. Local append (~33 MiB/s) is now the next ceiling.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt` clean.
- `go test -race ./pkg/block/...` green (concurrency change).
- New unit tests: flag plumbing (`add_test.go`), validation bounds (`blockstore_init_test.go`).
- Empirically benchmarked before/after on a Scaleway VM against real S3.

## Follow-up

Adaptive slow-start (BBR-style: ramp upload concurrency on aggregate-goodput gradient, back off on latency inflation / S3 `503 SlowDown`) to replace the CPU-deduced default when `--parallel-uploads` is unset — tracked separately. This flag becomes its hard ceiling.

Refs #1266.
