### PR TITLE
docs(smb): mark SACL/audit-ACE round-trip as shipped (#1389)

### DIFF
--- a/docs/guide/access-control.md
+++ b/docs/guide/access-control.md
@@ -162,7 +162,7 @@ The identity mapping package (`pkg/identity/`) resolves NFS principals to Unix c
 
 2. **Hash-based SID generation**: Named principals without numeric UIDs (e.g., `alice@EXAMPLE.COM`) produce a hash-based RID when converted to SID. This is deterministic but could theoretically collide.
 
-3. **No SACL support**: System ACLs for Windows auditing are always NULL in Security Descriptors. AUDIT/ALARM ACE types can be stored but are not exposed to SMB clients as a SACL.
+3. **SACL round-trips but audit events are not generated**: System ACLs (audit/alarm ACEs) are parsed, stored, and surfaced to SMB clients in the Security Descriptor's SACL section — Windows Explorer's "Auditing" tab reads back what was set, and the `ACCESS_SYSTEM_SECURITY` gate is enforced. What is not implemented is *acting* on them: the server emits no audit log when an operation matches a SUCCESSFUL/FAILED audit ACE, and ALARM ACEs raise no alarm. See [SMB ACL fidelity § SACL](smb-acl-fidelity.md#sacl-audit).
 
 4. **Owner/Group not in ACL**: Windows Security Descriptors bundle owner, group, and DACL together. DittoFS stores owner (UID) and group (GID) separately in file attributes. This is transparent to clients but means owner/group changes don't trigger ACL-related events.
 

--- a/docs/guide/smb-acl-fidelity.md
+++ b/docs/guide/smb-acl-fidelity.md
@@ -96,7 +96,7 @@ are distinct and only meaningful as inheritable placeholders (see Inheritance).
 | Aspect | State | Notes |
 |--------|-------|-------|
 | SACL read | Works | When `SACLSecurityInformation` is requested and the file carries stored SACL ACEs, `buildSACL` serializes them into the SD's SACL section (same MS-DTYP §2.4.5 + §2.4.4.2 wire layout as a DACL). Windows Explorer's "Auditing" tab shows the stored audit ACEs. `buildEmptySACL` is the fallback only when no SACL is stored (valid 0-ACE SACL). |
-| SACL write | Works | `ParseSecurityDescriptorWithOptions` parses the SACL body via the shared `parseACEs` and persists audit ACEs into `ACL.SACL`; `setSecurityInfo` installs it via `mergeSecurityACL`, preserving the unrequested DACL/SACL section. Access-gated (`AccessSystemSecurity` required). |
+| SACL write | Works | `ParseSecurityDescriptorWithOptions` parses the SACL body via the shared `parseACEs` and persists audit ACEs into `ACL.SACL`; `setSecurityInfo` installs it via `mergeSecurityACL`, preserving the unrequested DACL/SACL section. Access-gated (`ACCESS_SYSTEM_SECURITY` required). |
 | AUDIT / ALARM ACE round-trip | Works | `ACE4_SYSTEM_AUDIT_ACE_TYPE` ↔ `systemAuditACEType` and `ACE4_SYSTEM_ALARM_ACE_TYPE` ↔ `systemAlarmACEType` map both directions (`nfsToWindowsACEType` / `windowsToNFSACEType`); the SUCCESSFUL/FAILED audit flags round-trip through `NFSv4FlagsToWindowsFlags`. Audit ACEs ride the SACL section, not the DACL. |
 
 The SACL is stored on the same `acl.ACL` carrier as the DACL (`ACL.SACL`

--- a/docs/guide/smb-acl-fidelity.md
+++ b/docs/guide/smb-acl-fidelity.md
@@ -20,9 +20,9 @@ Code paths referenced:
 
 | Path | Function(s) | File |
 |------|-------------|------|
-| SD read (build) | `BuildSecurityDescriptor`, `buildDACL`, `buildEmptySACL` | `internal/adapter/smb/handlers/security.go` |
+| SD read (build) | `BuildSecurityDescriptor`, `buildDACL`, `buildSACL`, `buildEmptySACL` | `internal/adapter/smb/handlers/security.go` |
 | Read-side DACL synthesis | `SynthesizeWindowsDefault`, `SynthesizeFromMode` | `pkg/metadata/acl/synthesize.go` |
-| SD write (parse) | `ParseSecurityDescriptorWithOptions`, `parseDACL` | `internal/adapter/smb/handlers/security.go` |
+| SD write (parse) | `ParseSecurityDescriptorWithOptions`, `parseDACL`, `parseACEs` (shared DACL/SACL) | `internal/adapter/smb/handlers/security.go` |
 | SET_INFO Security | `setSecurityInfo`, `checkSetInfoSecurityAccess` | `internal/adapter/smb/handlers/set_info.go` |
 | SID derivation | `UserSID`, `GroupSID`, `UIDFromSID`, `GIDFromSID`, `PrincipalToSID`, `SIDToPrincipal` | `pkg/auth/sid/mapper.go` |
 | Generic-mask expansion | `ExpandGenericMask` | `pkg/metadata/acl/generic.go` |
@@ -82,7 +82,7 @@ are distinct and only meaningful as inheritable placeholders (see Inheritance).
 | SE_DACL_PROTECTED (0x1000) | Works | Read from `ACL.Protected`; written from inbound Control. Blocks inheritance from ancestors; never itself inherited onto children. |
 | SE_DACL_AUTO_INHERITED (0x0400) | Works (canonicalized) | Round-trips via `ACL.AutoInherited`. Default canonicalization (MS-DTYP §2.5.3.4.2, mirrors Samba `canonicalize_inheritance_bits`): persisted only when SET_INFO carries BOTH `AUTO_INHERITED` and `AUTO_INHERIT_REQ` (0x0100). Per-share opt-out (`acl flag inherited canonicalization = no`) preserves it verbatim. |
 | SE_DACL_AUTO_INHERIT_REQ (0x0100) | Works (request-only) | Processed as a request flag; never echoed back on read. |
-| SE_SACL_PRESENT (0x0010) | Partial | Set when `SACLSecurityInformation` requested, but the SACL body is an empty stub — see SACL below. |
+| SE_SACL_PRESENT (0x0010) | Works | Set when `SACLSecurityInformation` requested; the SACL body carries stored audit ACEs (or a valid 0-ACE SACL when none are stored) — see SACL below. |
 
 ## Null DACL
 
@@ -95,12 +95,15 @@ are distinct and only meaningful as inheritable placeholders (see Inheritance).
 
 | Aspect | State | Notes |
 |--------|-------|-------|
-| SACL read | Unsupported (empty stub) | `buildEmptySACL` emits a valid but zero-ACE SACL (revision 2, count 0, size 8) when `SACLSecurityInformation` is requested. No audit ACEs are ever surfaced. |
-| SACL write | Unsupported (dropped) | `ParseSecurityDescriptorWithOptions` skips the SACL offset entirely (`r.Skip(4)` with a "SACL parsing not implemented" comment). The write is access-gated (`AccessSystemSecurity` required) but the SACL content is discarded. |
-| AUDIT ACE storage | Partial | `ACE4_SYSTEM_AUDIT_ACE_TYPE` can be stored in the model and translated (`systemAuditACEType`), but is never placed in a DACL on read and never parsed from a SACL on write. ALARM ACEs have no Windows mapping (`nfsToWindowsACEType` returns false → dropped). |
+| SACL read | Works | When `SACLSecurityInformation` is requested and the file carries stored SACL ACEs, `buildSACL` serializes them into the SD's SACL section (same MS-DTYP §2.4.5 + §2.4.4.2 wire layout as a DACL). Windows Explorer's "Auditing" tab shows the stored audit ACEs. `buildEmptySACL` is the fallback only when no SACL is stored (valid 0-ACE SACL). |
+| SACL write | Works | `ParseSecurityDescriptorWithOptions` parses the SACL body via the shared `parseACEs` and persists audit ACEs into `ACL.SACL`; `setSecurityInfo` installs it via `mergeSecurityACL`, preserving the unrequested DACL/SACL section. Access-gated (`AccessSystemSecurity` required). |
+| AUDIT / ALARM ACE round-trip | Works | `ACE4_SYSTEM_AUDIT_ACE_TYPE` ↔ `systemAuditACEType` and `ACE4_SYSTEM_ALARM_ACE_TYPE` ↔ `systemAlarmACEType` map both directions (`nfsToWindowsACEType` / `windowsToNFSACEType`); the SUCCESSFUL/FAILED audit flags round-trip through `NFSv4FlagsToWindowsFlags`. Audit ACEs ride the SACL section, not the DACL. |
 
-Tracked alongside the broader cross-protocol SACL gap in
-[Access Control › Known Limitations](access-control.md#known-limitations).
+The SACL is stored on the same `acl.ACL` carrier as the DACL (`ACL.SACL`
+slice) and never participates in access checks. The store-layer round-trip
+shipped under [#1228](https://github.com/marmos91/dittofs/issues/1228); the SMB
+wire parse/serialize under
+[#1381](https://github.com/marmos91/dittofs/pull/1381).
 
 ## GENERIC_* mask expansion
 
@@ -162,15 +165,22 @@ project memory):
   (INHERITANCE/INHERITFLAGS), GENERIC expansion, and AUTO_INHERITED
   canonicalization paths are exercised by the SMB conformance suite (see
   inline references in `security.go`, `inherit.go`, `generic.go`).
+- **SACL round-trip.** Audit-ACE build → parse → re-build is covered by
+  `security_sacl_test.go` (`TestBuildSD_SACL_RoundTrip`): SE_SACL_PRESENT, the
+  serialized ACE count, and the audit ACE's type/flags/mask all survive a
+  full SD round-trip.
 - **macOS Finder.** Not separately validated for the ACL Security path; treat
   as untested for ACL fidelity.
 
 ## Known limitations
 
-1. **SACL is a stub.** Audit ACEs are never read out and are dropped on write
-   (empty SACL on QUERY_INFO; SACL offset skipped on SET_INFO). AUDIT ACEs can
-   be stored in the model but never reach a SMB client; ALARM ACEs have no
-   Windows mapping and are dropped.
+1. **SACL round-trips but does not drive audit-event generation.** Audit/alarm
+   ACEs are parsed, stored, and surfaced to the Windows "Auditing" tab
+   (read/write/round-trip via `ACL.SACL`), and the `ACCESS_SYSTEM_SECURITY` gate
+   is enforced. What is *not* implemented is acting on them: the server emits no
+   audit log when an operation matches a SUCCESSFUL/FAILED audit ACE, and ALARM
+   ACEs raise no alarm. The SACL is descriptive metadata only — it never
+   participates in access checks or event emission.
 2. **Foreign AD/LDAP SIDs are not mapped to local UID/GID.** They round-trip
    as opaque `sid:<canonical>` principals (so the ACE survives) but resolve to
    no local UID/GID. AD interop shipped under [#1231](https://github.com/marmos91/dittofs/issues/1231)

--- a/docs/guide/smb.md
+++ b/docs/guide/smb.md
@@ -103,7 +103,7 @@ AES-NI-capable hardware.
 | Persistent Handles | Cluster-aware handles (requires shared state) |
 | RDMA | Remote Direct Memory Access transport |
 | QUIC | UDP-based transport (SMB over QUIC) |
-| SACL / auditing | Audit ACEs are not enforced (owner/group/DACL **are** supported — see [Access Control](access-control.md)) |
+| SACL / auditing | Audit ACEs round-trip (read/write/Auditing tab) but are not *enforced* — no audit events are emitted (owner/group/DACL **are** supported — see [Access Control](access-control.md)) |
 | DFS | Distributed File System referrals |
 
 ---
@@ -629,7 +629,7 @@ See [Troubleshooting › Cross-Protocol Issues](troubleshooting.md#cross-protoco
 4. **No persistent handles**: Cluster-aware handles require shared state infrastructure
 5. **No RDMA transport**: Remote Direct Memory Access not supported
 6. **No QUIC transport**: SMB over QUIC (UDP) not supported
-7. **No SACL / audit ACEs**: Owner, group, and DACL security descriptors **are** supported (see [Access Control](access-control.md)); only audit ACEs (SACL) are not enforced
+7. **SACL audit events not generated**: Owner, group, and DACL security descriptors **are** supported (see [Access Control](access-control.md)); audit ACEs (SACL) round-trip through read/write and the Windows Auditing tab but are not *enforced* — no audit log is emitted on a matching access
 8. **No DFS referrals**: Distributed File System not supported
 
 ### Operational Limitations

--- a/docs/internals/acl-design.md
+++ b/docs/internals/acl-design.md
@@ -289,9 +289,9 @@ Add a mapping table linking NFS principals, Windows SIDs, and control-plane user
 
 Extend `IdentityMapper` to query this table for SID → principal resolution (and vice versa).
 
-### SACL container
+### SACL container (shipped)
 
-Add an optional SACL field on `FileAttr` for audit/alarm ACEs separate from the DACL. This enables SMB clients to set and query system ACLs independently.
+Implemented: `acl.ACL` carries an optional `SACL []ACE` slice for audit/alarm ACEs separate from the DACL, and SMB clients set and query system ACLs independently (store round-trip under #1228, SMB wire parse/serialize under #1381). SACL ACEs are descriptive metadata only — they round-trip but do not drive audit-event generation. See [SMB ACL fidelity § SACL](../guide/smb-acl-fidelity.md#sacl-audit).
 
 ### AD/LDAP integration
 

--- a/internal/adapter/smb/handlers/security.go
+++ b/internal/adapter/smb/handlers/security.go
@@ -146,7 +146,8 @@ func GetSIDMapper() *sid.SIDMapper {
 //   - Owner SID from file UID (if OwnerSecurityInformation requested)
 //   - Group SID from file GID (if GroupSecurityInformation requested)
 //   - DACL translated from file ACL (if DACLSecurityInformation requested)
-//   - SACL empty stub (if SACLSecurityInformation requested)
+//   - SACL from stored audit/alarm ACEs, or an empty SACL when none are
+//     stored (if SACLSecurityInformation requested)
 //
 // If additionalSecInfo is 0, no sections are included and a minimal empty SD
 // is returned (header only). Callers should pass explicit flags for the

--- a/internal/adapter/smb/handlers/set_info_security_authz_test.go
+++ b/internal/adapter/smb/handlers/set_info_security_authz_test.go
@@ -205,8 +205,10 @@ func TestSetInfo_SECINFO_SACL_AuthzAgainstHandleGrantedAccess(t *testing.T) {
 		if err != nil {
 			t.Fatalf("setSecurityInfo: %v", err)
 		}
-		// SACL changes are no-ops in DittoFS (no SACL persistence yet), so the
-		// handler returns SUCCESS once the gate passes.
+		// This SD carries no SACL body (DACL-only), so once the
+		// ACCESS_SYSTEM_SECURITY gate passes the handler returns SUCCESS with
+		// nothing to install. SACL persistence itself is covered by
+		// security_sacl_test.go's build/parse round-trip.
 		if resp.Status != types.StatusSuccess {
 			t.Fatalf("status = 0x%08x, want StatusSuccess (handle has ACCESS_SYSTEM_SECURITY)", resp.Status)
 		}


### PR DESCRIPTION
## Summary

Closes #1389. The issue describes the SMB SACL path as an unsupported stub, but that scope **already shipped** in #1381 (`b7d4f06b`, merged 16 minutes *before* #1389 was filed against a pre-#1381 working copy). This PR is the documentation/comment catch-up — **no behavior change**.

### What #1389 asked for vs. what's on develop

| #1389 scope | Status on develop |
|---|---|
| Parse SACL body in `ParseSecurityDescriptorWithOptions` (reuse shared `parseACEs`), persist into `ACL.SACL` | ✅ `security.go` — SACL parse branch + shared `parseACEs` |
| Serialize stored audit ACEs in `BuildSecurityDescriptor` instead of `buildEmptySACL` | ✅ `buildSACL` (empty SACL only when none stored) |
| SET_INFO SACL branch in `setSecurityInfo` | ✅ `mergeSecurityACL` (preserves the unrequested DACL/SACL section) |
| Keep the `ACCESS_SYSTEM_SECURITY` gate | ✅ `checkSetInfoSecurityAccess` (SET_INFO) + `query_info.go` (QUERY_INFO) |
| AUDIT + ALARM ACE round-trip | ✅ both directions via `nfsToWindowsACEType`/`windowsToNFSACEType` |

Test coverage already present: `security_sacl_test.go` (build/parse round-trip, empty-stub fallback, SACL-only-no-DACL, `mergeSecurityACL` preserve-section cases) and `set_info_security_authz_test.go` (ACCESS_SYSTEM_SECURITY gate, with/without).

### Changes here (docs + comments only)

- `docs/guide/smb-acl-fidelity.md` — SACL read/write/round-trip rows → **Works**; SE_SACL_PRESENT → Works; build/parse code-path table updated; known-limitation #1 reframed; client-tested note added.
- `docs/guide/access-control.md`, `docs/guide/smb.md` — "no SACL support" → "SACL round-trips but audit *events* are not generated" (the honest residual).
- `docs/internals/acl-design.md` — "SACL container" future-work note marked shipped.
- `internal/adapter/smb/handlers/security.go` — stale `BuildSecurityDescriptor` doc-comment ("empty stub").
- `set_info_security_authz_test.go` — stale "no SACL persistence yet" test comment.

### Residual (intentional, documented)

SACL is descriptive metadata: it round-trips and gates on `ACCESS_SYSTEM_SECURITY`, but the server emits no audit log on a matching access and ALARM ACEs raise no alarm. This is now stated as a known limitation rather than "stub".

🤖 Generated with [Claude Code](https://claude.com/claude-code)