### PR TITLE
docs(readme): add POSIX and SMB conformance CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 [![Integration Tests](https://github.com/marmos91/dittofs/actions/workflows/integration-tests.yml/badge.svg?branch=develop)](https://github.com/marmos91/dittofs/actions/workflows/integration-tests.yml)
 [![E2E Tests](https://github.com/marmos91/dittofs/actions/workflows/e2e-tests.yml/badge.svg?branch=develop)](https://github.com/marmos91/dittofs/actions/workflows/e2e-tests.yml)
 [![Lint](https://github.com/marmos91/dittofs/actions/workflows/lint.yml/badge.svg?branch=develop)](https://github.com/marmos91/dittofs/actions/workflows/lint.yml)
+[![POSIX Tests](https://github.com/marmos91/dittofs/actions/workflows/posix-tests.yml/badge.svg?branch=develop)](https://github.com/marmos91/dittofs/actions/workflows/posix-tests.yml)
+[![SMB Conformance](https://github.com/marmos91/dittofs/actions/workflows/smb-conformance.yml/badge.svg?branch=develop)](https://github.com/marmos91/dittofs/actions/workflows/smb-conformance.yml)
 
 **A modular virtual filesystem written entirely in Go**
 


### PR DESCRIPTION
Adds two more CI status badges to the README header (tracking `develop`):

- POSIX Tests
- SMB Conformance

Docs-only; no code or workflow changes.