### PR TITLE
fix(block): make WarmAll progress callbacks monotonic

### DIFF
--- a/pkg/block/engine/warm.go
+++ b/pkg/block/engine/warm.go
@@ -135,9 +135,12 @@ func (m *Syncer) WarmAll(ctx context.Context, progress func(done, total int64)) 
 			return
 		}
 		progressMu.Lock()
+		defer progressMu.Unlock()
 		done++
+		// Hold the lock across the user callback so emissions stay ordered;
+		// defer the unlock so a panicking callback can't leave it held and
+		// deadlock every later emit.
 		progress(done, total)
-		progressMu.Unlock()
 	}
 
 	g, gctx := errgroup.WithContext(ctx)

--- a/pkg/block/engine/warm.go
+++ b/pkg/block/engine/warm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 
 	"golang.org/x/sync/errgroup"
@@ -117,8 +118,27 @@ func (m *Syncer) WarmAll(ctx context.Context, progress func(done, total int64)) 
 	var (
 		blocksFetched atomic.Int64
 		bytesFetched  atomic.Int64
-		done          atomic.Int64
 	)
+
+	// progress reporting is serialized: the counter increment and the callback
+	// emission happen under one lock so callbacks fire in monotonic `done`
+	// order. Snapshotting an atomic counter and emitting outside the lock lets a
+	// goroutine that incremented to N-1 call back after the one that reached N,
+	// leaving the final observed progress below total even though every fetch
+	// finished.
+	var (
+		progressMu sync.Mutex
+		done       int64
+	)
+	emitProgress := func() {
+		if progress == nil {
+			return
+		}
+		progressMu.Lock()
+		done++
+		progress(done, total)
+		progressMu.Unlock()
+	}
 
 	g, gctx := errgroup.WithContext(ctx)
 	sem := make(chan struct{}, parallel)
@@ -148,10 +168,7 @@ func (m *Syncer) WarmAll(ctx context.Context, progress func(done, total int64)) 
 				blocksFetched.Add(1)
 				bytesFetched.Add(int64(len(data)))
 			}
-			cur := done.Add(1)
-			if progress != nil {
-				progress(cur, total)
-			}
+			emitProgress()
 			return nil
 		})
 	}

--- a/pkg/block/engine/warm_test.go
+++ b/pkg/block/engine/warm_test.go
@@ -133,6 +133,55 @@ func TestWarmAll_FetchesMissingSkipsLocal(t *testing.T) {
 	}
 }
 
+// TestWarmAll_ProgressMonotonic guards against the progress callback reporting
+// a stale, lower `done` last under concurrency: with the counter snapshot taken
+// outside the emit, a goroutine that incremented to N-1 could call back after
+// the one that reached N, leaving the final progress below total. With many
+// fetch targets and parallel downloads, the reported `done` sequence must be
+// non-decreasing and end exactly at total.
+func TestWarmAll_ProgressMonotonic(t *testing.T) {
+	ctx := context.Background()
+
+	const n = 12
+	payloads := make([]string, n)
+	for i := range payloads {
+		payloads[i] = "pay" + itoa(uint64(i))
+	}
+	m, _, rs, fbs := warmHarness(payloads)
+	for _, p := range payloads {
+		seedFileBlockAt(t, fbs, rs, p, 0, []byte(p+"-block-zero"))
+	}
+
+	var (
+		mu  sync.Mutex
+		seq []int64
+	)
+	res, err := m.WarmAll(ctx, func(done, total int64) {
+		mu.Lock()
+		seq = append(seq, done)
+		mu.Unlock()
+		if total != n {
+			t.Errorf("progress total = %d; want %d", total, n)
+		}
+	})
+	if err != nil {
+		t.Fatalf("WarmAll: %v", err)
+	}
+	if res.BlocksFetched != n {
+		t.Errorf("BlocksFetched = %d; want %d", res.BlocksFetched, n)
+	}
+
+	// Initial progress(0, total) plus one tick per fetch: 0,1,2,...,n.
+	if len(seq) != n+1 {
+		t.Fatalf("progress emitted %d times; want %d (got %v)", len(seq), n+1, seq)
+	}
+	for i, done := range seq {
+		if done != int64(i) {
+			t.Fatalf("progress not monotonic: seq[%d] = %d, want %d (full %v)", i, done, i, seq)
+		}
+	}
+}
+
 // TestWarmAll_FetchesNonAlignedChunk guards #1374: FastCDC chunks start at
 // arbitrary byte offsets that do NOT align to BlockSize. The old WarmAll
 // fetched via fetchBlock(payloadID, blockIdx), and fetchBlock resolves the row


### PR DESCRIPTION
## Summary

Fixes the CI flake `TestWarmAll_FetchesMissingSkipsLocal` (`progress final (1/2); want (2/2)`), surfaced on an unrelated PR's unit-test run.

## Root cause

`WarmAll`'s per-fetch progress reporting snapshotted an atomic counter and emitted the callback **outside** any lock:

```go
cur := done.Add(1)        // unique snapshot per goroutine
if progress != nil {
    progress(cur, total)  // emitted unordered
}
```

With `ParallelDownloads` > 1, the goroutine that incremented to N-1 could invoke its callback *after* the one that reached N. The last callback the consumer observes then carries a stale, lower `done` — so the final progress can read below `total` even though every fetch completed. Low-probability, hence the rare flake.

## Fix

Serialize the counter increment and the callback emission under one lock, so callbacks fire in monotonic `done` order and the final emission is always `(total, total)`:

```go
emitProgress := func() {
    if progress == nil {
        return
    }
    progressMu.Lock()
    done++
    progress(done, total)
    progressMu.Unlock()
}
```

## Tests
- New `TestWarmAll_ProgressMonotonic`: with 12 fetch targets under parallel downloads, asserts the reported sequence is exactly `0,1,…,12` (non-decreasing, ends at total). Passes deterministically with the fix — the serialized increment+emit guarantees ordering by construction.
- Existing `TestWarmAll_*` green; whole `pkg/block/engine` suite green under `-race` (50× on the warm tests). `gofmt`/`go vet`/`golangci-lint` clean.