### PR TITLE
feat(gc): reconcile + migration for stranded file_blocks rows (#1433)

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -230,6 +230,13 @@ func runStart(cmd *cobra.Command, args []string) error {
 		DryRunSampleSize: cfg.GC.DryRunSampleSize,
 	})
 
+	// One-time stranded-row reconcile migration (#1433): reaps file_blocks
+	// rows leaked by the pre-fix delete path and sweeps the now-orphaned
+	// chunks. Guarded by a per-store marker so it runs once per store. Detached
+	// from ctx (WithoutCancel) so a shutdown signal mid-scan doesn't abort it;
+	// errors are logged, never fatal.
+	go rt.RunBlockGCReconcileOnce(context.WithoutCancel(ctx))
+
 	// Thread the operator-configured lock-manager grace period into the
 	// MetadataService BEFORE loading shares: AddShare registers each share's
 	// lock manager and enters the post-restart grace window, so the duration

--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -230,13 +230,6 @@ func runStart(cmd *cobra.Command, args []string) error {
 		DryRunSampleSize: cfg.GC.DryRunSampleSize,
 	})
 
-	// One-time stranded-row reconcile migration (#1433): reaps file_blocks
-	// rows leaked by the pre-fix delete path and sweeps the now-orphaned
-	// chunks. Guarded by a per-store marker so it runs once per store. Detached
-	// from ctx (WithoutCancel) so a shutdown signal mid-scan doesn't abort it;
-	// errors are logged, never fatal.
-	go rt.RunBlockGCReconcileOnce(context.WithoutCancel(ctx))
-
 	// Thread the operator-configured lock-manager grace period into the
 	// MetadataService BEFORE loading shares: AddShare registers each share's
 	// lock manager and enters the post-restart grace window, so the duration
@@ -265,6 +258,15 @@ func runStart(cmd *cobra.Command, args []string) error {
 		"metadata_stores", rt.CountMetadataStores(),
 		"shares", rt.CountShares())
 	logger.Info("Per-share BlockStores created during share loading")
+
+	// One-time stranded-row reconcile migration (#1433): reaps file_blocks
+	// rows leaked by the pre-fix delete path and sweeps the now-orphaned
+	// chunks. Launched AFTER LoadSharesFromStore so ListShares() sees the
+	// registered shares (otherwise it no-ops and never sets its marker).
+	// Guarded by a per-store marker so it runs once per store. Detached from
+	// ctx (WithoutCancel) so a shutdown signal mid-scan doesn't abort it;
+	// errors are logged, never fatal.
+	go rt.RunBlockGCReconcileOnce(context.WithoutCancel(ctx))
 
 	// Configure runtime
 	rt.SetShutdownTimeout(cfg.ShutdownTimeout)

--- a/cmd/dfsctl/commands/store/block/gc.go
+++ b/cmd/dfsctl/commands/store/block/gc.go
@@ -31,9 +31,16 @@ Use --dry-run to skip deletes and print up to dry_run_sample_size
 candidate keys (default 1000). Recommended for first-time deployment
 confidence and for debugging suspected mark-phase bugs.
 
+Use --reconcile to additionally reap stranded file_blocks rows — rows
+whose owning file was deleted before the unlink-refcount fix, which a
+plain GC cannot reclaim because they keep their hashes in the live set.
+Reconcile is server-wide (all shares) and the recommended way to recover
+space leaked by older versions. Combine with --dry-run to preview.
+
 Examples:
   dfsctl store block gc myshare
   dfsctl store block gc myshare --dry-run
+  dfsctl store block gc myshare --reconcile
   dfsctl store block gc myshare -o json`,
 	Args: cobra.ExactArgs(1),
 	RunE: runBlockStoreGC,
@@ -41,18 +48,20 @@ Examples:
 
 func init() {
 	gcCmd.Flags().Bool("dry-run", false, "Run mark + sweep enumeration but skip deletes; print candidate keys")
+	gcCmd.Flags().Bool("reconcile", false, "Also reap stranded file_blocks rows leaked by older versions (server-wide), then sweep both tiers")
 }
 
 func runBlockStoreGC(cmd *cobra.Command, args []string) error {
 	share := args[0]
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	reconcile, _ := cmd.Flags().GetBool("reconcile")
 
 	client, err := cmdutil.GetAuthenticatedClient()
 	if err != nil {
 		return err
 	}
 
-	res, err := client.BlockStoreGC(share, &apiclient.BlockStoreGCOptions{DryRun: dryRun})
+	res, err := client.BlockStoreGC(share, &apiclient.BlockStoreGCOptions{DryRun: dryRun, Reconcile: reconcile})
 	if err != nil {
 		return fmt.Errorf("failed to run block store GC: %w", err)
 	}

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -5609,6 +5609,12 @@ Use --dry-run to skip deletes and print up to dry_run_sample_size
 candidate keys (default 1000). Recommended for first-time deployment
 confidence and for debugging suspected mark-phase bugs.
 
+Use --reconcile to additionally reap stranded file_blocks rows — rows
+whose owning file was deleted before the unlink-refcount fix, which a
+plain GC cannot reclaim because they keep their hashes in the live set.
+Reconcile is server-wide (all shares) and the recommended way to recover
+space leaked by older versions. Combine with --dry-run to preview.
+
 ```
 dfsctl store block gc <share> [flags]
 ```
@@ -5618,13 +5624,15 @@ dfsctl store block gc <share> [flags]
 ```bash
 dfsctl store block gc myshare
 dfsctl store block gc myshare --dry-run
+dfsctl store block gc myshare --reconcile
 dfsctl store block gc myshare -o json
 ```
 
 Flags:
 
 ```
-      --dry-run   Run mark + sweep enumeration but skip deletes; print candidate keys
+      --dry-run     Run mark + sweep enumeration but skip deletes; print candidate keys
+      --reconcile   Also reap stranded file_blocks rows leaked by older versions (server-wide), then sweep both tiers
 ```
 
 Global flags:

--- a/internal/controlplane/api/handlers/block_gc.go
+++ b/internal/controlplane/api/handlers/block_gc.go
@@ -26,6 +26,10 @@ type BlockGCRuntime interface {
 	// gc-state directory for last-run.json persistence.
 	RunBlockGCForShare(ctx context.Context, shareName string, dryRun bool) (*engine.GCStats, error)
 
+	// RunBlockGCReconcile reaps stranded file_blocks rows (leaked by the
+	// pre-fix delete path) across all shares, then runs the two-tier sweep.
+	RunBlockGCReconcile(ctx context.Context, dryRun bool) (*engine.GCStats, error)
+
 	// GCStateDirForShare returns the per-share gc-state directory the GC
 	// engine writes `last-run.json` into. Empty when the share's local
 	// store has no persistent root (in-memory backend).
@@ -51,6 +55,10 @@ func NewBlockStoreGCHandler(rt BlockGCRuntime) *BlockStoreGCHandler {
 // default 1000).
 type BlockStoreGCRequest struct {
 	DryRun bool `json:"dry_run,omitempty"`
+	// Reconcile runs the migration pass first: reap stranded file_blocks rows
+	// (leaked by the pre-fix delete path) across all shares, then sweep both
+	// tiers. Reclaims historical leaks a plain GC cannot (#1433).
+	Reconcile bool `json:"reconcile,omitempty"`
 }
 
 // BlockStoreGCResponse wraps the *engine.GCStats result for JSON output.
@@ -93,7 +101,15 @@ func (h *BlockStoreGCHandler) RunGC(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	stats, err := h.runtime.RunBlockGCForShare(r.Context(), name, req.DryRun)
+	// Reconcile is server-wide (reaps stranded rows across all shares), so it
+	// ignores the per-share scoping that RunBlockGCForShare applies.
+	var stats *engine.GCStats
+	var err error
+	if req.Reconcile {
+		stats, err = h.runtime.RunBlockGCReconcile(r.Context(), req.DryRun)
+	} else {
+		stats, err = h.runtime.RunBlockGCForShare(r.Context(), name, req.DryRun)
+	}
 	if err != nil {
 		if errors.Is(err, shares.ErrShareNotFound) {
 			NotFound(w, "share not found: "+name)

--- a/internal/controlplane/api/handlers/block_gc_test.go
+++ b/internal/controlplane/api/handlers/block_gc_test.go
@@ -45,6 +45,14 @@ func (f *fakeGCRuntime) RunBlockGCForShare(_ context.Context, shareName string, 
 	return f.runStats, nil
 }
 
+func (f *fakeGCRuntime) RunBlockGCReconcile(_ context.Context, dryRun bool) (*engine.GCStats, error) {
+	f.runCalls = append(f.runCalls, runCall{share: "<reconcile>", dryRun: dryRun})
+	if f.runErr != nil {
+		return nil, f.runErr
+	}
+	return f.runStats, nil
+}
+
 func (f *fakeGCRuntime) GCStateDirForShare(_ string) (string, error) {
 	if f.gcStateRootEr != nil {
 		return "", f.gcStateRootEr

--- a/pkg/apiclient/blockstore.go
+++ b/pkg/apiclient/blockstore.go
@@ -113,6 +113,10 @@ func (c *Client) GetShareWarm(name, jobID string) (*WarmJobStatus, error) {
 // dry-run sample size, default 1000).
 type BlockStoreGCOptions struct {
 	DryRun bool `json:"dry_run,omitempty"`
+	// Reconcile runs the migration pass: reap stranded file_blocks rows
+	// (leaked by the pre-fix delete path) across all shares, then sweep both
+	// tiers — reclaiming historical leaks a plain GC cannot (#1433).
+	Reconcile bool `json:"reconcile,omitempty"`
 }
 
 // BlockStoreGCResult is the response body for

--- a/pkg/block/engine/gc.go
+++ b/pkg/block/engine/gc.go
@@ -144,6 +144,11 @@ type GCStats struct {
 	DryRun           bool
 	DryRunCandidates []string
 
+	// StrandedRowsReaped counts file_blocks rows reaped by the reconcile pass
+	// (rows whose owning inode was already gone — the pre-fix leak). Zero for a
+	// plain GC run; only the reconcile sets it (#1433).
+	StrandedRowsReaped int64 `json:"stranded_rows_reaped,omitempty"`
+
 	// IsLocalTier is true when these stats come from a local-store pass
 	// (CollectGarbageLocal), false for the default remote pass. Per-invocation
 	// metadata only — accumulateGCStats does not fold it into a total; the

--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -324,6 +324,7 @@ func accumulateGCStats(total, stats *engine.GCStats, includeDryRunMeta bool) eng
 	total.ObjectsSwept += s.ObjectsSwept
 	total.BytesFreed += s.BytesFreed
 	total.ErrorCount += s.ErrorCount
+	total.StrandedRowsReaped += s.StrandedRowsReaped
 	// SharesScanned / BlocksScanned are deprecated REST wire fields that
 	// are never populated by the mark-sweep engine — accumulation would
 	// always be zero, so it is skipped here. See engine.GCStats godoc.

--- a/pkg/controlplane/runtime/blockgc_reconcile.go
+++ b/pkg/controlplane/runtime/blockgc_reconcile.go
@@ -1,0 +1,224 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// reconcileMarkerKey names the per-store CustomSettings entry recording that the
+// one-time stranded-row reconcile has run. Bump reconcileVersion to force a
+// re-run on upgrade if a future fix needs another pass.
+const (
+	reconcileMarkerKey = "gc.stranded_rows_reconciled_version"
+	reconcileVersion   = 1
+)
+
+// RunBlockGCReconcile reaps stranded file_blocks rows — rows whose owning inode
+// is already gone — and then runs the normal two-tier sweep so the now-orphaned
+// chunks are reclaimed on both local and remote stores.
+//
+// This is the migration path for blocks leaked by the pre-fix delete path
+// (#1433): a plain GC pass cannot reclaim them, because a stranded row keeps its
+// hash in the live set (the live set is built from file_blocks, which has no
+// namespace join). The reconcile recomputes the true live set from the inode
+// namespace (EnumerateLivePayloadIDs), reaps the rows the namespace no longer
+// references, then lets the grace- and snapshot-hold-aware sweep delete the
+// chunks.
+func (r *Runtime) RunBlockGCReconcile(ctx context.Context, dryRun bool) (*engine.GCStats, error) {
+	graceCutoff := time.Now().Add(-r.reconcileGracePeriod())
+
+	total := &engine.GCStats{DryRun: dryRun}
+	for _, shareName := range r.ListShares() {
+		if err := ctx.Err(); err != nil {
+			return total, err
+		}
+		mds, err := r.GetMetadataStoreForShare(shareName)
+		if err != nil {
+			logger.Warn("RunBlockGCReconcile: get metadata store", "share", shareName, "err", err)
+			total.ErrorCount++
+			continue
+		}
+		reaped, err := r.reapStrandedRows(ctx, shareName, mds, graceCutoff, dryRun)
+		if err != nil {
+			logger.Error("RunBlockGCReconcile: reap stranded rows", "share", shareName, "err", err)
+			total.ErrorCount++
+			continue
+		}
+		total.StrandedRowsReaped += int64(reaped)
+	}
+
+	// Stranded rows are gone, so their hashes have left the live set. RunBlockGC
+	// sweeps the remote tier and (since #1433) the local tier too, reclaiming
+	// the now-orphaned chunks under the usual grace + snapshot-hold guards.
+	sweep, err := r.RunBlockGC(ctx, "", dryRun)
+	if err != nil {
+		return total, err
+	}
+	accumulateGCStats(total, sweep, true)
+	logger.Info("RunBlockGCReconcile: complete",
+		"dryRun", dryRun,
+		"strandedRowsReaped", total.StrandedRowsReaped,
+		"objectsSwept", total.ObjectsSwept,
+		"bytesFreed", total.BytesFreed,
+		"errors", total.ErrorCount,
+	)
+	return total, nil
+}
+
+// reconcileGracePeriod returns the configured GC grace period (default 1h). The
+// reconcile uses it to skip rows created within the window, closing the TOCTOU
+// race where a file is created between the live-set snapshot and the stranded
+// scan.
+func (r *Runtime) reconcileGracePeriod() time.Duration {
+	if d := r.gcDefaultsSnapshot(); d != nil && d.GracePeriod > 0 {
+		return d.GracePeriod
+	}
+	return time.Hour
+}
+
+// reapStrandedRows reaps file_blocks rows for one share whose payloadID is not
+// referenced by any live inode. Rows newer than graceCutoff are skipped (a file
+// may have been created mid-scan). When dryRun is set, rows are counted but not
+// reaped.
+func (r *Runtime) reapStrandedRows(ctx context.Context, shareName string, mds metadata.Store, graceCutoff time.Time, dryRun bool) (int, error) {
+	// True live set, from the namespace.
+	live := make(map[string]struct{})
+	if err := mds.EnumerateLivePayloadIDs(ctx, func(p string) error {
+		live[p] = struct{}{}
+		return nil
+	}); err != nil {
+		return 0, fmt.Errorf("enumerate live payloads: %w", err)
+	}
+
+	// Payloads present in file_blocks but absent from the namespace = stranded.
+	var stranded []string
+	if err := mds.EnumeratePayloads(ctx, func(p string) error {
+		if _, ok := live[p]; !ok {
+			stranded = append(stranded, p)
+		}
+		return nil
+	}); err != nil {
+		return 0, fmt.Errorf("enumerate payloads: %w", err)
+	}
+	if len(stranded) == 0 {
+		return 0, nil
+	}
+
+	reaped, skippedGrace := 0, 0
+	for _, pid := range stranded {
+		if err := ctx.Err(); err != nil {
+			return reaped, err
+		}
+		rows, err := mds.ListFileBlocks(ctx, pid)
+		if err != nil {
+			logger.Warn("reconcile: list stranded blocks", "share", shareName, "payload", pid, "err", err)
+			continue
+		}
+		for _, fb := range rows {
+			if fb == nil {
+				continue
+			}
+			if fb.CreatedAt.After(graceCutoff) {
+				skippedGrace++
+				continue
+			}
+			if dryRun {
+				reaped++
+				continue
+			}
+			if _, err := mds.DecrementRefCountAndReap(ctx, fb.ID); err != nil {
+				logger.Warn("reconcile: reap row", "share", shareName, "id", fb.ID, "err", err)
+				continue
+			}
+			reaped++
+		}
+	}
+	logger.Info("reconcile: stranded rows processed",
+		"share", shareName,
+		"strandedPayloads", len(stranded),
+		"rowsReaped", reaped,
+		"skippedGrace", skippedGrace,
+		"dryRun", dryRun,
+	)
+	return reaped, nil
+}
+
+// RunBlockGCReconcileOnce runs the stranded-row reconcile exactly once per
+// metadata store, guarded by a persisted marker, then chains the sweep. It is
+// the upgrade migration: existing deployments leaked blocks before the
+// unlink-refcount fix, and this reclaims them without operator action. Safe to
+// call on every startup — it no-ops once the marker is set. Intended to run in a
+// detached goroutine; errors are logged, never fatal.
+func (r *Runtime) RunBlockGCReconcileOnce(ctx context.Context) {
+	shares := r.ListShares()
+	pending := make([]string, 0, len(shares))
+	for _, shareName := range shares {
+		mds, err := r.GetMetadataStoreForShare(shareName)
+		if err != nil {
+			logger.Warn("reconcile-once: get metadata store", "share", shareName, "err", err)
+			continue
+		}
+		if reconcileAlreadyDone(ctx, mds) {
+			continue
+		}
+		pending = append(pending, shareName)
+	}
+	if len(pending) == 0 {
+		logger.Debug("reconcile-once: all stores already reconciled; skipping")
+		return
+	}
+
+	logger.Info("reconcile-once: running one-time stranded-row migration", "shares", pending)
+	if _, err := r.RunBlockGCReconcile(ctx, false); err != nil {
+		logger.Error("reconcile-once: reconcile failed; marker not set, will retry next start", "err", err)
+		return
+	}
+
+	// Persist the marker on every pending store so we don't re-run.
+	for _, shareName := range pending {
+		mds, err := r.GetMetadataStoreForShare(shareName)
+		if err != nil {
+			continue
+		}
+		if err := markReconcileDone(ctx, mds); err != nil {
+			logger.Warn("reconcile-once: persist marker", "share", shareName, "err", err)
+		}
+	}
+}
+
+// reconcileAlreadyDone reports whether the store's marker is at or above the
+// current reconcile version. JSON round-trips numbers as float64, so the
+// assertion must be float64.
+func reconcileAlreadyDone(ctx context.Context, mds metadata.Store) bool {
+	cfg, err := mds.GetServerConfig(ctx)
+	if err != nil || cfg.CustomSettings == nil {
+		return false
+	}
+	switch v := cfg.CustomSettings[reconcileMarkerKey].(type) {
+	case float64:
+		return v >= reconcileVersion
+	case int:
+		return v >= reconcileVersion
+	default:
+		return false
+	}
+}
+
+// markReconcileDone records the current reconcile version in the store's
+// CustomSettings so RunBlockGCReconcileOnce no-ops on subsequent starts.
+func markReconcileDone(ctx context.Context, mds metadata.Store) error {
+	cfg, err := mds.GetServerConfig(ctx)
+	if err != nil {
+		return err
+	}
+	if cfg.CustomSettings == nil {
+		cfg.CustomSettings = make(map[string]any)
+	}
+	cfg.CustomSettings[reconcileMarkerKey] = reconcileVersion
+	return mds.SetServerConfig(ctx, cfg)
+}

--- a/pkg/controlplane/runtime/blockgc_reconcile_test.go
+++ b/pkg/controlplane/runtime/blockgc_reconcile_test.go
@@ -1,0 +1,111 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// seedReconcileFB seeds n file_blocks rows for payloadID with the given
+// CreatedAt (controls grace gating).
+func seedReconcileFB(t *testing.T, ctx context.Context, store metadata.Store, payloadID string, n int, created time.Time) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		b := &block.FileBlock{
+			ID:         fmt.Sprintf("%s/%d", payloadID, i),
+			State:      block.BlockStatePending,
+			LocalPath:  fmt.Sprintf("/cache/%s-%d", payloadID, i),
+			DataSize:   128,
+			RefCount:   1,
+			LastAccess: created,
+			CreatedAt:  created,
+		}
+		if err := store.Put(ctx, b); err != nil {
+			t.Fatalf("Put(%s): %v", b.ID, err)
+		}
+	}
+}
+
+// TestReapStrandedRows verifies the reconcile reaps file_blocks rows for
+// payloads with no live inode, leaves live payloads alone, and respects the
+// grace window.
+func TestReapStrandedRows(t *testing.T) {
+	ctx := context.Background()
+	store := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	old := time.Now().Add(-2 * time.Hour)
+
+	// A live inode referencing payload "live".
+	const livePID = "live"
+	h, err := store.GenerateHandle(ctx, "share", "/live.bin")
+	if err != nil {
+		t.Fatalf("GenerateHandle: %v", err)
+	}
+	_, id, err := metadata.DecodeFileHandle(h)
+	if err != nil {
+		t.Fatalf("DecodeFileHandle: %v", err)
+	}
+	if err := store.PutFile(ctx, &metadata.File{
+		ID:        id,
+		ShareName: "share",
+		Path:      "/live.bin",
+		FileAttr: metadata.FileAttr{
+			Type:      metadata.FileTypeRegular,
+			Mode:      0o644,
+			PayloadID: metadata.PayloadID(livePID),
+		},
+	}); err != nil {
+		t.Fatalf("PutFile: %v", err)
+	}
+
+	seedReconcileFB(t, ctx, store, livePID, 2, old)        // live, must survive
+	seedReconcileFB(t, ctx, store, "stranded", 3, old)     // stranded, must reap
+	seedReconcileFB(t, ctx, store, "fresh", 1, time.Now()) // stranded but within grace
+
+	rt := &Runtime{}
+	graceCutoff := time.Now().Add(-time.Hour)
+	reaped, err := rt.reapStrandedRows(ctx, "share", store, graceCutoff, false)
+	if err != nil {
+		t.Fatalf("reapStrandedRows: %v", err)
+	}
+	if reaped != 3 {
+		t.Errorf("reaped = %d, want 3 (stranded rows only)", reaped)
+	}
+
+	// Live payload rows must survive.
+	if rows, err := store.ListFileBlocks(ctx, livePID); err != nil || len(rows) != 2 {
+		t.Errorf("live rows = %d (err=%v), want 2 (reconcile must not reap live)", len(rows), err)
+	}
+	// Stranded payload rows must be gone.
+	if rows, err := store.ListFileBlocks(ctx, "stranded"); err != nil || len(rows) != 0 {
+		t.Errorf("stranded rows = %d (err=%v), want 0", len(rows), err)
+	}
+	// Within-grace stranded rows must be preserved (TOCTOU guard).
+	if rows, err := store.ListFileBlocks(ctx, "fresh"); err != nil || len(rows) != 1 {
+		t.Errorf("fresh (in-grace) rows = %d (err=%v), want 1 (grace must protect)", len(rows), err)
+	}
+}
+
+// TestReapStrandedRows_DryRun verifies dry-run counts but does not reap.
+func TestReapStrandedRows_DryRun(t *testing.T) {
+	ctx := context.Background()
+	store := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	old := time.Now().Add(-2 * time.Hour)
+	seedReconcileFB(t, ctx, store, "stranded", 4, old)
+
+	rt := &Runtime{}
+	reaped, err := rt.reapStrandedRows(ctx, "share", store, time.Now(), true)
+	if err != nil {
+		t.Fatalf("reapStrandedRows: %v", err)
+	}
+	if reaped != 4 {
+		t.Errorf("dry-run reaped count = %d, want 4", reaped)
+	}
+	if rows, err := store.ListFileBlocks(ctx, "stranded"); err != nil || len(rows) != 4 {
+		t.Errorf("dry-run deleted rows: got %d, want 4 preserved", len(rows))
+	}
+}

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -407,6 +407,18 @@ type Store interface {
 	// block.EngineFileBlockStore.
 	EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error
 
+	// EnumerateLivePayloadIDs streams every distinct PayloadID referenced by a
+	// live inode through fn (deduped, order-independent). "Live" includes
+	// nlink=0 inodes (open-but-unlinked files whose blocks are still in use),
+	// since their inode rows still exist. Unlike EnumeratePayloads — which
+	// reads file_blocks and therefore also yields payloads whose owning file is
+	// already gone (stranded rows) — this reads the namespace, so the set
+	// difference (EnumeratePayloads − EnumerateLivePayloadIDs) is exactly the
+	// stranded payloads the GC reconcile must reap (#1433). Implementations
+	// MUST drain the result set before invoking fn (collect-then-call) and
+	// honor ctx.Done() throughout.
+	EnumerateLivePayloadIDs(ctx context.Context, fn func(payloadID string) error) error
+
 	// ========================================================================
 	// Usage Tracking
 	// ========================================================================

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -407,6 +407,58 @@ func (s *BadgerMetadataStore) ListFileBlocks(_ context.Context, payloadID string
 	return result, nil
 }
 
+// EnumerateLivePayloadIDs streams every distinct PayloadID referenced by a live
+// inode. It scans the f: inode keyspace, decodes each file record, and collects
+// distinct non-empty PayloadIDs. Corrupt inode records are skipped so a single
+// bad row cannot block the reconcile. Hardlinks share one f: key, so DISTINCT
+// yields one payloadID per content; nlink=0 inodes still have their key and are
+// reported live.
+func (s *BadgerMetadataStore) EnumerateLivePayloadIDs(ctx context.Context, fn func(payloadID string) error) error {
+	seen := make(map[string]struct{})
+	err := s.db.View(func(txn *badger.Txn) error {
+		prefix := []byte(prefixFile)
+		opts := badger.DefaultIteratorOptions
+		opts.Prefix = prefix
+		opts.PrefetchValues = true // PayloadID lives in the value, not the key
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			verr := it.Item().Value(func(val []byte) error {
+				file, derr := decodeFile(val)
+				if derr != nil {
+					// Skip corrupt inode rows rather than fail-closed: a single
+					// bad row must not block reclaiming everything else.
+					return nil
+				}
+				if pid := string(file.PayloadID); pid != "" {
+					seen[pid] = struct{}{}
+				}
+				return nil
+			})
+			if verr != nil {
+				return verr
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	for payloadID := range seen {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := fn(payloadID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // EnumeratePayloads streams every distinct payloadID that has at least one
 // FileBlock row through fn. It iterates the fb-file:{payloadID}:{blockIdx}
 // secondary index, extracts the payloadID (the substring before the LAST ':')

--- a/pkg/metadata/store/memory/objects.go
+++ b/pkg/metadata/store/memory/objects.go
@@ -140,6 +140,34 @@ func (s *MemoryMetadataStore) ListFileBlocks(ctx context.Context, payloadID stri
 	return s.listFileBlocksLocked(ctx, payloadID)
 }
 
+// EnumerateLivePayloadIDs streams every distinct PayloadID referenced by a
+// live inode. It snapshots the distinct PayloadIDs under the read lock, then
+// calls fn per payloadID. Hardlinks share one fileData entry, so DISTINCT
+// yields one payloadID per content; nlink=0 inodes still have their entry and
+// are reported live.
+func (s *MemoryMetadataStore) EnumerateLivePayloadIDs(ctx context.Context, fn func(payloadID string) error) error {
+	seen := make(map[string]struct{})
+	s.mu.RLock()
+	for _, fd := range s.files {
+		if fd == nil || fd.Attr == nil {
+			continue
+		}
+		if pid := string(fd.Attr.PayloadID); pid != "" {
+			seen[pid] = struct{}{}
+		}
+	}
+	s.mu.RUnlock()
+	for payloadID := range seen {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := fn(payloadID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // EnumeratePayloads streams every distinct payloadID that has at least one
 // FileBlock row through fn. It collects distinct payloadIDs under the read
 // lock (splitting each block.ID on the LAST '/' to recover the payloadID —

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -367,6 +367,27 @@ func (s *PostgresMetadataStore) EnumeratePayloads(ctx context.Context, fn func(p
 	return nil
 }
 
+// EnumerateLivePayloadIDs streams every distinct content_id referenced by a
+// live inode. content_id IS the payloadID. Hardlinks share one inode row, so
+// DISTINCT yields one payloadID per content regardless of link count; nlink=0
+// (open-but-unlinked) inodes still have their row and are reported live.
+func (s *PostgresMetadataStore) EnumerateLivePayloadIDs(ctx context.Context, fn func(payloadID string) error) error {
+	const query = `SELECT DISTINCT content_id FROM inodes WHERE content_id IS NOT NULL AND content_id != ''`
+	ids, err := s.collectFileBlockIDs(ctx, query)
+	if err != nil {
+		return err
+	}
+	for _, id := range ids {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("enumerate live payloads: %w", err)
+		}
+		if err := fn(id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // collectFileBlockIDs runs query (which must SELECT a single TEXT id column),
 // scans every id into a slice, and closes the rows cursor before returning.
 func (s *PostgresMetadataStore) collectFileBlockIDs(ctx context.Context, query string) ([]string, error) {

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -367,6 +367,28 @@ func (s *SQLiteMetadataStore) EnumeratePayloads(ctx context.Context, fn func(pay
 	return nil
 }
 
+// EnumerateLivePayloadIDs streams every distinct content_id referenced by a
+// live inode. content_id IS the payloadID, so no id-splitting is needed.
+// Hardlinks share one inode row, so DISTINCT yields one payloadID regardless of
+// link count; nlink=0 (open-but-unlinked) inodes still have their row and are
+// correctly reported live.
+func (s *SQLiteMetadataStore) EnumerateLivePayloadIDs(ctx context.Context, fn func(payloadID string) error) error {
+	const query = `SELECT DISTINCT content_id FROM inodes WHERE content_id IS NOT NULL AND content_id != ''`
+	ids, err := s.collectFileBlockIDs(ctx, query)
+	if err != nil {
+		return err
+	}
+	for _, id := range ids {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("enumerate live payloads: %w", err)
+		}
+		if err := fn(id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // collectFileBlockIDs runs query (which must SELECT a single TEXT id column),
 // scans every id into a slice, and closes the rows cursor before returning so
 // the caller may safely issue further queries on the single-connection pool.

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -132,6 +132,13 @@ func runFileBlockOpsTests(t *testing.T, factory StoreFactory) {
 		testEnumeratePayloads_Empty(t, factory)
 	})
 
+	// EnumerateLivePayloadIDs reads the namespace (inodes), so the difference
+	// against EnumeratePayloads (which reads file_blocks) is exactly the
+	// stranded-payload set the GC reconcile reaps (#1433).
+	t.Run("EnumerateLivePayloadIDs", func(t *testing.T) {
+		testEnumerateLivePayloadIDs(t, factory)
+	})
+
 	// IncrementRefCount / DecrementRefCount called via a
 	// metadata.Transaction MUST roll back when the wrapping WithTransaction
 	// returns an error. All backends — memory, badger, postgres — honor the
@@ -1446,5 +1453,85 @@ func testAddRef_Concurrent_With_DecrementRefCountCascade(t *testing.T, factory S
 	}
 	if got.RefCount != 10 {
 		t.Errorf("RefCount post-cascade = %d; want 10 (8 AddRef + 8 Decrement on RefCount=10 seed; TOCTOU-free)", got.RefCount)
+	}
+}
+
+// testEnumerateLivePayloadIDs verifies the namespace-derived live set used by
+// the GC reconcile (#1433). A "stranded" payload — file_blocks rows whose
+// owning inode is gone (the historical leak) — must appear in EnumeratePayloads
+// but NOT in EnumerateLivePayloadIDs, so the reconcile can reap it. A live
+// file's payload must appear in both.
+func testEnumerateLivePayloadIDs(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	root := createTestShare(t, store, "myshare")
+
+	// A live file carrying a PayloadID, plus its file_blocks rows.
+	const livePID = "myshare/live.bin"
+	h := createTestFile(t, store, "myshare", root, "live.bin", 0o644)
+	f, err := store.GetFile(ctx, h)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	f.PayloadID = metadata.PayloadID(livePID)
+	if err := store.PutFile(ctx, f); err != nil {
+		t.Fatalf("PutFile (set payload): %v", err)
+	}
+	seedStrandedBlocks(t, ctx, store, livePID, 2)
+
+	// A STRANDED payload: file_blocks rows exist with no inode referencing them
+	// (owning file deleted without reaping — the pre-fix leak).
+	const strandedPID = "myshare/ghost.bin"
+	seedStrandedBlocks(t, ctx, store, strandedPID, 3)
+
+	// EnumerateLivePayloadIDs reads the namespace: live present, stranded absent.
+	live := make(map[string]int)
+	if err := store.EnumerateLivePayloadIDs(ctx, func(p string) error {
+		live[p]++
+		return nil
+	}); err != nil {
+		t.Fatalf("EnumerateLivePayloadIDs: %v", err)
+	}
+	if live[livePID] != 1 {
+		t.Errorf("live payload %q yielded %d times, want exactly 1", livePID, live[livePID])
+	}
+	if live[strandedPID] != 0 {
+		t.Errorf("stranded payload %q reported live — reconcile would never reap it", strandedPID)
+	}
+
+	// EnumeratePayloads reads file_blocks: BOTH present (stranded-inclusive).
+	all := make(map[string]int)
+	if err := store.EnumeratePayloads(ctx, func(p string) error {
+		all[p]++
+		return nil
+	}); err != nil {
+		t.Fatalf("EnumeratePayloads: %v", err)
+	}
+	if all[livePID] == 0 {
+		t.Errorf("EnumeratePayloads missing live payload %q", livePID)
+	}
+	if all[strandedPID] == 0 {
+		t.Errorf("EnumeratePayloads missing stranded payload %q (test setup invalid)", strandedPID)
+	}
+}
+
+// seedStrandedBlocks puts n file_blocks rows for payloadID without requiring an
+// inode — the exact shape of a leaked/stranded manifest.
+func seedStrandedBlocks(t *testing.T, ctx context.Context, store metadata.Store, payloadID string, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		b := &block.FileBlock{
+			ID:         fmt.Sprintf("%s/%d", payloadID, i),
+			State:      block.BlockStatePending,
+			LocalPath:  fmt.Sprintf("/cache/%s-%d", payloadID, i),
+			DataSize:   128,
+			RefCount:   1,
+			LastAccess: time.Now(),
+			CreatedAt:  time.Now(),
+		}
+		if err := store.Put(ctx, b); err != nil {
+			t.Fatalf("Put(%s): %v", b.ID, err)
+		}
 	}
 }


### PR DESCRIPTION
> Stacked on #1440 (base = `feat/1433-gc-local-sweep`). GitHub will retarget to `develop` when #1440 merges.

## Problem (part of #1433)

PR #1439 + #1440 fix GC for **future** deletes. But existing deployments already leaked blocks: before the unlink-refcount fix, deletes left `file_blocks` rows behind (refcount never decremented). The GC live set is built from `file_blocks` (`EnumerateFileBlocks`) with **no join to the namespace**, so those *stranded* rows keep their hashes "live" forever — a plain GC can never reclaim the chunks. This is the reporter's stuck ~9 GB.

## Fix — reconcile + one-time migration

Recompute the **true** live set from the inode namespace, reap stranded rows, then run the two-tier sweep.

- **`EnumerateLivePayloadIDs`** on `metadata.Store` + all 4 backends (sqlite/postgres/badger/memory): streams every PayloadID referenced by a live inode. The set difference `EnumeratePayloads − EnumerateLivePayloadIDs` is exactly the stranded payloads. Hardlink-safe (DISTINCT content_id), counts `nlink=0` (open-but-unlinked) inodes as live. Conformance-tested on all backends.
- **`RunBlockGCReconcile`**: per share, diff live vs payloads → reap stranded rows via `DecrementRefCountAndReap`, **grace-gated by `CreatedAt`** (closes the create-vs-scan race) → then `RunBlockGC` sweeps both tiers under the usual grace + snapshot-hold guards.
- **`RunBlockGCReconcileOnce`**: one-time upgrade migration guarded by a per-store `CustomSettings` marker, launched from server start (after shares load) in a detached goroutine — existing installs self-heal with no operator action.
- Surfaced as **`dfsctl store block gc <share> --reconcile`** + REST `reconcile` flag; `GCStats.StrandedRowsReaped` reports the count. `docs/guide/cli.md` regenerated.

## Tests

- `testEnumerateLivePayloadIDs` conformance — passes on memory, sqlite, badger (postgres in CI).
- `TestReapStrandedRows` (live survives, stranded reaped, grace protects fresh) + `_DryRun`.
- Handler tests updated. build/vet/gofmt clean.

## Safety (reviewed)

- No data-loss: live set includes nlink=0 + hardlinks; grace guard closes the TOCTOU window; dedup rows (refcount>1) only decrement, never over-reap; snapshot holds come from `FileAttr.Blocks`, not `file_blocks`, so reaping a row never exposes snapshot data.
- Reconcile reaps only metadata rows; chunk deletion happens in the grace+hold-aware sweep.

Part of #1433.
