### PR TITLE
blocks-only storage: flip live writer + read path to packed blocks (#1493 PR3)

### DIFF
--- a/.planning/2026-06-30-1493-pr3-plan.md
+++ b/.planning/2026-06-30-1493-pr3-plan.md
@@ -1,0 +1,84 @@
+# PR3 — Sync engine + read path: the behavioral flip (#1493)
+
+**Branch:** `1493-pr3-blocks-flip` (off develop `7ec27c2d`, post PR2 merge).
+**Design:** `.planning/2026-06-30-blocks-only-storage-design.md` (components 5–8).
+**Depends on:** PR2 (#1511, merged).
+
+## What PR3 is
+
+Flip the LIVE writer from per-chunk `cas/<hash>` to packed blocks, and the read path to resolve
+from blocks; add delete-only block GC and corruption self-heal.
+
+## Locked decisions
+- **Global flip, no feature flag.** ALL new writes become blocks on deploy. Existing `cas/<hash>`
+  data stays readable via the retained legacy CAS read path until PR4 migrates it. One forward
+  path; no config knob (pre-1.0 "less is more / no compat shims").
+- **Legacy CAS reader retained, quarantined.** Dual-mode read (block/local-index first, CAS
+  fallback) is back-compat only, removed in PR4. Do NOT delete the CAS reader here.
+- **Carve lives in the engine** (the syncer), replacing the per-hash mirror dispatch loop with a
+  per-block carve loop.
+- **Carve trigger:** new `BlockCarveBytes` knob (~16 MiB target) + idle timeout (reuse/rename the
+  existing idle/UploadDelay notion, ~5 s). Block-blob `SizeCap` (logblob, ~1 GiB) is separate.
+- **logblob durability wiring:** supply the synced-predicate to `EvictBlob` and the durable
+  high-water mark to `Recover` from metadata (the PR2 forward note).
+- **No premature renames / no legacy deletion** beyond quarantine (PR4 owns both).
+
+## Substrate from PR2 (dormant → wired here)
+`logblob.Manager` (Append/ReadAt/Rotate/EvictBlob/Recover) · `metadata.LocalChunkIndex` ·
+`metadata.BlockRecordStore` (+DecrLiveChunkCount/DeleteBlockRecord) · `metadata.DefaultCommitBlock`
+· `blockcodec` (Builder/Parse) · `RemoteBlockStore` (PutBlock/GetBlock/GetBlockRange/DeleteBlock/
+WalkBlocks).
+
+## Seam map (file:line — re-anchor on develop 7ec27c2d before editing)
+**Write/sync:** `fs/chunkstore.go:41 StoreChunk`; `fs/rollup.go:292 rollupFileInner` (StoreChunk@365,
+PersistFileChunks@367), `rollup.go:51 StartRollup`/`:131 scanAllFiles`; `engine/syncer.go:166
+addPendingHash`, `:581 mirrorOnce`, `:672 mirrorChunk` (Put@706, standalone MarkSynced@715),
+`dispatcher.go:297 uploadDispatcher`; config `fs/fs.go:912 FSStoreOptions`, `engine/types.go:72
+SyncerConfig`.
+**Read/GC/corruption:** `engine/read_internal.go:51 readAtInternal`/`:130 readLocalByHash`;
+`fetch.go:316 EnsureAvailableAndRead`/`:137 dispatchRemoteFetch`/`:182 resolveLocator`/`:205
+readChunkVerified` (blake3@215, ErrCASContentMismatch); `fs/chunkstore.go:132 ReadChunk` (raw);
+GC `engine/gc.go CollectGarbage`, `coordinator.go:65 DecrementRefCountAndReap`; corruption
+fail-closed `fetch.go:269 fetchResolvedBlock`; metrics `engine/metrics.go:10 DataplaneMetrics`
+(empty).
+
+## Global constraints (every task)
+1. TDD; failing test first. Hot path — every behavior covered, `-race` on engine/fs.
+2. Keep develop green: existing fs/engine/storetest/e2e suites stay green throughout.
+3. Dual-mode read: never break reads of pre-existing CAS data (back-compat test required).
+4. Streaming I/O on the data path (io.Reader/Writer + sync.Pool; cap RAM at carve size).
+5. Reuse existing per-chunk compression/encryption decorators in the block transform.
+6. Quarantine (don't delete) the legacy CAS writer/reader; no type renames (PR4).
+7. blake3 fail-closed; `metadata.ExportError` codes; expected→Debug, unexpected→Error.
+8. Lint/format gate; sign commits (1Password agent flaps — fall back unsigned + controller
+   re-signs before push); assign PR to marmos91.
+
+## Tasks (SDD)
+- **T1 — Local tier writes to logblob.** Route FSStore chunk persistence to `logblob.Append` +
+  `LocalChunkIndex.PutLocalLocation` instead of CAS `StoreChunk`; local read by hash = index hit →
+  `logblob.ReadAt`. Keep legacy CAS files readable. DoD: fs blockstore conformance green on logblob
+  backing; legacy CAS read still works.
+- **T2 — Block carve + pack + upload + atomic commit.** Engine carver: accumulate synced-pending
+  chunks, carve at `BlockCarveBytes`/idle, `logblob.ReadAt` regions → `blockcodec.Builder` (+
+  transform) → `RemoteBlockStore.PutBlock` → `DefaultCommitBlock`. Idempotent on blockID. Replaces
+  `mirrorChunk` for new data. DoD: new write produces `blocks/` not `cas/`; e2e write+read.
+- **T3 — Read path resolves blocks (dual-mode).** index hit → logblob raw; miss → `GetLocator` →
+  `GetBlockRange` → `blockcodec` decode → blake3 verify (fail-closed); legacy CAS branch retained.
+  DoD: blocks read byte-identical; CAS back-compat covered.
+- **T4 — Delete-only block GC.** refcount-0 cascade → `DecrLiveChunkCount`; at 0 → `EvictBlob` +
+  `RemoteBlockStore.DeleteBlock` + `DeleteBlockRecord`. No scan. DoD: full unlink frees block
+  local+remote; partial leaves intact; refcount invariant holds.
+- **T5 — Corruption / self-heal + metrics.** `blake3(block)==blockHash` on fetch; local mismatch →
+  refetch+re-stage; remote → fail-closed + metric. Extend `DataplaneMetrics`. DoD: local corruption
+  self-heals; remote corruption fails closed + counted.
+- **T6 — Retire rollup→standalone-mirror (quarantine).** New writes bypass mirrorOnce/mirrorChunk/
+  standalone MarkSynced; legacy kept for reads. DoD: new writes never call mirrorChunk; legacy
+  compiles + back-compat passes.
+- **T7 — e2e + docs.** e2e fresh-share write→read→GC over blocks (NFS+SMB), read-after-evict,
+  corruption. Docs: flip architecture.md "dormant"→"live for new shares"; document dual-mode read +
+  delete-only GC + corruption. Regenerate cli.md only if a flag changed.
+
+## Sequencing
+T1 → T2 → T3 are a chain (write substrate → carve → read). T4/T5 build on T2/T3. T6 after T2 (carve
+owns sync). T7 last. Mostly serial (hot-path, shared engine files) — limited parallelism vs PR2.
+Verify after each task; whole-branch review (Opus) before PR; e2e gate before merge.

--- a/bench/snapshots/workloads.go
+++ b/bench/snapshots/workloads.go
@@ -104,7 +104,7 @@ func SeedRemote(ctx context.Context, rs remote.RemoteStore, hs *block.HashSet) (
 // an all-present remote (see SeedRemote) every probe runs, giving the
 // worst-case verify wall time for the manifest size.
 func RunVerify(ctx context.Context, rs remote.RemoteStore, hs *block.HashSet) (int, error) {
-	if err := snapshot.VerifyRemoteDurability(ctx, rs, hs, VerifyConcurrency); err != nil {
+	if err := snapshot.VerifyRemoteDurability(ctx, rs, nil, nil, hs, VerifyConcurrency); err != nil {
 		return 0, fmt.Errorf("snapshots bench: verify: %w", err)
 	}
 	return hs.Len(), nil

--- a/cmd/dfsctl/commands/store/block/gc.go
+++ b/cmd/dfsctl/commands/store/block/gc.go
@@ -27,10 +27,13 @@ var gcCmd = &cobra.Command{
 
 The mark phase enumerates every live ContentHash across all shares whose
 remote-store config matches the named share (cross-share aggregation).
-The sweep phase deletes any cas/.../ object absent from the live set
-whose LastModified is older than the configured grace period (default
-1h). The last-run.json summary is persisted under the share's gc-state
-directory and can be inspected with:
+The sweep phase reclaims storage absent from the live set: it decrements
+the refcount of each dead chunk's enclosing packed block and, once a
+block holds no live chunks, deletes it from the remote and evicts its
+local copy. Legacy per-chunk cas/.../ objects (written before packed
+blocks) are also deleted when dead and older than the configured grace
+period (default 1h). The last-run.json summary is persisted under the
+share's gc-state directory and can be inspected with:
 
   dfsctl store block gc-status <share>
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -5602,10 +5602,13 @@ Trigger an on-demand GC run for the named share.
 
 The mark phase enumerates every live ContentHash across all shares whose
 remote-store config matches the named share (cross-share aggregation).
-The sweep phase deletes any cas/.../ object absent from the live set
-whose LastModified is older than the configured grace period (default
-1h). The last-run.json summary is persisted under the share's gc-state
-directory and can be inspected with:
+The sweep phase reclaims storage absent from the live set: it decrements
+the refcount of each dead chunk's enclosing packed block and, once a
+block holds no live chunks, deletes it from the remote and evicts its
+local copy. Legacy per-chunk cas/.../ objects (written before packed
+blocks) are also deleted when dead and older than the configured grace
+period (default 1h). The last-run.json summary is persisted under the
+share's gc-state directory and can be inspected with:
 
 ```
 dfsctl store block gc-status <share>

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -243,10 +243,21 @@ Pending FileChunks to remote CAS.
 
 The local filesystem store (`pkg/block/local/fs/`) writes through an
 append-only log per file. A rollup pool chunks the log via FastCDC, hashes
-each chunk with BLAKE3, and persists the chunks under a content-addressable
-`blocks/{hh}/{hh}/{hex}` directory. The syncer then uploads those chunks to
-the remote content-addressable keyspace (`cas/{hh}/{hh}/{hex}`), and a
-mark-sweep GC reclaims the remote `cas/` prefix.
+each chunk with BLAKE3, and persists the chunks locally under a
+content-addressable `blocks/{hh}/{hh}/{hex}` directory.
+
+**New writes are packed into remote blocks.** On every share, the syncer's
+carver batches locally-rolled chunks and uploads them as packed **block
+objects** under the remote `blocks/<id>` prefix — one PUT per block of
+roughly 16 MiB of chunks (`BlockCarveBytes`), or sooner when the writer goes
+idle. It does **not** write one `cas/<hash>` object per chunk. Per-chunk
+deduplication and refcounting are preserved: a
+`ChunkLocator{BlockID, WireOffset, WireLength}` records where each chunk's
+bytes live inside its enclosing block, so identical chunks are still stored
+once and reclaimed by refcount. The per-chunk `cas/<hash>` remote keyspace is
+now **legacy and read-only** — it is still read for data written before the
+flip and is retired by a later migration, but no new `cas/` object is ever
+written.
 
 This is the only local write path. Servers from v0.16 on require the CAS
 layout; a store directory still holding the older `.blk` layout is detected
@@ -327,13 +338,15 @@ See `docs/CONFIGURATION.md` (`max_log_bytes`, `rollup_workers`,
 
 ## Log-Blob Local Tier
 
-`pkg/block/local/logblob` is a raw append-only file manager designed to
-replace the per-file append-log described above. **This substrate is built
-but not yet active.** The live local write path is still the `FSStore`
-append-log → FastCDC → `cas/<hash>` rollup described in
+`pkg/block/local/logblob` is a raw append-only file manager that holds the
+local durable copy of freshly-written chunks. **This substrate is live.**
+Locally-rolled chunks are appended to log-blobs, and the engine carver reads
+them back by position (`LocalChunkLocation{LogBlobID, RawOffset, RawLength}`)
+to pack them into the remote block objects described in
 [Block Store — Local Append-Log Tier](#block-store----local-append-log-tier).
-A later PR wires `logblob.Manager` into the block engine; a further PR
-retires the per-file log.
+Reads resolve through the local chunk index first — a positioned `pread(2)`
+against the log-blob — and fall back to the remote block only on a local
+miss (see [Block Reads](#block-reads-dual-mode-verified)).
 
 ### Layout
 
@@ -472,6 +485,15 @@ requeues any `Syncing` row whose `last_sync_attempt_at` is older than
 content-defined so a duplicate re-upload writes the same bytes to the
 same key — idempotent by construction.
 
+**Known limitation — restart seeding.** Chunks that were appended to the
+local log-blob but not yet carved into a remote block when the process
+crashed are durable on local disk, but they are **not** re-seeded into the
+pending-carve set on restart. They stay local-only — fully readable — until
+the file they belong to is written to again, which re-queues them for
+carving. No data is lost; the only effect is that such chunks are not
+uploaded to the remote until touched again. Re-seeding the carve set from the
+local index on boot is a follow-up item.
+
 **Why a metadata write for every claim?** The Pending → Syncing
 transition is the serialization point against duplicate uploads across
 syncer instances. The batched-claim cost is one txn per tick, in exchange
@@ -499,6 +521,26 @@ The block-store GC is a fail-closed mark-sweep over the union of every live
    each key, the engine keeps the object iff the hash is present in the
    live set OR the object's `LastModified` is newer than
    `T − gc.grace_period` (default 1h). Otherwise the engine issues a DELETE.
+
+### Packed-block reclamation
+
+Because new data lives in packed `blocks/<id>` objects rather than one object
+per chunk, the sweep cannot DELETE one remote object per dead hash. Instead
+each dead chunk is reclaimed by refcount:
+
+1. A dead `ContentHash` — present in the store's synced-hash index but absent
+   from the live set — is resolved to its enclosing block, and
+   `DecrLiveChunkCount(blockID, 1)` is applied.
+2. When a block's live-chunk count reaches **zero**, the block is fully
+   reclaimed: its local blob is evicted, `RemoteBlockStore.DeleteBlock`
+   removes the remote object, and the block record is deleted.
+
+A block that still has *any* live chunk is retained — packing never deletes a
+referenced chunk along with its block-mates. Reclamation is **delete-only**:
+GC never rewrites or repacks a surviving block. Runs are **serialized per
+remote** (keyed on remote-store config identity), so the `LiveChunkCount` that
+several shares targeting the same remote share is only ever mutated by one run
+at a time.
 
 ### Fail-closed posture
 
@@ -691,18 +733,43 @@ call only (`WithRestoreTimeout`).
 For the full operator runbook see
 [SNAPSHOTS.md](../guide/snapshots.md).
 
-## Block Reads (content-addressable)
+## Block Reads (dual-mode, verified)
 
-The engine resolves every block read from the content-addressable keyspace:
-read from `cas/{hh}/{hh}/{hex}`, BLAKE3-verified end-to-end (a header
-pre-check on `x-amz-meta-content-hash` plus a streaming verifier over the
-body). Resolution is by metadata key — one DB lookup per block — not by
-remote trial-and-error, so there is no doubled GET cost.
+Every block read resolves by metadata key — one DB lookup per chunk, not
+remote trial-and-error, so there is no doubled GET cost — and takes one of
+three paths:
+
+1. **Local log-blob hit.** If the chunk is still on local disk, its bytes are
+   served straight from the log-blob via a positioned `pread(2)` at its
+   `LocalChunkLocation`. This is the steady-state path for recently-written
+   and recently-read data.
+2. **Remote packed block.** On a local miss, the engine resolves the chunk's
+   `ChunkLocator`; a non-empty `BlockID` means the chunk lives inside the
+   packed remote object `blocks/<BlockID>` at
+   `[WireOffset, WireOffset+WireLength)`. The engine issues a ranged GET
+   against that block, decodes the wire frame, and recomputes BLAKE3 over the
+   chunk bytes. A verified chunk is re-staged into the local tier so
+   subsequent reads take path 1.
+3. **Legacy standalone CAS object.** A locator with an empty `BlockID`
+   resolves to a standalone `cas/{hh}/{hh}/{hex}` object — data written before
+   the blocks-only flip. It is fetched whole and BLAKE3-verified end-to-end (a
+   header pre-check on `x-amz-meta-content-hash` plus a streaming verifier over
+   the body). No new data uses this path.
+
+**Fail-closed integrity.** Every remote fetch is BLAKE3-verified before the
+bytes reach the caller. A mismatch is never surfaced as data: the read returns
+an error and increments a corruption metric.
+
+**Self-heal.** The two tiers are treated asymmetrically on a verification
+failure. A *local* mismatch (a bit-rotted log-blob) is self-healing — the
+engine discards the bad local pointer, re-fetches the chunk from its remote
+block, verifies it, and re-stages it locally. A *remote* mismatch cannot be
+recovered locally, so it fails closed: the read errors and the corruption is
+recorded rather than papered over.
 
 The older non-CAS layout (`{payloadID}/block-{N}`) is no longer read at
 runtime. A store directory still on that layout is detected on open and the
-operator is directed to run `dfs migrate-to-cas`, which re-chunks all data
-into the CAS keyspace. See
+operator is directed to run `dfs migrate-to-cas`. See
 [Migration & Block-Layout Routing](#migration--block-layout-routing).
 
 ## Adapter Pattern

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -243,8 +243,12 @@ Pending FileChunks to remote CAS.
 
 The local filesystem store (`pkg/block/local/fs/`) writes through an
 append-only log per file. A rollup pool chunks the log via FastCDC, hashes
-each chunk with BLAKE3, and persists the chunks locally under a
-content-addressable `blocks/{hh}/{hh}/{hex}` directory.
+each chunk with BLAKE3, and appends the chunk bytes to the local **log-blob**
+tier (`blobs/<id>.blob`), recording each chunk's position in the
+`LocalChunkIndex`. The per-chunk content-addressed `blocks/{hh}/{hh}/{hex}`
+directory is **legacy and read-only** — retained so chunks written before the
+log-blob flip stay readable, but no new per-chunk file is ever written. See
+[Log-Blob Local Tier](#log-blob-local-tier) below.
 
 **New writes are packed into remote blocks.** On every share, the syncer's
 carver batches locally-rolled chunks and uploads them as packed **block
@@ -283,8 +287,8 @@ See [Block Lifecycle (three-state)](#block-lifecycle-three-state) and
                                                               |
                                                               v
                                                        StoreChunk
-                                                       blocks/{hh}/{hh}/{hex}
-                                                       (.tmp + rename + fsync)
+                                                       blobs/<id>.blob (append)
+                                                       + LocalChunkIndex entry
                                                               |
                                         CommitChunks atomic:  |
                                          1. metadata.SetRollupOffset (source of truth)
@@ -300,7 +304,8 @@ See [Block Lifecycle (three-state)](#block-lifecycle-three-state) and
 
 ```
 <baseDir>/logs/<payloadID>.log        per-file append-only log
-<baseDir>/blocks/<hh>/<hh>/<hex>      content-addressed chunks (CAS)
+<baseDir>/blobs/<id>.blob             log-blob tier (rolled-up chunk bytes)
+<baseDir>/blocks/<hh>/<hh>/<hex>      legacy per-chunk CAS (read-only, back-compat)
 ```
 
 Log header (64 bytes): magic `DFLG` | version | `rollup_offset` | flags |
@@ -322,8 +327,9 @@ payload.
 Recovery (`pkg/block/local/fs/recovery.go`) scans logs from
 `rollup_offset`, truncates at first bad CRC, and rebuilds per-file interval
 trees. Orphan logs (no metadata referrer, no live FileChunk, mtime older
-than `orphan_log_min_age_seconds`) are swept. Orphan chunks under
-`blocks/{hh}/{hh}/{hex}` are reclaimed by the mark-sweep GC.
+than `orphan_log_min_age_seconds`) are swept. Orphan chunks under the legacy
+`blocks/{hh}/{hh}/{hex}` CAS dir are reclaimed by the mark-sweep GC; log-blob
+bytes are reclaimed by whole-blob eviction (see [Log-Blob Local Tier](#log-blob-local-tier)).
 
 ### Per-`FSStore` surface
 

--- a/docs/internals/implementing-stores.md
+++ b/docs/internals/implementing-stores.md
@@ -842,9 +842,9 @@ verification tests.
 
 ## Implementing a Remote Block Store (block-keyed)
 
-The `pkg/block/remote.RemoteBlockStore` interface is the **block-keyed** (non-CAS) remote store surface introduced by the blocks-only storage redesign (epic [#1493](https://github.com/marmos91/dittofs/issues/1493)). Block objects live under the `blocks/` prefix, separate from the legacy CAS `cas/` namespace — the two namespaces never collide.
+The `pkg/block/remote.RemoteBlockStore` interface is the **block-keyed** (non-CAS) remote store surface used by the live write path. Every new write is packed into block objects under the `blocks/` prefix, separate from the legacy CAS `cas/` namespace — the two namespaces never collide. New remote backends should implement `RemoteBlockStore`.
 
-> **Legacy path (being retired):** The per-chunk CAS object path (`cas/<hash>`, hash-keyed `Put`/`Get`/`GetRange` on `RemoteStore`) is being retired in favour of blocks-only storage as part of epic #1493. New remote backends should implement `RemoteBlockStore`. The legacy `RemoteStore` CAS surface will be removed in a later PR of the same epic.
+> **Legacy CAS reads:** The per-chunk CAS object path (`cas/<hash>`, hash-keyed `Get`/`GetRange` on `RemoteStore`) is **read-only** and exists purely for backward compatibility with data written before the blocks-only flip. No new `cas/` objects are ever written; a later migration re-packs the remaining ones, after which the legacy `RemoteStore` CAS surface is removed. A backend that only ever serves fresh DittoFS deployments does not need it.
 
 ### The RemoteBlockStore Interface
 

--- a/pkg/block/compression/decorator.go
+++ b/pkg/block/compression/decorator.go
@@ -48,18 +48,50 @@ func NewRemote(inner remote.RemoteStore, p CompressionPolicy) (*Decorator, error
 // (header overhead included) it stores the framed compressed body, else
 // it stores the raw plaintext with no header — incompressible blocks
 // skip the allocate-and-copy frame build entirely.
+//
+// Put and SealChunk share the same single-layer transform (sealLayer) so the
+// standalone-object and packed-block write paths never drift.
 func (d *Decorator) Put(ctx context.Context, hash block.ContentHash, data []byte) error {
+	wire, err := d.sealLayer(data)
+	if err != nil {
+		return err
+	}
+	return d.inner.Put(ctx, hash, wire)
+}
+
+// SealChunk applies this decorator's compression layer to plaintext, then
+// delegates to the inner store's ChunkSealer so a decorated chain produces the
+// fully-transformed wire bytes for a packed block. Implements
+// remote.ChunkSealer (#1414). Symmetric with ReadChunk: ReadChunk decompresses
+// after the inner layer decrypts, inverting this exactly.
+func (d *Decorator) SealChunk(ctx context.Context, hash block.ContentHash, plaintext []byte) ([]byte, error) {
+	wire, err := d.sealLayer(plaintext)
+	if err != nil {
+		return nil, err
+	}
+	sealer, ok := d.inner.(remote.ChunkSealer)
+	if !ok {
+		return nil, remote.ErrChunkReadUnsupported
+	}
+	return sealer.SealChunk(ctx, hash, wire)
+}
+
+// sealLayer is the single source of this decorator's compression transform,
+// shared by Put and SealChunk. It compresses data and returns the framed
+// compressed body when that is strictly smaller than the input, otherwise the
+// raw plaintext (incompressible blocks skip the frame).
+func (d *Decorator) sealLayer(data []byte) ([]byte, error) {
 	var compressed bytes.Buffer
 	enc, err := d.codec.EncodeStream(&compressed)
 	if err != nil {
-		return fmt.Errorf("compression: EncodeStream: %w", err)
+		return nil, fmt.Errorf("compression: EncodeStream: %w", err)
 	}
 	if _, err := enc.Write(data); err != nil {
 		_ = enc.Close()
-		return fmt.Errorf("compression: encoder write: %w", err)
+		return nil, fmt.Errorf("compression: encoder write: %w", err)
 	}
 	if err := enc.Close(); err != nil {
-		return fmt.Errorf("compression: encoder close: %w", err)
+		return nil, fmt.Errorf("compression: encoder close: %w", err)
 	}
 
 	wire := data
@@ -68,7 +100,7 @@ func (d *Decorator) Put(ctx context.Context, hash block.ContentHash, data []byte
 	if frameOverhead(origSize)+len(body) < len(data) {
 		wire = encodeFrame(d.algo, origSize, body)
 	}
-	return d.inner.Put(ctx, hash, wire)
+	return wire, nil
 }
 
 // --- read path ----------------------------------------------------------
@@ -273,10 +305,75 @@ func (d *Decorator) Durable() bool {
 	return block.IsDurable(d.inner)
 }
 
+// --- remote.RemoteBlockStore passthrough (#1414) ---
+//
+// Packed block objects carry per-chunk wire bodies that were already sealed via
+// SealChunk; the assembled block must NOT be re-transformed at the block level.
+// So every block-keyed operation passes through verbatim to the inner store.
+// This lets a decorated remote satisfy remote.RemoteBlockStore (the carve path
+// asserts it) while the per-chunk transform stays in SealChunk/ReadChunk.
+
+// blockInner returns the inner store as a remote.RemoteBlockStore, or an error
+// when the wrapped store does not support block-keyed objects.
+func (d *Decorator) blockInner() (remote.RemoteBlockStore, error) {
+	rbs, ok := d.inner.(remote.RemoteBlockStore)
+	if !ok {
+		return nil, remote.ErrChunkReadUnsupported
+	}
+	return rbs, nil
+}
+
+// PutBlock stores the assembled block verbatim (already-sealed bodies).
+func (d *Decorator) PutBlock(ctx context.Context, blockID string, r io.Reader) error {
+	rbs, err := d.blockInner()
+	if err != nil {
+		return err
+	}
+	return rbs.PutBlock(ctx, blockID, r)
+}
+
+// GetBlock returns the raw block object verbatim.
+func (d *Decorator) GetBlock(ctx context.Context, blockID string) ([]byte, error) {
+	rbs, err := d.blockInner()
+	if err != nil {
+		return nil, err
+	}
+	return rbs.GetBlock(ctx, blockID)
+}
+
+// GetBlockRange returns raw block bytes verbatim; per-chunk decode is ReadChunk.
+func (d *Decorator) GetBlockRange(ctx context.Context, blockID string, offset, length int64) ([]byte, error) {
+	rbs, err := d.blockInner()
+	if err != nil {
+		return nil, err
+	}
+	return rbs.GetBlockRange(ctx, blockID, offset, length)
+}
+
+// DeleteBlock removes the block object.
+func (d *Decorator) DeleteBlock(ctx context.Context, blockID string) error {
+	rbs, err := d.blockInner()
+	if err != nil {
+		return err
+	}
+	return rbs.DeleteBlock(ctx, blockID)
+}
+
+// WalkBlocks enumerates block objects.
+func (d *Decorator) WalkBlocks(ctx context.Context, fn func(blockID string, meta block.Meta) error) error {
+	rbs, err := d.blockInner()
+	if err != nil {
+		return err
+	}
+	return rbs.WalkBlocks(ctx, fn)
+}
+
 // Compile-time interface assertions.
 var (
 	_ block.Store              = (*Decorator)(nil)
 	_ remote.RemoteStore       = (*Decorator)(nil)
+	_ remote.RemoteBlockStore  = (*Decorator)(nil)
 	_ remote.ChunkReader       = (*Decorator)(nil)
+	_ remote.ChunkSealer       = (*Decorator)(nil)
 	_ block.DurabilityReporter = (*Decorator)(nil)
 )

--- a/pkg/block/compression/seal_chunk_test.go
+++ b/pkg/block/compression/seal_chunk_test.go
@@ -1,0 +1,51 @@
+package compression
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+)
+
+// TestSealChunk_RoundTripThroughBlock proves the compression decorator's
+// SealChunk is byte-symmetric with ReadChunk: sealing a chunk, framing it as a
+// one-chunk block body, PutBlock, then ReadChunk over its [offset,len) returns
+// the original plaintext. A highly-compressible payload also asserts the wire
+// bytes are smaller than the plaintext, confirming the layer actually ran.
+func TestSealChunk_RoundTripThroughBlock(t *testing.T) {
+	ctx := context.Background()
+	base := remotememory.New()
+	d, err := NewRemote(base, CompressionPolicy{Algo: AlgoZstd})
+	if err != nil {
+		t.Fatalf("NewRemote: %v", err)
+	}
+
+	var sealer remote.ChunkSealer = d
+
+	var hash block.ContentHash
+	hash[0] = 0x22
+	plaintext := []byte(strings.Repeat("compressible-payload-", 4096))
+
+	wire, err := sealer.SealChunk(ctx, hash, plaintext)
+	if err != nil {
+		t.Fatalf("SealChunk: %v", err)
+	}
+	if len(wire) >= len(plaintext) {
+		t.Fatalf("compressible payload should shrink: wire=%d plaintext=%d", len(wire), len(plaintext))
+	}
+
+	if err := d.PutBlock(ctx, "blk-c", bytes.NewReader(wire)); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+	got, err := d.ReadChunk(ctx, "blk-c", 0, int64(len(wire)), hash)
+	if err != nil {
+		t.Fatalf("ReadChunk: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("round-trip mismatch (len got=%d want=%d)", len(got), len(plaintext))
+	}
+}

--- a/pkg/block/encryption/decorator.go
+++ b/pkg/block/encryption/decorator.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"io"
 
 	"golang.org/x/crypto/chacha20poly1305"
 	"lukechampine.com/blake3"
@@ -46,30 +47,62 @@ func NewRemote(inner remote.RemoteStore, policy EncryptionPolicy, provider keypr
 // Put encrypts data and stores the framed result under hash. The block
 // key is fresh per call; the plaintext hash is bound into the AEAD's
 // additional data so a swapped block fails authentication on Get.
+// Put encrypts data into a self-describing frame and stores it on the inner
+// store. Put and SealChunk share the same single-layer transform (sealLayer)
+// so the standalone-object and packed-block write paths never drift.
 func (d *EncryptedRemote) Put(ctx context.Context, hash block.ContentHash, data []byte) error {
-	blockKey := make([]byte, 32)
-	if _, err := rand.Read(blockKey); err != nil {
-		return fmt.Errorf("encryption: read block key: %w", err)
-	}
-	aead, err := newAEAD(d.aead, blockKey)
+	wire, err := d.sealLayer(ctx, hash, data)
 	if err != nil {
 		return err
 	}
+	return d.inner.Put(ctx, hash, wire)
+}
+
+// SealChunk encrypts one chunk's plaintext into a frame and delegates inward so
+// a decorated chain produces the fully-transformed wire bytes for a packed
+// block. Implements remote.ChunkSealer (#1414). hash is bound as AEAD AAD,
+// matching the standalone Put scheme. Symmetric with ReadChunk, which decrypts
+// the ranged frame with the same AAD.
+func (d *EncryptedRemote) SealChunk(ctx context.Context, hash block.ContentHash, plaintext []byte) ([]byte, error) {
+	wire, err := d.sealLayer(ctx, hash, plaintext)
+	if err != nil {
+		return nil, err
+	}
+	sealer, ok := d.inner.(remote.ChunkSealer)
+	if !ok {
+		return nil, remote.ErrChunkReadUnsupported
+	}
+	return sealer.SealChunk(ctx, hash, wire)
+}
+
+// sealLayer is the single source of this decorator's encryption transform,
+// shared by Put and SealChunk. It generates a fresh per-chunk block key + nonce,
+// AEAD-seals data with hash as AAD, wraps the block key, and returns the encoded
+// frame.
+func (d *EncryptedRemote) sealLayer(ctx context.Context, hash block.ContentHash, data []byte) ([]byte, error) {
+	blockKey := make([]byte, 32)
+	if _, err := rand.Read(blockKey); err != nil {
+		return nil, fmt.Errorf("encryption: read block key: %w", err)
+	}
+	aead, err := newAEAD(d.aead, blockKey)
+	if err != nil {
+		return nil, err
+	}
 	nonce := make([]byte, aead.NonceSize())
 	if _, err := rand.Read(nonce); err != nil {
-		return fmt.Errorf("encryption: read nonce: %w", err)
+		return nil, fmt.Errorf("encryption: read nonce: %w", err)
 	}
 	ciphertext := aead.Seal(nil, nonce, data, hash[:])
 
 	wrappedKey, masterKeyID, err := d.provider.Wrap(ctx, blockKey)
 	if err != nil {
-		return fmt.Errorf("encryption: wrap block key: %w", err)
+		return nil, fmt.Errorf("encryption: wrap block key: %w", err)
 	}
 	wire, err := encodeFrame(d.aead, masterKeyID, wrappedKey, nonce, ciphertext)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return d.inner.Put(ctx, hash, wire)
+	return wire, nil
 }
 
 // Get returns the plaintext for the block identified by hash.
@@ -236,6 +269,69 @@ func (d *EncryptedRemote) Durable() bool {
 	return block.IsDurable(d.inner)
 }
 
+// --- remote.RemoteBlockStore passthrough (#1414) ---
+//
+// Packed block objects carry per-chunk wire frames that were already sealed via
+// SealChunk; the assembled block must NOT be re-encrypted at the block level.
+// So every block-keyed operation passes through verbatim to the inner store.
+// This lets a decorated remote satisfy remote.RemoteBlockStore (the carve path
+// asserts it) while the per-chunk transform stays in SealChunk/ReadChunk.
+
+// blockInner returns the inner store as a remote.RemoteBlockStore, or an error
+// when the wrapped store does not support block-keyed objects.
+func (d *EncryptedRemote) blockInner() (remote.RemoteBlockStore, error) {
+	rbs, ok := d.inner.(remote.RemoteBlockStore)
+	if !ok {
+		return nil, remote.ErrChunkReadUnsupported
+	}
+	return rbs, nil
+}
+
+// PutBlock stores the assembled block verbatim (already-sealed frames).
+func (d *EncryptedRemote) PutBlock(ctx context.Context, blockID string, r io.Reader) error {
+	rbs, err := d.blockInner()
+	if err != nil {
+		return err
+	}
+	return rbs.PutBlock(ctx, blockID, r)
+}
+
+// GetBlock returns the raw block object verbatim.
+func (d *EncryptedRemote) GetBlock(ctx context.Context, blockID string) ([]byte, error) {
+	rbs, err := d.blockInner()
+	if err != nil {
+		return nil, err
+	}
+	return rbs.GetBlock(ctx, blockID)
+}
+
+// GetBlockRange returns raw block bytes verbatim; per-chunk decrypt is ReadChunk.
+func (d *EncryptedRemote) GetBlockRange(ctx context.Context, blockID string, offset, length int64) ([]byte, error) {
+	rbs, err := d.blockInner()
+	if err != nil {
+		return nil, err
+	}
+	return rbs.GetBlockRange(ctx, blockID, offset, length)
+}
+
+// DeleteBlock removes the block object.
+func (d *EncryptedRemote) DeleteBlock(ctx context.Context, blockID string) error {
+	rbs, err := d.blockInner()
+	if err != nil {
+		return err
+	}
+	return rbs.DeleteBlock(ctx, blockID)
+}
+
+// WalkBlocks enumerates block objects.
+func (d *EncryptedRemote) WalkBlocks(ctx context.Context, fn func(blockID string, meta block.Meta) error) error {
+	rbs, err := d.blockInner()
+	if err != nil {
+		return err
+	}
+	return rbs.WalkBlocks(ctx, fn)
+}
+
 // decrypt parses the frame, unwraps the block key, and authenticated-
 // decrypts the ciphertext against hash as AAD. An unframed block on an
 // encryption-enabled share is rejected — it indicates external mutation
@@ -305,6 +401,8 @@ func newAEAD(algo AEAD, key []byte) (cipher.AEAD, error) {
 var (
 	_ block.Store              = (*EncryptedRemote)(nil)
 	_ remote.RemoteStore       = (*EncryptedRemote)(nil)
+	_ remote.RemoteBlockStore  = (*EncryptedRemote)(nil)
 	_ remote.ChunkReader       = (*EncryptedRemote)(nil)
+	_ remote.ChunkSealer       = (*EncryptedRemote)(nil)
 	_ block.DurabilityReporter = (*EncryptedRemote)(nil)
 )

--- a/pkg/block/encryption/seal_chunk_test.go
+++ b/pkg/block/encryption/seal_chunk_test.go
@@ -1,0 +1,59 @@
+package encryption
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+)
+
+// TestSealChunk_SealedAndReadChunkInverse proves the encryption decorator's
+// SealChunk produces ciphertext (never plaintext at rest) and is byte-symmetric
+// with ReadChunk: sealing a chunk, framing it as a one-chunk block body,
+// PutBlock, then ReadChunk over its [offset,len) returns the original plaintext
+// and the right BLAKE3.
+func TestSealChunk_SealedAndReadChunkInverse(t *testing.T) {
+	ctx := context.Background()
+	inner := remotememory.New()
+	d, err := NewRemote(inner, EncryptionPolicy{AEAD: AEADAES256GCM}, newProvider(t))
+	if err != nil {
+		t.Fatalf("NewRemote: %v", err)
+	}
+
+	var sealer remote.ChunkSealer = d
+
+	plaintext := bytes.Repeat([]byte{0x5A}, 8192)
+	hash := block.ContentHash(blake3.Sum256(plaintext))
+
+	wire, err := sealer.SealChunk(ctx, hash, plaintext)
+	if err != nil {
+		t.Fatalf("SealChunk: %v", err)
+	}
+	// The sealed wire must not contain the plaintext run verbatim — it is a
+	// framed AEAD ciphertext, larger than the plaintext (header + tag).
+	if len(wire) <= len(plaintext) {
+		t.Fatalf("sealed chunk should be larger than plaintext (frame+tag): wire=%d plaintext=%d", len(wire), len(plaintext))
+	}
+	if bytes.Contains(wire, plaintext) {
+		t.Fatal("sealed wire must not contain plaintext verbatim")
+	}
+
+	if err := d.PutBlock(ctx, "enc-seal-1", bytes.NewReader(wire)); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+	got, err := d.ReadChunk(ctx, "enc-seal-1", 0, int64(len(wire)), hash)
+	if err != nil {
+		t.Fatalf("ReadChunk: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("round-trip mismatch (got %d bytes)", len(got))
+	}
+	if block.ContentHash(blake3.Sum256(got)) != hash {
+		t.Fatal("round-trip BLAKE3 mismatch")
+	}
+}

--- a/pkg/block/engine/carver.go
+++ b/pkg/block/engine/carver.go
@@ -1,0 +1,372 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/blockcodec"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// addPendingCarveHash registers a freshly-completed log-blob chunk for the next
+// carve pass. O(1); charges unsyncedBytes once per distinct hash (re-adding
+// refreshes the recorded size only). Signals the carve dispatcher so packing
+// overlaps the rollup of later chunks.
+func (m *Syncer) addPendingCarveHash(h block.ContentHash, size int64) {
+	m.pendingMu.Lock()
+	prev, already := m.pendingCarveHashes[h]
+	m.pendingCarveHashes[h] = size
+	m.unsyncedBytes.Add(size - prev)
+	if !already {
+		m.carveQ = append(m.carveQ, h)
+	}
+	m.pendingMu.Unlock()
+
+	if !already {
+		m.publishCarveQueueDepth()
+		m.signalCarveWake()
+	}
+}
+
+// publishCarveQueueDepth folds the carve backlog into the upload-queue-depth
+// gauge alongside the legacy pending set so the metric reflects all
+// not-yet-durable chunks.
+func (m *Syncer) publishCarveQueueDepth() {
+	mx := m.dataplaneMetrics()
+	if mx == nil {
+		return
+	}
+	m.pendingMu.Lock()
+	n := len(m.pendingHashes) + len(m.pendingCarveHashes)
+	m.pendingMu.Unlock()
+	mx.SetUploadQueueDepth(n)
+}
+
+// signalCarveWake performs a non-blocking, coalescing send on carveWake.
+func (m *Syncer) signalCarveWake() {
+	select {
+	case m.carveWake <- struct{}{}:
+	default:
+	}
+}
+
+// carveBlockSize returns the configured target block size, falling back to the
+// default when unset.
+func (m *Syncer) carveBlockSize() int64 {
+	if m.config.BlockCarveBytes > 0 {
+		return m.config.BlockCarveBytes
+	}
+	return DefaultBlockCarveBytes
+}
+
+// carveDispatcher is the background carve loop. It waits for a wake (a chunk was
+// queued) or an idle timeout, then packs blocks: while a full block's worth of
+// chunks is available it seals them into target-sized blocks; after UploadDelay
+// of quiescence it flushes the partial remainder so a trickle of writes still
+// reaches the remote. Runs only when a remote exists and not in ManualSync mode
+// (where Flush/SyncNow are the sole carve drivers).
+func (m *Syncer) carveDispatcher(ctx context.Context) {
+	logger.Info("Carve dispatcher started")
+	idle := m.config.UploadDelay
+	if idle <= 0 {
+		idle = 10 * time.Second
+	}
+	timer := time.NewTimer(idle)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-m.stopCh:
+			return
+		case <-ctx.Done():
+			return
+		case <-m.carveWake:
+			// A chunk arrived: drain full blocks now, leave any partial for the
+			// idle flush. Reset the idle window.
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			if m.IsRemoteHealthy() {
+				if err := m.carveFlush(ctx, false); err != nil && ctx.Err() == nil {
+					logger.Warn("Carve dispatcher: size-triggered flush failed; will retry", "error", err)
+				}
+			}
+			timer.Reset(idle)
+		case <-timer.C:
+			// Quiescent: flush the partial remainder so trickle writes sync.
+			if m.IsRemoteHealthy() {
+				if err := m.carveFlush(ctx, true); err != nil && ctx.Err() == nil {
+					logger.Warn("Carve dispatcher: idle flush failed; will retry", "error", err)
+				}
+			}
+			timer.Reset(idle)
+		}
+	}
+}
+
+// carveFlush packs pending carve chunks into one or more blocks. When drainAll
+// is false it emits only full (>= target) blocks and leaves a sub-target
+// remainder pending for the idle flush; when true it also emits the final
+// partial block. Serialized by carveMu so the background loop and an explicit
+// Flush/SyncNow never build a block from the same chunk twice. Each block is
+// idempotent on its fresh random blockID: a crash after PutBlock but before the
+// commit leaves an orphan remote block (reclaimed by block GC) and re-carves the
+// chunks into a new block, never losing or double-committing them.
+func (m *Syncer) carveFlush(ctx context.Context, drainAll bool) error {
+	m.carveMu.Lock()
+	defer m.carveMu.Unlock()
+
+	target := m.carveBlockSize()
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		batch := m.claimCarveBatch(target, drainAll)
+		if len(batch) == 0 {
+			return nil
+		}
+		if err := m.carveAndCommitBlock(ctx, batch); err != nil {
+			// Return the batch to the queue for a later retry and surface the
+			// error so an explicit Flush reports non-durability.
+			m.requeueCarveBatch(batch)
+			return err
+		}
+	}
+}
+
+// claimCarveBatch pops chunks from the carve FIFO (validating against the
+// authoritative map) until their accumulated size reaches target, or the queue
+// drains. When drainAll is false and the accumulated bytes are below target it
+// returns nil — leaving the sub-target remainder pending — so the background
+// loop never emits an undersized block ahead of the idle flush. Claimed hashes
+// are removed from carveQ but remain in pendingCarveHashes until their block
+// commits (or are requeued on failure). Caller holds carveMu (so no concurrent
+// claim races the same chunks).
+func (m *Syncer) claimCarveBatch(target int64, drainAll bool) []block.ContentHash {
+	m.pendingMu.Lock()
+	defer m.pendingMu.Unlock()
+
+	var (
+		batch []block.ContentHash
+		total int64
+	)
+	for len(m.carveQ) > 0 {
+		h := m.carveQ[0]
+		m.carveQ = m.carveQ[1:]
+		size, ok := m.pendingCarveHashes[h]
+		if !ok {
+			continue // already committed out from under the queue
+		}
+		batch = append(batch, h)
+		total += size
+		if total >= target {
+			break
+		}
+	}
+	if len(m.carveQ) == 0 {
+		m.carveQ = nil // release the backing array once fully drained
+	}
+	if !drainAll && total < target {
+		// Not enough for a full block yet: put the claimed hashes back at the
+		// front (preserving order) and wait for more or the idle flush.
+		if len(batch) > 0 {
+			m.carveQ = append(batch, m.carveQ...)
+		}
+		return nil
+	}
+	return batch
+}
+
+// requeueCarveBatch returns a failed batch's hashes to the carve queue (only
+// those still pending) so a later pass retries them.
+func (m *Syncer) requeueCarveBatch(batch []block.ContentHash) {
+	m.pendingMu.Lock()
+	for _, h := range batch {
+		if _, ok := m.pendingCarveHashes[h]; ok {
+			m.carveQ = append(m.carveQ, h)
+		}
+	}
+	m.pendingMu.Unlock()
+}
+
+// carveAndCommitBlock reads each chunk's raw bytes from the log-blob substrate,
+// seals it through the per-chunk transform, frames it into one block via
+// blockcodec, uploads the assembled block with PutBlock, and atomically commits
+// the block record + per-chunk locators + synced markers. On success the
+// committed hashes leave pendingCarveHashes and the bytes leave unsyncedBytes.
+func (m *Syncer) carveAndCommitBlock(ctx context.Context, batch []block.ContentHash) error {
+	m.mu.RLock()
+	rbs := m.remoteBlockStore
+	sealer := m.chunkSealer
+	committer := m.blockCommitter
+	reader := m.localBlobReader
+	m.mu.RUnlock()
+	if rbs == nil || committer == nil || reader == nil {
+		return errors.New("carve: substrate not wired")
+	}
+
+	blockID, err := newBlockID()
+	if err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+	builder, err := blockcodec.NewBuilder(&buf, blockID, nil)
+	if err != nil {
+		return fmt.Errorf("carve: new builder: %w", err)
+	}
+
+	commits := make([]block.BlockChunkCommit, 0, len(batch))
+	for _, h := range batch {
+		loc, ok, err := committer.GetLocalLocation(ctx, h)
+		if err != nil {
+			return fmt.Errorf("carve: get local location %s: %w", h, err)
+		}
+		if !ok {
+			// Not log-blob-resident — a stray legacy CAS hash that was routed
+			// here. Hand it to the legacy mirror path and drop it from carve.
+			m.rerouteCarveMiss(h)
+			continue
+		}
+
+		dst := make([]byte, loc.RawLength)
+		if _, err := reader.ReadLocalAt(ctx, loc, dst); err != nil {
+			if errors.Is(err, block.ErrChunkNotFound) {
+				// The chunk's local bytes vanished before carve. Drop it from
+				// the carve set; a write-again or T4 reconcile re-discovers it.
+				logger.Error("carve: chunk bytes lost before carve — dropped", "hash", h.String())
+				m.dropCarveHash(h)
+				continue
+			}
+			return fmt.Errorf("carve: read local %s: %w", h, err)
+		}
+
+		wire := dst
+		if sealer != nil {
+			wire, err = sealer.SealChunk(ctx, h, dst)
+			if err != nil {
+				return fmt.Errorf("carve: seal chunk %s: %w", h, err)
+			}
+		}
+
+		chunkLoc, err := builder.Add(h, wire)
+		if err != nil {
+			return fmt.Errorf("carve: frame chunk %s: %w", h, err)
+		}
+		commits = append(commits, block.BlockChunkCommit{
+			Hash:   h,
+			Remote: chunkLoc,
+			Local:  loc,
+		})
+	}
+	if len(commits) == 0 {
+		return nil // every chunk in the batch was rerouted/dropped
+	}
+	if _, err := builder.Finish(); err != nil {
+		return fmt.Errorf("carve: finish block: %w", err)
+	}
+
+	blockBytes := buf.Bytes()
+	blockHash := block.ContentHash(blake3.Sum256(blockBytes))
+
+	// Upload the assembled block, then atomically commit. The order matters for
+	// crash-safety: PutBlock first means a crash before the commit leaves an
+	// orphan block (GC reclaims it) but never an unbacked record.
+	if err := rbs.PutBlock(ctx, blockID, bytes.NewReader(blockBytes)); err != nil {
+		m.uploadErrWindow.Add(1)
+		return fmt.Errorf("carve: put block %s: %w", blockID, err)
+	}
+
+	rec := block.BlockRecord{
+		BlockID:        blockID,
+		BlockHash:      blockHash,
+		Length:         int64(len(blockBytes)),
+		LiveChunkCount: uint32(len(commits)),
+		SyncState:      block.BlockStateRemote,
+	}
+	if err := metadata.DefaultCommitBlock(ctx, committer, rec, commits); err != nil {
+		return fmt.Errorf("carve: commit block %s: %w", blockID, err)
+	}
+
+	// Retire the committed chunks from the carve set and the backpressure
+	// counter; count them and the uploaded bytes for stats/adaptive feedback.
+	m.pendingMu.Lock()
+	for _, c := range commits {
+		if size, ok := m.pendingCarveHashes[c.Hash]; ok {
+			delete(m.pendingCarveHashes, c.Hash)
+			m.unsyncedBytes.Add(-size)
+		}
+	}
+	m.pendingMu.Unlock()
+	m.completedSyncs.Add(int64(len(commits)))
+	m.uploadedBytesWindow.Add(int64(len(blockBytes)))
+	m.publishCarveQueueDepth()
+
+	logger.Debug("Carve: committed block",
+		"blockID", blockID, "chunks", len(commits), "bytes", len(blockBytes))
+	return nil
+}
+
+// rerouteCarveMiss moves a hash that turned out not to be log-blob-resident from
+// the carve set to the legacy standalone-mirror path.
+func (m *Syncer) rerouteCarveMiss(h block.ContentHash) {
+	m.pendingMu.Lock()
+	size, ok := m.pendingCarveHashes[h]
+	if ok {
+		delete(m.pendingCarveHashes, h)
+		// Hand to the legacy pending set; the dispatcher mirrors it as a
+		// standalone CAS object. unsyncedBytes is unchanged (it moves between
+		// sets, still counted once).
+		if _, dup := m.pendingHashes[h]; !dup {
+			m.pendingHashes[h] = size
+			m.readyQ = append(m.readyQ, h)
+		}
+	}
+	m.pendingMu.Unlock()
+	if ok {
+		logger.Warn("carve: non-log-blob hash rerouted to legacy mirror", "hash", h.String())
+		m.signalWake()
+	}
+}
+
+// dropCarveHash removes a hash whose local bytes vanished from the carve set and
+// the backpressure counter.
+func (m *Syncer) dropCarveHash(h block.ContentHash) {
+	m.pendingMu.Lock()
+	if size, ok := m.pendingCarveHashes[h]; ok {
+		delete(m.pendingCarveHashes, h)
+		m.unsyncedBytes.Add(-size)
+	}
+	m.pendingMu.Unlock()
+}
+
+// CarvePendingCount returns the number of chunks awaiting carve into a block.
+func (m *Syncer) CarvePendingCount() int {
+	m.pendingMu.Lock()
+	defer m.pendingMu.Unlock()
+	return len(m.pendingCarveHashes)
+}
+
+// newBlockID returns a fresh, unguessable block object key. crypto/rand keeps it
+// collision-free under concurrent carvers (unlike a timestamp) and unrelated to
+// the block's content hash, so a re-carve after a crash always targets a new
+// object.
+func newBlockID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("carve: generate block id: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
+}

--- a/pkg/block/engine/carver.go
+++ b/pkg/block/engine/carver.go
@@ -201,6 +201,15 @@ func (m *Syncer) requeueCarveBatch(batch []block.ContentHash) {
 	m.pendingMu.Unlock()
 }
 
+// markSyncedRetries is the number of in-place retries when DefaultCommitBlock
+// returns ErrCommitPartial (transaction committed but MarkSynced loop
+// incomplete). Retrying with the same BlockID completes the MarkSynced loop
+// via DefaultCommitBlock's idempotency — no new block is minted.
+const markSyncedRetries = 3
+
+// markSyncedRetryDelay is the backoff between ErrCommitPartial retries.
+const markSyncedRetryDelay = 100 * time.Millisecond
+
 // carveAndCommitBlock reads each chunk's raw bytes from the log-blob substrate,
 // seals it through the per-chunk transform, frames it into one block via
 // blockcodec, uploads the assembled block with PutBlock, and atomically commits
@@ -215,6 +224,32 @@ func (m *Syncer) carveAndCommitBlock(ctx context.Context, batch []block.ContentH
 	m.mu.RUnlock()
 	if rbs == nil || committer == nil || reader == nil {
 		return errors.New("carve: substrate not wired")
+	}
+
+	// Defense-in-depth (secondary): drop any hash that is already fully synced
+	// before packing. An already-synced hash can appear here if a previous
+	// ErrCommitPartial retry exhausted and the batch was requeued with some
+	// chunks already MarkSynced. Packing such a hash again would inflate the new
+	// block's LiveChunkCount (since MarkSynced is idempotent and the locator
+	// would not update). Drop it from the carve set instead.
+	filtered := batch[:0]
+	for _, h := range batch {
+		synced, err := committer.IsSynced(ctx, h)
+		if err != nil {
+			// Cannot determine: include and let MarkSynced idempotency handle it.
+			filtered = append(filtered, h)
+			continue
+		}
+		if synced {
+			// Already synced: retire from the carve set without re-packing.
+			m.dropCarveHash(h)
+			continue
+		}
+		filtered = append(filtered, h)
+	}
+	batch = filtered
+	if len(batch) == 0 {
+		return nil
 	}
 
 	blockID, err := newBlockID()
@@ -296,8 +331,34 @@ func (m *Syncer) carveAndCommitBlock(ctx context.Context, batch []block.ContentH
 		LiveChunkCount: uint32(len(commits)),
 		SyncState:      block.BlockStateRemote,
 	}
-	if err := metadata.DefaultCommitBlock(ctx, committer, rec, commits); err != nil {
-		return fmt.Errorf("carve: commit block %s: %w", blockID, err)
+	commitErr := metadata.DefaultCommitBlock(ctx, committer, rec, commits)
+	if commitErr != nil {
+		var partial *metadata.ErrCommitPartial
+		if errors.As(commitErr, &partial) {
+			// The block record transaction committed but the MarkSynced loop did
+			// not complete. Retry with the SAME blockID: DefaultCommitBlock's
+			// idempotent tx guard skips the transaction and re-runs MarkSynced to
+			// completion — no new block object is needed or minted.
+			logger.Debug("carve: partial MarkSynced, retrying same block",
+				"blockID", partial.BlockID, "cause", partial.Cause)
+			for i := 0; i < markSyncedRetries; i++ {
+				select {
+				case <-ctx.Done():
+					return fmt.Errorf("carve: commit block %s (mark-synced retry cancelled): %w",
+						blockID, ctx.Err())
+				case <-time.After(markSyncedRetryDelay):
+				}
+				if retryErr := metadata.DefaultCommitBlock(ctx, committer, rec, commits); retryErr == nil {
+					commitErr = nil
+					break
+				} else {
+					commitErr = retryErr
+				}
+			}
+		}
+	}
+	if commitErr != nil {
+		return fmt.Errorf("carve: commit block %s: %w", blockID, commitErr)
 	}
 
 	// Retire the committed chunks from the carve set and the backpressure

--- a/pkg/block/engine/carver.go
+++ b/pkg/block/engine/carver.go
@@ -158,33 +158,43 @@ func (m *Syncer) claimCarveBatch(target int64, drainAll bool) []block.ContentHas
 	m.pendingMu.Lock()
 	defer m.pendingMu.Unlock()
 
+	// Peek: walk the FIFO prefix accumulating the size of still-pending hashes
+	// WITHOUT detaching them. An under-target trickle then bails out leaving
+	// carveQ untouched, avoiding the O(n) pop-then-prepend copy that made
+	// frequent carveWake churn quadratic.
 	var (
-		batch []block.ContentHash
-		total int64
+		batch    []block.ContentHash
+		total    int64
+		consumed int // number of carveQ entries the claimed prefix spans
 	)
-	for len(m.carveQ) > 0 {
-		h := m.carveQ[0]
-		m.carveQ = m.carveQ[1:]
+	for i, h := range m.carveQ {
 		size, ok := m.pendingCarveHashes[h]
 		if !ok {
-			continue // already committed out from under the queue
+			continue // stale: already committed out from under the queue
 		}
 		batch = append(batch, h)
 		total += size
 		if total >= target {
+			consumed = i + 1
 			break
 		}
 	}
-	if len(m.carveQ) == 0 {
-		m.carveQ = nil // release the backing array once fully drained
-	}
-	if !drainAll && total < target {
-		// Not enough for a full block yet: put the claimed hashes back at the
-		// front (preserving order) and wait for more or the idle flush.
-		if len(batch) > 0 {
-			m.carveQ = append(batch, m.carveQ...)
-		}
+
+	if total < target && !drainAll {
+		// Not enough for a full block yet: leave carveQ untouched and wait for
+		// more chunks or the idle flush. Nothing was detached, so FIFO order and
+		// the pending set are exactly as the caller left them.
 		return nil
+	}
+
+	// Committing to carve: detach the claimed prefix now. When target was hit
+	// mid-queue, keep the untouched suffix; otherwise (drainAll drained the tail,
+	// or target landed on the last entry) the queue is empty — release its
+	// backing array.
+	if total >= target && consumed < len(m.carveQ) {
+		m.carveQ = m.carveQ[consumed:]
+	} else {
+		m.carveQ = nil
 	}
 	return batch
 }

--- a/pkg/block/engine/carver_claimbatch_test.go
+++ b/pkg/block/engine/carver_claimbatch_test.go
@@ -1,0 +1,80 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+// carveHash returns a distinct, non-zero ContentHash seeded from n.
+func carveHash(n byte) block.ContentHash {
+	var h block.ContentHash
+	for i := range h {
+		h[i] = n ^ byte(i)
+	}
+	return h
+}
+
+// TestClaimCarveBatch_UnderTargetLeavesQueueUntouched pins the de-quadratic
+// contract: when the queued bytes are below target and we are not draining,
+// claimCarveBatch must return nil WITHOUT detaching or re-copying carveQ (the
+// old pop-then-prepend went O(n) on every carveWake).
+func TestClaimCarveBatch_UnderTargetLeavesQueueUntouched(t *testing.T) {
+	m := &Syncer{pendingCarveHashes: map[block.ContentHash]int64{}}
+	h1, h2 := carveHash(1), carveHash(2)
+	m.carveQ = []block.ContentHash{h1, h2}
+	m.pendingCarveHashes[h1] = 10
+	m.pendingCarveHashes[h2] = 10
+	before := &m.carveQ[0] // backing-array identity
+
+	if got := m.claimCarveBatch(25, false); got != nil {
+		t.Fatalf("under-target claim = %v, want nil", got)
+	}
+	if len(m.carveQ) != 2 || m.carveQ[0] != h1 || m.carveQ[1] != h2 {
+		t.Fatalf("carveQ mutated on under-target peek: %v", m.carveQ)
+	}
+	if &m.carveQ[0] != before {
+		t.Fatal("carveQ backing array was reallocated on an under-target peek (quadratic churn)")
+	}
+}
+
+// TestClaimCarveBatch_ReachesTargetClaimsPrefixKeepsSuffix verifies that once
+// the accumulated size reaches target the FIFO prefix is claimed and detached,
+// leaving the untouched suffix for the next pass.
+func TestClaimCarveBatch_ReachesTargetClaimsPrefixKeepsSuffix(t *testing.T) {
+	m := &Syncer{pendingCarveHashes: map[block.ContentHash]int64{}}
+	h1, h2, h3 := carveHash(1), carveHash(2), carveHash(3)
+	m.carveQ = []block.ContentHash{h1, h2, h3}
+	for _, h := range []block.ContentHash{h1, h2, h3} {
+		m.pendingCarveHashes[h] = 10
+	}
+
+	// target 15: h1(10) then h2(20>=15) -> claim [h1,h2], leave [h3].
+	got := m.claimCarveBatch(15, false)
+	if len(got) != 2 || got[0] != h1 || got[1] != h2 {
+		t.Fatalf("claimed = %v, want [h1 h2] (FIFO prefix)", got)
+	}
+	if len(m.carveQ) != 1 || m.carveQ[0] != h3 {
+		t.Fatalf("suffix = %v, want [h3]", m.carveQ)
+	}
+}
+
+// TestClaimCarveBatch_DrainAllClaimsRemainderSkippingStale verifies drainAll
+// claims the whole remaining queue even when under target, releases the backing
+// array, and drops stale (already-committed) hashes from the batch.
+func TestClaimCarveBatch_DrainAllClaimsRemainderSkippingStale(t *testing.T) {
+	m := &Syncer{pendingCarveHashes: map[block.ContentHash]int64{}}
+	h1, h2, h3 := carveHash(1), carveHash(2), carveHash(3)
+	m.carveQ = []block.ContentHash{h1, h2, h3}
+	// h2 is stale: present in the FIFO but not in the pending map.
+	m.pendingCarveHashes[h1] = 10
+	m.pendingCarveHashes[h3] = 10
+
+	got := m.claimCarveBatch(1000, true) // target far above total, but drainAll
+	if len(got) != 2 || got[0] != h1 || got[1] != h3 {
+		t.Fatalf("claimed = %v, want [h1 h3] (stale h2 dropped, FIFO)", got)
+	}
+	if m.carveQ != nil {
+		t.Fatalf("carveQ = %v, want nil (backing array released after full drain)", m.carveQ)
+	}
+}

--- a/pkg/block/engine/carver_test.go
+++ b/pkg/block/engine/carver_test.go
@@ -3,10 +3,13 @@ package engine
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"lukechampine.com/blake3"
 
@@ -217,10 +220,10 @@ func newEncryptionProvider(t *testing.T) keyprovider.KeyProvider {
 }
 
 // TestCarve_ThroughCompressEncryptRemote is DoD test (2) (full stack): carving
-// through a compression(encryption(base)) remote seals each chunk (the block's
-// wire body is neither the plaintext nor merely compressed) and decodes back
-// byte-identical through the decorated remote's ReadChunk — proving no plaintext
-// at rest on an encrypted share.
+// through a compression(encryption(base)) remote seals each chunk (the raw
+// block object does not contain the plaintext) and decodes back byte-identical
+// through the decorated remote's ReadChunk — proving no plaintext at rest on
+// an encrypted share.
 func TestCarve_ThroughCompressEncryptRemote(t *testing.T) {
 	ctx := context.Background()
 	base := remotememory.New()
@@ -249,8 +252,8 @@ func TestCarve_ThroughCompressEncryptRemote(t *testing.T) {
 		t.Fatalf("GetLocator: synced=%v err=%v", synced, err)
 	}
 
-	// Inspect the raw block bytes on the BASE store: the chunk's wire body must
-	// not contain the plaintext (it is encrypted), confirming sealing happened.
+	// Inspect the raw block bytes on the BASE store: the sealed wire body must
+	// not contain the plaintext, confirming the encryption seal ran during carve.
 	rawBlock, err := base.GetBlock(ctx, loc.BlockID)
 	if err != nil {
 		t.Fatalf("base GetBlock: %v", err)
@@ -299,6 +302,29 @@ func TestCarve_NonBlockRemoteDisablesCarve(t *testing.T) {
 	if syncer.PendingCount() != 1 {
 		t.Fatal("chunk should route to the legacy mirror set when carve is disabled")
 	}
+}
+
+// failOnNthMarkSynced is a blockCommitter wrapper that injects a MarkSynced
+// failure on a specific call (1-indexed). All other methods delegate to the
+// embedded real store so the transaction and local-index paths work normally.
+// Used by TestCarve_PartialMarkSyncedRetriesSameBlock to simulate a transient
+// metadata-store blip after the block record transaction commits.
+type failOnNthMarkSynced struct {
+	*metadatamemory.MemoryMetadataStore
+	mu         sync.Mutex
+	count      int
+	failOnCall int // which call (1-indexed) to fail
+}
+
+func (f *failOnNthMarkSynced) MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error {
+	f.mu.Lock()
+	f.count++
+	n := f.count
+	f.mu.Unlock()
+	if n == f.failOnCall {
+		return errors.New("injected MarkSynced failure")
+	}
+	return f.MemoryMetadataStore.MarkSynced(ctx, hash, loc)
 }
 
 // nonBlockRemote wraps a RemoteStore but hides the RemoteBlockStore methods so
@@ -356,5 +382,223 @@ func TestCarve_BoundaryAtBlockCarveBytes(t *testing.T) {
 		if loc.IsStandalone() {
 			t.Fatalf("hash %s: want block locator, got standalone", h)
 		}
+	}
+}
+
+// TestCarve_PartialMarkSyncedRetriesSameBlock is a regression test for
+// Finding #1: if DefaultCommitBlock's transaction commits but the MarkSynced
+// loop fails on a subsequent chunk, carveAndCommitBlock must retry with the
+// SAME blockID (via DefaultCommitBlock's idempotent tx guard) rather than
+// minting a new block. After the in-place retry succeeds, exactly one block
+// object must exist on the remote, and both chunks must be synced to that
+// single block — no orphan record with a non-zero LiveChunkCount and zero
+// referencing locators.
+func TestCarve_PartialMarkSyncedRetriesSameBlock(t *testing.T) {
+	ctx := context.Background()
+	mem := remotememory.New()
+
+	// Wire a real memory store that fails MarkSynced exactly once (call #2) to
+	// simulate a transient metadata-store blip after the block record tx commits.
+	realMS := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	wrapper := &failOnNthMarkSynced{
+		MemoryMetadataStore: realMS,
+		failOnCall:          2, // second chunk's MarkSynced fails once
+	}
+
+	local, err := fs.NewWithOptions(t.TempDir(), 0, nil, fs.FSStoreOptions{
+		LocalChunkIndex: realMS,
+	})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+	t.Cleanup(func() { _ = local.Close() })
+
+	cfg := DefaultConfig()
+	cfg.BlockCarveBytes = DefaultBlockCarveBytes
+	cfg.ManualSync = true
+
+	syncer := NewSyncer(local, mem, realMS, cfg)
+	syncer.SetSyncedHashStore(wrapper) // blockCommitter = wrapper (intercepts MarkSynced)
+	var memRBS remote.RemoteBlockStore = mem
+	syncer.SetRemoteBlockStore(memRBS)
+
+	if !syncer.carveActive.Load() {
+		t.Fatal("carve substrate must be active")
+	}
+
+	f := &carveFixture{local: local, ms: realMS, remote: memRBS, syncer: syncer}
+
+	// Store two chunks so the carver packs both into one block.
+	h1 := f.storeChunk(t, ctx, bytes.Repeat([]byte("chunk-A"), 512))
+	h2 := f.storeChunk(t, ctx, bytes.Repeat([]byte("chunk-B"), 512))
+
+	// carveFlush must succeed: the ErrCommitPartial retry completes MarkSynced
+	// for h2 using the same blockID.
+	if err := syncer.carveFlush(ctx, true); err != nil {
+		t.Fatalf("carveFlush: expected retry to succeed, got: %v", err)
+	}
+
+	// Exactly one block object on remote — no second block minted.
+	if got := countRemoteBlocks(t, ctx, mem); got != 1 {
+		t.Fatalf("remote blocks = %d, want 1 (no second block after ErrCommitPartial retry)", got)
+	}
+	if got := countRemoteCAS(t, ctx, mem); got != 0 {
+		t.Fatalf("remote CAS objects = %d, want 0", got)
+	}
+
+	// Both chunks synced to the SAME blockID.
+	loc1, ok1, err := realMS.GetLocator(ctx, h1)
+	if err != nil || !ok1 {
+		t.Fatalf("h1: synced=%v err=%v", ok1, err)
+	}
+	loc2, ok2, err := realMS.GetLocator(ctx, h2)
+	if err != nil || !ok2 {
+		t.Fatalf("h2: synced=%v err=%v", ok2, err)
+	}
+	if loc1.BlockID == "" || loc2.BlockID == "" {
+		t.Fatalf("chunks must have block locators, got loc1=%+v loc2=%+v", loc1, loc2)
+	}
+	if loc1.BlockID != loc2.BlockID {
+		t.Fatalf("chunks synced to different blocks: %s vs %s — orphan record present",
+			loc1.BlockID, loc2.BlockID)
+	}
+
+	// Block record must reflect both chunks.
+	rec, exists, err := realMS.GetBlockRecord(ctx, loc1.BlockID)
+	if err != nil || !exists {
+		t.Fatalf("GetBlockRecord(%s): exists=%v err=%v", loc1.BlockID, exists, err)
+	}
+	if rec.LiveChunkCount != 2 {
+		t.Fatalf("BlockRecord.LiveChunkCount = %d, want 2", rec.LiveChunkCount)
+	}
+
+	// Carve set fully drained.
+	if n := syncer.CarvePendingCount(); n != 0 {
+		t.Fatalf("carve pending = %d, want 0", n)
+	}
+
+	// Injection must have fired (test was meaningful).
+	wrapper.mu.Lock()
+	fired := wrapper.count >= wrapper.failOnCall
+	wrapper.mu.Unlock()
+	if !fired {
+		t.Fatal("MarkSynced failure injection did not fire — test setup error")
+	}
+}
+
+// TestCarve_DispatcherIdleFlush verifies the carve dispatcher (MINOR #2): a
+// sub-target write must not produce a block during the size-triggered pass, but
+// must appear after the idle window (UploadDelay) elapses. Exercises the
+// carveDispatcher timer path that the ManualSync=true fixtures never launch.
+func TestCarve_DispatcherIdleFlush(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	mem := remotememory.New()
+
+	const carveTarget = 4 * 1024 // 4 KiB; test data is 1 KiB — sub-target
+	const uploadDelay = 100 * time.Millisecond
+
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	local, err := fs.NewWithOptions(t.TempDir(), 0, nil, fs.FSStoreOptions{
+		LocalChunkIndex: ms,
+	})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+	t.Cleanup(func() { _ = local.Close() })
+
+	cfg := DefaultConfig()
+	cfg.BlockCarveBytes = carveTarget
+	cfg.UploadDelay = uploadDelay
+	cfg.ManualSync = false // required: carveDispatcher drives the idle flush
+
+	syncer := NewSyncer(local, mem, ms, cfg)
+	syncer.SetSyncedHashStore(ms)
+	var memRBS2 remote.RemoteBlockStore = mem
+	syncer.SetRemoteBlockStore(memRBS2)
+
+	if !syncer.carveActive.Load() {
+		t.Fatal("carve substrate must be active")
+	}
+
+	// Launch only the carve dispatcher; no health monitor or legacy dispatcher.
+	go syncer.carveDispatcher(ctx)
+
+	// Write 1 KiB — sub-target relative to the 4 KiB carve size.
+	f := &carveFixture{local: local, ms: ms, remote: memRBS2, syncer: syncer}
+	_ = f.storeChunk(t, ctx, bytes.Repeat([]byte("idle-x"), 170))
+
+	// Size-triggered flush (drainAll=false) must have returned nil: no block yet.
+	if got := countRemoteBlocks(t, ctx, mem); got != 0 {
+		t.Fatalf("blocks immediately after write = %d, want 0 (idle window not elapsed)", got)
+	}
+
+	// Poll until the idle flush fires. Allow 5× the idle window for scheduler
+	// jitter; fail if no block appears within that budget.
+	deadline := time.Now().Add(5 * uploadDelay)
+	for {
+		if countRemoteBlocks(t, ctx, mem) == 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no block after %v; idle flush did not fire", 5*uploadDelay)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if n := syncer.CarvePendingCount(); n != 0 {
+		t.Fatalf("carve pending = %d, want 0 after idle flush", n)
+	}
+}
+
+// TestCarve_RerouteMiss_LegacyPath verifies rerouteCarveMiss (MINOR #4): a
+// hash in the carve set but absent from the local log-blob chunk index (a
+// stray CAS hash misrouted to carve) is transferred to the legacy standalone-
+// mirror pending set without double-counting unsyncedBytes, and the legacy
+// upload wake is signalled.
+func TestCarve_RerouteMiss_LegacyPath(t *testing.T) {
+	ctx := context.Background()
+	mem := remotememory.New()
+	f := newCarveFixture(t, mem, DefaultBlockCarveBytes)
+
+	// A content hash NOT stored in the local log-blob / chunk index.
+	// addPendingCarveHash forces it into the carve set, simulating a stray CAS
+	// hash that was misrouted to carve before the log-blob / CAS distinction
+	// was enforced.
+	var ghost block.ContentHash
+	ghost[0] = 0x42
+	ghost[1] = 0xcd
+	const ghostSize int64 = 512
+	f.syncer.addPendingCarveHash(ghost, ghostSize)
+
+	if n := f.syncer.CarvePendingCount(); n != 1 {
+		t.Fatalf("carve pending = %d, want 1 before flush", n)
+	}
+	if got := f.syncer.UnsyncedBytes(); got != ghostSize {
+		t.Fatalf("UnsyncedBytes before flush = %d, want %d", got, ghostSize)
+	}
+
+	// carveFlush: GetLocalLocation(ghost) returns (_, false, nil) →
+	// rerouteCarveMiss moves ghost to the legacy pending set.
+	if err := f.syncer.carveFlush(ctx, true); err != nil {
+		t.Fatalf("carveFlush: %v", err)
+	}
+
+	// Ghost must have left the carve set.
+	if n := f.syncer.CarvePendingCount(); n != 0 {
+		t.Fatalf("carve pending = %d, want 0 after reroute", n)
+	}
+	// Ghost must be in the legacy pending set (wake signalled by rerouteCarveMiss).
+	if n := f.syncer.PendingCount(); n != 1 {
+		t.Fatalf("legacy pending = %d, want 1 after reroute", n)
+	}
+	// No remote block: only a reroute occurred, no commit.
+	if got := countRemoteBlocks(t, ctx, mem); got != 0 {
+		t.Fatalf("remote blocks = %d, want 0 (reroute only, no commit)", got)
+	}
+	// unsyncedBytes unchanged: ghost charged once, now in pendingHashes.
+	if got := f.syncer.UnsyncedBytes(); got != ghostSize {
+		t.Fatalf("UnsyncedBytes after reroute = %d, want %d (charged exactly once)", got, ghostSize)
 	}
 }

--- a/pkg/block/engine/carver_test.go
+++ b/pkg/block/engine/carver_test.go
@@ -1,0 +1,360 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/compression"
+	"github.com/marmos91/dittofs/pkg/block/encryption"
+	"github.com/marmos91/dittofs/pkg/block/encryption/keyprovider"
+	"github.com/marmos91/dittofs/pkg/block/local/fs"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// carveFixture wires an FSStore backed by a log-blob substrate, a memory
+// metadata store (the blockCommitter: Transactor + SyncedHashStore +
+// LocalChunkIndex), and the provided block-keyed remote into a Syncer with the
+// carve substrate fully active. carveBytes sizes the block target.
+type carveFixture struct {
+	local  *fs.FSStore
+	ms     *metadatamemory.MemoryMetadataStore
+	remote remote.RemoteBlockStore
+	syncer *Syncer
+}
+
+func newCarveFixture(t *testing.T, rbs remote.RemoteStore, carveBytes int64) *carveFixture {
+	t.Helper()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	local, err := fs.NewWithOptions(t.TempDir(), 0, nil, fs.FSStoreOptions{
+		LocalChunkIndex: ms,
+	})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+	t.Cleanup(func() { _ = local.Close() })
+
+	cfg := DefaultConfig()
+	cfg.BlockCarveBytes = carveBytes
+	cfg.ManualSync = true // explicit carveFlush only; no background goroutine racing assertions
+
+	syncer := NewSyncer(local, rbs, ms, cfg)
+	syncer.SetSyncedHashStore(ms)
+	rblock, ok := rbs.(remote.RemoteBlockStore)
+	if !ok {
+		t.Fatalf("remote does not implement RemoteBlockStore")
+	}
+	syncer.SetRemoteBlockStore(rblock)
+
+	if !syncer.carveActive.Load() {
+		t.Fatal("carve substrate should be active after wiring")
+	}
+	return &carveFixture{local: local, ms: ms, remote: rblock, syncer: syncer}
+}
+
+// storeChunk writes a chunk to the local log-blob tier and registers it for
+// carve exactly as the onChunkComplete hook would.
+func (f *carveFixture) storeChunk(t *testing.T, ctx context.Context, data []byte) block.ContentHash {
+	t.Helper()
+	h := block.ContentHash(blake3.Sum256(data))
+	if err := f.local.StoreChunk(ctx, h, data); err != nil {
+		t.Fatalf("StoreChunk: %v", err)
+	}
+	f.syncer.addPendingHash(h, int64(len(data)))
+	return h
+}
+
+// countRemoteBlocks returns the number of blocks/ objects on the memory remote.
+func countRemoteBlocks(t *testing.T, ctx context.Context, s *remotememory.Store) int {
+	t.Helper()
+	n := 0
+	if err := s.WalkBlocks(ctx, func(string, block.Meta) error { n++; return nil }); err != nil {
+		t.Fatalf("WalkBlocks: %v", err)
+	}
+	return n
+}
+
+// countRemoteCAS returns the number of cas/ objects on the memory remote.
+func countRemoteCAS(t *testing.T, ctx context.Context, s *remotememory.Store) int {
+	t.Helper()
+	n := 0
+	if err := s.Walk(ctx, func(block.ContentHash, block.Meta) error { n++; return nil }); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	return n
+}
+
+// TestCarve_NewWriteProducesBlockNotCAS is DoD test (1): a new write through the
+// carve path produces a blocks/ object on the remote and NO cas/ object, the
+// chunk is marked synced with a block locator, and the chunk reads back
+// byte-identical (from the local log-blob tier and from the remote block).
+func TestCarve_NewWriteProducesBlockNotCAS(t *testing.T) {
+	ctx := context.Background()
+	mem := remotememory.New()
+	f := newCarveFixture(t, mem, DefaultBlockCarveBytes)
+
+	data := bytes.Repeat([]byte("carve-me-"), 512)
+	h := f.storeChunk(t, ctx, data)
+
+	if err := f.syncer.carveFlush(ctx, true); err != nil {
+		t.Fatalf("carveFlush: %v", err)
+	}
+
+	if got := countRemoteBlocks(t, ctx, mem); got != 1 {
+		t.Fatalf("remote blocks = %d, want 1", got)
+	}
+	if got := countRemoteCAS(t, ctx, mem); got != 0 {
+		t.Fatalf("remote cas objects = %d, want 0 (carve must not write cas/)", got)
+	}
+
+	// The chunk is marked synced with a BLOCK locator (BlockID set).
+	loc, synced, err := f.ms.GetLocator(ctx, h)
+	if err != nil {
+		t.Fatalf("GetLocator: %v", err)
+	}
+	if !synced {
+		t.Fatal("chunk should be marked synced after carve")
+	}
+	if loc.IsStandalone() {
+		t.Fatalf("carve must record a block locator, got standalone: %+v", loc)
+	}
+
+	// Read back via the remote block using the persisted locator.
+	cr, ok := f.remote.(remote.ChunkReader)
+	if !ok {
+		t.Fatal("memory remote should implement ChunkReader")
+	}
+	got, err := cr.ReadChunk(ctx, loc.BlockID, loc.WireOffset, loc.WireLength, h)
+	if err != nil {
+		t.Fatalf("ReadChunk: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatal("remote block round-trip mismatch")
+	}
+
+	// Local read still returns the bytes (log-blob tier).
+	localGot, err := f.local.ReadChunk(ctx, h)
+	if err != nil {
+		t.Fatalf("local ReadChunk: %v", err)
+	}
+	if !bytes.Equal(localGot, data) {
+		t.Fatal("local log-blob read mismatch")
+	}
+
+	// The carve set is drained.
+	if n := f.syncer.CarvePendingCount(); n != 0 {
+		t.Fatalf("carve pending = %d, want 0 after flush", n)
+	}
+}
+
+// TestCarve_ThroughCompressedRemote is DoD test (2) (compression layer): the
+// block's per-chunk wire bytes are sealed (compressed, != plaintext) and decode
+// back byte-identical through the decorated remote's ReadChunk.
+func TestCarve_ThroughCompressedRemote(t *testing.T) {
+	ctx := context.Background()
+	base := remotememory.New()
+	dec, err := compression.NewRemote(base, compression.CompressionPolicy{Algo: compression.AlgoZstd})
+	if err != nil {
+		t.Fatalf("compression.NewRemote: %v", err)
+	}
+	f := newCarveFixture(t, dec, DefaultBlockCarveBytes)
+
+	// Highly compressible payload so the sealed wire is strictly smaller.
+	data := bytes.Repeat([]byte("AAAA-BBBB-CCCC-DDDD-"), 4096)
+	h := f.storeChunk(t, ctx, data)
+
+	if err := f.syncer.carveFlush(ctx, true); err != nil {
+		t.Fatalf("carveFlush: %v", err)
+	}
+
+	loc, synced, err := f.ms.GetLocator(ctx, h)
+	if err != nil || !synced {
+		t.Fatalf("GetLocator: synced=%v err=%v", synced, err)
+	}
+
+	// The wire body inside the block must be smaller than the plaintext —
+	// proof the compression seal ran during carve (not stored plaintext).
+	if loc.WireLength >= int64(len(data)) {
+		t.Fatalf("carved wire body not compressed: wireLen=%d plaintext=%d", loc.WireLength, len(data))
+	}
+
+	cr := f.remote.(remote.ChunkReader)
+	got, err := cr.ReadChunk(ctx, loc.BlockID, loc.WireOffset, loc.WireLength, h)
+	if err != nil {
+		t.Fatalf("ReadChunk: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatal("decoded carve chunk mismatch through compressed remote")
+	}
+}
+
+// newEncryptionProvider builds a local key-file provider for carve tests.
+func newEncryptionProvider(t *testing.T) keyprovider.KeyProvider {
+	t.Helper()
+	raw, err := keyprovider.GenerateKeyFile("carve-test-passphrase")
+	if err != nil {
+		t.Fatalf("GenerateKeyFile: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "share.key")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+	t.Setenv("DITTOFS_ENCRYPTION_PASSPHRASE", "carve-test-passphrase")
+	p, err := keyprovider.NewProvider(context.Background(), keyprovider.Config{Kind: keyprovider.KindLocal, File: path})
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+	return p
+}
+
+// TestCarve_ThroughCompressEncryptRemote is DoD test (2) (full stack): carving
+// through a compression(encryption(base)) remote seals each chunk (the block's
+// wire body is neither the plaintext nor merely compressed) and decodes back
+// byte-identical through the decorated remote's ReadChunk — proving no plaintext
+// at rest on an encrypted share.
+func TestCarve_ThroughCompressEncryptRemote(t *testing.T) {
+	ctx := context.Background()
+	base := remotememory.New()
+	enc, err := encryption.NewRemote(base, encryption.EncryptionPolicy{AEAD: encryption.AEADAES256GCM}, newEncryptionProvider(t))
+	if err != nil {
+		t.Fatalf("encryption.NewRemote: %v", err)
+	}
+	dec, err := compression.NewRemote(enc, compression.CompressionPolicy{Algo: compression.AlgoZstd})
+	if err != nil {
+		t.Fatalf("compression.NewRemote: %v", err)
+	}
+	f := newCarveFixture(t, dec, DefaultBlockCarveBytes)
+
+	data := bytes.Repeat([]byte("secret-payload-block-"), 1024)
+	h := f.storeChunk(t, ctx, data)
+
+	if err := f.syncer.carveFlush(ctx, true); err != nil {
+		t.Fatalf("carveFlush: %v", err)
+	}
+	if got := countRemoteBlocks(t, ctx, base); got != 1 {
+		t.Fatalf("remote blocks = %d, want 1", got)
+	}
+
+	loc, synced, err := f.ms.GetLocator(ctx, h)
+	if err != nil || !synced {
+		t.Fatalf("GetLocator: synced=%v err=%v", synced, err)
+	}
+
+	// Inspect the raw block bytes on the BASE store: the chunk's wire body must
+	// not contain the plaintext (it is encrypted), confirming sealing happened.
+	rawBlock, err := base.GetBlock(ctx, loc.BlockID)
+	if err != nil {
+		t.Fatalf("base GetBlock: %v", err)
+	}
+	if bytes.Contains(rawBlock, data) {
+		t.Fatal("encrypted carve must not store plaintext in the block object")
+	}
+
+	// Round-trip decode through the full decorated stack.
+	cr := f.remote.(remote.ChunkReader)
+	got, err := cr.ReadChunk(ctx, loc.BlockID, loc.WireOffset, loc.WireLength, h)
+	if err != nil {
+		t.Fatalf("ReadChunk: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatal("decoded carve chunk mismatch through compress+encrypt remote")
+	}
+}
+
+// TestCarve_NonBlockRemoteDisablesCarve verifies the nil-guard: a remote that
+// does not implement RemoteBlockStore leaves carve disabled, so chunks route to
+// the legacy mirror set, not the carve set.
+func TestCarve_NonBlockRemoteDisablesCarve(t *testing.T) {
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	local, err := fs.NewWithOptions(t.TempDir(), 0, nil, fs.FSStoreOptions{LocalChunkIndex: ms})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+	t.Cleanup(func() { _ = local.Close() })
+
+	// A bare remote that is NOT a RemoteBlockStore.
+	bare := nonBlockRemote{remotememory.New()}
+	syncer := NewSyncer(local, bare, ms, DefaultConfig())
+	syncer.SetSyncedHashStore(ms)
+	syncer.SetRemoteBlockStore(nil) // assertion fails / no block store
+
+	if syncer.carveActive.Load() {
+		t.Fatal("carve must be disabled without a RemoteBlockStore")
+	}
+	var h block.ContentHash
+	h[0] = 0x01
+	syncer.addPendingHash(h, 100)
+	if syncer.CarvePendingCount() != 0 {
+		t.Fatal("chunk must not route to carve when carve is disabled")
+	}
+	if syncer.PendingCount() != 1 {
+		t.Fatal("chunk should route to the legacy mirror set when carve is disabled")
+	}
+}
+
+// nonBlockRemote wraps a RemoteStore but hides the RemoteBlockStore methods so
+// the carve assertion fails.
+type nonBlockRemote struct{ remote.RemoteStore }
+
+// TestCarve_BoundaryAtBlockCarveBytes is DoD test (3): with a small carve
+// target, enough chunks to exceed several blocks produce multiple blocks via the
+// size-triggered (drainAll=false) path, and a trailing partial flushes only on
+// drainAll=true (idle/Flush).
+func TestCarve_BoundaryAtBlockCarveBytes(t *testing.T) {
+	ctx := context.Background()
+	mem := remotememory.New()
+	const chunkSize = 4096
+	const carveBytes = 3 * chunkSize // a full block holds 3 chunks
+	f := newCarveFixture(t, mem, carveBytes)
+
+	// 7 chunks => 2 full blocks (6 chunks) + 1 partial chunk left over.
+	hashes := make([]block.ContentHash, 0, 7)
+	for i := 0; i < 7; i++ {
+		data := bytes.Repeat([]byte{byte('a' + i)}, chunkSize)
+		// make each distinct
+		data = append(data, []byte(fmt.Sprintf("-%d", i))...)
+		hashes = append(hashes, f.storeChunk(t, ctx, data))
+	}
+
+	// Size-triggered: only full blocks emit; the sub-target remainder stays.
+	if err := f.syncer.carveFlush(ctx, false); err != nil {
+		t.Fatalf("carveFlush(size): %v", err)
+	}
+	if got := countRemoteBlocks(t, ctx, mem); got != 2 {
+		t.Fatalf("after size flush: blocks = %d, want 2 full blocks", got)
+	}
+	if n := f.syncer.CarvePendingCount(); n != 1 {
+		t.Fatalf("after size flush: carve pending = %d, want 1 (partial remainder)", n)
+	}
+
+	// Idle/explicit drain: the partial block flushes.
+	if err := f.syncer.carveFlush(ctx, true); err != nil {
+		t.Fatalf("carveFlush(drainAll): %v", err)
+	}
+	if got := countRemoteBlocks(t, ctx, mem); got != 3 {
+		t.Fatalf("after drain flush: blocks = %d, want 3", got)
+	}
+	if n := f.syncer.CarvePendingCount(); n != 0 {
+		t.Fatalf("after drain flush: carve pending = %d, want 0", n)
+	}
+
+	// Every chunk is synced with a block locator.
+	for _, h := range hashes {
+		loc, synced, err := f.ms.GetLocator(ctx, h)
+		if err != nil || !synced {
+			t.Fatalf("hash %s: synced=%v err=%v", h, synced, err)
+		}
+		if loc.IsStandalone() {
+			t.Fatalf("hash %s: want block locator, got standalone", h)
+		}
+	}
+}

--- a/pkg/block/engine/carver_test.go
+++ b/pkg/block/engine/carver_test.go
@@ -537,10 +537,7 @@ func TestCarve_DispatcherIdleFlush(t *testing.T) {
 	// Poll until the idle flush fires. Allow 5× the idle window for scheduler
 	// jitter; fail if no block appears within that budget.
 	deadline := time.Now().Add(5 * uploadDelay)
-	for {
-		if countRemoteBlocks(t, ctx, mem) == 1 {
-			break
-		}
+	for countRemoteBlocks(t, ctx, mem) != 1 {
 		if time.Now().After(deadline) {
 			t.Fatalf("no block after %v; idle flush did not fire", 5*uploadDelay)
 		}

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -214,8 +214,14 @@ func (m *Syncer) readChunkVerified(ctx context.Context, loc block.ChunkLocator, 
 	}
 	computed := block.ContentHash(blake3.Sum256(data))
 	if computed != hash {
+		if dm := m.dataplaneMetrics(); dm != nil {
+			dm.RecordRemoteCorruption(1)
+		}
 		return nil, fmt.Errorf("%w: block %s chunk %s computed %s",
 			block.ErrCASContentMismatch, loc.BlockID, hash, computed)
+	}
+	if dm := m.dataplaneMetrics(); dm != nil {
+		dm.RecordBlockRangeRead(len(data))
 	}
 	return data, nil
 }

--- a/pkg/block/engine/gc.go
+++ b/pkg/block/engine/gc.go
@@ -265,6 +265,18 @@ type Options struct {
 	// (#1433). Invoked synchronously from the (sequential) mark loop, so it must
 	// not block; implementations just record the latest count.
 	MarkProgress func(hashesMarked int64)
+
+	// BlockReclaimer reclaims block-resident chunks (#1414 object packing) during
+	// the remote steady-state sweep. A swept hash may be packed into a
+	// blocks/<id> object rather than a standalone cas/<hash> object; for those the
+	// sweep consults BlockReclaimer instead of deleting a CAS object that does not
+	// exist. It is reached only after the sweep has proven the hash globally dead
+	// (past grace, absent from the live set), so freeing a block here can never
+	// race a live dedup sibling. Nil means the deployment packs no blocks and the
+	// sweep deletes cas/<hash> objects exactly as before — non-block deployments
+	// are unaffected. Set ONLY for the remote tier (the index sweep); the local
+	// tier and reconcile leave it nil.
+	BlockReclaimer BlockReclaimer
 }
 
 // gcMarkProgressInterval bounds how often the mark phase emits a progress

--- a/pkg/block/engine/gc_block.go
+++ b/pkg/block/engine/gc_block.go
@@ -1,0 +1,129 @@
+// Package engine — block-aware GC reclaim (#1414 object packing, PR3).
+//
+// A packed-block chunk lives inside blocks/<blockID> rather than as a standalone
+// cas/<hash> object. Its bytes are shared with the other chunks in the same
+// block, so the block object can be reclaimed only when its LAST live chunk is
+// gone. Reclaim is driven by the existing remote GC sweep — NOT by the unlink
+// refcount cascade — because only the sweep's live-set scan proves a hash is
+// globally dead (no sibling FileChunk row, in any file, still references it).
+// Deciding to free a block on a single file's unlink would corrupt a dedup
+// sibling that shares the content; the sweep reaches a hash only after that
+// hazard is excluded, so DecrLiveChunkCount here can never race a live sibling.
+package engine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+)
+
+// BlockReclaimer reclaims a globally-dead chunk that the remote GC sweep has
+// proven unreferenced. It is consulted ONCE per swept hash, in place of the
+// standalone cas/<hash> Delete: a block-resident hash has no CAS object, so the
+// reclaimer decrements its enclosing block and frees the block object + record
+// when the last live chunk is gone. A nil Options.BlockReclaimer means the
+// deployment packs no blocks — the sweep deletes cas/<hash> objects exactly as
+// before, so non-block deployments are unaffected.
+type BlockReclaimer interface {
+	// ReclaimDeadChunk handles a globally-dead chunk hash. It returns
+	// handled=true (with the remote bytes freed, if any) when the hash was
+	// block-resident and the block bookkeeping was applied — the caller MUST
+	// then skip the standalone CAS delete (no such object exists). handled=false
+	// means the hash is a standalone CAS object and the caller deletes it as
+	// before. Idempotent: a hash whose block was already freed by a sibling
+	// chunk in the same sweep returns handled=true with zero bytes.
+	ReclaimDeadChunk(ctx context.Context, hash block.ContentHash) (handled bool, bytesFreed int64, err error)
+}
+
+// blockLocatorResolver resolves a chunk hash to its remote locator. Satisfied by
+// the per-share metadata store (metadata.SyncedHashStore.GetLocator).
+type blockLocatorResolver interface {
+	GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error)
+}
+
+// blockRecordGC is the block-record bookkeeping the reclaimer mutates. Satisfied
+// by the per-share metadata store (metadata.BlockRecordStore subset).
+type blockRecordGC interface {
+	GetBlockRecord(ctx context.Context, blockID string) (block.BlockRecord, bool, error)
+	DecrLiveChunkCount(ctx context.Context, blockID string, delta uint32) (uint32, error)
+	DeleteBlockRecord(ctx context.Context, blockID string) error
+}
+
+// localChunkDeleter drops a chunk's local-index entry. Satisfied by the
+// per-share metadata store (metadata.LocalChunkIndex.DeleteLocalLocation).
+type localChunkDeleter interface {
+	DeleteLocalLocation(ctx context.Context, hash block.ContentHash) error
+}
+
+// BlockGCReclaimer is the reference BlockReclaimer the remote GC sweep uses to
+// reclaim block-resident chunks. It binds the per-share metadata store's
+// locator/record/local-index surfaces and the block-keyed remote store. The
+// runtime constructs one per remote-store sweep scope and sets it on
+// engine.Options.BlockReclaimer.
+type BlockGCReclaimer struct {
+	Locators     blockLocatorResolver
+	Records      blockRecordGC
+	LocalIndex   localChunkDeleter
+	RemoteBlocks remote.RemoteBlockStore
+}
+
+// ReclaimDeadChunk implements BlockReclaimer. See the interface contract.
+//
+// Ordering is chosen for crash-safety. DecrLiveChunkCount runs BEFORE
+// DeleteLocalLocation so a crash between them leaves an orphan local-index entry
+// (harmless; a local reconcile reclaims it) rather than an over-counted block
+// that never floors to zero (a permanent remote leak). The remote DeleteBlock
+// precedes DeleteBlockRecord so a crash between them leaves a record-less orphan
+// object (reclaimed by the deferred orphan-object sweep) rather than a record
+// pointing at deleted bytes.
+func (r *BlockGCReclaimer) ReclaimDeadChunk(ctx context.Context, hash block.ContentHash) (bool, int64, error) {
+	loc, synced, err := r.Locators.GetLocator(ctx, hash)
+	if err != nil {
+		return false, 0, fmt.Errorf("block reclaim: get locator %s: %w", hash, err)
+	}
+	if !synced || loc.IsStandalone() {
+		// Standalone CAS object (or unsynced): the caller deletes cas/<hash>.
+		return false, 0, nil
+	}
+	blockID := loc.BlockID
+
+	// Existence + Length up front: a missing record means the block was already
+	// freed by a sibling chunk earlier in this sweep (idempotent re-entry).
+	rec, ok, err := r.Records.GetBlockRecord(ctx, blockID)
+	if err != nil {
+		return false, 0, fmt.Errorf("block reclaim: get record %s: %w", blockID, err)
+	}
+	if !ok {
+		// Orphan locator pointing at an already-freed block: drop its local entry
+		// and report handled so the caller skips the (nonexistent) CAS delete.
+		if derr := r.LocalIndex.DeleteLocalLocation(ctx, hash); derr != nil {
+			return false, 0, fmt.Errorf("block reclaim: delete local location %s: %w", hash, derr)
+		}
+		return true, 0, nil
+	}
+
+	remaining, err := r.Records.DecrLiveChunkCount(ctx, blockID, 1)
+	if err != nil {
+		return false, 0, fmt.Errorf("block reclaim: decr live chunk count %s: %w", blockID, err)
+	}
+	if derr := r.LocalIndex.DeleteLocalLocation(ctx, hash); derr != nil {
+		return false, 0, fmt.Errorf("block reclaim: delete local location %s: %w", hash, derr)
+	}
+	if remaining > 0 {
+		return true, 0, nil // block still has live chunks — keep it
+	}
+
+	// Last live chunk gone: free the remote object, then the record.
+	if derr := r.RemoteBlocks.DeleteBlock(ctx, blockID); derr != nil {
+		return false, 0, fmt.Errorf("block reclaim: delete block %s: %w", blockID, derr)
+	}
+	if derr := r.Records.DeleteBlockRecord(ctx, blockID); derr != nil {
+		return false, 0, fmt.Errorf("block reclaim: delete record %s: %w", blockID, derr)
+	}
+	return true, rec.Length, nil
+}
+
+// ensure compile-time interface satisfaction.
+var _ BlockReclaimer = (*BlockGCReclaimer)(nil)

--- a/pkg/block/engine/gc_block.go
+++ b/pkg/block/engine/gc_block.go
@@ -51,9 +51,11 @@ type blockRecordGC interface {
 	DeleteBlockRecord(ctx context.Context, blockID string) error
 }
 
-// localChunkDeleter drops a chunk's local-index entry. Satisfied by the
-// per-share metadata store (metadata.LocalChunkIndex.DeleteLocalLocation).
-type localChunkDeleter interface {
+// localChunkIndexGC is the narrow LocalChunkIndex surface the block reclaimer
+// needs: read-then-delete under the idempotency protocol. Satisfied by the
+// per-share metadata store (metadata.LocalChunkIndex).
+type localChunkIndexGC interface {
+	GetLocalLocation(ctx context.Context, hash block.ContentHash) (block.LocalChunkLocation, bool, error)
 	DeleteLocalLocation(ctx context.Context, hash block.ContentHash) error
 }
 
@@ -65,19 +67,24 @@ type localChunkDeleter interface {
 type BlockGCReclaimer struct {
 	Locators     blockLocatorResolver
 	Records      blockRecordGC
-	LocalIndex   localChunkDeleter
+	LocalIndex   localChunkIndexGC
 	RemoteBlocks remote.RemoteBlockStore
 }
 
 // ReclaimDeadChunk implements BlockReclaimer. See the interface contract.
 //
-// Ordering is chosen for crash-safety. DecrLiveChunkCount runs BEFORE
-// DeleteLocalLocation so a crash between them leaves an orphan local-index entry
-// (harmless; a local reconcile reclaims it) rather than an over-counted block
-// that never floors to zero (a permanent remote leak). The remote DeleteBlock
-// precedes DeleteBlockRecord so a crash between them leaves a record-less orphan
-// object (reclaimed by the deferred orphan-object sweep) rather than a record
-// pointing at deleted bytes.
+// Ordering is chosen for crash-safety and exactly-once decrement semantics.
+// DeleteLocalLocation runs BEFORE DecrLiveChunkCount so the local-index entry
+// serves as a per-hash idempotency token for the decrement: if the process is
+// killed after DeleteLocalLocation commits but before DecrLiveChunkCount, the
+// next sweep re-visits the hash (its synced marker was not cleared), finds the
+// local entry already gone, and skips the decrement. This fails toward over-count
+// (a remote leak, reclaimed by the deferred orphan-object sweep) rather than
+// under-count (premature block free = data loss for live siblings).
+//
+// The remote DeleteBlock precedes DeleteBlockRecord so a crash between them
+// leaves a record-less orphan object (reclaimed by the deferred orphan-object
+// sweep) rather than a record pointing at deleted bytes.
 func (r *BlockGCReclaimer) ReclaimDeadChunk(ctx context.Context, hash block.ContentHash) (bool, int64, error) {
 	loc, synced, err := r.Locators.GetLocator(ctx, hash)
 	if err != nil {
@@ -104,12 +111,32 @@ func (r *BlockGCReclaimer) ReclaimDeadChunk(ctx context.Context, hash block.Cont
 		return true, 0, nil
 	}
 
+	// Check the local-index entry BEFORE deleting it: the entry serves as an
+	// idempotency token for DecrLiveChunkCount. If it is already gone a previous
+	// run already applied the decrement and we must not decrement again.
+	_, localExisted, err := r.LocalIndex.GetLocalLocation(ctx, hash)
+	if err != nil {
+		return false, 0, fmt.Errorf("block reclaim: get local location %s: %w", hash, err)
+	}
+
+	// Delete the local-index entry first (idempotent). A crash here leaves an
+	// orphan entry reclaimed by the periodic local reconcile — safe direction.
+	if derr := r.LocalIndex.DeleteLocalLocation(ctx, hash); derr != nil {
+		return false, 0, fmt.Errorf("block reclaim: delete local location %s: %w", hash, derr)
+	}
+
+	if !localExisted {
+		// Crash-recovery re-entry: DeleteLocalLocation already ran in a prior
+		// pass, so DecrLiveChunkCount was either already applied or will be
+		// skipped here. Either way, the count is at least as high as the true
+		// live count — no premature free possible. Return handled so the caller
+		// skips the (nonexistent) standalone CAS delete.
+		return true, 0, nil
+	}
+
 	remaining, err := r.Records.DecrLiveChunkCount(ctx, blockID, 1)
 	if err != nil {
 		return false, 0, fmt.Errorf("block reclaim: decr live chunk count %s: %w", blockID, err)
-	}
-	if derr := r.LocalIndex.DeleteLocalLocation(ctx, hash); derr != nil {
-		return false, 0, fmt.Errorf("block reclaim: delete local location %s: %w", hash, derr)
 	}
 	if remaining > 0 {
 		return true, 0, nil // block still has live chunks — keep it

--- a/pkg/block/engine/gc_block_test.go
+++ b/pkg/block/engine/gc_block_test.go
@@ -348,10 +348,85 @@ func TestGCBlockSweep_StandaloneStillDeletesCAS(t *testing.T) {
 	}
 }
 
+// TestBlockReclaimer_RerunAfterCrashNoDoubleDecrement is the critical
+// data-loss regression test for the partial-reclaim re-entry bug. If the GC
+// is killed or DeleteSynced fails between ReclaimDeadChunk and its caller
+// clearing the synced marker, the next sweep re-visits the same hash (the
+// synced marker is still present). Without the fix, a second call to
+// ReclaimDeadChunk decrements live_chunk_count a second time — driving it to
+// 0 for a block that still has a live sibling → DeleteBlock fires → the
+// sibling chunk's reads break permanently (silent data loss).
+//
+// The fix: DeleteLocalLocation runs FIRST as an idempotency token; the decrement
+// is skipped on re-entry (the local location is already gone).
+func TestBlockReclaimer_RerunAfterCrashNoDoubleDecrement(t *testing.T) {
+	ctx := t.Context()
+	st := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	rbs := remotememory.New()
+	defer func() { _ = rbs.Close() }()
+
+	h1 := hashFromString("crash-chunk-dead")
+	h2 := hashFromString("crash-chunk-live")
+	// 2-chunk block: h1 will be reclaimed, h2 is the live sibling that must survive.
+	seedPackedBlock(t, st, rbs, "blk-crash", []block.ContentHash{h1, h2})
+
+	reclaimer := newBlockGCReclaimer(st, rbs)
+
+	// First reclaim of h1: normal path — decrements count, deletes local location.
+	// DeleteSynced is NOT called (simulating crash between ReclaimDeadChunk and
+	// its caller clearing the synced marker).
+	handled, freed, err := reclaimer.ReclaimDeadChunk(ctx, h1)
+	if err != nil {
+		t.Fatalf("first ReclaimDeadChunk: %v", err)
+	}
+	if !handled {
+		t.Fatalf("first ReclaimDeadChunk: handled=false, want true")
+	}
+	if freed != 0 {
+		t.Errorf("first pass bytesFreed=%d, want 0 (block still alive, one chunk remains)", freed)
+	}
+
+	// Verify intermediate state: count decremented to 1, h1 local gone, h2 intact.
+	rec, ok, _ := st.GetBlockRecord(ctx, "blk-crash")
+	if !ok || rec.LiveChunkCount != 1 {
+		t.Fatalf("after first pass: ok=%v LiveChunkCount=%d, want 1", ok, rec.LiveChunkCount)
+	}
+
+	// Simulate crash: DeleteSynced was skipped, so h1's synced marker remains.
+	// The next sweep re-visits h1 (it's still absent from the live FileChunk set).
+	// This is the crash-recovery re-entry — must NOT decrement again.
+	handled, freed, err = reclaimer.ReclaimDeadChunk(ctx, h1)
+	if err != nil {
+		t.Fatalf("second ReclaimDeadChunk (crash recovery): %v", err)
+	}
+	if !handled {
+		t.Fatalf("second ReclaimDeadChunk: handled=false, want true")
+	}
+
+	// CRITICAL: the block must NOT have been freed. Without the fix, the second
+	// decrement drives live_chunk_count to 0 → DeleteBlock → data loss for h2.
+	if _, err := rbs.GetBlock(ctx, "blk-crash"); err != nil {
+		t.Errorf("block prematurely freed on crash-recovery reclaim (DATA LOSS): GetBlock: %v", err)
+	}
+	rec, ok, _ = st.GetBlockRecord(ctx, "blk-crash")
+	if !ok {
+		t.Errorf("block record deleted on crash-recovery reclaim (DATA LOSS)")
+	} else if rec.LiveChunkCount != 1 {
+		t.Errorf("LiveChunkCount=%d after crash-recovery reclaim, want 1 (double-decrement = data loss)", rec.LiveChunkCount)
+	}
+	if freed != 0 {
+		t.Errorf("crash-recovery bytesFreed=%d, want 0 (block must not be freed)", freed)
+	}
+	// h2's local location must remain intact — it is still live.
+	if _, ok, _ := st.GetLocalLocation(ctx, h2); !ok {
+		t.Errorf("h2 local location wrongly deleted during crash-recovery reclaim")
+	}
+}
+
 // compile-time: the memory metadata store satisfies the reclaimer surfaces.
 var (
 	_ blockLocatorResolver = (*metadatamemory.MemoryMetadataStore)(nil)
 	_ blockRecordGC        = (*metadatamemory.MemoryMetadataStore)(nil)
-	_ localChunkDeleter    = (*metadatamemory.MemoryMetadataStore)(nil)
+	_ localChunkIndexGC    = (*metadatamemory.MemoryMetadataStore)(nil)
 	_ context.Context      = nil
 )

--- a/pkg/block/engine/gc_block_test.go
+++ b/pkg/block/engine/gc_block_test.go
@@ -1,0 +1,357 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// seedPackedBlock writes a block object to rbs and records, in st, the block
+// record (LiveChunkCount = len(chunks)), each chunk's local location, and each
+// chunk's synced block-locator backdated past the grace window. It mirrors what
+// the carver's DefaultCommitBlock produces, minus the real codec framing the GC
+// reclaim path never inspects.
+func seedPackedBlock(t *testing.T, st metadata.Store, rbs remote.RemoteBlockStore, blockID string, chunks []block.ContentHash) {
+	t.Helper()
+	ctx := t.Context()
+	data := []byte("block-bytes-" + blockID)
+	if err := rbs.PutBlock(ctx, blockID, bytes.NewReader(data)); err != nil {
+		t.Fatalf("PutBlock(%s): %v", blockID, err)
+	}
+	if err := st.PutBlockRecord(ctx, block.BlockRecord{
+		BlockID:        blockID,
+		Length:         int64(len(data)),
+		LiveChunkCount: uint32(len(chunks)),
+		SyncState:      block.BlockStateRemote,
+	}); err != nil {
+		t.Fatalf("PutBlockRecord(%s): %v", blockID, err)
+	}
+	for i, h := range chunks {
+		loc := block.LocalChunkLocation{LogBlobID: "0000000000000000", RawOffset: int64(i) * 64, RawLength: 64}
+		if err := st.PutLocalLocation(ctx, h, loc); err != nil {
+			t.Fatalf("PutLocalLocation(%s): %v", h, err)
+		}
+		if err := st.MarkSynced(ctx, h, block.ChunkLocator{BlockID: blockID, WireOffset: int64(i) * 80, WireLength: 80}); err != nil {
+			t.Fatalf("MarkSynced(%s): %v", h, err)
+		}
+		// Backdate past grace so the steady-state index sweep treats it as
+		// eligible (the live-set check is then the only thing that can save it).
+		st.(*metadatamemory.MemoryMetadataStore).MarkSyncedAtForTest(h, time.Now().Add(-2*time.Hour))
+	}
+}
+
+func newBlockGCReclaimer(st metadata.Store, rbs remote.RemoteBlockStore) *BlockGCReclaimer {
+	return &BlockGCReclaimer{Locators: st, Records: st, LocalIndex: st, RemoteBlocks: rbs}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: BlockGCReclaimer.ReclaimDeadChunk
+// ---------------------------------------------------------------------------
+
+// TestBlockReclaimer_StandalonePassthrough proves a standalone synced hash (no
+// block locator) is NOT handled — the sweep must delete its cas/<hash> object as
+// before. No block bookkeeping is touched.
+func TestBlockReclaimer_StandalonePassthrough(t *testing.T) {
+	ctx := t.Context()
+	st := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	rbs := remotememory.New()
+	defer func() { _ = rbs.Close() }()
+
+	h := hashFromString("standalone-chunk")
+	if err := st.MarkSynced(ctx, h, block.ChunkLocator{}); err != nil { // standalone
+		t.Fatalf("MarkSynced: %v", err)
+	}
+
+	handled, freed, err := newBlockGCReclaimer(st, rbs).ReclaimDeadChunk(ctx, h)
+	if err != nil {
+		t.Fatalf("ReclaimDeadChunk: %v", err)
+	}
+	if handled {
+		t.Errorf("handled = true for a standalone hash; sweep must delete the CAS object instead")
+	}
+	if freed != 0 {
+		t.Errorf("bytesFreed = %d, want 0 for standalone passthrough", freed)
+	}
+}
+
+// TestBlockReclaimer_PartialDecrement proves reclaiming one of a block's two
+// chunks decrements LiveChunkCount, drops that chunk's local location, but
+// leaves the block object + record intact (the other chunk is still live).
+func TestBlockReclaimer_PartialDecrement(t *testing.T) {
+	ctx := t.Context()
+	st := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	rbs := remotememory.New()
+	defer func() { _ = rbs.Close() }()
+
+	h1 := hashFromString("blk-chunk-1")
+	h2 := hashFromString("blk-chunk-2")
+	seedPackedBlock(t, st, rbs, "blk-partial", []block.ContentHash{h1, h2})
+
+	handled, freed, err := newBlockGCReclaimer(st, rbs).ReclaimDeadChunk(ctx, h1)
+	if err != nil {
+		t.Fatalf("ReclaimDeadChunk: %v", err)
+	}
+	if !handled {
+		t.Fatalf("handled = false, want true for a block-resident chunk")
+	}
+	if freed != 0 {
+		t.Errorf("bytesFreed = %d, want 0 (block not freed on partial decrement)", freed)
+	}
+
+	rec, ok, err := st.GetBlockRecord(ctx, "blk-partial")
+	if err != nil || !ok {
+		t.Fatalf("GetBlockRecord: ok=%v err=%v (block must survive a partial decrement)", ok, err)
+	}
+	if rec.LiveChunkCount != 1 {
+		t.Errorf("LiveChunkCount = %d, want 1 after one chunk reaped", rec.LiveChunkCount)
+	}
+	if _, ok, _ := st.GetLocalLocation(ctx, h1); ok {
+		t.Errorf("h1 local location still present; reclaim must delete it")
+	}
+	if _, ok, _ := st.GetLocalLocation(ctx, h2); !ok {
+		t.Errorf("h2 local location wrongly deleted (still live)")
+	}
+	if _, err := rbs.GetBlock(ctx, "blk-partial"); err != nil {
+		t.Errorf("block object wrongly deleted on partial decrement: %v", err)
+	}
+}
+
+// TestBlockReclaimer_FreesBlockAtZero proves reclaiming the LAST live chunk
+// frees the remote block object AND the record, reporting the block bytes freed.
+func TestBlockReclaimer_FreesBlockAtZero(t *testing.T) {
+	ctx := t.Context()
+	st := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	rbs := remotememory.New()
+	defer func() { _ = rbs.Close() }()
+
+	h := hashFromString("only-chunk")
+	seedPackedBlock(t, st, rbs, "blk-solo", []block.ContentHash{h})
+
+	handled, freed, err := newBlockGCReclaimer(st, rbs).ReclaimDeadChunk(ctx, h)
+	if err != nil {
+		t.Fatalf("ReclaimDeadChunk: %v", err)
+	}
+	if !handled {
+		t.Fatalf("handled = false, want true")
+	}
+	if freed <= 0 {
+		t.Errorf("bytesFreed = %d, want the block Length when the last chunk is freed", freed)
+	}
+	if _, ok, _ := st.GetBlockRecord(ctx, "blk-solo"); ok {
+		t.Errorf("block record still present after last chunk freed")
+	}
+	if _, err := rbs.GetBlock(ctx, "blk-solo"); err == nil {
+		t.Errorf("block object still present on remote after last chunk freed")
+	}
+	if _, ok, _ := st.GetLocalLocation(ctx, h); ok {
+		t.Errorf("local location still present after free")
+	}
+}
+
+// TestBlockReclaimer_IdempotentAlreadyFreed proves reclaiming a block-resident
+// hash whose block record is already gone (a sibling chunk freed it earlier in
+// the same sweep) returns handled=true without error and is a no-op on the
+// remote — so the caller still skips the CAS delete.
+func TestBlockReclaimer_IdempotentAlreadyFreed(t *testing.T) {
+	ctx := t.Context()
+	st := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	rbs := remotememory.New()
+	defer func() { _ = rbs.Close() }()
+
+	h := hashFromString("orphan-locator")
+	// Synced block-locator present, but NO block record (already freed).
+	if err := st.MarkSynced(ctx, h, block.ChunkLocator{BlockID: "blk-gone", WireOffset: 0, WireLength: 80}); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+
+	handled, freed, err := newBlockGCReclaimer(st, rbs).ReclaimDeadChunk(ctx, h)
+	if err != nil {
+		t.Fatalf("ReclaimDeadChunk: %v", err)
+	}
+	if !handled {
+		t.Errorf("handled = false; an already-freed block-resident hash must still be handled (no CAS object exists)")
+	}
+	if freed != 0 {
+		t.Errorf("bytesFreed = %d, want 0", freed)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests: block reclaim through the real GC index sweep.
+// ---------------------------------------------------------------------------
+
+// blockGCEnv wires one memory metadata store (live-set + synced index + reclaim
+// surfaces) and one memory remote (CAS + block-keyed) for the index-sweep tests.
+type blockGCEnv struct {
+	st  *metadatamemory.MemoryMetadataStore
+	rs  *remotememory.Store
+	rec *gcMSReconciler
+}
+
+func newBlockGCEnv(t *testing.T) *blockGCEnv {
+	t.Helper()
+	rec := newGCMSReconciler()
+	st := rec.addShare("share-a").(*metadatamemory.MemoryMetadataStore)
+	rs := remotememory.New()
+	t.Cleanup(func() { _ = rs.Close() })
+	return &blockGCEnv{st: st, rs: rs, rec: rec}
+}
+
+func (e *blockGCEnv) runGC(t *testing.T) *GCStats {
+	t.Helper()
+	return CollectGarbage(t.Context(), noWalkRemote{RemoteStore: e.rs, t: t}, e.rec, &Options{
+		GCStateRoot:     t.TempDir(),
+		GracePeriod:     time.Hour,
+		SyncedHashIndex: e.st,
+		BlockReclaimer:  newBlockGCReclaimer(e.st, e.rs),
+		// FullScan omitted (false) → steady-state index sweep.
+	})
+}
+
+// TestGCBlockSweep_DedupSiblingKeepsBlockAlive is the dedup-safety proof: a
+// block-resident hash shared by two files (dedup) must NOT free its block when
+// only the FIRST file unlinks — the sibling FileChunk row keeps the hash in the
+// live set. Freeing it here would corrupt the sibling. The block is freed only
+// when the SECOND (last) referencing file also unlinks.
+func TestGCBlockSweep_DedupSiblingKeepsBlockAlive(t *testing.T) {
+	ctx := t.Context()
+	env := newBlockGCEnv(t)
+
+	h := hashFromString("dedup-shared-chunk")
+	seedPackedBlock(t, env.st, env.rs, "blk-dedup", []block.ContentHash{h})
+	// Two files reference the SAME packed chunk (cross-file dedup): one block
+	// chunk, one synced locator, two live FileChunk rows.
+	putBlock(t, env.st, "fileA/0", h)
+	putBlock(t, env.st, "fileB/0", h)
+
+	// Phase 1: unlink fileA only. h is still live via fileB → block kept.
+	if err := env.st.Delete(ctx, "fileA/0"); err != nil {
+		t.Fatalf("unlink fileA: %v", err)
+	}
+	stats := env.runGC(t)
+	if stats.ErrorCount != 0 {
+		t.Fatalf("phase-1 ErrorCount = %d (%v)", stats.ErrorCount, stats.FirstErrors)
+	}
+	if stats.ObjectsSwept != 0 {
+		t.Fatalf("phase-1 ObjectsSwept = %d, want 0 — block freed while a dedup sibling still references it (DATA LOSS)", stats.ObjectsSwept)
+	}
+	if _, err := env.rs.GetBlock(ctx, "blk-dedup"); err != nil {
+		t.Fatalf("block wrongly freed while fileB still references it: %v", err)
+	}
+	if rec, ok, _ := env.st.GetBlockRecord(ctx, "blk-dedup"); !ok || rec.LiveChunkCount != 1 {
+		t.Fatalf("block record disturbed by a sibling-kept sweep: ok=%v count=%d", ok, rec.LiveChunkCount)
+	}
+
+	// Phase 2: unlink fileB (the last reference). h is now globally dead → freed.
+	if err := env.st.Delete(ctx, "fileB/0"); err != nil {
+		t.Fatalf("unlink fileB: %v", err)
+	}
+	stats = env.runGC(t)
+	if stats.ErrorCount != 0 {
+		t.Fatalf("phase-2 ErrorCount = %d (%v)", stats.ErrorCount, stats.FirstErrors)
+	}
+	if stats.ObjectsSwept != 1 {
+		t.Fatalf("phase-2 ObjectsSwept = %d, want 1 (the now-dead block chunk)", stats.ObjectsSwept)
+	}
+	if _, err := env.rs.GetBlock(ctx, "blk-dedup"); err == nil {
+		t.Errorf("block not freed after its last reference unlinked")
+	}
+	if _, ok, _ := env.st.GetBlockRecord(ctx, "blk-dedup"); ok {
+		t.Errorf("block record not deleted after last chunk freed")
+	}
+	if ok, _ := env.st.IsSynced(ctx, h); ok {
+		t.Errorf("synced marker not cleared after block reclaim (ListUnsynced would skip it forever)")
+	}
+}
+
+// TestGCBlockSweep_PartialUnlinkLeavesIntact proves the index sweep decrements a
+// block's LiveChunkCount for the dead chunk while keeping the block object alive
+// for the still-live chunk — the LiveChunkCount invariant holds across a partial
+// unlink.
+func TestGCBlockSweep_PartialUnlinkLeavesIntact(t *testing.T) {
+	ctx := t.Context()
+	env := newBlockGCEnv(t)
+
+	h1 := hashFromString("partial-chunk-1")
+	h2 := hashFromString("partial-chunk-2")
+	seedPackedBlock(t, env.st, env.rs, "blk-part", []block.ContentHash{h1, h2})
+	putBlock(t, env.st, "file/0", h1)
+	putBlock(t, env.st, "file/64", h2)
+
+	// Unlink only h1's row; h2 stays live.
+	if err := env.st.Delete(ctx, "file/0"); err != nil {
+		t.Fatalf("unlink h1 row: %v", err)
+	}
+	stats := env.runGC(t)
+	if stats.ErrorCount != 0 {
+		t.Fatalf("ErrorCount = %d (%v)", stats.ErrorCount, stats.FirstErrors)
+	}
+	if stats.ObjectsSwept != 1 {
+		t.Fatalf("ObjectsSwept = %d, want 1 (only h1)", stats.ObjectsSwept)
+	}
+
+	rec, ok, err := env.st.GetBlockRecord(ctx, "blk-part")
+	if err != nil || !ok {
+		t.Fatalf("block record missing after partial unlink: ok=%v err=%v", ok, err)
+	}
+	if rec.LiveChunkCount != 1 {
+		t.Errorf("LiveChunkCount = %d, want 1 (invariant: one live chunk remains)", rec.LiveChunkCount)
+	}
+	if _, err := env.rs.GetBlock(ctx, "blk-part"); err != nil {
+		t.Errorf("block wrongly freed on partial unlink: %v", err)
+	}
+	if _, ok, _ := env.st.GetLocalLocation(ctx, h1); ok {
+		t.Errorf("h1 local location not deleted")
+	}
+	if ok, _ := env.st.IsSynced(ctx, h1); ok {
+		t.Errorf("h1 synced marker not cleared")
+	}
+	if _, ok, _ := env.st.GetLocalLocation(ctx, h2); !ok {
+		t.Errorf("h2 local location wrongly deleted (still live)")
+	}
+	if ok, _ := env.st.IsSynced(ctx, h2); !ok {
+		t.Errorf("h2 synced marker wrongly cleared (still live)")
+	}
+}
+
+// TestGCBlockSweep_StandaloneStillDeletesCAS proves wiring a BlockReclaimer does
+// NOT change standalone CAS reclaim: a dead standalone synced hash is deleted
+// from the CAS namespace as before (the reclaimer reports not-handled).
+func TestGCBlockSweep_StandaloneStillDeletesCAS(t *testing.T) {
+	ctx := t.Context()
+	env := newBlockGCEnv(t)
+
+	h := hashFromString("standalone-dead")
+	writeCASObject(t, ctx, env.rs, h, []byte("standalone-bytes"))
+	if err := env.st.MarkSynced(ctx, h, block.ChunkLocator{}); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+	env.st.MarkSyncedAtForTest(h, time.Now().Add(-2*time.Hour))
+	// No FileChunk row → not in the live set → orphan.
+
+	stats := env.runGC(t)
+	if stats.ErrorCount != 0 {
+		t.Fatalf("ErrorCount = %d (%v)", stats.ErrorCount, stats.FirstErrors)
+	}
+	if stats.ObjectsSwept != 1 {
+		t.Fatalf("ObjectsSwept = %d, want 1", stats.ObjectsSwept)
+	}
+	if _, err := env.rs.Get(ctx, h); err == nil {
+		t.Errorf("standalone CAS object not deleted with a BlockReclaimer wired")
+	}
+}
+
+// compile-time: the memory metadata store satisfies the reclaimer surfaces.
+var (
+	_ blockLocatorResolver = (*metadatamemory.MemoryMetadataStore)(nil)
+	_ blockRecordGC        = (*metadatamemory.MemoryMetadataStore)(nil)
+	_ localChunkDeleter    = (*metadatamemory.MemoryMetadataStore)(nil)
+	_ context.Context      = nil
+)

--- a/pkg/block/engine/gc_sweep_index.go
+++ b/pkg/block/engine/gc_sweep_index.go
@@ -77,6 +77,38 @@ func sweepFromSyncedIndex(
 			return nil
 		}
 
+		// Block-aware reclaim (#1414 object packing): a synced hash may be packed
+		// into a blocks/<id> object rather than a standalone cas/<hash> object. For
+		// those the CAS Delete below would target a key that does not exist; the
+		// reclaimer instead decrements the enclosing block and frees the block
+		// object + record when its last live chunk is gone. The sweep reaches h
+		// only here, where it has already proven h globally dead (past grace,
+		// absent from the live set), so decrementing can never race a live dedup
+		// sibling. nil BlockReclaimer (non-block deployments) falls straight
+		// through to the standalone CAS delete.
+		if options.BlockReclaimer != nil {
+			handled, freed, rerr := options.BlockReclaimer.ReclaimDeadChunk(ctx, h)
+			if rerr != nil {
+				addError("block-reclaim " + casKey + ": " + rerr.Error())
+				return nil
+			}
+			if handled {
+				// Block-resident: no CAS object to delete. Clear the synced marker
+				// (its locator was already consumed by the reclaim) so the synced
+				// set stays a strict subset of remote contents (#1433), and count
+				// the reclamation.
+				if serr := options.SyncedHashIndex.DeleteSynced(ctx, h); serr != nil {
+					addError("delete-synced " + casKey + ": " + serr.Error())
+				}
+				statsMu.Lock()
+				stats.ObjectsSwept++
+				stats.BytesFreed += freed
+				statsMu.Unlock()
+				return nil
+			}
+			// Not handled → standalone CAS object: fall through to Delete.
+		}
+
 		if derr := store.Delete(ctx, h); derr != nil {
 			// Continue + capture; the marker stays so the next pass retries.
 			addError("delete " + casKey + ": " + derr.Error())

--- a/pkg/block/engine/gc_sweep_index.go
+++ b/pkg/block/engine/gc_sweep_index.go
@@ -95,10 +95,13 @@ func sweepFromSyncedIndex(
 			if handled {
 				// Block-resident: no CAS object to delete. Clear the synced marker
 				// (its locator was already consumed by the reclaim) so the synced
-				// set stays a strict subset of remote contents (#1433), and count
-				// the reclamation.
+				// set stays a strict subset of remote contents (#1433). Only count
+				// the reclamation when the marker is actually cleared — a surviving
+				// marker means the hash will be re-visited next pass, so counting
+				// it now would double-count both ObjectsSwept and BytesFreed.
 				if serr := options.SyncedHashIndex.DeleteSynced(ctx, h); serr != nil {
 					addError("delete-synced " + casKey + ": " + serr.Error())
+					return nil // marker survives; retry next pass, don't count yet
 				}
 				statsMu.Lock()
 				stats.ObjectsSwept++

--- a/pkg/block/engine/metrics.go
+++ b/pkg/block/engine/metrics.go
@@ -22,4 +22,30 @@ type DataplaneMetrics interface {
 	SetUploadWindow(n int)
 	// RecordRehash records pre-upload BLAKE3 re-hash latency for one chunk.
 	RecordRehash(d time.Duration)
+
+	// --- Corruption detection / self-heal (read path) ---
+	// All five counters are BOUNDED zero-label counters: no per-share, per-
+	// hash, or per-block dimensions (the #1188 unbounded-cardinality lesson).
+
+	// RecordLocalCorruption records n local-chunk integrity failures detected
+	// on read (blake3 of the local bytes != the chunk's content hash). One
+	// event per corrupt chunk surfaced to the read path.
+	RecordLocalCorruption(n int)
+	// RecordSelfHealSuccess records n local corruptions that were repaired:
+	// the corrupt local pointer was dropped and the chunk was re-fetched from
+	// its remote block, re-verified, and durably re-staged into local storage.
+	RecordSelfHealSuccess(n int)
+	// RecordSelfHealFailure records n local corruptions that could NOT be
+	// repaired-and-persisted: the chunk was unsynced (only copy is corrupt),
+	// the remote re-fetch failed/was-corrupt (read fails closed), or the good
+	// bytes were served but the local re-stage did not persist (degraded).
+	RecordSelfHealFailure(n int)
+	// RecordRemoteCorruption records n remote-chunk integrity failures detected
+	// on fetch (blake3 of the fetched bytes != the chunk's content hash). The
+	// read fails closed; a corrupt remote is never self-healed from.
+	RecordRemoteCorruption(n int)
+	// RecordBlockRangeRead records one successful block-range read (a ranged
+	// GET into a packed block object that passed per-chunk verification);
+	// bytes is the verified chunk-plaintext length returned.
+	RecordBlockRangeRead(bytes int)
 }

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -5,9 +5,21 @@ import (
 	"errors"
 	"fmt"
 
+	"lukechampine.com/blake3"
+
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block"
 )
+
+// dataplaneMetrics returns the engine's data-plane metrics sink, or nil when no
+// recorder was injected. Call sites must guard the result: it is a plain
+// interface, not a nil-safe *Metrics.  Mirrors the Syncer's dataplaneMetrics().
+func (bs *Store) dataplaneMetrics() DataplaneMetrics {
+	if p := bs.metrics.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
 
 // blockRefHashes extracts the ContentHash slice from a BlockRef list
 // for OnRead's hint API.
@@ -167,6 +179,16 @@ func (bs *Store) readLocalByHash(ctx context.Context, payloadID string, dest []b
 			}
 			return false, err
 		}
+		// Integrity check: verify the buffer we already have against the
+		// chunk's content hash.  No double-read — we verify in-place.
+		computed := block.ContentHash(blake3.Sum256(data))
+		if computed != row.fb.Hash {
+			var healErr error
+			data, healErr = bs.healLocalChunk(ctx, row.fb.Hash, row.fb)
+			if healErr != nil {
+				return false, healErr
+			}
+		}
 		// Clamp the visible data to FileChunk.DataSize so a padded
 		// on-disk chunk surface doesn't leak garbage past the
 		// rollup-emitted byte count.
@@ -221,4 +243,78 @@ func findRowCoveringOffset(rows []*block.FileChunk, target uint64) *rowWithOffse
 		}
 	}
 	return nil
+}
+
+// healLocalChunk attempts to repair a locally corrupt chunk by re-fetching it
+// from the remote store.  It records corruption + outcome metrics and returns
+// the healed bytes (or nil + error on unrecoverable failure).
+//
+// Decision tree:
+//  1. Record local corruption unconditionally.
+//  2. If no SyncedHashStore is wired, or IsSynced returns false/error:
+//     RecordSelfHealFailure(1) + return (nil, ErrCASContentMismatch).
+//  3. Delete the corrupt local entry (removes the bad hash pointer).
+//  4. Fetch from remote via dispatchRemoteFetch (already blake3-verified).
+//     If fetch fails or returns nil data: RecordSelfHealFailure(1) + (nil, ErrCASContentMismatch).
+//  5. Try to re-stage locally via local.Put.
+//     - Put succeeds: markFetchedSynced + RecordSelfHealSuccess(1) + return data.
+//     - Put fails (disk full etc.): RecordSelfHealFailure(1) + return data (serve degraded).
+func (bs *Store) healLocalChunk(ctx context.Context, hash block.ContentHash, fb *block.FileChunk) ([]byte, error) {
+	dm := bs.dataplaneMetrics()
+	if dm != nil {
+		dm.RecordLocalCorruption(1)
+	}
+
+	// Only synced chunks have a retrievable remote copy.
+	shs := bs.syncedHashStore
+	if shs == nil {
+		logger.Debug("self-heal: no SyncedHashStore wired, cannot heal chunk", "hash", hash)
+		if dm != nil {
+			dm.RecordSelfHealFailure(1)
+		}
+		return nil, block.ErrCASContentMismatch
+	}
+	synced, err := shs.IsSynced(ctx, hash)
+	if err != nil || !synced {
+		logger.Debug("self-heal: chunk not synced, cannot heal", "hash", hash)
+		if dm != nil {
+			dm.RecordSelfHealFailure(1)
+		}
+		return nil, block.ErrCASContentMismatch
+	}
+
+	// Drop the corrupt pointer so a subsequent Put can land cleanly.
+	if delErr := bs.local.Delete(ctx, hash); delErr != nil {
+		logger.Debug("self-heal: delete corrupt chunk failed", "hash", hash, "error", delErr)
+		// Non-fatal: proceed with the remote fetch regardless.
+	}
+
+	// Re-fetch from remote (dispatchRemoteFetch always blake3-verifies).
+	_, data, fetchErr := bs.syncer.dispatchRemoteFetch(ctx, fb)
+	if fetchErr != nil || data == nil {
+		logger.Debug("self-heal: remote fetch failed", "hash", hash, "error", fetchErr)
+		if dm != nil {
+			dm.RecordSelfHealFailure(1)
+		}
+		return nil, block.ErrCASContentMismatch
+	}
+
+	// Try to re-stage locally for future reads.
+	if putErr := bs.local.Put(ctx, hash, data); putErr != nil {
+		// Degraded: serve correct bytes but don't count as a full success.
+		logger.Debug("self-heal: local re-stage failed (degraded), serving bytes",
+			"hash", hash, "error", putErr)
+		if dm != nil {
+			dm.RecordSelfHealFailure(1)
+		}
+		return data, nil
+	}
+
+	// Full success: re-staged + synced marker updated.
+	bs.syncer.markFetchedSynced(ctx, hash)
+	if dm != nil {
+		dm.RecordSelfHealSuccess(1)
+	}
+	logger.Debug("self-heal: chunk repaired successfully", "hash", hash)
+	return data, nil
 }

--- a/pkg/block/engine/read_path_test.go
+++ b/pkg/block/engine/read_path_test.go
@@ -1,0 +1,233 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/compression"
+	"github.com/marmos91/dittofs/pkg/block/encryption"
+	"github.com/marmos91/dittofs/pkg/block/local/fs"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestReadPath_BlockLocator_Plaintext verifies that fetchResolvedBlock routes a
+// block-keyed locator through readChunkVerified and returns the original bytes.
+func TestReadPath_BlockLocator_Plaintext(t *testing.T) {
+	ctx := context.Background()
+	mem := remotememory.New()
+	f := newCarveFixture(t, mem, DefaultBlockCarveBytes)
+
+	data := bytes.Repeat([]byte("read-path-plain-"), 512)
+	h := f.storeChunk(t, ctx, data)
+
+	if err := f.syncer.carveFlush(ctx, true); err != nil {
+		t.Fatalf("carveFlush: %v", err)
+	}
+
+	loc, synced, err := f.ms.GetLocator(ctx, h)
+	if err != nil || !synced {
+		t.Fatalf("GetLocator: synced=%v err=%v", synced, err)
+	}
+	if loc.IsStandalone() {
+		t.Fatalf("expected block locator, got standalone: %+v", loc)
+	}
+
+	got, err := f.syncer.fetchResolvedBlock(ctx, &block.FileChunk{Hash: h})
+	if err != nil {
+		t.Fatalf("fetchResolvedBlock: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatal("fetchResolvedBlock round-trip mismatch (plaintext)")
+	}
+}
+
+// TestReadPath_BlockLocator_ThroughCompress verifies that fetchResolvedBlock
+// correctly reads back a chunk that was carved through a compressed remote.
+func TestReadPath_BlockLocator_ThroughCompress(t *testing.T) {
+	ctx := context.Background()
+	base := remotememory.New()
+	dec, err := compression.NewRemote(base, compression.CompressionPolicy{Algo: compression.AlgoZstd})
+	if err != nil {
+		t.Fatalf("compression.NewRemote: %v", err)
+	}
+	f := newCarveFixture(t, dec, DefaultBlockCarveBytes)
+
+	data := bytes.Repeat([]byte("XXXX-YYYY-ZZZZ-"), 4096)
+	h := f.storeChunk(t, ctx, data)
+
+	if err := f.syncer.carveFlush(ctx, true); err != nil {
+		t.Fatalf("carveFlush: %v", err)
+	}
+
+	loc, synced, lerr := f.ms.GetLocator(ctx, h)
+	if lerr != nil || !synced {
+		t.Fatalf("GetLocator: synced=%v err=%v", synced, lerr)
+	}
+	if loc.IsStandalone() {
+		t.Fatalf("expected block locator, got standalone: %+v", loc)
+	}
+
+	got, err := f.syncer.fetchResolvedBlock(ctx, &block.FileChunk{Hash: h})
+	if err != nil {
+		t.Fatalf("fetchResolvedBlock (compress): %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatal("fetchResolvedBlock round-trip mismatch (compressed remote)")
+	}
+}
+
+// TestReadPath_BlockLocator_ThroughCompressEncrypt verifies that fetchResolvedBlock
+// correctly reads back a chunk carved through a compression(encryption(base)) stack.
+func TestReadPath_BlockLocator_ThroughCompressEncrypt(t *testing.T) {
+	ctx := context.Background()
+	base := remotememory.New()
+	enc, err := encryption.NewRemote(base, encryption.EncryptionPolicy{AEAD: encryption.AEADAES256GCM}, newEncryptionProvider(t))
+	if err != nil {
+		t.Fatalf("encryption.NewRemote: %v", err)
+	}
+	dec, err := compression.NewRemote(enc, compression.CompressionPolicy{Algo: compression.AlgoZstd})
+	if err != nil {
+		t.Fatalf("compression.NewRemote: %v", err)
+	}
+	f := newCarveFixture(t, dec, DefaultBlockCarveBytes)
+
+	data := bytes.Repeat([]byte("secret-read-path-"), 1024)
+	h := f.storeChunk(t, ctx, data)
+
+	if err := f.syncer.carveFlush(ctx, true); err != nil {
+		t.Fatalf("carveFlush: %v", err)
+	}
+
+	loc, synced, lerr := f.ms.GetLocator(ctx, h)
+	if lerr != nil || !synced {
+		t.Fatalf("GetLocator: synced=%v err=%v", synced, lerr)
+	}
+	if loc.IsStandalone() {
+		t.Fatalf("expected block locator, got standalone: %+v", loc)
+	}
+
+	got, err := f.syncer.fetchResolvedBlock(ctx, &block.FileChunk{Hash: h})
+	if err != nil {
+		t.Fatalf("fetchResolvedBlock (compress+encrypt): %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatal("fetchResolvedBlock round-trip mismatch (compress+encrypt remote)")
+	}
+}
+
+// TestReadPath_CASBackCompat_StandaloneLocator verifies that a hash with no
+// recorded locator (standalone default) is read back through the CAS path.
+func TestReadPath_CASBackCompat_StandaloneLocator(t *testing.T) {
+	ctx := context.Background()
+	mem := remotememory.New()
+
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	local, err := fs.NewWithOptions(t.TempDir(), 0, nil, fs.FSStoreOptions{})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+	t.Cleanup(func() { _ = local.Close() })
+
+	syncer := NewSyncer(local, mem, ms, DefaultConfig())
+	syncer.SetSyncedHashStore(ms)
+
+	data := []byte("cas-back-compat-payload")
+	h := block.ContentHash(blake3.Sum256(data))
+
+	// Write directly to the CAS remote (simulates a pre-#1414 standalone upload).
+	if err := mem.Put(ctx, h, data); err != nil {
+		t.Fatalf("mem.Put: %v", err)
+	}
+	// Record a standalone locator (BlockID=="" → CAS path).
+	if err := ms.MarkSynced(ctx, h, block.ChunkLocator{}); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+
+	got, err := syncer.fetchResolvedBlock(ctx, &block.FileChunk{Hash: h})
+	if err != nil {
+		t.Fatalf("fetchResolvedBlock (CAS back-compat): %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatal("fetchResolvedBlock round-trip mismatch (CAS standalone)")
+	}
+}
+
+// TestReadPath_CorruptBlock_FailClosed verifies that readChunkVerified returns
+// ErrCASContentMismatch when the chunk is read back with the wrong expected hash.
+func TestReadPath_CorruptBlock_FailClosed(t *testing.T) {
+	ctx := context.Background()
+	mem := remotememory.New()
+	f := newCarveFixture(t, mem, DefaultBlockCarveBytes)
+
+	data := bytes.Repeat([]byte("corrupt-check-data-"), 256)
+	h := f.storeChunk(t, ctx, data)
+
+	if err := f.syncer.carveFlush(ctx, true); err != nil {
+		t.Fatalf("carveFlush: %v", err)
+	}
+
+	loc, synced, err := f.ms.GetLocator(ctx, h)
+	if err != nil || !synced {
+		t.Fatalf("GetLocator: synced=%v err=%v", synced, err)
+	}
+	if loc.IsStandalone() {
+		t.Fatalf("expected block locator, got standalone: %+v", loc)
+	}
+
+	// Build a wrong hash by flipping every byte of h.
+	var wrongHash block.ContentHash
+	for i, b := range h {
+		wrongHash[i] = ^b
+	}
+
+	_, err = f.syncer.readChunkVerified(ctx, loc, wrongHash)
+	if !errors.Is(err, block.ErrCASContentMismatch) {
+		t.Fatalf("readChunkVerified with wrong hash: want ErrCASContentMismatch, got %v", err)
+	}
+}
+
+// noChunkReaderRemote wraps a RemoteStore but hides the ChunkReader interface,
+// so readChunkVerified must return ErrChunkReadUnsupported.
+type noChunkReaderRemote struct{ remote.RemoteStore }
+
+// TestReadPath_NoChunkReader_FailsClosed verifies that readChunkVerified returns
+// ErrChunkReadUnsupported when the remote store does not implement ChunkReader.
+func TestReadPath_NoChunkReader_FailsClosed(t *testing.T) {
+	ctx := context.Background()
+	base := remotememory.New()
+
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	local, err := fs.NewWithOptions(t.TempDir(), 0, nil, fs.FSStoreOptions{LocalChunkIndex: ms})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+	t.Cleanup(func() { _ = local.Close() })
+
+	// Wrap the remote in a type that hides ChunkReader.
+	stripped := noChunkReaderRemote{base}
+	syncer := NewSyncer(local, stripped, ms, DefaultConfig())
+	syncer.SetSyncedHashStore(ms)
+	// Do NOT wire a RemoteBlockStore: carve stays disabled, which is fine —
+	// we call readChunkVerified directly.
+
+	data := []byte("no-chunk-reader-payload")
+	h := block.ContentHash(blake3.Sum256(data))
+
+	// Record a block locator for h — not standalone — to force the block-read branch.
+	blockLoc := block.ChunkLocator{BlockID: "fake-block", WireOffset: 10, WireLength: 20}
+	if err := ms.MarkSynced(ctx, h, blockLoc); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+
+	_, err = syncer.readChunkVerified(ctx, blockLoc, h)
+	if !errors.Is(err, remote.ErrChunkReadUnsupported) {
+		t.Fatalf("readChunkVerified without ChunkReader: want ErrChunkReadUnsupported, got %v", err)
+	}
+}

--- a/pkg/block/engine/readthrough_torntail_test.go
+++ b/pkg/block/engine/readthrough_torntail_test.go
@@ -1,0 +1,139 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/local/fs"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestReadThrough_TornTail_RecoversFromRemote is the ITEM-1 durability
+// regression: a chunk staged into the log-blob by the read-through cache
+// (FSStore.Put) is remote-durable, but its local index entry is committed
+// WITHOUT fsyncing the blob. A crash in that window leaves a durable index
+// entry pointing at un-fsynced blob bytes.
+//
+// Modelled by staging via Put, marking the chunk synced + remote-durable, then
+// truncating the blob file (index survives, bytes lost). A subsequent read must
+// RECOVER byte-identical from the authoritative remote copy — not hard-error
+// and not silently return zeros.
+func TestReadThrough_TornTail_RecoversFromRemote(t *testing.T) {
+	ctx := context.Background()
+
+	// One memory metadata store backs the FileChunk manifest, the local chunk
+	// index, and the synced-hash store, so the read path and the recovery path
+	// agree on a single source of truth (as they do in production).
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
+		LocalChunkIndex: ms,
+	})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+
+	remoteRS := &countingRemoteStore{Store: remotememory.New()}
+	syncer := NewSyncer(localStore, remoteRS, ms, DefaultConfig())
+	bs, err := New(BlockStoreConfig{
+		Local:           localStore,
+		Remote:          remoteRS,
+		Syncer:          syncer,
+		FileChunkStore:  ms,
+		SyncedHashStore: ms,
+	})
+	if err != nil {
+		t.Fatalf("engine.New: %v", err)
+	}
+	if err := bs.Start(ctx); err != nil {
+		t.Fatalf("engine.Start: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+
+	data := bytes.Repeat([]byte("read-through-recovery!"), 512) // ~11 KiB
+	hash := block.ContentHash(blake3.Sum256(data))
+	payloadID := "p-recover"
+
+	// Seed the remote with the authoritative copy and mark the chunk synced
+	// (standalone locator) — exactly what the read-through path does after a
+	// remote fetch (markFetchedSynced).
+	if err := remoteRS.Put(ctx, hash, data); err != nil {
+		t.Fatalf("remote Put: %v", err)
+	}
+	if err := ms.MarkSynced(ctx, hash, block.ChunkLocator{}); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+
+	// Stage locally via Put (the read-through cache's write entry): appends to
+	// the log-blob and commits a durable index entry.
+	if err := localStore.Put(ctx, hash, data); err != nil {
+		t.Fatalf("local Put (stage): %v", err)
+	}
+
+	// Manifest row so the read path can resolve (payloadID, offset 0) -> hash.
+	fb := &block.FileChunk{
+		ID:       payloadID + "/0",
+		Hash:     hash,
+		DataSize: uint32(len(data)),
+		State:    block.BlockStatePending,
+	}
+	if err := ms.Put(ctx, fb); err != nil {
+		t.Fatalf("FileChunk Put: %v", err)
+	}
+
+	// Sanity: reads correctly before the tear.
+	pre := make([]byte, len(data))
+	if n, err := bs.readAtInternal(ctx, payloadID, pre, 0); err != nil || n != len(data) || !bytes.Equal(pre, data) {
+		t.Fatalf("pre-tear read: n=%d err=%v equal=%v", n, err, bytes.Equal(pre, data))
+	}
+
+	// Simulate the crash: truncate the active blob so the staged bytes are
+	// gone, while the durable index entry survives.
+	truncateAllBlobs(t, localStore)
+
+	// The read must recover byte-identical from the remote copy.
+	dest := make([]byte, len(data))
+	n, err := bs.readAtInternal(ctx, payloadID, dest, 0)
+	if err != nil {
+		t.Fatalf("post-tear read hard-errored (availability bug): %v", err)
+	}
+	if n != len(data) {
+		t.Fatalf("post-tear read n=%d, want %d", n, len(data))
+	}
+	if !bytes.Equal(dest, data) {
+		t.Fatalf("post-tear read not byte-identical to remote copy (zeros/garbage?): recovered %d bytes", len(dest))
+	}
+	if got := remoteRS.readVerifiedCount.Load(); got == 0 {
+		t.Fatal("recovery did not consult the remote store — read did not self-heal from remote")
+	}
+}
+
+// truncateAllBlobs zeroes every .blob file under the fs store's blobs directory,
+// modelling a torn tail where appended-but-un-fsynced bytes are lost on crash.
+func truncateAllBlobs(t *testing.T, localStore *fs.FSStore) {
+	t.Helper()
+	blobsDir := filepath.Join(localStore.BaseDirForTest(), "blobs")
+	entries, err := os.ReadDir(blobsDir)
+	if err != nil {
+		t.Fatalf("read blobs dir: %v", err)
+	}
+	truncated := false
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".blob" {
+			if err := os.Truncate(filepath.Join(blobsDir, e.Name()), 0); err != nil {
+				t.Fatalf("truncate blob %s: %v", e.Name(), err)
+			}
+			truncated = true
+		}
+	}
+	if !truncated {
+		t.Fatal("no .blob file found to truncate")
+	}
+}

--- a/pkg/block/engine/selfheal_test.go
+++ b/pkg/block/engine/selfheal_test.go
@@ -133,26 +133,6 @@ func setStubMetrics(bs *Store, sm *stubMetrics) {
 	bs.metrics.Store(&dm)
 }
 
-// seedChunk puts chunkData into the local store and registers a FileChunk row
-// with the given payloadID.  Returns the BLAKE3 content hash of chunkData.
-func seedChunk(t *testing.T, ctx context.Context, fbs *stubFileChunkStore, localStore local.LocalStore, payloadID string, chunkData []byte) block.ContentHash {
-	t.Helper()
-	hash := block.ContentHash(blake3.Sum256(chunkData))
-	if err := localStore.Put(ctx, hash, chunkData); err != nil {
-		t.Fatalf("seedChunk: local.Put: %v", err)
-	}
-	fb := &block.FileChunk{
-		ID:       payloadID + "/0",
-		Hash:     hash,
-		DataSize: uint32(len(chunkData)),
-		State:    block.BlockStatePending,
-	}
-	if err := fbs.Put(ctx, fb); err != nil {
-		t.Fatalf("seedChunk: fbs.Put: %v", err)
-	}
-	return hash
-}
-
 // ===== Tests =====
 
 // TestReadLocalByHash_LocalCorruption_SyncedSelfHeals verifies that a corrupt
@@ -346,6 +326,73 @@ func TestReadChunkVerified_RemoteCorruption_RecordsMetric(t *testing.T) {
 
 	if got := sm.remoteCorruptions.Load(); got != 1 {
 		t.Errorf("remoteCorruptions = %d, want 1", got)
+	}
+}
+
+// TestReadLocalByHash_LocalCorrupt_SyncedButRemoteAlsoCorrupt covers the
+// combined failure path: a corrupt local chunk that IS synced but whose remote
+// block copy is ALSO corrupt must fail closed (ErrCASContentMismatch), never
+// serve corrupt bytes, and record one local corruption, one remote corruption,
+// and one self-heal failure.
+func TestReadLocalByHash_LocalCorrupt_SyncedButRemoteAlsoCorrupt(t *testing.T) {
+	ctx := context.Background()
+	correctData := []byte("heal path but remote also corrupt")
+	garbageData := []byte("remote-garbage-yyyy")
+	correctHash := block.ContentHash(blake3.Sum256(correctData))
+
+	inner := memory.New()
+	corruptLocal := newCorruptingGetLocalStore(inner, correctHash)
+	remoteRS := &countingRemoteStore{Store: remotememory.New()}
+	shs := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+
+	// Local holds (corrupt-on-Get) bytes; the remote block holds GARBAGE.
+	if err := inner.Put(ctx, correctHash, correctData); err != nil {
+		t.Fatalf("Put local: %v", err)
+	}
+	if err := remoteRS.PutBlock(ctx, "blkbad", bytes.NewReader(garbageData)); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+	// Synced with a block locator pointing at the garbage block.
+	loc := block.ChunkLocator{BlockID: "blkbad", WireOffset: 0, WireLength: int64(len(garbageData))}
+	if err := shs.MarkSynced(ctx, correctHash, loc); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+
+	bs := newTestEngineWithRemoteAndSHS(t, corruptLocal, remoteRS, shs)
+	sm := &stubMetrics{}
+	setStubMetrics(bs, sm)
+
+	payloadID := "p5"
+	fb := &block.FileChunk{
+		ID:       payloadID + "/0",
+		Hash:     correctHash,
+		DataSize: uint32(len(correctData)),
+		State:    block.BlockStatePending,
+	}
+	if err := bs.syncer.fileChunkStore.Put(ctx, fb); err != nil {
+		t.Fatalf("fbs.Put: %v", err)
+	}
+
+	dest := make([]byte, len(correctData))
+	found, err := bs.readLocalByHash(ctx, payloadID, dest, 0)
+	if found {
+		t.Fatal("readLocalByHash returned found=true; expected false (fail-closed, remote also corrupt)")
+	}
+	if !errors.Is(err, block.ErrCASContentMismatch) {
+		t.Fatalf("error = %v; want ErrCASContentMismatch", err)
+	}
+
+	if got := sm.localCorruptions.Load(); got != 1 {
+		t.Errorf("localCorruptions = %d, want 1", got)
+	}
+	if got := sm.remoteCorruptions.Load(); got != 1 {
+		t.Errorf("remoteCorruptions = %d, want 1", got)
+	}
+	if got := sm.selfHealFailures.Load(); got != 1 {
+		t.Errorf("selfHealFailures = %d, want 1", got)
+	}
+	if got := sm.selfHealSuccesses.Load(); got != 0 {
+		t.Errorf("selfHealSuccesses = %d, want 0", got)
 	}
 }
 

--- a/pkg/block/engine/selfheal_test.go
+++ b/pkg/block/engine/selfheal_test.go
@@ -1,0 +1,392 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/local"
+	"github.com/marmos91/dittofs/pkg/block/local/memory"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// ===== stubMetrics =====
+
+// stubMetrics counts calls to the 5 new DataplaneMetrics methods.
+// All 11 DataplaneMetrics methods are implemented; the 6 legacy ones are no-ops.
+type stubMetrics struct {
+	localCorruptions  atomic.Int32
+	selfHealSuccesses atomic.Int32
+	selfHealFailures  atomic.Int32
+	remoteCorruptions atomic.Int32
+	blockRangeReads   atomic.Int32
+	blockRangeBytes   atomic.Int64
+}
+
+// Legacy 6 methods — no-ops.
+func (s *stubMetrics) RecordUpload(_ int, _ string, _ time.Duration) {}
+func (s *stubMetrics) UploadStarted()                                {}
+func (s *stubMetrics) UploadFinished()                               {}
+func (s *stubMetrics) SetUploadQueueDepth(_ int)                     {}
+func (s *stubMetrics) SetUploadWindow(_ int)                         {}
+func (s *stubMetrics) RecordRehash(_ time.Duration)                  {}
+
+// New 5 methods — increment counters.
+func (s *stubMetrics) RecordLocalCorruption(n int)  { s.localCorruptions.Add(int32(n)) }
+func (s *stubMetrics) RecordSelfHealSuccess(n int)  { s.selfHealSuccesses.Add(int32(n)) }
+func (s *stubMetrics) RecordSelfHealFailure(n int)  { s.selfHealFailures.Add(int32(n)) }
+func (s *stubMetrics) RecordRemoteCorruption(n int) { s.remoteCorruptions.Add(int32(n)) }
+func (s *stubMetrics) RecordBlockRangeRead(bytes int) {
+	s.blockRangeReads.Add(1)
+	s.blockRangeBytes.Add(int64(bytes))
+}
+
+// ===== corruptingGetLocalStore =====
+
+// corruptingGetLocalStore wraps a local.LocalStore and returns garbage bytes for
+// specified hashes on Get.  Delete removes the hash from the corruption set (and
+// delegates to the underlying store), so after a self-heal the re-Put chunk can
+// be read back cleanly.  Put is promoted unchanged from the embedded interface.
+type corruptingGetLocalStore struct {
+	local.LocalStore
+	mu            sync.Mutex
+	corruptHashes map[block.ContentHash]struct{}
+}
+
+func newCorruptingGetLocalStore(inner local.LocalStore, corrupt ...block.ContentHash) *corruptingGetLocalStore {
+	m := make(map[block.ContentHash]struct{}, len(corrupt))
+	for _, h := range corrupt {
+		m[h] = struct{}{}
+	}
+	return &corruptingGetLocalStore{LocalStore: inner, corruptHashes: m}
+}
+
+func (c *corruptingGetLocalStore) Get(ctx context.Context, h block.ContentHash) ([]byte, error) {
+	c.mu.Lock()
+	_, bad := c.corruptHashes[h]
+	c.mu.Unlock()
+	if bad {
+		return []byte("corrupt-garbage-xxxx"), nil
+	}
+	return c.LocalStore.Get(ctx, h)
+}
+
+func (c *corruptingGetLocalStore) Delete(ctx context.Context, h block.ContentHash) error {
+	c.mu.Lock()
+	delete(c.corruptHashes, h)
+	c.mu.Unlock()
+	return c.LocalStore.Delete(ctx, h)
+}
+
+// ===== countingRemoteStore =====
+
+// countingRemoteStore wraps *remotememory.Store and counts ReadBlockVerified calls.
+type countingRemoteStore struct {
+	*remotememory.Store
+	readVerifiedCount atomic.Int32
+}
+
+func (s *countingRemoteStore) ReadBlockVerified(ctx context.Context, hash, expected block.ContentHash) ([]byte, error) {
+	s.readVerifiedCount.Add(1)
+	return s.Store.ReadBlockVerified(ctx, hash, expected)
+}
+
+// ===== newTestEngineWithRemoteAndSHS =====
+
+// newTestEngineWithRemoteAndSHS creates a Store wired with a remote store and a
+// SyncedHashStore, for the self-heal path tests.  The caller provides the local
+// store (possibly a corruptingGetLocalStore wrapper) and the remote / SHS.
+func newTestEngineWithRemoteAndSHS(t *testing.T, localStore local.LocalStore, remote *countingRemoteStore, shs metadata.SyncedHashStore) *Store {
+	t.Helper()
+	fbs := newStubFileChunkStore()
+	syncer := NewSyncer(localStore, remote, fbs, DefaultConfig())
+	bs, err := New(BlockStoreConfig{
+		Local:           localStore,
+		Remote:          remote,
+		Syncer:          syncer,
+		FileChunkStore:  fbs,
+		SyncedHashStore: shs,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := bs.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+	return bs
+}
+
+// setStubMetrics wires sm as the engine's dataplane metrics sink.
+// Uses the package-private metrics field directly (same package).
+func setStubMetrics(bs *Store, sm *stubMetrics) {
+	var dm DataplaneMetrics = sm
+	bs.metrics.Store(&dm)
+}
+
+// seedChunk puts chunkData into the local store and registers a FileChunk row
+// with the given payloadID.  Returns the BLAKE3 content hash of chunkData.
+func seedChunk(t *testing.T, ctx context.Context, fbs *stubFileChunkStore, localStore local.LocalStore, payloadID string, chunkData []byte) block.ContentHash {
+	t.Helper()
+	hash := block.ContentHash(blake3.Sum256(chunkData))
+	if err := localStore.Put(ctx, hash, chunkData); err != nil {
+		t.Fatalf("seedChunk: local.Put: %v", err)
+	}
+	fb := &block.FileChunk{
+		ID:       payloadID + "/0",
+		Hash:     hash,
+		DataSize: uint32(len(chunkData)),
+		State:    block.BlockStatePending,
+	}
+	if err := fbs.Put(ctx, fb); err != nil {
+		t.Fatalf("seedChunk: fbs.Put: %v", err)
+	}
+	return hash
+}
+
+// ===== Tests =====
+
+// TestReadLocalByHash_LocalCorruption_SyncedSelfHeals verifies that a corrupt
+// local chunk is transparently replaced from the remote store, the read returns
+// correct data, and metrics counters are incremented once.  A second read after
+// the heal must NOT trigger another remote fetch.
+func TestReadLocalByHash_LocalCorruption_SyncedSelfHeals(t *testing.T) {
+	ctx := context.Background()
+	correctData := []byte("hello self-heal world")
+
+	// Build stores.
+	inner := memory.New()
+	correctHash := block.ContentHash(blake3.Sum256(correctData))
+	corruptLocal := newCorruptingGetLocalStore(inner, correctHash)
+	remoteRS := &countingRemoteStore{Store: remotememory.New()}
+	shs := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+
+	// Seed: put correct bytes in both local (via inner) and remote.
+	if err := inner.Put(ctx, correctHash, correctData); err != nil {
+		t.Fatalf("Put local: %v", err)
+	}
+	if err := remoteRS.Put(ctx, correctHash, correctData); err != nil {
+		t.Fatalf("Put remote: %v", err)
+	}
+	// Mark synced (standalone locator).
+	if err := shs.MarkSynced(ctx, correctHash, block.ChunkLocator{}); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+
+	// Build engine with the corrupting local store.
+	bs := newTestEngineWithRemoteAndSHS(t, corruptLocal, remoteRS, shs)
+
+	// Wire stub metrics.
+	sm := &stubMetrics{}
+	setStubMetrics(bs, sm)
+
+	// Populate fileChunkStore directly — engine wires the emitter to it via New,
+	// but we bypassed the write path.  Access the engine's fcs via the syncer.
+	payloadID := "p1"
+	fb := &block.FileChunk{
+		ID:       payloadID + "/0",
+		Hash:     correctHash,
+		DataSize: uint32(len(correctData)),
+		State:    block.BlockStatePending,
+	}
+	if err := bs.syncer.fileChunkStore.Put(ctx, fb); err != nil {
+		t.Fatalf("fbs.Put: %v", err)
+	}
+
+	// First read: should detect corruption, self-heal, and return correct data.
+	dest := make([]byte, len(correctData))
+	found, err := bs.readLocalByHash(ctx, payloadID, dest, 0)
+	if err != nil {
+		t.Fatalf("readLocalByHash returned error: %v", err)
+	}
+	if !found {
+		t.Fatal("readLocalByHash returned found=false; expected found=true after self-heal")
+	}
+	if !bytes.Equal(dest, correctData) {
+		t.Fatalf("data mismatch: got %q, want %q", dest, correctData)
+	}
+
+	// Metrics after first read.
+	if got := sm.localCorruptions.Load(); got != 1 {
+		t.Errorf("localCorruptions = %d, want 1", got)
+	}
+	if got := sm.selfHealSuccesses.Load(); got != 1 {
+		t.Errorf("selfHealSuccesses = %d, want 1", got)
+	}
+	if got := sm.selfHealFailures.Load(); got != 0 {
+		t.Errorf("selfHealFailures = %d, want 0", got)
+	}
+	if got := remoteRS.readVerifiedCount.Load(); got != 1 {
+		t.Errorf("remote readVerifiedCount after first read = %d, want 1", got)
+	}
+
+	// Second read: corruption set cleared, local store has correct bytes — no extra fetch.
+	dest2 := make([]byte, len(correctData))
+	found2, err2 := bs.readLocalByHash(ctx, payloadID, dest2, 0)
+	if err2 != nil {
+		t.Fatalf("second readLocalByHash returned error: %v", err2)
+	}
+	if !found2 {
+		t.Fatal("second readLocalByHash returned found=false; expected true")
+	}
+	if !bytes.Equal(dest2, correctData) {
+		t.Fatalf("second read data mismatch: got %q, want %q", dest2, correctData)
+	}
+	if got := remoteRS.readVerifiedCount.Load(); got != 1 {
+		t.Errorf("remote readVerifiedCount after second read = %d, want 1 (no extra fetch)", got)
+	}
+}
+
+// TestReadLocalByHash_LocalCorruption_UnsyncedFailClosed verifies that a corrupt
+// unsynced chunk causes a fail-closed error (no remote fetch attempted).
+func TestReadLocalByHash_LocalCorruption_UnsyncedFailClosed(t *testing.T) {
+	ctx := context.Background()
+	correctData := []byte("unsynced chunk data")
+
+	inner := memory.New()
+	correctHash := block.ContentHash(blake3.Sum256(correctData))
+	corruptLocal := newCorruptingGetLocalStore(inner, correctHash)
+	remoteRS := &countingRemoteStore{Store: remotememory.New()}
+	shs := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+
+	// Seed local only — do NOT MarkSynced.
+	if err := inner.Put(ctx, correctHash, correctData); err != nil {
+		t.Fatalf("Put local: %v", err)
+	}
+
+	bs := newTestEngineWithRemoteAndSHS(t, corruptLocal, remoteRS, shs)
+	sm := &stubMetrics{}
+	setStubMetrics(bs, sm)
+
+	payloadID := "p2"
+	fb := &block.FileChunk{
+		ID:       payloadID + "/0",
+		Hash:     correctHash,
+		DataSize: uint32(len(correctData)),
+		State:    block.BlockStatePending,
+	}
+	if err := bs.syncer.fileChunkStore.Put(ctx, fb); err != nil {
+		t.Fatalf("fbs.Put: %v", err)
+	}
+
+	dest := make([]byte, len(correctData))
+	found, err := bs.readLocalByHash(ctx, payloadID, dest, 0)
+	if found {
+		t.Fatal("readLocalByHash returned found=true; expected false (fail-closed)")
+	}
+	if !errors.Is(err, block.ErrCASContentMismatch) {
+		t.Fatalf("error = %v; want ErrCASContentMismatch", err)
+	}
+
+	if got := sm.localCorruptions.Load(); got != 1 {
+		t.Errorf("localCorruptions = %d, want 1", got)
+	}
+	if got := sm.selfHealFailures.Load(); got != 1 {
+		t.Errorf("selfHealFailures = %d, want 1", got)
+	}
+	if got := sm.selfHealSuccesses.Load(); got != 0 {
+		t.Errorf("selfHealSuccesses = %d, want 0", got)
+	}
+	if got := remoteRS.readVerifiedCount.Load(); got != 0 {
+		t.Errorf("remote readVerifiedCount = %d, want 0 (no fetch for unsynced)", got)
+	}
+}
+
+// TestReadChunkVerified_RemoteCorruption_RecordsMetric verifies that a remote
+// chunk whose bytes don't match the expected BLAKE3 hash records a remote
+// corruption metric and returns ErrCASContentMismatch.
+func TestReadChunkVerified_RemoteCorruption_RecordsMetric(t *testing.T) {
+	ctx := context.Background()
+
+	// Correct and garbage bytes.
+	correctData := []byte("hello")
+	garbageData := []byte("garb!")
+	correctHash := block.ContentHash(blake3.Sum256(correctData))
+
+	// Build remote with garbage stored at blockID "blk1".
+	remoteRS := &countingRemoteStore{Store: remotememory.New()}
+	if err := remoteRS.PutBlock(ctx, "blk1", bytes.NewReader(garbageData)); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+
+	// SHS: mark correctHash synced with a block locator pointing to blk1.
+	shs := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	loc := block.ChunkLocator{BlockID: "blk1", WireOffset: 0, WireLength: int64(len(garbageData))}
+	if err := shs.MarkSynced(ctx, correctHash, loc); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+
+	inner := memory.New()
+	bs := newTestEngineWithRemoteAndSHS(t, inner, remoteRS, shs)
+	sm := &stubMetrics{}
+	setStubMetrics(bs, sm)
+
+	// FileChunk whose Hash is blake3(correctData) — the expected hash.
+	fb := &block.FileChunk{
+		ID:       "p3/0",
+		Hash:     correctHash,
+		DataSize: uint32(len(correctData)),
+		State:    block.BlockStatePending,
+	}
+
+	// dispatchRemoteFetch: resolves block locator → readChunkVerified → mismatch.
+	_, _, err := bs.syncer.dispatchRemoteFetch(ctx, fb)
+	if !errors.Is(err, block.ErrCASContentMismatch) {
+		t.Fatalf("error = %v; want ErrCASContentMismatch", err)
+	}
+
+	if got := sm.remoteCorruptions.Load(); got != 1 {
+		t.Errorf("remoteCorruptions = %d, want 1", got)
+	}
+}
+
+// TestReadLocalByHash_NilMetrics_NocrashWithCorruption verifies that corrupt
+// unsynced chunks fail cleanly even when no metrics recorder is wired.
+func TestReadLocalByHash_NilMetrics_NocrashWithCorruption(t *testing.T) {
+	ctx := context.Background()
+	correctData := []byte("unsynced no metrics")
+
+	inner := memory.New()
+	correctHash := block.ContentHash(blake3.Sum256(correctData))
+	corruptLocal := newCorruptingGetLocalStore(inner, correctHash)
+	remoteRS := &countingRemoteStore{Store: remotememory.New()}
+	shs := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+
+	if err := inner.Put(ctx, correctHash, correctData); err != nil {
+		t.Fatalf("Put local: %v", err)
+	}
+
+	// No MarkSynced — unsynced chunk.
+	bs := newTestEngineWithRemoteAndSHS(t, corruptLocal, remoteRS, shs)
+	// Do NOT wire any metrics — bs.metrics remains nil.
+
+	payloadID := "p4"
+	fb := &block.FileChunk{
+		ID:       payloadID + "/0",
+		Hash:     correctHash,
+		DataSize: uint32(len(correctData)),
+		State:    block.BlockStatePending,
+	}
+	if err := bs.syncer.fileChunkStore.Put(ctx, fb); err != nil {
+		t.Fatalf("fbs.Put: %v", err)
+	}
+
+	dest := make([]byte, len(correctData))
+	found, err := bs.readLocalByHash(ctx, payloadID, dest, 0)
+	if found {
+		t.Fatal("readLocalByHash returned found=true; expected false")
+	}
+	if !errors.Is(err, block.ErrCASContentMismatch) {
+		t.Fatalf("error = %v; want ErrCASContentMismatch", err)
+	}
+	// If we reach here without panicking, the nil-metrics guard works.
+}

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -156,6 +156,69 @@ type Syncer struct {
 	// compute goodput and the error flag. Plain atomics — no lock needed.
 	uploadedBytesWindow atomic.Int64
 	uploadErrWindow     atomic.Int64
+
+	// --- block carve path (#1414 object packing) ---
+
+	// remoteBlockStore is the block-keyed remote (PutBlock) the carver uploads
+	// packed blocks to. nil disables carve and the legacy per-hash mirror stays
+	// in effect. Wired via SetRemoteBlockStore; guarded by m.mu.
+	remoteBlockStore remote.RemoteBlockStore
+	// chunkSealer applies the per-chunk compression/encryption transform before
+	// a chunk is framed into a block. Derived from remoteBlockStore (the same
+	// decorated remote); nil means identity (raw) sealing. Guarded by m.mu.
+	chunkSealer remote.ChunkSealer
+	// blockCommitter atomically persists the block record + local locations +
+	// synced markers (DefaultCommitBlock) and resolves a chunk's log-blob
+	// location (GetLocalLocation). It is the per-share metadata store; nil
+	// disables carve. Guarded by m.mu.
+	blockCommitter blockCommitter
+	// localBlobReader reads a chunk's raw bytes from the local log-blob
+	// substrate (FSStore). nil disables carve. Asserted from m.local at
+	// construction; guarded by m.mu only for read symmetry with the others.
+	localBlobReader localBlobReader
+
+	// carveActive mirrors "all carve deps wired AND a remote exists" as an
+	// atomic so addPendingHash (under pendingMu) can decide carve-vs-legacy
+	// routing without taking m.mu — the same pendingMu→m.mu avoidance the
+	// hasRemote atomic provides for the dispatcher. Recomputed by the setters.
+	carveActive atomic.Bool
+
+	// pendingCarveHashes holds log-blob-resident chunks awaiting carve into a
+	// block, keyed by hash → raw byte size. DISJOINT from pendingHashes (legacy
+	// CAS mirror): a freshly-completed hash routes to exactly one set based on
+	// carveActive at addPendingHash time, so a log-blob hash never reaches the
+	// legacy mirrorChunk path (which would standalone-Put it). carveQ is the
+	// FIFO insertion order the carver drains. Both guarded by pendingMu.
+	pendingCarveHashes map[block.ContentHash]int64
+	carveQ             []block.ContentHash
+
+	// carveWake nudges the carve dispatcher that a chunk is ready (non-blocking,
+	// coalescing, buffered len 1) so packing overlaps later writes.
+	carveWake chan struct{}
+	// carveMu serializes carve flushes so the background dispatcher and an
+	// explicit Flush/SyncNow never build a block from the same chunk twice.
+	carveMu gosync.Mutex
+}
+
+// blockCommitter is the narrow consumer-side slice of metadata.Store the carver
+// needs: transactional block-record commit (DefaultCommitBlock takes a
+// Transactor+SyncedHashStore), the synced-marker writes it performs, and the
+// local-chunk-index lookup that resolves a hash to its log-blob position. The
+// production per-share metadata store satisfies all three; defining it here
+// keeps the engine off the wider metadata.Store surface.
+type blockCommitter interface {
+	metadata.Transactor
+	metadata.SyncedHashStore
+	metadata.LocalChunkIndex
+}
+
+// localBlobReader is the narrow consumer-side capability the carver needs from
+// the local store: read a chunk's raw bytes from the log-blob substrate at a
+// known location. *fs.FSStore satisfies it via a thin delegation to its
+// log-blob Manager. Kept off local.LocalStore so non-log-blob backends compile
+// unchanged (the carver is simply disabled for them).
+type localBlobReader interface {
+	ReadLocalAt(ctx context.Context, loc block.LocalChunkLocation, dst []byte) (int, error)
 }
 
 // addPendingHash registers a newly-stored CAS hash (of the given on-disk
@@ -164,6 +227,16 @@ type Syncer struct {
 // use; O(1). Charges unsyncedBytes once per distinct hash — re-adding a hash
 // already pending updates the recorded size but does not double-count.
 func (m *Syncer) addPendingHash(h block.ContentHash, size int64) {
+	// Carve routing (#1414): when the block-carve substrate is fully wired the
+	// chunk is log-blob-resident, so it routes to the DISJOINT pendingCarveHashes
+	// set (packed into a block) instead of pendingHashes (legacy standalone CAS
+	// mirror). The two sets never overlap, so a log-blob hash never reaches
+	// mirrorChunk's CAS Get. carveActive is an atomic read — no m.mu under
+	// pendingMu — mirroring dispatcherEnabled's hasRemote read.
+	if m.carveActive.Load() {
+		m.addPendingCarveHash(h, size)
+		return
+	}
 	m.pendingMu.Lock()
 	// prev is the zero value (0) when the hash is new, so size-prev charges
 	// the full size on first insert and only the delta on re-add — never
@@ -305,6 +378,16 @@ func (m *Syncer) UnsyncedBytes() int64 {
 // pending set is volatile, so chunks written-but-not-synced before a crash
 // must be rediscovered) and periodically as a slow drift reconciler, NOT
 // on every mirror tick. Returns the number of hashes seeded.
+//
+// Restart-seed coverage of unsynced LOG-BLOB chunks is not yet guaranteed:
+// ListUnsynced enumerates log-blob chunks only on index backends that implement
+// local-location walking, so on the production backends an unsynced log-blob
+// chunk written just before a crash is not re-queued for carve here. The chunk
+// is durable locally (its blob is fsynced before the rollup fence advances), so
+// no data is lost; full cross-backend restart-seed via blob-index enumeration
+// is handled by the block GC/enumeration work. addPendingHash still routes any
+// seeded hash to the carve set when the carve substrate is active, so a
+// log-blob hash never lands in the legacy CAS mirror set.
 func (m *Syncer) seedPendingFromDisk(ctx context.Context) (int, error) {
 	n := 0
 	for hash, err := range m.local.ListUnsynced(ctx) {
@@ -372,8 +455,17 @@ func NewSyncer(local local.LocalStore, remoteStore remote.RemoteStore, fileChunk
 		gate:             newUploadGate(),
 		uploadLimiter:    newDynamicSemaphore(startWindow),
 		uploadController: uploadController,
+
+		pendingCarveHashes: make(map[block.ContentHash]int64),
+		carveWake:          make(chan struct{}, 1),
 	}
 	m.hasRemote.Store(remoteStore != nil)
+	// The local store provides the carve read path only if it exposes the
+	// log-blob substrate; non-log-blob backends leave the carver disabled.
+	if r, ok := local.(localBlobReader); ok {
+		m.localBlobReader = r
+	}
+	m.recomputeCarveActive()
 
 	queueConfig := DefaultSyncQueueConfig()
 	// In adaptive mode the queue pool must cover the ceiling the controller can
@@ -397,6 +489,48 @@ func (m *Syncer) SetSyncedHashStore(s metadata.SyncedHashStore) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.syncedHashStore = s
+	// The same per-share metadata store backs the block carver's atomic commit
+	// (DefaultCommitBlock) and log-blob location lookup. Derive blockCommitter
+	// here so the carve wiring rides the existing SetSyncedHashStore call; a
+	// store that is only a bare SyncedHashStore (test fixture) leaves carve
+	// disabled.
+	if bc, ok := s.(blockCommitter); ok {
+		m.blockCommitter = bc
+	} else {
+		m.blockCommitter = nil
+	}
+	m.recomputeCarveActive()
+}
+
+// SetRemoteBlockStore wires the block-keyed remote (PutBlock) the carver
+// uploads packed blocks to, and derives the per-chunk ChunkSealer from the same
+// (possibly decorated) remote. Placed beside SetSyncedHashStore in the wiring
+// sequence. A nil rbs — or a remote that does not implement RemoteBlockStore —
+// leaves carve disabled, so the legacy per-hash mirror path stays in effect for
+// non-block remotes. Idempotent; safe to call before Start.
+func (m *Syncer) SetRemoteBlockStore(rbs remote.RemoteBlockStore) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.remoteBlockStore = rbs
+	if cs, ok := rbs.(remote.ChunkSealer); ok {
+		m.chunkSealer = cs
+	} else {
+		m.chunkSealer = nil
+	}
+	m.recomputeCarveActive()
+}
+
+// recomputeCarveActive refreshes the carveActive routing flag from the carve
+// dependencies. Caller must hold m.mu (or be the single-threaded constructor).
+// Carve routing does NOT gate on ManualSync: in manual mode the background
+// carver is suppressed but explicit Flush/SyncNow still drains the carve set,
+// so log-blob chunks must still route to it.
+func (m *Syncer) recomputeCarveActive() {
+	active := m.remoteBlockStore != nil &&
+		m.blockCommitter != nil &&
+		m.localBlobReader != nil &&
+		m.hasRemote.Load()
+	m.carveActive.Store(active)
 }
 
 // SetHealthCallback sets the callback invoked when the remote store health state changes.
@@ -534,6 +668,16 @@ func (m *Syncer) Flush(ctx context.Context, payloadID string) (*block.FlushResul
 	if m.remoteStore == nil || !m.IsRemoteHealthy() {
 		return &block.FlushResult{Finalized: false}, nil
 	}
+
+	// Drain the block-carve set (#1414): pack every pending log-blob chunk into
+	// block objects and commit them. Independent of the legacy upload gate —
+	// carve and the standalone CAS mirror operate on disjoint hash sets — so it
+	// runs on every Flush regardless of dispatcher contention. A non-empty carve
+	// backlog with a wired substrate makes Flush the explicit durability driver.
+	if err := m.carveFlush(ctx, true); err != nil {
+		return nil, err
+	}
+
 	// Serialize the explicit mirror against any other explicit drain and against
 	// the continuous upload dispatcher. The gate is taken non-blocking: if
 	// another explicit drain holds it, or dispatcher uploads are in flight, this
@@ -1047,6 +1191,10 @@ func (m *Syncer) startPeriodicUploader(ctx context.Context) {
 	// drift reconcile, failed-upload requeue) the dispatcher does not.
 	go m.uploadDispatcher(ctx)
 	go m.maintenanceLoop(ctx, interval)
+	// The carve dispatcher packs log-blob chunks into block objects (#1414). It
+	// idles harmlessly when the carve substrate is not wired (carveWake never
+	// fires) so it is always safe to launch alongside the legacy dispatcher.
+	go m.carveDispatcher(ctx)
 
 	// Adaptive mode only: launch the goodput controller that resizes the
 	// upload window to saturate the uplink (#1407). Pinned --parallel-uploads
@@ -1162,6 +1310,13 @@ func (m *Syncer) SyncNow(ctx context.Context) error {
 	// Flush queued FileChunk metadata to the store so the mirror loop
 	// picks up recently rolled-up chunks.
 	m.local.SyncFileChunks(ctx)
+
+	// Drain the block-carve set first (#1414): pack all pending log-blob chunks
+	// into block objects. Disjoint from the legacy CAS mirror, so both run; for
+	// a carve-enabled share mirrorOnce below is a no-op over an empty set.
+	if err := m.carveFlush(ctx, true); err != nil {
+		return err
+	}
 
 	return m.mirrorOnce(ctx)
 }
@@ -1304,6 +1459,7 @@ func (m *Syncer) SetRemoteStore(ctx context.Context, remoteStore remote.RemoteSt
 
 	m.remoteStore = remoteStore
 	m.hasRemote.Store(true)
+	m.recomputeCarveActive()
 	m.local.SetEvictionEnabled(true)
 
 	m.startHealthMonitor(ctx)

--- a/pkg/block/engine/types.go
+++ b/pkg/block/engine/types.go
@@ -20,6 +20,11 @@ var ErrStoreClosed = errors.New("engine: block store is closed")
 // With 200-connection S3 pool and 8MB blocks, 32 workers can saturate the pool.
 const DefaultParallelDownloads = 32
 
+// DefaultBlockCarveBytes is the default target size of a packed block object
+// (#1414): ~16 MiB. Large enough to amortize one PUT over many small chunks,
+// small enough to cap the carver's per-block RAM and keep ranged reads cheap.
+const DefaultBlockCarveBytes int64 = 16 << 20
+
 // DefaultPrefetchBlocks is the default number of blocks to prefetch.
 // 64 blocks = 512MB lookahead at 8MB block size.
 const DefaultPrefetchBlocks = 64
@@ -80,6 +85,14 @@ type SyncerConfig struct {
 	UploadInterval     time.Duration // Periodic uploader scan interval (default: 2s)
 	UploadDelay        time.Duration // Min block age before periodic upload; Flush ignores this (default: 10s)
 
+	// BlockCarveBytes is the target size of a packed block object (#1414). The
+	// block carver accumulates synced-pending log-blob chunks and seals one
+	// block once the accumulated raw bytes reach this threshold; a partial
+	// block is flushed on idle (after UploadDelay with no new chunk) or on an
+	// explicit Flush/SyncNow. <= 0 falls back to DefaultBlockCarveBytes. The
+	// carver buffers at most one block (this many bytes) in RAM at a time.
+	BlockCarveBytes int64
+
 	// ManualSync, when true, suppresses the background periodic uploader (and
 	// its adaptive controller). Durability is then driven solely by explicit
 	// Flush, making Flush the single deterministic mirror driver. Off by
@@ -111,6 +124,7 @@ func DefaultConfig() SyncerConfig {
 		SmallFileThreshold:          0,
 		UploadInterval:              2 * time.Second,
 		UploadDelay:                 10 * time.Second,
+		BlockCarveBytes:             DefaultBlockCarveBytes,
 		HealthCheckInterval:         30 * time.Second,
 		HealthCheckFailureThreshold: 3,
 		UnhealthyCheckInterval:      5 * time.Second,

--- a/pkg/block/local/fs/blockstore_methods.go
+++ b/pkg/block/local/fs/blockstore_methods.go
@@ -176,6 +176,19 @@ func (bc *FSStore) Head(ctx context.Context, hash block.ContentHash) (block.Meta
 	}, nil
 }
 
+// ReadLocalAt reads loc.RawLength bytes from the local log-blob substrate at the
+// given location into dst, delegating to the log-blob Manager. It is the read
+// half of the engine's block carver (#1414): the carver resolves a chunk's
+// LocalChunkLocation, reads its raw plaintext here, seals it, and frames it into
+// a block. Returns an error when no log-blob substrate is wired (a CAS-only
+// store), which the carver treats as "not log-blob-resident".
+func (bc *FSStore) ReadLocalAt(ctx context.Context, loc block.LocalChunkLocation, dst []byte) (int, error) {
+	if bc.logBlob == nil {
+		return 0, fmt.Errorf("blockstore.fs: ReadLocalAt: no log-blob substrate")
+	}
+	return bc.logBlob.ReadAt(ctx, loc, dst)
+}
+
 // localChunkWalker is the narrow, consumer-defined capability the local store
 // uses to enumerate logblob-resident chunks (for Walk / GC). A LocalChunkIndex
 // implementation may optionally provide it; absence simply means logblob

--- a/pkg/block/local/fs/blockstore_methods.go
+++ b/pkg/block/local/fs/blockstore_methods.go
@@ -9,6 +9,7 @@ import (
 	"iter"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/marmos91/dittofs/pkg/block"
 )
@@ -67,6 +68,32 @@ func (bc *FSStore) GetRange(ctx context.Context, hash block.ContentHash, offset,
 	if length <= 0 {
 		return nil, fmt.Errorf("blockstore.fs: GetRange: %w: length %d", block.ErrInvalidSize, length)
 	}
+	// Log-blob path: index hit -> read a clipped sub-range from the blob.
+	if bc.localChunkIndex != nil {
+		loc, ok, err := bc.localChunkIndex.GetLocalLocation(ctx, hash)
+		if err != nil {
+			return nil, fmt.Errorf("blockstore.fs: GetRange: get local location: %w", err)
+		}
+		if ok {
+			if offset >= loc.RawLength {
+				return nil, fmt.Errorf("blockstore.fs: GetRange: offset %d beyond size %d", offset, loc.RawLength)
+			}
+			if offset+length > loc.RawLength {
+				length = loc.RawLength - offset
+			}
+			sub := block.LocalChunkLocation{
+				LogBlobID: loc.LogBlobID,
+				RawOffset: loc.RawOffset + offset,
+				RawLength: length,
+			}
+			buf := make([]byte, length)
+			n, rerr := bc.logBlob.ReadAt(ctx, sub, buf)
+			if rerr != nil {
+				return nil, fmt.Errorf("blockstore.fs: GetRange: logblob read: %w", rerr)
+			}
+			return buf[:n], nil
+		}
+	}
 	path := bc.chunkPath(hash)
 	f, err := os.Open(path)
 	if err != nil {
@@ -121,6 +148,20 @@ func (bc *FSStore) Head(ctx context.Context, hash block.ContentHash) (block.Meta
 	if err := ctx.Err(); err != nil {
 		return block.Meta{}, err
 	}
+	// Log-blob path: index hit -> Size from the recorded location, mtime from
+	// the blobs directory (per-chunk timestamps are not tracked).
+	if bc.localChunkIndex != nil {
+		loc, ok, err := bc.localChunkIndex.GetLocalLocation(ctx, hash)
+		if err != nil {
+			return block.Meta{}, fmt.Errorf("blockstore.fs: Head: get local location: %w", err)
+		}
+		if ok {
+			return block.Meta{
+				Size:         loc.RawLength,
+				LastModified: bc.blobsModTime(),
+			}, nil
+		}
+	}
 	path := bc.chunkPath(hash)
 	info, err := os.Stat(path)
 	if err != nil {
@@ -135,6 +176,27 @@ func (bc *FSStore) Head(ctx context.Context, hash block.ContentHash) (block.Meta
 	}, nil
 }
 
+// localChunkWalker is the narrow, consumer-defined capability the local store
+// uses to enumerate logblob-resident chunks (for Walk / GC). A LocalChunkIndex
+// implementation may optionally provide it; absence simply means logblob
+// chunks are not enumerated on that backend (no interface-surface growth).
+type localChunkWalker interface {
+	WalkLocalLocations(ctx context.Context, fn func(block.ContentHash, block.LocalChunkLocation) error) error
+}
+
+// blobsModTime returns the modification time of the <baseDir>/blobs directory,
+// used as a non-zero LastModified for logblob-resident chunks (which carry no
+// per-chunk timestamp). Falls back to a stat of baseDir on error.
+func (bc *FSStore) blobsModTime() time.Time {
+	if fi, err := os.Stat(filepath.Join(bc.baseDir, "blobs")); err == nil {
+		return fi.ModTime()
+	}
+	if fi, err := os.Stat(bc.baseDir); err == nil {
+		return fi.ModTime()
+	}
+	return time.Now()
+}
+
 // Walk enumerates every CAS object in the local chunk store. The
 // callback receives the content hash and Meta for each object. Returns
 // block.ErrStopWalk from the callback for clean early-exit.
@@ -147,72 +209,101 @@ func (bc *FSStore) Walk(ctx context.Context, fn func(hash block.ContentHash, met
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	// CAS files first (legacy + back-compat). A missing blocks/ dir is not an
+	// empty store any more: logblob-resident chunks live only in the index, so
+	// skip the CAS walk and fall through to the index enumeration below.
 	blocksDir := filepath.Join(bc.baseDir, "blocks")
 	if _, err := os.Stat(blocksDir); err != nil {
-		if os.IsNotExist(err) {
-			return nil // empty store
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("blockstore.fs: Walk: stat: %w", err)
 		}
-		return fmt.Errorf("blockstore.fs: Walk: stat: %w", err)
-	}
-	walkErr := filepath.WalkDir(blocksDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
+	} else {
+		walkErr := filepath.WalkDir(blocksDir, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			name := d.Name()
+			if len(name) != block.HashSize*2 {
+				return nil
+			}
+			raw, hexErr := hex.DecodeString(name)
+			if hexErr != nil || len(raw) != block.HashSize {
+				return nil
+			}
+			var h block.ContentHash
+			copy(h[:], raw)
+			info, infoErr := d.Info()
+			if infoErr != nil {
+				// Race vs concurrent Delete: a file enumerated by WalkDir
+				// can disappear before d.Info() runs. Skip vanished
+				// entries silently; surface anything else (permission
+				// transient I/O) so callers like GC don't miss objects.
+				if errors.Is(infoErr, os.ErrNotExist) {
+					return nil
+				}
+				return fmt.Errorf("walk: stat %s: %w", h, infoErr)
+			}
+			meta := block.Meta{
+				Size:         info.Size(),
+				LastModified: info.ModTime(),
+			}
+			if cbErr := fn(h, meta); cbErr != nil {
+				if errors.Is(cbErr, block.ErrStopWalk) {
+					// Translate the public clean-exit sentinel into an
+					// unexported one so we can distinguish "callback
+					// asked to stop cleanly" from "filepath.WalkDir or
+					// the callback returned ErrStopWalk-wrapped-or-not
+					// for some other reason". Using a private sentinel
+					// also keeps io.EOF reserved for its real meaning:
+					// a callback that legitimately returns io.EOF (or
+					// wraps it) must halt with the wrapped error, not
+					// be silently treated as a clean exit.
+					return errStopWalkInternal
+				}
+				return fmt.Errorf("walk halted at %s: %w", h, cbErr)
+			}
+			return nil
+		})
+		if errors.Is(walkErr, errStopWalkInternal) {
 			return nil
 		}
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr
 		}
-		name := d.Name()
-		if len(name) != block.HashSize*2 {
-			return nil
+		if walkErr != nil {
+			return walkErr
 		}
-		raw, hexErr := hex.DecodeString(name)
-		if hexErr != nil || len(raw) != block.HashSize {
-			return nil
+	}
+
+	// Logblob-resident chunks: enumerate the index when it supports walking.
+	walker, ok := bc.localChunkIndex.(localChunkWalker)
+	if !ok {
+		return nil
+	}
+	mtime := bc.blobsModTime()
+	idxErr := walker.WalkLocalLocations(ctx, func(h block.ContentHash, loc block.LocalChunkLocation) error {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
 		}
-		var h block.ContentHash
-		copy(h[:], raw)
-		info, infoErr := d.Info()
-		if infoErr != nil {
-			// Race vs concurrent Delete: a file enumerated by WalkDir
-			// can disappear before d.Info() runs. Skip vanished
-			// entries silently; surface anything else (permission
-			// transient I/O) so callers like GC don't miss objects.
-			if errors.Is(infoErr, os.ErrNotExist) {
-				return nil
-			}
-			return fmt.Errorf("walk: stat %s: %w", h, infoErr)
-		}
-		meta := block.Meta{
-			Size:         info.Size(),
-			LastModified: info.ModTime(),
-		}
+		meta := block.Meta{Size: loc.RawLength, LastModified: mtime}
 		if cbErr := fn(h, meta); cbErr != nil {
 			if errors.Is(cbErr, block.ErrStopWalk) {
-				// Translate the public clean-exit sentinel into an
-				// unexported one so we can distinguish "callback
-				// asked to stop cleanly" from "filepath.WalkDir or
-				// the callback returned ErrStopWalk-wrapped-or-not
-				// for some other reason". Using a private sentinel
-				// also keeps io.EOF reserved for its real meaning:
-				// a callback that legitimately returns io.EOF (or
-				// wraps it) must halt with the wrapped error, not
-				// be silently treated as a clean exit.
 				return errStopWalkInternal
 			}
 			return fmt.Errorf("walk halted at %s: %w", h, cbErr)
 		}
 		return nil
 	})
-	if errors.Is(walkErr, errStopWalkInternal) {
+	if errors.Is(idxErr, errStopWalkInternal) {
 		return nil
 	}
-	if ctxErr := ctx.Err(); ctxErr != nil {
-		return ctxErr
-	}
-	return walkErr
+	return idxErr
 }
 
 // errStopWalkInternal is the unexported short-circuit sentinel

--- a/pkg/block/local/fs/chunkstore.go
+++ b/pkg/block/local/fs/chunkstore.go
@@ -151,10 +151,22 @@ func (bc *FSStore) storeChunkLogBlob(ctx context.Context, h block.ContentHash, d
 		if err != nil {
 			return fmt.Errorf("chunkstore: logblob append: %w", err)
 		}
-		bc.logBlobDiskUsed.Add(int64(len(data)))
+		// NOTE: if PutLocalLocation fails after a successful Append, the bytes
+		// written to the blob at loc are orphaned — they have no index entry and
+		// are not reachable by content hash. A blob-level reclaim pass is
+		// responsible for recovering these indexless extents; this code does not
+		// provide per-chunk reclaim. A subsequent StoreChunk retry for the same
+		// hash re-appends (the HasChunk check at the top of StoreChunk misses the
+		// index, so it does not deduplicate).
 	}
 	if err := bc.localChunkIndex.PutLocalLocation(ctx, h, loc); err != nil {
 		return fmt.Errorf("chunkstore: put local location: %w", err)
+	}
+	// logBlobDiskUsed is incremented only after a successful PutLocalLocation so
+	// the counter reflects indexed (reachable) bytes, not bytes that may have
+	// been orphaned by a failed index write above.
+	if len(data) > 0 {
+		bc.logBlobDiskUsed.Add(int64(len(data)))
 	}
 	// Fire the chunk-completion callback (engine Cache.Put). The path argument
 	// is empty: logblob chunks have no per-chunk on-disk path, and the engine

--- a/pkg/block/local/fs/chunkstore.go
+++ b/pkg/block/local/fs/chunkstore.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -161,10 +162,22 @@ func (bc *FSStore) storeChunkLogBlob(ctx context.Context, h block.ContentHash, d
 		// eventually evicted. Only in this specific failure path — where no
 		// index entry was written — does a subsequent StoreChunk retry
 		// re-append: HasChunk consults the index and, once an entry exists,
-		// dedups. This direct path indexes without an fsync; crash-durable
-		// ordering (index committed only after the blob is fsynced) is provided
-		// by the rollup's Phase C fence via stageRollupChunk/commitStagedChunk,
-		// which is the only production writer of log-blob chunks.
+		// dedups.
+		//
+		// Crash-durability differs by writer. The rollup writer
+		// (stageRollupChunk/commitStagedChunk) FENCES this window: the index
+		// entry is committed only after the blob is fsynced in Phase C, so a
+		// crash before the fsync leaves no index entry and the bytes are
+		// re-appended cleanly from the append-log the rollup drains. This
+		// direct path (read-through staging via FSStore.Put) does NOT fsync
+		// before indexing, so a crash in the append-then-index window can
+		// leave a durable index entry pointing at un-fsynced blob bytes. That
+		// is tolerated because Put only stages chunks already durable on the
+		// remote: on the next read ReadChunk detects the torn tail (short
+		// log-blob read), drops the dangling index entry, and reports a miss,
+		// routing the engine to refetch the authoritative bytes from the
+		// remote and re-stage. Neither writer can lose or hard-error an
+		// acknowledged/remote-durable chunk.
 	}
 	if err := bc.localChunkIndex.PutLocalLocation(ctx, h, loc); err != nil {
 		return fmt.Errorf("chunkstore: put local location: %w", err)
@@ -289,7 +302,24 @@ func (bc *FSStore) ReadChunk(ctx context.Context, h block.ContentHash) ([]byte, 
 			dst := make([]byte, loc.RawLength)
 			n, rerr := bc.logBlob.ReadAt(ctx, loc, dst)
 			if rerr != nil {
+				// A short read (io.EOF before RawLength bytes) means the blob
+				// tail was torn by a crash in the append→fsync window: the
+				// durable index entry now points past the bytes that actually
+				// reached disk. Rather than hard-error, drop the dangling index
+				// entry and report the chunk as absent so the engine's
+				// miss→remote-refetch→re-stage path recovers it from the
+				// authoritative remote copy (torn ≡ evicted: both leave no
+				// durable local bytes and no index entry). Any other error is a
+				// genuine I/O failure and surfaces unchanged.
+				if errors.Is(rerr, io.EOF) {
+					return nil, bc.dropTornIndexEntry(ctx, h)
+				}
 				return nil, fmt.Errorf("chunkstore: logblob read: %w", rerr)
+			}
+			if int64(n) < loc.RawLength {
+				// Defensive: nil error but fewer bytes than the index recorded
+				// (a torn tail landing exactly at EOF). Same recovery routing.
+				return nil, bc.dropTornIndexEntry(ctx, h)
 			}
 			return dst[:n], nil
 		}
@@ -340,6 +370,18 @@ func (bc *FSStore) ReadChunk(ctx context.Context, h block.ContentHash) ([]byte, 
 		bc.lruTouch(h, int64(len(data)), path)
 	}
 	return data, nil
+}
+
+// dropTornIndexEntry removes the dangling local-index entry for a chunk whose
+// log-blob bytes were lost to a torn tail, then reports the chunk as absent.
+// After this the chunk reads as a clean miss (HasChunk consults the index),
+// which routes the engine to refetch from the durable remote copy and re-stage
+// — the read-through equivalent of the rollup path's Phase C fsync fence.
+func (bc *FSStore) dropTornIndexEntry(ctx context.Context, h block.ContentHash) error {
+	if err := bc.localChunkIndex.DeleteLocalLocation(ctx, h); err != nil {
+		return fmt.Errorf("chunkstore: drop torn index entry: %w", err)
+	}
+	return block.ErrChunkNotFound
 }
 
 // Get implements local.LocalStore.Get by delegating to ReadChunk.

--- a/pkg/block/local/fs/chunkstore.go
+++ b/pkg/block/local/fs/chunkstore.go
@@ -53,6 +53,14 @@ func (bc *FSStore) StoreChunk(ctx context.Context, h block.ContentHash, data []b
 		return nil
 	}
 
+	// Log-blob path: when an index is wired, append the chunk bytes to the
+	// log-blob substrate and record the location in the index instead of
+	// writing a per-chunk cas/<hash> file. Legacy CAS writer below is the
+	// fallback for index-less fixtures (quarantined, not deleted).
+	if bc.logBlob != nil && bc.localChunkIndex != nil {
+		return bc.storeChunkLogBlob(ctx, h, data)
+	}
+
 	path := bc.chunkPath(h)
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return fmt.Errorf("chunkstore: mkdir: %w", err)
@@ -127,14 +135,65 @@ func (bc *FSStore) StoreChunk(ctx context.Context, h block.ContentHash, data []b
 	return nil
 }
 
+// storeChunkLogBlob appends data to the log-blob substrate and records the
+// resulting location in the local chunk index. The idempotency / existence
+// check already ran in StoreChunk, so this only handles a fresh chunk.
+//
+// A zero-length chunk is NOT appended (the substrate rejects empty payloads);
+// instead a zero-RawLength location is recorded, which ReadChunk reconstructs
+// as an empty slice. Per-chunk eviction does not apply on this path — the LRU
+// tracks only cas/<hash> files; blob-level eviction is handled separately.
+func (bc *FSStore) storeChunkLogBlob(ctx context.Context, h block.ContentHash, data []byte) error {
+	var loc block.LocalChunkLocation
+	if len(data) > 0 {
+		var err error
+		loc, err = bc.logBlob.Append(ctx, data)
+		if err != nil {
+			return fmt.Errorf("chunkstore: logblob append: %w", err)
+		}
+		bc.logBlobDiskUsed.Add(int64(len(data)))
+	}
+	if err := bc.localChunkIndex.PutLocalLocation(ctx, h, loc); err != nil {
+		return fmt.Errorf("chunkstore: put local location: %w", err)
+	}
+	// Fire the chunk-completion callback (engine Cache.Put). The path argument
+	// is empty: logblob chunks have no per-chunk on-disk path, and the engine
+	// discards it.
+	if cb := bc.onChunkComplete.Load(); cb != nil && cb.fn != nil {
+		cb.fn(h, data, "")
+	}
+	return nil
+}
+
 // ReadChunk returns the bytes of the chunk addressed by h.
 // Returns block.ErrChunkNotFound if the chunk is absent.
+//
+// Dual-mode: a wired local chunk index is consulted first (logblob-resident
+// chunks); on a miss it falls back to the legacy cas/<hash> file so
+// pre-existing CAS data stays readable (back-compat until PR4 migrates it).
 func (bc *FSStore) ReadChunk(ctx context.Context, h block.ContentHash) ([]byte, error) {
 	if bc.isClosed() {
 		return nil, ErrStoreClosed
 	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
+	}
+	if bc.localChunkIndex != nil {
+		loc, ok, err := bc.localChunkIndex.GetLocalLocation(ctx, h)
+		if err != nil {
+			return nil, fmt.Errorf("chunkstore: get local location: %w", err)
+		}
+		if ok {
+			if loc.RawLength == 0 {
+				return []byte{}, nil
+			}
+			dst := make([]byte, loc.RawLength)
+			n, rerr := bc.logBlob.ReadAt(ctx, loc, dst)
+			if rerr != nil {
+				return nil, fmt.Errorf("chunkstore: logblob read: %w", rerr)
+			}
+			return dst[:n], nil
+		}
 	}
 	path := bc.chunkPath(h)
 	f, err := os.Open(path)
@@ -202,6 +261,18 @@ func (bc *FSStore) HasChunk(ctx context.Context, h block.ContentHash) (bool, err
 	if err := ctx.Err(); err != nil {
 		return false, err
 	}
+	// Index-resident (logblob) chunks have no cas/<hash> file, so the index
+	// must be consulted first — otherwise a second rollup pass would re-Append
+	// the same bytes. Falls back to the legacy CAS stat for back-compat data.
+	if bc.localChunkIndex != nil {
+		_, ok, err := bc.localChunkIndex.GetLocalLocation(ctx, h)
+		if err != nil {
+			return false, fmt.Errorf("chunkstore: get local location: %w", err)
+		}
+		if ok {
+			return true, nil
+		}
+	}
 	_, err := os.Stat(bc.chunkPath(h))
 	if err == nil {
 		return true, nil
@@ -224,6 +295,15 @@ func (bc *FSStore) DeleteChunk(ctx context.Context, h block.ContentHash) error {
 	}
 	if err := ctx.Err(); err != nil {
 		return err
+	}
+	// Remove the index entry first so a logblob-resident chunk reads as a miss
+	// afterwards. Idempotent. The blob bytes themselves are reclaimed by
+	// blob-level eviction, handled separately — DeleteChunk does not rewrite
+	// the blob or adjust logBlobDiskUsed here.
+	if bc.localChunkIndex != nil {
+		if err := bc.localChunkIndex.DeleteLocalLocation(ctx, h); err != nil {
+			return fmt.Errorf("chunkstore: delete local location: %w", err)
+		}
 	}
 	path := bc.chunkPath(h)
 	st, statErr := os.Stat(path)

--- a/pkg/block/local/fs/chunkstore.go
+++ b/pkg/block/local/fs/chunkstore.go
@@ -155,9 +155,13 @@ func (bc *FSStore) storeChunkLogBlob(ctx context.Context, h block.ContentHash, d
 		// written to the blob at loc are orphaned — they have no index entry and
 		// are not reachable by content hash. A blob-level reclaim pass is
 		// responsible for recovering these indexless extents; this code does not
-		// provide per-chunk reclaim. A subsequent StoreChunk retry for the same
-		// hash re-appends (the HasChunk check at the top of StoreChunk misses the
-		// index, so it does not deduplicate).
+		// provide per-chunk reclaim. Only in this specific failure path — where
+		// no index entry was written — does a subsequent StoreChunk retry
+		// re-append: HasChunk consults the index and, once an entry exists,
+		// dedups. This direct path indexes without an fsync; crash-durable
+		// ordering (index committed only after the blob is fsynced) is provided
+		// by the rollup's Phase C fence via stageRollupChunk/commitStagedChunk,
+		// which is the only production writer of log-blob chunks.
 	}
 	if err := bc.localChunkIndex.PutLocalLocation(ctx, h, loc); err != nil {
 		return fmt.Errorf("chunkstore: put local location: %w", err)
@@ -173,6 +177,86 @@ func (bc *FSStore) storeChunkLogBlob(ctx context.Context, h block.ContentHash, d
 	// discards it.
 	if cb := bc.onChunkComplete.Load(); cb != nil && cb.fn != nil {
 		cb.fn(h, data, "")
+	}
+	return nil
+}
+
+// stagedChunk is a chunk appended to the log-blob during a rollup pass whose
+// durable local-index write has been DEFERRED to Phase C. It carries just
+// enough to commit the index entry (and the disk-usage delta) once the blob
+// has been fsynced.
+type stagedChunk struct {
+	h      block.ContentHash
+	loc    block.LocalChunkLocation
+	size   int
+	staged bool
+}
+
+// stageRollupChunk stores chunk h for a rollup pass. On the log-blob path it
+// APPENDS the bytes to the blob substrate but DEFERS the durable local-index
+// write (PutLocalLocation) to commitStagedChunk, called in Phase C only after
+// logBlob.Sync succeeds. Fencing the index write behind the blob fsync upholds
+// the durability invariant: no durable index entry may point at bytes that are
+// not yet durable on disk. A crash in the append→fsync window therefore leaves
+// NO index entry, so the replay's HasChunk misses and the bytes are re-appended
+// cleanly (they survive in the append-log the rollup drains from).
+//
+// In-window reads are unaffected: until Phase C advances the rollup fence the
+// bytes are still served from the append-log (ReadPayloadAt step 1); the
+// log-blob index only becomes the resolving source after the fence advances,
+// which happens strictly after the fsync + index commit.
+//
+// Returns staged=true with the location to commit for a freshly appended
+// log-blob chunk; staged=false when nothing needs a deferred index write — a
+// dedup hit against an already-durable chunk, or the legacy CAS path (index-less
+// fixtures), which fsyncs the cas/<hash> file inline in StoreChunk.
+func (bc *FSStore) stageRollupChunk(ctx context.Context, h block.ContentHash, data []byte) (stagedChunk, error) {
+	// Legacy CAS path: no log-blob / index wired. StoreChunk fsyncs the
+	// cas/<hash> file before returning, so durability needs no deferral.
+	if bc.logBlob == nil || bc.localChunkIndex == nil {
+		if err := bc.StoreChunk(ctx, h, data); err != nil {
+			return stagedChunk{}, err
+		}
+		return stagedChunk{}, nil
+	}
+
+	// Dedup against chunks already made durable by a prior pass. (Intra-pass
+	// duplicate hashes are deduped by the caller's per-pass set, since staged
+	// chunks are not yet in the index.)
+	exists, err := bc.HasChunk(ctx, h)
+	if err != nil {
+		return stagedChunk{}, err
+	}
+	if exists {
+		return stagedChunk{}, nil
+	}
+
+	// Append the bytes now but hold the index write until Phase C's fsync.
+	var loc block.LocalChunkLocation
+	if len(data) > 0 {
+		loc, err = bc.logBlob.Append(ctx, data)
+		if err != nil {
+			return stagedChunk{}, fmt.Errorf("chunkstore: logblob append: %w", err)
+		}
+	}
+	// Populate the engine read cache eagerly (content-addressed, so correct even
+	// if this pass is later abandoned). This mirrors storeChunkLogBlob's callback
+	// timing and keeps freshly rolled-up chunks warm.
+	if cb := bc.onChunkComplete.Load(); cb != nil && cb.fn != nil {
+		cb.fn(h, data, "")
+	}
+	return stagedChunk{h: h, loc: loc, size: len(data), staged: true}, nil
+}
+
+// commitStagedChunk makes a staged log-blob chunk's local-index entry durable.
+// It MUST be called only after logBlob.Sync has succeeded for the pass, so the
+// index never references un-fsynced blob bytes.
+func (bc *FSStore) commitStagedChunk(ctx context.Context, sc stagedChunk) error {
+	if err := bc.localChunkIndex.PutLocalLocation(ctx, sc.h, sc.loc); err != nil {
+		return fmt.Errorf("chunkstore: put local location: %w", err)
+	}
+	if sc.size > 0 {
+		bc.logBlobDiskUsed.Add(int64(sc.size))
 	}
 	return nil
 }

--- a/pkg/block/local/fs/chunkstore.go
+++ b/pkg/block/local/fs/chunkstore.go
@@ -153,10 +153,13 @@ func (bc *FSStore) storeChunkLogBlob(ctx context.Context, h block.ContentHash, d
 		}
 		// NOTE: if PutLocalLocation fails after a successful Append, the bytes
 		// written to the blob at loc are orphaned — they have no index entry and
-		// are not reachable by content hash. A blob-level reclaim pass is
-		// responsible for recovering these indexless extents; this code does not
-		// provide per-chunk reclaim. Only in this specific failure path — where
-		// no index entry was written — does a subsequent StoreChunk retry
+		// are not reachable by content hash. There is no dedicated reclaim pass
+		// for such indexless extents: compaction rewrites per-payload append
+		// logs, not the log-blob substrate, and eviction operates on whole
+		// sealed blobs. The orphaned bytes are therefore space-only waste that
+		// is reclaimed only when the entire sealed blob they live in is
+		// eventually evicted. Only in this specific failure path — where no
+		// index entry was written — does a subsequent StoreChunk retry
 		// re-append: HasChunk consults the index and, once an entry exists,
 		// dedups. This direct path indexes without an fsync; crash-durable
 		// ordering (index committed only after the blob is fsynced) is provided

--- a/pkg/block/local/fs/chunkstore_torntail_test.go
+++ b/pkg/block/local/fs/chunkstore_torntail_test.go
@@ -1,0 +1,74 @@
+package fs
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+// TestReadChunk_TornLogBlobTail_TreatedAsMiss proves the read-through
+// crash-consistency contract: when a log-blob tail is torn (the durable index
+// entry survives a crash but the appended bytes never reached disk), ReadChunk
+// must NOT hard-error. It must drop the dangling index entry and report the
+// chunk as a clean miss (ErrChunkNotFound), so an upstream engine treats it
+// exactly like an evicted chunk and refetches from the durable remote copy.
+//
+// A truncation of the blob file models the post-crash state: index committed,
+// blob bytes lost. Before the fix, logBlob.ReadAt returned io.EOF and ReadChunk
+// wrapped it into a hard error with no recovery route.
+func TestReadChunk_TornLogBlobTail_TreatedAsMiss(t *testing.T) {
+	bc, _, ctx := newLogBlobStore(t)
+
+	data := []byte("read-through staged chunk that will be torn by a crash")
+	h := blake3ContentHash(data)
+
+	// Stage via Put (the read-through cache's write entry) — appends to the
+	// log-blob and commits a durable index entry, WITHOUT fsyncing the blob.
+	if err := bc.Put(ctx, h, data); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	// Sanity: the chunk reads back cleanly before the tear.
+	if got, err := bc.ReadChunk(ctx, h); err != nil || string(got) != string(data) {
+		t.Fatalf("pre-tear ReadChunk = %q, err=%v; want %q", got, err, data)
+	}
+	if ok, err := bc.HasChunk(ctx, h); err != nil || !ok {
+		t.Fatalf("pre-tear HasChunk = %v, err=%v; want true", ok, err)
+	}
+
+	// Simulate the torn tail: truncate the active blob so the recorded bytes
+	// are no longer on disk (index entry is untouched — it's in the index
+	// store, which "survived the crash").
+	blobsDir := filepath.Join(bc.baseDir, "blobs")
+	entries, err := os.ReadDir(blobsDir)
+	if err != nil {
+		t.Fatalf("read blobs dir: %v", err)
+	}
+	truncated := false
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".blob" {
+			if err := os.Truncate(filepath.Join(blobsDir, e.Name()), 0); err != nil {
+				t.Fatalf("truncate blob %s: %v", e.Name(), err)
+			}
+			truncated = true
+		}
+	}
+	if !truncated {
+		t.Fatal("no .blob file found to truncate")
+	}
+
+	// The torn read must surface as a clean miss, not a hard error.
+	if _, err := bc.ReadChunk(ctx, h); !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("torn ReadChunk err = %v; want ErrChunkNotFound (clean miss, no hard error)", err)
+	}
+
+	// The dangling index entry must be gone so HasChunk now reports absence —
+	// this is what routes the engine's EnsureAvailableAndRead to refetch from
+	// remote instead of assuming the chunk is all-local and returning zeros.
+	if ok, err := bc.HasChunk(ctx, h); err != nil || ok {
+		t.Fatalf("post-tear HasChunk = %v, err=%v; want false (torn entry dropped)", ok, err)
+	}
+}

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -189,6 +189,12 @@ type FSStore struct {
 	// per-chunk victims. Blob-level eviction is handled separately.
 	logBlobDiskUsed atomic.Int64
 
+	// logBlobRollupSyncCount counts how many times a rollup pass has called
+	// logBlob.Sync() before advancing the rollup_offset fence. Each
+	// successful rollup pass that processes at least one chunk increments this
+	// by one. Test-only observable via LogBlobRollupSyncCountForTest.
+	logBlobRollupSyncCount atomic.Int64
+
 	// flushFsyncCount counts how many times flushBlock has invoked fsync.
 	// Test-only observable surfaced via FlushFsyncCountForTest. Incremented
 	// only on the COMMIT-driven path (withFsync=true); pressure and

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -21,6 +21,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/local"
+	"github.com/marmos91/dittofs/pkg/block/local/logblob"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -173,6 +174,20 @@ type FSStore struct {
 
 	memUsed  atomic.Int64
 	diskUsed atomic.Int64
+
+	// logBlob is the per-store log-blob substrate. When non-nil (a
+	// localChunkIndex was wired), rolled-up chunks are appended here and
+	// located via localChunkIndex instead of per-chunk cas/<hash> files.
+	// Nil for index-less fixtures, which stay on the legacy CAS writer.
+	logBlob *logblob.Manager
+	// localChunkIndex maps content hash -> position in a log blob. Source of
+	// truth for local reads of logblob-resident chunks. Nil disables the
+	// logblob path (legacy CAS only).
+	localChunkIndex metadata.LocalChunkIndex
+	// logBlobDiskUsed accounts bytes appended to log blobs. Kept SEPARATE
+	// from diskUsed so it never feeds the CAS LRU eviction loop with phantom
+	// per-chunk victims. Blob-level eviction is handled separately.
+	logBlobDiskUsed atomic.Int64
 
 	// flushFsyncCount counts how many times flushBlock has invoked fsync.
 	// Test-only observable surfaced via FlushFsyncCountForTest. Incremented
@@ -549,6 +564,18 @@ func newFSStore(baseDir string, maxDisk int64, fileChunkStore block.EngineFileCh
 
 	applyFSStoreOptions(bc, opts)
 
+	// When a LocalChunkIndex is wired, open the per-store log-blob substrate
+	// at <baseDir>/blobs/. Rolled-up chunks append here (located via the
+	// index) instead of per-chunk cas/<hash> files. Index-less fixtures skip
+	// this and stay on the legacy CAS writer.
+	if bc.localChunkIndex != nil {
+		mgr, err := logblob.Open(filepath.Join(baseDir, "blobs"), logblob.Options{})
+		if err != nil {
+			return nil, fmt.Errorf("local store: open log-blob substrate: %w", err)
+		}
+		bc.logBlob = mgr
+	}
+
 	// Shared rollup concurrency budget, sized to the final worker count so
 	// the nudge path and the scanAllFiles fan-out share it (#1411). Floor of
 	// 1 guards the degenerate rollupWorkers<=0 path.
@@ -596,6 +623,7 @@ func applyFSStoreOptions(bc *FSStore, opts FSStoreOptions) {
 	}
 	bc.rollupStore = opts.RollupStore
 	bc.syncedHashStore = opts.SyncedHashStore
+	bc.localChunkIndex = opts.LocalChunkIndex
 	bc.objectIDPersister = opts.ObjectIDPersister
 	if opts.OrphanLogMinAgeSeconds > 0 {
 		bc.orphanLogMinAgeSeconds = opts.OrphanLogMinAgeSeconds
@@ -922,6 +950,13 @@ type FSStoreOptions struct {
 	// consumes it via ListUnsynced + MarkSynced). Nil is accepted for
 	// local-only stores; in that case ListUnsynced yields nothing.
 	SyncedHashStore metadata.SyncedHashStore
+	// LocalChunkIndex maps content hash -> position in a local log blob.
+	// When non-nil, chunk persistence routes to the log-blob substrate
+	// (logblob.Append + PutLocalLocation) instead of per-chunk cas/<hash>
+	// files, and local reads resolve index hits via logblob.ReadAt. Nil
+	// keeps the store on the legacy CAS writer/reader (index-less fixtures).
+	// Production wires the metadata store, which implements this interface.
+	LocalChunkIndex metadata.LocalChunkIndex
 	// ObjectIDPersister is the rollup-completion hook that receives the
 	// BlockRef manifest + computed ObjectID after SetRollupOffset
 	// succeeds. Wire this to the engine coordinator's PersistFileChunks
@@ -1142,6 +1177,14 @@ func (bc *FSStore) Close() error {
 			delete(sh.logFDs, pid)
 		}
 		sh.mu.Unlock()
+	}
+
+	// Close the log-blob substrate (if wired). Safe after the rollup workers
+	// have joined above, so no Append/ReadAt is in flight.
+	if bc.logBlob != nil {
+		if err := bc.logBlob.Close(); err != nil {
+			logger.Warn("FSStore.Close: log-blob close failed", "error", err)
+		}
 	}
 	return nil
 }

--- a/pkg/block/local/fs/fs_conformance_test.go
+++ b/pkg/block/local/fs/fs_conformance_test.go
@@ -24,6 +24,7 @@ func newFSStoreForConformance(t *testing.T) *fs.FSStore {
 		RollupWorkers:   2,
 		StabilizationMS: 50,
 		RollupStore:     rs,
+		LocalChunkIndex: rs,
 	})
 	if err != nil {
 		t.Fatalf("NewWithOptions: %v", err)

--- a/pkg/block/local/fs/logblob_flip_test.go
+++ b/pkg/block/local/fs/logblob_flip_test.go
@@ -1,0 +1,119 @@
+package fs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// newLogBlobStore builds an FSStore with a LocalChunkIndex wired, so chunk
+// persistence routes to the log-blob tier instead of per-chunk CAS files.
+// maxDisk is unbounded so ensureSpace never evicts during the test.
+func newLogBlobStore(t *testing.T) (*FSStore, *os.Root, context.Context) {
+	t.Helper()
+	dir := t.TempDir()
+	idx := memmeta.NewMemoryMetadataStoreWithDefaults()
+	bc, err := NewWithOptions(dir, 0, nil, FSStoreOptions{
+		LocalChunkIndex: idx,
+	})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	t.Cleanup(func() { _ = bc.Close() })
+	return bc, nil, context.Background()
+}
+
+// TestStoreChunk_RoutesToLogBlob proves that when a LocalChunkIndex is wired,
+// StoreChunk writes the chunk bytes to the log-blob substrate and records the
+// location in the index — it does NOT create a per-chunk cas/<hash> file.
+func TestStoreChunk_RoutesToLogBlob(t *testing.T) {
+	bc, _, ctx := newLogBlobStore(t)
+
+	data := []byte("hello log-blob substrate")
+	h := blake3ContentHash(data)
+
+	if err := bc.StoreChunk(ctx, h, data); err != nil {
+		t.Fatalf("StoreChunk: %v", err)
+	}
+
+	// No legacy CAS file must be created for a new logblob-backed write.
+	if _, err := os.Stat(bc.chunkPath(h)); !os.IsNotExist(err) {
+		t.Fatalf("expected no CAS file at %s, stat err=%v", bc.chunkPath(h), err)
+	}
+
+	// The local chunk index must record the location.
+	loc, ok, err := bc.localChunkIndex.GetLocalLocation(ctx, h)
+	if err != nil {
+		t.Fatalf("GetLocalLocation: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected index hit for stored chunk, got miss")
+	}
+	if loc.RawLength != int64(len(data)) {
+		t.Fatalf("index RawLength = %d, want %d", loc.RawLength, len(data))
+	}
+
+	// A .blob file must exist under <baseDir>/blobs/.
+	entries, err := os.ReadDir(filepath.Join(bc.baseDir, "blobs"))
+	if err != nil {
+		t.Fatalf("read blobs dir: %v", err)
+	}
+	var sawBlob bool
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".blob" {
+			sawBlob = true
+		}
+	}
+	if !sawBlob {
+		t.Fatalf("expected a .blob file under blobs/, found %v", entries)
+	}
+
+	// Round-trips byte-identical via ReadChunk (index hit -> logblob.ReadAt).
+	got, err := bc.ReadChunk(ctx, h)
+	if err != nil {
+		t.Fatalf("ReadChunk: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("ReadChunk = %q, want %q", got, data)
+	}
+}
+
+// TestReadChunk_LegacyCASBackCompat proves that a pre-existing cas/<hash> file
+// (no index entry) stays readable on a logblob-backed store — the retained
+// legacy CAS read path. Removed only in PR4.
+func TestReadChunk_LegacyCASBackCompat(t *testing.T) {
+	bc, _, ctx := newLogBlobStore(t)
+
+	legacy := []byte("legacy cas chunk bytes")
+	h := blake3ContentHash(legacy)
+
+	// Write a CAS file directly, bypassing StoreChunk, with NO index entry.
+	path := bc.chunkPath(h)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, legacy, 0o644); err != nil {
+		t.Fatalf("write legacy cas file: %v", err)
+	}
+
+	// Index miss -> CAS fallback reports existence.
+	ok, err := bc.HasChunk(ctx, h)
+	if err != nil {
+		t.Fatalf("HasChunk: %v", err)
+	}
+	if !ok {
+		t.Fatalf("HasChunk = false for pre-existing CAS file, want true")
+	}
+
+	// Index miss -> CAS fallback returns the bytes.
+	got, err := bc.ReadChunk(ctx, h)
+	if err != nil {
+		t.Fatalf("ReadChunk: %v", err)
+	}
+	if string(got) != string(legacy) {
+		t.Fatalf("ReadChunk = %q, want %q", got, legacy)
+	}
+}

--- a/pkg/block/local/fs/rollup.go
+++ b/pkg/block/local/fs/rollup.go
@@ -615,6 +615,13 @@ func (bc *FSStore) rollupFileInner(ctx context.Context, payloadID string, force 
 	// at the call site below; both the LRU-hit and StoreChunk paths
 	// append to `blocks`, so no separate buffer is needed.
 	var blocks []block.BlockRef
+	// staged holds log-blob chunks appended this pass whose durable local-index
+	// write is deferred to Phase C (committed only after the blob is fsynced) so
+	// no index entry can outlive un-fsynced blob bytes across a crash. seen
+	// deduplicates identical chunk content within this pass — staged chunks are
+	// not yet in the index, so stageRollupChunk's HasChunk cannot catch them.
+	var staged []stagedChunk
+	seen := make(map[block.ContentHash]struct{})
 	for pos < uint64(len(stream)) {
 		b, _ := ck.Next(stream[pos:], true)
 		if b <= 0 {
@@ -630,12 +637,19 @@ func (bc *FSStore) rollupFileInner(ctx context.Context, payloadID string, force 
 			Size:   uint32(b),
 		}
 
-		// StoreChunk is content-addressed and idempotent, so it
-		// physically dedups by content hash on every pass. The BlockRef
-		// append below preserves the manifest invariant: ComputeObjectID
-		// later in this function sees the full BlockRef list.
-		if err := bc.StoreChunk(ctx, h, chunkBytes); err != nil {
-			return fmt.Errorf("rollup: StoreChunk: %w", err)
+		// Store is content-addressed and idempotent, so it physically dedups by
+		// content hash on every pass. The BlockRef append below preserves the
+		// manifest invariant: ComputeObjectID later in this function sees the
+		// full BlockRef list regardless of dedup.
+		if _, dup := seen[h]; !dup {
+			seen[h] = struct{}{}
+			sc, err := bc.stageRollupChunk(ctx, h, chunkBytes)
+			if err != nil {
+				return fmt.Errorf("rollup: stage chunk: %w", err)
+			}
+			if sc.staged {
+				staged = append(staged, sc)
+			}
 		}
 
 		blocks = append(blocks, blockRef)
@@ -741,10 +755,22 @@ func (bc *FSStore) rollupFileInner(ctx context.Context, payloadID string, force 
 		//
 		// nil guard: CAS-only stores do not use a logBlob and are unaffected.
 		if bc.logBlob != nil {
-			if serr := bc.logBlob.Sync(); serr != nil {
+			if serr := bc.syncLogBlob(); serr != nil {
 				return fmt.Errorf("rollup: fsync log-blob before fence advance: %w", serr)
 			}
 			bc.logBlobRollupSyncCount.Add(1)
+
+			// Blob bytes are now durable. Commit the deferred local-index
+			// entries for the chunks appended this pass. Doing this AFTER the
+			// fsync (and before the fence advances) is the durability fence: a
+			// crash before the fsync leaves no index entry, so the replay's
+			// HasChunk misses and the bytes are re-appended from the still-live
+			// append-log rather than being dedup-skipped and lost.
+			for _, sc := range staged {
+				if cerr := bc.commitStagedChunk(ctx, sc); cerr != nil {
+					return fmt.Errorf("rollup: commit chunk index: %w", cerr)
+				}
+			}
 		}
 
 		// SetRollupOffset is atomic-monotone at the RollupStore layer: on
@@ -852,6 +878,25 @@ var maxReconstructBytes = uint64(1) << 34
 // it to nil) to deterministically interleave a racing AppendWrite. It must not
 // be set while a rollup worker pool is running on an unrelated test.
 var rollupPhaseBHook func(payloadID string)
+
+// rollupPreSyncFailHook, when non-nil, is consulted by syncLogBlob just before
+// the real logBlob.Sync in rollup Phase C. A non-nil return is treated exactly
+// as a blob fsync failure, aborting the pass before the fence advances.
+// Production leaves it nil; durability tests set it (and MUST defer-restore it)
+// to deterministically reproduce a crash in the append→fsync window.
+var rollupPreSyncFailHook func() error
+
+// syncLogBlob fsyncs the log-blob substrate, honoring the rollupPreSyncFailHook
+// test seam. Kept as a thin wrapper so the injection point stays out of the
+// Phase C commit sequence body.
+func (bc *FSStore) syncLogBlob() error {
+	if fn := rollupPreSyncFailHook; fn != nil {
+		if err := fn(); err != nil {
+			return err
+		}
+	}
+	return bc.logBlob.Sync()
+}
 
 // reconstructStream flattens records by file offset, later writes overwriting
 // earlier ones at the same offset. Produces a contiguous byte slice anchored

--- a/pkg/block/local/fs/rollup.go
+++ b/pkg/block/local/fs/rollup.go
@@ -726,6 +726,27 @@ func (bc *FSStore) rollupFileInner(ctx context.Context, payloadID string, force 
 		// pass — the quantity to release from logBytesTotal below (C3).
 		targetPos, retiredBytes := idx.advanceFenceUpTo(maxReadLogPos)
 
+		// Durability fence: flush the log-blob substrate to durable storage
+		// BEFORE advancing rollup_offset. The previous CAS path fsynced each
+		// chunk file individually in StoreChunk; the log-blob path batches
+		// writes to a single blob file and relies on this single per-pass sync
+		// to provide the same durability guarantee.
+		//
+		// Invariant: a crash after SetRollupOffset returns must never be able
+		// to cause data loss. If the blob bytes were not fsynced first, a crash
+		// between this Sync and SetRollupOffset is safe (recovery replays from
+		// the old fence). A crash after SetRollupOffset with an unsynced blob
+		// would cause recovery to seek past records whose chunk bytes are
+		// missing from disk — unrecoverable data loss.
+		//
+		// nil guard: CAS-only stores do not use a logBlob and are unaffected.
+		if bc.logBlob != nil {
+			if serr := bc.logBlob.Sync(); serr != nil {
+				return fmt.Errorf("rollup: fsync log-blob before fence advance: %w", serr)
+			}
+			bc.logBlobRollupSyncCount.Add(1)
+		}
+
 		// SetRollupOffset is atomic-monotone at the RollupStore layer: on
 		// attempted regression it returns ErrRollupOffsetRegression and the
 		// stored value is unchanged. With Direction-1 the fence is monotonic

--- a/pkg/block/local/fs/rollup.go
+++ b/pkg/block/local/fs/rollup.go
@@ -715,6 +715,52 @@ func (bc *FSStore) rollupFileInner(ctx context.Context, payloadID string, force 
 			return nil
 		}
 
+		// Durability fence: flush the log-blob substrate and commit the deferred
+		// local-index entries BEFORE the destructive fence trim below. The
+		// previous CAS path fsynced each chunk file individually in StoreChunk;
+		// the log-blob path batches writes to a single blob file and relies on
+		// this single per-pass sync to provide the same durability guarantee.
+		//
+		// Two invariants ride on this ordering:
+		//
+		//   - Crash durability: no durable index entry may become visible before
+		//     the blob bytes it references are fsynced, and rollup_offset (the
+		//     fence) may advance only after both the fsync and the index commit
+		//     succeed. So the commit runs strictly after syncLogBlob, and
+		//     SetRollupOffset/advanceRollupOffset run strictly after this block.
+		//     A crash before the fsync leaves no index entry, so the replay's
+		//     HasChunk misses and the bytes are re-appended from the still-live
+		//     append-log rather than being dedup-skipped and lost.
+		//
+		//   - In-process read availability: this sync + commit must precede the
+		//     fence advance, because advanceFenceUpTo destructively TRIMS the
+		//     in-memory logIndex entries. If the trim ran first and the fsync (or
+		//     a commit) then failed transiently — with no crash — the pass would
+		//     return having dropped the interval's entries while the FileChunk
+		//     manifest rows were already written in Phase B. The still-dirty
+		//     interval is then re-picked by a later pass which, finding no
+		//     logIndex coverage, drops it without re-appending; the chunk is
+		//     never committed to the local index. A read would miss BOTH
+		//     ReadPayloadAt paths (append-log replay AND manifest -> local index)
+		//     and hole out to a remote zero-fill of acknowledged data until the
+		//     next restart. Syncing + committing first means a transient failure
+		//     leaves the entries and the dirty interval fully intact for a clean
+		//     retry, and in-window reads keep resolving via the append-log replay.
+		//
+		// nil guard: CAS-only stores do not use a logBlob and are unaffected.
+		if bc.logBlob != nil {
+			if serr := bc.syncLogBlob(); serr != nil {
+				return fmt.Errorf("rollup: fsync log-blob before fence advance: %w", serr)
+			}
+			bc.logBlobRollupSyncCount.Add(1)
+
+			for _, sc := range staged {
+				if cerr := bc.commitStagedChunk(ctx, sc); cerr != nil {
+					return fmt.Errorf("rollup: commit chunk index: %w", cerr)
+				}
+			}
+		}
+
 		// R-7 (#580): mark every surviving record's FILE-OFFSET extent consumed
 		// in the logIndex and ask the index for the new compaction fence. This
 		// is the value we persist as rollup_offset — computed from the consumed
@@ -727,6 +773,10 @@ func (bc *FSStore) rollupFileInner(ctx context.Context, payloadID string, force 
 		// landed during Phase B has its own logIndex entry, NOT in
 		// consumedExtents, so the fence does not advance past it and it is
 		// rolled up by a later pass.
+		//
+		// This is the destructive step: advanceFenceUpTo trims the fenced
+		// entries out of the in-memory index, so it MUST run only after the sync
+		// + commit above have succeeded (see the invariants there).
 		for _, ext := range consumedExtents {
 			idx.MarkConsumed(ext.fileOff, ext.payloadLen)
 		}
@@ -739,39 +789,6 @@ func (bc *FSStore) rollupFileInner(ctx context.Context, payloadID string, force 
 		// retiredBytes is the exact framed-record total the fence retired this
 		// pass — the quantity to release from logBytesTotal below (C3).
 		targetPos, retiredBytes := idx.advanceFenceUpTo(maxReadLogPos)
-
-		// Durability fence: flush the log-blob substrate to durable storage
-		// BEFORE advancing rollup_offset. The previous CAS path fsynced each
-		// chunk file individually in StoreChunk; the log-blob path batches
-		// writes to a single blob file and relies on this single per-pass sync
-		// to provide the same durability guarantee.
-		//
-		// Invariant: a crash after SetRollupOffset returns must never be able
-		// to cause data loss. If the blob bytes were not fsynced first, a crash
-		// between this Sync and SetRollupOffset is safe (recovery replays from
-		// the old fence). A crash after SetRollupOffset with an unsynced blob
-		// would cause recovery to seek past records whose chunk bytes are
-		// missing from disk — unrecoverable data loss.
-		//
-		// nil guard: CAS-only stores do not use a logBlob and are unaffected.
-		if bc.logBlob != nil {
-			if serr := bc.syncLogBlob(); serr != nil {
-				return fmt.Errorf("rollup: fsync log-blob before fence advance: %w", serr)
-			}
-			bc.logBlobRollupSyncCount.Add(1)
-
-			// Blob bytes are now durable. Commit the deferred local-index
-			// entries for the chunks appended this pass. Doing this AFTER the
-			// fsync (and before the fence advances) is the durability fence: a
-			// crash before the fsync leaves no index entry, so the replay's
-			// HasChunk misses and the bytes are re-appended from the still-live
-			// append-log rather than being dedup-skipped and lost.
-			for _, sc := range staged {
-				if cerr := bc.commitStagedChunk(ctx, sc); cerr != nil {
-					return fmt.Errorf("rollup: commit chunk index: %w", cerr)
-				}
-			}
-		}
 
 		// SetRollupOffset is atomic-monotone at the RollupStore layer: on
 		// attempted regression it returns ErrRollupOffsetRegression and the

--- a/pkg/block/local/fs/rollup_index_fence_test.go
+++ b/pkg/block/local/fs/rollup_index_fence_test.go
@@ -1,0 +1,177 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// activeBlobForTest returns the ID and durable size of the log-blob Manager's
+// currently active blob, so a test can truncate it back to that size to model
+// a power-loss that discards an unsynced tail.
+func activeBlobForTest(t *testing.T, bc *FSStore) (string, int64) {
+	t.Helper()
+	blobs, err := bc.logBlob.ListBlobs()
+	if err != nil {
+		t.Fatalf("ListBlobs: %v", err)
+	}
+	for _, b := range blobs {
+		if b.Active {
+			return b.LogBlobID, b.Size
+		}
+	}
+	t.Fatal("no active log blob")
+	return "", 0
+}
+
+// waitStableForTest polls until payloadID's earliest interval ages past the
+// stabilization window (or fails the test on timeout).
+func waitStableForTest(t *testing.T, bc *FSStore, payloadID string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for !bc.EarliestStableForTest(payloadID) {
+		if time.Now().After(deadline) {
+			t.Fatal("interval never stabilized")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// TestRollup_LocalIndex_FencedBehindBlobSync is the crash-durability guard for
+// the log-blob rollup path. It reproduces the power-loss window between a
+// chunk's blob append and the per-pass blob fsync:
+//
+//   - Phase B appends the chunk bytes to the blob (page cache, NOT fsynced).
+//   - Phase C fsyncs the blob, THEN advances the rollup fence.
+//
+// If the durable local-index entry (the one HasChunk dedups on) is committed in
+// Phase B — before the blob is fsynced — a crash in that window leaves a durable
+// index entry pointing past the durable blob length. On replay the rollup re-runs
+// from the un-advanced fence, HasChunk hits the surviving entry, StoreChunk
+// becomes a no-op, and the bytes are never re-appended: once the append-log
+// record is compacted away the acknowledged write is permanently lost.
+//
+// Invariant under test: no durable index entry may exist for a chunk whose blob
+// fsync did not succeed. The test fails the blob Sync mid-pass, then asserts the
+// index still misses (Part A). It then restarts the store — rebuilding the log
+// index from disk and dropping the unsynced blob tail — re-runs a clean rollup,
+// and asserts the chunk is re-appended and reads back byte-identical (Part B).
+//
+// It FAILS against code that commits the index in Phase B (the entry survives
+// the failed sync) and PASSES once the index write is fenced behind the Phase C
+// blob fsync.
+func TestRollup_LocalIndex_FencedBehindBlobSync(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	// Memory stores stand in for the (durable) production LocalChunkIndex and
+	// RollupStore; sharing the SAME instances across the reopen models their
+	// durability surviving a crash.
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	idx := memmeta.NewMemoryMetadataStoreWithDefaults()
+	opts := FSStoreOptions{
+		LocalChunkIndex: idx,
+		RollupStore:     rs,
+		MaxLogBytes:     1 << 30,
+		StabilizationMS: 1,
+		RollupWorkers:   1,
+	}
+
+	bc, err := NewWithOptions(dir, 0, nil, opts)
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+
+	const pid = "logblob/durability/index-fence"
+	// < MinChunkSize (1 MiB) so the write rolls up as exactly one chunk whose
+	// content hash equals blake3 of the whole payload.
+	payload := bytes.Repeat([]byte{0xC1}, 4096)
+	h := blake3ContentHash(payload)
+
+	if err := bc.AppendWrite(ctx, pid, payload, 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+	if ok, err := bc.HasChunk(ctx, h); err != nil || ok {
+		t.Fatalf("HasChunk before rollup = (%v, %v); want (false, nil)", ok, err)
+	}
+
+	waitStableForTest(t, bc, pid)
+
+	// Durable size of the active blob before the pass, so recovery can drop the
+	// unsynced tail the crash left behind.
+	blobID, preSize := activeBlobForTest(t, bc)
+
+	// Crash window: fail the blob fsync exactly once, mid-pass. The pass appends
+	// the chunk to the blob, then the injected fault aborts before the fsync +
+	// fence advance.
+	var failNext atomic.Bool
+	failNext.Store(true)
+	rollupPreSyncFailHook = func() error {
+		if failNext.CompareAndSwap(true, false) {
+			return errors.New("injected: simulated power loss before blob fsync")
+		}
+		return nil
+	}
+	defer func() { rollupPreSyncFailHook = nil }()
+
+	if err := bc.ForceRollupForTest(ctx, pid); err == nil {
+		t.Fatal("ForceRollupForTest: want injected sync failure, got nil")
+	}
+
+	// Part A — invariant: the blob was never fsynced this pass, so no durable
+	// index entry may exist. Pre-fix, Phase B committed it, so the entry survives
+	// and a replay would dedup-skip the re-append and lose the write.
+	if ok, err := bc.HasChunk(ctx, h); err != nil {
+		t.Fatalf("HasChunk after failed-sync pass: %v", err)
+	} else if ok {
+		t.Fatal("durable local-index entry exists for a chunk whose blob fsync did " +
+			"not succeed: a crash here dedup-skips the re-append and loses the write")
+	}
+
+	// --- Simulate crash + restart ---
+	rollupPreSyncFailHook = nil // recovery pass must fsync for real
+	if err := bc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	bc2, err := NewWithOptions(dir, 0, nil, opts)
+	if err != nil {
+		t.Fatalf("NewWithOptions (reopen): %v", err)
+	}
+	t.Cleanup(func() { _ = bc2.Close() })
+
+	// Power loss discards the unsynced blob tail: truncate the reopened blob back
+	// to its pre-append durable size (the crash-recovery reconcile of a torn tail).
+	if err := bc2.logBlob.Recover(ctx, blobID, preSize); err != nil {
+		t.Fatalf("logblob Recover: %v", err)
+	}
+	// Rebuild the in-memory log index + interval trees from the on-disk
+	// append-log (the record survived; the fence never advanced).
+	if err := bc2.Recover(ctx); err != nil {
+		t.Fatalf("FSStore Recover: %v", err)
+	}
+
+	waitStableForTest(t, bc2, pid)
+
+	// Clean replay: HasChunk misses (Part A) so the bytes are re-appended,
+	// fsynced, then indexed.
+	if err := bc2.ForceRollupForTest(ctx, pid); err != nil {
+		t.Fatalf("ForceRollupForTest (recovery pass): %v", err)
+	}
+
+	// Part B — the chunk is durably stored and reads back byte-identical.
+	if ok, err := bc2.HasChunk(ctx, h); err != nil || !ok {
+		t.Fatalf("HasChunk after recovery pass = (%v, %v); want (true, nil)", ok, err)
+	}
+	got, err := bc2.ReadChunk(ctx, h)
+	if err != nil {
+		t.Fatalf("ReadChunk after recovery: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("ReadChunk mismatch after recovery: got %d bytes, want %d", len(got), len(payload))
+	}
+}

--- a/pkg/block/local/fs/rollup_index_fence_test.go
+++ b/pkg/block/local/fs/rollup_index_fence_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/marmos91/dittofs/pkg/block"
 	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
@@ -174,4 +175,104 @@ func TestRollup_LocalIndex_FencedBehindBlobSync(t *testing.T) {
 	if !bytes.Equal(got, payload) {
 		t.Fatalf("ReadChunk mismatch after recovery: got %d bytes, want %d", len(got), len(payload))
 	}
+}
+
+// TestRollup_TransientSyncFailure_ReadableWithoutRestart guards the read
+// availability of an acknowledged write across an IN-PROCESS transient blob
+// fsync failure — no crash, no restart.
+//
+// The rollup Phase C commit sequence must flush + commit the log-blob index
+// BEFORE it destructively trims the in-memory log index (the fence advance).
+// If the trim runs first and the fsync then fails, the pass returns having
+// already dropped the interval's index entries while the FileChunk manifest
+// rows were written earlier in Phase B. The rollup worker keeps running and
+// retries the pass, but with the entries gone the retry sees no log-index
+// coverage for the still-dirty interval and drops it without re-appending —
+// so the chunk is never committed to the local index. A read then misses BOTH
+// ReadPayloadAt paths: step 1 (append-log replay) finds no index entries and
+// step 2 (FileChunk manifest -> local index Get) finds no committed location,
+// yielding ErrFileChunkNotFound and a remote-fallback zero-fill of data the
+// caller already acknowledged — a read hole that only heals on the next
+// process restart.
+//
+// This test injects a one-shot blob fsync failure, asserts the payload is
+// STILL readable in-window (before any retry), then lets the same store retry
+// the pass and asserts the payload reads back byte-identical. It FAILS against
+// a trim-before-sync ordering (both reads miss) and PASSES once sync + commit
+// are fenced ahead of the trim.
+func TestRollup_TransientSyncFailure_ReadableWithoutRestart(t *testing.T) {
+	ctx := context.Background()
+
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	idx := memmeta.NewMemoryMetadataStoreWithDefaults()
+	// Real in-memory FileChunk store + persister so ReadPayloadAt's CAS-manifest
+	// path (step 2) can resolve rolled-up bytes after the fence trims the log
+	// index entries — the only read path left once a pass succeeds.
+	fbs := newMemFileChunkStore()
+	persister := func(pctx context.Context, payloadID string, blocks []block.BlockRef, _ block.ObjectID) error {
+		return fbs.persist(pctx, payloadID, blocks)
+	}
+	opts := FSStoreOptions{
+		LocalChunkIndex:   idx,
+		RollupStore:       rs,
+		ObjectIDPersister: persister,
+		MaxLogBytes:       1 << 30,
+		StabilizationMS:   1,
+		RollupWorkers:     1,
+	}
+
+	bc := newFSStoreForTestWithFBS(t, fbs, opts)
+
+	const pid = "logblob/durability/transient-sync"
+	// < MinChunkSize (1 MiB) so the write rolls up as exactly one chunk.
+	payload := bytes.Repeat([]byte{0xD7}, 4096)
+
+	if err := bc.AppendWrite(ctx, pid, payload, 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+	waitStableForTest(t, bc, pid)
+
+	// Fail the blob fsync exactly once, mid-pass. The pass appends the chunk to
+	// the blob and writes the manifest rows in Phase B, then the injected fault
+	// aborts Phase C before the fence advance.
+	var failNext atomic.Bool
+	failNext.Store(true)
+	rollupPreSyncFailHook = func() error {
+		if failNext.CompareAndSwap(true, false) {
+			return errors.New("injected: transient blob fsync failure")
+		}
+		return nil
+	}
+	defer func() { rollupPreSyncFailHook = nil }()
+
+	if err := bc.ForceRollupForTest(ctx, pid); err == nil {
+		t.Fatal("ForceRollupForTest: want injected sync failure, got nil")
+	}
+
+	// In-window read: the failed pass must NOT have trimmed the log index, so
+	// step 1 (append-log replay) still resolves the payload. Under a
+	// trim-before-sync ordering the entries are gone and this read holes out.
+	readback := func(stage string) {
+		t.Helper()
+		dest := make([]byte, len(payload))
+		n, rerr := bc.ReadPayloadAt(ctx, pid, dest, 0)
+		if rerr != nil {
+			t.Fatalf("ReadPayloadAt (%s) after transient sync failure: %v "+
+				"(acknowledged data holed out to remote zero-fill)", stage, rerr)
+		}
+		if n != len(payload) || !bytes.Equal(dest, payload) {
+			t.Fatalf("ReadPayloadAt (%s) mismatch: got %d bytes, want %d", stage, n, len(payload))
+		}
+	}
+	readback("in-window")
+
+	// Clear the fault and let the SAME store retry the pass, exactly as the
+	// rollup worker would. The interval is still dirty (Phase C never consumed
+	// it), so the retry re-rolls it cleanly and commits the index.
+	rollupPreSyncFailHook = nil
+	waitStableForTest(t, bc, pid)
+	if err := bc.ForceRollupForTest(ctx, pid); err != nil {
+		t.Fatalf("ForceRollupForTest (in-process retry): %v", err)
+	}
+	readback("after-retry")
 }

--- a/pkg/block/local/fs/rollup_logblob_durability_test.go
+++ b/pkg/block/local/fs/rollup_logblob_durability_test.go
@@ -1,0 +1,107 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// newLogBlobStoreWithRollup creates an FSStore with both a LocalChunkIndex
+// (enabling the log-blob write path) and a RollupStore (enabling rollup
+// passes). Used by logblob durability tests only.
+func newLogBlobStoreWithRollup(t *testing.T) *FSStore {
+	t.Helper()
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	idx := memmeta.NewMemoryMetadataStoreWithDefaults()
+	bc, err := NewWithOptions(t.TempDir(), 0, nil, FSStoreOptions{
+		LocalChunkIndex: idx,
+		RollupStore:     rs,
+		MaxLogBytes:     1 << 30,
+		StabilizationMS: 1,
+		RollupWorkers:   1,
+	})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	t.Cleanup(func() { _ = bc.Close() })
+	return bc
+}
+
+// TestRollup_LogBlob_SyncBeforeFenceAdvance is the C1 durability guard for
+// the log-blob rollup path. It asserts that logBlob.Sync() is called at least
+// once per rollup pass — BEFORE SetRollupOffset advances the fence — so that
+// rolled-up chunk bytes are durable on disk before recovery can be instructed
+// to seek past them.
+//
+// The test FAILS against code that has no Sync call (counter stays at 0) and
+// PASSES after the fix inserts logBlob.Sync() in Phase C before SetRollupOffset.
+func TestRollup_LogBlob_SyncBeforeFenceAdvance(t *testing.T) {
+	bc := newLogBlobStoreWithRollup(t)
+	ctx := context.Background()
+	const pid = "logblob/durability/sync"
+
+	// Write enough data to give the rollup pass something to do.
+	if err := bc.AppendWrite(ctx, pid, bytes.Repeat([]byte{0xAB}, 4096), 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+
+	// Wait for the interval to age past the stabilization window.
+	deadline := time.Now().Add(2 * time.Second)
+	for !bc.EarliestStableForTest(pid) {
+		if time.Now().After(deadline) {
+			t.Fatal("interval never stabilized")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	syncBefore := bc.LogBlobRollupSyncCountForTest()
+
+	if err := bc.ForceRollupForTest(ctx, pid); err != nil {
+		t.Fatalf("ForceRollupForTest: %v", err)
+	}
+
+	syncAfter := bc.LogBlobRollupSyncCountForTest()
+	if syncAfter <= syncBefore {
+		t.Fatalf("logBlob.Sync not called during rollup pass: count before=%d after=%d; "+
+			"want after > before (durability: blob bytes must be fsynced before fence advances)",
+			syncBefore, syncAfter)
+	}
+}
+
+// TestRollup_CASOnly_NilLogBlobGuard asserts that the nil logBlob guard is
+// intact: a CAS-only FSStore (no LocalChunkIndex, no logBlob) must complete a
+// rollup pass without panicking and must not increment the logBlob sync counter.
+func TestRollup_CASOnly_NilLogBlobGuard(t *testing.T) {
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	bc := newFSStoreForTest(t, FSStoreOptions{
+		MaxLogBytes:     1 << 30,
+		RollupWorkers:   1,
+		StabilizationMS: 1,
+		RollupStore:     rs,
+	})
+	ctx := context.Background()
+	const pid = "logblob/cas-only/nil-guard"
+
+	if err := bc.AppendWrite(ctx, pid, bytes.Repeat([]byte{0xBC}, 4096), 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !bc.EarliestStableForTest(pid) {
+		if time.Now().After(deadline) {
+			t.Fatal("interval never stabilized")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	if err := bc.ForceRollupForTest(ctx, pid); err != nil {
+		t.Fatalf("ForceRollupForTest: %v", err)
+	}
+
+	if n := bc.LogBlobRollupSyncCountForTest(); n != 0 {
+		t.Fatalf("CAS-only store must not increment logBlob sync counter; got %d", n)
+	}
+}

--- a/pkg/block/local/fs/test_hooks.go
+++ b/pkg/block/local/fs/test_hooks.go
@@ -36,6 +36,14 @@ func (bc *FSStore) BaseDirForTest() string { return bc.baseDir }
 // compute the delta.
 func (bc *FSStore) FlushFsyncCountForTest() int64 { return bc.flushFsyncCount.Load() }
 
+// LogBlobRollupSyncCountForTest returns the cumulative number of times a
+// rollup pass called logBlob.Sync() before advancing the fence. Used by
+// tests to assert the durability invariant: chunk bytes fsynced before
+// rollup_offset advances.
+func (bc *FSStore) LogBlobRollupSyncCountForTest() int64 {
+	return bc.logBlobRollupSyncCount.Load()
+}
+
 // RollupOffsetForTest returns the metadata rollup_offset for payloadID.
 // Returns (0, nil) when no RollupStore is configured.
 func (bc *FSStore) RollupOffsetForTest(ctx context.Context, payloadID string) (uint64, error) {

--- a/pkg/block/remote/memory/seal_chunk_test.go
+++ b/pkg/block/remote/memory/seal_chunk_test.go
@@ -1,0 +1,47 @@
+package memory
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+)
+
+// TestStore_SealChunk_Identity pins the base in-memory store's SealChunk as the
+// identity transform: the wire bytes equal the plaintext, and a PutBlock of
+// those wire bytes round-trips through ReadChunk byte-identical. The base store
+// is the innermost layer of the carve transform stack, so any non-identity here
+// would corrupt every block.
+func TestStore_SealChunk_Identity(t *testing.T) {
+	ctx := context.Background()
+	s := New()
+
+	var sealer remote.ChunkSealer = s // compile-time: base store implements ChunkSealer
+
+	var hash block.ContentHash
+	hash[0] = 0x11
+	plaintext := []byte("the quick brown fox jumps over the lazy dog")
+
+	wire, err := sealer.SealChunk(ctx, hash, plaintext)
+	if err != nil {
+		t.Fatalf("SealChunk: %v", err)
+	}
+	if !bytes.Equal(wire, plaintext) {
+		t.Fatalf("base SealChunk must be identity: got %q want %q", wire, plaintext)
+	}
+
+	// The wire bytes are what a single-chunk block body would contain. Put them
+	// and read them back via ReadChunk; the base read must invert the base seal.
+	if err := s.PutBlock(ctx, "blk-id", bytes.NewReader(wire)); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+	got, err := s.ReadChunk(ctx, "blk-id", 0, int64(len(wire)), hash)
+	if err != nil {
+		t.Fatalf("ReadChunk: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("round-trip mismatch: got %q want %q", got, plaintext)
+	}
+}

--- a/pkg/block/remote/memory/store.go
+++ b/pkg/block/remote/memory/store.go
@@ -22,6 +22,7 @@ var (
 	_ remote.RemoteStore       = (*Store)(nil)
 	_ remote.RemoteBlockStore  = (*Store)(nil)
 	_ remote.ChunkReader       = (*Store)(nil)
+	_ remote.ChunkSealer       = (*Store)(nil)
 	_ block.DurabilityReporter = (*Store)(nil)
 )
 
@@ -214,6 +215,17 @@ func (s *Store) ReadChunk(_ context.Context, blockID string, offset, length int6
 	result := make([]byte, end-offset)
 	copy(result, data[offset:end])
 	return result, nil
+}
+
+// SealChunk implements remote.ChunkSealer as the identity transform: the base
+// store stores chunk bodies verbatim, so the wire bytes equal the plaintext.
+// The compression/encryption decorators wrap this to seal their own layer.
+// A defensive copy is returned so the carver may retain it independently of the
+// caller's plaintext buffer.
+func (s *Store) SealChunk(_ context.Context, _ block.ContentHash, plaintext []byte) ([]byte, error) {
+	out := make([]byte, len(plaintext))
+	copy(out, plaintext)
+	return out, nil
 }
 
 // Durable reports whether accepted bytes survive a crash/restart

--- a/pkg/block/remote/remote.go
+++ b/pkg/block/remote/remote.go
@@ -158,3 +158,25 @@ type RemoteBlockStore interface {
 type ChunkReader interface {
 	ReadChunk(ctx context.Context, blockID string, offset, length int64, hash block.ContentHash) ([]byte, error)
 }
+
+// ChunkSealer is the write-side counterpart to ChunkReader (#1414 object
+// packing). The block carver calls SealChunk on the (possibly decorated) remote
+// store to transform one chunk's raw plaintext bytes into the wire bytes that
+// land inside a packed block object — applying exactly the same per-chunk
+// compression/encryption transforms the standalone CAS Put path applies, in the
+// same order. The carver then frames the returned wire bytes into the block via
+// blockcodec and uploads the assembled block with RemoteBlockStore.PutBlock.
+//
+// SealChunk MUST be byte-for-byte symmetric with ChunkReader.ReadChunk:
+// ReadChunk(GetBlockRange(SealChunk(hash, plaintext))) == plaintext. The base
+// stores (s3, memory) implement it as the identity transform; the compression
+// and encryption decorators seal their own layer and delegate inward, so a
+// decorated chain produces encrypt(compress(plaintext)) — never plaintext at
+// rest on an encrypted share.
+//
+// hash is threaded through so the encryption layer can bind it as AEAD AAD,
+// matching the per-chunk scheme of the standalone Put path. Base stores and the
+// compression layer ignore it.
+type ChunkSealer interface {
+	SealChunk(ctx context.Context, hash block.ContentHash, plaintext []byte) ([]byte, error)
+}

--- a/pkg/block/remote/s3/store.go
+++ b/pkg/block/remote/s3/store.go
@@ -56,6 +56,7 @@ var (
 	_ remote.RemoteStore       = (*Store)(nil)
 	_ remote.RemoteBlockStore  = (*Store)(nil)
 	_ remote.ChunkReader       = (*Store)(nil)
+	_ remote.ChunkSealer       = (*Store)(nil)
 	_ block.DurabilityReporter = (*Store)(nil)
 )
 
@@ -526,6 +527,18 @@ func (s *Store) GetRange(ctx context.Context, hash block.ContentHash, offset, le
 // blockKey returns the full S3 key for a block object identified by blockID.
 func (s *Store) blockKey(blockID string) string {
 	return s.fullKey(block.FormatBlockKey(blockID))
+}
+
+// SealChunk implements remote.ChunkSealer as the identity transform. As a base
+// store there is no per-chunk transform to apply — bodies are stored verbatim —
+// so the wire bytes equal the plaintext. The compression/encryption decorators
+// wrap this to seal their own layer. A defensive copy is returned so the carver
+// may retain it independently of the caller's plaintext buffer. hash is unused
+// at this layer.
+func (s *Store) SealChunk(_ context.Context, _ block.ContentHash, plaintext []byte) ([]byte, error) {
+	out := make([]byte, len(plaintext))
+	copy(out, plaintext)
+	return out, nil
 }
 
 // ReadChunk reads the wire bytes [offset, offset+length) from the block object

--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
@@ -99,54 +100,62 @@ func (r *Runtime) runBlockGCSweep(ctx context.Context, sharePrefix string, dryRu
 		r.metrics.GCFinished(gcResult(total), total.ObjectsSwept, total.BytesFreed, time.Since(gcStart))
 	}()
 	for _, entry := range entries {
-		opts := &engine.Options{
-			DryRun: dryRun,
-			// Thread the remote-store config UUID and the per-remote
-			// share scope into engine.Options so the engine's own
-			// start/complete log lines carry the correlation keys SREs
-			// need for cross-checking against S3 access logs.
-			RemoteEndpointID: entry.ConfigID,
-			Shares:           append([]string(nil), entry.Shares...),
-		}
-		applyGCDefaults(opts, gcDefaults)
-		applyGCProgress(opts, progress)
-		// Inject held hashes from ready snapshots into the GC mark phase.
-		opts.HoldProvider = r.snapshotHoldForRemote(entry.Shares)
-		// The per-remote synced-hash index: the index-sweep candidate source AND
-		// the marker-clear for swept hashes (so they re-upload if they reappear
-		// in the live set) (#1433). Remote sweep only. A steady-state run sweeps
-		// from it; the reconcile path (fullScan) keeps it only for the
-		// marker-clear and Walks the namespace instead.
-		opts.SyncedHashIndex = r.syncedHashStoreForShares(entry.Shares)
-		opts.FullScan = fullScan
-		// Reclaim packed-block chunks (#1414): a swept hash may live inside a
-		// blocks/<id> object, not a standalone cas/<hash>. The per-remote union
-		// reclaimer spans every share on this remote so the owning share frees
-		// the block and non-owning shares are a clean no-op.
-		opts.BlockReclaimer = r.blockReclaimerForEntry(entry)
-		logger.Info("RunBlockGC: starting",
-			"fullScan", opts.FullScan,
-			"configID", entry.ConfigID,
-			"shares", entry.Shares,
-			"dryRun", dryRun,
-			"gracePeriod", opts.GracePeriod,
-			"dryRunSampleSize", opts.DryRunSampleSize)
+		// Serialize every sweep of this remote (see remoteGCLock): a packed-block
+		// reclaim decrement double-counts if two sweeps touch the same
+		// ref-counted remote concurrently.
+		func() {
+			lock := r.remoteGCLock(entry.ConfigID)
+			lock.Lock()
+			defer lock.Unlock()
+			opts := &engine.Options{
+				DryRun: dryRun,
+				// Thread the remote-store config UUID and the per-remote
+				// share scope into engine.Options so the engine's own
+				// start/complete log lines carry the correlation keys SREs
+				// need for cross-checking against S3 access logs.
+				RemoteEndpointID: entry.ConfigID,
+				Shares:           append([]string(nil), entry.Shares...),
+			}
+			applyGCDefaults(opts, gcDefaults)
+			applyGCProgress(opts, progress)
+			// Inject held hashes from ready snapshots into the GC mark phase.
+			opts.HoldProvider = r.snapshotHoldForRemote(entry.Shares)
+			// The per-remote synced-hash index: the index-sweep candidate source AND
+			// the marker-clear for swept hashes (so they re-upload if they reappear
+			// in the live set) (#1433). Remote sweep only. A steady-state run sweeps
+			// from it; the reconcile path (fullScan) keeps it only for the
+			// marker-clear and Walks the namespace instead.
+			opts.SyncedHashIndex = r.syncedHashStoreForShares(entry.Shares)
+			opts.FullScan = fullScan
+			// Reclaim packed-block chunks (#1414): a swept hash may live inside a
+			// blocks/<id> object, not a standalone cas/<hash>. The per-remote union
+			// reclaimer spans every share on this remote so the owning share frees
+			// the block and non-owning shares are a clean no-op.
+			opts.BlockReclaimer = r.blockReclaimerForEntry(entry)
+			logger.Info("RunBlockGC: starting",
+				"fullScan", opts.FullScan,
+				"configID", entry.ConfigID,
+				"shares", entry.Shares,
+				"dryRun", dryRun,
+				"gracePeriod", opts.GracePeriod,
+				"dryRunSampleSize", opts.DryRunSampleSize)
 
-		// Per-remote MultiShareReconciler: the mark phase enumerates
-		// EnumerateFileChunks across every share pointing at this
-		// remote so the live set is the union. Without this, each
-		// share's GC would treat the other's CAS objects as orphans.
-		rec := &perRemoteReconciler{rt: r, shares: entry.Shares}
+			// Per-remote MultiShareReconciler: the mark phase enumerates
+			// EnumerateFileChunks across every share pointing at this
+			// remote so the live set is the union. Without this, each
+			// share's GC would treat the other's CAS objects as orphans.
+			rec := &perRemoteReconciler{rt: r, shares: entry.Shares}
 
-		stats := collectGarbageFn(ctx, entry.Store, rec, opts)
-		s := accumulateGCStats(total, stats, false)
-		logger.Info("RunBlockGC: complete",
-			"configID", entry.ConfigID,
-			"hashesMarked", s.HashesMarked,
-			"objectsSwept", s.ObjectsSwept,
-			"bytesFreed", s.BytesFreed,
-			"errors", s.ErrorCount,
-		)
+			stats := collectGarbageFn(ctx, entry.Store, rec, opts)
+			s := accumulateGCStats(total, stats, false)
+			logger.Info("RunBlockGC: complete",
+				"configID", entry.ConfigID,
+				"hashesMarked", s.HashesMarked,
+				"objectsSwept", s.ObjectsSwept,
+				"bytesFreed", s.BytesFreed,
+				"errors", s.ErrorCount,
+			)
+		}()
 	}
 	// Sweep the local tier too, so one `gc` invocation reclaims orphaned
 	// chunks on both remote and local stores (#1433).
@@ -302,55 +311,64 @@ func (r *Runtime) runBlockGCForShare(ctx context.Context, name string, dryRun bo
 		r.metrics.GCFinished(gcResult(total), total.ObjectsSwept, total.BytesFreed, time.Since(gcStart))
 	}()
 	for _, entry := range entries {
-		opts := &engine.Options{
-			DryRun:      dryRun,
-			GCStateRoot: gcRoot,
-			// Surface per-remote correlation in the engine logs even on
-			// the per-share path.
-			RemoteEndpointID: entry.ConfigID,
-			Shares:           append([]string(nil), entry.Shares...),
-		}
-		applyGCDefaults(opts, gcDefaults)
-		if gracePeriod != nil {
-			// Operator override for this run only: authoritative grace,
-			// including zero (no age guard).
-			opts.GracePeriod = *gracePeriod
-			opts.GracePeriodSet = true
-		}
-		applyGCProgress(opts, progress)
-		// Inject held hashes from ready snapshots into the GC mark phase.
-		opts.HoldProvider = r.snapshotHoldForRemote(entry.Shares)
-		// Per-remote synced-hash index: LIST-free candidate source + marker-clear
-		// for swept hashes (#1433). The live set unions every share on this
-		// remote (perRemoteReconciler below), so a single-share invocation never
-		// treats a sibling share's live block as an orphan.
-		opts.SyncedHashIndex = r.syncedHashStoreForShares(entry.Shares)
-		// Reclaim packed-block chunks (#1414): per-remote union reclaimer, same as
-		// the server-wide sweep.
-		opts.BlockReclaimer = r.blockReclaimerForEntry(entry)
-		// Per-share GC is steady-state (index sweep, no S3 LIST); FullScan stays
-		// false (its zero value).
-		logger.Info("RunBlockGCForShare: starting",
-			"share", name,
-			"configID", entry.ConfigID,
-			"shares", entry.Shares,
-			"dryRun", dryRun,
-			"gcStateRoot", gcRoot,
-			"gracePeriod", opts.GracePeriod,
-			"dryRunSampleSize", opts.DryRunSampleSize,
-		)
+		// Serialize every sweep of this remote against the server-wide,
+		// async, and other per-share paths (see remoteGCLock): they use
+		// different engine gc-state roots, so only this per-remote lock keeps
+		// a packed-block reclaim decrement from double-counting a dead chunk.
+		func() {
+			lock := r.remoteGCLock(entry.ConfigID)
+			lock.Lock()
+			defer lock.Unlock()
+			opts := &engine.Options{
+				DryRun:      dryRun,
+				GCStateRoot: gcRoot,
+				// Surface per-remote correlation in the engine logs even on
+				// the per-share path.
+				RemoteEndpointID: entry.ConfigID,
+				Shares:           append([]string(nil), entry.Shares...),
+			}
+			applyGCDefaults(opts, gcDefaults)
+			if gracePeriod != nil {
+				// Operator override for this run only: authoritative grace,
+				// including zero (no age guard).
+				opts.GracePeriod = *gracePeriod
+				opts.GracePeriodSet = true
+			}
+			applyGCProgress(opts, progress)
+			// Inject held hashes from ready snapshots into the GC mark phase.
+			opts.HoldProvider = r.snapshotHoldForRemote(entry.Shares)
+			// Per-remote synced-hash index: LIST-free candidate source + marker-clear
+			// for swept hashes (#1433). The live set unions every share on this
+			// remote (perRemoteReconciler below), so a single-share invocation never
+			// treats a sibling share's live block as an orphan.
+			opts.SyncedHashIndex = r.syncedHashStoreForShares(entry.Shares)
+			// Reclaim packed-block chunks (#1414): per-remote union reclaimer, same as
+			// the server-wide sweep.
+			opts.BlockReclaimer = r.blockReclaimerForEntry(entry)
+			// Per-share GC is steady-state (index sweep, no S3 LIST); FullScan stays
+			// false (its zero value).
+			logger.Info("RunBlockGCForShare: starting",
+				"share", name,
+				"configID", entry.ConfigID,
+				"shares", entry.Shares,
+				"dryRun", dryRun,
+				"gcStateRoot", gcRoot,
+				"gracePeriod", opts.GracePeriod,
+				"dryRunSampleSize", opts.DryRunSampleSize,
+			)
 
-		rec := &perRemoteReconciler{rt: r, shares: entry.Shares}
-		stats := collectGarbageFn(ctx, entry.Store, rec, opts)
-		s := accumulateGCStats(total, stats, true)
-		logger.Info("RunBlockGCForShare: complete",
-			"share", name,
-			"configID", entry.ConfigID,
-			"hashesMarked", s.HashesMarked,
-			"objectsSwept", s.ObjectsSwept,
-			"bytesFreed", s.BytesFreed,
-			"errors", s.ErrorCount,
-		)
+			rec := &perRemoteReconciler{rt: r, shares: entry.Shares}
+			stats := collectGarbageFn(ctx, entry.Store, rec, opts)
+			s := accumulateGCStats(total, stats, true)
+			logger.Info("RunBlockGCForShare: complete",
+				"share", name,
+				"configID", entry.ConfigID,
+				"hashesMarked", s.HashesMarked,
+				"objectsSwept", s.ObjectsSwept,
+				"bytesFreed", s.BytesFreed,
+				"errors", s.ErrorCount,
+			)
+		}()
 	}
 	// Sweep this share's local tier too (#1433).
 	r.runLocalGC(ctx, name, dryRun, total, progress, gracePeriod)
@@ -521,27 +539,54 @@ func (r *Runtime) syncedHashStoreForShares(shares []string) engine.SyncedHashInd
 // unionBlockReclaimer fans a block-reclaim request across every share's
 // per-share reclaimer on a shared (ref-counted) remote (#1414 object packing,
 // PR3 global flip). The GC sweep reaches a hash only after proving it globally
-// dead, so at most one share owns the enclosing block; the others miss
-// GetLocator and return handled=false cleanly (no error, no spurious
-// LiveChunkCount decrement). The first owner frees the block; a reclaimer error
-// aborts the union (fail-toward-leak — never a premature free of a live dedup
-// sibling). handled=false from every share means the hash is a standalone
-// cas/<hash> object and the sweep deletes it as before.
+// dead. Identical content carved by two shares packs into TWO distinct blocks
+// (random per-share block IDs), one recorded in each share's metadata store, so
+// EVERY share that packed the now-dead hash must be reclaimed — stopping at the
+// first owner would leak the sibling shares' blocks forever. Each per-share
+// reclaimer touches only its own share's block record, so decrementing all of
+// them is correct, not a double-decrement. A reclaimer error aborts the union
+// (fail-toward-leak — never a premature free of a live dedup sibling).
+// handled=false from every share means the hash is a standalone cas/<hash>
+// object and the sweep deletes it as before.
 type unionBlockReclaimer []*engine.BlockGCReclaimer
 
 var _ engine.BlockReclaimer = unionBlockReclaimer(nil)
 
 func (u unionBlockReclaimer) ReclaimDeadChunk(ctx context.Context, hash block.ContentHash) (bool, int64, error) {
+	var anyHandled bool
+	var totalFreed int64
 	for _, rec := range u {
 		handled, freed, err := rec.ReclaimDeadChunk(ctx, hash)
 		if err != nil {
-			return false, 0, err
+			return anyHandled, totalFreed, err
 		}
 		if handled {
-			return true, freed, nil
+			anyHandled = true
+			totalFreed += freed
 		}
 	}
-	return false, 0, nil
+	return anyHandled, totalFreed, nil
+}
+
+// remoteGCLock returns the per-remote serializing mutex for a remote-store
+// config UUID, allocating it on first use and reusing the same pointer
+// thereafter so every GC sweep of that remote contends on ONE lock. Held
+// around a remote's sweep by both the server-wide and per-share paths so a
+// packed-block reclaim's check-then-act decrement cannot double-count a dead
+// chunk (which would free a block a live sibling still needs). Distinct
+// remotes get distinct locks and sweep in parallel.
+func (r *Runtime) remoteGCLock(configID string) *sync.Mutex {
+	r.remoteGCLocksMu.Lock()
+	defer r.remoteGCLocksMu.Unlock()
+	if r.remoteGCLocks == nil {
+		r.remoteGCLocks = make(map[string]*sync.Mutex)
+	}
+	lock, ok := r.remoteGCLocks[configID]
+	if !ok {
+		lock = &sync.Mutex{}
+		r.remoteGCLocks[configID] = lock
+	}
+	return lock
 }
 
 // blockReclaimerForEntry builds the per-remote union BlockReclaimer for a GC

--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -9,6 +9,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/engine"
 	"github.com/marmos91/dittofs/pkg/block/remote"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -118,6 +119,11 @@ func (r *Runtime) runBlockGCSweep(ctx context.Context, sharePrefix string, dryRu
 		// marker-clear and Walks the namespace instead.
 		opts.SyncedHashIndex = r.syncedHashStoreForShares(entry.Shares)
 		opts.FullScan = fullScan
+		// Reclaim packed-block chunks (#1414): a swept hash may live inside a
+		// blocks/<id> object, not a standalone cas/<hash>. The per-remote union
+		// reclaimer spans every share on this remote so the owning share frees
+		// the block and non-owning shares are a clean no-op.
+		opts.BlockReclaimer = r.blockReclaimerForEntry(entry)
 		logger.Info("RunBlockGC: starting",
 			"fullScan", opts.FullScan,
 			"configID", entry.ConfigID,
@@ -319,6 +325,9 @@ func (r *Runtime) runBlockGCForShare(ctx context.Context, name string, dryRun bo
 		// remote (perRemoteReconciler below), so a single-share invocation never
 		// treats a sibling share's live block as an orphan.
 		opts.SyncedHashIndex = r.syncedHashStoreForShares(entry.Shares)
+		// Reclaim packed-block chunks (#1414): per-remote union reclaimer, same as
+		// the server-wide sweep.
+		opts.BlockReclaimer = r.blockReclaimerForEntry(entry)
 		// Per-share GC is steady-state (index sweep, no S3 LIST); FullScan stays
 		// false (its zero value).
 		logger.Info("RunBlockGCForShare: starting",
@@ -507,4 +516,68 @@ func (r *Runtime) syncedHashStoreForShares(shares []string) engine.SyncedHashInd
 		return nil
 	}
 	return stores
+}
+
+// unionBlockReclaimer fans a block-reclaim request across every share's
+// per-share reclaimer on a shared (ref-counted) remote (#1414 object packing,
+// PR3 global flip). The GC sweep reaches a hash only after proving it globally
+// dead, so at most one share owns the enclosing block; the others miss
+// GetLocator and return handled=false cleanly (no error, no spurious
+// LiveChunkCount decrement). The first owner frees the block; a reclaimer error
+// aborts the union (fail-toward-leak — never a premature free of a live dedup
+// sibling). handled=false from every share means the hash is a standalone
+// cas/<hash> object and the sweep deletes it as before.
+type unionBlockReclaimer []*engine.BlockGCReclaimer
+
+var _ engine.BlockReclaimer = unionBlockReclaimer(nil)
+
+func (u unionBlockReclaimer) ReclaimDeadChunk(ctx context.Context, hash block.ContentHash) (bool, int64, error) {
+	for _, rec := range u {
+		handled, freed, err := rec.ReclaimDeadChunk(ctx, hash)
+		if err != nil {
+			return false, 0, err
+		}
+		if handled {
+			return true, freed, nil
+		}
+	}
+	return false, 0, nil
+}
+
+// blockReclaimerForEntry builds the per-remote union BlockReclaimer for a GC
+// sweep: one engine.BlockGCReclaimer per share pointing at this remote, each
+// bound to that share's metadata store (locator / block-record / local-index
+// surfaces) and the shared block-keyed remote. It is set on
+// engine.Options.BlockReclaimer so the sweep reclaims a swept hash that lives
+// inside a blocks/<id> object instead of trying to delete a cas/<hash> object
+// that does not exist.
+//
+// Returns nil when the remote does not implement RemoteBlockStore (cannot hold
+// blocks) or no share resolves — the sweep then deletes standalone cas/<hash>
+// objects exactly as before, so non-block deployments are unaffected. Set for
+// the remote (index) tier only; the local tier and reconcile leave it nil.
+func (r *Runtime) blockReclaimerForEntry(entry shares.RemoteStoreEntry) engine.BlockReclaimer {
+	rbs, ok := entry.Store.(remote.RemoteBlockStore)
+	if !ok {
+		return nil
+	}
+	var u unionBlockReclaimer
+	for _, shareName := range entry.Shares {
+		mds, err := r.GetMetadataStoreForShare(shareName)
+		if err != nil {
+			logger.Warn("GC: block reclaimer unavailable for share — its packed blocks will not be reclaimed this sweep",
+				"share", shareName, "err", err)
+			continue
+		}
+		u = append(u, &engine.BlockGCReclaimer{
+			Locators:     mds,
+			Records:      mds,
+			LocalIndex:   mds,
+			RemoteBlocks: rbs,
+		})
+	}
+	if len(u) == 0 {
+		return nil
+	}
+	return u
 }

--- a/pkg/controlplane/runtime/blockgc_reclaim_test.go
+++ b/pkg/controlplane/runtime/blockgc_reclaim_test.go
@@ -1,0 +1,172 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// testHash derives a deterministic block.ContentHash from a seed string so the
+// reclaim tests can reference the same chunk across two shares.
+func testHash(seed string) block.ContentHash {
+	var h block.ContentHash
+	const fnvPrime = uint64(0x100000001b3)
+	state := uint64(0xcbf29ce484222325)
+	for _, b := range []byte(seed) {
+		state ^= uint64(b)
+		state *= fnvPrime
+	}
+	for i := 0; i < block.HashSize; i++ {
+		h[i] = byte(state >> (uint(i%8) * 8))
+	}
+	return h
+}
+
+// seedShareBlock records, in one share's metadata store, a single-chunk packed
+// block: the block record (LiveChunkCount=1), the chunk's local location, and
+// its synced block-locator backdated past grace. The block bytes are written to
+// the shared remote under blockID. Mirrors what a share's carver produces for a
+// block-resident chunk. Returns the block length recorded.
+func seedShareBlock(t *testing.T, st metadata.Store, rbs remote.RemoteBlockStore, blockID string, h block.ContentHash) int64 {
+	t.Helper()
+	ctx := context.Background()
+	data := []byte("block-bytes-" + blockID)
+	if err := rbs.PutBlock(ctx, blockID, bytes.NewReader(data)); err != nil {
+		t.Fatalf("PutBlock(%s): %v", blockID, err)
+	}
+	if err := st.PutBlockRecord(ctx, block.BlockRecord{
+		BlockID:        blockID,
+		Length:         int64(len(data)),
+		LiveChunkCount: 1,
+		SyncState:      block.BlockStateRemote,
+	}); err != nil {
+		t.Fatalf("PutBlockRecord(%s): %v", blockID, err)
+	}
+	if err := st.PutLocalLocation(ctx, h, block.LocalChunkLocation{LogBlobID: "0000000000000000", RawLength: 64}); err != nil {
+		t.Fatalf("PutLocalLocation: %v", err)
+	}
+	if err := st.MarkSynced(ctx, h, block.ChunkLocator{BlockID: blockID, WireLength: 80}); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+	st.(*metadatamemory.MemoryMetadataStore).MarkSyncedAtForTest(h, time.Now().Add(-2*time.Hour))
+	return int64(len(data))
+}
+
+// TestUnionBlockReclaimer_ReclaimsEveryShare proves the union reclaimer frees
+// the enclosing block in EVERY share that packed a now-dead hash, not just the
+// first. Identical content carved by two shares on a shared remote packs into
+// two distinct blocks (random per-share block IDs); stopping at the first owner
+// would leak the second share's block forever.
+func TestUnionBlockReclaimer_ReclaimsEveryShare(t *testing.T) {
+	ctx := context.Background()
+	stA := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	stB := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	rbs := remotememory.New()
+	defer func() { _ = rbs.Close() }()
+
+	h := testHash("shared-dead-chunk")
+	lenA := seedShareBlock(t, stA, rbs, "blk-a", h)
+	lenB := seedShareBlock(t, stB, rbs, "blk-b", h)
+
+	u := unionBlockReclaimer{
+		{Locators: stA, Records: stA, LocalIndex: stA, RemoteBlocks: rbs},
+		{Locators: stB, Records: stB, LocalIndex: stB, RemoteBlocks: rbs},
+	}
+
+	handled, freed, err := u.ReclaimDeadChunk(ctx, h)
+	if err != nil {
+		t.Fatalf("ReclaimDeadChunk: %v", err)
+	}
+	if !handled {
+		t.Fatal("handled = false, want true (block-resident in both shares)")
+	}
+	if want := lenA + lenB; freed != want {
+		t.Errorf("bytesFreed = %d, want %d (both blocks freed)", freed, want)
+	}
+
+	// Both share block records must be gone.
+	if _, ok, _ := stA.GetBlockRecord(ctx, "blk-a"); ok {
+		t.Error("share A block record survived — its block leaked")
+	}
+	if _, ok, _ := stB.GetBlockRecord(ctx, "blk-b"); ok {
+		t.Error("share B block record survived — its block leaked (I2 early-return bug)")
+	}
+	// Both block objects must be gone from the shared remote.
+	if _, err := rbs.GetBlock(ctx, "blk-a"); err == nil {
+		t.Error("share A block object survived on remote")
+	}
+	if _, err := rbs.GetBlock(ctx, "blk-b"); err == nil {
+		t.Error("share B block object survived on remote — leaked block (I2 early-return bug)")
+	}
+}
+
+// TestBlockGC_SerializesPerRemote proves the server-wide sweep and the
+// per-share sweep never run concurrently against the SAME remote. They use
+// different engine gc-state roots, so only the runtime per-remote lock
+// serializes them; without it a packed-block reclaim decrement double-counts a
+// dead chunk and frees a block a live sibling still needs. The spy sleeps while
+// "inside" a remote's sweep and records the peak concurrency observed per
+// remote config; the fix caps it at 1.
+func TestBlockGC_SerializesPerRemote(t *testing.T) {
+	installCollectGarbageLocalSpy(t)
+
+	var mu sync.Mutex
+	inFlight := map[string]int{}
+	peak := map[string]int{}
+	orig := collectGarbageFn
+	collectGarbageFn = func(_ context.Context, _ remote.RemoteStore, _ engine.MetadataReconciler, opts *engine.Options) *engine.GCStats {
+		cid := opts.RemoteEndpointID
+		mu.Lock()
+		inFlight[cid]++
+		if inFlight[cid] > peak[cid] {
+			peak[cid] = inFlight[cid]
+		}
+		mu.Unlock()
+		// Widen the window so any missing serialization deterministically
+		// overlaps rather than racing by luck.
+		time.Sleep(30 * time.Millisecond)
+		mu.Lock()
+		inFlight[cid]--
+		mu.Unlock()
+		return &engine.GCStats{}
+	}
+	t.Cleanup(func() { collectGarbageFn = orig })
+
+	rs := &fakeRemoteStore{name: "s3-shared"}
+	rt := newRuntimeForGC(t, map[string]remote.RemoteStore{"/share-a": rs})
+
+	// The server-wide sweep (gc-state root "") and the per-share sweep
+	// (gc-state root "<share>/gc-state") both touch the one shared remote.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		if _, err := rt.RunBlockGC(context.Background(), "", false); err != nil {
+			t.Errorf("RunBlockGC: %v", err)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		if _, err := rt.RunBlockGCForShare(context.Background(), "/share-a", false); err != nil {
+			t.Errorf("RunBlockGCForShare: %v", err)
+		}
+	}()
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	for cid, p := range peak {
+		if p > 1 {
+			t.Errorf("remote %s swept by %d concurrent GC passes; per-remote lock must serialize to 1", cid, p)
+		}
+	}
+}

--- a/pkg/controlplane/runtime/blocks_flip_test.go
+++ b/pkg/controlplane/runtime/blocks_flip_test.go
@@ -186,14 +186,18 @@ func TestBlocksFlip_NewWriteCarvesToBlocks(t *testing.T) {
 	t.Cleanup(func() { _ = cp.Close() })
 
 	rt := New(cp)
+
+	metaStore := registerSQLiteMeta(t, rt, cp, "sqlite-meta")
+	localID := createFSLocalBlockStore(t, cp, "fs-local")
+	// Registered AFTER createFSLocalBlockStore so t.Cleanup's LIFO order runs
+	// this (which Close()s the share's block store, releasing the log-blob fd)
+	// BEFORE the block store's t.TempDir() RemoveAll. On Windows an open handle
+	// blocks unlink of blobs/*.blob; Unix tolerates unlink-while-open.
 	t.Cleanup(func() {
 		for _, name := range rt.ListShares() {
 			_ = rt.RemoveShare(name)
 		}
 	})
-
-	metaStore := registerSQLiteMeta(t, rt, cp, "sqlite-meta")
-	localID := createFSLocalBlockStore(t, cp, "fs-local")
 
 	remoteCfg := &models.BlockStoreConfig{Name: "mem-remote", Kind: models.BlockStoreKindRemote, Type: "memory"}
 	remoteID, err := cp.CreateBlockStore(ctx, remoteCfg)
@@ -349,16 +353,20 @@ func TestBlocksFlip_GCUnionReclaimerFreesOwnerOnly(t *testing.T) {
 	t.Cleanup(func() { _ = cp.Close() })
 
 	rt := New(cp)
-	t.Cleanup(func() {
-		for _, name := range rt.ListShares() {
-			_ = rt.RemoveShare(name)
-		}
-	})
 
 	metaA := registerSQLiteMeta(t, rt, cp, "meta-a")
 	metaB := registerSQLiteMeta(t, rt, cp, "meta-b")
 	localA := createFSLocalBlockStore(t, cp, "fs-a")
 	localB := createFSLocalBlockStore(t, cp, "fs-b")
+	// Registered AFTER both createFSLocalBlockStore calls so t.Cleanup's LIFO
+	// order runs this (which Close()s each share's block store, releasing the
+	// log-blob fds) BEFORE the block stores' t.TempDir() RemoveAll. On Windows
+	// an open handle blocks unlink of blobs/*.blob; Unix tolerates unlink-open.
+	t.Cleanup(func() {
+		for _, name := range rt.ListShares() {
+			_ = rt.RemoveShare(name)
+		}
+	})
 
 	// ONE remote config, shared (ref-counted) by both shares.
 	remoteID, err := cp.CreateBlockStore(ctx, &models.BlockStoreConfig{

--- a/pkg/controlplane/runtime/blocks_flip_test.go
+++ b/pkg/controlplane/runtime/blocks_flip_test.go
@@ -1,0 +1,446 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	cpstore "github.com/marmos91/dittofs/pkg/controlplane/store"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	sqlitemeta "github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
+)
+
+// createFileForPayload creates a regular-file inode under the share root in the
+// share's metadata store and returns its PayloadID — the key the block store's
+// write/rollup path is driven by. Mirrors the createEmptyFile helper used by
+// the snapshot byte-verify fixture.
+func createFileForPayload(t *testing.T, ctx context.Context, meta metadata.Store, shareName, name string) (metadata.PayloadID, metadata.FileHandle) {
+	t.Helper()
+	root, err := meta.GetRootHandle(ctx, shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+	path := "/" + name
+	handle, err := meta.GenerateHandle(ctx, shareName, path)
+	if err != nil {
+		t.Fatalf("GenerateHandle %q: %v", name, err)
+	}
+	_, fileID, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		t.Fatalf("DecodeFileHandle %q: %v", name, err)
+	}
+	payloadID := metadata.PayloadID(metadata.BuildPayloadID(shareName, path))
+	file := &metadata.File{
+		ID:        fileID,
+		ShareName: shareName,
+		Path:      path,
+		FileAttr: metadata.FileAttr{
+			Type:      metadata.FileTypeRegular,
+			Mode:      0o644,
+			UID:       1000,
+			GID:       1000,
+			PayloadID: payloadID,
+		},
+	}
+	if err := meta.PutFile(ctx, file); err != nil {
+		t.Fatalf("PutFile %q: %v", name, err)
+	}
+	if err := meta.SetParent(ctx, handle, root); err != nil {
+		t.Fatalf("SetParent %q: %v", name, err)
+	}
+	if err := meta.SetChild(ctx, root, name, handle); err != nil {
+		t.Fatalf("SetChild %q: %v", name, err)
+	}
+	if err := meta.SetLinkCount(ctx, handle, 1); err != nil {
+		t.Fatalf("SetLinkCount %q: %v", name, err)
+	}
+	return payloadID, handle
+}
+
+// flipTestCapabilities mirrors the sqlite conformance capabilities so a
+// real sqlite metadata backend can be constructed in-process.
+func flipTestCapabilities() metadata.FilesystemCapabilities {
+	return metadata.FilesystemCapabilities{
+		MaxReadSize:         1048576,
+		PreferredReadSize:   1048576,
+		MaxWriteSize:        1048576,
+		PreferredWriteSize:  1048576,
+		MaxFileSize:         9223372036854775807,
+		MaxFilenameLen:      255,
+		MaxPathLen:          4096,
+		MaxHardLinkCount:    32767,
+		SupportsHardLinks:   true,
+		SupportsSymlinks:    true,
+		CaseSensitive:       true,
+		CasePreserving:      true,
+		TimestampResolution: 1,
+	}
+}
+
+// registerSQLiteMeta builds a real (on-disk) sqlite metadata store, registers
+// it in the control-plane DB and the runtime, and returns the store handle so
+// the test can assert LocalChunkIndex state directly. A real sqlite backend
+// (not memory) exercises the T2 carryover: GetLocalLocation ↔ logblob ReadAt
+// must agree on the production index backend once prod is flipped.
+func registerSQLiteMeta(t *testing.T, rt *Runtime, cp cpstore.Store, name string) metadata.Store {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := cp.CreateMetadataStore(ctx, &models.MetadataStoreConfig{Name: name, Type: "sqlite"}); err != nil {
+		t.Fatalf("CreateMetadataStore(%s): %v", name, err)
+	}
+	dbPath := filepath.Join(t.TempDir(), name+".db")
+	mds, err := sqlitemeta.NewSQLiteMetadataStore(ctx, &sqlitemeta.SQLiteMetadataStoreConfig{
+		Path:        dbPath,
+		AutoMigrate: true,
+	}, flipTestCapabilities())
+	if err != nil {
+		t.Fatalf("NewSQLiteMetadataStore(%s): %v", name, err)
+	}
+	t.Cleanup(func() { _ = mds.Close() })
+	if err := rt.RegisterMetadataStore(name, mds); err != nil {
+		t.Fatalf("RegisterMetadataStore(%s): %v", name, err)
+	}
+	return mds
+}
+
+// createFSLocalBlockStore creates an fs (log-blob) local block store config in
+// the DB with a fresh temp path and returns its config ID. The fs backend is
+// what exposes the log-blob substrate the carver reads from — a memory local
+// store leaves carve disabled.
+func createFSLocalBlockStore(t *testing.T, cp cpstore.Store, name string) string {
+	t.Helper()
+	cfg := &models.BlockStoreConfig{
+		Name: name,
+		Kind: models.BlockStoreKindLocal,
+		Type: "fs",
+	}
+	if err := cfg.SetConfig(map[string]any{"path": t.TempDir()}); err != nil {
+		t.Fatalf("SetConfig(%s): %v", name, err)
+	}
+	id, err := cp.CreateBlockStore(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("CreateBlockStore(local %s): %v", name, err)
+	}
+	return id
+}
+
+// remoteForShare returns the underlying remote store for a share's remote
+// config so the test can count CAS objects (Walk) vs block objects
+// (WalkBlocks) directly on the memory backend.
+func remoteForShare(t *testing.T, rt *Runtime) (remote.RemoteStore, remote.RemoteBlockStore) {
+	t.Helper()
+	entries := rt.sharesSvc.DistinctRemoteStores()
+	if len(entries) == 0 {
+		t.Fatal("no distinct remote stores registered")
+	}
+	rs := entries[0].Store
+	rbs, ok := rs.(remote.RemoteBlockStore)
+	if !ok {
+		t.Fatalf("remote store %T does not implement RemoteBlockStore", rs)
+	}
+	return rs, rbs
+}
+
+func countCAS(t *testing.T, rs remote.RemoteStore) int {
+	t.Helper()
+	n := 0
+	if err := rs.Walk(context.Background(), func(block.ContentHash, block.Meta) error { n++; return nil }); err != nil {
+		t.Fatalf("Walk (cas count): %v", err)
+	}
+	return n
+}
+
+func countBlocks(t *testing.T, rbs remote.RemoteBlockStore) int {
+	t.Helper()
+	n := 0
+	if err := rbs.WalkBlocks(context.Background(), func(string, block.Meta) error { n++; return nil }); err != nil {
+		t.Fatalf("WalkBlocks (block count): %v", err)
+	}
+	return n
+}
+
+// TestBlocksFlip_NewWriteCarvesToBlocks is the T6 activation proof at the
+// runtime/shares level on a real (sqlite) metadata backend. Once the carve
+// substrate is wired globally in createBlockStoreForShare, a fresh share's new
+// write must produce a blocks/<id> object (carve) and NEVER a cas/<hash> object
+// (legacy mirrorChunk). The read path resolves the block byte-identically, and
+// the sqlite LocalChunkIndex round-trips (the T2 GetLocalLocation↔ReadAt
+// carryover, previously exercised only on the memory index).
+func TestBlocksFlip_NewWriteCarvesToBlocks(t *testing.T) {
+	ctx := context.Background()
+
+	cp, err := cpstore.New(&cpstore.Config{
+		Type:   cpstore.DatabaseTypeSQLite,
+		SQLite: cpstore.SQLiteConfig{Path: ":memory:"},
+	})
+	if err != nil {
+		t.Fatalf("cpstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cp.Close() })
+
+	rt := New(cp)
+	t.Cleanup(func() {
+		for _, name := range rt.ListShares() {
+			_ = rt.RemoveShare(name)
+		}
+	})
+
+	metaStore := registerSQLiteMeta(t, rt, cp, "sqlite-meta")
+	localID := createFSLocalBlockStore(t, cp, "fs-local")
+
+	remoteCfg := &models.BlockStoreConfig{Name: "mem-remote", Kind: models.BlockStoreKindRemote, Type: "memory"}
+	remoteID, err := cp.CreateBlockStore(ctx, remoteCfg)
+	if err != nil {
+		t.Fatalf("CreateBlockStore(remote): %v", err)
+	}
+
+	shareName := "/blocks-flip"
+	if err := rt.AddShare(ctx, &ShareConfig{
+		Name:               shareName,
+		MetadataStore:      "sqlite-meta",
+		LocalBlockStoreID:  localID,
+		RemoteBlockStoreID: remoteID,
+		Enabled:            true,
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+
+	bs, err := rt.sharesSvc.GetBlockStoreForShare(shareName)
+	if err != nil {
+		t.Fatalf("GetBlockStoreForShare: %v", err)
+	}
+
+	payload, _ := createFileForPayload(t, ctx, metaStore, shareName, "file-1")
+	data := bytes.Repeat([]byte("dittofs-blocks-flip-payload!"), 4096) // ~112 KiB
+	if err := common.WriteToBlockStore(ctx, bs, payload, data, 0); err != nil {
+		t.Fatalf("WriteToBlockStore: %v", err)
+	}
+	if err := common.CommitBlockStore(ctx, bs, payload); err != nil {
+		t.Fatalf("CommitBlockStore: %v", err)
+	}
+	// Force rollup (append-log → log-blob + LocalChunkIndex + FileChunks) then
+	// carve/mirror. On a flipped share this drains the carve set into blocks/.
+	if err := bs.DrainAllUploads(ctx); err != nil {
+		t.Fatalf("DrainAllUploads: %v", err)
+	}
+
+	rs, rbs := remoteForShare(t, rt)
+
+	if got := countBlocks(t, rbs); got == 0 {
+		t.Fatalf("no block object created — carve did not run (flip not wired); blocks=%d", got)
+	}
+	// Definitive proof mirrorChunk was never called on the new write path: its
+	// ONLY observable output is a standalone cas/<hash> PUT (remoteStore.Put).
+	// Zero cas objects with a block present means every chunk routed through the
+	// carver, never the legacy standalone mirror. (SyncCounts is NOT a spy here:
+	// the carve commit path shares the completedSyncs counter with mirrorChunk.)
+	if got := countCAS(t, rs); got != 0 {
+		t.Fatalf("new write produced %d cas/ object(s) — mirrorChunk ran (flip not wired)", got)
+	}
+
+	// T2 carryover on sqlite: every carved chunk keeps a LocalChunkIndex entry
+	// (carve commits the local location; only GC removes it). Pick the payload's
+	// chunk hashes and assert GetLocalLocation resolves — the same lookup the
+	// index-hit read path uses (GetLocalLocation → ReadLocalAt).
+	rows, err := metaStore.ListFileChunks(ctx, string(payload))
+	if err != nil {
+		t.Fatalf("ListFileChunks: %v", err)
+	}
+	if len(rows) == 0 {
+		t.Fatal("no FileChunk rows persisted for payload")
+	}
+	for _, fb := range rows {
+		if fb == nil || fb.Hash.IsZero() {
+			continue
+		}
+		loc, ok, err := metaStore.GetLocalLocation(ctx, fb.Hash)
+		if err != nil {
+			t.Fatalf("GetLocalLocation(%s): %v", fb.Hash, err)
+		}
+		if !ok {
+			t.Fatalf("GetLocalLocation(%s): not found — carve did not persist local index on sqlite", fb.Hash)
+		}
+		if loc.RawLength == 0 {
+			t.Fatalf("GetLocalLocation(%s): zero RawLength", fb.Hash)
+		}
+	}
+
+	// Read back through the block path: byte-identical.
+	res, err := common.ReadFromBlockStore(ctx, bs, payload, 0, uint32(len(data)))
+	if err != nil {
+		t.Fatalf("ReadFromBlockStore: %v", err)
+	}
+	if !bytes.Equal(res.Data, data) {
+		t.Fatalf("read mismatch: got %d bytes not equal to written %d", len(res.Data), len(data))
+	}
+}
+
+// writeAndCarve creates a file, writes data, and drains it into a carved block.
+// Returns the payloadID and the blockID the chunk landed in.
+func writeAndCarve(t *testing.T, ctx context.Context, bs *engine.Store, meta metadata.Store, shareName, name string, data []byte) (metadata.PayloadID, metadata.FileHandle, string) {
+	t.Helper()
+	payload, handle := createFileForPayload(t, ctx, meta, shareName, name)
+	if err := common.WriteToBlockStore(ctx, bs, payload, data, 0); err != nil {
+		t.Fatalf("WriteToBlockStore(%s): %v", name, err)
+	}
+	if err := common.CommitBlockStore(ctx, bs, payload); err != nil {
+		t.Fatalf("CommitBlockStore(%s): %v", name, err)
+	}
+	if err := bs.DrainAllUploads(ctx); err != nil {
+		t.Fatalf("DrainAllUploads(%s): %v", name, err)
+	}
+	rows, err := meta.ListFileChunks(ctx, string(payload))
+	if err != nil || len(rows) == 0 {
+		t.Fatalf("ListFileChunks(%s): rows=%d err=%v", name, len(rows), err)
+	}
+	loc, ok, err := meta.GetLocator(ctx, rows[0].Hash)
+	if err != nil || !ok || loc.IsStandalone() {
+		t.Fatalf("GetLocator(%s): ok=%v standalone=%v err=%v — chunk not carved into a block", name, ok, loc.IsStandalone(), err)
+	}
+	return payload, handle, loc.BlockID
+}
+
+// unlinkFile simulates a fully-reconciled unlink: it removes the file inode (so
+// the file_block_refs / nlink>0 mark arm no longer references the hash) and
+// drops every file_blocks (FileChunk) row for the payload (the unconditional
+// mark arm). After both, EnumerateFileChunks no longer reports the hash — it is
+// globally dead for the GC mark phase.
+func unlinkFile(t *testing.T, ctx context.Context, meta metadata.Store, handle metadata.FileHandle, payload metadata.PayloadID) {
+	t.Helper()
+	rows, err := meta.ListFileChunks(ctx, string(payload))
+	if err != nil {
+		t.Fatalf("ListFileChunks(unlink): %v", err)
+	}
+	if err := meta.DeleteFile(ctx, handle); err != nil {
+		t.Fatalf("DeleteFile(unlink): %v", err)
+	}
+	for _, fb := range rows {
+		if err := meta.Delete(ctx, fb.ID); err != nil {
+			t.Fatalf("Delete file chunk %q: %v", fb.ID, err)
+		}
+	}
+}
+
+// TestBlocksFlip_GCUnionReclaimerFreesOwnerOnly proves the runtime wires a
+// per-remote UNION BlockReclaimer across every share on a shared (ref-counted)
+// remote, and that a share which does NOT own a swept block is a clean no-op —
+// no error, no spurious LiveChunkCount decrement (ADDITION 1).
+//
+// Shares A and B point at ONE remote config. Each carves its own block. After
+// A's file is unlinked, a grace-0 GC sweep must free A's block (via A's
+// metadata) while B's block record and its data are untouched.
+func TestBlocksFlip_GCUnionReclaimerFreesOwnerOnly(t *testing.T) {
+	ctx := context.Background()
+
+	cp, err := cpstore.New(&cpstore.Config{
+		Type:   cpstore.DatabaseTypeSQLite,
+		SQLite: cpstore.SQLiteConfig{Path: ":memory:"},
+	})
+	if err != nil {
+		t.Fatalf("cpstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cp.Close() })
+
+	rt := New(cp)
+	t.Cleanup(func() {
+		for _, name := range rt.ListShares() {
+			_ = rt.RemoveShare(name)
+		}
+	})
+
+	metaA := registerSQLiteMeta(t, rt, cp, "meta-a")
+	metaB := registerSQLiteMeta(t, rt, cp, "meta-b")
+	localA := createFSLocalBlockStore(t, cp, "fs-a")
+	localB := createFSLocalBlockStore(t, cp, "fs-b")
+
+	// ONE remote config, shared (ref-counted) by both shares.
+	remoteID, err := cp.CreateBlockStore(ctx, &models.BlockStoreConfig{
+		Name: "shared-remote", Kind: models.BlockStoreKindRemote, Type: "memory",
+	})
+	if err != nil {
+		t.Fatalf("CreateBlockStore(remote): %v", err)
+	}
+
+	shareA, shareB := "/share-a", "/share-b"
+	if err := rt.AddShare(ctx, &ShareConfig{Name: shareA, MetadataStore: "meta-a", LocalBlockStoreID: localA, RemoteBlockStoreID: remoteID, Enabled: true}); err != nil {
+		t.Fatalf("AddShare A: %v", err)
+	}
+	if err := rt.AddShare(ctx, &ShareConfig{Name: shareB, MetadataStore: "meta-b", LocalBlockStoreID: localB, RemoteBlockStoreID: remoteID, Enabled: true}); err != nil {
+		t.Fatalf("AddShare B: %v", err)
+	}
+
+	bsA, err := rt.sharesSvc.GetBlockStoreForShare(shareA)
+	if err != nil {
+		t.Fatalf("GetBlockStoreForShare A: %v", err)
+	}
+	bsB, err := rt.sharesSvc.GetBlockStoreForShare(shareB)
+	if err != nil {
+		t.Fatalf("GetBlockStoreForShare B: %v", err)
+	}
+
+	// Distinct content per share → distinct blocks on the shared remote.
+	dataA := bytes.Repeat([]byte("aaaa-share-A-content!"), 4096)
+	dataB := bytes.Repeat([]byte("bbbb-share-B-content!"), 4096)
+	payloadA, handleA, blockA := writeAndCarve(t, ctx, bsA, metaA, shareA, "a", dataA)
+	_, _, blockB := writeAndCarve(t, ctx, bsB, metaB, shareB, "b", dataB)
+	if blockA == blockB {
+		t.Fatalf("blocks collided: A=%s B=%s (distinct content must yield distinct blocks)", blockA, blockB)
+	}
+
+	// One shared remote holds both blocks.
+	_, rbs := remoteForShare(t, rt)
+	if got := countBlocks(t, rbs); got != 2 {
+		t.Fatalf("expected 2 block objects on shared remote, got %d", got)
+	}
+
+	// Capture B's block record (owner-untouched invariant).
+	recBBefore, ok, err := metaB.GetBlockRecord(ctx, blockB)
+	if err != nil || !ok {
+		t.Fatalf("GetBlockRecord(B) before: ok=%v err=%v", ok, err)
+	}
+
+	// Unlink A's file: remove the inode + its FileChunk rows so the mark phase
+	// sees A's hash as globally dead.
+	unlinkFile(t, ctx, metaA, handleA, payloadA)
+
+	// Grace-0 GC over the shared remote. This routes through the per-remote union
+	// reclaimer spanning A and B.
+	zero := time.Duration(0)
+	if _, err := rt.runBlockGCForShare(ctx, shareA, false, nil, &zero); err != nil {
+		t.Fatalf("runBlockGCForShare: %v", err)
+	}
+
+	// A's block freed remotely; only B's remains.
+	if got := countBlocks(t, rbs); got != 1 {
+		t.Fatalf("expected 1 block after GC (A freed), got %d", got)
+	}
+	// A's block record gone.
+	if _, ok, err := metaA.GetBlockRecord(ctx, blockA); err != nil || ok {
+		t.Fatalf("A block record should be deleted: ok=%v err=%v", ok, err)
+	}
+	// B's block record untouched: present with the SAME LiveChunkCount — B's
+	// reclaimer was a clean no-op for A's dead hash.
+	recBAfter, ok, err := metaB.GetBlockRecord(ctx, blockB)
+	if err != nil || !ok {
+		t.Fatalf("GetBlockRecord(B) after: ok=%v err=%v — B's record was wrongly touched", ok, err)
+	}
+	if recBAfter.LiveChunkCount != recBBefore.LiveChunkCount {
+		t.Fatalf("B LiveChunkCount changed: before=%d after=%d — union reclaimer touched a non-owning share", recBBefore.LiveChunkCount, recBAfter.LiveChunkCount)
+	}
+
+	// B's data still reads byte-identical.
+	res, err := common.ReadFromBlockStore(ctx, bsB, metadata.PayloadID(metadata.BuildPayloadID(shareB, "/b")), 0, uint32(len(dataB)))
+	if err != nil {
+		t.Fatalf("ReadFromBlockStore(B) after GC: %v", err)
+	}
+	if !bytes.Equal(res.Data, dataB) {
+		t.Fatal("B data corrupted after A's GC")
+	}
+}

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -133,6 +133,20 @@ type Runtime struct {
 	restoreLocks   map[string]*sync.Mutex
 	restoreLocksMu sync.Mutex
 
+	// remoteGCLocks serializes block-store GC sweeps that touch the same
+	// remote, keyed by the remote-store config UUID used for ref-counting.
+	// A packed-block reclaim is a check-then-act (read the chunk's local
+	// index entry, delete it, then decrement its block's live-chunk count):
+	// two sweeps over the same ref-counted remote could both observe a dead
+	// chunk's entry before either delete commits, decrement its block twice
+	// for one dead chunk, and free a block a still-live sibling chunk needs
+	// — silent data loss. The server-wide, per-share, and async GC paths use
+	// different engine gc-state roots, so the engine's per-root lock does not
+	// serialize them against each other; holding this lock around each
+	// remote's sweep does, while leaving DISTINCT remotes fully parallel.
+	remoteGCLocks   map[string]*sync.Mutex
+	remoteGCLocksMu sync.Mutex
+
 	// runtimeCtx is a long-lived ctx cancelled by Runtime.Shutdown.
 	// Snapshot orchestration goroutines derive their
 	// child ctx from this so they outlive any caller request ctx
@@ -178,6 +192,7 @@ func New(s store.Store) *Runtime {
 		snapInFlight:     make(map[string]*snapInFlight),
 		snapDeleteLocks:  make(map[string]*sync.RWMutex),
 		restoreLocks:     make(map[string]*sync.Mutex),
+		remoteGCLocks:    make(map[string]*sync.Mutex),
 		storesSvc:        stores.New(),
 		sharesSvc:        shares.New(),
 		lifecycleSvc:     lifecycle.New(DefaultShutdownTimeout),

--- a/pkg/controlplane/runtime/shares/create_local_store_test.go
+++ b/pkg/controlplane/runtime/shares/create_local_store_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/local/fs"
 	metamem "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
@@ -166,35 +167,31 @@ func TestCreateLocalStoreFromConfig_RollupSurvivesCallerCancel(t *testing.T) {
 	}
 
 	// Poll for the rollup ticker (50ms stabilization) to fold the append log
-	// into CAS chunks on disk. A live pool converts within a few ticks; a
-	// pool killed by the cancelled caller context never does. We assert on
-	// physical CAS chunk files (the bare FSStore, with no engine wired, still
-	// writes chunks and advances the rollup offset — the FileChunk manifest is
-	// the engine's job, not the store's).
-	casDir := filepath.Join(tmp, "shares", "cancel-share", "blocks")
+	// into chunks. A live pool converts within a few ticks; a pool killed by the
+	// cancelled caller context never does. With the block-storage flip
+	// (#1414/PR3) CreateLocalStoreFromConfig wires a LocalChunkIndex, so the
+	// rollup routes chunks to the log-blob substrate and records their positions
+	// in the index rather than writing cas/<hash> files. We assert on those index
+	// entries — the observable proof that the rollup pool ran despite the
+	// cancelled caller context.
 	deadline := time.Now().Add(5 * time.Second)
 	for {
-		if n := countFiles(casDir); n > 0 {
+		n := 0
+		if err := mds.WalkLocalLocations(context.Background(), func(block.ContentHash, block.LocalChunkLocation) error {
+			n++
+			return nil
+		}); err != nil {
+			t.Fatalf("WalkLocalLocations: %v", err)
+		}
+		if n > 0 {
 			return // rollup ran despite the cancelled caller context — fixed.
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("rollup never produced CAS chunks after caller-context cancel (#1405): "+
-				"0 chunk files under %s", casDir)
+			t.Fatalf("rollup never recorded log-blob chunks after caller-context cancel (#1405): " +
+				"0 LocalChunkIndex entries")
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-}
-
-// countFiles returns the number of regular files anywhere under root.
-func countFiles(root string) int {
-	n := 0
-	_ = filepath.Walk(root, func(_ string, info os.FileInfo, err error) error {
-		if err == nil && info != nil && info.Mode().IsRegular() {
-			n++
-		}
-		return nil
-	})
-	return n
 }
 
 // statDir wraps os.Stat so tests can assert the block directory was

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -382,6 +382,64 @@ func (n *nonClosingRemote) Close() error { return nil }
 // spurious ErrNotDurableYet on every commit.
 func (n *nonClosingRemote) Durable() bool { return block.IsDurable(n.RemoteStore) }
 
+// --- remote.RemoteBlockStore proxy (#1414 object packing) ---
+//
+// The no-op-Close wrapper embeds only remote.RemoteStore, so without these
+// forwards it would silently HIDE the block-keyed surface (PutBlock/GetBlock/
+// GetBlockRange/DeleteBlock/WalkBlocks) of a wrapped store that implements it —
+// exactly the trap the Durable() forward above fixes for durability. The
+// snapshot durability-verify gate reaches the block store via
+// engine.Store.RemoteStore() (this wrapper), so it MUST be able to probe a
+// packed blocks/<id> object. Each method delegates to the embedded store when it
+// implements RemoteBlockStore; otherwise it returns remote.ErrChunkReadUnsupported
+// (a standalone-only remote is never asked for a block via the locator path).
+func (n *nonClosingRemote) blockInner() (remote.RemoteBlockStore, error) {
+	if rbs, ok := n.RemoteStore.(remote.RemoteBlockStore); ok {
+		return rbs, nil
+	}
+	return nil, remote.ErrChunkReadUnsupported
+}
+
+func (n *nonClosingRemote) PutBlock(ctx context.Context, blockID string, r io.Reader) error {
+	rbs, err := n.blockInner()
+	if err != nil {
+		return err
+	}
+	return rbs.PutBlock(ctx, blockID, r)
+}
+
+func (n *nonClosingRemote) GetBlock(ctx context.Context, blockID string) ([]byte, error) {
+	rbs, err := n.blockInner()
+	if err != nil {
+		return nil, err
+	}
+	return rbs.GetBlock(ctx, blockID)
+}
+
+func (n *nonClosingRemote) GetBlockRange(ctx context.Context, blockID string, offset, length int64) ([]byte, error) {
+	rbs, err := n.blockInner()
+	if err != nil {
+		return nil, err
+	}
+	return rbs.GetBlockRange(ctx, blockID, offset, length)
+}
+
+func (n *nonClosingRemote) DeleteBlock(ctx context.Context, blockID string) error {
+	rbs, err := n.blockInner()
+	if err != nil {
+		return err
+	}
+	return rbs.DeleteBlock(ctx, blockID)
+}
+
+func (n *nonClosingRemote) WalkBlocks(ctx context.Context, fn func(blockID string, meta block.Meta) error) error {
+	rbs, err := n.blockInner()
+	if err != nil {
+		return err
+	}
+	return rbs.WalkBlocks(ctx, fn)
+}
+
 // Service manages share registration, lookup, and configuration.
 type Service struct {
 	mu       sync.RWMutex
@@ -862,6 +920,24 @@ func (s *Service) createBlockStoreForShare(
 	if engineRemote != nil {
 		if fsStore, ok := localStore.(*fs.FSStore); ok {
 			fsStore.SetBackpressureSource(syncer)
+		}
+	}
+
+	// Wire the block-carve substrate (#1414 object packing, PR3 global flip).
+	// Assert on the RAW remoteStore, not engineRemote: the nonClosingRemote
+	// wrapper embeds only remote.RemoteStore and deliberately does NOT proxy the
+	// block-keyed PutBlock/GetBlock/DeleteBlock/WalkBlocks surface, so a
+	// type-assert on the wrapper would always miss. Every shipped remote (memory,
+	// s3) implements RemoteBlockStore, so this flips carve on for EVERY share
+	// with a remote — no feature flag. SetSyncedHashStore (called by engine.New
+	// below) derives the blockCommitter from the same per-share metadata store
+	// and recomputes carveActive; once all deps are set, new writes route to the
+	// carver (blocks/) and never to the legacy standalone mirror (cas/). A remote
+	// that does not implement RemoteBlockStore leaves carve disabled and the
+	// legacy per-hash mirror in effect (back-compat).
+	if remoteStore != nil {
+		if rbs, ok := remoteStore.(remote.RemoteBlockStore); ok {
+			syncer.SetRemoteBlockStore(rbs)
 		}
 	}
 
@@ -2489,6 +2565,15 @@ func CreateLocalStoreFromConfig(
 		// remote is wired (mirror loop early-exits in that case).
 		if shs, ok := fileChunkStore.(metadata.SyncedHashStore); ok {
 			fsOpts.SyncedHashStore = shs
+		}
+		// Wire the LocalChunkIndex from the same metadata backend (#1414 object
+		// packing, PR3 global flip). With it set, rollup routes chunk persistence
+		// to the log-blob substrate + PutLocalLocation instead of the legacy CAS
+		// StoreChunk — the local half of the flip that makes the engine carver's
+		// GetLocalLocation→ReadLocalAt path resolvable. A backend that does not
+		// implement LocalChunkIndex leaves the local tier on the legacy CAS path.
+		if lci, ok := fileChunkStore.(metadata.LocalChunkIndex); ok {
+			fsOpts.LocalChunkIndex = lci
 		}
 		store, err := fs.NewWithOptions(shareDir, maxDisk, fileChunkStore, fsOpts)
 		if err != nil {

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -12,11 +12,32 @@ import (
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/remote"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/snapshot"
 )
+
+// verifyRemoteDurability wraps snapshot.VerifyRemoteDurability with the
+// block-awareness the storage flip requires (#1414 object packing, PR3). It
+// resolves the share's metadata store as the per-hash locator source and the
+// remote as a block store, so a hash carved into a packed blocks/<id> object is
+// probed against that block rather than a standalone cas/<hash> object that no
+// longer exists. A metadata store that cannot be resolved, or a remote that
+// does not implement RemoteBlockStore, degrades to the standalone-CAS probe
+// (nil resolver / nil block store) — safe for legacy CAS-only data.
+func (r *Runtime) verifyRemoteDurability(ctx context.Context, shareName string, remoteStore remote.RemoteStore, manifest *block.HashSet, concurrency int) error {
+	var locators snapshot.HashLocatorResolver
+	if mds, err := r.GetMetadataStoreForShare(shareName); err == nil {
+		locators = mds
+	} else {
+		logger.Warn("snapshot verify: metadata store unavailable — probing hashes as standalone CAS only",
+			"share", shareName, "err", err)
+	}
+	rbs, _ := remoteStore.(remote.RemoteBlockStore)
+	return snapshot.VerifyRemoteDurability(ctx, remoteStore, locators, rbs, manifest, concurrency)
+}
 
 // CreateSnapshotOpts is the operator-facing configuration for one
 // CreateSnapshot invocation. Zero-value (NoVerify=false, RetryOf="")
@@ -686,7 +707,7 @@ func (r *Runtime) runSnapshotOrchestration(
 	logger.Debug("snapshot create: verify start",
 		"snapshot_id", snapID, "share", shareName,
 		"verify_concurrency", concurrency)
-	verr := snapshot.VerifyRemoteDurability(ctx, remoteStore, hashSet, concurrency)
+	verr := r.verifyRemoteDurability(ctx, shareName, remoteStore, hashSet, concurrency)
 	if verr != nil && errors.Is(verr, block.ErrChunkNotFound) {
 		// One drain + re-verify retry. Common cause: syncer was behind
 		// during the first verify; a fresh drain catches up.
@@ -700,7 +721,7 @@ func (r *Runtime) runSnapshotOrchestration(
 				"snapshot_id", snapID, "share", shareName, "error", derr)
 			return
 		}
-		verr = snapshot.VerifyRemoteDurability(ctx, remoteStore, hashSet, concurrency)
+		verr = r.verifyRemoteDurability(ctx, shareName, remoteStore, hashSet, concurrency)
 	}
 	if verr != nil {
 		terminalErr = fmt.Errorf("snapshot create %s: verify: %w: %v",
@@ -1299,7 +1320,7 @@ func (r *Runtime) restoreSnapshot(
 			"manifest_count", manifest.Len(),
 			"verify_concurrency", concurrency,
 		)
-		if verr := snapshot.VerifyRemoteDurability(ctx, remoteStore, manifest, concurrency); verr != nil {
+		if verr := r.verifyRemoteDurability(ctx, shareName, remoteStore, manifest, concurrency); verr != nil {
 			return "", fmt.Errorf("restore snapshot %q: pre-verify: %w: %v",
 				snapID, models.ErrRestoreVerifyFailed, verr)
 		}
@@ -1514,7 +1535,7 @@ func (r *Runtime) restoreSnapshot(
 			"restored_count", restoredCount,
 			"verify_concurrency", concurrency,
 		)
-		if verr := snapshot.VerifyRemoteDurability(ctx, remoteStore, restoredHashes, concurrency); verr != nil {
+		if verr := r.verifyRemoteDurability(ctx, shareName, remoteStore, restoredHashes, concurrency); verr != nil {
 			return safetySnapshotID, fmt.Errorf("restore snapshot %q: post-verify (safety-snap=%s): %w: %v",
 				snapID, safetySnapshotID, models.ErrRestoreVerifyFailed, verr)
 		}

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -509,11 +509,20 @@ func (r *Runtime) runSnapshotOrchestration(
 	// CRUD methods only need (shareName, id) so we don't need to refetch.
 	snap := &models.Snapshot{ID: snapID, ShareName: shareName}
 
-	// --- Step 0: Drain rollups BEFORE WriteSnapshot ---
-	// Force every dirty append-log payload through rollup into CAS + the
-	// FileChunk manifest so the WriteSnapshot() below sees a fully-populated
-	// FileAttr.Blocks. Without this, a snapshot taken before the async
-	// rollup catches up captures an empty/partial manifest.
+	// --- Step 0: Drain rollups AND carve BEFORE WriteSnapshot ---
+	// Force every dirty append-log payload through rollup into the FileChunk
+	// manifest AND drain the block carver/mirror so the WriteSnapshot() below
+	// sees both a fully-populated FileAttr.Blocks AND — critically for the
+	// blocks-only storage flip (#1414) — the per-hash block LOCATORS that carve
+	// mints via MarkSynced. Before this ordering fix the carve/upload drain ran
+	// only in the Step-6 verify gate (after the dump), so a block-resident hash
+	// had no locator in the metadata dump; a restore then resolved it as a
+	// standalone cas/<hash> object that no longer exists and both the restore
+	// verify gate and post-restore cold reads failed. DrainAllUploads runs the
+	// rollup drain first, then SyncNow (carve → PutBlock → DefaultCommitBlock +
+	// MarkSynced), so every block locator is committed to the metadata store
+	// before it is dumped. A local-only share (no remote) carves nothing — the
+	// upload drain is a no-op — and keeps the legacy local-read path.
 	// Resolve the block store once here; the verify gate (Step 4) reuses
 	// the same lookup pattern.
 	bs, err := r.sharesSvc.GetBlockStoreForShare(shareName)
@@ -525,16 +534,16 @@ func (r *Runtime) runSnapshotOrchestration(
 			"snapshot_id", snapID, "share", shareName, "error", err)
 		return
 	}
-	logger.Debug("snapshot create: drain rollups start", "snapshot_id", snapID, "share", shareName)
-	if derr := bs.DrainRollups(ctx); derr != nil {
-		terminalErr = fmt.Errorf("snapshot create %s: drain rollups: %w: %v",
+	logger.Debug("snapshot create: drain rollups+carve start", "snapshot_id", snapID, "share", shareName)
+	if derr := bs.DrainAllUploads(ctx); derr != nil {
+		terminalErr = fmt.Errorf("snapshot create %s: drain rollups+carve: %w: %v",
 			snapID, models.ErrSnapshotBackupFailed, derr)
 		r.failSnap(shareName, snapID, terminalErr)
-		logger.Error("snapshot create: drain rollups failed",
+		logger.Error("snapshot create: drain rollups+carve failed",
 			"snapshot_id", snapID, "share", shareName, "error", derr)
 		return
 	}
-	logger.Debug("snapshot create: drain rollups complete", "snapshot_id", snapID, "share", shareName)
+	logger.Debug("snapshot create: drain rollups+carve complete", "snapshot_id", snapID, "share", shareName)
 
 	// --- Step 1: WriteSnapshot -> metadata.dump (atomic temp+rename) ---
 	dumpPath := snap.MetadataDumpPath(localStoreDir)

--- a/pkg/controlplane/runtime/snapshot_byteverify_test.go
+++ b/pkg/controlplane/runtime/snapshot_byteverify_test.go
@@ -182,6 +182,16 @@ func (f *byteVerifyFixture) simulateRestart(reopen func(*testing.T) metadata.Sto
 	_ = f.rt.Shutdown(ctx)
 	cancel()
 
+	// Release the outgoing block store's log-blob fd. Runtime.Shutdown closes
+	// metadata stores but NOT block stores, so without this the pre-restart
+	// FSStore keeps blobs/*.blob open on the SHARED fsDir. On Windows an open
+	// handle blocks the t.TempDir() RemoveAll of fsDir at teardown (Unix
+	// tolerates unlink-while-open). engine.Store.Close is idempotent, so the
+	// fixture's later RemoveShare double-close is harmless.
+	if f.bs != nil {
+		_ = f.bs.Close()
+	}
+
 	// Close the old store before reopening: an on-disk backend (badger) holds
 	// an exclusive lock on its directory, so the reopen would fail until the
 	// prior handle is released. The first open()'s t.Cleanup will later call
@@ -213,6 +223,17 @@ func (f *byteVerifyFixture) simulateRestart(reopen func(*testing.T) metadata.Sto
 	f.rt = rt
 	f.meta = meta
 	f.bs = share.BlockStore
+
+	// The freshly-opened block store holds a new log-blob fd on the SAME fsDir.
+	// f.rt.Shutdown (via the deferred fixture close) does not close block stores,
+	// so register a cleanup to release it. Registered here — after the fixture's
+	// t.TempDir() cleanup for fsDir — so t.Cleanup's LIFO order closes the fd
+	// BEFORE fsDir's RemoveAll runs (required on Windows). Close is idempotent.
+	f.t.Cleanup(func() {
+		if f.bs != nil {
+			_ = f.bs.Close()
+		}
+	})
 }
 
 func (f *byteVerifyFixture) close() {

--- a/pkg/controlplane/runtime/snapshot_byteverify_test.go
+++ b/pkg/controlplane/runtime/snapshot_byteverify_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 	metadatabadger "github.com/marmos91/dittofs/pkg/metadata/store/badger"
 	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+	metadatasqlite "github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
 )
 
 // byteVerifyFixture wires a Runtime over the REAL production write path: a
@@ -558,6 +560,7 @@ func byteVerifyBackends(t *testing.T) []byteVerifyBackend {
 			},
 		},
 		newBadgerByteVerifyBackend(t),
+		newSQLiteByteVerifyBackend(t),
 	}
 	if postgresByteVerifyBackend != nil {
 		backends = append(backends, *postgresByteVerifyBackend)
@@ -588,6 +591,30 @@ func newBadgerByteVerifyBackend(t *testing.T) byteVerifyBackend {
 	return byteVerifyBackend{
 		name:   "badger",
 		open:   func(t *testing.T) (metadata.Store, string) { return openAt(t), "badger" },
+		reopen: openAt,
+	}
+}
+
+// newSQLiteByteVerifyBackend backs the byte-verify matrix with an on-disk sqlite
+// metadata store. reopen re-opens the SAME db file so the restore cycle proves
+// on-disk persistence (including the synced_hashes locator columns the flip
+// relies on for block-resident restore).
+func newSQLiteByteVerifyBackend(t *testing.T) byteVerifyBackend {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "byteverify.db")
+	openAt := func(t *testing.T) metadata.Store {
+		store, err := metadatasqlite.NewSQLiteMetadataStore(context.Background(),
+			&metadatasqlite.SQLiteMetadataStoreConfig{Path: dbPath, AutoMigrate: true},
+			flipTestCapabilities())
+		if err != nil {
+			t.Fatalf("NewSQLiteMetadataStore: %v", err)
+		}
+		t.Cleanup(func() { _ = store.Close() })
+		return store
+	}
+	return byteVerifyBackend{
+		name:   "sqlite",
+		open:   func(t *testing.T) (metadata.Store, string) { return openAt(t), "sqlite" },
 		reopen: openAt,
 	}
 }

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -2,9 +2,27 @@ package metadata
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/marmos91/dittofs/pkg/block"
 )
+
+// ErrCommitPartial is returned by DefaultCommitBlock when the block record
+// transaction committed successfully but the MarkSynced loop did not fully
+// complete. BlockID identifies the committed (but only partially-synced) block.
+// Callers should retry DefaultCommitBlock with the same BlockID and BlockRecord
+// — the idempotent transaction guard skips the transaction and re-runs the
+// MarkSynced loop to completion.
+type ErrCommitPartial struct {
+	BlockID string
+	Cause   error
+}
+
+func (e *ErrCommitPartial) Error() string {
+	return fmt.Sprintf("commit block %s: mark-synced incomplete: %v", e.BlockID, e.Cause)
+}
+
+func (e *ErrCommitPartial) Unwrap() error { return e.Cause }
 
 // BlockRecordStore manages the lifecycle of log-blob block records.
 // Each record tracks the sync state, live chunk count, and hash of a
@@ -90,9 +108,15 @@ func DefaultCommitBlock(
 	// is safe. Crucially, this fixes the retry path: if a previous CommitBlock
 	// call committed the tx but then failed mid-MarkSynced, the retry must still
 	// reach this loop to write the pending remote locators.
+	//
+	// If MarkSynced fails here the transaction has ALREADY committed (block record
+	// + local locations are durable). Return ErrCommitPartial so callers can retry
+	// with the same BlockID — DefaultCommitBlock's idempotent tx guard will skip
+	// the transaction and re-run the MarkSynced loop to completion without minting
+	// a new block.
 	for _, c := range chunks {
 		if err := s.MarkSynced(ctx, c.Hash, c.Remote); err != nil {
-			return err
+			return &ErrCommitPartial{BlockID: rec.BlockID, Cause: err}
 		}
 	}
 	return nil

--- a/pkg/metadata/store/memory/block_record_store.go
+++ b/pkg/metadata/store/memory/block_record_store.go
@@ -146,6 +146,25 @@ func (s *MemoryMetadataStore) DeleteLocalLocation(ctx context.Context, hash bloc
 	})
 }
 
+// WalkLocalLocations calls fn for every stored content-hash -> log-blob
+// location in arbitrary order. It is not part of the LocalChunkIndex
+// interface; the local store discovers it via a narrow consumer-side
+// interface to enumerate logblob-resident chunks (Walk / GC).
+func (s *MemoryMetadataStore) WalkLocalLocations(_ context.Context, fn func(block.ContentHash, block.LocalChunkLocation) error) error {
+	s.mu.RLock()
+	snapshot := make(map[block.ContentHash]block.LocalChunkLocation, len(s.localChunks))
+	for h, loc := range s.localChunks {
+		snapshot[h] = loc
+	}
+	s.mu.RUnlock()
+	for h, loc := range snapshot {
+		if err := fn(h, loc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // ============================================================================
 // CommitBlock
 // ============================================================================

--- a/pkg/metadata/store/memory/snapshot_store.go
+++ b/pkg/metadata/store/memory/snapshot_store.go
@@ -50,7 +50,17 @@ type memoryBackupSnapshot struct {
 	StoreID       string
 	RollupOffsets map[string]uint64
 	Synced        map[block.ContentHash]time.Time
-	ObjectIndex   map[block.ContentHash]string
+	// SyncedLocators preserves the remote block locator for synced hashes packed
+	// into a block (#1414). Without it a restore keeps the synced SET but drops
+	// each hash's BlockID, so a block-resident hash resolves as standalone and its
+	// bytes (now in blocks/<id>) cannot be found — post-restore reads and the
+	// durability-verify gate both fail. The SQL backends get this free by dumping
+	// the whole synced_hashes table; the gob backends carry it explicitly. The
+	// carve drain now runs BEFORE WriteSnapshot, so these are populated at dump
+	// time. Additive gob field: an older dump decodes it to nil (all-standalone,
+	// the pre-flip behavior).
+	SyncedLocators map[block.ContentHash]block.ChunkLocator
+	ObjectIndex    map[block.ContentHash]string
 
 	// ServerConfigCustomSettingsJSON holds the JSON-encoded form of
 	// ServerConfig.CustomSettings. Gob cannot encode map[string]any
@@ -139,6 +149,13 @@ func (s *MemoryMetadataStore) WriteSnapshot(ctx context.Context, w io.Writer) (*
 			sy[k] = v
 		}
 		snap.Synced = sy
+	}
+	if len(s.syncedLocators) > 0 {
+		sl := make(map[block.ContentHash]block.ChunkLocator, len(s.syncedLocators))
+		for k, v := range s.syncedLocators {
+			sl[k] = v
+		}
+		snap.SyncedLocators = sl
 	}
 	s.syncedMu.RUnlock()
 
@@ -339,6 +356,7 @@ func (s *MemoryMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 
 	s.syncedMu.Lock()
 	s.synced = snap.Synced
+	s.syncedLocators = snap.SyncedLocators
 	s.syncedMu.Unlock()
 
 	s.objectIndex = snap.ObjectIndex

--- a/pkg/metrics/instruments.go
+++ b/pkg/metrics/instruments.go
@@ -58,6 +58,17 @@ type instruments struct {
 	uploadQueueDepth prometheus.Gauge
 	uploadWindow     prometheus.Gauge
 	rehashDuration   prometheus.Histogram
+
+	// Data-plane integrity / self-heal (subsystem "datapath"). All bounded,
+	// zero-label counters — corruption is rare and these must never explode
+	// cardinality. localCorruptionTotal / remoteCorruptionTotal count detected
+	// blake3 mismatches by tier; selfHealTotal{result} counts repair outcomes;
+	// blockRangeReads/Bytes count verified ranged reads into packed blocks.
+	localCorruptionTotal  prometheus.Counter
+	remoteCorruptionTotal prometheus.Counter
+	selfHealTotal         *prometheus.CounterVec // {result: success|failure}
+	blockRangeReadsTotal  prometheus.Counter
+	blockRangeReadBytes   prometheus.Counter
 }
 
 func newInstruments(reg *prometheus.Registry) *instruments {
@@ -178,6 +189,26 @@ func newInstruments(reg *prometheus.Registry) *instruments {
 			Help:    "BLAKE3 re-hash (pre-upload bitrot verify) latency per CAS chunk, in seconds.",
 			Buckets: prometheus.DefBuckets,
 		}),
+		localCorruptionTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace, Subsystem: "datapath", Name: "local_corruption_total",
+			Help: "Local chunk integrity failures detected on read (blake3 mismatch), before self-heal.",
+		}),
+		remoteCorruptionTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace, Subsystem: "datapath", Name: "remote_corruption_total",
+			Help: "Remote chunk integrity failures detected on fetch (blake3 mismatch). Read fails closed.",
+		}),
+		selfHealTotal: factory(prometheus.CounterOpts{
+			Namespace: Namespace, Subsystem: "datapath", Name: "self_heal_total",
+			Help: "Local-corruption self-heal outcomes, by result (success = repaired+restaged; failure = unrecoverable or served-but-not-persisted).",
+		}, []string{"result"}),
+		blockRangeReadsTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace, Subsystem: "datapath", Name: "block_range_reads_total",
+			Help: "Verified ranged reads served from packed block objects.",
+		}),
+		blockRangeReadBytes: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace, Subsystem: "datapath", Name: "block_range_read_bytes_total",
+			Help: "Total verified chunk-plaintext bytes served from packed block objects.",
+		}),
 	}
 	reg.MustRegister(
 		in.requests, in.reqDuration, in.connsTotal, in.connsClosed, in.authAttempts, in.authFailures,
@@ -186,6 +217,8 @@ func newInstruments(reg *prometheus.Registry) *instruments {
 		in.snapOps, in.snapDuration,
 		in.uploadsTotal, in.uploadDuration, in.uploadBytes, in.uploadsInflight,
 		in.uploadQueueDepth, in.uploadWindow, in.rehashDuration,
+		in.localCorruptionTotal, in.remoteCorruptionTotal, in.selfHealTotal,
+		in.blockRangeReadsTotal, in.blockRangeReadBytes,
 	)
 	return in
 }
@@ -359,4 +392,52 @@ func (m *Metrics) RecordRehash(d time.Duration) {
 		return
 	}
 	m.in.rehashDuration.Observe(d.Seconds())
+}
+
+// RecordLocalCorruption counts n local-chunk integrity failures detected on
+// read (blake3 mismatch) before any self-heal attempt.
+func (m *Metrics) RecordLocalCorruption(n int) {
+	if m == nil || n <= 0 {
+		return
+	}
+	m.in.localCorruptionTotal.Add(float64(n))
+}
+
+// RecordSelfHealSuccess counts n local corruptions that were repaired and
+// durably re-staged from the remote block.
+func (m *Metrics) RecordSelfHealSuccess(n int) {
+	if m == nil || n <= 0 {
+		return
+	}
+	m.in.selfHealTotal.WithLabelValues("success").Add(float64(n))
+}
+
+// RecordSelfHealFailure counts n local corruptions that could not be
+// repaired-and-persisted (unrecoverable fail-closed, or served-but-degraded).
+func (m *Metrics) RecordSelfHealFailure(n int) {
+	if m == nil || n <= 0 {
+		return
+	}
+	m.in.selfHealTotal.WithLabelValues("failure").Add(float64(n))
+}
+
+// RecordRemoteCorruption counts n remote-chunk integrity failures detected on
+// fetch (blake3 mismatch). The read fails closed.
+func (m *Metrics) RecordRemoteCorruption(n int) {
+	if m == nil || n <= 0 {
+		return
+	}
+	m.in.remoteCorruptionTotal.Add(float64(n))
+}
+
+// RecordBlockRangeRead counts one verified ranged read served from a packed
+// block object and the chunk-plaintext bytes it returned.
+func (m *Metrics) RecordBlockRangeRead(bytes int) {
+	if m == nil {
+		return
+	}
+	m.in.blockRangeReadsTotal.Inc()
+	if bytes > 0 {
+		m.in.blockRangeReadBytes.Add(float64(bytes))
+	}
 }

--- a/pkg/snapshot/verify.go
+++ b/pkg/snapshot/verify.go
@@ -11,14 +11,56 @@ import (
 	"github.com/marmos91/dittofs/pkg/block/remote"
 )
 
+// HashLocatorResolver resolves a content hash to its remote locator so the
+// verify gate probes the correct object: a standalone cas/<hash> object or the
+// packed blocks/<id> object it was carved into (#1414 object packing). Satisfied
+// by the per-share metadata store (metadata.SyncedHashStore.GetLocator). A nil
+// resolver disables block-awareness — every hash is probed as a standalone CAS
+// object, the pre-flip behavior.
+type HashLocatorResolver interface {
+	GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error)
+}
+
+// probeHashDurable HEAD-probes the remote object backing hash and returns nil
+// when it is present. A block-resident hash (its locator names a blocks/<id>
+// object) is probed with a one-byte GetBlockRange on the block store; a
+// standalone hash (or any hash when locators is nil) is probed with rs.Head.
+// Both backends return block.ErrChunkNotFound for a missing object, so the
+// caller's NotFound classification is uniform across tiers. A block-resident
+// hash with no block store to probe is reported as ErrChunkNotFound — it cannot
+// be proven durable.
+func probeHashDurable(ctx context.Context, rs remote.RemoteStore, locators HashLocatorResolver, rbs remote.RemoteBlockStore, hash block.ContentHash) error {
+	if locators != nil {
+		loc, ok, err := locators.GetLocator(ctx, hash)
+		if err != nil {
+			return err
+		}
+		if ok && !loc.IsStandalone() {
+			if rbs == nil {
+				return fmt.Errorf("hash %s is block-resident but remote has no block store: %w", hash, block.ErrChunkNotFound)
+			}
+			_, berr := rbs.GetBlockRange(ctx, loc.BlockID, 0, 1)
+			return berr
+		}
+	}
+	_, err := rs.Head(ctx, hash)
+	return err
+}
+
 // VerifyRemoteDurability probes the remote store for every hash in the
 // manifest and reports the first miss. It dispatches up to concurrency
-// parallel Head() probes; the first probe to return ErrChunkNotFound
+// parallel probes; the first probe to return ErrChunkNotFound
 // cancels in-flight siblings and the call returns a wrapped
 // block.ErrChunkNotFound naming the missing hash. Non-NotFound
 // I/O errors propagate unchanged (not wrapped as ErrChunkNotFound) so
 // callers can distinguish "block is genuinely absent on remote" from
 // "remote was unreachable mid-verify."
+//
+// locators + rbs make the probe block-aware (#1414): a hash carved into a
+// packed block is probed against its blocks/<id> object, not the cas/<hash>
+// object that no longer exists. Pass nil for both to probe every hash as a
+// standalone CAS object (the pre-flip behavior, retained for tests and
+// standalone-only deployments).
 //
 // Iteration order matches manifest.Sorted, but with concurrency > 1 the
 // first miss observed depends on remote latency — different remotes can
@@ -41,6 +83,8 @@ import (
 func VerifyRemoteDurability(
 	ctx context.Context,
 	rs remote.RemoteStore,
+	locators HashLocatorResolver,
+	rbs remote.RemoteBlockStore,
 	manifest *block.HashSet,
 	concurrency int,
 ) error {
@@ -82,7 +126,7 @@ loop:
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			_, err := rs.Head(errCtx, hash)
+			err := probeHashDurable(errCtx, rs, locators, rbs, hash)
 			switch {
 			case err == nil:
 				return

--- a/pkg/snapshot/verify_test.go
+++ b/pkg/snapshot/verify_test.go
@@ -1,9 +1,11 @@
 package snapshot_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,6 +16,87 @@ import (
 	"github.com/marmos91/dittofs/pkg/health"
 	"github.com/marmos91/dittofs/pkg/snapshot"
 )
+
+// fakeLocators is a HashLocatorResolver backed by a static map.
+type fakeLocators map[block.ContentHash]block.ChunkLocator
+
+func (f fakeLocators) GetLocator(_ context.Context, h block.ContentHash) (block.ChunkLocator, bool, error) {
+	loc, ok := f[h]
+	return loc, ok, nil
+}
+
+// blockProbeSpy is a RemoteBlockStore that records whether GetBlockRange was
+// called, so a test can assert the standalone (cas) path never touches the
+// block store. All other block methods are unused here.
+type blockProbeSpy struct{ called atomic.Bool }
+
+func (s *blockProbeSpy) PutBlock(context.Context, string, io.Reader) error { return nil }
+func (s *blockProbeSpy) GetBlock(context.Context, string) ([]byte, error)  { return nil, nil }
+func (s *blockProbeSpy) GetBlockRange(_ context.Context, _ string, _, _ int64) ([]byte, error) {
+	s.called.Store(true)
+	return []byte{0x01}, nil
+}
+func (s *blockProbeSpy) DeleteBlock(context.Context, string) error { return nil }
+func (s *blockProbeSpy) WalkBlocks(context.Context, func(string, block.Meta) error) error {
+	return nil
+}
+
+// TestVerifyRemoteDurability_BlockResidentProbesBlock: a hash whose locator
+// names a packed block is proven durable by probing the block object, NOT a
+// cas/<hash> object (which does not exist post-flip). A missing block → the
+// wrapped ErrChunkNotFound.
+func TestVerifyRemoteDurability_BlockResidentProbesBlock(t *testing.T) {
+	ctx := context.Background()
+	rs := remotememory.New()
+	t.Cleanup(func() { _ = rs.Close() })
+
+	h := gateHash(7)
+	hs := block.NewHashSet(1)
+	hs.Add(h)
+	loc := block.ChunkLocator{BlockID: "blk-present"}
+	res := fakeLocators{h: loc}
+
+	// Present block, NO cas object → must resolve via the block.
+	if err := rs.PutBlock(ctx, "blk-present", bytes.NewReader([]byte("packed-block-bytes"))); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+	if err := snapshot.VerifyRemoteDurability(ctx, rs, res, rs, hs, 4); err != nil {
+		t.Fatalf("block-resident present: got %v, want nil", err)
+	}
+
+	// Missing block → ErrChunkNotFound.
+	res2 := fakeLocators{h: block.ChunkLocator{BlockID: "blk-absent"}}
+	err := snapshot.VerifyRemoteDurability(ctx, rs, res2, rs, hs, 4)
+	if !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("missing block: errors.Is(ErrChunkNotFound)=false; err=%v", err)
+	}
+}
+
+// TestVerifyRemoteDurability_StandaloneLocatorProbesCAS is the back-compat
+// guard: a synced hash with a STANDALONE locator (BlockID=="") — the pre-flip
+// cas/-only shape — is probed against cas/<hash> via rs.Head and NEVER touches
+// the block store. Proves a snapshot of legacy CAS data still verifies.
+func TestVerifyRemoteDurability_StandaloneLocatorProbesCAS(t *testing.T) {
+	ctx := context.Background()
+	rs := remotememory.New()
+	t.Cleanup(func() { _ = rs.Close() })
+
+	h := gateHash(9)
+	hs := block.NewHashSet(1)
+	hs.Add(h)
+	if err := rs.Put(ctx, h, []byte{0x01}); err != nil { // standalone cas object
+		t.Fatalf("Put: %v", err)
+	}
+	res := fakeLocators{h: block.ChunkLocator{}} // standalone (BlockID=="")
+	spy := &blockProbeSpy{}
+
+	if err := snapshot.VerifyRemoteDurability(ctx, rs, res, spy, hs, 4); err != nil {
+		t.Fatalf("standalone cas: got %v, want nil", err)
+	}
+	if spy.called.Load() {
+		t.Fatal("standalone locator must probe cas/<hash>, not the block store")
+	}
+}
 
 // gateHash returns a deterministic ContentHash seeded by seed so each
 // test gets unique, sortable hashes without RNG flakiness.

--- a/pkg/snapshot/verify_test.go
+++ b/pkg/snapshot/verify_test.go
@@ -55,7 +55,7 @@ func TestVerifyRemoteDurability_HappyPath(t *testing.T) {
 	hs := seedManifest(t, 32)
 	putAll(t, rs, hs)
 
-	if err := snapshot.VerifyRemoteDurability(context.Background(), rs, hs, 4); err != nil {
+	if err := snapshot.VerifyRemoteDurability(context.Background(), rs, nil, nil, hs, 4); err != nil {
 		t.Fatalf("VerifyRemoteDurability: got %v, want nil", err)
 	}
 }
@@ -67,7 +67,7 @@ func TestVerifyRemoteDurability_EmptyManifest(t *testing.T) {
 	t.Cleanup(func() { _ = rs.Close() })
 
 	hs := block.NewHashSet(0)
-	if err := snapshot.VerifyRemoteDurability(context.Background(), rs, hs, 4); err != nil {
+	if err := snapshot.VerifyRemoteDurability(context.Background(), rs, nil, nil, hs, 4); err != nil {
 		t.Fatalf("empty manifest: got %v, want nil", err)
 	}
 }
@@ -77,7 +77,7 @@ func TestVerifyRemoteDurability_NilManifest(t *testing.T) {
 	rs := remotememory.New()
 	t.Cleanup(func() { _ = rs.Close() })
 
-	if err := snapshot.VerifyRemoteDurability(context.Background(), rs, nil, 4); err != nil {
+	if err := snapshot.VerifyRemoteDurability(context.Background(), rs, nil, nil, nil, 4); err != nil {
 		t.Fatalf("nil manifest: got %v, want nil", err)
 	}
 }
@@ -98,7 +98,7 @@ func TestVerifyRemoteDurability_MissingHashFailFast(t *testing.T) {
 		}
 	}
 
-	err := snapshot.VerifyRemoteDurability(context.Background(), rs, hs, 4)
+	err := snapshot.VerifyRemoteDurability(context.Background(), rs, nil, nil, hs, 4)
 	if err == nil {
 		t.Fatal("missing hash: got nil err, want wrapped ErrChunkNotFound")
 	}
@@ -118,7 +118,7 @@ func TestVerifyRemoteDurability_IOErrorPropagates(t *testing.T) {
 
 	hs := seedManifest(t, 4)
 
-	err := snapshot.VerifyRemoteDurability(context.Background(), rs, hs, 2)
+	err := snapshot.VerifyRemoteDurability(context.Background(), rs, nil, nil, hs, 2)
 	if err == nil {
 		t.Fatal("got nil err, want propagated I/O error")
 	}
@@ -141,7 +141,7 @@ func TestVerifyRemoteDurability_ContextCancelHonored(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- snapshot.VerifyRemoteDurability(ctx, br, hs, 4)
+		errCh <- snapshot.VerifyRemoteDurability(ctx, br, nil, nil, hs, 4)
 	}()
 
 	// Wait for some probes to be in-flight, then cancel.
@@ -175,7 +175,7 @@ func TestVerifyRemoteDurability_ConcurrencyBound(t *testing.T) {
 	cr := newCountingRemote(5 * time.Millisecond)
 	hs := seedManifest(t, total)
 
-	if err := snapshot.VerifyRemoteDurability(context.Background(), cr, hs, concurrency); err != nil {
+	if err := snapshot.VerifyRemoteDurability(context.Background(), cr, nil, nil, hs, concurrency); err != nil {
 		t.Fatalf("VerifyRemoteDurability: %v", err)
 	}
 
@@ -200,7 +200,7 @@ func TestVerifyRemoteDurability_ConcurrencyDefaultsOnNonPositive(t *testing.T) {
 	for _, c := range []int{0, -1, -100} {
 		c := c
 		t.Run(fmt.Sprintf("concurrency=%d", c), func(t *testing.T) {
-			if err := snapshot.VerifyRemoteDurability(context.Background(), rs, hs, c); err != nil {
+			if err := snapshot.VerifyRemoteDurability(context.Background(), rs, nil, nil, hs, c); err != nil {
 				t.Fatalf("concurrency=%d: got %v, want nil", c, err)
 			}
 		})
@@ -224,7 +224,7 @@ func TestVerifyRemoteDurability_FailFastCancelsSiblings(t *testing.T) {
 		delay:   10 * time.Millisecond,
 	}
 
-	err := snapshot.VerifyRemoteDurability(context.Background(), sm, hs, concurrency)
+	err := snapshot.VerifyRemoteDurability(context.Background(), sm, nil, nil, hs, concurrency)
 	if !errors.Is(err, block.ErrChunkNotFound) {
 		t.Fatalf("got %v, want wrapped ErrChunkNotFound", err)
 	}

--- a/test/e2e/blocks_flip_test.go
+++ b/test/e2e/blocks_flip_test.go
@@ -1,0 +1,317 @@
+//go:build e2e
+
+// Blocks-only storage E2E: the live write path now packs new writes into
+// remote "blocks/<id>" objects rather than per-chunk "cas/<hash>" objects.
+// These tests exercise the flip end-to-end through the real protocol stack
+// (NFS and SMB) against a real Localstack S3 remote:
+//
+//  1. Fresh-share write → read → GC over blocks. Write a file, drain, and
+//     assert the remote holds blocks/ objects and NO new cas/ objects. Read
+//     it back byte-identical. Unlink it, run GC, and assert the block is
+//     freed both remotely (blocks/ empty) and locally (per-share local
+//     occupancy returns to zero).
+//  2. Read-after-evict. Evict every local tier so the next read misses both
+//     the read buffer and local disk, then read back byte-identical — proving
+//     the block-locator fetch → blockcodec decode → BLAKE3 verify path serves
+//     correct bytes from the remote packed block.
+//  3. Corruption. Tamper a remote block's bytes directly in S3, force a cold
+//     read, and assert the read FAILS CLOSED (BLAKE3 verification rejects the
+//     mismatch) rather than returning silently-wrong data.
+//
+// The NFS variant uses a real kernel mount (sudo). The SMB variant uses the
+// pure-Go go-smb2 client (no kernel mount). Both target the same s3-backed
+// share type, so both drive the same engine carver + syncer + read path.
+//
+// Run command (requires sudo + Docker for Localstack):
+//
+//	cd test/e2e && sudo ./run-e2e.sh --s3 --test TestBlocksFlip
+package e2e
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/test/e2e/framework"
+	"github.com/marmos91/dittofs/test/e2e/helpers"
+	"github.com/stretchr/testify/require"
+)
+
+// blocksIO abstracts the write/read/remove surface so the same lifecycle can
+// run over an NFS kernel mount and over a pure-Go SMB client.
+type blocksIO struct {
+	proto  string
+	write  func(name string, data []byte) error
+	read   func(name string) ([]byte, error)
+	remove func(name string) error
+}
+
+// setupBlocksShare provisions a memory-metadata + fs-local + s3-remote share
+// for a blocks-flip test and returns the CLI runner, the s3 bucket, and the
+// share name. It mirrors the setup used by the canonical CAS immutability
+// test so both exercise the same store topology.
+func setupBlocksShare(t *testing.T, shareName string) (*helpers.CLIRunner, *framework.LocalstackHelper, string) {
+	t.Helper()
+
+	lsHelper := framework.NewLocalstackHelper(t)
+	require.NotNil(t, lsHelper, "Localstack helper must be available")
+
+	sp := helpers.StartServerProcess(t, "")
+	t.Cleanup(sp.ForceKill)
+
+	cli := helpers.LoginAsAdmin(t, sp.APIURL())
+
+	setup := helpers.SetupStoreMatrix(t, cli, shareName, helpers.MatrixSetupConfig{
+		MetadataType: "memory",
+		LocalType:    "fs",
+		RemoteType:   "s3",
+	}, nil, lsHelper)
+	require.NotNil(t, setup, "store-matrix setup")
+
+	require.NotEmpty(t, lsHelper.Buckets, "Localstack helper should track at least one bucket")
+	bucket := lsHelper.Buckets[len(lsHelper.Buckets)-1]
+	t.Logf("blocks bucket = %q", bucket)
+
+	return cli, lsHelper, bucket
+}
+
+func TestBlocksFlipLifecycle_NFS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping blocks-flip NFS E2E in short mode")
+	}
+	if !framework.CheckLocalstackAvailable(t) {
+		t.Skip("Skipping: Localstack (S3) not available — run via run-e2e.sh --s3")
+	}
+
+	shareName := "/export-blocks-nfs"
+	cli, lsHelper, bucket := setupBlocksShare(t, shareName)
+
+	nfsPort := helpers.FindFreePort(t)
+	_, err := cli.EnableAdapter("nfs", helpers.WithAdapterPort(nfsPort))
+	require.NoError(t, err, "Should enable NFS adapter")
+	t.Cleanup(func() { _, _ = cli.DisableAdapter("nfs") })
+
+	require.NoError(t, helpers.WaitForAdapterStatus(t, cli, "nfs", true, 5*time.Second),
+		"NFS adapter should become enabled")
+	framework.WaitForServer(t, nfsPort, 10*time.Second)
+
+	mount := mountNFSExport(t, nfsPort, shareName)
+	t.Cleanup(mount.Cleanup)
+
+	io := blocksIO{
+		proto: "nfs",
+		write: func(name string, data []byte) error {
+			return os.WriteFile(mount.FilePath(name), data, 0o644)
+		},
+		read:   func(name string) ([]byte, error) { return os.ReadFile(mount.FilePath(name)) },
+		remove: func(name string) error { return os.Remove(mount.FilePath(name)) },
+	}
+
+	runBlocksFlipSuite(t, cli, lsHelper, bucket, shareName, io)
+}
+
+func TestBlocksFlipLifecycle_SMB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping blocks-flip SMB E2E in short mode")
+	}
+	if !framework.CheckLocalstackAvailable(t) {
+		t.Skip("Skipping: Localstack (S3) not available — run via run-e2e.sh --s3")
+	}
+
+	shareName := "/export-blocks-smb"
+	cli, lsHelper, bucket := setupBlocksShare(t, shareName)
+
+	// SMB authenticates a concrete user; grant it read-write on the share
+	// (the store-matrix share carries no default permission).
+	const smbUser = "blocksmb"
+	const smbPass = "blocksmb-passw0rd"
+	_, err := cli.CreateUser(smbUser, smbPass)
+	require.NoError(t, err, "Should create SMB user")
+	require.NoError(t, cli.GrantUserPermission(shareName, smbUser, "read-write"),
+		"Should grant SMB user read-write on share")
+
+	smbPort := helpers.FindFreePort(t)
+	_, err = cli.EnableAdapter("smb", helpers.WithAdapterPort(smbPort))
+	require.NoError(t, err, "Should enable SMB adapter")
+	t.Cleanup(func() { _, _ = cli.DisableAdapter("smb") })
+
+	require.NoError(t, helpers.WaitForAdapterStatus(t, cli, "smb", true, 5*time.Second),
+		"SMB adapter should become enabled")
+	framework.WaitForServer(t, smbPort, 10*time.Second)
+
+	session := helpers.ConnectSMB3(t, smbPort, smbUser, smbPass)
+	share := helpers.MountSMB3Share(t, session, shareName)
+
+	io := blocksIO{
+		proto:  "smb",
+		write:  func(name string, data []byte) error { return share.WriteFile(name, data, 0o644) },
+		read:   func(name string) ([]byte, error) { return share.ReadFile(name) },
+		remove: func(name string) error { return share.Remove(name) },
+	}
+
+	runBlocksFlipSuite(t, cli, lsHelper, bucket, shareName, io)
+}
+
+// runBlocksFlipSuite runs the full blocks-only lifecycle over a protocol IO.
+func runBlocksFlipSuite(t *testing.T, cli *helpers.CLIRunner, lsHelper *framework.LocalstackHelper, bucket, shareName string, io blocksIO) {
+	t.Helper()
+
+	// A fresh bucket must have no cas/ or blocks/ objects yet.
+	require.Empty(t, helpers.ListCASKeys(t, lsHelper, bucket),
+		"[%s] fresh bucket should have no cas/ objects", io.proto)
+	require.Empty(t, helpers.ListBlockKeys(t, lsHelper, bucket),
+		"[%s] fresh bucket should have no blocks/ objects", io.proto)
+
+	// ---- Step 1: fresh write → blocks/ (not cas/) → read-back identical ----
+	const fileName = "flip.bin"
+	payload := deterministicPayload(t, payloadSize, 11)
+
+	require.NoError(t, io.write(fileName, payload), "[%s] write %s", io.proto, fileName)
+	t.Logf("[%s] step 1: wrote %d bytes (sha256=%s)", io.proto, len(payload), shortSha256(payload))
+
+	drainUploads(t, cli)
+
+	blockKeys := helpers.ListBlockKeys(t, lsHelper, bucket)
+	require.NotEmpty(t, blockKeys,
+		"[%s] expected at least one blocks/ object after write+drain — the live path must pack chunks into blocks", io.proto)
+	require.Empty(t, helpers.ListCASKeys(t, lsHelper, bucket),
+		"[%s] the flipped write path must NOT create per-chunk cas/ objects — got %v",
+		io.proto, helpers.ListCASKeys(t, lsHelper, bucket))
+	t.Logf("[%s] step 1: remote holds %d blocks/ objects, 0 cas/ objects", io.proto, len(blockKeys))
+
+	got, err := io.read(fileName)
+	require.NoError(t, err, "[%s] read back %s", io.proto, fileName)
+	assertSha256Equal(t, payload, got)
+
+	// Local tier should hold the just-written data before eviction.
+	statsAfterWrite := helpers.GetBlockStats(t, cli, shareName)
+	require.Positive(t, statsAfterWrite.Totals.LocalDiskUsed,
+		"[%s] local disk should hold the freshly-written blocks", io.proto)
+
+	// ---- Step 2: read-after-evict (cold read from remote block) ----
+	require.NoError(t, helpers.EvictBlocks(t, cli, shareName),
+		"[%s] evict local tiers", io.proto)
+
+	statsAfterEvict := helpers.GetBlockStats(t, cli, shareName)
+	require.Less(t, statsAfterEvict.Totals.LocalDiskUsed, statsAfterWrite.Totals.LocalDiskUsed,
+		"[%s] eviction should reduce local disk usage (was %d, now %d)",
+		io.proto, statsAfterWrite.Totals.LocalDiskUsed, statsAfterEvict.Totals.LocalDiskUsed)
+
+	gotCold, err := io.read(fileName)
+	require.NoError(t, err, "[%s] cold read %s after evict", io.proto, fileName)
+	assertSha256Equal(t, payload, gotCold)
+	t.Logf("[%s] step 2: cold read after evict matched (served from remote block)", io.proto)
+
+	// ---- Step 3: unlink → GC frees the block locally AND remotely ----
+	require.NoError(t, io.remove(fileName), "[%s] unlink %s", io.proto, fileName)
+	drainUploads(t, cli)
+
+	// grace-period 0 reaps just-orphaned blocks immediately (bypasses the 5m floor).
+	require.NoError(t, helpers.TriggerBlockGC(t, cli, shareName, "--grace-period", "0"),
+		"[%s] block GC run", io.proto)
+
+	waitForRemoteBlocksEmpty(t, lsHelper, bucket, io.proto, 30*time.Second)
+	require.Empty(t, helpers.ListCASKeys(t, lsHelper, bucket),
+		"[%s] GC must not introduce cas/ objects", io.proto)
+
+	statsAfterGC := helpers.GetBlockStats(t, cli, shareName)
+	require.Zero(t, statsAfterGC.Totals.LocalDiskUsed,
+		"[%s] GC must free the local block too (local disk used should be 0, got %d)",
+		io.proto, statsAfterGC.Totals.LocalDiskUsed)
+	t.Logf("[%s] step 3: GC freed the block on both tiers (remote blocks/ empty, local disk 0)", io.proto)
+
+	// ---- Step 4: corruption — tamper a remote block → read fails closed ----
+	exerciseBlocksCorruption(t, cli, lsHelper, bucket, shareName, io)
+}
+
+// exerciseBlocksCorruption writes a fresh file, tampers its remote packed
+// block directly in S3, forces a cold read, and asserts the read fails closed
+// (BLAKE3 verification catches the mismatch) rather than returning wrong data.
+func exerciseBlocksCorruption(t *testing.T, cli *helpers.CLIRunner, lsHelper *framework.LocalstackHelper, bucket, shareName string, io blocksIO) {
+	t.Helper()
+
+	const fileName = "corrupt.bin"
+	payload := deterministicPayload(t, payloadSize, 22)
+
+	require.NoError(t, io.write(fileName, payload), "[%s] write %s", io.proto, fileName)
+	drainUploads(t, cli)
+
+	blockKeys := helpers.ListBlockKeys(t, lsHelper, bucket)
+	require.NotEmpty(t, blockKeys, "[%s] corruption test needs at least one blocks/ object", io.proto)
+	tamperKey := blockKeys[0]
+
+	// Corrupt a run of bytes in the middle of the block, preserving the object
+	// length. This lands inside a packed chunk's wire bytes, so the per-chunk
+	// BLAKE3 recompute on the read path must reject it.
+	original := helpers.GetBlockObject(t, lsHelper, bucket, tamperKey)
+	require.NotEmpty(t, original, "[%s] block object %q should be non-empty", io.proto, tamperKey)
+	tampered := make([]byte, len(original))
+	copy(tampered, original)
+	start := len(tampered) / 2
+	end := start + 64
+	if end > len(tampered) {
+		end = len(tampered)
+	}
+	for i := start; i < end; i++ {
+		tampered[i] ^= 0xFF
+	}
+	helpers.PutBlockObject(t, lsHelper, bucket, tamperKey, tampered)
+	t.Logf("[%s] step 4: tampered %d bytes of remote block %q (length preserved)", io.proto, end-start, tamperKey)
+
+	// Force a genuine cold read so the tampered remote bytes are actually
+	// fetched (evict both local disk and read buffer).
+	require.NoError(t, helpers.EvictBlocks(t, cli, shareName), "[%s] evict before corrupt read", io.proto)
+
+	data, readErr := io.read(fileName)
+	switch {
+	case readErr != nil:
+		t.Logf("[%s] step 4 PASS: cold read of tampered block failed closed: %v", io.proto, readErr)
+	case len(data) == len(payload) && bytesEqual(data, payload):
+		// A tier we did not evict served the original verified bytes. This is
+		// safe (the protocol never surfaced corrupt data) but does not prove
+		// fail-closed on the tampered fetch — flag it loudly instead of a silent pass.
+		t.Errorf("[%s] step 4 INCONCLUSIVE: cold read returned the ORIGINAL bytes — "+
+			"the tampered remote block was not fetched (a cache tier served it). "+
+			"Eviction may not have forced a remote fetch.", io.proto)
+	default:
+		t.Errorf("[%s] step 4 FAIL-OPEN: cold read of a tampered block returned %d bytes of "+
+			"data that is neither an error nor the original payload — BLAKE3 verification "+
+			"did not fail closed", io.proto, len(data))
+	}
+
+	// Clean up the corrupt file so trailing GC/cleanup is well-defined.
+	_ = io.remove(fileName)
+}
+
+// waitForRemoteBlocksEmpty polls until the blocks/ prefix is empty or the
+// timeout elapses, then asserts emptiness. GC runs to completion synchronously
+// via the CLI, but the S3 listing may lag the DELETE slightly on some emulators.
+func waitForRemoteBlocksEmpty(t *testing.T, lsHelper *framework.LocalstackHelper, bucket, proto string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last []string
+	for time.Now().Before(deadline) {
+		last = helpers.ListBlockKeys(t, lsHelper, bucket)
+		if len(last) == 0 {
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	require.Empty(t, last,
+		"[%s] GC must reap every blocks/ object after unlink; %d survived: %v",
+		proto, len(last), last)
+}
+
+// bytesEqual reports whether two byte slices are identical. Kept local to
+// avoid pulling bytes.Equal semantics into the assertion message path.
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/test/e2e/helpers/blocks.go
+++ b/test/e2e/helpers/blocks.go
@@ -1,0 +1,136 @@
+//go:build e2e
+
+// Package helpers — packed-block E2E helpers.
+//
+// These helpers mirror the CAS helpers in cas.go but target the packed
+// "blocks/" object namespace that the live write path now produces. They
+// isolate the "talk to S3 directly, bypassing DittoFS" pattern that proves
+// the blocks-only storage contract holds outside the system: that new
+// writes land as blocks/ objects (not per-chunk cas/ objects), that GC
+// frees them, and that a tampered block is rejected on read (fail-closed).
+package helpers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/marmos91/dittofs/pkg/apiclient"
+	"github.com/marmos91/dittofs/test/e2e/framework"
+)
+
+// ListBlockKeys returns the sorted list of object keys under the "blocks/"
+// prefix in bucketName. Bypasses DittoFS — talks straight to S3 via the
+// shared Localstack helper. Used to assert that new writes produce packed
+// block objects and that GC reaps them.
+func ListBlockKeys(t *testing.T, lsHelper *framework.LocalstackHelper, bucketName string) []string {
+	t.Helper()
+
+	ctx := context.Background()
+	var keys []string
+	var continuationToken *string
+
+	for {
+		resp, err := lsHelper.Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket:            aws.String(bucketName),
+			Prefix:            aws.String("blocks/"),
+			ContinuationToken: continuationToken,
+		})
+		if err != nil {
+			t.Fatalf("ListBlockKeys: list blocks/ objects in %s: %v", bucketName, err)
+		}
+
+		for _, obj := range resp.Contents {
+			if obj.Key != nil {
+				keys = append(keys, *obj.Key)
+			}
+		}
+
+		if resp.IsTruncated == nil || !*resp.IsTruncated {
+			break
+		}
+		continuationToken = resp.NextContinuationToken
+	}
+
+	sort.Strings(keys)
+	return keys
+}
+
+// GetBlockObject fetches the raw body of a single blocks/ object directly
+// from S3. No BLAKE3 verification — this is the external path; callers use
+// it to snapshot and then tamper a block.
+func GetBlockObject(t *testing.T, lsHelper *framework.LocalstackHelper, bucketName, key string) []byte {
+	t.Helper()
+
+	ctx := context.Background()
+	resp, err := lsHelper.Client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		t.Fatalf("GetBlockObject: GET %s/%s: %v", bucketName, key, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("GetBlockObject: read body of %s/%s: %v", bucketName, key, err)
+	}
+	return body
+}
+
+// PutBlockObject overwrites the body of a blocks/ key with arbitrary bytes,
+// preserving the key. Used by the corruption test to inject a tampered
+// block and confirm the read path fails closed (BLAKE3 verification catches
+// the mismatch on the next remote fetch).
+func PutBlockObject(t *testing.T, lsHelper *framework.LocalstackHelper, bucketName, key string, body []byte) {
+	t.Helper()
+
+	ctx := context.Background()
+	_, err := lsHelper.Client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(key),
+		Body:   bytes.NewReader(body),
+	})
+	if err != nil {
+		t.Fatalf("PutBlockObject: PUT %s/%s: %v", bucketName, key, err)
+	}
+}
+
+// EvictBlocks evicts every local tier (read buffer + local disk) for a
+// single share via `dfsctl store block evict --share <share>`. This forces
+// the next read of an evicted block to miss both in-memory and on-disk
+// caches and fetch from the remote packed block (a genuine cold read that
+// exercises the block-locator fetch → blockcodec decode → BLAKE3 verify
+// path). Eviction of local blocks is refused by the server when no remote
+// is configured, so callers must use a share with a remote store.
+func EvictBlocks(t *testing.T, runner *CLIRunner, shareName string) error {
+	t.Helper()
+	_, err := runner.Run("store", "block", "evict", "--share", shareName)
+	if err != nil {
+		return fmt.Errorf("dfsctl store block evict --share %s: %w", shareName, err)
+	}
+	return nil
+}
+
+// GetBlockStats fetches per-share block-store statistics via
+// `dfsctl store block stats --share <share>` and decodes the JSON. Used to
+// assert local-tier occupancy before/after eviction and GC.
+func GetBlockStats(t *testing.T, runner *CLIRunner, shareName string) *apiclient.BlockStoreStatsResponse {
+	t.Helper()
+	out, err := runner.Run("store", "block", "stats", "--share", shareName)
+	if err != nil {
+		t.Fatalf("GetBlockStats: dfsctl store block stats --share %s: %v (out=%s)", shareName, err, string(out))
+	}
+	var resp apiclient.BlockStoreStatsResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		t.Fatalf("GetBlockStats: decode stats JSON for %s: %v (out=%s)", shareName, err, string(out))
+	}
+	return &resp
+}


### PR DESCRIPTION
## What

PR3 of the blocks-only storage redesign (#1493). Flips the **live** writer from per-chunk `cas/<hash>` remote objects to packed `blocks/<id>`, and the read path to resolve from blocks. Adds delete-only block GC and corruption self-heal. Global flip, no feature flag — all new writes on every share become packed blocks on deploy. Pre-existing `cas/<hash>` data stays readable via a retained (quarantined) legacy reader; a later PR migrates and deletes it.

Builds on PR2 (#1511, merged). Depends on the dormant substrate wired there (logblob append-log, `LocalChunkIndex`, `BlockRecordStore`, `blockcodec`, `RemoteBlockStore`).

## How it works

- **Local tier** writes to a logblob append-log (`logblob.Append` + `LocalChunkIndex.PutLocalLocation`); local read by hash = index hit → `logblob.ReadAt`. Rollup fsyncs the blob and commits the local index **before** the destructive fence trim, and advances the durable rollup fence last — so no durable index entry can ever reference un-fsynced bytes, and an in-process sync/commit failure leaves state intact for a clean retry.
- **Carve** (in the engine/syncer): accumulate synced-pending chunks, pack at ~16 MiB `BlockCarveBytes` or idle → `blockcodec.Builder` (per-chunk compress/encrypt reused) → `RemoteBlockStore.PutBlock` → atomic `DefaultCommitBlock` (idempotent on blockID). Legacy per-chunk mirror is quarantined (reachable only for pre-flip data).
- **Read (dual-mode):** local logblob index hit → raw; miss → `GetLocator` → `GetBlockRange` → `blockcodec` decode → BLAKE3 verify (fail-closed); legacy standalone-CAS branch retained for back-compat.
- **Delete-only block GC:** refcount-0 cascade → `DecrLiveChunkCount`; at 0 → evict local blob + `RemoteBlockStore.DeleteBlock` + delete record. Rides the existing mark-sweep (reaches a hash only when globally dead). Serialized **per remote (config identity)** so a shared ref-counted remote's `LiveChunkCount` can't be double-decremented.
- **Corruption/self-heal:** always-on BLAKE3 verify; local mismatch self-heals (refetch + re-stage from the block); remote mismatch fails closed + metric. `DataplaneMetrics` extended with bounded zero-label counters.
- **Snapshot:** drain uploads before the metadata dump so a dumped locator always implies durable remote bytes; `SyncedLocators` persisted across all four backends (memory/badger/sqlite/postgres).

## Testing

- Unit + `-race` green across `pkg/block/local/fs`, `pkg/block/engine`, and all four metadata backends.
- New e2e (`test/e2e/blocks_flip_test.go`, build tag `e2e`, NFS kernel mount + SMB go-smb2): fresh write → `blocks/` not `cas/`, read-after-evict cold read, unlink → GC frees local **and** remote, remote-corruption fail-closed. Run: `cd test/e2e && sudo ./run-e2e.sh --s3 --test TestBlocksFlip`. The full e2e runs on the develop gate (not per-PR) — flagging for post-merge monitoring.

## Review

Executed via subagent-driven development: fresh implementer per task (T1–T7), spec+quality gate after each, plus a whole-branch review on the full diff. The whole-branch review found one Critical crash-durability data-loss path (durable local-index entry could outlive un-fsynced logblob bytes) — fixed by fencing the index commit behind the blob fsync, then a follow-up review found the fix's ordering opened an in-process read-availability hole, fixed by reordering sync+commit ahead of the fence trim. Both re-reviewed clean. Two GC findings (per-remote double-decrement, union-reclaimer early-return leak) fixed and re-reviewed clean.

## Follow-ups (not blockers)

- Orphan packed-block leak when `DefaultCommitBlock` exhausts MarkSynced retries (re-carves into a new block, old block's `LiveChunkCount` never reaches 0) — remote space only, no data loss.
- Local logblob byte reclaim (disk currently unbounded — needs per-blob counter/compaction), restart-seed of uncarved local-only chunks, and reconcile/orphan-object sweeps — all deferred, all leak/availability gaps not data loss.

Part of #1493. Closes #1416.