### PR TITLE
fix(gc): keep synced marker on unlink so remote orphans stay GC-discoverable

### DIFF
--- a/pkg/block/engine/engine_delete_test.go
+++ b/pkg/block/engine/engine_delete_test.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -263,22 +262,26 @@ func buildCascadeFixture(t *testing.T, coord MetadataCoordinator, syncedStore me
 	return bs
 }
 
-// TestEngine_Delete_CascadesDeleteSynced asserts that engine.Delete
-// fires syncedHashStore.DeleteSynced exactly when the coordinator's
-// DecrementRefCount returns newCount == 0, and never otherwise. The
-// cascade keeps the synced set a strict subset of local CAS contents
-// a stale marker would cause the next mirror pass on a re-Put of the
-// same hash to skip the upload, leaving the remote out of sync with
-// local.
-func TestEngine_Delete_CascadesDeleteSynced(t *testing.T) {
+// TestEngine_Delete_PreservesSyncedMarker asserts that engine.Delete NEVER
+// clears a hash's synced marker on reap — not even when the coordinator reaps
+// the last reference (newCount == 0).
+//
+// The synced marker means "these bytes are on the remote", which remains true
+// after the last reference is reaped: the remote object survives until the GC
+// sweep physically deletes it. Since #1458 the steady-state remote sweep finds
+// orphan candidates from (synced − live), so the marker MUST outlive unlink —
+// otherwise the just-orphaned remote object drops out of the candidate set and
+// leaks forever (only a full-Walk reconcile could find it). The sweep clears
+// the marker itself, right after it deletes the remote object (#1433).
+func TestEngine_Delete_PreservesSyncedMarker(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("RefcountZero_CascadesDeleteSynced", func(t *testing.T) {
+	t.Run("RefcountZero_KeepsSyncedMarker", func(t *testing.T) {
 		var hash block.ContentHash
 		hash[0] = 0xC0
 
 		coord := newRefcountCoordinator()
-		coord.seedBlock("pid-cascade-zero", 0, hash, 1) // last reference → Delete reaps to 0
+		coord.seedBlock("pid-keep-zero", 0, hash, 1) // last reference → Delete reaps to 0
 
 		syncedStore := newRecordingSyncedHashStore()
 		syncedStore.markSyncedForTest(hash)
@@ -286,28 +289,38 @@ func TestEngine_Delete_CascadesDeleteSynced(t *testing.T) {
 		bs := buildCascadeFixture(t, coord, syncedStore)
 
 		blocks := []block.BlockRef{{Hash: hash, Offset: 0, Size: 4096}}
-		if err := bs.Delete(ctx, "pid-cascade-zero", blocks); err != nil {
+		if err := bs.Delete(ctx, "pid-keep-zero", blocks); err != nil {
 			t.Fatalf("Delete returned error: %v", err)
 		}
 
+		// The remote object still exists, so the marker MUST survive so the
+		// steady-state GC sweep can still find it as an orphan candidate.
 		got, err := syncedStore.IsSynced(ctx, hash)
 		if err != nil {
 			t.Fatalf("IsSynced: %v", err)
 		}
-		if got {
-			t.Errorf("IsSynced=true after refcount→0 Delete; want false (cascade should have fired)")
+		if !got {
+			t.Errorf("IsSynced=false after refcount→0 Delete; want true (marker must outlive unlink so GC can reclaim the remote orphan)")
 		}
-		if dels := syncedStore.deletedHashes(); len(dels) != 1 || dels[0] != hash {
-			t.Errorf("DeleteSynced invocations=%v; want [%x] exactly once", dels, hash[:4])
+		if dels := syncedStore.deletedHashes(); len(dels) != 0 {
+			t.Errorf("DeleteSynced invocations=%v; want none (unlink must not clear the marker)", dels)
+		}
+
+		// The block row itself is still reaped.
+		coord.mu.Lock()
+		count := coord.counts[hash]
+		coord.mu.Unlock()
+		if count != 0 {
+			t.Errorf("coordinator refcount=%d after Delete; want 0 (row still reaped)", count)
 		}
 	})
 
-	t.Run("RefcountNonZero_DoesNotCascade", func(t *testing.T) {
+	t.Run("RefcountNonZero_KeepsSyncedMarker", func(t *testing.T) {
 		var hash block.ContentHash
 		hash[0] = 0xC1
 
 		coord := newRefcountCoordinator()
-		coord.seedBlock("pid-cascade-nonzero", 0, hash, 2) // two refs; Delete drops one → newCount == 1
+		coord.seedBlock("pid-keep-nonzero", 0, hash, 2) // two refs; Delete drops one → newCount == 1
 
 		syncedStore := newRecordingSyncedHashStore()
 		syncedStore.markSyncedForTest(hash)
@@ -315,7 +328,7 @@ func TestEngine_Delete_CascadesDeleteSynced(t *testing.T) {
 		bs := buildCascadeFixture(t, coord, syncedStore)
 
 		blocks := []block.BlockRef{{Hash: hash, Offset: 0, Size: 4096}}
-		if err := bs.Delete(ctx, "pid-cascade-nonzero", blocks); err != nil {
+		if err := bs.Delete(ctx, "pid-keep-nonzero", blocks); err != nil {
 			t.Fatalf("Delete returned error: %v", err)
 		}
 
@@ -324,10 +337,10 @@ func TestEngine_Delete_CascadesDeleteSynced(t *testing.T) {
 			t.Fatalf("IsSynced: %v", err)
 		}
 		if !got {
-			t.Errorf("IsSynced=false after refcount→1 Delete; want true (cascade must NOT fire)")
+			t.Errorf("IsSynced=false after refcount→1 Delete; want true")
 		}
 		if dels := syncedStore.deletedHashes(); len(dels) != 0 {
-			t.Errorf("DeleteSynced invocations=%v; want none (newCount != 0)", dels)
+			t.Errorf("DeleteSynced invocations=%v; want none", dels)
 		}
 	})
 
@@ -336,48 +349,22 @@ func TestEngine_Delete_CascadesDeleteSynced(t *testing.T) {
 		hash[0] = 0xC2
 
 		coord := newRefcountCoordinator()
-		coord.seedBlock("pid-cascade-nil", 0, hash, 1)
+		coord.seedBlock("pid-keep-nil", 0, hash, 1)
 
-		// SyncedHashStore intentionally nil — exercises the bs.syncedHashStore
-		// nil-guard. Delete must not panic and must still drive the
-		// coordinator decrement.
+		// SyncedHashStore intentionally nil — Delete must not panic and must
+		// still drive the coordinator decrement.
 		bs := buildCascadeFixture(t, coord, nil)
 
 		blocks := []block.BlockRef{{Hash: hash, Offset: 0, Size: 4096}}
-		if err := bs.Delete(ctx, "pid-cascade-nil", blocks); err != nil {
+		if err := bs.Delete(ctx, "pid-keep-nil", blocks); err != nil {
 			t.Fatalf("Delete returned error: %v", err)
 		}
 
-		// DecrementRefCount fired — the seeded count is now zero.
 		coord.mu.Lock()
 		got := coord.counts[hash]
 		coord.mu.Unlock()
 		if got != 0 {
 			t.Errorf("coordinator refcount=%d after Delete with nil syncedStore; want 0", got)
-		}
-	})
-
-	t.Run("DeleteSyncedFailure_IsBenign", func(t *testing.T) {
-		var hash block.ContentHash
-		hash[0] = 0xC3
-
-		coord := newRefcountCoordinator()
-		coord.seedBlock("pid-cascade-benign", 0, hash, 1)
-
-		syncedStore := newRecordingSyncedHashStore()
-		syncedStore.markSyncedForTest(hash)
-		syncedStore.deleteErr = errors.New("induced DeleteSynced failure")
-
-		bs := buildCascadeFixture(t, coord, syncedStore)
-
-		blocks := []block.BlockRef{{Hash: hash, Offset: 0, Size: 4096}}
-		// Delete must NOT propagate the DeleteSynced failure — orphan
-		// marker is benign per the plan's threat-register disposition.
-		if err := bs.Delete(ctx, "pid-cascade-benign", blocks); err != nil {
-			t.Fatalf("Delete returned error on DeleteSynced failure (want nil — orphan is benign): %v", err)
-		}
-		if dels := syncedStore.deletedHashes(); len(dels) != 1 {
-			t.Errorf("DeleteSynced invocation count=%d; want 1 (cascade attempted)", len(dels))
 		}
 	})
 }

--- a/pkg/block/engine/engine_test.go
+++ b/pkg/block/engine/engine_test.go
@@ -418,5 +418,5 @@ func TestCopyPayload_EmptySource(t *testing.T) {
 // store under blocks/<hh>/ is the only on-disk layout), so there is
 // nothing to observe at this seam. End-to-end coverage of the
 // engine.Delete refcount → GC path is provided by
-// TestEngine_Delete_CascadesDeleteSynced in engine_delete_test.go and
+// TestEngine_Delete_PreservesSyncedMarker in engine_delete_test.go and
 // by the integration tests in syncer_test.go.

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -384,28 +384,25 @@ func (bs *Store) Delete(ctx context.Context, payloadID string, blocks []block.Bl
 			// Reap at RefCount 0 so the row leaves EnumerateFileBlocks once no
 			// sibling references the hash, letting the GC sweep reclaim the
 			// remote chunk (#832).
-			newCount, err := bs.coordinator.DecrementRefCountAndReap(ctx, payloadID, b.Offset)
-			if err != nil {
+			//
+			// Deliberately do NOT clear the synced marker here. The marker means
+			// "these bytes are on the remote", which stays TRUE after the last
+			// reference is reaped — the remote object lives until the GC sweep
+			// physically deletes it. Since #1458 the steady-state remote sweep
+			// derives orphan candidates from (synced − live); clearing the marker
+			// at unlink removes the just-orphaned hash from that candidate set, so
+			// the remote object becomes invisible to GC and leaks forever (only a
+			// full-Walk reconcile could ever find it again). The sweep clears the
+			// marker itself, immediately after it deletes the remote object
+			// (sweepFromSyncedIndex / sweepByWalk → DeleteSynced), which keeps
+			// `synced` a faithful subset of remote contents. A re-Put before GC
+			// correctly skips re-upload (bytes still remote-resident); a re-Put
+			// after GC re-uploads (GC already cleared the marker) (#1433).
+			if _, err := bs.coordinator.DecrementRefCountAndReap(ctx, payloadID, b.Offset); err != nil {
 				if coordErr == nil {
 					coordErr = fmt.Errorf("reap block on delete %s/%d: %w", payloadID, b.Offset, err)
 				}
 				continue
-			}
-			// Row reaped (count hit zero): the local CAS chunk for this hash
-			// may be reclaimed, so drop the synced marker too. Without this
-			// cascade the synced set would drift out of strict-subset
-			// relationship with local CAS contents — a future re-Put of the
-			// same hash would skip remote upload because the marker is stale.
-			// Failure here is benign (the marker becomes an orphan, but a stale
-			// marker only causes a single skipped upload on a re-Put; the bytes
-			// are already remote-resident from the original Mark). A sibling
-			// file still referencing this hash would likewise re-upload on its
-			// next flush — also benign. Logged at Warn for operator visibility.
-			if newCount == 0 && bs.syncedHashStore != nil {
-				if derr := bs.syncedHashStore.DeleteSynced(ctx, b.Hash); derr != nil {
-					logger.Warn("delete synced marker (orphan; benign)",
-						"hash", b.Hash.String(), "err", derr)
-				}
 			}
 		}
 	}

--- a/pkg/block/engine/syncer_test.go
+++ b/pkg/block/engine/syncer_test.go
@@ -39,8 +39,9 @@ import (
 //     no-op contract per the unified Store surface.
 //  3. ListUnsynced snapshot semantics — chunks rolled up mid-Flush land
 //     in the NEXT pass, not the current one.
-//  4. Refcount cascade — engine.Delete on a fully-synced file drops the
-//     synced marker so the synced set stays a strict subset of local CAS.
+//  4. Unlink preserves synced — engine.Delete on a fully-synced file reaps
+//     the refcount but KEEPS the synced marker, so the steady-state GC sweep
+//     can still reclaim the now-orphaned remote object (#1433).
 //
 // Two backend fixtures
 //
@@ -825,21 +826,21 @@ func diff(candidates []block.ContentHash, seen map[block.ContentHash]struct{}) [
 }
 
 // ----------------------------------------------------------------------
-// Scenario 4: Refcount cascade DeleteSynced end-to-end.
+// Scenario 4: unlink PRESERVES the synced marker, end-to-end.
 //
 // Write a file, Flush so its chunks land in remote + synced set, then
 // engine.Delete with the produced BlockRef list (refcount → 0 because
-// the coordinator is the test refcount fake). Assert: IsSynced flips
-// to false for every hash; the synced set is again a strict subset of
-// local CAS.
+// the coordinator is the test refcount fake). Assert: IsSynced stays
+// TRUE for every hash — the remote objects still exist, so the markers
+// must survive unlink or the steady-state GC sweep (which finds remote
+// orphans via synced − live) could never reclaim them (#1433).
 //
-// Distinct from the unit cascade test in engine_delete_test.go in that
-// it exercises the cascade end-to-end against a real remote backend —
-// 's unit suite proves the wiring; this proves the path under
-// real Put/MarkSynced state.
+// Distinct from the unit test in engine_delete_test.go in that it
+// exercises the path end-to-end against a real remote backend under real
+// Put/MarkSynced state.
 // ----------------------------------------------------------------------
 
-func TestEngine_Delete_CascadesDeleteSynced(t *testing.T) {
+func TestEngine_Delete_PreservesSyncedMarker(t *testing.T) {
 	runIntegrationMatrix(t, func(t *testing.T, backend remoteBackendFactory) {
 		ctx := context.Background()
 		rs := backend.new(t)
@@ -881,9 +882,9 @@ func TestEngine_Delete_CascadesDeleteSynced(t *testing.T) {
 		}
 
 		// Seed coord with refcount=1 per block ID so the by-ID reap on
-		// Delete drops each to 0 and triggers the cascade. The reap is
-		// keyed by EXACT ID "{payloadID}/{offset}"; the offsets here match
-		// the blockRefs the Delete below passes (i*4096).
+		// Delete drops each to 0. The reap is keyed by EXACT ID
+		// "{payloadID}/{offset}"; the offsets here match the blockRefs the
+		// Delete below passes (i*4096).
 		for i, h := range hashes {
 			coord.seedBlock(payloadID, uint64(i)*4096, h, 1)
 		}
@@ -900,14 +901,14 @@ func TestEngine_Delete_CascadesDeleteSynced(t *testing.T) {
 				t.Fatalf("IsSynced pre-Delete: %v", err)
 			}
 			if !ok {
-				t.Fatalf("hash %s not synced after Flush; cannot test cascade", h)
+				t.Fatalf("hash %s not synced after Flush; cannot test marker preservation", h)
 			}
 		}
 
 		// Build BlockRef list matching the produced hashes. Offset IS
 		// material: engine.Delete reaps by EXACT ID "{payloadID}/{offset}",
 		// and these offsets (i*4096) match the seedBlock bindings above so
-		// the by-ID reap resolves each hash and fires the cascade.
+		// the by-ID reap resolves and reaps each hash's row.
 		blockRefs := make([]block.BlockRef, 0, len(hashes))
 		for i, h := range hashes {
 			blockRefs = append(blockRefs, block.BlockRef{
@@ -921,14 +922,17 @@ func TestEngine_Delete_CascadesDeleteSynced(t *testing.T) {
 			t.Fatalf("Delete: %v", err)
 		}
 
-		// Cascade fired: synced is the empty set for these hashes.
+		// Marker preserved: the remote object still exists, so IsSynced must
+		// stay true — the steady-state GC sweep relies on (synced − live) to
+		// find this orphan and will clear the marker itself once it deletes the
+		// remote object (#1433).
 		for _, h := range hashes {
 			ok, err := synced.IsSynced(ctx, h)
 			if err != nil {
 				t.Fatalf("IsSynced post-Delete: %v", err)
 			}
-			if ok {
-				t.Errorf("hash %s still synced after Delete; cascade did not fire", h)
+			if !ok {
+				t.Errorf("hash %s no longer synced after Delete; marker must outlive unlink so GC can reclaim the remote orphan", h)
 			}
 		}
 	})


### PR DESCRIPTION
## Problem (root cause of the #1433 "S3 never shrinks" report)

Reproduced end-to-end on a VM (NFS + minio S3, `pin` share, develop). After writing a file, its chunks are uploaded and marked synced; after `rm`, the **synced markers drop to 0 while the remote objects remain**, and steady-state `dfsctl store block gc` reports `ObjectsSwept=0` — the remote space is never reclaimed.

Root cause: on delete, `engine.Delete` cleared a hash's synced marker as soon as the coordinator reaped its refcount to zero (`readwrite.go`). That cascade predates the index-based remote sweep (#1458), which derives orphan candidates from `(synced − live)`. Clearing the marker at unlink removes the **just-orphaned** hash from the candidate set, so the remote object — which still exists until GC physically deletes it — becomes invisible to the steady-state sweep and leaks on S3 forever. Only a full-Walk `--reconcile` could ever find it again (which is exactly why reconcile "worked" and startup-reconcile cleaned the bucket in testing).

## Fix

Stop clearing the synced marker on reap. The marker means "these bytes are on the remote", which stays true after the last reference is reaped. The sweep already clears the marker itself, immediately after it deletes the remote object (`sweepFromSyncedIndex` / `sweepByWalk` → `DeleteSynced`), so `synced` stays a faithful subset of remote contents:

- delete → marker kept, object on remote, hash leaves the live set → next steady-state GC sees it in `(synced − live)` past grace → deletes the object **and** the marker. ✓
- re-Put before GC → `IsSynced=true` correctly skips re-upload (bytes still remote-resident).
- re-Put after GC → marker already cleared by the sweep → re-uploads. ✓

## Test

`TestEngine_Delete_PreservesSyncedMarker` (rewrites the old `…_CascadesDeleteSynced`, which pinned the buggy behavior): asserts the marker survives reap at both refcount→0 and refcount→1, `DeleteSynced` is never invoked on unlink, the block row is still reaped, and the nil-store path still no-ops. Full `pkg/block/engine` suite green.

Note: historical objects already orphaned by the old code have no marker, so they still need a one-time `gc --reconcile` (full Walk) to clean up; this fix prevents *new* deletes from leaking. PR1 of the #1433 follow-ups (snapshot-dedup #1477, async GC #1479, slog #1475 ship separately).