### PR TITLE
fix(nfsv4): wire byte-range locks to per-share unified lock manager

### DIFF
--- a/internal/adapter/nfs/v4/state/delegation.go
+++ b/internal/adapter/nfs/v4/state/delegation.go
@@ -266,7 +266,7 @@ func (sm *StateManager) GrantDelegation(clientID uint64, fileHandle []byte, dele
 	fhKey := string(fileHandle)
 	sm.delegByFile[fhKey] = append(sm.delegByFile[fhKey], deleg)
 
-	if sm.lockManager != nil {
+	if lm := sm.lockManagerFor(fileHandle); lm != nil {
 		lmDelegType := lock.DelegTypeRead
 		if deleg.DelegType == types.OPEN_DELEGATE_WRITE {
 			lmDelegType = lock.DelegTypeWrite
@@ -277,7 +277,7 @@ func (sm *StateManager) GrantDelegation(clientID uint64, fileHandle []byte, dele
 		// correctness. To add share context, GrantDelegation would need to
 		// accept a shareName parameter threaded from the OPEN handler.
 		lockDeleg := lock.NewDelegation(lmDelegType, fmt.Sprintf("%d", clientID), "", false)
-		if err := sm.lockManager.GrantDelegation(fhKey, lockDeleg); err != nil {
+		if err := lm.GrantDelegation(fhKey, lockDeleg); err != nil {
 			logger.Debug("LockManager delegation grant failed, continuing with local state",
 				"error", err)
 		} else {
@@ -360,7 +360,7 @@ func (sm *StateManager) ReturnDelegation(stateid *types.Stateid4) error {
 		delegKind = "directory"
 	}
 
-	lockMgr := sm.lockManager
+	lockMgr := sm.lockManagerFor(deleg.FileHandle)
 
 	if deleg.Revoked {
 		logger.Info("Revoked delegation returned by client",

--- a/internal/adapter/nfs/v4/state/dir_delegation.go
+++ b/internal/adapter/nfs/v4/state/dir_delegation.go
@@ -106,11 +106,11 @@ func (sm *StateManager) GrantDirDelegation(clientID uint64, dirFH []byte, notifM
 	sm.delegByOther[other] = deleg
 	sm.delegByFile[fhKey] = append(sm.delegByFile[fhKey], deleg)
 
-	if sm.lockManager != nil {
+	if lm := sm.lockManagerFor(fhCopy); lm != nil {
 		// See GrantDelegation comment: NFS delegations lack share context at this layer.
 		lockDeleg := lock.NewDelegation(lock.DelegTypeRead, fmt.Sprintf("%d", clientID), "", true)
 		lockDeleg.NotificationMask = notifMask
-		if err := sm.lockManager.GrantDelegation(fhKey, lockDeleg); err != nil {
+		if err := lm.GrantDelegation(fhKey, lockDeleg); err != nil {
 			logger.Debug("LockManager directory delegation grant failed, continuing with local state",
 				"error", err)
 		} else {

--- a/internal/adapter/nfs/v4/state/lock_resolver_test.go
+++ b/internal/adapter/nfs/v4/state/lock_resolver_test.go
@@ -1,0 +1,138 @@
+package state
+
+import (
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// These tests cover the per-share lock-manager resolver that wires NFSv4
+// byte-range locks to the same unified lock manager instance used by SMB and
+// NLM. Before this wiring, the production NFSv4 StateManager had no lock manager
+// configured, so every LOCK returned "no lock manager configured"
+// (NFS4ERR_SERVERFAULT, surfaced to clients as EIO), and cross-protocol lock
+// conflicts could never be detected.
+
+// TestLockManagerResolver_FixesMissingManager verifies that a StateManager with
+// neither a static manager nor a resolver fails LOCK (the old, broken state),
+// while one with a resolver succeeds.
+func TestLockManagerResolver_FixesMissingManager(t *testing.T) {
+	// No manager, no resolver: LOCK must fail (reproduces the EIO bug).
+	smBroken := NewStateManager(90 * time.Second)
+	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, smBroken)
+	if _, err := smBroken.LockNew(
+		clientID, []byte("owner-a"), 1,
+		openStateid, openSeqid,
+		fileHandle, types.WRITE_LT, 0, 100, false,
+	); err == nil {
+		t.Fatal("expected LOCK to fail when no lock manager is configured")
+	}
+
+	// Resolver wired: LOCK must succeed.
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManagerResolver(func(_ []byte) lock.LockManager { return lm })
+	clientID, fileHandle, openStateid, openSeqid = setupClientAndOpenState(t, sm)
+	if _, err := sm.LockNew(
+		clientID, []byte("owner-a"), 1,
+		openStateid, openSeqid,
+		fileHandle, types.WRITE_LT, 0, 100, false,
+	); err != nil {
+		t.Fatalf("LOCK with resolved lock manager failed: %v", err)
+	}
+	if locks := lm.ListUnifiedLocks(string(fileHandle)); len(locks) != 1 {
+		t.Fatalf("expected 1 lock in resolved manager, got %d", len(locks))
+	}
+}
+
+// TestLockManagerResolver_DetectsCrossProtocolConflict seeds an SMB-style lock
+// directly in the unified manager, then verifies an NFSv4 LOCKT/LOCK on an
+// overlapping range observes the conflict — proving NFSv4 and SMB share the
+// same manager instance.
+func TestLockManagerResolver_DetectsCrossProtocolConflict(t *testing.T) {
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManagerResolver(func(_ []byte) lock.LockManager { return lm })
+
+	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
+
+	// SMB client takes an exclusive lock on bytes [0,100).
+	smbLock := &lock.UnifiedLock{
+		ID:         "smb-lock",
+		Owner:      lock.LockOwner{OwnerID: "smb:client-x", ClientID: "smb-x"},
+		FileHandle: lock.FileHandle(fileHandle),
+		Offset:     0,
+		Length:     100,
+		Type:       lock.LockTypeExclusive,
+		AcquiredAt: time.Now(),
+	}
+	if err := lm.AddUnifiedLock(string(fileHandle), smbLock); err != nil {
+		t.Fatalf("seeding SMB lock failed: %v", err)
+	}
+
+	// NFSv4 LOCKT for an overlapping range must report the conflict.
+	denied, err := sm.TestLock(clientID, []byte("nfs-owner"), fileHandle, types.WRITE_LT, 50, 100)
+	if err != nil {
+		t.Fatalf("TestLock returned error: %v", err)
+	}
+	if denied == nil {
+		t.Fatal("expected NFSv4 LOCKT to detect the overlapping SMB lock, got no conflict")
+	}
+
+	// NFSv4 LOCK for the same overlapping range must also be denied (not granted).
+	res, err := sm.LockNew(
+		clientID, []byte("nfs-owner"), 1,
+		openStateid, openSeqid,
+		fileHandle, types.WRITE_LT, 50, 100, false,
+	)
+	if err != nil {
+		t.Fatalf("LockNew returned error: %v", err)
+	}
+	if res == nil || res.Denied == nil {
+		t.Fatal("expected NFSv4 LOCK to be denied by the conflicting SMB lock")
+	}
+}
+
+// TestLockManagerResolver_RoutesByHandle verifies the resolver is consulted with
+// the operation's file handle, so locks on one share's handle are isolated from
+// another's.
+func TestLockManagerResolver_RoutesByHandle(t *testing.T) {
+	lmA := lock.NewManager()
+	lmB := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+
+	clientID, fileHandle, _, _ := setupClientAndOpenState(t, sm)
+	other := []byte("/export-b:test-file-002")
+
+	sm.SetLockManagerResolver(func(handle []byte) lock.LockManager {
+		if string(handle) == string(fileHandle) {
+			return lmA
+		}
+		return lmB
+	})
+
+	// Conflicting lock lives only in manager A (fileHandle's share).
+	if err := lmA.AddUnifiedLock(string(fileHandle), &lock.UnifiedLock{
+		ID:         "a-lock",
+		Owner:      lock.LockOwner{OwnerID: "smb:a"},
+		FileHandle: lock.FileHandle(fileHandle),
+		Offset:     0,
+		Length:     100,
+		Type:       lock.LockTypeExclusive,
+		AcquiredAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("seeding lock in manager A failed: %v", err)
+	}
+
+	// LOCKT on fileHandle → routed to A → conflict.
+	if denied, err := sm.TestLock(clientID, []byte("o"), fileHandle, types.WRITE_LT, 0, 100); err != nil || denied == nil {
+		t.Fatalf("expected conflict on fileHandle (manager A); denied=%v err=%v", denied, err)
+	}
+
+	// LOCKT on a different handle → routed to B (empty) → no conflict.
+	if denied, err := sm.TestLock(clientID, []byte("o"), other, types.WRITE_LT, 0, 100); err != nil || denied != nil {
+		t.Fatalf("expected no conflict on other handle (manager B); denied=%v err=%v", denied, err)
+	}
+}

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -117,9 +117,13 @@ type StateManager struct {
 	// for directory delegations. Defaults to 50ms.
 	dirDelegBatchWindow time.Duration
 
-	// lockManager is the unified lock manager for actual byte-range conflict
-	// detection and cross-protocol locking. Set via SetLockManager() or constructor.
+	// lockManager is a static unified lock manager used as a fallback when no
+	// resolver is set (primarily by tests). See SetLockManagerResolver.
 	lockManager lock.LockManager
+
+	// lockManagerResolver resolves the per-share unified lock manager for a file
+	// handle, taking precedence over lockManager. See SetLockManagerResolver.
+	lockManagerResolver func(handle []byte) lock.LockManager
 
 	// bootEpoch is the server boot epoch, used as the high 32 bits of
 	// client IDs to ensure uniqueness across server restarts.
@@ -756,13 +760,13 @@ func (sm *StateManager) onLeaseExpired(clientID uint64) {
 				delete(sm.lockStateByOther, lockState.Stateid.Other)
 
 				// Remove actual locks from unified lock manager
-				if sm.lockManager != nil {
+				if lm := sm.lockManagerFor(lockState.FileHandle); lm != nil {
 					ownerID := lockState.LockOwner.LockManagerOwnerID()
 					handleKey := string(lockState.FileHandle)
-					locks := sm.lockManager.ListUnifiedLocks(handleKey)
+					locks := lm.ListUnifiedLocks(handleKey)
 					for _, l := range locks {
 						if l.Owner.OwnerID == ownerID {
-							_ = sm.lockManager.RemoveUnifiedLock(
+							_ = lm.RemoveUnifiedLock(
 								handleKey,
 								l.Owner, l.Offset, l.Length,
 							)
@@ -847,7 +851,7 @@ func (sm *StateManager) RevokeDelegation(delegOther [types.NFS4_OTHER_SIZE]byte)
 	}
 
 	// Capture lockManager reference before releasing mu
-	lockMgr := sm.lockManager
+	lockMgr := sm.lockManagerFor(deleg.FileHandle)
 
 	// Keep in delegByOther for stale stateid detection.
 
@@ -1728,6 +1732,33 @@ func (sm *StateManager) SetLockManager(lm lock.LockManager) {
 	sm.lockManager = lm
 }
 
+// SetLockManagerResolver injects a function that resolves the per-share unified
+// lock manager for a file handle. Called by the NFS adapter after construction.
+//
+// Lock managers are per-share, but the NFSv4 StateManager is global. The
+// resolver lets each lock operation reach the same manager instance that SMB
+// and NLM use for the same file, which is what enables cross-protocol byte-range
+// lock conflict detection.
+func (sm *StateManager) SetLockManagerResolver(resolver func(handle []byte) lock.LockManager) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.lockManagerResolver = resolver
+}
+
+// lockManagerFor resolves the unified lock manager for a file handle. The
+// per-handle resolver (production: per-share managers) takes precedence; the
+// statically-set lockManager is the fallback (used by tests). May return nil.
+//
+// Lock-free by design: the resolver and lockManager are set once during adapter
+// startup (before any request is served), so reads need no synchronization. This
+// also lets callers that already hold sm.mu use it without deadlocking.
+func (sm *StateManager) lockManagerFor(handle []byte) lock.LockManager {
+	if sm.lockManagerResolver != nil {
+		return sm.lockManagerResolver(handle)
+	}
+	return sm.lockManager
+}
+
 // SetDelegationsEnabled controls whether delegations can be granted.
 // When false, ShouldGrantDelegation always returns OPEN_DELEGATE_NONE.
 // This is updated from live NFS adapter settings.
@@ -2044,7 +2075,8 @@ func (sm *StateManager) LockExisting(
 //
 // Caller must hold sm.mu.
 func (sm *StateManager) acquireLock(lockState *LockState, lockType uint32, offset, length uint64, reclaim bool) (*LOCK4denied, error) {
-	if sm.lockManager == nil {
+	lm := sm.lockManagerFor(lockState.FileHandle)
+	if lm == nil {
 		return nil, fmt.Errorf("no lock manager configured")
 	}
 
@@ -2072,11 +2104,11 @@ func (sm *StateManager) acquireLock(lockState *LockState, lockType uint32, offse
 
 	// Try to add the lock
 	handleKey := string(lockState.FileHandle)
-	err := sm.lockManager.AddUnifiedLock(handleKey, enhLock)
+	err := lm.AddUnifiedLock(handleKey, enhLock)
 	if err != nil {
 		// Lock conflict: query existing locks to find the conflicting one
 		// for the LOCK4denied response
-		existingLocks := sm.lockManager.ListUnifiedLocks(handleKey)
+		existingLocks := lm.ListUnifiedLocks(handleKey)
 		for _, el := range existingLocks {
 			if lock.IsUnifiedLockConflicting(el, enhLock) {
 				// Map the conflicting lock type back to NFS4
@@ -2136,7 +2168,8 @@ func (sm *StateManager) TestLock(
 	clientID uint64, ownerData []byte,
 	fileHandle []byte, lockType uint32, offset, length uint64,
 ) (*LOCK4denied, error) {
-	if sm.lockManager == nil {
+	lm := sm.lockManagerFor(fileHandle)
+	if lm == nil {
 		// No lock manager = no locks possible = no conflicts
 		return nil, nil
 	}
@@ -2167,7 +2200,7 @@ func (sm *StateManager) TestLock(
 	// NFSv4 LOCKT reports the same conflict an actual LOCK would be denied by
 	// when an overlapping SMB byte-range lock exists (xproto H1).
 	handleKey := string(fileHandle)
-	conflict := sm.lockManager.TestUnifiedLock(handleKey, testLock)
+	conflict := lm.TestUnifiedLock(handleKey, testLock)
 	if conflict != nil {
 		el := conflict.Lock
 		// Build LOCK4denied from the conflicting lock
@@ -2274,7 +2307,7 @@ func (sm *StateManager) UnlockFile(
 	}
 
 	// 4. Release the lock via unified lock manager
-	if sm.lockManager != nil {
+	if lm := sm.lockManagerFor(lockState.FileHandle); lm != nil {
 		owner := lock.LockOwner{
 			OwnerID:   lockOwner.LockManagerOwnerID(),
 			ClientID:  fmt.Sprintf("nfs4:%d", lockOwner.ClientID),
@@ -2282,7 +2315,7 @@ func (sm *StateManager) UnlockFile(
 		}
 
 		handleKey := string(lockState.FileHandle)
-		err := sm.lockManager.RemoveUnifiedLock(handleKey, owner, offset, length)
+		err := lm.RemoveUnifiedLock(handleKey, owner, offset, length)
 		if err != nil {
 			// Lock-not-found is OK for LOCKU (idempotent).
 			// Only fail on unexpected errors.
@@ -2332,24 +2365,27 @@ func (sm *StateManager) ReleaseLockOwner(clientID uint64, ownerData []byte) erro
 		return nil
 	}
 
-	// Check if this lock-owner has any active locks in the lock manager
-	if sm.lockManager != nil {
-		ownerID := lockOwner.LockManagerOwnerID()
+	// Check if this lock-owner has any active locks in the lock manager.
+	// Lock managers are per-share, so resolve one per file handle.
+	ownerID := lockOwner.LockManagerOwnerID()
 
-		// Find all lock states for this lock-owner by scanning lockStateByOther
-		for _, ls := range sm.lockStateByOther {
-			if ls.LockOwner != lockOwner {
-				continue
-			}
-			// Check if any locks are held for this owner on this file
-			handleKey := string(ls.FileHandle)
-			locks := sm.lockManager.ListUnifiedLocks(handleKey)
-			for _, l := range locks {
-				if l.Owner.OwnerID == ownerID {
-					return &NFS4StateError{
-						Status:  types.NFS4ERR_LOCKS_HELD,
-						Message: "cannot release lock-owner: locks still held",
-					}
+	// Find all lock states for this lock-owner by scanning lockStateByOther
+	for _, ls := range sm.lockStateByOther {
+		if ls.LockOwner != lockOwner {
+			continue
+		}
+		lm := sm.lockManagerFor(ls.FileHandle)
+		if lm == nil {
+			continue
+		}
+		// Check if any locks are held for this owner on this file
+		handleKey := string(ls.FileHandle)
+		locks := lm.ListUnifiedLocks(handleKey)
+		for _, l := range locks {
+			if l.Owner.OwnerID == ownerID {
+				return &NFS4StateError{
+					Status:  types.NFS4ERR_LOCKS_HELD,
+					Message: "cannot release lock-owner: locks still held",
 				}
 			}
 		}

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1724,24 +1724,27 @@ func (sm *StateManager) RenewLease(clientID uint64) error {
 // Lock Manager Integration
 // ============================================================================
 
-// SetLockManager sets the unified lock manager for byte-range conflict detection.
-// Called by the NFS adapter after construction to inject the lock manager.
+// SetLockManager sets the static unified lock manager for byte-range conflict
+// detection. Init-only: must be called during construction, before any goroutine
+// serves requests, so lock-free reads in lockManagerFor are safe. Primarily used
+// by tests; production uses SetLockManagerResolver.
 func (sm *StateManager) SetLockManager(lm lock.LockManager) {
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
 	sm.lockManager = lm
 }
 
 // SetLockManagerResolver injects a function that resolves the per-share unified
-// lock manager for a file handle. Called by the NFS adapter after construction.
+// lock manager for a file handle. Called by the NFS adapter during construction.
 //
 // Lock managers are per-share, but the NFSv4 StateManager is global. The
 // resolver lets each lock operation reach the same manager instance that SMB
 // and NLM use for the same file, which is what enables cross-protocol byte-range
 // lock conflict detection.
+//
+// Init-only: must be called before any goroutine serves requests. It is set once
+// at startup and never reassigned, so lockManagerFor reads it without a lock. Do
+// not call this after the adapter begins serving — there is no synchronization
+// against concurrent readers.
 func (sm *StateManager) SetLockManagerResolver(resolver func(handle []byte) lock.LockManager) {
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
 	sm.lockManagerResolver = resolver
 }
 
@@ -1749,9 +1752,10 @@ func (sm *StateManager) SetLockManagerResolver(resolver func(handle []byte) lock
 // per-handle resolver (production: per-share managers) takes precedence; the
 // statically-set lockManager is the fallback (used by tests). May return nil.
 //
-// Lock-free by design: the resolver and lockManager are set once during adapter
-// startup (before any request is served), so reads need no synchronization. This
-// also lets callers that already hold sm.mu use it without deadlocking.
+// Lock-free by design: the resolver and lockManager are init-only (set once
+// before any request is served — see SetLockManagerResolver), so reads need no
+// synchronization. This also lets callers that already hold sm.mu use it without
+// deadlocking.
 func (sm *StateManager) lockManagerFor(handle []byte) lock.LockManager {
 	if sm.lockManagerResolver != nil {
 		return sm.lockManagerResolver(handle)

--- a/internal/adapter/nfs/v4/state/stateid.go
+++ b/internal/adapter/nfs/v4/state/stateid.go
@@ -465,12 +465,12 @@ func (sm *StateManager) freeLockStateidLocked(clientID uint64, stateid *types.St
 	delete(sm.lockStateByOther, stateid.Other)
 
 	// Remove actual locks from unified lock manager
-	if sm.lockManager != nil && lockState.LockOwner != nil {
+	if lm := sm.lockManagerFor(lockState.FileHandle); lm != nil && lockState.LockOwner != nil {
 		ownerID := lockState.LockOwner.LockManagerOwnerID()
 		handleKey := string(lockState.FileHandle)
-		for _, l := range sm.lockManager.ListUnifiedLocks(handleKey) {
+		for _, l := range lm.ListUnifiedLocks(handleKey) {
 			if l.Owner.OwnerID == ownerID {
-				_ = sm.lockManager.RemoveUnifiedLock(handleKey, l.Owner, l.Offset, l.Length)
+				_ = lm.RemoveUnifiedLock(handleKey, l.Owner, l.Offset, l.Length)
 			}
 		}
 	}

--- a/internal/adapter/nfs/v4/state/v41_client.go
+++ b/internal/adapter/nfs/v4/state/v41_client.go
@@ -471,12 +471,12 @@ func (sm *StateManager) EvictV40Client(clientID uint64) error {
 				delete(sm.lockStateByOther, lockState.Stateid.Other)
 
 				// Remove actual locks from unified lock manager (matches onLeaseExpired)
-				if sm.lockManager != nil && lockState.LockOwner != nil {
+				if lm := sm.lockManagerFor(lockState.FileHandle); lm != nil && lockState.LockOwner != nil {
 					ownerID := lockState.LockOwner.LockManagerOwnerID()
 					handleKey := string(lockState.FileHandle)
-					for _, l := range sm.lockManager.ListUnifiedLocks(handleKey) {
+					for _, l := range lm.ListUnifiedLocks(handleKey) {
 						if l.Owner.OwnerID == ownerID {
-							_ = sm.lockManager.RemoveUnifiedLock(handleKey, l.Owner, l.Offset, l.Length)
+							_ = lm.RemoveUnifiedLock(handleKey, l.Owner, l.Offset, l.Length)
 						}
 					}
 				}

--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -514,6 +514,23 @@ func (s *NFSAdapter) SetRuntime(rtAny any) {
 	shares := rt.ListShares()
 	s.pseudoFS.Rebuild(shares)
 	v4StateManager := v4state.NewStateManager(v4state.DefaultLeaseDuration)
+
+	// Wire NFSv4 byte-range locks to the per-share unified lock managers so they
+	// use the same manager instance as SMB and NLM — this is what enables
+	// cross-protocol lock conflict detection (and fixes NFSv4 LOCK returning
+	// SERVERFAULT, surfaced to clients as EIO, when no manager was configured).
+	// Lock managers are per-share but the StateManager is global, so resolve the
+	// correct manager from each operation's file handle.
+	if metaSvc := rt.GetMetadataService(); metaSvc != nil {
+		v4StateManager.SetLockManagerResolver(func(handle []byte) lock.LockManager {
+			lm, err := metaSvc.GetLockManagerForHandle(metadata.FileHandle(handle))
+			if err != nil || lm == nil {
+				return nil
+			}
+			return lm
+		})
+	}
+
 	s.v4Handler = v4handlers.NewHandler(rt, s.pseudoFS, v4StateManager)
 	s.v4Handler.KerberosEnabled = s.kerberosConfig != nil
 

--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -524,7 +524,13 @@ func (s *NFSAdapter) SetRuntime(rtAny any) {
 	if metaSvc := rt.GetMetadataService(); metaSvc != nil {
 		v4StateManager.SetLockManagerResolver(func(handle []byte) lock.LockManager {
 			lm, err := metaSvc.GetLockManagerForHandle(metadata.FileHandle(handle))
-			if err != nil || lm == nil {
+			if err != nil {
+				// Stale/malformed handle, removed share, etc. Locking degrades to
+				// "no manager" for this op; log so operators can correlate.
+				logger.Debug("NFSv4 lock-manager resolution failed", "error", err)
+				return nil
+			}
+			if lm == nil {
 				return nil
 			}
 			return lm


### PR DESCRIPTION
## Problem

The production NFSv4 `StateManager` was constructed without a lock manager — `SetLockManager` was only ever called in unit tests. So in production every NFSv4 `LOCK`/`LOCKT` returned `no lock manager configured` → `NFS4ERR_SERVERFAULT`, which kernel clients surface as **EIO** (`remote I/O error`).

Surfaced by e2e: `TestNFSv4Locking`, `TestNFSv4BlockingLock`.

## Root cause

Lock managers are **per-share** (`metaSvc.lockManagers[shareName]`) but the NFSv4 `StateManager` is **global** (one per server). A single static `sm.lockManager` can't serve all shares, and nothing wired it anyway.

SMB and NLM already resolve the per-share unified `lock.Manager` from the file handle. NFSv4 was the only protocol not doing so.

## Fix

Per-handle resolver on the NFSv4 `StateManager`:

- `SetLockManagerResolver(func(handle []byte) lock.LockManager)` — takes precedence over the static `lockManager` (kept as a test fallback). Init-only (set once before serving), so reads are lock-free.
- Wired in the NFS adapter to `rt.GetMetadataService().GetLockManagerForHandle(...)`, so NFSv4 locks land in the **same `lock.Manager` instance** SMB/NLM use for that file.

All lock-touching sites resolve per handle: `acquireLock`, `TestLock`, `UnlockFile`, `ReleaseLockOwner`, `onLeaseExpired`, `RevokeDelegation`, plus the delegation grant/return, `FREE_STATEID`, and v4.0 client-eviction paths (which had the same dead `sm.lockManager != nil` guard and were never registering delegations / releasing locks).

## Validation

- In-process regression test (`lock_resolver_test.go`): nil-manager → LOCK fails (repro), resolver wired → succeeds; seeded SMB lock detected by NFSv4 LOCKT/LOCK on overlap (cross-protocol at the manager layer); per-handle routing.
- **On real Linux NFS mounts (SCW VM): `TestNFSv4Locking` and `TestNFSv4BlockingLock` now PASS** (previously EIO).

## Scope note

This fixes the **NFSv4** byte-range locking path. `TestCrossProtocolLocking` (NFS **v3/NLM** ↔ SMB) is a separate subsystem and is **not** addressed here — investigation shows the kernel v3 client's byte-range locks are not reaching the server's NLM/lock manager, so SMB can't observe them. Tracked separately in #1465.