### PR TITLE
feat(gc): async block-store GC (kick-off + poll) with mark-phase progress (#1433)

### DIFF
--- a/cmd/dfsctl/commands/store/block/gc.go
+++ b/cmd/dfsctl/commands/store/block/gc.go
@@ -3,12 +3,19 @@ package block
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
 	"github.com/marmos91/dittofs/internal/cli/output"
 	"github.com/marmos91/dittofs/pkg/apiclient"
+)
+
+// Terminal GC-job states (mirror runtime.GCState*).
+const (
+	gcStateDone   = "done"
+	gcStateFailed = "failed"
 )
 
 // gcCmd triggers an on-demand block-store GC run for the named share and
@@ -27,6 +34,11 @@ directory and can be inspected with:
 
   dfsctl store block gc-status <share>
 
+The run executes asynchronously on the server (the mark phase can take
+minutes on a large or snapshot-heavy deployment). By default this command
+polls until the job finishes, rendering progress; pass --no-wait to print
+the job id and return immediately.
+
 Use --dry-run to skip deletes and print up to dry_run_sample_size
 candidate keys (default 1000). Recommended for first-time deployment
 confidence and for debugging suspected mark-phase bugs.
@@ -41,6 +53,7 @@ Examples:
   dfsctl store block gc myshare
   dfsctl store block gc myshare --dry-run
   dfsctl store block gc myshare --reconcile
+  dfsctl store block gc myshare --no-wait
   dfsctl store block gc myshare -o json`,
 	Args: cobra.ExactArgs(1),
 	RunE: runBlockStoreGC,
@@ -49,61 +62,124 @@ Examples:
 func init() {
 	gcCmd.Flags().Bool("dry-run", false, "Run mark + sweep enumeration but skip deletes; print candidate keys")
 	gcCmd.Flags().Bool("reconcile", false, "Also reap stranded file_blocks rows leaked by older versions (server-wide), then sweep both tiers")
+	gcCmd.Flags().Bool("no-wait", false, "Start the job and print its id without waiting for completion")
 }
 
 func runBlockStoreGC(cmd *cobra.Command, args []string) error {
 	share := args[0]
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	reconcile, _ := cmd.Flags().GetBool("reconcile")
+	noWait, _ := cmd.Flags().GetBool("no-wait")
 
 	client, err := cmdutil.GetAuthenticatedClient()
 	if err != nil {
 		return err
 	}
 
-	res, err := client.BlockStoreGC(share, &apiclient.BlockStoreGCOptions{DryRun: dryRun, Reconcile: reconcile})
+	jobID, err := client.StartBlockStoreGC(share, &apiclient.BlockStoreGCOptions{DryRun: dryRun, Reconcile: reconcile})
 	if err != nil {
-		return fmt.Errorf("failed to run block store GC: %w", err)
-	}
-	if res == nil || res.Stats == nil {
-		return fmt.Errorf("block store GC: server returned empty response")
+		return fmt.Errorf("failed to start block store GC: %w", err)
 	}
 
-	format, err := cmdutil.GetOutputFormatParsed()
-	if err != nil {
-		return err
+	format, ferr := cmdutil.GetOutputFormatParsed()
+	if ferr != nil {
+		return ferr
 	}
 
-	// Emit the stats body first so observability is identical across
-	// formats, then surface sweep errors as a non-zero exit independently
-	// of the output format. A GC run that hit Delete/list errors left
-	// orphan objects unreclaimed (storage/cost leak) — scripts gating on
-	// the exit code must see that in -o json/-o yaml too, not only table.
+	if noWait {
+		switch format {
+		case output.FormatJSON:
+			return output.PrintJSON(os.Stdout, map[string]string{"job_id": jobID})
+		case output.FormatYAML:
+			return output.PrintYAML(os.Stdout, map[string]string{"job_id": jobID})
+		default:
+			fmt.Printf("GC job started: %s\n", jobID)
+		}
+		return nil
+	}
+
+	return watchGC(client, share, jobID, dryRun, format)
+}
+
+// watchGC polls the GC job until it reaches a terminal state. In table mode it
+// renders a live progress status line; in JSON/YAML mode it stays silent until
+// the terminal status so the machine-readable output is not polluted. On
+// completion it emits the full stats body and returns a non-zero error if the
+// run hit sweep errors, preserving the prior synchronous command's exit
+// semantics.
+func watchGC(client *apiclient.Client, share, jobID string, dryRun bool, format output.Format) error {
+	renderProgress := format == output.FormatTable
+	for {
+		status, err := client.GetBlockStoreGCJob(share, jobID)
+		if err != nil {
+			return fmt.Errorf("failed to poll GC job: %w", err)
+		}
+
+		switch status.State {
+		case gcStateDone:
+			if renderProgress {
+				fmt.Printf("\rmarked %d hashes, swept %d objects (%s) — done                \n",
+					status.HashesMarked, status.ObjectsSwept, formatBytes(status.BytesFreed))
+			}
+			return emitGCResult(status, format, dryRun)
+		case gcStateFailed:
+			if renderProgress {
+				fmt.Println()
+			}
+			return fmt.Errorf("GC job failed: %s", status.Error)
+		default:
+			if renderProgress {
+				fmt.Printf("\rmarked %d hashes, scanned %d, swept %d objects (%s)        ",
+					status.HashesMarked, status.ObjectsScanned, status.ObjectsSwept,
+					formatBytes(status.BytesFreed))
+			}
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+}
+
+// emitGCResult renders the terminal job's stats in the requested output format
+// and returns an error when the run reported sweep errors (so scripts gating on
+// the exit code see it in every format, not only the table).
+func emitGCResult(status *apiclient.GCJobStatus, format output.Format, dryRun bool) error {
 	switch format {
 	case output.FormatJSON:
-		if err := output.PrintJSON(os.Stdout, res); err != nil {
+		if err := output.PrintJSON(os.Stdout, status); err != nil {
 			return err
 		}
 	case output.FormatYAML:
-		if err := output.PrintYAML(os.Stdout, res); err != nil {
+		if err := output.PrintYAML(os.Stdout, status); err != nil {
 			return err
 		}
 	default:
-		if err := printGCStatsTable(res, dryRun); err != nil {
+		if err := printGCStatsTable(status, dryRun); err != nil {
 			return err
 		}
 	}
 
-	if res.Stats.ErrorCount > 0 {
-		return fmt.Errorf("GC completed with %d sweep error(s)", res.Stats.ErrorCount)
+	if status.Stats != nil && status.Stats.ErrorCount > 0 {
+		return fmt.Errorf("GC completed with %d sweep error(s)", status.Stats.ErrorCount)
 	}
 	return nil
 }
 
 // printGCStatsTable renders the GC summary as a key/value table plus an
 // optional dry-run candidate listing. Mirrors stats.go's output style.
-func printGCStatsTable(res *apiclient.BlockStoreGCResult, dryRun bool) error {
-	s := res.Stats
+func printGCStatsTable(status *apiclient.GCJobStatus, dryRun bool) error {
+	s := status.Stats
+	if s == nil {
+		// Terminal job without a persisted stats body (should not happen for a
+		// done run): fall back to the live counters.
+		pairs := [][2]string{
+			{"Hashes Marked", fmt.Sprintf("%d", status.HashesMarked)},
+			{"Objects Found", fmt.Sprintf("%d", status.ObjectsScanned)},
+			{"Objects Swept", fmt.Sprintf("%d", status.ObjectsSwept)},
+			{"Bytes Freed", formatBytes(status.BytesFreed)},
+		}
+		return output.SimpleTable(os.Stdout, pairs)
+	}
+
 	pairs := [][2]string{
 		{"Run ID", s.RunID},
 		{"Hashes Marked", fmt.Sprintf("%d", s.HashesMarked)},

--- a/cmd/dfsctl/commands/store/block/gc.go
+++ b/cmd/dfsctl/commands/store/block/gc.go
@@ -98,7 +98,7 @@ func runBlockStoreGC(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	return watchGC(client, share, jobID, dryRun, format)
+	return watchGC(client, share, jobID, format)
 }
 
 // watchGC polls the GC job until it reaches a terminal state. In table mode it
@@ -107,7 +107,7 @@ func runBlockStoreGC(cmd *cobra.Command, args []string) error {
 // completion it emits the full stats body and returns a non-zero error if the
 // run hit sweep errors, preserving the prior synchronous command's exit
 // semantics.
-func watchGC(client *apiclient.Client, share, jobID string, dryRun bool, format output.Format) error {
+func watchGC(client *apiclient.Client, share, jobID string, format output.Format) error {
 	renderProgress := format == output.FormatTable
 	for {
 		status, err := client.GetBlockStoreGCJob(share, jobID)
@@ -121,7 +121,7 @@ func watchGC(client *apiclient.Client, share, jobID string, dryRun bool, format 
 				fmt.Printf("\rmarked %d hashes, swept %d objects (%s) — done                \n",
 					status.HashesMarked, status.ObjectsSwept, formatBytes(status.BytesFreed))
 			}
-			return emitGCResult(status, format, dryRun)
+			return emitGCResult(status, format)
 		case gcStateFailed:
 			if renderProgress {
 				fmt.Println()
@@ -142,7 +142,7 @@ func watchGC(client *apiclient.Client, share, jobID string, dryRun bool, format 
 // emitGCResult renders the terminal job's stats in the requested output format
 // and returns an error when the run reported sweep errors (so scripts gating on
 // the exit code see it in every format, not only the table).
-func emitGCResult(status *apiclient.GCJobStatus, format output.Format, dryRun bool) error {
+func emitGCResult(status *apiclient.GCJobStatus, format output.Format) error {
 	switch format {
 	case output.FormatJSON:
 		if err := output.PrintJSON(os.Stdout, status); err != nil {
@@ -153,7 +153,7 @@ func emitGCResult(status *apiclient.GCJobStatus, format output.Format, dryRun bo
 			return err
 		}
 	default:
-		if err := printGCStatsTable(status, dryRun); err != nil {
+		if err := printGCStatsTable(status); err != nil {
 			return err
 		}
 	}
@@ -166,7 +166,7 @@ func emitGCResult(status *apiclient.GCJobStatus, format output.Format, dryRun bo
 
 // printGCStatsTable renders the GC summary as a key/value table plus an
 // optional dry-run candidate listing. Mirrors stats.go's output style.
-func printGCStatsTable(status *apiclient.GCJobStatus, dryRun bool) error {
+func printGCStatsTable(status *apiclient.GCJobStatus) error {
 	s := status.Stats
 	if s == nil {
 		// Terminal job without a persisted stats body (should not happen for a
@@ -202,7 +202,10 @@ func printGCStatsTable(status *apiclient.GCJobStatus, dryRun bool) error {
 		}
 	}
 
-	if dryRun || len(s.DryRunCandidates) > 0 {
+	// Use the JOB's actual dry-run flag, not the CLI request: StartBlockStoreGC
+	// may return an already-running job started with different flags, so the
+	// rendering must reflect what the job did, not what this invocation asked.
+	if status.DryRun || len(s.DryRunCandidates) > 0 {
 		fmt.Println()
 		fmt.Printf("Dry-run candidates (%d):\n", len(s.DryRunCandidates))
 		for _, c := range s.DryRunCandidates {

--- a/cmd/dfsctl/commands/store/block/gc_test.go
+++ b/cmd/dfsctl/commands/store/block/gc_test.go
@@ -21,12 +21,14 @@ import (
 // dry_run flag for assertions.
 type gcServer struct {
 	*httptest.Server
-	lastMethod string
-	lastPath   string
-	lastDryRun bool
-	gcStats    *engine.GCStats
-	summary    engine.GCRunSummary
-	status     int
+	lastMethod    string
+	lastPath      string
+	lastPostPath  string
+	lastDryRun    bool
+	lastReconcile bool
+	gcStats       *engine.GCStats
+	summary       engine.GCRunSummary
+	status        int
 }
 
 func newGCServer(t *testing.T) *gcServer {
@@ -51,8 +53,25 @@ func newGCServer(t *testing.T) *gcServer {
 			var opts apiclient.BlockStoreGCOptions
 			_ = json.Unmarshal(body, &opts)
 			s.lastDryRun = opts.DryRun
+			s.lastReconcile = opts.Reconcile
+			s.lastPostPath = r.URL.Path
+			// Async kick-off: 202 + job id; the command then polls the job.
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"job_id": "gc-1",
+				"status": apiclient.GCJobStatus{ID: "gc-1", State: "running"},
+			})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/gc/"):
+			// Poll: report a terminal (done) job carrying the canned stats.
+			job := apiclient.GCJobStatus{ID: "gc-1", State: "done", Stats: s.gcStats}
+			if s.gcStats != nil {
+				job.HashesMarked = s.gcStats.HashesMarked
+				job.ObjectsScanned = s.gcStats.ObjectsScanned
+				job.ObjectsSwept = s.gcStats.ObjectsSwept
+				job.BytesFreed = s.gcStats.BytesFreed
+			}
 			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(apiclient.BlockStoreGCResult{Stats: s.gcStats})
+			_ = json.NewEncoder(w).Encode(job)
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/gc-status"):
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(s.summary)
@@ -121,11 +140,8 @@ func TestGCCmd_CallsClient_AndPrintsSummary(t *testing.T) {
 		}
 	})
 
-	if s.lastMethod != http.MethodPost {
-		t.Errorf("method = %q, want POST", s.lastMethod)
-	}
-	if s.lastPath != "/api/v1/shares/myshare/blockstore/gc" {
-		t.Errorf("path = %q, want /api/v1/shares/myshare/blockstore/gc", s.lastPath)
+	if s.lastPostPath != "/api/v1/shares/myshare/blockstore/gc" {
+		t.Errorf("POST path = %q, want /api/v1/shares/myshare/blockstore/gc", s.lastPostPath)
 	}
 	if s.lastDryRun {
 		t.Error("dry_run flag should be false by default")

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -5610,6 +5610,11 @@ directory and can be inspected with:
 dfsctl store block gc-status <share>
 ```
 
+The run executes asynchronously on the server (the mark phase can take
+minutes on a large or snapshot-heavy deployment). By default this command
+polls until the job finishes, rendering progress; pass --no-wait to print
+the job id and return immediately.
+
 Use --dry-run to skip deletes and print up to dry_run_sample_size
 candidate keys (default 1000). Recommended for first-time deployment
 confidence and for debugging suspected mark-phase bugs.
@@ -5630,6 +5635,7 @@ dfsctl store block gc <share> [flags]
 dfsctl store block gc myshare
 dfsctl store block gc myshare --dry-run
 dfsctl store block gc myshare --reconcile
+dfsctl store block gc myshare --no-wait
 dfsctl store block gc myshare -o json
 ```
 
@@ -5637,6 +5643,7 @@ Flags:
 
 ```
       --dry-run     Run mark + sweep enumeration but skip deletes; print candidate keys
+      --no-wait     Start the job and print its id without waiting for completion
       --reconcile   Also reap stranded file_blocks rows leaked by older versions (server-wide), then sweep both tiers
 ```
 

--- a/internal/controlplane/api/handlers/block_gc.go
+++ b/internal/controlplane/api/handlers/block_gc.go
@@ -1,18 +1,19 @@
 package handlers
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
 )
 
@@ -22,13 +23,17 @@ import (
 // records calls and returns canned responses, mirroring the
 // testBlockStoreHandler pattern in blockstore_test.go.
 type BlockGCRuntime interface {
-	// RunBlockGCForShare dispatches a GC run scoped to the named share's
-	// gc-state directory for last-run.json persistence.
-	RunBlockGCForShare(ctx context.Context, shareName string, dryRun bool) (*engine.GCStats, error)
+	// StartBlockGC launches (or returns the already-running) async GC job. When
+	// reconcile is true the run reaps stranded file_blocks rows across all
+	// shares before sweeping both tiers; otherwise it runs the share-scoped
+	// sweep. The run executes on a context detached from the request, so a
+	// request/client timeout cannot abort the (potentially multi-minute) mark
+	// phase (#1433).
+	StartBlockGC(shareName string, dryRun, reconcile bool) (*runtime.GCJob, error)
 
-	// RunBlockGCReconcile reaps stranded file_blocks rows (leaked by the
-	// pre-fix delete path) across all shares, then runs the two-tier sweep.
-	RunBlockGCReconcile(ctx context.Context, dryRun bool) (*engine.GCStats, error)
+	// GetGCJobStatus returns a GC job by ID, or false if unknown (never started
+	// or evicted from the retained-terminal window).
+	GetGCJobStatus(jobID string) (*runtime.GCJob, bool)
 
 	// GCStateDirForShare returns the per-share gc-state directory the GC
 	// engine writes `last-run.json` into. Empty when the share's local
@@ -61,10 +66,46 @@ type BlockStoreGCRequest struct {
 	Reconcile bool `json:"reconcile,omitempty"`
 }
 
-// BlockStoreGCResponse wraps the *engine.GCStats result for JSON output.
-// Returned by POST /api/v1/shares/{name}/blockstore/gc.
-type BlockStoreGCResponse struct {
-	Stats *engine.GCStats `json:"stats"`
+// GCJobStatusResponse is the JSON status body for an async GC job, returned by
+// both RunGC (202) and GCJobStatus (200). Mirrors runtime.GCJob's wire shape;
+// Stats is populated once the job reaches a terminal state.
+type GCJobStatusResponse struct {
+	ID             string          `json:"id"`
+	State          string          `json:"state"`
+	Share          string          `json:"share"`
+	Reconcile      bool            `json:"reconcile"`
+	DryRun         bool            `json:"dry_run"`
+	HashesMarked   int64           `json:"hashes_marked"`
+	ObjectsScanned int64           `json:"objects_scanned"`
+	ObjectsSwept   int64           `json:"objects_swept"`
+	BytesFreed     int64           `json:"bytes_freed"`
+	StartedAt      string          `json:"started_at,omitempty"`
+	FinishedAt     string          `json:"finished_at,omitempty"`
+	Stats          *engine.GCStats `json:"stats,omitempty"`
+	Error          string          `json:"error,omitempty"`
+}
+
+func gcJobToResponse(j *runtime.GCJob) GCJobStatusResponse {
+	resp := GCJobStatusResponse{
+		ID:             j.ID,
+		State:          j.State,
+		Share:          j.Share,
+		Reconcile:      j.Reconcile,
+		DryRun:         j.DryRun,
+		HashesMarked:   j.HashesMarked,
+		ObjectsScanned: j.ObjectsScanned,
+		ObjectsSwept:   j.ObjectsSwept,
+		BytesFreed:     j.BytesFreed,
+		Stats:          j.Stats,
+		Error:          j.Err,
+	}
+	if !j.StartedAt.IsZero() {
+		resp.StartedAt = j.StartedAt.UTC().Format(time.RFC3339)
+	}
+	if !j.FinishedAt.IsZero() {
+		resp.FinishedAt = j.FinishedAt.UTC().Format(time.RFC3339)
+	}
+	return resp
 }
 
 // RunGC handles POST /api/v1/shares/{name}/blockstore/gc.
@@ -101,29 +142,53 @@ func (h *BlockStoreGCHandler) RunGC(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Reconcile is server-wide (reaps stranded rows across all shares), so it
-	// ignores the per-share scoping that RunBlockGCForShare applies.
-	var stats *engine.GCStats
-	var err error
-	if req.Reconcile {
-		stats, err = h.runtime.RunBlockGCReconcile(r.Context(), req.DryRun)
-	} else {
-		stats, err = h.runtime.RunBlockGCForShare(r.Context(), name, req.DryRun)
-	}
+	// Kick off the run asynchronously and return immediately: the mark phase can
+	// take minutes on a large or snapshot-heavy deployment, far longer than the
+	// request-middleware/client timeout, so a synchronous run was aborted
+	// mid-mark with "context deadline exceeded" and never reclaimed anything
+	// (#1433). The job runs on a detached context; clients poll
+	// GET .../blockstore/gc/{job_id}. Reconcile is server-wide (reaps stranded
+	// rows across all shares) and ignores the per-share scoping internally.
+	job, err := h.runtime.StartBlockGC(name, req.DryRun, req.Reconcile)
 	if err != nil {
 		if errors.Is(err, shares.ErrShareNotFound) {
 			NotFound(w, "share not found: "+name)
 			return
 		}
-		logger.Debug("Block store GC error", "share", name, "error", err)
-		// Strip the underlying err string from the response body — it
-		// can leak filesystem paths or other internal details. Details
-		// are logged at Debug above for operator postmortems.
-		InternalServerError(w, "GC failed")
+		logger.Debug("Block store GC start error", "share", name, "error", err)
+		InternalServerError(w, "GC failed to start")
 		return
 	}
 
-	WriteJSONOK(w, BlockStoreGCResponse{Stats: stats})
+	WriteJSON(w, http.StatusAccepted, map[string]any{
+		"job_id": job.ID,
+		"status": gcJobToResponse(job),
+	})
+}
+
+// GCJobStatus handles GET /api/v1/shares/{name}/blockstore/gc/{job_id}. It
+// returns the current status of an async GC job. The {name} segment is accepted
+// for route symmetry with the start endpoint; the job id alone identifies the
+// job.
+func (h *BlockStoreGCHandler) GCJobStatus(w http.ResponseWriter, r *http.Request) {
+	if h.runtime == nil {
+		InternalServerError(w, "runtime not initialized")
+		return
+	}
+
+	jobID := chi.URLParam(r, "job_id")
+	if jobID == "" {
+		BadRequest(w, "job id required")
+		return
+	}
+
+	job, ok := h.runtime.GetGCJobStatus(jobID)
+	if !ok {
+		NotFound(w, "GC job not found")
+		return
+	}
+
+	WriteJSONOK(w, gcJobToResponse(job))
 }
 
 // GCStatus handles GET /api/v1/shares/{name}/blockstore/gc-status.

--- a/internal/controlplane/api/handlers/block_gc_test.go
+++ b/internal/controlplane/api/handlers/block_gc_test.go
@@ -16,41 +16,46 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
 )
 
 // fakeGCRuntime is a recording stand-in for handlers.BlockGCRuntime.
 // Tests assert on captured arguments and feed canned responses.
 type fakeGCRuntime struct {
-	// RunBlockGCForShare hooks
-	runStats *engine.GCStats
-	runErr   error
-	runCalls []runCall
+	// StartBlockGC hooks
+	startJob   *runtime.GCJob
+	startErr   error
+	startCalls []startCall
+
+	// GetGCJobStatus hooks
+	statusJob *runtime.GCJob
+	statusOK  bool
 
 	// GCStateDirForShare hooks
 	gcStateRoot   string
 	gcStateRootEr error
 }
 
-type runCall struct {
-	share  string
-	dryRun bool
+type startCall struct {
+	share     string
+	dryRun    bool
+	reconcile bool
 }
 
-func (f *fakeGCRuntime) RunBlockGCForShare(_ context.Context, shareName string, dryRun bool) (*engine.GCStats, error) {
-	f.runCalls = append(f.runCalls, runCall{share: shareName, dryRun: dryRun})
-	if f.runErr != nil {
-		return nil, f.runErr
+func (f *fakeGCRuntime) StartBlockGC(shareName string, dryRun, reconcile bool) (*runtime.GCJob, error) {
+	f.startCalls = append(f.startCalls, startCall{share: shareName, dryRun: dryRun, reconcile: reconcile})
+	if f.startErr != nil {
+		return nil, f.startErr
 	}
-	return f.runStats, nil
+	if f.startJob != nil {
+		return f.startJob, nil
+	}
+	return &runtime.GCJob{ID: "gc-1", State: runtime.GCStateRunning, Share: shareName, DryRun: dryRun, Reconcile: reconcile}, nil
 }
 
-func (f *fakeGCRuntime) RunBlockGCReconcile(_ context.Context, dryRun bool) (*engine.GCStats, error) {
-	f.runCalls = append(f.runCalls, runCall{share: "<reconcile>", dryRun: dryRun})
-	if f.runErr != nil {
-		return nil, f.runErr
-	}
-	return f.runStats, nil
+func (f *fakeGCRuntime) GetGCJobStatus(string) (*runtime.GCJob, bool) {
+	return f.statusJob, f.statusOK
 }
 
 func (f *fakeGCRuntime) GCStateDirForShare(_ string) (string, error) {
@@ -60,9 +65,14 @@ func (f *fakeGCRuntime) GCStateDirForShare(_ string) (string, error) {
 	return f.gcStateRoot, nil
 }
 
-// newGCRequest builds a chi-aware httptest request with the {name} URL
-// param pre-populated. Mirrors newChiRequestForBlockStore but fixed to
-// the {name} key the GC handler reads.
+// gcStartBody mirrors the 202 response shape from RunGC.
+type gcStartBody struct {
+	JobID  string              `json:"job_id"`
+	Status GCJobStatusResponse `json:"status"`
+}
+
+// newGCRequest builds a chi-aware httptest request with the {name} URL param
+// pre-populated.
 func newGCRequest(method, path, share string, body io.Reader) *http.Request {
 	req := httptest.NewRequest(method, path, body)
 	rctx := chi.NewRouteContext()
@@ -70,17 +80,20 @@ func newGCRequest(method, path, share string, body io.Reader) *http.Request {
 	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 }
 
-// TestBlockStoreHandler_RunGC_Success_NotDryRun asserts a non-dry-run
-// POST invokes RunBlockGCForShare with dryRun=false and returns the
-// captured stats as JSON.
-func TestBlockStoreHandler_RunGC_Success_NotDryRun(t *testing.T) {
-	fake := &fakeGCRuntime{
-		runStats: &engine.GCStats{
-			HashesMarked: 42,
-			ObjectsSwept: 7,
-			BytesFreed:   1024,
-		},
-	}
+// newGCJobRequest additionally pre-populates the {job_id} param.
+func newGCJobRequest(method, path, share, jobID string, body io.Reader) *http.Request {
+	req := httptest.NewRequest(method, path, body)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("name", share)
+	rctx.URLParams.Add("job_id", jobID)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+// TestBlockStoreHandler_RunGC_KicksOffJob asserts a non-dry-run POST starts an
+// async job via StartBlockGC (dryRun=false, reconcile=false) and returns 202
+// with the job id + initial status.
+func TestBlockStoreHandler_RunGC_KicksOffJob(t *testing.T) {
+	fake := &fakeGCRuntime{}
 	h := NewBlockStoreGCHandler(fake)
 
 	body, _ := json.Marshal(BlockStoreGCRequest{DryRun: false})
@@ -89,72 +102,54 @@ func TestBlockStoreHandler_RunGC_Success_NotDryRun(t *testing.T) {
 
 	h.RunGC(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("RunGC: expected 200, got %d (body=%q)", w.Code, w.Body.String())
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("RunGC: expected 202, got %d (body=%q)", w.Code, w.Body.String())
 	}
-	if len(fake.runCalls) != 1 {
-		t.Fatalf("RunGC: expected 1 RunBlockGCForShare call, got %d", len(fake.runCalls))
+	if len(fake.startCalls) != 1 {
+		t.Fatalf("RunGC: expected 1 StartBlockGC call, got %d", len(fake.startCalls))
 	}
 	// The handler must normalize the bare URL param ("myshare") to the
-	// registry's leading-slash key ("/myshare") before calling the runtime;
-	// otherwise the lookup always fails with ErrShareNotFound.
-	if fake.runCalls[0].share != "/myshare" {
-		t.Fatalf("RunGC: expected normalized share=/myshare, got %q", fake.runCalls[0].share)
+	// registry key ("/myshare") before calling the runtime.
+	if fake.startCalls[0].share != "/myshare" {
+		t.Fatalf("RunGC: expected normalized share=/myshare, got %q", fake.startCalls[0].share)
 	}
-	if fake.runCalls[0].dryRun {
-		t.Fatal("RunGC: expected dryRun=false")
+	if fake.startCalls[0].dryRun || fake.startCalls[0].reconcile {
+		t.Fatalf("RunGC: expected dryRun=false reconcile=false, got %+v", fake.startCalls[0])
 	}
 
-	var resp BlockStoreGCResponse
+	var resp gcStartBody
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("RunGC: decode response: %v", err)
 	}
-	if resp.Stats == nil || resp.Stats.HashesMarked != 42 || resp.Stats.ObjectsSwept != 7 || resp.Stats.BytesFreed != 1024 {
-		t.Fatalf("RunGC: unexpected stats: %+v", resp.Stats)
+	if resp.JobID == "" || resp.Status.State != runtime.GCStateRunning {
+		t.Fatalf("RunGC: unexpected start body: %+v", resp)
 	}
 }
 
-// TestBlockStoreHandler_RunGC_DryRunPropagates asserts dry_run=true
-// reaches the runtime and DryRunCandidates round-trip in the response.
-func TestBlockStoreHandler_RunGC_DryRunPropagates(t *testing.T) {
-	fake := &fakeGCRuntime{
-		runStats: &engine.GCStats{
-			DryRun:           true,
-			HashesMarked:     100,
-			DryRunCandidates: []string{"cas/aa/bb/abcdef", "cas/aa/cc/123456"},
-		},
-	}
+// TestBlockStoreHandler_RunGC_DryRunReconcilePropagate asserts both flags reach
+// the runtime.
+func TestBlockStoreHandler_RunGC_DryRunReconcilePropagate(t *testing.T) {
+	fake := &fakeGCRuntime{}
 	h := NewBlockStoreGCHandler(fake)
 
-	body, _ := json.Marshal(BlockStoreGCRequest{DryRun: true})
+	body, _ := json.Marshal(BlockStoreGCRequest{DryRun: true, Reconcile: true})
 	req := newGCRequest(http.MethodPost, "/api/v1/shares/myshare/blockstore/gc", "myshare", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 
 	h.RunGC(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("RunGC: expected 200, got %d", w.Code)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("RunGC: expected 202, got %d", w.Code)
 	}
-	if len(fake.runCalls) != 1 || !fake.runCalls[0].dryRun {
-		t.Fatalf("RunGC: expected single call with dryRun=true; got %+v", fake.runCalls)
-	}
-
-	var resp BlockStoreGCResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("RunGC: decode response: %v", err)
-	}
-	if !resp.Stats.DryRun {
-		t.Fatal("RunGC: expected DryRun=true in response")
-	}
-	if len(resp.Stats.DryRunCandidates) != 2 {
-		t.Fatalf("RunGC: expected 2 DryRunCandidates, got %d", len(resp.Stats.DryRunCandidates))
+	if len(fake.startCalls) != 1 || !fake.startCalls[0].dryRun || !fake.startCalls[0].reconcile {
+		t.Fatalf("RunGC: expected dryRun+reconcile propagated; got %+v", fake.startCalls)
 	}
 }
 
-// TestBlockStoreHandler_RunGC_EmptyBody treats a missing body as the
-// zero value (DryRun=false). Operators commonly POST without a body.
+// TestBlockStoreHandler_RunGC_EmptyBody treats a missing body as the zero value
+// (DryRun=false).
 func TestBlockStoreHandler_RunGC_EmptyBody(t *testing.T) {
-	fake := &fakeGCRuntime{runStats: &engine.GCStats{}}
+	fake := &fakeGCRuntime{}
 	h := NewBlockStoreGCHandler(fake)
 
 	req := newGCRequest(http.MethodPost, "/api/v1/shares/myshare/blockstore/gc", "myshare", nil)
@@ -162,18 +157,18 @@ func TestBlockStoreHandler_RunGC_EmptyBody(t *testing.T) {
 
 	h.RunGC(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("RunGC: expected 200, got %d", w.Code)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("RunGC: expected 202, got %d", w.Code)
 	}
-	if len(fake.runCalls) != 1 || fake.runCalls[0].dryRun {
-		t.Fatalf("RunGC: expected single call with dryRun=false; got %+v", fake.runCalls)
+	if len(fake.startCalls) != 1 || fake.startCalls[0].dryRun {
+		t.Fatalf("RunGC: expected single call with dryRun=false; got %+v", fake.startCalls)
 	}
 }
 
-// TestBlockStoreHandler_RunGC_MalformedBody returns 400 on bad JSON,
-// matching evict's behavior — the request never reaches RunBlockGCForShare.
+// TestBlockStoreHandler_RunGC_MalformedBody returns 400 on bad JSON — the
+// request never reaches StartBlockGC.
 func TestBlockStoreHandler_RunGC_MalformedBody(t *testing.T) {
-	fake := &fakeGCRuntime{runStats: &engine.GCStats{}}
+	fake := &fakeGCRuntime{}
 	h := NewBlockStoreGCHandler(fake)
 
 	req := newGCRequest(http.MethodPost, "/api/v1/shares/myshare/blockstore/gc", "myshare", bytes.NewReader([]byte("{not-json")))
@@ -184,18 +179,15 @@ func TestBlockStoreHandler_RunGC_MalformedBody(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("RunGC: expected 400 on malformed body, got %d (body=%q)", w.Code, w.Body.String())
 	}
-	if len(fake.runCalls) != 0 {
-		t.Fatalf("RunGC: runtime must not be invoked on bad input; got %d calls", len(fake.runCalls))
+	if len(fake.startCalls) != 0 {
+		t.Fatalf("RunGC: runtime must not be invoked on bad input; got %d calls", len(fake.startCalls))
 	}
 }
 
-// TestBlockStoreHandler_RunGC_ShareNotFound returns 404 when the share
-// is unknown. Mirrors models.ErrShareNotFound mapping in MapStoreError
-// but goes through shares.ErrShareNotFound for runtime-layer errors.
+// TestBlockStoreHandler_RunGC_ShareNotFound returns 404 when StartBlockGC
+// rejects an unknown share.
 func TestBlockStoreHandler_RunGC_ShareNotFound(t *testing.T) {
-	fake := &fakeGCRuntime{
-		runErr: fmt.Errorf("%w: %q", shares.ErrShareNotFound, "ghost"),
-	}
+	fake := &fakeGCRuntime{startErr: fmt.Errorf("%w: %q", shares.ErrShareNotFound, "ghost")}
 	h := NewBlockStoreGCHandler(fake)
 
 	body, _ := json.Marshal(BlockStoreGCRequest{})
@@ -209,11 +201,9 @@ func TestBlockStoreHandler_RunGC_ShareNotFound(t *testing.T) {
 	}
 }
 
-// TestBlockStoreHandler_RunGC_EmptyShareName returns 400 when {name}
-// is empty. The chi router would normally not match the empty value,
-// but the handler defends against direct invocation in tests/probes.
+// TestBlockStoreHandler_RunGC_EmptyShareName returns 400 when {name} is empty.
 func TestBlockStoreHandler_RunGC_EmptyShareName(t *testing.T) {
-	fake := &fakeGCRuntime{runStats: &engine.GCStats{}}
+	fake := &fakeGCRuntime{}
 	h := NewBlockStoreGCHandler(fake)
 
 	req := newGCRequest(http.MethodPost, "/api/v1/shares//blockstore/gc", "", nil)
@@ -226,8 +216,8 @@ func TestBlockStoreHandler_RunGC_EmptyShareName(t *testing.T) {
 	}
 }
 
-// TestBlockStoreHandler_RunGC_NilRuntime fails closed when wired with
-// a nil runtime. Defends against a misconfigured server boot path.
+// TestBlockStoreHandler_RunGC_NilRuntime fails closed when wired with a nil
+// runtime.
 func TestBlockStoreHandler_RunGC_NilRuntime(t *testing.T) {
 	h := NewBlockStoreGCHandler(nil)
 
@@ -241,12 +231,74 @@ func TestBlockStoreHandler_RunGC_NilRuntime(t *testing.T) {
 	}
 }
 
-// TestBlockStoreHandler_GCStatus_Success reads a valid last-run.json
-// from the share's gc-state directory and round-trips the parsed
-// GCRunSummary as JSON.
+// TestBlockStoreHandler_RunGC_NormalizesShareName guards that the bare chi URL
+// param is normalized to the registry key before reaching the runtime.
+func TestBlockStoreHandler_RunGC_NormalizesShareName(t *testing.T) {
+	for _, urlParam := range []string{"myshare", "/myshare"} {
+		fake := &fakeGCRuntime{}
+		h := NewBlockStoreGCHandler(fake)
+
+		req := newGCRequest(http.MethodPost, "/api/v1/shares/myshare/blockstore/gc", urlParam, nil)
+		w := httptest.NewRecorder()
+		h.RunGC(w, req)
+
+		if w.Code != http.StatusAccepted {
+			t.Fatalf("RunGC(%q): expected 202, got %d", urlParam, w.Code)
+		}
+		if len(fake.startCalls) != 1 || fake.startCalls[0].share != "/myshare" {
+			t.Fatalf("RunGC(%q): expected runtime called with /myshare, got %+v", urlParam, fake.startCalls)
+		}
+	}
+}
+
+// TestBlockStoreHandler_GCJobStatus_Success returns the job for a known id.
+func TestBlockStoreHandler_GCJobStatus_Success(t *testing.T) {
+	fake := &fakeGCRuntime{
+		statusOK: true,
+		statusJob: &runtime.GCJob{
+			ID: "gc-7", State: runtime.GCStateDone, Share: "/myshare",
+			ObjectsSwept: 3, BytesFreed: 2048,
+			Stats: &engine.GCStats{RunID: "r-7", ObjectsSwept: 3, BytesFreed: 2048},
+		},
+	}
+	h := NewBlockStoreGCHandler(fake)
+
+	req := newGCJobRequest(http.MethodGet, "/api/v1/shares/myshare/blockstore/gc/gc-7", "myshare", "gc-7", nil)
+	w := httptest.NewRecorder()
+
+	h.GCJobStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GCJobStatus: expected 200, got %d (body=%q)", w.Code, w.Body.String())
+	}
+	var got GCJobStatusResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("GCJobStatus: decode: %v", err)
+	}
+	if got.ID != "gc-7" || got.State != runtime.GCStateDone || got.ObjectsSwept != 3 || got.Stats == nil {
+		t.Fatalf("GCJobStatus: unexpected body: %+v", got)
+	}
+}
+
+// TestBlockStoreHandler_GCJobStatus_NotFound returns 404 for an unknown id.
+func TestBlockStoreHandler_GCJobStatus_NotFound(t *testing.T) {
+	fake := &fakeGCRuntime{statusOK: false}
+	h := NewBlockStoreGCHandler(fake)
+
+	req := newGCJobRequest(http.MethodGet, "/api/v1/shares/myshare/blockstore/gc/nope", "myshare", "nope", nil)
+	w := httptest.NewRecorder()
+
+	h.GCJobStatus(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("GCJobStatus: expected 404, got %d", w.Code)
+	}
+}
+
+// TestBlockStoreHandler_GCStatus_Success reads a valid last-run.json from the
+// share's gc-state directory and round-trips the parsed GCRunSummary as JSON.
 func TestBlockStoreHandler_GCStatus_Success(t *testing.T) {
 	root := t.TempDir()
-	// Pre-seed last-run.json so the handler can read it.
 	summary := engine.GCRunSummary{
 		RunID:        "test-run-1",
 		StartedAt:    time.Now().UTC().Truncate(time.Second),
@@ -281,8 +333,8 @@ func TestBlockStoreHandler_GCStatus_Success(t *testing.T) {
 	}
 }
 
-// TestBlockStoreHandler_GCStatus_NoRunYet returns 404 when the
-// last-run.json file does not exist (the share has never run GC).
+// TestBlockStoreHandler_GCStatus_NoRunYet returns 404 when last-run.json does
+// not exist (the share has never run GC).
 func TestBlockStoreHandler_GCStatus_NoRunYet(t *testing.T) {
 	root := t.TempDir() // empty: no last-run.json
 
@@ -299,8 +351,8 @@ func TestBlockStoreHandler_GCStatus_NoRunYet(t *testing.T) {
 	}
 }
 
-// TestBlockStoreHandler_GCStatus_EmptyRoot returns 404 when the share's
-// local store has no persistent root (in-memory backend).
+// TestBlockStoreHandler_GCStatus_EmptyRoot returns 404 when the share's local
+// store has no persistent root (in-memory backend).
 func TestBlockStoreHandler_GCStatus_EmptyRoot(t *testing.T) {
 	fake := &fakeGCRuntime{gcStateRoot: ""}
 	h := NewBlockStoreGCHandler(fake)
@@ -315,8 +367,8 @@ func TestBlockStoreHandler_GCStatus_EmptyRoot(t *testing.T) {
 	}
 }
 
-// TestBlockStoreHandler_GCStatus_ShareNotFound returns 404 when the
-// share is unknown (GCStateDirForShare wraps shares.ErrShareNotFound).
+// TestBlockStoreHandler_GCStatus_ShareNotFound returns 404 when the share is
+// unknown (GCStateDirForShare wraps shares.ErrShareNotFound).
 func TestBlockStoreHandler_GCStatus_ShareNotFound(t *testing.T) {
 	fake := &fakeGCRuntime{
 		gcStateRootEr: fmt.Errorf("%w: %q", shares.ErrShareNotFound, "ghost"),
@@ -333,8 +385,8 @@ func TestBlockStoreHandler_GCStatus_ShareNotFound(t *testing.T) {
 	}
 }
 
-// TestBlockStoreHandler_GCStatus_MalformedFile returns 500 when
-// last-run.json exists but cannot be parsed (corrupt or truncated).
+// TestBlockStoreHandler_GCStatus_MalformedFile returns 500 when last-run.json
+// exists but cannot be parsed.
 func TestBlockStoreHandler_GCStatus_MalformedFile(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "last-run.json"), []byte("{not-json"), 0o644); err != nil {
@@ -354,8 +406,8 @@ func TestBlockStoreHandler_GCStatus_MalformedFile(t *testing.T) {
 	}
 }
 
-// TestBlockStoreHandler_GCStatus_NilRuntime fails closed when wired
-// with a nil runtime.
+// TestBlockStoreHandler_GCStatus_NilRuntime fails closed when wired with a nil
+// runtime.
 func TestBlockStoreHandler_GCStatus_NilRuntime(t *testing.T) {
 	h := NewBlockStoreGCHandler(nil)
 
@@ -366,28 +418,5 @@ func TestBlockStoreHandler_GCStatus_NilRuntime(t *testing.T) {
 
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("GCStatus: expected 500 on nil runtime, got %d", w.Code)
-	}
-}
-
-// TestBlockStoreHandler_RunGC_NormalizesShareName is the regression guard for
-// the missing-normalizeShareName bug: the bare chi URL param ("myshare") must
-// be normalized to the registry key ("/myshare") before reaching the runtime,
-// otherwise every real share resolves to ErrShareNotFound. Verifies for both a
-// bare name and an already-slashed name.
-func TestBlockStoreHandler_RunGC_NormalizesShareName(t *testing.T) {
-	for _, urlParam := range []string{"myshare", "/myshare"} {
-		fake := &fakeGCRuntime{runStats: &engine.GCStats{}}
-		h := NewBlockStoreGCHandler(fake)
-
-		req := newGCRequest(http.MethodPost, "/api/v1/shares/myshare/blockstore/gc", urlParam, nil)
-		w := httptest.NewRecorder()
-		h.RunGC(w, req)
-
-		if w.Code != http.StatusOK {
-			t.Fatalf("RunGC(%q): expected 200, got %d", urlParam, w.Code)
-		}
-		if len(fake.runCalls) != 1 || fake.runCalls[0].share != "/myshare" {
-			t.Fatalf("RunGC(%q): expected runtime called with /myshare, got %+v", urlParam, fake.runCalls)
-		}
 	}
 }

--- a/pkg/apiclient/blockstore.go
+++ b/pkg/apiclient/blockstore.go
@@ -108,9 +108,9 @@ func (c *Client) GetShareWarm(name, jobID string) (*WarmJobStatus, error) {
 // BlockStoreGCOptions is the request body for
 // POST /api/v1/shares/{name}/blockstore/gc. DryRun maps to
 // engine.Options.DryRun: mark + sweep enumeration runs but no DELETEs
-// are issued; candidate keys are returned in
-// BlockStoreGCResult.Stats.DryRunCandidates (capped at the engine
-// dry-run sample size, default 1000).
+// are issued; candidate keys are returned in the job's
+// GCJobStatus.Stats.DryRunCandidates (capped at the engine dry-run
+// sample size, default 1000).
 type BlockStoreGCOptions struct {
 	DryRun bool `json:"dry_run,omitempty"`
 	// Reconcile runs the migration pass: reap stranded file_blocks rows
@@ -119,35 +119,67 @@ type BlockStoreGCOptions struct {
 	Reconcile bool `json:"reconcile,omitempty"`
 }
 
-// BlockStoreGCResult is the response body for
-// POST /api/v1/shares/{name}/blockstore/gc. Stats wraps the *engine.GCStats
-// summed across every distinct remote scanned during the run
-// (cross-share aggregation). Mirrors the server-side
-// handlers.BlockStoreGCResponse shape.
-type BlockStoreGCResult struct {
-	Stats *engine.GCStats `json:"stats"`
+// GCJobStatus is the wire-shape for an async block-store GC job, returned by
+// GetBlockStoreGCJob and embedded in StartBlockStoreGC's response. Stats is
+// populated once State is terminal ("done"/"failed"); the live counters track
+// the in-flight run.
+type GCJobStatus struct {
+	ID             string          `json:"id"`
+	State          string          `json:"state"`
+	Share          string          `json:"share"`
+	Reconcile      bool            `json:"reconcile"`
+	DryRun         bool            `json:"dry_run"`
+	HashesMarked   int64           `json:"hashes_marked"`
+	ObjectsScanned int64           `json:"objects_scanned"`
+	ObjectsSwept   int64           `json:"objects_swept"`
+	BytesFreed     int64           `json:"bytes_freed"`
+	StartedAt      string          `json:"started_at,omitempty"`
+	FinishedAt     string          `json:"finished_at,omitempty"`
+	Stats          *engine.GCStats `json:"stats,omitempty"`
+	Error          string          `json:"error,omitempty"`
 }
 
-// BlockStoreGC triggers an on-demand GC run for the named share. The
-// run scans every share whose remote-store config matches the named
-// share's remote, but `last-run.json` is persisted under the
-// named share's gc-state directory. opts may be nil (treated as a
-// non-dry-run request).
+// gcStartResponse is the 202 body from POST .../blockstore/gc.
+type gcStartResponse struct {
+	JobID  string      `json:"job_id"`
+	Status GCJobStatus `json:"status"`
+}
+
+// StartBlockStoreGC kicks off (or returns the already-running) async GC run for
+// the named share and returns the job id to poll via GetBlockStoreGCJob. The
+// run scans every share whose remote-store config matches the named share's
+// remote, but `last-run.json` is persisted under the named share's gc-state
+// directory. The server runs it on a detached context, so this call returns
+// immediately rather than blocking for the (possibly multi-minute) run (#1433).
+// opts may be nil (treated as a non-dry-run request).
 //
-// Note: the route is mounted at /api/v1/shares/{name}/blockstore/gc
-// (not /api/v1/store/block/{name}/gc as initially scoped) because the
-// /store/block/{kind} sub-router would shadow a {name} segment at the
-// same level — chi v5 cannot disambiguate two differently-named wildcards
-// on the same path segment. The per-share /shares/{name}/blockstore/...
-// pattern matches the existing stats and evict endpoints.
-func (c *Client) BlockStoreGC(shareName string, opts *BlockStoreGCOptions) (*BlockStoreGCResult, error) {
+// Note: the route is mounted at /api/v1/shares/{name}/blockstore/gc because the
+// /store/block/{kind} sub-router would shadow a {name} segment at the same
+// level — chi v5 cannot disambiguate two differently-named wildcards on one path
+// segment. The per-share /shares/{name}/blockstore/... pattern matches the
+// existing stats and evict endpoints.
+func (c *Client) StartBlockStoreGC(shareName string, opts *BlockStoreGCOptions) (string, error) {
 	if opts == nil {
 		opts = &BlockStoreGCOptions{}
 	}
-	return createResource[BlockStoreGCResult](
+	resp, err := createResource[gcStartResponse](
 		c,
 		fmt.Sprintf("/api/v1/shares/%s/blockstore/gc", url.PathEscape(normalizeShareNameForAPI(shareName))),
 		opts,
+	)
+	if err != nil {
+		return "", err
+	}
+	return resp.JobID, nil
+}
+
+// GetBlockStoreGCJob returns the current status of GC job jobID for the named
+// share.
+func (c *Client) GetBlockStoreGCJob(shareName, jobID string) (*GCJobStatus, error) {
+	return getResource[GCJobStatus](
+		c,
+		fmt.Sprintf("/api/v1/shares/%s/blockstore/gc/%s",
+			url.PathEscape(normalizeShareNameForAPI(shareName)), url.PathEscape(jobID)),
 	)
 }
 

--- a/pkg/apiclient/blockstore_gc_test.go
+++ b/pkg/apiclient/blockstore_gc_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/marmos91/dittofs/pkg/block/engine"
 )
 
-// TestBlockStoreGC_RoundTrip verifies the dfsctl-bound BlockStoreGC
-// method posts to the per-share GC endpoint with the dry_run body and
-// decodes the BlockStoreGCResult correctly.
-func TestBlockStoreGC_RoundTrip(t *testing.T) {
+// TestStartBlockStoreGC_RoundTrip verifies the kick-off call posts to the
+// per-share GC endpoint with the dry_run body and returns the job id from the
+// 202 response.
+func TestStartBlockStoreGC_RoundTrip(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/api/v1/shares/myshare/blockstore/gc", r.URL.Path)
@@ -28,9 +28,58 @@ func TestBlockStoreGC_RoundTrip(t *testing.T) {
 		var got BlockStoreGCOptions
 		require.NoError(t, json.Unmarshal(body, &got))
 		assert.True(t, got.DryRun, "dry_run flag must propagate")
+		assert.True(t, got.Reconcile, "reconcile flag must propagate")
+
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(gcStartResponse{
+			JobID:  "gc-9",
+			Status: GCJobStatus{ID: "gc-9", State: "running"},
+		})
+	}))
+	defer server.Close()
+
+	client := New(server.URL).WithToken("test-token")
+	jobID, err := client.StartBlockStoreGC("myshare", &BlockStoreGCOptions{DryRun: true, Reconcile: true})
+	require.NoError(t, err)
+	assert.Equal(t, "gc-9", jobID)
+}
+
+// TestStartBlockStoreGC_NilOpts verifies that passing nil opts maps to a
+// dry_run=false body — matching the documented "nil = non-dry-run" contract.
+func TestStartBlockStoreGC_NilOpts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		var got BlockStoreGCOptions
+		require.NoError(t, json.Unmarshal(body, &got))
+		assert.False(t, got.DryRun, "nil opts must produce dry_run=false")
+		assert.False(t, got.Reconcile)
+
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(gcStartResponse{JobID: "gc-1", Status: GCJobStatus{ID: "gc-1", State: "running"}})
+	}))
+	defer server.Close()
+
+	client := New(server.URL).WithToken("test-token")
+	_, err := client.StartBlockStoreGC("myshare", nil)
+	require.NoError(t, err)
+}
+
+// TestGetBlockStoreGCJob_RoundTrip verifies the poll call GETs the job endpoint
+// and decodes the terminal status (including the embedded final stats).
+func TestGetBlockStoreGCJob_RoundTrip(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/shares/myshare/blockstore/gc/gc-9", r.URL.Path)
 
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(BlockStoreGCResult{
+		_ = json.NewEncoder(w).Encode(GCJobStatus{
+			ID:           "gc-9",
+			State:        "done",
+			HashesMarked: 12,
+			ObjectsSwept: 3,
+			BytesFreed:   4096,
 			Stats: &engine.GCStats{
 				HashesMarked:     12,
 				ObjectsSwept:     3,
@@ -43,36 +92,13 @@ func TestBlockStoreGC_RoundTrip(t *testing.T) {
 	defer server.Close()
 
 	client := New(server.URL).WithToken("test-token")
-	res, err := client.BlockStoreGC("myshare", &BlockStoreGCOptions{DryRun: true})
+	got, err := client.GetBlockStoreGCJob("myshare", "gc-9")
 	require.NoError(t, err)
-	require.NotNil(t, res)
-	require.NotNil(t, res.Stats)
-	assert.Equal(t, int64(12), res.Stats.HashesMarked)
-	assert.Equal(t, int64(3), res.Stats.ObjectsSwept)
-	assert.True(t, res.Stats.DryRun)
-	assert.Equal(t, []string{"cas/aa/bb/abc"}, res.Stats.DryRunCandidates)
-}
-
-// TestBlockStoreGC_NilOpts verifies that passing nil opts maps to a
-// dry_run=false body — matching the documented "nil = non-dry-run"
-// contract.
-func TestBlockStoreGC_NilOpts(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-
-		var got BlockStoreGCOptions
-		require.NoError(t, json.Unmarshal(body, &got))
-		assert.False(t, got.DryRun, "nil opts must produce dry_run=false")
-
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(BlockStoreGCResult{Stats: &engine.GCStats{}})
-	}))
-	defer server.Close()
-
-	client := New(server.URL).WithToken("test-token")
-	_, err := client.BlockStoreGC("myshare", nil)
-	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "done", got.State)
+	assert.Equal(t, int64(3), got.ObjectsSwept)
+	require.NotNil(t, got.Stats)
+	assert.Equal(t, []string{"cas/aa/bb/abc"}, got.Stats.DryRunCandidates)
 }
 
 // TestBlockStoreGCStatus_RoundTrip verifies the GC-status read returns

--- a/pkg/block/engine/gc.go
+++ b/pkg/block/engine/gc.go
@@ -248,7 +248,23 @@ type Options struct {
 	// leaves it false and sweeps from the index (no S3 LIST). Local-tier sweeps
 	// always Walk their own (local-disk) namespace regardless of this flag.
 	FullScan bool
+
+	// MarkProgress, when non-nil, is invoked during the mark phase with the
+	// running count of hashes marked so far — at each share boundary and every
+	// gcMarkProgressInterval hashes within a share. It gives long-running mark
+	// phases (millions of hashes on snapshot-heavy deployments) a liveness
+	// signal so an async caller can surface progress instead of a silent stall
+	// (#1433). Invoked synchronously from the (sequential) mark loop, so it must
+	// not block; implementations just record the latest count.
+	MarkProgress func(hashesMarked int64)
 }
+
+// gcMarkProgressInterval bounds how often the mark phase emits a progress
+// callback + INFO log line: once per this many hashes within a share. Large
+// enough that the logging/callback overhead is negligible against the Badger
+// live-set writes, small enough that a multi-minute mark phase still shows
+// movement.
+const gcMarkProgressInterval = 100_000
 
 // SyncedHashIndex is the narrow slice of the synced-hash marker store the GC
 // sweep depends on: enumerate the synced set (the LIST-free orphan-candidate
@@ -415,7 +431,7 @@ func collectGarbage(
 
 	// MARK: stream every FileChunk's ContentHash into gcs across every share
 	// the reconciler reports. Mark fail-closed.
-	if err := markPhase(ctx, reconciler, gcs, stats, options.HoldProvider, options.RemoteEndpointID, options.Shares); err != nil {
+	if err := markPhase(ctx, reconciler, gcs, stats, options.HoldProvider, options.RemoteEndpointID, options.Shares, options.MarkProgress); err != nil {
 		recordGCError(stats, "mark: "+err.Error())
 		slog.Error("GC: mark failed — aborting sweep (fail-closed)",
 			"run_id", runID, "err", err,
@@ -471,10 +487,20 @@ func collectGarbage(
 // live-data-deleted. Callers that genuinely have no shares must
 // short-circuit at a higher level (Runtime.RunBlockGC already does so
 // when DistinctRemoteStores returns an empty slice).
-func markPhase(ctx context.Context, reconciler MetadataReconciler, gcs *GCState, stats *GCStats, hold HoldProvider, remoteEndpointID string, shares []string) error {
+func markPhase(ctx context.Context, reconciler MetadataReconciler, gcs *GCState, stats *GCStats, hold HoldProvider, remoteEndpointID string, shares []string, markProgress func(int64)) error {
 	reconcilerShares := sharesForReconciler(reconciler)
 	if len(reconcilerShares) == 0 {
 		return fmt.Errorf("mark phase: reconciler reports zero shares — refusing to sweep CAS objects without a live set (fail-closed)")
+	}
+
+	// nextProgressAt is the HashesMarked threshold for the next progress
+	// callback + log line. Emitting every gcMarkProgressInterval hashes keeps a
+	// multi-minute mark phase visibly alive without per-hash overhead.
+	nextProgressAt := int64(gcMarkProgressInterval)
+	emitProgress := func() {
+		if markProgress != nil {
+			markProgress(stats.HashesMarked)
+		}
 	}
 
 	addHash := func(h block.ContentHash) error {
@@ -486,6 +512,11 @@ func markPhase(ctx context.Context, reconciler MetadataReconciler, gcs *GCState,
 			return fmt.Errorf("gcstate add: %w", err)
 		}
 		stats.HashesMarked++
+		if stats.HashesMarked >= nextProgressAt {
+			nextProgressAt += gcMarkProgressInterval
+			emitProgress()
+			slog.Info("GC: mark progress", "hashes_marked", stats.HashesMarked, "remote_endpoint_id", remoteEndpointID)
+		}
 		return nil
 	}
 
@@ -497,15 +528,23 @@ func markPhase(ctx context.Context, reconciler MetadataReconciler, gcs *GCState,
 		if err != nil {
 			return fmt.Errorf("get metadata store for share %q: %w", shareName, err)
 		}
+		before := stats.HashesMarked
 		if err := store.EnumerateFileChunks(ctx, addHash); err != nil {
 			return fmt.Errorf("enumerate share %q: %w", shareName, err)
 		}
+		slog.Info("GC: mark phase share enumerated",
+			"share", shareName,
+			"hashes_this_share", stats.HashesMarked-before,
+			"hashes_marked", stats.HashesMarked,
+			"remote_endpoint_id", remoteEndpointID)
+		emitProgress()
 	}
 
 	if hold != nil {
 		if err := hold.HeldHashes(ctx, remoteEndpointID, shares, addHash); err != nil {
 			return fmt.Errorf("hold provider: %w", err)
 		}
+		emitProgress()
 	}
 
 	// flush the batched Add()s so the sweep's Has() queries observe every

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -298,6 +298,7 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 				// /store/block/{kind} wildcard collision (chi cannot disambiguate
 				// {kind} vs {name} at the same segment).
 				r.Post("/{name}/blockstore/gc", blockGCHandler.RunGC)
+				r.Get("/{name}/blockstore/gc/{job_id}", blockGCHandler.GCJobStatus)
 				r.Get("/{name}/blockstore/gc-status", blockGCHandler.GCStatus)
 				// Per-share refcount reconciliation audit. Mirrors GC
 				// endpoint shape (per-share path, JWT auth via the

--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -47,7 +47,23 @@ func gcResult(total *engine.GCStats) string {
 // fatal error.
 func (r *Runtime) RunBlockGC(ctx context.Context, sharePrefix string, dryRun bool) (*engine.GCStats, error) {
 	// Steady-state GC: index-based remote sweep (synced − live), no S3 LIST.
-	return r.runBlockGCSweep(ctx, sharePrefix, dryRun, false)
+	return r.runBlockGCSweep(ctx, sharePrefix, dryRun, false, nil)
+}
+
+// applyGCProgress wires an optional progress sink into engine.Options so a
+// long-running run (mark phase on a snapshot-heavy deployment) reports liveness
+// to an async caller. The mark phase reports the running hash count;
+// ProgressCallback reports post-sweep totals. Both are best-effort liveness —
+// the authoritative result is the returned (accumulated) GCStats. No-op when
+// progress is nil (the scheduler / synchronous callers).
+func applyGCProgress(opts *engine.Options, progress func(engine.GCStats)) {
+	if progress == nil {
+		return
+	}
+	opts.MarkProgress = func(hashesMarked int64) {
+		progress(engine.GCStats{HashesMarked: hashesMarked})
+	}
+	opts.ProgressCallback = progress
 }
 
 // runBlockGCSweep is the shared remote+local GC pass. fullScan selects the
@@ -56,7 +72,7 @@ func (r *Runtime) RunBlockGC(ctx context.Context, sharePrefix string, dryRun boo
 // does not know about) instead of the steady-state index sweep (synced − live,
 // no S3 LIST). Both paths clear synced markers on delete, preserving the
 // synced ⊆ remote invariant (#1433).
-func (r *Runtime) runBlockGCSweep(ctx context.Context, sharePrefix string, dryRun, fullScan bool) (*engine.GCStats, error) {
+func (r *Runtime) runBlockGCSweep(ctx context.Context, sharePrefix string, dryRun, fullScan bool, progress func(engine.GCStats)) (*engine.GCStats, error) {
 	if sharePrefix != "" {
 		logger.Warn("RunBlockGC: sharePrefix is no longer honored — mark-sweep uses a global live set across every cas/XX prefix",
 			"ignored_sharePrefix", sharePrefix)
@@ -92,6 +108,7 @@ func (r *Runtime) runBlockGCSweep(ctx context.Context, sharePrefix string, dryRu
 			Shares:           append([]string(nil), entry.Shares...),
 		}
 		applyGCDefaults(opts, gcDefaults)
+		applyGCProgress(opts, progress)
 		// Inject held hashes from ready snapshots into the GC mark phase.
 		opts.HoldProvider = r.snapshotHoldForRemote(entry.Shares)
 		// The per-remote synced-hash index: the index-sweep candidate source AND
@@ -127,7 +144,7 @@ func (r *Runtime) runBlockGCSweep(ctx context.Context, sharePrefix string, dryRu
 	}
 	// Sweep the local tier too, so one `gc` invocation reclaims orphaned
 	// chunks on both remote and local stores (#1433).
-	r.runLocalGC(ctx, "", dryRun, total)
+	r.runLocalGC(ctx, "", dryRun, total, progress)
 	return total, nil
 }
 
@@ -148,7 +165,7 @@ var collectGarbageLocalFn = engine.CollectGarbageLocal
 // (#1433).
 func (r *Runtime) RunBlockGCLocal(ctx context.Context, dryRun bool) (*engine.GCStats, error) {
 	total := &engine.GCStats{}
-	r.runLocalGC(ctx, "", dryRun, total)
+	r.runLocalGC(ctx, "", dryRun, total, nil)
 	return total, nil
 }
 
@@ -158,7 +175,7 @@ func (r *Runtime) RunBlockGCLocal(ctx context.Context, dryRun bool) (*engine.GCS
 // backend (empty gc-state root) are skipped. Shared by RunBlockGC,
 // RunBlockGCForShare, and RunBlockGCLocal so a single `gc` invocation reclaims
 // orphans on BOTH tiers (#1433).
-func (r *Runtime) runLocalGC(ctx context.Context, shareFilter string, dryRun bool, total *engine.GCStats) {
+func (r *Runtime) runLocalGC(ctx context.Context, shareFilter string, dryRun bool, total *engine.GCStats, progress func(engine.GCStats)) {
 	gcDefaults := r.gcDefaultsSnapshot()
 	for _, entry := range r.sharesSvc.ShareLocalStores() {
 		if shareFilter != "" && entry.ShareName != shareFilter {
@@ -175,6 +192,7 @@ func (r *Runtime) runLocalGC(ctx context.Context, shareFilter string, dryRun boo
 			Shares:      []string{entry.ShareName},
 		}
 		applyGCDefaults(opts, gcDefaults)
+		applyGCProgress(opts, progress)
 		opts.HoldProvider = r.snapshotHoldForShare(entry.ShareName)
 		logger.Info("local GC: starting",
 			"tier", "local",
@@ -239,6 +257,13 @@ func (p *perRemoteReconciler) GetMetadataStoreForShare(shareName string) (metada
 //
 // Returns an ErrShareNotFound-wrapped error if name is unknown.
 func (r *Runtime) RunBlockGCForShare(ctx context.Context, name string, dryRun bool) (*engine.GCStats, error) {
+	return r.runBlockGCForShare(ctx, name, dryRun, nil)
+}
+
+// runBlockGCForShare is RunBlockGCForShare with an optional progress sink wired
+// into the engine for async callers (StartBlockGC). progress is nil for the
+// synchronous public entrypoint.
+func (r *Runtime) runBlockGCForShare(ctx context.Context, name string, dryRun bool, progress func(engine.GCStats)) (*engine.GCStats, error) {
 	gcRoot, err := r.sharesSvc.GetGCStateDirForShare(name)
 	if err != nil {
 		return nil, err
@@ -268,6 +293,7 @@ func (r *Runtime) RunBlockGCForShare(ctx context.Context, name string, dryRun bo
 			Shares:           append([]string(nil), entry.Shares...),
 		}
 		applyGCDefaults(opts, gcDefaults)
+		applyGCProgress(opts, progress)
 		// Inject held hashes from ready snapshots into the GC mark phase.
 		opts.HoldProvider = r.snapshotHoldForRemote(entry.Shares)
 		// Per-remote synced-hash index: LIST-free candidate source + marker-clear
@@ -300,7 +326,7 @@ func (r *Runtime) RunBlockGCForShare(ctx context.Context, name string, dryRun bo
 		)
 	}
 	// Sweep this share's local tier too (#1433).
-	r.runLocalGC(ctx, name, dryRun, total)
+	r.runLocalGC(ctx, name, dryRun, total, progress)
 	return total, nil
 }
 

--- a/pkg/controlplane/runtime/blockgc_job.go
+++ b/pkg/controlplane/runtime/blockgc_job.go
@@ -1,0 +1,239 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+)
+
+// Block-GC job states.
+const (
+	GCStateRunning = "running"
+	GCStateDone    = "done"
+	GCStateFailed  = "failed"
+)
+
+// maxRetainedGCJobs bounds the number of terminal GC jobs the registry keeps so
+// a client can still poll a recently-finished run, without the jobs map growing
+// without bound on a long-running server. A running job is never evicted. GC is
+// server-wide and serializes on the engine's per-root lock, so only a handful of
+// jobs are ever in flight; a small window suffices.
+const maxRetainedGCJobs = 16
+
+// GCJob is the process-local record of an async block-store GC run. It is
+// in-memory only (jobs do not survive a restart) and every field is read/written
+// under the gcRegistry mutex. The async run executes on a context detached from
+// the triggering HTTP request, so a request/client timeout cannot abort the
+// mark phase mid-run (the synchronous endpoint's failure mode on a large or
+// snapshot-heavy deployment) (#1433).
+type GCJob struct {
+	ID        string `json:"id"`
+	State     string `json:"state"` // GCState{Running,Done,Failed}
+	Share     string `json:"share"`
+	Reconcile bool   `json:"reconcile"`
+	DryRun    bool   `json:"dry_run"`
+
+	StartedAt  time.Time `json:"started_at"`
+	FinishedAt time.Time `json:"finished_at"`
+
+	// Live progress, updated from the engine mark/sweep callbacks while the run
+	// is in flight (best-effort liveness). The authoritative final counts live
+	// in Stats once State is terminal.
+	HashesMarked   int64 `json:"hashes_marked"`
+	ObjectsScanned int64 `json:"objects_scanned"`
+	ObjectsSwept   int64 `json:"objects_swept"`
+	BytesFreed     int64 `json:"bytes_freed"`
+
+	// Stats is the final accumulated GCStats, set when the run finishes.
+	Stats *engine.GCStats `json:"stats,omitempty"`
+	Err   string          `json:"error,omitempty"`
+}
+
+// clone returns a copy safe to hand outside the registry lock.
+func (j *GCJob) clone() *GCJob {
+	cp := *j
+	if j.Stats != nil {
+		s := *j.Stats
+		cp.Stats = &s
+	}
+	return &cp
+}
+
+// gcRegistry tracks the single in-flight GC run plus a bounded window of
+// recently-finished runs for polling. GC is server-wide and the engine
+// serializes concurrent runs on a per-root lock, so the registry permits at most
+// one active job: a start request while a run is in flight returns the running
+// job rather than launching a second.
+type gcRegistry struct {
+	mu        sync.Mutex
+	jobs      map[string]*GCJob
+	activeID  string                        // "" when no run is in flight
+	cancels   map[string]context.CancelFunc // jobID -> detached-context cancel
+	counter   int64
+	completed []string // FIFO of terminal jobIDs, bounded by maxRetainedGCJobs
+}
+
+func newGCRegistry() *gcRegistry {
+	return &gcRegistry{
+		jobs:    make(map[string]*GCJob),
+		cancels: make(map[string]context.CancelFunc),
+	}
+}
+
+// retire records a terminal job and evicts the oldest retained terminal jobs
+// once the window exceeds maxRetainedGCJobs. Caller must hold r.mu.
+func (r *gcRegistry) retire(jobID string) {
+	r.completed = append(r.completed, jobID)
+	for len(r.completed) > maxRetainedGCJobs {
+		oldest := r.completed[0]
+		r.completed = r.completed[1:]
+		delete(r.jobs, oldest)
+	}
+}
+
+// start launches a GC run on a DETACHED context (derived from
+// context.Background(), not the request ctx) so the job outlives the HTTP
+// request that triggered it. If a run is already in flight, the existing job is
+// returned and run is not invoked. run receives a progress sink it must forward
+// to the engine. Returns a snapshot of the (new or already-running) job.
+func (r *gcRegistry) start(share string, dryRun, reconcile bool, run func(ctx context.Context, progress func(engine.GCStats)) (*engine.GCStats, error)) *GCJob {
+	r.mu.Lock()
+	if r.activeID != "" {
+		job := r.jobs[r.activeID].clone()
+		r.mu.Unlock()
+		return job
+	}
+
+	r.counter++
+	// Opaque, slash-free id so the {job_id} poll route is unaffected by the
+	// (slash-bearing) share name.
+	jobID := fmt.Sprintf("gc-%d", r.counter)
+	job := &GCJob{
+		ID:        jobID,
+		State:     GCStateRunning,
+		Share:     share,
+		Reconcile: reconcile,
+		DryRun:    dryRun,
+		StartedAt: time.Now(),
+	}
+	r.jobs[jobID] = job
+	r.activeID = jobID
+
+	ctx, cancel := context.WithCancel(context.Background())
+	r.cancels[jobID] = cancel
+
+	snapshot := job.clone()
+	r.mu.Unlock()
+
+	go func() {
+		progress := func(s engine.GCStats) {
+			r.mu.Lock()
+			if j, ok := r.jobs[jobID]; ok {
+				// Merge by max: the mark callback reports only HashesMarked, the
+				// sweep callback reports per-invocation totals; max keeps the
+				// display monotonic across the run's phases/invocations.
+				j.HashesMarked = max(j.HashesMarked, s.HashesMarked)
+				j.ObjectsScanned = max(j.ObjectsScanned, s.ObjectsScanned)
+				j.ObjectsSwept = max(j.ObjectsSwept, s.ObjectsSwept)
+				j.BytesFreed = max(j.BytesFreed, s.BytesFreed)
+			}
+			r.mu.Unlock()
+		}
+
+		stats, err := run(ctx, progress)
+
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		if r.activeID == jobID {
+			r.activeID = ""
+		}
+		if c, ok := r.cancels[jobID]; ok {
+			c()
+			delete(r.cancels, jobID)
+		}
+		j, ok := r.jobs[jobID]
+		if !ok {
+			return
+		}
+		j.FinishedAt = time.Now()
+		if err != nil {
+			j.State = GCStateFailed
+			j.Err = err.Error()
+		} else {
+			j.State = GCStateDone
+			j.Stats = stats
+			if stats != nil {
+				j.HashesMarked = stats.HashesMarked
+				j.ObjectsScanned = stats.ObjectsScanned
+				j.ObjectsSwept = stats.ObjectsSwept
+				j.BytesFreed = stats.BytesFreed
+			}
+		}
+		r.retire(jobID)
+		logger.Info("block GC job finished",
+			"job", jobID, "share", share, "reconcile", reconcile,
+			"state", j.State, "objects_swept", j.ObjectsSwept,
+			"bytes_freed", j.BytesFreed, "error", j.Err)
+	}()
+
+	return snapshot
+}
+
+// get returns a copy of the job by ID.
+func (r *gcRegistry) get(jobID string) (*GCJob, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	job, ok := r.jobs[jobID]
+	if !ok {
+		return nil, false
+	}
+	return job.clone(), true
+}
+
+// cancelActive cancels any in-flight GC run. Called on server shutdown so a
+// long mark/sweep does not outlive the process's stores.
+func (r *gcRegistry) cancelActive() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.activeID == "" {
+		return
+	}
+	if c, ok := r.cancels[r.activeID]; ok {
+		c()
+	}
+}
+
+// StartBlockGC launches (or returns the already-running) async block-store GC
+// job. When reconcile is true the run reaps stranded file_blocks rows across all
+// shares before sweeping both tiers; otherwise it runs the share-scoped sweep.
+// The run executes on a detached context so a request/client timeout cannot
+// abort it. Returns a snapshot of the job; poll GetGCJobStatus(job.ID) for
+// completion.
+//
+// For the share-scoped (non-reconcile) path the share is validated up front so
+// an unknown share fails fast with an ErrShareNotFound-wrapped error rather than
+// surfacing only later as a failed job. Reconcile is server-wide and skips the
+// per-share check.
+func (r *Runtime) StartBlockGC(shareName string, dryRun, reconcile bool) (*GCJob, error) {
+	if !reconcile {
+		if _, err := r.sharesSvc.GetGCStateDirForShare(shareName); err != nil {
+			return nil, err
+		}
+	}
+	return r.gcReg.start(shareName, dryRun, reconcile, func(ctx context.Context, progress func(engine.GCStats)) (*engine.GCStats, error) {
+		if reconcile {
+			return r.runBlockGCReconcile(ctx, dryRun, progress)
+		}
+		return r.runBlockGCForShare(ctx, shareName, dryRun, progress)
+	}), nil
+}
+
+// GetGCJobStatus returns a snapshot of a GC job by ID, or false if unknown
+// (never started, or evicted from the retained-terminal window).
+func (r *Runtime) GetGCJobStatus(jobID string) (*GCJob, bool) {
+	return r.gcReg.get(jobID)
+}

--- a/pkg/controlplane/runtime/blockgc_job_test.go
+++ b/pkg/controlplane/runtime/blockgc_job_test.go
@@ -1,0 +1,119 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block/engine"
+)
+
+// TestGCRegistry_SingleActiveJob asserts that while a run is in flight a second
+// start returns the SAME job rather than launching a concurrent one (GC
+// serializes server-wide), and that progress callbacks update the job.
+func TestGCRegistry_SingleActiveJob(t *testing.T) {
+	reg := newGCRegistry()
+
+	release := make(chan struct{})
+	started := make(chan struct{})
+	run := func(ctx context.Context, progress func(engine.GCStats)) (*engine.GCStats, error) {
+		close(started)
+		progress(engine.GCStats{HashesMarked: 5})
+		<-release // block so the job stays "running" for the second start
+		return &engine.GCStats{HashesMarked: 5, ObjectsSwept: 2, BytesFreed: 1024}, nil
+	}
+
+	first := reg.start("/s", false, false, run)
+	<-started
+	if first.State != GCStateRunning {
+		t.Fatalf("first job state = %q, want running", first.State)
+	}
+
+	// Second start while the first is in flight must return the same job and
+	// must NOT invoke run again.
+	second := reg.start("/s", false, false, func(context.Context, func(engine.GCStats)) (*engine.GCStats, error) {
+		t.Fatal("second start must not launch a concurrent run")
+		return nil, nil
+	})
+	if second.ID != first.ID {
+		t.Fatalf("second start returned a different job: %q vs %q", second.ID, first.ID)
+	}
+
+	close(release)
+
+	// Wait for completion by polling the registry.
+	waitFor(t, func() bool {
+		j, ok := reg.get(first.ID)
+		return ok && j.State == GCStateDone
+	})
+
+	done, _ := reg.get(first.ID)
+	if done.ObjectsSwept != 2 || done.BytesFreed != 1024 || done.Stats == nil {
+		t.Fatalf("final job not populated from stats: %+v", done)
+	}
+}
+
+// TestGCRegistry_FailedJob records the error and frees the active slot for a
+// subsequent run.
+func TestGCRegistry_FailedJob(t *testing.T) {
+	reg := newGCRegistry()
+	job := reg.start("/s", false, false, func(context.Context, func(engine.GCStats)) (*engine.GCStats, error) {
+		return nil, context.DeadlineExceeded
+	})
+	waitFor(t, func() bool {
+		j, ok := reg.get(job.ID)
+		return ok && j.State == GCStateFailed
+	})
+	j, _ := reg.get(job.ID)
+	if j.Err == "" {
+		t.Fatal("failed job must record an error")
+	}
+
+	// Active slot is freed: a new run launches with a fresh id.
+	next := reg.start("/s", false, false, func(context.Context, func(engine.GCStats)) (*engine.GCStats, error) {
+		return &engine.GCStats{}, nil
+	})
+	if next.ID == job.ID {
+		t.Fatal("a new run after completion must get a fresh job id")
+	}
+}
+
+// TestGCRegistry_RetireBound caps retained terminal jobs at maxRetainedGCJobs.
+func TestGCRegistry_RetireBound(t *testing.T) {
+	reg := newGCRegistry()
+	var ids []string
+	for i := 0; i < maxRetainedGCJobs+5; i++ {
+		job := reg.start("/s", false, false, func(context.Context, func(engine.GCStats)) (*engine.GCStats, error) {
+			return &engine.GCStats{}, nil
+		})
+		ids = append(ids, job.ID)
+		waitFor(t, func() bool {
+			j, ok := reg.get(job.ID)
+			return ok && j.State == GCStateDone
+		})
+	}
+	reg.mu.Lock()
+	retained := len(reg.jobs)
+	reg.mu.Unlock()
+	if retained > maxRetainedGCJobs {
+		t.Fatalf("retained %d terminal jobs, want <= %d", retained, maxRetainedGCJobs)
+	}
+	// The oldest jobs must have been evicted.
+	if _, ok := reg.get(ids[0]); ok {
+		t.Fatal("oldest terminal job should have been evicted")
+	}
+}
+
+// waitFor polls cond until it holds or a short deadline elapses, failing the
+// test on timeout. Polling (rather than a fixed sleep) keeps the test fast.
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("condition never became true")
+}

--- a/pkg/controlplane/runtime/blockgc_job_test.go
+++ b/pkg/controlplane/runtime/blockgc_job_test.go
@@ -42,7 +42,7 @@ func TestGCRegistry_SingleActiveJob(t *testing.T) {
 	close(release)
 
 	// Wait for completion by polling the registry.
-	waitFor(t, func() bool {
+	waitForGCJob(t, func() bool {
 		j, ok := reg.get(first.ID)
 		return ok && j.State == GCStateDone
 	})
@@ -60,7 +60,7 @@ func TestGCRegistry_FailedJob(t *testing.T) {
 	job := reg.start("/s", false, false, func(context.Context, func(engine.GCStats)) (*engine.GCStats, error) {
 		return nil, context.DeadlineExceeded
 	})
-	waitFor(t, func() bool {
+	waitForGCJob(t, func() bool {
 		j, ok := reg.get(job.ID)
 		return ok && j.State == GCStateFailed
 	})
@@ -87,7 +87,7 @@ func TestGCRegistry_RetireBound(t *testing.T) {
 			return &engine.GCStats{}, nil
 		})
 		ids = append(ids, job.ID)
-		waitFor(t, func() bool {
+		waitForGCJob(t, func() bool {
 			j, ok := reg.get(job.ID)
 			return ok && j.State == GCStateDone
 		})
@@ -106,7 +106,7 @@ func TestGCRegistry_RetireBound(t *testing.T) {
 
 // waitFor polls cond until it holds or a short deadline elapses, failing the
 // test on timeout. Polling (rather than a fixed sleep) keeps the test fast.
-func waitFor(t *testing.T, cond func() bool) {
+func waitForGCJob(t *testing.T, cond func() bool) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {

--- a/pkg/controlplane/runtime/blockgc_reconcile.go
+++ b/pkg/controlplane/runtime/blockgc_reconcile.go
@@ -33,6 +33,13 @@ const (
 // references, then lets the grace- and snapshot-hold-aware sweep delete the
 // chunks.
 func (r *Runtime) RunBlockGCReconcile(ctx context.Context, dryRun bool) (*engine.GCStats, error) {
+	return r.runBlockGCReconcile(ctx, dryRun, nil)
+}
+
+// runBlockGCReconcile is RunBlockGCReconcile with an optional progress sink
+// wired into the sweep for async callers (StartBlockGC). progress is nil for
+// the synchronous public entrypoint and the startup reconcile-once.
+func (r *Runtime) runBlockGCReconcile(ctx context.Context, dryRun bool, progress func(engine.GCStats)) (*engine.GCStats, error) {
 	graceCutoff := time.Now().Add(-r.reconcileGracePeriod())
 
 	total := &engine.GCStats{DryRun: dryRun}
@@ -62,7 +69,7 @@ func (r *Runtime) RunBlockGCReconcile(ctx context.Context, dryRun bool) (*engine
 	// that must scan the real remote to find objects the synced-hash index does
 	// not know about (e.g. a Put-then-Mark crash), which the steady-state
 	// LIST-free sweep cannot see.
-	sweep, err := r.runBlockGCSweep(ctx, "", dryRun, true)
+	sweep, err := r.runBlockGCSweep(ctx, "", dryRun, true, progress)
 	// Record reaped rows regardless of the sweep result: the rows are already
 	// deleted from the metadata store, so the counter must reflect that even if
 	// the downstream sweep (e.g. S3 unreachable) then fails. Skip on dry-run —

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -98,6 +98,7 @@ type Runtime struct {
 	localStoreDefaults *shares.LocalStoreDefaults
 	syncerDefaults     *shares.SyncerDefaults
 	gcDefaults         *GCDefaults
+	gcReg              *gcRegistry
 	settingsWatcher    *SettingsWatcher
 
 	adapterProviders   map[string]any
@@ -182,6 +183,7 @@ func New(s store.Store) *Runtime {
 		lifecycleSvc:     lifecycle.New(DefaultShutdownTimeout),
 		identitySvc:      identity.New(),
 		statusCheckers:   newCheckerCache(StatusCacheTTL),
+		gcReg:            newGCRegistry(),
 	}
 
 	// Long-lived ctx for snapshot orchestration goroutines.
@@ -273,6 +275,12 @@ func (r *Runtime) Shutdown(ctx context.Context) error {
 	}
 	if ss != nil {
 		ss.Stop()
+	}
+
+	// Cancel any in-flight async GC so a long mark/sweep does not outlive the
+	// stores it operates on.
+	if r.gcReg != nil {
+		r.gcReg.cancelActive()
 	}
 
 	r.shutdownSnapshots(ctx)


### PR DESCRIPTION
## Problem

Reported on #1433: on a large/snapshot-heavy deployment the background auto-GC and manual `dfsctl store block gc` both fail with `mark phase ctx: context deadline exceeded`, and `dfsctl` times out after its client deadline while the server keeps running.

Root cause: the GC REST endpoint (`RunGC`) ran **synchronously on `r.Context()`**, which is bounded by the router's global `middleware.Timeout` (30s; 120s with pprof). The mark phase on a snapshot-heavy share takes minutes, so the request context was cancelled mid-mark and the engine aborted (`pkg/block/engine/gc.go` mark-phase ctx check) — GC never reached the sweep and reclaimed nothing. The dfsctl client timeout compounded it. Unlike snapshot Restore (which detaches + uses a long `timeouts.Restore`), GC got neither.

## Fix — PR3 of the #1433 follow-ups

**Async job, mirroring the existing share-warm pattern.** `POST .../blockstore/gc` kicks off the run on a context **detached** from the request (`context.WithoutCancel` semantics via a background context) and returns `202` + a job id; clients poll `GET .../blockstore/gc/{job_id}`. A process-local `gcRegistry` tracks the single active run (GC already serializes server-wide on the engine's per-root lock) plus a bounded window (`maxRetainedGCJobs`) of finished jobs. The active run is cancelled on server `Shutdown`.

**Mark-phase progress.** New `engine.Options.MarkProgress` reports the running hash count; `markPhase` logs at INFO per-share and every 100k hashes, so a multi-minute mark phase shows liveness instead of a silent stall. The existing sweep `ProgressCallback` is wired in too.

**dfsctl** kicks off then polls, rendering progress (suppressed under `-o json`/`yaml`); `--no-wait` returns the job id immediately. `--dry-run` / `--reconcile` preserved. The existing `gc-status` (last-run.json) command/endpoint is unchanged.

This complements the snapshot-hold dedup (separate PR) which cuts the mark phase from minutes to seconds; together they make auto-GC complete reliably.

## Tests
- `gcRegistry`: single-active-job (second start returns the running job, no concurrent run), failed-job records error + frees the slot, retire bound.
- Handler: 202 + job status, dry-run/reconcile propagation, 404 on unknown share, new `GCJobStatus` endpoint.
- apiclient round-trips (`StartBlockStoreGC` / `GetBlockStoreGCJob`); dfsctl command poll-to-completion + non-zero exit on sweep errors across formats.
- `go build ./... && go build -tags integration ./...`, `go vet`, `gofmt`, and the runtime/api/handlers/apiclient/engine/dfsctl package tests all green. `docs/guide/cli.md` regenerated via `cmd/gendocs`.

Note: I could not run the code-simplifier/code-reviewer subagents from this context; review was done manually.