### PR TITLE
perf(block): sustain upload concurrency in steady state (#1432)

### DIFF
--- a/.planning/2026-06-29-1432-upload-perf-plan.md
+++ b/.planning/2026-06-29-1432-upload-perf-plan.md
@@ -1,0 +1,96 @@
+# #1432 — S3 upload throughput plan
+
+**Date:** 2026-06-29
+**Issue:** #1432 — "S3 upload ~30× slower than rclone (~25 Mbit/s vs ~450)"
+**Status:** root cause confirmed by benchmark; PRs not yet started.
+
+## TL;DR
+
+The reporter's 25 Mbit/s is **dittofs uploading on a single TCP stream** (`inflight=1`) in
+steady state. A single stream to Cubbit is ~25 Mbit/s for *everyone* — reproduced exactly from a
+Scaleway VM. It is **not** Cubbit throttling, **not** the reporter's connection, **not** multipart.
+The fix is to **sustain upload concurrency** so `inflight ≈ window` during steady streaming, not
+only when a deep backlog happens to exist.
+
+## How it was measured
+
+Disposable Scaleway POP2-8C-32G VM in fr-par → Cubbit (`s3.cubbit.eu`, 17.8 ms RTT) and SCW S3
+(`s3.fr-par.scw.cloud`, 0.9 ms RTT). Apples-to-apples with dittofs's **own** S3 client via a
+throwaway `parallelput` tool (clean bounded-errgroup PUTs of 4 MiB CAS-sized objects — no engine).
+Full dfs server reproduction: NFS mount → `dd` 1.5 GiB → `dfsctl system drain-uploads`, sampling
+`/metrics` (`datapath_upload_window` / `_uploads_inflight` / `_upload_queue_depth`) at 0.5 s.
+
+CAS chunk sizing: FastCDC min 1 / **avg 4** / max 16 MiB. So ~375 objects per 1.5 GiB.
+
+## Data
+
+Cubbit, same VM/bucket:
+
+| Path | Throughput |
+|---|---|
+| rclone **multipart** 16M / conc64 | **402 Mbit/s** |
+| dittofs **parallel-PUT** 4MiB / conc64 (our client) | **337 Mbit/s** |
+| parallel-PUT 4MiB / conc16 | 197 |
+| parallel-PUT 4MiB / conc8 | ~150 |
+| parallel-PUT 4MiB / conc4 | 101 |
+| **parallel-PUT 4MiB / conc1 (single stream)** | **25** ← reporter's number, exactly |
+| dittofs **engine** (dd→drain, deep backlog) | 280 (bursts to inflight=64) |
+
+Near-linear: throughput ≈ streams × ~25 Mbit. conc32 dipped to 115 = tail-variance (only 96 ops),
+**not** 503s.
+
+Engine `/metrics` timeline (Cubbit): window ramps 16→64 and holds; **`inflight` sits at 1–2 for the
+whole steady state**, bursting to 64 only when `dd` had piled a deep backlog. Explicit
+`drain-uploads` (one big `mirrorOnce` pass) fills the window to 61 — proving dispatch *can*
+parallelize; the periodic/continuous path fails to.
+
+## Root cause
+
+1. **Primary — steady-state `inflight=1`.** The periodic uploader drains in tiny per-pass batches as
+   chunks trickle in (snapshot → dispatch → `g.Wait()` → return), so during steady streaming it runs
+   ~one PUT at a time = single TCP stream = 25 Mbit. It only reaches `inflight=64` when a deep backlog
+   already exists (reporter's queue stayed shallow 10–18 → never bursts). `mirrorOnce`/`mirrorChunk`
+   (`pkg/block/engine/syncer.go`) hold no lock — the limiter is fine; the problem is the *batching
+   structure* of the continuous path. Confirmed: explicit drain hits inflight 61.
+2. **Not Cubbit.** Zero 503 / SlowDown. Conn pool already 256.
+3. **Not multipart.** parallel-PUT 337 ≈ multipart 402 at conc64. Multipart's ~20% edge = bigger
+   parts (fewer round-trips), not the protocol.
+4. **Bonus bug.** `drain-uploads` is hard-capped at the controlplane `write_timeout` (30 s):
+   `Drain uploads failed error=context canceled duration=30.000s`. Large explicit flushes are killed
+   mid-drain. (Also invalidated the SCW engine measurement: egress 728 MiB < 1.5 GiB.)
+5. **Observability bug.** `datapath_upload_queue_depth` is a stale per-pass gauge (set once at
+   snapshot, never decrements — froze at 178). Misleading; made diagnosis ambiguous.
+
+## Plan (ordered by impact)
+
+### PR 1 — Sustain upload concurrency in steady state  *(the 13×; this is the issue)*
+Replace the per-pass snapshot + `g.Wait()` drain with a **continuous worker pool**: N persistent
+workers pull from the pending channel, each grabbing the next chunk the instant its PUT returns. No
+barrier between "passes." Goal: `inflight ≈ window` during steady streaming, not only on deep
+backlogs. Keep the adaptive window (#1407) — it already computes 64; the bug is `inflight` never
+reaching it. Branch off develop.
+- **Success:** streaming workload (not backlog-burst) sustains inflight 32–64 and ~300+ Mbit.
+
+### PR 2 — Fix `drain-uploads` 30 s timeout  *(quick, independent)*
+Decouple the drain handler from the HTTP `write_timeout` (background / `context.WithoutCancel`, or
+stream progress). Ship alongside PR 1.
+
+### PR 3 — Bigger PUT objects = **#1414 object packing**  *(secondary, ~20%)*
+Fewer/larger objects close most of the 337→402 gap. Do **after** PR 1; park on #1414. **Not**
+multipart adoption.
+
+### Minor — fix stale `queue_depth` gauge
+Make it real-time so future diagnosis isn't misled.
+
+## Explicitly NOT doing
+- Multipart rewrite (parallel-PUT ≈ multipart at concurrency).
+- Connection-pool tuning (256 already; 0× 503).
+- Bigger FastCDC blocks *instead of* fixing dispatch — masks the single-stream bug, hurts dedup/RAM.
+
+## Validation
+Re-spin the disposable SCW-VM → Cubbit harness after PR 1. Pass = steady-state (streaming, shallow
+queue) inflight 32–64 + ~300 Mbit, i.e. no longer single-stream-bound.
+
+## Cross-refs
+#1407 (adaptive window — ramps, but inflight≪window is the real gap) · #1411 (shallow-queue /
+rollup-starve) · #1414 (object packing = Lever 2) · #1415 (parallel rollup, shipped).

--- a/pkg/block/engine/dispatcher.go
+++ b/pkg/block/engine/dispatcher.go
@@ -1,0 +1,420 @@
+package engine
+
+import (
+	"context"
+	gosync "sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// dispatcherHealthRecheck bounds how often the dispatcher re-checks remote
+// health while parked during an outage, so a sick remote does not spin the
+// dispatcher between the work-available signal and the health gate.
+const dispatcherHealthRecheck = 500 * time.Millisecond
+
+// uploadGate coordinates the continuous upload dispatcher against the explicit
+// drain path (Flush / SyncNow / uploadBlock).
+//
+// The dispatcher keeps many per-chunk uploads in flight at once to saturate the
+// uplink during steady streaming (#1432). The explicit drain runs mirrorOnce,
+// which snapshots the pending set and reports durability/error for that
+// snapshot. If both ran at once they would double-upload the same CAS chunks
+// (wasting the very bandwidth we are trying to reclaim) and perturb mirrorOnce's
+// snapshot accounting. The gate gives the explicit path exclusive use of the
+// upload path: it blocks new dispatcher uploads and waits for in-flight ones to
+// quiesce, then lets mirrorOnce run alone.
+//
+// Invariant used by the explicit path: when active == 0, no dispatcher upload is
+// in flight, so the pending set is not being mutated by the dispatcher and
+// mirrorOnce can snapshot it cleanly.
+type uploadGate struct {
+	mu       gosync.Mutex
+	cond     *gosync.Cond
+	explicit bool // an explicit drain holds (or is acquiring) exclusivity
+	active   int  // dispatcher uploads currently in flight
+}
+
+func newUploadGate() *uploadGate {
+	g := &uploadGate{}
+	g.cond = gosync.NewCond(&g.mu)
+	return g
+}
+
+// ensureGate lazily creates the upload gate for Syncers built directly in test
+// fixtures rather than via NewSyncer (which always wires it). Idempotent under
+// m.mu; mirrors the existing ensureUploadLimiter guard.
+func (m *Syncer) ensureGate() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.gate == nil {
+		m.gate = newUploadGate()
+	}
+}
+
+// waitCtx parks on the cond until broadcast, returning early if ctx is
+// cancelled. The caller must hold g.mu. A watcher goroutine broadcasts under
+// g.mu on ctx.Done so a parked waiter cannot miss the wakeup (cond.Wait
+// atomically releases g.mu, so broadcasting under the lock serializes against
+// the release window). The watcher lives only for this wait.
+func (g *uploadGate) waitCtx(ctx context.Context) {
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			g.mu.Lock()
+			g.cond.Broadcast()
+			g.mu.Unlock()
+		case <-done:
+		}
+	}()
+	g.cond.Wait()
+}
+
+// beginDispatch registers one in-flight dispatcher upload, blocking while an
+// explicit drain holds exclusivity. Returns false (registering nothing) if ctx
+// is cancelled, so the dispatcher does not strand a slot on shutdown. Each
+// successful beginDispatch must be paired with exactly one endDispatch.
+func (g *uploadGate) beginDispatch(ctx context.Context) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for g.explicit {
+		if ctx.Err() != nil {
+			return false
+		}
+		g.waitCtx(ctx)
+	}
+	if ctx.Err() != nil {
+		return false
+	}
+	g.active++
+	return true
+}
+
+// endDispatch retires one in-flight dispatcher upload and wakes any explicit
+// drain waiting for the dispatcher to quiesce.
+func (g *uploadGate) endDispatch() {
+	g.mu.Lock()
+	g.active--
+	g.cond.Broadcast()
+	g.mu.Unlock()
+}
+
+// acquireExclusive takes the explicit-drain lock. When block is false and
+// another explicit drain holds the lock — or dispatcher uploads are in flight —
+// it returns (false, nil) immediately rather than waiting; this preserves the
+// non-blocking, soft-fail contract of Flush/uploadBlock (#670). When block is
+// true it waits (ctx-aware) for the explicit slot and then for dispatcher
+// uploads to drain to zero. On ctx cancellation it returns (false, ctx.Err())
+// without holding the lock.
+func (g *uploadGate) acquireExclusive(ctx context.Context, block bool) (bool, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	for g.explicit {
+		if !block {
+			return false, nil
+		}
+		if ctx.Err() != nil {
+			return false, ctx.Err()
+		}
+		g.waitCtx(ctx)
+	}
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+	g.explicit = true
+
+	// Drain in-flight dispatcher uploads so mirrorOnce runs alone.
+	for g.active > 0 {
+		if !block {
+			// Non-blocking caller cannot wait for the dispatcher to quiesce:
+			// release the slot it just took and soft-fail.
+			g.explicit = false
+			g.cond.Broadcast()
+			return false, nil
+		}
+		if ctx.Err() != nil {
+			g.explicit = false
+			g.cond.Broadcast()
+			return false, ctx.Err()
+		}
+		g.waitCtx(ctx)
+	}
+	return true, nil
+}
+
+// releaseExclusive releases the explicit-drain lock and wakes the dispatcher.
+func (g *uploadGate) releaseExclusive() {
+	g.mu.Lock()
+	g.explicit = false
+	g.cond.Broadcast()
+	g.mu.Unlock()
+}
+
+// dispatcherEnabled reports whether the continuous upload dispatcher runs for
+// this syncer: it needs a remote to upload to and must stay off in manual-sync
+// mode, where durability is driven solely by explicit Flush.
+func (m *Syncer) dispatcherEnabled() bool {
+	return m.hasRemote.Load() && !m.config.ManualSync
+}
+
+// currentHashStore returns the wired SyncedHashStore under the syncer RWMutex.
+func (m *Syncer) currentHashStore() metadata.SyncedHashStore {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.syncedHashStore
+}
+
+// claimReady pops the next dispatchable hash from the ready queue and marks it
+// in-flight, skipping entries that were synced out from under it (no longer
+// pending) or are already being uploaded. Returns ok=false when no dispatchable
+// work remains.
+func (m *Syncer) claimReady() (block.ContentHash, bool) {
+	m.pendingMu.Lock()
+	defer m.pendingMu.Unlock()
+	for len(m.readyQ) > 0 {
+		h := m.readyQ[0]
+		m.readyQ = m.readyQ[1:]
+		if len(m.readyQ) == 0 {
+			m.readyQ = nil // release the backing array once fully drained
+		}
+		if _, pending := m.pendingHashes[h]; !pending {
+			continue // already mirrored (e.g. via markFetchedSynced)
+		}
+		if _, busy := m.inflight[h]; busy {
+			continue // already being uploaded by another worker
+		}
+		m.inflight[h] = struct{}{}
+		return h, true
+	}
+	return block.ContentHash{}, false
+}
+
+// releaseInflight clears a hash's in-flight mark after its upload attempt
+// completes (success or failure). The pending-set deletion on success happens in
+// mirrorChunk; this only retires the in-flight claim so the dispatcher can
+// re-attempt a failed hash on the next requeue.
+func (m *Syncer) releaseInflight(h block.ContentHash) {
+	m.pendingMu.Lock()
+	delete(m.inflight, h)
+	m.pendingMu.Unlock()
+}
+
+// requeueOrphans rebuilds the ready queue from the authoritative pending set
+// (every pending hash not currently in flight). It re-queues hashes whose
+// previous upload attempt failed — they stay in pendingHashes but were dropped
+// from the ready queue when claimed — and seeds the queue for a dispatcher that
+// started after the pending set was populated (e.g. SetRemoteStore). Run from
+// the maintenance loop, so retries are paced at the upload interval rather than
+// hot-looping. Signals the dispatcher when there is work.
+func (m *Syncer) requeueOrphans() {
+	m.pendingMu.Lock()
+	q := make([]block.ContentHash, 0, len(m.pendingHashes))
+	for h := range m.pendingHashes {
+		if _, busy := m.inflight[h]; !busy {
+			q = append(q, h)
+		}
+	}
+	m.readyQ = q
+	m.pendingMu.Unlock()
+	if len(q) > 0 {
+		m.signalWake()
+	}
+}
+
+// publishQueueDepth updates the data-plane upload-queue-depth gauge to the live
+// pending-set size. Called whenever the pending set changes so the gauge tracks
+// real-time depth instead of freezing at a per-pass snapshot count (#1432).
+func (m *Syncer) publishQueueDepth() {
+	mx := m.dataplaneMetrics()
+	if mx == nil {
+		return
+	}
+	m.pendingMu.Lock()
+	n := len(m.pendingHashes)
+	m.pendingMu.Unlock()
+	mx.SetUploadQueueDepth(n)
+}
+
+// stopRequested reports whether shutdown has begun (stopCh closed), without
+// blocking. Close() closes stopCh BEFORE it drains, so the dispatcher uses this
+// to avoid spawning new uploads once a drain/Close is in progress (which would
+// otherwise race remote.Close()).
+func (m *Syncer) stopRequested() bool {
+	select {
+	case <-m.stopCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// waitForWork blocks until the ready queue is non-empty or the syncer is
+// shutting down. Returns false on shutdown (stop signal or ctx cancellation).
+// Shutdown wins over available work, so a non-empty readyQ at Close time does
+// not keep the dispatcher spawning uploads.
+func (m *Syncer) waitForWork(ctx context.Context) bool {
+	if m.stopRequested() {
+		return false
+	}
+	m.pendingMu.Lock()
+	has := len(m.readyQ) > 0
+	m.pendingMu.Unlock()
+	if has {
+		return true
+	}
+	select {
+	case <-m.wake:
+		return true
+	case <-m.stopCh:
+		return false
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// uploadDispatcher is the continuous steady-state uploader (#1432). It keeps the
+// upload window full by claiming the next pending hash the instant a slot frees,
+// with no per-pass barrier — so inflight tracks the adaptive window during
+// streaming instead of collapsing to a single TCP stream. The adaptive
+// controller resizes the window via uploadLimiter; this loop simply rides it.
+//
+// Concurrency: beginDispatch is taken BEFORE claiming a hash. A dispatcher
+// paused inside beginDispatch (blocked while an explicit drain holds the gate)
+// holds no claim and no slot. A dispatcher already past beginDispatch — blocked
+// in uploadLimiter.Acquire or running its upload goroutine — has incremented the
+// gate's active count and may have set inflight[h]; acquireExclusive waits for
+// active==0, so an explicit drain cannot start until that goroutine's deferred
+// endDispatch fires (i.e. DrainAllUploads on a saturated window can take up to
+// window+1 goroutine lifetimes). Each upload runs in its own goroutine bounded
+// by uploadLimiter; the gate's active count and the in-flight set are both
+// retired when that goroutine finishes.
+func (m *Syncer) uploadDispatcher(ctx context.Context) {
+	logger.Info("Upload dispatcher started")
+	for {
+		if !m.waitForWork(ctx) {
+			logger.Info("Upload dispatcher: shutting down")
+			return
+		}
+
+		// Circuit breaker: park (without claiming) while the remote is
+		// unhealthy so we do not burn attempts against a down endpoint.
+		if !m.IsRemoteHealthy() {
+			select {
+			case <-time.After(dispatcherHealthRecheck):
+			case <-m.stopCh:
+				return
+			case <-ctx.Done():
+				return
+			}
+			continue
+		}
+
+		// Register against explicit drains before claiming work.
+		if !m.gate.beginDispatch(ctx) {
+			return
+		}
+
+		// beginDispatch may have blocked while Close()'s drain held the gate.
+		// Close closes stopCh before draining, so if shutdown has begun do not
+		// spawn a new upload — it could outlive syncer.Close() and race
+		// remote.Close().
+		if m.stopRequested() {
+			m.gate.endDispatch()
+			return
+		}
+
+		h, ok := m.claimReady()
+		if !ok {
+			m.gate.endDispatch()
+			continue
+		}
+
+		hashStore := m.currentHashStore()
+		if hashStore == nil {
+			// No mirror-state oracle wired: nothing to do (matches mirrorOnce).
+			m.releaseInflight(h)
+			m.gate.endDispatch()
+			continue
+		}
+
+		// Block for a window slot. This is the backpressure that holds inflight
+		// at the adaptive window: when the window is full the dispatcher waits
+		// here and resumes the instant an in-flight upload releases its slot.
+		if err := m.uploadLimiter.Acquire(ctx); err != nil {
+			m.releaseInflight(h)
+			m.gate.endDispatch()
+			return
+		}
+
+		go func(h block.ContentHash) {
+			defer m.gate.endDispatch()
+			defer m.uploadLimiter.Release()
+			defer m.releaseInflight(h)
+
+			// The queue-depth gauge is driven by the pending-set mutators
+			// (addPendingHash / mirrorChunk success / markFetchedSynced); a
+			// failed or lost upload leaves the pending set unchanged, so the
+			// dispatcher does not republish here.
+			var lost atomic.Bool
+			if err := m.mirrorChunk(ctx, hashStore, h, &lost); err != nil {
+				if ctx.Err() != nil {
+					logger.Debug("Upload dispatcher: chunk upload aborted during shutdown", "hash", h.String(), "error", err)
+				} else {
+					// Retained in the pending set; the maintenance loop requeues
+					// it for a later retry.
+					logger.Warn("Upload dispatcher: chunk upload failed; will retry", "hash", h.String(), "error", err)
+				}
+			}
+		}(h)
+	}
+}
+
+// maintenanceLoop runs the slow periodic housekeeping that the steady-state
+// dispatcher does not: it persists queued FileBlock metadata, periodically
+// re-seeds the pending set from disk (drift reconcile), and requeues pending
+// hashes whose upload attempt failed so they are retried at the upload interval.
+// It never uploads — that is the dispatcher's job.
+func (m *Syncer) maintenanceLoop(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	// Re-seed the ready queue from any pending hashes that predate the
+	// dispatcher (e.g. SetRemoteStore attached a remote after chunks were
+	// already pending).
+	m.requeueOrphans()
+
+	reconcileEvery := int((10 * time.Minute) / interval)
+	if reconcileEvery < 1 {
+		reconcileEvery = 1
+	}
+	tick := 0
+
+	for {
+		select {
+		case <-ticker.C:
+			if !m.canProcess(ctx) {
+				return
+			}
+			tick++
+			// Persist queued FileBlock metadata so reads/restart-recovery see
+			// the authoritative manifest for recently rolled-up chunks.
+			m.local.SyncFileBlocks(ctx)
+			if tick%reconcileEvery == 0 {
+				if _, err := m.seedPendingFromDisk(ctx); err != nil {
+					logger.Warn("Maintenance loop: drift reconcile failed", "error", err)
+				}
+			}
+			m.requeueOrphans()
+		case <-m.stopCh:
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/pkg/block/engine/nil_remotestore_test.go
+++ b/pkg/block/engine/nil_remotestore_test.go
@@ -206,14 +206,16 @@ func TestSetRemoteStoreNilArg(t *testing.T) {
 	}
 }
 
-func TestNilRemoteStoreSyncLocalBlocks(t *testing.T) {
+func TestNilRemoteStoreSyncNow(t *testing.T) {
 	m, _, cleanup := newNilRemoteStoreEnv(t)
 	defer cleanup()
 	ctx := context.Background()
 
-	// syncLocalBlocks should be a no-op with nil remoteStore
-	m.syncLocalBlocks(ctx)
-	// If we reach here without panic, test passes
+	// The explicit drain path should be a no-op (and not error) with nil
+	// remoteStore.
+	if err := m.SyncNow(ctx); err != nil {
+		t.Fatalf("SyncNow with nil remoteStore should not error, got: %v", err)
+	}
 }
 
 func TestNilRemoteStoreFetchBlock(t *testing.T) {

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -35,6 +35,11 @@ type fetchResult struct {
 type Syncer struct {
 	local       local.LocalStore
 	remoteStore remote.RemoteStore
+	// hasRemote mirrors "remoteStore != nil" as an atomic so the dispatcher's
+	// hot-path gating (dispatcherEnabled, called from addPendingHash under
+	// pendingMu) can read it without taking m.mu — avoiding both a data race
+	// with SetRemoteStore and a pendingMu→m.mu lock-ordering edge.
+	hasRemote atomic.Bool
 	// the syncer is one of the engine-internal
 	// callers that still reaches into the wider EngineFileBlockStore
 	// surface (GetFileBlock for dual-read resolve, ListFileBlocks for
@@ -71,17 +76,21 @@ type Syncer struct {
 	closed bool
 	mu     gosync.RWMutex
 
-	// wake nudges the periodic uploader to run a mirror pass immediately
-	// instead of waiting up to UploadInterval for the next tick. It is
-	// signalled (non-blocking, coalescing) from addPendingHash on every
-	// freshly rolled-up chunk, so upload overlaps the rollup of later chunks
-	// rather than starting a full tick-interval after rollup finishes (#1407).
-	// Buffered length 1: a burst of chunk completions collapses to a single
-	// follow-up pass, which snapshots the whole pending set at once.
+	// wake nudges the upload dispatcher that work is ready, so it picks up a
+	// freshly rolled-up chunk immediately instead of idling. Signalled
+	// (non-blocking, coalescing) from addPendingHash on every freshly rolled-up
+	// chunk, so upload overlaps the rollup of later chunks rather than starting
+	// a full tick-interval after rollup finishes (#1407). Buffered length 1: a
+	// burst of completions collapses to a single wakeup, after which the
+	// dispatcher drains the whole ready queue continuously (#1432).
 	wake chan struct{}
 
-	periodicStarted bool        // true once periodicUploader goroutine is launched
-	uploading       atomic.Bool // Guards against overlapping periodic upload ticks
+	periodicStarted bool // true once the dispatcher + maintenance goroutines are launched
+
+	// gate serializes the explicit drain path (Flush / SyncNow / uploadBlock)
+	// against the continuous upload dispatcher so the two never upload the same
+	// CAS chunk concurrently (#1432). See uploadGate.
+	gate *uploadGate
 
 	healthMonitor   *HealthMonitor           // Monitors remote store health (nil when no remote)
 	onHealthChanged healthTransitionCallback // Callback invoked on health state transitions
@@ -103,6 +112,16 @@ type Syncer struct {
 	// local store consults to decide whether to keep stalling a writer.
 	pendingMu     gosync.Mutex
 	pendingHashes map[block.ContentHash]int64
+
+	// readyQ is the FIFO of pending hashes ready for the dispatcher to upload,
+	// and inflight is the set currently being uploaded. Both are guarded by
+	// pendingMu and used only by the continuous dispatcher (#1432); the explicit
+	// mirrorOnce path reads pendingHashes directly. Every pending hash is in
+	// exactly one of {readyQ, inflight, failed-awaiting-requeue}; the
+	// maintenance loop's requeueOrphans moves failed hashes back into readyQ.
+	// claimReady validates on pop, so a stale/duplicate readyQ entry is skipped.
+	readyQ   []block.ContentHash
+	inflight map[block.ContentHash]struct{}
 
 	// unsyncedBytes is the running total on-disk size of pendingHashes:
 	// the number of cache bytes that cannot be evicted until they reach
@@ -153,16 +172,33 @@ func (m *Syncer) addPendingHash(h block.ContentHash, size int64) {
 	// (which deletes from the map and subtracts under the same lock): an
 	// add that interleaved a concurrent drain otherwise leaked a phantom
 	// positive byte count that no future drain would ever subtract.
-	prev := m.pendingHashes[h]
+	prev, alreadyPending := m.pendingHashes[h]
 	m.pendingHashes[h] = size
 	m.unsyncedBytes.Add(size - prev)
+	// Queue a freshly-pending hash for the dispatcher. An already-pending hash
+	// is left where it is (in readyQ, in flight, or awaiting requeue) — only its
+	// recorded size is refreshed above. readyQ/dispatch state is meaningful only
+	// when the dispatcher runs (a remote exists and not manual-sync); otherwise
+	// the explicit mirrorOnce path drains pendingHashes directly, so skipping
+	// the append avoids unbounded readyQ growth with no consumer.
+	queued := false
+	if !alreadyPending && m.dispatcherEnabled() {
+		m.readyQ = append(m.readyQ, h)
+		queued = true
+	}
 	m.pendingMu.Unlock()
 
-	// Nudge the periodic uploader to mirror this chunk now instead of waiting
-	// for the next tick, so upload pipelines with the rollup of later chunks
-	// (#1407). Only meaningful when a remote exists (the periodic uploader does
-	// not run otherwise). Non-blocking + coalescing — see signalWake.
-	if m.remoteStore != nil {
+	// Only a newly-inserted hash changes the queue depth; re-adding an
+	// already-pending hash (size refresh) leaves the gauge unchanged, so skip
+	// the extra lock/metric churn on that hot path (incl. seedPendingFromDisk).
+	if !alreadyPending {
+		m.publishQueueDepth()
+	}
+
+	// Nudge the dispatcher to mirror this chunk now instead of idling, so upload
+	// pipelines with the rollup of later chunks (#1407). Non-blocking +
+	// coalescing — see signalWake.
+	if queued {
 		m.signalWake()
 	}
 }
@@ -187,10 +223,11 @@ func (m *Syncer) ensureUploadLimiter() {
 }
 
 // signalWake performs a non-blocking, coalescing send on the wake channel,
-// nudging the periodic uploader to run a mirror pass immediately. Because wake
-// is buffered length 1, a burst of chunk completions collapses into a single
-// follow-up pass that snapshots the whole pending set — bounding wake-driven
-// passes regardless of chunk arrival rate (#1407).
+// nudging the upload dispatcher to pick up freshly-ready work immediately
+// instead of idling. Because wake is buffered length 1, a burst of chunk
+// completions collapses into a single wakeup, after which the dispatcher drains
+// the whole ready queue continuously — bounding wakeups regardless of chunk
+// arrival rate (#1407).
 func (m *Syncer) signalWake() {
 	select {
 	case m.wake <- struct{}{}:
@@ -238,6 +275,7 @@ func (m *Syncer) markFetchedSynced(ctx context.Context, h block.ContentHash) {
 		m.unsyncedBytes.Add(-size)
 	}
 	m.pendingMu.Unlock()
+	m.publishQueueDepth()
 }
 
 // UnsyncedBytes returns the running total on-disk size of CAS chunks present
@@ -325,9 +363,12 @@ func NewSyncer(local local.LocalStore, remoteStore remote.RemoteStore, fileBlock
 		stopCh:           make(chan struct{}),
 		wake:             make(chan struct{}, 1),
 		pendingHashes:    make(map[block.ContentHash]int64),
+		inflight:         make(map[block.ContentHash]struct{}),
+		gate:             newUploadGate(),
 		uploadLimiter:    newDynamicSemaphore(startWindow),
 		uploadController: uploadController,
 	}
+	m.hasRemote.Store(remoteStore != nil)
 
 	queueConfig := DefaultSyncQueueConfig()
 	// In adaptive mode the queue pool must cover the ceiling the controller can
@@ -444,22 +485,30 @@ func (m *Syncer) canProcess(ctx context.Context) bool {
 // machine and caller-retry guidance. In brief:
 //   - Finalized=true, err=nil: durable on the configured remote.
 //   - Finalized=false, err=nil: SOFT condition (no remote configured,
-//     remote unhealthy, OR another in-flight mirror pass holds the
-//     `uploading` CAS gate). Callers MUST NOT tight-loop retry — see
-//     #670 below.
+//     remote unhealthy, OR the upload gate is held by another explicit
+//     drain or in-flight dispatcher uploads). Callers MUST NOT tight-loop
+//     retry — see #670 below.
 //   - err != nil: hard failure, do not retry until addressed.
 //
 // #670: callers driving NFS COMMIT or SMB Flush loops over this method
-// must rate-limit retries on Finalized=false. The `uploading`
-// CompareAndSwap gate below makes the EXPLICIT Flush caller lose every
-// attempt that races the periodic uploader's tick, so a tight
-// in-handler retry loop pegs the CPU without ever making progress and
-// starves the uploading goroutine. Recommended pattern: surface the
+// must rate-limit retries on Finalized=false. The non-blocking gate
+// acquisition below makes the EXPLICIT Flush caller soft-fail any
+// attempt that races the continuous dispatcher, so a tight in-handler
+// retry loop pegs the CPU without ever making progress and starves the
+// dispatcher. Recommended pattern: surface the
 // soft-fail to the protocol adapter and let the client drive the next
 // attempt on its own schedule (e.g. NFSv3 reports the WRITE's
 // "committed" enum as UNSTABLE rather than DATASYNC/FILESYNC so the
 // client reissues COMMIT later; SMB Flush returns success after a
 // bounded attempt) instead of spinning in-handler.
+//
+// #1432: the continuous dispatcher keeps the gate active for as long as
+// uploads are in flight, so under a sustained streaming workload Flush may
+// soft-fail (Finalized=false) until the pipeline momentarily idles. This is
+// expected and does not affect crash-safety: chunks are already durable in the
+// local log before Flush is ever called, and the dispatcher mirrors them to the
+// remote in the background. Callers needing a definitive remote-durable barrier
+// (ManualSync mode) use SyncNow, which blocks on the exclusive gate.
 func (m *Syncer) Flush(ctx context.Context, payloadID string) (*block.FlushResult, error) {
 	if err := m.checkReady(ctx); err != nil {
 		return nil, err
@@ -480,20 +529,25 @@ func (m *Syncer) Flush(ctx context.Context, payloadID string) (*block.FlushResul
 	if m.remoteStore == nil || !m.IsRemoteHealthy() {
 		return &block.FlushResult{Finalized: false}, nil
 	}
-	// Serialize the explicit mirror against the periodic uploader's
-	// tick body. Both paths take the uploading atomic gate; whichever
-	// holds it runs and the other observes Finalized=false.
+	// Serialize the explicit mirror against any other explicit drain and against
+	// the continuous upload dispatcher. The gate is taken non-blocking: if
+	// another explicit drain holds it, or dispatcher uploads are in flight, this
+	// returns Finalized=false rather than waiting.
 	//
-	// #670: the contention branch returns Finalized=false WITHOUT
-	// waiting for the in-flight pass to complete. This is intentional —
-	// blocking the explicit caller until the periodic uploader's tick
-	// finishes could span minutes of remote I/O and translate into
-	// protocol-client D-state. Callers MUST NOT spin-retry: see godoc
-	// above and the Flusher.Flush contract in pkg/block.
-	if !m.uploading.CompareAndSwap(false, true) {
+	// #670: the contention branch returns Finalized=false WITHOUT waiting. This
+	// is intentional — blocking the explicit caller until concurrent uploads
+	// finish could span seconds of remote I/O and translate into protocol-client
+	// D-state. Callers MUST NOT spin-retry: see godoc above and the
+	// Flusher.Flush contract in pkg/block.
+	m.ensureGate()
+	ok, err := m.gate.acquireExclusive(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
 		return &block.FlushResult{Finalized: false}, nil
 	}
-	defer m.uploading.Store(false)
+	defer m.gate.releaseExclusive()
 
 	if err := m.mirrorOnce(ctx); err != nil {
 		return nil, err
@@ -504,7 +558,8 @@ func (m *Syncer) Flush(ctx context.Context, payloadID string) (*block.FlushResul
 // mirrorOnce performs a single mirror-loop pass: every CAS hash
 // present locally but not yet marked synced is read out of the local
 // store, written to remote, then MarkSynced'd. Caller MUST hold the
-// uploading atomic gate.
+// upload gate's exclusive lock (acquireExclusive) so the pass does not
+// race the continuous dispatcher.
 //
 // Ordering is Put-then-Mark. A crash between remote.Put and MarkSynced
 // is safe because remote.Put is idempotent on (hash, identical bytes)
@@ -543,10 +598,6 @@ func (m *Syncer) mirrorOnce(ctx context.Context) error {
 		snapshot = append(snapshot, h)
 	}
 	m.pendingMu.Unlock()
-
-	if mx := m.dataplaneMetrics(); mx != nil {
-		mx.SetUploadQueueDepth(len(snapshot))
-	}
 
 	// Tracks whether at least one pending hash was retained-but-not-mirrored
 	// because its local bytes were gone. The pass continues draining the
@@ -687,6 +738,7 @@ func (m *Syncer) mirrorChunk(ctx context.Context, hashStore metadata.SyncedHashS
 		m.unsyncedBytes.Add(-size)
 	}
 	m.pendingMu.Unlock()
+	m.publishQueueDepth()
 	m.completedSyncs.Add(1)
 	return nil
 }
@@ -959,8 +1011,9 @@ func (m *Syncer) startHealthMonitor(ctx context.Context) {
 	m.healthMonitor.Start(ctx)
 }
 
-// startPeriodicUploader launches the periodic uploader goroutine if not already running.
-// Must be called with m.mu held.
+// startPeriodicUploader launches the continuous upload dispatcher, the
+// maintenance loop, and (in adaptive mode) the goodput controller, if not
+// already running. Must be called with m.mu held.
 func (m *Syncer) startPeriodicUploader(ctx context.Context) {
 	if m.periodicStarted {
 		return
@@ -980,7 +1033,11 @@ func (m *Syncer) startPeriodicUploader(ctx context.Context) {
 	if interval <= 0 {
 		interval = 2 * time.Second
 	}
-	go m.periodicUploader(ctx, interval)
+	// The dispatcher sustains upload concurrency in steady state (#1432); the
+	// maintenance loop handles the slow housekeeping (FileBlock metadata flush,
+	// drift reconcile, failed-upload requeue) the dispatcher does not.
+	go m.uploadDispatcher(ctx)
+	go m.maintenanceLoop(ctx, interval)
 
 	// Adaptive mode only: launch the goodput controller that resizes the
 	// upload window to saturate the uplink (#1407). Pinned --parallel-uploads
@@ -1077,25 +1134,21 @@ func (m *Syncer) adaptiveUploadTick(interval time.Duration) (window int, goodput
 // mirror loop. Callers such as the REST /drain-uploads endpoint and
 // Close() rely on this signal.
 //
-// Serializes against the periodic uploader via the m.uploading atomic
-// gate so the explicit drain and the periodic tick never both run the
-// mirror loop concurrently.
+// Serializes against the continuous upload dispatcher (and any other explicit
+// drain) via the upload gate, so the explicit mirror pass runs alone over a
+// clean pending set.
 func (m *Syncer) SyncNow(ctx context.Context) error {
 	if m.remoteStore == nil {
 		return nil
 	}
-	if !m.uploading.CompareAndSwap(false, true) {
-		ticker := time.NewTicker(10 * time.Millisecond)
-		defer ticker.Stop()
-		for !m.uploading.CompareAndSwap(false, true) {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-ticker.C:
-			}
-		}
+	// Take the explicit-drain lock, blocking (ctx-aware) for any other explicit
+	// drain to finish and for the continuous dispatcher's in-flight uploads to
+	// quiesce, so mirrorOnce runs alone over a clean pending set.
+	m.ensureGate()
+	if _, err := m.gate.acquireExclusive(ctx, true); err != nil {
+		return err
 	}
-	defer m.uploading.Store(false)
+	defer m.gate.releaseExclusive()
 
 	// Flush queued FileBlock metadata to the store so the mirror loop
 	// picks up recently rolled-up chunks.
@@ -1170,86 +1223,6 @@ type syncingEnumerator interface {
 	EnumerateSyncingBlocks(ctx context.Context) ([]*block.FileBlock, error)
 }
 
-// periodicUploader runs every interval, scanning for blocks to upload.
-// Uses an atomic guard to prevent overlapping ticks: if the previous upload
-// batch is still running when the ticker fires, the tick is skipped. This
-// prevents unbounded memory growth when uploads take longer than the interval
-// (e.g., 8 blocks x 2-3s S3 upload = 16-24s, but interval is only 2s).
-func (m *Syncer) periodicUploader(ctx context.Context, interval time.Duration) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	logger.Info("Periodic syncer started", "interval", interval, "upload_delay", m.config.UploadDelay)
-
-	// Drift reconcile: every ~10 minutes re-seed the pending set from disk
-	// to catch any chunk that bypassed the onChunkComplete chokepoint
-	// (defense-in-depth — the steady-state path keeps the set current via
-	// addPendingHash, so this is a safety net, not the primary mechanism).
-	reconcileEvery := int(((10 * time.Minute) / interval))
-	if reconcileEvery < 1 {
-		reconcileEvery = 1
-	}
-	tick := 0
-
-	for {
-		select {
-		case <-ticker.C:
-			if !m.canProcess(ctx) {
-				logger.Info("Periodic syncer: canProcess=false, exiting")
-				return
-			}
-			tick++
-			if tick%reconcileEvery == 0 {
-				if _, err := m.seedPendingFromDisk(ctx); err != nil {
-					logger.Warn("Periodic syncer: drift reconcile failed", "error", err)
-				}
-			}
-			m.runDrainPass(ctx)
-		case <-m.wake:
-			// A freshly rolled-up chunk signalled work (#1407). Drain now
-			// instead of idling up to UploadInterval, so the mirror pipelines
-			// with the rollup of later chunks. The wake is buffered length 1, so
-			// a burst of chunk completions collapses into a single queued wake;
-			// the follow-up pass snapshots the whole pending set at once.
-			if !m.canProcess(ctx) {
-				logger.Info("Periodic syncer: canProcess=false, exiting")
-				return
-			}
-			m.runDrainPass(ctx)
-		case <-m.stopCh:
-			logger.Info("Periodic syncer: stopCh received, exiting")
-			return
-		case <-ctx.Done():
-			logger.Info("Periodic syncer: context cancelled, exiting")
-			return
-		}
-	}
-}
-
-// runDrainPass runs one mirror pass under the uploading atomic gate. It is the
-// shared body of the periodic ticker and the wake signal (#1407). The ticker
-// and wake cases run in the same periodicUploader goroutine, so they already
-// cannot overlap each other; the gate's job is to serialize this pass against
-// the OTHER mirror entrypoints — Flush, SyncNow, and uploadBlock — which run
-// from caller goroutines and take the same gate. A pass that loses the gate is
-// a no-op: the pending set is retained for the next tick/wake. The circuit
-// breaker additionally skips uploads while the remote is unhealthy.
-func (m *Syncer) runDrainPass(ctx context.Context) {
-	if !m.uploading.CompareAndSwap(false, true) {
-		logger.Debug("Periodic syncer: previous pass still running, skipping")
-		return
-	}
-	defer m.uploading.Store(false)
-	// Circuit breaker: skip uploads when remote store is unhealthy.
-	if !m.IsRemoteHealthy() {
-		logger.Warn("Periodic syncer: remote unhealthy, skipping upload cycle",
-			"outage_duration", m.RemoteOutageDuration(),
-			"hint", "check S3 credentials, endpoint, and bucket configuration")
-		return
-	}
-	m.syncLocalBlocks(ctx)
-}
-
 // Close shuts down the syncer and waits for pending uploads.
 func (m *Syncer) Close() error {
 	m.mu.Lock()
@@ -1321,6 +1294,7 @@ func (m *Syncer) SetRemoteStore(ctx context.Context, remoteStore remote.RemoteSt
 	}
 
 	m.remoteStore = remoteStore
+	m.hasRemote.Store(true)
 	m.local.SetEvictionEnabled(true)
 
 	m.startHealthMonitor(ctx)

--- a/pkg/block/engine/upload.go
+++ b/pkg/block/engine/upload.go
@@ -5,44 +5,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block"
 )
-
-// syncLocalBlocks runs one mirror-loop pass for the periodic uploader
-// tick body. The mirror-loop helper is shared with explicit Flush
-// every CAS hash present locally but not yet marked synced is Put to
-// remote and MarkSynced, with Put-then-Mark ordering for crash safety.
-//
-// Caller (periodicUploader) MUST hold the uploading atomic gate.
-func (m *Syncer) syncLocalBlocks(ctx context.Context) {
-	if m.remoteStore == nil {
-		return
-	}
-	// Flush queued FileBlock metadata so subsequent passes see any
-	// recently rolled-up chunks.
-	m.local.SyncFileBlocks(ctx)
-
-	if err := m.mirrorOnce(ctx); err != nil {
-		switch {
-		case ctx.Err() != nil || errors.Is(err, ErrClosed):
-			// Shutdown paths (context cancelled, syncer closed) are
-			// expected during graceful Close and stay at Debug.
-			logger.Debug("Periodic mirror pass aborted during shutdown", "error", err)
-		case errors.Is(err, block.ErrChunkLostBeforeMirror):
-			// One or more pending hashes had no local bytes and were
-			// retained for the next tick. mirrorOnce already drained every
-			// healthy hash this pass, so this is non-fatal — swallow it as
-			// an expected retry condition rather than a failure.
-			logger.Info("Periodic mirror pass retained chunk(s) with missing local bytes for retry", "error", err)
-		default:
-			// A genuine remote upload failure (network, auth, quota, S3
-			// 5xx, local bitrot) is unexpected: log at Warn so it is
-			// visible before the next health-check interval.
-			logger.Warn("Periodic mirror pass failed", "error", err)
-		}
-	}
-}
 
 // uploadBlock uploads a single block from the local store to the
 // remote store. Wired into the SyncQueue's per-block upload worker
@@ -61,10 +25,15 @@ func (m *Syncer) uploadBlock(ctx context.Context, payloadID string, blockIdx uin
 	// Drive the mirror loop opportunistically — any locally present
 	// chunk for this payloadID that has not been marked synced will be
 	// caught up. The blockIdx hint is ignored under hash-keyed CAS.
-	if !m.uploading.CompareAndSwap(false, true) {
+	m.ensureGate()
+	ok, err := m.gate.acquireExclusive(ctx, false)
+	if err != nil {
+		return err
+	}
+	if !ok {
 		return nil
 	}
-	defer m.uploading.Store(false)
+	defer m.gate.releaseExclusive()
 	if err := m.mirrorOnce(ctx); err != nil {
 		if errors.Is(err, block.ErrChunkLostBeforeMirror) {
 			// Opportunistic drive-by drain: a retained-for-retry hash is

--- a/pkg/block/engine/upload_concurrency_test.go
+++ b/pkg/block/engine/upload_concurrency_test.go
@@ -1,0 +1,260 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/local/fs"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+	"lukechampine.com/blake3"
+)
+
+// blockingRemote wraps a real in-memory remote and makes every Put park until
+// the test releases it, recording the high-water mark of concurrent in-flight
+// Puts. It lets a deterministic test observe how many uploads the continuous
+// dispatcher keeps in flight at once — without any real network or timing.
+type blockingRemote struct {
+	remote.RemoteStore
+	release     chan struct{} // closed to let all parked Puts return
+	releaseOnce sync.Once
+	inflight    atomic.Int64
+	peak        atomic.Int64
+	started     atomic.Int64 // total Puts that have parked
+}
+
+func newBlockingRemote() *blockingRemote {
+	return &blockingRemote{
+		RemoteStore: remotememory.New(),
+		release:     make(chan struct{}),
+	}
+}
+
+// releaseAll unblocks every parked Put. Idempotent.
+func (b *blockingRemote) releaseAll() {
+	b.releaseOnce.Do(func() { close(b.release) })
+}
+
+func (b *blockingRemote) Put(ctx context.Context, hash block.ContentHash, data []byte) error {
+	cur := b.inflight.Add(1)
+	b.started.Add(1)
+	for {
+		p := b.peak.Load()
+		if cur <= p || b.peak.CompareAndSwap(p, cur) {
+			break
+		}
+	}
+	defer b.inflight.Add(-1)
+
+	// Park until the test releases the batch (or the context is cancelled), so
+	// many Puts pile up concurrently and the peak reflects the real window.
+	select {
+	case <-b.release:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return b.RemoteStore.Put(ctx, hash, data)
+}
+
+// newBlockingUploadEngine builds a started engine.Store whose remote parks
+// every Put, with the upload window pinned to `window` (no adaptive controller).
+// Returns the store, its local store (to feed chunks) and the blocking remote.
+func newBlockingUploadEngine(t *testing.T, window int) (*Store, *fs.FSStore, *blockingRemote) {
+	t.Helper()
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	localStore, err := fs.NewWithOptions(t.TempDir(), 1024*1024*1024, ms, fs.FSStoreOptions{
+		MaxLogBytes:     256 * 1024 * 1024,
+		RollupWorkers:   2,
+		StabilizationMS: 5,
+		RollupStore:     ms,
+		SyncedHashStore: ms,
+	})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+
+	rs := newBlockingRemote()
+	cfg := DefaultConfig()
+	cfg.ParallelUploads = window
+	syncer := NewSyncer(localStore, rs, ms, cfg)
+	bs, err := New(BlockStoreConfig{
+		Local:           localStore,
+		Remote:          rs,
+		Syncer:          syncer,
+		FileBlockStore:  ms,
+		SyncedHashStore: ms,
+		ReadBufferBytes: 64 * 1024 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("engine.New: %v", err)
+	}
+	if err := bs.Start(ctx); err != nil {
+		t.Fatalf("engine.Start: %v", err)
+	}
+	t.Cleanup(func() {
+		rs.releaseAll() // unblock anything still parked so Close can drain
+		_ = bs.Close()
+	})
+	return bs, localStore, rs
+}
+
+// TestUploadDispatcher_SustainsConcurrencyOnShallowFeed is the #1432 behavioural
+// guard. Chunks are fed into the pending set ONE AT A TIME (a trickle / shallow
+// queue) while every remote Put parks. The pre-#1432 periodic uploader drained
+// in snapshot-then-g.Wait() passes, so a trickle feed kept only a single Put in
+// flight (one TCP stream → ~25 Mbit/s). The continuous dispatcher must instead
+// fill the upload window: with parked Puts the in-flight count must climb to the
+// pinned window, proving inflight tracks the window rather than collapsing to 1.
+func TestUploadDispatcher_SustainsConcurrencyOnShallowFeed(t *testing.T) {
+	ctx := context.Background()
+	// Pin the upload window so the test isolates the dispatcher's behaviour from
+	// the adaptive controller (exercised separately in upload_adaptive_test):
+	// with a fixed window of `want`, the dispatcher must drive in-flight Puts up
+	// to exactly that window on a shallow feed.
+	const want = 24
+	bs, localStore, rs := newBlockingUploadEngine(t, want)
+
+	// Feed comfortably more chunks than the window so the dispatcher always has
+	// work to fill it.
+	total := want * 3
+
+	// Trickle the chunks in one at a time, each in its own goroutine-free step,
+	// to emulate a shallow queue rather than a deep backlog burst.
+	for i := 0; i < total; i++ {
+		data := []byte(fmt.Sprintf("upload-concurrency-chunk-%d-padding-for-distinct-bytes", i))
+		h := block.ContentHash(blake3.Sum256(data))
+		if err := localStore.StoreChunk(ctx, h, data); err != nil {
+			t.Fatalf("StoreChunk %d: %v", i, err)
+		}
+		// A brief yield between feeds keeps the queue shallow: without the
+		// dispatcher, only ~1 Put would ever be in flight at a time.
+		time.Sleep(time.Millisecond)
+	}
+
+	// The dispatcher keeps Puts in flight without a barrier, so concurrency must
+	// climb to the window. Poll the parked-Put count.
+	deadline := time.Now().Add(5 * time.Second)
+	for rs.inflight.Load() < int64(want) {
+		if time.Now().After(deadline) {
+			t.Fatalf("dispatcher did not sustain concurrency: peak in-flight Puts = %d, want >= %d (collapsed toward single-stream)",
+				rs.peak.Load(), want)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	if peak := rs.peak.Load(); peak < int64(want) {
+		t.Fatalf("peak concurrent Puts = %d, want >= %d", peak, want)
+	}
+	t.Logf("sustained %d concurrent in-flight Puts on a shallow trickle feed (window=%d)",
+		rs.peak.Load(), want)
+
+	// Release the batch and let the pipeline drain cleanly.
+	rs.releaseAll()
+
+	drainCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := bs.DrainAllUploads(drainCtx); err != nil {
+		t.Fatalf("DrainAllUploads: %v", err)
+	}
+}
+
+// TestFlush_NonManualSync_SoftFailsDuringUploadsThenFinalizes pins the
+// production (non-ManualSync) Flush durability contract under the continuous
+// dispatcher (#1432, #670). While dispatcher uploads are in flight, the
+// non-blocking Flush must soft-fail (Finalized=false) rather than block — the
+// upload gate is busy. Once the pipeline drains, Flush must finalize. This is
+// the only test that exercises Flush with the dispatcher running (the mirror-
+// loop scenarios all use ManualSync).
+func TestFlush_NonManualSync_SoftFailsDuringUploadsThenFinalizes(t *testing.T) {
+	ctx := context.Background()
+	bs, localStore, rs := newBlockingUploadEngine(t, 8)
+
+	const payloadID = "flush-contract"
+	for i := 0; i < 6; i++ {
+		data := []byte(fmt.Sprintf("flush-contract-chunk-%d-distinct-padding", i))
+		h := block.ContentHash(blake3.Sum256(data))
+		if err := localStore.StoreChunk(ctx, h, data); err != nil {
+			t.Fatalf("StoreChunk %d: %v", i, err)
+		}
+	}
+
+	// Wait until the dispatcher has at least one Put parked (gate.active > 0).
+	deadline := time.Now().Add(5 * time.Second)
+	for rs.inflight.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("no upload became in-flight")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// Flush must soft-fail (not block) while uploads are in flight.
+	res, err := bs.Flush(ctx, payloadID)
+	if err != nil {
+		t.Fatalf("Flush during uploads: unexpected error %v", err)
+	}
+	if res == nil || res.Finalized {
+		t.Fatalf("Flush during in-flight uploads = %+v; want Finalized=false (soft-fail per #670)", res)
+	}
+
+	// Drain the pipeline, then Flush must finalize.
+	rs.releaseAll()
+	drainCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := bs.DrainAllUploads(drainCtx); err != nil {
+		t.Fatalf("DrainAllUploads: %v", err)
+	}
+
+	// Poll: once the dispatcher is idle (gate.active==0, nothing pending), the
+	// non-blocking Flush acquires the gate and finalizes.
+	deadline = time.Now().Add(5 * time.Second)
+	for {
+		res, err := bs.Flush(ctx, payloadID)
+		if err != nil {
+			t.Fatalf("Flush after drain: %v", err)
+		}
+		if res != nil && res.Finalized {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("Flush never finalized after the pipeline drained")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestUploadDispatcher_SingleStreamWouldFailGuard documents, via a sanity check,
+// that the fake remote actually serializes when only one Put is allowed at a
+// time — guarding against a false-positive where the peak counter is broken.
+func TestUploadDispatcher_blockingRemoteCountsConcurrency(t *testing.T) {
+	rs := newBlockingRemote()
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	const n = 4
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			data := []byte(fmt.Sprintf("probe-%d", i))
+			_ = rs.Put(ctx, block.ContentHash(blake3.Sum256(data)), data)
+		}(i)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for rs.started.Load() < n {
+		if time.Now().After(deadline) {
+			t.Fatalf("only %d/%d Puts parked", rs.started.Load(), n)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if peak := rs.peak.Load(); peak < n {
+		t.Fatalf("blockingRemote peak=%d, want %d (counter broken)", peak, n)
+	}
+	rs.releaseAll()
+	wg.Wait()
+}


### PR DESCRIPTION
## Problem

The S3 upload path uploaded at `inflight=1` in steady state — a single TCP stream to Cubbit, which is ~25 Mbit/s for everyone (the reporter's exact number). It only reached the full window when a *deep* backlog already existed.

Root cause: the periodic uploader drained in per-pass batches — `snapshot pending → dispatch → g.Wait() → return`. During steady streaming the queue stays shallow (held down by unsynced-bytes backpressure), so each pass mirrored ~one chunk at a time. The explicit `drain-uploads` path (one big `mirrorOnce`) reaches `inflight=61`, proving dispatch *can* parallelize — the continuous path just never did.

## Fix

Replace the snapshot+barrier periodic path with a **continuous worker-pool dispatcher**: persistent workers claim the next pending hash the instant a slot frees, with no barrier between passes, so in-flight uploads track the adaptive window (#1407) during streaming instead of collapsing to 1.

- A new `uploadGate` serializes the explicit drain path (`Flush`/`SyncNow`/`uploadBlock`) against the continuous dispatcher, so the same CAS chunk is never double-uploaded and `mirrorOnce`'s snapshot/error semantics are unperturbed.
- `maintenanceLoop` keeps the slow housekeeping the dispatcher does not (FileBlock-metadata flush, drift reconcile, requeue of failed uploads).
- The stale `datapath_upload_queue_depth` gauge (it froze at a per-pass snapshot count) is now updated by the pending-set mutators, so it reflects real-time depth.

## Benchmark (SCW VM → Cubbit, 17.8 ms RTT)

| Path | Throughput |
|---|---|
| single stream (inflight=1) | **25 Mbit/s** ← reporter's number |
| parallel-PUT conc16 | 197 |
| parallel-PUT conc64 | **337** |
| rclone multipart conc64 | 402 (ceiling) |

## Invariants preserved

Put-then-MarkSynced ordering, rehash-before-upload (`ErrCASContentMismatch`), `lostBeforeMirror` retry semantics, and the #1407 adaptive-window feedback (`uploadedBytesWindow`/`uploadErrWindow`/`TakePeak`) are all intact. `ManualSync` mode is unchanged (no dispatcher; explicit Flush drives the mirror).

## Tests

New deterministic test `TestUploadDispatcher_SustainsConcurrencyOnShallowFeed`: a fake remote parks every `Put` and records peak concurrency; on a one-at-a-time trickle feed the dispatcher drives in-flight Puts up to the pinned window (24), not 1. `TestFlush_NonManualSync_SoftFailsDuringUploadsThenFinalizes` pins the production Flush contract (#670) with the dispatcher running. Full `pkg/block/...` suite passes with `-race`.

The benchmark + root-cause analysis is included at `.planning/2026-06-29-1432-upload-perf-plan.md`.

Refs #1432