### PR TITLE
fix(block): drain resident synced local blocks on demand (#1595)

### DIFF
--- a/bench/scripts/run-all.sh
+++ b/bench/scripts/run-all.sh
@@ -257,15 +257,19 @@ evict_dittofs_cache() {
         *) return 0 ;;
     esac
 
-    log "[${name}] Evicting DittoFS server-side cache via dfsctl..."
+    log "[${name}] Evicting DittoFS local block tier (read buffer + resident blobs) via dfsctl..."
 
     if $DRY_RUN; then
-        log "[DRY-RUN] Would SSH to server and run: dfsctl cache evict"
+        log "[DRY-RUN] Would SSH to server and run: dfsctl store block evict"
         return 0
     fi
 
-    if ! ssh_server "dfsctl cache evict -v" 2>&1; then
-        log "WARN: dfsctl cache evict failed (server cache may still be warm)"
+    # Drops the in-memory read buffer AND drains the resident local blocks that
+    # are already synced to the remote, so subsequent reads must fetch from S3
+    # (the cold-read path this benchmark measures). Synced-only: never loses
+    # not-yet-uploaded data. Replaces the removed `dfsctl cache evict`.
+    if ! ssh_server "dfsctl store block evict -v" 2>&1; then
+        log "WARN: dfsctl store block evict failed (local blocks may still be resident → reads served locally)"
     fi
 }
 

--- a/cmd/dfsctl/commands/store/block/evict.go
+++ b/cmd/dfsctl/commands/store/block/evict.go
@@ -13,18 +13,29 @@ import (
 var evictCmd = &cobra.Command{
 	Use:   "evict",
 	Short: "Evict block store data",
-	Long: `Evict block store data from local storage.
+	Long: `Evict block store data from local storage, forcing subsequent reads
+to fetch from the remote (S3) tier.
 
-By default, evicts both read buffer and local disk data for all shares.
+By default, evicts both the in-memory read buffer and the resident local
+disk blocks for all shares. Local eviction drains every locally-resident
+block whose bytes are already synced to the remote — including the sealed
+log blobs that hold the bulk of resident data after a rollup, which the
+lazy --local-store-size cap only reclaims on the write path. Blocks not yet
+uploaded to the remote are never dropped.
+
 Use --read-buffer-only to evict only the read buffer (in-memory).
 Use --local-only to evict only local disk data (preserves read buffer).
 Use --share to evict a specific share only.
 
-Safety: Eviction of local blocks is refused if no remote store is
+Safety: eviction of local blocks is refused if no remote store is
 configured for a share, since that would cause data loss.
 
+Uses: reclaim local disk on demand, or force cold (remote-served) reads for
+read-path benchmarking — the local tier is otherwise sticky, so a benchmark
+would measure locally-served reads.
+
 Examples:
-  # Evict all storage tiers for all shares
+  # Evict all storage tiers for all shares (drops resident local blocks)
   dfsctl store block evict
 
   # Evict only read buffer

--- a/cmd/dfsctl/commands/store/block/evict.go
+++ b/cmd/dfsctl/commands/store/block/evict.go
@@ -14,7 +14,7 @@ var evictCmd = &cobra.Command{
 	Use:   "evict",
 	Short: "Evict block store data",
 	Long: `Evict block store data from local storage, forcing subsequent reads
-to fetch from the remote (S3) tier.
+to fetch from the remote tier.
 
 By default, evicts both the in-memory read buffer and the resident local
 disk blocks for all shares. Local eviction drains every locally-resident

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -5512,7 +5512,7 @@ Global flags:
 Evict block store data
 
 Evict block store data from local storage, forcing subsequent reads
-to fetch from the remote (S3) tier.
+to fetch from the remote tier.
 
 By default, evicts both the in-memory read buffer and the resident local
 disk blocks for all shares. Local eviction drains every locally-resident

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -5511,15 +5511,26 @@ Global flags:
 
 Evict block store data
 
-Evict block store data from local storage.
+Evict block store data from local storage, forcing subsequent reads
+to fetch from the remote (S3) tier.
 
-By default, evicts both read buffer and local disk data for all shares.
+By default, evicts both the in-memory read buffer and the resident local
+disk blocks for all shares. Local eviction drains every locally-resident
+block whose bytes are already synced to the remote — including the sealed
+log blobs that hold the bulk of resident data after a rollup, which the
+lazy --local-store-size cap only reclaims on the write path. Blocks not yet
+uploaded to the remote are never dropped.
+
 Use --read-buffer-only to evict only the read buffer (in-memory).
 Use --local-only to evict only local disk data (preserves read buffer).
 Use --share to evict a specific share only.
 
-Safety: Eviction of local blocks is refused if no remote store is
+Safety: eviction of local blocks is refused if no remote store is
 configured for a share, since that would cause data loss.
+
+Uses: reclaim local disk on demand, or force cold (remote-served) reads for
+read-path benchmarking — the local tier is otherwise sticky, so a benchmark
+would measure locally-served reads.
 
 ```
 dfsctl store block evict [flags]
@@ -5528,7 +5539,7 @@ dfsctl store block evict [flags]
 **Examples:**
 
 ```bash
-# Evict all storage tiers for all shares
+# Evict all storage tiers for all shares (drops resident local blocks)
 dfsctl store block evict
 
 # Evict only read buffer

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -591,7 +591,7 @@ filling the host volume, the local cache is bounded and writes apply
   demand with `dfsctl store block evict` (drops the read buffer and drains
   resident synced blocks; never drops not-yet-uploaded data). Remote read-miss
   volume (the read-amplification signal) is observable via the
-  `datapath_block_range_read_bytes_total` metric.
+  `dittofs_datapath_block_range_read_bytes_total` metric.
 - **Backpressure stall.** When the cache is full and every cached chunk is
   still unsynced, a write **stalls** waiting for the syncer to drain to the
   remote and free space, rather than failing. The stall is bounded by

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -583,7 +583,15 @@ filling the host volume, the local cache is bounded and writes apply
   `blockstore.local.default_remote_cache_size` (default **10 GiB**). An
   explicit `--local-store-size` always wins. **Local-only shares are
   unaffected** — they keep their existing system-deduced local size and never
-  apply remote-cache backpressure.
+  apply remote-cache backpressure. The cap is enforced **lazily, on the
+  write/rollup path** (it evicts synced blocks to make room for new writes); it
+  is **not** a background reaper, so on an idle or read-only workload the
+  resident local tier is not shrunk toward the cap. To reclaim local disk — or
+  to force cold, remote-served reads for read-path benchmarking — evict on
+  demand with `dfsctl store block evict` (drops the read buffer and drains
+  resident synced blocks; never drops not-yet-uploaded data). Remote read-miss
+  volume (the read-amplification signal) is observable via the
+  `datapath_block_range_read_bytes_total` metric.
 - **Backpressure stall.** When the cache is full and every cached chunk is
   still unsynced, a write **stalls** waiting for the syncer to drain to the
   remote and free space, rather than failing. The stall is bounded by

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -839,6 +839,20 @@ func (bs *Store) EvictLocal(ctx context.Context, payloadID string) error {
 	return bs.local.DeleteAppendLog(ctx, payloadID)
 }
 
+// DrainLocalSynced evicts every locally-resident block already durable on the
+// remote, returning the bytes freed. Unlike EvictLocal (which clears per-file
+// append-log/memory state and whose ListFiles source goes empty after rollup),
+// this reclaims the sealed log-blob tier that holds the bulk of resident bytes
+// post-rollup — the on-demand path the shares evict admin uses to force reads
+// back onto the remote. Never drops unsynced (remote-missing) data.
+func (bs *Store) DrainLocalSynced(ctx context.Context) (int64, error) {
+	if err := bs.enter(); err != nil {
+		return 0, err
+	}
+	defer bs.closeMu.RUnlock()
+	return bs.local.DrainLocalSynced(ctx)
+}
+
 // WarmAll proactively fetches every remote block of every payload in this
 // share onto the local CAS tier, delegating to the syncer's WarmAll under the
 // store's close-gate so a concurrent Close drains the run instead of racing

--- a/pkg/block/local/fs/eviction.go
+++ b/pkg/block/local/fs/eviction.go
@@ -623,6 +623,58 @@ func (bc *FSStore) relocateSurvivors(ctx context.Context, oldBlobID string, surv
 // worker; the next pass retries after the syncer has drained more chunks.
 // Serialized via blobReclaimActive so concurrent rollup workers do not
 // stampede; losers skip (the winner is already draining to the limit).
+// DrainLocalSynced evicts every locally-resident block whose bytes are already
+// durable on the remote, on demand — the operator-triggered counterpart to
+// reclaimSpace (which runs only on the write/rollup path and only down to
+// maxDisk). It drives the same CAS-LRU → sealed-blob → compaction ladder to
+// exhaustion, ignoring the maxDisk cap and the pin / eviction-disabled *policy*
+// gates: this is an explicit "evict local now" command, not automatic pressure.
+//
+// Data safety is unconditional and independent of those gates: blobEvictOne
+// drops only fully-synced blobs and compactBlobOne relocates a blob's unsynced
+// survivors before reclaiming its dead space, so unsynced (remote-missing)
+// bytes are never lost. EvictBlockStore refuses to call this without a remote
+// store for that reason. Returns the total bytes freed.
+func (bc *FSStore) DrainLocalSynced(ctx context.Context) (int64, error) {
+	var total int64
+	for {
+		if ctx.Err() != nil {
+			return total, ctx.Err()
+		}
+		if freed, err := bc.lruEvictOne(ctx); err == nil {
+			bc.subUsed(&bc.diskUsed, freed, "cas")
+			total += freed
+			continue
+		} else if !errors.Is(err, errLRUEmpty) {
+			return total, fmt.Errorf("drain local synced: %w", err)
+		}
+		bfreed, err := bc.blobEvictOne(ctx)
+		if err != nil {
+			if !errors.Is(err, errLRUEmpty) {
+				return total, fmt.Errorf("drain local synced: %w", err)
+			}
+			// No fully-synced blob to drop whole. Compact a blob pinned by
+			// unsynced survivors (#1497); stop when nothing more can be freed.
+			cfreed, cerr := bc.compactBlobOne(ctx)
+			if cerr != nil {
+				if !errors.Is(cerr, errLRUEmpty) {
+					return total, fmt.Errorf("drain local synced: %w", cerr)
+				}
+				return total, nil
+			}
+			if cfreed == 0 {
+				return total, nil
+			}
+			total += cfreed
+			continue
+		}
+		if bfreed == 0 {
+			return total, nil
+		}
+		total += bfreed
+	}
+}
+
 func (bc *FSStore) reclaimSpace(ctx context.Context) {
 	if bc.maxDisk <= 0 || !bc.evictionEnabled.Load() {
 		return

--- a/pkg/block/local/fs/eviction_drain_test.go
+++ b/pkg/block/local/fs/eviction_drain_test.go
@@ -1,0 +1,113 @@
+package fs
+
+// Tests for DrainLocalSynced (#1595): the on-demand counterpart to reclaimSpace.
+// reclaimSpace only frees blob bytes on the write/rollup path and only down to
+// maxDisk, so with no disk pressure a sealed, fully-synced blob stays resident
+// forever — the "sticky local store" that made the live-VM read-path sweep
+// unmeasurable (reads served locally, s3_rx ≈ 0). DrainLocalSynced frees those
+// blobs on demand while never dropping unsynced (remote-missing) bytes.
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestDrainLocalSynced_FreesSealedSyncedBlobOnDemand is the headline: maxDisk=0
+// means reclaimSpace/ensureSpace never fire, so a sealed fully-synced blob is
+// sticky. DrainLocalSynced must still evict it on demand, dropping DiskUsed to 0
+// and routing subsequent reads to the remote refetch path (ErrChunkNotFound).
+func TestDrainLocalSynced_FreesSealedSyncedBlobOnDemand(t *testing.T) {
+	dir := t.TempDir()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc := newBlobStoreWithLimit(t, dir, 0, mds) // 0 = no maxDisk cap → no auto-eviction
+	ctx := context.Background()
+
+	a := bytes.Repeat([]byte{0xA1}, 400)
+	b := bytes.Repeat([]byte{0xA2}, 350)
+	aH, bH := blake3ContentHash(a), blake3ContentHash(b)
+	for _, kv := range []struct {
+		h block.ContentHash
+		d []byte
+	}{{aH, a}, {bH, b}} {
+		if err := bc.StoreChunk(ctx, kv.h, kv.d); err != nil {
+			t.Fatalf("StoreChunk: %v", err)
+		}
+		if err := mds.MarkSynced(ctx, kv.h, block.ChunkLocator{}); err != nil {
+			t.Fatalf("MarkSynced: %v", err)
+		}
+	}
+	if err := bc.logBlob.Rotate(); err != nil { // seal so the blob is evictable
+		t.Fatalf("Rotate: %v", err)
+	}
+	if got := bc.Stats().DiskUsed; got != 750 {
+		t.Fatalf("DiskUsed before drain = %d, want 750", got)
+	}
+
+	freed, err := bc.DrainLocalSynced(ctx)
+	if err != nil {
+		t.Fatalf("DrainLocalSynced: %v", err)
+	}
+	if freed != 750 {
+		t.Fatalf("DrainLocalSynced freed = %d, want 750", freed)
+	}
+	if got := bc.Stats().DiskUsed; got != 0 {
+		t.Fatalf("DiskUsed after drain = %d, want 0 (fully drained)", got)
+	}
+	for _, h := range []block.ContentHash{aH, bH} {
+		if _, err := bc.ReadChunk(ctx, h); !errors.Is(err, block.ErrChunkNotFound) {
+			t.Fatalf("ReadChunk after drain = %v, want ErrChunkNotFound (routes to remote refetch)", err)
+		}
+	}
+
+	// Idempotent: nothing left evictable → frees 0, no error.
+	if freed, err := bc.DrainLocalSynced(ctx); err != nil || freed != 0 {
+		t.Fatalf("second DrainLocalSynced = (%d, %v), want (0, nil)", freed, err)
+	}
+}
+
+// TestDrainLocalSynced_KeepsUnsyncedSurvivor pins the data-safety invariant: a
+// sealed blob mixing synced (evictable) and unsynced (only copy) chunks is
+// drained via compaction — the synced remainder is reclaimed, the unsynced
+// survivor is relocated and stays readable, never lost.
+func TestDrainLocalSynced_KeepsUnsyncedSurvivor(t *testing.T) {
+	dir := t.TempDir()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc := newBlobStoreWithLimit(t, dir, 0, mds)
+	ctx := context.Background()
+
+	synced := bytes.Repeat([]byte{0xC1}, 400)
+	syncedH := blake3ContentHash(synced)
+	unsynced := bytes.Repeat([]byte{0xD0}, 100)
+	unsyncedH := blake3ContentHash(unsynced)
+	if err := bc.StoreChunk(ctx, syncedH, synced); err != nil {
+		t.Fatalf("StoreChunk(synced): %v", err)
+	}
+	if err := mds.MarkSynced(ctx, syncedH, block.ChunkLocator{}); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+	if err := bc.StoreChunk(ctx, unsyncedH, unsynced); err != nil {
+		t.Fatalf("StoreChunk(unsynced): %v", err)
+	}
+	if err := bc.logBlob.Rotate(); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+
+	if freed, err := bc.DrainLocalSynced(ctx); err != nil || freed <= 0 {
+		t.Fatalf("DrainLocalSynced = (%d, %v), want (>0, nil)", freed, err)
+	}
+	// Only the relocated unsynced survivor remains resident.
+	if got := bc.Stats().DiskUsed; got != 100 {
+		t.Fatalf("DiskUsed after drain = %d, want 100 (unsynced survivor only)", got)
+	}
+	if got, err := bc.ReadChunk(ctx, unsyncedH); err != nil || !bytes.Equal(got, unsynced) {
+		t.Fatalf("unsynced survivor lost/corrupted after drain: err=%v", err)
+	}
+	if _, err := bc.ReadChunk(ctx, syncedH); !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("ReadChunk(drained synced) = %v, want ErrChunkNotFound", err)
+	}
+}

--- a/pkg/block/local/local.go
+++ b/pkg/block/local/local.go
@@ -154,6 +154,13 @@ type LocalStore interface {
 	// file.
 	EvictMemory(ctx context.Context, payloadID string) error
 
+	// DrainLocalSynced evicts every locally-resident block whose bytes are
+	// already durable on the remote, on demand, returning the bytes freed.
+	// Unsynced (remote-missing) blocks are never dropped. Used by the
+	// block-store evict admin path to force reads back onto the remote (e.g.
+	// cold-read benchmarking). A backend with no evictable local tier returns 0.
+	DrainLocalSynced(ctx context.Context) (int64, error)
+
 	// ListFiles returns the payloadIDs of all files currently tracked
 	// in the local store.
 	ListFiles() []string

--- a/pkg/block/local/memory/memory.go
+++ b/pkg/block/local/memory/memory.go
@@ -592,6 +592,11 @@ func (s *MemoryStore) EvictMemory(_ context.Context, payloadID string) error {
 // process lifetime), so the toggle is a no-op.
 func (s *MemoryStore) SetEvictionEnabled(_ bool) {}
 
+// DrainLocalSynced satisfies local.LocalStore. The in-memory backend has no
+// sealed-blob tier to reclaim (chunks live for the process lifetime), so there
+// is nothing to drain on demand.
+func (s *MemoryStore) DrainLocalSynced(_ context.Context) (int64, error) { return 0, nil }
+
 // SetRetentionPolicy is a no-op in the memory store (memory store doesn't do eviction).
 func (s *MemoryStore) SetRetentionPolicy(_ block.RetentionPolicy, _ time.Duration) {}
 

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -2567,6 +2567,15 @@ func (s *Service) EvictBlockStore(ctx context.Context, shareName string, opts Ev
 				result.LocalFilesEvicted++
 			}
 
+			// EvictLocal only clears per-file append-log/memory state, and
+			// ListFiles goes empty after rollup — so post-rollup the resident
+			// bytes live in sealed log blobs it never touches. Drain them now
+			// (synced-only; safe because the no-remote refusal above guarantees
+			// a remote copy exists) so reads fall back to the remote.
+			if _, err := bs.DrainLocalSynced(ctx); err != nil {
+				return nil, fmt.Errorf("drain local synced blocks for share %q: %w", share.Name, err)
+			}
+
 			result.BytesFreed += beforeDisk - bs.LocalStats().DiskUsed
 		}
 	}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -2572,11 +2572,17 @@ func (s *Service) EvictBlockStore(ctx context.Context, shareName string, opts Ev
 			// bytes live in sealed log blobs it never touches. Drain them now
 			// (synced-only; safe because the no-remote refusal above guarantees
 			// a remote copy exists) so reads fall back to the remote.
-			if _, err := bs.DrainLocalSynced(ctx); err != nil {
+			drained, err := bs.DrainLocalSynced(ctx)
+			if err != nil {
 				return nil, fmt.Errorf("drain local synced blocks for share %q: %w", share.Name, err)
 			}
 
-			result.BytesFreed += beforeDisk - bs.LocalStats().DiskUsed
+			// Report the larger of the observed DiskUsed delta (captures the
+			// EvictLocal loop plus the drain) and the drain's own freed count.
+			// The raw delta can go negative if a concurrent write grows DiskUsed
+			// mid-eviction; max with the non-negative drained count keeps
+			// BytesFreed honest and never negative.
+			result.BytesFreed += max(beforeDisk-bs.LocalStats().DiskUsed, drained)
 		}
 	}
 


### PR DESCRIPTION
## Problem

`dfsctl store block evict` is documented as the way to reclaim local disk and force cold (remote-served) reads, but its local-eviction path drives `bs.ListFiles()` → `EvictLocal`, and `ListFiles` **goes empty after a rollup**. Post-rollup the resident bytes live in **sealed log blobs**, which that path never touches — so nothing was freed.

Consequence (found validating #1569 on a live VM): the local store is **sticky**. Random reads over NFS were served entirely from local (`s3_rx ≈ 0` over 188 MiB of 4 KiB reads), so read-path perf work — chunk size (#1569), read-through cache — could not be measured. `--local-store-size` didn't help either: it's enforced lazily on the write/rollup path, not as a background reaper.

Closes #1595.

## Change

Add `DrainLocalSynced` (local `FSStore` + `engine.Store` passthrough + `LocalStore` interface; memory backend is a no-op — no blob tier). It runs the **same** evict ladder as the existing `reclaimSpace` (`lruEvictOne` → `blobEvictOne` → `compactBlobOne`) but:

- **to exhaustion** (not bounded by `maxDisk`), and
- **without the policy gates** (`maxDisk`/`RetentionPin`/`evictionEnabled`) — this is an explicit "evict now" admin op, not automatic pressure.

Wired into `EvictBlockStore` after the per-file loop. Then `dfsctl store block evict` truly drops the resident local tier and reads fall back to S3.

### Safety

Synced-only **by construction**, independent of the skipped policy gates:
- `blobEvictOne` evicts only fully-synced sealed blobs (oldest-first, stops at the first unsynced one);
- `compactBlobOne` relocates unsynced survivors (fsync-before-index-rewrite-before-drop) before reclaiming a blob's synced remainder;
- `lruEvictOne` refuses any CAS chunk it can't prove synced.

So not-yet-uploaded data is never dropped, and `EvictBlockStore` already refuses to drain a share with no remote store.

## Also

- Fix the dead `dfsctl cache evict` in `bench/scripts/run-all.sh` (that command was removed; the script silently WARNed and benchmarked a warm cache) → `dfsctl store block evict`.
- Document `--local-store-size` as lazy (write-path) enforcement + the on-demand evict; note the existing `datapath_block_range_read_bytes_total` metric as the read-amplification signal.
- Sharpen the `store block evict` help / regenerated `cli.md`.

## Tests

`TestDrainLocalSynced_FreesSealedSyncedBlobOnDemand` (sticky blob under `maxDisk=0` drained to 0, freed reads → `ErrChunkNotFound` → remote refetch, idempotent) and `TestDrainLocalSynced_KeepsUnsyncedSurvivor` (mixed blob: synced reclaimed, unsynced survivor relocated + still readable). Full `pkg/block/...` + `shares/...` suites green (1275 tests).