### PR TITLE
feat(gc): compact partially-dead blocks (#1487)

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -225,8 +225,9 @@ func runStart(cmd *cobra.Command, args []string) error {
 	// the validated gc.* config in pkg/config/config.go is silently dropped
 	// and the engine falls back to hardcoded defaults.
 	rt.SetGCDefaults(&runtime.GCDefaults{
-		GracePeriod:      cfg.GC.GracePeriod,
-		DryRunSampleSize: cfg.GC.DryRunSampleSize,
+		GracePeriod:         cfg.GC.GracePeriod,
+		DryRunSampleSize:    cfg.GC.DryRunSampleSize,
+		CompactionLiveRatio: cfg.GC.CompactionLiveRatio,
 	})
 
 	// Thread the operator-configured lock-manager grace period into the

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -487,6 +487,14 @@ gc:
                               # the snapshot.
   dry_run_sample_size: 1000   # Maximum candidate keys reported in
                               # --dry-run mode. Default 1000.
+  compaction_live_ratio: 0    # Reclaim dead bytes from partially-dead
+                              # blocks. After each sweep, a block whose
+                              # live bytes / object size is below this
+                              # ratio is repacked (live chunks only) and
+                              # the old block deleted. Must be in [0, 1];
+                              # 0 (default) disables compaction. A value
+                              # like 0.5 compacts a block once it is more
+                              # than half dead.
   auto_enabled: true          # Run background GC automatically so you
                               # don't have to invoke the CLI. Default
                               # true. Set false to require manual

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -553,12 +553,51 @@ each dead chunk is reclaimed by refcount:
    reclaimed: its local blob is evicted, `RemoteBlockStore.DeleteBlock`
    removes the remote object, and the block record is deleted.
 
-A block that still has *any* live chunk is retained — packing never deletes a
-referenced chunk along with its block-mates. Reclamation is **delete-only**:
-GC never rewrites or repacks a surviving block. Runs are **serialized per
-remote** (keyed on remote-store config identity), so the `LiveChunkCount` that
-several shares targeting the same remote share is only ever mutated by one run
-at a time.
+A block that still has *any* live chunk is retained by the refcount pass —
+packing never deletes a referenced chunk along with its block-mates. Runs are
+**serialized per remote** (keyed on remote-store config identity), so the
+`LiveChunkCount` that several shares targeting the same remote share is only
+ever mutated by one run at a time.
+
+### Compaction of partially-dead blocks
+
+Refcount reclamation alone frees a block only when its *last* live chunk dies,
+so a block that keeps a few live chunks but has shed many dead ones pins the
+dead bytes forever. Compaction (`engine.CompactBlocks`, #1487) closes that gap.
+It runs as an optional final phase of each per-remote sweep, under the same
+per-remote lock and immediately **after** the sweep — by which point the sweep
+has already cleared the synced marker of every past-grace dead chunk. So a
+chunk resident in a block is "still live here" iff its synced locator still
+points at that block; a chunk that lost its marker (swept dead) or whose
+locator has moved is dropped. This reuses the sweep's own keep/delete decision,
+so compaction never reclaims a chunk the sweep would have spared, and needs no
+second live-set scan.
+
+- **Candidate selection** is byte-based: the sum of the `WireLength` of every
+  live locator pointing at a block, over the block's object `Length`. Below the
+  operator's `gc.compaction_live_ratio` (0 disables; a value like `0.5` compacts
+  a block once it is more than half dead) the block is a candidate. Computed
+  from the block record + locators alone — no per-block download to decide, and
+  no extra stored field.
+- **Repack** downloads the candidate block once, verifies it against its
+  record's whole-block BLAKE3 hash, copies the still-live chunks' wire bodies
+  verbatim into a fresh block (the per-chunk encryption already lives in the
+  body), `PutBlock`s it, then `DefaultCommitBlock` writes the new record and
+  rewrites the moved chunks' locators (last-wins) in one transaction, and
+  finally deletes the old block object + record.
+- **Crash safety** is identical to the live carver / cas→blocks migration and
+  every crash window lands on an existing reconcile class: a crash after
+  `PutBlock` before the commit leaves an orphan object (reconcile class 3); a
+  crash after the commit before the old block is deleted leaves the old block as
+  a leaked record (class 2). A re-run converges — the moved chunks' locators no
+  longer point at the old block, so compaction finds nothing to move and just
+  deletes the husk.
+
+Because compaction rewrites a live chunk's locator to a new block before
+deleting the old one, a reader that resolved the old locator *before* the
+rewrite and issues its `GetBlock` *after* the delete sees a miss — the same
+narrow window the refcount reclaim already has; acceptable for this opt-in
+maintenance pass.
 
 ### Fail-closed posture
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -596,7 +596,8 @@ second live-set scan.
 Because compaction rewrites a live chunk's locator to a new block before
 deleting the old one, a reader that resolved the old locator *before* the
 rewrite and issues its `GetBlock` *after* the delete sees a miss. This is safe
-only because the read path (`fetchResolvedBlock`) re-resolves the locator once
+only because the read path (`dispatchRemoteFetch`, the chokepoint both the
+client demand read and background prefetch share) re-resolves the locator once
 on `ErrChunkNotFound` and retries against the moved chunk's new block — without
 that guard the delete would surface a spurious `EIO` for a perfectly live chunk.
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -595,9 +595,10 @@ second live-set scan.
 
 Because compaction rewrites a live chunk's locator to a new block before
 deleting the old one, a reader that resolved the old locator *before* the
-rewrite and issues its `GetBlock` *after* the delete sees a miss — the same
-narrow window the refcount reclaim already has; acceptable for this opt-in
-maintenance pass.
+rewrite and issues its `GetBlock` *after* the delete sees a miss. This is safe
+only because the read path (`fetchResolvedBlock`) re-resolves the locator once
+on `ErrChunkNotFound` and retries against the moved chunk's new block — without
+that guard the delete would surface a spurious `EIO` for a perfectly live chunk.
 
 ### Fail-closed posture
 

--- a/pkg/block/engine/compaction.go
+++ b/pkg/block/engine/compaction.go
@@ -239,11 +239,7 @@ func compactOneBlock(
 	// Select the chunks still live in THIS block: a synced locator that still
 	// points here. Dropped: dead chunks (marker cleared by the sweep) and any
 	// already moved to another block (locator points elsewhere — re-run).
-	type moved struct {
-		hash block.ContentHash
-		wire []byte
-	}
-	moveable := make([]moved, 0, len(records))
+	moveable := make([]blockcodec.Record, 0, len(records))
 	for _, r := range records {
 		loc, ok, err := v.GetLocator(ctx, r.Hash)
 		if err != nil {
@@ -252,7 +248,7 @@ func compactOneBlock(
 			return
 		}
 		if ok && loc.BlockID == blockID {
-			moveable = append(moveable, moved{hash: r.Hash, wire: data[r.WireOffset : r.WireOffset+r.WireLength]})
+			moveable = append(moveable, r)
 		}
 	}
 
@@ -291,16 +287,16 @@ func compactOneBlock(
 		return
 	}
 	commits := make([]block.BlockChunkCommit, 0, len(moveable))
-	for _, mv := range moveable {
-		loc, err := builder.Add(mv.hash, mv.wire)
+	for _, r := range moveable {
+		loc, err := builder.Add(r.Hash, data[r.WireOffset:r.WireOffset+r.WireLength])
 		if err != nil {
-			slog.Warn("compaction: frame chunk failed — skipping block", "block_id", blockID, "hash", mv.hash.String(), "err", err)
+			slog.Warn("compaction: frame chunk failed — skipping block", "block_id", blockID, "hash", r.Hash.String(), "err", err)
 			report.Errors++
 			return
 		}
 		// Local left zero: the bytes are read from remote and the chunk's local
 		// index entry (if any) already points at its log blob and is unchanged.
-		commits = append(commits, block.BlockChunkCommit{Hash: mv.hash, Remote: loc})
+		commits = append(commits, block.BlockChunkCommit{Hash: r.Hash, Remote: loc})
 	}
 	if _, err := builder.Finish(); err != nil {
 		slog.Warn("compaction: finish block failed — skipping", "block_id", blockID, "err", err)

--- a/pkg/block/engine/compaction.go
+++ b/pkg/block/engine/compaction.go
@@ -44,9 +44,11 @@
 // Concurrency: the caller MUST hold the per-remote GC lock (as the sweep and
 // reclaim do) so compaction cannot race a concurrent sweep's DecrLiveChunkCount
 // or DeleteBlock on the same block. An in-flight reader that resolved a locator
-// to the old block before step 2 and issues its GET after step 3 sees a 404 —
-// the same narrow window the delete-only reclaim already has for its blocks;
-// acceptable for an opt-in maintenance pass.
+// to the old block before step 2 and issues its GET after step 3 sees a 404.
+// That is NOT data loss only because the read path (fetchResolvedBlock) re-
+// resolves the locator once on ErrChunkNotFound and retries against the moved
+// chunk's new block — without that guard this delete would surface a spurious
+// EIO to the client, not the "harmless same-window-as-reclaim" it looks like.
 package engine
 
 import (
@@ -329,12 +331,15 @@ func compactOneBlock(
 	// (3) Delete the old block: object then record (matches reclaim order — a
 	// crash between leaves a class-2 leaked record, reclaimed by ReclaimRecords).
 	// The live chunks are already safe in the new block regardless of the outcome
-	// here; a failed delete leaves the old block for the next run / reconcile.
-	deleteOldBlock(ctx, v, rbs, blockID, report)
-
-	report.BlocksCompacted++
-	report.ChunksMoved += int64(len(commits))
-	report.BytesReclaimed += rec.Length - int64(len(newBytes))
+	// here; a failed delete leaves the old block for the next run / reconcile. Only
+	// count the reclaim (and this block) when the delete actually freed the old
+	// object — otherwise no space was reclaimed and the counters would over-report
+	// (mirrors the husk path above).
+	if deleteOldBlock(ctx, v, rbs, blockID, report) {
+		report.BlocksCompacted++
+		report.ChunksMoved += int64(len(commits))
+		report.BytesReclaimed += rec.Length - int64(len(newBytes))
+	}
 }
 
 // deleteOldBlock deletes a block's remote object then its record (that order —

--- a/pkg/block/engine/compaction.go
+++ b/pkg/block/engine/compaction.go
@@ -45,8 +45,9 @@
 // reclaim do) so compaction cannot race a concurrent sweep's DecrLiveChunkCount
 // or DeleteBlock on the same block. An in-flight reader that resolved a locator
 // to the old block before step 2 and issues its GET after step 3 sees a 404.
-// That is NOT data loss only because the read path (fetchResolvedBlock) re-
-// resolves the locator once on ErrChunkNotFound and retries against the moved
+// That is NOT data loss only because the read path (dispatchRemoteFetch, the
+// chokepoint both the client demand read and background prefetch route through)
+// re-resolves the locator once on ErrChunkNotFound and retries against the moved
 // chunk's new block — without that guard this delete would surface a spurious
 // EIO to the client, not the "harmless same-window-as-reclaim" it looks like.
 package engine

--- a/pkg/block/engine/compaction.go
+++ b/pkg/block/engine/compaction.go
@@ -1,0 +1,361 @@
+// Package engine — GC compaction of partially-dead blocks (#1487).
+//
+// Delete-only block GC (gc_block.go) frees a block object only once its LAST
+// live chunk dies. A block that keeps a few live chunks but has accumulated
+// many dead ones pins the dead chunks' bytes on the remote forever. Compaction
+// closes that gap: it copies a mostly-dead block's still-live chunks into a
+// fresh block, rewrites their locators to point at the new block, and deletes
+// the old block object + record — reclaiming the dead bytes.
+//
+// # Liveness signal (no live-set rebuild, no schema change)
+//
+// Compaction runs AFTER the GC sweep, under the same per-remote lock. By then
+// the sweep has already cleared the synced marker of every past-grace dead
+// chunk (DeleteSynced). So a chunk resident in block B is "still live here"
+// iff GetLocator(hash) is synced and points at B; a chunk that lost its marker
+// (swept dead) or whose locator moved elsewhere is dropped. Chunks still within
+// grace keep their marker and are carried forward conservatively — never a
+// premature drop. This is exactly the keep/delete decision the sweep just made,
+// so compaction never reclaims a chunk the sweep would have spared.
+//
+// # Candidate selection
+//
+// Byte-based live ratio: sum of the WireLength of every live locator pointing
+// at a block, divided by the block's object Length. Below the configured
+// threshold the block is a candidate. Computed from GetLocator + the block
+// record alone — no per-block GET and no extra stored field.
+//
+// # Crash safety & idempotency (identical to the live carver / migration)
+//
+//  1. PutBlock(new) — a crash here leaves an orphan remote object with no
+//     record (reconcile class 3), reclaimed by ReclaimOrphanObjects. Live
+//     chunks still resolve to the intact old block. No data loss.
+//  2. DefaultCommitBlock — one transaction writes the new record and overwrites
+//     each moved chunk's locator (last-wins DeleteSynced→MarkSynced) to the new
+//     block. All-or-nothing.
+//  3. DeleteBlock(old) then DeleteBlockRecord(old) — a crash between leaves the
+//     old block as a class-2 "leaked" record (no live locator points at it,
+//     since all moved), reclaimed by ReclaimRecords.
+//
+// A re-run converges: moved chunks' locators no longer point at the old block,
+// so compactOne finds nothing to move and simply deletes the husk. The whole
+// old block is BLAKE3-verified against its record before any byte is trusted.
+//
+// Concurrency: the caller MUST hold the per-remote GC lock (as the sweep and
+// reclaim do) so compaction cannot race a concurrent sweep's DecrLiveChunkCount
+// or DeleteBlock on the same block. An in-flight reader that resolved a locator
+// to the old block before step 2 and issues its GET after step 3 sees a 404 —
+// the same narrow window the delete-only reclaim already has for its blocks;
+// acceptable for an opt-in maintenance pass.
+package engine
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/blockcodec"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// CompactMetaView is the per-share metadata surface compaction needs: the
+// read-only reconcile view (EnumerateSynced + GetLocator + WalkBlockRecords)
+// plus record read/delete and a Transactor for DefaultCommitBlock's atomic
+// record+locator rewrite. metadata.Store satisfies it structurally.
+type CompactMetaView interface {
+	ReconcileMetaView
+	metadata.Transactor
+	GetBlockRecord(ctx context.Context, blockID string) (block.BlockRecord, bool, error)
+	DeleteBlockRecord(ctx context.Context, blockID string) error
+}
+
+// CompactOptions parameterizes a compaction pass.
+type CompactOptions struct {
+	// LiveRatio is the threshold below which a block is compacted: a block
+	// whose live bytes / object length is < LiveRatio is a candidate. Must be
+	// in (0, 1]; a non-positive value disables compaction (the pass no-ops).
+	LiveRatio float64
+	// DryRun reports candidates without moving or deleting anything.
+	DryRun bool
+}
+
+// CompactReport is the output of a compaction pass.
+type CompactReport struct {
+	BlocksScanned   int64 `json:"blocks_scanned"`
+	BlocksCompacted int64 `json:"blocks_compacted"`
+	ChunksMoved     int64 `json:"chunks_moved"`
+	// BytesReclaimed is the sum of (old block length − new block length) across
+	// compacted blocks; for a husk (all chunks already dead/moved) it is the
+	// whole old block length.
+	BytesReclaimed int64 `json:"bytes_reclaimed"`
+	Errors         int64 `json:"errors"`
+	DryRun         bool  `json:"dry_run"`
+}
+
+// Merge folds other into r, for aggregating per-remote passes.
+func (r *CompactReport) Merge(other CompactReport) {
+	r.BlocksScanned += other.BlocksScanned
+	r.BlocksCompacted += other.BlocksCompacted
+	r.ChunksMoved += other.ChunksMoved
+	r.BytesReclaimed += other.BytesReclaimed
+	r.Errors += other.Errors
+	if other.DryRun {
+		r.DryRun = true
+	}
+}
+
+// CompactBlocks repacks partially-dead blocks on one remote-store scope. views
+// are the per-share metadata views sharing the remote block store rbs. A block
+// is per-share (block IDs are minted per share), so each view is compacted
+// against its own live locator set. Returns a non-nil error only on an
+// enumeration/walk failure; per-block failures are counted in Report.Errors and
+// leave that block intact for the next run.
+//
+// The caller MUST hold the per-remote GC lock and run this AFTER the sweep.
+func CompactBlocks(
+	ctx context.Context,
+	views []CompactMetaView,
+	rbs remote.RemoteBlockStore,
+	opts CompactOptions,
+) (CompactReport, error) {
+	report := CompactReport{DryRun: opts.DryRun}
+	if rbs == nil || opts.LiveRatio <= 0 {
+		return report, nil // remote cannot hold blocks, or compaction disabled
+	}
+
+	for _, v := range views {
+		// Live bytes per block: sum the WireLength of every live synced locator.
+		// Drain EnumerateSynced THEN resolve locators — the sqlite pool is
+		// MaxOpenConns(1), so GetLocator inside the enumerate callback (cursor
+		// still open) would deadlock waiting for a second connection.
+		var synced []block.ContentHash
+		if err := v.EnumerateSynced(ctx, func(h block.ContentHash, _ time.Time) error {
+			synced = append(synced, h)
+			return nil
+		}); err != nil {
+			return report, fmt.Errorf("compaction: enumerate synced: %w", err)
+		}
+		liveBytes := make(map[string]int64)
+		for _, h := range synced {
+			if err := ctx.Err(); err != nil {
+				return report, err
+			}
+			loc, ok, err := v.GetLocator(ctx, h)
+			if err != nil {
+				return report, fmt.Errorf("compaction: get locator: %w", err)
+			}
+			if ok && loc.BlockID != "" {
+				liveBytes[loc.BlockID] += loc.WireLength
+			}
+		}
+
+		// Collect candidate block IDs first — never GET/commit/delete while the
+		// WalkBlockRecords cursor is open (sqlite single-connection rule).
+		var candidates []string
+		if err := v.WalkBlockRecords(ctx, func(rec block.BlockRecord) error {
+			report.BlocksScanned++
+			lb := liveBytes[rec.BlockID]
+			if lb > 0 && rec.Length > 0 && float64(lb)/float64(rec.Length) < opts.LiveRatio {
+				candidates = append(candidates, rec.BlockID)
+			}
+			return nil
+		}); err != nil {
+			return report, fmt.Errorf("compaction: walk block records: %w", err)
+		}
+
+		for _, blockID := range candidates {
+			if err := ctx.Err(); err != nil {
+				return report, err
+			}
+			compactOneBlock(ctx, v, rbs, blockID, opts, &report)
+		}
+	}
+	return report, nil
+}
+
+// compactOneBlock compacts a single candidate block. Errors are logged and
+// counted in report.Errors, leaving the block intact for the next run.
+func compactOneBlock(
+	ctx context.Context,
+	v CompactMetaView,
+	rbs remote.RemoteBlockStore,
+	blockID string,
+	opts CompactOptions,
+	report *CompactReport,
+) {
+	rec, ok, err := v.GetBlockRecord(ctx, blockID)
+	if err != nil {
+		slog.Warn("compaction: get block record failed — skipping", "block_id", blockID, "err", err)
+		report.Errors++
+		return
+	}
+	if !ok {
+		return // already gone (raced a concurrent reclaim in the same run)
+	}
+
+	data, err := rbs.GetBlock(ctx, blockID)
+	if err != nil {
+		if errors.Is(err, block.ErrChunkNotFound) {
+			// Object gone but record survives (a prior compaction's DeleteBlock
+			// landed, DeleteBlockRecord did not): finish the cleanup. The moved
+			// chunks already point at the new block; the husk record is safe to
+			// drop whatever its stale count says (block IDs are never reused).
+			if opts.DryRun {
+				return
+			}
+			if derr := v.DeleteBlockRecord(ctx, blockID); derr != nil {
+				slog.Warn("compaction: delete husk record failed — will retry next run", "block_id", blockID, "err", derr)
+				report.Errors++
+			}
+			return
+		}
+		slog.Warn("compaction: get block failed — skipping", "block_id", blockID, "err", err)
+		report.Errors++
+		return
+	}
+
+	// Whole-block BLAKE3 verify before trusting any byte (respects integrity;
+	// the wire bodies are copied verbatim so per-chunk hashes are preserved).
+	if block.ContentHash(blake3.Sum256(data)) != rec.BlockHash {
+		slog.Error("compaction: block hash mismatch — leaving for the scrubber", "block_id", blockID)
+		report.Errors++
+		return
+	}
+
+	_, records, err := blockcodec.Parse(data, nil)
+	if err != nil {
+		slog.Warn("compaction: parse block failed — skipping", "block_id", blockID, "err", err)
+		report.Errors++
+		return
+	}
+
+	// Select the chunks still live in THIS block: a synced locator that still
+	// points here. Dropped: dead chunks (marker cleared by the sweep) and any
+	// already moved to another block (locator points elsewhere — re-run).
+	type moved struct {
+		hash block.ContentHash
+		wire []byte
+	}
+	moveable := make([]moved, 0, len(records))
+	for _, r := range records {
+		loc, ok, err := v.GetLocator(ctx, r.Hash)
+		if err != nil {
+			slog.Warn("compaction: get locator failed — skipping block", "block_id", blockID, "hash", r.Hash.String(), "err", err)
+			report.Errors++
+			return
+		}
+		if ok && loc.BlockID == blockID {
+			moveable = append(moveable, moved{hash: r.Hash, wire: data[r.WireOffset : r.WireOffset+r.WireLength]})
+		}
+	}
+
+	if len(moveable) == len(records) {
+		return // nothing dead to reclaim (all chunks still live here) — leave it
+	}
+
+	if opts.DryRun {
+		report.BlocksCompacted++
+		return
+	}
+
+	if len(moveable) == 0 {
+		// Husk: every chunk is dead or already moved. Reclaim the whole object.
+		if deleteOldBlock(ctx, v, rbs, blockID, report) {
+			report.BlocksCompacted++
+			report.BytesReclaimed += rec.Length
+		}
+		return
+	}
+
+	// Pack the live chunks into a fresh block (verbatim wire bodies; the codec
+	// re-frames the record headers with the new block ID). nil Sealer matches
+	// the carver/migration — per-chunk encryption already lives in the body.
+	newID, err := newBlockID()
+	if err != nil {
+		slog.Warn("compaction: new block id failed — skipping", "block_id", blockID, "err", err)
+		report.Errors++
+		return
+	}
+	var buf bytes.Buffer
+	builder, err := blockcodec.NewBuilder(&buf, newID, nil)
+	if err != nil {
+		slog.Warn("compaction: new builder failed — skipping", "block_id", blockID, "err", err)
+		report.Errors++
+		return
+	}
+	commits := make([]block.BlockChunkCommit, 0, len(moveable))
+	for _, mv := range moveable {
+		loc, err := builder.Add(mv.hash, mv.wire)
+		if err != nil {
+			slog.Warn("compaction: frame chunk failed — skipping block", "block_id", blockID, "hash", mv.hash.String(), "err", err)
+			report.Errors++
+			return
+		}
+		// Local left zero: the bytes are read from remote and the chunk's local
+		// index entry (if any) already points at its log blob and is unchanged.
+		commits = append(commits, block.BlockChunkCommit{Hash: mv.hash, Remote: loc})
+	}
+	if _, err := builder.Finish(); err != nil {
+		slog.Warn("compaction: finish block failed — skipping", "block_id", blockID, "err", err)
+		report.Errors++
+		return
+	}
+	newBytes := buf.Bytes()
+
+	// (1) PutBlock — orphan object on crash (reconcile class 3), never data loss.
+	if err := rbs.PutBlock(ctx, newID, bytes.NewReader(newBytes)); err != nil {
+		slog.Warn("compaction: put new block failed — skipping", "block_id", blockID, "new_block_id", newID, "err", err)
+		report.Errors++
+		return
+	}
+	// (2) Atomic record + last-wins locator rewrite onto the new block.
+	newRec := block.BlockRecord{
+		BlockID:        newID,
+		BlockHash:      block.ContentHash(blake3.Sum256(newBytes)),
+		Length:         int64(len(newBytes)),
+		LiveChunkCount: uint32(len(commits)),
+		SyncState:      block.BlockStateRemote,
+	}
+	if err := metadata.DefaultCommitBlock(ctx, v, newRec, commits); err != nil {
+		// New block is an orphan object (no record) — reconcile class 3; the old
+		// block is untouched and still resolves. Safe to abandon this attempt.
+		slog.Warn("compaction: commit new block failed — old block kept, new object orphaned for reconcile", "block_id", blockID, "new_block_id", newID, "err", err)
+		report.Errors++
+		return
+	}
+	// (3) Delete the old block: object then record (matches reclaim order — a
+	// crash between leaves a class-2 leaked record, reclaimed by ReclaimRecords).
+	// The live chunks are already safe in the new block regardless of the outcome
+	// here; a failed delete leaves the old block for the next run / reconcile.
+	deleteOldBlock(ctx, v, rbs, blockID, report)
+
+	report.BlocksCompacted++
+	report.ChunksMoved += int64(len(commits))
+	report.BytesReclaimed += rec.Length - int64(len(newBytes))
+}
+
+// deleteOldBlock deletes a block's remote object then its record (that order —
+// a crash between leaves a class-2 leaked record, reclaimed by ReclaimRecords,
+// never a record pointing at freed bytes). Returns true on full success; a
+// failure is logged and counted in report.Errors, leaving the block for the
+// next run.
+func deleteOldBlock(ctx context.Context, v CompactMetaView, rbs remote.RemoteBlockStore, blockID string, report *CompactReport) bool {
+	if err := rbs.DeleteBlock(ctx, blockID); err != nil {
+		slog.Warn("compaction: delete old block failed — record kept, reclaim next run", "block_id", blockID, "err", err)
+		report.Errors++
+		return false
+	}
+	if err := v.DeleteBlockRecord(ctx, blockID); err != nil {
+		slog.Warn("compaction: delete old record failed — retry next run", "block_id", blockID, "err", err)
+		report.Errors++
+		return false
+	}
+	return true
+}

--- a/pkg/block/engine/compaction_test.go
+++ b/pkg/block/engine/compaction_test.go
@@ -1,0 +1,282 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/blockcodec"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// seedRealPackedBlock writes a real codec-framed block (nil Sealer, so each
+// wire body is the verbatim chunk plaintext) to rbs and records its block
+// record + a live synced locator for every chunk. It returns each chunk's hash
+// so a test can later kill a subset. Mirrors what the carver commits, with real
+// framing the compactor's Parse can decode.
+func seedRealPackedBlock(t *testing.T, st metadata.Store, rbs remote.RemoteBlockStore, blockID string, chunkData [][]byte) []block.ContentHash {
+	t.Helper()
+	ctx := t.Context()
+
+	var buf bytes.Buffer
+	builder, err := blockcodec.NewBuilder(&buf, blockID, nil)
+	if err != nil {
+		t.Fatalf("NewBuilder: %v", err)
+	}
+	hashes := make([]block.ContentHash, len(chunkData))
+	locs := make([]block.ChunkLocator, len(chunkData))
+	for i, d := range chunkData {
+		h := block.ContentHash(blake3.Sum256(d))
+		hashes[i] = h
+		loc, err := builder.Add(h, d)
+		if err != nil {
+			t.Fatalf("builder.Add: %v", err)
+		}
+		locs[i] = loc
+	}
+	if _, err := builder.Finish(); err != nil {
+		t.Fatalf("builder.Finish: %v", err)
+	}
+	blockBytes := buf.Bytes()
+
+	if err := rbs.PutBlock(ctx, blockID, bytes.NewReader(blockBytes)); err != nil {
+		t.Fatalf("PutBlock(%s): %v", blockID, err)
+	}
+	if err := st.PutBlockRecord(ctx, block.BlockRecord{
+		BlockID:        blockID,
+		BlockHash:      block.ContentHash(blake3.Sum256(blockBytes)),
+		Length:         int64(len(blockBytes)),
+		LiveChunkCount: uint32(len(chunkData)),
+		SyncState:      block.BlockStateRemote,
+	}); err != nil {
+		t.Fatalf("PutBlockRecord(%s): %v", blockID, err)
+	}
+	for i, h := range hashes {
+		if err := st.MarkSynced(ctx, h, locs[i]); err != nil {
+			t.Fatalf("MarkSynced(%s): %v", h, err)
+		}
+		st.(*metadatamemory.MemoryMetadataStore).MarkSyncedAtForTest(h, time.Now().Add(-2*time.Hour))
+	}
+	return hashes
+}
+
+// killChunk simulates the post-sweep state of a dead chunk: the sweep has
+// cleared its synced marker (DeleteSynced) and decremented the block's live
+// count. The chunk bytes remain physically in the old block object.
+func killChunk(t *testing.T, st metadata.Store, blockID string, h block.ContentHash) {
+	t.Helper()
+	ctx := t.Context()
+	if err := st.DeleteSynced(ctx, h); err != nil {
+		t.Fatalf("DeleteSynced(%s): %v", h, err)
+	}
+	if _, err := st.DecrLiveChunkCount(ctx, blockID, 1); err != nil {
+		t.Fatalf("DecrLiveChunkCount(%s): %v", blockID, err)
+	}
+}
+
+// liveChunkBytes resolves a chunk through its current locator and returns the
+// wire body (== plaintext for a nil-Sealer block), proving the chunk is still
+// readable and byte-identical after a relocation.
+func liveChunkBytes(t *testing.T, st metadata.Store, rbs remote.RemoteBlockStore, h block.ContentHash) []byte {
+	t.Helper()
+	ctx := t.Context()
+	loc, ok, err := st.GetLocator(ctx, h)
+	if err != nil || !ok {
+		t.Fatalf("GetLocator(%s): ok=%v err=%v", h, ok, err)
+	}
+	data, err := rbs.GetBlock(ctx, loc.BlockID)
+	if err != nil {
+		t.Fatalf("GetBlock(%s): %v", loc.BlockID, err)
+	}
+	return data[loc.WireOffset : loc.WireOffset+loc.WireLength]
+}
+
+// TestCompactBlocks_PartiallyDeadBlock is the core #1487 proof: a block whose
+// live bytes fall below the threshold is repacked so the surviving chunks stay
+// readable and byte-identical, the dead space is reclaimed, and the old block
+// (object + record) is gone.
+func TestCompactBlocks_PartiallyDeadBlock(t *testing.T) {
+	ctx := t.Context()
+	st := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	rbs := remotememory.New()
+	defer func() { _ = rbs.Close() }()
+
+	live := bytes.Repeat([]byte("L"), 100)
+	dead1 := bytes.Repeat([]byte("D"), 100)
+	dead2 := bytes.Repeat([]byte("E"), 100)
+	dead3 := bytes.Repeat([]byte("F"), 100)
+	hashes := seedRealPackedBlock(t, st, rbs, "blk-partial", [][]byte{live, dead1, dead2, dead3})
+	liveHash := hashes[0]
+
+	// Kill three of four chunks: block is now ~25% live by bytes.
+	killChunk(t, st, "blk-partial", hashes[1])
+	killChunk(t, st, "blk-partial", hashes[2])
+	killChunk(t, st, "blk-partial", hashes[3])
+
+	oldRec, _, _ := st.GetBlockRecord(ctx, "blk-partial")
+
+	rep, err := CompactBlocks(ctx, []CompactMetaView{st}, rbs, CompactOptions{LiveRatio: 0.5})
+	if err != nil {
+		t.Fatalf("CompactBlocks: %v", err)
+	}
+	if rep.BlocksCompacted != 1 || rep.ChunksMoved != 1 || rep.Errors != 0 {
+		t.Fatalf("report = %+v; want 1 compacted, 1 moved, 0 errors", rep)
+	}
+	if rep.BytesReclaimed <= 0 {
+		t.Errorf("BytesReclaimed = %d; want > 0", rep.BytesReclaimed)
+	}
+
+	// Old block is gone: record and remote object.
+	if _, ok, _ := st.GetBlockRecord(ctx, "blk-partial"); ok {
+		t.Error("old block record still present after compaction")
+	}
+	if _, err := rbs.GetBlock(ctx, "blk-partial"); err == nil {
+		t.Error("old block object still present after compaction")
+	}
+
+	// The live chunk moved to a fresh block and reads back byte-identical.
+	loc, ok, err := st.GetLocator(ctx, liveHash)
+	if err != nil || !ok {
+		t.Fatalf("live chunk locator missing: ok=%v err=%v", ok, err)
+	}
+	if loc.BlockID == "blk-partial" || loc.BlockID == "" {
+		t.Errorf("live chunk locator points at %q; want a fresh block", loc.BlockID)
+	}
+	if got := liveChunkBytes(t, st, rbs, liveHash); !bytes.Equal(got, live) {
+		t.Errorf("live chunk bytes changed after compaction: got %q", got)
+	}
+
+	// The dead chunks are unreferenced (no locator).
+	for _, h := range hashes[1:] {
+		if _, ok, _ := st.GetLocator(ctx, h); ok {
+			t.Errorf("dead chunk %s still has a locator after compaction", h)
+		}
+	}
+
+	// The new block is strictly smaller than the old (dead space reclaimed).
+	newRec, ok, _ := st.GetBlockRecord(ctx, loc.BlockID)
+	if !ok {
+		t.Fatal("new block record missing")
+	}
+	if newRec.Length >= oldRec.Length {
+		t.Errorf("new block length %d not smaller than old %d", newRec.Length, oldRec.Length)
+	}
+	if newRec.LiveChunkCount != 1 {
+		t.Errorf("new block LiveChunkCount = %d; want 1", newRec.LiveChunkCount)
+	}
+
+	// Idempotent: a second pass has nothing to do (the block is now fully live).
+	rep2, err := CompactBlocks(ctx, []CompactMetaView{st}, rbs, CompactOptions{LiveRatio: 0.5})
+	if err != nil {
+		t.Fatalf("CompactBlocks (2nd): %v", err)
+	}
+	if rep2.BlocksCompacted != 0 {
+		t.Errorf("second pass compacted %d blocks; want 0", rep2.BlocksCompacted)
+	}
+}
+
+// TestCompactBlocks_SkipsHealthyBlock proves a block above the live-ratio
+// threshold is left untouched.
+func TestCompactBlocks_SkipsHealthyBlock(t *testing.T) {
+	ctx := t.Context()
+	st := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	rbs := remotememory.New()
+	defer func() { _ = rbs.Close() }()
+
+	c0 := bytes.Repeat([]byte("A"), 100)
+	c1 := bytes.Repeat([]byte("B"), 100)
+	c2 := bytes.Repeat([]byte("C"), 100)
+	c3 := bytes.Repeat([]byte("D"), 100)
+	hashes := seedRealPackedBlock(t, st, rbs, "blk-healthy", [][]byte{c0, c1, c2, c3})
+	killChunk(t, st, "blk-healthy", hashes[3]) // 3 of 4 live → ~55% live by bytes
+
+	// Threshold 0.5: the block is above it, so nothing is compacted.
+	rep, err := CompactBlocks(ctx, []CompactMetaView{st}, rbs, CompactOptions{LiveRatio: 0.5})
+	if err != nil {
+		t.Fatalf("CompactBlocks: %v", err)
+	}
+	if rep.BlocksCompacted != 0 {
+		t.Errorf("compacted %d blocks; want 0 (block is above threshold)", rep.BlocksCompacted)
+	}
+	if _, ok, _ := st.GetBlockRecord(ctx, "blk-healthy"); !ok {
+		t.Error("healthy block was wrongly deleted")
+	}
+}
+
+// TestCompactBlocks_DisabledAndNilRemote proves the pass no-ops when compaction
+// is disabled (ratio <= 0) or the remote cannot hold blocks.
+func TestCompactBlocks_DisabledAndNilRemote(t *testing.T) {
+	ctx := t.Context()
+	st := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	rbs := remotememory.New()
+	defer func() { _ = rbs.Close() }()
+
+	rep, err := CompactBlocks(ctx, []CompactMetaView{st}, rbs, CompactOptions{LiveRatio: 0})
+	if err != nil || rep.BlocksScanned != 0 {
+		t.Errorf("disabled pass: rep=%+v err=%v; want no-op", rep, err)
+	}
+	rep, err = CompactBlocks(ctx, []CompactMetaView{st}, nil, CompactOptions{LiveRatio: 0.5})
+	if err != nil || rep.BlocksCompacted != 0 {
+		t.Errorf("nil-remote pass: rep=%+v err=%v; want no-op", rep, err)
+	}
+}
+
+// compactNestedGuardView models the sqlite MaxOpenConns(1) hazard: a metadata
+// query issued while the EnumerateSynced cursor is open would deadlock. It fails
+// loudly instead, so CompactBlocks must drain EnumerateSynced before resolving
+// locators (the collect-then-query rule).
+type compactNestedGuardView struct {
+	t           *testing.T
+	inEnumerate bool
+}
+
+func (v *compactNestedGuardView) EnumerateSynced(_ context.Context, fn func(block.ContentHash, time.Time) error) error {
+	v.inEnumerate = true
+	defer func() { v.inEnumerate = false }()
+	return fn(hashFromString("live-chunk"), time.Now().Add(-2*time.Hour))
+}
+
+func (v *compactNestedGuardView) GetLocator(_ context.Context, _ block.ContentHash) (block.ChunkLocator, bool, error) {
+	if v.inEnumerate {
+		v.t.Fatal("GetLocator called while EnumerateSynced cursor is open — deadlocks on sqlite MaxOpenConns(1)")
+	}
+	return block.ChunkLocator{BlockID: "blk-x", WireLength: 10}, true, nil
+}
+
+func (v *compactNestedGuardView) WalkBlockRecords(_ context.Context, fn func(block.BlockRecord) error) error {
+	// Length 1000 with only 10 live bytes → far below any threshold, but the
+	// GetBlock/parse never runs here (no remote), so the point is only that the
+	// candidate scan completes without a nested-query deadlock.
+	return fn(block.BlockRecord{BlockID: "blk-x", Length: 1000, LiveChunkCount: 1, SyncState: block.BlockStateRemote})
+}
+
+func (v *compactNestedGuardView) GetBlockRecord(_ context.Context, _ string) (block.BlockRecord, bool, error) {
+	return block.BlockRecord{}, false, nil // candidate vanished before compaction — clean skip
+}
+
+func (v *compactNestedGuardView) DeleteBlockRecord(_ context.Context, _ string) error { return nil }
+
+func (v *compactNestedGuardView) WithTransaction(_ context.Context, _ func(metadata.Transaction) error) error {
+	return nil
+}
+
+// TestCompactBlocks_NoNestedQueryDuringEnumerate guards the collect-then-query
+// rule so a GetLocator is never issued inside the EnumerateSynced callback.
+func TestCompactBlocks_NoNestedQueryDuringEnumerate(t *testing.T) {
+	rbs := remotememory.New()
+	defer func() { _ = rbs.Close() }()
+	v := &compactNestedGuardView{t: t}
+	// The candidate's GetBlockRecord returns false, so compaction cleanly skips
+	// it without touching the remote — the point is only that the candidate scan
+	// completes without a nested-query deadlock.
+	if _, err := CompactBlocks(t.Context(), []CompactMetaView{v}, rbs, CompactOptions{LiveRatio: 0.5}); err != nil {
+		t.Fatalf("CompactBlocks: %v", err)
+	}
+}

--- a/pkg/block/engine/engine_dualread_test.go
+++ b/pkg/block/engine/engine_dualread_test.go
@@ -330,30 +330,10 @@ func TestDualRead_RelocatedChunkReResolvesOnMiss(t *testing.T) {
 	}
 
 	// The instant the reader issues its (doomed) GET against the old block,
-	// simulate compaction committing the relocation: put the new block object
-	// (step 1) and rebind the locator to it (step 2). The reader's FIRST fetch
-	// still 404s on the already-deleted old object; the guard must re-resolve the
-	// now-updated locator and succeed against the new block.
-	var once gosync.Once
-	env.rs.onReadChunk = func(blockID string) {
-		if blockID != oldBlockID {
-			return
-		}
-		once.Do(func() {
-			if err := env.innerRS.PutBlock(ctx, newBlockID, bytes.NewReader(data)); err != nil {
-				t.Errorf("PutBlock(new): %v", err)
-			}
-			// Last-wins rebind, as DefaultCommitBlock does: clear the old marker
-			// then record the new locator so GetLocator now points at the new block.
-			if err := env.ms.DeleteSynced(ctx, hash); err != nil {
-				t.Errorf("DeleteSynced(old): %v", err)
-			}
-			newLoc := block.ChunkLocator{BlockID: newBlockID, WireOffset: 0, WireLength: int64(len(data))}
-			if err := env.ms.MarkSynced(ctx, hash, newLoc); err != nil {
-				t.Errorf("MarkSynced(new): %v", err)
-			}
-		})
-	}
+	// compaction commits the relocation (step 1 PutBlock + step 2 last-wins
+	// locator rebind). The reader's FIRST fetch still 404s on the already-deleted
+	// old object; the guard must re-resolve the now-updated locator and succeed.
+	env.rs.onReadChunk = relocateOnFirstRead(t, env, oldBlockID, newBlockID, hash, data)
 
 	got, err := env.syncer.fetchBlock(ctx, payloadID, 0)
 	if err != nil {
@@ -364,6 +344,78 @@ func TestDualRead_RelocatedChunkReResolvesOnMiss(t *testing.T) {
 	}
 	// Exactly two ReadChunk calls: the doomed old-block GET + the re-resolved
 	// new-block GET. Proves a single bounded retry, not a loop.
+	if n := env.rs.readChunkCalls.Load(); n != 2 {
+		t.Errorf("ReadChunk calls = %d, want 2 (one miss + one re-resolved hit)", n)
+	}
+}
+
+// relocateOnFirstRead returns a one-shot onReadChunk hook that, the first time
+// oldBlockID is read, simulates compaction committing the chunk's relocation
+// into newBlockID: PutBlock (step 1) then the last-wins DeleteSynced→MarkSynced
+// locator rebind DefaultCommitBlock performs (step 2). That reproduces the exact
+// #1487 stale-locator window — a locator resolved to the old block, then rebound
+// and the old object deleted, before the read's GET lands.
+func relocateOnFirstRead(t *testing.T, env *dualReadEnv, oldBlockID, newBlockID string, hash block.ContentHash, data []byte) func(string) {
+	t.Helper()
+	ctx := context.Background()
+	var once gosync.Once
+	return func(blockID string) {
+		if blockID != oldBlockID {
+			return
+		}
+		once.Do(func() {
+			if err := env.innerRS.PutBlock(ctx, newBlockID, bytes.NewReader(data)); err != nil {
+				t.Errorf("PutBlock(new): %v", err)
+			}
+			if err := env.ms.DeleteSynced(ctx, hash); err != nil {
+				t.Errorf("DeleteSynced(old): %v", err)
+			}
+			newLoc := block.ChunkLocator{BlockID: newBlockID, WireOffset: 0, WireLength: int64(len(data))}
+			if err := env.ms.MarkSynced(ctx, hash, newLoc); err != nil {
+				t.Errorf("MarkSynced(new): %v", err)
+			}
+		})
+	}
+}
+
+// TestEnsureAvailableAndRead_RelocatedChunkReResolvesOnMiss drives the CLIENT
+// demand read path (EnsureAvailableAndRead → inlineFetchOrWait →
+// dispatchRemoteFetch) — the path whose EIO actually propagates to a real
+// NFS/SMB read — through the same #1487 compaction relocation scenario. It
+// asserts the demand read SUCCEEDS via the shared re-resolve guard in
+// dispatchRemoteFetch instead of failing closed. This is the regression guard
+// for the path that mattered; the background fetchResolvedBlock path is covered
+// by TestDualRead_RelocatedChunkReResolvesOnMiss.
+func TestEnsureAvailableAndRead_RelocatedChunkReResolvesOnMiss(t *testing.T) {
+	env := newDualReadEnv(t)
+	ctx := context.Background()
+
+	const payloadID = "share/relocated-demand"
+	const oldBlockID = "blk-old-demand"
+	const newBlockID = "blk-new-demand"
+	data := []byte("client demand read of a compaction-relocated chunk")
+	hash := dualReadHash(data)
+
+	// Pre-compaction state, then delete the old object (compaction step 3) so the
+	// reader's first GET against the stale locator 404s.
+	env.seedBlockChunk(t, ctx, payloadID, oldBlockID, data, hash, uint32(len(data)))
+	if err := env.innerRS.DeleteBlock(ctx, oldBlockID); err != nil {
+		t.Fatalf("DeleteBlock(old): %v", err)
+	}
+	env.rs.onReadChunk = relocateOnFirstRead(t, env, oldBlockID, newBlockID, hash, data)
+
+	dest := make([]byte, len(data))
+	filled, err := env.syncer.EnsureAvailableAndRead(ctx, payloadID, 0, uint32(len(data)), dest)
+	if err != nil {
+		t.Fatalf("EnsureAvailableAndRead: relocated chunk must re-resolve and read through, got %v", err)
+	}
+	if !filled {
+		t.Fatal("EnsureAvailableAndRead filled=false; want the demand read served from the relocated block")
+	}
+	if !bytes.Equal(dest, data) {
+		t.Fatalf("demand read data mismatch: got %q, want %q", dest, data)
+	}
+	// One miss + one re-resolved hit: single bounded retry, not a loop.
 	if n := env.rs.readChunkCalls.Load(); n != 2 {
 		t.Errorf("ReadChunk calls = %d, want 2 (one miss + one re-resolved hit)", n)
 	}

--- a/pkg/block/engine/engine_dualread_test.go
+++ b/pkg/block/engine/engine_dualread_test.go
@@ -29,6 +29,9 @@ type spyingRemoteStore struct {
 	readChunkCalls atomic.Int64
 	mu             gosync.Mutex
 	readChunkKeys  []string // blocks/<id> store keys, in call order
+	// onReadChunk, if set, runs at the start of each ReadChunk with the target
+	// block ID — lets a test inject a concurrent relocation mid-fetch.
+	onReadChunk func(blockID string)
 }
 
 func newSpyingRemoteStore(inner remote.RemoteStore) *spyingRemoteStore {
@@ -39,7 +42,11 @@ func (s *spyingRemoteStore) ReadChunk(ctx context.Context, blockID string, offse
 	s.readChunkCalls.Add(1)
 	s.mu.Lock()
 	s.readChunkKeys = append(s.readChunkKeys, block.FormatBlockKey(blockID))
+	hook := s.onReadChunk
 	s.mu.Unlock()
+	if hook != nil {
+		hook(blockID)
+	}
 	return s.RemoteStore.(remote.ChunkReader).ReadChunk(ctx, blockID, offset, length, expected)
 }
 
@@ -293,6 +300,72 @@ func TestDualRead_MissingBlockObjectFailsClosed(t *testing.T) {
 	}
 	if got != nil {
 		t.Errorf("fetchBlock data = %v, want nil on fail-closed block miss", got)
+	}
+}
+
+// TestDualRead_RelocatedChunkReResolvesOnMiss pins the #1487 compaction
+// stale-locator guard: a reader that resolved a chunk's locator to the OLD
+// block, then had that block deleted after compaction relocated+recommitted the
+// chunk into a NEW block, must re-resolve and read through — NOT surface a
+// spurious EIO. Without the read-path re-resolve (fetchResolvedBlock) this fails
+// closed with ErrChunkNotFound even though the chunk is perfectly live.
+func TestDualRead_RelocatedChunkReResolvesOnMiss(t *testing.T) {
+	env := newDualReadEnv(t)
+	ctx := context.Background()
+
+	const payloadID = "share/relocated-chunk"
+	const oldBlockID = "blk-old-precompaction"
+	const newBlockID = "blk-new-postcompaction"
+	data := []byte("live chunk bytes relocated by compaction")
+	hash := dualReadHash(data)
+
+	// Seed the pre-compaction state: the locator points at the old block.
+	env.seedBlockChunk(t, ctx, payloadID, oldBlockID, data, hash, uint32(len(data)))
+
+	// Delete the old block object up front (compaction's step-3 DeleteBlock). The
+	// reader below still resolves the OLD locator first, so its first GET 404s —
+	// the stale-locator window.
+	if err := env.innerRS.DeleteBlock(ctx, oldBlockID); err != nil {
+		t.Fatalf("DeleteBlock(old): %v", err)
+	}
+
+	// The instant the reader issues its (doomed) GET against the old block,
+	// simulate compaction committing the relocation: put the new block object
+	// (step 1) and rebind the locator to it (step 2). The reader's FIRST fetch
+	// still 404s on the already-deleted old object; the guard must re-resolve the
+	// now-updated locator and succeed against the new block.
+	var once gosync.Once
+	env.rs.onReadChunk = func(blockID string) {
+		if blockID != oldBlockID {
+			return
+		}
+		once.Do(func() {
+			if err := env.innerRS.PutBlock(ctx, newBlockID, bytes.NewReader(data)); err != nil {
+				t.Errorf("PutBlock(new): %v", err)
+			}
+			// Last-wins rebind, as DefaultCommitBlock does: clear the old marker
+			// then record the new locator so GetLocator now points at the new block.
+			if err := env.ms.DeleteSynced(ctx, hash); err != nil {
+				t.Errorf("DeleteSynced(old): %v", err)
+			}
+			newLoc := block.ChunkLocator{BlockID: newBlockID, WireOffset: 0, WireLength: int64(len(data))}
+			if err := env.ms.MarkSynced(ctx, hash, newLoc); err != nil {
+				t.Errorf("MarkSynced(new): %v", err)
+			}
+		})
+	}
+
+	got, err := env.syncer.fetchBlock(ctx, payloadID, 0)
+	if err != nil {
+		t.Fatalf("fetchBlock: relocated chunk must re-resolve and read through, got %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("fetchBlock data mismatch: got %q, want %q", got, data)
+	}
+	// Exactly two ReadChunk calls: the doomed old-block GET + the re-resolved
+	// new-block GET. Proves a single bounded retry, not a loop.
+	if n := env.rs.readChunkCalls.Load(); n != 2 {
+		t.Errorf("ReadChunk calls = %d, want 2 (one miss + one re-resolved hit)", n)
 	}
 }
 

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -148,17 +148,40 @@ func (m *Syncer) dispatchRemoteFetch(ctx context.Context, fb *block.FileChunk) (
 			"block_id", fb.ID)
 		return "", nil, fmt.Errorf("blockstore: legacy zero-hash FileChunk encountered post-migration: block_id=%s", fb.ID)
 	}
-	// Resolve the block locator for the chunk (#1414). Two distinct cases:
-	//
-	//   - No synced marker at all (synced==false): the chunk has not been
-	//     uploaded yet, so it has no remote copy. This is NOT drift — the bytes
-	//     are still local-only (a read that raced the async carve). Return
-	//     ("", nil, nil) so the caller falls back to the local read path rather
-	//     than failing closed.
-	//   - Synced marker present but empty BlockID: post-#1493 every synced hash
-	//     carries a block locator (the startup migration repacked all legacy
-	//     standalone chunks), so a synced hash with no BlockID is genuine
-	//     metadata drift. Refuse the read.
+
+	key, data, err := m.resolveAndReadChunk(ctx, fb)
+	if err != nil && errors.Is(err, block.ErrChunkNotFound) {
+		// Stale-locator window (#1487 compaction, and the cas→blocks migration /
+		// refcount reclaim paths): a concurrent maintenance pass relocated this
+		// chunk into a fresh block and deleted the old one AFTER we resolved its
+		// locator, so the GET 404s against bytes that moved. Re-resolve ONCE — a
+		// fresh GetLocator now points at the new block, so a merely-relocated live
+		// chunk reads through instead of a spurious EIO. A second miss (locator
+		// unchanged, or the chunk is genuinely gone) is returned so the caller
+		// fails closed. Single bounded retry — never a loop, to avoid livelock.
+		// This is the shared chokepoint for BOTH read paths (fetchResolvedBlock's
+		// background prefetch/warm and inlineFetchOrWait's client demand read), so
+		// the guard lives here rather than in either caller.
+		key, data, err = m.resolveAndReadChunk(ctx, fb)
+	}
+	return key, data, err
+}
+
+// resolveAndReadChunk resolves fb.Hash's current remote block locator and does
+// one verified ranged read. Split out of dispatchRemoteFetch so the stale-
+// locator retry there can re-resolve from scratch (fresh GetLocator).
+//
+// Two distinct non-read outcomes, both returned to the caller unchanged:
+//
+//   - No synced marker at all (synced==false): the chunk has not been uploaded
+//     yet, so it has no remote copy. NOT drift — the bytes are still local-only
+//     (a read that raced the async carve). Returns ("", nil, nil) so the caller
+//     falls back to the local read path rather than failing closed.
+//   - Synced marker present but empty BlockID: post-#1493 every synced hash
+//     carries a block locator (the startup migration repacked all legacy
+//     standalone chunks), so a synced hash with no BlockID is genuine metadata
+//     drift. Refuse the read.
+func (m *Syncer) resolveAndReadChunk(ctx context.Context, fb *block.FileChunk) (string, []byte, error) {
 	loc, synced, err := m.resolveLocator(ctx, fb.Hash)
 	if err != nil {
 		return "", nil, err
@@ -271,19 +294,10 @@ func (m *Syncer) fetchResolvedBlock(ctx context.Context, fb *block.FileChunk) ([
 		return nil, nil
 	}
 
+	// dispatchRemoteFetch carries the stale-locator re-resolve retry (#1487), so
+	// a chunk relocated by compaction/migration reads through before we ever get
+	// here; a surviving ErrChunkNotFound is genuine live-data-loss.
 	storeKey, data, err := m.dispatchRemoteFetch(ctx, fb)
-	if err != nil && errors.Is(err, block.ErrChunkNotFound) {
-		// Stale-locator window (#1487 compaction, and the cas→blocks migration /
-		// refcount reclaim paths): a concurrent maintenance pass relocated this
-		// chunk into a fresh block and deleted the old one AFTER we resolved its
-		// locator, so the GET 404s against bytes that moved. Re-resolve ONCE — a
-		// fresh GetLocator (inside dispatchRemoteFetch) now points at the new
-		// block, so a merely-relocated live chunk reads through instead of a
-		// spurious EIO. A second miss (locator unchanged, or the chunk is
-		// genuinely gone) falls through to the fail-closed path below. Single
-		// bounded retry — never a loop, to avoid livelock.
-		storeKey, data, err = m.dispatchRemoteFetch(ctx, fb)
-	}
 	if err != nil {
 		if errors.Is(err, block.ErrChunkNotFound) {
 			// fail-closed on the CAS path. A row

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -272,6 +272,18 @@ func (m *Syncer) fetchResolvedBlock(ctx context.Context, fb *block.FileChunk) ([
 	}
 
 	storeKey, data, err := m.dispatchRemoteFetch(ctx, fb)
+	if err != nil && errors.Is(err, block.ErrChunkNotFound) {
+		// Stale-locator window (#1487 compaction, and the cas→blocks migration /
+		// refcount reclaim paths): a concurrent maintenance pass relocated this
+		// chunk into a fresh block and deleted the old one AFTER we resolved its
+		// locator, so the GET 404s against bytes that moved. Re-resolve ONCE — a
+		// fresh GetLocator (inside dispatchRemoteFetch) now points at the new
+		// block, so a merely-relocated live chunk reads through instead of a
+		// spurious EIO. A second miss (locator unchanged, or the chunk is
+		// genuinely gone) falls through to the fail-closed path below. Single
+		// bounded retry — never a loop, to avoid livelock.
+		storeKey, data, err = m.dispatchRemoteFetch(ctx, fb)
+	}
 	if err != nil {
 		if errors.Is(err, block.ErrChunkNotFound) {
 			// fail-closed on the CAS path. A row

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -143,6 +143,14 @@ type GCConfig struct {
 	// dry-run report. Defaults to 1000.
 	DryRunSampleSize int `mapstructure:"dry_run_sample_size" yaml:"dry_run_sample_size"`
 
+	// CompactionLiveRatio enables GC compaction of partially-dead blocks
+	// (#1487): after each sweep, a block whose live bytes / object length is
+	// below this ratio is repacked into a fresh block (live chunks only) and
+	// the old block is deleted, reclaiming the dead bytes. 0 (the default)
+	// disables compaction; a sensible enabled value is ~0.5 (compact once a
+	// block is more than half dead). Must be in [0, 1].
+	CompactionLiveRatio float64 `mapstructure:"compaction_live_ratio" yaml:"compaction_live_ratio"`
+
 	// AutoEnabled turns on the background GC scheduler, which periodically
 	// reclaims orphaned blocks on both tiers without operator action.
 	// Defaults to true. Set false to require manual `dfsctl store block gc`.
@@ -206,6 +214,9 @@ func (c *GCConfig) Validate() error {
 	}
 	if c.AutoInterval > 0 && c.AutoInterval < time.Minute {
 		return fmt.Errorf("gc.auto_interval must be >= 1m to avoid hammering the stores (got %v); set 0 to use the 15m default", c.AutoInterval)
+	}
+	if c.CompactionLiveRatio < 0 || c.CompactionLiveRatio > 1 {
+		return fmt.Errorf("gc.compaction_live_ratio must be in [0, 1] (got %v); 0 disables compaction", c.CompactionLiveRatio)
 	}
 	return nil
 }

--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -152,6 +152,11 @@ func (r *Runtime) runBlockGCSweep(ctx context.Context, sharePrefix string, dryRu
 				"bytesFreed", s.BytesFreed,
 				"errors", s.ErrorCount,
 			)
+			// Compact partially-dead blocks on this remote (#1487) while the
+			// per-remote lock is still held and the sweep has just cleared the
+			// synced markers of past-grace dead chunks. Gated by the operator's
+			// gc.compaction_live_ratio (no-op when unset or on dry-run).
+			r.compactRemoteForEntry(ctx, entry, dryRun, gcDefaults, total)
 		}()
 	}
 	// Sweep the local tier too, so one `gc` invocation reclaims orphaned
@@ -364,6 +369,9 @@ func (r *Runtime) runBlockGCForShare(ctx context.Context, name string, dryRun bo
 				"bytesFreed", s.BytesFreed,
 				"errors", s.ErrorCount,
 			)
+			// Compact partially-dead blocks on this remote (#1487), under the
+			// same per-remote lock and after the sweep. See runBlockGCSweep.
+			r.compactRemoteForEntry(ctx, entry, dryRun, gcDefaults, total)
 		}()
 	}
 	// Sweep this share's local tier too (#1433).
@@ -562,6 +570,63 @@ func (u unionBlockReclaimer) ReclaimDeadChunk(ctx context.Context, hash block.Co
 		}
 	}
 	return anyHandled, totalFreed, nil
+}
+
+// compactRemoteForEntry compacts partially-dead blocks on one remote (#1487).
+// It is a no-op unless the operator set gc.compaction_live_ratio > 0, and it is
+// skipped on dry-run (compaction mutates). The caller MUST already hold the
+// per-remote GC lock and MUST call this AFTER the sweep so the sweep has
+// cleared the synced markers of past-grace dead chunks — the signal compaction
+// uses to tell live chunks from dead. Errors are logged; per-block failures are
+// counted in the returned engine report and folded into total.BytesReclaimed.
+func (r *Runtime) compactRemoteForEntry(ctx context.Context, entry shares.RemoteStoreEntry, dryRun bool, gcDefaults *GCDefaults, total *engine.GCStats) {
+	if dryRun || gcDefaults == nil || gcDefaults.CompactionLiveRatio <= 0 {
+		return
+	}
+	rbs, ok := entry.Store.(remote.RemoteBlockStore)
+	if !ok {
+		return // remote cannot hold packed blocks — nothing to compact
+	}
+	var views []engine.CompactMetaView
+	for _, shareName := range entry.Shares {
+		mds, err := r.GetMetadataStoreForShare(shareName)
+		if err != nil {
+			logger.Warn("GC compaction: metadata store unavailable for share — its blocks are not compacted this run",
+				"share", shareName, "err", err)
+			continue
+		}
+		// EnumerateSynced is a concrete backend method, not on metadata.Store —
+		// assert the compaction view like the reconcile/reclaim passes do.
+		if cv, ok := mds.(engine.CompactMetaView); ok {
+			views = append(views, cv)
+		} else {
+			logger.Warn("GC compaction: metadata store does not implement the compaction view — share excluded",
+				"share", shareName)
+		}
+	}
+	if len(views) == 0 {
+		return
+	}
+	rep, err := engine.CompactBlocks(ctx, views, rbs, engine.CompactOptions{LiveRatio: gcDefaults.CompactionLiveRatio})
+	if err != nil {
+		logger.Warn("GC compaction: aborted", "configID", entry.ConfigID, "err", err)
+	}
+	if rep.BlocksCompacted > 0 || rep.Errors > 0 {
+		logger.Info("GC compaction: complete",
+			"configID", entry.ConfigID,
+			"blocksScanned", rep.BlocksScanned,
+			"blocksCompacted", rep.BlocksCompacted,
+			"chunksMoved", rep.ChunksMoved,
+			"bytesReclaimed", rep.BytesReclaimed,
+			"errors", rep.Errors,
+		)
+	}
+	// Fold reclaimed bytes into the run's total so `gc-status` reflects the space
+	// compaction freed alongside the sweep's.
+	total.BytesFreed += rep.BytesReclaimed
+	total.BytesReclaimed += rep.BytesReclaimed
+	total.ErrorCount += int(rep.Errors)
+	total.Errors += int(rep.Errors)
 }
 
 // remoteGCLock returns the per-remote serializing mutex for a remote-store

--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -610,6 +610,7 @@ func (r *Runtime) compactRemoteForEntry(ctx context.Context, entry shares.Remote
 	rep, err := engine.CompactBlocks(ctx, views, rbs, engine.CompactOptions{LiveRatio: gcDefaults.CompactionLiveRatio})
 	if err != nil {
 		logger.Warn("GC compaction: aborted", "configID", entry.ConfigID, "err", err)
+		return
 	}
 	if rep.BlocksCompacted > 0 || rep.Errors > 0 {
 		logger.Info("GC compaction: complete",

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -907,6 +907,10 @@ func (r *Runtime) SetSyncerDefaults(cfg *shares.SyncerDefaults) {
 type GCDefaults struct {
 	GracePeriod      time.Duration
 	DryRunSampleSize int
+	// CompactionLiveRatio, when > 0, enables GC compaction of partially-dead
+	// blocks after each remote sweep (#1487): a block whose live bytes /
+	// object length is below this ratio is repacked and its dead bytes freed.
+	CompactionLiveRatio float64
 }
 
 // SetGCDefaults sets the operator-configured GC knobs the runtime forwards


### PR DESCRIPTION
Closes #1487

## What

Delete-only block GC frees a block only when its **last** live chunk dies, so a block that keeps a few live chunks but has shed many dead ones pins the dead bytes on the remote forever. This adds `engine.CompactBlocks`: an optional final phase of each per-remote GC sweep that repacks a mostly-dead block's live chunks into a fresh block, rewrites their locators, and deletes the old block.

## How it stays correct

- **No second live-set scan, no schema change.** Compaction runs under the same per-remote GC lock, immediately *after* the sweep — by which point the sweep has cleared the synced marker of every past-grace dead chunk. So a chunk resident in a block is "still live here" iff its synced locator still points at that block. This reuses the sweep's own keep/delete decision, so compaction never reclaims a chunk the sweep would have spared.
- **Byte-based candidacy:** `sum(live locator WireLength) / block.Length < gc.compaction_live_ratio` (new knob; `0` disables, default off). Computed from the block record + locators alone — no per-block download to decide.
- **Repack:** download once, verify whole-block BLAKE3 against the record, copy the live chunks' wire bodies verbatim into a new block (per-chunk encryption already lives in the body), `PutBlock`, then `DefaultCommitBlock` (atomic record + last-wins locator rewrite), then delete old object + record.
- **Crash safety = the carver's / migration's.** Every crash window lands on an existing reconcile class: crash after `PutBlock` before commit → orphan object (class 3); crash after commit before delete → leaked record (class 2). A re-run converges — the moved chunks' locators no longer point at the old block, so compaction finds nothing to move and just deletes the husk.
- **sqlite `MaxOpenConns(1)`-safe:** collect-then-query throughout (drain `EnumerateSynced`/`WalkBlockRecords` before any `GetLocator`/commit). Guarded by a nested-query test.

## Concurrency

Wired into both `runBlockGCSweep` and `runBlockGCForShare`, inside the existing `remoteGCLock(configID)` closure — no new lock scope. Compaction can't race a concurrent sweep's `DecrLiveChunkCount`/`DeleteBlock` on the same remote.

## Tests

`pkg/block/engine/compaction_test.go`: partially-dead block compacted (live chunk survives byte-identical, dead space reclaimed, old block object+record gone, idempotent second pass); healthy block skipped; disabled/nil-remote no-op; collect-then-query nested-query guard. Block-store conformance + metadata storetest still pass.

Docs: `architecture.md` GC section + `configuration.md` knob.