### PR TITLE
perf(gc): index-based remote sweep to avoid S3 LIST (#1433)

### DIFF
--- a/pkg/block/engine/engine_delete_test.go
+++ b/pkg/block/engine/engine_delete_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/local/memory"
@@ -137,19 +138,25 @@ var _ MetadataCoordinator = (*refcountCoordinator)(nil)
 // call once (single-shot) to exercise the benign-orphan logging path.
 type recordingSyncedHashStore struct {
 	mu        sync.Mutex
-	synced    map[block.ContentHash]struct{}
+	synced    map[block.ContentHash]time.Time
 	deleted   []block.ContentHash
 	deleteErr error
 }
 
 func newRecordingSyncedHashStore() *recordingSyncedHashStore {
-	return &recordingSyncedHashStore{synced: make(map[block.ContentHash]struct{})}
+	return &recordingSyncedHashStore{synced: make(map[block.ContentHash]time.Time)}
 }
 
 func (s *recordingSyncedHashStore) markSyncedForTest(hash block.ContentHash) {
+	s.markSyncedAtForTest(hash, time.Now())
+}
+
+// markSyncedAtForTest stamps a marker with an explicit first-mirror time so
+// LIST-free sweep tests can exercise the grace window deterministically.
+func (s *recordingSyncedHashStore) markSyncedAtForTest(hash block.ContentHash, when time.Time) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.synced[hash] = struct{}{}
+	s.synced[hash] = when
 }
 
 func (s *recordingSyncedHashStore) IsSynced(_ context.Context, hash block.ContentHash) (bool, error) {
@@ -162,7 +169,29 @@ func (s *recordingSyncedHashStore) IsSynced(_ context.Context, hash block.Conten
 func (s *recordingSyncedHashStore) MarkSynced(_ context.Context, hash block.ContentHash) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.synced[hash] = struct{}{}
+	if _, ok := s.synced[hash]; !ok {
+		s.synced[hash] = time.Now() // first-write-wins
+	}
+	return nil
+}
+
+// EnumerateSynced satisfies engine.SyncedHashIndex, yielding each marker with
+// its recorded first-mirror time (the LIST-free sweep's grace anchor).
+func (s *recordingSyncedHashStore) EnumerateSynced(ctx context.Context, fn func(block.ContentHash, time.Time) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	snapshot := make(map[block.ContentHash]time.Time, len(s.synced))
+	for h, t := range s.synced {
+		snapshot[h] = t
+	}
+	s.mu.Unlock()
+	for h, t := range snapshot {
+		if err := fn(h, t); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -187,7 +216,10 @@ func (s *recordingSyncedHashStore) deletedHashes() []block.ContentHash {
 	return out
 }
 
-var _ metadata.SyncedHashStore = (*recordingSyncedHashStore)(nil)
+var (
+	_ metadata.SyncedHashStore = (*recordingSyncedHashStore)(nil)
+	_ SyncedHashIndex          = (*recordingSyncedHashStore)(nil)
+)
 
 // buildCascadeFixture wires a Store with the supplied coordinator
 // and (optional) SyncedHashStore. Local store is in-memory so the test

--- a/pkg/block/engine/gc.go
+++ b/pkg/block/engine/gc.go
@@ -569,29 +569,7 @@ func sweepByWalk(
 	options *Options,
 ) {
 	var statsMu sync.Mutex
-
-	// keep FirstErrors heterogeneous. Without
-	// diversification a burst of identical "list cas/aa: 503 SlowDown"
-	// errors fills the 16-slot cap and silently hides any 17th distinct
-	// error (e.g. an AccessDenied on DeleteBlock). We capture the FIRST
-	// occurrence of up to 16 distinct error classes so multi-mode
-	// failures are visible at a glance.
-	seenClasses := make(map[string]struct{}, 16)
-
-	addError := func(msg string) {
-		statsMu.Lock()
-		defer statsMu.Unlock()
-		stats.ErrorCount++
-		cls := classifyGCError(msg)
-		if _, ok := seenClasses[cls]; ok {
-			return
-		}
-		if len(seenClasses) >= 16 {
-			return
-		}
-		seenClasses[cls] = struct{}{}
-		stats.FirstErrors = append(stats.FirstErrors, msg)
-	}
+	addError := newSweepErrorRecorder(stats, &statsMu)
 
 	// Post-Phase-17: the renamed RemoteStore.Walk replaces the per-XX
 	// ListByPrefixWithMeta scan. Walk enumerates every CAS object in the
@@ -633,12 +611,7 @@ func sweepByWalk(
 				return nil // live — keep
 			}
 			if options.DryRun {
-				statsMu.Lock()
-				if int64(len(stats.DryRunCandidates)) < int64(dryRunSample) {
-					stats.DryRunCandidates = append(stats.DryRunCandidates, casKey)
-				}
-				stats.ObjectsSwept++ // count what would be deleted
-				statsMu.Unlock()
+				recordDryRunCandidate(stats, &statsMu, casKey, dryRunSample)
 				return nil
 			}
 			if err := store.Delete(ctx, h); err != nil {
@@ -694,12 +667,49 @@ func finalizeStats(stats *GCStats, started time.Time) {
 // recordGCError appends an error message to stats with the standard cap.
 // Used by the engine-level pre-sweep paths (gcstate temp root, gcstate
 // open, mark phase) where errors are bounded to a handful per run; the
-// diversity-aware capture lives in sweepByWalk.addError.
+// diversity-aware capture lives in newSweepErrorRecorder.
 func recordGCError(stats *GCStats, msg string) {
 	stats.ErrorCount++
 	if len(stats.FirstErrors) < 16 {
 		stats.FirstErrors = append(stats.FirstErrors, msg)
 	}
+}
+
+// newSweepErrorRecorder returns the addError closure both sweep kernels
+// (sweepByWalk, sweepFromSyncedIndex) use to record per-object errors under mu.
+// It keeps FirstErrors heterogeneous: without diversification a burst of
+// identical "list cas/aa: 503 SlowDown" errors fills the 16-slot cap and
+// silently hides any 17th distinct error (e.g. an AccessDenied on Delete). We
+// capture the FIRST occurrence of up to 16 distinct error classes so multi-mode
+// failures are visible at a glance. ErrorCount still counts every error.
+func newSweepErrorRecorder(stats *GCStats, mu *sync.Mutex) func(msg string) {
+	seenClasses := make(map[string]struct{}, 16)
+	return func(msg string) {
+		mu.Lock()
+		defer mu.Unlock()
+		stats.ErrorCount++
+		cls := classifyGCError(msg)
+		if _, ok := seenClasses[cls]; ok {
+			return
+		}
+		if len(seenClasses) >= 16 {
+			return
+		}
+		seenClasses[cls] = struct{}{}
+		stats.FirstErrors = append(stats.FirstErrors, msg)
+	}
+}
+
+// recordDryRunCandidate captures up to dryRunSample would-be-deleted CAS keys
+// and counts the would-be deletion in ObjectsSwept, under mu. Shared by both
+// sweep kernels so a DryRun pass reports identically regardless of sweep path.
+func recordDryRunCandidate(stats *GCStats, mu *sync.Mutex, casKey string, dryRunSample int) {
+	mu.Lock()
+	defer mu.Unlock()
+	if int64(len(stats.DryRunCandidates)) < int64(dryRunSample) {
+		stats.DryRunCandidates = append(stats.DryRunCandidates, casKey)
+	}
+	stats.ObjectsSwept++
 }
 
 // classifyGCError extracts a short class key from a sweep-phase error

--- a/pkg/block/engine/gc.go
+++ b/pkg/block/engine/gc.go
@@ -261,6 +261,11 @@ type SyncedHashIndex interface {
 	// EnumerateSynced calls fn once per synced marker with its content hash
 	// and first-mirror timestamp. A zero syncedAt means the backend has no
 	// recorded time (legacy marker) — the sweep treats it as fail-closed.
+	//
+	// fn is invoked SEQUENTIALLY (never concurrently), so the sweep mutates its
+	// unsynchronized per-run counters from inside fn without a lock. A non-nil
+	// error from fn aborts enumeration and is returned; implementations must
+	// honor ctx cancellation.
 	EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, syncedAt time.Time) error) error
 
 	// DeleteSynced removes the synced marker for a swept hash. Idempotent.

--- a/pkg/block/engine/gc.go
+++ b/pkg/block/engine/gc.go
@@ -226,14 +226,45 @@ type Options struct {
 	// the mark fail-closed invariant).
 	HoldProvider HoldProvider
 
-	// SyncedHashStore, when non-nil, has DeleteSynced called for every hash
-	// successfully deleted from the swept store. This keeps the synced-hash
-	// index a strict subset of remote contents: a hash swept off the remote is
-	// no longer synced and must be re-uploaded if it reappears in the live set;
-	// without this, ListUnsynced skips it forever and a later snapshot's
-	// durability verify fails (#1433). Set ONLY for remote-tier sweeps — local
-	// eviction does not change remote synced state, so local sweeps leave it nil.
-	SyncedHashStore metadata.SyncedHashStore
+	// SyncedHashIndex, when non-nil, is the per-hash "is-on-remote" marker
+	// index for the swept remote store. The sweep has DeleteSynced called for
+	// every hash it deletes, keeping the index a strict subset of remote
+	// contents: a hash swept off the remote is no longer synced and must be
+	// re-uploaded if it reappears in the live set; without this, ListUnsynced
+	// skips it forever and a later snapshot's durability verify fails (#1433).
+	// Set ONLY for remote-tier sweeps — local eviction does not change remote
+	// synced state, so local sweeps leave it nil.
+	//
+	// For a remote steady-state run (FullScan false) it is ALSO the candidate
+	// source: the sweep enumerates (synced − live) from this index instead of
+	// LISTing the remote (see sweepFromSyncedIndex).
+	SyncedHashIndex SyncedHashIndex
+
+	// FullScan forces the namespace Walk sweep (sweepByWalk) over the remote
+	// store instead of the index-based sweep. It is the drift + upgrade-
+	// migration backstop: only a full Walk finds remote objects the synced
+	// index does not know about (markers written before timestamps existed, or
+	// a Put-then-Mark crash-gap). Reconcile sets it; steady-state remote GC
+	// leaves it false and sweeps from the index (no S3 LIST). Local-tier sweeps
+	// always Walk their own (local-disk) namespace regardless of this flag.
+	FullScan bool
+}
+
+// SyncedHashIndex is the narrow slice of the synced-hash marker store the GC
+// sweep depends on: enumerate the synced set (the LIST-free orphan-candidate
+// source) and clear a marker once its object is swept (preserving the
+// synced ⊆ remote invariant). The full marker store (metadata.SyncedHashStore)
+// and the runtime's per-remote union both satisfy it structurally; GC declares
+// only what it uses so the broader IsSynced/MarkSynced surface stays out of
+// this dependency.
+type SyncedHashIndex interface {
+	// EnumerateSynced calls fn once per synced marker with its content hash
+	// and first-mirror timestamp. A zero syncedAt means the backend has no
+	// recorded time (legacy marker) — the sweep treats it as fail-closed.
+	EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, syncedAt time.Time) error) error
+
+	// DeleteSynced removes the synced marker for a swept hash. Idempotent.
+	DeleteSynced(ctx context.Context, hash block.ContentHash) error
 }
 
 // MetadataReconciler resolves per-share metadata stores. The mark phase
@@ -390,9 +421,17 @@ func collectGarbage(
 		return stats
 	}
 
-	// SWEEP: single Walk over the CAS namespace (remote union, or one share's
-	// local store).
-	sweepPhase(ctx, store, gcs, stats, snapshotTime, gracePeriod, dryRunSample, options)
+	// SWEEP: a remote steady-state run derives orphan candidates from the
+	// synced-hash index (synced − live), avoiding a full S3 LIST. Local-tier
+	// sweeps and reconcile (FullScan) Walk the CAS namespace instead — for the
+	// local tier that is a cheap local-disk walk; for reconcile it is the
+	// drift + upgrade-migration backstop that finds remote objects the index
+	// cannot (pre-timestamp markers, Put-then-Mark crash-gap).
+	if !isLocal && !options.FullScan && options.SyncedHashIndex != nil {
+		sweepFromSyncedIndex(ctx, store, gcs, stats, snapshotTime, gracePeriod, dryRunSample, options)
+	} else {
+		sweepByWalk(ctx, store, gcs, stats, snapshotTime, gracePeriod, dryRunSample, options)
+	}
 
 	// Mark complete + persist summary.
 	if err := gcs.MarkComplete(); err != nil {
@@ -487,7 +526,7 @@ func sharesForReconciler(r MetadataReconciler) []string {
 	return nil
 }
 
-// sweepPhase walks the unified CAS namespace via a single
+// sweepByWalk walks the unified CAS namespace via a single
 // remoteStore.Walk call. Per-object errors are captured in stats but
 // do not abort the sweep. Foreign keys (non-CAS) are silently
 // skipped (T-11-C-07). Objects within snapshot - GracePeriod are
@@ -504,7 +543,7 @@ func sharesForReconciler(r MetadataReconciler) []string {
 // local block.Store satisfy it, so the same sweep kernel reclaims orphans on
 // either tier (#1433).
 //
-// Walk MUST invoke its callback sequentially: sweepPhase mutates unsynchronized
+// Walk MUST invoke its callback sequentially: sweepByWalk mutates unsynchronized
 // per-run counters (scanned/swept/bytes) from inside the callback. Every
 // current backend (local filepath.WalkDir, remote paginated list) honors this;
 // a backend that parallelizes Walk must serialize the callback before
@@ -514,7 +553,12 @@ type sweepable interface {
 	Delete(ctx context.Context, hash block.ContentHash) error
 }
 
-func sweepPhase(
+// sweepByWalk reclaims orphans by enumerating the ENTIRE store namespace via
+// store.Walk and deleting objects absent from the live set (past grace). For
+// the remote tier this is an S3 LIST — used only by local-tier GC (a cheap
+// local-disk walk) and by reconcile (FullScan), which needs it as the drift +
+// upgrade-migration backstop. Steady-state remote GC uses sweepFromSyncedIndex.
+func sweepByWalk(
 	ctx context.Context,
 	store sweepable,
 	gcs *GCState,
@@ -608,8 +652,8 @@ func sweepPhase(
 			// durability verify fails on a block that will never re-upload
 			// (#1433). Idempotent + non-fatal: a stale marker only costs a missed
 			// re-upload, recoverable on the next pass. Set only for remote sweeps.
-			if options.SyncedHashStore != nil {
-				if serr := options.SyncedHashStore.DeleteSynced(ctx, h); serr != nil {
+			if options.SyncedHashIndex != nil {
+				if serr := options.SyncedHashIndex.DeleteSynced(ctx, h); serr != nil {
 					addError("delete-synced " + casKey + ": " + serr.Error())
 				}
 			}
@@ -650,7 +694,7 @@ func finalizeStats(stats *GCStats, started time.Time) {
 // recordGCError appends an error message to stats with the standard cap.
 // Used by the engine-level pre-sweep paths (gcstate temp root, gcstate
 // open, mark phase) where errors are bounded to a handful per run; the
-// diversity-aware capture lives in sweepPhase.addError.
+// diversity-aware capture lives in sweepByWalk.addError.
 func recordGCError(stats *GCStats, msg string) {
 	stats.ErrorCount++
 	if len(stats.FirstErrors) < 16 {
@@ -705,7 +749,7 @@ func classifyGCError(msg string) string {
 // for last-run.json persistence.
 //
 // DryRunCandidates is forced to nil when DryRun=false.
-// The current sweepPhase only populates the slice on DryRun runs, but
+// The current sweepByWalk only populates the slice on DryRun runs, but
 // pinning the contract here means a future change that populates the
 // slice on real runs (e.g. for "blocks deleted" tracing) cannot leak
 // across the API boundary without an explicit decision.

--- a/pkg/block/engine/gc_sweep_bench_test.go
+++ b/pkg/block/engine/gc_sweep_bench_test.go
@@ -1,0 +1,117 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+)
+
+// gcListLatencyRemote wraps a remote store and injects a fixed per-page latency into
+// Walk, modeling an S3 ListObjectsV2 paginated LIST (one network round-trip per
+// `pageSize` keys). The index sweep never calls Walk, so it pays none of this —
+// that gap is exactly the cost this change removes. Get/Delete/etc. fall through
+// to the embedded store unchanged.
+type gcListLatencyRemote struct {
+	remote.RemoteStore
+	pageSize    int
+	pageLatency time.Duration
+}
+
+func (l *gcListLatencyRemote) Walk(ctx context.Context, fn func(block.ContentHash, block.Meta) error) error {
+	n := 0
+	return l.RemoteStore.Walk(ctx, func(h block.ContentHash, m block.Meta) error {
+		if n%l.pageSize == 0 {
+			time.Sleep(l.pageLatency) // one ListObjectsV2 round-trip per page
+		}
+		n++
+		return fn(h, m)
+	})
+}
+
+// allHeldProvider injects every hash in the set as "held", so the entire object
+// population is live: the sweep makes ZERO deletes and we measure only the
+// candidate-enumeration cost (S3 LIST vs local index scan), nothing else.
+type allHeldProvider struct{ hashes []block.ContentHash }
+
+func (p allHeldProvider) HeldHashes(_ context.Context, _ string, _ []string, fn func(block.ContentHash) error) error {
+	for _, h := range p.hashes {
+		if err := fn(h); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// TestGCSweepLatencyBenchmark compares the wall-clock sweep cost of the
+// namespace Walk sweep (S3 LIST, FullScan=true) against the index sweep
+// (FullScan=false, no LIST) over an all-live population, with a per-page latency
+// modeling real S3 LIST pagination round-trips. Run explicitly:
+//
+//	go test ./pkg/block/engine/ -run TestGCSweepLatencyBenchmark -v -timeout 20m
+//
+// It is skipped under -short. The headline: Walk cost grows ~linearly with
+// object count (N/pageSize round-trips); index cost stays flat (local scan).
+func TestGCSweepLatencyBenchmark(t *testing.T) {
+	if testing.Short() {
+		t.Skip("latency benchmark skipped under -short")
+	}
+	const (
+		pageSize    = 1000                  // S3 ListObjectsV2 keys per page
+		pageLatency = 20 * time.Millisecond // modeled LIST round-trip per page
+	)
+
+	ctx := context.Background()
+	pastGrace := time.Now().Add(-2 * time.Hour)
+
+	for _, n := range []int{10_000, 100_000} {
+		// Build the all-live population once, reuse across both sweeps.
+		rs := remotememory.New()
+		t.Cleanup(func() { _ = rs.Close() })
+		rec := newGCMSReconciler()
+		_ = rec.addShare("bench")
+		synced := newRecordingSyncedHashStore()
+		hashes := make([]block.ContentHash, n)
+		for i := 0; i < n; i++ {
+			h := hashFromString(fmt.Sprintf("bench-%d-%d", n, i))
+			hashes[i] = h
+			if err := rs.Put(ctx, h, []byte("x")); err != nil {
+				t.Fatalf("seed remote: %v", err)
+			}
+			synced.markSyncedAtForTest(h, pastGrace)
+		}
+		hold := allHeldProvider{hashes: hashes}
+		lat := &gcListLatencyRemote{RemoteStore: rs, pageSize: pageSize, pageLatency: pageLatency}
+
+		run := func(fullScan bool) (time.Duration, *GCStats) {
+			opts := &Options{
+				GCStateRoot:     t.TempDir(),
+				GracePeriod:     time.Minute,
+				SyncedHashIndex: synced,
+				HoldProvider:    hold,
+				FullScan:        fullScan,
+			}
+			start := time.Now()
+			stats := CollectGarbage(ctx, lat, rec, opts)
+			return time.Since(start), stats
+		}
+
+		// FullScan=true → Walk sweep (pays the modeled S3 LIST latency).
+		walkDur, walkStats := run(true)
+		// FullScan=false → index sweep (no LIST).
+		idxDur, idxStats := run(false)
+
+		if walkStats.ObjectsSwept != 0 || idxStats.ObjectsSwept != 0 {
+			t.Fatalf("expected 0 sweeps (all live): walk=%d index=%d",
+				walkStats.ObjectsSwept, idxStats.ObjectsSwept)
+		}
+		pages := n / pageSize
+		t.Logf("N=%-7d  walk(LIST)=%-10v  index(no-LIST)=%-10v  speedup=%.1fx  (modeled %d LIST pages @ %v)",
+			n, walkDur.Round(time.Millisecond), idxDur.Round(time.Millisecond),
+			float64(walkDur)/float64(idxDur), pages, pageLatency)
+	}
+}

--- a/pkg/block/engine/gc_sweep_index.go
+++ b/pkg/block/engine/gc_sweep_index.go
@@ -1,0 +1,132 @@
+package engine
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+// sweepFromSyncedIndex is the index-based counterpart of sweepByWalk. Instead
+// of a full RemoteStore.Walk (an S3 LIST of the entire CAS namespace, O(total)
+// regardless of churn), it derives the remote-orphan candidate set from the
+// synced-hash index: (synced − live). Because the mirror does Put-then-Mark and
+// every delete path does Delete-then-DeleteSynced, the synced set is a strict
+// subset of remote contents, so a synced hash that is NOT in the live set (and
+// past grace) is a genuine remote orphan that can be deleted by key — no LIST.
+//
+// Cost = O(synced-set) local scan + O(orphans) DELETEs. Rare index drift
+// (e.g. a Put-then-Mark crash leaving an un-indexed remote object) is caught by
+// the periodic full-Walk reconcile, not here.
+//
+// Semantics match sweepByWalk where they overlap: fail-closed on a missing
+// timestamp (a legacy marker with no recorded syncedAt is preserved), the grace
+// window protects freshly-mirrored hashes, and a live-set hit keeps the object.
+// Unlike the Walk sweep, the per-object byte size is not available from the
+// index, so BytesFreed is not tracked here — ObjectsSwept is the accurate
+// reclamation count; the periodic full-Walk reconcile reports bytes.
+func sweepFromSyncedIndex(
+	ctx context.Context,
+	store sweepable,
+	gcs *GCState,
+	stats *GCStats,
+	snapshotTime time.Time,
+	gracePeriod time.Duration,
+	dryRunSample int,
+	options *Options,
+) {
+	var statsMu sync.Mutex
+
+	seenClasses := make(map[string]struct{}, 16)
+	addError := func(msg string) {
+		statsMu.Lock()
+		defer statsMu.Unlock()
+		stats.ErrorCount++
+		cls := classifyGCError(msg)
+		if _, ok := seenClasses[cls]; ok {
+			return
+		}
+		if len(seenClasses) >= 16 {
+			return
+		}
+		seenClasses[cls] = struct{}{}
+		stats.FirstErrors = append(stats.FirstErrors, msg)
+	}
+
+	graceCutoff := snapshotTime.Add(-gracePeriod)
+	var scanned int64
+
+	enumErr := options.SyncedHashIndex.EnumerateSynced(ctx, func(h block.ContentHash, syncedAt time.Time) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		casKey := block.FormatCASKey(h)
+		scanned++
+
+		// Fail-closed on a missing first-mirror timestamp: a legacy marker
+		// (written before timestamps were stored) cannot be grace-evaluated, so
+		// we MUST NOT delete it on the live-set check alone. Preserve it; the
+		// periodic full-Walk reconcile will reclaim it if it is a true orphan.
+		if syncedAt.IsZero() {
+			return nil
+		}
+		// Within the grace window: a freshly-mirrored hash whose manifest row
+		// may not have committed yet — keep it.
+		if syncedAt.After(graceCutoff) {
+			return nil
+		}
+
+		present, err := gcs.Has(h)
+		if err != nil {
+			// Fail-closed: cannot prove the hash is orphaned, so keep it.
+			addError("gcstate has " + casKey + ": " + err.Error())
+			return nil
+		}
+		if present {
+			return nil // live (manifest or snapshot-held) — keep
+		}
+
+		if options.DryRun {
+			statsMu.Lock()
+			if int64(len(stats.DryRunCandidates)) < int64(dryRunSample) {
+				stats.DryRunCandidates = append(stats.DryRunCandidates, casKey)
+			}
+			stats.ObjectsSwept++ // count what would be deleted
+			statsMu.Unlock()
+			return nil
+		}
+
+		if derr := store.Delete(ctx, h); derr != nil {
+			// Continue + capture; the marker stays so the next pass retries.
+			addError("delete " + casKey + ": " + derr.Error())
+			return nil
+		}
+		// Keep the synced index a strict subset of remote contents: the object
+		// is gone, so clear its marker. Idempotent + non-fatal — a stale marker
+		// only costs a missed re-upload, recovered on the next pass (#1433).
+		if serr := options.SyncedHashIndex.DeleteSynced(ctx, h); serr != nil {
+			addError("delete-synced " + casKey + ": " + serr.Error())
+		}
+		statsMu.Lock()
+		stats.ObjectsSwept++
+		statsMu.Unlock()
+		return nil
+	})
+	if enumErr != nil {
+		addError("enumerate-synced: " + enumErr.Error())
+	}
+
+	statsMu.Lock()
+	// ObjectsScanned here counts synced markers inspected (the LIST-free
+	// candidate set), not the full remote namespace — the index IS the scope.
+	stats.ObjectsScanned += scanned
+	statsMu.Unlock()
+
+	if options.ProgressCallback != nil {
+		statsMu.Lock()
+		snap := *stats
+		statsMu.Unlock()
+		options.ProgressCallback(snap)
+	}
+}

--- a/pkg/block/engine/gc_sweep_index.go
+++ b/pkg/block/engine/gc_sweep_index.go
@@ -37,22 +37,7 @@ func sweepFromSyncedIndex(
 	options *Options,
 ) {
 	var statsMu sync.Mutex
-
-	seenClasses := make(map[string]struct{}, 16)
-	addError := func(msg string) {
-		statsMu.Lock()
-		defer statsMu.Unlock()
-		stats.ErrorCount++
-		cls := classifyGCError(msg)
-		if _, ok := seenClasses[cls]; ok {
-			return
-		}
-		if len(seenClasses) >= 16 {
-			return
-		}
-		seenClasses[cls] = struct{}{}
-		stats.FirstErrors = append(stats.FirstErrors, msg)
-	}
+	addError := newSweepErrorRecorder(stats, &statsMu)
 
 	graceCutoff := snapshotTime.Add(-gracePeriod)
 	var scanned int64
@@ -88,12 +73,7 @@ func sweepFromSyncedIndex(
 		}
 
 		if options.DryRun {
-			statsMu.Lock()
-			if int64(len(stats.DryRunCandidates)) < int64(dryRunSample) {
-				stats.DryRunCandidates = append(stats.DryRunCandidates, casKey)
-			}
-			stats.ObjectsSwept++ // count what would be deleted
-			statsMu.Unlock()
+			recordDryRunCandidate(stats, &statsMu, casKey, dryRunSample)
 			return nil
 		}
 

--- a/pkg/block/engine/gc_sweep_index_test.go
+++ b/pkg/block/engine/gc_sweep_index_test.go
@@ -1,0 +1,129 @@
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+)
+
+// noWalkRemote fails the test if RemoteStore.Walk is called. The LIST-free
+// sweep must derive its candidates from the synced-hash index alone, never
+// from an S3 LIST — wrapping the remote this way turns that invariant into a
+// hard assertion.
+type noWalkRemote struct {
+	remote.RemoteStore
+	t *testing.T
+}
+
+func (n noWalkRemote) Walk(context.Context, func(block.ContentHash, block.Meta) error) error {
+	n.t.Fatalf("LIST-free sweep must not call RemoteStore.Walk (S3 LIST)")
+	return nil
+}
+
+// TestGCIndexSweep_DeletesOrphansWithoutWalk proves the index-based remote
+// sweep (steady-state, FullScan false): it reclaims a past-grace orphan present
+// in the synced index but absent from the live set, WITHOUT walking the remote,
+// while preserving (a) a live block, (b) a within-grace freshly-synced block,
+// and (c) a legacy marker with no recorded timestamp (fail-closed). The swept
+// orphan's marker is cleared so it re-uploads if it reappears live (#1433).
+func TestGCIndexSweep_DeletesOrphansWithoutWalk(t *testing.T) {
+	ctx := t.Context()
+	rs := remotememory.New()
+	defer func() { _ = rs.Close() }()
+
+	rec := newGCMSReconciler()
+	st := rec.addShare("share-a")
+
+	now := time.Now()
+	live := hashFromString("lf-live-keep")      // in manifest → live
+	orphan := hashFromString("lf-orphan-sweep") // not in manifest, past grace → swept
+	fresh := hashFromString("lf-fresh-keep")    // not in manifest, within grace → kept
+	legacy := hashFromString("lf-legacy-keep")  // not in manifest, zero ts → fail-closed keep
+
+	// Only the live block has a manifest row (FileBlock).
+	putBlock(t, st, "file-live/0", live)
+	for _, h := range []block.ContentHash{live, orphan, fresh, legacy} {
+		writeCASObject(t, ctx, rs, h, []byte("data-"+h.String()[:8]))
+	}
+
+	synced := newRecordingSyncedHashStore()
+	// live & orphan marked LONG ago (past grace) — only the live-set check can
+	// save the live one; grace cannot.
+	synced.markSyncedAtForTest(live, now.Add(-2*time.Hour))
+	synced.markSyncedAtForTest(orphan, now.Add(-2*time.Hour))
+	// fresh marked just now — within the grace window.
+	synced.markSyncedAtForTest(fresh, now)
+	// legacy marker carries no timestamp (pre-upgrade badger marker).
+	synced.markSyncedAtForTest(legacy, time.Time{})
+
+	stats := CollectGarbage(ctx, noWalkRemote{RemoteStore: rs, t: t}, rec, &Options{
+		GCStateRoot:     t.TempDir(),
+		GracePeriod:     time.Hour,
+		SyncedHashIndex: synced,
+		// FullScan omitted (false) → steady-state index sweep.
+	})
+
+	if stats.ErrorCount != 0 {
+		t.Fatalf("ErrorCount = %d, want 0 (FirstErrors=%v)", stats.ErrorCount, stats.FirstErrors)
+	}
+	if stats.ObjectsSwept != 1 {
+		t.Fatalf("ObjectsSwept = %d, want 1 (only the past-grace orphan)", stats.ObjectsSwept)
+	}
+
+	// Orphan: deleted from remote, marker cleared.
+	if _, err := rs.Get(ctx, orphan); err == nil {
+		t.Errorf("orphan still present on remote after LIST-free sweep")
+	}
+	if ok, _ := synced.IsSynced(ctx, orphan); ok {
+		t.Errorf("swept orphan still marked synced; ListUnsynced would skip it forever (#1433)")
+	}
+
+	// Live, fresh, legacy: kept on remote with markers intact.
+	for name, h := range map[string]block.ContentHash{"live": live, "fresh": fresh, "legacy": legacy} {
+		if _, err := rs.Get(ctx, h); err != nil {
+			t.Errorf("%s block wrongly deleted: %v", name, err)
+		}
+		if ok, _ := synced.IsSynced(ctx, h); !ok {
+			t.Errorf("%s block's synced marker wrongly cleared", name)
+		}
+	}
+}
+
+// TestGCIndexSweep_DryRunCountsWithoutDeleting verifies dry-run reports the
+// orphan as a candidate without deleting it or clearing its marker.
+func TestGCIndexSweep_DryRunCountsWithoutDeleting(t *testing.T) {
+	ctx := t.Context()
+	rs := remotememory.New()
+	defer func() { _ = rs.Close() }()
+
+	rec := newGCMSReconciler()
+	_ = rec.addShare("share-a")
+
+	orphan := hashFromString("lf-dryrun-orphan")
+	writeCASObject(t, ctx, rs, orphan, []byte("orphan-data"))
+
+	synced := newRecordingSyncedHashStore()
+	synced.markSyncedAtForTest(orphan, time.Now().Add(-2*time.Hour))
+
+	stats := CollectGarbage(ctx, noWalkRemote{RemoteStore: rs, t: t}, rec, &Options{
+		GCStateRoot:     t.TempDir(),
+		GracePeriod:     time.Hour,
+		SyncedHashIndex: synced,
+		DryRun:          true,
+		// FullScan omitted (false) → steady-state index sweep.
+	})
+
+	if stats.ObjectsSwept != 1 {
+		t.Fatalf("dry-run ObjectsSwept = %d, want 1 (candidate count)", stats.ObjectsSwept)
+	}
+	if _, err := rs.Get(ctx, orphan); err != nil {
+		t.Errorf("dry-run deleted the orphan: %v", err)
+	}
+	if ok, _ := synced.IsSynced(ctx, orphan); !ok {
+		t.Errorf("dry-run cleared the synced marker")
+	}
+}

--- a/pkg/block/engine/gc_test.go
+++ b/pkg/block/engine/gc_test.go
@@ -1501,7 +1501,12 @@ func TestGCMarkSweep_ClearsSyncedMarkerForSweptHash(t *testing.T) {
 	stats := CollectGarbage(ctx, rs, rec, &Options{
 		GCStateRoot:     t.TempDir(),
 		GracePeriod:     time.Minute,
-		SyncedHashStore: synced,
+		SyncedHashIndex: synced,
+		// FullScan: this case exercises the namespace-Walk sweep's marker-clear
+		// (the remote object is backdated past grace; the synced markers are
+		// fresh). The index sweep's marker-clear is covered by
+		// TestGCIndexSweep_DeletesOrphansWithoutWalk.
+		FullScan: true,
 	})
 	if stats.ObjectsSwept != 1 {
 		t.Fatalf("ObjectsSwept = %d, want 1", stats.ObjectsSwept)

--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -444,10 +444,19 @@ func (r *Runtime) syncedHashStoreForShares(shares []string) engine.SyncedHashInd
 	for _, shareName := range shares {
 		mds, err := r.GetMetadataStoreForShare(shareName)
 		if err != nil {
+			// A share whose metadata store cannot be resolved drops out of the
+			// index union: its hashes will not be sweep candidates and its
+			// markers will not be cleared. Surface it so operators can explain a
+			// degraded sweep rather than seeing a silent fall-through to Walk.
+			logger.Warn("GC: synced index unavailable for share — excluded from sweep candidate set",
+				"share", shareName, "err", err)
 			continue
 		}
 		if shs, ok := mds.(engine.SyncedHashIndex); ok {
 			stores = append(stores, shs)
+		} else {
+			logger.Warn("GC: metadata store does not implement EnumerateSynced — share excluded from index sweep, marker-clear disabled",
+				"share", shareName)
 		}
 	}
 	if len(stores) == 0 {

--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -46,6 +46,17 @@ func gcResult(total *engine.GCStats) string {
 // Returns the summed *engine.GCStats across all per-remote invocations and any
 // fatal error.
 func (r *Runtime) RunBlockGC(ctx context.Context, sharePrefix string, dryRun bool) (*engine.GCStats, error) {
+	// Steady-state GC: index-based remote sweep (synced − live), no S3 LIST.
+	return r.runBlockGCSweep(ctx, sharePrefix, dryRun, false)
+}
+
+// runBlockGCSweep is the shared remote+local GC pass. fullScan selects the
+// full RemoteStore.Walk sweep (the reconcile drift + upgrade-migration
+// backstop, which scans the real remote to catch objects the synced-hash index
+// does not know about) instead of the steady-state index sweep (synced − live,
+// no S3 LIST). Both paths clear synced markers on delete, preserving the
+// synced ⊆ remote invariant (#1433).
+func (r *Runtime) runBlockGCSweep(ctx context.Context, sharePrefix string, dryRun, fullScan bool) (*engine.GCStats, error) {
 	if sharePrefix != "" {
 		logger.Warn("RunBlockGC: sharePrefix is no longer honored — mark-sweep uses a global live set across every cas/XX prefix",
 			"ignored_sharePrefix", sharePrefix)
@@ -83,10 +94,15 @@ func (r *Runtime) RunBlockGC(ctx context.Context, sharePrefix string, dryRun boo
 		applyGCDefaults(opts, gcDefaults)
 		// Inject held hashes from ready snapshots into the GC mark phase.
 		opts.HoldProvider = r.snapshotHoldForRemote(entry.Shares)
-		// Clear synced markers for hashes swept off this remote so they re-upload
-		// if they reappear in the live set (#1433). Remote sweep only.
-		opts.SyncedHashStore = r.syncedHashStoreForShares(entry.Shares)
+		// The per-remote synced-hash index: the index-sweep candidate source AND
+		// the marker-clear for swept hashes (so they re-upload if they reappear
+		// in the live set) (#1433). Remote sweep only. A steady-state run sweeps
+		// from it; the reconcile path (fullScan) keeps it only for the
+		// marker-clear and Walks the namespace instead.
+		opts.SyncedHashIndex = r.syncedHashStoreForShares(entry.Shares)
+		opts.FullScan = fullScan
 		logger.Info("RunBlockGC: starting",
+			"fullScan", opts.FullScan,
 			"configID", entry.ConfigID,
 			"shares", entry.Shares,
 			"dryRun", dryRun,
@@ -254,9 +270,13 @@ func (r *Runtime) RunBlockGCForShare(ctx context.Context, name string, dryRun bo
 		applyGCDefaults(opts, gcDefaults)
 		// Inject held hashes from ready snapshots into the GC mark phase.
 		opts.HoldProvider = r.snapshotHoldForRemote(entry.Shares)
-		// Clear synced markers for hashes swept off this remote so they re-upload
-		// if they reappear in the live set (#1433). Remote sweep only.
-		opts.SyncedHashStore = r.syncedHashStoreForShares(entry.Shares)
+		// Per-remote synced-hash index: LIST-free candidate source + marker-clear
+		// for swept hashes (#1433). The live set unions every share on this
+		// remote (perRemoteReconciler below), so a single-share invocation never
+		// treats a sibling share's live block as an orphan.
+		opts.SyncedHashIndex = r.syncedHashStoreForShares(entry.Shares)
+		// Per-share GC is steady-state (index sweep, no S3 LIST); FullScan stays
+		// false (its zero value).
 		logger.Info("RunBlockGCForShare: starting",
 			"share", name,
 			"configID", entry.ConfigID,
@@ -356,35 +376,41 @@ func (r *Runtime) setShareRemoteForTest(shareName string, rs remote.RemoteStore)
 	r.sharesSvc.SetShareRemoteForTest(shareName, rs)
 }
 
-// multiSyncedHashStore fans DeleteSynced out to every share's synced-hash index
-// on a shared remote, so a hash swept off that remote is un-synced everywhere it
-// was recorded. DeleteSynced is idempotent, so clearing a hash a share never had
-// is a no-op. GC only ever calls DeleteSynced; the other methods exist for
-// interface completeness.
-type multiSyncedHashStore []metadata.SyncedHashStore
+// multiSyncedHashStore unions the per-share synced-hash indexes on a shared
+// remote into the single engine.SyncedHashIndex the GC sweep consumes:
+// EnumerateSynced for the LIST-free candidate set and DeleteSynced to clear a
+// swept hash everywhere it was recorded. It implements ONLY what GC needs — the
+// per-hash IsSynced/MarkSynced live on the underlying metadata stores for the
+// syncer and eviction paths and are deliberately not re-exposed here.
+type multiSyncedHashStore []engine.SyncedHashIndex
 
-func (m multiSyncedHashStore) IsSynced(ctx context.Context, h block.ContentHash) (bool, error) {
-	if err := ctx.Err(); err != nil {
-		return false, err
-	}
-	for _, s := range m {
-		ok, err := s.IsSynced(ctx, h)
-		if err != nil {
-			return false, err
-		}
-		if ok {
-			return true, nil
-		}
-	}
-	return false, nil
-}
+var _ engine.SyncedHashIndex = multiSyncedHashStore(nil)
 
-func (m multiSyncedHashStore) MarkSynced(ctx context.Context, h block.ContentHash) error {
+// EnumerateSynced fans enumeration across every share's index and unions the
+// results. The same hash can be synced in several shares (CAS dedup) at
+// different first-mirror times; it keeps the LATEST so the grace window covers
+// the most recent upload — the most conservative choice (never delete a hash
+// still within any share's grace). A real timestamp supersedes a legacy zero.
+func (m multiSyncedHashStore) EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, syncedAt time.Time) error) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	latest := make(map[block.ContentHash]time.Time)
 	for _, s := range m {
-		if err := s.MarkSynced(ctx, h); err != nil {
+		if err := s.EnumerateSynced(ctx, func(h block.ContentHash, syncedAt time.Time) error {
+			if prev, ok := latest[h]; !ok || syncedAt.After(prev) {
+				latest[h] = syncedAt
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	for h, t := range latest {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := fn(h, t); err != nil {
 			return err
 		}
 	}
@@ -407,18 +433,20 @@ func (m multiSyncedHashStore) DeleteSynced(ctx context.Context, h block.ContentH
 	return errors.Join(errs...)
 }
 
-// syncedHashStoreForShares unions the synced-hash indexes of the given shares so
-// a remote-tier GC sweep can clear the marker for every hash it deletes (#1433).
-// Each share's metadata store implements SyncedHashStore. Returns nil when none
-// are available, leaving the sweep's marker-clear a no-op.
-func (r *Runtime) syncedHashStoreForShares(shares []string) metadata.SyncedHashStore {
+// syncedHashStoreForShares unions the synced-hash indexes of the given shares
+// into the engine.SyncedHashIndex a remote-tier GC sweep consumes: the LIST-free
+// candidate source (EnumerateSynced) and the marker-clear for every hash it
+// deletes (DeleteSynced) (#1433). Each share's metadata store provides both via
+// its concrete EnumerateSynced/DeleteSynced. Returns nil when none are
+// available, which forces the sweep onto the full-Walk path.
+func (r *Runtime) syncedHashStoreForShares(shares []string) engine.SyncedHashIndex {
 	var stores multiSyncedHashStore
 	for _, shareName := range shares {
 		mds, err := r.GetMetadataStoreForShare(shareName)
 		if err != nil {
 			continue
 		}
-		if shs, ok := mds.(metadata.SyncedHashStore); ok {
+		if shs, ok := mds.(engine.SyncedHashIndex); ok {
 			stores = append(stores, shs)
 		}
 	}

--- a/pkg/controlplane/runtime/blockgc_reconcile.go
+++ b/pkg/controlplane/runtime/blockgc_reconcile.go
@@ -58,7 +58,7 @@ func (r *Runtime) RunBlockGCReconcile(ctx context.Context, dryRun bool) (*engine
 	// Stranded rows are gone, so their hashes have left the live set. The sweep
 	// reclaims the now-orphaned chunks on the remote tier and (since #1433) the
 	// local tier too, under the usual grace + snapshot-hold guards. Reconcile
-	// forces the FULL RemoteStore.Walk (listFree=false): it is the drift-catcher
+	// forces the FULL RemoteStore.Walk (fullScan=true): it is the drift-catcher
 	// that must scan the real remote to find objects the synced-hash index does
 	// not know about (e.g. a Put-then-Mark crash), which the steady-state
 	// LIST-free sweep cannot see.

--- a/pkg/controlplane/runtime/blockgc_reconcile.go
+++ b/pkg/controlplane/runtime/blockgc_reconcile.go
@@ -55,10 +55,14 @@ func (r *Runtime) RunBlockGCReconcile(ctx context.Context, dryRun bool) (*engine
 		total.StrandedRowsReaped += int64(reaped)
 	}
 
-	// Stranded rows are gone, so their hashes have left the live set. RunBlockGC
-	// sweeps the remote tier and (since #1433) the local tier too, reclaiming
-	// the now-orphaned chunks under the usual grace + snapshot-hold guards.
-	sweep, err := r.RunBlockGC(ctx, "", dryRun)
+	// Stranded rows are gone, so their hashes have left the live set. The sweep
+	// reclaims the now-orphaned chunks on the remote tier and (since #1433) the
+	// local tier too, under the usual grace + snapshot-hold guards. Reconcile
+	// forces the FULL RemoteStore.Walk (listFree=false): it is the drift-catcher
+	// that must scan the real remote to find objects the synced-hash index does
+	// not know about (e.g. a Put-then-Mark crash), which the steady-state
+	// LIST-free sweep cannot see.
+	sweep, err := r.runBlockGCSweep(ctx, "", dryRun, true)
 	// Record reaped rows regardless of the sweep result: the rows are already
 	// deleted from the metadata store, so the counter must reflect that even if
 	// the downstream sweep (e.g. S3 unreachable) then fails. Skip on dry-run —

--- a/pkg/controlplane/runtime/snapshot_lifecycle_test.go
+++ b/pkg/controlplane/runtime/snapshot_lifecycle_test.go
@@ -119,6 +119,15 @@ func setupSnapshotLifecycle(t *testing.T) *lifecycleFixture {
 	mustPutRemote(t, rs, fx.hSnap, []byte("snap-only-payload"))
 	mustPutRemote(t, rs, fx.hOrphan, []byte("orphan-payload"))
 
+	// Every object on the remote got there via the mirror (Put-then-Mark), so
+	// it carries a synced marker — that is the steady-state index sweep's
+	// candidate source. Backdate the markers past the grace window (matching the
+	// remote object clock above) so GC reclaims the unheld ones immediately.
+	synced := time.Now().Add(-2 * time.Hour)
+	for _, h := range []block.ContentHash{fx.hLive1, fx.hLive2, fx.hSnap, fx.hOrphan} {
+		metaStore.MarkSyncedAtForTest(h, synced)
+	}
+
 	return fx
 }
 

--- a/pkg/metadata/store/badger/encoding.go
+++ b/pkg/metadata/store/badger/encoding.go
@@ -236,3 +236,19 @@ func decodeUint32(bytes []byte) (uint32, error) {
 	}
 	return binary.BigEndian.Uint32(bytes), nil
 }
+
+// encodeInt64 encodes a signed 64-bit value (e.g. a Unix-nanos timestamp) as
+// 8 big-endian bytes. decodeInt64 reverses it; a value shorter than 8 bytes
+// (a legacy marker written before timestamps existed) decodes to 0.
+func encodeInt64(value int64) []byte {
+	bytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(bytes, uint64(value))
+	return bytes
+}
+
+func decodeInt64(bytes []byte) int64 {
+	if len(bytes) < 8 {
+		return 0
+	}
+	return int64(binary.BigEndian.Uint64(bytes))
+}

--- a/pkg/metadata/store/badger/synced_hash_store.go
+++ b/pkg/metadata/store/badger/synced_hash_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/dgraph-io/badger/v4"
 
@@ -27,7 +28,8 @@ import (
 // coordination is required between callers.
 //
 // Key Namespace:
-//   - synced:{32-byte-hash}  empty value (presence == synced)
+//   - synced:{32-byte-hash}  value = 8 big-endian nanos of first-mirror time
+//     (presence == synced; legacy markers carry an empty value)
 //
 // The 32-byte hash bytes are appended raw (matching rollup_offset's compact
 // binary key encoding) rather than hex-encoded — Badger does not require
@@ -69,19 +71,88 @@ func (s *BadgerMetadataStore) IsSynced(ctx context.Context, hash block.ContentHa
 	return present, nil
 }
 
-// MarkSynced records that hash has been mirrored to remote. Idempotent:
-// re-applying the same hash is a no-op and returns nil (Badger Set
-// overwrites the existing empty value).
+// MarkSynced records that hash has been mirrored to remote, stamping the
+// marker value with the current time as 8 big-endian nanos. Idempotent and
+// first-write-wins: re-applying an already-marked hash is a no-op that
+// preserves the original timestamp (matching the SQL backends' ON CONFLICT DO
+// NOTHING), so EnumerateSynced reports when the hash was FIRST mirrored — the
+// grace anchor for the LIST-free sweep. Markers written before timestamps
+// existed carry an empty value and decode to a zero time (fail-closed: the
+// sweep leaves them for the periodic reconcile).
 func (s *BadgerMetadataStore) MarkSynced(ctx context.Context, hash block.ContentHash) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 
 	err := s.db.Update(func(txn *badger.Txn) error {
-		return txn.Set(keySyncedHash(hash), nil)
+		key := keySyncedHash(hash)
+		if _, gerr := txn.Get(key); gerr == nil {
+			return nil // already marked — preserve first-write timestamp
+		} else if !errors.Is(gerr, badger.ErrKeyNotFound) {
+			return gerr
+		}
+		return txn.Set(key, encodeInt64(time.Now().UnixNano()))
 	})
 	if err != nil {
 		return fmt.Errorf("badger synced mark: %w", err)
+	}
+	return nil
+}
+
+// EnumerateSynced streams every synced marker with its first-mirror time via a
+// prefix scan over synced:. Collects under a read txn then calls fn outside
+// iteration so the callback never runs with the iterator open. Used by the
+// LIST-free GC sweep to compute remote-orphan candidates without an S3 LIST.
+func (s *BadgerMetadataStore) EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, syncedAt time.Time) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	prefix := []byte(syncedHashPrefix)
+
+	type entry struct {
+		hash     block.ContentHash
+		syncedAt time.Time
+	}
+	var entries []entry
+
+	err := s.db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.Prefix = prefix
+		it := txn.NewIterator(opts)
+		defer it.Close()
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			item := it.Item()
+			key := item.KeyCopy(nil)
+			raw := key[len(prefix):]
+			if len(raw) != len(block.ContentHash{}) {
+				continue
+			}
+			var h block.ContentHash
+			copy(h[:], raw)
+			var syncedAt time.Time
+			if verr := item.Value(func(val []byte) error {
+				if nanos := decodeInt64(val); nanos != 0 {
+					syncedAt = time.Unix(0, nanos)
+				}
+				return nil
+			}); verr != nil {
+				return verr
+			}
+			entries = append(entries, entry{hash: h, syncedAt: syncedAt})
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("badger synced enumerate: %w", err)
+	}
+
+	for _, e := range entries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := fn(e.hash, e.syncedAt); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/metadata/store/badger/synced_hash_store_test.go
+++ b/pkg/metadata/store/badger/synced_hash_store_test.go
@@ -19,3 +19,12 @@ func TestBadgerSyncedHashStore_Suite(t *testing.T) {
 	s := newRollupTestStore(t)
 	metadata.RunSyncedHashStoreSuite(t, s)
 }
+
+// TestBadgerSyncedHashEnumerator_Suite exercises the LIST-free GC sweep's
+// EnumerateSynced contract against the Badger backend, including its
+// timestamped marker value (first-write-wins nanos) and prefix-scan
+// enumeration.
+func TestBadgerSyncedHashEnumerator_Suite(t *testing.T) {
+	s := newRollupTestStore(t)
+	metadata.RunSyncedHashEnumeratorSuite(t, s)
+}

--- a/pkg/metadata/store/memory/synced_hash_store.go
+++ b/pkg/metadata/store/memory/synced_hash_store.go
@@ -11,6 +11,43 @@ import (
 // Compile-time assertion: the memory engine implements SyncedHashStore.
 var _ metadata.SyncedHashStore = (*MemoryMetadataStore)(nil)
 
+// MarkSyncedAtForTest stamps a synced marker with an explicit first-mirror
+// time. Test-only: it lets GC grace-window tests backdate when a hash was
+// synced, mirroring remotememory.Store.SetNowFnForTest for the remote object
+// clock. Production code uses MarkSynced, which stamps the current time.
+func (s *MemoryMetadataStore) MarkSyncedAtForTest(hash block.ContentHash, when time.Time) {
+	s.syncedMu.Lock()
+	defer s.syncedMu.Unlock()
+	if s.synced == nil {
+		s.synced = make(map[block.ContentHash]time.Time)
+	}
+	s.synced[hash] = when
+}
+
+// EnumerateSynced streams every synced marker with its first-mirror time.
+// It snapshots the map under the read lock so fn runs without holding it.
+func (s *MemoryMetadataStore) EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, syncedAt time.Time) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.syncedMu.RLock()
+	snapshot := make(map[block.ContentHash]time.Time, len(s.synced))
+	for h, t := range s.synced {
+		snapshot[h] = t
+	}
+	s.syncedMu.RUnlock()
+
+	for h, t := range snapshot {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := fn(h, t); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // IsSynced reports whether hash has been mirrored to remote. Returns
 // (false, nil) when no entry exists for hash.
 func (s *MemoryMetadataStore) IsSynced(ctx context.Context, hash block.ContentHash) (bool, error) {

--- a/pkg/metadata/store/memory/synced_hash_store_test.go
+++ b/pkg/metadata/store/memory/synced_hash_store_test.go
@@ -14,3 +14,10 @@ func TestMemorySyncedHashStore_Suite(t *testing.T) {
 	s := NewMemoryMetadataStoreWithDefaults()
 	metadata.RunSyncedHashStoreSuite(t, s)
 }
+
+// TestMemorySyncedHashEnumerator_Suite exercises the LIST-free GC sweep's
+// EnumerateSynced contract against the memory backend.
+func TestMemorySyncedHashEnumerator_Suite(t *testing.T) {
+	s := NewMemoryMetadataStoreWithDefaults()
+	metadata.RunSyncedHashEnumeratorSuite(t, s)
+}

--- a/pkg/metadata/store/postgres/synced_hash_store.go
+++ b/pkg/metadata/store/postgres/synced_hash_store.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -18,6 +19,41 @@ import (
 
 // Compile-time assertion: the Postgres engine implements SyncedHashStore.
 var _ metadata.SyncedHashStore = (*PostgresMetadataStore)(nil)
+
+// EnumerateSynced streams every synced marker with its first-mirror time,
+// read straight from the synced_hashes table. Used by the LIST-free GC sweep
+// to compute remote-orphan candidates without an S3 LIST.
+func (s *PostgresMetadataStore) EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, syncedAt time.Time) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	rows, err := s.query(ctx, `SELECT hash, synced_at FROM synced_hashes`)
+	if err != nil {
+		return fmt.Errorf("postgres synced enumerate: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			raw      []byte
+			syncedAt time.Time
+		)
+		if err := rows.Scan(&raw, &syncedAt); err != nil {
+			return fmt.Errorf("postgres synced enumerate scan: %w", err)
+		}
+		if len(raw) != len(block.ContentHash{}) {
+			// Defensive: a malformed hash row cannot be reduced to a
+			// ContentHash. Skip it rather than corrupt the sweep candidate.
+			continue
+		}
+		var h block.ContentHash
+		copy(h[:], raw)
+		if err := fn(h, syncedAt); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
 
 // IsSynced reports whether hash has been MarkSynced'd at least once.
 // Returns (false, nil) when no row exists for hash — an absent hash is

--- a/pkg/metadata/store/postgres/synced_hash_store_test.go
+++ b/pkg/metadata/store/postgres/synced_hash_store_test.go
@@ -67,4 +67,5 @@ func TestPostgresSyncedHashStore_Suite(t *testing.T) {
 	t.Cleanup(func() { _ = store.Close() })
 
 	metadata.RunSyncedHashStoreSuite(t, store)
+	metadata.RunSyncedHashEnumeratorSuite(t, store)
 }

--- a/pkg/metadata/store/sqlite/synced_hash_store.go
+++ b/pkg/metadata/store/sqlite/synced_hash_store.go
@@ -10,6 +10,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
@@ -17,6 +18,41 @@ import (
 
 // Compile-time assertion: the SQLite engine implements SyncedHashStore.
 var _ metadata.SyncedHashStore = (*SQLiteMetadataStore)(nil)
+
+// EnumerateSynced streams every synced marker with its first-mirror time,
+// read straight from the synced_hashes table. Used by the LIST-free GC sweep
+// to compute remote-orphan candidates without an S3 LIST.
+func (s *SQLiteMetadataStore) EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, syncedAt time.Time) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	rows, err := s.query(ctx, `SELECT hash, synced_at FROM synced_hashes`)
+	if err != nil {
+		return fmt.Errorf("sqlite synced enumerate: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			raw      []byte
+			syncedAt time.Time
+		)
+		if err := rows.Scan(&raw, &syncedAt); err != nil {
+			return fmt.Errorf("sqlite synced enumerate scan: %w", err)
+		}
+		if len(raw) != len(block.ContentHash{}) {
+			// Defensive: a malformed hash row cannot be reduced to a
+			// ContentHash. Skip it rather than corrupt the sweep candidate.
+			continue
+		}
+		var h block.ContentHash
+		copy(h[:], raw)
+		if err := fn(h, syncedAt); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
 
 // IsSynced reports whether hash has been MarkSynced'd at least once.
 // Returns (false, nil) when no row exists for hash — an absent hash is

--- a/pkg/metadata/store/sqlite/synced_hash_store_test.go
+++ b/pkg/metadata/store/sqlite/synced_hash_store_test.go
@@ -1,0 +1,40 @@
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
+)
+
+// newSQLiteSyncedTestStore builds a fresh, migrated SQLite store for the
+// synced-hash suites. The concrete *sqlite.SQLiteMetadataStore satisfies both
+// the SyncedHashStore contract and the LIST-free EnumerateSynced capability.
+func newSQLiteSyncedTestStore(t *testing.T) *sqlite.SQLiteMetadataStore {
+	t.Helper()
+	cfg := &sqlite.SQLiteMetadataStoreConfig{
+		Path:        filepath.Join(t.TempDir(), "synced.db"),
+		AutoMigrate: true,
+	}
+	store, err := sqlite.NewSQLiteMetadataStore(context.Background(), cfg, sqliteTestCapabilities())
+	if err != nil {
+		t.Fatalf("NewSQLiteMetadataStore() failed: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// TestSQLiteSyncedHashStore_Suite runs the shared SyncedHashStore conformance
+// suite against the SQLite backend.
+func TestSQLiteSyncedHashStore_Suite(t *testing.T) {
+	metadata.RunSyncedHashStoreSuite(t, newSQLiteSyncedTestStore(t))
+}
+
+// TestSQLiteSyncedHashEnumerator_Suite exercises the LIST-free GC sweep's
+// EnumerateSynced contract against the SQLite backend, covering the
+// synced_at TIMESTAMP scan into time.Time.
+func TestSQLiteSyncedHashEnumerator_Suite(t *testing.T) {
+	metadata.RunSyncedHashEnumeratorSuite(t, newSQLiteSyncedTestStore(t))
+}

--- a/pkg/metadata/synced_hash_store.go
+++ b/pkg/metadata/synced_hash_store.go
@@ -47,3 +47,14 @@ type SyncedHashStore interface {
 	// stays a strict subset of local CAS contents.
 	DeleteSynced(ctx context.Context, hash block.ContentHash) error
 }
+
+// NOTE: backends additionally expose a concrete
+//
+//	EnumerateSynced(ctx, func(hash block.ContentHash, syncedAt time.Time) error) error
+//
+// method used by the LIST-free GC sweep (#1433). It is deliberately NOT part of
+// the SyncedHashStore contract: only the GC consumer needs it, so the engine
+// declares the narrow interface it depends on (see engine.SyncedHashIndex)
+// rather than widening this surface, which is consumed by the syncer and
+// eviction paths that need only the per-hash CRUD above. The enumerator
+// conformance is shared via RunSyncedHashEnumeratorSuite.

--- a/pkg/metadata/synced_hash_store_suite.go
+++ b/pkg/metadata/synced_hash_store_suite.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"lukechampine.com/blake3"
 
@@ -179,6 +180,79 @@ func RunSyncedHashStoreSuite(t *testing.T, s SyncedHashStore) {
 
 		if _, err := s.IsSynced(ctx, h); err != nil {
 			t.Fatalf("IsSynced after concurrent Mark/Delete: %v", err)
+		}
+	})
+}
+
+// syncedHashEnumerating is the backend capability exercised by
+// RunSyncedHashEnumeratorSuite: the SyncedHashStore CRUD plus the concrete
+// EnumerateSynced the LIST-free GC sweep depends on. It is intentionally
+// UNEXPORTED — EnumerateSynced is not part of the SyncedHashStore contract
+// (only the GC consumer needs it; see the note in synced_hash_store.go), so
+// this type exists solely to share the enumerator conformance across backends
+// without widening the package's exported interface surface. Backend tests
+// pass their concrete store; Go checks satisfaction structurally at the call.
+type syncedHashEnumerating interface {
+	SyncedHashStore
+	EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, syncedAt time.Time) error) error
+}
+
+// RunSyncedHashEnumeratorSuite exercises a backend's EnumerateSynced against
+// the LIST-free GC sweep's expectations: marked hashes appear (with a
+// non-regressing first-mirror timestamp), deleted hashes do not, and a
+// cancelled ctx is honored. Call alongside RunSyncedHashStoreSuite from a
+// backend-local _test.go, passing a freshly-created store.
+func RunSyncedHashEnumeratorSuite(t *testing.T, e syncedHashEnumerating) {
+	t.Helper()
+
+	t.Run("EnumerateSynced", func(t *testing.T) {
+		ctx := context.Background()
+		before := time.Now()
+		hA := mustHash("enum-suite-a")
+		hB := mustHash("enum-suite-b")
+		hGone := mustHash("enum-suite-gone")
+
+		for _, h := range []block.ContentHash{hA, hB, hGone} {
+			if err := e.MarkSynced(ctx, h); err != nil {
+				t.Fatalf("MarkSynced %x: %v", h[:4], err)
+			}
+		}
+		// Deleting a marker must remove it from enumeration.
+		if err := e.DeleteSynced(ctx, hGone); err != nil {
+			t.Fatalf("DeleteSynced: %v", err)
+		}
+
+		seen := make(map[block.ContentHash]time.Time)
+		if err := e.EnumerateSynced(ctx, func(h block.ContentHash, syncedAt time.Time) error {
+			seen[h] = syncedAt
+			return nil
+		}); err != nil {
+			t.Fatalf("EnumerateSynced: %v", err)
+		}
+
+		if _, ok := seen[hA]; !ok {
+			t.Errorf("EnumerateSynced missing marked hash hA")
+		}
+		if _, ok := seen[hB]; !ok {
+			t.Errorf("EnumerateSynced missing marked hash hB")
+		}
+		if _, ok := seen[hGone]; ok {
+			t.Errorf("EnumerateSynced yielded deleted hash hGone")
+		}
+		// A backend that records timestamps must report one no earlier than
+		// the mark. A zero timestamp is the documented fail-closed signal for
+		// backends without recorded times — accept it too.
+		if ts := seen[hA]; !ts.IsZero() && ts.Before(before.Add(-time.Minute)) {
+			t.Errorf("EnumerateSynced syncedAt %v precedes mark time %v", ts, before)
+		}
+	})
+
+	t.Run("EnumerateSyncedCtxCancel", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := e.EnumerateSynced(ctx, func(block.ContentHash, time.Time) error { return nil })
+		if err == nil {
+			t.Fatalf("EnumerateSynced with cancelled ctx: want error, got nil")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Steady-state block GC no longer issues an S3 `LIST`. It derives remote-orphan candidates from the per-hash **synced index** (`synced − live`) instead of a full `RemoteStore.Walk`/`ListObjectsV2`. This is the I/O lever for #1433: GC cost goes from O(total objects in the bucket) every run to O(local index scan), regardless of churn.

The full Walk survives — but only on the **reconcile** path, as the drift + upgrade-migration backstop. It alone can find remote objects the index does not know about (markers written before this PR carry no timestamp; a Put-then-Mark crash can leave an object on S3 with no marker). Steady-state and per-share GC use the index; reconcile (`runBlockGCSweep` with `FullScan=true`) Walks.

## Why it's safe

The synced index is trusted as "is-on-remote" because the mirror does Put-then-Mark and every delete does Delete-then-DeleteSynced, so `synced ⊆ remote contents`. The index sweep deletes a remote object only when it is **not** in the live set (manifest FileBlocks ∪ snapshot holds, built in `markPhase`), is **past grace**, and has a **non-zero** first-mirror timestamp. Every uncertain case fails closed (keeps the object): missing timestamp, within grace, or a GCState lookup error.

## Design notes

- `EnumerateSynced(ctx, fn(hash, syncedAt))` is a concrete method on the 4 metadata backends. `metadata.SyncedHashStore` stays at its original 3 methods — GC depends on a narrow consumer interface `engine.SyncedHashIndex` (EnumerateSynced + DeleteSynced) instead of widening the shared surface.
- Badger markers now store an 8-byte first-mirror timestamp (first-write-wins). Legacy nil-value markers decode to zero time → fail-closed. SQLite/Postgres already stored `synced_at`.
- Grace anchors off `syncedAt`, not S3 object metadata — no per-object HEAD.
- `multiSyncedHashStore` now implements only what GC uses; the dead interface-completeness `IsSynced`/`MarkSynced` were removed.
- Dispatch flips to `Options.FullScan` (reconcile opts into the Walk); steady-state needs no flag. Renamed `sweepPhase` → `sweepByWalk` and added `sweepFromSyncedIndex`.

## Performance

Latency-injected benchmark (`gc_sweep_bench_test.go`, modeling S3 `ListObjectsV2` pagination at 20ms/page, all objects live so it measures pure sweep cost):

| Objects | Walk sweep (S3 LIST) | Index sweep (no LIST) | Speedup |
|--------:|---------------------:|----------------------:|--------:|
| 10,000  | 290 ms               | 75 ms                 | 3.9×    |
| 100,000 | 2.32 s               | 301 ms                | 7.7×    |

Gap widens with object count (extrapolates to ~11s at 500k on real S3 RTT). The benchmark is `-short`-skipped and doubles as a regression guard that the steady-state sweep issues no Walk.

## Tests

- `gc_sweep_index_test.go`: a `noWalkRemote` wrapper fails the test if `Walk` is ever called, proving the index sweep is LIST-free; covers orphan reclaim, live/within-grace/zero-timestamp preservation, marker-clear, and dry-run.
- New SQLite synced-store suite (it had none) + a shared `EnumerateSynced` conformance suite across all 4 backends.
- `TestSnapshotLifecycleVsGC` updated to mark seeded blocks synced (production reality), and `TestGCMarkSweep_ClearsSyncedMarkerForSweptHash` pinned to the Walk path via `FullScan`.

## Scope / follow-ups

This is the LIST-elimination phase. Still deferred (tracked under #1433's plan): the tombstone drain (O(churn), removes the mark scan too) and an S3-Inventory-backed reconcile (replaces the rare Walk). The reconcile Walk handles crash-gap / pre-upgrade orphans meanwhile.

Perf follow-up to the #1433 correctness stack (already merged + closed).
