### PR TITLE
perf(s3): disable redundant SDK request/response checksums (#1466)

### DIFF
--- a/pkg/block/remote/s3/checksum_config_test.go
+++ b/pkg/block/remote/s3/checksum_config_test.go
@@ -1,0 +1,37 @@
+package s3
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+// TestNewFromConfig_DisablesSDKChecksums pins #1466: block content is
+// BLAKE3-verified end-to-end, so the S3 client must run with the aws-sdk-go-v2
+// flexible-checksum layer set to WhenRequired. Left at the SDK default
+// (WhenSupported) every PutObject is wrapped in an aws-chunked streaming-trailer
+// encoding with a full CRC32 pass over each ~16 MiB block — redundant CPU + wire
+// framing, and an interop friction point with non-AWS S3 endpoints. This guards
+// against a future SDK default change or an accidental removal of the option.
+func TestNewFromConfig_DisablesSDKChecksums(t *testing.T) {
+	store, err := NewFromConfig(context.Background(), Config{
+		Bucket:    "b",
+		Region:    "us-east-1",
+		Endpoint:  "http://127.0.0.1:1", // never dialed — client construction is lazy
+		AccessKey: "ak",
+		SecretKey: "sk",
+	})
+	if err != nil {
+		t.Fatalf("NewFromConfig: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	opts := store.client.Options()
+	if opts.RequestChecksumCalculation != aws.RequestChecksumCalculationWhenRequired {
+		t.Errorf("RequestChecksumCalculation = %v, want WhenRequired (else PUTs use aws-chunked + CRC32)", opts.RequestChecksumCalculation)
+	}
+	if opts.ResponseChecksumValidation != aws.ResponseChecksumValidationWhenRequired {
+		t.Errorf("ResponseChecksumValidation = %v, want WhenRequired", opts.ResponseChecksumValidation)
+	}
+}

--- a/pkg/block/remote/s3/checksum_config_test.go
+++ b/pkg/block/remote/s3/checksum_config_test.go
@@ -7,14 +7,16 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
-// TestNewFromConfig_DisablesSDKChecksums pins #1466: block content is
-// BLAKE3-verified end-to-end, so the S3 client must run with the aws-sdk-go-v2
-// flexible-checksum layer set to WhenRequired. Left at the SDK default
-// (WhenSupported) every PutObject is wrapped in an aws-chunked streaming-trailer
-// encoding with a full CRC32 pass over each ~16 MiB block — redundant CPU + wire
-// framing, and an interop friction point with non-AWS S3 endpoints. This guards
-// against a future SDK default change or an accidental removal of the option.
-func TestNewFromConfig_DisablesSDKChecksums(t *testing.T) {
+// TestNewFromConfig_SkipsOptionalSDKChecksums pins #1466: block content is
+// BLAKE3-verified end-to-end, so the S3 client runs with the aws-sdk-go-v2
+// flexible-checksum layer set to WhenRequired — dropping the *optional*
+// checksums (operations the API mandates one for still get it). Left at the SDK
+// default (WhenSupported) every PutObject is wrapped in an aws-chunked
+// streaming-trailer encoding with a full CRC32 pass over each ~16 MiB block —
+// redundant CPU + wire framing, and an interop friction point with non-AWS S3
+// endpoints. This guards against a future SDK default change or an accidental
+// removal of the option.
+func TestNewFromConfig_SkipsOptionalSDKChecksums(t *testing.T) {
 	store, err := NewFromConfig(context.Background(), Config{
 		Bucket:    "b",
 		Region:    "us-east-1",

--- a/pkg/block/remote/s3/store.go
+++ b/pkg/block/remote/s3/store.go
@@ -201,6 +201,19 @@ func NewFromConfig(ctx context.Context, config Config) (*Store, error) {
 
 	var s3Opts []func(*s3.Options)
 
+	// Blocks are BLAKE3-verified end-to-end (sealed by the carver, re-verified
+	// on read), so the SDK's flexible-checksum layer is redundant work. At the
+	// aws-sdk-go-v2 default (WhenSupported) every PutObject is wrapped in an
+	// aws-chunked streaming-trailer encoding with a full CRC32 pass over each
+	// ~16 MiB block — extra CPU and wire framing, and a known interop friction
+	// point with non-AWS S3 endpoints. WhenRequired restores clean
+	// Content-Length PUTs (the block body is a seekable *bytes.Reader, so its
+	// length is known) and skips the redundant checksum work on PUT and GET.
+	s3Opts = append(s3Opts, func(o *s3.Options) {
+		o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+		o.ResponseChecksumValidation = aws.ResponseChecksumValidationWhenRequired
+	})
+
 	if config.Endpoint != "" {
 		s3Opts = append(s3Opts, func(o *s3.Options) {
 			o.BaseEndpoint = aws.String(normalizeEndpoint(config.Endpoint))

--- a/pkg/block/remote/s3/store.go
+++ b/pkg/block/remote/s3/store.go
@@ -206,9 +206,11 @@ func NewFromConfig(ctx context.Context, config Config) (*Store, error) {
 	// aws-sdk-go-v2 default (WhenSupported) every PutObject is wrapped in an
 	// aws-chunked streaming-trailer encoding with a full CRC32 pass over each
 	// ~16 MiB block — extra CPU and wire framing, and a known interop friction
-	// point with non-AWS S3 endpoints. WhenRequired restores clean
-	// Content-Length PUTs (the block body is a seekable *bytes.Reader, so its
-	// length is known) and skips the redundant checksum work on PUT and GET.
+	// point with non-AWS S3 endpoints. WhenRequired drops only these optional
+	// checksums (operations the API mandates one for still get it), so a PutBlock
+	// whose body length is known — the carver hands PutBlock a *bytes.Reader —
+	// goes out as a clean Content-Length PUT, and the redundant checksum work is
+	// skipped on PUT and GET.
 	s3Opts = append(s3Opts, func(o *s3.Options) {
 		o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
 		o.ResponseChecksumValidation = aws.ResponseChecksumValidationWhenRequired


### PR DESCRIPTION
## Problem

Part of #1466 (rclone upload-throughput parity). Every block PUT on `develop` goes out heavier than it needs to.

DittoFS block content is **BLAKE3-verified end-to-end** (sealed by the carver at write, re-verified on every read), so the S3 SDK's integrity checksums are pure redundant work. But the S3 client leaves `aws-sdk-go-v2`'s new default (`RequestChecksumCalculation = WhenSupported`) in place, which wraps **every** `PutObject` in an `aws-chunked` streaming-trailer encoding with a full CRC32 pass over each ~16 MiB block:

- extra CPU per block (a whole CRC32 pass on top of the BLAKE3 we already do),
- extra wire framing (aws-chunked instead of a clean Content-Length PUT),
- a known **interop friction point with non-AWS S3 endpoints** (Cubbit / Scaleway) — `aws-chunked` is exactly the kind of thing third-party gateways handle inconsistently.

## Change

Set both `RequestChecksumCalculation` and `ResponseChecksumValidation` to `WhenRequired` on the S3 client (`NewFromConfig`). Block PUTs become clean **Content-Length** requests (the block body is a seekable `*bytes.Reader`, so the SDK already knows the length), and the redundant checksum work is skipped on both PUT and GET.

### Why it's safe

- `WhenRequired` only drops **optional** checksums. Operations the S3 API *mandates* a checksum for (e.g. `DeleteObjects`) still get one — verified against the SDK middleware (`RequireChecksum` forces computation regardless of this setting). This store calls **none** of those operations.
- Reads of objects previously stored *with* a checksum (older builds under `WhenSupported`) simply **skip validation** rather than erroring — the SDK never inspects the stored `x-amz-checksum-*` header unless the caller sets `ChecksumMode: ENABLED`, which none of `ReadChunk`/`GetBlock`/`GetBlockRange` do. Integrity is unchanged: every block is BLAKE3-verified.

## Why not multipart / bigger carve (the originally-queued idea)

Investigated against `develop` (post-#1414 16 MiB packing):

- **Multipart is a no-op** at 16 MiB objects — `manager.Uploader` only splits when an object *exceeds* the part size — and it pulls in a new SDK dependency.
- **Bigger carve blocks** are measurement-gated and cost up to **~4 GiB worst-case in-flight RAM** (block held whole in memory × the 64-wide adaptive upload window).
- There is **no upload-throughput measurement post-#1414** in the repo, so any "raise the object size" change would be speculative.

The checksum fix is the root-cause, zero-risk win that needs neither a new dependency nor more RAM. The adaptive upload concurrency window is untouched.

## Tests

`TestNewFromConfig_DisablesSDKChecksums` pins the client config (guards against an SDK default-flip or accidental removal). Full `pkg/block/remote/s3` suite green (79 tests), incl. the in-process mock-S3 `RemoteBlockStoreConformance` that round-trips `PutBlock`/`GetBlock`/`GetBlockRange` with checksums off.