### PR TITLE
fix(gc): open-handle hold so open-but-unlinked files survive GC (#1448)

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -237,7 +237,11 @@ block's `ContentHash`:
    share that targets the same remote** (cross-share aggregation by
    `bucket+endpoint+prefix`, not share name). The live set is built on
    disk under `<localStore>/gc-state/<runID>/db/` (memory-bounded
-   regardless of metadata size).
+   regardless of metadata size). Hold providers then add hashes the
+   namespace no longer references but that must survive: snapshot
+   manifests, and files unlinked while still held open (NFSv4 open
+   stateids, SMB open handles) — POSIX unlink-while-open data stays
+   readable until the last close, beyond the grace period.
 2. **Sweep.** A single `RemoteStore.Walk` enumerates every CAS object
    cluster-wide (the backend paginates internally). An object is kept
    iff its hash is in the live set OR its `LastModified` is newer than

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -521,7 +521,15 @@ The block-store GC is a fail-closed mark-sweep over the union of every live
    (a Badger temp store). Snapshot time `T` is captured at the start of
    the run. Cross-share aggregation keys on **remote-store identity**
    (`bucket+endpoint+prefix`), not share name, so an object reachable from
-   any share that targets the same remote is considered live.
+   any share that targets the same remote is considered live. Hold
+   providers then inject hashes the namespace no longer references but
+   that must survive the sweep: snapshot manifests
+   (`SnapshotHoldProvider`) and open-but-unlinked files
+   (`openHandleHoldProvider`, #1448) — a file unlinked while still held
+   open via NFSv4 open stateids or SMB open handles keeps its blocks
+   until the last close, restoring POSIX unlink-while-open semantics
+   beyond the grace period. NFSv3 is stateless (kernel clients
+   silly-rename), so no server-side hold applies there.
 2. **Sweep phase.** A single `RemoteStore.Walk` enumerates every CAS
    object cluster-wide; the backend (e.g. S3) paginates internally. For
    each key, the engine keeps the object iff the hash is present in the

--- a/internal/adapter/nfs/v4/state/open_files.go
+++ b/internal/adapter/nfs/v4/state/open_files.go
@@ -1,0 +1,33 @@
+package state
+
+import "context"
+
+// EnumerateOpenFiles streams the metadata file handle of every file that
+// currently has at least one live NFSv4 open state. It implements the
+// runtime's OpenFileEnumerator interface (the state manager is registered as
+// the "nfs" adapter provider), feeding the block-GC open-handle hold (#1448):
+// an open-but-unlinked file's blocks must survive GC until the last CLOSE
+// (or client lease expiry, which purges the open states and thereby releases
+// the hold).
+//
+// Handles are copied out under the read lock and emitted afterwards so fn may
+// perform blocking work (metadata-store reads) without stalling state-machine
+// operations.
+func (sm *StateManager) EnumerateOpenFiles(_ context.Context, fn func(fileHandle []byte) error) error {
+	sm.mu.RLock()
+	handles := make([][]byte, 0, len(sm.openStateByFile))
+	for key, opens := range sm.openStateByFile {
+		if len(opens) == 0 {
+			continue
+		}
+		handles = append(handles, []byte(key))
+	}
+	sm.mu.RUnlock()
+
+	for _, h := range handles {
+		if err := fn(h); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/adapter/nfs/v4/state/open_files_test.go
+++ b/internal/adapter/nfs/v4/state/open_files_test.go
@@ -1,0 +1,69 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+)
+
+func enumerateHandles(t *testing.T, sm *StateManager) map[string]int {
+	t.Helper()
+	got := make(map[string]int)
+	if err := sm.EnumerateOpenFiles(context.Background(), func(fh []byte) error {
+		got[string(fh)]++
+		return nil
+	}); err != nil {
+		t.Fatalf("EnumerateOpenFiles: %v", err)
+	}
+	return got
+}
+
+// TestEnumerateOpenFiles_OpenThenClose verifies the enumeration reflects the
+// live open-state table: a file appears exactly once while open (regardless
+// of how many opens it has) and disappears after the last CLOSE — which is
+// what releases the block-GC open-handle hold (#1448).
+func TestEnumerateOpenFiles_OpenThenClose(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	fhA := []byte("fh-enum-a")
+	fhB := []byte("fh-enum-b")
+
+	sidA := openConfirmed(t, sm, 0, []byte("owner-enum-a"), fhA,
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE)
+	openConfirmed(t, sm, 0, []byte("owner-enum-b1"), fhB,
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE)
+	openConfirmed(t, sm, 0, []byte("owner-enum-b2"), fhB,
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE)
+
+	got := enumerateHandles(t, sm)
+	if len(got) != 2 {
+		t.Fatalf("open files = %d, want 2 (%v)", len(got), got)
+	}
+	if got[string(fhA)] != 1 || got[string(fhB)] != 1 {
+		t.Fatalf("each file must be emitted exactly once, got %v", got)
+	}
+
+	// Last close of A drops it from the enumeration.
+	if _, err := sm.CloseFile(&sidA, 3); err != nil {
+		t.Fatalf("CloseFile: %v", err)
+	}
+	got = enumerateHandles(t, sm)
+	if len(got) != 1 || got[string(fhB)] != 1 {
+		t.Fatalf("after close: got %v, want only %q", got, fhB)
+	}
+}
+
+// TestEnumerateOpenFiles_CallbackErrorPropagates verifies fn errors abort the
+// enumeration (the GC hold consumer fails closed on them).
+func TestEnumerateOpenFiles_CallbackErrorPropagates(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	openConfirmed(t, sm, 0, []byte("owner-err"), []byte("fh-err"),
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE)
+
+	boom := errors.New("boom")
+	if err := sm.EnumerateOpenFiles(context.Background(), func([]byte) error { return boom }); !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want %v", err, boom)
+	}
+}

--- a/internal/adapter/smb/handlers/open_files.go
+++ b/internal/adapter/smb/handlers/open_files.go
@@ -1,0 +1,32 @@
+package handlers
+
+import "context"
+
+// EnumerateOpenFiles streams the metadata file handle of every file with a
+// live SMB open. It implements the runtime's OpenFileEnumerator interface
+// (the handler is registered as the "smb_open_files" adapter provider),
+// feeding the block-GC open-handle hold (#1448): a file that is unlinked
+// (e.g. over NFS) while an SMB client still holds it open must keep its
+// blocks until the last SMB close. Session teardown removes the entries and
+// thereby releases the hold.
+//
+// Handles are collected during the Range and emitted afterwards so fn may
+// perform blocking work (metadata-store reads) without holding the map's
+// internal locks.
+func (h *Handler) EnumerateOpenFiles(_ context.Context, fn func(fileHandle []byte) error) error {
+	var handles [][]byte
+	h.files.Range(func(_, value any) bool {
+		of, ok := value.(*OpenFile)
+		if !ok || of == nil || len(of.MetadataHandle) == 0 {
+			return true
+		}
+		handles = append(handles, []byte(of.MetadataHandle))
+		return true
+	})
+	for _, fh := range handles {
+		if err := fn(fh); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/adapter/smb/handlers/open_files_test.go
+++ b/internal/adapter/smb/handlers/open_files_test.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// TestEnumerateOpenFiles_SMB verifies the handler's open-file table feeds the
+// block-GC open-handle hold (#1448): every live open with a metadata handle
+// is emitted, entries without a handle are skipped, and removing the open
+// (close/session teardown) releases the hold.
+func TestEnumerateOpenFiles_SMB(t *testing.T) {
+	h := &Handler{}
+	h.files.Store("fid-1", &OpenFile{MetadataHandle: metadata.FileHandle("mh-1")})
+	h.files.Store("fid-2", &OpenFile{MetadataHandle: metadata.FileHandle("mh-2")})
+	h.files.Store("fid-3", &OpenFile{}) // no metadata handle — skipped
+
+	collect := func() map[string]int {
+		got := make(map[string]int)
+		if err := h.EnumerateOpenFiles(context.Background(), func(fh []byte) error {
+			got[string(fh)]++
+			return nil
+		}); err != nil {
+			t.Fatalf("EnumerateOpenFiles: %v", err)
+		}
+		return got
+	}
+
+	got := collect()
+	if len(got) != 2 || got["mh-1"] != 1 || got["mh-2"] != 1 {
+		t.Fatalf("open files = %v, want mh-1 and mh-2 exactly once", got)
+	}
+
+	// Close: entry removed from the table → hold released.
+	h.files.Delete("fid-1")
+	got = collect()
+	if len(got) != 1 || got["mh-2"] != 1 {
+		t.Fatalf("after close: got %v, want only mh-2", got)
+	}
+
+	// Callback errors abort the enumeration (GC fails closed).
+	boom := errors.New("boom")
+	if err := h.EnumerateOpenFiles(context.Background(), func([]byte) error { return boom }); !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want %v", err, boom)
+	}
+}

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -140,6 +140,13 @@ type Adapter interface {
 // the cross-protocol oplock breaker without import cycles between protocol packages.
 const OplockBreakerProviderKey = "oplock_breaker"
 
+// SMBOpenFilesProviderKey is the Runtime adapter provider key under which the
+// SMB handler registers itself as an open-file enumerator for the block-GC
+// open-handle hold (#1448). The NFSv4 state manager needs no dedicated key:
+// it is already registered under "nfs" and the runtime discovers open-file
+// enumerators structurally across all registered adapter providers.
+const SMBOpenFilesProviderKey = "smb_open_files"
+
 // OplockBreaker provides cross-protocol oplock break coordination.
 // Adapters holding opportunistic locks register an implementation via
 // Runtime.SetAdapterProvider("oplock_breaker", breaker).

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -223,6 +223,12 @@ func (s *Adapter) SetRuntime(rtAny any) {
 	rt := rtAny.(*runtime.Runtime)
 	s.handler.Registry = rt
 
+	// Register the handler's open-file table as an open-file enumerator for
+	// the block-GC open-handle hold (#1448): files unlinked (e.g. over NFS)
+	// while an SMB client holds them open must keep their blocks until the
+	// last SMB close.
+	rt.SetAdapterProvider(adapter.SMBOpenFilesProviderKey, s.handler)
+
 	// Wire LeaseManager: create a thin wrapper over the shared LockManagers.
 	// The LockManagers are per-share, obtained from MetadataService. The
 	// LeaseManager uses a resolver pattern to find the correct LockManager

--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -118,8 +118,9 @@ func (r *Runtime) runBlockGCSweep(ctx context.Context, sharePrefix string, dryRu
 			}
 			applyGCDefaults(opts, gcDefaults)
 			applyGCProgress(opts, progress)
-			// Inject held hashes from ready snapshots into the GC mark phase.
-			opts.HoldProvider = r.snapshotHoldForRemote(entry.Shares)
+			// Inject held hashes from ready snapshots and open-but-unlinked
+			// files (#1448) into the GC mark phase.
+			opts.HoldProvider = r.gcHoldForRemote(entry.Shares)
 			// The per-remote synced-hash index: the index-sweep candidate source AND
 			// the marker-clear for swept hashes (so they re-upload if they reappear
 			// in the live set) (#1433). Remote sweep only. A steady-state run sweeps
@@ -217,7 +218,7 @@ func (r *Runtime) runLocalGC(ctx context.Context, shareFilter string, dryRun boo
 			opts.GracePeriodSet = true
 		}
 		applyGCProgress(opts, progress)
-		opts.HoldProvider = r.snapshotHoldForShare(entry.ShareName)
+		opts.HoldProvider = r.gcHoldForShare(entry.ShareName)
 		logger.Info("local GC: starting",
 			"tier", "local",
 			"share", entry.ShareName,
@@ -335,8 +336,9 @@ func (r *Runtime) runBlockGCForShare(ctx context.Context, name string, dryRun bo
 				opts.GracePeriodSet = true
 			}
 			applyGCProgress(opts, progress)
-			// Inject held hashes from ready snapshots into the GC mark phase.
-			opts.HoldProvider = r.snapshotHoldForRemote(entry.Shares)
+			// Inject held hashes from ready snapshots and open-but-unlinked
+			// files (#1448) into the GC mark phase.
+			opts.HoldProvider = r.gcHoldForRemote(entry.Shares)
 			// Per-remote synced-hash index: LIST-free candidate source + marker-clear
 			// for swept hashes (#1433). The live set unions every share on this
 			// remote (perRemoteReconciler below), so a single-share invocation never

--- a/pkg/controlplane/runtime/blockgc_reconcile.go
+++ b/pkg/controlplane/runtime/blockgc_reconcile.go
@@ -130,10 +130,24 @@ func (r *Runtime) reapStrandedRows(ctx context.Context, shareName string, mds me
 		return 0, nil
 	}
 
-	reaped, skippedGrace := 0, 0
+	// Open-handle hold (#1448): a payload referenced by an open-but-unlinked
+	// file is not stranded — the open handle still reads through its rows, and
+	// reaping them would both destroy the manifest and drop the hashes from
+	// the mark live set. Fail closed: if the held set cannot be resolved, the
+	// reconcile must not reap.
+	heldOpen, err := r.openPayloadIDsForShare(ctx, shareName)
+	if err != nil {
+		return 0, fmt.Errorf("resolve open-handle held payloads: %w", err)
+	}
+
+	reaped, skippedGrace, skippedOpen := 0, 0, 0
 	for _, pid := range stranded {
 		if err := ctx.Err(); err != nil {
 			return reaped, err
+		}
+		if _, ok := heldOpen[pid]; ok {
+			skippedOpen++
+			continue
 		}
 		rows, err := mds.ListFileChunks(ctx, pid)
 		if err != nil {
@@ -164,6 +178,7 @@ func (r *Runtime) reapStrandedRows(ctx context.Context, shareName string, mds me
 		"strandedPayloads", len(stranded),
 		"rowsReaped", reaped,
 		"skippedGrace", skippedGrace,
+		"skippedOpenHandle", skippedOpen,
 		"dryRun", dryRun,
 	)
 	return reaped, nil

--- a/pkg/controlplane/runtime/openhandle_hold.go
+++ b/pkg/controlplane/runtime/openhandle_hold.go
@@ -51,8 +51,16 @@ func (r *Runtime) openFileEnumerators() []OpenFileEnumerator {
 // so the caller fails closed (a GC pass that cannot determine the held set
 // must not sweep).
 func (r *Runtime) forEachOpenUnlinkedFile(ctx context.Context, shares map[string]struct{}, fn func(shareName string, file *metadata.File) error) error {
+	// A file open via multiple protocols at once (e.g. NFSv4 + SMB) is
+	// reported by every enumerator; visit each handle once so per-file work
+	// (GetFile) and observability counters don't scale with protocol fan-out.
+	seen := make(map[string]struct{})
 	for _, enum := range r.openFileEnumerators() {
 		err := enum.EnumerateOpenFiles(ctx, func(fileHandle []byte) error {
+			if _, dup := seen[string(fileHandle)]; dup {
+				return nil
+			}
+			seen[string(fileHandle)] = struct{}{}
 			handle := metadata.FileHandle(fileHandle)
 			shareName, err := r.GetShareNameForHandle(ctx, handle)
 			if err != nil {
@@ -115,7 +123,7 @@ func (p *openHandleHoldProvider) HeldHashes(ctx context.Context, remoteEndpointI
 	// files sharing chunks.
 	union := block.NewHashSet(0)
 	held := 0
-	err := p.rt.forEachOpenUnlinkedFile(ctx, p.shares, func(shareName string, file *metadata.File) error {
+	err := p.rt.forEachOpenUnlinkedFile(ctx, p.shares, func(_ string, file *metadata.File) error {
 		for i := range file.Blocks {
 			union.Add(file.Blocks[i].Hash)
 		}

--- a/pkg/controlplane/runtime/openhandle_hold.go
+++ b/pkg/controlplane/runtime/openhandle_hold.go
@@ -1,0 +1,196 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// OpenFileEnumerator is implemented by protocol adapters that track live open
+// handles server-side (the NFSv4 state manager and the SMB open-file table).
+// Any adapter provider registered via SetAdapterProvider that implements this
+// interface contributes its open files to the block-GC open-handle hold
+// (#1448): an open-but-unlinked file's blocks must survive GC until last
+// close, not merely for the grace period.
+//
+// EnumerateOpenFiles streams the opaque metadata file handle of every file
+// that currently has at least one open handle. Handles may be stale (share
+// removed, file purged) — the consumer skips those. fn must not be called
+// while adapter-internal locks are held if fn can block (the hold consumer
+// performs metadata-store reads inside fn).
+type OpenFileEnumerator interface {
+	EnumerateOpenFiles(ctx context.Context, fn func(fileHandle []byte) error) error
+}
+
+// openFileEnumerators snapshots the currently registered adapter providers
+// that implement OpenFileEnumerator. NFSv4 registers its state manager under
+// the "nfs" provider key; SMB registers its handler under "smb_open_files".
+func (r *Runtime) openFileEnumerators() []OpenFileEnumerator {
+	r.adapterProvidersMu.RLock()
+	defer r.adapterProvidersMu.RUnlock()
+	var out []OpenFileEnumerator
+	for _, p := range r.adapterProviders {
+		if e, ok := p.(OpenFileEnumerator); ok {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// forEachOpenUnlinkedFile streams every currently-open file that belongs to
+// one of the scoped shares and has been unlinked (nlink == 0). Files that are
+// still linked are skipped: their hashes are already in the GC mark live set
+// via the store's live-set query, so holding them would be redundant work.
+//
+// Stale handles (share gone, file object purged) are skipped: there is no
+// data left to protect behind them. Any other metadata-store error propagates
+// so the caller fails closed (a GC pass that cannot determine the held set
+// must not sweep).
+func (r *Runtime) forEachOpenUnlinkedFile(ctx context.Context, shares map[string]struct{}, fn func(shareName string, file *metadata.File) error) error {
+	for _, enum := range r.openFileEnumerators() {
+		err := enum.EnumerateOpenFiles(ctx, func(fileHandle []byte) error {
+			handle := metadata.FileHandle(fileHandle)
+			shareName, err := r.GetShareNameForHandle(ctx, handle)
+			if err != nil {
+				// Stale or foreign handle (share removed mid-scan) — nothing
+				// to hold for it.
+				logger.Debug("open-handle hold: unresolvable handle skipped", "err", err)
+				return nil
+			}
+			if _, ok := shares[shareName]; !ok {
+				return nil
+			}
+			mds, err := r.GetMetadataStoreForShare(shareName)
+			if err != nil {
+				return fmt.Errorf("open-handle hold: metadata store for share %q: %w", shareName, err)
+			}
+			file, err := mds.GetFile(ctx, handle)
+			if err != nil {
+				if metadata.IsNotFoundError(err) {
+					// File object already purged — the open handle can no
+					// longer reach any data, so there is nothing to hold.
+					return nil
+				}
+				return fmt.Errorf("open-handle hold: get file for share %q: %w", shareName, err)
+			}
+			if file.Nlink != 0 {
+				// Still linked — covered by the store live-set query.
+				return nil
+			}
+			return fn(shareName, file)
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// openHandleHoldProvider implements engine.HoldProvider by injecting the
+// block hashes of every open-but-unlinked file into the GC mark live set
+// (#1448). The store live-set query (EnumerateFileChunks) deliberately
+// excludes nlink=0 inodes (#1433) so deleted files are reclaimed; this hold
+// re-adds exactly the unlinked files that still have a live open handle
+// (NFSv4 open stateids, SMB open table), restoring POSIX
+// unlink-while-open semantics beyond the grace period. Once the last handle
+// closes (or the client's lease/session expires), the hold disappears and the
+// next GC pass reclaims the blocks as usual.
+type openHandleHoldProvider struct {
+	rt     *Runtime
+	shares map[string]struct{}
+}
+
+// HeldHashes implements engine.HoldProvider. The engine-passed shares
+// argument is informational only; iteration uses the closure-captured share
+// set fixed at construction time (same contract as SnapshotHoldProvider).
+func (p *openHandleHoldProvider) HeldHashes(ctx context.Context, remoteEndpointID string, _ []string, fn func(block.ContentHash) error) error {
+	if p == nil || p.rt == nil {
+		return nil
+	}
+	// Dedup across files before emitting: many open handles can reference
+	// files sharing chunks.
+	union := block.NewHashSet(0)
+	held := 0
+	err := p.rt.forEachOpenUnlinkedFile(ctx, p.shares, func(shareName string, file *metadata.File) error {
+		for i := range file.Blocks {
+			union.Add(file.Blocks[i].Hash)
+		}
+		held++
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if held == 0 {
+		return nil
+	}
+	if err := union.ForEach(fn); err != nil {
+		return fmt.Errorf("open-handle hold: emit union: %w", err)
+	}
+	logger.Debug("open-handle hold: emitted held hashes",
+		"open_unlinked_files", held,
+		"distinct_hashes", union.Len(),
+		"remote_endpoint_id", remoteEndpointID,
+	)
+	return nil
+}
+
+// openPayloadIDsForShare returns the PayloadIDs of every open-but-unlinked
+// file in the share. The stranded-row reconcile must not reap these payloads'
+// rows: reaping would both drop their hashes from the mark live set and
+// destroy the manifest the open handle still reads through.
+func (r *Runtime) openPayloadIDsForShare(ctx context.Context, shareName string) (map[string]struct{}, error) {
+	held := make(map[string]struct{})
+	scope := map[string]struct{}{shareName: {}}
+	err := r.forEachOpenUnlinkedFile(ctx, scope, func(_ string, file *metadata.File) error {
+		if file.PayloadID != "" {
+			held[string(file.PayloadID)] = struct{}{}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return held, nil
+}
+
+// multiHoldProvider chains hold providers: every provider contributes its
+// held hashes to the mark live set; any error fails the whole enumeration
+// (fail-closed).
+type multiHoldProvider []engine.HoldProvider
+
+func (m multiHoldProvider) HeldHashes(ctx context.Context, remoteEndpointID string, shares []string, fn func(block.ContentHash) error) error {
+	for _, p := range m {
+		if p == nil {
+			continue
+		}
+		if err := p.HeldHashes(ctx, remoteEndpointID, shares, fn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// gcHoldForShare returns the full hold set for a single share's local-tier GC
+// pass: snapshot manifests plus open-but-unlinked files.
+func (r *Runtime) gcHoldForShare(shareName string) engine.HoldProvider {
+	return r.gcHoldForRemote([]string{shareName})
+}
+
+// gcHoldForRemote returns the full hold set for a remote-tier GC pass scoped
+// to the shares that reference the remote: snapshot manifests plus
+// open-but-unlinked files.
+func (r *Runtime) gcHoldForRemote(shareNames []string) engine.HoldProvider {
+	scope := make(map[string]struct{}, len(shareNames))
+	for _, name := range shareNames {
+		scope[name] = struct{}{}
+	}
+	return multiHoldProvider{
+		r.snapshotHoldForRemote(shareNames),
+		&openHandleHoldProvider{rt: r, shares: scope},
+	}
+}

--- a/pkg/controlplane/runtime/openhandle_hold.go
+++ b/pkg/controlplane/runtime/openhandle_hold.go
@@ -2,11 +2,13 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -50,13 +52,16 @@ func (r *Runtime) openFileEnumerators() []OpenFileEnumerator {
 // data left to protect behind them. Any other metadata-store error propagates
 // so the caller fails closed (a GC pass that cannot determine the held set
 // must not sweep).
-func (r *Runtime) forEachOpenUnlinkedFile(ctx context.Context, shares map[string]struct{}, fn func(shareName string, file *metadata.File) error) error {
+func (r *Runtime) forEachOpenUnlinkedFile(ctx context.Context, scope map[string]struct{}, fn func(shareName string, file *metadata.File) error) error {
 	// A file open via multiple protocols at once (e.g. NFSv4 + SMB) is
 	// reported by every enumerator; visit each handle once so per-file work
 	// (GetFile) and observability counters don't scale with protocol fan-out.
 	seen := make(map[string]struct{})
 	for _, enum := range r.openFileEnumerators() {
 		err := enum.EnumerateOpenFiles(ctx, func(fileHandle []byte) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			if _, dup := seen[string(fileHandle)]; dup {
 				return nil
 			}
@@ -69,11 +74,17 @@ func (r *Runtime) forEachOpenUnlinkedFile(ctx context.Context, shares map[string
 				logger.Debug("open-handle hold: unresolvable handle skipped", "err", err)
 				return nil
 			}
-			if _, ok := shares[shareName]; !ok {
+			if _, ok := scope[shareName]; !ok {
 				return nil
 			}
 			mds, err := r.GetMetadataStoreForShare(shareName)
 			if err != nil {
+				if errors.Is(err, shares.ErrShareNotFound) {
+					// Share removed between handle resolution and store
+					// lookup — nothing left to hold behind the handle.
+					logger.Debug("open-handle hold: share removed mid-scan", "share", shareName)
+					return nil
+				}
 				return fmt.Errorf("open-handle hold: metadata store for share %q: %w", shareName, err)
 			}
 			file, err := mds.GetFile(ctx, handle)

--- a/pkg/controlplane/runtime/openhandle_hold_test.go
+++ b/pkg/controlplane/runtime/openhandle_hold_test.go
@@ -191,6 +191,26 @@ func TestOpenHandleHold_GCHoldForRemoteCombines(t *testing.T) {
 	assert.Contains(t, got, h)
 }
 
+// TestOpenHandleHold_CrossProtocolDedup verifies a file open via multiple
+// protocol enumerators at once (e.g. NFSv4 + SMB) is visited exactly once.
+func TestOpenHandleHold_CrossProtocolDedup(t *testing.T) {
+	rt, store := newOpenHoldRuntime(t, "share")
+	fh := openHoldPutFile(t, store, "share", "/both.bin", 0, "p4", []block.BlockRef{
+		{Hash: hashAll(0x66), Offset: 0, Size: 64},
+	})
+	rt.SetAdapterProvider("test_nfs_open", &fakeOpenFileSource{handles: [][]byte{fh}})
+	rt.SetAdapterProvider("test_smb_open", &fakeOpenFileSource{handles: [][]byte{fh}})
+
+	visits := 0
+	require.NoError(t, rt.forEachOpenUnlinkedFile(context.Background(),
+		map[string]struct{}{"share": {}},
+		func(string, *metadata.File) error {
+			visits++
+			return nil
+		}))
+	assert.Equal(t, 1, visits, "same handle from two enumerators must be visited once")
+}
+
 // TestReapStrandedRows_SkipsOpenUnlinkedPayloads verifies the stranded-row
 // reconcile leaves the payload rows of an open-but-unlinked file intact (the
 // open handle still reads through them) and reaps them after last close.

--- a/pkg/controlplane/runtime/openhandle_hold_test.go
+++ b/pkg/controlplane/runtime/openhandle_hold_test.go
@@ -1,0 +1,224 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// fakeOpenFileSource is a test OpenFileEnumerator registered through the
+// adapter-provider registry, exactly like the NFSv4 state manager and the
+// SMB handler are in production.
+type fakeOpenFileSource struct {
+	handles [][]byte
+	err     error
+}
+
+func (f *fakeOpenFileSource) EnumerateOpenFiles(_ context.Context, fn func(fileHandle []byte) error) error {
+	if f.err != nil {
+		return f.err
+	}
+	for _, h := range f.handles {
+		if err := fn(h); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// newOpenHoldRuntime builds a runtime with a single named share backed by an
+// in-memory metadata store, sufficient for handle→share routing and
+// GetMetadataStoreForShare resolution.
+func newOpenHoldRuntime(t *testing.T, shareName string) (*Runtime, metadata.Store) {
+	t.Helper()
+	rt := New(nil)
+	store := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	rt.sharesSvc.InjectShareForTesting(&shares.Share{
+		Name:          shareName,
+		MetadataStore: "memory",
+	})
+	require.NoError(t, rt.storesSvc.RegisterMetadataStore("memory", store))
+	require.NoError(t, rt.GetMetadataService().RegisterStoreForShare(shareName, store))
+	return rt, store
+}
+
+// openHoldPutFile persists a file object with the supplied nlink, payload and
+// blocks, returning its handle.
+func openHoldPutFile(t *testing.T, store metadata.Store, shareName, path string, nlink uint32, payloadID string, blocks []block.BlockRef) metadata.FileHandle {
+	t.Helper()
+	ctx := context.Background()
+	h, err := store.GenerateHandle(ctx, shareName, path)
+	require.NoError(t, err)
+	_, id, err := metadata.DecodeFileHandle(h)
+	require.NoError(t, err)
+	require.NoError(t, store.PutFile(ctx, &metadata.File{
+		ID:        id,
+		ShareName: shareName,
+		Path:      path,
+		FileAttr: metadata.FileAttr{
+			Type:      metadata.FileTypeRegular,
+			Mode:      0o644,
+			Nlink:     nlink,
+			PayloadID: metadata.PayloadID(payloadID),
+			Blocks:    blocks,
+		},
+	}))
+	// The memory store derives Nlink from its internal link-count tracking
+	// (defaulting to 1), so pin the requested value explicitly.
+	require.NoError(t, store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.SetLinkCount(ctx, h, nlink)
+	}))
+	return h
+}
+
+// heldHashes runs the open-handle hold provider scoped to shareName and
+// collects the emitted hashes.
+func heldHashes(t *testing.T, rt *Runtime, shareName string) map[block.ContentHash]struct{} {
+	t.Helper()
+	p := &openHandleHoldProvider{rt: rt, shares: map[string]struct{}{shareName: {}}}
+	got := make(map[block.ContentHash]struct{})
+	require.NoError(t, p.HeldHashes(context.Background(), "remote-1", nil, func(h block.ContentHash) error {
+		got[h] = struct{}{}
+		return nil
+	}))
+	return got
+}
+
+// TestOpenHandleHold_OpenUnlinkedFileHeld is the core #1448 scenario: a file
+// that is unlinked (nlink=0) while still open contributes its block hashes to
+// the GC mark live set; once the last handle closes, the hold disappears.
+func TestOpenHandleHold_OpenUnlinkedFileHeld(t *testing.T) {
+	rt, store := newOpenHoldRuntime(t, "share")
+	h1, h2 := hashAll(0x11), hashAll(0x22)
+	fh := openHoldPutFile(t, store, "share", "/scratch.bin", 0, "p1", []block.BlockRef{
+		{Hash: h1, Offset: 0, Size: 128},
+		{Hash: h2, Offset: 128, Size: 128},
+	})
+
+	src := &fakeOpenFileSource{handles: [][]byte{fh}}
+	rt.SetAdapterProvider("test_open_files", src)
+
+	got := heldHashes(t, rt, "share")
+	assert.Len(t, got, 2)
+	assert.Contains(t, got, h1)
+	assert.Contains(t, got, h2)
+
+	// Last close: the enumerator no longer yields the handle → no hold.
+	src.handles = nil
+	assert.Empty(t, heldHashes(t, rt, "share"))
+}
+
+// TestOpenHandleHold_LinkedFileSkipped verifies still-linked files are not
+// re-emitted by the hold: their hashes are already in the store live set.
+func TestOpenHandleHold_LinkedFileSkipped(t *testing.T) {
+	rt, store := newOpenHoldRuntime(t, "share")
+	fh := openHoldPutFile(t, store, "share", "/linked.bin", 1, "p1", []block.BlockRef{
+		{Hash: hashAll(0x33), Offset: 0, Size: 64},
+	})
+	rt.SetAdapterProvider("test_open_files", &fakeOpenFileSource{handles: [][]byte{fh}})
+	assert.Empty(t, heldHashes(t, rt, "share"))
+}
+
+// TestOpenHandleHold_StaleAndForeignHandlesSkipped verifies that handles for
+// purged files, unknown shares, and shares outside the GC scope are skipped
+// without failing the mark phase.
+func TestOpenHandleHold_StaleAndForeignHandlesSkipped(t *testing.T) {
+	rt, store := newOpenHoldRuntime(t, "share")
+	ctx := context.Background()
+
+	// Handle whose file object does not exist (purged).
+	stale, err := store.GenerateHandle(ctx, "share", "/gone.bin")
+	require.NoError(t, err)
+
+	// Handle for a share the runtime does not know.
+	foreign, err := store.GenerateHandle(ctx, "othershare", "/f.bin")
+	require.NoError(t, err)
+
+	rt.SetAdapterProvider("test_open_files", &fakeOpenFileSource{handles: [][]byte{stale, foreign}})
+	assert.Empty(t, heldHashes(t, rt, "share"))
+
+	// Open-unlinked file in a share outside the provider's scope contributes
+	// nothing to this share's pass.
+	fh := openHoldPutFile(t, store, "share", "/scoped.bin", 0, "p2", []block.BlockRef{
+		{Hash: hashAll(0x44), Offset: 0, Size: 64},
+	})
+	rt.SetAdapterProvider("test_open_files", &fakeOpenFileSource{handles: [][]byte{fh}})
+	p := &openHandleHoldProvider{rt: rt, shares: map[string]struct{}{"unrelated": {}}}
+	var emitted int
+	require.NoError(t, p.HeldHashes(ctx, "remote-1", nil, func(block.ContentHash) error {
+		emitted++
+		return nil
+	}))
+	assert.Zero(t, emitted)
+}
+
+// TestOpenHandleHold_EnumeratorErrorFailsClosed verifies an enumerator
+// failure aborts the mark phase instead of silently sweeping held blocks.
+func TestOpenHandleHold_EnumeratorErrorFailsClosed(t *testing.T) {
+	rt, _ := newOpenHoldRuntime(t, "share")
+	boom := errors.New("adapter unavailable")
+	rt.SetAdapterProvider("test_open_files", &fakeOpenFileSource{err: boom})
+	p := &openHandleHoldProvider{rt: rt, shares: map[string]struct{}{"share": {}}}
+	err := p.HeldHashes(context.Background(), "remote-1", nil, func(block.ContentHash) error { return nil })
+	require.ErrorIs(t, err, boom)
+}
+
+// TestOpenHandleHold_GCHoldForRemoteCombines verifies the combined provider
+// wired into the GC options includes the open-handle contribution.
+func TestOpenHandleHold_GCHoldForRemoteCombines(t *testing.T) {
+	rt, store := newOpenHoldRuntime(t, "share")
+	h := hashAll(0x55)
+	fh := openHoldPutFile(t, store, "share", "/combined.bin", 0, "p3", []block.BlockRef{
+		{Hash: h, Offset: 0, Size: 64},
+	})
+	rt.SetAdapterProvider("test_open_files", &fakeOpenFileSource{handles: [][]byte{fh}})
+
+	hold := rt.gcHoldForRemote([]string{"share"})
+	got := make(map[block.ContentHash]struct{})
+	require.NoError(t, hold.HeldHashes(context.Background(), "remote-1", []string{"share"}, func(h block.ContentHash) error {
+		got[h] = struct{}{}
+		return nil
+	}))
+	assert.Contains(t, got, h)
+}
+
+// TestReapStrandedRows_SkipsOpenUnlinkedPayloads verifies the stranded-row
+// reconcile leaves the payload rows of an open-but-unlinked file intact (the
+// open handle still reads through them) and reaps them after last close.
+func TestReapStrandedRows_SkipsOpenUnlinkedPayloads(t *testing.T) {
+	rt, store := newOpenHoldRuntime(t, "share")
+	ctx := context.Background()
+	old := time.Now().Add(-2 * time.Hour)
+
+	const heldPID = "held"
+	fh := openHoldPutFile(t, store, "share", "/held.bin", 0, heldPID, nil)
+	seedReconcileFB(t, ctx, store, heldPID, 2, old)
+	seedReconcileFB(t, ctx, store, "stranded", 1, old)
+
+	src := &fakeOpenFileSource{handles: [][]byte{fh}}
+	rt.SetAdapterProvider("test_open_files", src)
+
+	graceCutoff := time.Now().Add(-time.Hour)
+	reaped, err := rt.reapStrandedRows(ctx, "share", store, graceCutoff, false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, reaped, "only the truly stranded payload is reaped")
+
+	rows, err := store.ListFileChunks(ctx, heldPID)
+	require.NoError(t, err)
+	assert.Len(t, rows, 2, "open-but-unlinked payload rows must survive the reconcile")
+
+	// Last close releases the hold: the next reconcile reaps.
+	src.handles = nil
+	reaped, err = rt.reapStrandedRows(ctx, "share", store, graceCutoff, false)
+	require.NoError(t, err)
+	assert.Equal(t, 2, reaped, "after last close the payload is reclaimed")
+}

--- a/pkg/controlplane/runtime/openhandle_hold_test.go
+++ b/pkg/controlplane/runtime/openhandle_hold_test.go
@@ -172,6 +172,40 @@ func TestOpenHandleHold_EnumeratorErrorFailsClosed(t *testing.T) {
 	require.ErrorIs(t, err, boom)
 }
 
+// TestOpenHandleHold_CanceledContextStopsEarly verifies that a canceled GC
+// pass aborts the open-handle enumeration promptly and propagates the context
+// error, instead of iterating every open handle after cancellation.
+func TestOpenHandleHold_CanceledContextStopsEarly(t *testing.T) {
+	rt, store := newOpenHoldRuntime(t, "share")
+	// An open-unlinked file that would otherwise be held.
+	fh := openHoldPutFile(t, store, "share", "/scratch.bin", 0, "p1", []block.BlockRef{
+		{Hash: hashAll(0x77), Offset: 0, Size: 64},
+	})
+	rt.SetAdapterProvider("test_open_files", &fakeOpenFileSource{handles: [][]byte{fh}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	p := &openHandleHoldProvider{rt: rt, shares: map[string]struct{}{"share": {}}}
+	emitted := 0
+	err := p.HeldHashes(ctx, "remote-1", nil, func(block.ContentHash) error {
+		emitted++
+		return nil
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Zero(t, emitted, "a canceled pass must not emit held hashes")
+}
+
+// TestGetMetadataStoreForShare_UnknownShareIsErrShareNotFound guards the
+// linchpin the open-handle hold relies on: a share removed mid-scan surfaces
+// as an ErrShareNotFound-wrapped error, so forEachOpenUnlinkedFile can skip it
+// rather than fail the whole GC pass closed.
+func TestGetMetadataStoreForShare_UnknownShareIsErrShareNotFound(t *testing.T) {
+	rt, _ := newOpenHoldRuntime(t, "share")
+	_, err := rt.GetMetadataStoreForShare("ghost")
+	require.ErrorIs(t, err, shares.ErrShareNotFound)
+}
+
 // TestOpenHandleHold_GCHoldForRemoteCombines verifies the combined provider
 // wired into the GC options includes the open-handle contribution.
 func TestOpenHandleHold_GCHoldForRemoteCombines(t *testing.T) {

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1599,7 +1599,7 @@ func (s *Service) GetShare(name string) (*Share, error) {
 
 	share, exists := s.registry[name]
 	if !exists {
-		return nil, fmt.Errorf("share %q not found", name)
+		return nil, fmt.Errorf("%w: %q", ErrShareNotFound, name)
 	}
 	// Return a snapshot, not the live registry pointer: UpdateShare /
 	// SetShare* mutate the stored *Share under s.mu, so handing out the live

--- a/pkg/controlplane/runtime/snapshot_hold.go
+++ b/pkg/controlplane/runtime/snapshot_hold.go
@@ -251,13 +251,6 @@ func (p *SnapshotHoldProvider) AcquireDeleteLock(shareName string) (release func
 // per share, so AcquireDeleteLock on any instance blocks (or is blocked
 // by) every concurrent mark, closing the delete-vs-mark race the
 // per-instance mutex previously left open.
-// snapshotHoldForShare scopes snapshot holds to a single share for the
-// per-share local GC pass (#1433). Local stores are isolated per share, so the
-// local sweep must protect only that share's snapshot-held hashes.
-func (r *Runtime) snapshotHoldForShare(shareName string) engine.HoldProvider {
-	return r.snapshotHoldForRemote([]string{shareName})
-}
-
 func (r *Runtime) snapshotHoldForRemote(shareNames []string) engine.HoldProvider {
 	scoped := append([]string(nil), shareNames...)
 	locks := make([]*sync.RWMutex, 0, len(scoped))

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -423,12 +423,14 @@ type Store interface {
 	// count (SQL inodes.nlink, badger l: key, memory linkCounts), not the
 	// embedded File.Nlink.
 	//
-	// Open-but-unlinked caveat: DittoFS does not retain a file's data while it is
-	// held open after unlink (NFSv4 REMOVE drops the link immediately; SMB
-	// unlinks at last close), so excluding nlink=0 here does not break an
-	// existing guarantee. The GC grace period is the safety window for any
-	// in-flight reader; a proper open-handle GC hold (to support long-lived
-	// open-unlinked reads beyond grace) is future work.
+	// Open-but-unlinked caveat: excluding nlink=0 here is safe because the
+	// runtime layers an open-handle GC hold on top (#1448): files that are
+	// unlinked while still held open (NFSv4 open stateids, SMB open table)
+	// keep their block hashes in the GC mark live set and their payload rows
+	// out of the stranded-row reconcile until the last close. NFSv3 is
+	// stateless (kernel clients silly-rename), so the server never sees an
+	// open-unlinked file there; the GC grace period remains the safety window
+	// for stateless in-flight readers.
 	//
 	// Implementations MUST drain the result set before invoking fn
 	// (collect-then-call) and honor ctx.Done() throughout.


### PR DESCRIPTION
## Problem

#1433 excludes `nlink=0` inodes from the GC mark live set so deleted files' blocks are actually reclaimed. But a file that is **unlinked while still held open** could have its blocks reaped once the GC grace period (1h default, 5m floor) passed — breaking POSIX unlink-while-open semantics for long-lived scratch-file readers (classic `open(); unlink(); read()...` pattern).

## Fix

An **open-handle hold provider** at the runtime layer, mirroring `SnapshotHoldProvider`:

- `openHandleHoldProvider` (`pkg/controlplane/runtime/openhandle_hold.go`) re-injects the block hashes of every open-but-unlinked file into the GC mark live set, on both the remote-tier and local-tier passes (`gcHoldForRemote` / `gcHoldForShare` chain it with the snapshot hold via `multiHoldProvider`).
- The stranded-row reconcile (`reapStrandedRows`) skips payloads of open-but-unlinked files, so the chunk manifest the open handle reads through survives too.
- Open files are discovered by pulling from the adapters' authoritative open tables — no new bookkeeping, no push registry to leak. Any adapter provider registered via the existing `SetAdapterProvider` registry that implements `OpenFileEnumerator` contributes:
  - **NFSv4**: `StateManager.EnumerateOpenFiles` walks `openStateByFile` (already registered under the `"nfs"` provider key — zero new wiring).
  - **SMB**: `Handler.EnumerateOpenFiles` walks the open-file table (registered under the new `"smb_open_files"` key).
- Files open via multiple protocols at once are visited exactly once; per-file work is one `GetFile` per open unlinked file per GC pass.
- Fail-closed: enumerator/store errors abort the GC pass; stale handles (removed share, purged file) are skipped as no-data-to-protect.

## Semantics per protocol

| Protocol | Behavior |
|---|---|
| NFSv4 | `REMOVE` of an open file succeeds (dirent gone, `nlink=0`), but blocks stay held while any open stateid exists. Last `CLOSE` — or client **lease expiry**, which purges the open states — releases the hold; the next GC pass reclaims. |
| SMB | SMB itself unlinks at last close (delete-on-close), so no same-protocol window exists. The SMB open table still contributes holds so a file **removed over NFSv4 while an SMB client holds it open** stays readable until the SMB close. |
| NFSv3 | Stateless — no server-side opens exist to hold. Kernel clients silly-rename (`.nfsXXXX`) so the server never sees an open-unlinked file from a v3 client; the GC grace period remains the safety window for stateless in-flight readers (documented in `store.go` and `architecture.md`). |

## Restart story

Holds live only in the adapters' in-memory open tables. After a server restart the tables are empty, so an abandoned open-unlinked file is reclaimable on the next GC pass — no persistent hold can leak. NFSv4 clients that reclaim state within the lease window re-establish their opens (and thus their holds) before a GC pass can observe the gap plus outlive the grace period.

## Mark-order safety

The engine mark phase enumerates each share's live chunks **before** asking the hold provider. An unlink landing before the share enumeration is caught by the hold (open predates unlink, so the enumerators report it); an unlink landing after is already in the live set for that pass. No torn window.

## Tests

- `openhandle_hold_test.go`: hold emits hashes for open+unlinked files and stops after last close; linked files skipped; stale/foreign handles skipped; enumerator errors fail closed; cross-protocol dedup; combined provider wiring; reconcile skips held payloads and reaps after release.
- `state/open_files_test.go`: NFSv4 enumeration across OPEN/CLOSE, one emit per file, error propagation.
- `handlers/open_files_test.go`: SMB open-table enumeration, entry removal releases the hold, error propagation.
- No store-contract change, so `storetest` is untouched. An e2e was considered but kernel NFS clients silly-rename on unlink-while-open, so a faithful reproduction needs dual-superblock `nosharecache` mounts — too flaky for CI; the GC seam is pinned by the runtime-level tests instead.

Fixes #1448