### PR TITLE
perf(block): access-pattern-aware remote readahead

### DIFF
--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -383,7 +383,12 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 		}
 	}
 
-	for i := range m.config.PrefetchBlocks {
+	// Prefetch ahead only as far as the payload's access pattern justifies:
+	// a sequential run ramps the window up to PrefetchBlocks, a random read
+	// prefetches nothing (planReadahead returns 0) so we never spend remote
+	// GETs on blocks a random reader will not touch.
+	depth := m.planReadahead(payloadID, startBlockIdx, endBlockIdx)
+	for i := 0; i < depth; i++ {
 		m.enqueuePrefetch(payloadID, endBlockIdx+1+uint64(i))
 	}
 

--- a/pkg/block/engine/readahead.go
+++ b/pkg/block/engine/readahead.go
@@ -1,0 +1,64 @@
+package engine
+
+// maxReadaheadEntries bounds the per-payload readahead state map. Readahead
+// state is disposable — a dropped entry just re-ramps from depth 1 — so on
+// overflow we evict an arbitrary entry rather than track access order.
+// ponytail: arbitrary eviction; switch to LRU only if churn across >4096
+// concurrently-hot files ever measurably costs re-ramps.
+const maxReadaheadEntries = 4096
+
+// raState tracks a payload's recent read frontier so prefetch can distinguish
+// sequential runs (ramp the window) from random access (stop prefetching).
+type raState struct {
+	lastEnd uint64 // block index the previous read ended at
+	depth   int    // current prefetch window in blocks ahead; 0 = random / no prefetch
+	valid   bool   // false until the first read establishes lastEnd
+}
+
+// planReadahead updates the payload's access frontier for a read spanning
+// [startBlockIdx, endBlockIdx] and returns how many blocks to prefetch ahead.
+//
+// Sequential reads (continuing at or just past the previous frontier) ramp the
+// window 1->2->4->...->PrefetchBlocks, following the Linux readahead pattern.
+// A random jump resets the window to 0: prefetching blocks after a random read
+// only wastes remote GETs on data that will not be read, hurting WAN throughput
+// and object-store cost. The ramp cap is SyncerConfig.PrefetchBlocks.
+func (m *Syncer) planReadahead(payloadID string, startBlockIdx, endBlockIdx uint64) int {
+	maxDepth := m.config.PrefetchBlocks
+	if maxDepth <= 0 {
+		return 0 // prefetch disabled
+	}
+
+	m.readaheadMu.Lock()
+	defer m.readaheadMu.Unlock()
+
+	st, ok := m.readahead[payloadID]
+	if !ok {
+		if len(m.readahead) >= maxReadaheadEntries {
+			for k := range m.readahead { // evict one arbitrary disposable entry
+				delete(m.readahead, k)
+				break
+			}
+		}
+		st = &raState{}
+		m.readahead[payloadID] = st
+	}
+
+	// Sequential = the new read begins at or immediately after the previous
+	// frontier (tolerates a re-read of the last block and a contiguous advance).
+	sequential := st.valid && startBlockIdx >= st.lastEnd && startBlockIdx <= st.lastEnd+1
+	switch {
+	case !sequential:
+		st.depth = 0
+	case st.depth < 1:
+		st.depth = 1
+	case st.depth < maxDepth:
+		st.depth *= 2
+		if st.depth > maxDepth {
+			st.depth = maxDepth
+		}
+	}
+	st.lastEnd = endBlockIdx
+	st.valid = true
+	return st.depth
+}

--- a/pkg/block/engine/readahead.go
+++ b/pkg/block/engine/readahead.go
@@ -1,7 +1,8 @@
 package engine
 
 // maxReadaheadEntries bounds the per-payload readahead state map. Readahead
-// state is disposable — a dropped entry just re-ramps from depth 1 — so on
+// state is disposable — a dropped entry just re-ramps from a cold start (the
+// re-creating read returns 0, the next sequential read reaches depth 1) — so on
 // overflow we evict an arbitrary entry rather than track access order.
 // ponytail: arbitrary eviction; switch to LRU only if churn across >4096
 // concurrently-hot files ever measurably costs re-ramps.

--- a/pkg/block/engine/readahead_test.go
+++ b/pkg/block/engine/readahead_test.go
@@ -1,0 +1,76 @@
+package engine
+
+import (
+	"strconv"
+	"testing"
+)
+
+func newRAsyncer(prefetch int) *Syncer {
+	return &Syncer{
+		config:    SyncerConfig{PrefetchBlocks: prefetch},
+		readahead: make(map[string]*raState),
+	}
+}
+
+func TestPlanReadahead_SequentialRamps(t *testing.T) {
+	m := newRAsyncer(64)
+	// First read has no history: depth 0 (Linux-style cold start).
+	if d := m.planReadahead("p", 0, 0); d != 0 {
+		t.Fatalf("first read: got depth %d, want 0", d)
+	}
+	// Contiguous reads ramp 1 -> 2 -> 4 -> ... capped at PrefetchBlocks.
+	want := []int{1, 2, 4, 8, 16, 32, 64, 64}
+	for i, exp := range want {
+		start := uint64(i + 1)
+		if d := m.planReadahead("p", start, start); d != exp {
+			t.Fatalf("sequential read %d (block %d): got depth %d, want %d", i, start, d, exp)
+		}
+	}
+}
+
+func TestPlanReadahead_RandomResets(t *testing.T) {
+	m := newRAsyncer(64)
+	// Ramp up on a sequential run.
+	for b := uint64(0); b <= 5; b++ {
+		m.planReadahead("p", b, b)
+	}
+	if got := m.readahead["p"].depth; got == 0 {
+		t.Fatalf("expected ramped depth after sequential run, got 0")
+	}
+	// A random jump backs off to 0 — no wasted prefetch of blocks a random
+	// reader will not touch.
+	if d := m.planReadahead("p", 1000, 1000); d != 0 {
+		t.Fatalf("random jump: got depth %d, want 0", d)
+	}
+	// Re-establishing sequentiality from the new position ramps again.
+	if d := m.planReadahead("p", 1001, 1001); d != 1 {
+		t.Fatalf("resume after random: got depth %d, want 1", d)
+	}
+}
+
+func TestPlanReadahead_RereadSameBlockIsSequential(t *testing.T) {
+	m := newRAsyncer(64)
+	m.planReadahead("p", 0, 0)                   // depth 0, frontier 0
+	if d := m.planReadahead("p", 0, 0); d != 1 { // start==lastEnd tolerated as sequential
+		t.Fatalf("re-read same block: got depth %d, want 1", d)
+	}
+}
+
+func TestPlanReadahead_DisabledWhenZero(t *testing.T) {
+	m := newRAsyncer(0)
+	for b := uint64(0); b <= 5; b++ {
+		if d := m.planReadahead("p", b, b); d != 0 {
+			t.Fatalf("prefetch disabled: got depth %d, want 0", d)
+		}
+	}
+}
+
+func TestPlanReadahead_MapBounded(t *testing.T) {
+	m := newRAsyncer(64)
+	for i := 0; i < maxReadaheadEntries*2; i++ {
+		m.planReadahead("payload-"+strconv.Itoa(i), 0, 0)
+	}
+	if got := len(m.readahead); got > maxReadaheadEntries {
+		t.Fatalf("readahead map unbounded: %d entries, cap %d", got, maxReadaheadEntries)
+	}
+}

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -70,6 +70,11 @@ type Syncer struct {
 	inFlight   map[string]*fetchResult // In-flight download dedup (store key -> broadcast)
 	inFlightMu gosync.Mutex
 
+	// readahead holds per-payload sequential-access state so remote prefetch
+	// ramps on sequential runs and backs off on random access (see readahead.go).
+	readahead   map[string]*raState
+	readaheadMu gosync.Mutex
+
 	stopCh chan struct{} // Signals periodic uploader to stop
 	closed bool
 	mu     gosync.RWMutex
@@ -323,6 +328,7 @@ func NewSyncer(local local.LocalStore, remoteStore remote.RemoteStore, fileChunk
 		fileChunkStore: fileChunkStore,
 		config:         config,
 		inFlight:       make(map[string]*fetchResult),
+		readahead:      make(map[string]*raState),
 		stopCh:         make(chan struct{}),
 
 		uploadLimiter:    newDynamicSemaphore(startWindow),


### PR DESCRIPTION
## What

Remote block prefetch fired a **fixed `PrefetchBlocks` (default 64) after every remote read, regardless of access pattern**. On a random read that means 64 speculative S3 GETs for blocks the reader will never touch — wasted WAN bandwidth and object-store cost, and download-queue contention that can slow the demanded fetches. (`doc.go` already described a "1→2→4→8 adaptive" readahead, but the code never implemented it.)

This adds the access-pattern awareness the doc promised: a per-payload read frontier drives an adaptive prefetch window.

## How

- `planReadahead(payloadID, start, end)` (new `readahead.go`) tracks each payload's last read frontier.
  - **Sequential** run (a read continuing at/just past the frontier) ramps the window `1→2→4→…→PrefetchBlocks`, the Linux readahead pattern.
  - **Random** jump resets the window to **0** — no speculative GETs.
- `EnsureAvailableAndRead` replaces the fixed `for i := range PrefetchBlocks` loop with `for i := 0; i < planReadahead(...); i++`.
- Per-payload state is a bounded map (`maxReadaheadEntries`, arbitrary eviction — readahead state is disposable, a dropped entry just re-ramps).

## Tests

5 unit tests in `readahead_test.go` pin the logic: cold start (depth 0), sequential ramp `1,2,4,…,64` capped, random reset to 0, re-read tolerance, disabled-when-`PrefetchBlocks=0`, and the map bound. Full `pkg/block/engine` suite (328 tests) green, lint clean.

## Measurement status (follow-up)

WAN throughput/GET-count A/B is **not yet included** — the bench rig couldn't be held in an S3-only state (rollup logblob + `pin` retention keep data local), so the remote-fetch path wouldn't engage reproducibly. One cold-window sample did show the waste this fixes: a **baseline 8 MB random read pulled 20 MB from S3** (2.5× prefetch amplification). A clean throughput number needs a purpose-built harness (evict-retention + tiny local cache so blocks are S3-only by construction); tracked as a follow-up.
