### PR TITLE
perf(block): default upload concurrency to 32, not CPU count (#1407)

### DIFF
--- a/cmd/dfsctl/commands/store/block/remote/add.go
+++ b/cmd/dfsctl/commands/store/block/remote/add.go
@@ -83,7 +83,7 @@ func init() {
 	addCmd.Flags().StringVar(&addAccessKey, "access-key", "", "AWS access key ID (for s3)")
 	addCmd.Flags().StringVar(&addSecretKey, "secret-key", "", "AWS secret access key (for s3)")
 	addCmd.Flags().StringVar(&addCompression, "compression", "", "Enable per-block compression: zstd, lz4 (default: off)")
-	addCmd.Flags().IntVar(&addParallelUploads, "parallel-uploads", 0, "Max parallel chunk uploads to this remote (0 = auto, scales with CPU count)")
+	addCmd.Flags().IntVar(&addParallelUploads, "parallel-uploads", 0, "Max parallel chunk uploads to this remote (0 = use server default of 32)")
 	// Encryption flags
 	addCmd.Flags().StringVar(&addEncryptionAEAD, "encryption-aead", "", "Enable client-side encryption with the given AEAD: aes-256-gcm, chacha20-poly1305, xchacha20-poly1305")
 	addCmd.Flags().StringVar(&addEncryptionKeyKind, "encryption-key-kind", "", "Key provider: local | kmip (required when --encryption-aead is set)")

--- a/cmd/dfsctl/commands/store/block/remote/edit.go
+++ b/cmd/dfsctl/commands/store/block/remote/edit.go
@@ -52,7 +52,7 @@ func init() {
 	editCmd.Flags().StringVar(&editEndpoint, "endpoint", "", "Custom S3 endpoint")
 	editCmd.Flags().StringVar(&editAccessKey, "access-key", "", "AWS access key ID (for s3)")
 	editCmd.Flags().StringVar(&editSecretKey, "secret-key", "", "AWS secret access key (for s3)")
-	editCmd.Flags().IntVar(&editParallelUploads, "parallel-uploads", 0, "Max parallel chunk uploads to this remote (0 = auto, scales with CPU count)")
+	editCmd.Flags().IntVar(&editParallelUploads, "parallel-uploads", 0, "Max parallel chunk uploads to this remote (0 = use server default of 32)")
 }
 
 func runEdit(cmd *cobra.Command, args []string) error {

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -6069,7 +6069,7 @@ Flags:
       --encryption-kmip-key-uid string    KMIP managed symmetric key UID (kind=kmip)
       --endpoint string                   Custom S3 endpoint (for S3-compatible stores)
       --name string                       Store name (required)
-      --parallel-uploads int              Max parallel chunk uploads to this remote (0 = auto, scales with CPU count)
+      --parallel-uploads int              Max parallel chunk uploads to this remote (0 = use server default of 32)
       --prefix string                     Key prefix within the bucket (for s3)
       --region string                     AWS region (for s3) (default "us-east-1")
       --secret-key string                 AWS secret access key (for s3)
@@ -6123,7 +6123,7 @@ Flags:
       --bucket string          S3 bucket name (for s3)
       --config string          Store configuration as JSON
       --endpoint string        Custom S3 endpoint
-      --parallel-uploads int   Max parallel chunk uploads to this remote (0 = auto, scales with CPU count)
+      --parallel-uploads int   Max parallel chunk uploads to this remote (0 = use server default of 32)
       --region string          AWS region (for s3)
       --secret-key string      AWS secret access key (for s3)
       --type string            Store type: s3, memory

--- a/pkg/block/defaults.go
+++ b/pkg/block/defaults.go
@@ -19,9 +19,21 @@ const (
 	MinLocalStoreSize      uint64 = 256 << 20 // 256 MiB
 	MinReadBufferSize      int64  = 64 << 20  // 64 MiB
 	MinMaxLogBytes         uint64 = 1 << 30   // 1 GiB
-	MinParallelSyncs              = 4
 	MinParallelFetches            = 8
 	DefaultPrefetchWorkers        = 4
+
+	// DefaultParallelUploads is the default number of concurrent CAS-chunk
+	// uploads to a remote (the mirror semaphore in mirrorOnce). Uploads are
+	// network-latency bound, NOT CPU bound — a single PUT to a remote region
+	// sustains only ~2-3 MiB/s, so throughput scales with concurrency until the
+	// uplink saturates, and ~5.5% CPU is used even at saturation (#1266/#1398).
+	// Deriving this from CPU count (the old behaviour) throttled write→remote
+	// bandwidth to roughly cores × per-conn — e.g. an 8-core host mirrored at
+	// ~14 MiB/s while raw parallel PUTs of the same bytes hit ~55 MiB/s; at
+	// concurrency 32 the same host matched/beat raw (#1407). 32 saturates a
+	// typical uplink without an unreasonable connection/FD footprint; operators
+	// tune per-remote via the parallel_uploads config (--parallel-uploads).
+	DefaultParallelUploads = 32
 )
 
 // DeducedDefaults holds block store sizing values derived from system resources.
@@ -29,7 +41,7 @@ type DeducedDefaults struct {
 	LocalStoreSize  uint64 // 25% of memory, floor 256 MiB
 	ReadBufferSize  int64  // 12.5% of memory, floor 64 MiB
 	MaxLogBytes     uint64 // 25% of memory, floor 1 GiB (append-log pressure budget)
-	ParallelSyncs   int    // max(4, cpus)
+	ParallelSyncs   int    // upload concurrency: fixed DefaultParallelUploads (network-bound, not CPU) — #1407
 	ParallelFetches int    // max(8, cpus*2)
 	PrefetchWorkers int    // fixed at DefaultPrefetchWorkers
 
@@ -37,7 +49,6 @@ type DeducedDefaults struct {
 	localStoreClamped      bool
 	readBufferClamped      bool
 	maxLogBytesClamped     bool
-	parallelSyncsClamped   bool
 	parallelFetchesClamped bool
 }
 
@@ -78,11 +89,12 @@ func DeduceDefaults(d SystemDetector) *DeducedDefaults {
 		maxLogBytes = MinMaxLogBytes
 	}
 
-	parallelSyncs := cpus
-	parallelSyncsClamped := parallelSyncs < MinParallelSyncs
-	if parallelSyncsClamped {
-		parallelSyncs = MinParallelSyncs
-	}
+	// Upload concurrency is network-bound, not CPU-bound, so it is a fixed
+	// default rather than a function of cpus (#1407 — see DefaultParallelUploads).
+	// Kept on DeducedDefaults.ParallelSyncs so the existing config/log plumbing
+	// reports the effective value; it has no floor (it is a constant, not a
+	// memory/CPU-derived size that could be clamped on small hosts).
+	parallelSyncs := DefaultParallelUploads
 
 	parallelFetches := cpus * 2
 	parallelFetchesClamped := parallelFetches < MinParallelFetches
@@ -100,7 +112,6 @@ func DeduceDefaults(d SystemDetector) *DeducedDefaults {
 		localStoreClamped:      localStoreClamped,
 		readBufferClamped:      readBufferClamped,
 		maxLogBytesClamped:     maxLogBytesClamped,
-		parallelSyncsClamped:   parallelSyncsClamped,
 		parallelFetchesClamped: parallelFetchesClamped,
 	}
 }
@@ -119,9 +130,6 @@ func (d *DeducedDefaults) HitFloors() []string {
 	}
 	if d.maxLogBytesClamped {
 		floors = append(floors, fmt.Sprintf("max_log_bytes floored at %s", FormatBytes(MinMaxLogBytes)))
-	}
-	if d.parallelSyncsClamped {
-		floors = append(floors, fmt.Sprintf("parallel_syncs floored at %d", MinParallelSyncs))
 	}
 	if d.parallelFetchesClamped {
 		floors = append(floors, fmt.Sprintf("parallel_fetches floored at %d", MinParallelFetches))

--- a/pkg/block/defaults_test.go
+++ b/pkg/block/defaults_test.go
@@ -30,66 +30,66 @@ func TestDeduceDefaults(t *testing.T) {
 			name:           "normal machine 8GiB/8CPU",
 			memory:         8 * gib,
 			cpus:           8,
-			wantLocalStore: 2 * gib, // 25% of 8GiB
-			wantReadBuffer: 1 * gib, // 12.5% of 8GiB
-			wantLogBytes:   2 * gib, // 25% of 8GiB
-			wantSyncs:      8,       // max(4, 8)
-			wantFetches:    16,      // max(8, 8*2)
+			wantLocalStore: 2 * gib,                // 25% of 8GiB
+			wantReadBuffer: 1 * gib,                // 12.5% of 8GiB
+			wantLogBytes:   2 * gib,                // 25% of 8GiB
+			wantSyncs:      DefaultParallelUploads, // upload concurrency now fixed (network-bound, not CPU) — #1407
+			wantFetches:    16,                     // max(8, 8*2)
 			wantPrefetch:   DefaultPrefetchWorkers,
 		},
 		{
 			name:           "small machine 512MiB/1CPU",
 			memory:         512 * mib,
 			cpus:           1,
-			wantLocalStore: 256 * mib, // 25% of 512MiB = 128MiB, floor 256MiB
-			wantReadBuffer: 64 * mib,  // 12.5% of 512MiB = 64MiB, exactly at floor
-			wantLogBytes:   1 * gib,   // 25% of 512MiB = 128MiB, floor 1 GiB
-			wantSyncs:      4,         // max(4, 1) = floor
-			wantFetches:    8,         // max(8, 2) = floor
+			wantLocalStore: 256 * mib,              // 25% of 512MiB = 128MiB, floor 256MiB
+			wantReadBuffer: 64 * mib,               // 12.5% of 512MiB = 64MiB, exactly at floor
+			wantLogBytes:   1 * gib,                // 25% of 512MiB = 128MiB, floor 1 GiB
+			wantSyncs:      DefaultParallelUploads, // upload concurrency now fixed (network-bound, not CPU) — #1407
+			wantFetches:    8,                      // max(8, 2) = floor
 			wantPrefetch:   DefaultPrefetchWorkers,
 		},
 		{
 			name:           "very small machine 256MiB/1CPU",
 			memory:         256 * mib,
 			cpus:           1,
-			wantLocalStore: 256 * mib, // 25% of 256MiB = 64MiB, floor 256MiB
-			wantReadBuffer: 64 * mib,  // 12.5% of 256MiB = 32MiB, floor 64MiB
-			wantLogBytes:   1 * gib,   // 25% of 256MiB = 64MiB, floor 1 GiB
-			wantSyncs:      4,         // floor
-			wantFetches:    8,         // floor
+			wantLocalStore: 256 * mib,              // 25% of 256MiB = 64MiB, floor 256MiB
+			wantReadBuffer: 64 * mib,               // 12.5% of 256MiB = 32MiB, floor 64MiB
+			wantLogBytes:   1 * gib,                // 25% of 256MiB = 64MiB, floor 1 GiB
+			wantSyncs:      DefaultParallelUploads, // upload concurrency now fixed (network-bound, not CPU) — #1407
+			wantFetches:    8,                      // floor
 			wantPrefetch:   DefaultPrefetchWorkers,
 		},
 		{
 			name:           "large machine 256GiB/64CPU",
 			memory:         256 * gib,
 			cpus:           64,
-			wantLocalStore: 64 * gib, // 25% of 256GiB
-			wantReadBuffer: 32 * gib, // 12.5% of 256GiB
-			wantLogBytes:   64 * gib, // 25% of 256GiB
-			wantSyncs:      64,       // max(4, 64)
-			wantFetches:    128,      // max(8, 128)
+			wantLocalStore: 64 * gib,               // 25% of 256GiB
+			wantReadBuffer: 32 * gib,               // 12.5% of 256GiB
+			wantLogBytes:   64 * gib,               // 25% of 256GiB
+			wantSyncs:      DefaultParallelUploads, // upload concurrency now fixed (network-bound, not CPU) — #1407
+			wantFetches:    128,                    // max(8, 128)
 			wantPrefetch:   DefaultPrefetchWorkers,
 		},
 		{
 			name:           "medium machine 4GiB/4CPU",
 			memory:         4 * gib,
 			cpus:           4,
-			wantLocalStore: 1 * gib,   // 25% of 4GiB
-			wantReadBuffer: 512 * mib, // 12.5% of 4GiB
-			wantLogBytes:   1 * gib,   // 25% of 4GiB = 1 GiB, exactly at floor
-			wantSyncs:      4,         // max(4, 4)
-			wantFetches:    8,         // max(8, 8)
+			wantLocalStore: 1 * gib,                // 25% of 4GiB
+			wantReadBuffer: 512 * mib,              // 12.5% of 4GiB
+			wantLogBytes:   1 * gib,                // 25% of 4GiB = 1 GiB, exactly at floor
+			wantSyncs:      DefaultParallelUploads, // upload concurrency now fixed (network-bound, not CPU) — #1407
+			wantFetches:    8,                      // max(8, 8)
 			wantPrefetch:   DefaultPrefetchWorkers,
 		},
 		{
 			name:           "many CPUs low memory",
 			memory:         2 * gib,
 			cpus:           32,
-			wantLocalStore: 512 * mib, // 25% of 2GiB
-			wantReadBuffer: 256 * mib, // 12.5% of 2GiB
-			wantLogBytes:   1 * gib,   // 25% of 2GiB = 512MiB, floor 1 GiB
-			wantSyncs:      32,        // max(4, 32)
-			wantFetches:    64,        // max(8, 64)
+			wantLocalStore: 512 * mib,              // 25% of 2GiB
+			wantReadBuffer: 256 * mib,              // 12.5% of 2GiB
+			wantLogBytes:   1 * gib,                // 25% of 2GiB = 512MiB, floor 1 GiB
+			wantSyncs:      DefaultParallelUploads, // upload concurrency now fixed (network-bound, not CPU) — #1407
+			wantFetches:    64,                     // max(8, 64)
 			wantPrefetch:   DefaultPrefetchWorkers,
 		},
 	}
@@ -159,13 +159,16 @@ func TestHitFloors_OnlyReportsClamped(t *testing.T) {
 		t.Errorf("expected no floors on 4GiB/4CPU, got %v", floors)
 	}
 
-	// 256MiB/1CPU: everything is clamped (local_store, read_buffer,
-	// max_log_bytes, parallel_syncs, parallel_fetches).
+	// 256MiB/1CPU: the memory-derived sizes and parallel_fetches clamp
+	// (local_store, read_buffer, max_log_bytes, parallel_fetches).
+	// parallel_syncs is no longer reported: upload concurrency is a fixed
+	// network-bound default (DefaultParallelUploads), not a CPU function, so it
+	// never hits a floor (#1407).
 	d2 := &mockDetector{memory: 256 * mib, cpus: 1}
 	got2 := DeduceDefaults(d2)
 	floors2 := got2.HitFloors()
-	if len(floors2) != 5 {
-		t.Errorf("expected 5 floors on 256MiB/1CPU, got %d: %v", len(floors2), floors2)
+	if len(floors2) != 4 {
+		t.Errorf("expected 4 floors on 256MiB/1CPU, got %d: %v", len(floors2), floors2)
 	}
 }
 

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -252,7 +252,7 @@ func NewSyncer(local local.LocalStore, remoteStore remote.RemoteStore, fileBlock
 		panic("fileBlockStore is required for Syncer")
 	}
 	if config.ParallelUploads <= 0 {
-		config.ParallelUploads = DefaultParallelUploads
+		config.ParallelUploads = block.DefaultParallelUploads
 	}
 	if config.ParallelDownloads <= 0 {
 		config.ParallelDownloads = DefaultParallelDownloads

--- a/pkg/block/engine/types.go
+++ b/pkg/block/engine/types.go
@@ -3,6 +3,8 @@ package engine
 import (
 	"errors"
 	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
 )
 
 // ErrClosed is returned when an operation is attempted on a closed Syncer.
@@ -15,10 +17,6 @@ var ErrClosed = errors.New("syncer is closed")
 // status (NFS NFS3ERR_STALE / NFS4ERR_STALE, SMB STATUS_FILE_CLOSED) so the
 // client observes the share going away rather than a torn op or a panic.
 var ErrStoreClosed = errors.New("engine: block store is closed")
-
-// DefaultParallelUploads is the default number of concurrent uploads.
-// At ~8 MB/s per S3 connection, 16 connections yields ~128 MB/s upload bandwidth.
-const DefaultParallelUploads = 16
 
 // DefaultParallelDownloads is the default number of concurrent downloads per file.
 // With 200-connection S3 pool and 8MB blocks, 32 workers can saturate the pool.
@@ -64,7 +62,7 @@ type TransferRequest struct {
 
 // Config holds configuration for the Syncer.
 type SyncerConfig struct {
-	ParallelUploads    int           // Concurrent block uploads (default: 16)
+	ParallelUploads    int           // Concurrent block uploads (default: block.DefaultParallelUploads)
 	ParallelDownloads  int           // Concurrent block downloads per file (default: 32)
 	PrefetchBlocks     int           // Blocks to prefetch ahead of reads; 0 = disabled (default: 64)
 	SmallFileThreshold int64         // Files below this are flushed synchronously; 0 = disabled
@@ -87,7 +85,7 @@ type SyncerConfig struct {
 // DefaultConfig returns the default Syncer configuration tuned for S3 performance.
 func DefaultConfig() SyncerConfig {
 	return SyncerConfig{
-		ParallelUploads:             DefaultParallelUploads,
+		ParallelUploads:             block.DefaultParallelUploads,
 		ParallelDownloads:           DefaultParallelDownloads,
 		PrefetchBlocks:              DefaultPrefetchBlocks,
 		SmallFileThreshold:          0,

--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -159,7 +159,7 @@ controlplane:
 # derives optimal block store settings per share:
 #   - LocalStoreSize: 25% of available memory (per share)
 #   - ReadBufferSize: 12.5% of available memory (per share)
-#   - ParallelSyncs: max(4, CPU count)
+#   - ParallelSyncs: 32 (upload concurrency — network-bound, not CPU-derived)
 #   - ParallelFetches: max(8, CPU count * 2)
 #
 # View current deduced values:


### PR DESCRIPTION
## Why

Part of #1407. DittoFS write→remote **bandwidth** was throttled out of the box. Upload (mirror) concurrency defaulted to `max(4, CPU count)` via `deduced.ParallelSyncs`, but CAS-chunk uploads are **network-latency bound, not CPU bound** — a single PUT to a remote region sustains only ~2–3 MiB/s and ~5.5% CPU is used at saturation (#1266/#1398). Deriving the default from cores capped throughput at roughly `cores × per-conn`.

## Measured (8-core host → scw fr-par S3, 256 MiB, NIC TX via sar)

| config | sustained | inflight |
|---|---|---|
| **old default** (8 = CPU) | ~14 MiB/s | 8 |
| **new default** (32) | **43–64 MiB/s** | 32 |
| raw parallel PUTs (boto3, reference) | ~54 MiB/s | — |

Out of the box, no flags, the new default **matches/beats raw S3** and is ~3–4× the old default. Concurrency-sweep confirmed throughput scales with inflight (24→43, 48→64 MiB/s) and inflight tracks the setting exactly.

## What

- New `block.DefaultParallelUploads = 32` — a fixed, network-oriented default. `deduced.ParallelSyncs` now returns it instead of `cpus`.
- Removed the now-dead `parallelSyncsClamped` floor path and the unused `MinParallelSyncs` const (a constant never floors).
- Unified the constant: removed the duplicate `engine.DefaultParallelUploads = 16` (which was the `NewSyncer` zero-value fallback + `DefaultConfig()`); the engine now references `block.DefaultParallelUploads`, so there is a single source of truth (no more 32-vs-16 split).
- Updated `--parallel-uploads` CLI help (`add`/`edit`) — it no longer "scales with CPU count" — and regenerated `docs/guide/cli.md`.
- `ParallelSyncs` stays on `DeducedDefaults` so existing config-show / startup logging report the effective value (now 32).

Operators still tune per-remote via `parallel_uploads` (`--parallel-uploads`), which already overrides this default in the syncer mirror semaphore.

## Not in this PR (follow-ups on #1407)

- `s3.Store` hardcodes `MaxConnsPerHost: 50`, so `--parallel-uploads > 50` is silently capped — should scale with the configured value.
- CLI footgun: passing `--config <json>` to `store block remote add` silently drops sibling flags including `--parallel-uploads`.
- #1400's adaptive window ramps from 8 and is too slow to help short file-write bursts; a high static default is more effective for DittoFS's workload.

Builds on #1408 (rollup→upload pipelining), already merged.