### PR TITLE
perf(metadata): parse block index with strconv, not fmt.Sscanf (#1572)

### DIFF
--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -716,8 +717,7 @@ func splitBlockID(id string) (pid, idx string, ok bool) {
 // parseBlockIdx extracts the numeric block index from a block ID ("{payloadID}/{blockIdx}").
 func parseBlockIdx(id string) int {
 	if _, idx, ok := splitBlockID(id); ok {
-		var v int
-		if _, err := fmt.Sscanf(idx, "%d", &v); err == nil {
+		if v, err := strconv.Atoi(idx); err == nil {
 			return v
 		}
 	}

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -714,7 +714,7 @@ func splitBlockID(id string) (pid, idx string, ok bool) {
 	return id[:lastSlash], id[lastSlash+1:], true
 }
 
-// parseBlockIdx extracts the numeric block index from a block ID ("{payloadID}/{blockIdx}").
+// parseBlockIdx returns the numeric suffix of a block ID ("{payloadID}/{n}"), used as a sort key; 0 if absent.
 func parseBlockIdx(id string) int {
 	if _, idx, ok := splitBlockID(id); ok {
 		if v, err := strconv.Atoi(idx); err == nil {

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -457,7 +457,7 @@ func (s *PostgresMetadataStore) EnumerateFileChunks(ctx context.Context, fn func
 	return nil
 }
 
-// pgParseBlockIdx extracts the numeric block index from a block ID ("{payloadID}/{blockIdx}").
+// pgParseBlockIdx returns the numeric suffix of a block ID ("{payloadID}/{n}"), used as a sort key; 0 if absent.
 func pgParseBlockIdx(id string) int {
 	if idx := strings.LastIndex(id, "/"); idx >= 0 {
 		if v, err := strconv.Atoi(id[idx+1:]); err == nil {

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -459,8 +460,7 @@ func (s *PostgresMetadataStore) EnumerateFileChunks(ctx context.Context, fn func
 // pgParseBlockIdx extracts the numeric block index from a block ID ("{payloadID}/{blockIdx}").
 func pgParseBlockIdx(id string) int {
 	if idx := strings.LastIndex(id, "/"); idx >= 0 {
-		var v int
-		if _, err := fmt.Sscanf(id[idx+1:], "%d", &v); err == nil {
+		if v, err := strconv.Atoi(id[idx+1:]); err == nil {
 			return v
 		}
 	}

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -300,7 +301,7 @@ func (s *SQLiteMetadataStore) ListFileChunks(ctx context.Context, payloadID stri
 	// SQL ORDER BY id ASC gives lexicographic order which is wrong for multi-digit
 	// block indices (e.g., "10" < "2"). Sort by parsed numeric index.
 	sort.Slice(result, func(i, j int) bool {
-		return pgParseBlockIdx(result[i].ID) < pgParseBlockIdx(result[j].ID)
+		return parseBlockIdx(result[i].ID) < parseBlockIdx(result[j].ID)
 	})
 	if result == nil {
 		return []*metadata.FileChunk{}, nil
@@ -457,11 +458,10 @@ func (s *SQLiteMetadataStore) EnumerateFileChunks(ctx context.Context, fn func(b
 	return nil
 }
 
-// pgParseBlockIdx extracts the numeric block index from a block ID ("{payloadID}/{blockIdx}").
-func pgParseBlockIdx(id string) int {
+// parseBlockIdx extracts the numeric block index from a block ID ("{payloadID}/{blockIdx}").
+func parseBlockIdx(id string) int {
 	if idx := strings.LastIndex(id, "/"); idx >= 0 {
-		var v int
-		if _, err := fmt.Sscanf(id[idx+1:], "%d", &v); err == nil {
+		if v, err := strconv.Atoi(id[idx+1:]); err == nil {
 			return v
 		}
 	}
@@ -724,7 +724,7 @@ func (tx *sqliteTransaction) ListFileChunks(ctx context.Context, payloadID strin
 	// Lexicographic SQL order mis-sorts multi-digit indices ("10" < "2");
 	// sort by parsed numeric index, matching the store-level method.
 	sort.Slice(result, func(i, j int) bool {
-		return pgParseBlockIdx(result[i].ID) < pgParseBlockIdx(result[j].ID)
+		return parseBlockIdx(result[i].ID) < parseBlockIdx(result[j].ID)
 	})
 	if result == nil {
 		return []*metadata.FileChunk{}, nil

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -458,7 +458,7 @@ func (s *SQLiteMetadataStore) EnumerateFileChunks(ctx context.Context, fn func(b
 	return nil
 }
 
-// parseBlockIdx extracts the numeric block index from a block ID ("{payloadID}/{blockIdx}").
+// parseBlockIdx returns the numeric suffix of a block ID ("{payloadID}/{n}"), used as a sort key; 0 if absent.
 func parseBlockIdx(id string) int {
 	if idx := strings.LastIndex(id, "/"); idx >= 0 {
 		if v, err := strconv.Atoi(id[idx+1:]); err == nil {


### PR DESCRIPTION
## What

Swap block-index parsing from `fmt.Sscanf(s, "%d", &v)` to `strconv.Atoi(s)` in the three metadata backends (badger / postgres / sqlite). Also renames the sqlite copy `pgParseBlockIdx` → `parseBlockIdx` (copy-paste artifact from postgres — the `pg` prefix was misleading in the sqlite package).

## Why

A live CPU profile (SCW POP2-HC-32C-64G → SCW S3 fr-par, NFSv3 random-read load) showed `fmt.Sscanf` was **~32% of read CPU**. Every read enumerates the whole per-payload FileChunk manifest and `sort.Slice`-orders it; the comparator calls `parseBlockIdx`, which parsed each block index with reflection-based `fmt.Sscanf`.

Block IDs are uniformly `fmt.Sprintf("%s/%d", payloadID, blockIdx)` (`pkg/block/engine/fetch.go:18`) — base-10, non-negative, no padding — so `strconv.Atoi` on the tail after the last `/` is exactly equivalent, and far cheaper.

## Impact

Micro-benchmark of the exact hot path (sorting a 4096-chunk manifest):

| | ns/op | allocs/op |
|---|---|---|
| `fmt.Sscanf` | 25,876,470 | 442,834 |
| `strconv.Atoi` | 1,233,314 | 3 |

**~21× faster, allocations 442,834 → 3.** Equivalence verified across all 4096 keys.

## Scope

This is PR1 of the read-path perf roadmap. It does **not** touch the O(N²) `ListFileChunks` enumeration itself — that's the follow-up (`GetFileChunkAtOffset`, single indexed lookup by offset). This PR is the trivial, zero-risk first win that removes the per-parse CPU cost.

## Verification

- `go build ./...`, `go vet`, `gofmt -s` clean.
- 812 metadata tests pass, incl. the existing `ListFileChunks_Ordering` conformance case (pins the numeric-ordering contract across all 3 backends).
- `code-simplifier` + `code-reviewer`: both clean, swap confirmed behaviorally equivalent for every key the system produces.

Refs #1572