### PR TITLE
fix(shares): read-only share create returns EROFS, not EACCES

### DIFF
--- a/pkg/controlplane/runtime/shares/readonly_propagation_test.go
+++ b/pkg/controlplane/runtime/shares/readonly_propagation_test.go
@@ -1,0 +1,68 @@
+package shares
+
+import (
+	"context"
+	"testing"
+
+	metamem "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestAddShare_ReadOnlyPropagatesToShareOptions asserts that a genuinely
+// read-only share (ShareConfig.ReadOnly == true) has its flag propagated into
+// the metadata store's ShareOptions.
+//
+// The runtime initialises a share's metadata via CreateRootDirectory (not
+// CreateShare), which leaves ShareOptions zero-valued. Without propagation the
+// permission layer never sees ShareOptions.ReadOnly at runtime, so a store-level
+// read-only share is indistinguishable from a per-user read-only level
+// (ctx.ShareReadOnly, which is true for BOTH). That collapse made a read-only
+// share's create/write denials surface as EACCES instead of EROFS. This test
+// locks the store-level discriminator at its source: the flag must reach
+// GetShareOptions so checkPermission / CheckParentCreateAccess can return
+// ErrReadOnly (NFS3ERR_ROFS) for a genuine read-only share.
+func TestAddShare_ReadOnlyPropagatesToShareOptions(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name  string
+		share string
+		val   bool
+	}{
+		{"read_only_share_propagates", "/archive", true},
+		{"read_write_share_stays_false", "/scratch", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mds := metamem.NewMemoryMetadataStoreWithDefaults()
+			t.Cleanup(func() { _ = mds.Close() })
+
+			svc := New()
+			cfg := &ShareConfig{
+				Name:          tc.share,
+				MetadataStore: "meta-test",
+				Enabled:       true,
+				ReadOnly:      tc.val,
+			}
+
+			err := svc.AddShare(
+				ctx,
+				cfg,
+				&metaStoreProvider{name: "meta-test", store: mds},
+				metaSvcRegistrar{},
+				nil, // no block store provider — LocalBlockStoreID empty skips the path
+				nil,
+				nil,
+			)
+			if err != nil {
+				t.Fatalf("AddShare: %v", err)
+			}
+
+			opts, err := mds.GetShareOptions(ctx, tc.share)
+			if err != nil {
+				t.Fatalf("GetShareOptions: %v", err)
+			}
+			if opts.ReadOnly != tc.val {
+				t.Errorf("ShareOptions.ReadOnly=%v, want %v", opts.ReadOnly, tc.val)
+			}
+		})
+	}
+}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -678,6 +678,23 @@ func (s *Service) prepareShare(
 		return nil, nil, fmt.Errorf("failed to create root directory: %w", err)
 	}
 
+	// Propagate a read-only share into the metadata store's ShareOptions.
+	// The runtime seeds metadata via CreateRootDirectory (not CreateShare),
+	// which leaves Options zero-valued, so without this the permission layer
+	// never sees ShareOptions.ReadOnly — the store-level discriminator that lets
+	// it deny writes/creates with ErrReadOnly (EROFS) rather than ErrAccessDenied
+	// (EACCES). Only touch read-only shares; read-write shares use the zero default.
+	if config.ReadOnly {
+		shareOpts, err := metadataStore.GetShareOptions(ctx, config.Name)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to read share options: %w", err)
+		}
+		shareOpts.ReadOnly = true
+		if err := metadataStore.UpdateShareOptions(ctx, config.Name, shareOpts); err != nil {
+			return nil, nil, fmt.Errorf("failed to set read-only share options: %w", err)
+		}
+	}
+
 	rootHandle, err := metadata.EncodeFileHandle(rootFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to encode root handle: %w", err)

--- a/pkg/metadata/auth_permissions_readonly_share_test.go
+++ b/pkg/metadata/auth_permissions_readonly_share_test.go
@@ -197,6 +197,54 @@ func TestCheckParentCreateAccess_StoreReadOnlyShareReturnsErrReadOnly(t *testing
 	}
 }
 
+// TestCheckParentCreateAccess_NoACLParent_ReadOnlyDiscriminator locks the
+// EROFS-vs-EACCES discriminator for the CREATE path when the parent directory
+// has NO ACL (the generic POSIX-write fallback in CheckParentCreateAccess).
+// TestCheckParentCreateAccess_StoreReadOnlyShareReturnsErrReadOnly already
+// covers the ACL branch; this fills the non-ACL sub-path so both directions of
+// the fork are pinned:
+//   - store-level read-only share (ShareOptions.ReadOnly) → ErrReadOnly (EROFS);
+//   - per-user read-only level (ctx.ShareReadOnly on a writable share) → EACCES.
+//
+// f.rootHandle is a mode-0777 directory with no ACL, so a create there takes the
+// file.ACL == nil fallback → checkWritePermission → checkPermission, exercising
+// the shareIsReadOnly store-level discriminator rather than the ACL block.
+func TestCheckParentCreateAccess_NoACLParent_ReadOnlyDiscriminator(t *testing.T) {
+	asStoreErr := func(t *testing.T, err error) *metadata.StoreError {
+		t.Helper()
+		require.Error(t, err)
+		var storeErr *metadata.StoreError
+		require.True(t, errors.As(err, &storeErr), "err %v is not a *StoreError", err)
+		return storeErr
+	}
+
+	t.Run("store-level read-only share is EROFS", func(t *testing.T) {
+		f := newTestFixture(t)
+		_ = f.store.CreateShare(context.Background(), &metadata.Share{Name: f.shareName})
+		require.NoError(t, f.store.UpdateShareOptions(context.Background(), f.shareName,
+			&metadata.ShareOptions{ReadOnly: true}))
+		// Owner, per-user ShareReadOnly explicitly false: only the store-level
+		// flag is in play, so a non-EROFS result would mean the discriminator
+		// failed to consult ShareOptions.
+		owner := f.authContext(1700, 1700)
+		owner.ShareReadOnly = false
+		got := asStoreErr(t, f.service.CheckParentCreateAccess(owner, f.rootHandle, false))
+		require.Equal(t, metadata.ErrReadOnly, got.Code)
+	})
+
+	t.Run("per-user read-only on writable share is EACCES", func(t *testing.T) {
+		f := newTestFixture(t)
+		// Store NOT read-only; only the per-user ceiling denies. This must stay
+		// EACCES so a squashed/unknown-uid read level (which sets ctx.ShareReadOnly
+		// on a writable share) does not masquerade as a read-only filesystem —
+		// TestNFSRootSquash depends on this.
+		ro := f.authContext(1701, 1701)
+		ro.ShareReadOnly = true
+		got := asStoreErr(t, f.service.CheckParentCreateAccess(ro, f.rootHandle, false))
+		require.Equal(t, metadata.ErrAccessDenied, got.Code)
+	})
+}
+
 // TestCheckParentWriteAccess_ReadOnlyDiscriminator exercises the data-write
 // permission path (checkPermission via CheckParentWriteAccess) and asserts the
 // EROFS-vs-EACCES discriminator directly:

--- a/pkg/metadata/auth_permissions_readonly_share_test.go
+++ b/pkg/metadata/auth_permissions_readonly_share_test.go
@@ -220,6 +220,9 @@ func TestCheckParentCreateAccess_NoACLParent_ReadOnlyDiscriminator(t *testing.T)
 
 	t.Run("store-level read-only share is EROFS", func(t *testing.T) {
 		f := newTestFixture(t)
+		// The fixture already registered the share (via CreateRootDirectory), so
+		// CreateShare returns ErrExist here — intentionally ignored; the call only
+		// guarantees a share entry for UpdateShareOptions to target.
 		_ = f.store.CreateShare(context.Background(), &metadata.Share{Name: f.shareName})
 		require.NoError(t, f.store.UpdateShareOptions(context.Background(), f.shareName,
 			&metadata.ShareOptions{ReadOnly: true}))


### PR DESCRIPTION
## Problem

`TestCrossProtocol_ErrorConformance/ErrReadOnly/nfs` fails on develop: creating a file over NFSv3 on a store-level **read-only share** returns `errno=13` (EACCES) instead of `errno=30` (EROFS).

## Root cause — a #1516 whack-a-mole, one layer down

PR #1516 made the metadata permission layer distinguish:
- **store-level read-only share** (`ShareOptions.ReadOnly`) → `ErrReadOnly` (NFS3ERR_ROFS / EROFS)
- **per-user read-only level** (`ctx.ShareReadOnly` on a writable share, e.g. a squashed/unknown uid given the share's `read` default) → `ErrAccessDenied` (EACCES)

The discriminator is `ShareOptions.ReadOnly`, fetched via `GetShareOptions`. The catch: the runtime seeds a share's metadata via `metadataStore.CreateRootDirectory` (**not** `CreateShare`), which leaves `ShareOptions` zero-valued. So `ShareOptions.ReadOnly` was **never true at runtime**, and the only read-only signal reaching the metadata layer was `ctx.ShareReadOnly` — which is true for *both* a genuine RO share and a per-user read level. A genuine read-only share therefore fell through to the `ctx.ShareReadOnly` path and returned EACCES.

`ctx.ShareReadOnly` (set as `share.ReadOnly || defaultPerm == read`) cannot discriminate; `ShareOptions.ReadOnly` can — but it had to actually be populated.

## Fix

In `prepareShare` (runtime shares service), after `CreateRootDirectory`, when `config.ReadOnly` is set, propagate it into the metadata store's `ShareOptions` via `GetShareOptions` + `UpdateShareOptions` (read-modify-write preserves `BlockLayout`/other fields; no-op for read-write shares). This makes the store-level discriminator truthful, so:
- genuine read-only share → `ErrReadOnly` → EROFS (conformance `ErrReadOnly`)
- per-user read level / squash → `ErrAccessDenied` → EACCES (`TestNFSRootSquash` stays green)

## Tests

- `TestAddShare_ReadOnlyPropagatesToShareOptions` — locks propagation (RO true, RW false).
- `TestCheckParentCreateAccess_NoACLParent_ReadOnlyDiscriminator` — fills the no-ACL CREATE sub-path gap: store-level RO → `ErrReadOnly`, per-user RO → `ErrAccessDenied`. (ACL branch already covered by the #1516 test.)
- `gofmt`/`go vet`/`go build ./...` clean; `go test ./pkg/metadata/... ./pkg/controlplane/runtime/shares/...` green; `go build -tags e2e ./test/e2e/...` compiles. The e2e `ErrReadOnly` conformance + `TestNFSRootSquash` run in CI on develop.

## Known follow-up (not a blocker)

A live `UpdateShare` read-only **toggle** does not re-propagate `ShareOptions.ReadOnly` (the runtime `UpdateShare` holds no metadata-store reference). Writes are still denied after a toggle-to-RO, just as EACCES until a restart re-runs `AddShare`. Create-time (the failing test) is fixed here; the toggle path is a separate follow-up threaded through the API handler.