### PR TITLE
refactor(block): chunk locator indirection for object packing (#1414)

### DIFF
--- a/pkg/block/compression/decorator.go
+++ b/pkg/block/compression/decorator.go
@@ -235,19 +235,19 @@ func (d *Decorator) ReadBlockVerified(ctx context.Context, hash block.ContentHas
 	return plain, nil
 }
 
-// GetPackChunk reads the chunk's compressed wire bytes from the inner store's
-// pack object and decompresses them, returning the next layer's input (or the
-// engine's plaintext). A pack stores each chunk's full self-framed compression
+// ReadChunk reads the chunk's compressed wire bytes from the inner store's
+// block object and decompresses them, returning the next layer's input (or the
+// engine's plaintext). A block stores each chunk's full self-framed compression
 // blob (or raw passthrough) verbatim, so decoding the chunk's [offset, length)
 // slice is identical to decoding its standalone object. No verification here —
 // the engine verifies the BLAKE3 after the full stack. hash is unused at this
-// layer. Implements remote.PackChunkReader (#1414).
-func (d *Decorator) GetPackChunk(ctx context.Context, packID string, offset, length int64, hash block.ContentHash) ([]byte, error) {
-	pcr, ok := d.inner.(remote.PackChunkReader)
+// layer. Implements remote.ChunkReader (#1414).
+func (d *Decorator) ReadChunk(ctx context.Context, blockID string, offset, length int64, hash block.ContentHash) ([]byte, error) {
+	pcr, ok := d.inner.(remote.ChunkReader)
 	if !ok {
-		return nil, remote.ErrPackReadUnsupported
+		return nil, remote.ErrChunkReadUnsupported
 	}
-	raw, err := pcr.GetPackChunk(ctx, packID, offset, length, hash)
+	raw, err := pcr.ReadChunk(ctx, blockID, offset, length, hash)
 	if err != nil {
 		return nil, err
 	}
@@ -277,6 +277,6 @@ func (d *Decorator) Durable() bool {
 var (
 	_ block.Store              = (*Decorator)(nil)
 	_ remote.RemoteStore       = (*Decorator)(nil)
-	_ remote.PackChunkReader   = (*Decorator)(nil)
+	_ remote.ChunkReader       = (*Decorator)(nil)
 	_ block.DurabilityReporter = (*Decorator)(nil)
 )

--- a/pkg/block/compression/decorator.go
+++ b/pkg/block/compression/decorator.go
@@ -235,6 +235,25 @@ func (d *Decorator) ReadBlockVerified(ctx context.Context, hash block.ContentHas
 	return plain, nil
 }
 
+// GetPackChunk reads the chunk's compressed wire bytes from the inner store's
+// pack object and decompresses them, returning the next layer's input (or the
+// engine's plaintext). A pack stores each chunk's full self-framed compression
+// blob (or raw passthrough) verbatim, so decoding the chunk's [offset, length)
+// slice is identical to decoding its standalone object. No verification here —
+// the engine verifies the BLAKE3 after the full stack. hash is unused at this
+// layer. Implements remote.PackChunkReader (#1414).
+func (d *Decorator) GetPackChunk(ctx context.Context, packID string, offset, length int64, hash block.ContentHash) ([]byte, error) {
+	pcr, ok := d.inner.(remote.PackChunkReader)
+	if !ok {
+		return nil, remote.ErrPackReadUnsupported
+	}
+	raw, err := pcr.GetPackChunk(ctx, packID, offset, length, hash)
+	if err != nil {
+		return nil, err
+	}
+	return d.decode(raw)
+}
+
 // Close releases inner resources.
 func (d *Decorator) Close() error { return d.inner.Close() }
 
@@ -258,5 +277,6 @@ func (d *Decorator) Durable() bool {
 var (
 	_ block.Store              = (*Decorator)(nil)
 	_ remote.RemoteStore       = (*Decorator)(nil)
+	_ remote.PackChunkReader   = (*Decorator)(nil)
 	_ block.DurabilityReporter = (*Decorator)(nil)
 )

--- a/pkg/block/encryption/chunk_read_test.go
+++ b/pkg/block/encryption/chunk_read_test.go
@@ -11,11 +11,11 @@ import (
 	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
 )
 
-// TestEncryptedRemote_GetPackChunk de-risks PR3b's per-chunk crypto boundary: a
-// pack concatenates each chunk's self-framed encryption blob verbatim, so
-// reading one chunk's slice out of the pack and decrypting it must yield the
+// TestEncryptedRemote_ReadChunk de-risks PR3b's per-chunk crypto boundary: a
+// block concatenates each chunk's self-framed encryption blob verbatim, so
+// reading one chunk's slice out of the block and decrypting it must yield the
 // original plaintext — identical to decrypting that chunk's standalone object.
-func TestEncryptedRemote_GetPackChunk(t *testing.T) {
+func TestEncryptedRemote_ReadChunk(t *testing.T) {
 	ctx := context.Background()
 	inner := remotememory.New()
 	d, err := NewRemote(inner, EncryptionPolicy{AEAD: AEADAES256GCM}, newProvider(t))
@@ -35,28 +35,28 @@ func TestEncryptedRemote_GetPackChunk(t *testing.T) {
 		t.Fatalf("inner Get wire: %v", err)
 	}
 
-	// Build a pack: [filler][target wire blob] and stage it in the base store.
+	// Build a block: [filler][target wire blob] and stage it in the base store.
 	filler := bytes.Repeat([]byte{0x01}, 37)
-	pack := append(append([]byte{}, filler...), wire...)
-	const packID = "enc-pack-1"
-	if err := inner.PutPack(packID, pack); err != nil {
-		t.Fatalf("PutPack: %v", err)
+	blockData := append(append([]byte{}, filler...), wire...)
+	const blockID = "enc-block-1"
+	if err := inner.PutBlock(blockID, blockData); err != nil {
+		t.Fatalf("PutBlock: %v", err)
 	}
 
-	got, err := d.GetPackChunk(ctx, packID, int64(len(filler)), int64(len(wire)), hash)
+	got, err := d.ReadChunk(ctx, blockID, int64(len(filler)), int64(len(wire)), hash)
 	if err != nil {
-		t.Fatalf("GetPackChunk: %v", err)
+		t.Fatalf("ReadChunk: %v", err)
 	}
 	if !bytes.Equal(got, target) {
-		t.Fatalf("decrypted pack chunk != plaintext (got %d bytes)", len(got))
+		t.Fatalf("decrypted block chunk != plaintext (got %d bytes)", len(got))
 	}
 	if block.ContentHash(blake3.Sum256(got)) != hash {
-		t.Fatalf("decrypted pack chunk hash mismatch")
+		t.Fatalf("decrypted block chunk hash mismatch")
 	}
 
 	// Wrong hash → AEAD AAD mismatch → decrypt fails (no silent corruption).
 	wrong := block.ContentHash(blake3.Sum256([]byte("different")))
-	if _, err := d.GetPackChunk(ctx, packID, int64(len(filler)), int64(len(wire)), wrong); err == nil {
-		t.Fatalf("GetPackChunk with wrong AAD hash: want error, got nil")
+	if _, err := d.ReadChunk(ctx, blockID, int64(len(filler)), int64(len(wire)), wrong); err == nil {
+		t.Fatalf("ReadChunk with wrong AAD hash: want error, got nil")
 	}
 }

--- a/pkg/block/encryption/decorator.go
+++ b/pkg/block/encryption/decorator.go
@@ -193,19 +193,19 @@ func (d *EncryptedRemote) ReadBlockVerified(ctx context.Context, hash block.Cont
 	return plain, nil
 }
 
-// GetPackChunk reads the chunk's encrypted wire bytes from the inner store's
-// pack object and decrypts them against hash as the AEAD AAD, returning the
-// plaintext (for the next layer up / the engine). A pack stores each chunk's
+// ReadChunk reads the chunk's encrypted wire bytes from the inner store's
+// block object and decrypts them against hash as the AEAD AAD, returning the
+// plaintext (for the next layer up / the engine). A block stores each chunk's
 // full self-framed encryption blob (header||nonce||ciphertext||tag) verbatim, so
 // decrypting the chunk's [offset, length) slice is identical to decrypting its
 // standalone object. No verification here — the engine verifies the BLAKE3 after
-// the full stack. Implements remote.PackChunkReader (#1414).
-func (d *EncryptedRemote) GetPackChunk(ctx context.Context, packID string, offset, length int64, hash block.ContentHash) ([]byte, error) {
-	pcr, ok := d.inner.(remote.PackChunkReader)
+// the full stack. Implements remote.ChunkReader (#1414).
+func (d *EncryptedRemote) ReadChunk(ctx context.Context, blockID string, offset, length int64, hash block.ContentHash) ([]byte, error) {
+	pcr, ok := d.inner.(remote.ChunkReader)
 	if !ok {
-		return nil, remote.ErrPackReadUnsupported
+		return nil, remote.ErrChunkReadUnsupported
 	}
-	raw, err := pcr.GetPackChunk(ctx, packID, offset, length, hash)
+	raw, err := pcr.ReadChunk(ctx, blockID, offset, length, hash)
 	if err != nil {
 		return nil, err
 	}
@@ -305,6 +305,6 @@ func newAEAD(algo AEAD, key []byte) (cipher.AEAD, error) {
 var (
 	_ block.Store              = (*EncryptedRemote)(nil)
 	_ remote.RemoteStore       = (*EncryptedRemote)(nil)
-	_ remote.PackChunkReader   = (*EncryptedRemote)(nil)
+	_ remote.ChunkReader       = (*EncryptedRemote)(nil)
 	_ block.DurabilityReporter = (*EncryptedRemote)(nil)
 )

--- a/pkg/block/encryption/decorator.go
+++ b/pkg/block/encryption/decorator.go
@@ -193,6 +193,25 @@ func (d *EncryptedRemote) ReadBlockVerified(ctx context.Context, hash block.Cont
 	return plain, nil
 }
 
+// GetPackChunk reads the chunk's encrypted wire bytes from the inner store's
+// pack object and decrypts them against hash as the AEAD AAD, returning the
+// plaintext (for the next layer up / the engine). A pack stores each chunk's
+// full self-framed encryption blob (header||nonce||ciphertext||tag) verbatim, so
+// decrypting the chunk's [offset, length) slice is identical to decrypting its
+// standalone object. No verification here — the engine verifies the BLAKE3 after
+// the full stack. Implements remote.PackChunkReader (#1414).
+func (d *EncryptedRemote) GetPackChunk(ctx context.Context, packID string, offset, length int64, hash block.ContentHash) ([]byte, error) {
+	pcr, ok := d.inner.(remote.PackChunkReader)
+	if !ok {
+		return nil, remote.ErrPackReadUnsupported
+	}
+	raw, err := pcr.GetPackChunk(ctx, packID, offset, length, hash)
+	if err != nil {
+		return nil, err
+	}
+	return d.decrypt(ctx, hash, raw)
+}
+
 // Close releases inner resources and the provider.
 func (d *EncryptedRemote) Close() error {
 	innerErr := d.inner.Close()
@@ -286,5 +305,6 @@ func newAEAD(algo AEAD, key []byte) (cipher.AEAD, error) {
 var (
 	_ block.Store              = (*EncryptedRemote)(nil)
 	_ remote.RemoteStore       = (*EncryptedRemote)(nil)
+	_ remote.PackChunkReader   = (*EncryptedRemote)(nil)
 	_ block.DurabilityReporter = (*EncryptedRemote)(nil)
 )

--- a/pkg/block/encryption/pack_chunk_test.go
+++ b/pkg/block/encryption/pack_chunk_test.go
@@ -1,0 +1,62 @@
+package encryption
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+)
+
+// TestEncryptedRemote_GetPackChunk de-risks PR3b's per-chunk crypto boundary: a
+// pack concatenates each chunk's self-framed encryption blob verbatim, so
+// reading one chunk's slice out of the pack and decrypting it must yield the
+// original plaintext — identical to decrypting that chunk's standalone object.
+func TestEncryptedRemote_GetPackChunk(t *testing.T) {
+	ctx := context.Background()
+	inner := remotememory.New()
+	d, err := NewRemote(inner, EncryptionPolicy{AEAD: AEADAES256GCM}, newProvider(t))
+	if err != nil {
+		t.Fatalf("NewRemote: %v", err)
+	}
+
+	// Encrypt the target chunk via the decorator's Put so inner holds its real
+	// wire blob (header||nonce||ciphertext||tag), then read that blob back out.
+	target := bytes.Repeat([]byte{0x5A}, 8192)
+	hash := block.ContentHash(blake3.Sum256(target))
+	if err := d.Put(ctx, hash, target); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	wire, err := inner.Get(ctx, hash)
+	if err != nil {
+		t.Fatalf("inner Get wire: %v", err)
+	}
+
+	// Build a pack: [filler][target wire blob] and stage it in the base store.
+	filler := bytes.Repeat([]byte{0x01}, 37)
+	pack := append(append([]byte{}, filler...), wire...)
+	const packID = "enc-pack-1"
+	if err := inner.PutPack(packID, pack); err != nil {
+		t.Fatalf("PutPack: %v", err)
+	}
+
+	got, err := d.GetPackChunk(ctx, packID, int64(len(filler)), int64(len(wire)), hash)
+	if err != nil {
+		t.Fatalf("GetPackChunk: %v", err)
+	}
+	if !bytes.Equal(got, target) {
+		t.Fatalf("decrypted pack chunk != plaintext (got %d bytes)", len(got))
+	}
+	if block.ContentHash(blake3.Sum256(got)) != hash {
+		t.Fatalf("decrypted pack chunk hash mismatch")
+	}
+
+	// Wrong hash → AEAD AAD mismatch → decrypt fails (no silent corruption).
+	wrong := block.ContentHash(blake3.Sum256([]byte("different")))
+	if _, err := d.GetPackChunk(ctx, packID, int64(len(filler)), int64(len(wire)), wrong); err == nil {
+		t.Fatalf("GetPackChunk with wrong AAD hash: want error, got nil")
+	}
+}

--- a/pkg/block/engine/engine_delete_test.go
+++ b/pkg/block/engine/engine_delete_test.go
@@ -166,7 +166,7 @@ func (s *recordingSyncedHashStore) IsSynced(_ context.Context, hash block.Conten
 	return ok, nil
 }
 
-func (s *recordingSyncedHashStore) MarkSynced(_ context.Context, hash block.ContentHash) error {
+func (s *recordingSyncedHashStore) MarkSynced(_ context.Context, hash block.ContentHash, _ block.ChunkLocator) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.synced[hash]; !ok {
@@ -193,6 +193,13 @@ func (s *recordingSyncedHashStore) EnumerateSynced(ctx context.Context, fn func(
 		}
 	}
 	return nil
+}
+
+func (s *recordingSyncedHashStore) GetLocator(_ context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.synced[hash]
+	return block.ChunkLocator{}, ok, nil
 }
 
 func (s *recordingSyncedHashStore) DeleteSynced(_ context.Context, hash block.ContentHash) error {

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -151,10 +151,10 @@ func (m *Syncer) dispatchRemoteFetch(ctx context.Context, fb *block.FileBlock) (
 		return "", nil, fmt.Errorf("blockstore: legacy zero-hash FileBlock encountered post-migration: block_id=%s", fb.ID)
 	}
 	// Resolve where the chunk's bytes live (#1414). A standalone locator
-	// (PackID=="") — the only kind written on the live path today, and the
+	// (BlockID=="") — the only kind written on the live path today, and the
 	// default for any not-yet-recorded hash — reads the chunk's own CAS
-	// object exactly as before. A pack locator routes a ranged read into the
-	// enclosing pack object (produced by PR3b; exercised here only by tests).
+	// object exactly as before. A block locator routes a ranged read into the
+	// enclosing block object (produced by PR3b; exercised here only by tests).
 	loc, err := m.resolveLocator(ctx, fb.Hash)
 	if err != nil {
 		return "", nil, err
@@ -168,13 +168,13 @@ func (m *Syncer) dispatchRemoteFetch(ctx context.Context, fb *block.FileBlock) (
 		data, rerr := m.remoteStore.ReadBlockVerified(ctx, fb.Hash, fb.Hash)
 		return key, data, rerr
 	}
-	key := block.FormatPackKey(loc.PackID)
-	data, perr := m.readPackChunkVerified(ctx, loc, fb.Hash)
+	key := block.FormatBlockKey(loc.BlockID)
+	data, perr := m.readChunkVerified(ctx, loc, fb.Hash)
 	return key, data, perr
 }
 
 // resolveLocator returns the recorded remote locator for hash, defaulting to a
-// standalone locator (PackID=="") when no SyncedHashStore is wired (test
+// standalone locator (BlockID=="") when no SyncedHashStore is wired (test
 // fixtures) or when the hash has no recorded marker. The standalone default
 // preserves the exact pre-#1414 behavior — a direct CAS GET by hash — for every
 // existing path, since the live mirror path only ever records standalone
@@ -196,26 +196,26 @@ func (m *Syncer) resolveLocator(ctx context.Context, hash block.ContentHash) (bl
 	return loc, nil
 }
 
-// readPackChunkVerified fetches a pack-resident chunk through the remote store's
-// PackChunkReader capability and verifies its BLAKE3 matches hash. Verification
+// readChunkVerified fetches a block-resident chunk through the remote store's
+// ChunkReader capability and verifies its BLAKE3 matches hash. Verification
 // happens here (not in the store stack) because no single decorator layer holds
-// both the chunk's wire bytes and its plaintext-hash domain — GetPackChunk
+// both the chunk's wire bytes and its plaintext-hash domain — ReadChunk
 // returns decrypted/decompressed plaintext, and we recompute over it, mirroring
 // ReadBlockVerified's guarantee for standalone objects.
-func (m *Syncer) readPackChunkVerified(ctx context.Context, loc block.ChunkLocator, hash block.ContentHash) ([]byte, error) {
-	pcr, ok := m.remoteStore.(remote.PackChunkReader)
+func (m *Syncer) readChunkVerified(ctx context.Context, loc block.ChunkLocator, hash block.ContentHash) ([]byte, error) {
+	pcr, ok := m.remoteStore.(remote.ChunkReader)
 	if !ok {
-		return nil, fmt.Errorf("chunk %s has pack locator %q but remote store lacks pack-read support: %w",
-			hash, loc.PackID, remote.ErrPackReadUnsupported)
+		return nil, fmt.Errorf("chunk %s has block locator %q but remote store lacks block-read support: %w",
+			hash, loc.BlockID, remote.ErrChunkReadUnsupported)
 	}
-	data, err := pcr.GetPackChunk(ctx, loc.PackID, loc.Offset, loc.Length, hash)
+	data, err := pcr.ReadChunk(ctx, loc.BlockID, loc.Offset, loc.Length, hash)
 	if err != nil {
 		return nil, err
 	}
 	computed := block.ContentHash(blake3.Sum256(data))
 	if computed != hash {
-		return nil, fmt.Errorf("%w: pack %s chunk %s computed %s",
-			block.ErrCASContentMismatch, loc.PackID, hash, computed)
+		return nil, fmt.Errorf("%w: block %s chunk %s computed %s",
+			block.ErrCASContentMismatch, loc.BlockID, hash, computed)
 	}
 	return data, nil
 }

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"fmt"
 
+	"lukechampine.com/blake3"
+
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/remote"
 )
 
 // inFlightKey returns the deterministic per-block dedup key used by
@@ -147,13 +150,74 @@ func (m *Syncer) dispatchRemoteFetch(ctx context.Context, fb *block.FileBlock) (
 			"store_key", fb.BlockStoreKey)
 		return "", nil, fmt.Errorf("blockstore: legacy zero-hash FileBlock encountered post-migration: block_id=%s", fb.ID)
 	}
-	// CAS path: verified read via BLAKE3 recompute. Canonical key is
-	// derived from the hash; both arguments to ReadBlockVerified are
-	// the same hash per the signature (canonical-key hash +
-	// expected-body hash collapse onto one value when hash IS the key).
-	key := block.FormatCASKey(fb.Hash)
-	data, err := m.remoteStore.ReadBlockVerified(ctx, fb.Hash, fb.Hash)
-	return key, data, err
+	// Resolve where the chunk's bytes live (#1414). A standalone locator
+	// (PackID=="") — the only kind written on the live path today, and the
+	// default for any not-yet-recorded hash — reads the chunk's own CAS
+	// object exactly as before. A pack locator routes a ranged read into the
+	// enclosing pack object (produced by PR3b; exercised here only by tests).
+	loc, err := m.resolveLocator(ctx, fb.Hash)
+	if err != nil {
+		return "", nil, err
+	}
+	if loc.IsStandalone() {
+		// CAS path: verified read via BLAKE3 recompute. Canonical key is
+		// derived from the hash; both arguments to ReadBlockVerified are
+		// the same hash per the signature (canonical-key hash +
+		// expected-body hash collapse onto one value when hash IS the key).
+		key := block.FormatCASKey(fb.Hash)
+		data, rerr := m.remoteStore.ReadBlockVerified(ctx, fb.Hash, fb.Hash)
+		return key, data, rerr
+	}
+	key := block.FormatPackKey(loc.PackID)
+	data, perr := m.readPackChunkVerified(ctx, loc, fb.Hash)
+	return key, data, perr
+}
+
+// resolveLocator returns the recorded remote locator for hash, defaulting to a
+// standalone locator (PackID=="") when no SyncedHashStore is wired (test
+// fixtures) or when the hash has no recorded marker. The standalone default
+// preserves the exact pre-#1414 behavior — a direct CAS GET by hash — for every
+// existing path, since the live mirror path only ever records standalone
+// locators in PR3a.
+func (m *Syncer) resolveLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, error) {
+	m.mu.RLock()
+	hs := m.syncedHashStore
+	m.mu.RUnlock()
+	if hs == nil {
+		return block.ChunkLocator{}, nil
+	}
+	loc, ok, err := hs.GetLocator(ctx, hash)
+	if err != nil {
+		return block.ChunkLocator{}, fmt.Errorf("resolve locator %s: %w", hash, err)
+	}
+	if !ok {
+		return block.ChunkLocator{}, nil
+	}
+	return loc, nil
+}
+
+// readPackChunkVerified fetches a pack-resident chunk through the remote store's
+// PackChunkReader capability and verifies its BLAKE3 matches hash. Verification
+// happens here (not in the store stack) because no single decorator layer holds
+// both the chunk's wire bytes and its plaintext-hash domain — GetPackChunk
+// returns decrypted/decompressed plaintext, and we recompute over it, mirroring
+// ReadBlockVerified's guarantee for standalone objects.
+func (m *Syncer) readPackChunkVerified(ctx context.Context, loc block.ChunkLocator, hash block.ContentHash) ([]byte, error) {
+	pcr, ok := m.remoteStore.(remote.PackChunkReader)
+	if !ok {
+		return nil, fmt.Errorf("chunk %s has pack locator %q but remote store lacks pack-read support: %w",
+			hash, loc.PackID, remote.ErrPackReadUnsupported)
+	}
+	data, err := pcr.GetPackChunk(ctx, loc.PackID, loc.Offset, loc.Length, hash)
+	if err != nil {
+		return nil, err
+	}
+	computed := block.ContentHash(blake3.Sum256(data))
+	if computed != hash {
+		return nil, fmt.Errorf("%w: pack %s chunk %s computed %s",
+			block.ErrCASContentMismatch, loc.PackID, hash, computed)
+	}
+	return data, nil
 }
 
 // fetchBlock downloads a single block from the remote store and writes it to the local store.

--- a/pkg/block/engine/locator_fetch_test.go
+++ b/pkg/block/engine/locator_fetch_test.go
@@ -1,0 +1,165 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/local/fs"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// newLocatorFetchSyncer builds a Syncer over an in-memory local store, remote
+// store, and synced-hash store — the minimal wiring dispatchRemoteFetch needs to
+// resolve a chunk locator and route the read.
+func newLocatorFetchSyncer(t *testing.T) (*Syncer, *remotememory.Store, *metadatamemory.MemoryMetadataStore) {
+	t.Helper()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	t.Cleanup(func() { _ = ms.Close() })
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
+		MaxLogBytes:     128 * 1024 * 1024,
+		RollupWorkers:   2,
+		StabilizationMS: 5,
+		RollupStore:     ms,
+		SyncedHashStore: ms,
+	})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+	t.Cleanup(func() { _ = localStore.Close() })
+
+	rem := remotememory.New()
+	syncer := NewSyncer(localStore, rem, ms, DefaultConfig())
+	syncer.SetSyncedHashStore(ms)
+	return syncer, rem, ms
+}
+
+// TestDispatchRemoteFetch_StandaloneRoundTrip covers the live PR3a path: a chunk
+// written and marked synced with a standalone locator reads back via the direct
+// CAS object (ReadBlockVerified), and the recorded locator resolves as
+// standalone.
+func TestDispatchRemoteFetch_StandaloneRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	syncer, rem, ms := newLocatorFetchSyncer(t)
+
+	data := bytes.Repeat([]byte{0xAB}, 4096)
+	hash := block.ContentHash(blake3.Sum256(data))
+	if err := rem.Put(ctx, hash, data); err != nil {
+		t.Fatalf("remote Put: %v", err)
+	}
+	// The write path records a standalone locator on MarkSynced.
+	if err := ms.MarkSynced(ctx, hash, block.ChunkLocator{Length: int64(len(data))}); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+
+	loc, ok, err := ms.GetLocator(ctx, hash)
+	if err != nil || !ok {
+		t.Fatalf("GetLocator: ok=%v err=%v", ok, err)
+	}
+	if !loc.IsStandalone() {
+		t.Fatalf("standalone write resolved to pack: %+v", loc)
+	}
+
+	key, got, err := syncer.dispatchRemoteFetch(ctx, &block.FileBlock{Hash: hash})
+	if err != nil {
+		t.Fatalf("dispatchRemoteFetch: %v", err)
+	}
+	if key != block.FormatCASKey(hash) {
+		t.Fatalf("standalone key = %q, want %q", key, block.FormatCASKey(hash))
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("standalone data mismatch")
+	}
+}
+
+// TestDispatchRemoteFetch_LegacyNoLocator covers backward compatibility: a hash
+// with NO recorded synced marker (a pre-#1414 fixture, or drift) still reads via
+// the standalone CAS object — resolveLocator defaults to standalone.
+func TestDispatchRemoteFetch_LegacyNoLocator(t *testing.T) {
+	ctx := context.Background()
+	syncer, rem, _ := newLocatorFetchSyncer(t)
+
+	data := bytes.Repeat([]byte{0xCD}, 2048)
+	hash := block.ContentHash(blake3.Sum256(data))
+	if err := rem.Put(ctx, hash, data); err != nil {
+		t.Fatalf("remote Put: %v", err)
+	}
+	// Deliberately NOT MarkSynced — GetLocator returns (false).
+
+	key, got, err := syncer.dispatchRemoteFetch(ctx, &block.FileBlock{Hash: hash})
+	if err != nil {
+		t.Fatalf("dispatchRemoteFetch (legacy): %v", err)
+	}
+	if key != block.FormatCASKey(hash) {
+		t.Fatalf("legacy key = %q, want standalone CAS key", key)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("legacy data mismatch")
+	}
+}
+
+// TestDispatchRemoteFetch_PackLocator covers the indirection PR3b will exploit: a
+// synthetic pack locator routes a ranged read into the enclosing pack object and
+// verifies the chunk's BLAKE3. This branch is never taken on the live PR3a path.
+func TestDispatchRemoteFetch_PackLocator(t *testing.T) {
+	ctx := context.Background()
+	syncer, rem, ms := newLocatorFetchSyncer(t)
+
+	// A pack with a leading filler chunk so the target sits at a non-zero
+	// offset, exercising the range request.
+	filler := bytes.Repeat([]byte{0x11}, 100)
+	target := bytes.Repeat([]byte{0x22}, 4096)
+	pack := append(append([]byte{}, filler...), target...)
+	const packID = "pack-test-0001"
+	if err := rem.PutPack(packID, pack); err != nil {
+		t.Fatalf("PutPack: %v", err)
+	}
+
+	hash := block.ContentHash(blake3.Sum256(target))
+	loc := block.ChunkLocator{PackID: packID, Offset: int64(len(filler)), Length: int64(len(target))}
+	if err := ms.MarkSynced(ctx, hash, loc); err != nil {
+		t.Fatalf("MarkSynced pack: %v", err)
+	}
+
+	key, got, err := syncer.dispatchRemoteFetch(ctx, &block.FileBlock{Hash: hash})
+	if err != nil {
+		t.Fatalf("dispatchRemoteFetch (pack): %v", err)
+	}
+	if key != block.FormatPackKey(packID) {
+		t.Fatalf("pack key = %q, want %q", key, block.FormatPackKey(packID))
+	}
+	if !bytes.Equal(got, target) {
+		t.Fatalf("pack chunk data mismatch")
+	}
+}
+
+// TestDispatchRemoteFetch_PackLocatorVerifyMismatch proves the pack read path
+// fails closed when the bytes at the located range do not hash to the expected
+// chunk (corruption / wrong offset).
+func TestDispatchRemoteFetch_PackLocatorVerifyMismatch(t *testing.T) {
+	ctx := context.Background()
+	syncer, rem, ms := newLocatorFetchSyncer(t)
+
+	target := bytes.Repeat([]byte{0x33}, 4096)
+	hash := block.ContentHash(blake3.Sum256(target))
+	// Store a pack whose bytes do NOT match the claimed hash.
+	corrupt := bytes.Repeat([]byte{0x34}, 4096)
+	const packID = "pack-corrupt"
+	if err := rem.PutPack(packID, corrupt); err != nil {
+		t.Fatalf("PutPack: %v", err)
+	}
+	loc := block.ChunkLocator{PackID: packID, Offset: 0, Length: int64(len(target))}
+	if err := ms.MarkSynced(ctx, hash, loc); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+
+	_, _, err := syncer.dispatchRemoteFetch(ctx, &block.FileBlock{Hash: hash})
+	if !errors.Is(err, block.ErrCASContentMismatch) {
+		t.Fatalf("pack verify mismatch: got %v, want ErrCASContentMismatch", err)
+	}
+}

--- a/pkg/block/engine/locator_fetch_test.go
+++ b/pkg/block/engine/locator_fetch_test.go
@@ -62,7 +62,7 @@ func TestDispatchRemoteFetch_StandaloneRoundTrip(t *testing.T) {
 		t.Fatalf("GetLocator: ok=%v err=%v", ok, err)
 	}
 	if !loc.IsStandalone() {
-		t.Fatalf("standalone write resolved to pack: %+v", loc)
+		t.Fatalf("standalone write resolved to block: %+v", loc)
 	}
 
 	key, got, err := syncer.dispatchRemoteFetch(ctx, &block.FileBlock{Hash: hash})
@@ -103,63 +103,63 @@ func TestDispatchRemoteFetch_LegacyNoLocator(t *testing.T) {
 	}
 }
 
-// TestDispatchRemoteFetch_PackLocator covers the indirection PR3b will exploit: a
-// synthetic pack locator routes a ranged read into the enclosing pack object and
+// TestDispatchRemoteFetch_BlockLocator covers the indirection PR3b will exploit: a
+// synthetic block locator routes a ranged read into the enclosing block object and
 // verifies the chunk's BLAKE3. This branch is never taken on the live PR3a path.
-func TestDispatchRemoteFetch_PackLocator(t *testing.T) {
+func TestDispatchRemoteFetch_BlockLocator(t *testing.T) {
 	ctx := context.Background()
 	syncer, rem, ms := newLocatorFetchSyncer(t)
 
-	// A pack with a leading filler chunk so the target sits at a non-zero
+	// A block with a leading filler chunk so the target sits at a non-zero
 	// offset, exercising the range request.
 	filler := bytes.Repeat([]byte{0x11}, 100)
 	target := bytes.Repeat([]byte{0x22}, 4096)
-	pack := append(append([]byte{}, filler...), target...)
-	const packID = "pack-test-0001"
-	if err := rem.PutPack(packID, pack); err != nil {
-		t.Fatalf("PutPack: %v", err)
+	blockData := append(append([]byte{}, filler...), target...)
+	const blockID = "block-test-0001"
+	if err := rem.PutBlock(blockID, blockData); err != nil {
+		t.Fatalf("PutBlock: %v", err)
 	}
 
 	hash := block.ContentHash(blake3.Sum256(target))
-	loc := block.ChunkLocator{PackID: packID, Offset: int64(len(filler)), Length: int64(len(target))}
+	loc := block.ChunkLocator{BlockID: blockID, Offset: int64(len(filler)), Length: int64(len(target))}
 	if err := ms.MarkSynced(ctx, hash, loc); err != nil {
-		t.Fatalf("MarkSynced pack: %v", err)
+		t.Fatalf("MarkSynced block: %v", err)
 	}
 
 	key, got, err := syncer.dispatchRemoteFetch(ctx, &block.FileBlock{Hash: hash})
 	if err != nil {
-		t.Fatalf("dispatchRemoteFetch (pack): %v", err)
+		t.Fatalf("dispatchRemoteFetch (block): %v", err)
 	}
-	if key != block.FormatPackKey(packID) {
-		t.Fatalf("pack key = %q, want %q", key, block.FormatPackKey(packID))
+	if key != block.FormatBlockKey(blockID) {
+		t.Fatalf("block key = %q, want %q", key, block.FormatBlockKey(blockID))
 	}
 	if !bytes.Equal(got, target) {
-		t.Fatalf("pack chunk data mismatch")
+		t.Fatalf("block chunk data mismatch")
 	}
 }
 
-// TestDispatchRemoteFetch_PackLocatorVerifyMismatch proves the pack read path
+// TestDispatchRemoteFetch_BlockLocatorVerifyMismatch proves the block read path
 // fails closed when the bytes at the located range do not hash to the expected
 // chunk (corruption / wrong offset).
-func TestDispatchRemoteFetch_PackLocatorVerifyMismatch(t *testing.T) {
+func TestDispatchRemoteFetch_BlockLocatorVerifyMismatch(t *testing.T) {
 	ctx := context.Background()
 	syncer, rem, ms := newLocatorFetchSyncer(t)
 
 	target := bytes.Repeat([]byte{0x33}, 4096)
 	hash := block.ContentHash(blake3.Sum256(target))
-	// Store a pack whose bytes do NOT match the claimed hash.
+	// Store a block whose bytes do NOT match the claimed hash.
 	corrupt := bytes.Repeat([]byte{0x34}, 4096)
-	const packID = "pack-corrupt"
-	if err := rem.PutPack(packID, corrupt); err != nil {
-		t.Fatalf("PutPack: %v", err)
+	const blockID = "block-corrupt"
+	if err := rem.PutBlock(blockID, corrupt); err != nil {
+		t.Fatalf("PutBlock: %v", err)
 	}
-	loc := block.ChunkLocator{PackID: packID, Offset: 0, Length: int64(len(target))}
+	loc := block.ChunkLocator{BlockID: blockID, Offset: 0, Length: int64(len(target))}
 	if err := ms.MarkSynced(ctx, hash, loc); err != nil {
 		t.Fatalf("MarkSynced: %v", err)
 	}
 
 	_, _, err := syncer.dispatchRemoteFetch(ctx, &block.FileBlock{Hash: hash})
 	if !errors.Is(err, block.ErrCASContentMismatch) {
-		t.Fatalf("pack verify mismatch: got %v, want ErrCASContentMismatch", err)
+		t.Fatalf("block verify mismatch: got %v, want ErrCASContentMismatch", err)
 	}
 }

--- a/pkg/block/engine/pending_set_test.go
+++ b/pkg/block/engine/pending_set_test.go
@@ -156,7 +156,7 @@ func TestSyncer_SeedPendingFromDisk_RecoversUnsynced(t *testing.T) {
 	if err := localStore.StoreChunk(ctx, sh, syncedData); err != nil {
 		t.Fatalf("StoreChunk synced: %v", err)
 	}
-	if err := ms.MarkSynced(ctx, sh); err != nil {
+	if err := ms.MarkSynced(ctx, sh, block.ChunkLocator{}); err != nil {
 		t.Fatalf("MarkSynced: %v", err)
 	}
 

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -258,7 +258,11 @@ func (m *Syncer) markFetchedSynced(ctx context.Context, h block.ContentHash) {
 	hashStore := m.syncedHashStore
 	m.mu.RUnlock()
 	if hashStore != nil {
-		if err := hashStore.MarkSynced(ctx, h); err != nil {
+		// Fetched bytes came verbatim from the chunk's own standalone CAS
+		// object, so record a standalone locator (PackID==""). PR3b note: a
+		// chunk fetched out of a pack is re-stored locally and, when later
+		// re-mirrored, re-packed — markFetchedSynced still records standalone.
+		if err := hashStore.MarkSynced(ctx, h, block.ChunkLocator{}); err != nil {
 			// Non-fatal: leave the chunk pending so the mirror loop re-uploads
 			// and marks it synced on the next tick (remote.Put is idempotent).
 			logger.Warn("markFetchedSynced: MarkSynced failed; chunk will be re-mirrored",
@@ -728,7 +732,10 @@ func (m *Syncer) mirrorChunk(ctx context.Context, hashStore metadata.SyncedHashS
 	// Count delivered bytes for the adaptive controller's goodput sample. The
 	// bytes are on the wire regardless of MarkSynced, so charge them here.
 	m.uploadedBytesWindow.Add(int64(len(data)))
-	if err := hashStore.MarkSynced(ctx, hash); err != nil {
+	// PR3a: every chunk is still a standalone CAS object, so record a standalone
+	// locator (PackID=="" → persisted in the legacy form). PR3b's packer will
+	// record pack locators here instead.
+	if err := hashStore.MarkSynced(ctx, hash, block.ChunkLocator{Length: int64(len(data))}); err != nil {
 		m.failedSyncs.Add(1)
 		return fmt.Errorf("mark synced %s: %w", hash, err)
 	}

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -733,9 +733,10 @@ func (m *Syncer) mirrorChunk(ctx context.Context, hashStore metadata.SyncedHashS
 	// bytes are on the wire regardless of MarkSynced, so charge them here.
 	m.uploadedBytesWindow.Add(int64(len(data)))
 	// PR3a: every chunk is still a standalone CAS object, so record a standalone
-	// locator (PackID=="" → persisted in the legacy form). PR3b's packer will
+	// locator (PackID=="" → persisted in the legacy form; Offset/Length are
+	// unused for standalone per the ChunkLocator contract). PR3b's packer will
 	// record pack locators here instead.
-	if err := hashStore.MarkSynced(ctx, hash, block.ChunkLocator{Length: int64(len(data))}); err != nil {
+	if err := hashStore.MarkSynced(ctx, hash, block.ChunkLocator{}); err != nil {
 		m.failedSyncs.Add(1)
 		return fmt.Errorf("mark synced %s: %w", hash, err)
 	}

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -259,9 +259,10 @@ func (m *Syncer) markFetchedSynced(ctx context.Context, h block.ContentHash) {
 	m.mu.RUnlock()
 	if hashStore != nil {
 		// Fetched bytes came verbatim from the chunk's own standalone CAS
-		// object, so record a standalone locator (PackID==""). PR3b note: a
-		// chunk fetched out of a pack is re-stored locally and, when later
-		// re-mirrored, re-packed — markFetchedSynced still records standalone.
+		// object, so record a standalone locator (BlockID==""). PR3b note: a
+		// chunk fetched out of a block is re-stored locally and, when later
+		// re-mirrored, may be written into a new block — markFetchedSynced
+		// still records standalone here.
 		if err := hashStore.MarkSynced(ctx, h, block.ChunkLocator{}); err != nil {
 			// Non-fatal: leave the chunk pending so the mirror loop re-uploads
 			// and marks it synced on the next tick (remote.Put is idempotent).
@@ -733,9 +734,9 @@ func (m *Syncer) mirrorChunk(ctx context.Context, hashStore metadata.SyncedHashS
 	// bytes are on the wire regardless of MarkSynced, so charge them here.
 	m.uploadedBytesWindow.Add(int64(len(data)))
 	// PR3a: every chunk is still a standalone CAS object, so record a standalone
-	// locator (PackID=="" → persisted in the legacy form; Offset/Length are
+	// locator (BlockID=="" → persisted in the legacy form; Offset/Length are
 	// unused for standalone per the ChunkLocator contract). PR3b's packer will
-	// record pack locators here instead.
+	// record block locators here instead.
 	if err := hashStore.MarkSynced(ctx, hash, block.ChunkLocator{}); err != nil {
 		m.failedSyncs.Add(1)
 		return fmt.Errorf("mark synced %s: %w", hash, err)

--- a/pkg/block/engine/syncer_put_error_test.go
+++ b/pkg/block/engine/syncer_put_error_test.go
@@ -35,8 +35,11 @@ type noopSyncedHashStore struct{}
 func (noopSyncedHashStore) IsSynced(_ context.Context, _ block.ContentHash) (bool, error) {
 	return false, nil
 }
-func (noopSyncedHashStore) MarkSynced(_ context.Context, _ block.ContentHash) error {
+func (noopSyncedHashStore) MarkSynced(_ context.Context, _ block.ContentHash, _ block.ChunkLocator) error {
 	return nil
+}
+func (noopSyncedHashStore) GetLocator(_ context.Context, _ block.ContentHash) (block.ChunkLocator, bool, error) {
+	return block.ChunkLocator{}, false, nil
 }
 func (noopSyncedHashStore) DeleteSynced(_ context.Context, _ block.ContentHash) error {
 	return nil

--- a/pkg/block/engine/syncer_test.go
+++ b/pkg/block/engine/syncer_test.go
@@ -289,7 +289,7 @@ func (m *markFailingSyncedHashStore) IsSynced(ctx context.Context, hash block.Co
 	return m.inner.IsSynced(ctx, hash)
 }
 
-func (m *markFailingSyncedHashStore) MarkSynced(ctx context.Context, hash block.ContentHash) error {
+func (m *markFailingSyncedHashStore) MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error {
 	m.mu.Lock()
 	if !m.failOnceUsed && m.failOnceErr != nil {
 		m.failOnceUsed = true
@@ -297,11 +297,15 @@ func (m *markFailingSyncedHashStore) MarkSynced(ctx context.Context, hash block.
 		return m.failOnceErr
 	}
 	m.mu.Unlock()
-	if err := m.inner.MarkSynced(ctx, hash); err != nil {
+	if err := m.inner.MarkSynced(ctx, hash, loc); err != nil {
 		return err
 	}
 	m.marks.Add(1)
 	return nil
+}
+
+func (m *markFailingSyncedHashStore) GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
+	return m.inner.GetLocator(ctx, hash)
 }
 
 func (m *markFailingSyncedHashStore) DeleteSynced(ctx context.Context, hash block.ContentHash) error {

--- a/pkg/block/local/fs/backpressure_test.go
+++ b/pkg/block/local/fs/backpressure_test.go
@@ -98,7 +98,7 @@ func TestBackpressure_HealthyRemote_ReleasesWhenDrained(t *testing.T) {
 	// mark hA synced so it becomes evictable, freeing 200 bytes.
 	go func() {
 		time.Sleep(150 * time.Millisecond)
-		_ = mds.MarkSynced(ctx, hA)
+		_ = mds.MarkSynced(ctx, hA, block.ChunkLocator{})
 		src.unsynced.Add(-200)
 	}()
 

--- a/pkg/block/local/fs/blockstore_methods_test.go
+++ b/pkg/block/local/fs/blockstore_methods_test.go
@@ -120,7 +120,7 @@ func TestFSStore_ListUnsynced(t *testing.T) {
 		hashes := seedChunks(t, bc, 4)
 		ctx := context.Background()
 		for _, h := range hashes {
-			if err := shs.MarkSynced(ctx, h); err != nil {
+			if err := shs.MarkSynced(ctx, h, block.ChunkLocator{}); err != nil {
 				t.Fatalf("MarkSynced: %v", err)
 			}
 		}
@@ -161,7 +161,7 @@ func TestFSStore_ListUnsynced(t *testing.T) {
 		// Mark two as synced; remaining three must be the yielded set.
 		synced := []block.ContentHash{hashes[1], hashes[3]}
 		for _, h := range synced {
-			if err := shs.MarkSynced(ctx, h); err != nil {
+			if err := shs.MarkSynced(ctx, h, block.ChunkLocator{}); err != nil {
 				t.Fatalf("MarkSynced: %v", err)
 			}
 		}

--- a/pkg/block/local/fs/eviction_unsynced_protection_test.go
+++ b/pkg/block/local/fs/eviction_unsynced_protection_test.go
@@ -107,7 +107,7 @@ func TestLRU_SyncedChunk_EvictedBeforeUnsynced(t *testing.T) {
 	hSynced := storeChunk(t, bc, bytes.Repeat([]byte{0x10}, 200))
 	hUnsynced := storeChunk(t, bc, bytes.Repeat([]byte{0x11}, 200))
 
-	if err := mds.MarkSynced(ctx, hSynced); err != nil {
+	if err := mds.MarkSynced(ctx, hSynced, block.ChunkLocator{}); err != nil {
 		t.Fatalf("MarkSynced: %v", err)
 	}
 
@@ -143,8 +143,11 @@ func (s *slowSyncedHashStore) IsSynced(ctx context.Context, h block.ContentHash)
 	return s.inner.IsSynced(ctx, h)
 }
 
-func (s *slowSyncedHashStore) MarkSynced(ctx context.Context, h block.ContentHash) error {
-	return s.inner.MarkSynced(ctx, h)
+func (s *slowSyncedHashStore) MarkSynced(ctx context.Context, h block.ContentHash, loc block.ChunkLocator) error {
+	return s.inner.MarkSynced(ctx, h, loc)
+}
+func (s *slowSyncedHashStore) GetLocator(ctx context.Context, h block.ContentHash) (block.ChunkLocator, bool, error) {
+	return s.inner.GetLocator(ctx, h)
 }
 
 func (s *slowSyncedHashStore) DeleteSynced(ctx context.Context, h block.ContentHash) error {
@@ -183,7 +186,7 @@ func TestLRU_EvictTouchRace(t *testing.T) {
 		// Mark half synced so eviction actually removes some entries while
 		// the rest are moved-to-front — exercising both recheck branches.
 		if i%2 == 0 {
-			if err := mds.MarkSynced(ctx, h); err != nil {
+			if err := mds.MarkSynced(ctx, h, block.ChunkLocator{}); err != nil {
 				t.Fatalf("MarkSynced: %v", err)
 			}
 		}

--- a/pkg/block/locator.go
+++ b/pkg/block/locator.go
@@ -2,41 +2,41 @@ package block
 
 // ChunkLocator resolves a chunk content hash to the physical location of its
 // bytes in the remote store. It is the indirection layer that lets a chunk live
-// either as its own standalone CAS object (today) or inside a larger "pack"
+// either as its own standalone CAS object (today) or inside a larger "block"
 // object (#1414 object packing, PR3b).
 //
-//   - PackID == "" means the chunk is a standalone object at the canonical CAS
+//   - BlockID == "" means the chunk is a standalone object at the canonical CAS
 //     key cas/XX/YY/<hash> (see FormatCASKey) and occupies the WHOLE object.
 //     Offset/Length are not consulted in this case — the read path GETs the
 //     entire object and verifies it. This is the value EVERY chunk resolves to
 //     today (and what a synced hash with no recorded locator defaults to), so
 //     existing data needs no migration.
-//   - PackID != "" means the chunk lives inside the pack object packs/<PackID>
-//     (see FormatPackKey), and its wire bytes occupy [Offset, Offset+Length).
-//     The read path issues a ranged GET against the pack object. Only PR3b's
+//   - BlockID != "" means the chunk lives inside the block object blocks/<BlockID>
+//     (see FormatBlockKey), and its wire bytes occupy [Offset, Offset+Length).
+//     The read path issues a ranged GET against the block object. Only PR3b's
 //     packer ever produces such a locator.
 type ChunkLocator struct {
-	// PackID identifies the enclosing pack object. Empty means standalone.
-	PackID string
-	// Offset is the byte offset of the chunk's wire bytes within the pack
+	// BlockID identifies the enclosing block object. Empty means standalone.
+	BlockID string
+	// Offset is the byte offset of the chunk's wire bytes within the block
 	// object. Zero (and unused) for standalone chunks.
 	Offset int64
-	// Length is the chunk's wire byte length within the pack object. Zero
+	// Length is the chunk's wire byte length within the block object. Zero
 	// (and unused) for standalone chunks, whose length is the whole object.
 	Length int64
 }
 
 // IsStandalone reports whether the chunk is stored as its own CAS object
-// (PackID == "") rather than inside a pack.
-func (l ChunkLocator) IsStandalone() bool { return l.PackID == "" }
+// (BlockID == "") rather than inside a block.
+func (l ChunkLocator) IsStandalone() bool { return l.BlockID == "" }
 
-// PackKeyPrefix is the object-key prefix under which pack objects live, mirroring
+// BlockKeyPrefix is the object-key prefix under which block objects live, mirroring
 // CASKeyPrefix ("cas/") for standalone chunk objects.
-const PackKeyPrefix = "packs/"
+const BlockKeyPrefix = "blocks/"
 
-// FormatPackKey returns the object key for a pack identified by packID:
-// "packs/<packID>". It is the pack-object analogue of FormatCASKey for
+// FormatBlockKey returns the object key for a block identified by blockID:
+// "blocks/<blockID>". It is the block-object analogue of FormatCASKey for
 // standalone chunk objects.
-func FormatPackKey(packID string) string {
-	return PackKeyPrefix + packID
+func FormatBlockKey(blockID string) string {
+	return BlockKeyPrefix + blockID
 }

--- a/pkg/block/locator.go
+++ b/pkg/block/locator.go
@@ -1,0 +1,42 @@
+package block
+
+// ChunkLocator resolves a chunk content hash to the physical location of its
+// bytes in the remote store. It is the indirection layer that lets a chunk live
+// either as its own standalone CAS object (today) or inside a larger "pack"
+// object (#1414 object packing, PR3b).
+//
+//   - PackID == "" means the chunk is a standalone object at the canonical CAS
+//     key cas/XX/YY/<hash> (see FormatCASKey) and occupies the WHOLE object.
+//     Offset/Length are not consulted in this case — the read path GETs the
+//     entire object and verifies it. This is the value EVERY chunk resolves to
+//     today (and what a synced hash with no recorded locator defaults to), so
+//     existing data needs no migration.
+//   - PackID != "" means the chunk lives inside the pack object packs/<PackID>
+//     (see FormatPackKey), and its wire bytes occupy [Offset, Offset+Length).
+//     The read path issues a ranged GET against the pack object. Only PR3b's
+//     packer ever produces such a locator.
+type ChunkLocator struct {
+	// PackID identifies the enclosing pack object. Empty means standalone.
+	PackID string
+	// Offset is the byte offset of the chunk's wire bytes within the pack
+	// object. Zero (and unused) for standalone chunks.
+	Offset int64
+	// Length is the chunk's wire byte length within the pack object. Zero
+	// (and unused) for standalone chunks, whose length is the whole object.
+	Length int64
+}
+
+// IsStandalone reports whether the chunk is stored as its own CAS object
+// (PackID == "") rather than inside a pack.
+func (l ChunkLocator) IsStandalone() bool { return l.PackID == "" }
+
+// PackKeyPrefix is the object-key prefix under which pack objects live, mirroring
+// CASKeyPrefix ("cas/") for standalone chunk objects.
+const PackKeyPrefix = "packs/"
+
+// FormatPackKey returns the object key for a pack identified by packID:
+// "packs/<packID>". It is the pack-object analogue of FormatCASKey for
+// standalone chunk objects.
+func FormatPackKey(packID string) string {
+	return PackKeyPrefix + packID
+}

--- a/pkg/block/remote/memory/store.go
+++ b/pkg/block/remote/memory/store.go
@@ -19,6 +19,7 @@ import (
 // Compile-time interface satisfaction check.
 var (
 	_ remote.RemoteStore       = (*Store)(nil)
+	_ remote.PackChunkReader   = (*Store)(nil)
 	_ block.DurabilityReporter = (*Store)(nil)
 )
 
@@ -35,6 +36,11 @@ type memBlock struct {
 type Store struct {
 	mu     sync.RWMutex
 	blocks map[block.ContentHash]*memBlock
+	// packs holds pack objects keyed by PackID (#1414). Populated via PutPack
+	// (used by tests and the future packer); read by GetPackChunk. Separate
+	// from blocks because pack objects are keyed by an opaque PackID string,
+	// not a content hash.
+	packs map[string][]byte
 	// nowFn returns the current time for the store. Tests can override
 	// this to manipulate LastModified deterministically.
 	nowFn  func() time.Time
@@ -50,8 +56,57 @@ type Store struct {
 func New() *Store {
 	return &Store{
 		blocks: make(map[block.ContentHash]*memBlock),
+		packs:  make(map[string][]byte),
 		nowFn:  time.Now,
 	}
+}
+
+// PutPack stores a pack object under packID. It is the in-memory analogue of an
+// S3 PutObject(packs/<packID>); used by tests (and the future PR3b packer) to
+// stage packs that GetPackChunk then ranges into. A defensive copy is taken.
+func (s *Store) PutPack(packID string, data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return block.ErrStoreClosed
+	}
+	if s.packs == nil {
+		s.packs = make(map[string][]byte)
+	}
+	copied := make([]byte, len(data))
+	copy(copied, data)
+	s.packs[packID] = copied
+	return nil
+}
+
+// GetPackChunk returns the wire bytes [offset, offset+length) from the pack
+// object packID. As a base store there is no transform to invert and no
+// verification here. Implements remote.PackChunkReader; hash is unused at this
+// layer. Bounds semantics mirror GetRange.
+func (s *Store) GetPackChunk(_ context.Context, packID string, offset, length int64, _ block.ContentHash) ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return nil, block.ErrStoreClosed
+	}
+	data, ok := s.packs[packID]
+	if !ok {
+		return nil, block.ErrChunkNotFound
+	}
+	if offset < 0 || offset >= int64(len(data)) {
+		return nil, block.ErrInvalidOffset
+	}
+	if length <= 0 {
+		return nil, block.ErrInvalidSize
+	}
+	size := int64(len(data))
+	end := size
+	if length <= size-offset {
+		end = offset + length
+	}
+	result := make([]byte, end-offset)
+	copy(result, data[offset:end])
+	return result, nil
 }
 
 // Durable reports whether accepted bytes survive a crash/restart

--- a/pkg/block/remote/memory/store.go
+++ b/pkg/block/remote/memory/store.go
@@ -19,7 +19,7 @@ import (
 // Compile-time interface satisfaction check.
 var (
 	_ remote.RemoteStore       = (*Store)(nil)
-	_ remote.PackChunkReader   = (*Store)(nil)
+	_ remote.ChunkReader       = (*Store)(nil)
 	_ block.DurabilityReporter = (*Store)(nil)
 )
 
@@ -36,11 +36,11 @@ type memBlock struct {
 type Store struct {
 	mu     sync.RWMutex
 	blocks map[block.ContentHash]*memBlock
-	// packs holds pack objects keyed by PackID (#1414). Populated via PutPack
-	// (used by tests and the future packer); read by GetPackChunk. Separate
-	// from blocks because pack objects are keyed by an opaque PackID string,
+	// blocksByID holds block objects keyed by BlockID (#1414). Populated via PutBlock
+	// (used by tests and the future packer); read by ReadChunk. Separate
+	// from blocks because block objects are keyed by an opaque BlockID string,
 	// not a content hash.
-	packs map[string][]byte
+	blocksByID map[string][]byte
 	// nowFn returns the current time for the store. Tests can override
 	// this to manipulate LastModified deterministically.
 	nowFn  func() time.Time
@@ -55,41 +55,41 @@ type Store struct {
 // New creates a new in-memory remote block store.
 func New() *Store {
 	return &Store{
-		blocks: make(map[block.ContentHash]*memBlock),
-		packs:  make(map[string][]byte),
-		nowFn:  time.Now,
+		blocks:     make(map[block.ContentHash]*memBlock),
+		blocksByID: make(map[string][]byte),
+		nowFn:      time.Now,
 	}
 }
 
-// PutPack stores a pack object under packID. It is the in-memory analogue of an
-// S3 PutObject(packs/<packID>); used by tests (and the future PR3b packer) to
-// stage packs that GetPackChunk then ranges into. A defensive copy is taken.
-func (s *Store) PutPack(packID string, data []byte) error {
+// PutBlock stores a block object under blockID. It is the in-memory analogue of an
+// S3 PutObject(blocks/<blockID>); used by tests (and the future PR3b packer) to
+// stage blocksByID that ReadChunk then ranges into. A defensive copy is taken.
+func (s *Store) PutBlock(blockID string, data []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
 		return block.ErrStoreClosed
 	}
-	if s.packs == nil {
-		s.packs = make(map[string][]byte)
+	if s.blocksByID == nil {
+		s.blocksByID = make(map[string][]byte)
 	}
 	copied := make([]byte, len(data))
 	copy(copied, data)
-	s.packs[packID] = copied
+	s.blocksByID[blockID] = copied
 	return nil
 }
 
-// GetPackChunk returns the wire bytes [offset, offset+length) from the pack
-// object packID. As a base store there is no transform to invert and no
-// verification here. Implements remote.PackChunkReader; hash is unused at this
+// ReadChunk returns the wire bytes [offset, offset+length) from the block
+// object blockID. As a base store there is no transform to invert and no
+// verification here. Implements remote.ChunkReader; hash is unused at this
 // layer. Bounds semantics mirror GetRange.
-func (s *Store) GetPackChunk(_ context.Context, packID string, offset, length int64, _ block.ContentHash) ([]byte, error) {
+func (s *Store) ReadChunk(_ context.Context, blockID string, offset, length int64, _ block.ContentHash) ([]byte, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.closed {
 		return nil, block.ErrStoreClosed
 	}
-	data, ok := s.packs[packID]
+	data, ok := s.blocksByID[blockID]
 	if !ok {
 		return nil, block.ErrChunkNotFound
 	}

--- a/pkg/block/remote/memory/store_test.go
+++ b/pkg/block/remote/memory/store_test.go
@@ -322,40 +322,40 @@ func TestStore_Walk_CallbackErrorWrapped(t *testing.T) {
 
 // TestStore_ReadBlockVerified covers the happy path and the
 // body-mismatch failure mode.
-// TestStore_GetPackChunk covers the base-store pack range read used by the
-// #1414 locator read path: a chunk staged inside a pack object is returned
+// TestStore_ReadChunk covers the base-store block range read used by the
+// #1414 locator read path: a chunk staged inside a block object is returned
 // verbatim for its [offset, length) slice, with GetRange-style bounds checks.
-func TestStore_GetPackChunk(t *testing.T) {
+func TestStore_ReadChunk(t *testing.T) {
 	ctx := context.Background()
 	s := New()
 
 	a := bytes.Repeat([]byte{0xA1}, 64)
 	b := bytes.Repeat([]byte{0xB2}, 128)
-	pack := append(append([]byte{}, a...), b...)
-	const packID = "pack-mem-1"
-	if err := s.PutPack(packID, pack); err != nil {
-		t.Fatalf("PutPack: %v", err)
+	blockData := append(append([]byte{}, a...), b...)
+	const blockID = "block-mem-1"
+	if err := s.PutBlock(blockID, blockData); err != nil {
+		t.Fatalf("PutBlock: %v", err)
 	}
 
-	got, err := s.GetPackChunk(ctx, packID, int64(len(a)), int64(len(b)), block.ContentHash{})
+	got, err := s.ReadChunk(ctx, blockID, int64(len(a)), int64(len(b)), block.ContentHash{})
 	if err != nil {
-		t.Fatalf("GetPackChunk: %v", err)
+		t.Fatalf("ReadChunk: %v", err)
 	}
 	if !bytes.Equal(got, b) {
-		t.Fatalf("GetPackChunk returned wrong slice")
+		t.Fatalf("ReadChunk returned wrong slice")
 	}
 
-	if _, err := s.GetPackChunk(ctx, "missing", 0, 1, block.ContentHash{}); !errors.Is(err, block.ErrChunkNotFound) {
-		t.Fatalf("missing pack: got %v, want ErrChunkNotFound", err)
+	if _, err := s.ReadChunk(ctx, "missing", 0, 1, block.ContentHash{}); !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("missing block: got %v, want ErrChunkNotFound", err)
 	}
-	if _, err := s.GetPackChunk(ctx, packID, -1, 1, block.ContentHash{}); !errors.Is(err, block.ErrInvalidOffset) {
+	if _, err := s.ReadChunk(ctx, blockID, -1, 1, block.ContentHash{}); !errors.Is(err, block.ErrInvalidOffset) {
 		t.Fatalf("negative offset: got %v, want ErrInvalidOffset", err)
 	}
-	if _, err := s.GetPackChunk(ctx, packID, 0, 0, block.ContentHash{}); !errors.Is(err, block.ErrInvalidSize) {
+	if _, err := s.ReadChunk(ctx, blockID, 0, 0, block.ContentHash{}); !errors.Is(err, block.ErrInvalidSize) {
 		t.Fatalf("zero length: got %v, want ErrInvalidSize", err)
 	}
 	// Past-EOF length clamps to remaining bytes (no error), mirroring GetRange.
-	clamped, err := s.GetPackChunk(ctx, packID, int64(len(a)), 1<<20, block.ContentHash{})
+	clamped, err := s.ReadChunk(ctx, blockID, int64(len(a)), 1<<20, block.ContentHash{})
 	if err != nil {
 		t.Fatalf("clamped read: %v", err)
 	}

--- a/pkg/block/remote/memory/store_test.go
+++ b/pkg/block/remote/memory/store_test.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -321,6 +322,48 @@ func TestStore_Walk_CallbackErrorWrapped(t *testing.T) {
 
 // TestStore_ReadBlockVerified covers the happy path and the
 // body-mismatch failure mode.
+// TestStore_GetPackChunk covers the base-store pack range read used by the
+// #1414 locator read path: a chunk staged inside a pack object is returned
+// verbatim for its [offset, length) slice, with GetRange-style bounds checks.
+func TestStore_GetPackChunk(t *testing.T) {
+	ctx := context.Background()
+	s := New()
+
+	a := bytes.Repeat([]byte{0xA1}, 64)
+	b := bytes.Repeat([]byte{0xB2}, 128)
+	pack := append(append([]byte{}, a...), b...)
+	const packID = "pack-mem-1"
+	if err := s.PutPack(packID, pack); err != nil {
+		t.Fatalf("PutPack: %v", err)
+	}
+
+	got, err := s.GetPackChunk(ctx, packID, int64(len(a)), int64(len(b)), block.ContentHash{})
+	if err != nil {
+		t.Fatalf("GetPackChunk: %v", err)
+	}
+	if !bytes.Equal(got, b) {
+		t.Fatalf("GetPackChunk returned wrong slice")
+	}
+
+	if _, err := s.GetPackChunk(ctx, "missing", 0, 1, block.ContentHash{}); !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("missing pack: got %v, want ErrChunkNotFound", err)
+	}
+	if _, err := s.GetPackChunk(ctx, packID, -1, 1, block.ContentHash{}); !errors.Is(err, block.ErrInvalidOffset) {
+		t.Fatalf("negative offset: got %v, want ErrInvalidOffset", err)
+	}
+	if _, err := s.GetPackChunk(ctx, packID, 0, 0, block.ContentHash{}); !errors.Is(err, block.ErrInvalidSize) {
+		t.Fatalf("zero length: got %v, want ErrInvalidSize", err)
+	}
+	// Past-EOF length clamps to remaining bytes (no error), mirroring GetRange.
+	clamped, err := s.GetPackChunk(ctx, packID, int64(len(a)), 1<<20, block.ContentHash{})
+	if err != nil {
+		t.Fatalf("clamped read: %v", err)
+	}
+	if !bytes.Equal(clamped, b) {
+		t.Fatalf("clamped read returned wrong bytes")
+	}
+}
+
 func TestStore_ReadBlockVerified(t *testing.T) {
 	ctx := context.Background()
 	s := New()

--- a/pkg/block/remote/remote.go
+++ b/pkg/block/remote/remote.go
@@ -11,10 +11,17 @@ package remote
 
 import (
 	"context"
+	"errors"
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/health"
 )
+
+// ErrPackReadUnsupported is returned by a decorator's GetPackChunk when the
+// wrapped store does not implement PackChunkReader, so a pack read cannot be
+// composed through the transform stack. It cannot occur on the live PR3a path
+// (which never produces pack locators); it guards the capability boundary.
+var ErrPackReadUnsupported = errors.New("remote: wrapped store does not support pack reads")
 
 // RemoteStore is the unified content-addressed remote block storage
 // interface. Implemented by
@@ -74,4 +81,27 @@ type RemoteStore interface {
 	// [health.Checker]. Implementations typically delegate to HealthCheck
 	// and wrap the result via [health.ReportFromError].
 	Healthcheck(ctx context.Context) health.Report
+}
+
+// PackChunkReader is an OPTIONAL RemoteStore capability for reading a chunk that
+// lives inside a pack object (#1414 object packing). It is deliberately kept OFF
+// the RemoteStore contract — only the locator read path needs it, so the many
+// RemoteStore test fakes need not implement it (mirroring how EnumerateSynced is
+// kept off metadata.SyncedHashStore). The engine type-asserts m.remoteStore to
+// this interface when a block.ChunkLocator resolves to a pack (PackID != "");
+// the s3 + memory backends and the encryption/compression decorators implement
+// it.
+//
+// GetPackChunk reads the chunk whose stored wire bytes occupy
+// [offset, offset+length) within pack object packs/<packID> (see
+// block.FormatPackKey) and returns the chunk PLAINTEXT, inverting the store's
+// transform chain on the way up — each decorator decompresses/decrypts its own
+// layer, threading hash as the AEAD AAD. It does NOT verify the BLAKE3 (no
+// single layer holds both the wire bytes and the plaintext hash domain); the
+// engine read path verifies blake3(result) == hash after the top-level call,
+// exactly as ReadBlockVerified guarantees for standalone objects. hash is
+// consulted only by the encryption layer (AAD) and ignored by the base stores
+// and the compression layer.
+type PackChunkReader interface {
+	GetPackChunk(ctx context.Context, packID string, offset, length int64, hash block.ContentHash) ([]byte, error)
 }

--- a/pkg/block/remote/remote.go
+++ b/pkg/block/remote/remote.go
@@ -17,11 +17,11 @@ import (
 	"github.com/marmos91/dittofs/pkg/health"
 )
 
-// ErrPackReadUnsupported is returned by a decorator's GetPackChunk when the
-// wrapped store does not implement PackChunkReader, so a pack read cannot be
+// ErrChunkReadUnsupported is returned by a decorator's ReadChunk when the
+// wrapped store does not implement ChunkReader, so a block read cannot be
 // composed through the transform stack. It cannot occur on the live PR3a path
-// (which never produces pack locators); it guards the capability boundary.
-var ErrPackReadUnsupported = errors.New("remote: wrapped store does not support pack reads")
+// (which never produces block locators); it guards the capability boundary.
+var ErrChunkReadUnsupported = errors.New("remote: wrapped store does not support block reads")
 
 // RemoteStore is the unified content-addressed remote block storage
 // interface. Implemented by
@@ -83,18 +83,18 @@ type RemoteStore interface {
 	Healthcheck(ctx context.Context) health.Report
 }
 
-// PackChunkReader is an OPTIONAL RemoteStore capability for reading a chunk that
-// lives inside a pack object (#1414 object packing). It is deliberately kept OFF
+// ChunkReader is an OPTIONAL RemoteStore capability for reading a chunk that
+// lives inside a block object (#1414 object packing). It is deliberately kept OFF
 // the RemoteStore contract — only the locator read path needs it, so the many
 // RemoteStore test fakes need not implement it (mirroring how EnumerateSynced is
 // kept off metadata.SyncedHashStore). The engine type-asserts m.remoteStore to
-// this interface when a block.ChunkLocator resolves to a pack (PackID != "");
+// this interface when a block.ChunkLocator resolves to a block (BlockID != "");
 // the s3 + memory backends and the encryption/compression decorators implement
 // it.
 //
-// GetPackChunk reads the chunk whose stored wire bytes occupy
-// [offset, offset+length) within pack object packs/<packID> (see
-// block.FormatPackKey) and returns the chunk PLAINTEXT, inverting the store's
+// ReadChunk reads the chunk whose stored wire bytes occupy
+// [offset, offset+length) within block object blocks/<blockID> (see
+// block.FormatBlockKey) and returns the chunk PLAINTEXT, inverting the store's
 // transform chain on the way up — each decorator decompresses/decrypts its own
 // layer, threading hash as the AEAD AAD. It does NOT verify the BLAKE3 (no
 // single layer holds both the wire bytes and the plaintext hash domain); the
@@ -102,6 +102,6 @@ type RemoteStore interface {
 // exactly as ReadBlockVerified guarantees for standalone objects. hash is
 // consulted only by the encryption layer (AAD) and ignored by the base stores
 // and the compression layer.
-type PackChunkReader interface {
-	GetPackChunk(ctx context.Context, packID string, offset, length int64, hash block.ContentHash) ([]byte, error)
+type ChunkReader interface {
+	ReadChunk(ctx context.Context, blockID string, offset, length int64, hash block.ContentHash) ([]byte, error)
 }

--- a/pkg/block/remote/s3/store.go
+++ b/pkg/block/remote/s3/store.go
@@ -54,6 +54,7 @@ const maxS3ConnsPerHost = 256
 // Compile-time interface satisfaction check.
 var (
 	_ remote.RemoteStore       = (*Store)(nil)
+	_ remote.PackChunkReader   = (*Store)(nil)
 	_ block.DurabilityReporter = (*Store)(nil)
 )
 
@@ -511,6 +512,49 @@ func (s *Store) GetRange(ctx context.Context, hash block.ContentHash, offset, le
 			return nil, block.ErrChunkNotFound
 		}
 		return nil, fmt.Errorf("s3 get range: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	return readResponseBody(resp.Body, resp.ContentLength, length)
+}
+
+// packKey returns the full S3 key for a pack object identified by packID.
+func (s *Store) packKey(packID string) string {
+	return s.fullKey(block.FormatPackKey(packID))
+}
+
+// GetPackChunk reads the wire bytes [offset, offset+length) from the pack object
+// packs/<packID> via an S3 range request and returns them verbatim. As a base
+// store there is no transform to invert and no verification here (the engine
+// verifies the BLAKE3 after the decorator stack). Implements
+// remote.PackChunkReader; hash is unused at this layer. See GetRange for the
+// bounds-validation rationale.
+func (s *Store) GetPackChunk(ctx context.Context, packID string, offset, length int64, _ block.ContentHash) ([]byte, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, err
+	}
+	if offset < 0 {
+		return nil, block.ErrInvalidOffset
+	}
+	if length <= 0 {
+		return nil, block.ErrInvalidSize
+	}
+	if length > math.MaxInt64-offset {
+		return nil, block.ErrInvalidSize
+	}
+
+	key := s.packKey(packID)
+	rangeHeader := fmt.Sprintf("bytes=%d-%d", offset, offset+length-1)
+	resp, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+		Range:  aws.String(rangeHeader),
+	})
+	if err != nil {
+		if isNotFoundError(err) {
+			return nil, block.ErrChunkNotFound
+		}
+		return nil, fmt.Errorf("s3 get pack chunk: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/pkg/block/remote/s3/store.go
+++ b/pkg/block/remote/s3/store.go
@@ -54,7 +54,7 @@ const maxS3ConnsPerHost = 256
 // Compile-time interface satisfaction check.
 var (
 	_ remote.RemoteStore       = (*Store)(nil)
-	_ remote.PackChunkReader   = (*Store)(nil)
+	_ remote.ChunkReader       = (*Store)(nil)
 	_ block.DurabilityReporter = (*Store)(nil)
 )
 
@@ -518,18 +518,18 @@ func (s *Store) GetRange(ctx context.Context, hash block.ContentHash, offset, le
 	return readResponseBody(resp.Body, resp.ContentLength, length)
 }
 
-// packKey returns the full S3 key for a pack object identified by packID.
-func (s *Store) packKey(packID string) string {
-	return s.fullKey(block.FormatPackKey(packID))
+// blockKey returns the full S3 key for a block object identified by blockID.
+func (s *Store) blockKey(blockID string) string {
+	return s.fullKey(block.FormatBlockKey(blockID))
 }
 
-// GetPackChunk reads the wire bytes [offset, offset+length) from the pack object
-// packs/<packID> via an S3 range request and returns them verbatim. As a base
+// ReadChunk reads the wire bytes [offset, offset+length) from the block object
+// blocks/<blockID> via an S3 range request and returns them verbatim. As a base
 // store there is no transform to invert and no verification here (the engine
 // verifies the BLAKE3 after the decorator stack). Implements
-// remote.PackChunkReader; hash is unused at this layer. See GetRange for the
+// remote.ChunkReader; hash is unused at this layer. See GetRange for the
 // bounds-validation rationale.
-func (s *Store) GetPackChunk(ctx context.Context, packID string, offset, length int64, _ block.ContentHash) ([]byte, error) {
+func (s *Store) ReadChunk(ctx context.Context, blockID string, offset, length int64, _ block.ContentHash) ([]byte, error) {
 	if err := s.checkClosed(); err != nil {
 		return nil, err
 	}
@@ -543,7 +543,7 @@ func (s *Store) GetPackChunk(ctx context.Context, packID string, offset, length 
 		return nil, block.ErrInvalidSize
 	}
 
-	key := s.packKey(packID)
+	key := s.blockKey(blockID)
 	rangeHeader := fmt.Sprintf("bytes=%d-%d", offset, offset+length-1)
 	resp, err := s.client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(s.bucket),
@@ -554,7 +554,7 @@ func (s *Store) GetPackChunk(ctx context.Context, packID string, offset, length 
 		if isNotFoundError(err) {
 			return nil, block.ErrChunkNotFound
 		}
-		return nil, fmt.Errorf("s3 get pack chunk: %w", err)
+		return nil, fmt.Errorf("s3 get block chunk: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/pkg/metadata/store/badger/synced_hash_store.go
+++ b/pkg/metadata/store/badger/synced_hash_store.go
@@ -30,17 +30,17 @@ import (
 //
 // Key Namespace:
 //   - synced:{32-byte-hash}  value = 8 big-endian nanos of first-mirror time,
-//     OPTIONALLY followed by a pack-locator suffix (presence == synced; legacy
+//     OPTIONALLY followed by a block-locator suffix (presence == synced; legacy
 //     markers carry an empty value, decoded as a zero time + standalone locator)
 //
 // The 32-byte hash bytes are appended raw (matching rollup_offset's compact
 // binary key encoding) rather than hex-encoded — Badger does not require
 // printable keys, and raw bytes keep the key half the size on disk.
 //
-// Locator encoding (#1414): a standalone chunk (ChunkLocator.PackID == "")
+// Locator encoding (#1414): a standalone chunk (ChunkLocator.BlockID == "")
 // writes ONLY the 8-byte timestamp — byte-for-byte identical to a pre-locator
-// marker — because its location is fully implied by its hash. A pack-resident
-// chunk appends, after the timestamp: a uint16 PackID length, the PackID bytes,
+// marker — because its location is fully implied by its hash. A block-resident
+// chunk appends, after the timestamp: a uint16 BlockID length, the BlockID bytes,
 // then int64 Offset and int64 Length (all big-endian). A value of <= 8 bytes
 // therefore decodes to a standalone locator with no migration of existing rows.
 // ============================================================================
@@ -48,22 +48,22 @@ import (
 const syncedHashPrefix = "synced:"
 
 // encodeSyncedValue builds the marker value: an 8-byte first-mirror timestamp
-// followed, only for a pack-resident chunk, by the locator suffix described
+// followed, only for a block-resident chunk, by the locator suffix described
 // above. Standalone chunks produce the legacy 8-byte form.
 func encodeSyncedValue(nanos int64, loc block.ChunkLocator) []byte {
 	val := encodeInt64(nanos)
 	if loc.IsStandalone() {
 		return val
 	}
-	suffix := make([]byte, 2+len(loc.PackID)+16)
-	binary.BigEndian.PutUint16(suffix[0:2], uint16(len(loc.PackID)))
-	n := 2 + copy(suffix[2:], loc.PackID)
+	suffix := make([]byte, 2+len(loc.BlockID)+16)
+	binary.BigEndian.PutUint16(suffix[0:2], uint16(len(loc.BlockID)))
+	n := 2 + copy(suffix[2:], loc.BlockID)
 	binary.BigEndian.PutUint64(suffix[n:n+8], uint64(loc.Offset))
 	binary.BigEndian.PutUint64(suffix[n+8:n+16], uint64(loc.Length))
 	return append(val, suffix...)
 }
 
-// decodeSyncedLocator extracts the pack locator from a marker value. A value of
+// decodeSyncedLocator extracts the block locator from a marker value. A value of
 // 8 bytes or fewer (legacy/standalone) yields the zero (standalone) locator. A
 // malformed suffix also falls back to standalone — fail-safe, since standalone
 // is always a valid resolution.
@@ -79,10 +79,10 @@ func decodeSyncedLocator(val []byte) block.ChunkLocator {
 	if len(suffix) < 2+idLen+16 {
 		return block.ChunkLocator{}
 	}
-	packID := string(suffix[2 : 2+idLen])
+	blockID := string(suffix[2 : 2+idLen])
 	off := int64(binary.BigEndian.Uint64(suffix[2+idLen : 2+idLen+8]))
 	length := int64(binary.BigEndian.Uint64(suffix[2+idLen+8 : 2+idLen+16]))
-	return block.ChunkLocator{PackID: packID, Offset: off, Length: length}
+	return block.ChunkLocator{BlockID: blockID, Offset: off, Length: length}
 }
 
 // Compile-time assertion: the Badger engine implements SyncedHashStore.
@@ -147,7 +147,7 @@ func (s *BadgerMetadataStore) MarkSynced(ctx context.Context, hash block.Content
 }
 
 // GetLocator returns the recorded remote locator for hash. (zero, false, nil)
-// when unsynced; a synced hash with no pack-locator suffix (standalone/legacy)
+// when unsynced; a synced hash with no block-locator suffix (standalone/legacy)
 // yields the zero (standalone) locator with found == true.
 func (s *BadgerMetadataStore) GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
 	if err := ctx.Err(); err != nil {

--- a/pkg/metadata/store/badger/synced_hash_store.go
+++ b/pkg/metadata/store/badger/synced_hash_store.go
@@ -2,6 +2,7 @@ package badger
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"time"
@@ -28,15 +29,61 @@ import (
 // coordination is required between callers.
 //
 // Key Namespace:
-//   - synced:{32-byte-hash}  value = 8 big-endian nanos of first-mirror time
-//     (presence == synced; legacy markers carry an empty value)
+//   - synced:{32-byte-hash}  value = 8 big-endian nanos of first-mirror time,
+//     OPTIONALLY followed by a pack-locator suffix (presence == synced; legacy
+//     markers carry an empty value, decoded as a zero time + standalone locator)
 //
 // The 32-byte hash bytes are appended raw (matching rollup_offset's compact
 // binary key encoding) rather than hex-encoded — Badger does not require
 // printable keys, and raw bytes keep the key half the size on disk.
+//
+// Locator encoding (#1414): a standalone chunk (ChunkLocator.PackID == "")
+// writes ONLY the 8-byte timestamp — byte-for-byte identical to a pre-locator
+// marker — because its location is fully implied by its hash. A pack-resident
+// chunk appends, after the timestamp: a uint16 PackID length, the PackID bytes,
+// then int64 Offset and int64 Length (all big-endian). A value of <= 8 bytes
+// therefore decodes to a standalone locator with no migration of existing rows.
 // ============================================================================
 
 const syncedHashPrefix = "synced:"
+
+// encodeSyncedValue builds the marker value: an 8-byte first-mirror timestamp
+// followed, only for a pack-resident chunk, by the locator suffix described
+// above. Standalone chunks produce the legacy 8-byte form.
+func encodeSyncedValue(nanos int64, loc block.ChunkLocator) []byte {
+	val := encodeInt64(nanos)
+	if loc.IsStandalone() {
+		return val
+	}
+	suffix := make([]byte, 2+len(loc.PackID)+16)
+	binary.BigEndian.PutUint16(suffix[0:2], uint16(len(loc.PackID)))
+	n := 2 + copy(suffix[2:], loc.PackID)
+	binary.BigEndian.PutUint64(suffix[n:n+8], uint64(loc.Offset))
+	binary.BigEndian.PutUint64(suffix[n+8:n+16], uint64(loc.Length))
+	return append(val, suffix...)
+}
+
+// decodeSyncedLocator extracts the pack locator from a marker value. A value of
+// 8 bytes or fewer (legacy/standalone) yields the zero (standalone) locator. A
+// malformed suffix also falls back to standalone — fail-safe, since standalone
+// is always a valid resolution.
+func decodeSyncedLocator(val []byte) block.ChunkLocator {
+	if len(val) <= 8 {
+		return block.ChunkLocator{}
+	}
+	suffix := val[8:]
+	if len(suffix) < 2 {
+		return block.ChunkLocator{}
+	}
+	idLen := int(binary.BigEndian.Uint16(suffix[0:2]))
+	if len(suffix) < 2+idLen+16 {
+		return block.ChunkLocator{}
+	}
+	packID := string(suffix[2 : 2+idLen])
+	off := int64(binary.BigEndian.Uint64(suffix[2+idLen : 2+idLen+8]))
+	length := int64(binary.BigEndian.Uint64(suffix[2+idLen+8 : 2+idLen+16]))
+	return block.ChunkLocator{PackID: packID, Offset: off, Length: length}
+}
 
 // Compile-time assertion: the Badger engine implements SyncedHashStore.
 var _ metadata.SyncedHashStore = (*BadgerMetadataStore)(nil)
@@ -79,7 +126,7 @@ func (s *BadgerMetadataStore) IsSynced(ctx context.Context, hash block.ContentHa
 // grace anchor for the LIST-free sweep. Markers written before timestamps
 // existed carry an empty value and decode to a zero time (fail-closed: the
 // sweep leaves them for the periodic reconcile).
-func (s *BadgerMetadataStore) MarkSynced(ctx context.Context, hash block.ContentHash) error {
+func (s *BadgerMetadataStore) MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -87,16 +134,48 @@ func (s *BadgerMetadataStore) MarkSynced(ctx context.Context, hash block.Content
 	err := s.db.Update(func(txn *badger.Txn) error {
 		key := keySyncedHash(hash)
 		if _, gerr := txn.Get(key); gerr == nil {
-			return nil // already marked — preserve first-write timestamp
+			return nil // already marked — preserve first-write timestamp + locator
 		} else if !errors.Is(gerr, badger.ErrKeyNotFound) {
 			return gerr
 		}
-		return txn.Set(key, encodeInt64(time.Now().UnixNano()))
+		return txn.Set(key, encodeSyncedValue(time.Now().UnixNano(), loc))
 	})
 	if err != nil {
 		return fmt.Errorf("badger synced mark: %w", err)
 	}
 	return nil
+}
+
+// GetLocator returns the recorded remote locator for hash. (zero, false, nil)
+// when unsynced; a synced hash with no pack-locator suffix (standalone/legacy)
+// yields the zero (standalone) locator with found == true.
+func (s *BadgerMetadataStore) GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return block.ChunkLocator{}, false, err
+	}
+
+	var (
+		loc   block.ChunkLocator
+		found bool
+	)
+	err := s.db.View(func(txn *badger.Txn) error {
+		item, gerr := txn.Get(keySyncedHash(hash))
+		if errors.Is(gerr, badger.ErrKeyNotFound) {
+			return nil
+		}
+		if gerr != nil {
+			return gerr
+		}
+		found = true
+		return item.Value(func(val []byte) error {
+			loc = decodeSyncedLocator(val)
+			return nil
+		})
+	})
+	if err != nil {
+		return block.ChunkLocator{}, false, fmt.Errorf("badger synced get locator: %w", err)
+	}
+	return loc, found, nil
 }
 
 // EnumerateSynced streams every synced marker with its first-mirror time via a

--- a/pkg/metadata/store/memory/reset.go
+++ b/pkg/metadata/store/memory/reset.go
@@ -50,6 +50,7 @@ func (s *MemoryMetadataStore) Reset(ctx context.Context) error {
 
 	s.syncedMu.Lock()
 	s.synced = make(map[block.ContentHash]time.Time)
+	s.syncedLocators = nil // clear pack locators together with synced markers
 	s.syncedMu.Unlock()
 
 	return nil

--- a/pkg/metadata/store/memory/reset.go
+++ b/pkg/metadata/store/memory/reset.go
@@ -50,7 +50,7 @@ func (s *MemoryMetadataStore) Reset(ctx context.Context) error {
 
 	s.syncedMu.Lock()
 	s.synced = make(map[block.ContentHash]time.Time)
-	s.syncedLocators = nil // clear pack locators together with synced markers
+	s.syncedLocators = nil // clear block locators together with synced markers
 	s.syncedMu.Unlock()
 
 	return nil

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -267,10 +267,10 @@ type MemoryMetadataStore struct {
 	// time. Lazily initialized on first Mark; reads treat absence as
 	// not-synced.
 	synced map[block.ContentHash]time.Time
-	// syncedLocators records the remote pack locator for synced hashes that
-	// live inside a pack (#1414). Standalone chunks (ChunkLocator.PackID == "")
+	// syncedLocators records the remote block locator for synced hashes that
+	// live inside a block (#1414). Standalone chunks (ChunkLocator.BlockID == "")
 	// are NOT stored here — their absence resolves to the zero (standalone)
-	// locator, mirroring the SQL backends' NULL pack columns and badger's
+	// locator, mirroring the SQL backends' NULL block columns and badger's
 	// no-suffix marker, so the common case stays free. Guarded by syncedMu.
 	syncedLocators map[block.ContentHash]block.ChunkLocator
 

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -263,10 +263,16 @@ type MemoryMetadataStore struct {
 	// here (write-lock for Mark/Delete, read-lock for IsSynced).
 	syncedMu sync.RWMutex
 	// synced records "has this CAS hash been mirrored to remote?".
-	// Presence-of-key == synced; the time.Time value reserves capacity
-	// for future observability without a schema change. Lazily
-	// initialized on first Mark; reads treat absence as not-synced.
+	// Presence-of-key == synced; the time.Time value is the first-mirror
+	// time. Lazily initialized on first Mark; reads treat absence as
+	// not-synced.
 	synced map[block.ContentHash]time.Time
+	// syncedLocators records the remote pack locator for synced hashes that
+	// live inside a pack (#1414). Standalone chunks (ChunkLocator.PackID == "")
+	// are NOT stored here — their absence resolves to the zero (standalone)
+	// locator, mirroring the SQL backends' NULL pack columns and badger's
+	// no-suffix marker, so the common case stays free. Guarded by syncedMu.
+	syncedLocators map[block.ContentHash]block.ChunkLocator
 
 	// objectIndex maps FileAttr.ObjectID -> handle key (the same string
 	// used as the key in `files`) for the dedup short-circuit

--- a/pkg/metadata/store/memory/synced_hash_store.go
+++ b/pkg/metadata/store/memory/synced_hash_store.go
@@ -71,7 +71,7 @@ func (s *MemoryMetadataStore) IsSynced(ctx context.Context, hash block.ContentHa
 // would surface the most-recent re-Put time instead, which is
 // misleading when a periodic mirror loop re-checks already-synced
 // hashes.
-func (s *MemoryMetadataStore) MarkSynced(ctx context.Context, hash block.ContentHash) error {
+func (s *MemoryMetadataStore) MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -84,7 +84,32 @@ func (s *MemoryMetadataStore) MarkSynced(ctx context.Context, hash block.Content
 		return nil
 	}
 	s.synced[hash] = time.Now()
+	// Record only pack locators; standalone chunks resolve from absence.
+	if !loc.IsStandalone() {
+		if s.syncedLocators == nil {
+			s.syncedLocators = make(map[block.ContentHash]block.ChunkLocator)
+		}
+		s.syncedLocators[hash] = loc
+	}
 	return nil
+}
+
+// GetLocator returns the recorded remote locator for hash. (zero, false, nil)
+// when unsynced; a synced standalone/legacy hash yields the zero (standalone)
+// locator with found == true.
+func (s *MemoryMetadataStore) GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return block.ChunkLocator{}, false, err
+	}
+	s.syncedMu.RLock()
+	defer s.syncedMu.RUnlock()
+	if s.synced == nil {
+		return block.ChunkLocator{}, false, nil
+	}
+	if _, ok := s.synced[hash]; !ok {
+		return block.ChunkLocator{}, false, nil
+	}
+	return s.syncedLocators[hash], true, nil
 }
 
 // DeleteSynced removes the synced marker for hash. Idempotent: deleting
@@ -99,5 +124,6 @@ func (s *MemoryMetadataStore) DeleteSynced(ctx context.Context, hash block.Conte
 		return nil
 	}
 	delete(s.synced, hash)
+	delete(s.syncedLocators, hash)
 	return nil
 }

--- a/pkg/metadata/store/memory/synced_hash_store.go
+++ b/pkg/metadata/store/memory/synced_hash_store.go
@@ -84,7 +84,7 @@ func (s *MemoryMetadataStore) MarkSynced(ctx context.Context, hash block.Content
 		return nil
 	}
 	s.synced[hash] = time.Now()
-	// Record only pack locators; standalone chunks resolve from absence.
+	// Record only block locators; standalone chunks resolve from absence.
 	if !loc.IsStandalone() {
 		if s.syncedLocators == nil {
 			s.syncedLocators = make(map[block.ContentHash]block.ChunkLocator)

--- a/pkg/metadata/store/postgres/migrations/000035_synced_hash_locator.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000035_synced_hash_locator.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE synced_hashes DROP COLUMN IF EXISTS pack_length;
+ALTER TABLE synced_hashes DROP COLUMN IF EXISTS pack_offset;
+ALTER TABLE synced_hashes DROP COLUMN IF EXISTS pack_id;

--- a/pkg/metadata/store/postgres/migrations/000035_synced_hash_locator.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000035_synced_hash_locator.down.sql
@@ -1,3 +1,3 @@
-ALTER TABLE synced_hashes DROP COLUMN IF EXISTS pack_length;
-ALTER TABLE synced_hashes DROP COLUMN IF EXISTS pack_offset;
-ALTER TABLE synced_hashes DROP COLUMN IF EXISTS pack_id;
+ALTER TABLE synced_hashes DROP COLUMN IF EXISTS block_length;
+ALTER TABLE synced_hashes DROP COLUMN IF EXISTS block_offset;
+ALTER TABLE synced_hashes DROP COLUMN IF EXISTS block_id;

--- a/pkg/metadata/store/postgres/migrations/000035_synced_hash_locator.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000035_synced_hash_locator.up.sql
@@ -1,8 +1,8 @@
 -- #1414 object packing (PR3a): record WHERE a synced chunk's bytes live, so a
 -- chunk can resolve to either its standalone CAS object (NULL columns, the
 -- default for every existing row — no backfill needed) or a position inside a
--- pack object (pack_id/pack_offset/pack_length). Standalone marks leave these
--- NULL, so behavior is unchanged until PR3b's packer writes pack locators.
-ALTER TABLE synced_hashes ADD COLUMN IF NOT EXISTS pack_id TEXT;
-ALTER TABLE synced_hashes ADD COLUMN IF NOT EXISTS pack_offset BIGINT;
-ALTER TABLE synced_hashes ADD COLUMN IF NOT EXISTS pack_length BIGINT;
+-- block object (block_id/block_offset/block_length). Standalone marks leave these
+-- NULL, so behavior is unchanged until PR3b's packer writes block locators.
+ALTER TABLE synced_hashes ADD COLUMN IF NOT EXISTS block_id TEXT;
+ALTER TABLE synced_hashes ADD COLUMN IF NOT EXISTS block_offset BIGINT;
+ALTER TABLE synced_hashes ADD COLUMN IF NOT EXISTS block_length BIGINT;

--- a/pkg/metadata/store/postgres/migrations/000035_synced_hash_locator.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000035_synced_hash_locator.up.sql
@@ -1,0 +1,8 @@
+-- #1414 object packing (PR3a): record WHERE a synced chunk's bytes live, so a
+-- chunk can resolve to either its standalone CAS object (NULL columns, the
+-- default for every existing row — no backfill needed) or a position inside a
+-- pack object (pack_id/pack_offset/pack_length). Standalone marks leave these
+-- NULL, so behavior is unchanged until PR3b's packer writes pack locators.
+ALTER TABLE synced_hashes ADD COLUMN IF NOT EXISTS pack_id TEXT;
+ALTER TABLE synced_hashes ADD COLUMN IF NOT EXISTS pack_offset BIGINT;
+ALTER TABLE synced_hashes ADD COLUMN IF NOT EXISTS pack_length BIGINT;

--- a/pkg/metadata/store/postgres/synced_hash_store.go
+++ b/pkg/metadata/store/postgres/synced_hash_store.go
@@ -79,28 +79,28 @@ func (s *PostgresMetadataStore) IsSynced(ctx context.Context, hash block.Content
 }
 
 // MarkSynced records that hash has been mirrored to remote, persisting loc's
-// pack columns atomically. Idempotent via ON CONFLICT (hash) DO NOTHING —
+// block columns atomically. Idempotent via ON CONFLICT (hash) DO NOTHING —
 // re-applying the same hash is a no-op that preserves the first locator. A
-// standalone locator (PackID == "") leaves the pack columns NULL, identical to
+// standalone locator (BlockID == "") leaves the block columns NULL, identical to
 // a pre-locator row, so existing data needs no migration.
 func (s *PostgresMetadataStore) MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 
-	packID, off, length := locatorArgs(loc)
+	blockID, off, length := locatorArgs(loc)
 	if _, err := s.exec(ctx,
-		`INSERT INTO synced_hashes (hash, synced_at, pack_id, pack_offset, pack_length)
+		`INSERT INTO synced_hashes (hash, synced_at, block_id, block_offset, block_length)
 			VALUES ($1, NOW(), $2, $3, $4)
 			ON CONFLICT (hash) DO NOTHING`,
-		hash[:], packID, off, length); err != nil {
+		hash[:], blockID, off, length); err != nil {
 		return fmt.Errorf("postgres synced mark: %w", err)
 	}
 	return nil
 }
 
 // GetLocator returns the recorded remote locator for hash. (zero, false, nil)
-// when no row exists; a synced row with NULL/empty pack columns yields the zero
+// when no row exists; a synced row with NULL/empty block columns yields the zero
 // (standalone) locator with found == true.
 func (s *PostgresMetadataStore) GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
 	if err := ctx.Err(); err != nil {
@@ -108,31 +108,31 @@ func (s *PostgresMetadataStore) GetLocator(ctx context.Context, hash block.Conte
 	}
 
 	row := s.queryRow(ctx,
-		`SELECT pack_id, pack_offset, pack_length FROM synced_hashes WHERE hash = $1`,
+		`SELECT block_id, block_offset, block_length FROM synced_hashes WHERE hash = $1`,
 		hash[:])
-	var packID sql.NullString
+	var blockID sql.NullString
 	var off, length sql.NullInt64
-	err := row.Scan(&packID, &off, &length)
+	err := row.Scan(&blockID, &off, &length)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return block.ChunkLocator{}, false, nil
 	}
 	if err != nil {
 		return block.ChunkLocator{}, false, fmt.Errorf("postgres synced get locator: %w", err)
 	}
-	if !packID.Valid || packID.String == "" {
+	if !blockID.Valid || blockID.String == "" {
 		return block.ChunkLocator{}, true, nil
 	}
-	return block.ChunkLocator{PackID: packID.String, Offset: off.Int64, Length: length.Int64}, true, nil
+	return block.ChunkLocator{BlockID: blockID.String, Offset: off.Int64, Length: length.Int64}, true, nil
 }
 
-// locatorArgs maps a ChunkLocator onto the (pack_id, pack_offset, pack_length)
+// locatorArgs maps a ChunkLocator onto the (block_id, block_offset, block_length)
 // INSERT args: NULL for a standalone chunk (so its row is identical to a
-// pre-locator row), the recorded values for a pack-resident chunk.
-func locatorArgs(loc block.ChunkLocator) (packID, off, length any) {
+// pre-locator row), the recorded values for a block-resident chunk.
+func locatorArgs(loc block.ChunkLocator) (blockID, off, length any) {
 	if loc.IsStandalone() {
 		return nil, nil, nil
 	}
-	return loc.PackID, loc.Offset, loc.Length
+	return loc.BlockID, loc.Offset, loc.Length
 }
 
 // DeleteSynced removes the synced marker for hash. Idempotent: DELETE

--- a/pkg/metadata/store/postgres/synced_hash_store.go
+++ b/pkg/metadata/store/postgres/synced_hash_store.go
@@ -7,6 +7,7 @@ package postgres
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"time"
@@ -77,21 +78,61 @@ func (s *PostgresMetadataStore) IsSynced(ctx context.Context, hash block.Content
 	return true, nil
 }
 
-// MarkSynced records that hash has been mirrored to remote. Idempotent
-// via ON CONFLICT (hash) DO NOTHING — re-applying the same hash is a
-// no-op.
-func (s *PostgresMetadataStore) MarkSynced(ctx context.Context, hash block.ContentHash) error {
+// MarkSynced records that hash has been mirrored to remote, persisting loc's
+// pack columns atomically. Idempotent via ON CONFLICT (hash) DO NOTHING —
+// re-applying the same hash is a no-op that preserves the first locator. A
+// standalone locator (PackID == "") leaves the pack columns NULL, identical to
+// a pre-locator row, so existing data needs no migration.
+func (s *PostgresMetadataStore) MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 
+	packID, off, length := locatorArgs(loc)
 	if _, err := s.exec(ctx,
-		`INSERT INTO synced_hashes (hash, synced_at) VALUES ($1, NOW())
+		`INSERT INTO synced_hashes (hash, synced_at, pack_id, pack_offset, pack_length)
+			VALUES ($1, NOW(), $2, $3, $4)
 			ON CONFLICT (hash) DO NOTHING`,
-		hash[:]); err != nil {
+		hash[:], packID, off, length); err != nil {
 		return fmt.Errorf("postgres synced mark: %w", err)
 	}
 	return nil
+}
+
+// GetLocator returns the recorded remote locator for hash. (zero, false, nil)
+// when no row exists; a synced row with NULL/empty pack columns yields the zero
+// (standalone) locator with found == true.
+func (s *PostgresMetadataStore) GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return block.ChunkLocator{}, false, err
+	}
+
+	row := s.queryRow(ctx,
+		`SELECT pack_id, pack_offset, pack_length FROM synced_hashes WHERE hash = $1`,
+		hash[:])
+	var packID sql.NullString
+	var off, length sql.NullInt64
+	err := row.Scan(&packID, &off, &length)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return block.ChunkLocator{}, false, nil
+	}
+	if err != nil {
+		return block.ChunkLocator{}, false, fmt.Errorf("postgres synced get locator: %w", err)
+	}
+	if !packID.Valid || packID.String == "" {
+		return block.ChunkLocator{}, true, nil
+	}
+	return block.ChunkLocator{PackID: packID.String, Offset: off.Int64, Length: length.Int64}, true, nil
+}
+
+// locatorArgs maps a ChunkLocator onto the (pack_id, pack_offset, pack_length)
+// INSERT args: NULL for a standalone chunk (so its row is identical to a
+// pre-locator row), the recorded values for a pack-resident chunk.
+func locatorArgs(loc block.ChunkLocator) (packID, off, length any) {
+	if loc.IsStandalone() {
+		return nil, nil, nil
+	}
+	return loc.PackID, loc.Offset, loc.Length
 }
 
 // DeleteSynced removes the synced marker for hash. Idempotent: DELETE

--- a/pkg/metadata/store/postgres/synced_hash_store.go
+++ b/pkg/metadata/store/postgres/synced_hash_store.go
@@ -122,6 +122,9 @@ func (s *PostgresMetadataStore) GetLocator(ctx context.Context, hash block.Conte
 	if !blockID.Valid || blockID.String == "" {
 		return block.ChunkLocator{}, true, nil
 	}
+	if !off.Valid || !length.Valid {
+		return block.ChunkLocator{}, false, fmt.Errorf("corrupt locator row: block_id %q with NULL offset/length", blockID.String)
+	}
 	return block.ChunkLocator{BlockID: blockID.String, Offset: off.Int64, Length: length.Int64}, true, nil
 }
 

--- a/pkg/metadata/store/sqlite/migrations/000002_synced_hash_locator.down.sql
+++ b/pkg/metadata/store/sqlite/migrations/000002_synced_hash_locator.down.sql
@@ -1,3 +1,3 @@
-ALTER TABLE synced_hashes DROP COLUMN pack_length;
-ALTER TABLE synced_hashes DROP COLUMN pack_offset;
-ALTER TABLE synced_hashes DROP COLUMN pack_id;
+ALTER TABLE synced_hashes DROP COLUMN block_length;
+ALTER TABLE synced_hashes DROP COLUMN block_offset;
+ALTER TABLE synced_hashes DROP COLUMN block_id;

--- a/pkg/metadata/store/sqlite/migrations/000002_synced_hash_locator.down.sql
+++ b/pkg/metadata/store/sqlite/migrations/000002_synced_hash_locator.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE synced_hashes DROP COLUMN pack_length;
+ALTER TABLE synced_hashes DROP COLUMN pack_offset;
+ALTER TABLE synced_hashes DROP COLUMN pack_id;

--- a/pkg/metadata/store/sqlite/migrations/000002_synced_hash_locator.up.sql
+++ b/pkg/metadata/store/sqlite/migrations/000002_synced_hash_locator.up.sql
@@ -1,8 +1,8 @@
 -- #1414 object packing (PR3a): record WHERE a synced chunk's bytes live, so a
 -- chunk can resolve to either its standalone CAS object (NULL columns, the
 -- default for every existing row — no backfill needed) or a position inside a
--- pack object (pack_id/pack_offset/pack_length). Standalone marks leave these
--- NULL, so behavior is unchanged until PR3b's packer writes pack locators.
-ALTER TABLE synced_hashes ADD COLUMN pack_id TEXT;
-ALTER TABLE synced_hashes ADD COLUMN pack_offset INTEGER;
-ALTER TABLE synced_hashes ADD COLUMN pack_length INTEGER;
+-- block object (block_id/block_offset/block_length). Standalone marks leave these
+-- NULL, so behavior is unchanged until PR3b's packer writes block locators.
+ALTER TABLE synced_hashes ADD COLUMN block_id TEXT;
+ALTER TABLE synced_hashes ADD COLUMN block_offset INTEGER;
+ALTER TABLE synced_hashes ADD COLUMN block_length INTEGER;

--- a/pkg/metadata/store/sqlite/migrations/000002_synced_hash_locator.up.sql
+++ b/pkg/metadata/store/sqlite/migrations/000002_synced_hash_locator.up.sql
@@ -1,0 +1,8 @@
+-- #1414 object packing (PR3a): record WHERE a synced chunk's bytes live, so a
+-- chunk can resolve to either its standalone CAS object (NULL columns, the
+-- default for every existing row — no backfill needed) or a position inside a
+-- pack object (pack_id/pack_offset/pack_length). Standalone marks leave these
+-- NULL, so behavior is unchanged until PR3b's packer writes pack locators.
+ALTER TABLE synced_hashes ADD COLUMN pack_id TEXT;
+ALTER TABLE synced_hashes ADD COLUMN pack_offset INTEGER;
+ALTER TABLE synced_hashes ADD COLUMN pack_length INTEGER;

--- a/pkg/metadata/store/sqlite/synced_hash_store.go
+++ b/pkg/metadata/store/sqlite/synced_hash_store.go
@@ -76,21 +76,70 @@ func (s *SQLiteMetadataStore) IsSynced(ctx context.Context, hash block.ContentHa
 	return true, nil
 }
 
-// MarkSynced records that hash has been mirrored to remote. Idempotent
-// via ON CONFLICT (hash) DO NOTHING — re-applying the same hash is a
-// no-op.
-func (s *SQLiteMetadataStore) MarkSynced(ctx context.Context, hash block.ContentHash) error {
+// MarkSynced records that hash has been mirrored to remote, persisting loc's
+// pack columns atomically. Idempotent via ON CONFLICT (hash) DO NOTHING —
+// re-applying the same hash is a no-op that preserves the first locator. A
+// standalone locator (PackID == "") leaves the pack columns NULL, identical to
+// a pre-locator row, so existing data needs no migration.
+func (s *SQLiteMetadataStore) MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 
+	packID, off, length := locatorArgs(loc)
 	if _, err := s.exec(ctx,
-		`INSERT INTO synced_hashes (hash, synced_at) VALUES (?1, CURRENT_TIMESTAMP)
+		`INSERT INTO synced_hashes (hash, synced_at, pack_id, pack_offset, pack_length)
+			VALUES (?1, CURRENT_TIMESTAMP, ?2, ?3, ?4)
 			ON CONFLICT (hash) DO NOTHING`,
-		hash[:]); err != nil {
+		hash[:], packID, off, length); err != nil {
 		return fmt.Errorf("sqlite synced mark: %w", err)
 	}
 	return nil
+}
+
+// GetLocator returns the recorded remote locator for hash. (zero, false, nil)
+// when no row exists; a synced row with NULL/empty pack columns yields the zero
+// (standalone) locator with found == true.
+func (s *SQLiteMetadataStore) GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return block.ChunkLocator{}, false, err
+	}
+
+	row := s.queryRow(ctx,
+		`SELECT pack_id, pack_offset, pack_length FROM synced_hashes WHERE hash = ?1`,
+		hash[:])
+	loc, err := scanLocatorRow(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return block.ChunkLocator{}, false, nil
+	}
+	if err != nil {
+		return block.ChunkLocator{}, false, fmt.Errorf("sqlite synced get locator: %w", err)
+	}
+	return loc, true, nil
+}
+
+// locatorArgs maps a ChunkLocator onto the (pack_id, pack_offset, pack_length)
+// INSERT args: NULL for a standalone chunk (so its row is identical to a
+// pre-locator row), the recorded values for a pack-resident chunk.
+func locatorArgs(loc block.ChunkLocator) (packID, off, length any) {
+	if loc.IsStandalone() {
+		return nil, nil, nil
+	}
+	return loc.PackID, loc.Offset, loc.Length
+}
+
+// scanLocatorRow scans a (pack_id, pack_offset, pack_length) row into a
+// ChunkLocator. NULL/empty pack_id yields the zero (standalone) locator.
+func scanLocatorRow(row scanRow) (block.ChunkLocator, error) {
+	var packID sql.NullString
+	var off, length sql.NullInt64
+	if err := row.Scan(&packID, &off, &length); err != nil {
+		return block.ChunkLocator{}, err
+	}
+	if !packID.Valid || packID.String == "" {
+		return block.ChunkLocator{}, nil
+	}
+	return block.ChunkLocator{PackID: packID.String, Offset: off.Int64, Length: length.Int64}, nil
 }
 
 // DeleteSynced removes the synced marker for hash. Idempotent: DELETE

--- a/pkg/metadata/store/sqlite/synced_hash_store.go
+++ b/pkg/metadata/store/sqlite/synced_hash_store.go
@@ -139,6 +139,9 @@ func scanLocatorRow(row scanRow) (block.ChunkLocator, error) {
 	if !blockID.Valid || blockID.String == "" {
 		return block.ChunkLocator{}, nil
 	}
+	if !off.Valid || !length.Valid {
+		return block.ChunkLocator{}, fmt.Errorf("corrupt locator row: block_id %q with NULL offset/length", blockID.String)
+	}
 	return block.ChunkLocator{BlockID: blockID.String, Offset: off.Int64, Length: length.Int64}, nil
 }
 

--- a/pkg/metadata/store/sqlite/synced_hash_store.go
+++ b/pkg/metadata/store/sqlite/synced_hash_store.go
@@ -77,28 +77,28 @@ func (s *SQLiteMetadataStore) IsSynced(ctx context.Context, hash block.ContentHa
 }
 
 // MarkSynced records that hash has been mirrored to remote, persisting loc's
-// pack columns atomically. Idempotent via ON CONFLICT (hash) DO NOTHING —
+// block columns atomically. Idempotent via ON CONFLICT (hash) DO NOTHING —
 // re-applying the same hash is a no-op that preserves the first locator. A
-// standalone locator (PackID == "") leaves the pack columns NULL, identical to
+// standalone locator (BlockID == "") leaves the block columns NULL, identical to
 // a pre-locator row, so existing data needs no migration.
 func (s *SQLiteMetadataStore) MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 
-	packID, off, length := locatorArgs(loc)
+	blockID, off, length := locatorArgs(loc)
 	if _, err := s.exec(ctx,
-		`INSERT INTO synced_hashes (hash, synced_at, pack_id, pack_offset, pack_length)
+		`INSERT INTO synced_hashes (hash, synced_at, block_id, block_offset, block_length)
 			VALUES (?1, CURRENT_TIMESTAMP, ?2, ?3, ?4)
 			ON CONFLICT (hash) DO NOTHING`,
-		hash[:], packID, off, length); err != nil {
+		hash[:], blockID, off, length); err != nil {
 		return fmt.Errorf("sqlite synced mark: %w", err)
 	}
 	return nil
 }
 
 // GetLocator returns the recorded remote locator for hash. (zero, false, nil)
-// when no row exists; a synced row with NULL/empty pack columns yields the zero
+// when no row exists; a synced row with NULL/empty block columns yields the zero
 // (standalone) locator with found == true.
 func (s *SQLiteMetadataStore) GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
 	if err := ctx.Err(); err != nil {
@@ -106,7 +106,7 @@ func (s *SQLiteMetadataStore) GetLocator(ctx context.Context, hash block.Content
 	}
 
 	row := s.queryRow(ctx,
-		`SELECT pack_id, pack_offset, pack_length FROM synced_hashes WHERE hash = ?1`,
+		`SELECT block_id, block_offset, block_length FROM synced_hashes WHERE hash = ?1`,
 		hash[:])
 	loc, err := scanLocatorRow(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -118,28 +118,28 @@ func (s *SQLiteMetadataStore) GetLocator(ctx context.Context, hash block.Content
 	return loc, true, nil
 }
 
-// locatorArgs maps a ChunkLocator onto the (pack_id, pack_offset, pack_length)
+// locatorArgs maps a ChunkLocator onto the (block_id, block_offset, block_length)
 // INSERT args: NULL for a standalone chunk (so its row is identical to a
-// pre-locator row), the recorded values for a pack-resident chunk.
-func locatorArgs(loc block.ChunkLocator) (packID, off, length any) {
+// pre-locator row), the recorded values for a block-resident chunk.
+func locatorArgs(loc block.ChunkLocator) (blockID, off, length any) {
 	if loc.IsStandalone() {
 		return nil, nil, nil
 	}
-	return loc.PackID, loc.Offset, loc.Length
+	return loc.BlockID, loc.Offset, loc.Length
 }
 
-// scanLocatorRow scans a (pack_id, pack_offset, pack_length) row into a
-// ChunkLocator. NULL/empty pack_id yields the zero (standalone) locator.
+// scanLocatorRow scans a (block_id, block_offset, block_length) row into a
+// ChunkLocator. NULL/empty block_id yields the zero (standalone) locator.
 func scanLocatorRow(row scanRow) (block.ChunkLocator, error) {
-	var packID sql.NullString
+	var blockID sql.NullString
 	var off, length sql.NullInt64
-	if err := row.Scan(&packID, &off, &length); err != nil {
+	if err := row.Scan(&blockID, &off, &length); err != nil {
 		return block.ChunkLocator{}, err
 	}
-	if !packID.Valid || packID.String == "" {
+	if !blockID.Valid || blockID.String == "" {
 		return block.ChunkLocator{}, nil
 	}
-	return block.ChunkLocator{PackID: packID.String, Offset: off.Int64, Length: length.Int64}, nil
+	return block.ChunkLocator{BlockID: blockID.String, Offset: off.Int64, Length: length.Int64}, nil
 }
 
 // DeleteSynced removes the synced marker for hash. Idempotent: DELETE

--- a/pkg/metadata/synced_hash_store.go
+++ b/pkg/metadata/synced_hash_store.go
@@ -20,11 +20,12 @@ import (
 	"github.com/marmos91/dittofs/pkg/block"
 )
 
-// SyncedHashStore persists a single bit of per-hash state: "has this CAS
-// chunk been successfully mirrored to the remote store at least once?"
-// The marker is logically a set keyed by content hash; backends MAY
-// record auxiliary metadata (e.g. a timestamp) but the contract surface
-// is boolean.
+// SyncedHashStore persists per-hash remote-mirror state: "has this CAS chunk
+// been mirrored to the remote store at least once, and where do its bytes live?"
+// The marker is logically a set keyed by content hash; each member also carries
+// a block.ChunkLocator recording whether the chunk is a standalone CAS object
+// (today) or lives inside a pack object (#1414, PR3b). Backends MAY record
+// auxiliary metadata (e.g. a first-mirror timestamp).
 //
 // Implementations MUST be safe for concurrent use by multiple goroutines.
 // Methods MUST respect ctx cancellation and return the ctx error early
@@ -36,10 +37,27 @@ type SyncedHashStore interface {
 	// synced", not as an error.
 	IsSynced(ctx context.Context, hash block.ContentHash) (bool, error)
 
-	// MarkSynced records that hash has been mirrored to remote.
-	// Idempotent: re-applying the same hash is a no-op and returns
-	// nil. Callers do not need to check IsSynced before MarkSynced.
-	MarkSynced(ctx context.Context, hash block.ContentHash) error
+	// MarkSynced records that hash has been mirrored to remote, persisting
+	// loc as the chunk's remote location ATOMICALLY with the synced mark
+	// (so a crash never leaves a synced hash without a resolvable location).
+	// Idempotent: re-applying an already-marked hash is a no-op and returns
+	// nil — the first recorded locator wins. Callers do not need to check
+	// IsSynced before MarkSynced.
+	//
+	// A standalone locator (loc.PackID == "") is the common case today and
+	// is persisted in the legacy on-disk form — i.e. byte-for-byte identical
+	// to pre-locator markers — because a standalone chunk's location is fully
+	// implied by its hash (the CAS key, whole object). Only a pack locator
+	// (loc.PackID != "") records the extra PackID/Offset/Length, so existing
+	// synced rows need no migration and resolve as standalone.
+	MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error
+
+	// GetLocator returns the recorded remote locator for hash. The second
+	// return is true iff hash is synced. A synced hash with no recorded pack
+	// locator (a standalone or pre-locator marker) yields the zero
+	// block.ChunkLocator (PackID == ""), which the read path resolves to the
+	// standalone CAS object. An unsynced hash returns (zero, false, nil).
+	GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error)
 
 	// DeleteSynced removes the synced marker for hash. Idempotent:
 	// deleting an absent hash returns nil. Used by the refcount cascade

--- a/pkg/metadata/synced_hash_store.go
+++ b/pkg/metadata/synced_hash_store.go
@@ -24,7 +24,7 @@ import (
 // been mirrored to the remote store at least once, and where do its bytes live?"
 // The marker is logically a set keyed by content hash; each member also carries
 // a block.ChunkLocator recording whether the chunk is a standalone CAS object
-// (today) or lives inside a pack object (#1414, PR3b). Backends MAY record
+// (today) or lives inside a block object (#1414, PR3b). Backends MAY record
 // auxiliary metadata (e.g. a first-mirror timestamp).
 //
 // Implementations MUST be safe for concurrent use by multiple goroutines.
@@ -44,18 +44,18 @@ type SyncedHashStore interface {
 	// nil — the first recorded locator wins. Callers do not need to check
 	// IsSynced before MarkSynced.
 	//
-	// A standalone locator (loc.PackID == "") is the common case today and
+	// A standalone locator (loc.BlockID == "") is the common case today and
 	// is persisted in the legacy on-disk form — i.e. byte-for-byte identical
 	// to pre-locator markers — because a standalone chunk's location is fully
-	// implied by its hash (the CAS key, whole object). Only a pack locator
-	// (loc.PackID != "") records the extra PackID/Offset/Length, so existing
+	// implied by its hash (the CAS key, whole object). Only a block locator
+	// (loc.BlockID != "") records the extra BlockID/Offset/Length, so existing
 	// synced rows need no migration and resolve as standalone.
 	MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error
 
 	// GetLocator returns the recorded remote locator for hash. The second
-	// return is true iff hash is synced. A synced hash with no recorded pack
+	// return is true iff hash is synced. A synced hash with no recorded block
 	// locator (a standalone or pre-locator marker) yields the zero
-	// block.ChunkLocator (PackID == ""), which the read path resolves to the
+	// block.ChunkLocator (BlockID == ""), which the read path resolves to the
 	// standalone CAS object. An unsynced hash returns (zero, false, nil).
 	GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error)
 

--- a/pkg/metadata/synced_hash_store_suite.go
+++ b/pkg/metadata/synced_hash_store_suite.go
@@ -60,7 +60,7 @@ func RunSyncedHashStoreSuite(t *testing.T, s SyncedHashStore) {
 		ctx := context.Background()
 		h := mustHash("suite-mark-then-is-synced")
 
-		if err := s.MarkSynced(ctx, h); err != nil {
+		if err := s.MarkSynced(ctx, h, block.ChunkLocator{}); err != nil {
 			t.Fatalf("first MarkSynced: %v", err)
 		}
 		got, err := s.IsSynced(ctx, h)
@@ -72,7 +72,7 @@ func RunSyncedHashStoreSuite(t *testing.T, s SyncedHashStore) {
 		}
 
 		// Re-applying MarkSynced is a no-op.
-		if err := s.MarkSynced(ctx, h); err != nil {
+		if err := s.MarkSynced(ctx, h, block.ChunkLocator{}); err != nil {
 			t.Fatalf("second MarkSynced (idempotent): %v", err)
 		}
 		got, err = s.IsSynced(ctx, h)
@@ -89,7 +89,7 @@ func RunSyncedHashStoreSuite(t *testing.T, s SyncedHashStore) {
 		hA := mustHash("suite-iso-a")
 		hB := mustHash("suite-iso-b")
 
-		if err := s.MarkSynced(ctx, hA); err != nil {
+		if err := s.MarkSynced(ctx, hA, block.ChunkLocator{}); err != nil {
 			t.Fatalf("MarkSynced hA: %v", err)
 		}
 
@@ -113,10 +113,10 @@ func RunSyncedHashStoreSuite(t *testing.T, s SyncedHashStore) {
 		ctx := context.Background()
 		h := mustHash("suite-mark-idempotent")
 
-		if err := s.MarkSynced(ctx, h); err != nil {
+		if err := s.MarkSynced(ctx, h, block.ChunkLocator{}); err != nil {
 			t.Fatalf("first MarkSynced: %v", err)
 		}
-		if err := s.MarkSynced(ctx, h); err != nil {
+		if err := s.MarkSynced(ctx, h, block.ChunkLocator{}); err != nil {
 			t.Fatalf("second MarkSynced (idempotent): %v", err)
 		}
 		got, err := s.IsSynced(ctx, h)
@@ -128,11 +128,69 @@ func RunSyncedHashStoreSuite(t *testing.T, s SyncedHashStore) {
 		}
 	})
 
+	t.Run("GetLocatorUnsynced", func(t *testing.T) {
+		ctx := context.Background()
+		h := mustHash("suite-get-locator-unsynced")
+		loc, ok, err := s.GetLocator(ctx, h)
+		if err != nil {
+			t.Fatalf("GetLocator unsynced: %v", err)
+		}
+		if ok {
+			t.Fatalf("unsynced hash reports a locator: ok=true")
+		}
+		if loc != (block.ChunkLocator{}) {
+			t.Fatalf("unsynced hash returned non-zero locator: %+v", loc)
+		}
+	})
+
+	t.Run("StandaloneLocatorResolvesStandalone", func(t *testing.T) {
+		// A chunk marked synced with a standalone locator (the PR3a path, and
+		// the only on-disk form pre-PR3b) must resolve back as standalone —
+		// PackID=="" — so the read path falls back to the direct CAS GET. This
+		// also covers backward compatibility: a pre-locator row carries the
+		// same (no-pack) state.
+		ctx := context.Background()
+		h := mustHash("suite-standalone-locator")
+		if err := s.MarkSynced(ctx, h, block.ChunkLocator{Length: 1234}); err != nil {
+			t.Fatalf("MarkSynced standalone: %v", err)
+		}
+		loc, ok, err := s.GetLocator(ctx, h)
+		if err != nil {
+			t.Fatalf("GetLocator standalone: %v", err)
+		}
+		if !ok {
+			t.Fatalf("standalone synced hash reports ok=false")
+		}
+		if !loc.IsStandalone() {
+			t.Fatalf("standalone hash resolved to a pack: %+v", loc)
+		}
+	})
+
+	t.Run("PackLocatorRoundTrip", func(t *testing.T) {
+		// A pack locator must round-trip exactly through MarkSynced/GetLocator.
+		ctx := context.Background()
+		h := mustHash("suite-pack-locator")
+		want := block.ChunkLocator{PackID: "pack-abc123", Offset: 4096, Length: 65536}
+		if err := s.MarkSynced(ctx, h, want); err != nil {
+			t.Fatalf("MarkSynced pack: %v", err)
+		}
+		got, ok, err := s.GetLocator(ctx, h)
+		if err != nil {
+			t.Fatalf("GetLocator pack: %v", err)
+		}
+		if !ok {
+			t.Fatalf("pack-resident synced hash reports ok=false")
+		}
+		if got != want {
+			t.Fatalf("pack locator round-trip: got %+v want %+v", got, want)
+		}
+	})
+
 	t.Run("DeleteSyncedAfterMark", func(t *testing.T) {
 		ctx := context.Background()
 		h := mustHash("suite-delete-after-mark")
 
-		if err := s.MarkSynced(ctx, h); err != nil {
+		if err := s.MarkSynced(ctx, h, block.ChunkLocator{}); err != nil {
 			t.Fatalf("MarkSynced: %v", err)
 		}
 		if err := s.DeleteSynced(ctx, h); err != nil {
@@ -170,7 +228,7 @@ func RunSyncedHashStoreSuite(t *testing.T, s SyncedHashStore) {
 			go func() {
 				defer wg.Done()
 				if i%2 == 0 {
-					_ = s.MarkSynced(ctx, h)
+					_ = s.MarkSynced(ctx, h, block.ChunkLocator{})
 				} else {
 					_ = s.DeleteSynced(ctx, h)
 				}
@@ -213,7 +271,7 @@ func RunSyncedHashEnumeratorSuite(t *testing.T, e syncedHashEnumerating) {
 		hGone := mustHash("enum-suite-gone")
 
 		for _, h := range []block.ContentHash{hA, hB, hGone} {
-			if err := e.MarkSynced(ctx, h); err != nil {
+			if err := e.MarkSynced(ctx, h, block.ChunkLocator{}); err != nil {
 				t.Fatalf("MarkSynced %x: %v", h[:4], err)
 			}
 		}

--- a/pkg/metadata/synced_hash_store_suite.go
+++ b/pkg/metadata/synced_hash_store_suite.go
@@ -146,9 +146,9 @@ func RunSyncedHashStoreSuite(t *testing.T, s SyncedHashStore) {
 	t.Run("StandaloneLocatorResolvesStandalone", func(t *testing.T) {
 		// A chunk marked synced with a standalone locator (the PR3a path, and
 		// the only on-disk form pre-PR3b) must resolve back as standalone —
-		// PackID=="" — so the read path falls back to the direct CAS GET. This
+		// BlockID=="" — so the read path falls back to the direct CAS GET. This
 		// also covers backward compatibility: a pre-locator row carries the
-		// same (no-pack) state.
+		// same (no-block) state.
 		ctx := context.Background()
 		h := mustHash("suite-standalone-locator")
 		if err := s.MarkSynced(ctx, h, block.ChunkLocator{Length: 1234}); err != nil {
@@ -162,27 +162,27 @@ func RunSyncedHashStoreSuite(t *testing.T, s SyncedHashStore) {
 			t.Fatalf("standalone synced hash reports ok=false")
 		}
 		if !loc.IsStandalone() {
-			t.Fatalf("standalone hash resolved to a pack: %+v", loc)
+			t.Fatalf("standalone hash resolved to a block: %+v", loc)
 		}
 	})
 
-	t.Run("PackLocatorRoundTrip", func(t *testing.T) {
-		// A pack locator must round-trip exactly through MarkSynced/GetLocator.
+	t.Run("BlockLocatorRoundTrip", func(t *testing.T) {
+		// A block locator must round-trip exactly through MarkSynced/GetLocator.
 		ctx := context.Background()
-		h := mustHash("suite-pack-locator")
-		want := block.ChunkLocator{PackID: "pack-abc123", Offset: 4096, Length: 65536}
+		h := mustHash("suite-block-locator")
+		want := block.ChunkLocator{BlockID: "block-abc123", Offset: 4096, Length: 65536}
 		if err := s.MarkSynced(ctx, h, want); err != nil {
-			t.Fatalf("MarkSynced pack: %v", err)
+			t.Fatalf("MarkSynced block: %v", err)
 		}
 		got, ok, err := s.GetLocator(ctx, h)
 		if err != nil {
-			t.Fatalf("GetLocator pack: %v", err)
+			t.Fatalf("GetLocator block: %v", err)
 		}
 		if !ok {
-			t.Fatalf("pack-resident synced hash reports ok=false")
+			t.Fatalf("block-resident synced hash reports ok=false")
 		}
 		if got != want {
-			t.Fatalf("pack locator round-trip: got %+v want %+v", got, want)
+			t.Fatalf("block locator round-trip: got %+v want %+v", got, want)
 		}
 	})
 


### PR DESCRIPTION
## What & why

This is **PR3a** of #1414 (object packing) — the first, de-risking phase. It introduces a **locator indirection layer with NO packing yet**. After this PR, behavior is **byte-for-byte identical** to `develop` for every existing path: every chunk is still stored as its own standalone CAS object. PR3a only adds the indirection that PR3b will later exploit to store chunks inside packs.

## The model

A new `block.ChunkLocator{ PackID string; Offset int64; Length int64 }` resolves a chunk hash to where its bytes live:

- `PackID == ""` → **standalone**: the chunk is the whole object at the existing `cas/XX/YY/<hash>` key. This is what **every** chunk uses in PR3a, and the default for any hash with no recorded locator.
- `PackID != ""` → the chunk lives inside `packs/<PackID>` at `[Offset, Offset+Length)`. Only PR3b's packer produces these; here the range branch is exercised **only by tests**.

## Changes

- **Oracle extension.** `metadata.SyncedHashStore` (the remote-mirror-state oracle) now persists a locator per synced hash: `MarkSynced(ctx, hash, ChunkLocator)` records it **atomically** with the synced mark, and new `GetLocator` returns it. Extended in-place across all four backends (memory, badger, sqlite, postgres) rather than adding a parallel store.
- **Backward compat / no migration.** A standalone locator is persisted in the **legacy on-disk form** (badger: 8-byte timestamp only; SQL: NULL pack columns), so existing synced rows resolve as standalone with no backfill. SQL migrations (sqlite `000002`, postgres `000035`) only add nullable columns.
- **Read path.** The engine read path (`dispatchRemoteFetch`) now resolves the locator first. `PackID==""` → today's direct `ReadBlockVerified` on the CAS object (unchanged). Otherwise → a ranged read into the pack object, then a BLAKE3 verify.
- **Write path unchanged.** Still one standalone object per chunk; on successful `Put`+`MarkSynced` a standalone locator is recorded. Put-then-Mark crash-safety preserved.
- **Pack reads** use a new **optional** `remote.PackChunkReader` capability (`GetPackChunk`) implemented by the s3 + memory backends and the encryption/compression decorators. It is deliberately kept **off** the `RemoteStore` contract (mirroring how `EnumerateSynced` is kept off `SyncedHashStore`) so the ~11 `RemoteStore` test fakes are untouched. Each decorator inverts its own transform (encryption uses the chunk hash as the AEAD AAD); the engine verifies once at the top.

## Behavior change

**None for existing paths.** The standalone branch calls `ReadBlockVerified(ctx, hash, hash)` with the same arguments as before; `resolveLocator` returns the zero (standalone) locator whenever no `SyncedHashStore` is wired or the hash is unrecorded. No packing, no upload batching, no new config knobs (packing config arrives in PR3b).

## Tests

- Extended `SyncedHashStore` conformance suite (all 4 backends): locator round-trip, standalone-resolves-standalone, unsynced returns not-found.
- Engine: standalone round-trip, **legacy/no-locator backward compat**, synthetic **pack-locator range read**, and verify-mismatch fails closed.
- Base-store pack range read + bounds (memory), and an **encryption-decorator pack-chunk boundary** test (de-risks PR3b's per-chunk crypto inside packs).
- `blockstoretest` conformance unchanged and passing.

Verification: `go build ./...`, `go test -race ./pkg/block/... ./pkg/metadata/...`, `go vet`, and `golangci-lint` all clean.