### PR TITLE
test(snapshot): fix flaky TestSnapshotConcurrency_DeleteVsInFlightCreate

### DIFF
--- a/pkg/controlplane/runtime/snapshot_concurrency_test.go
+++ b/pkg/controlplane/runtime/snapshot_concurrency_test.go
@@ -396,7 +396,11 @@ func TestSnapshotConcurrency_DeleteVsInFlightCreate(t *testing.T) {
 		waitGroupGuard(t, 20*time.Second, "delete goroutine", wg.Wait)
 
 		// Drain the create so its registry slot is gone before next iter.
-		if _, werr := fx.rt.WaitForSnapshot(ctx, shareName, snapID); werr != nil {
+		// When the racing delete won, the snapshot is legitimately gone, so
+		// WaitForSnapshot returns ErrSnapshotNotFound — tolerate it, exactly
+		// as the delete branch above does; any other error is a real failure.
+		if _, werr := fx.rt.WaitForSnapshot(ctx, shareName, snapID); werr != nil &&
+			!errors.Is(werr, models.ErrSnapshotNotFound) {
 			t.Fatalf("iter %d: WaitForSnapshot: %v", i, werr)
 		}
 		cancel()


### PR DESCRIPTION
## Flake

`TestSnapshotConcurrency_DeleteVsInFlightCreate` intermittently fails on CI (e.g. `iter 184: WaitForSnapshot: snapshot not found`), surfacing as a red **Unit Tests** check on unrelated PRs.

## Root cause (test bug)

The test races `DeleteSnapshot` against a live `CreateSnapshot`, then drains with `WaitForSnapshot` and `t.Fatalf`s on **any** error. The delete branch already tolerates `ErrSnapshotNotFound` ("the orchestration may have finished and the row may have been deleted"). But when the delete **wins**, the snapshot is legitimately gone, so the subsequent `WaitForSnapshot` returns `ErrSnapshotNotFound` — and the test wrongly fatals.

Not a product bug: not-found only occurs when the delete succeeded (a refused/in-flight delete leaves the snapshot present). 

## Fix

Tolerate `ErrSnapshotNotFound` in the drain, mirroring the delete branch; any other error still fails.

## Validation

`go test -race -count=10 -run TestSnapshotConcurrency_DeleteVsInFlightCreate` — all green. `go vet` clean.