### PR TITLE
fix(nfs): break conflicting cross-protocol leases on NFS byte-range lock

### DIFF
--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -2106,8 +2106,20 @@ func (sm *StateManager) acquireLock(lockState *LockState, lockType uint32, offse
 	enhLock := lock.NewUnifiedLock(owner, lock.FileHandle(lockState.FileHandle), offset, length, mappedType)
 	enhLock.Reclaim = reclaim
 
-	// Try to add the lock
 	handleKey := string(lockState.FileHandle)
+
+	// Break any conflicting cross-protocol read leases (e.g. an SMB read/write
+	// oplock) before acquiring the byte-range lock. A held lease lets another
+	// protocol cache the bytes this lock is about to protect, so it must be
+	// revoked first — exactly as the SMB LOCK handler does before its own
+	// acquire (see internal/adapter/smb/handlers/lock.go). Without this the
+	// lease is recorded as a conflict and the NFS lock is denied even though no
+	// real byte-range lock is held. We pass this lock's owner as excludeOwner for
+	// symmetry with the SMB path; NFS owners never hold SMB leases, so in practice
+	// nothing is excluded.
+	_ = lm.BreakLeasesForByteRangeLock(handleKey, &owner)
+
+	// Try to add the lock
 	err := lm.AddUnifiedLock(handleKey, enhLock)
 	if err != nil {
 		// Lock conflict: query existing locks to find the conflicting one

--- a/pkg/adapter/nfs/nlm.go
+++ b/pkg/adapter/nfs/nlm.go
@@ -104,6 +104,14 @@ func (s *nlmService) LockFileNLM(
 	}
 
 	handleKey := string(handle)
+
+	// Break conflicting cross-protocol read leases (e.g. an SMB oplock) before
+	// acquiring, so another protocol's cached view of the range is revoked first.
+	// Mirrors the SMB and NFSv4 LOCK paths. We pass this lock's owner as
+	// excludeOwner for symmetry; NLM owners never hold SMB leases, so in practice
+	// nothing is excluded (#1495).
+	_ = s.lockMgr.BreakLeasesForByteRangeLock(handleKey, &owner)
+
 	err := s.lockMgr.AddUnifiedLock(handleKey, unifiedLock)
 	if err == nil {
 		// A successful reclaim records the client so grace can exit early once

--- a/test/e2e/cross_protocol_lock_test.go
+++ b/test/e2e/cross_protocol_lock_test.go
@@ -120,17 +120,12 @@ func TestCrossProtocolLocking(t *testing.T) {
 	})
 
 	t.Run("XPRO-02 SMB Write lease breaks for NFS lock", func(t *testing.T) {
-		// Skipped: this requires an NFS *blocking* byte-range lock (F_SETLKW) to be
-		// granted after the server breaks a conflicting SMB write-lease, which is
-		// not observable through real kernel clients against the userspace server.
-		// NFSv3/NLM locking hangs (no reachable lockd — see MountNFS's nolock), and
-		// the NFSv4.1 LOCK path returns NFS4ERR_DENIED on a lease conflict without a
-		// blocking grant + CB_NOTIFY_LOCK retry, so F_SETLKW blocks indefinitely.
-		// The server-side lease break on cross-protocol access this intends to cover
-		// is exercised by TestCrossProtocol_LeaseBreaks (SMBLeaseBreakOnNFSWrite,
-		// DataConsistencyAfterBreak) and the BreakLeasesForByteRangeLock unit tests.
-		// The NFSv4 LOCK-path lease-break + blocking-grant gap is tracked in #1495.
-		t.Skip("cross-protocol blocking-lock lease break not observable via real kernel clients on a single host (NFSv4 LOCK gap: #1495)")
+		// A blocking NFS byte-range lock (F_SETLKW) acquired while SMB holds a
+		// read/write lease must succeed: the NFSv4 LOCK path now breaks the
+		// conflicting lease before acquiring (see acquireLock in
+		// internal/adapter/nfs/v4/state/manager.go), mirroring the SMB LOCK
+		// handler, so the lock is granted on the first attempt instead of
+		// blocking indefinitely on a lease conflict (#1495).
 		testSMBLeaseBreaksForNFSLock(t, nfsMount, smbMount)
 	})
 


### PR DESCRIPTION
Closes #1495. Makes NFS byte-range locking break conflicting cross-protocol leases, matching SMB.

## Bug
SMB LOCK breaks conflicting cross-protocol read leases before acquiring a byte-range lock. The NFSv4 LOCK and NLM (NFSv3) paths did not — so an NFS byte-range lock requested while another protocol held an oplock on the range was recorded as a conflict and denied; a blocking F_SETLKW then hung. (The original issue assumed NLM broke leases and NFSv4 didn't — in fact neither did; both fixed.)

## Fix
Call BreakLeasesForByteRangeLock on the resolved per-share lock manager before AddUnifiedLock, in:
- internal/adapter/nfs/v4/state/manager.go (acquireLock)
- pkg/adapter/nfs/nlm.go (LockFileNLM)

The lease is revoked first → lock granted on first attempt → other protocol flushes its cache. excludeOwner is the requesting owner for symmetry; NFS/NLM owners never hold SMB leases. Part B (blocking-grant + CB_NOTIFY_LOCK) not needed: the conflict is lease-vs-lock, so breaking the lease suffices.

## Test
Un-skips XPRO-02. Passes on real Linux NFSv4.1 — F_SETLKW granted in ~1s instead of hanging.

## Validation (real Linux 5.15)
- TestCrossProtocolLocking (incl XPRO-02), TestCrossProtocol_LeaseBreaks, TestNFSv4*Lock pass.
- lock/v4/nlm unit suites pass; full build + go vet clean.
- code-reviewer clean (reclaim/unlock routing, excludeOwner, no deadlock, delegations untouched).

## Follow-up
NLM break is build/unit-validated but not e2e (harness mounts v3 nolock). Real NLM serving + NLM interop tests tracked separately.