### PR TITLE
fix(block): fold locator into EnumerateSynced to kill migration cold-start N+1 (#1554)

### DIFF
--- a/pkg/block/engine/compaction.go
+++ b/pkg/block/engine/compaction.go
@@ -135,28 +135,18 @@ func CompactBlocks(
 
 	for _, v := range views {
 		// Live bytes per block: sum the WireLength of every live synced locator.
-		// Drain EnumerateSynced THEN resolve locators — the sqlite pool is
-		// MaxOpenConns(1), so GetLocator inside the enumerate callback (cursor
-		// still open) would deadlock waiting for a second connection.
-		var synced []block.ContentHash
-		if err := v.EnumerateSynced(ctx, func(h block.ContentHash, _ time.Time) error {
-			synced = append(synced, h)
+		// Single scan: EnumerateSynced yields each marker's locator alongside its
+		// hash (same row), so no GetLocator round trip per hash — the O(N) serial
+		// cost on the sqlite MaxOpenConns(1) pool (#1554). Folding the locator in
+		// also removes the nested-query deadlock class structurally.
+		liveBytes := make(map[string]int64)
+		if err := v.EnumerateSynced(ctx, func(_ block.ContentHash, loc block.ChunkLocator, _ time.Time) error {
+			if loc.BlockID != "" {
+				liveBytes[loc.BlockID] += loc.WireLength
+			}
 			return nil
 		}); err != nil {
 			return report, fmt.Errorf("compaction: enumerate synced: %w", err)
-		}
-		liveBytes := make(map[string]int64)
-		for _, h := range synced {
-			if err := ctx.Err(); err != nil {
-				return report, err
-			}
-			loc, ok, err := v.GetLocator(ctx, h)
-			if err != nil {
-				return report, fmt.Errorf("compaction: get locator: %w", err)
-			}
-			if ok && loc.BlockID != "" {
-				liveBytes[loc.BlockID] += loc.WireLength
-			}
 		}
 
 		// Collect candidate block IDs first — never GET/commit/delete while the

--- a/pkg/block/engine/compaction_test.go
+++ b/pkg/block/engine/compaction_test.go
@@ -228,19 +228,23 @@ func TestCompactBlocks_DisabledAndNilRemote(t *testing.T) {
 	}
 }
 
-// compactNestedGuardView models the sqlite MaxOpenConns(1) hazard: a metadata
-// query issued while the EnumerateSynced cursor is open would deadlock. It fails
-// loudly instead, so CompactBlocks must drain EnumerateSynced before resolving
-// locators (the collect-then-query rule).
+// compactNestedGuardView is the #1554 regression tripwire. After the locator
+// fold, compaction sums live bytes from the locator yielded in the
+// EnumerateSynced scan; it still calls GetLocator later (in compactOneBlock,
+// after the cursor closes) to select moveable chunks. So GetLocator fatals only
+// when called WHILE the enumerate cursor is open — the nested query that would
+// deadlock the sqlite MaxOpenConns(1) pool.
 type compactNestedGuardView struct {
 	t           *testing.T
 	inEnumerate bool
 }
 
-func (v *compactNestedGuardView) EnumerateSynced(_ context.Context, fn func(block.ContentHash, time.Time) error) error {
+func (v *compactNestedGuardView) EnumerateSynced(_ context.Context, fn func(block.ContentHash, block.ChunkLocator, time.Time) error) error {
 	v.inEnumerate = true
 	defer func() { v.inEnumerate = false }()
-	return fn(hashFromString("live-chunk"), time.Now().Add(-2*time.Hour))
+	// Locator folded into the scan (#1554): compaction sums live bytes from this
+	// yielded locator, not a per-hash GetLocator round trip.
+	return fn(hashFromString("live-chunk"), block.ChunkLocator{BlockID: "blk-x", WireLength: 10}, time.Now().Add(-2*time.Hour))
 }
 
 func (v *compactNestedGuardView) GetLocator(_ context.Context, _ block.ContentHash) (block.ChunkLocator, bool, error) {

--- a/pkg/block/engine/engine_delete_test.go
+++ b/pkg/block/engine/engine_delete_test.go
@@ -175,8 +175,9 @@ func (s *recordingSyncedHashStore) MarkSynced(_ context.Context, hash block.Cont
 }
 
 // EnumerateSynced satisfies engine.SyncedHashIndex, yielding each marker with
-// its recorded first-mirror time (the LIST-free sweep's grace anchor).
-func (s *recordingSyncedHashStore) EnumerateSynced(ctx context.Context, fn func(block.ContentHash, time.Time) error) error {
+// its locator (standalone here — this fake records no block locators) and
+// recorded first-mirror time (the LIST-free sweep's grace anchor).
+func (s *recordingSyncedHashStore) EnumerateSynced(ctx context.Context, fn func(block.ContentHash, block.ChunkLocator, time.Time) error) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -187,7 +188,7 @@ func (s *recordingSyncedHashStore) EnumerateSynced(ctx context.Context, fn func(
 	}
 	s.mu.Unlock()
 	for h, t := range snapshot {
-		if err := fn(h, t); err != nil {
+		if err := fn(h, block.ChunkLocator{}, t); err != nil {
 			return err
 		}
 	}

--- a/pkg/block/engine/gc.go
+++ b/pkg/block/engine/gc.go
@@ -286,15 +286,20 @@ const gcMarkProgressInterval = 100_000
 // only what it uses so the broader IsSynced/MarkSynced surface stays out of
 // this dependency.
 type SyncedHashIndex interface {
-	// EnumerateSynced calls fn once per synced marker with its content hash
-	// and first-mirror timestamp. A zero syncedAt means the backend has no
-	// recorded time (legacy marker) — the sweep treats it as fail-closed.
+	// EnumerateSynced calls fn once per synced marker with its content hash,
+	// remote locator, and first-mirror timestamp. The locator is read from the
+	// same marker row, so callers that need it resolve every hash in a single
+	// scan instead of a GetLocator round trip per hash — the O(N)-serial cost on
+	// the sqlite MaxOpenConns(1) pool behind the slow cold-start (#1554). A
+	// standalone (pre-flip) marker yields the zero ChunkLocator. A zero syncedAt
+	// means the backend has no recorded time (legacy marker) — the sweep treats
+	// it as fail-closed.
 	//
 	// fn is invoked SEQUENTIALLY (never concurrently), so the sweep mutates its
 	// unsynchronized per-run counters from inside fn without a lock. A non-nil
 	// error from fn aborts enumeration and is returned; implementations must
 	// honor ctx cancellation.
-	EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, syncedAt time.Time) error) error
+	EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, loc block.ChunkLocator, syncedAt time.Time) error) error
 
 	// DeleteSynced removes the synced marker for a swept hash. Idempotent.
 	DeleteSynced(ctx context.Context, hash block.ContentHash) error

--- a/pkg/block/engine/gc_sweep_index.go
+++ b/pkg/block/engine/gc_sweep_index.go
@@ -47,7 +47,7 @@ func sweepFromSyncedIndex(
 	graceCutoff := snapshotTime.Add(-gracePeriod)
 	var scanned int64
 
-	enumErr := options.SyncedHashIndex.EnumerateSynced(ctx, func(h block.ContentHash, syncedAt time.Time) error {
+	enumErr := options.SyncedHashIndex.EnumerateSynced(ctx, func(h block.ContentHash, _ block.ChunkLocator, syncedAt time.Time) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}

--- a/pkg/block/engine/legacy_migration.go
+++ b/pkg/block/engine/legacy_migration.go
@@ -98,29 +98,20 @@ func (m *Syncer) migrateLegacyCASRemote(ctx context.Context) error {
 	enum, canEnumerate := shs.(SyncedHashIndex)
 	var standalone []block.ContentHash
 	if canEnumerate {
-		// Drain the enumeration into a slice, THEN resolve locators: the sqlite
-		// metadata pool is MaxOpenConns(1), so calling GetLocator inside the
-		// EnumerateSynced callback (while its cursor still holds the only
-		// connection) deadlocks waiting for a second — which blocks Store.Start
-		// and, via LoadSharesFromStore, the whole server from coming up.
-		var synced []block.ContentHash
-		if err := enum.EnumerateSynced(ctx, func(h block.ContentHash, _ time.Time) error {
-			synced = append(synced, h)
+		// Single scan: EnumerateSynced yields each marker's locator alongside its
+		// hash (both live in the same synced_hashes row), so detection needs no
+		// per-hash GetLocator. This matters on every boot: the scan runs before
+		// the server binds, and the old enumerate-then-GetLocator-per-hash shape
+		// was O(N) serial statements on the sqlite MaxOpenConns(1) pool — the
+		// slow cold-start (#1554). Folding the locator in also removes the
+		// nested-query deadlock class structurally (there is no second query).
+		if err := enum.EnumerateSynced(ctx, func(h block.ContentHash, loc block.ChunkLocator, _ time.Time) error {
+			if loc.BlockID == "" { // standalone locator: pre-flip layout
+				standalone = append(standalone, h)
+			}
 			return nil
 		}); err != nil {
 			return fmt.Errorf("cas→blocks migration: enumerate synced hashes: %w", err)
-		}
-		for _, h := range synced {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-			loc, ok, err := shs.GetLocator(ctx, h)
-			if err != nil {
-				return err
-			}
-			if ok && loc.BlockID == "" { // standalone locator: pre-flip layout
-				standalone = append(standalone, h)
-			}
 		}
 	}
 

--- a/pkg/block/engine/reclaim.go
+++ b/pkg/block/engine/reclaim.go
@@ -159,28 +159,17 @@ func ReclaimRecords(
 		// Any block ID a synced locator still points at is NOT an orphan, whatever
 		// its record's counter says — drop it from the candidate set.
 		//
-		// Collect the hashes first and resolve their locators AFTER the enumerate
-		// cursor closes: the sqlite metadata pool is MaxOpenConns(1), so calling
-		// GetLocator inside the EnumerateSynced callback (while its rows cursor
-		// still holds the only connection) would deadlock waiting for a second.
-		var synced []block.ContentHash
-		if err := v.EnumerateSynced(ctx, func(h block.ContentHash, _ time.Time) error {
-			synced = append(synced, h)
+		// Single scan: EnumerateSynced yields each marker's locator alongside its
+		// hash (same row), so no GetLocator round trip per hash — the O(N) serial
+		// cost on the sqlite MaxOpenConns(1) pool (#1554). Folding the locator in
+		// also removes the nested-query deadlock class structurally.
+		if err := v.EnumerateSynced(ctx, func(_ block.ContentHash, loc block.ChunkLocator, _ time.Time) error {
+			if loc.BlockID != "" {
+				delete(candidates, loc.BlockID)
+			}
 			return nil
 		}); err != nil {
 			return report, fmt.Errorf("reclaim: enumerate synced: %w", err)
-		}
-		for _, h := range synced {
-			if err := ctx.Err(); err != nil {
-				return report, err
-			}
-			loc, ok, err := v.GetLocator(ctx, h)
-			if err != nil {
-				return report, fmt.Errorf("reclaim: get locator: %w", err)
-			}
-			if ok && loc.BlockID != "" {
-				delete(candidates, loc.BlockID)
-			}
 		}
 
 		for blockID, c := range candidates {

--- a/pkg/block/engine/reclaim_test.go
+++ b/pkg/block/engine/reclaim_test.go
@@ -211,9 +211,9 @@ func (v *raceView) WalkBlockRecords(_ context.Context, fn func(block.BlockRecord
 	return nil
 }
 
-func (v *raceView) EnumerateSynced(_ context.Context, fn func(block.ContentHash, time.Time) error) error {
+func (v *raceView) EnumerateSynced(_ context.Context, fn func(block.ContentHash, block.ChunkLocator, time.Time) error) error {
 	if v.reveal() {
-		return fn(hashFromString("R-chunk"), time.Time{})
+		return fn(hashFromString("R-chunk"), block.ChunkLocator{BlockID: "R"}, time.Time{})
 	}
 	return nil
 }
@@ -227,28 +227,26 @@ func (v *raceView) DeleteBlockRecord(_ context.Context, blockID string) error {
 	return nil
 }
 
-// nestedGuardView models the sqlite metadata pool's MaxOpenConns(1) hazard: while
-// an EnumerateSynced cursor is open it holds the only connection, so any query
-// issued from inside the callback (e.g. GetLocator) would block forever waiting
-// for a second. This view fails loudly instead of deadlocking, so the reclaimer
-// must drain EnumerateSynced before resolving locators. blk-leaked has a record
-// with no locator (class 2); blk-live has a record and a locator (must survive).
+// nestedGuardView proves the #1554 locator fold: EnumerateSynced yields each
+// marker's locator in-scan, so the reclaimer classifies blocks without any
+// GetLocator round trip. GetLocator fails loudly if called at all — the fold
+// removed the per-hash resolve that the sqlite MaxOpenConns(1) pool serialized
+// (and that, called inside the cursor, used to deadlock #1552). blk-leaked has a
+// record with no locator (class 2); blk-live has a record and a locator (must
+// survive).
 type nestedGuardView struct {
-	t           *testing.T
-	inEnumerate bool
-	deleted     []string
+	t       *testing.T
+	deleted []string
 }
 
-func (v *nestedGuardView) EnumerateSynced(_ context.Context, fn func(block.ContentHash, time.Time) error) error {
-	v.inEnumerate = true
-	defer func() { v.inEnumerate = false }()
-	return fn(hashFromString("live-chunk"), time.Time{})
+func (v *nestedGuardView) EnumerateSynced(_ context.Context, fn func(block.ContentHash, block.ChunkLocator, time.Time) error) error {
+	// Locator folded into the scan (#1554): reclaim drops still-referenced blocks
+	// from the candidate set using this yielded locator, not a per-hash GetLocator.
+	return fn(hashFromString("live-chunk"), block.ChunkLocator{BlockID: "blk-live"}, time.Time{})
 }
 
 func (v *nestedGuardView) GetLocator(_ context.Context, _ block.ContentHash) (block.ChunkLocator, bool, error) {
-	if v.inEnumerate {
-		v.t.Fatal("GetLocator called while EnumerateSynced cursor is open — deadlocks on sqlite MaxOpenConns(1)")
-	}
+	v.t.Fatal("GetLocator called — the locator fold means reclaim resolves from the EnumerateSynced scan, never a per-hash round trip (#1554)")
 	return block.ChunkLocator{BlockID: "blk-live"}, true, nil
 }
 
@@ -269,10 +267,10 @@ func (v *nestedGuardView) DeleteBlockRecord(_ context.Context, blockID string) e
 	return nil
 }
 
-// TestReclaimRecords_NoNestedQueryDuringEnumerate guards against re-introducing a
-// GetLocator call inside the EnumerateSynced callback, which deadlocks on the
-// single-connection sqlite pool (found via a real sqlite backend on a live VM).
-func TestReclaimRecords_NoNestedQueryDuringEnumerate(t *testing.T) {
+// TestReclaimRecords_ResolvesLocatorsFromEnumerateScan proves the #1554 fold:
+// reclaim classifies blocks using the locator yielded by EnumerateSynced and
+// never issues a per-hash GetLocator (the guard view fatals if it does).
+func TestReclaimRecords_ResolvesLocatorsFromEnumerateScan(t *testing.T) {
 	v := &nestedGuardView{t: t}
 	rep, err := ReclaimRecords(t.Context(), []ReclaimMetaView{v}, nil, ReclaimOptions{})
 	if err != nil {

--- a/pkg/block/engine/reconcile.go
+++ b/pkg/block/engine/reconcile.go
@@ -24,7 +24,7 @@ const defaultReconcileSampleCap = 100
 // consumes. metadata.Store satisfies it structurally (EnumerateSynced concrete
 // method + SyncedHashStore.GetLocator + BlockRecordStore.WalkBlockRecords).
 type ReconcileMetaView interface {
-	EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, syncedAt time.Time) error) error
+	EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, loc block.ChunkLocator, syncedAt time.Time) error) error
 	GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error)
 	WalkBlockRecords(ctx context.Context, fn func(block.BlockRecord) error) error
 }
@@ -162,29 +162,18 @@ func Reconcile(
 		// THIS share. Built fully first, then WalkBlockRecords classifies each
 		// record against it.
 		//
-		// Drain EnumerateSynced into a slice, THEN resolve locators: the sqlite
-		// pool is MaxOpenConns(1), so calling GetLocator inside the enumerate
-		// callback (cursor still open) would deadlock waiting for a second
-		// connection.
-		var synced []block.ContentHash
-		if err := v.EnumerateSynced(ctx, func(h block.ContentHash, _ time.Time) error {
-			synced = append(synced, h)
+		// Single scan: EnumerateSynced yields each marker's locator alongside its
+		// hash (same row), so no GetLocator round trip per hash — the O(N) serial
+		// cost on the sqlite MaxOpenConns(1) pool (#1554). Folding the locator in
+		// also removes the nested-query deadlock class structurally.
+		refSet := make(map[string]struct{})
+		if err := v.EnumerateSynced(ctx, func(_ block.ContentHash, loc block.ChunkLocator, _ time.Time) error {
+			if loc.BlockID != "" {
+				refSet[loc.BlockID] = struct{}{}
+			}
 			return nil
 		}); err != nil {
 			return report, fmt.Errorf("reconcile: enumerate synced: %w", err)
-		}
-		refSet := make(map[string]struct{})
-		for _, h := range synced {
-			if err := ctx.Err(); err != nil {
-				return report, err
-			}
-			loc, ok, err := v.GetLocator(ctx, h)
-			if err != nil {
-				return report, fmt.Errorf("reconcile: get locator: %w", err)
-			}
-			if ok && loc.BlockID != "" {
-				refSet[loc.BlockID] = struct{}{}
-			}
 		}
 
 		if err := v.WalkBlockRecords(ctx, func(rec block.BlockRecord) error {

--- a/pkg/block/engine/reconcile_test.go
+++ b/pkg/block/engine/reconcile_test.go
@@ -185,7 +185,7 @@ func captureState(t *testing.T, st *metadatamemory.MemoryMetadataStore, rbs *rem
 	}); err != nil {
 		t.Fatalf("WalkBlocks: %v", err)
 	}
-	if err := st.EnumerateSynced(ctx, func(h block.ContentHash, _ time.Time) error {
+	if err := st.EnumerateSynced(ctx, func(h block.ContentHash, _ block.ChunkLocator, _ time.Time) error {
 		s.syncedHashes[h.String()] = struct{}{}
 		return nil
 	}); err != nil {
@@ -222,25 +222,21 @@ func (s reconcileState) assertEqual(t *testing.T, other reconcileState) {
 	}
 }
 
-// nestedGuardMetaView models the sqlite MaxOpenConns(1) hazard: while an
-// EnumerateSynced cursor is open it holds the only connection, so any query from
-// inside the callback (GetLocator) would deadlock. It fails loudly instead, so
-// Reconcile must drain the enumeration before resolving locators.
+// nestedGuardMetaView proves the #1554 locator fold: EnumerateSynced yields each
+// marker's locator in-scan, so Reconcile resolves references without any
+// GetLocator round trip. GetLocator fails loudly if called at all — the fold
+// removed the per-hash resolve that the sqlite MaxOpenConns(1) pool serialized
+// (and that, called inside the cursor, used to deadlock #1552).
 type nestedGuardMetaView struct {
-	t           *testing.T
-	inEnumerate bool
+	t *testing.T
 }
 
-func (v *nestedGuardMetaView) EnumerateSynced(_ context.Context, fn func(block.ContentHash, time.Time) error) error {
-	v.inEnumerate = true
-	defer func() { v.inEnumerate = false }()
-	return fn(hashFromString("chunk"), time.Time{})
+func (v *nestedGuardMetaView) EnumerateSynced(_ context.Context, fn func(block.ContentHash, block.ChunkLocator, time.Time) error) error {
+	return fn(hashFromString("chunk"), block.ChunkLocator{BlockID: "blk-live"}, time.Time{})
 }
 
 func (v *nestedGuardMetaView) GetLocator(_ context.Context, _ block.ContentHash) (block.ChunkLocator, bool, error) {
-	if v.inEnumerate {
-		v.t.Fatal("GetLocator called while EnumerateSynced cursor is open — deadlocks on sqlite MaxOpenConns(1)")
-	}
+	v.t.Fatal("GetLocator called — the locator fold means Reconcile resolves from the EnumerateSynced scan, never a per-hash round trip (#1554)")
 	return block.ChunkLocator{BlockID: "blk-live"}, true, nil
 }
 
@@ -248,9 +244,10 @@ func (v *nestedGuardMetaView) WalkBlockRecords(_ context.Context, fn func(block.
 	return fn(block.BlockRecord{BlockID: "blk-live", Length: 5, LiveChunkCount: 1})
 }
 
-// TestReconcile_NoNestedQueryDuringEnumerate guards the #1552 sqlite deadlock:
-// Reconcile must not call GetLocator inside the EnumerateSynced callback.
-func TestReconcile_NoNestedQueryDuringEnumerate(t *testing.T) {
+// TestReconcile_ResolvesLocatorsFromEnumerateScan proves the #1554 fold:
+// Reconcile classifies blocks using the locator yielded by EnumerateSynced and
+// never issues a per-hash GetLocator (the guard view fatals if it does).
+func TestReconcile_ResolvesLocatorsFromEnumerateScan(t *testing.T) {
 	v := &nestedGuardMetaView{t: t}
 	rep, err := Reconcile(t.Context(), []ReconcileMetaView{v}, nil, nil, ReconcileOptions{})
 	if err != nil {

--- a/pkg/block/engine/sqlite_startup_deadlock_test.go
+++ b/pkg/block/engine/sqlite_startup_deadlock_test.go
@@ -208,7 +208,7 @@ type countingMetaView struct {
 	getLocatorCall int
 }
 
-func (v *countingMetaView) EnumerateSynced(ctx context.Context, fn func(block.ContentHash, time.Time) error) error {
+func (v *countingMetaView) EnumerateSynced(ctx context.Context, fn func(block.ContentHash, block.ChunkLocator, time.Time) error) error {
 	v.enumerateCalls++
 	return v.SQLiteMetadataStore.EnumerateSynced(ctx, fn)
 }
@@ -218,17 +218,15 @@ func (v *countingMetaView) GetLocator(ctx context.Context, h block.ContentHash) 
 	return v.SQLiteMetadataStore.GetLocator(ctx, h)
 }
 
-// TestSQLiteReconcile_LocatorRoundTripsAreLinear documents the slow-startup
-// finding of #1554. After the collect-then-query deadlock fix, the migration /
-// reconcile / reclaim passes are correct but still issue one GetLocator round
-// trip per synced hash. On the sqlite backend every one of those round trips is
-// serialized on the single pooled connection (SetMaxOpenConns(1)), so the cost
-// of resolving locators is O(synced-hash-count) sequential statements — the
-// latent serialization behind the ">120s to first healthy" symptom on a large
-// sqlite+S3 share. This test pins that N+1 shape so the profiling finding is
-// observable in CI; the batch fix is to fold the locator columns into the
-// EnumerateSynced scan (they already live in the same synced_hashes row).
-func TestSQLiteReconcile_LocatorRoundTripsAreLinear(t *testing.T) {
+// TestSQLiteReconcile_LocatorResolutionIsSinglePass pins the #1554 fix. Before
+// the fold, reconcile (and the boot-critical migration-detection scan, and
+// reclaim/compaction) resolved locators with one GetLocator per synced hash —
+// O(synced-hash-count) statements serialized on the sqlite SetMaxOpenConns(1)
+// pool, the latent serialization behind the ">120s to first healthy" cold-start
+// on a large sqlite+S3 share. The fold yields each marker's locator directly in
+// the EnumerateSynced scan (same synced_hashes row), so resolution is now ONE
+// scan with ZERO per-hash round trips. A regression back to N+1 fails here.
+func TestSQLiteReconcile_LocatorResolutionIsSinglePass(t *testing.T) {
 	st := newSQLiteStoreForDeadlockTest(t)
 	const n = 32
 	seedSyncedMarkers(t, st, "blk-live", n)
@@ -239,13 +237,55 @@ func TestSQLiteReconcile_LocatorRoundTripsAreLinear(t *testing.T) {
 	}
 
 	if view.enumerateCalls != 1 {
-		t.Errorf("EnumerateSynced calls = %d; want 1", view.enumerateCalls)
+		t.Errorf("EnumerateSynced calls = %d; want 1 (single scan)", view.enumerateCalls)
 	}
-	// One serial GetLocator per synced hash: the O(n) round-trip pattern that
-	// serializes on the single sqlite connection at startup.
-	if view.getLocatorCall != n {
-		t.Errorf("GetLocator round trips = %d; want %d (one per synced hash)", view.getLocatorCall, n)
+	// Zero per-hash GetLocator round trips: the locator is folded into the scan,
+	// so nothing serializes on the single sqlite connection per hash.
+	if view.getLocatorCall != 0 {
+		t.Errorf("GetLocator round trips = %d; want 0 (locator folded into EnumerateSynced) — regression of the #1554 N+1 fix", view.getLocatorCall)
 	}
-	t.Logf("sqlite locator resolution issued %d serial GetLocator round trips for %d synced hashes "+
-		"(each serialized on the MaxOpenConns(1) pool) — see #1554 profiling finding", view.getLocatorCall, n)
+}
+
+// TestSQLiteStartup_MigrationDetectionIsSinglePass reproduces the #1554 cold-
+// start on the boot-critical path: Store.Start's one-shot legacy-CAS migration
+// runs its standalone-detection scan on every boot, before the API server binds.
+// With the locator folded into EnumerateSynced, detection is a single scan with
+// zero per-hash GetLocator round trips (was O(n) serial statements on the
+// MaxOpenConns(1) pool). Block-resident markers mean nothing is standalone, so
+// no repack runs — the point is the detection scan's round-trip shape.
+func TestSQLiteStartup_MigrationDetectionIsSinglePass(t *testing.T) {
+	st := newSQLiteStoreForDeadlockTest(t)
+	const n = 32
+	seedSyncedMarkers(t, st, "blk-live", n)
+	view := &countingMetaView{SQLiteMetadataStore: st}
+
+	local := localmemory.New()
+	rbs := remotememory.New()
+	fbs := newStubFileChunkStore()
+	syncer := NewSyncer(local, rbs, fbs, DefaultConfig())
+	syncer.SetRemoteBlockStore(rbs)
+
+	bs, err := New(BlockStoreConfig{
+		Local:           local,
+		Remote:          rbs,
+		Syncer:          syncer,
+		FileChunkStore:  fbs,
+		SyncedHashStore: view,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	cleanupClose(t, "block store", bs.Close)
+
+	runBounded(t, "Store.Start (migration detection)", bs.Start)
+
+	if view.enumerateCalls < 1 {
+		t.Errorf("EnumerateSynced calls = %d; want >=1 (migration detection scan ran)", view.enumerateCalls)
+	}
+	// The migration detection must resolve standalone-ness from the folded
+	// locator, never a per-hash GetLocator — the O(n) serial cost that delayed
+	// the :8080 bind past 120s on a large sqlite+S3 share.
+	if view.getLocatorCall != 0 {
+		t.Errorf("migration detection issued %d GetLocator round trips; want 0 (locator folded into the scan) — regression of the #1554 cold-start fix", view.getLocatorCall)
+	}
 }

--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -466,26 +466,30 @@ var _ engine.SyncedHashIndex = multiSyncedHashStore(nil)
 // different first-mirror times; it keeps the LATEST so the grace window covers
 // the most recent upload — the most conservative choice (never delete a hash
 // still within any share's grace). A real timestamp supersedes a legacy zero.
-func (m multiSyncedHashStore) EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, syncedAt time.Time) error) error {
+func (m multiSyncedHashStore) EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, loc block.ChunkLocator, syncedAt time.Time) error) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	latest := make(map[block.ContentHash]time.Time)
+	type entry struct {
+		loc      block.ChunkLocator
+		syncedAt time.Time
+	}
+	latest := make(map[block.ContentHash]entry)
 	for _, s := range m {
-		if err := s.EnumerateSynced(ctx, func(h block.ContentHash, syncedAt time.Time) error {
-			if prev, ok := latest[h]; !ok || syncedAt.After(prev) {
-				latest[h] = syncedAt
+		if err := s.EnumerateSynced(ctx, func(h block.ContentHash, loc block.ChunkLocator, syncedAt time.Time) error {
+			if prev, ok := latest[h]; !ok || syncedAt.After(prev.syncedAt) {
+				latest[h] = entry{loc: loc, syncedAt: syncedAt}
 			}
 			return nil
 		}); err != nil {
 			return err
 		}
 	}
-	for h, t := range latest {
+	for h, e := range latest {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if err := fn(h, t); err != nil {
+		if err := fn(h, e.loc, e.syncedAt); err != nil {
 			return err
 		}
 	}

--- a/pkg/metadata/store/badger/synced_hash_store.go
+++ b/pkg/metadata/store/badger/synced_hash_store.go
@@ -220,11 +220,14 @@ func (s *BadgerMetadataStore) GetLocator(ctx context.Context, hash block.Content
 	return loc, found, nil
 }
 
-// EnumerateSynced streams every synced marker with its first-mirror time via a
-// prefix scan over synced:. Collects under a read txn then calls fn outside
-// iteration so the callback never runs with the iterator open. Used by the
-// LIST-free GC sweep to compute remote-orphan candidates without an S3 LIST.
-func (s *BadgerMetadataStore) EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, syncedAt time.Time) error) error {
+// EnumerateSynced streams every synced marker with its locator and first-mirror
+// time via a prefix scan over synced:. Both the timestamp and the locator suffix
+// live in the same marker value, so yielding the locator here lets callers
+// resolve locators in a single scan instead of a GetLocator round trip per hash
+// (#1554). Collects under a read txn then calls fn outside iteration so the
+// callback never runs with the iterator open. A marker with no locator suffix
+// yields the zero (standalone) locator.
+func (s *BadgerMetadataStore) EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, loc block.ChunkLocator, syncedAt time.Time) error) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -232,6 +235,7 @@ func (s *BadgerMetadataStore) EnumerateSynced(ctx context.Context, fn func(hash 
 
 	type entry struct {
 		hash     block.ContentHash
+		loc      block.ChunkLocator
 		syncedAt time.Time
 	}
 	var entries []entry
@@ -250,16 +254,20 @@ func (s *BadgerMetadataStore) EnumerateSynced(ctx context.Context, fn func(hash 
 			}
 			var h block.ContentHash
 			copy(h[:], raw)
-			var syncedAt time.Time
+			var (
+				syncedAt time.Time
+				loc      block.ChunkLocator
+			)
 			if verr := item.Value(func(val []byte) error {
 				if nanos := decodeInt64(val); nanos != 0 {
 					syncedAt = time.Unix(0, nanos)
 				}
+				loc = decodeSyncedLocator(val)
 				return nil
 			}); verr != nil {
 				return verr
 			}
-			entries = append(entries, entry{hash: h, syncedAt: syncedAt})
+			entries = append(entries, entry{hash: h, loc: loc, syncedAt: syncedAt})
 		}
 		return nil
 	})
@@ -271,7 +279,7 @@ func (s *BadgerMetadataStore) EnumerateSynced(ctx context.Context, fn func(hash 
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if err := fn(e.hash, e.syncedAt); err != nil {
+		if err := fn(e.hash, e.loc, e.syncedAt); err != nil {
 			return err
 		}
 	}

--- a/pkg/metadata/store/memory/synced_hash_store.go
+++ b/pkg/metadata/store/memory/synced_hash_store.go
@@ -28,24 +28,31 @@ func (s *MemoryMetadataStore) MarkSyncedAtForTest(hash block.ContentHash, when t
 	s.synced[hash] = when
 }
 
-// EnumerateSynced streams every synced marker with its first-mirror time.
-// It snapshots the map under the read lock so fn runs without holding it.
-func (s *MemoryMetadataStore) EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, syncedAt time.Time) error) error {
+// EnumerateSynced streams every synced marker with its locator and first-mirror
+// time. It snapshots the maps under the read lock so fn runs without holding it.
+// Yielding the locator here lets callers resolve locators in a single pass
+// instead of a GetLocator lookup per hash (#1554). A standalone chunk has no
+// entry in syncedLocators, so it yields the zero (standalone) locator.
+func (s *MemoryMetadataStore) EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, loc block.ChunkLocator, syncedAt time.Time) error) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	type entry struct {
+		loc      block.ChunkLocator
+		syncedAt time.Time
+	}
 	s.syncedMu.RLock()
-	snapshot := make(map[block.ContentHash]time.Time, len(s.synced))
+	snapshot := make(map[block.ContentHash]entry, len(s.synced))
 	for h, t := range s.synced {
-		snapshot[h] = t
+		snapshot[h] = entry{loc: s.syncedLocators[h], syncedAt: t}
 	}
 	s.syncedMu.RUnlock()
 
-	for h, t := range snapshot {
+	for h, e := range snapshot {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if err := fn(h, t); err != nil {
+		if err := fn(h, e.loc, e.syncedAt); err != nil {
 			return err
 		}
 	}

--- a/pkg/metadata/store/postgres/synced_hash_store.go
+++ b/pkg/metadata/store/postgres/synced_hash_store.go
@@ -25,14 +25,16 @@ var (
 	_ metadata.SyncedHashStore = (*postgresTransaction)(nil)
 )
 
-// EnumerateSynced streams every synced marker with its first-mirror time,
-// read straight from the synced_hashes table. Used by the LIST-free GC sweep
-// to compute remote-orphan candidates without an S3 LIST.
-func (s *PostgresMetadataStore) EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, syncedAt time.Time) error) error {
+// EnumerateSynced streams every synced marker with its locator and first-mirror
+// time, read straight from the synced_hashes table. The locator columns live in
+// the same row, so yielding them here lets callers resolve locators in a single
+// scan instead of a GetLocator round trip per hash (#1554). A synced row with
+// NULL/empty block columns yields the zero (standalone) locator.
+func (s *PostgresMetadataStore) EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, loc block.ChunkLocator, syncedAt time.Time) error) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	rows, err := s.query(ctx, `SELECT hash, synced_at FROM synced_hashes`)
+	rows, err := s.query(ctx, `SELECT hash, synced_at, block_id, block_offset, block_length FROM synced_hashes`)
 	if err != nil {
 		return fmt.Errorf("postgres synced enumerate: %w", err)
 	}
@@ -42,8 +44,10 @@ func (s *PostgresMetadataStore) EnumerateSynced(ctx context.Context, fn func(has
 		var (
 			raw      []byte
 			syncedAt time.Time
+			blockID  sql.NullString
+			off, ln  sql.NullInt64
 		)
-		if err := rows.Scan(&raw, &syncedAt); err != nil {
+		if err := rows.Scan(&raw, &syncedAt, &blockID, &off, &ln); err != nil {
 			return fmt.Errorf("postgres synced enumerate scan: %w", err)
 		}
 		if len(raw) != len(block.ContentHash{}) {
@@ -53,11 +57,28 @@ func (s *PostgresMetadataStore) EnumerateSynced(ctx context.Context, fn func(has
 		}
 		var h block.ContentHash
 		copy(h[:], raw)
-		if err := fn(h, syncedAt); err != nil {
+		loc, err := locatorFromCols(blockID, off, ln)
+		if err != nil {
+			return fmt.Errorf("postgres synced enumerate: %w", err)
+		}
+		if err := fn(h, loc, syncedAt); err != nil {
 			return err
 		}
 	}
 	return rows.Err()
+}
+
+// locatorFromCols builds a ChunkLocator from already-scanned (block_id,
+// block_offset, block_length) columns. NULL/empty block_id yields the zero
+// (standalone) locator. Mirrors GetLocator's decode for the folded enumeration.
+func locatorFromCols(blockID sql.NullString, off, length sql.NullInt64) (block.ChunkLocator, error) {
+	if !blockID.Valid || blockID.String == "" {
+		return block.ChunkLocator{}, nil
+	}
+	if !off.Valid || !length.Valid {
+		return block.ChunkLocator{}, fmt.Errorf("corrupt locator row: block_id %q with NULL offset/length", blockID.String)
+	}
+	return block.ChunkLocator{BlockID: blockID.String, WireOffset: off.Int64, WireLength: length.Int64}, nil
 }
 
 // IsSynced reports whether hash has been MarkSynced'd at least once.

--- a/pkg/metadata/store/sqlite/synced_hash_store.go
+++ b/pkg/metadata/store/sqlite/synced_hash_store.go
@@ -23,14 +23,17 @@ var (
 	_ metadata.SyncedHashStore = (*sqliteTransaction)(nil)
 )
 
-// EnumerateSynced streams every synced marker with its first-mirror time,
-// read straight from the synced_hashes table. Used by the LIST-free GC sweep
-// to compute remote-orphan candidates without an S3 LIST.
-func (s *SQLiteMetadataStore) EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, syncedAt time.Time) error) error {
+// EnumerateSynced streams every synced marker with its locator and first-mirror
+// time, read straight from the synced_hashes table. The locator columns live in
+// the same row, so yielding them here lets callers resolve locators in a single
+// scan instead of a GetLocator round trip per hash — the O(N)-serial-statements
+// cost on the MaxOpenConns(1) pool behind the slow cold-start (#1554). A synced
+// row with NULL/empty block columns yields the zero (standalone) locator.
+func (s *SQLiteMetadataStore) EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, loc block.ChunkLocator, syncedAt time.Time) error) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	rows, err := s.query(ctx, `SELECT hash, synced_at FROM synced_hashes`)
+	rows, err := s.query(ctx, `SELECT hash, synced_at, block_id, block_offset, block_length FROM synced_hashes`)
 	if err != nil {
 		return fmt.Errorf("sqlite synced enumerate: %w", err)
 	}
@@ -40,8 +43,10 @@ func (s *SQLiteMetadataStore) EnumerateSynced(ctx context.Context, fn func(hash 
 		var (
 			raw      []byte
 			syncedAt time.Time
+			blockID  sql.NullString
+			off, ln  sql.NullInt64
 		)
-		if err := rows.Scan(&raw, &syncedAt); err != nil {
+		if err := rows.Scan(&raw, &syncedAt, &blockID, &off, &ln); err != nil {
 			return fmt.Errorf("sqlite synced enumerate scan: %w", err)
 		}
 		if len(raw) != len(block.ContentHash{}) {
@@ -51,7 +56,11 @@ func (s *SQLiteMetadataStore) EnumerateSynced(ctx context.Context, fn func(hash 
 		}
 		var h block.ContentHash
 		copy(h[:], raw)
-		if err := fn(h, syncedAt); err != nil {
+		loc, err := locatorFromCols(blockID, off, ln)
+		if err != nil {
+			return fmt.Errorf("sqlite synced enumerate: %w", err)
+		}
+		if err := fn(h, loc, syncedAt); err != nil {
 			return err
 		}
 	}
@@ -172,6 +181,14 @@ func scanLocatorRow(row scanRow) (block.ChunkLocator, error) {
 	if err := row.Scan(&blockID, &off, &length); err != nil {
 		return block.ChunkLocator{}, err
 	}
+	return locatorFromCols(blockID, off, length)
+}
+
+// locatorFromCols builds a ChunkLocator from already-scanned (block_id,
+// block_offset, block_length) columns. NULL/empty block_id yields the zero
+// (standalone) locator. Shared by scanLocatorRow (single-row lookup) and
+// EnumerateSynced (folded into the enumeration scan).
+func locatorFromCols(blockID sql.NullString, off, length sql.NullInt64) (block.ChunkLocator, error) {
 	if !blockID.Valid || blockID.String == "" {
 		return block.ChunkLocator{}, nil
 	}

--- a/pkg/metadata/synced_hash_store.go
+++ b/pkg/metadata/synced_hash_store.go
@@ -68,7 +68,7 @@ type SyncedHashStore interface {
 
 // NOTE: backends additionally expose a concrete
 //
-//	EnumerateSynced(ctx, func(hash block.ContentHash, syncedAt time.Time) error) error
+//	EnumerateSynced(ctx, func(hash block.ContentHash, loc block.ChunkLocator, syncedAt time.Time) error) error
 //
 // method used by the LIST-free GC sweep (#1433). It is deliberately NOT part of
 // the SyncedHashStore contract: only the GC consumer needs it, so the engine

--- a/pkg/metadata/synced_hash_store_suite.go
+++ b/pkg/metadata/synced_hash_store_suite.go
@@ -319,6 +319,12 @@ func RunSyncedHashEnumeratorSuite(t *testing.T, e syncedHashEnumerating) {
 		if want, ok, err := e.GetLocator(ctx, hA); err != nil || !ok || seen[hA].loc != want {
 			t.Errorf("EnumerateSynced locator for hA = %+v; GetLocator = %+v (ok=%v err=%v)", seen[hA].loc, want, ok, err)
 		}
+		// Standalone hB: the enumerated locator must match GetLocator too. A
+		// standalone row has no block locator, so GetLocator may report ok=false;
+		// either way its locator must equal the zero locator enumeration yielded.
+		if want, _, err := e.GetLocator(ctx, hB); err != nil || seen[hB].loc != want {
+			t.Errorf("EnumerateSynced locator for standalone hB = %+v; GetLocator = %+v (err=%v)", seen[hB].loc, want, err)
+		}
 		// A backend that records timestamps must report one no earlier than
 		// the mark. A zero timestamp is the documented fail-closed signal for
 		// backends without recorded times — accept it too.

--- a/pkg/metadata/synced_hash_store_suite.go
+++ b/pkg/metadata/synced_hash_store_suite.go
@@ -252,7 +252,7 @@ func RunSyncedHashStoreSuite(t *testing.T, s SyncedHashStore) {
 // pass their concrete store; Go checks satisfaction structurally at the call.
 type syncedHashEnumerating interface {
 	SyncedHashStore
-	EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, syncedAt time.Time) error) error
+	EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, loc block.ChunkLocator, syncedAt time.Time) error) error
 }
 
 // RunSyncedHashEnumeratorSuite exercises a backend's EnumerateSynced against
@@ -266,12 +266,19 @@ func RunSyncedHashEnumeratorSuite(t *testing.T, e syncedHashEnumerating) {
 	t.Run("EnumerateSynced", func(t *testing.T) {
 		ctx := context.Background()
 		before := time.Now()
-		hA := mustHash("enum-suite-a")
-		hB := mustHash("enum-suite-b")
+		hA := mustHash("enum-suite-a") // block-resident locator
+		hB := mustHash("enum-suite-b") // standalone (pre-flip) locator
 		hGone := mustHash("enum-suite-gone")
 
-		for _, h := range []block.ContentHash{hA, hB, hGone} {
-			if err := e.MarkSynced(ctx, h, block.ChunkLocator{}); err != nil {
+		// hA carries a real block locator; hB is standalone. EnumerateSynced must
+		// yield each marker's locator (folded into the scan) identical to what
+		// GetLocator returns — the contract that lets the migration/reconcile/
+		// reclaim/compaction passes resolve locators in one scan instead of a
+		// GetLocator round trip per hash (#1554).
+		locA := block.ChunkLocator{BlockID: "enum-suite-block", WireOffset: 128, WireLength: 64}
+		marks := map[block.ContentHash]block.ChunkLocator{hA: locA, hB: {}, hGone: {}}
+		for h, loc := range marks {
+			if err := e.MarkSynced(ctx, h, loc); err != nil {
 				t.Fatalf("MarkSynced %x: %v", h[:4], err)
 			}
 		}
@@ -280,9 +287,13 @@ func RunSyncedHashEnumeratorSuite(t *testing.T, e syncedHashEnumerating) {
 			t.Fatalf("DeleteSynced: %v", err)
 		}
 
-		seen := make(map[block.ContentHash]time.Time)
-		if err := e.EnumerateSynced(ctx, func(h block.ContentHash, syncedAt time.Time) error {
-			seen[h] = syncedAt
+		type seenEntry struct {
+			loc      block.ChunkLocator
+			syncedAt time.Time
+		}
+		seen := make(map[block.ContentHash]seenEntry)
+		if err := e.EnumerateSynced(ctx, func(h block.ContentHash, loc block.ChunkLocator, syncedAt time.Time) error {
+			seen[h] = seenEntry{loc: loc, syncedAt: syncedAt}
 			return nil
 		}); err != nil {
 			t.Fatalf("EnumerateSynced: %v", err)
@@ -297,10 +308,21 @@ func RunSyncedHashEnumeratorSuite(t *testing.T, e syncedHashEnumerating) {
 		if _, ok := seen[hGone]; ok {
 			t.Errorf("EnumerateSynced yielded deleted hash hGone")
 		}
+		// The yielded locator must match GetLocator for every enumerated hash:
+		// hA resolves to its block locator, hB to the zero (standalone) locator.
+		if got := seen[hA].loc; got != locA {
+			t.Errorf("EnumerateSynced yielded locator for hA = %+v; want %+v", got, locA)
+		}
+		if got := seen[hB].loc; got != (block.ChunkLocator{}) {
+			t.Errorf("EnumerateSynced yielded locator for standalone hB = %+v; want zero", got)
+		}
+		if want, ok, err := e.GetLocator(ctx, hA); err != nil || !ok || seen[hA].loc != want {
+			t.Errorf("EnumerateSynced locator for hA = %+v; GetLocator = %+v (ok=%v err=%v)", seen[hA].loc, want, ok, err)
+		}
 		// A backend that records timestamps must report one no earlier than
 		// the mark. A zero timestamp is the documented fail-closed signal for
 		// backends without recorded times — accept it too.
-		if ts := seen[hA]; !ts.IsZero() && ts.Before(before.Add(-time.Minute)) {
+		if ts := seen[hA].syncedAt; !ts.IsZero() && ts.Before(before.Add(-time.Minute)) {
 			t.Errorf("EnumerateSynced syncedAt %v precedes mark time %v", ts, before)
 		}
 	})
@@ -308,7 +330,7 @@ func RunSyncedHashEnumeratorSuite(t *testing.T, e syncedHashEnumerating) {
 	t.Run("EnumerateSyncedCtxCancel", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		err := e.EnumerateSynced(ctx, func(block.ContentHash, time.Time) error { return nil })
+		err := e.EnumerateSynced(ctx, func(block.ContentHash, block.ChunkLocator, time.Time) error { return nil })
 		if err == nil {
 			t.Fatalf("EnumerateSynced with cancelled ctx: want error, got nil")
 		}


### PR DESCRIPTION
## Problem (#1554)

On a real sqlite-metadata + S3 deployment the server binds `:8080` but `/api/v1/health` readiness stays non-200 for **>120s** on cold start, after the #1552/#1553 deadlock fixes.

## Root cause

The one-shot cas→blocks migration's **standalone-detection scan runs on every boot, synchronously**, inside `LoadSharesFromStore → bs.Start → migrateLegacyCAS` — which precedes `go rt.Serve`'s `:8080` bind. Detection enumerated *all* synced hashes then issued **one `GetLocator` per hash** to test the locator. On sqlite (`SetMaxOpenConns(1)`) those N calls serialize on the single connection → **O(synced-hash-count) sequential statements every boot**, even on a fully-migrated share (detection is state-free by design). Until it finishes `:8080` is never bound, so the fronting LB returns 503 for readiness.

The `MaxOpenConns(1)` *deadlock* was already fixed (#1553 collect-then-query); what remained was the N+1 *cost*. This is exactly what `TestSQLiteReconcile_LocatorRoundTripsAreLinear` (added in #1556) documented and prescribed a fix for.

## Fix

Fold the locator into `EnumerateSynced`'s callback: `func(hash, syncedAt)` → `func(hash, loc block.ChunkLocator, syncedAt)`. The locator columns already live in the **same `synced_hashes` row** the scan reads, so detection — and reconcile, reclaim, compaction, the GC sweep — resolve locators in a **single scan with zero per-hash round trips**. This also removes the nested-query deadlock class *structurally* (there is no second query to nest).

- One existing-method signature change; **no new interface method** (minimize surface).
- All 4 backends (sqlite/postgres/badger/memory) yield the locator from data they already read (same row / same value / same lock).
- Migration stays synchronous/blocking — **no startup reorder, no sentinel** (detection stays state-free).
- Call sites got shorter: the collect-then-query scaffolding is gone.

## Tests

- Conformance suite (`RunSyncedHashEnumeratorSuite`, all 4 backends) now asserts the **yielded locator equals `GetLocator`** for a block-resident and a standalone hash.
- Flipped the prior N+1-documenting test to pin the fix: `TestSQLiteReconcile_LocatorResolutionIsSinglePass` asserts `enumerate == 1`, `getLocator == 0`.
- Added `TestSQLiteStartup_MigrationDetectionIsSinglePass` — reproduces the boot-critical path against a real sqlite store, asserts detection is one scan with zero `GetLocator` round trips.
- `go build ./...` + `-tags integration`, `go vet ./...`, `golangci-lint`, and `go test -race ./pkg/block/engine/... ./pkg/metadata/...` all green.

## Follow-up (not in this PR)

`gc_sweep_index.go` calls `DeleteSynced` inside the `EnumerateSynced` callback — the same nested-statement class. It is safe in production because the sweep always runs through `multiSyncedHashStore`, which buffers all rows and closes the cursor before invoking the callback. Worth a small guard test / follow-up so that implicit invariant can't be broken by a future caller passing a raw sqlite store.

Closes #1554.