### PR TITLE
fix(block): drain-uploads forces rollup before mirroring

### DIFF
--- a/pkg/block/engine/flush.go
+++ b/pkg/block/engine/flush.go
@@ -18,12 +18,24 @@ func (bs *Store) Flush(ctx context.Context, payloadID string) (*block.FlushResul
 	return bs.syncer.Flush(ctx, payloadID)
 }
 
-// DrainAllUploads waits for all pending uploads to complete.
+// DrainAllUploads forces every dirty payload through rollup and then waits for
+// all pending remote uploads to complete.
+//
+// Rollup must run first: it is what turns still-dirty append-log data into CAS
+// chunks, which is the only thing the syncer mirrors to the remote. Draining
+// the syncer alone leaves any data still inside the rollup stabilization window
+// un-chunked, so it never reaches the remote and the caller's durability
+// guarantee silently does not hold (see DrainRollups). The snapshot path rolls
+// up explicitly before calling this; the standalone `system drain-uploads` path
+// relies on the rollup here.
 func (bs *Store) DrainAllUploads(ctx context.Context) error {
 	if err := bs.enter(); err != nil {
 		return err
 	}
 	defer bs.closeMu.RUnlock()
+	if err := bs.local.DrainRollups(ctx); err != nil {
+		return err
+	}
 	return bs.syncer.DrainAllUploads(ctx)
 }
 


### PR DESCRIPTION
Fixes #1505.

## Problem

`dfsctl system drain-uploads` (→ `Runtime.DrainAllUploads` → `shares.DrainAllBlockStores` → `engine.Store.DrainAllUploads`) drained only the syncer's in-flight mirror queue. Rollup is what turns still-dirty append-log data into CAS chunks — the only thing the syncer mirrors. So data still inside the rollup stabilization window was never chunked, the syncer had nothing to drain, and the remote silently missed it. The command's whole purpose (durably flush to remote) did not hold.

The `DrainRollups` docstring in the same file already states it "must run before DrainAllUploads". The snapshot path does both explicitly; the standalone CLI path skipped the rollup.

## Fix

`Store.DrainAllUploads` now forces `bs.local.DrainRollups(ctx)` before draining the syncer, so the engine-level contract holds for every caller. The snapshot path's explicit pre-rollup becomes a harmless idempotent no-op.

## Validation

Real NFS + Localstack S3 on a Linux VM, the canonical CAS test `TestBlockStoreImmutableOverwrites`:

- **before:** `step 1 cas/ keys after A = 0` → `Should NOT be empty, but was []` at write+drain.
- **after:** `step 1 cas/ keys after A = 16`; the test now advances through the overwrite-immutability step.

`go test ./pkg/block/engine/` green. code-reviewer: clean.

## Out of scope

The same e2e test now reaches a later, unrelated failure at its GC step: freshly-orphaned chunks aren't reaped because GC's grace period has a 5m floor (`grace_period=0` is remapped to the 1h default; `0 < grace < 5m` is rejected), so a fast test can't observe a sweep and there's no force/`grace=0` path. Tracked separately.
