### PR TITLE
fix(block): re-roll in-place overwrites whose region was already consumed (#1493)

### DIFF
--- a/pkg/block/local/fs/logindex.go
+++ b/pkg/block/local/fs/logindex.go
@@ -152,6 +152,16 @@ func (idx *logIndex) Append(logPos uint64, fileOff uint64, payloadLen uint32) {
 		fileOff:    fileOff,
 		payloadLen: payloadLen,
 	})
+	// #1493: a new write supersedes whatever bytes a prior generation's rollup
+	// stored at this file region, so the region's latest bytes are once again
+	// un-rolled-up. Un-mark it as consumed; otherwise advanceFenceUpTo sees the
+	// region still covered (from the earlier MarkConsumed, which is never
+	// trimmed) and retires this fresh entry WITHOUT rolling it up. The stable
+	// interval then has zero logIndex entries and the rollup drops it as a
+	// benign divergence — silently losing the overwrite's bytes (data
+	// corruption surfacing only under the concurrent ticker-driven rollup path,
+	// which is why a serial DrainRollups never hit it).
+	idx.consumedCoverage.remove(fileOff, fileOff+uint64(payloadLen))
 }
 
 // EntriesForInterval returns every entry whose file-offset extent
@@ -484,6 +494,37 @@ func (cs *coverageSet) add(start, end uint64) {
 	// subsumption (j > insertAt+1) uniformly.
 	cs.intervals = slices.Replace(cs.intervals, insertAt, j,
 		coverageInterval{start: mergeStart, end: mergeEnd})
+}
+
+// remove subtracts [start, end) from the set, trimming and splitting any
+// stored intervals that overlap it. Used when a new write lands at a file
+// region: the region's latest bytes are no longer the ones rolled into CAS,
+// so the region must be un-marked as consumed or the fence would retire the
+// new (still-unconsumed) entry without ever rolling it up — silent data loss
+// on in-place overwrite (#1493).
+//
+// Empty / inverted ranges (end <= start) are silently ignored.
+func (cs *coverageSet) remove(start, end uint64) {
+	if end <= start {
+		return
+	}
+	var out []coverageInterval
+	for _, iv := range cs.intervals {
+		// No overlap: keep as-is.
+		if iv.end <= start || iv.start >= end {
+			out = append(out, iv)
+			continue
+		}
+		// Left remainder survives [iv.start, start).
+		if iv.start < start {
+			out = append(out, coverageInterval{start: iv.start, end: start})
+		}
+		// Right remainder survives [end, iv.end).
+		if iv.end > end {
+			out = append(out, coverageInterval{start: end, end: iv.end})
+		}
+	}
+	cs.intervals = out
 }
 
 // covers reports whether [start, end) is fully covered by the union of

--- a/pkg/block/local/fs/logindex.go
+++ b/pkg/block/local/fs/logindex.go
@@ -161,7 +161,15 @@ func (idx *logIndex) Append(logPos uint64, fileOff uint64, payloadLen uint32) {
 	// benign divergence — silently losing the overwrite's bytes (data
 	// corruption surfacing only under the concurrent ticker-driven rollup path,
 	// which is why a serial DrainRollups never hit it).
-	idx.consumedCoverage.remove(fileOff, fileOff+uint64(payloadLen))
+	//
+	// Overflow saturation, consistent with EntriesForInterval / MarkConsumed:
+	// a region that would wrap past MaxUint64 clamps so the subtraction still
+	// covers the intended tail.
+	end := fileOff + uint64(payloadLen)
+	if end < fileOff {
+		end = ^uint64(0)
+	}
+	idx.consumedCoverage.remove(fileOff, end)
 }
 
 // EntriesForInterval returns every entry whose file-offset extent
@@ -506,6 +514,19 @@ func (cs *coverageSet) add(start, end uint64) {
 // Empty / inverted ranges (end <= start) are silently ignored.
 func (cs *coverageSet) remove(start, end uint64) {
 	if end <= start {
+		return
+	}
+	// Fast path: nothing overlaps, so the set is unchanged and no allocation is
+	// needed. This is the common case on a fresh or fully-rolled-up file, where
+	// every write hits this method but rarely lands on a still-consumed region.
+	overlaps := false
+	for _, iv := range cs.intervals {
+		if iv.end > start && iv.start < end {
+			overlaps = true
+			break
+		}
+	}
+	if !overlaps {
 		return
 	}
 	var out []coverageInterval

--- a/pkg/block/local/fs/logindex_test.go
+++ b/pkg/block/local/fs/logindex_test.go
@@ -571,6 +571,106 @@ func TestLogIndex_AdvanceFence_CoverageMerge(t *testing.T) {
 	}
 }
 
+// TestLogIndex_AppendAfterConsume_RerollsOverwrite is the #1493 regression:
+// an in-place overwrite at a file region a PRIOR rollup generation already
+// consumed must be rolled up again, not silently dropped. Pre-fix, the
+// generation-A MarkConsumed left consumedCoverage permanently covering the
+// region; the generation-B AppendWrite added a fresh entry but did NOT clear
+// that coverage, so AdvanceFence retired the new entry without rolling it up
+// (its bytes never reached CAS). The rollup pass then saw zero logIndex
+// entries for the dirty interval and dropped it as a benign divergence —
+// losing the overwrite's bytes. Under the concurrent ticker-driven rollup
+// this surfaced as silent data corruption after GC reaped the stale prior
+// generation's chunk.
+func TestLogIndex_AppendAfterConsume_RerollsOverwrite(t *testing.T) {
+	idx := newLogIndex()
+	const payload = uint32(4096)
+	step := uint64(recordFrameOverhead) + uint64(payload)
+	pos := uint64(logHeaderSize)
+
+	// Generation A: write [0, 4096), roll it up (MarkConsumed), advance the
+	// fence so the entry is retired/trimmed — exactly the steady state after
+	// the first version of a file has been rolled up to CAS.
+	idx.Append(pos, 0, payload)
+	idx.MarkConsumed(0, payload)
+	idx.AdvanceFence()
+	pos += step
+	if idx.Len() != 0 {
+		t.Fatalf("gen A not trimmed after consume+fence: Len=%d want 0", idx.Len())
+	}
+
+	// Generation B: overwrite the SAME region [0, 4096). These bytes have NOT
+	// been rolled up — they must remain a live, unconsumed entry.
+	genBPos := pos
+	idx.Append(genBPos, 0, payload)
+
+	// The fence must NOT retire generation B's entry. Pre-fix the stale
+	// consumedCoverage from generation A made AdvanceFence walk straight past
+	// it, leaving zero entries for the overwrite's dirty interval.
+	idx.AdvanceFence()
+	if idx.Len() != 1 {
+		t.Fatalf("overwrite entry prematurely fenced: Len=%d want 1 (gen B bytes would be lost)", idx.Len())
+	}
+	hits := idx.EntriesForInterval(0, uint64(payload), nil)
+	if len(hits) != 1 || hits[0].logPos != genBPos {
+		t.Fatalf("overwrite entry not found for rollup: got %+v want one entry at logPos %d", hits, genBPos)
+	}
+
+	// And once generation B is itself rolled up, the fence advances past it.
+	idx.MarkConsumed(0, payload)
+	wantFence := genBPos + step
+	if got := idx.AdvanceFence(); got != wantFence {
+		t.Fatalf("fence after gen B consume: got %d want %d", got, wantFence)
+	}
+}
+
+// TestCoverageSet_Remove exercises the remove primitive (#1493): subtracting
+// a range trims and splits overlapping intervals so a re-written region reads
+// as no-longer-covered.
+func TestCoverageSet_Remove(t *testing.T) {
+	t.Run("split-middle", func(t *testing.T) {
+		var cs coverageSet
+		cs.add(0, 100)
+		cs.remove(40, 60)
+		if cs.covers(40, 60) {
+			t.Fatal("removed middle still covered")
+		}
+		if !cs.covers(0, 40) || !cs.covers(60, 100) {
+			t.Fatalf("remainders not covered: intervals=%+v", cs.intervals)
+		}
+	})
+	t.Run("trim-left-edge", func(t *testing.T) {
+		var cs coverageSet
+		cs.add(10, 20)
+		cs.remove(5, 12)
+		if cs.covers(10, 12) {
+			t.Fatal("trimmed prefix still covered")
+		}
+		if !cs.covers(12, 20) {
+			t.Fatalf("tail not covered: %+v", cs.intervals)
+		}
+	})
+	t.Run("remove-whole", func(t *testing.T) {
+		var cs coverageSet
+		cs.add(10, 20)
+		cs.add(30, 40)
+		cs.remove(0, 100)
+		if cs.covers(10, 11) || cs.covers(30, 31) {
+			t.Fatalf("fully removed intervals still covered: %+v", cs.intervals)
+		}
+	})
+	t.Run("noop-cases", func(t *testing.T) {
+		var cs coverageSet
+		cs.add(10, 20)
+		cs.remove(20, 30) // adjacent, no overlap
+		cs.remove(0, 10)  // adjacent, no overlap
+		cs.remove(15, 15) // empty range
+		if !cs.covers(10, 20) {
+			t.Fatalf("non-overlapping/empty remove altered set: %+v", cs.intervals)
+		}
+	})
+}
+
 // TestCoverageSet exercises the coverage-set primitive in isolation —
 // add merges adjacent and overlapping intervals; covers returns the
 // strict containment predicate.


### PR DESCRIPTION
## Summary

Fixes #1493 — silent data corruption on file overwrite in the blocks-only persistence layer. The e2e `TestBlockStoreImmutableOverwrites` failed: write 16 MiB payload A, overwrite with 16 MiB payload B, GC, read back — the read returned a third hash (neither A nor B), 16 MiB of mixed/zero-filled bytes.

## Confirmed root cause (reproduced, not hypothesized)

Reproduced the real e2e in a privileged Linux container with Localstack and instrumented the server. The prior hypothesis (`reapSupersededFileChunks` leaving stale rows) was **refuted** — `reapSupersededFileChunks` is never even called on this path. The real cause is in the fs local-store rollup `logIndex`:

- After a rollup pass durably stores a file region to CAS, `MarkConsumed(off,len)` adds that region to the per-payload `consumedCoverage` set, which is **intentionally never trimmed**.
- `advanceFenceUpTo` retires a log entry once `consumedCoverage.covers(entry.region)` is true.
- An in-place **overwrite** writes new bytes to a region a prior generation already consumed. `Append` added the new log entry but did **not** clear `consumedCoverage` for that region. So the fence retired the fresh entry **without rolling it up**; the stable dirty interval was then left with zero `logIndex` entries and the rollup dropped it as a benign divergence (`rollup.go` ~439 `tree.DropExact`). The overwrite's bytes never reached CAS or the manifest.
- The offset kept the **prior generation's** chunk hash (so B falsely deduped against A — e2e showed B uploading only +12–14 of 16 chunks). Once GC reaped A's generation, those byte ranges were gone → corrupt read.

This only reproduces under the concurrent 200 ms ticker-driven rollup racing streaming writes; a serial `DrainRollups` never hits it, which is why ~19 in-process engine scenarios (in-place/truncate, random/shared, single/multi-pass, sync/async, evict, real GC) all passed — the engine, coordinator, syncer, and GC are all correct.

**Pre-GC vs post-GC:** the manifest is already wrong immediately after the overwrite rollup (B's manifest is missing the dropped chunks). GC is what makes it *observable* — it reaps the prior-generation chunk those offsets still secretly pointed at. The corruption originates in the overwrite rollup, not GC.

## Fix

`(*logIndex).Append` now removes the written region from `consumedCoverage`, restoring the invariant: a region is covered **iff** its latest bytes are durable in CAS. A new write supersedes the prior generation's bytes, so its region must be un-marked as consumed and re-rolled-up.

- `pkg/block/local/fs/logindex.go`: add `(*coverageSet).remove(start,end)` (subtract a range, split/trim overlapping intervals); call it from `Append`. Per-chunk dedup/refcount semantics from #1493 are preserved (storage-layer dedup still applies; only the per-file manifest entry is no longer dropped).

## Verification

- Real e2e `TestBlockStoreImmutableOverwrites` in container with Localstack: failed deterministically before, now passes 5/5. Post-fix counts are correct and stable: B adds +16, GC removes exactly A's 16, B intact, re-read matches.
- Regression tests (deterministic, logIndex layer): `TestLogIndex_AppendAfterConsume_RerollsOverwrite` (fails without the fix, passes with it) and `TestCoverageSet_Remove`.
- `gofmt -s`, `go vet ./pkg/block/...`, `go build ./...`, full `go test ./pkg/block/...` (incl. blockstoretest conformance), e2e compiles with `-tags e2e`.

Reviewed by code-simplifier and a rigorous data-plane code-review (interval math, locking under `idx.mu`, fence monotonicity, partial-overwrite handling, C1 race) — no issues found.