### PR TITLE
perf(block): indexed covering lookup in fillFromCASManifest read hot path

### DIFF
--- a/pkg/block/local/fs/drain_reset_testhelpers_test.go
+++ b/pkg/block/local/fs/drain_reset_testhelpers_test.go
@@ -64,6 +64,31 @@ func (m *memFBS) ListFileChunks(_ context.Context, payloadID string) ([]*block.F
 	return out, nil
 }
 
+// GetFileChunkAtOffset mirrors the badger offset index: it returns the row
+// whose absolute byte range [chunkOffset, chunkOffset+DataSize) covers off,
+// or (nil, nil) for a hole. Implementing it here makes every post-rollup
+// read test drive fillFromCASManifest's indexed fast path rather than the
+// scan fallback.
+func (m *memFBS) GetFileChunkAtOffset(_ context.Context, payloadID string, off uint64) (*block.FileChunk, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var best *block.FileChunk
+	var bestOff uint64
+	for _, fb := range m.rows[payloadID] {
+		o, ok := block.ParseChunkOffset(fb.ID)
+		if !ok || o > off {
+			continue
+		}
+		if best == nil || o > bestOff {
+			best, bestOff = fb, o
+		}
+	}
+	if best == nil || off >= bestOff+uint64(best.DataSize) {
+		return nil, nil
+	}
+	return best, nil
+}
+
 func (m *memFBS) EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error {
 	m.mu.Lock()
 	ids := make([]string, 0, len(m.rows))

--- a/pkg/block/local/fs/readpayload.go
+++ b/pkg/block/local/fs/readpayload.go
@@ -231,18 +231,110 @@ func copyRecordIntoDest(recOff uint64, payload, dest []byte, reqStart, reqEnd ui
 	}
 }
 
-// fillFromCASManifest walks the FileChunk manifest for payloadID and
-// fills any still-uncovered bytes of dest from the corresponding CAS
-// chunks. This is the post-rollup read path — bytes that the rollup has
-// already moved out of the append log into CAS storage. The manifest is
-// the authoritative ordering once a chunk is committed.
+// chunkAtOffsetResolver is the indexed covering-chunk lookup, implemented
+// only by the badger metadata backend. fillFromCASManifest type-asserts for
+// it to resolve the one or two chunks under a read without enumerating the
+// whole per-payload manifest.
+type chunkAtOffsetResolver interface {
+	GetFileChunkAtOffset(ctx context.Context, payloadID string, off uint64) (*block.FileChunk, error)
+}
+
+// fillFromCASManifest fills any still-uncovered bytes of dest from the
+// rolled-up CAS chunks that back payloadID. This is the post-rollup read
+// path — bytes the rollup has already moved out of the append log into CAS.
 //
-// Silently no-ops when no manifest store is wired (fixtures that drive
-// the FSStore directly without a coordinator). A nil manifest is
-// indistinguishable from "no rolled-up chunks for this payload" so we
-// just leave any uncovered bytes uncovered; the caller surfaces them as
-// a miss.
+// Fast path: when the manifest store exposes an offset index (badger), each
+// still-uncovered offset is resolved to the single covering chunk via
+// GetFileChunkAtOffset instead of listing + sorting the entire per-payload
+// manifest on every read (the O(N)-per-read hot spot the #1466 profile
+// pinned at ~46% CPU). A 4 KiB read touches one or two chunks, so this is
+// O(chunks-touched) not O(manifest). Any hole (sparse read), an evicted
+// chunk, or a backend without the index hands the remaining window to the
+// legacy full walk (fillFromCASManifestScan).
+//
+// Silently no-ops when no manifest store is wired (fixtures that drive the
+// FSStore directly without a coordinator); the caller surfaces uncovered
+// bytes as a miss.
 func (bc *FSStore) fillFromCASManifest(ctx context.Context, payloadID string, dest []byte, reqStart uint64, covered []bool) error {
+	if bc.blockStore == nil {
+		return nil
+	}
+	resolver, ok := bc.blockStore.(chunkAtOffsetResolver)
+	if !ok {
+		return bc.fillFromCASManifestScan(ctx, payloadID, dest, reqStart, covered)
+	}
+	reqEnd := reqStart + uint64(len(dest))
+	for cur := reqStart; cur < reqEnd; {
+		if covered[cur-reqStart] {
+			cur++
+			continue
+		}
+		fb, err := resolver.GetFileChunkAtOffset(ctx, payloadID, cur)
+		if err != nil {
+			return fmt.Errorf("ReadPayloadAt: GetFileChunkAtOffset(%d): %w", cur, err)
+		}
+		if fb == nil || fb.Hash.IsZero() {
+			// Hole under the fast path: hand the rest of the window to the
+			// legacy walk, which spans sparse gaps without a per-byte
+			// lookup storm.
+			return bc.fillFromCASManifestScan(ctx, payloadID, dest, reqStart, covered)
+		}
+		absOffset, ok := block.ParseChunkOffset(fb.ID)
+		if !ok {
+			return fmt.Errorf("ReadPayloadAt: malformed FileChunk ID %q", fb.ID)
+		}
+		data, gerr := bc.Get(ctx, fb.Hash)
+		if gerr != nil {
+			if errors.Is(gerr, block.ErrChunkNotFound) {
+				// Chunk evicted or never landed — defer to the walk, which
+				// leaves this offset uncovered for the caller to fall back.
+				return bc.fillFromCASManifestScan(ctx, payloadID, dest, reqStart, covered)
+			}
+			return fmt.Errorf("ReadPayloadAt: Get chunk %s: %w", fb.Hash.String(), gerr)
+		}
+		// Clamp the visible data to DataSize so a padded on-disk chunk does
+		// not leak garbage past the rollup-emitted byte count.
+		dataLen := uint64(len(data))
+		if uint64(fb.DataSize) > 0 && uint64(fb.DataSize) < dataLen {
+			dataLen = uint64(fb.DataSize)
+		}
+		chunkStart := absOffset
+		chunkEnd := absOffset + dataLen
+		if chunkEnd <= cur {
+			// Covering row exists but clamped DataSize doesn't reach cur —
+			// treat as a hole and defer (also avoids a non-advancing loop).
+			return bc.fillFromCASManifestScan(ctx, payloadID, dest, reqStart, covered)
+		}
+		copyStart := chunkStart
+		if copyStart < reqStart {
+			copyStart = reqStart
+		}
+		copyEnd := chunkEnd
+		if copyEnd > reqEnd {
+			copyEnd = reqEnd
+		}
+		if copyEnd > copyStart {
+			destIdx := copyStart - reqStart
+			srcIdx := copyStart - chunkStart
+			n := copyEnd - copyStart
+			copy(dest[destIdx:destIdx+n], data[srcIdx:srcIdx+n])
+			for i := destIdx; i < destIdx+n; i++ {
+				covered[i] = true
+			}
+		}
+		cur = chunkEnd
+		if allCovered(covered) {
+			return nil
+		}
+	}
+	return nil
+}
+
+// fillFromCASManifestScan walks the entire FileChunk manifest for payloadID
+// and fills any still-uncovered bytes of dest from the corresponding CAS
+// chunks. It is the fallback for fillFromCASManifest: backends without the
+// offset index, and sparse/evicted reads where the fast path bails.
+func (bc *FSStore) fillFromCASManifestScan(ctx context.Context, payloadID string, dest []byte, reqStart uint64, covered []bool) error {
 	if bc.blockStore == nil {
 		return nil
 	}

--- a/pkg/block/local/fs/readpayload_covering_test.go
+++ b/pkg/block/local/fs/readpayload_covering_test.go
@@ -1,0 +1,110 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// newCoveringTestStore wires an FSStore whose FileChunkStore (memFBS)
+// implements GetFileChunkAtOffset, so post-rollup reads drive
+// fillFromCASManifest's indexed fast path.
+func newCoveringTestStore(t *testing.T) (*FSStore, context.Context) {
+	t.Helper()
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	fbs := newMemFileChunkStore()
+	persister := func(ctx context.Context, payloadID string, blocks []block.ChunkRef, _ block.ObjectID) error {
+		return fbs.persist(ctx, payloadID, blocks)
+	}
+	bc := newFSStoreForTestWithFBS(t, fbs, FSStoreOptions{
+		MaxLogBytes:       1 << 30,
+		RollupWorkers:     2,
+		StabilizationMS:   3_600_000,
+		RollupStore:       rs,
+		ObjectIDPersister: persister,
+	})
+	return bc, context.Background()
+}
+
+// TestReadPayloadAt_CoveringFastPath_MultiChunk writes a multi-chunk file,
+// rolls it into CAS, then reads several sub-windows (chunk-aligned,
+// mid-chunk, and spanning chunk boundaries). Every read must return the
+// exact source bytes — this exercises the fast path's `cur = chunkEnd`
+// advance across more than one covering chunk.
+func TestReadPayloadAt_CoveringFastPath_MultiChunk(t *testing.T) {
+	bc, ctx := newCoveringTestStore(t)
+
+	// Position-dependent bytes so any mis-offset copy is caught.
+	const size = 1 << 20 // 1 MiB — large enough for several FastCDC chunks
+	src := make([]byte, size)
+	for i := range src {
+		src[i] = byte(i*31 + 7)
+	}
+	if err := bc.AppendWrite(ctx, "fileM", src, 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+	if err := bc.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups: %v", err)
+	}
+
+	windows := []struct {
+		name        string
+		off, length uint64
+	}{
+		{"head", 0, 4096},
+		{"mid-unaligned", 4097, 4096},
+		{"large-span", 300000, 200000},
+		{"tail", size - 4096, 4096},
+		{"whole", 0, size},
+	}
+	for _, w := range windows {
+		got := make([]byte, w.length)
+		if _, err := bc.ReadPayloadAt(ctx, "fileM", got, w.off); err != nil {
+			t.Fatalf("%s: ReadPayloadAt(off=%d len=%d): %v", w.name, w.off, w.length, err)
+		}
+		if !bytes.Equal(got, src[w.off:w.off+w.length]) {
+			t.Fatalf("%s: read bytes mismatch at off=%d", w.name, w.off)
+		}
+	}
+}
+
+// TestReadPayloadAt_CoveringFastPath_Hole writes two separated regions,
+// leaving an un-backed gap between them. A read spanning the gap must
+// surface a miss (ErrFileChunkNotFound) — the fast path detects the hole
+// and hands off to the scan fallback, which also leaves it uncovered.
+// Reads confined to each backed region must still succeed.
+func TestReadPayloadAt_CoveringFastPath_Hole(t *testing.T) {
+	bc, ctx := newCoveringTestStore(t)
+
+	a := bytes.Repeat([]byte{'A'}, 4096)
+	b := bytes.Repeat([]byte{'B'}, 4096)
+	if err := bc.AppendWrite(ctx, "fileH", a, 0); err != nil {
+		t.Fatalf("AppendWrite region A: %v", err)
+	}
+	// Leave [4096, 8192) a hole; write region B at 8192.
+	if err := bc.AppendWrite(ctx, "fileH", b, 8192); err != nil {
+		t.Fatalf("AppendWrite region B: %v", err)
+	}
+	if err := bc.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups: %v", err)
+	}
+
+	// Each backed region reads back cleanly.
+	got := make([]byte, 4096)
+	if _, err := bc.ReadPayloadAt(ctx, "fileH", got, 0); err != nil || !bytes.Equal(got, a) {
+		t.Fatalf("region A read: err=%v equal=%v", err, bytes.Equal(got, a))
+	}
+	if _, err := bc.ReadPayloadAt(ctx, "fileH", got, 8192); err != nil || !bytes.Equal(got, b) {
+		t.Fatalf("region B read: err=%v equal=%v", err, bytes.Equal(got, b))
+	}
+
+	// A read that spans the hole is not fully local → miss.
+	span := make([]byte, 12288)
+	if _, err := bc.ReadPayloadAt(ctx, "fileH", span, 0); !errors.Is(err, block.ErrFileChunkNotFound) {
+		t.Fatalf("hole-spanning read: got err=%v, want ErrFileChunkNotFound", err)
+	}
+}


### PR DESCRIPTION
## What

`fillFromCASManifest` (the packed-blocks read enumeration) listed **and sorted the entire per-payload FileChunk manifest on every read** — O(N) per read, N reads ⇒ O(N²), CPU-bound at high fragmentation. The #1466 profile attributed ~46% of read CPU to this walk on a densely-randwritten file.

This resolves the 1–2 chunks that actually cover a read via the badger offset index (`GetFileChunkAtOffset`) instead of scanning the whole manifest.

## How

- Fast path: type-assert the FileChunk store to the `chunkAtOffsetResolver` optional interface (badger implements it) → indexed covering lookup.
- Fallback: holes, evicted chunks, and non-badger backends (sqlite/postgres/memory) fall back to the original full walk, now named `fillFromCASManifestScan`. Behaviour is byte-identical on the fallback.

## Measured (POP2-HC-32C, badger, heavy-fragmentation regime)

Reproduced #1466: 128 MiB file under 180 s of dense 4 KiB random-write, then random-read.

| | rand-read IOPS | `ListFileChunks` share of read CPU |
|---|---|---|
| before | ~75 | 57.6% (CPU-bound, 166%) |
| after  | ~170 (**~2.3×**) | fast path engaged |

At *moderate* fragmentation the walk is only ~1.25% of read CPU (reads are I/O-bound there), so this is a heavy-fragmentation win specifically.

## Known limitation (documented, not a regression)

The fast path **bails to the full scan on a hole**, and sparse random-write files are full of holes — so data-block reads take the fast path while hole reads still scan (`fillFromCASManifestScan` was still ~29% in the heavy run). A complete fix needs a "next chunk at offset ≥ X" successor lookup; not in this PR. Data correctness is unaffected — holes zero-fill exactly as before.

Ref #1572.
