### PR TITLE
perf(block): route fillFromCASManifest through indexed covering+successor lookup (#1580)

### DIFF
--- a/pkg/block/local/fs/drain_reset_testhelpers_test.go
+++ b/pkg/block/local/fs/drain_reset_testhelpers_test.go
@@ -82,6 +82,42 @@ func (m *memFBS) EnumeratePayloads(ctx context.Context, fn func(payloadID string
 	return nil
 }
 
+// GetFileChunkAtOffset + GetFileChunkAtOrAfterOffset make memFBS satisfy the
+// coveringChunkResolver fast path so ReadPayloadAt drives fillFromCASManifest's
+// indexed covering + successor loop (not the ListFileChunks scan fallback).
+// Both mirror the badger backend's contract, which pkg/metadata/storetest pins.
+func (m *memFBS) GetFileChunkAtOffset(_ context.Context, payloadID string, off uint64) (*block.FileChunk, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, fb := range m.rows[payloadID] {
+		abs, ok := block.ParseChunkOffset(fb.ID)
+		if !ok {
+			continue
+		}
+		if off >= abs && off-abs < uint64(fb.DataSize) {
+			return fb, nil // covering guard: off is within [abs, abs+DataSize)
+		}
+	}
+	return nil, nil
+}
+
+func (m *memFBS) GetFileChunkAtOrAfterOffset(_ context.Context, payloadID string, off uint64) (*block.FileChunk, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var best *block.FileChunk
+	var bestAbs uint64
+	for _, fb := range m.rows[payloadID] {
+		abs, ok := block.ParseChunkOffset(fb.ID)
+		if !ok {
+			continue
+		}
+		if abs >= off && (best == nil || abs < bestAbs) {
+			best, bestAbs = fb, abs
+		}
+	}
+	return best, nil
+}
+
 func (m *memFBS) GetFileChunk(_ context.Context, blockID string) (*block.FileChunk, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/pkg/block/local/fs/readpayload.go
+++ b/pkg/block/local/fs/readpayload.go
@@ -231,21 +231,123 @@ func copyRecordIntoDest(recOff uint64, payload, dest []byte, reqStart, reqEnd ui
 	}
 }
 
-// fillFromCASManifest walks the FileChunk manifest for payloadID and
-// fills any still-uncovered bytes of dest from the corresponding CAS
-// chunks. This is the post-rollup read path — bytes that the rollup has
-// already moved out of the append log into CAS storage. The manifest is
-// the authoritative ordering once a chunk is committed.
+// coveringChunkResolver is the indexed covering + successor lookup,
+// implemented only by the badger metadata backend. fillFromCASManifest
+// type-asserts for it to resolve just the chunks a read touches (plus one
+// successor lookup per hole) instead of listing + sorting the entire
+// per-payload manifest on every read — the O(chunks)-per-read hot spot
+// (#1580: ~75-82% of read CPU on rolled-up files). GetFileChunkAtOffset
+// returns the chunk covering off (nil for a hole); GetFileChunkAtOrAfterOffset
+// returns the next chunk starting at or after off (nil past the last chunk).
+type coveringChunkResolver interface {
+	GetFileChunkAtOffset(ctx context.Context, payloadID string, off uint64) (*block.FileChunk, error)
+	GetFileChunkAtOrAfterOffset(ctx context.Context, payloadID string, off uint64) (*block.FileChunk, error)
+}
+
+// fillFromCASManifest fills any still-uncovered bytes of dest from the
+// rolled-up CAS chunks backing payloadID. This is the post-rollup read path —
+// bytes that the rollup has already moved out of the append log into CAS.
 //
-// Silently no-ops when no manifest store is wired (fixtures that drive
-// the FSStore directly without a coordinator). A nil manifest is
-// indistinguishable from "no rolled-up chunks for this payload" so we
-// just leave any uncovered bytes uncovered; the caller surfaces them as
-// a miss.
+// Fast path (badger): each still-uncovered offset is resolved to its single
+// covering chunk via GetFileChunkAtOffset; a hole is skipped straight to the
+// next chunk via GetFileChunkAtOrAfterOffset, so a read spanning a sparse gap
+// stays O(chunks-touched), never O(manifest). The covering guard lives in the
+// resolver: GetFileChunkAtOffset only returns a chunk whose range actually
+// contains the offset, so a hole can never be served a neighbour chunk's bytes.
+// Other backends fall back to fillFromCASManifestScan (the full walk).
+//
+// Silently no-ops when no manifest store is wired (fixtures that drive the
+// FSStore directly without a coordinator). A nil manifest is indistinguishable
+// from "no rolled-up chunks for this payload" so we just leave any uncovered
+// bytes uncovered; the caller surfaces them as a miss.
 func (bc *FSStore) fillFromCASManifest(ctx context.Context, payloadID string, dest []byte, reqStart uint64, covered []bool) error {
 	if bc.blockStore == nil {
 		return nil
 	}
+	resolver, ok := bc.blockStore.(coveringChunkResolver)
+	if !ok {
+		return bc.fillFromCASManifestScan(ctx, payloadID, dest, reqStart, covered)
+	}
+	reqEnd := reqStart + uint64(len(dest))
+	for cur := reqStart; cur < reqEnd; {
+		// Bytes already served from the append log need no CAS fetch.
+		if covered[cur-reqStart] {
+			cur++
+			continue
+		}
+		fb, err := resolver.GetFileChunkAtOffset(ctx, payloadID, cur)
+		if err != nil {
+			return fmt.Errorf("ReadPayloadAt: GetFileChunkAtOffset(%d): %w", cur, err)
+		}
+		if fb == nil {
+			// Hole at cur: jump to the next chunk starting at/after cur so
+			// the sparse gap stays uncovered without a per-byte lookup storm.
+			succ, serr := resolver.GetFileChunkAtOrAfterOffset(ctx, payloadID, cur)
+			if serr != nil {
+				return fmt.Errorf("ReadPayloadAt: GetFileChunkAtOrAfterOffset(%d): %w", cur, serr)
+			}
+			if succ == nil {
+				return nil // no more chunks — rest of the window stays a hole
+			}
+			nextAbs, ok := block.ParseChunkOffset(succ.ID)
+			if !ok || nextAbs <= cur {
+				// Malformed or non-advancing successor: bail to the caller
+				// rather than spin. Leaves cur..reqEnd uncovered (a miss).
+				return nil
+			}
+			cur = nextAbs
+			continue
+		}
+		absOffset, ok := block.ParseChunkOffset(fb.ID)
+		if !ok {
+			return fmt.Errorf("ReadPayloadAt: malformed FileChunk ID %q", fb.ID)
+		}
+		chunkEnd := absOffset + uint64(fb.DataSize)
+		if chunkEnd <= cur {
+			// Non-advancing (DataSize 0 or covering-guard/ID disagreement):
+			// stop rather than loop forever; leave the rest as a miss.
+			return nil
+		}
+		if !fb.Hash.IsZero() {
+			data, gerr := bc.Get(ctx, fb.Hash)
+			if gerr != nil {
+				if !errors.Is(gerr, block.ErrChunkNotFound) {
+					return fmt.Errorf("ReadPayloadAt: Get chunk %s: %w", fb.Hash.String(), gerr)
+				}
+				// Chunk evicted or never landed — leave uncovered and skip
+				// past this chunk; the caller falls back to remote for it.
+				data = nil
+			}
+			if data != nil {
+				// Clamp visible data to DataSize so a padded on-disk chunk
+				// does not leak garbage past the rollup-emitted byte count.
+				dataLen := uint64(len(data))
+				if uint64(fb.DataSize) > 0 && uint64(fb.DataSize) < dataLen {
+					dataLen = uint64(fb.DataSize)
+				}
+				// cur >= absOffset is guaranteed by the covering guard.
+				copyEnd := min(absOffset+dataLen, reqEnd)
+				if copyEnd > cur {
+					destIdx := cur - reqStart
+					srcIdx := cur - absOffset
+					n := copyEnd - cur
+					copy(dest[destIdx:destIdx+n], data[srcIdx:srcIdx+n])
+					for i := destIdx; i < destIdx+n; i++ {
+						covered[i] = true
+					}
+				}
+			}
+		}
+		cur = chunkEnd
+	}
+	return nil
+}
+
+// fillFromCASManifestScan is the full-manifest fallback for metadata backends
+// without the indexed covering lookup (memory/sqlite/postgres). It walks the
+// whole per-payload FileChunk manifest, sorts by absolute offset, and copies
+// every chunk that intersects the request window.
+func (bc *FSStore) fillFromCASManifestScan(ctx context.Context, payloadID string, dest []byte, reqStart uint64, covered []bool) error {
 	rows, err := bc.blockStore.ListFileChunks(ctx, payloadID)
 	if err != nil {
 		return fmt.Errorf("ReadPayloadAt: ListFileChunks: %w", err)

--- a/pkg/block/local/fs/readpayload_covering_test.go
+++ b/pkg/block/local/fs/readpayload_covering_test.go
@@ -1,0 +1,124 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// memFBS must satisfy the fast-path resolver so ReadPayloadAt drives the
+// indexed covering + successor loop rather than the ListFileChunks scan.
+var _ coveringChunkResolver = (*memFBS)(nil)
+
+// newCoveringTestStore wires an FSStore whose FileChunkStore (memFBS)
+// implements the covering + successor resolver, so post-rollup reads drive
+// fillFromCASManifest's indexed fast path.
+func newCoveringTestStore(t *testing.T) (*FSStore, context.Context) {
+	t.Helper()
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	fbs := newMemFileChunkStore()
+	persister := func(ctx context.Context, payloadID string, blocks []block.ChunkRef, _ block.ObjectID) error {
+		return fbs.persist(ctx, payloadID, blocks)
+	}
+	bc := newFSStoreForTestWithFBS(t, fbs, FSStoreOptions{
+		MaxLogBytes:       1 << 30,
+		RollupWorkers:     2,
+		StabilizationMS:   3_600_000,
+		RollupStore:       rs,
+		ObjectIDPersister: persister,
+	})
+	return bc, context.Background()
+}
+
+// TestReadPayloadAt_CoveringFastPath_MultiChunk writes a multi-chunk file,
+// rolls it into CAS, then reads several sub-windows (chunk-aligned, mid-chunk,
+// and spanning chunk boundaries). Every read must return the exact source bytes
+// — this exercises the fast path's `cur = chunkEnd` advance across more than one
+// covering chunk.
+func TestReadPayloadAt_CoveringFastPath_MultiChunk(t *testing.T) {
+	bc, ctx := newCoveringTestStore(t)
+
+	// Position-dependent bytes so any mis-offset copy is caught.
+	const size = 1 << 20 // 1 MiB — large enough for several FastCDC chunks
+	src := make([]byte, size)
+	for i := range src {
+		src[i] = byte(i*31 + 7)
+	}
+	if err := bc.AppendWrite(ctx, "fileM", src, 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+	if err := bc.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups: %v", err)
+	}
+
+	windows := []struct {
+		name        string
+		off, length uint64
+	}{
+		{"head", 0, 4096},
+		{"mid-unaligned", 4097, 4096},
+		{"large-span", 300000, 200000},
+		{"tail", size - 4096, 4096},
+		{"whole", 0, size},
+	}
+	for _, w := range windows {
+		got := make([]byte, w.length)
+		if _, err := bc.ReadPayloadAt(ctx, "fileM", got, w.off); err != nil {
+			t.Fatalf("%s: ReadPayloadAt(off=%d len=%d): %v", w.name, w.off, w.length, err)
+		}
+		if !bytes.Equal(got, src[w.off:w.off+w.length]) {
+			t.Fatalf("%s: read bytes mismatch at off=%d", w.name, w.off)
+		}
+	}
+}
+
+// TestReadPayloadAt_CoveringFastPath_Hole writes two separated regions, leaving
+// an un-backed gap between them, then verifies the successor lookup jumps the
+// hole without ever serving a neighbour chunk's bytes into it (the silent-
+// corruption guard). Each backed region reads back cleanly; any read that
+// touches the hole surfaces a miss (ErrFileChunkNotFound) rather than wrong
+// bytes.
+func TestReadPayloadAt_CoveringFastPath_Hole(t *testing.T) {
+	bc, ctx := newCoveringTestStore(t)
+
+	a := bytes.Repeat([]byte{'A'}, 4096)
+	c := bytes.Repeat([]byte{'C'}, 4096)
+	if err := bc.AppendWrite(ctx, "fileH", a, 0); err != nil {
+		t.Fatalf("AppendWrite region A: %v", err)
+	}
+	// Leave [4096, 8192) a hole; write region C at 8192.
+	if err := bc.AppendWrite(ctx, "fileH", c, 8192); err != nil {
+		t.Fatalf("AppendWrite region C: %v", err)
+	}
+	if err := bc.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups: %v", err)
+	}
+
+	// Each backed region reads back cleanly — proves the successor jump lands
+	// on the right chunk (C is not offset into A's slot or vice versa).
+	got := make([]byte, 4096)
+	if _, err := bc.ReadPayloadAt(ctx, "fileH", got, 0); err != nil || !bytes.Equal(got, a) {
+		t.Fatalf("region A read: err=%v equal=%v", err, bytes.Equal(got, a))
+	}
+	if _, err := bc.ReadPayloadAt(ctx, "fileH", got, 8192); err != nil || !bytes.Equal(got, c) {
+		t.Fatalf("region C read: err=%v equal=%v", err, bytes.Equal(got, c))
+	}
+
+	// A read confined to the hole must miss, not serve A's or C's bytes. If the
+	// covering guard were absent, GetFileChunkAtOffset could return a neighbour
+	// chunk and this would silently succeed with wrong data.
+	hole := make([]byte, 4096)
+	if _, err := bc.ReadPayloadAt(ctx, "fileH", hole, 4096); !errors.Is(err, block.ErrFileChunkNotFound) {
+		t.Fatalf("hole read: got err=%v, want ErrFileChunkNotFound", err)
+	}
+
+	// A read spanning the hole is not fully local → miss.
+	span := make([]byte, 12288)
+	if _, err := bc.ReadPayloadAt(ctx, "fileH", span, 0); !errors.Is(err, block.ErrFileChunkNotFound) {
+		t.Fatalf("hole-spanning read: got err=%v, want ErrFileChunkNotFound", err)
+	}
+}

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -409,6 +409,40 @@ func (s *BadgerMetadataStore) ListFileChunks(_ context.Context, payloadID string
 	return result, nil
 }
 
+// loadFileChunkAtIndexOffset resolves the FileChunk whose secondary-index key is
+// fb-file:{payloadID}:{off} via index key -> block ID -> primary row. It returns
+// (nil, nil) when either row is missing (ErrKeyNotFound) — a stale index entry
+// left by a deleted block, treated as absent, mirroring listFileChunksTxn's skip.
+// Any other Get/Value/unmarshal error is real IO or corruption and propagates.
+func loadFileChunkAtIndexOffset(txn *badger.Txn, payloadID string, off uint64) (*metadata.FileChunk, error) {
+	idxItem, gerr := txn.Get([]byte(fileChunkFilePrefix + payloadID + ":" + strconv.FormatUint(off, 10)))
+	if errors.Is(gerr, badger.ErrKeyNotFound) {
+		return nil, nil
+	} else if gerr != nil {
+		return nil, gerr
+	}
+	var blockID string
+	if verr := idxItem.Value(func(val []byte) error {
+		blockID = string(val)
+		return nil
+	}); verr != nil {
+		return nil, verr
+	}
+	fbItem, gerr := txn.Get([]byte(fileChunkPrefix + blockID))
+	if errors.Is(gerr, badger.ErrKeyNotFound) {
+		return nil, nil
+	} else if gerr != nil {
+		return nil, gerr
+	}
+	var fc metadata.FileChunk
+	if verr := fbItem.Value(func(val []byte) error {
+		return json.Unmarshal(val, &fc)
+	}); verr != nil {
+		return nil, verr
+	}
+	return &fc, nil
+}
+
 // GetFileChunkAtOffset returns the FileChunk covering absolute byte offset off
 // for payloadID — the row with the largest chunkOffset <= off whose range
 // [chunkOffset, chunkOffset+DataSize) contains off — or (nil, nil) for a sparse
@@ -447,35 +481,12 @@ func (s *BadgerMetadataStore) GetFileChunkAtOffset(_ context.Context, payloadID 
 			return nil // nothing starts at or before off — hole
 		}
 
-		// Fetch the winning row: index key -> block ID -> primary row. A
-		// missing index/primary row (ErrKeyNotFound) is a stale index entry —
-		// treat as a hole, mirroring listFileChunksTxn's "index stale, block
-		// deleted" skip. Any other Get/Value/unmarshal error is real IO or
-		// corruption and must propagate, not masquerade as a hole.
-		idxItem, gerr := txn.Get([]byte(fileChunkFilePrefix + payloadID + ":" + strconv.FormatUint(bestOff, 10)))
-		if errors.Is(gerr, badger.ErrKeyNotFound) {
-			return nil
-		} else if gerr != nil {
-			return gerr
+		fc, ferr := loadFileChunkAtIndexOffset(txn, payloadID, bestOff)
+		if ferr != nil {
+			return ferr
 		}
-		var blockID string
-		if verr := idxItem.Value(func(val []byte) error {
-			blockID = string(val)
-			return nil
-		}); verr != nil {
-			return verr
-		}
-		fbItem, gerr := txn.Get([]byte(fileChunkPrefix + blockID))
-		if errors.Is(gerr, badger.ErrKeyNotFound) {
-			return nil
-		} else if gerr != nil {
-			return gerr
-		}
-		var fc metadata.FileChunk
-		if verr := fbItem.Value(func(val []byte) error {
-			return json.Unmarshal(val, &fc)
-		}); verr != nil {
-			return verr
+		if fc == nil {
+			return nil // stale index entry — treat as a hole
 		}
 		// Covering guard keyed on the row's OWN start offset (the source of
 		// truth), not the index key, so an inconsistent index can't serve a
@@ -485,7 +496,57 @@ func (s *BadgerMetadataStore) GetFileChunkAtOffset(_ context.Context, payloadID 
 		if !ok || off < abs || off-abs >= uint64(fc.DataSize) {
 			return nil
 		}
-		result = &fc
+		result = fc
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// GetFileChunkAtOrAfterOffset returns the FileChunk with the smallest
+// chunkOffset >= off for payloadID — the next data boundary at or after a sparse
+// hole — or (nil, nil) when no chunk starts at or after off (a read past the last
+// chunk). The read path uses it to skip a hole straight to the next chunk in one
+// indexed keys-only scan instead of probing byte by byte. Same index, cost model,
+// and stale-index-as-absent semantics as GetFileChunkAtOffset. No covering guard:
+// the successor is returned regardless of whether it contains off.
+//
+// ponytail: O(n) keys-only scan per hole; shares the fb-off-index upgrade path
+// with GetFileChunkAtOffset if profiling at real N ever demands O(log n).
+func (s *BadgerMetadataStore) GetFileChunkAtOrAfterOffset(_ context.Context, payloadID string, off uint64) (*metadata.FileChunk, error) {
+	var result *metadata.FileChunk
+	err := s.db.View(func(txn *badger.Txn) error {
+		prefix := []byte(fileChunkFilePrefix + payloadID + ":")
+		opts := badger.DefaultIteratorOptions
+		opts.Prefix = prefix
+		opts.PrefetchValues = false // keys only — the offset lives in the key
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		var (
+			bestOff uint64
+			found   bool
+		)
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			suffix := it.Item().Key()[len(prefix):]
+			cand, perr := strconv.ParseUint(string(suffix), 10, 64)
+			if perr != nil {
+				continue // tolerate a malformed index row, like parseBlockIdx
+			}
+			if cand >= off && (!found || cand < bestOff) {
+				bestOff, found = cand, true
+			}
+		}
+		if !found {
+			return nil // nothing starts at or after off — past the last chunk
+		}
+		fc, ferr := loadFileChunkAtIndexOffset(txn, payloadID, bestOff)
+		if ferr != nil {
+			return ferr
+		}
+		result = fc // may be nil for a stale index entry — caller treats as end
 		return nil
 	})
 	if err != nil {

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -65,6 +65,14 @@ func runFileChunkOpsTests(t *testing.T, factory StoreFactory) {
 		testGetFileChunkAtOffset(t, factory)
 	})
 
+	// GetFileChunkAtOrAfterOffset is the read-path successor lookup: it resolves
+	// the next chunk starting at/after a byte offset so a hole read skips to the
+	// next data boundary in one indexed scan instead of a per-byte probe storm.
+	// Only badger implements it today; other backends skip.
+	t.Run("GetFileChunkAtOrAfterOffset", func(t *testing.T) {
+		testGetFileChunkAtOrAfterOffset(t, factory)
+	})
+
 	// the syncer claim cycle stamps
 	// LastSyncAttemptAt = now when flipping a block to Syncing, and the
 	// restart-recovery janitor compares it against ClaimTimeout. Every
@@ -373,13 +381,16 @@ func testGetFileChunkAtOffset(t *testing.T, factory StoreFactory) {
 	// Chunks at absolute byte offsets with deliberate holes. The decimal
 	// offsets in the IDs (0, 20, 100, 200) sort lexically as 0,100,20,200 —
 	// NOT numeric order — so this exercises the decimal-vs-numeric trap the
-	// badger keys-only scan must handle. Coverage: [0,20) [20,50) [100,110)
-	// [200,300); holes at [50,100), [110,200), and past 300.
+	// badger keys-only scan must handle. The 1-byte chunk at 300 exercises the
+	// single-byte covering guard (off==abs covers, off==abs+1 is a hole).
+	// Coverage: [0,20) [20,50) [100,110) [200,300) [300,301); holes at
+	// [50,100), [110,200), and past 301.
 	blocks := []*block.FileChunk{
 		{ID: "file-hole/0", State: block.BlockStatePending, DataSize: 20, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
 		{ID: "file-hole/20", State: block.BlockStatePending, DataSize: 30, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
 		{ID: "file-hole/100", State: block.BlockStatePending, DataSize: 10, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
 		{ID: "file-hole/200", State: block.BlockStatePending, DataSize: 100, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
+		{ID: "file-hole/300", State: block.BlockStatePending, DataSize: 1, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
 	}
 	for _, b := range blocks {
 		if err := store.Put(ctx, b); err != nil {
@@ -408,7 +419,8 @@ func testGetFileChunkAtOffset(t *testing.T, factory StoreFactory) {
 		{"hole-50", 50, ""},
 		{"hole-110", 110, ""},
 		{"hole-150", 150, ""},
-		{"past-eof-300", 300, ""},
+		{"single-byte-300", 300, "file-hole/300"}, // off==abs covers a 1-byte chunk
+		{"single-byte-past-301", 301, ""},         // off==abs+DataSize is a hole
 		{"past-eof-400", 400, ""},
 	}
 	for _, tc := range cases {
@@ -440,6 +452,112 @@ func testGetFileChunkAtOffset(t *testing.T, factory StoreFactory) {
 		t.Fatalf("GetFileChunkAtOffset(unknown): %v", err)
 	} else if got != nil {
 		t.Errorf("GetFileChunkAtOffset(unknown payload) = %q, want nil", got.ID)
+	}
+}
+
+// chunkAtOrAfterProbe is the indexed successor lookup, implemented only by the
+// badger backend today. Backends without it skip the subtest.
+type chunkAtOrAfterProbe interface {
+	GetFileChunkAtOrAfterOffset(ctx context.Context, payloadID string, off uint64) (*block.FileChunk, error)
+}
+
+// successorOracle independently resolves the chunk with the smallest start
+// offset >= off by walking the full ListFileChunks result — the reference the
+// indexed successor lookup must agree with.
+func successorOracle(rows []*block.FileChunk, off uint64) *block.FileChunk {
+	var best *block.FileChunk
+	var bestAbs uint64
+	for _, fb := range rows {
+		abs, ok := block.ParseChunkOffset(fb.ID)
+		if !ok {
+			continue
+		}
+		if abs >= off && (best == nil || abs < bestAbs) {
+			best, bestAbs = fb, abs
+		}
+	}
+	return best
+}
+
+func testGetFileChunkAtOrAfterOffset(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	probe, ok := store.(chunkAtOrAfterProbe)
+	if !ok {
+		t.Skipf("backend %T does not implement GetFileChunkAtOrAfterOffset", store)
+	}
+
+	// Same fixture as the covering test: chunk starts 0,20,100,200 (decimal
+	// offsets that sort lexically as 0,100,20,200 — the numeric-vs-lexical
+	// trap), coverage [0,20) [20,50) [100,110) [200,300), holes [50,100),
+	// [110,200), and past 300.
+	blocks := []*block.FileChunk{
+		{ID: "file-succ/0", State: block.BlockStatePending, DataSize: 20, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
+		{ID: "file-succ/20", State: block.BlockStatePending, DataSize: 30, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
+		{ID: "file-succ/100", State: block.BlockStatePending, DataSize: 10, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
+		{ID: "file-succ/200", State: block.BlockStatePending, DataSize: 100, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
+		{ID: "file-succ/300", State: block.BlockStatePending, DataSize: 1, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
+	}
+	for _, b := range blocks {
+		if err := store.Put(ctx, b); err != nil {
+			t.Fatalf("Put(%s): %v", b.ID, err)
+		}
+	}
+	rows, err := asLegacy(t, store).ListFileChunks(ctx, "file-succ")
+	if err != nil {
+		t.Fatalf("ListFileChunks: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		off  uint64
+		want string // next chunk ID with start >= off, "" for none
+	}{
+		{"at-start-0", 0, "file-succ/0"},
+		{"before-20", 1, "file-succ/20"},  // nothing else starts in [1,20)
+		{"last-of-0", 19, "file-succ/20"}, // successor is by start, not coverage
+		{"at-start-20", 20, "file-succ/20"},
+		{"after-20", 21, "file-succ/100"},
+		{"hole-50", 50, "file-succ/100"}, // hole → next data boundary
+		{"at-start-100", 100, "file-succ/100"},
+		{"hole-110", 110, "file-succ/200"}, // hole after /100's coverage ends
+		{"hole-150", 150, "file-succ/200"},
+		{"at-start-200", 200, "file-succ/200"},
+		{"after-200-hole", 201, "file-succ/300"}, // next start is the 1-byte chunk
+		{"at-single-byte-300", 300, "file-succ/300"},
+		{"past-last-301", 301, ""}, // nothing starts at/after 301
+		{"past-eof-400", 400, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := probe.GetFileChunkAtOrAfterOffset(ctx, "file-succ", tc.off)
+			if err != nil {
+				t.Fatalf("GetFileChunkAtOrAfterOffset(%d): %v", tc.off, err)
+			}
+			gotID := ""
+			if got != nil {
+				gotID = got.ID
+			}
+			if gotID != tc.want {
+				t.Errorf("GetFileChunkAtOrAfterOffset(%d) = %q, want %q", tc.off, gotID, tc.want)
+			}
+			// Cross-check against the independent ListFileChunks walk.
+			oracleID := ""
+			if o := successorOracle(rows, tc.off); o != nil {
+				oracleID = o.ID
+			}
+			if gotID != oracleID {
+				t.Errorf("GetFileChunkAtOrAfterOffset(%d) = %q disagrees with ListFileChunks oracle %q", tc.off, gotID, oracleID)
+			}
+		})
+	}
+
+	// Unknown payload → no successor, not error.
+	if got, err := probe.GetFileChunkAtOrAfterOffset(ctx, "no-such-payload", 0); err != nil {
+		t.Fatalf("GetFileChunkAtOrAfterOffset(unknown): %v", err)
+	} else if got != nil {
+		t.Errorf("GetFileChunkAtOrAfterOffset(unknown payload) = %q, want nil", got.ID)
 	}
 }
 


### PR DESCRIPTION
## What

Finishes the read-path fix for #1580 (reopened). Every read of a rolled-up file walked the **entire** per-payload FileChunk manifest — `ListFileChunks` + a JSON decode of every chunk — just to find the single chunk covering the requested offset. That is O(chunks) per read (O(N²) over a random scan) and dominates read CPU.

`FSStore.fillFromCASManifest` (`pkg/block/local/fs/readpayload.go`) now resolves each touched chunk through the badger secondary index instead:

- **Covering lookup** — `GetFileChunkAtOffset(off)` returns the single chunk whose range `[off, off+DataSize)` contains the offset (added on develop by #1577; this PR routes the block-store CAS-fill through it).
- **Successor lookup** — new `GetFileChunkAtOrAfterOffset(off)` returns the next chunk starting at/after `off`. On a sparse hole the loop jumps straight to the next data boundary in one indexed keys-only scan, so a read never re-enumerates the manifest and never probes byte-by-byte.
- Non-badger backends (memory/sqlite/postgres) keep the full-manifest walk, now named `fillFromCASManifestScan`.

## Why it's backed by clean rig evidence

From `results/read-baseline/READ-BASELINE.md` — validated on a clean SCW POP2-HC-32C rig, proven pure cache-hit (`dittofs_datapath_block_range_reads_total` delta = 0), rollup drained (dfs CPU 0%), S3 untouched:

```
handleNFSRead → ReadPayloadAt (82.8%) → fillFromCASManifest (82.7%)
   → ListFileChunks (80.1%) → JSON-decode all chunks (29.6%)
```

- rand-read-4k, 32MiB cache: **2771 IOPS**, fillFromCASManifest = **82%** of read CPU.
- rand-read-4k, default 10GB cache: **11756 IOPS**, fillFromCASManifest = **75.7%**, ListFileChunks = **57.2%**.

Same mechanism at both cache sizes → **not** a cache-size / rollup / S3 artifact. This corrects the earlier "rollup confound" dismissal (which had measured a fresh, unrolled file on the append-log fast path — steady state is rolled-up files, which route through `fillFromCASManifest`).

## Correctness (no wrong bytes on a hole)

The covering guard lives inside the resolver: `GetFileChunkAtOffset` only returns a chunk whose range actually contains the offset (guard keyed on the row's own start offset, so an inconsistent index can't serve a neighbour chunk's bytes). On a hole it returns nil, and the loop advances via the successor — the hole stays uncovered and `ReadPayloadAt` surfaces it as `ErrFileChunkNotFound` (caller zero-fills / fetches remote). A hole can never be served a neighbouring chunk's bytes.

New tests:
- `pkg/metadata/storetest/file_block_ops.go` — successor conformance cases (exact-boundary, holes between chunks, EOF, multi-chunk, single-byte chunk), each cross-checked against an independent `ListFileChunks` oracle. Single-byte case added to the covering test too.
- `pkg/block/local/fs/readpayload_covering_test.go` — drives the real fast path (`memFBS` now implements the resolver): multi-chunk covering reads (aligned/unaligned/spanning) return exact bytes; a hole read and a hole-spanning read both miss rather than serve wrong bytes.

## Gates

- `pkg/metadata/storetest` + `pkg/block/blockstoretest` conformance green on **all** backends (badger, sqlite, memory, postgres all runnable here).
- `go test -race ./pkg/block/local/fs/... ./pkg/metadata/store/badger/... ./pkg/block/engine/...` green.
- `gofmt -s`, `go vet`, `golangci-lint run` clean.

Baseline to beat (measured on the live rig by the maintainer): fillFromCASManifest/ListFileChunks should collapse off the read profile; local cache-hit IOPS ceiling up several-fold.

Closes #1580.
