### PR TITLE
fix(api): emit block-store config as a JSON object, not a string

### DIFF
--- a/internal/controlplane/api/handlers/block_stores.go
+++ b/internal/controlplane/api/handlers/block_stores.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
@@ -52,7 +53,7 @@ type BlockStoreResponse struct {
 	Name      string                `json:"name"`
 	Kind      models.BlockStoreKind `json:"kind"`
 	Type      string                `json:"type"`
-	Config    string                `json:"config,omitempty"`
+	Config    json.RawMessage       `json:"config,omitempty"`
 	CreatedAt time.Time             `json:"created_at"`
 	Status    health.Report         `json:"status"`
 }
@@ -324,7 +325,7 @@ func blockStoreToResponse(s *models.BlockStoreConfig) BlockStoreResponse {
 		Name:      s.Name,
 		Kind:      s.Kind,
 		Type:      s.Type,
-		Config:    redactSecretJSON(s.Config),
+		Config:    redactedConfigRaw(s.Config),
 		CreatedAt: s.CreatedAt,
 	}
 }

--- a/internal/controlplane/api/handlers/helpers.go
+++ b/internal/controlplane/api/handlers/helpers.go
@@ -55,10 +55,13 @@ func redactSecretJSON(blob string) string {
 // into a config map — which dropped every field on a partial `store block
 // remote edit` and forced re-passing the whole S3 config. A blank or
 // whitespace-only blob yields a nil RawMessage so the `omitempty` field is
-// omitted instead of serializing as invalid JSON.
+// omitted instead of serializing as invalid JSON. A non-empty blob that is not
+// valid JSON is also dropped rather than embedded: a json.RawMessage of invalid
+// bytes makes the streaming encoder fail and silently truncate the whole
+// response, so omitting the field is the safer degradation.
 func redactedConfigRaw(blob string) json.RawMessage {
 	redacted := redactSecretJSON(blob)
-	if strings.TrimSpace(redacted) == "" {
+	if strings.TrimSpace(redacted) == "" || !json.Valid([]byte(redacted)) {
 		return nil
 	}
 	return json.RawMessage(redacted)

--- a/internal/controlplane/api/handlers/helpers.go
+++ b/internal/controlplane/api/handlers/helpers.go
@@ -47,6 +47,23 @@ func redactSecretJSON(blob string) string {
 	return string(out)
 }
 
+// redactedConfigRaw returns a store-config blob, secrets redacted, as a
+// json.RawMessage for embedding directly in a response body. Emitting the
+// config as a JSON object (rather than a JSON-encoded string) is the contract
+// apiclient expects: its BlockStore.Config is a json.RawMessage, so a
+// stringified blob decodes to a quoted literal that silently fails to unmarshal
+// into a config map — which dropped every field on a partial `store block
+// remote edit` and forced re-passing the whole S3 config. A blank or
+// whitespace-only blob yields a nil RawMessage so the `omitempty` field is
+// omitted instead of serializing as invalid JSON.
+func redactedConfigRaw(blob string) json.RawMessage {
+	redacted := redactSecretJSON(blob)
+	if strings.TrimSpace(redacted) == "" {
+		return nil
+	}
+	return json.RawMessage(redacted)
+}
+
 // redactSecretValue walks an arbitrary JSON value, redacting secret-bearing
 // keys in any object it encounters.
 func redactSecretValue(v any) any {

--- a/internal/controlplane/api/handlers/metadata_stores.go
+++ b/internal/controlplane/api/handlers/metadata_stores.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
@@ -44,12 +45,12 @@ type UpdateMetadataStoreRequest struct {
 // Status is non-omitempty so clients can render "unknown" explicitly
 // rather than guessing from a missing field.
 type MetadataStoreResponse struct {
-	ID        string        `json:"id"`
-	Name      string        `json:"name"`
-	Type      string        `json:"type"`
-	Config    string        `json:"config,omitempty"`
-	CreatedAt time.Time     `json:"created_at"`
-	Status    health.Report `json:"status"`
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Type      string          `json:"type"`
+	Config    json.RawMessage `json:"config,omitempty"`
+	CreatedAt time.Time       `json:"created_at"`
+	Status    health.Report   `json:"status"`
 }
 
 // Create handles POST /api/v1/store/metadata.
@@ -292,7 +293,7 @@ func metadataStoreToResponse(s *models.MetadataStoreConfig) MetadataStoreRespons
 		ID:        s.ID,
 		Name:      s.Name,
 		Type:      s.Type,
-		Config:    redactSecretJSON(s.Config),
+		Config:    redactedConfigRaw(s.Config),
 		CreatedAt: s.CreatedAt,
 	}
 }

--- a/internal/controlplane/api/handlers/redact_secrets_test.go
+++ b/internal/controlplane/api/handlers/redact_secrets_test.go
@@ -224,10 +224,20 @@ func TestMetadataStoreToResponse_RedactsConfig(t *testing.T) {
 		CreatedAt: time.Now(),
 	}
 	resp := metadataStoreToResponse(m)
-	if strings.Contains(resp.Config, "LEAKED-PG-PASSWORD") {
+	if strings.Contains(string(resp.Config), "LEAKED-PG-PASSWORD") {
 		t.Fatalf("metadata store response leaked secret: %s", resp.Config)
 	}
-	if !strings.Contains(resp.Config, "db") {
+	if !strings.Contains(string(resp.Config), "db") {
 		t.Fatalf("non-secret host dropped: %s", resp.Config)
+	}
+
+	// Must serialize as a JSON object (not a JSON-encoded string) so apiclient's
+	// json.RawMessage decode and the `store metadata edit` merge preserve fields.
+	var asMap map[string]any
+	if err := json.Unmarshal(resp.Config, &asMap); err != nil {
+		t.Fatalf("response config is not a JSON object (got %s): %v", resp.Config, err)
+	}
+	if asMap["host"] != "db" {
+		t.Fatalf("host not preserved as an object field: %v", asMap)
 	}
 }

--- a/internal/controlplane/api/handlers/redact_secrets_test.go
+++ b/internal/controlplane/api/handlers/redact_secrets_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -109,11 +110,23 @@ func TestBlockStoreToResponse_RedactsConfig(t *testing.T) {
 		CreatedAt: time.Now(),
 	}
 	resp := blockStoreToResponse(m)
-	if strings.Contains(resp.Config, "LEAKED-S3-SECRET") {
+	if strings.Contains(string(resp.Config), "LEAKED-S3-SECRET") {
 		t.Fatalf("block store response leaked secret: %s", resp.Config)
 	}
-	if !strings.Contains(resp.Config, "b") {
+	if !strings.Contains(string(resp.Config), "b") {
 		t.Fatalf("non-secret bucket dropped: %s", resp.Config)
+	}
+
+	// The config must serialize as a JSON object, not a JSON-encoded string:
+	// apiclient decodes it into a json.RawMessage and unmarshals that into a
+	// config map, which fails on a quoted blob and silently drops fields on a
+	// partial `store block remote edit`.
+	var asMap map[string]any
+	if err := json.Unmarshal(resp.Config, &asMap); err != nil {
+		t.Fatalf("response config is not a JSON object (got %s): %v", resp.Config, err)
+	}
+	if asMap["bucket"] != "b" {
+		t.Fatalf("bucket not preserved as an object field: %v", asMap)
 	}
 }
 


### PR DESCRIPTION
## Summary

Surfaced while triaging #1432 (CLI blocker comment): `dfsctl store block remote edit cubbit --parallel-uploads 64` fails with

```
Error: failed to update remote block store: Invalid block store config: s3 remote block store requires bucket in config
```

forcing the whole S3 config — including the secret — to be re-passed on every partial edit.

## Root cause

A client/server **type contract mismatch** on the block-store `config` field, not a migration or DB issue (it fires on any remote with a non-empty config):

- Server `BlockStoreResponse.Config` was a Go `string` holding a JSON blob → it serialized as a JSON-encoded **string**: `"config":"{\"bucket\":...}"`.
- `apiclient.BlockStore.Config` is a `json.RawMessage`, so it captured the **quoted, escaped literal** `"{\"bucket\":...}"`.
- The CLI then does `json.Unmarshal(current.Config, &map)` — unmarshalling a JSON *string* into a *map* errors, and the error is swallowed (`_ =`) → empty config → only the changed field is re-sent → server validation rejects it for the now-missing `bucket`.

The same mishandling affected `local` edit and the `list` display path (both treat `Config` as raw JSON).

## Fix

Emit the redacted config as a `json.RawMessage` (a real JSON object on the wire) via a small `redactedConfigRaw` helper, matching what the client already expects. Partial edits now merge onto the real config and preserve stored fields. Blank configs yield `nil` so the `omitempty` field is omitted rather than serializing invalid JSON. No client change needed.

## Tests
- Extended the redaction test to assert the response `config` unmarshals as a JSON **object** with `bucket` preserved (locks the wire contract — reverting to a stringified blob fails the test).
- `internal/controlplane/api/handlers` + `pkg/apiclient` suites green; `gofmt`/`go vet`/`golangci-lint` clean.

Note: this is the CLI-blocker half of #1432. The throughput half (dittofs ~25 Mbit/s vs rclone ~450–520 on the same box) is still under investigation pending the reporter's adaptive-window metrics.