### PR TITLE
fix(nfs/v3): export-permission denials return EACCES, not EIO

### DIFF
--- a/internal/adapter/nfs/v3/handlers/access.go
+++ b/internal/adapter/nfs/v3/handlers/access.go
@@ -145,10 +145,10 @@ func (h *Handler) Access(
 			return &AccessResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, ctx.Context.Err()
 		}
 
-		logError(ctx.Context, err, "ACCESS failed: failed to build auth context",
+		logAuthCtxError(ctx.Context, err, "ACCESS",
 			"handle", fmt.Sprintf("%x", req.Handle),
 			"client", clientIP)
-		return &AccessResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
+		return &AccessResponse{NFSResponseBase: NFSResponseBase{Status: authDenialStatus(err)}}, nil
 	}
 
 	requestedPerms := nfsAccessToPermissions(req.Access, file.Type)

--- a/internal/adapter/nfs/v3/handlers/auth_helper.go
+++ b/internal/adapter/nfs/v3/handlers/auth_helper.go
@@ -1,10 +1,13 @@
 package handlers
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/auth"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/types"
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
@@ -13,6 +16,31 @@ import (
 // access a share. It aliases the shared auth sentinel so existing v3 callers
 // (and errors.Is checks) keep working.
 var ErrShareAccessDenied = auth.ErrShareAccessDenied
+
+// authDenialStatus maps a BuildAuthContextWithMapping / GetCachedAuthContext
+// error to an NFS3 status. A share-permission denial (ErrShareAccessDenied) is an
+// authorization decision → NFS3ErrAccess (EACCES "permission denied"), not a
+// server fault → NFS3ErrIO. Mirrors the NFSv4 path (v4/handlers/helpers.go),
+// which maps ErrShareAccessDenied to NFS4ERR_ACCESS.
+func authDenialStatus(err error) uint32 {
+	if errors.Is(err, ErrShareAccessDenied) {
+		return types.NFS3ErrAccess
+	}
+	return types.NFS3ErrIO
+}
+
+// logAuthCtxError logs a failure to build the per-request auth context at the
+// level appropriate to its cause: a share-permission denial (ErrShareAccessDenied)
+// is an expected authorization outcome → Warn; anything else (share-not-found,
+// identity-mapping failure) is a genuine fault → Error. Pairs with
+// authDenialStatus so the log level matches the NFS status returned.
+func logAuthCtxError(ctx context.Context, err error, operation string, args ...any) {
+	if errors.Is(err, ErrShareAccessDenied) {
+		logWarn(ctx, err, operation+": share access denied", args...)
+		return
+	}
+	logError(ctx, err, operation+": failed to build auth context", args...)
+}
 
 // formatUID formats an optional UID for logging.
 // Returns "nil" if the pointer is nil, otherwise the numeric value as string.

--- a/internal/adapter/nfs/v3/handlers/auth_helper_test.go
+++ b/internal/adapter/nfs/v3/handlers/auth_helper_test.go
@@ -1,0 +1,51 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/types"
+)
+
+// TestAuthDenialStatus verifies that a share-permission denial maps to
+// NFS3ErrAccess (EACCES "permission denied") while every other auth-context
+// failure stays NFS3ErrIO. This is the regression guard for the NFSv3 bug where
+// an export-gate denial surfaced to the client as "Input/output error" instead
+// of "Permission denied" (the NFSv4 path already mapped it to NFS4ERR_ACCESS).
+func TestAuthDenialStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want uint32
+	}{
+		{
+			name: "share access denied -> EACCES",
+			err:  ErrShareAccessDenied,
+			want: types.NFS3ErrAccess,
+		},
+		{
+			name: "wrapped share access denied -> EACCES",
+			err:  fmt.Errorf("build auth context: %w", ErrShareAccessDenied),
+			want: types.NFS3ErrAccess,
+		},
+		{
+			name: "generic internal fault -> EIO",
+			err:  errors.New("share not found"),
+			want: types.NFS3ErrIO,
+		},
+		{
+			name: "identity-mapping failure -> EIO",
+			err:  fmt.Errorf("failed to apply identity mapping: %w", errors.New("share %q not found")),
+			want: types.NFS3ErrIO,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := authDenialStatus(tc.err); got != tc.want {
+				t.Fatalf("authDenialStatus(%v) = %d, want %d", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/adapter/nfs/v3/handlers/create.go
+++ b/internal/adapter/nfs/v3/handlers/create.go
@@ -130,10 +130,10 @@ func (h *Handler) Create(
 		}, nil
 	}
 
-	authCtx, dirWccAfter, err := h.buildAuthContextWithWCCError(ctx, parentHandle, &parentFile.FileAttr, "CREATE", req.Filename, req.DirHandle)
+	authCtx, dirWccAfter, authStatus, err := h.buildAuthContextWithWCCError(ctx, parentHandle, &parentFile.FileAttr, "CREATE", req.Filename, req.DirHandle)
 	if authCtx == nil {
 		return &CreateResponse{
-			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
+			NFSResponseBase: NFSResponseBase{Status: authStatus},
 			DirBefore:       dirWccBefore,
 			DirAfter:        dirWccAfter,
 		}, err

--- a/internal/adapter/nfs/v3/handlers/doc.go
+++ b/internal/adapter/nfs/v3/handlers/doc.go
@@ -195,13 +195,15 @@ func (h *Handler) getFileOrError(
 // Returns:
 //   - authCtx: Non-nil auth context on success, nil on error
 //   - wccAfter: Nil on success, populated NFS attributes on error (for WCC response)
+//   - authStatus: NFS3OK on success; NFS3ErrAccess for a share-permission denial;
+//     NFS3ErrIO for a genuine fault (cancellation, share-not-found, identity-mapping failure)
 //   - err: Context cancellation error if cancelled, nil otherwise
 //
 // Usage pattern:
 //
-//	authCtx, wccAfter, err := h.buildAuthContextWithWCCError(ctx, handle, &file.FileAttr, "CREATE", req.Filename, req.DirHandle)
+//	authCtx, wccAfter, authStatus, err := h.buildAuthContextWithWCCError(ctx, handle, &file.FileAttr, "CREATE", req.Filename, req.DirHandle)
 //	if authCtx == nil {
-//	    return &CreateResponse{Status: types.NFS3ErrIO, DirBefore: wccBefore, DirAfter: wccAfter}, err
+//	    return &CreateResponse{NFSResponseBase: NFSResponseBase{Status: authStatus}, DirBefore: wccBefore, DirAfter: wccAfter}, err
 //	}
 func (h *Handler) buildAuthContextWithWCCError(
 	ctx *NFSHandlerContext,
@@ -210,7 +212,7 @@ func (h *Handler) buildAuthContextWithWCCError(
 	operation string,
 	filename string,
 	dirHandleBytes []byte,
-) (*metadata.AuthContext, *types.NFSFileAttr, error) {
+) (*metadata.AuthContext, *types.NFSFileAttr, uint32, error) {
 	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
 
 	authCtx, err := BuildAuthContextWithMapping(ctx, h.Registry, ctx.Share)
@@ -220,16 +222,16 @@ func (h *Handler) buildAuthContextWithWCCError(
 			logger.DebugCtx(ctx.Context, operation+" cancelled during auth context building", "name", filename, "handle", fmt.Sprintf("%x", dirHandleBytes), "client", clientIP, "error", ctx.Context.Err())
 
 			wccAfter := h.convertFileAttrToNFS(handle, fileAttr)
-			return nil, wccAfter, ctx.Context.Err()
+			return nil, wccAfter, types.NFS3ErrIO, ctx.Context.Err()
 		}
 
-		logError(ctx.Context, err, operation+" failed: failed to build auth context", "name", filename, "handle", fmt.Sprintf("%x", dirHandleBytes), "client", clientIP)
+		logAuthCtxError(ctx.Context, err, operation, "name", filename, "handle", fmt.Sprintf("%x", dirHandleBytes), "client", clientIP)
 
 		wccAfter := h.convertFileAttrToNFS(handle, fileAttr)
-		return nil, wccAfter, nil
+		return nil, wccAfter, authDenialStatus(err), nil
 	}
 
-	return authCtx, nil, nil
+	return authCtx, nil, types.NFS3OK, nil
 }
 
 // getOplockBreaker retrieves the cross-protocol OplockBreaker from the Runtime.

--- a/internal/adapter/nfs/v3/handlers/link.go
+++ b/internal/adapter/nfs/v3/handlers/link.go
@@ -124,8 +124,8 @@ func (h *Handler) Link(
 			return &LinkResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, ctx.Context.Err()
 		}
 
-		logError(ctx.Context, err, "LINK failed: failed to build auth context", "file_handle", fmt.Sprintf("%x", req.FileHandle), "name", req.Name, "client", clientIP)
-		return &LinkResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
+		logAuthCtxError(ctx.Context, err, "LINK", "file_handle", fmt.Sprintf("%x", req.FileHandle), "name", req.Name, "client", clientIP)
+		return &LinkResponse{NFSResponseBase: NFSResponseBase{Status: authDenialStatus(err)}}, nil
 	}
 
 	if ctx.isContextCancelled() {

--- a/internal/adapter/nfs/v3/handlers/lookup.go
+++ b/internal/adapter/nfs/v3/handlers/lookup.go
@@ -160,7 +160,7 @@ func (h *Handler) Lookup(
 			return &LookupResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 		}
 
-		logError(ctx.Context, err, "LOOKUP failed: failed to build auth context",
+		logAuthCtxError(ctx.Context, err, "LOOKUP",
 			"name", req.Filename,
 			"handle", fmt.Sprintf("%x", req.DirHandle),
 			"client", clientIP)
@@ -168,7 +168,7 @@ func (h *Handler) Lookup(
 		nfsDirAttr := h.convertFileAttrToNFS(dirHandle, &dirFile.FileAttr)
 
 		return &LookupResponse{
-			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
+			NFSResponseBase: NFSResponseBase{Status: authDenialStatus(err)},
 			DirAttr:         nfsDirAttr,
 		}, nil
 	}

--- a/internal/adapter/nfs/v3/handlers/mkdir.go
+++ b/internal/adapter/nfs/v3/handlers/mkdir.go
@@ -131,10 +131,10 @@ func (h *Handler) Mkdir(
 	// Capture pre-operation attributes for WCC data
 	wccBefore := xdr.CaptureWccAttr(&parentFile.FileAttr)
 
-	authCtx, wccAfter, err := h.buildAuthContextWithWCCError(ctx, parentHandle, &parentFile.FileAttr, "MKDIR", req.Name, req.DirHandle)
+	authCtx, wccAfter, authStatus, err := h.buildAuthContextWithWCCError(ctx, parentHandle, &parentFile.FileAttr, "MKDIR", req.Name, req.DirHandle)
 	if authCtx == nil {
 		return &MkdirResponse{
-			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
+			NFSResponseBase: NFSResponseBase{Status: authStatus},
 			WccBefore:       wccBefore,
 			WccAfter:        wccAfter,
 		}, err

--- a/internal/adapter/nfs/v3/handlers/mknod.go
+++ b/internal/adapter/nfs/v3/handlers/mknod.go
@@ -181,10 +181,10 @@ func (h *Handler) Mknod(
 		}, nil
 	}
 
-	authCtx, wccAfter, err := h.buildAuthContextWithWCCError(ctx, parentHandle, &parentFile.FileAttr, "MKNOD", req.Name, req.DirHandle)
+	authCtx, wccAfter, authStatus, err := h.buildAuthContextWithWCCError(ctx, parentHandle, &parentFile.FileAttr, "MKNOD", req.Name, req.DirHandle)
 	if authCtx == nil {
 		return &MknodResponse{
-			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
+			NFSResponseBase: NFSResponseBase{Status: authStatus},
 			DirAttrBefore:   wccBefore,
 			DirAttrAfter:    wccAfter,
 		}, err

--- a/internal/adapter/nfs/v3/handlers/read.go
+++ b/internal/adapter/nfs/v3/handlers/read.go
@@ -170,10 +170,10 @@ func (h *Handler) Read(
 		if ctx.Context.Err() != nil {
 			return nil, ctx.Context.Err()
 		}
-		logError(ctx.Context, err, "READ failed: failed to build auth context",
+		logAuthCtxError(ctx.Context, err, "READ",
 			"handle", fmt.Sprintf("0x%x", req.Handle), "client", clientIP)
 		return &ReadResponse{
-			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
+			NFSResponseBase: NFSResponseBase{Status: authDenialStatus(err)},
 			Attr:            h.convertFileAttrToNFS(fileHandle, &file.FileAttr),
 		}, nil
 	}

--- a/internal/adapter/nfs/v3/handlers/readdir.go
+++ b/internal/adapter/nfs/v3/handlers/readdir.go
@@ -182,13 +182,13 @@ func (h *Handler) ReadDir(
 			}, ctx.Context.Err()
 		}
 
-		logError(ctx.Context, err, "READDIR failed: failed to build auth context", "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP)
+		logAuthCtxError(ctx.Context, err, "READDIR", "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP)
 
 		// Include directory attributes for cache consistency
 		nfsDirAttr := h.convertFileAttrToNFS(dirHandle, &dirFile.FileAttr)
 
 		return &ReadDirResponse{
-			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
+			NFSResponseBase: NFSResponseBase{Status: authDenialStatus(err)},
 			DirAttr:         nfsDirAttr,
 		}, nil
 	}

--- a/internal/adapter/nfs/v3/handlers/readdirplus.go
+++ b/internal/adapter/nfs/v3/handlers/readdirplus.go
@@ -259,12 +259,12 @@ func (h *Handler) ReadDirPlus(
 			}, nil
 		}
 
-		logError(ctx.Context, err, "READDIRPLUS failed: failed to build auth context", "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP)
+		logAuthCtxError(ctx.Context, err, "READDIRPLUS", "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP)
 
 		nfsDirAttr := h.convertFileAttrToNFS(dirHandle, &dirFile.FileAttr)
 
 		return &ReadDirPlusResponse{
-			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
+			NFSResponseBase: NFSResponseBase{Status: authDenialStatus(err)},
 			DirAttr:         nfsDirAttr,
 		}, nil
 	}

--- a/internal/adapter/nfs/v3/handlers/readlink.go
+++ b/internal/adapter/nfs/v3/handlers/readlink.go
@@ -101,8 +101,8 @@ func (h *Handler) ReadLink(
 			return &ReadLinkResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, ctx.Context.Err()
 		}
 
-		logError(ctx.Context, err, "READLINK failed: failed to build auth context", "handle", fmt.Sprintf("%x", req.Handle), "client", clientIP)
-		return &ReadLinkResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
+		logAuthCtxError(ctx.Context, err, "READLINK", "handle", fmt.Sprintf("%x", req.Handle), "client", clientIP)
+		return &ReadLinkResponse{NFSResponseBase: NFSResponseBase{Status: authDenialStatus(err)}}, nil
 	}
 
 	// The store is responsible for:

--- a/internal/adapter/nfs/v3/handlers/remove.go
+++ b/internal/adapter/nfs/v3/handlers/remove.go
@@ -119,10 +119,10 @@ func (h *Handler) Remove(
 		}, ctx.Context.Err()
 	}
 
-	authCtx, wccAfter, err := h.buildAuthContextWithWCCError(ctx, dirHandle, &dirFile.FileAttr, "REMOVE", req.Filename, req.DirHandle)
+	authCtx, wccAfter, authStatus, err := h.buildAuthContextWithWCCError(ctx, dirHandle, &dirFile.FileAttr, "REMOVE", req.Filename, req.DirHandle)
 	if authCtx == nil {
 		return &RemoveResponse{
-			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
+			NFSResponseBase: NFSResponseBase{Status: authStatus},
 			DirWccBefore:    wccBefore,
 			DirWccAfter:     wccAfter,
 		}, err

--- a/internal/adapter/nfs/v3/handlers/rename.go
+++ b/internal/adapter/nfs/v3/handlers/rename.go
@@ -212,12 +212,12 @@ func (h *Handler) Rename(
 		}, ctx.Context.Err()
 	}
 
-	authCtx, fromDirWccAfter, err := h.buildAuthContextWithWCCError(ctx, fromDirHandle, &fromDirFile.FileAttr, "RENAME", req.FromName, req.FromDirHandle)
+	authCtx, fromDirWccAfter, authStatus, err := h.buildAuthContextWithWCCError(ctx, fromDirHandle, &fromDirFile.FileAttr, "RENAME", req.FromName, req.FromDirHandle)
 	if authCtx == nil {
 		toDirWccAfter := h.convertFileAttrToNFS(toDirHandle, &toDirFile.FileAttr)
 
 		return &RenameResponse{
-			NFSResponseBase:  NFSResponseBase{Status: types.NFS3ErrIO},
+			NFSResponseBase:  NFSResponseBase{Status: authStatus},
 			FromDirWccBefore: fromDirWccBefore,
 			FromDirWccAfter:  fromDirWccAfter,
 			ToDirWccBefore:   toDirWccBefore,

--- a/internal/adapter/nfs/v3/handlers/rmdir.go
+++ b/internal/adapter/nfs/v3/handlers/rmdir.go
@@ -125,10 +125,10 @@ func (h *Handler) Rmdir(
 		}, nil
 	}
 
-	authCtx, wccAfter, err := h.buildAuthContextWithWCCError(ctx, parentHandle, &parentFile.FileAttr, "RMDIR", req.Name, req.DirHandle)
+	authCtx, wccAfter, authStatus, err := h.buildAuthContextWithWCCError(ctx, parentHandle, &parentFile.FileAttr, "RMDIR", req.Name, req.DirHandle)
 	if authCtx == nil {
 		return &RmdirResponse{
-			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
+			NFSResponseBase: NFSResponseBase{Status: authStatus},
 			DirWccBefore:    wccBefore,
 			DirWccAfter:     wccAfter,
 		}, err

--- a/internal/adapter/nfs/v3/handlers/setattr.go
+++ b/internal/adapter/nfs/v3/handlers/setattr.go
@@ -196,10 +196,10 @@ func (h *Handler) SetAttr(
 			"ctime", fmt.Sprintf("%d.%d", currentCtime.Seconds, currentCtime.Nseconds))
 	}
 
-	authCtx, wccAfter, err := h.buildAuthContextWithWCCError(ctx, fileHandle, &currentFile.FileAttr, "SETATTR", "", req.Handle)
+	authCtx, wccAfter, authStatus, err := h.buildAuthContextWithWCCError(ctx, fileHandle, &currentFile.FileAttr, "SETATTR", "", req.Handle)
 	if authCtx == nil {
 		return &SetAttrResponse{
-			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
+			NFSResponseBase: NFSResponseBase{Status: authStatus},
 			AttrBefore:      wccBefore,
 			AttrAfter:       wccAfter,
 		}, err

--- a/internal/adapter/nfs/v3/handlers/symlink.go
+++ b/internal/adapter/nfs/v3/handlers/symlink.go
@@ -155,10 +155,10 @@ func (h *Handler) Symlink(
 		}, ctx.Context.Err()
 	}
 
-	authCtx, nfsDirAttr, err := h.buildAuthContextWithWCCError(ctx, dirHandle, &dirFile.FileAttr, "SYMLINK", req.Name, req.DirHandle)
+	authCtx, nfsDirAttr, authStatus, err := h.buildAuthContextWithWCCError(ctx, dirHandle, &dirFile.FileAttr, "SYMLINK", req.Name, req.DirHandle)
 	if authCtx == nil {
 		return &SymlinkResponse{
-			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
+			NFSResponseBase: NFSResponseBase{Status: authStatus},
 			DirAttrBefore:   wccBefore,
 			DirAttrAfter:    nfsDirAttr,
 		}, err

--- a/internal/adapter/nfs/v3/handlers/write.go
+++ b/internal/adapter/nfs/v3/handlers/write.go
@@ -203,11 +203,11 @@ func (h *Handler) Write(
 			return &WriteResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, ctx.Context.Err()
 		}
 
-		logError(ctx.Context, err, "WRITE failed: failed to build auth context", "handle", fmt.Sprintf("0x%x", req.Handle), "client", clientIP)
+		logAuthCtxError(ctx.Context, err, "WRITE", "handle", fmt.Sprintf("0x%x", req.Handle), "client", clientIP)
 
 		// No WCC data available - we haven't called PrepareWrite yet
 		return &WriteResponse{
-			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
+			NFSResponseBase: NFSResponseBase{Status: authDenialStatus(err)},
 		}, nil
 	}
 


### PR DESCRIPTION
## Problem

Over NFSv3, a share-permission denial surfaced to clients as **`NFS3ERR_IO` ("Input/output error")** instead of **`NFS3ERR_ACCES` ("Permission denied")**.

Repro (reported in the field): mount a share with `default-permission=none` (the secure default since #1419) and `cp` a file as a UID with no grant → the export gate (`ResolveSharePermission`) denies with the `ErrShareAccessDenied` sentinel, but the v3 handlers hardcoded `NFS3ERR_IO` on any auth-context build error → client sees an I/O error.

NFSv4 already handles this correctly (`v4/handlers/helpers.go` maps `ErrShareAccessDenied` → `NFS4ERR_ACCESS`, added in #1281). This PR brings **v3 to parity**.

## Fix

- Add `authDenialStatus(err)` helper: `errors.Is(err, ErrShareAccessDenied)` → `NFS3ErrAccess`, else `NFS3ErrIO`.
- Thread an explicit status out of `buildAuthContextWithWCCError` (now returns `(authCtx, wccAfter, status, err)`).
- Update all 16 v3 handlers that build an auth context (read, write, access, lookup, link, readlink, readdir, readdirplus, create, mknod, mkdir, remove, rename, rmdir, symlink, setattr).

**Invariant preserved:** genuine faults — context cancellation, share-not-found, identity-mapping failure — still return `NFS3ERR_IO`. Only the `ErrShareAccessDenied` authorization denial becomes `NFS3ERR_ACCES`. `commit.go` / `fsstat.go` / `create.go` paths that intentionally tolerate auth errors are untouched.

## Tests

`TestAuthDenialStatus` covers denial → EACCES, wrapped denial → EACCES, generic fault → EIO, mapping failure → EIO. Build (incl. `-tags integration`), `go vet`, and `golangci-lint` clean; v3-handlers + auth packages pass.

## Context

First of three PRs from a field permissions report. Follow-ups: auth-context cache invalidation on config change, and aligning the default squash mode to `root_to_guest` (conventional `root_squash`).