### PR TITLE
refactor(metadata): rename Backupable capability to Snapshotable (#1447)

### DIFF
--- a/bench/snapshots/workloads.go
+++ b/bench/snapshots/workloads.go
@@ -43,7 +43,7 @@ func (c *countingDiscard) Write(p []byte) (int, error) {
 
 // RunBackup runs a metadata Backup against a counting discard writer and
 // returns the dump size + the returned HashSet. The metadata engine must
-// implement Backupable (memory + badger both do). The harness itself does
+// implement Snapshotable (memory + badger both do). The harness itself does
 // not buffer the dump — the writer discards. Whether the dump is resident
 // depends on the engine: badger streams KV-by-KV (only the returned
 // HashSet is resident, the quantity the create-path ceiling is built
@@ -51,12 +51,12 @@ func (c *countingDiscard) Write(p []byte) (int, error) {
 // one internal buffer before writing (so its B/op reflects that buffer,
 // not a stream).
 func RunBackup(ctx context.Context, store metadata.Store) (BackupResult, error) {
-	backupable, ok := store.(metadata.Backupable)
+	snapshotable, ok := store.(metadata.Snapshotable)
 	if !ok {
-		return BackupResult{}, fmt.Errorf("snapshots bench: store is not Backupable")
+		return BackupResult{}, fmt.Errorf("snapshots bench: store is not Snapshotable")
 	}
 	cd := &countingDiscard{}
-	hs, err := backupable.Backup(ctx, cd)
+	hs, err := snapshotable.WriteSnapshot(ctx, cd)
 	if err != nil {
 		return BackupResult{}, fmt.Errorf("snapshots bench: backup: %w", err)
 	}

--- a/pkg/block/engine/drain_persist_test.go
+++ b/pkg/block/engine/drain_persist_test.go
@@ -292,17 +292,17 @@ func distinctContent(seed byte, n int) []byte {
 }
 
 // manifestHashes returns the set of DISTINCT content hashes the metadata
-// Backup manifest exposes, plus the serialized manifest size.
+// snapshot manifest exposes, plus the serialized manifest size.
 func manifestHashes(t *testing.T, ms metadata.Store) (*block.HashSet, int) {
 	t.Helper()
-	backupable, ok := ms.(metadata.Backupable)
+	snapshotable, ok := ms.(metadata.Snapshotable)
 	if !ok {
-		t.Fatal("store must implement metadata.Backupable")
+		t.Fatal("store must implement metadata.Snapshotable")
 	}
 	var buf bytes.Buffer
-	got, err := backupable.Backup(context.Background(), &buf)
+	got, err := snapshotable.WriteSnapshot(context.Background(), &buf)
 	if err != nil {
-		t.Fatalf("Backup: %v", err)
+		t.Fatalf("WriteSnapshot: %v", err)
 	}
 	return got, buf.Len()
 }
@@ -365,7 +365,7 @@ func runIdenticalContentDrain(t *testing.T, ms metadata.Store, sharePrefix strin
 		}
 	}
 	if missing > 0 {
-		t.Fatalf("Backup manifest missing %d/%d referenced hashes (manifest len=%d, buf=%d bytes)",
+		t.Fatalf("snapshot manifest missing %d/%d referenced hashes (manifest len=%d, buf=%d bytes)",
 			missing, want.Len(), got.Len(), bufLen)
 	}
 }

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -239,7 +239,7 @@ func (r *Runtime) SetShutdownTimeout(d time.Duration) {
 // ORDER IS LOAD-BEARING:
 //
 //  1. shutdownSnapshots — cancel in-flight snapshot goroutines and wait.
-//     These goroutines call into Backupable.Backup (on metadata stores)
+//     These goroutines call into Snapshotable.WriteSnapshot (on metadata stores)
 //     and r.store (control-plane DB). If metadata stores or the control
 //     plane were torn down first, snap goroutines would panic on
 //     use-after-close.

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -56,14 +56,14 @@ type CreateSnapshotOpts struct {
 // Synchronous failures returned to the caller:
 //   - shares.ErrShareNotFound — unknown share
 //   - ErrSnapshotBackupFailed wrap — share is memory-only (no local
-//     store dir) OR metadata engine doesn't implement metadata.Backupable
+//     store dir) OR metadata engine doesn't implement metadata.Snapshotable
 //   - models.ErrSnapshotRetryTargetNotFound / models.ErrSnapshotRetryTargetNotFailed
 //   - models.ErrSnapshotStateConflict — another in-flight snapshot
 //     already exists for this share (partial unique index)
 //   - wrapped fs error — snapshot directory could not be created
 //
 // Goroutine-only failures (observable via WaitForSnapshot):
-//   - models.ErrSnapshotBackupFailed — Backupable.Backup, dump write, or
+//   - models.ErrSnapshotBackupFailed — Snapshotable.WriteSnapshot, dump write, or
 //     manifest write failed
 //   - models.ErrSnapshotDrainTimeout — DrainAllUploads returned a ctx error
 //   - models.ErrSnapshotVerifyFailed — sync gate found missing hashes
@@ -88,14 +88,14 @@ func (r *Runtime) CreateSnapshot(ctx context.Context, shareName string, opts Cre
 			shareName, models.ErrSnapshotLocalStoreUnsupported)
 	}
 
-	// (2) Resolve metadata store + type-assert to Backupable.
+	// (2) Resolve metadata store + type-assert to Snapshotable.
 	metaStore, err := r.GetMetadataStoreForShare(shareName)
 	if err != nil {
 		return "", err
 	}
-	backupable, ok := metaStore.(metadata.Backupable)
+	snapshotable, ok := metaStore.(metadata.Snapshotable)
 	if !ok {
-		return "", fmt.Errorf("snapshot create %q: metadata engine does not implement Backupable: %w",
+		return "", fmt.Errorf("snapshot create %q: metadata engine does not implement Snapshotable: %w",
 			shareName, models.ErrSnapshotBackupFailed)
 	}
 
@@ -199,7 +199,7 @@ func (r *Runtime) CreateSnapshot(ctx context.Context, shareName string, opts Cre
 		snapID,
 		localStoreDir,
 		opts,
-		backupable,
+		snapshotable,
 		cancel,
 		doneCh,
 		entry,
@@ -449,7 +449,7 @@ func (r *Runtime) runSnapshotOrchestration(
 	snapID string,
 	localStoreDir string,
 	opts CreateSnapshotOpts,
-	backupable metadata.Backupable,
+	snapshotable metadata.Snapshotable,
 	cancel context.CancelFunc,
 	doneCh chan snapResult,
 	entry *snapInFlight,
@@ -488,9 +488,9 @@ func (r *Runtime) runSnapshotOrchestration(
 	// CRUD methods only need (shareName, id) so we don't need to refetch.
 	snap := &models.Snapshot{ID: snapID, ShareName: shareName}
 
-	// --- Step 0: Drain rollups BEFORE Backup ---
+	// --- Step 0: Drain rollups BEFORE WriteSnapshot ---
 	// Force every dirty append-log payload through rollup into CAS + the
-	// FileBlock manifest so the Backup() below sees a fully-populated
+	// FileBlock manifest so the WriteSnapshot() below sees a fully-populated
 	// FileAttr.Blocks. Without this, a snapshot taken before the async
 	// rollup catches up captures an empty/partial manifest.
 	// Resolve the block store once here; the verify gate (Step 4) reuses
@@ -515,15 +515,15 @@ func (r *Runtime) runSnapshotOrchestration(
 	}
 	logger.Debug("snapshot create: drain rollups complete", "snapshot_id", snapID, "share", shareName)
 
-	// --- Step 1: Backup -> metadata.dump (atomic temp+rename) ---
+	// --- Step 1: WriteSnapshot -> metadata.dump (atomic temp+rename) ---
 	dumpPath := snap.MetadataDumpPath(localStoreDir)
-	logger.Debug("snapshot create: backup start",
+	logger.Debug("snapshot create: write start",
 		"snapshot_id", snapID,
 		"share", shareName,
 		"dump_path", dumpPath,
 	)
 	hashSet, err := snapshot.WriteMetadataDumpAtomic(dumpPath, func(w io.Writer) (*block.HashSet, error) {
-		return backupable.Backup(ctx, w)
+		return snapshotable.WriteSnapshot(ctx, w)
 	})
 	if err != nil {
 		terminalErr = fmt.Errorf("snapshot create %s: backup: %w: %v",
@@ -839,7 +839,7 @@ func (r *Runtime) cancelAndWaitInFlightSnaps(shareName string) {
 //
 // Step 1 cancels runtimeCtx, which propagates to every child ctx derived in
 // registerSnapInFlight — every orchestration goroutine then notices the
-// cancellation at its next ctx-aware call (Backup, DrainAllUploads,
+// cancellation at its next ctx-aware call (WriteSnapshot, DrainAllUploads,
 // VerifyRemoteDurability, UpdateSnapshotState). The failSnap helper uses
 // context.Background, so the state=failed flip still completes even with
 // runtimeCtx cancelled.
@@ -1404,9 +1404,9 @@ func (r *Runtime) restoreSnapshot(
 		return safetySnapshotID, fmt.Errorf("restore snapshot %q: %w",
 			snapID, models.ErrMetadataStoreNotResetable)
 	}
-	backupable, ok := metaStore.(metadata.Backupable)
+	snapshotable, ok := metaStore.(metadata.Snapshotable)
 	if !ok {
-		return safetySnapshotID, fmt.Errorf("restore snapshot %q: metadata engine missing Backupable: %w",
+		return safetySnapshotID, fmt.Errorf("restore snapshot %q: metadata engine missing Snapshotable: %w",
 			snapID, models.ErrRestoreAborted)
 	}
 
@@ -1438,7 +1438,7 @@ func (r *Runtime) restoreSnapshot(
 	// corruption). Dropping the append-log overlay makes the restored CAS
 	// manifest the sole source of truth.
 	//
-	// This MUST run BEFORE resetable.Reset + backupable.Restore (not after):
+	// This MUST run BEFORE resetable.Reset + snapshotable.RestoreSnapshot (not after):
 	// background rollup workers run throughout the restore. If we cleared
 	// the overlay only after Restore repopulated the metadata, a rollup
 	// worker could call PersistFileBlocks against the freshly-restored
@@ -1485,7 +1485,7 @@ func (r *Runtime) restoreSnapshot(
 		"safety_snap_id", safetySnapshotID,
 		"dump_path", dumpPath,
 	)
-	if err := backupable.Restore(ctx, dumpFile); err != nil {
+	if err := snapshotable.RestoreSnapshot(ctx, dumpFile); err != nil {
 		return safetySnapshotID, fmt.Errorf("restore snapshot %q: restore (safety-snap=%s): %w: %v",
 			snapID, safetySnapshotID, models.ErrRestoreAborted, err)
 	}

--- a/pkg/controlplane/runtime/snapshot_concurrency_test.go
+++ b/pkg/controlplane/runtime/snapshot_concurrency_test.go
@@ -43,21 +43,21 @@ func stressIters() int {
 }
 
 // concFixture is a minimal runtime + one share wired with a real engine.Store
-// over memory local + memory remote + a controlledBackupable. Unlike
+// over memory local + memory remote + a controlledSnapshotable. Unlike
 // orchestrationFixture (one share for the whole test) this builds a fresh
 // share per call so each iteration gets a clean idx_share_creating slot. The
 // cpstore + remote are shared across iterations via t.Cleanup on the parent.
 type concFixture struct {
 	rt        *Runtime
-	backup    *controlledBackupable
+	backup    *controlledSnapshotable
 	shareName string
 }
 
 // newConcRuntime builds a Runtime with a shared cpstore + a single memory
 // metadata engine. Shares are added per scenario via addConcShare so the
 // idx_share_creating unique slot resets between iterations. Returns the shared
-// controlledBackupable so scenarios can install a per-test Backup hook.
-func newConcRuntime(t *testing.T) (*Runtime, *controlledBackupable) {
+// controlledSnapshotable so scenarios can install a per-test Backup hook.
+func newConcRuntime(t *testing.T) (*Runtime, *controlledSnapshotable) {
 	t.Helper()
 	// Use a real on-disk SQLite file rather than `:memory:` so the
 	// connection pool shares schema state across the orchestration
@@ -78,7 +78,7 @@ func newConcRuntime(t *testing.T) (*Runtime, *controlledBackupable) {
 	rt := New(cp)
 
 	mem := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	backup := &controlledBackupable{MemoryMetadataStore: mem}
+	backup := &controlledSnapshotable{MemoryMetadataStore: mem}
 	if err := rt.RegisterMetadataStore("memory", backup); err != nil {
 		t.Fatalf("RegisterMetadataStore: %v", err)
 	}
@@ -93,7 +93,7 @@ func newConcRuntime(t *testing.T) (*Runtime, *controlledBackupable) {
 
 // addConcShare registers a fresh share backed by a new engine.Store over the
 // shared memory metadata engine. Returns a concFixture pinned to that share.
-func addConcShare(t *testing.T, rt *Runtime, backup *controlledBackupable, shareName string) *concFixture {
+func addConcShare(t *testing.T, rt *Runtime, backup *controlledSnapshotable, shareName string) *concFixture {
 	t.Helper()
 
 	localStore := bsmemory.New()

--- a/pkg/controlplane/runtime/snapshot_consistency_test.go
+++ b/pkg/controlplane/runtime/snapshot_consistency_test.go
@@ -143,7 +143,7 @@ func (f *realBackupFixture) assertSnapshotConsistent(t *testing.T, snap *models.
 	// Restore the dump into a brand-new store. This reconstructs exactly
 	// the point-in-time metadata image the snapshot captured.
 	restored := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	if err := restored.Restore(context.Background(), dumpFile); err != nil {
+	if err := restored.RestoreSnapshot(context.Background(), dumpFile); err != nil {
 		t.Fatalf("snapshot %d: restore dump into fresh store: %v", n, err)
 	}
 
@@ -151,7 +151,7 @@ func (f *realBackupFixture) assertSnapshotConsistent(t *testing.T, snap *models.
 	// restored store (to a discard sink) and take the HashSet it derives
 	// from the restored files' BlockRefs. This is backend-agnostic and
 	// uses the same extraction path the manifest was built from.
-	dumpHashes, err := restored.Backup(context.Background(), io.Discard)
+	dumpHashes, err := restored.WriteSnapshot(context.Background(), io.Discard)
 	if err != nil {
 		t.Fatalf("snapshot %d: re-backup restored store: %v", n, err)
 	}

--- a/pkg/controlplane/runtime/snapshot_encryption_integration_test.go
+++ b/pkg/controlplane/runtime/snapshot_encryption_integration_test.go
@@ -81,7 +81,7 @@ func newEncryptedFixture(t *testing.T) *encryptedFixture {
 	rt := New(cp)
 
 	mem := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	backup := &controlledBackupable{MemoryMetadataStore: mem}
+	backup := &controlledSnapshotable{MemoryMetadataStore: mem}
 	if err := rt.RegisterMetadataStore("memory", backup); err != nil {
 		t.Fatalf("RegisterMetadataStore: %v", err)
 	}

--- a/pkg/controlplane/runtime/snapshot_integration_test.go
+++ b/pkg/controlplane/runtime/snapshot_integration_test.go
@@ -274,7 +274,7 @@ func testRemoveShareCancelsInFlight(t *testing.T) {
 	// Block Backup until either the context cancels or the test releases
 	// it explicitly. Per the plan body: prefer ctx-cancel-driven unblock
 	// (cancelAndWaitInFlightSnaps cancels the orchestration child ctx,
-	// which propagates to backupable.Backup's select).
+	// which propagates to snapshotable.WriteSnapshot's select).
 	started := make(chan struct{})
 	release := make(chan struct{})
 	fx.backup.setHook(func(ctx context.Context) error {
@@ -293,11 +293,11 @@ func testRemoveShareCancelsInFlight(t *testing.T) {
 		t.Fatalf("CreateSnapshot: %v", err)
 	}
 
-	// Wait for the orchestration goroutine to enter slowBackupable.Backup.
+	// Wait for the orchestration goroutine to enter slowSnapshotable.WriteSnapshot.
 	select {
 	case <-started:
 	case <-time.After(5 * time.Second):
-		t.Fatal("slowBackupable.Backup never reached: orchestration did not start backup")
+		t.Fatal("slowSnapshotable.WriteSnapshot never reached: orchestration did not start backup")
 	}
 
 	// Capture pre-RemoveShare on-disk paths so we can assert they
@@ -428,13 +428,13 @@ func testStartupRecovery(t *testing.T) {
 
 // orchestrationFixture composes every moving part the seven sub-tests
 // need: cpstore, runtime, memory metadata store wrapped in a controlled
-// Backupable, memory remote, real engine.Store wiring the local +
+// Snapshotable, memory remote, real engine.Store wiring the local +
 // remote, and an injected Share that ties them together.
 type orchestrationFixture struct {
 	t             *testing.T
 	rt            *Runtime
 	store         cpstore.Store
-	backup        *controlledBackupable
+	backup        *controlledSnapshotable
 	remote        *interceptingRemote
 	bs            *engine.Store
 	localStoreDir string
@@ -456,7 +456,7 @@ func newOrchestrationFixture(t *testing.T) *orchestrationFixture {
 	rt := New(cp)
 
 	mem := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	backup := &controlledBackupable{MemoryMetadataStore: mem}
+	backup := &controlledSnapshotable{MemoryMetadataStore: mem}
 	if err := rt.RegisterMetadataStore("memory", backup); err != nil {
 		t.Fatalf("RegisterMetadataStore: %v", err)
 	}
@@ -563,9 +563,9 @@ func (f *orchestrationFixture) seedRemoteSubset(hashes []block.ContentHash) {
 	}
 }
 
-// ----- controlledBackupable -----
+// ----- controlledSnapshotable -----
 
-// controlledBackupable wraps a real MemoryMetadataStore so it still
+// controlledSnapshotable wraps a real MemoryMetadataStore so it still
 // satisfies the full metadata.Store interface (via embedded
 // pointer method promotion) but overrides Backup so the test can:
 //   - return a deterministic HashSet without seeding files through the
@@ -575,7 +575,7 @@ func (f *orchestrationFixture) seedRemoteSubset(hashes []block.ContentHash) {
 //
 // The wrapper writes a few bytes to w so the resulting metadata.dump
 // file is non-empty (a SC-2 assertion).
-type controlledBackupable struct {
+type controlledSnapshotable struct {
 	*metadatamemory.MemoryMetadataStore
 
 	mu     sync.Mutex
@@ -583,19 +583,19 @@ type controlledBackupable struct {
 	hook   func(ctx context.Context) error
 }
 
-func (c *controlledBackupable) setHashes(h []block.ContentHash) {
+func (c *controlledSnapshotable) setHashes(h []block.ContentHash) {
 	c.mu.Lock()
 	c.hashes = append([]block.ContentHash(nil), h...)
 	c.mu.Unlock()
 }
 
-func (c *controlledBackupable) setHook(fn func(ctx context.Context) error) {
+func (c *controlledSnapshotable) setHook(fn func(ctx context.Context) error) {
 	c.mu.Lock()
 	c.hook = fn
 	c.mu.Unlock()
 }
 
-func (c *controlledBackupable) Backup(ctx context.Context, w io.Writer) (*block.HashSet, error) {
+func (c *controlledSnapshotable) WriteSnapshot(ctx context.Context, w io.Writer) (*block.HashSet, error) {
 	c.mu.Lock()
 	hook := c.hook
 	hashes := append([]block.ContentHash(nil), c.hashes...)

--- a/pkg/controlplane/runtime/snapshot_lifecycle_test.go
+++ b/pkg/controlplane/runtime/snapshot_lifecycle_test.go
@@ -143,17 +143,17 @@ func TestSnapshotLifecycleVsGC(t *testing.T) {
 		// live hash (hLive1) AND hSnap. hSnap diverges from live metadata
 		// to model the canonical "snapshot taken at T0, file deleted at
 		// T1" use case — without it the test would not distinguish
-		// "live FileBlock hash" from "snapshot-held hash". The Backup
-		// call below proves the Backupable wiring is reachable; the
+		// "live FileBlock hash" from "snapshot-held hash". The WriteSnapshot
+		// call below proves the Snapshotable wiring is reachable; the
 		// manifest itself is constructed explicitly so hSnap appears
-		// regardless of what live metadata Backup happens to extract.
+		// regardless of what live metadata WriteSnapshot happens to extract.
 		//
-		// Real callers persist Backup's bytes into metadata.dump; this
+		// Real callers persist WriteSnapshot's bytes into metadata.dump; this
 		// test discards them — only the GC mark phase consumes the
 		// manifest, and the manifest is written via WriteManifestAtomic
 		// below.
-		if _, err := backupAndDiscard(ctx, fx.metaStore); err != nil {
-			t.Fatalf("metadata Backup: %v", err)
+		if _, err := snapshotAndDiscard(ctx, fx.metaStore); err != nil {
+			t.Fatalf("metadata WriteSnapshot: %v", err)
 		}
 
 		manifestHS := block.NewHashSet(2)
@@ -336,14 +336,14 @@ func mustNotHave(t *testing.T, ctx context.Context, rs *remotememory.Store, h bl
 	}
 }
 
-// backupAndDiscard runs the memory backend's Backupable.Backup, discards the
-// bytes (real callers persist them to metadata.dump), and returns just the
-// HashSet for assertion. Surfaces the same call path the production snapshot
-// creator uses without coupling the test to manifest contents derived from
-// live metadata.
-func backupAndDiscard(ctx context.Context, st *metadatamemory.MemoryMetadataStore) (*block.HashSet, error) {
+// snapshotAndDiscard runs the memory backend's Snapshotable.WriteSnapshot,
+// discards the bytes (real callers persist them to metadata.dump), and returns
+// just the HashSet for assertion. Surfaces the same call path the production
+// snapshot creator uses without coupling the test to manifest contents derived
+// from live metadata.
+func snapshotAndDiscard(ctx context.Context, st *metadatamemory.MemoryMetadataStore) (*block.HashSet, error) {
 	var buf bytes.Buffer
-	return st.Backup(ctx, &buf)
+	return st.WriteSnapshot(ctx, &buf)
 }
 
 // TestSnapshotHoldProvider_DeleteVsHeldHashes_Race exercises the D-23-04

--- a/pkg/controlplane/runtime/snapshot_restore_test.go
+++ b/pkg/controlplane/runtime/snapshot_restore_test.go
@@ -906,7 +906,7 @@ var _ remote.RemoteStore = (*restoreRemote)(nil)
 // ----- failableResetable: Reset-injection wrapper for InterruptedRestore -----
 
 // failableResetable embeds a MemoryMetadataStore and forwards every
-// MetadataStore + Backupable method via method promotion. The Reset method
+// MetadataStore + Snapshotable method via method promotion. The Reset method
 // is overridden: when failNextReset is set the call returns a synthetic
 // error and the flag is consumed (one-shot). All other methods delegate
 // unchanged.
@@ -944,7 +944,7 @@ func (f *failableResetable) setFailNextReset(v bool) {
 
 // Compile-time guards: failableResetable satisfies both capabilities.
 var _ metadata.Resetable = (*failableResetable)(nil)
-var _ metadata.Backupable = (*failableResetable)(nil)
+var _ metadata.Snapshotable = (*failableResetable)(nil)
 
 // ----- shared helpers (subset duplicated from snapshot_integration_test.go) -----
 

--- a/pkg/metadata/resetable.go
+++ b/pkg/metadata/resetable.go
@@ -10,11 +10,11 @@ import "context"
 //
 // Reset is a destructive primitive intended to be invoked only by
 // Runtime.RestoreSnapshot after the operator has disabled the share.
-// It bypasses Backupable.Restore's ErrRestoreDestinationNotEmpty guard;
+// It bypasses Snapshotable.RestoreSnapshot's ErrRestoreDestinationNotEmpty guard;
 // callers must ensure no concurrent serving traffic is in flight.
 //
 // Implementations must preserve the live store handle so callers can
-// immediately follow up with Backupable.Restore. Engine-persistent
+// immediately follow up with Snapshotable.RestoreSnapshot. Engine-persistent
 // configuration that is not data (capabilities, storage/file limits,
 // GetStoreID) must also be preserved — resetting those would change
 // engine identity at the API surface.

--- a/pkg/metadata/snapshotable.go
+++ b/pkg/metadata/snapshotable.go
@@ -8,25 +8,25 @@ import (
 	"github.com/marmos91/dittofs/pkg/block"
 )
 
-// Backupable is an optional capability that metadata store backends may
-// implement to support share-level backup and restore. It is deliberately
+// Snapshotable is an optional capability that metadata store backends may
+// implement to support share-level snapshot and restore. It is deliberately
 // NOT embedded in MetadataStore so that protocol handlers and the runtime
-// never depend on backup support existing.
+// never depend on snapshot support existing.
 //
 // Call sites discover the capability via a type assertion:
 //
-//	if b, ok := store.(metadata.Backupable); ok {
-//	    hashes, err := b.Backup(ctx, w)
+//	if b, ok := store.(metadata.Snapshotable); ok {
+//	    hashes, err := b.WriteSnapshot(ctx, w)
 //	    ...
 //	}
 //
-// Backup writes engine-specific metadata into w and returns the set of
+// WriteSnapshot writes engine-specific metadata into w and returns the set of
 // block hashes referenced by the snapshot. The caller is responsible for
-// placing GC holds on those hashes before the backup stream is considered
+// placing GC holds on those hashes before the snapshot stream is considered
 // durable.
 //
-// Restore reads a previously-backed-up stream from r and rebuilds the
-// metadata state. The destination store must be empty (no existing share
+// RestoreSnapshot reads a previously-written snapshot stream from r and rebuilds
+// the metadata state. The destination store must be empty (no existing share
 // data); otherwise ErrRestoreDestinationNotEmpty is returned.
 //
 // Consistency contract (issue #811): blocks are immutable and
@@ -41,38 +41,38 @@ import (
 // concurrently; no global quiesce is required. The result is a true
 // point-in-time image: a file present in the dump always has its blocks in
 // the manifest, and vice versa. The ConcurrentWriter case in the storetest
-// backup conformance suite enforces this.
-type Backupable interface {
-	// Backup serializes all metadata into w and returns the set of
+// snapshot conformance suite enforces this.
+type Snapshotable interface {
+	// WriteSnapshot serializes all metadata into w and returns the set of
 	// content-addressed block hashes referenced by the snapshot, both
 	// captured from a single consistent read-view (see contract above).
-	Backup(ctx context.Context, w io.Writer) (*block.HashSet, error)
+	WriteSnapshot(ctx context.Context, w io.Writer) (*block.HashSet, error)
 
-	// Restore reads a backup stream from r and rebuilds metadata state.
+	// RestoreSnapshot reads a snapshot stream from r and rebuilds metadata state.
 	// The store must be empty; returns ErrRestoreDestinationNotEmpty otherwise.
-	Restore(ctx context.Context, r io.Reader) error
+	RestoreSnapshot(ctx context.Context, r io.Reader) error
 }
 
-// Backup/restore error sentinels. Callers detect these via errors.Is
+// Snapshot/restore error sentinels. Callers detect these via errors.Is
 // through any wrapping depth.
 var (
-	// ErrRestoreDestinationNotEmpty is returned by Restore when the target
+	// ErrRestoreDestinationNotEmpty is returned by RestoreSnapshot when the target
 	// store already contains data. The caller must provide an empty store.
 	ErrRestoreDestinationNotEmpty = errors.New("metadata: restore destination is not empty")
 
-	// ErrRestoreCorrupt is returned by Restore when the input stream
+	// ErrRestoreCorrupt is returned by RestoreSnapshot when the input stream
 	// fails integrity checks (bad CRC, truncated envelope, malformed
 	// engine payload).
 	ErrRestoreCorrupt = errors.New("metadata: restore data is corrupt")
 
-	// ErrSchemaVersionMismatch is returned by Restore when the backup
+	// ErrSchemaVersionMismatch is returned by RestoreSnapshot when the snapshot
 	// stream's schema version does not match the running engine's expected
 	// version. The operator must upgrade or downgrade the server before
 	// restoring.
 	ErrSchemaVersionMismatch = errors.New("metadata: schema version mismatch")
 
-	// ErrBackupAborted is returned by Backup when the operation is
+	// ErrSnapshotAborted is returned by WriteSnapshot when the operation is
 	// cancelled (context done) or otherwise cannot complete. Partial
 	// output written to w must be discarded by the caller.
-	ErrBackupAborted = errors.New("metadata: backup aborted")
+	ErrSnapshotAborted = errors.New("metadata: snapshot aborted")
 )

--- a/pkg/metadata/snapshotable_test.go
+++ b/pkg/metadata/snapshotable_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-func TestBackupSentinels_DetectThroughWrap(t *testing.T) {
+func TestSnapshotSentinels_DetectThroughWrap(t *testing.T) {
 	sentinels := []struct {
 		name string
 		err  error
@@ -16,7 +16,7 @@ func TestBackupSentinels_DetectThroughWrap(t *testing.T) {
 		{"ErrRestoreDestinationNotEmpty", metadata.ErrRestoreDestinationNotEmpty},
 		{"ErrRestoreCorrupt", metadata.ErrRestoreCorrupt},
 		{"ErrSchemaVersionMismatch", metadata.ErrSchemaVersionMismatch},
-		{"ErrBackupAborted", metadata.ErrBackupAborted},
+		{"ErrSnapshotAborted", metadata.ErrSnapshotAborted},
 	}
 	for _, tc := range sentinels {
 		t.Run(tc.name, func(t *testing.T) {
@@ -28,12 +28,12 @@ func TestBackupSentinels_DetectThroughWrap(t *testing.T) {
 	}
 }
 
-func TestBackupSentinels_NoCrossMatch(t *testing.T) {
+func TestSnapshotSentinels_NoCrossMatch(t *testing.T) {
 	sentinels := []error{
 		metadata.ErrRestoreDestinationNotEmpty,
 		metadata.ErrRestoreCorrupt,
 		metadata.ErrSchemaVersionMismatch,
-		metadata.ErrBackupAborted,
+		metadata.ErrSnapshotAborted,
 	}
 	for i, a := range sentinels {
 		for j, b := range sentinels {

--- a/pkg/metadata/store/badger/badger_conformance_test.go
+++ b/pkg/metadata/store/badger/badger_conformance_test.go
@@ -32,8 +32,8 @@ func TestConformance(t *testing.T) {
 	})
 }
 
-func TestBackupConformance(t *testing.T) {
-	storetest.RunBackupConformanceSuite(t, func(t *testing.T) metadata.Store {
+func TestSnapshotConformance(t *testing.T) {
+	storetest.RunSnapshotConformanceSuite(t, func(t *testing.T) metadata.Store {
 		dbPath := filepath.Join(t.TempDir(), "metadata.db")
 		store, err := badger.NewBadgerMetadataStoreWithDefaults(context.Background(), dbPath)
 		if err != nil {

--- a/pkg/metadata/store/badger/reset.go
+++ b/pkg/metadata/store/badger/reset.go
@@ -11,7 +11,7 @@ var _ metadata.Resetable = (*BadgerMetadataStore)(nil)
 
 // Reset truncates every key in the BadgerDB metadata store via db.DropAll.
 // The same *badger.DB handle stays valid; callers can immediately follow
-// up with Backupable.Restore. The cfg:store_id key is dropped along with
+// up with Snapshotable.RestoreSnapshot. The cfg:store_id key is dropped along with
 // everything else and gets repopulated by the next operation that needs
 // it (typically the restore dump that follows).
 func (s *BadgerMetadataStore) Reset(ctx context.Context) error {

--- a/pkg/metadata/store/badger/snapshot_store.go
+++ b/pkg/metadata/store/badger/snapshot_store.go
@@ -34,10 +34,10 @@ const (
 	maxRestoreAllocSize = 256 << 20
 )
 
-// Compile-time assertion: BadgerMetadataStore implements Backupable.
-var _ metadata.Backupable = (*BadgerMetadataStore)(nil)
+// Compile-time assertion: BadgerMetadataStore implements Snapshotable.
+var _ metadata.Snapshotable = (*BadgerMetadataStore)(nil)
 
-// Backup serializes all metadata into w using a custom length-prefixed KV
+// WriteSnapshot serializes all metadata into w using a custom length-prefixed KV
 // stream inside a single db.View() MVCC snapshot. It returns the set of
 // content-addressed block hashes referenced by file entries (f: prefix).
 //
@@ -48,9 +48,9 @@ var _ metadata.Backupable = (*BadgerMetadataStore)(nil)
 //   - value     [value_len]byte
 //
 // Stream terminated by sentinel key_len = 0 (4 zero bytes).
-func (s *BadgerMetadataStore) Backup(ctx context.Context, w io.Writer) (*block.HashSet, error) {
+func (s *BadgerMetadataStore) WriteSnapshot(ctx context.Context, w io.Writer) (*block.HashSet, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, fmt.Errorf("%w: %v", metadata.ErrBackupAborted, err)
+		return nil, fmt.Errorf("%w: %v", metadata.ErrSnapshotAborted, err)
 	}
 
 	hs := block.NewHashSet(0)
@@ -68,14 +68,14 @@ func (s *BadgerMetadataStore) Backup(ctx context.Context, w io.Writer) (*block.H
 		var writeErr error
 		envW, writeErr = backup.NewWriter(w, badgerEngineTag)
 		if writeErr != nil {
-			return fmt.Errorf("%w: envelope: %v", metadata.ErrBackupAborted, writeErr)
+			return fmt.Errorf("%w: envelope: %v", metadata.ErrSnapshotAborted, writeErr)
 		}
 
 		// Write schema version (uint32 LE).
 		var verBuf [4]byte
 		binary.LittleEndian.PutUint32(verBuf[:], badgerSchemaVersion)
 		if _, writeErr = envW.Write(verBuf[:]); writeErr != nil {
-			return fmt.Errorf("%w: schema version: %v", metadata.ErrBackupAborted, writeErr)
+			return fmt.Errorf("%w: schema version: %v", metadata.ErrSnapshotAborted, writeErr)
 		}
 
 		opts := badgerdb.DefaultIteratorOptions
@@ -89,32 +89,32 @@ func (s *BadgerMetadataStore) Backup(ctx context.Context, w io.Writer) (*block.H
 
 		for it.Rewind(); it.Valid(); it.Next() {
 			if err := ctx.Err(); err != nil {
-				return fmt.Errorf("%w: %v", metadata.ErrBackupAborted, err)
+				return fmt.Errorf("%w: %v", metadata.ErrSnapshotAborted, err)
 			}
 
 			item := it.Item()
 			key := item.KeyCopy(nil)
 			val, err := item.ValueCopy(nil)
 			if err != nil {
-				return fmt.Errorf("%w: value copy: %v", metadata.ErrBackupAborted, err)
+				return fmt.Errorf("%w: value copy: %v", metadata.ErrSnapshotAborted, err)
 			}
 
 			// Write key_len + key.
 			binary.LittleEndian.PutUint32(buf[:], uint32(len(key)))
 			if _, err := envW.Write(buf[:]); err != nil {
-				return fmt.Errorf("%w: write key_len: %v", metadata.ErrBackupAborted, err)
+				return fmt.Errorf("%w: write key_len: %v", metadata.ErrSnapshotAborted, err)
 			}
 			if _, err := envW.Write(key); err != nil {
-				return fmt.Errorf("%w: write key: %v", metadata.ErrBackupAborted, err)
+				return fmt.Errorf("%w: write key: %v", metadata.ErrSnapshotAborted, err)
 			}
 
 			// Write value_len + value.
 			binary.LittleEndian.PutUint32(buf[:], uint32(len(val)))
 			if _, err := envW.Write(buf[:]); err != nil {
-				return fmt.Errorf("%w: write value_len: %v", metadata.ErrBackupAborted, err)
+				return fmt.Errorf("%w: write value_len: %v", metadata.ErrSnapshotAborted, err)
 			}
 			if _, err := envW.Write(val); err != nil {
-				return fmt.Errorf("%w: write value: %v", metadata.ErrBackupAborted, err)
+				return fmt.Errorf("%w: write value: %v", metadata.ErrSnapshotAborted, err)
 			}
 
 			// Hash extraction: decode f: prefix entries for block hashes.
@@ -144,7 +144,7 @@ func (s *BadgerMetadataStore) Backup(ctx context.Context, w io.Writer) (*block.H
 		// Write sentinel: key_len = 0.
 		binary.LittleEndian.PutUint32(buf[:], 0)
 		if _, err := envW.Write(buf[:]); err != nil {
-			return fmt.Errorf("%w: write sentinel: %v", metadata.ErrBackupAborted, err)
+			return fmt.Errorf("%w: write sentinel: %v", metadata.ErrSnapshotAborted, err)
 		}
 
 		return nil
@@ -155,13 +155,13 @@ func (s *BadgerMetadataStore) Backup(ctx context.Context, w io.Writer) (*block.H
 
 	// Write trailing CRC.
 	if err := envW.Finish(); err != nil {
-		return nil, fmt.Errorf("%w: finish envelope: %v", metadata.ErrBackupAborted, err)
+		return nil, fmt.Errorf("%w: finish envelope: %v", metadata.ErrSnapshotAborted, err)
 	}
 
 	return hs, nil
 }
 
-// Restore reads a backup stream from r and rebuilds metadata state in the
+// RestoreSnapshot reads a backup stream from r and rebuilds metadata state in the
 // Badger store. The store must be empty (no existing share data); otherwise
 // ErrRestoreDestinationNotEmpty is returned.
 //
@@ -170,7 +170,7 @@ func (s *BadgerMetadataStore) Backup(ctx context.Context, w io.Writer) (*block.H
 // CRC is verified last, and any failure triggers a DropAll. Because the
 // destination was empty before restore began, a corrupt stream is wiped back
 // to empty and the restore stays retryable.
-func (s *BadgerMetadataStore) Restore(ctx context.Context, r io.Reader) error {
+func (s *BadgerMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) error {
 	// Check destination is empty by looking for any s: prefix key.
 	isEmpty, err := s.isStoreEmpty()
 	if err != nil {

--- a/pkg/metadata/store/badger/tx_usedbytes_integration_test.go
+++ b/pkg/metadata/store/badger/tx_usedbytes_integration_test.go
@@ -149,7 +149,7 @@ func TestBadger_Restore_ReinitsUsedBytes(t *testing.T) {
 
 	// --- BACKUP ---
 	var buf bytes.Buffer
-	if _, err := src.Backup(ctx, &buf); err != nil {
+	if _, err := src.WriteSnapshot(ctx, &buf); err != nil {
 		t.Fatalf("Backup: %v", err)
 	}
 
@@ -166,7 +166,7 @@ func TestBadger_Restore_ReinitsUsedBytes(t *testing.T) {
 	}
 
 	// --- RESTORE ---
-	if err := dst.Restore(ctx, &buf); err != nil {
+	if err := dst.RestoreSnapshot(ctx, &buf); err != nil {
 		t.Fatalf("Restore: %v", err)
 	}
 

--- a/pkg/metadata/store/memory/memory_conformance_test.go
+++ b/pkg/metadata/store/memory/memory_conformance_test.go
@@ -15,8 +15,8 @@ func TestConformance(t *testing.T) {
 	})
 }
 
-func TestBackupConformance(t *testing.T) {
-	storetest.RunBackupConformanceSuite(t, func(t *testing.T) metadata.Store {
+func TestSnapshotConformance(t *testing.T) {
+	storetest.RunSnapshotConformanceSuite(t, func(t *testing.T) metadata.Store {
 		return memory.NewMemoryMetadataStoreWithDefaults()
 	})
 }

--- a/pkg/metadata/store/memory/snapshot_store.go
+++ b/pkg/metadata/store/memory/snapshot_store.go
@@ -86,16 +86,16 @@ type durableSnapshotData struct {
 	Handles map[string]*lock.PersistedDurableHandle
 }
 
-// Compile-time assertion: MemoryMetadataStore implements Backupable.
-var _ metadata.Backupable = (*MemoryMetadataStore)(nil)
+// Compile-time assertion: MemoryMetadataStore implements Snapshotable.
+var _ metadata.Snapshotable = (*MemoryMetadataStore)(nil)
 
-// Backup serializes the entire in-memory state under a read lock and
+// WriteSnapshot serializes the entire in-memory state under a read lock and
 // writes it into w using the shared envelope format. The returned
 // HashSet contains every unique content-addressed block hash referenced
 // by the snapshot (extracted inline during serialization).
-func (s *MemoryMetadataStore) Backup(ctx context.Context, w io.Writer) (*block.HashSet, error) {
+func (s *MemoryMetadataStore) WriteSnapshot(ctx context.Context, w io.Writer) (*block.HashSet, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, fmt.Errorf("%w: %v", metadata.ErrBackupAborted, err)
+		return nil, fmt.Errorf("%w: %v", metadata.ErrSnapshotAborted, err)
 	}
 
 	s.mu.RLock()
@@ -147,7 +147,7 @@ func (s *MemoryMetadataStore) Backup(ctx context.Context, w io.Writer) (*block.H
 	if len(s.serverConfig.CustomSettings) > 0 {
 		csJSON, err := json.Marshal(s.serverConfig.CustomSettings)
 		if err != nil {
-			return nil, fmt.Errorf("%w: encode custom settings: %v", metadata.ErrBackupAborted, err)
+			return nil, fmt.Errorf("%w: encode custom settings: %v", metadata.ErrSnapshotAborted, err)
 		}
 		snap.ServerConfigCustomSettingsJSON = csJSON
 		// Nil out the unserializable field in the snapshot copy so gob
@@ -201,14 +201,14 @@ func (s *MemoryMetadataStore) Backup(ctx context.Context, w io.Writer) (*block.H
 	// Write the envelope: header (magic + version + engine tag).
 	envW, err := backup.NewWriter(w, memoryEngineTag)
 	if err != nil {
-		return nil, fmt.Errorf("%w: envelope header: %v", metadata.ErrBackupAborted, err)
+		return nil, fmt.Errorf("%w: envelope header: %v", metadata.ErrSnapshotAborted, err)
 	}
 
 	// Write schema version (4-byte LE uint32).
 	var vBuf [4]byte
 	binary.LittleEndian.PutUint32(vBuf[:], memorySchemaVersion)
 	if _, err := envW.Write(vBuf[:]); err != nil {
-		return nil, fmt.Errorf("%w: schema version: %v", metadata.ErrBackupAborted, err)
+		return nil, fmt.Errorf("%w: schema version: %v", metadata.ErrSnapshotAborted, err)
 	}
 
 	// Gob-encode the snapshot into a temporary buffer so we can write
@@ -218,33 +218,33 @@ func (s *MemoryMetadataStore) Backup(ctx context.Context, w io.Writer) (*block.H
 	var gobBuf bytes.Buffer
 	enc := gob.NewEncoder(&gobBuf)
 	if err := enc.Encode(&snap); err != nil {
-		return nil, fmt.Errorf("%w: gob encode: %v", metadata.ErrBackupAborted, err)
+		return nil, fmt.Errorf("%w: gob encode: %v", metadata.ErrSnapshotAborted, err)
 	}
 
 	// Write gob payload length (8-byte LE uint64).
 	var lenBuf [8]byte
 	binary.LittleEndian.PutUint64(lenBuf[:], uint64(gobBuf.Len()))
 	if _, err := envW.Write(lenBuf[:]); err != nil {
-		return nil, fmt.Errorf("%w: payload length: %v", metadata.ErrBackupAborted, err)
+		return nil, fmt.Errorf("%w: payload length: %v", metadata.ErrSnapshotAborted, err)
 	}
 
 	// Write the gob payload.
 	if _, err := envW.Write(gobBuf.Bytes()); err != nil {
-		return nil, fmt.Errorf("%w: payload write: %v", metadata.ErrBackupAborted, err)
+		return nil, fmt.Errorf("%w: payload write: %v", metadata.ErrSnapshotAborted, err)
 	}
 
 	// Trailing CRC.
 	if err := envW.Finish(); err != nil {
-		return nil, fmt.Errorf("%w: envelope finish: %v", metadata.ErrBackupAborted, err)
+		return nil, fmt.Errorf("%w: envelope finish: %v", metadata.ErrSnapshotAborted, err)
 	}
 
 	return hs, nil
 }
 
-// Restore reads a backup stream from r and rebuilds the store state.
+// RestoreSnapshot reads a backup stream from r and rebuilds the store state.
 // The destination store must be empty (no shares); otherwise
 // ErrRestoreDestinationNotEmpty is returned.
-func (s *MemoryMetadataStore) Restore(ctx context.Context, r io.Reader) error {
+func (s *MemoryMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) error {
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("restore cancelled: %w", err)
 	}

--- a/pkg/metadata/store/postgres/postgres_blockref_test.go
+++ b/pkg/metadata/store/postgres/postgres_blockref_test.go
@@ -408,13 +408,13 @@ func TestPostgres_Restore_ReconcilesNullHashFileBlocks(t *testing.T) {
 		t.Fatalf("pre-backup file_blocks.hash = %q, want NULL", got)
 	}
 
-	backupable, ok := store.(metadata.Backupable)
+	snapshotable, ok := store.(metadata.Snapshotable)
 	if !ok {
-		t.Fatalf("store does not implement Backupable")
+		t.Fatalf("store does not implement Snapshotable")
 	}
 
 	var buf bytes.Buffer
-	if _, err := backupable.Backup(ctx, &buf); err != nil {
+	if _, err := snapshotable.WriteSnapshot(ctx, &buf); err != nil {
 		t.Fatalf("Backup: %v", err)
 	}
 
@@ -428,7 +428,7 @@ func TestPostgres_Restore_ReconcilesNullHashFileBlocks(t *testing.T) {
 		t.Fatalf("Reset: %v", err)
 	}
 
-	if err := backupable.Restore(ctx, &buf); err != nil {
+	if err := snapshotable.RestoreSnapshot(ctx, &buf); err != nil {
 		t.Fatalf("Restore: %v", err)
 	}
 

--- a/pkg/metadata/store/postgres/postgres_conformance_test.go
+++ b/pkg/metadata/store/postgres/postgres_conformance_test.go
@@ -102,12 +102,12 @@ func TestConformance(t *testing.T) {
 	storetest.RunConformanceSuite(t, newPostgresStoreFactory())
 }
 
-func TestBackupConformance(t *testing.T) {
+func TestSnapshotConformance(t *testing.T) {
 	if os.Getenv("DITTOFS_TEST_POSTGRES_DSN") == "" {
-		t.Skip("DITTOFS_TEST_POSTGRES_DSN not set, skipping PostgreSQL backup conformance tests")
+		t.Skip("DITTOFS_TEST_POSTGRES_DSN not set, skipping PostgreSQL snapshot conformance tests")
 	}
 
-	storetest.RunBackupConformanceSuite(t, newPostgresStoreFactory())
+	storetest.RunSnapshotConformanceSuite(t, newPostgresStoreFactory())
 }
 
 func TestResetThenRestoreConformance(t *testing.T) {

--- a/pkg/metadata/store/postgres/snapshot_store.go
+++ b/pkg/metadata/store/postgres/snapshot_store.go
@@ -63,16 +63,16 @@ var backupTables = []string{
 	"synced_hashes",
 }
 
-// Compile-time assertion: PostgresMetadataStore implements Backupable.
-var _ metadata.Backupable = (*PostgresMetadataStore)(nil)
+// Compile-time assertion: PostgresMetadataStore implements Snapshotable.
+var _ metadata.Snapshotable = (*PostgresMetadataStore)(nil)
 
-// Backup serializes all Postgres metadata tables into w using COPY TO
+// WriteSnapshot serializes all Postgres metadata tables into w using COPY TO
 // STDOUT inside a single REPEATABLE READ transaction for snapshot
 // isolation. Returns the set of unique block hashes referenced by the
 // snapshot (extracted from file_block_refs via a dedicated COPY query).
-func (s *PostgresMetadataStore) Backup(ctx context.Context, w io.Writer) (*block.HashSet, error) {
+func (s *PostgresMetadataStore) WriteSnapshot(ctx context.Context, w io.Writer) (*block.HashSet, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, fmt.Errorf("%w: %v", metadata.ErrBackupAborted, err)
+		return nil, fmt.Errorf("%w: %v", metadata.ErrSnapshotAborted, err)
 	}
 
 	// Acquire a dedicated connection for raw protocol-level COPY operations.
@@ -118,7 +118,7 @@ func (s *PostgresMetadataStore) Backup(ctx context.Context, w io.Writer) (*block
 	// COPY each table to the envelope.
 	for _, table := range backupTables {
 		if err := ctx.Err(); err != nil {
-			return nil, fmt.Errorf("%w: %v", metadata.ErrBackupAborted, err)
+			return nil, fmt.Errorf("%w: %v", metadata.ErrSnapshotAborted, err)
 		}
 
 		if err := backupTable(ctx, raw, envW, table); err != nil {
@@ -232,10 +232,10 @@ func extractHashes(ctx context.Context, raw *pgconn.PgConn) (*block.HashSet, err
 	return hs, nil
 }
 
-// Restore reads a Postgres backup stream from r and rebuilds metadata
+// RestoreSnapshot reads a Postgres backup stream from r and rebuilds metadata
 // by COPY FROM STDIN into each table. The destination store must be
 // empty (no shares); returns ErrRestoreDestinationNotEmpty otherwise.
-func (s *PostgresMetadataStore) Restore(ctx context.Context, r io.Reader) error {
+func (s *PostgresMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) error {
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("restore cancelled: %w", err)
 	}

--- a/pkg/metadata/store/sqlite/snapshot_store.go
+++ b/pkg/metadata/store/sqlite/snapshot_store.go
@@ -13,15 +13,15 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/backup"
 )
 
-// sqliteEngineTag identifies SQLite-produced backup streams; Restore refuses a
+// sqliteEngineTag identifies SQLite-produced backup streams; RestoreSnapshot refuses a
 // stream tagged for a different engine.
 const sqliteEngineTag = "sqlite"
 
 // sqliteSchemaVersion is bumped whenever the on-disk schema changes in a way
-// that makes an older backup unrestorable. Restore rejects a mismatch.
+// that makes an older backup unrestorable. RestoreSnapshot rejects a mismatch.
 const sqliteSchemaVersion uint32 = 1
 
-// backupTables lists every table dumped by Backup and reloaded by Restore, in a
+// backupTables lists every table dumped by WriteSnapshot and reloaded by RestoreSnapshot, in a
 // FK-safe order for restore (parents before children). inodes must precede
 // parent_child_map / file_block_refs / locks / durable_handles (all reference
 // inodes), and shares references inodes(root_file_id).
@@ -62,14 +62,17 @@ const (
 	cellBlob  byte = 4
 )
 
-// Backup serializes the entire metadata database into a CRC-protected envelope
+// Compile-time assertion: SQLiteMetadataStore implements Snapshotable.
+var _ metadata.Snapshotable = (*SQLiteMetadataStore)(nil)
+
+// WriteSnapshot serializes the entire metadata database into a CRC-protected envelope
 // and returns the set of distinct content hashes referenced by file_block_refs
 // (so the caller can pin the corresponding blocks). It is a logical, row-based
 // export — portable across SQLite file formats and independent of the on-disk
 // page layout.
-func (s *SQLiteMetadataStore) Backup(ctx context.Context, w io.Writer) (*block.HashSet, error) {
+func (s *SQLiteMetadataStore) WriteSnapshot(ctx context.Context, w io.Writer) (*block.HashSet, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, fmt.Errorf("%w: %v", metadata.ErrBackupAborted, err)
+		return nil, fmt.Errorf("%w: %v", metadata.ErrSnapshotAborted, err)
 	}
 
 	// A single read transaction gives a consistent snapshot across all tables.
@@ -98,7 +101,7 @@ func (s *SQLiteMetadataStore) Backup(ctx context.Context, w io.Writer) (*block.H
 
 	for _, table := range backupTables {
 		if err := ctx.Err(); err != nil {
-			return nil, fmt.Errorf("%w: %v", metadata.ErrBackupAborted, err)
+			return nil, fmt.Errorf("%w: %v", metadata.ErrSnapshotAborted, err)
 		}
 		if err := backupTable(ctx, tx, envW, table); err != nil {
 			return nil, fmt.Errorf("backup: table %s: %w", table, err)
@@ -210,10 +213,10 @@ WHERE i.nlink > 0`)
 	return hs, nil
 }
 
-// Restore replaces the (must-be-empty) database contents from a backup stream
-// produced by Backup. It verifies the envelope CRC before committing so a
+// RestoreSnapshot replaces the (must-be-empty) database contents from a snapshot
+// stream produced by WriteSnapshot. It verifies the envelope CRC before committing so a
 // truncated or corrupt stream never leaves a partial state.
-func (s *SQLiteMetadataStore) Restore(ctx context.Context, r io.Reader) error {
+func (s *SQLiteMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) error {
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("restore cancelled: %w", err)
 	}

--- a/pkg/metadata/store/sqlite/sqlite_conformance_test.go
+++ b/pkg/metadata/store/sqlite/sqlite_conformance_test.go
@@ -59,8 +59,8 @@ func TestConformance(t *testing.T) {
 	storetest.RunConformanceSuite(t, newSQLiteStoreFactory())
 }
 
-func TestBackupConformance(t *testing.T) {
-	storetest.RunBackupConformanceSuite(t, newSQLiteStoreFactory())
+func TestSnapshotConformance(t *testing.T) {
+	storetest.RunSnapshotConformanceSuite(t, newSQLiteStoreFactory())
 }
 
 func TestResetThenRestoreConformance(t *testing.T) {

--- a/pkg/metadata/storetest/blockref_roundtrip.go
+++ b/pkg/metadata/storetest/blockref_roundtrip.go
@@ -61,7 +61,7 @@ func runBlockRefOpsTests(t *testing.T, factory StoreFactory) {
 // testBlockRef_MultiPassMerge guards the store-layer contract that a file's
 // complete block list survives successive PutFile calls — both an append
 // (A then A+B) and an in-place overlay of an existing offset (A'). GetFile
-// and Backup must return the full, correct set after each pass; no earlier
+// and WriteSnapshot must return the full, correct set after each pass; no earlier
 // offset may be dropped.
 //
 // This mirrors the engine's multi-pass rollup, which persists a file's blocks
@@ -69,7 +69,7 @@ func runBlockRefOpsTests(t *testing.T, factory StoreFactory) {
 // refs (REPLACE-by-partial-list) instead of the complete merged list would
 // silently drop earlier offsets — exactly the data-loss class this asserts
 // against. The contract is: whatever complete list the caller hands PutFile,
-// GetFile/Backup return it intact and ordered by offset.
+// GetFile/WriteSnapshot return it intact and ordered by offset.
 func testBlockRef_MultiPassMerge(t *testing.T, factory StoreFactory) {
 	store := factory(t)
 
@@ -84,7 +84,7 @@ func testBlockRef_MultiPassMerge(t *testing.T, factory StoreFactory) {
 	}
 	putBlocks(t, store, fileHandle, listA)
 	assertBlocks(t, store, fileHandle, listA)
-	assertBackupContains(t, store, listA)
+	assertSnapshotContains(t, store, listA)
 
 	// Pass 2 — append block list B onto A. The caller computes the complete
 	// merged list (A+B); the store must persist all of it. A REPLACE-only
@@ -96,7 +96,7 @@ func testBlockRef_MultiPassMerge(t *testing.T, factory StoreFactory) {
 	merged := append(append([]block.BlockRef(nil), listA...), listB...)
 	putBlocks(t, store, fileHandle, merged)
 	assertBlocks(t, store, fileHandle, merged)
-	assertBackupContains(t, store, merged)
+	assertSnapshotContains(t, store, merged)
 
 	// Pass 3 — in-place overlay: rewrite the block at offset 1 MiB (A1 -> A1')
 	// while keeping every other offset. The overlay must replace only that
@@ -105,12 +105,12 @@ func testBlockRef_MultiPassMerge(t *testing.T, factory StoreFactory) {
 	overlay[1].Hash = hashOfSeed("mp-a1-overlay")
 	putBlocks(t, store, fileHandle, overlay)
 	assertBlocks(t, store, fileHandle, overlay)
-	assertBackupContains(t, store, overlay)
+	assertSnapshotContains(t, store, overlay)
 
 	// The superseded hash must no longer be referenced after the overlay.
-	bk := backupHashes(t, store)
+	bk := snapshotHashes(t, store)
 	if bk.Contains(hashOfSeed("mp-a1")) {
-		t.Errorf("Backup still references superseded hash mp-a1 after overlay")
+		t.Errorf("WriteSnapshot still references superseded hash mp-a1 after overlay")
 	}
 }
 
@@ -150,33 +150,33 @@ func assertBlocks(t *testing.T, store metadata.Store, fileHandle metadata.FileHa
 	}
 }
 
-// backupHashes runs Backup and returns the referenced-hash set, discarding
+// snapshotHashes runs WriteSnapshot and returns the referenced-hash set, discarding
 // the serialized stream.
-func backupHashes(t *testing.T, store metadata.Store) *block.HashSet {
+func snapshotHashes(t *testing.T, store metadata.Store) *block.HashSet {
 	t.Helper()
 	ctx := t.Context()
 
-	bk, ok := store.(metadata.Backupable)
+	bk, ok := store.(metadata.Snapshotable)
 	if !ok {
-		t.Fatalf("backend does not implement metadata.Backupable")
+		t.Fatalf("backend does not implement metadata.Snapshotable")
 	}
-	hs, err := bk.Backup(ctx, io.Discard)
+	hs, err := bk.WriteSnapshot(ctx, io.Discard)
 	if err != nil {
-		t.Fatalf("Backup: %v", err)
+		t.Fatalf("WriteSnapshot: %v", err)
 	}
 	return hs
 }
 
-// assertBackupContains asserts Backup's referenced-hash set includes every
+// assertSnapshotContains asserts WriteSnapshot's referenced-hash set includes every
 // block hash in want — the snapshot's block manifest must cover the complete
 // list, not just the latest persisted segment.
-func assertBackupContains(t *testing.T, store metadata.Store, want []block.BlockRef) {
+func assertSnapshotContains(t *testing.T, store metadata.Store, want []block.BlockRef) {
 	t.Helper()
 
-	hs := backupHashes(t, store)
+	hs := snapshotHashes(t, store)
 	for _, b := range want {
 		if !hs.Contains(b.Hash) {
-			t.Errorf("Backup hash set missing block at offset %d (hash %x)", b.Offset, b.Hash[:8])
+			t.Errorf("WriteSnapshot hash set missing block at offset %d (hash %x)", b.Offset, b.Hash[:8])
 		}
 	}
 }

--- a/pkg/metadata/storetest/reset_conformance.go
+++ b/pkg/metadata/storetest/reset_conformance.go
@@ -8,7 +8,7 @@ import (
 )
 
 // asResetable is a helper that type-asserts a MetadataStore to Resetable,
-// calling t.Fatal if the assertion fails. Mirrors asBackupable.
+// calling t.Fatal if the assertion fails. Mirrors asSnapshotable.
 func asResetable(t *testing.T, store metadata.Store) metadata.Resetable {
 	t.Helper()
 	r, ok := store.(metadata.Resetable)
@@ -19,33 +19,33 @@ func asResetable(t *testing.T, store metadata.Store) metadata.Resetable {
 }
 
 // ResetThenRestoreConformance verifies that a store implementing both
-// Backupable and Resetable satisfies the restore-flow contract: a
+// Snapshotable and Resetable satisfies the restore-flow contract: a
 // populated store can be backed up, Reset to empty, then restored from
 // the same backup to its original content. Reset must leave the store
 // empty enough for Restore to proceed past its
 // ErrRestoreDestinationNotEmpty precondition, and the restored state
 // must equal the pre-Reset state.
-func ResetThenRestoreConformance(t *testing.T, factory BackupableStoreFactory) {
+func ResetThenRestoreConformance(t *testing.T, factory SnapshotableStoreFactory) {
 	t.Helper()
 
 	store := factory(t)
-	b := asBackupable(t, store)
+	b := asSnapshotable(t, store)
 	r := asResetable(t, store)
 
 	ctx := t.Context()
 
 	// Populate: unique prefix "rst" to avoid name collisions if a factory
-	// reuses the same backing DB across the Backup suite and this suite.
+	// reuses the same backing DB across the Snapshot suite and this suite.
 	shareName, uniqueHashes := populateTestData(t, store, "rst")
 
 	// 1. Back up the populated store into a buffer.
 	var dumpBuf bytes.Buffer
-	hs, err := b.Backup(ctx, &dumpBuf)
+	hs, err := b.WriteSnapshot(ctx, &dumpBuf)
 	if err != nil {
-		t.Fatalf("Backup: %v", err)
+		t.Fatalf("WriteSnapshot: %v", err)
 	}
 	if hs.Len() != len(uniqueHashes) {
-		t.Fatalf("Backup HashSet.Len() = %d, want %d", hs.Len(), len(uniqueHashes))
+		t.Fatalf("WriteSnapshot HashSet.Len() = %d, want %d", hs.Len(), len(uniqueHashes))
 	}
 
 	// 2. Reset the SAME store in place — no close/reopen.
@@ -65,7 +65,7 @@ func ResetThenRestoreConformance(t *testing.T, factory BackupableStoreFactory) {
 	// 4. Restore from the same dump into the (now-empty) same store
 	//    instance. The Reset above satisfied the
 	//    ErrRestoreDestinationNotEmpty precondition so Restore must succeed.
-	if err := b.Restore(ctx, &dumpBuf); err != nil {
+	if err := b.RestoreSnapshot(ctx, &dumpBuf); err != nil {
 		t.Fatalf("Restore post-Reset: %v", err)
 	}
 

--- a/pkg/metadata/storetest/snapshot_conformance.go
+++ b/pkg/metadata/storetest/snapshot_conformance.go
@@ -12,13 +12,13 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/backup"
 )
 
-// BackupableStoreFactory creates a fresh MetadataStore instance for each
-// backup conformance test. The returned store does NOT need to implement
-// metadata.Backupable at this type level -- the suite performs the type
+// SnapshotableStoreFactory creates a fresh MetadataStore instance for each
+// snapshot conformance test. The returned store does NOT need to implement
+// metadata.Snapshotable at this type level -- the suite performs the type
 // assertion internally and fails if the capability is absent.
-type BackupableStoreFactory func(t *testing.T) metadata.Store
+type SnapshotableStoreFactory func(t *testing.T) metadata.Store
 
-// RunBackupConformanceSuite runs the backup/restore conformance tests against
+// RunSnapshotConformanceSuite runs the snapshot/restore conformance tests against
 // the provided factory. Each subtest gets a fresh store instance to ensure
 // isolation.
 //
@@ -29,65 +29,65 @@ type BackupableStoreFactory func(t *testing.T) metadata.Store
 //   - NonEmptyDest: ErrRestoreDestinationNotEmpty on populated destination
 //   - HashSetCorrectness: exact hash match and dedup verification
 //
-// The factory MUST return a store that implements metadata.Backupable.
+// The factory MUST return a store that implements metadata.Snapshotable.
 // Unlike the optional-capability pattern used in BlockRefOps (which skips),
-// backup conformance uses t.Fatal because the factory explicitly opts in.
-func RunBackupConformanceSuite(t *testing.T, factory BackupableStoreFactory) {
+// snapshot conformance uses t.Fatal because the factory explicitly opts in.
+func RunSnapshotConformanceSuite(t *testing.T, factory SnapshotableStoreFactory) {
 	t.Helper()
 
-	// Verify the factory produces a Backupable store before dispatching.
+	// Verify the factory produces a Snapshotable store before dispatching.
 	probe := factory(t)
-	if _, ok := probe.(metadata.Backupable); !ok {
-		t.Fatal("factory must return a store implementing metadata.Backupable")
+	if _, ok := probe.(metadata.Snapshotable); !ok {
+		t.Fatal("factory must return a store implementing metadata.Snapshotable")
 	}
 
 	t.Run("RoundTrip", func(t *testing.T) {
-		testBackup_RoundTrip(t, factory)
+		testSnapshot_RoundTrip(t, factory)
 	})
 
 	t.Run("ConcurrentWriter", func(t *testing.T) {
-		testBackup_ConcurrentWriter(t, factory)
+		testSnapshot_ConcurrentWriter(t, factory)
 	})
 
 	t.Run("Corruption", func(t *testing.T) {
-		testBackup_Corruption(t, factory)
+		testSnapshot_Corruption(t, factory)
 	})
 
 	t.Run("NonEmptyDest", func(t *testing.T) {
-		testBackup_NonEmptyDest(t, factory)
+		testSnapshot_NonEmptyDest(t, factory)
 	})
 
 	t.Run("HashSetCorrectness", func(t *testing.T) {
-		testBackup_HashSetCorrectness(t, factory)
+		testSnapshot_HashSetCorrectness(t, factory)
 	})
 
-	t.Run("LiveSetSupersetOfBackup", func(t *testing.T) {
-		testBackup_LiveSetSupersetOfBackup(t, factory)
+	t.Run("LiveSetSupersetOfSnapshot", func(t *testing.T) {
+		testSnapshot_LiveSetSupersetOfSnapshot(t, factory)
 	})
 
 	t.Run("LiveSetUnionsManifestNegativeControl", func(t *testing.T) {
-		testBackup_LiveSetUnionsManifestNegativeControl(t, factory)
+		testSnapshot_LiveSetUnionsManifestNegativeControl(t, factory)
 	})
 
 	t.Run("ExcludesUnlinkedFileBlocks", func(t *testing.T) {
-		testBackup_ExcludesUnlinkedFileBlocks(t, factory)
+		testSnapshot_ExcludesUnlinkedFileBlocks(t, factory)
 	})
 
 	t.Run("UsedBytesAfterRestore", func(t *testing.T) {
-		testBackup_UsedBytesAfterRestore(t, factory)
+		testSnapshot_UsedBytesAfterRestore(t, factory)
 	})
 }
 
-// testBackup_UsedBytesAfterRestore pins the quota-counter invariant: after
+// testSnapshot_UsedBytesAfterRestore pins the quota-counter invariant: after
 // Restore the in-memory usedBytes counter MUST reflect the restored regular-file
 // bytes, not the destination's pre-restore value. GetUsedBytes feeds the quota
 // guard in metadata/io.go; a stale 0 (the value a freshly-opened store holds on
 // an empty DB) silently disables quota enforcement until the process restarts.
 // The postgres restore path failed to recompute the counter; memory and badger
 // recompute it. This conformance test catches the divergence for every backend.
-func testBackup_UsedBytesAfterRestore(t *testing.T, factory BackupableStoreFactory) {
+func testSnapshot_UsedBytesAfterRestore(t *testing.T, factory SnapshotableStoreFactory) {
 	srcStore := factory(t)
-	srcB := asBackupable(t, srcStore)
+	srcB := asSnapshotable(t, srcStore)
 	ctx := t.Context()
 
 	// populateTestData writes two regular files of 8 MiB and 6 MiB.
@@ -99,14 +99,14 @@ func testBackup_UsedBytesAfterRestore(t *testing.T, factory BackupableStoreFacto
 	}
 
 	var buf bytes.Buffer
-	if _, err := srcB.Backup(ctx, &buf); err != nil {
-		t.Fatalf("Backup: %v", err)
+	if _, err := srcB.WriteSnapshot(ctx, &buf); err != nil {
+		t.Fatalf("Snapshot: %v", err)
 	}
 
 	// Restore into a fresh store, whose usedBytes counter starts at 0.
 	dstStore := factory(t)
-	dstB := asBackupable(t, dstStore)
-	if err := dstB.Restore(ctx, &buf); err != nil {
+	dstB := asSnapshotable(t, dstStore)
+	if err := dstB.RestoreSnapshot(ctx, &buf); err != nil {
 		t.Fatalf("Restore: %v", err)
 	}
 
@@ -115,26 +115,26 @@ func testBackup_UsedBytesAfterRestore(t *testing.T, factory BackupableStoreFacto
 	}
 }
 
-// testBackup_LiveSetSupersetOfBackup pins the GC-vs-snapshot invariant fixed in
+// testSnapshot_LiveSetSupersetOfSnapshot pins the GC-vs-snapshot invariant fixed in
 // this change: the GC mark live set (EnumerateFileBlocks) MUST be a SUPERSET of
-// the snapshot Backup HashSet (built from File.Blocks / file_block_refs). Before
+// the snapshot Snapshot HashSet (built from File.Blocks / file_block_refs). Before
 // EnumerateFileBlocks unioned the manifest, a hash present only in the manifest
 // (the common case — populateTestData writes hashes via PutFile, never to the
 // CAS index) was MISSED by the mark phase and the sweep would reap the still-
 // live remote chunk once a snapshot hold lapsed (data loss). After the union the
 // two sets are equal here; the assertion is the weaker superset to stay robust
 // against CAS rows the engine adds independently of File.Blocks.
-func testBackup_LiveSetSupersetOfBackup(t *testing.T, factory BackupableStoreFactory) {
+func testSnapshot_LiveSetSupersetOfSnapshot(t *testing.T, factory SnapshotableStoreFactory) {
 	store := factory(t)
-	b := asBackupable(t, store)
+	b := asSnapshotable(t, store)
 	ctx := t.Context()
 
 	populateTestData(t, store, "superset")
 
 	var buf bytes.Buffer
-	backupHashes, err := b.Backup(ctx, &buf)
+	backupHashes, err := b.WriteSnapshot(ctx, &buf)
 	if err != nil {
-		t.Fatalf("Backup: %v", err)
+		t.Fatalf("Snapshot: %v", err)
 	}
 
 	liveSet := make(map[block.ContentHash]struct{})
@@ -149,24 +149,24 @@ func testBackup_LiveSetSupersetOfBackup(t *testing.T, factory BackupableStoreFac
 	if err := backupHashes.ForEach(func(h block.ContentHash) error {
 		if _, ok := liveSet[h]; !ok {
 			missing++
-			t.Errorf("hash %s in Backup HashSet but ABSENT from EnumerateFileBlocks (GC mark live set) — GC would reap a live chunk (data loss)", h)
+			t.Errorf("hash %s in Snapshot HashSet but ABSENT from EnumerateFileBlocks (GC mark live set) — GC would reap a live chunk (data loss)", h)
 		}
 		return nil
 	}); err != nil {
 		t.Fatalf("HashSet.ForEach: %v", err)
 	}
 	if missing == 0 && backupHashes.Len() == 0 {
-		t.Fatal("Backup HashSet empty — fixture wrote no block hashes; the superset assertion is vacuous")
+		t.Fatal("Snapshot HashSet empty — fixture wrote no block hashes; the superset assertion is vacuous")
 	}
 }
 
-// testBackup_LiveSetUnionsManifestNegativeControl is the demonstrable negative
+// testSnapshot_LiveSetUnionsManifestNegativeControl is the demonstrable negative
 // control mandated by the plan: write a hash to File.Blocks (the manifest) WITHOUT
 // a corresponding CAS index (file_blocks) row, then prove the union picks it up.
 // Before the union the hash would be absent from EnumerateFileBlocks (the CAS
 // index has no row for it); after, it is present. This is exactly the gap that
 // let GC reap a live block.
-func testBackup_LiveSetUnionsManifestNegativeControl(t *testing.T, factory BackupableStoreFactory) {
+func testSnapshot_LiveSetUnionsManifestNegativeControl(t *testing.T, factory SnapshotableStoreFactory) {
 	store := factory(t)
 	ctx := t.Context()
 
@@ -201,13 +201,13 @@ func testBackup_LiveSetUnionsManifestNegativeControl(t *testing.T, factory Backu
 	}
 }
 
-// testBackup_ExcludesUnlinkedFileBlocks proves the snapshot manifest HashSet
+// testSnapshot_ExcludesUnlinkedFileBlocks proves the snapshot manifest HashSet
 // excludes blocks of unlinked (nlink=0) files. Since GC now reclaims a deleted
 // file's blocks from remote (#1433), a manifest that still listed them would
 // reference hashes absent from remote and fail the snapshot durability verify.
-func testBackup_ExcludesUnlinkedFileBlocks(t *testing.T, factory BackupableStoreFactory) {
+func testSnapshot_ExcludesUnlinkedFileBlocks(t *testing.T, factory SnapshotableStoreFactory) {
 	store := factory(t)
-	b := asBackupable(t, store)
+	b := asSnapshotable(t, store)
 	ctx := t.Context()
 
 	shareName := "unlinked-bkp"
@@ -226,9 +226,9 @@ func testBackup_ExcludesUnlinkedFileBlocks(t *testing.T, factory BackupableStore
 	}
 
 	// Baseline: a live file's block IS in the manifest.
-	hs, err := b.Backup(ctx, io.Discard)
+	hs, err := b.WriteSnapshot(ctx, io.Discard)
 	if err != nil {
-		t.Fatalf("Backup (linked): %v", err)
+		t.Fatalf("Snapshot (linked): %v", err)
 	}
 	if !hs.Contains(dead) {
 		t.Fatalf("baseline: hash %s absent from backup manifest while nlink>0", dead)
@@ -241,22 +241,22 @@ func testBackup_ExcludesUnlinkedFileBlocks(t *testing.T, factory BackupableStore
 	if err := store.SetLinkCount(ctx, h, 0); err != nil {
 		t.Fatalf("SetLinkCount(0): %v", err)
 	}
-	hs, err = b.Backup(ctx, io.Discard)
+	hs, err = b.WriteSnapshot(ctx, io.Discard)
 	if err != nil {
-		t.Fatalf("Backup (unlinked): %v", err)
+		t.Fatalf("Snapshot (unlinked): %v", err)
 	}
 	if hs.Contains(dead) {
 		t.Errorf("hash %s still in backup manifest after unlink (nlink=0); GC may have reclaimed it from remote, so the snapshot durability verify would fail (#1433)", dead)
 	}
 }
 
-// asBackupable is a helper that type-asserts a MetadataStore to Backupable,
+// asSnapshotable is a helper that type-asserts a MetadataStore to Snapshotable,
 // calling t.Fatal if the assertion fails.
-func asBackupable(t *testing.T, store metadata.Store) metadata.Backupable {
+func asSnapshotable(t *testing.T, store metadata.Store) metadata.Snapshotable {
 	t.Helper()
-	b, ok := store.(metadata.Backupable)
+	b, ok := store.(metadata.Snapshotable)
 	if !ok {
-		t.Fatal("store does not implement metadata.Backupable")
+		t.Fatal("store does not implement metadata.Snapshotable")
 	}
 	return b
 }
@@ -312,21 +312,21 @@ func populateTestData(t *testing.T, store metadata.Store, sharePrefix string) (s
 // Subtest 1: RoundTrip
 // --------------------------------------------------------------------------
 
-// testBackup_RoundTrip verifies that Backup-then-Restore produces identical
+// testSnapshot_RoundTrip verifies that Snapshot-then-Restore produces identical
 // shares and files in the destination store.
-func testBackup_RoundTrip(t *testing.T, factory BackupableStoreFactory) {
+func testSnapshot_RoundTrip(t *testing.T, factory SnapshotableStoreFactory) {
 	srcStore := factory(t)
-	srcB := asBackupable(t, srcStore)
+	srcB := asSnapshotable(t, srcStore)
 
 	shareName, uniqueHashes := populateTestData(t, srcStore, "rt")
 
 	ctx := t.Context()
 
-	// Backup to buffer.
+	// Snapshot to buffer.
 	var buf bytes.Buffer
-	hashes, err := srcB.Backup(ctx, &buf)
+	hashes, err := srcB.WriteSnapshot(ctx, &buf)
 	if err != nil {
-		t.Fatalf("Backup: %v", err)
+		t.Fatalf("Snapshot: %v", err)
 	}
 
 	// Verify HashSet length matches expected unique hashes.
@@ -336,8 +336,8 @@ func testBackup_RoundTrip(t *testing.T, factory BackupableStoreFactory) {
 
 	// Restore into fresh destination.
 	dstStore := factory(t)
-	dstB := asBackupable(t, dstStore)
-	if err := dstB.Restore(ctx, &buf); err != nil {
+	dstB := asSnapshotable(t, dstStore)
+	if err := dstB.RestoreSnapshot(ctx, &buf); err != nil {
 		t.Fatalf("Restore: %v", err)
 	}
 
@@ -403,7 +403,7 @@ func testBackup_RoundTrip(t *testing.T, factory BackupableStoreFactory) {
 // Subtest 2: ConcurrentWriter
 // --------------------------------------------------------------------------
 
-// testBackup_ConcurrentWriter verifies that a backup snapshot is isolated
+// testSnapshot_ConcurrentWriter verifies that a backup snapshot is isolated
 // from concurrent writes: files created after the backup begins must NOT
 // appear in the restored state.
 // signalWriter wraps an io.Writer and closes a channel on the first
@@ -420,9 +420,9 @@ func (sw *signalWriter) Write(p []byte) (int, error) {
 	return sw.w.Write(p)
 }
 
-func testBackup_ConcurrentWriter(t *testing.T, factory BackupableStoreFactory) {
+func testSnapshot_ConcurrentWriter(t *testing.T, factory SnapshotableStoreFactory) {
 	store := factory(t)
-	b := asBackupable(t, store)
+	b := asSnapshotable(t, store)
 
 	shareName, _ := populateTestData(t, store, "cw")
 
@@ -445,7 +445,7 @@ func testBackup_ConcurrentWriter(t *testing.T, factory BackupableStoreFactory) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		hashes, backupErr = b.Backup(ctx, sw)
+		hashes, backupErr = b.WriteSnapshot(ctx, sw)
 	}()
 
 	// Wait until backup has started writing (lock acquired) before the
@@ -504,7 +504,7 @@ func testBackup_ConcurrentWriter(t *testing.T, factory BackupableStoreFactory) {
 	wg.Wait()
 
 	if backupErr != nil {
-		t.Fatalf("Backup: %v", backupErr)
+		t.Fatalf("Snapshot: %v", backupErr)
 	}
 	if concurrentErr != nil {
 		t.Logf("concurrent writer error (non-fatal): %v", concurrentErr)
@@ -512,8 +512,8 @@ func testBackup_ConcurrentWriter(t *testing.T, factory BackupableStoreFactory) {
 
 	// Restore into fresh store.
 	dstStore := factory(t)
-	dstB := asBackupable(t, dstStore)
-	if err := dstB.Restore(ctx, &buf); err != nil {
+	dstB := asSnapshotable(t, dstStore)
+	if err := dstB.RestoreSnapshot(ctx, &buf); err != nil {
 		t.Fatalf("Restore: %v", err)
 	}
 
@@ -537,7 +537,7 @@ func testBackup_ConcurrentWriter(t *testing.T, factory BackupableStoreFactory) {
 
 	// Hash set must contain only initial hashes, not the concurrent one.
 	if hashes == nil {
-		t.Fatal("Backup returned nil HashSet")
+		t.Fatal("Snapshot returned nil HashSet")
 	}
 	if hashes.Contains(concurrentHash) {
 		t.Error("HashSet contains concurrent hash — snapshot isolation violated")
@@ -551,19 +551,19 @@ func testBackup_ConcurrentWriter(t *testing.T, factory BackupableStoreFactory) {
 // Subtest 3: Corruption
 // --------------------------------------------------------------------------
 
-// testBackup_Corruption verifies that Restore detects corrupted backup
+// testSnapshot_Corruption verifies that Restore detects corrupted backup
 // streams. Three scenarios: truncated, bit-flip, and wrong engine tag.
-func testBackup_Corruption(t *testing.T, factory BackupableStoreFactory) {
+func testSnapshot_Corruption(t *testing.T, factory SnapshotableStoreFactory) {
 	// Create a valid backup first.
 	srcStore := factory(t)
-	srcB := asBackupable(t, srcStore)
+	srcB := asSnapshotable(t, srcStore)
 	populateTestData(t, srcStore, "corr")
 
 	ctx := t.Context()
 
 	var validBuf bytes.Buffer
-	if _, err := srcB.Backup(ctx, &validBuf); err != nil {
-		t.Fatalf("Backup: %v", err)
+	if _, err := srcB.WriteSnapshot(ctx, &validBuf); err != nil {
+		t.Fatalf("Snapshot: %v", err)
 	}
 	validData := validBuf.Bytes()
 
@@ -572,8 +572,8 @@ func testBackup_Corruption(t *testing.T, factory BackupableStoreFactory) {
 		truncated := validData[:len(validData)/2]
 
 		dstStore := factory(t)
-		dstB := asBackupable(t, dstStore)
-		err := dstB.Restore(ctx, bytes.NewReader(truncated))
+		dstB := asSnapshotable(t, dstStore)
+		err := dstB.RestoreSnapshot(ctx, bytes.NewReader(truncated))
 		if err == nil {
 			t.Fatal("Restore on truncated stream should have returned an error")
 		}
@@ -587,7 +587,7 @@ func testBackup_Corruption(t *testing.T, factory BackupableStoreFactory) {
 		// subsequent VALID restore into the SAME store must succeed — if the
 		// corrupt attempt left rows behind, Restore's empty-destination guard
 		// would reject this with ErrRestoreDestinationNotEmpty (#831).
-		if err := dstB.Restore(ctx, bytes.NewReader(validData)); err != nil {
+		if err := dstB.RestoreSnapshot(ctx, bytes.NewReader(validData)); err != nil {
 			t.Fatalf("valid restore after corrupt(truncated) restore must succeed (store left empty/retryable), got: %v", err)
 		}
 	})
@@ -604,8 +604,8 @@ func testBackup_Corruption(t *testing.T, factory BackupableStoreFactory) {
 		corrupted[midpoint] ^= 0xFF
 
 		dstStore := factory(t)
-		dstB := asBackupable(t, dstStore)
-		err := dstB.Restore(ctx, bytes.NewReader(corrupted))
+		dstB := asSnapshotable(t, dstStore)
+		err := dstB.RestoreSnapshot(ctx, bytes.NewReader(corrupted))
 		if err == nil {
 			t.Fatal("Restore on bit-flipped stream should have returned an error")
 		}
@@ -615,7 +615,7 @@ func testBackup_Corruption(t *testing.T, factory BackupableStoreFactory) {
 
 		// Same retryability contract as Truncated: a corrupt payload must
 		// leave the destination empty so a valid restore still succeeds (#831).
-		if err := dstB.Restore(ctx, bytes.NewReader(validData)); err != nil {
+		if err := dstB.RestoreSnapshot(ctx, bytes.NewReader(validData)); err != nil {
 			t.Fatalf("valid restore after corrupt(bit-flip) restore must succeed (store left empty/retryable), got: %v", err)
 		}
 	})
@@ -657,8 +657,8 @@ func testBackup_Corruption(t *testing.T, factory BackupableStoreFactory) {
 		}
 
 		dstStore := factory(t)
-		dstB := asBackupable(t, dstStore)
-		err = dstB.Restore(ctx, &fakeEnvelopeBuf)
+		dstB := asSnapshotable(t, dstStore)
+		err = dstB.RestoreSnapshot(ctx, &fakeEnvelopeBuf)
 		if err == nil {
 			t.Fatal("Restore with wrong engine tag should have returned an error")
 		}
@@ -674,27 +674,27 @@ func testBackup_Corruption(t *testing.T, factory BackupableStoreFactory) {
 // Subtest 4: NonEmptyDest
 // --------------------------------------------------------------------------
 
-// testBackup_NonEmptyDest verifies that Restore rejects a destination store
+// testSnapshot_NonEmptyDest verifies that Restore rejects a destination store
 // that already contains data.
-func testBackup_NonEmptyDest(t *testing.T, factory BackupableStoreFactory) {
+func testSnapshot_NonEmptyDest(t *testing.T, factory SnapshotableStoreFactory) {
 	// Create a valid backup.
 	srcStore := factory(t)
-	srcB := asBackupable(t, srcStore)
+	srcB := asSnapshotable(t, srcStore)
 	populateTestData(t, srcStore, "ned-src")
 
 	ctx := t.Context()
 
 	var buf bytes.Buffer
-	if _, err := srcB.Backup(ctx, &buf); err != nil {
-		t.Fatalf("Backup: %v", err)
+	if _, err := srcB.WriteSnapshot(ctx, &buf); err != nil {
+		t.Fatalf("Snapshot: %v", err)
 	}
 
 	// Create a destination store that is NOT empty.
 	dstStore := factory(t)
 	populateTestData(t, dstStore, "ned-dst")
-	dstB := asBackupable(t, dstStore)
+	dstB := asSnapshotable(t, dstStore)
 
-	err := dstB.Restore(ctx, &buf)
+	err := dstB.RestoreSnapshot(ctx, &buf)
 	if err == nil {
 		t.Fatal("Restore into non-empty store should have returned an error")
 	}
@@ -707,23 +707,23 @@ func testBackup_NonEmptyDest(t *testing.T, factory BackupableStoreFactory) {
 // Subtest 5: HashSetCorrectness
 // --------------------------------------------------------------------------
 
-// testBackup_HashSetCorrectness verifies that the HashSet returned by Backup
+// testSnapshot_HashSetCorrectness verifies that the HashSet returned by Snapshot
 // contains exactly the unique block hashes referenced by all files.
-func testBackup_HashSetCorrectness(t *testing.T, factory BackupableStoreFactory) {
+func testSnapshot_HashSetCorrectness(t *testing.T, factory SnapshotableStoreFactory) {
 	t.Run("ExactMatch", func(t *testing.T) {
-		testBackup_HashSet_ExactMatch(t, factory)
+		testSnapshot_HashSet_ExactMatch(t, factory)
 	})
 
 	t.Run("Dedup", func(t *testing.T) {
-		testBackup_HashSet_Dedup(t, factory)
+		testSnapshot_HashSet_Dedup(t, factory)
 	})
 }
 
-// testBackup_HashSet_ExactMatch creates files with K unique hashes across N
+// testSnapshot_HashSet_ExactMatch creates files with K unique hashes across N
 // files and verifies the HashSet matches a manually-collected reference set.
-func testBackup_HashSet_ExactMatch(t *testing.T, factory BackupableStoreFactory) {
+func testSnapshot_HashSet_ExactMatch(t *testing.T, factory SnapshotableStoreFactory) {
 	store := factory(t)
-	b := asBackupable(t, store)
+	b := asSnapshotable(t, store)
 	ctx := t.Context()
 
 	shareName := "hsem-bkp"
@@ -779,11 +779,11 @@ func testBackup_HashSet_ExactMatch(t *testing.T, factory BackupableStoreFactory)
 		t.Fatalf("PutFile f3: %v", err)
 	}
 
-	// Backup and collect HashSet.
+	// Snapshot and collect HashSet.
 	var buf bytes.Buffer
-	gotHS, err := b.Backup(ctx, &buf)
+	gotHS, err := b.WriteSnapshot(ctx, &buf)
 	if err != nil {
-		t.Fatalf("Backup: %v", err)
+		t.Fatalf("Snapshot: %v", err)
 	}
 
 	// Verify length.
@@ -799,11 +799,11 @@ func testBackup_HashSet_ExactMatch(t *testing.T, factory BackupableStoreFactory)
 	}
 }
 
-// testBackup_HashSet_Dedup creates two files that share the same BlockRef
+// testSnapshot_HashSet_Dedup creates two files that share the same BlockRef
 // hash and verifies the HashSet correctly deduplicates.
-func testBackup_HashSet_Dedup(t *testing.T, factory BackupableStoreFactory) {
+func testSnapshot_HashSet_Dedup(t *testing.T, factory SnapshotableStoreFactory) {
 	store := factory(t)
-	b := asBackupable(t, store)
+	b := asSnapshotable(t, store)
 	ctx := t.Context()
 
 	shareName := "hsdd-bkp"
@@ -837,11 +837,11 @@ func testBackup_HashSet_Dedup(t *testing.T, factory BackupableStoreFactory) {
 		t.Fatalf("PutFile dup-b: %v", err)
 	}
 
-	// Backup and collect HashSet.
+	// Snapshot and collect HashSet.
 	var buf bytes.Buffer
-	gotHS, err := b.Backup(ctx, &buf)
+	gotHS, err := b.WriteSnapshot(ctx, &buf)
 	if err != nil {
-		t.Fatalf("Backup: %v", err)
+		t.Fatalf("Snapshot: %v", err)
 	}
 
 	// Must be 1 unique hash, not 2.

--- a/pkg/snapshot/dump.go
+++ b/pkg/snapshot/dump.go
@@ -24,7 +24,7 @@ import (
 // outcome when the supplied callback writes nothing.
 //
 // The runtime snapshot orchestration uses this to
-// invoke Backupable.Backup against the temp file, capturing the returned
+// invoke Snapshotable.WriteSnapshot against the temp file, capturing the returned
 // HashSet for the subsequent WriteManifestAtomic step.
 func WriteMetadataDumpAtomic(
 	path string,


### PR DESCRIPTION
Closes #1447.

## Summary

The snapshot path is the only consumer of the metadata-store `Backupable` capability, so this aligns the naming. **Pure rename — no behavior change.**

| Before | After |
|--------|-------|
| `metadata.Backupable` | `metadata.Snapshotable` |
| `Backup(ctx, w)` | `WriteSnapshot(ctx, w)` |
| `Restore(ctx, r)` | `RestoreSnapshot(ctx, r)` |
| `metadata.ErrBackupAborted` | `metadata.ErrSnapshotAborted` |
| `storetest.BackupableStoreFactory` | `storetest.SnapshotableStoreFactory` |
| `storetest.RunBackupConformanceSuite` | `storetest.RunSnapshotConformanceSuite` |
| `backupable.go` | `snapshotable.go` |
| `store/*/backup.go` | `store/*/snapshot_store.go` |
| `storetest/backup_conformance.go` | `storetest/snapshot_conformance.go` |

Doc comments, test labels, and test-double/helper names updated for consistency. All four stores (memory/badger/sqlite/postgres) still satisfy `metadata.Snapshotable` (compile-time assertions in place, incl. a newly-added one for sqlite).

## Deliberately kept (out of scope)
- The separate `pkg/metadata/backup` serialization/envelope package.
- The `ErrRestoreDestinationNotEmpty` / `ErrRestoreCorrupt` / `ErrSchemaVersionMismatch` sentinels (restore concept stays).
- The bench harness `RunBackup` / `BenchmarkBackup` naming.

## Verification
- `go build ./...` and `go build -tags integration ./...` clean (caught two integration-tagged files gopls's symbol-rename skipped).
- `go vet`, `golangci-lint` clean; affected test packages pass.
- code-simplifier + code-reviewer run pre-PR; their findings (stale sqlite doc comments + missing sqlite compile-time assertion) addressed.