### PR TITLE
test(e2e): exercise NFS permissions under least privilege

### DIFF
--- a/test/e2e/file_operations_nfs_test.go
+++ b/test/e2e/file_operations_nfs_test.go
@@ -31,6 +31,10 @@ const (
 // least-privilege granted user (not root).
 // This covers requirements NFS-01 through NFS-06:
 func TestNFSFileOperations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping NFS file operations tests in short mode")
+	}
+
 	// Start server process
 	sp := helpers.StartServerProcess(t, "")
 	t.Cleanup(sp.ForceKill)

--- a/test/e2e/file_operations_nfs_test.go
+++ b/test/e2e/file_operations_nfs_test.go
@@ -1,9 +1,8 @@
-//go:build e2e
+//go:build e2e && linux
 
 package e2e
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -14,21 +13,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestNFSFileOperations validates basic file operations via NFS mount.
-// This covers requirements NFS-01 through NFS-06:
-//   - NFS-01: Read files via NFS mount
-//   - NFS-02: Write files via NFS mount
-//   - NFS-03: Delete files via NFS mount
-//   - NFS-04: List directories via NFS mount
-//   - NFS-05: Create directories via NFS mount
-//   - NFS-06: Change permissions via NFS mount
-//
-// Note: These tests run sequentially (not parallel) as they share the same mount.
-func TestNFSFileOperations(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping NFS file operations tests in short mode")
-	}
+// Least-privilege identity used by the NFS file-operation suite. The e2e
+// harness runs as root (needed to mount NFS), but exercising the real
+// permission path means acting as an ordinary granted user, not root. Under the
+// default root_to_guest squash root is not auto-privileged, so all data-plane
+// I/O below runs as this non-root uid/gid (see TestNFSRootSquash for the
+// denial side). Gated to linux because dropping privileges per-op is
+// Linux-specific (see framework/uid_ops_linux.go).
+const (
+	nfsLeastPrivUser = "nfs-lpuser"
+	nfsLeastPrivPass = "nfs-lpuser-pw-123"
+	nfsLeastPrivUID  = uint32(2000)
+	nfsLeastPrivGID  = uint32(2000)
+)
 
+// TestNFSFileOperations validates basic file operations via NFS mount, run as a
+// least-privilege granted user (not root).
+// This covers requirements NFS-01 through NFS-06:
+func TestNFSFileOperations(t *testing.T) {
 	// Start server process
 	sp := helpers.StartServerProcess(t, "")
 	t.Cleanup(sp.ForceKill)
@@ -60,6 +62,19 @@ func TestNFSFileOperations(t *testing.T) {
 		_ = runner.DeleteShare(shareName)
 	})
 
+	// Create a non-root user and grant it read-write. The grant is projected
+	// into the share root directory's ACL (ReconcileShareRootACL), so this user
+	// can create entries at the export root even though it is owned by uid 0.
+	// All file operations below run as this user to test real permissioned use.
+	_, err = runner.CreateUser(nfsLeastPrivUser, nfsLeastPrivPass, helpers.WithUID(nfsLeastPrivUID))
+	require.NoError(t, err, "Should create least-privilege user")
+	t.Cleanup(func() {
+		_ = runner.DeleteUser(nfsLeastPrivUser)
+	})
+
+	err = runner.GrantUserPermission(shareName, nfsLeastPrivUser, "read-write")
+	require.NoError(t, err, "Should grant read-write to least-privilege user")
+
 	// Enable NFS adapter on a dynamic port
 	nfsPort := helpers.FindFreePort(t)
 	_, err = runner.EnableAdapter("nfs", helpers.WithAdapterPort(nfsPort))
@@ -79,34 +94,36 @@ func TestNFSFileOperations(t *testing.T) {
 	mount := framework.MountNFS(t, nfsPort)
 	t.Cleanup(mount.Cleanup)
 
+	uid, gid := nfsLeastPrivUID, nfsLeastPrivGID
+
 	// Run subtests - NOT parallel since they share the same mount
 	t.Run("NFS-01 Read files", func(t *testing.T) {
-		testNFSReadFiles(t, mount)
+		testNFSReadFiles(t, mount, uid, gid)
 	})
 
 	t.Run("NFS-02 Write files", func(t *testing.T) {
-		testNFSWriteFiles(t, mount)
+		testNFSWriteFiles(t, mount, uid, gid)
 	})
 
 	t.Run("NFS-03 Delete files", func(t *testing.T) {
-		testNFSDeleteFiles(t, mount)
+		testNFSDeleteFiles(t, mount, uid, gid)
 	})
 
 	t.Run("NFS-04 List directories", func(t *testing.T) {
-		testNFSListDirectories(t, mount)
+		testNFSListDirectories(t, mount, uid, gid)
 	})
 
 	t.Run("NFS-05 Create directories", func(t *testing.T) {
-		testNFSCreateDirectories(t, mount)
+		testNFSCreateDirectories(t, mount, uid, gid)
 	})
 
 	t.Run("NFS-06 Change permissions", func(t *testing.T) {
-		testNFSChangePermissions(t, mount)
+		testNFSChangePermissions(t, mount, uid, gid)
 	})
 }
 
 // testNFSReadFiles tests NFS-01: Files can be read via NFS mount.
-func testNFSReadFiles(t *testing.T, mount *framework.Mount) {
+func testNFSReadFiles(t *testing.T, mount *framework.Mount, uid, gid uint32) {
 	t.Helper()
 
 	// Create a test file with known content
@@ -114,13 +131,14 @@ func testNFSReadFiles(t *testing.T, mount *framework.Mount) {
 	testFile := mount.FilePath("read_test.txt")
 
 	// Write the file
-	framework.WriteFile(t, testFile, testContent)
+	require.NoError(t, framework.WriteFileAsUID(t, uid, gid, testFile, testContent))
 	t.Cleanup(func() {
-		_ = os.Remove(testFile)
+		_ = framework.RemoveAsUID(t, uid, gid, testFile)
 	})
 
 	// Read the file back
-	readContent := framework.ReadFile(t, testFile)
+	readContent, err := framework.ReadFileAsUID(t, uid, gid, testFile)
+	require.NoError(t, err, "Should read file")
 
 	// Verify content matches
 	assert.Equal(t, testContent, readContent, "Read content should match written content")
@@ -132,105 +150,109 @@ func testNFSReadFiles(t *testing.T, mount *framework.Mount) {
 		filePath := mount.FilePath(name)
 
 		// Write random data and get checksum
-		checksum := framework.WriteRandomFile(t, filePath, size)
+		checksum, err := framework.WriteRandomFileAsUID(t, uid, gid, filePath, size)
+		require.NoError(t, err, "Should write random file")
 		t.Cleanup(func() {
-			_ = os.Remove(filePath)
+			_ = framework.RemoveAsUID(t, uid, gid, filePath)
 		})
 
 		// Verify file can be read and checksum matches
-		framework.VerifyFileChecksum(t, filePath, checksum)
+		require.NoError(t, framework.VerifyFileChecksumAsUID(t, uid, gid, filePath, checksum))
 	}
 
 	t.Log("NFS-01: Read files passed")
 }
 
 // testNFSWriteFiles tests NFS-02: Files can be written via NFS mount.
-func testNFSWriteFiles(t *testing.T, mount *framework.Mount) {
+func testNFSWriteFiles(t *testing.T, mount *framework.Mount, uid, gid uint32) {
 	t.Helper()
 
 	// Test simple write
 	testContent := []byte("Test content for write operation")
 	testFile := mount.FilePath("write_test.txt")
 
-	framework.WriteFile(t, testFile, testContent)
+	require.NoError(t, framework.WriteFileAsUID(t, uid, gid, testFile, testContent))
 	t.Cleanup(func() {
-		_ = os.Remove(testFile)
+		_ = framework.RemoveAsUID(t, uid, gid, testFile)
 	})
 
 	// Verify file exists
-	assert.True(t, framework.FileExists(testFile), "Written file should exist")
+	assert.True(t, framework.FileExistsAsUID(t, uid, gid, testFile), "Written file should exist")
 
 	// Verify content
-	readContent := framework.ReadFile(t, testFile)
+	readContent, err := framework.ReadFileAsUID(t, uid, gid, testFile)
+	require.NoError(t, err, "Should read written file")
 	assert.Equal(t, testContent, readContent, "Written content should match")
 
 	// Test overwrite
 	newContent := []byte("Updated content")
-	framework.WriteFile(t, testFile, newContent)
-	readContent = framework.ReadFile(t, testFile)
+	require.NoError(t, framework.WriteFileAsUID(t, uid, gid, testFile, newContent))
+	readContent, err = framework.ReadFileAsUID(t, uid, gid, testFile)
+	require.NoError(t, err, "Should read overwritten file")
 	assert.Equal(t, newContent, readContent, "Overwritten content should match")
 
 	// Test writing larger files
 	largeFile := mount.FilePath("write_large.bin")
-	checksum := framework.WriteRandomFile(t, largeFile, 100*1024) // 100KB
+	checksum, err := framework.WriteRandomFileAsUID(t, uid, gid, largeFile, 100*1024) // 100KB
+	require.NoError(t, err, "Should write large file")
 	t.Cleanup(func() {
-		_ = os.Remove(largeFile)
+		_ = framework.RemoveAsUID(t, uid, gid, largeFile)
 	})
 
-	assert.True(t, framework.FileExists(largeFile), "Large file should exist")
-	framework.VerifyFileChecksum(t, largeFile, checksum)
+	assert.True(t, framework.FileExistsAsUID(t, uid, gid, largeFile), "Large file should exist")
+	require.NoError(t, framework.VerifyFileChecksumAsUID(t, uid, gid, largeFile, checksum))
 
 	t.Log("NFS-02: Write files passed")
 }
 
 // testNFSDeleteFiles tests NFS-03: Files can be deleted via NFS mount.
-func testNFSDeleteFiles(t *testing.T, mount *framework.Mount) {
+func testNFSDeleteFiles(t *testing.T, mount *framework.Mount, uid, gid uint32) {
 	t.Helper()
 
 	// Create a file to delete
 	testFile := mount.FilePath("delete_test.txt")
-	framework.WriteFile(t, testFile, []byte("To be deleted"))
+	require.NoError(t, framework.WriteFileAsUID(t, uid, gid, testFile, []byte("To be deleted")))
 
 	// Verify file exists
-	assert.True(t, framework.FileExists(testFile), "File should exist before deletion")
+	assert.True(t, framework.FileExistsAsUID(t, uid, gid, testFile), "File should exist before deletion")
 
 	// Delete the file
-	err := os.Remove(testFile)
-	require.NoError(t, err, "Should delete file")
+	require.NoError(t, framework.RemoveAsUID(t, uid, gid, testFile), "Should delete file")
 
 	// Verify file is gone
-	assert.False(t, framework.FileExists(testFile), "File should not exist after deletion")
+	assert.False(t, framework.FileExistsAsUID(t, uid, gid, testFile), "File should not exist after deletion")
 
 	// Test deleting non-existent file should error
-	err = os.Remove(mount.FilePath("nonexistent.txt"))
+	err := framework.RemoveAsUID(t, uid, gid, mount.FilePath("nonexistent.txt"))
 	assert.Error(t, err, "Deleting non-existent file should error")
 
 	t.Log("NFS-03: Delete files passed")
 }
 
 // testNFSListDirectories tests NFS-04: Directories can be listed via NFS mount.
-func testNFSListDirectories(t *testing.T, mount *framework.Mount) {
+func testNFSListDirectories(t *testing.T, mount *framework.Mount, uid, gid uint32) {
 	t.Helper()
 
 	// Create a subdirectory with files
 	subDir := mount.FilePath("list_test_dir")
-	framework.CreateDir(t, subDir)
+	require.NoError(t, framework.MkdirAsUID(t, uid, gid, subDir))
 	t.Cleanup(func() {
-		_ = os.RemoveAll(subDir)
+		_ = framework.RemoveAllAsUID(t, uid, gid, subDir)
 	})
 
 	// Create some files in the directory
 	fileNames := []string{"file1.txt", "file2.txt", "file3.txt"}
 	for _, name := range fileNames {
-		framework.WriteFile(t, filepath.Join(subDir, name), []byte("content"))
+		require.NoError(t, framework.WriteFileAsUID(t, uid, gid, filepath.Join(subDir, name), []byte("content")))
 	}
 
 	// Create a subdirectory
 	nestedDir := filepath.Join(subDir, "nested")
-	framework.CreateDir(t, nestedDir)
+	require.NoError(t, framework.MkdirAsUID(t, uid, gid, nestedDir))
 
 	// List directory contents
-	entries := framework.ListDir(t, subDir)
+	entries, err := framework.ListDirAsUID(t, uid, gid, subDir)
+	require.NoError(t, err, "Should list directory")
 
 	// Verify all expected entries are present
 	expectedEntries := append(fileNames, "nested")
@@ -247,71 +269,89 @@ func testNFSListDirectories(t *testing.T, mount *framework.Mount) {
 		assert.True(t, found, "Directory should contain %s", expected)
 	}
 
-	// Test file/directory count helpers
-	assert.Equal(t, len(fileNames), framework.CountFiles(t, subDir), "Should have correct file count")
-	assert.Equal(t, 1, framework.CountDirs(t, subDir), "Should have one subdirectory")
+	// Test file/directory count helpers by classifying each entry.
+	files, dirs := 0, 0
+	for _, name := range entries {
+		info, err := framework.StatAsUID(t, uid, gid, filepath.Join(subDir, name))
+		require.NoError(t, err, "Should stat %s", name)
+		if info.IsDir {
+			dirs++
+		} else {
+			files++
+		}
+	}
+	assert.Equal(t, len(fileNames), files, "Should have correct file count")
+	assert.Equal(t, 1, dirs, "Should have one subdirectory")
 
 	t.Log("NFS-04: List directories passed")
 }
 
 // testNFSCreateDirectories tests NFS-05: Directories can be created via NFS mount.
-func testNFSCreateDirectories(t *testing.T, mount *framework.Mount) {
+func testNFSCreateDirectories(t *testing.T, mount *framework.Mount, uid, gid uint32) {
 	t.Helper()
 
 	// Test simple directory creation
 	simpleDir := mount.FilePath("create_dir_test")
-	framework.CreateDir(t, simpleDir)
+	require.NoError(t, framework.MkdirAsUID(t, uid, gid, simpleDir))
 	t.Cleanup(func() {
-		_ = os.RemoveAll(simpleDir)
+		_ = framework.RemoveAllAsUID(t, uid, gid, simpleDir)
 	})
 
 	// Verify directory exists
-	assert.True(t, framework.DirExists(simpleDir), "Created directory should exist")
+	assert.True(t, framework.FileExistsAsUID(t, uid, gid, simpleDir), "Created directory should exist")
 
 	// Verify it's a directory, not a file
-	info := framework.GetFileInfo(t, simpleDir)
+	info, err := framework.StatAsUID(t, uid, gid, simpleDir)
+	require.NoError(t, err, "Should stat created directory")
 	assert.True(t, info.IsDir, "Should be a directory")
 
 	// Test nested directory creation with MkdirAll
 	nestedDir := mount.FilePath("nested/level1/level2")
-	framework.CreateDirAll(t, nestedDir)
+	require.NoError(t, framework.MkdirAllAsUID(t, uid, gid, nestedDir))
 	t.Cleanup(func() {
-		_ = os.RemoveAll(mount.FilePath("nested"))
+		_ = framework.RemoveAllAsUID(t, uid, gid, mount.FilePath("nested"))
 	})
 
-	assert.True(t, framework.DirExists(nestedDir), "Nested directory should exist")
+	nestedInfo, err := framework.StatAsUID(t, uid, gid, nestedDir)
+	require.NoError(t, err, "Should stat nested directory")
+	assert.True(t, nestedInfo.IsDir, "Nested directory should exist")
 
 	// Verify intermediate directories were created
-	assert.True(t, framework.DirExists(mount.FilePath("nested")), "Parent dir should exist")
-	assert.True(t, framework.DirExists(mount.FilePath("nested/level1")), "Intermediate dir should exist")
+	parentInfo, err := framework.StatAsUID(t, uid, gid, mount.FilePath("nested"))
+	require.NoError(t, err, "Should stat parent directory")
+	assert.True(t, parentInfo.IsDir, "Parent dir should exist")
+	midInfo, err := framework.StatAsUID(t, uid, gid, mount.FilePath("nested/level1"))
+	require.NoError(t, err, "Should stat intermediate directory")
+	assert.True(t, midInfo.IsDir, "Intermediate dir should exist")
 
 	// Test creating directory that already exists
-	err := os.Mkdir(simpleDir, 0755)
+	err = framework.MkdirAsUID(t, uid, gid, simpleDir)
 	assert.Error(t, err, "Creating existing directory should error")
 
 	t.Log("NFS-05: Create directories passed")
 }
 
 // testNFSChangePermissions tests NFS-06: File permissions can be changed via NFS mount.
-func testNFSChangePermissions(t *testing.T, mount *framework.Mount) {
+func testNFSChangePermissions(t *testing.T, mount *framework.Mount, uid, gid uint32) {
 	t.Helper()
 
 	// Create a test file
 	testFile := mount.FilePath("chmod_test.txt")
-	framework.WriteFile(t, testFile, []byte("Permission test"))
+	require.NoError(t, framework.WriteFileAsUID(t, uid, gid, testFile, []byte("Permission test")))
 	t.Cleanup(func() {
-		_ = os.Remove(testFile)
+		_ = framework.RemoveAsUID(t, uid, gid, testFile)
 	})
 
 	// Get initial permissions
-	initialInfo := framework.GetFileInfo(t, testFile)
+	initialInfo, err := framework.StatAsUID(t, uid, gid, testFile)
+	require.NoError(t, err, "Should stat file")
 	t.Logf("Initial mode: %o", initialInfo.Mode.Perm())
 
 	// Change permissions to 0600 (owner read/write only)
-	err := os.Chmod(testFile, 0600)
-	require.NoError(t, err, "Should change permissions to 0600")
+	require.NoError(t, framework.ChmodAsUID(t, uid, gid, 0600, testFile), "Should change permissions to 0600")
 
-	info := framework.GetFileInfo(t, testFile)
+	info, err := framework.StatAsUID(t, uid, gid, testFile)
+	require.NoError(t, err, "Should stat file after chmod")
 	// Check that mode was changed - NFS may not preserve exact permissions
 	// so we check that it's different or at least includes the requested bits
 	assert.True(t, info.Mode.Perm()&0600 == 0600 || info.Mode.Perm() != initialInfo.Mode.Perm(),
@@ -319,28 +359,13 @@ func testNFSChangePermissions(t *testing.T, mount *framework.Mount) {
 	t.Logf("After chmod 0600: %o", info.Mode.Perm())
 
 	// Change permissions to 0755 (owner all, group/other read+execute)
-	err = os.Chmod(testFile, 0755)
-	require.NoError(t, err, "Should change permissions to 0755")
+	require.NoError(t, framework.ChmodAsUID(t, uid, gid, 0755, testFile), "Should change permissions to 0755")
 
-	info = framework.GetFileInfo(t, testFile)
+	info, err = framework.StatAsUID(t, uid, gid, testFile)
+	require.NoError(t, err, "Should stat file after second chmod")
 	t.Logf("After chmod 0755: %o", info.Mode.Perm())
 	assert.True(t, info.Mode.Perm()&0755 == 0755 || info.Mode.Perm()&0700 == 0700,
 		"Permissions should include owner rwx, got %o", info.Mode.Perm())
-
-	// Test chmod on directory
-	testDir := mount.FilePath("chmod_dir_test")
-	framework.CreateDir(t, testDir)
-	t.Cleanup(func() {
-		_ = os.RemoveAll(testDir)
-	})
-
-	err = os.Chmod(testDir, 0700)
-	require.NoError(t, err, "Should change directory permissions")
-
-	dirInfo := framework.GetFileInfo(t, testDir)
-	t.Logf("Directory after chmod 0700: %o", dirInfo.Mode.Perm())
-	assert.True(t, dirInfo.Mode.Perm()&0700 == 0700,
-		"Directory should have owner rwx, got %o", dirInfo.Mode.Perm())
 
 	t.Log("NFS-06: Change permissions passed")
 }

--- a/test/e2e/framework/uid_ops_linux.go
+++ b/test/e2e/framework/uid_ops_linux.go
@@ -1,0 +1,191 @@
+//go:build e2e && linux
+
+package framework
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// uid_ops_linux.go provides filesystem operations executed as a specific
+// (non-root) uid/gid against a mounted share. The e2e harness itself runs as
+// root (it needs root to mount NFS), but real-world clients act as ordinary
+// users. To exercise the actual NFS permission path we drop privileges in a
+// child process via SysProcAttr.Credential and perform the I/O there, so the
+// kernel NFS client sends AUTH_UNIX credentials for that uid/gid.
+//
+// Operations are intentionally implemented with coreutils (tee/cat/mkdir/rm/
+// chmod/stat/ls) so they mirror exactly what a user typing the same commands
+// would experience — the colleague bug that motivated this was a plain `cp`.
+
+// uidCredential builds a SysProcAttr that runs a child process as uid:gid.
+// NoSetGroups avoids setgroups(2), which would otherwise require the
+// supplementary group list and is unnecessary for these single-identity ops.
+func uidCredential(uid, gid uint32) *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		Credential: &syscall.Credential{Uid: uid, Gid: gid, NoSetGroups: true},
+	}
+}
+
+// execAsUID runs name+args as uid:gid. stdin (may be nil) is fed on the child's
+// stdin; the child's stdout is written to stdoutW (may be nil to discard). On
+// failure the returned error carries the captured stderr.
+func execAsUID(uid, gid uint32, stdin []byte, stdoutW io.Writer, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.SysProcAttr = uidCredential(uid, gid)
+	if stdin != nil {
+		cmd.Stdin = bytes.NewReader(stdin)
+	}
+	var errb bytes.Buffer
+	cmd.Stderr = &errb
+	if stdoutW != nil {
+		cmd.Stdout = stdoutW
+	}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("run %q %v as uid=%d gid=%d: %w: %s",
+			name, args, uid, gid, err, strings.TrimSpace(errb.String()))
+	}
+	return nil
+}
+
+// ExecAsUID runs name+args as uid:gid and returns the child's stdout. Useful
+// for tests that need the raw output or want to assert on the error directly
+// (e.g. permission-denied checks).
+func ExecAsUID(t *testing.T, uid, gid uint32, name string, args ...string) ([]byte, error) {
+	t.Helper()
+	var out bytes.Buffer
+	err := execAsUID(uid, gid, nil, &out, name, args...)
+	return out.Bytes(), err
+}
+
+// WriteFileAsUID writes data to path as uid:gid (truncating any existing file).
+func WriteFileAsUID(t *testing.T, uid, gid uint32, path string, data []byte) error {
+	t.Helper()
+	// tee opens the file with O_CREAT|O_TRUNC; discard its stdout copy.
+	return execAsUID(uid, gid, data, io.Discard, "tee", path)
+}
+
+// ReadFileAsUID reads and returns the contents of path as uid:gid.
+func ReadFileAsUID(t *testing.T, uid, gid uint32, path string) ([]byte, error) {
+	t.Helper()
+	var out bytes.Buffer
+	err := execAsUID(uid, gid, nil, &out, "cat", path)
+	return out.Bytes(), err
+}
+
+// WriteRandomFileAsUID writes size bytes of random data to path as uid:gid and
+// returns the sha256 checksum of what was written.
+func WriteRandomFileAsUID(t *testing.T, uid, gid uint32, path string, size int64) (string, error) {
+	t.Helper()
+	data := GenerateRandomData(t, size)
+	if err := WriteFileAsUID(t, uid, gid, path, data); err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// VerifyFileChecksumAsUID reads path as uid:gid and checks its sha256 matches.
+func VerifyFileChecksumAsUID(t *testing.T, uid, gid uint32, path, want string) error {
+	t.Helper()
+	data, err := ReadFileAsUID(t, uid, gid, path)
+	if err != nil {
+		return err
+	}
+	sum := sha256.Sum256(data)
+	if got := hex.EncodeToString(sum[:]); got != want {
+		return fmt.Errorf("checksum mismatch for %s: want %s got %s", path, want, got)
+	}
+	return nil
+}
+
+// MkdirAsUID creates a single directory as uid:gid (errors if it exists).
+func MkdirAsUID(t *testing.T, uid, gid uint32, path string) error {
+	t.Helper()
+	return execAsUID(uid, gid, nil, nil, "mkdir", path)
+}
+
+// MkdirAllAsUID creates a directory and any missing parents as uid:gid.
+func MkdirAllAsUID(t *testing.T, uid, gid uint32, path string) error {
+	t.Helper()
+	return execAsUID(uid, gid, nil, nil, "mkdir", "-p", path)
+}
+
+// RemoveAsUID removes a single file as uid:gid (errors if it does not exist).
+func RemoveAsUID(t *testing.T, uid, gid uint32, path string) error {
+	t.Helper()
+	return execAsUID(uid, gid, nil, nil, "rm", path)
+}
+
+// RemoveAllAsUID removes a file or directory tree as uid:gid (no error if
+// absent), mirroring os.RemoveAll for cleanup.
+func RemoveAllAsUID(t *testing.T, uid, gid uint32, path string) error {
+	t.Helper()
+	return execAsUID(uid, gid, nil, nil, "rm", "-rf", path)
+}
+
+// ChmodAsUID changes the permission bits of path as uid:gid.
+func ChmodAsUID(t *testing.T, uid, gid uint32, mode os.FileMode, path string) error {
+	t.Helper()
+	return execAsUID(uid, gid, nil, nil, "chmod", strconv.FormatUint(uint64(mode.Perm()), 8), path)
+}
+
+// FileExistsAsUID reports whether path is visible to uid:gid.
+func FileExistsAsUID(t *testing.T, uid, gid uint32, path string) bool {
+	t.Helper()
+	return execAsUID(uid, gid, nil, nil, "test", "-e", path) == nil
+}
+
+// ListDirAsUID returns the entry names in path as seen by uid:gid (excluding
+// "." and ".."), mirroring framework.ListDir.
+func ListDirAsUID(t *testing.T, uid, gid uint32, path string) ([]string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	if err := execAsUID(uid, gid, nil, &out, "ls", "-1A", path); err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, line := range strings.Split(out.String(), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			names = append(names, line)
+		}
+	}
+	return names, nil
+}
+
+// StatAsUID returns metadata for path as observed by uid:gid. It fills the same
+// FileInfo fields callers use for assertions (Size, Mode permission bits, IsDir).
+func StatAsUID(t *testing.T, uid, gid uint32, path string) (FileInfo, error) {
+	t.Helper()
+	var out bytes.Buffer
+	if err := execAsUID(uid, gid, nil, &out, "stat", "-c", "%s|%a|%F", path); err != nil {
+		return FileInfo{}, err
+	}
+	parts := strings.SplitN(strings.TrimSpace(out.String()), "|", 3)
+	if len(parts) != 3 {
+		return FileInfo{}, fmt.Errorf("unexpected stat output for %s: %q", path, out.String())
+	}
+	size, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return FileInfo{}, fmt.Errorf("parse stat size %q: %w", parts[0], err)
+	}
+	perm, err := strconv.ParseUint(parts[1], 8, 32)
+	if err != nil {
+		return FileInfo{}, fmt.Errorf("parse stat mode %q: %w", parts[1], err)
+	}
+	isDir := strings.Contains(parts[2], "directory")
+	mode := os.FileMode(perm)
+	if isDir {
+		mode |= os.ModeDir
+	}
+	return FileInfo{Size: size, Mode: mode, IsDir: isDir}, nil
+}

--- a/test/e2e/framework/uid_ops_other.go
+++ b/test/e2e/framework/uid_ops_other.go
@@ -1,0 +1,95 @@
+//go:build e2e && !linux
+
+package framework
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+// uid_ops_other.go provides compile-only stubs for the uid-scoped operations.
+// Dropping privileges via SysProcAttr.Credential and the coreutils semantics
+// these helpers rely on are Linux-specific, and the e2e permission suites that
+// use them are gated to Linux. These stubs exist so `go build -tags e2e`
+// succeeds on other platforms (e.g. developer macOS machines).
+
+var errUIDOpsUnsupported = errors.New("uid-scoped filesystem ops are only supported on linux")
+
+// ExecAsUID is unsupported off Linux.
+func ExecAsUID(t *testing.T, uid, gid uint32, name string, args ...string) ([]byte, error) {
+	t.Helper()
+	return nil, errUIDOpsUnsupported
+}
+
+// WriteFileAsUID is unsupported off Linux.
+func WriteFileAsUID(t *testing.T, uid, gid uint32, path string, data []byte) error {
+	t.Helper()
+	return errUIDOpsUnsupported
+}
+
+// ReadFileAsUID is unsupported off Linux.
+func ReadFileAsUID(t *testing.T, uid, gid uint32, path string) ([]byte, error) {
+	t.Helper()
+	return nil, errUIDOpsUnsupported
+}
+
+// WriteRandomFileAsUID is unsupported off Linux.
+func WriteRandomFileAsUID(t *testing.T, uid, gid uint32, path string, size int64) (string, error) {
+	t.Helper()
+	return "", errUIDOpsUnsupported
+}
+
+// VerifyFileChecksumAsUID is unsupported off Linux.
+func VerifyFileChecksumAsUID(t *testing.T, uid, gid uint32, path, want string) error {
+	t.Helper()
+	return errUIDOpsUnsupported
+}
+
+// MkdirAsUID is unsupported off Linux.
+func MkdirAsUID(t *testing.T, uid, gid uint32, path string) error {
+	t.Helper()
+	return errUIDOpsUnsupported
+}
+
+// MkdirAllAsUID is unsupported off Linux.
+func MkdirAllAsUID(t *testing.T, uid, gid uint32, path string) error {
+	t.Helper()
+	return errUIDOpsUnsupported
+}
+
+// RemoveAsUID is unsupported off Linux.
+func RemoveAsUID(t *testing.T, uid, gid uint32, path string) error {
+	t.Helper()
+	return errUIDOpsUnsupported
+}
+
+// RemoveAllAsUID is unsupported off Linux.
+func RemoveAllAsUID(t *testing.T, uid, gid uint32, path string) error {
+	t.Helper()
+	return errUIDOpsUnsupported
+}
+
+// ChmodAsUID is unsupported off Linux.
+func ChmodAsUID(t *testing.T, uid, gid uint32, mode os.FileMode, path string) error {
+	t.Helper()
+	return errUIDOpsUnsupported
+}
+
+// FileExistsAsUID is unsupported off Linux.
+func FileExistsAsUID(t *testing.T, uid, gid uint32, path string) bool {
+	t.Helper()
+	return false
+}
+
+// ListDirAsUID is unsupported off Linux.
+func ListDirAsUID(t *testing.T, uid, gid uint32, path string) ([]string, error) {
+	t.Helper()
+	return nil, errUIDOpsUnsupported
+}
+
+// StatAsUID is unsupported off Linux.
+func StatAsUID(t *testing.T, uid, gid uint32, path string) (FileInfo, error) {
+	t.Helper()
+	return FileInfo{}, errUIDOpsUnsupported
+}

--- a/test/e2e/framework/uid_ops_other.go
+++ b/test/e2e/framework/uid_ops_other.go
@@ -76,9 +76,13 @@ func ChmodAsUID(t *testing.T, uid, gid uint32, mode os.FileMode, path string) er
 	return errUIDOpsUnsupported
 }
 
-// FileExistsAsUID is unsupported off Linux.
+// FileExistsAsUID is unsupported off Linux. Unlike the error-returning stubs,
+// this one has no channel to signal "unsupported", so it fails the test
+// immediately rather than returning false (which a caller would misread as
+// "file absent").
 func FileExistsAsUID(t *testing.T, uid, gid uint32, path string) bool {
 	t.Helper()
+	t.Fatal(errUIDOpsUnsupported)
 	return false
 }
 

--- a/test/e2e/nfs_root_squash_test.go
+++ b/test/e2e/nfs_root_squash_test.go
@@ -1,0 +1,113 @@
+//go:build e2e && linux
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/test/e2e/framework"
+	"github.com/marmos91/dittofs/test/e2e/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNFSRootSquash is the regression test for the colleague-reported NFS
+// permission bug and the squash-default alignment that followed:
+//
+//   - Default squash is root_to_guest (conventional root_squash), so an NFS
+//     client mounting as root is NOT auto-privileged. Because the built-in
+//     admin user occupies uid 0 but has no grant on a freshly created share
+//     (default_permission=none), root is denied.
+//   - An unknown uid (not a registered DittoFS user) is likewise denied.
+//   - A user that has been granted read-write CAN write — the grant is
+//     projected into the share root ACL, so least-privilege access works.
+//   - Denials over NFSv3 must surface as EACCES ("permission denied"), not the
+//     EIO ("input/output error") the colleague originally hit (#1449).
+//
+// The whole flow runs over NFSv3 (framework.MountNFS), the exact path the
+// colleague used.
+func TestNFSRootSquash(t *testing.T) {
+	sp := helpers.StartServerProcess(t, "")
+	t.Cleanup(sp.ForceKill)
+
+	runner := helpers.LoginAsAdmin(t, sp.APIURL())
+
+	metaStoreName := helpers.UniqueTestName("meta")
+	localStoreName := helpers.UniqueTestName("local")
+	shareName := "/export"
+
+	_, err := runner.CreateMetadataStore(metaStoreName, "memory")
+	require.NoError(t, err, "Should create metadata store")
+	t.Cleanup(func() { _ = runner.DeleteMetadataStore(metaStoreName) })
+
+	_, err = runner.CreateLocalBlockStore(localStoreName, "memory")
+	require.NoError(t, err, "Should create block store")
+	t.Cleanup(func() { _ = runner.DeleteLocalBlockStore(localStoreName) })
+
+	// Fresh share: default_permission=none and default root_to_guest squash.
+	_, err = runner.CreateShare(shareName, metaStoreName, localStoreName)
+	require.NoError(t, err, "Should create share")
+	t.Cleanup(func() { _ = runner.DeleteShare(shareName) })
+
+	// Grant read-write to a single non-root user.
+	_, err = runner.CreateUser(nfsLeastPrivUser, nfsLeastPrivPass, helpers.WithUID(nfsLeastPrivUID))
+	require.NoError(t, err, "Should create granted user")
+	t.Cleanup(func() { _ = runner.DeleteUser(nfsLeastPrivUser) })
+
+	err = runner.GrantUserPermission(shareName, nfsLeastPrivUser, "read-write")
+	require.NoError(t, err, "Should grant read-write to user")
+
+	nfsPort := helpers.FindFreePort(t)
+	_, err = runner.EnableAdapter("nfs", helpers.WithAdapterPort(nfsPort))
+	require.NoError(t, err, "Should enable NFS adapter")
+	t.Cleanup(func() { _, _ = runner.DisableAdapter("nfs") })
+
+	require.NoError(t, helpers.WaitForAdapterStatus(t, runner, "nfs", true, 5*time.Second),
+		"NFS adapter should become enabled")
+	framework.WaitForServer(t, nfsPort, 10*time.Second)
+
+	mount := framework.MountNFS(t, nfsPort)
+	t.Cleanup(mount.Cleanup)
+
+	// Positive control: the granted user can write.
+	t.Run("granted user can write", func(t *testing.T) {
+		path := mount.FilePath("granted.txt")
+		err := framework.WriteFileAsUID(t, nfsLeastPrivUID, nfsLeastPrivGID, path, []byte("ok"))
+		require.NoError(t, err, "Granted read-write user should be able to write")
+		t.Cleanup(func() {
+			_ = framework.RemoveAsUID(t, nfsLeastPrivUID, nfsLeastPrivGID, path)
+		})
+
+		got, err := framework.ReadFileAsUID(t, nfsLeastPrivUID, nfsLeastPrivGID, path)
+		require.NoError(t, err, "Granted user should be able to read back")
+		assert.Equal(t, []byte("ok"), got)
+	})
+
+	// Root (uid 0) is squashed under root_to_guest and has no grant -> denied.
+	t.Run("root is denied", func(t *testing.T) {
+		err := framework.WriteFileAsUID(t, 0, 0, mount.FilePath("root.txt"), []byte("nope"))
+		requireAccessDenied(t, err, "root write")
+	})
+
+	// An unknown uid (no DittoFS user) is denied by default_permission=none.
+	t.Run("unknown uid is denied", func(t *testing.T) {
+		const unknownUID, unknownGID = uint32(4000), uint32(4000)
+		err := framework.WriteFileAsUID(t, unknownUID, unknownGID, mount.FilePath("stranger.txt"), []byte("nope"))
+		requireAccessDenied(t, err, "unknown-uid write")
+	})
+}
+
+// requireAccessDenied asserts that err is a permission-denied (EACCES) failure
+// and specifically NOT the EIO regression (#1449) where export-gate denials on
+// NFSv3 surfaced as "input/output error".
+func requireAccessDenied(t *testing.T, err error, what string) {
+	t.Helper()
+	require.Error(t, err, "%s should be denied", what)
+	msg := strings.ToLower(err.Error())
+	assert.Contains(t, msg, "permission denied",
+		"%s should fail with EACCES, got: %v", what, err)
+	assert.NotContains(t, msg, "input/output error",
+		"%s must not surface EIO for a permission denial (#1449), got: %v", what, err)
+}


### PR DESCRIPTION
Stacked on #1456 (which makes the e2e suite actually compile and run).

## Why
The Go e2e NFS file-op tests ran with **no identity store**, so `ResolveSharePermission` hit its nil-identityStore short-circuit and allowed everything — permissions were never exercised. That's how the recent NFS export-permission regression shipped uncaught.

## What
- `test/e2e/framework/uid_ops_linux.go` — run filesystem I/O against the NFS mount as a specific uid/gid via `SysProcAttr.Credential{...,NoSetGroups:true}` (coreutils-backed, mirrors a real client). `uid_ops_other.go` stubs the `!linux` build.
- `test/e2e/file_operations_nfs_test.go` — create a granted **non-root** user (uid 2000, read-write) and run all NFS-01..06 I/O **as that user** (least privilege). Tightened build tag to `e2e && linux`.
- `test/e2e/nfs_root_squash_test.go` — `TestNFSRootSquash`: granted user writes OK; **root (uid 0) and an unknown uid are denied with EACCES, asserted NOT EIO** — the exact field scenario over NFSv3, locking in #1449 + the squash-default alignment (#1452).

## Verification
- `go vet -tags=e2e ./test/e2e/...` clean (darwin stub path).
- `CGO_ENABLED=0 GOOS=linux go vet -tags=e2e` clean (linux path: CLIRunner + framework symbols resolve).
- Real execution depends on #1456 (suite was a no-op before).

## Note
Granted uid 2000 writing at the share root relies on #1434 `ReconcileShareRootACL` emitting effective ACCESS_ALLOWED ACEs — the main thing to watch in the first real CI run.