### PR TITLE
fix(snapshot): identity-guard in-flight cleanup on retry (#1423)

### DIFF
--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -177,7 +177,7 @@ func (r *Runtime) CreateSnapshot(ctx context.Context, shareName string, opts Cre
 	// abortSnapInFlight to release the wg.Add(1) the registration took
 	// and close+drain the doneCh, otherwise cancelAndWaitInFlightSnaps
 	// would block forever waiting for the never-launched goroutine.
-	childCtx, doneCh, entry := r.registerSnapInFlight(shareName, snapID)
+	childCtx, cancel, doneCh, entry := r.registerSnapInFlight(shareName, snapID)
 
 	// (5) Create on-disk dir. Failure here is synchronous — flip the row
 	// to failed so the index slot is released for the next attempt, AND
@@ -185,7 +185,7 @@ func (r *Runtime) CreateSnapshot(ctx context.Context, shareName string, opts Cre
 	// decrements.
 	dir := snap.SnapshotDir(localStoreDir)
 	if err := os.MkdirAll(dir, 0o750); err != nil {
-		r.abortSnapInFlight(shareName, snapID, entry, doneCh)
+		r.abortSnapInFlight(shareName, snapID, entry, cancel, doneCh)
 		_ = r.store.UpdateSnapshotState(ctx, shareName, snapID, models.StateFailed)
 		return "", fmt.Errorf("snapshot create %q: mkdir %q: %w", snapID, dir, err)
 	}
@@ -200,6 +200,7 @@ func (r *Runtime) CreateSnapshot(ctx context.Context, shareName string, opts Cre
 		localStoreDir,
 		opts,
 		backupable,
+		cancel,
 		doneCh,
 		entry,
 	)
@@ -314,7 +315,7 @@ func (r *Runtime) WaitForSnapshot(ctx context.Context, shareName, snapID string)
 // entry.mu while snapshotting cancels — so there is no inversion. We
 // don't block under r.snapInFlightMu either: every operation inside it
 // is in-process and bounded.
-func (r *Runtime) registerSnapInFlight(shareName, snapID string) (context.Context, chan snapResult, *snapInFlight) {
+func (r *Runtime) registerSnapInFlight(shareName, snapID string) (context.Context, context.CancelFunc, chan snapResult, *snapInFlight) {
 	childCtx, cancel := context.WithCancel(r.runtimeCtx)
 	doneCh := make(chan snapResult, 1)
 
@@ -349,28 +350,42 @@ func (r *Runtime) registerSnapInFlight(shareName, snapID string) (context.Contex
 	entry.wg.Add(1)
 	entry.mu.Unlock()
 
-	return childCtx, doneCh, entry
+	return childCtx, cancel, doneCh, entry
 }
 
 // unregisterSnap removes the per-snap done channel and cancel func from
-// the share entry. The cancel func is invoked here (cheap on an
-// already-completed ctx) and deleted so the derived ctx is released from
+// the share entry. The caller's own cancel func is always invoked (cheap
+// on an already-completed ctx) so the derived ctx is released from
 // runtimeCtx's child list — otherwise completed snapshot contexts would
-// pile up on runtimeCtx and entry.cancels would grow for the lifetime
-// of the share.
+// pile up on runtimeCtx.
+//
+// Registry deletion is identity-guarded on doneCh: the map slots are only
+// removed if entry.done[snapID] still points at THIS attempt's channel. A
+// retry reuses the original snapID (RetryOf), and the per-snap chan send
+// in runSnapshotOrchestration's cleanup happens before this call — so a
+// WaitForSnapshot can unblock and the retry's registerSnapInFlight can
+// re-register a fresh doneCh+cancel under the same snapID BEFORE this
+// cleanup runs. Deleting unconditionally would then wipe the retry's live
+// registration, making the next WaitForSnapshot miss the channel and read
+// a still-creating row (issue #1423). done and cancels are registered and
+// replaced together under entry.mu, so a doneCh identity match implies
+// cancels[snapID] is also ours.
 //
 // The share entry itself is intentionally left in place even when empty
 // — RemoveShare and Shutdown enumerate it and rely on wg.Wait. Leaving
 // stale empty maps around is acceptable bookkeeping cost vs. the
 // synchronization needed to delete on every snap completion.
-func (r *Runtime) unregisterSnap(shareName, snapID string, entry *snapInFlight) {
+func (r *Runtime) unregisterSnap(shareName, snapID string, entry *snapInFlight, cancel context.CancelFunc, doneCh chan snapResult) {
+	cancel()
 	entry.mu.Lock()
-	if cancel, ok := entry.cancels[snapID]; ok {
-		cancel()
-		delete(entry.cancels, snapID)
+	defer entry.mu.Unlock()
+	if cur, ok := entry.done[snapID]; !ok || cur != doneCh {
+		// A newer attempt (retry) owns this snapID now; leave its slots
+		// intact — it will clean up after itself.
+		return
 	}
+	delete(entry.cancels, snapID)
 	delete(entry.done, snapID)
-	entry.mu.Unlock()
 }
 
 // deriveWaitCtx returns a ctx rooted at r.runtimeCtx (so it is cancelled on
@@ -419,8 +434,8 @@ func (r *Runtime) isSnapInFlight(shareName, snapID string) bool {
 // Idempotent under the snapInFlight scheme — only invoked once per
 // failure path between registerSnapInFlight and the goroutine launch in
 // CreateSnapshot.
-func (r *Runtime) abortSnapInFlight(shareName, snapID string, entry *snapInFlight, doneCh chan snapResult) {
-	r.unregisterSnap(shareName, snapID, entry)
+func (r *Runtime) abortSnapInFlight(shareName, snapID string, entry *snapInFlight, cancel context.CancelFunc, doneCh chan snapResult) {
+	r.unregisterSnap(shareName, snapID, entry, cancel, doneCh)
 	close(doneCh)
 	entry.wg.Done()
 }
@@ -435,6 +450,7 @@ func (r *Runtime) runSnapshotOrchestration(
 	localStoreDir string,
 	opts CreateSnapshotOpts,
 	backupable metadata.Backupable,
+	cancel context.CancelFunc,
 	doneCh chan snapResult,
 	entry *snapInFlight,
 ) {
@@ -457,7 +473,7 @@ func (r *Runtime) runSnapshotOrchestration(
 		// receive.
 		doneCh <- snapResult{err: terminalErr}
 		close(doneCh)
-		r.unregisterSnap(shareName, snapID, entry)
+		r.unregisterSnap(shareName, snapID, entry, cancel, doneCh)
 		entry.wg.Done()
 	}()
 

--- a/pkg/controlplane/runtime/snapshot_test.go
+++ b/pkg/controlplane/runtime/snapshot_test.go
@@ -128,7 +128,7 @@ func TestWaitForSnapshot_CtxCancelDuringWait(t *testing.T) {
 
 	// Plant a registry entry by reusing registerSnapInFlight. The child
 	// ctx + cancel are discarded; we only care that the done chan exists.
-	_, _, _ = rt.registerSnapInFlight(shareName, snapID)
+	_, _, _, _ = rt.registerSnapInFlight(shareName, snapID)
 
 	ctx, cancel := context.WithCancel(bg)
 	cancel() // pre-cancel — guarantees Wait returns ctx.Err() without racing.
@@ -428,7 +428,7 @@ func TestRuntimeDeleteSnapshot_RefusesInFlight(t *testing.T) {
 	}
 
 	// Plant an in-flight registry entry (mimics a running orchestration).
-	_, _, entry := rt.registerSnapInFlight(shareName, snapID)
+	_, snapCancel, doneCh, entry := rt.registerSnapInFlight(shareName, snapID)
 
 	if derr := rt.DeleteSnapshot(ctx, shareName, snapID); !errors.Is(derr, models.ErrSnapshotInFlight) {
 		t.Fatalf("DeleteSnapshot err = %v, want errors.Is(ErrSnapshotInFlight)", derr)
@@ -440,7 +440,7 @@ func TestRuntimeDeleteSnapshot_RefusesInFlight(t *testing.T) {
 	}
 
 	// Drain the planted entry, then delete succeeds.
-	rt.unregisterSnap(shareName, snapID, entry)
+	rt.unregisterSnap(shareName, snapID, entry, snapCancel, doneCh)
 	entry.wg.Done()
 	if derr := rt.DeleteSnapshot(ctx, shareName, snapID); derr != nil {
 		t.Fatalf("DeleteSnapshot after drain: %v", derr)


### PR DESCRIPTION
## Summary

Fixes the flaky `TestCreateSnapshot_Integration/RetryOfFailed` (#1423): `WaitForSnapshot` on a retried snapshot intermittently returned a still-`creating` row with a nil error instead of blocking until the terminal state.

## Root cause

The retry path reuses the original snapshot ID (`RetryOf` → `retryID == firstID`). The original orchestration goroutine's deferred cleanup does, in order:

1. send result on its per-snap `doneCh`,
2. `close(doneCh)`,
3. `unregisterSnap` → `delete(entry.done, snapID)`,
4. `wg.Done()`.

`WaitForSnapshot` unblocks on step 1 and returns **before** step 3. The test then issues the retry `CreateSnapshot`, whose `registerSnapInFlight` re-registers a fresh `doneCh` under the **same** `snapID`. The original goroutine's still-pending `unregisterSnap` (step 3) then race-deletes the retry's live channel. The next `WaitForSnapshot` finds `hasCh == false`, falls through to `GetSnapshot`, and reads the mid-flight `creating` row.

## Fix

Identity-guarded cleanup. `unregisterSnap` now only removes the registry slots when `entry.done[snapID]` still points at **our own** `doneCh`; otherwise a newer attempt owns the slot and cleans up after itself. Our own `cancel()` always runs first to release the derived ctx (no leak), and `wg.Done()` is still called unconditionally by the caller (no WaitGroup imbalance).

- `registerSnapInFlight` now also returns the `context.CancelFunc`.
- `cancel` + `doneCh` threaded through `CreateSnapshot` → `runSnapshotOrchestration` / `abortSnapInFlight` → `unregisterSnap`.
- `done` and `cancels` are registered/replaced together under `entry.mu`, so a `done` identity match implies `cancels[snapID]` is ours.

## Verification

- `go test -race -run 'TestCreateSnapshot_Integration/RetryOfFailed' -count=50` — green (was flaky under CI load).
- Full `pkg/controlplane/runtime` package with `-race` — green.
- `golangci-lint` — 0 issues.
- code-simplifier: no changes needed. code-reviewer: no high-confidence issues; verified wg balance, cancel/ctx leaks, drain (`cancelAndWaitInFlightSnaps`) and `shutdownSnapshots` paths unaffected.

Closes #1423
