### PR TITLE
docs(gc): Garbage Collection guide + discoverability + stranded-rows metric (#1433)

### DIFF
--- a/cmd/dfsctl/commands/system/system.go
+++ b/cmd/dfsctl/commands/system/system.go
@@ -11,6 +11,10 @@ var Cmd = &cobra.Command{
 
 These commands expose low-level server controls that are not tied to a specific share or protocol. Currently available: drain-uploads, which blocks until all queued block-store uploads have completed.
 
+Note: garbage collection (reclaiming space from deleted files) is NOT here — it
+runs automatically in the background and is also available on demand via
+"dfsctl store block gc <share>" (see the Garbage Collection guide).
+
 Examples:
   # Wait for all in-flight uploads to finish (useful before benchmarking)
   dfsctl system drain-uploads`,

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -6631,6 +6631,10 @@ System-level operations for managing the DittoFS server.
 
 These commands expose low-level server controls that are not tied to a specific share or protocol. Currently available: drain-uploads, which blocks until all queued block-store uploads have completed.
 
+Note: garbage collection (reclaiming space from deleted files) is NOT here — it
+runs automatically in the background and is also available on demand via
+"dfsctl store block gc <share>" (see the Garbage Collection guide).
+
 **Examples:**
 
 ```bash

--- a/docs/guide/garbage-collection.md
+++ b/docs/guide/garbage-collection.md
@@ -1,0 +1,138 @@
+# Garbage Collection
+
+DittoFS stores file data as content-addressed **blocks** (chunks). When you delete
+a file, its directory entry disappears immediately, but the underlying blocks are
+reclaimed **asynchronously** by garbage collection (GC). GC frees space on **both**
+tiers of a share's block store:
+
+- the **local** tier (the on-disk cache, e.g. `/var/lib/dittofs/blocks`), and
+- the **remote** tier (S3 / object storage), if the share has one.
+
+A block is reclaimed only when **no live file references it** and **no snapshot
+holds it**. Blocks shared by several files (deduplication) survive until the last
+referrer is gone.
+
+## Automatic GC (default)
+
+Background GC is **on by default** — you do not need to run anything. The server
+reclaims orphaned blocks on a fixed interval:
+
+```yaml
+gc:
+  auto_enabled: true     # background GC on/off (default true)
+  auto_interval: 15m     # period between runs (default 15m; (0,1m) rejected)
+  grace_period: 1h       # blocks younger than this are never swept (default 1h)
+```
+
+(Env vars: `DITTOFS_GC_AUTO_ENABLED`, `DITTOFS_GC_AUTO_INTERVAL`,
+`DITTOFS_GC_GRACE_PERIOD`.)
+
+The **grace period** protects freshly written blocks: a block whose last
+modification is within `grace_period` is never deleted, even if it currently looks
+unreferenced. Keep it comfortably longer than your worst-case metadata-commit
+latency after a write (the 1h default is ample).
+
+Disable automatic GC (`auto_enabled: false`) only if you want to drive
+reclamation entirely on demand or via external scheduling.
+
+## Manual GC
+
+You can trigger GC at any time:
+
+```bash
+# Reclaim now (both tiers) for a share:
+dfsctl store block gc <share>
+
+# Preview only — enumerate candidates, delete nothing:
+dfsctl store block gc <share> --dry-run
+
+# See the last run's summary (objects swept, bytes freed, errors):
+dfsctl store block gc-status <share>
+```
+
+> The command lives under `dfsctl store block`, not `dfsctl system`.
+
+## Reclaiming space leaked by older versions
+
+Versions before the unlink-refcount fix could leave **stranded** block rows behind
+when files were deleted, so their blocks were never reclaimed and disk usage only
+grew. On upgrade, the server runs a **one-time reconcile** automatically (guarded by
+a per-store marker) to reap those stranded rows and reclaim the space.
+
+You can also run it on demand — recommended if an older deployment accumulated a
+large backlog:
+
+```bash
+# Server-wide: reap stranded rows, then sweep both tiers.
+dfsctl store block gc <share> --reconcile
+
+# Preview the reconcile first:
+dfsctl store block gc <share> --reconcile --dry-run
+```
+
+A reconcile run reports how many rows it reaped as `stranded_rows_reaped` — visible in
+`dfsctl store block gc <share> --reconcile -o json` (under `stats.stranded_rows_reaped`),
+in the Prometheus counter `dittofs_gc_stranded_rows_reaped_total`, and in the server log
+(`INFO RunBlockGCReconcile: complete`).
+
+## Retention and pinning
+
+A share's `retention` policy controls the **local cache**, not GC of orphans:
+
+- `retention: pin` keeps *referenced* blocks on local disk indefinitely (no cache
+  eviction). It does **not** protect *orphaned* blocks — GC still reclaims blocks
+  that no live file or snapshot references, on both tiers, regardless of `pin`.
+- Other retention policies additionally let the local cache evict cold *referenced*
+  blocks under disk pressure (they can be refetched from the remote tier).
+
+So under `retention: pin`, deleting files **does** free space once GC runs — pin
+only affects whether *live* data stays cached locally.
+
+## Snapshots
+
+GC never deletes a block held by a snapshot. Snapshot holds are derived from each
+snapshot's file manifests, independently of the live file set, so taking a snapshot
+pins its blocks until the snapshot is deleted. See [Snapshots](snapshots.md).
+
+## Trash (recycle bin)
+
+If a share has the [trash](configuration.md#8-shares-exports) feature enabled
+(`--enable-trash`, **off by default**), deleting a file **moves it to `#recycle`**
+rather than removing it — its blocks stay referenced and are **not** GC-eligible.
+Blocks are reclaimed only after the file leaves the trash:
+
+```
+delete file → moved to #recycle (blocks retained) → empty trash → real delete → GC reclaims
+```
+
+```bash
+dfsctl trash status <share>    # items + bytes held in the recycle bin
+dfsctl trash empty <share>     # purge — makes the blocks GC-eligible
+dfsctl trash restore <share> <id>
+```
+
+## Monitoring
+
+GC health is exported on the Prometheus endpoint (see
+[Configuration § Metrics](configuration.md)):
+
+| Metric | Meaning |
+| --- | --- |
+| `dittofs_gc_runs_total{result}` | GC passes, labelled `ok`/`error` |
+| `dittofs_gc_running` | passes currently in flight (0 when idle) |
+| `dittofs_gc_swept_objects_total` | objects reclaimed across both tiers |
+| `dittofs_gc_freed_bytes_total` | bytes reclaimed across both tiers |
+| `dittofs_gc_duration_seconds` | per-pass duration histogram |
+| `dittofs_gc_last_run_timestamp_seconds` | wall-clock of the last completed pass |
+| `dittofs_gc_stranded_rows_reaped_total` | rows reaped by reconcile/migration runs |
+
+A `gc_last_run_timestamp_seconds` that stops advancing means the scheduler is wedged
+or disabled; a climbing `gc_runs_total{result="error"}` means passes are failing —
+check the server logs.
+
+## Related
+
+- [Configuration § GC](configuration.md) — every knob and env var.
+- [FAQ](faq.md) — common questions about reclamation timing.
+- [Architecture: mark-sweep](../internals/architecture.md#garbage-collection-mark-sweep)
+  — the internal design.

--- a/pkg/controlplane/runtime/blockgc_reconcile.go
+++ b/pkg/controlplane/runtime/blockgc_reconcile.go
@@ -56,6 +56,13 @@ func (r *Runtime) RunBlockGCReconcile(ctx context.Context, dryRun bool) (*engine
 	// sweeps the remote tier and (since #1433) the local tier too, reclaiming
 	// the now-orphaned chunks under the usual grace + snapshot-hold guards.
 	sweep, err := r.RunBlockGC(ctx, "", dryRun)
+	// Record reaped rows regardless of the sweep result: the rows are already
+	// deleted from the metadata store, so the counter must reflect that even if
+	// the downstream sweep (e.g. S3 unreachable) then fails. Skip on dry-run —
+	// there the count is rows that *would* be reaped, nothing was deleted.
+	if !dryRun {
+		r.metrics.RecordGCStrandedRows(total.StrandedRowsReaped)
+	}
 	if err != nil {
 		return total, err
 	}

--- a/pkg/metrics/instruments.go
+++ b/pkg/metrics/instruments.go
@@ -36,6 +36,7 @@ type instruments struct {
 	gcSweptObjects prometheus.Counter
 	gcFreedBytes   prometheus.Counter
 	gcDurationSecs prometheus.Histogram
+	gcStrandedRows prometheus.Counter
 
 	// Snapshot / restore (subsystem "snapshot"). Only the event-driven
 	// operation count + duration live here; the held-snapshot count
@@ -131,6 +132,10 @@ func newInstruments(reg *prometheus.Registry) *instruments {
 			Help:    "Block-store GC pass duration, in seconds.",
 			Buckets: prometheus.DefBuckets,
 		}),
+		gcStrandedRows: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace, Subsystem: "gc", Name: "stranded_rows_reaped_total",
+			Help: "FileBlock rows reaped by GC reconcile/migration runs (rows whose owning file was already gone).",
+		}),
 
 		snapOps: factory(prometheus.CounterOpts{
 			Namespace: Namespace, Subsystem: "snapshot", Name: "operations_total",
@@ -177,7 +182,7 @@ func newInstruments(reg *prometheus.Registry) *instruments {
 	reg.MustRegister(
 		in.requests, in.reqDuration, in.connsTotal, in.connsClosed, in.authAttempts, in.authFailures,
 		in.backpressureTotal, in.backpressureWaitSeconds, in.evictionsTotal, in.evictedBytesTotal,
-		in.gcRuns, in.gcRunning, in.gcLastRunTime, in.gcSweptObjects, in.gcFreedBytes, in.gcDurationSecs,
+		in.gcRuns, in.gcRunning, in.gcLastRunTime, in.gcSweptObjects, in.gcFreedBytes, in.gcDurationSecs, in.gcStrandedRows,
 		in.snapOps, in.snapDuration,
 		in.uploadsTotal, in.uploadDuration, in.uploadBytes, in.uploadsInflight,
 		in.uploadQueueDepth, in.uploadWindow, in.rehashDuration,
@@ -278,6 +283,15 @@ func (m *Metrics) GCFinished(result string, sweptObjects, freedBytes int64, d ti
 	}
 	m.in.gcDurationSecs.Observe(d.Seconds())
 	m.in.gcLastRunTime.Set(float64(time.Now().Unix()))
+}
+
+// RecordGCStrandedRows adds to the count of FileBlock rows reaped by a GC
+// reconcile/migration pass. No-op for n <= 0.
+func (m *Metrics) RecordGCStrandedRows(n int64) {
+	if m == nil || n <= 0 {
+		return
+	}
+	m.in.gcStrandedRows.Add(float64(n))
 }
 
 // RecordSnapshotOp records one snapshot operation: its count (by op and result)


### PR DESCRIPTION
Final part of #1433 (GC fix series, PR6/6).

## What
Documentation + monitoring + discoverability for the now-working GC.

## Changes
- **`docs/guide/garbage-collection.md`** (new) — full GC guide: both tiers (local fs + remote S3), automatic vs manual, `--reconcile` migration for space leaked by older versions, `retention: pin` vs orphan semantics, snapshot + trash interaction, and a Prometheus metrics table.
- **`pkg/metrics/instruments.go`** — new counter `dittofs_gc_stranded_rows_reaped_total` + `RecordGCStrandedRows(n int64)` (nil-safe, ignores n<=0).
- **`pkg/controlplane/runtime/blockgc_reconcile.go`** — records the counter after a reconcile. Emitted even if the subsequent sweep fails, since the rows are already reaped (review fix).
- **`cmd/dfsctl/commands/system/system.go`** — Long text points operators to `dfsctl store block gc` (the reporter looked under `dfsctl system` and never found GC).
- `docs/guide/cli.md` regenerated.

## Review fixes (PR6 code-reviewer)
- Metric emitted regardless of sweep error (was undercounting when S3 unreachable mid-sweep).
- Corrected `garbage-collection.md`: `stranded_rows_reaped` is surfaced via `gc --reconcile -o json` / Prometheus / server log, not `gc-status`.

Stacked on PR5 (#1443, merged). Closes the operator-facing gaps of #1433; the issue's behavioural fix shipped in PR1/PR2/PR4.