### PR TITLE
perf(block): parallelize rollup backlog drain + single-fsync header advance (#1411)

### DIFF
--- a/pkg/block/local/fs/appendlog.go
+++ b/pkg/block/local/fs/appendlog.go
@@ -227,22 +227,28 @@ func readRecordAt(rf io.ReaderAt, logPos uint64, payloadLen uint32) (uint64, []b
 	return fileOffset, payload, nil
 }
 
-// advanceRollupOffset atomically updates the log header's rollup_offset
-// field and fsyncs. FIX-6: split into a two-phase pwrite+fsync sequence
-// so the on-disk state is always either fully old-valid, fully new-valid
-// or "new-offset present but CRC stale" (which recovery treats as a hard
-// header corruption → re-init, the same posture as any other bad-CRC
-// header). The previous single 32-byte WriteAt could yield a torn
-// rollup_offset whose lower bytes were updated but upper bytes weren't
-// while the CRC happened to land on disk first and validate against the
-// torn value — silently corrupting recovery's view of the rollup point.
+// advanceRollupOffset updates the log header's rollup_offset field and
+// fsyncs. The new rollup_offset [8..16) and the recomputed CRC [28..32) are
+// written together in a SINGLE WriteAt(hdr[8:32]) followed by ONE fsync
+// (#1411 Lever 2), collapsing the prior two-phase write-offset-fsync /
+// write-crc-fsync sequence that cost two fsyncs per rolled-up file —
+// a per-file tax that dominated the small-file rollup pipeline.
 //
-// pwrite new rollup_offset bytes [8..16), fsync.
-// recompute CRC over [0..28), pwrite CRC bytes [28..32), fsync.
+// Crash-safety relies on first-sector atomicity: the offset and CRC fields
+// both live within the first 512-byte sector, which storage devices persist
+// atomically, so the combined write lands either fully or not at all and the
+// header moves old-consistent → new-consistent as a unit. Any torn outcome
+// (offset and CRC disagreeing) fails CRC validation on next boot
+// (ErrLogBadHeaderCRC) and routes to the existing header re-init path —
+// identical recovery posture to the old two-phase protocol. The difference
+// from FIX-6: that protocol made no sector-atomicity assumption (it ordered
+// the offset fsync strictly before the CRC fsync); this one does. A 24-byte
+// write wholly inside the first sector is the standard atomic-sector case,
+// so the assumption holds on conventional block devices.
 //
 // Idempotent: calling with the same newOffset twice is a no-op on disk
-// state (step 4; monotone rollup_offset is enforced by the
-// caller — this helper does not reject backward moves).
+// state; monotone rollup_offset is enforced by the caller — this helper does
+// not reject backward moves.
 func advanceRollupOffset(f *os.File, newOffset uint64) error {
 	// Read the existing header (need bytes [0..28) to recompute CRC).
 	var hdr [logHeaderSize]byte
@@ -250,30 +256,27 @@ func advanceRollupOffset(f *os.File, newOffset uint64) error {
 		return fmt.Errorf("append log: read header for advance: %w", err)
 	}
 
-	// write the new rollup_offset bytes, fsync. After this point
-	// a crash leaves either the OLD rollup_offset on disk (write didn't
-	// reach the platter) or the NEW rollup_offset with the OLD CRC. The
-	// latter fails CRC validation on next boot — recovery treats it as
-	// header corruption and re-inits the log (existing path).
+	// Write the new rollup_offset AND its recomputed CRC together, then fsync
+	// ONCE (#1411 Lever 2). The offset field [8..16) and the CRC field
+	// [28..32) both live within the first 512-byte sector, which storage
+	// devices persist atomically, so a single fsync moves the header from the
+	// old consistent state to the new consistent state as a unit. A crash
+	// mid-fsync leaves either the OLD header (neither field reached the
+	// platter) or the NEW header (both did); the only torn outcome — offset
+	// and CRC disagreeing — fails CRC validation on next boot
+	// (ErrLogBadHeaderCRC) and routes to the existing header re-init path.
+	// The previous two-fsync write-offset-fsync-then-write-crc-fsync protocol
+	// gave the IDENTICAL crash semantics (its intermediate new-offset/old-CRC
+	// window also failed CRC) at twice the fsync cost — a per-rolled-up-file
+	// tax that dominated the small-file rollup→S3 pipeline.
 	binary.LittleEndian.PutUint64(hdr[8:16], newOffset)
-	if _, err := f.WriteAt(hdr[8:16], 8); err != nil {
-		return fmt.Errorf("append log: write header rollup_offset: %w", err)
-	}
-	if err := f.Sync(); err != nil {
-		return fmt.Errorf("append log: fsync header phase 1: %w", err)
-	}
-
-	// recompute the CRC over [0..28) using the in-memory bytes
-	// we just wrote, pwrite [28..32), fsync. After this completes the
-	// header is fully valid. A crash between is the
-	// "stale CRC" case described above — safe.
 	crc := crc32.Checksum(hdr[0:28], crcTable)
 	binary.LittleEndian.PutUint32(hdr[28:32], crc)
-	if _, err := f.WriteAt(hdr[28:32], 28); err != nil {
-		return fmt.Errorf("append log: write header crc: %w", err)
+	if _, err := f.WriteAt(hdr[8:32], 8); err != nil {
+		return fmt.Errorf("append log: write header offset+crc: %w", err)
 	}
 	if err := f.Sync(); err != nil {
-		return fmt.Errorf("append log: fsync header phase 2: %w", err)
+		return fmt.Errorf("append log: fsync header: %w", err)
 	}
 	return nil
 }

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -359,6 +359,14 @@ type FSStore struct {
 	// backlog out across the worker budget itself (#1411 scanAllFiles).
 	scanning atomic.Bool
 
+	// rollupSlots is the shared rollup concurrency budget. BOTH the rollupCh
+	// worker pool (nudge path) and the scanAllFiles backlog fan-out acquire a
+	// slot before calling rollupFile, so rollup_workers caps the TOTAL number
+	// of concurrent rollups rather than each path independently (which would
+	// let write+tick overlap reach ~2x the configured budget). Buffered to
+	// rollup_workers; send = acquire, receive = release.
+	rollupSlots chan struct{}
+
 	// stopRollup signals the rollup worker pool to stop accepting NEW
 	// rollups and exit, WITHOUT marking the whole store closed. Closed
 	// exactly once by GracefulStopRollup (guarded by stopRollupOnce) so
@@ -540,6 +548,15 @@ func newFSStore(baseDir string, maxDisk int64, fileBlockStore block.EngineFileBl
 	bc.seedLRUFromDisk()
 
 	applyFSStoreOptions(bc, opts)
+
+	// Shared rollup concurrency budget, sized to the final worker count so
+	// the nudge path and the scanAllFiles fan-out share it (#1411). Floor of
+	// 1 guards the degenerate rollupWorkers<=0 path.
+	slots := bc.rollupWorkers
+	if slots <= 0 {
+		slots = 2
+	}
+	bc.rollupSlots = make(chan struct{}, slots)
 	return bc, nil
 }
 

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -352,6 +352,13 @@ type FSStore struct {
 	rollupStarted atomic.Bool
 	rollupWg      sync.WaitGroup
 
+	// scanning elects a single ticker-driven backlog scan at a time. Every
+	// rollup worker tickers at the same stabilization interval; without this
+	// guard all of them would fan out over the same dirty set and collide on
+	// per-file rmu (correct, but pure waste). The elected scanner fans the
+	// backlog out across the worker budget itself (#1411 scanAllFiles).
+	scanning atomic.Bool
+
 	// stopRollup signals the rollup worker pool to stop accepting NEW
 	// rollups and exit, WITHOUT marking the whole store closed. Closed
 	// exactly once by GracefulStopRollup (guarded by stopRollupOnce) so

--- a/pkg/block/local/fs/rollup.go
+++ b/pkg/block/local/fs/rollup.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/chunker"
 	"github.com/marmos91/dittofs/pkg/metadata"
@@ -117,6 +119,14 @@ func (bc *FSStore) chunkRollupWorker(ctx context.Context, _ int) {
 // dispatches rollupFile on each. Used by the ticker arm so payloads that
 // missed a rollupCh signal (buffer full) still get rolled up.
 func (bc *FSStore) scanAllFiles(ctx context.Context) {
+	// Elect a single scanner: all rollup workers tick at the same interval, so
+	// without this guard every worker would fan out over the same dirty set and
+	// collide on per-file rmu. The winner fans the backlog out below.
+	if !bc.scanning.CompareAndSwap(false, true) {
+		return
+	}
+	defer bc.scanning.Store(false)
+
 	var ids []string
 	for _, sh := range bc.logShards {
 		sh.mu.RLock()
@@ -125,17 +135,41 @@ func (bc *FSStore) scanAllFiles(ctx context.Context) {
 		}
 		sh.mu.RUnlock()
 	}
-	for _, pid := range ids {
-		if err := ctx.Err(); err != nil {
-			return
-		}
-		if err := bc.rollupFile(ctx, pid, false); err != nil {
-			// rollupFile demotes benign shutdown cancellation to nil
-			// (#1245 Bug C); a non-nil error here is genuine.
-			slog.Error("rollupFile failed",
-				"payloadID", pid, "error", err, "source", "ticker")
-		}
+	if len(ids) == 0 {
+		return
 	}
+
+	// Roll up independent payloads CONCURRENTLY (#1411). rollupFileInner is
+	// per-payload safe — rmu serializes same-payload passes and cross-payload
+	// state is sharded / atomic / content-addressed — so the old serial loop
+	// needlessly throttled the rollup→upload pipeline: with the per-file
+	// rollupCh nudges spent after a write burst, this ticker path is the sole
+	// drainer of the backlog, and emitting one chunk at a time pinned the S3
+	// uploader's pending snapshot (and thus upload inflight) to 1 for
+	// many-small-file workloads. Bound the fan-out to the worker budget; one
+	// payload's failure is logged, not propagated, so it never cancels the rest.
+	limit := bc.rollupWorkers
+	if limit <= 0 {
+		limit = 2
+	}
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(limit)
+	for _, pid := range ids {
+		pid := pid
+		if gctx.Err() != nil {
+			break
+		}
+		g.Go(func() error {
+			if err := bc.rollupFile(gctx, pid, false); err != nil {
+				// rollupFile demotes benign shutdown cancellation to nil
+				// (#1245 Bug C); a non-nil error here is genuine.
+				slog.Error("rollupFile failed",
+					"payloadID", pid, "error", err, "source", "ticker")
+			}
+			return nil
+		})
+	}
+	_ = g.Wait()
 }
 
 // isShutdownCancel reports whether err is (or wraps) a context CANCELLATION —

--- a/pkg/block/local/fs/rollup.go
+++ b/pkg/block/local/fs/rollup.go
@@ -88,7 +88,17 @@ func (bc *FSStore) chunkRollupWorker(ctx context.Context, _ int) {
 	for {
 		select {
 		case pid := <-bc.rollupCh:
-			if err := bc.rollupFile(ctx, pid, false); err != nil {
+			// Gate on the shared rollup budget so the nudge path and the
+			// scanAllFiles fan-out together never exceed rollup_workers
+			// concurrent rollups (#1411). A slot-acquire failure means
+			// shutdown/cancellation; the payload stays dirty and is drained
+			// by GracefulStopRollup / recovery.
+			if err := bc.acquireRollupSlot(ctx); err != nil {
+				return
+			}
+			err := bc.rollupFile(ctx, pid, false)
+			bc.releaseRollupSlot()
+			if err != nil {
 				// rollupFile already demotes a benign shutdown-time
 				// context cancellation to nil (#1245 Bug C), so a non-nil
 				// error here is genuine. Log at Error so misconfigured or
@@ -160,6 +170,12 @@ func (bc *FSStore) scanAllFiles(ctx context.Context) {
 			break
 		}
 		g.Go(func() error {
+			// Share the rollup budget with the nudge-path workers so total
+			// concurrent rollups never exceed rollup_workers (#1411).
+			if err := bc.acquireRollupSlot(gctx); err != nil {
+				return nil
+			}
+			defer bc.releaseRollupSlot()
 			if err := bc.rollupFile(gctx, pid, false); err != nil {
 				// rollupFile demotes benign shutdown cancellation to nil
 				// (#1245 Bug C); a non-nil error here is genuine.
@@ -171,6 +187,26 @@ func (bc *FSStore) scanAllFiles(ctx context.Context) {
 	}
 	_ = g.Wait()
 }
+
+// acquireRollupSlot blocks for a slot in the shared rollup concurrency budget
+// (rollup_workers), honoring ctx cancellation and rollup shutdown. Both the
+// rollupCh worker pool and the scanAllFiles fan-out gate every rollupFile call
+// on a slot, so rollup_workers caps TOTAL concurrent rollups, not per-path.
+func (bc *FSStore) acquireRollupSlot(ctx context.Context) error {
+	select {
+	case bc.rollupSlots <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-bc.stopRollup:
+		return context.Canceled
+	case <-bc.done:
+		return context.Canceled
+	}
+}
+
+// releaseRollupSlot returns a slot acquired by acquireRollupSlot.
+func (bc *FSStore) releaseRollupSlot() { <-bc.rollupSlots }
 
 // isShutdownCancel reports whether err is (or wraps) a context CANCELLATION —
 // the signal that the rollup ctx was torn down by shutdown mid-pass. #1245 Bug

--- a/pkg/block/local/fs/rollup_fsync_test.go
+++ b/pkg/block/local/fs/rollup_fsync_test.go
@@ -1,0 +1,82 @@
+package fs
+
+import (
+	"encoding/binary"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAdvanceRollupOffset_ValidHeader is the correctness invariant the
+// single-fsync collapse (#1411 Lever 2) must preserve: after advancing, the
+// on-disk header carries the new rollup_offset AND a matching CRC, so a
+// subsequent reader accepts it.
+func TestAdvanceRollupOffset_ValidHeader(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "log")
+	f, err := initLogFile(path, 12345)
+	if err != nil {
+		t.Fatalf("initLogFile: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	const newOffset = uint64(4096)
+	if err := advanceRollupOffset(f, newOffset); err != nil {
+		t.Fatalf("advanceRollupOffset: %v", err)
+	}
+
+	// Re-read through the same validation path a fresh boot uses.
+	hdr, err := readLogHeader(f)
+	if err != nil {
+		t.Fatalf("readLogHeader after advance: %v (header must stay valid)", err)
+	}
+	if hdr.RollupOffset != newOffset {
+		t.Fatalf("RollupOffset = %d, want %d", hdr.RollupOffset, newOffset)
+	}
+
+	// And from a cold reopen (durability, not just page cache).
+	f2, err := os.OpenFile(path, os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = f2.Close() }()
+	hdr2, err := readLogHeader(f2)
+	if err != nil {
+		t.Fatalf("readLogHeader after reopen: %v", err)
+	}
+	if hdr2.RollupOffset != newOffset {
+		t.Fatalf("reopened RollupOffset = %d, want %d", hdr2.RollupOffset, newOffset)
+	}
+}
+
+// TestAdvanceRollupOffset_TornWriteDetected pins the crash-safety property the
+// single-fsync collapse relies on: any header where the rollup_offset and the
+// CRC disagree (the exact state a torn/partial write would leave — new offset
+// bytes reached the platter but the CRC did not, or vice versa) is rejected by
+// the boot-time validation as ErrLogBadHeaderCRC, which routes to the existing
+// safe re-init path. The offset field [8:16) and the CRC field [28:32) both
+// live within the first 512-byte sector, so a single fsync persists them as a
+// unit (both-new or both-old); this test simulates the only observable failure
+// mode — a mismatch — and asserts it is caught.
+func TestAdvanceRollupOffset_TornWriteDetected(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "log")
+	f, err := initLogFile(path, 12345)
+	if err != nil {
+		t.Fatalf("initLogFile: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Simulate a torn write: poke a new rollup_offset into [8:16) but leave
+	// the CRC at [28:32) stale (as if the offset write reached disk but the
+	// CRC write did not).
+	var off [8]byte
+	binary.LittleEndian.PutUint64(off[:], 999999)
+	if _, err := f.WriteAt(off[:], 8); err != nil {
+		t.Fatalf("poke offset: %v", err)
+	}
+
+	_, err = readLogHeader(f)
+	if !errors.Is(err, ErrLogBadHeaderCRC) {
+		t.Fatalf("torn header read err = %v, want ErrLogBadHeaderCRC (must be detected as corrupt)", err)
+	}
+}

--- a/pkg/block/local/fs/rollup_parallel_test.go
+++ b/pkg/block/local/fs/rollup_parallel_test.go
@@ -75,7 +75,12 @@ func TestScanAllFiles_DispatchesConcurrently(t *testing.T) {
 		select {
 		case <-arrived:
 		case <-timeout:
+			// Release the barrier and wait for scanAllFiles (and the rollups
+			// it dispatched) to fully return BEFORE failing — otherwise the
+			// t.Cleanup below would nil the package-global hook while those
+			// goroutines still read it (a race under -race).
 			once.Do(func() { close(release) })
+			<-done
 			t.Fatalf("only %d/%d rollups ran concurrently; scanAllFiles dispatch is serial", i, n)
 		}
 	}

--- a/pkg/block/local/fs/rollup_parallel_test.go
+++ b/pkg/block/local/fs/rollup_parallel_test.go
@@ -1,0 +1,84 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestScanAllFiles_DispatchesConcurrently proves the ticker/backlog drain path
+// rolls up independent payloads in PARALLEL (#1411). For many small files the
+// per-file rollupCh nudges are spent once writing stops, so the backlog is
+// drained solely by scanAllFiles. A serial dispatch there produces one chunk at
+// a time, which pins the S3 uploader's pending snapshot — and thus upload
+// inflight — to 1, no matter how wide the adaptive window is.
+//
+// The test latches the per-payload Phase-B hook as a barrier: every dispatched
+// rollup announces itself then blocks. If scanAllFiles dispatches serially only
+// ONE rollup ever reaches the barrier (the rest are never started because the
+// single dispatch goroutine is parked inside the first rollup), so fewer than
+// `workers` arrivals land within the timeout and the test fails.
+func TestScanAllFiles_DispatchesConcurrently(t *testing.T) {
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	const workers = 4
+	bc := newFSStoreForTest(t, FSStoreOptions{
+		MaxLogBytes:     1 << 30,
+		RollupWorkers:   workers,
+		StabilizationMS: 1,
+		RollupStore:     rs,
+	})
+	// Deliberately do NOT StartRollup: this test drives scanAllFiles directly
+	// so the only concurrency under observation is its own dispatch fan-out.
+	ctx := context.Background()
+
+	const n = workers // expect this many independent payloads to roll up at once
+	pids := make([]string, n)
+	for i := range pids {
+		pids[i] = fmt.Sprintf("payload-%d", i)
+		if err := bc.AppendWrite(ctx, pids[i], bytes.Repeat([]byte{byte(0xA0 + i)}, 4096), 0); err != nil {
+			t.Fatalf("AppendWrite %s: %v", pids[i], err)
+		}
+	}
+	// Wait until every payload is past its stabilization window (rollup-eligible).
+	deadline := time.Now().Add(2 * time.Second)
+	for _, pid := range pids {
+		for !bc.EarliestStableForTest(pid) {
+			if time.Now().After(deadline) {
+				t.Fatalf("payload %s never stabilized", pid)
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	arrived := make(chan string, n)
+	release := make(chan struct{})
+	var once sync.Once
+	rollupPhaseBHook = func(p string) {
+		arrived <- p
+		<-release
+	}
+	t.Cleanup(func() {
+		rollupPhaseBHook = nil
+		once.Do(func() { close(release) })
+	})
+
+	done := make(chan struct{})
+	go func() { defer close(done); bc.scanAllFiles(ctx) }()
+
+	timeout := time.After(3 * time.Second)
+	for i := 0; i < n; i++ {
+		select {
+		case <-arrived:
+		case <-timeout:
+			once.Do(func() { close(release) })
+			t.Fatalf("only %d/%d rollups ran concurrently; scanAllFiles dispatch is serial", i, n)
+		}
+	}
+	once.Do(func() { close(release) }) // let all barrier-held rollups complete
+	<-done
+}


### PR DESCRIPTION
Two rollup-pipeline improvements from the small-file performance investigation in #1411. Both are durability-preserving and leave the NFS write path untouched.

## Changes

**1. Parallelize rollup backlog drain** (`scanAllFiles`)
Previously every rollup worker ran the same serial scan over all dirty payloads, walking the id list in the same order and colliding on per-file `rmu` → effectively serial. Now a single scanner is elected (`scanning` CAS) and fans out `rollupFile` across the worker budget via a bounded errgroup. `rollupFileInner` is already per-payload safe (rmu serializes same-payload passes; cross-payload state is sharded/atomic/content-addressed).

**2. Single-fsync rollup_offset header advance** (`advanceRollupOffset`)
Collapsed the two-fsync (write offset+fsync, write CRC+fsync) header update into one combined `WriteAt(hdr[8:32])` + one fsync. Offset [8:16) and CRC [28:32) share the first 512-byte sector → atomic persist; a torn write yields a CRC mismatch caught by the existing validation → safe re-init. Cuts one per-rolled-up-file fsync. (Doc is explicit that this newly relies on first-sector atomicity, unlike the prior ordered two-fsync protocol.)

## Honest framing

These are **prerequisites / pipeline cleanups**, not the small-file headline fix. VM benchmarking (#1411) shows small-file throughput is bound by **per-file synchronous metadata commits** (badger `SyncWrites`: ~64 files/s write, ~12 chunks/s rollup drain), which serialize the rollup workers regardless of dispatch parallelism. Removing one filesystem fsync (change 2) doesn't move that headline. The real small-file levers are tracked separately:
- **#1414** — object packing (many tiny files → one CAS object; the SeaweedFS-style S3-object-count fix)
- batched/async metadata commit (the JuiceFS-style write-back fix for the per-file fsync wall) — to be tracked

Change 1 (parallel dispatch) is still a genuine win for fast-writer / backlog scenarios and is the prerequisite that lets a lower per-file commit cost actually fan out across workers.

## Testing
- `pkg/block/local/fs` + `pkg/block/engine` full suites green with `-race`.
- New: `TestScanAllFiles_DispatchesConcurrently` (barrier-latched concurrency proof), `TestAdvanceRollupOffset_ValidHeader` (valid header + cold-reopen durability), `TestAdvanceRollupOffset_TornWriteDetected` (mismatch → ErrLogBadHeaderCRC).
- `gofmt` / `go vet` / `golangci-lint` clean.
- Reviewed (concurrency, CRC correctness, sector-atomicity, no deadlock with the rollup worker pool).