### PR TITLE
fix(nfs): enable NFSv4.2 extended attributes (xattr)

### DIFF
--- a/internal/adapter/nfs/v4/attrs/encode.go
+++ b/internal/adapter/nfs/v4/attrs/encode.go
@@ -501,9 +501,15 @@ func encodeSingleAttr(buf *bytes.Buffer, bit uint32, node PseudoFSAttrSource) er
 		return EncodeBitmap4(buf, exclcreatAttrs())
 
 	case FATTR4_XATTR_SUPPORT:
-		// bool: the pseudo-fs carries no named attributes, but the attribute is
-		// advertised in SUPPORTED_ATTRS, so report false rather than erroring.
-		return xdr.WriteUint32(buf, 0) // false
+		// bool: report true so the Linux client enables NFS_CAP_XATTR for the whole
+		// mount. The client probes server xattr capability with a GETATTR on the
+		// pseudo-fs root at mount time (its FSINFO/server-capabilities call), and a
+		// false there disables xattr for every file under the mount regardless of
+		// what individual files report. The pseudo-fs is read-only, so a SETXATTR
+		// against it is rejected anyway; real files report true and serve the ops.
+		// Mirrors the CLONE_BLKSIZE case below, which also advertises a working
+		// value here even though the op itself is rejected on the pseudo-fs.
+		return xdr.WriteUint32(buf, 1) // true
 
 	case FATTR4_CLONE_BLKSIZE:
 		// uint32: CLONE alignment block size (RFC 7862 15.13). Advertised in

--- a/internal/adapter/nfs/v4/handlers/access.go
+++ b/internal/adapter/nfs/v4/handlers/access.go
@@ -13,7 +13,8 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// NFSv4 ACCESS bit constants per RFC 7530 Section 6.
+// NFSv4 ACCESS bit constants per RFC 7530 Section 6, plus the RFC 8276
+// extended-attribute bits added in NFSv4.2.
 const (
 	ACCESS4_READ    = 0x01
 	ACCESS4_LOOKUP  = 0x02
@@ -21,6 +22,16 @@ const (
 	ACCESS4_EXTEND  = 0x08
 	ACCESS4_DELETE  = 0x10
 	ACCESS4_EXECUTE = 0x20
+
+	// Extended-attribute access bits (RFC 8276 Section 5.3). The Linux NFSv4.2
+	// client probes these with an ACCESS call before issuing SETXATTR / GETXATTR
+	// / LISTXATTR; if the server does not report the relevant bit as both
+	// supported and granted, the client denies the op client-side with EACCES and
+	// never sends it on the wire. XAREAD/XALIST map to read permission, XAWRITE to
+	// write permission.
+	ACCESS4_XAREAD  = 0x40  // read a named (extended) attribute
+	ACCESS4_XAWRITE = 0x80  // create, modify, or remove a named attribute
+	ACCESS4_XALIST  = 0x100 // list named attributes
 )
 
 // handleAccess implements the ACCESS operation (RFC 7530 Section 16.1).
@@ -53,8 +64,8 @@ func (h *Handler) handleAccess(ctx *types.CompoundContext, reader io.Reader) *ty
 		// Pseudo-fs directories are always accessible: grant all requested bits
 		var buf bytes.Buffer
 		_ = xdr.WriteUint32(&buf, types.NFS4_OK)
-		_ = xdr.WriteUint32(&buf, ACCESS4_READ|ACCESS4_LOOKUP|ACCESS4_MODIFY|ACCESS4_EXTEND|ACCESS4_DELETE|ACCESS4_EXECUTE) // supported
-		_ = xdr.WriteUint32(&buf, accessReq)                                                                                // access granted
+		_ = xdr.WriteUint32(&buf, ACCESS4_READ|ACCESS4_LOOKUP|ACCESS4_MODIFY|ACCESS4_EXTEND|ACCESS4_DELETE|ACCESS4_EXECUTE|ACCESS4_XAREAD|ACCESS4_XAWRITE|ACCESS4_XALIST) // supported
+		_ = xdr.WriteUint32(&buf, accessReq)                                                                                                                              // access granted
 
 		return &types.CompoundResult{
 			Status: types.NFS4_OK,
@@ -130,9 +141,11 @@ func (h *Handler) accessRealFS(ctx *types.CompoundContext, accessReq uint32) *ty
 	// the requested ACCESS4 bits.
 	granted := permissionsToNFSAccess(grantedPerms, file.Type) & accessReq
 
-	// Report all ACCESS4 bits the server can evaluate
+	// Report all ACCESS4 bits the server can evaluate, including the RFC 8276
+	// extended-attribute bits so the NFSv4.2 client will issue xattr operations.
 	supported := uint32(ACCESS4_READ | ACCESS4_LOOKUP | ACCESS4_MODIFY |
-		ACCESS4_EXTEND | ACCESS4_DELETE | ACCESS4_EXECUTE)
+		ACCESS4_EXTEND | ACCESS4_DELETE | ACCESS4_EXECUTE |
+		ACCESS4_XAREAD | ACCESS4_XAWRITE | ACCESS4_XALIST)
 
 	// Debug log the access check result
 	var uid, gid uint32
@@ -193,6 +206,10 @@ func nfsAccessToPermissions(accessReq uint32, fileType metadata.FileType) metada
 		if accessReq&(ACCESS4_MODIFY|ACCESS4_EXTEND) != 0 {
 			perms |= metadata.PermissionWrite
 		}
+		// Reading or listing named attributes needs list access on the directory.
+		if accessReq&(ACCESS4_XAREAD|ACCESS4_XALIST) != 0 {
+			perms |= metadata.PermissionListDirectory
+		}
 	} else {
 		if accessReq&ACCESS4_READ != 0 {
 			perms |= metadata.PermissionRead
@@ -203,6 +220,16 @@ func nfsAccessToPermissions(accessReq uint32, fileType metadata.FileType) metada
 		if accessReq&ACCESS4_EXECUTE != 0 {
 			perms |= metadata.PermissionExecute
 		}
+		// Reading or listing named attributes needs read access on the file.
+		if accessReq&(ACCESS4_XAREAD|ACCESS4_XALIST) != 0 {
+			perms |= metadata.PermissionRead
+		}
+	}
+
+	// Writing (creating/modifying/removing) a named attribute needs write access
+	// on the object, for both files and directories.
+	if accessReq&ACCESS4_XAWRITE != 0 {
+		perms |= metadata.PermissionWrite
 	}
 
 	if accessReq&ACCESS4_DELETE != 0 {
@@ -227,9 +254,13 @@ func permissionsToNFSAccess(perms metadata.Permission, fileType metadata.FileTyp
 		if perms&metadata.PermissionWrite != 0 {
 			accessRes |= ACCESS4_MODIFY | ACCESS4_EXTEND
 		}
+		// List access on a directory grants reading/listing its named attributes.
+		if perms&metadata.PermissionListDirectory != 0 {
+			accessRes |= ACCESS4_XAREAD | ACCESS4_XALIST
+		}
 	} else {
 		if perms&metadata.PermissionRead != 0 {
-			accessRes |= ACCESS4_READ
+			accessRes |= ACCESS4_READ | ACCESS4_XAREAD | ACCESS4_XALIST
 		}
 		if perms&metadata.PermissionWrite != 0 {
 			accessRes |= ACCESS4_MODIFY | ACCESS4_EXTEND
@@ -237,6 +268,11 @@ func permissionsToNFSAccess(perms metadata.Permission, fileType metadata.FileTyp
 		if perms&metadata.PermissionExecute != 0 {
 			accessRes |= ACCESS4_EXECUTE
 		}
+	}
+
+	// Write access grants creating/modifying/removing named attributes.
+	if perms&metadata.PermissionWrite != 0 {
+		accessRes |= ACCESS4_XAWRITE
 	}
 
 	if perms&metadata.PermissionDelete != 0 {

--- a/internal/adapter/nfs/v4/handlers/access.go
+++ b/internal/adapter/nfs/v4/handlers/access.go
@@ -34,6 +34,13 @@ const (
 	ACCESS4_XALIST  = 0x100 // list named attributes
 )
 
+// accessSupported is every ACCESS4 bit this server can evaluate, reported in the
+// ACCESS reply's "supported" field. The "access" (granted) field is always a
+// subset of this.
+const accessSupported = uint32(ACCESS4_READ | ACCESS4_LOOKUP | ACCESS4_MODIFY |
+	ACCESS4_EXTEND | ACCESS4_DELETE | ACCESS4_EXECUTE |
+	ACCESS4_XAREAD | ACCESS4_XAWRITE | ACCESS4_XALIST)
+
 // handleAccess implements the ACCESS operation (RFC 7530 Section 16.1).
 // Checks access permissions for the current filehandle against a requested bitmask.
 // Delegates to MetadataService.CheckAccess for real files; pseudo-fs grants all access.
@@ -61,11 +68,13 @@ func (h *Handler) handleAccess(ctx *types.CompoundContext, reader io.Reader) *ty
 
 	// Check if current FH is a pseudo-fs handle
 	if pseudofs.IsPseudoFSHandle(ctx.CurrentFH) {
-		// Pseudo-fs directories are always accessible: grant all requested bits
+		// Pseudo-fs directories are always accessible: grant every supported bit
+		// the client asked for. Masking by accessSupported keeps the granted set a
+		// subset of supported even if the client sends unknown/reserved bits.
 		var buf bytes.Buffer
 		_ = xdr.WriteUint32(&buf, types.NFS4_OK)
-		_ = xdr.WriteUint32(&buf, ACCESS4_READ|ACCESS4_LOOKUP|ACCESS4_MODIFY|ACCESS4_EXTEND|ACCESS4_DELETE|ACCESS4_EXECUTE|ACCESS4_XAREAD|ACCESS4_XAWRITE|ACCESS4_XALIST) // supported
-		_ = xdr.WriteUint32(&buf, accessReq)                                                                                                                              // access granted
+		_ = xdr.WriteUint32(&buf, accessSupported)           // supported
+		_ = xdr.WriteUint32(&buf, accessReq&accessSupported) // access granted
 
 		return &types.CompoundResult{
 			Status: types.NFS4_OK,
@@ -143,9 +152,7 @@ func (h *Handler) accessRealFS(ctx *types.CompoundContext, accessReq uint32) *ty
 
 	// Report all ACCESS4 bits the server can evaluate, including the RFC 8276
 	// extended-attribute bits so the NFSv4.2 client will issue xattr operations.
-	supported := uint32(ACCESS4_READ | ACCESS4_LOOKUP | ACCESS4_MODIFY |
-		ACCESS4_EXTEND | ACCESS4_DELETE | ACCESS4_EXECUTE |
-		ACCESS4_XAREAD | ACCESS4_XAWRITE | ACCESS4_XALIST)
+	supported := accessSupported
 
 	// Debug log the access check result
 	var uid, gid uint32

--- a/internal/adapter/nfs/v4/handlers/ops_test.go
+++ b/internal/adapter/nfs/v4/handlers/ops_test.go
@@ -994,7 +994,8 @@ func TestAccess_PseudoFS(t *testing.T) {
 	ctx := newOpsTestContext()
 
 	allBits := uint32(ACCESS4_READ | ACCESS4_LOOKUP | ACCESS4_MODIFY |
-		ACCESS4_EXTEND | ACCESS4_DELETE | ACCESS4_EXECUTE)
+		ACCESS4_EXTEND | ACCESS4_DELETE | ACCESS4_EXECUTE |
+		ACCESS4_XAREAD | ACCESS4_XAWRITE | ACCESS4_XALIST)
 
 	data := encodeCompoundWithOps("", 0, []encodedOp{
 		encodePutRootFH(),

--- a/internal/adapter/nfs/v4/handlers/realfs_test.go
+++ b/internal/adapter/nfs/v4/handlers/realfs_test.go
@@ -654,7 +654,8 @@ func TestAccess_RealFS_RootGetsAll(t *testing.T) {
 	copy(ctx.CurrentFH, fileHandle)
 
 	allBits := uint32(ACCESS4_READ | ACCESS4_LOOKUP | ACCESS4_MODIFY |
-		ACCESS4_EXTEND | ACCESS4_DELETE | ACCESS4_EXECUTE)
+		ACCESS4_EXTEND | ACCESS4_DELETE | ACCESS4_EXECUTE |
+		ACCESS4_XAREAD | ACCESS4_XAWRITE | ACCESS4_XALIST)
 
 	result := fx.handler.accessRealFS(ctx, allBits)
 

--- a/test/e2e/cross_protocol_xattr_parity_test.go
+++ b/test/e2e/cross_protocol_xattr_parity_test.go
@@ -42,13 +42,16 @@ func TestCrossProtocolXattrParity(t *testing.T) {
 		helpers.WithShareDefaultPermission("read-write"))
 	require.NoError(t, err, "create share")
 
-	// SMB needs an authenticated user; NFS uses AUTH_UNIX.
-	smbUser := helpers.UniqueTestName("xpxuser")
-	const smbPass = "testpass123"
-	_, err = cli.CreateUser(smbUser, smbPass)
-	require.NoError(t, err, "create SMB user")
-	require.NoError(t, cli.GrantUserPermission(shareName, smbUser, "read-write"),
-		"grant SMB user permission")
+	// Map NFS root to UID 0 (no_root_squash) and authenticate SMB as the built-in
+	// admin (also UID 0) so both protocols act under one privileged identity.
+	// Cross-protocol *updates* require it: a file created over one protocol must be
+	// writable over the other, but default 0644 modes only grant write to the
+	// owner. Under the squash default (root_to_guest) an NFS-created file is owned
+	// by an anonymous user a distinct SMB user could not write — and vice versa.
+	_, err = cli.Run("share", "nfs-config", "set", shareName, "--squash", "root_to_admin")
+	require.NoError(t, err, "set no_root_squash on the share")
+	smbUser := "admin"
+	smbPass := helpers.GetAdminPassword()
 
 	nfsPort := helpers.FindFreePort(t)
 	smbPort := helpers.FindFreePort(t)

--- a/test/e2e/cross_protocol_xattr_parity_test.go
+++ b/test/e2e/cross_protocol_xattr_parity_test.go
@@ -49,7 +49,7 @@ func TestCrossProtocolXattrParity(t *testing.T) {
 	// owner. Under the squash default (root_to_guest) an NFS-created file is owned
 	// by an anonymous user a distinct SMB user could not write — and vice versa.
 	_, err = cli.Run("share", "nfs-config", "set", shareName, "--squash", "root_to_admin")
-	require.NoError(t, err, "set no_root_squash on the share")
+	require.NoError(t, err, "map NFS root to admin (UID 0) on the share")
 	smbUser := "admin"
 	smbPass := helpers.GetAdminPassword()
 


### PR DESCRIPTION
## Summary

NFSv4.2 extended attributes (`setfattr`/`getfattr`) failed against DittoFS — the kernel returned `Operation not supported` and never sent any xattr op. Root-caused on a real Linux 5.15 NFSv4.2 client with `tshark` (wire decode) + `bpftrace` (kernel cap inspection). There were **two independent bugs**, both fixed here.

### Bug 1 — pseudo-fs advertised `FATTR4_XATTR_SUPPORT = false`
The Linux client runs its server-capabilities `GETATTR` probe on the **pseudo-fs root** (`pseudofs:/`) at mount time and caches `NFS_CAP_XATTR` for the *whole mount* from that single response. Reporting `false` there disabled xattr for every file under the mount, regardless of what real files advertised.

`bpftrace` on `_nfs4_server_capabilities` confirmed the cap (`NFS_CAP_XATTR = 1<<28`) flipped from unset → set (`caps 0xaffbc03f → 0xbffbc03f`) once the pseudo-fs value was corrected to `true`. The pseudo-fs is read-only, so a `SETXATTR` against it is still rejected with `NFS4ERR_ROFS`.

### Bug 2 — ACCESS op omitted the RFC 8276 xattr access bits
After Bug 1, the error changed to `Permission denied`. The client runs an `ACCESS` check for `ACCESS4_XAWRITE` (`0x80`) *before* issuing `SETXATTR`; DittoFS never reported `XAREAD`/`XAWRITE`/`XALIST` in either `supported` or `access`, so the client denied the op client-side (`EACCES`) and never sent it. Wire trace: `ACCESS reply [NOT Supported: XAR XAW XAL]`; `bpftrace`: `nfs4_xattr_set_nfs4_user ret=-13`.

Fix: add the three constants, include them in the `supported` mask (real + pseudo-fs branches), and map `XAREAD`/`XALIST` → read and `XAWRITE` → write through the existing `nfsAccessToPermissions` / `permissionsToNFSAccess` translation — so xattr permission enforcement is identical to every other ACCESS path. Actual xattr ops already enforce read/write permission server-side in `pkg/metadata/xattr_service.go`, independent of ACCESS.

## Test changes
- `ops_test.go` / `realfs_test.go`: bump the expected `supported` mask to include the new bits.
- `cross_protocol_xattr_parity_test.go` (XPX-03): align NFS squash (`root_to_admin`) with the SMB admin identity so an NFS-created file is writable over SMB — same pattern as the merged #1496. This was a test-identity mismatch, not a product bug.

## Validation (real Linux 5.15 NFSv4.2)
- `TestNFSv42XattrRoundTrip`, `TestNFSv42XattrPersistAcrossRestart`, `TestCrossProtocolXattrParity` — all pass.
- All `internal/adapter/nfs/...` unit suites pass; `go vet` clean.
- NFSv4 basic + ACL e2e pass (no ACCESS regression).
- code-reviewer: no high-confidence issues; confirmed the mapping cannot over-grant and server-side enforcement is independent.

Closes #1485