### PR TITLE
fix(shares): persist share owner across restarts

### DIFF
--- a/cmd/dfsctl/commands/share/show.go
+++ b/cmd/dfsctl/commands/share/show.go
@@ -83,6 +83,7 @@ func (sd ShareDetail) Rows() [][]string {
 		{"Read Only", fmt.Sprintf("%v", s.ReadOnly)},
 		{"Enabled", shareEnabledString(s.Enabled)},
 		{"Default Permission", s.DefaultPermission},
+		{"Root Owner", shareOwnerString(s.OwnerUID, s.OwnerGID)},
 		{"ACL Canonicalize Inherited", fmt.Sprintf("%v", s.AclFlagInheritedCanonicalization)},
 		{"Access-Based Enumeration", fmt.Sprintf("%v", s.AccessBasedEnumeration)},
 		{"Change Notify Disabled", fmt.Sprintf("%v", s.ChangeNotifyDisabled)},
@@ -170,4 +171,17 @@ func runShow(cmd *cobra.Command, args []string) error {
 		metaStoreNames:  metaNames,
 		blockStoreNames: blockNames,
 	})
+}
+
+// shareOwnerString renders the persisted root-directory owner (#1534) for the
+// detail table. Nil UID means the root is owned by root (the default).
+func shareOwnerString(uid, gid *uint32) string {
+	if uid == nil {
+		return "root (0:0)"
+	}
+	group := *uid
+	if gid != nil {
+		group = *gid
+	}
+	return fmt.Sprintf("%d:%d", *uid, group)
 }

--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -216,9 +216,13 @@ type ShareResponse struct {
 	// Enabled mirrors models.Share.Enabled. No omitempty — `false` is
 	// semantically meaningful (the share is disabled) and consumers must
 	// render that state explicitly.
-	Enabled           bool     `json:"enabled"`
-	EncryptData       bool     `json:"encrypt_data"`
-	DefaultPermission string   `json:"default_permission"`
+	Enabled           bool   `json:"enabled"`
+	EncryptData       bool   `json:"encrypt_data"`
+	DefaultPermission string `json:"default_permission"`
+	// OwnerUID/OwnerGID mirror models.Share — the persisted root-directory
+	// owner (#1534). Nil (omitted) means root-owned.
+	OwnerUID          *uint32  `json:"owner_uid,omitempty"`
+	OwnerGID          *uint32  `json:"owner_gid,omitempty"`
 	BlockedOperations []string `json:"blocked_operations,omitempty"`
 	RetentionPolicy   string   `json:"retention_policy"`
 	RetentionTTL      string   `json:"retention_ttl,omitempty"`    // Human-readable duration
@@ -452,6 +456,36 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 		trashMaxBytes = *req.TrashMaxBytes
 	}
 
+	// Resolve the share owner (if any) to the UID/GID that will own the root
+	// directory. The root's owner governs who can write at the share root via
+	// POSIX; share permission grants are a separate, gate-only layer. The
+	// resolved IDs are persisted on the share so startup can re-apply them —
+	// otherwise a restart resets the root to UID/GID 0 (#1534).
+	var rootAttr *metadata.FileAttr
+	if req.Owner != "" {
+		owner, err := h.store.GetUser(r.Context(), req.Owner)
+		if err != nil {
+			if errors.Is(err, models.ErrUserNotFound) {
+				BadRequest(w, fmt.Sprintf("Owner user %q not found", req.Owner))
+				return
+			}
+			InternalServerError(w, "Failed to resolve owner")
+			return
+		}
+		if owner.UID == nil {
+			BadRequest(w, fmt.Sprintf("Owner user %q has no UID", req.Owner))
+			return
+		}
+		// Default the group to the owner's own UID rather than GID 0 (root):
+		// an --owner share with no explicit GID must not grant root-group
+		// ownership of the share root.
+		gid := *owner.UID
+		if owner.GID != nil {
+			gid = *owner.GID
+		}
+		rootAttr = &metadata.FileAttr{UID: *owner.UID, GID: gid}
+	}
+
 	now := time.Now()
 	share := &models.Share{
 		ID:                               uuid.New().String(),
@@ -480,6 +514,10 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 		TrashMaxBytes:                    trashMaxBytes,
 		CreatedAt:                        now,
 		UpdatedAt:                        now,
+	}
+	if rootAttr != nil {
+		share.OwnerUID = &rootAttr.UID
+		share.OwnerGID = &rootAttr.GID
 	}
 	if err := metadata.ValidateExcludePatterns(req.TrashExcludePatterns); err != nil {
 		BadRequest(w, err.Error())
@@ -518,34 +556,6 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 			logger.Warn("Failed to persist default SMB adapter config for new share",
 				"share", req.Name, "error", err)
 		}
-	}
-
-	// Resolve the share owner (if any) to the UID/GID that will own the root
-	// directory. The root's owner governs who can write at the share root via
-	// POSIX; share permission grants are a separate, gate-only layer.
-	var rootAttr *metadata.FileAttr
-	if req.Owner != "" {
-		owner, err := h.store.GetUser(r.Context(), req.Owner)
-		if err != nil {
-			if errors.Is(err, models.ErrUserNotFound) {
-				BadRequest(w, fmt.Sprintf("Owner user %q not found", req.Owner))
-				return
-			}
-			InternalServerError(w, "Failed to resolve owner")
-			return
-		}
-		if owner.UID == nil {
-			BadRequest(w, fmt.Sprintf("Owner user %q has no UID", req.Owner))
-			return
-		}
-		// Default the group to the owner's own UID rather than GID 0 (root):
-		// an --owner share with no explicit GID must not grant root-group
-		// ownership of the share root.
-		gid := *owner.UID
-		if owner.GID != nil {
-			gid = *owner.GID
-		}
-		rootAttr = &metadata.FileAttr{UID: *owner.UID, GID: gid}
 	}
 
 	// Add share to runtime if runtime is available
@@ -1304,6 +1314,8 @@ func shareToResponse(s *models.Share) ShareResponse {
 		Enabled:                          s.Enabled,
 		EncryptData:                      s.EncryptData,
 		DefaultPermission:                s.DefaultPermission,
+		OwnerUID:                         s.OwnerUID,
+		OwnerGID:                         s.OwnerGID,
 		BlockedOperations:                s.GetBlockedOps(),
 		RetentionPolicy:                  string(s.GetRetentionPolicy()),
 		RetentionTTL:                     retTTL,

--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -516,8 +516,12 @@ func (h *ShareHandler) Create(w http.ResponseWriter, r *http.Request) {
 		UpdatedAt:                        now,
 	}
 	if rootAttr != nil {
-		share.OwnerUID = &rootAttr.UID
-		share.OwnerGID = &rootAttr.GID
+		// Copy into locals so the persisted pointers don't alias the mutable
+		// rootAttr struct (prepareShare rewrites Mode/Type/timestamps on it).
+		uid := rootAttr.UID
+		gid := rootAttr.GID
+		share.OwnerUID = &uid
+		share.OwnerGID = &gid
 	}
 	if err := metadata.ValidateExcludePatterns(req.TrashExcludePatterns); err != nil {
 		BadRequest(w, err.Error())

--- a/internal/controlplane/api/handlers/shares_owner_test.go
+++ b/internal/controlplane/api/handlers/shares_owner_test.go
@@ -1,0 +1,94 @@
+//go:build integration
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// Creating a share with an owner persists the resolved UID/GID on the share
+// row so startup can re-apply the root ownership. Regression test for #1534:
+// the owner was applied to the root only in-memory, so a server restart reset
+// the share root to UID/GID 0 and the owner got ACCESS_DENIED on writes.
+func TestShareHandler_Create_PersistsOwner(t *testing.T) {
+	cpStore, _, handler := setupShareTestWithRuntime(t)
+	ctx := context.Background()
+
+	uid, gid := uint32(1000), uint32(2000)
+	user := &models.User{Username: "smb-user", UID: &uid, GID: &gid, Enabled: true}
+	if _, err := cpStore.CreateUser(ctx, user); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	metaStore := &models.MetadataStoreConfig{Name: "m-owner", Type: "memory"}
+	if _, err := cpStore.CreateMetadataStore(ctx, metaStore); err != nil {
+		t.Fatalf("CreateMetadataStore: %v", err)
+	}
+	blockStore := &models.BlockStoreConfig{Name: "b-owner", Kind: models.BlockStoreKindLocal, Type: "memory"}
+	if _, err := cpStore.CreateBlockStore(ctx, blockStore); err != nil {
+		t.Fatalf("CreateBlockStore: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"name":              "owned",
+		"metadata_store_id": metaStore.ID,
+		"local_block_store": blockStore.ID,
+		"owner":             "smb-user",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/shares", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	handler.Create(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Create = %d, want 201, body=%s", w.Code, w.Body.String())
+	}
+
+	share, err := cpStore.GetShare(ctx, "/owned")
+	if err != nil {
+		t.Fatalf("GetShare: %v", err)
+	}
+	if share.OwnerUID == nil || *share.OwnerUID != uid {
+		t.Errorf("persisted OwnerUID = %v, want %d", share.OwnerUID, uid)
+	}
+	if share.OwnerGID == nil || *share.OwnerGID != gid {
+		t.Errorf("persisted OwnerGID = %v, want %d", share.OwnerGID, gid)
+	}
+}
+
+// An unknown owner still fails the request up front — and must do so before
+// the share row is written, since owner resolution now happens pre-create.
+func TestShareHandler_Create_UnknownOwnerRejectedBeforePersist(t *testing.T) {
+	cpStore, _, handler := setupShareTestWithRuntime(t)
+	ctx := context.Background()
+
+	metaStore := &models.MetadataStoreConfig{Name: "m-noowner", Type: "memory"}
+	if _, err := cpStore.CreateMetadataStore(ctx, metaStore); err != nil {
+		t.Fatalf("CreateMetadataStore: %v", err)
+	}
+	blockStore := &models.BlockStoreConfig{Name: "b-noowner", Kind: models.BlockStoreKindLocal, Type: "memory"}
+	if _, err := cpStore.CreateBlockStore(ctx, blockStore); err != nil {
+		t.Fatalf("CreateBlockStore: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"name":              "ghost-owned",
+		"metadata_store_id": metaStore.ID,
+		"local_block_store": blockStore.ID,
+		"owner":             "no-such-user",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/shares", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	handler.Create(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("Create = %d, want 400, body=%s", w.Code, w.Body.String())
+	}
+	if _, err := cpStore.GetShare(ctx, "/ghost-owned"); err == nil {
+		t.Errorf("share row was persisted despite owner resolution failure")
+	}
+}

--- a/pkg/apiclient/shares.go
+++ b/pkg/apiclient/shares.go
@@ -59,13 +59,17 @@ type Share struct {
 	AllowMFsymlink bool `json:"allow_mfsymlink"`
 	// Per-share recycle-bin policy (#190). Mirrors the server
 	// ShareResponse so dfsctl share show can render the trash config.
-	TrashEnabled         bool      `json:"trash_enabled"`
-	TrashRetentionDays   int       `json:"trash_retention_days"`
-	TrashRestrictToAdmin bool      `json:"trash_restrict_to_admin"`
-	TrashMaxBytes        int64     `json:"trash_max_bytes"`
-	TrashExcludePatterns []string  `json:"trash_exclude_patterns,omitempty"`
-	CreatedAt            time.Time `json:"created_at"`
-	UpdatedAt            time.Time `json:"updated_at"`
+	TrashEnabled         bool     `json:"trash_enabled"`
+	TrashRetentionDays   int      `json:"trash_retention_days"`
+	TrashRestrictToAdmin bool     `json:"trash_restrict_to_admin"`
+	TrashMaxBytes        int64    `json:"trash_max_bytes"`
+	TrashExcludePatterns []string `json:"trash_exclude_patterns,omitempty"`
+	// OwnerUID/OwnerGID report the persisted root-directory owner (#1534).
+	// Nil means root-owned.
+	OwnerUID  *uint32   `json:"owner_uid,omitempty"`
+	OwnerGID  *uint32   `json:"owner_gid,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // CreateShareRequest is the request to create a share.

--- a/pkg/controlplane/models/share.go
+++ b/pkg/controlplane/models/share.go
@@ -76,17 +76,23 @@ type Share struct {
 	TrashMaxBytes int64 `gorm:"default:0;not null" json:"trash_max_bytes"`
 	// TrashExcludePatterns are globs that bypass the bin (immediate delete),
 	// stored as a JSON array string (same encoding as BlockedOperations).
-	TrashExcludePatterns string    `gorm:"type:text" json:"-"`
-	DefaultPermission    string    `gorm:"default:none;size:50" json:"default_permission"`            // none, read, read-write, admin
-	Config               string    `gorm:"type:text" json:"-"`                                        // JSON blob for additional share config
-	BlockedOperations    string    `gorm:"type:text" json:"-"`                                        // JSON array of blocked operations
-	RetentionPolicy      string    `gorm:"size:10;default:''" json:"retention_policy"`                // pin, ttl, lru (empty = LRU default)
-	RetentionTTL         int64     `gorm:"default:0" json:"retention_ttl"`                            // TTL in seconds (0 = not set)
-	LocalStoreSize       int64     `gorm:"default:0" json:"local_store_size"`                         // Per-share disk size override in bytes (0 = system default)
-	ReadBufferSize       int64     `gorm:"default:0;column:read_buffer_size" json:"read_buffer_size"` // Read buffer override in bytes (0 = system default)
-	QuotaBytes           int64     `gorm:"default:0;column:quota_bytes" json:"quota_bytes"`           // Per-share byte quota (0 = unlimited)
-	CreatedAt            time.Time `gorm:"autoCreateTime" json:"created_at"`
-	UpdatedAt            time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+	TrashExcludePatterns string `gorm:"type:text" json:"-"`
+	DefaultPermission    string `gorm:"default:none;size:50" json:"default_permission"` // none, read, read-write, admin
+	// OwnerUID/OwnerGID persist the UID/GID that owns the share's root
+	// directory (resolved from the owner username at creation). Nil means no
+	// explicit owner (root-owned). Startup re-applies these to the root so
+	// ownership survives restarts (#1534).
+	OwnerUID          *uint32   `gorm:"column:owner_uid" json:"owner_uid,omitempty"`
+	OwnerGID          *uint32   `gorm:"column:owner_gid" json:"owner_gid,omitempty"`
+	Config            string    `gorm:"type:text" json:"-"`                                        // JSON blob for additional share config
+	BlockedOperations string    `gorm:"type:text" json:"-"`                                        // JSON array of blocked operations
+	RetentionPolicy   string    `gorm:"size:10;default:''" json:"retention_policy"`                // pin, ttl, lru (empty = LRU default)
+	RetentionTTL      int64     `gorm:"default:0" json:"retention_ttl"`                            // TTL in seconds (0 = not set)
+	LocalStoreSize    int64     `gorm:"default:0" json:"local_store_size"`                         // Per-share disk size override in bytes (0 = system default)
+	ReadBufferSize    int64     `gorm:"default:0;column:read_buffer_size" json:"read_buffer_size"` // Read buffer override in bytes (0 = system default)
+	QuotaBytes        int64     `gorm:"default:0;column:quota_bytes" json:"quota_bytes"`           // Per-share byte quota (0 = unlimited)
+	CreatedAt         time.Time `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt         time.Time `gorm:"autoUpdateTime" json:"updated_at"`
 
 	// Relationships
 	MetadataStore    MetadataStoreConfig    `gorm:"foreignKey:MetadataStoreID" json:"metadata_store,omitempty"`

--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -266,9 +266,23 @@ func LoadSharesFromStore(ctx context.Context, rt *Runtime, s store.Store) error 
 			}
 		}
 
+		// Re-apply the persisted root owner so a restart does not reset the
+		// share root to UID/GID 0: prepareShare defaults a nil RootAttr to the
+		// zero value and the metadata stores force-sync existing root
+		// ownership to it (#1534).
+		var rootAttr *metadata.FileAttr
+		if share.OwnerUID != nil {
+			gid := *share.OwnerUID
+			if share.OwnerGID != nil {
+				gid = *share.OwnerGID
+			}
+			rootAttr = &metadata.FileAttr{UID: *share.OwnerUID, GID: gid}
+		}
+
 		shareConfig := &ShareConfig{
 			Name:                             share.Name,
 			MetadataStore:                    metaStoreCfg.Name,
+			RootAttr:                         rootAttr,
 			ReadOnly:                         share.ReadOnly,
 			Enabled:                          share.Enabled, // propagate DB Enabled flag so adapter gates read the correct runtime value.
 			EncryptData:                      share.EncryptData,

--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -272,11 +272,12 @@ func LoadSharesFromStore(ctx context.Context, rt *Runtime, s store.Store) error 
 		// ownership to it (#1534).
 		var rootAttr *metadata.FileAttr
 		if share.OwnerUID != nil {
-			gid := *share.OwnerUID
+			uid := *share.OwnerUID
+			gid := uid // default the group to the owner, never root
 			if share.OwnerGID != nil {
 				gid = *share.OwnerGID
 			}
-			rootAttr = &metadata.FileAttr{UID: *share.OwnerUID, GID: gid}
+			rootAttr = &metadata.FileAttr{UID: uid, GID: gid}
 		}
 
 		shareConfig := &ShareConfig{

--- a/pkg/controlplane/runtime/share_owner_restart_test.go
+++ b/pkg/controlplane/runtime/share_owner_restart_test.go
@@ -1,0 +1,115 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/metadata/store/badger"
+)
+
+// A share whose owner was persisted at creation (#1534) gets that ownership
+// re-applied to its root directory when shares are loaded from the DB at
+// startup. Before the fix, LoadSharesFromStore passed no RootAttr, so
+// prepareShare defaulted the root owner to UID/GID 0.
+func TestLoadSharesFromStore_ReappliesPersistedOwner(t *testing.T) {
+	rt, s := setupTestRuntime(t)
+	ctx := context.Background()
+
+	localID := createLocalBlockStoreConfig(t, s, "owner-local")
+	metaStores, err := s.ListMetadataStores(ctx)
+	if err != nil || len(metaStores) == 0 {
+		t.Fatalf("ListMetadataStores: %v", err)
+	}
+
+	uid, gid := uint32(1000), uint32(2000)
+	share := &models.Share{
+		Name:              "/owned-restart",
+		MetadataStoreID:   metaStores[0].ID,
+		LocalBlockStoreID: localID,
+		OwnerUID:          &uid,
+		OwnerGID:          &gid,
+	}
+	if _, err := s.CreateShare(ctx, share); err != nil {
+		t.Fatalf("CreateShare: %v", err)
+	}
+
+	if err := LoadSharesFromStore(ctx, rt, s); err != nil {
+		t.Fatalf("LoadSharesFromStore: %v", err)
+	}
+
+	rootHandle, err := rt.GetRootHandle("/owned-restart")
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+	root, err := rt.GetMetadataService().GetFile(ctx, rootHandle)
+	if err != nil {
+		t.Fatalf("GetFile(root): %v", err)
+	}
+	if root.UID != uid || root.GID != gid {
+		t.Errorf("root owner after load = %d:%d, want %d:%d", root.UID, root.GID, uid, gid)
+	}
+}
+
+// Full restart simulation against a persistent (badger) metadata store, which
+// force-syncs an existing root's UID/GID to the attrs the runtime passes on
+// AddShare. The regression (#1534): a share created with an owner came back
+// root-owned after a server restart, so the owner got EACCES/ACCESS_DENIED on
+// writes. The persisted owner must survive the reload.
+func TestLoadSharesFromStore_OwnerSurvivesRestart_Badger(t *testing.T) {
+	rt, s := setupTestRuntime(t)
+	ctx := context.Background()
+
+	metaStore, err := badger.NewBadgerMetadataStoreWithDefaults(ctx, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	metaCfg := &models.MetadataStoreConfig{Name: "badger-meta", Type: "badger"}
+	if _, err := s.CreateMetadataStore(ctx, metaCfg); err != nil {
+		t.Fatalf("CreateMetadataStore: %v", err)
+	}
+	if err := rt.RegisterMetadataStore("badger-meta", metaStore); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+
+	localID := createLocalBlockStoreConfig(t, s, "owner-local-badger")
+	uid, gid := uint32(1000), uint32(1000)
+	share := &models.Share{
+		Name:              "/owned-badger",
+		MetadataStoreID:   metaCfg.ID,
+		LocalBlockStoreID: localID,
+		OwnerUID:          &uid,
+		OwnerGID:          &gid,
+	}
+	if _, err := s.CreateShare(ctx, share); err != nil {
+		t.Fatalf("CreateShare: %v", err)
+	}
+
+	// First boot: root directory is created with the owner's UID/GID.
+	if err := LoadSharesFromStore(ctx, rt, s); err != nil {
+		t.Fatalf("LoadSharesFromStore (first boot): %v", err)
+	}
+
+	// Simulate a restart: drop the runtime share, then reload from the DB.
+	// The badger root directory persists, so the reload goes through the
+	// existing-root force-sync path.
+	if err := rt.RemoveShare("/owned-badger"); err != nil {
+		t.Fatalf("RemoveShare: %v", err)
+	}
+	if err := LoadSharesFromStore(ctx, rt, s); err != nil {
+		t.Fatalf("LoadSharesFromStore (restart): %v", err)
+	}
+
+	rootHandle, err := rt.GetRootHandle("/owned-badger")
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+	root, err := rt.GetMetadataService().GetFile(ctx, rootHandle)
+	if err != nil {
+		t.Fatalf("GetFile(root): %v", err)
+	}
+	if root.UID != uid || root.GID != gid {
+		t.Errorf("root owner after restart = %d:%d, want %d:%d", root.UID, root.GID, uid, gid)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1534. A share created with `dfsctl share create --owner <user>` lost its root ownership on server restart: the root directory's UID/GID were silently reset to `0:0`, so the owner got `NT_STATUS_ACCESS_DENIED` (SMB) / `EACCES` (NFS) on writes. The only workaround was deleting and recreating the share.

## Root cause

The owner was applied only at share-creation time (as `ShareConfig.RootAttr`) and never persisted. On restart:

1. `LoadSharesFromStore` rebuilt `ShareConfig` from the DB with **no `RootAttr`**.
2. `prepareShare` defaulted a nil `RootAttr` to the zero value → UID/GID 0.
3. The metadata stores *force-sync* an existing root's UID/GID to whatever the runtime passes ("Update attributes if config changed"), resetting ownership to `0:0`.

The force-sync dates back to when root attrs came from the config file and re-applying them on boot was intended. It became a bug when the per-share `--owner` feature (#1420) started setting ownership via the API — the ownership is now user data, but the load path still treated it as config to re-apply, with a zero value.

## Fix

- Persist `OwnerUID`/`OwnerGID` on the share model (new nullable columns; GORM AutoMigrate adds them).
- Resolve the owner **before** writing the share row and store the resolved IDs.
- `LoadSharesFromStore` rebuilds `RootAttr` from the persisted owner, so the startup force-sync re-applies the *correct* ownership instead of zeroing it.
- Surface the owner in the share API response, the Go API client, and `dfsctl share show` (new `Root Owner` row).

Nil owner = root-owned (unchanged default).

## Tests

- `runtime`: `LoadSharesFromStore` re-applies the persisted owner; a full **badger** restart simulation (create → load → drop → reload) confirms the owner survives the existing-root force-sync path. Both fail before the fix (`root owner after restart = 0:0, want 1000:1000`).
- `handlers` (integration): create-with-owner persists `OwnerUID`/`OwnerGID`; an unknown owner is rejected **before** the share row is written.

## End-to-end verification

Reproduced the original bug on v0.23.2, then verified the patched binary on the Scaleway VM: SMB write by the owner succeeds both before **and after** a full server restart; server log shows `Reusing existing root directory` with no UID reset; `sqlite3 … select owner_uid,owner_gid from shares` returns the owner's IDs.

Refs #1419, #1420.
