### PR TITLE
fix(truncate): reclaim block data on SMB truncate-down (data-integrity/info-leak)

### DIFF
--- a/internal/adapter/common/truncate_reclaim.go
+++ b/internal/adapter/common/truncate_reclaim.go
@@ -11,8 +11,8 @@ import (
 // updates the size, but the per-share block store still holds the tail bytes;
 // without this call a later re-extend re-exposes the discarded data as file
 // content instead of a zero-filled hole (silent data-integrity / info-leak
-// bug) and the dropped CAS chunks leak on the remote until GC never reclaims
-// them (#832).
+// bug) and the dropped CAS chunks leak on the remote because their RefCount is
+// never decremented, so GC never reclaims them (#832).
 //
 // Callers pass the PRE-truncate file snapshot (fetched via GetFile BEFORE
 // SetFileAttributes pruned it) so the engine reaps RefCount on every dropped

--- a/internal/adapter/common/truncate_reclaim.go
+++ b/internal/adapter/common/truncate_reclaim.go
@@ -1,0 +1,45 @@
+package common
+
+import (
+	"context"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// ReclaimTruncatedBlocks physically discards block data past newSize after a
+// metadata size-down. metaSvc.SetFileAttributes prunes FileAttr.Blocks and
+// updates the size, but the per-share block store still holds the tail bytes;
+// without this call a later re-extend re-exposes the discarded data as file
+// content instead of a zero-filled hole (silent data-integrity / info-leak
+// bug) and the dropped CAS chunks leak on the remote until GC never reclaims
+// them (#832).
+//
+// Callers pass the PRE-truncate file snapshot (fetched via GetFile BEFORE
+// SetFileAttributes pruned it) so the engine reaps RefCount on every dropped
+// block. This is the single seam all protocol adapters (NFSv3/v4 SETATTR +
+// CREATE-truncate, SMB SetEndOfFile) drive so the block-store truncate can
+// never be forgotten by one protocol while another gets it right.
+//
+// No-ops (returns nil) when the operation is not a genuine content shrink:
+// nil snapshot, no payload, or newSize >= the pre-op size. Best-effort by
+// contract — the metadata mutation is already committed, so callers log a
+// non-nil error rather than failing the operation.
+func ReclaimTruncatedBlocks(
+	ctx context.Context,
+	reg BlockStoreRegistry,
+	handle metadata.FileHandle,
+	preFile *metadata.File,
+	newSize uint64,
+) error {
+	if preFile == nil || preFile.PayloadID == "" || newSize >= preFile.Size {
+		return nil
+	}
+
+	blockStore, err := ResolveForWrite(ctx, reg, handle)
+	if err != nil {
+		return err
+	}
+
+	_, err = blockStore.Truncate(ctx, string(preFile.PayloadID), preFile.Blocks, newSize)
+	return err
+}

--- a/internal/adapter/nfs/v3/handlers/setattr.go
+++ b/internal/adapter/nfs/v3/handlers/setattr.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/marmos91/dittofs/internal/adapter/common"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr"
 	"github.com/marmos91/dittofs/internal/logger"
@@ -317,23 +318,17 @@ func (h *Handler) SetAttr(
 		}, nil
 	}
 
-	// SetFileAttributes prunes FileAttr.Blocks past the new size, but the
-	// per-share block store still holds the dropped CAS chunks. Mirror the
-	// CREATE-with-truncate path (truncateExistingFile): drive
-	// blockStore.Truncate with the file's PRE-truncate FileAttr.Blocks
-	// snapshot (captured in currentFile before SetFileAttributes ran) so the
-	// engine reaps RefCount on every dropped block and the GC sweep can
-	// reclaim the remote chunks (#832). Handler coordinates metaSvc +
-	// blockStore here exactly as the WRITE path does (invariants #1/#5).
-	// Treated as best-effort: a failure is logged but does not fail the
-	// already-committed metadata update.
-	if hasSize && currentFile.PayloadID != "" && *req.NewAttr.Size < currentFile.Size {
-		if _, blockStore, bsErr := getServicesForHandle(h.Registry, ctx.Context, fileHandle); bsErr != nil {
-			logger.WarnCtx(ctx.Context, "SETATTR: cannot resolve block store for truncate reclaim",
-				"handle", fmt.Sprintf("%x", req.Handle), "error", bsErr)
-		} else if _, tErr := blockStore.Truncate(ctx.Context, string(currentFile.PayloadID), currentFile.Blocks, *req.NewAttr.Size); tErr != nil {
+	// SetFileAttributes prunes FileAttr.Blocks + size, but the per-share block
+	// store still holds the dropped CAS chunks and physical tail bytes. Drive
+	// the shared reclaim with the PRE-truncate snapshot (currentFile, captured
+	// before SetFileAttributes ran) so the engine reaps RefCount on every
+	// dropped block (#832) and a later re-extend reads zeros, not stale data.
+	// No-ops unless a genuine shrink; best-effort (metadata already committed).
+	// Same helper as NFSv4 SETATTR / CREATE-truncate and SMB SetEndOfFile.
+	if hasSize {
+		if rErr := common.ReclaimTruncatedBlocks(ctx.Context, h.Registry, fileHandle, currentFile, *req.NewAttr.Size); rErr != nil {
 			logger.WarnCtx(ctx.Context, "SETATTR: block store truncate reclaim failed",
-				"handle", fmt.Sprintf("%x", req.Handle), "size", *req.NewAttr.Size, "error", tErr)
+				"handle", fmt.Sprintf("%x", req.Handle), "size", *req.NewAttr.Size, "error", rErr)
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/setattr.go
+++ b/internal/adapter/nfs/v4/handlers/setattr.go
@@ -12,7 +12,6 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
 	"github.com/marmos91/dittofs/internal/logger"
-	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -240,33 +239,22 @@ func (h *Handler) applySetAttrsWithTruncateReclaim(
 	preFile *metadata.File,
 	attrs *metadata.SetAttrs,
 ) error {
-	// Capture the pre-truncate FileAttr.Blocks snapshot BEFORE SetFileAttributes
-	// prunes them, so the engine reaps RefCount on every dropped block (#832).
-	// Stays nil unless this is a genuine shrink, so reclaim is skipped for
-	// grows / no-ops.
-	var (
-		preTruncateBlocks []block.BlockRef
-		preTruncatePID    metadata.PayloadID
-		newSize           uint64
-	)
-	if attrs.Size != nil && preFile != nil &&
-		*attrs.Size < preFile.Size && preFile.PayloadID != "" {
-		preTruncateBlocks = preFile.Blocks
-		preTruncatePID = preFile.PayloadID
-		newSize = *attrs.Size
-	}
-
 	if _, err := metaSvc.SetFileAttributes(authCtx, handle, attrs); err != nil {
 		return err
 	}
 
-	if preTruncateBlocks != nil {
-		if blockStore, bsErr := common.ResolveForWrite(ctx.Context, h.Registry, handle); bsErr != nil {
-			logger.Warn("NFSv4 truncate reclaim: cannot resolve block store",
-				"handle", string(handle), "error", bsErr)
-		} else if _, tErr := blockStore.Truncate(ctx.Context, string(preTruncatePID), preTruncateBlocks, newSize); tErr != nil {
-			logger.Warn("NFSv4 truncate reclaim: block store truncate failed",
-				"handle", string(handle), "size", newSize, "error", tErr)
+	// Reclaim block data past the new EOF only on a size change. This helper
+	// is also reached from OPEN(UNCHECKED4) with attrs carrying no size (mode
+	// only); guarding on attrs.Size != nil keeps a mode-only OPEN from
+	// truncating an existing file's content to zero. The helper further
+	// no-ops unless this is a genuine shrink (newSize < preFile.Size), reaps
+	// RefCount on every dropped block (#832), and is best-effort — the
+	// metadata write already committed. Same seam as NFSv3 SETATTR /
+	// CREATE-truncate and SMB SetEndOfFile.
+	if attrs.Size != nil {
+		if rErr := common.ReclaimTruncatedBlocks(ctx.Context, h.Registry, handle, preFile, *attrs.Size); rErr != nil {
+			logger.Warn("NFSv4 truncate reclaim failed",
+				"handle", string(handle), "size", *attrs.Size, "error", rErr)
 		}
 	}
 	return nil

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1359,10 +1359,26 @@ func (h *Handler) setFileInfoFromStore(
 			Size: &newSize,
 		}
 
+		// Snapshot the pre-truncate file BEFORE SetFileAttributes prunes
+		// FileAttr.Blocks, so the block-store truncate reclaim below can reap
+		// RefCount on every dropped block and discard the physical tail bytes.
+		// Best-effort: a snapshot failure only forfeits reclaim, not the op.
+		preFile, _ := metaSvc.GetFile(authCtx.Context, openFile.MetadataHandle)
+
 		_, err = metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, setAttrs)
 		if err != nil {
 			logger.Debug("SET_INFO: failed to set EOF", "path", openFile.Path, "error", err)
 			return setInfoStatus(common.MapToSMB(err)), nil
+		}
+
+		// Physically discard block data past the new EOF. SetFileAttributes
+		// only prunes the metadata block list + size; without this the tail
+		// bytes survive and a later re-extend re-exposes them as file content
+		// instead of a zero-filled hole (data-integrity / info-leak bug). NFS
+		// SETATTR/CREATE-truncate drive the same common helper.
+		if rErr := common.ReclaimTruncatedBlocks(authCtx.Context, h.Registry, openFile.MetadataHandle, preFile, newSize); rErr != nil {
+			logger.Warn("SET_INFO: block store truncate reclaim failed",
+				"path", openFile.Path, "size", newSize, "error", rErr)
 		}
 
 		// Restore frozen timestamps after truncation (which updates Mtime/Ctime)
@@ -1448,6 +1464,14 @@ func (h *Handler) setFileInfoFromStore(
 						logger.Debug("SET_INFO: allocation-driven truncate failed",
 							"path", openFile.Path, "error", err)
 						return setInfoStatus(common.MapToSMB(err)), nil
+					}
+					// Discard block data past the new EOF (curFile is the pre-op
+					// snapshot). Same reclaim the FileEndOfFileInformation path
+					// drives — without it a later re-extend re-exposes the tail
+					// bytes as content instead of zeros.
+					if rErr := common.ReclaimTruncatedBlocks(authCtx.Context, h.Registry, openFile.MetadataHandle, curFile, requested); rErr != nil {
+						logger.Warn("SET_INFO: allocation-driven block truncate reclaim failed",
+							"path", openFile.Path, "size", requested, "error", rErr)
 					}
 					h.restoreFrozenTimestamps(authCtx, openFile)
 					flushSmbDelayedWrite(openFile)

--- a/internal/adapter/smb/handlers/set_info_truncate_reclaim_test.go
+++ b/internal/adapter/smb/handlers/set_info_truncate_reclaim_test.go
@@ -224,7 +224,7 @@ func TestSetInfo_TruncateDown_ReExtend_ReadsZeros(t *testing.T) {
 
 	for i, b := range res.Data {
 		if b != 0 {
-			t.Fatalf("re-extended hole leaked stale data: read %x at offset %d, want zeros", res.Data, off+uint64(i))
+			t.Fatalf("re-extended hole leaked stale data: byte %#x at offset %d (full read %x), want zero", b, off+uint64(i), res.Data)
 		}
 	}
 }

--- a/internal/adapter/smb/handlers/set_info_truncate_reclaim_test.go
+++ b/internal/adapter/smb/handlers/set_info_truncate_reclaim_test.go
@@ -1,0 +1,240 @@
+// Regression coverage for SET_INFO FileEndOfFileInformation truncate-down: a
+// size-down must physically discard block data past the new EOF, so that a
+// later re-extend exposes a zero-filled hole rather than the pre-truncation
+// bytes (silent data-integrity / info-leak bug — BUGREPORT-sparse-truncate).
+package handlers
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	cpstore "github.com/marmos91/dittofs/pkg/controlplane/store"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// setupTruncateTest builds a memory-backed runtime with a single share
+// containing a regular file `repro.bin`, returning the handler, root auth
+// context, and an OpenFile granting read+write data access (the access an
+// SMB truncate authorizes from).
+func setupTruncateTest(t *testing.T) (*Handler, *metadata.AuthContext, *OpenFile) {
+	t.Helper()
+	ctx := context.Background()
+
+	cps, err := cpstore.New(&cpstore.Config{
+		Type:   cpstore.DatabaseTypeSQLite,
+		SQLite: cpstore.SQLiteConfig{Path: ":memory:"},
+	})
+	if err != nil {
+		t.Fatalf("cpstore.New: %v", err)
+	}
+	rt := runtime.New(cps)
+
+	if _, err := cps.CreateMetadataStore(ctx, &models.MetadataStoreConfig{Name: "trunc-meta", Type: "memory"}); err != nil {
+		t.Fatalf("CreateMetadataStore: %v", err)
+	}
+	if err := rt.RegisterMetadataStore("trunc-meta", metamemory.NewMemoryMetadataStoreWithDefaults()); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+	localBSID, err := cps.CreateBlockStore(ctx, &models.BlockStoreConfig{
+		Name: "trunc-bs", Kind: models.BlockStoreKindLocal, Type: "memory",
+	})
+	if err != nil {
+		t.Fatalf("CreateBlockStore: %v", err)
+	}
+
+	const shareName = "/trunc"
+	if err := rt.AddShare(ctx, &runtime.ShareConfig{
+		Name:              shareName,
+		MetadataStore:     "trunc-meta",
+		Enabled:           true,
+		LocalBlockStoreID: localBSID,
+		RootAttr:          &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o777},
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+	rootHandle, err := rt.GetRootHandle(shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+
+	uid, gid := uint32(0), uint32(0)
+	authCtx := &metadata.AuthContext{
+		Context:  ctx,
+		Identity: &metadata.Identity{UID: &uid, GID: &gid},
+	}
+
+	metaSvc := rt.GetMetadataService()
+	file, _, err := metaSvc.CreateFile(authCtx, rootHandle, "repro.bin", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular,
+		Mode: 0o644,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+	handle, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+
+	h := NewHandler()
+	h.Registry = rt
+
+	open := &OpenFile{
+		FileID:         [16]byte{0x7C, 0x01},
+		MetadataHandle: handle,
+		ParentHandle:   rootHandle,
+		FileName:       "repro.bin",
+		Path:           "repro.bin",
+		ShareName:      shareName,
+		GrantedAccess: uint32(types.FileWriteData) | uint32(types.FileReadData) |
+			uint32(types.FileWriteAttributes) | uint32(types.FileReadAttributes),
+		DesiredAccess: uint32(types.FileWriteData) | uint32(types.FileReadData),
+	}
+	h.StoreOpenFile(open)
+	return h, authCtx, open
+}
+
+// writeAt mirrors the SMB WRITE handler seam: reserve the size via PrepareWrite
+// then push bytes through common.WriteToBlockStore at an absolute offset.
+func writeAt(t *testing.T, h *Handler, authCtx *metadata.AuthContext, open *OpenFile, data []byte, offset uint64) {
+	t.Helper()
+	metaSvc := h.Registry.GetMetadataService()
+	blockStore, err := common.ResolveForWrite(authCtx.Context, h.Registry, open.MetadataHandle)
+	if err != nil {
+		t.Fatalf("ResolveForWrite: %v", err)
+	}
+	writeOp, err := metaSvc.PrepareWrite(authCtx, open.MetadataHandle, offset+uint64(len(data)))
+	if err != nil {
+		t.Fatalf("PrepareWrite@%d: %v", offset, err)
+	}
+	if err := common.WriteToBlockStore(authCtx.Context, blockStore, writeOp.PayloadID, data, offset); err != nil {
+		t.Fatalf("WriteToBlockStore@%d: %v", offset, err)
+	}
+	// Commit the size to metadata, exactly as the SMB WRITE handler does.
+	if _, err := metaSvc.CommitWrite(authCtx, writeOp); err != nil {
+		t.Fatalf("CommitWrite@%d: %v", offset, err)
+	}
+}
+
+// truncateTo drives the real SET_INFO FileEndOfFileInformation handler — the
+// code path under test — to shrink the file to newSize.
+func truncateTo(t *testing.T, h *Handler, authCtx *metadata.AuthContext, open *OpenFile, newSize uint64) {
+	t.Helper()
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, newSize)
+	resp, err := h.setFileInfoFromStore(nil, authCtx, open, types.FileEndOfFileInformation, buf)
+	if err != nil {
+		t.Fatalf("setFileInfoFromStore(EOF %d): %v", newSize, err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("SET_INFO EOF %d: status = 0x%08X, want SUCCESS", newSize, uint32(resp.Status))
+	}
+}
+
+// allocTo drives SET_INFO FileAllocationInformation (allocation-size set) to
+// shrink the file to newSize — the other SMB info class that can truncate.
+func allocTo(t *testing.T, h *Handler, authCtx *metadata.AuthContext, open *OpenFile, newSize uint64) {
+	t.Helper()
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, newSize)
+	resp, err := h.setFileInfoFromStore(nil, authCtx, open, types.FileAllocationInformation, buf)
+	if err != nil {
+		t.Fatalf("setFileInfoFromStore(alloc %d): %v", newSize, err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("SET_INFO alloc %d: status = 0x%08X, want SUCCESS", newSize, uint32(resp.Status))
+	}
+}
+
+// readAtOffset reads count bytes at offset through the block store, as the SMB
+// READ handler does.
+func readAtOffset(t *testing.T, h *Handler, authCtx *metadata.AuthContext, open *OpenFile, offset uint64, count uint32) []byte {
+	t.Helper()
+	blockStore, err := common.ResolveForRead(authCtx.Context, h.Registry, open.MetadataHandle)
+	if err != nil {
+		t.Fatalf("ResolveForRead: %v", err)
+	}
+	res, err := common.ReadFromBlockStore(authCtx.Context, blockStore, mustPayloadID(t, h, authCtx, open), offset, count)
+	if err != nil {
+		t.Fatalf("ReadFromBlockStore@%d: %v", offset, err)
+	}
+	return res.Data
+}
+
+// TestSetInfo_AllocationTruncateDown_ReExtend_ReadsZeros is the
+// FileAllocationInformation twin of the EOF test: SetAllocationInfo below the
+// current size (Samba does this — setinfo.c sets AllocationInformation=0) must
+// also discard block data past the new EOF, so a re-extend reads zeros.
+func TestSetInfo_AllocationTruncateDown_ReExtend_ReadsZeros(t *testing.T) {
+	h, authCtx, open := setupTruncateTest(t)
+
+	const off = uint64(1_000_000)
+	writeAt(t, h, authCtx, open, []byte("ABCDEFGH"), off)
+	allocTo(t, h, authCtx, open, 1000)                      // allocation-driven truncate DOWN
+	writeAt(t, h, authCtx, open, []byte("ZZZZ"), 2_000_000) // re-extend
+
+	for i, b := range readAtOffset(t, h, authCtx, open, off, 8) {
+		if b != 0 {
+			t.Fatalf("re-extended hole leaked stale data after alloc-truncate: byte %x at offset %d, want zero", b, off+uint64(i))
+		}
+	}
+}
+
+// TestSetInfo_TruncateDown_ReExtend_ReadsZeros reproduces the sparse-truncate
+// data-integrity bug end-to-end through the SMB set_info handler:
+//
+//  1. write bytes far past EOF,
+//  2. truncate DOWN below them (must discard the tail),
+//  3. re-extend past the old offset (the region becomes a hole),
+//  4. read the offset back — POSIX requires zeros.
+//
+// Before the fix, step 2 updated metadata size only and never called
+// blockStore.Truncate, so the tail bytes survived and step 4 returned them.
+func TestSetInfo_TruncateDown_ReExtend_ReadsZeros(t *testing.T) {
+	h, authCtx, open := setupTruncateTest(t)
+
+	const off = uint64(1_000_000)
+	secret := []byte("ABCDEFGH")
+
+	// 1. Write 8 bytes at a high offset.
+	writeAt(t, h, authCtx, open, secret, off)
+
+	// 2. Truncate DOWN below the written data — must discard it.
+	truncateTo(t, h, authCtx, open, 1000)
+
+	// 3. Re-extend past the old offset via a write further out; [1000, 2_000_000)
+	//    (including off) is now a hole.
+	writeAt(t, h, authCtx, open, []byte("ZZZZ"), 2_000_000)
+
+	// 4. Read back the offset — it must read as zeros, not the discarded bytes.
+	blockStore, err := common.ResolveForRead(authCtx.Context, h.Registry, open.MetadataHandle)
+	if err != nil {
+		t.Fatalf("ResolveForRead: %v", err)
+	}
+	res, err := common.ReadFromBlockStore(authCtx.Context, blockStore, mustPayloadID(t, h, authCtx, open), off, uint32(len(secret)))
+	if err != nil {
+		t.Fatalf("ReadFromBlockStore@%d: %v", off, err)
+	}
+
+	for i, b := range res.Data {
+		if b != 0 {
+			t.Fatalf("re-extended hole leaked stale data: read %x at offset %d, want zeros", res.Data, off+uint64(i))
+		}
+	}
+}
+
+// mustPayloadID returns the file's current PayloadID (assigned on first write).
+func mustPayloadID(t *testing.T, h *Handler, authCtx *metadata.AuthContext, open *OpenFile) metadata.PayloadID {
+	t.Helper()
+	file, err := h.Registry.GetMetadataService().GetFile(authCtx.Context, open.MetadataHandle)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	return file.PayloadID
+}


### PR DESCRIPTION
## Summary

Over SMB, truncating a file **down** and then re-extending it re-exposed the discarded bytes instead of a zero-filled hole — a silent **data-integrity** bug and potential **information-disclosure** issue. POSIX requires a re-extended hole to read back as zeros.

Root cause: the SMB `SetEndOfFile` (`FileEndOfFileInformation`) handler updated file metadata size via `SetFileAttributes` but **never called `blockStore.Truncate`**, so the tail block data survived. The allocation-driven path (`FileAllocationInformation` shrink) had the same gap. NFSv3/v4 already reclaimed correctly — this was SMB-only.

## Reproduction

Linux `cifs` mounted `cache=none` (server-side; macOS `mount_smbfs` masks it by zero-filling on extend):

```bash
printf 'ABCDEFGH' | dd of="$f" bs=1 seek=1000000 conv=notrunc  # write 8B @1,000,000
truncate -s 1000 "$f"                                          # truncate DOWN
printf 'ZZZZ'     | dd of="$f" bs=1 seek=2000000 conv=notrunc  # re-extend
dd if="$f" bs=1 skip=1000000 count=8 | od -An -tx1             # read back
```

Confirmed end-to-end on a real Linux cifs client (`cache=none`):

| Server | Read @ offset 1,000,000 |
|---|---|
| Before fix | `41 42 43 44 45 46 47 48` = `ABCDEFGH` — stale data leaked |
| After fix | `00 00 00 00 00 00 00 00` — zeros |

## Fix

- New `common.ReclaimTruncatedBlocks(ctx, reg, handle, preFile, newSize)` — factors the truncate-reclaim NFS already did into one shared seam. No-op unless a genuine content shrink (`preFile != nil && PayloadID != "" && newSize < preFile.Size`); best-effort (metadata is already committed), reaps RefCount on dropped blocks (#832).
- SMB `FileEndOfFileInformation` and allocation-driven `FileAllocationInformation` shrink now snapshot the pre-op file and drive the helper.
- NFSv3 SETATTR + NFSv4 SETATTR refactored onto the shared helper (removes duplicated inline logic). NFSv4's `applySetAttrsWithTruncateReclaim` keeps its `attrs.Size != nil` guard so the OPEN(UNCHECKED4) mode-only path never truncates content.
- NFSv3 CREATE-O_TRUNC intentionally left on its inline `blockStore.Truncate` (it receives the block store directly, not the registry).

## Tests

- `TestSetInfo_TruncateDown_ReExtend_ReadsZeros` — end-to-end through the real SMB `set_info` handler + block engine (write past EOF → truncate down → re-extend → read must be zeros). Verified it **fails** without the fix and passes with it.
- `TestSetInfo_AllocationTruncateDown_ReExtend_ReadsZeros` — same for the allocation-driven path.
- `gofmt`, `go vet`, `golangci-lint` (0 issues), and the common/SMB/NFSv3/NFSv4 handler suites all green.