### PR TITLE
test(e2e): fix control-plane CLI/API drift surfaced by e2e revival

### DIFF
--- a/pkg/apiclient/errors.go
+++ b/pkg/apiclient/errors.go
@@ -2,6 +2,8 @@ package apiclient
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 )
 
 // APIError represents an RFC 7807 problem+json error response from the API.
@@ -16,19 +18,42 @@ type APIError struct {
 	Code   string `json:"code,omitempty"`
 	Hint   string `json:"hint,omitempty"`
 
+	// Errors carries per-field validation messages (field -> reason) for 422
+	// responses. Without it, callers only see the generic Detail ("One or more
+	// settings are outside valid range") and lose which field/value was wrong.
+	Errors map[string]string `json:"errors,omitempty"`
+
 	// StatusCode is the HTTP status code, authoritative for classification.
 	StatusCode int `json:"-"`
 }
 
 // Error implements the error interface.
 func (e *APIError) Error() string {
-	if e.Detail != "" {
-		return e.Detail
+	base := e.Detail
+	if base == "" {
+		base = e.Title
 	}
-	if e.Title != "" {
-		return e.Title
+	if base == "" {
+		base = fmt.Sprintf("request failed with status %d", e.StatusCode)
 	}
-	return fmt.Sprintf("request failed with status %d", e.StatusCode)
+	if len(e.Errors) > 0 {
+		return base + " (" + e.fieldErrors() + ")"
+	}
+	return base
+}
+
+// fieldErrors renders the per-field validation messages in a stable order.
+func (e *APIError) fieldErrors() string {
+	keys := make([]string, 0, len(e.Errors))
+	for k := range e.Errors {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+": "+e.Errors[k])
+	}
+	return strings.Join(parts, "; ")
 }
 
 // IsAuthError returns true if this is an authentication/authorization error.

--- a/pkg/apiclient/errors_test.go
+++ b/pkg/apiclient/errors_test.go
@@ -1,0 +1,65 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestAPIError_Error_RendersFieldErrors(t *testing.T) {
+	t.Run("with field errors", func(t *testing.T) {
+		e := &APIError{
+			Detail:     "One or more settings are outside valid range",
+			StatusCode: 422,
+			Errors: map[string]string{
+				"blocked_operations": "unknown NFS operation: INVALID_OP",
+				"portmapper_port":    "must be >= 1",
+			},
+		}
+		got := e.Error()
+		// Base detail is preserved.
+		if !strings.Contains(got, "One or more settings are outside valid range") {
+			t.Fatalf("missing base detail: %q", got)
+		}
+		// Both field messages are surfaced, in stable (sorted) order.
+		if !strings.Contains(got, "blocked_operations: unknown NFS operation: INVALID_OP") {
+			t.Fatalf("missing blocked_operations field error: %q", got)
+		}
+		if !strings.Contains(got, "portmapper_port: must be >= 1") {
+			t.Fatalf("missing portmapper_port field error: %q", got)
+		}
+		if idx1, idx2 := strings.Index(got, "blocked_operations"), strings.Index(got, "portmapper_port"); idx1 > idx2 {
+			t.Fatalf("field errors not in sorted order: %q", got)
+		}
+	})
+
+	t.Run("without field errors falls back to detail", func(t *testing.T) {
+		e := &APIError{Detail: "boom", StatusCode: 400}
+		if got := e.Error(); got != "boom" {
+			t.Fatalf("want %q, got %q", "boom", got)
+		}
+	})
+
+	t.Run("empty falls back to title then status", func(t *testing.T) {
+		if got := (&APIError{Title: "Not Found", StatusCode: 404}).Error(); got != "Not Found" {
+			t.Fatalf("want title, got %q", got)
+		}
+		if got := (&APIError{StatusCode: 503}).Error(); !strings.Contains(got, "503") {
+			t.Fatalf("want status in message, got %q", got)
+		}
+	})
+
+	t.Run("errors map decodes from problem+json", func(t *testing.T) {
+		body := `{"title":"Validation Failed","detail":"bad","errors":{"x":"too big"}}`
+		var e APIError
+		if err := json.Unmarshal([]byte(body), &e); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if e.Errors["x"] != "too big" {
+			t.Fatalf("errors map not decoded: %+v", e.Errors)
+		}
+		if !strings.Contains(e.Error(), "x: too big") {
+			t.Fatalf("decoded field error not rendered: %q", e.Error())
+		}
+	})
+}

--- a/test/e2e/block_stores_test.go
+++ b/test/e2e/block_stores_test.go
@@ -245,7 +245,9 @@ func TestBlockStoresCRUD(t *testing.T) {
 			_ = cli.DeleteRemoteBlockStore(storeName)
 		})
 
-		s3Config := `{"bucket":"test-bucket","region":"us-east-1"}`
+		// An S3 remote store requires bucket + credentials; supply dummy keys so
+		// config validation passes (no real S3 connection is made here).
+		s3Config := `{"bucket":"test-bucket","region":"us-east-1","access_key_id":"test","secret_access_key":"test"}`
 		store, err := cli.CreateRemoteBlockStore(storeName, "s3",
 			helpers.WithBlockRawConfig(s3Config))
 		require.NoError(t, err, "Should create S3 remote block store")

--- a/test/e2e/controlplane_v2_test.go
+++ b/test/e2e/controlplane_v2_test.go
@@ -193,24 +193,14 @@ func TestControlPlaneV2_PatchVsPut(t *testing.T) {
 		// Reset first
 		helpers.ResetNFSSettings(t, client)
 
-		// PUT with all fields explicitly set
-		putReq := &apiclient.NFSAdapterSettingsResponse{
-			MinVersion:              defaults.MinVersion,
-			MaxVersion:              defaults.MaxVersion,
-			LeaseTime:               200,
-			GracePeriod:             defaults.GracePeriod,
-			DelegationRecallTimeout: defaults.DelegationRecallTimeout,
-			CallbackTimeout:         defaults.CallbackTimeout,
-			LeaseBreakTimeout:       defaults.LeaseBreakTimeout,
-			MaxConnections:          defaults.MaxConnections,
-			MaxClients:              defaults.MaxClients,
-			MaxCompoundOps:          defaults.MaxCompoundOps,
-			MaxReadSize:             defaults.MaxReadSize,
-			MaxWriteSize:            defaults.MaxWriteSize,
-			PreferredTransferSize:   defaults.PreferredTransferSize,
-			DelegationsEnabled:      false,
-			BlockedOperations:       defaults.BlockedOperations,
-		}
+		// PUT replaces every field, so start from the current (valid) settings
+		// and change only what this case asserts on. Hand-listing fields risks
+		// leaving a newly-added field at its zero value, which PUT validation
+		// then rejects as out of range.
+		putReqVal := *defaults
+		putReqVal.LeaseTime = 200
+		putReqVal.DelegationsEnabled = false
+		putReq := &putReqVal
 
 		result, err := client.UpdateNFSSettings(putReq)
 		require.NoError(t, err, "PUT should succeed")

--- a/test/e2e/helpers/cli.go
+++ b/test/e2e/helpers/cli.go
@@ -153,6 +153,11 @@ func (r *CLIRunner) getBinary() string {
 		return r.binary
 	}
 
+	// The build result lives in package-level state guarded by sync.Once, so it
+	// is safe to read concurrently from parallel subtests. Deliberately do NOT
+	// cache into r.binary here: getBinary is called from parallel goroutines and
+	// writing the shared field would be a data race (and buys nothing — the path
+	// is computed exactly once anyway).
 	dfsctlBuildOnce.Do(func() {
 		projectRoot := findProjectRootForCLI()
 		out := filepath.Join(projectRoot, "dfsctl")
@@ -167,12 +172,10 @@ func (r *CLIRunner) getBinary() string {
 
 	if dfsctlBuildErr != nil {
 		// Surface the build failure rather than silently using a stale binary.
-		r.binary = "dfsctl-build-failed"
-		return r.binary
+		return "dfsctl-build-failed"
 	}
 
-	r.binary = dfsctlBuildPath
-	return r.binary
+	return dfsctlBuildPath
 }
 
 // findProjectRootForCLI locates the project root by looking for go.mod.

--- a/test/e2e/helpers/cli.go
+++ b/test/e2e/helpers/cli.go
@@ -10,9 +10,19 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
+)
+
+// dfsctlBuild ensures the dfsctl binary is built exactly once from the source
+// in this checkout, regardless of how many CLIRunners (including parallel
+// subtests) ask for it.
+var (
+	dfsctlBuildOnce sync.Once
+	dfsctlBuildPath string
+	dfsctlBuildErr  error
 )
 
 // CLIRunner executes dfsctl commands with JSON output for reliable parsing.
@@ -130,36 +140,38 @@ func (r *CLIRunner) configHomeDir() (string, error) {
 	return filepath.Join(home, ".config"), nil
 }
 
-// getBinary returns the path to the dfsctl binary.
+// getBinary returns the path to the dfsctl binary, always built from the
+// source in this checkout.
+//
+// It deliberately does NOT honour a dfsctl found in PATH or a stale binary
+// left in the project root: a version-skewed dfsctl talking to the freshly
+// built server produces confusing failures (e.g. "unknown flag: --force"
+// after a CLI rename, or sparse API responses), which masquerade as product
+// bugs. Building from source guarantees the client matches the code under test.
 func (r *CLIRunner) getBinary() string {
 	if r.binary != "" {
 		return r.binary
 	}
 
-	// Check for dfsctl in PATH
-	if path, err := exec.LookPath("dfsctl"); err == nil {
-		r.binary = path
+	dfsctlBuildOnce.Do(func() {
+		projectRoot := findProjectRootForCLI()
+		out := filepath.Join(projectRoot, "dfsctl")
+		cmd := exec.Command("go", "build", "-o", out, "./cmd/dfsctl/")
+		cmd.Dir = projectRoot
+		if combined, err := cmd.CombinedOutput(); err != nil {
+			dfsctlBuildErr = fmt.Errorf("building dfsctl from source: %w\n%s", err, combined)
+			return
+		}
+		dfsctlBuildPath = out
+	})
+
+	if dfsctlBuildErr != nil {
+		// Surface the build failure rather than silently using a stale binary.
+		r.binary = "dfsctl-build-failed"
 		return r.binary
 	}
 
-	// Look in project root
-	projectRoot := findProjectRootForCLI()
-	localBinary := filepath.Join(projectRoot, "dfsctl")
-	if _, err := os.Stat(localBinary); err == nil {
-		r.binary = localBinary
-		return r.binary
-	}
-
-	// Build it
-	cmd := exec.Command("go", "build", "-o", localBinary, "./cmd/dfsctl/")
-	cmd.Dir = projectRoot
-	if _, err := cmd.CombinedOutput(); err != nil {
-		// Fall back to just "dfsctl" and let it fail later with better error
-		r.binary = "dfsctl"
-		return r.binary
-	}
-
-	r.binary = localBinary
+	r.binary = dfsctlBuildPath
 	return r.binary
 }
 

--- a/test/e2e/helpers/shares.go
+++ b/test/e2e/helpers/shares.go
@@ -139,21 +139,23 @@ func (r *CLIRunner) ListShares() ([]*Share, error) {
 }
 
 // GetShare retrieves a share by name.
-// Since there's no dedicated 'share get' command in the CLI, this lists all
-// shares and filters by name.
+//
+// It uses `share show`, which returns the full per-share detail (store IDs,
+// read-only, default permission). `share list` only renders resolved store
+// *names* for table display, so it cannot satisfy callers that assert on
+// store IDs or read-only state.
 func (r *CLIRunner) GetShare(name string) (*Share, error) {
-	shares, err := r.ListShares()
+	output, err := r.Run("share", "show", name)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, s := range shares {
-		if s.Name == name {
-			return s, nil
-		}
+	var share Share
+	if err := ParseJSONResponse(output, &share); err != nil {
+		return nil, err
 	}
 
-	return nil, fmt.Errorf("share not found: %s", name)
+	return &share, nil
 }
 
 // EditShare edits an existing share via the CLI.

--- a/test/e2e/snapshot/snapshot_cli_test.go
+++ b/test/e2e/snapshot/snapshot_cli_test.go
@@ -394,7 +394,7 @@ func TestCLI_Delete_RefusesWithoutYes(t *testing.T) {
 	seedReadyDurable(f, "/data", "snap-del-1")
 	srv := mountCLIServer(t, f)
 
-	res := runCLI(t, srv, "n\n", "share", "snapshot", "delete", "/data", "snap-del-1")
+	res := runCLI(t, srv, "n\n", "share", "snapshot", "remove", "/data", "snap-del-1")
 	if res.exitCode != 0 {
 		t.Fatalf("exit = %d, want 0\nstdout=%s\nstderr=%s", res.exitCode, res.stdout, res.stderr)
 	}
@@ -412,12 +412,12 @@ func TestCLI_Delete_YesFlag(t *testing.T) {
 	seedReadyDurable(f, "/data", "snap-del-2")
 	srv := mountCLIServer(t, f)
 
-	res := runCLI(t, srv, "", "share", "snapshot", "delete", "/data", "snap-del-2", "--yes")
+	res := runCLI(t, srv, "", "share", "snapshot", "remove", "/data", "snap-del-2", "--yes")
 	if res.exitCode != 0 {
 		t.Fatalf("exit = %d, want 0\nstdout=%s\nstderr=%s", res.exitCode, res.stdout, res.stderr)
 	}
-	if !strings.Contains(res.stdout, "deleted") {
-		t.Fatalf("stdout missing 'deleted' confirmation: %q", res.stdout)
+	if !strings.Contains(res.stdout, "removed") {
+		t.Fatalf("stdout missing 'removed' confirmation: %q", res.stdout)
 	}
 	// Subsequent list must not surface the snapshot.
 	listRes := runCLI(t, srv, "", "share", "snapshot", "list", "/data", "-o", "json")

--- a/test/e2e/users_test.go
+++ b/test/e2e/users_test.go
@@ -40,12 +40,19 @@ func TestUserCRUD(t *testing.T) {
 			_ = cli.DeleteUser(username)
 		})
 
+		// Groups must exist before a user can be assigned to them. "users" is
+		// seeded by default; "testers" is not, so create it first.
+		testersGroup := helpers.UniqueTestName("testers")
+		_, err := cli.CreateGroup(testersGroup)
+		require.NoError(t, err, "Should create testers group")
+		t.Cleanup(func() { _ = cli.DeleteGroup(testersGroup) })
+
 		// Create user with all fields
 		user, err := cli.CreateUser(username, password,
 			helpers.WithEmail(email),
 			helpers.WithRole("user"),
 			helpers.WithUID(uid),
-			helpers.WithGroups("users", "testers"),
+			helpers.WithGroups("users", testersGroup),
 			helpers.WithEnabled(true),
 		)
 		require.NoError(t, err, "Should create user successfully")


### PR DESCRIPTION
## What

The revived e2e suite (#1456 — first real run on develop) surfaced a cluster of
control-plane test failures. All were **harness/test drift or thin client gaps**,
not product regressions. Each fix targets the real behaviour.

### Fixes
- **Build `dfsctl` from source (harness).** `CLIRunner.getBinary` preferred a
  `dfsctl` found in `PATH`. A stale binary (pre `share delete --force` →
  `share remove --force` rename) made renamed flags surface as `unknown flag: --force`,
  and produced sparse/old API responses that looked like product bugs. Now always
  built once from this checkout's source (parallel-safe via `sync.Once`).
- **`GetShare` uses `share show`.** It read `share list`, which renders resolved
  store *names* (no IDs, no read-only) for table display. `share show` returns the
  full per-share detail the assertions need.
- **`APIError` surfaces field errors.** 422 problem+json responses carry a per-field
  `errors` map; the client dropped it, leaving only the generic
  `One or more settings are outside valid range`. Captured + rendered, so validation
  failures name the offending field/value (benefits every caller).
- **PUT settings test clones fetched settings.** Hand-listing fields left
  `portmapper_port` at 0 (below min) → spurious range rejection. Clone current
  settings and mutate only what the case asserts.
- **User test creates its group first** (`testers` isn't seeded).
- **S3 remote-store test supplies dummy credentials** (now required by config validation).

### Tests (all pass locally, e2e tag + docker)
`TestUserCRUD` · `TestBlockStoresCRUD` · `TestSharesCRUD` ·
`TestControlPlaneV2_PatchVsPut` · `TestControlPlaneV2_BlockedOperations` ·
`TestCLI_Delete_RefusesWithoutYes` · `TestCLI_Delete_YesFlag`

Part of the e2e backlog triage after revival; NFS/SMB/protocol clusters follow in
separate focused PRs.