### PR TITLE
ci(health): check out repo before building develop-red alarm email

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -61,6 +61,12 @@ jobs:
       IS_RED: ${{ github.event.workflow_run.conclusion != 'success' }}
 
     steps:
+      # The alarm builds its email body from a committed Python script, so the
+      # repo must be on the runner. workflow_run has no implicit checkout.
+      - name: Check out repo
+        if: env.IS_RED == 'true'
+        uses: actions/checkout@v4
+
       - name: Ensure develop-red label exists
         if: env.IS_RED == 'true'
         env:


### PR DESCRIPTION
## Problem

The `develop-red alarm` workflow fails whenever it fires. The alarm job runs the committed `.github/scripts/ci_health_email.py` to build its email body, but `workflow_run`-triggered jobs get **no implicit checkout** — the repo is never on the runner, so the script is missing:

```
python3: can't open file '.../.github/scripts/ci_health_email.py': [Errno 2] No such file or directory
##[error]Process completed with exit code 2.
```

The green-path steps only hit the `gh` API, which is why this only surfaces when develop goes red — the alarm meant to notify us is itself broken.

Example failure: [run 28897173760](https://github.com/marmos91/dittofs/actions/runs/28897173760/job/85724593118).

## Fix

Add a guarded `actions/checkout@v4` as the first step of the `alarm` job (same `if: env.IS_RED == 'true'` guard as the steps that use the checked-out files). No checkout on the green path.