### PR TITLE
feat(controlplane): name-or-ID addressing control-plane-wide (one reusable resolver)

### DIFF
--- a/cmd/dfsctl/commands/group/get.go
+++ b/cmd/dfsctl/commands/group/get.go
@@ -11,15 +11,19 @@ import (
 )
 
 var getCmd = &cobra.Command{
-	Use:   "get <name>",
+	Use:   "get <name|id>",
 	Short: "Get group details",
 	Long: `Get detailed information about a specific group on the DittoFS server.
+Accepts either the group name or the group's full ID (see 'dfsctl group list').
 The output includes the group's GID, description, member list, and creation
 timestamp. Use -o json or -o yaml for machine-readable output.
 
 Examples:
   # Show group details as a table
   dfsctl group get editors
+
+  # By ID
+  dfsctl group get 7a1e9f02-...
 
   # Output as JSON (useful for scripting)
   dfsctl group get editors -o json

--- a/cmd/dfsctl/commands/group/list.go
+++ b/cmd/dfsctl/commands/group/list.go
@@ -34,7 +34,7 @@ type GroupList []apiclient.Group
 
 // Headers implements TableRenderer.
 func (gl GroupList) Headers() []string {
-	return []string{"NAME", "GID", "MEMBERS", "DESCRIPTION"}
+	return []string{"NAME", "ID", "GID", "MEMBERS", "DESCRIPTION"}
 }
 
 // Rows implements TableRenderer.
@@ -47,7 +47,7 @@ func (gl GroupList) Rows() [][]string {
 		if g.GID != nil {
 			gidStr = fmt.Sprintf("%d", *g.GID)
 		}
-		rows = append(rows, []string{g.Name, gidStr, members, description})
+		rows = append(rows, []string{g.Name, g.ID, gidStr, members, description})
 	}
 	return rows
 }

--- a/cmd/dfsctl/commands/group/remove.go
+++ b/cmd/dfsctl/commands/group/remove.go
@@ -10,9 +10,10 @@ import (
 var removeForce bool
 
 var removeCmd = &cobra.Command{
-	Use:   "remove <name>",
+	Use:   "remove <name|id>",
 	Short: "Remove a group",
-	Long: `Remove a group from the DittoFS server. This action is irreversible:
+	Long: `Remove a group from the DittoFS server. Accepts either the group name
+or the group's full ID (see 'dfsctl group list'). This action is irreversible:
 the group record is permanently removed and any users that had it as their
 primary group will lose that association. You will be prompted for
 confirmation unless --force is specified.

--- a/cmd/dfsctl/commands/user/get.go
+++ b/cmd/dfsctl/commands/user/get.go
@@ -10,15 +10,19 @@ import (
 )
 
 var getCmd = &cobra.Command{
-	Use:   "get <username>",
+	Use:   "get <username|id>",
 	Short: "Get user details",
 	Long: `Get detailed information about a specific user on the DittoFS server.
+Accepts either the username or the user's full ID (see 'dfsctl user list').
 The output includes the user's role, UID, group memberships, account status,
 and last-login timestamp. Use -o json or -o yaml for machine-readable output.
 
 Examples:
   # Show user details as a table
   dfsctl user get alice
+
+  # By ID
+  dfsctl user get 3f2b1c4d-...
 
   # Output as JSON (useful for scripting)
   dfsctl user get alice -o json

--- a/cmd/dfsctl/commands/user/list.go
+++ b/cmd/dfsctl/commands/user/list.go
@@ -35,7 +35,7 @@ type UserList []apiclient.User
 
 // Headers implements TableRenderer.
 func (ul UserList) Headers() []string {
-	return []string{"USERNAME", "UID", "ROLE", "EMAIL", "GROUPS", "ENABLED"}
+	return []string{"USERNAME", "ID", "UID", "ROLE", "EMAIL", "GROUPS", "ENABLED"}
 }
 
 // Rows implements TableRenderer.
@@ -48,7 +48,7 @@ func (ul UserList) Rows() [][]string {
 		if u.UID != nil {
 			uidStr = fmt.Sprintf("%d", *u.UID)
 		}
-		rows = append(rows, []string{u.Username, uidStr, u.Role, email, groups, cmdutil.BoolToYesNo(u.Enabled)})
+		rows = append(rows, []string{u.Username, u.ID, uidStr, u.Role, email, groups, cmdutil.BoolToYesNo(u.Enabled)})
 	}
 	return rows
 }

--- a/cmd/dfsctl/commands/user/remove.go
+++ b/cmd/dfsctl/commands/user/remove.go
@@ -10,9 +10,10 @@ import (
 var removeForce bool
 
 var removeCmd = &cobra.Command{
-	Use:   "remove <username>",
+	Use:   "remove <username|id>",
 	Short: "Remove a user",
-	Long: `Remove a user from the DittoFS server. This action is irreversible:
+	Long: `Remove a user from the DittoFS server. Accepts either the username or
+the user's full ID (see 'dfsctl user list'). This action is irreversible:
 the account and its authentication tokens are permanently removed, though
 files the user owns are not deleted. You will be prompted for confirmation
 unless --force is specified.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -2393,11 +2393,12 @@ Global flags:
 Get group details
 
 Get detailed information about a specific group on the DittoFS server.
+Accepts either the group name or the group's full ID (see 'dfsctl group list').
 The output includes the group's GID, description, member list, and creation
 timestamp. Use -o json or -o yaml for machine-readable output.
 
 ```
-dfsctl group get <name>
+dfsctl group get <name|id>
 ```
 
 **Examples:**
@@ -2405,6 +2406,9 @@ dfsctl group get <name>
 ```bash
 # Show group details as a table
 dfsctl group get editors
+
+# By ID
+dfsctl group get 7a1e9f02-...
 
 # Output as JSON (useful for scripting)
 dfsctl group get editors -o json
@@ -2470,13 +2474,14 @@ Global flags:
 
 Remove a group
 
-Remove a group from the DittoFS server. This action is irreversible:
+Remove a group from the DittoFS server. Accepts either the group name
+or the group's full ID (see 'dfsctl group list'). This action is irreversible:
 the group record is permanently removed and any users that had it as their
 primary group will lose that association. You will be prompted for
 confirmation unless --force is specified.
 
 ```
-dfsctl group remove <name> [flags]
+dfsctl group remove <name|id> [flags]
 ```
 
 **Examples:**
@@ -7109,11 +7114,12 @@ Global flags:
 Get user details
 
 Get detailed information about a specific user on the DittoFS server.
+Accepts either the username or the user's full ID (see 'dfsctl user list').
 The output includes the user's role, UID, group memberships, account status,
 and last-login timestamp. Use -o json or -o yaml for machine-readable output.
 
 ```
-dfsctl user get <username>
+dfsctl user get <username|id>
 ```
 
 **Examples:**
@@ -7121,6 +7127,9 @@ dfsctl user get <username>
 ```bash
 # Show user details as a table
 dfsctl user get alice
+
+# By ID
+dfsctl user get 3f2b1c4d-...
 
 # Output as JSON (useful for scripting)
 dfsctl user get alice -o json
@@ -7231,13 +7240,14 @@ Global flags:
 
 Remove a user
 
-Remove a user from the DittoFS server. This action is irreversible:
+Remove a user from the DittoFS server. Accepts either the username or
+the user's full ID (see 'dfsctl user list'). This action is irreversible:
 the account and its authentication tokens are permanently removed, though
 files the user owns are not deleted. You will be prompted for confirmation
 unless --force is specified.
 
 ```
-dfsctl user remove <username> [flags]
+dfsctl user remove <username|id> [flags]
 ```
 
 **Examples:**

--- a/internal/controlplane/api/handlers/groups.go
+++ b/internal/controlplane/api/handlers/groups.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
@@ -151,24 +152,23 @@ func (h *GroupHandler) Update(w http.ResponseWriter, r *http.Request) {
 // Deletes a group (admin only).
 // System groups (admins, operators, users) cannot be deleted.
 func (h *GroupHandler) Remove(w http.ResponseWriter, r *http.Request) {
-	name := chi.URLParam(r, "name")
-	if name == "" {
+	token := chi.URLParam(r, "name")
+	if token == "" {
 		BadRequest(w, "Group name is required")
 		return
 	}
 
-	// Protect system groups from deletion
-	if models.IsSystemGroup(name) {
+	// The token may be a name or an ID. DeleteGroup resolves it and refuses to
+	// delete a system group by its canonical name, so the guard can't be bypassed
+	// by addressing the group via its ID.
+	switch err := h.store.DeleteGroup(r.Context(), token); {
+	case err == nil:
+		WriteNoContent(w)
+	case errors.Is(err, models.ErrCannotDeleteSysGroup):
 		Forbidden(w, "Cannot delete system group")
-		return
-	}
-
-	if err := h.store.DeleteGroup(r.Context(), name); err != nil {
+	default:
 		HandleStoreError(w, err)
-		return
 	}
-
-	WriteNoContent(w)
 }
 
 // AddMember handles POST /api/v1/groups/{name}/members.

--- a/internal/controlplane/api/handlers/groups_test.go
+++ b/internal/controlplane/api/handlers/groups_test.go
@@ -275,6 +275,38 @@ func TestGroupHandler_Delete(t *testing.T) {
 	}
 }
 
+// TestGroupHandler_Delete_SystemGroupByID guards the name-or-ID bypass: the
+// system-group protection must hold when the group is addressed by its UUID.
+func TestGroupHandler_Delete_SystemGroupByID(t *testing.T) {
+	cpStore, handler := setupGroupTest(t)
+	ctx := context.Background()
+
+	// "admins" is a system group; ensure it exists and grab its ID.
+	admins, err := cpStore.GetGroup(ctx, "admins")
+	if err != nil {
+		gid := uint32(0)
+		admins = &models.Group{ID: uuid.New().String(), Name: "admins", GID: &gid, CreatedAt: time.Now()}
+		if _, err := cpStore.CreateGroup(ctx, admins); err != nil {
+			t.Fatalf("Failed to create admins group: %v", err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/groups/"+admins.ID, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("name", admins.ID) // address by ID, not name
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	handler.Remove(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("Delete() system-group-by-id status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+	if _, err := cpStore.GetGroup(ctx, "admins"); err != nil {
+		t.Errorf("admins group must still exist after blocked delete-by-id: %v", err)
+	}
+}
+
 func TestGroupHandler_AddRemoveMember(t *testing.T) {
 	cpStore, handler := setupGroupTest(t)
 	ctx := context.Background()

--- a/internal/controlplane/api/handlers/users.go
+++ b/internal/controlplane/api/handlers/users.go
@@ -304,28 +304,25 @@ func (h *UserHandler) applySharePerms(r *http.Request, userID string, perms map[
 // Remove handles DELETE /api/v1/users/{username}.
 // Deletes a user (admin only).
 func (h *UserHandler) Remove(w http.ResponseWriter, r *http.Request) {
-	username := chi.URLParam(r, "username")
-	if username == "" {
+	token := chi.URLParam(r, "username")
+	if token == "" {
 		BadRequest(w, "Username is required")
 		return
 	}
 
-	// Prevent deleting admin user
-	if models.IsAdminUsername(username) {
+	// The token may be a username or an ID. DeleteUser resolves it and refuses to
+	// delete the admin account by its canonical username, so the guard can't be
+	// bypassed by addressing the admin via its ID.
+	switch err := h.store.DeleteUser(r.Context(), token); {
+	case err == nil:
+		WriteNoContent(w)
+	case errors.Is(err, models.ErrCannotDeleteAdmin):
 		Forbidden(w, "Cannot delete admin user")
-		return
-	}
-
-	if err := h.store.DeleteUser(r.Context(), username); err != nil {
-		if errors.Is(err, models.ErrUserNotFound) {
-			NotFound(w, "User not found")
-			return
-		}
+	case errors.Is(err, models.ErrUserNotFound):
+		NotFound(w, "User not found")
+	default:
 		InternalServerError(w, "Failed to delete user")
-		return
 	}
-
-	WriteNoContent(w)
 }
 
 // ResetPassword handles POST /api/v1/users/{username}/password.

--- a/internal/controlplane/api/handlers/users_test.go
+++ b/internal/controlplane/api/handlers/users_test.go
@@ -572,6 +572,43 @@ func TestUserHandler_Delete_Admin(t *testing.T) {
 	}
 }
 
+// TestUserHandler_Delete_AdminByID guards the name-or-ID bypass: the admin-user
+// protection must hold when the admin is addressed by its UUID, not just by name.
+func TestUserHandler_Delete_AdminByID(t *testing.T) {
+	cpStore, _, handler := setupUserTest(t)
+	ctx := context.Background()
+
+	adminID := uuid.New().String()
+	passwordHash, ntHash, _ := models.HashPasswordWithNT("password")
+	user := &models.User{
+		ID:           adminID,
+		Username:     models.AdminUsername,
+		PasswordHash: passwordHash,
+		NTHash:       ntHash,
+		Enabled:      true,
+		Role:         "admin",
+		CreatedAt:    time.Now(),
+	}
+	if _, err := cpStore.CreateUser(ctx, user); err != nil {
+		t.Fatalf("Failed to create admin user: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+adminID, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("username", adminID) // address by ID, not name
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	handler.Remove(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("Delete() admin-by-id status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+	if _, err := cpStore.GetUser(ctx, models.AdminUsername); err != nil {
+		t.Errorf("admin user must still exist after blocked delete-by-id: %v", err)
+	}
+}
+
 func TestUserHandler_ResetPassword(t *testing.T) {
 	cpStore, _, handler := setupUserTest(t)
 	ctx := context.Background()

--- a/pkg/controlplane/models/errors.go
+++ b/pkg/controlplane/models/errors.go
@@ -5,13 +5,15 @@ import "errors"
 // Common errors for identity and control plane operations.
 var (
 	// User errors
-	ErrUserNotFound  = errors.New("user not found")
-	ErrDuplicateUser = errors.New("user already exists")
-	ErrUserDisabled  = errors.New("user account is disabled")
+	ErrUserNotFound      = errors.New("user not found")
+	ErrDuplicateUser     = errors.New("user already exists")
+	ErrUserDisabled      = errors.New("user account is disabled")
+	ErrCannotDeleteAdmin = errors.New("cannot delete the admin user")
 
 	// Group errors
-	ErrGroupNotFound  = errors.New("group not found")
-	ErrDuplicateGroup = errors.New("group already exists")
+	ErrGroupNotFound        = errors.New("group not found")
+	ErrDuplicateGroup       = errors.New("group already exists")
+	ErrCannotDeleteSysGroup = errors.New("cannot delete a system group")
 
 	// Share errors
 	ErrShareNotFound  = errors.New("share not found")

--- a/pkg/controlplane/store/block.go
+++ b/pkg/controlplane/store/block.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -12,17 +11,9 @@ import (
 )
 
 func (s *GORMStore) GetBlockStore(ctx context.Context, name string, kind models.BlockStoreKind) (*models.BlockStoreConfig, error) {
-	var store models.BlockStoreConfig
-	// Resolve by name first, then by ID, scoped to the requested kind so an ID
-	// only matches a store of that kind (docker-style name-or-ID addressing).
-	err := s.db.WithContext(ctx).Where("name = ? AND kind = ?", name, kind).First(&store).Error
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		err = s.db.WithContext(ctx).Where("id = ? AND kind = ?", name, kind).First(&store).Error
-	}
-	if err != nil {
-		return nil, convertNotFoundError(err, models.ErrStoreNotFound)
-	}
-	return &store, nil
+	// Resolve by name then by ID, scoped to the requested kind so an ID only
+	// matches a store of that kind (docker-style name-or-ID addressing).
+	return getByNameOrIDWithin[models.BlockStoreConfig](s.db, ctx, "name", name, models.ErrStoreNotFound, []fieldEq{{"kind", kind}})
 }
 
 func (s *GORMStore) GetBlockStoreByID(ctx context.Context, id string) (*models.BlockStoreConfig, error) {
@@ -69,13 +60,9 @@ func (s *GORMStore) UpdateBlockStore(ctx context.Context, store *models.BlockSto
 
 func (s *GORMStore) DeleteBlockStore(ctx context.Context, name string, kind models.BlockStoreKind) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var store models.BlockStoreConfig
-		err := tx.Where("name = ? AND kind = ?", name, kind).First(&store).Error
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			err = tx.Where("id = ? AND kind = ?", name, kind).First(&store).Error
-		}
+		store, err := getByNameOrIDWithin[models.BlockStoreConfig](tx, ctx, "name", name, models.ErrStoreNotFound, []fieldEq{{"kind", kind}})
 		if err != nil {
-			return convertNotFoundError(err, models.ErrStoreNotFound)
+			return err
 		}
 
 		// Check if any shares reference this store (via local or remote block store ID)
@@ -89,7 +76,7 @@ func (s *GORMStore) DeleteBlockStore(ctx context.Context, name string, kind mode
 			return models.ErrStoreInUse
 		}
 
-		return tx.Delete(&store).Error
+		return tx.Delete(store).Error
 	})
 }
 

--- a/pkg/controlplane/store/groups.go
+++ b/pkg/controlplane/store/groups.go
@@ -56,6 +56,12 @@ func (s *GORMStore) DeleteGroup(ctx context.Context, name string) error {
 			return err
 		}
 
+		// Protect system groups. Resolved here (not at the call site) so the guard
+		// holds regardless of whether the caller addressed the group by name or ID.
+		if models.IsSystemGroup(group.Name) {
+			return models.ErrCannotDeleteSysGroup
+		}
+
 		// Delete share permissions
 		if err := tx.Where("group_id = ?", group.ID).Delete(&models.GroupSharePermission{}).Error; err != nil {
 			return err

--- a/pkg/controlplane/store/groups.go
+++ b/pkg/controlplane/store/groups.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (s *GORMStore) GetGroup(ctx context.Context, name string) (*models.Group, error) {
-	return getByField[models.Group](s.db, ctx, "name", name, models.ErrGroupNotFound, "Users", "SharePermissions")
+	return getByNameOrID[models.Group](s.db, ctx, "name", name, models.ErrGroupNotFound, "Users", "SharePermissions")
 }
 
 func (s *GORMStore) GetGroupByID(ctx context.Context, id string) (*models.Group, error) {
@@ -51,9 +51,9 @@ func (s *GORMStore) UpdateGroup(ctx context.Context, group *models.Group) error 
 
 func (s *GORMStore) DeleteGroup(ctx context.Context, name string) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var group models.Group
-		if err := tx.Where("name = ?", name).First(&group).Error; err != nil {
-			return convertNotFoundError(err, models.ErrGroupNotFound)
+		group, err := getByNameOrID[models.Group](tx, ctx, "name", name, models.ErrGroupNotFound)
+		if err != nil {
+			return err
 		}
 
 		// Delete share permissions
@@ -62,12 +62,12 @@ func (s *GORMStore) DeleteGroup(ctx context.Context, name string) error {
 		}
 
 		// Remove users from group (GORM handles the join table)
-		if err := tx.Model(&group).Association("Users").Clear(); err != nil {
+		if err := tx.Model(group).Association("Users").Clear(); err != nil {
 			return err
 		}
 
 		// Delete group
-		if err := tx.Delete(&group).Error; err != nil {
+		if err := tx.Delete(group).Error; err != nil {
 			return err
 		}
 

--- a/pkg/controlplane/store/helpers.go
+++ b/pkg/controlplane/store/helpers.go
@@ -21,10 +21,27 @@ import (
 //
 //	user, err := getByField[models.User](db, ctx, "username", "alice", models.ErrUserNotFound, "Groups", "SharePermissions")
 func getByField[T any](db *gorm.DB, ctx context.Context, field string, value any, notFoundErr error, preloads ...string) (*T, error) {
+	return getByFieldScoped[T](db, ctx, field, value, nil, notFoundErr, preloads...)
+}
+
+// fieldEq is an extra column=value equality constraint ANDed into a lookup. It
+// lets partitioned tables (e.g. block stores, which are scoped by kind) resolve
+// only within their partition.
+type fieldEq struct {
+	column string
+	value  any
+}
+
+// getByFieldScoped is getByField with additional equality constraints ANDed into
+// the query. Pass a nil scope for an unscoped lookup.
+func getByFieldScoped[T any](db *gorm.DB, ctx context.Context, field string, value any, scope []fieldEq, notFoundErr error, preloads ...string) (*T, error) {
 	var result T
 	q := db.WithContext(ctx)
 	for _, p := range preloads {
 		q = q.Preload(p)
+	}
+	for _, c := range scope {
+		q = q.Where(c.column+" = ?", c.value)
 	}
 	if err := q.Where(field+" = ?", value).First(&result).Error; err != nil {
 		return nil, convertNotFoundError(err, notFoundErr)
@@ -32,17 +49,23 @@ func getByField[T any](db *gorm.DB, ctx context.Context, field string, value any
 	return &result, nil
 }
 
-// getByNameOrID retrieves a single record of type T by its unique "name",
-// falling back to its "id" when no name matches. This lets API consumers address
-// a record by either its human-readable name or its opaque ID (docker-style).
-// Names are matched first and the ID lookup only runs on a name miss, so the two
-// can never resolve ambiguously.
+// getByNameOrIDWithin retrieves a single record of type T by its natural-key
+// column (name, username, type, ...), falling back to its opaque UUID "id" when
+// no natural-key match exists. This lets API consumers address a record by
+// either its human-readable name or its ID (docker-style). The natural key is
+// matched first and the ID lookup only runs on a genuine not-found, so a name
+// that happens to look like a UUID still resolves to the named record.
+//
+// scope confines resolution to one partition (e.g. block stores within a kind):
+// its constraints are ANDed into every attempt. Pass a nil scope for an
+// unpartitioned lookup, or use getByNameOrID.
 //
 // Share names are stored with a leading "/" (the API layer prepends it), so a
 // raw ID arrives here as "/<id>"; the final attempt strips that prefix. IDs
-// never contain a slash, so this is a no-op for every other caller.
-func getByNameOrID[T any](db *gorm.DB, ctx context.Context, token string, notFoundErr error, preloads ...string) (*T, error) {
-	result, err := getByField[T](db, ctx, "name", token, notFoundErr, preloads...)
+// never contain a slash, so this is a no-op for every other caller. Each
+// fallback is gated on notFoundErr so a genuine DB error is never masked.
+func getByNameOrIDWithin[T any](db *gorm.DB, ctx context.Context, naturalKey, token string, notFoundErr error, scope []fieldEq, preloads ...string) (*T, error) {
+	result, err := getByFieldScoped[T](db, ctx, naturalKey, token, scope, notFoundErr, preloads...)
 	if err == nil {
 		return result, nil
 	}
@@ -50,7 +73,7 @@ func getByNameOrID[T any](db *gorm.DB, ctx context.Context, token string, notFou
 		return nil, err
 	}
 
-	result, err = getByField[T](db, ctx, "id", token, notFoundErr, preloads...)
+	result, err = getByFieldScoped[T](db, ctx, "id", token, scope, notFoundErr, preloads...)
 	if err == nil {
 		return result, nil
 	}
@@ -58,9 +81,14 @@ func getByNameOrID[T any](db *gorm.DB, ctx context.Context, token string, notFou
 		return nil, err
 	}
 	if trimmed := strings.TrimPrefix(token, "/"); trimmed != token {
-		return getByField[T](db, ctx, "id", trimmed, notFoundErr, preloads...)
+		return getByFieldScoped[T](db, ctx, "id", trimmed, scope, notFoundErr, preloads...)
 	}
 	return nil, err
+}
+
+// getByNameOrID is getByNameOrIDWithin for unpartitioned entities (nil scope).
+func getByNameOrID[T any](db *gorm.DB, ctx context.Context, naturalKey, token string, notFoundErr error, preloads ...string) (*T, error) {
+	return getByNameOrIDWithin[T](db, ctx, naturalKey, token, notFoundErr, nil, preloads...)
 }
 
 // listAll retrieves all records of type T, applying optional GORM Preload clauses.

--- a/pkg/controlplane/store/metadata.go
+++ b/pkg/controlplane/store/metadata.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"gorm.io/gorm"
@@ -11,7 +10,7 @@ import (
 )
 
 func (s *GORMStore) GetMetadataStore(ctx context.Context, name string) (*models.MetadataStoreConfig, error) {
-	return getByNameOrID[models.MetadataStoreConfig](s.db, ctx, name, models.ErrStoreNotFound)
+	return getByNameOrID[models.MetadataStoreConfig](s.db, ctx, "name", name, models.ErrStoreNotFound)
 }
 
 func (s *GORMStore) GetMetadataStoreByID(ctx context.Context, id string) (*models.MetadataStoreConfig, error) {
@@ -48,13 +47,9 @@ func (s *GORMStore) UpdateMetadataStore(ctx context.Context, store *models.Metad
 
 func (s *GORMStore) DeleteMetadataStore(ctx context.Context, name string) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var store models.MetadataStoreConfig
-		err := tx.Where("name = ?", name).First(&store).Error
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			err = tx.Where("id = ?", name).First(&store).Error
-		}
+		store, err := getByNameOrID[models.MetadataStoreConfig](tx, ctx, "name", name, models.ErrStoreNotFound)
 		if err != nil {
-			return convertNotFoundError(err, models.ErrStoreNotFound)
+			return err
 		}
 
 		// Check if any shares reference this store
@@ -67,7 +62,7 @@ func (s *GORMStore) DeleteMetadataStore(ctx context.Context, name string) error 
 		}
 
 		// Delete store
-		return tx.Delete(&store).Error
+		return tx.Delete(store).Error
 	})
 }
 

--- a/pkg/controlplane/store/name_or_id_test.go
+++ b/pkg/controlplane/store/name_or_id_test.go
@@ -5,6 +5,7 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
@@ -96,6 +97,93 @@ func TestStoreAndShareNameOrIDResolution(t *testing.T) {
 		}
 		if _, err := store.GetMetadataStore(ctx, metaID); !errors.Is(err, models.ErrStoreNotFound) {
 			t.Fatalf("expected ErrStoreNotFound after delete, got %v", err)
+		}
+	})
+}
+
+// TestUserGroupNetgroupNameOrIDResolution extends the docker-style addressing
+// contract to identity entities: users (by username or id), groups and netgroups
+// (by name or id). It also pins that a POSIX uid/gid is NOT an addressing token —
+// it resolves only via the explicit *ByUID/*ByGID methods.
+func TestUserGroupNetgroupNameOrIDResolution(t *testing.T) {
+	store := createTestStore(t)
+	defer store.Close()
+	ctx := context.Background()
+	u32 := func(v uint32) *uint32 { return &v }
+
+	uid := uint32(5000)
+	userID, err := store.CreateUser(ctx, &models.User{Username: "alice", PasswordHash: "x", Role: "user", UID: u32(uid)})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	gid := uint32(6000)
+	groupID, err := store.CreateGroup(ctx, &models.Group{Name: "editors", GID: u32(gid)})
+	if err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	netID, err := store.CreateNetgroup(ctx, &models.Netgroup{Name: "ng"})
+	if err != nil {
+		t.Fatalf("create netgroup: %v", err)
+	}
+
+	t.Run("user by username and by id", func(t *testing.T) {
+		byName, err := store.GetUser(ctx, "alice")
+		if err != nil || byName.ID != userID {
+			t.Fatalf("by username: got %+v err %v", byName, err)
+		}
+		byID, err := store.GetUser(ctx, userID)
+		if err != nil || byID.Username != "alice" {
+			t.Fatalf("by id: got %+v err %v", byID, err)
+		}
+	})
+
+	t.Run("group and netgroup by name and by id", func(t *testing.T) {
+		if g, err := store.GetGroup(ctx, "editors"); err != nil || g.ID != groupID {
+			t.Fatalf("group by name: got %+v err %v", g, err)
+		}
+		if g, err := store.GetGroup(ctx, groupID); err != nil || g.Name != "editors" {
+			t.Fatalf("group by id: got %+v err %v", g, err)
+		}
+		if n, err := store.GetNetgroup(ctx, "ng"); err != nil || n.ID != netID {
+			t.Fatalf("netgroup by name: got %+v err %v", n, err)
+		}
+		if n, err := store.GetNetgroup(ctx, netID); err != nil || n.Name != "ng" {
+			t.Fatalf("netgroup by id: got %+v err %v", n, err)
+		}
+	})
+
+	t.Run("uid/gid is not an addressing token", func(t *testing.T) {
+		// A POSIX uid passed to GetUser must NOT resolve — it is neither the
+		// username nor the UUID. The explicit *ByUID path still works.
+		if _, err := store.GetUser(ctx, fmt.Sprintf("%d", uid)); !errors.Is(err, models.ErrUserNotFound) {
+			t.Fatalf("uid as token: expected ErrUserNotFound, got %v", err)
+		}
+		if u, err := store.GetUserByUID(ctx, uid); err != nil || u.ID != userID {
+			t.Fatalf("GetUserByUID: got %+v err %v", u, err)
+		}
+		if _, err := store.GetGroup(ctx, fmt.Sprintf("%d", gid)); !errors.Is(err, models.ErrGroupNotFound) {
+			t.Fatalf("gid as token: expected ErrGroupNotFound, got %v", err)
+		}
+	})
+
+	t.Run("unknown id does not resolve", func(t *testing.T) {
+		if _, err := store.GetUser(ctx, "00000000-0000-0000-0000-000000000000"); !errors.Is(err, models.ErrUserNotFound) {
+			t.Fatalf("expected ErrUserNotFound, got %v", err)
+		}
+	})
+
+	t.Run("delete by id", func(t *testing.T) {
+		if err := store.DeleteUser(ctx, userID); err != nil {
+			t.Fatalf("delete user by id: %v", err)
+		}
+		if _, err := store.GetUser(ctx, userID); !errors.Is(err, models.ErrUserNotFound) {
+			t.Fatalf("expected ErrUserNotFound after delete, got %v", err)
+		}
+		if err := store.DeleteGroup(ctx, groupID); err != nil {
+			t.Fatalf("delete group by id: %v", err)
+		}
+		if err := store.DeleteNetgroup(ctx, netID); err != nil {
+			t.Fatalf("delete netgroup by id: %v", err)
 		}
 	})
 }

--- a/pkg/controlplane/store/netgroups.go
+++ b/pkg/controlplane/store/netgroups.go
@@ -24,7 +24,7 @@ func netgroupIDExpr(dbType DatabaseType) string {
 }
 
 func (s *GORMStore) GetNetgroup(ctx context.Context, name string) (*models.Netgroup, error) {
-	return getByField[models.Netgroup](s.db, ctx, "name", name, models.ErrNetgroupNotFound, "Members")
+	return getByNameOrID[models.Netgroup](s.db, ctx, "name", name, models.ErrNetgroupNotFound, "Members")
 }
 
 func (s *GORMStore) GetNetgroupByID(ctx context.Context, id string) (*models.Netgroup, error) {
@@ -59,9 +59,9 @@ func (s *GORMStore) CreateNetgroup(ctx context.Context, netgroup *models.Netgrou
 
 func (s *GORMStore) DeleteNetgroup(ctx context.Context, name string) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var netgroup models.Netgroup
-		if err := tx.Where("name = ?", name).First(&netgroup).Error; err != nil {
-			return convertNotFoundError(err, models.ErrNetgroupNotFound)
+		netgroup, err := getByNameOrID[models.Netgroup](tx, ctx, "name", name, models.ErrNetgroupNotFound)
+		if err != nil {
+			return err
 		}
 
 		// Check if any NFS adapter configs reference this netgroup ID in their JSON config.
@@ -82,7 +82,7 @@ func (s *GORMStore) DeleteNetgroup(ctx context.Context, name string) error {
 		}
 
 		// Delete the netgroup
-		return tx.Delete(&netgroup).Error
+		return tx.Delete(netgroup).Error
 	})
 }
 

--- a/pkg/controlplane/store/shares.go
+++ b/pkg/controlplane/store/shares.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *GORMStore) GetShare(ctx context.Context, name string) (*models.Share, error) {
-	return getByNameOrID[models.Share](s.db, ctx, name, models.ErrShareNotFound,
+	return getByNameOrID[models.Share](s.db, ctx, "name", name, models.ErrShareNotFound,
 		"MetadataStore", "LocalBlockStore", "RemoteBlockStore", "AccessRules", "UserPermissions", "GroupPermissions")
 }
 
@@ -127,7 +127,7 @@ func (s *GORMStore) UpdateShare(ctx context.Context, share *models.Share) error 
 
 func (s *GORMStore) DeleteShare(ctx context.Context, name string) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		share, err := getByNameOrID[models.Share](tx, ctx, name, models.ErrShareNotFound)
+		share, err := getByNameOrID[models.Share](tx, ctx, "name", name, models.ErrShareNotFound)
 		if err != nil {
 			return err
 		}
@@ -233,7 +233,7 @@ func (s *GORMStore) GetShareAccessRules(ctx context.Context, shareName string) (
 
 func (s *GORMStore) SetShareAccessRules(ctx context.Context, shareName string, rules []*models.ShareAccessRule) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		share, err := getByNameOrID[models.Share](tx, ctx, shareName, models.ErrShareNotFound)
+		share, err := getByNameOrID[models.Share](tx, ctx, "name", shareName, models.ErrShareNotFound)
 		if err != nil {
 			return err
 		}
@@ -260,7 +260,7 @@ func (s *GORMStore) SetShareAccessRules(ctx context.Context, shareName string, r
 
 func (s *GORMStore) AddShareAccessRule(ctx context.Context, shareName string, rule *models.ShareAccessRule) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		share, err := getByNameOrID[models.Share](tx, ctx, shareName, models.ErrShareNotFound)
+		share, err := getByNameOrID[models.Share](tx, ctx, "name", shareName, models.ErrShareNotFound)
 		if err != nil {
 			return err
 		}
@@ -276,7 +276,7 @@ func (s *GORMStore) AddShareAccessRule(ctx context.Context, shareName string, ru
 
 func (s *GORMStore) RemoveShareAccessRule(ctx context.Context, shareName, ruleID string) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		share, err := getByNameOrID[models.Share](tx, ctx, shareName, models.ErrShareNotFound)
+		share, err := getByNameOrID[models.Share](tx, ctx, "name", shareName, models.ErrShareNotFound)
 		if err != nil {
 			return err
 		}

--- a/pkg/controlplane/store/users.go
+++ b/pkg/controlplane/store/users.go
@@ -131,6 +131,13 @@ func (s *GORMStore) DeleteUser(ctx context.Context, username string) error {
 			return err
 		}
 
+		// Protect the admin account. Resolved here (not at the call site) so the
+		// guard holds regardless of whether the caller addressed the user by name
+		// or by ID.
+		if models.IsAdminUsername(user.Username) {
+			return models.ErrCannotDeleteAdmin
+		}
+
 		// Delete share permissions
 		if err := tx.Where("user_id = ?", user.ID).Delete(&models.UserSharePermission{}).Error; err != nil {
 			return err

--- a/pkg/controlplane/store/users.go
+++ b/pkg/controlplane/store/users.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (s *GORMStore) GetUser(ctx context.Context, username string) (*models.User, error) {
-	return getByField[models.User](s.db, ctx, "username", username, models.ErrUserNotFound, "Groups", "SharePermissions")
+	return getByNameOrID[models.User](s.db, ctx, "username", username, models.ErrUserNotFound, "Groups", "SharePermissions")
 }
 
 func (s *GORMStore) GetUserByID(ctx context.Context, id string) (*models.User, error) {
@@ -126,9 +126,9 @@ func (s *GORMStore) UpdateUserSIDInfo(ctx context.Context, username, sid string,
 
 func (s *GORMStore) DeleteUser(ctx context.Context, username string) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var user models.User
-		if err := tx.Where("username = ?", username).First(&user).Error; err != nil {
-			return convertNotFoundError(err, models.ErrUserNotFound)
+		user, err := getByNameOrID[models.User](tx, ctx, "username", username, models.ErrUserNotFound)
+		if err != nil {
+			return err
 		}
 
 		// Delete share permissions
@@ -137,12 +137,12 @@ func (s *GORMStore) DeleteUser(ctx context.Context, username string) error {
 		}
 
 		// Remove from groups (GORM handles the join table)
-		if err := tx.Model(&user).Association("Groups").Clear(); err != nil {
+		if err := tx.Model(user).Association("Groups").Clear(); err != nil {
 			return err
 		}
 
 		// Delete user
-		if err := tx.Delete(&user).Error; err != nil {
+		if err := tx.Delete(user).Error; err != nil {
 			return err
 		}
 


### PR DESCRIPTION
## What

Generalizes the docker-style **name-or-ID addressing** shipped in #1473 (stores + shares) into a single reusable control-plane resolver, then applies it to every entity that has a human name **and** a separate UUID. Closes #1476.

`dfsctl <entity> get|remove <token>` now accepts either the natural name or the full ID, everywhere it makes sense.

## The abstraction (`pkg/controlplane/store/helpers.go`)

- `getByFieldScoped` — `getByField` plus extra `AND` constraints (`[]fieldEq`).
- `getByNameOrIDWithin(naturalKey, token, notFoundErr, scope, …)` — natural-key → id → slash-trimmed id, each fallback gated on `errors.Is(err, notFoundErr)`; `scope` ANDed into every attempt.
- `getByNameOrID` — wrapper passing `nil` scope (the common, unpartitioned case).

`naturalKey` is now a parameter (`name`/`username`), and `scope` confines partitioned lookups. **block.go's hand-rolled two-step name/id lookup is deleted** and routed through the helper — net simplification.

## Applied to

| Entity | by name | by id | notes |
|--------|:--:|:--:|-------|
| metadata store | ✅ | ✅ | refactored onto helper |
| block store | ✅ | ✅ | kind-scoped via `[]fieldEq{{"kind", kind}}` |
| share | ✅ | ✅ | refactored; leading-`/` trim preserved |
| user | ✅ | ✅ | `GetUser` / `DeleteUser` |
| group | ✅ | ✅ | `GetGroup` / `DeleteGroup` |
| netgroup | ✅ | ✅ | `GetNetgroup` / `DeleteNetgroup` |

Excluded (no single name+UUID pair): identity provider (PK is `type`), identity mapping (composite), snapshot/snapshot-policy (addressed via their share).

**uid/gid are NOT addressing tokens** — POSIX identity numbers, not handles. They still resolve only via the explicit `*ByUID` / `*ByGID` methods. Pinned by test.

## dfsctl
- `user list` / `group list` gain an `ID` column (parity with the store lists).
- `user get|remove` and `group get|remove` accept `<name|id>`; Long text updated; `cli.md` regenerated.

## Security (2nd commit)

Resolving Delete by id exposed a guard-bypass: the admin-user (`IsAdminUsername`) and system-group (`IsSystemGroup`) delete guards compared the **raw token**, so addressing the protected record by its UUID skipped the guard. Fixed by resolving first, then checking the **canonical** username/name before deleting. Caught in review; regression tests added for delete-by-id on both.

## Tests
- `pkg/controlplane/store/name_or_id_test.go` (integration): extended with users/groups/netgroups by name and id, uid/gid-not-a-token, unknown-id, delete-by-id.
- `internal/controlplane/api/handlers`: `TestUserHandler_Delete_AdminByID`, `TestGroupHandler_Delete_SystemGroupByID` (both `//go:build integration`).

## Verification
`go build ./...`, `go vet`, `gofmt -l` clean; `golangci-lint` 0 issues; integration store + handler suites green. No API/route/apiclient changes — resolution is entirely store-side (handlers already forward the raw token).

Design notes: `.planning/2026-06-30-1476-users-groups-name-or-id-design.md`.
