### PR TITLE
fix(smb): never grant directories a write-caching lease (#1570)

### DIFF
--- a/pkg/metadata/lock/directory_test.go
+++ b/pkg/metadata/lock/directory_test.go
@@ -651,3 +651,47 @@ func TestRenameC3_DstParent_PreConflictBreak_OnlyStripsHandle(t *testing.T) {
 	assert.Equal(t, 1, breakCount, "dst-parent dir lease must break exactly once on the pre-conflict path")
 	assert.Equal(t, uint32(LeaseStateRead), lastBreakTo, "pre-conflict dst-parent break must strip H but preserve R (RH → R, rename_dst_parent Phase 1)")
 }
+
+// TestRequestLease_DirectoryNeverGrantsWrite verifies that a directory is never
+// granted a Write-caching lease, on either the initial-grant or the same-key
+// upgrade path. Regression for #1570: Windows opened a directory with an RH
+// lease, then re-requested RWH; the directory-blind upgrade path applied the
+// RWH transition, handing the folder an illegal write-caching lease. Windows
+// then served a stale (empty) directory listing from cache and deleted the
+// folder without enumerating/removing its children, so the rmdir failed with
+// STATUS_DIRECTORY_NOT_EMPTY.
+func TestRequestLease_DirectoryNeverGrantsWrite(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	parentKey := [16]byte{}
+
+	t.Run("initial RWH request grants only RH", func(t *testing.T) {
+		t.Parallel()
+		mgr := NewManager()
+		leaseKey := [16]byte{0xa1}
+		state, _, err := mgr.RequestLease(ctx, FileHandle("dir-a"), leaseKey, parentKey,
+			"owner", "client", "/share", LeaseStateRead|LeaseStateWrite|LeaseStateHandle, true)
+		require.NoError(t, err)
+		assert.Equal(t, uint32(LeaseStateRead|LeaseStateHandle), state,
+			"directory RWH request must be capped at RH (Write not valid for directories)")
+	})
+
+	t.Run("RH then RWH upgrade stays RH", func(t *testing.T) {
+		t.Parallel()
+		mgr := NewManager()
+		leaseKey := [16]byte{0xb2}
+
+		state, _, err := mgr.RequestLease(ctx, FileHandle("dir-b"), leaseKey, parentKey,
+			"owner", "client", "/share", LeaseStateRead|LeaseStateHandle, true)
+		require.NoError(t, err)
+		require.Equal(t, uint32(LeaseStateRead|LeaseStateHandle), state)
+
+		// Same-key upgrade request to RWH — must not escalate a directory to Write.
+		state, _, err = mgr.RequestLease(ctx, FileHandle("dir-b"), leaseKey, parentKey,
+			"owner", "client", "/share", LeaseStateRead|LeaseStateWrite|LeaseStateHandle, true)
+		require.NoError(t, err)
+		assert.Equal(t, uint32(LeaseStateRead|LeaseStateHandle), state,
+			"RH→RWH upgrade on a directory must be rejected; state stays RH (#1570)")
+	})
+}

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -289,6 +289,21 @@ func (lm *Manager) requestLeaseImplWithMode(ctx context.Context, fileHandle File
 		return LeaseStateNone, 0, nil
 	}
 
+	// Directories may only be granted Read/Handle caching, never Write
+	// (MS-SMB2 §3.3.5.9.11 / IsValidDirectoryLeaseState allows only None, R,
+	// RH). Strip Write here, at the single request-normalization point, so
+	// BOTH the same-key upgrade path (isValidUpgrade) and the initial-grant
+	// path (bestGrantableState) observe a W-stripped request. The grant path
+	// already re-validates via IsValidDirectoryLeaseState, but isValidUpgrade
+	// is directory-blind — without this an RH→RWH upgrade would hand a
+	// directory an illegal write-caching lease. Windows then treats its local
+	// directory view as authoritative, serves a stale (empty) listing from
+	// cache, and deletes the folder without first enumerating and removing its
+	// children — so the rmdir fails with STATUS_DIRECTORY_NOT_EMPTY (#1570).
+	if isDirectory {
+		requestedState &^= LeaseStateWrite
+	}
+
 	handleKey := string(fileHandle)
 
 	// LeaseStateNone probe: clients (and smbtorture breaking4 / upgrade2)

--- a/pkg/metadata/lock/reclaim.go
+++ b/pkg/metadata/lock/reclaim.go
@@ -120,6 +120,14 @@ func (lm *Manager) reclaimLeaseImpl(ctx context.Context, leaseKey [16]byte,
 				}
 			}
 
+			// Directories may only reclaim Read/Handle caching, never Write
+			// (IsValidDirectoryLeaseState). Clamp before the subset check and
+			// the LeaseState overwrites below so a client reclaiming against a
+			// legacy RWH-directory record can't restore Write (#1570).
+			if pl.IsDirectory {
+				requestedState &^= LeaseStateWrite
+			}
+
 			// Step 6: Validate requested state is subset of persisted
 			if requestedState&^pl.LeaseState != 0 {
 				return nil, fmt.Errorf("requested state %s exceeds persisted state %s",

--- a/pkg/metadata/lock/reclaim_test.go
+++ b/pkg/metadata/lock/reclaim_test.go
@@ -224,3 +224,55 @@ func TestReclaimLeaseWithPrincipal_NoRecoveryRecord(t *testing.T) {
 	require.NotNil(t, lock)
 	require.True(t, lock.Reclaim)
 }
+
+// TestReclaimLease_DirectoryStripsWriteFromLegacyRecord ensures the persisted
+// -state ingestion path enforces the directory Write-strip invariant. A binary
+// predating the #1570 fix could persist an illegal RWH directory lease; after
+// upgrading and restarting, reclaiming that record must not restore Write —
+// otherwise Windows regains a write-caching directory lease and the stale
+// -listing delete bug returns for that session.
+func TestReclaimLease_DirectoryStripsWriteFromLegacyRecord(t *testing.T) {
+	ctx := context.Background()
+	lm, store := newGraceManagerWithStore(t, []string{"client-a"})
+	leaseKey := [16]byte{9, 8, 7, 6}
+
+	// Legacy illegal record: directory lease carrying Write (RWH).
+	require.NoError(t, store.PutLock(ctx, &PersistedLock{
+		ID:          "lease-dir",
+		ShareName:   "share-a",
+		FileID:      "share-a:dir-1",
+		ClientID:    "client-a",
+		LeaseKey:    leaseKey[:],
+		LeaseState:  LeaseStateRead | LeaseStateWrite | LeaseStateHandle,
+		IsDirectory: true,
+	}))
+
+	lock, err := lm.ReclaimLease(ctx, leaseKey, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, true, "client-a")
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+	require.Equal(t, uint32(LeaseStateRead|LeaseStateHandle), lock.Lease.LeaseState,
+		"reclaimed directory lease must have Write stripped (#1570)")
+}
+
+// TestRestoreLocks_DirectoryStripsWriteFromLegacyRecord ensures startup restore
+// (which loads persisted records directly, before any client reclaim) also
+// enforces the directory Write-strip invariant for legacy RWH records.
+func TestRestoreLocks_DirectoryStripsWriteFromLegacyRecord(t *testing.T) {
+	lm := NewManager()
+	leaseKey := [16]byte{5, 5, 5, 5}
+
+	require.NoError(t, lm.RestoreLocks([]*PersistedLock{{
+		ID:          "lease-dir",
+		ShareName:   "share-a",
+		FileID:      "share-a:dir-1",
+		ClientID:    "client-a",
+		LeaseKey:    leaseKey[:],
+		LeaseState:  LeaseStateRead | LeaseStateWrite | LeaseStateHandle,
+		IsDirectory: true,
+	}}))
+
+	_, lock, _ := lm.findLeaseByKey(leaseKey)
+	require.NotNil(t, lock, "restored lease must be present in memory")
+	require.Equal(t, uint32(LeaseStateRead|LeaseStateHandle), lock.Lease.LeaseState,
+		"restored directory lease must have Write stripped (#1570)")
+}

--- a/pkg/metadata/lock/reclaim_test.go
+++ b/pkg/metadata/lock/reclaim_test.go
@@ -225,12 +225,12 @@ func TestReclaimLeaseWithPrincipal_NoRecoveryRecord(t *testing.T) {
 	require.True(t, lock.Reclaim)
 }
 
-// TestReclaimLease_DirectoryStripsWriteFromLegacyRecord ensures the persisted
-// -state ingestion path enforces the directory Write-strip invariant. A binary
-// predating the #1570 fix could persist an illegal RWH directory lease; after
-// upgrading and restarting, reclaiming that record must not restore Write —
-// otherwise Windows regains a write-caching directory lease and the stale
-// -listing delete bug returns for that session.
+// TestReclaimLease_DirectoryStripsWriteFromLegacyRecord ensures the
+// persisted-state ingestion path enforces the directory Write-strip invariant.
+// A binary predating the #1570 fix could persist an illegal RWH directory
+// lease; after upgrading and restarting, reclaiming that record must not
+// restore Write — otherwise Windows regains a write-caching directory lease and
+// the stale-listing delete bug returns for that session.
 func TestReclaimLease_DirectoryStripsWriteFromLegacyRecord(t *testing.T) {
 	ctx := context.Background()
 	lm, store := newGraceManagerWithStore(t, []string{"client-a"})

--- a/pkg/metadata/lock/store.go
+++ b/pkg/metadata/lock/store.go
@@ -455,6 +455,19 @@ func FromPersistedLock(pl *PersistedLock) *UnifiedLock {
 				el.Lease.BreakingToRequired = el.Lease.LeaseState
 			}
 		}
+
+		// Directories may only carry Read/Handle caching, never Write
+		// (IsValidDirectoryLeaseState). A record written by a pre-fix binary
+		// could hold an illegal RWH directory lease (#1570); strip Write on
+		// ingestion so restoring or reclaiming that record can't reintroduce
+		// the stale-directory-cache bug after an upgrade + restart. Grant and
+		// upgrade paths already clamp before persisting, so this only rewrites
+		// legacy records.
+		if el.Lease.IsDirectory {
+			el.Lease.LeaseState &^= LeaseStateWrite
+			el.Lease.BreakToState &^= LeaseStateWrite
+			el.Lease.BreakingToRequired &^= LeaseStateWrite
+		}
 	}
 
 	// Restore delegation fields if this is a delegation (DelegationID present)


### PR DESCRIPTION
Fixes #1570.

## Symptom

Deleting a non-empty directory from Windows 11 File Explorer over SMB fails silently: the folder disappears from the view, then reappears intact on refresh (F5). Emptying the folder manually first, then deleting the empty folder, works.

## Root cause

There is no single SMB operation that recursively deletes a folder tree — Explorer deletes the children first, then `rmdir`s the now-empty folder. That final `rmdir` correctly fails with `STATUS_DIRECTORY_NOT_EMPTY` if anything is still inside.

In the reporter's DEBUG log, Explorer **never enumerated the folder's contents** before issuing the `rmdir` — so it never deleted the children. The reason is in the lease grant:

```
ProcessLeaseCreateContext: requestedState=RWH isDirectory=true
RequestLease: upgraded lease ... from=RH to=RWH epoch=6
```

DittoFS granted the **directory** an `RWH` (**Write**-caching) lease. Per MS-SMB2, a directory may only be granted `None`/`R`/`RH` — never Write (`IsValidDirectoryLeaseState`, `pkg/metadata/lock/oplock.go`). The initial-grant path already enforced this, but the **same-key upgrade path** (`isValidUpgrade` + the `validUpgrades` map) is directory-blind and happily applied the `RH → RWH` transition.

Holding a write-caching lease on the folder, Windows treated its local directory view as authoritative, served a stale (empty) listing from cache, and deleted the folder without enumerating/removing its children → `STATUS_DIRECTORY_NOT_EMPTY`, folder reappears intact.

## Fix

- **`leases.go`** — clamp `requestedState &^= Write` for directories at the single request-normalization choke point, so both the upgrade and initial-grant paths observe a W-stripped request.
- **`store.go` (`FromPersistedLock`)** and **`reclaim.go` (`reclaimLeaseImpl`)** — enforce the same invariant on persisted-lease ingestion. A binary predating this fix could have persisted an illegal `RWH`-directory record (exactly #1570's state); without this, restoring/reclaiming that record after upgrade + restart would silently reintroduce the bug for that session.

## Tests

Three regression tests, each verified to **fail without the fix** and pass with it:
- `TestRequestLease_DirectoryNeverGrantsWrite` — initial `RWH` request capped at `RH`; `RH→RWH` upgrade stays `RH`.
- `TestReclaimLease_DirectoryStripsWriteFromLegacyRecord` — reclaiming a legacy `RWH`-directory record strips Write.
- `TestRestoreLocks_DirectoryStripsWriteFromLegacyRecord` — startup restore strips Write.

Gates: 580 `pkg/metadata/lock` tests pass; `gofmt`, `go vet`, `golangci-lint` all clean.