### PR TITLE
feat(block): local log-blob compaction for hot-cache eviction (#1497)

### DIFF
--- a/pkg/block/local/fs/eviction.go
+++ b/pkg/block/local/fs/eviction.go
@@ -121,6 +121,16 @@ func (bc *FSStore) ensureSpace(ctx context.Context, needed int64) error {
 				return fmt.Errorf("ensureSpace: %w", berr)
 			}
 
+			// No fully-synced blob to drop whole. Try compaction (#1497):
+			// relocate a sealed blob's unsynced survivors into the active blob
+			// and reclaim the dead remainder, so a few unsynced chunks no longer
+			// pin a whole blob and --local-store-size stays enforceable.
+			if cfreed, cerr := bc.compactBlobOne(ctx); cerr == nil && cfreed > 0 {
+				continue
+			} else if cerr != nil && !errors.Is(cerr, errLRUEmpty) {
+				return fmt.Errorf("ensureSpace: %w", cerr)
+			}
+
 			// blobEvictOne found no sealed, fully-synced blob to reclaim, yet
 			// log-blob bytes remain — they are sitting in the still-open active
 			// blob. This is the read-through cache case: a small maxDisk fills
@@ -283,43 +293,60 @@ func (bc *FSStore) blobEvictOne(ctx context.Context) (int64, error) {
 		}
 		if !bc.blobSynced(ctx, id) {
 			// Blobs are strictly time-ordered: if the oldest candidate is
-			// unsynced, newer ones are too — stop scanning.
+			// unsynced, newer ones are too — stop scanning. The unsynced bytes
+			// pinning this blob are reclaimed at sub-blob granularity by
+			// compactBlobOne (#1497), which the caller tries next.
 			return 0, errLRUEmpty
 		}
-		// The synced predicate already ran above; EvictBlob re-checks active/
-		// already-evicted state itself.
-		if err := bc.logBlob.EvictBlob(ctx, id, func(string) bool { return true }); err != nil {
-			if errors.Is(err, logblob.ErrActiveBlob) {
-				return 0, errLRUEmpty
-			}
-			// The blob may still have transitioned to evicted in-memory (only
-			// the unlink failed). Do NOT mark it processed or adjust the
-			// counter: the retry path below settles the accounting.
-			return 0, fmt.Errorf("blob evict: %w", err)
+		freed, err := bc.evictBlobLocked(ctx, id, infos[i].Size)
+		if err != nil {
+			return 0, err // errLRUEmpty (active blob) or a real evict failure
 		}
-		// EvictBlob is idempotent-nil for a blob it already evicted, and it
-		// never retries a failed unlink — so nil does NOT guarantee the file
-		// is gone. Only subtract the bytes when the file has actually left
-		// the disk; otherwise usedBytes would undercount physical usage.
-		// An orphan's bytes stay counted until a restart re-seeds from the
-		// physical files and retries the eviction with a fresh manager.
-		bc.blobEvictedIDs[id] = struct{}{}
-		bc.dropBlobIndexEntries(ctx, id)
-		orphanPath := filepath.Join(bc.baseDir, "blobs", id+".blob")
-		if _, statErr := os.Stat(orphanPath); statErr == nil || !os.IsNotExist(statErr) {
-			logger.Warn("local store: evicted log blob still on disk (unlink failed earlier); keeping its bytes counted until restart",
-				"blob", id, "bytes", infos[i].Size, "dir", bc.baseDir)
-			continue // try the next candidate
-		}
-		bc.subUsed(&bc.logBlobDiskUsed, infos[i].Size, "logblob")
-		if rec := bc.recordMetrics(); rec != nil {
-			rec.RecordEviction(infos[i].Size)
+		if freed == 0 {
+			continue // orphan: unlink failed earlier, bytes stay counted
 		}
 		logger.Info("local store: evicted sealed log blob",
-			"blob", id, "bytes", infos[i].Size, "dir", bc.baseDir)
-		return infos[i].Size, nil
+			"blob", id, "bytes", freed, "dir", bc.baseDir)
+		return freed, nil
 	}
 	return 0, errLRUEmpty
+}
+
+// evictBlobLocked physically removes sealed blob id (size bytes) from disk,
+// records it evicted, prunes its stale index entries, and settles disk
+// accounting. It FORCES eviction (synced predicate always true), so callers
+// must have already relocated every must-keep chunk in the blob — blobEvictOne
+// gates on blobSynced first; compactBlobOne relocates unsynced survivors first.
+//
+// Caller MUST hold bc.blobEvictMu.
+//
+// Returns the bytes reclaimed, or 0 when the unlink failed and the file is
+// still on disk (its bytes stay counted until a restart re-seeds and retries).
+// EvictBlob is idempotent-nil for an already-evicted blob and never retries a
+// failed unlink, so a nil error does not guarantee the file is gone — only
+// subtract when it has actually left the disk, or usedBytes would undercount.
+func (bc *FSStore) evictBlobLocked(ctx context.Context, id string, size int64) (int64, error) {
+	if err := bc.logBlob.EvictBlob(ctx, id, func(string) bool { return true }); err != nil {
+		if errors.Is(err, logblob.ErrActiveBlob) {
+			return 0, errLRUEmpty
+		}
+		// The blob may still have transitioned to evicted in-memory (only the
+		// unlink failed). Do NOT mark it processed or adjust the counter.
+		return 0, fmt.Errorf("blob evict: %w", err)
+	}
+	bc.blobEvictedIDs[id] = struct{}{}
+	bc.dropBlobIndexEntries(ctx, id)
+	orphanPath := filepath.Join(bc.baseDir, "blobs", id+".blob")
+	if _, statErr := os.Stat(orphanPath); statErr == nil || !os.IsNotExist(statErr) {
+		logger.Warn("local store: evicted log blob still on disk (unlink failed earlier); keeping its bytes counted until restart",
+			"blob", id, "bytes", size, "dir", bc.baseDir)
+		return 0, nil
+	}
+	bc.subUsed(&bc.logBlobDiskUsed, size, "logblob")
+	if rec := bc.recordMetrics(); rec != nil {
+		rec.RecordEviction(size)
+	}
+	return size, nil
 }
 
 // blobSynced reports whether every chunk in blobID has been durably mirrored
@@ -381,6 +408,184 @@ func (bc *FSStore) dropBlobIndexEntries(ctx context.Context, blobID string) {
 	}
 }
 
+// compactBlobOne reclaims the dead space pinned inside a sealed log blob whose
+// only surviving bytes are unsynced (crash-stranded) chunks — the exact case
+// blobEvictOne refuses because the whole blob is not synced. Without this, one
+// small unsynced chunk pins a whole ~1 GB blob and --local-store-size cannot be
+// enforced.
+//
+// It relocates those unsynced survivors into the active blob, fsyncs them, and
+// then drops the old blob whole — reclaiming every dead/synced byte at sub-blob
+// granularity. Synced chunks are NOT relocated: dropping the old blob removes
+// their index entries so the next read refetches them from the durable remote
+// copy (they are hot-cache misses, never data loss).
+//
+// Returns the bytes reclaimed, or (0, errLRUEmpty) when no sealed blob has any
+// reclaimable dead weight: every candidate is either fully synced (handled by
+// blobEvictOne), entirely unsynced-live (nothing can be reclaimed), or a
+// pre-restart blob with no per-chunk record to enumerate.
+//
+// Durability invariant: the only durable copy of an unsynced chunk is its
+// log-blob bytes. relocateSurvivors fsyncs the active blob BEFORE rewriting any
+// durable index entry and BEFORE the old blob is deleted, so at every instant
+// the chunk is readable from at least one durable location. A crash mid-compact
+// leaves the index pointing at the still-present old blob (survivor re-appended
+// but index not yet flipped) or at the fsynced new copy (index flipped, old
+// blob not yet deleted) — never at lost bytes.
+//
+// ponytail: covers in-process blobs (those with a blobChunks record); a blob
+// carried over from a previous process is left to the coarse whole-blob gate,
+// matching blobEvictOne's tracked/untracked split. Add index-scan enumeration
+// only if pre-restart pinning is observed in practice.
+func (bc *FSStore) compactBlobOne(ctx context.Context) (int64, error) {
+	if bc.logBlob == nil || bc.localChunkIndex == nil || bc.syncedHashStore == nil {
+		return 0, errLRUEmpty
+	}
+
+	// Serialize with blobEvictOne (same accounting + evictedIDs bookkeeping).
+	bc.blobEvictMu.Lock()
+	defer bc.blobEvictMu.Unlock()
+
+	infos, err := bc.logBlob.ListBlobs()
+	if err != nil {
+		return 0, fmt.Errorf("blob compact: list blobs: %w", err)
+	}
+	// Oldest-first, matching blobEvictOne's LRU-ish ordering.
+	for i := range infos {
+		if infos[i].Active {
+			continue
+		}
+		id := infos[i].LogBlobID
+		if _, done := bc.blobEvictedIDs[id]; done {
+			continue
+		}
+		survivors, unsyncedBytes, ok := bc.blobSurvivors(ctx, id)
+		if !ok {
+			continue // pre-restart blob: no per-chunk record to enumerate
+		}
+		if unsyncedBytes >= infos[i].Size {
+			// Entirely unsynced-live: relocating would copy the whole blob for
+			// zero net reclaim. Nothing to gain — skip.
+			continue
+		}
+		if err := bc.relocateSurvivors(ctx, id, survivors); err != nil {
+			// A survivor's bytes were unreadable (torn/corrupt sealed blob).
+			// Never delete a blob whose must-keep chunks we could not relocate:
+			// skip it and try the next candidate. Any already-appended survivor
+			// bytes are harmless orphans (index still points at the old blob).
+			logger.Warn("local store: blob compaction relocate failed, skipping",
+				"blob", id, "error", err, "dir", bc.baseDir)
+			continue
+		}
+		freed, err := bc.evictBlobLocked(ctx, id, infos[i].Size)
+		if err != nil {
+			return 0, err // errLRUEmpty (active blob) or a real evict failure
+		}
+		if freed == 0 {
+			continue // orphan: unlink failed earlier, bytes stay counted
+		}
+		logger.Info("local store: compacted sealed log blob",
+			"blob", id, "reclaimed", freed, "relocated_bytes", unsyncedBytes,
+			"survivors", len(survivors), "dir", bc.baseDir)
+		return freed, nil
+	}
+	return 0, errLRUEmpty
+}
+
+// blobSurvivors returns the unsynced chunks still resident in blobID (index
+// entry still points at blobID and IsSynced reports false) — the chunks
+// compaction must relocate before the blob can be dropped — with their total
+// byte size. ok is false when blobID has no per-chunk record (a pre-restart
+// blob compaction cannot enumerate). A chunk whose sync state cannot be
+// confirmed is treated as a survivor (never drop a chunk we cannot prove is
+// durable elsewhere).
+func (bc *FSStore) blobSurvivors(ctx context.Context, blobID string) (survivors []block.ContentHash, unsyncedBytes int64, ok bool) {
+	bc.blobChunksMu.Lock()
+	recorded, tracked := bc.blobChunks[blobID]
+	hashes := make([]block.ContentHash, len(recorded))
+	copy(hashes, recorded)
+	bc.blobChunksMu.Unlock()
+	if !tracked {
+		return nil, 0, false
+	}
+	for _, h := range hashes {
+		loc, present, err := bc.localChunkIndex.GetLocalLocation(ctx, h)
+		if err != nil || !present || loc.LogBlobID != blobID {
+			continue // deleted or re-staged elsewhere: dead weight here
+		}
+		synced, serr := bc.syncedHashStore.IsSynced(ctx, h)
+		if serr == nil && synced {
+			continue // durable on remote: drop-and-refetch, no relocate needed
+		}
+		survivors = append(survivors, h)
+		unsyncedBytes += loc.RawLength
+	}
+	return survivors, unsyncedBytes, true
+}
+
+// relocateSurvivors copies each survivor chunk's bytes out of the old sealed
+// blob into the active blob, fsyncs the active blob, then rewrites the durable
+// index entry to the new location. The fsync BEFORE the index rewrite upholds
+// the durability invariant: no durable index entry may reference un-fsynced
+// bytes. Until the rewrite the old entry (and old blob) still resolve the
+// chunk, so a crash never strands it.
+//
+// One chunk is held in RAM at a time (bounded by the FastCDC chunk size), never
+// the whole blob. A read failure on any survivor returns an error so the caller
+// leaves the old blob in place rather than deleting bytes it could not relocate.
+func (bc *FSStore) relocateSurvivors(ctx context.Context, oldBlobID string, survivors []block.ContentHash) error {
+	if len(survivors) == 0 {
+		return nil
+	}
+	type moved struct {
+		h   block.ContentHash
+		loc block.LocalChunkLocation
+	}
+	relocated := make([]moved, 0, len(survivors))
+	for _, h := range survivors {
+		loc, present, err := bc.localChunkIndex.GetLocalLocation(ctx, h)
+		if err != nil {
+			return fmt.Errorf("get local location %s: %w", h.String(), err)
+		}
+		if !present || loc.LogBlobID != oldBlobID {
+			continue // moved/deleted since the survivor scan: no longer ours
+		}
+		if loc.RawLength == 0 {
+			continue // zero-length chunk has no bytes in any blob
+		}
+		// One chunk in RAM at a time — bounded by the FastCDC chunk size, never
+		// the whole log blob.
+		dst := make([]byte, loc.RawLength)
+		n, rerr := bc.logBlob.ReadAt(ctx, loc, dst)
+		if rerr != nil || int64(n) < loc.RawLength {
+			return fmt.Errorf("read survivor %s from %s (torn or unreadable): %w",
+				h.String(), oldBlobID, rerr)
+		}
+		newLoc, aerr := bc.logBlob.Append(ctx, dst)
+		if aerr != nil {
+			return fmt.Errorf("append survivor %s: %w", h.String(), aerr)
+		}
+		relocated = append(relocated, moved{h: h, loc: newLoc})
+	}
+	if len(relocated) == 0 {
+		return nil
+	}
+	// Durability fence: fsync the active blob so every relocated survivor is on
+	// stable storage BEFORE any durable index entry points at it. (Size-cap
+	// rotations during the Append loop already fsynced the blobs they sealed.)
+	if err := bc.logBlob.Sync(); err != nil {
+		return fmt.Errorf("sync active blob before index rewrite: %w", err)
+	}
+	for _, m := range relocated {
+		if err := bc.localChunkIndex.PutLocalLocation(ctx, m.h, m.loc); err != nil {
+			return fmt.Errorf("rewrite index %s: %w", m.h.String(), err)
+		}
+		bc.logBlobDiskUsed.Add(m.loc.RawLength)
+		bc.trackBlobChunk(m.loc.LogBlobID, m.h)
+	}
+	return nil
+}
+
 // reclaimSpace is the write-path counterpart of ensureSpace: called after a
 // rollup pass lands new log-blob bytes, it evicts synced CAS chunks and
 // sealed synced blobs until the store is back under maxDisk. Best-effort and
@@ -413,10 +618,22 @@ func (bc *FSStore) reclaimSpace(ctx context.Context) {
 			logger.Warn("reclaimSpace: CAS eviction failed", "dir", bc.baseDir, "error", err)
 			return
 		}
-		if _, err := bc.blobEvictOne(ctx); err != nil {
+		if bfreed, err := bc.blobEvictOne(ctx); err != nil {
 			if !errors.Is(err, errLRUEmpty) {
 				logger.Warn("reclaimSpace: blob eviction failed", "dir", bc.baseDir, "error", err)
+				return
 			}
+			// No fully-synced blob to drop whole. Compact a blob pinned by
+			// unsynced survivors (#1497); stop when nothing more can be freed.
+			if cfreed, cerr := bc.compactBlobOne(ctx); cerr != nil {
+				if !errors.Is(cerr, errLRUEmpty) {
+					logger.Warn("reclaimSpace: blob compaction failed", "dir", bc.baseDir, "error", cerr)
+				}
+				return
+			} else if cfreed == 0 {
+				return
+			}
+		} else if bfreed == 0 {
 			return
 		}
 	}

--- a/pkg/block/local/fs/eviction.go
+++ b/pkg/block/local/fs/eviction.go
@@ -420,9 +420,10 @@ func (bc *FSStore) dropBlobIndexEntries(ctx context.Context, blobID string) {
 // their index entries so the next read refetches them from the durable remote
 // copy (they are hot-cache misses, never data loss).
 //
-// Returns the bytes reclaimed, or (0, errLRUEmpty) when no sealed blob has any
-// reclaimable dead weight: every candidate is either fully synced (handled by
-// blobEvictOne), entirely unsynced-live (nothing can be reclaimed), or a
+// Returns the NET bytes reclaimed (the old blob's size minus the survivor bytes
+// re-appended into the active blob), or (0, errLRUEmpty) when no sealed blob has
+// any reclaimable dead weight: every candidate is either fully synced (handled
+// by blobEvictOne), entirely unsynced-live (nothing can be reclaimed), or a
 // pre-restart blob with no per-chunk record to enumerate.
 //
 // Durability invariant: the only durable copy of an unsynced chunk is its
@@ -468,7 +469,8 @@ func (bc *FSStore) compactBlobOne(ctx context.Context) (int64, error) {
 			// zero net reclaim. Nothing to gain — skip.
 			continue
 		}
-		if err := bc.relocateSurvivors(ctx, id, survivors); err != nil {
+		relocatedBytes, err := bc.relocateSurvivors(ctx, id, survivors)
+		if err != nil {
 			// A survivor's bytes were unreadable (torn/corrupt sealed blob).
 			// Never delete a blob whose must-keep chunks we could not relocate:
 			// skip it and try the next candidate. Any already-appended survivor
@@ -484,10 +486,13 @@ func (bc *FSStore) compactBlobOne(ctx context.Context) (int64, error) {
 		if freed == 0 {
 			continue // orphan: unlink failed earlier, bytes stay counted
 		}
+		// NET reclaimed: the old blob's bytes left disk, but the survivors were
+		// re-appended into the active blob, so those bytes were not freed.
+		net := freed - relocatedBytes
 		logger.Info("local store: compacted sealed log blob",
-			"blob", id, "reclaimed", freed, "relocated_bytes", unsyncedBytes,
-			"survivors", len(survivors), "dir", bc.baseDir)
-		return freed, nil
+			"blob", id, "net_reclaimed", net, "relocated_bytes", relocatedBytes,
+			"blob_size", freed, "survivors", len(survivors), "dir", bc.baseDir)
+		return net, nil
 	}
 	return 0, errLRUEmpty
 }
@@ -523,6 +528,26 @@ func (bc *FSStore) blobSurvivors(ctx context.Context, blobID string) (survivors 
 	return survivors, unsyncedBytes, true
 }
 
+// survivorReadErr classifies the result of reading a survivor chunk's bytes out
+// of the old blob. It returns a non-nil error whenever the bytes could not be
+// fully read — INCLUDING a short read with a nil error (n < want, rerr == nil).
+// That nil-error case is the trap: forwarding it as fmt.Errorf("...%w", rerr)
+// yields a NIL error, which would let the caller evict the old blob after only
+// partially relocating a must-keep (unsynced, only-copy) survivor — permanent
+// data loss. os.File.ReadAt honors the io.ReaderAt contract (short read ⇒
+// non-nil error), so the nil-short branch is defensive, but a silent nil here
+// is unrecoverable, so it is guarded explicitly.
+func survivorReadErr(n int, rerr error, want int64, h block.ContentHash, blobID string) error {
+	if rerr != nil {
+		return fmt.Errorf("read survivor %s from %s: %w", h.String(), blobID, rerr)
+	}
+	if int64(n) < want {
+		return fmt.Errorf("read survivor %s from %s: torn tail, got %d of %d bytes",
+			h.String(), blobID, n, want)
+	}
+	return nil
+}
+
 // relocateSurvivors copies each survivor chunk's bytes out of the old sealed
 // blob into the active blob, fsyncs the active blob, then rewrites the durable
 // index entry to the new location. The fsync BEFORE the index rewrite upholds
@@ -533,9 +558,12 @@ func (bc *FSStore) blobSurvivors(ctx context.Context, blobID string) (survivors 
 // One chunk is held in RAM at a time (bounded by the FastCDC chunk size), never
 // the whole blob. A read failure on any survivor returns an error so the caller
 // leaves the old blob in place rather than deleting bytes it could not relocate.
-func (bc *FSStore) relocateSurvivors(ctx context.Context, oldBlobID string, survivors []block.ContentHash) error {
+//
+// Returns the total bytes actually relocated (the second on-disk copy the caller
+// must subtract from the evicted blob's size to report NET reclaimed).
+func (bc *FSStore) relocateSurvivors(ctx context.Context, oldBlobID string, survivors []block.ContentHash) (int64, error) {
 	if len(survivors) == 0 {
-		return nil
+		return 0, nil
 	}
 	type moved struct {
 		h   block.ContentHash
@@ -545,7 +573,7 @@ func (bc *FSStore) relocateSurvivors(ctx context.Context, oldBlobID string, surv
 	for _, h := range survivors {
 		loc, present, err := bc.localChunkIndex.GetLocalLocation(ctx, h)
 		if err != nil {
-			return fmt.Errorf("get local location %s: %w", h.String(), err)
+			return 0, fmt.Errorf("get local location %s: %w", h.String(), err)
 		}
 		if !present || loc.LogBlobID != oldBlobID {
 			continue // moved/deleted since the survivor scan: no longer ours
@@ -557,33 +585,34 @@ func (bc *FSStore) relocateSurvivors(ctx context.Context, oldBlobID string, surv
 		// the whole log blob.
 		dst := make([]byte, loc.RawLength)
 		n, rerr := bc.logBlob.ReadAt(ctx, loc, dst)
-		if rerr != nil || int64(n) < loc.RawLength {
-			return fmt.Errorf("read survivor %s from %s (torn or unreadable): %w",
-				h.String(), oldBlobID, rerr)
+		if err := survivorReadErr(n, rerr, loc.RawLength, h, oldBlobID); err != nil {
+			return 0, err
 		}
 		newLoc, aerr := bc.logBlob.Append(ctx, dst)
 		if aerr != nil {
-			return fmt.Errorf("append survivor %s: %w", h.String(), aerr)
+			return 0, fmt.Errorf("append survivor %s: %w", h.String(), aerr)
 		}
 		relocated = append(relocated, moved{h: h, loc: newLoc})
 	}
 	if len(relocated) == 0 {
-		return nil
+		return 0, nil
 	}
 	// Durability fence: fsync the active blob so every relocated survivor is on
 	// stable storage BEFORE any durable index entry points at it. (Size-cap
 	// rotations during the Append loop already fsynced the blobs they sealed.)
 	if err := bc.logBlob.Sync(); err != nil {
-		return fmt.Errorf("sync active blob before index rewrite: %w", err)
+		return 0, fmt.Errorf("sync active blob before index rewrite: %w", err)
 	}
+	var relocatedBytes int64
 	for _, m := range relocated {
 		if err := bc.localChunkIndex.PutLocalLocation(ctx, m.h, m.loc); err != nil {
-			return fmt.Errorf("rewrite index %s: %w", m.h.String(), err)
+			return 0, fmt.Errorf("rewrite index %s: %w", m.h.String(), err)
 		}
 		bc.logBlobDiskUsed.Add(m.loc.RawLength)
 		bc.trackBlobChunk(m.loc.LogBlobID, m.h)
+		relocatedBytes += m.loc.RawLength
 	}
-	return nil
+	return relocatedBytes, nil
 }
 
 // reclaimSpace is the write-path counterpart of ensureSpace: called after a

--- a/pkg/block/local/fs/logblob_compaction_1497_test.go
+++ b/pkg/block/local/fs/logblob_compaction_1497_test.go
@@ -1,0 +1,237 @@
+package fs
+
+// Tests for #1497 (part of the blocks-only epic #1493): local log-blob
+// compaction. A sealed log blob mixes cold synced chunks (evictable, refetchable
+// from the remote) with unsynced chunks (the only durable copy). blobEvictOne
+// refuses the whole blob if any chunk is unsynced, so one small unsynced chunk
+// pins a whole ~1 GB blob and --local-store-size becomes unenforceable.
+//
+// compactBlobOne relocates the unsynced survivors into the active blob
+// (fsynced BEFORE the index is rewritten and BEFORE the old blob is dropped, so
+// the only durable copy is never stranded) and then drops the old blob whole,
+// reclaiming the cold remainder at sub-blob granularity.
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestCompaction_ReclaimsSyncedRemainderKeepsUnsynced is the core case: a sealed
+// blob holding one synced chunk (cold, evictable) and one unsynced chunk (only
+// copy). blobEvictOne refuses it; compaction relocates the unsynced survivor and
+// reclaims the synced chunk's bytes.
+func TestCompaction_ReclaimsSyncedRemainderKeepsUnsynced(t *testing.T) {
+	dir := t.TempDir()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc := newBlobStoreWithLimit(t, dir, 0, mds)
+	ctx := context.Background()
+
+	syncedData := bytes.Repeat([]byte{0x11}, 400)
+	syncedHash := blake3ContentHash(syncedData)
+	if err := bc.StoreChunk(ctx, syncedHash, syncedData); err != nil {
+		t.Fatalf("StoreChunk(synced): %v", err)
+	}
+	if err := mds.MarkSynced(ctx, syncedHash, block.ChunkLocator{}); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+
+	unsyncedData := bytes.Repeat([]byte{0x22}, 100)
+	unsyncedHash := blake3ContentHash(unsyncedData)
+	if err := bc.StoreChunk(ctx, unsyncedHash, unsyncedData); err != nil {
+		t.Fatalf("StoreChunk(unsynced): %v", err)
+	}
+
+	// Seal the blob so both chunks live in a sealed (compactable) blob.
+	if err := bc.logBlob.Rotate(); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+	if got := bc.Stats().DiskUsed; got != 500 {
+		t.Fatalf("DiskUsed before compaction = %d, want 500", got)
+	}
+
+	// blobEvictOne must REFUSE (the blob is not fully synced).
+	if freed, err := bc.blobEvictOne(ctx); !errors.Is(err, errLRUEmpty) || freed != 0 {
+		t.Fatalf("blobEvictOne = (%d, %v), want (0, errLRUEmpty) for a partly-unsynced blob", freed, err)
+	}
+
+	// Compaction reclaims the synced remainder, relocating the unsynced survivor.
+	if freed, err := bc.compactBlobOne(ctx); err != nil || freed <= 0 {
+		t.Fatalf("compactBlobOne = (%d, %v), want (>0, nil)", freed, err)
+	}
+
+	// Net on-disk usage is now just the relocated unsynced survivor.
+	if got := bc.Stats().DiskUsed; got != 100 {
+		t.Fatalf("DiskUsed after compaction = %d, want 100 (only the unsynced survivor remains)", got)
+	}
+
+	// The unsynced survivor must still read back byte-identical from its new home.
+	got, err := bc.ReadChunk(ctx, unsyncedHash)
+	if err != nil {
+		t.Fatalf("ReadChunk(unsynced survivor) after compaction: %v", err)
+	}
+	if !bytes.Equal(got, unsyncedData) {
+		t.Fatalf("relocated unsynced survivor returned wrong bytes")
+	}
+
+	// The synced chunk was dropped (durable on the remote): a clean local miss
+	// routes the engine to refetch.
+	if _, err := bc.ReadChunk(ctx, syncedHash); !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("ReadChunk(synced, dropped) = %v, want ErrChunkNotFound", err)
+	}
+}
+
+// TestCompaction_EntirelyUnsyncedBlob_Untouched pins the crash-stranded-data
+// invariant: a sealed blob whose every chunk is unsynced (the only durable copy)
+// has no reclaimable dead weight, so compaction must leave it entirely alone —
+// never relocate-then-drop for zero net gain, and never lose the bytes.
+func TestCompaction_EntirelyUnsyncedBlob_Untouched(t *testing.T) {
+	dir := t.TempDir()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc := newBlobStoreWithLimit(t, dir, 0, mds)
+	ctx := context.Background()
+
+	a := bytes.Repeat([]byte{0x33}, 200)
+	aHash := blake3ContentHash(a)
+	b := bytes.Repeat([]byte{0x44}, 150)
+	bHash := blake3ContentHash(b)
+	for _, d := range [][]byte{a, b} {
+		if err := bc.StoreChunk(ctx, blake3ContentHash(d), d); err != nil {
+			t.Fatalf("StoreChunk: %v", err)
+		}
+	}
+	if err := bc.logBlob.Rotate(); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+
+	// Nothing to reclaim: compaction reports errLRUEmpty and touches nothing.
+	if freed, err := bc.compactBlobOne(ctx); !errors.Is(err, errLRUEmpty) || freed != 0 {
+		t.Fatalf("compactBlobOne on all-unsynced blob = (%d, %v), want (0, errLRUEmpty)", freed, err)
+	}
+	if got := bc.Stats().DiskUsed; got != 350 {
+		t.Fatalf("DiskUsed = %d, want 350 (untouched)", got)
+	}
+	for _, tc := range []struct {
+		h    block.ContentHash
+		want []byte
+	}{{aHash, a}, {bHash, b}} {
+		got, err := bc.ReadChunk(ctx, tc.h)
+		if err != nil {
+			t.Fatalf("ReadChunk(unsynced) after compaction: %v", err)
+		}
+		if !bytes.Equal(got, tc.want) {
+			t.Fatalf("unsynced chunk bytes changed after compaction")
+		}
+	}
+}
+
+// TestCompaction_EnforcesLocalStoreSizeViaEnsureSpace is the headline: a Put
+// that pushes past --local-store-size succeeds because ensureSpace compacts a
+// sealed blob pinned by a small unsynced chunk — the exact enforcement gap
+// #1497 closes. Before compaction the same Put would fail with ErrDiskFull.
+func TestCompaction_EnforcesLocalStoreSizeViaEnsureSpace(t *testing.T) {
+	dir := t.TempDir()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc := newBlobStoreWithLimit(t, dir, 600, mds)
+	bc.evictMaxWait = 50 * time.Millisecond
+	ctx := context.Background()
+
+	// Sealed blob: 400 synced (cold) + 50 unsynced (pins the whole blob).
+	synced := bytes.Repeat([]byte{0x55}, 400)
+	syncedHash := blake3ContentHash(synced)
+	if err := bc.StoreChunk(ctx, syncedHash, synced); err != nil {
+		t.Fatalf("StoreChunk(synced): %v", err)
+	}
+	if err := mds.MarkSynced(ctx, syncedHash, block.ChunkLocator{}); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+	unsynced := bytes.Repeat([]byte{0x66}, 50)
+	unsyncedHash := blake3ContentHash(unsynced)
+	if err := bc.StoreChunk(ctx, unsyncedHash, unsynced); err != nil {
+		t.Fatalf("StoreChunk(unsynced): %v", err)
+	}
+	if err := bc.logBlob.Rotate(); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+
+	// used=450, +300 = 750 > 600. blobEvictOne can't touch the pinned blob;
+	// compaction reclaims the 400 synced bytes so the Put fits.
+	newData := bytes.Repeat([]byte{0x77}, 300)
+	newHash := blake3ContentHash(newData)
+	if err := bc.Put(ctx, newHash, newData); err != nil {
+		t.Fatalf("Put over limit: %v (compaction should have reclaimed the synced remainder)", err)
+	}
+
+	// Final footprint: relocated survivor (50) + new chunk (300).
+	if got := bc.Stats().DiskUsed; got != 350 {
+		t.Fatalf("DiskUsed after compacting Put = %d, want 350", got)
+	}
+	got, err := bc.ReadChunk(ctx, unsyncedHash)
+	if err != nil || !bytes.Equal(got, unsynced) {
+		t.Fatalf("unsynced survivor unreadable/wrong after compacting Put: err=%v", err)
+	}
+	if got, err := bc.ReadChunk(ctx, newHash); err != nil || !bytes.Equal(got, newData) {
+		t.Fatalf("new chunk unreadable/wrong after Put: err=%v", err)
+	}
+	if _, err := bc.ReadChunk(ctx, syncedHash); !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("ReadChunk(synced, dropped) = %v, want ErrChunkNotFound", err)
+	}
+}
+
+// TestCompaction_TornSurvivor_LeavesBlobInPlace covers the corruption guard:
+// if a must-keep (unsynced) survivor's bytes are unreadable, compaction must
+// NOT drop the blob (that would destroy the only remaining trace of the
+// survivor). It skips the blob and leaves it on disk.
+func TestCompaction_TornSurvivor_LeavesBlobInPlace(t *testing.T) {
+	dir := t.TempDir()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc := newBlobStoreWithLimit(t, dir, 0, mds)
+	ctx := context.Background()
+
+	// Synced chunk first, unsynced survivor LAST so truncation removes only the
+	// survivor's tail bytes.
+	synced := bytes.Repeat([]byte{0x88}, 300)
+	syncedHash := blake3ContentHash(synced)
+	if err := bc.StoreChunk(ctx, syncedHash, synced); err != nil {
+		t.Fatalf("StoreChunk(synced): %v", err)
+	}
+	if err := mds.MarkSynced(ctx, syncedHash, block.ChunkLocator{}); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+	unsynced := bytes.Repeat([]byte{0x99}, 100)
+	unsyncedHash := blake3ContentHash(unsynced)
+	if err := bc.StoreChunk(ctx, unsyncedHash, unsynced); err != nil {
+		t.Fatalf("StoreChunk(unsynced): %v", err)
+	}
+	loc, ok, err := bc.localChunkIndex.GetLocalLocation(ctx, unsyncedHash)
+	if err != nil || !ok {
+		t.Fatalf("GetLocalLocation(unsynced): ok=%v err=%v", ok, err)
+	}
+	if err := bc.logBlob.Rotate(); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+
+	// Physically truncate the sealed blob to lop off the unsynced survivor's
+	// bytes: its ReadAt now short-reads (torn). No cached fd exists yet (the
+	// blob has not been read since it sealed).
+	blobPath := filepath.Join(dir, "blobs", loc.LogBlobID+".blob")
+	if err := os.Truncate(blobPath, loc.RawOffset); err != nil {
+		t.Fatalf("truncate sealed blob: %v", err)
+	}
+
+	// Compaction cannot relocate the torn survivor, so it skips the blob and
+	// reports nothing reclaimable — the blob file must remain on disk.
+	if freed, err := bc.compactBlobOne(ctx); !errors.Is(err, errLRUEmpty) || freed != 0 {
+		t.Fatalf("compactBlobOne with torn survivor = (%d, %v), want (0, errLRUEmpty)", freed, err)
+	}
+	if _, statErr := os.Stat(blobPath); statErr != nil {
+		t.Fatalf("sealed blob was removed despite an un-relocatable survivor: %v", statErr)
+	}
+}

--- a/pkg/block/local/fs/logblob_compaction_1497_test.go
+++ b/pkg/block/local/fs/logblob_compaction_1497_test.go
@@ -15,6 +15,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -182,6 +183,30 @@ func TestCompaction_EnforcesLocalStoreSizeViaEnsureSpace(t *testing.T) {
 	}
 	if _, err := bc.ReadChunk(ctx, syncedHash); !errors.Is(err, block.ErrChunkNotFound) {
 		t.Fatalf("ReadChunk(synced, dropped) = %v, want ErrChunkNotFound", err)
+	}
+}
+
+// TestSurvivorReadErr_ShortReadNilError_IsNotNil is the regression for the
+// fmt.Errorf("...%w", nil) trap: a survivor read that returns fewer bytes than
+// wanted WITH a nil error must still yield a non-nil error. Forwarding the nil
+// would make relocateSurvivors "succeed" on a partially-read only-copy survivor,
+// letting compactBlobOne evict the old blob → permanent data loss. os.File can't
+// produce a nil-error short read (io.ReaderAt contract), so the classification
+// seam is unit-tested directly.
+func TestSurvivorReadErr_ShortReadNilError_IsNotNil(t *testing.T) {
+	h := blake3ContentHash([]byte("survivor"))
+
+	// Short read, nil error: the exact trap. Must be a real (non-nil) error.
+	if err := survivorReadErr(50, nil, 100, h, "0000000000000003"); err == nil {
+		t.Fatal("survivorReadErr(short, nil) = nil, want non-nil (else the old blob is evicted after a partial relocate → data loss)")
+	}
+	// Non-nil read error is propagated.
+	if err := survivorReadErr(0, io.EOF, 100, h, "0000000000000003"); err == nil {
+		t.Fatal("survivorReadErr(_, io.EOF) = nil, want non-nil")
+	}
+	// Full read, nil error: success.
+	if err := survivorReadErr(100, nil, 100, h, "0000000000000003"); err != nil {
+		t.Fatalf("survivorReadErr(full, nil) = %v, want nil", err)
 	}
 }
 


### PR DESCRIPTION
Closes #1497. Part of the blocks-only storage epic #1493.

## Problem

The local tier is a sequence of raw append-only log blobs. A durable index maps each chunk to a `{LogBlobID, RawOffset, RawLength}` byte-range. Eviction (`blobEvictOne`) works at **whole-blob** granularity and refuses any blob that is not fully synced — because an unsynced chunk is the only durable copy. So a single unsynced (or otherwise pinned) chunk pins an entire ~1 GB blob, and `--local-store-size` cannot actually be enforced: the disk can grow unbounded while eviction repeatedly gives up on the oldest blob.

## Change

`compactBlobOne` reclaims a sealed blob's dead byte-ranges at **sub-blob** granularity:

1. Enumerate the blob's chunks (via the in-process `blobChunks` record). A chunk is a **survivor** if its index entry still points at this blob and it is **not** synced.
2. Relocate the survivors' bytes into the active blob (`ReadAt` old -> `Append` new), one chunk in RAM at a time.
3. `fsync` the active blob, then rewrite each survivor's durable index entry to the new location.
4. Drop the old blob whole — reclaiming every synced/dead byte. Synced chunks are **not** relocated: dropping the blob removes their index entries so the next read refetches them from the durable remote copy (a hot-cache miss, never data loss).

Wired as a fallback after `blobEvictOne` in both `ensureSpace` (read-path staging) and `reclaimSpace` (post-rollup), so the disk limit is enforced even when the only reclaimable blobs are pinned by unsynced chunks. A pre-existing whole-blob physical-evict tail was extracted into `evictBlobLocked` and shared by both paths.

## Durability invariants preserved

- **No durable index entry ever references un-fsynced bytes** — `relocateSurvivors` calls `logBlob.Sync()` *before* any `PutLocalLocation` and *before* the old blob is deleted (size-cap rotations mid-loop also fsync the blob they seal). Every crash window leaves the chunk readable from either the still-present old blob or the already-fsynced new copy.
- **Crash-stranded (unsynced, local-only) chunks are never lost** — they are the only durable copy, so they are always relocated, never dropped.
- **Torn/short reads are safe** — an unreadable survivor aborts compaction of *that blob only* (skip-and-try-next); the blob is never deleted when a must-keep chunk could not be relocated. Covered by `TestCompaction_TornSurvivor_LeavesBlobInPlace`.
- **Disk accounting nets out** — relocated bytes are added to `logBlobDiskUsed`; the old blob's pre-relocation size is subtracted on evict; the orphan-unlink-failure path keeps bytes counted (unchanged contract).
- **Windows** — no new open-fd-over-removed-file hazard; the log-blob Manager already closes the sealed fd before unlink, and tests register store-close cleanup last (LIFO).

## Tests

New `logblob_compaction_1497_test.go`:
- reclaims the synced/dead remainder while the unsynced survivor stays readable byte-identical from its new location
- entirely-unsynced blob is left completely untouched (no zero-gain relocate, no data loss)
- end-to-end: a `Put` over `--local-store-size` succeeds because `ensureSpace` compacts a blob pinned by a small unsynced chunk
- torn survivor -> blob left in place

`go test -race ./pkg/block/...` green (1154 tests). `gofmt -s`, `go vet`, `golangci-lint run` clean.

## Known follow-up (out of scope)

Under compaction pressure the engine block carver does a non-atomic `GetLocalLocation` then `ReadLocalAt`; if compaction relocates+evicts the blob between those two calls, `ReadLocalAt` surfaces `ErrEvicted`/`ErrBlobNotFound` as a hard error instead of the "positively-located but gone" path. This is **self-healing today** — the carver requeues the hash and the next pass re-resolves the flipped location and succeeds; no data loss, just a spurious error log + one retried carve batch. A proper fix must distinguish "relocated" from "genuinely gone" (a naive widening of the error match would wrongly retire a still-unsynced chunk), so it is deliberately left for a separate change.
