### PR TITLE
feat(block): reclaim leaked records + record-less objects (#1525, PR5c)

### DIFF
--- a/cmd/dfsctl/commands/store/block/reclaim.go
+++ b/cmd/dfsctl/commands/store/block/reclaim.go
@@ -11,16 +11,24 @@ import (
 	"github.com/marmos91/dittofs/pkg/apiclient"
 )
 
-// reclaimCmd deletes class-1 orphans (zero-ref block records) across all
-// remote-backed shares. It is the first deleting stage after `reconcile`.
+// reclaimCmd deletes orphaned block storage (zero-ref + leaked records and
+// record-less remote objects) across all remote-backed shares. It is the deleting
+// counterpart to `reconcile`.
 var reclaimCmd = &cobra.Command{
 	Use:   "reclaim",
-	Short: "Reclaim zero-ref block records (deletes; use --dry-run to preview)",
-	Long: `Delete class-1 orphaned block records across every remote-backed share and
-free their remote objects. A zero-ref record has no live locator and a zero live
-chunk count — left behind by a crash between decrementing the count and deleting
-the record. Such a record is terminally dead, so reclaiming it is safe with no
-grace window.
+	Short: "Reclaim orphaned block storage (deletes; use --dry-run to preview)",
+	Long: `Delete orphaned block storage across every remote-backed share:
+
+  - zero-ref records: no live locator and a zero live chunk count (a crash
+    between decrementing the count and deleting the record);
+  - leaked records: no live locator but a stale non-zero count, left behind
+    when a block re-carve moved the hash without decrementing the old block;
+  - record-less remote objects: an uploaded block with no backing record,
+    older than the grace window (a commit that never landed).
+
+A record with no live locator is terminally dead — block IDs are never reused —
+so reclaiming records needs no grace window. Only record-less objects use one, to
+spare an upload whose commit may still be in flight.
 
 This DELETES. Run 'dfsctl store block reconcile' first to review what exists, or
 pass --dry-run here to preview the exact set this command would delete without
@@ -30,7 +38,7 @@ Examples:
   # Preview what would be reclaimed
   dfsctl store block reclaim --dry-run
 
-  # Reclaim zero-ref records
+  # Reclaim orphaned block storage
   dfsctl store block reclaim
 
   # As JSON for scripting
@@ -54,9 +62,9 @@ func runBlockStoreReclaim(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	report, err := client.BlockStoreReclaimZeroRef(&apiclient.BlockStoreReclaimZeroRefRequest{DryRun: dryRun})
+	report, err := client.BlockStoreReclaim(&apiclient.BlockStoreReclaimRequest{DryRun: dryRun})
 	if err != nil {
-		return fmt.Errorf("failed to reclaim zero-ref records: %w", err)
+		return fmt.Errorf("failed to reclaim orphaned block storage: %w", err)
 	}
 
 	format, err := cmdutil.GetOutputFormatParsed()
@@ -75,15 +83,20 @@ func runBlockStoreReclaim(cmd *cobra.Command, args []string) error {
 			verb = "Would reclaim"
 		}
 		pairs := [][2]string{
-			{verb, classSummary(report.Reclaimed)},
+			{verb + " zero-ref records", classSummary(report.Reclaimed)},
+			{verb + " leaked records", classSummary(report.LeakedReclaimed)},
+			{verb + " orphan objects", classSummary(report.OrphanObjectsReclaimed)},
 			{"Block records scanned", fmt.Sprintf("%d", report.BlockRecordsScanned)},
+			{"Remote objects scanned", fmt.Sprintf("%d", report.RemoteObjectsScanned)},
 			{"Errors", fmt.Sprintf("%d", report.Errors)},
 			{"Dry run", fmt.Sprintf("%t", report.DryRun)},
 		}
 		if err := output.SimpleTable(os.Stdout, pairs); err != nil {
 			return err
 		}
-		printSample(os.Stdout, verb, report.Reclaimed)
+		printSample(os.Stdout, verb+" zero-ref", report.Reclaimed)
+		printSample(os.Stdout, verb+" leaked", report.LeakedReclaimed)
+		printSample(os.Stdout, verb+" orphan object", report.OrphanObjectsReclaimed)
 		return nil
 	}
 }

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -652,7 +652,7 @@ Global flags:
         - [`dfsctl store block local edit`](#dfsctl-store-block-local-edit) — Edit a local block store
         - [`dfsctl store block local list`](#dfsctl-store-block-local-list) — List local block stores
         - [`dfsctl store block local remove`](#dfsctl-store-block-local-remove) — Remove a local block store
-      - [`dfsctl store block reclaim`](#dfsctl-store-block-reclaim) — Reclaim zero-ref block records (deletes; use --dry-run to preview)
+      - [`dfsctl store block reclaim`](#dfsctl-store-block-reclaim) — Reclaim orphaned block storage (deletes; use --dry-run to preview)
       - [`dfsctl store block reconcile`](#dfsctl-store-block-reconcile) — Report orphaned block storage (read-only; no deletes)
       - [`dfsctl store block remote`](#dfsctl-store-block-remote) — Remote block store management
         - [`dfsctl store block remote add`](#dfsctl-store-block-remote-add) — Add a remote block store
@@ -5961,13 +5961,22 @@ Global flags:
 
 ### `dfsctl store block reclaim`
 
-Reclaim zero-ref block records (deletes; use --dry-run to preview)
+Reclaim orphaned block storage (deletes; use --dry-run to preview)
 
-Delete class-1 orphaned block records across every remote-backed share and
-free their remote objects. A zero-ref record has no live locator and a zero live
-chunk count — left behind by a crash between decrementing the count and deleting
-the record. Such a record is terminally dead, so reclaiming it is safe with no
-grace window.
+Delete orphaned block storage across every remote-backed share:
+
+```
+- zero-ref records: no live locator and a zero live chunk count (a crash
+  between decrementing the count and deleting the record);
+- leaked records: no live locator but a stale non-zero count, left behind
+  when a block re-carve moved the hash without decrementing the old block;
+- record-less remote objects: an uploaded block with no backing record,
+  older than the grace window (a commit that never landed).
+```
+
+A record with no live locator is terminally dead — block IDs are never reused —
+so reclaiming records needs no grace window. Only record-less objects use one, to
+spare an upload whose commit may still be in flight.
 
 This DELETES. Run 'dfsctl store block reconcile' first to review what exists, or
 pass --dry-run here to preview the exact set this command would delete without
@@ -5983,7 +5992,7 @@ dfsctl store block reclaim [flags]
 # Preview what would be reclaimed
 dfsctl store block reclaim --dry-run
 
-# Reclaim zero-ref records
+# Reclaim orphaned block storage
 dfsctl store block reclaim
 
 # As JSON for scripting

--- a/internal/controlplane/api/handlers/block_gc.go
+++ b/internal/controlplane/api/handlers/block_gc.go
@@ -47,10 +47,11 @@ type BlockGCRuntime interface {
 	// mutates nothing (#1493/#1525 reconcile reporter).
 	ReconcileReport(ctx context.Context) (*engine.ReconcileReport, error)
 
-	// ReconcileReclaimZeroRef deletes class-1 orphans server-wide (block records
-	// with a zero live chunk count and no live locator) and frees their remote
-	// objects. dryRun previews without deleting (#1493 PR5b).
-	ReconcileReclaimZeroRef(ctx context.Context, dryRun bool) (*engine.ReclaimReport, error)
+	// ReconcileReclaim deletes orphaned block storage server-wide: class-1
+	// zero-ref and class-2 leaked records (with their remote objects) plus class-3
+	// record-less remote objects past the grace window. dryRun previews without
+	// deleting (#1493 PR5b+PR5c).
+	ReconcileReclaim(ctx context.Context, dryRun bool) (*engine.ReclaimReport, error)
 }
 
 // BlockStoreGCHandler exposes on-demand GC + last-run-summary endpoints.
@@ -324,30 +325,30 @@ func (h *BlockStoreGCHandler) ReconcileReport(w http.ResponseWriter, r *http.Req
 	WriteJSONOK(w, report)
 }
 
-// ReconcileReclaimZeroRefRequest is the JSON body for the zero-ref reclaim
-// endpoint. dry_run previews the exact set without deleting.
-type ReconcileReclaimZeroRefRequest struct {
+// ReconcileReclaimRequest is the JSON body for the reclaim endpoint. dry_run
+// previews the exact set without deleting.
+type ReconcileReclaimRequest struct {
 	DryRun bool `json:"dry_run,omitempty"`
 }
 
-// ReconcileReclaimZeroRef handles POST /api/v1/blockstore/reconcile/zero-ref-records.
+// ReconcileReclaim handles POST /api/v1/blockstore/reconcile/reclaim.
 //
-// Server-wide, admin-only. It DELETES class-1 orphans (block records with a zero
-// live chunk count and no live locator — a crash between decrementing the count
-// and deleting the record) and frees their remote objects. Set dry_run to preview
-// the set without deleting. First deleting reconcile stage (#1493/#1525 PR5b).
+// Server-wide, admin-only. It DELETES orphaned block storage: class-1 zero-ref and
+// class-2 leaked block records (with their remote objects) plus class-3 record-less
+// remote objects past the grace window. Set dry_run to preview the set without
+// deleting. Deleting reconcile stages (#1493/#1525 PR5b+PR5c).
 //
 // Status codes:
 //   - 200 OK with engine.ReclaimReport
 //   - 400 Bad Request when the body decode fails
 //   - 500 Internal Server Error on unexpected runtime errors
-func (h *BlockStoreGCHandler) ReconcileReclaimZeroRef(w http.ResponseWriter, r *http.Request) {
+func (h *BlockStoreGCHandler) ReconcileReclaim(w http.ResponseWriter, r *http.Request) {
 	if h.runtime == nil {
 		InternalServerError(w, "runtime not initialized")
 		return
 	}
 
-	var req ReconcileReclaimZeroRefRequest
+	var req ReconcileReclaimRequest
 	if r.Body != nil && r.ContentLength != 0 {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
 			BadRequest(w, "invalid request body: "+err.Error())
@@ -355,10 +356,10 @@ func (h *BlockStoreGCHandler) ReconcileReclaimZeroRef(w http.ResponseWriter, r *
 		}
 	}
 
-	report, err := h.runtime.ReconcileReclaimZeroRef(r.Context(), req.DryRun)
+	report, err := h.runtime.ReconcileReclaim(r.Context(), req.DryRun)
 	if err != nil {
-		logger.Debug("Block store zero-ref reclaim error", "error", err)
-		InternalServerError(w, "zero-ref reclaim failed")
+		logger.Debug("Block store reclaim error", "error", err)
+		InternalServerError(w, "reclaim failed")
 		return
 	}
 

--- a/internal/controlplane/api/handlers/block_gc_test.go
+++ b/internal/controlplane/api/handlers/block_gc_test.go
@@ -587,7 +587,7 @@ func TestBlockStoreHandler_ReclaimZeroRef_PropagatesDryRun(t *testing.T) {
 	h := NewBlockStoreGCHandler(fake)
 
 	body, _ := json.Marshal(ReconcileReclaimRequest{DryRun: true})
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/blockstore/reconcile/zero-ref-records", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/blockstore/reconcile/reclaim", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 
 	h.ReconcileReclaim(w, req)
@@ -612,7 +612,7 @@ func TestBlockStoreHandler_ReclaimZeroRef_RuntimeError(t *testing.T) {
 	fake := &fakeGCRuntime{reclaimErr: fmt.Errorf("boom")}
 	h := NewBlockStoreGCHandler(fake)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/blockstore/reconcile/zero-ref-records", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/blockstore/reconcile/reclaim", nil)
 	w := httptest.NewRecorder()
 
 	h.ReconcileReclaim(w, req)
@@ -626,7 +626,7 @@ func TestBlockStoreHandler_ReclaimZeroRef_RuntimeError(t *testing.T) {
 func TestBlockStoreHandler_ReclaimZeroRef_NilRuntime(t *testing.T) {
 	h := NewBlockStoreGCHandler(nil)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/blockstore/reconcile/zero-ref-records", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/blockstore/reconcile/reclaim", nil)
 	w := httptest.NewRecorder()
 
 	h.ReconcileReclaim(w, req)

--- a/internal/controlplane/api/handlers/block_gc_test.go
+++ b/internal/controlplane/api/handlers/block_gc_test.go
@@ -40,7 +40,7 @@ type fakeGCRuntime struct {
 	report    *engine.ReconcileReport
 	reportErr error
 
-	// ReconcileReclaimZeroRef hooks
+	// ReconcileReclaim hooks
 	reclaim        *engine.ReclaimReport
 	reclaimErr     error
 	reclaimDryRuns []bool
@@ -85,7 +85,7 @@ func (f *fakeGCRuntime) ReconcileReport(context.Context) (*engine.ReconcileRepor
 	return &engine.ReconcileReport{}, nil
 }
 
-func (f *fakeGCRuntime) ReconcileReclaimZeroRef(_ context.Context, dryRun bool) (*engine.ReclaimReport, error) {
+func (f *fakeGCRuntime) ReconcileReclaim(_ context.Context, dryRun bool) (*engine.ReclaimReport, error) {
 	f.reclaimDryRuns = append(f.reclaimDryRuns, dryRun)
 	if f.reclaimErr != nil {
 		return nil, f.reclaimErr
@@ -586,24 +586,24 @@ func TestBlockStoreHandler_ReclaimZeroRef_PropagatesDryRun(t *testing.T) {
 	}}
 	h := NewBlockStoreGCHandler(fake)
 
-	body, _ := json.Marshal(ReconcileReclaimZeroRefRequest{DryRun: true})
+	body, _ := json.Marshal(ReconcileReclaimRequest{DryRun: true})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/blockstore/reconcile/zero-ref-records", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 
-	h.ReconcileReclaimZeroRef(w, req)
+	h.ReconcileReclaim(w, req)
 
 	if w.Code != http.StatusOK {
-		t.Fatalf("ReconcileReclaimZeroRef: expected 200, got %d (body=%q)", w.Code, w.Body.String())
+		t.Fatalf("ReconcileReclaim: expected 200, got %d (body=%q)", w.Code, w.Body.String())
 	}
 	if len(fake.reclaimDryRuns) != 1 || !fake.reclaimDryRuns[0] {
-		t.Fatalf("ReconcileReclaimZeroRef: expected dry_run=true propagated, got %v", fake.reclaimDryRuns)
+		t.Fatalf("ReconcileReclaim: expected dry_run=true propagated, got %v", fake.reclaimDryRuns)
 	}
 	var got engine.ReclaimReport
 	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
-		t.Fatalf("ReconcileReclaimZeroRef: decode: %v", err)
+		t.Fatalf("ReconcileReclaim: decode: %v", err)
 	}
 	if got.Reclaimed.Count != 2 || got.Reclaimed.Bytes != 42 || !got.DryRun {
-		t.Fatalf("ReconcileReclaimZeroRef: unexpected body: %+v", got)
+		t.Fatalf("ReconcileReclaim: unexpected body: %+v", got)
 	}
 }
 
@@ -615,10 +615,10 @@ func TestBlockStoreHandler_ReclaimZeroRef_RuntimeError(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/blockstore/reconcile/zero-ref-records", nil)
 	w := httptest.NewRecorder()
 
-	h.ReconcileReclaimZeroRef(w, req)
+	h.ReconcileReclaim(w, req)
 
 	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("ReconcileReclaimZeroRef: expected 500 on runtime error, got %d", w.Code)
+		t.Fatalf("ReconcileReclaim: expected 500 on runtime error, got %d", w.Code)
 	}
 }
 
@@ -629,9 +629,9 @@ func TestBlockStoreHandler_ReclaimZeroRef_NilRuntime(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/blockstore/reconcile/zero-ref-records", nil)
 	w := httptest.NewRecorder()
 
-	h.ReconcileReclaimZeroRef(w, req)
+	h.ReconcileReclaim(w, req)
 
 	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("ReconcileReclaimZeroRef: expected 500 on nil runtime, got %d", w.Code)
+		t.Fatalf("ReconcileReclaim: expected 500 on nil runtime, got %d", w.Code)
 	}
 }

--- a/pkg/apiclient/blockstore.go
+++ b/pkg/apiclient/blockstore.go
@@ -206,17 +206,18 @@ func (c *Client) BlockStoreReconcileReport() (*engine.ReconcileReport, error) {
 	return getResource[engine.ReconcileReport](c, "/api/v1/blockstore/reconcile-report")
 }
 
-// BlockStoreReclaimZeroRefRequest is the request body for the zero-ref reclaim.
-type BlockStoreReclaimZeroRefRequest struct {
+// BlockStoreReclaimRequest is the request body for the reclaim endpoint.
+type BlockStoreReclaimRequest struct {
 	DryRun bool `json:"dry_run,omitempty"`
 }
 
-// BlockStoreReclaimZeroRef deletes class-1 orphans server-wide (block records
-// with a zero live chunk count and no live locator) and frees their remote
-// objects, returning the engine.ReclaimReport tally. Server-wide, admin-only.
-// Set DryRun to preview the set without deleting (#1493/#1525 PR5b).
-func (c *Client) BlockStoreReclaimZeroRef(req *BlockStoreReclaimZeroRefRequest) (*engine.ReclaimReport, error) {
-	return createResource[engine.ReclaimReport](c, "/api/v1/blockstore/reconcile/zero-ref-records", req)
+// BlockStoreReclaim deletes orphaned block storage server-wide — class-1 zero-ref
+// and class-2 leaked block records (with their remote objects) plus class-3
+// record-less remote objects past the grace window — returning the
+// engine.ReclaimReport tally. Server-wide, admin-only. Set DryRun to preview the
+// set without deleting (#1493/#1525 PR5b+PR5c).
+func (c *Client) BlockStoreReclaim(req *BlockStoreReclaimRequest) (*engine.ReclaimReport, error) {
+	return createResource[engine.ReclaimReport](c, "/api/v1/blockstore/reconcile/reclaim", req)
 }
 
 // BlockStoreAuditResult is the response body for

--- a/pkg/block/engine/reclaim.go
+++ b/pkg/block/engine/reclaim.go
@@ -158,17 +158,29 @@ func ReclaimRecords(
 
 		// Any block ID a synced locator still points at is NOT an orphan, whatever
 		// its record's counter says — drop it from the candidate set.
+		//
+		// Collect the hashes first and resolve their locators AFTER the enumerate
+		// cursor closes: the sqlite metadata pool is MaxOpenConns(1), so calling
+		// GetLocator inside the EnumerateSynced callback (while its rows cursor
+		// still holds the only connection) would deadlock waiting for a second.
+		var synced []block.ContentHash
 		if err := v.EnumerateSynced(ctx, func(h block.ContentHash, _ time.Time) error {
+			synced = append(synced, h)
+			return nil
+		}); err != nil {
+			return report, fmt.Errorf("reclaim: enumerate synced: %w", err)
+		}
+		for _, h := range synced {
+			if err := ctx.Err(); err != nil {
+				return report, err
+			}
 			loc, ok, err := v.GetLocator(ctx, h)
 			if err != nil {
-				return err
+				return report, fmt.Errorf("reclaim: get locator: %w", err)
 			}
 			if ok && loc.BlockID != "" {
 				delete(candidates, loc.BlockID)
 			}
-			return nil
-		}); err != nil {
-			return report, fmt.Errorf("reclaim: enumerate synced: %w", err)
 		}
 
 		for blockID, c := range candidates {

--- a/pkg/block/engine/reclaim.go
+++ b/pkg/block/engine/reclaim.go
@@ -1,9 +1,23 @@
-// Package engine — zero-ref record reclaim (#1493/#1525 reconcile, PR5b), the
-// first *deleting* stage after the read-only reporter (reconcile.go). It reclaims
-// class-1 orphans: block records with LiveChunkCount == 0 and no live locator — a
-// crash between DecrLiveChunkCount and DeleteBlockRecord. Such a record is
-// terminally dead (the count only ever decrements and block IDs are never reused),
-// so deleting it and any lingering remote object is safe with no grace window.
+// Package engine — orphan-storage reclaim (#1493/#1525 reconcile, PR5b+PR5c), the
+// *deleting* stages after the read-only reporter (reconcile.go). Both operate on a
+// record's live-locator status, never its (possibly stale) LiveChunkCount:
+//
+//   - class 1 (ReclaimRecords, zero-ref): record with no live locator and
+//     LiveChunkCount == 0 — a crash between DecrLiveChunkCount and
+//     DeleteBlockRecord.
+//   - class 2 (ReclaimRecords, leaked): record with no live locator but
+//     LiveChunkCount > 0 — DefaultCommitBlock's last-wins DeleteSynced→MarkSynced
+//     moved the hash onto a new block without decrementing this one, leaving its
+//     count stuck > 0 forever, invisible to the hash-driven sweep (#1525).
+//   - class 3 (ReclaimOrphanObjects): a remote blocks/<id> object with no backing
+//     record, older than the grace window — PutBlock succeeded but the commit
+//     never landed.
+//
+// A record with no live locator is terminally dead whatever its count: block IDs
+// are fresh crypto/rand per carve and never reused, so no future locator can ever
+// point back at it. Deleting it (and any lingering remote object) is therefore safe
+// with no grace window. Class 3 alone needs a grace window, because a just-uploaded
+// object may still have a commit in flight.
 package engine
 
 import (
@@ -24,7 +38,7 @@ type ReclaimMetaView interface {
 	DeleteBlockRecord(ctx context.Context, blockID string) error
 }
 
-// ReclaimOptions parameterizes a zero-ref reclaim pass.
+// ReclaimOptions parameterizes a reclaim pass.
 type ReclaimOptions struct {
 	// DryRun classifies and tallies without deleting anything, so an operator
 	// can preview the exact set a live run would act on.
@@ -32,17 +46,29 @@ type ReclaimOptions struct {
 	// SampleCap bounds the per-run ID sample. Zero defaults to
 	// defaultReconcileSampleCap. Counts are always exact.
 	SampleCap int
+	// GracePeriod keeps freshly-uploaded, not-yet-committed remote objects from
+	// being reclaimed as class-3 orphans (mirrors the GC sweep TTL). Non-positive
+	// falls back to the sweep default via resolveGracePeriod. Ignored by
+	// ReclaimRecords (records need no grace window).
+	GracePeriod time.Duration
 }
 
-// ReclaimReport is the output of a zero-ref reclaim pass.
+// ReclaimReport is the output of a reclaim pass.
 type ReclaimReport struct {
-	// Reclaimed tallies the zero-ref records deleted (Count) and the remote
-	// bytes freed (Bytes, from each record's Length). On a dry run it tallies
-	// what WOULD be deleted.
+	// Reclaimed tallies class-1 zero-ref records deleted (Count) and remote bytes
+	// freed (Bytes, from each record's Length). On a dry run it tallies what WOULD
+	// be deleted.
 	Reclaimed ReconcileClass `json:"reclaimed"`
+	// LeakedReclaimed tallies class-2 leaked block records deleted (#1525): no
+	// live locator but a stale LiveChunkCount > 0.
+	LeakedReclaimed ReconcileClass `json:"leaked_reclaimed"`
+	// OrphanObjectsReclaimed tallies class-3 record-less remote objects deleted.
+	OrphanObjectsReclaimed ReconcileClass `json:"orphan_objects_reclaimed"`
 	// BlockRecordsScanned is every record examined across all shares.
 	BlockRecordsScanned int64 `json:"block_records_scanned"`
-	// Errors counts records that could not be fully reclaimed (a DeleteBlock or
+	// RemoteObjectsScanned is every remote object examined for class 3.
+	RemoteObjectsScanned int64 `json:"remote_objects_scanned"`
+	// Errors counts orphans that could not be fully reclaimed (a DeleteBlock or
 	// DeleteBlockRecord failure); each is left intact for the next run.
 	Errors    int64 `json:"errors"`
 	DryRun    bool  `json:"dry_run"`
@@ -58,31 +84,37 @@ func (r *ReclaimReport) Merge(other ReclaimReport) {
 		r.SampleCap = cap
 	}
 	r.Reclaimed.merge(other.Reclaimed, cap)
+	r.LeakedReclaimed.merge(other.LeakedReclaimed, cap)
+	r.OrphanObjectsReclaimed.merge(other.OrphanObjectsReclaimed, cap)
 	r.BlockRecordsScanned += other.BlockRecordsScanned
+	r.RemoteObjectsScanned += other.RemoteObjectsScanned
 	r.Errors += other.Errors
 	if other.DryRun {
 		r.DryRun = true
 	}
 }
 
-// ReclaimZeroRefRecords deletes class-1 orphans across the given per-share views
-// that share one remote store: block records with LiveChunkCount == 0 and no live
-// locator. For each it frees the remote block object (idempotent — the object may
-// already be gone if the crash landed after DeleteBlock) then deletes the record,
-// matching the GC reclaimer's DeleteBlock→DeleteBlockRecord order so a crash
-// between them leaves a record-less orphan object (class 3, swept later) rather
-// than a record pointing at freed bytes.
+// ReclaimRecords deletes class-1 and class-2 orphan records across the given
+// per-share views that share one remote store: block records with no live locator,
+// split by their (possibly stale) LiveChunkCount into zero-ref (== 0, class 1) and
+// leaked (> 0, class 2 / #1525). For each it frees the remote block object
+// (idempotent — the object may already be gone if a crash landed after DeleteBlock)
+// then deletes the record, matching the GC reclaimer's DeleteBlock→DeleteBlockRecord
+// order so a crash between them leaves a record-less orphan object (class 3, swept
+// by ReclaimOrphanObjects) rather than a record pointing at freed bytes.
 //
 // It RE-DERIVES the classification here — never trusting a stale report — so a
-// record re-referenced since the report is not deleted. rbs is the shared block
-// store (nil = record-only reclaim; nothing to free remotely). The caller MUST
-// hold the per-remote GC lock so this cannot race a concurrent sweep's
-// DecrLiveChunkCount on the same block.
+// record re-referenced since the report is not deleted. Both classes are terminal:
+// with no live locator, no future locator can point back (block IDs are never
+// reused), so a stale count > 0 is safe to drop. rbs is the shared block store
+// (nil = record-only reclaim; nothing to free remotely). The caller MUST hold the
+// per-remote GC lock so this cannot race a concurrent sweep's DecrLiveChunkCount on
+// the same block.
 //
 // A per-record delete failure is non-fatal: it is logged, counted in Errors, and
-// the record is left intact for the next run. Only an enumerate/walk failure
-// aborts the pass.
-func ReclaimZeroRefRecords(
+// the record is left intact for the next run. Only an enumerate/walk failure aborts
+// the pass.
+func ReclaimRecords(
 	ctx context.Context,
 	views []ReclaimMetaView,
 	rbs remote.RemoteBlockStore,
@@ -95,48 +127,60 @@ func ReclaimZeroRefRecords(
 	report := ReclaimReport{DryRun: opts.DryRun, SampleCap: sampleCap}
 
 	for _, v := range views {
-		// Live locator set for THIS share: any block ID a synced locator still
-		// points at is NOT a zero-ref orphan, whatever its counter says.
-		refSet := make(map[string]struct{})
+		// Collect EVERY record first, then build the live set, then filter. Order
+		// matters for safety: a client commit (DefaultCommitBlock) writes a new
+		// record AND its locators in one transaction, so if it lands while we are
+		// scanning, walking records BEFORE building the live set guarantees any
+		// record we captured has its locators visible to the later EnumerateSynced
+		// — the live set can only be a superset of what was live at record-walk
+		// time. Building the live set first would let a fresh commit slip in
+		// between the two scans: its record (LiveChunkCount > 0) would be walked
+		// but its BlockID missing from the stale live set, and we would delete a
+		// live block. (Class 1 is incidentally immune — a fresh commit is never
+		// count 0 — but class 2 has no such floor.)
+		//
+		// candidates maps blockID → its record meta; the live-set pass then
+		// deletes referenced IDs from it, leaving only orphans. Records are
+		// collected up front rather than acted on mid-walk because mutating the
+		// record store during its own walk is unsafe on some backends.
+		type candidate struct {
+			length int64
+			leaked bool // class 2 (stale count > 0) → tally into LeakedReclaimed
+		}
+		candidates := make(map[string]candidate)
+		if err := v.WalkBlockRecords(ctx, func(rec block.BlockRecord) error {
+			report.BlockRecordsScanned++
+			candidates[rec.BlockID] = candidate{rec.Length, rec.LiveChunkCount != 0}
+			return nil
+		}); err != nil {
+			return report, fmt.Errorf("reclaim: walk block records: %w", err)
+		}
+
+		// Any block ID a synced locator still points at is NOT an orphan, whatever
+		// its record's counter says — drop it from the candidate set.
 		if err := v.EnumerateSynced(ctx, func(h block.ContentHash, _ time.Time) error {
 			loc, ok, err := v.GetLocator(ctx, h)
 			if err != nil {
 				return err
 			}
 			if ok && loc.BlockID != "" {
-				refSet[loc.BlockID] = struct{}{}
+				delete(candidates, loc.BlockID)
 			}
 			return nil
 		}); err != nil {
 			return report, fmt.Errorf("reclaim: enumerate synced: %w", err)
 		}
 
-		// Collect candidates during the walk and delete AFTER it: mutating the
-		// record store mid-walk is unsafe on some backends.
-		type candidate struct {
-			blockID string
-			length  int64
-		}
-		var candidates []candidate
-		if err := v.WalkBlockRecords(ctx, func(rec block.BlockRecord) error {
-			report.BlockRecordsScanned++
-			if _, live := refSet[rec.BlockID]; live {
-				return nil // healthy: a live locator still points at this block
-			}
-			if rec.LiveChunkCount == 0 {
-				candidates = append(candidates, candidate{rec.BlockID, rec.Length})
-			}
-			return nil
-		}); err != nil {
-			return report, fmt.Errorf("reclaim: walk block records: %w", err)
-		}
-
-		for _, c := range candidates {
+		for blockID, c := range candidates {
 			if err := ctx.Err(); err != nil {
 				return report, err
 			}
+			tally := &report.Reclaimed
+			if c.leaked {
+				tally = &report.LeakedReclaimed
+			}
 			if opts.DryRun {
-				report.Reclaimed.add(c.blockID, c.length, sampleCap)
+				tally.add(blockID, c.length, sampleCap)
 				continue
 			}
 			// DeleteBlock before DeleteBlockRecord: a crash between them leaves a
@@ -144,29 +188,107 @@ func ReclaimZeroRefRecords(
 			// freed bytes. DeleteBlock is idempotent, so a block already freed by
 			// the crash-before-DeleteBlockRecord path is a clean no-op.
 			if rbs != nil {
-				if err := rbs.DeleteBlock(ctx, c.blockID); err != nil {
+				if err := rbs.DeleteBlock(ctx, blockID); err != nil {
 					slog.Warn("reclaim: delete remote block failed — record kept for retry",
-						"block_id", c.blockID, "err", err)
+						"block_id", blockID, "err", err)
 					report.Errors++
 					continue
 				}
 			}
-			if err := v.DeleteBlockRecord(ctx, c.blockID); err != nil {
+			if err := v.DeleteBlockRecord(ctx, blockID); err != nil {
 				// The object may already be freed above; the record survives and
 				// is retried next run. A now-record-less object is a class-3
 				// orphan the object sweep reclaims.
 				slog.Warn("reclaim: delete block record failed — will retry next run",
-					"block_id", c.blockID, "err", err)
+					"block_id", blockID, "err", err)
 				report.Errors++
 				continue
 			}
-			report.Reclaimed.add(c.blockID, c.length, sampleCap)
+			tally.add(blockID, c.length, sampleCap)
 		}
 	}
 
-	if report.Reclaimed.Truncated {
+	if report.Reclaimed.Truncated || report.LeakedReclaimed.Truncated {
 		slog.Warn("reclaim: ID sample truncated — full reclaimed set is larger than the sample cap",
-			"sample_cap", sampleCap, "reclaimed", report.Reclaimed.Count)
+			"sample_cap", sampleCap,
+			"reclaimed", report.Reclaimed.Count,
+			"leaked_reclaimed", report.LeakedReclaimed.Count)
+	}
+	return report, nil
+}
+
+// ReclaimOrphanObjects deletes class-3 orphans: remote blocks/<id> objects with no
+// backing block record, older than the grace window. metaBlockIDs is the set of
+// every block ID that HAS a record, unioned across ALL shares on this remote — the
+// caller MUST build it from every share (not just the reclaim-eligible ones) and
+// MUST NOT call this if any share on the remote could not be enumerated, or a
+// sibling share's live object would be misread as an orphan and deleted.
+//
+// The grace window (mirroring the reporter and the GC walk sweep) protects a
+// freshly-uploaded object whose commit may still be in flight; an object whose age
+// cannot be evaluated (zero LastModified) is preserved fail-closed. The caller MUST
+// hold the per-remote GC lock. A per-object DeleteBlock failure is non-fatal.
+func ReclaimOrphanObjects(
+	ctx context.Context,
+	metaBlockIDs map[string]struct{},
+	rbs remote.RemoteBlockStore,
+	opts ReclaimOptions,
+) (ReclaimReport, error) {
+	sampleCap := opts.SampleCap
+	if sampleCap <= 0 {
+		sampleCap = defaultReconcileSampleCap
+	}
+	report := ReclaimReport{DryRun: opts.DryRun, SampleCap: sampleCap}
+	if rbs == nil {
+		return report, nil // remote cannot hold packed blocks — nothing to sweep
+	}
+	grace := resolveGracePeriod(&Options{GracePeriod: opts.GracePeriod})
+	cutoff := time.Now().Add(-grace)
+
+	// Collect during the walk, delete after: mutating the bucket mid-walk is
+	// unsafe on some backends.
+	type candidate struct {
+		blockID string
+		size    int64
+	}
+	var candidates []candidate
+	if err := rbs.WalkBlocks(ctx, func(blockID string, meta block.Meta) error {
+		report.RemoteObjectsScanned++
+		if _, known := metaBlockIDs[blockID]; known {
+			return nil // has a record — not an orphan
+		}
+		if meta.LastModified.IsZero() {
+			return nil // cannot evaluate grace TTL — fail closed
+		}
+		if meta.LastModified.After(cutoff) {
+			return nil // within grace: commit may still land
+		}
+		candidates = append(candidates, candidate{blockID, meta.Size})
+		return nil
+	}); err != nil {
+		return report, fmt.Errorf("reclaim: walk blocks: %w", err)
+	}
+
+	for _, c := range candidates {
+		if err := ctx.Err(); err != nil {
+			return report, err
+		}
+		if opts.DryRun {
+			report.OrphanObjectsReclaimed.add(c.blockID, c.size, sampleCap)
+			continue
+		}
+		if err := rbs.DeleteBlock(ctx, c.blockID); err != nil {
+			slog.Warn("reclaim: delete orphan object failed — will retry next run",
+				"block_id", c.blockID, "err", err)
+			report.Errors++
+			continue
+		}
+		report.OrphanObjectsReclaimed.add(c.blockID, c.size, sampleCap)
+	}
+
+	if report.OrphanObjectsReclaimed.Truncated {
+		slog.Warn("reclaim: orphan-object ID sample truncated — full set is larger than the sample cap",
+			"sample_cap", sampleCap, "orphan_objects_reclaimed", report.OrphanObjectsReclaimed.Count)
 	}
 	return report, nil
 }

--- a/pkg/block/engine/reclaim_test.go
+++ b/pkg/block/engine/reclaim_test.go
@@ -2,7 +2,9 @@ package engine
 
 import (
 	"bytes"
+	"context"
 	"testing"
+	"time"
 
 	"github.com/marmos91/dittofs/pkg/block"
 	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
@@ -50,10 +52,11 @@ func remoteHasBlock(t *testing.T, rbs *remotememory.Store, blockID string) bool 
 	return found
 }
 
-// TestReclaimZeroRefRecords_DeletesOnlyZeroRef proves the reclaimer deletes a
-// zero-ref record AND its remote object, leaves a healthy block and a leaked
-// (class-2) block untouched, and is idempotent on a second pass.
-func TestReclaimZeroRefRecords_DeletesOnlyZeroRef(t *testing.T) {
+// TestReclaimRecords_DeletesUnreferencedRecords proves the reclaimer deletes both
+// a zero-ref (class-1) and a leaked (class-2) record along with their remote
+// objects, tallies them separately, leaves a healthy block untouched, and is
+// idempotent on a second pass.
+func TestReclaimRecords_DeletesUnreferencedRecords(t *testing.T) {
 	ctx := t.Context()
 	st := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	rbs := remotememory.New()
@@ -66,17 +69,20 @@ func TestReclaimZeroRefRecords_DeletesOnlyZeroRef(t *testing.T) {
 	// Class 1: zero-ref record + its object → must be deleted.
 	putZeroRefRecord(t, st, rbs, "blk-zeroref", 111)
 
-	// Class 2: leaked block (LiveChunkCount>0, no live locator) → NOT this
-	// stage's job; must be left intact for PR5c.
+	// Class 2: leaked block (LiveChunkCount>0, no live locator) → the stale count
+	// is a lie; with no locator it is terminally dead and must be reclaimed (#1525).
+	if err := rbs.PutBlock(ctx, "blk-leaked", bytes.NewReader([]byte("blk-leaked"))); err != nil {
+		t.Fatalf("PutBlock(blk-leaked): %v", err)
+	}
 	if err := st.PutBlockRecord(ctx, block.BlockRecord{
 		BlockID: "blk-leaked", Length: 222, LiveChunkCount: 2, SyncState: block.BlockStateRemote,
 	}); err != nil {
 		t.Fatalf("PutBlockRecord(blk-leaked): %v", err)
 	}
 
-	rep, err := ReclaimZeroRefRecords(ctx, []ReclaimMetaView{st}, rbs, ReclaimOptions{})
+	rep, err := ReclaimRecords(ctx, []ReclaimMetaView{st}, rbs, ReclaimOptions{})
 	if err != nil {
-		t.Fatalf("ReclaimZeroRefRecords: %v", err)
+		t.Fatalf("ReclaimRecords: %v", err)
 	}
 
 	if rep.Reclaimed.Count != 1 || len(rep.Reclaimed.Sample) != 1 || rep.Reclaimed.Sample[0] != "blk-zeroref" {
@@ -85,38 +91,79 @@ func TestReclaimZeroRefRecords_DeletesOnlyZeroRef(t *testing.T) {
 	if rep.Reclaimed.Bytes != 111 {
 		t.Errorf("Reclaimed.Bytes = %d; want 111", rep.Reclaimed.Bytes)
 	}
+	if rep.LeakedReclaimed.Count != 1 || len(rep.LeakedReclaimed.Sample) != 1 || rep.LeakedReclaimed.Sample[0] != "blk-leaked" {
+		t.Errorf("LeakedReclaimed = %+v; want count 1 sample [blk-leaked]", rep.LeakedReclaimed)
+	}
+	if rep.LeakedReclaimed.Bytes != 222 {
+		t.Errorf("LeakedReclaimed.Bytes = %d; want 222", rep.LeakedReclaimed.Bytes)
+	}
 	if rep.Errors != 0 {
 		t.Errorf("Errors = %d; want 0", rep.Errors)
 	}
 
-	// Zero-ref record and its object are gone.
-	if recordExists(t, st, "blk-zeroref") {
-		t.Error("blk-zeroref record still present after reclaim")
+	// Both unreferenced records and their objects are gone.
+	for _, id := range []string{"blk-zeroref", "blk-leaked"} {
+		if recordExists(t, st, id) {
+			t.Errorf("%s record still present after reclaim", id)
+		}
+		if remoteHasBlock(t, rbs, id) {
+			t.Errorf("%s remote object still present after reclaim", id)
+		}
 	}
-	if remoteHasBlock(t, rbs, "blk-zeroref") {
-		t.Error("blk-zeroref remote object still present after reclaim")
-	}
-	// Healthy and leaked survive.
+	// Healthy survives.
 	if !recordExists(t, st, "blk-healthy") || !remoteHasBlock(t, rbs, "blk-healthy") {
 		t.Error("healthy block was wrongly reclaimed")
 	}
-	if !recordExists(t, st, "blk-leaked") {
-		t.Error("leaked (class-2) record was wrongly reclaimed")
-	}
 
 	// Idempotent: a second pass finds nothing to reclaim.
-	rep2, err := ReclaimZeroRefRecords(ctx, []ReclaimMetaView{st}, rbs, ReclaimOptions{})
+	rep2, err := ReclaimRecords(ctx, []ReclaimMetaView{st}, rbs, ReclaimOptions{})
 	if err != nil {
-		t.Fatalf("ReclaimZeroRefRecords (2nd): %v", err)
+		t.Fatalf("ReclaimRecords (2nd): %v", err)
 	}
-	if rep2.Reclaimed.Count != 0 {
-		t.Errorf("second pass Reclaimed.Count = %d; want 0", rep2.Reclaimed.Count)
+	if rep2.Reclaimed.Count != 0 || rep2.LeakedReclaimed.Count != 0 {
+		t.Errorf("second pass reclaimed %d zero-ref + %d leaked; want 0", rep2.Reclaimed.Count, rep2.LeakedReclaimed.Count)
 	}
 }
 
-// TestReclaimZeroRefRecords_DryRun proves a dry run tallies the same set but
+// TestReclaimOrphanObjects_GraceWindow proves the object sweep deletes an aged
+// record-less object, spares one still inside the grace window, spares one whose
+// age cannot be evaluated (zero LastModified, fail-closed), and never touches an
+// object that still has a backing record.
+func TestReclaimOrphanObjects_GraceWindow(t *testing.T) {
+	ctx := t.Context()
+	rbs := remotememory.New()
+	defer func() { _ = rbs.Close() }()
+
+	// blk-known has a record; the union protects it. blk-aged-orphan is old and
+	// record-less → reclaimed. blk-fresh-orphan is record-less but recently
+	// written, so it is inside the grace window → spared.
+	putBareBlock(t, rbs, "blk-known", time.Now().Add(-2*time.Hour))
+	putBareBlock(t, rbs, "blk-aged-orphan", time.Now().Add(-2*time.Hour))
+	putBareBlock(t, rbs, "blk-fresh-orphan", time.Now())
+	metaBlockIDs := map[string]struct{}{"blk-known": {}}
+
+	rep, err := ReclaimOrphanObjects(ctx, metaBlockIDs, rbs, ReclaimOptions{GracePeriod: time.Hour})
+	if err != nil {
+		t.Fatalf("ReclaimOrphanObjects: %v", err)
+	}
+
+	if rep.OrphanObjectsReclaimed.Count != 1 || rep.OrphanObjectsReclaimed.Sample[0] != "blk-aged-orphan" {
+		t.Errorf("OrphanObjectsReclaimed = %+v; want count 1 sample [blk-aged-orphan]", rep.OrphanObjectsReclaimed)
+	}
+	if remoteHasBlock(t, rbs, "blk-aged-orphan") {
+		t.Error("aged orphan object still present after reclaim")
+	}
+	if !remoteHasBlock(t, rbs, "blk-fresh-orphan") {
+		t.Error("fresh orphan inside grace window was wrongly reclaimed")
+	}
+	if !remoteHasBlock(t, rbs, "blk-known") {
+		t.Error("object with a backing record was wrongly reclaimed")
+	}
+}
+
+// TestReclaimRecords_DryRun proves a dry run tallies the same set but
 // deletes nothing.
-func TestReclaimZeroRefRecords_DryRun(t *testing.T) {
+func TestReclaimRecords_DryRun(t *testing.T) {
 	ctx := t.Context()
 	st := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	rbs := remotememory.New()
@@ -124,14 +171,68 @@ func TestReclaimZeroRefRecords_DryRun(t *testing.T) {
 
 	putZeroRefRecord(t, st, rbs, "blk-zeroref", 500)
 
-	rep, err := ReclaimZeroRefRecords(ctx, []ReclaimMetaView{st}, rbs, ReclaimOptions{DryRun: true})
+	rep, err := ReclaimRecords(ctx, []ReclaimMetaView{st}, rbs, ReclaimOptions{DryRun: true})
 	if err != nil {
-		t.Fatalf("ReclaimZeroRefRecords: %v", err)
+		t.Fatalf("ReclaimRecords: %v", err)
 	}
 	if !rep.DryRun || rep.Reclaimed.Count != 1 || rep.Reclaimed.Bytes != 500 {
 		t.Errorf("dry-run report = %+v; want DryRun count 1 bytes 500", rep)
 	}
 	if !recordExists(t, st, "blk-zeroref") || !remoteHasBlock(t, rbs, "blk-zeroref") {
 		t.Error("dry run deleted something; must be non-mutating")
+	}
+}
+
+// raceView simulates a client commit (DefaultCommitBlock — record + locator in
+// one transaction) landing BETWEEN the reclaimer's two metadata scans. Block "R"
+// is invisible to the first scan the reclaimer performs and visible to the second.
+// A correct reclaimer walks records BEFORE building the live set, so it either
+// never sees R (skipped this run, safe) or sees both R and its locator (survives).
+// A reclaimer that builds the live set first would capture an empty set, then walk
+// R (LiveChunkCount>0, absent from the stale set) and delete a live block — the
+// #1525 TOCTOU. This test fails if the scan order is ever reverted.
+type raceView struct {
+	scans   int
+	deleted []string
+}
+
+func (v *raceView) reveal() bool { visible := v.scans > 0; v.scans++; return visible }
+
+func (v *raceView) WalkBlockRecords(_ context.Context, fn func(block.BlockRecord) error) error {
+	if v.reveal() {
+		return fn(block.BlockRecord{BlockID: "R", Length: 10, LiveChunkCount: 3, SyncState: block.BlockStateRemote})
+	}
+	return nil
+}
+
+func (v *raceView) EnumerateSynced(_ context.Context, fn func(block.ContentHash, time.Time) error) error {
+	if v.reveal() {
+		return fn(hashFromString("R-chunk"), time.Time{})
+	}
+	return nil
+}
+
+func (v *raceView) GetLocator(_ context.Context, _ block.ContentHash) (block.ChunkLocator, bool, error) {
+	return block.ChunkLocator{BlockID: "R"}, true, nil
+}
+
+func (v *raceView) DeleteBlockRecord(_ context.Context, blockID string) error {
+	v.deleted = append(v.deleted, blockID)
+	return nil
+}
+
+// TestReclaimRecords_CommitDuringScanNotDeleted is the #1525 TOCTOU regression:
+// a block committed while a reclaim is scanning must never be reclaimed.
+func TestReclaimRecords_CommitDuringScanNotDeleted(t *testing.T) {
+	v := &raceView{}
+	rep, err := ReclaimRecords(t.Context(), []ReclaimMetaView{v}, nil, ReclaimOptions{})
+	if err != nil {
+		t.Fatalf("ReclaimRecords: %v", err)
+	}
+	if len(v.deleted) != 0 {
+		t.Errorf("deleted live block(s) committed mid-scan: %v", v.deleted)
+	}
+	if rep.Reclaimed.Count != 0 || rep.LeakedReclaimed.Count != 0 {
+		t.Errorf("reclaimed a mid-scan commit: zeroRef=%d leaked=%d", rep.Reclaimed.Count, rep.LeakedReclaimed.Count)
 	}
 }

--- a/pkg/block/engine/reclaim_test.go
+++ b/pkg/block/engine/reclaim_test.go
@@ -140,6 +140,9 @@ func TestReclaimOrphanObjects_GraceWindow(t *testing.T) {
 	putBareBlock(t, rbs, "blk-known", time.Now().Add(-2*time.Hour))
 	putBareBlock(t, rbs, "blk-aged-orphan", time.Now().Add(-2*time.Hour))
 	putBareBlock(t, rbs, "blk-fresh-orphan", time.Now())
+	// blk-noage-orphan is record-less with a zero LastModified: its age cannot
+	// be evaluated, so the sweep must fail closed and spare it.
+	putBareBlock(t, rbs, "blk-noage-orphan", time.Time{})
 	metaBlockIDs := map[string]struct{}{"blk-known": {}}
 
 	rep, err := ReclaimOrphanObjects(ctx, metaBlockIDs, rbs, ReclaimOptions{GracePeriod: time.Hour})
@@ -155,6 +158,9 @@ func TestReclaimOrphanObjects_GraceWindow(t *testing.T) {
 	}
 	if !remoteHasBlock(t, rbs, "blk-fresh-orphan") {
 		t.Error("fresh orphan inside grace window was wrongly reclaimed")
+	}
+	if !remoteHasBlock(t, rbs, "blk-noage-orphan") {
+		t.Error("zero-LastModified orphan (unevaluable age) was wrongly reclaimed; must fail closed")
 	}
 	if !remoteHasBlock(t, rbs, "blk-known") {
 		t.Error("object with a backing record was wrongly reclaimed")

--- a/pkg/block/engine/reclaim_test.go
+++ b/pkg/block/engine/reclaim_test.go
@@ -221,6 +221,66 @@ func (v *raceView) DeleteBlockRecord(_ context.Context, blockID string) error {
 	return nil
 }
 
+// nestedGuardView models the sqlite metadata pool's MaxOpenConns(1) hazard: while
+// an EnumerateSynced cursor is open it holds the only connection, so any query
+// issued from inside the callback (e.g. GetLocator) would block forever waiting
+// for a second. This view fails loudly instead of deadlocking, so the reclaimer
+// must drain EnumerateSynced before resolving locators. blk-leaked has a record
+// with no locator (class 2); blk-live has a record and a locator (must survive).
+type nestedGuardView struct {
+	t           *testing.T
+	inEnumerate bool
+	deleted     []string
+}
+
+func (v *nestedGuardView) EnumerateSynced(_ context.Context, fn func(block.ContentHash, time.Time) error) error {
+	v.inEnumerate = true
+	defer func() { v.inEnumerate = false }()
+	return fn(hashFromString("live-chunk"), time.Time{})
+}
+
+func (v *nestedGuardView) GetLocator(_ context.Context, _ block.ContentHash) (block.ChunkLocator, bool, error) {
+	if v.inEnumerate {
+		v.t.Fatal("GetLocator called while EnumerateSynced cursor is open — deadlocks on sqlite MaxOpenConns(1)")
+	}
+	return block.ChunkLocator{BlockID: "blk-live"}, true, nil
+}
+
+func (v *nestedGuardView) WalkBlockRecords(_ context.Context, fn func(block.BlockRecord) error) error {
+	for _, r := range []block.BlockRecord{
+		{BlockID: "blk-live", Length: 5, LiveChunkCount: 1},
+		{BlockID: "blk-leaked", Length: 7, LiveChunkCount: 3},
+	} {
+		if err := fn(r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v *nestedGuardView) DeleteBlockRecord(_ context.Context, blockID string) error {
+	v.deleted = append(v.deleted, blockID)
+	return nil
+}
+
+// TestReclaimRecords_NoNestedQueryDuringEnumerate guards against re-introducing a
+// GetLocator call inside the EnumerateSynced callback, which deadlocks on the
+// single-connection sqlite pool (found via a real sqlite backend on a live VM).
+func TestReclaimRecords_NoNestedQueryDuringEnumerate(t *testing.T) {
+	v := &nestedGuardView{t: t}
+	rep, err := ReclaimRecords(t.Context(), []ReclaimMetaView{v}, nil, ReclaimOptions{})
+	if err != nil {
+		t.Fatalf("ReclaimRecords: %v", err)
+	}
+	// Only the unreferenced leaked record is reclaimed; the located one survives.
+	if len(v.deleted) != 1 || v.deleted[0] != "blk-leaked" {
+		t.Errorf("deleted = %v; want [blk-leaked]", v.deleted)
+	}
+	if rep.LeakedReclaimed.Count != 1 || rep.Reclaimed.Count != 0 {
+		t.Errorf("tally: leaked=%d zeroRef=%d; want leaked=1 zeroRef=0", rep.LeakedReclaimed.Count, rep.Reclaimed.Count)
+	}
+}
+
 // TestReclaimRecords_CommitDuringScanNotDeleted is the #1525 TOCTOU regression:
 // a block committed while a reclaim is scanning must never be reclaimed.
 func TestReclaimRecords_CommitDuringScanNotDeleted(t *testing.T) {

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -326,7 +326,7 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 				// Zero-ref record reclaim (#1493 PR5b): deletes class-1 orphans
 				// and frees their remote objects. Mutating, so POST; dry_run
 				// previews.
-				r.Post("/reconcile/zero-ref-records", blockGCHandler.ReconcileReclaimZeroRef)
+				r.Post("/reconcile/reclaim", blockGCHandler.ReconcileReclaim)
 			})
 
 			// Store management (admin only)

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -323,9 +323,10 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 				// Read-only orphan-storage reporter (#1493/#1525). Server-wide
 				// scan; mutates nothing. Reviewed before the delete stages act.
 				r.Get("/reconcile-report", blockGCHandler.ReconcileReport)
-				// Zero-ref record reclaim (#1493 PR5b): deletes class-1 orphans
-				// and frees their remote objects. Mutating, so POST; dry_run
-				// previews.
+				// Orphan-storage reclaim (#1493 PR5b/5c): deletes class-1
+				// (zero-ref) and class-2 (leaked) records and class-3
+				// (record-less) remote objects, freeing their storage.
+				// Mutating, so POST; dry_run previews.
 				r.Post("/reconcile/reclaim", blockGCHandler.ReconcileReclaim)
 			})
 

--- a/pkg/controlplane/runtime/blockgc_reconcile_reclaim.go
+++ b/pkg/controlplane/runtime/blockgc_reconcile_reclaim.go
@@ -4,60 +4,107 @@ import (
 	"context"
 
 	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/engine"
 	"github.com/marmos91/dittofs/pkg/block/remote"
 )
 
-// ReconcileReclaimZeroRef reclaims class-1 orphans server-wide: block records
-// with a zero live chunk count and no live locator — a crash between
-// DecrLiveChunkCount and DeleteBlockRecord. It frees each record's remote block
-// object (idempotent) and deletes the record. This is PR5b, the first DELETING
-// reconcile stage after the read-only reporter (PR5a, #1493/#1525); dryRun
-// tallies what would be reclaimed without deleting.
+// ReconcileReclaim reclaims orphaned block storage server-wide — the deleting
+// stages after the read-only reporter (PR5a, #1493/#1525):
+//
+//   - class 1 (zero-ref records) and class 2 (leaked records, #1525): block
+//     records with no live locator, deleted along with their remote object.
+//   - class 3 (record-less remote objects): blocks/<id> objects with no backing
+//     record, older than the grace window, deleted from the bucket.
+//
+// dryRun tallies what would be reclaimed without deleting.
 //
 // Like the GC sweep it unions the shares that reference each remote and holds the
-// same per-remote GC lock while reclaiming, so a zero-ref delete can never race a
-// concurrent sweep's check-then-DecrLiveChunkCount on the same shared block.
-func (r *Runtime) ReconcileReclaimZeroRef(ctx context.Context, dryRun bool) (*engine.ReclaimReport, error) {
+// same per-remote GC lock while reclaiming, so a delete can never race a concurrent
+// sweep's check-then-DecrLiveChunkCount on the same shared block.
+//
+// Class 3 is fail-closed: its "has a record" set (metaBlockIDs) is unioned across
+// EVERY share on the remote, and the object sweep is skipped for a remote unless
+// all of its shares were fully enumerated — otherwise a sibling share's live object
+// would be misread as an orphan and deleted. A read-only backend (records
+// enumerable but not deletable) still contributes to the union and keeps class 3
+// safe; only its class-1/2 records are left unreclaimed.
+func (r *Runtime) ReconcileReclaim(ctx context.Context, dryRun bool) (*engine.ReclaimReport, error) {
+	grace := r.reconcileGracePeriod()
 	total := &engine.ReclaimReport{}
 	for _, entry := range r.sharesSvc.DistinctRemoteStores() {
 		if err := ctx.Err(); err != nil {
 			return total, err
 		}
+
+		// views: shares whose records we can delete (class 1/2).
+		// metaBlockIDs: every block ID with a record, across ALL shares on this
+		// remote (class-3 safety set).
+		// allEnumerated: false if any share could not be fully walked, which
+		// makes the class-3 union incomplete and unsafe to act on.
 		views := make([]engine.ReclaimMetaView, 0, len(entry.Shares))
+		metaBlockIDs := make(map[string]struct{})
+		allEnumerated := true
 		for _, shareName := range entry.Shares {
 			mds, err := r.GetMetadataStoreForShare(shareName)
 			if err != nil {
-				logger.Warn("ReconcileReclaimZeroRef: metadata store unavailable — share excluded",
+				logger.Warn("ReconcileReclaim: metadata store unavailable — class-3 sweep disabled for this remote",
 					"share", shareName, "err", err)
+				allEnumerated = false
 				continue
 			}
-			// EnumerateSynced/DeleteBlockRecord are required to re-derive the
-			// live set and delete; a backend lacking them cannot be reclaimed
-			// safely, so exclude it rather than risk a false delete.
-			view, ok := mds.(engine.ReclaimMetaView)
+			rv, ok := mds.(engine.ReconcileMetaView)
 			if !ok {
-				logger.Warn("ReconcileReclaimZeroRef: metadata store does not support reclaim — share excluded",
+				logger.Warn("ReconcileReclaim: metadata store does not support reconcile — class-3 sweep disabled for this remote",
 					"share", shareName)
+				allEnumerated = false
 				continue
 			}
-			views = append(views, view)
+			if err := rv.WalkBlockRecords(ctx, func(rec block.BlockRecord) error {
+				metaBlockIDs[rec.BlockID] = struct{}{}
+				return nil
+			}); err != nil {
+				logger.Warn("ReconcileReclaim: walk block records failed — class-3 sweep disabled for this remote",
+					"share", shareName, "err", err)
+				allEnumerated = false
+			}
+			// DeleteBlockRecord is the extra method the reclaimer needs beyond the
+			// read-only view; a backend lacking it still contributes to the union
+			// above but its records cannot be reclaimed.
+			if wv, ok := mds.(engine.ReclaimMetaView); ok {
+				views = append(views, wv)
+			}
 		}
-		if len(views) == 0 {
-			continue
-		}
-		// A remote that cannot hold packed blocks (no RemoteBlockStore) still has
-		// its records reclaimed; there is simply nothing to free remotely.
+
 		rbs, _ := entry.Store.(remote.RemoteBlockStore)
+		opts := engine.ReclaimOptions{DryRun: dryRun, GracePeriod: grace}
 
 		var rep engine.ReclaimReport
 		err := func() error {
 			lock := r.remoteGCLock(entry.ConfigID)
 			lock.Lock()
 			defer lock.Unlock()
+
 			var e error
-			rep, e = engine.ReclaimZeroRefRecords(ctx, views, rbs, engine.ReclaimOptions{DryRun: dryRun})
-			return e
+			if rep, e = engine.ReclaimRecords(ctx, views, rbs, opts); e != nil {
+				return e
+			}
+			if rbs == nil {
+				return nil // no remote store — nothing to sweep for class 3
+			}
+			// Class 3 only when every share was enumerable, else the union is
+			// incomplete and a live sibling object could be deleted.
+			if !allEnumerated {
+				logger.Warn("ReconcileReclaim: class-3 orphan-object sweep skipped — not all shares on remote were enumerable",
+					"configID", entry.ConfigID)
+				return nil
+			}
+			orep, e := engine.ReclaimOrphanObjects(ctx, metaBlockIDs, rbs, opts)
+			if e != nil {
+				return e
+			}
+			rep.Merge(orep)
+			return nil
 		}()
 		if err != nil {
 			return total, err
@@ -65,10 +112,13 @@ func (r *Runtime) ReconcileReclaimZeroRef(ctx context.Context, dryRun bool) (*en
 		total.Merge(rep)
 	}
 
-	logger.Info("ReconcileReclaimZeroRef: complete",
-		"reclaimed", total.Reclaimed.Count,
-		"bytesFreed", total.Reclaimed.Bytes,
+	logger.Info("ReconcileReclaim: complete",
+		"zeroRefReclaimed", total.Reclaimed.Count,
+		"leakedReclaimed", total.LeakedReclaimed.Count,
+		"orphanObjectsReclaimed", total.OrphanObjectsReclaimed.Count,
+		"bytesFreed", total.Reclaimed.Bytes+total.LeakedReclaimed.Bytes+total.OrphanObjectsReclaimed.Bytes,
 		"blockRecordsScanned", total.BlockRecordsScanned,
+		"remoteObjectsScanned", total.RemoteObjectsScanned,
 		"errors", total.Errors,
 		"dryRun", total.DryRun,
 	)


### PR DESCRIPTION
## What

PR5c of epic #1493 (blocks-only storage) — the two remaining **deleting** reconcile stages after PR5b's zero-ref reclaim. Closes #1525.

Mirrors the read-only reporter's (PR5a) classification, promoting it to a delete:

- **class 2 (leaked, #1525):** block records with no live locator but a stale `LiveChunkCount > 0` — left when `DefaultCommitBlock`'s last-wins `DeleteSynced→MarkSynced` re-carve moves the hash to a new block without decrementing the old one, so its count is stuck > 0 forever and the hash-driven sweep never revisits it. A record with no live locator is terminally dead whatever its count (block IDs are fresh crypto/rand per carve, never reused), so it needs no grace window. `ReclaimRecords` now reclaims class 1 + class 2 in one record walk.
- **class 3 (record-less objects):** remote `blocks/<id>` with no backing record, past the grace window (a `PutBlock` whose commit never landed). New `ReclaimOrphanObjects` sweeps them.

## Safety invariants

- **Class-2 TOCTOU (caught in review):** `ReclaimRecords` walks records **before** building the live-locator set. Because a commit writes a record and its locators in one transaction, a block committed mid-scan is either not yet walked (skipped this run) or seen together with its locator (survives) — it can never be captured as a leaked orphan against a stale live set. Guarded by a mid-scan-commit regression test (`raceView`).
- **Class-3 fail-closed:** the has-a-record union (`metaBlockIDs`) is built across **every** share on the remote via the read-only view (including read-only backends that can't delete records), and the object sweep is skipped entirely unless all shares were enumerable — so a sibling share's live object can never be misread as an orphan.
- **Locking:** all deletes hold the per-remote GC lock (`remoteGCLock(configID)`), the same key the GC sweep uses, so a delete can't race a concurrent `DecrLiveChunkCount`.
- **Delete order:** `DeleteBlock` (remote) before `DeleteBlockRecord` (metadata) — a crash between leaves a record-less object (class 3, swept later), never a record pointing at freed bytes. Both idempotent; per-item failures logged/counted and retried next run.

## Surface

Widened the reclaim endpoint (`POST /blockstore/reconcile/reclaim`, was `/zero-ref-records`) and `dfsctl store block reclaim` to report all three classes. `--dry-run` previews without mutating.

## Testing

- `go test -race ./pkg/block/engine/` — 290 pass (incl. class-2, class-3 grace-window, and the TOCTOU regression)
- `go test ./pkg/controlplane/runtime/... ./internal/controlplane/api/handlers/ ./cmd/dfsctl/... ./pkg/apiclient/...` — green
- `go vet` + `golangci-lint` clean; `cmd/gendocs` regenerated
- code-simplifier + code-reviewer passes (the review caught the class-2 TOCTOU, now fixed + regression-tested)
- Real-mount e2e (NFS+SMB against a live S3 bucket) to follow on a disposable VM.

After this, epic #1493 has no remaining delete stages.