### PR TITLE
fix(nfs): invalidate v3 auth-context cache on share-config change

### DIFF
--- a/internal/adapter/nfs/v3/handlers/clear_auth_cache_test.go
+++ b/internal/adapter/nfs/v3/handlers/clear_auth_cache_test.go
@@ -1,0 +1,43 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// TestClearAuthCache verifies ClearAuthCache drops all cached auth contexts so
+// active clients re-resolve permissions after a share-config change.
+func TestClearAuthCache(t *testing.T) {
+	h := &Handler{}
+
+	// Seed a few entries directly (the cache is keyed "share:uid:gid").
+	h.authCache.Store("/export:1000:1000", &metadata.AuthContext{})
+	h.authCache.Store("/export:0:0", &metadata.AuthContext{})
+	h.authCache.Store("/other:2000:2000", &metadata.AuthContext{})
+
+	count := func() int {
+		n := 0
+		h.authCache.Range(func(_, _ any) bool {
+			n++
+			return true
+		})
+		return n
+	}
+
+	if got := count(); got != 3 {
+		t.Fatalf("expected 3 seeded entries, got %d", got)
+	}
+
+	h.ClearAuthCache()
+
+	if got := count(); got != 0 {
+		t.Fatalf("expected cache empty after ClearAuthCache, got %d", got)
+	}
+
+	// Idempotent: clearing an empty cache is a no-op.
+	h.ClearAuthCache()
+	if got := count(); got != 0 {
+		t.Fatalf("expected cache still empty, got %d", got)
+	}
+}

--- a/internal/adapter/nfs/v3/handlers/doc.go
+++ b/internal/adapter/nfs/v3/handlers/doc.go
@@ -101,6 +101,18 @@ func (h *Handler) GetCachedAuthContext(
 	return authCtx, nil
 }
 
+// ClearAuthCache drops all cached auth contexts. Called when share permission
+// state changes (grants, default-permission, squash) so active clients pick up
+// the new policy without a server restart. Config changes are rare admin
+// operations, so clearing the whole (small) cache is preferred over fragile
+// per-share key-prefix matching; entries repopulate on the next op.
+func (h *Handler) ClearAuthCache() {
+	h.authCache.Range(func(key, _ any) bool {
+		h.authCache.Delete(key)
+		return true
+	})
+}
+
 // convertFileAttrToNFS converts metadata file attributes to NFS wire format.
 // Extracts the file ID from the handle and converts the attributes.
 func (h *Handler) convertFileAttrToNFS(fileHandle metadata.FileHandle, fileAttr *metadata.FileAttr) *types.NFSFileAttr {

--- a/internal/controlplane/api/handlers/share_adapter_config.go
+++ b/internal/controlplane/api/handlers/share_adapter_config.go
@@ -169,6 +169,13 @@ func (h *ShareNFSConfigHandler) Patch(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// A squash-mode change alters how client UIDs map to identities, but does not
+	// flow through ReconcileShareRootACL. Drop cached per-identity authorization
+	// so the new squash policy takes effect on active clients without a restart.
+	if h.runtime != nil {
+		h.runtime.InvalidateAuthCache()
+	}
+
 	resp, ok := h.optionsToResponse(w, r, opts)
 	if !ok {
 		return

--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -551,9 +551,21 @@ func (s *NFSAdapter) SetRuntime(rtAny any) {
 	// loop and subscription is missed.
 	unsubPseudoFS := rt.OnShareChange(func(shares []string) {
 		s.pseudoFS.Rebuild(shares)
+		// A share add/remove/enable/disable can change which identities resolve;
+		// drop cached v3 auth contexts so removed/disabled shares stop serving
+		// stale authorization.
+		s.nfsHandler.ClearAuthCache()
 		logger.Info("NFSv4 pseudo-fs rebuilt", "shares", len(shares))
 	})
 	s.shareUnsubscribers = append(s.shareUnsubscribers, unsubPseudoFS)
+
+	// Drop cached v3 auth contexts when a share's permission state changes
+	// (grant/revoke, default-permission, squash) so active clients pick up the
+	// new policy without a server restart.
+	unsubAuthInvalidate := rt.OnAuthCacheInvalidate(func() {
+		s.nfsHandler.ClearAuthCache()
+	})
+	s.shareUnsubscribers = append(s.shareUnsubscribers, unsubAuthInvalidate)
 
 	// Create blocking queue for NLM lock operations
 	s.blockingQueue = blocking.NewBlockingQueue(nlm_handlers.DefaultBlockingQueueSize)

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -576,6 +576,20 @@ func (r *Runtime) OnShareChange(callback func(shares []string)) func() {
 	return r.sharesSvc.OnShareChange(callback)
 }
 
+// OnAuthCacheInvalidate registers a callback fired when a share's permission
+// state changes (grant/revoke, default-permission, squash), so protocol adapters
+// can drop cached per-identity authorization. Returns an unsubscribe function.
+func (r *Runtime) OnAuthCacheInvalidate(callback func()) func() {
+	return r.sharesSvc.OnAuthCacheInvalidate(callback)
+}
+
+// InvalidateAuthCache notifies registered adapters to drop cached authorization
+// after a permission-relevant share change that does not flow through
+// ReconcileShareRootACL (e.g. a squash-mode change).
+func (r *Runtime) InvalidateAuthCache() {
+	r.sharesSvc.InvalidateAuthCache()
+}
+
 func (r *Runtime) GetShareNameForHandle(ctx context.Context, handle metadata.FileHandle) (string, error) {
 	return r.sharesSvc.GetShareNameForHandle(ctx, handle)
 }

--- a/pkg/controlplane/runtime/share_root_acl.go
+++ b/pkg/controlplane/runtime/share_root_acl.go
@@ -121,5 +121,10 @@ func (r *Runtime) ReconcileShareRootACL(ctx context.Context, shareName string) e
 	if _, err := r.metadataService.SetFileAttributes(sysCtx, share.RootHandle, &metadata.SetAttrs{ACL: dacl}); err != nil {
 		return fmt.Errorf("reconcile root ACL for %q: set attributes: %w", shareName, err)
 	}
+
+	// A grant/revoke or default-permission change just altered who may access
+	// the share. Drop any cached per-identity authorization so active clients
+	// pick up the new policy without a server restart.
+	r.InvalidateAuthCache()
 	return nil
 }

--- a/pkg/controlplane/runtime/shares/auth_invalidate_test.go
+++ b/pkg/controlplane/runtime/shares/auth_invalidate_test.go
@@ -1,0 +1,52 @@
+package shares
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+// TestOnAuthCacheInvalidate_FiresAndUnsubscribes verifies that registered
+// auth-cache-invalidate callbacks fire on InvalidateAuthCache and that the
+// returned unsubscribe function removes them.
+func TestOnAuthCacheInvalidate_FiresAndUnsubscribes(t *testing.T) {
+	svc := New()
+
+	var calls atomic.Int32
+	unsub := svc.OnAuthCacheInvalidate(func() { calls.Add(1) })
+
+	svc.InvalidateAuthCache()
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected callback to fire once, got %d", got)
+	}
+
+	svc.InvalidateAuthCache()
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("expected callback to fire twice, got %d", got)
+	}
+
+	unsub()
+	svc.InvalidateAuthCache()
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("expected no further calls after unsubscribe, got %d", got)
+	}
+}
+
+// TestOnAuthCacheInvalidate_DoesNotFireShareChange verifies the two callback
+// registries are independent: an auth-cache invalidation must not trigger the
+// heavier share-set listeners (pseudo-fs rebuild, NFSv4 delegation recall).
+func TestOnAuthCacheInvalidate_DoesNotFireShareChange(t *testing.T) {
+	svc := New()
+
+	var authCalls, shareCalls atomic.Int32
+	svc.OnAuthCacheInvalidate(func() { authCalls.Add(1) })
+	svc.OnShareChange(func(_ []string) { shareCalls.Add(1) })
+
+	svc.InvalidateAuthCache()
+
+	if got := authCalls.Load(); got != 1 {
+		t.Fatalf("expected auth callback to fire once, got %d", got)
+	}
+	if got := shareCalls.Load(); got != 0 {
+		t.Fatalf("expected share-change callback NOT to fire, got %d", got)
+	}
+}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -399,6 +399,12 @@ type Service struct {
 	nextCallbackID  int
 	changeCallbacks map[int]func(shares []string)
 
+	// authInvalidateCallbacks fire when a share's permission state changes
+	// (grant/revoke, default-permission, squash). They are kept separate from
+	// changeCallbacks so a permission edit does not trigger the heavier
+	// share-set listeners (pseudo-fs rebuild, NFSv4 delegation recall).
+	authInvalidateCallbacks map[int]func()
+
 	// metricsRec is the inline metrics recorder threaded into every per-share
 	// block store's eviction/backpressure path. Shares are constructed before
 	// the metrics registry exists, so the runtime installs it post-startup via
@@ -415,11 +421,12 @@ type Service struct {
 
 func New() *Service {
 	return &Service{
-		registry:        make(map[string]*Share),
-		reservations:    make(map[string]struct{}),
-		remoteStores:    make(map[string]*sharedRemote),
-		changeCallbacks: make(map[int]func(shares []string)),
-		warmJobs:        newWarmRegistry(),
+		registry:                make(map[string]*Share),
+		reservations:            make(map[string]struct{}),
+		remoteStores:            make(map[string]*sharedRemote),
+		changeCallbacks:         make(map[int]func(shares []string)),
+		authInvalidateCallbacks: make(map[int]func()),
+		warmJobs:                newWarmRegistry(),
 	}
 }
 
@@ -1710,6 +1717,39 @@ func (s *Service) notifyShareChange() {
 
 	for _, cb := range callbacks {
 		cb(shareNames)
+	}
+}
+
+// OnAuthCacheInvalidate registers a callback fired when a share's permission
+// state changes (grant/revoke, default-permission, squash) so adapters can drop
+// any cached per-identity authorization. It returns an unsubscribe function that
+// removes the callback; callers should invoke it (e.g. in their Stop method) to
+// prevent stale callbacks from accumulating across adapter restarts.
+func (s *Service) OnAuthCacheInvalidate(callback func()) func() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := s.nextCallbackID
+	s.nextCallbackID++
+	s.authInvalidateCallbacks[id] = callback
+	return func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		delete(s.authInvalidateCallbacks, id)
+	}
+}
+
+// InvalidateAuthCache fires the registered auth-cache-invalidate callbacks. It
+// must NOT be called while holding s.mu.
+func (s *Service) InvalidateAuthCache() {
+	s.mu.RLock()
+	callbacks := make([]func(), 0, len(s.authInvalidateCallbacks))
+	for _, cb := range s.authInvalidateCallbacks {
+		callbacks = append(callbacks, cb)
+	}
+	s.mu.RUnlock()
+
+	for _, cb := range callbacks {
+		cb()
 	}
 }
 


### PR DESCRIPTION

## Problem

The NFS v3 `Handler.authCache` (keyed `share:uid:gid`, populated by `GetCachedAuthContext` to keep registry lookups off the hot WRITE path) was **never invalidated**. So changing a share's per-principal grants, `default-permission`, or squash mode via dfsctl/API had **no effect on already-connected NFS clients until the server process restarted**.

This is the cause of the field report where "I changed the squash mode, nothing happened — then I restarted the pod and the behavior changed": the restart was merely clearing the stale cache.

## Fix

- Add a **dedicated** share-auth invalidation callback registry on the shares service (`OnAuthCacheInvalidate` / `InvalidateAuthCache`), kept separate from `OnShareChange` so a permission edit does **not** trigger NFSv4 delegation recall / pseudo-fs rebuild.
- Fire it from `ReconcileShareRootACL` (already called on grant/revoke/default-permission + AddShare) and from the NFS squash config patch (`share_adapter_config.go`).
- NFS adapter subscribes and calls `Handler.ClearAuthCache()` on that signal, and also clears on share add/remove/enable/disable (existing `OnShareChange` subscription).
- `ClearAuthCache()` drops the whole (small) cache — config changes are rare admin ops, so whole-clear is simpler and avoids fragile key-prefix matching.

## Tests

`TestOnAuthCacheInvalidate_FiresAndUnsubscribes`, `TestOnAuthCacheInvalidate_DoesNotFireShareChange` (proves the dedicated registry doesn't bleed into OnShareChange), `TestClearAuthCache`. Build (incl. `-tags integration`), vet, golangci-lint clean.

## Context

PR 2 of 3 from a field permissions report (after #1449 EIO→EACCES). Final PR: align default squash to `root_to_guest` (conventional `root_squash`).