### PR TITLE
fix(block): live API-created shares never reach remote (rollup pool bound to request ctx) + truthful sync stats

### DIFF
--- a/pkg/block/engine/stats.go
+++ b/pkg/block/engine/stats.go
@@ -126,8 +126,13 @@ func (bs *Store) getStats(withBlockCounts bool) BlockStoreStats {
 
 	cacheStats := bs.loadCache().Stats()
 
-	pending, completed, failed := bs.syncer.Queue().Stats()
-	_, uploads, _ := bs.syncer.Queue().PendingByType()
+	// Source sync stats from the live mirror path (pendingHashes set +
+	// completed/failed counters), NOT the vestigial SyncQueue, whose Stats()
+	// always read zero because it has no production callers (#1266). The
+	// dead-queue numbers made operators believe nothing synced even when
+	// uploads provably succeeded (#1405 diagnosis).
+	pendingUploads := bs.syncer.PendingCount()
+	completed, failed := bs.syncer.SyncCounts()
 
 	remoteHealthy := bs.syncer.IsRemoteHealthy()
 	outageDuration := bs.syncer.RemoteOutageDuration()
@@ -147,8 +152,8 @@ func (bs *Store) getStats(withBlockCounts bool) BlockStoreStats {
 		ReadBufferUsed:      cacheStats.CurBytes,
 		ReadBufferMax:       cacheStats.MaxBytes,
 		HasRemote:           bs.remote != nil,
-		PendingSyncs:        pending,
-		PendingUploads:      uploads,
+		PendingSyncs:        pendingUploads,
+		PendingUploads:      pendingUploads,
 		CompletedSyncs:      completed,
 		FailedSyncs:         failed,
 		RemoteHealthy:       remoteHealthy,

--- a/pkg/block/engine/stats.go
+++ b/pkg/block/engine/stats.go
@@ -131,8 +131,16 @@ func (bs *Store) getStats(withBlockCounts bool) BlockStoreStats {
 	// always read zero because it has no production callers (#1266). The
 	// dead-queue numbers made operators believe nothing synced even when
 	// uploads provably succeeded (#1405 diagnosis).
-	pendingUploads := bs.syncer.PendingCount()
-	completed, failed := bs.syncer.SyncCounts()
+	//
+	// In local-only mode (no remote) these counters are meaningless: addPendingHash
+	// still records rolled-up chunks but nothing ever mirrors them, so a nonzero
+	// PendingUploads would falsely imply an upload backlog. Report zeros when there
+	// is no remote — there is nothing to sync.
+	var pendingUploads, completed, failed int
+	if bs.remote != nil {
+		pendingUploads = bs.syncer.PendingCount()
+		completed, failed = bs.syncer.SyncCounts()
+	}
 
 	remoteHealthy := bs.syncer.IsRemoteHealthy()
 	outageDuration := bs.syncer.RemoteOutageDuration()

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -102,6 +102,14 @@ type Syncer struct {
 	// distinct hash (CAS dedup): re-adding a hash already pending does not
 	// double-count, and a drained hash subtracts exactly what it added.
 	unsyncedBytes atomic.Int64
+
+	// completedSyncs / failedSyncs are lifetime counters of CAS chunks that
+	// reached remote (Put + MarkSynced succeeded) and that failed a mirror
+	// attempt (Put or MarkSynced errored). They source the truthful
+	// CompletedSyncs / FailedSyncs fields in block stats; the legacy SyncQueue
+	// has no production callers, so its counters always read zero (#1266).
+	completedSyncs atomic.Int64
+	failedSyncs    atomic.Int64
 }
 
 // addPendingHash registers a newly-stored CAS hash (of the given on-disk
@@ -542,6 +550,7 @@ func (m *Syncer) mirrorChunk(ctx context.Context, hashStore metadata.SyncedHashS
 		return nil
 	}
 	if err != nil {
+		m.failedSyncs.Add(1)
 		return fmt.Errorf("local get %s: %w", hash, err)
 	}
 
@@ -558,6 +567,7 @@ func (m *Syncer) mirrorChunk(ctx context.Context, hashStore metadata.SyncedHashS
 		mx.RecordRehash(time.Since(rehashStart))
 	}
 	if computed != hash {
+		m.failedSyncs.Add(1)
 		logger.Error("local corruption detected before mirror upload — refusing to upload",
 			"hash", hash.String(),
 			"computed", computed.String(),
@@ -579,9 +589,11 @@ func (m *Syncer) mirrorChunk(ctx context.Context, hashStore metadata.SyncedHashS
 		mx.RecordUpload(len(data), result, time.Since(uploadStart))
 	}
 	if err != nil {
+		m.failedSyncs.Add(1)
 		return fmt.Errorf("remote put %s: %w", hash, err)
 	}
 	if err := hashStore.MarkSynced(ctx, hash); err != nil {
+		m.failedSyncs.Add(1)
 		return fmt.Errorf("mark synced %s: %w", hash, err)
 	}
 	m.pendingMu.Lock()
@@ -590,7 +602,24 @@ func (m *Syncer) mirrorChunk(ctx context.Context, hashStore metadata.SyncedHashS
 		m.unsyncedBytes.Add(-size)
 	}
 	m.pendingMu.Unlock()
+	m.completedSyncs.Add(1)
 	return nil
+}
+
+// PendingCount returns the number of CAS chunks present locally but not yet
+// mirrored to remote — the live pending-upload backlog. Sourced from the
+// addPendingHash/mirrorChunk set, which is the actual upload path (unlike the
+// vestigial SyncQueue).
+func (m *Syncer) PendingCount() int {
+	m.pendingMu.Lock()
+	defer m.pendingMu.Unlock()
+	return len(m.pendingHashes)
+}
+
+// SyncCounts returns lifetime (completed, failed) mirror counts: chunks that
+// reached remote and chunks that failed a mirror attempt.
+func (m *Syncer) SyncCounts() (completed, failed int) {
+	return int(m.completedSyncs.Load()), int(m.failedSyncs.Load())
 }
 
 // DrainAllUploads performs an immediate synchronous upload of every local

--- a/pkg/controlplane/runtime/shares/create_local_store_test.go
+++ b/pkg/controlplane/runtime/shares/create_local_store_test.go
@@ -150,7 +150,10 @@ func TestCreateLocalStoreFromConfig_RollupSurvivesCallerCancel(t *testing.T) {
 	// while the store lives on. The rollup pool must NOT die with it.
 	cancel()
 
-	fsStore := store.(*fs.FSStore)
+	fsStore, ok := store.(*fs.FSStore)
+	if !ok {
+		t.Fatalf("CreateLocalStoreFromConfig returned %T, want *fs.FSStore", store)
+	}
 	const payloadID = "cancel-payload"
 	// 256 KiB of dedup-resistant content — comfortably past the chunker's
 	// minimum so the rollup produces at least one CAS block.

--- a/pkg/controlplane/runtime/shares/create_local_store_test.go
+++ b/pkg/controlplane/runtime/shares/create_local_store_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/marmos91/dittofs/pkg/block/local/fs"
 	metamem "github.com/marmos91/dittofs/pkg/metadata/store/memory"
@@ -106,6 +107,91 @@ func TestCreateLocalStoreFromConfig_InvalidTypesIgnored(t *testing.T) {
 	if err := fsStore.AppendWrite(ctx, "p", []byte("x"), 0); err != nil {
 		t.Fatalf("AppendWrite under invalid-types config: %v", err)
 	}
+}
+
+// TestCreateLocalStoreFromConfig_RollupSurvivesCallerCancel is the #1405
+// regression guard. A share created live via the REST API passes the HTTP
+// request context all the way down to FSStore.StartRollup. That context is
+// cancelled the instant the create-share response is sent. If the rollup
+// worker pool inherits the caller's cancellation, the ticker exits
+// immediately and append-log data is NEVER chunked into CAS (and therefore
+// never mirrored to a remote) — the exact bug a contributor hit (files on
+// the mount, empty S3 bucket, block stats all zero).
+//
+// This test reproduces that lifecycle: it cancels the context right after
+// CreateLocalStoreFromConfig returns, then writes through the append log and
+// asserts the rollup ticker still converts it to CAS. With the bug
+// (StartRollup(ctx)) the cancellation kills the pool and no FileBlock rows
+// ever appear; the fix (StartRollup(context.WithoutCancel(ctx))) keeps the
+// pool alive — shutdown is driven by store.Close instead.
+func TestCreateLocalStoreFromConfig_RollupSurvivesCallerCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	tmp := t.TempDir()
+
+	cfg := &fakeBlockStoreConfig{
+		cfg: map[string]any{
+			"path":             tmp,
+			"max_log_bytes":    float64(2_000_000_000),
+			"rollup_workers":   float64(2),
+			"stabilization_ms": float64(50), // roll up quickly once idle
+		},
+	}
+
+	mds := metamem.NewMemoryMetadataStoreWithDefaults()
+	t.Cleanup(func() { _ = mds.Close() })
+
+	store, err := CreateLocalStoreFromConfig(ctx, "fs", cfg, "cancel-share", nil, mds)
+	if err != nil {
+		t.Fatalf("CreateLocalStoreFromConfig: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	// Simulate the HTTP handler returning: the request context is cancelled
+	// while the store lives on. The rollup pool must NOT die with it.
+	cancel()
+
+	fsStore := store.(*fs.FSStore)
+	const payloadID = "cancel-payload"
+	// 256 KiB of dedup-resistant content — comfortably past the chunker's
+	// minimum so the rollup produces at least one CAS block.
+	data := make([]byte, 256*1024)
+	for i := range data {
+		data[i] = byte(i*7 + 1)
+	}
+	if err := fsStore.AppendWrite(context.Background(), payloadID, data, 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+
+	// Poll for the rollup ticker (50ms stabilization) to fold the append log
+	// into CAS chunks on disk. A live pool converts within a few ticks; a
+	// pool killed by the cancelled caller context never does. We assert on
+	// physical CAS chunk files (the bare FSStore, with no engine wired, still
+	// writes chunks and advances the rollup offset — the FileBlock manifest is
+	// the engine's job, not the store's).
+	casDir := filepath.Join(tmp, "shares", "cancel-share", "blocks")
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if n := countFiles(casDir); n > 0 {
+			return // rollup ran despite the cancelled caller context — fixed.
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("rollup never produced CAS chunks after caller-context cancel (#1405): "+
+				"0 chunk files under %s", casDir)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// countFiles returns the number of regular files anywhere under root.
+func countFiles(root string) int {
+	n := 0
+	_ = filepath.Walk(root, func(_ string, info os.FileInfo, err error) error {
+		if err == nil && info != nil && info.Mode().IsRegular() {
+			n++
+		}
+		return nil
+	})
+	return n
 }
 
 // statDir wraps os.Stat so tests can assert the block directory was

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -2322,7 +2322,16 @@ func CreateLocalStoreFromConfig(
 		if err != nil {
 			return nil, err
 		}
-		if err := store.StartRollup(ctx); err != nil {
+		// The rollup worker pool is a persistent, store-lifetime background
+		// goroutine — it must NOT be tied to the caller's context. When a share
+		// is created live via the REST API, ctx is the HTTP request context and
+		// is cancelled the instant the response is sent; binding the rollup
+		// ticker to it kills the pool immediately, so append-log data is never
+		// chunked into CAS (and therefore never mirrored to the remote). Detach
+		// cancellation (keeping ctx values for tracing); shutdown is driven by
+		// store.Close()/GracefulStopRollup, mirroring engine.Start's use of a
+		// background context for the syncer and local-store loops.
+		if err := store.StartRollup(context.WithoutCancel(ctx)); err != nil {
 			_ = store.Close()
 			return nil, fmt.Errorf("fs local store: StartRollup: %w", err)
 		}


### PR DESCRIPTION
## What

Fixes #1405. A share created **live via the REST API** never rolled up its append log into CAS and so **never mirrored data to the remote (S3)**. Files were visible on the mount but absent from the bucket; `dfsctl store block stats` showed all zeros despite `Has Remote=true`. Only a manual or scheduled `snapshot` rescued the data.

## Root cause

`POST /api/v1/shares` passes `r.Context()` (the HTTP request context) down through `AddShare` → `createBlockStoreForShare` → `CreateLocalStoreFromConfig` → `FSStore.StartRollup(ctx)`. The rollup worker goroutines select on `case <-ctx.Done(): return`. The moment the create-share response is sent, that context is cancelled and **the rollup ticker pool exits**. With no ticker, append-log data is never chunked into CAS, `onChunkComplete→addPendingHash` never fires, and the (healthy) periodic syncer has nothing to upload.

`engine.Start` already detached the request context for the syncer and local-store loops (`context.Background()`); the rollup pool was the one background goroutine still inheriting the caller's cancellable context.

## Fix

- `store.StartRollup(context.WithoutCancel(ctx))` — keep ctx values for tracing, sever cancellation. Shutdown is driven by `store.Close()` / `GracefulStopRollup` (`bc.done` / `bc.stopRollup`, joined by `rollupWg.Wait()`), so no goroutine leak.
- **Truthful sync stats:** `block stats` `PendingUploads` / `CompletedSyncs` / `FailedSyncs` read from the vestigial `SyncQueue` (no production callers since #1266) and always reported 0 even when uploads succeeded — which is what made the bug look total. Now sourced from the live mirror path: `Syncer.PendingCount()` (live pending-hash set) + `completedSyncs`/`failedSyncs` atomics incremented in `mirrorChunk` on every success/failure.
- Regression test `TestCreateLocalStoreFromConfig_RollupSurvivesCallerCancel`: cancels the caller context after store creation, writes through the append log, asserts CAS chunks still appear. Fails without the fix (0 chunks/5s), passes with it (~0.13s).

## Why it slipped past POSIX/SMB/E2E

No test asserted that an **API-created** share's data reaches a remote on its own. Tests pre-create shares at boot (long-lived context, ticker survives) or assert while the test context is alive. The new regression test closes that gap.

## Verification (real Scaleway S3, fs-local + s3-remote)

| | broken (develop) | fixed |
|---|---|---|
| 8 MiB write+close, no snapshot, 90s | 0 objects in S3 | **8 objects in 6s** |
| `block stats` Completed Syncs | 0 | **8** |

Confirmed on the live bench VM against real fr-par S3.