### PR TITLE
perf(block): adaptive upload concurrency (#1407)

### DIFF
--- a/cmd/dfsctl/commands/store/block/remote/add.go
+++ b/cmd/dfsctl/commands/store/block/remote/add.go
@@ -83,7 +83,7 @@ func init() {
 	addCmd.Flags().StringVar(&addAccessKey, "access-key", "", "AWS access key ID (for s3)")
 	addCmd.Flags().StringVar(&addSecretKey, "secret-key", "", "AWS secret access key (for s3)")
 	addCmd.Flags().StringVar(&addCompression, "compression", "", "Enable per-block compression: zstd, lz4 (default: off)")
-	addCmd.Flags().IntVar(&addParallelUploads, "parallel-uploads", 0, "Max parallel chunk uploads to this remote (0 = use server default of 32)")
+	addCmd.Flags().IntVar(&addParallelUploads, "parallel-uploads", 0, "Max parallel chunk uploads to this remote (0 = adaptive: auto-tune to saturate the uplink)")
 	// Encryption flags
 	addCmd.Flags().StringVar(&addEncryptionAEAD, "encryption-aead", "", "Enable client-side encryption with the given AEAD: aes-256-gcm, chacha20-poly1305, xchacha20-poly1305")
 	addCmd.Flags().StringVar(&addEncryptionKeyKind, "encryption-key-kind", "", "Key provider: local | kmip (required when --encryption-aead is set)")

--- a/cmd/dfsctl/commands/store/block/remote/edit.go
+++ b/cmd/dfsctl/commands/store/block/remote/edit.go
@@ -52,7 +52,7 @@ func init() {
 	editCmd.Flags().StringVar(&editEndpoint, "endpoint", "", "Custom S3 endpoint")
 	editCmd.Flags().StringVar(&editAccessKey, "access-key", "", "AWS access key ID (for s3)")
 	editCmd.Flags().StringVar(&editSecretKey, "secret-key", "", "AWS secret access key (for s3)")
-	editCmd.Flags().IntVar(&editParallelUploads, "parallel-uploads", 0, "Max parallel chunk uploads to this remote (0 = use server default of 32)")
+	editCmd.Flags().IntVar(&editParallelUploads, "parallel-uploads", 0, "Max parallel chunk uploads to this remote (0 = adaptive: auto-tune to saturate the uplink)")
 }
 
 func runEdit(cmd *cobra.Command, args []string) error {

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -6069,7 +6069,7 @@ Flags:
       --encryption-kmip-key-uid string    KMIP managed symmetric key UID (kind=kmip)
       --endpoint string                   Custom S3 endpoint (for S3-compatible stores)
       --name string                       Store name (required)
-      --parallel-uploads int              Max parallel chunk uploads to this remote (0 = use server default of 32)
+      --parallel-uploads int              Max parallel chunk uploads to this remote (0 = adaptive: auto-tune to saturate the uplink)
       --prefix string                     Key prefix within the bucket (for s3)
       --region string                     AWS region (for s3) (default "us-east-1")
       --secret-key string                 AWS secret access key (for s3)
@@ -6123,7 +6123,7 @@ Flags:
       --bucket string          S3 bucket name (for s3)
       --config string          Store configuration as JSON
       --endpoint string        Custom S3 endpoint
-      --parallel-uploads int   Max parallel chunk uploads to this remote (0 = use server default of 32)
+      --parallel-uploads int   Max parallel chunk uploads to this remote (0 = adaptive: auto-tune to saturate the uplink)
       --region string          AWS region (for s3)
       --secret-key string      AWS secret access key (for s3)
       --type string            Store type: s3, memory

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -430,11 +430,42 @@ the way to observe the async mirror backlog under the default policy.
 #### GC knobs
 
 The CAS write path uses an async syncer and a fail-closed mark-sweep
-garbage collector. The syncer's sizing (upload concurrency, claim timeout,
-etc.) is **not** an operator-facing config section — it is auto-deduced from
-system resources at startup and constructed in code; there is no `syncer:`
-config block (a stale `syncer:` section in a config file is tolerated but
-ignored, logged as an unknown key).
+garbage collector. The syncer's sizing (claim timeout, etc.) is **not** an
+operator-facing config section — it is auto-deduced from system resources at
+startup and constructed in code; there is no `syncer:` config block (a stale
+`syncer:` section in a config file is tolerated but ignored, logged as an
+unknown key). Upload concurrency is **adaptive by default** — see below.
+
+#### Adaptive upload concurrency
+
+When you mirror a share to a remote (S3 or filesystem remote), DittoFS uploads
+CAS chunks concurrently. Uploads are **network-latency bound**, not CPU bound:
+a single PUT to a remote region sustains only a few MiB/s, so throughput scales
+with the number of concurrent uploads until the uplink saturates. The right
+number depends on the link, not the host — a CPU-derived default throttled fast
+links and over-subscribed slow ones.
+
+By default DittoFS **discovers the right concurrency itself**. It starts
+conservative and ramps the number of in-flight uploads up while delivered
+throughput (goodput) keeps rising, settling at the point where opening more
+connections stops helping. It backs off only on upload errors or a real
+throughput collapse — never on the latency rise that healthy concurrency itself
+causes. No configuration is required to saturate the uplink.
+
+To **pin** a fixed concurrency instead (disabling auto-tuning), set
+`--parallel-uploads N` on the remote:
+
+```bash
+dfsctl store block remote add --name r1 --type s3 \
+  --bucket … --region … --endpoint … \
+  --parallel-uploads 32          # fixed window of 32; 0 (default) = adaptive
+```
+
+`dfsctl store block remote edit --name r1 --parallel-uploads 0` returns a remote
+to adaptive mode. Observe the live window via the Prometheus gauge
+`dittofs_datapath_upload_window` (target concurrency) alongside
+`dittofs_datapath_uploads_inflight` (actual in-flight uploads); see
+[Metrics](#metrics-prometheus).
 
 The mark-sweep GC is the one tunable surface, configured via the top-level
 `gc:` server-config section:

--- a/pkg/block/defaults.go
+++ b/pkg/block/defaults.go
@@ -3,6 +3,7 @@ package block
 import (
 	"fmt"
 	"math"
+	"strconv"
 )
 
 // SystemDetector provides system resource information for deduction.
@@ -22,18 +23,18 @@ const (
 	MinParallelFetches            = 8
 	DefaultPrefetchWorkers        = 4
 
-	// DefaultParallelUploads is the default number of concurrent CAS-chunk
-	// uploads to a remote (the mirror semaphore in mirrorOnce). Uploads are
-	// network-latency bound, NOT CPU bound — a single PUT to a remote region
-	// sustains only ~2-3 MiB/s, so throughput scales with concurrency until the
-	// uplink saturates, and ~5.5% CPU is used even at saturation (#1266/#1398).
-	// Deriving this from CPU count (the old behaviour) throttled write→remote
-	// bandwidth to roughly cores × per-conn — e.g. an 8-core host mirrored at
-	// ~14 MiB/s while raw parallel PUTs of the same bytes hit ~55 MiB/s; at
-	// concurrency 32 the same host matched/beat raw (#1407). 32 saturates a
-	// typical uplink without an unreasonable connection/FD footprint; operators
-	// tune per-remote via the parallel_uploads config (--parallel-uploads).
-	DefaultParallelUploads = 32
+	// AdaptiveUploadDefault is the sentinel for the default upload-concurrency
+	// setting: 0 means "auto-tune" — the syncer's adaptive controller ramps the
+	// mirror window to saturate the uplink (#1407). Uploads are network-latency
+	// bound, NOT CPU bound — a single PUT to a remote region sustains only ~2-3
+	// MiB/s, so throughput scales with concurrency until the uplink saturates,
+	// and ~5.5% CPU is used even at saturation (#1266/#1398). Deriving
+	// concurrency from CPU count (the original behaviour) throttled write→remote
+	// bandwidth to roughly cores × per-conn — an 8-core host mirrored at ~14
+	// MiB/s while raw parallel PUTs hit ~55 MiB/s. Rather than guess a fixed
+	// default, the syncer discovers the right window per remote; operators can
+	// still pin it via the parallel_uploads config (--parallel-uploads).
+	AdaptiveUploadDefault = 0
 )
 
 // DeducedDefaults holds block store sizing values derived from system resources.
@@ -41,7 +42,7 @@ type DeducedDefaults struct {
 	LocalStoreSize  uint64 // 25% of memory, floor 256 MiB
 	ReadBufferSize  int64  // 12.5% of memory, floor 64 MiB
 	MaxLogBytes     uint64 // 25% of memory, floor 1 GiB (append-log pressure budget)
-	ParallelSyncs   int    // upload concurrency: fixed DefaultParallelUploads (network-bound, not CPU) — #1407
+	ParallelSyncs   int    // upload concurrency: 0 = adaptive auto-tune (default), >0 = pinned — #1407
 	ParallelFetches int    // max(8, cpus*2)
 	PrefetchWorkers int    // fixed at DefaultPrefetchWorkers
 
@@ -89,12 +90,12 @@ func DeduceDefaults(d SystemDetector) *DeducedDefaults {
 		maxLogBytes = MinMaxLogBytes
 	}
 
-	// Upload concurrency is network-bound, not CPU-bound, so it is a fixed
-	// default rather than a function of cpus (#1407 — see DefaultParallelUploads).
-	// Kept on DeducedDefaults.ParallelSyncs so the existing config/log plumbing
-	// reports the effective value; it has no floor (it is a constant, not a
-	// memory/CPU-derived size that could be clamped on small hosts).
-	parallelSyncs := DefaultParallelUploads
+	// Upload concurrency is network-bound, not CPU-bound, so the default is
+	// adaptive auto-tuning rather than a function of cpus (#1407 — see
+	// AdaptiveUploadDefault). 0 flows through SyncerDefaults → cfg.ParallelUploads
+	// unchanged, which the syncer reads as "auto-tune". An explicit
+	// per-remote parallel_uploads pins a fixed window instead.
+	parallelSyncs := AdaptiveUploadDefault
 
 	parallelFetches := cpus * 2
 	parallelFetchesClamped := parallelFetches < MinParallelFetches
@@ -139,11 +140,16 @@ func (d *DeducedDefaults) HitFloors() []string {
 
 // String returns a human-readable summary of deduced defaults.
 func (d *DeducedDefaults) String() string {
+	// ParallelSyncs <= 0 is the adaptive sentinel (auto-tune upload concurrency).
+	parallelSyncs := strconv.Itoa(d.ParallelSyncs)
+	if d.ParallelSyncs <= 0 {
+		parallelSyncs = "adaptive"
+	}
 	return fmt.Sprintf(
-		"LocalStoreSize=%s, ReadBufferSize=%s, ParallelSyncs=%d, ParallelFetches=%d, MaxLogBytes=%s, PrefetchWorkers=%d",
+		"LocalStoreSize=%s, ReadBufferSize=%s, ParallelSyncs=%s, ParallelFetches=%d, MaxLogBytes=%s, PrefetchWorkers=%d",
 		FormatBytes(d.LocalStoreSize),
 		FormatBytes(uint64(d.ReadBufferSize)),
-		d.ParallelSyncs,
+		parallelSyncs,
 		d.ParallelFetches,
 		FormatBytes(d.MaxLogBytes),
 		d.PrefetchWorkers,

--- a/pkg/block/defaults_test.go
+++ b/pkg/block/defaults_test.go
@@ -30,66 +30,66 @@ func TestDeduceDefaults(t *testing.T) {
 			name:           "normal machine 8GiB/8CPU",
 			memory:         8 * gib,
 			cpus:           8,
-			wantLocalStore: 2 * gib,                // 25% of 8GiB
-			wantReadBuffer: 1 * gib,                // 12.5% of 8GiB
-			wantLogBytes:   2 * gib,                // 25% of 8GiB
-			wantSyncs:      DefaultParallelUploads, // upload concurrency now fixed (network-bound, not CPU) — #1407
-			wantFetches:    16,                     // max(8, 8*2)
+			wantLocalStore: 2 * gib,               // 25% of 8GiB
+			wantReadBuffer: 1 * gib,               // 12.5% of 8GiB
+			wantLogBytes:   2 * gib,               // 25% of 8GiB
+			wantSyncs:      AdaptiveUploadDefault, // 0 = adaptive auto-tune (network-bound, not CPU) — #1407
+			wantFetches:    16,                    // max(8, 8*2)
 			wantPrefetch:   DefaultPrefetchWorkers,
 		},
 		{
 			name:           "small machine 512MiB/1CPU",
 			memory:         512 * mib,
 			cpus:           1,
-			wantLocalStore: 256 * mib,              // 25% of 512MiB = 128MiB, floor 256MiB
-			wantReadBuffer: 64 * mib,               // 12.5% of 512MiB = 64MiB, exactly at floor
-			wantLogBytes:   1 * gib,                // 25% of 512MiB = 128MiB, floor 1 GiB
-			wantSyncs:      DefaultParallelUploads, // upload concurrency now fixed (network-bound, not CPU) — #1407
-			wantFetches:    8,                      // max(8, 2) = floor
+			wantLocalStore: 256 * mib,             // 25% of 512MiB = 128MiB, floor 256MiB
+			wantReadBuffer: 64 * mib,              // 12.5% of 512MiB = 64MiB, exactly at floor
+			wantLogBytes:   1 * gib,               // 25% of 512MiB = 128MiB, floor 1 GiB
+			wantSyncs:      AdaptiveUploadDefault, // 0 = adaptive auto-tune (network-bound, not CPU) — #1407
+			wantFetches:    8,                     // max(8, 2) = floor
 			wantPrefetch:   DefaultPrefetchWorkers,
 		},
 		{
 			name:           "very small machine 256MiB/1CPU",
 			memory:         256 * mib,
 			cpus:           1,
-			wantLocalStore: 256 * mib,              // 25% of 256MiB = 64MiB, floor 256MiB
-			wantReadBuffer: 64 * mib,               // 12.5% of 256MiB = 32MiB, floor 64MiB
-			wantLogBytes:   1 * gib,                // 25% of 256MiB = 64MiB, floor 1 GiB
-			wantSyncs:      DefaultParallelUploads, // upload concurrency now fixed (network-bound, not CPU) — #1407
-			wantFetches:    8,                      // floor
+			wantLocalStore: 256 * mib,             // 25% of 256MiB = 64MiB, floor 256MiB
+			wantReadBuffer: 64 * mib,              // 12.5% of 256MiB = 32MiB, floor 64MiB
+			wantLogBytes:   1 * gib,               // 25% of 256MiB = 64MiB, floor 1 GiB
+			wantSyncs:      AdaptiveUploadDefault, // 0 = adaptive auto-tune (network-bound, not CPU) — #1407
+			wantFetches:    8,                     // floor
 			wantPrefetch:   DefaultPrefetchWorkers,
 		},
 		{
 			name:           "large machine 256GiB/64CPU",
 			memory:         256 * gib,
 			cpus:           64,
-			wantLocalStore: 64 * gib,               // 25% of 256GiB
-			wantReadBuffer: 32 * gib,               // 12.5% of 256GiB
-			wantLogBytes:   64 * gib,               // 25% of 256GiB
-			wantSyncs:      DefaultParallelUploads, // upload concurrency now fixed (network-bound, not CPU) — #1407
-			wantFetches:    128,                    // max(8, 128)
+			wantLocalStore: 64 * gib,              // 25% of 256GiB
+			wantReadBuffer: 32 * gib,              // 12.5% of 256GiB
+			wantLogBytes:   64 * gib,              // 25% of 256GiB
+			wantSyncs:      AdaptiveUploadDefault, // 0 = adaptive auto-tune (network-bound, not CPU) — #1407
+			wantFetches:    128,                   // max(8, 128)
 			wantPrefetch:   DefaultPrefetchWorkers,
 		},
 		{
 			name:           "medium machine 4GiB/4CPU",
 			memory:         4 * gib,
 			cpus:           4,
-			wantLocalStore: 1 * gib,                // 25% of 4GiB
-			wantReadBuffer: 512 * mib,              // 12.5% of 4GiB
-			wantLogBytes:   1 * gib,                // 25% of 4GiB = 1 GiB, exactly at floor
-			wantSyncs:      DefaultParallelUploads, // upload concurrency now fixed (network-bound, not CPU) — #1407
-			wantFetches:    8,                      // max(8, 8)
+			wantLocalStore: 1 * gib,               // 25% of 4GiB
+			wantReadBuffer: 512 * mib,             // 12.5% of 4GiB
+			wantLogBytes:   1 * gib,               // 25% of 4GiB = 1 GiB, exactly at floor
+			wantSyncs:      AdaptiveUploadDefault, // 0 = adaptive auto-tune (network-bound, not CPU) — #1407
+			wantFetches:    8,                     // max(8, 8)
 			wantPrefetch:   DefaultPrefetchWorkers,
 		},
 		{
 			name:           "many CPUs low memory",
 			memory:         2 * gib,
 			cpus:           32,
-			wantLocalStore: 512 * mib,              // 25% of 2GiB
-			wantReadBuffer: 256 * mib,              // 12.5% of 2GiB
-			wantLogBytes:   1 * gib,                // 25% of 2GiB = 512MiB, floor 1 GiB
-			wantSyncs:      DefaultParallelUploads, // upload concurrency now fixed (network-bound, not CPU) — #1407
-			wantFetches:    64,                     // max(8, 64)
+			wantLocalStore: 512 * mib,             // 25% of 2GiB
+			wantReadBuffer: 256 * mib,             // 12.5% of 2GiB
+			wantLogBytes:   1 * gib,               // 25% of 2GiB = 512MiB, floor 1 GiB
+			wantSyncs:      AdaptiveUploadDefault, // 0 = adaptive auto-tune (network-bound, not CPU) — #1407
+			wantFetches:    64,                    // max(8, 64)
 			wantPrefetch:   DefaultPrefetchWorkers,
 		},
 	}
@@ -161,9 +161,8 @@ func TestHitFloors_OnlyReportsClamped(t *testing.T) {
 
 	// 256MiB/1CPU: the memory-derived sizes and parallel_fetches clamp
 	// (local_store, read_buffer, max_log_bytes, parallel_fetches).
-	// parallel_syncs is no longer reported: upload concurrency is a fixed
-	// network-bound default (DefaultParallelUploads), not a CPU function, so it
-	// never hits a floor (#1407).
+	// parallel_syncs never hits a floor: upload concurrency defaults to adaptive
+	// auto-tuning (AdaptiveUploadDefault), not a CPU/memory-derived size (#1407).
 	d2 := &mockDetector{memory: 256 * mib, cpus: 1}
 	got2 := DeduceDefaults(d2)
 	floors2 := got2.HitFloors()

--- a/pkg/block/engine/dynsem.go
+++ b/pkg/block/engine/dynsem.go
@@ -1,0 +1,120 @@
+package engine
+
+import (
+	"context"
+	gosync "sync"
+)
+
+// dynamicSemaphore is a counting semaphore whose limit can change while slots
+// are held. The adaptive upload controller (#1407) resizes it every control
+// interval, so the fixed-size golang.org/x/sync/semaphore.Weighted (size set at
+// construction) does not fit. Growing the limit wakes blocked Acquire callers
+// immediately; shrinking never preempts existing holders — it only withholds
+// new slots until in-flight falls below the new limit.
+//
+// It is also context-aware: Acquire returns ctx.Err() if the context is
+// cancelled while waiting, so a failing/cancelled mirror pass does not strand a
+// goroutine on a slot that will never free.
+type dynamicSemaphore struct {
+	mu       gosync.Mutex
+	cond     *gosync.Cond
+	limit    int
+	inflight int
+	peak     int // high-water mark of inflight since the last TakePeak
+}
+
+func newDynamicSemaphore(limit int) *dynamicSemaphore {
+	if limit < 1 {
+		limit = 1
+	}
+	s := &dynamicSemaphore{limit: limit}
+	s.cond = gosync.NewCond(&s.mu)
+	return s
+}
+
+// Acquire blocks until a slot is available or ctx is done. On ctx cancellation
+// it returns ctx.Err() without consuming a slot.
+func (s *dynamicSemaphore) Acquire(ctx context.Context) error {
+	// Fast path / context check before waiting.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	// Wake this waiter if the context is cancelled while it is parked on the
+	// cond. The watcher goroutine lives only for the duration of the wait.
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.cond.Broadcast()
+		case <-done:
+		}
+	}()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for s.inflight >= s.limit {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		s.cond.Wait()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.inflight++
+	if s.inflight > s.peak {
+		s.peak = s.inflight
+	}
+	return nil
+}
+
+// TakePeak returns the high-water mark of in-flight slots since the last call
+// and resets it to the current in-flight count. The adaptive controller uses it
+// to tell window-limited intervals (peak reached the limit) from app-limited
+// ones (peak stayed below it) — see goodputController.observe.
+func (s *dynamicSemaphore) TakePeak() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p := s.peak
+	s.peak = s.inflight
+	return p
+}
+
+// Release returns a slot and wakes one waiter.
+func (s *dynamicSemaphore) Release() {
+	s.mu.Lock()
+	if s.inflight > 0 {
+		s.inflight--
+	}
+	s.mu.Unlock()
+	s.cond.Broadcast()
+}
+
+// SetLimit changes the maximum concurrency. Growing wakes blocked waiters;
+// shrinking takes effect for future acquires only (current holders run to
+// completion).
+func (s *dynamicSemaphore) SetLimit(n int) {
+	if n < 1 {
+		n = 1
+	}
+	s.mu.Lock()
+	s.limit = n
+	s.mu.Unlock()
+	s.cond.Broadcast()
+}
+
+// Limit returns the current maximum concurrency.
+func (s *dynamicSemaphore) Limit() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.limit
+}
+
+// InFlight returns the number of currently held slots.
+func (s *dynamicSemaphore) InFlight() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.inflight
+}

--- a/pkg/block/engine/dynsem.go
+++ b/pkg/block/engine/dynsem.go
@@ -35,19 +35,37 @@ func newDynamicSemaphore(limit int) *dynamicSemaphore {
 // Acquire blocks until a slot is available or ctx is done. On ctx cancellation
 // it returns ctx.Err() without consuming a slot.
 func (s *dynamicSemaphore) Acquire(ctx context.Context) error {
-	// Fast path / context check before waiting.
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 
-	// Wake this waiter if the context is cancelled while it is parked on the
-	// cond. The watcher goroutine lives only for the duration of the wait.
+	s.mu.Lock()
+	// Fast path: a slot is free now — take it without parking or spawning a
+	// cancellation watcher. This is the common case in the mirror loop (one
+	// Acquire per chunk), so it must not allocate a goroutine per call.
+	if s.inflight < s.limit {
+		s.inflight++
+		if s.inflight > s.peak {
+			s.peak = s.inflight
+		}
+		s.mu.Unlock()
+		return nil
+	}
+	s.mu.Unlock()
+
+	// Slow path: park on the cond. A watcher wakes us if ctx is cancelled while
+	// parked. It broadcasts UNDER s.mu so the wakeup cannot fire in the gap
+	// between our ctx re-check and cond.Wait — Wait atomically releases s.mu, so
+	// holding the lock around Broadcast serializes it against that window and
+	// prevents a lost wakeup. The watcher lives only for this wait.
 	done := make(chan struct{})
 	defer close(done)
 	go func() {
 		select {
 		case <-ctx.Done():
+			s.mu.Lock()
 			s.cond.Broadcast()
+			s.mu.Unlock()
 		case <-done:
 		}
 	}()
@@ -82,14 +100,18 @@ func (s *dynamicSemaphore) TakePeak() int {
 	return p
 }
 
-// Release returns a slot and wakes one waiter.
+// Release returns a slot and wakes waiters. Broadcast (not Signal) under the
+// lock: a woken waiter may bail on a cancelled context without consuming the
+// freed slot, so waking exactly one risks stranding it — Broadcast lets the
+// next live waiter take the slot. Signalling under s.mu serializes it against a
+// waiter's ctx-check/Wait window (no lost wakeup).
 func (s *dynamicSemaphore) Release() {
 	s.mu.Lock()
 	if s.inflight > 0 {
 		s.inflight--
 	}
-	s.mu.Unlock()
 	s.cond.Broadcast()
+	s.mu.Unlock()
 }
 
 // SetLimit changes the maximum concurrency. Growing wakes blocked waiters;
@@ -101,8 +123,8 @@ func (s *dynamicSemaphore) SetLimit(n int) {
 	}
 	s.mu.Lock()
 	s.limit = n
-	s.mu.Unlock()
 	s.cond.Broadcast()
+	s.mu.Unlock()
 }
 
 // Limit returns the current maximum concurrency.

--- a/pkg/block/engine/dynsem_test.go
+++ b/pkg/block/engine/dynsem_test.go
@@ -1,0 +1,187 @@
+package engine
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// dynamicSemaphore is the concurrency primitive the adaptive upload controller
+// resizes at runtime. golang.org/x/sync/semaphore fixes its size at
+// construction, so the syncer needs one whose limit can grow and shrink while
+// slots are held. These tests pin the contract independently of the syncer.
+
+func TestDynamicSemaphore_BlocksAtLimit(t *testing.T) {
+	s := newDynamicSemaphore(2)
+	ctx := context.Background()
+	if err := s.Acquire(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Acquire(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if s.InFlight() != 2 {
+		t.Fatalf("InFlight = %d, want 2", s.InFlight())
+	}
+
+	// Third acquire must block until a slot frees.
+	acquired := make(chan struct{})
+	go func() {
+		_ = s.Acquire(ctx)
+		close(acquired)
+	}()
+	select {
+	case <-acquired:
+		t.Fatal("third Acquire returned while at limit")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	s.Release()
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("Acquire did not unblock after Release")
+	}
+}
+
+func TestDynamicSemaphore_GrowUnblocksWaiter(t *testing.T) {
+	s := newDynamicSemaphore(1)
+	ctx := context.Background()
+	if err := s.Acquire(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	acquired := make(chan struct{})
+	go func() {
+		_ = s.Acquire(ctx)
+		close(acquired)
+	}()
+	// Waiter is blocked at limit 1.
+	select {
+	case <-acquired:
+		t.Fatal("Acquire returned before grow")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Raising the limit must wake the waiter without any Release.
+	s.SetLimit(2)
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("grow did not unblock the waiter")
+	}
+}
+
+func TestDynamicSemaphore_ShrinkHoldsNewAcquires(t *testing.T) {
+	s := newDynamicSemaphore(4)
+	ctx := context.Background()
+	for i := 0; i < 4; i++ {
+		if err := s.Acquire(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Shrink below the in-flight count. Existing holders are not preempted, but
+	// no new slot may be handed out until in-flight drops below the new limit.
+	s.SetLimit(2)
+	if s.Limit() != 2 {
+		t.Fatalf("Limit = %d, want 2", s.Limit())
+	}
+
+	acquired := make(chan struct{})
+	go func() {
+		_ = s.Acquire(ctx)
+		close(acquired)
+	}()
+	// 4 in-flight, limit 2: releasing one (→3) must NOT admit the waiter.
+	s.Release()
+	select {
+	case <-acquired:
+		t.Fatal("Acquire admitted while in-flight (3) still above limit (2)")
+	case <-time.After(50 * time.Millisecond):
+	}
+	// Release two more (→1, below limit 2): now the waiter may proceed.
+	s.Release()
+	s.Release()
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("Acquire did not proceed after in-flight fell below limit")
+	}
+}
+
+func TestDynamicSemaphore_TakePeakTracksHighWater(t *testing.T) {
+	s := newDynamicSemaphore(8)
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		if err := s.Acquire(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Peak reached 5 even though we now release down to 2.
+	s.Release()
+	s.Release()
+	s.Release()
+	if p := s.TakePeak(); p != 5 {
+		t.Fatalf("TakePeak = %d, want high-water 5", p)
+	}
+	// After TakePeak the high-water resets to the current in-flight (2).
+	if p := s.TakePeak(); p != 2 {
+		t.Fatalf("TakePeak after reset = %d, want current in-flight 2", p)
+	}
+}
+
+func TestDynamicSemaphore_AcquireRespectsContext(t *testing.T) {
+	s := newDynamicSemaphore(1)
+	if err := s.Acquire(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	errc := make(chan error, 1)
+	go func() { errc <- s.Acquire(ctx) }()
+	cancel()
+	select {
+	case err := <-errc:
+		if err == nil {
+			t.Fatal("Acquire returned nil after context cancel")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Acquire did not return after context cancel")
+	}
+}
+
+func TestDynamicSemaphore_ConcurrentNeverExceedsLimit(t *testing.T) {
+	const limit = 5
+	s := newDynamicSemaphore(limit)
+	ctx := context.Background()
+	var (
+		mu      sync.Mutex
+		inFlt   int
+		maxSeen int
+		wg      sync.WaitGroup
+	)
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := s.Acquire(ctx); err != nil {
+				return
+			}
+			mu.Lock()
+			inFlt++
+			if inFlt > maxSeen {
+				maxSeen = inFlt
+			}
+			mu.Unlock()
+			time.Sleep(time.Millisecond)
+			mu.Lock()
+			inFlt--
+			mu.Unlock()
+			s.Release()
+		}()
+	}
+	wg.Wait()
+	if maxSeen > limit {
+		t.Fatalf("observed %d concurrent holders, limit was %d", maxSeen, limit)
+	}
+}

--- a/pkg/block/engine/metrics.go
+++ b/pkg/block/engine/metrics.go
@@ -17,6 +17,9 @@ type DataplaneMetrics interface {
 	UploadFinished()
 	// SetUploadQueueDepth publishes pending-upload backlog at mirror-pass start.
 	SetUploadQueueDepth(n int)
+	// SetUploadWindow publishes the target upload concurrency (adaptive window
+	// or pinned --parallel-uploads value).
+	SetUploadWindow(n int)
 	// RecordRehash records pre-upload BLAKE3 re-hash latency for one chunk.
 	RecordRehash(d time.Duration)
 }

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -119,6 +119,24 @@ type Syncer struct {
 	// has no production callers, so its counters always read zero (#1266).
 	completedSyncs atomic.Int64
 	failedSyncs    atomic.Int64
+
+	// uploadLimiter bounds concurrent CAS-chunk uploads in mirrorOnce. When
+	// --parallel-uploads is pinned (config.ParallelUploads > 0) its limit is
+	// fixed at that value. When unset (adaptive mode), the uploadController
+	// resizes it every control interval to track the goodput knee (#1407).
+	uploadLimiter *dynamicSemaphore
+
+	// uploadController is non-nil only in adaptive mode. It consumes one
+	// (goodput, sawError) sample per control interval and returns the next
+	// target window, which the controller goroutine applies to uploadLimiter.
+	uploadController *goodputController
+
+	// uploadedBytesWindow accumulates bytes successfully Put to remote since
+	// the last control tick; uploadErrWindow counts upload errors in the same
+	// span. The adaptive controller goroutine swaps both to zero each tick to
+	// compute goodput and the error flag. Plain atomics — no lock needed.
+	uploadedBytesWindow atomic.Int64
+	uploadErrWindow     atomic.Int64
 }
 
 // addPendingHash registers a newly-stored CAS hash (of the given on-disk
@@ -147,6 +165,25 @@ func (m *Syncer) addPendingHash(h block.ContentHash, size int64) {
 	if m.remoteStore != nil {
 		m.signalWake()
 	}
+}
+
+// ensureUploadLimiter lazily creates the shared upload limiter for Syncers
+// built directly (test fixtures) rather than via NewSyncer, which always wires
+// it. A fixture has no adaptive controller goroutine, so the limiter stays at a
+// fixed window: the pinned ParallelUploads if set, else the adaptive ceiling so
+// fixtures get full concurrency. Matches the existing nil-fixture guards
+// (syncedHashStore, bs, metrics). Cheap and idempotent under m.mu.
+func (m *Syncer) ensureUploadLimiter() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.uploadLimiter != nil {
+		return
+	}
+	start := m.config.ParallelUploads
+	if start <= 0 {
+		start = AdaptiveUploadCeiling
+	}
+	m.uploadLimiter = newDynamicSemaphore(start)
 }
 
 // signalWake performs a non-blocking, coalescing send on the wake channel,
@@ -251,8 +288,22 @@ func NewSyncer(local local.LocalStore, remoteStore remote.RemoteStore, fileBlock
 	if fileBlockStore == nil {
 		panic("fileBlockStore is required for Syncer")
 	}
-	if config.ParallelUploads <= 0 {
-		config.ParallelUploads = block.DefaultParallelUploads
+	// Upload concurrency: a pinned ParallelUploads > 0 fixes the window;
+	// otherwise (the default) the syncer auto-tunes between the adaptive floor
+	// and ceiling (#1407). The limiter starts at the floor in adaptive mode and
+	// at the pinned value otherwise; the controller goroutine (adaptive only)
+	// resizes it at runtime.
+	adaptive := config.ParallelUploads <= 0
+	uploadCeiling := AdaptiveUploadCeiling
+	var uploadController *goodputController
+	startWindow := config.ParallelUploads
+	if adaptive {
+		startWindow = AdaptiveUploadFloor
+		uploadController = newGoodputController(AdaptiveUploadFloor, AdaptiveUploadCeiling)
+	} else if config.ParallelUploads > uploadCeiling {
+		// A pinned window above the adaptive ceiling is honored; the queue
+		// worker pool must cover it.
+		uploadCeiling = config.ParallelUploads
 	}
 	if config.ParallelDownloads <= 0 {
 		config.ParallelDownloads = DefaultParallelDownloads
@@ -266,18 +317,22 @@ func NewSyncer(local local.LocalStore, remoteStore remote.RemoteStore, fileBlock
 	}
 
 	m := &Syncer{
-		local:          local,
-		remoteStore:    remoteStore,
-		fileBlockStore: fileBlockStore,
-		config:         config,
-		inFlight:       make(map[string]*fetchResult),
-		stopCh:         make(chan struct{}),
-		wake:           make(chan struct{}, 1),
-		pendingHashes:  make(map[block.ContentHash]int64),
+		local:            local,
+		remoteStore:      remoteStore,
+		fileBlockStore:   fileBlockStore,
+		config:           config,
+		inFlight:         make(map[string]*fetchResult),
+		stopCh:           make(chan struct{}),
+		wake:             make(chan struct{}, 1),
+		pendingHashes:    make(map[block.ContentHash]int64),
+		uploadLimiter:    newDynamicSemaphore(startWindow),
+		uploadController: uploadController,
 	}
 
 	queueConfig := DefaultSyncQueueConfig()
-	queueConfig.Workers = config.ParallelUploads
+	// In adaptive mode the queue pool must cover the ceiling the controller can
+	// ramp to; pinned mode sizes it at the fixed window.
+	queueConfig.Workers = uploadCeiling
 	queueConfig.DownloadWorkers = config.ParallelDownloads
 	m.queue = NewSyncQueue(m, queueConfig)
 
@@ -470,6 +525,7 @@ func (m *Syncer) mirrorOnce(ctx context.Context) error {
 	if hashStore == nil {
 		return nil
 	}
+	m.ensureUploadLimiter()
 
 	// Snapshot the pending set, then upload outside the lock. Hashes
 	// added mid-pass surface on the NEXT pass (same snapshot-at-start
@@ -500,33 +556,26 @@ func (m *Syncer) mirrorOnce(ctx context.Context) error {
 	// non-fatal retry-next-tick condition.
 	var lostBeforeMirror atomic.Bool
 
-	// Upload the snapshot concurrently, bounded by ParallelUploads. Each
-	// chunk is independent — a distinct CAS hash, an idempotent remote Put,
-	// and a per-hash MarkSynced — and the path is network-latency-bound, so
-	// a serial loop leaves the link idle (one in-flight S3 Put gave only
-	// ~2.7 MiB/s VM→fr-par; #1266). The first fatal error cancels the group
-	// via gctx; in-flight Puts observe the cancellation. Mirrors the bounded
-	// errgroup pattern used by warm().
-	parallel := m.config.ParallelUploads
-	if parallel < 1 {
-		parallel = 1
-	}
+	// Upload the snapshot concurrently, bounded by the shared uploadLimiter.
+	// Each chunk is independent — a distinct CAS hash, an idempotent remote Put,
+	// and a per-hash MarkSynced — and the path is network-latency-bound, so a
+	// serial loop leaves the link idle (one in-flight S3 Put gave only ~2.7
+	// MiB/s VM→fr-par; #1266). The limiter's window is fixed when
+	// --parallel-uploads is pinned and resized by the adaptive controller
+	// otherwise (#1407), so a long pass picks up window changes mid-flight. The
+	// first fatal error cancels the group via gctx; in-flight Puts observe the
+	// cancellation. Mirrors the bounded errgroup pattern used by warm().
 	g, gctx := errgroup.WithContext(ctx)
-	sem := make(chan struct{}, parallel)
 
 	for _, hash := range snapshot {
 		hash := hash
 		// Block for a slot, but stop dispatching the moment the group is
-		// failing/cancelled.
-		select {
-		case <-gctx.Done():
-		case sem <- struct{}{}:
-		}
-		if gctx.Err() != nil {
+		// failing/cancelled (Acquire returns gctx.Err() then).
+		if err := m.uploadLimiter.Acquire(gctx); err != nil {
 			break
 		}
 		g.Go(func() error {
-			defer func() { <-sem }()
+			defer m.uploadLimiter.Release()
 			return m.mirrorChunk(gctx, hashStore, hash, &lostBeforeMirror)
 		})
 	}
@@ -620,8 +669,14 @@ func (m *Syncer) mirrorChunk(ctx context.Context, hashStore metadata.SyncedHashS
 	}
 	if err != nil {
 		m.failedSyncs.Add(1)
+		// Feed the adaptive controller: an upload error in this interval signals
+		// server pushback, so the controller backs the window off next tick.
+		m.uploadErrWindow.Add(1)
 		return fmt.Errorf("remote put %s: %w", hash, err)
 	}
+	// Count delivered bytes for the adaptive controller's goodput sample. The
+	// bytes are on the wire regardless of MarkSynced, so charge them here.
+	m.uploadedBytesWindow.Add(int64(len(data)))
 	if err := hashStore.MarkSynced(ctx, hash); err != nil {
 		m.failedSyncs.Add(1)
 		return fmt.Errorf("mark synced %s: %w", hash, err)
@@ -917,6 +972,93 @@ func (m *Syncer) startPeriodicUploader(ctx context.Context) {
 		interval = 2 * time.Second
 	}
 	go m.periodicUploader(ctx, interval)
+
+	// Adaptive mode only: launch the goodput controller that resizes the
+	// upload window to saturate the uplink (#1407). Pinned --parallel-uploads
+	// leaves uploadController nil and keeps the fixed window — publish that
+	// fixed window once so the gauge reflects it instead of reading 0.
+	if m.uploadController != nil {
+		go m.runUploadController(ctx, uploadControlInterval)
+	} else if mx := m.dataplaneMetrics(); mx != nil {
+		mx.SetUploadWindow(m.uploadLimiter.Limit())
+	}
+}
+
+// uploadControlInterval is how often the adaptive controller samples goodput
+// and resizes the upload window. One second is long enough for several S3 Puts
+// to complete (so the goodput sample is stable) yet short enough to ramp from
+// the floor to the ceiling within a few seconds.
+const uploadControlInterval = time.Second
+
+// runUploadController is the adaptive upload-concurrency loop (#1407). Every
+// interval it converts the bytes successfully uploaded since the last tick into
+// a goodput sample, feeds it (with the interval's error flag) to the goodput
+// controller, and applies the returned window to the shared uploadLimiter.
+//
+// Idle intervals (no bytes, nothing in flight, no error) are skipped entirely:
+// feeding a zero-goodput sample during a write pause would otherwise be read as
+// a collapse and shrink the window for no reason. Runs only when
+// uploadController is non-nil (adaptive mode).
+func (m *Syncer) runUploadController(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	// Publish the starting window so the metric is populated before the first
+	// adjustment.
+	if mx := m.dataplaneMetrics(); mx != nil {
+		mx.SetUploadWindow(m.uploadLimiter.Limit())
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-m.stopCh:
+			return
+		case <-ticker.C:
+		}
+
+		window, goodput, inflight, sawErr, acted := m.adaptiveUploadTick(interval)
+		if !acted {
+			continue
+		}
+		logger.Debug("adaptive upload window",
+			"window", window,
+			"inflight", inflight,
+			"goodput_mibps", goodput/(1024*1024),
+			"saw_error", sawErr)
+	}
+}
+
+// adaptiveUploadTick performs one control step: it converts the bytes uploaded
+// since the last tick into a goodput sample, feeds it (with the interval's
+// error flag) to the goodput controller, and applies the resulting window to
+// the upload limiter. It returns the new window, the measured goodput (bytes/s),
+// the current in-flight count, the error flag, and acted=false for a skipped
+// idle interval (no bytes, nothing in flight, no error) where there is no
+// signal to act on. Extracted from the goroutine loop so the bytes→goodput→
+// window glue is unit-testable without a clock.
+func (m *Syncer) adaptiveUploadTick(interval time.Duration) (window int, goodput float64, inflight int, sawErr, acted bool) {
+	bytes := m.uploadedBytesWindow.Swap(0)
+	sawErr = m.uploadErrWindow.Swap(0) > 0
+	// Peak in-flight over the interval tells window-limited from app-limited:
+	// if uploads filled the window the goodput reflects the window, otherwise
+	// the upstream pipeline was the constraint (see goodputController.observe).
+	inflight = m.uploadLimiter.TakePeak()
+	curWindow := m.uploadLimiter.Limit()
+
+	if bytes == 0 && inflight == 0 && !sawErr {
+		return curWindow, 0, inflight, false, false
+	}
+
+	windowLimited := inflight >= curWindow
+	goodput = float64(bytes) / interval.Seconds()
+	window = m.uploadController.observe(goodput, windowLimited, sawErr)
+	m.uploadLimiter.SetLimit(window)
+	if mx := m.dataplaneMetrics(); mx != nil {
+		mx.SetUploadWindow(window)
+	}
+	return window, goodput, inflight, sawErr, true
 }
 
 // SyncNow triggers an immediate mirror-loop pass for every locally

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -965,6 +965,15 @@ func (m *Syncer) startPeriodicUploader(ctx context.Context) {
 	if m.periodicStarted {
 		return
 	}
+	// Manual-sync mode: durability is driven solely by explicit Flush, so the
+	// background uploader (and its adaptive controller) must not run. This makes
+	// Flush the single, deterministic mirror driver — required to observe
+	// snapshot-bounded / crash-replay mirror semantics that a concurrent
+	// uploader would otherwise race.
+	if m.config.ManualSync {
+		m.periodicStarted = true
+		return
+	}
 	m.periodicStarted = true
 
 	interval := m.config.UploadInterval

--- a/pkg/block/engine/syncer_test.go
+++ b/pkg/block/engine/syncer_test.go
@@ -428,13 +428,18 @@ type integrationFixture struct {
 }
 
 func newIntegrationFixture(t *testing.T, rs remote.RemoteStore, synced metadata.SyncedHashStore) *integrationFixture {
-	return newIntegrationFixtureWithConfig(t, rs, synced, engine.DefaultConfig())
+	// These mirror-loop scenarios drive durability via explicit Flush and
+	// assert on the exact mirror set (snapshot bounds, crash-replay window).
+	// Run in manual-sync mode so the background periodic uploader — which #1408
+	// wakes the instant a chunk rolls up, regardless of UploadInterval — does
+	// not race the Flush calls and mirror chunks out from under the assertions.
+	cfg := engine.DefaultConfig()
+	cfg.ManualSync = true
+	return newIntegrationFixtureWithConfig(t, rs, synced, cfg)
 }
 
-// newIntegrationFixtureWithConfig is newIntegrationFixture with an
-// explicit SyncerConfig. The snapshot-semantics scenario uses it to set
-// a long UploadInterval so the periodic uploader cannot drain the
-// pending set between the two explicit Flush passes the test drives.
+// newIntegrationFixtureWithConfig is newIntegrationFixture with an explicit
+// SyncerConfig.
 func newIntegrationFixtureWithConfig(t *testing.T, rs remote.RemoteStore, synced metadata.SyncedHashStore, cfg engine.SyncerConfig) *integrationFixture {
 	t.Helper()
 	if synced == nil {

--- a/pkg/block/engine/types.go
+++ b/pkg/block/engine/types.go
@@ -3,8 +3,6 @@ package engine
 import (
 	"errors"
 	"time"
-
-	"github.com/marmos91/dittofs/pkg/block"
 )
 
 // ErrClosed is returned when an operation is attempted on a closed Syncer.
@@ -60,9 +58,22 @@ type TransferRequest struct {
 	Done       chan error   // Completion channel; nil for async (fire-and-forget)
 }
 
+// Adaptive upload-concurrency bounds (#1407). When ParallelUploads is unset
+// (<= 0), the syncer auto-tunes the number of concurrent CAS-chunk uploads to
+// saturate the uplink: it starts at AdaptiveUploadFloor and ramps toward
+// AdaptiveUploadCeiling, settling at the goodput knee. A pinned
+// ParallelUploads > 0 overrides this with a fixed window.
+const (
+	AdaptiveUploadFloor   = 16 // starting window in adaptive mode (greedy start)
+	AdaptiveUploadCeiling = 64 // max window adaptive mode ramps to
+)
+
 // Config holds configuration for the Syncer.
 type SyncerConfig struct {
-	ParallelUploads    int           // Concurrent block uploads (default: block.DefaultParallelUploads)
+	// ParallelUploads is the concurrent CAS-chunk upload count. > 0 pins a fixed
+	// window; <= 0 (the default) enables adaptive auto-tuning between
+	// AdaptiveUploadFloor and AdaptiveUploadCeiling (#1407).
+	ParallelUploads    int
 	ParallelDownloads  int           // Concurrent block downloads per file (default: 32)
 	PrefetchBlocks     int           // Blocks to prefetch ahead of reads; 0 = disabled (default: 64)
 	SmallFileThreshold int64         // Files below this are flushed synchronously; 0 = disabled
@@ -85,7 +96,9 @@ type SyncerConfig struct {
 // DefaultConfig returns the default Syncer configuration tuned for S3 performance.
 func DefaultConfig() SyncerConfig {
 	return SyncerConfig{
-		ParallelUploads:             block.DefaultParallelUploads,
+		// 0 = adaptive: the syncer auto-tunes upload concurrency to saturate the
+		// uplink (#1407). A pinned --parallel-uploads overrides this.
+		ParallelUploads:             0,
 		ParallelDownloads:           DefaultParallelDownloads,
 		PrefetchBlocks:              DefaultPrefetchBlocks,
 		SmallFileThreshold:          0,

--- a/pkg/block/engine/types.go
+++ b/pkg/block/engine/types.go
@@ -80,6 +80,13 @@ type SyncerConfig struct {
 	UploadInterval     time.Duration // Periodic uploader scan interval (default: 2s)
 	UploadDelay        time.Duration // Min block age before periodic upload; Flush ignores this (default: 10s)
 
+	// ManualSync, when true, suppresses the background periodic uploader (and
+	// its adaptive controller). Durability is then driven solely by explicit
+	// Flush, making Flush the single deterministic mirror driver. Off by
+	// default; used where a concurrent uploader would race observable
+	// mirror-loop semantics (snapshot bounds, crash-replay).
+	ManualSync bool
+
 	// Health check configuration for remote store monitoring.
 	HealthCheckInterval         time.Duration // Probe interval when healthy (default: 30s)
 	HealthCheckFailureThreshold int           // Consecutive failures to mark unhealthy (default: 3)

--- a/pkg/block/engine/upload_adaptive_test.go
+++ b/pkg/block/engine/upload_adaptive_test.go
@@ -1,0 +1,140 @@
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// These tests exercise the adaptive control glue end-to-end through
+// adaptiveUploadTick: the bytes counter the upload path increments + the
+// limiter's peak in-flight → goodput + window-limited flag →
+// goodputController.observe → uploadLimiter.SetLimit. They drive the limiter the
+// way mirrorOnce does (Acquire/Release) so the window-limited vs app-limited
+// distinction is real, then run a tick — pinning the integration without a clock.
+
+func newAdaptiveTestSyncer() *Syncer {
+	return &Syncer{
+		uploadLimiter:    newDynamicSemaphore(AdaptiveUploadFloor),
+		uploadController: newGoodputController(AdaptiveUploadFloor, AdaptiveUploadCeiling),
+	}
+}
+
+// runTick simulates one control interval: `held` uploads run and complete
+// within it (acquire then release sets the limiter's peak high-water, so the
+// window-limited signal is real), delivering `bytes` with an optional error.
+// The uploads have finished by the time the controller samples, exactly as in
+// production, so in-flight is back to zero at tick time.
+func runTick(t *testing.T, m *Syncer, held int, bytes int64, errFlag bool) int {
+	t.Helper()
+	ctx := context.Background()
+	for j := 0; j < held; j++ {
+		if err := m.uploadLimiter.Acquire(ctx); err != nil {
+			t.Fatalf("acquire: %v", err)
+		}
+	}
+	for j := 0; j < held; j++ {
+		m.uploadLimiter.Release()
+	}
+	m.uploadedBytesWindow.Store(bytes)
+	if errFlag {
+		m.uploadErrWindow.Store(1)
+	}
+	w, _, _, _, _ := m.adaptiveUploadTick(time.Second)
+	return w
+}
+
+func TestAdaptiveUploadTick_RampsWindowAsGoodputRises(t *testing.T) {
+	m := newAdaptiveTestSyncer()
+	const perConn = 2 * 1024 * 1024 // 2 MiB/s/conn — unsaturated link
+
+	start := m.uploadLimiter.Limit()
+	// Each interval fully saturates the window and delivers goodput proportional
+	// to it (link not saturated), so the controller must keep opening the window.
+	for i := 0; i < 6; i++ {
+		w := m.uploadLimiter.Limit()
+		runTick(t, m, w, int64(w*perConn), false)
+	}
+	if m.uploadLimiter.Limit() <= start {
+		t.Fatalf("window did not ramp on rising goodput: start=%d end=%d", start, m.uploadLimiter.Limit())
+	}
+}
+
+func TestAdaptiveUploadTick_SettlesWhenLinkSaturates(t *testing.T) {
+	m := newAdaptiveTestSyncer()
+	const perConn = 2 * 1024 * 1024
+	const saturationConns = 40 // goodput stops rising past this many connections (above the floor)
+
+	var last int
+	for i := 0; i < 20; i++ {
+		w := m.uploadLimiter.Limit()
+		effective := w
+		if effective > saturationConns {
+			effective = saturationConns
+		}
+		// Window fully saturated, but goodput plateaus past the knee.
+		last = runTick(t, m, w, int64(effective*perConn), false)
+	}
+	if last >= AdaptiveUploadCeiling {
+		t.Fatalf("window pinned at ceiling on a saturated link: %d", last)
+	}
+	if last <= AdaptiveUploadFloor {
+		t.Fatalf("window collapsed to the floor despite useful goodput: %d", last)
+	}
+}
+
+func TestAdaptiveUploadTick_HoldsWindowWhenPipelineStarves(t *testing.T) {
+	m := newAdaptiveTestSyncer()
+	const perConn = 2 * 1024 * 1024
+	// Ramp up while window-limited.
+	for i := 0; i < 5; i++ {
+		w := m.uploadLimiter.Limit()
+		runTick(t, m, w, int64(w*perConn), false)
+	}
+	high := m.uploadLimiter.Limit()
+	if high <= AdaptiveUploadFloor {
+		t.Fatalf("precondition: expected ramp, got %d", high)
+	}
+	// Upstream pipeline starves: only 2 chunks ever in flight (peak=2 << window),
+	// goodput tiny. This is app-limited, not congestion — the window MUST hold so
+	// the drain is fast when the backlog bursts (the #1407 collapse bug).
+	for i := 0; i < 6; i++ {
+		w := runTick(t, m, 2, 2*perConn, false)
+		if w != high {
+			t.Fatalf("starve sample %d moved the window: %d -> %d", i, high, w)
+		}
+	}
+}
+
+func TestAdaptiveUploadTick_SkipsIdleInterval(t *testing.T) {
+	m := newAdaptiveTestSyncer()
+	// Saturate + deliver bytes so the first tick acts.
+	runTick(t, m, m.uploadLimiter.Limit(), 64*1024*1024, false)
+	before := m.uploadLimiter.Limit()
+
+	// Idle interval: no bytes, nothing in flight, no error. Must not act.
+	_, _, _, _, acted := m.adaptiveUploadTick(time.Second)
+	if acted {
+		t.Fatal("adaptiveUploadTick acted on an idle interval")
+	}
+	if m.uploadLimiter.Limit() != before {
+		t.Fatalf("idle interval changed the window: %d -> %d", before, m.uploadLimiter.Limit())
+	}
+}
+
+func TestAdaptiveUploadTick_BacksOffOnError(t *testing.T) {
+	m := newAdaptiveTestSyncer()
+	for i := 0; i < 4; i++ {
+		w := m.uploadLimiter.Limit()
+		runTick(t, m, w, int64(w)*4*1024*1024, false)
+	}
+	high := m.uploadLimiter.Limit()
+	if high <= AdaptiveUploadFloor {
+		t.Fatalf("precondition: expected ramp above floor, got %d", high)
+	}
+	// An upload error in the interval must shrink the window.
+	after := runTick(t, m, high, int64(high)*4*1024*1024, true)
+	if after >= high {
+		t.Fatalf("window did not back off after an upload error: %d -> %d", high, after)
+	}
+}

--- a/pkg/block/engine/upload_controller.go
+++ b/pkg/block/engine/upload_controller.go
@@ -1,0 +1,157 @@
+package engine
+
+import "math"
+
+// goodputController is the pure decision core of adaptive upload concurrency
+// (#1407). When the user does not pin --parallel-uploads, the syncer ramps the
+// number of concurrent CAS-chunk uploads to saturate the uplink on its own.
+//
+// The control signal is GOODPUT (delivered bytes/sec), not latency. An earlier
+// latency-gradient design (#1400) read the per-PUT latency rise *caused by
+// useful concurrency* as congestion and collapsed the window to ~4, far below
+// the bandwidth knee. Uploads here are network-latency bound, so opening more
+// connections raises both latency and throughput together until the link
+// saturates — the only honest saturation signal is "did goodput stop rising".
+//
+// The loop is TCP-slow-start-like: start at a floor, ramp multiplicatively
+// while goodput keeps improving, hold when it plateaus, settle at the window
+// that delivered the best goodput (the knee), and back off only on upload
+// errors or a goodput collapse. It is deterministic and depends on no clock,
+// network, or goroutine, so its behaviour is pinned entirely by unit tests.
+type goodputController struct {
+	floor   int
+	ceiling int
+
+	cur        int     // current target concurrency
+	bestWindow int     // window that delivered bestGoodput (the knee)
+	best       float64 // best smoothed goodput seen so far
+	ema        float64 // EWMA-smoothed goodput
+	emaInit    bool
+	stall      int // consecutive samples without a meaningful improvement
+
+	// Tunables. Defaults chosen for the S3 upload path (see newGoodputController).
+	rampFactor    float64 // multiplicative window increase while improving
+	backoffFactor float64 // multiplicative decrease on error / collapse
+	improveFrac   float64 // min relative goodput gain that counts as "improving"
+	collapseFrac  float64 // goodput below best*collapseFrac is treated as collapse
+	emaAlpha      float64 // EWMA weight on the newest sample
+	stallLimit    int     // plateau samples before settling at the knee
+}
+
+// newGoodputController returns a controller that ramps within [floor, ceiling].
+func newGoodputController(floor, ceiling int) *goodputController {
+	if floor < 1 {
+		floor = 1
+	}
+	if ceiling < floor {
+		ceiling = floor
+	}
+	return &goodputController{
+		floor:         floor,
+		ceiling:       ceiling,
+		cur:           floor,
+		bestWindow:    floor,
+		rampFactor:    1.5,
+		backoffFactor: 0.7,
+		improveFrac:   0.10,
+		collapseFrac:  0.5,
+		emaAlpha:      0.5,
+		stallLimit:    3,
+	}
+}
+
+// window returns the current target concurrency.
+func (c *goodputController) window() int { return c.cur }
+
+// observe feeds one control-interval sample and returns the next target window.
+// goodput is the delivered bytes/sec over the interval; windowLimited is true
+// when the window was actually saturated during the interval (in-flight uploads
+// reached the limit); sawError is true if any upload failed.
+//
+// windowLimited is the crux. Goodput only carries information about the window
+// when the window is the binding constraint. When it is NOT — the upstream
+// rollup pipeline produced fewer chunks than the window could carry — goodput
+// is app-limited, and reacting to it would shrink the window precisely when the
+// pipeline is about to burst a backlog that a wide window must drain fast. The
+// bursty rollup→upload pipeline does exactly this, so the controller only ramps
+// or backs off on window-limited samples and otherwise holds (#1407).
+func (c *goodputController) observe(goodput float64, windowLimited, sawError bool) int {
+	// Smooth the (noisy) per-interval goodput before any decision.
+	if !c.emaInit {
+		c.ema = goodput
+		c.emaInit = true
+	} else {
+		c.ema = c.emaAlpha*goodput + (1-c.emaAlpha)*c.ema
+	}
+
+	switch {
+	case sawError && windowLimited:
+		// Server pushback / overload while the window was the binding constraint.
+		// Shrink and re-probe later. Decay the best reference too so recovery is
+		// judged against the post-backoff regime rather than an unreachable peak.
+		c.shrink()
+		c.best *= c.backoffFactor
+
+	case !windowLimited:
+		// App-limited: the upstream pipeline, not the window, capped goodput.
+		// Hold the window — there is no congestion signal, and shrinking would
+		// throttle the drain the moment upstream catches up. A stray error here
+		// (e.g. one chunk failing during a low-trickle phase) is NOT treated as
+		// congestion: the window had nothing to do with it, so corrupting the
+		// learned knee over it would needlessly deflate the next burst.
+		return c.cur
+
+	case c.best > 0 && goodput < c.best*c.collapseFrac:
+		// Goodput fell sharply below the best we have seen with no explicit
+		// error — treat as congestion collapse and back off. This branch reads
+		// the RAW sample, not the EWMA: a real collapse must be reacted to
+		// immediately (AIMD-style), whereas the improvement branch below stays
+		// smoothed so transient noise does not drive the window up.
+		c.shrink()
+
+	case c.ema > c.best*(1+c.improveFrac):
+		// Still climbing: record the knee-so-far and open the window further.
+		c.best = c.ema
+		c.bestWindow = c.cur
+		c.stall = 0
+		c.grow()
+
+	default:
+		// Plateau: goodput is not meaningfully better than the best seen. Hold,
+		// and after enough flat samples settle back at the knee (the smallest
+		// window that delivered near-peak goodput — less resource use for the
+		// same throughput).
+		if c.ema > c.best {
+			c.best = c.ema
+		}
+		c.stall++
+		if c.stall >= c.stallLimit {
+			c.cur = c.bestWindow
+		}
+	}
+	return c.cur
+}
+
+func (c *goodputController) grow() {
+	next := int(math.Ceil(float64(c.cur) * c.rampFactor))
+	if next <= c.cur {
+		next = c.cur + 1
+	}
+	if next > c.ceiling {
+		next = c.ceiling
+	}
+	c.cur = next
+}
+
+func (c *goodputController) shrink() {
+	next := int(math.Round(float64(c.cur) * c.backoffFactor))
+	if next >= c.cur {
+		next = c.cur - 1
+	}
+	if next < c.floor {
+		next = c.floor
+	}
+	c.cur = next
+	c.bestWindow = next
+	c.stall = 0
+}

--- a/pkg/block/engine/upload_controller_test.go
+++ b/pkg/block/engine/upload_controller_test.go
@@ -1,0 +1,182 @@
+package engine
+
+import "testing"
+
+// The goodput controller is the pure decision core of adaptive upload
+// concurrency (#1407). It consumes one (goodput, sawError) sample per control
+// interval and returns the next target window. It must:
+//   - start at the floor,
+//   - ramp up while delivered goodput keeps improving (TCP-slow-start-like),
+//   - settle at the knee once goodput stops improving (no endless growth),
+//   - back off on upload errors or a goodput collapse,
+//   - never leave [floor, ceiling].
+//
+// These tests pin the algorithm independently of any network, goroutine, or
+// clock, so a regression in the math is caught here rather than only on the VM.
+
+func TestGoodputController_StartsAtFloor(t *testing.T) {
+	c := newGoodputController(8, 64)
+	if got := c.window(); got != 8 {
+		t.Fatalf("initial window = %d, want floor 8", got)
+	}
+}
+
+func TestGoodputController_RampsUpWhileGoodputImproves(t *testing.T) {
+	c := newGoodputController(8, 64)
+	// Each wider window delivers strictly more goodput: the link is not yet
+	// saturated, so the controller must keep opening the window.
+	prev := c.window()
+	goodput := 10.0
+	for i := 0; i < 8; i++ {
+		w := c.observe(goodput, true, false)
+		if w < prev {
+			t.Fatalf("sample %d: window shrank (%d -> %d) while goodput rising", i, prev, w)
+		}
+		prev = w
+		goodput *= 2 // keep improving well above the noise threshold
+		if w >= 64 {
+			break // reached the ceiling; cannot grow further
+		}
+	}
+	if prev <= 8 {
+		t.Fatalf("window stayed at floor despite rising goodput: %d", prev)
+	}
+}
+
+func TestGoodputController_SettlesAtKneeWhenGoodputPlateaus(t *testing.T) {
+	c := newGoodputController(8, 64)
+	// Phase 1: goodput climbs, window ramps.
+	c.observe(10, true, false)
+	c.observe(20, true, false)
+	c.observe(30, true, false)
+	peak := c.window()
+	// Phase 2: goodput flat (link saturated). The window must stop growing and
+	// converge — it must NOT keep climbing to the ceiling on a saturated link.
+	var last int
+	for i := 0; i < 8; i++ {
+		last = c.observe(30, true, false)
+	}
+	if last > peak {
+		t.Fatalf("window kept growing past the knee on flat goodput: peak=%d last=%d", peak, last)
+	}
+	// And it must have converged (a second identical run of samples is stable).
+	stable := c.observe(30, true, false)
+	if stable != last {
+		t.Fatalf("window not converged on flat goodput: %d then %d", last, stable)
+	}
+}
+
+func TestGoodputController_DoesNotExceedCeiling(t *testing.T) {
+	c := newGoodputController(8, 32)
+	// Goodput improves forever; only the ceiling should stop the ramp.
+	goodput := 10.0
+	for i := 0; i < 20; i++ {
+		w := c.observe(goodput, true, false)
+		if w > 32 {
+			t.Fatalf("window exceeded ceiling: %d", w)
+		}
+		goodput *= 1.5
+	}
+	if c.window() != 32 {
+		t.Fatalf("window did not reach ceiling under unbounded goodput: %d", c.window())
+	}
+}
+
+func TestGoodputController_BacksOffOnError(t *testing.T) {
+	c := newGoodputController(8, 64)
+	// Ramp up first.
+	c.observe(10, true, false)
+	c.observe(20, true, false)
+	c.observe(40, true, false)
+	high := c.window()
+	if high <= 8 {
+		t.Fatalf("precondition: window should have ramped, got %d", high)
+	}
+	// An upload error must shrink the window (server pushback / overload).
+	after := c.observe(40, true, true)
+	if after >= high {
+		t.Fatalf("window did not back off on error: %d -> %d", high, after)
+	}
+}
+
+func TestGoodputController_BacksOffOnGoodputCollapse(t *testing.T) {
+	c := newGoodputController(8, 64)
+	c.observe(10, true, false)
+	c.observe(40, true, false)
+	c.observe(80, true, false)
+	high := c.window()
+	// Goodput collapses to a fraction of the best seen (congestion), no explicit
+	// error. The controller must still shrink.
+	after := c.observe(10, true, false)
+	if after >= high {
+		t.Fatalf("window did not back off on goodput collapse: %d -> %d", high, after)
+	}
+}
+
+func TestGoodputController_NeverBelowFloor(t *testing.T) {
+	c := newGoodputController(8, 64)
+	c.observe(50, true, false)
+	// Hammer it with errors; it must never drop below the floor.
+	for i := 0; i < 20; i++ {
+		w := c.observe(1, true, true)
+		if w < 8 {
+			t.Fatalf("window dropped below floor: %d", w)
+		}
+	}
+}
+
+func TestGoodputController_HoldsWindowWhenAppLimited(t *testing.T) {
+	c := newGoodputController(8, 64)
+	// Ramp up while window-limited.
+	c.observe(10, true, false)
+	c.observe(20, true, false)
+	c.observe(40, true, false)
+	high := c.window()
+	if high <= 8 {
+		t.Fatalf("precondition: expected ramp, got %d", high)
+	}
+	// Now the upstream pipeline starves the uploader: goodput collapses but the
+	// window was NOT the constraint (app-limited). The controller must HOLD the
+	// window — shrinking here would cripple throughput the moment upstream
+	// catches up (the bursty rollup→upload pipeline does exactly this, #1407).
+	for i := 0; i < 5; i++ {
+		w := c.observe(1, false, false) // low goodput, app-limited
+		if w != high {
+			t.Fatalf("app-limited sample %d moved the window: %d -> %d", i, high, w)
+		}
+	}
+}
+
+func TestGoodputController_HoldsOnErrorWhenAppLimited(t *testing.T) {
+	c := newGoodputController(8, 64)
+	// Ramp up while window-limited.
+	c.observe(10, true, false)
+	c.observe(20, true, false)
+	c.observe(40, true, false)
+	high := c.window()
+	if high <= 8 {
+		t.Fatalf("precondition: expected ramp, got %d", high)
+	}
+	// A stray error during an app-limited interval (window was NOT the
+	// constraint) must NOT shrink the window or corrupt the learned knee — that
+	// would needlessly deflate the next burst.
+	after := c.observe(1, false, true)
+	if after != high {
+		t.Fatalf("app-limited error moved the window: %d -> %d", high, after)
+	}
+}
+
+func TestGoodputController_RecoversAfterBackoff(t *testing.T) {
+	c := newGoodputController(8, 64)
+	c.observe(10, true, false)
+	c.observe(20, true, false)
+	c.observe(40, true, false)
+	c.observe(40, true, true) // back off
+	low := c.window()
+	// Conditions recover: goodput climbs again, window must re-open.
+	c.observe(80, true, false)
+	c.observe(160, true, false)
+	if c.window() <= low {
+		t.Fatalf("window did not recover after backoff: low=%d now=%d", low, c.window())
+	}
+}

--- a/pkg/block/remote/s3/store.go
+++ b/pkg/block/remote/s3/store.go
@@ -43,6 +43,12 @@ const casPrefix = "cas/"
 // their drain deadlines.
 const s3HTTPRequestTimeout = 2 * time.Minute
 
+// maxS3ConnsPerHost sizes the HTTP connection pool. It must stay >=
+// engine.AdaptiveUploadCeiling (64) plus room for concurrent downloads so the
+// pool never caps the syncer's adaptive upload window (#1407). Defined locally
+// rather than imported from engine to avoid a dependency cycle.
+const maxS3ConnsPerHost = 128
+
 // Compile-time interface satisfaction check.
 var (
 	_ remote.RemoteStore       = (*Store)(nil)
@@ -135,12 +141,16 @@ func NewFromConfig(ctx context.Context, config Config) (*Store, error) {
 		credentials.NewStaticCredentialsProvider(config.AccessKey, config.SecretKey, ""),
 	))
 
-	// Configure HTTP client for parallel uploads. Pool size kept moderate
-	// to limit memory overhead (~50 conns x 512KB buffers = ~25MB).
+	// Configure HTTP client for parallel uploads. The pool must not cap the
+	// syncer's upload window below its ceiling, or it becomes the hidden
+	// bottleneck: the adaptive controller ramps to engine.AdaptiveUploadCeiling
+	// (64) and downloads run concurrently on the same host, so size for both
+	// (128 conns x ~512KB buffers ≈ 64MB worst case, created on demand). A
+	// pinned --parallel-uploads above this still caps here (#1407 follow-up).
 	httpTransport := &http.Transport{
-		MaxIdleConns:        50,
-		MaxIdleConnsPerHost: 50,
-		MaxConnsPerHost:     50,
+		MaxIdleConns:        maxS3ConnsPerHost,
+		MaxIdleConnsPerHost: maxS3ConnsPerHost,
+		MaxConnsPerHost:     maxS3ConnsPerHost,
 		IdleConnTimeout:     90 * time.Second,
 		ForceAttemptHTTP2:   false,
 		TLSNextProto:        make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),

--- a/pkg/block/remote/s3/store.go
+++ b/pkg/block/remote/s3/store.go
@@ -43,11 +43,13 @@ const casPrefix = "cas/"
 // their drain deadlines.
 const s3HTTPRequestTimeout = 2 * time.Minute
 
-// maxS3ConnsPerHost sizes the HTTP connection pool. It must stay >=
-// engine.AdaptiveUploadCeiling (64) plus room for concurrent downloads so the
-// pool never caps the syncer's adaptive upload window (#1407). Defined locally
+// maxS3ConnsPerHost sizes the HTTP connection pool so it never caps the
+// syncer's upload concurrency (#1407): it matches the maximum a user can pin
+// via --parallel-uploads (validateParallelUploads allows up to 256) and so also
+// covers the adaptive ceiling (engine.AdaptiveUploadCeiling, 64) plus concurrent
+// downloads. 256 conns are created on demand, not preallocated. Defined locally
 // rather than imported from engine to avoid a dependency cycle.
-const maxS3ConnsPerHost = 128
+const maxS3ConnsPerHost = 256
 
 // Compile-time interface satisfaction check.
 var (

--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -159,7 +159,7 @@ controlplane:
 # derives optimal block store settings per share:
 #   - LocalStoreSize: 25% of available memory (per share)
 #   - ReadBufferSize: 12.5% of available memory (per share)
-#   - ParallelSyncs: 32 (upload concurrency — network-bound, not CPU-derived)
+#   - ParallelSyncs: adaptive (upload concurrency auto-tunes to saturate the uplink)
 #   - ParallelFetches: max(8, CPU count * 2)
 #
 # View current deduced values:

--- a/pkg/metrics/instruments.go
+++ b/pkg/metrics/instruments.go
@@ -55,6 +55,7 @@ type instruments struct {
 	uploadBytes      prometheus.Histogram
 	uploadsInflight  prometheus.Gauge
 	uploadQueueDepth prometheus.Gauge
+	uploadWindow     prometheus.Gauge
 	rehashDuration   prometheus.Histogram
 }
 
@@ -163,6 +164,10 @@ func newInstruments(reg *prometheus.Registry) *instruments {
 			Namespace: Namespace, Subsystem: "datapath", Name: "upload_queue_depth",
 			Help: "CAS chunks pending upload, sampled at the start of each mirror pass.",
 		}),
+		uploadWindow: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace, Subsystem: "datapath", Name: "upload_window",
+			Help: "Target upload concurrency: the adaptive controller's current window, or the pinned --parallel-uploads value.",
+		}),
 		rehashDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: Namespace, Subsystem: "datapath", Name: "rehash_duration_seconds",
 			Help:    "BLAKE3 re-hash (pre-upload bitrot verify) latency per CAS chunk, in seconds.",
@@ -175,7 +180,7 @@ func newInstruments(reg *prometheus.Registry) *instruments {
 		in.gcRuns, in.gcRunning, in.gcLastRunTime, in.gcSweptObjects, in.gcFreedBytes, in.gcDurationSecs,
 		in.snapOps, in.snapDuration,
 		in.uploadsTotal, in.uploadDuration, in.uploadBytes, in.uploadsInflight,
-		in.uploadQueueDepth, in.rehashDuration,
+		in.uploadQueueDepth, in.uploadWindow, in.rehashDuration,
 	)
 	return in
 }
@@ -322,6 +327,15 @@ func (m *Metrics) SetUploadQueueDepth(n int) {
 		return
 	}
 	m.in.uploadQueueDepth.Set(float64(n))
+}
+
+// SetUploadWindow publishes the target upload concurrency — the adaptive
+// controller's current window, or the pinned --parallel-uploads value.
+func (m *Metrics) SetUploadWindow(n int) {
+	if m == nil {
+		return
+	}
+	m.in.uploadWindow.Set(float64(n))
 }
 
 // RecordRehash records the BLAKE3 re-hash (pre-upload bitrot verify) latency


### PR DESCRIPTION
## Adaptive upload concurrency (#1407, redesign of #1400)

Auto-tune the number of concurrent CAS-chunk uploads to **saturate the uplink with no configuration**. When `--parallel-uploads` is unset (the new default) the syncer discovers the right concurrency itself; an explicit `--parallel-uploads N` still pins a fixed window (unchanged behaviour).

### Why

Uploads are **network-latency bound, not CPU bound** — a single PUT to a remote region sustains only a few MiB/s, so throughput scales with concurrency until the uplink saturates. The previous default derived concurrency from CPU count, which throttled fast links (an 8-core host mirrored at ~14 MiB/s while the link could do far more). v0.22.2 replaced that with a fixed default of 32; this PR removes the guesswork entirely.

#1400 tried a latency-gradient controller, but its closed-form equilibrium collapses the window to ~4: it reads the per-PUT latency rise *caused by useful concurrency* as congestion. The only honest saturation signal is **"did goodput stop rising"**, so this controller is goodput-driven.

### How

- **`goodputController`** — pure, deterministic, unit-tested. TCP-slow-start-like: ramp the window while delivered goodput keeps improving (EWMA-smoothed), settle at the knee once it plateaus, back off only on upload errors or a real goodput collapse — never on latency.
- **`windowLimited` gate (the crux)** — the controller only ramps/backs-off when the window was actually saturated. When the upstream rollup pipeline produced fewer chunks than the window could carry (app-limited), it **holds** the window. Without this, a transient pipeline stall collapses the window and throttles the drain the moment the backlog bursts — caught on the VM (see below).
- **`dynamicSemaphore`** — resizable concurrency limiter the controller drives; `TakePeak()` reports the in-flight high-water (the window-limited signal).
- A 1s control-interval goroutine samples delivered bytes → goodput → new window. `mirrorOnce` uses the shared limiter. Pinned mode keeps a fixed window and runs no controller.
- s3 HTTP pool sized so it never caps the window; new `dittofs_datapath_upload_window` gauge.

### Benchmarks (VM → Scaleway fr-par S3, 1 GiB, sar NIC TX, avg over active interval)

| config | throughput | in-flight |
|---|---|---|
| pinned 8 (old CPU-derived default) | 17.7 MiB/s | 8 |
| pinned 32 (v0.22.2 default) | 73.5 MiB/s | 32 |
| **adaptive — no flag (this PR)** | **73.6 MiB/s** | **auto 16→64** |
| raw boto3 C=32 (uplink ceiling, no CAS pipeline) | 114.9 MiB/s | 32 |

The window auto-ramps (16→24→36→54→64) and holds; adaptive **matches the best hand-tuned fixed window with zero configuration** (4.2× the old CPU-derived default). The remaining gap to raw S3 is the rollup/CAS pipeline (FastCDC + BLAKE3 + NFS read), not upload concurrency — that's tracked as the separate #1407 levers.

A first VM run exposed (and this PR fixes) the window collapsing to the floor when the rollup pipeline briefly starved the uploader — the `windowLimited` gate now holds the window so the backlog drains fast.

### Tests

- `upload_controller_test.go` — ramp / settle-at-knee / ceiling / error backoff / collapse backoff / floor / **app-limited hold** / recovery.
- `dynsem_test.go` — limit/grow/shrink/context/peak, race-clean.
- `upload_adaptive_test.go` — end-to-end tick glue (ramp, settle, **hold-on-starve**, idle-skip, error backoff).

### Follow-ups

- Rollup pipeline is now the throughput ceiling (#1407 levers 2/3: parallelize rollup chunk emission, batch fsync) — that's the remaining gap to raw S3, not upload concurrency.
- CLI footgun: `--config <json>` silently drops sibling flags incl. `--parallel-uploads`.
- A shared per-remote limiter (so two shares on one uplink cooperate on a single window) — currently each share auto-tunes independently, bounded by the shared 128-conn pool.

Part of #1407 (upload-concurrency lever). **Supersedes #1400** (latency-gradient design — its equilibrium collapses the window to ~4).
