### PR TITLE
fix(metadata): read-only denial returns ErrReadOnly so NFSv3 yields ROFS

### DIFF
--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -490,12 +490,43 @@ func (s *Service) checkPermission(ctx *AuthContext, handle FileHandle, perm Perm
 		return err
 	}
 	if granted&perm == 0 {
+		// A write or delete denied solely because the share is read-only must
+		// surface as ErrReadOnly so NFSv3 returns NFS3ERR_ROFS (EROFS) per
+		// RFC 1813, rather than NFS3ERR_ACCES. SMB is unaffected: the error
+		// map renders ErrReadOnly and ErrAccessDenied alike as
+		// STATUS_ACCESS_DENIED.
+		if perm&(PermissionWrite|PermissionDelete) != 0 && s.shareForbidsWrites(ctx, handle) {
+			return &StoreError{
+				Code:    ErrReadOnly,
+				Message: msg,
+			}
+		}
 		return &StoreError{
 			Code:    ErrAccessDenied,
 			Message: msg,
 		}
 	}
 	return nil
+}
+
+// shareForbidsWrites reports whether a read-only ceiling — per-user
+// (ctx.ShareReadOnly) or store-level (share options) — forbids modification of
+// the given file's share. It is consulted only on the permission-denied path,
+// so the extra share-options lookup is off the hot path.
+func (s *Service) shareForbidsWrites(ctx *AuthContext, handle FileHandle) bool {
+	if ctx.ShareReadOnly {
+		return true
+	}
+	store, err := s.storeForHandle(handle)
+	if err != nil {
+		return false
+	}
+	file, err := store.GetFile(ctx.Context, handle)
+	if err != nil {
+		return false
+	}
+	shareOpts, err := store.GetShareOptions(ctx.Context, file.ShareName)
+	return err == nil && shareOpts != nil && shareOpts.ReadOnly
 }
 
 // checkWritePermission checks write permission on a file.
@@ -561,7 +592,10 @@ func (s *Service) CheckParentCreateAccess(ctx *AuthContext, parentHandle FileHan
 	// ctx.ShareReadOnly arm a read-only user could create entries under an
 	// ALLOW-granting parent DACL on an otherwise read-write share. #1276.
 	if ctx.ShareReadOnly || (shareOpts != nil && shareOpts.ReadOnly) {
-		return &StoreError{Code: ErrAccessDenied, Message: "write permission denied"}
+		// Read-only denial → ErrReadOnly so NFSv3 returns NFS3ERR_ROFS
+		// (EROFS) per RFC 1813. SMB renders it as STATUS_ACCESS_DENIED,
+		// identical to the prior ErrAccessDenied.
+		return &StoreError{Code: ErrReadOnly, Message: "read-only share"}
 	}
 
 	// CREATE has no open handle yet, so the handle-based write authorization

--- a/pkg/metadata/auth_permissions_readonly_share_test.go
+++ b/pkg/metadata/auth_permissions_readonly_share_test.go
@@ -135,13 +135,15 @@ func TestCheckParentCreateAccess_PerUserReadOnlyDenies(t *testing.T) {
 	ro := f.authContext(uid, gid)
 	ro.ShareReadOnly = true
 
+	// Read-only denial → ErrReadOnly (NFS3ERR_ROFS / EROFS) per RFC 1813; SMB
+	// renders it as STATUS_ACCESS_DENIED, identical to the prior code.
 	err = f.service.CheckParentCreateAccess(ro, dirHandle, false)
 	if err == nil {
-		t.Fatal("CheckParentCreateAccess returned nil for read-only user, want ErrAccessDenied")
+		t.Fatal("CheckParentCreateAccess returned nil for read-only user, want ErrReadOnly")
 	}
 	var storeErr *metadata.StoreError
-	if !errors.As(err, &storeErr) || storeErr.Code != metadata.ErrAccessDenied {
-		t.Fatalf("CheckParentCreateAccess err = %v, want StoreError{Code: ErrAccessDenied}", err)
+	if !errors.As(err, &storeErr) || storeErr.Code != metadata.ErrReadOnly {
+		t.Fatalf("CheckParentCreateAccess err = %v, want StoreError{Code: ErrReadOnly}", err)
 	}
 
 	// And the POSIX-only parent-write path (no ACL) must deny too.
@@ -187,8 +189,8 @@ func TestSetFileAttributes_PerUserReadOnlyDeniesOwnerMutation(t *testing.T) {
 			continue
 		}
 		var storeErr *metadata.StoreError
-		if !errors.As(err, &storeErr) || storeErr.Code != metadata.ErrAccessDenied {
-			t.Errorf("%s: err = %v, want StoreError{Code: ErrAccessDenied}", name, err)
+		if !errors.As(err, &storeErr) || storeErr.Code != metadata.ErrReadOnly {
+			t.Errorf("%s: err = %v, want StoreError{Code: ErrReadOnly}", name, err)
 		}
 	}
 

--- a/pkg/metadata/auth_permissions_readonly_share_test.go
+++ b/pkg/metadata/auth_permissions_readonly_share_test.go
@@ -201,6 +201,44 @@ func TestSetFileAttributes_PerUserReadOnlyDeniesOwnerMutation(t *testing.T) {
 	}
 }
 
+// TestSetFileAttributes_StoreReadOnlyDeniesOwnerMutation asserts the SETATTR
+// ceiling also fires for the STORE-level read-only flag (ShareOptions.ReadOnly),
+// not just the per-user ctx.ShareReadOnly: an owner may not chmod their own file
+// on a share configured read-only. The owner-bypass path skips
+// checkWritePermission, so without consulting both ceilings the store-level flag
+// would be silently ignored for SETATTR.
+func TestSetFileAttributes_StoreReadOnlyDeniesOwnerMutation(t *testing.T) {
+	f := newTestFixture(t)
+
+	uid, gid := uint32(1600), uint32(1600)
+	// Create the file BEFORE toggling the share read-only (creation is denied
+	// on a read-only share).
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "store-ro.txt",
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: uid, GID: gid})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(f.shareName, created.ID)
+	require.NoError(t, err)
+
+	_ = f.store.CreateShare(context.Background(), &metadata.Share{Name: f.shareName})
+	require.NoError(t, f.store.UpdateShareOptions(context.Background(), f.shareName,
+		&metadata.ShareOptions{ReadOnly: true}))
+
+	// The OWNER, with per-user ShareReadOnly explicitly false — only the
+	// store-level flag is in play.
+	owner := f.authContext(uid, gid)
+	owner.ShareReadOnly = false
+
+	newMode := uint32(0o777)
+	_, err = f.service.SetFileAttributes(owner, handle, &metadata.SetAttrs{Mode: &newMode})
+	if err == nil {
+		t.Fatal("SetFileAttributes returned nil for owner on store-level read-only share, want ErrReadOnly")
+	}
+	var storeErr *metadata.StoreError
+	if !errors.As(err, &storeErr) || storeErr.Code != metadata.ErrReadOnly {
+		t.Fatalf("SetFileAttributes err = %v, want StoreError{Code: ErrReadOnly}", err)
+	}
+}
+
 // TestLockFile_PerUserReadOnlyDeniesExclusiveLock asserts a read-only user
 // cannot acquire an exclusive (write) byte-range lock, while a shared (read)
 // lock is still allowed.

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -237,8 +237,11 @@ func (s *Service) SetFileAttributes(ctx *AuthContext, handle FileHandle, attrs *
 	// a permissive DACL on it). Mirrors the write/delete strip in
 	// checkFilePermissions for the data path.
 	if ctx.ShareReadOnly {
+		// Read-only denial → ErrReadOnly so NFSv3 SETATTR returns
+		// NFS3ERR_ROFS (EROFS) per RFC 1813 §3.3.7, matching the WRITE and
+		// xattr paths. SMB renders ErrReadOnly as STATUS_ACCESS_DENIED.
 		return nil, &StoreError{
-			Code:    ErrAccessDenied,
+			Code:    ErrReadOnly,
 			Message: "read-only share: attribute change denied",
 			Path:    file.Path,
 		}

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -229,14 +229,15 @@ func (s *Service) SetFileAttributes(ctx *AuthContext, handle FileHandle, attrs *
 	isOwner := identity != nil && identity.UID != nil && *identity.UID == file.UID
 	isRoot := identity != nil && identity.UID != nil && *identity.UID == 0
 
-	// Per-user read-only share ceiling (#1276). Every SETATTR mutation —
-	// chmod, chown/chgrp, ACL replace, explicit/utime-now timestamps, truncate —
-	// is a write, so a read-only user may perform none of them. This guard sits
-	// BEFORE the owner/root bypass below: without it, the isOwner short-circuit
-	// would let a read-only user mutate their own file (most dangerously, install
-	// a permissive DACL on it). Mirrors the write/delete strip in
-	// checkFilePermissions for the data path.
-	if ctx.ShareReadOnly {
+	// Read-only share ceiling — both the per-user flag (#1276) and the
+	// store-level ShareOptions.ReadOnly. Every SETATTR mutation — chmod,
+	// chown/chgrp, ACL replace, explicit/utime-now timestamps, truncate — is a
+	// write, so neither a read-only user nor any user on a read-only share may
+	// perform them. This guard sits BEFORE the owner/root bypass below: without
+	// it, the isOwner short-circuit would let an owner mutate their own file on
+	// a read-only share (most dangerously, install a permissive DACL on it).
+	// shareForbidsWrites checks both ceilings, mirroring the data path.
+	if s.shareForbidsWrites(ctx, handle) {
 		// Read-only denial → ErrReadOnly so NFSv3 SETATTR returns
 		// NFS3ERR_ROFS (EROFS) per RFC 1813 §3.3.7, matching the WRITE and
 		// xattr paths. SMB renders ErrReadOnly as STATUS_ACCESS_DENIED.

--- a/pkg/metadata/service_test.go
+++ b/pkg/metadata/service_test.go
@@ -711,7 +711,9 @@ func TestMetadataService_RemoveFile_DeletePermission(t *testing.T) {
 		require.Error(t, err)
 		var storeErr *metadata.StoreError
 		require.ErrorAs(t, err, &storeErr)
-		assert.Equal(t, metadata.ErrAccessDenied, storeErr.Code)
+		// Read-only denial → ErrReadOnly (NFS3ERR_ROFS / EROFS) per RFC 1813.
+		// SMB still renders it as STATUS_ACCESS_DENIED.
+		assert.Equal(t, metadata.ErrReadOnly, storeErr.Code)
 	})
 
 	// Sticky bit: caller has WRITE on parent but is neither the file owner
@@ -838,7 +840,9 @@ func TestMetadataService_RemoveDirectory_DeletePermission(t *testing.T) {
 		require.Error(t, err)
 		var storeErr *metadata.StoreError
 		require.ErrorAs(t, err, &storeErr)
-		assert.Equal(t, metadata.ErrAccessDenied, storeErr.Code)
+		// Read-only denial → ErrReadOnly (NFS3ERR_ROFS / EROFS) per RFC 1813.
+		// SMB still renders it as STATUS_ACCESS_DENIED.
+		assert.Equal(t, metadata.ErrReadOnly, storeErr.Code)
 	})
 }
 

--- a/test/e2e/cross_protocol_test.go
+++ b/test/e2e/cross_protocol_test.go
@@ -710,11 +710,14 @@ func smbStatusToErrno(code smbtypes.Status) syscall.Errno {
 		// (TriggerErrNameTooLong uses a 300-char name).
 		return syscall.ENAMETOOLONG
 	case smbtypes.StatusFileLockConflict:
-		// SMB general-context lock-conflict → EAGAIN (same family as NFS's
-		// EAGAIN for NFS3ERR_JUKEBOX on lock contention).
-		return syscall.EAGAIN
+		// Real Linux cifs maps the SMB lock-conflict NT statuses to -EACCES,
+		// NOT -EAGAIN (fs/smb/client/smb2maperror.c). A non-blocking flock()
+		// conflict over cifs therefore surfaces EACCES to userspace even
+		// though POSIX flock() would otherwise report EWOULDBLOCK. (NFS keeps
+		// EAGAIN: its NFS3ERR_JUKEBOX → EAGAIN mapping is unaffected.)
+		return syscall.EACCES
 	case smbtypes.StatusLockNotGranted:
-		return syscall.EAGAIN
+		return syscall.EACCES
 	case smbtypes.StatusRangeNotLocked:
 		return syscall.EINVAL
 	case smbtypes.StatusUnexpectedIOError:

--- a/test/e2e/helpers/error_triggers.go
+++ b/test/e2e/helpers/error_triggers.go
@@ -195,35 +195,24 @@ func TriggerErrInvalidArgument(t *testing.T, mountRoot string) TriggerResult {
 // errno, so the cross-protocol assertion holds.
 func TriggerErrInvalidHandle(t *testing.T, mountRoot string) TriggerResult {
 	t.Helper()
-	path := filepath.Join(mountRoot, UniqueTestName("stale")+".txt")
-	if err := os.WriteFile(path, []byte("seed"), 0644); err != nil {
-		t.Fatalf("TriggerErrInvalidHandle: seed create failed: %v", err)
-	}
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("TriggerErrInvalidHandle: open failed: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = f.Close()
-		_ = os.Remove(path)
-	})
-
-	// Unlink the file; the server-side metadata handle becomes stale.
-	if err := os.Remove(path); err != nil {
-		t.Fatalf("TriggerErrInvalidHandle: remove failed: %v", err)
-	}
-
-	// Reading through the now-stale handle should surface ESTALE on NFS /
-	// STATUS_FILE_CLOSED on SMB.
-	buf := make([]byte, 16)
-	_, readErr := f.ReadAt(buf, 0)
-	return newResult(readErr)
+	// A stale/invalid file handle is not reproducible from a single client at
+	// the e2e tier. The intuitive scenario — unlink a file, then read through
+	// an fd you still hold — does NOT produce ESTALE: keeping your own open fd
+	// after unlink is valid POSIX (the inode lives until last close), and over
+	// NFS the client silly-renames the file so the read simply succeeds (or
+	// returns EOF), never ESTALE. A genuinely stale handle requires a *foreign*
+	// deleter or a server restart that drops the handle — neither of which this
+	// single-client fixture sets up. Coverage for the error→errno mapping lives
+	// in the unit tier (common/errmap_test.go); the e2e row is retained for
+	// shape and skipped with a documented reason.
+	t.Skip("ErrInvalidHandle/ErrStaleHandle not e2e-triggerable from one client (own-fd read after unlink is valid POSIX; NFS silly-renames) — covered by unit tier in common/errmap_test.go")
+	return TriggerResult{}
 }
 
-// TriggerErrStaleHandle is an alias for TriggerErrInvalidHandle — the same
-// kernel-level scenario reproduces either code depending on server-side
-// routing. The common/ errmap maps both to protocol codes that surface as
-// ESTALE client-side.
+// TriggerErrStaleHandle is an alias for TriggerErrInvalidHandle — both name the
+// same un-triggerable single-client scenario and skip with the same reason.
+// The common/ errmap maps both to protocol codes that surface as ESTALE
+// client-side; that mapping is asserted in the unit tier.
 func TriggerErrStaleHandle(t *testing.T, mountRoot string) TriggerResult {
 	return TriggerErrInvalidHandle(t, mountRoot)
 }


### PR DESCRIPTION
## Summary

Greens the e2e `TestCrossProtocol_ErrorConformance` (a backlog red surfaced by the revived suite #1456). One real product bug + test recalibration.

### Product fix — read-only → `NFS3ERR_ROFS`
A `create` / `write` / `delete` / `setattr` denied because the share is read-only now surfaces `metadata.ErrReadOnly`, so NFSv3 returns `NFS3ERR_ROFS` (EROFS) per RFC 1813 instead of `NFS3ERR_ACCES`. The xattr paths already did this; this aligns create/write/delete/setattr.

- `checkPermission`: a denied write/delete now returns `ErrReadOnly` (via new `shareForbidsWrites` helper) when the share is read-only — genuine ACL/mode denials still return `ErrAccessDenied`.
- `CheckParentCreateAccess` and `SetFileAttributes`: read-only branches return `ErrReadOnly`.

**SMB is unaffected** — the error map renders `ErrReadOnly` and `ErrAccessDenied` alike as `STATUS_ACCESS_DENIED`.

### Test recalibration
- `ErrInvalidHandle` / `ErrStaleHandle`: skipped — not e2e-triggerable from a single client. Reading your own fd after unlink is valid POSIX (inode lives until last close), and NFS silly-renames the file, so the read succeeds/returns EOF, never ESTALE. A genuine stale handle needs a foreign deleter or server restart. The error→errno mapping is covered in the unit tier.
- `ErrLocked` / SMB: real Linux `cifs` maps the SMB lock-conflict NT statuses to `-EACCES`, not `-EAGAIN` (`fs/smb/client/smb2maperror.c`). Corrected the test's kernel-errno model. (NFS keeps EAGAIN.)

## Validation
- `TestCrossProtocol_ErrorConformance` **PASS** on a Linux NFS/SMB kernel-client VM (`ErrReadOnly/nfs`→EROFS, `ErrLocked/smb`→EACCES, handle legs SKIP).
- `pkg/metadata` + `internal/adapter/...` unit suites green.
- code-reviewer pass (the SETATTR straggler it flagged is fixed here).