### PR TITLE
test(e2e): real NFSv3 NLM cross-protocol lock interop (#1503)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -105,7 +105,9 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update
-          sudo apt-get install -y nfs-common cifs-utils smbclient krb5-user
+          # rpcbind: required by the real-NLM lock-interop tests, which run a
+          # kernel NFSv3 client (no `nolock`) in an isolated network namespace.
+          sudo apt-get install -y nfs-common cifs-utils smbclient krb5-user rpcbind
           # Start rpc-gssd for Kerberos NFS tests
           sudo systemctl start rpc-gssd || true
 
@@ -122,7 +124,10 @@ jobs:
           # external-service env vars the suite reads. pipefail is required so the
           # go-test exit code propagates through `tee` — without it the job was a
           # false-green no-op regardless of whether the tests ran or passed.
-          sudo -E env "PATH=$PATH" nix develop .#ci --command \
+          # DITTOFS_E2E_REQUIRE_NLM=1: the real-NLM lock-interop test hard-fails
+          # (instead of skipping) if its prerequisites are missing, so a
+          # misconfigured runner can't silently drop that coverage.
+          sudo -E env "PATH=$PATH" "DITTOFS_E2E_REQUIRE_NLM=1" nix develop .#ci --command \
             go test -tags=e2e -v -timeout 30m ./test/e2e/... \
             2>&1 | tee "$GITHUB_WORKSPACE/e2e.log"
 

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ test/smb-conformance/docker-compose.override.yml
 # Phase 13 DEDUP-03 (VER-03 gate) qcow2 fixture cache. Pinned base
 # image is downloaded on first nightly run; never committed.
 test/e2e/fixtures/qcow2/*.qcow2
+__pycache__/

--- a/docs/guide/nfs.md
+++ b/docs/guide/nfs.md
@@ -185,6 +185,13 @@ Best effort: if no `rpcbind` answers on 111 the registration is skipped with a
 warning (NFS still serves; only `nolock`-free v3 locking is unavailable). The
 mappings are unregistered cleanly on shutdown.
 
+> **Same-host clients:** if you mount an NFSv3 export *from the same machine that
+> runs DittoFS*, the host kernel's own `lockd` reclaims the NLM (100021)
+> registration and the client sends locks to the kernel, not DittoFS. Mount from
+> a different host, or isolate the client in its own network namespace. This is
+> why the NLM lock-interop tests use netns isolation — see
+> [Real NFSv3 NLM lock testing](../internals/testing.md#real-nfsv3-nlm-lock-testing-network-namespace-isolation).
+
 ### Security
 
 The embedded portmapper follows standard security practices:

--- a/docs/internals/testing.md
+++ b/docs/internals/testing.md
@@ -297,6 +297,95 @@ limitations compared to Linux/macOS NFS clients.
 
 ---
 
+## Real NFSv3 NLM lock testing (network-namespace isolation)
+
+DittoFS coordinates byte-range locks across NFSv3 NLM, NFSv4, and SMB through a single
+cross-protocol lock manager (`pkg/metadata/lock/manager.go`). Proving this end-to-end with a
+**real kernel NFSv3 client** — not the `nolock` mount option, which makes the kernel resolve
+locks locally and never contact the server — requires a specific harness. This section explains
+why, and how the e2e suite does it.
+
+### Why a single host is not enough
+
+A kernel NFSv3 client discovers the server's NLM (lockd) port by querying rpcbind on port 111 —
+a location fixed by RFC 1833 with no client-side override. But the kernel's *own* lockd also
+registers program 100021 with the local rpcbind. The moment an NFSv3-with-locking mount activates
+on the same host as DittoFS, the kernel lockd reclaims the 100021 mapping, so the client sends its
+NLM requests to the local kernel lockd instead of to DittoFS. You cannot run both a userspace NLM
+server and a kernel NFSv3 client's lockd against one shared rpcbind.
+
+This is the same constraint NFS-Ganesha hits, and DittoFS copies Ganesha's solution:
+**isolate the client in a separate Linux network namespace.**
+
+### Harness layout
+
+```
+  server netns (sns)                client netns (cns)
+  ┌────────────────────────┐        ┌────────────────────────┐
+  │ dfs (NFSv3/v4 + SMB)    │        │ kernel NFSv3 client     │
+  │ rpcbind :111 (own)      │◀──────▶│ rpcbind :111 (own)      │
+  │   NLM 100021 → dfs port │  veth  │ rpc.statd (NSM)         │
+  │                         │        │ mount -o nfsvers=3      │
+  └────────────────────────┘        │   (NO nolock)           │
+                                     └────────────────────────┘
+```
+
+Both the server and the client run in their *own* network namespace, each with its *own* rpcbind
+and its own lockd/NSM port space, so the two 100021 registrations never collide. The server's
+rpcbind is made private by launching dfs under `unshare --mount` with a fresh tmpfs on `/run` —
+otherwise it would share the host's rpcbind socket. The client's `GETPORT` for NLM queries the
+**server** namespace's rpcbind across the veth and correctly resolves to the DittoFS port;
+SM_NOTIFY / GRANTED callbacks flow back over the same veth.
+
+Gotchas mirrored from Ganesha (each is a real failure mode):
+
+- **`rpc.statd` must run in the client netns.** Without a reachable NSM, the first lock fails with
+  `SM_MON status 1` → `NLM4_DENIED_NOLOCKS`. The harness gates on a warm-up lock so a not-ready NSM
+  can never be mistaken for a conflict.
+- **Give each side its own rpcbind** (the netns-native form of Ganesha's multi-homed `rpcbind -h`
+  fix). If you see "failed to contact remote rpcbind", a shared/misbound rpcbind is the usual cause.
+- **Use IP addresses, not hostnames**, for the mount target and NSM — the two namespaces do not
+  share DNS resolution.
+- DittoFS must be started with system-rpcbind registration and UDP enabled (below); UDP carries
+  NSM/SM_NOTIFY.
+
+### Enabling server-side registration
+
+The registration is opt-in (default off). The e2e harness turns it on at runtime:
+
+```
+PATCH /api/v1/adapters/nfs/settings
+{ "portmapper_register_with_system": true, "udp_enabled": true }
+```
+
+Equivalent YAML / env: `adapters.nfs.portmapper.register_with_system: true` /
+`DITTOFS_ADAPTERS_NFS_PORTMAPPER_REGISTER_WITH_SYSTEM=true`. See issue #1503.
+
+### What it covers
+
+- **NLM ↔ SMB** — an NFSv3 NLM byte-range lock conflicts with a CIFS byte-range lock on the same
+  file, resolved by the server's unified lock manager (both directions).
+- **NLM ↔ NFSv4** — an NFSv3 NLM lock conflicts with an NFSv4 `LOCK`, both directions.
+- Registration reachability — `rpcinfo -p` shows DittoFS's NLM (100021) mapping.
+
+### Running / prerequisites
+
+These tests need **root**, `rpcbind`, `rpc.statd`, and `iproute2` (network namespaces), so they
+run only on Linux. On unsupported environments (macOS, no root, no rpcbind) they `t.Skip` rather
+than fail. In CI the e2e workflow installs `rpcbind` and the job runs privileged enough to create
+namespaces; locally:
+
+```bash
+cd test/e2e
+sudo ./run-e2e.sh --test TestNLMAxisInterop
+```
+
+Framework code lives in `test/e2e/framework/netns.go`; the tests in
+`test/e2e/nlm_axis_interop_test.go`. The single-host reachability check (which cannot take a real
+lock, for the reason above) is `TestNLMSystemRpcbindRegistration` in `test/e2e/nlm_locking_test.go`.
+
+---
+
 ## Conformance test suites
 
 DittoFS is validated against two industry-standard conformance test suites.

--- a/test/e2e/framework/netns.go
+++ b/test/e2e/framework/netns.go
@@ -1,0 +1,146 @@
+//go:build e2e
+
+package framework
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// NLMCaseResult is the outcome of one cross-protocol lock-interop case: a holder
+// takes an exclusive byte-range lock via one protocol, a tester attempts a
+// conflicting non-blocking lock via another, then the holder releases and the
+// tester retries.
+type NLMCaseResult struct {
+	Conflict     string // BLOCKED (server denied the conflicting lock) or ACQUIRED
+	AfterRelease string // ACQUIRED once the holder released, or NA
+}
+
+// nlmInteropBinaries are the host tools the netns-isolated real-NLM harness
+// needs. Real NFSv3 NLM locking (no `nolock`) requires the server and client to
+// live in separate network namespaces, each with its own rpcbind — see
+// docs/internals/testing.md and issue #1503.
+var nlmInteropBinaries = []string{
+	"ip", "unshare", "rpcbind", "rpc.statd", "rpcinfo",
+	"mount.nfs", "mount.cifs", "python3", "bash",
+}
+
+// sbinDirs are searched in addition to PATH for the harness's system tools,
+// which commonly live in /usr/sbin or /sbin — directories a restricted (e.g.
+// Nix) PATH may omit even though the tools are installed.
+var sbinDirs = []string{"/usr/sbin", "/sbin", "/usr/bin", "/bin"}
+
+// lookTool resolves a binary via PATH, falling back to the well-known sbin
+// directories so a trimmed PATH doesn't make the harness spuriously skip.
+func lookTool(name string) (string, error) {
+	if p, err := exec.LookPath(name); err == nil {
+		return p, nil
+	}
+	for _, dir := range sbinDirs {
+		p := filepath.Join(dir, name)
+		if info, err := os.Stat(p); err == nil && !info.IsDir() {
+			return p, nil
+		}
+	}
+	return "", exec.ErrNotFound
+}
+
+// SkipIfNLMInteropUnsupported skips unless the host can run the netns-isolated
+// real-NLM interop harness: Linux, root (for namespaces + mounts), and all the
+// required tooling available. This keeps the suite green (skipped) on macOS,
+// unprivileged runners, and minimal images while still exercising the harness
+// wherever it can run.
+//
+// Set DITTOFS_E2E_REQUIRE_NLM=1 (CI does) to turn any missing prerequisite into
+// a hard failure instead of a skip — so a misconfigured runner can't silently
+// drop this coverage.
+func SkipIfNLMInteropUnsupported(t *testing.T) {
+	t.Helper()
+	require := os.Getenv("DITTOFS_E2E_REQUIRE_NLM") == "1"
+	bail := func(format string, args ...any) {
+		if require {
+			t.Fatalf("NLM interop required but "+format, args...)
+		}
+		t.Skipf(format, args...)
+	}
+	if runtime.GOOS != "linux" {
+		bail("harness requires Linux network namespaces")
+		return
+	}
+	if os.Geteuid() != 0 {
+		bail("harness requires root (network namespaces, mounts)")
+		return
+	}
+	for _, bin := range nlmInteropBinaries {
+		if _, err := lookTool(bin); err != nil {
+			bail("harness needs %q available: %v", bin, err)
+			return
+		}
+	}
+}
+
+var nlmResultRE = regexp.MustCompile(`(\S+) conflict=(\S+) afterRelease=(\S+)`)
+
+// RunNLMAxisInterop builds dfs/dfsctl, runs the netns-isolated driver script
+// (test/e2e/testdata/nlm/nlm_axis_interop.sh), and returns the parsed
+// per-direction results. The driver stands up a DittoFS server and a real
+// kernel NFSv3 client in isolated network namespaces and exercises byte-range
+// lock conflicts across the NLM, NFSv4, and SMB protocols.
+func RunNLMAxisInterop(t *testing.T) map[string]NLMCaseResult {
+	t.Helper()
+
+	root := getProjectRoot(t)
+	dfs := buildE2EBinary(t, root, "./cmd/dfs", "dfs")
+	dfsctl := buildE2EBinary(t, root, "./cmd/dfsctl", "dfsctl")
+
+	base := filepath.Join(root, "test", "e2e", "testdata", "nlm")
+	script := filepath.Join(base, "nlm_axis_interop.sh")
+	lockpy := filepath.Join(base, "nlmlock.py")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	// Resolve bash the same sbin-aware way as the skip guard, so a trimmed PATH
+	// (which passed the guard via lookTool) doesn't fail exec here.
+	bash, err := lookTool("bash")
+	if err != nil {
+		t.Fatalf("bash not found: %v", err)
+	}
+	cmd := exec.CommandContext(ctx, bash, script, lockpy)
+	cmd.Env = append(os.Environ(), "DFS_BIN="+dfs, "DFSCTL_BIN="+dfsctl)
+	out, err := cmd.CombinedOutput()
+	t.Logf("NLM interop driver output:\n%s", out)
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatalf("NLM interop driver timed out")
+	}
+	if err != nil {
+		t.Fatalf("NLM interop driver failed: %v", err)
+	}
+
+	results := make(map[string]NLMCaseResult)
+	for _, m := range nlmResultRE.FindAllStringSubmatch(string(out), -1) {
+		results[m[1]] = NLMCaseResult{Conflict: m[2], AfterRelease: m[3]}
+	}
+	if len(results) == 0 {
+		t.Fatalf("no NLM interop case results parsed from driver output")
+	}
+	return results
+}
+
+// buildE2EBinary compiles a command in the repo to a temp path and returns it.
+func buildE2EBinary(t *testing.T, root, pkg, name string) string {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), name)
+	cmd := exec.Command("go", "build", "-o", out, pkg)
+	cmd.Dir = root
+	if combined, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build %s: %v\n%s", name, err, combined)
+	}
+	return out
+}

--- a/test/e2e/nlm_axis_interop_test.go
+++ b/test/e2e/nlm_axis_interop_test.go
@@ -1,0 +1,43 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/test/e2e/framework"
+)
+
+// TestNLMAxisInterop proves DittoFS's unified lock manager coordinates
+// byte-range locks across a REAL kernel NFSv3 client (NLM, no `nolock`) and the
+// NFSv4 and SMB protocols. Because a single host cannot run both a userspace NLM
+// server and a kernel NFSv3 client's lockd against one rpcbind, the driver
+// isolates the client in its own network namespace — see
+// docs/internals/testing.md ("Real NFSv3 NLM lock testing") and issue #1503.
+//
+// Each direction holds an exclusive lock via one protocol and asserts a
+// conflicting lock via another is denied by the server (BLOCKED), then that the
+// lock becomes acquirable once the holder releases (ACQUIRED).
+func TestNLMAxisInterop(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping NLM interop tests in short mode")
+	}
+	framework.SkipIfNLMInteropUnsupported(t)
+
+	results := framework.RunNLMAxisInterop(t)
+
+	for _, name := range []string{"NLM_vs_SMB", "NLM_vs_NFSv4", "SMB_vs_NLM", "NFSv4_vs_NLM"} {
+		t.Run(name, func(t *testing.T) {
+			r, ok := results[name]
+			if !ok {
+				t.Fatalf("no result reported for %s", name)
+			}
+			if r.Conflict != "BLOCKED" {
+				t.Errorf("conflicting lock should be denied by the server (BLOCKED), got %q", r.Conflict)
+			}
+			if r.AfterRelease != "ACQUIRED" {
+				t.Errorf("lock should be acquirable after the holder releases (ACQUIRED), got %q", r.AfterRelease)
+			}
+		})
+	}
+}

--- a/test/e2e/testdata/nlm/nlm_axis_interop.sh
+++ b/test/e2e/testdata/nlm/nlm_axis_interop.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Real NFSv3 NLM cross-protocol lock-interop driver (issue #1503).
+#
+# Proves DittoFS's unified lock manager coordinates byte-range locks across the
+# NFSv3 NLM axis and the NFSv4 / SMB axes, using a REAL kernel NFSv3 client (no
+# `nolock`). Requires dual network-namespace isolation — see
+# docs/internals/testing.md ("Real NFSv3 NLM lock testing").
+#
+# Layout:
+#   sns (server netns, 10.50.0.1) — dfs + its own rpcbind (private /run)
+#   cns (client netns, 10.50.0.2) — kernel NFSv3 client + own rpcbind/statd
+#   veth-s <-> veth-c joins them.
+#
+# Usage: nlm_axis_interop.sh <path-to-nlmlock.py>
+# Emits one line per case:  "<CASE> conflict=<BLOCKED|ACQUIRED|...> afterRelease=<...>"
+# and finally "NLM_AXIS_RESULT=PASS" or "=FAIL".
+set -u
+
+# System tools (ip, rpcbind, mount.nfs, mount.cifs, rpcinfo) live in sbin, which
+# a restricted/Nix PATH may omit. Ensure they resolve.
+export PATH="/usr/sbin:/sbin:/usr/bin:/bin:$PATH"
+
+LOCKPY="${1:?path to nlmlock.py required}"
+WORK="$(mktemp -d /tmp/nlm-e2e.XXXXXX)"
+API=18080; NFSP=12049; SMBP=12445; PW=adminpassword
+SIP=10.50.0.1; CIP=10.50.0.2
+DFS="${DFS_BIN:-dfs}"; DFSCTL="${DFSCTL_BIN:-dfsctl}"
+
+log() { echo "[nlm] $*"; }
+
+clean_ns() {
+  set +e
+  for ns in sns cns; do
+    ip netns pids "$ns" 2>/dev/null | xargs -r kill -9 2>/dev/null
+  done
+  ip netns del cns 2>/dev/null
+  ip netns del sns 2>/dev/null
+  ip link del veth-s 2>/dev/null
+}
+teardown() {
+  clean_ns
+  rm -rf "$WORK" 2>/dev/null
+}
+trap teardown EXIT
+
+# --- 0. pre-clean leftovers from a prior aborted run (idempotent) ----------
+clean_ns
+sleep 0.3
+
+# --- 1. netns + veth -------------------------------------------------------
+ip netns add sns || exit 1
+ip netns add cns || exit 1
+ip link add veth-s type veth peer name veth-c || exit 1
+ip link set veth-s netns sns
+ip link set veth-c netns cns
+ip netns exec sns ip addr add $SIP/24 dev veth-s
+ip netns exec sns ip link set veth-s up
+ip netns exec sns ip link set lo up
+ip netns exec cns ip addr add $CIP/24 dev veth-c
+ip netns exec cns ip link set veth-c up
+ip netns exec cns ip link set lo up
+ip netns exec cns ping -c1 -W2 $SIP >/dev/null 2>&1 && log "veth up" || { log "veth FAIL"; exit 1; }
+
+# --- 2. server (dfs) in sns with a private /run + rpcbind ------------------
+cat > "$WORK/config.yaml" <<CFG
+logging: {level: INFO, format: text, output: stdout}
+controlplane:
+  port: $API
+  jwt: {secret: "test-secret-key-for-e2e-testing-only-must-be-32-chars"}
+database: {type: sqlite, sqlite: {path: "$WORK/dittofs.db"}}
+CFG
+
+ip netns exec sns unshare --mount bash -c "
+  mount -t tmpfs tmpfs /run
+  mkdir -p /run/rpcbind /run/sendsigs.omit.d
+  rpcbind
+  sleep 0.5
+  export DITTOFS_ADMIN_INITIAL_PASSWORD=$PW
+  exec $DFS start --foreground --config $WORK/config.yaml --pid-file $WORK/dfs.pid --log-file $WORK/dfs.log
+" >"$WORK/dfs.out" 2>&1 &
+
+for _ in $(seq 1 80); do
+  ip netns exec sns curl -sf http://127.0.0.1:$API/health >/dev/null 2>&1 && { log "server ready"; break; }
+  sleep 0.3
+done
+ip netns exec sns curl -sf http://127.0.0.1:$API/health >/dev/null 2>&1 || { log "server never ready"; tail -20 "$WORK/dfs.log" 2>/dev/null; exit 1; }
+
+# --- 3. provision (dfsctl, inside sns so the API is reachable) -------------
+NS="ip netns exec sns"
+export XDG_CONFIG_HOME="$WORK/cfg"; mkdir -p "$XDG_CONFIG_HOME"
+$NS env XDG_CONFIG_HOME="$XDG_CONFIG_HOME" $DFSCTL login --server "http://127.0.0.1:$API" --username admin --password "$PW" || { log "login FAIL"; exit 1; }
+dctl() { $NS env XDG_CONFIG_HOME="$XDG_CONFIG_HOME" $DFSCTL "$@"; }
+
+dctl store metadata add --name meta --type memory || { log "meta store FAIL"; exit 1; }
+dctl store block local add --name blk --type memory || { log "block store FAIL"; exit 1; }
+dctl share create --name /export --metadata meta --local blk --default-permission read-write || { log "share FAIL"; exit 1; }
+dctl share nfs-config set /export --squash root_to_admin 2>/dev/null || dctl share nfs-config set /export --squash root_to_admin || true
+dctl adapter settings nfs update --portmapper-register-with-system --udp-enabled || { log "nfs settings FAIL"; exit 1; }
+dctl adapter enable nfs --port $NFSP || { log "nfs enable FAIL"; exit 1; }
+dctl adapter enable smb --port $SMBP || { log "smb enable FAIL"; exit 1; }
+sleep 1
+
+# NLM (100021) must be registered in sns's rpcbind
+if $NS rpcinfo -p $SIP 2>/dev/null | grep -q 100021; then
+  log "NLM registered:"; $NS rpcinfo -p $SIP 2>/dev/null | grep 100021 | sed 's/^/[nlm]   /'
+else
+  log "NLM NOT registered in sns rpcbind"; $NS rpcinfo -p $SIP 2>/dev/null | sed 's/^/[nlm]   /'; exit 1
+fi
+
+# --- 4. client side: mounts + all cases in ONE cns/unshare shell -----------
+ip netns exec cns unshare --mount bash -s "$LOCKPY" "$SIP" "$NFSP" "$SMBP" "$PW" <<'CLIENT'
+set -u
+LOCKPY="$1"; SIP="$2"; NFSP="$3"; SMBP="$4"; PW="$5"
+cl() { echo "[cns] $*"; }
+
+mount -t tmpfs tmpfs /run
+mkdir -p /run/rpcbind /run/sendsigs.omit.d
+rpcbind
+sleep 0.3
+( rpc.statd --no-notify 2>/dev/null || rpc.statd 2>/dev/null ) ; sleep 0.3
+
+# A failed mount would leave a plain local dir behind, so locks would be
+# resolved locally and the cases would be meaningless — hard-fail instead.
+mkdir -p /mnt/v3 /mnt/v4 /mnt/smb
+mount -t nfs -o nfsvers=3,tcp,port=$NFSP,mountport=$NFSP,actimeo=0 $SIP:/export /mnt/v3 || { cl "V3_MOUNT_FAIL"; exit 1; }
+mount -t nfs -o nfsvers=4.0,tcp,port=$NFSP $SIP:/export /mnt/v4 || { cl "V4_MOUNT_FAIL"; exit 1; }
+mount -t cifs -o port=$SMBP,username=admin,password=$PW,vers=3.0 //$SIP/export /mnt/smb || { cl "SMB_MOUNT_FAIL"; exit 1; }
+mount | grep -E "/mnt/(v3|v4|smb)" | sed 's/^/[cns]   /'
+
+# Per-run scratch for holder handshake files (avoids collisions between runs).
+TMPD=$(mktemp -d)
+ACQ="$TMPD/acq"; REL="$TMPD/rel"
+
+# seed a shared file (same backing object on the server)
+echo seed > /mnt/v3/lock.dat 2>/dev/null || echo seed > /mnt/smb/lock.dat 2>/dev/null || echo seed > /mnt/v4/lock.dat
+sleep 0.3
+
+# Warm-up: the client lockd/statd NLM handshake is not instant after the first
+# NFSv3 mount; a lock can transiently fail with ENOLCK/NLM4_DENIED_NOLOCKS.
+# Poll a throwaway NLM lock until it is granted before running the cases.
+warm_ok=no
+for i in $(seq 1 40); do
+  if python3 "$LOCKPY" try /mnt/v3/warmup.dat w 0 100 2>/dev/null | grep -q ACQUIRED; then
+    warm_ok=yes; cl "NLM warm-up ok after $((i*250))ms"; break
+  fi
+  sleep 0.25
+done
+# Hard-fail if NLM never came ready: otherwise a not-ready lock manager (ENOLCK)
+# could be misread as a conflict and green-light a server that never coordinated.
+[ "$warm_ok" = yes ] || { cl "NLM_WARMUP_FAILED"; exit 1; }
+
+FAILS=0
+run_case() { # name holder_path tester_path
+  local name="$1" hp="$2" tp="$3"
+  rm -f "$ACQ" "$REL"
+  python3 "$LOCKPY" hold "$hp" w 0 100 "$ACQ" "$REL" &
+  local hpid=$!
+  for _ in $(seq 1 50); do [ -f "$ACQ" ] && break; sleep 0.1; done
+  if ! grep -q ok "$ACQ" 2>/dev/null; then
+    echo "$name conflict=HOLDER_FAIL($(tr '\n' ' ' <"$ACQ" 2>/dev/null)) afterRelease=NA"
+    kill $hpid 2>/dev/null; wait $hpid 2>/dev/null; FAILS=$((FAILS+1)); return
+  fi
+  local res; res=$(python3 "$LOCKPY" try "$tp" w 0 100 2>/dev/null)
+  touch "$REL"; wait $hpid 2>/dev/null
+  sleep 0.3
+  local res2; res2=$(python3 "$LOCKPY" try "$tp" w 0 100 2>/dev/null)
+  echo "$name conflict=$res afterRelease=$res2"
+  # A pass = the conflicting lock was denied by the server, then granted once
+  # the holder released. Anything else (ACQUIRED-while-held, ERROR, ...) fails.
+  [ "$res" = BLOCKED ] && [ "$res2" = ACQUIRED ] || FAILS=$((FAILS+1))
+}
+
+run_case NLM_vs_SMB   /mnt/v3/lock.dat  /mnt/smb/lock.dat
+run_case NLM_vs_NFSv4 /mnt/v3/lock.dat  /mnt/v4/lock.dat
+run_case SMB_vs_NLM   /mnt/smb/lock.dat /mnt/v3/lock.dat
+run_case NFSv4_vs_NLM /mnt/v4/lock.dat  /mnt/v3/lock.dat
+
+umount -f -l /mnt/v3 /mnt/v4 /mnt/smb 2>/dev/null
+if [ "$FAILS" -eq 0 ]; then echo "NLM_AXIS_RESULT=PASS"; else echo "NLM_AXIS_RESULT=FAIL"; fi
+exit "$FAILS"
+CLIENT
+client_rc=$?
+[ "$client_rc" -eq 0 ] || { log "client cases failed (rc=$client_rc)"; exit "$client_rc"; }

--- a/test/e2e/testdata/nlm/nlmlock.py
+++ b/test/e2e/testdata/nlm/nlmlock.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Byte-range lock helper for the NLM cross-protocol interop e2e (issue #1503).
+#
+# Uses fcntl.lockf() (non-blocking POSIX byte-range locks) so a conflict returns
+# immediately and we avoid any arch-specific `struct flock` layout.
+#
+# Two modes:
+#
+#   hold  PATH TYPE START LEN ACQFILE RELFILE
+#       Acquire the lock, write "ok" to ACQFILE (or "err: ..." on failure), then
+#       block until RELFILE appears (or a 30s safety timeout), then release.
+#
+#   try   PATH TYPE START LEN
+#       Attempt the lock once. Print "ACQUIRED" (and release) if granted, or
+#       "BLOCKED" if it conflicts (EACCES/EAGAIN). Any other error prints
+#       "ERROR: ..." and exits 2.
+#
+# TYPE is "w" (exclusive) or "r" (shared).
+import errno
+import fcntl
+import os
+import sys
+import time
+
+# Errnos that mean "another holder owns a conflicting lock" — the only outcome
+# that counts as a real, server-detected conflict. Anything else (ENOLCK from a
+# not-ready lock manager, ESTALE, EIO, ...) is a harness error, NOT a conflict,
+# and must not be reported as BLOCKED.
+_CONFLICT_ERRNOS = (errno.EACCES, errno.EAGAIN)
+
+
+def _open(path):
+    return os.open(path, os.O_RDWR | os.O_CREAT, 0o644)
+
+
+def _cmd(ltype):
+    base = fcntl.LOCK_EX if ltype == "w" else fcntl.LOCK_SH
+    return base | fcntl.LOCK_NB
+
+
+def main():
+    mode = sys.argv[1]
+    path = sys.argv[2]
+    cmd = _cmd(sys.argv[3])
+    start = int(sys.argv[4])
+    length = int(sys.argv[5])
+
+    if mode == "try":
+        fd = _open(path)
+        try:
+            fcntl.lockf(fd, cmd, length, start, os.SEEK_SET)
+        except OSError as e:
+            if e.errno in _CONFLICT_ERRNOS:
+                print("BLOCKED")
+                return 0
+            print("ERROR: %s" % e)
+            return 2
+        else:
+            print("ACQUIRED")
+            fcntl.lockf(fd, fcntl.LOCK_UN, length, start, os.SEEK_SET)
+            return 0
+        finally:
+            os.close(fd)
+
+    if mode == "hold":
+        acqfile, relfile = sys.argv[6], sys.argv[7]
+        fd = _open(path)
+        try:
+            fcntl.lockf(fd, cmd, length, start, os.SEEK_SET)
+        except OSError as e:
+            with open(acqfile, "w") as f:
+                f.write("err: %s" % e)
+            os.close(fd)
+            return 3
+        with open(acqfile, "w") as f:
+            f.write("ok pid=%d" % os.getpid())
+        for _ in range(300):  # 30s safety cap
+            if os.path.exists(relfile):
+                break
+            time.sleep(0.1)
+        os.close(fd)
+        return 0
+
+    print("ERROR: unknown mode %r" % mode)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1503.

## What

Proves DittoFS's unified lock manager coordinates byte-range locks across a **real kernel NFSv3 client** (NLM, no `nolock`), NFSv4, and SMB — validated on a Linux VM, all four directions passing.

## Why it needs network namespaces

A single host can't run both a userspace NLM server and a kernel NFSv3 client's `lockd` against one rpcbind: the client reclaims the `100021` mapping and sends locks to the local kernel instead of DittoFS. This is the same constraint NFS-Ganesha hits. The driver copies Ganesha's fix — isolate client and server in **separate network namespaces** (veth pair, each side its own `rpcbind` + `rpc.statd`; server launched via `unshare --mount` + private `/run`), so the client's `GETPORT` for NLM resolves to DittoFS.

## Coverage

Four server-mediated directions, each: hold an exclusive byte-range lock via one protocol, assert a conflicting lock via another is **denied while held**, then **granted after release**.

| Holder | Conflicting | 
|--------|-------------|
| NLM (real NFSv3) | SMB |
| NLM | NFSv4 |
| SMB | NLM |
| NFSv4 | NLM |

Verdict: real cross-netns NFSv3 NLM reaches DittoFS; the unified lock manager coordinates NLM↔SMB and NLM↔NFSv4 both ways. **No server bug on the lock axis.**

## Safety against false-green

- Skips cleanly off Linux / non-root / missing tooling (sbin-aware lookup).
- `DITTOFS_E2E_REQUIRE_NLM=1` (set in the e2e workflow) turns a missing prerequisite into a **hard failure**, so a misconfigured runner can't silently drop this coverage.
- Lock helper reports only `EACCES`/`EAGAIN` as a conflict; any other errno is a harness error, not a fake "blocked".
- Warm-up gate hard-fails if the client NLM never becomes ready.

## Files

- `test/e2e/framework/netns.go`, `test/e2e/nlm_axis_interop_test.go`
- `test/e2e/testdata/nlm/{nlm_axis_interop.sh,nlmlock.py}`
- `docs/internals/testing.md` (new "Real NFSv3 NLM lock testing" section), `docs/guide/nfs.md` (same-host caveat)
- `.github/workflows/e2e-tests.yml`: install `rpcbind`, set the require gate