### PR TITLE
perf(block): resolve covering chunk by offset, not full manifest scan (#1572)

### DIFF
--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -36,23 +36,15 @@ func inFlightKey(payloadID string, blockIdx uint64) string {
 // zero for any reachable block; the dispatchRemoteFetch helper enforces
 // this.
 func (m *Syncer) resolveFileChunk(ctx context.Context, payloadID string, blockIdx uint64) (*block.FileChunk, error) {
-	rows, err := m.listFileChunksSnapshot(ctx, payloadID)
-	if err != nil {
-		return nil, err
-	}
-	return resolveFileChunkFromRows(rows, blockIdx), nil
+	fb, _, err := resolveCovering(ctx, m.fileChunkStore, payloadID, blockIdx*uint64(BlockSize))
+	return fb, err
 }
 
-// listFileChunksSnapshot returns a point-in-time snapshot of the FileChunk rows
-// for payloadID with a single ListFileChunks store scan. A sparse / not-yet-
-// uploaded payload (ErrFileChunkNotFound) yields (nil, nil). Callers that need
-// to test many block indices for one read should fetch the snapshot ONCE and
-// pass it to resolveFileChunkFromRows / blockIsLocalFromRows: each block lookup
-// then walks the in-memory snapshot instead of issuing its own store scan,
-// collapsing the previous N store scans (one per block index) into one. The
-// snapshot is point-in-time: a concurrent writer that mutates the block set
-// after the scan is not reflected for the remainder of that read, which is the
-// acceptable (and arguably more correct) per-read isolation semantics.
+// listFileChunksSnapshot returns a point-in-time snapshot of the whole
+// FileChunk row list for payloadID with a single ListFileChunks store scan. A
+// sparse / not-yet-uploaded payload (ErrFileChunkNotFound) yields (nil, nil).
+// Used by whole-manifest consumers (warm); the read path resolves a single
+// covering chunk via resolveCovering instead of enumerating.
 func (m *Syncer) listFileChunksSnapshot(ctx context.Context, payloadID string) ([]*block.FileChunk, error) {
 	rows, err := m.fileChunkStore.ListFileChunks(ctx, payloadID)
 	if err != nil {
@@ -62,29 +54,6 @@ func (m *Syncer) listFileChunksSnapshot(ctx context.Context, payloadID string) (
 		return nil, fmt.Errorf("list file blocks for %s: %w", payloadID, err)
 	}
 	return rows, nil
-}
-
-// resolveFileChunkFromRows finds the FileChunk covering blockIdx's byte window
-// within an already-fetched row snapshot. See resolveFileChunk for the offset-
-// covering semantics. Returns nil when no row covers the window.
-func resolveFileChunkFromRows(rows []*block.FileChunk, blockIdx uint64) *block.FileChunk {
-	if len(rows) == 0 {
-		return nil
-	}
-	target := blockIdx * uint64(BlockSize)
-	for _, fb := range rows {
-		if fb == nil {
-			continue
-		}
-		abs, ok := block.ParseChunkOffset(fb.ID)
-		if !ok {
-			continue
-		}
-		if target >= abs && target < abs+uint64(fb.DataSize) {
-			return fb
-		}
-	}
-	return nil
 }
 
 // blockIsLocal reports whether the bytes for (payloadID, blockIdx) are
@@ -101,12 +70,6 @@ func (m *Syncer) blockIsLocal(ctx context.Context, payloadID string, blockIdx ui
 		return false
 	}
 	return m.blockIsLocalFromRow(ctx, fb)
-}
-
-// blockIsLocalFromRows answers blockIsLocal against an already-fetched row
-// snapshot, avoiding a fresh ListFileChunks scan per block index.
-func (m *Syncer) blockIsLocalFromRows(ctx context.Context, rows []*block.FileChunk, blockIdx uint64) bool {
-	return m.blockIsLocalFromRow(ctx, resolveFileChunkFromRows(rows, blockIdx))
 }
 
 // blockIsLocalFromRow reports whether the resolved FileChunk's CAS chunk is
@@ -359,21 +322,18 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 
 	startBlockIdx, endBlockIdx := blockRange(offset, length)
 
-	// Single point-in-time store scan of the per-payload FileChunk rows,
-	// reused for the all-local fast path, the per-block locality checks below,
-	// and the inline fetch hash lookups (all of which walk this in-memory
-	// snapshot). This replaces the prior 2N+ ListFileChunks store scans (one
-	// per block in the all-local check + one per block in the download loop,
-	// plus one more inside each inlineFetchOrWait) with a single store scan per
-	// read.
-	rows, err := m.listFileChunksSnapshot(ctx, payloadID)
-	if err != nil {
-		return false, err
-	}
-
+	// Resolve the covering chunk per block via the indexed lookup
+	// (resolveCovering) rather than enumerating the whole manifest. Each block
+	// is a cheap single-chunk lookup, so the all-local probe and the download
+	// loop each resolve independently; a genuine store error now propagates
+	// (the prior in-memory snapshot could not surface one mid-loop).
 	allLocal := true
 	for blockIdx := startBlockIdx; blockIdx <= endBlockIdx; blockIdx++ {
-		if !m.blockIsLocalFromRows(ctx, rows, blockIdx) {
+		fb, err := m.resolveFileChunk(ctx, payloadID, blockIdx)
+		if err != nil {
+			return false, err
+		}
+		if !m.blockIsLocalFromRow(ctx, fb) {
 			allLocal = false
 			break
 		}
@@ -393,12 +353,16 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 	needLocalReadAt := false
 
 	for blockIdx := startBlockIdx; blockIdx <= endBlockIdx; blockIdx++ {
-		if m.blockIsLocalFromRows(ctx, rows, blockIdx) {
+		fb, err := m.resolveFileChunk(ctx, payloadID, blockIdx)
+		if err != nil {
+			return false, err
+		}
+		if m.blockIsLocalFromRow(ctx, fb) {
 			needLocalReadAt = true
 			continue
 		}
 
-		data, downloaded, err := m.inlineFetchOrWait(ctx, payloadID, blockIdx, rows)
+		data, downloaded, err := m.inlineFetchOrWait(ctx, payloadID, blockIdx, fb)
 		if err != nil {
 			return false, err
 		}
@@ -432,9 +396,9 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 // inlineFetchOrWait downloads a block inline or waits for an in-flight download.
 // Returns (data, true, nil) for inline download, (nil, false, nil) if piggybacked on existing.
 //
-// rows is the caller's point-in-time FileChunk snapshot for payloadID; the
-// block is resolved from it instead of re-scanning the store.
-func (m *Syncer) inlineFetchOrWait(ctx context.Context, payloadID string, blockIdx uint64, rows []*block.FileChunk) ([]byte, bool, error) {
+// fb is the caller's already-resolved covering FileChunk for the block; a nil
+// fb is a sparse block (nothing to fetch).
+func (m *Syncer) inlineFetchOrWait(ctx context.Context, payloadID string, blockIdx uint64, fb *block.FileChunk) ([]byte, bool, error) {
 	key := inFlightKey(payloadID, blockIdx)
 
 	m.inFlightMu.Lock()
@@ -466,7 +430,6 @@ func (m *Syncer) inlineFetchOrWait(ctx context.Context, payloadID string, blockI
 		}
 	}()
 
-	fb := resolveFileChunkFromRows(rows, blockIdx)
 	if fb == nil {
 		return nil, true, nil
 	}

--- a/pkg/block/engine/fetch_test.go
+++ b/pkg/block/engine/fetch_test.go
@@ -103,12 +103,12 @@ func TestInlineFetchOrWait_LocalPutError_PropagatesToCaller(t *testing.T) {
 
 	m := newFetchSyncer(loc, rs, fbs, mds)
 
-	rows, err := m.listFileChunksSnapshot(ctx, payloadID)
+	fb, err := m.resolveFileChunk(ctx, payloadID, 0)
 	if err != nil {
-		t.Fatalf("listFileChunksSnapshot: %v", err)
+		t.Fatalf("resolveFileChunk: %v", err)
 	}
 
-	gotData, downloaded, err := m.inlineFetchOrWait(ctx, payloadID, 0, rows)
+	gotData, downloaded, err := m.inlineFetchOrWait(ctx, payloadID, 0, fb)
 	if err == nil {
 		t.Fatalf("inlineFetchOrWait returned nil err; want error wrapping %v", errBoomLocalPut)
 	}
@@ -151,9 +151,9 @@ func TestInlineFetchOrWait_LocalPutError_PropagatesToWaiter(t *testing.T) {
 
 	m := newFetchSyncer(loc, rs, fbs, mds)
 
-	rows, err := m.listFileChunksSnapshot(ctx, payloadID)
+	fb, err := m.resolveFileChunk(ctx, payloadID, 0)
 	if err != nil {
-		t.Fatalf("listFileChunksSnapshot: %v", err)
+		t.Fatalf("resolveFileChunk: %v", err)
 	}
 
 	// Goroutine A: enters inlineFetchOrWait first, registers the in-flight
@@ -165,7 +165,7 @@ func TestInlineFetchOrWait_LocalPutError_PropagatesToWaiter(t *testing.T) {
 	}
 	chA := make(chan result, 1)
 	go func() {
-		d, dl, e := m.inlineFetchOrWait(ctx, payloadID, 0, rows)
+		d, dl, e := m.inlineFetchOrWait(ctx, payloadID, 0, fb)
 		chA <- result{d, dl, e}
 	}()
 
@@ -181,7 +181,7 @@ func TestInlineFetchOrWait_LocalPutError_PropagatesToWaiter(t *testing.T) {
 	// the waiter branch, and blocks on <-existing.done.
 	chB := make(chan result, 1)
 	go func() {
-		d, dl, e := m.inlineFetchOrWait(ctx, payloadID, 0, rows)
+		d, dl, e := m.inlineFetchOrWait(ctx, payloadID, 0, fb)
 		chB <- result{d, dl, e}
 	}()
 

--- a/pkg/block/engine/read_cache_sync_test.go
+++ b/pkg/block/engine/read_cache_sync_test.go
@@ -50,11 +50,11 @@ func TestInlineFetch_MarksFetchedChunkSyncedAndCancelsReupload(t *testing.T) {
 		t.Fatalf("precondition unsyncedBytes=%d, want %d", got, len(data))
 	}
 
-	rows, err := m.listFileChunksSnapshot(ctx, payloadID)
+	fb, err := m.resolveFileChunk(ctx, payloadID, 0)
 	if err != nil {
-		t.Fatalf("listFileChunksSnapshot: %v", err)
+		t.Fatalf("resolveFileChunk: %v", err)
 	}
-	gotData, downloaded, err := m.inlineFetchOrWait(ctx, payloadID, 0, rows)
+	gotData, downloaded, err := m.inlineFetchOrWait(ctx, payloadID, 0, fb)
 	if err != nil {
 		t.Fatalf("inlineFetchOrWait: %v", err)
 	}

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -144,35 +144,23 @@ func (bs *Store) readLocalByHash(ctx context.Context, payloadID string, dest []b
 		return true, nil
 	}
 	// The engine consults the same EngineFileChunkStore the syncer
-	// uses; ListFileChunks returns the per-payload row list in
-	// blockIdx order, which is offset order under the persister's
-	// blockIdx := chunkOffset / BlockSize derivation. Rows missing
-	// from the list are sparse: the caller falls back to the
-	// remote-fetch + zero-fill path.
+	// uses. resolveCovering resolves the single chunk covering each
+	// offset via the badger index (falling back to a ListFileChunks
+	// walk for other backends); a nil result is sparse and the caller
+	// falls back to the remote-fetch + zero-fill path.
 	if bs.fileChunkStore == nil {
-		return false, nil
-	}
-	rows, err := bs.fileChunkStore.ListFileChunks(ctx, payloadID)
-	if err != nil {
-		return false, err
-	}
-	if len(rows) == 0 {
 		return false, nil
 	}
 	endOff := offset + uint64(len(dest))
 	for currentOffset := offset; currentOffset < endOff; {
-		// Find the row whose chunk covers currentOffset. blockIdx is
-		// chunkOffset / BlockSize so the chunk's absolute Offset is
-		// not directly stored on the row, but we can reconstruct
-		// the chunk start by walking rows in order and tracking a
-		// running expected offset. For the test fixtures + steady-
-		// state production stream chunks land in offset-ascending
-		// order, and the row ID's blockIdx component is monotone.
-		row := findRowCoveringOffset(rows, currentOffset)
-		if row == nil || row.fb.Hash.IsZero() {
+		fb, absOffset, err := resolveCovering(ctx, bs.fileChunkStore, payloadID, currentOffset)
+		if err != nil {
+			return false, err
+		}
+		if fb == nil || fb.Hash.IsZero() {
 			return false, nil
 		}
-		data, err := bs.local.Get(ctx, row.fb.Hash)
+		data, err := bs.local.Get(ctx, fb.Hash)
 		if err != nil {
 			if errors.Is(err, block.ErrChunkNotFound) {
 				return false, nil
@@ -182,9 +170,9 @@ func (bs *Store) readLocalByHash(ctx context.Context, payloadID string, dest []b
 		// Integrity check: verify the buffer we already have against the
 		// chunk's content hash.  No double-read — we verify in-place.
 		computed := block.ContentHash(blake3.Sum256(data))
-		if computed != row.fb.Hash {
+		if computed != fb.Hash {
 			var healErr error
-			data, healErr = bs.healLocalChunk(ctx, row.fb.Hash, row.fb)
+			data, healErr = bs.healLocalChunk(ctx, fb.Hash, fb)
 			if healErr != nil {
 				return false, healErr
 			}
@@ -193,17 +181,17 @@ func (bs *Store) readLocalByHash(ctx context.Context, payloadID string, dest []b
 		// on-disk chunk surface doesn't leak garbage past the
 		// rollup-emitted byte count.
 		dataLen := uint64(len(data))
-		if uint64(row.fb.DataSize) > 0 && uint64(row.fb.DataSize) < dataLen {
-			dataLen = uint64(row.fb.DataSize)
+		if uint64(fb.DataSize) > 0 && uint64(fb.DataSize) < dataLen {
+			dataLen = uint64(fb.DataSize)
 		}
-		chunkAbsEnd := row.absOffset + dataLen
+		chunkAbsEnd := absOffset + dataLen
 		if currentOffset >= chunkAbsEnd {
-			// Should not happen if findRowCoveringOffset returned
-			// a row covering currentOffset — surface as sparse and
-			// let the caller fall back.
+			// Should not happen if resolveCovering returned a row
+			// covering currentOffset — surface as sparse and let
+			// the caller fall back.
 			return false, nil
 		}
-		srcOff := currentOffset - row.absOffset
+		srcOff := currentOffset - absOffset
 		copyLen := chunkAbsEnd - currentOffset
 		if copyLen > endOff-currentOffset {
 			copyLen = endOff - currentOffset
@@ -243,6 +231,45 @@ func findRowCoveringOffset(rows []*block.FileChunk, target uint64) *rowWithOffse
 		}
 	}
 	return nil
+}
+
+// chunkAtOffsetResolver is the indexed covering-chunk lookup, implemented only
+// by the badger metadata backend. resolveCovering type-asserts for it and falls
+// back to a ListFileChunks walk otherwise.
+type chunkAtOffsetResolver interface {
+	GetFileChunkAtOffset(ctx context.Context, payloadID string, off uint64) (*block.FileChunk, error)
+}
+
+// resolveCovering returns the FileChunk covering absolute byte offset off and
+// its parsed absolute start offset, or (nil, 0, nil) for a hole. When the store
+// implements chunkAtOffsetResolver (badger) it uses the indexed single-chunk
+// lookup that avoids enumerating the whole per-payload manifest; otherwise it
+// falls back to ListFileChunks + findRowCoveringOffset (memory/sqlite/postgres —
+// not the profiled hot path).
+func resolveCovering(ctx context.Context, store block.EngineFileChunkStore, payloadID string, off uint64) (*block.FileChunk, uint64, error) {
+	if store == nil {
+		return nil, 0, nil
+	}
+	if r, ok := store.(chunkAtOffsetResolver); ok {
+		fb, err := r.GetFileChunkAtOffset(ctx, payloadID, off)
+		if err != nil || fb == nil {
+			return nil, 0, err
+		}
+		abs, _ := block.ParseChunkOffset(fb.ID)
+		return fb, abs, nil
+	}
+	rows, err := store.ListFileChunks(ctx, payloadID)
+	if err != nil {
+		if errors.Is(err, block.ErrFileChunkNotFound) {
+			return nil, 0, nil
+		}
+		return nil, 0, err
+	}
+	rw := findRowCoveringOffset(rows, off)
+	if rw == nil {
+		return nil, 0, nil
+	}
+	return rw.fb, rw.absOffset, nil
 }
 
 // healLocalChunk attempts to repair a locally corrupt chunk by re-fetching it

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -255,7 +255,10 @@ func resolveCovering(ctx context.Context, store block.EngineFileChunkStore, payl
 		if err != nil || fb == nil {
 			return nil, 0, err
 		}
-		abs, _ := block.ParseChunkOffset(fb.ID)
+		abs, ok := block.ParseChunkOffset(fb.ID)
+		if !ok {
+			return nil, 0, fmt.Errorf("resolveCovering: malformed FileChunk ID %q", fb.ID)
+		}
 		return fb, abs, nil
 	}
 	rows, err := store.ListFileChunks(ctx, payloadID)

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -3,6 +3,7 @@ package badger
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -446,34 +447,42 @@ func (s *BadgerMetadataStore) GetFileChunkAtOffset(_ context.Context, payloadID 
 			return nil // nothing starts at or before off — hole
 		}
 
-		// Fetch the winning row: index key -> block ID -> primary row. A stale
-		// index row (deleted block) is treated as a hole, mirroring
-		// listFileChunksTxn's "index stale, block deleted" skip.
+		// Fetch the winning row: index key -> block ID -> primary row. A
+		// missing index/primary row (ErrKeyNotFound) is a stale index entry —
+		// treat as a hole, mirroring listFileChunksTxn's "index stale, block
+		// deleted" skip. Any other Get/Value/unmarshal error is real IO or
+		// corruption and must propagate, not masquerade as a hole.
 		idxItem, gerr := txn.Get([]byte(fileChunkFilePrefix + payloadID + ":" + strconv.FormatUint(bestOff, 10)))
-		if gerr != nil {
+		if errors.Is(gerr, badger.ErrKeyNotFound) {
 			return nil
+		} else if gerr != nil {
+			return gerr
 		}
 		var blockID string
 		if verr := idxItem.Value(func(val []byte) error {
 			blockID = string(val)
 			return nil
 		}); verr != nil {
-			return nil
+			return verr
 		}
 		fbItem, gerr := txn.Get([]byte(fileChunkPrefix + blockID))
-		if gerr != nil {
+		if errors.Is(gerr, badger.ErrKeyNotFound) {
 			return nil
+		} else if gerr != nil {
+			return gerr
 		}
 		var fc metadata.FileChunk
 		if verr := fbItem.Value(func(val []byte) error {
 			return json.Unmarshal(val, &fc)
 		}); verr != nil {
-			return nil
+			return verr
 		}
-		// Covering guard: the scan guarantees bestOff <= off; require
-		// off < bestOff+DataSize, else off falls in a hole past this chunk and
-		// must NOT be served this chunk's bytes.
-		if off >= bestOff+uint64(fc.DataSize) {
+		// Covering guard keyed on the row's OWN start offset (the source of
+		// truth), not the index key, so an inconsistent index can't serve a
+		// neighbour chunk's bytes into a hole. off-abs is overflow-free since
+		// the scan guarantees abs <= off.
+		abs, ok := blockpkg.ParseChunkOffset(fc.ID)
+		if !ok || off < abs || off-abs >= uint64(fc.DataSize) {
 			return nil
 		}
 		result = &fc

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -408,6 +408,83 @@ func (s *BadgerMetadataStore) ListFileChunks(_ context.Context, payloadID string
 	return result, nil
 }
 
+// GetFileChunkAtOffset returns the FileChunk covering absolute byte offset off
+// for payloadID — the row with the largest chunkOffset <= off whose range
+// [chunkOffset, chunkOffset+DataSize) contains off — or (nil, nil) for a sparse
+// hole, an empty payload, or a read past EOF. This is the read hot path: a
+// keys-only scan of the fb-file:{payloadID}: secondary index finds the covering
+// offset without materializing the whole manifest (no per-row Get, no JSON
+// unmarshal, no sort), then two point Gets fetch the winning row.
+//
+// ponytail: O(n) keys-only scan per read; upgrade to a big-endian fb-off index
+// for a true O(log n) reverse-seek only if profiling at real N still shows it.
+func (s *BadgerMetadataStore) GetFileChunkAtOffset(_ context.Context, payloadID string, off uint64) (*metadata.FileChunk, error) {
+	var result *metadata.FileChunk
+	err := s.db.View(func(txn *badger.Txn) error {
+		prefix := []byte(fileChunkFilePrefix + payloadID + ":")
+		opts := badger.DefaultIteratorOptions
+		opts.Prefix = prefix
+		opts.PrefetchValues = false // keys only — the offset lives in the key
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		var (
+			bestOff uint64
+			found   bool
+		)
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			suffix := it.Item().Key()[len(prefix):]
+			cand, perr := strconv.ParseUint(string(suffix), 10, 64)
+			if perr != nil {
+				continue // tolerate a malformed index row, like parseBlockIdx
+			}
+			if cand <= off && (!found || cand > bestOff) {
+				bestOff, found = cand, true
+			}
+		}
+		if !found {
+			return nil // nothing starts at or before off — hole
+		}
+
+		// Fetch the winning row: index key -> block ID -> primary row. A stale
+		// index row (deleted block) is treated as a hole, mirroring
+		// listFileChunksTxn's "index stale, block deleted" skip.
+		idxItem, gerr := txn.Get([]byte(fileChunkFilePrefix + payloadID + ":" + strconv.FormatUint(bestOff, 10)))
+		if gerr != nil {
+			return nil
+		}
+		var blockID string
+		if verr := idxItem.Value(func(val []byte) error {
+			blockID = string(val)
+			return nil
+		}); verr != nil {
+			return nil
+		}
+		fbItem, gerr := txn.Get([]byte(fileChunkPrefix + blockID))
+		if gerr != nil {
+			return nil
+		}
+		var fc metadata.FileChunk
+		if verr := fbItem.Value(func(val []byte) error {
+			return json.Unmarshal(val, &fc)
+		}); verr != nil {
+			return nil
+		}
+		// Covering guard: the scan guarantees bestOff <= off; require
+		// off < bestOff+DataSize, else off falls in a hole past this chunk and
+		// must NOT be served this chunk's bytes.
+		if off >= bestOff+uint64(fc.DataSize) {
+			return nil
+		}
+		result = &fc
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 // EnumerateLivePayloadIDs streams every distinct PayloadID referenced by a live
 // inode. It scans the f: inode keyspace, decodes each file record, and collects
 // distinct non-empty PayloadIDs. Corrupt inode records are skipped so a single

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -56,6 +56,15 @@ func runFileChunkOpsTests(t *testing.T, factory StoreFactory) {
 		testListFileChunksEmptyStore(t, factory)
 	})
 
+	// GetFileChunkAtOffset is the read-path fast path: it resolves the single
+	// chunk covering a byte offset without enumerating the manifest. The
+	// covering guard (off < chunkOffset+DataSize) must return nil for a hole /
+	// past-EOF rather than a neighbouring chunk's bytes (silent corruption).
+	// Only badger implements it today; other backends skip.
+	t.Run("GetFileChunkAtOffset", func(t *testing.T) {
+		testGetFileChunkAtOffset(t, factory)
+	})
+
 	// the syncer claim cycle stamps
 	// LastSyncAttemptAt = now when flipping a block to Syncing, and the
 	// restart-recovery janitor compares it against ClaimTimeout. Every
@@ -327,6 +336,113 @@ func testDecrementRefCountAndReap(t *testing.T, factory StoreFactory) {
 }
 
 // ============================================================================
+// GetFileChunkAtOffset Test
+// ============================================================================
+
+// chunkAtOffsetProbe is the indexed covering-chunk lookup, implemented only by
+// the badger backend today. Backends without it skip the subtest.
+type chunkAtOffsetProbe interface {
+	GetFileChunkAtOffset(ctx context.Context, payloadID string, off uint64) (*block.FileChunk, error)
+}
+
+// coveringOracle independently resolves the chunk covering off by walking the
+// full ListFileChunks result with the same covering check the fast path uses —
+// the reference the indexed lookup must agree with.
+func coveringOracle(rows []*block.FileChunk, off uint64) *block.FileChunk {
+	for _, fb := range rows {
+		abs, ok := block.ParseChunkOffset(fb.ID)
+		if !ok {
+			continue
+		}
+		if off >= abs && off < abs+uint64(fb.DataSize) {
+			return fb
+		}
+	}
+	return nil
+}
+
+func testGetFileChunkAtOffset(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	probe, ok := store.(chunkAtOffsetProbe)
+	if !ok {
+		t.Skipf("backend %T does not implement GetFileChunkAtOffset", store)
+	}
+
+	// Chunks at absolute byte offsets with deliberate holes. The decimal
+	// offsets in the IDs (0, 20, 100, 200) sort lexically as 0,100,20,200 —
+	// NOT numeric order — so this exercises the decimal-vs-numeric trap the
+	// badger keys-only scan must handle. Coverage: [0,20) [20,50) [100,110)
+	// [200,300); holes at [50,100), [110,200), and past 300.
+	blocks := []*block.FileChunk{
+		{ID: "file-hole/0", State: block.BlockStatePending, DataSize: 20, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
+		{ID: "file-hole/20", State: block.BlockStatePending, DataSize: 30, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
+		{ID: "file-hole/100", State: block.BlockStatePending, DataSize: 10, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
+		{ID: "file-hole/200", State: block.BlockStatePending, DataSize: 100, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
+	}
+	for _, b := range blocks {
+		if err := store.Put(ctx, b); err != nil {
+			t.Fatalf("Put(%s): %v", b.ID, err)
+		}
+	}
+	rows, err := asLegacy(t, store).ListFileChunks(ctx, "file-hole")
+	if err != nil {
+		t.Fatalf("ListFileChunks: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		off  uint64
+		want string // covering block ID, "" for a hole
+	}{
+		{"exact-start-0", 0, "file-hole/0"},
+		{"exact-start-20", 20, "file-hole/20"},
+		{"exact-start-100", 100, "file-hole/100"},
+		{"exact-start-200", 200, "file-hole/200"},
+		{"mid-chunk-10", 10, "file-hole/0"},
+		{"mid-chunk-35", 35, "file-hole/20"},
+		{"mid-chunk-250", 250, "file-hole/200"},
+		{"last-byte-19", 19, "file-hole/0"},
+		{"last-byte-49", 49, "file-hole/20"},
+		{"hole-50", 50, ""},
+		{"hole-110", 110, ""},
+		{"hole-150", 150, ""},
+		{"past-eof-300", 300, ""},
+		{"past-eof-400", 400, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := probe.GetFileChunkAtOffset(ctx, "file-hole", tc.off)
+			if err != nil {
+				t.Fatalf("GetFileChunkAtOffset(%d): %v", tc.off, err)
+			}
+			gotID := ""
+			if got != nil {
+				gotID = got.ID
+			}
+			if gotID != tc.want {
+				t.Errorf("GetFileChunkAtOffset(%d) = %q, want %q", tc.off, gotID, tc.want)
+			}
+			// Cross-check against the independent ListFileChunks walk.
+			oracleID := ""
+			if o := coveringOracle(rows, tc.off); o != nil {
+				oracleID = o.ID
+			}
+			if gotID != oracleID {
+				t.Errorf("GetFileChunkAtOffset(%d) = %q disagrees with ListFileChunks oracle %q", tc.off, gotID, oracleID)
+			}
+		})
+	}
+
+	// Unknown payload → hole, not error.
+	if got, err := probe.GetFileChunkAtOffset(ctx, "no-such-payload", 0); err != nil {
+		t.Fatalf("GetFileChunkAtOffset(unknown): %v", err)
+	} else if got != nil {
+		t.Errorf("GetFileChunkAtOffset(unknown payload) = %q, want nil", got.ID)
+	}
+}
+
 // ListFileChunks Tests
 //
 // ListFileChunks is no longer on the public


### PR DESCRIPTION
## What

Adds `BadgerMetadataStore.GetFileChunkAtOffset` — an indexed covering-chunk lookup — and routes the read path, prefetch probe, and inline fetch through it, replacing the full per-payload `ListFileChunks` manifest enumeration that every read performed.

## Why

Every NFS/SMB read resolved *which chunk covers byte offset T* by fetching the **entire** per-payload FileChunk manifest and scanning it — **twice per read** (once on the read path, once on the prefetch probe). A live CPU profile (SCW POP2-HC-32C-64G → SCW S3 fr-par, NFSv3 random-read load) put `ListFileChunks` at **81% of read CPU**, zero network. Random reads collapsed to **~2 IOPS** on large/scattered files: O(N) per read × N reads = O(N²).

This is PR2 of the read-path perf roadmap. PR1 (#1575) removed the per-row parse cost; this removes the enumeration itself.

## How

Chunks are variable-length FastCDC; the ID is `"{payloadID}/{absoluteByteOffset}"`, so this is a **predecessor + covering-check** lookup (SeaweedFS/JuiceFS-slice pattern), not a fixed-grid direct key.

- **`GetFileChunkAtOffset`** (badger): a **keys-only** prefix scan of the existing `fb-file:{payloadID}:` secondary index tracks the largest chunk offset ≤ target (no value prefetch, no unmarshal, no sort — that's the 81%), then **two point Gets** fetch the winning row. Covering guard: `off < chunkOffset+DataSize`, else the offset is a hole/past-EOF → returns `nil` (caller zero-fills) and **never** serves a neighbour chunk's bytes.
- **`resolveCovering`** + narrow `chunkAtOffsetResolver` interface (engine): type-asserts badger for the indexed path, falls back to the existing `ListFileChunks`+walk for memory/sqlite/postgres. No `EngineFileChunkStore` widening, **no schema migration**.
- Rewires `readLocalByHash`, `resolveFileChunk` (thin wrapper), `EnsureAvailableAndRead`/`inlineFetchOrWait` (resolve per-block). Deletes the now-dead `resolveFileChunkFromRows` / `blockIsLocalFromRows`.

True O(log N) (fixed-width big-endian offset key + reverse-seek) is deferred — the keys-only scan already removes essentially all the cost at realistic N.

## Impact

Covering-lookup microbench on a 4096-chunk manifest:

| | ns/op | allocs/op |
|---|---|---|
| old `ListFileChunks`+walk | 16,798,320 | 78,415 |
| new `GetFileChunkAtOffset` | 378,288 | 51 |

**~44× faster, allocations 78,415 → 51** (33× at n=256 — scales with N as expected). Full VM fio→IOPS (~2 → thousands) is the roadmap's end-to-end gate, to run when the bench VM is next up.

## Correctness

The covering guard is the linchpin (a predecessor without the range check would serve a neighbour's bytes into a hole = silent corruption). Guarded by:
- New storetest `GetFileChunkAtOffset` case: exact-start / mid-chunk / hole-between-chunks / past-EOF / empty-payload, cross-checked against a `ListFileChunks`+walk oracle, with a deliberately lexically-scrambled decimal-offset layout (0/20/100/200) to exercise the decimal-vs-numeric trap.
- Existing sparse/hole/EOF suites stay green: `copychunk_sparse_dest_test.go`, `dataextents_test.go`, `range_test.go`, `api_blockref_test.go`, `truncate_block_refs.go`.

## Verification

- `go build ./...`, `go vet`, `gofmt -s`, `golangci-lint`: clean.
- **3599 block+metadata tests pass, race-clean.**
- `code-simplifier` + `code-reviewer`: clean (one dedup applied; reviewer confirmed the covering guard, decimal-ordering, parity, and error/stale-index behavior all sound).

Refs #1572