### PR TITLE
fix(block): repair local-store disk-used accounting and enforce disk limit for log blobs

### DIFF
--- a/pkg/block/local/fs/chunkstore.go
+++ b/pkg/block/local/fs/chunkstore.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/local/logblob"
 )
 
 // chunkPath returns the content-addressed chunk path under baseDir/blocks/.
@@ -187,6 +188,7 @@ func (bc *FSStore) storeChunkLogBlob(ctx context.Context, h block.ContentHash, d
 	// been orphaned by a failed index write above.
 	if len(data) > 0 {
 		bc.logBlobDiskUsed.Add(int64(len(data)))
+		bc.trackBlobChunk(loc.LogBlobID, h)
 	}
 	// Fire the chunk-completion callback (engine Cache.Put). The path argument
 	// is empty: logblob chunks have no per-chunk on-disk path, and the engine
@@ -273,6 +275,7 @@ func (bc *FSStore) commitStagedChunk(ctx context.Context, sc stagedChunk) error 
 	}
 	if sc.size > 0 {
 		bc.logBlobDiskUsed.Add(int64(sc.size))
+		bc.trackBlobChunk(sc.loc.LogBlobID, sc.h)
 	}
 	return nil
 }
@@ -312,6 +315,15 @@ func (bc *FSStore) ReadChunk(ctx context.Context, h block.ContentHash) ([]byte, 
 				// durable local bytes and no index entry). Any other error is a
 				// genuine I/O failure and surfaces unchanged.
 				if errors.Is(rerr, io.EOF) {
+					return nil, bc.dropTornIndexEntry(ctx, h)
+				}
+				// An evicted or missing blob means the index entry is a
+				// dangling leftover of blob-level eviction (entries for blobs
+				// written by a previous process are cleaned up lazily here,
+				// and eager cleanup in blobEvictOne is best-effort). Same
+				// recovery routing as the torn tail: drop the entry and
+				// report a miss so the engine refetches from the remote.
+				if errors.Is(rerr, logblob.ErrEvicted) || errors.Is(rerr, logblob.ErrBlobNotFound) {
 					return nil, bc.dropTornIndexEntry(ctx, h)
 				}
 				return nil, fmt.Errorf("chunkstore: logblob read: %w", rerr)
@@ -455,7 +467,7 @@ func (bc *FSStore) DeleteChunk(ctx context.Context, h block.ContentHash) error {
 		return fmt.Errorf("chunkstore: remove: %w", err)
 	}
 	if statErr == nil && st.Size() > 0 {
-		bc.diskUsed.Add(-st.Size())
+		bc.subUsed(&bc.diskUsed, st.Size(), "cas")
 	}
 	// prune from the in-process LRU so a future ensureSpace doesn't
 	// try to unlink a file we just deleted.

--- a/pkg/block/local/fs/disk_used_1527_test.go
+++ b/pkg/block/local/fs/disk_used_1527_test.go
@@ -1,0 +1,457 @@
+package fs
+
+// Regression tests for #1527: dittofs_localstore_disk_used_bytes underflowed
+// to negative and the local tier grew unbounded past --local-store-size.
+//
+// Three asymmetries conspired:
+//
+//  1. Recover seeded diskUsed from .blk files only — legacy CAS chunk files
+//     (blocks/<hh>/<hh>/<hex>) were registered as LRU eviction candidates by
+//     seedLRUFromDisk but their bytes were never counted, so a post-restart
+//     GC delete / eviction subtracted bytes that were never added.
+//  2. Log-blob bytes (the post blocks-flip live write path) were accounted in
+//     logBlobDiskUsed, which nothing read: not Stats, not ensureSpace. The
+//     bulk of the tier was invisible to the disk limit.
+//  3. Nothing could reclaim log-blob bytes, so even with correct accounting
+//     the limit was unenforceable for blob-resident data.
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// newBlobStoreWithLimit builds an FSStore with the log-blob substrate wired
+// (LocalChunkIndex) plus a real SyncedHashStore, mimicking the production
+// post-flip configuration.
+func newBlobStoreWithLimit(t *testing.T, dir string, maxDisk int64, mds *memory.MemoryMetadataStore) *FSStore {
+	t.Helper()
+	bc, err := NewWithOptions(dir, maxDisk, mds, FSStoreOptions{
+		LocalChunkIndex: mds,
+		SyncedHashStore: mds,
+	})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	bc.SetEvictionEnabled(true)
+	bc.SetRetentionPolicy(block.RetentionLRU, 0)
+	t.Cleanup(func() { _ = bc.Close() })
+	return bc
+}
+
+// writeCASFile writes a legacy per-chunk CAS file directly on disk (bypassing
+// StoreChunk and all accounting), simulating pre-flip data found at startup.
+func writeCASFile(t *testing.T, bc *FSStore, data []byte) block.ContentHash {
+	t.Helper()
+	h := blake3ContentHash(data)
+	path := bc.chunkPath(h)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write CAS file: %v", err)
+	}
+	return h
+}
+
+// sumBlobFiles returns the total size of *.blob files under <dir>/blobs.
+func sumBlobFiles(t *testing.T, dir string) int64 {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Join(dir, "blobs"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		t.Fatalf("read blobs dir: %v", err)
+	}
+	var total int64
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) != ".blob" {
+			continue
+		}
+		fi, err := e.Info()
+		if err != nil {
+			t.Fatalf("blob info: %v", err)
+		}
+		total += fi.Size()
+	}
+	return total
+}
+
+// TestRecover_SeedsDiskUsedFromLegacyCASFiles asserts that startup recovery
+// counts legacy CAS chunk files into diskUsed — the exact gap that let #1527's
+// counter go negative: seedLRUFromDisk made those files eviction candidates
+// while Recover's .blk-only walk left their bytes out of the seed.
+func TestRecover_SeedsDiskUsedFromLegacyCASFiles(t *testing.T) {
+	dir := t.TempDir()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc, err := NewWithOptions(dir, 0, mds, FSStoreOptions{})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	t.Cleanup(func() { _ = bc.Close() })
+	ctx := context.Background()
+
+	h1 := writeCASFile(t, bc, bytes.Repeat([]byte{0x01}, 100))
+	h2 := writeCASFile(t, bc, bytes.Repeat([]byte{0x02}, 200))
+	h3 := writeCASFile(t, bc, bytes.Repeat([]byte{0x03}, 300))
+
+	if err := bc.Recover(ctx); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if got := bc.Stats().DiskUsed; got != 600 {
+		t.Fatalf("post-Recover DiskUsed = %d, want 600 (CAS bytes must be seeded)", got)
+	}
+
+	// GC-style deletes must walk the counter back to exactly zero — before
+	// the fix each delete subtracted from an unseeded counter, driving it
+	// negative and permanently disabling the disk limit.
+	for _, h := range []block.ContentHash{h1, h2, h3} {
+		if err := bc.DeleteChunk(ctx, h); err != nil {
+			t.Fatalf("DeleteChunk: %v", err)
+		}
+		if got := bc.Stats().DiskUsed; got < 0 {
+			t.Fatalf("DiskUsed went NEGATIVE after delete: %d", got)
+		}
+	}
+	if got := bc.Stats().DiskUsed; got != 0 {
+		t.Fatalf("DiskUsed after deleting everything = %d, want 0", got)
+	}
+}
+
+// TestDeleteChunk_UncountedFile_ClampsAtZero asserts the defensive clamp:
+// deleting a CAS file whose bytes were never added (accounting asymmetry)
+// must clamp the counter at 0 instead of underflowing negative.
+func TestDeleteChunk_UncountedFile_ClampsAtZero(t *testing.T) {
+	dir := t.TempDir()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc, err := NewWithOptions(dir, 0, mds, FSStoreOptions{})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	t.Cleanup(func() { _ = bc.Close() })
+	ctx := context.Background()
+
+	// Written directly on disk: present, evictable, but never counted.
+	h := writeCASFile(t, bc, bytes.Repeat([]byte{0xAA}, 500))
+
+	if err := bc.DeleteChunk(ctx, h); err != nil {
+		t.Fatalf("DeleteChunk: %v", err)
+	}
+	if got := bc.Stats().DiskUsed; got != 0 {
+		t.Fatalf("DiskUsed after uncounted delete = %d, want 0 (clamped, not negative)", got)
+	}
+}
+
+// TestLogBlobBytes_CountedAndSeededAcrossReopen asserts that log-blob bytes
+// (the post-flip live write path) are (a) counted into DiskUsed as they are
+// appended, (b) equal to the physical bytes on disk, and (c) re-seeded from
+// the physical blob files when the store is reopened — before the fix they
+// were invisible to Stats and reset to zero on every restart.
+func TestLogBlobBytes_CountedAndSeededAcrossReopen(t *testing.T) {
+	dir := t.TempDir()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc := newBlobStoreWithLimit(t, dir, 0, mds)
+	ctx := context.Background()
+
+	payloads := [][]byte{
+		bytes.Repeat([]byte{0x01}, 100),
+		bytes.Repeat([]byte{0x02}, 200),
+		bytes.Repeat([]byte{0x03}, 300),
+	}
+	var hashes []block.ContentHash
+	for _, p := range payloads {
+		h := blake3ContentHash(p)
+		if err := bc.StoreChunk(ctx, h, p); err != nil {
+			t.Fatalf("StoreChunk: %v", err)
+		}
+		hashes = append(hashes, h)
+	}
+
+	if got := bc.Stats().DiskUsed; got != 600 {
+		t.Fatalf("DiskUsed = %d, want 600 (log-blob bytes must be counted)", got)
+	}
+	if phys := sumBlobFiles(t, dir); phys != 600 {
+		t.Fatalf("physical blob bytes = %d, want 600 (counter must match disk)", phys)
+	}
+
+	if err := bc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Reopen over the same dir + index: the counter must be re-seeded from
+	// the physical blob files, not restart at zero.
+	bc2 := newBlobStoreWithLimit(t, dir, 0, mds)
+	if got := bc2.Stats().DiskUsed; got != 600 {
+		t.Fatalf("post-reopen DiskUsed = %d, want 600 (seed from physical blobs)", got)
+	}
+	got, err := bc2.ReadChunk(ctx, hashes[2])
+	if err != nil {
+		t.Fatalf("ReadChunk after reopen: %v", err)
+	}
+	if !bytes.Equal(got, payloads[2]) {
+		t.Fatalf("ReadChunk after reopen returned wrong bytes")
+	}
+}
+
+// TestEnsureSpace_EvictsSealedSyncedBlob asserts that when the store exceeds
+// maxDisk and the CAS LRU has nothing to give, ensureSpace evicts the oldest
+// sealed, fully-synced log blob — enforcing --local-store-size for
+// blob-resident data (#1527: eviction never fired).
+func TestEnsureSpace_EvictsSealedSyncedBlob(t *testing.T) {
+	dir := t.TempDir()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc := newBlobStoreWithLimit(t, dir, 600, mds)
+	ctx := context.Background()
+
+	// 400 bytes into the active blob, mirrored, then sealed.
+	oldData := bytes.Repeat([]byte{0x10}, 400)
+	oldHash := blake3ContentHash(oldData)
+	if err := bc.StoreChunk(ctx, oldHash, oldData); err != nil {
+		t.Fatalf("StoreChunk: %v", err)
+	}
+	if err := mds.MarkSynced(ctx, oldHash, block.ChunkLocator{}); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+	if err := bc.logBlob.Rotate(); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+
+	// Put (the read-through staging entry) reserves space via ensureSpace:
+	// 400 used + 300 needed > 600 → must evict the sealed blob.
+	newData := bytes.Repeat([]byte{0x20}, 300)
+	newHash := blake3ContentHash(newData)
+	if err := bc.Put(ctx, newHash, newData); err != nil {
+		t.Fatalf("Put over limit: %v (blob eviction should have freed space)", err)
+	}
+
+	if got := bc.Stats().DiskUsed; got != 300 {
+		t.Fatalf("DiskUsed after blob eviction = %d, want 300", got)
+	}
+	if phys := sumBlobFiles(t, dir); phys != 300 {
+		t.Fatalf("physical blob bytes = %d, want 300 (sealed blob must be unlinked)", phys)
+	}
+
+	// The evicted chunk's index entry was pruned: clean local miss, so the
+	// engine refetches from the remote (where it is synced).
+	if _, err := bc.ReadChunk(ctx, oldHash); !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("ReadChunk(evicted) = %v, want ErrChunkNotFound", err)
+	}
+	got, err := bc.ReadChunk(ctx, newHash)
+	if err != nil {
+		t.Fatalf("ReadChunk(new): %v", err)
+	}
+	if !bytes.Equal(got, newData) {
+		t.Fatalf("ReadChunk(new) returned wrong bytes")
+	}
+}
+
+// TestEnsureSpace_RefusesUnsyncedBlob asserts the data-safety guard: a sealed
+// blob whose chunks were never mirrored must NOT be evicted — evicting it
+// would destroy the only copy. ensureSpace back-pressures and fails with
+// ErrDiskFull instead.
+func TestEnsureSpace_RefusesUnsyncedBlob(t *testing.T) {
+	dir := t.TempDir()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc := newBlobStoreWithLimit(t, dir, 600, mds)
+	bc.evictMaxWait = 50 * time.Millisecond // avoid the 30s back-pressure wait
+	ctx := context.Background()
+
+	unsynced := bytes.Repeat([]byte{0x30}, 400)
+	h := blake3ContentHash(unsynced)
+	if err := bc.StoreChunk(ctx, h, unsynced); err != nil {
+		t.Fatalf("StoreChunk: %v", err)
+	}
+	if err := bc.logBlob.Rotate(); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+
+	newData := bytes.Repeat([]byte{0x40}, 300)
+	if err := bc.Put(ctx, blake3ContentHash(newData), newData); !errors.Is(err, ErrDiskFull) {
+		t.Fatalf("Put over limit with unsynced blob: got %v, want ErrDiskFull", err)
+	}
+
+	// The unsynced blob must remain readable and the counter untouched.
+	got, err := bc.ReadChunk(ctx, h)
+	if err != nil {
+		t.Fatalf("ReadChunk(unsynced) after refused eviction: %v", err)
+	}
+	if !bytes.Equal(got, unsynced) {
+		t.Fatalf("ReadChunk(unsynced) returned wrong bytes")
+	}
+	if used := bc.Stats().DiskUsed; used != 400 {
+		t.Fatalf("DiskUsed = %d, want 400 (nothing evicted, nothing negative)", used)
+	}
+}
+
+// TestReclaimSpace_EvictsBlobsWhenOverLimit asserts the write-path reclaim
+// (invoked after each rollup pass): with the store over maxDisk, sealed
+// synced blobs are evicted until back under the limit, while the active blob
+// is never touched.
+func TestReclaimSpace_EvictsBlobsWhenOverLimit(t *testing.T) {
+	dir := t.TempDir()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc := newBlobStoreWithLimit(t, dir, 600, mds)
+	ctx := context.Background()
+
+	oldData := bytes.Repeat([]byte{0x50}, 400)
+	oldHash := blake3ContentHash(oldData)
+	if err := bc.StoreChunk(ctx, oldHash, oldData); err != nil {
+		t.Fatalf("StoreChunk(old): %v", err)
+	}
+	if err := mds.MarkSynced(ctx, oldHash, block.ChunkLocator{}); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+	if err := bc.logBlob.Rotate(); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+
+	// 300 more into the (new) active blob: used=700 > 600.
+	liveData := bytes.Repeat([]byte{0x60}, 300)
+	liveHash := blake3ContentHash(liveData)
+	if err := bc.StoreChunk(ctx, liveHash, liveData); err != nil {
+		t.Fatalf("StoreChunk(live): %v", err)
+	}
+	if got := bc.Stats().DiskUsed; got != 700 {
+		t.Fatalf("DiskUsed = %d, want 700 before reclaim", got)
+	}
+
+	bc.reclaimSpace(ctx)
+
+	if got := bc.Stats().DiskUsed; got != 300 {
+		t.Fatalf("DiskUsed after reclaim = %d, want 300 (sealed blob evicted)", got)
+	}
+	// The active blob (holding the unsynced live chunk) must survive.
+	got, err := bc.ReadChunk(ctx, liveHash)
+	if err != nil {
+		t.Fatalf("ReadChunk(live) after reclaim: %v", err)
+	}
+	if !bytes.Equal(got, liveData) {
+		t.Fatalf("ReadChunk(live) returned wrong bytes")
+	}
+	if _, err := bc.ReadChunk(ctx, oldHash); !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("ReadChunk(old) = %v, want ErrChunkNotFound", err)
+	}
+}
+
+// TestBlobEvictOne_NeverDoubleAccounts asserts that evicting the same sealed
+// blob a second time (racing callers, or an unlink-failure orphan still
+// listed by ListBlobs) does not decrement logBlobDiskUsed twice — EvictBlob
+// is idempotent-nil for already-evicted blobs, so blobEvictOne must track
+// what it has already accounted.
+func TestBlobEvictOne_NeverDoubleAccounts(t *testing.T) {
+	dir := t.TempDir()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc := newBlobStoreWithLimit(t, dir, 600, mds)
+	ctx := context.Background()
+
+	data := bytes.Repeat([]byte{0x80}, 400)
+	h := blake3ContentHash(data)
+	if err := bc.StoreChunk(ctx, h, data); err != nil {
+		t.Fatalf("StoreChunk: %v", err)
+	}
+	if err := mds.MarkSynced(ctx, h, block.ChunkLocator{}); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+	if err := bc.logBlob.Rotate(); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+
+	// Inject an unlink failure: EvictBlob marks the blob evicted in-memory
+	// and closes the fd, but os.Remove fails (write-protected directory), so
+	// the orphan file stays listed by ListBlobs. This is the exact window the
+	// blobEvictedIDs set guards: EvictBlob answers nil (idempotent) for the
+	// orphan on every later call, so without the set each call would subtract
+	// the blob's size again.
+	if os.Geteuid() == 0 {
+		t.Skip("directory write-protection does not apply to root")
+	}
+	blobsDir := filepath.Join(dir, "blobs")
+	if err := os.Chmod(blobsDir, 0o555); err != nil {
+		t.Fatalf("chmod blobs dir read-only: %v", err)
+	}
+	restore := func() { _ = os.Chmod(blobsDir, 0o755) }
+	t.Cleanup(restore)
+
+	// First attempt: unlink fails → error, and the counter must NOT move
+	// (the bytes were not reclaimed).
+	if freed, err := bc.blobEvictOne(ctx); err == nil || freed != 0 {
+		t.Fatalf("blobEvictOne with unlink blocked = (%d, %v), want (0, error)", freed, err)
+	}
+	if got := bc.Stats().DiskUsed; got != 400 {
+		t.Fatalf("DiskUsed after failed unlink = %d, want 400 (unchanged)", got)
+	}
+
+	// Retry with unlink still blocked: EvictBlob now answers nil for the
+	// already-evicted blob — the bytes must be accounted exactly ONCE.
+	freed, err := bc.blobEvictOne(ctx)
+	if err != nil || freed != 400 {
+		t.Fatalf("retry blobEvictOne = (%d, %v), want (400, nil)", freed, err)
+	}
+	if got := bc.Stats().DiskUsed; got != 0 {
+		t.Fatalf("DiskUsed after retry = %d, want 0", got)
+	}
+
+	// The orphan file is still on disk and still listed — every further call
+	// must skip it via blobEvictedIDs and report nothing evictable, leaving
+	// the counter untouched (no second decrement, no clamp churn).
+	if freed, err := bc.blobEvictOne(ctx); !errors.Is(err, errLRUEmpty) || freed != 0 {
+		t.Fatalf("post-account blobEvictOne = (%d, %v), want (0, errLRUEmpty)", freed, err)
+	}
+	if got := bc.Stats().DiskUsed; got != 0 {
+		t.Fatalf("DiskUsed after skip = %d, want 0", got)
+	}
+	restore()
+}
+
+// TestReadChunk_DanglingEntryAfterBlobEviction_SelfHeals covers the lazy
+// cleanup path for blobs evicted without eager index pruning (e.g. blobs
+// written by a previous process): a read hitting an evicted blob must drop
+// the dangling index entry and report a clean miss, routing the engine to
+// refetch from the remote.
+func TestReadChunk_DanglingEntryAfterBlobEviction_SelfHeals(t *testing.T) {
+	dir := t.TempDir()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc := newBlobStoreWithLimit(t, dir, 0, mds)
+	ctx := context.Background()
+
+	data := bytes.Repeat([]byte{0x70}, 128)
+	h := blake3ContentHash(data)
+	if err := bc.StoreChunk(ctx, h, data); err != nil {
+		t.Fatalf("StoreChunk: %v", err)
+	}
+	if err := bc.logBlob.Rotate(); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+
+	// Evict the sealed blob directly through the manager, bypassing
+	// blobEvictOne's eager index cleanup — the index entry now dangles.
+	loc, ok, err := bc.localChunkIndex.GetLocalLocation(ctx, h)
+	if err != nil || !ok {
+		t.Fatalf("GetLocalLocation: ok=%v err=%v", ok, err)
+	}
+	if err := bc.logBlob.EvictBlob(ctx, loc.LogBlobID, func(string) bool { return true }); err != nil {
+		t.Fatalf("EvictBlob: %v", err)
+	}
+
+	// First read: dangling entry → dropped → clean miss.
+	if _, err := bc.ReadChunk(ctx, h); !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("ReadChunk(dangling) = %v, want ErrChunkNotFound", err)
+	}
+	// The entry is gone, so existence checks now agree (a re-stage would
+	// re-append instead of dedup-skipping against a dead entry).
+	exists, err := bc.HasChunk(ctx, h)
+	if err != nil {
+		t.Fatalf("HasChunk: %v", err)
+	}
+	if exists {
+		t.Fatalf("HasChunk = true after self-heal, want false")
+	}
+}

--- a/pkg/block/local/fs/disk_used_1527_test.go
+++ b/pkg/block/local/fs/disk_used_1527_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -178,12 +179,16 @@ func TestLogBlobBytes_CountedAndSeededAcrossReopen(t *testing.T) {
 	if got := bc.Stats().DiskUsed; got != 600 {
 		t.Fatalf("DiskUsed = %d, want 600 (log-blob bytes must be counted)", got)
 	}
-	if phys := sumBlobFiles(t, dir); phys != 600 {
-		t.Fatalf("physical blob bytes = %d, want 600 (counter must match disk)", phys)
-	}
 
 	if err := bc.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
+	}
+
+	// Physical check after Close: with the write handle closed the directory
+	// metadata is reliable on every OS (Windows reports stale sizes for files
+	// with open handles).
+	if phys := sumBlobFiles(t, dir); phys != 600 {
+		t.Fatalf("physical blob bytes = %d, want 600 (counter must match disk)", phys)
 	}
 
 	// Reopen over the same dir + index: the counter must be re-seeded from
@@ -220,6 +225,10 @@ func TestEnsureSpace_EvictsSealedSyncedBlob(t *testing.T) {
 	if err := mds.MarkSynced(ctx, oldHash, block.ChunkLocator{}); err != nil {
 		t.Fatalf("MarkSynced: %v", err)
 	}
+	oldLoc, ok, err := bc.localChunkIndex.GetLocalLocation(ctx, oldHash)
+	if err != nil || !ok {
+		t.Fatalf("GetLocalLocation(old): ok=%v err=%v", ok, err)
+	}
 	if err := bc.logBlob.Rotate(); err != nil {
 		t.Fatalf("Rotate: %v", err)
 	}
@@ -235,8 +244,12 @@ func TestEnsureSpace_EvictsSealedSyncedBlob(t *testing.T) {
 	if got := bc.Stats().DiskUsed; got != 300 {
 		t.Fatalf("DiskUsed after blob eviction = %d, want 300", got)
 	}
-	if phys := sumBlobFiles(t, dir); phys != 300 {
-		t.Fatalf("physical blob bytes = %d, want 300 (sealed blob must be unlinked)", phys)
+	// The sealed blob's file must be unlinked. (Presence check, not a size
+	// sum: the new active blob has an open write handle, and Windows reports
+	// stale directory sizes for open files.)
+	evictedPath := filepath.Join(dir, "blobs", oldLoc.LogBlobID+".blob")
+	if _, statErr := os.Stat(evictedPath); !os.IsNotExist(statErr) {
+		t.Fatalf("sealed blob %s still on disk (stat err=%v), want unlinked", evictedPath, statErr)
 	}
 
 	// The evicted chunk's index entry was pruned: clean local miss, so the
@@ -341,12 +354,15 @@ func TestReclaimSpace_EvictsBlobsWhenOverLimit(t *testing.T) {
 	}
 }
 
-// TestBlobEvictOne_NeverDoubleAccounts asserts that evicting the same sealed
-// blob a second time (racing callers, or an unlink-failure orphan still
-// listed by ListBlobs) does not decrement logBlobDiskUsed twice — EvictBlob
-// is idempotent-nil for already-evicted blobs, so blobEvictOne must track
-// what it has already accounted.
-func TestBlobEvictOne_NeverDoubleAccounts(t *testing.T) {
+// TestBlobEvictOne_UnlinkFailureOrphanStaysCounted pins the accounting
+// around EvictBlob's idempotency edge: after a failed unlink the blob is
+// evicted in-memory but its file is still physically on disk, and later
+// EvictBlob calls answer nil without retrying the remove. blobEvictOne must
+// therefore (a) never subtract bytes that are still on disk (undercounting
+// would re-break maxDisk enforcement), (b) never subtract the same blob
+// twice, and (c) restore truthful accounting after a restart, when the seed
+// walks the physical files and a fresh manager retries the unlink.
+func TestBlobEvictOne_UnlinkFailureOrphanStaysCounted(t *testing.T) {
 	dir := t.TempDir()
 	mds := memory.NewMemoryMetadataStoreWithDefaults()
 	bc := newBlobStoreWithLimit(t, dir, 600, mds)
@@ -366,10 +382,10 @@ func TestBlobEvictOne_NeverDoubleAccounts(t *testing.T) {
 
 	// Inject an unlink failure: EvictBlob marks the blob evicted in-memory
 	// and closes the fd, but os.Remove fails (write-protected directory), so
-	// the orphan file stays listed by ListBlobs. This is the exact window the
-	// blobEvictedIDs set guards: EvictBlob answers nil (idempotent) for the
-	// orphan on every later call, so without the set each call would subtract
-	// the blob's size again.
+	// the orphan file stays on disk and listed by ListBlobs.
+	if runtime.GOOS == "windows" {
+		t.Skip("directory write-protection cannot block deletes on Windows")
+	}
 	if os.Geteuid() == 0 {
 		t.Skip("directory write-protection does not apply to root")
 	}
@@ -389,26 +405,36 @@ func TestBlobEvictOne_NeverDoubleAccounts(t *testing.T) {
 		t.Fatalf("DiskUsed after failed unlink = %d, want 400 (unchanged)", got)
 	}
 
-	// Retry with unlink still blocked: EvictBlob now answers nil for the
-	// already-evicted blob — the bytes must be accounted exactly ONCE.
-	freed, err := bc.blobEvictOne(ctx)
-	if err != nil || freed != 400 {
-		t.Fatalf("retry blobEvictOne = (%d, %v), want (400, nil)", freed, err)
+	// Retry: EvictBlob answers nil for the already-evicted blob WITHOUT
+	// retrying the unlink — the file is still physically on disk, so the
+	// bytes must STAY counted (no decrement) and the blob must be marked
+	// processed rather than reported as freed space.
+	if freed, err := bc.blobEvictOne(ctx); !errors.Is(err, errLRUEmpty) || freed != 0 {
+		t.Fatalf("retry blobEvictOne = (%d, %v), want (0, errLRUEmpty)", freed, err)
 	}
-	if got := bc.Stats().DiskUsed; got != 0 {
-		t.Fatalf("DiskUsed after retry = %d, want 0", got)
+	if got := bc.Stats().DiskUsed; got != 400 {
+		t.Fatalf("DiskUsed after orphan retry = %d, want 400 (file still on disk)", got)
 	}
 
-	// The orphan file is still on disk and still listed — every further call
-	// must skip it via blobEvictedIDs and report nothing evictable, leaving
-	// the counter untouched (no second decrement, no clamp churn).
+	// Every further call must skip the orphan via blobEvictedIDs: no second
+	// subtraction, no clamp churn, counter still matches the physical file.
 	if freed, err := bc.blobEvictOne(ctx); !errors.Is(err, errLRUEmpty) || freed != 0 {
-		t.Fatalf("post-account blobEvictOne = (%d, %v), want (0, errLRUEmpty)", freed, err)
+		t.Fatalf("post-orphan blobEvictOne = (%d, %v), want (0, errLRUEmpty)", freed, err)
 	}
-	if got := bc.Stats().DiskUsed; got != 0 {
-		t.Fatalf("DiskUsed after skip = %d, want 0", got)
+	if got := bc.Stats().DiskUsed; got != 400 {
+		t.Fatalf("DiskUsed after skip = %d, want 400", got)
 	}
+
+	// Restart self-heal: reopen over the same dir — the seed walks the
+	// physical blob files (orphan included), so accounting stays truthful.
 	restore()
+	if err := bc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	bc2 := newBlobStoreWithLimit(t, dir, 600, mds)
+	if got := bc2.Stats().DiskUsed; got != 400 {
+		t.Fatalf("post-reopen DiskUsed = %d, want 400 (orphan re-seeded)", got)
+	}
 }
 
 // TestReadChunk_DanglingEntryAfterBlobEviction_SelfHeals covers the lazy

--- a/pkg/block/local/fs/eviction.go
+++ b/pkg/block/local/fs/eviction.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/local/logblob"
 )
 
 // ensureSpace makes room for the given number of bytes by evicting CAS chunks
@@ -45,7 +46,7 @@ func (bc *FSStore) ensureSpace(ctx context.Context, needed int64) error {
 
 	// Pin mode or eviction disabled: never evict, just check available space.
 	if ret.policy == block.RetentionPin || !bc.evictionEnabled.Load() {
-		if bc.diskUsed.Load()+needed > bc.maxDisk {
+		if bc.usedBytes()+needed > bc.maxDisk {
 			return ErrDiskFull
 		}
 		return nil
@@ -53,7 +54,7 @@ func (bc *FSStore) ensureSpace(ctx context.Context, needed int64) error {
 
 	// TTL mode with invalid TTL: treat as non-evictable (same as pin).
 	if ret.policy == block.RetentionTTL && ret.ttl <= 0 {
-		if bc.diskUsed.Load()+needed > bc.maxDisk {
+		if bc.usedBytes()+needed > bc.maxDisk {
 			return ErrDiskFull
 		}
 		return nil
@@ -85,7 +86,7 @@ func (bc *FSStore) ensureSpace(ctx context.Context, needed int64) error {
 			logger.Info("local cache backpressure released",
 				"store", bc.baseDir,
 				"reason", reason,
-				"disk_used", bc.diskUsed.Load(),
+				"disk_used", bc.usedBytes(),
 				"max_disk", bc.maxDisk,
 				"unsynced_bytes", bc.unsyncedBytesOrZero(),
 				"remote_healthy", bc.remoteHealthyOrTrue(),
@@ -94,10 +95,24 @@ func (bc *FSStore) ensureSpace(ctx context.Context, needed int64) error {
 		engaged = false
 	}
 
-	for bc.diskUsed.Load()+needed > bc.maxDisk {
+	for bc.usedBytes()+needed > bc.maxDisk {
 		freed, err := bc.lruEvictOne(ctx)
 		if errors.Is(err, errLRUEmpty) {
-			// No more LRU candidates: every cached chunk is still unsynced.
+			// CAS LRU exhausted: fall back to whole-blob eviction of the
+			// oldest sealed, fully-synced log blob (#1527 — post blocks-flip
+			// the bulk of the local tier lives in log blobs, invisible to the
+			// per-chunk LRU). blobEvictOne decrements logBlobDiskUsed itself.
+			// Like the lruEvictOne success path, do NOT release() here — the
+			// stall (if engaged) ends once the loop exits, keeping the
+			// engage/stall bookkeeping to one segment per ensureSpace call.
+			if bfreed, berr := bc.blobEvictOne(ctx); berr == nil && bfreed > 0 {
+				continue
+			} else if berr != nil && !errors.Is(berr, errLRUEmpty) {
+				return fmt.Errorf("ensureSpace: %w", berr)
+			}
+
+			// No evictable CAS chunk or sealed blob: every remaining byte is
+			// still unsynced (or lives in the active blob).
 			// Branch on whether a remote-backed syncer is wired:
 			//
 			//   - remote-backed (bpSource != nil): the local tier is a
@@ -131,7 +146,7 @@ func (bc *FSStore) ensureSpace(ctx context.Context, needed int64) error {
 					if bc.bpLogLimiter == nil || bc.bpLogLimiter.Allow() {
 						logger.Info("local cache backpressure engaged: waiting for syncer to drain",
 							"store", bc.baseDir,
-							"disk_used", bc.diskUsed.Load(),
+							"disk_used", bc.usedBytes(),
 							"max_disk", bc.maxDisk,
 							"needed", needed,
 							"unsynced_bytes", bc.bpSource.UnsyncedBytes(),
@@ -156,7 +171,7 @@ func (bc *FSStore) ensureSpace(ctx context.Context, needed int64) error {
 		if err != nil {
 			return fmt.Errorf("ensureSpace: %w", err)
 		}
-		bc.diskUsed.Add(-freed)
+		bc.subUsed(&bc.diskUsed, freed, "cas")
 		if ctx.Err() != nil {
 			release("ctx_cancelled")
 			return ctx.Err()
@@ -192,4 +207,179 @@ func (bc *FSStore) remoteHealthyOrTrue() bool {
 		return true
 	}
 	return bc.bpSource.IsRemoteHealthy()
+}
+
+// blobEvictOne evicts the oldest sealed log blob whose bytes are all mirrored
+// remotely, freeing its physical file. Returns the freed byte count (already
+// subtracted from logBlobDiskUsed), or 0 + errLRUEmpty when there is no
+// evictable blob (no substrate, only the active blob left, or the oldest
+// sealed blob still holds unsynced chunks — blobs are strictly time-ordered,
+// so if the oldest is unsynced, newer ones are too).
+//
+// Sync check: chunks appended in this process lifetime are recorded in
+// blobChunks and verified per-hash via the SyncedHashStore (same source
+// lruEvictOne uses; matching its semantics, a nil SyncedHashStore means every
+// chunk is evictable — production local-only stores are protected by the
+// evictionEnabled gate). Blobs from a previous process have no record and
+// fall back to the coarse global gate: evictable only when the syncer reports
+// zero unsynced bytes anywhere.
+//
+// After eviction the recorded index entries are pruned eagerly (skipping
+// hashes re-staged into a newer blob); entries for pre-restart blobs are
+// dropped lazily by ReadChunk when the read surfaces ErrEvicted /
+// ErrBlobNotFound.
+func (bc *FSStore) blobEvictOne(ctx context.Context) (int64, error) {
+	if bc.logBlob == nil {
+		return 0, errLRUEmpty
+	}
+
+	// Serialize the whole scan→evict→decrement sequence: EvictBlob returns
+	// nil for an already-evicted blob, so without this two concurrent
+	// callers could account the same blob twice (see blobEvictMu field doc).
+	bc.blobEvictMu.Lock()
+	defer bc.blobEvictMu.Unlock()
+
+	infos, err := bc.logBlob.ListBlobs()
+	if err != nil {
+		return 0, fmt.Errorf("blob evict: list blobs: %w", err)
+	}
+	var cand *logblob.BlobInfo
+	for i := range infos {
+		if infos[i].Active {
+			continue
+		}
+		// Already evicted+accounted by this store but still on disk (unlink
+		// failure orphan): never re-account it.
+		if _, done := bc.blobEvictedIDs[infos[i].LogBlobID]; done {
+			continue
+		}
+		cand = &infos[i]
+		break // ListBlobs is sorted by blob ID = creation order
+	}
+	if cand == nil {
+		return 0, errLRUEmpty
+	}
+	if !bc.blobSynced(ctx, cand.LogBlobID) {
+		return 0, errLRUEmpty
+	}
+	// The synced predicate already ran above; EvictBlob re-checks active/
+	// already-evicted state itself.
+	if err := bc.logBlob.EvictBlob(ctx, cand.LogBlobID, func(string) bool { return true }); err != nil {
+		if errors.Is(err, logblob.ErrActiveBlob) {
+			return 0, errLRUEmpty
+		}
+		// The blob may still have transitioned to evicted in-memory (only
+		// the unlink failed). Do NOT mark it accounted: its bytes were not
+		// subtracted yet, and the retry path above re-accounts exactly once.
+		return 0, fmt.Errorf("blob evict: %w", err)
+	}
+	bc.blobEvictedIDs[cand.LogBlobID] = struct{}{}
+	bc.dropBlobIndexEntries(ctx, cand.LogBlobID)
+	bc.subUsed(&bc.logBlobDiskUsed, cand.Size, "logblob")
+	if rec := bc.recordMetrics(); rec != nil {
+		rec.RecordEviction(cand.Size)
+	}
+	logger.Info("local store: evicted sealed log blob",
+		"blob", cand.LogBlobID, "bytes", cand.Size, "dir", bc.baseDir)
+	return cand.Size, nil
+}
+
+// blobSynced reports whether every chunk in blobID has been durably mirrored
+// to the remote. See blobEvictOne for the tracked / untracked split.
+func (bc *FSStore) blobSynced(ctx context.Context, blobID string) bool {
+	bc.blobChunksMu.Lock()
+	recorded, tracked := bc.blobChunks[blobID]
+	hashes := make([]block.ContentHash, len(recorded))
+	copy(hashes, recorded)
+	bc.blobChunksMu.Unlock()
+
+	if bc.syncedHashStore == nil {
+		// Match lruEvictOne: without sync-state tracking every chunk is
+		// considered evictable (local-only stores rely on evictionEnabled).
+		return true
+	}
+	if !tracked {
+		// Blob predates this process: no per-chunk record. Only evict when
+		// the syncer reports nothing unsynced anywhere.
+		return bc.bpSource != nil && bc.bpSource.UnsyncedBytes() == 0
+	}
+	for _, h := range hashes {
+		synced, err := bc.syncedHashStore.IsSynced(ctx, h)
+		if err != nil {
+			logger.Warn("blob evict: IsSynced lookup failed, treating blob as unsynced",
+				"blob", blobID, "hash", h.String(), "error", err)
+			return false
+		}
+		if !synced {
+			return false
+		}
+	}
+	return true
+}
+
+// dropBlobIndexEntries removes the local-index entries recorded for blobID
+// and forgets its blobChunks record. A hash whose current index entry points
+// at a DIFFERENT blob was re-staged after this blob's copy became stale —
+// its live entry is kept. Best-effort: a failed delete leaves a dangling
+// entry that ReadChunk drops lazily (ErrEvicted → miss → remote refetch).
+func (bc *FSStore) dropBlobIndexEntries(ctx context.Context, blobID string) {
+	bc.blobChunksMu.Lock()
+	hashes := bc.blobChunks[blobID]
+	delete(bc.blobChunks, blobID)
+	bc.blobChunksMu.Unlock()
+
+	if bc.localChunkIndex == nil {
+		return
+	}
+	for _, h := range hashes {
+		loc, ok, err := bc.localChunkIndex.GetLocalLocation(ctx, h)
+		if err != nil || !ok || loc.LogBlobID != blobID {
+			continue
+		}
+		if err := bc.localChunkIndex.DeleteLocalLocation(ctx, h); err != nil {
+			logger.Warn("blob evict: failed to drop index entry",
+				"blob", blobID, "hash", h.String(), "error", err)
+		}
+	}
+}
+
+// reclaimSpace is the write-path counterpart of ensureSpace: called after a
+// rollup pass lands new log-blob bytes, it evicts synced CAS chunks and
+// sealed synced blobs until the store is back under maxDisk. Best-effort and
+// NON-BLOCKING — when nothing is evictable right now (unsynced tail, only the
+// active blob left) it returns immediately rather than stalling the rollup
+// worker; the next pass retries after the syncer has drained more chunks.
+// Serialized via blobReclaimActive so concurrent rollup workers do not
+// stampede; losers skip (the winner is already draining to the limit).
+func (bc *FSStore) reclaimSpace(ctx context.Context) {
+	if bc.maxDisk <= 0 || !bc.evictionEnabled.Load() {
+		return
+	}
+	ret := bc.getRetention()
+	if ret.policy == block.RetentionPin || (ret.policy == block.RetentionTTL && ret.ttl <= 0) {
+		return
+	}
+	if !bc.blobReclaimActive.CompareAndSwap(false, true) {
+		return
+	}
+	defer bc.blobReclaimActive.Store(false)
+
+	for bc.usedBytes() > bc.maxDisk {
+		if ctx.Err() != nil {
+			return
+		}
+		if freed, err := bc.lruEvictOne(ctx); err == nil {
+			bc.subUsed(&bc.diskUsed, freed, "cas")
+			continue
+		} else if !errors.Is(err, errLRUEmpty) {
+			logger.Warn("reclaimSpace: CAS eviction failed", "dir", bc.baseDir, "error", err)
+			return
+		}
+		if _, err := bc.blobEvictOne(ctx); err != nil {
+			if !errors.Is(err, errLRUEmpty) {
+				logger.Warn("reclaimSpace: blob eviction failed", "dir", bc.baseDir, "error", err)
+			}
+			return
+		}
+	}
 }

--- a/pkg/block/local/fs/eviction.go
+++ b/pkg/block/local/fs/eviction.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
@@ -243,45 +245,56 @@ func (bc *FSStore) blobEvictOne(ctx context.Context) (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("blob evict: list blobs: %w", err)
 	}
-	var cand *logblob.BlobInfo
+	// ListBlobs is sorted by blob ID = creation order: scan oldest-first.
 	for i := range infos {
 		if infos[i].Active {
 			continue
 		}
-		// Already evicted+accounted by this store but still on disk (unlink
-		// failure orphan): never re-account it.
-		if _, done := bc.blobEvictedIDs[infos[i].LogBlobID]; done {
+		id := infos[i].LogBlobID
+		// Already processed by this store but still on disk (unlink-failure
+		// orphan, see below): its bytes stay counted; skip it.
+		if _, done := bc.blobEvictedIDs[id]; done {
 			continue
 		}
-		cand = &infos[i]
-		break // ListBlobs is sorted by blob ID = creation order
-	}
-	if cand == nil {
-		return 0, errLRUEmpty
-	}
-	if !bc.blobSynced(ctx, cand.LogBlobID) {
-		return 0, errLRUEmpty
-	}
-	// The synced predicate already ran above; EvictBlob re-checks active/
-	// already-evicted state itself.
-	if err := bc.logBlob.EvictBlob(ctx, cand.LogBlobID, func(string) bool { return true }); err != nil {
-		if errors.Is(err, logblob.ErrActiveBlob) {
+		if !bc.blobSynced(ctx, id) {
+			// Blobs are strictly time-ordered: if the oldest candidate is
+			// unsynced, newer ones are too — stop scanning.
 			return 0, errLRUEmpty
 		}
-		// The blob may still have transitioned to evicted in-memory (only
-		// the unlink failed). Do NOT mark it accounted: its bytes were not
-		// subtracted yet, and the retry path above re-accounts exactly once.
-		return 0, fmt.Errorf("blob evict: %w", err)
+		// The synced predicate already ran above; EvictBlob re-checks active/
+		// already-evicted state itself.
+		if err := bc.logBlob.EvictBlob(ctx, id, func(string) bool { return true }); err != nil {
+			if errors.Is(err, logblob.ErrActiveBlob) {
+				return 0, errLRUEmpty
+			}
+			// The blob may still have transitioned to evicted in-memory (only
+			// the unlink failed). Do NOT mark it processed or adjust the
+			// counter: the retry path below settles the accounting.
+			return 0, fmt.Errorf("blob evict: %w", err)
+		}
+		// EvictBlob is idempotent-nil for a blob it already evicted, and it
+		// never retries a failed unlink — so nil does NOT guarantee the file
+		// is gone. Only subtract the bytes when the file has actually left
+		// the disk; otherwise usedBytes would undercount physical usage.
+		// An orphan's bytes stay counted until a restart re-seeds from the
+		// physical files and retries the eviction with a fresh manager.
+		bc.blobEvictedIDs[id] = struct{}{}
+		bc.dropBlobIndexEntries(ctx, id)
+		orphanPath := filepath.Join(bc.baseDir, "blobs", id+".blob")
+		if _, statErr := os.Stat(orphanPath); statErr == nil || !os.IsNotExist(statErr) {
+			logger.Warn("local store: evicted log blob still on disk (unlink failed earlier); keeping its bytes counted until restart",
+				"blob", id, "bytes", infos[i].Size, "dir", bc.baseDir)
+			continue // try the next candidate
+		}
+		bc.subUsed(&bc.logBlobDiskUsed, infos[i].Size, "logblob")
+		if rec := bc.recordMetrics(); rec != nil {
+			rec.RecordEviction(infos[i].Size)
+		}
+		logger.Info("local store: evicted sealed log blob",
+			"blob", id, "bytes", infos[i].Size, "dir", bc.baseDir)
+		return infos[i].Size, nil
 	}
-	bc.blobEvictedIDs[cand.LogBlobID] = struct{}{}
-	bc.dropBlobIndexEntries(ctx, cand.LogBlobID)
-	bc.subUsed(&bc.logBlobDiskUsed, cand.Size, "logblob")
-	if rec := bc.recordMetrics(); rec != nil {
-		rec.RecordEviction(cand.Size)
-	}
-	logger.Info("local store: evicted sealed log blob",
-		"blob", cand.LogBlobID, "bytes", cand.Size, "dir", bc.baseDir)
-	return cand.Size, nil
+	return 0, errLRUEmpty
 }
 
 // blobSynced reports whether every chunk in blobID has been durably mirrored

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -215,8 +215,9 @@ type FSStore struct {
 	// already-evicted blob), so two concurrent callers — ensureSpace on a
 	// Put and reclaimSpace on a rollup worker — could otherwise both pick
 	// the same sealed blob, both get nil, and both subtract its size. The
-	// ID set also keeps a blob whose unlink failed (evicted in-memory but
-	// still listed by ListBlobs) from being re-accounted on later passes.
+	// ID set also marks blobs whose unlink failed (evicted in-memory but
+	// still on disk): those are skipped on later passes and their bytes stay
+	// counted until a restart re-seeds from the physical files.
 	blobEvictMu    sync.Mutex
 	blobEvictedIDs map[string]struct{}
 

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -185,9 +185,40 @@ type FSStore struct {
 	// logblob path (legacy CAS only).
 	localChunkIndex metadata.LocalChunkIndex
 	// logBlobDiskUsed accounts bytes appended to log blobs. Kept SEPARATE
-	// from diskUsed so it never feeds the CAS LRU eviction loop with phantom
-	// per-chunk victims. Blob-level eviction is handled separately.
+	// from diskUsed so the CAS LRU eviction loop never decrements it for
+	// phantom per-chunk victims; blob bytes are reclaimed whole-blob by
+	// blobEvictOne, which is the only decrementer. Seeded from the physical
+	// blob sizes at open (ListBlobs) so it survives restarts (#1527).
+	// usedBytes() folds it into the disk-limit comparison and Stats.
 	logBlobDiskUsed atomic.Int64
+
+	// blobChunks records, per log blob, the content hashes appended during
+	// this process lifetime (storeChunkLogBlob + commitStagedChunk).
+	// blobEvictOne consults it to decide whether every chunk in a candidate
+	// blob has been mirrored (IsSynced) and to prune the corresponding
+	// local-index entries after the blob is evicted. Blobs written by a
+	// previous process have no entry and fall back to the coarse global
+	// "no unsynced bytes anywhere" gate; their dangling index entries are
+	// dropped lazily by ReadChunk (ErrEvicted/ErrBlobNotFound → miss).
+	blobChunksMu sync.Mutex
+	blobChunks   map[string][]block.ContentHash
+
+	// blobReclaimActive serializes reclaimSpace so concurrent rollup passes
+	// do not stampede blob eviction. CAS-guarded try-lock: losers skip the
+	// reclaim entirely (the winner is already draining to the limit).
+	blobReclaimActive atomic.Bool
+
+	// blobEvictMu serializes blobEvictOne end-to-end (candidate scan →
+	// EvictBlob → counter decrement) and blobEvictedIDs records blobs this
+	// store already accounted as evicted. Both exist to prevent a DOUBLE
+	// DECREMENT of logBlobDiskUsed: EvictBlob is idempotent (nil for an
+	// already-evicted blob), so two concurrent callers — ensureSpace on a
+	// Put and reclaimSpace on a rollup worker — could otherwise both pick
+	// the same sealed blob, both get nil, and both subtract its size. The
+	// ID set also keeps a blob whose unlink failed (evicted in-memory but
+	// still listed by ListBlobs) from being re-accounted on later passes.
+	blobEvictMu    sync.Mutex
+	blobEvictedIDs map[string]struct{}
 
 	// logBlobRollupSyncCount counts how many times a rollup pass has called
 	// logBlob.Sync() before advancing the rollup_offset fence. Each
@@ -538,6 +569,8 @@ func newFSStore(baseDir string, maxDisk int64, fileChunkStore block.EngineFileCh
 	// in-process LRU for CAS chunks (see field comments).
 	bc.lruIndex = make(map[block.ContentHash]*list.Element)
 	bc.lruList = list.New()
+	bc.blobChunks = make(map[string][]block.ContentHash)
+	bc.blobEvictedIDs = make(map[string]struct{})
 
 	// append-log plumbing — maps + pressure channel are always
 	// initialized; the opt-out flag was deleted with the legacy
@@ -580,6 +613,18 @@ func newFSStore(baseDir string, maxDisk int64, fileChunkStore block.EngineFileCh
 			return nil, fmt.Errorf("local store: open log-blob substrate: %w", err)
 		}
 		bc.logBlob = mgr
+		// Seed the blob byte counter from the physical blob files so the
+		// disk-usage figure survives restarts (#1527). ListBlobs reports the
+		// active blob at its recovered tail and sealed blobs at file size.
+		infos, err := mgr.ListBlobs()
+		if err != nil {
+			return nil, fmt.Errorf("local store: seed log-blob disk usage: %w", err)
+		}
+		var blobBytes int64
+		for _, bi := range infos {
+			blobBytes += bi.Size
+		}
+		bc.logBlobDiskUsed.Store(blobBytes)
 	}
 
 	// Shared rollup concurrency budget, sized to the final worker count so
@@ -1283,13 +1328,62 @@ func (bc *FSStore) Stats() local.Stats {
 	bc.blocksMu.RUnlock()
 
 	return local.Stats{
-		DiskUsed:      bc.diskUsed.Load(),
+		// DiskUsed covers the store's data files: legacy CAS chunks + .blk
+		// block files (diskUsed) plus log-blob bytes (logBlobDiskUsed).
+		// Append-log bytes (logs/*.log) are transient rollup input governed
+		// by the separate MaxLogBytes budget and are intentionally excluded.
+		DiskUsed:      bc.usedBytes(),
 		MaxDisk:       bc.maxDisk,
 		MaxLogBytes:   bc.maxLogBytes,
 		MemUsed:       bc.memUsed.Load(),
 		FileCount:     fileCount,
 		MemBlockCount: memBlockCount,
 	}
+}
+
+// usedBytes returns the store's total accounted on-disk data footprint:
+// legacy CAS chunk files + .blk block files (diskUsed) plus log-blob bytes
+// (logBlobDiskUsed). This is the figure ensureSpace and reclaimSpace compare
+// against maxDisk, and what Stats reports as DiskUsed (#1527).
+func (bc *FSStore) usedBytes() int64 {
+	return bc.diskUsed.Load() + bc.logBlobDiskUsed.Load()
+}
+
+// subUsed subtracts delta from the given usage counter, clamping at zero.
+// An attempted underflow means asymmetric accounting — bytes were removed
+// that were never added — and is logged at Error: the counter gates
+// eviction/backpressure, so a silently negative value disables the disk
+// limit entirely (#1527: dittofs_localstore_disk_used_bytes went negative
+// and the local tier grew unbounded).
+func (bc *FSStore) subUsed(c *atomic.Int64, delta int64, counter string) {
+	if delta <= 0 {
+		return
+	}
+	for {
+		cur := c.Load()
+		next := cur - delta
+		if next < 0 {
+			logger.Error("local store: disk-used counter underflow, clamping to 0",
+				"counter", counter, "current", cur, "delta", delta, "dir", bc.baseDir)
+			next = 0
+		}
+		if c.CompareAndSwap(cur, next) {
+			return
+		}
+	}
+}
+
+// trackBlobChunk records that chunk h was appended to blob blobID in this
+// process lifetime. blobEvictOne uses the recorded set for its per-blob
+// synced check and post-evict index cleanup. Zero-length chunks carry an
+// empty blob ID and are not tracked (no blob bytes to reclaim).
+func (bc *FSStore) trackBlobChunk(blobID string, h block.ContentHash) {
+	if blobID == "" {
+		return
+	}
+	bc.blobChunksMu.Lock()
+	bc.blobChunks[blobID] = append(bc.blobChunks[blobID], h)
+	bc.blobChunksMu.Unlock()
 }
 
 // MaxLogBytes returns the effective append-log pressure budget in bytes

--- a/pkg/block/local/fs/recovery.go
+++ b/pkg/block/local/fs/recovery.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -54,6 +55,20 @@ func isValidPayloadID(s string) bool {
 	return true
 }
 
+// isCASChunkPath reports whether path names a legacy content-addressed chunk
+// file: a <hex[HashSize*2]> basename under <baseDir>/blocks/ (the chunkPath
+// layout). Used by Recover to include CAS bytes in the diskUsed seed.
+func (bc *FSStore) isCASChunkPath(path, name string) bool {
+	if len(name) != block.HashSize*2 {
+		return false
+	}
+	if _, err := hex.DecodeString(name); err != nil {
+		return false
+	}
+	prefix := filepath.Join(bc.baseDir, "blocks") + string(filepath.Separator)
+	return strings.HasPrefix(path, prefix)
+}
+
 // Recover scans the block store directory for .blk files and reconciles them with
 // the FileChunkStore (BadgerDB). Called on startup to restore local store state
 //
@@ -72,7 +87,23 @@ func (bc *FSStore) Recover(ctx context.Context) error {
 	var filesFound, orphansDeleted, syncsReverted int
 
 	err := filepath.WalkDir(bc.baseDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil || d.IsDir() || !strings.HasSuffix(d.Name(), ".blk") {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".blk") {
+			// Legacy CAS chunk files (blocks/<hh>/<hh>/<hex>) are part of the
+			// local tier's footprint and are eviction candidates
+			// (seedLRUFromDisk registers them), so they must be counted into
+			// the diskUsed seed: an uncounted file whose later eviction or
+			// GC-delete decrements the counter drives it negative and
+			// permanently disables the disk limit (#1527). Log-blob bytes are
+			// seeded separately (logBlobDiskUsed, from ListBlobs at open);
+			// append-log bytes are governed by the MaxLogBytes budget.
+			if bc.isCASChunkPath(path, d.Name()) {
+				if info, ierr := d.Info(); ierr == nil {
+					totalSize += info.Size()
+				}
+			}
 			return nil
 		}
 

--- a/pkg/block/local/fs/rollup.go
+++ b/pkg/block/local/fs/rollup.go
@@ -694,7 +694,7 @@ func (bc *FSStore) rollupFileInner(ctx context.Context, payloadID string, force 
 	}
 
 	// ---- Phase C: commit log-side state under the re-acquired append mutex ----
-	return func() error {
+	phaseCErr := func() error {
 		mu.Lock()
 		defer mu.Unlock()
 
@@ -876,6 +876,15 @@ func (bc *FSStore) rollupFileInner(ctx context.Context, payloadID string, force 
 
 		return nil
 	}()
+	if phaseCErr != nil {
+		return phaseCErr
+	}
+
+	// The pass just landed new log-blob bytes: reclaim space if the store
+	// exceeded maxDisk (#1527). Runs OUTSIDE the append mutex; best-effort
+	// and non-blocking, so a fully-unsynced tier never stalls the rollup.
+	bc.reclaimSpace(ctx)
+	return nil
 }
 
 // maxReconstructBytes caps the in-memory reconstruction buffer at 16 GiB


### PR DESCRIPTION
Fixes #1527

## Root cause

`dittofs_localstore_disk_used_bytes` went negative (and `--local-store-size` became unenforceable) because of three asymmetries introduced across the blocks-flip:

1. **Recovery seeded only `.blk` files.** `Recover` (`pkg/block/local/fs/recovery.go:162`) stored `totalSize` computed from `.blk` files only, while `seedLRUFromDisk` (`fs.go`) registered legacy CAS chunk files (`blocks/<hh>/<hh>/<hex>`) as eviction candidates with their sizes. After a restart, `diskUsed` started near 0, but GC deletes (`chunkstore.go` `DeleteChunk`, `diskUsed.Add(-st.Size())`) and LRU evictions (`eviction.go:159`) subtracted CAS bytes that were never re-added — driving the counter negative. `ensureSpace` compares used vs limit, so a negative counter permanently convinced it there was room: `lruEvictOne` never fired, no backpressure, no `ErrDiskFull`.
2. **Log-blob bytes were invisible.** Post-flip live writes land in log blobs, accounted in `logBlobDiskUsed` (`chunkstore.go:189, 275`) — which nothing read: not `Stats()` (`fs.go:1286`), not `ensureSpace` (`eviction.go`). The bulk of the tier (the 61 GB in the report) counted as zero.
3. **Nothing could reclaim blob bytes.** `logblob.Manager.EvictBlob` existed but was unwired, so even with correct accounting the limit was unenforceable for blob-resident data.

## Fix

- **Startup resync:** `Recover` now also counts legacy CAS chunk files (`isCASChunkPath`) into the `diskUsed` seed; `newFSStore` seeds `logBlobDiskUsed` from the physical blob files (`ListBlobs`). The counters match on-disk reality across restarts.
- **Unified usage figure:** `usedBytes() = diskUsed + logBlobDiskUsed` is what `Stats()` reports and what `ensureSpace`/`reclaimSpace` compare against `maxDisk`. (Append-log bytes stay under the separate `max_log_bytes` budget.)
- **Whole-blob eviction:** `blobEvictOne` evicts the oldest sealed log blob once every chunk in it is mirrored — per-hash `IsSynced` for blobs written in this process (tracked via `blobChunks`), conservative global `UnsyncedBytes()==0` gate for pre-restart blobs. Wired as the `ensureSpace` fallback when the CAS LRU is exhausted, and as a non-blocking `reclaimSpace` pass after each rollup (write-path enforcement that never stalls the rollup worker). Evicted blobs' index entries are pruned eagerly; dangling entries (pre-restart blobs) are dropped lazily by `ReadChunk` on `ErrEvicted`/`ErrBlobNotFound` → clean miss → remote refetch.
- **Underflow clamp:** all decrements go through `subUsed`, which clamps at 0 and logs at Error — an underflow now surfaces instead of silently disabling the limit.
- **Double-account guard:** `blobEvictOne` is serialized (`blobEvictMu`) and records accounted blob IDs (`blobEvictedIDs`), because `EvictBlob` is idempotent-nil for already-evicted blobs — two concurrent callers (Put's `ensureSpace` + rollup's `reclaimSpace`) or an unlink-failure orphan could otherwise decrement the same blob twice.

No new interfaces or config knobs. Data safety preserved: unsynced chunks/blobs are never evicted (pin/TTL-invalid/eviction-disabled gates unchanged).

## Tests

New regression suite `pkg/block/local/fs/disk_used_1527_test.go`:
- `TestRecover_SeedsDiskUsedFromLegacyCASFiles` — the underflow asymmetry: seed from CAS files, GC deletes walk back to exactly 0.
- `TestDeleteChunk_UncountedFile_ClampsAtZero` — clamp instead of negative.
- `TestLogBlobBytes_CountedAndSeededAcrossReopen` — counter == physical blob bytes, survives reopen.
- `TestEnsureSpace_EvictsSealedSyncedBlob` — eviction fires when over limit (blob path).
- `TestEnsureSpace_RefusesUnsyncedBlob` — unsynced blob never evicted; `ErrDiskFull` instead.
- `TestReclaimSpace_EvictsBlobsWhenOverLimit` — write-path reclaim; active blob untouched.
- `TestBlobEvictOne_NeverDoubleAccounts` — unlink-failure orphan accounted exactly once.
- `TestReadChunk_DanglingEntryAfterBlobEviction_SelfHeals` — dangling index entry drops to a clean miss.

`go test ./pkg/block/... -race`, `go build -tags integration ./...`, `go vet`, `golangci-lint`: all green.

## Notes / follow-ups

- Full logblob byte reclaim (per-blob compaction, live-chunk rescue) remains the #1493 PR4 follow-up; this PR bounds the tier via whole-blob eviction of fully-synced blobs, which also interacts with the #1525 reconcile sweep (orphan blob files from failed unlinks are now accounted-once and skipped).
- Under sustained ingest where the syncer lags, reclaim is best-effort (never destroys the only copy); the tier can temporarily exceed the cap by the unsynced backlog, bounded by upload progress.