### PR TITLE
ci: fix SMB-client + integration test harness flakes

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -39,13 +39,19 @@ jobs:
       # localhost:5432, database dittofs_test, postgres/postgres.
       - name: Start PostgreSQL (with pull retry)
         run: |
+          pulled=false
           for attempt in 1 2 3 4 5; do
             if docker pull postgres:16; then
+              pulled=true
               break
             fi
             echo "docker pull postgres:16 failed (attempt $attempt), retrying..."
             sleep $((attempt * 5))
           done
+          if [ "$pulled" != "true" ]; then
+            echo "docker pull postgres:16 failed after 5 attempts"
+            exit 1
+          fi
           docker run -d --name dittofs-postgres \
             -e POSTGRES_USER=postgres \
             -e POSTGRES_PASSWORD=postgres \

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,27 +27,49 @@ jobs:
       matrix:
         go-version: ["1.25.x"]
 
-    # PostgreSQL service so the metadata-store integration + conformance
-    # suites actually run in CI. The postgres test factory connects to
-    # localhost:5432, database dittofs_test, postgres/postgres.
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: dittofs_test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 10
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      # PostgreSQL for the metadata-store integration + conformance suites.
+      # Started as a step-managed container (not a `services:` block) so the
+      # image pull can be retried — GitHub Actions cannot retry a service
+      # container's pull, and a transient Docker Hub hiccup there fails the
+      # whole job before any step runs. The test factory connects to
+      # localhost:5432, database dittofs_test, postgres/postgres.
+      - name: Start PostgreSQL (with pull retry)
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if docker pull postgres:16; then
+              break
+            fi
+            echo "docker pull postgres:16 failed (attempt $attempt), retrying..."
+            sleep $((attempt * 5))
+          done
+          docker run -d --name dittofs-postgres \
+            -e POSTGRES_USER=postgres \
+            -e POSTGRES_PASSWORD=postgres \
+            -e POSTGRES_DB=dittofs_test \
+            -p 5432:5432 \
+            --health-cmd "pg_isready -U postgres" \
+            --health-interval 5s \
+            --health-timeout 5s \
+            --health-retries 10 \
+            postgres:16
+          # Wait for the container to report healthy before running tests.
+          for i in $(seq 1 30); do
+            status=$(docker inspect -f '{{.State.Health.Status}}' dittofs-postgres 2>/dev/null || echo starting)
+            if [ "$status" = "healthy" ]; then
+              echo "PostgreSQL is healthy"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "PostgreSQL did not become healthy in time"
+              docker logs dittofs-postgres
+              exit 1
+            fi
+            sleep 2
+          done
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/smb-client-compat.yml
+++ b/.github/workflows/smb-client-compat.yml
@@ -50,6 +50,12 @@ jobs:
           go build -o dfsctl cmd/dfsctl/main.go
 
       - name: Start DittoFS and bootstrap SMB
+        env:
+          # Set a known admin password out-of-band. This also clears the
+          # forced first-login change (store/users.go: passwordFromEnv →
+          # MustChangePassword=false), so no fragile log-scrape / change-password
+          # dance is needed (the old scrape broke when the log format changed).
+          DITTOFS_ADMIN_INITIAL_PASSWORD: adminpass123
         run: |
           # Initialize and start server in background
           ./dfs init --force
@@ -66,17 +72,8 @@ jobs:
             sleep 1
           done
 
-          # Extract admin password from logs (format: "password=<pass>" / "password: <pass>")
-          ADMIN_PASS=$(./dfs logs 2>&1 | grep -oP 'password[=:] *\K[^ *]+' | head -1)
-
-          # Login as admin (initial credentials)
-          ./dfsctl login --server http://localhost:8080 --username admin --password "$ADMIN_PASS"
-
-          # The server requires a password change before any privileged operation.
-          # change-password invalidates the session token, so re-login afterwards.
-          NEW_ADMIN_PASS='adminpass123'
-          ./dfsctl user change-password --current "$ADMIN_PASS" --new "$NEW_ADMIN_PASS"
-          ./dfsctl login --server http://localhost:8080 --username admin --password "$NEW_ADMIN_PASS"
+          # Login as admin with the env-configured password (no forced change).
+          ./dfsctl login --server http://localhost:8080 --username admin --password adminpass123
 
           # Create stores
           ./dfsctl store metadata add --name mem-meta --type memory
@@ -369,6 +366,12 @@ jobs:
           # Initialize config
           .\dfs.exe init --force
 
+          # Set a known admin password out-of-band. This also clears the forced
+          # first-login change (store/users.go: passwordFromEnv →
+          # MustChangePassword=false), so no fragile log-scrape / change-password
+          # dance is needed (the old scrape broke when the log format changed).
+          $env:DITTOFS_ADMIN_INITIAL_PASSWORD = 'adminpass123'
+
           # Start server in background with DEBUG logging so the SMB/NTLM
           # session-setup trace is captured for #879 diagnosis.
           $env:DITTOFS_LOGGING_LEVEL = "DEBUG"
@@ -376,21 +379,8 @@ jobs:
           echo "DFS_PID=$($proc.Id)" >> $env:GITHUB_ENV
           Start-Sleep -Seconds 10
 
-          # Extract admin password. `dfs start` daemonizes and writes to its state
-          # log; fall back to the redirected stdout/stderr if needed.
-          $logContent = (& .\dfs.exe logs 2>&1 | Out-String)
-          $logContent += (Get-Content dfs-stdout.log, dfs-stderr.log -ErrorAction SilentlyContinue | Out-String)
-          $match = [regex]::Match($logContent, 'password[=:]\s*(\S+)')
-          $adminPass = $match.Groups[1].Value.TrimEnd('*')
-
-          # Login as admin (initial credentials)
-          .\dfsctl.exe login --server http://localhost:8080 --username admin --password $adminPass
-
-          # The server requires a password change before any privileged operation.
-          # change-password invalidates the session token, so re-login afterwards.
-          $newAdminPass = 'adminpass123'
-          .\dfsctl.exe user change-password --current $adminPass --new $newAdminPass
-          .\dfsctl.exe login --server http://localhost:8080 --username admin --password $newAdminPass
+          # Login as admin with the env-configured password (no forced change).
+          .\dfsctl.exe login --server http://localhost:8080 --username admin --password adminpass123
 
           .\dfsctl.exe store metadata add --name mem-meta --type memory
           .\dfsctl.exe store block local add --name mem-payload --type memory

--- a/.github/workflows/smb-client-compat.yml
+++ b/.github/workflows/smb-client-compat.yml
@@ -73,7 +73,7 @@ jobs:
           done
 
           # Login as admin with the env-configured password (no forced change).
-          ./dfsctl login --server http://localhost:8080 --username admin --password adminpass123
+          ./dfsctl login --server http://localhost:8080 --username admin --password "$DITTOFS_ADMIN_INITIAL_PASSWORD"
 
           # Create stores
           ./dfsctl store metadata add --name mem-meta --type memory
@@ -204,7 +204,7 @@ jobs:
           done
 
           # Login as admin with the env-configured password (no forced change).
-          ./dfsctl login --server http://localhost:8080 --username admin --password adminpass123
+          ./dfsctl login --server http://localhost:8080 --username admin --password "$DITTOFS_ADMIN_INITIAL_PASSWORD"
 
           ./dfsctl store metadata add --name mem-meta --type memory
           ./dfsctl store block local add --name mem-payload --type memory
@@ -380,7 +380,7 @@ jobs:
           Start-Sleep -Seconds 10
 
           # Login as admin with the env-configured password (no forced change).
-          .\dfsctl.exe login --server http://localhost:8080 --username admin --password adminpass123
+          .\dfsctl.exe login --server http://localhost:8080 --username admin --password $env:DITTOFS_ADMIN_INITIAL_PASSWORD
 
           .\dfsctl.exe store metadata add --name mem-meta --type memory
           .\dfsctl.exe store block local add --name mem-payload --type memory

--- a/test/smb-conformance/bootstrap.sh
+++ b/test/smb-conformance/bootstrap.sh
@@ -248,8 +248,8 @@ reset_share() {
     log_info "Logging in as admin..."
     $DFSCTL login --server "$API_URL" --username admin --password "$TEST_PASSWORD"
 
-    log_info "Resetting share ${name} (delete + recreate)..."
-    $DFSCTL share delete "$name" --force
+    log_info "Resetting share ${name} (remove + recreate)..."
+    $DFSCTL share remove "$name" --force
     create_one_share "$name"
     # Recreating the share makes a fresh root (owned by wpts-admin via
     # common_share_flags) and drops the old permission grants, so re-open the


### PR DESCRIPTION
## Problem

Two CI workflows were red on `develop`:

### SMB Client Compatibility (12/12 runs red since 2026-06-23)
Linux + Windows bootstrap scraped the admin password out of `dfs logs`:
```
ADMIN_PASS=$(./dfs logs 2>&1 | grep -oP 'password[=:] *\K[^ *]+' | head -1)
```
The log now masks the secret as `***`, so the regex (`[^ *]+` excludes `*`) matched nothing → empty `ADMIN_PASS` → `dfsctl login` dropped to an interactive prompt and died on EOF (`Error: ^D`, `not logged in`). All privileged bootstrap steps then failed.

### Integration Tests (intermittent)
`postgres:16` ran as a `services:` container. GitHub Actions cannot retry a service-container image pull, so a transient Docker Hub hiccup (`Docker pull failed with exit code 1`) failed the whole job before any step ran.

## Fix

- **SMB Client (Linux + Windows):** adopt the env-var bootstrap the **macOS** job already used — `DITTOFS_ADMIN_INITIAL_PASSWORD` sets a known admin password and clears the forced first-login change (`pkg/controlplane/store/users.go`: `passwordFromEnv` → `MustChangePassword=false`, also derives the NT hash for SMB). Drops the log-scrape + change-password dance entirely.
- **Integration:** move `postgres:16` into a step that retries `docker pull` (5×, backoff) then `docker run` + health-waits the container.

## Notes
- The macOS leg of SMB Client Compatibility surfaces a *separate, real* regression (share-grant vs POSIX root-dir permission conflict) tracked + fixed in a follow-up PR; this PR only repairs the test harness.
