### PR TITLE
perf(block): per-stage CPU+mem profiling of the write data path (#1555)

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -338,6 +338,80 @@ To re-baseline on a new machine class: capture several runs, take the lowest
 ops/sec, multiply by 0.90, and update the floor constant — a deliberate
 calibration event that must be reviewed in PR.
 
+### Per-stage write-path profiling (#1555)
+
+The blocks-only write path splits into stages that each own a CPU and allocation
+budget. One `Benchmark*` per stage measures it *in isolation* against in-process
+memory stores, so a `-cpuprofile` / `-memprofile` run attributes cost to a single
+seam instead of a tangled end-to-end flow. All four are plain `testing.B` +
+`runtime/pprof` (no harness, no deps): standard
+`go test -benchmem -cpuprofile -memprofile` wiring is all that's needed.
+
+| Stage | Bench (package) | Code seam |
+| ----- | --------------- | --------- |
+| Append log | `BenchmarkAppendWrite_GroupCommit` (`pkg/block/local/fs/`) | `appendwrite.go` + `groupcommit.go` |
+| FastCDC chunker | `BenchmarkChunker_Throughput_64MiB` (`pkg/block/chunker/`) | `chunker.go` |
+| BLAKE3 hash | `BenchmarkBLAKE3_256MiB` (`pkg/block/`) | content-hash layer |
+| Streamer (carve→codec→PutBlock) | `BenchmarkStreamer_CarveCodecPutBlock` (`pkg/block/engine/`) | `carver.go:carveAndCommitBlock` + `blockcodec/codec.go` |
+
+```bash
+# Profile any single stage — CPU + heap attributed to that seam only:
+go test -bench=BenchmarkStreamer_CarveCodecPutBlock -benchmem -run=^$ \
+    -cpuprofile=cpu.out -memprofile=mem.out ./pkg/block/engine/
+go tool pprof -top cpu.out      # where the CPU went
+go tool pprof -top -alloc_space mem.out   # where the bytes were allocated
+```
+
+Two memory invariants are pinned as hard tests (fail the build, not just report):
+
+- `TestChunker_ConstantMemory` (`pkg/block/chunker/`) — the FastCDC scan is
+  allocation-free regardless of input size; `Next` must report offsets into the
+  caller's slice, never copy chunk bytes.
+- `TestStreamer_AllocationTracksBlockCount` (`pkg/block/engine/`) — the streamer's
+  allocation grows linearly with block count, not super-linearly with file size;
+  it must carve one block at a time, never buffer the whole file.
+
+GC + compaction is intentionally **not** benched here: #1487 reshaped that path
+and it is latency/sweep-bound rather than a CPU/alloc hot spot on the write path —
+a dedicated bench is deferred until there is a measured reason to add one.
+
+#### Baseline reading (Apple M1 Max, in-memory, `-benchtime=5x`)
+
+| Stage | ns/op | Throughput | B/op | allocs/op |
+| ----- | ----: | ---------: | ---: | --------: |
+| Append log (coalesced 64 B) | 4.6 ms | — | 353 | 6 |
+| FastCDC chunker (64 MiB) | 42.2 ms | 1,592 MB/s | **0** | **0** |
+| BLAKE3 hash (256 MiB) | 53.8 ms | 4,994 MB/s | 3.7 MB | 35,713 |
+| Streamer (64 MiB) | 19.6 ms | 3,426 MB/s | **346 MB** | 753 |
+
+Normalizing to cost-per-MiB pushed through the write path:
+
+- **CPU is dominated by the FastCDC chunker** — 0.63 ms/MiB, ~3× the hash
+  (0.20 ms/MiB) and ~2× the streamer (0.29 ms/MiB of codec framing + remote body
+  copy; hashing is the separate BLAKE3 stage above and is precomputed in the
+  streamer fixture, matching production carve, which reuses each chunk's
+  write-time hash). The boundary scan, not framing or upload, is the write-path
+  CPU floor.
+- **Allocations are dominated by the streamer** — ~346 MB allocated per 64 MiB
+  carved (~5× write amplification), from `bytes.Buffer` doubling growth while
+  assembling each block plus the remote body copy. The chunker is allocation-free;
+  the streamer is the only stage with a real allocation lever, and the cheap fix is
+  pre-sizing the carve buffer to the target block size — no format or sizing change.
+
+Gate call for the deferred perf issues this profiling was meant to decide:
+
+- **#1491 (decoupled log-blob / block sizing) — not justified by this data.** The
+  streamer's allocation cost is transient buffer growth, not sizing granularity;
+  a one-line buffer pre-size captures the win without decoupling the two sizes.
+- **#1488 (chunk-range refetch granularity) — read-path, not a write-path
+  bottleneck here.** The warm read path already avoids the WAN round-trip
+  (`BenchmarkReadThroughCache_ColdVsWarm`), so there is no measured pressure to
+  build finer read-miss granularity yet.
+
+Re-run all four on a new machine class before trusting the ranking — the absolute
+numbers are machine-specific; the *ordering* (chunker = CPU, streamer = allocs) is
+the durable finding.
+
 ### A/B comparing commits
 
 For ad-hoc before/after work, run any package's `Benchmark*` against two commits

--- a/pkg/block/chunker/chunker_bench_test.go
+++ b/pkg/block/chunker/chunker_bench_test.go
@@ -12,6 +12,7 @@ func BenchmarkChunker_Throughput_64MiB(b *testing.B) {
 	data := make([]byte, 64*1024*1024)
 	_, _ = rng.Read(data)
 	b.SetBytes(int64(len(data)))
+	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
 		c := NewChunker()
@@ -23,5 +24,33 @@ func BenchmarkChunker_Throughput_64MiB(b *testing.B) {
 			}
 			pos += bnd
 		}
+	}
+}
+
+// TestChunker_ConstantMemory pins the chunker's memory invariant: scanning a
+// buffer for boundaries allocates nothing on the heap, independent of input
+// size. Next reports offsets into the caller's slice — it must never copy chunk
+// bytes. A regression here (e.g. Next starting to buffer or return copies)
+// turns per-block streaming into per-file RAM — exactly the silent memory
+// blow-up the #1555 per-stage profiling exists to catch.
+func TestChunker_ConstantMemory(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	data := make([]byte, 16*1024*1024) // 16 MiB → many boundaries
+	_, _ = rng.Read(data)
+
+	chunkAll := func() {
+		c := NewChunker()
+		pos := 0
+		for pos < len(data) {
+			bnd, _ := c.Next(data[pos:], true)
+			if bnd == 0 {
+				t.Fatalf("zero boundary at pos %d", pos)
+			}
+			pos += bnd
+		}
+	}
+
+	if allocs := testing.AllocsPerRun(5, chunkAll); allocs != 0 {
+		t.Fatalf("chunking allocated %.0f objects/run; want 0 (Next must scan in place, not copy)", allocs)
 	}
 }

--- a/pkg/block/engine/streamer_bench_test.go
+++ b/pkg/block/engine/streamer_bench_test.go
@@ -1,0 +1,150 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"runtime"
+	"testing"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/blockcodec"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+)
+
+const (
+	streamerChunkSize = 1 * 1024 * 1024 // 1 MiB — FastCDC MinChunkSize floor
+	streamerPerBlock  = 4               // 4 chunks × 1 MiB ≈ 4 MiB target block
+)
+
+// streamerFixture holds pre-hashed pseudo-random chunks and block IDs for
+// blockCount blocks of streamerPerBlock chunks each. Building it is kept out of
+// every timed / measured region so only the carve→codec→PutBlock cost is seen.
+type streamerFixture struct {
+	chunks   [][]byte
+	hashes   []block.ContentHash
+	blockIDs []string
+}
+
+func newStreamerFixture(blockCount int) streamerFixture {
+	chunkCount := blockCount * streamerPerBlock
+	rng := rand.New(rand.NewSource(1))
+	f := streamerFixture{
+		chunks:   make([][]byte, chunkCount),
+		hashes:   make([]block.ContentHash, chunkCount),
+		blockIDs: make([]string, blockCount),
+	}
+	for i := range f.chunks {
+		c := make([]byte, streamerChunkSize)
+		_, _ = rng.Read(c) // distinct bytes so hashes/codec bodies don't dedup
+		f.chunks[i] = c
+		f.hashes[i] = block.ContentHash(blake3.Sum256(c))
+	}
+	for i := range f.blockIDs {
+		f.blockIDs[i] = fmt.Sprintf("blk-%d", i)
+	}
+	return f
+}
+
+// streamBlocks runs the carve→codec→PutBlock inner loop for every block in the
+// fixture: frame streamerPerBlock chunks into one block via blockcodec and
+// upload it. This is the stage under profile — no Syncer orchestration, no WAN.
+func (f streamerFixture) streamBlocks(ctx context.Context, rbs *remotememory.Store) error {
+	for blk := range f.blockIDs {
+		var buf bytes.Buffer
+		builder, err := blockcodec.NewBuilder(&buf, f.blockIDs[blk], nil)
+		if err != nil {
+			return err
+		}
+		for j := range streamerPerBlock {
+			idx := blk*streamerPerBlock + j
+			if _, err := builder.Add(f.hashes[idx], f.chunks[idx]); err != nil {
+				return err
+			}
+		}
+		if _, err := builder.Finish(); err != nil {
+			return err
+		}
+		if err := rbs.PutBlock(ctx, f.blockIDs[blk], &buf); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// BenchmarkStreamer_CarveCodecPutBlock profiles the upload streamer stage in
+// isolation: frame pre-hashed chunks into target-sized blocks via blockcodec
+// (the carveAndCommitBlock inner loop, which reuses each chunk's write-time hash
+// rather than rehashing) and PutBlock each assembled block to an in-memory
+// remote. It deliberately drops the Syncer orchestration (carve queue, retries,
+// dispatcher, dynsem) and real WAN — those are latency/concurrency-bound and
+// covered by BenchmarkReadThroughCache_ColdVsWarm and the #1432 remote lane.
+// BLAKE3 hashing is its own stage (BenchmarkBLAKE3_256MiB) and is precomputed
+// in the fixture here, matching production carve. This is the in-memory
+// CPU+alloc floor of carve → codec → PutBlock, so a -cpuprofile / -memprofile
+// run attributes cost between codec framing and the remote body copy.
+//
+//	go test -bench=BenchmarkStreamer_CarveCodecPutBlock -benchmem -run=^$ \
+//	    -cpuprofile=cpu.out -memprofile=mem.out ./pkg/block/engine/
+func BenchmarkStreamer_CarveCodecPutBlock(b *testing.B) {
+	const blockCount = 16 // 16 × 4 MiB ≈ 64 MiB working set
+	f := newStreamerFixture(blockCount)
+	ctx := context.Background()
+
+	// One remote reused across iterations: same block IDs overwrite in place, so
+	// the fake's retained bytes are not re-charged each op — leaving the timed
+	// allocations to the codec framing and PutBlock body copy, not fixture churn.
+	rbs := remotememory.New()
+	b.SetBytes(int64(blockCount * streamerPerBlock * streamerChunkSize))
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		if err := f.streamBlocks(ctx, rbs); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// TestStreamer_AllocationTracksBlockCount pins the streaming data-plane memory
+// invariant (#1555 Refinement 2): the streamer's allocation grows linearly with
+// the number of blocks, never super-linearly with total file size. A regression
+// that buffers the whole file instead of one block at a time would inflate
+// bytes-per-block as the file grows. We stream two file sizes and assert
+// per-block allocation stays flat.
+func TestStreamer_AllocationTracksBlockCount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("allocates ~80 MiB of chunk fixtures across the two runs; skip under -short")
+	}
+	ctx := context.Background()
+
+	// bytesPerBlock streams blockCount blocks and returns the cumulative bytes
+	// allocated by streamBlocks alone (fixture build is excluded), divided by the
+	// block count. TotalAlloc is monotonic-cumulative, so the delta captures
+	// allocation pressure independent of GC timing.
+	bytesPerBlock := func(blockCount int) float64 {
+		f := newStreamerFixture(blockCount)
+		rbs := remotememory.New()
+		runtime.GC()
+		var before, after runtime.MemStats
+		runtime.ReadMemStats(&before)
+		if err := f.streamBlocks(ctx, rbs); err != nil {
+			t.Fatalf("streamBlocks(%d): %v", blockCount, err)
+		}
+		runtime.ReadMemStats(&after)
+		return float64(after.TotalAlloc-before.TotalAlloc) / float64(blockCount)
+	}
+
+	small := bytesPerBlock(4)
+	large := bytesPerBlock(16)
+
+	// Linear streaming keeps per-block bytes flat; allow 50% slack for heap
+	// bookkeeping noise. A whole-file-buffering regression blows well past this.
+	if ratio := large / small; ratio > 1.5 {
+		t.Fatalf("per-block allocation grew %.2fx from 4→16 blocks (small=%.0f B, large=%.0f B); "+
+			"streamer must carve one block at a time, not buffer the whole file", ratio, small, large)
+	}
+}


### PR DESCRIPTION
Closes #1555.

Per-stage CPU + memory profiling for the blocks-only write data path, reusing plain `testing.B` + `runtime/pprof` — no new harness, no new deps. Test/tooling + docs only; zero production data-path changes.

## What's added

One isolated `Benchmark*` per write-path stage so a `-cpuprofile` / `-memprofile` run attributes cost to a single seam:

| Stage | Bench | Code seam |
| ----- | ----- | --------- |
| Append log | `BenchmarkAppendWrite_GroupCommit` (existing) | `appendwrite.go` + `groupcommit.go` |
| FastCDC chunker | `BenchmarkChunker_Throughput_64MiB` (+`ReportAllocs`) | `chunker.go` |
| BLAKE3 hash | `BenchmarkBLAKE3_256MiB` (existing) | content-hash layer |
| Streamer (carve→codec→PutBlock) | `BenchmarkStreamer_CarveCodecPutBlock` (**new**) | `carver.go:carveAndCommitBlock` + `blockcodec/codec.go` |

Plus two hard memory invariants (fail the build, not just report):

- `TestChunker_ConstantMemory` — the FastCDC scan is allocation-free regardless of input size.
- `TestStreamer_AllocationTracksBlockCount` — streamer allocation grows linearly with block count, never super-linearly with file size (Refinement 2 pass/fail signal).

`docs/BENCHMARKS.md` gains a "Per-stage write-path profiling" section: the table above, `pprof` how-to, and the baseline reading.

## Baseline reading (Apple M1 Max, in-memory, `-benchtime=5x`)

| Stage | ns/op | Throughput | B/op | allocs/op |
| ----- | ----: | ---------: | ---: | --------: |
| FastCDC chunker (64 MiB) | 42.2 ms | 1,592 MB/s | 0 | 0 |
| BLAKE3 hash (256 MiB) | 53.8 ms | 4,994 MB/s | 3.7 MB | 35,713 |
| Streamer (64 MiB) | 19.6 ms | 3,426 MB/s | 346 MB | 753 |
| Append log (coalesced 64 B) | 4.6 ms | — | 353 | 6 |

Normalized per MiB of write-path data:

- **CPU is dominated by the FastCDC chunker** — 0.63 ms/MiB, ~3× the hash (0.20) and ~2× the streamer (0.29). The boundary scan, not framing or upload, is the write-path CPU floor.
- **Allocations are dominated by the streamer** — ~346 MB per 64 MiB carved (~5× write amplification) from `bytes.Buffer` doubling growth + the remote body copy. The chunker is allocation-free.

## Gate call for the deferred perf issues this was meant to decide

- **#1491 (decoupled log-blob / block sizing) — not justified by this data.** The streamer's allocation cost is transient buffer growth, not sizing granularity; a one-line carve-buffer pre-size captures the win without decoupling the two sizes.
- **#1488 (chunk-range refetch granularity) — read-path, not a write-path bottleneck here.** The warm read path already avoids the WAN round-trip (`BenchmarkReadThroughCache_ColdVsWarm`), so there is no measured pressure to build finer read-miss granularity yet.

Runnable check: `go test -run 'TestChunker_ConstantMemory|TestStreamer_AllocationTracksBlockCount' -bench BenchmarkStreamer_CarveCodecPutBlock -benchtime=1x ./pkg/block/engine/ ./pkg/block/chunker/`.