### PR TITLE
fix(kerberos): resolve krb5.conf per-platform, honor KRB5_CONFIG (#1529)

### DIFF
--- a/pkg/auth/kerberos/keytab.go
+++ b/pkg/auth/kerberos/keytab.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -172,8 +173,15 @@ func resolveKrb5ConfPath(configPath string) string {
 	if configPath != "" {
 		return configPath
 	}
+	// KRB5_CONFIG (MIT convention) may be a path list of multiple config files
+	// separated by os.PathListSeparator (':' on Unix, ';' on Windows). gokrb5
+	// loads a single file, so use the first non-empty entry.
 	if envPath := os.Getenv("KRB5_CONFIG"); envPath != "" {
-		return envPath
+		for _, p := range strings.Split(envPath, string(os.PathListSeparator)) {
+			if p != "" {
+				return p
+			}
+		}
 	}
 	return defaultKrb5ConfPath(runtime.GOOS, os.Getenv("ProgramData"))
 }

--- a/pkg/auth/kerberos/keytab.go
+++ b/pkg/auth/kerberos/keytab.go
@@ -3,6 +3,7 @@ package kerberos
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"sync"
 	"time"
 
@@ -156,18 +157,39 @@ func resolveServicePrincipal(configPrincipal string) string {
 	return configPrincipal
 }
 
-// resolveKrb5ConfPath resolves the krb5.conf path with environment variable override.
+// resolveKrb5ConfPath resolves the krb5.conf path.
 //
 // Resolution order (highest priority first):
-//  1. DITTOFS_KERBEROS_KRB5CONF env var
-//  2. configPath from configuration file
-//  3. Default: /etc/krb5.conf
+//  1. DITTOFS_KERBEROS_KRB5CONF env var (explicit DittoFS override)
+//  2. configPath from the identity provider / config file (krb5_conf)
+//  3. KRB5_CONFIG env var (standard MIT Kerberos convention)
+//  4. Platform default: %ProgramData%\MIT\Kerberos5\krb5.ini on Windows,
+//     /etc/krb5.conf elsewhere.
 func resolveKrb5ConfPath(configPath string) string {
 	if envPath := os.Getenv("DITTOFS_KERBEROS_KRB5CONF"); envPath != "" {
 		return envPath
 	}
 	if configPath != "" {
 		return configPath
+	}
+	if envPath := os.Getenv("KRB5_CONFIG"); envPath != "" {
+		return envPath
+	}
+	return defaultKrb5ConfPath(runtime.GOOS, os.Getenv("ProgramData"))
+}
+
+// defaultKrb5ConfPath returns the platform-appropriate default krb5.conf path.
+//
+// Split out from resolveKrb5ConfPath so the OS-specific branching is unit
+// testable without depending on the host platform. The Windows path is built
+// with literal backslashes (not filepath.Join) so it is deterministic when
+// exercised from a non-Windows host.
+func defaultKrb5ConfPath(goos, programData string) string {
+	if goos == "windows" {
+		if programData == "" {
+			programData = `C:\ProgramData`
+		}
+		return programData + `\MIT\Kerberos5\krb5.ini`
 	}
 	return "/etc/krb5.conf"
 }

--- a/pkg/auth/kerberos/keytab_test.go
+++ b/pkg/auth/kerberos/keytab_test.go
@@ -3,6 +3,7 @@ package kerberos
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -125,12 +126,58 @@ func TestResolveKrb5ConfPath_FallbackToConfig(t *testing.T) {
 	}
 }
 
-func TestResolveKrb5ConfPath_DefaultFallback(t *testing.T) {
+func TestResolveKrb5ConfPath_KRB5ConfigEnvFallback(t *testing.T) {
+	// With no DittoFS override and no configured path, the standard MIT
+	// KRB5_CONFIG env var is honored before falling back to the platform default.
 	t.Setenv("DITTOFS_KERBEROS_KRB5CONF", "")
+	t.Setenv("KRB5_CONFIG", "/env/standard/krb5.conf")
 
 	result := resolveKrb5ConfPath("")
-	if result != "/etc/krb5.conf" {
-		t.Fatalf("expected /etc/krb5.conf, got %s", result)
+	if result != "/env/standard/krb5.conf" {
+		t.Fatalf("expected /env/standard/krb5.conf, got %s", result)
+	}
+}
+
+func TestResolveKrb5ConfPath_ConfigBeatsKRB5Config(t *testing.T) {
+	// An explicitly configured krb5_conf takes precedence over KRB5_CONFIG.
+	t.Setenv("DITTOFS_KERBEROS_KRB5CONF", "")
+	t.Setenv("KRB5_CONFIG", "/env/standard/krb5.conf")
+
+	result := resolveKrb5ConfPath("/config/path/krb5.conf")
+	if result != "/config/path/krb5.conf" {
+		t.Fatalf("expected /config/path/krb5.conf, got %s", result)
+	}
+}
+
+func TestResolveKrb5ConfPath_DefaultFallback(t *testing.T) {
+	t.Setenv("DITTOFS_KERBEROS_KRB5CONF", "")
+	t.Setenv("KRB5_CONFIG", "")
+
+	result := resolveKrb5ConfPath("")
+	want := defaultKrb5ConfPath(runtime.GOOS, os.Getenv("ProgramData"))
+	if result != want {
+		t.Fatalf("expected %s, got %s", want, result)
+	}
+}
+
+func TestDefaultKrb5ConfPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		goos        string
+		programData string
+		want        string
+	}{
+		{"linux", "linux", "", "/etc/krb5.conf"},
+		{"darwin", "darwin", "", "/etc/krb5.conf"},
+		{"windows with ProgramData", "windows", `D:\ProgramData`, `D:\ProgramData\MIT\Kerberos5\krb5.ini`},
+		{"windows without ProgramData", "windows", "", `C:\ProgramData\MIT\Kerberos5\krb5.ini`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := defaultKrb5ConfPath(tt.goos, tt.programData); got != tt.want {
+				t.Fatalf("defaultKrb5ConfPath(%q, %q) = %q, want %q", tt.goos, tt.programData, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/pkg/auth/kerberos/keytab_test.go
+++ b/pkg/auth/kerberos/keytab_test.go
@@ -138,6 +138,32 @@ func TestResolveKrb5ConfPath_KRB5ConfigEnvFallback(t *testing.T) {
 	}
 }
 
+func TestResolveKrb5ConfPath_KRB5ConfigPathList(t *testing.T) {
+	// KRB5_CONFIG may be a path list (MIT convention). gokrb5 loads a single
+	// file, so the first non-empty entry is used.
+	t.Setenv("DITTOFS_KERBEROS_KRB5CONF", "")
+	sep := string(os.PathListSeparator)
+	t.Setenv("KRB5_CONFIG", "/env/first/krb5.conf"+sep+"/env/second/krb5.conf")
+
+	result := resolveKrb5ConfPath("")
+	if result != "/env/first/krb5.conf" {
+		t.Fatalf("expected /env/first/krb5.conf, got %s", result)
+	}
+}
+
+func TestResolveKrb5ConfPath_KRB5ConfigPathListLeadingEmpty(t *testing.T) {
+	// Leading empty entries in the path list are skipped in favor of the first
+	// non-empty path.
+	t.Setenv("DITTOFS_KERBEROS_KRB5CONF", "")
+	sep := string(os.PathListSeparator)
+	t.Setenv("KRB5_CONFIG", sep+"/env/real/krb5.conf")
+
+	result := resolveKrb5ConfPath("")
+	if result != "/env/real/krb5.conf" {
+		t.Fatalf("expected /env/real/krb5.conf, got %s", result)
+	}
+}
+
 func TestResolveKrb5ConfPath_ConfigBeatsKRB5Config(t *testing.T) {
 	// An explicitly configured krb5_conf takes precedence over KRB5_CONFIG.
 	t.Setenv("DITTOFS_KERBEROS_KRB5CONF", "")

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -95,10 +95,11 @@ func applyKerberosDefaults(cfg *KerberosConfig) {
 	// Enabled defaults to false (opt-in for Kerberos)
 	// No need to set, zero value is false
 
-	// Default krb5.conf path
-	if cfg.Krb5Conf == "" {
-		cfg.Krb5Conf = "/etc/krb5.conf"
-	}
+	// Krb5Conf is intentionally left empty here. The path is resolved at load
+	// time by resolveKrb5ConfPath (pkg/auth/kerberos), which layers the
+	// DITTOFS_KERBEROS_KRB5CONF override, the configured krb5_conf value, the
+	// standard KRB5_CONFIG env var, and a platform-appropriate default. Stamping
+	// a Unix "/etc/krb5.conf" here would shadow KRB5_CONFIG and break Windows.
 
 	// AD domain identity (AD-4): all optional and back-compatible.
 	//


### PR DESCRIPTION
## Problem

Closes #1529. On Windows, `dfs start` crashes at boot: the SMB adapter's Kerberos provider tries to load `/etc/krb5.conf`, ignoring both the `krb5_conf` identity-provider field and the standard `KRB5_CONFIG` env var. The SMB adapter returns a fatal error, so the whole server exits.

Root cause: `applyKerberosDefaults` stamped `cfg.Krb5Conf = "/etc/krb5.conf"` when empty. That pre-fill meant `resolveKrb5ConfPath` never saw an empty config path, so its `KRB5_CONFIG` fallback and platform default were dead code in production — the Unix path always won, even on Windows.

## Fix

- `resolveKrb5ConfPath` resolves in the order the issue's *Expected* section documents:
  1. `DITTOFS_KERBEROS_KRB5CONF` (explicit DittoFS override)
  2. `krb5_conf` config field
  3. `KRB5_CONFIG` (standard MIT Kerberos env var)
  4. Platform default — `%ProgramData%\MIT\Kerberos5\krb5.ini` on Windows, `/etc/krb5.conf` elsewhere.
- Remove the premature default from `applyKerberosDefaults` so the chain above is reachable. Path is now resolved at load time, platform-aware.
- Platform branch split into a pure `defaultKrb5ConfPath(goos, programData)` so the Windows path is table-testable from a non-Windows host.

## Tests

Table tests for the full precedence chain (`DITTOFS_KERBEROS_KRB5CONF` > config > `KRB5_CONFIG` > default) and the platform default (linux/darwin/windows ± `ProgramData`). `go build`, `go vet`, `golangci-lint` clean; `pkg/auth/kerberos` + `pkg/config` green.

## Scope / follow-up

This delivers the exact resolution chain the issue asks for. If the identity-provider → `KerberosConfig` mapping drops `krb5_conf` before it reaches `NewProvider` (the reporter set the field yet still saw `/etc/krb5.conf`), that's a separate wiring bug best confirmed against a live Windows DC — the new `KRB5_CONFIG` + Windows default give a working fallback regardless. End-to-end Windows verification pending the AD VM.