### PR TITLE
fix(bench): make dfsctl bench run resilient + harness passthrough (#1574)

### DIFF
--- a/bench/scripts/run-all.sh
+++ b/bench/scripts/run-all.sh
@@ -30,6 +30,8 @@ BENCH_FILE_SIZE="${BENCH_FILE_SIZE:-1GiB}"
 BENCH_BLOCK_SIZE="${BENCH_BLOCK_SIZE:-4KiB}"
 BENCH_DURATION="${BENCH_DURATION:-60s}"
 BENCH_META_FILES="${BENCH_META_FILES:-1000}"
+BENCH_SMALL_FILES="${BENCH_SMALL_FILES:-10000}"
+BENCH_WORKLOAD="${BENCH_WORKLOAD:-}"
 RESULTS_DIR="${RESULTS_DIR:-./results}"
 MOUNT_POINT="${MOUNT_POINT:-/mnt/bench}"
 SCRIPTS_DIR="${SCRIPTS_DIR:-/opt/dittofs/bench/infra/scripts}"
@@ -65,6 +67,8 @@ Environment Variables:
   BENCH_BLOCK_SIZE I/O block size for random workloads (default: 4KiB)
   BENCH_DURATION   Duration for time-based workloads (default: 60s)
   BENCH_META_FILES Number of files for metadata workload (default: 1000)
+  BENCH_SMALL_FILES Number of files for small-files workload (default: 10000)
+  BENCH_WORKLOAD   Comma-separated workloads to run (default: all)
   RESULTS_DIR      Directory for JSON result files (default: ./results)
   MOUNT_POINT      Local mount point (default: /mnt/bench)
   SCRIPTS_DIR      Path to install scripts on server (default: /opt/dittofs/bench/infra/scripts)
@@ -131,6 +135,7 @@ ALL_SYSTEMS=(
 # Logging
 # ---------------------------------------------------------------------------
 LOG_FILE="${RESULTS_DIR}/run-all.log"
+mkdir -p "$(dirname "$LOG_FILE")"
 
 log() {
     local ts
@@ -675,8 +680,10 @@ benchmark_system() {
         --block-size "$BENCH_BLOCK_SIZE"
         --duration "$BENCH_DURATION"
         --meta-files "$BENCH_META_FILES"
+        --small-file-count "$BENCH_SMALL_FILES"
         --save "$result_file"
     )
+    [ -n "$BENCH_WORKLOAD" ] && bench_cmd+=(--workload "$BENCH_WORKLOAD")
 
     if $DRY_RUN; then
         log "[DRY-RUN] ${bench_cmd[*]}"

--- a/cmd/dfsctl/commands/bench/run.go
+++ b/cmd/dfsctl/commands/bench/run.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 
 	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
 	"github.com/marmos91/dittofs/pkg/bench"
@@ -21,6 +24,7 @@ var (
 	runMetaFiles      int
 	runSmallFileCount int
 	runClean          bool
+	runQuiet          bool
 )
 
 var runCmd = &cobra.Command{
@@ -57,6 +61,7 @@ func init() {
 	runCmd.Flags().IntVar(&runMetaFiles, "meta-files", 1000, "Number of files for metadata workload")
 	runCmd.Flags().IntVar(&runSmallFileCount, "small-file-count", 10000, "Number of files for small-files workload")
 	runCmd.Flags().BoolVar(&runClean, "clean", false, "Remove test files after benchmark (default: keep for cold read reruns)")
+	runCmd.Flags().BoolVar(&runQuiet, "quiet", false, "Suppress per-workload progress output (useful for log files)")
 }
 
 func runBench(cmd *cobra.Command, args []string) error {
@@ -93,9 +98,26 @@ func runBench(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	runner := bench.NewRunner(cfg, func(w bench.WorkloadType, pct float64) {
-		fmt.Fprintf(os.Stderr, "\r  %s: %.0f%%", w, pct*100)
-	})
+	// Progress is throttled to whole-percent changes so it stays a single
+	// updating line on a TTY and doesn't spam log files (each \r is a fresh
+	// line when stderr isn't a terminal). --quiet suppresses it entirely.
+	progress := func(bench.WorkloadType, float64) {}
+	if !runQuiet {
+		var mu sync.Mutex
+		lastPct := make(map[bench.WorkloadType]int)
+		progress = func(w bench.WorkloadType, pct float64) {
+			p := int(pct * 100)
+			mu.Lock()
+			if p == lastPct[w] {
+				mu.Unlock()
+				return
+			}
+			lastPct[w] = p
+			mu.Unlock()
+			fmt.Fprintf(os.Stderr, "\r  %s: %d%%", w, p)
+		}
+	}
+	runner := bench.NewRunner(cfg, progress)
 
 	if err := runner.Validate(); err != nil {
 		return err
@@ -111,8 +133,26 @@ func runBench(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintln(os.Stderr) // Clear progress line
 
+	// Surface any lanes that failed — the run continued past them so their
+	// failure didn't discard the lanes that succeeded.
+	var failed []string
+	for w, wr := range result.Workloads {
+		if wr.Error != "" {
+			failed = append(failed, fmt.Sprintf("%s (%s)", w, wr.Error))
+		}
+	}
+	if len(failed) > 0 {
+		fmt.Fprintf(os.Stderr, "warning: %d workload(s) failed: %s\n",
+			len(failed), strings.Join(failed, "; "))
+	}
+
 	// Save JSON if requested.
 	if runSave != "" {
+		if dir := filepath.Dir(runSave); dir != "" && dir != "." {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return fmt.Errorf("create results dir: %w", err)
+			}
+		}
 		data, err := json.MarshalIndent(result, "", "  ")
 		if err != nil {
 			return fmt.Errorf("marshal results: %w", err)

--- a/cmd/dfsctl/commands/bench/run.go
+++ b/cmd/dfsctl/commands/bench/run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 
@@ -107,6 +108,9 @@ func runBench(cmd *cobra.Command, args []string) error {
 		lastPct := make(map[bench.WorkloadType]int)
 		progress = func(w bench.WorkloadType, pct float64) {
 			p := int(pct * 100)
+			if p > 100 { // time-based lanes can tick elapsed/duration slightly over 1
+				p = 100
+			}
 			mu.Lock()
 			if p == lastPct[w] {
 				mu.Unlock()
@@ -142,6 +146,7 @@ func runBench(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if len(failed) > 0 {
+		sort.Strings(failed) // stable order for log diffing
 		fmt.Fprintf(os.Stderr, "warning: %d workload(s) failed: %s\n",
 			len(failed), strings.Join(failed, "; "))
 	}

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1443,6 +1443,7 @@ Flags:
       --duration string        Time limit for duration-based workloads (default "60s")
       --file-size string       Size of each test file (default "1GiB")
       --meta-files int         Number of files for metadata workload (default 1000)
+      --quiet                  Suppress per-workload progress output (useful for log files)
       --save string            Save results to JSON file
       --small-file-count int   Number of files for small-files workload (default 10000)
       --system string          Label identifying the system under test
@@ -4254,8 +4255,8 @@ mkdir -p ~/mnt/dittofs && dfsctl share mount /export --protocol smb ~/mnt/dittof
 Flags:
 
 ```
-      --dir-mode string      Directory permissions for SMB mount (octal)
-      --file-mode string     File permissions (not applicable on Windows)
+      --dir-mode string      Directory permissions for SMB mount (octal) (default "0777")
+      --file-mode string     File permissions for SMB mount (octal, default 0777 on macOS since uid/gid not supported) (default "0777")
       --nfs-version string   NFS protocol version for NFS mounts (3, 4, 4.0, 4.1, 4.2). v4 carries locking in-protocol; v3 locking needs the server UDP transport + portmapper (default "3")
   -P, --password string      Password for SMB mount (will prompt if not provided)
   -p, --protocol string      Protocol to use (nfs or smb) (required)

--- a/pkg/bench/runner.go
+++ b/pkg/bench/runner.go
@@ -78,7 +78,10 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 	for _, w := range workloads {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			// Cancelled (e.g. Ctrl-C): stop launching lanes but return
+			// whatever completed so partial results aren't lost.
+			result.TotalDuration = time.Since(start)
+			return result, nil
 		default:
 		}
 
@@ -101,11 +104,15 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 		case SmallFiles:
 			wr, err = runSmallFiles(ctx, r.cfg, dir, r.progress)
 		default:
-			return nil, fmt.Errorf("unknown workload %q", w)
+			err = fmt.Errorf("unknown workload %q", w)
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("workload %s: %w", w, err)
+			// Record the failure and keep going — one bad lane must not
+			// discard every other lane's results. The caller surfaces the
+			// error and the JSON preserves it per lane.
+			result.Workloads[w] = &WorkloadResult{Workload: w, Error: err.Error()}
+			continue
 		}
 
 		result.Workloads[w] = wr

--- a/pkg/bench/runner_test.go
+++ b/pkg/bench/runner_test.go
@@ -501,9 +501,17 @@ func TestRun_ContextCancelled(t *testing.T) {
 	cancel() // Cancel immediately.
 
 	r := NewRunner(cfg, nil)
-	_, err := r.Run(ctx)
-	if err == nil {
-		t.Fatal("Run() with cancelled context expected error, got nil")
+	res, err := r.Run(ctx)
+	// Cancellation stops launching lanes but returns the partial result so
+	// completed lanes aren't discarded — no error, no lanes for this run.
+	if err != nil {
+		t.Fatalf("Run() with cancelled context returned error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("Run() returned nil result on cancellation")
+	}
+	if len(res.Workloads) != 0 {
+		t.Errorf("expected no completed workloads, got %d", len(res.Workloads))
 	}
 }
 
@@ -559,9 +567,15 @@ func TestRun_UnknownWorkload(t *testing.T) {
 	}
 
 	r := NewRunner(cfg, nil)
-	_, err := r.Run(context.Background())
-	if err == nil {
-		t.Fatal("Run() with unknown workload expected error, got nil")
+	res, err := r.Run(context.Background())
+	// An unknown workload is recorded as a failed lane, not a fatal run
+	// error — one bad lane must not discard the others' results.
+	if err != nil {
+		t.Fatalf("Run() with unknown workload returned error: %v", err)
+	}
+	wr := res.Workloads["nonexistent-workload"]
+	if wr == nil || wr.Error == "" {
+		t.Fatalf("expected failed lane with Error set, got %+v", wr)
 	}
 }
 

--- a/pkg/bench/types.go
+++ b/pkg/bench/types.go
@@ -131,6 +131,11 @@ type WorkloadResult struct {
 
 	// Duration is the wall-clock time for this workload.
 	Duration time.Duration `json:"duration"`
+
+	// Error is set when the workload failed to complete. The metric fields
+	// above are then zero; the lane is recorded so one failure doesn't
+	// discard the other lanes' results. Empty on success.
+	Error string `json:"error,omitempty"`
 }
 
 // ProgressFunc is called to report benchmark progress.


### PR DESCRIPTION
Addresses the code-side papercuts from #1574 (the #1466 real-hardware matrix run).

## `dfsctl bench run` robustness
- **One failing lane no longer discards the whole run.** A workload failure is now recorded per-lane (`WorkloadResult.Error`) and the runner continues; partial results are returned and saved. The command prints a `warning: N workload(s) failed: ...` summary.
- **Cancellation (Ctrl-C) returns completed lanes** instead of dropping everything.
- **`--save` now creates its parent directory** if it doesn't exist (was erroring).
- **Progress is throttled to whole-percent changes**, and `--quiet` suppresses it — no more per-percent spam in log files (where `\r` doesn't overwrite).

## bench harness (`run-all.sh`)
- `mkdir -p` the log dir before `tee` (was dying instantly).
- `BENCH_SMALL_FILES` / `BENCH_WORKLOAD` passthrough (was stuck at 10000 small files, ~14 min/run).

## Already resolved on develop (checklist cleanup — no code here)
- **`dfsctl cache evict`** → superseded by `dfsctl store block evict` (read-buffer / local / per-share tiers). Harness cold-cache step should call that.
- **NFS squash flag** → `dfsctl share nfs-config set /export --squash none|root_to_guest|...` already exists; the curl PATCH workaround is no longer needed.

## Deferred (harness-only, separate follow-up)
- Batched `run-all.sh` NFS cross-contamination (rpcbind isolation between systems).
- `s3-baseline.sh` JSON parse.

## Notes
- `docs/guide/cli.md` regenerated via `cmd/gendocs`; besides the new `--quiet` flag it picked up a pre-existing mount-flag default drift (generated truth, not hand-edited).
- `go test -race ./pkg/bench/...`: 23 pass. `go vet` + `gofmt` clean.