### PR TITLE
fix(nfs): bound system rpcbind registration so it cannot stall Serve

### DIFF
--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -791,8 +791,9 @@ func (s *NFSAdapter) Serve(ctx context.Context) error {
 
 	// Register services with the host's system rpcbind (port 111) when enabled,
 	// so a kernel NFSv3 client can discover the NLM port and lock without
-	// `nolock`. Non-fatal: if no rpcbind answers, NFS serves but v3 locking
-	// stays unavailable.
+	// `nolock`. Non-fatal and time-bounded: if no rpcbind answers (or it hangs)
+	// NFS still serves; registration cannot delay NFS availability for more than
+	// systemRegTimeout.
 	s.startSystemPortmapRegistration(ctx)
 
 	// Start the UDP transport for NLM/NSM/MOUNT when enabled. NFSv3 lock

--- a/pkg/adapter/nfs/portmap.go
+++ b/pkg/adapter/nfs/portmap.go
@@ -106,8 +106,12 @@ func systemPortmapAddr() string {
 // startSystemPortmapRegistration registers DittoFS's services with the host's
 // system rpcbind (port 111) when adapters.nfs.portmapper.register_with_system is
 // enabled. Best effort: a missing/unreachable rpcbind is logged and skipped —
-// NFS still serves, only kernel NFSv3 (NLM) locking without `nolock` stays
-// unavailable. On success it sets sysregActive so shutdown unregisters.
+// systemRegTimeout bounds the whole startup registration (Ping + all SET/UNSET
+// round-trips) so a slow or hung system rpcbind can never delay NFS
+// availability by more than this. The normal local-rpcbind case completes in
+// well under a millisecond.
+const systemRegTimeout = 10 * time.Second
+
 // systemRegMappings returns the service mappings to register with the system
 // rpcbind. It deliberately EXCLUDES NSM (prog 100024): on a host that runs
 // rpc.statd, NSM is already owned by the host's status monitor, which is shared
@@ -130,6 +134,10 @@ func (s *NFSAdapter) startSystemPortmapRegistration(ctx context.Context) {
 	if !s.registerWithSystemEnabled() {
 		return
 	}
+
+	// Bound the whole registration so a slow/hung rpcbind cannot stall Serve.
+	ctx, cancel := context.WithTimeout(ctx, systemRegTimeout)
+	defer cancel()
 
 	addr := systemPortmapAddr()
 	if err := sysreg.Ping(ctx, addr); err != nil {


### PR DESCRIPTION
Follow-up to #1512 (addresses a Copilot review note). Part of #1503.

`startSystemPortmapRegistration` ran synchronously in `Serve` with a 5s per-call dial timeout. A responsive local rpcbind completes the ~16 SET/UNSET round-trips in well under a millisecond, but a *hung-but-listening* rpcbind could in principle delay NFS availability across many 5s timeouts.

Wrap the whole registration (the `Ping` + every SET/UNSET) in a single 10s context (`systemRegTimeout`) so a slow or hung rpcbind bounds the startup delay. Kept synchronous rather than backgrounded to avoid a shutdown race (a background goroutine could re-register during the teardown window before the adapter context is cancelled); a bounded synchronous call is race-free and simple.