### PR TITLE
fix(smb): smb2.lease.timeout — deadbeat late-ack UNSUCCESSFUL + cap WRITE for still-open holder

### DIFF
--- a/internal/adapter/smb/handlers/disconnected_state_machine.go
+++ b/internal/adapter/smb/handlers/disconnected_state_machine.go
@@ -490,7 +490,12 @@ func (h *Handler) disallowWriteLeaseForFile(
 		isSameClientLease := excludeClientGUID != ([16]byte{}) &&
 			existing.ClientGUID == excludeClientGUID &&
 			existing.OplockLevel == OplockLevelLease
-		if isSameClientLease {
+		// A same-client lease whose break was force-completed on timeout is a
+		// dead lease on a still-open handle (smb2.lease.timeout): it must keep W
+		// off the new grant (h2 → RH, not RWH). An active self-upgrade
+		// (upgrade2/upgrade3) is not a timeout tombstone, so it stays bypassed.
+		if isSameClientLease &&
+			!h.LeaseManager.IsLeaseBrokenViaTimeout(existing.ShareName, existing.LeaseKey) {
 			return true
 		}
 		// e contributes when it holds an oplock/lease OR is a non-stat open.

--- a/internal/adapter/smb/handlers/disconnected_state_machine.go
+++ b/internal/adapter/smb/handlers/disconnected_state_machine.go
@@ -495,7 +495,7 @@ func (h *Handler) disallowWriteLeaseForFile(
 		// off the new grant (h2 → RH, not RWH). An active self-upgrade
 		// (upgrade2/upgrade3) is not a timeout tombstone, so it stays bypassed.
 		if isSameClientLease &&
-			!h.LeaseManager.IsLeaseBrokenViaTimeout(existing.ShareName, existing.LeaseKey) {
+			!h.LeaseManager.IsLeaseBrokenViaTimeout(existing.ShareName, string(metaHandle), existing.LeaseKey) {
 			return true
 		}
 		// e contributes when it holds an oplock/lease OR is a non-stat open.

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -844,12 +844,13 @@ func (lm *LeaseManager) HasActiveLeaseRecord(fileHandle lock.FileHandle, shareNa
 	return false
 }
 
-// IsLeaseBrokenViaTimeout reports whether the lease identified by leaseKey on
-// shareName is a timeout tombstone (its break was force-completed because the
-// holder never acknowledged it). Used by the CREATE W-strip to keep WRITE off a
-// new grant when a same-client lease holder timed out but its handle is still
-// open (smb2.lease.timeout).
-func (lm *LeaseManager) IsLeaseBrokenViaTimeout(shareName string, leaseKey [16]byte) bool {
+// IsLeaseBrokenViaTimeout reports whether the lease identified by (handleKey,
+// leaseKey) on shareName is a timeout tombstone (its break was force-completed
+// because the holder never acknowledged it). Used by the CREATE W-strip to keep
+// WRITE off a new grant when a same-client lease holder timed out but its handle
+// is still open (smb2.lease.timeout). handleKey scopes the lookup to the file
+// being granted.
+func (lm *LeaseManager) IsLeaseBrokenViaTimeout(shareName, handleKey string, leaseKey [16]byte) bool {
 	if lm == nil {
 		return false
 	}
@@ -858,7 +859,7 @@ func (lm *LeaseManager) IsLeaseBrokenViaTimeout(shareName string, leaseKey [16]b
 		return false
 	}
 	if mgr, ok := lockMgr.(*lock.Manager); ok {
-		return mgr.IsLeaseBrokenViaTimeout(leaseKey)
+		return mgr.IsLeaseBrokenViaTimeout(handleKey, leaseKey)
 	}
 	return false
 }

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -844,6 +844,25 @@ func (lm *LeaseManager) HasActiveLeaseRecord(fileHandle lock.FileHandle, shareNa
 	return false
 }
 
+// IsLeaseBrokenViaTimeout reports whether the lease identified by leaseKey on
+// shareName is a timeout tombstone (its break was force-completed because the
+// holder never acknowledged it). Used by the CREATE W-strip to keep WRITE off a
+// new grant when a same-client lease holder timed out but its handle is still
+// open (smb2.lease.timeout).
+func (lm *LeaseManager) IsLeaseBrokenViaTimeout(shareName string, leaseKey [16]byte) bool {
+	if lm == nil {
+		return false
+	}
+	lockMgr := lm.resolveLockManager(shareName)
+	if lockMgr == nil {
+		return false
+	}
+	if mgr, ok := lockMgr.(*lock.Manager); ok {
+		return mgr.IsLeaseBrokenViaTimeout(leaseKey)
+	}
+	return false
+}
+
 // WaitForOtherKeyBreaks waits on ctx for all breaks on fileHandle other than
 // excludeKey to drain. The caller controls the cancellation context — the
 // SMB CREATE async-park path passes a context whose lifetime is bound to

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -593,11 +593,16 @@ func (lm *Manager) requestLeaseImplWithMode(ctx context.Context, fileHandle File
 				"requestedState", LeaseStateToString(requestedState),
 				"breakToState", LeaseStateToString(breakTo))
 
-			// Mark lease as breaking before dispatching callbacks
+			// Mark lease as breaking before dispatching callbacks. This is the
+			// open-time lease-conflict downgrade (breakTo computed with
+			// BreakReasonDefault above), so record the reason for symmetry with
+			// breakOpLocks — a deadbeat holder that times out here must also
+			// surface STATUS_UNSUCCESSFUL on a late ack.
 			lock.Lease.Breaking = true
 			lock.Lease.BreakToState = breakTo
 			lock.Lease.BreakingToRequired = breakTo
 			lock.Lease.BreakStarted = time.Now()
+			lock.Lease.BreakReason = BreakReasonDefault
 			advanceEpoch(lock.Lease)
 
 			// Persist the breaking state
@@ -919,9 +924,26 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(ctx context.Context, leaseKey [16]b
 		// BrokenViaTimeout=false and still surfaces as STATUS_UNSUCCESSFUL
 		// via the fall-through below.
 		if lock.Lease.BrokenViaTimeout && lock.Lease.LeaseState == LeaseStateNone {
+			// A plain open-time lease-conflict downgrade (BreakReasonDefault on
+			// a file lease) that the holder ignored straight through the force-
+			// complete is a genuine deadbeat: MS-SMB2 §3.3.5.22.2 requires the
+			// late ACK to fail with STATUS_UNSUCCESSFUL (smb2.lease.timeout).
+			// Other force-completes — sharing-violation handle-strips (#1322)
+			// and parent-directory breaks (#454/WPTS) — fire under CI jitter
+			// while the holder's ACK is merely in flight, and must still
+			// succeed. The break reason, recorded at break time and preserved
+			// across force-complete, is the only signal that distinguishes
+			// them (post-force-complete state is otherwise identical).
+			if lock.Lease.BreakReason == BreakReasonDefault && !lock.Lease.IsDirectory {
+				logger.Debug("AcknowledgeLeaseBreak: late ACK after lease-conflict force-complete → UNSUCCESSFUL",
+					"leaseKey", fmt.Sprintf("%x", leaseKey),
+					"acknowledgedState", LeaseStateToString(acknowledgedState))
+				return ErrLeaseAckNotBreaking
+			}
 			logger.Debug("AcknowledgeLeaseBreak: late ACK after timeout force-complete, treating as success",
 				"leaseKey", fmt.Sprintf("%x", leaseKey),
-				"acknowledgedState", LeaseStateToString(acknowledgedState))
+				"acknowledgedState", LeaseStateToString(acknowledgedState),
+				"breakReason", lock.Lease.BreakReason)
 			return nil
 		}
 		return ErrLeaseAckNotBreaking

--- a/pkg/metadata/lock/leases_test.go
+++ b/pkg/metadata/lock/leases_test.go
@@ -1151,6 +1151,68 @@ func TestAcknowledgeLeaseBreak_LateAckNonNoneAfterTimeout_Succeeds(t *testing.T)
 	assert.Equal(t, LeaseStateNone, state, "late ACK must not resurrect lease bits")
 }
 
+// TestAcknowledgeLeaseBreak_LateAckAfterLeaseConflictTimeout_Unsuccessful pins
+// smb2.lease.timeout: a holder that ignores an open-time lease-conflict break
+// (BreakReasonDefault) straight through the force-complete is a deadbeat, so its
+// late ACK must return STATUS_UNSUCCESSFUL (ErrLeaseAckNotBreaking) — unlike the
+// sharing-violation / parent-dir late ACKs (#1322 / #454) which still succeed.
+// Driving the break through BreakLeasesOnOpenConflict (not a manual field poke)
+// also guards against a future forceCompleteBreaks that clears BreakReason.
+func TestAcknowledgeLeaseBreak_LateAckAfterLeaseConflictTimeout_Unsuccessful(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	key1 := [16]byte{1, 0, 0, 0}
+
+	// Holder takes an RWH lease.
+	_, _, err := mgr.RequestLease(ctx, FileHandle("file1"), key1, [16]byte{}, "owner1", "client1", "/share",
+		LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+
+	// A conflicting open breaks the holder's lease via the open-conflict path,
+	// recording BreakReasonDefault on the live record.
+	err = mgr.BreakLeasesOnOpenConflict("file1", nil, BreakReasonDefault)
+	require.NoError(t, err)
+
+	// Holder ignores the break; the parked CREATE's wait fires force-complete,
+	// which must preserve BreakReason on the tombstone.
+	mgr.forceCompleteBreaks("file1")
+	state, _, found := mgr.GetLeaseState(ctx, key1)
+	require.True(t, found, "force-completed record persists at None")
+	require.Equal(t, LeaseStateNone, state, "force-complete revoked to None")
+
+	// The deadbeat holder's late ACK must fail with STATUS_UNSUCCESSFUL.
+	err = mgr.AcknowledgeLeaseBreak(ctx, key1, LeaseStateRead|LeaseStateHandle, 0)
+	require.ErrorIs(t, err, ErrLeaseAckNotBreaking,
+		"late ACK after open-conflict force-complete must be UNSUCCESSFUL (smb2.lease.timeout)")
+}
+
+// TestIsLeaseBrokenViaTimeout covers the discriminator the SMB CREATE W-strip
+// uses to keep WRITE off a new grant for a deadbeat same-client lease holder
+// (smb2.lease.timeout) while leaving an active self-upgrade bypassed.
+func TestIsLeaseBrokenViaTimeout(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager()
+	ctx := context.Background()
+	key1 := [16]byte{1, 0, 0, 0}
+
+	// Absent lease → false.
+	require.False(t, mgr.IsLeaseBrokenViaTimeout(key1))
+
+	// Active lease → false (not a timeout tombstone).
+	_, _, err := mgr.RequestLease(ctx, FileHandle("file1"), key1, [16]byte{}, "owner1", "client1", "/share",
+		LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
+	require.NoError(t, err)
+	require.False(t, mgr.IsLeaseBrokenViaTimeout(key1), "active lease is not a timeout tombstone")
+
+	// Unacked open-conflict break that force-completes → timeout tombstone.
+	require.NoError(t, mgr.BreakLeasesOnOpenConflict("file1", nil, BreakReasonDefault))
+	mgr.forceCompleteBreaks("file1")
+	require.True(t, mgr.IsLeaseBrokenViaTimeout(key1), "force-completed lease is a timeout tombstone")
+}
+
 // ============================================================================
 // ReleaseLease Tests
 // ============================================================================

--- a/pkg/metadata/lock/leases_test.go
+++ b/pkg/metadata/lock/leases_test.go
@@ -1199,18 +1199,18 @@ func TestIsLeaseBrokenViaTimeout(t *testing.T) {
 	key1 := [16]byte{1, 0, 0, 0}
 
 	// Absent lease → false.
-	require.False(t, mgr.IsLeaseBrokenViaTimeout(key1))
+	require.False(t, mgr.IsLeaseBrokenViaTimeout("file1", key1))
 
 	// Active lease → false (not a timeout tombstone).
 	_, _, err := mgr.RequestLease(ctx, FileHandle("file1"), key1, [16]byte{}, "owner1", "client1", "/share",
 		LeaseStateRead|LeaseStateWrite|LeaseStateHandle, false)
 	require.NoError(t, err)
-	require.False(t, mgr.IsLeaseBrokenViaTimeout(key1), "active lease is not a timeout tombstone")
+	require.False(t, mgr.IsLeaseBrokenViaTimeout("file1", key1), "active lease is not a timeout tombstone")
 
 	// Unacked open-conflict break that force-completes → timeout tombstone.
 	require.NoError(t, mgr.BreakLeasesOnOpenConflict("file1", nil, BreakReasonDefault))
 	mgr.forceCompleteBreaks("file1")
-	require.True(t, mgr.IsLeaseBrokenViaTimeout(key1), "force-completed lease is a timeout tombstone")
+	require.True(t, mgr.IsLeaseBrokenViaTimeout("file1", key1), "force-completed lease is a timeout tombstone")
 }
 
 // ============================================================================

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -2236,17 +2236,24 @@ func (lm *Manager) HasActiveLeaseRecord(handleKey string, excludeKey [16]byte) b
 	return false
 }
 
-// IsLeaseBrokenViaTimeout reports whether the lease identified by leaseKey is a
-// timeout tombstone — its break was force-completed because the holder never
-// acknowledged it. The handle may still be open; the lease itself is dead.
-// The SMB CREATE W-strip uses this to tell a deadbeat same-client lease
-// (smb2.lease.timeout: keep WRITE off the new grant) from an active same-client
-// lease being upgraded (upgrade2/upgrade3: bypass the strip).
-func (lm *Manager) IsLeaseBrokenViaTimeout(leaseKey [16]byte) bool {
+// IsLeaseBrokenViaTimeout reports whether the lease identified by (handleKey,
+// leaseKey) is a timeout tombstone — its break was force-completed because the
+// holder never acknowledged it. The handle may still be open; the lease itself
+// is dead. The SMB CREATE W-strip uses this to tell a deadbeat same-client
+// lease (smb2.lease.timeout: keep WRITE off the new grant) from an active
+// same-client lease being upgraded (upgrade2/upgrade3: bypass the strip).
+//
+// Scoped to handleKey so a lease key bound on more than one file resolves to
+// the record on the file being granted, not an arbitrary same-key match.
+func (lm *Manager) IsLeaseBrokenViaTimeout(handleKey string, leaseKey [16]byte) bool {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-	_, lock, _ := lm.findLeaseByKey(leaseKey)
-	return lock != nil && lock.Lease != nil && lock.Lease.BrokenViaTimeout
+	for _, l := range lm.unifiedLocks[handleKey] {
+		if l.Lease != nil && l.Lease.LeaseKey == leaseKey {
+			return l.Lease.BrokenViaTimeout
+		}
+	}
+	return false
 }
 
 // AnyHolderIsTraditionalOplock reports whether any record on handleKey is a

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -2034,7 +2034,7 @@ func (lm *Manager) CheckAndBreakOpLocksForDelete(handleKey string, excludeOwner 
 // CheckAndBreakCachingForWrite breaks all leases AND all delegations.
 // Used for cross-protocol writes (e.g., NFS write breaking SMB leases).
 func (lm *Manager) CheckAndBreakCachingForWrite(handleKey string, excludeOwner *LockOwner) error {
-	if err := lm.breakOpLocks(handleKey, excludeOwner, LeaseStateNone, func(lease *OpLock) bool {
+	if err := lm.breakOpLocks(handleKey, excludeOwner, LeaseStateNone, BreakReasonUnspecified, func(lease *OpLock) bool {
 		return lease.HasRead() || lease.HasWrite()
 	}); err != nil {
 		return err
@@ -2049,7 +2049,7 @@ func (lm *Manager) CheckAndBreakCachingForWrite(handleKey string, excludeOwner *
 // CheckAndBreakCachingForRead breaks write leases (to Read) and write delegations.
 // Read delegations and read leases coexist with reads.
 func (lm *Manager) CheckAndBreakCachingForRead(handleKey string, excludeOwner *LockOwner) error {
-	if err := lm.breakOpLocks(handleKey, excludeOwner, LeaseStateRead, func(lease *OpLock) bool {
+	if err := lm.breakOpLocks(handleKey, excludeOwner, LeaseStateRead, BreakReasonUnspecified, func(lease *OpLock) bool {
 		return lease.HasWrite()
 	}); err != nil {
 		return err
@@ -2074,7 +2074,7 @@ func (lm *Manager) CheckAndBreakCachingForRead(handleKey string, excludeOwner *L
 //   - R   -> not broken (no Write to strip)
 //   - RH  -> not broken (no Write to strip)
 func (lm *Manager) CheckAndBreakLeasesForSMBOpen(handleKey string, excludeOwner *LockOwner) error {
-	return lm.breakOpLocks(handleKey, excludeOwner, BreakToStripWrite, func(lease *OpLock) bool {
+	return lm.breakOpLocks(handleKey, excludeOwner, BreakToStripWrite, BreakReasonUnspecified, func(lease *OpLock) bool {
 		return lease.HasWrite()
 	})
 }
@@ -2098,7 +2098,7 @@ func (lm *Manager) CheckAndBreakLeasesForSMBOpen(handleKey string, excludeOwner 
 // disallows in practice) are skipped: there is no read cache to flush.
 // The break target is None — full revocation — not "strip W" or "strip H".
 func (lm *Manager) BreakLeasesForByteRangeLock(handleKey string, excludeOwner *LockOwner) error {
-	return lm.breakOpLocks(handleKey, excludeOwner, LeaseStateNone, func(lease *OpLock) bool {
+	return lm.breakOpLocks(handleKey, excludeOwner, LeaseStateNone, BreakReasonUnspecified, func(lease *OpLock) bool {
 		return lease.HasRead()
 	})
 }
@@ -2109,7 +2109,7 @@ func (lm *Manager) BreakLeasesForByteRangeLock(handleKey string, excludeOwner *L
 // computed via ComputeLeaseBreakTo(state, reason); a lease is broken only
 // when the computed target differs from its current state.
 func (lm *Manager) BreakLeasesOnOpenConflict(handleKey string, excludeOwner *LockOwner, reason BreakReason) error {
-	return lm.breakOpLocks(handleKey, excludeOwner, breakSentinelForReason(reason), func(lease *OpLock) bool {
+	return lm.breakOpLocks(handleKey, excludeOwner, breakSentinelForReason(reason), reason, func(lease *OpLock) bool {
 		return ComputeLeaseBreakTo(lease.LeaseState, reason) != lease.LeaseState
 	})
 }
@@ -2123,14 +2123,14 @@ func (lm *Manager) BreakLeasesOnOpenConflict(handleKey string, excludeOwner *Loc
 //   - R  -> None
 //   - RW -> None
 func (lm *Manager) BreakReadLeasesForParentDir(handleKey string, excludeOwner *LockOwner) error {
-	return lm.breakOpLocks(handleKey, excludeOwner, LeaseStateNone, func(lease *OpLock) bool {
+	return lm.breakOpLocks(handleKey, excludeOwner, LeaseStateNone, BreakReasonUnspecified, func(lease *OpLock) bool {
 		return lease.IsDirectory && lease.HasRead()
 	})
 }
 
 // CheckAndBreakCachingForDelete breaks all leases AND all delegations.
 func (lm *Manager) CheckAndBreakCachingForDelete(handleKey string, excludeOwner *LockOwner) error {
-	if err := lm.breakOpLocks(handleKey, excludeOwner, LeaseStateNone, func(lease *OpLock) bool {
+	if err := lm.breakOpLocks(handleKey, excludeOwner, LeaseStateNone, BreakReasonUnspecified, func(lease *OpLock) bool {
 		return lease.LeaseState != LeaseStateNone
 	}); err != nil {
 		return err
@@ -2234,6 +2234,19 @@ func (lm *Manager) HasActiveLeaseRecord(handleKey string, excludeKey [16]byte) b
 		return true
 	}
 	return false
+}
+
+// IsLeaseBrokenViaTimeout reports whether the lease identified by leaseKey is a
+// timeout tombstone — its break was force-completed because the holder never
+// acknowledged it. The handle may still be open; the lease itself is dead.
+// The SMB CREATE W-strip uses this to tell a deadbeat same-client lease
+// (smb2.lease.timeout: keep WRITE off the new grant) from an active same-client
+// lease being upgraded (upgrade2/upgrade3: bypass the strip).
+func (lm *Manager) IsLeaseBrokenViaTimeout(leaseKey [16]byte) bool {
+	lm.mu.RLock()
+	defer lm.mu.RUnlock()
+	_, lock, _ := lm.findLeaseByKey(leaseKey)
+	return lock != nil && lock.Lease != nil && lock.Lease.BrokenViaTimeout
 }
 
 // AnyHolderIsTraditionalOplock reports whether any record on handleKey is a
@@ -2543,6 +2556,7 @@ func (lm *Manager) breakOpLocks(
 	handleKey string,
 	excludeOwner *LockOwner,
 	breakToState uint32,
+	reason BreakReason,
 	shouldBreak func(lease *OpLock) bool,
 ) error {
 	lm.mu.Lock()
@@ -2639,6 +2653,12 @@ func (lm *Manager) breakOpLocks(
 			// (Samba intentionally skips the bump per its inline comment).
 			// The next progressive stage will be dispatched on ACK.
 			lock.Lease.BreakingToRequired &= targetState
+			// Upgrade the recorded reason if this opener classifies the break
+			// (e.g. an open-conflict lease downgrade merging into an in-flight
+			// fire-and-forget break); never clobber a real reason with Unspecified.
+			if reason != BreakReasonUnspecified {
+				lock.Lease.BreakReason = reason
+			}
 			lm.persistUnifiedLockLocked(lock)
 			// This key's break is already in flight; record it so a sibling
 			// record sharing the key is not freshly dispatched below and so
@@ -2654,6 +2674,7 @@ func (lm *Manager) breakOpLocks(
 		// pre-bumped (per MS-SMB2 2.2.23.2). Post-ACK progressive stages do
 		// NOT advance — the multi-stage progression is one logical break.
 		lock.Lease.BreakingToRequired = targetState
+		lock.Lease.BreakReason = reason
 		advanceEpoch(lock.Lease)
 		snapshot := lm.applyBreakStageLocked(lock, targetState)
 		// Persist the in-flight Breaking state so a crash/restart preserves

--- a/pkg/metadata/lock/oplock.go
+++ b/pkg/metadata/lock/oplock.go
@@ -52,10 +52,17 @@ const (
 type BreakReason uint8
 
 const (
+	// BreakReasonUnspecified is the zero value: no break has been recorded on
+	// the record, or the break was initiated by a path that does not classify
+	// its reason. The late-break-ack path treats this as "not a deadbeat
+	// lease-conflict break" and returns success, preserving prior behavior for
+	// any uninstrumented break path.
+	BreakReasonUnspecified BreakReason = iota
+
 	// BreakReasonDefault: a non-conflicting open that just needs the existing
 	// holder to flush dirty data. Strip Write, keep Read + Handle.
 	// (RWH→RH, RW→R, RH/R→unchanged)
-	BreakReasonDefault BreakReason = iota
+	BreakReasonDefault
 
 	// BreakReasonSharingViolation: the new open conflicts on share mode, so
 	// the existing holder must release its cached handles. Strip Handle, keep
@@ -233,6 +240,16 @@ type OpLock struct {
 	// expected) and exclusive9 SUPERSEDE iteration (ack → tree2 LEVEL_II
 	// expected) despite identical post-break LeaseState=None records.
 	BrokenViaTimeout bool
+
+	// BreakReason records why the in-flight break was initiated. It is set
+	// when a break is applied and survives force-completion (it is NOT reset
+	// by forceCompleteBreaks), so the late-break-ack path can tell a genuine
+	// open-time lease-conflict deadbeat (BreakReasonDefault on a file lease —
+	// smb2.lease.timeout) from a force-complete the holder is merely late to
+	// ack (sharing-violation #1322, parent-dir #454). The former must return
+	// STATUS_UNSUCCESSFUL; the latter STATUS_OK. Zero value (Unspecified)
+	// means "not a classified conflict break" → treated as the latter.
+	BreakReason BreakReason
 }
 
 // HasRead returns true if the lease includes Read caching permission.
@@ -318,6 +335,7 @@ func (l *OpLock) Clone() *OpLock {
 		IsDirectory:         l.IsDirectory,
 		IsTraditionalOplock: l.IsTraditionalOplock,
 		BrokenViaTimeout:    l.BrokenViaTimeout,
+		BreakReason:         l.BreakReason,
 	}
 }
 


### PR DESCRIPTION
Closes #1428. Supersedes #1427 (which took the wrong, regression-causing approach).

## Problem

`smb2.lease.timeout` fails on develop (not in KNOWN_FAILURES). A holder takes RWH, a conflicting opener breaks it, the holder **ignores** the break, it force-completes (`LeaseState=None`, `BrokenViaTimeout=true`) — but the holder's handle stays open. Two MS-SMB2 behaviors were wrong:

1. **Late `LEASE_BREAK_ACK` returned `STATUS_OK`** — spec requires `UNSUCCESSFUL`.
2. **The new same-client opener was granted RWH instead of RH** — WRITE must be capped while the timed-out holder's handle is still open.

## Why it's subtle

The late-ack `return nil` is deliberate: sharing-violation handle-strips (#1322) and parent-dir breaks (#454/WPTS) force-complete under CI jitter and **must** still return OK. Post-force-complete the server state is otherwise identical — a deadbeat and a slow-but-valid ack look the same.

## Fix

**Break-cause discrimination (late-ack):**
- Add `BreakReason` to `OpLock`, recorded at break time and **preserved across force-complete** (prepend `BreakReasonUnspecified` so the zero value never misfires).
- `acknowledgeLeaseBreakImpl` returns `UNSUCCESSFUL` only for a plain open-conflict (`BreakReasonDefault`) **file** lease deadbeat; sharing-violation and directory (`#454`) breaks still return OK.

**Handle-liveness W-strip (grant state):**
- `disallowWriteLeaseForFile` bypassed same-client lease holders unconditionally (for legit self-upgrade, upgrade2/3). Now it does **not** bypass when that holder's lease is a `BrokenViaTimeout` tombstone — its handle is still open, so WRITE is stripped → opener gets RH.
- Operates on **live opens only** (`h.files`); disconnected-durable handles keep their separate `DurableStore` path — so this does **not** reproduce #1427's dirlease/durable regression.

New query: `Manager.IsLeaseBrokenViaTimeout(leaseKey)` + SMB-adapter wrapper (nil-guarded).

## Validation

- `smb2.lease.timeout` **passes** on both **memory** and **badger-fs** profiles.
- **Zero regressions** vs develop baseline across `smb2.lease`, `smb2.oplock`, `smb2.dirlease`, `smb2.durable-open`, `smb2.durable-v2-open`, `smb2.replay`. Remaining reds (`v2_complex1`, `delete_on_close2`, `batch22b`, `replay *-windows`) are pre-existing/KNOWN_FAILURES; `rename_wait` is a pre-existing flake (fails on develop too). #1322 `dhv2-pending1n-vs-violation-lease-ack-sane` still **passes**.
- New unit tests: deadbeat late-ack → `ErrLeaseAckNotBreaking`; `IsLeaseBrokenViaTimeout`. Existing #1322 OK-path test still green. `go build`, `go vet`, `golangci-lint` (0 issues), full lock + SMB unit suites pass.
- The handler W-strip guard is covered by the `smb2.lease.timeout` integration test (the lock-layer force-complete it needs is unexported, so a handler-package unit test would require adding test-only production surface).

## Notes

- `BreakReason` is not persisted (consistent with `BrokenViaTimeout`); the late-ack path is gated behind `BrokenViaTimeout`, which is in-memory only — a force-completed break cannot survive a restart (the holder's handle is gone).