### PR TITLE
feat(nfs,smb): default squash to root_to_guest (conventional root_squash)

### DIFF
--- a/docs/guide/nfs.md
+++ b/docs/guide/nfs.md
@@ -437,17 +437,17 @@ options) rather than separate `root_squash` / `all_squash` toggles:
 | Mode | Effect | Traditional NFS equivalent |
 |------|--------|----------------------------|
 | `none` | No remapping. UIDs pass through unchanged. | `no_root_squash` |
-| `root_to_admin` **(default)** | Root (UID 0) keeps root. Other UIDs unchanged. | `no_root_squash` |
-| `root_to_guest` | Root (UID 0) → anonymous. Other UIDs unchanged. | `root_squash` |
+| `root_to_admin` | Root (UID 0) keeps root. Other UIDs unchanged. | `no_root_squash` |
+| `root_to_guest` **(default)** | Root (UID 0) → anonymous. Other UIDs unchanged. | `root_squash` |
 | `all_to_admin` | **Every** client UID → root (UID 0). | `all_squash` to root |
 | `all_to_guest` | **Every** client UID → anonymous. | `all_squash` |
 
-> **Heads-up — the default is permissive.** DittoFS defaults to
-> `root_to_admin`, which means a remote root **keeps root privileges** on the
-> export (the opposite of many traditional NFS servers, which default to
-> `root_squash`). If untrusted hosts can reach the export over AUTH_SYS, set
-> `root_to_guest` (or stronger) explicitly. `none` and `root_to_admin` behave
-> identically for UID remapping.
+> **Default — root is squashed.** DittoFS defaults to `root_to_guest`, matching
+> the conventional NFS `root_squash`: a remote root is mapped to the anonymous
+> identity and does **not** keep root privileges on the export. If a trusted
+> client's root must act as the server's root (e.g. single-tenant admin
+> automation), opt into `root_to_admin` (`no_root_squash`) per share. `none` and
+> `root_to_admin` behave identically for UID remapping.
 
 The **anonymous** identity is UID/GID **65534** (`nobody`/`nogroup`) by default.
 
@@ -465,8 +465,8 @@ dfsctl share nfs-config show /export
 ```
 
 Valid values: `none`, `root_to_admin`, `root_to_guest`, `all_to_admin`,
-`all_to_guest`. A squash change takes effect on the **next NFS adapter restart**
-(unlike netgroup changes, which apply immediately). The anonymous UID/GID is
+`all_to_guest`. A squash change applies to active clients immediately — no NFS
+adapter restart is required. The anonymous UID/GID is
 configurable via the REST API (`anonymous_uid` / `anonymous_gid` on the share's
 NFS config); it is not exposed as a `dfsctl` flag and defaults to 65534.
 
@@ -477,8 +477,8 @@ Assume a file owned by UID 1000, mode `0644`, and a share-gate
 
 | Client mounts and acts as… | Squash mode | Effective identity | Result |
 |----------------------------|-------------|--------------------|--------|
-| `root` (UID 0) | `root_to_admin` (default) | UID 0 (root) | Full access — root bypasses POSIX. |
-| `root` (UID 0) | `root_to_guest` | UID 65534 (nobody) | Treated as `EVERYONE@`; can read the `0644` file, **cannot** write it. |
+| `root` (UID 0) | `root_to_admin` | UID 0 (root) | Full access — root bypasses POSIX. |
+| `root` (UID 0) | `root_to_guest` (default) | UID 65534 (nobody) | Treated as `EVERYONE@`; can read the `0644` file, **cannot** write it. |
 | UID 1000 | `root_to_guest` | UID 1000 (unchanged) | Owner access — read/write its own file. |
 | UID 1000 | `all_to_guest` | UID 65534 (nobody) | Squashed to nobody; read-only on the `0644` file even though it "owns" it. |
 | any UID | `all_to_admin` | UID 0 (root) | Everyone gets root — only for fully-trusted, single-tenant exports. |

--- a/internal/adapter/nfs/auth/share_permission.go
+++ b/internal/adapter/nfs/auth/share_permission.go
@@ -36,7 +36,8 @@ type SharePermissionResult struct {
 //     bypassed: denied when default_permission is "none", otherwise granted with
 //     read-only coerced when the default permission is "read".
 //   - Root (UID 0) under a squash mode that keeps root privileged (none,
-//     root_to_admin, all_to_admin, or empty/default) → admin, username "root".
+//     root_to_admin, or all_to_admin) → admin, username "root". An empty/unset
+//     squash normalizes to root_to_guest (the default) and does NOT promote root.
 //   - Unknown UID → guest: denied when default_permission is "none", otherwise
 //     granted with read-only coerced when the default permission is "read".
 //   - Known user → their resolved share permission (falling back to the share
@@ -85,13 +86,14 @@ func ResolveSharePermission(
 	}
 
 	// Check if caller is root (UID 0) and squash mode doesn't map root away.
-	// Root has full admin access when squash mode is: none, root_to_admin,
-	// all_to_admin, or empty string (default behavior = root_to_admin).
+	// Root has full admin access only when squash mode is: none, root_to_admin,
+	// or all_to_admin. An empty/unset squash normalizes to DefaultSquashMode
+	// (root_to_guest), which does NOT promote root.
 	isCallerRoot := *uid == 0
-	rootHasAdmin := share.Squash == "" || // Empty string = default (root_to_admin)
-		share.Squash == models.SquashNone ||
-		share.Squash == models.SquashRootToAdmin ||
-		share.Squash == models.SquashAllToAdmin
+	effSquash := share.Squash.OrDefault()
+	rootHasAdmin := effSquash == models.SquashNone ||
+		effSquash == models.SquashRootToAdmin ||
+		effSquash == models.SquashAllToAdmin
 	if isCallerRoot && rootHasAdmin {
 		result.ReadOnly = share.ReadOnly
 		result.Username = "root"

--- a/internal/adapter/nfs/auth/share_permission_test.go
+++ b/internal/adapter/nfs/auth/share_permission_test.go
@@ -90,10 +90,11 @@ func TestResolveSharePermission_DefaultPermissionReadWriteAllowsUnknownUID(t *te
 	}
 }
 
-// Behavior 2: SquashRootToAdmin (and the default empty squash) promote root
-// (UID 0) to admin with username "root".
+// Behavior 2: SquashRootToAdmin (and none / all_to_admin) promote root (UID 0)
+// to admin with username "root". Empty squash is NOT in this set — it defaults
+// to root_to_guest (see TestResolveSharePermission_EmptySquashDoesNotPromoteRoot).
 func TestResolveSharePermission_RootPromotedToAdmin(t *testing.T) {
-	for _, sq := range []models.SquashMode{"", models.SquashNone, models.SquashRootToAdmin, models.SquashAllToAdmin} {
+	for _, sq := range []models.SquashMode{models.SquashNone, models.SquashRootToAdmin, models.SquashAllToAdmin} {
 		store := newPermMockStore() // no user mapping; root path must not need one
 		share := &runtime.Share{
 			Name:              "/export",
@@ -111,6 +112,24 @@ func TestResolveSharePermission_RootPromotedToAdmin(t *testing.T) {
 		if res.ReadOnly {
 			t.Errorf("squash=%q: ReadOnly = true, want false (admin)", sq)
 		}
+	}
+}
+
+// Behavior 2b: an empty/unset squash defaults to root_to_guest, so root (UID 0)
+// is NOT promoted to admin — it is gated by default_permission like any guest.
+// With default_permission=none this denies root, matching conventional NFS
+// root_squash (the new default).
+func TestResolveSharePermission_EmptySquashDoesNotPromoteRoot(t *testing.T) {
+	store := newPermMockStore() // no UID 0 mapping → root falls through to guest
+	share := &runtime.Share{
+		Name:              "/export",
+		DefaultPermission: "none",
+		Squash:            "", // unset → DefaultSquashMode (root_to_guest)
+	}
+
+	_, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(0))
+	if !errors.Is(err, ErrShareAccessDenied) {
+		t.Fatalf("empty squash + default none: err = %v, want ErrShareAccessDenied (root not promoted)", err)
 	}
 }
 

--- a/internal/adapter/smb/handlers/tree_connect.go
+++ b/internal/adapter/smb/handlers/tree_connect.go
@@ -408,8 +408,8 @@ func isRootUser(user *models.User) bool {
 }
 
 // rootHasAdminAccess checks if the share's squash mode allows root to have admin access.
-// Root has admin access when squash mode is:
-//   - Empty string (default behavior = root_to_admin)
+// An empty/unset squash normalizes to DefaultSquashMode (root_to_guest), which
+// does NOT grant root admin. Root has admin access only when squash mode is:
 //   - SquashNone (no mapping)
 //   - SquashRootToAdmin (root keeps admin)
 //   - SquashAllToAdmin (everyone gets admin)
@@ -417,8 +417,10 @@ func rootHasAdminAccess(share *runtime.Share) bool {
 	if share == nil {
 		return false
 	}
-	return share.Squash == "" ||
-		share.Squash == models.SquashNone ||
-		share.Squash == models.SquashRootToAdmin ||
-		share.Squash == models.SquashAllToAdmin
+	switch share.Squash.OrDefault() {
+	case models.SquashNone, models.SquashRootToAdmin, models.SquashAllToAdmin:
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/adapter/smb/handlers/tree_connect_test.go
+++ b/internal/adapter/smb/handlers/tree_connect_test.go
@@ -390,9 +390,11 @@ func TestRootHasAdminAccess(t *testing.T) {
 	})
 
 	t.Run("EmptySquash", func(t *testing.T) {
+		// Empty squash normalizes to DefaultSquashMode (root_to_guest), which
+		// does NOT grant root admin.
 		share := &runtime.Share{Name: "/test", Squash: ""}
-		if !rootHasAdminAccess(share) {
-			t.Error("empty squash should allow root admin access")
+		if rootHasAdminAccess(share) {
+			t.Error("empty squash defaults to root_to_guest and should not allow root admin access")
 		}
 	})
 
@@ -812,7 +814,8 @@ func TestResolveSharePermission_RootBypass(t *testing.T) {
 		uid := uint32(0)
 		user := &models.User{Username: "admin", UID: &uid}
 		sess := session.NewSessionWithUser(1, "127.0.0.1", user, "")
-		share := &runtime.Share{Name: "/export", Squash: "", DefaultPermission: "read-write"}
+		// Explicit root_to_admin (no_root_squash) — root keeps admin.
+		share := &runtime.Share{Name: "/export", Squash: models.SquashRootToAdmin, DefaultPermission: "read-write"}
 		defaultPerm := models.PermissionReadWrite
 
 		perm, username := resolveSharePermission(ctx, sess, share, defaultPerm, nil)
@@ -822,6 +825,22 @@ func TestResolveSharePermission_RootBypass(t *testing.T) {
 		}
 		if username != "admin" {
 			t.Errorf("Username should be 'admin', got %q", username)
+		}
+	})
+
+	t.Run("RootUserWithEmptySquashIsSquashed", func(t *testing.T) {
+		uid := uint32(0)
+		user := &models.User{Username: "admin", UID: &uid}
+		sess := session.NewSessionWithUser(1, "127.0.0.1", user, "")
+		// Empty squash normalizes to DefaultSquashMode (root_to_guest), so root
+		// gets NO admin bypass — it falls back to the default permission.
+		share := &runtime.Share{Name: "/export", Squash: "", DefaultPermission: "read-write"}
+		defaultPerm := models.PermissionReadWrite
+
+		perm, _ := resolveSharePermission(ctx, sess, share, defaultPerm, nil)
+
+		if perm == models.PermissionAdmin {
+			t.Error("Root user with empty (default root_to_guest) squash should not get admin bypass")
 		}
 	})
 

--- a/internal/controlplane/api/handlers/share_adapter_config.go
+++ b/internal/controlplane/api/handlers/share_adapter_config.go
@@ -122,8 +122,8 @@ func (h *ShareNFSConfigHandler) Patch(w http.ResponseWriter, r *http.Request) {
 
 	if req.Squash != nil {
 		// Validate rather than store-and-echo: ParseSquashMode silently falls back
-		// to the default (root_to_admin) for anything unrecognized, so `--squash root`
-		// would quietly become "no root squash" without an error (#1181).
+		// to the default (root_to_guest) for anything unrecognized, so `--squash root`
+		// would quietly become the default squash without an error (#1181).
 		if *req.Squash != "" && !models.SquashMode(*req.Squash).IsValid() {
 			BadRequest(w, "Invalid squash: "+*req.Squash+" (want none|root_to_admin|root_to_guest|all_to_admin|all_to_guest)")
 			return

--- a/pkg/controlplane/models/permission.go
+++ b/pkg/controlplane/models/permission.go
@@ -97,8 +97,8 @@ func ParseSharePermission(s string) SharePermission {
 //
 // Options:
 //   - none: No mapping, UIDs pass through unchanged
-//   - root_to_admin: Root (UID 0) retains admin/root privileges (default)
-//   - root_to_guest: Root (UID 0) is mapped to anonymous (root_squash)
+//   - root_to_admin: Root (UID 0) retains admin/root privileges (no_root_squash)
+//   - root_to_guest: Root (UID 0) is mapped to anonymous (root_squash) (default)
 //   - all_to_admin: All users are mapped to root/admin
 //   - all_to_guest: All users are mapped to anonymous (all_squash)
 type SquashMode string
@@ -109,11 +109,13 @@ const (
 	SquashNone SquashMode = "none"
 
 	// SquashRootToAdmin means root (UID 0) retains admin/root privileges.
-	// This is the default behavior - root has full access.
+	// Equivalent to NFS "no_root_squash"; opt in per-share when a client's
+	// root must act as the server's root.
 	SquashRootToAdmin SquashMode = "root_to_admin"
 
 	// SquashRootToGuest means root (UID 0) is mapped to anonymous UID/GID.
-	// This is equivalent to traditional NFS "root_squash".
+	// This is equivalent to traditional NFS "root_squash" and is the default
+	// for new shares.
 	SquashRootToGuest SquashMode = "root_to_guest"
 
 	// SquashAllToAdmin means all users are mapped to root (UID 0).
@@ -125,9 +127,10 @@ const (
 	SquashAllToGuest SquashMode = "all_to_guest"
 )
 
-// DefaultSquashMode is the default squash mode for new shares.
-// Root retains admin privileges by default.
-const DefaultSquashMode = SquashRootToAdmin
+// DefaultSquashMode is the default squash mode for new shares. Root (UID 0) is
+// squashed to the anonymous identity (conventional NFS root_squash) unless a
+// share explicitly opts into root_to_admin / none / all_to_admin.
+const DefaultSquashMode = SquashRootToGuest
 
 // IsValid returns true if this is a valid squash mode.
 func (s SquashMode) IsValid() bool {
@@ -147,9 +150,14 @@ func (s SquashMode) String() string {
 // ParseSquashMode converts a string to a SquashMode.
 // Returns DefaultSquashMode if the string is not a valid mode.
 func ParseSquashMode(s string) SquashMode {
-	m := SquashMode(s)
-	if m.IsValid() {
-		return m
+	return SquashMode(s).OrDefault()
+}
+
+// OrDefault normalizes an empty or invalid squash mode to DefaultSquashMode
+// (root_to_guest), leaving any explicitly set valid mode unchanged.
+func (s SquashMode) OrDefault() SquashMode {
+	if s.IsValid() {
+		return s
 	}
 	return DefaultSquashMode
 }

--- a/pkg/controlplane/runtime/identity/service.go
+++ b/pkg/controlplane/runtime/identity/service.go
@@ -44,8 +44,11 @@ func (s *Service) ApplyIdentityMapping(shareName string, identity *metadata.Iden
 		return effective, nil
 	}
 
-	switch info.Squash {
-	case "", models.SquashNone, models.SquashRootToAdmin:
+	// Normalize empty/unset squash to DefaultSquashMode (root_to_guest) so an
+	// unconfigured share squashes root to anonymous instead of leaving it
+	// unmapped.
+	switch info.Squash.OrDefault() {
+	case models.SquashNone, models.SquashRootToAdmin:
 		// No mapping
 
 	case models.SquashRootToGuest:

--- a/pkg/controlplane/runtime/identity/service_test.go
+++ b/pkg/controlplane/runtime/identity/service_test.go
@@ -86,6 +86,9 @@ func TestApplyIdentityMapping_SquashModes(t *testing.T) {
 		// root_to_guest only squashes UID 0.
 		{"root_to_guest/root", models.SquashRootToGuest, 0, anonUID, "anonymous(65534)"},
 		{"root_to_guest/nonroot", models.SquashRootToGuest, 1000, 1000, "user"},
+		// Empty squash defaults to root_to_guest, so root (UID 0) is squashed
+		// to anonymous (the new default).
+		{"empty/root", "", 0, anonUID, "anonymous(65534)"},
 		// all_to_admin maps every UID to root.
 		{"all_to_admin/nonroot", models.SquashAllToAdmin, 1000, 0, "root"},
 		{"all_to_admin/root", models.SquashAllToAdmin, 0, 0, "root"},

--- a/test/posix/setup-posix.sh
+++ b/test/posix/setup-posix.sh
@@ -273,6 +273,17 @@ configure_via_api() {
         "$DITTOFSCTL_BIN" share create --name /export --metadata default --local default
     fi
 
+    # pjdfstest's prove(1) harness runs as root and relies on uid 0 retaining
+    # POSIX superuser privileges to build/tear down the test tree (chown to
+    # arbitrary uids, mknod, setuid bits) before it seteuid()s to the unprivileged
+    # test UIDs. The server default is now root_to_guest (root squashed to the
+    # anonymous identity), which strips that bypass and breaks the harness setup.
+    # POSIX conformance inherently requires a privileged root, so this export
+    # explicitly opts into no_root_squash — the legitimate root_to_admin use case,
+    # not a workaround for the new default.
+    log_info "Setting export squash to root_to_admin (pjdfstest requires a privileged root)..."
+    "$DITTOFSCTL_BIN" share nfs-config set /export --squash root_to_admin
+
     # Create and gate-grant the principals pjdfstest operates as.
     #
     # pjdfstest runs prove(1) as root (uid 0 superuser-bypasses POSIX, so it sets


### PR DESCRIPTION
## Why

DittoFS defaulted to `root_to_admin` (**no_root_squash**) — the inverse of every conventional NFS server / NAS (Linux nfsd, Synology, QNAP, TrueNAS all default to **root_squash**). Net effect: a client that could become root (`sudo`) wrote across the export as the *server's* root. This surprised a field user and is a well-known footgun.

This flips the default to `root_to_guest` (conventional `root_squash`): remote root is squashed to the anonymous identity. Regular UIDs still pass through (this is **not** `all_squash`).

## How

- `DefaultSquashMode = SquashRootToGuest`.
- New `SquashMode.OrDefault()` normalizes an empty/unset squash to the default; applied at the **three** interpretation sites — NFS `share_permission.go`, identity `ApplyIdentityMapping`, SMB `tree_connect.go` — so NFS and SMB stay aligned and the default is driven off one constant.
- **No DB migration**: existing empty-squash shares follow the new default at read time; new shares are stamped `root_to_guest` explicitly via `DefaultNFSExportOptions()`.

## Keeping root privileged

Set the share explicitly: `dfsctl share nfs-config set <share> --squash root_to_admin` (the real-NAS `no_root_squash` checkbox). `none` / `all_to_admin` also keep root privileged. Only the empty/default case changed.

## Safety

Audited: no raw `Squash == ""` / `root_to_admin` readers bypass normalization; explicit modes unchanged; the server's internal share-root creation never goes through `ApplyIdentityMapping`, so no internal UID-0 path is affected.

## Tests

`TestResolveSharePermission_EmptySquashDoesNotPromoteRoot`, identity `empty/root → anonymous(65534)`, SMB `RootUserWithEmptySquashIsSquashed`; `TestResolveSharePermission_RootPromotedToAdmin` now excludes empty. Build (incl. `-tags integration`), vet, golangci-lint clean.

## Docs

`docs/guide/nfs.md`: default marker moved to `root_to_guest`; squash now noted as applying live (no adapter restart — see #1451).

## Context

PR 3 of 3 from a field permissions report. Pairs with #1449 (NFSv3 denials → EACCES not EIO) and #1451 (auth-cache invalidation so squash changes apply live).