### PR TITLE
fix(block): scale timing-flake deadlines off runner speed; idempotent log-fd close (#1585)

### DIFF
--- a/pkg/block/local/fs/appendwrite.go
+++ b/pkg/block/local/fs/appendwrite.go
@@ -22,6 +22,15 @@ import (
 type logFile struct {
 	f    *os.File
 	path string
+	// closeOnce guards the fd close. Concurrent DeleteAppendLog callers (and
+	// the AppendWrite error-recovery paths) can snapshot the same *logFile
+	// before its shard entry is cleared and would otherwise each call
+	// f.Close(), producing benign but noisy "file already closed" errors on
+	// Windows whose logging inflates per-op latency under stress (#1585). A
+	// logFile is never reused after its fd is closed (the instance is dropped
+	// from logFDs and a fresh one built on next touch), so a lifetime once is
+	// correct. Compaction's fd-swap does not route through closeFD.
+	closeOnce sync.Once
 	// syncedPos is the on-disk-durable watermark: bytes at log positions
 	// below syncedPos have been fsync'd to the platter. It is always
 	// <= eofPos. AppendWrite advances eofPos on the page-cache pwrite but,
@@ -394,7 +403,7 @@ func (bc *FSStore) AppendWrite(ctx context.Context, payloadID string, data []byt
 		tsh.mu.Lock()
 		delete(tsh.logFDs, payloadID)
 		tsh.mu.Unlock()
-		_ = lf.f.Close()
+		_ = lf.closeFD()
 		return fmt.Errorf("append log: %w", err)
 	}
 	// Honor NFS UNSTABLE (PR3): the default path does NOT fsync here — the
@@ -420,7 +429,7 @@ func (bc *FSStore) AppendWrite(ctx context.Context, payloadID string, data []byt
 			tsh.mu.Lock()
 			delete(tsh.logFDs, payloadID)
 			tsh.mu.Unlock()
-			_ = lf.f.Close()
+			_ = lf.closeFD()
 			return fmt.Errorf("log fsync: %w", err)
 		}
 	}
@@ -603,6 +612,19 @@ func (bc *FSStore) SyncPayload(ctx context.Context, payloadID string) error {
 // Orphan content-addressed chunks in the log-blob substrate are NOT
 // removed here; they are swept by the mark-sweep GC. This is a
 // known and documented limitation.
+// closeFD closes the log's fd exactly once. Redundant callers get nil (the
+// fd is already closed — not an error worth logging); only the goroutine that
+// performs the real close observes its error. See the closeOnce field doc.
+func (lf *logFile) closeFD() error {
+	var err error
+	lf.closeOnce.Do(func() {
+		if lf.f != nil {
+			err = lf.f.Close()
+		}
+	})
+	return err
+}
+
 func (bc *FSStore) DeleteAppendLog(ctx context.Context, payloadID string) error {
 	if bc.isClosed() {
 		return ErrStoreClosed
@@ -671,10 +693,8 @@ func (bc *FSStore) DeleteAppendLog(ctx context.Context, payloadID string) error 
 	// boot-time orphan sweep eventually cleans the residual file.
 	var stepFourErr error
 	if lf != nil {
-		if lf.f != nil {
-			if cerr := lf.f.Close(); cerr != nil {
-				logger.Warn("DeleteAppendLog: log file close failed", "payloadID", payloadID, "path", lf.path, "error", cerr)
-			}
+		if cerr := lf.closeFD(); cerr != nil {
+			logger.Warn("DeleteAppendLog: log file close failed", "payloadID", payloadID, "path", lf.path, "error", cerr)
 		}
 		if lf.path != "" {
 			if rerr := removeLogFile(lf.path); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {

--- a/pkg/block/local/fs/appendwrite_test.go
+++ b/pkg/block/local/fs/appendwrite_test.go
@@ -13,6 +13,17 @@ import (
 	"time"
 )
 
+// waitTimeout scales a "goroutine should have completed by now" ceiling for
+// timing-sensitive tests. Windows CI runners have much slower NTFS
+// open/close/fsync latency under contention, so a base that is ample on Linux
+// fires as a false positive there (#1585). Scale it up on Windows.
+func waitTimeout(base time.Duration) time.Duration {
+	if runtime.GOOS == "windows" {
+		return base * 8
+	}
+	return base
+}
+
 // TestAppendWrite_Enabled_HappyPath writes three records and verifies
 // - the on-disk log has header + 3 records of the expected total size
 // - logBytesTotal counts the framed-record overhead (not just payload)
@@ -136,7 +147,7 @@ func TestAppendWrite_PressureBlocks_UntilSignaled(t *testing.T) {
 		if err != nil {
 			t.Fatalf("AppendWrite after pressure release: %v", err)
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(waitTimeout(2 * time.Second)):
 		t.Fatal("AppendWrite did not unblock after pressure release")
 	}
 }
@@ -311,7 +322,7 @@ func TestAppendWrite_CtxCancel_StillFsyncs(t *testing.T) {
 		if err != nil {
 			t.Fatalf("A: %v", err)
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(waitTimeout(2 * time.Second)):
 		t.Fatal("A did not complete")
 	}
 	select {
@@ -323,7 +334,7 @@ func TestAppendWrite_CtxCancel_StillFsyncs(t *testing.T) {
 			// abort A's fsync".
 			t.Logf("B finished with: %v (acceptable)", err)
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(waitTimeout(2 * time.Second)):
 		t.Fatal("B did not return")
 	}
 

--- a/pkg/block/local/fs/lockorder_test.go
+++ b/pkg/block/local/fs/lockorder_test.go
@@ -71,11 +71,17 @@ func TestAppendWrite_DeleteRace_NoDeadlock(t *testing.T) {
 		close(done)
 	}()
 
-	deadline := 10 * time.Second
+	// Budget the deadlock guard off the actual go-test timeout rather than a
+	// fixed 10s. A real lock-order regression still hangs and trips this with
+	// a clear message just before Go's own raw timeout panic; a slow/contended
+	// runner (Windows CI) gets the full budget instead of a hardcoded 10s that
+	// fires as a false positive under load (#1585). The fixed fallback only
+	// applies when the test runs without a deadline.
+	deadline := 30 * time.Second
 	if dl, ok := t.Deadline(); ok {
 		// Leave a 2 s buffer so we fail with a clear message rather than
 		// truncating arbitrary post-test cleanup.
-		if budget := time.Until(dl) - 2*time.Second; budget > 0 && budget < deadline {
+		if budget := time.Until(dl) - 2*time.Second; budget > 0 {
 			deadline = budget
 		}
 	}


### PR DESCRIPTION
Fixes #1585.

## Root cause
Both failing tests in `pkg/block/local/fs` hardcode tight wall-clock deadlines in timing-sensitive concurrency tests. On slow/contended **Windows** CI runners, NTFS open/close/fsync latency pushes runtime past the deadline **without an actual deadlock** — a false positive. Develop's Windows job is green; the failures surfaced on a docs-only PR (#1583) that touched nothing in this package.

## Changes
- **`TestAppendWrite_DeleteRace_NoDeadlock`** — the deadlock guard now budgets off `t.Deadline()` (grows to the go-test timeout minus 2s) instead of a fixed 10s. A real lock-order regression still hangs and trips the guard with its clear message just before Go's raw timeout panic; a slow runner gets the full budget.
- **`TestAppendWrite_CtxCancel_StillFsyncs`** (and the two sibling `2s` waits in the file) — scaled `8x` on `runtime.GOOS == "windows"` via a small `waitTimeout` helper.
- **`logFile.closeFD` (idempotent close)** — addresses the secondary signal in the issue. Concurrent `DeleteAppendLog` callers snapshot the same `*logFile` and each called `f.Close()`, producing benign but noisy `file already closed` WARNs on Windows whose logging inflated per-op latency under exactly the stress the flake hits. A lifetime `sync.Once` makes redundant closes no-ops; only the first caller performs the real close and observes its error. Compaction's fd-swap does not route through it (the fd is reassigned under `mu`).

## Verification
`go test -race` on the full `pkg/block/local/fs` package: **289 pass**. The two named tests pass `-count=5 -race`. `go vet` and `gofmt` clean.