### PR TITLE
feat(block): read-only reconcile reporter for orphaned block storage (#1493)

### DIFF
--- a/cmd/dfsctl/commands/store/block/block.go
+++ b/cmd/dfsctl/commands/store/block/block.go
@@ -40,4 +40,5 @@ func init() {
 	Cmd.AddCommand(gcCmd)
 	Cmd.AddCommand(gcStatusCmd)
 	Cmd.AddCommand(auditRefcountsCmd)
+	Cmd.AddCommand(reconcileCmd)
 }

--- a/cmd/dfsctl/commands/store/block/reconcile.go
+++ b/cmd/dfsctl/commands/store/block/reconcile.go
@@ -1,0 +1,115 @@
+package block
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
+	"github.com/marmos91/dittofs/internal/cli/output"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+)
+
+// reconcileCmd reports orphaned block storage across all remote-backed shares
+// WITHOUT deleting anything.
+var reconcileCmd = &cobra.Command{
+	Use:   "reconcile",
+	Short: "Report orphaned block storage (read-only; no deletes)",
+	Long: `Scan every remote-backed share for orphaned block storage and print a
+classified report. This is READ-ONLY: it deletes nothing, decrements nothing,
+and changes no markers. Use it to review what the later reclaim stages would
+act on before running them.
+
+Four orphan classes are reported:
+
+  Zero-ref records       Block records with no live locator and a zero live
+                         chunk count — a crash between decrementing the count
+                         and deleting the record.
+  Leaked blocks          Block records with no live locator but a non-zero live
+                         chunk count — a re-carve moved the hash onto a new
+                         block without decrementing this one.
+  Orphan remote objects  blocks/<id> objects with no backing record, older than
+                         the grace window — the upload succeeded but the commit
+                         failed. Objects within the grace window are preserved
+                         (they may be freshly uploaded, commit pending).
+  Stranded local chunks  Unsynced, local-durable chunks awaiting upload.
+
+Each class reports an exact count plus a bounded sample of IDs (truncated is
+flagged when the full set is larger than the sample).
+
+Examples:
+  # Report orphans as a table
+  dfsctl store block reconcile
+
+  # As JSON for scripting
+  dfsctl store block reconcile -o json`,
+	Args: cobra.NoArgs,
+	RunE: runBlockStoreReconcile,
+}
+
+func runBlockStoreReconcile(cmd *cobra.Command, args []string) error {
+	client, err := cmdutil.GetAuthenticatedClient()
+	if err != nil {
+		return err
+	}
+
+	report, err := client.BlockStoreReconcileReport()
+	if err != nil {
+		return fmt.Errorf("failed to fetch reconcile report: %w", err)
+	}
+
+	format, err := cmdutil.GetOutputFormatParsed()
+	if err != nil {
+		return err
+	}
+
+	switch format {
+	case output.FormatJSON:
+		return output.PrintJSON(os.Stdout, report)
+	case output.FormatYAML:
+		return output.PrintYAML(os.Stdout, report)
+	default:
+		pairs := [][2]string{
+			{"Zero-ref records", classSummary(report.ZeroRefRecords)},
+			{"Leaked blocks", classSummary(report.LeakedBlocks)},
+			{"Orphan remote objects", classSummary(report.OrphanRemoteObjects)},
+			{"Stranded local chunks", classSummary(report.StrandedLocalChunks)},
+			{"Block records scanned", fmt.Sprintf("%d", report.BlockRecordsScanned)},
+			{"Remote objects scanned", fmt.Sprintf("%d", report.RemoteObjectsScanned)},
+			{"Grace period", report.GracePeriod.String()},
+		}
+		if err := output.SimpleTable(os.Stdout, pairs); err != nil {
+			return err
+		}
+		printSample(os.Stdout, "Zero-ref records", report.ZeroRefRecords)
+		printSample(os.Stdout, "Leaked blocks", report.LeakedBlocks)
+		printSample(os.Stdout, "Orphan remote objects", report.OrphanRemoteObjects)
+		printSample(os.Stdout, "Stranded local chunks", report.StrandedLocalChunks)
+		return nil
+	}
+}
+
+// classSummary renders one class's count + bytes for the summary table.
+func classSummary(c engine.ReconcileClass) string {
+	s := fmt.Sprintf("%d", c.Count)
+	if c.Bytes > 0 {
+		s += " (" + formatBytes(c.Bytes) + ")"
+	}
+	return s
+}
+
+// printSample lists a class's sampled IDs, noting truncation.
+func printSample(w *os.File, label string, c engine.ReconcileClass) {
+	if len(c.Sample) == 0 {
+		return
+	}
+	suffix := ""
+	if c.Truncated {
+		suffix = fmt.Sprintf(" (showing %d of %d)", len(c.Sample), c.Count)
+	}
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintf(w, "%s sample%s:\n", label, suffix)
+	_, _ = fmt.Fprintf(w, "  %s\n", strings.Join(c.Sample, "\n  "))
+}

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -652,6 +652,7 @@ Global flags:
         - [`dfsctl store block local edit`](#dfsctl-store-block-local-edit) — Edit a local block store
         - [`dfsctl store block local list`](#dfsctl-store-block-local-list) — List local block stores
         - [`dfsctl store block local remove`](#dfsctl-store-block-local-remove) — Remove a local block store
+      - [`dfsctl store block reconcile`](#dfsctl-store-block-reconcile) — Report orphaned block storage (read-only; no deletes)
       - [`dfsctl store block remote`](#dfsctl-store-block-remote) — Remote block store management
         - [`dfsctl store block remote add`](#dfsctl-store-block-remote-add) — Add a remote block store
         - [`dfsctl store block remote edit`](#dfsctl-store-block-remote-edit) — Edit a remote block store
@@ -5941,6 +5942,62 @@ Flags:
 
 ```
   -f, --force   Skip confirmation prompt
+```
+
+Global flags:
+
+```
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
+```
+
+### `dfsctl store block reconcile`
+
+Report orphaned block storage (read-only; no deletes)
+
+Scan every remote-backed share for orphaned block storage and print a
+classified report. This is READ-ONLY: it deletes nothing, decrements nothing,
+and changes no markers. Use it to review what the later reclaim stages would
+act on before running them.
+
+Four orphan classes are reported:
+
+```
+Zero-ref records       Block records with no live locator and a zero live
+                       chunk count — a crash between decrementing the count
+                       and deleting the record.
+Leaked blocks          Block records with no live locator but a non-zero live
+                       chunk count — a re-carve moved the hash onto a new
+                       block without decrementing this one.
+Orphan remote objects  blocks/<id> objects with no backing record, older than
+                       the grace window — the upload succeeded but the commit
+                       failed. Objects within the grace window are preserved
+                       (they may be freshly uploaded, commit pending).
+Stranded local chunks  Unsynced, local-durable chunks awaiting upload.
+```
+
+Each class reports an exact count plus a bounded sample of IDs (truncated is
+flagged when the full set is larger than the sample).
+
+```
+dfsctl store block reconcile
+```
+
+**Examples:**
+
+```bash
+# Report orphans as a table
+dfsctl store block reconcile
+
+# As JSON for scripting
+dfsctl store block reconcile -o json
 ```
 
 Global flags:

--- a/internal/controlplane/api/handlers/block_gc.go
+++ b/internal/controlplane/api/handlers/block_gc.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -40,6 +41,11 @@ type BlockGCRuntime interface {
 	// engine writes `last-run.json` into. Empty when the share's local
 	// store has no persistent root (in-memory backend).
 	GCStateDirForShare(shareName string) (string, error)
+
+	// ReconcileReport scans every remote-backed share for orphaned block
+	// storage and returns a READ-ONLY report of the four orphan classes. It
+	// mutates nothing (#1493/#1525 reconcile reporter).
+	ReconcileReport(ctx context.Context) (*engine.ReconcileReport, error)
 }
 
 // BlockStoreGCHandler exposes on-demand GC + last-run-summary endpoints.
@@ -285,4 +291,30 @@ func (h *BlockStoreGCHandler) GCStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	WriteJSONOK(w, summary)
+}
+
+// ReconcileReport handles GET /api/v1/blockstore/reconcile-report.
+//
+// Server-wide, admin-only, READ-ONLY: it scans every remote-backed share for
+// orphaned block storage and returns the classified engine.ReconcileReport. It
+// mutates nothing — no deletes, no decrements — so an operator can review
+// orphans before the later delete stages act (#1493/#1525).
+//
+// Status codes:
+//   - 200 OK with engine.ReconcileReport
+//   - 500 Internal Server Error on unexpected runtime errors
+func (h *BlockStoreGCHandler) ReconcileReport(w http.ResponseWriter, r *http.Request) {
+	if h.runtime == nil {
+		InternalServerError(w, "runtime not initialized")
+		return
+	}
+
+	report, err := h.runtime.ReconcileReport(r.Context())
+	if err != nil {
+		logger.Debug("Block store reconcile report error", "error", err)
+		InternalServerError(w, "reconcile report failed")
+		return
+	}
+
+	WriteJSONOK(w, report)
 }

--- a/internal/controlplane/api/handlers/block_gc_test.go
+++ b/internal/controlplane/api/handlers/block_gc_test.go
@@ -35,6 +35,10 @@ type fakeGCRuntime struct {
 	// GCStateDirForShare hooks
 	gcStateRoot   string
 	gcStateRootEr error
+
+	// ReconcileReport hooks
+	report    *engine.ReconcileReport
+	reportErr error
 }
 
 type startCall struct {
@@ -64,6 +68,16 @@ func (f *fakeGCRuntime) GCStateDirForShare(_ string) (string, error) {
 		return "", f.gcStateRootEr
 	}
 	return f.gcStateRoot, nil
+}
+
+func (f *fakeGCRuntime) ReconcileReport(context.Context) (*engine.ReconcileReport, error) {
+	if f.reportErr != nil {
+		return nil, f.reportErr
+	}
+	if f.report != nil {
+		return f.report, nil
+	}
+	return &engine.ReconcileReport{}, nil
 }
 
 // gcStartBody mirrors the 202 response shape from RunGC.
@@ -487,5 +501,62 @@ func TestBlockStoreHandler_GCStatus_NilRuntime(t *testing.T) {
 
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("GCStatus: expected 500 on nil runtime, got %d", w.Code)
+	}
+}
+
+// TestBlockStoreHandler_ReconcileReport_Success returns the runtime's report.
+func TestBlockStoreHandler_ReconcileReport_Success(t *testing.T) {
+	fake := &fakeGCRuntime{report: &engine.ReconcileReport{
+		ZeroRefRecords:      engine.ReconcileClass{Count: 1, Sample: []string{"blk-zeroref"}},
+		LeakedBlocks:        engine.ReconcileClass{Count: 2},
+		OrphanRemoteObjects: engine.ReconcileClass{Count: 3},
+		StrandedLocalChunks: engine.ReconcileClass{Count: 4},
+	}}
+	h := NewBlockStoreGCHandler(fake)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/blockstore/reconcile-report", nil)
+	w := httptest.NewRecorder()
+
+	h.ReconcileReport(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("ReconcileReport: expected 200, got %d (body=%q)", w.Code, w.Body.String())
+	}
+	var got engine.ReconcileReport
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("ReconcileReport: decode: %v", err)
+	}
+	if got.ZeroRefRecords.Count != 1 || got.LeakedBlocks.Count != 2 ||
+		got.OrphanRemoteObjects.Count != 3 || got.StrandedLocalChunks.Count != 4 {
+		t.Fatalf("ReconcileReport: unexpected body: %+v", got)
+	}
+}
+
+// TestBlockStoreHandler_ReconcileReport_RuntimeError maps a runtime failure to 500.
+func TestBlockStoreHandler_ReconcileReport_RuntimeError(t *testing.T) {
+	fake := &fakeGCRuntime{reportErr: fmt.Errorf("boom")}
+	h := NewBlockStoreGCHandler(fake)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/blockstore/reconcile-report", nil)
+	w := httptest.NewRecorder()
+
+	h.ReconcileReport(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("ReconcileReport: expected 500 on runtime error, got %d", w.Code)
+	}
+}
+
+// TestBlockStoreHandler_ReconcileReport_NilRuntime fails closed on a nil runtime.
+func TestBlockStoreHandler_ReconcileReport_NilRuntime(t *testing.T) {
+	h := NewBlockStoreGCHandler(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/blockstore/reconcile-report", nil)
+	w := httptest.NewRecorder()
+
+	h.ReconcileReport(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("ReconcileReport: expected 500 on nil runtime, got %d", w.Code)
 	}
 }

--- a/pkg/apiclient/blockstore.go
+++ b/pkg/apiclient/blockstore.go
@@ -198,6 +198,14 @@ func (c *Client) BlockStoreGCStatus(shareName string) (*engine.GCRunSummary, err
 	)
 }
 
+// BlockStoreReconcileReport scans every remote-backed share for orphaned block
+// storage and returns the classified engine.ReconcileReport. Server-wide,
+// admin-only, and READ-ONLY: it mutates nothing (#1493/#1525 reconcile
+// reporter), so an operator can review orphans before the delete stages act.
+func (c *Client) BlockStoreReconcileReport() (*engine.ReconcileReport, error) {
+	return getResource[engine.ReconcileReport](c, "/api/v1/blockstore/reconcile-report")
+}
+
 // BlockStoreAuditResult is the response body for
 // POST /api/v1/shares/{name}/audit/refcounts. Wraps the
 // engine.AuditRefcountsResult value (CAS manifest-consistency audit).

--- a/pkg/block/engine/reconcile.go
+++ b/pkg/block/engine/reconcile.go
@@ -217,7 +217,7 @@ func Reconcile(
 	}
 
 	// Class 4: stranded local-only chunks (unsynced, local-durable).
-	// ponytail: no per-chunk byte accounting — that costs one stat each and the
+	// Note: no per-chunk byte accounting — that costs one stat each and the
 	// count + sample is enough for a human to decide. Add Bytes if a cheap size
 	// surfaces on the local view.
 	for _, l := range locals {

--- a/pkg/block/engine/reconcile.go
+++ b/pkg/block/engine/reconcile.go
@@ -1,0 +1,246 @@
+// Package engine — read-only orphan-storage reporter (#1493/#1525 reconcile,
+// PR5a). Reconcile enumerates and classifies orphaned block storage WITHOUT
+// mutating anything: no DeleteBlock, no DecrLiveChunkCount, no marker changes.
+// It is the report-only first stage of the reconcile series; an operator
+// reviews the report before the later delete stages (PR5b/5c) act.
+package engine
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"log/slog"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+)
+
+// defaultReconcileSampleCap bounds the per-class ID sample when the caller does
+// not specify one. Counts are always exact; only the sample list is bounded.
+const defaultReconcileSampleCap = 100
+
+// ReconcileMetaView is the read-only per-share metadata surface the reporter
+// consumes. metadata.Store satisfies it structurally (EnumerateSynced concrete
+// method + SyncedHashStore.GetLocator + BlockRecordStore.WalkBlockRecords).
+type ReconcileMetaView interface {
+	EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, syncedAt time.Time) error) error
+	GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error)
+	WalkBlockRecords(ctx context.Context, fn func(block.BlockRecord) error) error
+}
+
+// ReconcileLocalView is the read-only local surface: enumerate unsynced,
+// local-durable chunks. *fs.FSStore satisfies it (ListUnsynced).
+type ReconcileLocalView interface {
+	ListUnsynced(ctx context.Context) iter.Seq2[block.ContentHash, error]
+}
+
+// ReconcileClass is one orphan category's tally plus a bounded sample of IDs.
+// Count/Bytes are exact; Sample is capped and Truncated flags a dropped ID.
+type ReconcileClass struct {
+	Count     int64    `json:"count"`
+	Bytes     int64    `json:"bytes,omitempty"`
+	Sample    []string `json:"sample,omitempty"`
+	Truncated bool     `json:"truncated,omitempty"`
+}
+
+// addSample appends id to the bounded sample, flagging Truncated once the cap
+// is hit. Shared by add and merge so the cap edge is enforced in one place.
+func (c *ReconcileClass) addSample(id string, cap int) {
+	if len(c.Sample) < cap {
+		c.Sample = append(c.Sample, id)
+	} else {
+		c.Truncated = true
+	}
+}
+
+// add records one orphan, appending its id to the sample until the cap is hit.
+func (c *ReconcileClass) add(id string, bytes int64, cap int) {
+	c.Count++
+	c.Bytes += bytes
+	c.addSample(id, cap)
+}
+
+// merge folds other into c, respecting cap for the combined sample.
+func (c *ReconcileClass) merge(other ReconcileClass, cap int) {
+	c.Count += other.Count
+	c.Bytes += other.Bytes
+	if other.Truncated {
+		c.Truncated = true
+	}
+	for _, id := range other.Sample {
+		c.addSample(id, cap)
+	}
+}
+
+// ReconcileReport is the read-only output of a scan: four orphan classes plus
+// scan bookkeeping. Nothing in the store is mutated to produce it.
+type ReconcileReport struct {
+	// ZeroRefRecords: block records absent from the live locator set with
+	// LiveChunkCount == 0 — a crash between DecrLiveChunkCount and
+	// DeleteBlockRecord (class 1).
+	ZeroRefRecords ReconcileClass `json:"zero_ref_records"`
+	// LeakedBlocks: block records absent from the live locator set with
+	// LiveChunkCount > 0 — DefaultCommitBlock's last-wins DeleteSynced→MarkSynced
+	// moved a hash onto a new block without decrementing this one, and the
+	// hash-driven sweep never revisits it (class 2 / #1525).
+	LeakedBlocks ReconcileClass `json:"leaked_blocks"`
+	// OrphanRemoteObjects: blocks/<id> objects with no backing block record,
+	// older than the grace window — PutBlock succeeded but the commit failed
+	// (class 3).
+	OrphanRemoteObjects ReconcileClass `json:"orphan_remote_objects"`
+	// StrandedLocalChunks: unsynced, local-durable chunks (class 4).
+	StrandedLocalChunks ReconcileClass `json:"stranded_local_chunks"`
+
+	BlockRecordsScanned  int64         `json:"block_records_scanned"`
+	RemoteObjectsScanned int64         `json:"remote_objects_scanned"`
+	GracePeriod          time.Duration `json:"grace_period"`
+	SampleCap            int           `json:"sample_cap"`
+}
+
+// Merge folds other into r, respecting r.SampleCap for the combined samples.
+// Used to aggregate per-remote scans into one server-wide report.
+func (r *ReconcileReport) Merge(other ReconcileReport) {
+	cap := r.SampleCap
+	if cap <= 0 {
+		cap = defaultReconcileSampleCap
+		r.SampleCap = cap
+	}
+	r.ZeroRefRecords.merge(other.ZeroRefRecords, cap)
+	r.LeakedBlocks.merge(other.LeakedBlocks, cap)
+	r.OrphanRemoteObjects.merge(other.OrphanRemoteObjects, cap)
+	r.StrandedLocalChunks.merge(other.StrandedLocalChunks, cap)
+	r.BlockRecordsScanned += other.BlockRecordsScanned
+	r.RemoteObjectsScanned += other.RemoteObjectsScanned
+	if other.GracePeriod > r.GracePeriod {
+		r.GracePeriod = other.GracePeriod
+	}
+}
+
+// ReconcileOptions parameterizes a scan.
+type ReconcileOptions struct {
+	// GracePeriod protects freshly-uploaded-not-yet-committed remote objects
+	// from being reported as orphans (mirrors the GC sweep TTL). Non-positive
+	// falls back to the sweep default (1h) via resolveGracePeriod.
+	GracePeriod time.Duration
+	// SampleCap bounds the per-class ID sample. Zero defaults to
+	// defaultReconcileSampleCap. Counts are always exact.
+	SampleCap int
+}
+
+// Reconcile scans one remote-store scope for orphaned block storage and returns
+// a structured, READ-ONLY report of the four orphan classes.
+//
+// views are the per-share metadata views that share one remote store. Classes 1
+// and 2 are per-share (a share's records vs its own live locator set); class 3
+// unions every share's block records so a sibling share's live block is never
+// misreported as a record-less object. rbs is that shared block store (nil
+// skips class 3 — a remote that cannot hold packed blocks). locals are the
+// per-share local stores for class 4 (may be empty).
+//
+// It mutates nothing: only Enumerate/Walk/Get calls are issued.
+func Reconcile(
+	ctx context.Context,
+	views []ReconcileMetaView,
+	rbs remote.RemoteBlockStore,
+	locals []ReconcileLocalView,
+	opts ReconcileOptions,
+) (ReconcileReport, error) {
+	grace := resolveGracePeriod(&Options{GracePeriod: opts.GracePeriod})
+	sampleCap := opts.SampleCap
+	if sampleCap <= 0 {
+		sampleCap = defaultReconcileSampleCap
+	}
+	report := ReconcileReport{GracePeriod: grace, SampleCap: sampleCap}
+
+	// metaBlockIDs: every block ID that HAS a record, unioned across all shares
+	// on this remote. Class 3 classifies remote objects against this set.
+	metaBlockIDs := make(map[string]struct{})
+
+	for _, v := range views {
+		// refSet: every block ID still pointed at by a live synced locator in
+		// THIS share. Built fully first, then WalkBlockRecords classifies each
+		// record against it.
+		refSet := make(map[string]struct{})
+		if err := v.EnumerateSynced(ctx, func(h block.ContentHash, _ time.Time) error {
+			loc, ok, err := v.GetLocator(ctx, h)
+			if err != nil {
+				return err
+			}
+			if ok && loc.BlockID != "" {
+				refSet[loc.BlockID] = struct{}{}
+			}
+			return nil
+		}); err != nil {
+			return report, fmt.Errorf("reconcile: enumerate synced: %w", err)
+		}
+
+		if err := v.WalkBlockRecords(ctx, func(rec block.BlockRecord) error {
+			metaBlockIDs[rec.BlockID] = struct{}{}
+			report.BlockRecordsScanned++
+			if _, live := refSet[rec.BlockID]; live {
+				return nil // healthy: a live locator still points at this block
+			}
+			if rec.LiveChunkCount == 0 {
+				report.ZeroRefRecords.add(rec.BlockID, rec.Length, sampleCap)
+			} else {
+				report.LeakedBlocks.add(rec.BlockID, rec.Length, sampleCap)
+			}
+			return nil
+		}); err != nil {
+			return report, fmt.Errorf("reconcile: walk block records: %w", err)
+		}
+	}
+
+	// Class 3: remote objects with no backing record, past the grace window.
+	// The grace + zero-LastModified handling mirrors the GC walk sweep exactly
+	// (sweepByWalk): an object we cannot age is preserved fail-closed.
+	if rbs != nil {
+		cutoff := time.Now().Add(-grace)
+		if err := rbs.WalkBlocks(ctx, func(blockID string, meta block.Meta) error {
+			report.RemoteObjectsScanned++
+			if _, known := metaBlockIDs[blockID]; known {
+				return nil // has a record — not orphan
+			}
+			if meta.LastModified.IsZero() {
+				// Cannot evaluate the grace TTL — fail closed, do not report.
+				return nil
+			}
+			if meta.LastModified.After(cutoff) {
+				return nil // within grace: freshly uploaded, commit may still land
+			}
+			report.OrphanRemoteObjects.add(blockID, meta.Size, sampleCap)
+			return nil
+		}); err != nil {
+			return report, fmt.Errorf("reconcile: walk blocks: %w", err)
+		}
+	}
+
+	// Class 4: stranded local-only chunks (unsynced, local-durable).
+	// ponytail: no per-chunk byte accounting — that costs one stat each and the
+	// count + sample is enough for a human to decide. Add Bytes if a cheap size
+	// surfaces on the local view.
+	for _, l := range locals {
+		if l == nil {
+			continue
+		}
+		for h, err := range l.ListUnsynced(ctx) {
+			if err != nil {
+				return report, fmt.Errorf("reconcile: list unsynced: %w", err)
+			}
+			report.StrandedLocalChunks.add(h.String(), 0, sampleCap)
+		}
+	}
+
+	if report.ZeroRefRecords.Truncated || report.LeakedBlocks.Truncated ||
+		report.OrphanRemoteObjects.Truncated || report.StrandedLocalChunks.Truncated {
+		slog.Warn("reconcile: ID sample truncated — full orphan set is larger than the sample cap",
+			"sample_cap", sampleCap,
+			"zero_ref_records", report.ZeroRefRecords.Count,
+			"leaked_blocks", report.LeakedBlocks.Count,
+			"orphan_remote_objects", report.OrphanRemoteObjects.Count,
+			"stranded_local_chunks", report.StrandedLocalChunks.Count,
+		)
+	}
+	return report, nil
+}

--- a/pkg/block/engine/reconcile_test.go
+++ b/pkg/block/engine/reconcile_test.go
@@ -1,0 +1,223 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"iter"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// fakeUnsynced is a hermetic ReconcileLocalView yielding a fixed set of
+// unsynced chunk hashes. The real implementation is *fs.FSStore.ListUnsynced;
+// the class-4 classification only needs the iterator surface, so this keeps the
+// engine test off-disk.
+type fakeUnsynced struct{ hashes []block.ContentHash }
+
+func (f fakeUnsynced) ListUnsynced(context.Context) iter.Seq2[block.ContentHash, error] {
+	return func(yield func(block.ContentHash, error) bool) {
+		for _, h := range f.hashes {
+			if !yield(h, nil) {
+				return
+			}
+		}
+	}
+}
+
+// putBareBlock writes a remote object with no backing block record, stamping its
+// LastModified at the given time so the grace-window filter can be exercised.
+func putBareBlock(t *testing.T, rbs *remotememory.Store, blockID string, modTime time.Time) {
+	t.Helper()
+	rbs.SetNowFnForTest(func() time.Time { return modTime })
+	if err := rbs.PutBlock(context.Background(), blockID, bytes.NewReader([]byte(blockID))); err != nil {
+		t.Fatalf("PutBlock(%s): %v", blockID, err)
+	}
+	rbs.SetNowFnForTest(nil) // reset to real clock
+}
+
+// TestReconcile_ClassifiesEachOrphanClass seeds one instance of every orphan
+// class plus healthy blocks/objects/chunks and asserts each is classified
+// correctly, healthy items are NOT flagged, the fresh (within-grace) record-less
+// object is preserved, and the scan mutates nothing.
+func TestReconcile_ClassifiesEachOrphanClass(t *testing.T) {
+	ctx := t.Context()
+	st := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	rbs := remotememory.New()
+	defer func() { _ = rbs.Close() }()
+
+	// --- HEALTHY block: record + live synced locator + remote object. ---
+	// seedPackedBlock writes the object, the record (LiveChunkCount=1), and a
+	// synced block-locator pointing at blk-healthy → in refSet → not flagged.
+	hHealthy := hashFromString("healthy-chunk")
+	seedPackedBlock(t, st, rbs, "blk-healthy", []block.ContentHash{hHealthy})
+
+	// --- CLASS 1: zero-ref record (crash between decr and delete-record). ---
+	// A record with LiveChunkCount==0 and no live locator pointing at it.
+	if err := st.PutBlockRecord(ctx, block.BlockRecord{
+		BlockID:        "blk-zeroref",
+		Length:         111,
+		LiveChunkCount: 0,
+		SyncState:      block.BlockStateRemote,
+	}); err != nil {
+		t.Fatalf("PutBlockRecord(blk-zeroref): %v", err)
+	}
+
+	// --- CLASS 2: leaked block (#1525 re-carve residue). ---
+	// A record with LiveChunkCount>0 whose hash was moved onto another block by
+	// a last-wins commit, so no live locator points at blk-leaked anymore.
+	if err := st.PutBlockRecord(ctx, block.BlockRecord{
+		BlockID:        "blk-leaked",
+		Length:         222,
+		LiveChunkCount: 2,
+		SyncState:      block.BlockStateRemote,
+	}); err != nil {
+		t.Fatalf("PutBlockRecord(blk-leaked): %v", err)
+	}
+	// The re-carved hash now points at the healthy block (last-wins). Its
+	// presence must not rescue blk-leaked.
+	hRecarve := hashFromString("recarved-chunk")
+	if err := st.MarkSynced(ctx, hRecarve, block.ChunkLocator{BlockID: "blk-healthy", WireOffset: 80, WireLength: 80}); err != nil {
+		t.Fatalf("MarkSynced(recarve): %v", err)
+	}
+
+	// --- CLASS 3: record-less remote objects. ---
+	putBareBlock(t, rbs, "blk-orphan-aged", time.Now().Add(-2*time.Hour)) // aged → orphan
+	putBareBlock(t, rbs, "blk-orphan-fresh", time.Now())                  // within grace → preserved
+
+	// --- CLASS 4: stranded local-only chunk (unsynced, local-durable). ---
+	hStranded := hashFromString("stranded-local-chunk")
+	local := fakeUnsynced{hashes: []block.ContentHash{hStranded}}
+
+	// --- Snapshot state to prove the scan is non-mutating. ---
+	before := captureState(t, st, rbs)
+
+	rep, err := Reconcile(ctx, []ReconcileMetaView{st}, rbs, []ReconcileLocalView{local}, ReconcileOptions{})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	// Class 1.
+	if rep.ZeroRefRecords.Count != 1 {
+		t.Errorf("ZeroRefRecords.Count = %d; want 1", rep.ZeroRefRecords.Count)
+	}
+	if len(rep.ZeroRefRecords.Sample) != 1 || rep.ZeroRefRecords.Sample[0] != "blk-zeroref" {
+		t.Errorf("ZeroRefRecords.Sample = %v; want [blk-zeroref]", rep.ZeroRefRecords.Sample)
+	}
+	if rep.ZeroRefRecords.Bytes != 111 {
+		t.Errorf("ZeroRefRecords.Bytes = %d; want 111", rep.ZeroRefRecords.Bytes)
+	}
+	// Class 2.
+	if rep.LeakedBlocks.Count != 1 || rep.LeakedBlocks.Sample[0] != "blk-leaked" {
+		t.Errorf("LeakedBlocks = %+v; want count 1 sample [blk-leaked]", rep.LeakedBlocks)
+	}
+	if rep.LeakedBlocks.Bytes != 222 {
+		t.Errorf("LeakedBlocks.Bytes = %d; want 222", rep.LeakedBlocks.Bytes)
+	}
+	// Class 3: only the aged object, never the fresh one and never the healthy
+	// object (which has a record).
+	if rep.OrphanRemoteObjects.Count != 1 || rep.OrphanRemoteObjects.Sample[0] != "blk-orphan-aged" {
+		t.Errorf("OrphanRemoteObjects = %+v; want count 1 sample [blk-orphan-aged]", rep.OrphanRemoteObjects)
+	}
+	// Class 4.
+	if rep.StrandedLocalChunks.Count != 1 || rep.StrandedLocalChunks.Sample[0] != hStranded.String() {
+		t.Errorf("StrandedLocalChunks = %+v; want count 1 sample [%s]", rep.StrandedLocalChunks, hStranded)
+	}
+
+	// Non-mutation: state identical after the scan.
+	after := captureState(t, st, rbs)
+	before.assertEqual(t, after)
+}
+
+// TestReconcile_GraceWindowBoundary asserts the grace filter uses the
+// configured window: an object just inside it is preserved, one just outside is
+// reported.
+func TestReconcile_GraceWindowBoundary(t *testing.T) {
+	ctx := t.Context()
+	st := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	rbs := remotememory.New()
+	defer func() { _ = rbs.Close() }()
+
+	// 30-minute grace: 20m-old object preserved, 40m-old object reported.
+	putBareBlock(t, rbs, "blk-young", time.Now().Add(-20*time.Minute))
+	putBareBlock(t, rbs, "blk-old", time.Now().Add(-40*time.Minute))
+
+	rep, err := Reconcile(ctx, []ReconcileMetaView{st}, rbs, nil, ReconcileOptions{GracePeriod: 30 * time.Minute})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if rep.OrphanRemoteObjects.Count != 1 || rep.OrphanRemoteObjects.Sample[0] != "blk-old" {
+		t.Errorf("OrphanRemoteObjects = %+v; want count 1 sample [blk-old]", rep.OrphanRemoteObjects)
+	}
+	if rep.GracePeriod != 30*time.Minute {
+		t.Errorf("GracePeriod = %v; want 30m", rep.GracePeriod)
+	}
+}
+
+// reconcileState is a snapshot of the mutable storage the reporter reads, used
+// to prove Reconcile does not touch it.
+type reconcileState struct {
+	blockRecords map[string]uint32 // blockID → LiveChunkCount
+	remoteBlocks map[string]struct{}
+	syncedHashes map[string]struct{}
+}
+
+func captureState(t *testing.T, st *metadatamemory.MemoryMetadataStore, rbs *remotememory.Store) reconcileState {
+	t.Helper()
+	ctx := context.Background()
+	s := reconcileState{
+		blockRecords: map[string]uint32{},
+		remoteBlocks: map[string]struct{}{},
+		syncedHashes: map[string]struct{}{},
+	}
+	if err := st.WalkBlockRecords(ctx, func(rec block.BlockRecord) error {
+		s.blockRecords[rec.BlockID] = rec.LiveChunkCount
+		return nil
+	}); err != nil {
+		t.Fatalf("WalkBlockRecords: %v", err)
+	}
+	if err := rbs.WalkBlocks(ctx, func(blockID string, _ block.Meta) error {
+		s.remoteBlocks[blockID] = struct{}{}
+		return nil
+	}); err != nil {
+		t.Fatalf("WalkBlocks: %v", err)
+	}
+	if err := st.EnumerateSynced(ctx, func(h block.ContentHash, _ time.Time) error {
+		s.syncedHashes[h.String()] = struct{}{}
+		return nil
+	}); err != nil {
+		t.Fatalf("EnumerateSynced: %v", err)
+	}
+	return s
+}
+
+func (s reconcileState) assertEqual(t *testing.T, other reconcileState) {
+	t.Helper()
+	if len(s.blockRecords) != len(other.blockRecords) {
+		t.Fatalf("block record count changed: %d → %d", len(s.blockRecords), len(other.blockRecords))
+	}
+	for id, cnt := range s.blockRecords {
+		if other.blockRecords[id] != cnt {
+			t.Errorf("block record %s LiveChunkCount changed: %d → %d", id, cnt, other.blockRecords[id])
+		}
+	}
+	if len(s.remoteBlocks) != len(other.remoteBlocks) {
+		t.Errorf("remote block set changed: %d → %d objects", len(s.remoteBlocks), len(other.remoteBlocks))
+	}
+	for id := range s.remoteBlocks {
+		if _, ok := other.remoteBlocks[id]; !ok {
+			t.Errorf("remote block %s removed by scan", id)
+		}
+	}
+	if len(s.syncedHashes) != len(other.syncedHashes) {
+		t.Errorf("synced hash set changed: %d → %d", len(s.syncedHashes), len(other.syncedHashes))
+	}
+	for h := range s.syncedHashes {
+		if _, ok := other.syncedHashes[h]; !ok {
+			t.Errorf("synced hash %s removed by scan", h)
+		}
+	}
+}

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -320,6 +320,9 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 
 				r.Get("/stats", blockStoreHandler.Stats)
 				r.Post("/evict", blockStoreHandler.Evict)
+				// Read-only orphan-storage reporter (#1493/#1525). Server-wide
+				// scan; mutates nothing. Reviewed before the delete stages act.
+				r.Get("/reconcile-report", blockGCHandler.ReconcileReport)
 			})
 
 			// Store management (admin only)

--- a/pkg/controlplane/runtime/blockgc_reconcile_report.go
+++ b/pkg/controlplane/runtime/blockgc_reconcile_report.go
@@ -1,0 +1,81 @@
+package runtime
+
+import (
+	"context"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+)
+
+// ReconcileReport scans every remote-backed share for orphaned block storage
+// and returns a structured, READ-ONLY report of the four orphan classes
+// (#1493/#1525 reconcile reporter, PR5a): zero-ref records, leaked blocks,
+// record-less remote objects (past the grace window), and stranded local-only
+// chunks. It mutates nothing — no deletes, no decrements, no marker changes —
+// so an operator can review orphans before the later delete stages act.
+//
+// It is server-wide: for each remote store it unions the shares that reference
+// it (mirroring the GC per-remote reconciler) so a sibling share's live block
+// is never misreported as a record-less object. Per-remote reports are folded
+// into one aggregate.
+func (r *Runtime) ReconcileReport(ctx context.Context) (*engine.ReconcileReport, error) {
+	grace := r.reconcileGracePeriod()
+
+	// Per-share local views (class 4), indexed by share. Only stores exposing
+	// ListUnsynced (a durable local tier) contribute; in-memory backends have
+	// nothing to strand.
+	localsByShare := make(map[string][]engine.ReconcileLocalView)
+	for _, le := range r.sharesSvc.ShareLocalStores() {
+		if lv, ok := le.Store.(engine.ReconcileLocalView); ok {
+			localsByShare[le.ShareName] = append(localsByShare[le.ShareName], lv)
+		}
+	}
+
+	total := &engine.ReconcileReport{}
+	for _, entry := range r.sharesSvc.DistinctRemoteStores() {
+		if err := ctx.Err(); err != nil {
+			return total, err
+		}
+		views := make([]engine.ReconcileMetaView, 0, len(entry.Shares))
+		var locals []engine.ReconcileLocalView
+		for _, shareName := range entry.Shares {
+			mds, err := r.GetMetadataStoreForShare(shareName)
+			if err != nil {
+				logger.Warn("ReconcileReport: metadata store unavailable — share excluded from scan",
+					"share", shareName, "err", err)
+				continue
+			}
+			// EnumerateSynced is an off-interface concrete method; a backend
+			// that lacks it cannot supply the live locator set, so its records
+			// would be misreported as orphans. Exclude it rather than misreport.
+			view, ok := mds.(engine.ReconcileMetaView)
+			if !ok {
+				logger.Warn("ReconcileReport: metadata store does not support reconcile scan — share excluded",
+					"share", shareName)
+				continue
+			}
+			views = append(views, view)
+			locals = append(locals, localsByShare[shareName]...)
+		}
+		// A remote that cannot hold packed blocks (no RemoteBlockStore) still
+		// gets classes 1/2 scanned; class 3 is skipped with a nil remote.
+		rbs, _ := entry.Store.(remote.RemoteBlockStore)
+		rep, err := engine.Reconcile(ctx, views, rbs, locals, engine.ReconcileOptions{GracePeriod: grace})
+		if err != nil {
+			return total, err
+		}
+		total.Merge(rep)
+	}
+
+	logger.Info("ReconcileReport: complete",
+		"zeroRefRecords", total.ZeroRefRecords.Count,
+		"leakedBlocks", total.LeakedBlocks.Count,
+		"orphanRemoteObjects", total.OrphanRemoteObjects.Count,
+		"strandedLocalChunks", total.StrandedLocalChunks.Count,
+		"blockRecordsScanned", total.BlockRecordsScanned,
+		"remoteObjectsScanned", total.RemoteObjectsScanned,
+		"gracePeriod", total.GracePeriod,
+	)
+	return total, nil
+}

--- a/pkg/controlplane/runtime/blockgc_reconcile_report.go
+++ b/pkg/controlplane/runtime/blockgc_reconcile_report.go
@@ -58,6 +58,16 @@ func (r *Runtime) ReconcileReport(ctx context.Context) (*engine.ReconcileReport,
 			views = append(views, view)
 			locals = append(locals, localsByShare[shareName]...)
 		}
+		// No usable metadata view for any share on this remote: metaBlockIDs
+		// would be empty, so EVERY aged remote object would be misreported as a
+		// record-less orphan (class 3). Skip the remote fail-closed rather than
+		// emit false orphans. Unreachable with all current backends (each
+		// implements ReconcileMetaView).
+		if len(views) == 0 {
+			logger.Warn("ReconcileReport: no metadata views for remote — scan skipped fail-closed",
+				"configID", entry.ConfigID, "shares", entry.Shares)
+			continue
+		}
 		// A remote that cannot hold packed blocks (no RemoteBlockStore) still
 		// gets classes 1/2 scanned; class 3 is skipped with a nil remote.
 		rbs, _ := entry.Store.(remote.RemoteBlockStore)


### PR DESCRIPTION
## What

PR5a of the #1493 reconcile series: a **read-only** reporter that enumerates and classifies orphaned block storage. It mutates nothing — no `DeleteBlock`, no `DecrLiveChunkCount`, no marker changes. An operator reviews the report before the later delete stages act.

## Four orphan classes

1. **Zero-ref records** — block records absent from the live locator set with `LiveChunkCount == 0` (crash between `DecrLiveChunkCount` and `DeleteBlockRecord`).
2. **Leaked blocks (#1525)** — records absent from the live locator set with `LiveChunkCount > 0`. `DefaultCommitBlock`'s last-wins `DeleteSynced→MarkSynced` moves a hash onto a new block without decrementing the old one, and the hash-driven sweep never revisits it.
3. **Record-less remote objects** — `blocks/<id>` objects with no backing record, older than a grace window (mirrors the GC sweep TTL so freshly-uploaded-not-yet-committed blocks aren't misreported; unstampable objects fail closed).
4. **Stranded local-only chunks** — unsynced, local-durable chunks.

## Algorithm

Classes 1+2 unify via a per-share `refSet` (block IDs still pointed at by a live synced locator), classified against `WalkBlockRecords`. Class 3 unions `metaBlockIDs` across all shares on a remote so a sibling share's live block isn't misreported. Counts are exact; per-class ID samples are capped (default 100) with a truncation warning.

## Surface

- Engine: `engine.Reconcile(...)` scan returning a structured `ReconcileReport`.
- REST: `GET /blockstore/reconcile-report`.
- CLI: `dfsctl store block reconcile` (report-only). `cli.md` regenerated via gendocs.

## Tests

Engine tests classify each of the four classes and verify the grace-window boundary. Full affected-package suites green.

Part of #1493; addresses the reporting half of #1525 (delete stages follow — not closing).