### PR TITLE
test(e2e): adapt NFS/SMB tests to the squash-default + per-share permission model

### DIFF
--- a/test/e2e/framework/mount.go
+++ b/test/e2e/framework/mount.go
@@ -257,117 +257,70 @@ func DefaultSMBCredentials() SMBCredentials {
 	}
 }
 
-// MountSMB mounts an SMB share and returns the mount info.
-func MountSMB(t *testing.T, port int, creds SMBCredentials) *Mount {
-	t.Helper()
-
-	// Give the SMB server a moment to fully initialize
-	time.Sleep(500 * time.Millisecond)
-
-	// Create mount directory
-	mountPath, err := makeTraversableMountPoint("dittofs-e2e-smb-")
-	if err != nil {
-		t.Fatalf("Failed to create SMB mount directory: %v", err)
-	}
-
-	// Build mount command based on platform
-	var cmd *exec.Cmd
+// buildSMBMountCmd builds the platform-specific mount command for an SMB share.
+// shareName is the DittoFS share name (with or without a leading slash); the SMB
+// tree name is the same path without the leading slash.
+func buildSMBMountCmd(port int, shareName, mountPath string, creds SMBCredentials) *exec.Cmd {
+	tree := strings.TrimPrefix(shareName, "/")
 	switch runtime.GOOS {
 	case "darwin":
 		// macOS: mount_smbfs
-		smbURL := fmt.Sprintf("//%s:%s@localhost:%d/export", creds.Username, creds.Password, port)
-		cmd = exec.Command("mount_smbfs", smbURL, mountPath)
+		smbURL := fmt.Sprintf("//%s:%s@localhost:%d/%s", creds.Username, creds.Password, port, tree)
+		return exec.Command("mount_smbfs", smbURL, mountPath)
 	case "linux":
 		// Linux: mount -t cifs
-		cmd = exec.Command("mount", "-t", "cifs",
-			"//localhost/export",
+		return exec.Command("mount", "-t", "cifs",
+			fmt.Sprintf("//localhost/%s", tree),
 			mountPath,
 			"-o", cifsMountOptions(port, creds))
 	default:
-		_ = os.RemoveAll(mountPath)
-		t.Fatalf("Unsupported platform for SMB: %s", runtime.GOOS)
-	}
-
-	// Execute mount command with retries
-	var output []byte
-	var lastErr error
-	maxRetries := 3
-
-	for i := range maxRetries {
-		output, lastErr = cmd.CombinedOutput()
-
-		if lastErr == nil {
-			t.Logf("SMB share mounted successfully at %s", mountPath)
-			break
-		}
-
-		if i < maxRetries-1 {
-			t.Logf("SMB mount attempt %d failed (error: %v), retrying in 1 second...", i+1, lastErr)
-			time.Sleep(time.Second)
-
-			// Rebuild command for next attempt (cmd can only be run once)
-			switch runtime.GOOS {
-			case "darwin":
-				smbURL := fmt.Sprintf("//%s:%s@localhost:%d/export", creds.Username, creds.Password, port)
-				cmd = exec.Command("mount_smbfs", smbURL, mountPath)
-			case "linux":
-				cmd = exec.Command("mount", "-t", "cifs",
-					"//localhost/export",
-					mountPath,
-					"-o", cifsMountOptions(port, creds))
-			}
-		}
-	}
-
-	if lastErr != nil {
-		_ = os.RemoveAll(mountPath)
-		t.Fatalf("Failed to mount SMB share after %d attempts: %v\nOutput: %s",
-			maxRetries, lastErr, string(output))
-	}
-
-	return &Mount{
-		T:        t,
-		Path:     mountPath,
-		Protocol: "smb",
-		Port:     port,
-		mounted:  true,
+		return nil
 	}
 }
 
-// MountSMBWithError mounts an SMB share and returns the mount info or an error.
-// Unlike MountSMB, it does NOT call t.Fatal on mount failure.
-// Use this for testing scenarios where mount is expected to fail (e.g., permission denied).
+// MountSMB mounts the default "/export" SMB share and returns the mount info.
+func MountSMB(t *testing.T, port int, creds SMBCredentials) *Mount {
+	t.Helper()
+	return MountSMBExport(t, port, "/export", creds)
+}
+
+// MountSMBExport mounts a named SMB share and returns the mount info.
+func MountSMBExport(t *testing.T, port int, shareName string, creds SMBCredentials) *Mount {
+	t.Helper()
+	mount, err := MountSMBExportWithError(t, port, shareName, creds)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	return mount
+}
+
+// MountSMBWithError mounts the default "/export" SMB share and returns the mount
+// info or an error. Unlike MountSMB it does NOT call t.Fatal on mount failure;
+// use it where a mount is expected to fail (e.g. permission denied).
 func MountSMBWithError(t *testing.T, port int, creds SMBCredentials) (*Mount, error) {
+	t.Helper()
+	return MountSMBExportWithError(t, port, "/export", creds)
+}
+
+// MountSMBExportWithError mounts a named SMB share and returns the mount info or
+// an error, without calling t.Fatal.
+func MountSMBExportWithError(t *testing.T, port int, shareName string, creds SMBCredentials) (*Mount, error) {
 	t.Helper()
 
 	// Give the SMB server a moment to fully initialize
 	time.Sleep(500 * time.Millisecond)
 
-	// Create mount directory
 	mountPath, err := makeTraversableMountPoint("dittofs-e2e-smb-")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SMB mount directory: %w", err)
 	}
 
-	// Build mount command based on platform
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		// macOS: mount_smbfs
-		smbURL := fmt.Sprintf("//%s:%s@localhost:%d/export", creds.Username, creds.Password, port)
-		cmd = exec.Command("mount_smbfs", smbURL, mountPath)
-	case "linux":
-		// Linux: mount -t cifs
-		cmd = exec.Command("mount", "-t", "cifs",
-			"//localhost/export",
-			mountPath,
-			"-o", cifsMountOptions(port, creds))
-	default:
+	cmd := buildSMBMountCmd(port, shareName, mountPath, creds)
+	if cmd == nil {
 		_ = os.RemoveAll(mountPath)
 		return nil, fmt.Errorf("unsupported platform for SMB: %s", runtime.GOOS)
 	}
 
-	// Execute mount command with retries
 	var output []byte
 	var lastErr error
 	maxRetries := 3
@@ -376,7 +329,7 @@ func MountSMBWithError(t *testing.T, port int, creds SMBCredentials) (*Mount, er
 		output, lastErr = cmd.CombinedOutput()
 
 		if lastErr == nil {
-			t.Logf("SMB share mounted successfully at %s", mountPath)
+			t.Logf("SMB share %s mounted successfully at %s", shareName, mountPath)
 			return &Mount{
 				T:        t,
 				Path:     mountPath,
@@ -389,22 +342,10 @@ func MountSMBWithError(t *testing.T, port int, creds SMBCredentials) (*Mount, er
 		if i < maxRetries-1 {
 			t.Logf("SMB mount attempt %d failed (error: %v), retrying in 1 second...", i+1, lastErr)
 			time.Sleep(time.Second)
-
-			// Rebuild command for next attempt (cmd can only be run once)
-			switch runtime.GOOS {
-			case "darwin":
-				smbURL := fmt.Sprintf("//%s:%s@localhost:%d/export", creds.Username, creds.Password, port)
-				cmd = exec.Command("mount_smbfs", smbURL, mountPath)
-			case "linux":
-				cmd = exec.Command("mount", "-t", "cifs",
-					"//localhost/export",
-					mountPath,
-					"-o", cifsMountOptions(port, creds))
-			}
+			cmd = buildSMBMountCmd(port, shareName, mountPath, creds) // cmd can only run once
 		}
 	}
 
-	// Clean up mount directory on failure
 	_ = os.RemoveAll(mountPath)
 	return nil, fmt.Errorf("failed to mount SMB share after %d attempts: %v\nOutput: %s",
 		maxRetries, lastErr, string(output))

--- a/test/e2e/helpers/controlplane.go
+++ b/test/e2e/helpers/controlplane.go
@@ -138,6 +138,12 @@ func CreateShareWithPolicy(t *testing.T, client *apiclient.Client, name, metadat
 		Name:            name,
 		MetadataStoreID: metadataStore,
 		LocalBlockStore: localBlockStore,
+		// Default to a writable share, matching the CLI CreateShare helper. These
+		// are functional tests (e.g. netgroup IP access control); the share knob
+		// under test is the policy, not least-privilege user permissions. Without
+		// this the server default ("none") makes the share unwritable — and even
+		// unmountable over NFSv4 by a squashed root client.
+		DefaultPermission: "read-write",
 	}
 
 	if policy != nil {

--- a/test/e2e/multi_share_isolation_test.go
+++ b/test/e2e/multi_share_isolation_test.go
@@ -382,7 +382,7 @@ func TestMultiShareIsolation(t *testing.T) {
 		// Grant permission to the share
 		_ = runner.GrantUserPermission("/share-iso-a", "testuser", "read-write")
 
-		mountSMB := framework.MountSMB(t, smbPort, framework.SMBCredentials{
+		mountSMB := framework.MountSMBExport(t, smbPort, "/share-iso-a", framework.SMBCredentials{
 			Username: "testuser",
 			Password: "testpass123",
 		})

--- a/test/e2e/nfsv4_basic_test.go
+++ b/test/e2e/nfsv4_basic_test.go
@@ -45,6 +45,14 @@ func setupNFSv4TestServer(t *testing.T) (*helpers.ServerProcess, *helpers.CLIRun
 	require.NoError(t, err, "Should create share")
 	t.Cleanup(func() { _ = runner.DeleteShare("/export") })
 
+	// These exercise privileged POSIX filesystem semantics (chown to an
+	// arbitrary uid, etc.) which require real root. The default squash is
+	// root_to_guest, mapping an NFS root client to an unprivileged anonymous
+	// identity that may not chown — so model a trusted-admin export with
+	// no_root_squash (root_to_admin) where root retains its privileges.
+	_, err = runner.Run("share", "nfs-config", "set", "/export", "--squash", "root_to_admin")
+	require.NoError(t, err, "Should set no_root_squash on the share")
+
 	nfsPort := helpers.FindFreePort(t)
 	_, err = runner.EnableAdapter("nfs", helpers.WithAdapterPort(nfsPort))
 	require.NoError(t, err, "Should enable NFS adapter")

--- a/test/e2e/permission_enforcement_test.go
+++ b/test/e2e/permission_enforcement_test.go
@@ -74,17 +74,13 @@ func TestPermissionEnforcement(t *testing.T) {
 	framework.WaitForServer(t, nfsPort, 10*time.Second)
 	framework.WaitForServer(t, smbPort, 10*time.Second)
 
-	// Mount NFS as admin for test file setup (no auth required for NFS)
-	adminMount := framework.MountNFS(t, nfsPort)
-	t.Cleanup(adminMount.Cleanup)
-
 	t.Cleanup(func() {
 		_ = cli.DeleteShare(shareName)
 		_ = cli.DeleteMetadataStore(metaStoreName)
 		_ = cli.DeleteLocalBlockStore(localStoreName)
 	})
 
-	// Create an admin user for SMB testing
+	// Create an admin user for SMB testing.
 	adminUser := helpers.UniqueTestName("smbadmin")
 	adminPass := "testpassword123"
 	_, err = cli.CreateUser(adminUser, adminPass)
@@ -96,14 +92,18 @@ func TestPermissionEnforcement(t *testing.T) {
 	require.NoError(t, err, "Should grant admin permission")
 	t.Cleanup(func() { _ = cli.RevokeUserPermission(shareName, adminUser) })
 
-	// Verify SMB connectivity works before running permission tests
-	// Use MountSMBWithError to gracefully handle mount failures
-	testCreds := framework.SMBCredentials{Username: adminUser, Password: adminPass}
-	testMount, mountErr := framework.MountSMBWithError(t, smbPort, testCreds)
+	// Set up test files through an authenticated admin SMB mount, not NFS.
+	// The share's default permission is "none", so an NFS client (squashed to an
+	// unprivileged identity with no grant) cannot write the fixtures — that is
+	// the correct least-privilege behaviour. The admin user holds an explicit
+	// admin grant, so its authenticated SMB session can. This also keeps the
+	// whole test on the protocol it actually exercises (SMB).
+	adminMount, mountErr := framework.MountSMBWithError(t, smbPort,
+		framework.SMBCredentials{Username: adminUser, Password: adminPass})
 	if mountErr != nil {
 		t.Skipf("Skipping: SMB mount not working on this system: %v", mountErr)
 	}
-	testMount.Unmount()
+	t.Cleanup(adminMount.Cleanup)
 
 	// Run subtests for each requirement
 	t.Run("ENF-01 read-only user cannot write", func(t *testing.T) {

--- a/test/e2e/permission_enforcement_test.go
+++ b/test/e2e/permission_enforcement_test.go
@@ -55,23 +55,15 @@ func TestPermissionEnforcement(t *testing.T) {
 		helpers.WithShareDefaultPermission("none"))
 	require.NoError(t, err, "Should create share with default permission none")
 
-	// Enable NFS adapter for admin setup (creating test files)
-	nfsPort := helpers.FindFreePort(t)
-	_, err = cli.EnableAdapter("nfs", helpers.WithAdapterPort(nfsPort))
-	require.NoError(t, err, "Should enable NFS adapter")
-
-	// Enable SMB adapter for permission-enforced testing
+	// This test exercises SMB only — fixtures are created over the admin SMB
+	// mount and the permission checks run over per-user SMB mounts. No NFS.
 	smbPort := helpers.FindFreePort(t)
 	_, err = cli.EnableAdapter("smb", helpers.WithAdapterPort(smbPort))
 	require.NoError(t, err, "Should enable SMB adapter")
 
-	// Wait for adapters to be ready
-	err = helpers.WaitForAdapterStatus(t, cli, "nfs", true, 5*time.Second)
-	require.NoError(t, err, "NFS adapter should become enabled")
 	err = helpers.WaitForAdapterStatus(t, cli, "smb", true, 5*time.Second)
 	require.NoError(t, err, "SMB adapter should become enabled")
 
-	framework.WaitForServer(t, nfsPort, 10*time.Second)
 	framework.WaitForServer(t, smbPort, 10*time.Second)
 
 	t.Cleanup(func() {


### PR DESCRIPTION
## What

The revived e2e suite exposed tests written against the **old** NFS model (an
NFS root client implicitly privileged). Under the current defaults — squash
`root_to_guest` and `default_permission=none` — an NFS root client is mapped to
an unprivileged anonymous identity, which is correct least-privilege behaviour.
These tests are updated to exercise the real model.

### Fixes (each validated on a real Linux kernel mount)
- **`TestPermissionEnforcement`** — created its fixtures over NFS as root on a
  `none` share (now correctly denied). Create them through the admin user's
  authenticated **SMB** session instead (it holds an explicit admin grant) —
  which is also the protocol the test actually exercises.
- **`TestNFSv4ControlPlaneNetgroup`** — `CreateShareWithPolicy` now defaults
  `default_permission=read-write` (matching the CLI `CreateShare` helper). A
  `none` share is unwritable and unmountable over NFSv4 by a squashed root
  client, which isn't what an IP-netgroup access-control test means to assert.
- **`TestMultiShareIsolation`** — `MountSMB` hard-coded `//localhost/export`, so
  mounting `/share-iso-a` failed tree-connect (`exit 32`). Added
  `MountSMBExport`/`MountSMBExportWithError` to mount a named SMB share;
  `MountSMB` now delegates with `/export`.
- **`TestNFSv4AdvancedFileOps`** — exercises privileged ops (chown to an
  arbitrary uid) that need real root. Set the share's NFS config to
  `root_to_admin` (no_root_squash), the realistic trusted-admin export.

Part of the e2e backlog triage after revival; protocol-feature clusters (xattr,
clone/sparse, locking, errno) follow in separate PRs.