### PR TITLE
feat(shares): grant share access directly to AD principals by SID (#1528)

### DIFF
--- a/cmd/dfsctl/commands/share/permission/grant.go
+++ b/cmd/dfsctl/commands/share/permission/grant.go
@@ -12,6 +12,7 @@ import (
 var (
 	grantUser  string
 	grantGroup string
+	grantSID   string
 	grantLevel string
 )
 
@@ -20,33 +21,43 @@ var grantCmd = &cobra.Command{
 	Short: "Grant permission on a share",
 	Long: `Grant a permission level to a user or group on a share.
 
-Specify exactly one of --user or --group together with --level. Re-running
-the command on a principal that already has a permission replaces the existing
-level. Permission levels in order of increasing access:
+Specify exactly one of --user, --group, or --sid together with --level.
+Re-running the command on a principal that already has a permission replaces the
+existing level. Permission levels in order of increasing access:
   - none:       No access (explicitly blocks the principal)
   - read:       Read-only access
   - read-write: Read and write access
   - admin:      Full administrative access including ACL management
 
+Active Directory principals can be granted directly, with no local DittoFS
+account (issue #1528). --user / --group accept a local name, an AD name
+(user@REALM or DOMAIN\group, resolved to a SID via the configured LDAP
+directory), or a raw Windows SID. A bare name resolves to a local user/group if
+one exists, otherwise to the directory. --sid grants to a raw SID explicitly.
+
 Examples:
-  # Grant read-write access to a specific user
+  # Grant read-write access to a local user
   dfsctl share permission grant /archive --user alice --level read-write
 
-  # Grant read-only access to a group
+  # Grant read-only access to a local group
   dfsctl share permission grant /archive --group editors --level read
 
-  # Block a specific user despite a permissive share default
-  dfsctl share permission grant /archive --user bob --level none
+  # Grant directly to an AD group (resolved to its SID via LDAP) — no local group
+  dfsctl share permission grant /archive --group 'CUBBIT\Cubbit' --level read-write
 
-  # Grant admin access to a service account
-  dfsctl share permission grant /archive --user svc-backup --level admin`,
+  # Grant directly to an AD user by Kerberos principal
+  dfsctl share permission grant /archive --user alice@cubbit.local --level read
+
+  # Grant to a raw Windows SID (no directory lookup)
+  dfsctl share permission grant /archive --sid S-1-5-21-1111-2222-3333-1104 --level read`,
 	Args: cobra.ExactArgs(1),
 	RunE: runGrant,
 }
 
 func init() {
-	grantCmd.Flags().StringVar(&grantUser, "user", "", "Username to grant permission to")
-	grantCmd.Flags().StringVar(&grantGroup, "group", "", "Group name to grant permission to")
+	grantCmd.Flags().StringVar(&grantUser, "user", "", "User to grant permission to (local name, AD name, or SID)")
+	grantCmd.Flags().StringVar(&grantGroup, "group", "", "Group to grant permission to (local name, AD name, or SID)")
+	grantCmd.Flags().StringVar(&grantSID, "sid", "", "Raw Windows SID to grant permission to (e.g. S-1-5-21-...)")
 	grantCmd.Flags().StringVar(&grantLevel, "level", "", "Permission level (none|read|read-write|admin)")
 	_ = grantCmd.MarkFlagRequired("level")
 }
@@ -54,11 +65,12 @@ func init() {
 func runGrant(cmd *cobra.Command, args []string) error {
 	shareName := args[0]
 
-	if grantUser == "" && grantGroup == "" {
-		return fmt.Errorf("either --user or --group must be specified")
-	}
-	if grantUser != "" && grantGroup != "" {
-		return fmt.Errorf("--user and --group are mutually exclusive")
+	// A raw SID short-circuits to the SID endpoint; a name goes to the local
+	// user/group endpoint, which falls back to the directory when no local
+	// object exists (#1528).
+	kind, value, isGroup, target, err := selectPrincipal(grantUser, grantGroup, grantSID)
+	if err != nil {
+		return err
 	}
 
 	client, err := cmdutil.GetAuthenticatedClient()
@@ -66,17 +78,16 @@ func runGrant(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var target string
-	if grantUser != "" {
-		if err := client.SetUserSharePermission(shareName, grantUser, grantLevel); err != nil {
-			return fmt.Errorf("failed to grant permission: %w", err)
-		}
-		target = fmt.Sprintf("user '%s'", grantUser)
-	} else {
-		if err := client.SetGroupSharePermission(shareName, grantGroup, grantLevel); err != nil {
-			return fmt.Errorf("failed to grant permission: %w", err)
-		}
-		target = fmt.Sprintf("group '%s'", grantGroup)
+	switch kind {
+	case principalSID:
+		err = client.SetSIDSharePermission(shareName, value, grantLevel, isGroup, "")
+	case principalUserName:
+		err = client.SetUserSharePermission(shareName, value, grantLevel)
+	case principalGroupName:
+		err = client.SetGroupSharePermission(shareName, value, grantLevel)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to grant permission: %w", err)
 	}
 
 	format, err := cmdutil.GetOutputFormatParsed()

--- a/cmd/dfsctl/commands/share/permission/list.go
+++ b/cmd/dfsctl/commands/share/permission/list.go
@@ -38,14 +38,14 @@ type PermissionList []apiclient.SharePermission
 
 // Headers implements TableRenderer.
 func (pl PermissionList) Headers() []string {
-	return []string{"TYPE", "NAME", "LEVEL"}
+	return []string{"TYPE", "NAME", "LEVEL", "SID"}
 }
 
 // Rows implements TableRenderer.
 func (pl PermissionList) Rows() [][]string {
 	rows := make([][]string, 0, len(pl))
 	for _, p := range pl {
-		rows = append(rows, []string{p.Type, p.Name, p.Level})
+		rows = append(rows, []string{p.Type, p.Name, p.Level, p.SID})
 	}
 	return rows
 }

--- a/cmd/dfsctl/commands/share/permission/principal.go
+++ b/cmd/dfsctl/commands/share/permission/principal.go
@@ -49,12 +49,12 @@ func selectPrincipal(user, group, sidFlag string) (kind principalKind, value str
 		return principalSID, sidFlag, true, fmt.Sprintf("SID '%s'", sidFlag), nil
 	case user != "":
 		if isSIDLiteral(user) {
-			return principalSID, user, false, fmt.Sprintf("user '%s'", user), nil
+			return principalSID, user, false, fmt.Sprintf("user SID '%s'", user), nil
 		}
 		return principalUserName, user, false, fmt.Sprintf("user '%s'", user), nil
 	default: // group
 		if isSIDLiteral(group) {
-			return principalSID, group, true, fmt.Sprintf("group '%s'", group), nil
+			return principalSID, group, true, fmt.Sprintf("group SID '%s'", group), nil
 		}
 		return principalGroupName, group, true, fmt.Sprintf("group '%s'", group), nil
 	}

--- a/cmd/dfsctl/commands/share/permission/principal.go
+++ b/cmd/dfsctl/commands/share/permission/principal.go
@@ -1,0 +1,61 @@
+package permission
+
+import (
+	"fmt"
+
+	"github.com/marmos91/dittofs/pkg/auth/sid"
+)
+
+// principalKind classifies the target of a grant/revoke after resolving the
+// --user / --group / --sid flags.
+type principalKind int
+
+const (
+	principalUserName  principalKind = iota // a local-or-directory user name
+	principalGroupName                      // a local-or-directory group name
+	principalSID                            // a raw Windows SID
+)
+
+// isSIDLiteral reports whether v is a syntactically valid Windows SID string.
+func isSIDLiteral(v string) bool {
+	_, err := sid.ParseSIDString(v)
+	return err == nil
+}
+
+// selectPrincipal validates that exactly one of user/group/sid is set and
+// classifies the target, shared by the grant and revoke commands. A --user or
+// --group value that is itself a SID literal is treated as a SID grant (isGroup
+// reflecting the user/group intent); an explicit --sid is a group-form SID.
+// target is a human-readable label for command output.
+func selectPrincipal(user, group, sidFlag string) (kind principalKind, value string, isGroup bool, target string, err error) {
+	set := 0
+	for _, v := range []string{user, group, sidFlag} {
+		if v != "" {
+			set++
+		}
+	}
+	if set == 0 {
+		return 0, "", false, "", fmt.Errorf("one of --user, --group, or --sid must be specified")
+	}
+	if set > 1 {
+		return 0, "", false, "", fmt.Errorf("--user, --group, and --sid are mutually exclusive")
+	}
+
+	switch {
+	case sidFlag != "":
+		if !isSIDLiteral(sidFlag) {
+			return 0, "", false, "", fmt.Errorf("invalid SID %q", sidFlag)
+		}
+		return principalSID, sidFlag, true, fmt.Sprintf("SID '%s'", sidFlag), nil
+	case user != "":
+		if isSIDLiteral(user) {
+			return principalSID, user, false, fmt.Sprintf("user '%s'", user), nil
+		}
+		return principalUserName, user, false, fmt.Sprintf("user '%s'", user), nil
+	default: // group
+		if isSIDLiteral(group) {
+			return principalSID, group, true, fmt.Sprintf("group '%s'", group), nil
+		}
+		return principalGroupName, group, true, fmt.Sprintf("group '%s'", group), nil
+	}
+}

--- a/cmd/dfsctl/commands/share/permission/revoke.go
+++ b/cmd/dfsctl/commands/share/permission/revoke.go
@@ -12,6 +12,7 @@ import (
 var (
 	revokeUser  string
 	revokeGroup string
+	revokeSID   string
 )
 
 var revokeCmd = &cobra.Command{
@@ -22,31 +23,36 @@ var revokeCmd = &cobra.Command{
 After revoking, the user or group falls back to the share's default permission
 level (see 'dfsctl share show'). To explicitly block a principal rather than
 fall back to the default, use 'dfsctl share permission grant ... --level none'
-instead. Specify exactly one of --user or --group.
+instead. Specify exactly one of --user, --group, or --sid.
+
+--user / --group accept a local name, an AD name, or a raw SID (matching the
+grant command); --sid revokes a raw SID grant directly.
 
 Examples:
   # Revoke a user's explicit permission (they fall back to the share default)
   dfsctl share permission revoke /archive --user alice
 
   # Revoke a group's explicit permission
-  dfsctl share permission revoke /archive --group editors`,
+  dfsctl share permission revoke /archive --group editors
+
+  # Revoke a direct AD/SID grant
+  dfsctl share permission revoke /archive --sid S-1-5-21-1111-2222-3333-1104`,
 	Args: cobra.ExactArgs(1),
 	RunE: runRevoke,
 }
 
 func init() {
-	revokeCmd.Flags().StringVar(&revokeUser, "user", "", "Username to revoke permission from")
-	revokeCmd.Flags().StringVar(&revokeGroup, "group", "", "Group name to revoke permission from")
+	revokeCmd.Flags().StringVar(&revokeUser, "user", "", "User to revoke permission from (local name, AD name, or SID)")
+	revokeCmd.Flags().StringVar(&revokeGroup, "group", "", "Group to revoke permission from (local name, AD name, or SID)")
+	revokeCmd.Flags().StringVar(&revokeSID, "sid", "", "Raw Windows SID to revoke permission from")
 }
 
 func runRevoke(cmd *cobra.Command, args []string) error {
 	shareName := args[0]
 
-	if revokeUser == "" && revokeGroup == "" {
-		return fmt.Errorf("either --user or --group must be specified")
-	}
-	if revokeUser != "" && revokeGroup != "" {
-		return fmt.Errorf("--user and --group are mutually exclusive")
+	kind, value, _, target, err := selectPrincipal(revokeUser, revokeGroup, revokeSID)
+	if err != nil {
+		return err
 	}
 
 	client, err := cmdutil.GetAuthenticatedClient()
@@ -54,17 +60,16 @@ func runRevoke(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var target string
-	if revokeUser != "" {
-		if err := client.RemoveUserSharePermission(shareName, revokeUser); err != nil {
-			return fmt.Errorf("failed to revoke permission: %w", err)
-		}
-		target = fmt.Sprintf("user '%s'", revokeUser)
-	} else {
-		if err := client.RemoveGroupSharePermission(shareName, revokeGroup); err != nil {
-			return fmt.Errorf("failed to revoke permission: %w", err)
-		}
-		target = fmt.Sprintf("group '%s'", revokeGroup)
+	switch kind {
+	case principalSID:
+		err = client.RemoveSIDSharePermission(shareName, value)
+	case principalUserName:
+		err = client.RemoveUserSharePermission(shareName, value)
+	case principalGroupName:
+		err = client.RemoveGroupSharePermission(shareName, value)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to revoke permission: %w", err)
 	}
 
 	format, err := cmdutil.GetOutputFormatParsed()

--- a/docs/guide/access-control.md
+++ b/docs/guide/access-control.md
@@ -22,6 +22,24 @@ Access to a file is decided by **two independent layers**, both of which must al
 
    A grant **only opens the gate**. It does not modify any file's owner, mode, or ACL.
 
+   **Granting AD principals directly by SID (no local users).** A grant can
+   target a raw Windows **SID**, or an AD **name** that DittoFS resolves to a SID
+   via the configured LDAP directory — with **no local DittoFS user/group
+   object** (#1528). `--user`/`--group` accept a local name, an AD name
+   (`user@REALM` / `DOMAIN\group`), or a SID; a bare name resolves to a local
+   object if one exists, otherwise to the directory. The resolved SID is stored.
+
+   ```bash
+   dfsctl share permission grant /data --group 'CUBBIT\Cubbit'    --level read-write
+   dfsctl share permission grant /data --sid   S-1-5-21-...-1104  --level read
+   ```
+
+   At the gate, a Kerberos login is matched against SID grants by its **PAC user
+   + group SIDs** (SMB) or the Unix id the SID resolves to (NFS); the highest
+   matching level wins, alongside any local grant. The share-root ACL projects a
+   `sid:<SID>` ACE per grant so the filesystem layer agrees. See
+   [windows-ad-setup.md](windows-ad-setup.md) for the operator walkthrough.
+
 2. **Filesystem permissions (POSIX mode + ACL).** Once past the gate, the file's own POSIX mode bits and ACL decide the actual operation — exactly as described in the rest of this page. A share-level grant never overrides these; a user granted `read-write` on the export still cannot write a file whose mode/ACL denies them.
 
 **Effective access = share gate AND filesystem permission.** Both must allow.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -4254,8 +4254,8 @@ mkdir -p ~/mnt/dittofs && dfsctl share mount /export --protocol smb ~/mnt/dittof
 Flags:
 
 ```
-      --dir-mode string      Directory permissions for SMB mount (octal) (default "0777")
-      --file-mode string     File permissions for SMB mount (octal, default 0777 on macOS since uid/gid not supported) (default "0777")
+      --dir-mode string      Directory permissions for SMB mount (octal)
+      --file-mode string     File permissions (not applicable on Windows)
       --nfs-version string   NFS protocol version for NFS mounts (3, 4, 4.0, 4.1, 4.2). v4 carries locking in-protocol; v3 locking needs the server UDP transport + portmapper (default "3")
   -P, --password string      Password for SMB mount (will prompt if not provided)
   -p, --protocol string      Protocol to use (nfs or smb) (required)
@@ -4451,9 +4451,9 @@ Grant permission on a share
 
 Grant a permission level to a user or group on a share.
 
-Specify exactly one of --user or --group together with --level. Re-running
-the command on a principal that already has a permission replaces the existing
-level. Permission levels in order of increasing access:
+Specify exactly one of --user, --group, or --sid together with --level.
+Re-running the command on a principal that already has a permission replaces the
+existing level. Permission levels in order of increasing access:
 
 ```
 - none:       No access (explicitly blocks the principal)
@@ -4462,6 +4462,12 @@ level. Permission levels in order of increasing access:
 - admin:      Full administrative access including ACL management
 ```
 
+Active Directory principals can be granted directly, with no local DittoFS
+account (issue #1528). --user / --group accept a local name, an AD name
+(user@REALM or DOMAIN\group, resolved to a SID via the configured LDAP
+directory), or a raw Windows SID. A bare name resolves to a local user/group if
+one exists, otherwise to the directory. --sid grants to a raw SID explicitly.
+
 ```
 dfsctl share permission grant <share> [flags]
 ```
@@ -4469,25 +4475,29 @@ dfsctl share permission grant <share> [flags]
 **Examples:**
 
 ```bash
-# Grant read-write access to a specific user
+# Grant read-write access to a local user
 dfsctl share permission grant /archive --user alice --level read-write
 
-# Grant read-only access to a group
+# Grant read-only access to a local group
 dfsctl share permission grant /archive --group editors --level read
 
-# Block a specific user despite a permissive share default
-dfsctl share permission grant /archive --user bob --level none
+# Grant directly to an AD group (resolved to its SID via LDAP) — no local group
+dfsctl share permission grant /archive --group 'CUBBIT\Cubbit' --level read-write
 
-# Grant admin access to a service account
-dfsctl share permission grant /archive --user svc-backup --level admin
+# Grant directly to an AD user by Kerberos principal
+dfsctl share permission grant /archive --user alice@cubbit.local --level read
+
+# Grant to a raw Windows SID (no directory lookup)
+dfsctl share permission grant /archive --sid S-1-5-21-1111-2222-3333-1104 --level read
 ```
 
 Flags:
 
 ```
-      --group string   Group name to grant permission to
+      --group string   Group to grant permission to (local name, AD name, or SID)
       --level string   Permission level (none|read|read-write|admin)
-      --user string    Username to grant permission to
+      --sid string     Raw Windows SID to grant permission to (e.g. S-1-5-21-...)
+      --user string    User to grant permission to (local name, AD name, or SID)
 ```
 
 Global flags:
@@ -4555,7 +4565,10 @@ Remove a per-principal permission entry from a share.
 After revoking, the user or group falls back to the share's default permission
 level (see 'dfsctl share show'). To explicitly block a principal rather than
 fall back to the default, use 'dfsctl share permission grant ... --level none'
-instead. Specify exactly one of --user or --group.
+instead. Specify exactly one of --user, --group, or --sid.
+
+--user / --group accept a local name, an AD name, or a raw SID (matching the
+grant command); --sid revokes a raw SID grant directly.
 
 ```
 dfsctl share permission revoke <share> [flags]
@@ -4569,13 +4582,17 @@ dfsctl share permission revoke /archive --user alice
 
 # Revoke a group's explicit permission
 dfsctl share permission revoke /archive --group editors
+
+# Revoke a direct AD/SID grant
+dfsctl share permission revoke /archive --sid S-1-5-21-1111-2222-3333-1104
 ```
 
 Flags:
 
 ```
-      --group string   Group name to revoke permission from
-      --user string    Username to revoke permission from
+      --group string   Group to revoke permission from (local name, AD name, or SID)
+      --sid string     Raw Windows SID to revoke permission from
+      --user string    User to revoke permission from (local name, AD name, or SID)
 ```
 
 Global flags:

--- a/docs/guide/identity.md
+++ b/docs/guide/identity.md
@@ -19,6 +19,11 @@ See also: [docs/CONFIGURATION.md](configuration.md) (every config key + env var)
 [docs/SMB.md](smb.md), [docs/NFS.md](nfs.md), and [docs/ACLS.md](access-control.md) (the
 cross-protocol ACL/SID model).
 
+> **Joining a real Windows Server AD?** For an end-to-end operator runbook
+> (`ktpass` keytab, LDAP, granting AD users/groups directly, and per-user
+> "mount on login"), see [windows-ad-setup.md](windows-ad-setup.md). This page
+> is the reference for every provider field; that page is the step-by-step.
+
 ---
 
 ## Overview: cross-protocol identity unification
@@ -311,6 +316,35 @@ Each key has a `DITTOFS_LDAP_*` env equivalent (e.g. `DITTOFS_LDAP_ENABLED`,
 
 (Verified against `cmd/dfs/commands/start.go` `resolveIdentityProviders` and the
 handler in `internal/controlplane/api/handlers/identity_providers.go`.)
+
+---
+
+## Part B2: Grant AD principals directly to shares (no local users)
+
+With LDAP configured, you can grant share access straight to an AD user or group
+— resolved to its **SID** — with **no local DittoFS user/group object** (#1528).
+At login, a Kerberos-authenticated principal's PAC user + group SIDs are matched
+against these grants.
+
+```bash
+# By AD name (resolved to a SID via LDAP; a bare name resolves to a local
+# object first, otherwise to the directory):
+dfsctl share permission grant /ditto --group 'CUBBIT\Cubbit'     --level read-write
+dfsctl share permission grant /ditto --user  alice@cubbit.local  --level read
+
+# By raw SID (no directory lookup — works even with LDAP disabled):
+dfsctl share permission grant /ditto --sid S-1-5-21-...-1104      --level read
+
+dfsctl share permission list /ditto     # shows each grant + its resolved SID
+```
+
+Grants are additive (highest matching level wins) and apply on both SMB (matched
+on PAC SIDs) and NFS (matched on the Unix id the SID resolves to — the RID under
+`idmap: rid`, so grant by name or use `idmap: rid` for an NFS-matchable id). This
+is the Samba `idmap_rid`-style, no-shadow-users model. For the full Windows
+Server walkthrough including per-user "mount on login", see
+[windows-ad-setup.md](windows-ad-setup.md); for the ACE model, see
+[access-control.md](access-control.md).
 
 ---
 

--- a/docs/guide/windows-ad-setup.md
+++ b/docs/guide/windows-ad-setup.md
@@ -275,5 +275,14 @@ workstation never bleed permissions.
   principal resolves to (the RID in `idmap: rid`), and the NFS gate + root ACL
   match on that GID/UID. Grant by **name** (or a raw SID in `idmap: rid`) so the
   numeric id is captured; see [identity.md](identity.md) for NFS client setup.
+  Because NFS matches by the *mapped* id (no SID is on the NFS wire), NFS
+  authorization inherits the idmap's range contract: ensure AD ids do not overlap
+  your local UID/GID space (the same requirement Samba meets with dedicated idmap
+  ranges), or a local principal could match an AD grant over NFS. The SMB path is
+  always SID-exact and not subject to this. A raw `--sid` grant only carries an
+  NFS-matchable id under `idmap: rid`; under `idmap: rfc2307` grant by **name** so
+  the correct `gidNumber` is captured.
+- A **user-explicit** local grant (including `--level none`) is authoritative and
+  is never overridden by a group or AD/SID grant — an explicit block stays a block.
 
 See [access-control.md](access-control.md) for the full SID/ACL model.

--- a/docs/guide/windows-ad-setup.md
+++ b/docs/guide/windows-ad-setup.md
@@ -1,0 +1,279 @@
+# Windows Active Directory Setup Runbook
+
+End-to-end guide for a Windows administrator to join **DittoFS** to an existing
+**Windows Server Active Directory** domain and give domain users SMB (and NFS)
+access to a share — **without creating any local DittoFS user for them**
+(issue #1528). Domain users authenticate with their own Kerberos credentials and
+are authorized directly by their AD user/group **SID**.
+
+This is the production Windows-Server companion to
+[identity.md](identity.md) (which uses a Samba AD-DC dev fixture). The commands
+are shown two ways: the **`dfsctl`** CLI (authoritative) and the **DittoFS Pro
+dashboard** UI where applicable; Windows-side steps use the native tools
+(`ktpass`, ADUC/ADSI Edit, Group Policy Management Console).
+
+> **Status.** AD/LDAP/Kerberos support is functional but the project is **not
+> production ready**. See [faq.md](faq.md).
+
+The worked example uses realm **`CUBBIT.LOCAL`** / NetBIOS **`CUBBIT`**, a
+member server **`vm2.cubbit.local`**, a service account **`svc-dittofs`**, and
+domain users **alice** / **bob** in an AD group **Cubbit**. Substitute your own.
+
+---
+
+## 0. Accounts: what you create and what you don't
+
+There are **two kinds of account**, and #1528 only removes one of them:
+
+| | Control-plane (management) | Data-plane (mounting) |
+|---|---|---|
+| Who | The **one native DittoFS admin** | AD users (alice, bob, Administrator) |
+| Auth | Local password → `dfsctl login` / dashboard | Kerberos ticket from the domain |
+| Created how | Auto-provisioned at first server start (`DITTOFS_ADMIN_INITIAL_PASSWORD`) | **Never created in DittoFS** |
+| Used for | Configure LDAP + create grants (once) | Mount shares |
+
+So the workflow is: **sign in once as the native admin to wire up LDAP and
+grants; from then on, domain users just mount.** You do **not** create AD-backed
+admin logins, and you do **not** create a DittoFS user for each AD user.
+
+---
+
+## 1. Create the service account, SPN, and AES keytab (in AD)
+
+DittoFS authenticates SMB/NFS clients as a Kerberos service. It needs a domain
+**service account** that holds the service principal name (SPN) and an exported
+**keytab**.
+
+1. **Create the service account** (Active Directory Users and Computers, or
+   PowerShell). Give it a strong password; it needs no special privileges.
+   ```powershell
+   New-ADUser -Name svc-dittofs -SamAccountName svc-dittofs `
+     -AccountPassword (Read-Host -AsSecureString "svc-dittofs password") `
+     -Enabled $true -PasswordNeverExpires $true
+   ```
+
+2. **Map the SPN and export an AES keytab** with `ktpass` (run on a DC or any
+   RSAT-equipped admin box). This binds `cifs/<host>` (SMB) to the account and
+   writes the keytab. **Use AES** — Windows 11 rejects RC4-only service tickets
+   (#1318):
+   ```cmd
+   ktpass -princ cifs/vm2.cubbit.local@CUBBIT.LOCAL ^
+     -mapuser CUBBIT\svc-dittofs -pass * ^
+     -crypto AES256-SHA1 -ptype KRB5_NT_PRINCIPAL ^
+     -out C:\dittofs\dittofs.keytab
+   ```
+   For NFS as well, repeat with `-princ nfs/vm2.cubbit.local@CUBBIT.LOCAL` and
+   `-in`/`-out` the same file to append (or export a second keytab and merge).
+
+3. **Advertise AES on the account** so the KDC issues AES tickets. In ADUC enable
+   *"This account supports Kerberos AES 256 bit encryption"* (Account tab), or
+   set `msDS-SupportedEncryptionTypes` via ADSI Edit / Attribute Editor. `ktpass`
+   usually sets this; verify it.
+
+4. Copy `dittofs.keytab` to the DittoFS host (e.g. `C:\ProgramData\dittofs\`).
+   Treat it as a **secret** — it is the service's Kerberos key. Restrict its ACL
+   to the DittoFS service account.
+
+> If SMB port 445 on the host is held by the Windows *Server* service, stop and
+> disable `LanmanServer` so DittoFS can bind 445 (or run DittoFS on a host that
+> is not itself an SMB server).
+
+---
+
+## 2. Kerberos config and start the server
+
+Provide a `krb5.conf` pointing at the realm/KDC (e.g. `C:\etc\krb5.conf`):
+
+```ini
+[libdefaults]
+  default_realm = CUBBIT.LOCAL
+[realms]
+  CUBBIT.LOCAL = { kdc = vm1.cubbit.local }
+[domain_realm]
+  .cubbit.local = CUBBIT.LOCAL
+  cubbit.local  = CUBBIT.LOCAL
+```
+
+Add the `kerberos:` block to the DittoFS config (or set it via
+`dfsctl identity-provider set kerberos …` after start — note Kerberos changes are
+restart-required):
+
+```yaml
+kerberos:
+  enabled: true
+  keytab_path: "C:/ProgramData/dittofs/dittofs.keytab"
+  service_principal: "cifs/vm2.cubbit.local@CUBBIT.LOCAL"
+  krb5_conf: "C:/etc/krb5.conf"
+  realm: "CUBBIT.LOCAL"
+  netbios_domain: "CUBBIT"
+  dns_domain: "cubbit.local"
+```
+
+Start the server (the native admin password is provisioned on first start):
+
+```powershell
+$env:DITTOFS_ADMIN_INITIAL_PASSWORD = "<choose-a-strong-admin-password>"
+dfs start --config C:\dittofs\config.yaml
+```
+
+Sign in with the native admin — this is the one management account from step 0:
+
+```powershell
+dfsctl login --server https://127.0.0.1:8080 --username admin
+```
+
+---
+
+## 3. Connect the LDAP directory (read-only)
+
+DittoFS reads the directory to (a) resolve an AD **name → SID** when you type a
+grant, and (b) resolve a domain user's UID/GID at login. Use a **read-only**
+service account (the same `svc-dittofs` is fine — it only needs to read
+directory objects) and **LDAPS**.
+
+Use `idmap: rid` (Samba `idmap_rid`-style): UIDs/GIDs are derived
+deterministically from the SID's RID, so you do **not** need to stamp
+`uidNumber`/`gidNumber` POSIX attributes on your AD objects.
+
+**CLI** (LDAP is hot-reloaded — no restart):
+
+```powershell
+dfsctl identity-provider test ldap --config '{ ...json below... }'   # dry-run first
+dfsctl identity-provider set  ldap --config '{
+  "enabled": true,
+  "url": "ldaps://vm1.cubbit.local:636",
+  "base_dn": "DC=cubbit,DC=local",
+  "bind_dn": "CN=svc-dittofs,CN=Users,DC=cubbit,DC=local",
+  "bind_password": "<svc-dittofs password>",
+  "idmap": "rid",
+  "realm": "CUBBIT.LOCAL",
+  "nested_groups": true
+}'
+dfsctl identity-provider list        # confirm LDAP shows configured + enabled
+```
+
+**Pro dashboard:** go to **Identity Providers → LDAP**, fill in the URL, base DN,
+bind DN/password, and set idmap to `rid`; click **Test**, then **Save**.
+
+**Security notes:**
+- Use `ldaps://` (or `start_tls: true`) — a plaintext bind is refused unless you
+  explicitly opt in. Set `tls.ca_cert_file` to validate the DC certificate.
+- The bind account needs **read only**. Never use a domain-admin bind.
+- The bind password is write-only over the API (redacted on read).
+
+See [identity.md §Part B](identity.md) for every LDAP config field.
+
+---
+
+## 4. Grant AD users and groups directly (no local users)
+
+Now grant share access straight to AD principals. `--user` / `--group` accept a
+**local name, an AD name (`user@REALM` or `DOMAIN\group`), or a raw SID**. A bare
+name resolves to a local object if one exists, otherwise to the directory; the
+resolved **SID** is stored. No DittoFS user/group object is created.
+
+Grant **distinct levels per principal** — this is what makes the same share
+behave differently for each person:
+
+```powershell
+# AD user alice → read-only
+dfsctl share permission grant ditto --user alice@cubbit.local --level read
+
+# AD user bob → read-write
+dfsctl share permission grant ditto --user bob@cubbit.local --level read-write
+
+# AD group (everyone in Cubbit) → read-write, resolved to the group SID via LDAP
+dfsctl share permission grant ditto --group "CUBBIT\Cubbit" --level read-write
+
+# Domain Admins → admin (full control)
+dfsctl share permission grant ditto --group "Domain Admins" --level admin
+
+# By raw SID (no directory lookup needed)
+dfsctl share permission grant ditto --sid S-1-5-21-1111-2222-3333-1104 --level read
+
+dfsctl share permission list ditto     # shows each grant + resolved SID
+```
+
+**Pro dashboard:** **Access Control → Shares → <share> → Grant**, type the AD
+user/group (or SID), pick a level, save.
+
+Levels, lowest to highest: `none < read < read-write < admin`. Grants are
+**additive** — a user gets the highest level of any grant that matches their own
+SID or one of their group SIDs.
+
+Revoke symmetrically: `dfsctl share permission revoke ditto --group "CUBBIT\Cubbit"`
+(or `--sid …`).
+
+---
+
+## 5. Per-user "mount on login" (the target experience)
+
+The goal: on a shared workstation, **each user who logs in gets the share mounted
+with their own permissions.** This works because each interactive Windows logon
+holds its own Kerberos ticket, so mounting `\\vm2.cubbit.local\ditto` under that
+logon presents *that user's* identity; DittoFS reads their PAC user + group SIDs
+and applies the grants keyed to those SIDs. No configuration ties a mount to a
+specific person — DittoFS simply authorizes whoever connects.
+
+- **alice logs in →** the share mounts **read-only** (her grant).
+- **bob logs in on the same box →** his own logon, his own ticket → **read-write**.
+- **Administrator logs in →** matched via *Domain Admins* → **admin**.
+
+Mount on login is a **client-side** Windows step (nothing DittoFS-specific):
+
+**Option A — Group Policy Drive Maps (recommended).** In the Group Policy
+Management Console, edit a GPO applied to the workstations:
+*User Configuration → Preferences → Windows Settings → Drive Maps → New → Mapped
+Drive.* Set Location `\\vm2.cubbit.local\ditto`, Action *Update*, a drive letter,
+and **Reconnect**. Use **item-level targeting** if you want different drives for
+different groups. Because it is under *User Configuration*, the drive maps under
+each user's own logon and ticket.
+
+**Option B — logon script.** A per-user logon script running:
+```cmd
+net use Z: \\vm2.cubbit.local\ditto /persistent:yes
+```
+No credentials are passed — Windows uses the logged-in user's Kerberos ticket
+(single sign-on).
+
+**Verify the resolved identity** in Explorer: right-click a file →
+*Properties → Security*. Owner/ACE SIDs resolve to `CUBBIT\<name>` when the LDAP
+directory is configured (step 3); without it they show as raw `S-1-5-21-…`.
+
+---
+
+## 6. Verify and troubleshoot
+
+**Prove no local users are needed:** you never ran `dfsctl user create` for alice
+or bob — they mount purely as AD principals.
+
+Check each logon gets the right level: as alice, reading works but writing is
+denied; as bob, both work; as Administrator, full control. In the server debug
+log (`DITTOFS_LOGGING_LEVEL=DEBUG`) each TREE_CONNECT logs the per-session SID
+match — the decision is derived from that session's own PAC, so two users on one
+workstation never bleed permissions.
+
+| Symptom | Cause / fix |
+|---|---|
+| `System error 1219` on `net use` | A pre-existing/"Disconnected" session to the same server under different creds. `net use * /delete /y` and `cmdkey /delete:vm2.cubbit.local`, then retry. Not a DittoFS bug. |
+| Mount falls back to NTLM or fails with a signing error | Keytab lacks AES keys (RC4-only) — Windows 11 rejects RC4 (#1318). Re-export with `-crypto AES256-SHA1` and set `msDS-SupportedEncryptionTypes`. |
+| Grant by name returns "not found" | LDAP not configured/reachable, or the name isn't a directory object. Check `dfsctl identity-provider list` and `… test ldap`. Grant by `--sid` to bypass LDAP. |
+| Access denied despite a grant | Confirm the grant with `dfsctl share permission list <share>`; confirm the user's ticket carries the granted group (their PAC group SIDs). |
+| `ldaps://` cert error | Set `tls.ca_cert_file` to the DC's issuing CA; do not disable verification in production. |
+
+---
+
+## How authorization works (reference)
+
+- At SMB **TREE_CONNECT**, DittoFS resolves the session's permission from (a) any
+  local user/group grant and (b) the **SID grants** matched against the login's
+  Kerberos PAC user + group SIDs — the higher wins. An AD principal with **no
+  local account** is authorized entirely by (b).
+- At the **file** layer, the share-root ACL carries a `sid:<SID>` ACE per grant,
+  matched against the same PAC SIDs, so file operations agree with the share gate.
+- **NFS** carries GIDs, not SIDs, so each SID grant also records the Unix id the
+  principal resolves to (the RID in `idmap: rid`), and the NFS gate + root ACL
+  match on that GID/UID. Grant by **name** (or a raw SID in `idmap: rid`) so the
+  numeric id is captured; see [identity.md](identity.md) for NFS client setup.
+
+See [access-control.md](access-control.md) for the full SID/ACL model.

--- a/docs/guide/windows.md
+++ b/docs/guide/windows.md
@@ -105,6 +105,23 @@ Open Explorer and type the UNC path in the address bar:
 
 Windows will prompt for credentials if the server requires them.
 
+### Per-user access on a shared workstation (Active Directory)
+
+When DittoFS is joined to AD (Kerberos), each interactive Windows logon mounts
+the share with **that user's own permissions** — no per-user configuration on the
+DittoFS side. Because each logon holds its own Kerberos ticket, mounting
+`\\<host>\<share>` presents that user's identity, and DittoFS authorizes them by
+their AD user/group SIDs. On one shared machine: alice logs in and gets her
+level, bob logs in and gets his, an administrator gets theirs — each independent.
+
+To mount automatically at logon for every user, use **Group Policy Drive Maps**
+(User Configuration → Preferences → Windows Settings → Drive Maps) or a per-user
+logon script running `net use Z: \\<host>\<share> /persistent:yes` — no
+credentials are passed, Windows uses the logged-in user's ticket (SSO).
+
+Grant AD users/groups directly, with no local DittoFS accounts — see the
+[Windows AD setup runbook](windows-ad-setup.md).
+
 ---
 
 ## Mounting an NFS share
@@ -159,7 +176,7 @@ SMB3 encryption and signing, change notifications, durable handles, and server-s
 | Symptom | Cause | Solution |
 |---------|-------|----------|
 | "The network path was not found" | DittoFS not running or firewall blocking the port | Verify `dfs start` is running; check port 12445 is accessible with `Test-NetConnection` |
-| "Access denied" | Invalid credentials or missing share permissions | Verify user exists (`dfsctl user list`); check share permissions (`dfsctl share permission list /<share>`) |
+| "Access denied" | Invalid credentials or missing share permissions | Check share permissions (`dfsctl share permission list /<share>`). For a local user, verify it exists (`dfsctl user list`). For an AD user, no local account is needed — confirm a grant matches their SID or one of their AD group SIDs (see [windows-ad-setup.md](windows-ad-setup.md)) |
 | "The specified network name is no longer available" | Connection dropped during operation | Retry `net use`; check DittoFS logs for errors |
 | "Insecure guest logon" error | Windows 11 24H2 blocks guest logons by default | Follow [Enabling insecure guest logons](#enabling-insecure-guest-logons-if-needed) above |
 

--- a/internal/adapter/nfs/auth/share_permission.go
+++ b/internal/adapter/nfs/auth/share_permission.go
@@ -17,7 +17,7 @@ var ErrShareAccessDenied = errors.New("share access denied")
 // sidUnixSharePermissionResolver is the subset of the control-plane store that
 // resolves a share permission from an NFS login's numeric UID + GIDs against
 // direct AD/SID grants (#1528). The concrete store implements it; a store that
-// does not simply skips the direct-AD-grant path.
+// does not implement it simply skips the direct-AD-grant path.
 type sidUnixSharePermissionResolver interface {
 	ResolveSharePermissionForUnixIDs(ctx context.Context, uid uint32, gids []uint32, shareName string) (models.SharePermission, error)
 }

--- a/internal/adapter/nfs/auth/share_permission.go
+++ b/internal/adapter/nfs/auth/share_permission.go
@@ -158,8 +158,9 @@ func ResolveSharePermission(
 		perm = defaultPerm
 	}
 	// A direct AD/SID grant can elevate a local user's access (additive, like
-	// group membership).
-	if sidPerm.Level() > perm.Level() {
+	// group membership) — but NOT when the user has an explicit per-user grant
+	// (including an explicit 'none' block), which is authoritative.
+	if _, explicit := user.GetExplicitSharePermission(shareName); !explicit && sidPerm.Level() > perm.Level() {
 		perm = sidPerm
 	}
 

--- a/internal/adapter/nfs/auth/share_permission.go
+++ b/internal/adapter/nfs/auth/share_permission.go
@@ -14,6 +14,14 @@ import (
 // resolved permission for a known user is "none").
 var ErrShareAccessDenied = errors.New("share access denied")
 
+// sidUnixSharePermissionResolver is the subset of the control-plane store that
+// resolves a share permission from an NFS login's numeric UID + GIDs against
+// direct AD/SID grants (#1528). The concrete store implements it; a store that
+// does not simply skips the direct-AD-grant path.
+type sidUnixSharePermissionResolver interface {
+	ResolveSharePermissionForUnixIDs(ctx context.Context, uid uint32, gids []uint32, shareName string) (models.SharePermission, error)
+}
+
 // SharePermissionResult is the outcome of export-squash permission resolution.
 type SharePermissionResult struct {
 	// ReadOnly is true when the effective access is read-only — either the
@@ -52,6 +60,7 @@ func ResolveSharePermission(
 	shareName string,
 	clientAddr string,
 	uid *uint32,
+	gids []uint32,
 ) (SharePermissionResult, error) {
 	var result SharePermissionResult
 
@@ -100,21 +109,41 @@ func ResolveSharePermission(
 		return result, nil
 	}
 
+	// Direct AD/SID grants (#1528): match the login's UID + group GIDs against
+	// the share's SID grants. This authorizes an AD principal that has no local
+	// DittoFS account — the NFS analogue of the SMB PAC-SID path (NFS carries no
+	// SID, so grants are matched on the numeric id the login resolved to).
+	sidPerm := models.PermissionNone
+	if r, ok := identityStore.(sidUnixSharePermissionResolver); ok {
+		if p, sErr := r.ResolveSharePermissionForUnixIDs(ctx, *uid, gids, shareName); sErr != nil {
+			logger.DebugCtx(ctx, "SID permission resolution failed, ignoring",
+				"share", shareName, "uid", *uid, "error", sErr)
+		} else {
+			sidPerm = p
+		}
+	}
+
 	// Try reverse lookup: find user by UID.
 	user, err := identityStore.GetUserByUID(ctx, *uid)
 	if err != nil || user == nil {
 		logger.DebugCtx(ctx, "NFS UID reverse lookup failed, treating as guest",
 			"share", shareName, "uid", *uid, "client", clientAddr, "error", err)
 
-		// Guest access - check default permission.
-		if defaultPerm == models.PermissionNone {
-			logger.DebugCtx(ctx, "Share access denied (unknown UID, default permission is none)",
+		// Guest access: the higher of the share default and any direct AD/SID
+		// grant. A SID grant lets an AD principal with no local account through
+		// even when default_permission is none.
+		guestPerm := defaultPerm
+		if sidPerm.Level() > guestPerm.Level() {
+			guestPerm = sidPerm
+		}
+		if guestPerm == models.PermissionNone {
+			logger.DebugCtx(ctx, "Share access denied (unknown UID, no default or SID grant)",
 				"share", shareName, "uid", *uid)
 			return SharePermissionResult{}, ErrShareAccessDenied
 		}
 
-		result.ReadOnly = share.ReadOnly || defaultPerm == models.PermissionRead
-		logger.DebugCtx(ctx, "Guest access granted", "share", shareName, "permission", defaultPerm, "readOnly", result.ReadOnly)
+		result.ReadOnly = share.ReadOnly || guestPerm == models.PermissionRead
+		logger.DebugCtx(ctx, "Access granted (guest/AD-SID)", "share", shareName, "permission", guestPerm, "readOnly", result.ReadOnly)
 		return result, nil
 	}
 
@@ -127,6 +156,11 @@ func ResolveSharePermission(
 		logger.DebugCtx(ctx, "Permission resolution failed, using default",
 			"share", shareName, "user", user.Username, "error", permErr, "default", defaultPerm)
 		perm = defaultPerm
+	}
+	// A direct AD/SID grant can elevate a local user's access (additive, like
+	// group membership).
+	if sidPerm.Level() > perm.Level() {
+		perm = sidPerm
 	}
 
 	if perm == models.PermissionNone {

--- a/internal/adapter/nfs/auth/share_permission_sid_test.go
+++ b/internal/adapter/nfs/auth/share_permission_sid_test.go
@@ -1,0 +1,58 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+)
+
+// A direct AD/SID grant (#1528) authorizes an NFS login that has no local user
+// (GetUserByUID fails) by matching one of its GIDs, even when the share default
+// is "none" — the NFS analogue of the SMB PAC-SID path.
+func TestResolveSharePermission_SIDGrantByGID(t *testing.T) {
+	share := &runtime.Share{Name: "/export", DefaultPermission: "none", Squash: models.SquashRootToGuest}
+
+	t.Run("group GID grant grants access under default none", func(t *testing.T) {
+		store := newPermMockStore() // no local user for this UID
+		store.sidPerm = models.PermissionReadWrite
+		store.sidMatchIDs = map[uint32]bool{1104: true} // the granted group's GID
+
+		res, err := ResolveSharePermission(
+			context.Background(), store, share, "/export", "10.0.0.1:1", ptrUID(50001), []uint32{1104})
+		if err != nil {
+			t.Fatalf("expected access via SID grant, got denial: %v", err)
+		}
+		if res.ReadOnly {
+			t.Errorf("read-write SID grant should not be read-only")
+		}
+	})
+
+	t.Run("no GID match still denies under default none", func(t *testing.T) {
+		store := newPermMockStore()
+		store.sidPerm = models.PermissionReadWrite
+		store.sidMatchIDs = map[uint32]bool{1104: true}
+
+		_, err := ResolveSharePermission(
+			context.Background(), store, share, "/export", "10.0.0.1:1", ptrUID(50001), []uint32{9999})
+		if err != ErrShareAccessDenied {
+			t.Fatalf("expected ErrShareAccessDenied for an unmatched GID, got %v", err)
+		}
+	})
+
+	t.Run("read-level SID grant coerces read-only", func(t *testing.T) {
+		store := newPermMockStore()
+		store.sidPerm = models.PermissionRead
+		store.sidMatchIDs = map[uint32]bool{1104: true}
+
+		res, err := ResolveSharePermission(
+			context.Background(), store, share, "/export", "10.0.0.1:1", ptrUID(50001), []uint32{1104})
+		if err != nil {
+			t.Fatalf("unexpected denial: %v", err)
+		}
+		if !res.ReadOnly {
+			t.Errorf("read-level SID grant should be read-only")
+		}
+	})
+}

--- a/internal/adapter/nfs/auth/share_permission_sid_test.go
+++ b/internal/adapter/nfs/auth/share_permission_sid_test.go
@@ -41,6 +41,28 @@ func TestResolveSharePermission_SIDGrantByGID(t *testing.T) {
 		}
 	})
 
+	t.Run("explicit local none blocks a matching SID grant (no override)", func(t *testing.T) {
+		// A known local user explicitly granted 'none' must stay denied even when
+		// a group-SID grant matches one of their GIDs.
+		uid := uint32(4000)
+		store := newPermMockStore()
+		store.usersByUID[uid] = &models.User{
+			Username: "blocked", UID: &uid,
+			SharePermissions: []models.UserSharePermission{
+				{ShareName: "/export", Permission: string(models.PermissionNone)},
+			},
+		}
+		store.perm = models.PermissionNone // explicit user 'none'
+		store.sidPerm = models.PermissionReadWrite
+		store.sidMatchIDs = map[uint32]bool{1104: true}
+
+		_, err := ResolveSharePermission(
+			context.Background(), store, share, "/export", "10.0.0.1:1", ptrUID(uid), []uint32{1104})
+		if err != ErrShareAccessDenied {
+			t.Fatalf("explicit local 'none' must deny despite a matching SID grant; got err=%v", err)
+		}
+	})
+
 	t.Run("read-level SID grant coerces read-only", func(t *testing.T) {
 		store := newPermMockStore()
 		store.sidPerm = models.PermissionRead

--- a/internal/adapter/nfs/auth/share_permission_test.go
+++ b/internal/adapter/nfs/auth/share_permission_test.go
@@ -15,6 +15,12 @@ type permMockStore struct {
 	usersByUID map[uint32]*models.User
 	perm       models.SharePermission
 	permErr    error
+
+	// sidPerm is returned by ResolveSharePermissionForUnixIDs when the login's
+	// UID or one of its GIDs is present in sidMatchIDs (a direct AD/SID grant,
+	// #1528). Left zero, the SID path resolves to none — existing tests unchanged.
+	sidPerm     models.SharePermission
+	sidMatchIDs map[uint32]bool
 }
 
 func newPermMockStore() *permMockStore {
@@ -55,6 +61,21 @@ func (m *permMockStore) GetUserByUID(_ context.Context, uid uint32) (*models.Use
 	return user, nil
 }
 
+func (m *permMockStore) ResolveSharePermissionForUnixIDs(_ context.Context, uid uint32, gids []uint32, _ string) (models.SharePermission, error) {
+	if m.sidMatchIDs == nil {
+		return models.PermissionNone, nil
+	}
+	if m.sidMatchIDs[uid] {
+		return m.sidPerm, nil
+	}
+	for _, g := range gids {
+		if m.sidMatchIDs[g] {
+			return m.sidPerm, nil
+		}
+	}
+	return models.PermissionNone, nil
+}
+
 func ptrUID(v uint32) *uint32 { return &v }
 
 // Behavior 1: default_permission=none denies an unknown UID. This is the v4
@@ -67,7 +88,7 @@ func TestResolveSharePermission_DefaultPermissionNoneDeniesUnknownUID(t *testing
 		Squash:            models.SquashNone,
 	}
 
-	_, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(1234))
+	_, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(1234), nil)
 	if !errors.Is(err, ErrShareAccessDenied) {
 		t.Fatalf("expected ErrShareAccessDenied for unknown UID under default_permission=none, got %v", err)
 	}
@@ -81,7 +102,7 @@ func TestResolveSharePermission_DefaultPermissionReadWriteAllowsUnknownUID(t *te
 		Squash:            models.SquashNone,
 	}
 
-	res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(1234))
+	res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(1234), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -102,7 +123,7 @@ func TestResolveSharePermission_RootPromotedToAdmin(t *testing.T) {
 			Squash:            sq,
 		}
 
-		res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(0))
+		res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(0), nil)
 		if err != nil {
 			t.Fatalf("squash=%q: unexpected error: %v", sq, err)
 		}
@@ -127,7 +148,7 @@ func TestResolveSharePermission_EmptySquashDoesNotPromoteRoot(t *testing.T) {
 		Squash:            "", // unset → DefaultSquashMode (root_to_guest)
 	}
 
-	_, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(0))
+	_, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(0), nil)
 	if !errors.Is(err, ErrShareAccessDenied) {
 		t.Fatalf("empty squash + default none: err = %v, want ErrShareAccessDenied (root not promoted)", err)
 	}
@@ -145,7 +166,7 @@ func TestResolveSharePermission_ReadPermissionCoercesReadOnly(t *testing.T) {
 		Squash:            models.SquashNone,
 	}
 
-	res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(1000))
+	res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(1000), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -164,7 +185,7 @@ func TestResolveSharePermission_KnownUserPermissionNoneDenied(t *testing.T) {
 
 	share := &runtime.Share{Name: "/export", DefaultPermission: "read-write", Squash: models.SquashNone}
 
-	_, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(1000))
+	_, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(1000), nil)
 	if !errors.Is(err, ErrShareAccessDenied) {
 		t.Fatalf("expected ErrShareAccessDenied for known user with permission=none, got %v", err)
 	}
@@ -186,7 +207,7 @@ func TestResolveSharePermission_NilInputsAllow(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			res, err := ResolveSharePermission(context.Background(), tc.store, tc.share, "/export", "127.0.0.1:1", tc.uid)
+			res, err := ResolveSharePermission(context.Background(), tc.store, tc.share, "/export", "127.0.0.1:1", tc.uid, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -203,7 +224,7 @@ func TestResolveSharePermission_NilInputsAllow(t *testing.T) {
 func TestResolveSharePermission_NilStoreHonoursShareReadOnly(t *testing.T) {
 	share := &runtime.Share{Name: "/export", ReadOnly: true}
 
-	res, err := ResolveSharePermission(context.Background(), nil, share, "/export", "127.0.0.1:1", ptrUID(1000))
+	res, err := ResolveSharePermission(context.Background(), nil, share, "/export", "127.0.0.1:1", ptrUID(1000), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -224,7 +245,7 @@ func TestResolveSharePermission_AnonymousAuthNullDeniedWhenDefaultNone(t *testin
 		Squash:            models.SquashNone,
 	}
 
-	_, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", nil)
+	_, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", nil, nil)
 	if !errors.Is(err, ErrShareAccessDenied) {
 		t.Fatalf("anonymous AUTH_NULL caller on default_permission=none: expected ErrShareAccessDenied, got %v", err)
 	}
@@ -238,7 +259,7 @@ func TestResolveSharePermission_AnonymousAuthNullCoercedReadOnly(t *testing.T) {
 
 	t.Run("share read-only flag", func(t *testing.T) {
 		share := &runtime.Share{Name: "/export", DefaultPermission: "read-write", ReadOnly: true}
-		res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", nil)
+		res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", nil, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -249,7 +270,7 @@ func TestResolveSharePermission_AnonymousAuthNullCoercedReadOnly(t *testing.T) {
 
 	t.Run("default_permission=read", func(t *testing.T) {
 		share := &runtime.Share{Name: "/export", DefaultPermission: "read"}
-		res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", nil)
+		res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", nil, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -265,7 +286,7 @@ func TestResolveSharePermission_AnonymousAuthNullAllowedReadWrite(t *testing.T) 
 	store := newPermMockStore()
 	share := &runtime.Share{Name: "/export", DefaultPermission: "read-write"}
 
-	res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", nil)
+	res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -283,7 +304,7 @@ func TestResolveSharePermission_ShareReadOnlyForcesReadOnly(t *testing.T) {
 
 	share := &runtime.Share{Name: "/export", DefaultPermission: "read-write", Squash: models.SquashNone, ReadOnly: true}
 
-	res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(1000))
+	res, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(1000), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -304,7 +325,7 @@ func TestResolveSharePermission_DefaultNoneDeniesUnmappedUID(t *testing.T) {
 		Squash:            models.SquashNone,
 	}
 
-	_, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(2001))
+	_, err := ResolveSharePermission(context.Background(), store, share, "/export", "127.0.0.1:1", ptrUID(2001), nil)
 	if !errors.Is(err, ErrShareAccessDenied) {
 		t.Fatalf("uid=2001 on default_permission=none: expected ErrShareAccessDenied, got %v", err)
 	}

--- a/internal/adapter/nfs/v3/handlers/auth_helper.go
+++ b/internal/adapter/nfs/v3/handlers/auth_helper.go
@@ -102,9 +102,14 @@ func BuildAuthContextWithMapping(
 		return nil, fmt.Errorf("failed to get share: %w", shareErr)
 	}
 
-	// Resolve permissions (export-squash policy, shared with NFSv4).
+	// Resolve permissions (export-squash policy, shared with NFSv4). The GID set
+	// (supplementary + primary) lets a direct AD/SID grant match by GID (#1528).
 	identityStore := reg.GetIdentityStore()
-	permResult, err := auth.ResolveSharePermission(ctx, identityStore, share, shareName, clientAddr, nfsCtx.UID)
+	permGIDs := append([]uint32(nil), nfsCtx.GIDs...)
+	if nfsCtx.GID != nil {
+		permGIDs = append(permGIDs, *nfsCtx.GID)
+	}
+	permResult, err := auth.ResolveSharePermission(ctx, identityStore, share, shareName, clientAddr, nfsCtx.UID, permGIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapter/nfs/v4/handlers/helpers.go
+++ b/internal/adapter/nfs/v4/handlers/helpers.go
@@ -144,8 +144,12 @@ func (h *Handler) buildV4AuthContext(ctx *types.CompoundContext, handle []byte) 
 	// SAME policy the v3 path applies via auth.ResolveSharePermission; v4
 	// previously skipped it, so default_permission=none did not deny unknown
 	// UIDs and read-only coercion never fired.
+	permGIDs := append([]uint32(nil), ctx.GIDs...)
+	if ctx.GID != nil {
+		permGIDs = append(permGIDs, *ctx.GID)
+	}
 	permResult, err := auth.ResolveSharePermission(
-		ctx.Context, h.Registry.GetIdentityStore(), share, shareName, ctx.ClientAddr, ctx.UID)
+		ctx.Context, h.Registry.GetIdentityStore(), share, shareName, ctx.ClientAddr, ctx.UID, permGIDs)
 	if err != nil {
 		// A share-permission denial (e.g. default_permission=none for an
 		// unmapped principal — the krb5 machine-principal-maps-to-nobody case)

--- a/internal/adapter/smb/handlers/tree_connect.go
+++ b/internal/adapter/smb/handlers/tree_connect.go
@@ -403,10 +403,16 @@ func resolveSharePermission(
 
 	// 3. Direct AD/SID grants (#1528). The Kerberos PAC user + group SIDs are on
 	// the session independent of local user resolution, so this authorizes an AD
-	// principal that has no local DittoFS account. The higher of the local and
-	// SID-grant levels wins (additive, like group membership).
+	// principal that has no local DittoFS account. SID grants are additive (like
+	// group membership) EXCEPT when the user has an explicit per-user local grant
+	// — including an explicit 'none' block — which is authoritative and must not
+	// be overridden, mirroring the local resolver's "user-explicit wins" rule.
 	effective := localPerm
-	if r, ok := userStore.(sidSharePermissionResolver); ok {
+	userExplicit := false
+	if sess.User != nil {
+		_, userExplicit = sess.User.GetExplicitSharePermission(share.Name)
+	}
+	if r, ok := userStore.(sidSharePermissionResolver); ok && !userExplicit {
 		groupSIDs, userSID := sess.PACIdentity()
 		sids := groupSIDs
 		if userSID != "" {

--- a/internal/adapter/smb/handlers/tree_connect.go
+++ b/internal/adapter/smb/handlers/tree_connect.go
@@ -342,7 +342,7 @@ func parseSharePath(path string) string {
 // sidSharePermissionResolver is the subset of the control-plane store that
 // resolves a share permission from a set of Windows SIDs (a login's PAC user +
 // group SIDs). The concrete store implements it; a mock userStore that does not
-// simply skips the direct-AD-grant path (#1528).
+// implement it simply skips the direct-AD-grant path (#1528).
 type sidSharePermissionResolver interface {
 	ResolveSharePermissionForSIDs(ctx context.Context, sids []string, shareName string) (models.SharePermission, error)
 }

--- a/internal/adapter/smb/handlers/tree_connect.go
+++ b/internal/adapter/smb/handlers/tree_connect.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -338,13 +339,24 @@ func parseSharePath(path string) string {
 	return "/" + strings.ToLower(parts[1])
 }
 
+// sidSharePermissionResolver is the subset of the control-plane store that
+// resolves a share permission from a set of Windows SIDs (a login's PAC user +
+// group SIDs). The concrete store implements it; a mock userStore that does not
+// simply skips the direct-AD-grant path (#1528).
+type sidSharePermissionResolver interface {
+	ResolveSharePermissionForSIDs(ctx context.Context, sids []string, shareName string) (models.SharePermission, error)
+}
+
 // resolveSharePermission determines the effective permission for a session on a share.
 // Returns the permission level and a user identifier for logging.
 //
 // Permission resolution follows this order:
 //  1. Root user bypass: If user has UID=0 and squash mode allows root access, grant PermissionAdmin
-//  2. User-level permission from UserStore.ResolveSharePermission (if userStore available)
-//  3. Default permission if no explicit permission found
+//  2. Local user/group permission from UserStore.ResolveSharePermission (if userStore available)
+//  3. Direct AD/SID grants (#1528): the session's Kerberos PAC user + group SIDs
+//     matched against the share's SID grants — applied even when the principal
+//     has no local User object. The higher of (2) and (3) wins.
+//  4. Default permission if no explicit permission found
 //
 // This mirrors the NFS behavior where root users get automatic admin access based on squash settings.
 func resolveSharePermission(
@@ -354,52 +366,65 @@ func resolveSharePermission(
 	defaultPerm models.SharePermission,
 	userStore models.UserStore,
 ) (models.SharePermission, string) {
-	// Authenticated user with valid session
-	if sess != nil && sess.User != nil {
-		// Check if user is root (UID 0) and squash mode allows root access
-		// This mirrors the NFS behavior in resolveNFSSharePermission
-		// Root bypass applies regardless of whether userStore is available
-		if isRootUser(sess.User) && rootHasAdminAccess(share) {
-			logger.Debug("Root user granted admin access via squash mode",
-				"shareName", share.Name, "user", sess.User.Username, "squash", share.Squash)
-			return models.PermissionAdmin, sess.User.Username
-		}
-
-		// If userStore is available, use it to resolve permission
-		if userStore != nil {
-			perm, err := userStore.ResolveSharePermission(ctx.Context, sess.User, share.Name)
-			if err != nil {
-				logger.Debug("Permission resolution failed, using default",
-					"shareName", share.Name, "user", sess.User.Username, "error", err, "default", defaultPerm)
-				return defaultPerm, sess.User.Username
-			}
-			return perm, sess.User.Username
-		}
-
-		// No userStore - use default permission
-		logger.Debug("No userStore available, using default permission",
-			"shareName", share.Name, "user", sess.User.Username, "default", defaultPerm)
-		return defaultPerm, sess.User.Username
-	}
-
-	// Guest session - use default permission
-	if sess != nil && sess.IsGuest {
-		return defaultPerm, "guest"
-	}
-
-	// Session exists but its identity was not resolved to a User (e.g. an
-	// authenticated username with no matching user record) and it is not a
-	// guest: apply the share's default permission, same as a guest. NOT
-	// read-write — defaulting an unresolved identity to read-write is an
-	// authorization bypass (a share with no configured default resolves to
-	// PermissionNone, i.e. access denied).
-	if sess != nil {
-		return defaultPerm, sess.Username
-	}
-
 	// No session at all — deny (the caller maps PermissionNone to
 	// STATUS_ACCESS_DENIED).
-	return models.PermissionNone, ""
+	if sess == nil {
+		return models.PermissionNone, ""
+	}
+
+	// 1. Root user bypass: UID 0 with a squash mode that allows root access gets
+	// admin regardless of grants. Mirrors resolveNFSSharePermission.
+	if sess.User != nil && isRootUser(sess.User) && rootHasAdminAccess(share) {
+		logger.Debug("Root user granted admin access via squash mode",
+			"shareName", share.Name, "user", sess.User.Username, "squash", share.Squash)
+		return models.PermissionAdmin, sess.User.Username
+	}
+
+	// 2. Local user/group resolution.
+	localPerm := defaultPerm
+	identifier := sess.Username
+	switch {
+	case sess.User != nil:
+		identifier = sess.User.Username
+		if userStore != nil {
+			if perm, err := userStore.ResolveSharePermission(ctx.Context, sess.User, share.Name); err != nil {
+				logger.Debug("Permission resolution failed, using default",
+					"shareName", share.Name, "user", sess.User.Username, "error", err, "default", defaultPerm)
+			} else {
+				localPerm = perm
+			}
+		} else {
+			logger.Debug("No userStore available, using default permission",
+				"shareName", share.Name, "user", sess.User.Username, "default", defaultPerm)
+		}
+	case sess.IsGuest:
+		identifier = "guest"
+	}
+
+	// 3. Direct AD/SID grants (#1528). The Kerberos PAC user + group SIDs are on
+	// the session independent of local user resolution, so this authorizes an AD
+	// principal that has no local DittoFS account. The higher of the local and
+	// SID-grant levels wins (additive, like group membership).
+	effective := localPerm
+	if r, ok := userStore.(sidSharePermissionResolver); ok {
+		groupSIDs, userSID := sess.PACIdentity()
+		sids := groupSIDs
+		if userSID != "" {
+			sids = append(sids, userSID)
+		}
+		if len(sids) > 0 {
+			if sidPerm, err := r.ResolveSharePermissionForSIDs(ctx.Context, sids, share.Name); err != nil {
+				logger.Debug("SID permission resolution failed, ignoring",
+					"shareName", share.Name, "error", err)
+			} else if sidPerm.Level() > effective.Level() {
+				logger.Debug("Direct AD/SID grant elevates share permission",
+					"shareName", share.Name, "user", identifier, "from", effective, "to", sidPerm)
+				effective = sidPerm
+			}
+		}
+	}
+
+	return effective, identifier
 }
 
 // isRootUser checks if the user has UID 0 (root).

--- a/internal/adapter/smb/handlers/tree_connect_sid_test.go
+++ b/internal/adapter/smb/handlers/tree_connect_sid_test.go
@@ -1,0 +1,98 @@
+package handlers
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/session"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+)
+
+// sidGrantStore is a minimal models.UserStore that also resolves direct AD/SID
+// grants (#1528), for exercising the PAC-SID path of resolveSharePermission.
+type sidGrantStore struct {
+	// localPerm is returned by ResolveSharePermission (the local user/group
+	// path); PermissionNone means "no local grant".
+	localPerm models.SharePermission
+	// grant maps a granted SID to its level (the SID grant table).
+	grant map[string]models.SharePermission
+}
+
+func (s *sidGrantStore) GetUser(context.Context, string) (*models.User, error) { return nil, models.ErrUserNotFound }
+func (s *sidGrantStore) ValidateCredentials(context.Context, string, string) (*models.User, error) {
+	return nil, models.ErrUserNotFound
+}
+func (s *sidGrantStore) ListUsers(context.Context) ([]*models.User, error)         { return nil, nil }
+func (s *sidGrantStore) GetGuestUser(context.Context, string) (*models.User, error) { return nil, nil }
+func (s *sidGrantStore) GetGroup(context.Context, string) (*models.Group, error)    { return nil, models.ErrGroupNotFound }
+func (s *sidGrantStore) ListGroups(context.Context) ([]*models.Group, error)        { return nil, nil }
+func (s *sidGrantStore) GetUserGroups(context.Context, string) ([]*models.Group, error) {
+	return nil, nil
+}
+func (s *sidGrantStore) ResolveSharePermission(context.Context, *models.User, string) (models.SharePermission, error) {
+	return s.localPerm, nil
+}
+func (s *sidGrantStore) ResolveSharePermissionForSIDs(_ context.Context, sids []string, _ string) (models.SharePermission, error) {
+	highest := models.PermissionNone
+	for sid, lvl := range s.grant {
+		if slices.Contains(sids, sid) && lvl.Level() > highest.Level() {
+			highest = lvl
+		}
+	}
+	return highest, nil
+}
+
+func TestResolveSharePermission_SIDGrant(t *testing.T) {
+	ctx := NewSMBHandlerContext(context.Background(), "127.0.0.1:12345", 1, 0, 1)
+	const groupSID = "S-1-5-21-1-2-3-1104"
+	share := &runtime.Share{Name: "/export", DefaultPermission: "none"}
+
+	t.Run("AD user with no local account is authorized by a group-SID grant", func(t *testing.T) {
+		// No local User on the session (sess.User == nil) — the #1528 target.
+		sess := session.NewSession(1, "127.0.0.1", false, "alice@cubbit.local", "")
+		sess.SetPACIdentity([]string{groupSID}, "S-1-5-21-1-2-3-1200")
+
+		store := &sidGrantStore{
+			localPerm: models.PermissionNone,
+			grant:     map[string]models.SharePermission{groupSID: models.PermissionReadWrite},
+		}
+
+		perm, _ := resolveSharePermission(ctx, sess, share, models.PermissionNone, store)
+		if perm != models.PermissionReadWrite {
+			t.Errorf("PAC group-SID grant should authorize read-write, got %v", perm)
+		}
+	})
+
+	t.Run("no matching SID grant denies (default none)", func(t *testing.T) {
+		sess := session.NewSession(1, "127.0.0.1", false, "bob@cubbit.local", "")
+		sess.SetPACIdentity([]string{"S-1-5-21-9-9-9-500"}, "S-1-5-21-9-9-9-501")
+
+		store := &sidGrantStore{
+			localPerm: models.PermissionNone,
+			grant:     map[string]models.SharePermission{groupSID: models.PermissionReadWrite},
+		}
+
+		perm, _ := resolveSharePermission(ctx, sess, share, models.PermissionNone, store)
+		if perm != models.PermissionNone {
+			t.Errorf("unmatched PAC SIDs should deny (none), got %v", perm)
+		}
+	})
+
+	t.Run("SID grant elevates a lower local permission", func(t *testing.T) {
+		uid := uint32(1000)
+		sess := session.NewSessionWithUser(1, "127.0.0.1", &models.User{Username: "alice", UID: &uid}, "")
+		sess.SetPACIdentity([]string{groupSID}, "")
+
+		store := &sidGrantStore{
+			localPerm: models.PermissionRead, // local grant is read...
+			grant:     map[string]models.SharePermission{groupSID: models.PermissionReadWrite}, // ...SID grant is higher
+		}
+
+		perm, _ := resolveSharePermission(ctx, sess, share, models.PermissionNone, store)
+		if perm != models.PermissionReadWrite {
+			t.Errorf("higher SID grant should elevate local read to read-write, got %v", perm)
+		}
+	})
+}

--- a/internal/adapter/smb/handlers/tree_connect_sid_test.go
+++ b/internal/adapter/smb/handlers/tree_connect_sid_test.go
@@ -20,14 +20,18 @@ type sidGrantStore struct {
 	grant map[string]models.SharePermission
 }
 
-func (s *sidGrantStore) GetUser(context.Context, string) (*models.User, error) { return nil, models.ErrUserNotFound }
+func (s *sidGrantStore) GetUser(context.Context, string) (*models.User, error) {
+	return nil, models.ErrUserNotFound
+}
 func (s *sidGrantStore) ValidateCredentials(context.Context, string, string) (*models.User, error) {
 	return nil, models.ErrUserNotFound
 }
-func (s *sidGrantStore) ListUsers(context.Context) ([]*models.User, error)         { return nil, nil }
+func (s *sidGrantStore) ListUsers(context.Context) ([]*models.User, error)          { return nil, nil }
 func (s *sidGrantStore) GetGuestUser(context.Context, string) (*models.User, error) { return nil, nil }
-func (s *sidGrantStore) GetGroup(context.Context, string) (*models.Group, error)    { return nil, models.ErrGroupNotFound }
-func (s *sidGrantStore) ListGroups(context.Context) ([]*models.Group, error)        { return nil, nil }
+func (s *sidGrantStore) GetGroup(context.Context, string) (*models.Group, error) {
+	return nil, models.ErrGroupNotFound
+}
+func (s *sidGrantStore) ListGroups(context.Context) ([]*models.Group, error) { return nil, nil }
 func (s *sidGrantStore) GetUserGroups(context.Context, string) ([]*models.Group, error) {
 	return nil, nil
 }
@@ -80,13 +84,37 @@ func TestResolveSharePermission_SIDGrant(t *testing.T) {
 		}
 	})
 
+	t.Run("explicit local none blocks a matching SID grant (no override)", func(t *testing.T) {
+		// Admin explicitly blocked alice locally with --level none; a SID grant on
+		// her group must NOT override that block.
+		uid := uint32(1000)
+		user := &models.User{
+			Username: "alice", UID: &uid,
+			SharePermissions: []models.UserSharePermission{
+				{ShareName: "/export", Permission: string(models.PermissionNone)},
+			},
+		}
+		sess := session.NewSessionWithUser(1, "127.0.0.1", user, "")
+		sess.SetPACIdentity([]string{groupSID}, "")
+
+		store := &sidGrantStore{
+			localPerm: models.PermissionNone, // explicit user 'none'
+			grant:     map[string]models.SharePermission{groupSID: models.PermissionReadWrite},
+		}
+
+		perm, _ := resolveSharePermission(ctx, sess, share, models.PermissionNone, store)
+		if perm != models.PermissionNone {
+			t.Errorf("explicit local 'none' must block; SID grant overrode it to %v", perm)
+		}
+	})
+
 	t.Run("SID grant elevates a lower local permission", func(t *testing.T) {
 		uid := uint32(1000)
 		sess := session.NewSessionWithUser(1, "127.0.0.1", &models.User{Username: "alice", UID: &uid}, "")
 		sess.SetPACIdentity([]string{groupSID}, "")
 
 		store := &sidGrantStore{
-			localPerm: models.PermissionRead, // local grant is read...
+			localPerm: models.PermissionRead,                                                   // local grant is read...
 			grant:     map[string]models.SharePermission{groupSID: models.PermissionReadWrite}, // ...SID grant is higher
 		}
 

--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/marmos91/dittofs/internal/bytesize"
 	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/auth/sid"
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
@@ -1112,17 +1113,6 @@ func (h *ShareHandler) SetUserPermission(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Look up user and share to get their IDs
-	user, err := h.store.GetUser(r.Context(), username)
-	if err != nil {
-		if errors.Is(err, models.ErrUserNotFound) {
-			NotFound(w, "User not found")
-			return
-		}
-		InternalServerError(w, "Failed to get user")
-		return
-	}
-
 	share, err := h.store.GetShare(r.Context(), shareName)
 	if err != nil {
 		if errors.Is(err, models.ErrShareNotFound) {
@@ -1130,6 +1120,29 @@ func (h *ShareHandler) SetUserPermission(w http.ResponseWriter, r *http.Request)
 			return
 		}
 		InternalServerError(w, "Failed to get share")
+		return
+	}
+
+	// Look up the local user. When no local user exists, fall back to the
+	// directory: an AD user with no local DittoFS account is granted directly by
+	// SID (#1528).
+	user, err := h.store.GetUser(r.Context(), username)
+	if err != nil {
+		if errors.Is(err, models.ErrUserNotFound) {
+			handled, gerr := h.grantDirectoryPrincipal(r.Context(), share, username, false, req.Level)
+			if gerr != nil {
+				InternalServerError(w, "Failed to set user permission")
+				return
+			}
+			if !handled {
+				NotFound(w, "User not found")
+				return
+			}
+			h.reconcileRootACL(r.Context(), shareName)
+			WriteNoContent(w)
+			return
+		}
+		InternalServerError(w, "Failed to get user")
 		return
 	}
 
@@ -1147,6 +1160,50 @@ func (h *ShareHandler) SetUserPermission(w http.ResponseWriter, r *http.Request)
 
 	h.reconcileRootACL(r.Context(), shareName)
 	WriteNoContent(w)
+}
+
+// grantDirectoryPrincipal resolves an AD principal NAME to its SID via the
+// configured LDAP directory and stores a direct SID grant on the share (#1528),
+// so a domain user/group can be granted with no local DittoFS object. Returns
+// handled=false (with no error) when LDAP is unconfigured or the name does not
+// resolve — the caller then surfaces the original "not found".
+func (h *ShareHandler) grantDirectoryPrincipal(ctx context.Context, share *models.Share, name string, isGroup bool, level string) (handled bool, err error) {
+	if h.runtime == nil {
+		return false, nil
+	}
+	resolved, found, err := h.runtime.ResolveDirectoryPrincipalSID(ctx, name, isGroup)
+	if err != nil {
+		return false, err
+	}
+	if !found {
+		return false, nil
+	}
+	display := resolved.DisplayName
+	if display == "" {
+		display = name
+	}
+	perm := &models.SIDSharePermission{
+		SID:         resolved.SID,
+		ShareID:     share.ID,
+		ShareName:   share.Name,
+		Permission:  level,
+		IsGroup:     isGroup,
+		DisplayName: display,
+		UnixID:      resolved.UnixID,
+	}
+	return true, h.store.SetSIDSharePermission(ctx, perm)
+}
+
+// revokeDirectoryPrincipal best-effort removes a direct AD/SID grant for a
+// principal NAME by resolving it via the directory (#1528). A directory outage
+// must not fail a revoke, so resolution errors are ignored.
+func (h *ShareHandler) revokeDirectoryPrincipal(ctx context.Context, shareName, name string, isGroup bool) {
+	if h.runtime == nil {
+		return
+	}
+	if resolved, found, err := h.runtime.ResolveDirectoryPrincipalSID(ctx, name, isGroup); err == nil && found {
+		_ = h.store.DeleteSIDSharePermission(ctx, resolved.SID, shareName)
+	}
 }
 
 // reconcileRootACL projects the share's current permission grants onto its root
@@ -1183,6 +1240,9 @@ func (h *ShareHandler) RemoveUserPermission(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// Also drop a direct AD/SID grant for the same principal name (#1528).
+	h.revokeDirectoryPrincipal(r.Context(), shareName, username, false)
+
 	h.reconcileRootACL(r.Context(), shareName)
 	WriteNoContent(w)
 }
@@ -1214,17 +1274,6 @@ func (h *ShareHandler) SetGroupPermission(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Look up group and share to get their IDs
-	group, err := h.store.GetGroup(r.Context(), groupName)
-	if err != nil {
-		if errors.Is(err, models.ErrGroupNotFound) {
-			NotFound(w, "Group not found")
-			return
-		}
-		InternalServerError(w, "Failed to get group")
-		return
-	}
-
 	share, err := h.store.GetShare(r.Context(), shareName)
 	if err != nil {
 		if errors.Is(err, models.ErrShareNotFound) {
@@ -1232,6 +1281,29 @@ func (h *ShareHandler) SetGroupPermission(w http.ResponseWriter, r *http.Request
 			return
 		}
 		InternalServerError(w, "Failed to get share")
+		return
+	}
+
+	// Look up the local group. When no local group exists, fall back to the
+	// directory: an AD group with no local DittoFS object is granted directly by
+	// SID (#1528).
+	group, err := h.store.GetGroup(r.Context(), groupName)
+	if err != nil {
+		if errors.Is(err, models.ErrGroupNotFound) {
+			handled, gerr := h.grantDirectoryPrincipal(r.Context(), share, groupName, true, req.Level)
+			if gerr != nil {
+				InternalServerError(w, "Failed to set group permission")
+				return
+			}
+			if !handled {
+				NotFound(w, "Group not found")
+				return
+			}
+			h.reconcileRootACL(r.Context(), shareName)
+			WriteNoContent(w)
+			return
+		}
+		InternalServerError(w, "Failed to get group")
 		return
 	}
 
@@ -1271,15 +1343,120 @@ func (h *ShareHandler) RemoveGroupPermission(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	// Also drop a direct AD/SID grant for the same principal name (#1528).
+	h.revokeDirectoryPrincipal(r.Context(), shareName, groupName, true)
+
+	h.reconcileRootACL(r.Context(), shareName)
+	WriteNoContent(w)
+}
+
+// SetSIDPermission handles PUT /api/v1/shares/{name}/permissions/sids/{sid}.
+// Grants a permission on a share directly to a Windows/AD SID — a domain user or
+// group — with no local DittoFS user/group object (#1528). Admin only.
+func (h *ShareHandler) SetSIDPermission(w http.ResponseWriter, r *http.Request) {
+	shareName := normalizeShareName(chi.URLParam(r, "name"))
+	sidStr := chi.URLParam(r, "sid")
+
+	if shareName == "/" {
+		BadRequest(w, "Share name is required")
+		return
+	}
+	parsedSID, err := sid.ParseSIDString(sidStr)
+	if err != nil {
+		BadRequest(w, "Invalid SID")
+		return
+	}
+	// Canonicalize so the stored SID exactly matches the form a login's PAC
+	// user/group SIDs carry (the "sid:" ACE matcher is string-equality).
+	sidStr = sid.FormatSID(parsedSID)
+
+	var req struct {
+		Level       string `json:"level"`
+		IsGroup     *bool  `json:"is_group"`
+		DisplayName string `json:"display_name"`
+	}
+	if !decodeJSONBody(w, r, &req) {
+		return
+	}
+	if req.Level == "" {
+		BadRequest(w, "Permission level is required")
+		return
+	}
+
+	// No GetUser/GetGroup lookup: a SID grant intentionally requires no local
+	// object. Only the share must exist.
+	share, err := h.store.GetShare(r.Context(), shareName)
+	if err != nil {
+		if errors.Is(err, models.ErrShareNotFound) {
+			NotFound(w, "Share not found")
+			return
+		}
+		InternalServerError(w, "Failed to get share")
+		return
+	}
+
+	// A SID grant defaults to a group grant (the common case); an explicit
+	// is_group=false marks a user SID (affects NFS numeric projection + display).
+	isGroup := true
+	if req.IsGroup != nil {
+		isGroup = *req.IsGroup
+	}
+
+	// Derive the Unix id from the SID's RID for the NFS numeric projection
+	// (idmap=rid: the login path derives the same RID). A raw-SID grant has no
+	// directory context, so an rfc2307 deployment (GID = gidNumber, not the RID)
+	// should grant by name instead to get an NFS-matchable id.
+	perm := &models.SIDSharePermission{
+		SID:         sidStr,
+		ShareID:     share.ID,
+		ShareName:   share.Name,
+		Permission:  req.Level,
+		IsGroup:     isGroup,
+		DisplayName: req.DisplayName,
+		UnixID:      parsedSID.RID(),
+	}
+
+	if err := h.store.SetSIDSharePermission(r.Context(), perm); err != nil {
+		InternalServerError(w, "Failed to set SID permission")
+		return
+	}
+
+	h.reconcileRootACL(r.Context(), shareName)
+	WriteNoContent(w)
+}
+
+// RemoveSIDPermission handles DELETE /api/v1/shares/{name}/permissions/sids/{sid}.
+// Removes a SID's permission on a share (admin only).
+func (h *ShareHandler) RemoveSIDPermission(w http.ResponseWriter, r *http.Request) {
+	shareName := normalizeShareName(chi.URLParam(r, "name"))
+	sidStr := chi.URLParam(r, "sid")
+
+	if shareName == "/" {
+		BadRequest(w, "Share name is required")
+		return
+	}
+	if sidStr == "" {
+		BadRequest(w, "SID is required")
+		return
+	}
+
+	if err := h.store.DeleteSIDSharePermission(r.Context(), sidStr, shareName); err != nil {
+		InternalServerError(w, "Failed to delete SID permission")
+		return
+	}
+
 	h.reconcileRootACL(r.Context(), shareName)
 	WriteNoContent(w)
 }
 
 // PermissionResponse represents a permission entry for a share.
 type PermissionResponse struct {
-	Type  string `json:"type"`  // "user" or "group"
-	Name  string `json:"name"`  // username or group name
+	Type  string `json:"type"`  // "user", "group", or "sid"
+	Name  string `json:"name"`  // username, group name, or SID/display name
 	Level string `json:"level"` // permission level
+	// SID and IsGroup are populated only for "sid" entries (direct AD grants).
+	SID     string `json:"sid,omitempty"`
+	IsGroup *bool  `json:"is_group,omitempty"`
 }
 
 // ListPermissions handles GET /api/v1/shares/{name}/permissions.
@@ -1332,6 +1509,23 @@ func (h *ShareHandler) ListPermissions(w http.ResponseWriter, r *http.Request) {
 			Type:  "group",
 			Name:  group.Name,
 			Level: gp.Permission,
+		})
+	}
+
+	// Direct AD/SID grants (#1528). No local object to look up: the display
+	// name (captured at grant time) or the raw SID identifies the principal.
+	for _, sp := range share.SIDPermissions {
+		name := sp.DisplayName
+		if name == "" {
+			name = sp.SID
+		}
+		isGroup := sp.IsGroup
+		perms = append(perms, PermissionResponse{
+			Type:    "sid",
+			Name:    name,
+			Level:   sp.Permission,
+			SID:     sp.SID,
+			IsGroup: &isGroup,
 		})
 	}
 

--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -20,6 +20,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
 	"github.com/marmos91/dittofs/pkg/health"
+	"github.com/marmos91/dittofs/pkg/identity/ldap"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -1194,16 +1195,26 @@ func (h *ShareHandler) grantDirectoryPrincipal(ctx context.Context, share *model
 	return true, h.store.SetSIDSharePermission(ctx, perm)
 }
 
-// revokeDirectoryPrincipal best-effort removes a direct AD/SID grant for a
-// principal NAME by resolving it via the directory (#1528). A directory outage
-// must not fail a revoke, so resolution errors are ignored.
-func (h *ShareHandler) revokeDirectoryPrincipal(ctx context.Context, shareName, name string, isGroup bool) {
-	if h.runtime == nil {
-		return
+// revokeDirectoryPrincipal removes any direct AD/SID grant for a principal NAME
+// (#1528). The SID grant stored the principal's sAMAccountName as its
+// DisplayName at grant time, so the grant is deleted by that name WITHOUT
+// re-resolving through LDAP — keeping revoke working when the directory is
+// unreachable and avoiding a directory round-trip on every local revoke.
+func (h *ShareHandler) revokeDirectoryPrincipal(ctx context.Context, shareName, name string, isGroup bool) error {
+	return h.store.DeleteSIDSharePermissionsByDisplayName(ctx, shareName, samAccountName(name), isGroup)
+}
+
+// samAccountName reduces a principal string to its bare sAMAccountName by
+// stripping a "DOMAIN\" prefix and/or an "@REALM" suffix, matching how a
+// directory grant stores its DisplayName.
+func samAccountName(s string) string {
+	if i := strings.LastIndex(s, "\\"); i >= 0 {
+		s = s[i+1:]
 	}
-	if resolved, found, err := h.runtime.ResolveDirectoryPrincipalSID(ctx, name, isGroup); err == nil && found {
-		_ = h.store.DeleteSIDSharePermission(ctx, resolved.SID, shareName)
+	if i := strings.Index(s, "@"); i > 0 {
+		s = s[:i]
 	}
+	return strings.TrimSpace(s)
 }
 
 // reconcileRootACL projects the share's current permission grants onto its root
@@ -1241,7 +1252,10 @@ func (h *ShareHandler) RemoveUserPermission(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Also drop a direct AD/SID grant for the same principal name (#1528).
-	h.revokeDirectoryPrincipal(r.Context(), shareName, username, false)
+	if err := h.revokeDirectoryPrincipal(r.Context(), shareName, username, false); err != nil {
+		InternalServerError(w, "Failed to delete user permission")
+		return
+	}
 
 	h.reconcileRootACL(r.Context(), shareName)
 	WriteNoContent(w)
@@ -1344,7 +1358,10 @@ func (h *ShareHandler) RemoveGroupPermission(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Also drop a direct AD/SID grant for the same principal name (#1528).
-	h.revokeDirectoryPrincipal(r.Context(), shareName, groupName, true)
+	if err := h.revokeDirectoryPrincipal(r.Context(), shareName, groupName, true); err != nil {
+		InternalServerError(w, "Failed to delete group permission")
+		return
+	}
 
 	h.reconcileRootACL(r.Context(), shareName)
 	WriteNoContent(w)
@@ -1382,6 +1399,10 @@ func (h *ShareHandler) SetSIDPermission(w http.ResponseWriter, r *http.Request) 
 		BadRequest(w, "Permission level is required")
 		return
 	}
+	if !models.SharePermission(req.Level).IsValid() {
+		BadRequest(w, "Invalid permission level")
+		return
+	}
 
 	// No GetUser/GetGroup lookup: a SID grant intentionally requires no local
 	// object. Only the share must exist.
@@ -1403,9 +1424,17 @@ func (h *ShareHandler) SetSIDPermission(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Derive the Unix id from the SID's RID for the NFS numeric projection
-	// (idmap=rid: the login path derives the same RID). A raw-SID grant has no
-	// directory context, so an rfc2307 deployment (GID = gidNumber, not the RID)
-	// should grant by name instead to get an NFS-matchable id.
+	// (idmap=rid: the login path derives the same RID). Under idmap=rfc2307 the
+	// login GID comes from gidNumber, not the RID, so a raw-SID grant cannot
+	// supply an NFS-matchable id — leave it unset (SMB still matches via the
+	// sid: ACE; grant by name to get an NFS-matchable id under rfc2307).
+	unixID := parsedSID.RID()
+	if h.runtime != nil {
+		if cfg := h.runtime.LDAPConfig(); cfg != nil && cfg.Idmap == ldap.IdmapRFC2307 {
+			unixID = 0
+		}
+	}
+
 	perm := &models.SIDSharePermission{
 		SID:         sidStr,
 		ShareID:     share.ID,
@@ -1413,7 +1442,7 @@ func (h *ShareHandler) SetSIDPermission(w http.ResponseWriter, r *http.Request) 
 		Permission:  req.Level,
 		IsGroup:     isGroup,
 		DisplayName: req.DisplayName,
-		UnixID:      parsedSID.RID(),
+		UnixID:      unixID,
 	}
 
 	if err := h.store.SetSIDSharePermission(r.Context(), perm); err != nil {
@@ -1435,10 +1464,14 @@ func (h *ShareHandler) RemoveSIDPermission(w http.ResponseWriter, r *http.Reques
 		BadRequest(w, "Share name is required")
 		return
 	}
-	if sidStr == "" {
-		BadRequest(w, "SID is required")
+	// Canonicalize to match the stored form (SetSIDPermission stores the
+	// canonical SID), so a non-canonical revoke does not silently no-op.
+	parsedSID, err := sid.ParseSIDString(sidStr)
+	if err != nil {
+		BadRequest(w, "Invalid SID")
 		return
 	}
+	sidStr = sid.FormatSID(parsedSID)
 
 	if err := h.store.DeleteSIDSharePermission(r.Context(), sidStr, shareName); err != nil {
 		InternalServerError(w, "Failed to delete SID permission")

--- a/pkg/apiclient/shares.go
+++ b/pkg/apiclient/shares.go
@@ -192,9 +192,12 @@ type PatchShareNFSConfigRequest struct {
 
 // SharePermission represents a permission on a share.
 type SharePermission struct {
-	Type  string `json:"type"`  // "user" or "group"
-	Name  string `json:"name"`  // username or group name
+	Type  string `json:"type"`  // "user", "group", or "sid"
+	Name  string `json:"name"`  // username, group name, or SID/display name
 	Level string `json:"level"` // "none", "read", "read-write", "admin"
+	// SID and IsGroup are populated only for "sid" entries (direct AD grants).
+	SID     string `json:"sid,omitempty"`
+	IsGroup *bool  `json:"is_group,omitempty"`
 }
 
 // ListShares returns all shares.
@@ -281,6 +284,20 @@ func (c *Client) SetGroupSharePermission(shareName, groupName, level string) err
 // RemoveGroupSharePermission removes a group's permission from a share.
 func (c *Client) RemoveGroupSharePermission(shareName, groupName string) error {
 	return c.delete(fmt.Sprintf("/api/v1/shares/%s/permissions/groups/%s", url.PathEscape(normalizeShareNameForAPI(shareName)), groupName), nil)
+}
+
+// SetSIDSharePermission grants a permission on a share directly to a Windows/AD
+// SID — a domain user or group — with no local DittoFS object (#1528). isGroup
+// marks a group SID vs a user SID; displayName is an optional label captured for
+// listing/UI.
+func (c *Client) SetSIDSharePermission(shareName, sidStr, level string, isGroup bool, displayName string) error {
+	req := map[string]any{"level": level, "is_group": isGroup, "display_name": displayName}
+	return c.put(fmt.Sprintf("/api/v1/shares/%s/permissions/sids/%s", url.PathEscape(normalizeShareNameForAPI(shareName)), url.PathEscape(sidStr)), req, nil)
+}
+
+// RemoveSIDSharePermission removes a SID's permission from a share.
+func (c *Client) RemoveSIDSharePermission(shareName, sidStr string) error {
+	return c.delete(fmt.Sprintf("/api/v1/shares/%s/permissions/sids/%s", url.PathEscape(normalizeShareNameForAPI(shareName)), url.PathEscape(sidStr)), nil)
 }
 
 // DisableShare flips Enabled=false on the share. Returns the updated Share

--- a/pkg/auth/sid/sid.go
+++ b/pkg/auth/sid/sid.go
@@ -45,6 +45,16 @@ func SIDSize(sid *SID) int {
 	return 8 + 4*int(sid.SubAuthorityCount)
 }
 
+// RID returns the SID's relative identifier — the final sub-authority — or 0
+// when the SID has none. For an AD principal SID this is the value used as the
+// Unix UID/GID under idmap_rid.
+func (s *SID) RID() uint32 {
+	if len(s.SubAuthorities) == 0 {
+		return 0
+	}
+	return s.SubAuthorities[len(s.SubAuthorities)-1]
+}
+
 // EncodeSID writes a binary SID to buf per MS-DTYP Section 2.4.2.
 func EncodeSID(buf *bytes.Buffer, sid *SID) {
 	buf.WriteByte(sid.Revision)

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -284,6 +284,9 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 				r.Delete("/{name}/permissions/users/{username}", shareHandler.RemoveUserPermission)
 				r.Put("/{name}/permissions/groups/{groupname}", shareHandler.SetGroupPermission)
 				r.Delete("/{name}/permissions/groups/{groupname}", shareHandler.RemoveGroupPermission)
+				// Direct AD/SID grants (#1528): grant to a Windows SID with no local object.
+				r.Put("/{name}/permissions/sids/{sid}", shareHandler.SetSIDPermission)
+				r.Delete("/{name}/permissions/sids/{sid}", shareHandler.RemoveSIDPermission)
 
 				// Per-share block store management
 				r.Get("/{name}/blockstore/stats", blockStoreHandler.Stats)

--- a/pkg/controlplane/models/models.go
+++ b/pkg/controlplane/models/models.go
@@ -17,6 +17,7 @@ func AllModels() []any {
 		&ShareAdapterConfig{},
 		&UserSharePermission{},
 		&GroupSharePermission{},
+		&SIDSharePermission{},
 		&AdapterConfig{},
 		&Setting{},
 		&IdentityMapping{},

--- a/pkg/controlplane/models/share.go
+++ b/pkg/controlplane/models/share.go
@@ -101,6 +101,7 @@ type Share struct {
 	AccessRules      []ShareAccessRule      `gorm:"foreignKey:ShareID" json:"access_rules,omitempty"`
 	UserPermissions  []UserSharePermission  `gorm:"foreignKey:ShareID" json:"user_permissions,omitempty"`
 	GroupPermissions []GroupSharePermission `gorm:"foreignKey:ShareID" json:"group_permissions,omitempty"`
+	SIDPermissions   []SIDSharePermission   `gorm:"foreignKey:ShareID" json:"sid_permissions,omitempty"`
 
 	// Parsed configuration (not stored in DB)
 	ParsedConfig map[string]any `gorm:"-" json:"config,omitempty"`

--- a/pkg/controlplane/models/sid_share_permission.go
+++ b/pkg/controlplane/models/sid_share_permission.go
@@ -1,0 +1,56 @@
+package models
+
+// SIDSharePermission grants a share permission directly to a Windows/AD security
+// identifier (SID) — a domain user or group — WITHOUT a local DittoFS user or
+// group object.
+//
+// This is the storage behind issue #1528: an operator grants access to an AD
+// principal (resolved to its SID at grant time, or a raw SID) and, at login, a
+// Kerberos-authenticated principal's PAC user/group SIDs are matched against
+// these grants. Unlike UserSharePermission/GroupSharePermission — which are
+// foreign-keyed to a local users/groups row — this record is keyed on the raw
+// SID and has NO foreign key, so no local shadow object is ever needed.
+//
+// The primary key is (SID, ShareID): one permission level per principal per
+// share, upserted on re-grant, exactly like the local grant tables.
+type SIDSharePermission struct {
+	// SID is the canonical Windows SID string (e.g.
+	// "S-1-5-21-111-222-333-1107"). Part of the primary key.
+	SID string `gorm:"column:sid;primaryKey;type:varchar(184)" json:"sid"`
+
+	// ShareID is the share this grant applies to. Part of the primary key.
+	ShareID string `gorm:"primaryKey;size:36" json:"share_id"`
+
+	// ShareName is denormalized for lookups without a shares join, matching
+	// UserSharePermission/GroupSharePermission.
+	ShareName string `gorm:"size:255" json:"share_name"`
+
+	// Permission is the granted level (none, read, read-write, admin).
+	Permission string `gorm:"not null;size:50" json:"permission"`
+
+	// IsGroup reports whether the SID is a group SID (matched against a login's
+	// PAC group SIDs) or a user SID (matched against the user SID). It also
+	// selects the NFS numeric projection: a group SID maps to a GID. No GORM
+	// `default:` is set: a `default:true` would coerce an explicit Go false back
+	// to true on INSERT (refs #514), silently turning a user-SID grant into a
+	// group grant. Every writer sets this field explicitly.
+	IsGroup bool `gorm:"not null" json:"is_group"`
+
+	// UnixID is the Unix GID (group SID) or UID (user SID) this SID resolves to,
+	// captured at grant time. NFS carries no SID on the wire, so it authorizes an
+	// AD principal by matching this numeric id against the login's UID/GIDs — the
+	// same id the LDAP provider derives at login (the RID in idmap=rid mode, or
+	// the RFC2307 uidNumber/gidNumber). 0 means unresolved (e.g. a raw-SID grant
+	// while LDAP is unavailable): the grant still works over SMB via the SID, but
+	// has no NFS numeric projection.
+	UnixID uint32 `gorm:"column:unix_id;not null;default:0" json:"unix_id"`
+
+	// DisplayName is the human-readable principal captured at grant time (e.g.
+	// "CUBBIT\\Cubbit" or "alice@cubbit.local"), for diagnostics and UI display.
+	DisplayName string `gorm:"size:255" json:"display_name,omitempty"`
+}
+
+// TableName returns the table name for SIDSharePermission.
+func (SIDSharePermission) TableName() string {
+	return "sid_share_permissions"
+}

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -1028,6 +1028,27 @@ func (r *Runtime) LDAPConfig() *ldap.Config {
 	return r.ldapConfig
 }
 
+// ResolveDirectoryPrincipalSID resolves an AD principal NAME (bare
+// sAMAccountName, DOMAIN\name, or name@REALM) to its Windows SID and Unix id via
+// the configured LDAP directory, so a share can be granted to a domain
+// user/group with no local DittoFS object (#1528). isGroup selects a group vs
+// user object.
+//
+// Returns found=false when LDAP is not configured/enabled or no object matches;
+// an error only for a directory infrastructure failure. A one-shot provider is
+// built per call — grants are infrequent, so no connection is cached.
+func (r *Runtime) ResolveDirectoryPrincipalSID(ctx context.Context, name string, isGroup bool) (ldap.ResolvedPrincipal, bool, error) {
+	cfg := r.LDAPConfig()
+	if cfg == nil || !cfg.Enabled {
+		return ldap.ResolvedPrincipal{}, false, nil
+	}
+	provider, err := ldap.New(cfg, nil, nil)
+	if err != nil {
+		return ldap.ResolvedPrincipal{}, false, err
+	}
+	return provider.ResolvePrincipalSID(ctx, name, isGroup)
+}
+
 // SetNetlogonCredential sets the NETLOGON machine credential / DC binding used
 // for SMB NTLM pass-through. A nil value disables passthrough. It is set at
 // startup from the Kerberos machine-account config and updated by the

--- a/pkg/controlplane/runtime/share_root_acl.go
+++ b/pkg/controlplane/runtime/share_root_acl.go
@@ -113,6 +113,22 @@ func (r *Runtime) ReconcileShareRootACL(ctx context.Context, shareName string) e
 		grants = append(grants, acl.RootGrant{ID: *group.GID, IsGroup: true, Level: level})
 	}
 
+	// Direct AD/SID grants (#1528): project a "sid:<SID>" ACE (matched against a
+	// login's PAC SIDs on the SMB path) and, when the grant carries a resolved
+	// Unix id, an additional "{id}@localdomain" numeric ACE so NFS — which has no
+	// SID on the wire — matches by UID/GID. No local object to resolve.
+	sidPerms, err := r.store.GetShareSIDPermissions(ctx, shareName)
+	if err != nil {
+		return fmt.Errorf("reconcile root ACL for %q: list SID permissions: %w", shareName, err)
+	}
+	for _, p := range sidPerms {
+		level := grantLevelFor(p.Permission)
+		if level == acl.GrantNone {
+			continue
+		}
+		grants = append(grants, acl.RootGrant{ID: p.UnixID, SID: p.SID, IsGroup: p.IsGroup, Level: level})
+	}
+
 	dacl := acl.BuildShareRootACL(grantLevelFor(share.DefaultPermission), grants)
 
 	// The root directory is owned by uid 0; only a superuser context may

--- a/pkg/controlplane/store/interface.go
+++ b/pkg/controlplane/store/interface.go
@@ -336,6 +336,11 @@ type PermissionStore interface {
 	// enumerate grants for listing.
 	GetShareSIDPermissions(ctx context.Context, shareName string) ([]*models.SIDSharePermission, error)
 
+	// DeleteSIDSharePermissionsByDisplayName removes SID grants on a share whose
+	// stored DisplayName (sAMAccountName) and IsGroup match, so a name-based
+	// revoke works without re-resolving the name through LDAP.
+	DeleteSIDSharePermissionsByDisplayName(ctx context.Context, shareName, displayName string, isGroup bool) error
+
 	// ResolveSharePermissionForSIDs returns the highest permission any of the
 	// given SIDs (a login's PAC user SID + group SIDs) has been granted on the
 	// share, or PermissionNone if none match. Unlike ResolveSharePermission it

--- a/pkg/controlplane/store/interface.go
+++ b/pkg/controlplane/store/interface.go
@@ -321,6 +321,34 @@ type PermissionStore interface {
 	// Resolution order: user explicit > group permissions (highest wins) > share default
 	// Fetches the share's default permission internally.
 	ResolveSharePermission(ctx context.Context, user *models.User, shareName string) (models.SharePermission, error)
+
+	// SetSIDSharePermission grants a permission on a share directly to a Windows/AD
+	// SID (#1528). No local user/group object is required; the record is keyed on
+	// the raw SID and upserted on (sid, share_id).
+	SetSIDSharePermission(ctx context.Context, perm *models.SIDSharePermission) error
+
+	// DeleteSIDSharePermission removes a SID's permission on a share. Not an error
+	// if the share or grant does not exist.
+	DeleteSIDSharePermission(ctx context.Context, sid, shareName string) error
+
+	// GetShareSIDPermissions returns every SID permission granted on a share.
+	// Used to project SID grants onto the share root directory's ACL and to
+	// enumerate grants for listing.
+	GetShareSIDPermissions(ctx context.Context, shareName string) ([]*models.SIDSharePermission, error)
+
+	// ResolveSharePermissionForSIDs returns the highest permission any of the
+	// given SIDs (a login's PAC user SID + group SIDs) has been granted on the
+	// share, or PermissionNone if none match. Unlike ResolveSharePermission it
+	// consults ONLY the SID grant table — the caller combines it with the
+	// local-user/group resolution and takes the higher level.
+	ResolveSharePermissionForSIDs(ctx context.Context, sids []string, shareName string) (models.SharePermission, error)
+
+	// ResolveSharePermissionForUnixIDs returns the highest permission any SID
+	// grant with a resolved numeric id matches, given an NFS login's UID and
+	// group GIDs. A group-SID grant matches when its UnixID is in gids; a
+	// user-SID grant matches when its UnixID equals uid. This is the NFS
+	// counterpart of ResolveSharePermissionForSIDs (NFS carries no SID).
+	ResolveSharePermissionForUnixIDs(ctx context.Context, uid uint32, gids []uint32, shareName string) (models.SharePermission, error)
 }
 
 // MetadataStoreConfigStore provides metadata store configuration CRUD.

--- a/pkg/controlplane/store/permissions.go
+++ b/pkg/controlplane/store/permissions.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"errors"
+	"slices"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -213,4 +214,95 @@ func (s *GORMStore) ResolveSharePermission(ctx context.Context, user *models.Use
 	}
 
 	return highestPerm, nil
+}
+
+func (s *GORMStore) SetSIDSharePermission(ctx context.Context, perm *models.SIDSharePermission) error {
+	return s.db.WithContext(ctx).
+		Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "sid"}, {Name: "share_id"}},
+			DoUpdates: clause.AssignmentColumns([]string{"share_name", "permission", "is_group", "display_name", "unix_id"}),
+		}).
+		Create(perm).Error
+}
+
+func (s *GORMStore) DeleteSIDSharePermission(ctx context.Context, sid, shareName string) error {
+	share, err := s.GetShare(ctx, shareName)
+	if err != nil {
+		if errors.Is(err, models.ErrShareNotFound) {
+			return nil // Not an error if share doesn't exist
+		}
+		return err
+	}
+
+	return s.db.WithContext(ctx).
+		Where("sid = ? AND share_id = ?", sid, share.ID).
+		Delete(&models.SIDSharePermission{}).Error
+}
+
+func (s *GORMStore) GetShareSIDPermissions(ctx context.Context, shareName string) ([]*models.SIDSharePermission, error) {
+	share, err := s.GetShare(ctx, shareName)
+	if err != nil {
+		return nil, err
+	}
+
+	var perms []*models.SIDSharePermission
+	if err := s.db.WithContext(ctx).
+		Where("share_id = ?", share.ID).
+		Find(&perms).Error; err != nil {
+		return nil, err
+	}
+	return perms, nil
+}
+
+// ResolveSharePermissionForSIDs is on the SMB TREE_CONNECT hot path, so it
+// queries the SID grant table directly by the denormalized share_name (unique)
+// rather than loading the share with all its associations first.
+func (s *GORMStore) ResolveSharePermissionForSIDs(ctx context.Context, sids []string, shareName string) (models.SharePermission, error) {
+	if len(sids) == 0 {
+		return models.PermissionNone, nil
+	}
+
+	var perms []models.SIDSharePermission
+	if err := s.db.WithContext(ctx).
+		Where("share_name = ? AND sid IN ?", shareName, sids).
+		Find(&perms).Error; err != nil {
+		return models.PermissionNone, err
+	}
+
+	highest := models.PermissionNone
+	for _, perm := range perms {
+		p := models.ParseSharePermission(perm.Permission)
+		if p.Level() > highest.Level() {
+			highest = p
+		}
+	}
+	return highest, nil
+}
+
+// ResolveSharePermissionForUnixIDs is on the NFS auth hot path; like
+// ResolveSharePermissionForSIDs it queries by share_name to avoid a full share
+// load. Only SID grants that carry a resolved numeric id can match an NFS login,
+// which has no SID on the wire.
+func (s *GORMStore) ResolveSharePermissionForUnixIDs(ctx context.Context, uid uint32, gids []uint32, shareName string) (models.SharePermission, error) {
+	var perms []models.SIDSharePermission
+	if err := s.db.WithContext(ctx).
+		Where("share_name = ? AND unix_id <> 0", shareName).
+		Find(&perms).Error; err != nil {
+		return models.PermissionNone, err
+	}
+
+	highest := models.PermissionNone
+	for _, perm := range perms {
+		matched := perm.UnixID == uid
+		if perm.IsGroup {
+			matched = slices.Contains(gids, perm.UnixID)
+		}
+		if !matched {
+			continue
+		}
+		if p := models.ParseSharePermission(perm.Permission); p.Level() > highest.Level() {
+			highest = p
+		}
+	}
+	return highest, nil
 }

--- a/pkg/controlplane/store/permissions.go
+++ b/pkg/controlplane/store/permissions.go
@@ -304,9 +304,15 @@ func (s *GORMStore) ResolveSharePermissionForSIDs(ctx context.Context, sids []st
 // requirement Samba meets with dedicated idmap ranges. The SMB path
 // (ResolveSharePermissionForSIDs) is always SID-exact and not subject to this.
 func (s *GORMStore) ResolveSharePermissionForUnixIDs(ctx context.Context, uid uint32, gids []uint32, shareName string) (models.SharePermission, error) {
+	// Restrict the query to the login's candidate ids (uid + gids) so the scan
+	// is bounded by the caller's group count, not the total number of grants on
+	// the share. The in-memory pass below still applies the user-vs-group rule.
+	candidates := append(make([]uint32, 0, len(gids)+1), uid)
+	candidates = append(candidates, gids...)
+
 	var perms []models.SIDSharePermission
 	if err := s.db.WithContext(ctx).
-		Where("share_name = ? AND unix_id <> 0", shareName).
+		Where("share_name = ? AND unix_id <> 0 AND unix_id IN ?", shareName, candidates).
 		Find(&perms).Error; err != nil {
 		return models.PermissionNone, err
 	}

--- a/pkg/controlplane/store/permissions.go
+++ b/pkg/controlplane/store/permissions.go
@@ -239,6 +239,19 @@ func (s *GORMStore) DeleteSIDSharePermission(ctx context.Context, sid, shareName
 		Delete(&models.SIDSharePermission{}).Error
 }
 
+// DeleteSIDSharePermissionsByDisplayName removes SID grants on a share whose
+// stored DisplayName (the principal's sAMAccountName, captured at grant time)
+// matches, so a name-based revoke works without re-resolving the name through
+// LDAP. isGroup disambiguates a user grant from a group grant of the same name.
+func (s *GORMStore) DeleteSIDSharePermissionsByDisplayName(ctx context.Context, shareName, displayName string, isGroup bool) error {
+	if displayName == "" {
+		return nil
+	}
+	return s.db.WithContext(ctx).
+		Where("share_name = ? AND display_name = ? AND is_group = ?", shareName, displayName, isGroup).
+		Delete(&models.SIDSharePermission{}).Error
+}
+
 func (s *GORMStore) GetShareSIDPermissions(ctx context.Context, shareName string) ([]*models.SIDSharePermission, error) {
 	share, err := s.GetShare(ctx, shareName)
 	if err != nil {
@@ -283,6 +296,13 @@ func (s *GORMStore) ResolveSharePermissionForSIDs(ctx context.Context, sids []st
 // ResolveSharePermissionForSIDs it queries by share_name to avoid a full share
 // load. Only SID grants that carry a resolved numeric id can match an NFS login,
 // which has no SID on the wire.
+//
+// CAVEAT: NFS matching is by MAPPED Unix id, not the SID itself (the SID is not
+// on the NFS wire), so it inherits the idmap's range contract: a local principal
+// whose UID/GID collides with a foreign SID's mapped id would match the grant.
+// This is safe only when AD ids do not overlap the local id space — the same
+// requirement Samba meets with dedicated idmap ranges. The SMB path
+// (ResolveSharePermissionForSIDs) is always SID-exact and not subject to this.
 func (s *GORMStore) ResolveSharePermissionForUnixIDs(ctx context.Context, uid uint32, gids []uint32, shareName string) (models.SharePermission, error) {
 	var perms []models.SIDSharePermission
 	if err := s.db.WithContext(ctx).

--- a/pkg/controlplane/store/permissions_sid_test.go
+++ b/pkg/controlplane/store/permissions_sid_test.go
@@ -140,4 +140,32 @@ func TestSIDSharePermission_CRUDAndResolve(t *testing.T) {
 			t.Errorf("after delete = %q, want none", got)
 		}
 	})
+
+	t.Run("delete by display name (name-based revoke, no LDAP)", func(t *testing.T) {
+		// Re-grant the group with a DisplayName, then revoke by that name.
+		if err := st.SetSIDSharePermission(ctx, &models.SIDSharePermission{
+			SID: groupSID, ShareID: shareID, ShareName: share, Permission: string(models.PermissionRead),
+			IsGroup: true, UnixID: 1104, DisplayName: "Cubbit",
+		}); err != nil {
+			t.Fatalf("re-grant: %v", err)
+		}
+		// A user-form grant of the same display name must NOT be removed by a
+		// group revoke (is_group disambiguates).
+		if err := st.SetSIDSharePermission(ctx, &models.SIDSharePermission{
+			SID: "S-1-5-21-111-222-333-1300", ShareID: shareID, ShareName: share,
+			Permission: string(models.PermissionRead), IsGroup: false, UnixID: 1300, DisplayName: "Cubbit",
+		}); err != nil {
+			t.Fatalf("grant user with same name: %v", err)
+		}
+
+		if err := st.DeleteSIDSharePermissionsByDisplayName(ctx, share, "Cubbit", true); err != nil {
+			t.Fatalf("delete by display name: %v", err)
+		}
+		if got, _ := st.ResolveSharePermissionForSIDs(ctx, []string{groupSID}, share); got != models.PermissionNone {
+			t.Errorf("group grant should be revoked by name, still = %q", got)
+		}
+		if got, _ := st.ResolveSharePermissionForSIDs(ctx, []string{"S-1-5-21-111-222-333-1300"}, share); got != models.PermissionRead {
+			t.Errorf("user grant of same name must survive a group revoke, got %q", got)
+		}
+	})
 }

--- a/pkg/controlplane/store/permissions_sid_test.go
+++ b/pkg/controlplane/store/permissions_sid_test.go
@@ -1,0 +1,143 @@
+//go:build integration
+
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// setupShareForSIDPerms creates the prerequisite stores + a share and returns
+// the store, share name, and share ID.
+func setupShareForSIDPerms(t *testing.T) (*GORMStore, string, string) {
+	t.Helper()
+	st := openSQLiteFileStore(t)
+	t.Cleanup(func() { _ = st.Close() })
+	ctx := context.Background()
+
+	metaID, err := st.CreateMetadataStore(ctx, &models.MetadataStoreConfig{Name: "m", Type: "memory"})
+	if err != nil {
+		t.Fatalf("create metadata store: %v", err)
+	}
+	blkID, err := st.CreateBlockStore(ctx, &models.BlockStoreConfig{Name: "b", Kind: models.BlockStoreKindLocal, Type: "fs"})
+	if err != nil {
+		t.Fatalf("create block store: %v", err)
+	}
+	shareID, err := st.CreateShare(ctx, &models.Share{Name: "/export", MetadataStoreID: metaID, LocalBlockStoreID: blkID})
+	if err != nil {
+		t.Fatalf("create share: %v", err)
+	}
+	return st, "/export", shareID
+}
+
+func TestSIDSharePermission_CRUDAndResolve(t *testing.T) {
+	st, share, shareID := setupShareForSIDPerms(t)
+	ctx := context.Background()
+
+	const groupSID = "S-1-5-21-111-222-333-1104"
+	const userSID = "S-1-5-21-111-222-333-1200"
+
+	// Grant a group SID read-write with an allocated GID, and a user SID read.
+	if err := st.SetSIDSharePermission(ctx, &models.SIDSharePermission{
+		SID: groupSID, ShareID: shareID, ShareName: share, Permission: string(models.PermissionReadWrite),
+		IsGroup: true, UnixID: 1104, DisplayName: "CUBBIT\\Cubbit",
+	}); err != nil {
+		t.Fatalf("set group SID grant: %v", err)
+	}
+	if err := st.SetSIDSharePermission(ctx, &models.SIDSharePermission{
+		SID: userSID, ShareID: shareID, ShareName: share, Permission: string(models.PermissionRead),
+		IsGroup: false, UnixID: 1200, DisplayName: "alice",
+	}); err != nil {
+		t.Fatalf("set user SID grant: %v", err)
+	}
+
+	t.Run("list returns both grants", func(t *testing.T) {
+		perms, err := st.GetShareSIDPermissions(ctx, share)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(perms) != 2 {
+			t.Fatalf("got %d SID grants, want 2", len(perms))
+		}
+	})
+
+	t.Run("resolve by SID takes the highest matching", func(t *testing.T) {
+		got, err := st.ResolveSharePermissionForSIDs(ctx, []string{"S-1-0-0", groupSID}, share)
+		if err != nil {
+			t.Fatalf("resolve by SIDs: %v", err)
+		}
+		if got != models.PermissionReadWrite {
+			t.Errorf("resolve [group] = %q, want read-write", got)
+		}
+	})
+
+	t.Run("resolve by SID with no match is none", func(t *testing.T) {
+		got, err := st.ResolveSharePermissionForSIDs(ctx, []string{"S-1-0-0"}, share)
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if got != models.PermissionNone {
+			t.Errorf("resolve [none] = %q, want none", got)
+		}
+	})
+
+	t.Run("resolve by unix IDs: group GID matches", func(t *testing.T) {
+		got, err := st.ResolveSharePermissionForUnixIDs(ctx, 9999, []uint32{1104}, share)
+		if err != nil {
+			t.Fatalf("resolve by unix ids: %v", err)
+		}
+		if got != models.PermissionReadWrite {
+			t.Errorf("resolve gid 1104 = %q, want read-write", got)
+		}
+	})
+
+	t.Run("resolve by unix IDs: user UID matches", func(t *testing.T) {
+		got, err := st.ResolveSharePermissionForUnixIDs(ctx, 1200, nil, share)
+		if err != nil {
+			t.Fatalf("resolve by unix ids: %v", err)
+		}
+		if got != models.PermissionRead {
+			t.Errorf("resolve uid 1200 = %q, want read", got)
+		}
+	})
+
+	t.Run("resolve by unix IDs: a group grant does NOT match on UID", func(t *testing.T) {
+		// The group SID's UnixID (1104) must not authorize a user whose UID is
+		// 1104 — group grants match GIDs only.
+		got, err := st.ResolveSharePermissionForUnixIDs(ctx, 1104, nil, share)
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if got != models.PermissionNone {
+			t.Errorf("group GID leaked into UID match: got %q, want none", got)
+		}
+	})
+
+	t.Run("re-grant upserts the level", func(t *testing.T) {
+		if err := st.SetSIDSharePermission(ctx, &models.SIDSharePermission{
+			SID: groupSID, ShareID: shareID, ShareName: share, Permission: string(models.PermissionAdmin), IsGroup: true, UnixID: 1104,
+		}); err != nil {
+			t.Fatalf("re-grant: %v", err)
+		}
+		got, _ := st.ResolveSharePermissionForSIDs(ctx, []string{groupSID}, share)
+		if got != models.PermissionAdmin {
+			t.Errorf("after re-grant = %q, want admin", got)
+		}
+		perms, _ := st.GetShareSIDPermissions(ctx, share)
+		if len(perms) != 2 {
+			t.Errorf("re-grant created a duplicate row: %d grants, want 2", len(perms))
+		}
+	})
+
+	t.Run("delete removes the grant", func(t *testing.T) {
+		if err := st.DeleteSIDSharePermission(ctx, groupSID, share); err != nil {
+			t.Fatalf("delete: %v", err)
+		}
+		got, _ := st.ResolveSharePermissionForSIDs(ctx, []string{groupSID}, share)
+		if got != models.PermissionNone {
+			t.Errorf("after delete = %q, want none", got)
+		}
+	})
+}

--- a/pkg/controlplane/store/shares.go
+++ b/pkg/controlplane/store/shares.go
@@ -15,12 +15,12 @@ import (
 
 func (s *GORMStore) GetShare(ctx context.Context, name string) (*models.Share, error) {
 	return getByNameOrID[models.Share](s.db, ctx, "name", name, models.ErrShareNotFound,
-		"MetadataStore", "LocalBlockStore", "RemoteBlockStore", "AccessRules", "UserPermissions", "GroupPermissions")
+		"MetadataStore", "LocalBlockStore", "RemoteBlockStore", "AccessRules", "UserPermissions", "GroupPermissions", "SIDPermissions")
 }
 
 func (s *GORMStore) GetShareByID(ctx context.Context, id string) (*models.Share, error) {
 	return getByField[models.Share](s.db, ctx, "id", id, models.ErrShareNotFound,
-		"MetadataStore", "LocalBlockStore", "RemoteBlockStore", "AccessRules", "UserPermissions", "GroupPermissions")
+		"MetadataStore", "LocalBlockStore", "RemoteBlockStore", "AccessRules", "UserPermissions", "GroupPermissions", "SIDPermissions")
 }
 
 func (s *GORMStore) ListShares(ctx context.Context) ([]*models.Share, error) {

--- a/pkg/identity/ldap/provider.go
+++ b/pkg/identity/ldap/provider.go
@@ -203,6 +203,115 @@ func (p *Provider) Resolve(ctx context.Context, cred *identity.Credential) (*ide
 	}, nil
 }
 
+// ResolvedPrincipal is the directory resolution of a principal name for a share
+// grant (#1528): its canonical Windows SID plus the Unix id it maps to.
+type ResolvedPrincipal struct {
+	// SID is the canonical Windows SID string ("S-1-5-21-...").
+	SID string
+	// UnixID is the Unix GID (group) or UID (user) the principal maps to under
+	// the configured idmap mode — the SAME id the login path derives — so NFS,
+	// which carries no SID, can match the grant numerically.
+	UnixID uint32
+	// DisplayName is the object's sAMAccountName, captured for listing/UI.
+	DisplayName string
+}
+
+// ResolvePrincipalSID resolves a directory principal NAME to its canonical
+// Windows SID and Unix id, for granting share access directly to an AD user or
+// group with no local DittoFS object (#1528). The name may be a bare
+// sAMAccountName ("Cubbit"), a NetBIOS-qualified name ("CUBBIT\\Cubbit"), or a
+// UPN/Kerberos principal ("alice@cubbit.local") — the domain qualifier is
+// stripped and the sAMAccountName is matched. isGroup selects the object class.
+//
+// Returns found=false when no object matches; an error only for dial/bind/search
+// failures.
+func (p *Provider) ResolvePrincipalSID(ctx context.Context, name string, isGroup bool) (result ResolvedPrincipal, found bool, err error) {
+	sam := sAMAccountNameFromPrincipal(name)
+	if sam == "" {
+		return ResolvedPrincipal{}, false, nil
+	}
+
+	c, err := p.connect(ctx, p.cfg)
+	if err != nil {
+		return ResolvedPrincipal{}, false, fmt.Errorf("ldap: connect/bind: %w", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	objectClass := "user"
+	if isGroup {
+		objectClass = "group"
+	}
+	filter := fmt.Sprintf("(&(objectClass=%s)(%s=%s))", objectClass, p.cfg.UserAttr, ldapv3.EscapeFilter(sam))
+	req := ldapv3.NewSearchRequest(
+		p.cfg.BaseDN,
+		ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 2, int(p.cfg.Timeout.Seconds()), false,
+		filter, []string{"objectSid", "sAMAccountName", "uidNumber", "gidNumber"}, nil,
+	)
+	res, err := c.Search(req)
+	if err != nil {
+		return ResolvedPrincipal{}, false, fmt.Errorf("ldap: principal search: %w", err)
+	}
+	if len(res.Entries) == 0 {
+		logger.Debug("ldap: no principal matched", "filter", filter, "base", p.cfg.BaseDN)
+		return ResolvedPrincipal{}, false, nil
+	}
+	if len(res.Entries) > 1 {
+		logger.Warn("ldap: ambiguous principal lookup — multiple entries matched, using first",
+			"filter", filter, "base", p.cfg.BaseDN, "count", len(res.Entries))
+	}
+	entry := res.Entries[0]
+
+	raw := entry.GetRawAttributeValue("objectSid")
+	if len(raw) == 0 {
+		return ResolvedPrincipal{}, false, fmt.Errorf("ldap: entry %s has no objectSid", entry.DN)
+	}
+	s, _, err := sid.DecodeSID(raw)
+	if err != nil {
+		return ResolvedPrincipal{}, false, fmt.Errorf("ldap: decode objectSid for %s: %w", entry.DN, err)
+	}
+	unixID, err := p.unixIDFromEntry(entry, isGroup)
+	if err != nil {
+		return ResolvedPrincipal{}, false, err
+	}
+	return ResolvedPrincipal{
+		SID:         sid.FormatSID(s),
+		UnixID:      unixID,
+		DisplayName: entry.GetAttributeValue("sAMAccountName"),
+	}, true, nil
+}
+
+// unixIDFromEntry derives the Unix id a principal maps to under the configured
+// idmap mode, matching the login path so a grant's numeric NFS projection equals
+// the id the principal resolves to at login.
+func (p *Provider) unixIDFromEntry(entry *ldapv3.Entry, isGroup bool) (uint32, error) {
+	if !isGroup {
+		// Reuse the exact user derivation the login path uses (deriveUIDGID
+		// applies the rfc2307 both-attrs-required rule, else the RID).
+		uid, _, err := p.deriveUIDGID(entry)
+		return uid, err
+	}
+	// Group: rfc2307 gidNumber, else the RID — mirroring groupGID's handling of
+	// a group entry.
+	if p.cfg.Idmap == IdmapRFC2307 {
+		if g := entry.GetAttributeValue("gidNumber"); g != "" {
+			return parseUint32(g)
+		}
+	}
+	return ridFromEntry(entry)
+}
+
+// sAMAccountNameFromPrincipal reduces a principal string to its bare
+// sAMAccountName by stripping a "DOMAIN\\" prefix and/or an "@REALM" suffix.
+func sAMAccountNameFromPrincipal(s string) string {
+	if i := strings.LastIndex(s, "\\"); i >= 0 {
+		s = s[i+1:]
+	}
+	if i := strings.Index(s, "@"); i > 0 {
+		s = s[:i]
+	}
+	return strings.TrimSpace(s)
+}
+
 // LookupUID resolves a POSIX UID to an AD account name + realm via an
 // RFC2307 reverse search (&(objectClass=user)(uidNumber=N)). It backs the
 // LSARPC owner-SID display path: the machine-domain SID decodes to a UID that

--- a/pkg/identity/ldap/provider.go
+++ b/pkg/identity/ldap/provider.go
@@ -237,11 +237,14 @@ func (p *Provider) ResolvePrincipalSID(ctx context.Context, name string, isGroup
 	}
 	defer func() { _ = c.Close() }()
 
-	objectClass := "user"
+	// Users are matched on the configured name attribute (UserAttr); groups are
+	// matched on sAMAccountName, the AD group-name attribute — UserAttr may be a
+	// user-only attribute (e.g. "uid") that group objects do not carry.
+	objectClass, nameAttr := "user", p.cfg.UserAttr
 	if isGroup {
-		objectClass = "group"
+		objectClass, nameAttr = "group", "sAMAccountName"
 	}
-	filter := fmt.Sprintf("(&(objectClass=%s)(%s=%s))", objectClass, p.cfg.UserAttr, ldapv3.EscapeFilter(sam))
+	filter := fmt.Sprintf("(&(objectClass=%s)(%s=%s))", objectClass, nameAttr, ldapv3.EscapeFilter(sam))
 	req := ldapv3.NewSearchRequest(
 		p.cfg.BaseDN,
 		ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 2, int(p.cfg.Timeout.Seconds()), false,

--- a/pkg/identity/ldap/provider.go
+++ b/pkg/identity/ldap/provider.go
@@ -218,10 +218,11 @@ type ResolvedPrincipal struct {
 
 // ResolvePrincipalSID resolves a directory principal NAME to its canonical
 // Windows SID and Unix id, for granting share access directly to an AD user or
-// group with no local DittoFS object (#1528). The name may be a bare
-// sAMAccountName ("Cubbit"), a NetBIOS-qualified name ("CUBBIT\\Cubbit"), or a
-// UPN/Kerberos principal ("alice@cubbit.local") — the domain qualifier is
-// stripped and the sAMAccountName is matched. isGroup selects the object class.
+// group with no local DittoFS object (#1528). The name may be a bare name
+// ("Cubbit"), a NetBIOS-qualified name ("CUBBIT\\Cubbit"), or a UPN/Kerberos
+// principal ("alice@cubbit.local") — the domain qualifier is stripped, then a
+// user is matched on the configured UserAttr and a group on sAMAccountName.
+// isGroup selects the object class.
 //
 // Returns found=false when no object matches; an error only for dial/bind/search
 // failures.

--- a/pkg/identity/ldap/resolve_principal_test.go
+++ b/pkg/identity/ldap/resolve_principal_test.go
@@ -1,0 +1,90 @@
+package ldap
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	ldapv3 "github.com/go-ldap/ldap/v3"
+)
+
+// TestResolvePrincipalSID_Group covers name→SID resolution for a share grant
+// (#1528): the sAMAccountName is extracted from a DOMAIN\name form, searched as
+// a group, and the objectSid + Unix id are returned.
+func TestResolvePrincipalSID_Group(t *testing.T) {
+	const groupDN = "CN=Cubbit,CN=Users,DC=dittofs,DC=ad"
+
+	fc := &fakeConn{
+		search: func(req *ldapv3.SearchRequest) ([]*ldapv3.Entry, error) {
+			if strings.Contains(req.Filter, "objectClass=group") && strings.Contains(req.Filter, "sAMAccountName=Cubbit") {
+				return []*ldapv3.Entry{entry(groupDN, map[string][]string{
+					"sAMAccountName": {"Cubbit"},
+					"gidNumber":      {"10010"},
+				}, encodeSID(t, 1104))}, nil
+			}
+			return nil, nil
+		},
+	}
+
+	t.Run("rfc2307 returns gidNumber as the unix id", func(t *testing.T) {
+		p := newTestProvider(t, baseCfg(), fc) // baseCfg is rfc2307
+		got, found, err := p.ResolvePrincipalSID(context.Background(), `CUBBIT\Cubbit`, true)
+		if err != nil {
+			t.Fatalf("ResolvePrincipalSID: %v", err)
+		}
+		if !found {
+			t.Fatal("expected found=true")
+		}
+		if got.SID != "S-1-5-21-1-2-3-1104" {
+			t.Errorf("SID = %q, want S-1-5-21-1-2-3-1104", got.SID)
+		}
+		if got.UnixID != 10010 {
+			t.Errorf("UnixID = %d, want 10010 (gidNumber)", got.UnixID)
+		}
+		if got.DisplayName != "Cubbit" {
+			t.Errorf("DisplayName = %q, want Cubbit", got.DisplayName)
+		}
+	})
+
+	t.Run("rid mode returns the RID as the unix id", func(t *testing.T) {
+		cfg := baseCfg()
+		cfg.Idmap = IdmapRID
+		p := newTestProvider(t, cfg, fc)
+		got, found, err := p.ResolvePrincipalSID(context.Background(), "Cubbit", true)
+		if err != nil {
+			t.Fatalf("ResolvePrincipalSID: %v", err)
+		}
+		if !found {
+			t.Fatal("expected found=true")
+		}
+		if got.UnixID != 1104 {
+			t.Errorf("UnixID = %d, want 1104 (RID)", got.UnixID)
+		}
+	})
+
+	t.Run("no match returns found=false", func(t *testing.T) {
+		empty := &fakeConn{search: func(*ldapv3.SearchRequest) ([]*ldapv3.Entry, error) { return nil, nil }}
+		p := newTestProvider(t, baseCfg(), empty)
+		_, found, err := p.ResolvePrincipalSID(context.Background(), "nope@DITTOFS.AD", true)
+		if err != nil {
+			t.Fatalf("ResolvePrincipalSID: %v", err)
+		}
+		if found {
+			t.Error("expected found=false for a non-existent principal")
+		}
+	})
+}
+
+func TestSAMAccountNameFromPrincipal(t *testing.T) {
+	cases := map[string]string{
+		`CUBBIT\Cubbit`:      "Cubbit",
+		"alice@cubbit.local": "alice",
+		"Cubbit":             "Cubbit",
+		`CUBBIT\alice@x`:     "alice", // both qualifiers stripped
+	}
+	for in, want := range cases {
+		if got := sAMAccountNameFromPrincipal(in); got != want {
+			t.Errorf("sAMAccountNameFromPrincipal(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/pkg/metadata/acl/share_grant.go
+++ b/pkg/metadata/acl/share_grant.go
@@ -32,6 +32,12 @@ type RootGrant struct {
 	IsGroup bool
 	// Level is the access level to grant.
 	Level GrantLevel
+	// SID, when non-empty, is a direct Active Directory grant (#1528): it
+	// projects an additional "sid:<SID>" ACE so a Kerberos/PAC login is matched
+	// by its Windows user/group SID (the SMB path). Such a grant may ALSO carry
+	// a non-zero ID — a Unix GID allocated for the SID — so NFS, which has no
+	// SID on the wire, matches via the "{id}@localdomain" numeric form.
+	SID string
 }
 
 // LocalDomainPrincipal formats a Unix UID/GID as the "{id}@localdomain" ACE
@@ -94,6 +100,29 @@ func BuildShareRootACL(defaultLevel GrantLevel, grants []RootGrant) *ACL {
 		allow(SpecialAdministrators, FullAccessMask),
 	}
 
+	// Direct AD/SID grants (#1528): project a "sid:<SID>" ACE matched against a
+	// login's PAC user/group SIDs (the SMB path). Dedup by SID keeping the
+	// highest level; deterministic order by SID string.
+	sidMerged := make(map[string]GrantLevel, len(grants))
+	for _, g := range grants {
+		if g.SID == "" {
+			continue
+		}
+		if lvl, ok := sidMerged[g.SID]; !ok || g.Level > lvl {
+			sidMerged[g.SID] = g.Level
+		}
+	}
+	sidKeys := make([]string, 0, len(sidMerged))
+	for s := range sidMerged {
+		sidKeys = append(sidKeys, s)
+	}
+	sort.Strings(sidKeys)
+	for _, s := range sidKeys {
+		if mask := maskForLevel(sidMerged[s]); mask != 0 {
+			aces = append(aces, allow("sid:"+s, mask))
+		}
+	}
+
 	// Merge grants that project to the same ACE, keeping the highest level.
 	// The merge key is the numeric id, not (id, isGroup): LocalDomainPrincipal
 	// encodes only the id, so a user UID and a group GID with the same value
@@ -102,8 +131,15 @@ func BuildShareRootACL(defaultLevel GrantLevel, grants []RootGrant) *ACL {
 	// collapse here (all to the same fallback id). A user grant takes
 	// precedence over a group grant for ordering when ids collide, so the order
 	// stays deterministic.
+	//
+	// A pure SID grant (SID set, no allocated Unix id) is excluded — it projects
+	// only the "sid:" ACE above. A SID grant that carries a numeric GID for NFS
+	// (#1528) has ID != 0 and IS merged here so it also gets a numeric ACE.
 	merged := make(map[uint32]RootGrant, len(grants))
 	for _, g := range grants {
+		if g.SID != "" && g.ID == 0 {
+			continue
+		}
 		cur, ok := merged[g.ID]
 		if !ok {
 			merged[g.ID] = g

--- a/pkg/metadata/acl/share_grant_sid_test.go
+++ b/pkg/metadata/acl/share_grant_sid_test.go
@@ -1,0 +1,70 @@
+package acl
+
+import "testing"
+
+// TestBuildShareRootACL_SIDGrant verifies a direct AD/SID grant (#1528) projects
+// a "sid:<SID>" ACE for the SMB PAC-SID path, and — when the grant carries a
+// resolved Unix id — an additional "{id}@localdomain" numeric ACE for NFS.
+func TestBuildShareRootACL_SIDGrant(t *testing.T) {
+	const groupSID = "S-1-5-21-111-222-333-1104"
+
+	t.Run("sid only (no unix id) projects only the sid: ACE", func(t *testing.T) {
+		a := BuildShareRootACL(GrantNone, []RootGrant{
+			{SID: groupSID, IsGroup: true, Level: GrantReadWrite},
+		})
+		sidACE := allowACE(a, "sid:"+groupSID)
+		if sidACE == nil {
+			t.Fatalf("missing sid: ACE for %q", groupSID)
+		}
+		if !maskAllows(sidACE.AccessMask, modeWrite) {
+			t.Errorf("sid: ACE mask %#x does not allow write for read-write grant", sidACE.AccessMask)
+		}
+		// A pure SID grant (ID == 0) must NOT emit a "0@localdomain" ACE.
+		if ace := allowACE(a, LocalDomainPrincipal(0)); ace != nil {
+			t.Errorf("unexpected numeric ACE for a pure SID grant (id 0)")
+		}
+	})
+
+	t.Run("sid with unix id projects both sid: and numeric ACEs", func(t *testing.T) {
+		const gid uint32 = 1104
+		a := BuildShareRootACL(GrantNone, []RootGrant{
+			{ID: gid, SID: groupSID, IsGroup: true, Level: GrantRead},
+		})
+		if ace := allowACE(a, "sid:"+groupSID); ace == nil {
+			t.Errorf("missing sid: ACE (SMB path)")
+		}
+		if ace := allowACE(a, LocalDomainPrincipal(gid)); ace == nil {
+			t.Errorf("missing {gid}@localdomain numeric ACE (NFS path)")
+		}
+	})
+
+	t.Run("highest level wins on duplicate SID", func(t *testing.T) {
+		a := BuildShareRootACL(GrantNone, []RootGrant{
+			{SID: groupSID, IsGroup: true, Level: GrantRead},
+			{SID: groupSID, IsGroup: true, Level: GrantAdmin},
+		})
+		ace := allowACE(a, "sid:"+groupSID)
+		if ace == nil {
+			t.Fatalf("missing sid: ACE")
+		}
+		if ace.AccessMask != FullAccessMask {
+			t.Errorf("merged sid: ACE mask = %#x, want FullAccessMask (admin) %#x", ace.AccessMask, FullAccessMask)
+		}
+	})
+
+	t.Run("GrantNone SID emits no ACE", func(t *testing.T) {
+		a := BuildShareRootACL(GrantNone, []RootGrant{
+			{SID: groupSID, IsGroup: true, Level: GrantNone},
+		})
+		if ace := allowACE(a, "sid:"+groupSID); ace != nil {
+			t.Errorf("GrantNone SID grant unexpectedly emitted a sid: ACE")
+		}
+	})
+}
+
+// maskAllows reports whether mask grants the rwx bit(s) implied by the given
+// mode bits, using the same rwxToFullMask mapping BuildShareRootACL uses.
+func maskAllows(mask, modeBits uint32) bool {
+	want := rwxToFullMask(modeBits, true)
+	return mask&want == want
+}


### PR DESCRIPTION
## Summary

Authorize **Active Directory users and groups on a share directly, by SID — with no local DittoFS user/group object** (Samba `idmap_rid`-style). This closes the #1528 gap where every AD principal first needed a shadow DittoFS account.

A grant targets a raw Windows SID, or an AD name resolved to its SID via the configured LDAP directory. At login, a Kerberos principal's **PAC user + group SIDs** (SMB) — or the **Unix id** the SID resolves to (NFS, which carries no SID) — are matched against these grants. Grants are additive (highest matching level wins) and coexist with local user/group grants.

The two account planes are preserved: the single native DittoFS **admin** stays (control-plane/`dfsctl`); only **data-plane** shadow users are eliminated.

## What changed

- **Storage:** new `SIDSharePermission` (SID + share, no FK) + hot-path store resolvers keyed by the denormalized `share_name` (no share preload on the TREE_CONNECT / NFS-auth paths).
- **API/CLI:** `PUT/DELETE /shares/{name}/permissions/sids/{sid}`; `dfsctl share permission grant/revoke` gain `--sid`, and `--user`/`--group` accept an AD name or SID (a local object still wins; otherwise the name is resolved to a SID via LDAP at grant time and stored).
- **LDAP:** `ResolvePrincipalSID` (name → SID + Unix id) reusing the login-path idmap derivation so a grant's numeric id equals the id the principal resolves to at login.
- **Enforcement:** the share-root ACL projects a `sid:<SID>` ACE (SMB) and a `{id}@localdomain` numeric ACE (NFS) per grant; the SMB `TREE_CONNECT` gate and the NFS auth gate match SID grants against the session, even for a principal with no local account.
- **Docs:** new `docs/guide/windows-ad-setup.md` operator runbook (ktpass keytab → LDAP → direct grants → per-user "mount on login"), plus updates to `identity.md`, `access-control.md`, `windows.md`, and regenerated `cli.md`.

## Validation

Verified end-to-end on a real **Windows Server AD** domain (Kerberos AES256), with **all local users deleted** except `admin`:

| Principal | Local account? | Matched via | Level | Result |
|---|---|---|---|---|
| alice | none | user SID …-1106 | read | write **denied** |
| bob | none | user SID …-1107 | read-write | write **allowed** |
| Administrator | none | **group SID …-512 (Domain Admins)** | admin | write **allowed** |

Server log confirmed `directory-resolved identity (no local account)` and the per-session SID match at TREE_CONNECT. Unit + integration tests added (ACL projection, store resolvers, SMB gate, NFS gate, LDAP name→SID); `go test ./...` + `go vet ./...` green.

## Review

Cleanup pass + a high-effort adversarial code review were run on the diff. The review's verified findings are addressed in the second commit: an explicit user-local `--level none` now wins over group/SID grants on both gates (no bypass), SID canonicalization on revoke, permission-level validation, group-name resolution on `sAMAccountName`, correct `UnixID` handling under `idmap=rfc2307`, and name-based revoke that works with the DC offline. Regression tests added for the block-not-overridden invariant and name-based revoke.

## Note on Kerberos on real Windows

Real-Windows Kerberos SMB mounts require the SPNEGO acceptor-mechListMIC fix in #1582 (RFC 4178). This branch is off `develop`; testing was done with #1582 merged in. #1582 should land first (or together).

Closes #1528.
