### PR TITLE
fix(block): reap block refcounts on file unlink (#1433)

### DIFF
--- a/internal/adapter/nfs/v3/handlers/remove.go
+++ b/internal/adapter/nfs/v3/handlers/remove.go
@@ -196,9 +196,9 @@ func (h *Handler) Remove(
 	// Any unflushed cache data will be cleaned up by cache eviction.
 
 	if removedFileAttr.PayloadID != "" {
-		// Nil []BlockRef triggers the dual-read / legacy delete path.
-		// A later refactor will thread the file's FileAttr.Blocks
-		// snapshot here.
+		// Pass nil blocks: the block store resolves this payload's manifest
+		// and reaps each row's refcount, so the chunks become GC-eligible
+		// (#1433). Passing nil here is the supported file-removal contract.
 		if err := blockStore.Delete(ctx.Context, string(removedFileAttr.PayloadID), nil); err != nil {
 			// Log but don't fail the operation - metadata is already removed
 			logger.WarnCtx(ctx.Context, "REMOVE: failed to delete content", "name", req.Filename, "payload_id", removedFileAttr.PayloadID, "error", err)

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -1538,8 +1538,9 @@ func (h *Handler) purgeBlockStorePayload(ctx context.Context, handle metadata.Fi
 	if err != nil {
 		return
 	}
-	// Nil []BlockRef triggers the legacy delete path (purges the append log
-	// + tracked size).
+	// Pass nil blocks: the block store resolves this payload's manifest and
+	// reaps each row's refcount so the chunks become GC-eligible (#1433), in
+	// addition to purging the append log + tracked size.
 	if delErr := blockStore.Delete(ctx, string(payloadID), nil); delErr != nil {
 		logger.Debug(caller+": block-store payload delete failed (non-fatal)",
 			"path", path, "payloadID", payloadID, "error", delErr)

--- a/pkg/block/engine/delete_nilblocks_test.go
+++ b/pkg/block/engine/delete_nilblocks_test.go
@@ -1,0 +1,82 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/local/memory"
+)
+
+// newReapFixture wires a Store with both a FileBlockStore and a refcount
+// coordinator so the delete reap path can resolve a payload's manifest.
+// buildCascadeFixture deliberately omits the FileBlockStore; the #1433 fix
+// depends on it, so this fixture supplies one.
+func newReapFixture(t *testing.T, coord MetadataCoordinator, fbs *stubFileBlockStore) *Store {
+	t.Helper()
+	localStore := memory.New()
+	syncer := NewSyncer(localStore, nil, fbs, DefaultConfig())
+	bs, err := New(BlockStoreConfig{
+		Local:          localStore,
+		Remote:         nil,
+		Syncer:         syncer,
+		Coordinator:    coord,
+		FileBlockStore: fbs,
+	})
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	if err := bs.Start(context.Background()); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+	return bs
+}
+
+// TestDelete_NilBlocks_ReapsPayloadManifest reproduces #1433: the file-removal
+// path (NFS REMOVE, SMB delete) calls Delete(payloadID, nil). Before the fix
+// the nil slice skipped the coordinator entirely, so block refcounts were
+// never decremented — the FileBlock rows survived, the hashes stayed in the GC
+// live set, and the chunks were never reclaimed on either tier. With the fix
+// Delete enumerates the payload's own manifest and reaps each row.
+func TestDelete_NilBlocks_ReapsPayloadManifest(t *testing.T) {
+	ctx := context.Background()
+	coord := newRefcountCoordinator()
+	fbs := newStubFileBlockStore()
+	bs := newReapFixture(t, coord, fbs)
+
+	const payloadID = "file-1"
+	h0 := hashN(0xA0)
+	h1 := hashN(0xB1)
+
+	// Seed the payload's manifest rows and matching refcounts (one referrer
+	// each — this file).
+	for _, r := range []struct {
+		off  uint64
+		hash block.ContentHash
+	}{{0, h0}, {4096, h1}} {
+		if err := fbs.Put(ctx, &block.FileBlock{
+			ID:       fmt.Sprintf("%s/%d", payloadID, r.off),
+			Hash:     r.hash,
+			DataSize: 4096,
+		}); err != nil {
+			t.Fatalf("seed FileBlock: %v", err)
+		}
+		coord.seedBlock(payloadID, r.off, r.hash, 1)
+	}
+
+	// File-removal path: no manifest carried.
+	if err := bs.Delete(ctx, payloadID, nil); err != nil {
+		t.Fatalf("Delete(nil blocks): %v", err)
+	}
+
+	coord.mu.Lock()
+	defer coord.mu.Unlock()
+	if c := coord.counts[h0]; c != 0 {
+		t.Errorf("h0 refcount = %d, want 0 (row not reaped — #1433 regression)", c)
+	}
+	if c := coord.counts[h1]; c != 0 {
+		t.Errorf("h1 refcount = %d, want 0 (row not reaped — #1433 regression)", c)
+	}
+}

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -327,6 +327,17 @@ func (bs *Store) Delete(ctx context.Context, payloadID string, blocks []block.Bl
 	if err := bs.local.DeleteAppendLog(ctx, payloadID); err != nil {
 		return fmt.Errorf("local delete append log failed: %w", err)
 	}
+	// Resolve the manifest to reap. The file-removal path (NFS REMOVE, SMB
+	// delete) unlinks a file without carrying its block list, passing nil.
+	// Historically nil short-circuited the coordinator, so refcounts were
+	// never decremented: the FileBlock rows survived, the hashes stayed in
+	// the GC live set, and the chunks leaked on BOTH tiers (#1433). When no
+	// blocks are supplied, enumerate the payload's own FileBlock rows so the
+	// reap below operates on the file's real manifest.
+	if len(blocks) == 0 {
+		blocks = bs.payloadBlockRefs(ctx, payloadID)
+	}
+
 	// Surgical invalidation: drop ALL hashes belonging to this file
 	// (even though dedup-shared hashes might survive elsewhere — Delete
 	// is the strongest signal). nullCache is a no-op; for the real
@@ -334,15 +345,14 @@ func (bs *Store) Delete(ctx context.Context, payloadID string, blocks []block.Bl
 	if len(blocks) > 0 {
 		bs.loadCache().InvalidateFile(payloadID, blockRefHashes(blocks))
 	} else {
-		// Legacy/dual-read empty-blocks path: at least reset the
-		// per-payload tracker so prefetch doesn't chase stale hashes.
+		// No manifest rows (already reaped, or no FileBlockStore wired):
+		// reset the per-payload tracker so prefetch doesn't chase stale hashes.
 		bs.loadCache().OnRead(payloadID, nil, 0)
 	}
 
 	// Decrement RefCount for every BlockRef hash before remote cleanup
 	// so the coordinator's bookkeeping is consistent even if the remote
-	// sweep fails (Truncate / janitor will reconcile orphans). Empty
-	// blocks (legacy / dual-read shim) skips the coordinator entirely.
+	// sweep fails (Truncate / janitor will reconcile orphans).
 	//
 	// continue past coordinator errors so the syncer.Delete
 	// remote sweep ALWAYS runs. Returning early left the local data
@@ -407,6 +417,40 @@ func (bs *Store) Delete(ctx context.Context, payloadID string, blocks []block.Bl
 		return delErr
 	}
 	return coordErr
+}
+
+// payloadBlockRefs enumerates a payload's FileBlock rows and returns them as
+// BlockRefs so the Delete reap path can decrement refcounts. It is the bridge
+// for callers that unlink a file without carrying its manifest (NFS REMOVE /
+// SMB delete pass nil): without it those deletes never decrement refcounts and
+// their chunks leak on both tiers (#1433).
+//
+// Returns nil when no FileBlockStore is wired or enumeration fails — Delete
+// still proceeds to the remote sweep, and the full GC reconcile reclaims any
+// rows this pass missed. Best-effort matches the rest of Delete's posture:
+// reclaiming disk must never wedge an unlink.
+func (bs *Store) payloadBlockRefs(ctx context.Context, payloadID string) []block.BlockRef {
+	if bs.fileBlockStore == nil {
+		return nil
+	}
+	rows, err := bs.fileBlockStore.ListFileBlocks(ctx, payloadID)
+	if err != nil {
+		logger.Warn("delete: list file blocks for reap (proceeding; reconcile will catch orphans)",
+			"payloadID", payloadID, "err", err)
+		return nil
+	}
+	refs := make([]block.BlockRef, 0, len(rows))
+	for _, r := range rows {
+		if r == nil {
+			continue
+		}
+		off, ok := block.ParseChunkOffset(r.ID)
+		if !ok {
+			continue
+		}
+		refs = append(refs, block.BlockRef{Hash: r.Hash, Offset: off, Size: r.DataSize})
+	}
+	return refs
 }
 
 // CopyPayload duplicates a file's content by referencing the source's

--- a/pkg/controlplane/runtime/trash/service.go
+++ b/pkg/controlplane/runtime/trash/service.go
@@ -66,10 +66,12 @@ type Deps interface {
 	EnabledTrashShares() []string
 	// FreeBlocks frees the CAS blocks for a permanently-deleted file (the
 	// payloadID and BlockRef list RemoveFile returned). Implemented by the
-	// runtime via GetBlockStoreForHandle + blockStore.Delete. The blocks list is
-	// required: blockStore.Delete only decrements per-block CAS RefCounts (so the
-	// GC can reclaim now-unreferenced chunks) when it is given the file's blocks
-	// — passing nil leaks the refcounts. A no-op when payloadID is empty.
+	// runtime via GetBlockStoreForHandle + blockStore.Delete. The reaper holds
+	// the file's blocks, so it threads them through directly; blockStore.Delete
+	// decrements each block's CAS RefCount so the GC can reclaim now-unreferenced
+	// chunks. (Callers without the manifest may pass nil — Delete then resolves
+	// it from the payload's FileBlock rows; see #1433.) No-op when payloadID is
+	// empty.
 	FreeBlocks(ctx context.Context, shareName string, root metadata.FileHandle, payloadID string, blocks []block.BlockRef) error
 }
 

--- a/pkg/controlplane/runtime/trash_deps.go
+++ b/pkg/controlplane/runtime/trash_deps.go
@@ -78,10 +78,10 @@ func (d *trashDeps) EnabledTrashShares() []string {
 // no-op. The per-share block store is resolved from the share root handle, and
 // Delete is invoked WITH the file's BlockRef list so the engine decrements each
 // block's CAS RefCount and lets the GC reclaim chunks no other file references.
-// Passing nil here would skip the per-block decrement and leak the refcounts
-// (#832); unlike the NFS v3 / SMB close path (which deletes a still-live file
-// whose blocks it does not have on hand), the reaper holds the removed file's
-// blocks and must thread them through.
+// The reaper holds the removed file's blocks, so it threads them through
+// directly rather than making the engine re-enumerate them. (The NFS v3 / SMB
+// unlink path does not have the manifest on hand and passes nil; Delete then
+// resolves it from the payload's FileBlock rows — see #1433/#832.)
 func (d *trashDeps) FreeBlocks(ctx context.Context, shareName string, root metadata.FileHandle, payloadID string, blocks []block.BlockRef) error {
 	if payloadID == "" {
 		return nil


### PR DESCRIPTION
## Problem (part of #1433)

File unlink leaks blocks. Both NFS REMOVE (`remove.go:202`) and SMB delete (`handler.go:1543`) call `blockStore.Delete(ctx, payloadID, nil)`. The nil block slice short-circuited the coordinator, so block refcounts were **never decremented**: the `file_blocks` rows survived, the hashes stayed in GC's live set (`EnumerateFileBlocks` has no inode join — a hash leaves the live set only when its row is reaped), and the chunks leaked on **both** the local and remote tiers. Operators saw `/var/lib/dittofs/blocks` grow and never shrink, and `dfsctl store block gc` reclaimed nothing for deleted files.

## Fix

`engine.Store.Delete` now resolves a nil manifest from the payload's own FileBlock rows (`payloadBlockRefs`) and reaps each via the existing coordinator path. One engine-side chokepoint fixes NFS + SMB (+ NFSv4) at once.

- Best-effort: if enumeration fails, log and proceed to the remote sweep — the full GC reconcile (later PR) catches any stragglers. An unlink must never wedge on disk reclamation.
- Resolution runs after `SyncFileBlocksForFile` (manifest complete) and before the row-deleting reap, so it sees the full manifest.
- Only the `len(blocks)==0` branch changed; callers passing a real manifest (trash purge) are unaffected.

## Tests

- New `TestDelete_NilBlocks_ReapsPayloadManifest` — red before the fix, green after.
- engine, NFS/SMB handler, and full runtime **snapshot** suites pass; build/vet/gofmt clean.

## Scope

This is **PR1 of a series** for #1433. It makes the *existing* remote GC actually reclaim newly-deleted files. Still to come: local-tier sweep, incremental (tombstone) GC, a reconcile/migration pass for already-leaked installs, auto-GC + config knob, and monitoring/docs.

Part of #1433.
