### PR TITLE
fix(logger): route stdlib slog default through the configured handler

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -115,6 +115,15 @@ func reconfigure() {
 	}
 
 	slogger = slog.New(handler)
+
+	// Route the standard-library default logger through our configured
+	// handler too. Large parts of the codebase (notably pkg/block — the GC
+	// engine and the fs/rollup stores) log via the package-level slog.*
+	// functions rather than this package's wrappers. Without SetDefault those
+	// calls go to slog's built-in default handler, which ignores both the
+	// configured format AND the configured level — so DITTOFS_LOGGING_LEVEL=DEBUG
+	// never surfaced their Debug lines and their output used a different format.
+	slog.SetDefault(slogger)
 }
 
 // Init initializes the logger with the given configuration.

--- a/internal/logger/slog_default_test.go
+++ b/internal/logger/slog_default_test.go
@@ -1,0 +1,26 @@
+package logger
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// Verifies that std-lib slog.* (used across pkg/block, incl. the GC engine)
+// honors DITTOFS_LOGGING_LEVEL via slog.SetDefault in reconfigure().
+func TestStdlibSlogHonorsConfiguredLevel(t *testing.T) {
+	var buf bytes.Buffer
+	InitWithWriter(&buf, "DEBUG", "text", false)
+	slog.Debug("engine-style-debug-line", "k", "v")
+	if !strings.Contains(buf.String(), "engine-style-debug-line") {
+		t.Fatalf("std slog.Debug did not route through configured DEBUG handler; got: %q", buf.String())
+	}
+
+	buf.Reset()
+	InitWithWriter(&buf, "INFO", "text", false)
+	slog.Debug("should-be-suppressed")
+	if strings.Contains(buf.String(), "should-be-suppressed") {
+		t.Fatalf("std slog.Debug leaked at INFO level; got: %q", buf.String())
+	}
+}


### PR DESCRIPTION
## Problem

Reported on #1433: `DITTOFS_LOGGING_LEVEL=DEBUG` produced no DEBUG output.

Root cause: `internal/logger.reconfigure()` builds the package `slog.Logger` (with the configured level + format handler) but **never calls `slog.SetDefault`**. A large share of the codebase — notably all of `pkg/block` (the GC engine in `gc.go`, the `fs`/`rollup` stores) — logs via the package-level `slog.Debug/Info/Warn/Error` functions rather than this package's wrappers. Those calls hit slog's built-in default handler, which:

- ignores `DITTOFS_LOGGING_LEVEL` (its level is fixed at INFO), so their `Debug` lines were always dropped; and
- ignores the configured format (text/json + color).

## Fix

Call `slog.SetDefault(slogger)` at the end of `reconfigure()`, so the stdlib default routes through the same handler + level var as this package's wrappers. One line.

## Test

`TestStdlibSlogHonorsConfiguredLevel` asserts a stdlib `slog.Debug` lands when the configured level is DEBUG and is suppressed at INFO. Verified it fails without the fix and passes with it.

Refs #1433 (the DEBUG-logging sub-issue). The substantive GC follow-ups from that thread ship separately.