### PR TITLE
feat(block): PR1 — slim RemoteBlockStore interface + block codec (#1493)

### DIFF
--- a/.planning/2026-06-30-1493-blocks-only-roadmap.md
+++ b/.planning/2026-06-30-1493-blocks-only-roadmap.md
@@ -12,6 +12,32 @@ Locked decisions (2026-06-30):
   metadata store is the one durable place already in the share's transaction domain.
 - **Migration:** automatic, **blocking at startup**, resumable/idempotent.
 - **PR1 backends:** S3 + memory + filesystem-remote all implement the new interface.
+- **Refactor in place, no additive parallel types.** Existing functions/structs/interfaces
+  are reshaped to the new model and renamed — we do NOT leave the old CAS/additive surface
+  beside the new one. Each PR refactors the surface in its blast radius; PR4 does the final
+  sweep. (Per minimize-interface-surface + no-compat-shims.)
+- **Docs updated per PR.** Every PR updates the docs it touches (`docs/internals/
+  implementing-stores.md`, `architecture.md`, `docs/guide/*`); PR4 does the final docs pass.
+
+## Naming model (fix everywhere)
+
+The current names collide: `FileBlock` / `BlockRef` / `BlockState` / `ObjectID` actually
+describe **chunks**, while the new model reserves **Block** for the packed remote container.
+Normalize so "Block" means only the container:
+
+| Current (means chunk) | New | Notes |
+|---|---|---|
+| `FileBlock` (row `{payloadID}/{offset}`) | `FileChunk` / chunk row | per-chunk metadata row |
+| `BlockRef{Hash,Offset,Size}` | `ChunkRef` | chunk locator within a file |
+| `BlockState` (Pending/Syncing/Remote) | `ChunkSyncState` | per-chunk sync state |
+| `RemoteStore` (CAS, hash-keyed) | `RemoteBlockStore` (BlockID-keyed) | slim block interface |
+| `ChunkReader.ReadChunk` (additive) | folded into `GetBlockRange` + decode | remove additive surface |
+| `ChunkLocator{Offset,Length}` | `ChunkLocator{WireOffset,WireLength}` | drop `IsStandalone`/standalone |
+| `ObjectID` (Merkle root) | reassess — keep only if still load-bearing | |
+
+New names with no collision today: **Block** (packed container, `BlockID`), **block record**
+(`BlockID → {blockHash, length, liveChunkCount, syncState}`), **log blob** (`logBlobID`),
+**local index** (`hash → {logBlobID, rawOffset, rawLength}`).
 
 ---
 
@@ -30,7 +56,12 @@ Pure new code. No wiring into the live path. Fully unit-tested.
 - Conformance: new `blockstoretest` block-interface suite + codec round-trip
   (encrypted/plaintext, incompressible input, range reads, blake3 verify).
 
-DoD: interface + codec + 3 backends + conformance green. Nothing else touched.
+- Refactor/naming in this PR's blast radius: rename `RemoteStore`→`RemoteBlockStore`,
+  reshape `ChunkLocator` fields to `WireOffset`/`WireLength`, begin folding the additive
+  `ChunkReader.ReadChunk` into `GetBlockRange`+decode. Update `docs/internals/
+  implementing-stores.md` for the new block-store contract.
+
+DoD: interface + codec + 3 backends + conformance green; touched surface renamed; docs current.
 
 ## PR2 — Persistence layer: local log-blob tier + metadata block records
 
@@ -79,9 +110,13 @@ green. Legacy CAS reader present only for back-compat reads.
   `FormatCASKey`/`ParseCASKey`, the `cas/` walk + keying, `ReadBlockVerified`'s standalone
   use, per-chunk local CAS storage remnants, dead config knobs/tests/interfaces.
 - Leave no vestigial interfaces (minimize-interface-surface rule).
+- **Final naming sweep** (`FileBlock`→`FileChunk`, `BlockRef`→`ChunkRef`,
+  `BlockState`→`ChunkSyncState`, etc. — anything not already renamed in PR1–3) and **final
+  docs pass** across `docs/internals/` + `docs/guide/`, then regenerate `docs/guide/cli.md`
+  via `go run ./cmd/gendocs` if any command/flag changed.
 
 DoD: migration converts a `cas/<hash>` fixture byte-identically + resumable; no standalone
-code remains (`grep` clean); full suite + e2e green.
+code remains (`grep` clean); naming model fully applied; docs current; full suite + e2e green.
 
 ---
 

--- a/.planning/2026-06-30-1493-blocks-only-roadmap.md
+++ b/.planning/2026-06-30-1493-blocks-only-roadmap.md
@@ -1,0 +1,98 @@
+# Blocks-Only Storage — Implementation Roadmap (#1493)
+
+**Branch:** `1493-blocks-only-storage` (off `develop`).
+**Design:** `.planning/2026-06-30-blocks-only-storage-design.md` (approved).
+**Split:** 4 PRs. Each keeps `develop` green and is independently reviewable.
+
+Locked decisions (2026-06-30):
+- **PR count:** 4 (folded from the 6-component design).
+- **Local index** (`hash → {logBlobID, rawOffset, rawLength}`): lives **in the metadata
+  store**, alongside the existing `FileBlock` rows + `SyncedHashStore` — not a separate
+  local KV. Raw log blobs carry no per-chunk framing, so the index must be persisted; the
+  metadata store is the one durable place already in the share's transaction domain.
+- **Migration:** automatic, **blocking at startup**, resumable/idempotent.
+- **PR1 backends:** S3 + memory + filesystem-remote all implement the new interface.
+
+---
+
+## PR1 — Foundation: remote block interface + codec + backends
+
+Pure new code. No wiring into the live path. Fully unit-tested.
+
+- Slim `RemoteBlockStore` interface: `PutBlock(ctx, blockID, r)` (only writer),
+  `GetBlock(ctx, blockID)`, `GetBlockRange(ctx, blockID, off, len)`,
+  `DeleteBlock(ctx, blockID)`, `Walk(ctx, blocks/…)`.
+- Block codec: streaming build `[preamble][record{hash,length} + enc(comp(chunk))]…`;
+  range-resolve from a locator; sequential record parse for DR. Per-chunk transform reuses
+  the existing compression/encryption decorators. Record sub-headers AEAD-framed on
+  encrypted shares; plaintext otherwise.
+- Backends implementing the interface: **S3, memory, filesystem-remote**.
+- Conformance: new `blockstoretest` block-interface suite + codec round-trip
+  (encrypted/plaintext, incompressible input, range reads, blake3 verify).
+
+DoD: interface + codec + 3 backends + conformance green. Nothing else touched.
+
+## PR2 — Persistence layer: local log-blob tier + metadata block records
+
+The durable substrate. New code; old standalone path still the default writer.
+
+- Local tier (`pkg/block/local/fs`): replace per-chunk CAS files with RocksDB-style
+  **log blobs** — append-at-tail (`pwrite`), concurrent `pread` carve, ~1 GB rotation,
+  whole-blob eviction, torn-tail recovery (truncate to last validated chunk).
+- **Local index in metadata:** `hash → {logBlobID, rawOffset, rawLength}` rows.
+- Metadata locator: `SyncedHashStore` → `hash → {BlockID, wireOffset, wireLength}`.
+- Metadata **block record:** `BlockID → {blockHash, length, liveChunkCount, syncState}`.
+- **Single-transaction per-block commit** of all of a block's chunk locators + its block
+  record (delivers #1416 — one fsync per block, not per file).
+- Conformance: `storetest` (block-record + locator + batched commit) and
+  `blockstoretest` append/log-blob behavior.
+
+DoD: log-blob local tier + metadata schema + atomic per-block commit, conformance green.
+
+## PR3 — Sync engine + read path (the behavioral flip)
+
+New shares now write blocks. Legacy CAS reader is kept, quarantined, for un-migrated data
+(removed in PR4).
+
+- Sync engine: real-time **carve** (block-size ~16 MiB or 5s idle), `pread` the carved
+  region, stream transform+frame into `PutBlock`, then the atomic locator+block-record
+  write. Crash after `PutBlock` before the locator write → chunks stay unsynced, re-carved
+  into a fresh block (idempotent on `blockID`).
+- Read path: local-index hit → raw blob, zero decode; miss → `GetBlockRange` via locator →
+  decode → `blake3(plaintext)==hash` verify (fail-closed).
+- **GC (delete-only):** `liveChunkCount` decremented on refcount-0 cascade; at 0, delete
+  block (local + remote) + drop record. No scan.
+- **Corruption/self-heal:** `blake3(block)==blockHash` on fetch (checksum-in-parent);
+  local mismatch → refetch block from remote, re-verify, re-stage; remote mismatch →
+  fail-closed + metric/alert.
+- Retire old rollup→standalone-mirror (`mirrorChunk` + standalone `MarkSynced`).
+
+DoD: blocks-only write+read for new shares, GC + corruption handling, conformance + e2e
+green. Legacy CAS reader present only for back-compat reads.
+
+## PR4 — Migration + legacy cleanup (definition of done)
+
+- **Migration:** automatic, blocking at startup, resumable/idempotent. Detect `cas/<hash>`
+  (local + remote), re-pack into blocks, rewrite locators in one pass, delete old objects.
+  Legacy standalone reader lives only inside this routine.
+- **Delete the standalone/CAS path end to end:** `RemoteStore.Put/Get/GetRange`-by-hash,
+  `FormatCASKey`/`ParseCASKey`, the `cas/` walk + keying, `ReadBlockVerified`'s standalone
+  use, per-chunk local CAS storage remnants, dead config knobs/tests/interfaces.
+- Leave no vestigial interfaces (minimize-interface-surface rule).
+
+DoD: migration converts a `cas/<hash>` fixture byte-identically + resumable; no standalone
+code remains (`grep` clean); full suite + e2e green.
+
+---
+
+## Out of scope (deferred follow-up issues)
+
+#1487 GC compaction · #1488 chunk-range refetch · #1489 remote manifests (namespace DR) ·
+#1490 background scrubber · #1491 decoupled log-blob/block sizing · #1492 group-commit fsync.
+
+## Discarded
+
+The in-flight `1414-pr3b` additive commits (`BlockWriter` / `ChunkTransformer` /
+`MarkSyncedBatch`, S3/memory pass-through `PutBlock`) are **not** cherry-picked — they
+assume the additive two-object-kind model this design supersedes (notably `Put`-by-hash,
+which the slim interface removes). Re-derived from scratch per this roadmap.

--- a/.planning/2026-06-30-1493-pr1-plan.md
+++ b/.planning/2026-06-30-1493-pr1-plan.md
@@ -138,7 +138,9 @@ type RemoteBlockStore interface {
 }
 ```
 
-- Implement on **memory**, **s3**, **fs-remote** backends. Keys via `block.FormatBlockKey`.
+- Implement on the **memory** and **s3** backends (the only remote backends — the old
+  fs-remote was folded into the local tier/FSStore in v0.15; the local filesystem store is
+  PR2's log-blob tier, not a remote backend). Keys via `block.FormatBlockKey`.
 - `PutBlock` streams `r` (S3: streaming/multipart as the existing CAS `Put` does); idempotent
   on `blockID`.
 - `GetBlockRange` issues a ranged GET (S3 `Range:` header; memory/fs slice).
@@ -162,7 +164,7 @@ Add `blockstoretest.RemoteBlockStoreConformance(t, factory)` covering the Task-3
 put+walk, zero-byte body). Wire memory + s3 + fs-remote factories to it.
 
 DoD: conformance green for all wired backends; mirrors the existing `BlockStoreConformance`
-structure in `pkg/block/blockstoretest/`.
+structure in `pkg/block/blockstoretest/`. Wire memory + s3 factories (no fs-remote — see Task 3).
 
 ---
 

--- a/.planning/2026-06-30-1493-pr1-plan.md
+++ b/.planning/2026-06-30-1493-pr1-plan.md
@@ -1,0 +1,173 @@
+# PR1 Plan — Foundation: block codec + slim block-store interface + backends
+
+Epic: #1493. Roadmap: `.planning/2026-06-30-1493-blocks-only-roadmap.md`.
+Design: `.planning/2026-06-30-blocks-only-storage-design.md`.
+Branch: `1493-blocks-only-storage` (off develop). Module: `github.com/marmos91/dittofs`.
+
+## Global constraints (bind every task)
+
+- **TDD**: failing test first, watched fail, minimal code to pass. No production code
+  without a failing test.
+- **Additive at the live path**: PR1 does NOT change runtime behavior. The existing CAS
+  path (`RemoteStore.Put/Get/GetRange`-by-hash, standalone reads) stays live and untouched;
+  PR4 deletes it. New block methods/codec are added beside it, exercised only by tests.
+- **Do not rename doomed code** (CAS `RemoteStore`, `FormatCASKey`, standalone path) — it is
+  deleted in PR4, not renamed. PR1 renames only surviving types it touches (`ChunkLocator`).
+- **Signed commits** (`git commit -S`). Conventional commits, concise, no AI mentions.
+- **Sign-off gate per task**: `go build ./... && go vet ./... && gofmt -l pkg/block` clean +
+  the task's tests green.
+- Match existing package conventions (errors via `pkg/block/errors.go` sentinels; hashing via
+  existing BLAKE3 helpers; transform via `pkg/block/compression` + `pkg/block/encryption`).
+
+## Vocabulary (this PR)
+
+- **Block** = packed remote container, addressed by `BlockID` (string). Key =
+  `block.FormatBlockKey(blockID)` → `blocks/<…>` (already exists).
+- **Chunk** = FastCDC/BLAKE3 unit; its transformed *wire bytes* live inside a block.
+- **`ChunkLocator{BlockID, WireOffset, WireLength}`** — resolves a chunk's wire bytes inside
+  a block (renamed from `{Offset, Length}` this PR).
+
+---
+
+## Task 1 — Block codec (`pkg/block/blockcodec`, new package)
+
+Pure, self-contained, no dependency on the rename or backends. **Do this first** — it pins
+the wire format.
+
+### Wire format (v1)
+
+```
+Block = [ preamble ][ record_0 ][ record_1 ] … [ record_{N-1} ]   (records run to EOF)
+
+preamble:
+  magic      [4]byte = {'D','F','B','1'}
+  flags      uint8            // bit0 = 1 → record headers are AEAD-sealed (encrypted share)
+  blockID    uvarint(len) + len bytes (UTF-8)
+
+record (plaintext, flags bit0 = 0):
+  hash       [32]byte         // chunk BLAKE3 (plaintext-domain content hash)
+  wireLen    uvarint
+  wire       [wireLen]byte    // enc(comp(chunk)) — already-transformed, independently decodable
+
+record (sealed, flags bit0 = 1):
+  sealedHdrLen uvarint
+  sealedHdr    [sealedHdrLen]byte   // AEAD seal of {hash[32], wireLen uvarint}; AAD = blockID||recordIndex
+  wire         [wireLen]byte        // wireLen recovered by opening sealedHdr
+```
+
+The per-chunk **`wire`** body is supplied already-transformed by the caller (the codec does
+not compress/encrypt chunk bodies — that is the existing transform chain's job). The codec
+only frames records and, on encrypted shares, seals the `{hash,wireLen}` sub-header.
+
+### API
+
+```go
+package blockcodec
+
+// Sealer seals/opens record sub-headers on encrypted shares. nil ⇒ plaintext framing.
+type Sealer interface {
+    Seal(plaintextHdr, aad []byte) ([]byte, error)
+    Open(sealedHdr, aad []byte) ([]byte, error)
+}
+
+// Builder streams one block to w. Bodies are never all held in RAM.
+type Builder struct { /* … */ }
+
+// NewBuilder writes the preamble immediately and returns a streaming builder.
+// sealer == nil ⇒ plaintext records.
+func NewBuilder(w io.Writer, blockID string, sealer Sealer) (*Builder, error)
+
+// Add frames one record (header + body) and returns the chunk's locator. wireOffset/
+// wireLength point at the body region within the block as written so far.
+func (b *Builder) Add(hash block.ContentHash, wire []byte) (block.ChunkLocator, error)
+
+// Finish flushes/validates the block. Returns total bytes written.
+func (b *Builder) Finish() (int64, error)
+
+// Record is one parsed record (disaster-recovery / index-rebuild path).
+type Record struct {
+    Hash       block.ContentHash
+    WireOffset int64
+    WireLength int64
+}
+
+// Parse reads a whole block (sealer to open headers on encrypted shares; nil ⇒ plaintext)
+// and returns the block ID and the record index, for rebuilding hash → locator.
+func Parse(block []byte, sealer Sealer) (blockID string, records []Record, err error)
+```
+
+### Tests (TDD order)
+
+1. Plaintext round-trip: build 2 chunks → `Parse` → records' hashes match; each returned
+   locator's `WireOffset/WireLength` slice the block to exactly that chunk's `wire` bytes.
+2. Empty/zero-length chunk body framed and parsed.
+3. Single chunk larger than any block target (one-chunk block) round-trips.
+4. Sealed round-trip with a test `Sealer` (e.g. XOR/identity-AEAD fake): headers opaque in
+   the raw block bytes; `Parse` with the sealer recovers hashes + locators; bodies at the
+   plaintext-visible `WireOffset/WireLength`.
+5. Truncated/garbled block → `Parse` returns a structural error (not a panic).
+6. `flags`/`magic` mismatch → error.
+
+DoD: `go test ./pkg/block/blockcodec/...` green; format precisely as above.
+
+---
+
+## Task 2 — `ChunkLocator` field rename (surviving type)
+
+Rename `ChunkLocator.Offset`→`WireOffset`, `Length`→`WireLength` across `pkg/block` and all
+callers (engine, remote decorators, tests). **Keep `BlockID` and `IsStandalone`** (the live
+standalone path still uses them; removed in PR4). Update field doc comments to "wire bytes".
+
+DoD: `go build ./... && go test ./pkg/block/... ./pkg/controlplane/...` green; `gofmt` clean.
+
+---
+
+## Task 3 — Slim block-store methods on backends + interface
+
+Add the block-keyed write/read/delete surface to the remote backends, beside the existing
+CAS methods (do not remove CAS yet).
+
+```go
+// In pkg/block/remote (new slim interface; backends also satisfy the existing RemoteStore).
+type RemoteBlockStore interface {
+    PutBlock(ctx context.Context, blockID string, r io.Reader) error            // only writer
+    GetBlock(ctx context.Context, blockID string) ([]byte, error)              // whole
+    GetBlockRange(ctx context.Context, blockID string, off, length int64) ([]byte, error)
+    DeleteBlock(ctx context.Context, blockID string) error
+    WalkBlocks(ctx context.Context, fn func(blockID string, meta block.Meta) error) error
+}
+```
+
+- Implement on **memory**, **s3**, **fs-remote** backends. Keys via `block.FormatBlockKey`.
+- `PutBlock` streams `r` (S3: streaming/multipart as the existing CAS `Put` does); idempotent
+  on `blockID`.
+- `GetBlockRange` issues a ranged GET (S3 `Range:` header; memory/fs slice).
+- The existing develop `memory.PutBlock(blockID string, data []byte)` test helper is replaced
+  by the streaming `io.Reader` signature.
+
+### Tests
+- Per backend: PutBlock→GetBlock round-trip; GetBlockRange bounds (mid, past-EOF clamped,
+  invalid); DeleteBlock; WalkBlocks enumerates; PutBlock idempotent + concurrent-same-id.
+- Use the existing memory backend for fast coverage; s3 against the existing s3 test harness
+  (localstack/minio if the repo already has one — else memory + fs only, note the gap).
+
+DoD: backend tests green; `RemoteBlockStore` satisfied by all three (compile-time assert).
+
+---
+
+## Task 4 — Block-store conformance suite
+
+Add `blockstoretest.RemoteBlockStoreConformance(t, factory)` covering the Task-3 contract
+(round-trip, range bounds, delete durability, walk completeness, idempotency, concurrent
+put+walk, zero-byte body). Wire memory + s3 + fs-remote factories to it.
+
+DoD: conformance green for all wired backends; mirrors the existing `BlockStoreConformance`
+structure in `pkg/block/blockstoretest/`.
+
+---
+
+## Docs (this PR)
+
+Update `docs/internals/implementing-stores.md`: document the `RemoteBlockStore` contract and
+the block codec format; note the CAS path is being retired (link the epic). Do NOT touch
+generated `docs/guide/cli.md` (no command/flag change in PR1).

--- a/.planning/2026-06-30-blocks-only-storage-design.md
+++ b/.planning/2026-06-30-blocks-only-storage-design.md
@@ -113,41 +113,6 @@ record_i = { hash, length }  +  chunk wire bytes
   Full file-namespace recovery (which file is composed of which chunks) is **out of
   scope** here and will be addressed later via remote **manifest files** (deferred issue).
 
-## Read path
-
-A read is **local-first, remote on miss, then read-ahead** — cheap when data is resident,
-low-latency-first-byte when it isn't, and self-warming for the common sequential case.
-
-1. **Local-first.** When NFS/SMB asks to read bytes, DittoFS maps the file offset to the
-   chunk(s) it needs and reads them **from the local append log at the right offset** (via
-   the local index `hash → {logBlobID, rawOffset, rawLength}`). If resident → serve raw
-   plaintext directly (`pread`, **zero decode, no network**) — the hot path, and the common
-   case for recently-written or already-cached data.
-2. **Remote on miss.** If a chunk is not resident (evicted, or never local), fetch it from
-   the remote block store: `GetBlockRange(BlockID, wireOffset, wireLength)` for just the
-   bytes needed to satisfy the request, decode (decrypt/decompress), verify
-   `blake3(plaintext) == hash` (fail-closed), serve. Fetching the exact range gives a **fast
-   first byte** without waiting on a whole block.
-3. **Read-ahead (a miss predicts more reads).** A miss strongly implies the client will keep
-   reading, so after serving the immediate range DittoFS speculatively downloads the **whole
-   enclosing block** — and, under sustained sequential access, **several subsequent blocks**
-   — in the background, re-staging them into a local log blob so following reads become local
-   hits. Prefetch depth **adapts** to the access pattern: it ramps up on sequential streams
-   and stays minimal on random access (where whole-block prefetch is wasteful — the
-   random-read lever is chunk-range-only refetch, #1488).
-
-**Efficiency properties:**
-- **Write-order contiguity → coalesced reads.** Chunks are appended in write order and
-  carved into blocks in that order, so a file's chunks (written contiguously between
-  commit/close) usually sit **contiguous within one block**. A sequential read then maps to
-  a contiguous wire range served by a **single `GetBlockRange`** spanning many chunks — not
-  one GET per chunk. Adjacent same-block locators are coalesced; dedup / concurrent-writer
-  interleaving can scatter chunks, and the path falls back to per-locator fetches.
-- **Indirection cost** is one metadata locator lookup per non-resident chunk (cached,
-  batchable); resident reads never touch metadata or the network.
-- **Verification cost** is one BLAKE3 over each chunk's plaintext on cold reads; resident
-  reads skip it (verified when the bytes entered the local tier).
-
 ## Components
 
 1. **Remote block store interface (slimmed).**
@@ -165,17 +130,8 @@ low-latency-first-byte when it isn't, and self-warming for the common sequential
    (RocksDB-style: append at the tail, read earlier offsets concurrently). No block files,
    no per-chunk CAS files. The local store keeps its own index `hash → {logBlobID,
    rawOffset, rawLength}` and serves local reads straight from the blob (zero decode).
-   The local tier is a **hot cache**, not a permanent home — it serves two roles at once:
-   **write-staging** (durability for not-yet-synced data) and **read acceleration** (hot
-   data served locally). A configurable **`MaxLocalStoreSize`** high-water mark triggers
-   eviction: when local usage crosses it, evict **cold, fully-synced** data (LRU) down to a
-   low-water mark, keeping hot data resident to speed reads; **unsynced data is never
-   evicted** (it is the only copy). v1 evicts whole fully-synced blobs; because a ~1 GB blob
-   can mix synced/cold (evictable) with unsynced/hot (must-keep) chunks, fine-grained reclaim
-   needs **local blob compaction** — rewrite a blob's survivors (unsynced + hot) into a fresh
-   blob and free the rest — tracked as #1497. On a later read of an evicted chunk, GET its
-   (whole) remote block, decode, verify, and re-stage locally — read-ahead warms the cache
-   for sequential follow-on reads.
+   Eviction drops **whole synced log blobs** to reclaim disk; on a later read of an evicted
+   chunk, GET its (whole) remote block, decode, verify, and re-stage into a fresh log blob.
 
 4. **Metadata.** Per-chunk surface unchanged: `chunk hash → {BlockID, Offset, Length}`;
    dedup short-circuit before a chunk is stored (known hash → refcount bump only); refcount
@@ -214,21 +170,8 @@ low-latency-first-byte when it isn't, and self-warming for the common sequential
 - **Block-carve idle timeout:** 5s. Carve+upload a sub-`BlockSize` block when no new
   chunks arrive. Gates only **upload latency**, not durability — a chunk is durable in the
   (fsynced) log blob the instant it's written, well before carve.
-- **`MaxBlobSize`** (config): max **local** log-blob size before rotating to a new blob;
-  **default 1 GB**. Bounds file size + corruption blast radius. (RocksDB defaults are smaller
-  — SST `target_file_size_base` 64 MB, BlobDB `blob_file_size` 256 MB; a larger blob means
-  fewer files + better sequential append but coarser eviction, hence local compaction #1497.)
-- **`MaxLocalStoreSize`** (config): high-water mark for the local hot cache; crossing it
-  triggers synced-only LRU eviction (+ compaction #1497) down to a low-water mark. Unsynced
-  data is never evictable.
-- **Size hierarchy (do not conflate):** local **blob** ~1 GB (`MaxBlobSize`) is a large
-  on-disk append file; remote **block** ~16 MiB default (`TargetBlockSize`) is carved from it.
-  At the default a remote object is a single S3 PUT. **`TargetBlockSize` is configurable**, so
-  the S3 store uses **multipart upload** for large blocks — beneficial above a part-size
-  threshold and **mandatory above S3's 5 GB single-PUT limit** (e.g. a 256 MB or larger block
-  size). `GetBlockRange` is unaffected — a ranged GET works regardless of how the object was
-  PUT. Multipart also improves resilience: a failed upload **retries only the failed part**
-  (not the whole block), and parts upload in parallel.
+- **LogBlobSizeCap:** ~1 GB (rotate to a new blob at the cap, or on long idle). Bounds
+  file size and corruption blast radius.
 
 ## Performance & footprint requirements (now)
 
@@ -314,32 +257,6 @@ existing data). Leftover standalone-path code is a bug, not acceptable dead code
   `MarkSyncedBatch`) — re-implement against this design on the new branch.
 - Grep for and delete now-dead helpers, tests, and config knobs tied to the standalone
   path; leave no vestigial interfaces (per the minimize-interface-surface rule).
-
-## Performance & efficiency levers (state of the art, future)
-
-Candidate techniques beyond v1, ordered by leverage. Adopt behind clean seams; do not add to
-the hot path without a measured win (keep v1 simple).
-
-- **Smarter cache policy than LRU** (eviction / #1497 area): **W-TinyLFU** or **ARC** beat
-  plain LRU hit-rate, directly speeding reads. Keep the eviction policy behind an interface so
-  it can be swapped.
-- **Bloom / ribbon filter on the chunk-hash index** (P3 area): a fast "definitely-new chunk"
-  test skips a metadata lookup for unique chunks on the write path (classic LSM technique).
-- **Trained zstd dictionaries for small chunks** (codec / P1 area): a shared per-share/per-
-  block dictionary greatly improves compression ratio for many small similar files — directly
-  the #1414 motivation. Per-chunk framing stays; the dictionary is a codec parameter.
-- **Adaptive / strided prefetch:** detect access stride and tune read-ahead depth instead of a
-  fixed depth.
-- **Async local I/O (io_uring / vectored):** higher-throughput, lower-overhead local blob I/O
-  on Linux; platform-gated.
-- **S3 read hedging:** duplicate a lagging GET to cut tail latency.
-- **Merkle tree over block hashes — #1498:** interior nodes up to a per-share root enable
-  cheap local↔remote anti-entropy (scrubber #1490), tamper-evident manifests (#1489), and
-  future replication (compare roots, descend only on divergence). Off the hot path.
-
-Explicitly **skipped** (complexity not justified pre-1.0 / single-node): learned indexes,
-similarity/delta dedup, sparse dedup indexing (until the index outgrows RAM), client-side
-erasure coding (the object store already provides redundancy).
 
 ## Deferred — future work (tracked as issues)
 

--- a/docs/internals/implementing-stores.md
+++ b/docs/internals/implementing-stores.md
@@ -10,10 +10,11 @@ This guide provides comprehensive instructions for implementing custom metadata 
 4. [Implementing Metadata Stores](#implementing-metadata-stores)
 5. [Implementing a Local Store](#implementing-a-local-store)
 6. [Implementing a Remote Store](#implementing-a-remote-store)
-7. [Best Practices](#best-practices)
-8. [Testing Your Implementation](#testing-your-implementation)
-9. [Common Pitfalls](#common-pitfalls)
-10. [Integration with DittoFS](#integration-with-dittofs)
+7. [Implementing a Remote Block Store (block-keyed)](#implementing-a-remote-block-store-block-keyed)
+8. [Best Practices](#best-practices)
+9. [Testing Your Implementation](#testing-your-implementation)
+10. [Common Pitfalls](#common-pitfalls)
+11. [Integration with DittoFS](#integration-with-dittofs)
 
 ## Overview
 
@@ -695,6 +696,111 @@ The dedicated `ReadBlockVerified` path on `RemoteStore` (round-trip succeeds;
 body-mismatch returns `block.ErrCASContentMismatch`; corrupt bytes never
 surface upstream) is exercised separately — see `pkg/block/remote/s3` for the
 verification tests.
+
+## Implementing a Remote Block Store (block-keyed)
+
+The `pkg/block/remote.RemoteBlockStore` interface is the **block-keyed** (non-CAS) remote store surface introduced by the blocks-only storage redesign (epic [#1493](https://github.com/marmos91/dittofs/issues/1493)). Block objects live under the `blocks/` prefix, separate from the legacy CAS `cas/` namespace — the two namespaces never collide.
+
+> **Legacy path (being retired):** The per-chunk CAS object path (`cas/<hash>`, hash-keyed `Put`/`Get`/`GetRange` on `RemoteStore`) is being retired in favour of blocks-only storage as part of epic #1493. New remote backends should implement `RemoteBlockStore`. The legacy `RemoteStore` CAS surface will be removed in a later PR of the same epic.
+
+### The RemoteBlockStore Interface
+
+```go
+type RemoteBlockStore interface {
+    PutBlock(ctx context.Context, blockID string, r io.Reader) error
+    GetBlock(ctx context.Context, blockID string) ([]byte, error)
+    GetBlockRange(ctx context.Context, blockID string, offset, length int64) ([]byte, error)
+    DeleteBlock(ctx context.Context, blockID string) error
+    WalkBlocks(ctx context.Context, fn func(blockID string, meta block.Meta) error) error
+}
+```
+
+See `pkg/block/remote/remote.go` for the authoritative definition and per-method docstrings. Current implementations: `pkg/block/remote/s3/` and `pkg/block/remote/memory/`.
+
+#### Key shape
+
+Objects are keyed by an opaque `blockID` string. The on-disk/on-wire key is `block.FormatBlockKey(blockID)` = `"blocks/<blockID>"`. Backends derive this key internally; callers and the engine never construct raw S3/object-store keys.
+
+#### PutBlock
+
+Writes the content of `r` under `blocks/<blockID>`. Implementations **must** stream `r` without buffering the full body — callers may supply an unbounded reader (e.g., an in-progress packing file). The call is idempotent: a second `PutBlock` for the same `blockID` overwrites silently.
+
+#### GetBlock
+
+Returns the full bytes of the named block object. Returns `block.ErrChunkNotFound` when the block is absent. The returned slice must be freshly allocated and must not alias internal storage.
+
+#### GetBlockRange
+
+Returns `[offset, offset+length)` bytes of the block object. Bounds validation:
+
+- **Negative offset** — must return `block.ErrInvalidOffset` (client-validated before any network call).
+- **Past-EOF offset** — a past-EOF offset cannot be detected here without a `HEAD`, so backends surface a native error (S3: HTTP 416) rather than `ErrInvalidOffset`. The contract only requires _some_ error for `offset >= EOF`.
+- **Non-positive length** — must return `block.ErrInvalidSize`.
+- **Past-EOF length** — clamped to the object's remaining bytes on backends that support partial-content (S3 `Range` header); no error.
+- **Absent blockID** — must return `block.ErrChunkNotFound`.
+
+#### DeleteBlock
+
+Removes the block object. Idempotent: deleting an absent `blockID` must return `nil`.
+
+#### WalkBlocks
+
+Enumerates every block object under the `blocks/` prefix. The callback receives the `blockID` (with the `blocks/` prefix stripped) and a `block.Meta` (size, last-modified timestamp). Ordering is unspecified.
+
+- Returning `block.ErrStopWalk` from the callback is a clean early exit — `WalkBlocks` returns `nil`.
+- Any other callback error halts enumeration and is returned wrapped as `"walk halted at <blockID>: %w"`.
+- Context cancellation aborts immediately.
+
+### Block codec wire format
+
+Block objects are written by `pkg/block/blockcodec`. A single block packs one or more chunk records into a continuous byte stream:
+
+```
+Block = [ preamble ][ record_0 ][ record_1 ] … [ record_{N-1} ]
+
+preamble:
+  magic      [4]byte = {'D','F','B','1'}   // "DFB1" — identifies a DittoFS block object
+  flags      uint8                          // bit0 = 1 → record headers are AEAD-sealed
+  blockID    uvarint(len) + len bytes (UTF-8)
+
+record (plaintext, flags bit0 = 0):
+  hash       [32]byte                       // chunk BLAKE3 content hash
+  wireLen    uvarint
+  wire       [wireLen]byte                  // enc(comp(chunk)) — already-transformed body
+
+record (sealed, flags bit0 = 1):
+  sealedHdrLen  uvarint
+  sealedHdr     [sealedHdrLen]byte          // AEAD seal of {hash[32], wireLen uvarint}
+                                            // AAD = blockID || recordIndex(uvarint)
+  wire          [wireLen]byte               // wireLen recovered by opening sealedHdr
+```
+
+**Sealed-header framing** is used on encrypted shares. The AEAD tag covers `hash + wireLen` with `blockID||recordIndex` as additional authenticated data, while the `wire` body is already the encrypted chunk body (the encryption decorator applies its transform before `Builder.Add` is called). The chunk metadata is therefore authenticated even though the wire body is opaque.
+
+**Locators.** Each call to `Builder.Add(hash, wire)` returns a `block.ChunkLocator{BlockID, WireOffset, WireLength}` — the byte range of the wire body within the block object. `WireOffset` and `WireLength` are over wire bytes (after the per-record header), not plaintext bytes. The engine stores these locators in the metadata store and recovers an individual chunk via `GetBlockRange(blockID, WireOffset, WireLength)` (surfaced through the optional `ChunkReader.ReadChunk` extension on the same backend).
+
+### Conformance suite
+
+Every new `RemoteBlockStore` backend must pass `blockstoretest.RemoteBlockStoreConformance`:
+
+```go
+package myremote_test
+
+import (
+    "testing"
+    "github.com/marmos91/dittofs/pkg/block/blockstoretest"
+)
+
+func TestMyRemoteBlockStore(t *testing.T) {
+    factory := func(t *testing.T) (blockstoretest.RemoteBlockStore, func()) {
+        store, cleanup := createTestStore(t)
+        return store, cleanup
+    }
+    blockstoretest.RemoteBlockStoreConformance(t, factory)
+}
+```
+
+The suite covers: `PutBlock`/`GetBlock` round-trip, no-aliasing, `GetBlockRange` mid-range/past-EOF-clamped/invalid-offset/invalid-size/absent, `DeleteBlock` durability and idempotency, `WalkBlocks` enumeration and `ErrStopWalk`, idempotent `PutBlock`, zero-byte blocks, and concurrent same-ID `PutBlock`.
 
 ## Best Practices
 

--- a/pkg/block/blockcodec/codec.go
+++ b/pkg/block/blockcodec/codec.go
@@ -149,6 +149,9 @@ func Parse(data []byte, sealer Sealer) (blockID string, records []Record, err er
 				return "", nil, fmt.Errorf("blockcodec: record %d: read wireLen: %w", idx, err)
 			}
 
+			if wireLen > uint64(r.remaining()) {
+				return "", nil, fmt.Errorf("blockcodec: record %d: wireLen %d exceeds remaining %d bytes", idx, wireLen, r.remaining())
+			}
 			rec.WireOffset = int64(r.pos)
 			if _, err := r.readN(int(wireLen)); err != nil {
 				return "", nil, fmt.Errorf("blockcodec: record %d: read wire body: %w", idx, err)
@@ -176,6 +179,9 @@ func Parse(data []byte, sealer Sealer) (blockID string, records []Record, err er
 				return "", nil, fmt.Errorf("blockcodec: record %d: decode wireLen from sealed header (n=%d)", idx, n)
 			}
 
+			if wireLen > uint64(r.remaining()) {
+				return "", nil, fmt.Errorf("blockcodec: record %d: sealed wireLen %d exceeds remaining %d bytes", idx, wireLen, r.remaining())
+			}
 			rec.WireOffset = int64(r.pos)
 			if _, err := r.readN(int(wireLen)); err != nil {
 				return "", nil, fmt.Errorf("blockcodec: record %d: read wire body: %w", idx, err)
@@ -339,6 +345,9 @@ func (c *cursor) readVarBytes() ([]byte, error) {
 	l, err := c.readUvarint()
 	if err != nil {
 		return nil, err
+	}
+	if l > uint64(c.remaining()) {
+		return nil, fmt.Errorf("blockcodec: varint length %d exceeds available bytes %d", l, c.remaining())
 	}
 	return c.readN(int(l))
 }

--- a/pkg/block/blockcodec/codec.go
+++ b/pkg/block/blockcodec/codec.go
@@ -72,7 +72,8 @@ func NewBuilder(w io.Writer, blockID string, sealer Sealer) (*Builder, error) {
 }
 
 // Add frames one record (header + body) and returns a ChunkLocator whose
-// Offset and Length address the wire body within the block object being built.
+// WireOffset and WireLength address the wire body within the block object being
+// built.
 func (b *Builder) Add(hash block.ContentHash, wire []byte) (block.ChunkLocator, error) {
 	if b.sealer != nil {
 		return b.addSealed(hash, wire)
@@ -276,6 +277,12 @@ func (b *Builder) writeByte(v byte) error {
 func (b *Builder) writeRaw(p []byte) error {
 	n, err := b.w.Write(p)
 	b.written += int64(n)
+	// A conforming io.Writer must return a non-nil error on a short write, but
+	// guard defensively: a truncated record body would desync every later
+	// locator (WireOffset/WireLength address bytes that never reached the wire).
+	if err == nil && n < len(p) {
+		return io.ErrShortWrite
+	}
 	return err
 }
 

--- a/pkg/block/blockcodec/codec.go
+++ b/pkg/block/blockcodec/codec.go
@@ -230,9 +230,9 @@ func (b *Builder) addPlaintext(hash block.ContentHash, wire []byte) (block.Chunk
 	}
 	b.recordIndex++
 	return block.ChunkLocator{
-		BlockID: b.blockID,
-		Offset:  wireBodyStart,
-		Length:  int64(len(wire)),
+		BlockID:    b.blockID,
+		WireOffset: wireBodyStart,
+		WireLength: int64(len(wire)),
 	}, nil
 }
 
@@ -262,9 +262,9 @@ func (b *Builder) addSealed(hash block.ContentHash, wire []byte) (block.ChunkLoc
 	}
 	b.recordIndex++
 	return block.ChunkLocator{
-		BlockID: b.blockID,
-		Offset:  wireBodyStart,
-		Length:  int64(len(wire)),
+		BlockID:    b.blockID,
+		WireOffset: wireBodyStart,
+		WireLength: int64(len(wire)),
 	}, nil
 }
 

--- a/pkg/block/blockcodec/codec.go
+++ b/pkg/block/blockcodec/codec.go
@@ -80,8 +80,9 @@ func (b *Builder) Add(hash block.ContentHash, wire []byte) (block.ChunkLocator, 
 	return b.addPlaintext(hash, wire)
 }
 
-// Finish validates the block state and returns the total number of bytes
-// written to the underlying writer.
+// Finish returns the total number of bytes written to the underlying writer.
+// Records are framed as they are added, so there is no deferred validation or
+// footer to flush here.
 func (b *Builder) Finish() (int64, error) {
 	return b.written, nil
 }

--- a/pkg/block/blockcodec/codec.go
+++ b/pkg/block/blockcodec/codec.go
@@ -1,0 +1,344 @@
+// Package blockcodec implements the DittoFS block wire format: a streaming
+// framing layer that packs one or more chunk records into a single block object.
+//
+// # Wire format
+//
+//	Block = [ preamble ][ record_0 ][ record_1 ] … [ record_{N-1} ]
+//
+//	preamble:
+//	  magic      [4]byte = {'D','F','B','1'}
+//	  flags      uint8            // bit0 = 1 → record headers are AEAD-sealed
+//	  blockID    uvarint(len) + len bytes (UTF-8)
+//
+//	record (plaintext, flags bit0 = 0):
+//	  hash       [32]byte         // chunk BLAKE3 content hash
+//	  wireLen    uvarint
+//	  wire       [wireLen]byte    // enc(comp(chunk)) — already-transformed body
+//
+//	record (sealed, flags bit0 = 1):
+//	  sealedHdrLen uvarint
+//	  sealedHdr    [sealedHdrLen]byte   // AEAD seal of {hash[32], wireLen uvarint}
+//	                                    // AAD = blockID||recordIndex(uvarint)
+//	  wire         [wireLen]byte        // wireLen recovered by opening sealedHdr
+package blockcodec
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+// magic is the 4-byte preamble for DittoFS block objects.
+var magic = [4]byte{'D', 'F', 'B', '1'}
+
+const flagSealed = uint8(1 << 0) // bit0: record headers are AEAD-sealed
+
+// Sealer seals and opens record sub-headers for encrypted shares.
+// A nil Sealer means plaintext framing with no header encryption.
+type Sealer interface {
+	// Seal encrypts plaintextHdr using aad as additional authenticated data.
+	Seal(plaintextHdr, aad []byte) ([]byte, error)
+	// Open decrypts and authenticates sealedHdr.
+	Open(sealedHdr, aad []byte) ([]byte, error)
+}
+
+// Builder streams one block to an underlying writer. Bodies are never held
+// entirely in RAM — each call to Add writes immediately.
+type Builder struct {
+	w           io.Writer
+	blockID     string
+	sealer      Sealer
+	written     int64
+	recordIndex uint64
+}
+
+// NewBuilder writes the block preamble to w and returns a streaming Builder.
+// sealer == nil produces plaintext record framing; a non-nil Sealer encrypts
+// the {hash, wireLen} sub-header of every record (the body remains plaintext).
+func NewBuilder(w io.Writer, blockID string, sealer Sealer) (*Builder, error) {
+	b := &Builder{
+		w:       w,
+		blockID: blockID,
+		sealer:  sealer,
+	}
+	if err := b.writePreamble(); err != nil {
+		return nil, fmt.Errorf("blockcodec: write preamble: %w", err)
+	}
+	return b, nil
+}
+
+// Add frames one record (header + body) and returns a ChunkLocator whose
+// Offset and Length address the wire body within the block object being built.
+func (b *Builder) Add(hash block.ContentHash, wire []byte) (block.ChunkLocator, error) {
+	if b.sealer != nil {
+		return b.addSealed(hash, wire)
+	}
+	return b.addPlaintext(hash, wire)
+}
+
+// Finish validates the block state and returns the total number of bytes
+// written to the underlying writer.
+func (b *Builder) Finish() (int64, error) {
+	return b.written, nil
+}
+
+// Record is one entry in a parsed block, carrying the chunk hash and the
+// byte range of its wire body within the block object. It is the codec's
+// index-rebuild output — callers convert it to a block.ChunkLocator by
+// supplying the block's object key.
+type Record struct {
+	Hash       block.ContentHash
+	WireOffset int64 // byte offset of the wire body within the block object
+	WireLength int64 // byte length of the wire body
+}
+
+// Parse reads a complete block from data, decodes the preamble and every
+// record, and returns the block ID and an ordered slice of Records. sealer
+// must be non-nil when the block was written with a Sealer; nil for plaintext
+// blocks.
+func Parse(data []byte, sealer Sealer) (blockID string, records []Record, err error) {
+	r := &cursor{buf: data}
+
+	// preamble: magic
+	m, err := r.readN(4)
+	if err != nil {
+		return "", nil, fmt.Errorf("blockcodec: read magic: %w", err)
+	}
+	if m[0] != magic[0] || m[1] != magic[1] || m[2] != magic[2] || m[3] != magic[3] {
+		return "", nil, fmt.Errorf("blockcodec: invalid magic bytes %v", m)
+	}
+
+	// preamble: flags
+	flags, err := r.readByte()
+	if err != nil {
+		return "", nil, fmt.Errorf("blockcodec: read flags: %w", err)
+	}
+
+	// preamble: blockID
+	idBytes, err := r.readVarBytes()
+	if err != nil {
+		return "", nil, fmt.Errorf("blockcodec: read blockID: %w", err)
+	}
+	blockID = string(idBytes)
+
+	sealed := flags&flagSealed != 0
+	if sealed && sealer == nil {
+		return "", nil, errors.New("blockcodec: block is sealed but no Sealer provided")
+	}
+	if !sealed {
+		sealer = nil // belt-and-suspenders: don't use a sealer on a plaintext block
+	}
+
+	var idx uint64
+	for r.remaining() > 0 {
+		var rec Record
+		if sealer == nil {
+			// Plaintext record: hash[32] + wireLen uvarint + wire[wireLen]
+			hashBytes, err := r.readN(32)
+			if err != nil {
+				return "", nil, fmt.Errorf("blockcodec: record %d: read hash: %w", idx, err)
+			}
+			copy(rec.Hash[:], hashBytes)
+
+			wireLen, err := r.readUvarint()
+			if err != nil {
+				return "", nil, fmt.Errorf("blockcodec: record %d: read wireLen: %w", idx, err)
+			}
+
+			rec.WireOffset = int64(r.pos)
+			if _, err := r.readN(int(wireLen)); err != nil {
+				return "", nil, fmt.Errorf("blockcodec: record %d: read wire body: %w", idx, err)
+			}
+			rec.WireLength = int64(wireLen)
+		} else {
+			// Sealed record: sealedHdrLen uvarint + sealedHdr + wire[wireLen]
+			sealedHdr, err := r.readVarBytes()
+			if err != nil {
+				return "", nil, fmt.Errorf("blockcodec: record %d: read sealed header: %w", idx, err)
+			}
+
+			aad := buildAAD(blockID, idx)
+			plaintextHdr, err := sealer.Open(sealedHdr, aad)
+			if err != nil {
+				return "", nil, fmt.Errorf("blockcodec: record %d: open sealed header: %w", idx, err)
+			}
+			if len(plaintextHdr) < 32 {
+				return "", nil, fmt.Errorf("blockcodec: record %d: sealed header plaintext too short (%d bytes)", idx, len(plaintextHdr))
+			}
+			copy(rec.Hash[:], plaintextHdr[:32])
+
+			wireLen, n := binary.Uvarint(plaintextHdr[32:])
+			if n <= 0 {
+				return "", nil, fmt.Errorf("blockcodec: record %d: decode wireLen from sealed header (n=%d)", idx, n)
+			}
+
+			rec.WireOffset = int64(r.pos)
+			if _, err := r.readN(int(wireLen)); err != nil {
+				return "", nil, fmt.Errorf("blockcodec: record %d: read wire body: %w", idx, err)
+			}
+			rec.WireLength = int64(wireLen)
+		}
+		records = append(records, rec)
+		idx++
+	}
+
+	return blockID, records, nil
+}
+
+// ---- Builder helpers --------------------------------------------------------
+
+func (b *Builder) writePreamble() error {
+	// magic [4]byte
+	if err := b.writeRaw(magic[:]); err != nil {
+		return err
+	}
+	// flags uint8
+	flags := uint8(0)
+	if b.sealer != nil {
+		flags |= flagSealed
+	}
+	if err := b.writeByte(flags); err != nil {
+		return err
+	}
+	// blockID: uvarint(len) + bytes
+	return b.writeVarBytes([]byte(b.blockID))
+}
+
+func (b *Builder) addPlaintext(hash block.ContentHash, wire []byte) (block.ChunkLocator, error) {
+	// hash [32]byte
+	if err := b.writeRaw(hash[:]); err != nil {
+		return block.ChunkLocator{}, fmt.Errorf("blockcodec: write hash: %w", err)
+	}
+	// wireLen uvarint
+	if err := b.writeUvarint(uint64(len(wire))); err != nil {
+		return block.ChunkLocator{}, fmt.Errorf("blockcodec: write wireLen: %w", err)
+	}
+	// body
+	wireBodyStart := b.written
+	if err := b.writeRaw(wire); err != nil {
+		return block.ChunkLocator{}, fmt.Errorf("blockcodec: write wire body: %w", err)
+	}
+	b.recordIndex++
+	return block.ChunkLocator{
+		BlockID: b.blockID,
+		Offset:  wireBodyStart,
+		Length:  int64(len(wire)),
+	}, nil
+}
+
+func (b *Builder) addSealed(hash block.ContentHash, wire []byte) (block.ChunkLocator, error) {
+	// Build plaintext header: hash[32] + wireLen uvarint
+	var hdrBuf bytes.Buffer
+	hdrBuf.Write(hash[:])
+	var tmp [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(tmp[:], uint64(len(wire)))
+	hdrBuf.Write(tmp[:n])
+
+	aad := buildAAD(b.blockID, b.recordIndex)
+	sealedHdr, err := b.sealer.Seal(hdrBuf.Bytes(), aad)
+	if err != nil {
+		return block.ChunkLocator{}, fmt.Errorf("blockcodec: seal header: %w", err)
+	}
+
+	// sealedHdrLen uvarint + sealedHdr bytes
+	if err := b.writeVarBytes(sealedHdr); err != nil {
+		return block.ChunkLocator{}, fmt.Errorf("blockcodec: write sealed header: %w", err)
+	}
+
+	// body (plaintext-visible position in the block)
+	wireBodyStart := b.written
+	if err := b.writeRaw(wire); err != nil {
+		return block.ChunkLocator{}, fmt.Errorf("blockcodec: write wire body: %w", err)
+	}
+	b.recordIndex++
+	return block.ChunkLocator{
+		BlockID: b.blockID,
+		Offset:  wireBodyStart,
+		Length:  int64(len(wire)),
+	}, nil
+}
+
+func (b *Builder) writeByte(v byte) error {
+	return b.writeRaw([]byte{v})
+}
+
+func (b *Builder) writeRaw(p []byte) error {
+	n, err := b.w.Write(p)
+	b.written += int64(n)
+	return err
+}
+
+func (b *Builder) writeUvarint(v uint64) error {
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], v)
+	return b.writeRaw(buf[:n])
+}
+
+func (b *Builder) writeVarBytes(data []byte) error {
+	if err := b.writeUvarint(uint64(len(data))); err != nil {
+		return err
+	}
+	return b.writeRaw(data)
+}
+
+// buildAAD constructs the additional authenticated data for a sealed record:
+// blockID bytes concatenated with the record index encoded as a uvarint.
+func buildAAD(blockID string, recordIndex uint64) []byte {
+	idBytes := []byte(blockID)
+	var tmp [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(tmp[:], recordIndex)
+	aad := make([]byte, len(idBytes)+n)
+	copy(aad, idBytes)
+	copy(aad[len(idBytes):], tmp[:n])
+	return aad
+}
+
+// ---- cursor: read-only view over a byte slice --------------------------------
+
+type cursor struct {
+	buf []byte
+	pos int
+}
+
+func (c *cursor) remaining() int { return len(c.buf) - c.pos }
+
+func (c *cursor) readN(n int) ([]byte, error) {
+	if c.remaining() < n {
+		return nil, fmt.Errorf("unexpected EOF: need %d bytes, have %d", n, c.remaining())
+	}
+	data := c.buf[c.pos : c.pos+n]
+	c.pos += n
+	return data, nil
+}
+
+func (c *cursor) readByte() (byte, error) {
+	b, err := c.readN(1)
+	if err != nil {
+		return 0, err
+	}
+	return b[0], nil
+}
+
+func (c *cursor) readUvarint() (uint64, error) {
+	v, n := binary.Uvarint(c.buf[c.pos:])
+	if n == 0 {
+		return 0, errors.New("buffer too small for uvarint")
+	}
+	if n < 0 {
+		return 0, errors.New("uvarint value overflows uint64")
+	}
+	c.pos += n
+	return v, nil
+}
+
+func (c *cursor) readVarBytes() ([]byte, error) {
+	l, err := c.readUvarint()
+	if err != nil {
+		return nil, err
+	}
+	return c.readN(int(l))
+}

--- a/pkg/block/blockcodec/codec_test.go
+++ b/pkg/block/blockcodec/codec_test.go
@@ -1,0 +1,341 @@
+package blockcodec_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/blockcodec"
+)
+
+// fakeSealer is a test Sealer that prepends a fixed nonce byte (0xFE) and XORs
+// the plaintext with 0x42. Round-trips correctly through Seal/Open and ensures
+// the sealed bytes differ from plaintext (opacity test in TestSealedRoundTrip).
+type fakeSealer struct{}
+
+func (fakeSealer) Seal(plaintext, _ []byte) ([]byte, error) {
+	out := make([]byte, len(plaintext)+1)
+	out[0] = 0xFE // fixed nonce marker
+	for i, b := range plaintext {
+		out[i+1] = b ^ 0x42
+	}
+	return out, nil
+}
+
+func (fakeSealer) Open(sealed, _ []byte) ([]byte, error) {
+	if len(sealed) < 1 || sealed[0] != 0xFE {
+		return nil, errors.New("fakeSealer: invalid nonce marker")
+	}
+	out := make([]byte, len(sealed)-1)
+	for i, b := range sealed[1:] {
+		out[i] = b ^ 0x42
+	}
+	return out, nil
+}
+
+// TestPlaintextRoundTrip builds a two-chunk plaintext block, parses it, and
+// verifies that hashes, locators, and body bytes all round-trip correctly.
+func TestPlaintextRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+
+	var hash1 block.ContentHash
+	hash1[0] = 0xAA
+	hash1[1] = 0xBB
+
+	var hash2 block.ContentHash
+	hash2[0] = 0xCC
+	hash2[31] = 0xDD
+
+	wire1 := []byte("chunk-one-bytes")
+	wire2 := []byte("chunk-two-bytes-longer-payload-here")
+
+	b, err := blockcodec.NewBuilder(&buf, "block-001", nil)
+	if err != nil {
+		t.Fatalf("NewBuilder: %v", err)
+	}
+
+	loc1, err := b.Add(hash1, wire1)
+	if err != nil {
+		t.Fatalf("Add(hash1): %v", err)
+	}
+
+	loc2, err := b.Add(hash2, wire2)
+	if err != nil {
+		t.Fatalf("Add(hash2): %v", err)
+	}
+
+	total, err := b.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	if int64(buf.Len()) != total {
+		t.Errorf("Finish total=%d != buf.Len()=%d", total, buf.Len())
+	}
+
+	raw := buf.Bytes()
+
+	blockID, records, err := blockcodec.Parse(raw, nil)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if blockID != "block-001" {
+		t.Errorf("blockID=%q want %q", blockID, "block-001")
+	}
+	if len(records) != 2 {
+		t.Fatalf("len(records)=%d want 2", len(records))
+	}
+
+	// Record 0
+	if records[0].Hash != hash1 {
+		t.Errorf("records[0].Hash mismatch")
+	}
+	if records[0].WireOffset != loc1.Offset {
+		t.Errorf("records[0].WireOffset=%d want %d", records[0].WireOffset, loc1.Offset)
+	}
+	if records[0].WireLength != loc1.Length {
+		t.Errorf("records[0].WireLength=%d want %d", records[0].WireLength, loc1.Length)
+	}
+	got1 := raw[records[0].WireOffset : records[0].WireOffset+records[0].WireLength]
+	if !bytes.Equal(got1, wire1) {
+		t.Errorf("body1=%q want %q", got1, wire1)
+	}
+
+	// Record 1
+	if records[1].Hash != hash2 {
+		t.Errorf("records[1].Hash mismatch")
+	}
+	if records[1].WireOffset != loc2.Offset {
+		t.Errorf("records[1].WireOffset=%d want %d", records[1].WireOffset, loc2.Offset)
+	}
+	if records[1].WireLength != loc2.Length {
+		t.Errorf("records[1].WireLength=%d want %d", records[1].WireLength, loc2.Length)
+	}
+	got2 := raw[records[1].WireOffset : records[1].WireOffset+records[1].WireLength]
+	if !bytes.Equal(got2, wire2) {
+		t.Errorf("body2=%q want %q", got2, wire2)
+	}
+}
+
+// TestEmptyBody verifies that a zero-length wire body is framed and parsed
+// without error, and the returned locator reports Length==0.
+func TestEmptyBody(t *testing.T) {
+	var buf bytes.Buffer
+
+	var hash block.ContentHash
+	hash[0] = 0xCC
+
+	b, err := blockcodec.NewBuilder(&buf, "b", nil)
+	if err != nil {
+		t.Fatalf("NewBuilder: %v", err)
+	}
+
+	loc, err := b.Add(hash, nil)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if loc.Length != 0 {
+		t.Errorf("loc.Length=%d want 0", loc.Length)
+	}
+
+	if _, err := b.Finish(); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	blockID, records, err := blockcodec.Parse(buf.Bytes(), nil)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if blockID != "b" {
+		t.Errorf("blockID=%q want %q", blockID, "b")
+	}
+	if len(records) != 1 {
+		t.Fatalf("len(records)=%d want 1", len(records))
+	}
+	if records[0].Hash != hash {
+		t.Errorf("records[0].Hash mismatch")
+	}
+	if records[0].WireLength != 0 {
+		t.Errorf("records[0].WireLength=%d want 0", records[0].WireLength)
+	}
+}
+
+// TestLargeChunk verifies that a chunk larger than any typical block target
+// (one-chunk block) round-trips correctly.
+func TestLargeChunk(t *testing.T) {
+	const size = 16 * 1024 * 1024 // 16 MiB, well above any block target
+
+	wire := make([]byte, size)
+	for i := range wire {
+		wire[i] = byte(i & 0xFF)
+	}
+
+	var hash block.ContentHash
+	hash[0] = 0xDD
+
+	var buf bytes.Buffer
+	b, err := blockcodec.NewBuilder(&buf, "large-block", nil)
+	if err != nil {
+		t.Fatalf("NewBuilder: %v", err)
+	}
+
+	loc, err := b.Add(hash, wire)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if loc.Length != int64(size) {
+		t.Errorf("loc.Length=%d want %d", loc.Length, size)
+	}
+
+	if _, err := b.Finish(); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	raw := buf.Bytes()
+	blockID, records, err := blockcodec.Parse(raw, nil)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if blockID != "large-block" {
+		t.Errorf("blockID=%q want %q", blockID, "large-block")
+	}
+	if len(records) != 1 {
+		t.Fatalf("len(records)=%d want 1", len(records))
+	}
+	if records[0].Hash != hash {
+		t.Errorf("records[0].Hash mismatch")
+	}
+	if records[0].WireLength != int64(size) {
+		t.Errorf("records[0].WireLength=%d want %d", records[0].WireLength, size)
+	}
+	got := raw[records[0].WireOffset : records[0].WireOffset+records[0].WireLength]
+	if !bytes.Equal(got, wire) {
+		t.Errorf("large chunk body mismatch (first diff at byte %d)", firstDiff(got, wire))
+	}
+}
+
+func firstDiff(a, b []byte) int {
+	for i := range a {
+		if i >= len(b) || a[i] != b[i] {
+			return i
+		}
+	}
+	return len(a)
+}
+
+// TestSealedRoundTrip builds a sealed block, verifies that parsing without a
+// Sealer fails (headers are opaque), then parses with the Sealer and verifies
+// hashes and locators recover correctly. Bodies are always plaintext-visible at
+// WireOffset/WireLength.
+func TestSealedRoundTrip(t *testing.T) {
+	sealer := fakeSealer{}
+
+	var hash1 block.ContentHash
+	hash1[0] = 0xAA
+	hash1[1] = 0xBB
+
+	wire1 := []byte("sealed-chunk-payload")
+
+	var buf bytes.Buffer
+	b, err := blockcodec.NewBuilder(&buf, "enc-block", sealer)
+	if err != nil {
+		t.Fatalf("NewBuilder: %v", err)
+	}
+
+	loc, err := b.Add(hash1, wire1)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	if _, err := b.Finish(); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	raw := buf.Bytes()
+
+	// Sealed block parsed without a Sealer must error (headers are opaque).
+	if _, _, err := blockcodec.Parse(raw, nil); err == nil {
+		t.Error("Parse of sealed block without Sealer should have failed")
+	}
+
+	// With the Sealer the block round-trips.
+	blockID, records, err := blockcodec.Parse(raw, sealer)
+	if err != nil {
+		t.Fatalf("Parse with sealer: %v", err)
+	}
+	if blockID != "enc-block" {
+		t.Errorf("blockID=%q want %q", blockID, "enc-block")
+	}
+	if len(records) != 1 {
+		t.Fatalf("len(records)=%d want 1", len(records))
+	}
+	if records[0].Hash != hash1 {
+		t.Errorf("records[0].Hash mismatch")
+	}
+	if records[0].WireOffset != loc.Offset {
+		t.Errorf("records[0].WireOffset=%d want %d", records[0].WireOffset, loc.Offset)
+	}
+	if records[0].WireLength != loc.Length {
+		t.Errorf("records[0].WireLength=%d want %d", records[0].WireLength, loc.Length)
+	}
+	// Bodies live in plaintext-visible region (after the sealed header).
+	got := raw[records[0].WireOffset : records[0].WireOffset+records[0].WireLength]
+	if !bytes.Equal(got, wire1) {
+		t.Errorf("body=%q want %q", got, wire1)
+	}
+}
+
+// TestTruncated verifies that truncating a valid block at various offsets
+// returns a structural error and never panics.
+func TestTruncated(t *testing.T) {
+	// Build a reference block.
+	var buf bytes.Buffer
+	b, err := blockcodec.NewBuilder(&buf, "block", nil)
+	if err != nil {
+		t.Fatalf("NewBuilder: %v", err)
+	}
+	var hash block.ContentHash
+	if _, err := b.Add(hash, []byte("body data here")); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if _, err := b.Finish(); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	raw := buf.Bytes()
+
+	cuts := []int{0, 1, 2, 4, len(raw) / 2, len(raw) - 1}
+	for _, n := range cuts {
+		t.Run(fmt.Sprintf("truncate_at_%d", n), func(t *testing.T) {
+			_, _, err := blockcodec.Parse(raw[:n], nil)
+			if err == nil {
+				t.Errorf("expected error for truncation at %d, got nil", n)
+			}
+		})
+	}
+}
+
+// TestMagicMismatch verifies that wrong magic bytes and wrong flags produce errors.
+func TestMagicMismatch(t *testing.T) {
+	t.Run("wrong_magic", func(t *testing.T) {
+		data := []byte{'X', 'Y', 'Z', 'W', 0x00, 0x00} // bad magic + flags + empty blockID
+		_, _, err := blockcodec.Parse(data, nil)
+		if err == nil {
+			t.Error("expected error for wrong magic, got nil")
+		}
+	})
+
+	t.Run("sealed_flag_no_sealer", func(t *testing.T) {
+		// Build a valid plaintext block then flip the sealed flag bit.
+		var buf bytes.Buffer
+		b, _ := blockcodec.NewBuilder(&buf, "b", nil)
+		b.Finish() //nolint:errcheck
+		raw := make([]byte, buf.Len())
+		copy(raw, buf.Bytes())
+		raw[4] |= 0x01 // set bit0 = sealed
+		_, _, err := blockcodec.Parse(raw, nil)
+		if err == nil {
+			t.Error("expected error for sealed block without Sealer, got nil")
+		}
+	})
+}

--- a/pkg/block/blockcodec/codec_test.go
+++ b/pkg/block/blockcodec/codec_test.go
@@ -4,11 +4,25 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/blockcodec"
 )
+
+// shortWriter simulates a non-conforming io.Writer that returns n < len(p) with
+// a nil error on writes larger than threshold. A conforming writer must report
+// an error on a short write; the codec must not trust that and silently emit a
+// truncated record body.
+type shortWriter struct{ threshold int }
+
+func (s shortWriter) Write(p []byte) (int, error) {
+	if len(p) > s.threshold {
+		return len(p) - 1, nil
+	}
+	return len(p), nil
+}
 
 // fakeSealer is a test Sealer that:
 //   - embeds the AAD in the sealed output so Open rejects AAD mismatches
@@ -403,4 +417,20 @@ func TestMagicMismatch(t *testing.T) {
 			t.Error("expected error for sealed block without Sealer, got nil")
 		}
 	})
+}
+
+// TestBuilderAddRejectsShortWrite proves Add fails closed when the underlying
+// writer drops bytes without erroring — a truncated body would desync every
+// later locator (WireOffset/WireLength would address bytes never written).
+func TestBuilderAddRejectsShortWrite(t *testing.T) {
+	// Preamble writes are small (<= threshold) and succeed; the 64-byte body
+	// exceeds the threshold and is short-written.
+	b, err := blockcodec.NewBuilder(shortWriter{threshold: 32}, "blk-short", nil)
+	if err != nil {
+		t.Fatalf("NewBuilder: %v", err)
+	}
+	var h block.ContentHash
+	if _, err := b.Add(h, bytes.Repeat([]byte{0x07}, 64)); !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("Add short write: got %v, want io.ErrShortWrite", err)
+	}
 }

--- a/pkg/block/blockcodec/codec_test.go
+++ b/pkg/block/blockcodec/codec_test.go
@@ -113,11 +113,11 @@ func TestPlaintextRoundTrip(t *testing.T) {
 	if records[0].Hash != hash1 {
 		t.Errorf("records[0].Hash mismatch")
 	}
-	if records[0].WireOffset != loc1.Offset {
-		t.Errorf("records[0].WireOffset=%d want %d", records[0].WireOffset, loc1.Offset)
+	if records[0].WireOffset != loc1.WireOffset {
+		t.Errorf("records[0].WireOffset=%d want %d", records[0].WireOffset, loc1.WireOffset)
 	}
-	if records[0].WireLength != loc1.Length {
-		t.Errorf("records[0].WireLength=%d want %d", records[0].WireLength, loc1.Length)
+	if records[0].WireLength != loc1.WireLength {
+		t.Errorf("records[0].WireLength=%d want %d", records[0].WireLength, loc1.WireLength)
 	}
 	got1 := raw[records[0].WireOffset : records[0].WireOffset+records[0].WireLength]
 	if !bytes.Equal(got1, wire1) {
@@ -128,11 +128,11 @@ func TestPlaintextRoundTrip(t *testing.T) {
 	if records[1].Hash != hash2 {
 		t.Errorf("records[1].Hash mismatch")
 	}
-	if records[1].WireOffset != loc2.Offset {
-		t.Errorf("records[1].WireOffset=%d want %d", records[1].WireOffset, loc2.Offset)
+	if records[1].WireOffset != loc2.WireOffset {
+		t.Errorf("records[1].WireOffset=%d want %d", records[1].WireOffset, loc2.WireOffset)
 	}
-	if records[1].WireLength != loc2.Length {
-		t.Errorf("records[1].WireLength=%d want %d", records[1].WireLength, loc2.Length)
+	if records[1].WireLength != loc2.WireLength {
+		t.Errorf("records[1].WireLength=%d want %d", records[1].WireLength, loc2.WireLength)
 	}
 	got2 := raw[records[1].WireOffset : records[1].WireOffset+records[1].WireLength]
 	if !bytes.Equal(got2, wire2) {
@@ -157,8 +157,8 @@ func TestEmptyBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Add: %v", err)
 	}
-	if loc.Length != 0 {
-		t.Errorf("loc.Length=%d want 0", loc.Length)
+	if loc.WireLength != 0 {
+		t.Errorf("loc.WireLength=%d want 0", loc.WireLength)
 	}
 
 	if _, err := b.Finish(); err != nil {
@@ -206,8 +206,8 @@ func TestLargeChunk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Add: %v", err)
 	}
-	if loc.Length != int64(size) {
-		t.Errorf("loc.Length=%d want %d", loc.Length, size)
+	if loc.WireLength != int64(size) {
+		t.Errorf("loc.WireLength=%d want %d", loc.WireLength, size)
 	}
 
 	if _, err := b.Finish(); err != nil {
@@ -298,11 +298,11 @@ func TestSealedRoundTrip(t *testing.T) {
 	if records[0].Hash != hash1 {
 		t.Errorf("records[0].Hash mismatch")
 	}
-	if records[0].WireOffset != loc.Offset {
-		t.Errorf("records[0].WireOffset=%d want %d", records[0].WireOffset, loc.Offset)
+	if records[0].WireOffset != loc.WireOffset {
+		t.Errorf("records[0].WireOffset=%d want %d", records[0].WireOffset, loc.WireOffset)
 	}
-	if records[0].WireLength != loc.Length {
-		t.Errorf("records[0].WireLength=%d want %d", records[0].WireLength, loc.Length)
+	if records[0].WireLength != loc.WireLength {
+		t.Errorf("records[0].WireLength=%d want %d", records[0].WireLength, loc.WireLength)
 	}
 	// Bodies live in plaintext-visible region (after the sealed header).
 	got := raw[records[0].WireOffset : records[0].WireOffset+records[0].WireLength]

--- a/pkg/block/blockcodec/codec_test.go
+++ b/pkg/block/blockcodec/codec_test.go
@@ -10,26 +10,48 @@ import (
 	"github.com/marmos91/dittofs/pkg/block/blockcodec"
 )
 
-// fakeSealer is a test Sealer that prepends a fixed nonce byte (0xFE) and XORs
-// the plaintext with 0x42. Round-trips correctly through Seal/Open and ensures
-// the sealed bytes differ from plaintext (opacity test in TestSealedRoundTrip).
-type fakeSealer struct{}
+// fakeSealer is a test Sealer that:
+//   - embeds the AAD in the sealed output so Open rejects AAD mismatches
+//   - captures each AAD passed to Seal for post-round-trip assertions
+//   - XORs the plaintext with 0x42 for opacity
+//
+// Wire format: [0xFE marker] [aadLen uint8] [aad bytes] [XOR(plaintext, 0x42)]
+type fakeSealer struct {
+	capturedAADs [][]byte
+}
 
-func (fakeSealer) Seal(plaintext, _ []byte) ([]byte, error) {
-	out := make([]byte, len(plaintext)+1)
-	out[0] = 0xFE // fixed nonce marker
+func (s *fakeSealer) Seal(plaintext, aad []byte) ([]byte, error) {
+	if len(aad) > 255 {
+		return nil, fmt.Errorf("fakeSealer: aad length %d exceeds 255", len(aad))
+	}
+	aadCopy := make([]byte, len(aad))
+	copy(aadCopy, aad)
+	s.capturedAADs = append(s.capturedAADs, aadCopy)
+
+	out := make([]byte, 2+len(aad)+len(plaintext))
+	out[0] = 0xFE // nonce marker
+	out[1] = byte(len(aad))
+	copy(out[2:], aad)
 	for i, b := range plaintext {
-		out[i+1] = b ^ 0x42
+		out[2+len(aad)+i] = b ^ 0x42
 	}
 	return out, nil
 }
 
-func (fakeSealer) Open(sealed, _ []byte) ([]byte, error) {
-	if len(sealed) < 1 || sealed[0] != 0xFE {
+func (s *fakeSealer) Open(sealed, aad []byte) ([]byte, error) {
+	if len(sealed) < 2 || sealed[0] != 0xFE {
 		return nil, errors.New("fakeSealer: invalid nonce marker")
 	}
-	out := make([]byte, len(sealed)-1)
-	for i, b := range sealed[1:] {
+	aadLen := int(sealed[1])
+	if len(sealed) < 2+aadLen {
+		return nil, errors.New("fakeSealer: sealed data truncated")
+	}
+	if !bytes.Equal(sealed[2:2+aadLen], aad) {
+		return nil, fmt.Errorf("fakeSealer: AAD mismatch: sealed %x, open %x", sealed[2:2+aadLen], aad)
+	}
+	ciphertext := sealed[2+aadLen:]
+	out := make([]byte, len(ciphertext))
+	for i, b := range ciphertext {
 		out[i] = b ^ 0x42
 	}
 	return out, nil
@@ -228,8 +250,11 @@ func firstDiff(a, b []byte) int {
 // Sealer fails (headers are opaque), then parses with the Sealer and verifies
 // hashes and locators recover correctly. Bodies are always plaintext-visible at
 // WireOffset/WireLength.
+//
+// It also asserts that buildAAD produces blockID_bytes || uvarint(recordIndex)
+// by inspecting the AAD captured by fakeSealer for record 0.
 func TestSealedRoundTrip(t *testing.T) {
-	sealer := fakeSealer{}
+	sealer := &fakeSealer{}
 
 	var hash1 block.ContentHash
 	hash1[0] = 0xAA
@@ -284,6 +309,16 @@ func TestSealedRoundTrip(t *testing.T) {
 	if !bytes.Equal(got, wire1) {
 		t.Errorf("body=%q want %q", got, wire1)
 	}
+
+	// Assert buildAAD("enc-block", 0) == []byte("enc-block") || uvarint(0).
+	// uvarint(0) encodes as a single 0x00 byte.
+	if len(sealer.capturedAADs) < 1 {
+		t.Fatal("fakeSealer captured no AADs during Build")
+	}
+	wantAAD := append([]byte("enc-block"), 0x00) // blockID bytes || uvarint(0)
+	if !bytes.Equal(sealer.capturedAADs[0], wantAAD) {
+		t.Errorf("record 0 AAD = %x, want %x", sealer.capturedAADs[0], wantAAD)
+	}
 }
 
 // TestTruncated verifies that truncating a valid block at various offsets
@@ -315,6 +350,33 @@ func TestTruncated(t *testing.T) {
 	}
 }
 
+// TestParseRejectsOverlongLength verifies that a crafted block whose wireLen
+// uvarint encodes math.MaxUint64 is rejected with an error and does not panic.
+// Before the bounds guard, int(wireLen) wraps to -1 on amd64, bypasses the
+// readN guard (remaining >= 0 is never < -1), and the slice expression
+// buf[pos : pos+(-1)] panics. This test must fail (panic) before the fix.
+func TestParseRejectsOverlongLength(t *testing.T) {
+	// Construct a syntactically plausible plaintext block:
+	//   magic(4) | flags=0x00 | blockID "test" (uvarint(4) + 4 bytes) |
+	//   hash(32 zero bytes) | wireLen = MaxUint64 (10-byte uvarint) | (no body)
+	var buf []byte
+	buf = append(buf, 'D', 'F', 'B', '1') // magic
+	buf = append(buf, 0x00)               // flags = plaintext
+	// blockID = "test" — length 4 as uvarint(4) = 0x04
+	buf = append(buf, 0x04, 't', 'e', 's', 't')
+	// hash: 32 zero bytes
+	buf = append(buf, make([]byte, 32)...)
+	// wireLen = math.MaxUint64 = 0xFFFFFFFFFFFFFFFF encoded as uvarint:
+	//   9 bytes of 0xFF (7-bit groups with continuation) + 0x01 (final bit)
+	buf = append(buf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01)
+	// No body follows — Parse must return a structural error, never panic.
+
+	_, _, err := blockcodec.Parse(buf, nil)
+	if err == nil {
+		t.Fatal("Parse with wireLen=math.MaxUint64 must return an error, got nil")
+	}
+}
+
 // TestMagicMismatch verifies that wrong magic bytes and wrong flags produce errors.
 func TestMagicMismatch(t *testing.T) {
 	t.Run("wrong_magic", func(t *testing.T) {
@@ -328,12 +390,15 @@ func TestMagicMismatch(t *testing.T) {
 	t.Run("sealed_flag_no_sealer", func(t *testing.T) {
 		// Build a valid plaintext block then flip the sealed flag bit.
 		var buf bytes.Buffer
-		b, _ := blockcodec.NewBuilder(&buf, "b", nil)
+		b, err := blockcodec.NewBuilder(&buf, "b", nil)
+		if err != nil {
+			t.Fatalf("NewBuilder: %v", err)
+		}
 		b.Finish() //nolint:errcheck
 		raw := make([]byte, buf.Len())
 		copy(raw, buf.Bytes())
 		raw[4] |= 0x01 // set bit0 = sealed
-		_, _, err := blockcodec.Parse(raw, nil)
+		_, _, err = blockcodec.Parse(raw, nil)
 		if err == nil {
 			t.Error("expected error for sealed block without Sealer, got nil")
 		}

--- a/pkg/block/blockstoretest/doc.go
+++ b/pkg/block/blockstoretest/doc.go
@@ -2,7 +2,7 @@
 // BlockStore and BlockStoreAppend contracts declared in
 // pkg/block/blockstore.go.
 //
-// Two top-level entrypoints are exposed:
+// Three top-level entrypoints are exposed:
 //
 //   - BlockStoreConformance(t, factory) — runs the CAS-keyed contract
 //     suite against any BlockStore implementation. The fs, s3, and
@@ -11,6 +11,10 @@
 //     absorber suite against any BlockStoreAppend implementation. Only
 //     the fs backend implements BlockStoreAppend and therefore calls
 //     this entrypoint.
+//   - RemoteBlockStoreConformance(t, factory) — runs the block-keyed
+//     (non-CAS) contract suite against any RemoteBlockStore
+//     implementation. The memory and s3 backends both call this
+//     entrypoint.
 //
 // This package replaces pkg/block/local/localtest and
 // pkg/block/remote/remotetest. The three fs-internal scenarios

--- a/pkg/block/blockstoretest/remoteblock.go
+++ b/pkg/block/blockstoretest/remoteblock.go
@@ -1,0 +1,479 @@
+package blockstoretest
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+)
+
+// RemoteBlockStore is re-exported from remote.RemoteBlockStore so that
+// test files only need to import blockstoretest (not pkg/block/remote).
+type RemoteBlockStore = remote.RemoteBlockStore
+
+// RemoteBlockStoreFactory creates a fresh RemoteBlockStore per subtest.
+// The returned cleanup function must release all resources. Implementations
+// must not share state across factory calls.
+type RemoteBlockStoreFactory func(t *testing.T) (RemoteBlockStore, func())
+
+// RemoteBlockStoreConformance runs the unified contract suite for
+// remote.RemoteBlockStore. Every method is covered by at least one subtest.
+// Wire one backend at a time; if an assertion fails against a correct backend,
+// fix the suite — only stop and report a concern if you find a genuine backend
+// bug.
+//
+// Subtests:
+//
+//   - PutBlock_GetBlock_RoundTrip — happy-path idempotent PutBlock then GetBlock.
+//   - GetBlock_NoAliasing — mutating a returned slice must not change the stored bytes.
+//   - GetBlock_NotFound — absent blockID returns ErrChunkNotFound.
+//   - GetBlockRange_Mid — range read from the middle of a stored block.
+//   - GetBlockRange_PastEOFClamped — length past EOF is clamped without error.
+//   - GetBlockRange_InvalidOffset — negative / past-EOF offset returns ErrInvalidOffset.
+//   - GetBlockRange_InvalidSize — zero / negative length returns ErrInvalidSize.
+//   - GetBlockRange_ZeroLength — explicit zero-length returns ErrInvalidSize.
+//   - GetBlockRange_NotFound — absent blockID returns ErrChunkNotFound.
+//   - DeleteBlock_Durable — delete removes the block durably.
+//   - DeleteBlock_Idempotent — deleting an absent blockID returns nil.
+//   - WalkBlocks_EnumeratesAll — every PutBlock'd object is visited exactly once.
+//   - WalkBlocks_ErrStopWalk — ErrStopWalk halts enumeration cleanly (returns nil).
+//   - WalkBlocks_SkipsCASObjects — WalkBlocks does NOT surface blocks written by PutBlock only; see note.
+//   - PutBlock_Idempotent — second PutBlock for same ID overwrites content.
+//   - PutBlock_ZeroBody — zero-byte block is accepted; GetBlock returns empty slice.
+//   - PutBlock_Concurrent_SameID — concurrent same-ID PutBlocks produce a coherent result.
+func RemoteBlockStoreConformance(t *testing.T, factory RemoteBlockStoreFactory) {
+	t.Helper()
+
+	t.Run("PutBlock_GetBlock_RoundTrip", func(t *testing.T) {
+		testRBSPutGetRoundTrip(t, factory)
+	})
+	t.Run("GetBlock_NoAliasing", func(t *testing.T) {
+		testRBSGetNoAliasing(t, factory)
+	})
+	t.Run("GetBlock_NotFound", func(t *testing.T) {
+		testRBSGetNotFound(t, factory)
+	})
+	t.Run("GetBlockRange_Mid", func(t *testing.T) {
+		testRBSGetBlockRangeMid(t, factory)
+	})
+	t.Run("GetBlockRange_PastEOFClamped", func(t *testing.T) {
+		testRBSGetBlockRangePastEOFClamped(t, factory)
+	})
+	t.Run("GetBlockRange_InvalidOffset", func(t *testing.T) {
+		testRBSGetBlockRangeInvalidOffset(t, factory)
+	})
+	t.Run("GetBlockRange_InvalidSize", func(t *testing.T) {
+		testRBSGetBlockRangeInvalidSize(t, factory)
+	})
+	t.Run("GetBlockRange_ZeroLength", func(t *testing.T) {
+		testRBSGetBlockRangeZeroLength(t, factory)
+	})
+	t.Run("GetBlockRange_NotFound", func(t *testing.T) {
+		testRBSGetBlockRangeNotFound(t, factory)
+	})
+	t.Run("DeleteBlock_Durable", func(t *testing.T) {
+		testRBSDeleteBlockDurable(t, factory)
+	})
+	t.Run("DeleteBlock_Idempotent", func(t *testing.T) {
+		testRBSDeleteBlockIdempotent(t, factory)
+	})
+	t.Run("WalkBlocks_EnumeratesAll", func(t *testing.T) {
+		testRBSWalkBlocksEnumeratesAll(t, factory)
+	})
+	t.Run("WalkBlocks_ErrStopWalk", func(t *testing.T) {
+		testRBSWalkBlocksStopWalk(t, factory)
+	})
+	t.Run("PutBlock_Idempotent", func(t *testing.T) {
+		testRBSPutBlockIdempotent(t, factory)
+	})
+	t.Run("PutBlock_ZeroBody", func(t *testing.T) {
+		testRBSPutBlockZeroBody(t, factory)
+	})
+	t.Run("PutBlock_Concurrent_SameID", func(t *testing.T) {
+		testRBSPutBlockConcurrentSameID(t, factory)
+	})
+}
+
+// ---- subtest implementations ----
+
+func testRBSPutGetRoundTrip(t *testing.T, factory RemoteBlockStoreFactory) {
+	t.Helper()
+	s, cleanup := factory(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	data := []byte("conformance: RemoteBlockStore round-trip payload")
+	if err := s.PutBlock(ctx, "blk-rtrip", strings.NewReader(string(data))); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+	got, err := s.GetBlock(ctx, "blk-rtrip")
+	if err != nil {
+		t.Fatalf("GetBlock: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("GetBlock = %q, want %q", got, data)
+	}
+}
+
+func testRBSGetNoAliasing(t *testing.T, factory RemoteBlockStoreFactory) {
+	t.Helper()
+	s, cleanup := factory(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	original := []byte("aliasing-guard payload for RemoteBlockStore")
+	if err := s.PutBlock(ctx, "blk-alias", strings.NewReader(string(original))); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+
+	got1, err := s.GetBlock(ctx, "blk-alias")
+	if err != nil {
+		t.Fatalf("GetBlock #1: %v", err)
+	}
+	// Mutate the returned slice — the store must not share its internal buffer.
+	got1[0] ^= 0xFF
+
+	got2, err := s.GetBlock(ctx, "blk-alias")
+	if err != nil {
+		t.Fatalf("GetBlock #2: %v", err)
+	}
+	if !bytes.Equal(got2, original) {
+		t.Fatalf("GetBlock aliasing: mutating first-Get slice changed second-Get result")
+	}
+}
+
+func testRBSGetNotFound(t *testing.T, factory RemoteBlockStoreFactory) {
+	t.Helper()
+	s, cleanup := factory(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	if _, err := s.GetBlock(ctx, "absent-block-id"); !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("GetBlock absent: want ErrChunkNotFound, got %v", err)
+	}
+}
+
+func testRBSGetBlockRangeMid(t *testing.T, factory RemoteBlockStoreFactory) {
+	t.Helper()
+	s, cleanup := factory(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	data := []byte("0123456789abcdef") // 16 bytes
+	if err := s.PutBlock(ctx, "blk-range", strings.NewReader(string(data))); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+
+	got, err := s.GetBlockRange(ctx, "blk-range", 4, 8)
+	if err != nil {
+		t.Fatalf("GetBlockRange mid: %v", err)
+	}
+	want := data[4:12] // "456789ab"
+	if !bytes.Equal(got, want) {
+		t.Fatalf("GetBlockRange mid = %q, want %q", got, want)
+	}
+}
+
+func testRBSGetBlockRangePastEOFClamped(t *testing.T, factory RemoteBlockStoreFactory) {
+	t.Helper()
+	s, cleanup := factory(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	data := []byte("0123456789abcdef") // 16 bytes
+	if err := s.PutBlock(ctx, "blk-clamp", strings.NewReader(string(data))); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+
+	// offset=8, length=100: runs past the 16-byte EOF; expect the remaining 8 bytes.
+	got, err := s.GetBlockRange(ctx, "blk-clamp", 8, 100)
+	if err != nil {
+		t.Fatalf("GetBlockRange past-EOF length: %v", err)
+	}
+	want := data[8:] // "89abcdef"
+	if !bytes.Equal(got, want) {
+		t.Fatalf("GetBlockRange clamped = %q, want %q", got, want)
+	}
+}
+
+func testRBSGetBlockRangeInvalidOffset(t *testing.T, factory RemoteBlockStoreFactory) {
+	t.Helper()
+	s, cleanup := factory(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	data := []byte("0123456789abcdef")
+	if err := s.PutBlock(ctx, "blk-invoff", strings.NewReader(string(data))); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+
+	// Negative offset: must be caught before the wire call and return ErrInvalidOffset.
+	if _, err := s.GetBlockRange(ctx, "blk-invoff", -1, 4); !errors.Is(err, block.ErrInvalidOffset) {
+		t.Fatalf("GetBlockRange offset=-1: want ErrInvalidOffset, got %v", err)
+	}
+	// Offset strictly past EOF: some backends (S3) cannot detect this without
+	// a pre-flight HEAD and instead surface a native 416. The contract only
+	// guarantees some error — not necessarily ErrInvalidOffset — for this case.
+	// See also pkg/block/remote/s3/store.go GetBlockRange comment.
+	if _, err := s.GetBlockRange(ctx, "blk-invoff", int64(len(data)), 4); err == nil {
+		t.Fatal("GetBlockRange offset=EOF: want error, got nil")
+	}
+}
+
+func testRBSGetBlockRangeInvalidSize(t *testing.T, factory RemoteBlockStoreFactory) {
+	t.Helper()
+	s, cleanup := factory(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	data := []byte("0123456789abcdef")
+	if err := s.PutBlock(ctx, "blk-invsize", strings.NewReader(string(data))); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+
+	// Negative length.
+	if _, err := s.GetBlockRange(ctx, "blk-invsize", 0, -4); !errors.Is(err, block.ErrInvalidSize) {
+		t.Fatalf("GetBlockRange length=-4: want ErrInvalidSize, got %v", err)
+	}
+}
+
+func testRBSGetBlockRangeZeroLength(t *testing.T, factory RemoteBlockStoreFactory) {
+	t.Helper()
+	s, cleanup := factory(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	data := []byte("0123456789abcdef")
+	if err := s.PutBlock(ctx, "blk-zerolen", strings.NewReader(string(data))); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+
+	if _, err := s.GetBlockRange(ctx, "blk-zerolen", 0, 0); !errors.Is(err, block.ErrInvalidSize) {
+		t.Fatalf("GetBlockRange length=0: want ErrInvalidSize, got %v", err)
+	}
+}
+
+func testRBSGetBlockRangeNotFound(t *testing.T, factory RemoteBlockStoreFactory) {
+	t.Helper()
+	s, cleanup := factory(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	if _, err := s.GetBlockRange(ctx, "absent-block", 0, 4); !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("GetBlockRange absent: want ErrChunkNotFound, got %v", err)
+	}
+}
+
+func testRBSDeleteBlockDurable(t *testing.T, factory RemoteBlockStoreFactory) {
+	t.Helper()
+	s, cleanup := factory(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	data := []byte("to-be-deleted block content")
+	if err := s.PutBlock(ctx, "blk-del", strings.NewReader(string(data))); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+
+	// Confirm presence before delete.
+	if _, err := s.GetBlock(ctx, "blk-del"); err != nil {
+		t.Fatalf("GetBlock before DeleteBlock: %v", err)
+	}
+
+	if err := s.DeleteBlock(ctx, "blk-del"); err != nil {
+		t.Fatalf("DeleteBlock: %v", err)
+	}
+
+	// Block must be gone.
+	if _, err := s.GetBlock(ctx, "blk-del"); !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("GetBlock after DeleteBlock: want ErrChunkNotFound, got %v", err)
+	}
+}
+
+func testRBSDeleteBlockIdempotent(t *testing.T, factory RemoteBlockStoreFactory) {
+	t.Helper()
+	s, cleanup := factory(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	// Delete absent block — must not error.
+	if err := s.DeleteBlock(ctx, "never-existed"); err != nil {
+		t.Fatalf("DeleteBlock on absent block: want nil, got %v", err)
+	}
+
+	// Put then delete twice.
+	data := []byte("idempotent-delete payload")
+	if err := s.PutBlock(ctx, "blk-idem-del", strings.NewReader(string(data))); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+	if err := s.DeleteBlock(ctx, "blk-idem-del"); err != nil {
+		t.Fatalf("DeleteBlock first: %v", err)
+	}
+	if err := s.DeleteBlock(ctx, "blk-idem-del"); err != nil {
+		t.Fatalf("DeleteBlock second (idempotent): %v", err)
+	}
+}
+
+func testRBSWalkBlocksEnumeratesAll(t *testing.T, factory RemoteBlockStoreFactory) {
+	t.Helper()
+	s, cleanup := factory(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	want := make(map[string]int64)
+	for i := 0; i < 5; i++ {
+		id := fmt.Sprintf("walk-blk-%d", i)
+		data := []byte(fmt.Sprintf("walk-payload-%d-xxxx", i))
+		want[id] = int64(len(data))
+		if err := s.PutBlock(ctx, id, strings.NewReader(string(data))); err != nil {
+			t.Fatalf("PutBlock %s: %v", id, err)
+		}
+	}
+
+	seen := make(map[string]int)
+	err := s.WalkBlocks(ctx, func(blockID string, m block.Meta) error {
+		seen[blockID]++
+		if m.LastModified.IsZero() {
+			t.Errorf("WalkBlocks: LastModified is zero for %s", blockID)
+		}
+		if w, ok := want[blockID]; ok && m.Size != w {
+			t.Errorf("WalkBlocks: Size for %s = %d, want %d", blockID, m.Size, w)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkBlocks: %v", err)
+	}
+
+	if len(seen) != len(want) {
+		t.Fatalf("WalkBlocks visited %d blocks, want %d; seen=%v", len(seen), len(want), seen)
+	}
+	for id, n := range seen {
+		if n != 1 {
+			t.Errorf("WalkBlocks: block %s visited %d times, want 1", id, n)
+		}
+	}
+}
+
+func testRBSWalkBlocksStopWalk(t *testing.T, factory RemoteBlockStoreFactory) {
+	t.Helper()
+	s, cleanup := factory(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	for i := 0; i < 4; i++ {
+		id := fmt.Sprintf("stop-blk-%d", i)
+		if err := s.PutBlock(ctx, id, strings.NewReader(id)); err != nil {
+			t.Fatalf("PutBlock: %v", err)
+		}
+	}
+
+	seen := 0
+	err := s.WalkBlocks(ctx, func(string, block.Meta) error {
+		seen++
+		return block.ErrStopWalk
+	})
+	if err != nil {
+		t.Fatalf("WalkBlocks ErrStopWalk: want nil, got %v", err)
+	}
+	if seen != 1 {
+		t.Errorf("WalkBlocks: expected to stop after first callback; saw %d", seen)
+	}
+}
+
+func testRBSPutBlockIdempotent(t *testing.T, factory RemoteBlockStoreFactory) {
+	t.Helper()
+	s, cleanup := factory(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	original := []byte("original-block-v1")
+	updated := []byte("updated-block-v2-xxxx")
+
+	if err := s.PutBlock(ctx, "blk-idem", strings.NewReader(string(original))); err != nil {
+		t.Fatalf("PutBlock original: %v", err)
+	}
+	if err := s.PutBlock(ctx, "blk-idem", strings.NewReader(string(updated))); err != nil {
+		t.Fatalf("PutBlock updated: %v", err)
+	}
+
+	got, err := s.GetBlock(ctx, "blk-idem")
+	if err != nil {
+		t.Fatalf("GetBlock: %v", err)
+	}
+	if !bytes.Equal(got, updated) {
+		t.Fatalf("PutBlock idempotent: got %q, want %q", got, updated)
+	}
+}
+
+func testRBSPutBlockZeroBody(t *testing.T, factory RemoteBlockStoreFactory) {
+	t.Helper()
+	s, cleanup := factory(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	if err := s.PutBlock(ctx, "blk-zero", strings.NewReader("")); err != nil {
+		t.Fatalf("PutBlock zero-byte: %v", err)
+	}
+	got, err := s.GetBlock(ctx, "blk-zero")
+	if err != nil {
+		t.Fatalf("GetBlock zero-byte: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("GetBlock zero-byte: want 0 bytes, got %d", len(got))
+	}
+}
+
+func testRBSPutBlockConcurrentSameID(t *testing.T, factory RemoteBlockStoreFactory) {
+	t.Helper()
+	s, cleanup := factory(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	const id = "blk-concurrent"
+	payloadA := strings.Repeat("A", 512)
+	payloadB := strings.Repeat("B", 512)
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		errs[0] = s.PutBlock(ctx, id, strings.NewReader(payloadA))
+	}()
+	go func() {
+		defer wg.Done()
+		errs[1] = s.PutBlock(ctx, id, strings.NewReader(payloadB))
+	}()
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("concurrent PutBlock[%d]: %v", i, err)
+		}
+	}
+
+	got, err := s.GetBlock(ctx, id)
+	if err != nil {
+		t.Fatalf("GetBlock after concurrent put: %v", err)
+	}
+	// Must be entirely A or entirely B — no interleaved bytes.
+	if len(got) != 512 {
+		t.Fatalf("GetBlock length = %d, want 512", len(got))
+	}
+	first := got[0]
+	if first != 'A' && first != 'B' {
+		t.Fatalf("unexpected first byte 0x%02X", first)
+	}
+	for i, b := range got {
+		if b != first {
+			t.Fatalf("GetBlock[%d] = 0x%02X, want all 0x%02X (concurrent blend detected)", i, b, first)
+		}
+	}
+}

--- a/pkg/block/blockstoretest/remoteblock.go
+++ b/pkg/block/blockstoretest/remoteblock.go
@@ -35,7 +35,8 @@ type RemoteBlockStoreFactory func(t *testing.T) (RemoteBlockStore, func())
 //   - GetBlock_NotFound — absent blockID returns ErrChunkNotFound.
 //   - GetBlockRange_Mid — range read from the middle of a stored block.
 //   - GetBlockRange_PastEOFClamped — length past EOF is clamped without error.
-//   - GetBlockRange_InvalidOffset — negative / past-EOF offset returns ErrInvalidOffset.
+//   - GetBlockRange_InvalidOffset — negative offset returns ErrInvalidOffset (a past-EOF
+//     offset cannot be detected without a HEAD, so backends may surface a native error).
 //   - GetBlockRange_InvalidSize — zero / negative length returns ErrInvalidSize.
 //   - GetBlockRange_ZeroLength — explicit zero-length returns ErrInvalidSize.
 //   - GetBlockRange_NotFound — absent blockID returns ErrChunkNotFound.
@@ -43,7 +44,6 @@ type RemoteBlockStoreFactory func(t *testing.T) (RemoteBlockStore, func())
 //   - DeleteBlock_Idempotent — deleting an absent blockID returns nil.
 //   - WalkBlocks_EnumeratesAll — every PutBlock'd object is visited exactly once.
 //   - WalkBlocks_ErrStopWalk — ErrStopWalk halts enumeration cleanly (returns nil).
-//   - WalkBlocks_SkipsCASObjects — WalkBlocks does NOT surface blocks written by PutBlock only; see note.
 //   - PutBlock_Idempotent — second PutBlock for same ID overwrites content.
 //   - PutBlock_ZeroBody — zero-byte block is accepted; GetBlock returns empty slice.
 //   - PutBlock_Concurrent_SameID — concurrent same-ID PutBlocks produce a coherent result.

--- a/pkg/block/encryption/chunk_read_test.go
+++ b/pkg/block/encryption/chunk_read_test.go
@@ -39,7 +39,7 @@ func TestEncryptedRemote_ReadChunk(t *testing.T) {
 	filler := bytes.Repeat([]byte{0x01}, 37)
 	blockData := append(append([]byte{}, filler...), wire...)
 	const blockID = "enc-block-1"
-	if err := inner.PutBlock(blockID, blockData); err != nil {
+	if err := inner.PutBlock(ctx, blockID, bytes.NewReader(blockData)); err != nil {
 		t.Fatalf("PutBlock: %v", err)
 	}
 

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -208,7 +208,7 @@ func (m *Syncer) readChunkVerified(ctx context.Context, loc block.ChunkLocator, 
 		return nil, fmt.Errorf("chunk %s has block locator %q but remote store lacks block-read support: %w",
 			hash, loc.BlockID, remote.ErrChunkReadUnsupported)
 	}
-	data, err := pcr.ReadChunk(ctx, loc.BlockID, loc.Offset, loc.Length, hash)
+	data, err := pcr.ReadChunk(ctx, loc.BlockID, loc.WireOffset, loc.WireLength, hash)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/block/engine/locator_fetch_test.go
+++ b/pkg/block/engine/locator_fetch_test.go
@@ -53,7 +53,7 @@ func TestDispatchRemoteFetch_StandaloneRoundTrip(t *testing.T) {
 		t.Fatalf("remote Put: %v", err)
 	}
 	// The write path records a standalone locator on MarkSynced.
-	if err := ms.MarkSynced(ctx, hash, block.ChunkLocator{Length: int64(len(data))}); err != nil {
+	if err := ms.MarkSynced(ctx, hash, block.ChunkLocator{WireLength: int64(len(data))}); err != nil {
 		t.Fatalf("MarkSynced: %v", err)
 	}
 
@@ -121,7 +121,7 @@ func TestDispatchRemoteFetch_BlockLocator(t *testing.T) {
 	}
 
 	hash := block.ContentHash(blake3.Sum256(target))
-	loc := block.ChunkLocator{BlockID: blockID, Offset: int64(len(filler)), Length: int64(len(target))}
+	loc := block.ChunkLocator{BlockID: blockID, WireOffset: int64(len(filler)), WireLength: int64(len(target))}
 	if err := ms.MarkSynced(ctx, hash, loc); err != nil {
 		t.Fatalf("MarkSynced block: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestDispatchRemoteFetch_BlockLocatorVerifyMismatch(t *testing.T) {
 	if err := rem.PutBlock(blockID, corrupt); err != nil {
 		t.Fatalf("PutBlock: %v", err)
 	}
-	loc := block.ChunkLocator{BlockID: blockID, Offset: 0, Length: int64(len(target))}
+	loc := block.ChunkLocator{BlockID: blockID, WireOffset: 0, WireLength: int64(len(target))}
 	if err := ms.MarkSynced(ctx, hash, loc); err != nil {
 		t.Fatalf("MarkSynced: %v", err)
 	}

--- a/pkg/block/engine/locator_fetch_test.go
+++ b/pkg/block/engine/locator_fetch_test.go
@@ -116,7 +116,7 @@ func TestDispatchRemoteFetch_BlockLocator(t *testing.T) {
 	target := bytes.Repeat([]byte{0x22}, 4096)
 	blockData := append(append([]byte{}, filler...), target...)
 	const blockID = "block-test-0001"
-	if err := rem.PutBlock(blockID, blockData); err != nil {
+	if err := rem.PutBlock(ctx, blockID, bytes.NewReader(blockData)); err != nil {
 		t.Fatalf("PutBlock: %v", err)
 	}
 
@@ -150,7 +150,7 @@ func TestDispatchRemoteFetch_BlockLocatorVerifyMismatch(t *testing.T) {
 	// Store a block whose bytes do NOT match the claimed hash.
 	corrupt := bytes.Repeat([]byte{0x34}, 4096)
 	const blockID = "block-corrupt"
-	if err := rem.PutBlock(blockID, corrupt); err != nil {
+	if err := rem.PutBlock(ctx, blockID, bytes.NewReader(corrupt)); err != nil {
 		t.Fatalf("PutBlock: %v", err)
 	}
 	loc := block.ChunkLocator{BlockID: blockID, WireOffset: 0, WireLength: int64(len(target))}

--- a/pkg/block/locator.go
+++ b/pkg/block/locator.go
@@ -7,23 +7,23 @@ package block
 //
 //   - BlockID == "" means the chunk is a standalone object at the canonical CAS
 //     key cas/XX/YY/<hash> (see FormatCASKey) and occupies the WHOLE object.
-//     Offset/Length are not consulted in this case — the read path GETs the
-//     entire object and verifies it. This is the value EVERY chunk resolves to
-//     today (and what a synced hash with no recorded locator defaults to), so
+//     WireOffset/WireLength are not consulted in this case — the read path GETs
+//     the entire object and verifies it. This is the value EVERY chunk resolves
+//     to today (and what a synced hash with no recorded locator defaults to), so
 //     existing data needs no migration.
 //   - BlockID != "" means the chunk lives inside the block object blocks/<BlockID>
-//     (see FormatBlockKey), and its wire bytes occupy [Offset, Offset+Length).
-//     The read path issues a ranged GET against the block object. Only PR3b's
-//     packer ever produces such a locator.
+//     (see FormatBlockKey), and its wire bytes occupy
+//     [WireOffset, WireOffset+WireLength). The read path issues a ranged GET
+//     against the block object. Only PR3b's packer ever produces such a locator.
 type ChunkLocator struct {
 	// BlockID identifies the enclosing block object. Empty means standalone.
 	BlockID string
-	// Offset is the byte offset of the chunk's wire bytes within the block
-	// object. Zero (and unused) for standalone chunks.
-	Offset int64
-	// Length is the chunk's wire byte length within the block object. Zero
-	// (and unused) for standalone chunks, whose length is the whole object.
-	Length int64
+	// WireOffset is the chunk's wire-byte offset within the block object.
+	// Zero (and unused) for standalone chunks.
+	WireOffset int64
+	// WireLength is the chunk's wire-byte length within the block object.
+	// Zero (and unused) for standalone chunks, whose length is the whole object.
+	WireLength int64
 }
 
 // IsStandalone reports whether the chunk is stored as its own CAS object

--- a/pkg/block/remote/memory/store.go
+++ b/pkg/block/remote/memory/store.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -19,6 +20,7 @@ import (
 // Compile-time interface satisfaction check.
 var (
 	_ remote.RemoteStore       = (*Store)(nil)
+	_ remote.RemoteBlockStore  = (*Store)(nil)
 	_ remote.ChunkReader       = (*Store)(nil)
 	_ block.DurabilityReporter = (*Store)(nil)
 )
@@ -37,10 +39,10 @@ type Store struct {
 	mu     sync.RWMutex
 	blocks map[block.ContentHash]*memBlock
 	// blocksByID holds block objects keyed by BlockID (#1414). Populated via PutBlock
-	// (used by tests and the future packer); read by ReadChunk. Separate
-	// from blocks because block objects are keyed by an opaque BlockID string,
-	// not a content hash.
-	blocksByID map[string][]byte
+	// (used by tests and the future packer); read by ReadChunk and the new
+	// block-keyed methods. Separate from blocks because block objects are keyed
+	// by an opaque BlockID string, not a content hash.
+	blocksByID map[string]*memBlock
 	// nowFn returns the current time for the store. Tests can override
 	// this to manipulate LastModified deterministically.
 	nowFn  func() time.Time
@@ -56,26 +58,130 @@ type Store struct {
 func New() *Store {
 	return &Store{
 		blocks:     make(map[block.ContentHash]*memBlock),
-		blocksByID: make(map[string][]byte),
+		blocksByID: make(map[string]*memBlock),
 		nowFn:      time.Now,
 	}
 }
 
-// PutBlock stores a block object under blockID. It is the in-memory analogue of an
-// S3 PutObject(blocks/<blockID>); used by tests (and the future PR3b packer) to
-// stage blocksByID that ReadChunk then ranges into. A defensive copy is taken.
-func (s *Store) PutBlock(blockID string, data []byte) error {
+// PutBlock writes the content of r under blocks/<blockID>. Implements
+// remote.RemoteBlockStore. Idempotent: a second call overwrites silently.
+// A defensive copy is taken via io.ReadAll; callers may reuse r after return.
+func (s *Store) PutBlock(_ context.Context, blockID string, r io.Reader) error {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return fmt.Errorf("memory put block %s: %w", blockID, err)
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
 		return block.ErrStoreClosed
 	}
 	if s.blocksByID == nil {
-		s.blocksByID = make(map[string][]byte)
+		s.blocksByID = make(map[string]*memBlock)
 	}
 	copied := make([]byte, len(data))
 	copy(copied, data)
-	s.blocksByID[blockID] = copied
+	s.blocksByID[blockID] = &memBlock{data: copied, lastModified: s.nowFn()}
+	return nil
+}
+
+// GetBlock returns the full bytes of the block object identified by blockID.
+// Returns block.ErrChunkNotFound when the block is absent.
+func (s *Store) GetBlock(_ context.Context, blockID string) ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return nil, block.ErrStoreClosed
+	}
+	mb, ok := s.blocksByID[blockID]
+	if !ok {
+		return nil, block.ErrChunkNotFound
+	}
+	copied := make([]byte, len(mb.data))
+	copy(copied, mb.data)
+	return copied, nil
+}
+
+// GetBlockRange returns [offset, offset+length) bytes of the block object
+// identified by blockID. Bounds semantics mirror GetRange.
+func (s *Store) GetBlockRange(_ context.Context, blockID string, offset, length int64) ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return nil, block.ErrStoreClosed
+	}
+	mb, ok := s.blocksByID[blockID]
+	if !ok {
+		return nil, block.ErrChunkNotFound
+	}
+	if offset < 0 || offset >= int64(len(mb.data)) {
+		return nil, block.ErrInvalidOffset
+	}
+	if length <= 0 {
+		return nil, block.ErrInvalidSize
+	}
+	size := int64(len(mb.data))
+	end := size
+	if length <= size-offset {
+		end = offset + length
+	}
+	result := make([]byte, end-offset)
+	copy(result, mb.data[offset:end])
+	return result, nil
+}
+
+// DeleteBlock removes the block object keyed by blockID. Idempotent:
+// deleting an absent blockID returns nil.
+func (s *Store) DeleteBlock(_ context.Context, blockID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return block.ErrStoreClosed
+	}
+	delete(s.blocksByID, blockID)
+	return nil
+}
+
+// WalkBlocks enumerates every block object in the store. The callback receives
+// the blockID and block.Meta. Honors block.ErrStopWalk; any other callback
+// error halts the walk and is wrapped as "walk halted at <blockID>: %w".
+// Context cancellation aborts immediately.
+func (s *Store) WalkBlocks(ctx context.Context, fn func(blockID string, meta block.Meta) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.RLock()
+	if s.closed {
+		s.mu.RUnlock()
+		return block.ErrStoreClosed
+	}
+	type entry struct {
+		id   string
+		meta block.Meta
+	}
+	snap := make([]entry, 0, len(s.blocksByID))
+	for id, mb := range s.blocksByID {
+		snap = append(snap, entry{
+			id: id,
+			meta: block.Meta{
+				Size:         int64(len(mb.data)),
+				LastModified: mb.lastModified,
+			},
+		})
+	}
+	s.mu.RUnlock()
+
+	for _, e := range snap {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if cberr := fn(e.id, e.meta); cberr != nil {
+			if errors.Is(cberr, block.ErrStopWalk) {
+				return nil
+			}
+			return fmt.Errorf("walk halted at %s: %w", e.id, cberr)
+		}
+	}
 	return nil
 }
 
@@ -89,10 +195,11 @@ func (s *Store) ReadChunk(_ context.Context, blockID string, offset, length int6
 	if s.closed {
 		return nil, block.ErrStoreClosed
 	}
-	data, ok := s.blocksByID[blockID]
+	mb, ok := s.blocksByID[blockID]
 	if !ok {
 		return nil, block.ErrChunkNotFound
 	}
+	data := mb.data
 	if offset < 0 || offset >= int64(len(data)) {
 		return nil, block.ErrInvalidOffset
 	}
@@ -353,6 +460,7 @@ func (s *Store) Close() error {
 
 	s.closed = true
 	s.blocks = nil
+	s.blocksByID = nil
 	return nil
 }
 

--- a/pkg/block/remote/memory/store_test.go
+++ b/pkg/block/remote/memory/store_test.go
@@ -37,6 +37,18 @@ func TestStore_BlockStoreConformance(t *testing.T) {
 	blockstoretest.BlockStoreConformance(t, factory)
 }
 
+// TestMemory_RemoteBlockStoreConformance runs the unified
+// RemoteBlockStoreConformance suite against the in-memory backend. All
+// subtests run in-process with no I/O; they cover the block-keyed (non-CAS)
+// surface: PutBlock/GetBlock/GetBlockRange/DeleteBlock/WalkBlocks.
+func TestMemory_RemoteBlockStoreConformance(t *testing.T) {
+	blockstoretest.RemoteBlockStoreConformance(t, func(t *testing.T) (blockstoretest.RemoteBlockStore, func()) {
+		t.Helper()
+		s := New()
+		return s, func() { _ = s.Close() }
+	})
+}
+
 // hashOf returns the BLAKE3-256 hash of data as a block.ContentHash.
 func hashOf(t *testing.T, data []byte) block.ContentHash {
 	t.Helper()

--- a/pkg/block/remote/memory/store_test.go
+++ b/pkg/block/remote/memory/store_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 	"testing"
 
 	"lukechampine.com/blake3"
@@ -333,7 +334,7 @@ func TestStore_ReadChunk(t *testing.T) {
 	b := bytes.Repeat([]byte{0xB2}, 128)
 	blockData := append(append([]byte{}, a...), b...)
 	const blockID = "block-mem-1"
-	if err := s.PutBlock(blockID, blockData); err != nil {
+	if err := s.PutBlock(ctx, blockID, bytes.NewReader(blockData)); err != nil {
 		t.Fatalf("PutBlock: %v", err)
 	}
 
@@ -500,5 +501,300 @@ func TestStore_TotalSize(t *testing.T) {
 
 	if s.TotalSize() != 10 {
 		t.Errorf("TotalSize returned %d, want 10", s.TotalSize())
+	}
+}
+
+// ---- RemoteBlockStore method tests ----
+
+// TestStore_PutBlock_GetBlock_RoundTrip verifies a PutBlock followed by
+// GetBlock returns the exact bytes that were written.
+func TestStore_PutBlock_GetBlock_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	s := New()
+	defer func() { _ = s.Close() }()
+
+	data := []byte("block round-trip payload")
+	if err := s.PutBlock(ctx, "blk-1", bytes.NewReader(data)); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+	got, err := s.GetBlock(ctx, "blk-1")
+	if err != nil {
+		t.Fatalf("GetBlock: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("GetBlock = %q, want %q", got, data)
+	}
+}
+
+// TestStore_GetBlock_NotFound pins the ErrChunkNotFound mapping.
+func TestStore_GetBlock_NotFound(t *testing.T) {
+	ctx := context.Background()
+	s := New()
+	defer func() { _ = s.Close() }()
+
+	if _, err := s.GetBlock(ctx, "absent"); !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("GetBlock absent: want ErrChunkNotFound, got %v", err)
+	}
+}
+
+// TestStore_GetBlockRange_Bounds exercises mid, past-EOF clamping, and the
+// invalid-offset / invalid-size sentinels.
+func TestStore_GetBlockRange_Bounds(t *testing.T) {
+	ctx := context.Background()
+	s := New()
+	defer func() { _ = s.Close() }()
+
+	data := []byte("0123456789abcdef") // 16 bytes
+	const id = "blk-range"
+	if err := s.PutBlock(ctx, id, bytes.NewReader(data)); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+
+	// Mid-block.
+	got, err := s.GetBlockRange(ctx, id, 4, 8)
+	if err != nil {
+		t.Fatalf("GetBlockRange mid: %v", err)
+	}
+	if string(got) != "456789ab" {
+		t.Fatalf("GetBlockRange mid = %q, want %q", got, "456789ab")
+	}
+
+	// Past-EOF length: clamped to remaining bytes.
+	got, err = s.GetBlockRange(ctx, id, 8, 100)
+	if err != nil {
+		t.Fatalf("GetBlockRange past-EOF length: %v", err)
+	}
+	if string(got) != "89abcdef" {
+		t.Fatalf("GetBlockRange clamped = %q, want %q", got, "89abcdef")
+	}
+
+	// Offset at EOF: ErrInvalidOffset.
+	if _, err := s.GetBlockRange(ctx, id, 16, 4); !errors.Is(err, block.ErrInvalidOffset) {
+		t.Fatalf("offset=EOF: want ErrInvalidOffset, got %v", err)
+	}
+
+	// Negative offset: ErrInvalidOffset.
+	if _, err := s.GetBlockRange(ctx, id, -1, 4); !errors.Is(err, block.ErrInvalidOffset) {
+		t.Fatalf("negative offset: want ErrInvalidOffset, got %v", err)
+	}
+
+	// Zero length: ErrInvalidSize.
+	if _, err := s.GetBlockRange(ctx, id, 0, 0); !errors.Is(err, block.ErrInvalidSize) {
+		t.Fatalf("zero length: want ErrInvalidSize, got %v", err)
+	}
+
+	// Negative length: ErrInvalidSize.
+	if _, err := s.GetBlockRange(ctx, id, 0, -1); !errors.Is(err, block.ErrInvalidSize) {
+		t.Fatalf("negative length: want ErrInvalidSize, got %v", err)
+	}
+
+	// MaxInt64 length clamps without overflow.
+	got, err = s.GetBlockRange(ctx, id, 8, math.MaxInt64)
+	if err != nil {
+		t.Fatalf("GetBlockRange MaxInt64 length: %v", err)
+	}
+	if string(got) != "89abcdef" {
+		t.Fatalf("GetBlockRange MaxInt64 clamp = %q, want %q", got, "89abcdef")
+	}
+
+	// Missing block.
+	if _, err := s.GetBlockRange(ctx, "missing", 0, 4); !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("missing block: want ErrChunkNotFound, got %v", err)
+	}
+}
+
+// TestStore_DeleteBlock confirms idempotent delete and that GetBlock misses
+// after deletion.
+func TestStore_DeleteBlock(t *testing.T) {
+	ctx := context.Background()
+	s := New()
+	defer func() { _ = s.Close() }()
+
+	data := []byte("to be deleted")
+	if err := s.PutBlock(ctx, "blk-del", bytes.NewReader(data)); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+	if err := s.DeleteBlock(ctx, "blk-del"); err != nil {
+		t.Fatalf("DeleteBlock: %v", err)
+	}
+	if _, err := s.GetBlock(ctx, "blk-del"); !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("GetBlock after delete: want ErrChunkNotFound, got %v", err)
+	}
+	// Idempotent: deleting absent block returns nil.
+	if err := s.DeleteBlock(ctx, "blk-del"); err != nil {
+		t.Fatalf("DeleteBlock idempotent: %v", err)
+	}
+}
+
+// TestStore_WalkBlocks_EnumeratesAll verifies WalkBlocks visits every block
+// exactly once with a non-zero LastModified and correct size.
+func TestStore_WalkBlocks_EnumeratesAll(t *testing.T) {
+	ctx := context.Background()
+	s := New()
+	defer func() { _ = s.Close() }()
+
+	want := map[string]int{}
+	for i := 0; i < 5; i++ {
+		id := fmt.Sprintf("blk-%d", i)
+		data := []byte(fmt.Sprintf("block-data-%d", i))
+		want[id] = len(data)
+		if err := s.PutBlock(ctx, id, bytes.NewReader(data)); err != nil {
+			t.Fatalf("PutBlock %s: %v", id, err)
+		}
+	}
+
+	seen := map[string]int{}
+	err := s.WalkBlocks(ctx, func(blockID string, meta block.Meta) error {
+		seen[blockID]++
+		if meta.LastModified.IsZero() {
+			t.Errorf("WalkBlocks: LastModified zero for %s", blockID)
+		}
+		if wantSize, ok := want[blockID]; ok && meta.Size != int64(wantSize) {
+			t.Errorf("WalkBlocks size for %s = %d, want %d", blockID, meta.Size, wantSize)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkBlocks: %v", err)
+	}
+	if len(seen) != len(want) {
+		t.Fatalf("WalkBlocks visited %d blocks, want %d", len(seen), len(want))
+	}
+	for id, n := range seen {
+		if n != 1 {
+			t.Errorf("WalkBlocks visited %s %d times, want 1", id, n)
+		}
+	}
+}
+
+// TestStore_WalkBlocks_StopWalk pins the ErrStopWalk clean-exit contract.
+func TestStore_WalkBlocks_StopWalk(t *testing.T) {
+	ctx := context.Background()
+	s := New()
+	defer func() { _ = s.Close() }()
+
+	for i := 0; i < 3; i++ {
+		id := fmt.Sprintf("blk-stop-%d", i)
+		if err := s.PutBlock(ctx, id, bytes.NewReader([]byte(id))); err != nil {
+			t.Fatalf("PutBlock: %v", err)
+		}
+	}
+	seen := 0
+	err := s.WalkBlocks(ctx, func(string, block.Meta) error {
+		seen++
+		return block.ErrStopWalk
+	})
+	if err != nil {
+		t.Fatalf("WalkBlocks ErrStopWalk: want nil, got %v", err)
+	}
+	if seen != 1 {
+		t.Fatalf("WalkBlocks should stop after first ErrStopWalk; saw %d", seen)
+	}
+}
+
+// TestStore_WalkBlocks_ErrorWrap pins the "walk halted at <blockID>: %w"
+// wrapping contract for a non-sentinel callback error.
+func TestStore_WalkBlocks_ErrorWrap(t *testing.T) {
+	ctx := context.Background()
+	s := New()
+	defer func() { _ = s.Close() }()
+
+	if err := s.PutBlock(ctx, "blk-wrap", bytes.NewReader([]byte("data"))); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+	sentinel := errors.New("boom")
+	err := s.WalkBlocks(ctx, func(string, block.Meta) error { return sentinel })
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("WalkBlocks err does not wrap sentinel: got %v", err)
+	}
+	if !strings.Contains(err.Error(), "walk halted at") {
+		t.Errorf("WalkBlocks err missing 'walk halted at' prefix: %q", err.Error())
+	}
+}
+
+// TestStore_PutBlock_Idempotent verifies a second PutBlock with the same
+// blockID silently overwrites with the new content.
+func TestStore_PutBlock_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	s := New()
+	defer func() { _ = s.Close() }()
+
+	original := []byte("original-content")
+	updated := []byte("updated-content-v2")
+	if err := s.PutBlock(ctx, "blk-idem", bytes.NewReader(original)); err != nil {
+		t.Fatalf("PutBlock original: %v", err)
+	}
+	if err := s.PutBlock(ctx, "blk-idem", bytes.NewReader(updated)); err != nil {
+		t.Fatalf("PutBlock updated: %v", err)
+	}
+	got, err := s.GetBlock(ctx, "blk-idem")
+	if err != nil {
+		t.Fatalf("GetBlock: %v", err)
+	}
+	if !bytes.Equal(got, updated) {
+		t.Fatalf("PutBlock idempotent: got %q, want %q", got, updated)
+	}
+}
+
+// TestStore_PutBlock_ZeroBody verifies a zero-byte body is accepted and
+// round-trips correctly.
+func TestStore_PutBlock_ZeroBody(t *testing.T) {
+	ctx := context.Background()
+	s := New()
+	defer func() { _ = s.Close() }()
+
+	if err := s.PutBlock(ctx, "blk-zero", bytes.NewReader(nil)); err != nil {
+		t.Fatalf("PutBlock zero-byte: %v", err)
+	}
+	got, err := s.GetBlock(ctx, "blk-zero")
+	if err != nil {
+		t.Fatalf("GetBlock zero-byte: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("GetBlock zero-byte: want 0 bytes, got %d", len(got))
+	}
+}
+
+// TestStore_PutBlock_Concurrent_SameID verifies concurrent PutBlock calls for
+// the same blockID do not race or corrupt the store. The final stored value must
+// be one of the two payloads (not a blend), and GetBlock must return consistent
+// bytes.
+func TestStore_PutBlock_Concurrent_SameID(t *testing.T) {
+	ctx := context.Background()
+	s := New()
+	defer func() { _ = s.Close() }()
+
+	const id = "blk-concurrent"
+	payloadA := bytes.Repeat([]byte{0xAA}, 1024)
+	payloadB := bytes.Repeat([]byte{0xBB}, 1024)
+
+	done := make(chan error, 2)
+	go func() { done <- s.PutBlock(ctx, id, bytes.NewReader(payloadA)) }()
+	go func() { done <- s.PutBlock(ctx, id, bytes.NewReader(payloadB)) }()
+	for i := 0; i < 2; i++ {
+		if err := <-done; err != nil {
+			t.Errorf("concurrent PutBlock: %v", err)
+		}
+	}
+
+	got, err := s.GetBlock(ctx, id)
+	if err != nil {
+		t.Fatalf("GetBlock after concurrent put: %v", err)
+	}
+	// Must be one of the two payloads, all-same-byte.
+	if len(got) != 1024 {
+		t.Fatalf("GetBlock length = %d, want 1024", len(got))
+	}
+	for _, b := range got {
+		if b != 0xAA && b != 0xBB {
+			t.Fatalf("GetBlock returned unexpected byte 0x%02X (not 0xAA or 0xBB)", b)
+		}
+	}
+	// All bytes must be the same value (no interleaving).
+	first := got[0]
+	for i, b := range got {
+		if b != first {
+			t.Fatalf("GetBlock[%d] = 0x%02X, want all 0x%02X (concurrent blend)", i, b, first)
+		}
 	}
 }

--- a/pkg/block/remote/remote.go
+++ b/pkg/block/remote/remote.go
@@ -111,11 +111,13 @@ type RemoteBlockStore interface {
 
 	// GetBlockRange returns [offset, offset+length) bytes of the block
 	// object identified by blockID. Bounds semantics mirror
-	// block.Store.GetRange: ErrInvalidOffset for a negative or past-EOF
-	// offset, ErrInvalidSize for a non-positive length; past-EOF length
-	// is clamped to the object's remaining bytes on backends that support
-	// it (S3 partial-content). Returns block.ErrChunkNotFound when the
-	// block is absent.
+	// block.Store.GetRange: ErrInvalidOffset for a negative offset; a
+	// past-EOF offset cannot be detected here without a HEAD, so
+	// backends surface a native error (S3: 416) instead — the contract
+	// only guarantees some error for offset >= EOF. ErrInvalidSize for a
+	// non-positive length; past-EOF length is clamped to the object's
+	// remaining bytes on backends that support it (S3 partial-content).
+	// Returns block.ErrChunkNotFound when the block is absent.
 	GetBlockRange(ctx context.Context, blockID string, offset, length int64) ([]byte, error)
 
 	// DeleteBlock removes the block object keyed by blockID. Idempotent:

--- a/pkg/block/remote/remote.go
+++ b/pkg/block/remote/remote.go
@@ -7,11 +7,16 @@
 // not expose. The interface embeds block.BlockStore and adds
 // backend-specific extras (ReadBlockVerified for production CAS reads,
 // Close + HealthCheck + Healthcheck for backend lifecycle / health).
+//
+// RemoteBlockStore is the block-keyed (non-CAS) surface for objects stored
+// under the "blocks/" prefix (#1414 object packing). Operations are keyed by
+// an opaque blockID string; the on-wire key is block.FormatBlockKey(blockID).
 package remote
 
 import (
 	"context"
 	"errors"
+	"io"
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/health"
@@ -81,6 +86,52 @@ type RemoteStore interface {
 	// [health.Checker]. Implementations typically delegate to HealthCheck
 	// and wrap the result via [health.ReportFromError].
 	Healthcheck(ctx context.Context) health.Report
+}
+
+// RemoteBlockStore is the block-keyed (non-CAS) remote store contract for
+// objects stored under the "blocks/" prefix (#1414 object packing). Implemented
+// by pkg/block/remote/s3.Store and pkg/block/remote/memory.Store.
+//
+// Objects are keyed by an opaque blockID string; the on-disk/on-wire key shape
+// is block.FormatBlockKey(blockID) = "blocks/<blockID>". This surface is
+// intentionally separate from RemoteStore (CAS-keyed) — the two namespaces
+// never collide because CAS keys live under "cas/" and block objects under
+// "blocks/".
+type RemoteBlockStore interface {
+	// PutBlock writes the content of r under blocks/<blockID>. Idempotent:
+	// a second call with the same blockID overwrites silently. Implementations
+	// MUST stream r without buffering the whole body; callers may provide an
+	// unbounded reader (e.g., a packing file).
+	PutBlock(ctx context.Context, blockID string, r io.Reader) error
+
+	// GetBlock returns the full bytes of the block object identified by
+	// blockID. Returns block.ErrChunkNotFound when the block is absent.
+	// The returned slice is freshly allocated and owned by the caller.
+	GetBlock(ctx context.Context, blockID string) ([]byte, error)
+
+	// GetBlockRange returns [offset, offset+length) bytes of the block
+	// object identified by blockID. Bounds semantics mirror
+	// block.Store.GetRange: ErrInvalidOffset for a negative or past-EOF
+	// offset, ErrInvalidSize for a non-positive length; past-EOF length
+	// is clamped to the object's remaining bytes on backends that support
+	// it (S3 partial-content). Returns block.ErrChunkNotFound when the
+	// block is absent.
+	GetBlockRange(ctx context.Context, blockID string, offset, length int64) ([]byte, error)
+
+	// DeleteBlock removes the block object keyed by blockID. Idempotent:
+	// deleting an absent blockID returns nil.
+	DeleteBlock(ctx context.Context, blockID string) error
+
+	// WalkBlocks enumerates every block object in the store. The callback
+	// receives the blockID (the key with the "blocks/" prefix stripped) and
+	// block.Meta. Ordering is unspecified. Honors block.ErrStopWalk for
+	// clean early exit (WalkBlocks returns nil); any other callback error
+	// halts enumeration and is returned wrapped as
+	//
+	//   fmt.Errorf("walk halted at %s: %w", blockID, err)
+	//
+	// Context cancellation aborts immediately.
+	WalkBlocks(ctx context.Context, fn func(blockID string, meta block.Meta) error) error
 }
 
 // ChunkReader is an OPTIONAL RemoteStore capability for reading a chunk that

--- a/pkg/block/remote/s3/mock_store_test.go
+++ b/pkg/block/remote/s3/mock_store_test.go
@@ -808,6 +808,264 @@ func TestStore_Get_NoContentLength(t *testing.T) {
 	}
 }
 
+// ---- RemoteBlockStore method tests ----
+
+// TestStore_PutBlock_GetBlock_RoundTrip drives the PutBlock→GetBlock wire
+// path using the mock S3 server.
+func TestStore_PutBlock_GetBlock_RoundTrip(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	data := []byte("block round-trip payload — s3 wire path")
+	if err := store.PutBlock(ctx, "blk-1", strings.NewReader(string(data))); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+	got, err := store.GetBlock(ctx, "blk-1")
+	if err != nil {
+		t.Fatalf("GetBlock: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("GetBlock = %q, want %q", got, data)
+	}
+}
+
+// TestStore_GetBlock_NotFound pins the NoSuchKey → ErrChunkNotFound mapping.
+func TestStore_GetBlock_NotFound(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	if _, err := store.GetBlock(ctx, "absent"); !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("GetBlock absent: want ErrChunkNotFound, got %v", err)
+	}
+}
+
+// TestStore_GetBlockRange_Bounds exercises mid-block, past-EOF clamping, and
+// the argument-validation sentinels.
+func TestStore_GetBlockRange_Bounds(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	data := []byte("0123456789abcdef") // 16 bytes
+	const id = "blk-range"
+	if err := store.PutBlock(ctx, id, strings.NewReader(string(data))); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+
+	// Mid-block.
+	got, err := store.GetBlockRange(ctx, id, 4, 8)
+	if err != nil {
+		t.Fatalf("GetBlockRange mid: %v", err)
+	}
+	if string(got) != "456789ab" {
+		t.Fatalf("GetBlockRange mid = %q, want %q", got, "456789ab")
+	}
+
+	// Past-EOF length: mock returns available tail.
+	got, err = store.GetBlockRange(ctx, id, 8, 100)
+	if err != nil {
+		t.Fatalf("GetBlockRange past-EOF length: %v", err)
+	}
+	if string(got) != "89abcdef" {
+		t.Fatalf("GetBlockRange clamped = %q, want %q", got, "89abcdef")
+	}
+
+	// Offset strictly past EOF: mock returns 416.
+	if _, err := store.GetBlockRange(ctx, id, 100, 4); err == nil {
+		t.Fatal("GetBlockRange offset past EOF: want error, got nil")
+	}
+
+	// Argument validation sentinels (before any wire call).
+	if _, err := store.GetBlockRange(ctx, id, -1, 4); !errors.Is(err, block.ErrInvalidOffset) {
+		t.Fatalf("negative offset: want ErrInvalidOffset, got %v", err)
+	}
+	if _, err := store.GetBlockRange(ctx, id, 0, 0); !errors.Is(err, block.ErrInvalidSize) {
+		t.Fatalf("zero length: want ErrInvalidSize, got %v", err)
+	}
+	if _, err := store.GetBlockRange(ctx, id, 0, -1); !errors.Is(err, block.ErrInvalidSize) {
+		t.Fatalf("negative length: want ErrInvalidSize, got %v", err)
+	}
+
+	// Missing block.
+	if _, err := store.GetBlockRange(ctx, "missing", 0, 4); !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("missing block: want ErrChunkNotFound, got %v", err)
+	}
+}
+
+// TestStore_DeleteBlock_Idempotent confirms DeleteBlock succeeds whether or
+// not the block exists and that a subsequent GetBlock misses.
+func TestStore_DeleteBlock_Idempotent(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	data := []byte("delete-me block")
+	if err := store.PutBlock(ctx, "blk-del", strings.NewReader(string(data))); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+	if err := store.DeleteBlock(ctx, "blk-del"); err != nil {
+		t.Fatalf("DeleteBlock: %v", err)
+	}
+	if _, err := store.GetBlock(ctx, "blk-del"); !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("GetBlock after delete: want ErrChunkNotFound, got %v", err)
+	}
+	// Idempotent.
+	if err := store.DeleteBlock(ctx, "blk-del"); err != nil {
+		t.Fatalf("DeleteBlock idempotent: %v", err)
+	}
+}
+
+// TestStore_WalkBlocks_EnumeratesAll verifies WalkBlocks visits every block
+// object exactly once with correct size and non-zero LastModified, skips CAS
+// keys, and spans multiple paginator pages.
+func TestStore_WalkBlocks_EnumeratesAll(t *testing.T) {
+	store, mock := newTestStore(t)
+	mock.mu.Lock()
+	mock.listPageSize = 2 // force multi-page pagination
+	mock.mu.Unlock()
+	ctx := context.Background()
+
+	want := make(map[string]int64)
+	for i := 0; i < 5; i++ {
+		id := fmt.Sprintf("blk-%d", i)
+		data := []byte(fmt.Sprintf("walk-block-%d-payload", i))
+		want[id] = int64(len(data))
+		if err := store.PutBlock(ctx, id, strings.NewReader(string(data))); err != nil {
+			t.Fatalf("PutBlock %s: %v", id, err)
+		}
+	}
+
+	// Also put a CAS object; WalkBlocks must not surface it.
+	casData := []byte("cas-only")
+	if err := store.Put(ctx, mustHash(casData), casData); err != nil {
+		t.Fatalf("Put CAS: %v", err)
+	}
+
+	seen := make(map[string]int)
+	err := store.WalkBlocks(ctx, func(blockID string, m block.Meta) error {
+		seen[blockID]++
+		if m.LastModified.IsZero() {
+			t.Errorf("WalkBlocks: LastModified zero for %s", blockID)
+		}
+		if w, ok := want[blockID]; ok && m.Size != w {
+			t.Errorf("WalkBlocks size for %s = %d, want %d", blockID, m.Size, w)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkBlocks: %v", err)
+	}
+	if len(seen) != len(want) {
+		t.Fatalf("WalkBlocks visited %d blocks, want %d", len(seen), len(want))
+	}
+	for id, n := range seen {
+		if n != 1 {
+			t.Errorf("WalkBlocks visited %s %d times, want 1", id, n)
+		}
+	}
+}
+
+// TestStore_WalkBlocks_StopSentinel pins the ErrStopWalk clean-exit contract.
+func TestStore_WalkBlocks_StopSentinel(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	for i := 0; i < 4; i++ {
+		id := fmt.Sprintf("blk-stop-%d", i)
+		if err := store.PutBlock(ctx, id, strings.NewReader(id)); err != nil {
+			t.Fatalf("PutBlock: %v", err)
+		}
+	}
+	seen := 0
+	err := store.WalkBlocks(ctx, func(string, block.Meta) error {
+		seen++
+		return block.ErrStopWalk
+	})
+	if err != nil {
+		t.Fatalf("WalkBlocks ErrStopWalk: want nil, got %v", err)
+	}
+	if seen != 1 {
+		t.Fatalf("WalkBlocks should stop after first ErrStopWalk; saw %d", seen)
+	}
+}
+
+// TestStore_PutBlock_Idempotent verifies a second PutBlock for the same ID
+// overwrites the stored content.
+func TestStore_PutBlock_Idempotent(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	original := []byte("original-block-content")
+	updated := []byte("updated-block-content-v2")
+	if err := store.PutBlock(ctx, "blk-idem", strings.NewReader(string(original))); err != nil {
+		t.Fatalf("PutBlock original: %v", err)
+	}
+	if err := store.PutBlock(ctx, "blk-idem", strings.NewReader(string(updated))); err != nil {
+		t.Fatalf("PutBlock updated: %v", err)
+	}
+	got, err := store.GetBlock(ctx, "blk-idem")
+	if err != nil {
+		t.Fatalf("GetBlock: %v", err)
+	}
+	if string(got) != string(updated) {
+		t.Fatalf("PutBlock idempotent: got %q, want %q", got, updated)
+	}
+}
+
+// TestStore_PutBlock_ZeroBody verifies a zero-byte PutBlock is accepted and
+// GetBlock returns an empty slice.
+func TestStore_PutBlock_ZeroBody(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	if err := store.PutBlock(ctx, "blk-zero", strings.NewReader("")); err != nil {
+		t.Fatalf("PutBlock zero-byte: %v", err)
+	}
+	got, err := store.GetBlock(ctx, "blk-zero")
+	if err != nil {
+		t.Fatalf("GetBlock zero-byte: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("GetBlock zero-byte: want 0 bytes, got %d", len(got))
+	}
+}
+
+// TestStore_PutBlock_Concurrent_SameID verifies concurrent PutBlock calls for
+// the same blockID don't corrupt the mock; the last writer wins on the store.
+func TestStore_PutBlock_Concurrent_SameID(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	const id = "blk-concurrent"
+	payloadA := strings.Repeat("A", 512)
+	payloadB := strings.Repeat("B", 512)
+
+	done := make(chan error, 2)
+	go func() { done <- store.PutBlock(ctx, id, strings.NewReader(payloadA)) }()
+	go func() { done <- store.PutBlock(ctx, id, strings.NewReader(payloadB)) }()
+	for i := 0; i < 2; i++ {
+		if err := <-done; err != nil {
+			t.Errorf("concurrent PutBlock: %v", err)
+		}
+	}
+
+	got, err := store.GetBlock(ctx, id)
+	if err != nil {
+		t.Fatalf("GetBlock after concurrent put: %v", err)
+	}
+	// Must be entirely A or entirely B — no interleaving.
+	if len(got) != 512 {
+		t.Fatalf("GetBlock length = %d, want 512", len(got))
+	}
+	first := got[0]
+	if first != 'A' && first != 'B' {
+		t.Fatalf("unexpected first byte 0x%02X", first)
+	}
+	for i, b := range got {
+		if b != first {
+			t.Fatalf("GetBlock[%d] = %q, want all %q (concurrent blend)", i, b, first)
+		}
+	}
+}
+
 // TestNewFromConfig_Validation pins the required-field validation and a
 // successful construction (which does not perform any network I/O).
 func TestNewFromConfig_Validation(t *testing.T) {

--- a/pkg/block/remote/s3/store.go
+++ b/pkg/block/remote/s3/store.go
@@ -769,8 +769,10 @@ func (s *Store) GetBlock(ctx context.Context, blockID string) ([]byte, error) {
 
 // GetBlockRange returns [offset, offset+length) bytes of the block object
 // identified by blockID via an S3 ranged GET. Bounds semantics mirror
-// GetRange: ErrInvalidOffset for negative/past-EOF offset, ErrInvalidSize for
-// non-positive length; past-EOF length is clamped by S3 (partial content).
+// GetRange: ErrInvalidOffset for a negative offset and ErrInvalidSize for
+// non-positive length. A past-EOF offset cannot be detected here without a
+// HEAD, so S3 surfaces a native error (416) instead; past-EOF length is
+// clamped by S3 (partial content).
 func (s *Store) GetBlockRange(ctx context.Context, blockID string, offset, length int64) ([]byte, error) {
 	if err := s.checkClosed(); err != nil {
 		return nil, err

--- a/pkg/block/remote/s3/store.go
+++ b/pkg/block/remote/s3/store.go
@@ -54,9 +54,14 @@ const maxS3ConnsPerHost = 256
 // Compile-time interface satisfaction check.
 var (
 	_ remote.RemoteStore       = (*Store)(nil)
+	_ remote.RemoteBlockStore  = (*Store)(nil)
 	_ remote.ChunkReader       = (*Store)(nil)
 	_ block.DurabilityReporter = (*Store)(nil)
 )
+
+// blockObjectPrefix is the S3 object-key prefix walked by WalkBlocks.
+// Mirrors casPrefix ("cas/") for block objects.
+const blockObjectPrefix = "blocks/"
 
 // Config holds configuration for the S3 block store.
 type Config struct {
@@ -718,6 +723,162 @@ func (s *Store) Walk(ctx context.Context, fn func(hash block.ContentHash, meta b
 		}
 	}
 
+	return nil
+}
+
+// PutBlock writes the content of r under blocks/<blockID> via S3 PutObject.
+// Implements remote.RemoteBlockStore. Idempotent: a second call overwrites
+// silently. r is streamed directly to S3; the SDK uses chunked transfer
+// encoding when ContentLength is not set.
+func (s *Store) PutBlock(ctx context.Context, blockID string, r io.Reader) error {
+	if err := s.checkClosed(); err != nil {
+		return err
+	}
+	key := s.blockKey(blockID)
+	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+		Body:   r,
+	})
+	if err != nil {
+		return fmt.Errorf("s3 put block %s: %w", blockID, err)
+	}
+	return nil
+}
+
+// GetBlock returns the full bytes of the block object identified by blockID.
+// Returns block.ErrChunkNotFound when the block is absent.
+func (s *Store) GetBlock(ctx context.Context, blockID string) ([]byte, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, err
+	}
+	key := s.blockKey(blockID)
+	resp, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		if isNotFoundError(err) {
+			return nil, block.ErrChunkNotFound
+		}
+		return nil, fmt.Errorf("s3 get block %s: %w", blockID, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return readResponseBody(resp.Body, resp.ContentLength, maxBlockReadSize)
+}
+
+// GetBlockRange returns [offset, offset+length) bytes of the block object
+// identified by blockID via an S3 ranged GET. Bounds semantics mirror
+// GetRange: ErrInvalidOffset for negative/past-EOF offset, ErrInvalidSize for
+// non-positive length; past-EOF length is clamped by S3 (partial content).
+func (s *Store) GetBlockRange(ctx context.Context, blockID string, offset, length int64) ([]byte, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, err
+	}
+	if offset < 0 {
+		return nil, block.ErrInvalidOffset
+	}
+	if length <= 0 {
+		return nil, block.ErrInvalidSize
+	}
+	if length > math.MaxInt64-offset {
+		return nil, block.ErrInvalidSize
+	}
+	key := s.blockKey(blockID)
+	rangeHeader := fmt.Sprintf("bytes=%d-%d", offset, offset+length-1)
+	resp, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+		Range:  aws.String(rangeHeader),
+	})
+	if err != nil {
+		if isNotFoundError(err) {
+			return nil, block.ErrChunkNotFound
+		}
+		return nil, fmt.Errorf("s3 get block range %s: %w", blockID, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return readResponseBody(resp.Body, resp.ContentLength, length)
+}
+
+// DeleteBlock removes the block object keyed by blockID. Idempotent: S3's
+// DeleteObject succeeds with 204 even when the key is absent.
+func (s *Store) DeleteBlock(ctx context.Context, blockID string) error {
+	if err := s.checkClosed(); err != nil {
+		return err
+	}
+	key := s.blockKey(blockID)
+	_, err := s.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return fmt.Errorf("s3 delete block %s: %w", blockID, err)
+	}
+	return nil
+}
+
+// WalkBlocks enumerates every block object in the store. Iterates S3 listing
+// pages under the blocks/ prefix, strips the prefix to recover the blockID,
+// and dispatches the callback with the blockID and block.Meta. Honors
+// block.ErrStopWalk for clean early exit; any other callback error halts and
+// is wrapped as "walk halted at <blockID>: %w". Context cancellation aborts.
+func (s *Store) WalkBlocks(ctx context.Context, fn func(blockID string, meta block.Meta) error) error {
+	if err := s.checkClosed(); err != nil {
+		return err
+	}
+
+	fullPrefix := s.fullKey(blockObjectPrefix)
+
+	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
+		Bucket: aws.String(s.bucket),
+		Prefix: aws.String(fullPrefix),
+	})
+
+	for paginator.HasMorePages() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return fmt.Errorf("s3 walk blocks: %w", err)
+		}
+		for _, obj := range page.Contents {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			rawKey := ""
+			if obj.Key != nil {
+				rawKey = *obj.Key
+			}
+			// Strip keyPrefix so we see the canonical "blocks/<blockID>" shape,
+			// then strip the "blocks/" prefix to recover the bare blockID.
+			parseKey := rawKey
+			if s.keyPrefix != "" && strings.HasPrefix(parseKey, s.keyPrefix) {
+				parseKey = parseKey[len(s.keyPrefix):]
+			}
+			if !strings.HasPrefix(parseKey, blockObjectPrefix) {
+				continue // skip non-block keys that share the prefix
+			}
+			blockID := parseKey[len(blockObjectPrefix):]
+			if blockID == "" {
+				continue // skip the prefix key itself if it were ever stored
+			}
+			meta := block.Meta{}
+			if obj.Size != nil {
+				meta.Size = *obj.Size
+			}
+			if obj.LastModified != nil {
+				meta.LastModified = *obj.LastModified
+			}
+			if cberr := fn(blockID, meta); cberr != nil {
+				if errors.Is(cberr, block.ErrStopWalk) {
+					return nil
+				}
+				return fmt.Errorf("walk halted at %s: %w", blockID, cberr)
+			}
+		}
+	}
 	return nil
 }
 

--- a/pkg/block/remote/s3/store.go
+++ b/pkg/block/remote/s3/store.go
@@ -578,13 +578,30 @@ func readResponseBody(body io.ReadCloser, contentLength *int64, fallbackSize int
 		return data, nil
 	}
 
-	buf := bytes.NewBuffer(make([]byte, 0, fallbackSize))
+	// Content-Length absent or zero: grow the buffer as we read. Cap the eager
+	// preallocation so a missing/lying header can't drive an oversized up-front
+	// allocation from an attacker- or caller-supplied range length; ReadFrom
+	// still grows the buffer to whatever the body actually contains.
+	prealloc := fallbackSize
+	if prealloc < 0 {
+		prealloc = 0
+	}
+	if prealloc > maxFallbackPrealloc {
+		prealloc = maxFallbackPrealloc
+	}
+	buf := bytes.NewBuffer(make([]byte, 0, prealloc))
 	_, err := buf.ReadFrom(body)
 	if err != nil {
 		return nil, fmt.Errorf("read s3 object body: %w", err)
 	}
 	return buf.Bytes(), nil
 }
+
+// maxFallbackPrealloc bounds the up-front buffer reserved when an S3 response
+// omits Content-Length. 1 MiB is large enough to absorb most single-chunk
+// reads without reallocation, small enough that a bogus header cannot force a
+// large speculative allocation.
+const maxFallbackPrealloc = 1 << 20
 
 // Has reports whether the CAS object addressed by hash exists in the
 // bucket. Implements the block.BlockStore contract.

--- a/pkg/block/remote/s3/store_test.go
+++ b/pkg/block/remote/s3/store_test.go
@@ -108,3 +108,21 @@ func TestStore_BlockStoreConformance(t *testing.T) {
 	}
 	blockstoretest.BlockStoreConformance(t, factory)
 }
+
+// TestS3_RemoteBlockStoreConformance runs the unified
+// RemoteBlockStoreConformance suite against the S3 backend using the
+// in-process mockS3 server (no Localstack/MinIO required). All subtests
+// exercise the block-keyed (non-CAS) surface: PutBlock/GetBlock/
+// GetBlockRange/DeleteBlock/WalkBlocks.
+func TestS3_RemoteBlockStoreConformance(t *testing.T) {
+	blockstoretest.RemoteBlockStoreConformance(t, func(t *testing.T) (blockstoretest.RemoteBlockStore, func()) {
+		t.Helper()
+		store, mock := newTestStore(t)
+		// Force multi-page pagination so WalkBlocks_EnumeratesAll exercises
+		// the paginator code path with the 5 blocks the suite inserts.
+		mock.mu.Lock()
+		mock.listPageSize = 2
+		mock.mu.Unlock()
+		return store, func() { _ = store.Close() }
+	})
+}

--- a/pkg/metadata/store/badger/synced_hash_store.go
+++ b/pkg/metadata/store/badger/synced_hash_store.go
@@ -58,8 +58,8 @@ func encodeSyncedValue(nanos int64, loc block.ChunkLocator) []byte {
 	suffix := make([]byte, 2+len(loc.BlockID)+16)
 	binary.BigEndian.PutUint16(suffix[0:2], uint16(len(loc.BlockID)))
 	n := 2 + copy(suffix[2:], loc.BlockID)
-	binary.BigEndian.PutUint64(suffix[n:n+8], uint64(loc.Offset))
-	binary.BigEndian.PutUint64(suffix[n+8:n+16], uint64(loc.Length))
+	binary.BigEndian.PutUint64(suffix[n:n+8], uint64(loc.WireOffset))
+	binary.BigEndian.PutUint64(suffix[n+8:n+16], uint64(loc.WireLength))
 	return append(val, suffix...)
 }
 
@@ -82,7 +82,7 @@ func decodeSyncedLocator(val []byte) block.ChunkLocator {
 	blockID := string(suffix[2 : 2+idLen])
 	off := int64(binary.BigEndian.Uint64(suffix[2+idLen : 2+idLen+8]))
 	length := int64(binary.BigEndian.Uint64(suffix[2+idLen+8 : 2+idLen+16]))
-	return block.ChunkLocator{BlockID: blockID, Offset: off, Length: length}
+	return block.ChunkLocator{BlockID: blockID, WireOffset: off, WireLength: length}
 }
 
 // Compile-time assertion: the Badger engine implements SyncedHashStore.

--- a/pkg/metadata/store/postgres/synced_hash_store.go
+++ b/pkg/metadata/store/postgres/synced_hash_store.go
@@ -125,7 +125,7 @@ func (s *PostgresMetadataStore) GetLocator(ctx context.Context, hash block.Conte
 	if !off.Valid || !length.Valid {
 		return block.ChunkLocator{}, false, fmt.Errorf("corrupt locator row: block_id %q with NULL offset/length", blockID.String)
 	}
-	return block.ChunkLocator{BlockID: blockID.String, Offset: off.Int64, Length: length.Int64}, true, nil
+	return block.ChunkLocator{BlockID: blockID.String, WireOffset: off.Int64, WireLength: length.Int64}, true, nil
 }
 
 // locatorArgs maps a ChunkLocator onto the (block_id, block_offset, block_length)
@@ -135,7 +135,7 @@ func locatorArgs(loc block.ChunkLocator) (blockID, off, length any) {
 	if loc.IsStandalone() {
 		return nil, nil, nil
 	}
-	return loc.BlockID, loc.Offset, loc.Length
+	return loc.BlockID, loc.WireOffset, loc.WireLength
 }
 
 // DeleteSynced removes the synced marker for hash. Idempotent: DELETE

--- a/pkg/metadata/store/sqlite/synced_hash_store.go
+++ b/pkg/metadata/store/sqlite/synced_hash_store.go
@@ -125,7 +125,7 @@ func locatorArgs(loc block.ChunkLocator) (blockID, off, length any) {
 	if loc.IsStandalone() {
 		return nil, nil, nil
 	}
-	return loc.BlockID, loc.Offset, loc.Length
+	return loc.BlockID, loc.WireOffset, loc.WireLength
 }
 
 // scanLocatorRow scans a (block_id, block_offset, block_length) row into a
@@ -142,7 +142,7 @@ func scanLocatorRow(row scanRow) (block.ChunkLocator, error) {
 	if !off.Valid || !length.Valid {
 		return block.ChunkLocator{}, fmt.Errorf("corrupt locator row: block_id %q with NULL offset/length", blockID.String)
 	}
-	return block.ChunkLocator{BlockID: blockID.String, Offset: off.Int64, Length: length.Int64}, nil
+	return block.ChunkLocator{BlockID: blockID.String, WireOffset: off.Int64, WireLength: length.Int64}, nil
 }
 
 // DeleteSynced removes the synced marker for hash. Idempotent: DELETE

--- a/pkg/metadata/synced_hash_store_suite.go
+++ b/pkg/metadata/synced_hash_store_suite.go
@@ -151,7 +151,7 @@ func RunSyncedHashStoreSuite(t *testing.T, s SyncedHashStore) {
 		// same (no-block) state.
 		ctx := context.Background()
 		h := mustHash("suite-standalone-locator")
-		if err := s.MarkSynced(ctx, h, block.ChunkLocator{Length: 1234}); err != nil {
+		if err := s.MarkSynced(ctx, h, block.ChunkLocator{WireLength: 1234}); err != nil {
 			t.Fatalf("MarkSynced standalone: %v", err)
 		}
 		loc, ok, err := s.GetLocator(ctx, h)
@@ -170,7 +170,7 @@ func RunSyncedHashStoreSuite(t *testing.T, s SyncedHashStore) {
 		// A block locator must round-trip exactly through MarkSynced/GetLocator.
 		ctx := context.Background()
 		h := mustHash("suite-block-locator")
-		want := block.ChunkLocator{BlockID: "block-abc123", Offset: 4096, Length: 65536}
+		want := block.ChunkLocator{BlockID: "block-abc123", WireOffset: 4096, WireLength: 65536}
 		if err := s.MarkSynced(ctx, h, want); err != nil {
 			t.Fatalf("MarkSynced block: %v", err)
 		}


### PR DESCRIPTION
First PR of the **blocks-only storage redesign** epic #1493. Foundation only — **additive, zero runtime behavior change**: the new block-keyed surface is added beside the existing CAS path (retired in a later PR) and is exercised only by tests.

Design: `.planning/2026-06-30-blocks-only-storage-design.md` (approved). Roadmap (4 PRs): `.planning/2026-06-30-1493-blocks-only-roadmap.md`.

## What's in PR1
- **Block codec** (`pkg/block/blockcodec`): streaming `Builder` + `Parse`. Wire format `[preamble][record{hash,wireLen}+wire]…` — `DFB1` magic, flags, length-prefixed blockID; inline self-describing per-chunk index (single pass, no footer). Sealed `{hash,wireLen}` sub-headers on encrypted shares (AAD = blockID‖recordIndex). Overlong-length panic guards.
- **`RemoteBlockStore`** (`pkg/block/remote`): slim block-keyed interface — `PutBlock` (streaming `io.Reader`, only writer), `GetBlock`, `GetBlockRange` (ranged GET), `DeleteBlock`, `WalkBlocks`. Implemented on **memory** + **s3** (keys via `block.FormatBlockKey` → `blocks/<id>`). CAS `Put/Get/GetRange/Delete/Walk` untouched.
- **`ChunkLocator`** field rename `Offset/Length` → `WireOffset/WireLength` (surviving type; `BlockID`/`IsStandalone` kept for the still-live standalone path).
- **Conformance**: `blockstoretest.RemoteBlockStoreConformance` (16 subtests), wired to memory + s3 (s3 via in-process mock with forced pagination).
- **Docs**: `docs/internals/implementing-stores.md` documents the contract + codec format.

## Verification
`go build ./...` (+ `-tags integration`), `go vet ./pkg/block/...`, `go test ./pkg/block/... ./pkg/metadata/...` all green. Both conformance suites genuinely run + pass. Per-task spec+quality reviews + a final whole-branch review (verdict: **READY**) cleared it; all known findings were Minor and either fixed or deferred with rationale.

## Not in this PR (epic #1493)
PR2 local log-blob tier + metadata block records (#1416) · PR3 sync-engine carve + streaming upload + GC + corruption · PR4 migration + legacy CAS deletion + final naming sweep. Deferred follow-ups: #1487 #1488 #1489 #1490 #1491 #1492.