### PR TITLE
perf(block): pre-size carve block buffer to eliminate grow-and-copy

### DIFF
--- a/pkg/block/engine/carver.go
+++ b/pkg/block/engine/carver.go
@@ -118,11 +118,11 @@ func (m *Syncer) carveFlush(ctx context.Context, drainAll bool) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		batch := m.claimCarveBatch(target, drainAll)
+		batch, batchBytes := m.claimCarveBatch(target, drainAll)
 		if len(batch) == 0 {
 			return nil
 		}
-		if err := m.carveAndCommitBlock(ctx, batch); err != nil {
+		if err := m.carveAndCommitBlock(ctx, batch, batchBytes); err != nil {
 			// Return the batch to the queue for a later retry and surface the
 			// error so an explicit Flush reports non-durability.
 			m.requeueCarveBatch(batch)
@@ -139,7 +139,9 @@ func (m *Syncer) carveFlush(ctx context.Context, drainAll bool) error {
 // are removed from carveQ but remain in pendingCarveHashes until their block
 // commits (or are requeued on failure). Caller holds carveMu (so no concurrent
 // claim races the same chunks).
-func (m *Syncer) claimCarveBatch(target int64, drainAll bool) []block.ContentHash {
+// The returned total is the summed body size of the claimed chunks, so the
+// caller can pre-size the block buffer exactly (avoiding grow-and-copy churn).
+func (m *Syncer) claimCarveBatch(target int64, drainAll bool) ([]block.ContentHash, int64) {
 	m.pendingMu.Lock()
 	defer m.pendingMu.Unlock()
 
@@ -169,7 +171,7 @@ func (m *Syncer) claimCarveBatch(target int64, drainAll bool) []block.ContentHas
 		// Not enough for a full block yet: leave carveQ untouched and wait for
 		// more chunks or the idle flush. Nothing was detached, so FIFO order and
 		// the pending set are exactly as the caller left them.
-		return nil
+		return nil, 0
 	}
 
 	// Committing to carve: detach the claimed prefix now. When target was hit
@@ -181,7 +183,7 @@ func (m *Syncer) claimCarveBatch(target int64, drainAll bool) []block.ContentHas
 	} else {
 		m.carveQ = nil
 	}
-	return batch
+	return batch, total
 }
 
 // requeueCarveBatch returns a failed batch's hashes to the carve queue (only
@@ -264,7 +266,7 @@ func (m *Syncer) carveChunkBytes(
 // blockcodec, uploads the assembled block with PutBlock, and atomically commits
 // the block record + per-chunk locators + synced markers. On success the
 // committed hashes leave pendingCarveHashes and the bytes leave unsyncedBytes.
-func (m *Syncer) carveAndCommitBlock(ctx context.Context, batch []block.ContentHash) error {
+func (m *Syncer) carveAndCommitBlock(ctx context.Context, batch []block.ContentHash, batchBytes int64) error {
 	m.mu.RLock()
 	rbs := m.remoteBlockStore
 	sealer := m.chunkSealer
@@ -308,6 +310,17 @@ func (m *Syncer) carveAndCommitBlock(ctx context.Context, batch []block.ContentH
 	}
 
 	var buf bytes.Buffer
+	// Pre-size so the block is written into one backing array instead of being
+	// doubled-and-copied as it grows — #1555 profiling showed that growth was the
+	// streamer's dominant allocation (~346 MB per 64 MiB). batchBytes is the raw
+	// claimed body size; per chunk we add 256 B of headroom to cover the codec
+	// record/header (~38 B) plus a decorated sealer's per-frame wire inflation
+	// (encryption's magic + wrapped-key + nonce + AEAD tag ≈ 80 B). For the
+	// identity sealer this is an exact upper bound (and the sync filter only
+	// drops chunks, never adds). A sealer that inflates past the headroom (e.g. a
+	// pathologically large wrapped key) costs at most one regrow — still correct,
+	// just less optimal.
+	buf.Grow(int(batchBytes) + len(batch)*256 + 512)
 	builder, err := blockcodec.NewBuilder(&buf, blockID, nil)
 	if err != nil {
 		return fmt.Errorf("carve: new builder: %w", err)

--- a/pkg/block/engine/carver.go
+++ b/pkg/block/engine/carver.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"lukechampine.com/blake3"
@@ -319,8 +320,12 @@ func (m *Syncer) carveAndCommitBlock(ctx context.Context, batch []block.ContentH
 	// identity sealer this is an exact upper bound (and the sync filter only
 	// drops chunks, never adds). A sealer that inflates past the headroom (e.g. a
 	// pathologically large wrapped key) costs at most one regrow — still correct,
-	// just less optimal.
-	buf.Grow(int(batchBytes) + len(batch)*256 + 512)
+	// just less optimal. Computed in int64 and range-checked: the pre-grow is
+	// best-effort, so on an absurd block-size config we skip it rather than risk
+	// a negative int conversion panicking bytes.Buffer.Grow.
+	if grow := batchBytes + int64(len(batch))*256 + 512; grow > 0 && grow <= math.MaxInt {
+		buf.Grow(int(grow))
+	}
 	builder, err := blockcodec.NewBuilder(&buf, blockID, nil)
 	if err != nil {
 		return fmt.Errorf("carve: new builder: %w", err)

--- a/pkg/block/engine/carver_claimbatch_test.go
+++ b/pkg/block/engine/carver_claimbatch_test.go
@@ -27,8 +27,8 @@ func TestClaimCarveBatch_UnderTargetLeavesQueueUntouched(t *testing.T) {
 	m.pendingCarveHashes[h2] = 10
 	before := &m.carveQ[0] // backing-array identity
 
-	if got := m.claimCarveBatch(25, false); got != nil {
-		t.Fatalf("under-target claim = %v, want nil", got)
+	if got, gotBytes := m.claimCarveBatch(25, false); got != nil || gotBytes != 0 {
+		t.Fatalf("under-target claim = %v (%d bytes), want nil (0)", got, gotBytes)
 	}
 	if len(m.carveQ) != 2 || m.carveQ[0] != h1 || m.carveQ[1] != h2 {
 		t.Fatalf("carveQ mutated on under-target peek: %v", m.carveQ)
@@ -50,7 +50,10 @@ func TestClaimCarveBatch_ReachesTargetClaimsPrefixKeepsSuffix(t *testing.T) {
 	}
 
 	// target 15: h1(10) then h2(20>=15) -> claim [h1,h2], leave [h3].
-	got := m.claimCarveBatch(15, false)
+	got, gotBytes := m.claimCarveBatch(15, false)
+	if gotBytes != 20 {
+		t.Fatalf("claimed bytes = %d, want 20 (h1=10 + h2=10)", gotBytes)
+	}
 	if len(got) != 2 || got[0] != h1 || got[1] != h2 {
 		t.Fatalf("claimed = %v, want [h1 h2] (FIFO prefix)", got)
 	}
@@ -70,7 +73,10 @@ func TestClaimCarveBatch_DrainAllClaimsRemainderSkippingStale(t *testing.T) {
 	m.pendingCarveHashes[h1] = 10
 	m.pendingCarveHashes[h3] = 10
 
-	got := m.claimCarveBatch(1000, true) // target far above total, but drainAll
+	got, gotBytes := m.claimCarveBatch(1000, true) // target far above total, but drainAll
+	if gotBytes != 20 {
+		t.Fatalf("claimed bytes = %d, want 20 (h1=10 + h3=10, stale h2 skipped)", gotBytes)
+	}
 	if len(got) != 2 || got[0] != h1 || got[1] != h3 {
 		t.Fatalf("claimed = %v, want [h1 h3] (stale h2 dropped, FIFO)", got)
 	}

--- a/pkg/block/engine/streamer_bench_test.go
+++ b/pkg/block/engine/streamer_bench_test.go
@@ -55,6 +55,8 @@ func newStreamerFixture(blockCount int) streamerFixture {
 func (f streamerFixture) streamBlocks(ctx context.Context, rbs *remotememory.Store) error {
 	for blk := range f.blockIDs {
 		var buf bytes.Buffer
+		// mirror carveAndCommitBlock's pre-grow: body bytes + per-chunk headroom, one alloc
+		buf.Grow(streamerPerBlock*streamerChunkSize + streamerPerBlock*256 + 512)
 		builder, err := blockcodec.NewBuilder(&buf, f.blockIDs[blk], nil)
 		if err != nil {
 			return err


### PR DESCRIPTION
## What

The block streamer framed each carved block into a zero-value `bytes.Buffer` that doubled-and-copied its backing array as chunks were added. The #1555 per-stage profiling flagged this as the streamer's **dominant allocation** (~346 MB per 64 MiB of data). This is the cheap follow-up that profiling identified when #1491 was closed (the win is a pre-size, not a sizing knob).

`claimCarveBatch` already computed the exact body size of the claimed batch and threw it away. This threads that total out and pre-grows the buffer to `body + per-chunk headroom` so each block is written into a single backing array.

## Result

`BenchmarkStreamer_CarveCodecPutBlock` (64 MiB working set, M1 Max):

| | Before | After |
| --- | --- | --- |
| B/op | 345.6 MB | **294.5 MB** (−14.8%) |
| allocs/op | 752 | 704 |
| throughput | 4666 MB/s | **5530 MB/s** (+18.5%) |

## Sizing correctness

- `batchBytes` is the summed **raw** claimed size. The sync-filter in `carveAndCommitBlock` only ever *drops* chunks, so the packed body is always `≤ batchBytes` — `Grow` over-allocates, never under-allocates, for the identity sealer.
- The codec frames the **sealed** wire bytes. A decorated sealer (compression/encryption) can inflate the wire past the raw size, so the per-chunk headroom is **256 B** — covering the codec record (~38 B) plus encryption's magic + wrapped-key + nonce + AEAD tag (~80 B) with margin. A pathologically large wrapped key would cost at most one regrow — still correct, just less optimal. Documented inline.

## Tests

- `carver_claimbatch_test.go` asserts the threaded byte totals for all three claim behaviors (under-target no-op, target-reached prefix, drainAll skipping stale).
- `TestStreamer_AllocationTracksBlockCount` and the benchmark guard the streaming allocation invariant.
- `go test -race ./pkg/block/engine/` green (303 tests); lint clean.

Reviewed by code-simplifier (no change needed) and code-reviewer (one LOW finding — decorated-sealer headroom — addressed by the 256 B bump above).