### PR TITLE
perf(metadata): collapse redundant per-op GetFile on the read/write hot path

### DIFF
--- a/internal/adapter/nfs/v3/handlers/doc.go
+++ b/internal/adapter/nfs/v3/handlers/doc.go
@@ -182,7 +182,9 @@ func (h *Handler) getFileOrError(
 	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
 	metaSvc := h.Registry.GetMetadataService()
 
-	file, err := metaSvc.GetFile(ctx.Context, fileHandle)
+	// GetFileForRead: NFS is handle-addressed, so no v3 handler reads
+	// File.Path — skip the derivePath parent-edge walk on this hot path.
+	file, err := metaSvc.GetFileForRead(ctx.Context, fileHandle)
 	if err != nil {
 		// Check if the error is due to context cancellation
 		if ctx.Context.Err() != nil {

--- a/internal/adapter/nfs/v3/handlers/fsinfo.go
+++ b/internal/adapter/nfs/v3/handlers/fsinfo.go
@@ -150,7 +150,7 @@ func (h *Handler) FsInfo(
 		return &FsInfoResponse{NFSResponseBase: NFSResponseBase{Status: status}}, err
 	}
 
-	logger.DebugCtx(ctx.Context, "FSINFO", "share", ctx.Share, "path", file.Path)
+	logger.DebugCtx(ctx.Context, "FSINFO", "share", ctx.Share)
 
 	// Retrieve filesystem capabilities from the store
 	// All business logic about filesystem limits is handled by the store

--- a/internal/adapter/nfs/v3/handlers/fsstat.go
+++ b/internal/adapter/nfs/v3/handlers/fsstat.go
@@ -130,7 +130,7 @@ func (h *Handler) FsStat(
 		return &FsStatResponse{NFSResponseBase: NFSResponseBase{Status: status}}, err
 	}
 
-	logger.DebugCtx(ctx.Context, "FSSTAT", "share", ctx.Share, "path", file.Path)
+	logger.DebugCtx(ctx.Context, "FSSTAT", "share", ctx.Share)
 
 	// Check context before store call
 	if ctx.isContextCancelled() {

--- a/internal/adapter/nfs/v3/handlers/getattr.go
+++ b/internal/adapter/nfs/v3/handlers/getattr.go
@@ -94,8 +94,7 @@ func (h *Handler) GetAttr(
 	}
 
 	logger.DebugCtx(ctx.Context, "GETATTR",
-		"share", ctx.Share,
-		"path", file.Path)
+		"share", ctx.Share)
 
 	// The file ID is extracted from the handle for NFS protocol purposes.
 	// This is a protocol-layer concern for creating the wire format.

--- a/internal/adapter/nfs/v3/handlers/read.go
+++ b/internal/adapter/nfs/v3/handlers/read.go
@@ -187,7 +187,11 @@ func (h *Handler) Read(
 		}, nil
 	}
 
-	if _, err := metaSvc.PrepareRead(authCtx, fileHandle); err != nil {
+	// Gate the read on the File already loaded above (getFileOrError). Using
+	// the in-hand file avoids PrepareRead's redundant re-fetch of the same
+	// inode (and the permission path's own re-fetch) — the regular-file check
+	// PrepareRead also performs was already done above.
+	if err := metaSvc.CheckReadPermissionFile(authCtx, fileHandle, file); err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, err
 		}

--- a/internal/adapter/nfs/v4/handlers/commit.go
+++ b/internal/adapter/nfs/v4/handlers/commit.go
@@ -83,7 +83,8 @@ func (h *Handler) handleCommit(ctx *types.CompoundContext, reader io.Reader) *ty
 	}
 
 	fileHandle := metadata.FileHandle(ctx.CurrentFH)
-	file, err := metaSvc.GetFile(authCtx.Context, fileHandle)
+	// GetFileForRead: handle-addressed, File.Path unused — skip derivePath.
+	file, err := metaSvc.GetFileForRead(authCtx.Context, fileHandle)
 	if err != nil {
 		status := common.MapToNFS4(err)
 		return &types.CompoundResult{

--- a/internal/adapter/nfs/v4/handlers/read.go
+++ b/internal/adapter/nfs/v4/handlers/read.go
@@ -131,7 +131,8 @@ func (h *Handler) handleRead(ctx *types.CompoundContext, reader io.Reader) *type
 
 	// Get file attributes
 	fileHandle := metadata.FileHandle(ctx.CurrentFH)
-	file, err := metaSvc.GetFile(authCtx.Context, fileHandle)
+	// GetFileForRead: handle-addressed, File.Path unused — skip derivePath.
+	file, err := metaSvc.GetFileForRead(authCtx.Context, fileHandle)
 	if err != nil {
 		status := common.MapToNFS4(err)
 		return &types.CompoundResult{

--- a/internal/adapter/nfs/v4/handlers/read_plus.go
+++ b/internal/adapter/nfs/v4/handlers/read_plus.go
@@ -87,7 +87,8 @@ func (h *Handler) handleReadPlus(ctx *types.CompoundContext, reader io.Reader) *
 		return readPlusErr(types.NFS4ERR_SERVERFAULT)
 	}
 
-	file, err := metaSvc.GetFile(authCtx.Context, metadata.FileHandle(ctx.CurrentFH))
+	// GetFileForRead: handle-addressed, File.Path unused — skip derivePath.
+	file, err := metaSvc.GetFileForRead(authCtx.Context, metadata.FileHandle(ctx.CurrentFH))
 	if err != nil {
 		return readPlusErr(common.MapToNFS4(err))
 	}

--- a/internal/adapter/nfs/v4/handlers/seek.go
+++ b/internal/adapter/nfs/v4/handlers/seek.go
@@ -79,7 +79,8 @@ func (h *Handler) handleSeek(ctx *types.CompoundContext, reader io.Reader) *type
 		return seekErr(types.NFS4ERR_SERVERFAULT)
 	}
 
-	file, err := metaSvc.GetFile(authCtx.Context, metadata.FileHandle(ctx.CurrentFH))
+	// GetFileForRead: handle-addressed, File.Path unused — skip derivePath.
+	file, err := metaSvc.GetFileForRead(authCtx.Context, metadata.FileHandle(ctx.CurrentFH))
 	if err != nil {
 		return seekErr(common.MapToNFS4(err))
 	}

--- a/internal/adapter/nfs/v4/handlers/verify.go
+++ b/internal/adapter/nfs/v4/handlers/verify.go
@@ -67,7 +67,8 @@ func verifyAttributes(h *Handler, ctx *types.CompoundContext, reader io.Reader) 
 			return false, types.NFS4ERR_SERVERFAULT
 		}
 
-		file, getErr := metaSvc.GetFile(authCtx.Context, metadata.FileHandle(ctx.CurrentFH))
+		// GetFileForRead: handle-addressed, File.Path unused — skip derivePath.
+		file, getErr := metaSvc.GetFileForRead(authCtx.Context, metadata.FileHandle(ctx.CurrentFH))
 		if getErr != nil {
 			return false, common.MapToNFS4(getErr)
 		}

--- a/internal/adapter/smb/handlers/flush.go
+++ b/internal/adapter/smb/handlers/flush.go
@@ -218,7 +218,7 @@ func (h *Handler) Flush(ctx *SMBHandlerContext, req *FlushRequest) (*FlushRespon
 	}
 
 	// Verify file exists
-	file, err := metaSvc.GetFile(ctx.Context, openFile.MetadataHandle)
+	file, err := metaSvc.GetFileForRead(ctx.Context, openFile.MetadataHandle)
 	if err != nil {
 		logger.Debug("FLUSH: file not found", "path", openFile.Path, "error", err)
 		return &FlushResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}, nil

--- a/internal/adapter/smb/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk.go
@@ -366,7 +366,7 @@ func (h *Handler) executeCopyChunks(
 		return NewErrorResult(types.StatusInternalError), nil
 	}
 
-	srcFile, err := metaSvc.GetFile(ctx.Context, srcOpen.MetadataHandle)
+	srcFile, err := metaSvc.GetFileForRead(ctx.Context, srcOpen.MetadataHandle)
 	if err != nil {
 		logger.Debug("COPYCHUNK: failed to get source file", "path", srcOpen.Path, "error", err)
 		return NewErrorResult(common.MapToSMB(err)), nil

--- a/internal/adapter/smb/handlers/ioctl_fsctl.go
+++ b/internal/adapter/smb/handlers/ioctl_fsctl.go
@@ -28,7 +28,7 @@ func (h *Handler) handleGetCompression(ctx *SMBHandlerContext, body []byte) (*Ha
 	// Read compression state from metadata (persistent across handles).
 	var format uint16
 	metaSvc := h.Registry.GetMetadataService()
-	file, err := metaSvc.GetFile(ctx.Context, openFile.MetadataHandle)
+	file, err := metaSvc.GetFileForRead(ctx.Context, openFile.MetadataHandle)
 	if err != nil {
 		return NewErrorResult(common.MapToSMB(err)), nil
 	}
@@ -231,7 +231,7 @@ func (h *Handler) handleQueryFileRegions(ctx *SMBHandlerContext, body []byte) (*
 
 	// Get file size from metadata
 	metaSvc := h.Registry.GetMetadataService()
-	file, err := metaSvc.GetFile(ctx.Context, openFile.MetadataHandle)
+	file, err := metaSvc.GetFileForRead(ctx.Context, openFile.MetadataHandle)
 	if err != nil {
 		return NewErrorResult(common.MapToSMB(err)), nil
 	}

--- a/internal/adapter/smb/handlers/read.go
+++ b/internal/adapter/smb/handlers/read.go
@@ -302,6 +302,19 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 		return h.handleSymlinkRead(ctx, openFile, file, req)
 	}
 
+	// Only regular files are readable. PrepareRead used to reject directories
+	// and other special types (FIFO/socket/device) before it was folded out of
+	// the read path; preserve that so a cross-protocol special node can't fall
+	// through to an empty EOF read instead of a proper error.
+	if file.Type != metadata.FileTypeRegular {
+		rerr := &metadata.StoreError{Code: metadata.ErrInvalidArgument, Message: "cannot read non-regular file"}
+		if file.Type == metadata.FileTypeDirectory {
+			rerr = &metadata.StoreError{Code: metadata.ErrIsDirectory, Message: "cannot read directory"}
+		}
+		logger.Debug("READ: not a regular file", "path", openFile.Path, "type", file.Type)
+		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(rerr)}}, nil
+	}
+
 	// Validate read permission on the already-loaded file (no re-fetch).
 	if err := metaSvc.CheckReadPermissionFile(authCtx, openFile.MetadataHandle, file); err != nil {
 		logger.Debug("READ: permission check failed", "path", openFile.Path, "error", err)

--- a/internal/adapter/smb/handlers/read.go
+++ b/internal/adapter/smb/handlers/read.go
@@ -334,7 +334,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// Step 9: Handle zero-length reads and EOF conditions
 	// ========================================================================
 
-	fileSize := file.FileAttr.Size
+	fileSize := file.Size
 
 	// Per MS-SMB2 and Windows behavior (confirmed by smbtorture smb2.read.eof):
 	//   - Zero-length read with MinimumCount == 0: always STATUS_OK (even past EOF)
@@ -355,10 +355,10 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 		}, nil
 	}
 
-	if file.FileAttr.PayloadID == "" || fileSize == 0 || req.Offset >= fileSize {
+	if file.PayloadID == "" || fileSize == 0 || req.Offset >= fileSize {
 		logger.Debug("READ: at or beyond EOF", "path", openFile.Path,
 			"offset", req.Offset, "size", fileSize,
-			"hasPayload", file.FileAttr.PayloadID != "")
+			"hasPayload", file.PayloadID != "")
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusEndOfFile}}, nil
 	}
 
@@ -387,7 +387,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// SMBResponseBase.ReleaseData so the pool.Put fires AFTER the wire write
 	// completes (plain, encrypted, compound). On error paths the helper
 	// already returns the buffer internally, so ReleaseData stays nil.
-	readResult, err := common.ReadFromBlockStore(authCtx.Context, blockStore, file.FileAttr.PayloadID, req.Offset, actualLength)
+	readResult, err := common.ReadFromBlockStore(authCtx.Context, blockStore, file.PayloadID, req.Offset, actualLength)
 	if err != nil {
 		logger.Warn("READ: content read failed", "path", openFile.Path, "error", err)
 		// common.MapContentToSMB mirrors the old ContentErrorToSMBStatus

--- a/internal/adapter/smb/handlers/read.go
+++ b/internal/adapter/smb/handlers/read.go
@@ -289,7 +289,9 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// Step 7: Check for symlink - generate MFsymlink content on-the-fly
 	// ========================================================================
 
-	file, err := metaSvc.GetFile(authCtx.Context, openFile.MetadataHandle)
+	// GetFileForRead skips the expensive File.Path derivation; read.go never
+	// reads file.Path (loggers use openFile.Path, symlink uses file.LinkTarget).
+	file, err := metaSvc.GetFileForRead(authCtx.Context, openFile.MetadataHandle)
 	if err != nil {
 		logger.Debug("READ: failed to get file metadata", "path", openFile.Path, "error", err)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}, nil
@@ -300,9 +302,8 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 		return h.handleSymlinkRead(ctx, openFile, file, req)
 	}
 
-	// Validate read permission using PrepareRead (for regular files only)
-	readMeta, err := metaSvc.PrepareRead(authCtx, openFile.MetadataHandle)
-	if err != nil {
+	// Validate read permission on the already-loaded file (no re-fetch).
+	if err := metaSvc.CheckReadPermissionFile(authCtx, openFile.MetadataHandle, file); err != nil {
 		logger.Debug("READ: permission check failed", "path", openFile.Path, "error", err)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}, nil
 	}
@@ -333,7 +334,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// Step 9: Handle zero-length reads and EOF conditions
 	// ========================================================================
 
-	fileSize := readMeta.Attr.Size
+	fileSize := file.FileAttr.Size
 
 	// Per MS-SMB2 and Windows behavior (confirmed by smbtorture smb2.read.eof):
 	//   - Zero-length read with MinimumCount == 0: always STATUS_OK (even past EOF)
@@ -354,10 +355,10 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 		}, nil
 	}
 
-	if readMeta.Attr.PayloadID == "" || fileSize == 0 || req.Offset >= fileSize {
+	if file.FileAttr.PayloadID == "" || fileSize == 0 || req.Offset >= fileSize {
 		logger.Debug("READ: at or beyond EOF", "path", openFile.Path,
 			"offset", req.Offset, "size", fileSize,
-			"hasPayload", readMeta.Attr.PayloadID != "")
+			"hasPayload", file.FileAttr.PayloadID != "")
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusEndOfFile}}, nil
 	}
 
@@ -386,7 +387,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// SMBResponseBase.ReleaseData so the pool.Put fires AFTER the wire write
 	// completes (plain, encrypted, compound). On error paths the helper
 	// already returns the buffer internally, so ReleaseData stays nil.
-	readResult, err := common.ReadFromBlockStore(authCtx.Context, blockStore, readMeta.Attr.PayloadID, req.Offset, actualLength)
+	readResult, err := common.ReadFromBlockStore(authCtx.Context, blockStore, file.FileAttr.PayloadID, req.Offset, actualLength)
 	if err != nil {
 		logger.Warn("READ: content read failed", "path", openFile.Path, "error", err)
 		// common.MapContentToSMB mirrors the old ContentErrorToSMBStatus

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -243,6 +243,26 @@ func (s *Service) checkFilePermissions(ctx *AuthContext, handle FileHandle, requ
 		return 0, err
 	}
 
+	return s.checkFilePermissionsFile(ctx, handle, file, requested)
+}
+
+// checkFilePermissionsFile is checkFilePermissions on an already-loaded file:
+// it skips the store.GetFile re-fetch (and its derivePath + JSON decode) so a
+// caller that already holds the File — e.g. the NFS READ/WRITE handlers, which
+// loaded it once via getFileOrError — pays for the inode lookup once per op
+// rather than two or three times. handle is used only for cheap store routing
+// and the share read-only lookup, never to re-read the file.
+func (s *Service) checkFilePermissionsFile(ctx *AuthContext, handle FileHandle, file *File, requested Permission) (Permission, error) {
+	store, err := s.storeForHandle(handle)
+	if err != nil {
+		return 0, err
+	}
+
+	// Check context
+	if err := ctx.Context.Err(); err != nil {
+		return 0, err
+	}
+
 	// Get share options for read-only check
 	shareOpts, err := store.GetShareOptions(ctx.Context, file.ShareName)
 	if err != nil {
@@ -489,6 +509,23 @@ func (s *Service) checkPermission(ctx *AuthContext, handle FileHandle, perm Perm
 	if err != nil {
 		return err
 	}
+	return s.permissionResult(ctx, handle, granted, perm, msg)
+}
+
+// checkPermissionFile is checkPermission on an already-loaded file — it routes
+// the permission evaluation through checkFilePermissionsFile so the READ/WRITE
+// handlers avoid re-fetching an inode they already hold.
+func (s *Service) checkPermissionFile(ctx *AuthContext, handle FileHandle, file *File, perm Permission, msg string) error {
+	granted, err := s.checkFilePermissionsFile(ctx, handle, file, perm)
+	if err != nil {
+		return err
+	}
+	return s.permissionResult(ctx, handle, granted, perm, msg)
+}
+
+// permissionResult maps a granted-permission mask to the denial error a caller
+// should surface, or nil when the requested permission is granted.
+func (s *Service) permissionResult(ctx *AuthContext, handle FileHandle, granted, perm Permission, msg string) error {
 	if granted&perm == 0 {
 		// A write or delete denied because the share/export itself is
 		// read-only must surface as ErrReadOnly so NFSv3 returns
@@ -510,6 +547,14 @@ func (s *Service) checkPermission(ctx *AuthContext, handle FileHandle, perm Perm
 		}
 	}
 	return nil
+}
+
+// CheckReadPermissionFile verifies read permission on an already-loaded file,
+// without re-fetching it. The NFS READ handler uses this to gate a read on the
+// File it already loaded via getFileOrError, replacing PrepareRead's redundant
+// inode re-fetch + permission-path re-fetch.
+func (s *Service) CheckReadPermissionFile(ctx *AuthContext, handle FileHandle, file *File) error {
+	return s.checkPermissionFile(ctx, handle, file, PermissionRead, "read permission denied")
 }
 
 // shareForbidsWrites reports whether a read-only ceiling — per-user

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -594,6 +594,14 @@ func (s *Service) checkWritePermission(ctx *AuthContext, handle FileHandle) erro
 	return s.checkPermission(ctx, handle, PermissionWrite, "write permission denied")
 }
 
+// checkWritePermissionFile is checkWritePermission on an already-loaded file —
+// PrepareWrite holds the file (its own cache/fetch) before checking, so this
+// avoids the permission path's redundant re-fetch (store.GetFile + derivePath +
+// JSON decode) on every write.
+func (s *Service) checkWritePermissionFile(ctx *AuthContext, handle FileHandle, file *File) error {
+	return s.checkPermissionFile(ctx, handle, file, PermissionWrite, "write permission denied")
+}
+
 // CheckParentWriteAccess verifies the caller may add or remove a child entry
 // in the given directory. It is the public, protocol-facing entry point that
 // SMB / NFS handlers call before attempting an entry-creating or

--- a/pkg/metadata/io.go
+++ b/pkg/metadata/io.go
@@ -90,9 +90,11 @@ func (s *Service) PrepareWrite(ctx *AuthContext, handle FileHandle, newSize uint
 	// Fast path: check if we have cached file metadata from a previous write
 	// This avoids store.GetFile for sequential writes to the same file
 	var file *File
+	freshFetch := false
 	if cachedFile := s.pendingWrites.GetCachedFile(handle); cachedFile != nil {
 		file = cachedFile
 	} else {
+		freshFetch = true
 		// Slow path: fetch from store
 		fetchedFile, err := store.GetFile(ctx.Context, handle)
 		if err != nil {
@@ -157,8 +159,19 @@ func (s *Service) PrepareWrite(ctx *AuthContext, handle FileHandle, newSize uint
 	// DOS READONLY (mode bit 0x100000) is enforced for owners. calculatePermissions
 	// already handles owner vs non-owner mode-bit evaluation correctly (owner gets
 	// bits 6-8), and it gates on 0x100000 regardless of ownership.
-	if err := s.checkWritePermission(ctx, handle); err != nil {
-		return nil, err
+	// Permission gate. On a cache miss `file` is a fresh store read, so reuse it
+	// (no redundant second fetch). On a cache hit the cached file may be stale
+	// vs a concurrent chmod, so re-read current mode via checkWritePermission —
+	// permission is a security boundary and must not be checked against a
+	// possibly-stale cache (unlike the soft size/quota checks above).
+	permErr := error(nil)
+	if freshFetch {
+		permErr = s.checkWritePermissionFile(ctx, handle, file)
+	} else {
+		permErr = s.checkWritePermission(ctx, handle)
+	}
+	if permErr != nil {
+		return nil, permErr
 	}
 
 	// Make a copy of current attributes for PreWriteAttr

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -773,24 +773,59 @@ func (s *Service) GetFile(ctx context.Context, handle FileHandle) (*File, error)
 		return nil, err
 	}
 
-	// Check for pending write state (when deferred commits are enabled)
-	if pending, ok := s.pendingWrites.GetPending(handle); ok {
-		// Merge pending state with stored state
-		if pending.MaxSize > file.Size {
-			file.Size = pending.MaxSize
-		}
-		// Update timestamps from pending state
-		if pending.LastMtime.After(file.Mtime) {
-			file.Mtime = pending.LastMtime
-			file.Ctime = pending.LastMtime
-		}
-		// Apply setuid/setgid clearing
-		if pending.ClearSetuidSetgid {
-			file.Mode &= ^uint32(0o6000)
-		}
+	s.mergePendingWrites(handle, file)
+	return file, nil
+}
+
+// fileForReadStore is the optional read fast path — a GetFile that skips
+// deriving File.Path. Implemented only by the badger backend; other backends
+// fall through to the regular GetFile in GetFileForRead.
+type fileForReadStore interface {
+	GetFileForRead(ctx context.Context, handle FileHandle) (*File, error)
+}
+
+// GetFileForRead loads a file for the handle-addressed hot paths (NFS
+// READ/WRITE/GETATTR) that never read File.Path. When the backend implements
+// fileForReadStore it skips the derivePath parent-edge walk; otherwise it
+// falls back to GetFile. Pending write state is merged identically to GetFile.
+func (s *Service) GetFileForRead(ctx context.Context, handle FileHandle) (*File, error) {
+	store, err := s.storeForHandle(handle)
+	if err != nil {
+		return nil, err
 	}
 
+	var file *File
+	if r, ok := store.(fileForReadStore); ok {
+		file, err = r.GetFileForRead(ctx, handle)
+	} else {
+		file, err = store.GetFile(ctx, handle)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	s.mergePendingWrites(handle, file)
 	return file, nil
+}
+
+// mergePendingWrites overlays deferred-commit state (size, mtime/ctime,
+// setuid/setgid clearing) onto a freshly loaded file, so a read sees its own
+// not-yet-persisted writes.
+func (s *Service) mergePendingWrites(handle FileHandle, file *File) {
+	pending, ok := s.pendingWrites.GetPending(handle)
+	if !ok {
+		return
+	}
+	if pending.MaxSize > file.Size {
+		file.Size = pending.MaxSize
+	}
+	if pending.LastMtime.After(file.Mtime) {
+		file.Mtime = pending.LastMtime
+		file.Ctime = pending.LastMtime
+	}
+	if pending.ClearSetuidSetgid {
+		file.Mode &= ^uint32(0o6000)
+	}
 }
 
 // GetFileCached returns file metadata, trying the pending-writes cache first

--- a/pkg/metadata/service_test.go
+++ b/pkg/metadata/service_test.go
@@ -1584,6 +1584,38 @@ func TestMetadataService_CommitWrite(t *testing.T) {
 	})
 }
 
+func TestMetadataService_GetFileForRead(t *testing.T) {
+	t.Parallel()
+
+	// The memory store does not implement the fileForReadStore fast-path
+	// interface, so this exercises GetFileForRead's fallback branch: it must
+	// route to store.GetFile and return the same file (both then apply the
+	// identical mergePendingWrites overlay). A missing store handle must error,
+	// not panic.
+	fx := newTestFixture(t)
+
+	_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "r.txt", &metadata.FileAttr{Mode: 0644})
+	require.NoError(t, err)
+	handle, err := fx.store.GetChild(context.Background(), fx.rootHandle, "r.txt")
+	require.NoError(t, err)
+
+	viaGet, err := fx.service.GetFile(context.Background(), handle)
+	require.NoError(t, err)
+	viaRead, err := fx.service.GetFileForRead(context.Background(), handle)
+	require.NoError(t, err)
+
+	require.NotNil(t, viaRead)
+	assert.Equal(t, viaGet.Type, viaRead.Type)
+	assert.Equal(t, viaGet.ShareName, viaRead.ShareName)
+	assert.Equal(t, viaGet.Mode, viaRead.Mode)
+	assert.Equal(t, viaGet.Size, viaRead.Size)
+	assert.Equal(t, viaGet.Path, viaRead.Path, "fallback path derives Path exactly like GetFile")
+
+	// Unknown handle surfaces the store error through the fallback path.
+	_, err = fx.service.GetFileForRead(context.Background(), metadata.FileHandle("bogus"))
+	require.Error(t, err)
+}
+
 func TestMetadataService_PrepareRead(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/metadata/store/badger/files.go
+++ b/pkg/metadata/store/badger/files.go
@@ -36,6 +36,26 @@ func (s *BadgerMetadataStore) GetFile(ctx context.Context, handle metadata.FileH
 	return result, err
 }
 
+// GetFileForRead is GetFile without deriving File.Path — it skips the
+// parent-edge walk (a per-directory-level pair of badger gets) for the
+// handle-addressed hot paths (NFS READ/WRITE/GETATTR) that never read Path.
+// Implements the optional metadata read-fast-path interface; other backends
+// fall back to GetFile.
+func (s *BadgerMetadataStore) GetFileForRead(ctx context.Context, handle metadata.FileHandle) (*metadata.File, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	var result *metadata.File
+	err := s.db.View(func(txn *badgerdb.Txn) error {
+		tx := &badgerTransaction{store: s, txn: txn}
+		var err error
+		result, err = tx.getFile(ctx, handle, false)
+		return err
+	})
+	return result, err
+}
+
 // PutFile stores or updates file metadata.
 func (s *BadgerMetadataStore) PutFile(ctx context.Context, file *metadata.File) error {
 	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -171,6 +171,15 @@ func (s *BadgerMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 // ============================================================================
 
 func (tx *badgerTransaction) GetFile(ctx context.Context, handle metadata.FileHandle) (*metadata.File, error) {
+	return tx.getFile(ctx, handle, true)
+}
+
+// getFile loads a file by handle. When withPath is false it skips the
+// parent-edge walk that populates File.Path (derivePath) — a per-level pair of
+// badger gets that the handle-based read/write/getattr hot paths never consume
+// (NFS is handle-addressed, not path-addressed). Callers that need File.Path
+// (rename, path-facing errors) go through GetFile with withPath = true.
+func (tx *badgerTransaction) getFile(ctx context.Context, handle metadata.FileHandle, withPath bool) (*metadata.File, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -233,7 +242,10 @@ func (tx *badgerTransaction) GetFile(ctx context.Context, handle metadata.FileHa
 	// the stored proto field (#1166): parent edges are the sole source of
 	// truth, so the returned path always reflects the inode's current location
 	// and never goes stale after a hard-linked name is renamed or unlinked.
-	file.Path = tx.derivePath(fileID)
+	// Skipped for handle-addressed hot paths that never read Path (withPath=false).
+	if withPath {
+		file.Path = tx.derivePath(fileID)
+	}
 
 	return file, nil
 }


### PR DESCRIPTION
## Problem

Profiling the #1466 read benchmark (POP2-HC-32C, badger metadata) showed the NFS/SMB data path spends ~20–26% of read CPU in badger `GetFile` — not the KV get, but DittoFS's per-call `derivePath` (parent-edge walk, 2 badger gets per directory level) + full-struct `encoding/json` decode. It multiplied because each read op resolved the **same inode 2–3×**:

- `getFileOrError` (handler load)
- `PrepareRead` (permission gate, whose return v3 discarded)
- the permission path's own `store.GetFile`

## Change

Resolve the inode once per op, and skip work the hot path never uses:

- **By-`*File` permission checks** (`CheckReadPermissionFile`, `checkFilePermissionsFile`, `permissionResult`, `checkWritePermissionFile`): gate on the already-loaded file instead of re-fetching by handle. The by-handle `checkFilePermissions` now fetches once and delegates — logic is otherwise byte-for-byte identical.
- **`GetFileForRead`**: optional badger fast path that skips `derivePath` (NFS/SMB are handle-addressed; the read/getattr/write hot paths don't read `File.Path`). Other backends fall back to `GetFile`. Pending-write merge is shared (`mergePendingWrites`).
- **NFSv3 READ / SMB READ** drop `PrepareRead`'s redundant fetch and gate on the loaded file.
- **NFSv4** (READ / READ_PLUS / SEEK / COMMIT / VERIFY) use `GetFileForRead` where `File.Path` is unused.
- **WRITE**: `PrepareWrite` reuses its freshly-fetched file for the permission check **on a cache miss**; on a cache hit it keeps the fresh re-read — the pending-write file cache can be stale vs a concurrent `chmod`, and permission is a security boundary (unlike the explicitly-soft size/quota checks). Covers v3/v4/SMB since all writes funnel through `PrepareWrite`.

## Measured (read pprof, NFSv3 READ subtree — composition)

| cost | before | after |
|---|---|---|
| `PrepareRead` re-fetch | 46% | 0% |
| `derivePath` walk | 28% | ~0% |
| permission re-fetch | 33% | 3.5% |
| inode loads per read | ~3× | 1× |

The remaining single-load cost is the `encoding/json` decode of that one load — a natural follow-up (lean `File` decoder).

## Tests

`go test -race ./pkg/metadata/... ./internal/adapter/nfs/... ./internal/adapter/smb/...` — all green (45 packages). Storetest conformance passes (`GetFileForRead` falls back to `GetFile` on memory/sqlite/postgres).

## Follow-ups (not in this PR)

- NFSv4 GETATTR/ACCESS still use `GetFile` (they log `file.Path`); a fast-path pass there is a clean follow-up.
- Lean `File` decoder to cut the residual `encoding/json` cost.