### PR TITLE
fix(smb): omit unsolicited SPNEGO acceptor mechListMIC (RFC 4178)

### DIFF
--- a/internal/adapter/smb/auth/spnego.go
+++ b/internal/adapter/smb/auth/spnego.go
@@ -187,6 +187,16 @@ func (p *ParsedToken) HasKerberos() bool {
 	return p.HasMechanism(OIDKerberosV5) || p.HasMechanism(OIDMSKerberosV5)
 }
 
+// HasMechListMIC reports whether the initiator supplied a mechListMIC (the
+// SPNEGO downgrade-protection MIC over the mechList, RFC 4178). An SPNEGO
+// acceptor consults this to decide whether it must answer with its own
+// mechListMIC: per RFC 4178 §5, when the initiator's optimistic mechanism is
+// accepted and the initiator sent no MIC, the acceptor MUST NOT attach an
+// unsolicited one. Nil-safe so callers can query a token that failed to parse.
+func (p *ParsedToken) HasMechListMIC() bool {
+	return p != nil && len(p.MechListMIC) > 0
+}
+
 // BuildResponse creates a SPNEGO NegTokenResp for server responses.
 //
 // Parameters:

--- a/internal/adapter/smb/auth/spnego_mechlistmic_test.go
+++ b/internal/adapter/smb/auth/spnego_mechlistmic_test.go
@@ -1,0 +1,48 @@
+package auth
+
+import "testing"
+
+// TestParsedToken_HasMechListMIC is the #1530 regression guard. A real Windows
+// SMB client authenticating with Kerberos presents an optimistic AP-REQ for its
+// preferred mechanism and sends NO mechListMIC of its own. Per RFC 4178 §5 the
+// acceptor must then answer WITHOUT a mechListMIC; attaching an unsolicited one
+// makes Windows reject the completed context and forcibly close the connection
+// right after the signed SESSION_SETUP success (System error 1359). The Kerberos
+// response builders gate the acceptor MIC on this predicate, so it must report
+// true only when the initiator actually supplied a mechListMIC.
+func TestParsedToken_HasMechListMIC(t *testing.T) {
+	tests := []struct {
+		name  string
+		token *ParsedToken
+		want  bool
+	}{
+		{
+			name:  "nil token",
+			token: nil,
+			want:  false,
+		},
+		{
+			name:  "no mechListMIC (Windows Kerberos optimistic path)",
+			token: &ParsedToken{MechListBytes: []byte{0x30, 0x2e}},
+			want:  false,
+		},
+		{
+			name:  "empty mechListMIC",
+			token: &ParsedToken{MechListBytes: []byte{0x30, 0x2e}, MechListMIC: []byte{}},
+			want:  false,
+		},
+		{
+			name:  "mechListMIC present",
+			token: &ParsedToken{MechListBytes: []byte{0x30, 0x2e}, MechListMIC: []byte{0x04, 0x04, 0x01}},
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.token.HasMechListMIC(); got != tt.want {
+				t.Errorf("HasMechListMIC() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/adapter/smb/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/handlers/kerberos_auth.go
@@ -286,7 +286,7 @@ func (h *Handler) buildKerberosAcceptResponse(
 	var serverMIC []byte
 	if parsedToken != nil && len(parsedToken.MechListBytes) > 0 {
 		// Verify client-sent MIC if present
-		if len(parsedToken.MechListMIC) > 0 {
+		if parsedToken.HasMechListMIC() {
 			if err := auth.VerifyMechListMIC(authResult.SessionKey, parsedToken.MechListBytes, parsedToken.MechListMIC); err != nil {
 				logger.Debug("Client mechListMIC verification failed", "error", err)
 				// Per RFC 4178, failed MIC verification should reject the negotiation
@@ -295,13 +295,20 @@ func (h *Handler) buildKerberosAcceptResponse(
 			logger.Debug("Client mechListMIC verified successfully")
 		}
 
-		// Compute server mechListMIC using the Kerberos session key
-		// (NOT the normalized 16-byte key -- MIC uses the full session key)
-		serverMIC, err = auth.ComputeMechListMIC(authResult.SessionKey, parsedToken.MechListBytes)
-		if err != nil {
-			logger.Debug("Failed to compute server mechListMIC", "error", err)
-			// Non-fatal: response without MIC still works
-			serverMIC = nil
+		// RFC 4178 §5: answer with an acceptor mechListMIC only when the initiator
+		// sent one. Here the mech we complete is the initiator's own optimistic
+		// Kerberos choice (a failure restarts SESSION_SETUP as NTLM, not an in-band
+		// downgrade), so there is nothing to protect against — and an UNSOLICITED
+		// acceptor MIC makes a real Windows client treat the completed context as a
+		// negotiation failure and forcibly close the connection right after the
+		// signed SESSION_SETUP success (STATUS_INTERNAL_ERROR / error 1359, #1530).
+		if parsedToken.HasMechListMIC() {
+			serverMIC, err = auth.ComputeMechListMIC(authResult.SessionKey, parsedToken.MechListBytes)
+			if err != nil {
+				logger.Debug("Failed to compute server mechListMIC", "error", err)
+				// Non-fatal: response without MIC still works
+				serverMIC = nil
+			}
 		}
 	}
 
@@ -400,7 +407,7 @@ func (h *Handler) completeKerberosBind(ctx *SMBHandlerContext, sess *session.Ses
 	// BEFORE registering any channel state. A bad MIC rejects the bind, so it
 	// must be checked before AddChannel — otherwise a live signing channel
 	// would be left attached to the session on a rejected bind.
-	if len(parsedToken.MechListBytes) > 0 && len(parsedToken.MechListMIC) > 0 {
+	if len(parsedToken.MechListBytes) > 0 && parsedToken.HasMechListMIC() {
 		if vErr := auth.VerifyMechListMIC(authResult.SessionKey, parsedToken.MechListBytes, parsedToken.MechListMIC); vErr != nil {
 			logger.Debug("Kerberos bind: client mechListMIC verification failed", "error", vErr)
 			return NewErrorResult(types.StatusLogonFailure), nil
@@ -460,10 +467,12 @@ func (h *Handler) completeKerberosBind(ctx *SMBHandlerContext, sess *session.Ses
 	}
 	responseOID := clientKerberosOID(parsedToken)
 
-	// Compute the server-side mechListMIC for the response (the client MIC was
-	// already verified above, before any channel state was registered).
+	// RFC 4178 §5: answer with an acceptor mechListMIC only when the initiator
+	// sent one (see buildKerberosAcceptResponse for why an unsolicited MIC breaks
+	// real Windows clients). The client MIC, if any, was already verified above,
+	// before any channel state was registered.
 	var serverMIC []byte
-	if len(parsedToken.MechListBytes) > 0 {
+	if parsedToken.HasMechListMIC() {
 		serverMIC, _ = auth.ComputeMechListMIC(authResult.SessionKey, parsedToken.MechListBytes)
 	}
 


### PR DESCRIPTION
## Summary

Fixes Kerberos SMB mounts from Windows clients failing with **System error 1359 / `STATUS_INTERNAL_ERROR`** immediately after a successful (signed) `SESSION_SETUP`, before `TREE_CONNECT`.

## Root cause

A domain-joined Windows client authenticating with Kerberos presents an **optimistic AP-REQ** for its preferred mechanism and sends **no `mechListMIC`** of its own. DittoFS was **unconditionally** attaching an acceptor `mechListMIC` to the accept-complete `SESSION_SETUP` response. Per **RFC 4178 §5**, when the initiator's optimistic mechanism is accepted and the initiator sent no MIC, the acceptor **MUST NOT** send one. Windows treats the unsolicited MIC as a negotiation/downgrade failure and forcibly closes the connection — surfacing as error 1359.

This is the **true root cause** behind the symptom originally filed as an AES256 signing bug in #1530. The signing-key derivation was already correct (`normalizeTo16` → 16-byte SP800-108 signing key for both AES128 and AES256); the failure was dialect- and etype-independent, which is what pointed here.

## Fix

Gate the acceptor `mechListMIC` on the initiator having sent one, via a new nil-safe `(*auth.ParsedToken).HasMechListMIC()` predicate (alongside `HasNTLM`/`HasKerberos`), in **both** the session-setup (`buildKerberosAcceptResponse`) and multichannel session-bind (`completeKerberosBind`) Kerberos paths. The client-MIC **verification** path is unchanged (still rejects a bad client MIC). This matches Samba's SMB-server behavior.

## Validation

Against a real Windows client on a Windows Server 2025 AD domain (`cubbit.local`):

- ✅ Alice **and** Bob mount `\host\share` over Kerberos, read + write
- ✅ **AES128** (etype 17) and **AES256** (etype 18) tickets
- ✅ SMB 3.1.1, signing on — `TREE_CONNECT` signatures verified both directions
- ✅ Self-mount **and** cross-machine (from the DC)
- ✅ `go test ./internal/adapter/smb/...` green; new regression test `TestParsedToken_HasMechListMIC`

## Tested scope / follow-up

Validated with the Windows SSPI SPNEGO client, and the new behavior matches Samba as an SMB server (which the Linux/macOS `cifs`/`smbclient` + MIT/Heimdal ecosystem interoperates with over Kerberos). A Linux/macOS Kerberos-mount smoke test is a reasonable follow-up but not expected to regress, since those clients do not require an acceptor MIC they didn't solicit.

Closes #1530
