### PR TITLE
fix(gc): clear synced markers for hashes swept off the remote (#1433)

### DIFF
--- a/pkg/block/engine/gc.go
+++ b/pkg/block/engine/gc.go
@@ -225,6 +225,15 @@ type Options struct {
 	// (orphan-not-deleted is always preferred over live-data-deleted, per
 	// the mark fail-closed invariant).
 	HoldProvider HoldProvider
+
+	// SyncedHashStore, when non-nil, has DeleteSynced called for every hash
+	// successfully deleted from the swept store. This keeps the synced-hash
+	// index a strict subset of remote contents: a hash swept off the remote is
+	// no longer synced and must be re-uploaded if it reappears in the live set;
+	// without this, ListUnsynced skips it forever and a later snapshot's
+	// durability verify fails (#1433). Set ONLY for remote-tier sweeps — local
+	// eviction does not change remote synced state, so local sweeps leave it nil.
+	SyncedHashStore metadata.SyncedHashStore
 }
 
 // MetadataReconciler resolves per-share metadata stores. The mark phase
@@ -592,6 +601,17 @@ func sweepPhase(
 				// continue + capture
 				addError("delete " + casKey + ": " + err.Error())
 				return nil
+			}
+			// Keep the synced-hash index a strict subset of remote contents: the
+			// hash is gone from this store, so it is no longer synced. Without
+			// this, ListUnsynced skips it forever and a later snapshot's
+			// durability verify fails on a block that will never re-upload
+			// (#1433). Idempotent + non-fatal: a stale marker only costs a missed
+			// re-upload, recoverable on the next pass. Set only for remote sweeps.
+			if options.SyncedHashStore != nil {
+				if serr := options.SyncedHashStore.DeleteSynced(ctx, h); serr != nil {
+					addError("delete-synced " + casKey + ": " + serr.Error())
+				}
 			}
 			statsMu.Lock()
 			stats.ObjectsSwept++

--- a/pkg/block/engine/gc_test.go
+++ b/pkg/block/engine/gc_test.go
@@ -1472,3 +1472,50 @@ func mustHashWithPrefix(t *testing.T, hexPrefix string) block.ContentHash {
 	t.Fatalf("could not find hash with prefix %q", hexPrefix)
 	return block.ContentHash{}
 }
+
+// TestGCMarkSweep_ClearsSyncedMarkerForSweptHash proves the remote sweep clears
+// the synced marker for every hash it deletes, keeping the synced set a strict
+// subset of remote contents. Without it, ListUnsynced skips a swept hash forever
+// and a later snapshot's durability verify fails on a block that never re-uploads
+// (#1433). A surviving live block keeps its marker.
+func TestGCMarkSweep_ClearsSyncedMarkerForSweptHash(t *testing.T) {
+	ctx := t.Context()
+	rs := remotememory.New()
+	defer func() { _ = rs.Close() }()
+	old := time.Now().Add(-2 * time.Hour)
+	rs.SetNowFnForTest(func() time.Time { return old })
+
+	rec := newGCMSReconciler()
+	st := rec.addShare("share-a")
+
+	live := hashFromString("live-keep")
+	orphan := hashFromString("orphan-sweep")
+	putBlock(t, st, "file-live/0", live)
+	writeCASObject(t, ctx, rs, live, []byte("live-data"))
+	writeCASObject(t, ctx, rs, orphan, []byte("orphan-data"))
+
+	synced := newRecordingSyncedHashStore()
+	synced.markSyncedForTest(live)
+	synced.markSyncedForTest(orphan)
+
+	stats := CollectGarbage(ctx, rs, rec, &Options{
+		GCStateRoot:     t.TempDir(),
+		GracePeriod:     time.Minute,
+		SyncedHashStore: synced,
+	})
+	if stats.ObjectsSwept != 1 {
+		t.Fatalf("ObjectsSwept = %d, want 1", stats.ObjectsSwept)
+	}
+
+	// Swept orphan: marker cleared so it can re-upload if it reappears live.
+	if ok, _ := synced.IsSynced(ctx, orphan); ok {
+		t.Errorf("swept orphan still marked synced; ListUnsynced would skip it forever (#1433)")
+	}
+	// Live block: still on remote AND still synced (marker untouched).
+	if ok, _ := synced.IsSynced(ctx, live); !ok {
+		t.Errorf("live block's synced marker wrongly cleared")
+	}
+	if _, err := rs.Get(ctx, live); err != nil {
+		t.Errorf("live block deleted: %v", err)
+	}
+}

--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -2,9 +2,11 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/engine"
 	"github.com/marmos91/dittofs/pkg/block/remote"
 	"github.com/marmos91/dittofs/pkg/metadata"
@@ -81,6 +83,9 @@ func (r *Runtime) RunBlockGC(ctx context.Context, sharePrefix string, dryRun boo
 		applyGCDefaults(opts, gcDefaults)
 		// Inject held hashes from ready snapshots into the GC mark phase.
 		opts.HoldProvider = r.snapshotHoldForRemote(entry.Shares)
+		// Clear synced markers for hashes swept off this remote so they re-upload
+		// if they reappear in the live set (#1433). Remote sweep only.
+		opts.SyncedHashStore = r.syncedHashStoreForShares(entry.Shares)
 		logger.Info("RunBlockGC: starting",
 			"configID", entry.ConfigID,
 			"shares", entry.Shares,
@@ -249,6 +254,9 @@ func (r *Runtime) RunBlockGCForShare(ctx context.Context, name string, dryRun bo
 		applyGCDefaults(opts, gcDefaults)
 		// Inject held hashes from ready snapshots into the GC mark phase.
 		opts.HoldProvider = r.snapshotHoldForRemote(entry.Shares)
+		// Clear synced markers for hashes swept off this remote so they re-upload
+		// if they reappear in the live set (#1433). Remote sweep only.
+		opts.SyncedHashStore = r.syncedHashStoreForShares(entry.Shares)
 		logger.Info("RunBlockGCForShare: starting",
 			"share", name,
 			"configID", entry.ConfigID,
@@ -346,4 +354,76 @@ func accumulateGCStats(total, stats *engine.GCStats, includeDryRunMeta bool) eng
 // share. Delegates to shares.Service.SetShareRemoteForTest. Test-only.
 func (r *Runtime) setShareRemoteForTest(shareName string, rs remote.RemoteStore) {
 	r.sharesSvc.SetShareRemoteForTest(shareName, rs)
+}
+
+// multiSyncedHashStore fans DeleteSynced out to every share's synced-hash index
+// on a shared remote, so a hash swept off that remote is un-synced everywhere it
+// was recorded. DeleteSynced is idempotent, so clearing a hash a share never had
+// is a no-op. GC only ever calls DeleteSynced; the other methods exist for
+// interface completeness.
+type multiSyncedHashStore []metadata.SyncedHashStore
+
+func (m multiSyncedHashStore) IsSynced(ctx context.Context, h block.ContentHash) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	for _, s := range m {
+		ok, err := s.IsSynced(ctx, h)
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (m multiSyncedHashStore) MarkSynced(ctx context.Context, h block.ContentHash) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	for _, s := range m {
+		if err := s.MarkSynced(ctx, h); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m multiSyncedHashStore) DeleteSynced(ctx context.Context, h block.ContentHash) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	// Attempt every store even if one fails, so a hash is un-synced everywhere it
+	// can be, then surface the failures: the GC sweep records them as non-fatal
+	// errors (a stale marker only costs a missed re-upload, recovered next pass).
+	var errs []error
+	for _, s := range m {
+		if err := s.DeleteSynced(ctx, h); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// syncedHashStoreForShares unions the synced-hash indexes of the given shares so
+// a remote-tier GC sweep can clear the marker for every hash it deletes (#1433).
+// Each share's metadata store implements SyncedHashStore. Returns nil when none
+// are available, leaving the sweep's marker-clear a no-op.
+func (r *Runtime) syncedHashStoreForShares(shares []string) metadata.SyncedHashStore {
+	var stores multiSyncedHashStore
+	for _, shareName := range shares {
+		mds, err := r.GetMetadataStoreForShare(shareName)
+		if err != nil {
+			continue
+		}
+		if shs, ok := mds.(metadata.SyncedHashStore); ok {
+			stores = append(stores, shs)
+		}
+	}
+	if len(stores) == 0 {
+		return nil
+	}
+	return stores
 }


### PR DESCRIPTION
Follow-up to PR #1445. A durability invariant violation that #1445 made load-bearing by enabling actual GC sweeps. Found by tracing a snapshot-verify failure during live VM testing.

## Bug
The remote-tier GC sweep deletes a chunk from the remote store but never clears its **synced-hash marker**. That breaks the documented "synced ⊆ remote contents" invariant (`readwrite.go`):
- `ListUnsynced` skips any hash where `IsSynced=true`.
- So a hash swept off remote, but whose marker lingers, is **never re-uploaded** if it later reappears in the live set (e.g. dedup re-write of the same content).
- A subsequent snapshot's `VerifyRemoteDurability` then fails on a block genuinely absent from S3.

The unlink-time refcount cascade already clears the marker (`readwrite.go` `DeleteSynced` at refcount 0), but the **reconcile reap** (`reapStrandedRows` → `mds.DecrementRefCountAndReap`) and any sweep of a not-already-cleared hash did not — exposed now that GC actually deletes blocks (the upgrade/migration path is the main exposure).

## Fix
- **engine**: `Options.SyncedHashStore`; `sweepPhase` calls `DeleteSynced` for every hash it successfully deletes (idempotent, non-fatal). Set **only** for remote sweeps — local eviction does not change remote synced state, so local sweeps leave it nil.
- **runtime**: `multiSyncedHashStore` unions the per-share synced-hash indexes for the shares on a remote endpoint (each share's metadata store implements `SyncedHashStore`) and wires it into the remote GC opts; `runLocalGC` leaves it nil.
- **test**: `TestGCMarkSweep_ClearsSyncedMarkerForSweptHash` — sweep clears the swept orphan's marker while a live block keeps both its remote object and its marker.

Note: #1433's nlink fix already *defends* this going forward (live hashes stay in the live set, so they aren't swept); this closes the invariant for the reconcile/upgrade path and any future reap path. Stacked on #1445 (merged).