### PR TITLE
fix(nfs): implement NFSv4.1 OPEN CLAIM_FH (intermittent EINVAL)

### DIFF
--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -204,6 +204,12 @@ func (h *Handler) handleOpen(ctx *types.CompoundContext, reader io.Reader) *type
 				"client", ctx.ClientAddr)
 			return openError(nfsStatus)
 		}
+		// CLAIM_FH re-opens an existing filehandle, so OPEN4_CREATE is illegal
+		// (RFC 8881: createhow4 is only meaningful for CLAIM_NULL). Reject it
+		// rather than silently treating a create as a plain open.
+		if openType == types.OPEN4_CREATE {
+			return openError(types.NFS4ERR_INVAL)
+		}
 		return h.handleOpenClaimFH(ctx, seqid, shareAccess, shareDeny,
 			clientID, ownerData, claimType)
 

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -190,6 +190,23 @@ func (h *Handler) handleOpen(ctx *types.CompoundContext, reader io.Reader) *type
 		return h.handleOpenClaimNull(ctx, reader, seqid, shareAccess, shareDeny,
 			clientID, ownerData, openType, createMode, claimType, createAttrs, createVerifier)
 
+	case types.CLAIM_FH:
+		// CLAIM_FH (RFC 8881 Section 18.16.3): re-open the file named by the
+		// current filehandle, with no component name and no additional args
+		// (open_claim4 is void for this case). Linux NFSv4.1 clients use this to
+		// re-open a file they still hold a filehandle for (e.g. reading back a
+		// file they just created and closed) instead of a fresh CLAIM_NULL
+		// lookup. It is a new open, so it is grace-blocked like CLAIM_NULL.
+		if graceErr := h.StateManager.CheckGraceForNewState(); graceErr != nil {
+			nfsStatus := mapStateError(graceErr)
+			logger.Debug("NFSv4 OPEN blocked by grace period",
+				"claim_type", "CLAIM_FH",
+				"client", ctx.ClientAddr)
+			return openError(nfsStatus)
+		}
+		return h.handleOpenClaimFH(ctx, seqid, shareAccess, shareDeny,
+			clientID, ownerData, claimType)
+
 	case types.CLAIM_PREVIOUS:
 		return h.handleOpenClaimPrevious(ctx, reader, seqid, shareAccess, shareDeny,
 			clientID, ownerData, claimType)
@@ -487,6 +504,93 @@ func (h *Handler) handleOpenClaimNull(
 
 	return h.encodeOpenResult(clientID, ownerData, &openResult.Stateid, openResult.RFlags,
 		beforeCtime, afterCtime, deleg)
+}
+
+// handleOpenClaimFH handles the CLAIM_FH path for OPEN (NFSv4.1).
+//
+// The file to open is identified by the current filehandle (set by a preceding
+// PUTFH), so there is no component name to look up and open_claim4 carries no
+// additional arguments (it is void). This is otherwise a normal open of an
+// existing file: it always behaves like OPEN4_NOCREATE regardless of the
+// opentype the client sent.
+func (h *Handler) handleOpenClaimFH(
+	ctx *types.CompoundContext,
+	seqid, shareAccess, shareDeny uint32,
+	clientID uint64, ownerData []byte,
+	claimType uint32,
+) *types.CompoundResult {
+	// The current filehandle is the file being opened.
+	fileHandle := make(metadata.FileHandle, len(ctx.CurrentFH))
+	copy(fileHandle, ctx.CurrentFH)
+
+	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
+	if err != nil {
+		logger.Debug("NFSv4 OPEN CLAIM_FH auth context failed",
+			"error", err,
+			"client", ctx.ClientAddr)
+		return openError(nfs4StatusForAuthError(err))
+	}
+
+	metaSvc, err := getMetadataServiceForCtx(h)
+	if err != nil {
+		return openError(types.NFS4ERR_SERVERFAULT)
+	}
+
+	// Enforce the requested share_access against the file's permissions.
+	if accessErr := checkOpenAccess(metaSvc, authCtx, fileHandle, shareAccess); accessErr != nil {
+		return openError(common.MapToNFS4(accessErr))
+	}
+
+	// If another client holds a conflicting delegation, recall it and ask the
+	// client to retry, mirroring the CLAIM_NULL NOCREATE path.
+	if conflict, _ := h.StateManager.CheckDelegationConflict([]byte(fileHandle), clientID, shareAccess); conflict {
+		logger.Debug("NFSv4 OPEN CLAIM_FH delegation conflict, returning NFS4ERR_DELAY",
+			"client_id", clientID,
+			"client", ctx.ClientAddr)
+		return openError(types.NFS4ERR_DELAY)
+	}
+
+	// Create tracked open state (enforces share reservations and seqid/replay).
+	openResult, stateErr := h.StateManager.OpenFile(
+		clientID, ownerData, seqid,
+		[]byte(fileHandle),
+		shareAccess, shareDeny,
+		claimType,
+	)
+	if stateErr != nil {
+		return openError(mapStateError(stateErr))
+	}
+
+	if openResult.IsReplay {
+		return &types.CompoundResult{
+			Status: openResult.CachedStatus,
+			OpCode: types.OP_OPEN,
+			Data:   openResult.CachedData,
+		}
+	}
+
+	// NFSv4.1 removed OPEN_CONFIRM; owners are implicitly confirmed via the
+	// session, so strip OPEN4_RESULT_CONFIRM and auto-confirm.
+	if ctx.SkipOwnerSeqid && openResult.RFlags&types.OPEN4_RESULT_CONFIRM != 0 {
+		openResult.RFlags &^= types.OPEN4_RESULT_CONFIRM
+		_ = h.StateManager.ConfirmOpenV41(&openResult.Stateid)
+	}
+
+	delegType, shouldGrant := h.StateManager.ShouldGrantDelegation(clientID, []byte(fileHandle), shareAccess)
+	var deleg *state.DelegationState
+	if shouldGrant {
+		deleg = h.StateManager.GrantDelegation(clientID, []byte(fileHandle), delegType)
+	}
+
+	logger.Debug("NFSv4 OPEN CLAIM_FH successful",
+		"stateid_seqid", openResult.Stateid.Seqid,
+		"rflags", openResult.RFlags,
+		"delegation", delegType,
+		"client", ctx.ClientAddr)
+
+	// CLAIM_FH does not create or change a directory, so change_info is empty.
+	return h.encodeOpenResult(clientID, ownerData, &openResult.Stateid, openResult.RFlags,
+		0, 0, deleg)
 }
 
 // handleOpenClaimPrevious handles the CLAIM_PREVIOUS path for OPEN.

--- a/internal/adapter/nfs/v4/handlers/open_claim_fh_test.go
+++ b/internal/adapter/nfs/v4/handlers/open_claim_fh_test.go
@@ -55,3 +55,37 @@ func TestOpen_ClaimFH_ReopenExistingFile(t *testing.T) {
 		t.Fatalf("CLAIM_FH OPEN status = %d, want NFS4_OK", r.Status)
 	}
 }
+
+// TestOpen_ClaimFH_CreateRejected verifies that OPEN4_CREATE combined with
+// CLAIM_FH is rejected. CLAIM_FH re-opens an existing filehandle; createhow4 is
+// only meaningful for CLAIM_NULL (RFC 8881), so a create claim must not be
+// silently downgraded to a plain open.
+func TestOpen_ClaimFH_CreateRejected(t *testing.T) {
+	const clientID = uint64(0x0BADF00D)
+	owner := []byte("claim-fh-create-owner")
+
+	fx := newRealFSTestFixture(t, "/export")
+	fileHandle := fx.createTestFile(t, fx.rootHandle, "reopen.txt",
+		metadata.FileTypeRegular, 0o644, 1000, 1000)
+
+	ctx := newRealFSContext(1000, 1000)
+	ctx.SkipOwnerSeqid = true
+	ctx.CurrentFH = make([]byte, len(fileHandle))
+	copy(ctx.CurrentFH, fileHandle)
+
+	// UNCHECKED4 createattrs are still encoded so the args are well-formed; the
+	// handler must reject on the OPEN4_CREATE opentype before consuming them.
+	args := encodeOpenArgs(
+		0,
+		types.OPEN4_SHARE_ACCESS_BOTH,
+		types.OPEN4_SHARE_DENY_NONE,
+		clientID, owner,
+		types.OPEN4_CREATE, types.UNCHECKED4, types.CLAIM_FH,
+		"",
+	)
+
+	r := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	if r.Status != types.NFS4ERR_INVAL {
+		t.Fatalf("CLAIM_FH OPEN4_CREATE status = %d, want NFS4ERR_INVAL", r.Status)
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/open_claim_fh_test.go
+++ b/internal/adapter/nfs/v4/handlers/open_claim_fh_test.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// TestOpen_ClaimFH_ReopenExistingFile reproduces the intermittent EINVAL a
+// Linux NFSv4.1 client hits when it re-opens a file it already holds a
+// filehandle for (e.g. reading back a file it just created and closed).
+//
+// Instead of a fresh CLAIM_NULL lookup, the client sends OPEN with claim type
+// CLAIM_FH (RFC 8881 Section 18.16.3): open the current filehandle, no name,
+// void args. The server previously had no case for CLAIM_FH and fell through
+// to the dispatch default, returning NFS4ERR_INVAL — surfacing to the client
+// as EINVAL from open(2). Whether the kernel used CLAIM_FH or CLAIM_NULL
+// depended on its cache state, which made the failure look intermittent.
+//
+// A CLAIM_FH open of an existing, accessible file must succeed with NFS4_OK.
+func TestOpen_ClaimFH_ReopenExistingFile(t *testing.T) {
+	const clientID = uint64(0x0BADF00D)
+	owner := []byte("claim-fh-owner")
+
+	fx := newRealFSTestFixture(t, "/export")
+
+	// Create the file and grab its filehandle, as if the client had just
+	// created it and still held the handle.
+	fileHandle := fx.createTestFile(t, fx.rootHandle, "reopen.txt",
+		metadata.FileTypeRegular, 0o644, 1000, 1000)
+
+	ctx := newRealFSContext(1000, 1000)
+	ctx.SkipOwnerSeqid = true // NFSv4.1 session semantics
+	ctx.CurrentFH = make([]byte, len(fileHandle))
+	copy(ctx.CurrentFH, fileHandle)
+
+	// OPEN with CLAIM_FH: NOCREATE, READ, no filename (void claim args).
+	args := encodeOpenArgs(
+		0, // seqid ignored in v4.1
+		types.OPEN4_SHARE_ACCESS_READ,
+		types.OPEN4_SHARE_DENY_NONE,
+		clientID, owner,
+		types.OPEN4_NOCREATE, 0, types.CLAIM_FH,
+		"", // CLAIM_FH carries no component name
+	)
+
+	r := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	if r.Status == types.NFS4ERR_INVAL {
+		t.Fatalf("CLAIM_FH OPEN returned NFS4ERR_INVAL (regression: server has no " +
+			"CLAIM_FH case and rejected the re-open)")
+	}
+	if r.Status != types.NFS4_OK {
+		t.Fatalf("CLAIM_FH OPEN status = %d, want NFS4_OK", r.Status)
+	}
+}

--- a/internal/adapter/nfs/v4/types/constants.go
+++ b/internal/adapter/nfs/v4/types/constants.go
@@ -375,12 +375,17 @@ const (
 	OPEN4_CREATE   = 1
 )
 
-// OPEN claim types (RFC 7530 Section 16.16.4)
+// OPEN claim types (RFC 7530 Section 16.16.4, RFC 8881 Section 18.16.3).
+// CLAIM_FH and the CLAIM_DELEG_*_FH variants are NFSv4.1 additions: they open
+// the file identified by the current filehandle instead of by (dir, name).
 const (
 	CLAIM_NULL          = 0
 	CLAIM_PREVIOUS      = 1
 	CLAIM_DELEGATE_CUR  = 2
 	CLAIM_DELEGATE_PREV = 3
+	CLAIM_FH            = 4 // v4.1: open the current filehandle (no name, void args)
+	CLAIM_DELEG_CUR_FH  = 5 // v4.1: CLAIM_DELEGATE_CUR by current filehandle
+	CLAIM_DELEG_PREV_FH = 6 // v4.1: CLAIM_DELEGATE_PREV by current filehandle
 )
 
 // OPEN result flags (rflags)


### PR DESCRIPTION
## Problem

`TestNFSv41MultipleSessions` (e2e) fails intermittently: a client's `os.ReadFile` re-open of a file it just created+wrote+closed returns `EINVAL`:

```
open .../session_0_file.txt: invalid argument
```

The 3 mounts use identical options, so the Linux kernel coalesces them into one `nfs_client` / one session / one shared open-owner — which is what stresses the re-open path.

## Root cause (reproduced on a Linux NFSv4.1 kernel client, with wire capture)

Reproduced on a disposable Scaleway VM (Ubuntu 24.04, kernel 6.8, 32 cores). tcpdump + tshark on the failing run showed the server returning **`NFS4ERR_INVAL` on the `OPEN` operation**, for an OPEN with **claim type `CLAIM_FH` (4)**, `OPEN4_NOCREATE`, `SHARE_ACCESS_READ`.

`CLAIM_FH` (RFC 8881 §18.16.3) is an NFSv4.1 addition: open the file named by the *current filehandle*, with no component name and void claim args. A Linux 4.1 client uses it to re-open a file it still holds a filehandle for (reading back a file it just created and closed) instead of a fresh `CLAIM_NULL` lookup. Whether the kernel picks `CLAIM_FH` vs `CLAIM_NULL` depends on its inode/FH cache state, which is why the failure was intermittent.

The server's OPEN dispatch (`internal/adapter/nfs/v4/handlers/open.go`) had **no `case` for `CLAIM_FH`**, so it fell through to the `default` and returned `NFS4ERR_INVAL` → `EINVAL` at the client. `CLAIM_FH` is mandatory for servers that support NFSv4.1.

## Fix

- Add `CLAIM_FH` (and the `CLAIM_DELEG_*_FH` constants) to `types/constants.go`.
- Add a `case types.CLAIM_FH` to the OPEN dispatch that grace-checks (it is a new open, like `CLAIM_NULL`) then calls a new `handleOpenClaimFH`.
- `handleOpenClaimFH` opens the current filehandle (always NOCREATE, void claim args — nothing to decode), enforcing the same share-access and delegation-conflict checks as the `CLAIM_NULL` existing-file path, then runs the shared open tail (`StateManager.OpenFile` → replay → v4.1 auto-confirm → delegation grant → `encodeOpenResult` with empty change_info).
- Add regression test `open_claim_fh_test.go`.

## Validation

- New unit regression test + full `./internal/adapter/nfs/v4/...` suite green.
- On the VM: `TestNFSv41MultipleSessions` reproduced the `EINVAL` reliably pre-fix (caught within 1–8 iterations, repeatedly). Post-fix: **80/80 iterations green**, plus additional parallel stress iterations with **zero** failures.

Note: this also makes the e2e test's unconditional `t.Log("...: PASSED")` truthful — pre-fix it printed PASSED even while `assert` recorded the failure. Left as-is here since the fix removes the failure; tightening that log to `require` can be a separate cleanup.