### PR TITLE
ci(release): drop broken Microsoft apt repos before packaging install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,12 @@ jobs:
         uses: sigstore/cosign-installer@f713795cb21599bc4e5c4b58cbad1da852d7eeb9 # v3
 
       - name: Install Linux packaging tools
-        run: sudo apt-get update && sudo apt-get install -y dpkg-dev createrepo-c
+        run: |
+          # Drop the runner image's pre-configured Microsoft apt repos; they
+          # periodically break signing verification and fail apt-get update
+          # (NOSPLIT / "no longer signed"). We don't need them here.
+          sudo grep -rlZ packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -0r rm -f
+          sudo apt-get update && sudo apt-get install -y dpkg-dev createrepo-c
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@9a127d869fb706213d29cdf8eef3a4ea2b869415 # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           # Drop the runner image's pre-configured Microsoft apt repos; they
           # periodically break signing verification and fail apt-get update
           # (NOSPLIT / "no longer signed"). We don't need them here.
-          sudo grep -rlZ packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -0r rm -f
+          sudo bash -c 'grep -rlZ packages.microsoft.com /etc/apt/sources.list.d/ 2>/dev/null || true' | sudo xargs -0r rm -f
           sudo apt-get update && sudo apt-get install -y dpkg-dev createrepo-c
 
       - name: Run GoReleaser


### PR DESCRIPTION
The v0.25.0 release run failed at the **Install Linux packaging tools** step:

```
E: Failed to fetch https://packages.microsoft.com/repos/azure-cli/dists/noble/InRelease  Clearsigned file isn't valid, got 'NOSPLIT'
E: repository 'https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease' is no longer signed.
##[error]Process completed with exit code 100.
```

The ubuntu-24.04 runner image ships with Microsoft apt repos pre-configured. When their signing metadata breaks, `apt-get update` exits 100 and kills the release job — even though we only need `dpkg-dev` / `createrepo-c` from the Ubuntu archives.

Fix: remove any `sources.list.d` entry referencing `packages.microsoft.com` before `apt-get update`. We don't use those repos.

Run: https://github.com/marmos91/dittofs/actions/runs/28897157837