### PR TITLE
ci(release): trigger website docs sync on stable tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,3 +210,19 @@ jobs:
             org.opencontainers.image.version=${{ steps.version.outputs.VERSION }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.licenses=Apache-2.0
+
+  sync-docs:
+    name: Sync docs to website
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger dittofs-web docs refresh
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_SYNC_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          # Docs "latest" tracks develop; skip pre-release (rc) tags.
+          if [[ "${VERSION}" == *-* ]]; then
+            echo "Pre-release ${VERSION}; skipping docs sync."
+            exit 0
+          fi
+          gh workflow run refresh-docs.yml --repo marmos91/dittofs-web


### PR DESCRIPTION
## What

Adds a `sync-docs` job to `release.yml` that fires the website repo's existing `refresh-docs.yml` workflow on every stable `vX.Y.Z` tag push (rc tags skipped).

## Why

Docs on dittofs.io/docs are vendored in `marmos91/dittofs-web` and only refreshed by `refresh-docs.yml` (weekly cron / manual dispatch). Nothing connected a dittofs release to that sync, so published docs lagged. This closes the loop: tag → dispatch → sync PR on dittofs-web → merge → site rebuild.

## Requires

- Secret `DOCS_SYNC_TOKEN` on this repo — a fine-grained PAT scoped to `marmos91/dittofs-web` with **Actions: Read and write** (default `GITHUB_TOKEN` can't reach another repo). Already configured.

## Notes

- Only refreshes **latest** `/docs`. Pinned `/vX.Y/docs` snapshots remain the manual `scripts/VERSIONING.md` flow in dittofs-web.
- Separately fixed: dittofs-web had "Allow Actions to create PRs" disabled, which had been silently failing the weekly sync's PR step.