### PR TITLE
feat(block): sweep the local tier during GC (#1433)

### DIFF
--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -730,10 +730,11 @@ func (bs *Store) SetMetrics(rec local.MetricsRecorder) {
 // Do not use in production code.
 func (bs *Store) LocalForTest() local.LocalStore { return bs.local }
 
-// LocalStore exposes the engine's local block store as the narrow block.Store
-// (Walk + Delete) surface the garbage collector needs. Returned to the runtime
-// so per-share local GC (CollectGarbageLocal) can sweep orphaned chunks off
-// disk (#1433); the narrowed type keeps the GC path off the full admin surface.
+// LocalStore exposes the engine's local block store as a block.Store. The GC
+// uses only its Walk + Delete methods to sweep orphaned chunks off disk via
+// per-share local GC (CollectGarbageLocal); returning block.Store rather than
+// the concrete local.LocalStore keeps GC callers off the admin/rollup surface
+// (#1433).
 func (bs *Store) LocalStore() block.Store { return bs.local }
 
 // LocalDurable reports whether the engine's local store survives a process

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -730,6 +730,12 @@ func (bs *Store) SetMetrics(rec local.MetricsRecorder) {
 // Do not use in production code.
 func (bs *Store) LocalForTest() local.LocalStore { return bs.local }
 
+// LocalStore exposes the engine's local block store as the narrow block.Store
+// (Walk + Delete) surface the garbage collector needs. Returned to the runtime
+// so per-share local GC (CollectGarbageLocal) can sweep orphaned chunks off
+// disk (#1433); the narrowed type keeps the GC path off the full admin surface.
+func (bs *Store) LocalStore() block.Store { return bs.local }
+
 // LocalDurable reports whether the engine's local store survives a process
 // crash / restart (block.DurabilityReporter). It is the localDurable input to
 // the honest CLOSE/COMMIT commit rule (#1274). When the local store does not

--- a/pkg/block/engine/gc.go
+++ b/pkg/block/engine/gc.go
@@ -144,6 +144,12 @@ type GCStats struct {
 	DryRun           bool
 	DryRunCandidates []string
 
+	// IsLocalTier is true when these stats come from a local-store pass
+	// (CollectGarbageLocal), false for the default remote pass. Per-invocation
+	// metadata only — accumulateGCStats does not fold it into a total; the
+	// runtime uses it to tag metrics/logs with the tier.
+	IsLocalTier bool
+
 	// Legacy aggregator fields (compat aliases — see finalizeStats).
 
 	// Deprecated: SharesScanned is retained on the REST/dfsctl wire for
@@ -254,18 +260,47 @@ type HoldProvider interface {
 // MetadataReconciler is treated as "no shares" — the live set is empty
 // and every CAS object is a sweep candidate. Callers in production
 // (Runtime.RunBlockGC) supply a MultiShareReconciler.
+// CollectGarbage reclaims orphaned objects on a remote (S3) store via the
+// shared mark-sweep kernel (collectGarbage).
 func CollectGarbage(
 	ctx context.Context,
 	remoteStore remote.RemoteStore,
 	reconciler MetadataReconciler,
 	options *Options,
 ) *GCStats {
+	return collectGarbage(ctx, remoteStore, reconciler, options, false)
+}
+
+// CollectGarbageLocal reclaims orphaned chunks on a per-share LOCAL block
+// store. Local stores are isolated per share (architecture invariant #4), so
+// the caller scopes the reconciler and snapshot holds to that single share.
+// The grace period protects freshly-written chunks whose FileBlock rows have
+// not yet committed (#1433).
+func CollectGarbageLocal(
+	ctx context.Context,
+	localStore block.Store,
+	reconciler MetadataReconciler,
+	options *Options,
+) *GCStats {
+	return collectGarbage(ctx, localStore, reconciler, options, true)
+}
+
+// collectGarbage is the shared mark-sweep kernel for both tiers. isLocal only
+// tags the resulting stats; the live-set, grace, and fail-closed semantics are
+// identical regardless of tier.
+func collectGarbage(
+	ctx context.Context,
+	store sweepable,
+	reconciler MetadataReconciler,
+	options *Options,
+	isLocal bool,
+) *GCStats {
 	if options == nil {
 		options = &Options{}
 	}
 	started := time.Now()
 	runID := started.UTC().Format("20060102T150405Z") + "-" + randSuffix(6)
-	stats := &GCStats{RunID: runID, DryRun: options.DryRun}
+	stats := &GCStats{RunID: runID, DryRun: options.DryRun, IsLocalTier: isLocal}
 
 	// serialize concurrent CollectGarbage calls that
 	// share a GCStateRoot. Without this, two parallel runs race in
@@ -341,8 +376,9 @@ func CollectGarbage(
 		return stats
 	}
 
-	// SWEEP: single Walk over the unified CAS namespace.
-	sweepPhase(ctx, remoteStore, gcs, stats, snapshotTime, gracePeriod, dryRunSample, options)
+	// SWEEP: single Walk over the CAS namespace (remote union, or one share's
+	// local store).
+	sweepPhase(ctx, store, gcs, stats, snapshotTime, gracePeriod, dryRunSample, options)
 
 	// Mark complete + persist summary.
 	if err := gcs.MarkComplete(); err != nil {
@@ -449,9 +485,18 @@ func sharesForReconciler(r MetadataReconciler) []string {
 // fan-out) is expected to re-wire concurrency at the backend, not
 // here. Callers wanting per-prefix parallelism should file against
 // the backend.
+// sweepable is the minimal store surface the sweep phase needs: enumerate the
+// CAS namespace and delete one object by hash. Both remote.RemoteStore and the
+// local block.Store satisfy it, so the same sweep kernel reclaims orphans on
+// either tier (#1433).
+type sweepable interface {
+	Walk(ctx context.Context, fn func(block.ContentHash, block.Meta) error) error
+	Delete(ctx context.Context, hash block.ContentHash) error
+}
+
 func sweepPhase(
 	ctx context.Context,
-	remoteStore remote.RemoteStore,
+	store sweepable,
 	gcs *GCState,
 	stats *GCStats,
 	snapshotTime time.Time,
@@ -496,7 +541,7 @@ func sweepPhase(
 		// invokes the callback sequentially, so a local counter folded into
 		// stats once after the walk avoids a mutex round-trip per object.
 		var scanned int64
-		walkErr := remoteStore.Walk(ctx, func(h block.ContentHash, meta block.Meta) error {
+		walkErr := store.Walk(ctx, func(h block.ContentHash, meta block.Meta) error {
 			if err := ctx.Err(); err != nil {
 				return err
 			}
@@ -532,7 +577,7 @@ func sweepPhase(
 				statsMu.Unlock()
 				return nil
 			}
-			if err := remoteStore.Delete(ctx, h); err != nil {
+			if err := store.Delete(ctx, h); err != nil {
 				// continue + capture
 				addError("delete " + casKey + ": " + err.Error())
 				return nil

--- a/pkg/block/engine/gc.go
+++ b/pkg/block/engine/gc.go
@@ -489,6 +489,12 @@ func sharesForReconciler(r MetadataReconciler) []string {
 // CAS namespace and delete one object by hash. Both remote.RemoteStore and the
 // local block.Store satisfy it, so the same sweep kernel reclaims orphans on
 // either tier (#1433).
+//
+// Walk MUST invoke its callback sequentially: sweepPhase mutates unsynchronized
+// per-run counters (scanned/swept/bytes) from inside the callback. Every
+// current backend (local filepath.WalkDir, remote paginated list) honors this;
+// a backend that parallelizes Walk must serialize the callback before
+// satisfying this interface.
 type sweepable interface {
 	Walk(ctx context.Context, fn func(block.ContentHash, block.Meta) error) error
 	Delete(ctx context.Context, hash block.ContentHash) error

--- a/pkg/block/engine/gc_local_test.go
+++ b/pkg/block/engine/gc_local_test.go
@@ -1,0 +1,129 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+)
+
+// stubHold is a HoldProvider that injects a fixed set of held hashes into the
+// mark phase, standing in for snapshot holds.
+type stubHold struct {
+	held []block.ContentHash
+}
+
+func (s stubHold) HeldHashes(_ context.Context, _ string, _ []string, fn func(block.ContentHash) error) error {
+	for _, h := range s.held {
+		if err := fn(h); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// TestCollectGarbageLocal_SweepsOrphansKeepsLive proves the local-tier sweep
+// reclaims orphaned chunks while preserving live ones — the same mark-sweep
+// kernel as the remote pass, driven through CollectGarbageLocal against a
+// generic block.Store (#1433). IsLocalTier must be tagged.
+func TestCollectGarbageLocal_SweepsOrphansKeepsLive(t *testing.T) {
+	ctx := t.Context()
+	// A memory remote store satisfies block.Store (Walk+Delete+Put), standing
+	// in for a share's local CAS namespace.
+	ls := remotememory.New()
+	defer func() { _ = ls.Close() }()
+	old := time.Now().Add(-2 * time.Hour)
+	ls.SetNowFnForTest(func() time.Time { return old })
+
+	rec := newGCMSReconciler()
+	st := rec.addShare("share-a")
+
+	live := []block.ContentHash{hashFromString("L1"), hashFromString("L2")}
+	orphans := []block.ContentHash{hashFromString("O1"), hashFromString("O2")}
+	for i, h := range live {
+		putBlock(t, st, fmt.Sprintf("file-live/%d", i), h)
+		if err := ls.Put(ctx, h, []byte("live-"+string(rune('a'+i)))); err != nil {
+			t.Fatalf("Put live: %v", err)
+		}
+	}
+	for i, h := range orphans {
+		if err := ls.Put(ctx, h, []byte("orphan-"+string(rune('a'+i)))); err != nil {
+			t.Fatalf("Put orphan: %v", err)
+		}
+	}
+
+	stats := CollectGarbageLocal(ctx, ls, rec, &Options{
+		GCStateRoot: t.TempDir(),
+		GracePeriod: time.Minute,
+		Shares:      []string{"share-a"},
+	})
+
+	if !stats.IsLocalTier {
+		t.Error("IsLocalTier = false, want true")
+	}
+	if stats.HashesMarked != 2 {
+		t.Errorf("HashesMarked = %d, want 2", stats.HashesMarked)
+	}
+	if stats.ObjectsSwept != 2 {
+		t.Errorf("ObjectsSwept = %d, want 2 (orphans)", stats.ObjectsSwept)
+	}
+	if stats.ErrorCount != 0 {
+		t.Errorf("ErrorCount = %d, want 0; %v", stats.ErrorCount, stats.FirstErrors)
+	}
+	for _, h := range live {
+		if _, err := ls.Get(ctx, h); err != nil {
+			t.Errorf("live chunk %x swept: %v", h[:8], err)
+		}
+	}
+	for _, h := range orphans {
+		if _, err := ls.Get(ctx, h); err == nil {
+			t.Errorf("orphan %x not swept", h[:8])
+		}
+	}
+}
+
+// TestCollectGarbageLocal_SkipsSnapshotHeldChunks proves the local sweep never
+// deletes a chunk held by a snapshot, even when no live file references it —
+// the must-not-break-snapshots guardrail (#1433).
+func TestCollectGarbageLocal_SkipsSnapshotHeldChunks(t *testing.T) {
+	ctx := t.Context()
+	ls := remotememory.New()
+	defer func() { _ = ls.Close() }()
+	old := time.Now().Add(-2 * time.Hour)
+	ls.SetNowFnForTest(func() time.Time { return old })
+
+	rec := newGCMSReconciler()
+	rec.addShare("share-a") // no live files
+
+	held := hashFromString("held-by-snapshot")
+	orphan := hashFromString("real-orphan")
+	if err := ls.Put(ctx, held, []byte("snapshot-data")); err != nil {
+		t.Fatalf("Put held: %v", err)
+	}
+	if err := ls.Put(ctx, orphan, []byte("orphan-data")); err != nil {
+		t.Fatalf("Put orphan: %v", err)
+	}
+
+	stats := CollectGarbageLocal(ctx, ls, rec, &Options{
+		GCStateRoot:  t.TempDir(),
+		GracePeriod:  time.Minute,
+		Shares:       []string{"share-a"},
+		HoldProvider: stubHold{held: []block.ContentHash{held}},
+	})
+
+	if stats.ErrorCount != 0 {
+		t.Fatalf("ErrorCount = %d, want 0; %v", stats.ErrorCount, stats.FirstErrors)
+	}
+	if _, err := ls.Get(ctx, held); err != nil {
+		t.Errorf("snapshot-held chunk %x was swept — snapshot data loss", held[:8])
+	}
+	if _, err := ls.Get(ctx, orphan); err == nil {
+		t.Errorf("orphan %x not swept", orphan[:8])
+	}
+	if stats.ObjectsSwept != 1 {
+		t.Errorf("ObjectsSwept = %d, want 1 (only the true orphan)", stats.ObjectsSwept)
+	}
+}

--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -104,7 +104,92 @@ func (r *Runtime) RunBlockGC(ctx context.Context, sharePrefix string, dryRun boo
 			"errors", s.ErrorCount,
 		)
 	}
+	// Sweep the local tier too, so one `gc` invocation reclaims orphaned
+	// chunks on both remote and local stores (#1433).
+	r.runLocalGC(ctx, "", dryRun, total)
 	return total, nil
+}
+
+// collectGarbageLocalFn is a package-level indirection that lets tests
+// intercept the engine.CollectGarbageLocal call. Production code always
+// resolves to engine.CollectGarbageLocal.
+var collectGarbageLocalFn = engine.CollectGarbageLocal
+
+// RunBlockGCLocal sweeps orphaned chunks off every registered share's LOCAL
+// block store. Local stores are isolated per share (architecture invariant
+// #4), so each share is swept against its OWN live set: that share's
+// EnumerateFileBlocks plus its snapshot holds. Shares with an in-memory
+// backend (no persistent gc-state root) are skipped — their chunks evaporate
+// on restart, so on-disk reclamation is moot.
+//
+// This is the local-tier counterpart to RunBlockGC (which sweeps the shared
+// remote tier). Together they reclaim deleted-file blocks on both tiers
+// (#1433).
+func (r *Runtime) RunBlockGCLocal(ctx context.Context, dryRun bool) (*engine.GCStats, error) {
+	total := &engine.GCStats{}
+	r.runLocalGC(ctx, "", dryRun, total)
+	return total, nil
+}
+
+// runLocalGC sweeps each share's local block store, accumulating per-share
+// stats into total. When shareFilter is non-empty only that share is swept;
+// otherwise every share with a local store is swept. Shares with an in-memory
+// backend (empty gc-state root) are skipped. Shared by RunBlockGC,
+// RunBlockGCForShare, and RunBlockGCLocal so a single `gc` invocation reclaims
+// orphans on BOTH tiers (#1433).
+func (r *Runtime) runLocalGC(ctx context.Context, shareFilter string, dryRun bool, total *engine.GCStats) {
+	gcDefaults := r.gcDefaultsSnapshot()
+	for _, entry := range r.sharesSvc.ShareLocalStores() {
+		if shareFilter != "" && entry.ShareName != shareFilter {
+			continue
+		}
+		if entry.GCStateRoot == "" {
+			logger.Debug("local GC: skipping in-memory share (no persistent gc-state)",
+				"share", entry.ShareName)
+			continue
+		}
+		opts := &engine.Options{
+			DryRun:      dryRun,
+			GCStateRoot: entry.GCStateRoot,
+			Shares:      []string{entry.ShareName},
+		}
+		applyGCDefaults(opts, gcDefaults)
+		opts.HoldProvider = r.snapshotHoldForShare(entry.ShareName)
+		logger.Info("local GC: starting",
+			"tier", "local",
+			"share", entry.ShareName,
+			"dryRun", dryRun,
+			"gcStateRoot", entry.GCStateRoot,
+			"gracePeriod", opts.GracePeriod,
+		)
+
+		rec := &singleShareReconciler{rt: r, shareName: entry.ShareName}
+		stats := collectGarbageLocalFn(ctx, entry.Store, rec, opts)
+		s := accumulateGCStats(total, stats, true)
+		logger.Info("local GC: complete",
+			"tier", "local",
+			"share", entry.ShareName,
+			"hashesMarked", s.HashesMarked,
+			"objectsSwept", s.ObjectsSwept,
+			"bytesFreed", s.BytesFreed,
+			"errors", s.ErrorCount,
+		)
+	}
+}
+
+// singleShareReconciler scopes the GC mark phase to exactly one share, for the
+// per-share local sweep. Implements engine.MultiShareReconciler.
+type singleShareReconciler struct {
+	rt        *Runtime
+	shareName string
+}
+
+// SharesForGC implements engine.MultiShareReconciler.
+func (s *singleShareReconciler) SharesForGC() []string { return []string{s.shareName} }
+
+// GetMetadataStoreForShare implements engine.MultiShareReconciler.
+func (s *singleShareReconciler) GetMetadataStoreForShare(shareName string) (metadata.Store, error) {
+	return s.rt.GetMetadataStoreForShare(shareName)
 }
 
 // perRemoteReconciler scopes the GC mark phase to the shares pointing at
@@ -186,6 +271,8 @@ func (r *Runtime) RunBlockGCForShare(ctx context.Context, name string, dryRun bo
 			"errors", s.ErrorCount,
 		)
 	}
+	// Sweep this share's local tier too (#1433).
+	r.runLocalGC(ctx, name, dryRun, total)
 	return total, nil
 }
 

--- a/pkg/controlplane/runtime/blockgc_test.go
+++ b/pkg/controlplane/runtime/blockgc_test.go
@@ -66,6 +66,44 @@ func installCollectGarbageSpy(t *testing.T) *[]*engine.Options {
 	return &captured
 }
 
+// installCollectGarbageLocalSpy replaces collectGarbageLocalFn with a spy that
+// records each invocation's *engine.Options (one per swept share).
+func installCollectGarbageLocalSpy(t *testing.T) *[]*engine.Options {
+	t.Helper()
+	captured := make([]*engine.Options, 0, 4)
+	orig := collectGarbageLocalFn
+	collectGarbageLocalFn = func(_ context.Context, _ block.Store, _ engine.MetadataReconciler, opts *engine.Options) *engine.GCStats {
+		captured = append(captured, opts)
+		return &engine.GCStats{IsLocalTier: true}
+	}
+	t.Cleanup(func() { collectGarbageLocalFn = orig })
+	return &captured
+}
+
+// TestRunBlockGCLocal_SkipsInMemoryShares asserts RunBlockGCLocal does not
+// invoke the local sweep for shares with no persistent gc-state root
+// (in-memory backends): their chunks evaporate on restart.
+func TestRunBlockGCLocal_SkipsInMemoryShares(t *testing.T) {
+	captured := installCollectGarbageLocalSpy(t)
+	rt := newRuntimeForGC(t, map[string]remote.RemoteStore{"/share-a": &fakeRemoteStore{name: "s3"}})
+
+	stats, err := rt.RunBlockGCLocal(context.Background(), false)
+	if err != nil {
+		t.Fatalf("RunBlockGCLocal: %v", err)
+	}
+	if stats == nil {
+		t.Fatal("expected non-nil stats")
+	}
+	for _, opts := range *captured {
+		if opts.GCStateRoot == "" {
+			t.Error("local sweep invoked for a share with empty GCStateRoot")
+		}
+		if len(opts.Shares) != 1 {
+			t.Errorf("local sweep Options.Shares = %v, want exactly one share", opts.Shares)
+		}
+	}
+}
+
 // ---- Helpers ----
 
 // newRuntimeForGC builds a Runtime fixture for RunBlockGC tests. Each entry

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1863,7 +1863,8 @@ func (s *Service) DistinctRemoteStores() []RemoteStoreEntry {
 type LocalStoreEntry struct {
 	// ShareName is the single share that owns this local store.
 	ShareName string
-	// Store is the narrow Walk+Delete surface of the share's local block store.
+	// Store is the share's local block store. The local GC pass uses only its
+	// Walk + Delete methods.
 	Store block.Store
 	// GCStateRoot is the persistent gc-state directory for this share. Empty
 	// for in-memory backends (no on-disk chunks worth sweeping).

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1856,6 +1856,45 @@ func (s *Service) DistinctRemoteStores() []RemoteStoreEntry {
 	return out
 }
 
+// LocalStoreEntry describes one share's local block store for a per-share local
+// GC pass. Unlike remote stores, local stores are never shared across shares
+// (architecture invariant #4), so there is exactly one entry per share and no
+// deduplication is needed.
+type LocalStoreEntry struct {
+	// ShareName is the single share that owns this local store.
+	ShareName string
+	// Store is the narrow Walk+Delete surface of the share's local block store.
+	Store block.Store
+	// GCStateRoot is the persistent gc-state directory for this share. Empty
+	// for in-memory backends (no on-disk chunks worth sweeping).
+	GCStateRoot string
+}
+
+// ShareLocalStores returns one LocalStoreEntry per registered share that has a
+// block store with a non-nil local tier. The local GC pass sweeps each share's
+// own local store against that share's live set (per-share isolation).
+func (s *Service) ShareLocalStores() []LocalStoreEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]LocalStoreEntry, 0, len(s.registry))
+	for name, sh := range s.registry {
+		if sh.BlockStore == nil {
+			continue
+		}
+		local := sh.BlockStore.LocalStore()
+		if local == nil {
+			continue
+		}
+		out = append(out, LocalStoreEntry{
+			ShareName:   name,
+			Store:       local,
+			GCStateRoot: sh.gcStateRoot,
+		})
+	}
+	return out
+}
+
 // SetShareRemoteForTest installs a remote.RemoteStore for the named share
 // and registers it under a synthetic configID derived from the store's
 // pointer identity. Two calls with the same remote store for different

--- a/pkg/controlplane/runtime/snapshot_hold.go
+++ b/pkg/controlplane/runtime/snapshot_hold.go
@@ -228,6 +228,13 @@ func (p *SnapshotHoldProvider) AcquireDeleteLock(shareName string) (release func
 // per share, so AcquireDeleteLock on any instance blocks (or is blocked
 // by) every concurrent mark, closing the delete-vs-mark race the
 // per-instance mutex previously left open.
+// snapshotHoldForShare scopes snapshot holds to a single share for the
+// per-share local GC pass (#1433). Local stores are isolated per share, so the
+// local sweep must protect only that share's snapshot-held hashes.
+func (r *Runtime) snapshotHoldForShare(shareName string) engine.HoldProvider {
+	return r.snapshotHoldForRemote([]string{shareName})
+}
+
 func (r *Runtime) snapshotHoldForRemote(shareNames []string) engine.HoldProvider {
 	scoped := append([]string(nil), shareNames...)
 	locks := make([]*sync.RWMutex, 0, len(scoped))


### PR DESCRIPTION
## Problem (part of #1433)

Block GC swept only the **remote** (S3) tier — `pkg/block/engine/gc.go`'s sweep walked `remoteStore` and deleted only from it. The local `fs` block store was never swept, so orphaned chunks accumulated on disk. Under `retention: pin` (which disables local LRU eviction entirely) they leaked forever — this is the reporter's "47→57 GB, never shrinks".

## Fix

Add a per-share **local-tier** sweep that reuses the existing mark-sweep kernel:

- `sweepPhase` now takes a small `sweepable` (Walk+Delete) interface that both `remote.RemoteStore` and the local `block.Store` satisfy — zero adapters.
- `CollectGarbage` / `CollectGarbageLocal` are thin wrappers over one shared `collectGarbage(...)` kernel; the local variant tags `GCStats.IsLocalTier`.
- Local stores are isolated per share (architecture invariant #4), so each share is swept against its **own** live set: that share's `EnumerateFileBlocks` + its snapshot holds (`snapshotHoldForShare`).
- **Pin only gates eviction, not GC.** `DeleteChunk` does a direct unlink with no eviction-policy check, so orphans are reclaimed even under `retention: pin`. Referenced/snapshot-held chunks stay in the live set and are never swept.
- `RunBlockGC` / `RunBlockGCForShare` now also run the local sweep, so a single `dfsctl store block gc` reclaims **both** tiers. In-memory shares (no persistent gc-state) are skipped.

## Tests

- `TestCollectGarbageLocal_SweepsOrphansKeepsLive` — orphans swept, live kept, `IsLocalTier` tagged.
- `TestCollectGarbageLocal_SkipsSnapshotHeldChunks` — snapshot-held chunk survives (guardrail).
- `TestRunBlockGCLocal_SkipsInMemoryShares` — per-share scoping + skip-empty-gc-state.
- engine + full runtime (incl. snapshot) suites green; build/vet/gofmt clean.

## Notes

- Stacks logically on #1439 (refcount fix): the local sweep reclaims chunks once their hashes leave the live set, which #1439 makes happen on unlink. Files are disjoint; merges in either order. Full end-to-end (delete → both tiers shrink) validated once both land.
- Still to come: incremental/tombstone GC, reconcile-migration for historical leaks, auto-GC + config, monitoring/docs.

Part of #1433.
