### PR TITLE
feat(gc): --grace-period override for on-demand block GC

### DIFF
--- a/cmd/dfsctl/commands/store/block/gc.go
+++ b/cmd/dfsctl/commands/store/block/gc.go
@@ -49,10 +49,18 @@ plain GC cannot reclaim because they keep their hashes in the live set.
 Reconcile is server-wide (all shares) and the recommended way to recover
 space leaked by older versions. Combine with --dry-run to preview.
 
+Use --grace-period to override the configured sweep grace for this run
+only. A zero grace (--grace-period 0) reaps every eligible orphan with no
+age guard, bypassing the server's 5-minute floor — useful to reclaim
+just-orphaned chunks immediately in tests or one-off cleanups. Cannot be
+combined with --reconcile.
+
 Examples:
   dfsctl store block gc myshare
   dfsctl store block gc myshare --dry-run
   dfsctl store block gc myshare --reconcile
+  dfsctl store block gc myshare --grace-period 0
+  dfsctl store block gc myshare --grace-period 30m
   dfsctl store block gc myshare --no-wait
   dfsctl store block gc myshare -o json`,
 	Args: cobra.ExactArgs(1),
@@ -63,6 +71,7 @@ func init() {
 	gcCmd.Flags().Bool("dry-run", false, "Run mark + sweep enumeration but skip deletes; print candidate keys")
 	gcCmd.Flags().Bool("reconcile", false, "Also reap stranded file_blocks rows leaked by older versions (server-wide), then sweep both tiers")
 	gcCmd.Flags().Bool("no-wait", false, "Start the job and print its id without waiting for completion")
+	gcCmd.Flags().Duration("grace-period", 0, "Override the sweep grace for this run (e.g. 30m, 0 to reap immediately); bypasses the server's 5m floor. Unset = server default")
 }
 
 func runBlockStoreGC(cmd *cobra.Command, args []string) error {
@@ -71,12 +80,25 @@ func runBlockStoreGC(cmd *cobra.Command, args []string) error {
 	reconcile, _ := cmd.Flags().GetBool("reconcile")
 	noWait, _ := cmd.Flags().GetBool("no-wait")
 
+	opts := &apiclient.BlockStoreGCOptions{DryRun: dryRun, Reconcile: reconcile}
+	if cmd.Flags().Changed("grace-period") {
+		grace, _ := cmd.Flags().GetDuration("grace-period")
+		if grace < 0 {
+			return fmt.Errorf("--grace-period must not be negative")
+		}
+		if reconcile {
+			return fmt.Errorf("--grace-period cannot be combined with --reconcile")
+		}
+		secs := int64(grace / time.Second)
+		opts.GracePeriodSeconds = &secs
+	}
+
 	client, err := cmdutil.GetAuthenticatedClient()
 	if err != nil {
 		return err
 	}
 
-	jobID, err := client.StartBlockStoreGC(share, &apiclient.BlockStoreGCOptions{DryRun: dryRun, Reconcile: reconcile})
+	jobID, err := client.StartBlockStoreGC(share, opts)
 	if err != nil {
 		return fmt.Errorf("failed to start block store GC: %w", err)
 	}

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -5625,6 +5625,12 @@ plain GC cannot reclaim because they keep their hashes in the live set.
 Reconcile is server-wide (all shares) and the recommended way to recover
 space leaked by older versions. Combine with --dry-run to preview.
 
+Use --grace-period to override the configured sweep grace for this run
+only. A zero grace (--grace-period 0) reaps every eligible orphan with no
+age guard, bypassing the server's 5-minute floor — useful to reclaim
+just-orphaned chunks immediately in tests or one-off cleanups. Cannot be
+combined with --reconcile.
+
 ```
 dfsctl store block gc <share> [flags]
 ```
@@ -5635,6 +5641,8 @@ dfsctl store block gc <share> [flags]
 dfsctl store block gc myshare
 dfsctl store block gc myshare --dry-run
 dfsctl store block gc myshare --reconcile
+dfsctl store block gc myshare --grace-period 0
+dfsctl store block gc myshare --grace-period 30m
 dfsctl store block gc myshare --no-wait
 dfsctl store block gc myshare -o json
 ```
@@ -5642,9 +5650,10 @@ dfsctl store block gc myshare -o json
 Flags:
 
 ```
-      --dry-run     Run mark + sweep enumeration but skip deletes; print candidate keys
-      --no-wait     Start the job and print its id without waiting for completion
-      --reconcile   Also reap stranded file_blocks rows leaked by older versions (server-wide), then sweep both tiers
+      --dry-run                 Run mark + sweep enumeration but skip deletes; print candidate keys
+      --grace-period duration   Override the sweep grace for this run (e.g. 30m, 0 to reap immediately); bypasses the server's 5m floor. Unset = server default
+      --no-wait                 Start the job and print its id without waiting for completion
+      --reconcile               Also reap stranded file_blocks rows leaked by older versions (server-wide), then sweep both tiers
 ```
 
 Global flags:

--- a/internal/controlplane/api/handlers/block_gc.go
+++ b/internal/controlplane/api/handlers/block_gc.go
@@ -29,7 +29,7 @@ type BlockGCRuntime interface {
 	// sweep. The run executes on a context detached from the request, so a
 	// request/client timeout cannot abort the (potentially multi-minute) mark
 	// phase (#1433).
-	StartBlockGC(shareName string, dryRun, reconcile bool) (*runtime.GCJob, error)
+	StartBlockGC(shareName string, dryRun, reconcile bool, gracePeriod *time.Duration) (*runtime.GCJob, error)
 
 	// GetGCJobStatus returns a GC job by ID, or false if unknown (never started
 	// or evicted from the retained-terminal window).
@@ -64,6 +64,12 @@ type BlockStoreGCRequest struct {
 	// (leaked by the pre-fix delete path) across all shares, then sweep both
 	// tiers. Reclaims historical leaks a plain GC cannot (#1433).
 	Reconcile bool `json:"reconcile,omitempty"`
+	// GracePeriodSeconds, when non-nil, overrides the server-configured sweep
+	// grace for this run only. Zero is valid and meaningful: reap every
+	// eligible orphan with no age guard (bypassing the config's 5-minute
+	// floor). Honoured only on the share-scoped path — combining it with
+	// reconcile is rejected with 400.
+	GracePeriodSeconds *int64 `json:"grace_period_seconds,omitempty"`
 }
 
 // GCJobStatusResponse is the JSON status body for an async GC job, returned by
@@ -142,6 +148,20 @@ func (h *BlockStoreGCHandler) RunGC(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	var gracePeriod *time.Duration
+	if req.GracePeriodSeconds != nil {
+		if *req.GracePeriodSeconds < 0 {
+			BadRequest(w, "grace_period_seconds must not be negative")
+			return
+		}
+		if req.Reconcile {
+			BadRequest(w, "grace_period_seconds cannot be combined with reconcile")
+			return
+		}
+		d := time.Duration(*req.GracePeriodSeconds) * time.Second
+		gracePeriod = &d
+	}
+
 	// Kick off the run asynchronously and return immediately: the mark phase can
 	// take minutes on a large or snapshot-heavy deployment, far longer than the
 	// request-middleware/client timeout, so a synchronous run was aborted
@@ -149,7 +169,7 @@ func (h *BlockStoreGCHandler) RunGC(w http.ResponseWriter, r *http.Request) {
 	// (#1433). The job runs on a detached context; clients poll
 	// GET .../blockstore/gc/{job_id}. Reconcile is server-wide (reaps stranded
 	// rows across all shares) and ignores the per-share scoping internally.
-	job, err := h.runtime.StartBlockGC(name, req.DryRun, req.Reconcile)
+	job, err := h.runtime.StartBlockGC(name, req.DryRun, req.Reconcile, gracePeriod)
 	if err != nil {
 		if errors.Is(err, shares.ErrShareNotFound) {
 			NotFound(w, "share not found: "+name)

--- a/internal/controlplane/api/handlers/block_gc.go
+++ b/internal/controlplane/api/handlers/block_gc.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"math"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -156,6 +157,14 @@ func (h *BlockStoreGCHandler) RunGC(w http.ResponseWriter, r *http.Request) {
 		}
 		if req.Reconcile {
 			BadRequest(w, "grace_period_seconds cannot be combined with reconcile")
+			return
+		}
+		// Guard the seconds→Duration multiply: without this an absurdly large
+		// value overflows int64 nanoseconds and wraps negative, which the engine
+		// then clamps to 0 (GracePeriodSet) — silently turning a "very long
+		// grace" request into the most aggressive possible reap.
+		if *req.GracePeriodSeconds > int64(math.MaxInt64/int64(time.Second)) {
+			BadRequest(w, "grace_period_seconds is too large")
 			return
 		}
 		d := time.Duration(*req.GracePeriodSeconds) * time.Second

--- a/internal/controlplane/api/handlers/block_gc_test.go
+++ b/internal/controlplane/api/handlers/block_gc_test.go
@@ -38,13 +38,14 @@ type fakeGCRuntime struct {
 }
 
 type startCall struct {
-	share     string
-	dryRun    bool
-	reconcile bool
+	share       string
+	dryRun      bool
+	reconcile   bool
+	gracePeriod *time.Duration
 }
 
-func (f *fakeGCRuntime) StartBlockGC(shareName string, dryRun, reconcile bool) (*runtime.GCJob, error) {
-	f.startCalls = append(f.startCalls, startCall{share: shareName, dryRun: dryRun, reconcile: reconcile})
+func (f *fakeGCRuntime) StartBlockGC(shareName string, dryRun, reconcile bool, gracePeriod *time.Duration) (*runtime.GCJob, error) {
+	f.startCalls = append(f.startCalls, startCall{share: shareName, dryRun: dryRun, reconcile: reconcile, gracePeriod: gracePeriod})
 	if f.startErr != nil {
 		return nil, f.startErr
 	}
@@ -143,6 +144,74 @@ func TestBlockStoreHandler_RunGC_DryRunReconcilePropagate(t *testing.T) {
 	}
 	if len(fake.startCalls) != 1 || !fake.startCalls[0].dryRun || !fake.startCalls[0].reconcile {
 		t.Fatalf("RunGC: expected dryRun+reconcile propagated; got %+v", fake.startCalls)
+	}
+}
+
+// TestBlockStoreHandler_RunGC_GracePeriodOverride asserts a zero grace override
+// reaches the runtime as an explicit 0 duration (not nil).
+func TestBlockStoreHandler_RunGC_GracePeriodOverride(t *testing.T) {
+	fake := &fakeGCRuntime{}
+	h := NewBlockStoreGCHandler(fake)
+
+	zero := int64(0)
+	body, _ := json.Marshal(BlockStoreGCRequest{GracePeriodSeconds: &zero})
+	req := newGCRequest(http.MethodPost, "/api/v1/shares/myshare/blockstore/gc", "myshare", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	h.RunGC(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("RunGC: expected 202, got %d (body=%q)", w.Code, w.Body.String())
+	}
+	if len(fake.startCalls) != 1 {
+		t.Fatalf("RunGC: expected 1 StartBlockGC call, got %d", len(fake.startCalls))
+	}
+	gp := fake.startCalls[0].gracePeriod
+	if gp == nil || *gp != 0 {
+		t.Fatalf("RunGC: expected gracePeriod==0 override, got %v", gp)
+	}
+}
+
+// TestBlockStoreHandler_RunGC_GracePeriodRejectsReconcile returns 400 when the
+// grace override is combined with reconcile (the override is share-scoped only),
+// and never starts a job.
+func TestBlockStoreHandler_RunGC_GracePeriodRejectsReconcile(t *testing.T) {
+	fake := &fakeGCRuntime{}
+	h := NewBlockStoreGCHandler(fake)
+
+	secs := int64(30)
+	body, _ := json.Marshal(BlockStoreGCRequest{Reconcile: true, GracePeriodSeconds: &secs})
+	req := newGCRequest(http.MethodPost, "/api/v1/shares/myshare/blockstore/gc", "myshare", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	h.RunGC(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("RunGC: expected 400 for grace+reconcile, got %d", w.Code)
+	}
+	if len(fake.startCalls) != 0 {
+		t.Fatalf("RunGC: expected no StartBlockGC call on rejected request, got %d", len(fake.startCalls))
+	}
+}
+
+// TestBlockStoreHandler_RunGC_GracePeriodRejectsNegative returns 400 for a
+// negative grace override.
+func TestBlockStoreHandler_RunGC_GracePeriodRejectsNegative(t *testing.T) {
+	fake := &fakeGCRuntime{}
+	h := NewBlockStoreGCHandler(fake)
+
+	neg := int64(-1)
+	body, _ := json.Marshal(BlockStoreGCRequest{GracePeriodSeconds: &neg})
+	req := newGCRequest(http.MethodPost, "/api/v1/shares/myshare/blockstore/gc", "myshare", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	h.RunGC(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("RunGC: expected 400 for negative grace, got %d", w.Code)
+	}
+	if len(fake.startCalls) != 0 {
+		t.Fatalf("RunGC: expected no StartBlockGC call, got %d", len(fake.startCalls))
 	}
 }
 

--- a/pkg/apiclient/blockstore.go
+++ b/pkg/apiclient/blockstore.go
@@ -117,6 +117,11 @@ type BlockStoreGCOptions struct {
 	// (leaked by the pre-fix delete path) across all shares, then sweep both
 	// tiers — reclaiming historical leaks a plain GC cannot (#1433).
 	Reconcile bool `json:"reconcile,omitempty"`
+	// GracePeriodSeconds, when non-nil, overrides the server-configured sweep
+	// grace for this run only. Zero is valid: reap every eligible orphan with
+	// no age guard, bypassing the config's 5-minute floor. The server rejects
+	// combining it with Reconcile.
+	GracePeriodSeconds *int64 `json:"grace_period_seconds,omitempty"`
 }
 
 // GCJobStatus is the wire-shape for an async block-store GC job, returned by

--- a/pkg/block/engine/gc.go
+++ b/pkg/block/engine/gc.go
@@ -191,8 +191,16 @@ type Options struct {
 
 	// GracePeriod is the TTL applied during sweep: an object whose
 	// LastModified is within snapshot - GracePeriod is preserved.
-	// Zero defaults to one hour.
+	// Zero defaults to one hour unless GracePeriodSet is true.
 	GracePeriod time.Duration
+
+	// GracePeriodSet, when true, makes GracePeriod authoritative — it is used
+	// verbatim, including a value of zero (reap every eligible orphan with no
+	// age guard). When false, a non-positive GracePeriod falls back to the
+	// one-hour default. This lets an explicit operator override (dfsctl store
+	// block gc --grace-period 0) bypass the floor without changing the
+	// default-substitution behaviour for every other caller.
+	GracePeriodSet bool
 
 	// DryRunSampleSize bounds the count of candidate keys captured in
 	// GCStats.DryRunCandidates. Zero defaults to 1000.
@@ -377,9 +385,16 @@ func collectGarbage(
 	rootLock := acquireGCRootLock(options.GCStateRoot)
 	defer releaseGCRootLock(options.GCStateRoot, rootLock)
 
-	// Apply defaults that the caller did not specify.
+	// Apply defaults that the caller did not specify. An explicit override
+	// (GracePeriodSet) is authoritative — including a zero grace, which a
+	// negative value is clamped to.
 	gracePeriod := options.GracePeriod
-	if gracePeriod <= 0 {
+	switch {
+	case options.GracePeriodSet:
+		if gracePeriod < 0 {
+			gracePeriod = 0
+		}
+	case gracePeriod <= 0:
 		gracePeriod = time.Hour
 	}
 	dryRunSample := options.DryRunSampleSize

--- a/pkg/block/engine/gc.go
+++ b/pkg/block/engine/gc.go
@@ -359,6 +359,24 @@ func CollectGarbageLocal(
 	return collectGarbage(ctx, localStore, reconciler, options, true)
 }
 
+// resolveGracePeriod returns the effective sweep grace period. An explicit
+// override (GracePeriodSet) is authoritative — including a zero grace, which a
+// negative value is clamped to. Without an override, a non-positive grace falls
+// back to the 1h default so an unconfigured sweep never reaps freshly-written
+// chunks.
+func resolveGracePeriod(options *Options) time.Duration {
+	if options.GracePeriodSet {
+		if options.GracePeriod < 0 {
+			return 0
+		}
+		return options.GracePeriod
+	}
+	if options.GracePeriod <= 0 {
+		return time.Hour
+	}
+	return options.GracePeriod
+}
+
 // collectGarbage is the shared mark-sweep kernel for both tiers. isLocal only
 // tags the resulting stats; the live-set, grace, and fail-closed semantics are
 // identical regardless of tier.
@@ -385,18 +403,8 @@ func collectGarbage(
 	rootLock := acquireGCRootLock(options.GCStateRoot)
 	defer releaseGCRootLock(options.GCStateRoot, rootLock)
 
-	// Apply defaults that the caller did not specify. An explicit override
-	// (GracePeriodSet) is authoritative — including a zero grace, which a
-	// negative value is clamped to.
-	gracePeriod := options.GracePeriod
-	switch {
-	case options.GracePeriodSet:
-		if gracePeriod < 0 {
-			gracePeriod = 0
-		}
-	case gracePeriod <= 0:
-		gracePeriod = time.Hour
-	}
+	// Apply defaults that the caller did not specify.
+	gracePeriod := resolveGracePeriod(options)
 	dryRunSample := options.DryRunSampleSize
 	if dryRunSample <= 0 {
 		dryRunSample = 1000

--- a/pkg/block/engine/gc_test.go
+++ b/pkg/block/engine/gc_test.go
@@ -1524,3 +1524,27 @@ func TestGCMarkSweep_ClearsSyncedMarkerForSweptHash(t *testing.T) {
 		t.Errorf("live block deleted: %v", err)
 	}
 }
+
+func TestResolveGracePeriod(t *testing.T) {
+	const hour = time.Hour
+	tests := []struct {
+		name string
+		opts Options
+		want time.Duration
+	}{
+		{"unset positive uses caller value", Options{GracePeriod: 30 * time.Minute}, 30 * time.Minute},
+		{"unset zero falls back to 1h", Options{GracePeriod: 0}, hour},
+		{"unset negative falls back to 1h", Options{GracePeriod: -5 * time.Second}, hour},
+		{"set zero is authoritative", Options{GracePeriod: 0, GracePeriodSet: true}, 0},
+		{"set positive is authoritative", Options{GracePeriod: 2 * hour, GracePeriodSet: true}, 2 * hour},
+		{"set negative clamps to zero", Options{GracePeriod: -1, GracePeriodSet: true}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := tt.opts
+			if got := resolveGracePeriod(&opts); got != tt.want {
+				t.Fatalf("resolveGracePeriod(%+v) = %v, want %v", tt.opts, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -144,7 +144,7 @@ func (r *Runtime) runBlockGCSweep(ctx context.Context, sharePrefix string, dryRu
 	}
 	// Sweep the local tier too, so one `gc` invocation reclaims orphaned
 	// chunks on both remote and local stores (#1433).
-	r.runLocalGC(ctx, "", dryRun, total, progress)
+	r.runLocalGC(ctx, "", dryRun, total, progress, nil)
 	return total, nil
 }
 
@@ -165,7 +165,7 @@ var collectGarbageLocalFn = engine.CollectGarbageLocal
 // (#1433).
 func (r *Runtime) RunBlockGCLocal(ctx context.Context, dryRun bool) (*engine.GCStats, error) {
 	total := &engine.GCStats{}
-	r.runLocalGC(ctx, "", dryRun, total, nil)
+	r.runLocalGC(ctx, "", dryRun, total, nil, nil)
 	return total, nil
 }
 
@@ -175,7 +175,10 @@ func (r *Runtime) RunBlockGCLocal(ctx context.Context, dryRun bool) (*engine.GCS
 // backend (empty gc-state root) are skipped. Shared by RunBlockGC,
 // RunBlockGCForShare, and RunBlockGCLocal so a single `gc` invocation reclaims
 // orphans on BOTH tiers (#1433).
-func (r *Runtime) runLocalGC(ctx context.Context, shareFilter string, dryRun bool, total *engine.GCStats, progress func(engine.GCStats)) {
+// gracePeriod, when non-nil, overrides the configured local-tier sweep grace
+// for this run (including zero). nil leaves the configured/default grace, used
+// by the server-wide and reconcile sweeps.
+func (r *Runtime) runLocalGC(ctx context.Context, shareFilter string, dryRun bool, total *engine.GCStats, progress func(engine.GCStats), gracePeriod *time.Duration) {
 	gcDefaults := r.gcDefaultsSnapshot()
 	for _, entry := range r.sharesSvc.ShareLocalStores() {
 		if shareFilter != "" && entry.ShareName != shareFilter {
@@ -192,6 +195,12 @@ func (r *Runtime) runLocalGC(ctx context.Context, shareFilter string, dryRun boo
 			Shares:      []string{entry.ShareName},
 		}
 		applyGCDefaults(opts, gcDefaults)
+		if gracePeriod != nil {
+			// Operator override for this run only: authoritative grace,
+			// including zero (no age guard).
+			opts.GracePeriod = *gracePeriod
+			opts.GracePeriodSet = true
+		}
 		applyGCProgress(opts, progress)
 		opts.HoldProvider = r.snapshotHoldForShare(entry.ShareName)
 		logger.Info("local GC: starting",
@@ -257,13 +266,16 @@ func (p *perRemoteReconciler) GetMetadataStoreForShare(shareName string) (metada
 //
 // Returns an ErrShareNotFound-wrapped error if name is unknown.
 func (r *Runtime) RunBlockGCForShare(ctx context.Context, name string, dryRun bool) (*engine.GCStats, error) {
-	return r.runBlockGCForShare(ctx, name, dryRun, nil)
+	return r.runBlockGCForShare(ctx, name, dryRun, nil, nil)
 }
 
 // runBlockGCForShare is RunBlockGCForShare with an optional progress sink wired
 // into the engine for async callers (StartBlockGC). progress is nil for the
-// synchronous public entrypoint.
-func (r *Runtime) runBlockGCForShare(ctx context.Context, name string, dryRun bool, progress func(engine.GCStats)) (*engine.GCStats, error) {
+// synchronous public entrypoint. gracePeriod, when non-nil, overrides the
+// server-configured sweep grace for this run only — including zero, which reaps
+// every eligible orphan with no age guard (dfsctl store block gc
+// --grace-period).
+func (r *Runtime) runBlockGCForShare(ctx context.Context, name string, dryRun bool, progress func(engine.GCStats), gracePeriod *time.Duration) (*engine.GCStats, error) {
 	gcRoot, err := r.sharesSvc.GetGCStateDirForShare(name)
 	if err != nil {
 		return nil, err
@@ -293,6 +305,12 @@ func (r *Runtime) runBlockGCForShare(ctx context.Context, name string, dryRun bo
 			Shares:           append([]string(nil), entry.Shares...),
 		}
 		applyGCDefaults(opts, gcDefaults)
+		if gracePeriod != nil {
+			// Operator override for this run only: authoritative grace,
+			// including zero (no age guard).
+			opts.GracePeriod = *gracePeriod
+			opts.GracePeriodSet = true
+		}
 		applyGCProgress(opts, progress)
 		// Inject held hashes from ready snapshots into the GC mark phase.
 		opts.HoldProvider = r.snapshotHoldForRemote(entry.Shares)
@@ -326,7 +344,7 @@ func (r *Runtime) runBlockGCForShare(ctx context.Context, name string, dryRun bo
 		)
 	}
 	// Sweep this share's local tier too (#1433).
-	r.runLocalGC(ctx, name, dryRun, total, progress)
+	r.runLocalGC(ctx, name, dryRun, total, progress, gracePeriod)
 	return total, nil
 }
 

--- a/pkg/controlplane/runtime/blockgc_job.go
+++ b/pkg/controlplane/runtime/blockgc_job.go
@@ -218,7 +218,11 @@ func (r *gcRegistry) cancelActive() {
 // an unknown share fails fast with an ErrShareNotFound-wrapped error rather than
 // surfacing only later as a failed job. Reconcile is server-wide and skips the
 // per-share check.
-func (r *Runtime) StartBlockGC(shareName string, dryRun, reconcile bool) (*GCJob, error) {
+// gracePeriod, when non-nil, overrides the server-configured sweep grace for
+// this run only (including zero, which reaps every eligible orphan with no age
+// guard). It is honoured only on the share-scoped path; reconcile runs ignore
+// it (the caller rejects the combination up front).
+func (r *Runtime) StartBlockGC(shareName string, dryRun, reconcile bool, gracePeriod *time.Duration) (*GCJob, error) {
 	if !reconcile {
 		if _, err := r.sharesSvc.GetGCStateDirForShare(shareName); err != nil {
 			return nil, err
@@ -228,7 +232,7 @@ func (r *Runtime) StartBlockGC(shareName string, dryRun, reconcile bool) (*GCJob
 		if reconcile {
 			return r.runBlockGCReconcile(ctx, dryRun, progress)
 		}
-		return r.runBlockGCForShare(ctx, shareName, dryRun, progress)
+		return r.runBlockGCForShare(ctx, shareName, dryRun, progress, gracePeriod)
 	}), nil
 }
 

--- a/test/e2e/cas_immutable_overwrites_test.go
+++ b/test/e2e/cas_immutable_overwrites_test.go
@@ -154,19 +154,13 @@ func TestBlockStoreImmutableOverwrites(t *testing.T) {
 			"should produce different chunk hashes)")
 
 	// ---- Step 3: GC reaps the old keys ----
-	if err := helpers.TriggerBlockGC(t, cli, shareName); err != nil {
+	// --grace-period 0 reaps just-orphaned chunks immediately, bypassing the
+	// server's 5-minute grace floor so the freshly-overwritten A chunks are
+	// eligible within the test's lifetime. The command waits for the async job
+	// to finish before returning.
+	if err := helpers.TriggerBlockGC(t, cli, shareName, "--grace-period", "0"); err != nil {
 		t.Skipf("DEFERRED: dfsctl store block gc subcommand not yet wired (Plan 11-07 dependency): %v", err)
 	}
-
-	// GC has a grace period (default 1h). The test config does NOT
-	// override that today — once a knob to set gc.grace_period or pass
-	// --grace-period 0 on the CLI lands, this test can drop the
-	// conservative wait. For now: sleep briefly to let the in-process
-	// GC last-run.json land, then re-list. If the keys have not yet
-	// been reaped (because the grace period swallowed the run), surface
-	// that as a clear error so the operator knows to configure grace=0
-	// in the test profile.
-	time.Sleep(1 * time.Second)
 
 	keysAfterGC := helpers.ListCASKeys(t, lsHelper, bucket)
 	addedSinceGC, removedByGC := helpers.CASKeySetDiff(keysAB, keysAfterGC)

--- a/test/e2e/helpers/cas.go
+++ b/test/e2e/helpers/cas.go
@@ -172,10 +172,11 @@ func CASKeySetDiff(before, after []string) (added, removed []string) {
 // build (e.g. older binary), the dfsctl runner rejects the unknown
 // subcommand and this helper returns an error. The canonical E2E
 // recognizes that and SKIPS with an explanatory message.
-func TriggerBlockGC(t *testing.T, runner *CLIRunner, shareName string) error {
+func TriggerBlockGC(t *testing.T, runner *CLIRunner, shareName string, extraArgs ...string) error {
 	t.Helper()
 
-	_, err := runner.Run("store", "block", "gc", shareName)
+	args := append([]string{"store", "block", "gc", shareName}, extraArgs...)
+	_, err := runner.Run(args...)
 	if err != nil {
 		return fmt.Errorf("dfsctl store block gc %s: %w", shareName, err)
 	}

--- a/test/e2e/helpers/cas.go
+++ b/test/e2e/helpers/cas.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -178,7 +179,7 @@ func TriggerBlockGC(t *testing.T, runner *CLIRunner, shareName string, extraArgs
 	args := append([]string{"store", "block", "gc", shareName}, extraArgs...)
 	_, err := runner.Run(args...)
 	if err != nil {
-		return fmt.Errorf("dfsctl store block gc %s: %w", shareName, err)
+		return fmt.Errorf("dfsctl %s: %w", strings.Join(args, " "), err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Adds an optional per-invocation **sweep-grace override** to `dfsctl store block gc`. A zero grace (`--grace-period 0`) reaps every eligible orphan with no age guard, bypassing the server config's 5-minute grace floor — needed to reclaim just-orphaned chunks immediately in tests and one-off operator cleanups. Greens the e2e `TestBlockStoreImmutableOverwrites` backlog red (#1456 revival).

## Change

- `engine.Options.GracePeriodSet` makes `GracePeriod` authoritative, **including 0**. When unset, a non-positive grace still defaults to 1h — backward compatible for every existing caller.
- Threaded: CLI flag `--grace-period` → `apiclient.BlockStoreGCOptions.GracePeriodSeconds *int64` → REST `BlockStoreGCRequest` → `Runtime.StartBlockGC` → `runBlockGCForShare` **and** `runLocalGC` (both tiers).
- **Share-scoped only.** Combining with `--reconcile` is rejected (400, and at the CLI). Negative is rejected at both layers.

## Safety

The override changes **only the age guard**, never the mark phase: the live-set (`EnumerateFileChunks` + snapshot `HoldProvider`) still protects every referenced chunk regardless of grace. `grace=0` reaps only *unreferenced* orphans immediately. (code-reviewer confirmed no new data-loss path.)

## Validation
- e2e `TestBlockStoreImmutableOverwrites` **PASS** on a Localstack-S3 VM: GC step with `--grace-period 0` reaps the 16 orphaned A-chunks (`-16 removed`), retains live B-chunks.
- Unit tests added: handler grace-override pass-through + 400 guards (reconcile/negative).
- `pkg/block/engine`, `pkg/controlplane/runtime`, handler suites green. `docs/guide/cli.md` regenerated.