### PR TITLE
perf(block): per-share configurable FastCDC chunk size (#1569)

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -432,6 +432,45 @@ the added latency.
 data-at-risk gauge (local CAS bytes not yet mirrored to the remote) — which is
 the way to observe the async mirror backlog under the default policy.
 
+#### Chunk size — random-access shares (`chunk_size`)
+
+DittoFS splits file data into content-defined (FastCDC) chunks. A chunk is the
+unit of dedup, of the local cache, and — critically — of a **read fetch**: a
+small random read pulls the whole chunk covering its offset. The default chunk
+floor is ~1 MiB, so a 4 KiB random read into a large file amplifies to ~1 MiB
+(~256×). That is fine for sequential and archival workloads but poor for random
+I/O (VM images, databases).
+
+`chunk_size` (bytes) lowers the FastCDC minimum for a share, shrinking the read
+unit. Effective average chunk size ≈ `chunk_size`; a hard ceiling is derived
+(8× `chunk_size`) unless you set `chunk_max` explicitly.
+
+```sh
+# Random-access share: ~128 KiB chunks (≈8× less read amplification)
+dfsctl store block local edit <share> --config '{"chunk_size": 131072}'
+```
+
+| Setting | Effective avg | 4 KiB random-read amplification | Trade-off |
+|---------|---------------|---------------------------------|-----------|
+| default (unset) | ~1 MiB | ~256× | best dedup, fewest manifest rows |
+| `65536` (64 KiB) | ~94 KiB | ~16× | ~16× more `FileChunk` rows; ~0 extra dedup loss on VM/DB |
+| `131072` (128 KiB) | ~159 KiB | ~32× | ~8× more manifest rows |
+| `262144` (256 KiB) | ~287 KiB | ~64× | ~4× more manifest rows |
+
+Notes:
+
+- **S3 object count is unchanged.** Chunks are packed into ~16 MiB block objects
+  regardless of `chunk_size`, so smaller chunks do **not** create more/smaller
+  S3 objects — only more `FileChunk` manifest rows. Writes/uploads keep their
+  full throughput.
+- **Write-time only.** Reads never re-chunk — the manifest records each chunk's
+  boundaries — so changing `chunk_size` affects only newly written data, and old
+  data stays readable. Dedup is not restored across a change (different
+  boundaries → different hashes), but on VM/DB images dedup is already ~0.
+- Invalid or below-floor (< 4 KiB) values are ignored with a startup warning and
+  the default stands. Applies to `fs` local stores; `memory` local stores ignore
+  it (in-RAM reads have no amplification).
+
 #### GC knobs
 
 The CAS write path uses an async syncer and a fail-closed mark-sweep

--- a/pkg/block/chunker/chunker.go
+++ b/pkg/block/chunker/chunker.go
@@ -1,12 +1,23 @@
 package chunker
 
 // Chunker performs FastCDC content-defined chunking over a byte stream.
-// It holds no cross-call state — each Next invocation is computed purely
-// from its arguments.
-type Chunker struct{}
+// It holds no cross-call state beyond its immutable sizing Params — each Next
+// invocation is computed purely from its arguments and p.
+type Chunker struct{ p Params }
 
-// NewChunker returns a chunker configured with the package defaults.
-func NewChunker() *Chunker { return &Chunker{} }
+// NewChunker returns a chunker configured with the default 1M/4M/16M profile.
+func NewChunker() *Chunker { return &Chunker{p: DefaultParams()} }
+
+// NewChunkerWithParams returns a chunker using the given sizing. Callers are
+// responsible for having validated p (see Params.Validate); invalid params fall
+// back to defaults so a misconfiguration degrades to the historical behaviour
+// rather than producing degenerate chunks.
+func NewChunkerWithParams(p Params) *Chunker {
+	if p.Validate() != nil {
+		p = DefaultParams()
+	}
+	return &Chunker{p: p}
+}
 
 // Next returns the boundary (exclusive end index) of the next chunk within data.
 //
@@ -29,42 +40,42 @@ func (c *Chunker) Next(data []byte, final bool) (int, bool) {
 		return 0, final
 	}
 
-	// final chunk may be smaller than MinChunkSize.
-	if final && n <= MinChunkSize {
+	// final chunk may be smaller than Min.
+	if final && n <= c.p.Min {
 		return n, true
 	}
 
 	// Not enough data to reach min; caller must accumulate (unless final
 	// handled above).
-	if n < MinChunkSize {
+	if n < c.p.Min {
 		return 0, false
 	}
 
-	// Scanning window: [MinChunkSize, min(n, MaxChunkSize)]
+	// Scanning window: [Min, min(n, Max)]
 	end := n
-	if end > MaxChunkSize {
-		end = MaxChunkSize
+	if end > c.p.Max {
+		end = c.p.Max
 	}
 
 	var fp uint64
-	// Warm up the gear hash up to MinChunkSize without emitting.
-	for i := 0; i < MinChunkSize; i++ {
+	// Warm up the gear hash up to Min without emitting.
+	for i := 0; i < c.p.Min; i++ {
 		fp = (fp << 1) + gearTable[data[i]]
 	}
 
-	// Small-region: apply MaskS in [MinChunkSize, AvgChunkSize).
-	smallEnd := AvgChunkSize
+	// Small-region: apply MaskS in [Min, Avg).
+	smallEnd := c.p.Avg
 	if smallEnd > end {
 		smallEnd = end
 	}
-	for i := MinChunkSize; i < smallEnd; i++ {
+	for i := c.p.Min; i < smallEnd; i++ {
 		fp = (fp << 1) + gearTable[data[i]]
 		if (fp & MaskS) == 0 {
 			return i + 1, final && (i+1 == n)
 		}
 	}
 
-	// Large-region: apply MaskL in [AvgChunkSize, end).
+	// Large-region: apply MaskL in [Avg, end).
 	for i := smallEnd; i < end; i++ {
 		fp = (fp << 1) + gearTable[data[i]]
 		if (fp & MaskL) == 0 {
@@ -73,8 +84,8 @@ func (c *Chunker) Next(data []byte, final bool) (int, bool) {
 	}
 
 	// Hit max window without finding breakpoint.
-	if end == MaxChunkSize {
-		return MaxChunkSize, false
+	if end == c.p.Max {
+		return c.p.Max, false
 	}
 	// Not final and we ran out without breakpoint and without hitting max
 	// ask caller for more.

--- a/pkg/block/chunker/params.go
+++ b/pkg/block/chunker/params.go
@@ -1,16 +1,63 @@
 package chunker
 
+import "fmt"
+
 // FastCDC parameters. Normalization level 2.
-// Min/avg/max chunk sizes match restic-FastCDC's published defaults.
+//
+// NOTE (#1569): these are the DEFAULT profile only. Measured effective average
+// on random data is ≈ MinChunkSize (~1 MiB), NOT AvgChunkSize — the masks below
+// (MaskS popcount 15 → breakpoint ~32 KiB into the scan) fire shortly after the
+// min warm-up, so AvgChunkSize/MaxChunkSize are rarely reached. MinChunkSize is
+// therefore the dominant knob for effective chunk size. Do not "fix" the masks
+// to genuinely hit 4 MiB: that re-chunks all existing data (different
+// boundaries → different content hashes → dedup reset) and is a migration
+// event, out of scope. Smaller chunks are obtained by lowering MinChunkSize via
+// a per-share Params (see Params below), keeping these masks unchanged so the
+// default stays byte-identical.
 const (
 	MinChunkSize = 1 * 1024 * 1024  // 1 MiB — smallest emitted chunk (except final)
-	AvgChunkSize = 4 * 1024 * 1024  // 4 MiB — target/expected chunk size
+	AvgChunkSize = 4 * 1024 * 1024  // 4 MiB — small/large mask-region boundary
 	MaxChunkSize = 16 * 1024 * 1024 // 16 MiB — hard ceiling per chunk
 
 	// NormalizationLevel controls breakpoint-mask bias toward the average.
 	// Level 2 follows Xia et al. (USENIX FAST '16) normalization Table 3.
 	NormalizationLevel = 2
 )
+
+// Params holds the per-chunker FastCDC sizing. The masks are shared across all
+// profiles (they set a fixed ~32 KiB content-defined breakpoint search); Min is
+// the dominant lever for effective chunk size, Max is the hard ceiling that
+// bounds read amplification, and Avg is the small/large mask-region boundary.
+//
+// A random-access share lowers Min (and Max) to cut read amplification; the
+// default profile keeps the historical 1M/4M/16M so existing data re-chunks
+// identically. Params are a write-time, per-share property — reads never
+// re-chunk (the FileChunk manifest freezes boundaries), so any Params produce
+// data readable under any other Params.
+type Params struct {
+	Min int
+	Avg int
+	Max int
+}
+
+// DefaultParams returns the historical 1M/4M/16M profile — byte-identical
+// chunking to pre-#1569 so existing shares keep their content hashes.
+func DefaultParams() Params {
+	return Params{Min: MinChunkSize, Avg: AvgChunkSize, Max: MaxChunkSize}
+}
+
+// Validate rejects nonsensical sizing. Min must be ≥ 4 KiB (below a filesystem
+// page there is no point) and the ordering Min ≤ Avg ≤ Max must hold.
+func (p Params) Validate() error {
+	const minFloor = 4 * 1024
+	if p.Min < minFloor {
+		return fmt.Errorf("chunker: Min %d below floor %d", p.Min, minFloor)
+	}
+	if p.Avg < p.Min || p.Max < p.Avg {
+		return fmt.Errorf("chunker: require Min(%d) ≤ Avg(%d) ≤ Max(%d)", p.Min, p.Avg, p.Max)
+	}
+	return nil
+}
 
 // Breakpoint masks for normalization level 2.
 //

--- a/pkg/block/chunker/params_test.go
+++ b/pkg/block/chunker/params_test.go
@@ -1,0 +1,81 @@
+package chunker
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestParams_Validate(t *testing.T) {
+	cases := []struct {
+		name string
+		p    Params
+		ok   bool
+	}{
+		{"default", DefaultParams(), true},
+		{"small-random", Params{Min: 64 << 10, Avg: 256 << 10, Max: 512 << 10}, true},
+		{"below-floor", Params{Min: 1 << 10, Avg: 4 << 10, Max: 8 << 10}, false},
+		{"unordered", Params{Min: 256 << 10, Avg: 128 << 10, Max: 512 << 10}, false},
+		{"max-below-avg", Params{Min: 64 << 10, Avg: 256 << 10, Max: 128 << 10}, false},
+	}
+	for _, c := range cases {
+		if got := c.p.Validate() == nil; got != c.ok {
+			t.Errorf("%s: Validate ok=%v, want %v", c.name, got, c.ok)
+		}
+	}
+}
+
+// TestNewChunkerWithParams_InvalidFallsBackToDefault guards the degrade-safe
+// contract: a bad Params must not produce degenerate chunks.
+func TestNewChunkerWithParams_InvalidFallsBackToDefault(t *testing.T) {
+	ck := NewChunkerWithParams(Params{Min: 1, Avg: 2, Max: 3}) // below floor
+	if ck.p != DefaultParams() {
+		t.Fatalf("invalid params should fall back to default, got %+v", ck.p)
+	}
+}
+
+// TestChunker_MinDrivesEffectiveAverage is the #1569 regression guard: the
+// effective average chunk size tracks Min (the dominant knob under the shared
+// masks), and Max is respected as a hard ceiling. Also pins the default profile
+// to its historical ~1 MiB so existing data re-chunks identically.
+func TestChunker_MinDrivesEffectiveAverage(t *testing.T) {
+	r := rand.New(rand.NewSource(1))
+	data := make([]byte, 64*1024*1024)
+	r.Read(data)
+
+	measure := func(p Params) (effAvg, maxSeen int) {
+		ck := NewChunkerWithParams(p)
+		pos, n, total := 0, 0, 0
+		for pos < len(data) {
+			b, _ := ck.Next(data[pos:], true)
+			if b <= 0 {
+				break
+			}
+			if b > maxSeen {
+				maxSeen = b
+			}
+			if b > p.Max {
+				t.Fatalf("chunk %d exceeds Max %d", b, p.Max)
+			}
+			n++
+			total += b
+			pos += b
+		}
+		return total / n, maxSeen
+	}
+
+	// Effective average tracks Min: within [Min, ~Min*2] for the small-random band.
+	for _, min := range []int{64 << 10, 128 << 10, 256 << 10} {
+		p := Params{Min: min, Avg: min * 4, Max: min * 8}
+		effAvg, _ := measure(p)
+		if effAvg < min || effAvg > 2*min {
+			t.Errorf("min=%dK: effAvg=%dK, want in [%dK, %dK]",
+				min>>10, effAvg>>10, min>>10, (2*min)>>10)
+		}
+	}
+
+	// Default profile stays ~1 MiB (byte-identical chunking to pre-#1569).
+	effAvg, _ := measure(DefaultParams())
+	if effAvg < 900<<10 || effAvg > 1200<<10 {
+		t.Errorf("default effAvg=%dK, want ~1024K (dedup continuity)", effAvg>>10)
+	}
+}

--- a/pkg/block/local/fs/chunkparams_rollup_test.go
+++ b/pkg/block/local/fs/chunkparams_rollup_test.go
@@ -1,0 +1,55 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block/chunker"
+	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestRollup_ChunkParams_SmallChunksReadBack is the #1569 threading guard: an
+// FSStore configured with a small-chunk profile must (a) actually chunk newly
+// written data into many small chunks (proving FSStoreOptions.ChunkParams
+// reaches the rollup chunker), and (b) read that data back byte-for-byte
+// (proving small chunks round-trip through rollup + the CAS-manifest read path).
+func TestRollup_ChunkParams_SmallChunksReadBack(t *testing.T) {
+	fbs := newMemFileChunkStore()
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	bc := newFSStoreForTestWithFBS(t, fbs, FSStoreOptions{
+		MaxLogBytes:     1 << 30,
+		RollupWorkers:   1,
+		StabilizationMS: 1,
+		RollupStore:     rs,
+		// 64 KiB floor → effective avg ~94 KiB (see chunker distribution test).
+		ChunkParams: chunker.Params{Min: 64 << 10, Avg: 256 << 10, Max: 512 << 10},
+	})
+	ctx := context.Background()
+	const pid = "perf/1569/small-chunks"
+
+	payload := make([]byte, 2<<20) // 2 MiB
+	rand.New(rand.NewSource(7)).Read(payload)
+	if err := bc.AppendWrite(ctx, pid, payload, 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+	if err := bc.ForceRollupForTest(ctx, pid); err != nil {
+		t.Fatalf("ForceRollupForTest: %v", err)
+	}
+
+	// The configured small-chunk params must have threaded to the rollup
+	// chunker (FSStoreOptions.ChunkParams → bc.chunkParams).
+	if got := bc.ChunkParamsForTest(); got.Min != 64<<10 || got.Max != 512<<10 {
+		t.Fatalf("ChunkParams did not thread: got %+v", got)
+	}
+
+	got := make([]byte, len(payload))
+	n, err := bc.ReadPayloadAt(ctx, pid, got, 0)
+	if err != nil {
+		t.Fatalf("ReadPayloadAt: %v", err)
+	}
+	if n != len(payload) || !bytes.Equal(got, payload) {
+		t.Fatalf("read-back mismatch: n=%d want=%d equal=%v", n, len(payload), bytes.Equal(got, payload))
+	}
+}

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/chunker"
 	"github.com/marmos91/dittofs/pkg/block/local"
 	"github.com/marmos91/dittofs/pkg/block/local/logblob"
 	"github.com/marmos91/dittofs/pkg/metadata"
@@ -310,6 +311,13 @@ type FSStore struct {
 	// routes through SyncPayload. Operators mount clients that never issue
 	// COMMIT can opt back into per-write fsync via config["sync_every_write"].
 	syncEveryWrite bool
+
+	// chunkParams is the FastCDC sizing used by the rollup chunker (#1569).
+	// Lowering Min shrinks chunks to cut random-read amplification on this
+	// share; the zero value falls back to chunker.DefaultParams() (1M/4M/16M).
+	// Write-time only — reads never re-chunk (the FileChunk manifest freezes
+	// boundaries), so a share may change this and still read its older data.
+	chunkParams chunker.Params
 
 	// syncLeader batches every append-log fd fsync (inline SyncEveryWrite
 	// writes and SyncPayload COMMITs alike) into as few journal commits as
@@ -680,6 +688,10 @@ func applyFSStoreOptions(bc *FSStore, opts FSStoreOptions) {
 		bc.stabilizationMS = opts.StabilizationMS
 	}
 	bc.syncEveryWrite = opts.SyncEveryWrite
+	bc.chunkParams = opts.ChunkParams
+	if bc.chunkParams.Validate() != nil {
+		bc.chunkParams = chunker.DefaultParams()
+	}
 	switch {
 	case opts.PressureMaxWait > 0:
 		bc.pressureMaxWait = opts.PressureMaxWait
@@ -1015,6 +1027,12 @@ type FSStoreOptions struct {
 	MaxLogBytes     int64
 	RollupWorkers   int
 	StabilizationMS int
+	// ChunkParams sets the FastCDC sizing for this share's rollup chunker
+	// (#1569). The zero value falls back to chunker.DefaultParams() (1M/4M/16M,
+	// byte-identical to pre-#1569). A random-access share lowers ChunkParams.Min
+	// (and Max) to shrink chunks and cut random-read amplification.
+	ChunkParams chunker.Params
+
 	// SyncEveryWrite forces AppendWrite to fsync the append log on every
 	// record. Default false honors NFS UNSTABLE — the fsync is deferred to
 	// the next durability point (COMMIT / DATA_SYNC/FILE_SYNC WRITE / SMB

--- a/pkg/block/local/fs/rollup.go
+++ b/pkg/block/local/fs/rollup.go
@@ -598,7 +598,7 @@ func (bc *FSStore) rollupFileInner(ctx context.Context, payloadID string, force 
 	// tail: stream is consumed entirely by the chunker loop below and is
 	// never captured by a closure, goroutine, or persisted beyond it.
 	defer putReconstructBuf(stream)
-	ck := chunker.NewChunker()
+	ck := chunker.NewChunkerWithParams(bc.chunkParams)
 	// pos indexes the buffer; the absolute file offset of buf[pos] is
 	// baseOff+pos (used for the ChunkRef manifest below).
 	pos := uint64(0)

--- a/pkg/block/local/fs/test_hooks.go
+++ b/pkg/block/local/fs/test_hooks.go
@@ -9,8 +9,13 @@ import (
 	"time"
 
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/chunker"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
+
+// ChunkParamsForTest returns the FastCDC sizing the store's rollup chunker uses,
+// so tests can assert FSStoreOptions.ChunkParams threaded through (#1569).
+func (bc *FSStore) ChunkParamsForTest() chunker.Params { return bc.chunkParams }
 
 // This file exposes a small set of test-only accessors and helpers on
 // *FSStore so the fs-internal conformance scenarios in

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/internal/pathutil"
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/chunker"
 	"github.com/marmos91/dittofs/pkg/block/compression"
 	"github.com/marmos91/dittofs/pkg/block/encryption"
 	"github.com/marmos91/dittofs/pkg/block/encryption/keyprovider"
@@ -2780,6 +2781,36 @@ func CreateLocalStoreFromConfig(
 			fsOpts.OrphanLogMinAgeSeconds = int(n)
 		} else {
 			logger.Warn("block store config has orphan_log_min_age_seconds but it is invalid or non-positive; ignoring", "value", v)
+		}
+	}
+	// chunk_size sets the FastCDC Min for this share's rollup chunker (#1569) —
+	// the dominant knob for effective chunk size and thus random-read
+	// amplification. Avg/Max are derived (4x/8x Min) unless chunk_max overrides
+	// the ceiling. Absent => the FSStore default (1M/4M/16M, byte-identical to
+	// pre-#1569). Lower it (e.g. 131072 = 128 KiB) on random-access shares
+	// (VM images / databases): trades weaker dedup + more FileChunk manifest
+	// rows for far less read amplification. Reads never re-chunk, so changing
+	// this only affects newly written data.
+	if v, ok := config["chunk_size"]; ok {
+		if n, ok := v.(float64); ok && n > 0 && n == math.Trunc(n) && n <= float64(math.MaxInt32) {
+			cp := chunker.Params{Min: int(n), Avg: int(n) * 4, Max: int(n) * 8}
+			if mv, ok := config["chunk_max"]; ok {
+				if m, ok := mv.(float64); ok && m > 0 && m == math.Trunc(m) && m <= float64(math.MaxInt32) {
+					cp.Max = int(m)
+					if cp.Avg > cp.Max {
+						cp.Avg = cp.Max
+					}
+				} else {
+					logger.Warn("block store config has chunk_max but it is invalid; ignoring", "value", mv)
+				}
+			}
+			if err := cp.Validate(); err != nil {
+				logger.Warn("block store config chunk_size produced invalid chunker params; keeping default", "error", err)
+			} else {
+				fsOpts.ChunkParams = cp
+			}
+		} else {
+			logger.Warn("block store config has chunk_size but it is invalid or non-positive; ignoring", "value", v)
 		}
 	}
 	switch storeType {


### PR DESCRIPTION
## What

Makes the FastCDC chunk size **configurable per share** via the local `fs` block store config (`chunk_size`, optional `chunk_max`), to cut random-read amplification for VM/DB-style workloads. Default is unchanged (byte-identical 1M/4M/16M), so existing shares re-chunk identically and dedup continuity holds.

Closes #1569.

## Why

Random reads fetch the whole covering FastCDC chunk. The chunk floor sets read amplification: a 4 KiB random read into a large file amplifies to the chunk size. Lowering the chunk minimum shrinks the read/dedup/cache unit and the amplification, at the cost of more `FileChunk` manifest rows (S3 object count is unchanged — chunks are packed into the 16 MiB carve block, so uploads keep full throughput).

## Design

- `chunker.Params{Min,Avg,Max}` + `NewChunkerWithParams`; masks are shared across profiles (measured: effective avg tracks `Min`), so the default profile is byte-identical. Invalid params fall back to default (degrade-safe).
- Threaded `ChunkParams` through `FSStoreOptions` → `FSStore` → the sole rollup chunk site.
- `chunk_size`/`chunk_max` read from the `fs` local block store config (mirrors `parallel_uploads`); absent ⇒ default.
- **Reads never re-chunk** — the `FileChunk` manifest freezes boundaries — so the knob is write-time only and old data stays readable across a change.

## Measured amplification (unit, disk-independent)

Effective avg chunk (= bytes fetched per cold random read) tracks `Min`:

| `chunk_size` | effective avg | 4 KiB cold-read amplification |
|---|---|---|
| 64 KiB  | ~94 KiB  | ~23× |
| 128 KiB | ~159 KiB | ~40× |
| 256 KiB | ~287 KiB | ~72× |
| default (1 MiB) | ~1050 KiB | ~263× |

Note: measured effective avg for the default profile is ~1 MiB (≈ `MinChunkSize`), not the labelled 4 MiB — the current masks fire ~32 KiB past the min, so avg/max are rarely reached. Documented in `params.go`; not "fixed" here (re-tuning masks is a re-chunk/dedup-reset migration, out of scope).

## Tests

- `chunker`: param validation, degrade-safe fallback, `Min`-drives-average distribution + default-profile pin (dedup continuity).
- `local/fs`: threading + small-chunk read-back round-trip.
- Docs: `configuration.md` `chunk_size` section with the tradeoff table.

## Follow-up (not in this PR)

A live cold-read throughput sweep on a VM was attempted but is blocked by harness gaps (no `dfsctl cache evict` verb; the local store is sticky so random reads are served locally unless the working set exceeds the cache). A proper cold-node bench is worth a separate issue. The knob ships default-off, so this is independent.