### PR TITLE
fix(nfs): apply squash-config changes to the live share (follow-up to #1451)

### DIFF
--- a/internal/adapter/nfs/v3/handlers/clear_auth_cache_test.go
+++ b/internal/adapter/nfs/v3/handlers/clear_auth_cache_test.go
@@ -11,7 +11,9 @@ import (
 func TestClearAuthCache(t *testing.T) {
 	h := &Handler{}
 
-	// Seed a few entries directly (the cache is keyed "share:uid:gid").
+	// Seed a few entries directly. ClearAuthCache drops every entry regardless of
+	// key shape; the real key (see authCacheKey) is share:authflavor:uid:gid[:gid...],
+	// but the exact format is irrelevant here — these stand-ins just need to exist.
 	h.authCache.Store("/export:1000:1000", &metadata.AuthContext{})
 	h.authCache.Store("/export:0:0", &metadata.AuthContext{})
 	h.authCache.Store("/other:2000:2000", &metadata.AuthContext{})

--- a/internal/controlplane/api/handlers/share_adapter_config.go
+++ b/internal/controlplane/api/handlers/share_adapter_config.go
@@ -169,10 +169,18 @@ func (h *ShareNFSConfigHandler) Patch(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// A squash-mode change alters how client UIDs map to identities, but does not
-	// flow through ReconcileShareRootACL. Drop cached per-identity authorization
-	// so the new squash policy takes effect on active clients without a restart.
+	// Squash / anonymous-UID changes alter how client UIDs map to identities but
+	// do not flow through ReconcileShareRootACL. Push them into the running share
+	// so ResolveSharePermission / ApplyIdentityMapping read the new policy, then
+	// drop cached per-identity authorization so it takes effect on active clients
+	// without an adapter restart.
 	if h.runtime != nil {
+		if req.Squash != nil || req.AnonymousUID != nil || req.AnonymousGID != nil {
+			if err := h.runtime.SetShareSquash(share.Name, opts.GetSquashMode(), opts.AnonymousUID, opts.AnonymousGID); err != nil {
+				logger.Warn("NFS config persisted but failed to update runtime squash policy",
+					"share", share.Name, "squash", opts.Squash, "error", err)
+			}
+		}
 		h.runtime.InvalidateAuthCache()
 	}
 

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -526,6 +526,14 @@ func (r *Runtime) SetShareNetgroup(name, netgroupName string) error {
 	return r.sharesSvc.SetShareNetgroup(name, netgroupName)
 }
 
+// SetShareSquash updates the live in-memory squash policy (and optionally the
+// anonymous UID/GID) for a share so an NFS squash-config change applies to
+// active clients without an adapter restart. nil anon pointers leave those
+// fields unchanged.
+func (r *Runtime) SetShareSquash(name string, squash models.SquashMode, anonUID, anonGID *uint32) error {
+	return r.sharesSvc.SetShareSquash(name, squash, anonUID, anonGID)
+}
+
 // DisableShare sets enabled=false on the share's DB row and runtime
 // registry, then notifies adapters so active sessions drop.
 // Idempotent on already-disabled shares (returns shares.ErrShareAlreadyDisabled

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1214,6 +1214,34 @@ func (s *Service) UpdateShare(name string, readOnly *bool, defaultPermission *st
 	return nil
 }
 
+// SetShareSquash updates the live in-memory squash policy (and optionally the
+// anonymous UID/GID) for a share, so an NFS squash-config change applies to
+// active clients without an adapter restart. The on-disk config is persisted
+// separately by the API handler; this only refreshes the runtime Share that
+// ResolveSharePermission / ApplyIdentityMapping read from. anonUID/anonGID are
+// pointers so an unspecified field is left unchanged. Mirrors UpdateShare's
+// lock+mutate pattern; GetShare hands callers a snapshot copy, so mutating the
+// registry entry under the lock is race-free.
+func (s *Service) SetShareSquash(name string, squash models.SquashMode, anonUID, anonGID *uint32) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	share, exists := s.registry[name]
+	if !exists {
+		return fmt.Errorf("share %q not found", name)
+	}
+
+	share.Squash = squash
+	if anonUID != nil {
+		share.AnonymousUID = *anonUID
+	}
+	if anonGID != nil {
+		share.AnonymousGID = *anonGID
+	}
+
+	return nil
+}
+
 // TrashSettings is a per-share recycle-bin policy snapshot, returned by value
 // under the service lock so callers never read a mutating shared pointer.
 type TrashSettings struct {

--- a/pkg/controlplane/runtime/shares/set_share_squash_test.go
+++ b/pkg/controlplane/runtime/shares/set_share_squash_test.go
@@ -1,0 +1,50 @@
+package shares
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// TestSetShareSquash_UpdatesLiveShare verifies that SetShareSquash mutates the
+// in-memory runtime share so a squash-config change is visible to readers
+// (GetShare) without a restart, and that anon UID/GID are updated only when a
+// non-nil pointer is supplied.
+func TestSetShareSquash_UpdatesLiveShare(t *testing.T) {
+	svc := New()
+	svc.registry["/export"] = &Share{
+		Name:         "/export",
+		Squash:       models.SquashRootToAdmin,
+		AnonymousUID: 65534,
+		AnonymousGID: 65534,
+	}
+
+	newUID := uint32(1000)
+	if err := svc.SetShareSquash("/export", models.SquashRootToGuest, &newUID, nil); err != nil {
+		t.Fatalf("SetShareSquash: %v", err)
+	}
+
+	got, err := svc.GetShare("/export")
+	if err != nil {
+		t.Fatalf("GetShare: %v", err)
+	}
+	if got.Squash != models.SquashRootToGuest {
+		t.Errorf("Squash = %q, want %q", got.Squash, models.SquashRootToGuest)
+	}
+	if got.AnonymousUID != 1000 {
+		t.Errorf("AnonymousUID = %d, want 1000", got.AnonymousUID)
+	}
+	// nil anonGID must leave the existing value untouched.
+	if got.AnonymousGID != 65534 {
+		t.Errorf("AnonymousGID = %d, want 65534 (unchanged)", got.AnonymousGID)
+	}
+}
+
+// TestSetShareSquash_UnknownShare verifies SetShareSquash reports a not-found
+// error for a share that is not registered.
+func TestSetShareSquash_UnknownShare(t *testing.T) {
+	svc := New()
+	if err := svc.SetShareSquash("/missing", models.SquashRootToGuest, nil, nil); err == nil {
+		t.Fatal("expected error for unknown share, got nil")
+	}
+}


### PR DESCRIPTION
## Problem

Follow-up to #1451 (Copilot flagged this on that PR, but it merged before the fix landed).

#1451 made the NFS squash config PATCH clear the v3 auth cache so changes apply without a restart — but it **only cleared the cache**. `ResolveSharePermission` / `ApplyIdentityMapping` read `Squash` / `AnonymousUID` / `AnonymousGID` from the **running in-memory Share** (`sharesSvc.GetShare`), which the PATCH never updated. So after clearing the cache, clients just re-resolved against the **same stale squash** → no live effect until restart.

(Default-permission already applies live because `Service.UpdateShare` mutates the runtime Share in place; squash was the missing twin.)

## Fix

- `Service.SetShareSquash(name, squash, anonUID, anonGID)` — mirrors `UpdateShare`'s lock+mutate. `GetShare` returns a snapshot copy, so mutating the registry entry under the lock is race-free.
- `Runtime.SetShareSquash` proxy.
- NFS config PATCH now calls `SetShareSquash` (when squash/anon present) **before** `InvalidateAuthCache()` — update the source of truth, then flush the cache.
- Corrected the auth-cache key-format comment (`share:authflavor:uid:gid[:gid...]`).

## Tests

`TestSetShareSquash_UpdatesLiveShare`, `TestSetShareSquash_UnknownShare`. Build (incl. `-tags integration`), vet, golangci-lint clean.

Makes the "squash changes apply live (no adapter restart)" claim from #1452's nfs.md doc actually true.