### PR TITLE
feat(shares): hot-reload block store binding without restart

### DIFF
--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -922,7 +922,7 @@ func (h *ShareHandler) Update(w http.ResponseWriter, r *http.Request) {
 			logger.Error("Failed to hot-reload share block store after binding change; a restart is required",
 				"share", share.Name, "error", err)
 			updateWarnings = append(updateWarnings,
-				"block store binding changed but live reload failed ("+err.Error()+"); a server restart is required for the change to take effect")
+				"block store binding changed but live reload failed; a server restart is required for the change to take effect")
 		} else {
 			logger.Info("Share block store rebound live after binding change",
 				"share", share.Name,

--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -912,18 +912,23 @@ func (h *ShareHandler) Update(w http.ResponseWriter, r *http.Request) {
 			"local_store_size", share.LocalStoreSize, "read_buffer_size", share.ReadBufferSize)
 	}
 
-	// The per-share syncer/BlockStore mode is not hot-reloaded (#1532): a
-	// binding change is persisted but only takes effect after a server restart.
-	// Warn loudly so the change is not silently a no-op for mirroring.
+	// A block-store binding change is not picked up by the running syncer until
+	// the per-share BlockStore is rebuilt. Attempt a live hot-reload (#1532); only
+	// if that fails do we warn the operator that a restart is required, so the
+	// change is never a silent no-op for mirroring.
 	var updateWarnings []string
-	if blockStoreBindingChanged {
-		const bindingWarn = "block store binding changed but only takes effect after a server restart; " +
-			"until then the running share keeps using its previous block store binding"
-		logger.Warn("Share block store binding changed (takes effect on restart)",
-			"share", share.Name,
-			"local_block_store_id", share.LocalBlockStoreID,
-			"remote_block_store_id", newRemoteBlockStoreID)
-		updateWarnings = append(updateWarnings, bindingWarn)
+	if blockStoreBindingChanged && h.runtime != nil {
+		if err := h.runtime.RebindShareBlockStore(r.Context(), share.Name, prevLocalBlockStoreID, prevRemoteBlockStoreID); err != nil {
+			logger.Error("Failed to hot-reload share block store after binding change; a restart is required",
+				"share", share.Name, "error", err)
+			updateWarnings = append(updateWarnings,
+				"block store binding changed but live reload failed ("+err.Error()+"); a server restart is required for the change to take effect")
+		} else {
+			logger.Info("Share block store rebound live after binding change",
+				"share", share.Name,
+				"local_block_store_id", share.LocalBlockStoreID,
+				"remote_block_store_id", newRemoteBlockStoreID)
+		}
 	}
 
 	// Update runtime if available

--- a/internal/controlplane/api/handlers/shares_test.go
+++ b/internal/controlplane/api/handlers/shares_test.go
@@ -435,10 +435,12 @@ func TestShareHandler_Update_RejectsInvalidDefaultPermission(t *testing.T) {
 	}
 }
 
-// TestShareHandler_Update_WarnsOnBlockStoreBindingChange verifies that
-// attaching/changing a share's block store returns an operator-facing warning,
-// since the running syncer/BlockStore is not hot-reloaded (#1532).
-func TestShareHandler_Update_WarnsOnBlockStoreBindingChange(t *testing.T) {
+// TestShareHandler_Update_WarnsWhenLiveReloadFails verifies the #1532 fallback:
+// a binding change triggers a live block-store rebind, and if that rebind fails
+// (here the share is DB-configured but not loaded into the runtime registry) the
+// response carries an operator-facing "restart required" warning instead of
+// silently doing nothing.
+func TestShareHandler_Update_WarnsWhenLiveReloadFails(t *testing.T) {
 	cpStore, _, handler := setupShareTestWithRuntime(t)
 	seedShare(t, cpStore, "s-bswarn")
 	ctx := context.Background()

--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -234,88 +234,13 @@ func LoadSharesFromStore(ctx context.Context, rt *Runtime, s store.Store) error 
 	}
 
 	for _, share := range shares {
-		// Try by ID first, fall back to name lookup
-		metaStoreCfg, err := s.GetMetadataStoreByID(ctx, share.MetadataStoreID)
+		shareConfig, err := buildShareConfig(ctx, s, share)
 		if err != nil {
-			metaStoreCfg, err = s.GetMetadataStore(ctx, share.MetadataStoreID)
-			if err != nil {
-				logger.Warn("Share references unknown metadata store",
-					"share", share.Name,
-					"metadata_store_id", share.MetadataStoreID)
-				continue
-			}
+			return err
 		}
-
-		nfsOpts := models.DefaultNFSExportOptions()
-		nfsCfg, err := s.GetShareAdapterConfig(ctx, share.ID, "nfs")
-		if err == nil && nfsCfg != nil {
-			_ = nfsCfg.ParseConfig(&nfsOpts)
-		}
-
-		var netgroupName string
-		if nfsOpts.NetgroupID != nil && *nfsOpts.NetgroupID != "" {
-			if ns, ok := s.(store.NetgroupStore); ok {
-				ng, ngErr := ns.GetNetgroupByID(ctx, *nfsOpts.NetgroupID)
-				if ngErr == nil {
-					netgroupName = ng.Name
-				} else {
-					logger.Warn("Share references unknown netgroup",
-						"share", share.Name,
-						"netgroup_id", *nfsOpts.NetgroupID)
-				}
-			}
-		}
-
-		// Re-apply the persisted root owner so a restart does not reset the
-		// share root to UID/GID 0: prepareShare defaults a nil RootAttr to the
-		// zero value and the metadata stores force-sync existing root
-		// ownership to it (#1534).
-		var rootAttr *metadata.FileAttr
-		if share.OwnerUID != nil {
-			uid := *share.OwnerUID
-			gid := uid // default the group to the owner, never root
-			if share.OwnerGID != nil {
-				gid = *share.OwnerGID
-			}
-			rootAttr = &metadata.FileAttr{UID: uid, GID: gid}
-		}
-
-		shareConfig := &ShareConfig{
-			Name:                             share.Name,
-			MetadataStore:                    metaStoreCfg.Name,
-			RootAttr:                         rootAttr,
-			ReadOnly:                         share.ReadOnly,
-			Enabled:                          share.Enabled, // propagate DB Enabled flag so adapter gates read the correct runtime value.
-			EncryptData:                      share.EncryptData,
-			AclFlagInheritedCanonicalization: share.AclFlagInheritedCanonicalization,
-			AccessBasedEnumeration:           share.AccessBasedEnumeration,
-			ChangeNotifyDisabled:             share.ChangeNotifyDisabled,
-			StreamsDisabled:                  share.StreamsDisabled,
-			ContinuousAvailability:           share.ContinuousAvailability,
-			AllowMFsymlink:                   share.AllowMFsymlink,
-			TrashEnabled:                     share.TrashEnabled,
-			TrashRetentionDays:               share.TrashRetentionDays,
-			TrashRestrictToAdmin:             share.TrashRestrictToAdmin,
-			TrashMaxBytes:                    share.TrashMaxBytes,
-			TrashExcludePatterns:             share.GetTrashExcludePatterns(),
-			DefaultPermission:                share.DefaultPermission,
-			Squash:                           nfsOpts.GetSquashMode(),
-			AnonymousUID:                     nfsOpts.GetAnonymousUID(),
-			AnonymousGID:                     nfsOpts.GetAnonymousGID(),
-			AllowAuthSys:                     nfsOpts.AllowAuthSys,
-			AllowAuthSysSet:                  true,
-			RequireKerberos:                  nfsOpts.RequireKerberos,
-			MinKerberosLevel:                 nfsOpts.MinKerberosLevel,
-			DisableReaddirplus:               nfsOpts.DisableReaddirplus,
-			NetgroupName:                     netgroupName,
-			BlockedOperations:                share.GetBlockedOps(),
-			RetentionPolicy:                  share.GetRetentionPolicy(),
-			RetentionTTL:                     share.GetRetentionTTL(),
-			LocalStoreSize:                   share.LocalStoreSize,
-			ReadBufferSize:                   share.ReadBufferSize,
-			QuotaBytes:                       share.QuotaBytes,
-			LocalBlockStoreID:                share.LocalBlockStoreID,
-			RemoteBlockStoreID:               derefString(share.RemoteBlockStoreID),
+		if shareConfig == nil {
+			// Share references an unknown metadata store; already logged.
+			continue
 		}
 
 		if err := rt.AddShare(ctx, shareConfig); err != nil {
@@ -333,10 +258,100 @@ func LoadSharesFromStore(ctx context.Context, rt *Runtime, s store.Store) error 
 			continue
 		}
 
-		logger.Info("Loaded share", "name", share.Name, "metadata_store", metaStoreCfg.Name)
+		logger.Info("Loaded share", "name", share.Name, "metadata_store", shareConfig.MetadataStore)
 	}
 
 	return nil
+}
+
+// buildShareConfig assembles the runtime ShareConfig for a persisted share row,
+// resolving its metadata store, NFS export options, and netgroup. It returns
+// (nil, nil) when the share references an unknown metadata store so the caller
+// can skip it (already logged). Extracted so both startup load and live
+// block-store rebind (#1532) build an identical config from the same row.
+func buildShareConfig(ctx context.Context, s store.Store, share *models.Share) (*ShareConfig, error) {
+	// Try by ID first, fall back to name lookup.
+	metaStoreCfg, err := s.GetMetadataStoreByID(ctx, share.MetadataStoreID)
+	if err != nil {
+		metaStoreCfg, err = s.GetMetadataStore(ctx, share.MetadataStoreID)
+		if err != nil {
+			logger.Warn("Share references unknown metadata store",
+				"share", share.Name,
+				"metadata_store_id", share.MetadataStoreID)
+			return nil, nil
+		}
+	}
+
+	nfsOpts := models.DefaultNFSExportOptions()
+	nfsCfg, err := s.GetShareAdapterConfig(ctx, share.ID, "nfs")
+	if err == nil && nfsCfg != nil {
+		_ = nfsCfg.ParseConfig(&nfsOpts)
+	}
+
+	var netgroupName string
+	if nfsOpts.NetgroupID != nil && *nfsOpts.NetgroupID != "" {
+		if ns, ok := s.(store.NetgroupStore); ok {
+			ng, ngErr := ns.GetNetgroupByID(ctx, *nfsOpts.NetgroupID)
+			if ngErr == nil {
+				netgroupName = ng.Name
+			} else {
+				logger.Warn("Share references unknown netgroup",
+					"share", share.Name,
+					"netgroup_id", *nfsOpts.NetgroupID)
+			}
+		}
+	}
+
+	// Re-apply the persisted root owner so a restart does not reset the share
+	// root to UID/GID 0: prepareShare defaults a nil RootAttr to the zero value
+	// and the metadata stores force-sync existing root ownership to it (#1534).
+	var rootAttr *metadata.FileAttr
+	if share.OwnerUID != nil {
+		uid := *share.OwnerUID
+		gid := uid // default the group to the owner, never root
+		if share.OwnerGID != nil {
+			gid = *share.OwnerGID
+		}
+		rootAttr = &metadata.FileAttr{UID: uid, GID: gid}
+	}
+
+	return &ShareConfig{
+		Name:                             share.Name,
+		MetadataStore:                    metaStoreCfg.Name,
+		RootAttr:                         rootAttr,
+		ReadOnly:                         share.ReadOnly,
+		Enabled:                          share.Enabled, // propagate DB Enabled flag so adapter gates read the correct runtime value.
+		EncryptData:                      share.EncryptData,
+		AclFlagInheritedCanonicalization: share.AclFlagInheritedCanonicalization,
+		AccessBasedEnumeration:           share.AccessBasedEnumeration,
+		ChangeNotifyDisabled:             share.ChangeNotifyDisabled,
+		StreamsDisabled:                  share.StreamsDisabled,
+		ContinuousAvailability:           share.ContinuousAvailability,
+		AllowMFsymlink:                   share.AllowMFsymlink,
+		TrashEnabled:                     share.TrashEnabled,
+		TrashRetentionDays:               share.TrashRetentionDays,
+		TrashRestrictToAdmin:             share.TrashRestrictToAdmin,
+		TrashMaxBytes:                    share.TrashMaxBytes,
+		TrashExcludePatterns:             share.GetTrashExcludePatterns(),
+		DefaultPermission:                share.DefaultPermission,
+		Squash:                           nfsOpts.GetSquashMode(),
+		AnonymousUID:                     nfsOpts.GetAnonymousUID(),
+		AnonymousGID:                     nfsOpts.GetAnonymousGID(),
+		AllowAuthSys:                     nfsOpts.AllowAuthSys,
+		AllowAuthSysSet:                  true,
+		RequireKerberos:                  nfsOpts.RequireKerberos,
+		MinKerberosLevel:                 nfsOpts.MinKerberosLevel,
+		DisableReaddirplus:               nfsOpts.DisableReaddirplus,
+		NetgroupName:                     netgroupName,
+		BlockedOperations:                share.GetBlockedOps(),
+		RetentionPolicy:                  share.GetRetentionPolicy(),
+		RetentionTTL:                     share.GetRetentionTTL(),
+		LocalStoreSize:                   share.LocalStoreSize,
+		ReadBufferSize:                   share.ReadBufferSize,
+		QuotaBytes:                       share.QuotaBytes,
+		LocalBlockStoreID:                share.LocalBlockStoreID,
+		RemoteBlockStoreID:               derefString(share.RemoteBlockStoreID),
+	}, nil
 }
 
 // derefString safely dereferences a *string, returning "" if nil.

--- a/pkg/controlplane/runtime/init_test.go
+++ b/pkg/controlplane/runtime/init_test.go
@@ -204,6 +204,93 @@ func TestLoadSharesResolvesBlockStoreByName(t *testing.T) {
 	}
 }
 
+// TestRebindShareBlockStore_Live exercises the #1532 hot-reload: changing a
+// running share's block-store binding takes effect live (no restart). It walks
+// local-only -> attach remote -> swap remote -> detach remote and asserts the
+// per-share BlockStore's remote presence flips each time without an error.
+func TestRebindShareBlockStore_Live(t *testing.T) {
+	rt, s := setupTestRuntime(t)
+	ctx := context.Background()
+
+	localID := createLocalBlockStoreConfig(t, s, "reb-local")
+	remoteA := createRemoteBlockStoreConfig(t, s, "reb-remote-a")
+	remoteB := createRemoteBlockStoreConfig(t, s, "reb-remote-b")
+
+	metaStores, _ := s.ListMetadataStores(ctx)
+	share := &models.Share{
+		Name:              "/reb",
+		MetadataStoreID:   metaStores[0].ID,
+		LocalBlockStoreID: localID,
+	}
+	if _, err := s.CreateShare(ctx, share); err != nil {
+		t.Fatalf("CreateShare: %v", err)
+	}
+	if err := LoadSharesFromStore(ctx, rt, s); err != nil {
+		t.Fatalf("LoadSharesFromStore: %v", err)
+	}
+
+	hasRemote := func() bool {
+		shareObj, err := rt.GetShare("/reb")
+		if err != nil {
+			t.Fatalf("GetShare: %v", err)
+		}
+		return shareObj.BlockStore.RemoteStore() != nil
+	}
+	// setRemote persists a new remote binding to the DB, mirroring the PUT handler
+	// before the runtime rebind is invoked.
+	setRemote := func(remoteID string) {
+		dbShare, err := s.GetShare(ctx, "/reb")
+		if err != nil {
+			t.Fatalf("GetShare(db): %v", err)
+		}
+		if remoteID == "" {
+			dbShare.RemoteBlockStoreID = nil
+		} else {
+			dbShare.RemoteBlockStoreID = &remoteID
+		}
+		if err := s.UpdateShare(ctx, dbShare); err != nil {
+			t.Fatalf("UpdateShare: %v", err)
+		}
+	}
+
+	if hasRemote() {
+		t.Fatal("expected local-only share to start with no remote store")
+	}
+
+	// 1) Attach a remote live (the #1532 scenario: bind remote to enable mirroring).
+	setRemote(remoteA)
+	if err := rt.RebindShareBlockStore(ctx, "/reb", localID, ""); err != nil {
+		t.Fatalf("rebind attach: %v", err)
+	}
+	if !hasRemote() {
+		t.Fatal("expected remote store attached after live rebind")
+	}
+
+	// 2) Swap remote A -> remote B.
+	setRemote(remoteB)
+	if err := rt.RebindShareBlockStore(ctx, "/reb", localID, remoteA); err != nil {
+		t.Fatalf("rebind swap: %v", err)
+	}
+	if !hasRemote() {
+		t.Fatal("expected remote store still attached after swap")
+	}
+
+	// 3) Detach: remote -> local-only.
+	setRemote("")
+	if err := rt.RebindShareBlockStore(ctx, "/reb", localID, remoteB); err != nil {
+		t.Fatalf("rebind detach: %v", err)
+	}
+	if hasRemote() {
+		t.Fatal("expected no remote store after detach")
+	}
+
+	// The rebuilt store is still usable after all the swaps.
+	shareObj, _ := rt.GetShare("/reb")
+	if _, err := shareObj.BlockStore.WriteAt(ctx, "payload", nil, []byte("ok"), 0); err != nil {
+		t.Fatalf("WriteAt after rebind: %v", err)
+	}
+}
+
 func TestPerShareBlockStoreIsolation(t *testing.T) {
 	rt, s := setupTestRuntime(t)
 	ctx := context.Background()

--- a/pkg/controlplane/runtime/init_test.go
+++ b/pkg/controlplane/runtime/init_test.go
@@ -285,7 +285,10 @@ func TestRebindShareBlockStore_Live(t *testing.T) {
 	}
 
 	// The rebuilt store is still usable after all the swaps.
-	shareObj, _ := rt.GetShare("/reb")
+	shareObj, err := rt.GetShare("/reb")
+	if err != nil {
+		t.Fatalf("GetShare after rebind: %v", err)
+	}
 	if _, err := shareObj.BlockStore.WriteAt(ctx, "payload", nil, []byte("ok"), 0); err != nil {
 		t.Fatalf("WriteAt after rebind: %v", err)
 	}

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -501,7 +501,7 @@ func (r *Runtime) RebindShareBlockStore(ctx context.Context, name, oldLocalBlock
 	}
 	newCfg, err := buildShareConfig(ctx, r.store, shareModel)
 	if err != nil {
-		return err
+		return fmt.Errorf("rebind: failed to build share config for %q: %w", name, err)
 	}
 	if newCfg == nil {
 		return fmt.Errorf("rebind: share %q references an unknown metadata store", name)

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -486,6 +487,38 @@ func (r *Runtime) AddShare(ctx context.Context, config *ShareConfig) error {
 		logger.Warn("failed to reconcile share root ACL", "share", config.Name, "error", err)
 	}
 	return nil
+}
+
+// RebindShareBlockStore hot-reloads a running share's per-share BlockStore after
+// its local/remote block-store binding changed, so the change takes effect
+// without a server restart (#1532). It rebuilds the new ShareConfig from the
+// (already-persisted) DB row and passes the previous block-store IDs so the
+// share service can restore the old binding if the new one fails to build.
+func (r *Runtime) RebindShareBlockStore(ctx context.Context, name, oldLocalBlockStoreID, oldRemoteBlockStoreID string) error {
+	shareModel, err := r.store.GetShare(ctx, name)
+	if err != nil {
+		return fmt.Errorf("rebind: failed to load share %q: %w", name, err)
+	}
+	newCfg, err := buildShareConfig(ctx, r.store, shareModel)
+	if err != nil {
+		return err
+	}
+	if newCfg == nil {
+		return fmt.Errorf("rebind: share %q references an unknown metadata store", name)
+	}
+
+	// oldConfig is the same row with the previous block-store binding — used only
+	// for recovery if the new store fails to build.
+	oldCfg := *newCfg
+	oldCfg.LocalBlockStoreID = oldLocalBlockStoreID
+	oldCfg.RemoteBlockStoreID = oldRemoteBlockStoreID
+
+	r.mu.RLock()
+	localDefaults := r.localStoreDefaults
+	syncDefaults := r.syncerDefaults
+	r.mu.RUnlock()
+
+	return r.sharesSvc.RebindShareBlockStore(ctx, newCfg, &oldCfg, r.storesSvc, r.store, localDefaults, syncDefaults)
 }
 
 // RegisterShareForTesting registers a minimal enabled share in the share

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1154,8 +1154,21 @@ func (s *Service) RebindShareBlockStore(
 			return fmt.Errorf("rebind failed for share %q and previous binding could not be restored (%v); share needs a restart: %w", name, recErr, buildErr)
 		}
 		// Previous binding restored. Swap it in and drop the original remote ref
-		// (the recovery rebuild acquired its own).
+		// (the recovery rebuild acquired its own) — but only if the share is
+		// still registered; a concurrent RemoveShare would already have released
+		// oldRemoteConfigID, so releasing it again here underflows the ref-count.
 		s.mu.Lock()
+		if cur, ok := s.registry[name]; !ok || cur != share {
+			s.mu.Unlock()
+			if closeErr := recovered.BlockStore.Close(); closeErr != nil {
+				logger.Warn("rebind: failed to close recovered block store after concurrent share removal",
+					"share", name, "error", closeErr)
+			}
+			if recovered.remoteConfigID != "" {
+				s.releaseRemoteStore(recovered.remoteConfigID)
+			}
+			return fmt.Errorf("share %q was removed during rebind (new binding also failed: %v)", name, buildErr)
+		}
 		share.BlockStore = recovered.BlockStore
 		share.remoteConfigID = recovered.remoteConfigID
 		share.gcStateRoot = recovered.gcStateRoot
@@ -1167,8 +1180,26 @@ func (s *Service) RebindShareBlockStore(
 		return fmt.Errorf("failed to rebind block store for share %q (previous binding restored): %w", name, buildErr)
 	}
 
-	// Swap the new store into the registry.
+	// Swap the new store into the registry, but only if the share is still
+	// registered under the same pointer. A concurrent RemoveShare (which does
+	// not take rebindMu) can delete it and release oldRemoteConfigID while we
+	// rebuild; swapping into the stale pointer and releasing the old ref again
+	// would double-decrement the shared remote ref-count and could close a
+	// remote store still used by other shares.
 	s.mu.Lock()
+	if cur, ok := s.registry[name]; !ok || cur != share {
+		s.mu.Unlock()
+		// Share removed during rebind. Tear down the store we just built and
+		// drop its own remote ref; leave the old ref to RemoveShare.
+		if closeErr := rebuilt.BlockStore.Close(); closeErr != nil {
+			logger.Warn("rebind: failed to close new block store after concurrent share removal",
+				"share", name, "error", closeErr)
+		}
+		if rebuilt.remoteConfigID != "" {
+			s.releaseRemoteStore(rebuilt.remoteConfigID)
+		}
+		return fmt.Errorf("share %q was removed during rebind", name)
+	}
 	share.BlockStore = rebuilt.BlockStore
 	share.remoteConfigID = rebuilt.remoteConfigID
 	share.gcStateRoot = rebuilt.gcStateRoot

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -471,6 +471,13 @@ type Service struct {
 	// inline recording.
 	metricsRec local.MetricsRecorder
 
+	// rebindMu serializes RebindShareBlockStore calls. A rebind tears down and
+	// rebuilds a share's per-share BlockStore over the same local dir, which is
+	// not safe to overlap with another rebind of the same share. Rebinds are
+	// rare (operator-initiated binding changes), so a single coarse mutex across
+	// all shares is acceptable and keeps the teardown/rebuild strictly ordered.
+	rebindMu sync.Mutex
+
 	// warmJobs tracks in-flight/completed async share-warm jobs (one active per
 	// share). Self-guarded; runs warm runs on detached contexts cancelled on
 	// RemoveShare. See warm.go.
@@ -1047,6 +1054,138 @@ func (s *Service) createBlockStoreForShare(
 		"retention", config.RetentionPolicy,
 		"retention_ttl", config.RetentionTTL)
 
+	return nil
+}
+
+// RebindShareBlockStore hot-reloads a running share's per-share BlockStore so a
+// changed local/remote block-store binding takes effect WITHOUT a server
+// restart (see #1532). The syncer mode (local-only vs. remote) and the remote
+// target are fixed at BlockStore construction, so the only correct way to
+// change them on a live share is to tear the old store down and build a new one.
+//
+// The fs local backend is not safe to double-open, and for a remote-only change
+// the local directory is unchanged, so the old store is fully drained + closed
+// BEFORE the new one is constructed over the same dir. The share therefore has a
+// brief I/O gap during the swap: in-flight ops complete (Close drains them),
+// new ops briefly get ErrClosed and are retried by the NFS/SMB client. Binding
+// a remote also backfills pre-existing local blocks — the rebuilt syncer's
+// Start seeds the pending-upload set from disk.
+//
+// newConfig carries the new binding; oldConfig is identical except for the
+// block-store IDs and is used only to rebuild the previous store if the new one
+// fails to build, so a rebind failure never leaves the share storeless.
+func (s *Service) RebindShareBlockStore(
+	ctx context.Context,
+	newConfig *ShareConfig,
+	oldConfig *ShareConfig,
+	storeProvider MetadataStoreProvider,
+	blockStoreProvider BlockStoreConfigProvider,
+	localStoreDefaults *LocalStoreDefaults,
+	syncerDefaults *SyncerDefaults,
+) error {
+	name := newConfig.Name
+	if newConfig.LocalBlockStoreID == "" {
+		return fmt.Errorf("cannot rebind share %q: no local block store configured", name)
+	}
+
+	// Serialize rebinds: overlapping teardown/rebuild over the same local dir is
+	// unsafe.
+	s.rebindMu.Lock()
+	defer s.rebindMu.Unlock()
+
+	s.mu.RLock()
+	share, ok := s.registry[name]
+	s.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("cannot rebind share %q: not found in registry", name)
+	}
+
+	// Resolve the metadata store (fileChunkStore); unchanged by a binding change.
+	fileChunkStore, err := storeProvider.GetMetadataStore(newConfig.MetadataStore)
+	if err != nil {
+		return fmt.Errorf("failed to resolve metadata store for share %q: %w", name, err)
+	}
+
+	// Pre-validate the new binding resolves BEFORE tearing down the live store,
+	// so a bad binding fails fast without disrupting the running share.
+	if _, err := resolveBlockStoreConfig(ctx, blockStoreProvider, newConfig.LocalBlockStoreID, models.BlockStoreKindLocal); err != nil {
+		return fmt.Errorf("failed to resolve new local block store %q: %w", newConfig.LocalBlockStoreID, err)
+	}
+	if newConfig.RemoteBlockStoreID != "" {
+		if _, err := resolveBlockStoreConfig(ctx, blockStoreProvider, newConfig.RemoteBlockStoreID, models.BlockStoreKindRemote); err != nil {
+			return fmt.Errorf("failed to resolve new remote block store %q: %w", newConfig.RemoteBlockStoreID, err)
+		}
+	}
+
+	s.mu.RLock()
+	oldBS := share.BlockStore
+	oldRemoteConfigID := share.remoteConfigID
+	s.mu.RUnlock()
+
+	// Flush pending uploads to the OLD remote before teardown so switching or
+	// detaching a remote does not strand unmirrored blocks. Best-effort: a drain
+	// error must not block the rebind.
+	if oldBS != nil {
+		if err := oldBS.DrainAllUploads(ctx); err != nil {
+			logger.Warn("rebind: failed to drain uploads before teardown; continuing",
+				"share", name, "error", err)
+		}
+		if err := oldBS.Close(); err != nil {
+			logger.Warn("rebind: error closing previous block store; continuing",
+				"share", name, "error", err)
+		}
+	}
+
+	// Build the new store over the same (now-closed) local dir.
+	rebuilt := &Share{Name: name}
+	if buildErr := s.createBlockStoreForShare(ctx, rebuilt, newConfig, blockStoreProvider, fileChunkStore, localStoreDefaults, syncerDefaults); buildErr != nil {
+		// Recovery: rebuild the previous binding so the share is not left
+		// storeless. oldConfig differs from newConfig only in the block-store IDs.
+		logger.Error("rebind: failed to build new block store; restoring previous binding",
+			"share", name, "error", buildErr)
+		recovered := &Share{Name: name}
+		if recErr := s.createBlockStoreForShare(ctx, recovered, oldConfig, blockStoreProvider, fileChunkStore, localStoreDefaults, syncerDefaults); recErr != nil {
+			// Both failed: the share keeps its now-closed store (ops return
+			// ErrClosed, not a nil-deref panic) and needs a restart. Release the
+			// original remote ref since nothing holds it anymore.
+			if oldRemoteConfigID != "" {
+				s.releaseRemoteStore(oldRemoteConfigID)
+			}
+			return fmt.Errorf("rebind failed for share %q and previous binding could not be restored (%v); share needs a restart: %w", name, recErr, buildErr)
+		}
+		// Previous binding restored. Swap it in and drop the original remote ref
+		// (the recovery rebuild acquired its own).
+		s.mu.Lock()
+		share.BlockStore = recovered.BlockStore
+		share.remoteConfigID = recovered.remoteConfigID
+		share.gcStateRoot = recovered.gcStateRoot
+		share.localStoreDir = recovered.localStoreDir
+		s.mu.Unlock()
+		if oldRemoteConfigID != "" {
+			s.releaseRemoteStore(oldRemoteConfigID)
+		}
+		return fmt.Errorf("failed to rebind block store for share %q (previous binding restored): %w", name, buildErr)
+	}
+
+	// Swap the new store into the registry.
+	s.mu.Lock()
+	share.BlockStore = rebuilt.BlockStore
+	share.remoteConfigID = rebuilt.remoteConfigID
+	share.gcStateRoot = rebuilt.gcStateRoot
+	share.localStoreDir = rebuilt.localStoreDir
+	s.mu.Unlock()
+
+	// Drop the previous remote ref now that the new store holds its own.
+	if oldRemoteConfigID != "" {
+		s.releaseRemoteStore(oldRemoteConfigID)
+	}
+
+	s.notifyShareChange()
+	logger.Info("Per-share BlockStore rebound live",
+		"share", name,
+		"local_block_store_id", newConfig.LocalBlockStoreID,
+		"remote_block_store_id", newConfig.RemoteBlockStoreID,
+		"mode", modeLabel(newConfig.RemoteBlockStoreID != ""))
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Delivers the **preferred** fix for #1532: changing a share's block-store binding (`dfsctl share edit --local/--remote`) now takes effect on the **running server** — no restart. Supersedes the warn-only fallback from #1536 (that warning now only fires if a live reload fails).

```
$ dfsctl share edit /my-share --remote cubbit-tim
Share '/my-share' updated successfully      # mirroring is live immediately
```

## Why a rebuild (not a live attach)

The syncer's mode (local-only vs. remote) and its remote target are fixed at BlockStore construction. The engine has no clean live attach/detach/swap: `Syncer.SetRemoteStore` is one-shot attach-only, isn't wired above the syncer, and there's no detach/swap. So the only correct way to change a live share's binding is **teardown + rebuild**.

Because the fs local backend takes no directory lock, two BlockStores over the same local dir race (append-log / rollup / logblob). For a remote-only change the local dir is unchanged, so the old store must be fully **drained + closed before** the new one is built — never overlapping.

## What it does

New `Service.RebindShareBlockStore` (via `Runtime.RebindShareBlockStore`, called from the PUT `/shares/{name}` handler when the binding actually changes):

1. **Pre-validate** the new local/remote configs resolve — before touching the live store, so a bad binding fails fast with no disruption.
2. **Drain** pending uploads to the old remote (`DrainAllUploads`) so switching/detaching a remote never strands unmirrored blocks.
3. **Close** the old store (drains in-flight ops), then **build + start** the new one over the same local dir.
4. **Swap** it into the registry under the lock and release the old remote ref-count.
5. **Backfill for free:** binding a remote rebuilds the syncer, whose `Start` seeds the pending-upload set from disk — so pre-existing local blocks mirror (the follow-up #1532 flagged).

**Failure handling:** if the new store fails to build, the previous binding is rebuilt so the share is never left storeless; the handler then falls back to the #1536 "restart required" warning. Rebinds are serialized per `Service` (`rebindMu`) since overlapping teardown/rebuild over one dir is unsafe.

**Tradeoff (documented):** there is a brief per-share I/O gap during the swap — in-flight ops complete (Close drains them), new ops briefly get `ErrClosed` and are retried by the NFS/SMB client. The rebuild's `Start` also runs `seedPendingFromDisk`, so a very large local store makes the PUT response slower.

## Changes

- `pkg/controlplane/runtime/shares/service.go` — `RebindShareBlockStore` + `rebindMu`.
- `pkg/controlplane/runtime/runtime.go` — `Runtime.RebindShareBlockStore` wrapper (builds the new config from the persisted row, passes the old binding for recovery).
- `pkg/controlplane/runtime/init.go` — extracted `buildShareConfig` so startup load and rebind build an identical config.
- `internal/controlplane/api/handlers/shares.go` — PUT handler attempts the live rebind; warns only on failure.

## Tests

- `TestRebindShareBlockStore_Live` (runtime) — local-only → attach remote → swap remote → detach, asserting the per-share BlockStore's remote presence flips live each time, store still writable after.
- Handler: binding change with an unreloadable share → fallback warning; non-binding update → no warning.
- `go test -race ./...` green.

Closes #1532
