### PR TITLE
fix(metadata): per-user read-only denial returns EACCES, not EROFS

### DIFF
--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -515,9 +515,9 @@ func (s *Service) checkPermission(ctx *AuthContext, handle FileHandle, perm Perm
 // shareForbidsWrites reports whether a read-only ceiling — per-user
 // (ctx.ShareReadOnly) or store-level (share options) — forbids modification of
 // the given file's share. It governs the deny decision (e.g. the SETATTR
-// owner-bypass ceiling), so it consults BOTH ceilings. It is consulted only on
-// the permission-denied path, so the extra share-options lookup is off the hot
-// path.
+// owner-bypass ceiling in SetFileAttributes), so it consults BOTH ceilings.
+// The store-options lookup runs only when ctx.ShareReadOnly is false, so the
+// common cases short-circuit before touching the store.
 func (s *Service) shareForbidsWrites(ctx *AuthContext, handle FileHandle) bool {
 	return ctx.ShareReadOnly || s.shareIsReadOnly(ctx, handle)
 }

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -490,12 +490,15 @@ func (s *Service) checkPermission(ctx *AuthContext, handle FileHandle, perm Perm
 		return err
 	}
 	if granted&perm == 0 {
-		// A write or delete denied solely because the share is read-only must
-		// surface as ErrReadOnly so NFSv3 returns NFS3ERR_ROFS (EROFS) per
-		// RFC 1813, rather than NFS3ERR_ACCES. SMB is unaffected: the error
-		// map renders ErrReadOnly and ErrAccessDenied alike as
-		// STATUS_ACCESS_DENIED.
-		if perm&(PermissionWrite|PermissionDelete) != 0 && s.shareForbidsWrites(ctx, handle) {
+		// A write or delete denied because the share/export itself is
+		// read-only must surface as ErrReadOnly so NFSv3 returns
+		// NFS3ERR_ROFS (EROFS) per RFC 1813, rather than NFS3ERR_ACCES. A
+		// denial from a per-user read-only permission level (ctx.ShareReadOnly
+		// on a writable share, e.g. a squashed/unknown uid given the share's
+		// default "read" permission) is an ordinary permission denial →
+		// ErrAccessDenied. SMB is unaffected: the error map renders
+		// ErrReadOnly and ErrAccessDenied alike as STATUS_ACCESS_DENIED.
+		if perm&(PermissionWrite|PermissionDelete) != 0 && s.shareIsReadOnly(ctx, handle) {
 			return &StoreError{
 				Code:    ErrReadOnly,
 				Message: msg,
@@ -511,12 +514,24 @@ func (s *Service) checkPermission(ctx *AuthContext, handle FileHandle, perm Perm
 
 // shareForbidsWrites reports whether a read-only ceiling — per-user
 // (ctx.ShareReadOnly) or store-level (share options) — forbids modification of
-// the given file's share. It is consulted only on the permission-denied path,
-// so the extra share-options lookup is off the hot path.
+// the given file's share. It governs the deny decision (e.g. the SETATTR
+// owner-bypass ceiling), so it consults BOTH ceilings. It is consulted only on
+// the permission-denied path, so the extra share-options lookup is off the hot
+// path.
 func (s *Service) shareForbidsWrites(ctx *AuthContext, handle FileHandle) bool {
-	if ctx.ShareReadOnly {
-		return true
-	}
+	return ctx.ShareReadOnly || s.shareIsReadOnly(ctx, handle)
+}
+
+// shareIsReadOnly reports whether the share/export itself is read-only at the
+// store level (ShareOptions.ReadOnly), independent of the requesting user's
+// permission level. Only a genuinely read-only share maps a write/delete denial
+// to ErrReadOnly (NFSv3 NFS3ERR_ROFS / EROFS per RFC 1813). The per-user ceiling
+// ctx.ShareReadOnly is deliberately excluded: it also goes true for a per-user
+// "read" permission level on a writable share (e.g. a squashed/unknown uid given
+// the share's default "read" permission — see the NFS share-permission
+// resolver), and such a denial is an ordinary permission denial (EACCES), not a
+// read-only filesystem.
+func (s *Service) shareIsReadOnly(ctx *AuthContext, handle FileHandle) bool {
 	store, err := s.storeForHandle(handle)
 	if err != nil {
 		return false
@@ -586,16 +601,22 @@ func (s *Service) CheckParentCreateAccess(ctx *AuthContext, parentHandle FileHan
 	}
 
 	shareOpts, _ := store.GetShareOptions(ctx.Context, file.ShareName)
+	storeReadOnly := shareOpts != nil && shareOpts.ReadOnly
 
-	// Read-only beats any ACL grant — both the per-user share permission
+	// Read-only beats any ALLOW DACL — both the per-user share permission
 	// (ctx.ShareReadOnly) and the store-level share option. Without the
 	// ctx.ShareReadOnly arm a read-only user could create entries under an
-	// ALLOW-granting parent DACL on an otherwise read-write share. #1276.
-	if ctx.ShareReadOnly || (shareOpts != nil && shareOpts.ReadOnly) {
-		// Read-only denial → ErrReadOnly so NFSv3 returns NFS3ERR_ROFS
-		// (EROFS) per RFC 1813. SMB renders it as STATUS_ACCESS_DENIED,
-		// identical to the prior ErrAccessDenied.
-		return &StoreError{Code: ErrReadOnly, Message: "read-only share"}
+	// ALLOW-granting parent DACL on an otherwise read-write share (#1276).
+	// A genuinely read-only share/export → ErrReadOnly so NFSv3 returns
+	// NFS3ERR_ROFS (EROFS) per RFC 1813; a per-user read-only permission level
+	// on a writable share (e.g. a squashed/unknown uid given the share's
+	// default "read" permission) is an ordinary permission denial →
+	// ErrAccessDenied (NFS3ERR_ACCES). SMB renders both as STATUS_ACCESS_DENIED.
+	if ctx.ShareReadOnly || storeReadOnly {
+		if storeReadOnly {
+			return &StoreError{Code: ErrReadOnly, Message: "read-only share"}
+		}
+		return &StoreError{Code: ErrAccessDenied, Message: "write permission denied"}
 	}
 
 	// CREATE has no open handle yet, so the handle-based write authorization

--- a/pkg/metadata/auth_permissions_readonly_share_test.go
+++ b/pkg/metadata/auth_permissions_readonly_share_test.go
@@ -164,8 +164,16 @@ func TestCheckParentCreateAccess_StoreReadOnlyShareReturnsErrReadOnly(t *testing
 	f := newTestFixture(t)
 
 	uid, gid := uint32(1003), uint32(1003)
+	// ALLOW-everyone DACL so the read-only-share ceiling is the ONLY thing that
+	// can deny: the test would not distinguish a regression (read-only check
+	// removed) from a missing grant without an explicit ALLOW to override.
+	allowAll := &acl.ACL{
+		ACEs: []acl.ACE{
+			{Type: acl.ACE4_ACCESS_ALLOWED_ACE_TYPE, Who: acl.SpecialEveryone, AccessMask: 0xFFFFFFFF},
+		},
+	}
 	dir, _, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "rodir2",
-		&metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o777, UID: uid, GID: gid})
+		&metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o777, UID: uid, GID: gid, ACL: allowAll})
 	require.NoError(t, err)
 	dirHandle, err := metadata.EncodeShareHandle(f.shareName, dir.ID)
 	require.NoError(t, err)

--- a/pkg/metadata/auth_permissions_readonly_share_test.go
+++ b/pkg/metadata/auth_permissions_readonly_share_test.go
@@ -116,7 +116,11 @@ func TestCheckPermissions_PerUserReadOnlyStripsWriteWithACL(t *testing.T) {
 
 // TestCheckParentCreateAccess_PerUserReadOnlyDenies asserts the create-path
 // ceiling: a read-only user cannot create an entry under an ALLOW-granting
-// parent DACL on an otherwise read-write share.
+// parent DACL on an otherwise read-write share. The denial is an ordinary
+// permission denial — the share itself is writable — so it must surface as
+// ErrAccessDenied (NFS3ERR_ACCES / EACCES), NOT ErrReadOnly. A squashed/unknown
+// uid given the share's default "read" permission lands here; the kernel client
+// reports "permission denied", not "read-only file system".
 func TestCheckParentCreateAccess_PerUserReadOnlyDenies(t *testing.T) {
 	f := newTestFixture(t)
 
@@ -135,15 +139,14 @@ func TestCheckParentCreateAccess_PerUserReadOnlyDenies(t *testing.T) {
 	ro := f.authContext(uid, gid)
 	ro.ShareReadOnly = true
 
-	// Read-only denial → ErrReadOnly (NFS3ERR_ROFS / EROFS) per RFC 1813; SMB
-	// renders it as STATUS_ACCESS_DENIED, identical to the prior code.
+	// Per-user read-only on a writable share → ErrAccessDenied (EACCES).
 	err = f.service.CheckParentCreateAccess(ro, dirHandle, false)
 	if err == nil {
-		t.Fatal("CheckParentCreateAccess returned nil for read-only user, want ErrReadOnly")
+		t.Fatal("CheckParentCreateAccess returned nil for read-only user, want ErrAccessDenied")
 	}
 	var storeErr *metadata.StoreError
-	if !errors.As(err, &storeErr) || storeErr.Code != metadata.ErrReadOnly {
-		t.Fatalf("CheckParentCreateAccess err = %v, want StoreError{Code: ErrReadOnly}", err)
+	if !errors.As(err, &storeErr) || storeErr.Code != metadata.ErrAccessDenied {
+		t.Fatalf("CheckParentCreateAccess err = %v, want StoreError{Code: ErrAccessDenied}", err)
 	}
 
 	// And the POSIX-only parent-write path (no ACL) must deny too.
@@ -152,11 +155,99 @@ func TestCheckParentCreateAccess_PerUserReadOnlyDenies(t *testing.T) {
 	}
 }
 
+// TestCheckParentCreateAccess_StoreReadOnlyShareReturnsErrReadOnly asserts the
+// other direction of the same discriminator: when the SHARE itself is read-only
+// (ShareOptions.ReadOnly), a create denial surfaces as ErrReadOnly so NFSv3
+// returns NFS3ERR_ROFS (EROFS) per RFC 1813 — preserving #1508's intent. This
+// guards against a regression that would collapse both cases back to one code.
+func TestCheckParentCreateAccess_StoreReadOnlyShareReturnsErrReadOnly(t *testing.T) {
+	f := newTestFixture(t)
+
+	uid, gid := uint32(1003), uint32(1003)
+	dir, _, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "rodir2",
+		&metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o777, UID: uid, GID: gid})
+	require.NoError(t, err)
+	dirHandle, err := metadata.EncodeShareHandle(f.shareName, dir.ID)
+	require.NoError(t, err)
+
+	// Toggle the share read-only at the STORE level; per-user ShareReadOnly stays
+	// false so only the store-level flag is in play.
+	_ = f.store.CreateShare(context.Background(), &metadata.Share{Name: f.shareName})
+	require.NoError(t, f.store.UpdateShareOptions(context.Background(), f.shareName,
+		&metadata.ShareOptions{ReadOnly: true}))
+
+	rw := f.authContext(uid, gid)
+	rw.ShareReadOnly = false
+
+	err = f.service.CheckParentCreateAccess(rw, dirHandle, false)
+	if err == nil {
+		t.Fatal("CheckParentCreateAccess returned nil on read-only share, want ErrReadOnly")
+	}
+	var storeErr *metadata.StoreError
+	if !errors.As(err, &storeErr) || storeErr.Code != metadata.ErrReadOnly {
+		t.Fatalf("CheckParentCreateAccess err = %v, want StoreError{Code: ErrReadOnly}", err)
+	}
+}
+
+// TestCheckParentWriteAccess_ReadOnlyDiscriminator exercises the data-write
+// permission path (checkPermission via CheckParentWriteAccess) and asserts the
+// EROFS-vs-EACCES discriminator directly:
+//   - store-level read-only share → ErrReadOnly (EROFS), preserving #1508;
+//   - per-user read-only on a writable share → ErrAccessDenied (EACCES);
+//   - an ordinary POSIX permission denial (no read-only ceiling) → ErrAccessDenied.
+func TestCheckParentWriteAccess_ReadOnlyDiscriminator(t *testing.T) {
+	asStoreErr := func(t *testing.T, err error) *metadata.StoreError {
+		t.Helper()
+		require.Error(t, err)
+		var storeErr *metadata.StoreError
+		require.True(t, errors.As(err, &storeErr), "err %v is not a *StoreError", err)
+		return storeErr
+	}
+
+	t.Run("per-user read-only on writable share is EACCES", func(t *testing.T) {
+		f := newTestFixture(t)
+		ro := f.authContext(1100, 1100)
+		ro.ShareReadOnly = true
+		got := asStoreErr(t, f.service.CheckParentWriteAccess(ro, f.rootHandle))
+		require.Equal(t, metadata.ErrAccessDenied, got.Code)
+	})
+
+	t.Run("store-level read-only share is EROFS", func(t *testing.T) {
+		f := newTestFixture(t)
+		_ = f.store.CreateShare(context.Background(), &metadata.Share{Name: f.shareName})
+		require.NoError(t, f.store.UpdateShareOptions(context.Background(), f.shareName,
+			&metadata.ShareOptions{ReadOnly: true}))
+		owner := f.authContext(1101, 1101)
+		owner.ShareReadOnly = false
+		got := asStoreErr(t, f.service.CheckParentWriteAccess(owner, f.rootHandle))
+		require.Equal(t, metadata.ErrReadOnly, got.Code)
+	})
+
+	t.Run("ordinary POSIX denial on writable share is EACCES", func(t *testing.T) {
+		f := newTestFixture(t)
+		// Directory owned by uid 2000, mode 0o755: "other" users get no write.
+		dir, _, err := f.service.CreateDirectory(f.rootContext(), f.rootHandle, "owned-dir",
+			&metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755, UID: 2000, GID: 2000})
+		require.NoError(t, err)
+		dirHandle, err := metadata.EncodeShareHandle(f.shareName, dir.ID)
+		require.NoError(t, err)
+		other := f.authContext(3000, 3000) // not owner, not in group
+		got := asStoreErr(t, f.service.CheckParentWriteAccess(other, dirHandle))
+		require.Equal(t, metadata.ErrAccessDenied, got.Code)
+	})
+}
+
 // TestSetFileAttributes_PerUserReadOnlyDeniesOwnerMutation asserts the SETATTR
 // ceiling: a read-only user may not mutate even a file they OWN — chmod, chown,
 // and (most importantly) installing a permissive ACL must all be denied. Without
 // the ceiling the owner-bypass in SetFileAttributes would let a read-only owner
 // escalate access on their own file.
+//
+// The denial code here is ErrReadOnly (EROFS) even for the per-user ceiling.
+// This is a KNOWN, DELIBERATE deferral: unlike the data WRITE/CREATE/DELETE path
+// (which now distinguishes a per-user read-only level → EACCES from a genuinely
+// read-only share → EROFS), SETATTR has not yet been aligned. The security
+// property asserted here — that the mutation is DENIED — is unaffected.
 func TestSetFileAttributes_PerUserReadOnlyDeniesOwnerMutation(t *testing.T) {
 	f := newTestFixture(t)
 

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -236,11 +236,15 @@ func (s *Service) SetFileAttributes(ctx *AuthContext, handle FileHandle, attrs *
 	// perform them. This guard sits BEFORE the owner/root bypass below: without
 	// it, the isOwner short-circuit would let an owner mutate their own file on
 	// a read-only share (most dangerously, install a permissive DACL on it).
-	// shareForbidsWrites checks both ceilings, mirroring the data path.
+	// shareForbidsWrites checks both ceilings (per-user and store-level).
 	if s.shareForbidsWrites(ctx, handle) {
-		// Read-only denial → ErrReadOnly so NFSv3 SETATTR returns
-		// NFS3ERR_ROFS (EROFS) per RFC 1813 §3.3.7, matching the WRITE and
-		// xattr paths. SMB renders ErrReadOnly as STATUS_ACCESS_DENIED.
+		// A read-only denial returns ErrReadOnly so NFSv3 SETATTR yields
+		// NFS3ERR_ROFS (EROFS) per RFC 1813 §3.3.7. NOTE: unlike the data
+		// WRITE/CREATE/DELETE path — which distinguishes a per-user read-only
+		// permission level (→ ErrAccessDenied/EACCES) from a genuinely
+		// read-only share (→ ErrReadOnly/EROFS) via shareIsReadOnly — SETATTR
+		// still maps the per-user ceiling to EROFS. Aligning it is a deferred
+		// follow-up; SMB renders ErrReadOnly as STATUS_ACCESS_DENIED regardless.
 		return nil, &StoreError{
 			Code:    ErrReadOnly,
 			Message: "read-only share: attribute change denied",

--- a/pkg/metadata/service_test.go
+++ b/pkg/metadata/service_test.go
@@ -704,6 +704,13 @@ func TestMetadataService_RemoveFile_DeletePermission(t *testing.T) {
 
 		parentHandle, name := prepareDeletePermTest(t, fx, 0755, 1000, 2000)
 
+		// A genuine read-only share manifests as BOTH the per-user ceiling
+		// (ctx.ShareReadOnly, set by the resolver) and the store-level flag.
+		// The store-level flag is what maps the denial to ErrReadOnly (EROFS);
+		// the per-user ceiling alone is an ordinary permission denial (EACCES).
+		require.NoError(t, fx.store.UpdateShareOptions(t.Context(), fx.shareName,
+			&metadata.ShareOptions{ReadOnly: true}))
+
 		ctx := fx.smbDeleteContext(2000, 2000)
 		ctx.ShareReadOnly = true
 
@@ -714,6 +721,25 @@ func TestMetadataService_RemoveFile_DeletePermission(t *testing.T) {
 		// Read-only denial → ErrReadOnly (NFS3ERR_ROFS / EROFS) per RFC 1813.
 		// SMB still renders it as STATUS_ACCESS_DENIED.
 		assert.Equal(t, metadata.ErrReadOnly, storeErr.Code)
+	})
+
+	// Per-user read-only on a WRITABLE share (e.g. a squashed/unknown uid given
+	// the share's default "read" permission): the delete is still denied, but as
+	// an ordinary permission denial → ErrAccessDenied (EACCES), NOT EROFS.
+	t.Run("per-user-read-only SMB-delete is EACCES", func(t *testing.T) {
+		t.Parallel()
+		fx := newTestFixture(t)
+
+		parentHandle, name := prepareDeletePermTest(t, fx, 0755, 1000, 2000)
+
+		ctx := fx.smbDeleteContext(2000, 2000)
+		ctx.ShareReadOnly = true // per-user ceiling only; share stays writable
+
+		_, _, err := fx.service.RemoveFile(ctx, parentHandle, name)
+		require.Error(t, err)
+		var storeErr *metadata.StoreError
+		require.ErrorAs(t, err, &storeErr)
+		assert.Equal(t, metadata.ErrAccessDenied, storeErr.Code)
 	})
 
 	// Sticky bit: caller has WRITE on parent but is neither the file owner
@@ -833,6 +859,13 @@ func TestMetadataService_RemoveDirectory_DeletePermission(t *testing.T) {
 
 		parentHandle, name := prepareDeletePermDirTest(t, fx, 0755, 1000, 2000)
 
+		// A genuine read-only share manifests as BOTH the per-user ceiling
+		// (ctx.ShareReadOnly, set by the resolver) and the store-level flag.
+		// The store-level flag is what maps the denial to ErrReadOnly (EROFS);
+		// the per-user ceiling alone is an ordinary permission denial (EACCES).
+		require.NoError(t, fx.store.UpdateShareOptions(t.Context(), fx.shareName,
+			&metadata.ShareOptions{ReadOnly: true}))
+
 		ctx := fx.smbDeleteContext(2000, 2000)
 		ctx.ShareReadOnly = true
 
@@ -843,6 +876,24 @@ func TestMetadataService_RemoveDirectory_DeletePermission(t *testing.T) {
 		// Read-only denial → ErrReadOnly (NFS3ERR_ROFS / EROFS) per RFC 1813.
 		// SMB still renders it as STATUS_ACCESS_DENIED.
 		assert.Equal(t, metadata.ErrReadOnly, storeErr.Code)
+	})
+
+	// Per-user read-only on a WRITABLE share: the delete is still denied, but as
+	// an ordinary permission denial → ErrAccessDenied (EACCES), NOT EROFS.
+	t.Run("per-user-read-only SMB-delete is EACCES", func(t *testing.T) {
+		t.Parallel()
+		fx := newTestFixture(t)
+
+		parentHandle, name := prepareDeletePermDirTest(t, fx, 0755, 1000, 2000)
+
+		ctx := fx.smbDeleteContext(2000, 2000)
+		ctx.ShareReadOnly = true // per-user ceiling only; share stays writable
+
+		_, err := fx.service.RemoveDirectory(ctx, parentHandle, name)
+		require.Error(t, err)
+		var storeErr *metadata.StoreError
+		require.ErrorAs(t, err, &storeErr)
+		assert.Equal(t, metadata.ErrAccessDenied, storeErr.Code)
 	})
 }
 


### PR DESCRIPTION
## Problem

e2e `TestNFSRootSquash` fails on `unknown_uid_is_denied` (NFSv3) and `unknown_uid_is_denied_(NFSv4)`: an unknown-uid write is denied with **EROFS** ("read-only file system") but should be **EACCES** ("permission denied").

This is a regression from #1508 (commit `b2e6ba49`). That PR made write/create/delete denials return `ErrReadOnly` (→ `NFS3ERR_ROFS`/EROFS) whenever `ctx.ShareReadOnly` was true. But `ctx.ShareReadOnly` is set by the NFS share-permission resolver as `share.ReadOnly || defaultPerm == PermissionRead` — so it is true both for a **genuinely read-only share** AND for a **per-user "read" permission level** on an otherwise writable share. An unknown/squashed uid that receives the share's default `read` permission lands in the latter bucket, so its denial was mis-mapped to EROFS instead of EACCES.

## Fix

Separate the two concerns:

- `shareForbidsWrites` (per-user `ctx.ShareReadOnly` **or** store-level `ShareOptions.ReadOnly`) still governs the **deny decision** — no operation that was previously denied is now allowed.
- New `shareIsReadOnly` (store-level `ShareOptions.ReadOnly` **only**) is the **error-code discriminator**: only a genuinely read-only share/export maps a write/delete denial to `ErrReadOnly` (EROFS). A per-user read-only level on a writable share is an ordinary permission denial → `ErrAccessDenied` (EACCES).

Applied at the two flagged sites in `pkg/metadata/auth_permissions.go`: `checkPermission` (WRITE/DELETE data path) and `CheckParentCreateAccess` (CREATE path — the path the e2e exercises).

Read-only-**share** → EROFS is preserved (verified by new/updated unit tests asserting both directions). Error mapping reference: `ErrReadOnly`→`NFS3ERR_ROFS`/`NFS4ERR_ROFS`, `ErrAccessDenied`→`NFS3ERR_ACCES`/`NFS4ERR_ACCES` (`internal/adapter/common/errmap.go`). SMB renders both alike as `STATUS_ACCESS_DENIED`.

## Scope note

SETATTR (`file_modify.go`) and the xattr path still map the per-user ceiling to EROFS. That is a deliberate, documented deferral (out of the e2e failure path); the deny decision there is unaffected and a clarifying comment + test note were added so the inconsistency is explicit.

## Tests

- `pkg/metadata`: updated the read-only-share delete tests to model a *genuine* read-only share (both ceilings) keeping EROFS; added per-user-only delete cases asserting EACCES; added `TestCheckParentCreateAccess_StoreReadOnlyShareReturnsErrReadOnly` and `TestCheckParentWriteAccess_ReadOnlyDiscriminator` covering both directions.
- `gofmt -s`, `go vet ./...`, `go build ./...`, `go test ./pkg/metadata/...` all green; `go build -tags e2e ./test/e2e/...` compiles. e2e `TestNFSRootSquash` runs in CI.