### PR TITLE
feat(gc): background auto-GC scheduler + enable/disable knob (#1433)

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -268,6 +268,15 @@ func runStart(cmd *cobra.Command, args []string) error {
 	// errors are logged, never fatal.
 	go rt.RunBlockGCReconcileOnce(context.WithoutCancel(ctx))
 
+	// Background auto-GC (#1433): periodically reclaims orphaned blocks on both
+	// tiers so operators don't have to run `dfsctl store block gc` by hand.
+	// Enabled by default; bound to ctx so it stops on shutdown.
+	if cfg.GC.AutoGCEnabled() {
+		rt.StartScheduledGC(ctx, cfg.GC.AutoInterval)
+	} else {
+		logger.Info("auto-GC disabled by config (gc.auto_enabled=false)")
+	}
+
 	// Configure runtime
 	rt.SetShutdownTimeout(cfg.ShutdownTimeout)
 	// Seed an operator-pinned machine SID (if configured) BEFORE Serve so the

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -482,16 +482,26 @@ gc:
                               # the snapshot.
   dry_run_sample_size: 1000   # Maximum candidate keys reported in
                               # --dry-run mode. Default 1000.
+  auto_enabled: true          # Run background GC automatically so you
+                              # don't have to invoke the CLI. Default
+                              # true. Set false to require manual
+                              # `dfsctl store block gc`.
+  auto_interval: 15m          # Period between background GC runs.
+                              # Default 15m. Values in (0, 1m) are
+                              # REJECTED. Ignored when auto_enabled is
+                              # false.
 ```
 
 **Tuning guidance:**
 
-- v0.15.0 ships only on-demand GC. Run via
-  `dfsctl store block gc <share> --dry-run` (capped by
-  `gc.dry_run_sample_size`) until you have measured the
-  hashes_marked / objects_swept ratio for your workload, then schedule
-  the real run via cron at the cadence that matches your delete rate.
-  No periodic-GC scheduler ships today; trigger GC on demand or via cron.
+- Background GC is **on by default** (`auto_enabled: true`, every
+  `auto_interval`) and reclaims orphaned blocks on **both** the local
+  and remote tiers. Disable it (`auto_enabled: false`) only if you want
+  to drive GC entirely on demand or via external scheduling.
+- You can still run GC on demand at any time:
+  `dfsctl store block gc <share>` (add `--dry-run` to preview, capped by
+  `gc.dry_run_sample_size`; add `--reconcile` to also reap rows leaked by
+  older versions).
 - `gc.grace_period` MUST be longer than your worst-case
   metadata-commit latency after a successful PUT. The default 1h is
   comfortable for any commit path that completes in seconds.
@@ -499,7 +509,9 @@ gc:
 Env-var mapping (dot-path convention; the top-level `gc` block binds
 directly):
 `DITTOFS_GC_GRACE_PERIOD`,
-`DITTOFS_GC_DRY_RUN_SAMPLE_SIZE`.
+`DITTOFS_GC_DRY_RUN_SAMPLE_SIZE`,
+`DITTOFS_GC_AUTO_ENABLED`,
+`DITTOFS_GC_AUTO_INTERVAL`.
 
 See [ARCHITECTURE.md](../internals/architecture.md#garbage-collection-mark-sweep)
 for the full mark-sweep design and [CLI.md](cli.md) for the on-demand

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -130,8 +130,8 @@ func (c *IdentityConfig) Validate() error {
 }
 
 // GCConfig configures the engine.CollectGarbage mark-sweep run. Knobs
-// cover the grace TTL and the dry-run sample bound; GC is on-demand only
-// (dfsctl/REST) with no periodic scheduler.
+// cover the grace TTL, the dry-run sample bound, and the background
+// auto-GC schedule. GC is also runnable on demand (dfsctl/REST).
 type GCConfig struct {
 	// GracePeriod is the TTL applied during sweep: an object whose
 	// LastModified is within snapshot - GracePeriod is preserved.
@@ -142,6 +142,16 @@ type GCConfig struct {
 	// DryRunSampleSize bounds the number of candidate keys captured by a
 	// dry-run report. Defaults to 1000.
 	DryRunSampleSize int `mapstructure:"dry_run_sample_size" yaml:"dry_run_sample_size"`
+
+	// AutoEnabled turns on the background GC scheduler, which periodically
+	// reclaims orphaned blocks on both tiers without operator action.
+	// Defaults to true. Set false to require manual `dfsctl store block gc`.
+	AutoEnabled *bool `mapstructure:"auto_enabled" yaml:"auto_enabled"`
+
+	// AutoInterval is the period between background GC runs. Defaults to
+	// 15m. Values in (0, 1m) are rejected at config load. Ignored when
+	// AutoEnabled is false.
+	AutoInterval time.Duration `mapstructure:"auto_interval" yaml:"auto_interval"`
 }
 
 // ApplyDefaults fills any zero-valued field with the defaults.
@@ -152,6 +162,20 @@ func (c *GCConfig) ApplyDefaults() {
 	if c.DryRunSampleSize <= 0 {
 		c.DryRunSampleSize = 1000
 	}
+	if c.AutoEnabled == nil {
+		on := true
+		c.AutoEnabled = &on
+	}
+	// Only fill the unset (zero) case. A negative value is a user mistake and
+	// must survive to Validate, not be silently rewritten to the default.
+	if c.AutoInterval == 0 {
+		c.AutoInterval = 15 * time.Minute
+	}
+}
+
+// AutoGCEnabled reports whether background GC is on (default true when unset).
+func (c *GCConfig) AutoGCEnabled() bool {
+	return c.AutoEnabled == nil || *c.AutoEnabled
 }
 
 // Validate returns an error if the GCConfig has invalid values.
@@ -176,6 +200,12 @@ func (c *GCConfig) Validate() error {
 	}
 	if c.DryRunSampleSize < 0 {
 		return fmt.Errorf("gc.dry_run_sample_size must be >= 0 (got %d)", c.DryRunSampleSize)
+	}
+	if c.AutoInterval < 0 {
+		return fmt.Errorf("gc.auto_interval must be >= 0 (got %v)", c.AutoInterval)
+	}
+	if c.AutoInterval > 0 && c.AutoInterval < time.Minute {
+		return fmt.Errorf("gc.auto_interval must be >= 1m to avoid hammering the stores (got %v); set 0 to use the 15m default", c.AutoInterval)
 	}
 	return nil
 }

--- a/pkg/config/env_binding_test.go
+++ b/pkg/config/env_binding_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
 )
@@ -23,6 +24,32 @@ func writeConfigFile(t *testing.T, content string) string {
 // key that is NOT present in the config file — the round-1 §2.2 / round-2 §2.4
 // env-precedence-drop class. The documented precedence is env > file >
 // defaults, which only holds if every key is bound for AutomaticEnv.
+func TestLoad_GCAutoEnv_RoundTrip(t *testing.T) {
+	// Proves the *bool and Duration auto-GC knobs decode from env through Load.
+	content := `
+database:
+  type: sqlite
+controlplane:
+  jwt:
+    secret: "test-secret-key-for-testing-minimum-32-chars"
+`
+	path := writeConfigFile(t, content)
+
+	t.Setenv("DITTOFS_GC_AUTO_ENABLED", "false")
+	t.Setenv("DITTOFS_GC_AUTO_INTERVAL", "30m")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.GC.AutoGCEnabled() {
+		t.Errorf("gc.auto_enabled: env override dropped, got true want false")
+	}
+	if cfg.GC.AutoInterval != 30*time.Minute {
+		t.Errorf("gc.auto_interval: env override dropped, got %v want 30m", cfg.GC.AutoInterval)
+	}
+}
+
 func TestLoad_EnvOverride_KeyAbsentFromFile(t *testing.T) {
 	// File omits controlplane.port and logging.level entirely.
 	content := `

--- a/pkg/config/gc_auto_test.go
+++ b/pkg/config/gc_auto_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGCConfig_AutoDefaults(t *testing.T) {
+	var c GCConfig
+	c.ApplyDefaults()
+
+	if !c.AutoGCEnabled() {
+		t.Error("AutoGCEnabled() = false after defaults, want true (auto-GC on by default)")
+	}
+	if c.AutoEnabled == nil || !*c.AutoEnabled {
+		t.Errorf("AutoEnabled = %v, want non-nil true", c.AutoEnabled)
+	}
+	if c.AutoInterval != 15*time.Minute {
+		t.Errorf("AutoInterval = %v, want 15m default", c.AutoInterval)
+	}
+}
+
+func TestGCConfig_AutoDisabledRespected(t *testing.T) {
+	off := false
+	c := GCConfig{AutoEnabled: &off}
+	c.ApplyDefaults()
+
+	if c.AutoGCEnabled() {
+		t.Error("AutoGCEnabled() = true, want false when explicitly disabled")
+	}
+	// ApplyDefaults must not flip an explicit false back to true.
+	if c.AutoEnabled == nil || *c.AutoEnabled {
+		t.Errorf("ApplyDefaults overwrote explicit AutoEnabled=false: %v", c.AutoEnabled)
+	}
+}
+
+func TestGCConfig_Validate_AutoInterval(t *testing.T) {
+	cases := []struct {
+		name     string
+		interval time.Duration
+		wantErr  bool
+	}{
+		{"zero ok (uses default)", 0, false},
+		{"15m ok", 15 * time.Minute, false},
+		{"1m ok", time.Minute, false},
+		{"30s rejected", 30 * time.Second, true},
+		{"negative rejected", -time.Second, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := GCConfig{GracePeriod: time.Hour, DryRunSampleSize: 1000, AutoInterval: tc.interval}
+			err := c.Validate()
+			if tc.wantErr && err == nil {
+				t.Errorf("Validate() = nil, want error for interval %v", tc.interval)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("Validate() = %v, want nil for interval %v", err, tc.interval)
+			}
+		})
+	}
+}

--- a/pkg/controlplane/runtime/blockgc_scheduler.go
+++ b/pkg/controlplane/runtime/blockgc_scheduler.go
@@ -1,0 +1,59 @@
+package runtime
+
+import (
+	"context"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/logger"
+)
+
+// StartScheduledGC runs background garbage collection on the given interval
+// until ctx is cancelled, reclaiming orphaned blocks on both the local and
+// remote tiers without operator action (#1433). It returns immediately; the
+// loop runs in its own goroutine and exits when ctx is done (server shutdown).
+//
+// Each tick runs RunBlockGC synchronously, so runs never overlap — a long run
+// simply delays the next tick. GC is idempotent, so a tick skipped by shutdown
+// or an error is harmless; the next tick catches up.
+func (r *Runtime) StartScheduledGC(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = 15 * time.Minute
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		logger.Info("auto-GC: scheduler started", "interval", interval)
+		for {
+			select {
+			case <-ctx.Done():
+				logger.Info("auto-GC: scheduler stopped")
+				return
+			case <-ticker.C:
+				// A tick and ctx.Done() can be ready at the same time; select
+				// picks randomly. Re-check so shutdown never triggers one last run.
+				if ctx.Err() != nil {
+					logger.Info("auto-GC: scheduler stopped")
+					return
+				}
+				r.runScheduledGCOnce(ctx)
+			}
+		}
+	}()
+}
+
+// runScheduledGCOnce performs one background GC pass and logs the outcome.
+// Errors are logged, never fatal — the scheduler keeps running.
+func (r *Runtime) runScheduledGCOnce(ctx context.Context) {
+	start := time.Now()
+	stats, err := r.RunBlockGC(ctx, "", false)
+	if err != nil {
+		logger.Error("auto-GC: run failed", "err", err)
+		return
+	}
+	logger.Info("auto-GC: run complete",
+		"objectsSwept", stats.ObjectsSwept,
+		"bytesFreed", stats.BytesFreed,
+		"errors", stats.ErrorCount,
+		"durationMs", time.Since(start).Milliseconds(),
+	)
+}

--- a/pkg/controlplane/runtime/blockgc_scheduler_test.go
+++ b/pkg/controlplane/runtime/blockgc_scheduler_test.go
@@ -1,0 +1,46 @@
+package runtime
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+)
+
+// TestStartScheduledGC_TicksAndStops verifies the auto-GC scheduler runs GC on
+// its interval and exits cleanly when its context is cancelled.
+func TestStartScheduledGC_TicksAndStops(t *testing.T) {
+	var runs int32
+	orig := collectGarbageFn
+	collectGarbageFn = func(_ context.Context, _ remote.RemoteStore, _ engine.MetadataReconciler, _ *engine.Options) *engine.GCStats {
+		atomic.AddInt32(&runs, 1)
+		return &engine.GCStats{}
+	}
+	t.Cleanup(func() { collectGarbageFn = orig })
+
+	rt := newRuntimeForGC(t, map[string]remote.RemoteStore{"/share-a": &fakeRemoteStore{name: "s3"}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rt.StartScheduledGC(ctx, 10*time.Millisecond)
+
+	// Wait for a few ticks.
+	deadline := time.Now().Add(2 * time.Second)
+	for atomic.LoadInt32(&runs) < 2 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := atomic.LoadInt32(&runs); got < 2 {
+		t.Fatalf("auto-GC ran %d times, want >= 2", got)
+	}
+
+	// Cancel and confirm the loop stops (run count stops climbing).
+	cancel()
+	time.Sleep(30 * time.Millisecond)
+	stopped := atomic.LoadInt32(&runs)
+	time.Sleep(60 * time.Millisecond)
+	if after := atomic.LoadInt32(&runs); after != stopped {
+		t.Errorf("auto-GC kept running after cancel: %d -> %d", stopped, after)
+	}
+}


### PR DESCRIPTION
Part of #1433 (GC fix series, PR5/6).

## What
Background garbage collection now runs automatically on a fixed interval — operators no longer have to invoke `dfsctl store block gc` by hand. Previously GC was operator-only, which is the core reason the reporter never saw space reclaimed.

## Changes
- `pkg/config/config.go` — `GCConfig` gains `auto_enabled` (`*bool`, default **true**) and `auto_interval` (default **15m**). `ApplyDefaults` fills them; `Validate` rejects an interval in `(0, 1m)`; `AutoGCEnabled()` accessor.
- `pkg/controlplane/runtime/blockgc_scheduler.go` — `StartScheduledGC(ctx, interval)`: ticker loop → `RunBlockGC`, survives individual pass errors, exits on ctx cancel.
- `cmd/dfs/commands/start.go` — starts the scheduler at boot when enabled.
- `docs/guide/configuration.md` — documents `gc.auto_enabled` / `gc.auto_interval` + `DITTOFS_GC_AUTO_*` env vars.

## Config
```yaml
gc:
  auto_enabled: true   # default
  auto_interval: 15m   # default; (0,1m) rejected
```

## Tests
- `pkg/config/gc_auto_test.go` — defaults, validation, nil-bool handling.
- `pkg/controlplane/runtime/blockgc_scheduler_test.go` — ticker fires, cancel stops the loop.

Stacked on PR4 (#1442, merged). Auto-GC default-on confirmed with the user.