### PR TITLE
fix(nfs): honour default_permission over NFSv3 + run least-privilege tests on real mounts

### DIFF
--- a/docs/guide/nfs.md
+++ b/docs/guide/nfs.md
@@ -18,6 +18,7 @@ This guide covers everything an operator or end user needs to mount and use Ditt
   - [With Portmapper on Port 111](#with-portmapper-on-port-111)
   - [With Explicit Ports](#with-explicit-ports)
 - [Identity Squashing (root_squash and friends)](#identity-squashing-root_squash-and-friends)
+- [Permissions: share grants over NFS](#permissions-share-grants-over-nfs)
 - [Kerberos Exports (sec=krb5)](#kerberos-exports-seckrb5)
 - [NFS-over-TLS (RFC 9289)](#nfs-over-tls-rfc-9289)
 - [Testing Your Mount](#testing-your-mount)
@@ -489,6 +490,62 @@ Assume a file owned by UID 1000, mode `0644`, and a share-gate
 > [export gate](access-control.md) must still admit them. Use squashing to
 > *constrain* identity, and the [export gate + POSIX/ACL](access-control.md) to
 > *grant* access.
+
+---
+
+## Permissions: share grants over NFS
+
+Access is decided in two layers, and which layer a client can *see* depends on
+the NFS version. Understanding this avoids the most common surprise:
+**"I granted a user read-write but they get Permission denied over NFSv3."**
+
+### The two layers
+
+1. **Export gate** — the share's `default_permission` (access for principals
+   without an explicit grant) plus per-user / per-group grants. Enforced
+   server-side on every request.
+2. **Filesystem layer** — the file/directory's POSIX mode bits and, where the
+   protocol carries it, its ACL.
+
+The share root directory's mode bits track `default_permission` so that
+mode-only clients honour the share's access level:
+
+| `default_permission` | Share root mode | A non-root client can… |
+|----------------------|-----------------|------------------------|
+| `none` / unset       | `0755`          | traverse/read only if the export gate admits it; never write |
+| `read`               | `0755`          | read; not write |
+| `read-write` / `admin` | `0777`        | read and write |
+
+### NFSv3 vs NFSv4: where per-user grants apply
+
+- **NFSv3 carries only mode bits — no ACL.** The Linux client enforces those
+  bits *client-side*, before sending an RPC. So a **per-user grant is invisible
+  over NFSv3**: mode bits cannot express "uid 2000 may write, uid 4000 may not."
+  Over NFSv3 a non-root user can write the share root only when
+  `default_permission` is `read-write` (root mode `0777`). This is normal Unix
+  behaviour, not a DittoFS limitation — and it is also POSIX-ACL consistent
+  (a named-user ACL entry simply has no NFSv3 transport).
+- **NFSv4 (and SMB) carry the ACL.** Per-user and per-group grants *are*
+  honoured: grant a user read-write and they can write over NFSv4 even on a
+  share whose default is read-only.
+
+**Rule of thumb:** for per-user least-privilege access, use **NFSv4**. Reserve
+NFSv3 for share-wide access levels set via `default_permission`.
+
+### Other behaviours worth knowing
+
+- **Denials are `EACCES` ("Permission denied"), never `EIO`.** A permission
+  failure — including a squashed-root or ungranted-user write — surfaces as
+  `Permission denied`, not the misleading `Input/output error` older builds
+  returned on NFSv3.
+- **A fully-locked (`none`) share is not mountable over NFSv4 by a root client.**
+  The mount runs as root, which `root_to_guest` squashes to the guest identity;
+  with `default_permission=none` the guest cannot traverse the export to
+  complete the NFSv4 mount. Such a share is reachable only over NFSv3 (whose
+  separate mount protocol does not gate on the export root). For the common
+  "world-readable, granted-writable" pattern, use `default_permission=read` and
+  grant write to the specific users — they then write over NFSv4 while everyone
+  else is read-only.
 
 ---
 

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -610,6 +610,26 @@ func (s *Service) releaseShareName(name string) {
 	s.mu.Unlock()
 }
 
+// rootModeForDefaultPermission projects a share's default_permission onto the
+// share root directory's POSIX permission bits. NFSv3 has no ACL transport, so
+// for its clients the mode bits are the only access signal — and the Linux
+// client enforces them *client-side*, before any RPC. The bits can therefore
+// only restrict, never grant (the server's export gate + ACL remain the real
+// authority); but a too-narrow root silently blocked legitimate access. The
+// only case that needed opening is read-write: a non-root user on a read-write
+// share was denied at the 0755 root before reaching the server. So read-write
+// (and admin) widen "other" to rwx; read and the secure none/unset default keep
+// the historical 0755 (the export gate still denies ungranted access server-
+// side). Per-user grants remain NFSv4/SMB-only — mode bits cannot express them.
+func rootModeForDefaultPermission(perm string) uint32 {
+	switch models.SharePermission(perm) {
+	case models.PermissionReadWrite, models.PermissionAdmin:
+		return 0o777
+	default: // none / unset / read: preserve the historical 0755 root
+		return 0o755
+	}
+}
+
 // prepareShare validates config, resolves the metadata store, and creates the
 // root directory. Returns the built Share (not yet in the registry) and the
 // metadata store. The caller (AddShare) is responsible for inserting the share
@@ -644,7 +664,7 @@ func (s *Service) prepareShare(
 		rootAttr.Type = metadata.FileTypeDirectory
 	}
 	if rootAttr.Mode == 0 {
-		rootAttr.Mode = 0755
+		rootAttr.Mode = rootModeForDefaultPermission(config.DefaultPermission)
 	}
 	if rootAttr.Atime.IsZero() {
 		now := time.Now()

--- a/pkg/controlplane/runtime/shares/service_test.go
+++ b/pkg/controlplane/runtime/shares/service_test.go
@@ -502,3 +502,27 @@ func TestEnabledTrashShares_FiltersByFlag(t *testing.T) {
 		t.Errorf("expected [/on], got %v", got)
 	}
 }
+
+// TestRootModeForDefaultPermission pins the share-root POSIX mode projected from
+// a share's default_permission. This is security-sensitive: only read-write and
+// admin may widen the root to world-writable (0777) so NFSv3 clients honour the
+// share-level access; read and the secure none/unset default must stay 0755
+// (the export gate remains the server-side authority).
+func TestRootModeForDefaultPermission(t *testing.T) {
+	cases := []struct {
+		perm string
+		want uint32
+	}{
+		{string(models.PermissionReadWrite), 0o777},
+		{string(models.PermissionAdmin), 0o777},
+		{string(models.PermissionRead), 0o755},
+		{string(models.PermissionNone), 0o755},
+		{"", 0o755},      // unset → secure default
+		{"bogus", 0o755}, // unknown → secure default, never world-writable
+	}
+	for _, tc := range cases {
+		if got := rootModeForDefaultPermission(tc.perm); got != tc.want {
+			t.Errorf("rootModeForDefaultPermission(%q) = %#o, want %#o", tc.perm, got, tc.want)
+		}
+	}
+}

--- a/test/e2e/framework/mount.go
+++ b/test/e2e/framework/mount.go
@@ -14,6 +14,27 @@ import (
 	"time"
 )
 
+// makeTraversableMountPoint creates a mount-point directory that unprivileged
+// UIDs can traverse. Several e2e tests mount a share and then run filesystem
+// operations as non-root users (e.g. uid 2000 via SysProcAttr.Credential) to
+// exercise real permission enforcement. Go's os.MkdirTemp("")/t.TempDir() place
+// directories under $TMPDIR with mode 0700, and `nix develop` points $TMPDIR at
+// its own 0700 private dir — so an unprivileged child cannot even reach the
+// mount and every op fails with EACCES *before* an NFS RPC is sent. Anchoring
+// under /tmp (mode 1777) with a 0755 leaf keeps the whole path traversable; once
+// mounted, the leaf's bits are masked by the exported root's permissions.
+func makeTraversableMountPoint(prefix string) (string, error) {
+	p, err := os.MkdirTemp("/tmp", prefix)
+	if err != nil {
+		return "", err
+	}
+	if err := os.Chmod(p, 0o755); err != nil {
+		_ = os.RemoveAll(p)
+		return "", err
+	}
+	return p, nil
+}
+
 // cifsMountOptions builds the mount options string for Linux CIFS mounts.
 // cache=none disables CIFS client caching to ensure tests see fresh data.
 func cifsMountOptions(port int, creds SMBCredentials) string {
@@ -39,7 +60,7 @@ func MountNFS(t *testing.T, port int) *Mount {
 	time.Sleep(500 * time.Millisecond)
 
 	// Create mount directory
-	mountPath, err := os.MkdirTemp("", "dittofs-e2e-nfs-*")
+	mountPath, err := makeTraversableMountPoint("dittofs-e2e-nfs-")
 	if err != nil {
 		t.Fatalf("Failed to create NFS mount directory: %v", err)
 	}
@@ -116,7 +137,7 @@ func MountNFSExportWithVersion(t *testing.T, port int, exportPath string, versio
 	time.Sleep(500 * time.Millisecond)
 
 	// Create mount directory
-	mountPath, err := os.MkdirTemp("", "dittofs-e2e-nfs-*")
+	mountPath, err := makeTraversableMountPoint("dittofs-e2e-nfs-")
 	if err != nil {
 		t.Fatalf("Failed to create NFS mount directory: %v", err)
 	}
@@ -244,7 +265,7 @@ func MountSMB(t *testing.T, port int, creds SMBCredentials) *Mount {
 	time.Sleep(500 * time.Millisecond)
 
 	// Create mount directory
-	mountPath, err := os.MkdirTemp("", "dittofs-e2e-smb-*")
+	mountPath, err := makeTraversableMountPoint("dittofs-e2e-smb-")
 	if err != nil {
 		t.Fatalf("Failed to create SMB mount directory: %v", err)
 	}
@@ -323,7 +344,7 @@ func MountSMBWithError(t *testing.T, port int, creds SMBCredentials) (*Mount, er
 	time.Sleep(500 * time.Millisecond)
 
 	// Create mount directory
-	mountPath, err := os.MkdirTemp("", "dittofs-e2e-smb-*")
+	mountPath, err := makeTraversableMountPoint("dittofs-e2e-smb-")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SMB mount directory: %w", err)
 	}

--- a/test/e2e/nfs_root_squash_test.go
+++ b/test/e2e/nfs_root_squash_test.go
@@ -14,20 +14,27 @@ import (
 )
 
 // TestNFSRootSquash is the regression test for the colleague-reported NFS
-// permission bug and the squash-default alignment that followed:
+// permission bug (#1449) and the squash-default alignment that followed (#1452).
+// It asserts the post-change behaviour for a world-readable, granted-writable
+// share (default_permission=read) under the conventional root_to_guest squash:
 //
-//   - Default squash is root_to_guest (conventional root_squash), so an NFS
-//     client mounting as root is NOT auto-privileged. Because the built-in
-//     admin user occupies uid 0 but has no grant on a freshly created share
-//     (default_permission=none), root is denied.
-//   - An unknown uid (not a registered DittoFS user) is likewise denied.
-//   - A user that has been granted read-write CAN write — the grant is
-//     projected into the share root ACL, so least-privilege access works.
-//   - Denials over NFSv3 must surface as EACCES ("permission denied"), not the
-//     EIO ("input/output error") the colleague originally hit (#1449).
+//   - root_to_guest means an NFS client mounting as root is NOT auto-privileged.
+//     The built-in admin occupies uid 0 but has no grant on a fresh share, so
+//     root is squashed to guest and cannot write.
+//   - An unknown uid (no registered DittoFS user, no grant) cannot write.
+//   - A user granted read-write CAN write — the grant projects into the share
+//     root ACL.
+//   - Denials must surface as EACCES ("permission denied"), never the EIO
+//     ("input/output error") the colleague hit on NFSv3 (#1449).
 //
-// The whole flow runs over NFSv3 (framework.MountNFS), the exact path the
-// colleague used.
+// Protocol split is deliberate and reflects what each NFS version can express:
+//   - The write-denial cases run over NFSv3 — the exact path the colleague used,
+//     and where the #1449 EACCES-vs-EIO mapping matters. Over NFSv3 access is
+//     decided by POSIX mode bits: default_permission=read → root mode 0755, so a
+//     root-squashed-to-guest or unknown uid (both "other") may read but not write.
+//   - The granted-user positive control runs over NFSv4. A *per-user* grant is
+//     an ACL entry; NFSv3 has no ACL transport (mode bits cannot express
+//     "uid 2000 yes, uid 4000 no"), so only NFSv4 honours it.
 func TestNFSRootSquash(t *testing.T) {
 	sp := helpers.StartServerProcess(t, "")
 	t.Cleanup(sp.ForceKill)
@@ -46,8 +53,16 @@ func TestNFSRootSquash(t *testing.T) {
 	require.NoError(t, err, "Should create block store")
 	t.Cleanup(func() { _ = runner.DeleteLocalBlockStore(localStoreName) })
 
-	// Fresh share: default_permission=none and default root_to_guest squash.
-	_, err = runner.CreateShare(shareName, metaStoreName, localStoreName)
+	// default_permission=read models the common "world-readable, granted-writable"
+	// share: everyone may read/traverse (so an NFSv4 client mounting as the
+	// squashed-guest root can complete the mount), but WRITE is least-privilege —
+	// only an explicit grant opens it. A fully-locked "none" share is intentionally
+	// not used here: over NFSv4 the mount runs as root→guest and "none" denies even
+	// the traversal needed to mount, so "none" is reachable only over NFSv3's
+	// separate mount protocol. All assertions below are about write access, which
+	// "read" leaves least-privilege.
+	_, err = runner.CreateShare(shareName, metaStoreName, localStoreName,
+		helpers.WithShareDefaultPermission("read"))
 	require.NoError(t, err, "Should create share")
 	t.Cleanup(func() { _ = runner.DeleteShare(shareName) })
 
@@ -68,12 +83,33 @@ func TestNFSRootSquash(t *testing.T) {
 		"NFS adapter should become enabled")
 	framework.WaitForServer(t, nfsPort, 10*time.Second)
 
-	mount := framework.MountNFS(t, nfsPort)
-	t.Cleanup(mount.Cleanup)
+	// Denials over NFSv3 — the colleague's exact path.
+	mountV3 := framework.MountNFS(t, nfsPort)
+	t.Cleanup(mountV3.Cleanup)
 
-	// Positive control: the granted user can write.
-	t.Run("granted user can write", func(t *testing.T) {
-		path := mount.FilePath("granted.txt")
+	// Root (uid 0) is squashed to guest under root_to_guest and has no grant. It
+	// is the case that reaches the server (root skips client-side mode checks), so
+	// it exercises the #1449 EACCES-not-EIO server mapping directly.
+	t.Run("root is denied (EACCES not EIO)", func(t *testing.T) {
+		err := framework.WriteFileAsUID(t, 0, 0, mountV3.FilePath("root.txt"), []byte("nope"))
+		requireAccessDenied(t, err, "root write")
+	})
+
+	// An unknown uid (no DittoFS user, no grant) gets only the read default, so
+	// its write is denied.
+	t.Run("unknown uid is denied", func(t *testing.T) {
+		const unknownUID, unknownGID = uint32(4000), uint32(4000)
+		err := framework.WriteFileAsUID(t, unknownUID, unknownGID, mountV3.FilePath("stranger.txt"), []byte("nope"))
+		requireAccessDenied(t, err, "unknown-uid write")
+	})
+
+	// Positive control over NFSv4: the per-user grant is an ACL entry, which only
+	// NFSv4 carries. The granted user can write and read back.
+	t.Run("granted user can write (NFSv4)", func(t *testing.T) {
+		mountV4 := framework.MountNFSWithVersion(t, nfsPort, "4.1")
+		t.Cleanup(mountV4.Cleanup)
+
+		path := mountV4.FilePath("granted.txt")
 		err := framework.WriteFileAsUID(t, nfsLeastPrivUID, nfsLeastPrivGID, path, []byte("ok"))
 		require.NoError(t, err, "Granted read-write user should be able to write")
 		t.Cleanup(func() {
@@ -85,17 +121,15 @@ func TestNFSRootSquash(t *testing.T) {
 		assert.Equal(t, []byte("ok"), got)
 	})
 
-	// Root (uid 0) is squashed under root_to_guest and has no grant -> denied.
-	t.Run("root is denied", func(t *testing.T) {
-		err := framework.WriteFileAsUID(t, 0, 0, mount.FilePath("root.txt"), []byte("nope"))
-		requireAccessDenied(t, err, "root write")
-	})
+	// Counter-control over NFSv4: an unknown uid is still denied even where ACLs
+	// are honoured — the grant, not the protocol, is what opens access.
+	t.Run("unknown uid is denied (NFSv4)", func(t *testing.T) {
+		mountV4 := framework.MountNFSWithVersion(t, nfsPort, "4.1")
+		t.Cleanup(mountV4.Cleanup)
 
-	// An unknown uid (no DittoFS user) is denied by default_permission=none.
-	t.Run("unknown uid is denied", func(t *testing.T) {
-		const unknownUID, unknownGID = uint32(4000), uint32(4000)
-		err := framework.WriteFileAsUID(t, unknownUID, unknownGID, mount.FilePath("stranger.txt"), []byte("nope"))
-		requireAccessDenied(t, err, "unknown-uid write")
+		const unknownUID, unknownGID = uint32(4001), uint32(4001)
+		err := framework.WriteFileAsUID(t, unknownUID, unknownGID, mountV4.FilePath("stranger4.txt"), []byte("nope"))
+		requireAccessDenied(t, err, "unknown-uid write over NFSv4")
 	})
 }
 


### PR DESCRIPTION
## Why

Reviving the e2e suite (#1456) and merging the least-privilege NFS tests (#1457) surfaced that those tests fail on real kernel mounts. Root-causing on a real Linux box turned up **two distinct issues** — one test-harness, one product — plus the test asserting something NFSv3 cannot express.

## What this fixes

### 1. Product: `default_permission` now reaches the share root mode bits
NFSv3 has no ACL transport; the Linux client enforces the root directory's POSIX **mode bits client-side, before any RPC**. A `read-write` share kept a `0755` root, so a non-root user was denied at the client before the server's read-write default could apply — i.e. **a read-write NFS share was not writable by non-root users over NFSv3**.

Fix: `read-write`/`admin` shares get a `0777` root; `read` and the secure `none`/unset default keep `0755` (the export gate still denies ungranted access server-side — mode bits can only restrict the client, never grant). Per-user grants remain NFSv4/SMB-only (they are ACL entries; mode bits cannot express them).

### 2. Harness: mount points must be traversable by non-root UIDs
The suite mounted under `os.MkdirTemp("")`/`t.TempDir()` (mode `0700`), and `nix develop` points `$TMPDIR` at its own `0700` private dir. A non-root child (uid 2000) could not even **traverse** to the mount — every op failed with `EACCES` before any NFS RPC. Mount points are now anchored under `/tmp` (1777) and chmod `0755`.

### 3. Test: split `TestNFSRootSquash` by what each NFS version can express
- Write-denials (root squashed to guest, unknown uid) run over **NFSv3** — the colleague's path where the #1449 `EACCES`-not-`EIO` mapping matters.
- The per-user granted write runs over **NFSv4** — a per-user grant is an ACL entry NFSv3 cannot carry.
- Uses `default_permission=read` so the squashed-root NFSv4 mount can traverse to complete the mount, while writes stay least-privilege.

### 4. Docs
`docs/guide/nfs.md` gains a "Permissions: share grants over NFS" section: the two access layers, mode-bit projection, NFSv3-vs-NFSv4 per-user grants, EACCES-not-EIO, and the `none`-share-unmountable-over-NFSv4 caveat.

## Validation

Verified on a real Linux host (kernel NFS client, root): both `TestNFSFileOperations` (NFSv3, uid 2000) and `TestNFSRootSquash` (v3 denials + v4 grant matrix) pass.