### PR TITLE
perf(block): pipeline rollup into upload via wake signal (#1407)

### DIFF
--- a/pkg/block/engine/pending_set_test.go
+++ b/pkg/block/engine/pending_set_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"testing"
+	"time"
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/local/fs"
@@ -14,7 +15,12 @@ import (
 
 // newPendingSetFixture builds an engine.Store with a memory remote + a
 // memory SyncedHashStore so the upload mirror loop is exercised.
-func newPendingSetFixture(t *testing.T) (*Store, *fs.FSStore, *metadatamemory.MemoryMetadataStore) {
+// startUploader controls whether the fixture launches the background periodic
+// uploader. Tests that observe an intermediate pending-set state must pass
+// false: since #1407 the uploader wakes the instant a chunk is registered, so a
+// running uploader would drain the pending set out from under the assertion
+// (a race). Tests that exercise the live upload pipeline pass true.
+func newPendingSetFixture(t *testing.T, startUploader bool) (*Store, *fs.FSStore, *metadatamemory.MemoryMetadataStore) {
 	t.Helper()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
@@ -40,8 +46,10 @@ func newPendingSetFixture(t *testing.T) (*Store, *fs.FSStore, *metadatamemory.Me
 	if err != nil {
 		t.Fatalf("engine.New: %v", err)
 	}
-	if err := bs.Start(context.Background()); err != nil {
-		t.Fatalf("engine.Start: %v", err)
+	if startUploader {
+		if err := bs.Start(context.Background()); err != nil {
+			t.Fatalf("engine.Start: %v", err)
+		}
 	}
 	t.Cleanup(func() { _ = bs.Close() })
 	return bs, localStore, ms
@@ -57,7 +65,9 @@ func (m *Syncer) pendingLen() int {
 // chunk is registered for upload via the onChunkComplete chokepoint —
 // without any directory walk.
 func TestSyncer_StoreChunk_PopulatesPendingSet(t *testing.T) {
-	bs, localStore, _ := newPendingSetFixture(t)
+	// No background uploader: this test observes the pending set immediately
+	// after StoreChunk, which the #1407 eager uploader would otherwise drain.
+	bs, localStore, _ := newPendingSetFixture(t, false)
 	ctx := context.Background()
 
 	data := bytes.Repeat([]byte{0x7E}, 4096)
@@ -77,7 +87,9 @@ func TestSyncer_StoreChunk_PopulatesPendingSet(t *testing.T) {
 // TestSyncer_MirrorOnce_DrainsPendingSet proves mirrorOnce uploads every
 // pending hash, marks it synced, and removes it from the set.
 func TestSyncer_MirrorOnce_DrainsPendingSet(t *testing.T) {
-	bs, localStore, ms := newPendingSetFixture(t)
+	// No background uploader: mirrorOnce is driven explicitly here, and a live
+	// uploader would race the manual drain (#1407 eager wake).
+	bs, localStore, ms := newPendingSetFixture(t, false)
 	ctx := context.Background()
 
 	data := bytes.Repeat([]byte{0x22}, 4096)
@@ -110,8 +122,29 @@ func TestSyncer_MirrorOnce_DrainsPendingSet(t *testing.T) {
 // chunk written before a (simulated) restart is rediscovered, while an
 // already-synced chunk is not.
 func TestSyncer_SeedPendingFromDisk_RecoversUnsynced(t *testing.T) {
-	bs, localStore, ms := newPendingSetFixture(t)
 	ctx := context.Background()
+
+	// Build the "crashed before upload" disk state directly on a bare local
+	// store with NO running engine uploader. The engine Store wires
+	// StoreChunk's onChunkComplete to syncer.addPendingHash, which (since
+	// #1407) immediately wakes the periodic uploader and mirrors the chunk —
+	// that eager pipelining would MarkSynced the chunk we deliberately want to
+	// leave unsynced, defeating the restart simulation. A bare FSStore has no
+	// such wiring, so the unsynced chunk stays unsynced until seedPendingFromDisk
+	// rediscovers it.
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	t.Cleanup(func() { _ = ms.Close() })
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
+		MaxLogBytes:     128 * 1024 * 1024,
+		RollupWorkers:   2,
+		StabilizationMS: 5,
+		RollupStore:     ms,
+		SyncedHashStore: ms,
+	})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+	t.Cleanup(func() { _ = localStore.Close() })
 
 	unsynced := bytes.Repeat([]byte{0x01}, 4096)
 	uh := block.ContentHash(blake3.Sum256(unsynced))
@@ -129,7 +162,7 @@ func TestSyncer_SeedPendingFromDisk_RecoversUnsynced(t *testing.T) {
 
 	// Simulate restart: a fresh syncer with an empty pending set over the
 	// same local store + synced-hash store.
-	fresh := NewSyncer(localStore, bs.syncer.remoteStore, ms, DefaultConfig())
+	fresh := NewSyncer(localStore, remotememory.New(), ms, DefaultConfig())
 	fresh.SetSyncedHashStore(ms)
 	if fresh.pendingLen() != 0 {
 		t.Fatalf("fresh syncer pending set not empty: %d", fresh.pendingLen())
@@ -151,5 +184,43 @@ func TestSyncer_SeedPendingFromDisk_RecoversUnsynced(t *testing.T) {
 	}
 	if hasSynced {
 		t.Error("already-synced chunk wrongly re-seeded")
+	}
+}
+
+// TestSyncer_WakePipelinesUploadBeforeTick is the #1407 behavioural guard. A
+// rolled-up chunk registers in the pending set via onChunkComplete, which now
+// wakes the periodic uploader immediately instead of letting it idle until the
+// next UploadInterval tick. With the live uploader running, the chunk must
+// mirror to the remote well inside one tick interval — proving the wake, not
+// the ticker, drove the upload. Without the wake the chunk would sit unsynced
+// until the (multi-second) tick fired.
+func TestSyncer_WakePipelinesUploadBeforeTick(t *testing.T) {
+	interval := DefaultConfig().UploadInterval
+	if interval < time.Second {
+		t.Skipf("UploadInterval %v too short to distinguish wake from tick", interval)
+	}
+	bs, localStore, _ := newPendingSetFixture(t, true)
+	ctx := context.Background()
+
+	data := bytes.Repeat([]byte{0x5A}, 4096)
+	h := block.ContentHash(blake3.Sum256(data))
+	if err := localStore.StoreChunk(ctx, h, data); err != nil {
+		t.Fatalf("StoreChunk: %v", err)
+	}
+
+	// Generous margin below the tick interval: the wake-driven pass mirrors to
+	// the in-memory remote within milliseconds, so anything well under one tick
+	// proves pipelining. If the wake regressed, the first upload would not land
+	// until the tick at ~interval and this would fail.
+	budget := interval - 500*time.Millisecond
+	deadline := time.Now().Add(budget)
+	for {
+		if c, _ := bs.syncer.SyncCounts(); c >= 1 {
+			return // mirrored before the tick — wake pipelining fired.
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("chunk not mirrored within %v of the write — wake pipelining did not fire (#1407)", budget)
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -71,6 +71,15 @@ type Syncer struct {
 	closed bool
 	mu     gosync.RWMutex
 
+	// wake nudges the periodic uploader to run a mirror pass immediately
+	// instead of waiting up to UploadInterval for the next tick. It is
+	// signalled (non-blocking, coalescing) from addPendingHash on every
+	// freshly rolled-up chunk, so upload overlaps the rollup of later chunks
+	// rather than starting a full tick-interval after rollup finishes (#1407).
+	// Buffered length 1: a burst of chunk completions collapses to a single
+	// follow-up pass, which snapshots the whole pending set at once.
+	wake chan struct{}
+
 	periodicStarted bool        // true once periodicUploader goroutine is launched
 	uploading       atomic.Bool // Guards against overlapping periodic upload ticks
 
@@ -130,6 +139,26 @@ func (m *Syncer) addPendingHash(h block.ContentHash, size int64) {
 	m.pendingHashes[h] = size
 	m.unsyncedBytes.Add(size - prev)
 	m.pendingMu.Unlock()
+
+	// Nudge the periodic uploader to mirror this chunk now instead of waiting
+	// for the next tick, so upload pipelines with the rollup of later chunks
+	// (#1407). Only meaningful when a remote exists (the periodic uploader does
+	// not run otherwise). Non-blocking + coalescing — see signalWake.
+	if m.remoteStore != nil {
+		m.signalWake()
+	}
+}
+
+// signalWake performs a non-blocking, coalescing send on the wake channel,
+// nudging the periodic uploader to run a mirror pass immediately. Because wake
+// is buffered length 1, a burst of chunk completions collapses into a single
+// follow-up pass that snapshots the whole pending set — bounding wake-driven
+// passes regardless of chunk arrival rate (#1407).
+func (m *Syncer) signalWake() {
+	select {
+	case m.wake <- struct{}{}:
+	default:
+	}
 }
 
 // markFetchedSynced records a chunk that was just downloaded from the remote
@@ -243,6 +272,7 @@ func NewSyncer(local local.LocalStore, remoteStore remote.RemoteStore, fileBlock
 		config:         config,
 		inFlight:       make(map[string]*fetchResult),
 		stopCh:         make(chan struct{}),
+		wake:           make(chan struct{}, 1),
 		pendingHashes:  make(map[block.ContentHash]int64),
 	}
 
@@ -1023,23 +1053,18 @@ func (m *Syncer) periodicUploader(ctx context.Context, interval time.Duration) {
 					logger.Warn("Periodic syncer: drift reconcile failed", "error", err)
 				}
 			}
-			// Skip this tick if the previous upload batch is still running.
-			// This prevents overlapping ticks from multiplying memory usage.
-			if !m.uploading.CompareAndSwap(false, true) {
-				logger.Debug("Periodic syncer: previous tick still running, skipping")
-				continue
+			m.runDrainPass(ctx)
+		case <-m.wake:
+			// A freshly rolled-up chunk signalled work (#1407). Drain now
+			// instead of idling up to UploadInterval, so the mirror pipelines
+			// with the rollup of later chunks. The wake is coalesced, so this
+			// fires at most once per in-flight batch; runDrainPass still skips
+			// when a pass is already running, so wake never multiplies passes.
+			if !m.canProcess(ctx) {
+				logger.Info("Periodic syncer: canProcess=false, exiting")
+				return
 			}
-			func() {
-				defer m.uploading.Store(false)
-				// Circuit breaker: skip uploads when remote store is unhealthy
-				if !m.IsRemoteHealthy() {
-					logger.Warn("Periodic syncer: remote unhealthy, skipping upload cycle",
-						"outage_duration", m.RemoteOutageDuration(),
-						"hint", "check S3 credentials, endpoint, and bucket configuration")
-					return
-				}
-				m.syncLocalBlocks(ctx)
-			}()
+			m.runDrainPass(ctx)
 		case <-m.stopCh:
 			logger.Info("Periodic syncer: stopCh received, exiting")
 			return
@@ -1048,6 +1073,28 @@ func (m *Syncer) periodicUploader(ctx context.Context, interval time.Duration) {
 			return
 		}
 	}
+}
+
+// runDrainPass runs one mirror pass under the uploading atomic gate. It is the
+// shared body of the periodic ticker and the wake signal (#1407): the gate
+// ensures a tick and a wake never run overlapping passes (which would multiply
+// memory and double-upload), and the circuit breaker skips uploads while the
+// remote is unhealthy. A skipped pass is a no-op — the pending set is retained
+// for the next tick/wake.
+func (m *Syncer) runDrainPass(ctx context.Context) {
+	if !m.uploading.CompareAndSwap(false, true) {
+		logger.Debug("Periodic syncer: previous pass still running, skipping")
+		return
+	}
+	defer m.uploading.Store(false)
+	// Circuit breaker: skip uploads when remote store is unhealthy.
+	if !m.IsRemoteHealthy() {
+		logger.Warn("Periodic syncer: remote unhealthy, skipping upload cycle",
+			"outage_duration", m.RemoteOutageDuration(),
+			"hint", "check S3 credentials, endpoint, and bucket configuration")
+		return
+	}
+	m.syncLocalBlocks(ctx)
 }
 
 // Close shuts down the syncer and waits for pending uploads.

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -1057,9 +1057,9 @@ func (m *Syncer) periodicUploader(ctx context.Context, interval time.Duration) {
 		case <-m.wake:
 			// A freshly rolled-up chunk signalled work (#1407). Drain now
 			// instead of idling up to UploadInterval, so the mirror pipelines
-			// with the rollup of later chunks. The wake is coalesced, so this
-			// fires at most once per in-flight batch; runDrainPass still skips
-			// when a pass is already running, so wake never multiplies passes.
+			// with the rollup of later chunks. The wake is buffered length 1, so
+			// a burst of chunk completions collapses into a single queued wake;
+			// the follow-up pass snapshots the whole pending set at once.
 			if !m.canProcess(ctx) {
 				logger.Info("Periodic syncer: canProcess=false, exiting")
 				return
@@ -1076,11 +1076,13 @@ func (m *Syncer) periodicUploader(ctx context.Context, interval time.Duration) {
 }
 
 // runDrainPass runs one mirror pass under the uploading atomic gate. It is the
-// shared body of the periodic ticker and the wake signal (#1407): the gate
-// ensures a tick and a wake never run overlapping passes (which would multiply
-// memory and double-upload), and the circuit breaker skips uploads while the
-// remote is unhealthy. A skipped pass is a no-op — the pending set is retained
-// for the next tick/wake.
+// shared body of the periodic ticker and the wake signal (#1407). The ticker
+// and wake cases run in the same periodicUploader goroutine, so they already
+// cannot overlap each other; the gate's job is to serialize this pass against
+// the OTHER mirror entrypoints — Flush, SyncNow, and uploadBlock — which run
+// from caller goroutines and take the same gate. A pass that loses the gate is
+// a no-op: the pending set is retained for the next tick/wake. The circuit
+// breaker additionally skips uploads while the remote is unhealthy.
 func (m *Syncer) runDrainPass(ctx context.Context) {
 	if !m.uploading.CompareAndSwap(false, true) {
 		logger.Debug("Periodic syncer: previous pass still running, skipping")


### PR DESCRIPTION
## Why

Closes part of #1407 (rollup→S3 write-path throughput). The periodic uploader idled up to one `UploadInterval` tick (2s default) after each rollup before it started mirroring CAS chunks to the remote. For a write that rolls up in under a tick, that is up to ~2s of dead time before the first byte goes to S3, and the uploader then bursts once per tick instead of staying fed.

## What

- `addPendingHash` now nudges a coalescing, buffered-length-1 `wake` channel (`signalWake`) whenever a chunk is registered and a remote exists.
- `periodicUploader` gains a `case <-m.wake:` that drains immediately, so upload **overlaps the rollup of later chunks** instead of waiting for the next tick.
- The tick and the wake share one `runDrainPass` body, so they run under the same `uploading` CompareAndSwap gate (never overlapping passes) and the same remote-health circuit breaker. Length-1 buffering collapses a burst of completions into a single follow-up pass that snapshots the whole pending set.

This is the lowest-risk, highest-leverage of the three #1407 levers. The other two — parallelizing rollup chunk emission within a stabilization interval (`rollup.go`), and batching the per-chunk fsync in `StoreChunk` — are more invasive and tracked as follow-ups on #1407.

## Tests

- `TestSyncer_WakePipelinesUploadBeforeTick` (new): a write mirrors to the remote well inside one tick interval, proving the wake — not the ticker — drove the upload.
- The pending-set mechanic tests (`StoreChunk_PopulatesPendingSet`, `MirrorOnce_DrainsPendingSet`) now use a no-uploader fixture: since the wake drains eagerly, a running uploader would race their intermediate-state assertions. `newPendingSetFixture` gained a `startUploader bool`.
- `go test -race ./pkg/block/...` green; new + mechanic tests pass 3× under `-race`.

Builds on #1406 (the rollup-context fix + truthful sync stats), already merged to develop.