### PR TITLE
fix(block): implement WalkLocalLocations on production stores for restart-seed

### DIFF
--- a/pkg/block/local/fs/restart_seed_sqlite_test.go
+++ b/pkg/block/local/fs/restart_seed_sqlite_test.go
@@ -1,0 +1,53 @@
+package fs
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
+)
+
+// TestFSStore_ListUnsynced_SQLiteIndex is the restart-seed regression guard for
+// production metadata backends. An FSStore whose LocalChunkIndex is a real
+// SQLite store holds unsynced chunks only in the logblob index (no CAS files).
+// ListUnsynced must re-discover them via FSStore.Walk, which enumerates the
+// index through the localChunkWalker capability. Before SQLite implemented
+// WalkLocalLocations the type-assertion in Walk failed, Walk silently skipped
+// the index, and ListUnsynced returned nothing — so the syncer never re-seeded
+// crash-stranded chunks on restart. This test fails without that method.
+func TestFSStore_ListUnsynced_SQLiteIndex(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := &sqlite.SQLiteMetadataStoreConfig{
+		Path:        filepath.Join(t.TempDir(), "restart-seed.db"),
+		AutoMigrate: true,
+	}
+	idx, err := sqlite.NewSQLiteMetadataStore(ctx, cfg, metadata.FilesystemCapabilities{})
+	if err != nil {
+		t.Fatalf("NewSQLiteMetadataStore: %v", err)
+	}
+	t.Cleanup(func() { _ = idx.Close() })
+
+	// SyncedHashStore with nothing marked synced → every logblob chunk is
+	// unsynced. Wire the SQLite store as the LocalChunkIndex so the seed path
+	// must walk a production backend's index, not the memory one.
+	bc := newFSStoreForTest(t, FSStoreOptions{
+		LocalChunkIndex: idx,
+		SyncedHashStore: memory.NewMemoryMetadataStoreWithDefaults(),
+	})
+
+	want := seedChunks(t, bc, 3)
+
+	got, errs := collectIter(bc.ListUnsynced(ctx))
+	for _, e := range errs {
+		if e != nil {
+			t.Fatalf("ListUnsynced yielded error: %v", e)
+		}
+	}
+	if !hashSetEqual(got, want) {
+		t.Fatalf("ListUnsynced returned %d chunks, want %d (SQLite index not walked — restart-seed broken)", len(got), len(want))
+	}
+}

--- a/pkg/metadata/store/badger/block_record_store.go
+++ b/pkg/metadata/store/badger/block_record_store.go
@@ -445,6 +445,81 @@ func (s *BadgerMetadataStore) DeleteLocalLocation(ctx context.Context, hash bloc
 	return nil
 }
 
+// WalkLocalLocations calls fn for every stored content-hash -> log-blob
+// location. Read-only; deliberately NOT part of the LocalChunkIndex interface —
+// the local block store discovers it via a narrow consumer-side interface to
+// re-seed crash-stranded unsynced logblob chunks on restart (Walk / ListUnsynced).
+// Collects all entries under a read-only View first, then calls fn outside the
+// iterator so the callback never runs with the iterator open (mirrors
+// WalkBlockRecords).
+func (s *BadgerMetadataStore) WalkLocalLocations(ctx context.Context, fn func(block.ContentHash, block.LocalChunkLocation) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	prefix := []byte(prefixLocalChunkIdx)
+
+	type entry struct {
+		hash block.ContentHash
+		loc  block.LocalChunkLocation
+	}
+	var entries []entry
+	if err := s.db.View(func(txn *badgerdb.Txn) error {
+		opts := badgerdb.DefaultIteratorOptions
+		opts.Prefix = prefix
+		it := txn.NewIterator(opts)
+		defer it.Close()
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			// The local chunk index can be very large (one entry per unique
+			// chunk); re-check cancellation per entry to stay responsive.
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			item := it.Item()
+			hash, err := hashFromLocalChunkKey(item.Key())
+			if err != nil {
+				return err
+			}
+			var loc block.LocalChunkLocation
+			if verr := item.Value(func(val []byte) error {
+				var decErr error
+				loc, decErr = decodeLocalChunkLocation(val)
+				return decErr
+			}); verr != nil {
+				return verr
+			}
+			entries = append(entries, entry{hash: hash, loc: loc})
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("badger WalkLocalLocations: %w", err)
+	}
+
+	for _, e := range entries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := fn(e.hash, e.loc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// hashFromLocalChunkKey decodes a li:{hex(hash)} key back into a ContentHash.
+func hashFromLocalChunkKey(key []byte) (block.ContentHash, error) {
+	hexHash := key[len(prefixLocalChunkIdx):]
+	raw, err := hex.DecodeString(string(hexHash))
+	if err != nil {
+		return block.ContentHash{}, fmt.Errorf("badger: decode local-chunk key %q: %w", key, err)
+	}
+	if len(raw) != len(block.ContentHash{}) {
+		return block.ContentHash{}, fmt.Errorf("badger: local-chunk key %q decodes to %d bytes", key, len(raw))
+	}
+	var h block.ContentHash
+	copy(h[:], raw)
+	return h, nil
+}
+
 // ============================================================================
 // CommitBlock — delegate to shared DefaultCommitBlock logic
 // ============================================================================

--- a/pkg/metadata/store/postgres/block_record_store.go
+++ b/pkg/metadata/store/postgres/block_record_store.go
@@ -226,6 +226,51 @@ func (s *PostgresMetadataStore) DeleteLocalLocation(ctx context.Context, hash bl
 	})
 }
 
+// WalkLocalLocations calls fn for every stored content-hash -> log-blob
+// location. Read-only; deliberately NOT part of the LocalChunkIndex interface —
+// the local block store discovers it via a narrow consumer-side interface to
+// re-seed crash-stranded unsynced logblob chunks on restart (Walk / ListUnsynced).
+func (s *PostgresMetadataStore) WalkLocalLocations(ctx context.Context, fn func(block.ContentHash, block.LocalChunkLocation) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	rows, err := s.query(ctx,
+		`SELECT hash, log_blob_id, raw_offset, raw_length FROM local_chunk_index`)
+	if err != nil {
+		return fmt.Errorf("postgres WalkLocalLocations: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		// The local chunk index can be very large (one row per unique chunk),
+		// so re-check cancellation per row to stay responsive during a full walk.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		var (
+			hashRaw   []byte
+			logBlobID string
+			rawOffset int64
+			rawLength int64
+		)
+		if err := rows.Scan(&hashRaw, &logBlobID, &rawOffset, &rawLength); err != nil {
+			return fmt.Errorf("postgres WalkLocalLocations scan: %w", err)
+		}
+		if len(hashRaw) != len(block.ContentHash{}) {
+			return fmt.Errorf("postgres WalkLocalLocations: malformed hash length %d", len(hashRaw))
+		}
+		var h block.ContentHash
+		copy(h[:], hashRaw)
+		if err := fn(h, block.LocalChunkLocation{
+			LogBlobID: logBlobID,
+			RawOffset: rawOffset,
+			RawLength: rawLength,
+		}); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
 // ============================================================================
 // CommitBlock
 // ============================================================================

--- a/pkg/metadata/store/sqlite/block_record_store.go
+++ b/pkg/metadata/store/sqlite/block_record_store.go
@@ -173,6 +173,38 @@ func (s *SQLiteMetadataStore) DeleteLocalLocation(ctx context.Context, hash bloc
 	return nil
 }
 
+// WalkLocalLocations calls fn for every stored content-hash -> log-blob
+// location. Read-only; deliberately NOT part of the LocalChunkIndex interface —
+// the local block store discovers it via a narrow consumer-side interface to
+// re-seed crash-stranded unsynced logblob chunks on restart (Walk / ListUnsynced).
+// Streams rows on the pool path, mirroring WalkBlockRecords.
+func (s *SQLiteMetadataStore) WalkLocalLocations(ctx context.Context, fn func(block.ContentHash, block.LocalChunkLocation) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	rows, err := s.query(ctx,
+		`SELECT hash, log_blob_id, raw_offset, raw_length FROM local_chunk_index`)
+	if err != nil {
+		return fmt.Errorf("sqlite local_chunk_index walk: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		// The local chunk index can be very large (one row per unique chunk),
+		// so re-check cancellation per row to stay responsive during a full walk.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		h, loc, err := scanLocalLocationRow(rows)
+		if err != nil {
+			return fmt.Errorf("sqlite local_chunk_index walk scan: %w", err)
+		}
+		if err := fn(h, loc); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
 // ============================================================================
 // CommitBlock (store-level, delegates to DefaultCommitBlock)
 // ============================================================================
@@ -398,6 +430,30 @@ func scanBlockRecordRow(rows scanRows) (block.BlockRecord, bool, error) {
 		LiveChunkCount: liveCount,
 		SyncState:      block.BlockState(syncState),
 	}, true, nil
+}
+
+// scanLocalLocationRow scans a streaming Rows cursor (from WalkLocalLocations),
+// including the hash key column. The caller drives rows.Next().
+func scanLocalLocationRow(rows scanRows) (block.ContentHash, block.LocalChunkLocation, error) {
+	var (
+		hashRaw   []byte
+		logBlobID string
+		rawOffset int64
+		rawLength int64
+	)
+	if err := rows.Scan(&hashRaw, &logBlobID, &rawOffset, &rawLength); err != nil {
+		return block.ContentHash{}, block.LocalChunkLocation{}, err
+	}
+	if len(hashRaw) != len(block.ContentHash{}) {
+		return block.ContentHash{}, block.LocalChunkLocation{}, fmt.Errorf("sqlite scanLocalLocationRow: malformed hash length %d", len(hashRaw))
+	}
+	var h block.ContentHash
+	copy(h[:], hashRaw)
+	return h, block.LocalChunkLocation{
+		LogBlobID: logBlobID,
+		RawOffset: rawOffset,
+		RawLength: rawLength,
+	}, nil
 }
 
 // scanLocalLocation scans a single-row query result into a LocalChunkLocation.

--- a/pkg/metadata/storetest/local_index_ops.go
+++ b/pkg/metadata/storetest/local_index_ops.go
@@ -85,4 +85,74 @@ func runLocalIndexOps(t *testing.T, store metadata.Store) {
 			t.Fatal("GetLocalLocation(missing) found = true, want false")
 		}
 	})
+
+	// WalkEnumeratesAll guards the restart-seed path: FSStore.Walk /
+	// ListUnsynced discover logblob-resident chunks by type-asserting the
+	// LocalChunkIndex to this exact walker capability. A production backend
+	// that fails to implement it silently drops crash-stranded unsynced chunks
+	// from re-seeding, so this FAILS (not skips) when the method is absent.
+	//
+	// The suite shares one store across subtests, so the walk legitimately
+	// contains entries from earlier cases — this asserts SUPERSET semantics, not
+	// exact-set equality: every location we Put here is enumerated with the
+	// correct value, each hash is yielded at most once, and a deleted entry is
+	// never surfaced. It does not couple to any other subtest's contents.
+	t.Run("WalkEnumeratesAll", func(t *testing.T) {
+		walker, ok := store.(interface {
+			WalkLocalLocations(context.Context, func(block.ContentHash, block.LocalChunkLocation) error) error
+		})
+		if !ok {
+			t.Fatalf("%T does not implement WalkLocalLocations — restart-seed of unsynced logblob chunks is broken on this backend", store)
+		}
+
+		want := map[block.ContentHash]block.LocalChunkLocation{
+			{0xA1}: {LogBlobID: "walk-blob-1", RawOffset: 0, RawLength: 128},
+			{0xA2}: {LogBlobID: "walk-blob-2", RawOffset: 128, RawLength: 256},
+			{0xA3}: {LogBlobID: "walk-blob-3", RawOffset: 384, RawLength: 512},
+		}
+		for h, l := range want {
+			if err := store.PutLocalLocation(ctx, h, l); err != nil {
+				t.Fatalf("PutLocalLocation(%x) error = %v", h, err)
+			}
+		}
+
+		// Sentinel: put then delete — the walk must NOT surface it (proves Walk
+		// honors deletes, not just accumulates every hash ever written).
+		deleted := block.ContentHash{0xA4}
+		if err := store.PutLocalLocation(ctx, deleted, block.LocalChunkLocation{LogBlobID: "walk-blob-deleted", RawLength: 64}); err != nil {
+			t.Fatalf("PutLocalLocation(sentinel) error = %v", err)
+		}
+		if err := store.DeleteLocalLocation(ctx, deleted); err != nil {
+			t.Fatalf("DeleteLocalLocation(sentinel) error = %v", err)
+		}
+
+		got := make(map[block.ContentHash]block.LocalChunkLocation)
+		seen := make(map[block.ContentHash]int)
+		if err := walker.WalkLocalLocations(ctx, func(h block.ContentHash, l block.LocalChunkLocation) error {
+			got[h] = l
+			seen[h]++
+			return nil
+		}); err != nil {
+			t.Fatalf("WalkLocalLocations() error = %v", err)
+		}
+
+		for h, n := range seen {
+			if n > 1 {
+				t.Errorf("WalkLocalLocations() enumerated hash %x %d times, want at most 1", h, n)
+			}
+		}
+		if _, ok := got[deleted]; ok {
+			t.Errorf("WalkLocalLocations() surfaced deleted hash %x", deleted)
+		}
+		for h, l := range want {
+			g, ok := got[h]
+			if !ok {
+				t.Errorf("WalkLocalLocations() did not enumerate hash %x", h)
+				continue
+			}
+			if g != l {
+				t.Errorf("WalkLocalLocations()[%x] = %+v, want %+v", h, g, l)
+			}
+		}
+	})
 }


### PR DESCRIPTION
## Problem

The restart-seed of crash-stranded unsynced chunks was broken on **every production metadata backend** (sqlite, postgres, badger).

Local chunks live in a logblob append-log; a `LocalChunkIndex` maps content-hash → `block.LocalChunkLocation`. `FSStore.Walk` (pkg/block/local/fs/blockstore_methods.go) enumerates logblob-resident chunks by type-asserting the index to a narrow, consumer-defined interface:

```go
type localChunkWalker interface {
    WalkLocalLocations(ctx context.Context, fn func(block.ContentHash, block.LocalChunkLocation) error) error
}
walker, ok := bc.localChunkIndex.(localChunkWalker)
if !ok { return nil } // silently skips the index
```

Only the **memory** backend implemented `WalkLocalLocations`. On sqlite/postgres/badger the assertion failed, so:

- `FSStore.Walk` silently skipped every logblob-resident chunk,
- `FSStore.ListUnsynced` returned nothing,
- `Syncer.seedPendingFromDisk` (called from `Start` and `maintenanceLoop`) never re-enqueued crash-stranded unsynced chunks.

Those chunks were only ever carved/uploaded if the same content was written again. On a real backend after a crash, unsynced data could sit local-only indefinitely.

## Fix

Implement `WalkLocalLocations(ctx, fn)` on `SQLiteMetadataStore`, `PostgresMetadataStore`, and `BadgerMetadataStore`, so the type-assertion succeeds and the restart-seed path enumerates the local chunk index.

- sqlite / postgres stream rows from `local_chunk_index` (mirrors each backend's existing `WalkBlockRecords`).
- badger collects entries under a read-only `db.View`, then invokes `fn` outside the iterator (never runs the callback with a Badger iterator/txn open).
- Read-only; no write txn is held while `fn` runs; no store-lock deadlock.

The method is deliberately kept **off** the `LocalChunkIndex` interface — the consumer-side `localChunkWalker` type-assertion stays the contract, matching the codebase convention of minimizing interface surface (same as the memory backend).

## Tests

- **Conformance** (`pkg/metadata/storetest/local_index_ops.go`): new `WalkEnumeratesAll` case type-asserts the store to the walker capability and **fails** (not skips) if a production backend lacks it, then asserts the walk enumerates exactly the Put set. Runs against every backend via the shared suite — the guard for all three.
- **Regression** (`pkg/block/local/fs/restart_seed_sqlite_test.go`): an `FSStore` backed by a real sqlite `LocalChunkIndex` with unsynced logblob chunks — `ListUnsynced` now returns them (returned nothing before this change).

Local runs: `go build ./...`, `go vet`, `golangci-lint run` (0 issues), `go test ./pkg/metadata/... ./pkg/block/...` (3540 pass), `go test -race ./pkg/metadata/storetest/...`. Postgres conformance requires a live DB and was not exercised locally, but the sqlite/badger/memory conformance runs cover the same shared suite.

Prerequisite commit for the #1493 PR5 reconcile series. Refs #1493, #1525.