### PR TITLE
fix(shares): warn when block store binding change needs a restart

### DIFF
--- a/cmd/dfsctl/commands/share/edit.go
+++ b/cmd/dfsctl/commands/share/edit.go
@@ -265,6 +265,13 @@ func runEdit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to update share: %w", err)
 	}
 
+	// Surface any server-side warnings (e.g. a block-store binding change that
+	// only takes effect after a restart — #1532) so the update is not silently
+	// a partial no-op.
+	for _, warning := range share.Warnings {
+		fmt.Fprintf(os.Stderr, "Warning: %s\n", warning)
+	}
+
 	return cmdutil.PrintResourceWithSuccess(os.Stdout, share, fmt.Sprintf("Share '%s' updated successfully", share.Name))
 }
 
@@ -419,6 +426,13 @@ func runEditInteractive(client *apiclient.Client, name string) error {
 	share, err := client.UpdateShare(name, req)
 	if err != nil {
 		return fmt.Errorf("failed to update share: %w", err)
+	}
+
+	// Surface any server-side warnings (e.g. a block-store binding change that
+	// only takes effect after a restart — #1532) so the update is not silently
+	// a partial no-op.
+	for _, warning := range share.Warnings {
+		fmt.Fprintf(os.Stderr, "Warning: %s\n", warning)
 	}
 
 	return cmdutil.PrintResourceWithSuccess(os.Stdout, share, fmt.Sprintf("Share '%s' updated successfully", share.Name))

--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -904,7 +904,7 @@ func (h *ShareHandler) Update(w http.ResponseWriter, r *http.Request) {
 	var updateWarnings []string
 	if blockStoreBindingChanged {
 		const bindingWarn = "block store binding changed but only takes effect after a server restart; " +
-			"until then the running share keeps its previous local-only/remote mode and new writes are not mirrored"
+			"until then the running share keeps using its previous block store binding"
 		logger.Warn("Share block store binding changed (takes effect on restart)",
 			"share", share.Name,
 			"local_block_store_id", share.LocalBlockStoreID,

--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -262,6 +262,11 @@ type ShareResponse struct {
 	// clients can render "unknown" explicitly when the runtime has
 	// not loaded the share yet.
 	Status health.Report `json:"status"`
+
+	// Warnings carries non-fatal operator-facing messages about the request
+	// that just completed — e.g. a block-store binding change that only takes
+	// effect after a server restart. Omitted when empty.
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 // Create handles POST /api/v1/shares.
@@ -673,6 +678,17 @@ func (h *ShareHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Snapshot the block-store binding before applying updates. The running
+	// per-share syncer/BlockStore mode (local-only vs. remote) is fixed at
+	// share-load and is NOT hot-reloaded on a binding change (see #1532), so
+	// changing it here silently has no effect on mirroring until a full server
+	// restart. We detect the change below and warn the operator.
+	prevLocalBlockStoreID := share.LocalBlockStoreID
+	prevRemoteBlockStoreID := ""
+	if share.RemoteBlockStoreID != nil {
+		prevRemoteBlockStoreID = *share.RemoteBlockStoreID
+	}
+
 	// Apply updates
 	if req.MetadataStoreID != nil {
 		share.MetadataStoreID = *req.MetadataStoreID
@@ -702,6 +718,16 @@ func (h *ShareHandler) Update(w http.ResponseWriter, r *http.Request) {
 			share.RemoteBlockStoreID = &remoteBlockStore.ID
 		}
 	}
+
+	// Detect an effective block-store binding change (see #1532). Compared
+	// against the canonical resolved IDs so a no-op re-submit does not warn.
+	newRemoteBlockStoreID := ""
+	if share.RemoteBlockStoreID != nil {
+		newRemoteBlockStoreID = *share.RemoteBlockStoreID
+	}
+	blockStoreBindingChanged := share.LocalBlockStoreID != prevLocalBlockStoreID ||
+		newRemoteBlockStoreID != prevRemoteBlockStoreID
+
 	if req.ReadOnly != nil {
 		share.ReadOnly = *req.ReadOnly
 	}
@@ -872,6 +898,20 @@ func (h *ShareHandler) Update(w http.ResponseWriter, r *http.Request) {
 			"local_store_size", share.LocalStoreSize, "read_buffer_size", share.ReadBufferSize)
 	}
 
+	// The per-share syncer/BlockStore mode is not hot-reloaded (#1532): a
+	// binding change is persisted but only takes effect after a server restart.
+	// Warn loudly so the change is not silently a no-op for mirroring.
+	var updateWarnings []string
+	if blockStoreBindingChanged {
+		const bindingWarn = "block store binding changed but only takes effect after a server restart; " +
+			"until then the running share keeps its previous local-only/remote mode and new writes are not mirrored"
+		logger.Warn("Share block store binding changed (takes effect on restart)",
+			"share", share.Name,
+			"local_block_store_id", share.LocalBlockStoreID,
+			"remote_block_store_id", newRemoteBlockStoreID)
+		updateWarnings = append(updateWarnings, bindingWarn)
+	}
+
 	// Update runtime if available
 	if h.runtime != nil {
 		if err := h.runtime.UpdateShare(share.Name, req.ReadOnly, req.DefaultPermission, rtRetPolicy, rtRetTTL); err != nil {
@@ -916,7 +956,9 @@ func (h *ShareHandler) Update(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithTimeout(r.Context(), HealthCheckTimeout)
 	defer cancel()
-	WriteJSONOK(w, h.shareToResponseWithUsage(ctx, share))
+	resp := h.shareToResponseWithUsage(ctx, share)
+	resp.Warnings = updateWarnings
+	WriteJSONOK(w, resp)
 }
 
 // Remove handles DELETE /api/v1/shares/{name}.

--- a/internal/controlplane/api/handlers/shares_test.go
+++ b/internal/controlplane/api/handlers/shares_test.go
@@ -434,3 +434,64 @@ func TestShareHandler_Update_RejectsInvalidDefaultPermission(t *testing.T) {
 		t.Fatalf("Update(invalid default_permission) = %d, want 400; body=%s", w.Code, w.Body.String())
 	}
 }
+
+// TestShareHandler_Update_WarnsOnBlockStoreBindingChange verifies that
+// attaching/changing a share's block store returns an operator-facing warning,
+// since the running syncer/BlockStore is not hot-reloaded (#1532).
+func TestShareHandler_Update_WarnsOnBlockStoreBindingChange(t *testing.T) {
+	cpStore, _, handler := setupShareTestWithRuntime(t)
+	seedShare(t, cpStore, "s-bswarn")
+	ctx := context.Background()
+
+	remote := &models.BlockStoreConfig{
+		ID: uuid.New().String(), Name: "warn-remote", Kind: models.BlockStoreKindRemote, Type: "memory", CreatedAt: time.Now(),
+	}
+	if _, err := cpStore.CreateBlockStore(ctx, remote); err != nil {
+		t.Fatalf("CreateBlockStore(remote): %v", err)
+	}
+
+	body := []byte(`{"remote_block_store_id":"warn-remote"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/shares/s-bswarn", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withShareName(req, "s-bswarn")
+	w := httptest.NewRecorder()
+
+	handler.Update(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("Update = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	var resp ShareResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Warnings) == 0 {
+		t.Fatalf("expected a restart-required warning on binding change, got none")
+	}
+}
+
+// TestShareHandler_Update_NoWarnWithoutBindingChange verifies a non-binding
+// update (read-only toggle) returns no spurious binding warning.
+func TestShareHandler_Update_NoWarnWithoutBindingChange(t *testing.T) {
+	cpStore, _, handler := setupShareTestWithRuntime(t)
+	seedShare(t, cpStore, "s-nowarn")
+
+	body := []byte(`{"read_only":true}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/shares/s-nowarn", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withShareName(req, "s-nowarn")
+	w := httptest.NewRecorder()
+
+	handler.Update(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("Update = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	var resp ShareResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Warnings) != 0 {
+		t.Errorf("expected no warnings for a non-binding update, got %v", resp.Warnings)
+	}
+}

--- a/pkg/apiclient/shares.go
+++ b/pkg/apiclient/shares.go
@@ -45,6 +45,10 @@ type Share struct {
 	// AccessBasedEnumeration mirrors models.Share — Refs #532. No omitempty
 	// for the same reason.
 	AccessBasedEnumeration bool `json:"access_based_enumeration"`
+	// Warnings carries non-fatal operator-facing messages about the request
+	// that just completed (e.g. a block-store binding change that only takes
+	// effect after a server restart — #1532). Omitted when empty.
+	Warnings []string `json:"warnings,omitempty"`
 	// ChangeNotifyDisabled mirrors models.Share. No omitempty: `false` is
 	// the operator-meaningful "change notify enabled" state.
 	ChangeNotifyDisabled bool `json:"change_notify_disabled"`


### PR DESCRIPTION
## Summary

Fixes the **silent no-mirroring trap** from #1532 (ported from dittofs-pro#140): changing a share's block-store binding (`dfsctl share edit --remote <store>`) persists to the DB and `share list` shows the new remote, but the running per-share syncer/BlockStore mode is fixed at share-load and is **not** hot-reloaded — so mirroring silently does nothing until a full server restart, with no error or warning.

This PR makes the behavior **non-silent**: when a block-store binding actually changes, the API returns an operator-facing warning and `dfsctl` prints it.

```
$ dfsctl share edit /my-share --remote cubbit-tim
Warning: block store binding changed but only takes effect after a server restart;
until then the running share keeps its previous local-only/remote mode and new writes are not mirrored
Share '/my-share' updated successfully
```

This is the issue's explicit **"at minimum"** bar ("clearly warn that a server restart is required … so the behavior is not silent").

## Changes

- **PUT `/api/v1/shares/{name}`** (`internal/controlplane/api/handlers/shares.go`) — snapshot the local/remote block-store IDs before applying the update; after applying, detect a real binding change (canonical resolved IDs, so a no-op re-submit doesn't warn); on change, log a `WARN` and attach a warning to the response.
- **`ShareResponse` / apiclient `Share`** — new `warnings []string` (omitempty), backward compatible.
- **`dfsctl share edit`** — prints any returned warnings to stderr (both the flag-based and interactive paths).
- Tests: binding change → warning present; non-binding update (read-only toggle) → no warning.

## Deliberately NOT in this PR (follow-up)

The issue's **preferred** fix — hot-reloading the syncer/BlockStore live so the binding takes effect without a restart — is a real data-plane change and is left as a follow-up because it needs design sign-off:

- Thread `blockStoreProvider` / `localStoreDefaults` / `syncerDefaults` (currently per-`AddShare` args) into an `UpdateShare`/`RebindShareBlockStore` path.
- Drain in-flight I/O against the old `*engine.BlockStore` before swap (there is a `DrainAllBlockStores` primitive to build on).
- Correctly adjust the ref-counted shared remote-store map (`acquireRemoteStore`/`releaseRemoteStore`) and swap `share.BlockStore` under `s.mu` vs. concurrent `GetBlockStoreForHandle`.
- **Backfill** of pre-existing local blocks to a newly-attached remote (write-through alone won't mirror old content) — a related sub-task the issue also flags.

The teardown (`RemoveShare`) and rebuild (`createBlockStoreForShare`) primitives already exist, so the rebind is feasible — it's the drain/ref-count/concurrency correctness that warrants its own reviewed change rather than riding along here.

`go test -race ./...` green.

Refs #1532
