### PR TITLE
fix(badger): index payload lookups to kill full-scan crash (#1435)

### DIFF
--- a/pkg/metadata/store/badger/cache.go
+++ b/pkg/metadata/store/badger/cache.go
@@ -177,6 +177,15 @@ var detectAvailableMemory = func() uint64 {
 	return sysinfo.NewDetector().AvailableMemory()
 }
 
+// constrainedHostMemThreshold is the process-available-memory figure (bytes)
+// below which buildBadgerOptions trims Badger's LSM in-memory footprint. A
+// SIGSEGV was observed faulting on an mmap'd SST block under memory pressure on
+// an 8 GB host (#1435); shrinking the memtable footprint and compactor
+// concurrency leaves more RAM for the OS page cache that backs those mmaps,
+// narrowing the fault window. The sysinfo detector's failure fallback sits at
+// this boundary, so a failed detection does not trip the constrained path.
+const constrainedHostMemThreshold = 4 << 30 // 4 GiB
+
 // buildBadgerOptions constructs the badger.Options used to open a metadata
 // store. It is a pure function of its inputs (the store config and the
 // process-available memory figure), which makes the option construction — in
@@ -214,6 +223,19 @@ func buildBadgerOptions(config BadgerMetadataStoreConfig, availMem uint64) badge
 
 	opts = opts.WithBlockCacheSize(blockCacheMB << 20) // MiB -> bytes
 	opts = opts.WithIndexCacheSize(indexCacheMB << 20) // MiB -> bytes
+
+	// On memory-constrained hosts, trim the LSM in-memory footprint and
+	// compaction concurrency (#1435) so the OS keeps more SST pages resident,
+	// narrowing the mmap-fault window seen under upload pressure. Values stay
+	// well above Badger's minimums and only apply to the auto-tuned path —
+	// operator-supplied BadgerOptions returned verbatim above are untouched.
+	if availMem > 0 && availMem < constrainedHostMemThreshold {
+		opts = opts.WithMemTableSize(32 << 20)     // default 64 MiB
+		opts = opts.WithNumMemtables(2)            // default 5
+		opts = opts.WithNumLevelZeroTables(2)      // default 5
+		opts = opts.WithNumLevelZeroTablesStall(4) // default 15
+		opts = opts.WithNumCompactors(2)           // default 4 (Badger min 2)
+	}
 
 	return opts
 }

--- a/pkg/metadata/store/badger/cache_test.go
+++ b/pkg/metadata/store/badger/cache_test.go
@@ -172,6 +172,35 @@ func TestBuildBadgerOptions_ThreadsAutoSizes(t *testing.T) {
 	}
 }
 
+// TestBuildBadgerOptions_ConstrainedHostTrimsLSM asserts that below the
+// memory threshold the LSM footprint and compactor concurrency are trimmed
+// (#1435), and that at/above the threshold the Badger defaults are retained.
+func TestBuildBadgerOptions_ConstrainedHostTrimsLSM(t *testing.T) {
+	SetGlobalBadgerCacheDefaults(0, 0)
+
+	constrained := buildBadgerOptions(BadgerMetadataStoreConfig{DBPath: t.TempDir()}, constrainedHostMemThreshold-1)
+	if got, want := constrained.MemTableSize, int64(32<<20); got != want {
+		t.Errorf("constrained MemTableSize: got %d, want %d", got, want)
+	}
+	if got, want := constrained.NumMemtables, 2; got != want {
+		t.Errorf("constrained NumMemtables: got %d, want %d", got, want)
+	}
+	if got, want := constrained.NumCompactors, 2; got != want {
+		t.Errorf("constrained NumCompactors: got %d, want %d", got, want)
+	}
+
+	// At the threshold (and on detection failure, which falls back here) the
+	// defaults are preserved — no trimming.
+	defaults := badger.DefaultOptions(t.TempDir())
+	roomy := buildBadgerOptions(BadgerMetadataStoreConfig{DBPath: t.TempDir()}, constrainedHostMemThreshold)
+	if roomy.MemTableSize != defaults.MemTableSize {
+		t.Errorf("roomy MemTableSize trimmed: got %d, want default %d", roomy.MemTableSize, defaults.MemTableSize)
+	}
+	if roomy.NumMemtables != defaults.NumMemtables {
+		t.Errorf("roomy NumMemtables trimmed: got %d, want default %d", roomy.NumMemtables, defaults.NumMemtables)
+	}
+}
+
 // TestBuildBadgerOptions_CustomOptionsPassthrough asserts that an operator who
 // supplies BadgerOptions takes full control: the helper returns them verbatim
 // and does not override the caches.

--- a/pkg/metadata/store/badger/encoding.go
+++ b/pkg/metadata/store/badger/encoding.go
@@ -52,6 +52,7 @@ const (
 	prefixConfig       = "cfg:"
 	prefixCapabilities = "cap:"
 	prefixObjectID     = "obj:" // ObjectID -> file UUID
+	prefixPayloadID    = "pl:"  // PayloadID (content ID) -> file UUID
 )
 
 // ============================================================================
@@ -119,6 +120,17 @@ func keyFilesystemCapabilities() []byte {
 // helper -- caller checks IsZero() first.
 func keyObjectID(h metadata.ContentHash) []byte {
 	return []byte(prefixObjectID + h.String())
+}
+
+// keyPayloadID generates a key for the PayloadID secondary index:
+// "pl:<payloadID>". Empty PayloadIDs MUST NOT be written through this helper --
+// caller checks for "" first. PayloadID is the inode's stable content
+// identifier (share/<inode-uuid>, see buildPayloadID), so one key maps to
+// exactly one file and stays valid across rename/relink (#1166). The index lets
+// GetFileByPayloadID resolve a file with an O(1) point lookup instead of a
+// full-keyspace scan on the hot rollup persist path (#1435).
+func keyPayloadID(p metadata.PayloadID) []byte {
+	return []byte(prefixPayloadID + string(p))
 }
 
 // ============================================================================

--- a/pkg/metadata/store/badger/files.go
+++ b/pkg/metadata/store/badger/files.go
@@ -60,6 +60,17 @@ func (s *BadgerMetadataStore) GetFileByPayloadID(ctx context.Context, payloadID 
 	var result *metadata.File
 
 	err := s.db.View(func(txn *badgerdb.Txn) error {
+		btx := &badgerTransaction{store: s, txn: txn}
+
+		// Fast path: resolve via the pl:<payloadID> secondary index (#1435); an
+		// index miss or stale entry falls through to the legacy full scan below.
+		if file, found, lookupErr := btx.lookupFileByPayloadIndex(payloadID); lookupErr != nil {
+			return lookupErr
+		} else if found {
+			result = file
+			return nil
+		}
+
 		opts := badgerdb.DefaultIteratorOptions
 		opts.PrefetchSize = 100
 		it := txn.NewIterator(opts)

--- a/pkg/metadata/store/badger/files.go
+++ b/pkg/metadata/store/badger/files.go
@@ -51,7 +51,9 @@ func (s *BadgerMetadataStore) DeleteFile(ctx context.Context, handle metadata.Fi
 }
 
 // GetFileByPayloadID retrieves file metadata by its content identifier.
-// Note: This is O(n) and may be slow for large filesystems.
+// Steady-state this is an O(1) point lookup via the pl:<payloadID> secondary
+// index (#1435); it degrades to an O(n) keyspace scan only for legacy rows
+// written before the index existed (those are indexed on their next write).
 func (s *BadgerMetadataStore) GetFileByPayloadID(ctx context.Context, payloadID metadata.PayloadID) (*metadata.File, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/pkg/metadata/store/badger/payload_index_test.go
+++ b/pkg/metadata/store/badger/payload_index_test.go
@@ -1,0 +1,161 @@
+package badger
+
+import (
+	"context"
+	"testing"
+
+	badgerdb "github.com/dgraph-io/badger/v4"
+	"github.com/google/uuid"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/stretchr/testify/require"
+)
+
+// mkPayloadShare creates a share and returns its root handle.
+func mkPayloadShare(t *testing.T, store *BadgerMetadataStore, shareName string) metadata.FileHandle {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, store.CreateShare(ctx, &metadata.Share{Name: shareName}))
+	rootFile, err := store.CreateRootDirectory(ctx, shareName, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory, Mode: 0o755,
+	})
+	require.NoError(t, err)
+	h, err := metadata.EncodeFileHandle(rootFile)
+	require.NoError(t, err)
+	return h
+}
+
+// mkPayloadFile creates a regular file with the given PayloadID and wires its
+// parent/child links, returning its handle.
+func mkPayloadFile(t *testing.T, store *BadgerMetadataStore, shareName string, dir metadata.FileHandle, name, fullPath string, pid metadata.PayloadID) metadata.FileHandle {
+	t.Helper()
+	ctx := context.Background()
+	handle, err := store.GenerateHandle(ctx, shareName, fullPath)
+	require.NoError(t, err)
+	_, id, err := metadata.DecodeFileHandle(handle)
+	require.NoError(t, err)
+
+	file := &metadata.File{
+		ShareName: shareName,
+		Path:      fullPath,
+		FileAttr: metadata.FileAttr{
+			Type: metadata.FileTypeRegular, Mode: 0o600, UID: 1000, GID: 1000,
+			PayloadID: pid,
+		},
+	}
+	file.ID = id
+	require.NoError(t, store.PutFile(ctx, file))
+	require.NoError(t, store.SetParent(ctx, handle, dir))
+	require.NoError(t, store.SetChild(ctx, dir, name, handle))
+	return handle
+}
+
+// payloadIndexValue reads the pl:<payloadID> secondary-index entry directly and
+// returns the file UUID it maps to (and whether it exists). It lets the tests
+// assert index maintenance independently of the GetFileByPayloadID read path.
+func payloadIndexValue(t *testing.T, s *BadgerMetadataStore, pid metadata.PayloadID) (uuid.UUID, bool) {
+	t.Helper()
+	var id uuid.UUID
+	found := false
+	require.NoError(t, s.db.View(func(txn *badgerdb.Txn) error {
+		item, err := txn.Get(keyPayloadID(pid))
+		if err == badgerdb.ErrKeyNotFound {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		raw, err := item.ValueCopy(nil)
+		if err != nil {
+			return err
+		}
+		if err := id.UnmarshalBinary(raw); err != nil {
+			return err
+		}
+		found = true
+		return nil
+	}))
+	return id, found
+}
+
+// TestPayloadIndex_PointLookupAndTeardown covers the #1435 secondary index: it
+// is written on PutFile, resolves GetFileByPayloadID, still works via the legacy
+// scan fallback when the entry is absent, and is torn down on DeleteFile.
+func TestPayloadIndex_PointLookupAndTeardown(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewBadgerMetadataStoreWithDefaults(ctx, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	const shareName = "s1"
+	root := mkPayloadShare(t, store, shareName)
+	pid := metadata.PayloadID(shareName + "/" + uuid.NewString())
+
+	handle := mkPayloadFile(t, store, shareName, root, "f.bin", "/f.bin", pid)
+	_, fileID, err := metadata.DecodeFileHandle(handle)
+	require.NoError(t, err)
+
+	// Index written and points at the file.
+	idxID, ok := payloadIndexValue(t, store, pid)
+	require.True(t, ok, "pl: index entry must exist after PutFile")
+	require.Equal(t, fileID, idxID)
+
+	// Lookup resolves (via the index fast path).
+	got, err := store.GetFileByPayloadID(ctx, pid)
+	require.NoError(t, err)
+	require.Equal(t, fileID, got.ID)
+	require.Equal(t, pid, got.PayloadID)
+
+	// Legacy fallback: drop the index entry and confirm the scan still finds it.
+	require.NoError(t, store.db.Update(func(txn *badgerdb.Txn) error {
+		return txn.Delete(keyPayloadID(pid))
+	}))
+	got, err = store.GetFileByPayloadID(ctx, pid)
+	require.NoError(t, err)
+	require.Equal(t, fileID, got.ID, "scan fallback must resolve an unindexed file")
+
+	// Teardown: deleting the file removes the index entry and the lookup 404s.
+	require.NoError(t, store.DeleteFile(ctx, handle))
+	if _, ok := payloadIndexValue(t, store, pid); ok {
+		t.Fatal("pl: index entry must be gone after DeleteFile")
+	}
+	_, err = store.GetFileByPayloadID(ctx, pid)
+	require.Error(t, err)
+	require.True(t, metadata.IsNotFoundError(err), "want not-found, got %v", err)
+}
+
+// TestPayloadIndex_MovesOnPayloadIDChange asserts that re-persisting a file with
+// a changed PayloadID drops the stale index entry and creates a fresh one, so a
+// single file never leaves a dangling pl: key behind.
+func TestPayloadIndex_MovesOnPayloadIDChange(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewBadgerMetadataStoreWithDefaults(ctx, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	const shareName = "s1"
+	root := mkPayloadShare(t, store, shareName)
+	oldPID := metadata.PayloadID(shareName + "/" + uuid.NewString())
+
+	handle := mkPayloadFile(t, store, shareName, root, "f.bin", "/f.bin", oldPID)
+	_, fileID, err := metadata.DecodeFileHandle(handle)
+	require.NoError(t, err)
+
+	// Re-persist the same inode with a new PayloadID.
+	file, err := store.GetFile(ctx, handle)
+	require.NoError(t, err)
+	newPID := metadata.PayloadID(shareName + "/" + uuid.NewString())
+	file.PayloadID = newPID
+	require.NoError(t, store.PutFile(ctx, file))
+
+	// Old entry gone, new entry points at the same file.
+	if _, ok := payloadIndexValue(t, store, oldPID); ok {
+		t.Fatal("stale pl: entry for old PayloadID must be removed")
+	}
+	idxID, ok := payloadIndexValue(t, store, newPID)
+	require.True(t, ok, "pl: entry for new PayloadID must exist")
+	require.Equal(t, fileID, idxID)
+
+	got, err := store.GetFileByPayloadID(ctx, newPID)
+	require.NoError(t, err)
+	require.Equal(t, fileID, got.ID)
+}

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -285,13 +285,14 @@ func (s *BadgerMetadataStore) applyQuotaDelta(delta map[badgerQuotaKey]metadata.
 // double-counts. The counter is statfs-only, not quota-enforcing.
 func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName string) (freedBytes int64, quota map[badgerQuotaKey]metadata.UsageStat, err error) {
 	type doomed struct {
-		id       uuid.UUID
-		objectID metadata.ContentHash
-		isDir    bool
-		size     uint64
-		isReg    bool
-		uid      uint32
-		gid      uint32
+		id        uuid.UUID
+		objectID  metadata.ContentHash
+		payloadID metadata.PayloadID
+		isDir     bool
+		size      uint64
+		isReg     bool
+		uid       uint32
+		gid       uint32
 	}
 	var victims []doomed
 
@@ -316,20 +317,21 @@ func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName stri
 			continue
 		}
 		victims = append(victims, doomed{
-			id:       file.ID,
-			objectID: file.ObjectID,
-			isDir:    file.Type == metadata.FileTypeDirectory,
-			size:     file.Size,
-			isReg:    file.Type == metadata.FileTypeRegular,
-			uid:      file.UID,
-			gid:      file.GID,
+			id:        file.ID,
+			objectID:  file.ObjectID,
+			payloadID: file.PayloadID,
+			isDir:     file.Type == metadata.FileTypeDirectory,
+			size:      file.Size,
+			isReg:     file.Type == metadata.FileTypeRegular,
+			uid:       file.UID,
+			gid:       file.GID,
 		})
 	}
 	it.Close()
 
 	quota = make(map[badgerQuotaKey]metadata.UsageStat)
 	for _, v := range victims {
-		if delErr := deleteFileKeys(txn, v.id, v.objectID); delErr != nil {
+		if delErr := deleteFileKeys(txn, v.id, v.objectID, v.payloadID); delErr != nil {
 			return 0, nil, delErr
 		}
 		// Directories own c:<uuid>:<name> child entries; prefix-scan and
@@ -360,10 +362,10 @@ func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName stri
 }
 
 // deleteFileKeys removes the primary file row plus its parent, link-count, and
-// (when present) ObjectID secondary-index keys. Shared by DeleteFile and
-// DeleteShare so the per-file teardown lives in one place. Missing keys are
-// tolerated; the caller owns child-entry and usedBytes cleanup.
-func deleteFileKeys(txn *badgerdb.Txn, id uuid.UUID, objectID metadata.ContentHash) error {
+// (when present) ObjectID and PayloadID secondary-index keys. Shared by
+// DeleteFile and DeleteShare so the per-file teardown lives in one place.
+// Missing keys are tolerated; the caller owns child-entry and usedBytes cleanup.
+func deleteFileKeys(txn *badgerdb.Txn, id uuid.UUID, objectID metadata.ContentHash, payloadID metadata.PayloadID) error {
 	keys := [][]byte{
 		keyFile(id),
 		keyParent(id),
@@ -377,6 +379,11 @@ func deleteFileKeys(txn *badgerdb.Txn, id uuid.UUID, objectID metadata.ContentHa
 	if !objectID.IsZero() {
 		if err := txn.Delete(keyObjectID(objectID)); err != nil && err != badgerdb.ErrKeyNotFound {
 			return fmt.Errorf("badger: delete obj index: %w", err)
+		}
+	}
+	if payloadID != "" {
+		if err := txn.Delete(keyPayloadID(payloadID)); err != nil && err != badgerdb.ErrKeyNotFound {
+			return fmt.Errorf("badger: delete payload index: %w", err)
 		}
 	}
 	return nil

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -326,6 +326,7 @@ func (tx *badgerTransaction) PutFile(ctx context.Context, file *metadata.File) e
 	var oldUID, oldGID uint32
 	var hadOldRegular bool
 	var oldObjectID metadata.ContentHash
+	var oldPayloadID metadata.PayloadID
 	if item, err := tx.txn.Get(keyFile(file.ID)); err == nil {
 		_ = item.Value(func(val []byte) error {
 			existing, decErr := decodeFile(val)
@@ -337,6 +338,7 @@ func (tx *badgerTransaction) PutFile(ctx context.Context, file *metadata.File) e
 					hadOldRegular = true
 				}
 				oldObjectID = existing.ObjectID
+				oldPayloadID = existing.PayloadID
 			}
 			return nil
 		})
@@ -404,6 +406,25 @@ func (tx *badgerTransaction) PutFile(ctx context.Context, file *metadata.File) e
 		}
 	}
 
+	// maintain PayloadID -> file UUID secondary index (#1435) in the same Txn.
+	// PayloadID is unique per inode and stable across rename, so unlike the
+	// ObjectID index this needs no conflict probe -- drop the stale entry if it
+	// changed, then point the (possibly new) PayloadID at this file.
+	if oldPayloadID != "" && oldPayloadID != file.PayloadID {
+		if err := tx.txn.Delete(keyPayloadID(oldPayloadID)); err != nil && !goerrors.Is(err, badgerdb.ErrKeyNotFound) {
+			return fmt.Errorf("badger PutFile: delete stale payload index: %w", err)
+		}
+	}
+	if file.PayloadID != "" {
+		idBin, merr := file.ID.MarshalBinary()
+		if merr != nil {
+			return fmt.Errorf("badger PutFile: marshal file ID: %w", merr)
+		}
+		if err := tx.txn.Set(keyPayloadID(file.PayloadID), idBin); err != nil {
+			return fmt.Errorf("badger PutFile: set payload index: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -433,9 +454,10 @@ func (tx *badgerTransaction) DeleteFile(ctx context.Context, handle metadata.Fil
 		return err
 	}
 
-	// Subtract size from counter for regular files; capture ObjectID for
-	// secondary-index cleanup.
+	// Subtract size from counter for regular files; capture ObjectID and
+	// PayloadID for secondary-index cleanup.
 	var existingObjectID metadata.ContentHash
+	var existingPayloadID metadata.PayloadID
 	_ = item.Value(func(val []byte) error {
 		file, decErr := decodeFile(val)
 		if decErr == nil {
@@ -446,13 +468,14 @@ func (tx *badgerTransaction) DeleteFile(ctx context.Context, handle metadata.Fil
 				tx.addQuota(file.UID, file.GID, -int64(file.Size), -1)
 			}
 			existingObjectID = file.ObjectID
+			existingPayloadID = file.PayloadID
 		}
 		return nil
 	})
 
-	// Delete the primary file row plus parent/link-count/ObjectID keys via
-	// the shared per-file teardown (also used by DeleteShare).
-	if err := deleteFileKeys(tx.txn, fileID, existingObjectID); err != nil {
+	// Delete the primary file row plus parent/link-count/ObjectID/PayloadID
+	// keys via the shared per-file teardown (also used by DeleteShare).
+	if err := deleteFileKeys(tx.txn, fileID, existingObjectID, existingPayloadID); err != nil {
 		return err
 	}
 
@@ -1454,9 +1477,100 @@ func (tx *badgerTransaction) GetFilesystemStatistics(ctx context.Context, handle
 // Transaction Files Operations (additional)
 // ============================================================================
 
+// loadEnrichedFileByID loads a file row by UUID and populates Nlink (from the
+// link-count key, defaulted by type when absent) and the derived Path (#1166),
+// matching what the GetFileByPayloadID scan returns. Returns (nil, nil) when no
+// row exists for the ID -- a stale secondary-index entry, which the caller
+// treats as an index miss and falls back to the full scan.
+func (tx *badgerTransaction) loadEnrichedFileByID(fileID uuid.UUID) (*metadata.File, error) {
+	item, err := tx.txn.Get(keyFile(fileID))
+	if goerrors.Is(err, badgerdb.ErrKeyNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var file *metadata.File
+	if err := item.Value(func(val []byte) error {
+		f, decErr := decodeFile(val)
+		if decErr != nil {
+			return decErr
+		}
+		file = f
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	linkItem, linkErr := tx.txn.Get(keyLinkCount(fileID))
+	switch linkErr {
+	case nil:
+		_ = linkItem.Value(func(linkVal []byte) error {
+			if count, cErr := decodeUint32(linkVal); cErr == nil {
+				file.Nlink = count
+			}
+			return nil
+		})
+	case badgerdb.ErrKeyNotFound:
+		if file.Type == metadata.FileTypeDirectory {
+			file.Nlink = 2
+		} else {
+			file.Nlink = 1
+		}
+	}
+
+	file.Path = tx.derivePath(fileID)
+	return file, nil
+}
+
+// lookupFileByPayloadIndex resolves a file through the pl:<payloadID> secondary
+// index (#1435) with an O(1) point lookup. found is true only on a confirmed
+// hit; it is false (with a nil error) whenever the caller should fall back to
+// the legacy full scan: an empty PayloadID, an index miss (legacy row written
+// before the index), or a stale/corrupt index entry.
+func (tx *badgerTransaction) lookupFileByPayloadIndex(payloadID metadata.PayloadID) (file *metadata.File, found bool, err error) {
+	if payloadID == "" {
+		return nil, false, nil
+	}
+
+	item, err := tx.txn.Get(keyPayloadID(payloadID))
+	switch {
+	case err == nil:
+		raw, cErr := item.ValueCopy(nil)
+		if cErr != nil {
+			return nil, false, nil // corrupt index entry: fall back to scan
+		}
+		var fileID uuid.UUID
+		if uErr := fileID.UnmarshalBinary(raw); uErr != nil {
+			return nil, false, nil // corrupt index entry: fall back to scan
+		}
+		f, lErr := tx.loadEnrichedFileByID(fileID)
+		if lErr != nil {
+			return nil, false, lErr
+		}
+		if f != nil && f.PayloadID == payloadID {
+			return f, true, nil
+		}
+		return nil, false, nil // stale index entry: fall back to scan
+	case goerrors.Is(err, badgerdb.ErrKeyNotFound):
+		return nil, false, nil // not indexed (legacy row): fall back to scan
+	default:
+		return nil, false, err
+	}
+}
+
 func (tx *badgerTransaction) GetFileByPayloadID(ctx context.Context, payloadID metadata.PayloadID) (*metadata.File, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
+	}
+
+	// Fast path: resolve via the pl:<payloadID> secondary index (#1435); an
+	// index miss or stale entry falls through to the legacy full scan below.
+	if file, found, err := tx.lookupFileByPayloadIndex(payloadID); err != nil {
+		return nil, err
+	} else if found {
+		return file, nil
 	}
 
 	opts := badgerdb.DefaultIteratorOptions

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -1503,29 +1503,23 @@ func (tx *badgerTransaction) loadEnrichedFileByID(fileID uuid.UUID) (*metadata.F
 		return nil, err
 	}
 
-	linkItem, linkErr := tx.txn.Get(keyLinkCount(fileID))
-	switch {
-	case linkErr == nil:
-		if err := linkItem.Value(func(linkVal []byte) error {
-			count, cErr := decodeUint32(linkVal)
-			if cErr != nil {
-				return cErr
+	// The link count is secondary data stored under a separate key. Mirror
+	// GetFile and the legacy scan path: a missing or unreadable link-count key
+	// never fails the lookup. Seed the type default first so any such case
+	// returns a sensible Nlink rather than 0 (#1435 review), then override it
+	// with the stored count when the key reads and decodes cleanly.
+	if file.Type == metadata.FileTypeDirectory {
+		file.Nlink = 2
+	} else {
+		file.Nlink = 1
+	}
+	if linkItem, linkErr := tx.txn.Get(keyLinkCount(fileID)); linkErr == nil {
+		_ = linkItem.Value(func(linkVal []byte) error {
+			if count, cErr := decodeUint32(linkVal); cErr == nil {
+				file.Nlink = count
 			}
-			file.Nlink = count
 			return nil
-		}); err != nil {
-			return nil, err
-		}
-	case goerrors.Is(linkErr, badgerdb.ErrKeyNotFound):
-		if file.Type == metadata.FileTypeDirectory {
-			file.Nlink = 2
-		} else {
-			file.Nlink = 1
-		}
-	default:
-		// Unexpected Badger/IO error: surface it rather than returning a file
-		// with Nlink silently left at 0.
-		return nil, linkErr
+		})
 	}
 
 	file.Path = tx.derivePath(fileID)

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -1504,20 +1504,28 @@ func (tx *badgerTransaction) loadEnrichedFileByID(fileID uuid.UUID) (*metadata.F
 	}
 
 	linkItem, linkErr := tx.txn.Get(keyLinkCount(fileID))
-	switch linkErr {
-	case nil:
-		_ = linkItem.Value(func(linkVal []byte) error {
-			if count, cErr := decodeUint32(linkVal); cErr == nil {
-				file.Nlink = count
+	switch {
+	case linkErr == nil:
+		if err := linkItem.Value(func(linkVal []byte) error {
+			count, cErr := decodeUint32(linkVal)
+			if cErr != nil {
+				return cErr
 			}
+			file.Nlink = count
 			return nil
-		})
-	case badgerdb.ErrKeyNotFound:
+		}); err != nil {
+			return nil, err
+		}
+	case goerrors.Is(linkErr, badgerdb.ErrKeyNotFound):
 		if file.Type == metadata.FileTypeDirectory {
 			file.Nlink = 2
 		} else {
 			file.Nlink = 1
 		}
+	default:
+		// Unexpected Badger/IO error: surface it rather than returning a file
+		// with Nlink silently left at 0.
+		return nil, linkErr
 	}
 
 	file.Path = tx.derivePath(fileID)
@@ -1528,7 +1536,9 @@ func (tx *badgerTransaction) loadEnrichedFileByID(fileID uuid.UUID) (*metadata.F
 // index (#1435) with an O(1) point lookup. found is true only on a confirmed
 // hit; it is false (with a nil error) whenever the caller should fall back to
 // the legacy full scan: an empty PayloadID, an index miss (legacy row written
-// before the index), or a stale/corrupt index entry.
+// before the index), or a stale entry. Unexpected Badger/IO errors are
+// propagated rather than masked as a fallback, so a transient fault does not
+// silently re-trigger the expensive scan this index exists to avoid.
 func (tx *badgerTransaction) lookupFileByPayloadIndex(payloadID metadata.PayloadID) (file *metadata.File, found bool, err error) {
 	if payloadID == "" {
 		return nil, false, nil
@@ -1539,11 +1549,11 @@ func (tx *badgerTransaction) lookupFileByPayloadIndex(payloadID metadata.Payload
 	case err == nil:
 		raw, cErr := item.ValueCopy(nil)
 		if cErr != nil {
-			return nil, false, nil // corrupt index entry: fall back to scan
+			return nil, false, cErr // transactional/IO error: propagate
 		}
 		var fileID uuid.UUID
 		if uErr := fileID.UnmarshalBinary(raw); uErr != nil {
-			return nil, false, nil // corrupt index entry: fall back to scan
+			return nil, false, nil // corrupt index value: fall back to scan
 		}
 		f, lErr := tx.loadEnrichedFileByID(fileID)
 		if lErr != nil {


### PR DESCRIPTION
## Summary

Fixes #1435 — a SIGSEGV inside the Badger metadata store on the upload/rollup path.

`GetFileByPayloadID` did a **full-keyspace iterator scan** over every `f:` file row, and it sits on the hot persist path (`PersistFileBlocks` → once per `Flush`). On a memory-constrained host that scan faulted on an mmap'd SST block (`table.block` → `BytesToU32`), taking the whole process down. It's also an obvious O(n) perf smell.

## Changes

**1. `pl:<payloadID>` → file UUID secondary index** (the real fix)
- Mirrors the existing `obj:<hash>` ObjectID index already in this package.
- Maintained atomically inside the same Badger txn as the primary `f:` write: stale entry dropped + new entry written in `PutFile`; torn down in `deleteFileKeys` (shared by `DeleteFile` and `DeleteShare`).
- PayloadID is `share/<inode-uuid>` — unique per inode and stable across rename — so unlike the ObjectID index it needs no conflict probe.
- `GetFileByPayloadID` (both tx-level and store-level) now resolves via an **O(1) point lookup**, falling back to the legacy scan on an index miss so files written before the index still resolve. Lazily indexed on their next `PutFile`. No migration needed.

**2. Constrained-host Badger tuning**
- When process-available memory is below 4 GiB, `buildBadgerOptions` trims the LSM in-memory footprint (memtables, compactors) so the OS keeps more SST pages resident, narrowing the mmap-fault window. Skipped on detection failure and when an operator supplies `BadgerOptions` verbatim. Values stay above Badger's minimums.

The index eliminates the full scan that was the fault trigger; the LSM tuning is secondary hardening for genuinely small hosts.

## Tests
- `TestPayloadIndex_PointLookupAndTeardown` — index write, point-lookup resolution, scan fallback when the entry is absent, teardown on delete.
- `TestPayloadIndex_MovesOnPayloadIDChange` — stale entry dropped + fresh entry on PayloadID change.
- `TestBuildBadgerOptions_ConstrainedHostTrimsLSM` — trims below threshold, keeps defaults at/above it.
- Full `pkg/metadata/store/badger` suite green under `-race`, plus `runtime/shares` and `block/engine`. `gofmt`/`go vet`/`golangci-lint` clean.