### PR TITLE
fix(controlplane): decouple drain-uploads from request write timeout (#1432)

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -311,7 +311,10 @@ func runStart(cmd *cobra.Command, args []string) error {
 	rt.SetAdapterFactory(createAdapterFactory(&effectiveKerberos, nlAuth))
 
 	// Create and set API server
-	apiServer, err := api.NewServer(cfg.ControlPlane, rt, cpStore, cfg.Snapshot.RestoreHTTPTimeout)
+	apiServer, err := api.NewServer(cfg.ControlPlane, rt, cpStore, api.Timeouts{
+		Restore:    cfg.Snapshot.RestoreHTTPTimeout,
+		DrainStall: cfg.ControlPlane.DrainStallTimeout,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to create API server: %w", err)
 	}

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -176,6 +176,10 @@ controlplane:
   read_timeout: 10s          # Max time to read request
   write_timeout: 10s         # Max time to write response
   idle_timeout: 60s          # Max idle time for keep-alive
+  drain_stall_timeout: 5m    # Abort POST /system/drain-uploads only if no
+                             # upload completes within this window (inactivity
+                             # timeout, NOT a total cap — a large flush may run
+                             # for as long as it keeps making progress)
 
   # Force the bootstrap "admin" user to set a new password on first login.
   # Default true (secure by default). Set to false for automated/test
@@ -221,6 +225,7 @@ controlplane:
 | `read_timeout` | `10s` | Maximum duration to read request |
 | `write_timeout` | `10s` | Maximum duration to write response |
 | `idle_timeout` | `60s` | Maximum idle time for keep-alive |
+| `drain_stall_timeout` | `5m` | Inactivity bound for `POST /system/drain-uploads`. The drain has **no total time cap** — a multi-GiB flush runs as long as it keeps making progress — and is aborted (504) only if no upload completes within this window (the remote stalled). Mirrors rclone's `--timeout` |
 | `require_initial_password_change` | `true` | Force the bootstrap `admin` user to change its password on first login. Set to `false` to opt out (automated/test deployments). Also skipped when `DITTOFS_ADMIN_INITIAL_PASSWORD` is set |
 | `pprof` | `false` | Expose Go `/debug/pprof/*` profiling endpoints |
 | `pprof_mutex_rate` | `100` (when `pprof: true`; else `0`) | Mutex contention sampling, 1 per N events. Applied only when `pprof: true`; unset/`0` then falls back to `100`. Without it `/debug/pprof/mutex` is header-only. Disable profiling via `pprof: false`, not by zeroing this |

--- a/internal/controlplane/api/handlers/helpers.go
+++ b/internal/controlplane/api/handlers/helpers.go
@@ -1,13 +1,56 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 )
+
+// detachFromRequest builds a context for a long-running handler that must
+// outlive the control plane's short global request deadline (chi
+// middleware.Timeout / write_timeout, ~30s) while still stopping if the client
+// genuinely disconnects.
+//
+// The returned context is detached from the request deadline via
+// context.WithoutCancel, so middleware.Timeout cannot abort the work. When
+// total > 0 it carries that wall-clock budget; when total <= 0 it has no
+// deadline of its own and the caller is expected to supply its own bound (e.g.
+// an inactivity watchdog). Either way a real client disconnect — the request
+// context reporting Canceled, as opposed to the DeadlineExceeded fired by
+// middleware.Timeout — cancels it.
+//
+// The returned CancelFunc both unregisters the disconnect watcher and cancels
+// the context; it is idempotent, must be deferred, and may also be called early
+// (e.g. by a watchdog) to abort the work.
+func detachFromRequest(r *http.Request, total time.Duration) (context.Context, context.CancelFunc) {
+	base := context.WithoutCancel(r.Context())
+
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+	if total > 0 {
+		ctx, cancel = context.WithTimeout(base, total)
+	} else {
+		ctx, cancel = context.WithCancel(base)
+	}
+
+	stop := context.AfterFunc(r.Context(), func() {
+		if r.Context().Err() == context.Canceled {
+			cancel()
+		}
+	})
+
+	return ctx, func() {
+		stop()
+		cancel()
+	}
+}
 
 // redactedSecret is the sentinel substituted for secret values in store
 // config blobs returned on read paths.

--- a/internal/controlplane/api/handlers/snapshot.go
+++ b/internal/controlplane/api/handlers/snapshot.go
@@ -225,18 +225,8 @@ func (h *SnapshotHandler) Restore(w http.ResponseWriter, r *http.Request) {
 	// 200/4xx/5xx response before returning — so the middleware's later 504
 	// WriteHeader is a no-op (first write wins), the client gets the genuine
 	// result. (Covered by TestSnapshotHandler_Restore_DecoupledFromGlobalTimeout.)
-	base := context.WithoutCancel(r.Context())
-	ctx, cancel := context.WithTimeout(base, h.restoreHTTPTimeout)
+	ctx, cancel := detachFromRequest(r, h.restoreHTTPTimeout)
 	defer cancel()
-
-	// Propagate a real client disconnect (not the middleware timeout) so the
-	// restore is cancelled if the caller goes away.
-	stop := context.AfterFunc(r.Context(), func() {
-		if r.Context().Err() == context.Canceled {
-			cancel()
-		}
-	})
-	defer stop()
 
 	safetyID, err := h.runtime.RestoreSnapshot(ctx, name, snapID,
 		runtime.RestoreSnapshotOpts{AllowNonDurable: body.AllowNonDurable})

--- a/internal/controlplane/api/handlers/system.go
+++ b/internal/controlplane/api/handlers/system.go
@@ -9,46 +9,104 @@ import (
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 )
 
-// DrainUploadsTimeout is the maximum time allowed for draining all uploads.
-const DrainUploadsTimeout = 5 * time.Minute
+// DefaultDrainStallTimeout is the fallback inactivity bound for DrainUploads,
+// used when the configured value is non-positive (e.g. a zero-valued test
+// handler). Mirrors pkg/controlplane/api.APIConfig.DrainStallTimeout's default.
+const DefaultDrainStallTimeout = 5 * time.Minute
+
+// drainProgressInterval is how often the idle watchdog samples upload progress.
+// Smaller than any sane DrainStallTimeout so the watchdog reacts promptly once
+// the idle window elapses, without busy-polling.
+const drainProgressInterval = time.Second
+
+// drainRuntime is the narrow slice of the runtime that the system handler
+// needs. Defining it here (rather than depending on the whole *runtime.Runtime)
+// keeps the handler testable with a lightweight fake. *runtime.Runtime
+// satisfies it.
+type drainRuntime interface {
+	// DrainAllUploads blocks until every pending block has reached the remote
+	// (or ctx is cancelled / a block fails permanently).
+	DrainAllUploads(ctx context.Context) error
+	// UploadProgress returns a monotonic count of concluded mirror attempts.
+	// Used purely as a liveness signal by the idle watchdog.
+	UploadProgress() int64
+}
 
 // SystemHandler handles system-level endpoints.
 type SystemHandler struct {
-	runtime *runtime.Runtime
+	runtime drainRuntime
+	// drainStallTimeout bounds DrainUploads by inactivity, not wall-clock.
+	drainStallTimeout time.Duration
 }
 
-// NewSystemHandler creates a new system handler.
-func NewSystemHandler(rt *runtime.Runtime) *SystemHandler {
-	return &SystemHandler{runtime: rt}
+// NewSystemHandler creates a new system handler. drainStallTimeout is the
+// inactivity bound for the drain-uploads endpoint; a non-positive value falls
+// back to DefaultDrainStallTimeout.
+func NewSystemHandler(rt *runtime.Runtime, drainStallTimeout time.Duration) *SystemHandler {
+	if drainStallTimeout <= 0 {
+		drainStallTimeout = DefaultDrainStallTimeout
+	}
+	// A typed-nil *runtime.Runtime would make the interface non-nil, defeating
+	// the nil check in DrainUploads, so store nil explicitly in that case.
+	if rt == nil {
+		return &SystemHandler{drainStallTimeout: drainStallTimeout}
+	}
+	return &SystemHandler{runtime: rt, drainStallTimeout: drainStallTimeout}
 }
 
 // DrainUploads handles POST /api/v1/system/drain-uploads.
 //
-// Waits for all in-flight block store uploads to complete across all files.
-// Useful for benchmarking to ensure clean boundaries between test workloads.
+// Blocks until every in-flight block store upload has reached the remote across
+// all shares. Useful for benchmarking (clean boundaries between test workloads)
+// and for operators forcing a flush before maintenance.
 //
-// Returns 200 OK when all uploads have drained, or 504 Gateway Timeout
-// if the drain does not complete within 5 minutes.
+// Timeout model. A real flush of many GiB legitimately runs for minutes — far
+// longer than the control plane's global request timeout (chi
+// middleware.Timeout, ~30s) and the HTTP write_timeout. Two things follow:
+//
+//  1. The drain must not inherit the request deadline, or it would be cancelled
+//     at ~30s with data still un-uploaded (issue #1432). So it runs on a
+//     context detached from the request via context.WithoutCancel.
+//
+//  2. There is deliberately no total wall-clock budget. A correct flush of an
+//     arbitrarily large backlog takes arbitrarily long; any fixed cap is just a
+//     number that's wrong for some workload. Instead the drain is bounded by
+//     *inactivity*: an idle watchdog samples UploadProgress and aborts only if
+//     no upload completes within drainStallTimeout (the remote has stalled).
+//     This mirrors rclone's --timeout (an idle, progress-resetting timeout) and
+//     matches how juicefs/s3ql treat a forced flush — block until done, give up
+//     only on a genuine stall. CAS chunks are at most a few MiB, so even on a
+//     slow link a single chunk finishes well inside any sane idle window; only
+//     a truly wedged remote keeps progress flat long enough to trip it.
+//
+// A genuine client disconnect (request context Canceled, as opposed to the
+// deadline-exceeded fired by middleware.Timeout) still aborts the drain.
+//
+// Returns 200 OK when all uploads have drained, or 504 Gateway Timeout if the
+// drain stalls for drainStallTimeout.
 func (h *SystemHandler) DrainUploads(w http.ResponseWriter, r *http.Request) {
 	if h.runtime == nil {
 		InternalServerError(w, "runtime not initialized")
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), DrainUploadsTimeout)
+	// Detach from the request deadline (total <= 0 → no wall-clock cap); the
+	// idle watchdog below is the only bound. A real client disconnect still
+	// cancels via the helper. cancel doubles as the watchdog's abort handle.
+	ctx, cancel := detachFromRequest(r, 0)
 	defer cancel()
 
-	logger.Info("Drain uploads requested")
+	logger.Info("Drain uploads requested", "idle_timeout", h.drainStallTimeout)
 	start := time.Now()
 
-	if err := h.runtime.DrainAllUploads(ctx); err != nil {
-		logger.Error("Drain uploads failed", "error", err, "duration", time.Since(start))
-		if ctx.Err() == context.DeadlineExceeded {
-			WriteProblem(w, http.StatusGatewayTimeout, "Gateway Timeout",
-				"drain uploads did not complete within timeout: "+err.Error())
+	err, stalled := h.runWithIdleWatchdog(ctx, cancel)
+	if err != nil {
+		logger.Error("Drain uploads failed", "error", err, "duration", time.Since(start), "stalled", stalled)
+		if stalled {
+			GatewayTimeout(w, "drain uploads stalled: no upload progress within "+
+				h.drainStallTimeout.String()+": "+err.Error())
 		} else {
-			WriteProblem(w, http.StatusInternalServerError, "Internal Server Error",
-				"drain uploads failed: "+err.Error())
+			InternalServerError(w, "drain uploads failed: "+err.Error())
 		}
 		return
 	}
@@ -58,4 +116,45 @@ func (h *SystemHandler) DrainUploads(w http.ResponseWriter, r *http.Request) {
 		"status":   "drained",
 		"duration": time.Since(start).String(),
 	})
+}
+
+// runWithIdleWatchdog runs DrainAllUploads in a goroutine and supervises it
+// with an inactivity watchdog, blocking until the drain finishes or stalls. It
+// returns the drain's error and whether the watchdog aborted it — true when
+// UploadProgress stayed flat for drainStallTimeout, which the caller maps to a
+// 504. cancel must cancel the same ctx passed in.
+func (h *SystemHandler) runWithIdleWatchdog(ctx context.Context, cancel context.CancelFunc) (error, bool) {
+	drainDone := make(chan error, 1)
+	go func() { drainDone <- h.runtime.DrainAllUploads(ctx) }()
+
+	// Sample at least as often as the idle window itself, so a small configured
+	// timeout still trips after roughly that window (and tests don't have to
+	// wait a full second).
+	interval := drainProgressInterval
+	if h.drainStallTimeout < interval {
+		interval = h.drainStallTimeout
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	lastProgress := h.runtime.UploadProgress()
+	idleFor := time.Duration(0)
+	for {
+		select {
+		case err := <-drainDone:
+			return err, false
+		case <-ticker.C:
+			cur := h.runtime.UploadProgress()
+			if cur != lastProgress {
+				lastProgress = cur
+				idleFor = 0
+				continue
+			}
+			idleFor += interval
+			if idleFor >= h.drainStallTimeout {
+				cancel()
+				return <-drainDone, true // wait for the drain to unwind on ctx cancel
+			}
+		}
+	}
 }

--- a/internal/controlplane/api/handlers/system_test.go
+++ b/internal/controlplane/api/handlers/system_test.go
@@ -1,0 +1,231 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+// fakeDrainRuntime is a minimal drainRuntime test double. drainFn overrides
+// DrainAllUploads; uploadProgressFn overrides UploadProgress. The zero value
+// drains instantly with no error and reports no progress.
+type fakeDrainRuntime struct {
+	drainFn          func(ctx context.Context) error
+	uploadProgressFn func() int64
+}
+
+func (f *fakeDrainRuntime) DrainAllUploads(ctx context.Context) error {
+	if f.drainFn != nil {
+		return f.drainFn(ctx)
+	}
+	return nil
+}
+
+func (f *fakeDrainRuntime) UploadProgress() int64 {
+	if f.uploadProgressFn != nil {
+		return f.uploadProgressFn()
+	}
+	return 0
+}
+
+// newSystemRouterWithGlobalTimeout mirrors the production router's short global
+// request timeout (middleware.Timeout) applied to the drain route, so a test
+// can assert the drain handler is not cancelled by it (issue #1432).
+func newSystemRouterWithGlobalTimeout(h *SystemHandler, d time.Duration) http.Handler {
+	r := chi.NewRouter()
+	r.Use(middleware.Timeout(d))
+	r.Route("/api/v1/system", func(r chi.Router) {
+		r.Post("/drain-uploads", h.DrainUploads)
+	})
+	return r
+}
+
+// TestSystemHandler_DrainUploads_DecoupledFromGlobalTimeout asserts that the
+// router's short global request timeout does not abort a drain whose own budget
+// is larger — a real multi-GiB flush must be allowed to run past the global
+// handler deadline AND the client must still receive the real 200 success
+// response, not the middleware's 504 (issue #1432).
+func TestSystemHandler_DrainUploads_DecoupledFromGlobalTimeout(t *testing.T) {
+	gotCtxErr := make(chan error, 1)
+	fake := &fakeDrainRuntime{
+		drainFn: func(ctx context.Context) error {
+			// Simulate a flush that outlasts the global 20ms timeout but
+			// finishes well inside the stall budget.
+			select {
+			case <-ctx.Done():
+				gotCtxErr <- ctx.Err()
+				return ctx.Err()
+			case <-time.After(80 * time.Millisecond):
+				gotCtxErr <- nil
+				return nil
+			}
+		},
+	}
+	h := &SystemHandler{runtime: fake, drainStallTimeout: time.Minute}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/drain-uploads", nil)
+	rr := httptest.NewRecorder()
+	newSystemRouterWithGlobalTimeout(h, 20*time.Millisecond).ServeHTTP(rr, req)
+
+	select {
+	case err := <-gotCtxErr:
+		if err != nil {
+			t.Fatalf("drain was cancelled by the global request timeout: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("drainFn never returned")
+	}
+
+	// The decoupling is only real if the client gets the genuine success
+	// response. chi middleware.Timeout fires its deferred 504 WriteHeader after
+	// the handler returns (the request context's deadline elapsed during the
+	// 80ms drain); the handler must have already written 200 + body so that
+	// stale 504 is a no-op.
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (middleware 504 must not clobber the success response): body=%s",
+			rr.Code, rr.Body.String())
+	}
+	var got map[string]any
+	if err := json.NewDecoder(rr.Body).Decode(&got); err != nil {
+		t.Fatalf("decode body: %v (body=%s)", err, rr.Body.String())
+	}
+	if got["status"] != "drained" {
+		t.Fatalf("body = %+v, want status=drained", got)
+	}
+}
+
+// TestSystemHandler_DrainUploads_ClientDisconnectStopsDrain asserts that a
+// genuine client disconnect (request context Canceled, not the deadline fired
+// by middleware.Timeout) still aborts the drain — decoupling from the global
+// timeout must not make the drain ignore an aborted request.
+func TestSystemHandler_DrainUploads_ClientDisconnectStopsDrain(t *testing.T) {
+	started := make(chan struct{})
+	gotCtxErr := make(chan error, 1)
+	fake := &fakeDrainRuntime{
+		drainFn: func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			gotCtxErr <- ctx.Err()
+			return ctx.Err()
+		},
+	}
+	h := &SystemHandler{runtime: fake, drainStallTimeout: time.Minute}
+
+	clientCtx, clientCancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/drain-uploads", nil).
+		WithContext(clientCtx)
+	rr := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		h.DrainUploads(rr, req)
+		close(done)
+	}()
+
+	<-started
+	clientCancel() // simulate the client hanging up
+
+	select {
+	case err := <-gotCtxErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("drain ctx err = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("client disconnect did not stop the drain")
+	}
+	<-done
+}
+
+// TestSystemHandler_DrainUploads_StallReturns504 asserts that a drain that
+// makes no upload progress for the stall window is aborted and reported as 504.
+// This is the core of the inactivity model: a wedged remote must not hang the
+// request forever.
+func TestSystemHandler_DrainUploads_StallReturns504(t *testing.T) {
+	fake := &fakeDrainRuntime{
+		drainFn: func(ctx context.Context) error {
+			// Never makes progress; unblocks only when the watchdog cancels.
+			<-ctx.Done()
+			return ctx.Err()
+		},
+		// uploadProgressFn nil → constant 0 → watchdog sees a flat counter.
+	}
+	h := &SystemHandler{runtime: fake, drainStallTimeout: 20 * time.Millisecond}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/drain-uploads", nil)
+	rr := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		h.DrainUploads(rr, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("stalled drain did not return")
+	}
+	if rr.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504 for a stalled drain: body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestSystemHandler_DrainUploads_ProgressResetsWatchdog proves there is no
+// total wall-clock cap: a drain that runs far longer than the stall window
+// still succeeds as long as it keeps making progress. The total runtime (~120ms
+// in 30ms steps) deliberately exceeds the 50ms stall budget — a fixed total
+// timeout would wrongly abort it; the inactivity watchdog must not.
+func TestSystemHandler_DrainUploads_ProgressResetsWatchdog(t *testing.T) {
+	var progress atomic.Int64
+	fake := &fakeDrainRuntime{
+		uploadProgressFn: progress.Load,
+		drainFn: func(ctx context.Context) error {
+			for i := 0; i < 4; i++ {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(30 * time.Millisecond):
+					progress.Add(1) // a chunk completed → resets the watchdog
+				}
+			}
+			return nil
+		},
+	}
+	h := &SystemHandler{runtime: fake, drainStallTimeout: 50 * time.Millisecond}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/drain-uploads", nil)
+	rr := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		h.DrainUploads(rr, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("drain did not return")
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (progress must reset the stall watchdog): body=%s",
+			rr.Code, rr.Body.String())
+	}
+}
+
+// TestSystemHandler_DrainUploads_NilRuntime returns 500 rather than panicking
+// when the handler was constructed without a runtime.
+func TestSystemHandler_DrainUploads_NilRuntime(t *testing.T) {
+	h := NewSystemHandler(nil, 0)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/drain-uploads", nil)
+	rr := httptest.NewRecorder()
+	h.DrainUploads(rr, req)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rr.Code)
+	}
+}

--- a/pkg/block/engine/flush.go
+++ b/pkg/block/engine/flush.go
@@ -27,6 +27,23 @@ func (bs *Store) DrainAllUploads(ctx context.Context) error {
 	return bs.syncer.DrainAllUploads(ctx)
 }
 
+// SyncCounts returns the lifetime (completed, failed) mirror counts for this
+// store: chunks that reached the remote and chunks whose mirror attempt
+// failed. Both are monotonic. The drain-uploads idle watchdog reads them as a
+// progress signal. Returns (0, 0) when the store is closing or has no remote
+// (local-only stores never mirror, so the counters are meaningless — matching
+// stats.go, which also reports zeros in that mode).
+func (bs *Store) SyncCounts() (completed, failed int) {
+	if err := bs.enter(); err != nil {
+		return 0, 0
+	}
+	defer bs.closeMu.RUnlock()
+	if bs.remote == nil {
+		return 0, 0
+	}
+	return bs.syncer.SyncCounts()
+}
+
 // DrainRollups forces the local store to roll up every currently-dirty
 // payload into CAS + the FileBlock manifest, bypassing the
 // stabilization-window gate. The snapshot-create orchestration calls this

--- a/pkg/controlplane/api/cleartext_warn_test.go
+++ b/pkg/controlplane/api/cleartext_warn_test.go
@@ -39,7 +39,7 @@ func TestNewServer_CleartextWarnOnNonLoopbackNoTLS(t *testing.T) {
 		cpStore, cfg := testSetup(t, 0)
 		t.Cleanup(func() { _ = cpStore.Close() })
 		cfg.Host = "0.0.0.0"
-		if _, err := NewServer(cfg, nil, cpStore, 30*time.Minute); err != nil {
+		if _, err := NewServer(cfg, nil, cpStore, Timeouts{Restore: 30 * time.Minute}); err != nil {
 			t.Fatalf("NewServer: %v", err)
 		}
 		if !strings.Contains(buf.String(), warnNeedle) {
@@ -52,7 +52,7 @@ func TestNewServer_CleartextWarnOnNonLoopbackNoTLS(t *testing.T) {
 		cpStore, cfg := testSetup(t, 0)
 		t.Cleanup(func() { _ = cpStore.Close() })
 		cfg.Host = "127.0.0.1"
-		if _, err := NewServer(cfg, nil, cpStore, 30*time.Minute); err != nil {
+		if _, err := NewServer(cfg, nil, cpStore, Timeouts{Restore: 30 * time.Minute}); err != nil {
 			t.Fatalf("NewServer: %v", err)
 		}
 		if strings.Contains(buf.String(), warnNeedle) {
@@ -68,7 +68,7 @@ func TestNewServer_CleartextWarnOnNonLoopbackNoTLS(t *testing.T) {
 		serverCert := generateCert(t, "localhost", []string{"localhost"}, false, nil)
 		certPath, keyPath := writeCertFiles(t, t.TempDir(), serverCert)
 		cfg.TLS = TLSConfig{CertFile: certPath, KeyFile: keyPath}
-		if _, err := NewServer(cfg, nil, cpStore, 30*time.Minute); err != nil {
+		if _, err := NewServer(cfg, nil, cpStore, Timeouts{Restore: 30 * time.Minute}); err != nil {
 			t.Fatalf("NewServer: %v", err)
 		}
 		if strings.Contains(buf.String(), warnNeedle) {

--- a/pkg/controlplane/api/config.go
+++ b/pkg/controlplane/api/config.go
@@ -51,6 +51,13 @@ type APIConfig struct {
 	// Default: 60s
 	IdleTimeout time.Duration `mapstructure:"idle_timeout" yaml:"idle_timeout"`
 
+	// DrainStallTimeout bounds the POST /system/drain-uploads handler. The drain
+	// has no total time budget — a multi-GiB flush legitimately runs for as long
+	// as it keeps making progress — so this is an *inactivity* timeout, not a
+	// wall-clock cap: the drain is aborted only if no upload completes within
+	// this window (the remote stalled). Mirrors rclone's --timeout. Default: 5m.
+	DrainStallTimeout time.Duration `mapstructure:"drain_stall_timeout" yaml:"drain_stall_timeout"`
+
 	// JWT configures JWT authentication for API endpoints.
 	JWT JWTConfig `mapstructure:"jwt" yaml:"jwt"`
 
@@ -214,6 +221,9 @@ func (c *APIConfig) ApplyDefaults() {
 	}
 	if c.IdleTimeout == 0 {
 		c.IdleTimeout = 60 * time.Second
+	}
+	if c.DrainStallTimeout == 0 {
+		c.DrainStallTimeout = 5 * time.Minute
 	}
 	// When pprof is on but the sampling rates are left unset, fall back to
 	// sensible defaults so /debug/pprof/{mutex,block} return non-empty profiles

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -56,7 +56,7 @@ const passwordChangePath = "/api/v1/users/me/password"
 //   - /api/v1/mounts - Unified mount listing (admin only)
 //   - GET /api/v1/durable-handles - List active durable handles (admin only)
 //   - DELETE /api/v1/durable-handles/{id} - Force-close a durable handle (admin only)
-func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.Store, pprofEnabled bool, restoreHTTPTimeout time.Duration) http.Handler {
+func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.Store, pprofEnabled bool, timeouts Timeouts) http.Handler {
 	r := chi.NewRouter()
 
 	// Middleware stack - order matters
@@ -219,7 +219,7 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 
 				// Per-share snapshot lifecycle. RequireAdmin is inherited
 				// from the parent /shares group.
-				snapshotHandler := handlers.NewSnapshotHandler(rt, restoreHTTPTimeout, rt.LocalStoreDir)
+				snapshotHandler := handlers.NewSnapshotHandler(rt, timeouts.Restore, rt.LocalStoreDir)
 				r.Route("/{name}/snapshots", func(r chi.Router) {
 					r.Post("/", snapshotHandler.Create)
 					r.Get("/", snapshotHandler.List)
@@ -469,7 +469,7 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 			// System operations (admin only)
 			r.Route("/system", func(r chi.Router) {
 				r.Use(apiMiddleware.RequireAdmin())
-				systemHandler := handlers.NewSystemHandler(rt)
+				systemHandler := handlers.NewSystemHandler(rt, timeouts.DrainStall)
 				r.Post("/drain-uploads", systemHandler.DrainUploads)
 			})
 

--- a/pkg/controlplane/api/router_test.go
+++ b/pkg/controlplane/api/router_test.go
@@ -33,7 +33,7 @@ func newTestRouter(t *testing.T, pprofEnabled bool) (http.Handler, *auth.JWTServ
 		t.Fatalf("create jwt service: %v", err)
 	}
 
-	router := NewRouter(nil, jwtService, cpStore, pprofEnabled, 30*time.Minute)
+	router := NewRouter(nil, jwtService, cpStore, pprofEnabled, Timeouts{Restore: 30 * time.Minute, DrainStall: 5 * time.Minute})
 	return router, jwtService
 }
 

--- a/pkg/controlplane/api/server.go
+++ b/pkg/controlplane/api/server.go
@@ -24,6 +24,21 @@ import (
 // timeout. The dfs binary sources this from config.SnapshotConfig.
 const DefaultRestoreHTTPTimeout = 30 * time.Minute
 
+// Timeouts bundles the per-handler budgets for long-running control-plane
+// operations that must outlive the global HTTP request timeout
+// (middleware.Timeout / write_timeout, ~30s). They are assembled by the caller
+// from the config sections that own each one (see cmd/dfs start), keeping the
+// constructor signatures stable as more such operations are added.
+type Timeouts struct {
+	// Restore is the total wall-clock budget for a snapshot restore. Zero
+	// falls back to the snapshot handler's default.
+	Restore time.Duration
+	// DrainStall is the inactivity budget for POST /system/drain-uploads — an
+	// idle timeout, not a wall-clock cap. Zero falls back to the system
+	// handler's DefaultDrainStallTimeout.
+	DrainStall time.Duration
+}
+
 // Server provides an HTTP server for the REST API.
 //
 // The server exposes health check endpoints and authentication APIs.
@@ -61,7 +76,7 @@ type Server struct {
 //   - cpStore: Control plane store for user/group management
 //
 // Returns a configured but not yet started Server, or an error if JWT configuration is invalid.
-func NewServer(config APIConfig, rt *runtime.Runtime, cpStore store.Store, restoreHTTPTimeout time.Duration) (*Server, error) {
+func NewServer(config APIConfig, rt *runtime.Runtime, cpStore store.Store, timeouts Timeouts) (*Server, error) {
 	config.ApplyDefaults()
 
 	// Fail fast on internally inconsistent TLS settings (cert without key, etc.).
@@ -127,7 +142,7 @@ func NewServer(config APIConfig, rt *runtime.Runtime, cpStore store.Store, resto
 	}
 
 	// cpStore implements both IdentityStore and Store
-	router := NewRouter(rt, jwtService, cpStore, config.Pprof, restoreHTTPTimeout)
+	router := NewRouter(rt, jwtService, cpStore, config.Pprof, timeouts)
 
 	writeTimeout := config.WriteTimeout
 	if config.Pprof && writeTimeout < 120*time.Second {

--- a/pkg/controlplane/api/server_test.go
+++ b/pkg/controlplane/api/server_test.go
@@ -78,7 +78,7 @@ func testSetup(t *testing.T, port int) (store.Store, APIConfig) {
 func TestAPIServer_Lifecycle(t *testing.T) {
 	cpStore, cfg := testSetup(t, 18080)
 
-	server, err := NewServer(cfg, nil, cpStore, 30*time.Minute)
+	server, err := NewServer(cfg, nil, cpStore, Timeouts{Restore: 30 * time.Minute})
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestAPIServer_Lifecycle(t *testing.T) {
 func TestAPIServer_Port(t *testing.T) {
 	cpStore, cfg := testSetup(t, 9999)
 
-	server, err := NewServer(cfg, nil, cpStore, 30*time.Minute)
+	server, err := NewServer(cfg, nil, cpStore, Timeouts{Restore: 30 * time.Minute})
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestAPIServer_DefaultConfig(t *testing.T) {
 		},
 	}
 
-	server, err := NewServer(cfg, nil, cpStore, 30*time.Minute)
+	server, err := NewServer(cfg, nil, cpStore, Timeouts{Restore: 30 * time.Minute})
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestAPIServer_DefaultConfig(t *testing.T) {
 func TestAPIServer_HealthEndpoint_NoRuntime(t *testing.T) {
 	cpStore, cfg := testSetup(t, 18081)
 
-	server, err := NewServer(cfg, nil, cpStore, 30*time.Minute)
+	server, err := NewServer(cfg, nil, cpStore, Timeouts{Restore: 30 * time.Minute})
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -205,7 +205,7 @@ func TestAPIServer_HealthEndpoint_NoRuntime(t *testing.T) {
 func TestAPIServer_RootRedirectsToHealth(t *testing.T) {
 	cpStore, cfg := testSetup(t, 18082)
 
-	server, err := NewServer(cfg, nil, cpStore, 30*time.Minute)
+	server, err := NewServer(cfg, nil, cpStore, Timeouts{Restore: 30 * time.Minute})
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -253,7 +253,7 @@ func TestAPIServer_InvalidJWTSecret(t *testing.T) {
 		},
 	}
 
-	_, err := NewServer(cfg, nil, cpStore, 30*time.Minute)
+	_, err := NewServer(cfg, nil, cpStore, Timeouts{Restore: 30 * time.Minute})
 	if err == nil {
 		t.Fatal("Expected error for invalid JWT secret, got nil")
 	}
@@ -319,7 +319,7 @@ func TestNewServer_PprofSamplingWired(t *testing.T) {
 	cfg.Pprof = true
 	cfg.PprofMutexRate = 137 // distinctive, non-default value
 
-	if _, err := NewServer(cfg, nil, cpStore, 30*time.Minute); err != nil {
+	if _, err := NewServer(cfg, nil, cpStore, Timeouts{Restore: 30 * time.Minute}); err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
 
@@ -345,7 +345,7 @@ func TestNewServer_PprofOffResetsSampling(t *testing.T) {
 	cpStore, cfg := testSetup(t, 18100)
 	cfg.Pprof = false
 
-	if _, err := NewServer(cfg, nil, cpStore, 30*time.Minute); err != nil {
+	if _, err := NewServer(cfg, nil, cpStore, Timeouts{Restore: 30 * time.Minute}); err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
 

--- a/pkg/controlplane/api/tls_test.go
+++ b/pkg/controlplane/api/tls_test.go
@@ -137,7 +137,7 @@ func TestNewServer_TLSCertFilesMissing_FailsFast(t *testing.T) {
 	cpStore, cfg := testSetup(t, 0)
 	cfg.TLS = TLSConfig{CertFile: "/nonexistent/tls.crt", KeyFile: "/nonexistent/tls.key"}
 
-	_, err := NewServer(cfg, nil, cpStore, 30*time.Minute)
+	_, err := NewServer(cfg, nil, cpStore, Timeouts{Restore: 30 * time.Minute})
 	if err == nil {
 		t.Fatal("expected NewServer to fail when cert files are missing")
 	}
@@ -147,7 +147,7 @@ func TestNewServer_TLSCertFilesMissing_FailsFast(t *testing.T) {
 
 func TestNewServer_HTTPByDefault(t *testing.T) {
 	cpStore, cfg := testSetup(t, 0)
-	server, err := NewServer(cfg, nil, cpStore, 30*time.Minute)
+	server, err := NewServer(cfg, nil, cpStore, Timeouts{Restore: 30 * time.Minute})
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -197,7 +197,7 @@ func TestAPIServer_HTTPS_Serves_And_RejectsPlainHTTP(t *testing.T) {
 	cfg.Host = "127.0.0.1"
 	cfg.TLS = TLSConfig{CertFile: certPath, KeyFile: keyPath}
 
-	server, err := NewServer(cfg, nil, cpStore, 30*time.Minute)
+	server, err := NewServer(cfg, nil, cpStore, Timeouts{Restore: 30 * time.Minute})
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -256,7 +256,7 @@ func TestAPIServer_MTLS_RejectsNoClientCert_AcceptsValid(t *testing.T) {
 	cfg.Host = "127.0.0.1"
 	cfg.TLS = TLSConfig{CertFile: certPath, KeyFile: keyPath, ClientCA: caPath}
 
-	server, err := NewServer(cfg, nil, cpStore, 30*time.Minute)
+	server, err := NewServer(cfg, nil, cpStore, Timeouts{Restore: 30 * time.Minute})
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -312,7 +312,7 @@ func TestAPIServer_BindAddressHonored(t *testing.T) {
 	cpStore, cfg := testSetup(t, port)
 	cfg.Host = "127.0.0.1"
 
-	server, err := NewServer(cfg, nil, cpStore, 30*time.Minute)
+	server, err := NewServer(cfg, nil, cpStore, Timeouts{Restore: 30 * time.Minute})
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}

--- a/pkg/controlplane/controlplane.go
+++ b/pkg/controlplane/controlplane.go
@@ -93,7 +93,10 @@ func New(ctx context.Context, opts *Options) (*ControlPlane, error) {
 		if timeout == 0 {
 			timeout = api.DefaultRestoreHTTPTimeout
 		}
-		apiServer, err := api.NewServer(*opts.API, rt, cpStore, timeout)
+		apiServer, err := api.NewServer(*opts.API, rt, cpStore, api.Timeouts{
+			Restore:    timeout,
+			DrainStall: opts.API.DrainStallTimeout,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create API server: %w", err)
 		}

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -860,6 +860,14 @@ func (r *Runtime) DrainAllUploads(ctx context.Context) error {
 	return r.sharesSvc.DrainAllBlockStores(ctx)
 }
 
+// UploadProgress returns a monotonic count of concluded mirror attempts
+// (completed + failed) across all per-share BlockStores. The drain-uploads
+// handler polls it as an idle/liveness signal: a flat value across the idle
+// window means the drain has stalled.
+func (r *Runtime) UploadProgress() int64 {
+	return r.sharesSvc.UploadProgress()
+}
+
 // GetBlockStoreStats returns block store statistics, optionally filtered by share name.
 func (r *Runtime) GetBlockStoreStats(shareName string) (*shares.BlockStoreStatsResponse, error) {
 	return r.sharesSvc.GetBlockStoreStats(shareName)

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -2016,6 +2016,33 @@ func (s *Service) DrainAllBlockStores(ctx context.Context) error {
 	return errors.Join(errs...)
 }
 
+// UploadProgress returns a monotonic count of mirror attempts that have
+// concluded (completed + failed) summed across every share's block store.
+//
+// It is a liveness signal for the drain-uploads idle watchdog: while a drain
+// is genuinely making progress this value keeps rising; a value that stays
+// flat across an idle window means the drain has stalled (e.g. the remote went
+// unreachable). Counting failed attempts as well as completed ones means a
+// retrying upload still registers as activity, so transient errors don't trip
+// the watchdog.
+func (s *Service) UploadProgress() int64 {
+	s.mu.RLock()
+	blockStores := make([]*engine.Store, 0, len(s.registry))
+	for _, share := range s.registry {
+		if share.BlockStore != nil {
+			blockStores = append(blockStores, share.BlockStore)
+		}
+	}
+	s.mu.RUnlock()
+
+	var total int64
+	for _, bs := range blockStores {
+		completed, failed := bs.SyncCounts()
+		total += int64(completed) + int64(failed)
+	}
+	return total
+}
+
 // ShareBlockStoreStats holds block store statistics for a single share.
 type ShareBlockStoreStats struct {
 	ShareName string                 `json:"share_name"`


### PR DESCRIPTION
## What

`POST /system/drain-uploads` derived its context from the HTTP request, so chi `middleware.Timeout` / `write_timeout` (~30s) cancelled large flushes mid-drain — a multi-GiB flush returned `context canceled` with data still un-uploaded (#1432).

## Fix — inactivity timeout, no total cap

The drain is detached from the request deadline (`context.WithoutCancel`) and bounded by **inactivity**, not wall-clock:

- Aborts (504) **only if no upload completes within `controlplane.drain_stall_timeout`** (default 5m) — i.e. the remote stalled.
- **No total time budget.** A correct flush of an arbitrarily large backlog takes arbitrarily long; any fixed cap is just a number that's wrong for some workload. This mirrors **rclone's `--timeout`** (a progress-resetting idle timeout) and matches how **juicefs / s3ql** treat a forced flush — block until done, give up only on a genuine stall.
- A real client disconnect (request ctx `Canceled`, not the middleware's `DeadlineExceeded`) still cancels it.

## How it works

- **Progress signal:** `Store.SyncCounts` → `Service.UploadProgress` → `Runtime.UploadProgress` — a monotonic count of concluded mirror attempts (completed + failed) aggregated across all shares. The watchdog samples it; a flat value across the window = stall.
- **Shared helper:** `detachFromRequest` (handlers/helpers.go) dedups the `WithoutCancel` + client-disconnect dance previously inline in both the restore and drain handlers.
- **Signature cleanup:** long-running-op budgets bundled into `api.Timeouts{Restore, DrainStall}` instead of growing positional params on `NewServer`/`NewRouter`.
- **Config:** `controlplane.drain_stall_timeout` (documented in configuration.md).

## Tests

- `StallReturns504` — wedged remote → 504.
- `ProgressResetsWatchdog` — a drain that runs **longer than the stall budget** (120ms run vs 50ms budget) still returns 200 as long as it keeps making progress. Proves there is no total cap.
- `DecoupledFromGlobalTimeout` — 20ms global request timeout, 80ms drain → client still gets the real 200, not the middleware 504.
- `ClientDisconnectStopsDrain`, `NilRuntime`.

## Context

Throughput root-cause for #1432 is single-stream-over-WAN (see PR1, sustained upload concurrency). This PR fixes the **drain cutoff** that the user's "why 30s?" surfaced — orthogonal to throughput, but it's why large explicit flushes were dying at 30s.

Gates: `gofmt -s`, `go vet`, `golangci-lint` (0), `go test -race`, code-simplifier + code-reviewer (no findings). Not for merge — human review.