### PR TITLE
fix(nfs): wait for SMB lease break before granting byte-range lock

### DIFF
--- a/internal/adapter/nfs/v4/handlers/lock.go
+++ b/internal/adapter/nfs/v4/handlers/lock.go
@@ -152,6 +152,7 @@ func (h *Handler) handleLock(ctx *types.CompoundContext, reader io.Reader) *type
 			"client", ctx.ClientAddr)
 
 		result, stateErr = h.StateManager.LockNew(
+			ctx.Context,
 			lockOwnerClientID, lockOwnerData, lockSeqid,
 			openStateid, openSeqid,
 			ctx.CurrentFH, lockType, offset, length, reclaim,
@@ -190,6 +191,7 @@ func (h *Handler) handleLock(ctx *types.CompoundContext, reader io.Reader) *type
 			"client", ctx.ClientAddr)
 
 		result, stateErr = h.StateManager.LockExisting(
+			ctx.Context,
 			lockStateid, lockSeqid,
 			ctx.CurrentFH, lockType, offset, length, reclaim,
 		)

--- a/internal/adapter/nfs/v4/state/batch_state_manager_test.go
+++ b/internal/adapter/nfs/v4/state/batch_state_manager_test.go
@@ -28,7 +28,7 @@ func TestLockNew_BadLockSeqidDoesNotLeakState(t *testing.T) {
 	ownerData := []byte("new-owner")
 
 	// Bad lock seqid for a brand-new lock-owner: only nextSeqID(0)==1 is valid.
-	_, err := sm.LockNew(
+	_, err := sm.LockNew(context.Background(),
 		clientID, ownerData, 99,
 		openStateid, openSeqid+1,
 		fileHandle, types.WRITE_LT, 0, 100, false,
@@ -63,7 +63,7 @@ func TestLockNew_BadLockSeqidDoesNotLeakLockState(t *testing.T) {
 	ownerData := []byte("new-owner")
 
 	// Bad seqid rejection.
-	if _, err := sm.LockNew(
+	if _, err := sm.LockNew(context.Background(),
 		clientID, ownerData, 99,
 		openStateid, openSeqid+1,
 		fileHandle, types.WRITE_LT, 0, 100, false,
@@ -76,7 +76,7 @@ func TestLockNew_BadLockSeqidDoesNotLeakLockState(t *testing.T) {
 	}
 
 	// A valid follow-up LOCK (seqid=1) must now succeed cleanly.
-	res, err := sm.LockNew(
+	res, err := sm.LockNew(context.Background(),
 		clientID, ownerData, 1,
 		openStateid, openSeqid+1,
 		fileHandle, types.WRITE_LT, 0, 100, false,
@@ -205,7 +205,7 @@ func TestAcquireLock_DeniedOwnerDataIsDecodedBytes(t *testing.T) {
 
 	// Client A acquires an exclusive lock on [0, 100).
 	ownerA := []byte("owner-a")
-	if _, err := sm.LockNew(
+	if _, err := sm.LockNew(context.Background(),
 		clientA, ownerA, 1,
 		stateidA, seqA+1,
 		fh, types.WRITE_LT, 0, 100, false,
@@ -214,7 +214,7 @@ func TestAcquireLock_DeniedOwnerDataIsDecodedBytes(t *testing.T) {
 	}
 
 	// Client B requests an overlapping exclusive lock -> DENIED.
-	resB, err := sm.LockNew(
+	resB, err := sm.LockNew(context.Background(),
 		clientB, []byte("owner-b"), 1,
 		stateidB, seqB+1,
 		fh, types.WRITE_LT, 0, 100, false,

--- a/internal/adapter/nfs/v4/state/lock_resolver_test.go
+++ b/internal/adapter/nfs/v4/state/lock_resolver_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -22,7 +23,7 @@ func TestLockManagerResolver_FixesMissingManager(t *testing.T) {
 	// No manager, no resolver: LOCK must fail (reproduces the EIO bug).
 	smBroken := NewStateManager(90 * time.Second)
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, smBroken)
-	if _, err := smBroken.LockNew(
+	if _, err := smBroken.LockNew(context.Background(),
 		clientID, []byte("owner-a"), 1,
 		openStateid, openSeqid,
 		fileHandle, types.WRITE_LT, 0, 100, false,
@@ -35,7 +36,7 @@ func TestLockManagerResolver_FixesMissingManager(t *testing.T) {
 	sm := NewStateManager(90 * time.Second)
 	sm.SetLockManagerResolver(func(_ []byte) lock.LockManager { return lm })
 	clientID, fileHandle, openStateid, openSeqid = setupClientAndOpenState(t, sm)
-	if _, err := sm.LockNew(
+	if _, err := sm.LockNew(context.Background(),
 		clientID, []byte("owner-a"), 1,
 		openStateid, openSeqid,
 		fileHandle, types.WRITE_LT, 0, 100, false,
@@ -82,7 +83,7 @@ func TestLockManagerResolver_DetectsCrossProtocolConflict(t *testing.T) {
 	}
 
 	// NFSv4 LOCK for the same overlapping range must also be denied (not granted).
-	res, err := sm.LockNew(
+	res, err := sm.LockNew(context.Background(),
 		clientID, []byte("nfs-owner"), 1,
 		openStateid, openSeqid,
 		fileHandle, types.WRITE_LT, 50, 100, false,

--- a/internal/adapter/nfs/v4/state/lockowner_test.go
+++ b/internal/adapter/nfs/v4/state/lockowner_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -183,7 +184,7 @@ func TestLockNew_CreatesLockOwnerAndState(t *testing.T) {
 
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
-	lockResult, err := sm.LockNew(
+	lockResult, err := sm.LockNew(context.Background(),
 		clientID, []byte("lock-owner-1"), 1,
 		openStateid, openSeqid+1,
 		fileHandle, types.WRITE_LT, 0, 100, false,
@@ -207,7 +208,7 @@ func TestLockNew_ExistingLockOwner(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	// First lock
-	_, err := sm.LockNew(
+	_, err := sm.LockNew(context.Background(),
 		clientID, []byte("lock-owner-1"), 1,
 		openStateid, openSeqid+1,
 		fileHandle, types.WRITE_LT, 0, 50, false,
@@ -217,7 +218,7 @@ func TestLockNew_ExistingLockOwner(t *testing.T) {
 	}
 
 	// Second lock with same owner on different range
-	result, err := sm.LockNew(
+	result, err := sm.LockNew(context.Background(),
 		clientID, []byte("lock-owner-1"), 2,
 		openStateid, openSeqid+2,
 		fileHandle, types.WRITE_LT, 100, 50, false,
@@ -240,7 +241,7 @@ func TestLockNew_BadOpenStateid(t *testing.T) {
 	// Use a bogus open stateid
 	bogusStateid := &types.Stateid4{Seqid: 1}
 
-	_, err := sm.LockNew(
+	_, err := sm.LockNew(context.Background(),
 		clientID, []byte("lock-owner-1"), 1,
 		bogusStateid, 1,
 		fileHandle, types.WRITE_LT, 0, 100, false,
@@ -265,7 +266,7 @@ func TestLockNew_BadOpenSeqid(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	// Use a wrong open seqid (too high)
-	_, err := sm.LockNew(
+	_, err := sm.LockNew(context.Background(),
 		clientID, []byte("lock-owner-1"), 1,
 		openStateid, openSeqid+100,
 		fileHandle, types.WRITE_LT, 0, 100, false,
@@ -320,7 +321,7 @@ func TestLockNew_OpenModeViolation(t *testing.T) {
 	confirmedStateid := &confirmedRes.Stateid
 
 	// Try to get a write lock on a read-only open
-	_, lockErr := sm.LockNew(
+	_, lockErr := sm.LockNew(context.Background(),
 		result.ClientID, []byte("lock-owner"), 1,
 		confirmedStateid, 3,
 		fh, types.WRITE_LT, 0, 100, false,
@@ -348,7 +349,7 @@ func TestLockNew_GracePeriod(t *testing.T) {
 	sm.StartGracePeriod([]uint64{clientID})
 
 	// Non-reclaim should be blocked
-	_, err := sm.LockNew(
+	_, err := sm.LockNew(context.Background(),
 		clientID, []byte("lock-owner-1"), 1,
 		openStateid, openSeqid+1,
 		fileHandle, types.WRITE_LT, 0, 100, false,
@@ -365,7 +366,7 @@ func TestLockNew_GracePeriod(t *testing.T) {
 	}
 
 	// Reclaim should be allowed
-	result, err := sm.LockNew(
+	result, err := sm.LockNew(context.Background(),
 		clientID, []byte("lock-owner-1"), 1,
 		openStateid, openSeqid+1,
 		fileHandle, types.WRITE_LT, 0, 100, true,
@@ -393,7 +394,7 @@ func TestLockExisting_Success(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	// First lock to get a lock stateid
-	lockResult, err := sm.LockNew(
+	lockResult, err := sm.LockNew(context.Background(),
 		clientID, []byte("lock-owner-1"), 1,
 		openStateid, openSeqid+1,
 		fileHandle, types.WRITE_LT, 0, 50, false,
@@ -403,7 +404,7 @@ func TestLockExisting_Success(t *testing.T) {
 	}
 
 	// Second lock using existing lock stateid
-	existResult, err := sm.LockExisting(
+	existResult, err := sm.LockExisting(context.Background(),
 		&lockResult.Stateid, 2,
 		fileHandle, types.WRITE_LT, 100, 50, false,
 	)
@@ -431,7 +432,7 @@ func TestLockExisting_BadStateid(t *testing.T) {
 	// The epoch bytes won't match current boot epoch, so it's stale.
 	bogusStateid := &types.Stateid4{Seqid: 1}
 
-	_, err := sm.LockExisting(
+	_, err := sm.LockExisting(context.Background(),
 		bogusStateid, 1,
 		fileHandle, types.WRITE_LT, 0, 100, false,
 	)
@@ -457,7 +458,7 @@ func TestLockExisting_BadSeqid(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	// First lock
-	lockResult, err := sm.LockNew(
+	lockResult, err := sm.LockNew(context.Background(),
 		clientID, []byte("lock-owner-1"), 1,
 		openStateid, openSeqid+1,
 		fileHandle, types.WRITE_LT, 0, 50, false,
@@ -467,7 +468,7 @@ func TestLockExisting_BadSeqid(t *testing.T) {
 	}
 
 	// LockExisting with wrong seqid (too high)
-	_, err = sm.LockExisting(
+	_, err = sm.LockExisting(context.Background(),
 		&lockResult.Stateid, 100,
 		fileHandle, types.WRITE_LT, 100, 50, false,
 	)
@@ -535,7 +536,7 @@ func TestLockNew_Conflict(t *testing.T) {
 	confirmed2 := &confirmed2Res.Stateid
 
 	// Client 1 acquires exclusive lock on range [0, 100)
-	lockResult1, err := sm.LockNew(
+	lockResult1, err := sm.LockNew(context.Background(),
 		res1.ClientID, []byte("lock-owner-1"), 1,
 		confirmed1, 3,
 		fh, types.WRITE_LT, 0, 100, false,
@@ -548,7 +549,7 @@ func TestLockNew_Conflict(t *testing.T) {
 	}
 
 	// Client 2 tries to acquire exclusive lock on overlapping range [50, 150)
-	lockResult2, err := sm.LockNew(
+	lockResult2, err := sm.LockNew(context.Background(),
 		res2.ClientID, []byte("lock-owner-2"), 1,
 		confirmed2, 3,
 		fh, types.WRITE_LT, 50, 100, false,
@@ -594,7 +595,7 @@ func TestLockNew_SharedNoConflict(t *testing.T) {
 	confirmed2 := &confirmed2Res.Stateid
 
 	// Client 1 acquires shared lock
-	lockResult1, err := sm.LockNew(
+	lockResult1, err := sm.LockNew(context.Background(),
 		res1.ClientID, []byte("lock-owner-1"), 1,
 		confirmed1, 3,
 		fh, types.READ_LT, 0, 100, false,
@@ -607,7 +608,7 @@ func TestLockNew_SharedNoConflict(t *testing.T) {
 	}
 
 	// Client 2 acquires shared lock on same range -- should succeed
-	lockResult2, err := sm.LockNew(
+	lockResult2, err := sm.LockNew(context.Background(),
 		res2.ClientID, []byte("lock-owner-2"), 1,
 		confirmed2, 3,
 		fh, types.READ_LT, 0, 100, false,
@@ -632,7 +633,7 @@ func TestCloseFile_LocksHeld(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	// Acquire a lock
-	lockResult, err := sm.LockNew(
+	lockResult, err := sm.LockNew(context.Background(),
 		clientID, []byte("close-lock-owner"), 1,
 		openStateid, openSeqid+1,
 		fileHandle, types.WRITE_LT, 0, 100, false,
@@ -693,7 +694,7 @@ func TestReleaseLockOwner_NoLocks(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	// Create lock-owner via LockNew
-	lockResult, err := sm.LockNew(
+	lockResult, err := sm.LockNew(context.Background(),
 		clientID, []byte("release-owner"), 1,
 		openStateid, openSeqid+1,
 		fileHandle, types.WRITE_LT, 0, 100, false,
@@ -715,7 +716,7 @@ func TestReleaseLockOwner_NoLocks(t *testing.T) {
 	}
 
 	// Verify lock stateid is now invalid
-	_, valErr := sm.LockExisting(&lockResult.Stateid, 3, fileHandle, types.WRITE_LT, 0, 100, false)
+	_, valErr := sm.LockExisting(context.Background(), &lockResult.Stateid, 3, fileHandle, types.WRITE_LT, 0, 100, false)
 	if valErr == nil {
 		t.Fatal("expected error for lock stateid after RELEASE_LOCKOWNER")
 	}
@@ -729,7 +730,7 @@ func TestReleaseLockOwner_WithLocks(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	// Create lock-owner and hold a lock
-	_, err := sm.LockNew(
+	_, err := sm.LockNew(context.Background(),
 		clientID, []byte("held-lock-owner"), 1,
 		openStateid, openSeqid+1,
 		fileHandle, types.WRITE_LT, 0, 100, false,
@@ -774,7 +775,7 @@ func TestLeaseExpiry_CleansLockState(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	// Acquire a lock
-	lockResult, err := sm.LockNew(
+	lockResult, err := sm.LockNew(context.Background(),
 		clientID, []byte("expiry-lock-owner"), 1,
 		openStateid, openSeqid+1,
 		fileHandle, types.WRITE_LT, 0, 100, false,
@@ -796,7 +797,7 @@ func TestLeaseExpiry_CleansLockState(t *testing.T) {
 	time.Sleep(150 * time.Millisecond)
 
 	// Verify lock stateid is now invalid (cleaned up by onLeaseExpired)
-	_, valErr := sm.LockExisting(&lockResult.Stateid, 2, fileHandle, types.WRITE_LT, 0, 100, false)
+	_, valErr := sm.LockExisting(context.Background(), &lockResult.Stateid, 2, fileHandle, types.WRITE_LT, 0, 100, false)
 	if valErr == nil {
 		t.Fatal("expected error for lock stateid after lease expiry")
 	}
@@ -823,7 +824,7 @@ func TestLeaseExpiry_CleansLockManager(t *testing.T) {
 	clientID1, fileHandle, openStateid1, openSeqid1 := setupClientAndOpenState(t, sm)
 
 	// Acquire a lock with client 1
-	_, err := sm.LockNew(
+	_, err := sm.LockNew(context.Background(),
 		clientID1, []byte("client1-lock-owner"), 1,
 		openStateid1, openSeqid1+1,
 		fileHandle, types.WRITE_LT, 0, 100, false,
@@ -863,7 +864,7 @@ func TestLeaseExpiry_CleansLockManager(t *testing.T) {
 
 	// Client 2 should be able to acquire a lock on the same range
 	// (previously held by expired client 1)
-	lockResult2, err := sm.LockNew(
+	lockResult2, err := sm.LockNew(context.Background(),
 		res2.ClientID, []byte("client2-lock-owner"), 1,
 		confirmed2, 3,
 		fileHandle, types.WRITE_LT, 0, 100, false,
@@ -903,7 +904,7 @@ func TestLockNew_BlockingType(t *testing.T) {
 	confirmed2 := &confirmed2Res.Stateid
 
 	// Client 1 acquires exclusive lock
-	_, err := sm.LockNew(
+	_, err := sm.LockNew(context.Background(),
 		res1.ClientID, []byte("lock-owner-1"), 1,
 		confirmed1, 3,
 		fh, types.WRITE_LT, 0, 100, false,
@@ -913,7 +914,7 @@ func TestLockNew_BlockingType(t *testing.T) {
 	}
 
 	// Client 2 tries blocking write lock (WRITEW_LT) -- should get DENIED, not block
-	lockResult, err := sm.LockNew(
+	lockResult, err := sm.LockNew(context.Background(),
 		res2.ClientID, []byte("lock-owner-2"), 1,
 		confirmed2, 3,
 		fh, types.WRITEW_LT, 0, 100, false,
@@ -929,7 +930,7 @@ func TestLockNew_BlockingType(t *testing.T) {
 	// the open-owner seqid (RFC 7530 §8.1.5: NFS4ERR_DENIED is not a
 	// seqid-exempt error), so this reuse of the same open-owner uses the next
 	// open seqid (4), not 3.
-	lockResult2, err := sm.LockNew(
+	lockResult2, err := sm.LockNew(context.Background(),
 		res2.ClientID, []byte("lock-owner-2b"), 1,
 		confirmed2, 4,
 		fh, types.READW_LT, 0, 100, false,

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1812,6 +1812,7 @@ func (sm *StateManager) SetGracePeriodDuration(d time.Duration) {
 //
 // Caller must NOT hold sm.mu.
 func (sm *StateManager) LockNew(
+	ctx context.Context,
 	lockClientID uint64, lockOwnerData []byte, lockSeqid uint32,
 	openStateid *types.Stateid4, openSeqid uint32,
 	fileHandle []byte, lockType uint32, offset, length uint64, reclaim bool,
@@ -1945,7 +1946,7 @@ func (sm *StateManager) LockNew(
 	}
 
 	// 7. Acquire the lock via unified lock manager
-	denied, err := sm.acquireLock(lockState, lockType, offset, length, reclaim)
+	denied, err := sm.acquireLock(ctx, lockState, lockType, offset, length, reclaim)
 	if err != nil {
 		return nil, err
 	}
@@ -1980,6 +1981,7 @@ func (sm *StateManager) LockNew(
 //
 // Caller must NOT hold sm.mu.
 func (sm *StateManager) LockExisting(
+	ctx context.Context,
 	lockStateid *types.Stateid4, lockSeqid uint32,
 	fileHandle []byte, lockType uint32, offset, length uint64, reclaim bool,
 ) (*LockResult, error) {
@@ -2047,7 +2049,7 @@ func (sm *StateManager) LockExisting(
 	}
 
 	// 4. Acquire the lock
-	denied, err := sm.acquireLock(lockState, lockType, offset, length, reclaim)
+	denied, err := sm.acquireLock(ctx, lockState, lockType, offset, length, reclaim)
 	if err != nil {
 		return nil, err
 	}
@@ -2078,7 +2080,7 @@ func (sm *StateManager) LockExisting(
 // or (nil, error) on internal errors.
 //
 // Caller must hold sm.mu.
-func (sm *StateManager) acquireLock(lockState *LockState, lockType uint32, offset, length uint64, reclaim bool) (*LOCK4denied, error) {
+func (sm *StateManager) acquireLock(ctx context.Context, lockState *LockState, lockType uint32, offset, length uint64, reclaim bool) (*LOCK4denied, error) {
 	lm := sm.lockManagerFor(lockState.FileHandle)
 	if lm == nil {
 		return nil, fmt.Errorf("no lock manager configured")
@@ -2118,6 +2120,16 @@ func (sm *StateManager) acquireLock(lockState *LockState, lockType uint32, offse
 	// symmetry with the SMB path; NFS owners never hold SMB leases, so in practice
 	// nothing is excluded.
 	_ = lm.BreakLeasesForByteRangeLock(handleKey, &owner)
+
+	// Drain the in-flight lease break before inserting the lock: the break is
+	// fire-and-forget, so a still-present (Breaking, not-yet-ACKed) write lease is
+	// otherwise observed as a spurious DENIED → client EIO (#1501). See
+	// lock.WaitForByteRangeLockBreak for the deadlock-safety and timeout reasoning.
+	// A non-nil error means the originating request was cancelled, so don't insert
+	// a lock nobody is waiting for.
+	if err := lock.WaitForByteRangeLockBreak(ctx, lm, handleKey); err != nil {
+		return nil, err
+	}
 
 	// Try to add the lock
 	err := lm.AddUnifiedLock(handleKey, enhLock)

--- a/internal/adapter/nfs/v4/state/replay_cache_test.go
+++ b/internal/adapter/nfs/v4/state/replay_cache_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -148,7 +149,7 @@ func TestReplay_Lock_ReturnsCachedReply(t *testing.T) {
 	clientID, fh, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	// LOCK (new lock-owner) at lock seqid 1.
-	res, err := sm.LockNew(clientID, []byte("lock-replay-owner"), 1,
+	res, err := sm.LockNew(context.Background(), clientID, []byte("lock-replay-owner"), 1,
 		openStateid, openSeqid+1, fh, types.WRITE_LT, 0, 100, false)
 	if err != nil {
 		t.Fatalf("LockNew: %v", err)
@@ -162,7 +163,7 @@ func TestReplay_Lock_ReturnsCachedReply(t *testing.T) {
 	// Retransmit the LOCK at the SAME lock seqid via the existing-lock-owner
 	// path. The old code returned NFS4ERR_BAD_SEQID here (fatal to the Linux
 	// client -> dropped lock-owner / silent lock loss); it must replay instead.
-	_, err = sm.LockExisting(&res.Stateid, 1, fh, types.WRITE_LT, 0, 100, false)
+	_, err = sm.LockExisting(context.Background(), &res.Stateid, 1, fh, types.WRITE_LT, 0, 100, false)
 	mustReplay(t, err, types.NFS4_OK, cachedReply)
 }
 
@@ -174,7 +175,7 @@ func TestReplay_LockU_ReturnsCachedReply(t *testing.T) {
 
 	clientID, fh, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
-	res, err := sm.LockNew(clientID, []byte("locku-replay-owner"), 1,
+	res, err := sm.LockNew(context.Background(), clientID, []byte("locku-replay-owner"), 1,
 		openStateid, openSeqid+1, fh, types.WRITE_LT, 0, 100, false)
 	if err != nil {
 		t.Fatalf("LockNew: %v", err)
@@ -208,13 +209,13 @@ func TestReplay_Lock_Denied_CachesAndReplays(t *testing.T) {
 
 	// Client 1 holds an exclusive lock on [0,100).
 	c1, _, open1, seq1 := setupClientAndOpenStateNamed(t, sm, "denied-c1", "owner-1", fh)
-	if _, err := sm.LockNew(c1, []byte("lock-owner-1"), 1, open1, seq1+1, fh, types.WRITE_LT, 0, 100, false); err != nil {
+	if _, err := sm.LockNew(context.Background(), c1, []byte("lock-owner-1"), 1, open1, seq1+1, fh, types.WRITE_LT, 0, 100, false); err != nil {
 		t.Fatalf("LockNew c1: %v", err)
 	}
 
 	// Client 2's overlapping LOCK is DENIED.
 	c2, _, open2, seq2 := setupClientAndOpenStateNamed(t, sm, "denied-c2", "owner-2", fh)
-	res, err := sm.LockNew(c2, []byte("lock-owner-2"), 1, open2, seq2+1, fh, types.WRITE_LT, 50, 100, false)
+	res, err := sm.LockNew(context.Background(), c2, []byte("lock-owner-2"), 1, open2, seq2+1, fh, types.WRITE_LT, 50, 100, false)
 	if err != nil {
 		t.Fatalf("LockNew c2: %v", err)
 	}
@@ -226,7 +227,7 @@ func TestReplay_Lock_Denied_CachesAndReplays(t *testing.T) {
 
 	// Retransmit client 2's LOCK at the SAME open+lock seqids -> replay the
 	// cached DENIED reply (both seqids were advanced by the DENIED original).
-	_, err = sm.LockNew(c2, []byte("lock-owner-2"), 1, open2, seq2+1, fh, types.WRITE_LT, 50, 100, false)
+	_, err = sm.LockNew(context.Background(), c2, []byte("lock-owner-2"), 1, open2, seq2+1, fh, types.WRITE_LT, 50, 100, false)
 	mustReplay(t, err, types.NFS4ERR_DENIED, cachedReply)
 }
 

--- a/internal/adapter/nfs/v4/state/stateid_authz_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_authz_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -25,7 +26,7 @@ func newLockedFile(t *testing.T, sm *StateManager, clientID uint64, fh []byte) t
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
-	lockResult, err := sm.LockNew(
+	lockResult, err := sm.LockNew(context.Background(),
 		clientID, []byte("lock-owner"), 1,
 		&confirmed.Stateid, 3,
 		fh, types.WRITE_LT, 0, 100, false,
@@ -215,7 +216,7 @@ func TestLockExisting_V41Seqid0(t *testing.T) {
 	// protection). Extend the lock with a second byte range via LockExisting.
 	v41Stateid := lockStateid
 	v41Stateid.Seqid = 0
-	result, err := sm.LockExisting(&v41Stateid, 0, fh, types.WRITE_LT, 200, 100, false)
+	result, err := sm.LockExisting(context.Background(), &v41Stateid, 0, fh, types.WRITE_LT, 200, 100, false)
 	if err != nil {
 		t.Fatalf("LockExisting with v4.1 stateid seqid=0: %v", err)
 	}
@@ -241,7 +242,7 @@ func TestUnlockFile_V41Seqid0(t *testing.T) {
 	// the LOCKU below is unambiguously after a seqid increment.
 	v41Lock := lockStateid
 	v41Lock.Seqid = 0
-	if _, err := sm.LockExisting(&v41Lock, 0, fh, types.WRITE_LT, 200, 100, false); err != nil {
+	if _, err := sm.LockExisting(context.Background(), &v41Lock, 0, fh, types.WRITE_LT, 200, 100, false); err != nil {
 		t.Fatalf("LockExisting setup: %v", err)
 	}
 

--- a/internal/adapter/nfs/v4/state/stateid_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -1135,7 +1136,7 @@ func TestFreeStateid(t *testing.T) {
 		confirmedStateid := &confirmed.Stateid
 
 		// Create lock state
-		lockResult, err := sm.LockNew(
+		lockResult, err := sm.LockNew(context.Background(),
 			0, []byte("lock-owner1"), 1,
 			confirmedStateid, 3,
 			fh, types.WRITE_LT, 0, 100, false,
@@ -1190,7 +1191,7 @@ func TestFreeStateid(t *testing.T) {
 		// open2 uses a confirmed owner; no OPEN_CONFIRM needed.
 
 		// Acquire a lock on file1 with the shared lock owner.
-		lock1, err := sm.LockNew(
+		lock1, err := sm.LockNew(context.Background(),
 			clientID, lockOwnerData, 1,
 			&conf1.Stateid, 4,
 			fh1, types.WRITE_LT, 0, 100, false,
@@ -1210,7 +1211,7 @@ func TestFreeStateid(t *testing.T) {
 
 		// Acquire a lock on file2 with the SAME lock owner — this reuses the
 		// existing LockOwner entry in sm.lockOwners and creates a second LockState.
-		lock2, err := sm.LockNew(
+		lock2, err := sm.LockNew(context.Background(),
 			clientID, lockOwnerData, 3,
 			&open2.Stateid, 5,
 			fh2, types.WRITE_LT, 0, 50, false,
@@ -1338,7 +1339,7 @@ func TestFreeStateid(t *testing.T) {
 		confirmedStateid := &confirmed.Stateid
 
 		// Create a lock
-		_, err = sm.LockNew(
+		_, err = sm.LockNew(context.Background(),
 			0, []byte("lock-owner1"), 1,
 			confirmedStateid, 3,
 			fh, types.WRITE_LT, 0, 100, false,

--- a/pkg/adapter/nfs/nlm.go
+++ b/pkg/adapter/nfs/nlm.go
@@ -112,6 +112,16 @@ func (s *nlmService) LockFileNLM(
 	// nothing is excluded (#1495).
 	_ = s.lockMgr.BreakLeasesForByteRangeLock(handleKey, &owner)
 
+	// Drain the in-flight lease break before inserting the lock: the break is
+	// fire-and-forget, so a still-present (Breaking, not-yet-ACKed) write lease is
+	// otherwise observed as a spurious LockConflict (NLM4_DENIED → client EIO,
+	// #1501). See lock.WaitForByteRangeLockBreak for the deadlock-safety and
+	// timeout reasoning. A non-nil error means the originating request was
+	// cancelled, so don't insert an orphan lock.
+	if err := lock.WaitForByteRangeLockBreak(ctx, s.lockMgr, handleKey); err != nil {
+		return nil, err
+	}
+
 	err := s.lockMgr.AddUnifiedLock(handleKey, unifiedLock)
 	if err == nil {
 		// A successful reclaim records the client so grace can exit early once

--- a/pkg/metadata/lock/byte_range_lock_wait_test.go
+++ b/pkg/metadata/lock/byte_range_lock_wait_test.go
@@ -18,10 +18,10 @@ import (
 // LeaseState (RWH) until the holder ACKs. opLockConflictsWithByteLock gates on
 // lease.HasWrite(), not on the Breaking flag, so AddUnifiedLock observes the
 // still-present write lease as a conflict if it runs before the break drains.
-// The adapter fix waits (WaitForBreakCompletionExceptKey) between the break and
-// the insert; this test pins the underlying lock-manager contract that makes
-// that wait correct: the byte lock is denied while the break is in flight and
-// granted once the holder ACKs to None.
+// The adapter fix waits (WaitForByteRangeLockBreak, the helper the NFSv4 and NLM
+// LOCK paths call) between the break and the insert; this test drives that exact
+// helper: the byte lock is denied while the break is in flight and granted once
+// the holder ACKs to None.
 func TestByteRangeLock_WaitForBreakBeforeGrant_ACK(t *testing.T) {
 	t.Parallel()
 
@@ -63,9 +63,8 @@ func TestByteRangeLock_WaitForBreakBeforeGrant_ACK(t *testing.T) {
 	}()
 
 	// The adapter fix: wait for the break to drain before retrying the insert.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	require.NoError(t, lm.WaitForBreakCompletionExceptKey(ctx, fileID, [16]byte{}),
+	// Drive the exact helper the NFSv4/NLM LOCK paths use.
+	require.NoError(t, WaitForByteRangeLockBreak(context.Background(), lm, fileID),
 		"wait must observe the ACK and return without a timeout")
 
 	// Post-break: the write bit is gone, so the byte lock is granted.
@@ -156,4 +155,38 @@ func TestWaitForByteRangeLeaseBreak_IgnoresBreakingDelegation(t *testing.T) {
 	require.Len(t, lm.unifiedLocks[fileID], 1)
 	assert.True(t, lm.unifiedLocks[fileID][0].Delegation.Breaking,
 		"the wait must not force-complete or remove the delegation")
+}
+
+// TestWaitForByteRangeLeaseBreak_CancelDoesNotForceBreak asserts that a client
+// cancellation of the LOCK request does NOT force-downgrade the conflicting SMB
+// lease. Only a genuine wait-deadline expiry (the holder failed to ACK) may
+// revoke the lease — a cancelled request inserts no lock, so it must leave the
+// holder's lease intact.
+func TestWaitForByteRangeLeaseBreak_CancelDoesNotForceBreak(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+
+	const fileID = "xpro2-cancel.dat"
+	smbLease := [16]byte{0xF1}
+
+	require.NoError(t, lm.AddUnifiedLock(fileID, &UnifiedLock{
+		ID:    "ul-smb-write",
+		Owner: LockOwner{OwnerID: "smb:writer", ClientID: "client-SMB"},
+		Lease: &OpLock{LeaseKey: smbLease, LeaseState: LeaseStateRead | LeaseStateWrite | LeaseStateHandle},
+	}))
+	require.NoError(t, lm.BreakLeasesForByteRangeLock(fileID, &LockOwner{}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // client gave up before the holder ACKed
+	require.ErrorIs(t, lm.WaitForByteRangeLeaseBreak(ctx, fileID), context.Canceled)
+
+	// The lease must NOT have been force-downgraded: it is still Breaking with
+	// its Write bit intact, awaiting the holder's own ACK.
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+	_, ul, _ := lm.findLeaseByKey(smbLease)
+	require.NotNil(t, ul)
+	assert.True(t, ul.Lease.Breaking, "cancellation must not resolve the break")
+	assert.True(t, ul.Lease.HasWrite(), "cancellation must not strip the holder's Write lease")
 }

--- a/pkg/metadata/lock/byte_range_lock_wait_test.go
+++ b/pkg/metadata/lock/byte_range_lock_wait_test.go
@@ -1,0 +1,159 @@
+package lock
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestByteRangeLock_WaitForBreakBeforeGrant_ACK reproduces the XPRO-02
+// regression (issue #1501): an NFS exclusive byte-range LOCK on a file whose
+// conflicting SMB write-lease must first be broken.
+//
+// BreakLeasesForByteRangeLock is fire-and-forget — it marks the write lease
+// Breaking and dispatches the break asynchronously, but the lease keeps its
+// LeaseState (RWH) until the holder ACKs. opLockConflictsWithByteLock gates on
+// lease.HasWrite(), not on the Breaking flag, so AddUnifiedLock observes the
+// still-present write lease as a conflict if it runs before the break drains.
+// The adapter fix waits (WaitForBreakCompletionExceptKey) between the break and
+// the insert; this test pins the underlying lock-manager contract that makes
+// that wait correct: the byte lock is denied while the break is in flight and
+// granted once the holder ACKs to None.
+func TestByteRangeLock_WaitForBreakBeforeGrant_ACK(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	cb := &recordingBreakCallbacks{}
+	lm.RegisterBreakCallbacks(cb)
+
+	const fileID = "xpro2-ack.dat"
+	smbLease := [16]byte{0xD1}
+
+	// SMB write lease (RWH) held by another client.
+	require.NoError(t, lm.AddUnifiedLock(fileID, &UnifiedLock{
+		ID:    "ul-smb-write",
+		Owner: LockOwner{OwnerID: "smb:writer", ClientID: "client-SMB"},
+		Lease: &OpLock{LeaseKey: smbLease, LeaseState: LeaseStateRead | LeaseStateWrite | LeaseStateHandle},
+	}))
+
+	// NFS asks for an exclusive byte-range lock → break the write lease.
+	require.NoError(t, lm.BreakLeasesForByteRangeLock(fileID, &LockOwner{}))
+
+	nfsLock := NewUnifiedLock(
+		LockOwner{OwnerID: "nfs:owner", ClientID: "client-NFS"},
+		FileHandle(fileID), 0, 100, LockTypeExclusive,
+	)
+
+	// Pre-fix behaviour: inserting now (lease still Breaking, LeaseState=RWH)
+	// is a conflict — this is exactly the path that returned NFS4ERR_DENIED →
+	// client EIO.
+	require.Error(t, lm.AddUnifiedLock(fileID, nfsLock),
+		"byte lock must conflict while the write lease is still present (Breaking, not yet ACKed)")
+
+	// Holder ACKs the break to None (concurrently, as the real SMB client does).
+	go func() {
+		// Small stagger so the wait below parks on the break-wait channel first;
+		// correctness does not depend on it (the wait re-checks state on entry),
+		// but it exercises the channel-signal path.
+		time.Sleep(10 * time.Millisecond)
+		_ = lm.AcknowledgeLeaseBreak(context.Background(), smbLease, LeaseStateNone, 0)
+	}()
+
+	// The adapter fix: wait for the break to drain before retrying the insert.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, lm.WaitForBreakCompletionExceptKey(ctx, fileID, [16]byte{}),
+		"wait must observe the ACK and return without a timeout")
+
+	// Post-break: the write bit is gone, so the byte lock is granted.
+	require.NoError(t, lm.AddUnifiedLock(fileID, nfsLock),
+		"byte lock must be granted once the conflicting write lease has drained to None")
+}
+
+// TestByteRangeLock_WaitForBreakBeforeGrant_Timeout covers the non-ACKing
+// holder: WaitForBreakCompletionExceptKey honours the context deadline and, on
+// expiry, force-downgrades the breaking lease to None (Samba lease_timeout
+// parity). The byte lock is then grantable. This guarantees the adapter cannot
+// hang forever and never returns EIO when the SMB client misbehaves.
+func TestByteRangeLock_WaitForBreakBeforeGrant_Timeout(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	cb := &recordingBreakCallbacks{}
+	lm.RegisterBreakCallbacks(cb)
+
+	const fileID = "xpro2-timeout.dat"
+	smbLease := [16]byte{0xE1}
+
+	require.NoError(t, lm.AddUnifiedLock(fileID, &UnifiedLock{
+		ID:    "ul-smb-write",
+		Owner: LockOwner{OwnerID: "smb:writer", ClientID: "client-SMB"},
+		Lease: &OpLock{LeaseKey: smbLease, LeaseState: LeaseStateRead | LeaseStateWrite | LeaseStateHandle},
+	}))
+
+	require.NoError(t, lm.BreakLeasesForByteRangeLock(fileID, &LockOwner{}))
+
+	// No ACK ever arrives → the bounded wait expires and force-completes.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	err := lm.WaitForBreakCompletionExceptKey(ctx, fileID, [16]byte{})
+	require.ErrorIs(t, err, context.DeadlineExceeded,
+		"wait must time out when the holder never ACKs")
+
+	// Force-complete downgraded the lease to None, so the byte lock is grantable.
+	nfsLock := NewUnifiedLock(
+		LockOwner{OwnerID: "nfs:owner", ClientID: "client-NFS"},
+		FileHandle(fileID), 0, 100, LockTypeExclusive,
+	)
+	assert.NoError(t, lm.AddUnifiedLock(fileID, nfsLock),
+		"after force-complete the write lease no longer conflicts with the byte lock")
+}
+
+// TestWaitForByteRangeLeaseBreak_IgnoresBreakingDelegation pins the deadlock
+// fix: the byte-range-lock wait must NOT block on an in-flight NFSv4 delegation
+// break. acquireLock runs this wait while holding the StateManager mutex, and
+// DELEGRETURN (which clears a delegation break) needs that same mutex — waiting
+// on a delegation here would be a circular wait. The byte-lock break never
+// marks a delegation Breaking and byte locks never conflict with delegations,
+// so a Breaking delegation on the file must be invisible to this wait: it
+// returns immediately even with no context deadline.
+func TestWaitForByteRangeLeaseBreak_IgnoresBreakingDelegation(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+
+	const fileID = "xpro2-deleg.dat"
+
+	// A write delegation mid-recall (Breaking) on the same file, e.g. recalled
+	// by a concurrent open. No SMB lease is breaking.
+	require.NoError(t, lm.AddUnifiedLock(fileID, &UnifiedLock{
+		ID:    "ul-deleg",
+		Owner: LockOwner{OwnerID: "nfs:delegholder", ClientID: "client-NFS-D"},
+		Delegation: &Delegation{
+			DelegType: DelegTypeWrite,
+			Breaking:  true,
+		},
+	}))
+
+	// Must return immediately (no timeout, no block) despite the Breaking
+	// delegation — a background context has no deadline, so a hang would wedge
+	// the test rather than time out.
+	done := make(chan error, 1)
+	go func() { done <- lm.WaitForByteRangeLeaseBreak(context.Background(), fileID) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err, "wait must ignore delegation breaks and return nil")
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForByteRangeLeaseBreak blocked on a Breaking delegation (deadlock risk)")
+	}
+
+	// The delegation is left untouched — only DELEGRETURN may clear it.
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+	require.Len(t, lm.unifiedLocks[fileID], 1)
+	assert.True(t, lm.unifiedLocks[fileID][0].Delegation.Breaking,
+		"the wait must not force-complete or remove the delegation")
+}

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -241,6 +241,12 @@ type LockManager interface {
 	// otherwise clear, while other-key breaks still need to drain first.
 	WaitForBreakCompletionExceptKey(ctx context.Context, handleKey string, exceptKey [16]byte) error
 
+	// WaitForByteRangeLeaseBreak blocks until every breaking SMB lease on
+	// handleKey resolves, ignoring in-flight NFSv4 delegation breaks. Used by the
+	// byte-range-lock acquisition path, which holds the NFSv4 StateManager mutex
+	// and must not wait on delegation breaks (DELEGRETURN needs that same mutex).
+	WaitForByteRangeLeaseBreak(ctx context.Context, handleKey string) error
+
 	// HasOtherBreakingLeases reports whether any lease on handleKey (excluding
 	// exceptKey) or any delegation is currently Breaking. Non-blocking peek
 	// used by the SMB CREATE async-park path: if BreakLeasesOnOpenConflict
@@ -2183,6 +2189,95 @@ func (lm *Manager) WaitForBreakCompletionExceptKey(ctx context.Context, handleKe
 			continue
 		}
 	}
+}
+
+// WaitForByteRangeLeaseBreak blocks until every breaking SMB lease on handleKey
+// resolves, IGNORING in-flight NFSv4 delegation breaks. It is the wait used by
+// the byte-range-lock acquisition path (NFSv4 LOCK / NLM), which runs while the
+// caller holds the NFSv4 StateManager mutex.
+//
+// It deliberately does NOT wait for delegation breaks, unlike
+// WaitForBreakCompletionExceptKey. A delegation break is resolved by
+// DELEGRETURN, whose handler must take the StateManager mutex; waiting for it
+// here while that same mutex is held would be a circular wait (only force-
+// broken after the bounded timeout, then re-stalled on the next LOCK, since
+// forceCompleteBreaksExceptKey only force-completes leases). Skipping
+// delegations is also correct: BreakLeasesForByteRangeLock never marks a
+// delegation Breaking, and a byte-range lock never conflicts with a delegation
+// (UnifiedLock.ConflictsWith ignores delegations), so there is nothing to wait
+// for. On timeout the breaking leases are force-downgraded to None (Samba
+// lease_timeout parity) and ctx.Err() is returned.
+func (lm *Manager) WaitForByteRangeLeaseBreak(ctx context.Context, handleKey string) error {
+	for {
+		lm.mu.Lock()
+		hasBreakingLease := false
+		for _, l := range lm.unifiedLocks[handleKey] {
+			if l.Lease != nil && l.Lease.Breaking {
+				hasBreakingLease = true
+				break
+			}
+		}
+		if !hasBreakingLease {
+			lm.mu.Unlock()
+			return nil
+		}
+
+		ch, ok := lm.breakWaitChans[handleKey]
+		if !ok {
+			ch = make(chan struct{})
+			lm.breakWaitChans[handleKey] = ch
+		}
+		lm.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			lm.forceCompleteBreaksExceptKey(handleKey, [16]byte{})
+			return ctx.Err()
+		case <-ch:
+			continue
+		}
+	}
+}
+
+// byteRangeLockBreakWaitTimeout bounds how long a byte-range LOCK (NFSv4 or NLM)
+// waits for a conflicting SMB write-lease to finish breaking before it inserts
+// the lock. It mirrors the SMB lease-break ack-wait timeout: a holder that has
+// not ACKed within this window is treated as non-responsive, its lease is
+// force-downgraded to None (Samba lease_timeout parity), and the lock is granted.
+const byteRangeLockBreakWaitTimeout = 5 * time.Second
+
+// WaitForByteRangeLockBreak drains an in-flight lease break before a byte-range
+// LOCK inserts its lock. Callers must invoke it between
+// BreakLeasesForByteRangeLock and AddUnifiedLock.
+//
+// BreakLeasesForByteRangeLock is fire-and-forget: it marks the conflicting lease
+// Breaking and dispatches the break asynchronously, but the lease keeps its state
+// until the holder ACKs. The byte-lock conflict check gates on the lease's Write
+// bit, not on the Breaking flag, so inserting the lock before the break drains
+// returns a spurious DENIED (surfaced to the client as EIO) — the #1501
+// regression.
+//
+// Deadlock safety: WaitForBreakCompletionExceptKey releases the manager mutex
+// before blocking, so it cannot deadlock against the break dispatch or the SMB
+// LEASE_BREAK_ACK path. The wait is bounded by byteRangeLockBreakWaitTimeout so a
+// stuck holder cannot stall the lock indefinitely; on expiry the breaking lease
+// is force-downgraded to None and the lock is granted. The empty exclude key
+// means "no exclusion": NFS/NLM owners hold no SMB lease of their own.
+//
+// It returns a non-nil error only when the originating ctx itself was cancelled
+// (e.g. the client disconnected) — the caller must then abort rather than insert
+// a lock nobody is waiting for. A derived deadline expiry returns nil: the lease
+// was force-downgraded above, so granting the lock is correct.
+func WaitForByteRangeLockBreak(ctx context.Context, lm LockManager, handleKey string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, byteRangeLockBreakWaitTimeout)
+	defer cancel()
+	if err := lm.WaitForByteRangeLeaseBreak(waitCtx, handleKey); err != nil && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return nil
 }
 
 // AnyHolderHasLeaseBits reports whether any lease on handleKey (other than

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -3,6 +3,7 @@ package lock
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -2231,7 +2232,13 @@ func (lm *Manager) WaitForByteRangeLeaseBreak(ctx context.Context, handleKey str
 
 		select {
 		case <-ctx.Done():
-			lm.forceCompleteBreaksExceptKey(handleKey, [16]byte{})
+			// Force-break the holder's lease only when our own wait deadline
+			// expired (the holder genuinely failed to ACK in time). On a client
+			// cancellation no byte-range lock will be inserted, so we must not
+			// downgrade the SMB holder's lease as a side effect.
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				lm.forceCompleteBreaksExceptKey(handleKey, [16]byte{})
+			}
 			return ctx.Err()
 		case <-ch:
 			continue
@@ -2257,8 +2264,10 @@ const byteRangeLockBreakWaitTimeout = 5 * time.Second
 // returns a spurious DENIED (surfaced to the client as EIO) — the #1501
 // regression.
 //
-// Deadlock safety: WaitForBreakCompletionExceptKey releases the manager mutex
-// before blocking, so it cannot deadlock against the break dispatch or the SMB
+// Deadlock safety: it waits via WaitForByteRangeLeaseBreak, which is leases-only
+// (it never blocks on an NFSv4 delegation break — DELEGRETURN needs the
+// StateManager mutex this path holds) and releases the lock-manager mutex before
+// blocking, so it cannot deadlock against the break dispatch or the SMB
 // LEASE_BREAK_ACK path. The wait is bounded by byteRangeLockBreakWaitTimeout so a
 // stuck holder cannot stall the lock indefinitely; on expiry the breaking lease
 // is force-downgraded to None and the lock is granted. The empty exclude key
@@ -2274,10 +2283,22 @@ func WaitForByteRangeLockBreak(ctx context.Context, lm LockManager, handleKey st
 	}
 	waitCtx, cancel := context.WithTimeout(ctx, byteRangeLockBreakWaitTimeout)
 	defer cancel()
-	if err := lm.WaitForByteRangeLeaseBreak(waitCtx, handleKey); err != nil && ctx.Err() != nil {
+	switch err := lm.WaitForByteRangeLeaseBreak(waitCtx, handleKey); {
+	case err == nil:
+		// Break drained (ACK or no breaking lease) — caller may insert the lock.
+		return nil
+	case ctx.Err() != nil:
+		// The originating request was cancelled/expired; abort the lock so we
+		// don't insert one nobody is waiting for.
 		return ctx.Err()
+	case errors.Is(err, context.DeadlineExceeded):
+		// Our derived deadline expired: the holder never ACKed, the lease was
+		// force-downgraded to None, and the lock may now be granted.
+		return nil
+	default:
+		// Unexpected error from the wait implementation — surface it.
+		return err
 	}
-	return nil
 }
 
 // AnyHolderHasLeaseBits reports whether any lease on handleKey (other than


### PR DESCRIPTION
## Problem

e2e `TestCrossProtocolLocking/XPRO-02` fails: an NFSv4 byte-range `LOCK` on a file that holds a conflicting SMB write-lease returns **EIO** instead of succeeding after breaking the lease (XPRO-01/03/04 pass — they involve no lease break). Regression from #1501 / commit 93a5d0f8.

## Root cause

`BreakLeasesForByteRangeLock` is **fire-and-forget**: it marks the conflicting lease `Breaking` and dispatches the break notification asynchronously, returning `nil` immediately. The lease keeps its state until the holder ACKs. Both byte-range-lock sites then called `AddUnifiedLock` right away, while the lease was still present. The conflict check (`opLockConflictsWithByteLock`) gates on the lease's Write bit **regardless of the `Breaking` flag**, so the insert returned a spurious conflict → `NFS4ERR_DENIED` / `NLM4_DENIED` → client EIO.

## Fix

Insert a **bounded wait** between the break and `AddUnifiedLock` at both sites:

- `internal/adapter/nfs/v4/state/manager.go` — `acquireLock` (NFSv4 LOCK)
- `pkg/adapter/nfs/nlm.go` — `LockFileNLM` (NLM)

A `context.Context` is threaded from the LOCK handler through `LockNew` / `LockExisting` / `acquireLock`. The shared logic lives in one helper, `lock.WaitForByteRangeLockBreak`.

### Deadlock safety (leases-only wait)

`acquireLock` runs the wait while holding the NFSv4 `StateManager` mutex. The general `WaitForBreakCompletionExceptKey` also waits for in-flight **NFSv4 delegation** breaks — but `DELEGRETURN` (`ReturnDelegation`) needs that same `StateManager` mutex, so waiting on a delegation here would be a circular wait (and the 5s force-complete only clears leases, not delegations, so it would re-stall on every subsequent LOCK).

The wait is therefore **leases-only** (`WaitForByteRangeLeaseBreak`), which is also correct: `BreakLeasesForByteRangeLock` never marks a delegation `Breaking`, and a byte-range lock never conflicts with a delegation (`UnifiedLock.ConflictsWith` ignores delegations). The wait releases the lock-manager mutex before blocking, and the SMB `LEASE_BREAK_ACK` path that clears the lease never touches the `StateManager` mutex.

### Timeout path

Bounded to 5s (matching the SMB lease-break ack-wait). On expiry the breaking lease is force-downgraded to `None` (Samba `lease_timeout` parity) and the lock is granted. Only a genuine cancellation of the originating request propagates an error; a derived-deadline expiry proceeds to grant. Never returns EIO.

## Tests

- New `pkg/metadata/lock/byte_range_lock_wait_test.go`: conflict-before-wait then grant-after-ACK (the XPRO-02 scenario), the force-complete timeout path, and a regression test asserting the leases-only wait does **not** block on a `Breaking` delegation.
- `go build`, `go vet`, `golangci-lint`, e2e `-tags e2e` compile, and the lock / NFS / SMB suites (incl. `-race`) all pass. The real XPRO-02 proof runs in CI e2e on develop.