### PR TITLE
fix(smb): keep WRITE off new grant while timed-out lease handle still open

### DIFF
--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -742,16 +742,24 @@ func bestGrantableState(locks []*UnifiedLock, leaseKey [16]byte, requestedState 
 	// `disallow_write_lease`), and a trad-oplock requestor additionally
 	// drops H so a BATCH/EXCLUSIVE request collapses to LEVEL_II — per the
 	// `map_lease_type_to_oplock` round-trip which Samba applies for non-
-	// LEASE_OPLOCK requests. Timeout tombstones (BrokenViaTimeout=true)
-	// are excluded so smb2.oplock.batch22b can grant a fresh BATCH after
-	// the abandoned holder times out. Required by smbtorture
+	// LEASE_OPLOCK requests. Required by smbtorture
 	// smb2.oplock.batch9a / batch13 / batch14 / batch16.
+	//
+	// Traditional-oplock timeout tombstones (BrokenViaTimeout=true) are
+	// excluded so smb2.oplock.batch22b can grant a fresh BATCH after the
+	// abandoned holder times out. Lease tombstones are NOT excluded: a lease
+	// record lives only while its handle is open (forceCompleteBreaks settles
+	// a timed-out lease to LeaseState=None rather than deleting it), so a
+	// still-open timed-out lease is a real second handle that must keep W off
+	// a new grant (smb2.lease.timeout: the parked conflicting opener gets RH,
+	// not RWH). The record is removed, and the cap lifts, when that handle
+	// closes.
 	var hasOtherActiveHolder bool
 	for _, lock := range locks {
 		if lock.Lease == nil || lock.Lease.LeaseKey == leaseKey {
 			continue
 		}
-		if lock.Lease.BrokenViaTimeout {
+		if lock.Lease.BrokenViaTimeout && lock.Lease.IsTraditionalOplock {
 			continue
 		}
 		hasOtherActiveHolder = true


### PR DESCRIPTION
## Problem

`smb2.lease.timeout` fails on clean develop (5/5, deterministic — not a flake). When a lease holder lets its break time out and a parked conflicting opener then completes, that opener is granted **RWH** when SMB semantics require **RH** (the timed-out handle is still open).

## Root cause

`bestGrantableState` (`pkg/metadata/lock/leases.go`) excluded *every* `BrokenViaTimeout` tombstone from the active-holder cap. That is wrong for **lease** records:

- A timed-out lease record **outlives the timeout** — its handle stays open. `forceCompleteBreaks` settles it to `LeaseState=None` rather than deleting it; the record is only removed by `ReleaseLeaseForHandle` on CLOSE.
- Treating that still-open handle as gone let a new grant include WRITE.

Traditional-oplock tombstones genuinely *are* abandoned and must stay excluded (required by `smb2.oplock.batch22b`).

## Fix

Narrow the exclusion to traditional-oplock tombstones only:

\`\`\`go
if lock.Lease.BrokenViaTimeout && lock.Lease.IsTraditionalOplock {
    continue
}
\`\`\`

Real-lease tombstones now keep WRITE off a new grant until their handle closes and the record is removed. `IsTraditionalOplock` is immutable after creation (set once from the request entry point), so the predicate is reliable.

## Verification

- `go build ./...`, `go test ./pkg/metadata/lock/...` green.
- smbtorture (local Docker repro): fixes **3/4** `smb2.lease.timeout` assertions.
- **Zero regressions** across `smb2.lease` / `smb2.oplock` / `smb2.replay` vs develop baseline.

## Known limitation (follow-up)

The 4th assertion (late break-ack returning UNSUCCESSFUL vs SUCCESS) needs break-cause tracking (open-conflict vs rename vs share-violation) that DittoFS does not currently record. Tracked separately in #1428. This PR banks the correct, regression-free grant-path fix.
