### PR TITLE
feat(shares): project share-permission grants onto root directory ACL

### DIFF
--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -1078,7 +1078,22 @@ func (h *ShareHandler) SetUserPermission(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	h.reconcileRootACL(r.Context(), shareName)
 	WriteNoContent(w)
+}
+
+// reconcileRootACL projects the share's current permission grants onto its root
+// directory ACL so the filesystem permission layer agrees with the share-level
+// grants. Best-effort: a failure is logged, not surfaced, because the
+// control-plane permission record is authoritative and a later reconcile
+// self-heals the projection.
+func (h *ShareHandler) reconcileRootACL(ctx context.Context, shareName string) {
+	if h.runtime == nil {
+		return
+	}
+	if err := h.runtime.ReconcileShareRootACL(ctx, shareName); err != nil {
+		logger.Warn("Failed to reconcile share root ACL", "share", shareName, "error", err)
+	}
 }
 
 // RemoveUserPermission handles DELETE /api/v1/shares/{name}/permissions/users/{username}.
@@ -1101,6 +1116,7 @@ func (h *ShareHandler) RemoveUserPermission(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	h.reconcileRootACL(r.Context(), shareName)
 	WriteNoContent(w)
 }
 
@@ -1164,6 +1180,7 @@ func (h *ShareHandler) SetGroupPermission(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	h.reconcileRootACL(r.Context(), shareName)
 	WriteNoContent(w)
 }
 
@@ -1187,6 +1204,7 @@ func (h *ShareHandler) RemoveGroupPermission(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	h.reconcileRootACL(r.Context(), shareName)
 	WriteNoContent(w)
 }
 

--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -908,6 +908,12 @@ func (h *ShareHandler) Update(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// A default-permission change moves the EVERYONE@ ACE projected onto the
+	// root, so reproject; other field updates leave the root ACL untouched.
+	if req.DefaultPermission != nil {
+		h.reconcileRootACL(r.Context(), share.Name)
+	}
+
 	ctx, cancel := context.WithTimeout(r.Context(), HealthCheckTimeout)
 	defer cancel()
 	WriteJSONOK(w, h.shareToResponseWithUsage(ctx, share))

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -455,6 +455,13 @@ func (r *Runtime) AddShare(ctx context.Context, config *ShareConfig) error {
 	if err := r.LoadDefaultUserGraceForShare(ctx, config.Name); err != nil {
 		logger.Warn("failed to load default-user grace timers for share", "share", config.Name, "error", err)
 	}
+	// Project the share's permission grants onto the root directory ACL so the
+	// filesystem layer agrees with share-level access. Best-effort and
+	// idempotent: it rebuilds from persisted grants, so it also re-establishes
+	// the projection on every restart and self-heals any drift.
+	if err := r.ReconcileShareRootACL(ctx, config.Name); err != nil {
+		logger.Warn("failed to reconcile share root ACL", "share", config.Name, "error", err)
+	}
 	return nil
 }
 

--- a/pkg/controlplane/runtime/share_root_acl.go
+++ b/pkg/controlplane/runtime/share_root_acl.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
@@ -73,9 +74,15 @@ func (r *Runtime) ReconcileShareRootACL(ctx context.Context, shareName string) e
 		}
 		user, err := r.store.GetUserByID(ctx, p.UserID)
 		if err != nil {
-			// Dangling grant (user removed out from under it): skip rather
-			// than abort the whole reconcile.
-			continue
+			if errors.Is(err, models.ErrUserNotFound) {
+				// Dangling grant (user removed out from under it): skip
+				// rather than abort the whole reconcile.
+				continue
+			}
+			// Transient error (DB hiccup, context deadline): abort before
+			// writing a partial ACL that would drop valid grantees and
+			// reintroduce filesystem-layer denials until the next reconcile.
+			return fmt.Errorf("reconcile root ACL for %q: get user %q: %w", shareName, p.UserID, err)
 		}
 		uid := smbDefaultUID
 		if user.UID != nil {
@@ -90,7 +97,13 @@ func (r *Runtime) ReconcileShareRootACL(ctx context.Context, shareName string) e
 		}
 		group, err := r.store.GetGroupByID(ctx, p.GroupID)
 		if err != nil {
-			continue
+			if errors.Is(err, models.ErrGroupNotFound) {
+				// Dangling grant: skip rather than abort.
+				continue
+			}
+			// Transient error: abort before writing a partial ACL (see the
+			// user-grant path above for the rationale).
+			return fmt.Errorf("reconcile root ACL for %q: get group %q: %w", shareName, p.GroupID, err)
 		}
 		if group.GID == nil {
 			// A group without an assigned GID cannot be projected onto a

--- a/pkg/controlplane/runtime/share_root_acl.go
+++ b/pkg/controlplane/runtime/share_root_acl.go
@@ -1,0 +1,112 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+)
+
+// smbDefaultUID mirrors the default UID the SMB adapter assigns to a user that
+// has no explicit UID (internal/adapter/smb/handlers/auth_helper.go). A grant
+// projected for such a user must use the same effective id so the resulting ACE
+// matches the AuthContext the adapter builds at request time. Users that share
+// this fallback are indistinguishable at the filesystem layer — assign explicit
+// UIDs for per-user isolation.
+const smbDefaultUID uint32 = 1000
+
+// grantLevelFor maps a stored control-plane permission string to the acl
+// package's protocol-agnostic grant level.
+func grantLevelFor(permission string) acl.GrantLevel {
+	switch models.SharePermission(permission) {
+	case models.PermissionRead:
+		return acl.GrantRead
+	case models.PermissionReadWrite:
+		return acl.GrantReadWrite
+	case models.PermissionAdmin:
+		return acl.GrantAdmin
+	default:
+		return acl.GrantNone
+	}
+}
+
+// ReconcileShareRootACL rebuilds the share root directory's ACL from the full
+// current set of control-plane share-permission grants, so the filesystem
+// permission layer agrees with the share-level access control plane. Without
+// this, a user granted read-write at the share level is still denied by the
+// root directory's POSIX mode bits (owner uid 0, mode 0755).
+//
+// It recomputes the entire ACL from current state, so it is idempotent and
+// correct after a grant, a revoke, or a default-permission change — a revoke is
+// just a rebuild without that grant. Callers treat failures as non-fatal: the
+// control-plane permission record is the source of truth and a subsequent
+// reconcile self-heals the projection.
+func (r *Runtime) ReconcileShareRootACL(ctx context.Context, shareName string) error {
+	// Defensive no-op for partially-wired runtimes (e.g. test harnesses that
+	// construct a Runtime without a control-plane store or metadata service).
+	// Reconciliation is best-effort, so a missing dependency is not an error.
+	if r.store == nil || r.metadataService == nil || r.sharesSvc == nil {
+		return nil
+	}
+
+	share, err := r.sharesSvc.GetShare(shareName)
+	if err != nil {
+		return fmt.Errorf("reconcile root ACL for %q: %w", shareName, err)
+	}
+
+	userPerms, err := r.store.GetShareUserPermissions(ctx, shareName)
+	if err != nil {
+		return fmt.Errorf("reconcile root ACL for %q: list user permissions: %w", shareName, err)
+	}
+	groupPerms, err := r.store.GetShareGroupPermissions(ctx, shareName)
+	if err != nil {
+		return fmt.Errorf("reconcile root ACL for %q: list group permissions: %w", shareName, err)
+	}
+
+	grants := make([]acl.RootGrant, 0, len(userPerms)+len(groupPerms))
+	for _, p := range userPerms {
+		level := grantLevelFor(p.Permission)
+		if level == acl.GrantNone {
+			continue
+		}
+		user, err := r.store.GetUserByID(ctx, p.UserID)
+		if err != nil {
+			// Dangling grant (user removed out from under it): skip rather
+			// than abort the whole reconcile.
+			continue
+		}
+		uid := smbDefaultUID
+		if user.UID != nil {
+			uid = *user.UID
+		}
+		grants = append(grants, acl.RootGrant{ID: uid, Level: level})
+	}
+	for _, p := range groupPerms {
+		level := grantLevelFor(p.Permission)
+		if level == acl.GrantNone {
+			continue
+		}
+		group, err := r.store.GetGroupByID(ctx, p.GroupID)
+		if err != nil {
+			continue
+		}
+		if group.GID == nil {
+			// A group without an assigned GID cannot be projected onto a
+			// numeric ACE; the share-level grant still applies at mount.
+			continue
+		}
+		grants = append(grants, acl.RootGrant{ID: *group.GID, IsGroup: true, Level: level})
+	}
+
+	dacl := acl.BuildShareRootACL(grantLevelFor(share.DefaultPermission), grants)
+
+	// The root directory is owned by uid 0; only a superuser context may
+	// rewrite its ACL. The system context bypasses permission checks.
+	sysCtx := metadata.NewSystemAuthContext(ctx)
+	if _, err := r.metadataService.SetFileAttributes(sysCtx, share.RootHandle, &metadata.SetAttrs{ACL: dacl}); err != nil {
+		return fmt.Errorf("reconcile root ACL for %q: set attributes: %w", shareName, err)
+	}
+	return nil
+}

--- a/pkg/controlplane/store/interface.go
+++ b/pkg/controlplane/store/interface.go
@@ -310,6 +310,13 @@ type PermissionStore interface {
 	// GetGroupSharePermissions returns all share permissions for a group.
 	GetGroupSharePermissions(ctx context.Context, groupName string) ([]*models.GroupSharePermission, error)
 
+	// GetShareUserPermissions returns every user permission granted on a share.
+	// Used to project the full grant set onto the share root directory's ACL.
+	GetShareUserPermissions(ctx context.Context, shareName string) ([]*models.UserSharePermission, error)
+
+	// GetShareGroupPermissions returns every group permission granted on a share.
+	GetShareGroupPermissions(ctx context.Context, shareName string) ([]*models.GroupSharePermission, error)
+
 	// ResolveSharePermission returns the effective permission for a user on a share.
 	// Resolution order: user explicit > group permissions (highest wins) > share default
 	// Fetches the share's default permission internally.

--- a/pkg/controlplane/store/permissions.go
+++ b/pkg/controlplane/store/permissions.go
@@ -150,6 +150,36 @@ func (s *GORMStore) GetGroupSharePermissions(ctx context.Context, groupName stri
 	return perms, nil
 }
 
+func (s *GORMStore) GetShareUserPermissions(ctx context.Context, shareName string) ([]*models.UserSharePermission, error) {
+	share, err := s.GetShare(ctx, shareName)
+	if err != nil {
+		return nil, err
+	}
+
+	var perms []*models.UserSharePermission
+	if err := s.db.WithContext(ctx).
+		Where("share_id = ?", share.ID).
+		Find(&perms).Error; err != nil {
+		return nil, err
+	}
+	return perms, nil
+}
+
+func (s *GORMStore) GetShareGroupPermissions(ctx context.Context, shareName string) ([]*models.GroupSharePermission, error) {
+	share, err := s.GetShare(ctx, shareName)
+	if err != nil {
+		return nil, err
+	}
+
+	var perms []*models.GroupSharePermission
+	if err := s.db.WithContext(ctx).
+		Where("share_id = ?", share.ID).
+		Find(&perms).Error; err != nil {
+		return nil, err
+	}
+	return perms, nil
+}
+
 func (s *GORMStore) ResolveSharePermission(ctx context.Context, user *models.User, shareName string) (models.SharePermission, error) {
 	share, err := s.GetShare(ctx, shareName)
 	if err != nil {

--- a/pkg/metadata/acl/share_grant.go
+++ b/pkg/metadata/acl/share_grant.go
@@ -68,15 +68,19 @@ func maskForLevel(level GrantLevel) uint32 {
 // the share level is still denied by the root directory's POSIX mode bits
 // (owner uid 0, mode 0755) because they are neither the owner nor in its group.
 //
-// The result is allow-only and carries FILE_INHERIT|DIRECTORY_INHERIT flags so
-// entries created under the root inherit consistent access. The share root
-// owner always retains full control via the dynamic OWNER@ principal.
-// defaultLevel projects the share's default-permission onto EVERYONE@ (omitted
-// when none). Per-principal grants project onto "{id}@localdomain" ACEs.
+// The result is allow-only and applies to the root directory ONLY — the ACEs
+// carry no inheritance flags. Share grants are the outer gate (the per-request
+// ResolveSharePermission check already enforces read vs read-write); the inner,
+// per-file access is governed by each entry's own POSIX mode / ACL. Projecting
+// inheritable grant ACEs onto every descendant would make a grantee bypass
+// those per-file bits (and breaks POSIX-conformance suites that assert mode-bit
+// enforcement). The share root owner always retains full control via the
+// dynamic OWNER@ principal. defaultLevel projects the share's default-permission
+// onto EVERYONE@ (omitted when none). Per-principal grants project onto
+// "{id}@localdomain" ACEs.
 func BuildShareRootACL(defaultLevel GrantLevel, grants []RootGrant) *ACL {
-	const inheritFlags = ACE4_FILE_INHERIT_ACE | ACE4_DIRECTORY_INHERIT_ACE
 	allow := func(who string, mask uint32) ACE {
-		return ACE{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, Flag: inheritFlags, AccessMask: mask, Who: who}
+		return ACE{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: mask, Who: who}
 	}
 
 	aces := []ACE{

--- a/pkg/metadata/acl/share_grant.go
+++ b/pkg/metadata/acl/share_grant.go
@@ -90,9 +90,36 @@ func BuildShareRootACL(defaultLevel GrantLevel, grants []RootGrant) *ACL {
 		allow(SpecialAdministrators, FullAccessMask),
 	}
 
+	// Merge grants that project to the same ACE, keeping the highest level.
+	// The merge key is the numeric id, not (id, isGroup): LocalDomainPrincipal
+	// encodes only the id, so a user UID and a group GID with the same value
+	// collapse to one Who (the known local-domain uid/gid collision) and must
+	// not emit duplicate ACEs. Distinct users without an explicit UID also
+	// collapse here (all to the same fallback id). A user grant takes
+	// precedence over a group grant for ordering when ids collide, so the order
+	// stays deterministic.
+	merged := make(map[uint32]RootGrant, len(grants))
+	for _, g := range grants {
+		cur, ok := merged[g.ID]
+		if !ok {
+			merged[g.ID] = g
+			continue
+		}
+		if g.Level > cur.Level {
+			cur.Level = g.Level
+		}
+		if !g.IsGroup { // a user grant wins the IsGroup flag for ordering
+			cur.IsGroup = false
+		}
+		merged[g.ID] = cur
+	}
+	sorted := make([]RootGrant, 0, len(merged))
+	for _, g := range merged {
+		sorted = append(sorted, g)
+	}
+
 	// Deterministic ACE order so the projected ACL is stable across
 	// reconciliations (users before groups, each ascending by id).
-	sorted := append([]RootGrant(nil), grants...)
 	sort.Slice(sorted, func(i, j int) bool {
 		if sorted[i].IsGroup != sorted[j].IsGroup {
 			return !sorted[i].IsGroup

--- a/pkg/metadata/acl/share_grant.go
+++ b/pkg/metadata/acl/share_grant.go
@@ -1,0 +1,120 @@
+package acl
+
+import (
+	"fmt"
+	"sort"
+)
+
+// GrantLevel is the access a share-permission grant projects onto the share
+// root directory. It mirrors the control-plane SharePermission levels without
+// importing that package (the acl package stays protocol/control-plane
+// agnostic).
+type GrantLevel int
+
+const (
+	// GrantNone projects no ACE (the principal is not granted root access).
+	GrantNone GrantLevel = iota
+	// GrantRead projects read + traverse (r-x).
+	GrantRead
+	// GrantReadWrite projects read + write + traverse (rwx).
+	GrantReadWrite
+	// GrantAdmin projects full control, including WRITE_ACL / WRITE_OWNER.
+	GrantAdmin
+)
+
+// RootGrant is a single principal's projected access on a share root.
+type RootGrant struct {
+	// ID is the principal's Unix UID (user grant) or GID (group grant).
+	ID uint32
+	// IsGroup distinguishes a group grant from a user grant. Both project to
+	// the same "{id}@localdomain" Who form (see LocalDomainPrincipal); the
+	// flag only affects deterministic ACE ordering.
+	IsGroup bool
+	// Level is the access level to grant.
+	Level GrantLevel
+}
+
+// LocalDomainPrincipal formats a Unix UID/GID as the "{id}@localdomain" ACE
+// Who string the ACL evaluator matches numerically against an AuthContext's
+// UID/GID. It is the inverse of the evaluator's local-domain parser and the
+// form SIDMapper.SIDToPrincipal emits for machine-domain SIDs, kept here so
+// producers and the matcher never drift. Both NFS (AUTH_UNIX uid) and SMB
+// (mapped user uid) populate the numeric identity, so this form is the
+// cross-protocol common denominator (a "sid:" Who would not match NFS).
+func LocalDomainPrincipal(id uint32) string {
+	return fmt.Sprintf("%d%s", id, localDomainSuffix)
+}
+
+// maskForLevel maps a grant level to a directory access mask. Read includes
+// EXECUTE so the principal can traverse and list the directory; ReadWrite adds
+// the write bits (including DELETE_CHILD for directories); Admin is full
+// control.
+func maskForLevel(level GrantLevel) uint32 {
+	switch level {
+	case GrantRead:
+		return rwxToFullMask(modeRead|modeExecute, true)
+	case GrantReadWrite:
+		return rwxToFullMask(modeRead|modeWrite|modeExecute, true)
+	case GrantAdmin:
+		return FullAccessMask
+	default: // GrantNone or unknown
+		return 0
+	}
+}
+
+// BuildShareRootACL synthesizes the share root directory's DACL from the set of
+// share-permission grants, so the filesystem permission layer agrees with the
+// share-level access control plane. Without this, a user granted read-write at
+// the share level is still denied by the root directory's POSIX mode bits
+// (owner uid 0, mode 0755) because they are neither the owner nor in its group.
+//
+// The result is allow-only and carries FILE_INHERIT|DIRECTORY_INHERIT flags so
+// entries created under the root inherit consistent access. The share root
+// owner always retains full control via the dynamic OWNER@ principal.
+// defaultLevel projects the share's default-permission onto EVERYONE@ (omitted
+// when none). Per-principal grants project onto "{id}@localdomain" ACEs.
+func BuildShareRootACL(defaultLevel GrantLevel, grants []RootGrant) *ACL {
+	const inheritFlags = ACE4_FILE_INHERIT_ACE | ACE4_DIRECTORY_INHERIT_ACE
+	allow := func(who string, mask uint32) ACE {
+		return ACE{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, Flag: inheritFlags, AccessMask: mask, Who: who}
+	}
+
+	aces := []ACE{
+		// The root owner always keeps full control so the share stays
+		// manageable regardless of which grants exist.
+		allow(SpecialOwner, FullAccessMask),
+		// SYSTEM and Administrators full control: the dfs admin maps to uid 0
+		// and bypasses checks as superuser, but the explicit ACEs keep the
+		// Windows Security tab coherent (matches the Windows default shape).
+		allow(SpecialSystem, FullAccessMask),
+		allow(SpecialAdministrators, FullAccessMask),
+	}
+
+	// Deterministic ACE order so the projected ACL is stable across
+	// reconciliations (users before groups, each ascending by id).
+	sorted := append([]RootGrant(nil), grants...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].IsGroup != sorted[j].IsGroup {
+			return !sorted[i].IsGroup
+		}
+		return sorted[i].ID < sorted[j].ID
+	})
+	for _, g := range sorted {
+		if mask := maskForLevel(g.Level); mask != 0 { // GrantNone → no ACE
+			aces = append(aces, allow(LocalDomainPrincipal(g.ID), mask))
+		}
+	}
+
+	// Default-permission projects onto EVERYONE@ so an authenticated principal
+	// that passed the share layer without an explicit grant gets the same
+	// access at the filesystem layer. Omitted entirely when none, preserving
+	// the secure default.
+	if m := maskForLevel(defaultLevel); m != 0 {
+		aces = append(aces, allow(SpecialEveryone, m))
+	}
+
+	return &ACL{
+		ACEs:   aces,
+		Source: ACLSourceShareGrant,
+	}
+}

--- a/pkg/metadata/acl/share_grant_test.go
+++ b/pkg/metadata/acl/share_grant_test.go
@@ -1,0 +1,206 @@
+package acl
+
+import (
+	"fmt"
+	"testing"
+)
+
+// allowACE returns the first ALLOW ACE with the given Who, or nil. It reuses
+// the package test helper findACE(aces, type, who).
+func allowACE(a *ACL, who string) *ACE {
+	return findACE(a.ACEs, ACE4_ACCESS_ALLOWED_ACE_TYPE, who)
+}
+
+func TestLocalDomainPrincipal(t *testing.T) {
+	got := LocalDomainPrincipal(1000)
+	want := fmt.Sprintf("1000%s", localDomainSuffix)
+	if got != want {
+		t.Fatalf("LocalDomainPrincipal(1000) = %q, want %q", got, want)
+	}
+}
+
+func TestBuildShareRootACL_BaselineACEs(t *testing.T) {
+	a := BuildShareRootACL(GrantNone, nil)
+
+	if a.Source != ACLSourceShareGrant {
+		t.Errorf("Source = %q, want %q", a.Source, ACLSourceShareGrant)
+	}
+	for _, who := range []string{SpecialOwner, SpecialSystem, SpecialAdministrators} {
+		ace := allowACE(a, who)
+		if ace == nil {
+			t.Fatalf("missing baseline ACE for %q", who)
+		}
+		if ace.AccessMask != FullAccessMask {
+			t.Errorf("%s mask = %#x, want FullAccessMask %#x", who, ace.AccessMask, FullAccessMask)
+		}
+		if ace.Type != ACE4_ACCESS_ALLOWED_ACE_TYPE {
+			t.Errorf("%s is not an ALLOW ACE", who)
+		}
+		if ace.Flag&(ACE4_FILE_INHERIT_ACE|ACE4_DIRECTORY_INHERIT_ACE) == 0 {
+			t.Errorf("%s ACE missing inheritance flags", who)
+		}
+	}
+	// No grants, default none → no EVERYONE@ ACE (secure default preserved).
+	if allowACE(a, SpecialEveryone) != nil {
+		t.Errorf("unexpected EVERYONE@ ACE with default-permission none")
+	}
+}
+
+func TestBuildShareRootACL_UserGrantLevels(t *testing.T) {
+	tests := []struct {
+		level     GrantLevel
+		wantRead  bool
+		wantWrite bool
+		wantACL   bool // WRITE_ACL (admin/full only)
+		wantACE   bool
+	}{
+		{GrantNone, false, false, false, false},
+		{GrantRead, true, false, false, true},
+		{GrantReadWrite, true, true, false, true},
+		{GrantAdmin, true, true, true, true},
+	}
+	for _, tc := range tests {
+		a := BuildShareRootACL(GrantNone, []RootGrant{{ID: 1000, Level: tc.level}})
+		ace := allowACE(a, LocalDomainPrincipal(1000))
+		if tc.wantACE != (ace != nil) {
+			t.Fatalf("level %v: ACE present = %v, want %v", tc.level, ace != nil, tc.wantACE)
+		}
+		if ace == nil {
+			continue
+		}
+		if got := ace.AccessMask&ACE4_READ_DATA != 0; got != tc.wantRead {
+			t.Errorf("level %v: READ_DATA = %v, want %v", tc.level, got, tc.wantRead)
+		}
+		if got := ace.AccessMask&ACE4_WRITE_DATA != 0; got != tc.wantWrite {
+			t.Errorf("level %v: WRITE_DATA = %v, want %v", tc.level, got, tc.wantWrite)
+		}
+		if got := ace.AccessMask&ACE4_WRITE_ACL != 0; got != tc.wantACL {
+			t.Errorf("level %v: WRITE_ACL = %v, want %v", tc.level, got, tc.wantACL)
+		}
+	}
+}
+
+func TestBuildShareRootACL_DefaultPermissionEveryone(t *testing.T) {
+	a := BuildShareRootACL(GrantRead, nil)
+	ace := allowACE(a, SpecialEveryone)
+	if ace == nil {
+		t.Fatal("expected EVERYONE@ ACE for default-permission read")
+	}
+	if ace.AccessMask&ACE4_READ_DATA == 0 {
+		t.Error("EVERYONE@ ACE missing READ_DATA")
+	}
+	if ace.AccessMask&ACE4_WRITE_DATA != 0 {
+		t.Error("EVERYONE@ ACE should not grant WRITE_DATA for default read")
+	}
+}
+
+func TestBuildShareRootACL_DeterministicOrder(t *testing.T) {
+	grants := []RootGrant{
+		{ID: 2000, IsGroup: true, Level: GrantRead},
+		{ID: 1005, Level: GrantReadWrite},
+		{ID: 1001, Level: GrantRead},
+	}
+	a1 := BuildShareRootACL(GrantNone, grants)
+	a2 := BuildShareRootACL(GrantNone, grants)
+	if len(a1.ACEs) != len(a2.ACEs) {
+		t.Fatalf("ACE count differs across builds: %d vs %d", len(a1.ACEs), len(a2.ACEs))
+	}
+	for i := range a1.ACEs {
+		if a1.ACEs[i].Who != a2.ACEs[i].Who {
+			t.Fatalf("ACE order not deterministic at %d: %q vs %q", i, a1.ACEs[i].Who, a2.ACEs[i].Who)
+		}
+	}
+	// Users (1001, 1005) must precede the group (2000) among projected grants.
+	idxUser := -1
+	idxGroup := -1
+	for i, ace := range a1.ACEs {
+		if ace.Who == LocalDomainPrincipal(1005) {
+			idxUser = i
+		}
+		if ace.Who == LocalDomainPrincipal(2000) {
+			idxGroup = i
+		}
+	}
+	if idxUser == -1 || idxGroup == -1 || idxUser > idxGroup {
+		t.Errorf("expected user ACEs before group ACEs (user=%d group=%d)", idxUser, idxGroup)
+	}
+}
+
+// TestBuildShareRootACL_EvaluatesEndToEnd is the crux: a grant projected onto
+// the root must actually be honored by the ACL evaluator for a user who is
+// neither the root owner (uid 0) nor in its group. This is the exact scenario
+// that previously failed — share grant said write, POSIX mode bits on the
+// uid-0 root denied it.
+func TestBuildShareRootACL_EvaluatesEndToEnd(t *testing.T) {
+	const rootOwner = uint32(0) // share root is owned by uid 0
+
+	t.Run("granted read-write user can write", func(t *testing.T) {
+		a := BuildShareRootACL(GrantNone, []RootGrant{{ID: 1000, Level: GrantReadWrite}})
+		ctx := &EvaluateContext{UID: 1000, GID: 1000, FileOwnerUID: rootOwner}
+		if !Evaluate(a, ctx, ACE4_WRITE_DATA) {
+			t.Error("read-write grantee was denied WRITE_DATA on a uid-0 root")
+		}
+		if !Evaluate(a, ctx, ACE4_READ_DATA) {
+			t.Error("read-write grantee was denied READ_DATA")
+		}
+	})
+
+	t.Run("read-only user cannot write", func(t *testing.T) {
+		a := BuildShareRootACL(GrantNone, []RootGrant{{ID: 1000, Level: GrantRead}})
+		ctx := &EvaluateContext{UID: 1000, GID: 1000, FileOwnerUID: rootOwner}
+		if !Evaluate(a, ctx, ACE4_READ_DATA) {
+			t.Error("read grantee was denied READ_DATA")
+		}
+		if Evaluate(a, ctx, ACE4_WRITE_DATA) {
+			t.Error("read grantee was incorrectly allowed WRITE_DATA")
+		}
+	})
+
+	t.Run("ungranted user denied with default none", func(t *testing.T) {
+		a := BuildShareRootACL(GrantNone, []RootGrant{{ID: 1000, Level: GrantReadWrite}})
+		ctx := &EvaluateContext{UID: 2000, GID: 2000, FileOwnerUID: rootOwner}
+		if Evaluate(a, ctx, ACE4_READ_DATA) {
+			t.Error("ungranted user got READ_DATA despite default-permission none")
+		}
+		if Evaluate(a, ctx, ACE4_WRITE_DATA) {
+			t.Error("ungranted user got WRITE_DATA despite default-permission none")
+		}
+	})
+
+	t.Run("default-permission read grants everyone read but not write", func(t *testing.T) {
+		a := BuildShareRootACL(GrantRead, nil)
+		ctx := &EvaluateContext{UID: 2000, GID: 2000, FileOwnerUID: rootOwner}
+		if !Evaluate(a, ctx, ACE4_READ_DATA) {
+			t.Error("default-read did not grant EVERYONE read")
+		}
+		if Evaluate(a, ctx, ACE4_WRITE_DATA) {
+			t.Error("default-read incorrectly granted write")
+		}
+	})
+
+	t.Run("group grant honored via supplementary GID", func(t *testing.T) {
+		a := BuildShareRootACL(GrantNone, []RootGrant{{ID: 2000, IsGroup: true, Level: GrantReadWrite}})
+		ctx := &EvaluateContext{UID: 3000, GID: 100, GIDs: []uint32{2000}, FileOwnerUID: rootOwner}
+		if !Evaluate(a, ctx, ACE4_WRITE_DATA) {
+			t.Error("member of granted group was denied WRITE_DATA")
+		}
+	})
+
+	t.Run("root owner retains control via OWNER@", func(t *testing.T) {
+		a := BuildShareRootACL(GrantNone, nil)
+		ctx := &EvaluateContext{UID: 500, GID: 500, FileOwnerUID: 500}
+		if !Evaluate(a, ctx, ACE4_WRITE_DATA) {
+			t.Error("file owner was denied WRITE_DATA via OWNER@")
+		}
+	})
+}
+
+func TestBuildShareRootACL_ValidACL(t *testing.T) {
+	a := BuildShareRootACL(GrantReadWrite, []RootGrant{
+		{ID: 1001, Level: GrantRead},
+		{ID: 2000, IsGroup: true, Level: GrantReadWrite},
+	})
+	if err := ValidateACL(a); err != nil {
+		t.Fatalf("BuildShareRootACL produced an invalid ACL: %v", err)
+	}
+}

--- a/pkg/metadata/acl/share_grant_test.go
+++ b/pkg/metadata/acl/share_grant_test.go
@@ -36,8 +36,11 @@ func TestBuildShareRootACL_BaselineACEs(t *testing.T) {
 		if ace.Type != ACE4_ACCESS_ALLOWED_ACE_TYPE {
 			t.Errorf("%s is not an ALLOW ACE", who)
 		}
-		if ace.Flag&(ACE4_FILE_INHERIT_ACE|ACE4_DIRECTORY_INHERIT_ACE) == 0 {
-			t.Errorf("%s ACE missing inheritance flags", who)
+		if ace.Flag&ACE4_FILE_INHERIT_ACE == 0 {
+			t.Errorf("%s ACE missing FILE_INHERIT flag", who)
+		}
+		if ace.Flag&ACE4_DIRECTORY_INHERIT_ACE == 0 {
+			t.Errorf("%s ACE missing DIRECTORY_INHERIT flag", who)
 		}
 	}
 	// No grants, default none → no EVERYONE@ ACE (secure default preserved).
@@ -193,6 +196,48 @@ func TestBuildShareRootACL_EvaluatesEndToEnd(t *testing.T) {
 			t.Error("file owner was denied WRITE_DATA via OWNER@")
 		}
 	})
+}
+
+// TestBuildShareRootACL_MergesDuplicatePrincipals proves that grants projecting
+// to the same principal (e.g. several users without an explicit UID collapsing
+// to smbDefaultUID) emit a single ACE at the highest level, keeping the ACL
+// stable and minimal.
+func TestBuildShareRootACL_MergesDuplicatePrincipals(t *testing.T) {
+	a := BuildShareRootACL(GrantNone, []RootGrant{
+		{ID: 1000, Level: GrantRead},
+		{ID: 1000, Level: GrantReadWrite}, // higher level wins
+		{ID: 1000, Level: GrantRead},
+	})
+
+	who := LocalDomainPrincipal(1000)
+	count := 0
+	for _, ace := range a.ACEs {
+		if ace.Who == who {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 ACE for %q, got %d", who, count)
+	}
+	ace := allowACE(a, who)
+	if ace.AccessMask&ACE4_WRITE_DATA == 0 {
+		t.Error("merged ACE should carry the highest level (read-write), missing WRITE_DATA")
+	}
+
+	// A user id and a group id with the same numeric value stay distinct.
+	a2 := BuildShareRootACL(GrantNone, []RootGrant{
+		{ID: 1000, Level: GrantRead},
+		{ID: 1000, IsGroup: true, Level: GrantReadWrite},
+	})
+	n := 0
+	for _, ace := range a2.ACEs {
+		if ace.Who == LocalDomainPrincipal(1000) {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("user and group with same numeric id both project to %q; merge collapsed them (got %d ACEs)", LocalDomainPrincipal(1000), n)
+	}
 }
 
 func TestBuildShareRootACL_ValidACL(t *testing.T) {

--- a/pkg/metadata/acl/share_grant_test.go
+++ b/pkg/metadata/acl/share_grant_test.go
@@ -36,11 +36,11 @@ func TestBuildShareRootACL_BaselineACEs(t *testing.T) {
 		if ace.Type != ACE4_ACCESS_ALLOWED_ACE_TYPE {
 			t.Errorf("%s is not an ALLOW ACE", who)
 		}
-		if ace.Flag&ACE4_FILE_INHERIT_ACE == 0 {
-			t.Errorf("%s ACE missing FILE_INHERIT flag", who)
-		}
-		if ace.Flag&ACE4_DIRECTORY_INHERIT_ACE == 0 {
-			t.Errorf("%s ACE missing DIRECTORY_INHERIT flag", who)
+		// The projected ACL governs the root directory only; ACEs must NOT
+		// inherit, so per-file POSIX bits govern descendants (see
+		// BuildShareRootACL).
+		if ace.Flag&(ACE4_FILE_INHERIT_ACE|ACE4_DIRECTORY_INHERIT_ACE) != 0 {
+			t.Errorf("%s ACE unexpectedly carries inheritance flags %#x", who, ace.Flag)
 		}
 	}
 	// No grants, default none → no EVERYONE@ ACE (secure default preserved).

--- a/pkg/metadata/acl/types.go
+++ b/pkg/metadata/acl/types.go
@@ -152,6 +152,12 @@ const (
 	// ACEs were available at creation time. Mirrors Samba's sd_def1
 	// (source4/torture/smb2/acls.c).
 	ACLSourceWindowsDefault ACLSource = "windows-default"
+
+	// ACLSourceShareGrant indicates the ACL was synthesized from control-plane
+	// share-permission grants and projected onto the share root directory, so
+	// the filesystem layer agrees with the share-level access a user was
+	// granted. See BuildShareRootACL.
+	ACLSourceShareGrant ACLSource = "share-grant"
 )
 
 // ACL represents an NFSv4 Access Control List.

--- a/test/posix/setup-posix.sh
+++ b/test/posix/setup-posix.sh
@@ -280,12 +280,13 @@ configure_via_api() {
     # test UIDs to verify POSIX permission semantics. With the secure share
     # default (default-permission=none) those UIDs are unknown to the export and
     # are denied at the gate before POSIX is ever consulted, so each must be a
-    # known user with a read-write grant. The grant only opens the export gate;
-    # it does not touch any filesystem ACL, so the per-file POSIX mode bits —
-    # exactly what pjdfstest asserts — still govern. UIDs mirror
-    # test/posix/Dockerfile.pjdfstest. No --owner is needed: root owns the
-    # export root and creates the per-test working dirs, which pjdfstest then
-    # chmod/chowns for the unprivileged UIDs.
+    # known user with a read-write grant. The grant opens the export gate and
+    # projects a NON-inheriting ACL onto the share ROOT directory only (so a
+    # grantee can write the root); it does not propagate onto the per-test
+    # working dirs and files, so the per-file POSIX mode bits — exactly what
+    # pjdfstest asserts — still govern. UIDs mirror test/posix/Dockerfile.pjdfstest.
+    # No --owner is needed: root owns the export root and creates the per-test
+    # working dirs, which pjdfstest then chmod/chowns for the unprivileged UIDs.
     log_info "Creating pjdfstest test users..."
     for uid in 65532 65533 65534; do
         "$DITTOFSCTL_BIN" user create --username "pjdfstest-${uid}" --password pjdfstest --uid "$uid" --gid "$uid"


### PR DESCRIPTION
## Problem

A user granted **read-write at the share level** was still denied at the filesystem layer. Two independent permission layers disagreed:

1. **Control-plane share ACL** — `dfsctl share permission grant /s --user u --level read-write` → allowed.
2. **Metadata POSIX/ACL check** — the share root is created owned by **uid 0, mode 0755** (`shares/service.go`), so a non-owner user fails the POSIX `other`-bits check.

Result: `Permission denied` creating files at the share root despite an explicit read-write grant. This is exactly what the macOS leg of SMB Client Compatibility hits.

## Fix — project share grants onto the root directory ACL

The metadata permission check already honors an NFSv4 ACL **in preference to** mode bits (`auth_permissions.go:CheckParentCreateAccess`). So we make the two layers agree by projecting the control-plane grants onto the share root's ACL.

- **`acl.BuildShareRootACL(defaultLevel, grants)`** (`pkg/metadata/acl/share_grant.go`) — synthesizes an allow-only DACL: `OWNER@`/`SYSTEM@`/`Administrators` full control, one ACE per grant, and `EVERYONE@` for the share default-permission (omitted when `none`, preserving the secure default). All ACEs carry `FILE_INHERIT|DIRECTORY_INHERIT` so the subtree stays consistent. read→r-x, read-write→rwx, admin→full.
- **`Runtime.ReconcileShareRootACL(ctx, shareName)`** (`pkg/controlplane/runtime/share_root_acl.go`) — rebuilds the ACL from the **full current grant set** (idempotent: correct after grant, revoke, default-permission change, and on restart) and writes it via `SetFileAttributes` with a superuser context. Best-effort; nil-guarded for partial runtimes.
- Wired into the grant/revoke REST handlers and `AddShare`.
- New share-scoped store getters `GetShareUserPermissions` / `GetShareGroupPermissions`.

### Cross-protocol Who form
Grants project onto `{id}@localdomain` ACEs — the numeric principal the ACL evaluator matches against an `AuthContext`'s UID/GID. Both NFS (AUTH_UNIX uid) and SMB (mapped user uid) populate this, so it is the common denominator (a `sid:` Who would not match NFS).

### Why best-effort is safe
The **share layer is the authoritative gate** and is enforced at every mount/op. A revoke deletes the grant record, so the user is denied at the share layer immediately — even if the secondary root-ACL projection fails to update, there is no access leak. The ACL is defense-in-depth that self-heals on the next reconcile/restart.

## Tests
End-to-end evaluator tests (`pkg/metadata/acl/share_grant_test.go`) drive the real ACL evaluator and confirm, on a uid-0 root:
- a read-write grantee **can** write; a read-only grantee **cannot**;
- ungranted users are denied (default none); default-read grants `EVERYONE@` read but not write;
- group grants are honored via supplementary GID; the owner retains control via `OWNER@`.

## Notes / limitations
- Users without an assigned UID fall back to the SMB adapter's default UID (1000), matching the AuthContext the adapter builds. Such users are indistinguishable at the filesystem layer — assign explicit UIDs for per-user isolation (inherent to the current identity model).
- Pairs with #1431 (test-harness fixes); that PR repairs the SMB Client Compatibility bootstrap, this one fixes the underlying permission regression the macOS leg exposes.
