### PR TITLE
feat(block): reclaim zero-ref block records (#1493 reconcile PR5b)

### DIFF
--- a/cmd/dfsctl/commands/store/block/block.go
+++ b/cmd/dfsctl/commands/store/block/block.go
@@ -41,4 +41,5 @@ func init() {
 	Cmd.AddCommand(gcStatusCmd)
 	Cmd.AddCommand(auditRefcountsCmd)
 	Cmd.AddCommand(reconcileCmd)
+	Cmd.AddCommand(reclaimCmd)
 }

--- a/cmd/dfsctl/commands/store/block/reclaim.go
+++ b/cmd/dfsctl/commands/store/block/reclaim.go
@@ -1,0 +1,89 @@
+package block
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
+	"github.com/marmos91/dittofs/internal/cli/output"
+	"github.com/marmos91/dittofs/pkg/apiclient"
+)
+
+// reclaimCmd deletes class-1 orphans (zero-ref block records) across all
+// remote-backed shares. It is the first deleting stage after `reconcile`.
+var reclaimCmd = &cobra.Command{
+	Use:   "reclaim",
+	Short: "Reclaim zero-ref block records (deletes; use --dry-run to preview)",
+	Long: `Delete class-1 orphaned block records across every remote-backed share and
+free their remote objects. A zero-ref record has no live locator and a zero live
+chunk count — left behind by a crash between decrementing the count and deleting
+the record. Such a record is terminally dead, so reclaiming it is safe with no
+grace window.
+
+This DELETES. Run 'dfsctl store block reconcile' first to review what exists, or
+pass --dry-run here to preview the exact set this command would delete without
+deleting anything.
+
+Examples:
+  # Preview what would be reclaimed
+  dfsctl store block reclaim --dry-run
+
+  # Reclaim zero-ref records
+  dfsctl store block reclaim
+
+  # As JSON for scripting
+  dfsctl store block reclaim -o json`,
+	Args: cobra.NoArgs,
+	RunE: runBlockStoreReclaim,
+}
+
+func init() {
+	reclaimCmd.Flags().Bool("dry-run", false, "Report the records that would be reclaimed without deleting anything")
+}
+
+func runBlockStoreReclaim(cmd *cobra.Command, args []string) error {
+	dryRun, err := cmd.Flags().GetBool("dry-run")
+	if err != nil {
+		return err
+	}
+
+	client, err := cmdutil.GetAuthenticatedClient()
+	if err != nil {
+		return err
+	}
+
+	report, err := client.BlockStoreReclaimZeroRef(&apiclient.BlockStoreReclaimZeroRefRequest{DryRun: dryRun})
+	if err != nil {
+		return fmt.Errorf("failed to reclaim zero-ref records: %w", err)
+	}
+
+	format, err := cmdutil.GetOutputFormatParsed()
+	if err != nil {
+		return err
+	}
+
+	switch format {
+	case output.FormatJSON:
+		return output.PrintJSON(os.Stdout, report)
+	case output.FormatYAML:
+		return output.PrintYAML(os.Stdout, report)
+	default:
+		verb := "Reclaimed"
+		if report.DryRun {
+			verb = "Would reclaim"
+		}
+		pairs := [][2]string{
+			{verb, classSummary(report.Reclaimed)},
+			{"Block records scanned", fmt.Sprintf("%d", report.BlockRecordsScanned)},
+			{"Errors", fmt.Sprintf("%d", report.Errors)},
+			{"Dry run", fmt.Sprintf("%t", report.DryRun)},
+		}
+		if err := output.SimpleTable(os.Stdout, pairs); err != nil {
+			return err
+		}
+		printSample(os.Stdout, verb, report.Reclaimed)
+		return nil
+	}
+}

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -652,6 +652,7 @@ Global flags:
         - [`dfsctl store block local edit`](#dfsctl-store-block-local-edit) — Edit a local block store
         - [`dfsctl store block local list`](#dfsctl-store-block-local-list) — List local block stores
         - [`dfsctl store block local remove`](#dfsctl-store-block-local-remove) — Remove a local block store
+      - [`dfsctl store block reclaim`](#dfsctl-store-block-reclaim) — Reclaim zero-ref block records (deletes; use --dry-run to preview)
       - [`dfsctl store block reconcile`](#dfsctl-store-block-reconcile) — Report orphaned block storage (read-only; no deletes)
       - [`dfsctl store block remote`](#dfsctl-store-block-remote) — Remote block store management
         - [`dfsctl store block remote add`](#dfsctl-store-block-remote-add) — Add a remote block store
@@ -5942,6 +5943,57 @@ Flags:
 
 ```
   -f, --force   Skip confirmation prompt
+```
+
+Global flags:
+
+```
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
+```
+
+### `dfsctl store block reclaim`
+
+Reclaim zero-ref block records (deletes; use --dry-run to preview)
+
+Delete class-1 orphaned block records across every remote-backed share and
+free their remote objects. A zero-ref record has no live locator and a zero live
+chunk count — left behind by a crash between decrementing the count and deleting
+the record. Such a record is terminally dead, so reclaiming it is safe with no
+grace window.
+
+This DELETES. Run 'dfsctl store block reconcile' first to review what exists, or
+pass --dry-run here to preview the exact set this command would delete without
+deleting anything.
+
+```
+dfsctl store block reclaim [flags]
+```
+
+**Examples:**
+
+```bash
+# Preview what would be reclaimed
+dfsctl store block reclaim --dry-run
+
+# Reclaim zero-ref records
+dfsctl store block reclaim
+
+# As JSON for scripting
+dfsctl store block reclaim -o json
+```
+
+Flags:
+
+```
+      --dry-run   Report the records that would be reclaimed without deleting anything
 ```
 
 Global flags:

--- a/internal/controlplane/api/handlers/block_gc.go
+++ b/internal/controlplane/api/handlers/block_gc.go
@@ -46,6 +46,11 @@ type BlockGCRuntime interface {
 	// storage and returns a READ-ONLY report of the four orphan classes. It
 	// mutates nothing (#1493/#1525 reconcile reporter).
 	ReconcileReport(ctx context.Context) (*engine.ReconcileReport, error)
+
+	// ReconcileReclaimZeroRef deletes class-1 orphans server-wide (block records
+	// with a zero live chunk count and no live locator) and frees their remote
+	// objects. dryRun previews without deleting (#1493 PR5b).
+	ReconcileReclaimZeroRef(ctx context.Context, dryRun bool) (*engine.ReclaimReport, error)
 }
 
 // BlockStoreGCHandler exposes on-demand GC + last-run-summary endpoints.
@@ -313,6 +318,47 @@ func (h *BlockStoreGCHandler) ReconcileReport(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		logger.Debug("Block store reconcile report error", "error", err)
 		InternalServerError(w, "reconcile report failed")
+		return
+	}
+
+	WriteJSONOK(w, report)
+}
+
+// ReconcileReclaimZeroRefRequest is the JSON body for the zero-ref reclaim
+// endpoint. dry_run previews the exact set without deleting.
+type ReconcileReclaimZeroRefRequest struct {
+	DryRun bool `json:"dry_run,omitempty"`
+}
+
+// ReconcileReclaimZeroRef handles POST /api/v1/blockstore/reconcile/zero-ref-records.
+//
+// Server-wide, admin-only. It DELETES class-1 orphans (block records with a zero
+// live chunk count and no live locator — a crash between decrementing the count
+// and deleting the record) and frees their remote objects. Set dry_run to preview
+// the set without deleting. First deleting reconcile stage (#1493/#1525 PR5b).
+//
+// Status codes:
+//   - 200 OK with engine.ReclaimReport
+//   - 400 Bad Request when the body decode fails
+//   - 500 Internal Server Error on unexpected runtime errors
+func (h *BlockStoreGCHandler) ReconcileReclaimZeroRef(w http.ResponseWriter, r *http.Request) {
+	if h.runtime == nil {
+		InternalServerError(w, "runtime not initialized")
+		return
+	}
+
+	var req ReconcileReclaimZeroRefRequest
+	if r.Body != nil && r.ContentLength != 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+			BadRequest(w, "invalid request body: "+err.Error())
+			return
+		}
+	}
+
+	report, err := h.runtime.ReconcileReclaimZeroRef(r.Context(), req.DryRun)
+	if err != nil {
+		logger.Debug("Block store zero-ref reclaim error", "error", err)
+		InternalServerError(w, "zero-ref reclaim failed")
 		return
 	}
 

--- a/internal/controlplane/api/handlers/block_gc_test.go
+++ b/internal/controlplane/api/handlers/block_gc_test.go
@@ -39,6 +39,11 @@ type fakeGCRuntime struct {
 	// ReconcileReport hooks
 	report    *engine.ReconcileReport
 	reportErr error
+
+	// ReconcileReclaimZeroRef hooks
+	reclaim        *engine.ReclaimReport
+	reclaimErr     error
+	reclaimDryRuns []bool
 }
 
 type startCall struct {
@@ -78,6 +83,17 @@ func (f *fakeGCRuntime) ReconcileReport(context.Context) (*engine.ReconcileRepor
 		return f.report, nil
 	}
 	return &engine.ReconcileReport{}, nil
+}
+
+func (f *fakeGCRuntime) ReconcileReclaimZeroRef(_ context.Context, dryRun bool) (*engine.ReclaimReport, error) {
+	f.reclaimDryRuns = append(f.reclaimDryRuns, dryRun)
+	if f.reclaimErr != nil {
+		return nil, f.reclaimErr
+	}
+	if f.reclaim != nil {
+		return f.reclaim, nil
+	}
+	return &engine.ReclaimReport{}, nil
 }
 
 // gcStartBody mirrors the 202 response shape from RunGC.
@@ -558,5 +574,64 @@ func TestBlockStoreHandler_ReconcileReport_NilRuntime(t *testing.T) {
 
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("ReconcileReport: expected 500 on nil runtime, got %d", w.Code)
+	}
+}
+
+// TestBlockStoreHandler_ReclaimZeroRef_PropagatesDryRun asserts the dry_run flag
+// reaches the runtime and the report is returned.
+func TestBlockStoreHandler_ReclaimZeroRef_PropagatesDryRun(t *testing.T) {
+	fake := &fakeGCRuntime{reclaim: &engine.ReclaimReport{
+		Reclaimed: engine.ReconcileClass{Count: 2, Bytes: 42, Sample: []string{"blk-a", "blk-b"}},
+		DryRun:    true,
+	}}
+	h := NewBlockStoreGCHandler(fake)
+
+	body, _ := json.Marshal(ReconcileReclaimZeroRefRequest{DryRun: true})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/blockstore/reconcile/zero-ref-records", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	h.ReconcileReclaimZeroRef(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("ReconcileReclaimZeroRef: expected 200, got %d (body=%q)", w.Code, w.Body.String())
+	}
+	if len(fake.reclaimDryRuns) != 1 || !fake.reclaimDryRuns[0] {
+		t.Fatalf("ReconcileReclaimZeroRef: expected dry_run=true propagated, got %v", fake.reclaimDryRuns)
+	}
+	var got engine.ReclaimReport
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("ReconcileReclaimZeroRef: decode: %v", err)
+	}
+	if got.Reclaimed.Count != 2 || got.Reclaimed.Bytes != 42 || !got.DryRun {
+		t.Fatalf("ReconcileReclaimZeroRef: unexpected body: %+v", got)
+	}
+}
+
+// TestBlockStoreHandler_ReclaimZeroRef_RuntimeError maps a runtime failure to 500.
+func TestBlockStoreHandler_ReclaimZeroRef_RuntimeError(t *testing.T) {
+	fake := &fakeGCRuntime{reclaimErr: fmt.Errorf("boom")}
+	h := NewBlockStoreGCHandler(fake)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/blockstore/reconcile/zero-ref-records", nil)
+	w := httptest.NewRecorder()
+
+	h.ReconcileReclaimZeroRef(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("ReconcileReclaimZeroRef: expected 500 on runtime error, got %d", w.Code)
+	}
+}
+
+// TestBlockStoreHandler_ReclaimZeroRef_NilRuntime fails closed on a nil runtime.
+func TestBlockStoreHandler_ReclaimZeroRef_NilRuntime(t *testing.T) {
+	h := NewBlockStoreGCHandler(nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/blockstore/reconcile/zero-ref-records", nil)
+	w := httptest.NewRecorder()
+
+	h.ReconcileReclaimZeroRef(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("ReconcileReclaimZeroRef: expected 500 on nil runtime, got %d", w.Code)
 	}
 }

--- a/pkg/apiclient/blockstore.go
+++ b/pkg/apiclient/blockstore.go
@@ -206,6 +206,19 @@ func (c *Client) BlockStoreReconcileReport() (*engine.ReconcileReport, error) {
 	return getResource[engine.ReconcileReport](c, "/api/v1/blockstore/reconcile-report")
 }
 
+// BlockStoreReclaimZeroRefRequest is the request body for the zero-ref reclaim.
+type BlockStoreReclaimZeroRefRequest struct {
+	DryRun bool `json:"dry_run,omitempty"`
+}
+
+// BlockStoreReclaimZeroRef deletes class-1 orphans server-wide (block records
+// with a zero live chunk count and no live locator) and frees their remote
+// objects, returning the engine.ReclaimReport tally. Server-wide, admin-only.
+// Set DryRun to preview the set without deleting (#1493/#1525 PR5b).
+func (c *Client) BlockStoreReclaimZeroRef(req *BlockStoreReclaimZeroRefRequest) (*engine.ReclaimReport, error) {
+	return createResource[engine.ReclaimReport](c, "/api/v1/blockstore/reconcile/zero-ref-records", req)
+}
+
 // BlockStoreAuditResult is the response body for
 // POST /api/v1/shares/{name}/audit/refcounts. Wraps the
 // engine.AuditRefcountsResult value (CAS manifest-consistency audit).

--- a/pkg/block/engine/reclaim.go
+++ b/pkg/block/engine/reclaim.go
@@ -1,0 +1,172 @@
+// Package engine — zero-ref record reclaim (#1493/#1525 reconcile, PR5b), the
+// first *deleting* stage after the read-only reporter (reconcile.go). It reclaims
+// class-1 orphans: block records with LiveChunkCount == 0 and no live locator — a
+// crash between DecrLiveChunkCount and DeleteBlockRecord. Such a record is
+// terminally dead (the count only ever decrements and block IDs are never reused),
+// so deleting it and any lingering remote object is safe with no grace window.
+package engine
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+)
+
+// ReclaimMetaView is the per-share metadata surface the zero-ref reclaimer needs:
+// the read-only reconcile view plus the record delete. metadata.Store satisfies
+// it structurally.
+type ReclaimMetaView interface {
+	ReconcileMetaView
+	DeleteBlockRecord(ctx context.Context, blockID string) error
+}
+
+// ReclaimOptions parameterizes a zero-ref reclaim pass.
+type ReclaimOptions struct {
+	// DryRun classifies and tallies without deleting anything, so an operator
+	// can preview the exact set a live run would act on.
+	DryRun bool
+	// SampleCap bounds the per-run ID sample. Zero defaults to
+	// defaultReconcileSampleCap. Counts are always exact.
+	SampleCap int
+}
+
+// ReclaimReport is the output of a zero-ref reclaim pass.
+type ReclaimReport struct {
+	// Reclaimed tallies the zero-ref records deleted (Count) and the remote
+	// bytes freed (Bytes, from each record's Length). On a dry run it tallies
+	// what WOULD be deleted.
+	Reclaimed ReconcileClass `json:"reclaimed"`
+	// BlockRecordsScanned is every record examined across all shares.
+	BlockRecordsScanned int64 `json:"block_records_scanned"`
+	// Errors counts records that could not be fully reclaimed (a DeleteBlock or
+	// DeleteBlockRecord failure); each is left intact for the next run.
+	Errors    int64 `json:"errors"`
+	DryRun    bool  `json:"dry_run"`
+	SampleCap int   `json:"sample_cap"`
+}
+
+// Merge folds other into r, aggregating per-remote passes into one server-wide
+// report while respecting the sample cap.
+func (r *ReclaimReport) Merge(other ReclaimReport) {
+	cap := r.SampleCap
+	if cap <= 0 {
+		cap = defaultReconcileSampleCap
+		r.SampleCap = cap
+	}
+	r.Reclaimed.merge(other.Reclaimed, cap)
+	r.BlockRecordsScanned += other.BlockRecordsScanned
+	r.Errors += other.Errors
+	if other.DryRun {
+		r.DryRun = true
+	}
+}
+
+// ReclaimZeroRefRecords deletes class-1 orphans across the given per-share views
+// that share one remote store: block records with LiveChunkCount == 0 and no live
+// locator. For each it frees the remote block object (idempotent — the object may
+// already be gone if the crash landed after DeleteBlock) then deletes the record,
+// matching the GC reclaimer's DeleteBlock→DeleteBlockRecord order so a crash
+// between them leaves a record-less orphan object (class 3, swept later) rather
+// than a record pointing at freed bytes.
+//
+// It RE-DERIVES the classification here — never trusting a stale report — so a
+// record re-referenced since the report is not deleted. rbs is the shared block
+// store (nil = record-only reclaim; nothing to free remotely). The caller MUST
+// hold the per-remote GC lock so this cannot race a concurrent sweep's
+// DecrLiveChunkCount on the same block.
+//
+// A per-record delete failure is non-fatal: it is logged, counted in Errors, and
+// the record is left intact for the next run. Only an enumerate/walk failure
+// aborts the pass.
+func ReclaimZeroRefRecords(
+	ctx context.Context,
+	views []ReclaimMetaView,
+	rbs remote.RemoteBlockStore,
+	opts ReclaimOptions,
+) (ReclaimReport, error) {
+	sampleCap := opts.SampleCap
+	if sampleCap <= 0 {
+		sampleCap = defaultReconcileSampleCap
+	}
+	report := ReclaimReport{DryRun: opts.DryRun, SampleCap: sampleCap}
+
+	for _, v := range views {
+		// Live locator set for THIS share: any block ID a synced locator still
+		// points at is NOT a zero-ref orphan, whatever its counter says.
+		refSet := make(map[string]struct{})
+		if err := v.EnumerateSynced(ctx, func(h block.ContentHash, _ time.Time) error {
+			loc, ok, err := v.GetLocator(ctx, h)
+			if err != nil {
+				return err
+			}
+			if ok && loc.BlockID != "" {
+				refSet[loc.BlockID] = struct{}{}
+			}
+			return nil
+		}); err != nil {
+			return report, fmt.Errorf("reclaim: enumerate synced: %w", err)
+		}
+
+		// Collect candidates during the walk and delete AFTER it: mutating the
+		// record store mid-walk is unsafe on some backends.
+		type candidate struct {
+			blockID string
+			length  int64
+		}
+		var candidates []candidate
+		if err := v.WalkBlockRecords(ctx, func(rec block.BlockRecord) error {
+			report.BlockRecordsScanned++
+			if _, live := refSet[rec.BlockID]; live {
+				return nil // healthy: a live locator still points at this block
+			}
+			if rec.LiveChunkCount == 0 {
+				candidates = append(candidates, candidate{rec.BlockID, rec.Length})
+			}
+			return nil
+		}); err != nil {
+			return report, fmt.Errorf("reclaim: walk block records: %w", err)
+		}
+
+		for _, c := range candidates {
+			if err := ctx.Err(); err != nil {
+				return report, err
+			}
+			if opts.DryRun {
+				report.Reclaimed.add(c.blockID, c.length, sampleCap)
+				continue
+			}
+			// DeleteBlock before DeleteBlockRecord: a crash between them leaves a
+			// record-less orphan object (class 3), never a record pointing at
+			// freed bytes. DeleteBlock is idempotent, so a block already freed by
+			// the crash-before-DeleteBlockRecord path is a clean no-op.
+			if rbs != nil {
+				if err := rbs.DeleteBlock(ctx, c.blockID); err != nil {
+					slog.Warn("reclaim: delete remote block failed — record kept for retry",
+						"block_id", c.blockID, "err", err)
+					report.Errors++
+					continue
+				}
+			}
+			if err := v.DeleteBlockRecord(ctx, c.blockID); err != nil {
+				// The object may already be freed above; the record survives and
+				// is retried next run. A now-record-less object is a class-3
+				// orphan the object sweep reclaims.
+				slog.Warn("reclaim: delete block record failed — will retry next run",
+					"block_id", c.blockID, "err", err)
+				report.Errors++
+				continue
+			}
+			report.Reclaimed.add(c.blockID, c.length, sampleCap)
+		}
+	}
+
+	if report.Reclaimed.Truncated {
+		slog.Warn("reclaim: ID sample truncated — full reclaimed set is larger than the sample cap",
+			"sample_cap", sampleCap, "reclaimed", report.Reclaimed.Count)
+	}
+	return report, nil
+}

--- a/pkg/block/engine/reclaim_test.go
+++ b/pkg/block/engine/reclaim_test.go
@@ -1,0 +1,137 @@
+package engine
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// putZeroRefRecord seeds a class-1 orphan: a remote object plus a block record
+// with LiveChunkCount==0 and no synced locator pointing at it.
+func putZeroRefRecord(t *testing.T, st *metadatamemory.MemoryMetadataStore, rbs *remotememory.Store, blockID string, length int64) {
+	t.Helper()
+	ctx := t.Context()
+	if err := rbs.PutBlock(ctx, blockID, bytes.NewReader([]byte(blockID))); err != nil {
+		t.Fatalf("PutBlock(%s): %v", blockID, err)
+	}
+	if err := st.PutBlockRecord(ctx, block.BlockRecord{
+		BlockID:        blockID,
+		Length:         length,
+		LiveChunkCount: 0,
+		SyncState:      block.BlockStateRemote,
+	}); err != nil {
+		t.Fatalf("PutBlockRecord(%s): %v", blockID, err)
+	}
+}
+
+func recordExists(t *testing.T, st *metadatamemory.MemoryMetadataStore, blockID string) bool {
+	t.Helper()
+	_, ok, err := st.GetBlockRecord(t.Context(), blockID)
+	if err != nil {
+		t.Fatalf("GetBlockRecord(%s): %v", blockID, err)
+	}
+	return ok
+}
+
+func remoteHasBlock(t *testing.T, rbs *remotememory.Store, blockID string) bool {
+	t.Helper()
+	found := false
+	if err := rbs.WalkBlocks(t.Context(), func(id string, _ block.Meta) error {
+		if id == blockID {
+			found = true
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("WalkBlocks: %v", err)
+	}
+	return found
+}
+
+// TestReclaimZeroRefRecords_DeletesOnlyZeroRef proves the reclaimer deletes a
+// zero-ref record AND its remote object, leaves a healthy block and a leaked
+// (class-2) block untouched, and is idempotent on a second pass.
+func TestReclaimZeroRefRecords_DeletesOnlyZeroRef(t *testing.T) {
+	ctx := t.Context()
+	st := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	rbs := remotememory.New()
+	defer func() { _ = rbs.Close() }()
+
+	// Healthy: record + live locator + object → must survive.
+	hHealthy := hashFromString("healthy-chunk")
+	seedPackedBlock(t, st, rbs, "blk-healthy", []block.ContentHash{hHealthy})
+
+	// Class 1: zero-ref record + its object → must be deleted.
+	putZeroRefRecord(t, st, rbs, "blk-zeroref", 111)
+
+	// Class 2: leaked block (LiveChunkCount>0, no live locator) → NOT this
+	// stage's job; must be left intact for PR5c.
+	if err := st.PutBlockRecord(ctx, block.BlockRecord{
+		BlockID: "blk-leaked", Length: 222, LiveChunkCount: 2, SyncState: block.BlockStateRemote,
+	}); err != nil {
+		t.Fatalf("PutBlockRecord(blk-leaked): %v", err)
+	}
+
+	rep, err := ReclaimZeroRefRecords(ctx, []ReclaimMetaView{st}, rbs, ReclaimOptions{})
+	if err != nil {
+		t.Fatalf("ReclaimZeroRefRecords: %v", err)
+	}
+
+	if rep.Reclaimed.Count != 1 || len(rep.Reclaimed.Sample) != 1 || rep.Reclaimed.Sample[0] != "blk-zeroref" {
+		t.Errorf("Reclaimed = %+v; want count 1 sample [blk-zeroref]", rep.Reclaimed)
+	}
+	if rep.Reclaimed.Bytes != 111 {
+		t.Errorf("Reclaimed.Bytes = %d; want 111", rep.Reclaimed.Bytes)
+	}
+	if rep.Errors != 0 {
+		t.Errorf("Errors = %d; want 0", rep.Errors)
+	}
+
+	// Zero-ref record and its object are gone.
+	if recordExists(t, st, "blk-zeroref") {
+		t.Error("blk-zeroref record still present after reclaim")
+	}
+	if remoteHasBlock(t, rbs, "blk-zeroref") {
+		t.Error("blk-zeroref remote object still present after reclaim")
+	}
+	// Healthy and leaked survive.
+	if !recordExists(t, st, "blk-healthy") || !remoteHasBlock(t, rbs, "blk-healthy") {
+		t.Error("healthy block was wrongly reclaimed")
+	}
+	if !recordExists(t, st, "blk-leaked") {
+		t.Error("leaked (class-2) record was wrongly reclaimed")
+	}
+
+	// Idempotent: a second pass finds nothing to reclaim.
+	rep2, err := ReclaimZeroRefRecords(ctx, []ReclaimMetaView{st}, rbs, ReclaimOptions{})
+	if err != nil {
+		t.Fatalf("ReclaimZeroRefRecords (2nd): %v", err)
+	}
+	if rep2.Reclaimed.Count != 0 {
+		t.Errorf("second pass Reclaimed.Count = %d; want 0", rep2.Reclaimed.Count)
+	}
+}
+
+// TestReclaimZeroRefRecords_DryRun proves a dry run tallies the same set but
+// deletes nothing.
+func TestReclaimZeroRefRecords_DryRun(t *testing.T) {
+	ctx := t.Context()
+	st := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	rbs := remotememory.New()
+	defer func() { _ = rbs.Close() }()
+
+	putZeroRefRecord(t, st, rbs, "blk-zeroref", 500)
+
+	rep, err := ReclaimZeroRefRecords(ctx, []ReclaimMetaView{st}, rbs, ReclaimOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("ReclaimZeroRefRecords: %v", err)
+	}
+	if !rep.DryRun || rep.Reclaimed.Count != 1 || rep.Reclaimed.Bytes != 500 {
+		t.Errorf("dry-run report = %+v; want DryRun count 1 bytes 500", rep)
+	}
+	if !recordExists(t, st, "blk-zeroref") || !remoteHasBlock(t, rbs, "blk-zeroref") {
+		t.Error("dry run deleted something; must be non-mutating")
+	}
+}

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -323,6 +323,10 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 				// Read-only orphan-storage reporter (#1493/#1525). Server-wide
 				// scan; mutates nothing. Reviewed before the delete stages act.
 				r.Get("/reconcile-report", blockGCHandler.ReconcileReport)
+				// Zero-ref record reclaim (#1493 PR5b): deletes class-1 orphans
+				// and frees their remote objects. Mutating, so POST; dry_run
+				// previews.
+				r.Post("/reconcile/zero-ref-records", blockGCHandler.ReconcileReclaimZeroRef)
 			})
 
 			// Store management (admin only)

--- a/pkg/controlplane/runtime/blockgc_reconcile_reclaim.go
+++ b/pkg/controlplane/runtime/blockgc_reconcile_reclaim.go
@@ -1,0 +1,76 @@
+package runtime
+
+import (
+	"context"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+)
+
+// ReconcileReclaimZeroRef reclaims class-1 orphans server-wide: block records
+// with a zero live chunk count and no live locator — a crash between
+// DecrLiveChunkCount and DeleteBlockRecord. It frees each record's remote block
+// object (idempotent) and deletes the record. This is the first DELETING
+// reconcile stage after the read-only reporter (PR5b, #1493/#1525); dryRun
+// tallies what would be reclaimed without deleting.
+//
+// Like the GC sweep it unions the shares that reference each remote and holds the
+// same per-remote GC lock while reclaiming, so a zero-ref delete can never race a
+// concurrent sweep's check-then-DecrLiveChunkCount on the same shared block.
+func (r *Runtime) ReconcileReclaimZeroRef(ctx context.Context, dryRun bool) (*engine.ReclaimReport, error) {
+	total := &engine.ReclaimReport{}
+	for _, entry := range r.sharesSvc.DistinctRemoteStores() {
+		if err := ctx.Err(); err != nil {
+			return total, err
+		}
+		views := make([]engine.ReclaimMetaView, 0, len(entry.Shares))
+		for _, shareName := range entry.Shares {
+			mds, err := r.GetMetadataStoreForShare(shareName)
+			if err != nil {
+				logger.Warn("ReconcileReclaimZeroRef: metadata store unavailable — share excluded",
+					"share", shareName, "err", err)
+				continue
+			}
+			// EnumerateSynced/DeleteBlockRecord are required to re-derive the
+			// live set and delete; a backend lacking them cannot be reclaimed
+			// safely, so exclude it rather than risk a false delete.
+			view, ok := mds.(engine.ReclaimMetaView)
+			if !ok {
+				logger.Warn("ReconcileReclaimZeroRef: metadata store does not support reclaim — share excluded",
+					"share", shareName)
+				continue
+			}
+			views = append(views, view)
+		}
+		if len(views) == 0 {
+			continue
+		}
+		// A remote that cannot hold packed blocks (no RemoteBlockStore) still has
+		// its records reclaimed; there is simply nothing to free remotely.
+		rbs, _ := entry.Store.(remote.RemoteBlockStore)
+
+		var rep engine.ReclaimReport
+		err := func() error {
+			lock := r.remoteGCLock(entry.ConfigID)
+			lock.Lock()
+			defer lock.Unlock()
+			var e error
+			rep, e = engine.ReclaimZeroRefRecords(ctx, views, rbs, engine.ReclaimOptions{DryRun: dryRun})
+			return e
+		}()
+		if err != nil {
+			return total, err
+		}
+		total.Merge(rep)
+	}
+
+	logger.Info("ReconcileReclaimZeroRef: complete",
+		"reclaimed", total.Reclaimed.Count,
+		"bytesFreed", total.Reclaimed.Bytes,
+		"blockRecordsScanned", total.BlockRecordsScanned,
+		"errors", total.Errors,
+		"dryRun", total.DryRun,
+	)
+	return total, nil
+}

--- a/pkg/controlplane/runtime/blockgc_reconcile_reclaim.go
+++ b/pkg/controlplane/runtime/blockgc_reconcile_reclaim.go
@@ -11,8 +11,8 @@ import (
 // ReconcileReclaimZeroRef reclaims class-1 orphans server-wide: block records
 // with a zero live chunk count and no live locator — a crash between
 // DecrLiveChunkCount and DeleteBlockRecord. It frees each record's remote block
-// object (idempotent) and deletes the record. This is the first DELETING
-// reconcile stage after the read-only reporter (PR5b, #1493/#1525); dryRun
+// object (idempotent) and deletes the record. This is PR5b, the first DELETING
+// reconcile stage after the read-only reporter (PR5a, #1493/#1525); dryRun
 // tallies what would be reclaimed without deleting.
 //
 // Like the GC sweep it unions the shares that reference each remote and holds the


### PR DESCRIPTION
## What

First **deleting** stage of the `#1493`/`#1525` reconcile sweep, after the read-only reporter (PR5a). Reclaims **class-1 orphans**: block records with `LiveChunkCount == 0` and no live locator — left behind by a crash between `DecrLiveChunkCount` and `DeleteBlockRecord`.

## Why it's safe (no grace window, no TOCTOU)

A zero-ref record is **provably terminal**: `LiveChunkCount` is set once at carve time and only ever decremented (there is no `IncrLiveChunkCount` anywhere), and every commit mints a fresh `crypto/rand` block ID — so no writer can ever revive a zero-count block ID. Deleting it and any lingering remote object is therefore safe with no grace window.

## How

- `engine.ReclaimZeroRefRecords` — **re-derives** the classification per share under the caller's lock (never trusts a stale report), collects candidates during the `WalkBlockRecords` pass then deletes **after** the walk (no mutate-during-iteration), and for each frees the remote object (idempotent `DeleteBlock`) **before** the record — the same `DeleteBlock`→`DeleteBlockRecord` order as the GC reclaimer, so a crash leaves a record-less orphan (class 3, swept later), never a record pointing at freed bytes. Per-record delete failures are non-fatal (counted, logged, retried next run).
- `Runtime.ReconcileReclaimZeroRef` — iterates `DistinctRemoteStores` and holds the **same per-remote GC lock** (`remoteGCLock[configID]`) the sweep uses, so a reclaim can never race a concurrent `DecrLiveChunkCount` on a shared, ref-counted block.
- REST: `POST /api/v1/blockstore/reconcile/zero-ref-records` (admin), `dry_run` body flag.
- CLI: `dfsctl store block reclaim [--dry-run]`.

Mirrors the read-only sibling (`reconcile.go` / `blockgc_reconcile_report.go`) and reuses its helpers.

## Tests

- `pkg/block/engine/reclaim_test.go`: deletes only the zero-ref record + its object, leaves a healthy block and a class-2 leaked block untouched, idempotent second pass; dry-run is non-mutating.
- `internal/controlplane/api/handlers/block_gc_test.go`: handler dry-run propagation, runtime-error → 500, nil-runtime → 500.
- All touched packages: build, vet, `golangci-lint`, and full test suite green. `docs/guide/cli.md` regenerated via `cmd/gendocs`.

## Follow-ups (epic #1493 stays open)

- **PR5c**: class-2 leaked blocks (`#1525`) + record-less remote object delete.
- Local logblob byte reclaim (`#1497`).

Part of `#1493`.