### PR TITLE
fix(block): restore parallel + adaptive upload concurrency in carve path (#1432)

### DIFF
--- a/pkg/block/engine/carve_concurrency_test.go
+++ b/pkg/block/engine/carve_concurrency_test.go
@@ -1,0 +1,98 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+)
+
+// concCountingRemote wraps the memory block store and records the peak number
+// of PutBlock calls in flight at once, so a test can assert the carver actually
+// uploads blocks concurrently (#1432 — the serial carver capped this at 1).
+type concCountingRemote struct {
+	*remotememory.Store
+	mu   sync.Mutex
+	cur  int
+	peak int
+}
+
+func (c *concCountingRemote) PutBlock(ctx context.Context, blockID string, r io.Reader) error {
+	c.mu.Lock()
+	c.cur++
+	if c.cur > c.peak {
+		c.peak = c.cur
+	}
+	c.mu.Unlock()
+	// Hold the slot briefly so genuinely-concurrent PutBlocks overlap in time.
+	time.Sleep(40 * time.Millisecond)
+	c.mu.Lock()
+	c.cur--
+	c.mu.Unlock()
+	return c.Store.PutBlock(ctx, blockID, r)
+}
+
+func (c *concCountingRemote) peakInFlight() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.peak
+}
+
+// feedBlocks stores n distinct chunks each at least carveBytes, so each chunk
+// carves into its own block and carveFlush has n independent blocks to upload.
+func feedBlocks(t *testing.T, ctx context.Context, f *carveFixture, n int, carveBytes int64) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		data := bytes.Repeat([]byte(fmt.Sprintf("blk%03d-", i)), int(carveBytes))
+		f.storeChunk(t, ctx, data)
+	}
+}
+
+// TestCarve_UploadsConcurrently proves the carve path PUTs blocks in parallel
+// (the #1432 fix): with the default adaptive window the peak in-flight PutBlock
+// count exceeds 1, and a pinned window of 1 serializes it back to 1.
+func TestCarve_UploadsConcurrently(t *testing.T) {
+	const carveBytes = 64
+	const nBlocks = 8
+
+	t.Run("adaptive window uploads concurrently", func(t *testing.T) {
+		ctx := context.Background()
+		rem := &concCountingRemote{Store: remotememory.New()}
+		f := newCarveFixture(t, rem, carveBytes)
+		feedBlocks(t, ctx, f, nBlocks, carveBytes)
+
+		if err := f.syncer.carveFlush(ctx, true); err != nil {
+			t.Fatalf("carveFlush: %v", err)
+		}
+		if got := rem.peakInFlight(); got < 2 {
+			t.Fatalf("peak in-flight PutBlock = %d, want >= 2 (carver must upload concurrently)", got)
+		}
+		if got := countRemoteBlocks(t, ctx, rem.Store); got != nBlocks {
+			t.Fatalf("remote blocks = %d, want %d", got, nBlocks)
+		}
+	})
+
+	t.Run("pinned window of 1 serializes", func(t *testing.T) {
+		ctx := context.Background()
+		rem := &concCountingRemote{Store: remotememory.New()}
+		f := newCarveFixture(t, rem, carveBytes)
+		// Pin the upload window to 1: carveFlush must never run two PutBlocks at once.
+		f.syncer.uploadLimiter = newDynamicSemaphore(1)
+		feedBlocks(t, ctx, f, nBlocks, carveBytes)
+
+		if err := f.syncer.carveFlush(ctx, true); err != nil {
+			t.Fatalf("carveFlush: %v", err)
+		}
+		if got := rem.peakInFlight(); got != 1 {
+			t.Fatalf("peak in-flight PutBlock = %d, want 1 (pinned window must serialize)", got)
+		}
+		if got := countRemoteBlocks(t, ctx, rem.Store); got != nBlocks {
+			t.Fatalf("remote blocks = %d, want %d", got, nBlocks)
+		}
+	})
+}

--- a/pkg/block/engine/carver.go
+++ b/pkg/block/engine/carver.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	gosync "sync"
+	"sync/atomic"
 	"time"
 
 	"lukechampine.com/blake3"
@@ -111,25 +113,87 @@ func (m *Syncer) carveFlush(ctx context.Context, drainAll bool) error {
 		// condition honestly.
 		return nil
 	}
+	// Created outside carveMu to avoid a carveMu→m.mu nesting; idempotent.
+	m.ensureUploadLimiter()
+
 	m.carveMu.Lock()
 	defer m.carveMu.Unlock()
 
 	target := m.carveBlockSize()
+
+	var (
+		wg       gosync.WaitGroup
+		errOnce  gosync.Once
+		firstErr error
+		failed   atomic.Bool
+	)
+	fail := func(err error) {
+		errOnce.Do(func() { firstErr = err })
+		failed.Store(true)
+	}
+
 	for {
 		if err := ctx.Err(); err != nil {
-			return err
+			fail(err)
+			break
+		}
+		// Stop claiming more once any in-flight block failed: a failing remote
+		// should not keep draining the queue this pass (it retries next pass).
+		if failed.Load() {
+			break
 		}
 		batch, batchBytes := m.claimCarveBatch(target, drainAll)
 		if len(batch) == 0 {
-			return nil
+			break
 		}
-		if err := m.carveAndCommitBlock(ctx, batch, batchBytes); err != nil {
-			// Return the batch to the queue for a later retry and surface the
-			// error so an explicit Flush reports non-durability.
+		// Bound concurrent PutBlocks by the pinned or adaptive window. Acquire
+		// blocks for a slot and returns ctx.Err() on cancellation, so a
+		// cancelled flush stops dispatching without stranding the claimed batch.
+		if err := m.uploadLimiter.Acquire(ctx); err != nil {
 			m.requeueCarveBatch(batch)
-			return err
+			fail(err)
+			break
 		}
+		wg.Add(1)
+		go func(batch []block.ContentHash, batchBytes int64) {
+			defer wg.Done()
+			defer m.uploadLimiter.Release()
+			// Each block is independent — distinct chunks, a fresh random
+			// blockID, an idempotent PutBlock, an atomic per-block commit — so
+			// blocks carve and upload concurrently. claimCarveBatch and
+			// requeueCarveBatch serialize carveQ under pendingMu; carveMu (held
+			// by the parent) serializes whole flushes so a background pass and an
+			// explicit Flush never build a block from the same chunk twice.
+			if err := m.carveAndCommitBlock(ctx, batch, batchBytes); err != nil {
+				// Return the batch to the queue for a later retry and surface the
+				// first error so an explicit Flush reports non-durability.
+				m.requeueCarveBatch(batch)
+				fail(err)
+			}
+		}(batch, batchBytes)
 	}
+	// Block until every dispatched block is durable (or errored). Flush/SyncNow
+	// must not report success while a PutBlock is still in flight.
+	wg.Wait()
+	return firstErr
+}
+
+// ensureUploadLimiter lazily creates the upload limiter for Syncers built
+// directly (test fixtures) rather than via NewSyncer, which always wires it. A
+// fixture has no adaptive control goroutine, so the limiter holds a fixed
+// window: the pinned ParallelUploads if set, else the adaptive ceiling so
+// fixtures still get full concurrency. Idempotent under m.mu.
+func (m *Syncer) ensureUploadLimiter() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.uploadLimiter != nil {
+		return
+	}
+	start := m.config.ParallelUploads
+	if start <= 0 {
+		start = AdaptiveUploadCeiling
+	}
+	m.uploadLimiter = newDynamicSemaphore(start)
 }
 
 // claimCarveBatch pops chunks from the carve FIFO (validating against the
@@ -398,8 +462,14 @@ func (m *Syncer) carveAndCommitBlock(ctx context.Context, batch []block.ContentH
 	}
 	if err != nil {
 		m.failedSyncs.Add(1)
+		// Feed the adaptive controller: an upload error this interval signals
+		// server pushback, so the controller backs the window off next tick.
+		m.uploadErrWindow.Add(1)
 		return fmt.Errorf("carve: put block %s: %w", blockID, err)
 	}
+	// Count delivered bytes for the adaptive controller's goodput sample. The
+	// control goroutine swaps this to zero each tick to compute bytes/sec.
+	m.uploadedBytesWindow.Add(int64(len(blockBytes)))
 
 	rec := block.BlockRecord{
 		BlockID:        blockID,

--- a/pkg/block/engine/dynsem.go
+++ b/pkg/block/engine/dynsem.go
@@ -1,0 +1,142 @@
+package engine
+
+import (
+	"context"
+	gosync "sync"
+)
+
+// dynamicSemaphore is a counting semaphore whose limit can change while slots
+// are held. The adaptive upload controller (#1407) resizes it every control
+// interval, so the fixed-size golang.org/x/sync/semaphore.Weighted (size set at
+// construction) does not fit. Growing the limit wakes blocked Acquire callers
+// immediately; shrinking never preempts existing holders — it only withholds
+// new slots until in-flight falls below the new limit.
+//
+// It is also context-aware: Acquire returns ctx.Err() if the context is
+// cancelled while waiting, so a failing/cancelled mirror pass does not strand a
+// goroutine on a slot that will never free.
+type dynamicSemaphore struct {
+	mu       gosync.Mutex
+	cond     *gosync.Cond
+	limit    int
+	inflight int
+	peak     int // high-water mark of inflight since the last TakePeak
+}
+
+func newDynamicSemaphore(limit int) *dynamicSemaphore {
+	if limit < 1 {
+		limit = 1
+	}
+	s := &dynamicSemaphore{limit: limit}
+	s.cond = gosync.NewCond(&s.mu)
+	return s
+}
+
+// Acquire blocks until a slot is available or ctx is done. On ctx cancellation
+// it returns ctx.Err() without consuming a slot.
+func (s *dynamicSemaphore) Acquire(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	// Fast path: a slot is free now — take it without parking or spawning a
+	// cancellation watcher. This is the common case in the mirror loop (one
+	// Acquire per chunk), so it must not allocate a goroutine per call.
+	if s.inflight < s.limit {
+		s.inflight++
+		if s.inflight > s.peak {
+			s.peak = s.inflight
+		}
+		s.mu.Unlock()
+		return nil
+	}
+	s.mu.Unlock()
+
+	// Slow path: park on the cond. A watcher wakes us if ctx is cancelled while
+	// parked. It broadcasts UNDER s.mu so the wakeup cannot fire in the gap
+	// between our ctx re-check and cond.Wait — Wait atomically releases s.mu, so
+	// holding the lock around Broadcast serializes it against that window and
+	// prevents a lost wakeup. The watcher lives only for this wait.
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.mu.Lock()
+			s.cond.Broadcast()
+			s.mu.Unlock()
+		case <-done:
+		}
+	}()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for s.inflight >= s.limit {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		s.cond.Wait()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.inflight++
+	if s.inflight > s.peak {
+		s.peak = s.inflight
+	}
+	return nil
+}
+
+// TakePeak returns the high-water mark of in-flight slots since the last call
+// and resets it to the current in-flight count. The adaptive controller uses it
+// to tell window-limited intervals (peak reached the limit) from app-limited
+// ones (peak stayed below it) — see goodputController.observe.
+func (s *dynamicSemaphore) TakePeak() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p := s.peak
+	s.peak = s.inflight
+	return p
+}
+
+// Release returns a slot and wakes waiters. Broadcast (not Signal) under the
+// lock: a woken waiter may bail on a cancelled context without consuming the
+// freed slot, so waking exactly one risks stranding it — Broadcast lets the
+// next live waiter take the slot. Signalling under s.mu serializes it against a
+// waiter's ctx-check/Wait window (no lost wakeup).
+func (s *dynamicSemaphore) Release() {
+	s.mu.Lock()
+	if s.inflight > 0 {
+		s.inflight--
+	}
+	s.cond.Broadcast()
+	s.mu.Unlock()
+}
+
+// SetLimit changes the maximum concurrency. Growing wakes blocked waiters;
+// shrinking takes effect for future acquires only (current holders run to
+// completion).
+func (s *dynamicSemaphore) SetLimit(n int) {
+	if n < 1 {
+		n = 1
+	}
+	s.mu.Lock()
+	s.limit = n
+	s.cond.Broadcast()
+	s.mu.Unlock()
+}
+
+// Limit returns the current maximum concurrency.
+func (s *dynamicSemaphore) Limit() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.limit
+}
+
+// InFlight returns the number of currently held slots.
+func (s *dynamicSemaphore) InFlight() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.inflight
+}

--- a/pkg/block/engine/dynsem_test.go
+++ b/pkg/block/engine/dynsem_test.go
@@ -1,0 +1,187 @@
+package engine
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// dynamicSemaphore is the concurrency primitive the adaptive upload controller
+// resizes at runtime. golang.org/x/sync/semaphore fixes its size at
+// construction, so the syncer needs one whose limit can grow and shrink while
+// slots are held. These tests pin the contract independently of the syncer.
+
+func TestDynamicSemaphore_BlocksAtLimit(t *testing.T) {
+	s := newDynamicSemaphore(2)
+	ctx := context.Background()
+	if err := s.Acquire(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Acquire(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if s.InFlight() != 2 {
+		t.Fatalf("InFlight = %d, want 2", s.InFlight())
+	}
+
+	// Third acquire must block until a slot frees.
+	acquired := make(chan struct{})
+	go func() {
+		_ = s.Acquire(ctx)
+		close(acquired)
+	}()
+	select {
+	case <-acquired:
+		t.Fatal("third Acquire returned while at limit")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	s.Release()
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("Acquire did not unblock after Release")
+	}
+}
+
+func TestDynamicSemaphore_GrowUnblocksWaiter(t *testing.T) {
+	s := newDynamicSemaphore(1)
+	ctx := context.Background()
+	if err := s.Acquire(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	acquired := make(chan struct{})
+	go func() {
+		_ = s.Acquire(ctx)
+		close(acquired)
+	}()
+	// Waiter is blocked at limit 1.
+	select {
+	case <-acquired:
+		t.Fatal("Acquire returned before grow")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Raising the limit must wake the waiter without any Release.
+	s.SetLimit(2)
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("grow did not unblock the waiter")
+	}
+}
+
+func TestDynamicSemaphore_ShrinkHoldsNewAcquires(t *testing.T) {
+	s := newDynamicSemaphore(4)
+	ctx := context.Background()
+	for i := 0; i < 4; i++ {
+		if err := s.Acquire(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Shrink below the in-flight count. Existing holders are not preempted, but
+	// no new slot may be handed out until in-flight drops below the new limit.
+	s.SetLimit(2)
+	if s.Limit() != 2 {
+		t.Fatalf("Limit = %d, want 2", s.Limit())
+	}
+
+	acquired := make(chan struct{})
+	go func() {
+		_ = s.Acquire(ctx)
+		close(acquired)
+	}()
+	// 4 in-flight, limit 2: releasing one (→3) must NOT admit the waiter.
+	s.Release()
+	select {
+	case <-acquired:
+		t.Fatal("Acquire admitted while in-flight (3) still above limit (2)")
+	case <-time.After(50 * time.Millisecond):
+	}
+	// Release two more (→1, below limit 2): now the waiter may proceed.
+	s.Release()
+	s.Release()
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("Acquire did not proceed after in-flight fell below limit")
+	}
+}
+
+func TestDynamicSemaphore_TakePeakTracksHighWater(t *testing.T) {
+	s := newDynamicSemaphore(8)
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		if err := s.Acquire(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Peak reached 5 even though we now release down to 2.
+	s.Release()
+	s.Release()
+	s.Release()
+	if p := s.TakePeak(); p != 5 {
+		t.Fatalf("TakePeak = %d, want high-water 5", p)
+	}
+	// After TakePeak the high-water resets to the current in-flight (2).
+	if p := s.TakePeak(); p != 2 {
+		t.Fatalf("TakePeak after reset = %d, want current in-flight 2", p)
+	}
+}
+
+func TestDynamicSemaphore_AcquireRespectsContext(t *testing.T) {
+	s := newDynamicSemaphore(1)
+	if err := s.Acquire(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	errc := make(chan error, 1)
+	go func() { errc <- s.Acquire(ctx) }()
+	cancel()
+	select {
+	case err := <-errc:
+		if err == nil {
+			t.Fatal("Acquire returned nil after context cancel")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Acquire did not return after context cancel")
+	}
+}
+
+func TestDynamicSemaphore_ConcurrentNeverExceedsLimit(t *testing.T) {
+	const limit = 5
+	s := newDynamicSemaphore(limit)
+	ctx := context.Background()
+	var (
+		mu      sync.Mutex
+		inFlt   int
+		maxSeen int
+		wg      sync.WaitGroup
+	)
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := s.Acquire(ctx); err != nil {
+				return
+			}
+			mu.Lock()
+			inFlt++
+			if inFlt > maxSeen {
+				maxSeen = inFlt
+			}
+			mu.Unlock()
+			time.Sleep(time.Millisecond)
+			mu.Lock()
+			inFlt--
+			mu.Unlock()
+			s.Release()
+		}()
+	}
+	wg.Wait()
+	if maxSeen > limit {
+		t.Fatalf("observed %d concurrent holders, limit was %d", maxSeen, limit)
+	}
+}

--- a/pkg/block/engine/metrics.go
+++ b/pkg/block/engine/metrics.go
@@ -17,6 +17,12 @@ type DataplaneMetrics interface {
 	UploadFinished()
 	// SetUploadQueueDepth publishes the pending-carve backlog.
 	SetUploadQueueDepth(n int)
+	// SetUploadWindow publishes the target upload concurrency — the pinned
+	// parallel_uploads value or the adaptive controller's current window (#1407).
+	SetUploadWindow(n int)
+	// SetUploadGoodput publishes the delivered bytes/sec the adaptive controller
+	// measured over the last control interval (#1407).
+	SetUploadGoodput(bytesPerSec float64)
 
 	// --- Corruption detection / self-heal (read path) ---
 	// All five counters are BOUNDED zero-label counters: no per-share, per-

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -101,6 +101,23 @@ type Syncer struct {
 	completedSyncs atomic.Int64
 	failedSyncs    atomic.Int64
 
+	// uploadLimiter bounds concurrent block PUTs in carveFlush (#1407 / #1432).
+	// When ParallelUploads is pinned (> 0) its limit is fixed at that value.
+	// When unset (adaptive mode) the uploadController resizes it every control
+	// interval to track the goodput knee. Lazily created by ensureUploadLimiter
+	// so directly-built test fixtures still get bounded concurrency.
+	uploadLimiter *dynamicSemaphore
+	// uploadController is non-nil only in adaptive mode. It consumes one
+	// (goodput, windowLimited, sawError) sample per control interval and returns
+	// the next target window, applied to uploadLimiter by the control goroutine.
+	uploadController *goodputController
+	// uploadedBytesWindow accumulates bytes successfully PutBlock'd since the
+	// last control tick; uploadErrWindow counts block-upload errors in the same
+	// span. The control goroutine swaps both to zero each tick to compute the
+	// goodput sample and the error flag. Plain atomics — no lock needed.
+	uploadedBytesWindow atomic.Int64
+	uploadErrWindow     atomic.Int64
+
 	// --- block carve path (#1414 object packing) ---
 
 	// remoteBlockStore is the block-keyed remote (PutBlock) the carver uploads
@@ -288,6 +305,18 @@ func NewSyncer(local local.LocalStore, remoteStore remote.RemoteStore, fileChunk
 		config.ClaimTimeout = 10 * time.Minute
 	}
 
+	// Upload concurrency (#1407 / #1432): a pinned ParallelUploads > 0 fixes the
+	// window; otherwise (the default) the carver auto-tunes between the adaptive
+	// floor and ceiling. The limiter starts at the floor in adaptive mode and at
+	// the pinned value otherwise; the control goroutine (adaptive only, launched
+	// in Start) resizes it at runtime.
+	var uploadController *goodputController
+	startWindow := config.ParallelUploads
+	if config.ParallelUploads <= 0 {
+		startWindow = AdaptiveUploadFloor
+		uploadController = newGoodputController(AdaptiveUploadFloor, AdaptiveUploadCeiling)
+	}
+
 	m := &Syncer{
 		local:          local,
 		remoteStore:    remoteStore,
@@ -295,6 +324,9 @@ func NewSyncer(local local.LocalStore, remoteStore remote.RemoteStore, fileChunk
 		config:         config,
 		inFlight:       make(map[string]*fetchResult),
 		stopCh:         make(chan struct{}),
+
+		uploadLimiter:    newDynamicSemaphore(startWindow),
+		uploadController: uploadController,
 
 		pendingCarveHashes: make(map[block.ContentHash]int64),
 		carveWake:          make(chan struct{}, 1),
@@ -810,6 +842,76 @@ func (m *Syncer) startPeriodicUploader(ctx context.Context) {
 	// (FileChunk metadata flush, drift reconcile) the dispatcher does not.
 	go m.maintenanceLoop(ctx, interval)
 	go m.carveDispatcher(ctx)
+
+	// Adaptive mode (ParallelUploads unset): launch the goodput controller that
+	// resizes the upload window to saturate the uplink (#1407). Pinned
+	// --parallel-uploads leaves uploadController nil and keeps the fixed window;
+	// publish it once so the gauge reflects it instead of reading 0.
+	if m.uploadController != nil {
+		go m.runUploadController(ctx, uploadControlInterval)
+	} else if mx := m.dataplaneMetrics(); mx != nil && m.uploadLimiter != nil {
+		mx.SetUploadWindow(m.uploadLimiter.Limit())
+	}
+}
+
+// runUploadController is the adaptive upload-concurrency control loop (#1407).
+// Every interval it turns the bytes/error accumulated by carveAndCommitBlock
+// into a goodput sample, feeds the goodputController, and applies the returned
+// window to the shared uploadLimiter. Runs only in adaptive mode (controller
+// non-nil). Idle intervals (no bytes, nothing in flight, no error) are skipped
+// so a write pause is not misread as a goodput collapse.
+func (m *Syncer) runUploadController(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	// Publish the starting window so the gauge is populated before the first
+	// adjustment.
+	if mx := m.dataplaneMetrics(); mx != nil {
+		mx.SetUploadWindow(m.uploadLimiter.Limit())
+	}
+	seconds := interval.Seconds()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-m.stopCh:
+			return
+		case <-ticker.C:
+			m.adaptiveUploadTick(seconds)
+		}
+	}
+}
+
+// adaptiveUploadTick converts one control interval's accumulated bytes and
+// error flag into a goodput sample, feeds the controller, and applies the
+// resulting window to the upload limiter. Extracted from the goroutine loop so
+// the bytes→goodput→window glue is unit-testable without a clock. intervalSec
+// is the control interval in seconds.
+func (m *Syncer) adaptiveUploadTick(intervalSec float64) {
+	bytes := m.uploadedBytesWindow.Swap(0)
+	sawErr := m.uploadErrWindow.Swap(0) > 0
+	// Peak in-flight over the interval distinguishes window-limited from
+	// app-limited: uploads that filled the window mean goodput reflects the
+	// window; otherwise the upstream carve pipeline was the constraint (see
+	// goodputController.observe).
+	peak := m.uploadLimiter.TakePeak()
+	windowLimited := peak >= m.uploadLimiter.Limit()
+
+	if bytes == 0 && peak == 0 && !sawErr {
+		// Idle interval: no control decision, but publish an honest zero so the
+		// goodput gauge does not freeze at the last active sample.
+		if mx := m.dataplaneMetrics(); mx != nil {
+			mx.SetUploadGoodput(0)
+		}
+		return
+	}
+
+	goodput := float64(bytes) / intervalSec
+	window := m.uploadController.observe(goodput, windowLimited, sawErr)
+	m.uploadLimiter.SetLimit(window)
+	if mx := m.dataplaneMetrics(); mx != nil {
+		mx.SetUploadWindow(window)
+		mx.SetUploadGoodput(goodput)
+	}
 }
 
 // maintenanceLoop runs the slow periodic housekeeping that the steady-state

--- a/pkg/block/engine/types.go
+++ b/pkg/block/engine/types.go
@@ -32,9 +32,10 @@ const DefaultBlockCarveBytes int64 = 16 << 20
 // a fixed window. Block PUTs are network-latency bound, so a serial carver leaves
 // the link idle — one in-flight PutBlock sustained only ~200 Mbit/s VM→fr-par.
 const (
-	AdaptiveUploadFloor   = 16 // starting window in adaptive mode (greedy start)
-	AdaptiveUploadCeiling = 64 // max window the adaptive controller ramps to
-	AdaptiveUploadDefault = 0  // ParallelUploads sentinel: 0 = adaptive auto-tune
+	AdaptiveUploadFloor   = 16  // starting window in adaptive mode (greedy start)
+	AdaptiveUploadCeiling = 64  // max window the adaptive controller ramps to
+	AdaptiveUploadDefault = 0   // ParallelUploads sentinel: 0 = adaptive auto-tune
+	MaxParallelUploads    = 256 // upper bound on a pinned ParallelUploads window
 )
 
 // uploadControlInterval is how often the adaptive controller samples goodput and

--- a/pkg/block/engine/types.go
+++ b/pkg/block/engine/types.go
@@ -25,6 +25,22 @@ const DefaultParallelDownloads = 32
 // small enough to cap the carver's per-block RAM and keep ranged reads cheap.
 const DefaultBlockCarveBytes int64 = 16 << 20
 
+// Adaptive upload-concurrency bounds (#1407). When SyncerConfig.ParallelUploads
+// is unset (0), the carver auto-tunes concurrent block PUTs to saturate the
+// uplink: it starts at AdaptiveUploadFloor and ramps toward AdaptiveUploadCeiling,
+// settling at the goodput knee. A pinned ParallelUploads > 0 overrides this with
+// a fixed window. Block PUTs are network-latency bound, so a serial carver leaves
+// the link idle — one in-flight PutBlock sustained only ~200 Mbit/s VM→fr-par.
+const (
+	AdaptiveUploadFloor   = 16 // starting window in adaptive mode (greedy start)
+	AdaptiveUploadCeiling = 64 // max window the adaptive controller ramps to
+	AdaptiveUploadDefault = 0  // ParallelUploads sentinel: 0 = adaptive auto-tune
+)
+
+// uploadControlInterval is how often the adaptive controller samples goodput and
+// resizes the upload window (#1407).
+const uploadControlInterval = 500 * time.Millisecond
+
 // DefaultPrefetchBlocks is the default number of blocks to prefetch.
 // 64 blocks = 512MB lookahead at 8MB block size.
 const DefaultPrefetchBlocks = 64
@@ -75,6 +91,14 @@ type SyncerConfig struct {
 	// carver buffers at most one block (this many bytes) in RAM at a time.
 	BlockCarveBytes int64
 
+	// ParallelUploads bounds concurrent block PUTs from the carver (#1407 /
+	// #1432). 0 (the default, AdaptiveUploadDefault) means the carver auto-tunes
+	// the window between AdaptiveUploadFloor and AdaptiveUploadCeiling to
+	// saturate the uplink; > 0 pins a fixed window (from the per-remote
+	// parallel_uploads config / --parallel-uploads). A serial carver (window 1)
+	// leaves a WAN link idle, which is the #1432 upload-throughput regression.
+	ParallelUploads int
+
 	// ManualSync, when true, suppresses the background carve dispatcher.
 	// Durability is then driven solely by explicit Flush, making Flush the
 	// single deterministic durability driver. Off by default; used where a
@@ -104,6 +128,7 @@ func DefaultConfig() SyncerConfig {
 		UploadInterval:              2 * time.Second,
 		UploadDelay:                 10 * time.Second,
 		BlockCarveBytes:             DefaultBlockCarveBytes,
+		ParallelUploads:             AdaptiveUploadDefault,
 		HealthCheckInterval:         30 * time.Second,
 		HealthCheckFailureThreshold: 3,
 		UnhealthyCheckInterval:      5 * time.Second,

--- a/pkg/block/engine/upload_controller.go
+++ b/pkg/block/engine/upload_controller.go
@@ -1,0 +1,157 @@
+package engine
+
+import "math"
+
+// goodputController is the pure decision core of adaptive upload concurrency
+// (#1407). When the user does not pin --parallel-uploads, the syncer ramps the
+// number of concurrent CAS-chunk uploads to saturate the uplink on its own.
+//
+// The control signal is GOODPUT (delivered bytes/sec), not latency. An earlier
+// latency-gradient design (#1400) read the per-PUT latency rise *caused by
+// useful concurrency* as congestion and collapsed the window to ~4, far below
+// the bandwidth knee. Uploads here are network-latency bound, so opening more
+// connections raises both latency and throughput together until the link
+// saturates — the only honest saturation signal is "did goodput stop rising".
+//
+// The loop is TCP-slow-start-like: start at a floor, ramp multiplicatively
+// while goodput keeps improving, hold when it plateaus, settle at the window
+// that delivered the best goodput (the knee), and back off only on upload
+// errors or a goodput collapse. It is deterministic and depends on no clock,
+// network, or goroutine, so its behaviour is pinned entirely by unit tests.
+type goodputController struct {
+	floor   int
+	ceiling int
+
+	cur        int     // current target concurrency
+	bestWindow int     // window that delivered bestGoodput (the knee)
+	best       float64 // best smoothed goodput seen so far
+	ema        float64 // EWMA-smoothed goodput
+	emaInit    bool
+	stall      int // consecutive samples without a meaningful improvement
+
+	// Tunables. Defaults chosen for the S3 upload path (see newGoodputController).
+	rampFactor    float64 // multiplicative window increase while improving
+	backoffFactor float64 // multiplicative decrease on error / collapse
+	improveFrac   float64 // min relative goodput gain that counts as "improving"
+	collapseFrac  float64 // goodput below best*collapseFrac is treated as collapse
+	emaAlpha      float64 // EWMA weight on the newest sample
+	stallLimit    int     // plateau samples before settling at the knee
+}
+
+// newGoodputController returns a controller that ramps within [floor, ceiling].
+func newGoodputController(floor, ceiling int) *goodputController {
+	if floor < 1 {
+		floor = 1
+	}
+	if ceiling < floor {
+		ceiling = floor
+	}
+	return &goodputController{
+		floor:         floor,
+		ceiling:       ceiling,
+		cur:           floor,
+		bestWindow:    floor,
+		rampFactor:    1.5,
+		backoffFactor: 0.7,
+		improveFrac:   0.10,
+		collapseFrac:  0.5,
+		emaAlpha:      0.5,
+		stallLimit:    3,
+	}
+}
+
+// window returns the current target concurrency.
+func (c *goodputController) window() int { return c.cur }
+
+// observe feeds one control-interval sample and returns the next target window.
+// goodput is the delivered bytes/sec over the interval; windowLimited is true
+// when the window was actually saturated during the interval (in-flight uploads
+// reached the limit); sawError is true if any upload failed.
+//
+// windowLimited is the crux. Goodput only carries information about the window
+// when the window is the binding constraint. When it is NOT — the upstream
+// rollup pipeline produced fewer chunks than the window could carry — goodput
+// is app-limited, and reacting to it would shrink the window precisely when the
+// pipeline is about to burst a backlog that a wide window must drain fast. The
+// bursty rollup→upload pipeline does exactly this, so the controller only ramps
+// or backs off on window-limited samples and otherwise holds (#1407).
+func (c *goodputController) observe(goodput float64, windowLimited, sawError bool) int {
+	// Smooth the (noisy) per-interval goodput before any decision.
+	if !c.emaInit {
+		c.ema = goodput
+		c.emaInit = true
+	} else {
+		c.ema = c.emaAlpha*goodput + (1-c.emaAlpha)*c.ema
+	}
+
+	switch {
+	case sawError && windowLimited:
+		// Server pushback / overload while the window was the binding constraint.
+		// Shrink and re-probe later. Decay the best reference too so recovery is
+		// judged against the post-backoff regime rather than an unreachable peak.
+		c.shrink()
+		c.best *= c.backoffFactor
+
+	case !windowLimited:
+		// App-limited: the upstream pipeline, not the window, capped goodput.
+		// Hold the window — there is no congestion signal, and shrinking would
+		// throttle the drain the moment upstream catches up. A stray error here
+		// (e.g. one chunk failing during a low-trickle phase) is NOT treated as
+		// congestion: the window had nothing to do with it, so corrupting the
+		// learned knee over it would needlessly deflate the next burst.
+		return c.cur
+
+	case c.best > 0 && goodput < c.best*c.collapseFrac:
+		// Goodput fell sharply below the best we have seen with no explicit
+		// error — treat as congestion collapse and back off. This branch reads
+		// the RAW sample, not the EWMA: a real collapse must be reacted to
+		// immediately (AIMD-style), whereas the improvement branch below stays
+		// smoothed so transient noise does not drive the window up.
+		c.shrink()
+
+	case c.ema > c.best*(1+c.improveFrac):
+		// Still climbing: record the knee-so-far and open the window further.
+		c.best = c.ema
+		c.bestWindow = c.cur
+		c.stall = 0
+		c.grow()
+
+	default:
+		// Plateau: goodput is not meaningfully better than the best seen. Hold,
+		// and after enough flat samples settle back at the knee (the smallest
+		// window that delivered near-peak goodput — less resource use for the
+		// same throughput).
+		if c.ema > c.best {
+			c.best = c.ema
+		}
+		c.stall++
+		if c.stall >= c.stallLimit {
+			c.cur = c.bestWindow
+		}
+	}
+	return c.cur
+}
+
+func (c *goodputController) grow() {
+	next := int(math.Ceil(float64(c.cur) * c.rampFactor))
+	if next <= c.cur {
+		next = c.cur + 1
+	}
+	if next > c.ceiling {
+		next = c.ceiling
+	}
+	c.cur = next
+}
+
+func (c *goodputController) shrink() {
+	next := int(math.Round(float64(c.cur) * c.backoffFactor))
+	if next >= c.cur {
+		next = c.cur - 1
+	}
+	if next < c.floor {
+		next = c.floor
+	}
+	c.cur = next
+	c.bestWindow = next
+	c.stall = 0
+}

--- a/pkg/block/engine/upload_controller.go
+++ b/pkg/block/engine/upload_controller.go
@@ -3,8 +3,9 @@ package engine
 import "math"
 
 // goodputController is the pure decision core of adaptive upload concurrency
-// (#1407). When the user does not pin --parallel-uploads, the syncer ramps the
-// number of concurrent CAS-chunk uploads to saturate the uplink on its own.
+// (#1407 / #1432). When the user does not pin parallel_uploads, the syncer ramps
+// the number of concurrent block PutBlock uploads in the carve path to saturate
+// the uplink on its own.
 //
 // The control signal is GOODPUT (delivered bytes/sec), not latency. An earlier
 // latency-gradient design (#1400) read the per-PUT latency rise *caused by

--- a/pkg/block/engine/upload_controller_test.go
+++ b/pkg/block/engine/upload_controller_test.go
@@ -1,0 +1,182 @@
+package engine
+
+import "testing"
+
+// The goodput controller is the pure decision core of adaptive upload
+// concurrency (#1407). It consumes one (goodput, sawError) sample per control
+// interval and returns the next target window. It must:
+//   - start at the floor,
+//   - ramp up while delivered goodput keeps improving (TCP-slow-start-like),
+//   - settle at the knee once goodput stops improving (no endless growth),
+//   - back off on upload errors or a goodput collapse,
+//   - never leave [floor, ceiling].
+//
+// These tests pin the algorithm independently of any network, goroutine, or
+// clock, so a regression in the math is caught here rather than only on the VM.
+
+func TestGoodputController_StartsAtFloor(t *testing.T) {
+	c := newGoodputController(8, 64)
+	if got := c.window(); got != 8 {
+		t.Fatalf("initial window = %d, want floor 8", got)
+	}
+}
+
+func TestGoodputController_RampsUpWhileGoodputImproves(t *testing.T) {
+	c := newGoodputController(8, 64)
+	// Each wider window delivers strictly more goodput: the link is not yet
+	// saturated, so the controller must keep opening the window.
+	prev := c.window()
+	goodput := 10.0
+	for i := 0; i < 8; i++ {
+		w := c.observe(goodput, true, false)
+		if w < prev {
+			t.Fatalf("sample %d: window shrank (%d -> %d) while goodput rising", i, prev, w)
+		}
+		prev = w
+		goodput *= 2 // keep improving well above the noise threshold
+		if w >= 64 {
+			break // reached the ceiling; cannot grow further
+		}
+	}
+	if prev <= 8 {
+		t.Fatalf("window stayed at floor despite rising goodput: %d", prev)
+	}
+}
+
+func TestGoodputController_SettlesAtKneeWhenGoodputPlateaus(t *testing.T) {
+	c := newGoodputController(8, 64)
+	// Phase 1: goodput climbs, window ramps.
+	c.observe(10, true, false)
+	c.observe(20, true, false)
+	c.observe(30, true, false)
+	peak := c.window()
+	// Phase 2: goodput flat (link saturated). The window must stop growing and
+	// converge — it must NOT keep climbing to the ceiling on a saturated link.
+	var last int
+	for i := 0; i < 8; i++ {
+		last = c.observe(30, true, false)
+	}
+	if last > peak {
+		t.Fatalf("window kept growing past the knee on flat goodput: peak=%d last=%d", peak, last)
+	}
+	// And it must have converged (a second identical run of samples is stable).
+	stable := c.observe(30, true, false)
+	if stable != last {
+		t.Fatalf("window not converged on flat goodput: %d then %d", last, stable)
+	}
+}
+
+func TestGoodputController_DoesNotExceedCeiling(t *testing.T) {
+	c := newGoodputController(8, 32)
+	// Goodput improves forever; only the ceiling should stop the ramp.
+	goodput := 10.0
+	for i := 0; i < 20; i++ {
+		w := c.observe(goodput, true, false)
+		if w > 32 {
+			t.Fatalf("window exceeded ceiling: %d", w)
+		}
+		goodput *= 1.5
+	}
+	if c.window() != 32 {
+		t.Fatalf("window did not reach ceiling under unbounded goodput: %d", c.window())
+	}
+}
+
+func TestGoodputController_BacksOffOnError(t *testing.T) {
+	c := newGoodputController(8, 64)
+	// Ramp up first.
+	c.observe(10, true, false)
+	c.observe(20, true, false)
+	c.observe(40, true, false)
+	high := c.window()
+	if high <= 8 {
+		t.Fatalf("precondition: window should have ramped, got %d", high)
+	}
+	// An upload error must shrink the window (server pushback / overload).
+	after := c.observe(40, true, true)
+	if after >= high {
+		t.Fatalf("window did not back off on error: %d -> %d", high, after)
+	}
+}
+
+func TestGoodputController_BacksOffOnGoodputCollapse(t *testing.T) {
+	c := newGoodputController(8, 64)
+	c.observe(10, true, false)
+	c.observe(40, true, false)
+	c.observe(80, true, false)
+	high := c.window()
+	// Goodput collapses to a fraction of the best seen (congestion), no explicit
+	// error. The controller must still shrink.
+	after := c.observe(10, true, false)
+	if after >= high {
+		t.Fatalf("window did not back off on goodput collapse: %d -> %d", high, after)
+	}
+}
+
+func TestGoodputController_NeverBelowFloor(t *testing.T) {
+	c := newGoodputController(8, 64)
+	c.observe(50, true, false)
+	// Hammer it with errors; it must never drop below the floor.
+	for i := 0; i < 20; i++ {
+		w := c.observe(1, true, true)
+		if w < 8 {
+			t.Fatalf("window dropped below floor: %d", w)
+		}
+	}
+}
+
+func TestGoodputController_HoldsWindowWhenAppLimited(t *testing.T) {
+	c := newGoodputController(8, 64)
+	// Ramp up while window-limited.
+	c.observe(10, true, false)
+	c.observe(20, true, false)
+	c.observe(40, true, false)
+	high := c.window()
+	if high <= 8 {
+		t.Fatalf("precondition: expected ramp, got %d", high)
+	}
+	// Now the upstream pipeline starves the uploader: goodput collapses but the
+	// window was NOT the constraint (app-limited). The controller must HOLD the
+	// window — shrinking here would cripple throughput the moment upstream
+	// catches up (the bursty rollup→upload pipeline does exactly this, #1407).
+	for i := 0; i < 5; i++ {
+		w := c.observe(1, false, false) // low goodput, app-limited
+		if w != high {
+			t.Fatalf("app-limited sample %d moved the window: %d -> %d", i, high, w)
+		}
+	}
+}
+
+func TestGoodputController_HoldsOnErrorWhenAppLimited(t *testing.T) {
+	c := newGoodputController(8, 64)
+	// Ramp up while window-limited.
+	c.observe(10, true, false)
+	c.observe(20, true, false)
+	c.observe(40, true, false)
+	high := c.window()
+	if high <= 8 {
+		t.Fatalf("precondition: expected ramp, got %d", high)
+	}
+	// A stray error during an app-limited interval (window was NOT the
+	// constraint) must NOT shrink the window or corrupt the learned knee — that
+	// would needlessly deflate the next burst.
+	after := c.observe(1, false, true)
+	if after != high {
+		t.Fatalf("app-limited error moved the window: %d -> %d", high, after)
+	}
+}
+
+func TestGoodputController_RecoversAfterBackoff(t *testing.T) {
+	c := newGoodputController(8, 64)
+	c.observe(10, true, false)
+	c.observe(20, true, false)
+	c.observe(40, true, false)
+	c.observe(40, true, true) // back off
+	low := c.window()
+	// Conditions recover: goodput climbs again, window must re-open.
+	c.observe(80, true, false)
+	c.observe(160, true, false)
+	if c.window() <= low {
+		t.Fatalf("window did not recover after backoff: low=%d now=%d", low, c.window())
+	}
+}

--- a/pkg/controlplane/runtime/blockstore_init.go
+++ b/pkg/controlplane/runtime/blockstore_init.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/marmos91/dittofs/internal/pathutil"
+	"github.com/marmos91/dittofs/pkg/block/engine"
 	s3store "github.com/marmos91/dittofs/pkg/block/remote/s3"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 )
@@ -135,10 +136,6 @@ func validateCompressionSubconfig(config map[string]any) error {
 	}
 }
 
-// maxParallelUploads bounds the per-remote parallel_uploads override. It is a
-// safety rail against FD/goroutine exhaustion, not a tuning target.
-const maxParallelUploads = 256
-
 // validateParallelUploads checks the optional per-remote parallel_uploads
 // override. 0 / absent means "use the server default" (CPU-deduced); a
 // positive value pins the per-remote upload concurrency. JSON numbers decode
@@ -155,8 +152,8 @@ func validateParallelUploads(config map[string]any) error {
 	if n != float64(int(n)) {
 		return fmt.Errorf("parallel_uploads: expected integer, got %v", n)
 	}
-	if n < 0 || n > maxParallelUploads {
-		return fmt.Errorf("parallel_uploads: must be between 0 and %d (got %d)", maxParallelUploads, int(n))
+	if n < 0 || n > engine.MaxParallelUploads {
+		return fmt.Errorf("parallel_uploads: must be between 0 and %d (got %d)", engine.MaxParallelUploads, int(n))
 	}
 	return nil
 }

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -553,7 +553,11 @@ func buildSyncerConfigFromDefaults(defaults *SyncerDefaults) engine.SyncerConfig
 // (#1407 / #1432). Any lookup/parse miss falls back to 0 (adaptive) so a
 // malformed value never blocks share creation — validateParallelUploads already
 // rejects out-of-range values at store-create time. The value arrives as a JSON
-// number (float64) from the stored config blob.
+// number (float64) from the stored config blob. We still re-validate here
+// (integer-ness + 0..engine.MaxParallelUploads clamp) as defense-in-depth against a
+// corrupted or old-server config blob that skipped validateParallelUploads —
+// silently truncating 2.5 or honoring an absurd window would risk FD/goroutine
+// exhaustion.
 func remotePinnedUploads(ctx context.Context, provider BlockStoreConfigProvider, ref string) int {
 	if ref == "" || provider == nil {
 		return 0
@@ -566,17 +570,22 @@ func remotePinnedUploads(ctx context.Context, provider BlockStoreConfigProvider,
 	if err != nil {
 		return 0
 	}
+	var n int
 	switch v := m["parallel_uploads"].(type) {
 	case float64:
-		if v > 0 {
-			return int(v)
+		if v != math.Trunc(v) { // fractional => malformed, fall back to adaptive
+			return 0
 		}
+		n = int(v)
 	case int:
-		if v > 0 {
-			return v
-		}
+		n = v
+	default:
+		return 0
 	}
-	return 0
+	if n <= 0 || n > engine.MaxParallelUploads {
+		return 0
+	}
+	return n
 }
 
 func (s *Service) AddShare(

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -548,6 +548,37 @@ func buildSyncerConfigFromDefaults(defaults *SyncerDefaults) engine.SyncerConfig
 	return cfg
 }
 
+// remotePinnedUploads returns the per-remote parallel_uploads override: > 0
+// pins the carver's upload window, 0/absent keeps the adaptive auto-tune
+// (#1407 / #1432). Any lookup/parse miss falls back to 0 (adaptive) so a
+// malformed value never blocks share creation — validateParallelUploads already
+// rejects out-of-range values at store-create time. The value arrives as a JSON
+// number (float64) from the stored config blob.
+func remotePinnedUploads(ctx context.Context, provider BlockStoreConfigProvider, ref string) int {
+	if ref == "" || provider == nil {
+		return 0
+	}
+	cfg, err := resolveBlockStoreConfig(ctx, provider, ref, models.BlockStoreKindRemote)
+	if err != nil {
+		return 0
+	}
+	m, err := cfg.GetConfig()
+	if err != nil {
+		return 0
+	}
+	switch v := m["parallel_uploads"].(type) {
+	case float64:
+		if v > 0 {
+			return int(v)
+		}
+	case int:
+		if v > 0 {
+			return v
+		}
+	}
+	return 0
+}
+
 func (s *Service) AddShare(
 	ctx context.Context,
 	config *ShareConfig,
@@ -899,6 +930,11 @@ func (s *Service) createBlockStoreForShare(
 	localStore.SetRetentionPolicy(config.RetentionPolicy, config.RetentionTTL)
 
 	syncerCfg := buildSyncerConfigFromDefaults(syncerDefaults)
+	// A per-remote parallel_uploads override pins the carver's upload window;
+	// 0 (the default) keeps the adaptive auto-tune (#1407 / #1432).
+	if pinned := remotePinnedUploads(ctx, blockStoreProvider, config.RemoteBlockStoreID); pinned > 0 {
+		syncerCfg.ParallelUploads = pinned
+	}
 
 	// Wrap shared remote in nonClosingRemote so engine.Close() doesn't close it;
 	// releaseRemoteStore handles actual closing via ref counting.


### PR DESCRIPTION
## Problem

The blocks-only refactor (#1493) deleted the upload-concurrency machinery. Two regressions resulted:

- `carveFlush` sealed and `PutBlock`'d **one block at a time** — remote upload inflight pinned at **1** regardless of link headroom.
- The `parallel_uploads` per-remote config knob was still *validated* but **silently dropped** (it never reached `SyncerConfig`), so operators had no lever either.

Confirmed three ways on a real SCW VM → SCW S3 (fr-par):
1. Code — `ParallelUploads` absent from `SyncerConfig`; `carveFlush` serial.
2. Live gauges — `dittofs_datapath_uploads_inflight` = 1, `_upload_window` = 0, queue depth climbing.
3. Git — #1493 (`8f483986`) removed `dynsem.go`, `upload_controller.go`, `upload.go`.

## Fix

Restore **both** levers that existed pre-#1493:

- **`parallel_uploads`** (per-remote config) pins a fixed upload window.
- **Default `0` ⇒ adaptive**: `goodputController` auto-sizes the window between `AdaptiveUploadFloor` (16) and `AdaptiveUploadCeiling` (64) from observed goodput / window-limited / error signals.

`carveFlush` now dispatches block PUTs concurrently under a `dynamicSemaphore` sized by the active window. A failed block is requeued and the first error is returned after all in-flight uploads drain (`Flush`/`SyncNow` stay synchronous — no batch left un-requeued on return). `parallel_uploads` is threaded through `shares.AddShare` via `remotePinnedUploads`.

Resurrected `dynamicSemaphore` and `goodputController` verbatim from pre-#1493 (their original unit tests come back with them).

## Testing

- New `TestCarve_UploadsConcurrently`: adaptive window peak in-flight `PutBlock` **>= 2**; pinned window of 1 **serializes to 1**.
- `go test -race ./pkg/block/engine/...` clean; full build + shares tests green; `gofmt`/`vet` clean.
- **Empirical A/B** (SCW VM → SCW S3, parity upload-large, 2×1 GiB): conc=1 **358.7 Mbit/s** on the fixed binary vs **201 Mbit/s** on develop — **1.78×** at a single writer, because the adaptive controller opens the window as block backlog builds. Full concurrency-sweep matrix to follow.

Fixes the upload half of #1432.