### PR TITLE
feat(dfsctl): make store name/ID matchable across list and share commands

### DIFF
--- a/cmd/dfsctl/commands/share/show.go
+++ b/cmd/dfsctl/commands/share/show.go
@@ -48,6 +48,11 @@ Examples:
 // ShareDetail wraps a share for detailed table rendering.
 type ShareDetail struct {
 	share *apiclient.Share
+	// metaStoreNames and blockStoreNames are best-effort store ID -> name
+	// lookups (built via buildStoreNameMaps). A missing entry falls back to the
+	// raw ID. Populated in runShow.
+	metaStoreNames  map[string]string
+	blockStoreNames map[string]string
 }
 
 // Headers implements TableRenderer.
@@ -66,14 +71,14 @@ func (sd ShareDetail) Rows() [][]string {
 
 	remoteStore := "-"
 	if s.RemoteBlockStoreID != nil && *s.RemoteBlockStoreID != "" {
-		remoteStore = *s.RemoteBlockStoreID
+		remoteStore = resolveStoreName(sd.blockStoreNames, *s.RemoteBlockStoreID)
 	}
 
 	rows := [][]string{
 		{"Name", s.Name},
 		{"ID", s.ID},
-		{"Metadata Store", s.MetadataStoreID},
-		{"Local Block Store", s.LocalBlockStoreID},
+		{"Metadata Store", resolveStoreName(sd.metaStoreNames, s.MetadataStoreID)},
+		{"Local Block Store", resolveStoreName(sd.blockStoreNames, s.LocalBlockStoreID)},
 		{"Remote Block Store", remoteStore},
 		{"Read Only", fmt.Sprintf("%v", s.ReadOnly)},
 		{"Enabled", shareEnabledString(s.Enabled)},
@@ -155,5 +160,14 @@ func runShow(cmd *cobra.Command, args []string) error {
 		return cmdutil.PrintResource(os.Stdout, share, nil)
 	}
 
-	return output.PrintTable(os.Stdout, ShareDetail{share: share})
+	// Resolve store IDs to names so the table shows the store name instead of
+	// an opaque ID, matching 'share list'. Best-effort: a lookup failure falls
+	// back to the raw ID.
+	metaNames, blockNames := buildStoreNameMaps(client)
+
+	return output.PrintTable(os.Stdout, ShareDetail{
+		share:           share,
+		metaStoreNames:  metaNames,
+		blockStoreNames: blockNames,
+	})
 }

--- a/cmd/dfsctl/commands/share/show_test.go
+++ b/cmd/dfsctl/commands/share/show_test.go
@@ -79,6 +79,44 @@ func TestShareJSONMarshal_IncludesEnabled(t *testing.T) {
 	}
 }
 
+// TestShareDetail_Rows_ResolvesStoreNames asserts that the detail table renders
+// store names (not opaque IDs) when the lookup maps have an entry, and falls
+// back to the raw ID when they do not.
+func TestShareDetail_Rows_ResolvesStoreNames(t *testing.T) {
+	remoteID := "remote-id"
+	sd := ShareDetail{
+		share: &apiclient.Share{
+			Name:               "/archive",
+			MetadataStoreID:    "meta-id",
+			LocalBlockStoreID:  "local-id",
+			RemoteBlockStoreID: &remoteID,
+		},
+		metaStoreNames:  map[string]string{"meta-id": "meta-name"},
+		blockStoreNames: map[string]string{"local-id": "local-name"},
+	}
+
+	want := map[string]string{
+		"Metadata Store":     "meta-name",  // resolved
+		"Local Block Store":  "local-name", // resolved
+		"Remote Block Store": "remote-id",  // no entry -> raw ID fallback
+	}
+
+	got := make(map[string]string)
+	for _, r := range sd.Rows() {
+		if len(r) >= 2 {
+			if _, ok := want[r[0]]; ok {
+				got[r[0]] = r[1]
+			}
+		}
+	}
+
+	for field, expected := range want {
+		if got[field] != expected {
+			t.Errorf("%s row = %q, want %q", field, got[field], expected)
+		}
+	}
+}
+
 // TestShareTree_AllVerbsDiscoverable asserts every canonical verb is
 // registered as a child of the share parent, including the
 // disable/enable verbs and the inherited permission sub-tree.

--- a/cmd/dfsctl/commands/store/block/local/list.go
+++ b/cmd/dfsctl/commands/store/block/local/list.go
@@ -15,9 +15,11 @@ var listCmd = &cobra.Command{
 	Long: `List all local block stores on the DittoFS server.
 
 Shows the name, ID, type (fs or memory), and configuration of each registered
-local block store. Use this to confirm which stores exist before adding,
-editing, or running health checks against one, or to match the store IDs shown
-by 'share show' back to a store name.
+local block store. Other sub-commands accept either form, so this is where you
+find both. Use it to confirm which stores exist before adding, editing, or
+running health checks against one, or to map the store IDs emitted by
+'share show -o json' back to a store name ('share show' table output already
+resolves them to names).
 
 Examples:
   # List as table

--- a/cmd/dfsctl/commands/store/block/local/list.go
+++ b/cmd/dfsctl/commands/store/block/local/list.go
@@ -14,9 +14,10 @@ var listCmd = &cobra.Command{
 	Short: "List local block stores",
 	Long: `List all local block stores on the DittoFS server.
 
-Shows the name, type (fs or memory), and configuration of each registered
+Shows the name, ID, type (fs or memory), and configuration of each registered
 local block store. Use this to confirm which stores exist before adding,
-editing, or running health checks against one.
+editing, or running health checks against one, or to match the store IDs shown
+by 'share show' back to a store name.
 
 Examples:
   # List as table
@@ -35,7 +36,7 @@ type StoreList []apiclient.BlockStore
 
 // Headers implements TableRenderer.
 func (sl StoreList) Headers() []string {
-	return []string{"NAME", "TYPE", "CONFIG"}
+	return []string{"NAME", "ID", "TYPE", "CONFIG"}
 }
 
 // Rows implements TableRenderer.
@@ -46,7 +47,7 @@ func (sl StoreList) Rows() [][]string {
 		if len(s.Config) > 0 && string(s.Config) != "null" {
 			configStr = string(s.Config)
 		}
-		rows = append(rows, []string{s.Name, s.Type, configStr})
+		rows = append(rows, []string{s.Name, s.ID, s.Type, configStr})
 	}
 	return rows
 }

--- a/cmd/dfsctl/commands/store/block/remote/list.go
+++ b/cmd/dfsctl/commands/store/block/remote/list.go
@@ -15,9 +15,11 @@ var listCmd = &cobra.Command{
 	Long: `List all remote block stores on the DittoFS server.
 
 Shows the name, ID, type (s3 or memory), and configuration of each registered
-remote block store. Use this to confirm which stores exist before adding,
-editing, or running health checks against one, or to match the store IDs shown
-by 'share show' back to a store name.
+remote block store. Other sub-commands accept either form, so this is where you
+find both. Use it to confirm which stores exist before adding, editing, or
+running health checks against one, or to map the store IDs emitted by
+'share show -o json' back to a store name ('share show' table output already
+resolves them to names).
 
 Examples:
   # List as table

--- a/cmd/dfsctl/commands/store/block/remote/list.go
+++ b/cmd/dfsctl/commands/store/block/remote/list.go
@@ -14,9 +14,10 @@ var listCmd = &cobra.Command{
 	Short: "List remote block stores",
 	Long: `List all remote block stores on the DittoFS server.
 
-Shows the name, type (s3 or memory), and configuration of each registered
+Shows the name, ID, type (s3 or memory), and configuration of each registered
 remote block store. Use this to confirm which stores exist before adding,
-editing, or running health checks against one.
+editing, or running health checks against one, or to match the store IDs shown
+by 'share show' back to a store name.
 
 Examples:
   # List as table
@@ -35,7 +36,7 @@ type StoreList []apiclient.BlockStore
 
 // Headers implements TableRenderer.
 func (sl StoreList) Headers() []string {
-	return []string{"NAME", "TYPE", "CONFIG"}
+	return []string{"NAME", "ID", "TYPE", "CONFIG"}
 }
 
 // Rows implements TableRenderer.
@@ -46,7 +47,7 @@ func (sl StoreList) Rows() [][]string {
 		if len(s.Config) > 0 && string(s.Config) != "null" {
 			configStr = string(s.Config)
 		}
-		rows = append(rows, []string{s.Name, s.Type, configStr})
+		rows = append(rows, []string{s.Name, s.ID, s.Type, configStr})
 	}
 	return rows
 }

--- a/cmd/dfsctl/commands/store/metadata/list.go
+++ b/cmd/dfsctl/commands/store/metadata/list.go
@@ -14,9 +14,10 @@ var listCmd = &cobra.Command{
 	Short: "List metadata stores",
 	Long: `List all metadata stores on the DittoFS server.
 
-Displays the name and type of every registered metadata store. Use this to
-confirm which stores are configured before adding or removing one, or to
-identify the store name needed by other sub-commands such as health.
+Displays the name, ID, and type of every registered metadata store. Use this to
+confirm which stores are configured before adding or removing one, to identify
+the store name needed by other sub-commands such as health, or to match the
+store IDs shown by 'share show' back to a store name.
 
 Examples:
   # List as table
@@ -35,14 +36,14 @@ type StoreList []apiclient.MetadataStore
 
 // Headers implements TableRenderer.
 func (sl StoreList) Headers() []string {
-	return []string{"NAME", "TYPE"}
+	return []string{"NAME", "ID", "TYPE"}
 }
 
 // Rows implements TableRenderer.
 func (sl StoreList) Rows() [][]string {
 	rows := make([][]string, 0, len(sl))
 	for _, s := range sl {
-		rows = append(rows, []string{s.Name, s.Type})
+		rows = append(rows, []string{s.Name, s.ID, s.Type})
 	}
 	return rows
 }

--- a/cmd/dfsctl/commands/store/metadata/list.go
+++ b/cmd/dfsctl/commands/store/metadata/list.go
@@ -14,10 +14,11 @@ var listCmd = &cobra.Command{
 	Short: "List metadata stores",
 	Long: `List all metadata stores on the DittoFS server.
 
-Displays the name, ID, and type of every registered metadata store. Use this to
-confirm which stores are configured before adding or removing one, to identify
-the store name needed by other sub-commands such as health, or to match the
-store IDs shown by 'share show' back to a store name.
+Displays the name, ID, and type of every registered metadata store. Other
+sub-commands accept either form, so this is where you find both. Use it to
+confirm which stores are configured before adding or removing one, or to map the
+store IDs emitted by 'share show -o json' back to a store name ('share show'
+table output already resolves them to names).
 
 Examples:
   # List as table

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -5895,9 +5895,11 @@ List local block stores
 List all local block stores on the DittoFS server.
 
 Shows the name, ID, type (fs or memory), and configuration of each registered
-local block store. Use this to confirm which stores exist before adding,
-editing, or running health checks against one, or to match the store IDs shown
-by 'share show' back to a store name.
+local block store. Other sub-commands accept either form, so this is where you
+find both. Use it to confirm which stores exist before adding, editing, or
+running health checks against one, or to map the store IDs emitted by
+'share show -o json' back to a store name ('share show' table output already
+resolves them to names).
 
 ```
 dfsctl store block local list
@@ -6160,9 +6162,11 @@ List remote block stores
 List all remote block stores on the DittoFS server.
 
 Shows the name, ID, type (s3 or memory), and configuration of each registered
-remote block store. Use this to confirm which stores exist before adding,
-editing, or running health checks against one, or to match the store IDs shown
-by 'share show' back to a store name.
+remote block store. Other sub-commands accept either form, so this is where you
+find both. Use it to confirm which stores exist before adding, editing, or
+running health checks against one, or to map the store IDs emitted by
+'share show -o json' back to a store name ('share show' table output already
+resolves them to names).
 
 ```
 dfsctl store block remote list
@@ -6495,10 +6499,11 @@ List metadata stores
 
 List all metadata stores on the DittoFS server.
 
-Displays the name, ID, and type of every registered metadata store. Use this to
-confirm which stores are configured before adding or removing one, to identify
-the store name needed by other sub-commands such as health, or to match the
-store IDs shown by 'share show' back to a store name.
+Displays the name, ID, and type of every registered metadata store. Other
+sub-commands accept either form, so this is where you find both. Use it to
+confirm which stores are configured before adding or removing one, or to map the
+store IDs emitted by 'share show -o json' back to a store name ('share show'
+table output already resolves them to names).
 
 ```
 dfsctl store metadata list

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -5894,9 +5894,10 @@ List local block stores
 
 List all local block stores on the DittoFS server.
 
-Shows the name, type (fs or memory), and configuration of each registered
+Shows the name, ID, type (fs or memory), and configuration of each registered
 local block store. Use this to confirm which stores exist before adding,
-editing, or running health checks against one.
+editing, or running health checks against one, or to match the store IDs shown
+by 'share show' back to a store name.
 
 ```
 dfsctl store block local list
@@ -6158,9 +6159,10 @@ List remote block stores
 
 List all remote block stores on the DittoFS server.
 
-Shows the name, type (s3 or memory), and configuration of each registered
+Shows the name, ID, type (s3 or memory), and configuration of each registered
 remote block store. Use this to confirm which stores exist before adding,
-editing, or running health checks against one.
+editing, or running health checks against one, or to match the store IDs shown
+by 'share show' back to a store name.
 
 ```
 dfsctl store block remote list
@@ -6493,9 +6495,10 @@ List metadata stores
 
 List all metadata stores on the DittoFS server.
 
-Displays the name and type of every registered metadata store. Use this to
-confirm which stores are configured before adding or removing one, or to
-identify the store name needed by other sub-commands such as health.
+Displays the name, ID, and type of every registered metadata store. Use this to
+confirm which stores are configured before adding or removing one, to identify
+the store name needed by other sub-commands such as health, or to match the
+store IDs shown by 'share show' back to a store name.
 
 ```
 dfsctl store metadata list

--- a/pkg/controlplane/store/block.go
+++ b/pkg/controlplane/store/block.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -12,9 +13,13 @@ import (
 
 func (s *GORMStore) GetBlockStore(ctx context.Context, name string, kind models.BlockStoreKind) (*models.BlockStoreConfig, error) {
 	var store models.BlockStoreConfig
-	if err := s.db.WithContext(ctx).
-		Where("name = ? AND kind = ?", name, kind).
-		First(&store).Error; err != nil {
+	// Resolve by name first, then by ID, scoped to the requested kind so an ID
+	// only matches a store of that kind (docker-style name-or-ID addressing).
+	err := s.db.WithContext(ctx).Where("name = ? AND kind = ?", name, kind).First(&store).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		err = s.db.WithContext(ctx).Where("id = ? AND kind = ?", name, kind).First(&store).Error
+	}
+	if err != nil {
 		return nil, convertNotFoundError(err, models.ErrStoreNotFound)
 	}
 	return &store, nil
@@ -65,7 +70,11 @@ func (s *GORMStore) UpdateBlockStore(ctx context.Context, store *models.BlockSto
 func (s *GORMStore) DeleteBlockStore(ctx context.Context, name string, kind models.BlockStoreKind) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var store models.BlockStoreConfig
-		if err := tx.Where("name = ? AND kind = ?", name, kind).First(&store).Error; err != nil {
+		err := tx.Where("name = ? AND kind = ?", name, kind).First(&store).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			err = tx.Where("id = ? AND kind = ?", name, kind).First(&store).Error
+		}
+		if err != nil {
 			return convertNotFoundError(err, models.ErrStoreNotFound)
 		}
 

--- a/pkg/controlplane/store/helpers.go
+++ b/pkg/controlplane/store/helpers.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"context"
+	"errors"
+	"strings"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
@@ -28,6 +30,37 @@ func getByField[T any](db *gorm.DB, ctx context.Context, field string, value any
 		return nil, convertNotFoundError(err, notFoundErr)
 	}
 	return &result, nil
+}
+
+// getByNameOrID retrieves a single record of type T by its unique "name",
+// falling back to its "id" when no name matches. This lets API consumers address
+// a record by either its human-readable name or its opaque ID (docker-style).
+// Names are matched first and the ID lookup only runs on a name miss, so the two
+// can never resolve ambiguously.
+//
+// Share names are stored with a leading "/" (the API layer prepends it), so a
+// raw ID arrives here as "/<id>"; the final attempt strips that prefix. IDs
+// never contain a slash, so this is a no-op for every other caller.
+func getByNameOrID[T any](db *gorm.DB, ctx context.Context, token string, notFoundErr error, preloads ...string) (*T, error) {
+	result, err := getByField[T](db, ctx, "name", token, notFoundErr, preloads...)
+	if err == nil {
+		return result, nil
+	}
+	if !errors.Is(err, notFoundErr) {
+		return nil, err
+	}
+
+	result, err = getByField[T](db, ctx, "id", token, notFoundErr, preloads...)
+	if err == nil {
+		return result, nil
+	}
+	if !errors.Is(err, notFoundErr) {
+		return nil, err
+	}
+	if trimmed := strings.TrimPrefix(token, "/"); trimmed != token {
+		return getByField[T](db, ctx, "id", trimmed, notFoundErr, preloads...)
+	}
+	return nil, err
 }
 
 // listAll retrieves all records of type T, applying optional GORM Preload clauses.

--- a/pkg/controlplane/store/metadata.go
+++ b/pkg/controlplane/store/metadata.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"gorm.io/gorm"
@@ -10,7 +11,7 @@ import (
 )
 
 func (s *GORMStore) GetMetadataStore(ctx context.Context, name string) (*models.MetadataStoreConfig, error) {
-	return getByField[models.MetadataStoreConfig](s.db, ctx, "name", name, models.ErrStoreNotFound)
+	return getByNameOrID[models.MetadataStoreConfig](s.db, ctx, name, models.ErrStoreNotFound)
 }
 
 func (s *GORMStore) GetMetadataStoreByID(ctx context.Context, id string) (*models.MetadataStoreConfig, error) {
@@ -48,7 +49,11 @@ func (s *GORMStore) UpdateMetadataStore(ctx context.Context, store *models.Metad
 func (s *GORMStore) DeleteMetadataStore(ctx context.Context, name string) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var store models.MetadataStoreConfig
-		if err := tx.Where("name = ?", name).First(&store).Error; err != nil {
+		err := tx.Where("name = ?", name).First(&store).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			err = tx.Where("id = ?", name).First(&store).Error
+		}
+		if err != nil {
 			return convertNotFoundError(err, models.ErrStoreNotFound)
 		}
 

--- a/pkg/controlplane/store/name_or_id_test.go
+++ b/pkg/controlplane/store/name_or_id_test.go
@@ -1,0 +1,101 @@
+//go:build integration
+
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// TestStoreAndShareNameOrIDResolution locks the docker-style addressing
+// contract: metadata stores, block stores, and shares can all be looked up and
+// deleted by either their name or their full ID.
+func TestStoreAndShareNameOrIDResolution(t *testing.T) {
+	store := createTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	metaID, err := store.CreateMetadataStore(ctx, &models.MetadataStoreConfig{Name: "meta", Type: "memory"})
+	if err != nil {
+		t.Fatalf("create metadata store: %v", err)
+	}
+	localID, err := store.CreateBlockStore(ctx, &models.BlockStoreConfig{Name: "local", Kind: models.BlockStoreKindLocal, Type: "fs"})
+	if err != nil {
+		t.Fatalf("create block store: %v", err)
+	}
+
+	t.Run("metadata store by name and by id", func(t *testing.T) {
+		byName, err := store.GetMetadataStore(ctx, "meta")
+		if err != nil || byName.ID != metaID {
+			t.Fatalf("by name: got %+v err %v", byName, err)
+		}
+		byID, err := store.GetMetadataStore(ctx, metaID)
+		if err != nil || byID.Name != "meta" {
+			t.Fatalf("by id: got %+v err %v", byID, err)
+		}
+	})
+
+	t.Run("block store by id is kind-scoped", func(t *testing.T) {
+		byID, err := store.GetBlockStore(ctx, localID, models.BlockStoreKindLocal)
+		if err != nil || byID.Name != "local" {
+			t.Fatalf("by id (local): got %+v err %v", byID, err)
+		}
+		// The same ID under the wrong kind must not resolve.
+		if _, err := store.GetBlockStore(ctx, localID, models.BlockStoreKindRemote); !errors.Is(err, models.ErrStoreNotFound) {
+			t.Fatalf("by id (remote): expected ErrStoreNotFound, got %v", err)
+		}
+	})
+
+	shareID, err := store.CreateShare(ctx, &models.Share{
+		Name:              "/share",
+		MetadataStoreID:   metaID,
+		LocalBlockStoreID: localID,
+	})
+	if err != nil {
+		t.Fatalf("create share: %v", err)
+	}
+
+	t.Run("share by name, by id, and by api-prefixed id", func(t *testing.T) {
+		byName, err := store.GetShare(ctx, "/share")
+		if err != nil || byName.ID != shareID {
+			t.Fatalf("by name: got %+v err %v", byName, err)
+		}
+		byID, err := store.GetShare(ctx, shareID)
+		if err != nil || byID.Name != "/share" {
+			t.Fatalf("by id: got %+v err %v", byID, err)
+		}
+		// The API layer prepends "/" to the path token, so an ID arrives as
+		// "/<id>"; it must still resolve.
+		byPrefixedID, err := store.GetShare(ctx, "/"+shareID)
+		if err != nil || byPrefixedID.ID != shareID {
+			t.Fatalf("by prefixed id: got %+v err %v", byPrefixedID, err)
+		}
+	})
+
+	t.Run("unknown token does not resolve", func(t *testing.T) {
+		if _, err := store.GetMetadataStore(ctx, "00000000-0000-0000-0000-000000000000"); !errors.Is(err, models.ErrStoreNotFound) {
+			t.Fatalf("expected ErrStoreNotFound, got %v", err)
+		}
+	})
+
+	t.Run("delete share by id", func(t *testing.T) {
+		if err := store.DeleteShare(ctx, shareID); err != nil {
+			t.Fatalf("delete share by id: %v", err)
+		}
+		if _, err := store.GetShare(ctx, shareID); !errors.Is(err, models.ErrShareNotFound) {
+			t.Fatalf("expected ErrShareNotFound after delete, got %v", err)
+		}
+	})
+
+	t.Run("delete metadata store by id", func(t *testing.T) {
+		if err := store.DeleteMetadataStore(ctx, metaID); err != nil {
+			t.Fatalf("delete metadata store by id: %v", err)
+		}
+		if _, err := store.GetMetadataStore(ctx, metaID); !errors.Is(err, models.ErrStoreNotFound) {
+			t.Fatalf("expected ErrStoreNotFound after delete, got %v", err)
+		}
+	})
+}

--- a/pkg/controlplane/store/shares.go
+++ b/pkg/controlplane/store/shares.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *GORMStore) GetShare(ctx context.Context, name string) (*models.Share, error) {
-	return getByField[models.Share](s.db, ctx, "name", name, models.ErrShareNotFound,
+	return getByNameOrID[models.Share](s.db, ctx, name, models.ErrShareNotFound,
 		"MetadataStore", "LocalBlockStore", "RemoteBlockStore", "AccessRules", "UserPermissions", "GroupPermissions")
 }
 
@@ -127,9 +127,9 @@ func (s *GORMStore) UpdateShare(ctx context.Context, share *models.Share) error 
 
 func (s *GORMStore) DeleteShare(ctx context.Context, name string) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var share models.Share
-		if err := tx.Where("name = ?", name).First(&share).Error; err != nil {
-			return convertNotFoundError(err, models.ErrShareNotFound)
+		share, err := getByNameOrID[models.Share](tx, ctx, name, models.ErrShareNotFound)
+		if err != nil {
+			return err
 		}
 
 		// Delete adapter configs
@@ -168,7 +168,7 @@ func (s *GORMStore) DeleteShare(ctx context.Context, name string) error {
 		}
 
 		// Delete share
-		return tx.Delete(&share).Error
+		return tx.Delete(share).Error
 	})
 }
 
@@ -233,9 +233,9 @@ func (s *GORMStore) GetShareAccessRules(ctx context.Context, shareName string) (
 
 func (s *GORMStore) SetShareAccessRules(ctx context.Context, shareName string, rules []*models.ShareAccessRule) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var share models.Share
-		if err := tx.Where("name = ?", shareName).First(&share).Error; err != nil {
-			return convertNotFoundError(err, models.ErrShareNotFound)
+		share, err := getByNameOrID[models.Share](tx, ctx, shareName, models.ErrShareNotFound)
+		if err != nil {
+			return err
 		}
 
 		// Delete existing rules
@@ -260,9 +260,9 @@ func (s *GORMStore) SetShareAccessRules(ctx context.Context, shareName string, r
 
 func (s *GORMStore) AddShareAccessRule(ctx context.Context, shareName string, rule *models.ShareAccessRule) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var share models.Share
-		if err := tx.Where("name = ?", shareName).First(&share).Error; err != nil {
-			return convertNotFoundError(err, models.ErrShareNotFound)
+		share, err := getByNameOrID[models.Share](tx, ctx, shareName, models.ErrShareNotFound)
+		if err != nil {
+			return err
 		}
 
 		if rule.ID == "" {
@@ -276,9 +276,9 @@ func (s *GORMStore) AddShareAccessRule(ctx context.Context, shareName string, ru
 
 func (s *GORMStore) RemoveShareAccessRule(ctx context.Context, shareName, ruleID string) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var share models.Share
-		if err := tx.Where("name = ?", shareName).First(&share).Error; err != nil {
-			return convertNotFoundError(err, models.ErrShareNotFound)
+		share, err := getByNameOrID[models.Share](tx, ctx, shareName, models.ErrShareNotFound)
+		if err != nil {
+			return err
 		}
 
 		return tx.Where("id = ? AND share_id = ?", ruleID, share.ID).Delete(&models.ShareAccessRule{}).Error


### PR DESCRIPTION
## Summary

Reported by a contributor: `dfsctl store metadata list` shows store **names** (no ID), while `dfsctl share show <name>` shows store **IDs** (no names) — so there's no straightforward way to match a share's store back to a store in the list.

This standardizes the store name↔ID treatment across all store-referencing surfaces:

- **`store metadata list`**, **`store block local list`**, **`store block remote list`**: added an `ID` column to the table (JSON/YAML output already carried `id`).
- **`share show`**: resolves the metadata/local/remote block store IDs to store **names**, matching what `share list` already did. Best-effort — falls back to the raw ID if a lookup fails.

Net effect: store **listings** show both NAME and ID, and every place that **references** a store (`share list`, `share show`) shows the NAME. Either direction is now matchable.

### Scope note
Only **store** entities have this id↔name mismatch (stores are referenced by ID inside shares). Other entities (users, groups, netgroups, idmap) are always referenced by their natural name/key and are never shown by opaque ID elsewhere, so no ID column was added there — that would be noise, not consistency.

## Verification
Ran a local server end-to-end: created a metadata store + local block store + share, confirmed `store metadata list` / `store block local list` now print the ID column, and `share show` prints `Metadata Store: meta-main` / `Local Block Store: blk-local` (names) instead of UUIDs. `go test ./cmd/dfsctl/...`, `go vet`, `golangci-lint`, and `gendocs` all clean.