### PR TITLE
fix(operator): mark admin Secret bootstrap-only and harden operator re-provision (#1412, #1413)

### DIFF
--- a/k8s/dittofs-operator/api/v1alpha1/helpers.go
+++ b/k8s/dittofs-operator/api/v1alpha1/helpers.go
@@ -47,8 +47,19 @@ const (
 	// OperatorCredentialsSecretSuffix is the naming convention for the operator credentials Secret.
 	OperatorCredentialsSecretSuffix = "-operator-credentials"
 
-	// AdminCredentialsSecretSuffix is the naming convention for the admin bootstrap Secret.
-	AdminCredentialsSecretSuffix = "-admin-credentials"
+	// AdminBootstrapCredentialsSecretSuffix is the naming convention for the admin
+	// bootstrap Secret. The "bootstrap" marker makes it self-evident that this
+	// password is consumed once, on first server start, to seed the admin user
+	// (via DITTOFS_ADMIN_INITIAL_PASSWORD). It is NOT the live admin password and
+	// is not kept in sync after `dfsctl user passwd admin`.
+	AdminBootstrapCredentialsSecretSuffix = "-admin-bootstrap-credentials"
+
+	// legacyAdminCredentialsSecretSuffix is the pre-rename Secret name suffix.
+	// Retained only so the operator can adopt an existing bootstrap Secret on
+	// upgrade instead of generating a fresh password that would no longer match
+	// the already-bootstrapped server. Remove once no deployment predates the
+	// rename.
+	legacyAdminCredentialsSecretSuffix = "-admin-credentials"
 
 	// OperatorServiceAccountUsername is the fixed username for the operator service account.
 	OperatorServiceAccountUsername = "k8s-operator"
@@ -92,9 +103,18 @@ func (ds *DittoServer) GetOperatorCredentialsSecretName() string {
 	return ds.Name + OperatorCredentialsSecretSuffix
 }
 
-// GetAdminCredentialsSecretName returns the name of the admin credentials Secret.
-func (ds *DittoServer) GetAdminCredentialsSecretName() string {
-	return ds.Name + AdminCredentialsSecretSuffix
+// GetAdminBootstrapCredentialsSecretName returns the name of the admin bootstrap
+// credentials Secret. The password it holds is used once to seed the admin user;
+// see AdminBootstrapCredentialsSecretSuffix.
+func (ds *DittoServer) GetAdminBootstrapCredentialsSecretName() string {
+	return ds.Name + AdminBootstrapCredentialsSecretSuffix
+}
+
+// GetLegacyAdminCredentialsSecretName returns the pre-rename bootstrap Secret
+// name. Used only by the migration path in reconcileAdminCredentials to adopt an
+// existing password on upgrade; remove once no pre-rename deployments remain.
+func (ds *DittoServer) GetLegacyAdminCredentialsSecretName() string {
+	return ds.Name + legacyAdminCredentialsSecretSuffix
 }
 
 // GetAPIServiceURL returns the in-cluster URL for the DittoFS API service.

--- a/k8s/dittofs-operator/internal/controller/auth_reconciler.go
+++ b/k8s/dittofs-operator/internal/controller/auth_reconciler.go
@@ -59,7 +59,7 @@ func (r *DittoServerReconciler) reconcileAdminCredentials(ctx context.Context, d
 		return nil
 	}
 
-	secretName := dittoServer.GetAdminCredentialsSecretName()
+	secretName := dittoServer.GetAdminBootstrapCredentialsSecretName()
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
@@ -67,13 +67,31 @@ func (r *DittoServerReconciler) reconcileAdminCredentials(ctx context.Context, d
 		},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
+	// Migration: on upgrade the bootstrap Secret was renamed. If the new-named
+	// Secret does not yet exist but a pre-rename one does, adopt its password
+	// rather than generating a fresh one. Generating fresh here would diverge
+	// from the already-bootstrapped server's admin password and break operator
+	// service-account (re)provisioning, which logs in as admin. Fetched outside
+	// the mutate closure so the legacy Secret can be garbage-collected after the
+	// new one is committed. A non-NotFound read error must abort the reconcile
+	// (retried with backoff): silently treating it as "no legacy Secret" would
+	// generate a fresh, diverging password and permanently lock out the operator.
+	legacyData, err := r.legacyAdminSecretData(ctx, dittoServer)
+	if err != nil {
+		return err
+	}
+
+	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
 		if err := controllerutil.SetControllerReference(dittoServer, secret, r.Scheme); err != nil {
 			return err
 		}
 
-		// Only generate password if Secret data is nil or empty
+		// Only generate/adopt a password if Secret data is nil or empty
 		if secret.Data == nil || len(secret.Data["password"]) == 0 {
+			if legacyData != nil {
+				secret.Data = legacyData
+				return nil
+			}
 			password, err := generateRandomPassword()
 			if err != nil {
 				return fmt.Errorf("failed to generate admin password: %w", err)
@@ -88,10 +106,65 @@ func (r *DittoServerReconciler) reconcileAdminCredentials(ctx context.Context, d
 	})
 
 	if err != nil {
-		return fmt.Errorf("failed to create/update admin credentials secret: %w", err)
+		return fmt.Errorf("failed to create/update admin bootstrap credentials secret: %w", err)
+	}
+
+	// Best-effort GC of the adopted legacy Secret so the confusingly-named object
+	// does not linger. Failure is non-fatal: the CR owner reference still cleans
+	// it up on teardown.
+	if legacyData != nil {
+		r.deleteLegacyAdminSecret(ctx, dittoServer)
 	}
 
 	return nil
+}
+
+// legacyAdminSecretData returns the username/password data of the pre-rename
+// admin bootstrap Secret. It returns (nil, nil) when no legacy Secret exists (or
+// it holds no password) so the caller generates a fresh one, and a non-nil error
+// on any other read failure so the caller aborts and retries rather than
+// regenerating a diverging password. Used only by the one-shot rename migration.
+func (r *DittoServerReconciler) legacyAdminSecretData(ctx context.Context, ds *dittoiov1alpha1.DittoServer) (map[string][]byte, error) {
+	logger := logf.FromContext(ctx)
+	legacy := &corev1.Secret{}
+	if err := r.Get(ctx, client.ObjectKey{
+		Namespace: ds.Namespace,
+		Name:      ds.GetLegacyAdminCredentialsSecretName(),
+	}, legacy); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read legacy admin credentials secret for migration: %w", err)
+	}
+	if len(legacy.Data["password"]) == 0 {
+		return nil, nil
+	}
+	username := legacy.Data["username"]
+	if len(username) == 0 {
+		username = []byte("admin")
+	}
+	logger.Info("Adopting password from legacy admin credentials secret for rename migration",
+		"legacySecret", ds.GetLegacyAdminCredentialsSecretName())
+	return map[string][]byte{
+		"username": username,
+		"password": legacy.Data["password"],
+	}, nil
+}
+
+// deleteLegacyAdminSecret removes the pre-rename admin bootstrap Secret after its
+// value has been adopted. Best-effort: errors are logged, not returned.
+func (r *DittoServerReconciler) deleteLegacyAdminSecret(ctx context.Context, ds *dittoiov1alpha1.DittoServer) {
+	logger := logf.FromContext(ctx)
+	legacy := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ds.GetLegacyAdminCredentialsSecretName(),
+			Namespace: ds.Namespace,
+		},
+	}
+	if err := r.Delete(ctx, legacy); err != nil && !apierrors.IsNotFound(err) {
+		logger.Info("Failed to delete legacy admin credentials secret after migration (harmless)",
+			"error", err.Error())
+	}
 }
 
 // newAPIClient builds a DittoFSClient for the given base URL, wiring TLS trust
@@ -195,7 +268,7 @@ func (r *DittoServerReconciler) provisionOperatorAccount(ctx context.Context, ds
 
 	// Read admin credentials
 	adminSecret := &corev1.Secret{}
-	adminSecretName := ds.GetAdminCredentialsSecretName()
+	adminSecretName := ds.GetAdminBootstrapCredentialsSecretName()
 
 	// passwordKey is the Secret key holding the admin password (cleartext). For
 	// the operator-managed auto-generated Secret this is always "password"; for a
@@ -249,6 +322,23 @@ func (r *DittoServerReconciler) provisionOperatorAccount(ctx context.Context, ds
 	}
 	tokenResp, err := apiClient.Login(ctx, adminUsername, adminPassword)
 	if err != nil {
+		// The operator only needs the admin password at (re)provisioning time. A
+		// rejected admin login here almost always means the bootstrap Secret no
+		// longer matches the live admin — e.g. the password was rotated with
+		// `dfsctl user passwd admin` after first boot, then the operator-credentials
+		// Secret was deleted/recreated. Surface an actionable event pointing at the
+		// fix instead of an opaque, indefinitely-retried 401.
+		var apiErr *DittoFSAPIError
+		if errors.As(err, &apiErr) && apiErr.IsAuthError() {
+			r.Recorder.Eventf(ds, corev1.EventTypeWarning, "AdminBootstrapUnauthorized",
+				"Admin login rejected (%d) while provisioning the operator service account. "+
+					"The bootstrap credentials Secret %q is likely out of sync with the live admin password "+
+					"(rotated via dfsctl?). Update that Secret to the current admin password, or set "+
+					"spec.identity.admin.passwordSecretRef.", apiErr.StatusCode, adminSecretName)
+			return ctrl.Result{}, fmt.Errorf(
+				"admin login rejected (%d) provisioning operator service account: bootstrap credentials secret %q is out of sync with the live admin password: %w",
+				apiErr.StatusCode, adminSecretName, err)
+		}
 		return ctrl.Result{}, fmt.Errorf("failed to login as admin: %w", err)
 	}
 	apiClient.SetToken(tokenResp.AccessToken)
@@ -395,7 +485,7 @@ func (r *DittoServerReconciler) cleanupOperatorServiceAccount(ctx context.Contex
 
 	// Read admin credentials
 	adminSecret := &corev1.Secret{}
-	adminSecretName := ds.GetAdminCredentialsSecretName()
+	adminSecretName := ds.GetAdminBootstrapCredentialsSecretName()
 	passwordKey := "password"
 	var specAdminUsername string
 

--- a/k8s/dittofs-operator/internal/controller/auth_reconciler.go
+++ b/k8s/dittofs-operator/internal/controller/auth_reconciler.go
@@ -67,21 +67,27 @@ func (r *DittoServerReconciler) reconcileAdminCredentials(ctx context.Context, d
 		},
 	}
 
-	// Migration: on upgrade the bootstrap Secret was renamed. If the new-named
-	// Secret does not yet exist but a pre-rename one does, adopt its password
-	// rather than generating a fresh one. Generating fresh here would diverge
-	// from the already-bootstrapped server's admin password and break operator
-	// service-account (re)provisioning, which logs in as admin. Fetched outside
-	// the mutate closure so the legacy Secret can be garbage-collected after the
-	// new one is committed. A non-NotFound read error must abort the reconcile
-	// (retried with backoff): silently treating it as "no legacy Secret" would
-	// generate a fresh, diverging password and permanently lock out the operator.
-	legacyData, err := r.legacyAdminSecretData(ctx, dittoServer)
-	if err != nil {
-		return err
+	// Migration: on upgrade the bootstrap Secret was renamed. Only consult the
+	// pre-rename Secret while the new-named one is still missing or password-empty
+	// — the one-shot migration window. Once it holds a password we skip the legacy
+	// GET entirely, so a transient legacy-read error can never abort an otherwise
+	// healthy reconcile. When migrating, adopt the legacy password rather than
+	// generating a fresh one: a fresh password would diverge from the already
+	// bootstrapped server's admin and break operator (re)provisioning, which logs
+	// in as admin. A non-NotFound legacy read error aborts (retried with backoff)
+	// rather than silently regenerating.
+	if err := r.Get(ctx, client.ObjectKey{Namespace: dittoServer.Namespace, Name: secretName}, secret); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to read admin bootstrap credentials secret: %w", err)
+	}
+	var legacyData map[string][]byte
+	if secret.Data == nil || len(secret.Data["password"]) == 0 {
+		var err error
+		if legacyData, err = r.legacyAdminSecretData(ctx, dittoServer); err != nil {
+			return err
+		}
 	}
 
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
 		if err := controllerutil.SetControllerReference(dittoServer, secret, r.Scheme); err != nil {
 			return err
 		}
@@ -279,8 +285,9 @@ func (r *DittoServerReconciler) provisionOperatorAccount(ctx context.Context, ds
 
 	// If user provided admin password via spec, use that Secret + key.
 	var specAdminUsername string
-	if ds.Spec.Identity != nil && ds.Spec.Identity.Admin != nil &&
-		ds.Spec.Identity.Admin.PasswordSecretRef != nil {
+	userProvidedRef := ds.Spec.Identity != nil && ds.Spec.Identity.Admin != nil &&
+		ds.Spec.Identity.Admin.PasswordSecretRef != nil
+	if userProvidedRef {
 		ref := ds.Spec.Identity.Admin.PasswordSecretRef
 		adminSecretName = ref.Name
 		if ref.Key != "" {
@@ -330,13 +337,17 @@ func (r *DittoServerReconciler) provisionOperatorAccount(ctx context.Context, ds
 		// fix instead of an opaque, indefinitely-retried 401.
 		var apiErr *DittoFSAPIError
 		if errors.As(err, &apiErr) && apiErr.IsAuthError() {
-			r.Recorder.Eventf(ds, corev1.EventTypeWarning, "AdminBootstrapUnauthorized",
-				"Admin login rejected (%d) while provisioning the operator service account. "+
-					"The bootstrap credentials Secret %q is likely out of sync with the live admin password "+
-					"(rotated via dfsctl?). Update that Secret to the current admin password, or set "+
-					"spec.identity.admin.passwordSecretRef.", apiErr.StatusCode, adminSecretName)
+			reason, advice := "AdminBootstrapUnauthorized",
+				fmt.Sprintf("Update the operator-managed bootstrap Secret %q to the current admin password, or set spec.identity.admin.passwordSecretRef.", adminSecretName)
+			if userProvidedRef {
+				reason, advice = "AdminCredentialUnauthorized",
+					fmt.Sprintf("Update the admin password in Secret %q (key %q) referenced by spec.identity.admin.passwordSecretRef to match the live admin password.", adminSecretName, passwordKey)
+			}
+			r.Recorder.Eventf(ds, corev1.EventTypeWarning, reason,
+				"Admin login rejected (%d) while provisioning the operator service account: the admin password is out of sync with the live admin (rotated via dfsctl?). %s",
+				apiErr.StatusCode, advice)
 			return ctrl.Result{}, fmt.Errorf(
-				"admin login rejected (%d) provisioning operator service account: bootstrap credentials secret %q is out of sync with the live admin password: %w",
+				"admin login rejected (%d) provisioning operator service account: admin credentials secret %q is out of sync with the live admin password: %w",
 				apiErr.StatusCode, adminSecretName, err)
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to login as admin: %w", err)

--- a/k8s/dittofs-operator/internal/controller/auth_reconciler_test.go
+++ b/k8s/dittofs-operator/internal/controller/auth_reconciler_test.go
@@ -881,3 +881,54 @@ func TestReconcileAdminCredentials_LegacyReadError_AbortsWithoutRegenerating(t *
 		t.Errorf("bootstrap secret must not be created on legacy read error, got err=%v data=%v", err, newSecret.Data)
 	}
 }
+
+// TestProvisionOperatorAccount_UserProvidedRef_StalePassword_EmitsTailoredEvent
+// verifies #1413: when the user supplied spec.identity.admin.passwordSecretRef,
+// a rejected admin login emits AdminCredentialUnauthorized (not the bootstrap
+// reason) and names the referenced key — the bootstrap/dfsctl advice would be
+// misleading here.
+func TestProvisionOperatorAccount_UserProvidedRef_StalePassword_EmitsTailoredEvent(t *testing.T) {
+	const userKey = "adminpw"
+	ds := newTestDittoServer("test-server", "default")
+	ds.Spec.Identity = &dittoiov1alpha1.IdentityConfig{
+		Admin: &dittoiov1alpha1.AdminConfig{
+			Username: "admin",
+			PasswordSecretRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "user-admin-secret"},
+				Key:                  userKey,
+			},
+		},
+	}
+	adminSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "user-admin-secret", Namespace: "default"},
+		Data:       map[string][]byte{userKey: []byte("stale-user-pass")},
+	}
+	r := setupAuthReconciler(t, ds, adminSecret)
+
+	server := mockDittoFSServer(t, map[string]http.HandlerFunc{
+		"POST /api/v1/auth/login": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"title":"invalid credentials"}`))
+		},
+	})
+
+	if _, err := r.provisionOperatorAccount(context.Background(), ds, server.URL); err == nil {
+		t.Fatal("expected error when admin login is rejected")
+	}
+
+	rec := r.Recorder.(*record.FakeRecorder)
+	select {
+	case ev := <-rec.Events:
+		if !strings.Contains(ev, "AdminCredentialUnauthorized") {
+			t.Errorf("event = %q, want reason AdminCredentialUnauthorized for a passwordSecretRef deployment", ev)
+		}
+		if !strings.Contains(ev, userKey) {
+			t.Errorf("event = %q, want it to name the referenced key %q", ev, userKey)
+		}
+		if strings.Contains(ev, "AdminBootstrapUnauthorized") || strings.Contains(ev, "bootstrap Secret") {
+			t.Errorf("event = %q, should not give bootstrap-Secret advice when a passwordSecretRef is set", ev)
+		}
+	default:
+		t.Error("expected a Warning event on rejected admin login, got none")
+	}
+}

--- a/k8s/dittofs-operator/internal/controller/auth_reconciler_test.go
+++ b/k8s/dittofs-operator/internal/controller/auth_reconciler_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -35,6 +36,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 // newTestDittoServer creates a DittoServer for auth reconciler tests.
@@ -108,7 +110,7 @@ func TestProvisionOperatorAccount_Success(t *testing.T) {
 	// Create admin credentials Secret
 	adminSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ds.GetAdminCredentialsSecretName(),
+			Name:      ds.GetAdminBootstrapCredentialsSecretName(),
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
@@ -253,7 +255,7 @@ func TestProvisionOperatorAccount_UserAlreadyExists(t *testing.T) {
 
 	adminSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ds.GetAdminCredentialsSecretName(),
+			Name:      ds.GetAdminBootstrapCredentialsSecretName(),
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
@@ -345,7 +347,7 @@ func TestReconcileAuth_DBReset_ReprovisionsAuthenticatableSecret(t *testing.T) {
 
 	adminSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ds.GetAdminCredentialsSecretName(),
+			Name:      ds.GetAdminBootstrapCredentialsSecretName(),
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
@@ -558,7 +560,7 @@ func TestReconcileAuth_APIUnreachable(t *testing.T) {
 
 	adminSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ds.GetAdminCredentialsSecretName(),
+			Name:      ds.GetAdminBootstrapCredentialsSecretName(),
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
@@ -608,7 +610,7 @@ func TestReconcileAuth_APIUnreachable(t *testing.T) {
 	stillExists := &corev1.Secret{}
 	err = r.Get(context.Background(), types.NamespacedName{
 		Namespace: "default",
-		Name:      ds.GetAdminCredentialsSecretName(),
+		Name:      ds.GetAdminBootstrapCredentialsSecretName(),
 	}, stillExists)
 	if err != nil {
 		t.Errorf("Admin credentials Secret should still exist after transient failure: %v", err)
@@ -620,7 +622,7 @@ func TestCleanupOperatorServiceAccount_BestEffort(t *testing.T) {
 
 	adminSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ds.GetAdminCredentialsSecretName(),
+			Name:      ds.GetAdminBootstrapCredentialsSecretName(),
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
@@ -653,7 +655,7 @@ func TestReconcileAdminCredentials_AutoGenerate(t *testing.T) {
 	secret := &corev1.Secret{}
 	err = r.Get(context.Background(), types.NamespacedName{
 		Namespace: "default",
-		Name:      ds.GetAdminCredentialsSecretName(),
+		Name:      ds.GetAdminBootstrapCredentialsSecretName(),
 	}, secret)
 	if err != nil {
 		t.Fatalf("Failed to get admin credentials secret: %v", err)
@@ -677,7 +679,7 @@ func TestReconcileAdminCredentials_AutoGenerate(t *testing.T) {
 	secret2 := &corev1.Secret{}
 	err = r.Get(context.Background(), types.NamespacedName{
 		Namespace: "default",
-		Name:      ds.GetAdminCredentialsSecretName(),
+		Name:      ds.GetAdminBootstrapCredentialsSecretName(),
 	}, secret2)
 	if err != nil {
 		t.Fatalf("Failed to get admin credentials secret (second call): %v", err)
@@ -711,7 +713,7 @@ func TestReconcileAdminCredentials_SkipWhenUserProvided(t *testing.T) {
 	secret := &corev1.Secret{}
 	err = r.Get(context.Background(), types.NamespacedName{
 		Namespace: "default",
-		Name:      ds.GetAdminCredentialsSecretName(),
+		Name:      ds.GetAdminBootstrapCredentialsSecretName(),
 	}, secret)
 	if err == nil {
 		t.Errorf("Admin credentials Secret should NOT be created when user provides passwordSecretRef")
@@ -747,5 +749,135 @@ func TestComputeBackoff_NegativeRetry(t *testing.T) {
 	result := computeBackoff(-1)
 	if result != 2*time.Second {
 		t.Errorf("computeBackoff(-1) = %v, want %v", result, 2*time.Second)
+	}
+}
+
+// TestReconcileAdminCredentials_MigratesLegacySecret verifies the #1412 rename
+// migration: when only the pre-rename bootstrap Secret exists, the operator
+// adopts its password under the new name (generating a fresh one would diverge
+// from the already-bootstrapped server and lock out operator provisioning) and
+// garbage-collects the legacy Secret.
+func TestReconcileAdminCredentials_MigratesLegacySecret(t *testing.T) {
+	ds := newTestDittoServer("test-server", "default")
+
+	legacy := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ds.GetLegacyAdminCredentialsSecretName(),
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"username": []byte("admin"),
+			"password": []byte("preserved-bootstrap-pass"),
+		},
+	}
+	r := setupAuthReconciler(t, ds, legacy)
+
+	if err := r.reconcileAdminCredentials(context.Background(), ds); err != nil {
+		t.Fatalf("reconcileAdminCredentials failed: %v", err)
+	}
+
+	newSecret := &corev1.Secret{}
+	if err := r.Get(context.Background(), types.NamespacedName{
+		Namespace: "default",
+		Name:      ds.GetAdminBootstrapCredentialsSecretName(),
+	}, newSecret); err != nil {
+		t.Fatalf("renamed bootstrap secret not created: %v", err)
+	}
+	if got := string(newSecret.Data["password"]); got != "preserved-bootstrap-pass" {
+		t.Errorf("migrated password = %q, want the legacy value preserved", got)
+	}
+
+	old := &corev1.Secret{}
+	err := r.Get(context.Background(), types.NamespacedName{
+		Namespace: "default",
+		Name:      ds.GetLegacyAdminCredentialsSecretName(),
+	}, old)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("legacy secret should be deleted after migration, got err=%v", err)
+	}
+}
+
+// TestProvisionOperatorAccount_StaleAdminPassword_EmitsActionableEvent verifies
+// the #1413 mitigation: a rejected admin login during provisioning emits an
+// actionable AdminBootstrapUnauthorized event instead of an opaque 401.
+func TestProvisionOperatorAccount_StaleAdminPassword_EmitsActionableEvent(t *testing.T) {
+	ds := newTestDittoServer("test-server", "default")
+	adminSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ds.GetAdminBootstrapCredentialsSecretName(),
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"username": []byte("admin"),
+			"password": []byte("stale-pass"),
+		},
+	}
+	r := setupAuthReconciler(t, ds, adminSecret)
+
+	server := mockDittoFSServer(t, map[string]http.HandlerFunc{
+		"POST /api/v1/auth/login": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"title":"invalid credentials"}`))
+		},
+	})
+
+	if _, err := r.provisionOperatorAccount(context.Background(), ds, server.URL); err == nil {
+		t.Fatal("expected error when admin login is rejected")
+	}
+
+	rec := r.Recorder.(*record.FakeRecorder)
+	select {
+	case ev := <-rec.Events:
+		if !strings.Contains(ev, "AdminBootstrapUnauthorized") {
+			t.Errorf("event = %q, want it to mention AdminBootstrapUnauthorized", ev)
+		}
+	default:
+		t.Error("expected a Warning event on rejected admin login, got none")
+	}
+}
+
+// TestReconcileAdminCredentials_LegacyReadError_AbortsWithoutRegenerating checks
+// the anti-lockout invariant: a transient (non-NotFound) failure reading the
+// legacy bootstrap Secret must abort the reconcile for retry, NOT be treated as
+// "no legacy Secret" and fall through to generating a fresh, diverging password.
+func TestReconcileAdminCredentials_LegacyReadError_AbortsWithoutRegenerating(t *testing.T) {
+	ds := newTestDittoServer("test-server", "default")
+	legacyName := ds.GetLegacyAdminCredentialsSecretName()
+
+	s := runtime.NewScheme()
+	if err := scheme.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add core scheme: %v", err)
+	}
+	if err := dittoiov1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add v1alpha1 scheme: %v", err)
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(ds).
+		WithStatusSubresource(&dittoiov1alpha1.DittoServer{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if key.Name == legacyName {
+					return apierrors.NewServiceUnavailable("apiserver busy")
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &DittoServerReconciler{Client: fakeClient, Scheme: s, Recorder: record.NewFakeRecorder(100)}
+
+	if err := r.reconcileAdminCredentials(context.Background(), ds); err == nil {
+		t.Fatal("expected reconcile to abort on legacy secret read error, got nil (would regenerate a diverging password)")
+	}
+
+	newSecret := &corev1.Secret{}
+	err := r.Get(context.Background(), types.NamespacedName{
+		Namespace: "default",
+		Name:      ds.GetAdminBootstrapCredentialsSecretName(),
+	}, newSecret)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("bootstrap secret must not be created on legacy read error, got err=%v data=%v", err, newSecret.Data)
 	}
 }

--- a/k8s/dittofs-operator/internal/controller/dittoserver_controller.go
+++ b/k8s/dittofs-operator/internal/controller/dittoserver_controller.go
@@ -1451,7 +1451,7 @@ func buildSecretEnvVars(dittoServer *dittoiov1alpha1.DittoServer) []corev1.EnvVa
 		// Optional=true so the pod doesn't fail if the Secret is manually deleted.
 		envVars = append(envVars, secretEnvVar(
 			"DITTOFS_ADMIN_INITIAL_PASSWORD",
-			dittoServer.GetAdminCredentialsSecretName(),
+			dittoServer.GetAdminBootstrapCredentialsSecretName(),
 			"password",
 			true,
 		))
@@ -1686,7 +1686,7 @@ func (r *DittoServerReconciler) collectSecretData(ctx context.Context, dittoServ
 		adminSecret := &corev1.Secret{}
 		if err := r.Get(ctx, client.ObjectKey{
 			Namespace: dittoServer.Namespace,
-			Name:      dittoServer.GetAdminCredentialsSecretName(),
+			Name:      dittoServer.GetAdminBootstrapCredentialsSecretName(),
 		}, adminSecret); err == nil {
 			if data, ok := adminSecret.Data["password"]; ok {
 				secrets["admin:password"] = data


### PR DESCRIPTION
## Summary

Addresses #1412 and #1413 together — they are two facets of the same confusion around the operator-managed admin credential.

### #1412 — rename the bootstrap admin Secret
The operator-managed admin Secret holds a **write-once, first-boot-only** password (consumed by the server exactly once via `DITTOFS_ADMIN_INITIAL_PASSWORD`), but its old name `<name>-admin-credentials` read like a live credential. It is renamed to `<name>-admin-bootstrap-credentials` (const `AdminCredentialsSecretSuffix` → `AdminBootstrapCredentialsSecretSuffix`, helper `GetAdminCredentialsSecretName` → `GetAdminBootstrapCredentialsSecretName`).

**Safe migration (no lockout):** on upgrade, `reconcileAdminCredentials` adopts the legacy Secret's password under the new name instead of generating a fresh one — a regenerated password would diverge from the already-bootstrapped server's admin and break operator provisioning. After adoption the legacy Secret is best-effort garbage-collected. A non-`NotFound` error reading the legacy Secret aborts the reconcile for retry rather than falling through to a fresh (diverging) password.

### #1413 — actionable failure on stale admin during re-provision
`provisionOperatorAccount` still logs in as admin at (re)provision time. When that login is rejected (401/403) — e.g. the admin password was rotated with `dfsctl user passwd admin` and the operator-credentials Secret was later deleted/recreated — the operator now emits an actionable `AdminBootstrapUnauthorized` event and returns a clear error naming the bootstrap Secret and the fix, instead of an opaque, indefinitely-retried 401. The error stays classified non-transient so it is not misread as a retryable API-unreachable condition.

## Scope / design note

The **full** decoupling of operator (re)provisioning from the admin password (issue #1413 direction 1: a server-seeded operator-bootstrap credential, analogous to `DITTOFS_ADMIN_INITIAL_PASSWORD`) requires a change in the **server** module — the operator alone cannot create the operator service account without an admin-authenticated API call. That is intentionally **not** included here: it is a cross-module architecture decision for the maintainer. This PR ships the safe, operator-only mitigation (actionable degraded status) plus the rename, which together remove the day-to-day confusion and turn the latent lockout into an actionable condition.

- Does **not** touch user-provided `spec.identity.admin.passwordSecretRef` (caller owns that name/key).
- No CRD/RBAC/chart changes (the Secret is created at runtime, not templated; no docs reference the concrete old name).

## Tests

New unit tests in `auth_reconciler_test.go`:
- `TestReconcileAdminCredentials_MigratesLegacySecret` — adopts the legacy password and GCs the old Secret.
- `TestReconcileAdminCredentials_LegacyReadError_AbortsWithoutRegenerating` — a transient legacy-read error aborts (retries) rather than regenerating a diverging password.
- `TestProvisionOperatorAccount_StaleAdminPassword_EmitsActionableEvent` — rejected admin login emits `AdminBootstrapUnauthorized`.

`go build`, `go vet`, `gofmt -s`, and `golangci-lint run --new-from-rev` are clean; all operator unit tests pass. The ginkgo `TestControllers` envtest suite requires kubebuilder `etcd`/`kube-apiserver` binaries and runs in CI (`make test`); it is skipped locally.

## Follow-up

- #1413 full decoupling (server-seeded operator bootstrap credential) — needs a server-module change; tracked as the remaining work on #1413.