### PR TITLE
fix(runtime): fence rollup ticker before closing metadata stores (#1543)

### DIFF
--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -714,6 +714,34 @@ func (bs *Store) Close() error {
 	return bs.closeErr
 }
 
+// rollupStopper is the narrow, consumer-defined capability a local store
+// exposes to stop + drain its rollup worker pool WITHOUT a full Close. Only
+// *fs.FSStore implements it (memory stores have no rollup pool), so absence is
+// a benign no-op.
+type rollupStopper interface {
+	GracefulStopRollup(grace time.Duration) error
+}
+
+// StopRollup stops and drains the local store's rollup worker pool, if it has
+// one, using the given grace deadline (grace <= 0 defers to the store default).
+//
+// This is the shutdown-ordering fence for #1543. The rollup ticker persists
+// FileChunk manifest rows and rollup offsets THROUGH the metadata store, so it
+// must be quiesced BEFORE the runtime closes the metadata stores — otherwise an
+// in-flight rollup races the DB close and fails with "sql: database is closed",
+// which can leave a chunk dropped locally but never mirrored to the remote.
+//
+// The block store itself stays open (fds intact); the full teardown still
+// happens in the engine Close driven by RemoveShare. Idempotent: the underlying
+// GracefulStopRollup guards with stopRollupOnce, so the later Close is a no-op.
+func (bs *Store) StopRollup(grace time.Duration) error {
+	rs, ok := bs.local.(rollupStopper)
+	if !ok {
+		return nil
+	}
+	return rs.GracefulStopRollup(grace)
+}
+
 // SetMetrics forwards the inline metrics recorder to the underlying local
 // store when it participates in the [local.MetricsAware] capability surface
 // (the *fs.FSStore eviction/backpressure path). Stores that emit no inline

--- a/pkg/controlplane/runtime/lifecycle/service.go
+++ b/pkg/controlplane/runtime/lifecycle/service.go
@@ -57,9 +57,11 @@ type SnapshotDrainer interface {
 // flight races it and fails with "sql: database is closed", which can drop a
 // local chunk that was never mirrored. Called AFTER StopAllAdapters (no new
 // writes create fresh rollup work) and BEFORE the stores close. Pass nil to
-// skip (tests without a block-store rollup pool).
+// skip (tests without a block-store rollup pool). The ctx bounds the total
+// drain time so shutdown has a predictable upper bound regardless of share
+// count; each share's rollup fence still runs even once the deadline passes.
 type RollupStopper interface {
-	StopRollups()
+	StopRollups(ctx context.Context)
 }
 
 // MachineSIDStore provides access to the SettingsStore for machine SID
@@ -347,7 +349,9 @@ func (s *Service) shutdown(
 	// the DB is still open or it races the close ("sql: database is closed").
 	// Runs after StopAllAdapters (no new writes create fresh rollup work).
 	if rollupStopper != nil {
-		rollupStopper.StopRollups()
+		rollupCtx, cancel := context.WithTimeout(context.Background(), s.shutdownTimeout)
+		rollupStopper.StopRollups(rollupCtx)
+		cancel()
 	}
 
 	if storeCloser != nil {

--- a/pkg/controlplane/runtime/lifecycle/service.go
+++ b/pkg/controlplane/runtime/lifecycle/service.go
@@ -49,6 +49,19 @@ type SnapshotDrainer interface {
 	ShutdownSnapshots(ctx context.Context)
 }
 
+// RollupStopper stops + drains every share's block-store rollup worker pool.
+// Threaded through Serve so the normal server shutdown path (signal -> ctx
+// cancel -> lifecycle.shutdown) fences the rollup ticker BEFORE
+// CloseMetadataStores (#1543): the ticker persists FileChunk manifests and
+// rollup offsets through the metadata store, so closing the DB with a rollup in
+// flight races it and fails with "sql: database is closed", which can drop a
+// local chunk that was never mirrored. Called AFTER StopAllAdapters (no new
+// writes create fresh rollup work) and BEFORE the stores close. Pass nil to
+// skip (tests without a block-store rollup pool).
+type RollupStopper interface {
+	StopRollups()
+}
+
 // MachineSIDStore provides access to the SettingsStore for machine SID
 // persistence. The lifecycle service uses this to load or generate the
 // machine SID on first boot, ensuring consistent identity mapping across
@@ -222,12 +235,13 @@ func (s *Service) Serve(
 	storeCloser StoreCloser,
 	machineSIDStore MachineSIDStore,
 	snapshotDrainer SnapshotDrainer,
+	rollupStopper RollupStopper,
 ) error {
 	var err error
 
 	s.serveOnce.Do(func() {
 		s.served = true
-		err = s.serve(ctx, settings, adapterLoader, metadataFlusher, storeCloser, machineSIDStore, snapshotDrainer)
+		err = s.serve(ctx, settings, adapterLoader, metadataFlusher, storeCloser, machineSIDStore, snapshotDrainer, rollupStopper)
 	})
 
 	return err
@@ -241,6 +255,7 @@ func (s *Service) serve(
 	storeCloser StoreCloser,
 	machineSIDStore MachineSIDStore,
 	snapshotDrainer SnapshotDrainer,
+	rollupStopper RollupStopper,
 ) error {
 	logger.Info("Starting DittoFS runtime")
 
@@ -281,7 +296,7 @@ func (s *Service) serve(
 		shutdownErr = fmt.Errorf("API server error: %w", err)
 	}
 
-	s.shutdown(settings, adapterLoader, metadataFlusher, storeCloser, snapshotDrainer)
+	s.shutdown(settings, adapterLoader, metadataFlusher, storeCloser, snapshotDrainer, rollupStopper)
 
 	logger.Info("DittoFS runtime stopped")
 	return shutdownErr
@@ -293,6 +308,7 @@ func (s *Service) shutdown(
 	metadataFlusher MetadataFlusher,
 	storeCloser StoreCloser,
 	snapshotDrainer SnapshotDrainer,
+	rollupStopper RollupStopper,
 ) {
 	if settings != nil {
 		settings.Stop()
@@ -323,6 +339,15 @@ func (s *Service) shutdown(
 		} else if flushed > 0 {
 			logger.Info("Flushed pending metadata writes", "count", flushed)
 		}
+	}
+
+	// Fence the per-share rollup workers BEFORE closing the metadata stores
+	// (#1543): the rollup ticker persists FileChunk manifests + rollup offsets
+	// through the metadata store, so an in-flight rollup must be drained while
+	// the DB is still open or it races the close ("sql: database is closed").
+	// Runs after StopAllAdapters (no new writes create fresh rollup work).
+	if rollupStopper != nil {
+		rollupStopper.StopRollups()
 	}
 
 	if storeCloser != nil {

--- a/pkg/controlplane/runtime/lifecycle/service_test.go
+++ b/pkg/controlplane/runtime/lifecycle/service_test.go
@@ -78,6 +78,21 @@ type fakeDrainer struct{ drained bool }
 
 func (f *fakeDrainer) ShutdownSnapshots(ctx context.Context) { f.drained = true }
 
+// fakeRollupStopper records whether StopRollups ran and, via the shared closer,
+// that it ran BEFORE the metadata stores were closed (#1543 ordering).
+type fakeRollupStopper struct {
+	stopped       bool
+	closedAtStop  bool
+	closerToCheck *fakeStoreCloser
+}
+
+func (f *fakeRollupStopper) StopRollups() {
+	f.stopped = true
+	if f.closerToCheck != nil {
+		f.closedAtStop = f.closerToCheck.closed
+	}
+}
+
 type fakeAPIServer struct {
 	port     int
 	stopped  bool
@@ -129,7 +144,7 @@ func TestSetAPIServerPanicsAfterServe(t *testing.T) {
 	s := New(time.Second)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Serve returns immediately on cancelled ctx
-	_ = s.Serve(ctx, nil, &fakeAdapters{}, nil, nil, nil, nil)
+	_ = s.Serve(ctx, nil, &fakeAdapters{}, nil, nil, nil, nil, nil)
 
 	defer func() {
 		if recover() == nil {
@@ -148,11 +163,12 @@ func TestServeGracefulShutdownOnCancel(t *testing.T) {
 	flusher := &fakeFlusher{n: 3}
 	closer := &fakeStoreCloser{}
 	drainer := &fakeDrainer{}
+	rollups := &fakeRollupStopper{closerToCheck: closer}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := s.Serve(ctx, settings, adapters, flusher, closer, nil, drainer)
+	err := s.Serve(ctx, settings, adapters, flusher, closer, nil, drainer, rollups)
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("err = %v, want context.Canceled", err)
 	}
@@ -174,6 +190,14 @@ func TestServeGracefulShutdownOnCancel(t *testing.T) {
 	if !closer.closed {
 		t.Error("metadata stores not closed")
 	}
+	if !rollups.stopped {
+		t.Error("rollup stopper not invoked")
+	}
+	// #1543: rollups MUST be fenced before the metadata stores close, or an
+	// in-flight rollup races the DB close ("sql: database is closed").
+	if rollups.closedAtStop {
+		t.Error("StopRollups ran AFTER CloseMetadataStores — rollup ticker can race the DB close")
+	}
 }
 
 // A failure loading adapters aborts Serve before entering the select loop and
@@ -185,7 +209,7 @@ func TestServeAdapterLoadFailure(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	err := s.Serve(ctx, nil, adapters, nil, closer, nil, nil)
+	err := s.Serve(ctx, nil, adapters, nil, closer, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error from adapter load failure")
 	}
@@ -207,7 +231,7 @@ func TestServeAPIServerFailureTriggersShutdown(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	err := s.Serve(ctx, nil, &fakeAdapters{}, nil, closer, nil, nil)
+	err := s.Serve(ctx, nil, &fakeAdapters{}, nil, closer, nil, nil, nil)
 	if err == nil || !errors.Is(err, api.startErr) {
 		t.Errorf("err = %v, want wrapped %v", err, api.startErr)
 	}
@@ -225,10 +249,10 @@ func TestServeOnlyRunsOnce(t *testing.T) {
 	adapters := &fakeAdapters{}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_ = s.Serve(ctx, nil, adapters, nil, nil, nil, nil)
+	_ = s.Serve(ctx, nil, adapters, nil, nil, nil, nil, nil)
 
 	second := &fakeAdapters{}
-	if err := s.Serve(ctx, nil, second, nil, nil, nil, nil); err != nil {
+	if err := s.Serve(ctx, nil, second, nil, nil, nil, nil, nil); err != nil {
 		t.Errorf("second Serve = %v, want nil", err)
 	}
 	if second.loaded {

--- a/pkg/controlplane/runtime/lifecycle/service_test.go
+++ b/pkg/controlplane/runtime/lifecycle/service_test.go
@@ -86,7 +86,7 @@ type fakeRollupStopper struct {
 	closerToCheck *fakeStoreCloser
 }
 
-func (f *fakeRollupStopper) StopRollups() {
+func (f *fakeRollupStopper) StopRollups(ctx context.Context) {
 	f.stopped = true
 	if f.closerToCheck != nil {
 		f.closedAtStop = f.closerToCheck.closed

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -263,7 +263,13 @@ func (r *Runtime) SetShutdownTimeout(d time.Duration) {
 //     use-after-close.
 //  2. StopAllAdapters — adapters no longer accept new RPCs. Existing
 //     in-flight RPCs fail naturally (no waiters left to receive them).
-//  3. CloseMetadataStores — now safe; nothing holds open references.
+//  3. StopRollups — fence every share's rollup worker pool (#1543). The
+//     rollup ticker persists FileChunk manifests + rollup offsets through the
+//     metadata store; if the store's DB closes while a rollup is in flight it
+//     fails with "sql: database is closed" and can drop a local chunk that was
+//     never mirrored. Draining here (metadata still open) closes that race.
+//     Block stores stay open — their full teardown is RemoveShare's job.
+//  4. CloseMetadataStores — now safe; nothing holds open references.
 //
 // Idempotent: a second call is a no-op (runtimeCancel is already
 // triggered, adapters and storesSvc handle re-close internally).
@@ -305,6 +311,11 @@ func (r *Runtime) Shutdown(ctx context.Context) error {
 		// close still must run so file handles are released.
 		logger.Warn("Runtime.Shutdown: StopAllAdapters error", "error", err)
 	}
+	// Fence the per-share rollup workers BEFORE closing the metadata stores
+	// (#1543): the rollup ticker writes FileChunk manifests + rollup offsets
+	// through the metadata store, so an in-flight rollup must be drained while
+	// the DB is still open or it races the close.
+	r.sharesSvc.StopRollups()
 	r.CloseMetadataStores()
 	return nil
 }
@@ -761,8 +772,15 @@ func (r *Runtime) Serve(ctx context.Context) error {
 		logger.Error("restore recovery returned error (continuing startup)", "error", err)
 	}
 
-	return r.lifecycleSvc.Serve(ctx, r.settingsWatcher, r.adaptersSvc, r.metadataService, r.storesSvc, r.store, r)
+	return r.lifecycleSvc.Serve(ctx, r.settingsWatcher, r.adaptersSvc, r.metadataService, r.storesSvc, r.store, r, r)
 }
+
+// StopRollups stops + drains every share's block-store rollup worker pool.
+// Exposed for the lifecycle.Service shutdown sequence (#1543) so the normal
+// server path (signal -> ctx cancel -> lifecycle.shutdown) fences the rollup
+// ticker BEFORE CloseMetadataStores — otherwise an in-flight rollup races the
+// metadata-store close and fails with "sql: database is closed".
+func (r *Runtime) StopRollups() { r.sharesSvc.StopRollups() }
 
 // ShutdownSnapshots exposes shutdownSnapshots for the lifecycle.Service
 // shutdown sequence so the normal server path (signal -> ctx cancel ->

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -314,8 +314,9 @@ func (r *Runtime) Shutdown(ctx context.Context) error {
 	// Fence the per-share rollup workers BEFORE closing the metadata stores
 	// (#1543): the rollup ticker writes FileChunk manifests + rollup offsets
 	// through the metadata store, so an in-flight rollup must be drained while
-	// the DB is still open or it races the close.
-	r.sharesSvc.StopRollups()
+	// the DB is still open or it races the close. Bounded by the caller's ctx
+	// (an overall deadline across shares) so shutdown stays predictable.
+	r.sharesSvc.StopRollups(ctx)
 	r.CloseMetadataStores()
 	return nil
 }
@@ -780,7 +781,7 @@ func (r *Runtime) Serve(ctx context.Context) error {
 // server path (signal -> ctx cancel -> lifecycle.shutdown) fences the rollup
 // ticker BEFORE CloseMetadataStores — otherwise an in-flight rollup races the
 // metadata-store close and fails with "sql: database is closed".
-func (r *Runtime) StopRollups() { r.sharesSvc.StopRollups() }
+func (r *Runtime) StopRollups(ctx context.Context) { r.sharesSvc.StopRollups(ctx) }
 
 // ShutdownSnapshots exposes shutdownSnapshots for the lifecycle.Service
 // shutdown sequence so the normal server path (signal -> ctx cancel ->

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1457,25 +1457,44 @@ func (s *Service) RemoveShare(name string) error {
 // an in-flight rollup races the DB close ("sql: database is closed") and can
 // drop a local chunk that was never mirrored.
 //
+// The ctx bounds the TOTAL drain time (an overall deadline): each store is
+// given the time remaining until ctx's deadline as its grace, so shutdown stays
+// bounded regardless of share count. Once the budget is spent the worker-pool
+// fence still runs (that is the load-bearing part — it stops the ticker); only
+// the best-effort drain is skipped, and those intervals resume on restart.
+//
 // Best-effort — a per-share drain error is logged, not propagated, so one share
 // cannot block the rest of shutdown. Drains run outside the registry lock (a
-// drain can block up to the store's grace window). The block stores stay OPEN;
-// their full teardown still happens in RemoveShare.
-func (s *Service) StopRollups() {
+// drain can block up to its grace window). The block stores stay OPEN; their
+// full teardown still happens in RemoveShare.
+func (s *Service) StopRollups(ctx context.Context) {
+	type namedStore struct {
+		name string
+		bs   *engine.Store
+	}
 	s.mu.RLock()
-	stores := make([]*engine.Store, 0, len(s.registry))
-	for _, share := range s.registry {
+	stores := make([]namedStore, 0, len(s.registry))
+	for name, share := range s.registry {
 		if share.BlockStore != nil {
-			stores = append(stores, share.BlockStore)
+			stores = append(stores, namedStore{name: name, bs: share.BlockStore})
 		}
 	}
 	s.mu.RUnlock()
 
-	for _, bs := range stores {
-		// grace 0 defers to the store's default drain window, matching Close.
-		if err := bs.StopRollup(0); err != nil {
-			logger.Warn("StopRollups: rollup drain incomplete for a share; remaining rollups resume on restart",
-				"error", err)
+	for _, ns := range stores {
+		// grace = time left until the shared deadline (overall bound). No
+		// deadline → 0, which defers to the store's default. Budget already
+		// spent → a 1ms floor so we still fence the pool without reviving the
+		// 30s default that GracefulStopRollup applies to grace <= 0.
+		grace := time.Duration(0)
+		if dl, ok := ctx.Deadline(); ok {
+			if grace = time.Until(dl); grace <= 0 {
+				grace = time.Millisecond
+			}
+		}
+		if err := ns.bs.StopRollup(grace); err != nil {
+			logger.Warn("Failed to stop rollup for share; remaining rollups resume on restart",
+				"share", ns.name, "error", err)
 		}
 	}
 }

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1450,6 +1450,36 @@ func (s *Service) RemoveShare(name string) error {
 	return errors.Join(errs...)
 }
 
+// StopRollups stops and drains the rollup worker pool of every registered
+// share's block store. The runtime calls this during shutdown BEFORE it closes
+// the metadata stores (#1543): the rollup ticker persists FileChunk manifests
+// and rollup offsets through the metadata store, so it must be fenced first or
+// an in-flight rollup races the DB close ("sql: database is closed") and can
+// drop a local chunk that was never mirrored.
+//
+// Best-effort — a per-share drain error is logged, not propagated, so one share
+// cannot block the rest of shutdown. Drains run outside the registry lock (a
+// drain can block up to the store's grace window). The block stores stay OPEN;
+// their full teardown still happens in RemoveShare.
+func (s *Service) StopRollups() {
+	s.mu.RLock()
+	stores := make([]*engine.Store, 0, len(s.registry))
+	for _, share := range s.registry {
+		if share.BlockStore != nil {
+			stores = append(stores, share.BlockStore)
+		}
+	}
+	s.mu.RUnlock()
+
+	for _, bs := range stores {
+		// grace 0 defers to the store's default drain window, matching Close.
+		if err := bs.StopRollup(0); err != nil {
+			logger.Warn("StopRollups: rollup drain incomplete for a share; remaining rollups resume on restart",
+				"error", err)
+		}
+	}
+}
+
 func (s *Service) UpdateShare(name string, readOnly *bool, defaultPermission *string, retentionPolicy *block.RetentionPolicy, retentionTTL *time.Duration) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
## Problem

`TestSnapshotByteVerify_EncryptedRemote_Matrix/sqlite` flakes on Windows CI with:

```
rollupFile failed ... error=rollup: ObjectIDPersister: ... sql: database is closed source=ticker
```

Closes #1543.

## Root cause

Teardown/shutdown ordering race. The per-share rollup ticker persists FileChunk manifests and rollup offsets **through the metadata store**. On shutdown the runtime closed the metadata stores while those rollup worker goroutines were still live, so an in-flight `rollupFile` hit `sql: database is closed`. Because the local chunk can already be staged while the mirror-to-remote persist fails mid-flight, the test then sees a chunk "lost locally before mirror to remote".

Block-store lifecycle is share-scoped (`RemoveShare`), which runs *after* shutdown closes metadata — so nothing fenced the ticker before the DB closed. This affects **both** shutdown paths:
- `Runtime.Shutdown` (test / API), and
- the production `lifecycle.Service.shutdown` sequence the real `dfs` server runs on SIGINT/SIGTERM.

## Fix

Stop + drain every share's rollup worker pool **before** `CloseMetadataStores`, in both shutdown paths (after adapters stop, so no new writes create fresh rollup work):

- `engine.Store.StopRollup(grace)` — delegates to the existing, idempotent `FSStore.GracefulStopRollup` via a narrow consumer-defined `rollupStopper` interface (memory stores have no rollup pool → benign no-op).
- `shares.Service.StopRollups()` — drains every registered share's block store (best-effort; per-share error logged, not propagated).
- Wired into `Runtime.Shutdown` and threaded through `lifecycle.Service.Serve/shutdown` via a narrow `RollupStopper` interface.

Block stores otherwise **stay open** — their full teardown (fds, remote, Windows tempdir ordering) remains `RemoveShare`'s job. `GracefulStopRollup` is guarded by `stopRollupOnce`, so the later `Close` is a safe no-op.

## Verification

- `go test -race ./pkg/controlplane/runtime/ -run TestSnapshotByteVerify_EncryptedRemote_Matrix -count=5` — green, race-clean.
- `go test -race ./pkg/controlplane/runtime/... ./pkg/block/engine/... ./pkg/block/local/...` — 1034 passed.
- New lifecycle unit assertion proves `StopRollups` runs before `CloseMetadataStores`.
- `gofmt` / `go vet` / `golangci-lint` clean on touched packages.

Note: commit is unsigned — the SSH signing agent (1Password) isn't reachable from the automation shell.