### PR TITLE
fix(block): clear rollup_offset on delete even when a rollup raced it

### DIFF
--- a/pkg/block/local/fs/appendwrite.go
+++ b/pkg/block/local/fs/appendwrite.go
@@ -531,11 +531,13 @@ func (bc *FSStore) AppendWrite(ctx context.Context, payloadID string, data []byt
 //     for a tombstoned payload even if it acquired the mutex first — so
 //     once we hold the mutex, metadata is guaranteed consistent with the
 //     tombstone we just set.
-//  3. Clear the rollup_offset row (best-effort; rejection is
-//     expected when a prior rollup persisted a positive offset and is
-//     treated as benign — the tombstone blocks any future rollup so a
-//     residual positive offset is harmless once the log and dirty state
-//     are gone).
+//  3. Reset the rollup_offset row to 0. SetRollupOffset treats newOffset==0
+//     as an unconditional reset that bypasses the monotone guard (see
+//     metadata.RollupStore), so this reliably removes the row even when a
+//     rollup that raced this delete already persisted a positive offset. The
+//     rmu drain in step 2 guarantees that racing rollup has fully committed
+//     before we get here, and the tombstone blocks any future rollup — so
+//     after this the fence is gone and stays gone (no zombie row).
 //  4. Close + unlink the log file.
 //  5. Clear per-file in-memory state (fd, lock, interval tree
 //     truncation boundary) AND clear the tombstone — the drain in
@@ -590,15 +592,17 @@ func (bc *FSStore) DeleteAppendLog(ctx context.Context, payloadID string) error 
 		mu.Unlock() //nolint:staticcheck // SA2001: see above
 	}
 
-	// Step 3: clear metadata row (source of truth advance).
-	// monotone enforcement means SetRollupOffset(payloadID, 0) is
-	// rejected with ErrRollupOffsetRegression when a prior rollup
-	// persisted a positive offset. That rejection is BENIGN: the
-	// tombstone set in step 1 prevents any future rollup from touching
-	// this payload, and mark-sweep GC will collect the
-	// associated chunks. We deliberately swallow the error.
+	// Step 3: clear the metadata row. SetRollupOffset(payloadID, 0) is an
+	// unconditional reset (0 == unrolled sentinel) that bypasses the monotone
+	// guard, so it removes the row even when a rollup that raced this delete
+	// already persisted a positive offset — the rmu drain in step 2 guarantees
+	// that rollup has fully committed by now, and the tombstone blocks any
+	// future one. This is what keeps a deleted payload from leaving a zombie
+	// rollup_offset row behind. mark-sweep GC collects the associated chunks.
 	if bc.rollupStore != nil {
-		_, _ = bc.rollupStore.SetRollupOffset(ctx, payloadID, 0)
+		if _, err := bc.rollupStore.SetRollupOffset(ctx, payloadID, 0); err != nil {
+			logger.Warn("DeleteAppendLog: rollup_offset reset failed", "payloadID", payloadID, "error", err)
+		}
 	}
 
 	// Step 4: close + unlink the log file. Closing an already-closed fd is

--- a/pkg/metadata/rollup_store.go
+++ b/pkg/metadata/rollup_store.go
@@ -29,6 +29,16 @@ type RollupStore interface {
 	//
 	// On monotone violation (newOffset < stored), returns (storedOffset,
 	// ErrRollupOffsetRegression); the stored value is unchanged.
+	//
+	// newOffset == 0 is a special case: it unconditionally resets (removes)
+	// the stored offset, bypassing the monotone guard, and returns the
+	// previous value with a nil error. 0 is the "unrolled" sentinel —
+	// GetRollupOffset already reports an absent row as 0 — so a reset is
+	// observationally identical to "never rolled up". DeleteAppendLog relies
+	// on this to clear a deleted payload's fence even when a racing rollup
+	// already persisted a positive offset (otherwise the row leaks as a
+	// zombie). rollupFile only ever persists positive offsets, so this never
+	// collides with a legitimate monotone advance.
 	SetRollupOffset(ctx context.Context, payloadID string, newOffset uint64) (storedOffset uint64, err error)
 
 	// GetRollupOffset returns the persisted rollup_offset for payloadID.

--- a/pkg/metadata/rollup_store_suite.go
+++ b/pkg/metadata/rollup_store_suite.go
@@ -1,7 +1,7 @@
 // Package metadata — rollup_store_suite.go.
 //
 // Shared conformance suite for the RollupStore interface. Each metadata
-// backend (memory, badger, postgres) exercises this suite to prove it
+// backend (memory, badger, postgres, sqlite) exercises this suite to prove it
 // upholds the atomic-monotone contract.
 //
 // The suite lives in the metadata package rather than storetest to keep
@@ -123,6 +123,33 @@ func RunRollupStoreSuite(t *testing.T, rs RollupStore) {
 		}
 		if got != 500 {
 			t.Fatalf("stored offset regressed despite ErrRollupOffsetRegression: got %d want 500", got)
+		}
+	})
+
+	t.Run("SetRollupOffset_ZeroResets", func(t *testing.T) {
+		// newOffset == 0 unconditionally resets the row, bypassing the
+		// monotone guard — the escape hatch DeleteAppendLog uses to clear a
+		// deleted payload's fence even behind a racing rollup's positive
+		// offset. Without this the row leaks as a zombie (issue #1570 CI flake).
+		ctx := context.Background()
+		const pid = "suite-zero-reset"
+
+		if _, err := rs.SetRollupOffset(ctx, pid, 900); err != nil {
+			t.Fatalf("initial Set: %v", err)
+		}
+		prev, err := rs.SetRollupOffset(ctx, pid, 0)
+		if err != nil {
+			t.Fatalf("reset to 0 must not error (monotone guard bypassed): %v", err)
+		}
+		if prev != 900 {
+			t.Fatalf("reset prev: got %d want 900", prev)
+		}
+		got, err := rs.GetRollupOffset(ctx, pid)
+		if err != nil {
+			t.Fatalf("Get after reset: %v", err)
+		}
+		if got != 0 {
+			t.Fatalf("offset after reset: got %d want 0", got)
 		}
 	})
 

--- a/pkg/metadata/store/badger/rollup.go
+++ b/pkg/metadata/store/badger/rollup.go
@@ -83,6 +83,15 @@ func (s *BadgerMetadataStore) SetRollupOffset(ctx context.Context, payloadID str
 			}
 		}
 
+		if newOffset == 0 {
+			// 0 is the "unrolled" sentinel: unconditionally clear the row,
+			// bypassing the monotone guard. DeleteAppendLog uses this to drop a
+			// deleted payload's fence even when a racing rollup already
+			// persisted a positive offset — otherwise the row leaks as a
+			// zombie. Delete of a missing key is a no-op.
+			return txn.Delete(keyRollupOffset(payloadID))
+		}
+
 		if newOffset < prev {
 			// Regression rejected. Commit the txn with no write so the
 			// stored value remains untouched.

--- a/pkg/metadata/store/memory/rollup.go
+++ b/pkg/metadata/store/memory/rollup.go
@@ -26,6 +26,14 @@ func (s *MemoryMetadataStore) SetRollupOffset(ctx context.Context, payloadID str
 		s.rollupOffsets = make(map[string]uint64)
 	}
 	prev := s.rollupOffsets[payloadID]
+	if newOffset == 0 {
+		// 0 is the "unrolled" sentinel: unconditionally clear the row,
+		// bypassing the monotone guard. DeleteAppendLog uses this to drop a
+		// deleted payload's fence even when a racing rollup already persisted
+		// a positive offset — otherwise the row leaks as a zombie.
+		delete(s.rollupOffsets, payloadID)
+		return prev, nil
+	}
 	if newOffset < prev {
 		// Regression rejected; leave stored value untouched.
 		return prev, metadata.ErrRollupOffsetRegression

--- a/pkg/metadata/store/postgres/rollup.go
+++ b/pkg/metadata/store/postgres/rollup.go
@@ -100,6 +100,21 @@ func (s *PostgresMetadataStore) SetRollupOffset(ctx context.Context, payloadID s
 		prev = v
 	}
 
+	if newOffset == 0 {
+		// 0 is the "unrolled" sentinel: unconditionally delete the row,
+		// bypassing the monotone WHERE guard. DeleteAppendLog uses this to drop
+		// a deleted payload's fence even when a racing rollup already persisted
+		// a positive offset — otherwise the row leaks as a zombie.
+		if _, err := tx.Exec(ctx,
+			`DELETE FROM rollup_offsets WHERE payload_id = $1`, payloadID); err != nil {
+			return 0, fmt.Errorf("postgres rollup reset: %w", err)
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return 0, fmt.Errorf("postgres rollup reset commit: %w", err)
+		}
+		return prev, nil
+	}
+
 	// Monotone upsert: the WHERE predicate rejects a strictly-lower offset on
 	// the conflict branch, so a regression performs no write and reports
 	// RowsAffected()==0. This is the single point that enforces INV-03 and is

--- a/pkg/metadata/store/sqlite/rollup.go
+++ b/pkg/metadata/store/sqlite/rollup.go
@@ -101,6 +101,22 @@ func (s *SQLiteMetadataStore) SetRollupOffset(ctx context.Context, payloadID str
 		prev = v
 	}
 
+	if newOffset == 0 {
+		// 0 is the "unrolled" sentinel: unconditionally delete the row,
+		// bypassing the monotone WHERE guard. DeleteAppendLog uses this to drop
+		// a deleted payload's fence even when a racing rollup already persisted
+		// a positive offset — otherwise the row leaks as a zombie.
+		if _, err := tx.Exec(ctx,
+			`DELETE FROM rollup_offsets WHERE payload_id = ?1`, payloadID); err != nil {
+			return 0, fmt.Errorf("sqlite rollup reset: %w", err)
+		}
+		if err := rawTx.Commit(); err != nil {
+			return 0, fmt.Errorf("sqlite rollup reset commit: %w", err)
+		}
+		committed = true
+		return prev, nil
+	}
+
 	// Monotone upsert: the WHERE predicate rejects a strictly-lower offset on
 	// the conflict branch, so a regression performs no write and reports
 	// RowsAffected()==0. This is the single point that enforces INV-03 and is

--- a/pkg/metadata/store/sqlite/rollup_test.go
+++ b/pkg/metadata/store/sqlite/rollup_test.go
@@ -1,0 +1,28 @@
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
+)
+
+// TestSQLiteRollupStore_Suite runs the shared RollupStore conformance suite
+// against the SQLite backend, so every backend (memory, badger, postgres,
+// sqlite) exercises the same contract from a single source of truth —
+// including the newOffset==0 unconditional-reset behavior.
+func TestSQLiteRollupStore_Suite(t *testing.T) {
+	cfg := &sqlite.SQLiteMetadataStoreConfig{
+		Path:        filepath.Join(t.TempDir(), "rollup.db"),
+		AutoMigrate: true,
+	}
+	store, err := sqlite.NewSQLiteMetadataStore(context.Background(), cfg, sqliteTestCapabilities())
+	if err != nil {
+		t.Fatalf("NewSQLiteMetadataStore() failed: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	metadata.RunRollupStoreSuite(t, store)
+}


### PR DESCRIPTION
## Problem

CI flake `TestDelete_DuringActiveRollup_NoMetadataZombie` (`pkg/block/local/fs`): `delete_truncate_test.go:292: zombie rollup_offset row for deleted payload: got 65616 want 0`.

Not a timing artifact — a real ordering bug. `DeleteAppendLog` clears a deleted payload's rollup fence with `SetRollupOffset(payloadID, 0)`, but that setter is **atomic-monotone**: when a `rollupFile` pass races the delete and commits a positive offset first, the `0` is rejected with `ErrRollupOffsetRegression` and the error was swallowed — leaving a **zombie `rollup_offset` row** keyed by a now-dead UUID payload. On persistent backends (badger/postgres/sqlite) this leaks unbounded under create/delete churn.

## Fix

Make `SetRollupOffset(pid, 0)` an **unconditional reset** across all four backends (memory/badger/postgres/sqlite): `0` is the "unrolled" sentinel (`GetRollupOffset` already maps an absent row to `0`), so a reset is observationally identical to "never rolled up" and safely bypasses the monotone guard.

- The `rmu` drain in `DeleteAppendLog` guarantees any racing rollup has **fully committed** before the reset runs, and the tombstone blocks any future rollup — so the reset reliably removes the row (race-safe; verified by tracing `rollupFileInner`'s lock/tombstone sequence).
- `rollupFile` only ever persists positive offsets, so `0` never collides with a legitimate monotone advance. `DeleteAppendLog` is the only `0` caller.
- Documented in the `RollupStore` interface contract.

## Tests

- New conformance subtest `SetRollupOffset_ZeroResets` in the shared `RollupStore` suite — fails on the old (monotone-rejecting) impls, passes on the new, across **all four** backends.
- Added the missing `TestSQLiteRollupStore_Suite` wiring (SQLite was never running the shared suite — caught in review).
- `DeleteAppendLog` now logs the reset error instead of swallowing it.

Verified: previously-flaky `TestDelete_DuringActiveRollup_NoMetadataZombie` passes 30/30 under `-race`; 2680 `pkg/metadata` + `pkg/block/local/fs` tests green; gofmt/vet/golangci-lint clean.