### PR TITLE
perf(metadata): relaxed durability for namespace ops (#1573 Wall 1)

### DIFF
--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -88,10 +88,17 @@ func CreateMetadataStoreFromConfig(ctx context.Context, storeType string, cfg in
 		if indexCacheMB < 0 {
 			return nil, fmt.Errorf("badger metadata store index_cache_mb must be >= 0 (0 = auto), got %d", indexCacheMB)
 		}
-		return badger.NewBadgerMetadataStoreWithDefaultsAndCaches(ctx, dbPath, blockCacheMB, indexCacheMB)
+		// Relaxed durability defers namespace-op fsyncs for higher single-thread
+		// throughput; data-paired writes stay synchronous (#1573 Wall 1).
+		// Shipped default: enabled. Operators restore strict per-txn fsync with
+		// relaxed_durability: false.
+		relaxedDurability := configBoolDefault(config, "relaxed_durability", true)
+		return badger.NewBadgerMetadataStoreWithDefaultsAndCaches(ctx, dbPath, blockCacheMB, indexCacheMB, relaxedDurability)
 
 	case "postgres":
 		pgCfg := &postgres.PostgresMetadataStoreConfig{}
+		// See badger branch: relaxed by default, opt out with relaxed_durability: false.
+		pgCfg.RelaxedDurability = configBoolDefault(config, "relaxed_durability", true)
 
 		if host, ok := config["host"].(string); ok {
 			pgCfg.Host = host
@@ -224,6 +231,17 @@ func configInt64(config map[string]any, key string) int64 {
 	default:
 		return 0
 	}
+}
+
+// configBoolDefault extracts a bool value from a type-specific config map under
+// key, returning def when the key is absent. Used for opt-out flags whose
+// shipped default is not the zero value (e.g. relaxed_durability defaults to
+// true — #1573 Wall 1).
+func configBoolDefault(config map[string]any, key string, def bool) bool {
+	if v, ok := config[key].(bool); ok {
+		return v
+	}
+	return def
 }
 
 // LoadSharesFromStore loads shares from the database into the runtime.

--- a/pkg/metadata/directory.go
+++ b/pkg/metadata/directory.go
@@ -220,7 +220,10 @@ func (s *Service) RemoveDirectory(ctx *AuthContext, parentHandle FileHandle, nam
 	wcc := &DirWcc{}
 
 	// Execute all write operations in a single transaction for better performance.
-	txErr := store.WithTransaction(ctx.Context, func(tx Transaction) error {
+	// Relaxed durability (#1573 Wall 1): rmdir touches only namespace keys, not
+	// block data. A crash can lose the removal (dir reappears empty), never
+	// corrupt data.
+	txErr := withRelaxedTransaction(store, ctx.Context, func(tx Transaction) error {
 		// Re-read the parent inside the transaction so the pre-op snapshot and
 		// the timestamp mutation derive from the same committed state.
 		if txParent, pErr := tx.GetFile(ctx.Context, parentHandle); pErr == nil && txParent != nil {

--- a/pkg/metadata/file_create.go
+++ b/pkg/metadata/file_create.go
@@ -128,7 +128,11 @@ func (s *Service) CreateHardLink(ctx *AuthContext, dirHandle FileHandle, name st
 	wcc := &DirWcc{}
 
 	// Execute all write operations in a single transaction for better performance.
-	err = store.WithTransaction(ctx.Context, func(tx Transaction) error {
+	// Relaxed durability (#1573 Wall 1): a create writes only child keys (+
+	// parent nlink for mkdir) — pure namespace, not paired with block data — so
+	// its commit may become durable with bounded lag. A crash can lose the
+	// just-created entry (the client re-creates); it can never corrupt data.
+	err = withRelaxedTransaction(store, ctx.Context, func(tx Transaction) error {
 		// Re-read the directory inside the transaction so the pre-op snapshot and
 		// the timestamp mutation derive from the same committed state.
 		if txDir, dErr := tx.GetFile(ctx.Context, dirHandle); dErr == nil && txDir != nil {
@@ -368,7 +372,12 @@ func (s *Service) createEntry(
 	// which BadgerDB SSI aborts as a conflict, serializing them on retry-backoff
 	// (#1573). Touching only the new child's disjoint keys lets group-commit
 	// batch concurrent creates; the parent timestamp is coalesced below.
-	err = store.WithTransaction(ctx.Context, func(tx Transaction) error {
+	//
+	// Relaxed durability (#1573 Wall 1): these are pure-namespace child keys, not
+	// paired with block data, so the commit may become durable with bounded lag.
+	// A crash can lose the just-created entry (the client re-creates); it can
+	// never corrupt data.
+	err = withRelaxedTransaction(store, ctx.Context, func(tx Transaction) error {
 		// TOCTOU guard: re-check inside transaction.
 		if _, innerErr := tx.GetChild(ctx.Context, parentHandle, name); innerErr == nil {
 			return &StoreError{

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -535,7 +535,20 @@ func (s *Service) SetFileAttributes(ctx *AuthContext, handle FileHandle, attrs *
 		if attrs.Ctime == nil {
 			file.Ctime = now
 		}
-		if err := store.PutFile(ctx.Context, file); err != nil {
+		// A size change (truncate/grow) is data-paired: the new size must
+		// survive a crash together with the block data, or a read past the new
+		// EOF returns stale-tail / silent-truncation bytes (#588). Persist it
+		// through a fully-durable transaction so relaxed-durability mode still
+		// fsyncs it. Pure-attribute changes (mode/owner/times/xattr/ACL) are not
+		// data-paired and take the store's default PutFile path, which defers in
+		// relaxed mode (#1573 Wall 1).
+		if attrs.Size != nil {
+			if err := store.WithTransaction(ctx.Context, func(tx Transaction) error {
+				return tx.PutFile(ctx.Context, file)
+			}); err != nil {
+				return nil, err
+			}
+		} else if err := store.PutFile(ctx.Context, file); err != nil {
 			return nil, err
 		}
 
@@ -748,7 +761,11 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 	}
 
 	// Execute all write operations in a single transaction for better performance.
-	txErr := store.WithTransaction(ctx.Context, func(tx Transaction) error {
+	// Relaxed durability (#1573 Wall 1): rename rewrites only directory entries
+	// and inode paths — the moved file's size and block manifest are untouched,
+	// so this is pure namespace. A crash can lose the rename (old name
+	// persists), never corrupt data.
+	txErr := withRelaxedTransaction(store, ctx.Context, func(tx Transaction) error {
 		// Re-read the source/destination directories inside the transaction so
 		// the pre-op snapshots and the timestamp mutations derive from the same
 		// committed state (After then monotonic w.r.t. Before).

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -540,15 +540,19 @@ func (s *Service) SetFileAttributes(ctx *AuthContext, handle FileHandle, attrs *
 		// EOF returns stale-tail / silent-truncation bytes (#588). Persist it
 		// through a fully-durable transaction so relaxed-durability mode still
 		// fsyncs it. Pure-attribute changes (mode/owner/times/xattr/ACL) are not
-		// data-paired and take the store's default PutFile path, which defers in
-		// relaxed mode (#1573 Wall 1).
+		// data-paired, so they take the relaxed path — note store.PutFile would
+		// force an inline fsync (it wraps the durable WithTransaction), so it is
+		// deliberately bypassed here in favor of withRelaxedTransaction to
+		// actually defer the write (#1573 Wall 1).
 		if attrs.Size != nil {
 			if err := store.WithTransaction(ctx.Context, func(tx Transaction) error {
 				return tx.PutFile(ctx.Context, file)
 			}); err != nil {
 				return nil, err
 			}
-		} else if err := store.PutFile(ctx.Context, file); err != nil {
+		} else if err := withRelaxedTransaction(store, ctx.Context, func(tx Transaction) error {
+			return tx.PutFile(ctx.Context, file)
+		}); err != nil {
 			return nil, err
 		}
 

--- a/pkg/metadata/file_remove.go
+++ b/pkg/metadata/file_remove.go
@@ -134,7 +134,11 @@ func (s *Service) RemoveFile(ctx *AuthContext, parentHandle FileHandle, name str
 	// this transaction does NOT touch the parent inode — the parent timestamp
 	// bump that used to serialize concurrent same-dir removes on a BadgerDB SSI
 	// hot key is coalesced after commit instead (#1573).
-	err = store.WithTransaction(ctx.Context, func(tx Transaction) error {
+	//
+	// Relaxed durability (#1573 Wall 1): these writes are pure namespace — the
+	// child unlink and link-count — not paired with block data. A crash can lose
+	// the removal (the entry reappears; the client re-unlinks), never corrupt data.
+	err = withRelaxedTransaction(store, ctx.Context, func(tx Transaction) error {
 		// Read the link count INSIDE the transaction so the read, the
 		// branch decision, and the write are atomic. Reading it outside the
 		// tx is a TOCTOU race with CreateHardLink: a concurrent link bump in

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -303,6 +303,31 @@ type Transactor interface {
 	WithTransaction(ctx context.Context, fn func(tx Transaction) error) error
 }
 
+// RelaxedTransactor is an OPTIONAL store capability (#1573 Wall 1): running a
+// transaction whose commit may become durable with bounded lag instead of an
+// inline fsync. It is intended ONLY for pure-namespace/attr writes
+// (create/remove/rename/mkdir/mode/owner/times) that are not paired with block
+// data — a crash can lose the last sub-interval of such ops (the op vanishes or
+// reappears), never corrupt data. Data-paired writes (file size, block
+// manifest, rollup offset) must always use the fully-durable WithTransaction.
+//
+// Stores that do not implement this interface transparently fall back to
+// WithTransaction (fully durable) via withRelaxedTransaction, so a missing
+// implementation is always safe — never a correctness hazard.
+type RelaxedTransactor interface {
+	WithTransactionRelaxed(ctx context.Context, fn func(tx Transaction) error) error
+}
+
+// withRelaxedTransaction runs fn with relaxed durability when the store
+// supports it, otherwise fully durably. Namespace/attr mutations route through
+// here to opt into the deferred-fsync fast path (#1573 Wall 1).
+func withRelaxedTransaction(store Transactor, ctx context.Context, fn func(tx Transaction) error) error {
+	if r, ok := store.(RelaxedTransactor); ok {
+		return r.WithTransactionRelaxed(ctx, fn)
+	}
+	return store.WithTransaction(ctx, fn)
+}
+
 // ============================================================================
 // FilesystemMeta
 // ============================================================================

--- a/pkg/metadata/store/badger/relaxed_durability_bench_test.go
+++ b/pkg/metadata/store/badger/relaxed_durability_bench_test.go
@@ -1,0 +1,62 @@
+package badger_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/badger"
+)
+
+// BenchmarkNamespaceCommit measures serial single-thread namespace-commit
+// throughput — the create/remove/rename hot path (#1573 Wall 1). Both sub-benchmarks
+// run the SAME code a create runs (WithTransactionRelaxed committing a PutFile);
+// only the store's durability config differs, so the delta is purely the
+// per-commit fsync the strict store still pays and the relaxed store defers.
+//
+// NOTE: on macOS the badger fsync is cheap (Darwin's fsync is not a full
+// barrier), so the local ratio understates the win. On a Linux disk that honors
+// fsync (the bench VM) the strict path is fsync-bound at ~168 commits/s and the
+// relaxed path runs at memtable speed — the headline Wall 1 improvement.
+func BenchmarkNamespaceCommit(b *testing.B) {
+	for _, tc := range []struct {
+		name    string
+		relaxed bool
+	}{
+		{"strict", false},
+		{"relaxed", true},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			dbPath := filepath.Join(b.TempDir(), "metadata.db")
+			store, err := badger.NewBadgerMetadataStore(context.Background(), badger.BadgerMetadataStoreConfig{
+				DBPath:            dbPath,
+				RelaxedDurability: tc.relaxed,
+			})
+			require.NoError(b, err)
+			b.Cleanup(func() { _ = store.Close() })
+
+			ctx := context.Background()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				f := &metadata.File{
+					ID:        uuid.New(),
+					ShareName: "bench",
+					Path:      "/f",
+					FileAttr:  metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644},
+				}
+				// Same call the create path uses: relaxed in relaxed mode,
+				// fsync-per-commit in strict mode (SyncWrites=true).
+				if err := store.WithTransactionRelaxed(ctx, func(tx metadata.Transaction) error {
+					return tx.PutFile(ctx, f)
+				}); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/metadata/store/badger/relaxed_durability_test.go
+++ b/pkg/metadata/store/badger/relaxed_durability_test.go
@@ -1,0 +1,120 @@
+package badger_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/badger"
+	"github.com/marmos91/dittofs/pkg/metadata/storetest"
+)
+
+// openRelaxed opens a relaxed-durability badger store at dbPath. Reusable so a
+// reopen test can point two store instances at the same directory.
+func openRelaxed(t *testing.T, dbPath string) *badger.BadgerMetadataStore {
+	t.Helper()
+	// WithDefaultsAndCaches applies the default filesystem capabilities the
+	// conformance suite expects, plus the relaxed-durability flag.
+	store, err := badger.NewBadgerMetadataStoreWithDefaultsAndCaches(context.Background(), dbPath, 0, 0, true)
+	require.NoError(t, err)
+	return store
+}
+
+func openStrict(t *testing.T, dbPath string) *badger.BadgerMetadataStore {
+	t.Helper()
+	store, err := badger.NewBadgerMetadataStoreWithDefaultsAndCaches(context.Background(), dbPath, 0, 0, false)
+	require.NoError(t, err)
+	return store
+}
+
+// TestConformance_RelaxedDurability runs the entire metadata conformance suite
+// against a relaxed-durability store (#1573 Wall 1). It is the primary
+// no-loss/no-corruption guard: every create/write/rename/remove/truncate/link/
+// xattr/attr operation the suite exercises must still read back correctly when
+// namespace-op fsyncs are deferred. A regression that dropped or corrupted data
+// on the relaxed path fails here exactly as it would on the strict store.
+func TestConformance_RelaxedDurability(t *testing.T) {
+	storetest.RunConformanceSuite(t, func(t *testing.T) metadata.Store {
+		dbPath := filepath.Join(t.TempDir(), "metadata.db")
+		store := openRelaxed(t, dbPath)
+		t.Cleanup(func() {
+			if err := store.Close(); err != nil {
+				t.Errorf("store.Close() failed: %v", err)
+			}
+		})
+		return store
+	})
+}
+
+// TestRelaxedDurability_DurablePathFsyncsInline pins the durable/relaxed
+// classification: in relaxed mode a durable commit (WithTransaction) and a
+// data-paired write (SetRollupOffset) fsync inline, while a relaxed commit
+// (WithTransactionRelaxed) does not. If a future change accidentally routed a
+// data-paired write through the relaxed path (reintroducing the #588
+// silent-zeros hazard), the inline-sync count would not advance and this fails.
+func TestRelaxedDurability_DurablePathFsyncsInline(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "metadata.db")
+	store := openRelaxed(t, dbPath)
+	t.Cleanup(func() { _ = store.Close() })
+
+	// Durable commit must fsync inline.
+	before := store.InlineSyncCountForTest()
+	require.NoError(t, store.WithTransaction(ctx, func(tx metadata.Transaction) error { return nil }))
+	require.Equal(t, before+1, store.InlineSyncCountForTest(),
+		"durable WithTransaction must fsync inline in relaxed mode")
+
+	// Relaxed commit must NOT fsync inline (bounded-lag syncer handles it).
+	before = store.InlineSyncCountForTest()
+	require.NoError(t, store.WithTransactionRelaxed(ctx, func(tx metadata.Transaction) error { return nil }))
+	require.Equal(t, before, store.InlineSyncCountForTest(),
+		"relaxed WithTransactionRelaxed must NOT fsync inline")
+
+	// SetRollupOffset is data-paired with the append-log fsync → must fsync.
+	before = store.InlineSyncCountForTest()
+	_, err := store.SetRollupOffset(ctx, "payload-A", 4096)
+	require.NoError(t, err)
+	require.Greater(t, store.InlineSyncCountForTest(), before,
+		"SetRollupOffset must fsync inline (data-paired)")
+}
+
+// TestRelaxedDurability_StrictModeNoInlineSync verifies that with relaxed
+// durability disabled (the opt-out), no inline db.Sync() runs — durability is
+// carried by SyncWrites=true on every commit, exactly reproducing the pre-#1573
+// posture.
+func TestRelaxedDurability_StrictModeNoInlineSync(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "metadata.db")
+	store := openStrict(t, dbPath)
+	t.Cleanup(func() { _ = store.Close() })
+
+	before := store.InlineSyncCountForTest()
+	require.NoError(t, store.WithTransaction(ctx, func(tx metadata.Transaction) error { return nil }))
+	require.NoError(t, store.WithTransactionRelaxed(ctx, func(tx metadata.Transaction) error { return nil }))
+	_, err := store.SetRollupOffset(ctx, "payload-A", 4096)
+	require.NoError(t, err)
+	require.Equal(t, before, store.InlineSyncCountForTest(),
+		"strict mode must fsync via SyncWrites, never inline db.Sync")
+}
+
+// TestRelaxedDurability_DurableWriteSurvivesReopen confirms a data-paired write
+// on the relaxed store persists across a clean close+reopen with no loss — the
+// everyday durability the deferred-fsync path must never compromise.
+func TestRelaxedDurability_DurableWriteSurvivesReopen(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "metadata.db")
+
+	store := openRelaxed(t, dbPath)
+	_, err := store.SetRollupOffset(ctx, "payload-A", 8192)
+	require.NoError(t, err)
+	require.NoError(t, store.Close()) // clean close flushes everything durably
+
+	reopened := openRelaxed(t, dbPath)
+	t.Cleanup(func() { _ = reopened.Close() })
+	got, err := reopened.GetRollupOffset(ctx, "payload-A")
+	require.NoError(t, err)
+	require.Equal(t, uint64(8192), got, "durable rollup offset must survive close+reopen")
+}

--- a/pkg/metadata/store/badger/rollup.go
+++ b/pkg/metadata/store/badger/rollup.go
@@ -106,6 +106,12 @@ func (s *BadgerMetadataStore) SetRollupOffset(ctx context.Context, payloadID str
 	if err != nil {
 		return 0, fmt.Errorf("badger rollup set: %w", err)
 	}
+	// The rollup offset is paired with the append-log fsync it fences; losing
+	// it after a crash re-replays or zero-fills, so it must be durable even in
+	// relaxed mode. No-op in strict mode (commit already fsynced).
+	if syncErr := s.syncIfRelaxed(); syncErr != nil {
+		return 0, fmt.Errorf("badger rollup set: durability sync: %w", syncErr)
+	}
 	if regressed {
 		return prev, metadata.ErrRollupOffsetRegression
 	}

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -139,6 +139,26 @@ type BadgerMetadataStore struct {
 	// DB reset (which rotates cfg.ID) does NOT cause the engine to report a
 	// different identity.
 	storeID string
+
+	// relaxedDurability, when set, opens the DB with SyncWrites=false and
+	// defers namespace-op fsyncs to the background syncLoop below; durable
+	// writes (WithTransaction, SetRollupOffset) call db.Sync() explicitly.
+	// When false the DB is opened SyncWrites=true and every commit fsyncs, so
+	// WithTransactionRelaxed is indistinguishable from WithTransaction (the
+	// pre-#1573 posture). See BadgerMetadataStoreConfig.RelaxedDurability.
+	relaxedDurability bool
+
+	// syncStop signals the bounded-lag background syncer to exit; syncWG waits
+	// for it in Close(). Only started when relaxedDurability is set. Mirrors the
+	// gcStop/gcWG lifecycle so the syncer never runs against a closed DB.
+	syncStop     chan struct{}
+	syncStopOnce sync.Once
+	syncWG       sync.WaitGroup
+
+	// inlineSyncs counts explicit db.Sync() calls on the durable write path
+	// (syncIfRelaxed), NOT the background ticker. Tests read it to assert the
+	// durable/relaxed classification is wired correctly.
+	inlineSyncs atomic.Int64
 }
 
 // BadgerMetadataStoreConfig contains configuration for creating a BadgerDB metadata store.
@@ -164,6 +184,18 @@ type BadgerMetadataStoreConfig struct {
 	// BadgerOptions allows customization of BadgerDB behavior
 	// If nil, sensible defaults are used
 	BadgerOptions *badger.Options
+
+	// RelaxedDurability defers the per-transaction fsync for pure-namespace
+	// metadata writes (create/remove/rename/mkdir/attr) to a bounded-lag
+	// background sync, honoring the same UNSTABLE-style tradeoff the block
+	// append-log took in #1584. Data-paired writes — file size on WRITE, the
+	// block manifest (DefaultCommitBlock), and the rollup offset — stay
+	// synchronous regardless, so this can never resurrect the #588 silent-zeros
+	// bug; only a hard crash can lose the last sub-100ms of namespace ops (the
+	// op vanishes / reappears, never corrupts). When false (the safe default at
+	// the store layer) every commit fsyncs, exactly reproducing pre-#1573
+	// behavior. The server product enables it via config (#1573 Wall 1).
+	RelaxedDurability bool `mapstructure:"relaxed_durability"`
 
 	// BlockCacheSizeMB is BadgerDB's block cache size in MiB. This caches
 	// decompressed LSM-tree data blocks for faster reads. When 0 (unset) the
@@ -247,20 +279,26 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 	// (engine.go:1072 `clear(dest)`), returning silent zeros for files
 	// whose CAS chunks are still on disk.
 	//
-	// Override here UNCONDITIONALLY so an operator tuning unrelated
-	// knobs via BadgerOptions cannot accidentally re-disable crash
-	// durability by inheriting badger's default SyncWrites=false. If a
-	// future workload needs to opt out (e.g. dev/test harnesses
-	// favoring perf over durability) a dedicated config flag should
-	// be introduced rather than relying on badger's permissive default.
+	// Override here so an operator tuning unrelated knobs via BadgerOptions
+	// cannot accidentally change the durability posture by inheriting badger's
+	// permissive SyncWrites=false default — the posture is decided ONLY by
+	// config.RelaxedDurability.
 	//
-	// Performance cost: every metadata Update transaction now fsyncs.
-	// In our deployment profile (NFSv3/SMB workloads with high write
-	// concurrency) this is acceptable because (a) badger amortizes
-	// fsyncs across the transactions in a single commit batch and
-	// (b) DittoFS already requires durability at every COMMIT /
-	// FILE_FLUSH so the cost was paid elsewhere previously.
-	opts = opts.WithSyncWrites(true)
+	// Strict (default, RelaxedDurability=false): SyncWrites=true, every commit
+	// fsyncs — the #583/#588 posture, unchanged.
+	//
+	// Relaxed (RelaxedDurability=true, #1573 Wall 1): SyncWrites=false, so
+	// namespace-op commits return once the write lands in the memtable/WAL
+	// buffer. Durability is re-established two ways: (a) durable writes
+	// (WithTransaction, SetRollupOffset) call db.Sync() explicitly after commit
+	// — this keeps every DATA-PAIRED write (file size, block manifest, rollup
+	// offset) synchronous, so #588 silent-zeros cannot recur; (b) the
+	// background syncLoop fsyncs on a bounded interval so an un-barriered
+	// namespace op is durable within syncLoopInterval. A hard crash can lose
+	// only the last <interval of pure-namespace ops (the op vanishes/reappears,
+	// never corrupts) — the same UNSTABLE-style tradeoff #1584 took for the
+	// block append-log.
+	opts = opts.WithSyncWrites(!config.RelaxedDurability)
 
 	// Open BadgerDB
 	db, err := badger.Open(opts)
@@ -278,12 +316,14 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 	}
 
 	store := &BadgerMetadataStore{
-		db:              db,
-		gcStop:          make(chan struct{}),
-		capabilities:    config.Capabilities,
-		maxStorageBytes: config.MaxStorageBytes,
-		maxFiles:        config.MaxFiles,
-		storeID:         sid,
+		db:                db,
+		gcStop:            make(chan struct{}),
+		capabilities:      config.Capabilities,
+		maxStorageBytes:   config.MaxStorageBytes,
+		maxFiles:          config.MaxFiles,
+		storeID:           sid,
+		relaxedDurability: config.RelaxedDurability,
+		syncStop:          make(chan struct{}),
 	}
 
 	// Initialize stats cache with a 5-second TTL for responsive updates
@@ -309,6 +349,15 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 	// stopped in Close().
 	store.gcWG.Add(1)
 	go store.runValueLogGC()
+
+	// Bounded-lag durability syncer: only needed in relaxed mode, where
+	// namespace-op commits do not fsync inline. It caps how long an
+	// un-barriered namespace op can sit un-fsynced (worst-case crash-loss
+	// window). Strict mode fsyncs every commit, so no syncer runs.
+	if store.relaxedDurability {
+		store.syncWG.Add(1)
+		go store.runDurabilitySync()
+	}
 
 	return store, nil
 }
@@ -358,6 +407,48 @@ func (s *BadgerMetadataStore) runValueLogGC() {
 			}
 		}
 	}
+}
+
+// durabilitySyncInterval bounds how long a relaxed (namespace-op) commit can
+// sit un-fsynced before the background syncer forces it to disk — i.e. the
+// worst-case crash-loss window for pure-namespace ops. 100ms is an order of
+// magnitude tighter than ext4's default 5s journal-commit interval.
+const durabilitySyncInterval = 100 * time.Millisecond
+
+// runDurabilitySync periodically fsyncs the value log so relaxed-mode
+// namespace commits become durable within durabilitySyncInterval even when no
+// durable write (which fsyncs inline) happens to follow them. Only started in
+// relaxed mode. Exits promptly when syncStop is closed by Close(); a final
+// flush is guaranteed by db.Close() itself.
+func (s *BadgerMetadataStore) runDurabilitySync() {
+	defer s.syncWG.Done()
+
+	ticker := time.NewTicker(durabilitySyncInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.syncStop:
+			return
+		case <-ticker.C:
+			// A failed periodic sync is not fatal here: the next durable
+			// write or db.Close() will retry, and callers that need a hard
+			// guarantee go through the inline db.Sync() on the durable path.
+			_ = s.db.Sync()
+		}
+	}
+}
+
+// syncIfRelaxed fsyncs the value log when running in relaxed mode, turning a
+// just-committed (SyncWrites=false) write durable. In strict mode SyncWrites=true
+// already fsynced on commit, so this is a no-op. Callers on the DATA-PAIRED
+// path (WithTransaction, SetRollupOffset) use it to keep #588 durability.
+func (s *BadgerMetadataStore) syncIfRelaxed() error {
+	if !s.relaxedDurability {
+		return nil
+	}
+	s.inlineSyncs.Add(1)
+	return s.db.Sync()
 }
 
 // storeIDKey is the BadgerDB key for the engine-persistent store identifier.
@@ -502,10 +593,11 @@ func NewBadgerMetadataStoreWithDefaults(ctx context.Context, dbPath string) (*Ba
 // (see cache.go / #1245 Bug D). Used by the per-store config-map path so an
 // operator can pin caches on a single metadata store via its config keys
 // (block_cache_mb / index_cache_mb).
-func NewBadgerMetadataStoreWithDefaultsAndCaches(ctx context.Context, dbPath string, blockCacheMB, indexCacheMB int64) (*BadgerMetadataStore, error) {
+func NewBadgerMetadataStoreWithDefaultsAndCaches(ctx context.Context, dbPath string, blockCacheMB, indexCacheMB int64, relaxedDurability bool) (*BadgerMetadataStore, error) {
 	cfg := defaultStoreConfig(dbPath)
 	cfg.BlockCacheSizeMB = blockCacheMB
 	cfg.IndexCacheSizeMB = indexCacheMB
+	cfg.RelaxedDurability = relaxedDurability
 	return NewBadgerMetadataStore(ctx, cfg)
 }
 
@@ -624,6 +716,13 @@ func (s *BadgerMetadataStore) Close() error {
 			close(s.gcStop)
 		})
 		s.gcWG.Wait()
+
+		// Stop the bounded-lag durability syncer (relaxed mode only) before
+		// closing the DB. syncStopOnce is a no-op if the syncer never started.
+		s.syncStopOnce.Do(func() {
+			close(s.syncStop)
+		})
+		s.syncWG.Wait()
 
 		// Record a clean-shutdown marker LAST, after the GC goroutine has
 		// drained and before closing the DB, so the lock-recovery boot path can

--- a/pkg/metadata/store/badger/sync_writes_test.go
+++ b/pkg/metadata/store/badger/sync_writes_test.go
@@ -8,20 +8,13 @@ import (
 	badger "github.com/dgraph-io/badger/v4"
 )
 
-// TestBadgerStore_SyncWritesEnabledByDefault asserts the crash-consistency
-// fix from #583: badger.DefaultOptions has SyncWrites=false, which causes
-// FileChunk rows (and every other metadata write) to live in the memtable
-// + WAL buffer rather than fsyncing to disk on commit. A `kill -9`
-// between flush boundaries loses every metadata write since the last
-// sync, including the rollup-produced FileChunk manifest rows — the
-// engine's CAS read path then falls into the sparse-block zero-fill
-// branch and returns silent zeros for files whose chunks survived on
-// disk.
-//
-// The store constructor (NewBadgerMetadataStore) now applies
-// WithSyncWrites(true) over the default options. This test pins that
-// invariant.
-func TestBadgerStore_SyncWritesEnabledByDefault(t *testing.T) {
+// TestBadgerStore_StrictDurabilityForcesSyncWrites pins the #583/#588
+// crash-consistency posture for the DEFAULT (strict) store: SyncWrites=true, so
+// every commit fsyncs and no metadata write can be lost between flush
+// boundaries. Badger's own default is SyncWrites=false, which loses rolled-up
+// FileChunk / FileAttr.Blocks rows on a kill-9 and makes the CAS read path
+// return silent zeros — this test guards against that regressing.
+func TestBadgerStore_StrictDurabilityForcesSyncWrites(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "badger")
 
@@ -31,36 +24,54 @@ func TestBadgerStore_SyncWritesEnabledByDefault(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = store.Close() })
 
-	opts := store.db.Opts()
-	if !opts.SyncWrites {
-		t.Fatalf("badger SyncWrites: got false, want true (crash-consistency regression — see #583)")
+	if !store.db.Opts().SyncWrites {
+		t.Fatalf("badger SyncWrites: got false, want true for strict store (crash-consistency regression — see #583)")
 	}
 }
 
-// TestBadgerStore_SyncWritesEnforcedOnCustomConfig asserts the #588
-// follow-up to #583: the SyncWrites=true override is applied regardless
-// of whether the caller passed custom badger.Options. Without this
-// enforcement, an operator tuning unrelated knobs (cache sizes, value
-// log thresholds, etc.) via BadgerOptions could accidentally re-disable
-// crash durability by inheriting badger's default SyncWrites=false.
-func TestBadgerStore_SyncWritesEnforcedOnCustomConfig(t *testing.T) {
+// TestBadgerStore_StrictEnforcedOnCustomConfig asserts the #588 follow-up: a
+// strict store (RelaxedDurability=false) forces SyncWrites=true even when the
+// caller passes custom options with SyncWrites explicitly false, so an operator
+// tuning unrelated knobs cannot accidentally disable crash durability.
+func TestBadgerStore_StrictEnforcedOnCustomConfig(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "badger")
 
-	// Caller passes options with SyncWrites EXPLICITLY false — the store
-	// constructor must still force SyncWrites=true.
 	customOpts := badger.DefaultOptions(dbPath).WithSyncWrites(false)
 	store, err := NewBadgerMetadataStore(context.Background(), BadgerMetadataStoreConfig{
 		DBPath:        dbPath,
 		BadgerOptions: &customOpts,
+		// RelaxedDurability defaults false → strict.
 	})
 	if err != nil {
 		t.Fatalf("NewBadgerMetadataStore custom: %v", err)
 	}
 	t.Cleanup(func() { _ = store.Close() })
 
-	opts := store.db.Opts()
-	if !opts.SyncWrites {
-		t.Fatalf("badger SyncWrites under custom config: got false, want true (#588 enforcement bypass)")
+	if !store.db.Opts().SyncWrites {
+		t.Fatalf("badger SyncWrites under strict custom config: got false, want true (#588 enforcement bypass)")
+	}
+}
+
+// TestBadgerStore_RelaxedDurabilityDisablesSyncWrites is the #1573 Wall 1
+// counterpart: a relaxed store opens with SyncWrites=false so namespace-op
+// commits do not fsync inline. Durability for data-paired writes is
+// re-established by the explicit db.Sync() on the durable path (covered by
+// relaxed_durability_test.go), not by SyncWrites.
+func TestBadgerStore_RelaxedDurabilityDisablesSyncWrites(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "badger")
+
+	store, err := NewBadgerMetadataStore(context.Background(), BadgerMetadataStoreConfig{
+		DBPath:            dbPath,
+		RelaxedDurability: true,
+	})
+	if err != nil {
+		t.Fatalf("NewBadgerMetadataStore relaxed: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	if store.db.Opts().SyncWrites {
+		t.Fatalf("badger SyncWrites under relaxed config: got true, want false (#1573 Wall 1)")
 	}
 }

--- a/pkg/metadata/store/badger/testhooks.go
+++ b/pkg/metadata/store/badger/testhooks.go
@@ -6,6 +6,15 @@ package badger
 // shrink the budget to deterministically drive WithTransaction into its
 // retry-exhausted conflict path without spinning thousands of contending
 // goroutines. Production code never calls it.
+// InlineSyncCountForTest returns the number of explicit db.Sync() calls made on
+// the durable write path (WithTransaction / SetRollupOffset in relaxed mode).
+// It excludes the background bounded-lag syncer, so a test can assert that a
+// durable commit fsynced inline and a relaxed commit did not. Production code
+// never calls it.
+func (s *BadgerMetadataStore) InlineSyncCountForTest() int64 {
+	return s.inlineSyncs.Load()
+}
+
 func SetMaxTransactionRetriesForTest(n int) func() {
 	prev := maxTransactionRetries.Load()
 	// Clamp to at least 1: a value <= 0 would make WithTransaction run zero

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -98,6 +98,27 @@ var maxTransactionRetries = func() *atomic.Int32 {
 // If fn returns nil, the transaction is committed.
 // Retries automatically on transaction conflicts (ErrConflict).
 func (s *BadgerMetadataStore) WithTransaction(ctx context.Context, fn func(tx metadata.Transaction) error) error {
+	return s.withTransaction(ctx, fn, true)
+}
+
+// WithTransactionRelaxed runs fn exactly like WithTransaction but, in
+// relaxed-durability mode, does NOT force an inline fsync on commit — the write
+// becomes durable via the background syncer within durabilitySyncInterval
+// instead (#1573 Wall 1). Use ONLY for pure-namespace/attr writes
+// (create/remove/rename/mkdir/mode/owner/times) that are not paired with block
+// data. NEVER use it for file-size, block-manifest, or rollup-offset writes —
+// those are data-paired and must stay synchronous (WithTransaction) or #588
+// silent-zeros can recur. In strict mode this is identical to WithTransaction.
+func (s *BadgerMetadataStore) WithTransactionRelaxed(ctx context.Context, fn func(tx metadata.Transaction) error) error {
+	return s.withTransaction(ctx, fn, false)
+}
+
+// withTransaction is the shared retry/commit loop. When durable is true and the
+// store runs relaxed (SyncWrites=false), it fsyncs after a successful commit so
+// data-paired writes survive a crash; when durable is false it relies on the
+// background syncer. In strict mode (SyncWrites=true) the flag is moot — every
+// commit already fsynced — so both paths behave identically.
+func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx metadata.Transaction) error, durable bool) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -126,6 +147,14 @@ func (s *BadgerMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 			}
 			// Apply per-identity usage deltas once, after commit.
 			s.applyQuotaDelta(quotaDelta)
+			// Durable (data-paired) commit in relaxed mode: fsync now so the
+			// write survives a crash. A sync failure must not falsely ack a
+			// durable write (#588), so surface it. No-op in strict mode.
+			if durable {
+				if syncErr := s.syncIfRelaxed(); syncErr != nil {
+					return fmt.Errorf("badger WithTransaction: durability sync after commit: %w", syncErr)
+				}
+			}
 			return nil // Success
 		}
 

--- a/pkg/metadata/store/postgres/config.go
+++ b/pkg/metadata/store/postgres/config.go
@@ -32,6 +32,15 @@ type PostgresMetadataStoreConfig struct {
 	PrepareStatements bool          `mapstructure:"prepare_statements"` // Default: true
 	AutoMigrate       bool          `mapstructure:"auto_migrate"`       // Default: false (manual control)
 	StatsCacheTTL     time.Duration `mapstructure:"stats_cache_ttl"`    // Default: 5s
+
+	// RelaxedDurability defers commit-time WAL flush for pure-namespace metadata
+	// writes via SET LOCAL synchronous_commit=off, honoring the same
+	// UNSTABLE-style tradeoff as badger's relaxed mode (#1573 Wall 1).
+	// Data-paired writes (file size, block manifest, rollup offset) keep the
+	// default synchronous_commit=on, so #588 silent-zeros cannot recur; a hard
+	// crash can lose only the last few async-committed namespace ops (Postgres
+	// never corrupts — WAL replay is consistent). Default false (strict).
+	RelaxedDurability bool `mapstructure:"relaxed_durability"`
 }
 
 // ApplyDefaults sets default values for unspecified configuration fields

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -105,9 +105,28 @@ func isRetryableError(err error) bool {
 // Connection acquisition has a timeout to prevent indefinite blocking when
 // the pool is exhausted under high concurrent load.
 func (s *PostgresMetadataStore) WithTransaction(ctx context.Context, fn func(tx metadata.Transaction) error) error {
+	return s.withTransaction(ctx, fn, false)
+}
+
+// WithTransactionRelaxed runs fn like WithTransaction but, when the store is
+// configured for relaxed durability, sets synchronous_commit=off for the
+// transaction so its commit does not wait for a WAL fsync (#1573 Wall 1). Use
+// ONLY for pure-namespace/attr writes not paired with block data. Data-paired
+// writes must use WithTransaction so their WAL is flushed synchronously (#588).
+// In strict mode this is identical to WithTransaction.
+func (s *PostgresMetadataStore) WithTransactionRelaxed(ctx context.Context, fn func(tx metadata.Transaction) error) error {
+	return s.withTransaction(ctx, fn, true)
+}
+
+func (s *PostgresMetadataStore) withTransaction(ctx context.Context, fn func(tx metadata.Transaction) error, relaxed bool) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+
+	// synchronous_commit=off is honored only for relaxed namespace writes AND
+	// only when the operator opted in. SET LOCAL is transaction-scoped, so it
+	// resets at COMMIT and never leaks across pooled connections.
+	relaxCommit := relaxed && s.config.RelaxedDurability
 
 	var lastErr error
 	for attempt := 0; attempt < maxTransactionRetries; attempt++ {
@@ -132,6 +151,17 @@ func (s *PostgresMetadataStore) WithTransaction(ctx context.Context, fn func(tx 
 					"constructing_conns", stats.ConstructingConns())
 			}
 			return err
+		}
+
+		// Relaxed namespace write: drop synchronous_commit for this transaction
+		// only. SET LOCAL is scoped to the tx and reset at COMMIT/ROLLBACK, so
+		// pooled connections are never left in an off state. A failure here is
+		// non-fatal — fall through to a fully-durable commit rather than abort.
+		if relaxCommit {
+			if _, serr := tx.Exec(ctx, "SET LOCAL synchronous_commit = off"); serr != nil {
+				s.logger.Warn("relaxed durability: SET LOCAL synchronous_commit failed; committing synchronously",
+					"error", serr)
+			}
 		}
 
 		ptx := &postgresTransaction{store: s, tx: tx}


### PR DESCRIPTION
## What

Wall 1 of #1573: single-thread metadata create/remove/rename was fsync-bound. Every metadata transaction fsynced (`SyncWrites=true`, forced by #583/#588), so serial namespace ops hit a hard floor (~168 ops/s on the bench VM).

This defers the per-transaction fsync for **pure-namespace** writes (create/remove/rename/mkdir/attr) to a bounded-lag background sync — the same UNSTABLE-style tradeoff #1584 took for the block append-log — while keeping every **data-paired** write synchronous.

## Why it's safe (can't regress #588 silent-zeros)

Metadata writes split cleanly:

- **Data-paired (stay synchronous):** file size on WRITE (`immediateCommitWrite`/`flushPendingWrite`), block manifest (`DefaultCommitBlock`), rollup offset (`SetRollupOffset`), truncate size (`SetFileAttributes`). Losing these while block data survives = silent zeros / truncation.
- **Pure namespace (deferred):** create/remove/rename/mkdir/rmdir + mode/owner/times/xattr. A crash loses only the op itself (file vanishes / reappears) — never corrupts data.

The default is safe-by-construction: `WithTransaction` stays fully durable; only the namespace hot paths opt into `WithTransactionRelaxed`. A forgotten/new data-paired write is therefore *slow*, never *corrupt*.

## Store-agnostic (badger + postgres)

Narrow optional `RelaxedTransactor` capability; stores without it fall back to fully-durable `WithTransaction`.

- **badger:** `SyncWrites=false` + explicit `db.Sync()` on the durable path + a 100ms bounded-lag background syncer.
- **postgres:** `SET LOCAL synchronous_commit = off` per relaxed txn (tx-scoped, no pooled-conn leak; PG never corrupts WAL).
- **memory / sqlite:** safe durable fallback.

**Relaxed by default** (shipped posture). Operators restore strict per-txn fsync with `relaxed_durability: false`.

## Prior art

Standard practice: ext4 journal commit (5s), NFS `async` export, JuiceFS via Redis `appendfsync everysec` (1s), ZFS txg (5s). Our ~100ms window is tighter, and unlike those we keep data-paired writes synchronous — sidestepping the ext4-2009 zero-length-file trap by construction.

## Consistency & performance validation

- **Full metadata conformance suite passes in relaxed mode** (`TestConformance_RelaxedDurability`) — every op reads back correctly with deferred fsyncs.
- **Durability-contract test** pins the classification: durable commits + `SetRollupOffset` fsync inline; relaxed commits do not; strict mode fsyncs via `SyncWrites`.
- **Reopen test** confirms a data-paired write survives close+reopen.
- **Bench** (`BenchmarkNamespaceCommit`): **3.9x** serial namespace-commit throughput locally (macOS fsync is weak — on a real-fsync disk the strict path is the ~168/s floor and relaxed runs at memtable speed, i.e. far larger).
- `go test -race ./pkg/metadata/...` green; `go vet` + `golangci-lint` clean.

## Notes

- Branches off `develop`; overlaps a few files with #1590 (Wall 2) — will rebase whichever lands second.
- True power-loss testing (vs process-crash) needs the bench VM / `dm-flakey` and is out of unit-test scope; the contract + conformance + documented backend semantics cover CI.

Closes #1573 (with #1590).