### PR TITLE
fix(block): sqlite deadlock — drain EnumerateSynced before GetLocator (#1552)

### DIFF
--- a/pkg/block/engine/legacy_migration.go
+++ b/pkg/block/engine/legacy_migration.go
@@ -98,7 +98,19 @@ func (m *Syncer) migrateLegacyCASRemote(ctx context.Context) error {
 	enum, canEnumerate := shs.(SyncedHashIndex)
 	var standalone []block.ContentHash
 	if canEnumerate {
+		// Drain the enumeration into a slice, THEN resolve locators: the sqlite
+		// metadata pool is MaxOpenConns(1), so calling GetLocator inside the
+		// EnumerateSynced callback (while its cursor still holds the only
+		// connection) deadlocks waiting for a second — which blocks Store.Start
+		// and, via LoadSharesFromStore, the whole server from coming up.
+		var synced []block.ContentHash
 		if err := enum.EnumerateSynced(ctx, func(h block.ContentHash, _ time.Time) error {
+			synced = append(synced, h)
+			return nil
+		}); err != nil {
+			return fmt.Errorf("cas→blocks migration: enumerate synced hashes: %w", err)
+		}
+		for _, h := range synced {
 			if err := ctx.Err(); err != nil {
 				return err
 			}
@@ -109,9 +121,6 @@ func (m *Syncer) migrateLegacyCASRemote(ctx context.Context) error {
 			if ok && loc.BlockID == "" { // standalone locator: pre-flip layout
 				standalone = append(standalone, h)
 			}
-			return nil
-		}); err != nil {
-			return fmt.Errorf("cas→blocks migration: enumerate synced hashes: %w", err)
 		}
 	}
 

--- a/pkg/block/engine/reconcile.go
+++ b/pkg/block/engine/reconcile.go
@@ -161,18 +161,30 @@ func Reconcile(
 		// refSet: every block ID still pointed at by a live synced locator in
 		// THIS share. Built fully first, then WalkBlockRecords classifies each
 		// record against it.
-		refSet := make(map[string]struct{})
+		//
+		// Drain EnumerateSynced into a slice, THEN resolve locators: the sqlite
+		// pool is MaxOpenConns(1), so calling GetLocator inside the enumerate
+		// callback (cursor still open) would deadlock waiting for a second
+		// connection.
+		var synced []block.ContentHash
 		if err := v.EnumerateSynced(ctx, func(h block.ContentHash, _ time.Time) error {
+			synced = append(synced, h)
+			return nil
+		}); err != nil {
+			return report, fmt.Errorf("reconcile: enumerate synced: %w", err)
+		}
+		refSet := make(map[string]struct{})
+		for _, h := range synced {
+			if err := ctx.Err(); err != nil {
+				return report, err
+			}
 			loc, ok, err := v.GetLocator(ctx, h)
 			if err != nil {
-				return err
+				return report, fmt.Errorf("reconcile: get locator: %w", err)
 			}
 			if ok && loc.BlockID != "" {
 				refSet[loc.BlockID] = struct{}{}
 			}
-			return nil
-		}); err != nil {
-			return report, fmt.Errorf("reconcile: enumerate synced: %w", err)
 		}
 
 		if err := v.WalkBlockRecords(ctx, func(rec block.BlockRecord) error {

--- a/pkg/block/engine/reconcile_test.go
+++ b/pkg/block/engine/reconcile_test.go
@@ -221,3 +221,43 @@ func (s reconcileState) assertEqual(t *testing.T, other reconcileState) {
 		}
 	}
 }
+
+// nestedGuardMetaView models the sqlite MaxOpenConns(1) hazard: while an
+// EnumerateSynced cursor is open it holds the only connection, so any query from
+// inside the callback (GetLocator) would deadlock. It fails loudly instead, so
+// Reconcile must drain the enumeration before resolving locators.
+type nestedGuardMetaView struct {
+	t           *testing.T
+	inEnumerate bool
+}
+
+func (v *nestedGuardMetaView) EnumerateSynced(_ context.Context, fn func(block.ContentHash, time.Time) error) error {
+	v.inEnumerate = true
+	defer func() { v.inEnumerate = false }()
+	return fn(hashFromString("chunk"), time.Time{})
+}
+
+func (v *nestedGuardMetaView) GetLocator(_ context.Context, _ block.ContentHash) (block.ChunkLocator, bool, error) {
+	if v.inEnumerate {
+		v.t.Fatal("GetLocator called while EnumerateSynced cursor is open — deadlocks on sqlite MaxOpenConns(1)")
+	}
+	return block.ChunkLocator{BlockID: "blk-live"}, true, nil
+}
+
+func (v *nestedGuardMetaView) WalkBlockRecords(_ context.Context, fn func(block.BlockRecord) error) error {
+	return fn(block.BlockRecord{BlockID: "blk-live", Length: 5, LiveChunkCount: 1})
+}
+
+// TestReconcile_NoNestedQueryDuringEnumerate guards the #1552 sqlite deadlock:
+// Reconcile must not call GetLocator inside the EnumerateSynced callback.
+func TestReconcile_NoNestedQueryDuringEnumerate(t *testing.T) {
+	v := &nestedGuardMetaView{t: t}
+	rep, err := Reconcile(t.Context(), []ReconcileMetaView{v}, nil, nil, ReconcileOptions{})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	// blk-live has a live locator → healthy, not flagged in any class.
+	if rep.ZeroRefRecords.Count != 0 || rep.LeakedBlocks.Count != 0 {
+		t.Errorf("healthy located block misclassified: zeroRef=%d leaked=%d", rep.ZeroRefRecords.Count, rep.LeakedBlocks.Count)
+	}
+}


### PR DESCRIPTION
## What

Fixes a **hard deadlock on the sqlite metadata backend**: the sqlite pool is `SetMaxOpenConns(1)` (`store.go:108`), and `EnumerateSynced` (`synced_hash_store.go:29`) runs its callback while the rows cursor still holds the only connection. Any query issued from inside that callback (`GetLocator`) blocks forever waiting for a second connection.

Two sites shared the pattern:
- **`legacy_migration.go` (`migrateLegacyCASRemote`)** — runs synchronously from `Store.Start` via `LoadSharesFromStore`, so the deadlock **blocked the whole server from starting** whenever an S3-backed share existed in a sqlite store.
- **`reconcile.go` (PR5a reporter)** — `GET /blockstore/reconcile-report` hung (client saw a 30s server write-timeout).

Both fixed by draining `EnumerateSynced` into a slice first, then resolving locators after the cursor closes — the collect-then-query rule the store already documents in `objects.go:342` for its warm/stats callbacks.

## Why it escaped CI

**Every** e2e/integration test uses the memory metadata store (`MatrixSetupConfig{MetadataType: "memory"}`), which has no connection cap. This class of bug is invisible to the entire suite. Found by running dfs on a VM with a real sqlite + MinIO(S3) share and capturing a goroutine dump parked at `legacy_migration.go:105`.

## Testing

- Regression guards (`nestedGuardView` / `nestedGuardMetaView`) that **fail** if `GetLocator` is called while the `EnumerateSynced` cursor is open — they'd catch a reintroduction without needing a real sqlite backend.
- `go test -race ./pkg/block/engine/` green.
- Live: with this binary the server's startup goroutine advances **past** `migrateLegacyCAS` into `ListenAndServe` (previously parked forever in the migration).

## Follow-up

The sqlite + real-S3 startup path has more latent issues the memory-only suite can't see (startup is slow / additional serialization). Recommend adding a **sqlite-backed startup/reconcile integration test** so this whole path gets exercised. The reclaim counterpart of this deadlock is fixed in #1551.

Closes #1552.