### PR TITLE
fix(test): prove SMB3 dialect via client-min-protocol, not debug grep

### DIFF
--- a/test/e2e/helpers/smb3_helpers.go
+++ b/test/e2e/helpers/smb3_helpers.go
@@ -202,9 +202,13 @@ func RunSMBClient(t *testing.T, port int, user, pass, share, command string) (st
 	return string(output), cmdErr
 }
 
-// RunSMBClientDebug executes smbclient with debug output for protocol analysis.
-// Returns the combined stdout/stderr output and any error.
-func RunSMBClientDebug(t *testing.T, port int, user, pass, share, command string, debugLevel int) (string, error) {
+// RunSMBClientMinProtocol executes smbclient with the client's minimum SMB
+// dialect pinned to minProtocol (e.g. "SMB3"). If the server negotiates a lower
+// dialect, or negotiation fails, smbclient aborts with an NT_STATUS error before
+// running the command. A successful command therefore proves that a dialect at
+// or above minProtocol was negotiated end-to-end, without depending on the exact
+// strings smbclient prints in its debug output (which vary by Samba version).
+func RunSMBClientMinProtocol(t *testing.T, port int, user, pass, share, command, minProtocol string) (string, error) {
 	t.Helper()
 
 	smbclientPath, err := exec.LookPath("smbclient")
@@ -221,8 +225,8 @@ func RunSMBClientDebug(t *testing.T, port int, user, pass, share, command string
 		"-A", authFile,
 		"-p", fmt.Sprintf("%d", port),
 		"-c", command,
-		fmt.Sprintf("--debuglevel=%d", debugLevel),
 		"--max-protocol=SMB3",
+		fmt.Sprintf("--option=client min protocol=%s", minProtocol),
 	}
 
 	cmd := exec.Command(smbclientPath, args...)

--- a/test/e2e/smb3_smbclient_test.go
+++ b/test/e2e/smb3_smbclient_test.go
@@ -98,49 +98,41 @@ func TestSMB3_SmbClient_FileOps(t *testing.T) {
 		"Deleted file should not appear in listing")
 }
 
-// TestSMB3_SmbClient_DialectNegotiation verifies that SMB3 protocol is negotiated
-// by parsing smbclient debug output.
+// TestSMB3_SmbClient_DialectNegotiation verifies that an SMB3 dialect is
+// negotiated between smbclient and the DittoFS server.
+//
+// Rather than grepping smbclient's debug output for dialect strings -- which are
+// absent at low debug levels and vary across Samba versions -- this pins the
+// client's *minimum* dialect to SMB3. If the server negotiated anything lower,
+// or negotiation failed, smbclient would abort with an NT_STATUS error before
+// ever listing the share. A clean directory listing therefore proves that an
+// SMB 3.x dialect was negotiated end-to-end.
 func TestSMB3_SmbClient_DialectNegotiation(t *testing.T) {
 	skipIfSMBClientUnavailable(t)
 	env := helpers.SetupSMB3TestEnv(t)
 
-	// Run smbclient with debug output to capture protocol negotiation
-	output, err := helpers.RunSMBClientDebug(t, env.SMBPort, env.Username, env.Password,
-		env.ShareName, "ls", 1)
+	output, err := helpers.RunSMBClientMinProtocol(t, env.SMBPort, env.Username,
+		env.Password, env.ShareName, "ls", "SMB3")
 
-	// smbclient may return non-zero on empty directories or debug mode
-	if err != nil && strings.Contains(output, "NT_STATUS_LOGON_FAILURE") {
-		t.Fatalf("smbclient auth failed: %s\nOutput: %s", err, output)
+	t.Logf("smbclient (client min protocol=SMB3) output:\n%s", output)
+
+	// Any NT_STATUS error means negotiation or auth failed under the SMB3-only
+	// constraint -- the server did not negotiate an SMB3 dialect.
+	if err != nil && strings.Contains(output, "NT_STATUS_") {
+		t.Fatalf("smbclient failed to negotiate an SMB3 dialect: %s\nOutput: %s", err, output)
 	}
 
-	t.Logf("smbclient debug output:\n%s", output)
-
-	// Assert that SMB2/3 protocol was actually negotiated by checking for
-	// concrete dialect indicators in the debug output. smbclient at debug level 1+
-	// logs protocol negotiation details containing dialect hex codes or protocol names.
-	hasSMB3Dialect := strings.Contains(output, "0x0300") || // SMB 3.0.0
-		strings.Contains(output, "0x0302") || // SMB 3.0.2
-		strings.Contains(output, "0x0311") // SMB 3.1.1
-
-	hasSMBIndicator := hasSMB3Dialect ||
-		strings.Contains(output, "SMB3") ||
-		strings.Contains(output, "smb3") ||
-		strings.Contains(output, "SMB2") ||
-		strings.Contains(output, "smb2")
-
-	assert.True(t, hasSMBIndicator,
-		"Expected SMB2/3 protocol indicator in smbclient debug output, got:\n%s", output)
-
-	if hasSMB3Dialect {
-		t.Log("SMB3 dialect confirmed in negotiation output")
-	}
-
-	// Verify no fatal errors occurred during negotiation
-	assert.NotContains(t, output, "NT_STATUS_NOT_SUPPORTED",
-		"Server should support the negotiated protocol")
 	assert.NotContains(t, output, "NT_STATUS_LOGON_FAILURE",
 		"Authentication should succeed")
+	assert.NotContains(t, output, "NT_STATUS_NOT_SUPPORTED",
+		"Server should support an SMB3 dialect")
+	assert.NotContains(t, strings.ToLower(output), "protocol negotiation failed",
+		"An SMB3 dialect should be negotiated")
 
+	// smbclient prints this trailer only after a successful listing over the
+	// negotiated (SMB3-minimum) session.
+	assert.Contains(t, output, "blocks of size",
+		"Expected a successful directory listing over an SMB3 session, got:\n%s", output)
 }
 
 // TestSMB3_SmbClient_DirectoryOps validates smbclient mkdir, cd, ls, rmdir operations.


### PR DESCRIPTION
## Problem

`TestSMB3_SmbClient_DialectNegotiation` has failed in **every** real develop e2e run (pre-existing, not a regression). It is NTLM/SMB, unrelated to Kerberos/AD.

The failure is a **deterministic test bug**, not a product bug. The DittoFS SMB server negotiates SMB 3.1.1 correctly — confirmed in the failing run's server-side logs:

```
SMB2 NEGOTIATE dialect selection dialect=SMB 3.1.1 responseDialect=SMB 3.1.1 supported=true
SMB3 encryption available for session ... dialect=SMB 3.1.1
```

But the test grepped `smbclient --debuglevel=1` output for dialect strings (`SMB2`/`SMB3`/hex `0x0311`) that Samba does **not** emit at debug level 1. The captured client output was only the `ls` trailer, so the assertion failed every run:

```
Expected SMB2/3 protocol indicator in smbclient debug output, got:
    274877906944 blocks of size 4096. 274877906944 blocks available
```

The sibling `smb-client-compat.yml` workflow already runs `--debuglevel=1` and never asserts on a dialect string, for the same reason.

## Fix

Stop parsing fragile client debug output. Instead pin smbclient's **client min protocol** to SMB3 (new helper `RunSMBClientMinProtocol`, passing `--option=client min protocol=SMB3` alongside `--max-protocol=SMB3`). If the server negotiated anything below SMB3, or negotiation failed, smbclient aborts with an `NT_STATUS` error before listing. A clean listing — asserted via the `blocks of size` session trailer — therefore proves an SMB 3.x dialect was negotiated end-to-end, independent of Samba's debug-string formatting.

Also removes the now-unused `RunSMBClientDebug` helper.

## Validation

- `gofmt -s -w . && go vet ./... && go build ./...` clean
- `go build -tags e2e ./test/e2e/...` and `go vet -tags e2e` clean
- Test-only change behind the `e2e` build tag; no product code touched
- code-simplifier: no changes warranted; code-reviewer: no material issues (verified argv passing of the space-containing option, `blocks of size` as a reliable session-level trailer, and that a false-pass would require a broken Samba or DittoFS regressing to SMB2)