### PR TITLE
feat(metadata,block): blocks-only persistence layer — block records + local index + log-blob tier (#1493)

### DIFF
--- a/.planning/2026-06-30-1493-pr2-plan.md
+++ b/.planning/2026-06-30-1493-pr2-plan.md
@@ -1,0 +1,240 @@
+# PR2 — Persistence layer: local log-blob tier + metadata block records
+
+**Branch:** `1493-pr2-local-log-blob` (off PR1 `1493-blocks-only-storage`).
+**Design:** `.planning/2026-06-30-blocks-only-storage-design.md` (components 3, 4).
+**Roadmap:** `.planning/2026-06-30-1493-blocks-only-roadmap.md` (PR2 section).
+**Delivers:** #1416 (single-transaction per-block commit — one fsync per block, not per file).
+
+## What PR2 is / is NOT
+
+PR2 builds the **durable substrate** for blocks-only storage as **new, dormant capability**.
+It does NOT flip the live writer — the existing per-file append-log → FastCDC → per-chunk
+`cas/<hash>` rollup stays the default write path. PR3 wires the new substrate in and flips
+behavior; PR4 deletes the old CAS path.
+
+**Sanctioned temporary coexistence.** The new log-blob primitive and the existing per-file
+appendlog/rollup coexist on `develop` after PR2. This is NOT a "no-additive-parallel-types"
+violation — it is the forced intermediate state of a green-per-PR migration that ends in
+deletion (PR3 flips, PR4 deletes). Do not delete the old path in PR2 (it is still live).
+
+## Existing surface (from exploration — file:line anchors)
+
+- Local tier: `pkg/block/local/fs/` — per-file append logs (`appendlog.go`, `appendwrite.go`,
+  `logindex.go`), background rollup to CAS (`rollup.go`, `chunkstore.go:chunkPath` shard
+  `blocks/<hex0:2>/<hex2:4>/<hex>`), LRU eviction (`eviction.go`), constructor
+  `fs.NewWithOptions` + `FSStoreOptions` (`fs.go:912,998`).
+- Locator: `block.ChunkLocator{BlockID, WireOffset, WireLength}` + `IsStandalone()`
+  (`pkg/block/locator.go`).
+- Per-chunk row: `block.FileChunk` (`pkg/block/types.go:240`), keyed `{payloadID}/{blockIndex}`;
+  `State BlockState` (Pending=0/Syncing=1/Remote=2, `types.go:52`); `RefCount`.
+- Remote locator store: `metadata.SyncedHashStore{IsSynced, MarkSynced(hash,loc), GetLocator,
+  DeleteSynced}` (`pkg/metadata/synced_hash_store.go:23`). Backends: memory, badger, sqlite
+  (migration 000002 added `block_id/block_offset/block_length`), postgres (migration 000035).
+- Transactions: `metadata.Transactor.WithTransaction(ctx, fn func(tx Transaction) error)`
+  (`pkg/metadata/store.go:288`); native ACID on all 4 backends; memory uses txSnapshot rollback.
+- Conformance: `pkg/metadata/storetest/RunConformanceSuite(t, factory)` (`suite.go:43`);
+  per-backend factories already register it. Block-store conformance:
+  `pkg/block/blockstoretest/` (`BlockStoreConformance`, `BlockStoreAppendConformance`).
+
+## Naming (this PR)
+
+Reserve **Block** for the packed remote container. New structures introduced here:
+- **block record** — `block.BlockRecord{BlockID, BlockHash, Length, LiveChunkCount, SyncState}`.
+  `SyncState` reuses the existing `block.BlockState` enum (do NOT rename it to `ChunkSyncState`
+  yet — that rename is PR4's final sweep; renaming here would balloon the diff).
+- **local chunk location** — `block.LocalChunkLocation{LogBlobID, RawOffset, RawLength}`.
+- **log blob** — `logblob.Blob` / `logblob.Manager` in new package `pkg/block/local/logblob`.
+
+Do NOT rename `FileChunk`/`BlockState`/etc. here — PR4 owns the final naming sweep. PR2 only
+*adds* new, already-correctly-named structures.
+
+## Global constraints (every task)
+
+1. **TDD, no exceptions.** Failing test first, watched fail, minimal code to green. New
+   metadata structures get `storetest` contract tests that RED across all 4 backends before
+   any backend implements them. The log-blob primitive gets package unit tests first.
+2. **New code only — do NOT flip the live writer.** No change to the rollup→CAS default path.
+   `go test ./...` and the existing conformance suites stay green throughout.
+3. **All 4 metadata backends** (memory, badger, sqlite, postgres) implement every new metadata
+   structure and pass the new `storetest` contract tests. A backend that compiles but skips a
+   contract is a failure.
+4. **`CommitBlock` is one transaction.** All of a block's chunk remote-locators + each chunk's
+   local-index entry + the block record commit in a single `WithTransaction` — one fsync per
+   block. The contract test asserts atomicity (inject a mid-commit error → nothing persists).
+5. **Idempotency.** `CommitBlock` re-applied with the same `BlockID` is a no-op-or-overwrite,
+   never a double-count of `LiveChunkCount`. Local-index `Put` and block-record `Put` are
+   upserts.
+6. **Concurrency-safe.** Log-blob append is mutex-serialized at the tail; `pread` of earlier
+   offsets runs concurrently with appends. Race-test the primitive (`go test -race`).
+7. **Minimize interface surface.** Fold new methods onto the existing composed `Store` /
+   `Transaction` interfaces (as `SyncedHashStore` already is); add narrow new interfaces
+   (`BlockRecordStore`, `LocalChunkIndex`) only for the new structures. No capability-only
+   interfaces. `CommitBlock` is ONE method with a single default implementation over
+   `WithTransaction` (not 4 hand-written copies) where the backend allows.
+8. **Lint/format gate.** `gofmt -s -w .`, `go vet ./...`, `golangci-lint run` clean before a
+   task is DONE.
+9. **Commits signed, no AI mentions.** `git commit -S`; messages scoped `feat(metadata):` /
+   `feat(block):` / `test(...)` / `docs(...)`; reference `#1493` / `#1416` where apt.
+
+## Symmetry insight (design rationale to preserve)
+
+The **local chunk index** (`hash → {logBlobID, rawOffset, rawLength}`) is the local-tier
+analog of `SyncedHashStore`'s **remote locator** (`hash → {BlockID, wireOffset, wireLength}`).
+Both are hash-keyed (dedup: many `FileChunk` rows, one physical location). Model
+`LocalChunkIndex` deliberately parallel to `SyncedHashStore` — same shape, same backend
+patterns, same conformance style. Keeping them symmetric is a correctness and review aid.
+
+---
+
+## Tasks
+
+### Task 1 — Metadata types + interfaces + storetest contracts + memory backend
+
+**Goal:** define the new structures and their contracts; make memory pass.
+
+- Types in `pkg/block/types.go` (or `locator.go`): `BlockRecord{BlockID string, BlockHash
+  ContentHash, Length int64, LiveChunkCount uint32, SyncState BlockState}`,
+  `LocalChunkLocation{LogBlobID string, RawOffset int64, RawLength int64}`.
+- Interfaces in `pkg/metadata/`:
+  - `BlockRecordStore{ PutBlockRecord(ctx, BlockRecord) error; GetBlockRecord(ctx, blockID)
+    (BlockRecord, bool, error); DeleteBlockRecord(ctx, blockID) error; WalkBlockRecords(ctx,
+    func(BlockRecord) error) error; DecrLiveChunkCount(ctx, blockID, delta uint32) (remaining
+    uint32, err error) }` — `DecrLiveChunkCount` is GC's hook (PR3 uses it; define + test now).
+  - `LocalChunkIndex{ PutLocalLocation(ctx, hash, LocalChunkLocation) error;
+    GetLocalLocation(ctx, hash) (LocalChunkLocation, bool, error); DeleteLocalLocation(ctx,
+    hash) error }` — mirrors `SyncedHashStore`.
+  - `CommitBlock(ctx, rec BlockRecord, chunks []BlockChunkCommit) error` on the composed
+    `Store`, where `BlockChunkCommit{Hash, Remote ChunkLocator, Local LocalChunkLocation}`.
+    Default implementation over `WithTransaction`: writes block record + per-chunk MarkSynced
+    (remote locator) + per-chunk PutLocalLocation, atomically. Idempotent on `BlockID`.
+- Add the two interfaces to the composed `Store` AND `Transaction` interfaces
+  (`pkg/metadata/store.go`) so they run inside `WithTransaction`.
+- storetest contracts (RED for all backends, GREEN for memory):
+  - `block_record_ops.go`: Put/Get/Delete/Walk round-trip; `DecrLiveChunkCount` floors at 0
+    and reports remaining; Walk enumerates all; missing → `(_, false, nil)`.
+  - `local_index_ops.go`: Put/Get/Delete round-trip; upsert overwrites; missing →
+    `(_, false, nil)`; symmetric to existing SyncedHashStore tests.
+  - `commit_block_ops.go`: one `CommitBlock` persists record + all locators + all local
+    locations; **atomicity** (mid-commit error → none persist — drive via a chunk that forces
+    a tx error, or a fault hook); **idempotency** (re-commit same BlockID → LiveChunkCount not
+    doubled); dedup (two chunks same hash in one block tolerated).
+  - Register all three under `RunConformanceSuite` (`suite.go`).
+- Memory backend (`pkg/metadata/store/memory/`): implement both interfaces + the tx variants;
+  `CommitBlock` via existing memory `WithTransaction` snapshot path. → memory GREEN.
+
+**DoD:** types + interfaces defined; 3 storetest groups registered; memory passes; other
+backends RED (expected — they don't implement yet, guarded so the suite compiles).
+
+> Note for controller: storetest runs against every registered backend. To keep `develop`
+> green per-PR while backends are implemented across Tasks 2–4, the new contract groups must
+> be added so they only run against backends that advertise support, OR Tasks 1–4 land as one
+> reviewed unit. Decide at dispatch: prefer a `supportsBlockRecords` capability probe in the
+> suite (skip+log for un-implemented backends) so each task keeps the full `go test ./...`
+> green, and remove the probe in Task 4 once all four pass. Log every skip (no silent gaps).
+
+### Task 2 — Badger backend
+
+- Implement `BlockRecordStore` + `LocalChunkIndex` + tx variants in
+  `pkg/metadata/store/badger/`. Key prefixes e.g. `br:{blockID}`, `li:{hex(hash)}`. JSON or
+  binary value encoding consistent with the existing `synced:` encoding. `CommitBlock` runs in
+  one `badger.Txn`.
+- Flip the capability probe so badger runs the 3 contract groups. → badger GREEN.
+
+**DoD:** badger passes block_record/local_index/commit_block contracts; `-race` clean.
+
+### Task 3 — SQLite backend
+
+- Migration `pkg/metadata/store/sqlite/migrations/000003_block_records.up.sql` (+down):
+  `block_records(block_id PK, block_hash BLOB, length INT, live_chunk_count INT,
+  sync_state INT)`; `local_chunk_index(hash BLOB PK, log_blob_id TEXT, raw_offset INT,
+  raw_length INT)`.
+- Impl + tx variants in `pkg/metadata/store/sqlite/`; `CommitBlock` in one `sql.Tx`
+  (reuse the busy-retry loop). Flip probe for sqlite. → sqlite GREEN.
+
+**DoD:** sqlite passes contracts; migration up+down tested; lint clean.
+
+### Task 4 — Postgres backend + remove capability probe
+
+- Migration `pkg/metadata/store/postgres/migrations/000036_block_records.up.sql` (+down):
+  same two tables (`BYTEA`/`TEXT`/`BIGINT`/`SMALLINT`).
+- Impl + tx variants in `pkg/metadata/store/postgres/`; `CommitBlock` in one `pgx.Tx`.
+- **Remove the capability probe** from `storetest` — all 4 backends now implement the
+  contracts, so they run unconditionally. → all backends GREEN.
+
+**DoD:** postgres passes; probe removed; `go test ./...` green across all backends.
+
+### Task 5 — Log-blob local primitive (write + read + rotation)
+
+New package `pkg/block/local/logblob/`. Pure primitive — NOT wired into `FSStore` (PR3 wires).
+
+- `Manager` owns a directory of raw log blobs (`<dir>/<logBlobID>.blob`). One **active** blob
+  receives appends; older blobs are read-only.
+- `Append(ctx, p []byte) (LocalChunkLocation, error)` — mutex-serialized `pwrite` at the tail
+  of the active blob, returns `{LogBlobID, RawOffset, RawLength=len(p)}`. fsync on an explicit
+  `Sync()`/commit boundary (caller controls durability cadence; default fsync-on-commit).
+  Bytes are **raw** — no framing, no transform (transform happens at block carve, PR3).
+- `ReadAt(ctx, loc LocalChunkLocation, dst []byte) (int, error)` — `pread` from the named
+  blob at `RawOffset`; runs concurrently with tail appends (positioned I/O, no shared offset).
+- **Rotation:** when the active blob reaches `SizeCap` (default ~1 GiB, configurable) or on a
+  caller-driven rotate, seal it and start a fresh active blob. Blob IDs are monotonic/unique
+  and stable across restart.
+- `ListBlobs()` / manifest enumeration for eviction + recovery.
+- TDD unit tests: append→ReadAt round-trip; many appends interleaved, each ReadAt exact;
+  concurrent ReadAt of sealed offsets during active appends (`-race`); rotation at cap creates
+  a new blob and old stays readable; IDs stable across `Manager` reopen.
+
+**DoD:** logblob primitive round-trips + rotates; `-race` clean; lint clean; not referenced
+by `FSStore`.
+
+### Task 6 — Log-blob eviction + torn-tail recovery + blockstoretest
+
+- **Whole-blob eviction:** `EvictBlob(ctx, logBlobID) error` removes a fully-synced blob to
+  reclaim disk; refuses/returns sentinel if the blob is the active one or has unsynced bytes
+  (caller passes the synced predicate — PR3 supplies it from metadata). Test: evict a sealed
+  blob, ReadAt of an evicted location returns a typed `ErrEvicted`.
+- **Torn-tail recovery:** `Recover(ctx, logBlobID string, validUpToOffset int64) error` —
+  truncate the active blob to `validUpToOffset` (the durable high-water mark; PR3 computes it
+  from the local index). On `Manager` open, the active blob is opened for append at its
+  recovered tail. Test: write past a mark, simulate torn tail (extra garbage bytes), recover
+  to mark → blob length == mark, subsequent appends land at mark, earlier reads intact.
+- `blockstoretest` log-blob behavior suite (append/pread/rotate/evict/recover) usable by any
+  future log-blob impl, mirroring the existing append conformance style.
+
+**DoD:** eviction + torn-tail recovery tested (including acked-survives / unacked-dropped
+boundary); conformance suite added; `-race` + lint clean.
+
+### Task 7 — Docs
+
+- `docs/internals/implementing-stores.md`: document the metadata **block record** + **local
+  chunk index** contracts and the **`CommitBlock`** atomic per-block commit (one fsync per
+  block, #1416), beside the existing SyncedHashStore section.
+- `docs/internals/architecture.md`: add the log-blob local tier to the block-storage section
+  (raw append-at-tail, pread carve, rotation, whole-blob eviction, torn-tail recovery) and
+  note it is dormant until PR3 wires it.
+- No CLI/flag changes expected → no `gendocs` run (confirm; run it only if a flag changed).
+
+**DoD:** docs reflect the new substrate; cross-referenced; no generated-doc hand-edits.
+
+---
+
+## Pre-task cleanup (fold Copilot PR1 nits here, Task 1 prelude)
+
+PR2 extends the exact code PR1's Copilot review flagged. Fix in Task 1's first commit:
+- `pkg/block/blockcodec/codec.go:75` — `Builder.Add` doc still says `Offset/Length`; update to
+  `WireOffset/WireLength`.
+- `pkg/block/blockcodec/codec.go:280` — `Builder.writeRaw`: add a defensive short-write guard
+  (`if n < len(p) && err == nil { err = io.ErrShortWrite }`) even though a conforming
+  `io.Writer` must already error on short writes — cheap, removes the ambiguity.
+- `pkg/block/remote/s3/store.go:803` — `GetBlockRange` preallocation: cap the fallback
+  preallocation when Content-Length is absent/0 so a missing header can't drive an oversized
+  eager allocation.
+
+## Verification (whole-PR, before final review)
+
+- `go test ./...` and `go test -race ./pkg/block/... ./pkg/metadata/...` green.
+- All 4 backends pass `RunConformanceSuite` including the 3 new groups; capability probe gone.
+- `gofmt -s -l .` empty; `go vet ./...` clean; `golangci-lint run` clean.
+- No change to the live write path: rollup→CAS still default; existing fs/append conformance
+  unchanged and green.
+- Grep: new structures correctly named (`BlockRecord`, `LocalChunkLocation`, `logblob`); no
+  premature `FileChunk→`/`BlockState→ChunkSyncState` renames (PR4 owns those).

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -420,7 +420,13 @@ LocalChunkLocation{LogBlobID, RawOffset, RawLength}
     │
     ├─▶ metadata.LocalChunkIndex.PutLocalLocation  ─┐
     └─▶ metadata.BlockRecordStore.PutBlockRecord   ─┴─ single transaction
-            via metadata.DefaultCommitBlock            (one fsync per block)
+            via metadata.DefaultCommitBlock            (one fsync per block —
+                                                        the local durable commit)
+            then, after that transaction commits:
+    └─▶ metadata.SyncedHashStore.MarkSynced (per chunk, remote locator)
+            runs as a separate idempotent post-commit phase — SyncedHashStore is
+            on Store but not Transaction, so remote locators are written outside
+            the block transaction and re-driven safely on retry.
 
 Read path:
     ContentHash

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -325,6 +325,117 @@ shares.
 See `docs/CONFIGURATION.md` (`max_log_bytes`, `rollup_workers`,
 `stabilization_ms`, `orphan_log_min_age_seconds`) for the tunables.
 
+## Log-Blob Local Tier
+
+`pkg/block/local/logblob` is a raw append-only file manager designed to
+replace the per-file append-log described above. **This substrate is built
+but not yet active.** The live local write path is still the `FSStore`
+append-log → FastCDC → `cas/<hash>` rollup described in
+[Block Store — Local Append-Log Tier](#block-store----local-append-log-tier).
+A later PR wires `logblob.Manager` into the block engine; a further PR
+retires the per-file log.
+
+### Layout
+
+A `Manager` owns a directory of flat binary files called log-blobs (`*.blob`):
+
+```
+<dir>/0000000000000000.blob    ← active blob (accepts appends)
+<dir>/0000000000000001.blob    ← sealed (read-only, eligible for eviction)
+...
+```
+
+Blob IDs are zero-padded 16-digit decimals, giving lexicographic sort order
+matching creation order. Chunks are stored raw — no per-record framing, no
+checksum inside the blob — so the single read primitive is a positioned
+`pread(2)` against a `LocalChunkLocation{LogBlobID, RawOffset, RawLength}`.
+Durability is caller-controlled: call `Sync` at commit boundaries.
+
+### API
+
+```go
+// Open opens (or creates) a Manager rooted at dir.
+// On a fresh directory it creates the first blob. On reopen the
+// highest-numbered blob becomes active and appends resume at its tail.
+func Open(dir string, opts Options) (*Manager, error)
+
+// Append writes p to the tail of the active blob and returns the chunk's
+// position. Rotates automatically when the active blob would exceed SizeCap
+// (default 1 GiB). Empty payloads are rejected.
+func (m *Manager) Append(ctx context.Context, p []byte) (block.LocalChunkLocation, error)
+
+// ReadAt reads loc.RawLength bytes from blob loc.LogBlobID at loc.RawOffset
+// into dst (len(dst) >= loc.RawLength). Safe to call concurrently with Append.
+func (m *Manager) ReadAt(ctx context.Context, loc block.LocalChunkLocation, dst []byte) (int, error)
+
+// Rotate seals the active blob and opens a fresh one. Callers can rotate
+// at application-defined boundaries without waiting for SizeCap.
+func (m *Manager) Rotate() error
+
+// Sync fsyncs the active blob to durable storage.
+func (m *Manager) Sync() error
+
+// ListBlobs returns metadata for every blob, sorted by creation order.
+// Includes the active blob.
+func (m *Manager) ListBlobs() ([]BlobInfo, error)
+
+// EvictBlob removes a sealed blob from disk and the in-memory fd cache.
+// The caller supplies a synced func that reports whether the blob's bytes
+// are durable elsewhere; eviction is refused with ErrUnsyncedBytes if not.
+// Idempotent: a second call on an already-evicted blob returns nil.
+// After eviction, ReadAt on that blob returns ErrEvicted.
+func (m *Manager) EvictBlob(ctx context.Context, logBlobID string, synced func(string) bool) error
+
+// Recover truncates logBlobID to validUpToOffset, discarding torn tail bytes.
+// For the active blob it also updates the in-memory tail pointer.
+// Rejects offset > current blob size to prevent POSIX ftruncate from
+// zero-filling. Callers must quiesce concurrent I/O before calling Recover.
+func (m *Manager) Recover(ctx context.Context, logBlobID string, validUpToOffset int64) error
+```
+
+### Concurrency
+
+`Append` and `Rotate` are mutex-serialized. `ReadAt` acquires the mutex
+briefly to snapshot the active blob's identity and file descriptor, then
+releases it before the `pread(2)` call. Reads and appends on non-overlapping
+byte ranges therefore proceed concurrently. The race detector is clean.
+
+### Sentinel errors
+
+| Error | Condition |
+|---|---|
+| `logblob.ErrClosed` | Operation attempted after `Close` |
+| `logblob.ErrBlobNotFound` | `ReadAt` targets a non-existent blob ID |
+| `logblob.ErrEvicted` | `ReadAt` or `Recover` targets an evicted blob |
+| `logblob.ErrActiveBlob` | `EvictBlob` called on the current active blob |
+| `logblob.ErrUnsyncedBytes` | `EvictBlob` refused because the caller's `synced` func returned false |
+
+### Data flow (once wired in)
+
+```
+Chunk bytes
+    │
+    ▼ logblob.Manager.Append
+LocalChunkLocation{LogBlobID, RawOffset, RawLength}
+    │
+    ├─▶ metadata.LocalChunkIndex.PutLocalLocation  ─┐
+    └─▶ metadata.BlockRecordStore.PutBlockRecord   ─┴─ single transaction
+            via metadata.DefaultCommitBlock            (one fsync per block)
+
+Read path:
+    ContentHash
+    │
+    ▼ metadata.LocalChunkIndex.GetLocalLocation
+    LocalChunkLocation
+    │
+    ▼ logblob.Manager.ReadAt
+    chunk bytes
+```
+
+The `metadata.LocalChunkIndex` and `metadata.BlockRecordStore` contracts
+that feed this flow are described in
+[Block Record and Local Chunk Index](implementing-stores.md#block-record-and-local-chunk-index).
+
 ## Block Lifecycle (three-state)
 
 The block lifecycle has three persisted states held on `FileChunk.State`

--- a/docs/internals/implementing-stores.md
+++ b/docs/internals/implementing-stores.md
@@ -377,6 +377,149 @@ Cross-references:
 - [BLOCKSTORE_MIGRATION.md](../guide/block-store-migration.md)
   for the operator-facing migration story.
 
+### Block Record and Local Chunk Index
+
+Two additional metadata interfaces persist the bookkeeping needed by the
+blocks-only storage path. All four backends (memory, badger, sqlite, postgres)
+implement both and pass the corresponding conformance groups.
+
+#### BlockRecordStore
+
+Tracks each log-blob block object: its content hash, byte length, live chunk
+count, and sync state. The syncer uses this to decide which blocks are safe to
+upload; the GC uses it to decide which may be deleted.
+
+```go
+// pkg/block/block_record.go
+type BlockRecord struct {
+    BlockID        string
+    BlockHash      block.ContentHash
+    Length         int64
+    LiveChunkCount uint32
+    SyncState      block.BlockState // block.BlockStatePending = 0 while uploading
+}
+```
+
+```go
+// pkg/metadata/block_record_store.go
+type BlockRecordStore interface {
+    // PutBlockRecord writes or overwrites the record for rec.BlockID.
+    PutBlockRecord(ctx context.Context, rec block.BlockRecord) error
+
+    // GetBlockRecord retrieves the record for blockID.
+    // Returns (_, false, nil) when no record exists — absence is not an error.
+    GetBlockRecord(ctx context.Context, blockID string) (block.BlockRecord, bool, error)
+
+    // DeleteBlockRecord removes the record for blockID. Idempotent.
+    DeleteBlockRecord(ctx context.Context, blockID string) error
+
+    // WalkBlockRecords calls fn for every stored block record.
+    // Returns the first non-nil error from fn or from the store iterator.
+    WalkBlockRecords(ctx context.Context, fn func(block.BlockRecord) error) error
+
+    // DecrLiveChunkCount atomically decrements LiveChunkCount for blockID
+    // by delta, flooring at 0. Returns the remaining count.
+    // Returns an error if blockID does not exist.
+    DecrLiveChunkCount(ctx context.Context, blockID string, delta uint32) (remaining uint32, err error)
+}
+```
+
+Conformance: `storetest` group **BlockRecordOps** covers put/get round-trip,
+missing-key (returns `false`, not an error), delete idempotency, walk, and
+`DecrLiveChunkCount` with floor clamping.
+
+#### LocalChunkIndex
+
+Maps a chunk's content hash to its position in a local log-blob file. It is
+the local-tier analog of `SyncedHashStore`: both are keyed by `ContentHash`,
+both carry a physical locator, and both follow the same idempotent-put /
+safe-miss-on-get / idempotent-delete contract.
+
+| Interface         | Key           | Value                        | Tier   |
+|-------------------|---------------|------------------------------|--------|
+| `SyncedHashStore` | `ContentHash` | `block.ChunkLocator`         | Remote |
+| `LocalChunkIndex` | `ContentHash` | `block.LocalChunkLocation`   | Local  |
+
+```go
+// pkg/block/block_record.go
+type LocalChunkLocation struct {
+    LogBlobID string // blob filename stem, e.g. "0000000000000001"
+    RawOffset int64  // byte offset within that blob
+    RawLength int64  // byte length of the raw chunk
+}
+```
+
+```go
+// pkg/metadata/block_record_store.go
+type LocalChunkIndex interface {
+    // PutLocalLocation records or overwrites the local position for hash.
+    PutLocalLocation(ctx context.Context, hash block.ContentHash, loc block.LocalChunkLocation) error
+
+    // GetLocalLocation returns the local position for hash.
+    // Returns (_, false, nil) when no entry exists.
+    GetLocalLocation(ctx context.Context, hash block.ContentHash) (block.LocalChunkLocation, bool, error)
+
+    // DeleteLocalLocation removes the local position for hash. Idempotent.
+    DeleteLocalLocation(ctx context.Context, hash block.ContentHash) error
+}
+```
+
+Conformance: group **LocalIndexOps** covers put/get round-trip, upsert
+overwrites (second write wins), missing-key, and delete idempotency.
+
+#### DefaultCommitBlock — one fsync per block
+
+`metadata.DefaultCommitBlock` atomically commits an entire block's metadata
+in a single transaction — one fsync per block, not one per chunk:
+
+```go
+// pkg/metadata/block_record_store.go
+func DefaultCommitBlock(
+    ctx context.Context,
+    s interface {
+        Transactor
+        SyncedHashStore
+    },
+    rec block.BlockRecord,
+    chunks []block.BlockChunkCommit,
+) error
+```
+
+`BlockChunkCommit` bundles the per-chunk commit data:
+
+```go
+// pkg/block/block_record.go
+type BlockChunkCommit struct {
+    Hash   block.ContentHash
+    Remote block.ChunkLocator      // remote locator passed to MarkSynced
+    Local  block.LocalChunkLocation // local locator stored in LocalChunkIndex
+}
+```
+
+Inside `WithTransaction`, `DefaultCommitBlock`:
+
+1. Calls `GetBlockRecord` — if the block record already exists the whole
+   function is a no-op (idempotent restart path; no double-counting).
+2. Calls `PutBlockRecord` with `rec`.
+3. Calls `PutLocalLocation` for every chunk in `chunks`.
+
+After the transaction commits, it calls `MarkSynced` on `SyncedHashStore`
+for every chunk, recording the remote locator. `MarkSynced` runs outside
+the transaction and is itself idempotent, so a crash between the committed
+transaction and the last `MarkSynced` call is safe: the next retry skips the
+transaction (block record already exists) and re-runs only the `MarkSynced`
+loop.
+
+Backends expose `CommitBlock` on the `Store` interface and SHOULD delegate to
+`DefaultCommitBlock`:
+
+```go
+CommitBlock(ctx context.Context, rec block.BlockRecord, chunks []block.BlockChunkCommit) error
+```
+
+Conformance: group **CommitBlockOps** covers full commit with multiple chunks,
+idempotent re-commit, and `MarkSynced` retry after a simulated mid-commit crash.
+
 ### Engine API surface
 
 Custom block-store implementations that compose into `*engine.BlockStore`

--- a/pkg/block/block_record.go
+++ b/pkg/block/block_record.go
@@ -1,0 +1,25 @@
+package block
+
+// BlockRecord tracks the lifecycle and sync state of a single log-blob block.
+type BlockRecord struct {
+	BlockID        string
+	BlockHash      ContentHash
+	Length         int64
+	LiveChunkCount uint32
+	SyncState      BlockState
+}
+
+// LocalChunkLocation identifies the position of a chunk within a local log-blob.
+type LocalChunkLocation struct {
+	LogBlobID string
+	RawOffset int64
+	RawLength int64
+}
+
+// BlockChunkCommit bundles everything needed to persist one chunk's locations
+// when a block is committed.
+type BlockChunkCommit struct {
+	Hash   ContentHash
+	Remote ChunkLocator
+	Local  LocalChunkLocation
+}

--- a/pkg/block/blockstoretest/logblob_conformance.go
+++ b/pkg/block/blockstoretest/logblob_conformance.go
@@ -1,0 +1,421 @@
+package blockstoretest
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/local/logblob"
+)
+
+// LogBlobFactory creates a fresh *logblob.Manager for a single subtest along
+// with the directory it was opened on and a cleanup closure. The Manager MUST
+// be created with SizeCap ≤ 256 so that rotation can be triggered by small
+// test payloads.
+type LogBlobFactory func(t *testing.T) (mgr *logblob.Manager, dir string, cleanup func())
+
+// LogBlobConformance runs the logblob Manager conformance suite against any
+// *logblob.Manager returned by factory.
+//
+// Scenarios exercised:
+//   - AppendReadAtRoundTrip
+//   - Rotate
+//   - EvictSealed
+//   - EvictActive_Refused
+//   - EvictUnsynced_Refused
+//   - ReadAtEvicted
+//   - RecoverActiveTorn
+//   - RecoverSealedTorn
+//   - RecoverAckedBoundary
+func LogBlobConformance(t *testing.T, factory LogBlobFactory) {
+	t.Helper()
+	t.Run("AppendReadAtRoundTrip", func(t *testing.T) { lbcAppendReadAt(t, factory) })
+	t.Run("Rotate", func(t *testing.T) { lbcRotate(t, factory) })
+	t.Run("EvictSealed", func(t *testing.T) { lbcEvictSealed(t, factory) })
+	t.Run("EvictActive_Refused", func(t *testing.T) { lbcEvictActiveRefused(t, factory) })
+	t.Run("EvictUnsynced_Refused", func(t *testing.T) { lbcEvictUnsyncedRefused(t, factory) })
+	t.Run("ReadAtEvicted", func(t *testing.T) { lbcReadAtEvicted(t, factory) })
+	t.Run("RecoverActiveTorn", func(t *testing.T) { lbcRecoverActiveTorn(t, factory) })
+	t.Run("RecoverSealedTorn", func(t *testing.T) { lbcRecoverSealedTorn(t, factory) })
+	t.Run("RecoverAckedBoundary", func(t *testing.T) { lbcRecoverAckedBoundary(t, factory) })
+}
+
+// lbcAppendReadAt verifies that a single Append followed by ReadAt returns
+// the original bytes at the reported offset.
+func lbcAppendReadAt(t *testing.T, factory LogBlobFactory) {
+	t.Helper()
+	m, _, cleanup := factory(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	data := []byte("lbc-append-readat-roundtrip")
+	loc, err := m.Append(ctx, data)
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	dst := make([]byte, loc.RawLength)
+	n, err := m.ReadAt(ctx, loc, dst)
+	if err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if n != len(data) || !bytes.Equal(dst[:n], data) {
+		t.Errorf("ReadAt = %q (%d bytes), want %q", dst[:n], n, data)
+	}
+}
+
+// lbcRotate verifies that Rotate seals the active blob and the next Append
+// lands in a new blob with a higher ID.
+func lbcRotate(t *testing.T, factory LogBlobFactory) {
+	t.Helper()
+	m, _, cleanup := factory(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	loc1, err := m.Append(ctx, []byte("before-rotate"))
+	if err != nil {
+		t.Fatalf("Append(before): %v", err)
+	}
+	if err := m.Rotate(); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+	loc2, err := m.Append(ctx, []byte("after-rotate"))
+	if err != nil {
+		t.Fatalf("Append(after): %v", err)
+	}
+	if loc1.LogBlobID == loc2.LogBlobID {
+		t.Errorf("Rotate did not produce a new blob: both use %q", loc1.LogBlobID)
+	}
+	if loc2.LogBlobID <= loc1.LogBlobID {
+		t.Errorf("new blobID %q not > old %q", loc2.LogBlobID, loc1.LogBlobID)
+	}
+
+	// Both still readable.
+	for _, tc := range []struct {
+		loc  block.LocalChunkLocation
+		want []byte
+	}{
+		{loc1, []byte("before-rotate")},
+		{loc2, []byte("after-rotate")},
+	} {
+		dst := make([]byte, tc.loc.RawLength)
+		if _, err := m.ReadAt(ctx, tc.loc, dst); err != nil {
+			t.Errorf("ReadAt(%s): %v", tc.loc.LogBlobID, err)
+		} else if !bytes.Equal(dst, tc.want) {
+			t.Errorf("ReadAt(%s) = %q, want %q", tc.loc.LogBlobID, dst, tc.want)
+		}
+	}
+}
+
+// lbcEvictSealed verifies that a sealed blob can be evicted: the .blob file
+// is removed from disk and ReadAt returns ErrEvicted.
+//
+// With SizeCap=128, a 100-byte payload fills the active blob beyond the cap on
+// the second append, which triggers rotation before the second write.
+func lbcEvictSealed(t *testing.T, factory LogBlobFactory) {
+	t.Helper()
+	m, dir, cleanup := factory(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	// First append: goes into blob 0. Its 100 bytes exceed SizeCap=128 on the
+	// next call, so blob 0 gets sealed before the second append lands.
+	loc0, err := m.Append(ctx, bytes.Repeat([]byte("S"), 100))
+	if err != nil {
+		t.Fatalf("Append(0): %v", err)
+	}
+	blob0 := loc0.LogBlobID
+
+	// Second append triggers rotation; blob0 is now sealed.
+	if _, err := m.Append(ctx, bytes.Repeat([]byte("T"), 100)); err != nil {
+		t.Fatalf("Append(1): %v", err)
+	}
+
+	// Evict blob0.
+	if err := m.EvictBlob(ctx, blob0, func(string) bool { return true }); err != nil {
+		t.Fatalf("EvictBlob: %v", err)
+	}
+
+	// File must be gone.
+	blobPath := filepath.Join(dir, blob0+".blob")
+	if _, statErr := os.Stat(blobPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("evicted blob file still present at %s (stat err: %v)", blobPath, statErr)
+	}
+
+	// ReadAt on the evicted blob must return ErrEvicted.
+	dst := make([]byte, loc0.RawLength)
+	_, readErr := m.ReadAt(ctx, loc0, dst)
+	if !errors.Is(readErr, logblob.ErrEvicted) {
+		t.Errorf("ReadAt after eviction: got %v, want ErrEvicted", readErr)
+	}
+}
+
+// lbcEvictActiveRefused verifies that EvictBlob on the active blob returns
+// ErrActiveBlob.
+func lbcEvictActiveRefused(t *testing.T, factory LogBlobFactory) {
+	t.Helper()
+	m, _, cleanup := factory(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	loc, err := m.Append(ctx, []byte("active"))
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	evictErr := m.EvictBlob(ctx, loc.LogBlobID, func(string) bool { return true })
+	if !errors.Is(evictErr, logblob.ErrActiveBlob) {
+		t.Errorf("EvictBlob(active): got %v, want ErrActiveBlob", evictErr)
+	}
+}
+
+// lbcEvictUnsyncedRefused verifies that EvictBlob with a synced function that
+// returns false returns ErrUnsyncedBytes.
+func lbcEvictUnsyncedRefused(t *testing.T, factory LogBlobFactory) {
+	t.Helper()
+	m, _, cleanup := factory(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	loc0, err := m.Append(ctx, bytes.Repeat([]byte("U"), 100))
+	if err != nil {
+		t.Fatalf("Append(0): %v", err)
+	}
+	blob0 := loc0.LogBlobID
+	if _, err := m.Append(ctx, bytes.Repeat([]byte("V"), 100)); err != nil {
+		t.Fatalf("Append(1): %v", err)
+	}
+
+	evictErr := m.EvictBlob(ctx, blob0, func(string) bool { return false })
+	if !errors.Is(evictErr, logblob.ErrUnsyncedBytes) {
+		t.Errorf("EvictBlob(unsynced): got %v, want ErrUnsyncedBytes", evictErr)
+	}
+}
+
+// lbcReadAtEvicted verifies that ReadAt after EvictBlob returns ErrEvicted.
+func lbcReadAtEvicted(t *testing.T, factory LogBlobFactory) {
+	t.Helper()
+	m, _, cleanup := factory(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	loc0, err := m.Append(ctx, bytes.Repeat([]byte("R"), 100))
+	if err != nil {
+		t.Fatalf("Append(0): %v", err)
+	}
+	blob0 := loc0.LogBlobID
+	if _, err := m.Append(ctx, bytes.Repeat([]byte("Q"), 100)); err != nil {
+		t.Fatalf("Append(1): %v", err)
+	}
+	if err := m.EvictBlob(ctx, blob0, func(string) bool { return true }); err != nil {
+		t.Fatalf("EvictBlob: %v", err)
+	}
+
+	dst := make([]byte, loc0.RawLength)
+	_, readErr := m.ReadAt(ctx, loc0, dst)
+	if !errors.Is(readErr, logblob.ErrEvicted) {
+		t.Errorf("ReadAt after eviction: got %v, want ErrEvicted", readErr)
+	}
+}
+
+// lbcRecoverActiveTorn injects garbage past the valid tail of the active blob,
+// calls Recover to the valid offset, then verifies that Append resumes at that
+// offset and prior reads succeed.
+func lbcRecoverActiveTorn(t *testing.T, factory LogBlobFactory) {
+	t.Helper()
+	m, dir, cleanup := factory(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	p1 := bytes.Repeat([]byte("A"), 50)
+	p2 := bytes.Repeat([]byte("B"), 50)
+
+	loc1, err := m.Append(ctx, p1)
+	if err != nil {
+		t.Fatalf("Append(1): %v", err)
+	}
+	loc2, err := m.Append(ctx, p2)
+	if err != nil {
+		t.Fatalf("Append(2): %v", err)
+	}
+	mark := loc2.RawOffset + loc2.RawLength // = 100
+
+	blobPath := filepath.Join(dir, loc1.LogBlobID+".blob")
+	f, openErr := os.OpenFile(blobPath, os.O_WRONLY, 0)
+	if openErr != nil {
+		t.Fatalf("OpenFile: %v", openErr)
+	}
+	if _, werr := f.WriteAt(bytes.Repeat([]byte("Z"), 20), mark); werr != nil {
+		_ = f.Close()
+		t.Fatalf("WriteAt garbage: %v", werr)
+	}
+	_ = f.Close()
+
+	if err := m.Recover(ctx, loc1.LogBlobID, mark); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+
+	// Append must resume at mark.
+	afterLoc, err := m.Append(ctx, []byte("after"))
+	if err != nil {
+		t.Fatalf("Append(after): %v", err)
+	}
+	if afterLoc.RawOffset != mark {
+		t.Errorf("RawOffset after Recover = %d, want %d", afterLoc.RawOffset, mark)
+	}
+
+	// Prior reads must succeed.
+	for _, tc := range []struct {
+		loc  block.LocalChunkLocation
+		want []byte
+	}{
+		{loc1, p1},
+		{loc2, p2},
+	} {
+		dst := make([]byte, tc.loc.RawLength)
+		if _, err := m.ReadAt(ctx, tc.loc, dst); err != nil {
+			t.Errorf("ReadAt(%s): %v", tc.loc.LogBlobID, err)
+		} else if !bytes.Equal(dst, tc.want) {
+			t.Errorf("ReadAt(%s) = %q, want %q", tc.loc.LogBlobID, dst, tc.want)
+		}
+	}
+
+	// Reading in the former garbage zone must fail.
+	garbageLoc := block.LocalChunkLocation{
+		LogBlobID: loc1.LogBlobID,
+		RawOffset: mark + 5,
+		RawLength: 5,
+	}
+	dst := make([]byte, 5)
+	_, readErr := m.ReadAt(ctx, garbageLoc, dst)
+	if readErr == nil {
+		t.Error("ReadAt beyond Recover boundary: expected error, got nil")
+	}
+}
+
+// lbcRecoverSealedTorn injects garbage past the valid tail of a sealed blob,
+// calls Recover to the valid offset, then verifies that prior reads succeed
+// and the file size matches the recovery offset.
+func lbcRecoverSealedTorn(t *testing.T, factory LogBlobFactory) {
+	t.Helper()
+	m, dir, cleanup := factory(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	p1 := bytes.Repeat([]byte("C"), 50)
+	p2 := bytes.Repeat([]byte("D"), 50)
+
+	loc1, err := m.Append(ctx, p1)
+	if err != nil {
+		t.Fatalf("Append(1): %v", err)
+	}
+	loc2, err := m.Append(ctx, p2)
+	if err != nil {
+		t.Fatalf("Append(2): %v", err)
+	}
+	blob0 := loc1.LogBlobID
+	validOffset := loc2.RawOffset + loc2.RawLength // = 100
+
+	// Seal blob0 by rotating.
+	if err := m.Rotate(); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+
+	// Inject garbage past validOffset.
+	blobPath := filepath.Join(dir, blob0+".blob")
+	f, openErr := os.OpenFile(blobPath, os.O_WRONLY, 0)
+	if openErr != nil {
+		t.Fatalf("OpenFile: %v", openErr)
+	}
+	if _, werr := f.WriteAt(bytes.Repeat([]byte("X"), 30), validOffset); werr != nil {
+		_ = f.Close()
+		t.Fatalf("WriteAt garbage: %v", werr)
+	}
+	_ = f.Close()
+
+	// Recover sealed blob.
+	if err := m.Recover(ctx, blob0, validOffset); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+
+	// Reads before offset must succeed.
+	for _, tc := range []struct {
+		loc  block.LocalChunkLocation
+		want []byte
+	}{
+		{loc1, p1},
+		{loc2, p2},
+	} {
+		dst := make([]byte, tc.loc.RawLength)
+		if _, err := m.ReadAt(ctx, tc.loc, dst); err != nil {
+			t.Errorf("ReadAt(%s): %v", tc.loc.LogBlobID, err)
+		} else if !bytes.Equal(dst, tc.want) {
+			t.Errorf("ReadAt(%s) = %q, want %q", tc.loc.LogBlobID, dst, tc.want)
+		}
+	}
+
+	// File size must equal validOffset.
+	fi, statErr := os.Stat(blobPath)
+	if statErr != nil {
+		t.Fatalf("Stat: %v", statErr)
+	}
+	if fi.Size() != validOffset {
+		t.Errorf("file size = %d, want %d", fi.Size(), validOffset)
+	}
+}
+
+// lbcRecoverAckedBoundary verifies the acked/unacked boundary: data at or
+// before the mark survives, data after is discarded.
+func lbcRecoverAckedBoundary(t *testing.T, factory LogBlobFactory) {
+	t.Helper()
+	m, _, cleanup := factory(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	acked := bytes.Repeat([]byte("E"), 50)
+	unacked := bytes.Repeat([]byte("F"), 50)
+
+	locAcked, err := m.Append(ctx, acked)
+	if err != nil {
+		t.Fatalf("Append(acked): %v", err)
+	}
+	mark := locAcked.RawOffset + locAcked.RawLength // = 50
+
+	locUnacked, err := m.Append(ctx, unacked)
+	if err != nil {
+		t.Fatalf("Append(unacked): %v", err)
+	}
+
+	blobID := locAcked.LogBlobID
+	if err := m.Recover(ctx, blobID, mark); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+
+	// Acked data must still be readable.
+	dst := make([]byte, locAcked.RawLength)
+	if _, err := m.ReadAt(ctx, locAcked, dst); err != nil {
+		t.Fatalf("ReadAt(acked): %v", err)
+	}
+	if !bytes.Equal(dst, acked) {
+		t.Errorf("ReadAt(acked) = %q, want %q", dst, acked)
+	}
+
+	// Unacked data is now beyond truncation: reading must fail or return a
+	// short read (file ends at mark).
+	dstU := make([]byte, locUnacked.RawLength)
+	n, readErr := m.ReadAt(ctx, locUnacked, dstU)
+	if readErr == nil && n == len(unacked) {
+		t.Error("ReadAt(unacked) after Recover: expected error or short read, got full success")
+	}
+
+	// Next Append must resume at mark.
+	postLoc, err := m.Append(ctx, []byte("post-recover"))
+	if err != nil {
+		t.Fatalf("Append(post): %v", err)
+	}
+	if postLoc.RawOffset != mark {
+		t.Errorf("Append after Recover: RawOffset = %d, want %d", postLoc.RawOffset, mark)
+	}
+}

--- a/pkg/block/local/logblob/doc.go
+++ b/pkg/block/local/logblob/doc.go
@@ -1,0 +1,20 @@
+// Package logblob implements a directory-backed sequence of raw log blobs.
+//
+// A [Manager] owns a directory and provides [Manager.Append] / [Manager.ReadAt]
+// primitives over a sequence of bounded raw files ("blobs"). One blob is active
+// (writable at its tail); older blobs are sealed and read-only. Blob IDs are
+// monotonically increasing, zero-padded decimal strings that sort
+// lexicographically in creation order and remain stable across [Manager]
+// close/reopen.
+//
+// Append is mutex-serialized; ReadAt uses pread(2) (via [os.File.ReadAt]) and
+// is safe to call concurrently with active Appends — reads and writes operate
+// at explicit byte offsets and never share a file cursor.
+//
+// Bytes are stored raw: no framing, no checksum, no compression. The caller
+// controls fsync cadence via the explicit [Manager.Sync] method.
+//
+// This package is an internal primitive for #1493 PR2 Task 5. It is wired into
+// higher-level stores (FSStore, engine) in PR3 — do NOT import it from FSStore
+// in this iteration.
+package logblob

--- a/pkg/block/local/logblob/manager.go
+++ b/pkg/block/local/logblob/manager.go
@@ -1,0 +1,458 @@
+package logblob
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	iofs "io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+const (
+	// defaultSizeCap is the default active-blob size limit (1 GiB).
+	defaultSizeCap int64 = 1 << 30
+
+	// blobSuffix is the file extension for every log-blob file.
+	blobSuffix = ".blob"
+
+	// blobIDFmt is the zero-padded decimal format for blob IDs.
+	// 16 digits gives a lexicographic order that matches numeric order up to
+	// 10^16 − 1 blobs — far more than any real deployment will ever create.
+	blobIDFmt = "%016d"
+)
+
+// Errors returned by Manager operations.
+var (
+	// ErrClosed is returned when an operation is attempted on a closed Manager.
+	ErrClosed = errors.New("logblob: manager closed")
+
+	// ErrBlobNotFound is returned when ReadAt references a blob ID that does
+	// not exist in the Manager's directory.
+	ErrBlobNotFound = errors.New("logblob: blob not found")
+)
+
+// Options configures a Manager.
+type Options struct {
+	// SizeCap is the maximum number of bytes the active blob may hold
+	// before the Manager rotates to a new blob. Zero or negative defaults
+	// to 1 GiB.
+	SizeCap int64
+}
+
+// BlobInfo describes a single log blob in the Manager's directory.
+type BlobInfo struct {
+	// LogBlobID is the blob's stable identifier, matching the filename stem
+	// (e.g. "0000000000000003" for "0000000000000003.blob").
+	LogBlobID string
+	// Size is the number of bytes currently stored in the blob.
+	Size int64
+	// Active is true for the one blob that currently accepts appends.
+	Active bool
+}
+
+// Manager owns a directory of raw log blobs.
+//
+// Concurrency contract:
+//   - [Append] and [Rotate] are mutex-serialized (one at a time).
+//   - [ReadAt] takes the mutex briefly to snapshot the active blob's identity
+//     and file descriptor, then releases it before the actual pread(2). This
+//     allows concurrent reads and appends on non-overlapping byte ranges.
+//   - The race detector is clean: all shared state is accessed under mu, and
+//     positioned file I/O (pread/pwrite via [os.File.ReadAt]/[os.File.WriteAt])
+//     does not share a file cursor.
+type Manager struct {
+	dir     string
+	sizeCap int64
+
+	// mu serializes Append, Rotate, Close, and the brief state snapshots in
+	// ReadAt/fdForBlob. It is never held across blocking I/O.
+	mu sync.Mutex
+
+	// nextID is the uint64 counter for the next blob to be created.
+	nextID uint64
+	// activeID is the blobID string (e.g. "0000000000000002") of the current
+	// active blob.
+	activeID string
+	// activeFD is the open O_RDWR file for the active blob.
+	activeFD *os.File
+	// activeTail is the number of bytes already written to the active blob.
+	// New Appends write at this offset and increment it.
+	activeTail int64
+
+	closed bool
+
+	// sealedMu guards sealedFDs. It is acquired ONLY after mu is released,
+	// preserving the lock-order invariant (mu before sealedMu where both are
+	// needed — and in practice they are never held simultaneously).
+	sealedMu  sync.Mutex
+	sealedFDs map[string]*os.File // blobID → open O_RDONLY fd (lazy)
+}
+
+// Open opens (or creates) a Manager rooted at dir with the given options.
+//
+// On a fresh directory an initial blob ("0000000000000000.blob") is created.
+// On reopen of an existing directory the highest-numbered blob is treated as
+// the active blob and subsequent Appends resume at its current tail.
+func Open(dir string, opts Options) (*Manager, error) {
+	sizeCap := opts.SizeCap
+	if sizeCap <= 0 {
+		sizeCap = defaultSizeCap
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("logblob: mkdir %q: %w", dir, err)
+	}
+
+	ids, err := scanBlobIDs(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	m := &Manager{
+		dir:       dir,
+		sizeCap:   sizeCap,
+		sealedFDs: make(map[string]*os.File),
+	}
+
+	if len(ids) == 0 {
+		// Fresh directory: create the first blob.
+		if err := m.createNewActive(); err != nil {
+			return nil, err
+		}
+	} else {
+		// Reopen: the highest ID is the active blob.
+		activeIDUint := ids[len(ids)-1]
+		m.nextID = activeIDUint + 1
+		m.activeID = fmt.Sprintf(blobIDFmt, activeIDUint)
+
+		path := filepath.Join(dir, m.activeID+blobSuffix)
+		fd, err := os.OpenFile(path, os.O_RDWR, 0o644)
+		if err != nil {
+			return nil, fmt.Errorf("logblob: open active blob %q: %w", path, err)
+		}
+		fi, err := fd.Stat()
+		if err != nil {
+			_ = fd.Close()
+			return nil, fmt.Errorf("logblob: stat active blob %q: %w", path, err)
+		}
+		m.activeFD = fd
+		m.activeTail = fi.Size()
+	}
+
+	return m, nil
+}
+
+// Append writes the raw bytes p to the tail of the active blob and returns
+// the LocalChunkLocation that identifies where those bytes were stored.
+//
+// The operation is mutex-serialized. Bytes are stored raw — no framing, no
+// checksum. If the write would cause the active blob to exceed SizeCap, the
+// blob is rotated first (a new active blob is created and p is written there).
+//
+// An empty payload is rejected (callers must not append zero bytes).
+func (m *Manager) Append(ctx context.Context, p []byte) (block.LocalChunkLocation, error) {
+	if ctx.Err() != nil {
+		return block.LocalChunkLocation{}, ctx.Err()
+	}
+	if len(p) == 0 {
+		return block.LocalChunkLocation{}, errors.New("logblob: Append: empty payload")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.closed {
+		return block.LocalChunkLocation{}, ErrClosed
+	}
+
+	// Rotate if this write would push the active blob past SizeCap.
+	if m.activeTail+int64(len(p)) > m.sizeCap {
+		if err := m.rotateLocked(); err != nil {
+			return block.LocalChunkLocation{}, fmt.Errorf("logblob: rotate before append: %w", err)
+		}
+	}
+
+	offset := m.activeTail
+	blobID := m.activeID
+
+	n, err := m.activeFD.WriteAt(p, offset)
+	if err != nil {
+		return block.LocalChunkLocation{}, fmt.Errorf("logblob: WriteAt %s@%d: %w", blobID, offset, err)
+	}
+	if n != len(p) {
+		return block.LocalChunkLocation{}, fmt.Errorf("logblob: short write: %d of %d bytes", n, len(p))
+	}
+	m.activeTail += int64(n)
+
+	return block.LocalChunkLocation{
+		LogBlobID: blobID,
+		RawOffset: offset,
+		RawLength: int64(n),
+	}, nil
+}
+
+// ReadAt reads exactly loc.RawLength bytes from blob loc.LogBlobID starting at
+// byte offset loc.RawOffset into dst (which must have len ≥ loc.RawLength).
+//
+// ReadAt is safe to call concurrently with Append. It acquires the mutex
+// briefly to snapshot the active blob's identity and file descriptor, then
+// releases it before calling pread(2) — so Append is never blocked by reads.
+func (m *Manager) ReadAt(ctx context.Context, loc block.LocalChunkLocation, dst []byte) (int, error) {
+	if ctx.Err() != nil {
+		return 0, ctx.Err()
+	}
+	if loc.RawLength == 0 {
+		return 0, nil
+	}
+	if int64(len(dst)) < loc.RawLength {
+		return 0, fmt.Errorf("logblob: ReadAt: dst too small: have %d bytes, need %d", len(dst), loc.RawLength)
+	}
+
+	fd, err := m.fdForBlob(loc.LogBlobID)
+	if err != nil {
+		return 0, err
+	}
+
+	n, err := fd.ReadAt(dst[:loc.RawLength], loc.RawOffset)
+	if err != nil {
+		return n, fmt.Errorf("logblob: ReadAt %s@%d: %w", loc.LogBlobID, loc.RawOffset, err)
+	}
+	return n, nil
+}
+
+// Rotate seals the current active blob and creates a fresh one. Subsequent
+// Appends will target the new blob starting at offset 0.
+//
+// Callers may use Rotate to segment the log at application-defined boundaries
+// (e.g. before a snapshot) without waiting for SizeCap to be reached.
+func (m *Manager) Rotate() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return ErrClosed
+	}
+	return m.rotateLocked()
+}
+
+// Sync fsyncs the active blob to durable storage. Durability cadence is
+// caller-controlled; call Sync at commit boundaries.
+func (m *Manager) Sync() error {
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return ErrClosed
+	}
+	fd := m.activeFD
+	m.mu.Unlock()
+
+	if err := fd.Sync(); err != nil {
+		return fmt.Errorf("logblob: fsync: %w", err)
+	}
+	return nil
+}
+
+// ListBlobs returns a BlobInfo for every blob in the Manager's directory,
+// including the currently active blob, sorted by blob ID (creation order).
+func (m *Manager) ListBlobs() ([]BlobInfo, error) {
+	// Snapshot active state under mu.
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return nil, ErrClosed
+	}
+	activeID := m.activeID
+	activeTail := m.activeTail
+	m.mu.Unlock()
+
+	entries, err := os.ReadDir(m.dir)
+	if err != nil {
+		return nil, fmt.Errorf("logblob: readdir: %w", err)
+	}
+
+	var infos []BlobInfo
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, blobSuffix) {
+			continue
+		}
+		stem := strings.TrimSuffix(name, blobSuffix)
+		if _, err := strconv.ParseUint(stem, 10, 64); err != nil {
+			continue // skip unrecognized files
+		}
+		blobID := stem
+
+		var size int64
+		if blobID == activeID {
+			size = activeTail
+		} else {
+			fi, err := e.Info()
+			if err != nil {
+				return nil, fmt.Errorf("logblob: info %s: %w", name, err)
+			}
+			size = fi.Size()
+		}
+
+		infos = append(infos, BlobInfo{
+			LogBlobID: blobID,
+			Size:      size,
+			Active:    blobID == activeID,
+		})
+	}
+
+	return infos, nil
+}
+
+// Close closes the Manager and all open file descriptors.
+//
+// Close is idempotent. After Close, all operations return ErrClosed.
+// Close does not guarantee that in-progress ReadAt calls finish before file
+// descriptors are closed — callers must quiesce concurrent I/O before calling
+// Close (the same contract as [os.File.Close]).
+func (m *Manager) Close() error {
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return nil
+	}
+	m.closed = true
+	activeFD := m.activeFD
+	m.activeFD = nil
+	m.mu.Unlock()
+
+	var firstErr error
+	if activeFD != nil {
+		if err := activeFD.Close(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("logblob: close active fd: %w", err)
+		}
+	}
+
+	m.sealedMu.Lock()
+	for id, fd := range m.sealedFDs {
+		if err := fd.Close(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("logblob: close sealed fd %s: %w", id, err)
+		}
+	}
+	m.sealedFDs = nil
+	m.sealedMu.Unlock()
+
+	return firstErr
+}
+
+// ---- internal helpers ----
+
+// rotateLocked seals the current active blob (adds its fd to the sealedFDs
+// cache without closing it, so in-flight ReadAt calls remain valid) and
+// creates a new active blob.
+//
+// Caller MUST hold m.mu.
+func (m *Manager) rotateLocked() error {
+	// Hand the old active fd to the sealed cache so it stays readable.
+	oldID := m.activeID
+	oldFD := m.activeFD
+
+	m.sealedMu.Lock()
+	m.sealedFDs[oldID] = oldFD
+	m.sealedMu.Unlock()
+
+	return m.createNewActive()
+}
+
+// createNewActive allocates the next blob ID, creates the file, and wires up
+// activeFD / activeID / activeTail / nextID.
+//
+// Caller MUST hold m.mu.
+func (m *Manager) createNewActive() error {
+	id := m.nextID
+	m.nextID++
+	newID := fmt.Sprintf(blobIDFmt, id)
+	path := filepath.Join(m.dir, newID+blobSuffix)
+
+	fd, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return fmt.Errorf("create blob %q: %w", path, err)
+	}
+	m.activeID = newID
+	m.activeFD = fd
+	m.activeTail = 0
+	return nil
+}
+
+// fdForBlob returns an open file descriptor for the blob identified by blobID.
+//
+// If blobID is the current active blob the active fd is returned (no sealedMu
+// contention on the happy path). For sealed blobs a read-only fd is opened
+// lazily and cached in sealedFDs.
+//
+// The mutex is held only briefly (to snapshot activeID/activeFD), then
+// released before any blocking I/O — so Append is never blocked by reads.
+func (m *Manager) fdForBlob(blobID string) (*os.File, error) {
+	// Fast path: snapshot active state under mu.
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return nil, ErrClosed
+	}
+	if blobID == m.activeID {
+		fd := m.activeFD
+		m.mu.Unlock()
+		return fd, nil
+	}
+	m.mu.Unlock()
+
+	// Sealed blob: check / populate the read-only fd cache.
+	m.sealedMu.Lock()
+	defer m.sealedMu.Unlock()
+
+	if fd, ok := m.sealedFDs[blobID]; ok {
+		return fd, nil
+	}
+
+	path := filepath.Join(m.dir, blobID+blobSuffix)
+	fd, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, iofs.ErrNotExist) {
+			return nil, fmt.Errorf("logblob: %w: %s", ErrBlobNotFound, blobID)
+		}
+		return nil, fmt.Errorf("logblob: open blob %q: %w", path, err)
+	}
+	m.sealedFDs[blobID] = fd
+	return fd, nil
+}
+
+// scanBlobIDs reads dir and returns the uint64 IDs of every *.blob file whose
+// stem is a valid zero-padded decimal, sorted ascending.
+func scanBlobIDs(dir string) ([]uint64, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("logblob: readdir %q: %w", dir, err)
+	}
+
+	var ids []uint64
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, blobSuffix) {
+			continue
+		}
+		stem := strings.TrimSuffix(name, blobSuffix)
+		id, err := strconv.ParseUint(stem, 10, 64)
+		if err != nil {
+			continue // skip unrecognized files
+		}
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids, nil
+}

--- a/pkg/block/local/logblob/manager.go
+++ b/pkg/block/local/logblob/manager.go
@@ -88,9 +88,9 @@ type Manager struct {
 
 	closed bool
 
-	// sealedMu guards sealedFDs. It is acquired ONLY after mu is released,
-	// preserving the lock-order invariant (mu before sealedMu where both are
-	// needed — and in practice they are never held simultaneously).
+	// sealedMu guards sealedFDs. Lock order: mu must always be acquired before
+	// sealedMu when both are needed (rotateLocked holds mu and acquires sealedMu).
+	// Never acquire mu while holding sealedMu.
 	sealedMu  sync.Mutex
 	sealedFDs map[string]*os.File // blobID → open O_RDONLY fd (lazy)
 }

--- a/pkg/block/local/logblob/manager.go
+++ b/pkg/block/local/logblob/manager.go
@@ -36,6 +36,16 @@ var (
 	// ErrBlobNotFound is returned when ReadAt references a blob ID that does
 	// not exist in the Manager's directory.
 	ErrBlobNotFound = errors.New("logblob: blob not found")
+
+	// ErrEvicted is returned when an operation targets a blob that has been evicted.
+	ErrEvicted = errors.New("logblob: blob evicted")
+
+	// ErrActiveBlob is returned when EvictBlob is called on the active (unsealed) blob.
+	ErrActiveBlob = errors.New("logblob: cannot evict the active blob")
+
+	// ErrUnsyncedBytes is returned when EvictBlob is called on a blob that has
+	// not been fully synced to durable storage according to the caller's synced function.
+	ErrUnsyncedBytes = errors.New("logblob: blob has unsynced bytes")
 )
 
 // Options configures a Manager.
@@ -93,6 +103,10 @@ type Manager struct {
 	// Never acquire mu while holding sealedMu.
 	sealedMu  sync.Mutex
 	sealedFDs map[string]*os.File // blobID → open O_RDONLY fd (lazy)
+
+	// evictedBlobs records the IDs of blobs that have been evicted.
+	// Protected by sealedMu (same mutex that guards sealedFDs).
+	evictedBlobs map[string]struct{}
 }
 
 // Open opens (or creates) a Manager rooted at dir with the given options.
@@ -116,9 +130,10 @@ func Open(dir string, opts Options) (*Manager, error) {
 	}
 
 	m := &Manager{
-		dir:       dir,
-		sizeCap:   sizeCap,
-		sealedFDs: make(map[string]*os.File),
+		dir:          dir,
+		sizeCap:      sizeCap,
+		sealedFDs:    make(map[string]*os.File),
+		evictedBlobs: make(map[string]struct{}),
 	}
 
 	if len(ids) == 0 {
@@ -312,6 +327,115 @@ func (m *Manager) ListBlobs() ([]BlobInfo, error) {
 	return infos, nil
 }
 
+// EvictBlob removes a sealed blob from disk and the in-memory fd cache.
+// The caller provides a synced function that reports whether logBlobID's
+// bytes have been durably stored elsewhere; if it returns false the eviction
+// is refused with ErrUnsyncedBytes.
+//
+// EvictBlob is idempotent: if the blob has already been evicted the call
+// returns nil.
+//
+// ErrActiveBlob is returned if logBlobID is the current active blob.
+func (m *Manager) EvictBlob(ctx context.Context, logBlobID string, synced func(string) bool) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return ErrClosed
+	}
+	if logBlobID == m.activeID {
+		m.mu.Unlock()
+		return ErrActiveBlob
+	}
+	m.mu.Unlock()
+
+	if !synced(logBlobID) {
+		return ErrUnsyncedBytes
+	}
+
+	// Mark evicted (idempotent) and grab the cached fd if any.
+	m.sealedMu.Lock()
+	if _, already := m.evictedBlobs[logBlobID]; already {
+		m.sealedMu.Unlock()
+		return nil
+	}
+	m.evictedBlobs[logBlobID] = struct{}{}
+	fd := m.sealedFDs[logBlobID]
+	delete(m.sealedFDs, logBlobID)
+	m.sealedMu.Unlock()
+
+	// Close the cached fd if one was open.
+	if fd != nil {
+		_ = fd.Close()
+	}
+
+	// Remove the file; ignore ErrNotExist so repeated calls are safe.
+	path := filepath.Join(m.dir, logBlobID+blobSuffix)
+	if err := os.Remove(path); err != nil && !errors.Is(err, iofs.ErrNotExist) {
+		return fmt.Errorf("logblob: remove blob %q: %w", path, err)
+	}
+	return nil
+}
+
+// Recover truncates a blob to validUpToOffset, discarding any bytes beyond
+// that offset. It is intended for crash-recovery scenarios where a torn
+// write left the tail of a blob in an indeterminate state.
+//
+// For the active blob the in-memory activeTail is also updated.
+// For sealed blobs the cached fd (if any) is closed and removed from the
+// cache before truncation so the next read re-opens the file at the new size.
+//
+// validUpToOffset must be ≥ 0.
+func (m *Manager) Recover(ctx context.Context, logBlobID string, validUpToOffset int64) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if validUpToOffset < 0 {
+		return fmt.Errorf("logblob: Recover: negative offset %d", validUpToOffset)
+	}
+
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return ErrClosed
+	}
+
+	if logBlobID == m.activeID {
+		// Truncate active blob while holding mu (acceptable for a startup op).
+		if err := m.activeFD.Truncate(validUpToOffset); err != nil {
+			m.mu.Unlock()
+			return fmt.Errorf("logblob: truncate active blob %q: %w", logBlobID, err)
+		}
+		m.activeTail = validUpToOffset
+		m.mu.Unlock()
+		return nil
+	}
+	m.mu.Unlock()
+
+	// Sealed blob: evict from fd cache before truncating.
+	m.sealedMu.Lock()
+	if _, evicted := m.evictedBlobs[logBlobID]; evicted {
+		m.sealedMu.Unlock()
+		return fmt.Errorf("logblob: Recover: %w: %s", ErrEvicted, logBlobID)
+	}
+	fd := m.sealedFDs[logBlobID]
+	delete(m.sealedFDs, logBlobID)
+	m.sealedMu.Unlock()
+
+	if fd != nil {
+		_ = fd.Close()
+	}
+
+	path := filepath.Join(m.dir, logBlobID+blobSuffix)
+	if err := os.Truncate(path, validUpToOffset); err != nil {
+		return fmt.Errorf("logblob: truncate sealed blob %q: %w", logBlobID, err)
+	}
+	return nil
+}
+
 // Close closes the Manager and all open file descriptors.
 //
 // Close is idempotent. After Close, all operations return ErrClosed.
@@ -412,6 +536,10 @@ func (m *Manager) fdForBlob(blobID string) (*os.File, error) {
 	// Sealed blob: check / populate the read-only fd cache.
 	m.sealedMu.Lock()
 	defer m.sealedMu.Unlock()
+
+	if _, evicted := m.evictedBlobs[blobID]; evicted {
+		return nil, ErrEvicted
+	}
 
 	if fd, ok := m.sealedFDs[blobID]; ok {
 		return fd, nil

--- a/pkg/block/local/logblob/manager.go
+++ b/pkg/block/local/logblob/manager.go
@@ -352,11 +352,23 @@ func (m *Manager) EvictBlob(ctx context.Context, logBlobID string, synced func(s
 	}
 	m.mu.Unlock()
 
+	// Idempotency check: if already evicted, return nil without invoking synced.
+	// This must come before synced() so a second call with synced=false still
+	// returns nil, matching the documented idempotency contract.
+	m.sealedMu.Lock()
+	if _, already := m.evictedBlobs[logBlobID]; already {
+		m.sealedMu.Unlock()
+		return nil
+	}
+	m.sealedMu.Unlock()
+
 	if !synced(logBlobID) {
 		return ErrUnsyncedBytes
 	}
 
-	// Mark evicted (idempotent) and grab the cached fd if any.
+	// Mark evicted and grab the cached fd if any.
+	// Double-check under sealedMu in case a concurrent EvictBlob won the race
+	// between our early check above and now.
 	m.sealedMu.Lock()
 	if _, already := m.evictedBlobs[logBlobID]; already {
 		m.sealedMu.Unlock()
@@ -388,7 +400,14 @@ func (m *Manager) EvictBlob(ctx context.Context, logBlobID string, synced func(s
 // For sealed blobs the cached fd (if any) is closed and removed from the
 // cache before truncation so the next read re-opens the file at the new size.
 //
-// validUpToOffset must be ≥ 0.
+// validUpToOffset must be ≥ 0 and ≤ the blob's current size. Passing an
+// offset beyond the current size is rejected with an error to prevent POSIX
+// ftruncate from zero-filling the file.
+//
+// Concurrency precondition: callers must quiesce concurrent [ReadAt] and
+// [Append] calls that target logBlobID before calling Recover — the same
+// contract as [Close]. Recover is designed for startup-time recovery where no
+// concurrent I/O is in flight on the target blob.
 func (m *Manager) Recover(ctx context.Context, logBlobID string, validUpToOffset int64) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -404,6 +423,13 @@ func (m *Manager) Recover(ctx context.Context, logBlobID string, validUpToOffset
 	}
 
 	if logBlobID == m.activeID {
+		// Guard against extending the file: POSIX ftruncate zero-fills when the
+		// target length exceeds the current file size, which would silently corrupt
+		// a crash-recovery operation.
+		if validUpToOffset > m.activeTail {
+			m.mu.Unlock()
+			return fmt.Errorf("logblob: Recover: offset %d exceeds active blob size %d", validUpToOffset, m.activeTail)
+		}
 		// Truncate active blob while holding mu (acceptable for a startup op).
 		if err := m.activeFD.Truncate(validUpToOffset); err != nil {
 			m.mu.Unlock()
@@ -430,6 +456,17 @@ func (m *Manager) Recover(ctx context.Context, logBlobID string, validUpToOffset
 	}
 
 	path := filepath.Join(m.dir, logBlobID+blobSuffix)
+
+	// Guard against extending the file: POSIX truncate zero-fills when the
+	// target length exceeds the current file size.
+	fi, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("logblob: stat sealed blob %q: %w", logBlobID, err)
+	}
+	if validUpToOffset > fi.Size() {
+		return fmt.Errorf("logblob: Recover: offset %d exceeds sealed blob size %d", validUpToOffset, fi.Size())
+	}
+
 	if err := os.Truncate(path, validUpToOffset); err != nil {
 		return fmt.Errorf("logblob: truncate sealed blob %q: %w", logBlobID, err)
 	}

--- a/pkg/block/local/logblob/manager.go
+++ b/pkg/block/local/logblob/manager.go
@@ -521,6 +521,15 @@ func (m *Manager) rotateLocked() error {
 	oldID := m.activeID
 	oldFD := m.activeFD
 
+	// Fsync the blob before sealing it: once rotated it is immutable and never
+	// becomes the active blob again, while Sync only fsyncs the active blob. A
+	// caller that flushes at commit boundaries must not silently lose bytes that
+	// a size-cap rotation sealed between commits, so make rotation a durability
+	// boundary here.
+	if err := oldFD.Sync(); err != nil {
+		return fmt.Errorf("fsync blob %q before seal: %w", oldID, err)
+	}
+
 	m.sealedMu.Lock()
 	m.sealedFDs[oldID] = oldFD
 	m.sealedMu.Unlock()

--- a/pkg/block/local/logblob/manager.go
+++ b/pkg/block/local/logblob/manager.go
@@ -224,6 +224,14 @@ func (m *Manager) ReadAt(ctx context.Context, loc block.LocalChunkLocation, dst 
 		return 0, ctx.Err()
 	}
 	if loc.RawLength == 0 {
+		// Check closed even for zero-length reads: after Close all operations
+		// must return ErrClosed, not silently succeed.
+		m.mu.Lock()
+		closed := m.closed
+		m.mu.Unlock()
+		if closed {
+			return 0, ErrClosed
+		}
 		return 0, nil
 	}
 	if int64(len(dst)) < loc.RawLength {
@@ -384,7 +392,14 @@ func (m *Manager) EvictBlob(ctx context.Context, logBlobID string, synced func(s
 		_ = fd.Close()
 	}
 
-	// Remove the file; ignore ErrNotExist so repeated calls are safe.
+	// Remove the file from disk.  ErrNotExist is silenced for idempotency.
+	//
+	// If os.Remove fails for any other reason the blob is still permanently
+	// evicted: m.evictedBlobs was updated above and the cached fd is already
+	// closed, so subsequent ReadAt calls correctly return ErrEvicted.  We
+	// return the error so the caller knows the on-disk file was not reclaimed;
+	// it becomes an orphan that a startup scan can clean up.  Eviction is a
+	// one-way transition — we never reverse it even when the unlink fails.
 	path := filepath.Join(m.dir, logBlobID+blobSuffix)
 	if err := os.Remove(path); err != nil && !errors.Is(err, iofs.ErrNotExist) {
 		return fmt.Errorf("logblob: remove blob %q: %w", path, err)

--- a/pkg/block/local/logblob/manager_test.go
+++ b/pkg/block/local/logblob/manager_test.go
@@ -1,0 +1,639 @@
+package logblob_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/local/logblob"
+)
+
+// TestAppendReadAtRoundTrip: single Append followed by a ReadAt returns the
+// original bytes at the reported offset.
+func TestAppendReadAtRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	m, err := logblob.Open(dir, logblob.Options{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	data := []byte("hello, log blob!")
+	ctx := context.Background()
+
+	loc, err := m.Append(ctx, data)
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	if loc.RawLength != int64(len(data)) {
+		t.Errorf("RawLength = %d, want %d", loc.RawLength, len(data))
+	}
+	if loc.RawOffset != 0 {
+		t.Errorf("RawOffset = %d, want 0 (first append)", loc.RawOffset)
+	}
+	if loc.LogBlobID == "" {
+		t.Error("LogBlobID must not be empty")
+	}
+
+	dst := make([]byte, loc.RawLength)
+	n, err := m.ReadAt(ctx, loc, dst)
+	if err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if n != len(data) {
+		t.Errorf("ReadAt n = %d, want %d", n, len(data))
+	}
+	if !bytes.Equal(dst, data) {
+		t.Errorf("ReadAt data = %q, want %q", dst, data)
+	}
+}
+
+// TestManyInterleavedAppends: many sequential Appends; each ReadAt using the
+// returned LocalChunkLocation returns the exact bytes written.
+func TestManyInterleavedAppends(t *testing.T) {
+	dir := t.TempDir()
+	m, err := logblob.Open(dir, logblob.Options{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+	const n = 100
+	locs := make([]block.LocalChunkLocation, n)
+	payloads := make([][]byte, n)
+
+	for i := 0; i < n; i++ {
+		payloads[i] = []byte(fmt.Sprintf("payload-%04d-data", i))
+		locs[i], err = m.Append(ctx, payloads[i])
+		if err != nil {
+			t.Fatalf("Append[%d]: %v", i, err)
+		}
+	}
+
+	for i := 0; i < n; i++ {
+		dst := make([]byte, locs[i].RawLength)
+		nn, err := m.ReadAt(ctx, locs[i], dst)
+		if err != nil {
+			t.Fatalf("ReadAt[%d]: %v", i, err)
+		}
+		if nn != len(payloads[i]) {
+			t.Errorf("ReadAt[%d] n = %d, want %d", i, nn, len(payloads[i]))
+		}
+		if !bytes.Equal(dst, payloads[i]) {
+			t.Errorf("ReadAt[%d] = %q, want %q", i, dst, payloads[i])
+		}
+	}
+}
+
+// TestOffsetMonotonicity: each successive Append starts where the previous one
+// ended (within the same blob).
+func TestOffsetMonotonicity(t *testing.T) {
+	dir := t.TempDir()
+	m, err := logblob.Open(dir, logblob.Options{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+	var prevEnd int64
+	prevBlob := ""
+
+	for i := 0; i < 10; i++ {
+		p := []byte(fmt.Sprintf("item%04d", i))
+		loc, err := m.Append(ctx, p)
+		if err != nil {
+			t.Fatalf("Append[%d]: %v", i, err)
+		}
+		if loc.RawLength != int64(len(p)) {
+			t.Errorf("[%d] RawLength = %d, want %d", i, loc.RawLength, len(p))
+		}
+		if prevBlob == "" || loc.LogBlobID == prevBlob {
+			// Same blob: offset must be contiguous.
+			if i > 0 && loc.LogBlobID == prevBlob && loc.RawOffset != prevEnd {
+				t.Errorf("[%d] RawOffset = %d, want %d (contiguous)", i, loc.RawOffset, prevEnd)
+			}
+			prevEnd = loc.RawOffset + loc.RawLength
+		} else {
+			// New blob after rotation: offset resets to 0.
+			if loc.RawOffset != 0 {
+				t.Errorf("[%d] after rotation: RawOffset = %d, want 0", i, loc.RawOffset)
+			}
+			prevEnd = loc.RawLength
+		}
+		prevBlob = loc.LogBlobID
+	}
+}
+
+// TestConcurrentReadsDuringAppend: concurrent ReadAt of already-committed
+// offsets runs cleanly alongside active Appends under the race detector.
+func TestConcurrentReadsDuringAppend(t *testing.T) {
+	dir := t.TempDir()
+	// Small SizeCap to trigger rotations during the test.
+	m, err := logblob.Open(dir, logblob.Options{SizeCap: 512})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+
+	// Pre-write a batch of known payloads.
+	const preN = 30
+	preLocs := make([]block.LocalChunkLocation, preN)
+	prePayloads := make([][]byte, preN)
+	for i := 0; i < preN; i++ {
+		prePayloads[i] = []byte(fmt.Sprintf("pre-%04d-xxxxxxxxxx", i))
+		preLocs[i], err = m.Append(ctx, prePayloads[i])
+		if err != nil {
+			t.Fatalf("pre-Append[%d]: %v", i, err)
+		}
+	}
+
+	var wg sync.WaitGroup
+
+	// Readers: verify each pre-written payload repeatedly.
+	for r := 0; r < 8; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < preN; i++ {
+				dst := make([]byte, preLocs[i].RawLength)
+				if _, err := m.ReadAt(ctx, preLocs[i], dst); err != nil {
+					t.Errorf("concurrent ReadAt[%d]: %v", i, err)
+					return
+				}
+				if !bytes.Equal(dst, prePayloads[i]) {
+					t.Errorf("concurrent ReadAt[%d]: got %q, want %q", i, dst, prePayloads[i])
+					return
+				}
+			}
+		}()
+	}
+
+	// Appenders: write new data concurrently.
+	for a := 0; a < 4; a++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < 25; i++ {
+				p := []byte(fmt.Sprintf("concurrent-a%d-i%04d", id, i))
+				if _, err := m.Append(ctx, p); err != nil {
+					t.Errorf("concurrent Append a=%d i=%d: %v", id, i, err)
+					return
+				}
+			}
+		}(a)
+	}
+
+	wg.Wait()
+}
+
+// TestRotationAtSizeCap: once the active blob reaches SizeCap, a new blob is
+// created. The old blob remains readable via its original LocalChunkLocations.
+func TestRotationAtSizeCap(t *testing.T) {
+	dir := t.TempDir()
+	const payloadSize = 100
+	const sizeCap = int64(payloadSize * 3) // fits exactly 3 writes before rotation
+
+	m, err := logblob.Open(dir, logblob.Options{SizeCap: sizeCap})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+	const total = 5
+	locs := make([]block.LocalChunkLocation, total)
+	payloads := make([][]byte, total)
+
+	for i := 0; i < total; i++ {
+		payloads[i] = bytes.Repeat([]byte{byte('A' + i)}, payloadSize)
+		locs[i], err = m.Append(ctx, payloads[i])
+		if err != nil {
+			t.Fatalf("Append[%d]: %v", i, err)
+		}
+	}
+
+	// Expect at least 2 blobs.
+	blobs, err := m.ListBlobs()
+	if err != nil {
+		t.Fatalf("ListBlobs: %v", err)
+	}
+	if len(blobs) < 2 {
+		t.Fatalf("expected ≥2 blobs after rotation, got %d", len(blobs))
+	}
+
+	// First and last writes should be in different blobs.
+	if locs[0].LogBlobID == locs[total-1].LogBlobID {
+		t.Errorf("expected rotation: locs[0] and locs[%d] both in %q", total-1, locs[0].LogBlobID)
+	}
+
+	// All data must be readable regardless of which blob it landed in.
+	for i, loc := range locs {
+		dst := make([]byte, loc.RawLength)
+		n, err := m.ReadAt(ctx, loc, dst)
+		if err != nil {
+			t.Fatalf("ReadAt[%d] after rotation: %v", i, err)
+		}
+		if n != payloadSize {
+			t.Errorf("ReadAt[%d] n = %d, want %d", i, n, payloadSize)
+		}
+		if !bytes.Equal(dst, payloads[i]) {
+			t.Errorf("ReadAt[%d] = %q, want %q", i, dst, payloads[i])
+		}
+	}
+}
+
+// TestCallerDrivenRotate: the explicit Rotate() call seals the current blob
+// and the next Append targets a new blob with a higher ID.
+func TestCallerDrivenRotate(t *testing.T) {
+	dir := t.TempDir()
+	m, err := logblob.Open(dir, logblob.Options{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+	data1 := []byte("before-rotate")
+	loc1, err := m.Append(ctx, data1)
+	if err != nil {
+		t.Fatalf("Append before Rotate: %v", err)
+	}
+
+	if err := m.Rotate(); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+
+	data2 := []byte("after-rotate")
+	loc2, err := m.Append(ctx, data2)
+	if err != nil {
+		t.Fatalf("Append after Rotate: %v", err)
+	}
+
+	if loc1.LogBlobID == loc2.LogBlobID {
+		t.Errorf("Rotate did not produce a new blob: both use %q", loc1.LogBlobID)
+	}
+	if loc2.LogBlobID <= loc1.LogBlobID {
+		t.Errorf("new blobID %q not monotonically greater than %q", loc2.LogBlobID, loc1.LogBlobID)
+	}
+	if loc2.RawOffset != 0 {
+		t.Errorf("first append after rotate: offset = %d, want 0", loc2.RawOffset)
+	}
+
+	// Old blob still readable.
+	dst1 := make([]byte, loc1.RawLength)
+	if _, err := m.ReadAt(ctx, loc1, dst1); err != nil {
+		t.Fatalf("ReadAt after Rotate (old blob): %v", err)
+	}
+	if !bytes.Equal(dst1, data1) {
+		t.Errorf("old blob data = %q, want %q", dst1, data1)
+	}
+
+	// New blob also readable.
+	dst2 := make([]byte, loc2.RawLength)
+	if _, err := m.ReadAt(ctx, loc2, dst2); err != nil {
+		t.Fatalf("ReadAt after Rotate (new blob): %v", err)
+	}
+	if !bytes.Equal(dst2, data2) {
+		t.Errorf("new blob data = %q, want %q", dst2, data2)
+	}
+}
+
+// TestBlobIDStableAcrossReopen: blob IDs present before Close are the same IDs
+// visible on the next Open of the same directory.
+func TestBlobIDStableAcrossReopen(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	m, err := logblob.Open(dir, logblob.Options{SizeCap: 50})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	// Write enough to create two blobs. Keep locs+payloads to verify after reopen.
+	type entry struct {
+		loc  block.LocalChunkLocation
+		data []byte
+	}
+	var entries []entry
+	for i := 0; i < 5; i++ {
+		p := []byte(fmt.Sprintf("item%04d-xxxxxxxxxxxxxxxxxxx", i)) // ≥ 20 bytes each
+		loc, err := m.Append(ctx, p)
+		if err != nil {
+			t.Fatalf("Append[%d]: %v", i, err)
+		}
+		entries = append(entries, entry{loc, p})
+	}
+
+	blobsBefore, err := m.ListBlobs()
+	if err != nil {
+		t.Fatalf("ListBlobs before close: %v", err)
+	}
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	m2, err := logblob.Open(dir, logblob.Options{SizeCap: 50})
+	if err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	defer func() { _ = m2.Close() }()
+
+	// Verify all previously written data is still readable after reopen.
+	for i, e := range entries {
+		dst := make([]byte, e.loc.RawLength)
+		if _, err := m2.ReadAt(ctx, e.loc, dst); err != nil {
+			t.Fatalf("ReadAt[%d] after reopen: %v", i, err)
+		}
+		if !bytes.Equal(dst, e.data) {
+			t.Errorf("ReadAt[%d] = %q, want %q", i, dst, e.data)
+		}
+	}
+
+	blobsAfter, err := m2.ListBlobs()
+	if err != nil {
+		t.Fatalf("ListBlobs after reopen: %v", err)
+	}
+
+	// Same set of blob IDs.
+	beforeIDs := blobIDSet(blobsBefore)
+	afterIDs := blobIDSet(blobsAfter)
+	for id := range beforeIDs {
+		if !afterIDs[id] {
+			t.Errorf("blob ID %q present before close but missing after reopen", id)
+		}
+	}
+	for id := range afterIDs {
+		if !beforeIDs[id] {
+			t.Errorf("blob ID %q appeared after reopen but was not present before", id)
+		}
+	}
+}
+
+// TestReopenResumesAtTail: after Close and reopen, Append writes at the
+// correct tail offset (not at 0, not past the end).
+func TestReopenResumesAtTail(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	m, err := logblob.Open(dir, logblob.Options{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	data1 := []byte("first-write-before-close")
+	loc1, err := m.Append(ctx, data1)
+	if err != nil {
+		t.Fatalf("Append before close: %v", err)
+	}
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	m2, err := logblob.Open(dir, logblob.Options{})
+	if err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	defer func() { _ = m2.Close() }()
+
+	data2 := []byte("second-write-after-reopen")
+	loc2, err := m2.Append(ctx, data2)
+	if err != nil {
+		t.Fatalf("Append after reopen: %v", err)
+	}
+
+	// Same blob (no rotation between writes).
+	if loc1.LogBlobID != loc2.LogBlobID {
+		t.Errorf("expected same blob after reopen: %q vs %q", loc1.LogBlobID, loc2.LogBlobID)
+	}
+
+	// loc2 starts where loc1 ended.
+	wantOffset := loc1.RawOffset + loc1.RawLength
+	if loc2.RawOffset != wantOffset {
+		t.Errorf("loc2.RawOffset = %d, want %d", loc2.RawOffset, wantOffset)
+	}
+
+	// Both records readable.
+	dst1 := make([]byte, loc1.RawLength)
+	if _, err := m2.ReadAt(ctx, loc1, dst1); err != nil {
+		t.Fatalf("ReadAt loc1 after reopen: %v", err)
+	}
+	if !bytes.Equal(dst1, data1) {
+		t.Errorf("ReadAt loc1 = %q, want %q", dst1, data1)
+	}
+
+	dst2 := make([]byte, loc2.RawLength)
+	if _, err := m2.ReadAt(ctx, loc2, dst2); err != nil {
+		t.Fatalf("ReadAt loc2: %v", err)
+	}
+	if !bytes.Equal(dst2, data2) {
+		t.Errorf("ReadAt loc2 = %q, want %q", dst2, data2)
+	}
+}
+
+// TestListBlobs: ListBlobs returns all blobs including the active one, with
+// exactly one Active blob.
+func TestListBlobs(t *testing.T) {
+	dir := t.TempDir()
+	const sizeCap = 50
+	m, err := logblob.Open(dir, logblob.Options{SizeCap: sizeCap})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+
+	// Fresh Manager: one active blob.
+	blobs, err := m.ListBlobs()
+	if err != nil {
+		t.Fatalf("ListBlobs (empty): %v", err)
+	}
+	if len(blobs) != 1 {
+		t.Fatalf("expected 1 blob initially, got %d", len(blobs))
+	}
+	if !blobs[0].Active {
+		t.Errorf("initial blob must be marked Active")
+	}
+
+	// Write enough to trigger at least one rotation.
+	for i := 0; i < 8; i++ {
+		p := []byte(fmt.Sprintf("data-%d-padding-xxxxxxxxxxx", i))
+		if _, err := m.Append(ctx, p); err != nil {
+			t.Fatalf("Append[%d]: %v", i, err)
+		}
+	}
+
+	blobs, err = m.ListBlobs()
+	if err != nil {
+		t.Fatalf("ListBlobs after writes: %v", err)
+	}
+	if len(blobs) < 2 {
+		t.Errorf("expected ≥2 blobs after rotation, got %d", len(blobs))
+	}
+
+	activeCount := 0
+	for _, b := range blobs {
+		if b.Active {
+			activeCount++
+		}
+	}
+	if activeCount != 1 {
+		t.Errorf("expected exactly 1 active blob, got %d", activeCount)
+	}
+}
+
+// TestNewBlobIDIsHigherAfterReopen: after reopen, the first new blob created
+// by rotation gets an ID strictly greater than any existing ID.
+func TestNewBlobIDIsHigherAfterReopen(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	m, err := logblob.Open(dir, logblob.Options{SizeCap: 20})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	// Write enough to create several blobs.
+	for i := 0; i < 5; i++ {
+		if _, err := m.Append(ctx, []byte("12345678901234567890")); err != nil {
+			t.Fatalf("Append[%d]: %v", i, err)
+		}
+	}
+	blobsBefore, _ := m.ListBlobs()
+	maxIDBefore := ""
+	for _, b := range blobsBefore {
+		if b.LogBlobID > maxIDBefore {
+			maxIDBefore = b.LogBlobID
+		}
+	}
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Reopen, force a rotation, check new ID > old max.
+	m2, err := logblob.Open(dir, logblob.Options{SizeCap: 20})
+	if err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	defer func() { _ = m2.Close() }()
+
+	if err := m2.Rotate(); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+	loc, err := m2.Append(ctx, []byte("new"))
+	if err != nil {
+		t.Fatalf("Append after reopen+rotate: %v", err)
+	}
+	if loc.LogBlobID <= maxIDBefore {
+		t.Errorf("new blob ID %q ≤ max before reopen %q", loc.LogBlobID, maxIDBefore)
+	}
+}
+
+// TestSyncFlushes: Sync() does not error on a healthy Manager.
+func TestSyncFlushes(t *testing.T) {
+	dir := t.TempDir()
+	m, err := logblob.Open(dir, logblob.Options{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+	if _, err := m.Append(ctx, []byte("data")); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := m.Sync(); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+}
+
+// TestClosedManagerErrors: operations on a closed Manager return ErrClosed.
+func TestClosedManagerErrors(t *testing.T) {
+	dir := t.TempDir()
+	m, err := logblob.Open(dir, logblob.Options{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ctx := context.Background()
+	if _, err := m.Append(ctx, []byte("x")); err != nil {
+		t.Fatalf("Append before Close: %v", err)
+	}
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if _, err := m.Append(ctx, []byte("y")); err == nil {
+		t.Error("expected error from Append after Close, got nil")
+	}
+	loc := block.LocalChunkLocation{LogBlobID: "0000000000000000", RawOffset: 0, RawLength: 1}
+	if _, err := m.ReadAt(ctx, loc, make([]byte, 1)); err == nil {
+		t.Error("expected error from ReadAt after Close, got nil")
+	}
+	if err := m.Rotate(); err == nil {
+		t.Error("expected error from Rotate after Close, got nil")
+	}
+	if err := m.Sync(); err == nil {
+		t.Error("expected error from Sync after Close, got nil")
+	}
+}
+
+// TestMultipleReopenCycles: open→write→close→reopen repeated several times;
+// each cycle correctly resumes at the tail.
+func TestMultipleReopenCycles(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	type record struct {
+		loc  block.LocalChunkLocation
+		data []byte
+	}
+	var records []record
+
+	for cycle := 0; cycle < 4; cycle++ {
+		m, err := logblob.Open(dir, logblob.Options{})
+		if err != nil {
+			t.Fatalf("cycle %d Open: %v", cycle, err)
+		}
+
+		p := []byte(fmt.Sprintf("cycle-%d-payload", cycle))
+		loc, err := m.Append(ctx, p)
+		if err != nil {
+			_ = m.Close()
+			t.Fatalf("cycle %d Append: %v", cycle, err)
+		}
+		records = append(records, record{loc, p})
+
+		// Verify all previously written records are still readable.
+		for _, r := range records {
+			dst := make([]byte, r.loc.RawLength)
+			if _, err := m.ReadAt(ctx, r.loc, dst); err != nil {
+				_ = m.Close()
+				t.Fatalf("cycle %d ReadAt: %v", cycle, err)
+			}
+			if !bytes.Equal(dst, r.data) {
+				_ = m.Close()
+				t.Fatalf("cycle %d ReadAt = %q, want %q", cycle, dst, r.data)
+			}
+		}
+
+		if err := m.Close(); err != nil {
+			t.Fatalf("cycle %d Close: %v", cycle, err)
+		}
+	}
+}
+
+// blobIDSet converts a BlobInfo slice to a set of IDs.
+func blobIDSet(blobs []logblob.BlobInfo) map[string]bool {
+	s := make(map[string]bool, len(blobs))
+	for _, b := range blobs {
+		s[b.LogBlobID] = true
+	}
+	return s
+}

--- a/pkg/block/local/logblob/manager_test.go
+++ b/pkg/block/local/logblob/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -627,6 +628,131 @@ func TestMultipleReopenCycles(t *testing.T) {
 			t.Fatalf("cycle %d Close: %v", cycle, err)
 		}
 	}
+}
+
+// TestReadAtDuringRotate exercises the race window where fdForBlob snapshots
+// the active fd under mu, releases mu, Rotate moves that fd to sealedFDs, and
+// then ReadAt runs on the former-active fd. Every ReadAt must return the exact
+// original bytes.
+func TestReadAtDuringRotate(t *testing.T) {
+	dir := t.TempDir()
+	// Small SizeCap keeps the active blob small; we drive rotations manually too.
+	m, err := logblob.Open(dir, logblob.Options{SizeCap: 4096})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+	payload := []byte("readat-during-rotate-payload-data")
+	loc, err := m.Append(ctx, payload)
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	const (
+		readers  = 8
+		rotators = 4
+		iters    = 50
+	)
+
+	var wg sync.WaitGroup
+
+	// Readers: repeatedly read the same location and verify bytes.
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			dst := make([]byte, loc.RawLength)
+			for i := 0; i < iters; i++ {
+				n, err := m.ReadAt(ctx, loc, dst)
+				if err != nil {
+					t.Errorf("ReadAt during rotate: %v", err)
+					return
+				}
+				if n != len(payload) {
+					t.Errorf("ReadAt short: got %d, want %d", n, len(payload))
+					return
+				}
+				if !bytes.Equal(dst[:n], payload) {
+					t.Errorf("ReadAt corrupt: got %q, want %q", dst[:n], payload)
+					return
+				}
+			}
+		}()
+	}
+
+	// Rotators: keep sealing the active blob and opening a fresh one.
+	for r := 0; r < rotators; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				if err := m.Rotate(); err != nil {
+					t.Errorf("Rotate: %v", err)
+					return
+				}
+				// Write something so the new active blob isn't empty.
+				if _, err := m.Append(ctx, []byte("filler")); err != nil {
+					t.Errorf("Append filler: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestReadAtDuringClose fires many concurrent ReadAt goroutines while another
+// goroutine calls Close. Each ReadAt must return either correct bytes or an
+// error (ErrClosed / os.ErrClosed / a wrapped variant). A nil error paired with
+// wrong or garbage bytes is a bug.
+func TestReadAtDuringClose(t *testing.T) {
+	dir := t.TempDir()
+	m, err := logblob.Open(dir, logblob.Options{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	ctx := context.Background()
+	payload := []byte("readat-during-close-payload-data")
+	loc, err := m.Append(ctx, payload)
+	if err != nil {
+		_ = m.Close()
+		t.Fatalf("Append: %v", err)
+	}
+
+	const readers = 16
+
+	var wg sync.WaitGroup
+	// Closer: let all readers start, then close.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Brief yield so readers are in flight.
+		runtime.Gosched()
+		_ = m.Close()
+	}()
+
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			dst := make([]byte, loc.RawLength)
+			n, err := m.ReadAt(ctx, loc, dst)
+			if err != nil {
+				// Any error is acceptable — closed sentinel or OS error on closed fd.
+				return
+			}
+			// Success: bytes must be exactly right.
+			if n != len(payload) || !bytes.Equal(dst[:n], payload) {
+				t.Errorf("ReadAt during Close: nil err but wrong bytes: got %q (%d bytes), want %q", dst[:n], n, payload)
+			}
+		}()
+	}
+
+	wg.Wait()
 }
 
 // blobIDSet converts a BlobInfo slice to a set of IDs.

--- a/pkg/block/local/logblob/manager_test.go
+++ b/pkg/block/local/logblob/manager_test.go
@@ -3,12 +3,16 @@ package logblob_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
 	"sync"
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/blockstoretest"
 	"github.com/marmos91/dittofs/pkg/block/local/logblob"
 )
 
@@ -762,4 +766,418 @@ func blobIDSet(blobs []logblob.BlobInfo) map[string]bool {
 		s[b.LogBlobID] = true
 	}
 	return s
+}
+
+// TestEvictSealedBlob rotates to produce a sealed blob, evicts it, and
+// verifies the .blob file is gone from disk.
+func TestEvictSealedBlob(t *testing.T) {
+	dir := t.TempDir()
+	m, err := logblob.Open(dir, logblob.Options{SizeCap: 64})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+
+	// First append → blob 0 (active).
+	loc0, err := m.Append(ctx, bytes.Repeat([]byte("A"), 70))
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	blob0 := loc0.LogBlobID
+
+	// Second append → triggers rotation, blob 0 becomes sealed.
+	if _, err := m.Append(ctx, []byte("second")); err != nil {
+		t.Fatalf("Append(second): %v", err)
+	}
+
+	// Evict blob 0 (sealed).
+	if err := m.EvictBlob(ctx, blob0, func(string) bool { return true }); err != nil {
+		t.Fatalf("EvictBlob: %v", err)
+	}
+
+	// File must be gone.
+	blobPath := filepath.Join(dir, blob0+".blob")
+	if _, statErr := os.Stat(blobPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("expected blob file to be gone, got stat err: %v", statErr)
+	}
+}
+
+// TestReadAtEvictedReturnsErrEvicted evicts a sealed blob then expects
+// ReadAt to return ErrEvicted.
+func TestReadAtEvictedReturnsErrEvicted(t *testing.T) {
+	dir := t.TempDir()
+	m, err := logblob.Open(dir, logblob.Options{SizeCap: 64})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+	loc0, err := m.Append(ctx, bytes.Repeat([]byte("B"), 70))
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	blob0 := loc0.LogBlobID
+	if _, err := m.Append(ctx, []byte("seal-trigger")); err != nil {
+		t.Fatalf("Append(trigger): %v", err)
+	}
+
+	if err := m.EvictBlob(ctx, blob0, func(string) bool { return true }); err != nil {
+		t.Fatalf("EvictBlob: %v", err)
+	}
+
+	dst := make([]byte, loc0.RawLength)
+	_, readErr := m.ReadAt(ctx, loc0, dst)
+	if !errors.Is(readErr, logblob.ErrEvicted) {
+		t.Errorf("ReadAt after eviction: got %v, want ErrEvicted", readErr)
+	}
+}
+
+// TestEvictActiveBlobRefused verifies that EvictBlob returns ErrActiveBlob
+// when called on the currently active blob.
+func TestEvictActiveBlobRefused(t *testing.T) {
+	dir := t.TempDir()
+	m, err := logblob.Open(dir, logblob.Options{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+	loc, err := m.Append(ctx, []byte("active-data"))
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	evictErr := m.EvictBlob(ctx, loc.LogBlobID, func(string) bool { return true })
+	if !errors.Is(evictErr, logblob.ErrActiveBlob) {
+		t.Errorf("EvictBlob(active): got %v, want ErrActiveBlob", evictErr)
+	}
+}
+
+// TestEvictUnsyncedBytesRefused verifies that a synced function returning
+// false causes EvictBlob to return ErrUnsyncedBytes.
+func TestEvictUnsyncedBytesRefused(t *testing.T) {
+	dir := t.TempDir()
+	m, err := logblob.Open(dir, logblob.Options{SizeCap: 64})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+	loc0, err := m.Append(ctx, bytes.Repeat([]byte("C"), 70))
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	blob0 := loc0.LogBlobID
+	if _, err := m.Append(ctx, []byte("seal")); err != nil {
+		t.Fatalf("Append(seal): %v", err)
+	}
+
+	evictErr := m.EvictBlob(ctx, blob0, func(string) bool { return false })
+	if !errors.Is(evictErr, logblob.ErrUnsyncedBytes) {
+		t.Errorf("EvictBlob(unsynced): got %v, want ErrUnsyncedBytes", evictErr)
+	}
+}
+
+// TestEvictIdempotent verifies that calling EvictBlob twice on the same
+// sealed blob returns nil on the second call.
+func TestEvictIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	m, err := logblob.Open(dir, logblob.Options{SizeCap: 64})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+	loc0, err := m.Append(ctx, bytes.Repeat([]byte("D"), 70))
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	blob0 := loc0.LogBlobID
+	if _, err := m.Append(ctx, []byte("seal")); err != nil {
+		t.Fatalf("Append(seal): %v", err)
+	}
+
+	if err := m.EvictBlob(ctx, blob0, func(string) bool { return true }); err != nil {
+		t.Fatalf("EvictBlob(first): %v", err)
+	}
+	if err := m.EvictBlob(ctx, blob0, func(string) bool { return true }); err != nil {
+		t.Errorf("EvictBlob(second, idempotent): got %v, want nil", err)
+	}
+}
+
+// TestEvictRaceDuringReadAt exercises concurrent ReadAt goroutines against an
+// EvictBlob call on the same sealed blob. A nil error from ReadAt must be
+// paired with correct bytes; the race detector validates locking.
+func TestEvictRaceDuringReadAt(t *testing.T) {
+	dir := t.TempDir()
+	payload := bytes.Repeat([]byte("E"), 70)
+	m, err := logblob.Open(dir, logblob.Options{SizeCap: 64})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+	loc0, err := m.Append(ctx, payload)
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if _, err := m.Append(ctx, []byte("seal")); err != nil {
+		t.Fatalf("Append(seal): %v", err)
+	}
+
+	var wg sync.WaitGroup
+	const readers = 8
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			dst := make([]byte, loc0.RawLength)
+			n, err := m.ReadAt(ctx, loc0, dst)
+			if err != nil {
+				// Eviction may have raced: any error is acceptable.
+				return
+			}
+			if n != len(payload) || !bytes.Equal(dst[:n], payload) {
+				t.Errorf("ReadAt during evict race: nil err but wrong bytes: got %q, want %q", dst[:n], payload)
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = m.EvictBlob(ctx, loc0.LogBlobID, func(string) bool { return true })
+	}()
+
+	wg.Wait()
+}
+
+// TestRecoverActiveBlobTornTail writes 3 payloads, injects garbage beyond
+// them, calls Recover to the valid offset, then verifies that subsequent
+// Append lands at that offset and earlier reads are intact.
+func TestRecoverActiveBlobTornTail(t *testing.T) {
+	dir := t.TempDir()
+	m, err := logblob.Open(dir, logblob.Options{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+	payloads := [][]byte{
+		[]byte("payload-one"),
+		[]byte("payload-two"),
+		[]byte("payload-three"),
+	}
+	locs := make([]block.LocalChunkLocation, 3)
+	for i, p := range payloads {
+		locs[i], err = m.Append(ctx, p)
+		if err != nil {
+			t.Fatalf("Append[%d]: %v", i, err)
+		}
+	}
+
+	// mark is the valid data boundary.
+	mark := locs[2].RawOffset + locs[2].RawLength
+
+	// Inject garbage after the mark directly into the blob file.
+	blobPath := filepath.Join(dir, locs[0].LogBlobID+".blob")
+	f, openErr := os.OpenFile(blobPath, os.O_WRONLY, 0)
+	if openErr != nil {
+		t.Fatalf("OpenFile: %v", openErr)
+	}
+	if _, werr := f.WriteAt([]byte("GARBAGE!!"), mark); werr != nil {
+		_ = f.Close()
+		t.Fatalf("WriteAt garbage: %v", werr)
+	}
+	_ = f.Close()
+
+	// Recover to mark.
+	if err := m.Recover(ctx, locs[0].LogBlobID, mark); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+
+	// Next Append must land at mark.
+	afterLoc, err := m.Append(ctx, []byte("after"))
+	if err != nil {
+		t.Fatalf("Append(after): %v", err)
+	}
+	if afterLoc.RawOffset != mark {
+		t.Errorf("Append after Recover: RawOffset = %d, want %d", afterLoc.RawOffset, mark)
+	}
+
+	// Original payloads still readable.
+	for i, loc := range locs {
+		dst := make([]byte, loc.RawLength)
+		if _, err := m.ReadAt(ctx, loc, dst); err != nil {
+			t.Fatalf("ReadAt[%d]: %v", i, err)
+		}
+		if !bytes.Equal(dst, payloads[i]) {
+			t.Errorf("ReadAt[%d] = %q, want %q", i, dst, payloads[i])
+		}
+	}
+
+	// Reading at mark+5 (inside the former garbage) should fail (file truncated).
+	garbageLoc := block.LocalChunkLocation{
+		LogBlobID: locs[0].LogBlobID,
+		RawOffset: mark + 5,
+		RawLength: 5,
+	}
+	dst := make([]byte, 5)
+	_, readErr := m.ReadAt(ctx, garbageLoc, dst)
+	if readErr == nil {
+		t.Errorf("ReadAt beyond Recover boundary: expected error (EOF/short), got nil")
+	}
+}
+
+// TestRecoverSealedBlobTornTail appends 2 payloads, seals the blob, injects
+// garbage after the payloads, calls Recover, then verifies reads before the
+// offset succeed and the file size matches the offset.
+func TestRecoverSealedBlobTornTail(t *testing.T) {
+	dir := t.TempDir()
+	payload1 := bytes.Repeat([]byte("F"), 50)
+	payload2 := bytes.Repeat([]byte("G"), 50)
+
+	m, err := logblob.Open(dir, logblob.Options{SizeCap: 200})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+	loc1, err := m.Append(ctx, payload1)
+	if err != nil {
+		t.Fatalf("Append(1): %v", err)
+	}
+	loc2, err := m.Append(ctx, payload2)
+	if err != nil {
+		t.Fatalf("Append(2): %v", err)
+	}
+	blob0 := loc1.LogBlobID
+	validOffset := loc2.RawOffset + loc2.RawLength // = 100
+
+	// Seal blob0 by rotating.
+	if err := m.Rotate(); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+
+	// Inject garbage directly past validOffset.
+	blobPath := filepath.Join(dir, blob0+".blob")
+	f, openErr := os.OpenFile(blobPath, os.O_WRONLY, 0)
+	if openErr != nil {
+		t.Fatalf("OpenFile: %v", openErr)
+	}
+	garbage := bytes.Repeat([]byte("X"), 30)
+	if _, werr := f.WriteAt(garbage, validOffset); werr != nil {
+		_ = f.Close()
+		t.Fatalf("WriteAt garbage: %v", werr)
+	}
+	_ = f.Close()
+
+	// Recover sealed blob.
+	if err := m.Recover(ctx, blob0, validOffset); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+
+	// Reads before offset must succeed.
+	dst1 := make([]byte, loc1.RawLength)
+	if _, err := m.ReadAt(ctx, loc1, dst1); err != nil {
+		t.Fatalf("ReadAt(loc1): %v", err)
+	}
+	if !bytes.Equal(dst1, payload1) {
+		t.Errorf("ReadAt(loc1) = %q, want %q", dst1, payload1)
+	}
+	dst2 := make([]byte, loc2.RawLength)
+	if _, err := m.ReadAt(ctx, loc2, dst2); err != nil {
+		t.Fatalf("ReadAt(loc2): %v", err)
+	}
+	if !bytes.Equal(dst2, payload2) {
+		t.Errorf("ReadAt(loc2) = %q, want %q", dst2, payload2)
+	}
+
+	// File size must equal validOffset.
+	fi, statErr := os.Stat(blobPath)
+	if statErr != nil {
+		t.Fatalf("Stat: %v", statErr)
+	}
+	if fi.Size() != validOffset {
+		t.Errorf("blob file size = %d, want %d", fi.Size(), validOffset)
+	}
+}
+
+// TestRecoverAckedBoundary verifies the acked/unacked boundary: data written
+// before the mark survives Recover, data written after is gone.
+func TestRecoverAckedBoundary(t *testing.T) {
+	dir := t.TempDir()
+	acked := bytes.Repeat([]byte("H"), 50)
+	unacked := bytes.Repeat([]byte("I"), 50)
+
+	m, err := logblob.Open(dir, logblob.Options{SizeCap: 256})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+	locAcked, err := m.Append(ctx, acked)
+	if err != nil {
+		t.Fatalf("Append(acked): %v", err)
+	}
+	mark := locAcked.RawOffset + locAcked.RawLength // = 50
+
+	locUnacked, err := m.Append(ctx, unacked)
+	if err != nil {
+		t.Fatalf("Append(unacked): %v", err)
+	}
+
+	// Recover to mark; discards the "unacked" portion.
+	blobID := locAcked.LogBlobID
+	if err := m.Recover(ctx, blobID, mark); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+
+	// Acked data must still be readable.
+	dst := make([]byte, locAcked.RawLength)
+	if _, err := m.ReadAt(ctx, locAcked, dst); err != nil {
+		t.Fatalf("ReadAt(acked): %v", err)
+	}
+	if !bytes.Equal(dst, acked) {
+		t.Errorf("ReadAt(acked) = %q, want %q", dst, acked)
+	}
+
+	// Unacked loc is now beyond the truncation point: reading must fail.
+	dstU := make([]byte, locUnacked.RawLength)
+	n, readErr := m.ReadAt(ctx, locUnacked, dstU)
+	if readErr == nil && n == len(unacked) {
+		t.Error("ReadAt(unacked) after Recover: expected error or short read, got full success")
+	}
+
+	// Next Append must resume at mark.
+	postLoc, err := m.Append(ctx, []byte("post"))
+	if err != nil {
+		t.Fatalf("Append(post): %v", err)
+	}
+	if postLoc.RawOffset != mark {
+		t.Errorf("Append after Recover: RawOffset = %d, want %d", postLoc.RawOffset, mark)
+	}
+}
+
+// TestLogBlobConformance runs the logblob conformance suite.
+func TestLogBlobConformance(t *testing.T) {
+	blockstoretest.LogBlobConformance(t, func(t *testing.T) (*logblob.Manager, string, func()) {
+		t.Helper()
+		dir := t.TempDir()
+		m, err := logblob.Open(dir, logblob.Options{SizeCap: 128})
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		return m, dir, func() { _ = m.Close() }
+	})
 }

--- a/pkg/block/local/logblob/manager_test.go
+++ b/pkg/block/local/logblob/manager_test.go
@@ -1279,6 +1279,77 @@ func TestRecoverSealedOverrunRejected(t *testing.T) {
 	}
 }
 
+// TestReadAtZeroLengthAfterClose verifies that a zero-length ReadAt on a
+// closed Manager returns ErrClosed rather than silently succeeding.
+func TestReadAtZeroLengthAfterClose(t *testing.T) {
+	dir := t.TempDir()
+	m, err := logblob.Open(dir, logblob.Options{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ctx := context.Background()
+	if _, err := m.Append(ctx, []byte("data")); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	loc := block.LocalChunkLocation{LogBlobID: "0000000000000000", RawOffset: 0, RawLength: 0}
+	_, readErr := m.ReadAt(ctx, loc, nil)
+	if !errors.Is(readErr, logblob.ErrClosed) {
+		t.Errorf("ReadAt(zero-length) on closed Manager: got %v, want ErrClosed", readErr)
+	}
+}
+
+// TestEvictBlobRemoveFailure verifies that EvictBlob correctly handles a
+// failed os.Remove: the blob is permanently marked evicted (ReadAt → ErrEvicted)
+// and the error is returned to the caller so it knows the file is an orphan.
+func TestEvictBlobRemoveFailure(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: cannot revoke directory write permission")
+	}
+	dir := t.TempDir()
+	m, err := logblob.Open(dir, logblob.Options{SizeCap: 64})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	ctx := context.Background()
+	loc0, err := m.Append(ctx, bytes.Repeat([]byte("F"), 70))
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	blob0 := loc0.LogBlobID
+	if _, err := m.Append(ctx, []byte("seal")); err != nil {
+		t.Fatalf("Append(seal): %v", err)
+	}
+
+	// Make the directory read-only so os.Remove cannot delete the blob file.
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	defer func() {
+		// Restore permissions so t.TempDir() cleanup succeeds.
+		_ = os.Chmod(dir, 0o755)
+		_ = m.Close()
+	}()
+
+	// EvictBlob must return an error because the unlink fails.
+	evictErr := m.EvictBlob(ctx, blob0, func(string) bool { return true })
+	if evictErr == nil {
+		t.Fatal("EvictBlob: expected error when os.Remove fails, got nil")
+	}
+
+	// Despite the unlink failure, the blob must be permanently evicted so
+	// ReadAt returns ErrEvicted — not stale bytes from the still-present file.
+	dst := make([]byte, loc0.RawLength)
+	_, readErr := m.ReadAt(ctx, loc0, dst)
+	if !errors.Is(readErr, logblob.ErrEvicted) {
+		t.Errorf("ReadAt after failed eviction: got %v, want ErrEvicted", readErr)
+	}
+}
+
 // TestLogBlobConformance runs the logblob conformance suite.
 func TestLogBlobConformance(t *testing.T) {
 	blockstoretest.LogBlobConformance(t, func(t *testing.T) (*logblob.Manager, string, func()) {

--- a/pkg/block/local/logblob/manager_test.go
+++ b/pkg/block/local/logblob/manager_test.go
@@ -1306,6 +1306,9 @@ func TestReadAtZeroLengthAfterClose(t *testing.T) {
 // failed os.Remove: the blob is permanently marked evicted (ReadAt → ErrEvicted)
 // and the error is returned to the caller so it knows the file is an orphan.
 func TestEvictBlobRemoveFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Remove failure injection via a read-only parent directory is a Unix-ism; Windows permits deleting files inside a read-only directory")
+	}
 	if os.Getuid() == 0 {
 		t.Skip("running as root: cannot revoke directory write permission")
 	}

--- a/pkg/block/local/logblob/manager_test.go
+++ b/pkg/block/local/logblob/manager_test.go
@@ -1169,6 +1169,116 @@ func TestRecoverAckedBoundary(t *testing.T) {
 	}
 }
 
+// TestEvictIdempotentUnsyncedSecondCall verifies that EvictBlob is idempotent
+// even when the synced function returns false on the second call. Once a blob
+// has been evicted the synced check must not be re-evaluated — the eviction
+// record is authoritative.
+func TestEvictIdempotentUnsyncedSecondCall(t *testing.T) {
+	dir := t.TempDir()
+	m, err := logblob.Open(dir, logblob.Options{SizeCap: 64})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+	loc0, err := m.Append(ctx, bytes.Repeat([]byte("D"), 70))
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	blob0 := loc0.LogBlobID
+	if _, err := m.Append(ctx, []byte("seal")); err != nil {
+		t.Fatalf("Append(seal): %v", err)
+	}
+
+	// First eviction: synced=true, must succeed.
+	if err := m.EvictBlob(ctx, blob0, func(string) bool { return true }); err != nil {
+		t.Fatalf("EvictBlob(first): %v", err)
+	}
+	// Second eviction with synced=false: blob is already evicted, must return nil.
+	if err := m.EvictBlob(ctx, blob0, func(string) bool { return false }); err != nil {
+		t.Errorf("EvictBlob(second, unsynced but already evicted): got %v, want nil", err)
+	}
+}
+
+// TestRecoverActiveOverrunRejected verifies that Recover returns an error and
+// does NOT extend the active blob when validUpToOffset exceeds the blob's
+// current size (POSIX ftruncate would zero-fill if we let it through).
+func TestRecoverActiveOverrunRejected(t *testing.T) {
+	dir := t.TempDir()
+	m, err := logblob.Open(dir, logblob.Options{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+	data := []byte("hello")
+	loc, err := m.Append(ctx, data)
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	currentSize := loc.RawOffset + loc.RawLength // = 5
+	overrunOffset := currentSize + 100
+
+	// Recover with offset > size must return an error.
+	if recoverErr := m.Recover(ctx, loc.LogBlobID, overrunOffset); recoverErr == nil {
+		t.Fatal("Recover(active) with offset > blob size: expected error, got nil")
+	}
+
+	// File must not have been extended.
+	blobPath := filepath.Join(dir, loc.LogBlobID+".blob")
+	fi, statErr := os.Stat(blobPath)
+	if statErr != nil {
+		t.Fatalf("Stat: %v", statErr)
+	}
+	if fi.Size() != currentSize {
+		t.Errorf("Recover(active) extended file: size = %d, want %d", fi.Size(), currentSize)
+	}
+}
+
+// TestRecoverSealedOverrunRejected verifies that Recover returns an error and
+// does NOT extend a sealed blob when validUpToOffset exceeds the file size.
+func TestRecoverSealedOverrunRejected(t *testing.T) {
+	dir := t.TempDir()
+	m, err := logblob.Open(dir, logblob.Options{SizeCap: 200})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+	data := bytes.Repeat([]byte("Z"), 50)
+	loc, err := m.Append(ctx, data)
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	blob0 := loc.LogBlobID
+	currentSize := loc.RawOffset + loc.RawLength // = 50
+
+	// Seal blob0.
+	if err := m.Rotate(); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+
+	overrunOffset := currentSize + 100
+
+	// Recover with offset > size must return an error.
+	if recoverErr := m.Recover(ctx, blob0, overrunOffset); recoverErr == nil {
+		t.Fatal("Recover(sealed) with offset > blob size: expected error, got nil")
+	}
+
+	// File must not have been extended.
+	blobPath := filepath.Join(dir, blob0+".blob")
+	fi, statErr := os.Stat(blobPath)
+	if statErr != nil {
+		t.Fatalf("Stat: %v", statErr)
+	}
+	if fi.Size() != currentSize {
+		t.Errorf("Recover(sealed) extended file: size = %d, want %d", fi.Size(), currentSize)
+	}
+}
+
 // TestLogBlobConformance runs the logblob conformance suite.
 func TestLogBlobConformance(t *testing.T) {
 	blockstoretest.LogBlobConformance(t, func(t *testing.T) (*logblob.Manager, string, func()) {

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -64,7 +64,6 @@ func DefaultCommitBlock(
 	rec block.BlockRecord,
 	chunks []block.BlockChunkCommit,
 ) error {
-	var justCommitted bool
 	if err := s.WithTransaction(ctx, func(tx Transaction) error {
 		_, exists, err := tx.GetBlockRecord(ctx, rec.BlockID)
 		if err != nil {
@@ -81,14 +80,16 @@ func DefaultCommitBlock(
 				return err
 			}
 		}
-		justCommitted = true
 		return nil
 	}); err != nil {
 		return err
 	}
-	if !justCommitted {
-		return nil
-	}
+	// MarkSynced runs unconditionally after the transaction commits — even when
+	// the block record already existed (justCommitted would have been false in the
+	// old guard). MarkSynced is idempotent, so a no-op on a fully-committed block
+	// is safe. Crucially, this fixes the retry path: if a previous CommitBlock
+	// call committed the tx but then failed mid-MarkSynced, the retry must still
+	// reach this loop to write the pending remote locators.
 	for _, c := range chunks {
 		if err := s.MarkSynced(ctx, c.Hash, c.Remote); err != nil {
 			return err

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -48,14 +48,14 @@ type LocalChunkIndex interface {
 	DeleteLocalLocation(ctx context.Context, hash block.ContentHash) error
 }
 
-// CommitBlockImpl atomically writes a block record and all associated local
+// DefaultCommitBlock atomically writes a block record and all associated local
 // chunk locations within a single transaction, then (outside the tx) marks
 // each chunk synced via MarkSynced. Idempotent: if the block record already
 // exists the function is a no-op (LiveChunkCount is not double-counted).
 //
 // Exported so Store implementations in sub-packages can delegate CommitBlock
 // to this shared logic.
-func CommitBlockImpl(
+func DefaultCommitBlock(
 	ctx context.Context,
 	s interface {
 		Transactor

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -1,0 +1,98 @@
+package metadata
+
+import (
+	"context"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+// BlockRecordStore manages the lifecycle of log-blob block records.
+// Each record tracks the sync state, live chunk count, and hash of a
+// single block object. Implementations MUST be safe for concurrent use.
+type BlockRecordStore interface {
+	// PutBlockRecord writes or overwrites the block record for rec.BlockID.
+	PutBlockRecord(ctx context.Context, rec block.BlockRecord) error
+
+	// GetBlockRecord retrieves the block record for blockID.
+	// Returns (_, false, nil) when no record exists — absence is not an error.
+	GetBlockRecord(ctx context.Context, blockID string) (block.BlockRecord, bool, error)
+
+	// DeleteBlockRecord removes the block record for blockID.
+	// Idempotent: deleting an absent record returns nil.
+	DeleteBlockRecord(ctx context.Context, blockID string) error
+
+	// WalkBlockRecords calls fn for every stored block record in
+	// implementation-defined order. Returns the first non-nil error from fn
+	// or from the underlying store iterator.
+	WalkBlockRecords(ctx context.Context, fn func(block.BlockRecord) error) error
+
+	// DecrLiveChunkCount atomically decrements the LiveChunkCount for blockID
+	// by delta, flooring at 0. Returns the remaining count after the decrement.
+	// Returns an error if blockID does not exist.
+	DecrLiveChunkCount(ctx context.Context, blockID string, delta uint32) (remaining uint32, err error)
+}
+
+// LocalChunkIndex maps content hashes to their position in a local log-blob.
+// It mirrors SyncedHashStore in interface shape: idempotent put, safe miss on
+// get, idempotent delete.
+type LocalChunkIndex interface {
+	// PutLocalLocation records or overwrites the local position for hash.
+	PutLocalLocation(ctx context.Context, hash block.ContentHash, loc block.LocalChunkLocation) error
+
+	// GetLocalLocation returns the local position for hash.
+	// Returns (_, false, nil) when no entry exists.
+	GetLocalLocation(ctx context.Context, hash block.ContentHash) (block.LocalChunkLocation, bool, error)
+
+	// DeleteLocalLocation removes the local position for hash.
+	// Idempotent: deleting an absent entry returns nil.
+	DeleteLocalLocation(ctx context.Context, hash block.ContentHash) error
+}
+
+// CommitBlockImpl atomically writes a block record and all associated local
+// chunk locations within a single transaction, then (outside the tx) marks
+// each chunk synced via MarkSynced. Idempotent: if the block record already
+// exists the function is a no-op (LiveChunkCount is not double-counted).
+//
+// Exported so Store implementations in sub-packages can delegate CommitBlock
+// to this shared logic.
+func CommitBlockImpl(
+	ctx context.Context,
+	s interface {
+		Transactor
+		SyncedHashStore
+	},
+	rec block.BlockRecord,
+	chunks []block.BlockChunkCommit,
+) error {
+	var justCommitted bool
+	if err := s.WithTransaction(ctx, func(tx Transaction) error {
+		_, exists, err := tx.GetBlockRecord(ctx, rec.BlockID)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return nil // idempotent: already committed
+		}
+		if err := tx.PutBlockRecord(ctx, rec); err != nil {
+			return err
+		}
+		for _, c := range chunks {
+			if err := tx.PutLocalLocation(ctx, c.Hash, c.Local); err != nil {
+				return err
+			}
+		}
+		justCommitted = true
+		return nil
+	}); err != nil {
+		return err
+	}
+	if !justCommitted {
+		return nil
+	}
+	for _, c := range chunks {
+		if err := s.MarkSynced(ctx, c.Hash, c.Remote); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -256,11 +256,13 @@ type FileChunkStore = block.FileChunkStore
 // This interface combines Files, Shares, ServerConfig, FileChunkStore, and LockStore
 // interfaces to enable atomic operations across all metadata domains.
 type Transaction interface {
-	Files          // File CRUD operations
-	Shares         // Share management
-	ServerConfig   // Server configuration
-	FileChunkStore // Content-addressed block management
-	lock.LockStore // Lock persistence for NLM/SMB
+	Files            // File CRUD operations
+	Shares           // Share management
+	ServerConfig     // Server configuration
+	FileChunkStore   // Content-addressed block management
+	lock.LockStore   // Lock persistence for NLM/SMB
+	BlockRecordStore // Log-blob block record lifecycle
+	LocalChunkIndex  // Content-hash → local log-blob position
 }
 
 // ============================================================================
@@ -342,11 +344,14 @@ type FilesystemMeta struct {
 // Thread Safety:
 // Implementations must be safe for concurrent use by multiple goroutines.
 type Store interface {
-	Files          // File CRUD operations (non-transactional calls)
-	Shares         // Share lifecycle and handle management
-	ServerConfig   // Server configuration and capabilities
-	Transactor     // Transaction support for atomic operations
-	FileChunkStore // Content-addressed block management
+	Files            // File CRUD operations (non-transactional calls)
+	Shares           // Share lifecycle and handle management
+	ServerConfig     // Server configuration and capabilities
+	Transactor       // Transaction support for atomic operations
+	FileChunkStore   // Content-addressed block management
+	SyncedHashStore  // Per-hash remote-mirror state
+	BlockRecordStore // Log-blob block record lifecycle
+	LocalChunkIndex  // Content-hash → local log-blob position
 
 	// EnumerateFileChunks streams every FileChunk's ContentHash through fn
 	// in implementation-defined order. Returns the first non-nil error
@@ -428,6 +433,15 @@ type Store interface {
 	// Implementations MUST drain the result set before invoking fn
 	// (collect-then-call) and honor ctx.Done() throughout.
 	EnumerateLivePayloadIDs(ctx context.Context, fn func(payloadID string) error) error
+
+	// ========================================================================
+	// Block Packing
+	// ========================================================================
+
+	// CommitBlock atomically writes rec and the local location for each chunk,
+	// then marks every chunk synced with its remote locator. Idempotent on
+	// BlockID: if the block record already exists the call is a no-op.
+	CommitBlock(ctx context.Context, rec block.BlockRecord, chunks []block.BlockChunkCommit) error
 
 	// ========================================================================
 	// Usage Tracking

--- a/pkg/metadata/store/badger/block_record_store.go
+++ b/pkg/metadata/store/badger/block_record_store.go
@@ -2,83 +2,459 @@ package badger
 
 import (
 	"context"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
+	"fmt"
+
+	badgerdb "github.com/dgraph-io/badger/v4"
 
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-var errNotImplemented = errors.New("not implemented")
+// ============================================================================
+// Key Namespace
+// ============================================================================
+//
+// Block Record Store:
+//   br:{blockID}          value = JSON-encoded block.BlockRecord
+//
+// Local Chunk Index:
+//   li:{hex(hash)}        value = JSON-encoded block.LocalChunkLocation
+//
+// Hex-encoding the 32-byte hash keeps keys printable and unambiguous without
+// the separator complications that raw binary would require against the
+// br: prefix.
+// ============================================================================
 
-// BlockRecordStore stubs — not yet implemented for the badger backend.
+const (
+	prefixBlockRecord   = "br:"
+	prefixLocalChunkIdx = "li:"
+)
 
-func (tx *badgerTransaction) PutBlockRecord(_ context.Context, _ block.BlockRecord) error {
-	return errNotImplemented
+// keyBlockRecord builds the br:{blockID} key.
+func keyBlockRecord(blockID string) []byte {
+	return append([]byte(prefixBlockRecord), blockID...)
 }
 
-func (tx *badgerTransaction) GetBlockRecord(_ context.Context, _ string) (block.BlockRecord, bool, error) {
-	return block.BlockRecord{}, false, errNotImplemented
+// keyLocalChunk builds the li:{hex(hash)} key.
+func keyLocalChunk(hash block.ContentHash) []byte {
+	h := hex.EncodeToString(hash[:])
+	return append([]byte(prefixLocalChunkIdx), h...)
 }
 
-func (tx *badgerTransaction) DeleteBlockRecord(_ context.Context, _ string) error {
-	return errNotImplemented
+// ============================================================================
+// JSON value helpers
+// ============================================================================
+
+func encodeBlockRecord(rec block.BlockRecord) ([]byte, error) {
+	return json.Marshal(rec)
 }
 
-func (tx *badgerTransaction) WalkBlockRecords(_ context.Context, _ func(block.BlockRecord) error) error {
-	return errNotImplemented
+func decodeBlockRecord(b []byte) (block.BlockRecord, error) {
+	var rec block.BlockRecord
+	if err := json.Unmarshal(b, &rec); err != nil {
+		return block.BlockRecord{}, fmt.Errorf("badger: decode BlockRecord: %w", err)
+	}
+	return rec, nil
 }
 
-func (tx *badgerTransaction) DecrLiveChunkCount(_ context.Context, _ string, _ uint32) (uint32, error) {
-	return 0, errNotImplemented
+func encodeLocalChunkLocation(loc block.LocalChunkLocation) ([]byte, error) {
+	return json.Marshal(loc)
 }
 
-// LocalChunkIndex stubs — not yet implemented for the badger backend.
-
-func (tx *badgerTransaction) PutLocalLocation(_ context.Context, _ block.ContentHash, _ block.LocalChunkLocation) error {
-	return errNotImplemented
+func decodeLocalChunkLocation(b []byte) (block.LocalChunkLocation, error) {
+	var loc block.LocalChunkLocation
+	if err := json.Unmarshal(b, &loc); err != nil {
+		return block.LocalChunkLocation{}, fmt.Errorf("badger: decode LocalChunkLocation: %w", err)
+	}
+	return loc, nil
 }
 
-func (tx *badgerTransaction) GetLocalLocation(_ context.Context, _ block.ContentHash) (block.LocalChunkLocation, bool, error) {
-	return block.LocalChunkLocation{}, false, errNotImplemented
+// ============================================================================
+// Capability probe
+// ============================================================================
+
+// BlockRecordStoreEnabled implements storetest.BlockRecordStoreProvider.
+func (s *BadgerMetadataStore) BlockRecordStoreEnabled() bool { return true }
+
+// LocalChunkIndexEnabled implements storetest.LocalChunkIndexProvider.
+func (s *BadgerMetadataStore) LocalChunkIndexEnabled() bool { return true }
+
+// CommitBlockEnabled implements storetest.CommitBlockProvider.
+func (s *BadgerMetadataStore) CommitBlockEnabled() bool { return true }
+
+// ============================================================================
+// BlockRecordStore — transaction level
+// ============================================================================
+
+func (tx *badgerTransaction) PutBlockRecord(_ context.Context, rec block.BlockRecord) error {
+	data, err := encodeBlockRecord(rec)
+	if err != nil {
+		return fmt.Errorf("badger PutBlockRecord encode: %w", err)
+	}
+	return tx.txn.Set(keyBlockRecord(rec.BlockID), data)
 }
 
-func (tx *badgerTransaction) DeleteLocalLocation(_ context.Context, _ block.ContentHash) error {
-	return errNotImplemented
+func (tx *badgerTransaction) GetBlockRecord(_ context.Context, blockID string) (block.BlockRecord, bool, error) {
+	item, err := tx.txn.Get(keyBlockRecord(blockID))
+	if errors.Is(err, badgerdb.ErrKeyNotFound) {
+		return block.BlockRecord{}, false, nil
+	}
+	if err != nil {
+		return block.BlockRecord{}, false, fmt.Errorf("badger GetBlockRecord: %w", err)
+	}
+	var rec block.BlockRecord
+	if verr := item.Value(func(val []byte) error {
+		var decErr error
+		rec, decErr = decodeBlockRecord(val)
+		return decErr
+	}); verr != nil {
+		return block.BlockRecord{}, false, verr
+	}
+	return rec, true, nil
 }
 
-// Store-level stubs.
-
-func (s *BadgerMetadataStore) PutBlockRecord(_ context.Context, _ block.BlockRecord) error {
-	return errNotImplemented
+func (tx *badgerTransaction) DeleteBlockRecord(_ context.Context, blockID string) error {
+	err := tx.txn.Delete(keyBlockRecord(blockID))
+	if errors.Is(err, badgerdb.ErrKeyNotFound) {
+		return nil // idempotent
+	}
+	return err
 }
 
-func (s *BadgerMetadataStore) GetBlockRecord(_ context.Context, _ string) (block.BlockRecord, bool, error) {
-	return block.BlockRecord{}, false, errNotImplemented
+// WalkBlockRecords iterates br:* within the transaction. Collects all records
+// first, then calls fn outside iteration so the callback never runs with the
+// iterator open (mirrors EnumerateSynced's safe pattern).
+func (tx *badgerTransaction) WalkBlockRecords(_ context.Context, fn func(block.BlockRecord) error) error {
+	prefix := []byte(prefixBlockRecord)
+	opts := badgerdb.DefaultIteratorOptions
+	opts.Prefix = prefix
+
+	it := tx.txn.NewIterator(opts)
+
+	var recs []block.BlockRecord
+	for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+		item := it.Item()
+		var rec block.BlockRecord
+		if verr := item.Value(func(val []byte) error {
+			var decErr error
+			rec, decErr = decodeBlockRecord(val)
+			return decErr
+		}); verr != nil {
+			it.Close()
+			return verr
+		}
+		recs = append(recs, rec)
+	}
+	it.Close()
+
+	for _, rec := range recs {
+		if err := fn(rec); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-func (s *BadgerMetadataStore) DeleteBlockRecord(_ context.Context, _ string) error {
-	return errNotImplemented
+// DecrLiveChunkCount atomically decrements LiveChunkCount within the
+// transaction, flooring at 0. Returns the remaining count. Returns an error
+// if blockID does not exist.
+func (tx *badgerTransaction) DecrLiveChunkCount(_ context.Context, blockID string, delta uint32) (uint32, error) {
+	item, err := tx.txn.Get(keyBlockRecord(blockID))
+	if errors.Is(err, badgerdb.ErrKeyNotFound) {
+		return 0, fmt.Errorf("badger DecrLiveChunkCount: block %q not found", blockID)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("badger DecrLiveChunkCount get: %w", err)
+	}
+
+	var rec block.BlockRecord
+	if verr := item.Value(func(val []byte) error {
+		var decErr error
+		rec, decErr = decodeBlockRecord(val)
+		return decErr
+	}); verr != nil {
+		return 0, verr
+	}
+
+	if delta >= rec.LiveChunkCount {
+		rec.LiveChunkCount = 0
+	} else {
+		rec.LiveChunkCount -= delta
+	}
+
+	data, err := encodeBlockRecord(rec)
+	if err != nil {
+		return 0, fmt.Errorf("badger DecrLiveChunkCount encode: %w", err)
+	}
+	if err := tx.txn.Set(keyBlockRecord(blockID), data); err != nil {
+		return 0, fmt.Errorf("badger DecrLiveChunkCount set: %w", err)
+	}
+	return rec.LiveChunkCount, nil
 }
 
-func (s *BadgerMetadataStore) WalkBlockRecords(_ context.Context, _ func(block.BlockRecord) error) error {
-	return errNotImplemented
+// ============================================================================
+// LocalChunkIndex — transaction level
+// ============================================================================
+
+func (tx *badgerTransaction) PutLocalLocation(_ context.Context, hash block.ContentHash, loc block.LocalChunkLocation) error {
+	data, err := encodeLocalChunkLocation(loc)
+	if err != nil {
+		return fmt.Errorf("badger PutLocalLocation encode: %w", err)
+	}
+	return tx.txn.Set(keyLocalChunk(hash), data)
 }
 
-func (s *BadgerMetadataStore) DecrLiveChunkCount(_ context.Context, _ string, _ uint32) (uint32, error) {
-	return 0, errNotImplemented
+func (tx *badgerTransaction) GetLocalLocation(_ context.Context, hash block.ContentHash) (block.LocalChunkLocation, bool, error) {
+	item, err := tx.txn.Get(keyLocalChunk(hash))
+	if errors.Is(err, badgerdb.ErrKeyNotFound) {
+		return block.LocalChunkLocation{}, false, nil
+	}
+	if err != nil {
+		return block.LocalChunkLocation{}, false, fmt.Errorf("badger GetLocalLocation: %w", err)
+	}
+	var loc block.LocalChunkLocation
+	if verr := item.Value(func(val []byte) error {
+		var decErr error
+		loc, decErr = decodeLocalChunkLocation(val)
+		return decErr
+	}); verr != nil {
+		return block.LocalChunkLocation{}, false, verr
+	}
+	return loc, true, nil
 }
 
-func (s *BadgerMetadataStore) PutLocalLocation(_ context.Context, _ block.ContentHash, _ block.LocalChunkLocation) error {
-	return errNotImplemented
+func (tx *badgerTransaction) DeleteLocalLocation(_ context.Context, hash block.ContentHash) error {
+	err := tx.txn.Delete(keyLocalChunk(hash))
+	if errors.Is(err, badgerdb.ErrKeyNotFound) {
+		return nil // idempotent
+	}
+	return err
 }
 
-func (s *BadgerMetadataStore) GetLocalLocation(_ context.Context, _ block.ContentHash) (block.LocalChunkLocation, bool, error) {
-	return block.LocalChunkLocation{}, false, errNotImplemented
+// ============================================================================
+// BlockRecordStore — store level (delegate to Badger txns)
+// ============================================================================
+
+func (s *BadgerMetadataStore) PutBlockRecord(ctx context.Context, rec block.BlockRecord) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	data, err := encodeBlockRecord(rec)
+	if err != nil {
+		return fmt.Errorf("badger PutBlockRecord encode: %w", err)
+	}
+	if err := s.db.Update(func(txn *badgerdb.Txn) error {
+		return txn.Set(keyBlockRecord(rec.BlockID), data)
+	}); err != nil {
+		return fmt.Errorf("badger PutBlockRecord: %w", err)
+	}
+	return nil
 }
 
-func (s *BadgerMetadataStore) DeleteLocalLocation(_ context.Context, _ block.ContentHash) error {
-	return errNotImplemented
+func (s *BadgerMetadataStore) GetBlockRecord(ctx context.Context, blockID string) (block.BlockRecord, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return block.BlockRecord{}, false, err
+	}
+	var (
+		rec   block.BlockRecord
+		found bool
+	)
+	err := s.db.View(func(txn *badgerdb.Txn) error {
+		item, err := txn.Get(keyBlockRecord(blockID))
+		if errors.Is(err, badgerdb.ErrKeyNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		found = true
+		return item.Value(func(val []byte) error {
+			var decErr error
+			rec, decErr = decodeBlockRecord(val)
+			return decErr
+		})
+	})
+	if err != nil {
+		return block.BlockRecord{}, false, fmt.Errorf("badger GetBlockRecord: %w", err)
+	}
+	return rec, found, nil
 }
 
-func (s *BadgerMetadataStore) CommitBlock(_ context.Context, _ block.BlockRecord, _ []block.BlockChunkCommit) error {
-	return errNotImplemented
+func (s *BadgerMetadataStore) DeleteBlockRecord(ctx context.Context, blockID string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	err := s.db.Update(func(txn *badgerdb.Txn) error {
+		err := txn.Delete(keyBlockRecord(blockID))
+		if errors.Is(err, badgerdb.ErrKeyNotFound) {
+			return nil
+		}
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("badger DeleteBlockRecord: %w", err)
+	}
+	return nil
+}
+
+func (s *BadgerMetadataStore) WalkBlockRecords(ctx context.Context, fn func(block.BlockRecord) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	prefix := []byte(prefixBlockRecord)
+
+	var recs []block.BlockRecord
+	if err := s.db.View(func(txn *badgerdb.Txn) error {
+		opts := badgerdb.DefaultIteratorOptions
+		opts.Prefix = prefix
+		it := txn.NewIterator(opts)
+		defer it.Close()
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			item := it.Item()
+			var rec block.BlockRecord
+			if verr := item.Value(func(val []byte) error {
+				var decErr error
+				rec, decErr = decodeBlockRecord(val)
+				return decErr
+			}); verr != nil {
+				return verr
+			}
+			recs = append(recs, rec)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("badger WalkBlockRecords: %w", err)
+	}
+
+	for _, rec := range recs {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := fn(rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DecrLiveChunkCount atomically decrements LiveChunkCount for the named block,
+// flooring at 0. Returns the remaining count. Returns an error if blockID does
+// not exist. Uses a Badger Update transaction for atomicity (read-modify-write).
+func (s *BadgerMetadataStore) DecrLiveChunkCount(ctx context.Context, blockID string, delta uint32) (uint32, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	var remaining uint32
+	err := s.db.Update(func(txn *badgerdb.Txn) error {
+		item, err := txn.Get(keyBlockRecord(blockID))
+		if errors.Is(err, badgerdb.ErrKeyNotFound) {
+			return fmt.Errorf("badger DecrLiveChunkCount: block %q not found", blockID)
+		}
+		if err != nil {
+			return err
+		}
+		var rec block.BlockRecord
+		if verr := item.Value(func(val []byte) error {
+			var decErr error
+			rec, decErr = decodeBlockRecord(val)
+			return decErr
+		}); verr != nil {
+			return verr
+		}
+		if delta >= rec.LiveChunkCount {
+			rec.LiveChunkCount = 0
+		} else {
+			rec.LiveChunkCount -= delta
+		}
+		remaining = rec.LiveChunkCount
+		data, encErr := encodeBlockRecord(rec)
+		if encErr != nil {
+			return encErr
+		}
+		return txn.Set(keyBlockRecord(blockID), data)
+	})
+	if err != nil {
+		return 0, fmt.Errorf("badger DecrLiveChunkCount: %w", err)
+	}
+	return remaining, nil
+}
+
+// ============================================================================
+// LocalChunkIndex — store level
+// ============================================================================
+
+func (s *BadgerMetadataStore) PutLocalLocation(ctx context.Context, hash block.ContentHash, loc block.LocalChunkLocation) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	data, err := encodeLocalChunkLocation(loc)
+	if err != nil {
+		return fmt.Errorf("badger PutLocalLocation encode: %w", err)
+	}
+	if err := s.db.Update(func(txn *badgerdb.Txn) error {
+		return txn.Set(keyLocalChunk(hash), data)
+	}); err != nil {
+		return fmt.Errorf("badger PutLocalLocation: %w", err)
+	}
+	return nil
+}
+
+func (s *BadgerMetadataStore) GetLocalLocation(ctx context.Context, hash block.ContentHash) (block.LocalChunkLocation, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return block.LocalChunkLocation{}, false, err
+	}
+	var (
+		loc   block.LocalChunkLocation
+		found bool
+	)
+	err := s.db.View(func(txn *badgerdb.Txn) error {
+		item, err := txn.Get(keyLocalChunk(hash))
+		if errors.Is(err, badgerdb.ErrKeyNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		found = true
+		return item.Value(func(val []byte) error {
+			var decErr error
+			loc, decErr = decodeLocalChunkLocation(val)
+			return decErr
+		})
+	})
+	if err != nil {
+		return block.LocalChunkLocation{}, false, fmt.Errorf("badger GetLocalLocation: %w", err)
+	}
+	return loc, found, nil
+}
+
+func (s *BadgerMetadataStore) DeleteLocalLocation(ctx context.Context, hash block.ContentHash) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	err := s.db.Update(func(txn *badgerdb.Txn) error {
+		err := txn.Delete(keyLocalChunk(hash))
+		if errors.Is(err, badgerdb.ErrKeyNotFound) {
+			return nil
+		}
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("badger DeleteLocalLocation: %w", err)
+	}
+	return nil
+}
+
+// ============================================================================
+// CommitBlock — delegate to shared DefaultCommitBlock logic
+// ============================================================================
+
+// CommitBlock atomically writes the block record and all local chunk locations
+// within a single transaction (via DefaultCommitBlock), then marks each chunk
+// synced. Idempotent: a second call for an already-committed block is a no-op.
+func (s *BadgerMetadataStore) CommitBlock(ctx context.Context, rec block.BlockRecord, chunks []block.BlockChunkCommit) error {
+	return metadata.DefaultCommitBlock(ctx, s, rec, chunks)
 }

--- a/pkg/metadata/store/badger/block_record_store.go
+++ b/pkg/metadata/store/badger/block_record_store.go
@@ -1,0 +1,84 @@
+package badger
+
+import (
+	"context"
+	"errors"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+var errNotImplemented = errors.New("not implemented")
+
+// BlockRecordStore stubs — not yet implemented for the badger backend.
+
+func (tx *badgerTransaction) PutBlockRecord(_ context.Context, _ block.BlockRecord) error {
+	return errNotImplemented
+}
+
+func (tx *badgerTransaction) GetBlockRecord(_ context.Context, _ string) (block.BlockRecord, bool, error) {
+	return block.BlockRecord{}, false, errNotImplemented
+}
+
+func (tx *badgerTransaction) DeleteBlockRecord(_ context.Context, _ string) error {
+	return errNotImplemented
+}
+
+func (tx *badgerTransaction) WalkBlockRecords(_ context.Context, _ func(block.BlockRecord) error) error {
+	return errNotImplemented
+}
+
+func (tx *badgerTransaction) DecrLiveChunkCount(_ context.Context, _ string, _ uint32) (uint32, error) {
+	return 0, errNotImplemented
+}
+
+// LocalChunkIndex stubs — not yet implemented for the badger backend.
+
+func (tx *badgerTransaction) PutLocalLocation(_ context.Context, _ block.ContentHash, _ block.LocalChunkLocation) error {
+	return errNotImplemented
+}
+
+func (tx *badgerTransaction) GetLocalLocation(_ context.Context, _ block.ContentHash) (block.LocalChunkLocation, bool, error) {
+	return block.LocalChunkLocation{}, false, errNotImplemented
+}
+
+func (tx *badgerTransaction) DeleteLocalLocation(_ context.Context, _ block.ContentHash) error {
+	return errNotImplemented
+}
+
+// Store-level stubs.
+
+func (s *BadgerMetadataStore) PutBlockRecord(_ context.Context, _ block.BlockRecord) error {
+	return errNotImplemented
+}
+
+func (s *BadgerMetadataStore) GetBlockRecord(_ context.Context, _ string) (block.BlockRecord, bool, error) {
+	return block.BlockRecord{}, false, errNotImplemented
+}
+
+func (s *BadgerMetadataStore) DeleteBlockRecord(_ context.Context, _ string) error {
+	return errNotImplemented
+}
+
+func (s *BadgerMetadataStore) WalkBlockRecords(_ context.Context, _ func(block.BlockRecord) error) error {
+	return errNotImplemented
+}
+
+func (s *BadgerMetadataStore) DecrLiveChunkCount(_ context.Context, _ string, _ uint32) (uint32, error) {
+	return 0, errNotImplemented
+}
+
+func (s *BadgerMetadataStore) PutLocalLocation(_ context.Context, _ block.ContentHash, _ block.LocalChunkLocation) error {
+	return errNotImplemented
+}
+
+func (s *BadgerMetadataStore) GetLocalLocation(_ context.Context, _ block.ContentHash) (block.LocalChunkLocation, bool, error) {
+	return block.LocalChunkLocation{}, false, errNotImplemented
+}
+
+func (s *BadgerMetadataStore) DeleteLocalLocation(_ context.Context, _ block.ContentHash) error {
+	return errNotImplemented
+}
+
+func (s *BadgerMetadataStore) CommitBlock(_ context.Context, _ block.BlockRecord, _ []block.BlockChunkCommit) error {
+	return errNotImplemented
+}

--- a/pkg/metadata/store/badger/block_record_store.go
+++ b/pkg/metadata/store/badger/block_record_store.go
@@ -132,23 +132,31 @@ func (tx *badgerTransaction) WalkBlockRecords(_ context.Context, fn func(block.B
 	opts := badgerdb.DefaultIteratorOptions
 	opts.Prefix = prefix
 
-	it := tx.txn.NewIterator(opts)
-
-	var recs []block.BlockRecord
-	for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
-		item := it.Item()
-		var rec block.BlockRecord
-		if verr := item.Value(func(val []byte) error {
-			var decErr error
-			rec, decErr = decodeBlockRecord(val)
-			return decErr
-		}); verr != nil {
-			it.Close()
-			return verr
+	// Collect inside an inner closure so the iterator is closed by defer
+	// (panic-safe) yet still closed before fn runs — fn must never execute with
+	// the iterator open.
+	collect := func() ([]block.BlockRecord, error) {
+		it := tx.txn.NewIterator(opts)
+		defer it.Close()
+		var recs []block.BlockRecord
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			item := it.Item()
+			var rec block.BlockRecord
+			if verr := item.Value(func(val []byte) error {
+				var decErr error
+				rec, decErr = decodeBlockRecord(val)
+				return decErr
+			}); verr != nil {
+				return nil, verr
+			}
+			recs = append(recs, rec)
 		}
-		recs = append(recs, rec)
+		return recs, nil
 	}
-	it.Close()
+	recs, err := collect()
+	if err != nil {
+		return err
+	}
 
 	for _, rec := range recs {
 		if err := fn(rec); err != nil {
@@ -342,13 +350,15 @@ func (s *BadgerMetadataStore) WalkBlockRecords(ctx context.Context, fn func(bloc
 
 // DecrLiveChunkCount atomically decrements LiveChunkCount for the named block,
 // flooring at 0. Returns the remaining count. Returns an error if blockID does
-// not exist. Uses a Badger Update transaction for atomicity (read-modify-write).
+// not exist. The read-modify-write runs under updateWithConflictRetry so a
+// Badger SSI ErrConflict from a concurrent decrement is retried internally
+// rather than surfaced to the GC caller (which has no retry of its own).
 func (s *BadgerMetadataStore) DecrLiveChunkCount(ctx context.Context, blockID string, delta uint32) (uint32, error) {
 	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
 	var remaining uint32
-	err := s.db.Update(func(txn *badgerdb.Txn) error {
+	err := s.updateWithConflictRetry(ctx, func(txn *badgerdb.Txn) error {
 		item, err := txn.Get(keyBlockRecord(blockID))
 		if errors.Is(err, badgerdb.ErrKeyNotFound) {
 			return fmt.Errorf("badger DecrLiveChunkCount: block %q not found", blockID)
@@ -458,3 +468,13 @@ func (s *BadgerMetadataStore) DeleteLocalLocation(ctx context.Context, hash bloc
 func (s *BadgerMetadataStore) CommitBlock(ctx context.Context, rec block.BlockRecord, chunks []block.BlockChunkCommit) error {
 	return metadata.DefaultCommitBlock(ctx, s, rec, chunks)
 }
+
+// Compile-time guards: both the store and its transaction implement the new
+// block-record and local-index contracts (store-level is not otherwise checked
+// via the Transaction interface).
+var (
+	_ metadata.BlockRecordStore = (*BadgerMetadataStore)(nil)
+	_ metadata.BlockRecordStore = (*badgerTransaction)(nil)
+	_ metadata.LocalChunkIndex  = (*BadgerMetadataStore)(nil)
+	_ metadata.LocalChunkIndex  = (*badgerTransaction)(nil)
+)

--- a/pkg/metadata/store/badger/block_record_store.go
+++ b/pkg/metadata/store/badger/block_record_store.go
@@ -73,19 +73,6 @@ func decodeLocalChunkLocation(b []byte) (block.LocalChunkLocation, error) {
 }
 
 // ============================================================================
-// Capability probe
-// ============================================================================
-
-// BlockRecordStoreEnabled implements storetest.BlockRecordStoreProvider.
-func (s *BadgerMetadataStore) BlockRecordStoreEnabled() bool { return true }
-
-// LocalChunkIndexEnabled implements storetest.LocalChunkIndexProvider.
-func (s *BadgerMetadataStore) LocalChunkIndexEnabled() bool { return true }
-
-// CommitBlockEnabled implements storetest.CommitBlockProvider.
-func (s *BadgerMetadataStore) CommitBlockEnabled() bool { return true }
-
-// ============================================================================
 // BlockRecordStore — transaction level
 // ============================================================================
 

--- a/pkg/metadata/store/memory/block_record_store.go
+++ b/pkg/metadata/store/memory/block_record_store.go
@@ -160,7 +160,7 @@ func (s *MemoryMetadataStore) DeleteLocalLocation(ctx context.Context, hash bloc
 // ============================================================================
 
 // CommitBlock atomically writes rec and all chunk local locations, then marks
-// each chunk synced. Delegates to CommitBlockImpl for idempotency logic.
+// each chunk synced. Delegates to DefaultCommitBlock for idempotency logic.
 func (s *MemoryMetadataStore) CommitBlock(ctx context.Context, rec block.BlockRecord, chunks []block.BlockChunkCommit) error {
-	return metadata.CommitBlockImpl(ctx, s, rec, chunks)
+	return metadata.DefaultCommitBlock(ctx, s, rec, chunks)
 }

--- a/pkg/metadata/store/memory/block_record_store.go
+++ b/pkg/metadata/store/memory/block_record_store.go
@@ -1,0 +1,81 @@
+package memory
+
+import (
+	"context"
+	"errors"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// Transaction-level stubs — replaced by full implementation in Phase 4.
+
+func (tx *memoryTransaction) PutBlockRecord(_ context.Context, _ block.BlockRecord) error {
+	return errors.New("not implemented")
+}
+
+func (tx *memoryTransaction) GetBlockRecord(_ context.Context, _ string) (block.BlockRecord, bool, error) {
+	return block.BlockRecord{}, false, errors.New("not implemented")
+}
+
+func (tx *memoryTransaction) DeleteBlockRecord(_ context.Context, _ string) error {
+	return errors.New("not implemented")
+}
+
+func (tx *memoryTransaction) WalkBlockRecords(_ context.Context, _ func(block.BlockRecord) error) error {
+	return errors.New("not implemented")
+}
+
+func (tx *memoryTransaction) DecrLiveChunkCount(_ context.Context, _ string, _ uint32) (uint32, error) {
+	return 0, errors.New("not implemented")
+}
+
+func (tx *memoryTransaction) PutLocalLocation(_ context.Context, _ block.ContentHash, _ block.LocalChunkLocation) error {
+	return errors.New("not implemented")
+}
+
+func (tx *memoryTransaction) GetLocalLocation(_ context.Context, _ block.ContentHash) (block.LocalChunkLocation, bool, error) {
+	return block.LocalChunkLocation{}, false, errors.New("not implemented")
+}
+
+func (tx *memoryTransaction) DeleteLocalLocation(_ context.Context, _ block.ContentHash) error {
+	return errors.New("not implemented")
+}
+
+// Store-level stubs — replaced by full implementation in Phase 4.
+
+func (s *MemoryMetadataStore) PutBlockRecord(_ context.Context, _ block.BlockRecord) error {
+	return errors.New("not implemented")
+}
+
+func (s *MemoryMetadataStore) GetBlockRecord(_ context.Context, _ string) (block.BlockRecord, bool, error) {
+	return block.BlockRecord{}, false, errors.New("not implemented")
+}
+
+func (s *MemoryMetadataStore) DeleteBlockRecord(_ context.Context, _ string) error {
+	return errors.New("not implemented")
+}
+
+func (s *MemoryMetadataStore) WalkBlockRecords(_ context.Context, _ func(block.BlockRecord) error) error {
+	return errors.New("not implemented")
+}
+
+func (s *MemoryMetadataStore) DecrLiveChunkCount(_ context.Context, _ string, _ uint32) (uint32, error) {
+	return 0, errors.New("not implemented")
+}
+
+func (s *MemoryMetadataStore) PutLocalLocation(_ context.Context, _ block.ContentHash, _ block.LocalChunkLocation) error {
+	return errors.New("not implemented")
+}
+
+func (s *MemoryMetadataStore) GetLocalLocation(_ context.Context, _ block.ContentHash) (block.LocalChunkLocation, bool, error) {
+	return block.LocalChunkLocation{}, false, errors.New("not implemented")
+}
+
+func (s *MemoryMetadataStore) DeleteLocalLocation(_ context.Context, _ block.ContentHash) error {
+	return errors.New("not implemented")
+}
+
+func (s *MemoryMetadataStore) CommitBlock(ctx context.Context, rec block.BlockRecord, chunks []block.BlockChunkCommit) error {
+	return metadata.CommitBlockImpl(ctx, s, rec, chunks)
+}

--- a/pkg/metadata/store/memory/block_record_store.go
+++ b/pkg/metadata/store/memory/block_record_store.go
@@ -2,80 +2,165 @@ package memory
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// Transaction-level stubs — replaced by full implementation in Phase 4.
+// BlockRecordStoreEnabled implements storetest.BlockRecordStoreProvider.
+func (s *MemoryMetadataStore) BlockRecordStoreEnabled() bool { return true }
 
-func (tx *memoryTransaction) PutBlockRecord(_ context.Context, _ block.BlockRecord) error {
-	return errors.New("not implemented")
+// LocalChunkIndexEnabled implements storetest.LocalChunkIndexProvider.
+func (s *MemoryMetadataStore) LocalChunkIndexEnabled() bool { return true }
+
+// CommitBlockEnabled implements storetest.CommitBlockProvider.
+func (s *MemoryMetadataStore) CommitBlockEnabled() bool { return true }
+
+// ============================================================================
+// Transaction-level BlockRecordStore (runs under store.mu write lock)
+// ============================================================================
+
+func (tx *memoryTransaction) PutBlockRecord(_ context.Context, rec block.BlockRecord) error {
+	cp := rec
+	tx.store.blockRecords[rec.BlockID] = &cp
+	return nil
 }
 
-func (tx *memoryTransaction) GetBlockRecord(_ context.Context, _ string) (block.BlockRecord, bool, error) {
-	return block.BlockRecord{}, false, errors.New("not implemented")
+func (tx *memoryTransaction) GetBlockRecord(_ context.Context, blockID string) (block.BlockRecord, bool, error) {
+	r, ok := tx.store.blockRecords[blockID]
+	if !ok {
+		return block.BlockRecord{}, false, nil
+	}
+	return *r, true, nil
 }
 
-func (tx *memoryTransaction) DeleteBlockRecord(_ context.Context, _ string) error {
-	return errors.New("not implemented")
+func (tx *memoryTransaction) DeleteBlockRecord(_ context.Context, blockID string) error {
+	delete(tx.store.blockRecords, blockID)
+	return nil
 }
 
-func (tx *memoryTransaction) WalkBlockRecords(_ context.Context, _ func(block.BlockRecord) error) error {
-	return errors.New("not implemented")
+func (tx *memoryTransaction) WalkBlockRecords(_ context.Context, fn func(block.BlockRecord) error) error {
+	for _, r := range tx.store.blockRecords {
+		if err := fn(*r); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-func (tx *memoryTransaction) DecrLiveChunkCount(_ context.Context, _ string, _ uint32) (uint32, error) {
-	return 0, errors.New("not implemented")
+func (tx *memoryTransaction) DecrLiveChunkCount(_ context.Context, blockID string, delta uint32) (uint32, error) {
+	r, ok := tx.store.blockRecords[blockID]
+	if !ok {
+		return 0, fmt.Errorf("block record %q not found", blockID)
+	}
+	if delta >= r.LiveChunkCount {
+		r.LiveChunkCount = 0
+	} else {
+		r.LiveChunkCount -= delta
+	}
+	return r.LiveChunkCount, nil
 }
 
-func (tx *memoryTransaction) PutLocalLocation(_ context.Context, _ block.ContentHash, _ block.LocalChunkLocation) error {
-	return errors.New("not implemented")
+// Transaction-level LocalChunkIndex (runs under store.mu write lock)
+
+func (tx *memoryTransaction) PutLocalLocation(_ context.Context, hash block.ContentHash, loc block.LocalChunkLocation) error {
+	tx.store.localChunks[hash] = loc
+	return nil
 }
 
-func (tx *memoryTransaction) GetLocalLocation(_ context.Context, _ block.ContentHash) (block.LocalChunkLocation, bool, error) {
-	return block.LocalChunkLocation{}, false, errors.New("not implemented")
+func (tx *memoryTransaction) GetLocalLocation(_ context.Context, hash block.ContentHash) (block.LocalChunkLocation, bool, error) {
+	loc, ok := tx.store.localChunks[hash]
+	if !ok {
+		return block.LocalChunkLocation{}, false, nil
+	}
+	return loc, true, nil
 }
 
-func (tx *memoryTransaction) DeleteLocalLocation(_ context.Context, _ block.ContentHash) error {
-	return errors.New("not implemented")
+func (tx *memoryTransaction) DeleteLocalLocation(_ context.Context, hash block.ContentHash) error {
+	delete(tx.store.localChunks, hash)
+	return nil
 }
 
-// Store-level stubs — replaced by full implementation in Phase 4.
+// ============================================================================
+// Store-level BlockRecordStore (delegates through WithTransaction for writes)
+// ============================================================================
 
-func (s *MemoryMetadataStore) PutBlockRecord(_ context.Context, _ block.BlockRecord) error {
-	return errors.New("not implemented")
+func (s *MemoryMetadataStore) PutBlockRecord(ctx context.Context, rec block.BlockRecord) error {
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.PutBlockRecord(ctx, rec)
+	})
 }
 
-func (s *MemoryMetadataStore) GetBlockRecord(_ context.Context, _ string) (block.BlockRecord, bool, error) {
-	return block.BlockRecord{}, false, errors.New("not implemented")
+func (s *MemoryMetadataStore) GetBlockRecord(ctx context.Context, blockID string) (block.BlockRecord, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	r, ok := s.blockRecords[blockID]
+	if !ok {
+		return block.BlockRecord{}, false, nil
+	}
+	return *r, true, nil
 }
 
-func (s *MemoryMetadataStore) DeleteBlockRecord(_ context.Context, _ string) error {
-	return errors.New("not implemented")
+func (s *MemoryMetadataStore) DeleteBlockRecord(ctx context.Context, blockID string) error {
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.DeleteBlockRecord(ctx, blockID)
+	})
 }
 
-func (s *MemoryMetadataStore) WalkBlockRecords(_ context.Context, _ func(block.BlockRecord) error) error {
-	return errors.New("not implemented")
+func (s *MemoryMetadataStore) WalkBlockRecords(ctx context.Context, fn func(block.BlockRecord) error) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, r := range s.blockRecords {
+		if err := fn(*r); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-func (s *MemoryMetadataStore) DecrLiveChunkCount(_ context.Context, _ string, _ uint32) (uint32, error) {
-	return 0, errors.New("not implemented")
+func (s *MemoryMetadataStore) DecrLiveChunkCount(ctx context.Context, blockID string, delta uint32) (uint32, error) {
+	var remaining uint32
+	err := s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		var err error
+		remaining, err = tx.DecrLiveChunkCount(ctx, blockID, delta)
+		return err
+	})
+	return remaining, err
 }
 
-func (s *MemoryMetadataStore) PutLocalLocation(_ context.Context, _ block.ContentHash, _ block.LocalChunkLocation) error {
-	return errors.New("not implemented")
+// ============================================================================
+// Store-level LocalChunkIndex
+// ============================================================================
+
+func (s *MemoryMetadataStore) PutLocalLocation(ctx context.Context, hash block.ContentHash, loc block.LocalChunkLocation) error {
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.PutLocalLocation(ctx, hash, loc)
+	})
 }
 
-func (s *MemoryMetadataStore) GetLocalLocation(_ context.Context, _ block.ContentHash) (block.LocalChunkLocation, bool, error) {
-	return block.LocalChunkLocation{}, false, errors.New("not implemented")
+func (s *MemoryMetadataStore) GetLocalLocation(ctx context.Context, hash block.ContentHash) (block.LocalChunkLocation, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	loc, ok := s.localChunks[hash]
+	if !ok {
+		return block.LocalChunkLocation{}, false, nil
+	}
+	return loc, true, nil
 }
 
-func (s *MemoryMetadataStore) DeleteLocalLocation(_ context.Context, _ block.ContentHash) error {
-	return errors.New("not implemented")
+func (s *MemoryMetadataStore) DeleteLocalLocation(ctx context.Context, hash block.ContentHash) error {
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.DeleteLocalLocation(ctx, hash)
+	})
 }
 
+// ============================================================================
+// CommitBlock
+// ============================================================================
+
+// CommitBlock atomically writes rec and all chunk local locations, then marks
+// each chunk synced. Delegates to CommitBlockImpl for idempotency logic.
 func (s *MemoryMetadataStore) CommitBlock(ctx context.Context, rec block.BlockRecord, chunks []block.BlockChunkCommit) error {
 	return metadata.CommitBlockImpl(ctx, s, rec, chunks)
 }

--- a/pkg/metadata/store/memory/block_record_store.go
+++ b/pkg/metadata/store/memory/block_record_store.go
@@ -8,15 +8,6 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// BlockRecordStoreEnabled implements storetest.BlockRecordStoreProvider.
-func (s *MemoryMetadataStore) BlockRecordStoreEnabled() bool { return true }
-
-// LocalChunkIndexEnabled implements storetest.LocalChunkIndexProvider.
-func (s *MemoryMetadataStore) LocalChunkIndexEnabled() bool { return true }
-
-// CommitBlockEnabled implements storetest.CommitBlockProvider.
-func (s *MemoryMetadataStore) CommitBlockEnabled() bool { return true }
-
 // ============================================================================
 // Transaction-level BlockRecordStore (runs under store.mu write lock)
 // ============================================================================

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -288,6 +288,11 @@ type MemoryMetadataStore struct {
 	// output). FindByObjectID resolves through this map -> files lookup
 	// chain (added in).
 	objectIndex map[block.ContentHash]string
+
+	// blockRecords maps BlockID → BlockRecord. Protected by mu.
+	blockRecords map[string]*block.BlockRecord
+	// localChunks maps ContentHash → LocalChunkLocation. Protected by mu.
+	localChunks map[block.ContentHash]block.LocalChunkLocation
 }
 
 // MemoryMetadataStoreConfig contains configuration for creating a memory metadata store.
@@ -360,6 +365,9 @@ func NewMemoryMetadataStore(config MemoryMetadataStoreConfig) *MemoryMetadataSto
 		// per-identity quota usage counters.
 		userUsage:  make(map[uint32]*metadata.UsageStat),
 		groupUsage: make(map[uint32]*metadata.UsageStat),
+		// Block packing record store.
+		blockRecords: make(map[string]*block.BlockRecord),
+		localChunks:  make(map[block.ContentHash]block.LocalChunkLocation),
 	}
 
 	return store

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -88,6 +88,9 @@ type txSnapshot struct {
 	hashIndex        map[metadata.ContentHash]string
 	serverConfig     metadata.MetadataServerConfig
 	capabilities     metadata.FilesystemCapabilities
+	// Block packing snapshots.
+	blockRecords map[string]*block.BlockRecord
+	localChunks  map[block.ContentHash]block.LocalChunkLocation
 }
 
 // snapshotLocked captures the store's mutable maps. Caller MUST hold the
@@ -109,6 +112,8 @@ func (store *MemoryMetadataStore) snapshotLocked() *txSnapshot {
 		objectIndex:   maps.Clone(store.objectIndex),
 		serverConfig:  store.serverConfig,
 		capabilities:  store.capabilities,
+		blockRecords:  make(map[string]*block.BlockRecord, len(store.blockRecords)),
+		localChunks:   maps.Clone(store.localChunks),
 	}
 	for k, v := range store.shares {
 		sc := *v
@@ -128,6 +133,10 @@ func (store *MemoryMetadataStore) snapshotLocked() *txSnapshot {
 			snap.blocks[k] = &bc
 		}
 	}
+	for k, v := range store.blockRecords {
+		rc := *v
+		snap.blockRecords[k] = &rc
+	}
 	return snap
 }
 
@@ -143,6 +152,8 @@ func (store *MemoryMetadataStore) restoreLocked(snap *txSnapshot) {
 	store.objectIndex = snap.objectIndex
 	store.serverConfig = snap.serverConfig
 	store.capabilities = snap.capabilities
+	store.blockRecords = snap.blockRecords
+	store.localChunks = snap.localChunks
 	switch {
 	case snap.hadFileChunkData:
 		// fileChunkData existed at snapshot time — restore its maps to the

--- a/pkg/metadata/store/postgres/block_record_store.go
+++ b/pkg/metadata/store/postgres/block_record_store.go
@@ -1,0 +1,84 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+var errNotImplemented = errors.New("not implemented")
+
+// BlockRecordStore stubs — not yet implemented for the postgres backend.
+
+func (tx *postgresTransaction) PutBlockRecord(_ context.Context, _ block.BlockRecord) error {
+	return errNotImplemented
+}
+
+func (tx *postgresTransaction) GetBlockRecord(_ context.Context, _ string) (block.BlockRecord, bool, error) {
+	return block.BlockRecord{}, false, errNotImplemented
+}
+
+func (tx *postgresTransaction) DeleteBlockRecord(_ context.Context, _ string) error {
+	return errNotImplemented
+}
+
+func (tx *postgresTransaction) WalkBlockRecords(_ context.Context, _ func(block.BlockRecord) error) error {
+	return errNotImplemented
+}
+
+func (tx *postgresTransaction) DecrLiveChunkCount(_ context.Context, _ string, _ uint32) (uint32, error) {
+	return 0, errNotImplemented
+}
+
+// LocalChunkIndex stubs — not yet implemented for the postgres backend.
+
+func (tx *postgresTransaction) PutLocalLocation(_ context.Context, _ block.ContentHash, _ block.LocalChunkLocation) error {
+	return errNotImplemented
+}
+
+func (tx *postgresTransaction) GetLocalLocation(_ context.Context, _ block.ContentHash) (block.LocalChunkLocation, bool, error) {
+	return block.LocalChunkLocation{}, false, errNotImplemented
+}
+
+func (tx *postgresTransaction) DeleteLocalLocation(_ context.Context, _ block.ContentHash) error {
+	return errNotImplemented
+}
+
+// Store-level stubs.
+
+func (s *PostgresMetadataStore) PutBlockRecord(_ context.Context, _ block.BlockRecord) error {
+	return errNotImplemented
+}
+
+func (s *PostgresMetadataStore) GetBlockRecord(_ context.Context, _ string) (block.BlockRecord, bool, error) {
+	return block.BlockRecord{}, false, errNotImplemented
+}
+
+func (s *PostgresMetadataStore) DeleteBlockRecord(_ context.Context, _ string) error {
+	return errNotImplemented
+}
+
+func (s *PostgresMetadataStore) WalkBlockRecords(_ context.Context, _ func(block.BlockRecord) error) error {
+	return errNotImplemented
+}
+
+func (s *PostgresMetadataStore) DecrLiveChunkCount(_ context.Context, _ string, _ uint32) (uint32, error) {
+	return 0, errNotImplemented
+}
+
+func (s *PostgresMetadataStore) PutLocalLocation(_ context.Context, _ block.ContentHash, _ block.LocalChunkLocation) error {
+	return errNotImplemented
+}
+
+func (s *PostgresMetadataStore) GetLocalLocation(_ context.Context, _ block.ContentHash) (block.LocalChunkLocation, bool, error) {
+	return block.LocalChunkLocation{}, false, errNotImplemented
+}
+
+func (s *PostgresMetadataStore) DeleteLocalLocation(_ context.Context, _ block.ContentHash) error {
+	return errNotImplemented
+}
+
+func (s *PostgresMetadataStore) CommitBlock(_ context.Context, _ block.BlockRecord, _ []block.BlockChunkCommit) error {
+	return errNotImplemented
+}

--- a/pkg/metadata/store/postgres/block_record_store.go
+++ b/pkg/metadata/store/postgres/block_record_store.go
@@ -1,84 +1,329 @@
+// Block-record and local-chunk-index implementation for the PostgreSQL
+// metadata backend. See metadata.BlockRecordStore and metadata.LocalChunkIndex
+// for the contracts; pkg/metadata/store/memory/ is the canonical semantic
+// reference.
 package postgres
 
 import (
 	"context"
 	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
 
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-var errNotImplemented = errors.New("not implemented")
+// Compile-time assertions: the store and its transaction both satisfy the
+// two capability interfaces. The type-assertion probe in the conformance
+// suite verifies them at runtime once the capability flags return true.
+var _ metadata.BlockRecordStore = (*PostgresMetadataStore)(nil)
+var _ metadata.LocalChunkIndex = (*PostgresMetadataStore)(nil)
+var _ metadata.BlockRecordStore = (*postgresTransaction)(nil)
+var _ metadata.LocalChunkIndex = (*postgresTransaction)(nil)
 
-// BlockRecordStore stubs — not yet implemented for the postgres backend.
+// ============================================================================
+// Capability probes
+// ============================================================================
 
-func (tx *postgresTransaction) PutBlockRecord(_ context.Context, _ block.BlockRecord) error {
-	return errNotImplemented
+// BlockRecordStoreEnabled signals that the postgres backend implements
+// metadata.BlockRecordStore (picked up by the conformance type-assertion probe).
+func (s *PostgresMetadataStore) BlockRecordStoreEnabled() bool { return true }
+
+// LocalChunkIndexEnabled signals that the postgres backend implements
+// metadata.LocalChunkIndex.
+func (s *PostgresMetadataStore) LocalChunkIndexEnabled() bool { return true }
+
+// CommitBlockEnabled signals that the postgres backend implements CommitBlock.
+func (s *PostgresMetadataStore) CommitBlockEnabled() bool { return true }
+
+// ============================================================================
+// Transaction-level BlockRecordStore
+// ============================================================================
+
+func (tx *postgresTransaction) PutBlockRecord(ctx context.Context, rec block.BlockRecord) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	_, err := tx.tx.Exec(ctx, `
+		INSERT INTO block_records (block_id, block_hash, length, live_chunk_count, sync_state)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (block_id) DO UPDATE SET
+			block_hash       = EXCLUDED.block_hash,
+			length           = EXCLUDED.length,
+			live_chunk_count = EXCLUDED.live_chunk_count,
+			sync_state       = EXCLUDED.sync_state`,
+		rec.BlockID, rec.BlockHash[:], rec.Length, rec.LiveChunkCount, int16(rec.SyncState),
+	)
+	if err != nil {
+		return fmt.Errorf("postgres PutBlockRecord: %w", err)
+	}
+	return nil
 }
 
-func (tx *postgresTransaction) GetBlockRecord(_ context.Context, _ string) (block.BlockRecord, bool, error) {
-	return block.BlockRecord{}, false, errNotImplemented
+func (tx *postgresTransaction) GetBlockRecord(ctx context.Context, blockID string) (block.BlockRecord, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return block.BlockRecord{}, false, err
+	}
+	return scanBlockRecord(tx.tx.QueryRow(ctx,
+		`SELECT block_id, block_hash, length, live_chunk_count, sync_state
+		 FROM block_records WHERE block_id = $1`,
+		blockID,
+	))
 }
 
-func (tx *postgresTransaction) DeleteBlockRecord(_ context.Context, _ string) error {
-	return errNotImplemented
+func (tx *postgresTransaction) DeleteBlockRecord(ctx context.Context, blockID string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	_, err := tx.tx.Exec(ctx, `DELETE FROM block_records WHERE block_id = $1`, blockID)
+	if err != nil {
+		return fmt.Errorf("postgres DeleteBlockRecord: %w", err)
+	}
+	return nil
 }
 
-func (tx *postgresTransaction) WalkBlockRecords(_ context.Context, _ func(block.BlockRecord) error) error {
-	return errNotImplemented
+func (tx *postgresTransaction) WalkBlockRecords(ctx context.Context, fn func(block.BlockRecord) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	rows, err := tx.tx.Query(ctx,
+		`SELECT block_id, block_hash, length, live_chunk_count, sync_state FROM block_records`,
+	)
+	if err != nil {
+		return fmt.Errorf("postgres WalkBlockRecords: %w", err)
+	}
+	defer rows.Close()
+	return iterBlockRecordRows(rows, fn)
 }
 
-func (tx *postgresTransaction) DecrLiveChunkCount(_ context.Context, _ string, _ uint32) (uint32, error) {
-	return 0, errNotImplemented
+// DecrLiveChunkCount atomically floors live_chunk_count at 0.
+// Returns an error if blockID does not exist (matches memory semantics).
+func (tx *postgresTransaction) DecrLiveChunkCount(ctx context.Context, blockID string, delta uint32) (uint32, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	var remaining int64
+	err := tx.tx.QueryRow(ctx, `
+		UPDATE block_records
+		SET live_chunk_count = GREATEST(0, live_chunk_count - $2)
+		WHERE block_id = $1
+		RETURNING live_chunk_count`,
+		blockID, int64(delta),
+	).Scan(&remaining)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, fmt.Errorf("block record %q not found", blockID)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("postgres DecrLiveChunkCount: %w", err)
+	}
+	return uint32(remaining), nil
 }
 
-// LocalChunkIndex stubs — not yet implemented for the postgres backend.
+// ============================================================================
+// Transaction-level LocalChunkIndex
+// ============================================================================
 
-func (tx *postgresTransaction) PutLocalLocation(_ context.Context, _ block.ContentHash, _ block.LocalChunkLocation) error {
-	return errNotImplemented
+func (tx *postgresTransaction) PutLocalLocation(ctx context.Context, hash block.ContentHash, loc block.LocalChunkLocation) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	_, err := tx.tx.Exec(ctx, `
+		INSERT INTO local_chunk_index (hash, log_blob_id, raw_offset, raw_length)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (hash) DO UPDATE SET
+			log_blob_id = EXCLUDED.log_blob_id,
+			raw_offset  = EXCLUDED.raw_offset,
+			raw_length  = EXCLUDED.raw_length`,
+		hash[:], loc.LogBlobID, loc.RawOffset, loc.RawLength,
+	)
+	if err != nil {
+		return fmt.Errorf("postgres PutLocalLocation: %w", err)
+	}
+	return nil
 }
 
-func (tx *postgresTransaction) GetLocalLocation(_ context.Context, _ block.ContentHash) (block.LocalChunkLocation, bool, error) {
-	return block.LocalChunkLocation{}, false, errNotImplemented
+func (tx *postgresTransaction) GetLocalLocation(ctx context.Context, hash block.ContentHash) (block.LocalChunkLocation, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return block.LocalChunkLocation{}, false, err
+	}
+	return scanLocalLocation(tx.tx.QueryRow(ctx,
+		`SELECT log_blob_id, raw_offset, raw_length FROM local_chunk_index WHERE hash = $1`,
+		hash[:],
+	))
 }
 
-func (tx *postgresTransaction) DeleteLocalLocation(_ context.Context, _ block.ContentHash) error {
-	return errNotImplemented
+func (tx *postgresTransaction) DeleteLocalLocation(ctx context.Context, hash block.ContentHash) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	_, err := tx.tx.Exec(ctx, `DELETE FROM local_chunk_index WHERE hash = $1`, hash[:])
+	if err != nil {
+		return fmt.Errorf("postgres DeleteLocalLocation: %w", err)
+	}
+	return nil
 }
 
-// Store-level stubs.
+// ============================================================================
+// Store-level BlockRecordStore (delegates writes through WithTransaction)
+// ============================================================================
 
-func (s *PostgresMetadataStore) PutBlockRecord(_ context.Context, _ block.BlockRecord) error {
-	return errNotImplemented
+func (s *PostgresMetadataStore) PutBlockRecord(ctx context.Context, rec block.BlockRecord) error {
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.PutBlockRecord(ctx, rec)
+	})
 }
 
-func (s *PostgresMetadataStore) GetBlockRecord(_ context.Context, _ string) (block.BlockRecord, bool, error) {
-	return block.BlockRecord{}, false, errNotImplemented
+func (s *PostgresMetadataStore) GetBlockRecord(ctx context.Context, blockID string) (block.BlockRecord, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return block.BlockRecord{}, false, err
+	}
+	return scanBlockRecord(s.queryRow(ctx,
+		`SELECT block_id, block_hash, length, live_chunk_count, sync_state
+		 FROM block_records WHERE block_id = $1`,
+		blockID,
+	))
 }
 
-func (s *PostgresMetadataStore) DeleteBlockRecord(_ context.Context, _ string) error {
-	return errNotImplemented
+func (s *PostgresMetadataStore) DeleteBlockRecord(ctx context.Context, blockID string) error {
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.DeleteBlockRecord(ctx, blockID)
+	})
 }
 
-func (s *PostgresMetadataStore) WalkBlockRecords(_ context.Context, _ func(block.BlockRecord) error) error {
-	return errNotImplemented
+func (s *PostgresMetadataStore) WalkBlockRecords(ctx context.Context, fn func(block.BlockRecord) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	rows, err := s.query(ctx,
+		`SELECT block_id, block_hash, length, live_chunk_count, sync_state FROM block_records`,
+	)
+	if err != nil {
+		return fmt.Errorf("postgres WalkBlockRecords: %w", err)
+	}
+	defer rows.Close()
+	return iterBlockRecordRows(rows, fn)
 }
 
-func (s *PostgresMetadataStore) DecrLiveChunkCount(_ context.Context, _ string, _ uint32) (uint32, error) {
-	return 0, errNotImplemented
+func (s *PostgresMetadataStore) DecrLiveChunkCount(ctx context.Context, blockID string, delta uint32) (uint32, error) {
+	var remaining uint32
+	err := s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		var err error
+		remaining, err = tx.DecrLiveChunkCount(ctx, blockID, delta)
+		return err
+	})
+	return remaining, err
 }
 
-func (s *PostgresMetadataStore) PutLocalLocation(_ context.Context, _ block.ContentHash, _ block.LocalChunkLocation) error {
-	return errNotImplemented
+// ============================================================================
+// Store-level LocalChunkIndex
+// ============================================================================
+
+func (s *PostgresMetadataStore) PutLocalLocation(ctx context.Context, hash block.ContentHash, loc block.LocalChunkLocation) error {
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.PutLocalLocation(ctx, hash, loc)
+	})
 }
 
-func (s *PostgresMetadataStore) GetLocalLocation(_ context.Context, _ block.ContentHash) (block.LocalChunkLocation, bool, error) {
-	return block.LocalChunkLocation{}, false, errNotImplemented
+func (s *PostgresMetadataStore) GetLocalLocation(ctx context.Context, hash block.ContentHash) (block.LocalChunkLocation, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return block.LocalChunkLocation{}, false, err
+	}
+	return scanLocalLocation(s.queryRow(ctx,
+		`SELECT log_blob_id, raw_offset, raw_length FROM local_chunk_index WHERE hash = $1`,
+		hash[:],
+	))
 }
 
-func (s *PostgresMetadataStore) DeleteLocalLocation(_ context.Context, _ block.ContentHash) error {
-	return errNotImplemented
+func (s *PostgresMetadataStore) DeleteLocalLocation(ctx context.Context, hash block.ContentHash) error {
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.DeleteLocalLocation(ctx, hash)
+	})
 }
 
-func (s *PostgresMetadataStore) CommitBlock(_ context.Context, _ block.BlockRecord, _ []block.BlockChunkCommit) error {
-	return errNotImplemented
+// ============================================================================
+// CommitBlock
+// ============================================================================
+
+// CommitBlock atomically writes rec and all chunk local locations within a
+// single transaction, then marks each chunk synced outside the transaction.
+// Delegates to DefaultCommitBlock for idempotency logic — identical to the
+// memory and badger backends.
+func (s *PostgresMetadataStore) CommitBlock(ctx context.Context, rec block.BlockRecord, chunks []block.BlockChunkCommit) error {
+	return metadata.DefaultCommitBlock(ctx, s, rec, chunks)
+}
+
+// ============================================================================
+// Shared row-scan helpers
+// ============================================================================
+
+// scanBlockRecord reads a BlockRecord from a single pgx.Row (or pgx.Rows
+// result reused as a row). Returns (_, false, nil) on a missing row.
+func scanBlockRecord(row pgx.Row) (block.BlockRecord, bool, error) {
+	var (
+		blockID        string
+		blockHashRaw   []byte
+		length         int64
+		liveChunkCount int64
+		syncState      int16
+	)
+	err := row.Scan(&blockID, &blockHashRaw, &length, &liveChunkCount, &syncState)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return block.BlockRecord{}, false, nil
+	}
+	if err != nil {
+		return block.BlockRecord{}, false, fmt.Errorf("postgres scanBlockRecord: %w", err)
+	}
+	if len(blockHashRaw) != len(block.ContentHash{}) {
+		return block.BlockRecord{}, false, fmt.Errorf("postgres scanBlockRecord: malformed block_hash length %d", len(blockHashRaw))
+	}
+	var h block.ContentHash
+	copy(h[:], blockHashRaw)
+	return block.BlockRecord{
+		BlockID:        blockID,
+		BlockHash:      h,
+		Length:         length,
+		LiveChunkCount: uint32(liveChunkCount),
+		SyncState:      block.BlockState(syncState),
+	}, true, nil
+}
+
+// iterBlockRecordRows calls fn for every row in rows, returning the first error.
+func iterBlockRecordRows(rows pgx.Rows, fn func(block.BlockRecord) error) error {
+	for rows.Next() {
+		rec, ok, err := scanBlockRecord(rows)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue
+		}
+		if err := fn(rec); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
+// scanLocalLocation reads a LocalChunkLocation from a single row.
+// Returns (_, false, nil) on a missing row.
+func scanLocalLocation(row pgx.Row) (block.LocalChunkLocation, bool, error) {
+	var (
+		logBlobID string
+		rawOffset int64
+		rawLength int64
+	)
+	err := row.Scan(&logBlobID, &rawOffset, &rawLength)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return block.LocalChunkLocation{}, false, nil
+	}
+	if err != nil {
+		return block.LocalChunkLocation{}, false, fmt.Errorf("postgres scanLocalLocation: %w", err)
+	}
+	return block.LocalChunkLocation{
+		LogBlobID: logBlobID,
+		RawOffset: rawOffset,
+		RawLength: rawLength,
+	}, true, nil
 }

--- a/pkg/metadata/store/postgres/block_record_store.go
+++ b/pkg/metadata/store/postgres/block_record_store.go
@@ -16,27 +16,11 @@ import (
 )
 
 // Compile-time assertions: the store and its transaction both satisfy the
-// two capability interfaces. The type-assertion probe in the conformance
-// suite verifies them at runtime once the capability flags return true.
+// interfaces.
 var _ metadata.BlockRecordStore = (*PostgresMetadataStore)(nil)
 var _ metadata.LocalChunkIndex = (*PostgresMetadataStore)(nil)
 var _ metadata.BlockRecordStore = (*postgresTransaction)(nil)
 var _ metadata.LocalChunkIndex = (*postgresTransaction)(nil)
-
-// ============================================================================
-// Capability probes
-// ============================================================================
-
-// BlockRecordStoreEnabled signals that the postgres backend implements
-// metadata.BlockRecordStore (picked up by the conformance type-assertion probe).
-func (s *PostgresMetadataStore) BlockRecordStoreEnabled() bool { return true }
-
-// LocalChunkIndexEnabled signals that the postgres backend implements
-// metadata.LocalChunkIndex.
-func (s *PostgresMetadataStore) LocalChunkIndexEnabled() bool { return true }
-
-// CommitBlockEnabled signals that the postgres backend implements CommitBlock.
-func (s *PostgresMetadataStore) CommitBlockEnabled() bool { return true }
 
 // ============================================================================
 // Transaction-level BlockRecordStore

--- a/pkg/metadata/store/postgres/migrations/000036_block_records.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000036_block_records.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS local_chunk_index;
+DROP TABLE IF EXISTS block_records;

--- a/pkg/metadata/store/postgres/migrations/000036_block_records.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000036_block_records.up.sql
@@ -1,0 +1,26 @@
+-- #1416 blocks-only storage (PR2): persist block lifecycle records and the
+-- local chunk position index used by the log-blob engine.
+--
+-- block_records: one row per log-blob block, tracking its hash, byte length,
+-- number of live (un-GC'd) chunks it contains, and its sync state.
+-- live_chunk_count is BIGINT so GREATEST(0, live_chunk_count - delta) never
+-- overflows in the atomic-decrement UPDATE.
+--
+-- local_chunk_index: maps a content hash to the position of that chunk inside
+-- a local log-blob. Mirrors synced_hashes in shape (hash BYTEA primary key)
+-- but points at local storage rather than remote.
+
+CREATE TABLE IF NOT EXISTS block_records (
+    block_id        TEXT    PRIMARY KEY,
+    block_hash      BYTEA   NOT NULL,
+    length          BIGINT  NOT NULL,
+    live_chunk_count BIGINT NOT NULL DEFAULT 0,
+    sync_state      SMALLINT NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS local_chunk_index (
+    hash        BYTEA   PRIMARY KEY,
+    log_blob_id TEXT    NOT NULL,
+    raw_offset  BIGINT  NOT NULL,
+    raw_length  BIGINT  NOT NULL
+);

--- a/pkg/metadata/store/postgres/snapshot_store.go
+++ b/pkg/metadata/store/postgres/snapshot_store.go
@@ -35,7 +35,9 @@ const (
 	// pre-v4 streams with ErrSchemaVersionMismatch — consistent with the prior
 	// bumps, which added/removed tables with no cross-version restore shim.
 	// Pre-1.0 backups are not forward-portable across schema versions.
-	postgresSchemaVersion = uint32(4)
+	// v5 adds the block_records and local_chunk_index table sections (#1493 PR2),
+	// raising the backup table count from 15 to 17.
+	postgresSchemaVersion = uint32(5)
 )
 
 // backupTables lists every metadata table in FK-safe dependency order

--- a/pkg/metadata/store/postgres/snapshot_store.go
+++ b/pkg/metadata/store/postgres/snapshot_store.go
@@ -61,6 +61,8 @@ var backupTables = []string{
 	"v4_client_recovery",
 	"rollup_offsets",
 	"synced_hashes",
+	"block_records",
+	"local_chunk_index",
 }
 
 // Compile-time assertion: PostgresMetadataStore implements Snapshotable.

--- a/pkg/metadata/store/sqlite/block_record_store.go
+++ b/pkg/metadata/store/sqlite/block_record_store.go
@@ -31,22 +31,6 @@ var _ metadata.BlockRecordStore = (*sqliteTransaction)(nil)
 var _ metadata.LocalChunkIndex = (*sqliteTransaction)(nil)
 
 // ============================================================================
-// Capability probes (type-asserted by storetest to decide skip vs run)
-// ============================================================================
-
-// BlockRecordStoreEnabled signals to the conformance suite that this backend
-// fully implements metadata.BlockRecordStore.
-func (s *SQLiteMetadataStore) BlockRecordStoreEnabled() bool { return true }
-
-// LocalChunkIndexEnabled signals to the conformance suite that this backend
-// fully implements metadata.LocalChunkIndex.
-func (s *SQLiteMetadataStore) LocalChunkIndexEnabled() bool { return true }
-
-// CommitBlockEnabled signals to the conformance suite that CommitBlock is
-// implemented (it delegates to metadata.DefaultCommitBlock).
-func (s *SQLiteMetadataStore) CommitBlockEnabled() bool { return true }
-
-// ============================================================================
 // Store-level BlockRecordStore (pool path)
 // ============================================================================
 

--- a/pkg/metadata/store/sqlite/block_record_store.go
+++ b/pkg/metadata/store/sqlite/block_record_store.go
@@ -1,0 +1,84 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+var errNotImplemented = errors.New("not implemented")
+
+// BlockRecordStore stubs — not yet implemented for the sqlite backend.
+
+func (tx *sqliteTransaction) PutBlockRecord(_ context.Context, _ block.BlockRecord) error {
+	return errNotImplemented
+}
+
+func (tx *sqliteTransaction) GetBlockRecord(_ context.Context, _ string) (block.BlockRecord, bool, error) {
+	return block.BlockRecord{}, false, errNotImplemented
+}
+
+func (tx *sqliteTransaction) DeleteBlockRecord(_ context.Context, _ string) error {
+	return errNotImplemented
+}
+
+func (tx *sqliteTransaction) WalkBlockRecords(_ context.Context, _ func(block.BlockRecord) error) error {
+	return errNotImplemented
+}
+
+func (tx *sqliteTransaction) DecrLiveChunkCount(_ context.Context, _ string, _ uint32) (uint32, error) {
+	return 0, errNotImplemented
+}
+
+// LocalChunkIndex stubs — not yet implemented for the sqlite backend.
+
+func (tx *sqliteTransaction) PutLocalLocation(_ context.Context, _ block.ContentHash, _ block.LocalChunkLocation) error {
+	return errNotImplemented
+}
+
+func (tx *sqliteTransaction) GetLocalLocation(_ context.Context, _ block.ContentHash) (block.LocalChunkLocation, bool, error) {
+	return block.LocalChunkLocation{}, false, errNotImplemented
+}
+
+func (tx *sqliteTransaction) DeleteLocalLocation(_ context.Context, _ block.ContentHash) error {
+	return errNotImplemented
+}
+
+// Store-level stubs.
+
+func (s *SQLiteMetadataStore) PutBlockRecord(_ context.Context, _ block.BlockRecord) error {
+	return errNotImplemented
+}
+
+func (s *SQLiteMetadataStore) GetBlockRecord(_ context.Context, _ string) (block.BlockRecord, bool, error) {
+	return block.BlockRecord{}, false, errNotImplemented
+}
+
+func (s *SQLiteMetadataStore) DeleteBlockRecord(_ context.Context, _ string) error {
+	return errNotImplemented
+}
+
+func (s *SQLiteMetadataStore) WalkBlockRecords(_ context.Context, _ func(block.BlockRecord) error) error {
+	return errNotImplemented
+}
+
+func (s *SQLiteMetadataStore) DecrLiveChunkCount(_ context.Context, _ string, _ uint32) (uint32, error) {
+	return 0, errNotImplemented
+}
+
+func (s *SQLiteMetadataStore) PutLocalLocation(_ context.Context, _ block.ContentHash, _ block.LocalChunkLocation) error {
+	return errNotImplemented
+}
+
+func (s *SQLiteMetadataStore) GetLocalLocation(_ context.Context, _ block.ContentHash) (block.LocalChunkLocation, bool, error) {
+	return block.LocalChunkLocation{}, false, errNotImplemented
+}
+
+func (s *SQLiteMetadataStore) DeleteLocalLocation(_ context.Context, _ block.ContentHash) error {
+	return errNotImplemented
+}
+
+func (s *SQLiteMetadataStore) CommitBlock(_ context.Context, _ block.BlockRecord, _ []block.BlockChunkCommit) error {
+	return errNotImplemented
+}

--- a/pkg/metadata/store/sqlite/block_record_store.go
+++ b/pkg/metadata/store/sqlite/block_record_store.go
@@ -1,84 +1,437 @@
+// BlockRecordStore + LocalChunkIndex implementations for the SQLite metadata
+// store.  Both interfaces are required by metadata.Transaction, so every method
+// exists in two variants: a store-level (pool path) variant on
+// *SQLiteMetadataStore and a transaction-scoped variant on *sqliteTransaction.
+//
+// Semantics match the memory backend exactly:
+//   - PutBlockRecord / PutLocalLocation — idempotent upserts.
+//   - GetBlockRecord / GetLocalLocation — (_, false, nil) on miss.
+//   - DeleteBlockRecord / DeleteLocalLocation — idempotent (missing row → nil).
+//   - DecrLiveChunkCount — floors at 0; error when blockID absent.
+//   - WalkBlockRecords — enumerates all rows in implementation-defined order.
+//   - CommitBlock — delegates to metadata.DefaultCommitBlock.
 package sqlite
 
 import (
 	"context"
+	"database/sql"
 	"errors"
+	"fmt"
 
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-var errNotImplemented = errors.New("not implemented")
+// Compile-time assertions: the store and its transaction both satisfy the new
+// interfaces.  If a method signature drifts these lines will fail to compile
+// before any test runs.
+var _ metadata.BlockRecordStore = (*SQLiteMetadataStore)(nil)
+var _ metadata.LocalChunkIndex = (*SQLiteMetadataStore)(nil)
+var _ metadata.BlockRecordStore = (*sqliteTransaction)(nil)
+var _ metadata.LocalChunkIndex = (*sqliteTransaction)(nil)
 
-// BlockRecordStore stubs — not yet implemented for the sqlite backend.
+// ============================================================================
+// Capability probes (type-asserted by storetest to decide skip vs run)
+// ============================================================================
 
-func (tx *sqliteTransaction) PutBlockRecord(_ context.Context, _ block.BlockRecord) error {
-	return errNotImplemented
+// BlockRecordStoreEnabled signals to the conformance suite that this backend
+// fully implements metadata.BlockRecordStore.
+func (s *SQLiteMetadataStore) BlockRecordStoreEnabled() bool { return true }
+
+// LocalChunkIndexEnabled signals to the conformance suite that this backend
+// fully implements metadata.LocalChunkIndex.
+func (s *SQLiteMetadataStore) LocalChunkIndexEnabled() bool { return true }
+
+// CommitBlockEnabled signals to the conformance suite that CommitBlock is
+// implemented (it delegates to metadata.DefaultCommitBlock).
+func (s *SQLiteMetadataStore) CommitBlockEnabled() bool { return true }
+
+// ============================================================================
+// Store-level BlockRecordStore (pool path)
+// ============================================================================
+
+// PutBlockRecord writes or overwrites the block record for rec.BlockID.
+func (s *SQLiteMetadataStore) PutBlockRecord(ctx context.Context, rec block.BlockRecord) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	_, err := s.exec(ctx,
+		`INSERT INTO block_records (block_id, block_hash, length, live_chunk_count, sync_state)
+		 VALUES (?1, ?2, ?3, ?4, ?5)
+		 ON CONFLICT (block_id) DO UPDATE SET
+		     block_hash       = EXCLUDED.block_hash,
+		     length           = EXCLUDED.length,
+		     live_chunk_count = EXCLUDED.live_chunk_count,
+		     sync_state       = EXCLUDED.sync_state`,
+		rec.BlockID, rec.BlockHash[:], rec.Length, rec.LiveChunkCount, int(rec.SyncState))
+	if err != nil {
+		return fmt.Errorf("sqlite block_records put: %w", err)
+	}
+	return nil
 }
 
-func (tx *sqliteTransaction) GetBlockRecord(_ context.Context, _ string) (block.BlockRecord, bool, error) {
-	return block.BlockRecord{}, false, errNotImplemented
+// GetBlockRecord retrieves the block record for blockID.
+// Returns (_, false, nil) when no record exists.
+func (s *SQLiteMetadataStore) GetBlockRecord(ctx context.Context, blockID string) (block.BlockRecord, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return block.BlockRecord{}, false, err
+	}
+	rec, found, err := scanBlockRecord(s.queryRow(ctx,
+		`SELECT block_id, block_hash, length, live_chunk_count, sync_state
+		 FROM block_records WHERE block_id = ?1`,
+		blockID))
+	if err != nil {
+		return block.BlockRecord{}, false, fmt.Errorf("sqlite block_records get: %w", err)
+	}
+	return rec, found, nil
 }
 
-func (tx *sqliteTransaction) DeleteBlockRecord(_ context.Context, _ string) error {
-	return errNotImplemented
+// DeleteBlockRecord removes the block record for blockID. Idempotent.
+func (s *SQLiteMetadataStore) DeleteBlockRecord(ctx context.Context, blockID string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if _, err := s.exec(ctx,
+		`DELETE FROM block_records WHERE block_id = ?1`,
+		blockID); err != nil {
+		return fmt.Errorf("sqlite block_records delete: %w", err)
+	}
+	return nil
 }
 
-func (tx *sqliteTransaction) WalkBlockRecords(_ context.Context, _ func(block.BlockRecord) error) error {
-	return errNotImplemented
+// WalkBlockRecords calls fn for every stored block record.
+func (s *SQLiteMetadataStore) WalkBlockRecords(ctx context.Context, fn func(block.BlockRecord) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	rows, err := s.query(ctx,
+		`SELECT block_id, block_hash, length, live_chunk_count, sync_state FROM block_records`)
+	if err != nil {
+		return fmt.Errorf("sqlite block_records walk: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		rec, _, err := scanBlockRecordRow(rows)
+		if err != nil {
+			return fmt.Errorf("sqlite block_records walk scan: %w", err)
+		}
+		if err := fn(rec); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
 }
 
-func (tx *sqliteTransaction) DecrLiveChunkCount(_ context.Context, _ string, _ uint32) (uint32, error) {
-	return 0, errNotImplemented
+// DecrLiveChunkCount atomically decrements LiveChunkCount, flooring at 0.
+// Returns the remaining count.  Errors if blockID does not exist.
+// Uses WithTransaction so the check + update is atomic under SQLite's busy-retry loop.
+func (s *SQLiteMetadataStore) DecrLiveChunkCount(ctx context.Context, blockID string, delta uint32) (uint32, error) {
+	var remaining uint32
+	err := s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		rem, err := tx.DecrLiveChunkCount(ctx, blockID, delta)
+		if err != nil {
+			return err
+		}
+		remaining = rem
+		return nil
+	})
+	return remaining, err
 }
 
-// LocalChunkIndex stubs — not yet implemented for the sqlite backend.
+// ============================================================================
+// Store-level LocalChunkIndex (pool path)
+// ============================================================================
 
-func (tx *sqliteTransaction) PutLocalLocation(_ context.Context, _ block.ContentHash, _ block.LocalChunkLocation) error {
-	return errNotImplemented
+// PutLocalLocation records or overwrites the local position for hash.
+func (s *SQLiteMetadataStore) PutLocalLocation(ctx context.Context, hash block.ContentHash, loc block.LocalChunkLocation) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	_, err := s.exec(ctx,
+		`INSERT INTO local_chunk_index (hash, log_blob_id, raw_offset, raw_length)
+		 VALUES (?1, ?2, ?3, ?4)
+		 ON CONFLICT (hash) DO UPDATE SET
+		     log_blob_id = EXCLUDED.log_blob_id,
+		     raw_offset  = EXCLUDED.raw_offset,
+		     raw_length  = EXCLUDED.raw_length`,
+		hash[:], loc.LogBlobID, loc.RawOffset, loc.RawLength)
+	if err != nil {
+		return fmt.Errorf("sqlite local_chunk_index put: %w", err)
+	}
+	return nil
 }
 
-func (tx *sqliteTransaction) GetLocalLocation(_ context.Context, _ block.ContentHash) (block.LocalChunkLocation, bool, error) {
-	return block.LocalChunkLocation{}, false, errNotImplemented
+// GetLocalLocation returns the local position for hash.
+// Returns (_, false, nil) when no entry exists.
+func (s *SQLiteMetadataStore) GetLocalLocation(ctx context.Context, hash block.ContentHash) (block.LocalChunkLocation, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return block.LocalChunkLocation{}, false, err
+	}
+	loc, found, err := scanLocalLocation(s.queryRow(ctx,
+		`SELECT log_blob_id, raw_offset, raw_length FROM local_chunk_index WHERE hash = ?1`,
+		hash[:]))
+	if err != nil {
+		return block.LocalChunkLocation{}, false, fmt.Errorf("sqlite local_chunk_index get: %w", err)
+	}
+	return loc, found, nil
 }
 
-func (tx *sqliteTransaction) DeleteLocalLocation(_ context.Context, _ block.ContentHash) error {
-	return errNotImplemented
+// DeleteLocalLocation removes the local position for hash. Idempotent.
+func (s *SQLiteMetadataStore) DeleteLocalLocation(ctx context.Context, hash block.ContentHash) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if _, err := s.exec(ctx,
+		`DELETE FROM local_chunk_index WHERE hash = ?1`,
+		hash[:]); err != nil {
+		return fmt.Errorf("sqlite local_chunk_index delete: %w", err)
+	}
+	return nil
 }
 
-// Store-level stubs.
+// ============================================================================
+// CommitBlock (store-level, delegates to DefaultCommitBlock)
+// ============================================================================
 
-func (s *SQLiteMetadataStore) PutBlockRecord(_ context.Context, _ block.BlockRecord) error {
-	return errNotImplemented
+// CommitBlock atomically writes rec and all chunk local locations within a
+// single transaction, then marks each chunk synced.  Idempotent on BlockID.
+func (s *SQLiteMetadataStore) CommitBlock(ctx context.Context, rec block.BlockRecord, chunks []block.BlockChunkCommit) error {
+	return metadata.DefaultCommitBlock(ctx, s, rec, chunks)
 }
 
-func (s *SQLiteMetadataStore) GetBlockRecord(_ context.Context, _ string) (block.BlockRecord, bool, error) {
-	return block.BlockRecord{}, false, errNotImplemented
+// ============================================================================
+// Transaction-level BlockRecordStore
+// ============================================================================
+
+// PutBlockRecord writes or overwrites the block record for rec.BlockID.
+func (tx *sqliteTransaction) PutBlockRecord(ctx context.Context, rec block.BlockRecord) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	_, err := tx.tx.Exec(ctx,
+		`INSERT INTO block_records (block_id, block_hash, length, live_chunk_count, sync_state)
+		 VALUES (?1, ?2, ?3, ?4, ?5)
+		 ON CONFLICT (block_id) DO UPDATE SET
+		     block_hash       = EXCLUDED.block_hash,
+		     length           = EXCLUDED.length,
+		     live_chunk_count = EXCLUDED.live_chunk_count,
+		     sync_state       = EXCLUDED.sync_state`,
+		rec.BlockID, rec.BlockHash[:], rec.Length, rec.LiveChunkCount, int(rec.SyncState))
+	if err != nil {
+		return fmt.Errorf("sqlite tx block_records put: %w", err)
+	}
+	return nil
 }
 
-func (s *SQLiteMetadataStore) DeleteBlockRecord(_ context.Context, _ string) error {
-	return errNotImplemented
+// GetBlockRecord retrieves the block record for blockID.
+// Returns (_, false, nil) when no record exists.
+func (tx *sqliteTransaction) GetBlockRecord(ctx context.Context, blockID string) (block.BlockRecord, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return block.BlockRecord{}, false, err
+	}
+	rec, found, err := scanBlockRecord(tx.tx.QueryRow(ctx,
+		`SELECT block_id, block_hash, length, live_chunk_count, sync_state
+		 FROM block_records WHERE block_id = ?1`,
+		blockID))
+	if err != nil {
+		return block.BlockRecord{}, false, fmt.Errorf("sqlite tx block_records get: %w", err)
+	}
+	return rec, found, nil
 }
 
-func (s *SQLiteMetadataStore) WalkBlockRecords(_ context.Context, _ func(block.BlockRecord) error) error {
-	return errNotImplemented
+// DeleteBlockRecord removes the block record for blockID. Idempotent.
+func (tx *sqliteTransaction) DeleteBlockRecord(ctx context.Context, blockID string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if _, err := tx.tx.Exec(ctx,
+		`DELETE FROM block_records WHERE block_id = ?1`,
+		blockID); err != nil {
+		return fmt.Errorf("sqlite tx block_records delete: %w", err)
+	}
+	return nil
 }
 
-func (s *SQLiteMetadataStore) DecrLiveChunkCount(_ context.Context, _ string, _ uint32) (uint32, error) {
-	return 0, errNotImplemented
+// WalkBlockRecords calls fn for every stored block record.
+func (tx *sqliteTransaction) WalkBlockRecords(ctx context.Context, fn func(block.BlockRecord) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	rows, err := tx.tx.Query(ctx,
+		`SELECT block_id, block_hash, length, live_chunk_count, sync_state FROM block_records`)
+	if err != nil {
+		return fmt.Errorf("sqlite tx block_records walk: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		rec, _, err := scanBlockRecordRow(rows)
+		if err != nil {
+			return fmt.Errorf("sqlite tx block_records walk scan: %w", err)
+		}
+		if err := fn(rec); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
 }
 
-func (s *SQLiteMetadataStore) PutLocalLocation(_ context.Context, _ block.ContentHash, _ block.LocalChunkLocation) error {
-	return errNotImplemented
+// DecrLiveChunkCount atomically decrements LiveChunkCount, flooring at 0.
+// Returns the remaining count.  Errors if blockID does not exist.
+func (tx *sqliteTransaction) DecrLiveChunkCount(ctx context.Context, blockID string, delta uint32) (uint32, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	// Verify the record exists first so we can return a meaningful error on miss.
+	var current int64
+	err := tx.tx.QueryRow(ctx,
+		`SELECT live_chunk_count FROM block_records WHERE block_id = ?1`,
+		blockID).Scan(&current)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, fmt.Errorf("sqlite block_records decr: block %q not found", blockID)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("sqlite block_records decr read: %w", err)
+	}
+
+	d := int64(delta)
+	newCount := current - d
+	if newCount < 0 {
+		newCount = 0
+	}
+	if _, err := tx.tx.Exec(ctx,
+		`UPDATE block_records SET live_chunk_count = ?1 WHERE block_id = ?2`,
+		newCount, blockID); err != nil {
+		return 0, fmt.Errorf("sqlite block_records decr update: %w", err)
+	}
+	return uint32(newCount), nil
 }
 
-func (s *SQLiteMetadataStore) GetLocalLocation(_ context.Context, _ block.ContentHash) (block.LocalChunkLocation, bool, error) {
-	return block.LocalChunkLocation{}, false, errNotImplemented
+// ============================================================================
+// Transaction-level LocalChunkIndex
+// ============================================================================
+
+// PutLocalLocation records or overwrites the local position for hash.
+func (tx *sqliteTransaction) PutLocalLocation(ctx context.Context, hash block.ContentHash, loc block.LocalChunkLocation) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	_, err := tx.tx.Exec(ctx,
+		`INSERT INTO local_chunk_index (hash, log_blob_id, raw_offset, raw_length)
+		 VALUES (?1, ?2, ?3, ?4)
+		 ON CONFLICT (hash) DO UPDATE SET
+		     log_blob_id = EXCLUDED.log_blob_id,
+		     raw_offset  = EXCLUDED.raw_offset,
+		     raw_length  = EXCLUDED.raw_length`,
+		hash[:], loc.LogBlobID, loc.RawOffset, loc.RawLength)
+	if err != nil {
+		return fmt.Errorf("sqlite tx local_chunk_index put: %w", err)
+	}
+	return nil
 }
 
-func (s *SQLiteMetadataStore) DeleteLocalLocation(_ context.Context, _ block.ContentHash) error {
-	return errNotImplemented
+// GetLocalLocation returns the local position for hash.
+// Returns (_, false, nil) when no entry exists.
+func (tx *sqliteTransaction) GetLocalLocation(ctx context.Context, hash block.ContentHash) (block.LocalChunkLocation, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return block.LocalChunkLocation{}, false, err
+	}
+	loc, found, err := scanLocalLocation(tx.tx.QueryRow(ctx,
+		`SELECT log_blob_id, raw_offset, raw_length FROM local_chunk_index WHERE hash = ?1`,
+		hash[:]))
+	if err != nil {
+		return block.LocalChunkLocation{}, false, fmt.Errorf("sqlite tx local_chunk_index get: %w", err)
+	}
+	return loc, found, nil
 }
 
-func (s *SQLiteMetadataStore) CommitBlock(_ context.Context, _ block.BlockRecord, _ []block.BlockChunkCommit) error {
-	return errNotImplemented
+// DeleteLocalLocation removes the local position for hash. Idempotent.
+func (tx *sqliteTransaction) DeleteLocalLocation(ctx context.Context, hash block.ContentHash) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if _, err := tx.tx.Exec(ctx,
+		`DELETE FROM local_chunk_index WHERE hash = ?1`,
+		hash[:]); err != nil {
+		return fmt.Errorf("sqlite tx local_chunk_index delete: %w", err)
+	}
+	return nil
+}
+
+// ============================================================================
+// Scan helpers
+// ============================================================================
+
+// scanBlockRecord scans a single-row query result into a BlockRecord.
+// Returns (_, false, nil) on sql.ErrNoRows (miss is not an error).
+func scanBlockRecord(row scanRow) (block.BlockRecord, bool, error) {
+	var (
+		blockID   string
+		hashRaw   []byte
+		length    int64
+		liveCount uint32
+		syncState int
+	)
+	err := row.Scan(&blockID, &hashRaw, &length, &liveCount, &syncState)
+	if errors.Is(err, sql.ErrNoRows) {
+		return block.BlockRecord{}, false, nil
+	}
+	if err != nil {
+		return block.BlockRecord{}, false, err
+	}
+	var h block.ContentHash
+	copy(h[:], hashRaw)
+	return block.BlockRecord{
+		BlockID:        blockID,
+		BlockHash:      h,
+		Length:         length,
+		LiveChunkCount: liveCount,
+		SyncState:      block.BlockState(syncState),
+	}, true, nil
+}
+
+// scanBlockRecordRow scans a streaming Rows cursor (from WalkBlockRecords).
+// The caller drives rows.Next(); this only scans the current row.
+// found is always true here since we are iterating an existing row set.
+func scanBlockRecordRow(rows scanRows) (block.BlockRecord, bool, error) {
+	var (
+		blockID   string
+		hashRaw   []byte
+		length    int64
+		liveCount uint32
+		syncState int
+	)
+	if err := rows.Scan(&blockID, &hashRaw, &length, &liveCount, &syncState); err != nil {
+		return block.BlockRecord{}, false, err
+	}
+	var h block.ContentHash
+	copy(h[:], hashRaw)
+	return block.BlockRecord{
+		BlockID:        blockID,
+		BlockHash:      h,
+		Length:         length,
+		LiveChunkCount: liveCount,
+		SyncState:      block.BlockState(syncState),
+	}, true, nil
+}
+
+// scanLocalLocation scans a single-row query result into a LocalChunkLocation.
+// Returns (_, false, nil) on sql.ErrNoRows.
+func scanLocalLocation(row scanRow) (block.LocalChunkLocation, bool, error) {
+	var (
+		logBlobID string
+		rawOffset int64
+		rawLength int64
+	)
+	err := row.Scan(&logBlobID, &rawOffset, &rawLength)
+	if errors.Is(err, sql.ErrNoRows) {
+		return block.LocalChunkLocation{}, false, nil
+	}
+	if err != nil {
+		return block.LocalChunkLocation{}, false, err
+	}
+	return block.LocalChunkLocation{
+		LogBlobID: logBlobID,
+		RawOffset: rawOffset,
+		RawLength: rawLength,
+	}, true, nil
 }

--- a/pkg/metadata/store/sqlite/block_record_store.go
+++ b/pkg/metadata/store/sqlite/block_record_store.go
@@ -265,29 +265,25 @@ func (tx *sqliteTransaction) DecrLiveChunkCount(ctx context.Context, blockID str
 	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
-	// Verify the record exists first so we can return a meaningful error on miss.
-	var current int64
+	// Single atomic statement: MAX(0, ...) floors the count at zero in SQL,
+	// avoiding a separate client-side SELECT and preventing lost updates when
+	// multiple deferred transactions decrement the same row concurrently.
+	// RETURNING live_chunk_count gives the post-update value without a second
+	// round-trip.  ErrNoRows means the block does not exist.
+	var remaining int64
 	err := tx.tx.QueryRow(ctx,
-		`SELECT live_chunk_count FROM block_records WHERE block_id = ?1`,
-		blockID).Scan(&current)
+		`UPDATE block_records
+		 SET live_chunk_count = MAX(0, live_chunk_count - ?1)
+		 WHERE block_id = ?2
+		 RETURNING live_chunk_count`,
+		int64(delta), blockID).Scan(&remaining)
 	if errors.Is(err, sql.ErrNoRows) {
 		return 0, fmt.Errorf("sqlite block_records decr: block %q not found", blockID)
 	}
 	if err != nil {
-		return 0, fmt.Errorf("sqlite block_records decr read: %w", err)
+		return 0, fmt.Errorf("sqlite block_records decr: %w", err)
 	}
-
-	d := int64(delta)
-	newCount := current - d
-	if newCount < 0 {
-		newCount = 0
-	}
-	if _, err := tx.tx.Exec(ctx,
-		`UPDATE block_records SET live_chunk_count = ?1 WHERE block_id = ?2`,
-		newCount, blockID); err != nil {
-		return 0, fmt.Errorf("sqlite block_records decr update: %w", err)
-	}
-	return uint32(newCount), nil
+	return uint32(remaining), nil
 }
 
 // ============================================================================
@@ -362,6 +358,9 @@ func scanBlockRecord(row scanRow) (block.BlockRecord, bool, error) {
 	if err != nil {
 		return block.BlockRecord{}, false, err
 	}
+	if len(hashRaw) != len(block.ContentHash{}) {
+		return block.BlockRecord{}, false, fmt.Errorf("sqlite scanBlockRecord: malformed block_hash length %d", len(hashRaw))
+	}
 	var h block.ContentHash
 	copy(h[:], hashRaw)
 	return block.BlockRecord{
@@ -386,6 +385,9 @@ func scanBlockRecordRow(rows scanRows) (block.BlockRecord, bool, error) {
 	)
 	if err := rows.Scan(&blockID, &hashRaw, &length, &liveCount, &syncState); err != nil {
 		return block.BlockRecord{}, false, err
+	}
+	if len(hashRaw) != len(block.ContentHash{}) {
+		return block.BlockRecord{}, false, fmt.Errorf("sqlite scanBlockRecordRow: malformed block_hash length %d", len(hashRaw))
 	}
 	var h block.ContentHash
 	copy(h[:], hashRaw)

--- a/pkg/metadata/store/sqlite/migrations/000003_block_records.down.sql
+++ b/pkg/metadata/store/sqlite/migrations/000003_block_records.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS local_chunk_index;
+DROP TABLE IF EXISTS block_records;

--- a/pkg/metadata/store/sqlite/migrations/000003_block_records.up.sql
+++ b/pkg/metadata/store/sqlite/migrations/000003_block_records.up.sql
@@ -1,0 +1,24 @@
+-- #1416 blocks-only storage (PR2): block record lifecycle and local chunk index.
+--
+-- block_records tracks each log-blob block committed to the local store:
+-- its content hash, byte length, how many live (not-yet-GC'd) chunks refer to
+-- it, and the sync state (pending/syncing/synced enum — mirrors block.BlockState).
+--
+-- local_chunk_index maps a content hash to the position of that chunk inside
+-- its local log-blob file.  It is the read-path complement to block_records:
+-- given a hash the engine looks up its log-blob + byte range here.
+
+CREATE TABLE block_records (
+    block_id         TEXT PRIMARY KEY,
+    block_hash       BLOB NOT NULL,
+    length           INTEGER NOT NULL,
+    live_chunk_count INTEGER NOT NULL,
+    sync_state       INTEGER NOT NULL
+);
+
+CREATE TABLE local_chunk_index (
+    hash        BLOB PRIMARY KEY,
+    log_blob_id TEXT NOT NULL,
+    raw_offset  INTEGER NOT NULL,
+    raw_length  INTEGER NOT NULL
+);

--- a/pkg/metadata/storetest/block_record_ops.go
+++ b/pkg/metadata/storetest/block_record_ops.go
@@ -1,0 +1,138 @@
+package storetest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// BlockRecordStoreProvider is implemented by stores with full BlockRecordStore
+// support. The conformance suite type-asserts to this and skips if unimplemented.
+type BlockRecordStoreProvider interface {
+	BlockRecordStoreEnabled() bool
+}
+
+func runBlockRecordOps(t *testing.T, store metadata.Store) {
+	t.Helper()
+	if p, ok := store.(BlockRecordStoreProvider); !ok || !p.BlockRecordStoreEnabled() {
+		t.Skip("BlockRecordStore not implemented by this backend")
+	}
+
+	ctx := context.Background()
+
+	rec := block.BlockRecord{
+		BlockID:        "blk-001",
+		BlockHash:      block.ContentHash{1, 2, 3},
+		Length:         1024,
+		LiveChunkCount: 5,
+		SyncState:      block.BlockStatePending,
+	}
+
+	t.Run("PutGetRoundTrip", func(t *testing.T) {
+		if err := store.PutBlockRecord(ctx, rec); err != nil {
+			t.Fatalf("PutBlockRecord() error = %v", err)
+		}
+		got, found, err := store.GetBlockRecord(ctx, rec.BlockID)
+		if err != nil {
+			t.Fatalf("GetBlockRecord() error = %v", err)
+		}
+		if !found {
+			t.Fatal("GetBlockRecord() found = false, want true")
+		}
+		if got != rec {
+			t.Errorf("GetBlockRecord() = %+v, want %+v", got, rec)
+		}
+	})
+
+	t.Run("MissingReturnsNotFound", func(t *testing.T) {
+		_, found, err := store.GetBlockRecord(ctx, "nonexistent-block")
+		if err != nil {
+			t.Fatalf("GetBlockRecord(missing) error = %v", err)
+		}
+		if found {
+			t.Fatal("GetBlockRecord(missing) found = true, want false")
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		del := block.BlockRecord{
+			BlockID:        "blk-del",
+			BlockHash:      block.ContentHash{9},
+			Length:         512,
+			LiveChunkCount: 1,
+			SyncState:      block.BlockStatePending,
+		}
+		if err := store.PutBlockRecord(ctx, del); err != nil {
+			t.Fatalf("PutBlockRecord() error = %v", err)
+		}
+		if err := store.DeleteBlockRecord(ctx, del.BlockID); err != nil {
+			t.Fatalf("DeleteBlockRecord() error = %v", err)
+		}
+		_, found, err := store.GetBlockRecord(ctx, del.BlockID)
+		if err != nil {
+			t.Fatalf("GetBlockRecord(after delete) error = %v", err)
+		}
+		if found {
+			t.Fatal("GetBlockRecord(after delete) found = true, want false")
+		}
+	})
+
+	t.Run("Walk", func(t *testing.T) {
+		a := block.BlockRecord{BlockID: "walk-a", Length: 100, LiveChunkCount: 1, SyncState: block.BlockStatePending}
+		b := block.BlockRecord{BlockID: "walk-b", Length: 200, LiveChunkCount: 2, SyncState: block.BlockStateSyncing}
+		if err := store.PutBlockRecord(ctx, a); err != nil {
+			t.Fatalf("PutBlockRecord(a) error = %v", err)
+		}
+		if err := store.PutBlockRecord(ctx, b); err != nil {
+			t.Fatalf("PutBlockRecord(b) error = %v", err)
+		}
+
+		seen := map[string]bool{}
+		if err := store.WalkBlockRecords(ctx, func(r block.BlockRecord) error {
+			seen[r.BlockID] = true
+			return nil
+		}); err != nil {
+			t.Fatalf("WalkBlockRecords() error = %v", err)
+		}
+		if !seen["walk-a"] {
+			t.Error("WalkBlockRecords() did not yield walk-a")
+		}
+		if !seen["walk-b"] {
+			t.Error("WalkBlockRecords() did not yield walk-b")
+		}
+	})
+
+	t.Run("DecrLiveChunkCount", func(t *testing.T) {
+		r := block.BlockRecord{BlockID: "decr-test", Length: 256, LiveChunkCount: 10, SyncState: block.BlockStatePending}
+		if err := store.PutBlockRecord(ctx, r); err != nil {
+			t.Fatalf("PutBlockRecord() error = %v", err)
+		}
+
+		// Normal decrement.
+		rem, err := store.DecrLiveChunkCount(ctx, r.BlockID, 3)
+		if err != nil {
+			t.Fatalf("DecrLiveChunkCount() error = %v", err)
+		}
+		if rem != 7 {
+			t.Errorf("DecrLiveChunkCount() remaining = %d, want 7", rem)
+		}
+
+		// Floor at zero.
+		rem, err = store.DecrLiveChunkCount(ctx, r.BlockID, 100)
+		if err != nil {
+			t.Fatalf("DecrLiveChunkCount(floor) error = %v", err)
+		}
+		if rem != 0 {
+			t.Errorf("DecrLiveChunkCount(floor) remaining = %d, want 0", rem)
+		}
+	})
+
+	t.Run("DecrLiveChunkCountMissing", func(t *testing.T) {
+		_, err := store.DecrLiveChunkCount(ctx, "does-not-exist", 1)
+		if err == nil {
+			t.Fatal("DecrLiveChunkCount(missing) expected error, got nil")
+		}
+	})
+}

--- a/pkg/metadata/storetest/block_record_ops.go
+++ b/pkg/metadata/storetest/block_record_ops.go
@@ -8,17 +8,8 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// BlockRecordStoreProvider is implemented by stores with full BlockRecordStore
-// support. The conformance suite type-asserts to this and skips if unimplemented.
-type BlockRecordStoreProvider interface {
-	BlockRecordStoreEnabled() bool
-}
-
 func runBlockRecordOps(t *testing.T, store metadata.Store) {
 	t.Helper()
-	if p, ok := store.(BlockRecordStoreProvider); !ok || !p.BlockRecordStoreEnabled() {
-		t.Skip("BlockRecordStore not implemented by this backend")
-	}
 
 	ctx := context.Background()
 

--- a/pkg/metadata/storetest/commit_block_ops.go
+++ b/pkg/metadata/storetest/commit_block_ops.go
@@ -2,11 +2,79 @@ package storetest
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// ===========================================================================
+// Fault-injecting helpers for atomicity subtests
+// ===========================================================================
+
+// errPutLocalInjected is the sentinel returned by faultyLocalLocationStore.
+var errPutLocalInjected = errors.New("injected PutLocalLocation failure")
+
+// faultyLocalLocationStore wraps a Store and makes PutLocalLocation fail
+// inside WithTransaction. CommitBlock delegates to metadata.DefaultCommitBlock
+// with itself as the receiver so the injected WithTransaction is exercised.
+type faultyLocalLocationStore struct {
+	metadata.Store
+	errPut error
+}
+
+func (f *faultyLocalLocationStore) WithTransaction(ctx context.Context, fn func(metadata.Transaction) error) error {
+	return f.Store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return fn(&faultyLocalLocationTx{Transaction: tx, errPut: f.errPut})
+	})
+}
+
+func (f *faultyLocalLocationStore) CommitBlock(ctx context.Context, rec block.BlockRecord, chunks []block.BlockChunkCommit) error {
+	return metadata.DefaultCommitBlock(ctx, f, rec, chunks)
+}
+
+type faultyLocalLocationTx struct {
+	metadata.Transaction
+	errPut error
+}
+
+func (tx *faultyLocalLocationTx) PutLocalLocation(ctx context.Context, hash block.ContentHash, loc block.LocalChunkLocation) error {
+	if tx.errPut != nil {
+		return tx.errPut
+	}
+	return tx.Transaction.PutLocalLocation(ctx, hash, loc)
+}
+
+// errMarkSyncedInjected is the sentinel returned by faultyMarkSyncedStore.
+var errMarkSyncedInjected = errors.New("injected MarkSynced failure")
+
+// faultyMarkSyncedStore wraps a Store and makes MarkSynced fail the first time
+// it is called, then delegates subsequent calls. CommitBlock delegates to
+// metadata.DefaultCommitBlock with itself as the receiver so the injected
+// MarkSynced is actually exercised.
+type faultyMarkSyncedStore struct {
+	metadata.Store
+	mu        sync.Mutex
+	hasFailed bool
+}
+
+func (f *faultyMarkSyncedStore) MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if !f.hasFailed {
+		f.hasFailed = true
+		return errMarkSyncedInjected
+	}
+	return f.Store.MarkSynced(ctx, hash, loc)
+}
+
+func (f *faultyMarkSyncedStore) CommitBlock(ctx context.Context, rec block.BlockRecord, chunks []block.BlockChunkCommit) error {
+	return metadata.DefaultCommitBlock(ctx, f, rec, chunks)
+}
 
 // CommitBlockProvider is implemented by stores with full CommitBlock support.
 // The conformance suite type-asserts to this and skips if unimplemented.
@@ -191,5 +259,97 @@ func runCommitBlockOps(t *testing.T, store metadata.Store) {
 		if loc != local {
 			t.Errorf("GetLocalLocation() = %+v, want %+v", loc, local)
 		}
+	})
+
+	t.Run("Atomicity", func(t *testing.T) {
+		t.Run("InTxRollback", func(t *testing.T) {
+			t.Parallel()
+
+			rec := block.BlockRecord{
+				BlockID:        "atomicity-rollback",
+				BlockHash:      makeHash(0xA0),
+				Length:         1024,
+				LiveChunkCount: 1,
+				SyncState:      block.BlockStatePending,
+			}
+			chunks := []block.BlockChunkCommit{
+				{
+					Hash:   makeHash(0xA1),
+					Remote: block.ChunkLocator{BlockID: "atomicity-rollback", WireOffset: 0, WireLength: 1024},
+					Local:  block.LocalChunkLocation{LogBlobID: "log-atm-01", RawOffset: 0, RawLength: 1024},
+				},
+			}
+
+			faulty := &faultyLocalLocationStore{Store: store, errPut: errPutLocalInjected}
+			err := faulty.CommitBlock(ctx, rec, chunks)
+			require.Error(t, err, "CommitBlock must fail on injected PutLocalLocation error")
+			require.ErrorIs(t, err, errPutLocalInjected)
+
+			// Neither block record nor local location must have persisted: tx rolled back.
+			_, found, err := store.GetBlockRecord(ctx, rec.BlockID)
+			require.NoError(t, err)
+			assert.False(t, found, "block record must not persist after in-tx rollback")
+
+			_, found, err = store.GetLocalLocation(ctx, chunks[0].Hash)
+			require.NoError(t, err)
+			assert.False(t, found, "local location must not persist after in-tx rollback")
+		})
+
+		t.Run("CrossPhaseRetry", func(t *testing.T) {
+			t.Parallel()
+
+			rec := block.BlockRecord{
+				BlockID:        "atomicity-retry",
+				BlockHash:      makeHash(0xB0),
+				Length:         512,
+				LiveChunkCount: 1,
+				SyncState:      block.BlockStatePending,
+			}
+			chunks := []block.BlockChunkCommit{
+				{
+					Hash:   makeHash(0xB1),
+					Remote: block.ChunkLocator{BlockID: "atomicity-retry", WireOffset: 0, WireLength: 512},
+					Local:  block.LocalChunkLocation{LogBlobID: "log-atm-02", RawOffset: 0, RawLength: 512},
+				},
+			}
+
+			faulty := &faultyMarkSyncedStore{Store: store}
+
+			// First call: transaction commits (block record + local location written)
+			// but MarkSynced fails → error returned. This mimics a crash between the
+			// commit phase and the MarkSynced phase.
+			err := faulty.CommitBlock(ctx, rec, chunks)
+			require.Error(t, err, "first CommitBlock must fail on injected MarkSynced failure")
+			require.ErrorIs(t, err, errMarkSyncedInjected)
+
+			// Retry with no more MarkSynced faults. The idempotency guard must NOT
+			// short-circuit before the MarkSynced loop — all remote locators must be
+			// written even though the block record already exists from the first call.
+			err = faulty.CommitBlock(ctx, rec, chunks)
+			require.NoError(t, err, "retry CommitBlock must succeed")
+
+			// Block record must be present with the original LiveChunkCount (not doubled).
+			got, found, err := store.GetBlockRecord(ctx, rec.BlockID)
+			require.NoError(t, err)
+			require.True(t, found, "block record must be present after retry")
+			assert.Equal(t, rec.LiveChunkCount, got.LiveChunkCount,
+				"LiveChunkCount must not be doubled by the retry")
+
+			// Local location must be present.
+			lloc, found, err := store.GetLocalLocation(ctx, chunks[0].Hash)
+			require.NoError(t, err)
+			require.True(t, found, "local location must be present after retry")
+			assert.Equal(t, chunks[0].Local, lloc)
+
+			// Remote locator must now be marked synced.
+			synced, err := store.IsSynced(ctx, chunks[0].Hash)
+			require.NoError(t, err)
+			assert.True(t, synced, "chunk must be marked synced after retry CommitBlock")
+
+			locator, found, err := store.GetLocator(ctx, chunks[0].Hash)
+			require.NoError(t, err)
+			assert.True(t, found, "GetLocator must find chunk after retry")
+			assert.Equal(t, chunks[0].Remote, locator)
+		})
 	})
 }

--- a/pkg/metadata/storetest/commit_block_ops.go
+++ b/pkg/metadata/storetest/commit_block_ops.go
@@ -1,0 +1,195 @@
+package storetest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// CommitBlockProvider is implemented by stores with full CommitBlock support.
+// The conformance suite type-asserts to this and skips if unimplemented.
+type CommitBlockProvider interface {
+	CommitBlockEnabled() bool
+}
+
+func runCommitBlockOps(t *testing.T, store metadata.Store) {
+	t.Helper()
+	if p, ok := store.(CommitBlockProvider); !ok || !p.CommitBlockEnabled() {
+		t.Skip("CommitBlock not implemented by this backend")
+	}
+
+	ctx := context.Background()
+
+	makeHash := func(b byte) block.ContentHash {
+		var h block.ContentHash
+		h[0] = b
+		return h
+	}
+
+	t.Run("FullCommit", func(t *testing.T) {
+		rec := block.BlockRecord{
+			BlockID:        "commit-full",
+			BlockHash:      makeHash(0x01),
+			Length:         2048,
+			LiveChunkCount: 2,
+			SyncState:      block.BlockStatePending,
+		}
+		chunks := []block.BlockChunkCommit{
+			{
+				Hash:   makeHash(0x10),
+				Remote: block.ChunkLocator{BlockID: "commit-full", WireOffset: 0, WireLength: 1024},
+				Local:  block.LocalChunkLocation{LogBlobID: "log-001", RawOffset: 0, RawLength: 1024},
+			},
+			{
+				Hash:   makeHash(0x11),
+				Remote: block.ChunkLocator{BlockID: "commit-full", WireOffset: 1024, WireLength: 1024},
+				Local:  block.LocalChunkLocation{LogBlobID: "log-001", RawOffset: 1024, RawLength: 1024},
+			},
+		}
+
+		if err := store.CommitBlock(ctx, rec, chunks); err != nil {
+			t.Fatalf("CommitBlock() error = %v", err)
+		}
+
+		// Block record persisted.
+		got, found, err := store.GetBlockRecord(ctx, rec.BlockID)
+		if err != nil {
+			t.Fatalf("GetBlockRecord() error = %v", err)
+		}
+		if !found {
+			t.Fatal("GetBlockRecord() found = false after CommitBlock")
+		}
+		if got != rec {
+			t.Errorf("GetBlockRecord() = %+v, want %+v", got, rec)
+		}
+
+		// Local locations persisted.
+		for i, c := range chunks {
+			loc, found, err := store.GetLocalLocation(ctx, c.Hash)
+			if err != nil {
+				t.Fatalf("GetLocalLocation(chunk %d) error = %v", i, err)
+			}
+			if !found {
+				t.Fatalf("GetLocalLocation(chunk %d) found = false", i)
+			}
+			if loc != c.Local {
+				t.Errorf("GetLocalLocation(chunk %d) = %+v, want %+v", i, loc, c.Local)
+			}
+		}
+
+		// Remote locators synced.
+		for i, c := range chunks {
+			synced, err := store.IsSynced(ctx, c.Hash)
+			if err != nil {
+				t.Fatalf("IsSynced(chunk %d) error = %v", i, err)
+			}
+			if !synced {
+				t.Errorf("IsSynced(chunk %d) = false, want true", i)
+			}
+			locator, found, err := store.GetLocator(ctx, c.Hash)
+			if err != nil {
+				t.Fatalf("GetLocator(chunk %d) error = %v", i, err)
+			}
+			if !found {
+				t.Fatalf("GetLocator(chunk %d) found = false", i)
+			}
+			if locator != c.Remote {
+				t.Errorf("GetLocator(chunk %d) = %+v, want %+v", i, locator, c.Remote)
+			}
+		}
+	})
+
+	t.Run("Idempotency", func(t *testing.T) {
+		rec := block.BlockRecord{
+			BlockID:        "commit-idem",
+			BlockHash:      makeHash(0x02),
+			Length:         512,
+			LiveChunkCount: 3,
+			SyncState:      block.BlockStatePending,
+		}
+		chunks := []block.BlockChunkCommit{
+			{
+				Hash:   makeHash(0x20),
+				Remote: block.ChunkLocator{BlockID: "commit-idem", WireOffset: 0, WireLength: 512},
+				Local:  block.LocalChunkLocation{LogBlobID: "log-002", RawOffset: 0, RawLength: 512},
+			},
+		}
+
+		if err := store.CommitBlock(ctx, rec, chunks); err != nil {
+			t.Fatalf("CommitBlock() first call error = %v", err)
+		}
+		// Second call must be a no-op (not an error, not doubling count).
+		if err := store.CommitBlock(ctx, rec, chunks); err != nil {
+			t.Fatalf("CommitBlock() second call error = %v", err)
+		}
+
+		got, found, err := store.GetBlockRecord(ctx, rec.BlockID)
+		if err != nil {
+			t.Fatalf("GetBlockRecord() error = %v", err)
+		}
+		if !found {
+			t.Fatal("GetBlockRecord() found = false")
+		}
+		// LiveChunkCount must still equal the first-call value (not doubled).
+		if got.LiveChunkCount != rec.LiveChunkCount {
+			t.Errorf("LiveChunkCount = %d after idempotent CommitBlock, want %d",
+				got.LiveChunkCount, rec.LiveChunkCount)
+		}
+	})
+
+	t.Run("Dedup", func(t *testing.T) {
+		// Two chunks sharing the same content hash in one block must yield a
+		// single synced entry (MarkSynced is idempotent).
+		dupHash := makeHash(0x30)
+		rec := block.BlockRecord{
+			BlockID:        "commit-dedup",
+			BlockHash:      makeHash(0x03),
+			Length:         2048,
+			LiveChunkCount: 1,
+			SyncState:      block.BlockStatePending,
+		}
+		remote := block.ChunkLocator{BlockID: "commit-dedup", WireOffset: 0, WireLength: 1024}
+		local := block.LocalChunkLocation{LogBlobID: "log-003", RawOffset: 0, RawLength: 1024}
+		chunks := []block.BlockChunkCommit{
+			{Hash: dupHash, Remote: remote, Local: local},
+			{Hash: dupHash, Remote: remote, Local: local},
+		}
+
+		if err := store.CommitBlock(ctx, rec, chunks); err != nil {
+			t.Fatalf("CommitBlock() error = %v", err)
+		}
+
+		// Exactly one synced entry exists for the shared hash.
+		synced, err := store.IsSynced(ctx, dupHash)
+		if err != nil {
+			t.Fatalf("IsSynced() error = %v", err)
+		}
+		if !synced {
+			t.Error("IsSynced() = false, want true for deduped chunk")
+		}
+		locator, found, err := store.GetLocator(ctx, dupHash)
+		if err != nil {
+			t.Fatalf("GetLocator() error = %v", err)
+		}
+		if !found {
+			t.Fatal("GetLocator() found = false for deduped chunk")
+		}
+		if locator != remote {
+			t.Errorf("GetLocator() = %+v, want %+v", locator, remote)
+		}
+
+		// And the single local location resolves correctly.
+		loc, found, err := store.GetLocalLocation(ctx, dupHash)
+		if err != nil {
+			t.Fatalf("GetLocalLocation() error = %v", err)
+		}
+		if !found {
+			t.Fatal("GetLocalLocation() found = false for deduped chunk")
+		}
+		if loc != local {
+			t.Errorf("GetLocalLocation() = %+v, want %+v", loc, local)
+		}
+	})
+}

--- a/pkg/metadata/storetest/commit_block_ops.go
+++ b/pkg/metadata/storetest/commit_block_ops.go
@@ -76,17 +76,8 @@ func (f *faultyMarkSyncedStore) CommitBlock(ctx context.Context, rec block.Block
 	return metadata.DefaultCommitBlock(ctx, f, rec, chunks)
 }
 
-// CommitBlockProvider is implemented by stores with full CommitBlock support.
-// The conformance suite type-asserts to this and skips if unimplemented.
-type CommitBlockProvider interface {
-	CommitBlockEnabled() bool
-}
-
 func runCommitBlockOps(t *testing.T, store metadata.Store) {
 	t.Helper()
-	if p, ok := store.(CommitBlockProvider); !ok || !p.CommitBlockEnabled() {
-		t.Skip("CommitBlock not implemented by this backend")
-	}
 
 	ctx := context.Background()
 

--- a/pkg/metadata/storetest/local_index_ops.go
+++ b/pkg/metadata/storetest/local_index_ops.go
@@ -8,17 +8,8 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// LocalChunkIndexProvider is implemented by stores with full LocalChunkIndex
-// support. The conformance suite type-asserts to this and skips if unimplemented.
-type LocalChunkIndexProvider interface {
-	LocalChunkIndexEnabled() bool
-}
-
 func runLocalIndexOps(t *testing.T, store metadata.Store) {
 	t.Helper()
-	if p, ok := store.(LocalChunkIndexProvider); !ok || !p.LocalChunkIndexEnabled() {
-		t.Skip("LocalChunkIndex not implemented by this backend")
-	}
 
 	ctx := context.Background()
 

--- a/pkg/metadata/storetest/local_index_ops.go
+++ b/pkg/metadata/storetest/local_index_ops.go
@@ -1,0 +1,97 @@
+package storetest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// LocalChunkIndexProvider is implemented by stores with full LocalChunkIndex
+// support. The conformance suite type-asserts to this and skips if unimplemented.
+type LocalChunkIndexProvider interface {
+	LocalChunkIndexEnabled() bool
+}
+
+func runLocalIndexOps(t *testing.T, store metadata.Store) {
+	t.Helper()
+	if p, ok := store.(LocalChunkIndexProvider); !ok || !p.LocalChunkIndexEnabled() {
+		t.Skip("LocalChunkIndex not implemented by this backend")
+	}
+
+	ctx := context.Background()
+
+	hash := block.ContentHash{0xAA, 0xBB, 0xCC}
+	loc := block.LocalChunkLocation{LogBlobID: "logblob-001", RawOffset: 4096, RawLength: 512}
+
+	t.Run("PutGetRoundTrip", func(t *testing.T) {
+		if err := store.PutLocalLocation(ctx, hash, loc); err != nil {
+			t.Fatalf("PutLocalLocation() error = %v", err)
+		}
+		got, found, err := store.GetLocalLocation(ctx, hash)
+		if err != nil {
+			t.Fatalf("GetLocalLocation() error = %v", err)
+		}
+		if !found {
+			t.Fatal("GetLocalLocation() found = false, want true")
+		}
+		if got != loc {
+			t.Errorf("GetLocalLocation() = %+v, want %+v", got, loc)
+		}
+	})
+
+	t.Run("UpsertOverwrites", func(t *testing.T) {
+		h := block.ContentHash{0x11}
+		first := block.LocalChunkLocation{LogBlobID: "blob-first", RawOffset: 0, RawLength: 100}
+		second := block.LocalChunkLocation{LogBlobID: "blob-second", RawOffset: 100, RawLength: 200}
+
+		if err := store.PutLocalLocation(ctx, h, first); err != nil {
+			t.Fatalf("PutLocalLocation(first) error = %v", err)
+		}
+		if err := store.PutLocalLocation(ctx, h, second); err != nil {
+			t.Fatalf("PutLocalLocation(second) error = %v", err)
+		}
+
+		got, found, err := store.GetLocalLocation(ctx, h)
+		if err != nil {
+			t.Fatalf("GetLocalLocation() error = %v", err)
+		}
+		if !found {
+			t.Fatal("GetLocalLocation() found = false, want true")
+		}
+		if got != second {
+			t.Errorf("GetLocalLocation() = %+v, want %+v (second write should win)", got, second)
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		h := block.ContentHash{0x22}
+		l := block.LocalChunkLocation{LogBlobID: "blob-del", RawOffset: 8, RawLength: 16}
+		if err := store.PutLocalLocation(ctx, h, l); err != nil {
+			t.Fatalf("PutLocalLocation() error = %v", err)
+		}
+		if err := store.DeleteLocalLocation(ctx, h); err != nil {
+			t.Fatalf("DeleteLocalLocation() error = %v", err)
+		}
+		_, found, err := store.GetLocalLocation(ctx, h)
+		if err != nil {
+			t.Fatalf("GetLocalLocation(after delete) error = %v", err)
+		}
+		if found {
+			t.Fatal("GetLocalLocation(after delete) found = true, want false")
+		}
+	})
+
+	t.Run("MissingReturnsNotFound", func(t *testing.T) {
+		var absent block.ContentHash
+		absent[0] = 0xFF
+		_, found, err := store.GetLocalLocation(ctx, absent)
+		if err != nil {
+			t.Fatalf("GetLocalLocation(missing) error = %v", err)
+		}
+		if found {
+			t.Fatal("GetLocalLocation(missing) found = true, want false")
+		}
+	})
+}

--- a/pkg/metadata/storetest/suite.go
+++ b/pkg/metadata/storetest/suite.go
@@ -171,21 +171,18 @@ func RunConformanceSuite(t *testing.T, factory StoreFactory) {
 
 	// BlockRecordOps covers BlockRecordStore: put/get round-trip, delete,
 	// walk, missing-ID miss, DecrLiveChunkCount (normal + floor + missing).
-	// Stores lacking BlockRecordStoreEnabled() skip cleanly.
 	t.Run("BlockRecordOps", func(t *testing.T) {
 		runBlockRecordOps(t, factory(t))
 	})
 
 	// LocalIndexOps covers LocalChunkIndex: put/get round-trip, upsert
-	// overwrites, delete, missing-hash miss. Skips unless
-	// LocalChunkIndexEnabled().
+	// overwrites, delete, missing-hash miss.
 	t.Run("LocalIndexOps", func(t *testing.T) {
 		runLocalIndexOps(t, factory(t))
 	})
 
 	// CommitBlockOps covers CommitBlock: full commit (record + local locations
-	// + synced markers), idempotency (second call is no-op). Skips unless
-	// CommitBlockEnabled().
+	// + synced markers), idempotency (second call is no-op).
 	t.Run("CommitBlockOps", func(t *testing.T) {
 		runCommitBlockOps(t, factory(t))
 	})

--- a/pkg/metadata/storetest/suite.go
+++ b/pkg/metadata/storetest/suite.go
@@ -168,6 +168,27 @@ func RunConformanceSuite(t *testing.T, factory StoreFactory) {
 	t.Run("Trash", func(t *testing.T) {
 		runTrashConformanceTests(t, factory)
 	})
+
+	// BlockRecordOps covers BlockRecordStore: put/get round-trip, delete,
+	// walk, missing-ID miss, DecrLiveChunkCount (normal + floor + missing).
+	// Stores lacking BlockRecordStoreEnabled() skip cleanly.
+	t.Run("BlockRecordOps", func(t *testing.T) {
+		runBlockRecordOps(t, factory(t))
+	})
+
+	// LocalIndexOps covers LocalChunkIndex: put/get round-trip, upsert
+	// overwrites, delete, missing-hash miss. Skips unless
+	// LocalChunkIndexEnabled().
+	t.Run("LocalIndexOps", func(t *testing.T) {
+		runLocalIndexOps(t, factory(t))
+	})
+
+	// CommitBlockOps covers CommitBlock: full commit (record + local locations
+	// + synced markers), idempotency (second call is no-op). Skips unless
+	// CommitBlockEnabled().
+	t.Run("CommitBlockOps", func(t *testing.T) {
+		runCommitBlockOps(t, factory(t))
+	})
 }
 
 // createTestShare is a helper that creates a share and root directory for testing.


### PR DESCRIPTION
PR2 of the blocks-only storage redesign (epic #1493). Adds the **durable substrate** as **dormant capability** — the live writer is unchanged (still the per-file append-log → FastCDC → `cas/<hash>` rollup). PR3 wires this in and flips behavior; PR4 deletes the legacy path.

Delivers **#1416** (single-transaction per-block commit — one fsync per block for the local durable commit, not one per file).

## What landed

**Metadata (all 4 backends: memory, badger, sqlite, postgres)**
- `block.BlockRecord{BlockID, BlockHash, Length, LiveChunkCount, SyncState}` + `metadata.BlockRecordStore` (Put/Get/Delete/Walk/`DecrLiveChunkCount`).
- `block.LocalChunkLocation{LogBlobID, RawOffset, RawLength}` + `metadata.LocalChunkIndex` — the local-tier analog of `SyncedHashStore`'s remote locator (both hash-keyed).
- `metadata.DefaultCommitBlock` — block record + every chunk's local-index entry written in one transaction; the per-chunk remote locator (`MarkSynced`) runs as a separate idempotent post-commit phase. Idempotent and retry-safe.
- `storetest` conformance groups (`BlockRecordOps`, `LocalIndexOps`, `CommitBlockOps`) run unconditionally on every backend. sqlite migration `000003`, postgres migration `000036` (+ backup schema v5).

**Log-blob local tier — new package `pkg/block/local/logblob`**
- `Manager`: raw append-at-tail (`Append` → pwrite), positioned `ReadAt` (pread, concurrent with appends), `Rotate` at ~1 GiB cap (fsyncs on seal → rotation is a durability boundary), whole-blob `EvictBlob` (refuses active/unsynced; evicted reads → `ErrEvicted`), torn-tail `Recover` (truncate to durable high-water mark, rejects offset > size).
- `blockstoretest.LogBlobConformance`. Race-clean. **Not wired into FSStore** (PR3 wires it).

**Docs:** `docs/internals/implementing-stores.md` (block record / local index / CommitBlock contracts) + `architecture.md` (log-blob tier, explicit dormant-until-PR3 caveat).

## Verification
- `go test ./pkg/metadata/... ./pkg/block/...` green; `-race` clean on `logblob`.
- postgres conformance verified locally against a real postgres:16 container (190 PASS incl. the 3 new groups + snapshot/restore). CI runs it via `-tags integration`.
- Whole-branch review (independent): backend parity exact, CommitBlock idempotent on all 4 backends, no live-path leak, no premature type renames, capability probe fully removed.

## Forward note (PR3)
The log-blob tier is dormant; PR3 wires `FSStore`/syncer to carve blocks → `PutBlock`, then `DefaultCommitBlock`, and supplies the synced-predicate to `EvictBlob` + the high-water mark to `Recover`.

Refs #1493, #1416.