### PR TITLE
fix(metadata): register runtime-created shares in the memory store (fixes trash over NFS/SMB)

### DIFF
--- a/pkg/metadata/store/memory/shares.go
+++ b/pkg/metadata/store/memory/shares.go
@@ -89,12 +89,23 @@ func (store *MemoryMetadataStore) CreateShare(ctx context.Context, share *metada
 	store.mu.Lock()
 	defer store.mu.Unlock()
 
-	if _, exists := store.shares[share.Name]; exists {
-		return &metadata.StoreError{
-			Code:    metadata.ErrAlreadyExists,
-			Message: "share already exists",
-			Path:    share.Name,
+	if existing, exists := store.shares[share.Name]; exists {
+		// A seeded entry (from CreateRootDirectory) is not a "real" share yet —
+		// finish it by recording the caller's options while keeping the root
+		// handle that the already-materialized root inode is keyed under. A
+		// non-seeded entry is a genuine duplicate.
+		if !existing.seeded {
+			return &metadata.StoreError{
+				Code:    metadata.ErrAlreadyExists,
+				Message: "share already exists",
+				Path:    share.Name,
+			}
 		}
+		store.shares[share.Name] = &shareData{
+			Share:      *share,
+			RootHandle: existing.RootHandle,
+		}
+		return nil
 	}
 
 	// Generate root handle
@@ -216,6 +227,19 @@ func (store *MemoryMetadataStore) CreateRootDirectory(
 		rootHandle = store.generateFileHandle(shareName, "/")
 	}
 	key := handleToKey(rootHandle)
+
+	// Seed the share registry so the share can be resolved by name. The runtime
+	// initialises a share's metadata via CreateRootDirectory (not CreateShare),
+	// so without this GetRootHandle/GetShareOptions return "share not found" for
+	// runtime shares. Idempotent: an existing entry (seeded or from CreateShare)
+	// is left untouched.
+	if _, ok := store.shares[shareName]; !ok {
+		store.shares[shareName] = &shareData{
+			Share:      metadata.Share{Name: shareName},
+			RootHandle: rootHandle,
+			seeded:     true,
+		}
+	}
 
 	// Check if root already exists - if so, just return success (idempotent)
 	if existingData, exists := store.files[key]; exists {

--- a/pkg/metadata/store/memory/shares_test.go
+++ b/pkg/metadata/store/memory/shares_test.go
@@ -1,6 +1,7 @@
 package memory_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
@@ -13,5 +14,83 @@ import (
 func TestBlockLayoutConformance(t *testing.T) {
 	storetest.RunBlockLayoutSuite(t, func(t *testing.T) metadata.Store {
 		return memory.NewMemoryMetadataStoreWithDefaults()
+	})
+}
+
+// TestSeededShareRegistration verifies that CreateRootDirectory alone (the path
+// the runtime uses — it never calls CreateShare) makes a share resolvable by
+// name, and that a later CreateShare "finishes" the seeded entry without
+// changing the root handle. Regression for the #recycle trash path returning
+// "share not found" (PR #1463).
+func TestSeededShareRegistration(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("CreateRootDirectory seeds by-name resolution", func(t *testing.T) {
+		store := memory.NewMemoryMetadataStoreWithDefaults()
+
+		root, err := store.CreateRootDirectory(ctx, "/export", &metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o755,
+		})
+		if err != nil {
+			t.Fatalf("CreateRootDirectory: %v", err)
+		}
+
+		// GetRootHandle must resolve the share without a prior CreateShare.
+		rh, err := store.GetRootHandle(ctx, "/export")
+		if err != nil {
+			t.Fatalf("GetRootHandle after CreateRootDirectory: %v", err)
+		}
+		if len(rh) == 0 {
+			t.Fatal("GetRootHandle returned an empty handle")
+		}
+
+		// GetShareOptions returns defaults (not "share not found") for a seeded share.
+		if _, err := store.GetShareOptions(ctx, "/export"); err != nil {
+			t.Fatalf("GetShareOptions after CreateRootDirectory: %v", err)
+		}
+
+		// The root file returned must match the handle GetRootHandle reports.
+		gotRoot, err := store.GetFile(ctx, rh)
+		if err != nil {
+			t.Fatalf("GetFile(rootHandle): %v", err)
+		}
+		if gotRoot.ID != root.ID {
+			t.Fatalf("root handle points to %s, want the created root %s", gotRoot.ID, root.ID)
+		}
+	})
+
+	t.Run("CreateShare finishes a seed without changing the root handle", func(t *testing.T) {
+		store := memory.NewMemoryMetadataStoreWithDefaults()
+
+		if _, err := store.CreateRootDirectory(ctx, "/export", &metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o755,
+		}); err != nil {
+			t.Fatalf("CreateRootDirectory: %v", err)
+		}
+		seedHandle, err := store.GetRootHandle(ctx, "/export")
+		if err != nil {
+			t.Fatalf("GetRootHandle (seed): %v", err)
+		}
+
+		// CreateShare on a seeded share must succeed (finish it), not error
+		// "already exists", and must keep the seed's root handle so the existing
+		// file tree stays reachable.
+		if err := store.CreateShare(ctx, &metadata.Share{Name: "/export"}); err != nil {
+			t.Fatalf("CreateShare finishing a seed: %v", err)
+		}
+		afterHandle, err := store.GetRootHandle(ctx, "/export")
+		if err != nil {
+			t.Fatalf("GetRootHandle (after CreateShare): %v", err)
+		}
+		if string(afterHandle) != string(seedHandle) {
+			t.Fatal("CreateShare changed the seeded root handle")
+		}
+
+		// A second CreateShare on a now-real share is a genuine duplicate.
+		if err := store.CreateShare(ctx, &metadata.Share{Name: "/export"}); err == nil {
+			t.Fatal("expected ErrAlreadyExists creating a non-seeded share twice")
+		}
 	})
 }

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -24,6 +24,15 @@ import (
 type shareData struct {
 	Share      metadata.Share
 	RootHandle metadata.FileHandle
+	// seeded is true when this entry was created by CreateRootDirectory (which
+	// records only the share name + root handle) rather than by a full
+	// CreateShare. A seeded entry lets GetRootHandle/GetShareOptions resolve a
+	// runtime-created share by name (the runtime calls CreateRootDirectory, not
+	// CreateShare), and is later "finished" by CreateShare/UpdateShareOptions.
+	// This mirrors the SQLite backend, where a share exists once its root inode
+	// does. Without it, by-name lookups (e.g. the #recycle trash path) fail with
+	// "share not found" for every runtime-created share.
+	seeded bool
 }
 
 type fileData struct {

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -679,12 +679,21 @@ func (tx *memoryTransaction) CreateShare(ctx context.Context, share *metadata.Sh
 		return err
 	}
 
-	if _, exists := tx.store.shares[share.Name]; exists {
-		return &metadata.StoreError{
-			Code:    metadata.ErrAlreadyExists,
-			Message: "share already exists",
-			Path:    share.Name,
+	if existing, exists := tx.store.shares[share.Name]; exists {
+		// Finish a seeded entry (from CreateRootDirectory) rather than rejecting
+		// it; a non-seeded entry is a genuine duplicate. See store-level CreateShare.
+		if !existing.seeded {
+			return &metadata.StoreError{
+				Code:    metadata.ErrAlreadyExists,
+				Message: "share already exists",
+				Path:    share.Name,
+			}
 		}
+		tx.store.shares[share.Name] = &shareData{
+			Share:      *share,
+			RootHandle: existing.RootHandle,
+		}
+		return nil
 	}
 
 	rootHandle := tx.store.generateFileHandle(share.Name, "/")
@@ -783,9 +792,25 @@ func (tx *memoryTransaction) CreateRootDirectory(ctx context.Context, shareName 
 		}
 	}
 
-	// Generate deterministic handle for root directory based on share name
-	rootHandle := tx.store.generateFileHandle(shareName, "/")
+	// Reuse the share's pre-assigned RootHandle if present (see the store-level
+	// CreateRootDirectory), otherwise generate a fresh one.
+	var rootHandle metadata.FileHandle
+	if sd, ok := tx.store.shares[shareName]; ok && len(sd.RootHandle) > 0 {
+		rootHandle = sd.RootHandle
+	} else {
+		rootHandle = tx.store.generateFileHandle(shareName, "/")
+	}
 	key := handleToKey(rootHandle)
+
+	// Seed the share registry so the share resolves by name (see store-level
+	// CreateRootDirectory). Idempotent.
+	if _, ok := tx.store.shares[shareName]; !ok {
+		tx.store.shares[shareName] = &shareData{
+			Share:      metadata.Share{Name: shareName},
+			RootHandle: rootHandle,
+			seeded:     true,
+		}
+	}
 
 	// Check if root already exists - if so, just return success (idempotent)
 	if existingData, exists := tx.store.files[key]; exists {


### PR DESCRIPTION
## Problem

The revived e2e suite surfaced `TestNFSTrashRecycleAndRestore` /
`TestSMBTrashRecycleAndRestore` failing: a `REMOVE` on a trash-enabled share
returned **"share not found" (NFS3ERR_NOENT)** even though the file had just been
written successfully.

## Root cause

The runtime initialises a share's metadata via `CreateRootDirectory`, which
materializes the root inode but **never recorded a `store.shares` entry** — that
was only done by `CreateShare`, which the runtime does not call. So the memory
backend's `GetRootHandle` / `GetShareOptions` returned "share not found" for
every runtime-created share. Normal CRUD survives because it routes by file
handle; the `#recycle` path (`recycleNode → GetRootHandle(shareName)`) resolves
the share **by name**, so it broke. The root handle uses a random UUID and can't
be recomputed — it must be recorded.

The SQLite backend doesn't have this bug: its `CreateRootDirectory` upserts the
shares row, so "a share exists once its root inode exists". The memory backend
was the outlier.

## Fix

`CreateRootDirectory` now **seeds** a `store.shares` entry (share name + root
handle), matching SQLite. A later `CreateShare` **finishes** the seeded entry
with the caller's options instead of rejecting it as a duplicate, preserving the
`CreateRootDirectory → CreateShare` ordering used by tests. Applied to both the
store-level and transaction-level methods (the recycle `Move` runs in a tx).

## Validation

- `pkg/metadata/...` unit + conformance suites pass.
- `TestNFSTrashRecycleAndRestore` and `TestSMBTrashRecycleAndRestore` pass on a
  real Linux kernel mount (NFSv3 + SMB).