### PR TITLE
fix(gc): deduplicate snapshot-hold hashes across snapshots in the mark phase

### DIFF
--- a/pkg/controlplane/runtime/snapshot_hold.go
+++ b/pkg/controlplane/runtime/snapshot_hold.go
@@ -89,6 +89,15 @@ func (p *SnapshotHoldProvider) HeldHashes(ctx context.Context, remoteEndpointID 
 			return fmt.Errorf("snapshot hold: list snapshots for share %q: %w", shareName, err)
 		}
 
+		// Union every snapshot's manifest into one set BEFORE emitting, so a
+		// hash referenced by N snapshots is forwarded to fn once, not N times.
+		// Hourly snapshots of a slowly-changing tree all re-reference the same
+		// hashes; without this dedup the mark phase issues O(snapshots × tree)
+		// live-set writes — on a real deployment ~70 snapshots inflated
+		// hashes_marked to 4.8M and blew the GC deadline (#1433). Peak memory is
+		// the per-share distinct-hash count, which — given the heavy overlap —
+		// is of the same order as a single manifest, not the sum.
+		union := block.NewHashSet(0)
 		for _, snap := range snaps {
 			manifestPath := snap.ManifestPath(localStoreDir)
 			if _, err := os.Stat(manifestPath); err != nil {
@@ -100,7 +109,10 @@ func (p *SnapshotHoldProvider) HeldHashes(ctx context.Context, remoteEndpointID 
 				}
 				return fmt.Errorf("snapshot hold: stat manifest %q: %w", manifestPath, err)
 			}
-			count, err := streamManifest(manifestPath, fn)
+			count, err := streamManifest(manifestPath, func(h block.ContentHash) error {
+				union.Add(h)
+				return nil
+			})
 			if err != nil {
 				if errors.Is(err, fs.ErrNotExist) {
 					// TOCTOU: the manifest passed the Stat above but was
@@ -119,6 +131,17 @@ func (p *SnapshotHoldProvider) HeldHashes(ctx context.Context, remoteEndpointID 
 				"remote_endpoint_id", remoteEndpointID,
 			)
 		}
+
+		// Emit the deduplicated union once for this share.
+		if err := union.ForEach(fn); err != nil {
+			return fmt.Errorf("snapshot hold: emit union for share %q: %w", shareName, err)
+		}
+		logger.Debug("snapshot hold: emitted deduplicated union",
+			"share", shareName,
+			"distinct_hashes", union.Len(),
+			"snapshots", len(snaps),
+			"remote_endpoint_id", remoteEndpointID,
+		)
 	}
 	return nil
 }

--- a/pkg/controlplane/runtime/snapshot_hold_test.go
+++ b/pkg/controlplane/runtime/snapshot_hold_test.go
@@ -292,6 +292,52 @@ func TestSnapshotHoldProvider_MultipleSharesUnion(t *testing.T) {
 	assert.Equal(t, want, got, "union of held hashes across both shares")
 }
 
+// TestSnapshotHoldProvider_DedupAcrossSnapshots asserts that when many
+// snapshots of one share re-reference the same hashes (the common case: hourly
+// snapshots of a slowly-changing tree), HeldHashes emits each distinct hash
+// EXACTLY ONCE rather than once per snapshot. Without per-share dedup the mark
+// phase issues O(snapshots × tree) live-set writes — on a real deployment ~70
+// snapshots inflated hashes_marked to 4.8M and blew the GC deadline (#1433).
+func TestSnapshotHoldProvider_DedupAcrossSnapshots(t *testing.T) {
+	rt := newSnapshotHoldRuntime(t)
+	localStoreDir := t.TempDir()
+
+	shareName := "alpha"
+	rt.sharesSvc.InjectShareForTesting(&shares.Share{Name: shareName, MetadataStore: "memory"})
+	require.NoError(t, rt.sharesSvc.SetLocalStoreDirForTesting(shareName, localStoreDir))
+
+	// Same two hashes in every snapshot manifest — the overlap GC must collapse.
+	shared := []block.ContentHash{hashAll(0xC1), hashAll(0xC2)}
+	const numSnapshots = 5
+	for i := 0; i < numSnapshots; i++ {
+		// Each snapshot needs its own row: the partial unique index forbids two
+		// concurrent "creating" rows, so drive each to ready before the next.
+		id := snapshotHoldCreateReady(t, rt, shareName)
+		snapshotHoldWriteManifest(t, (&models.Snapshot{ID: id}).ManifestPath(localStoreDir), shared)
+	}
+
+	provider := rt.snapshotHoldForRemote([]string{shareName})
+
+	var got []block.ContentHash
+	seen := map[block.ContentHash]int{}
+	err := provider.HeldHashes(context.Background(), "remote-1", []string{shareName},
+		func(h block.ContentHash) error {
+			got = append(got, h)
+			seen[h]++
+			return nil
+		})
+	require.NoError(t, err)
+
+	require.Len(t, got, len(shared), "each distinct hash must be emitted once, not once per snapshot")
+	for h, n := range seen {
+		assert.Equalf(t, 1, n, "hash %x emitted %d times; expected exactly once", h, n)
+	}
+	want := append([]block.ContentHash{}, shared...)
+	sortHashes(got)
+	sortHashes(want)
+	assert.Equal(t, want, got)
+}
+
 // sortHashes sorts a ContentHash slice in lexicographic byte order so
 // per-share ordering does not destabilize assertions.
 func sortHashes(hs []block.ContentHash) {


### PR DESCRIPTION
## Problem

Reported on #1433: on a ~44GB / 58k-file share with ~70 hourly snapshots (7-day retention), every GC mark phase reported `hashes_marked=4,848,172` and took ~8.7 min — long enough to blow the auto-GC deadline and the dfsctl client timeout.

Root cause: `SnapshotHoldProvider.HeldHashes` walks **each snapshot's manifest independently** and forwards every hash to the live-set callback. Hourly snapshots of a slowly-changing tree all re-reference the same hashes, so the callback (a `GCState` Badger write + `HashesMarked++`) fired ~70× per hash: `70 snapshots × ~69k hashes ≈ 4.8M`. The live set was correct (Badger dedups at the storage layer), but the work — and the metric — scaled with snapshot count.

## Fix

Union each share's snapshot manifests into one `HashSet` before emitting, so a hash held by N snapshots is forwarded to the mark callback exactly once. `4.8M → ~69k` live-set writes; `HashesMarked` becomes the distinct-per-share count.

Peak memory is the per-share distinct-hash count. Given the heavy cross-snapshot overlap that's of the same order as a single manifest (the path already materialized one full manifest `HashSet` at a time), not the sum — so no meaningful increase over the previous peak.

All TOCTOU / fail-closed / delete-vs-mark-lock semantics are preserved; only the emit is deduplicated.

## Test

`TestSnapshotHoldProvider_DedupAcrossSnapshots`: 5 snapshots with identical manifests must emit each distinct hash exactly once. Fails before the fix (10 emissions), passes after (2). Existing snapshot-hold suite (filter-by-manifest, fail-closed, multi-share union, memory-share skip, stress) stays green.

This is the keystone perf fix for the #1433 follow-ups; the async-GC + progress-logging change (so long mark phases survive request/client timeouts) ships separately.