### PR TITLE
fix(gc): exclude unlinked (nlink=0) inodes from the GC live set (#1433)

### DIFF
--- a/pkg/controlplane/runtime/blockgc_reconcile.go
+++ b/pkg/controlplane/runtime/blockgc_reconcile.go
@@ -15,7 +15,10 @@ import (
 // re-run on upgrade if a future fix needs another pass.
 const (
 	reconcileMarkerKey = "gc.stranded_rows_reconciled_version"
-	reconcileVersion   = 1
+	// v2 (#1433): EnumerateLivePayloadIDs now excludes nlink=0 inodes, so the
+	// reconcile reaps stranded file_blocks rows left by pre-fix unlinks. Bumping
+	// the version forces one more startup pass on stores last reconciled at v1.
+	reconcileVersion = 2
 )
 
 // RunBlockGCReconcile reaps stranded file_blocks rows — rows whose owning inode

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -408,15 +408,25 @@ type Store interface {
 	EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error
 
 	// EnumerateLivePayloadIDs streams every distinct PayloadID referenced by a
-	// live inode through fn (deduped, order-independent). "Live" includes
-	// nlink=0 inodes (open-but-unlinked files whose blocks are still in use),
-	// since their inode rows still exist. Unlike EnumeratePayloads — which
-	// reads file_blocks and therefore also yields payloads whose owning file is
-	// already gone (stranded rows) — this reads the namespace, so the set
-	// difference (EnumeratePayloads − EnumerateLivePayloadIDs) is exactly the
-	// stranded payloads the GC reconcile must reap (#1433). Implementations
-	// MUST drain the result set before invoking fn (collect-then-call) and
-	// honor ctx.Done() throughout.
+	// live inode through fn (deduped, order-independent). "Live" means nlink>0:
+	// nlink=0 (unlinked) inodes are EXCLUDED (#1433) — the file is dead, so its
+	// payload must be reclaimable, not pinned forever. Unlike EnumeratePayloads
+	// — which reads file_blocks and therefore also yields payloads whose owning
+	// file is already gone (stranded rows) — this reads the namespace, so the
+	// set difference (EnumeratePayloads − EnumerateLivePayloadIDs) is exactly the
+	// stranded payloads the GC reconcile must reap. Use the authoritative link
+	// count (SQL inodes.nlink, badger l: key, memory linkCounts), not the
+	// embedded File.Nlink.
+	//
+	// Open-but-unlinked caveat: DittoFS does not retain a file's data while it is
+	// held open after unlink (NFSv4 REMOVE drops the link immediately; SMB
+	// unlinks at last close), so excluding nlink=0 here does not break an
+	// existing guarantee. The GC grace period is the safety window for any
+	// in-flight reader; a proper open-handle GC hold (to support long-lived
+	// open-unlinked reads beyond grace) is future work.
+	//
+	// Implementations MUST drain the result set before invoking fn
+	// (collect-then-call) and honor ctx.Done() throughout.
 	EnumerateLivePayloadIDs(ctx context.Context, fn func(payloadID string) error) error
 
 	// ========================================================================

--- a/pkg/metadata/store/badger/backup.go
+++ b/pkg/metadata/store/badger/backup.go
@@ -125,6 +125,16 @@ func (s *BadgerMetadataStore) Backup(ctx context.Context, w io.Writer) (*block.H
 						"key", string(key), "error", err)
 					continue
 				}
+				// Skip unlinked (nlink=0) files: they are dead and GC may have
+				// already reclaimed their blocks, so adding them would make the
+				// snapshot manifest reference hashes absent from remote and fail
+				// the durability verify (#1433). Use the authoritative link count
+				// (l: key), not the embedded File.Nlink which SetLinkCount does
+				// not rewrite. The raw f: record is still dumped verbatim above so
+				// a restore stays consistent (the file remains nlink=0, invisible).
+				if fileLinkCountTxn(txn, &file) == 0 {
+					continue
+				}
 				for _, br := range file.Blocks {
 					hs.Add(br.Hash)
 				}

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -681,15 +681,23 @@ func enumeratePrefixFileBlocks(ctx context.Context, txn *badger.Txn, fn func(blo
 // key, not the embedded File.Nlink, so the embedded value alone is unreliable;
 // fall back to it only when the l: key is absent.
 func fileLinkCountTxn(txn *badger.Txn, file *metadata.File) uint32 {
-	nlink := file.Nlink
-	if item, err := txn.Get(keyLinkCount(file.ID)); err == nil {
-		_ = item.Value(func(val []byte) error {
-			if c, derr := decodeUint32(val); derr == nil {
-				nlink = c
-			}
-			return nil
-		})
+	item, err := txn.Get(keyLinkCount(file.ID))
+	if err != nil {
+		// No l: key yet: mirror GetFile's default-by-type so a freshly created
+		// file (link count not persisted yet) is never treated as dead. The
+		// embedded File.Nlink may be zero/stale and must NOT be trusted here.
+		if file.Type == metadata.FileTypeDirectory {
+			return 2
+		}
+		return 1
 	}
+	nlink := file.Nlink
+	_ = item.Value(func(val []byte) error {
+		if c, derr := decodeUint32(val); derr == nil {
+			nlink = c
+		}
+		return nil
+	})
 	return nlink
 }
 

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -411,8 +411,8 @@ func (s *BadgerMetadataStore) ListFileBlocks(_ context.Context, payloadID string
 // inode. It scans the f: inode keyspace, decodes each file record, and collects
 // distinct non-empty PayloadIDs. Corrupt inode records are skipped so a single
 // bad row cannot block the reconcile. Hardlinks share one f: key, so DISTINCT
-// yields one payloadID per content; nlink=0 inodes still have their key and are
-// reported live.
+// yields one payloadID per content. nlink=0 (unlinked) inodes are excluded
+// (#1433): their payload is dead, so the reconcile treats it as stranded.
 func (s *BadgerMetadataStore) EnumerateLivePayloadIDs(ctx context.Context, fn func(payloadID string) error) error {
 	seen := make(map[string]struct{})
 	err := s.db.View(func(txn *badger.Txn) error {
@@ -433,6 +433,9 @@ func (s *BadgerMetadataStore) EnumerateLivePayloadIDs(ctx context.Context, fn fu
 					// Skip corrupt inode rows rather than fail-closed: a single
 					// bad row must not block reclaiming everything else.
 					return nil
+				}
+				if fileLinkCountTxn(txn, file) == 0 {
+					return nil // unlinked: payload is dead, not live (#1433)
 				}
 				if pid := string(file.PayloadID); pid != "" {
 					seen[pid] = struct{}{}
@@ -653,6 +656,17 @@ func enumeratePrefixFileBlocks(ctx context.Context, txn *badger.Txn, fn func(blo
 		}); err != nil {
 			return fmt.Errorf("enumerate file blocks: decode file: %w", err)
 		}
+		// nlink=0 (unlinked) inodes keep their f: record but the file is dead.
+		// Excluding their manifest blocks from the GC live set is what lets the
+		// sweep reclaim orphaned chunks (#1433). Snapshot-held blocks are
+		// protected independently by the GC HoldProvider, not by this manifest.
+		// The authoritative link count lives in the l: key (#1166), not the
+		// embedded File.Nlink (which SetLinkCount does not rewrite); read it the
+		// same way GetFile overlays it, falling back to the embedded value when
+		// the l: key is absent.
+		if fileLinkCountTxn(txn, file) == 0 {
+			continue
+		}
 		for _, br := range file.Blocks {
 			if err := fn(br.Hash); err != nil {
 				return err
@@ -660,6 +674,23 @@ func enumeratePrefixFileBlocks(ctx context.Context, txn *badger.Txn, fn func(blo
 		}
 	}
 	return nil
+}
+
+// fileLinkCountTxn returns the authoritative link count for a file, reading the
+// l: key (#1166) the same way GetFile overlays it. SetLinkCount writes the l:
+// key, not the embedded File.Nlink, so the embedded value alone is unreliable;
+// fall back to it only when the l: key is absent.
+func fileLinkCountTxn(txn *badger.Txn, file *metadata.File) uint32 {
+	nlink := file.Nlink
+	if item, err := txn.Get(keyLinkCount(file.ID)); err == nil {
+		_ = item.Value(func(val []byte) error {
+			if c, derr := decodeUint32(val); derr == nil {
+				nlink = c
+			}
+			return nil
+		})
+	}
+	return nlink
 }
 
 // splitBlockID splits a block ID into (payloadID, blockIdx) on the LAST

--- a/pkg/metadata/store/memory/backup.go
+++ b/pkg/metadata/store/memory/backup.go
@@ -179,10 +179,18 @@ func (s *MemoryMetadataStore) Backup(ctx context.Context, w io.Writer) (*block.H
 		}
 	}
 
-	// Extract every unique block hash into a HashSet.
+	// Extract every unique block hash into a HashSet. Skip unlinked (nlink=0)
+	// files: they are dead and GC may have already reclaimed their blocks, so
+	// adding them would make the snapshot manifest reference hashes absent from
+	// remote and fail the durability verify (#1433). The authoritative link
+	// count is the linkCounts map, not the embedded fd.Attr.Nlink which
+	// SetLinkCount does not rewrite; a missing entry is treated as live.
 	hs := block.NewHashSet(len(s.files))
-	for _, fd := range s.files {
+	for key, fd := range s.files {
 		if fd.Attr == nil {
+			continue
+		}
+		if n, ok := s.linkCounts[key]; ok && n == 0 {
 			continue
 		}
 		for _, br := range fd.Attr.Blocks {

--- a/pkg/metadata/store/memory/objects.go
+++ b/pkg/metadata/store/memory/objects.go
@@ -143,14 +143,17 @@ func (s *MemoryMetadataStore) ListFileBlocks(ctx context.Context, payloadID stri
 // EnumerateLivePayloadIDs streams every distinct PayloadID referenced by a
 // live inode. It snapshots the distinct PayloadIDs under the read lock, then
 // calls fn per payloadID. Hardlinks share one fileData entry, so DISTINCT
-// yields one payloadID per content; nlink=0 inodes still have their entry and
-// are reported live.
+// yields one payloadID per content. nlink=0 (unlinked) inodes are excluded
+// (#1433): their payload is dead, so the reconcile treats it as stranded.
 func (s *MemoryMetadataStore) EnumerateLivePayloadIDs(ctx context.Context, fn func(payloadID string) error) error {
 	seen := make(map[string]struct{})
 	s.mu.RLock()
-	for _, fd := range s.files {
+	for key, fd := range s.files {
 		if fd == nil || fd.Attr == nil {
 			continue
+		}
+		if n, ok := s.linkCounts[key]; ok && n == 0 {
+			continue // unlinked: payload is dead, not live (#1433)
 		}
 		if pid := string(fd.Attr.PayloadID); pid != "" {
 			seen[pid] = struct{}{}
@@ -228,9 +231,18 @@ func (s *MemoryMetadataStore) snapshotBlockHashesLocked() []block.ContentHash {
 		}
 	}
 	// Union the per-file manifest (File.Blocks). Duplicates across the two
-	// structures are harmless — GCState.Add deduplicates the live set.
-	for _, fd := range s.files {
+	// structures are harmless — GCState.Add deduplicates the live set. nlink=0
+	// (unlinked) inodes keep their entry but the file is dead, so their manifest
+	// blocks are excluded (#1433): including them would pin orphaned chunks live
+	// forever. Snapshot-held blocks are protected separately by the GC
+	// HoldProvider, not by this manifest. The authoritative link count is the
+	// linkCounts map (#1166), not the embedded fd.Attr.Nlink (which SetLinkCount
+	// does not rewrite); a missing entry is treated as live (fail-closed).
+	for key, fd := range s.files {
 		if fd == nil || fd.Attr == nil {
+			continue
+		}
+		if n, ok := s.linkCounts[key]; ok && n == 0 {
 			continue
 		}
 		for _, br := range fd.Attr.Blocks {

--- a/pkg/metadata/store/postgres/backup.go
+++ b/pkg/metadata/store/postgres/backup.go
@@ -193,7 +193,10 @@ func backupTable(ctx context.Context, raw *pgconn.PgConn, envW io.Writer, table 
 // by hex digits. Each line is one hash value.
 func extractHashes(ctx context.Context, raw *pgconn.PgConn) (*block.HashSet, error) {
 	var hashBuf bytes.Buffer
-	sql := `COPY (SELECT DISTINCT hash FROM file_block_refs) TO STDOUT WITH (FORMAT csv)`
+	// Exclude unlinked (nlink=0) files: they are dead and GC may have already
+	// reclaimed their blocks, so a manifest listing them would reference hashes
+	// absent from remote and fail the snapshot durability verify (#1433).
+	sql := `COPY (SELECT DISTINCT fbr.hash FROM file_block_refs fbr JOIN inodes i ON fbr.file_id = i.id WHERE i.nlink > 0) TO STDOUT WITH (FORMAT csv)`
 	if _, err := raw.CopyTo(ctx, &hashBuf, sql); err != nil {
 		return nil, fmt.Errorf("COPY hash query: %w", err)
 	}

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -312,11 +312,13 @@ func (s *PostgresMetadataStore) ListFileBlocks(ctx context.Context, payloadID st
 // enumerateHashesQuery is the GC mark live-set query. It UNIONs the CAS index
 // (file_blocks.hash, VARCHAR hex) with the per-file manifest
 // (file_block_refs.hash, BYTEA → encode hex) so the live set is a strict
-// SUPERSET of both structures. The snapshot Backup HashSet is built from
-// file_block_refs alone (File.Blocks); without the union a hash present only in
-// file_block_refs (e.g. a manifest row whose CAS index row was never written or
-// already reaped) would be absent from the live set and the GC sweep would reap
-// the still-live remote chunk once a snapshot hold lapsed (data loss). NULL
+// SUPERSET of both structures, so a hash present in only one (e.g. a manifest
+// row whose CAS index row was never written or already reaped) still keeps its
+// chunk live. The manifest arm is filtered to nlink>0 inodes (#1433): once a
+// file is unlinked its manifest rows linger but the payload is dead, so
+// including them would pin orphaned chunks live forever and the sweep could
+// never reclaim them. Snapshot-held blocks are protected independently by the
+// GC HoldProvider (on-disk snapshot manifests), not by this union. NULL
 // hashes (legacy pre-CAS file_blocks rows) are emitted as the zero ContentHash
 // and skipped by the mark phase; file_block_refs.hash is NOT NULL.
 //
@@ -325,7 +327,9 @@ func (s *PostgresMetadataStore) ListFileBlocks(ctx context.Context, payloadID st
 // expensive sort/hash-aggregate to dedupe at the query layer for no benefit.
 const enumerateHashesQuery = `SELECT hash FROM file_blocks
 UNION ALL
-SELECT encode(hash, 'hex') FROM file_block_refs`
+SELECT encode(fbr.hash, 'hex') FROM file_block_refs fbr
+JOIN inodes i ON fbr.file_id = i.id
+WHERE i.nlink > 0`
 
 // EnumeratePayloads streams every distinct payloadID that has at least one
 // FileBlock row through fn. FileBlock row IDs have the form
@@ -369,10 +373,11 @@ func (s *PostgresMetadataStore) EnumeratePayloads(ctx context.Context, fn func(p
 
 // EnumerateLivePayloadIDs streams every distinct content_id referenced by a
 // live inode. content_id IS the payloadID. Hardlinks share one inode row, so
-// DISTINCT yields one payloadID per content regardless of link count; nlink=0
-// (open-but-unlinked) inodes still have their row and are reported live.
+// DISTINCT yields one payloadID per content regardless of link count. nlink=0
+// (unlinked) inodes are excluded (#1433): their payload is dead, so the
+// reconcile must treat it as stranded, not live.
 func (s *PostgresMetadataStore) EnumerateLivePayloadIDs(ctx context.Context, fn func(payloadID string) error) error {
-	const query = `SELECT DISTINCT content_id FROM inodes WHERE content_id IS NOT NULL AND content_id != ''`
+	const query = `SELECT DISTINCT content_id FROM inodes WHERE content_id IS NOT NULL AND content_id != '' AND nlink > 0`
 	ids, err := s.collectFileBlockIDs(ctx, query)
 	if err != nil {
 		return err

--- a/pkg/metadata/store/sqlite/backup.go
+++ b/pkg/metadata/store/sqlite/backup.go
@@ -180,7 +180,12 @@ func backupTable(ctx context.Context, tx *sql.Tx, w io.Writer, table string) err
 // extractHashes collects the distinct content hashes referenced by
 // file_block_refs so the caller can pin the corresponding blocks.
 func extractHashes(ctx context.Context, tx *sql.Tx) (*block.HashSet, error) {
-	rows, err := tx.QueryContext(ctx, `SELECT DISTINCT hash FROM file_block_refs`)
+	// Exclude unlinked (nlink=0) files: they are dead and GC may have already
+	// reclaimed their blocks, so a manifest listing them would reference hashes
+	// absent from remote and fail the snapshot durability verify (#1433).
+	rows, err := tx.QueryContext(ctx, `SELECT DISTINCT fbr.hash FROM file_block_refs fbr
+JOIN inodes i ON fbr.file_id = i.id
+WHERE i.nlink > 0`)
 	if err != nil {
 		return nil, fmt.Errorf("query hashes: %w", err)
 	}

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -311,11 +311,13 @@ func (s *SQLiteMetadataStore) ListFileBlocks(ctx context.Context, payloadID stri
 // enumerateHashesQuery is the GC mark live-set query. It UNIONs the CAS index
 // (file_blocks.hash, VARCHAR hex) with the per-file manifest
 // (file_block_refs.hash, BYTEA → encode hex) so the live set is a strict
-// SUPERSET of both structures. The snapshot Backup HashSet is built from
-// file_block_refs alone (File.Blocks); without the union a hash present only in
-// file_block_refs (e.g. a manifest row whose CAS index row was never written or
-// already reaped) would be absent from the live set and the GC sweep would reap
-// the still-live remote chunk once a snapshot hold lapsed (data loss). NULL
+// SUPERSET of both structures, so a hash present in only one (e.g. a manifest
+// row whose CAS index row was never written or already reaped) still keeps its
+// chunk live. The manifest arm is filtered to nlink>0 inodes (#1433): once a
+// file is unlinked its manifest rows linger but the payload is dead, so
+// including them would pin orphaned chunks live forever and the sweep could
+// never reclaim them. Snapshot-held blocks are protected independently by the
+// GC HoldProvider (on-disk snapshot manifests), not by this union. NULL
 // hashes (legacy pre-CAS file_blocks rows) are emitted as the zero ContentHash
 // and skipped by the mark phase; file_block_refs.hash is NOT NULL.
 //
@@ -324,7 +326,9 @@ func (s *SQLiteMetadataStore) ListFileBlocks(ctx context.Context, payloadID stri
 // expensive sort/hash-aggregate to dedupe at the query layer for no benefit.
 const enumerateHashesQuery = `SELECT hash FROM file_blocks
 UNION ALL
-SELECT lower(hex(hash)) FROM file_block_refs`
+SELECT lower(hex(fbr.hash)) FROM file_block_refs fbr
+JOIN inodes i ON fbr.file_id = i.id
+WHERE i.nlink > 0`
 
 // EnumeratePayloads streams every distinct payloadID that has at least one
 // FileBlock row through fn. FileBlock row IDs have the form
@@ -370,10 +374,10 @@ func (s *SQLiteMetadataStore) EnumeratePayloads(ctx context.Context, fn func(pay
 // EnumerateLivePayloadIDs streams every distinct content_id referenced by a
 // live inode. content_id IS the payloadID, so no id-splitting is needed.
 // Hardlinks share one inode row, so DISTINCT yields one payloadID regardless of
-// link count; nlink=0 (open-but-unlinked) inodes still have their row and are
-// correctly reported live.
+// link count. nlink=0 (unlinked) inodes are excluded (#1433): their payload is
+// dead, so the reconcile must treat it as stranded, not live.
 func (s *SQLiteMetadataStore) EnumerateLivePayloadIDs(ctx context.Context, fn func(payloadID string) error) error {
-	const query = `SELECT DISTINCT content_id FROM inodes WHERE content_id IS NOT NULL AND content_id != ''`
+	const query = `SELECT DISTINCT content_id FROM inodes WHERE content_id IS NOT NULL AND content_id != '' AND nlink > 0`
 	ids, err := s.collectFileBlockIDs(ctx, query)
 	if err != nil {
 		return err

--- a/pkg/metadata/storetest/backup_conformance.go
+++ b/pkg/metadata/storetest/backup_conformance.go
@@ -69,6 +69,10 @@ func RunBackupConformanceSuite(t *testing.T, factory BackupableStoreFactory) {
 		testBackup_LiveSetUnionsManifestNegativeControl(t, factory)
 	})
 
+	t.Run("ExcludesUnlinkedFileBlocks", func(t *testing.T) {
+		testBackup_ExcludesUnlinkedFileBlocks(t, factory)
+	})
+
 	t.Run("UsedBytesAfterRestore", func(t *testing.T) {
 		testBackup_UsedBytesAfterRestore(t, factory)
 	})
@@ -194,6 +198,55 @@ func testBackup_LiveSetUnionsManifestNegativeControl(t *testing.T, factory Backu
 	}
 	if !found {
 		t.Errorf("manifest-only hash %s absent from EnumerateFileBlocks; the live set must UNION File.Blocks with the CAS index, else GC reaps the chunk", manifestOnly)
+	}
+}
+
+// testBackup_ExcludesUnlinkedFileBlocks proves the snapshot manifest HashSet
+// excludes blocks of unlinked (nlink=0) files. Since GC now reclaims a deleted
+// file's blocks from remote (#1433), a manifest that still listed them would
+// reference hashes absent from remote and fail the snapshot durability verify.
+func testBackup_ExcludesUnlinkedFileBlocks(t *testing.T, factory BackupableStoreFactory) {
+	store := factory(t)
+	b := asBackupable(t, store)
+	ctx := t.Context()
+
+	shareName := "unlinked-bkp"
+	root := createTestShare(t, store, shareName)
+	h := createTestFile(t, store, shareName, root, "dead.bin", 0o644)
+
+	dead := hashOfSeed("backup-unlinked-hash")
+	f, err := store.GetFile(ctx, h)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	f.Blocks = []block.BlockRef{{Hash: dead, Offset: 0, Size: 4 << 20}}
+	f.Size = 4 << 20
+	if err := store.PutFile(ctx, f); err != nil {
+		t.Fatalf("PutFile: %v", err)
+	}
+
+	// Baseline: a live file's block IS in the manifest.
+	hs, err := b.Backup(ctx, io.Discard)
+	if err != nil {
+		t.Fatalf("Backup (linked): %v", err)
+	}
+	if !hs.Contains(dead) {
+		t.Fatalf("baseline: hash %s absent from backup manifest while nlink>0", dead)
+	}
+
+	// Unlink -> nlink=0; its block must leave the manifest.
+	if err := store.DeleteChild(ctx, root, "dead.bin"); err != nil {
+		t.Fatalf("DeleteChild: %v", err)
+	}
+	if err := store.SetLinkCount(ctx, h, 0); err != nil {
+		t.Fatalf("SetLinkCount(0): %v", err)
+	}
+	hs, err = b.Backup(ctx, io.Discard)
+	if err != nil {
+		t.Fatalf("Backup (unlinked): %v", err)
+	}
+	if hs.Contains(dead) {
+		t.Errorf("hash %s still in backup manifest after unlink (nlink=0); GC may have reclaimed it from remote, so the snapshot durability verify would fail (#1433)", dead)
 	}
 }
 

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -139,6 +139,19 @@ func runFileBlockOpsTests(t *testing.T, factory StoreFactory) {
 		testEnumerateLivePayloadIDs(t, factory)
 	})
 
+	// The GC mark live set unions the CAS index with the per-file manifest, but
+	// a manifest on an nlink=0 (unlinked) inode is dead and must NOT keep its
+	// chunks live — else GC can never reclaim deleted files (#1433).
+	t.Run("EnumerateFileBlocks_UnlinkedFileExcludesManifest", func(t *testing.T) {
+		testEnumerateFileBlocks_UnlinkedFileExcludesManifest(t, factory)
+	})
+	t.Run("EnumerateFileBlocks_HardLinkSurvivesOneRemoval", func(t *testing.T) {
+		testEnumerateFileBlocks_HardLinkSurvivesOneRemoval(t, factory)
+	})
+	t.Run("EnumerateLivePayloadIDs_ExcludesNlinkZero", func(t *testing.T) {
+		testEnumerateLivePayloadIDs_ExcludesNlinkZero(t, factory)
+	})
+
 	// IncrementRefCount / DecrementRefCount called via a
 	// metadata.Transaction MUST roll back when the wrapping WithTransaction
 	// returns an error. All backends — memory, badger, postgres — honor the
@@ -1534,4 +1547,151 @@ func seedStrandedBlocks(t *testing.T, ctx context.Context, store metadata.Store,
 			t.Fatalf("Put(%s): %v", b.ID, err)
 		}
 	}
+}
+
+// testEnumerateFileBlocks_UnlinkedFileExcludesManifest proves that once a file
+// is unlinked (nlink=0) its manifest blocks leave the GC mark live set, so the
+// sweep can reclaim the orphaned chunks. This is the core of the #1433 fix: the
+// manifest (file_block_refs / f: File.Blocks) lingers on the nlink=0 inode, but
+// the file is dead and must not pin its chunks live.
+func testEnumerateFileBlocks_UnlinkedFileExcludesManifest(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	shareName := "nlink0-exclude"
+	root := createTestShare(t, store, shareName)
+	h := createTestFile(t, store, shareName, root, "dead.bin", 0o644)
+
+	want := hashOfSeed("nlink0-manifest-hash")
+	f, err := store.GetFile(ctx, h)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	f.Blocks = []block.BlockRef{{Hash: want, Offset: 0, Size: 4 << 20}}
+	f.Size = 4 << 20
+	if err := store.PutFile(ctx, f); err != nil {
+		t.Fatalf("PutFile (linked): %v", err)
+	}
+	if !enumerateContains(t, store, want) {
+		t.Fatalf("baseline: hash %s absent from live set while nlink>0", want)
+	}
+
+	// Unlink: drop the dir edge and set nlink=0 (what RemoveFile does on the last
+	// link). nlink is the link-count source of truth across all backends, so
+	// SetLinkCount is the faithful simulation — mutating File.Nlink + PutFile is
+	// ignored by the SQL backends, which recompute nlink from the structure.
+	if err := store.DeleteChild(ctx, root, "dead.bin"); err != nil {
+		t.Fatalf("DeleteChild: %v", err)
+	}
+	if err := store.SetLinkCount(ctx, h, 0); err != nil {
+		t.Fatalf("SetLinkCount(0): %v", err)
+	}
+	if enumerateContains(t, store, want) {
+		t.Errorf("hash %s still in GC live set after unlink (nlink=0); its manifest must be excluded so the sweep can reclaim it (#1433)", want)
+	}
+}
+
+// testEnumerateFileBlocks_HardLinkSurvivesOneRemoval guards against an
+// over-eager exclusion: a file with two hard links that loses one (nlink 2→1)
+// is still alive, so its blocks MUST remain in the live set.
+func testEnumerateFileBlocks_HardLinkSurvivesOneRemoval(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	shareName := "hardlink-survive"
+	root := createTestShare(t, store, shareName)
+	h := createTestFile(t, store, shareName, root, "shared.bin", 0o644)
+
+	want := hashOfSeed("hardlink-hash")
+	f, err := store.GetFile(ctx, h)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	f.Blocks = []block.BlockRef{{Hash: want, Offset: 0, Size: 4 << 20}}
+	f.Size = 4 << 20
+	if err := store.PutFile(ctx, f); err != nil {
+		t.Fatalf("PutFile: %v", err)
+	}
+	// Two hard links.
+	if err := store.SetLinkCount(ctx, h, 2); err != nil {
+		t.Fatalf("SetLinkCount(2): %v", err)
+	}
+	if !enumerateContains(t, store, want) {
+		t.Fatalf("baseline: hash %s absent from live set while nlink=2", want)
+	}
+
+	// Remove one link: nlink 2→1, still alive.
+	if err := store.SetLinkCount(ctx, h, 1); err != nil {
+		t.Fatalf("SetLinkCount(1): %v", err)
+	}
+	if !enumerateContains(t, store, want) {
+		t.Errorf("hash %s dropped from live set at nlink=1; a still-linked file's blocks must stay live", want)
+	}
+}
+
+// testEnumerateLivePayloadIDs_ExcludesNlinkZero proves the reconcile live-set
+// query also excludes nlink=0 inodes, so their payload is classified stranded
+// (and its pre-fix file_blocks rows get reaped on upgrade).
+func testEnumerateLivePayloadIDs_ExcludesNlinkZero(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	shareName := "livepayload-nlink0"
+	root := createTestShare(t, store, shareName)
+	h := createTestFile(t, store, shareName, root, "payload.bin", 0o644)
+
+	const payloadID = "pl-nlink0-dead"
+	f, err := store.GetFile(ctx, h)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	f.PayloadID = payloadID
+	if err := store.PutFile(ctx, f); err != nil {
+		t.Fatalf("PutFile (linked): %v", err)
+	}
+	if !livePayloadContains(t, store, payloadID) {
+		t.Fatalf("baseline: payload %s absent from live payloads while nlink>0", payloadID)
+	}
+
+	// Unlink → nlink=0; the payload is now dead and must not be reported live.
+	if err := store.DeleteChild(ctx, root, "payload.bin"); err != nil {
+		t.Fatalf("DeleteChild: %v", err)
+	}
+	if err := store.SetLinkCount(ctx, h, 0); err != nil {
+		t.Fatalf("SetLinkCount(0): %v", err)
+	}
+	if livePayloadContains(t, store, payloadID) {
+		t.Errorf("payload %s still reported live after unlink (nlink=0); reconcile must treat it as stranded (#1433)", payloadID)
+	}
+}
+
+// enumerateContains reports whether hash h appears in the store's GC mark live
+// set (EnumerateFileBlocks).
+func enumerateContains(t *testing.T, store metadata.Store, h block.ContentHash) bool {
+	t.Helper()
+	found := false
+	if err := store.EnumerateFileBlocks(t.Context(), func(got block.ContentHash) error {
+		if got == h {
+			found = true
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("EnumerateFileBlocks: %v", err)
+	}
+	return found
+}
+
+// livePayloadContains reports whether payloadID appears in EnumerateLivePayloadIDs.
+func livePayloadContains(t *testing.T, store metadata.Store, payloadID string) bool {
+	t.Helper()
+	found := false
+	if err := store.EnumerateLivePayloadIDs(t.Context(), func(got string) error {
+		if got == payloadID {
+			found = true
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("EnumerateLivePayloadIDs: %v", err)
+	}
+	return found
 }

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -1577,9 +1577,10 @@ func testEnumerateFileBlocks_UnlinkedFileExcludesManifest(t *testing.T, factory 
 	}
 
 	// Unlink: drop the dir edge and set nlink=0 (what RemoveFile does on the last
-	// link). nlink is the link-count source of truth across all backends, so
-	// SetLinkCount is the faithful simulation — mutating File.Nlink + PutFile is
-	// ignored by the SQL backends, which recompute nlink from the structure.
+	// link). The embedded File.Nlink is not the authoritative link count (#1166):
+	// SetLinkCount is the only API that updates the source of truth (SQL
+	// inodes.nlink, badger l: key, memory linkCounts), so it is the faithful
+	// simulation — mutating File.Nlink + PutFile would not move it.
 	if err := store.DeleteChild(ctx, root, "dead.bin"); err != nil {
 		t.Fatalf("DeleteChild: %v", err)
 	}


### PR DESCRIPTION
The missing half of #1433. The merged GC stack (#1439/#1440/#1442/#1443/#1444) was necessary but **not sufficient** — live testing on a Scaleway VM proved deleted files still reclaimed **zero** bytes. This is the actual fix.

## Root cause
The GC mark live set is the **union** of two structures:
- CAS refcount index (`file_blocks` / `fb:`) — reaped on unlink by #1439 ✅
- per-file manifest (`file_block_refs` / `f:` File.Blocks) — **never reaped on unlink** ❌

`RemoveFile` sets `nlink=0` but keeps the inode record (POSIX) **and its manifest**. The mark phase enumerated every manifest with **no nlink check**, so a deleted file's blocks stayed "live" forever and the sweep reclaimed nothing — on either tier. PR1's refcount reap was fully masked by the manifest union. Affects **both** NFS and SMB (both route through `RemoveFile` → `SetLinkCount(0)`).

## Fix
Exclude `nlink=0` inodes from both the mark live set (`EnumerateFileBlocks`) and the reconcile live set (`EnumerateLivePayloadIDs`), across all four backends.

The authoritative link count is **not** the embedded `File.Nlink` — `SetLinkCount` does not rewrite it (#1166). Per backend, read the same source the real unlink writes:
- **sqlite/postgres**: `JOIN file_block_refs → inodes WHERE nlink > 0`
- **badger**: read the `l:` link-count key (`fileLinkCountTxn`), mirroring `GetFile`'s overlay; fall back to embedded `Nlink` only when the `l:` key is absent
- **memory**: read the `linkCounts` map (same key as `s.files`); a missing entry is treated as live (fail-open)

`reconcileVersion` bumped 1→2 so the one-time startup migration re-runs and reaps stranded `file_blocks` rows left by pre-fix unlinks.

## Safety
- **Snapshots unaffected**: snapshot-held blocks are protected independently by the GC `HoldProvider` (on-disk snapshot manifests), not by the manifest union — confirmed wired at all three GC entrypoints (`RunBlockGC`, `runLocalGC`, `RunBlockGCForShare`).
- **Hard links**: `nlink>0` keeps blocks live (conformance test).
- **Open-unlinked**: covered by the grace period.
- Fail-closed mark-phase semantics preserved.

## Validation
- code-reviewer: clean, verified the nlink source matches `SetLinkCount` for all 4 backends + snapshot-hold safety.
- **VM e2e (Scaleway S3, NFSv3)**: write 500 MB → `rm` all → GC → **`ObjectsSwept=1000` (both tiers), `BytesFreed=1.05 GB`, S3 objects 500→0, local `du` →~2 MB, `HashesMarked=0`**. `--reconcile` clean; pinned live data retained. (Pre-PR7 build on the same harness swept 0 — clean reversal.)
- New storetest conformance: `UnlinkedFileExcludesManifest`, `HardLinkSurvivesOneRemoval`, `EnumerateLivePayloadIDs_ExcludesNlinkZero` — all 4 backends.

## Note (separate, pre-existing)
VM testing also surfaced a snapshot-create durability-verify failure (`missing hashes on remote after drain`) that reproduces on a **never-deleted** file — so it is independent of this read-only GC change. Tracking separately; not a blocker for this fix.