### PR TITLE
perf(bench): FastCDC chunk-size sweep axis in parity harness (#1569)

### DIFF
--- a/bench/blockstore/fixture.go
+++ b/bench/blockstore/fixture.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/chunker"
 	"github.com/marmos91/dittofs/pkg/block/engine"
 	"github.com/marmos91/dittofs/pkg/block/local"
 	"github.com/marmos91/dittofs/pkg/block/local/fs"
@@ -53,6 +54,12 @@ type EngineOpts struct {
 	// reroute path when per-op Flush supersedes still-pending chunks — their
 	// baselines keep the legacy mirror until that is resolved.
 	PackedBlocks bool
+
+	// ChunkParams overrides the rollup chunker's FastCDC sizing (#1569) for
+	// this engine. Zero value falls back to chunker.DefaultParams() (1M/4M/16M).
+	// Write-time only — reads resolve through the frozen FileChunk manifest, so
+	// a cold-restart download engine ignores it.
+	ChunkParams chunker.Params
 }
 
 // nonClosingRemote makes engine.Close a no-op on the shared remote, like the
@@ -101,6 +108,7 @@ func NewEngineWithOpts(baseDir string, remoteStore remote.RemoteStore, opts Engi
 		StabilizationMS: StabilizationMS,
 		RollupStore:     ms,
 		SyncedHashStore: ms,
+		ChunkParams:     opts.ChunkParams,
 	}
 	// Wire the LocalChunkIndex like the production share factory (#1414 PR3
 	// flip): rollup then persists chunks to the log-blob substrate so the

--- a/bench/parity/chunkparams_test.go
+++ b/bench/parity/chunkparams_test.go
@@ -33,4 +33,23 @@ func TestOptsChunkParams(t *testing.T) {
 	if err := (&Opts{MinChunk: 1024}).Validate(); err == nil {
 		t.Fatal("expected sub-floor MinChunk to be rejected")
 	}
+
+	// Validate normalizes the persisted knobs to the effective params so the
+	// scorecard RunOpts is self-describing.
+	// --min-chunk alone → Max resolves to the 16 MiB ceiling.
+	o := &Opts{MinChunk: 128 << 10}
+	if err := o.Validate(); err != nil {
+		t.Fatalf("validate min-only: %v", err)
+	}
+	if o.MinChunk != 128<<10 || o.MaxChunk != chunker.MaxChunkSize {
+		t.Fatalf("min-only normalize: got Min=%d Max=%d", o.MinChunk, o.MaxChunk)
+	}
+	// --max-chunk without --min-chunk has no effect → cleared so it isn't persisted.
+	o2 := &Opts{MaxChunk: 256 << 10}
+	if err := o2.Validate(); err != nil {
+		t.Fatalf("validate max-only: %v", err)
+	}
+	if o2.MinChunk != 0 || o2.MaxChunk != 0 {
+		t.Fatalf("max-only normalize: got Min=%d Max=%d, want both 0", o2.MinChunk, o2.MaxChunk)
+	}
 }

--- a/bench/parity/chunkparams_test.go
+++ b/bench/parity/chunkparams_test.go
@@ -1,0 +1,36 @@
+package parity
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block/chunker"
+)
+
+// Opts.ChunkParams maps the --min-chunk/--max-chunk knobs onto a valid FastCDC
+// profile (or the zero value the FSStore reads as default).
+func TestOptsChunkParams(t *testing.T) {
+	// Unset → zero Params (FSStore maps to DefaultParams).
+	if got := (&Opts{}).ChunkParams(); got != (chunker.Params{}) {
+		t.Fatalf("default: want zero Params, got %+v", got)
+	}
+	// Min only → Max defaults to the 16 MiB ceiling, Avg=Max, and it validates.
+	p := (&Opts{MinChunk: 64 << 10}).ChunkParams()
+	if p.Min != 64<<10 || p.Max != chunker.MaxChunkSize || p.Avg != p.Max {
+		t.Fatalf("min-only: got %+v", p)
+	}
+	if err := p.Validate(); err != nil {
+		t.Fatalf("min-only params rejected: %v", err)
+	}
+	// Min + Max both set.
+	p2 := (&Opts{MinChunk: 128 << 10, MaxChunk: 256 << 10}).ChunkParams()
+	if p2.Min != 128<<10 || p2.Max != 256<<10 || p2.Avg != 256<<10 {
+		t.Fatalf("min+max: got %+v", p2)
+	}
+	if err := p2.Validate(); err != nil {
+		t.Fatalf("min+max params rejected: %v", err)
+	}
+	// A too-small Min is rejected by Validate (surfaced through Opts.Validate).
+	if err := (&Opts{MinChunk: 1024}).Validate(); err == nil {
+		t.Fatal("expected sub-floor MinChunk to be rejected")
+	}
+}

--- a/bench/parity/dittofs.go
+++ b/bench/parity/dittofs.go
@@ -73,6 +73,7 @@ func runDittofsConc(ctx context.Context, opts Opts, s3cfg *s3Config, basePrefix 
 		upDir := filepath.Join(opts.WorkDir, fmt.Sprintf("engine-c%d-%s-up", conc, cl.name))
 		bs, ms, cleanup, err := blockstore.NewEngineWithOpts(upDir, remoteStore, blockstore.EngineOpts{
 			Syncer: &cfg, Metrics: upMx, KeepRemoteOpen: true, PackedBlocks: true,
+			ChunkParams: opts.ChunkParams(),
 		})
 		if err != nil {
 			_ = remoteStore.Close()

--- a/bench/parity/parity.go
+++ b/bench/parity/parity.go
@@ -28,6 +28,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/marmos91/dittofs/pkg/block/chunker"
 )
 
 // Quadrant identifiers. "meta" is the metadata-ops lane: remote-object
@@ -68,7 +70,31 @@ type Opts struct {
 	SmallFileBytes int64 // size of each small file
 	SmallFileCount int   // number of small files
 
+	// MinChunk / MaxChunk sweep the dittofs FastCDC chunk size (#1569) to
+	// measure cold-read amplification. MinChunk is the dominant knob (effective
+	// chunk ≈ Min under the shared masks); 0 keeps the default 1M/4M/16M
+	// profile. MaxChunk is the ceiling (default 16 MiB when only MinChunk set).
+	MinChunk int // FastCDC min chunk bytes; 0 = default profile
+	MaxChunk int // FastCDC max chunk bytes; 0 = 16 MiB when MinChunk > 0
+
 	KeepRemote bool // skip remote cleanup (debugging); meta-delete phase is skipped
+}
+
+// ChunkParams builds the dittofs upload engine's FastCDC sizing from the
+// Min/Max knobs. Zero MinChunk → zero Params, which the FSStore maps to
+// chunker.DefaultParams(). When only MinChunk is set, Max defaults to the
+// 16 MiB ceiling and Avg=Max so the shared small-region mask spans the whole
+// [Min,Max) range (see pkg/block/chunker). MaxChunk alone (no MinChunk) is
+// ignored — Min drives the sweep.
+func (o *Opts) ChunkParams() chunker.Params {
+	if o.MinChunk == 0 {
+		return chunker.Params{}
+	}
+	max := o.MaxChunk
+	if max == 0 {
+		max = chunker.MaxChunkSize
+	}
+	return chunker.Params{Min: o.MinChunk, Avg: max, Max: max}
 }
 
 // Validate applies defaults and rejects nonsense.
@@ -117,6 +143,11 @@ func (o *Opts) Validate() error {
 	}
 	if o.SmallFileCount <= 0 {
 		o.SmallFileCount = 2048
+	}
+	if o.MinChunk != 0 {
+		if err := o.ChunkParams().Validate(); err != nil {
+			return err
+		}
 	}
 	if o.OutDir == "" {
 		o.OutDir = filepath.Join("bench", "results")
@@ -175,6 +206,8 @@ type RunOpts struct {
 	SmallFileBytes int64  `json:"small_file_bytes"`
 	SmallFileCount int    `json:"small_file_count"`
 	Seed           uint64 `json:"seed"`
+	MinChunk       int    `json:"min_chunk,omitempty"` // FastCDC min chunk bytes (#1569 sweep); absent = default profile
+	MaxChunk       int    `json:"max_chunk,omitempty"` // FastCDC max chunk bytes (#1569 sweep); absent = default profile
 }
 
 // Execute runs the full harness and writes the scorecard artifacts.
@@ -212,6 +245,8 @@ func Execute(ctx context.Context, opts Opts) (string, error) {
 			SmallFileBytes: opts.SmallFileBytes,
 			SmallFileCount: opts.SmallFileCount,
 			Seed:           opts.Seed,
+			MinChunk:       opts.MinChunk,
+			MaxChunk:       opts.MaxChunk,
 		},
 		Timelines: map[string]Timeline{},
 	}

--- a/bench/parity/parity.go
+++ b/bench/parity/parity.go
@@ -144,10 +144,17 @@ func (o *Opts) Validate() error {
 	if o.SmallFileCount <= 0 {
 		o.SmallFileCount = 2048
 	}
+	// Normalize the chunk knobs to the effective params so the persisted
+	// RunOpts is self-describing: a default run omits both; a sweep run records
+	// the real min and the resolved ceiling (16 MiB when --max-chunk is unset).
 	if o.MinChunk != 0 {
-		if err := o.ChunkParams().Validate(); err != nil {
+		p := o.ChunkParams()
+		if err := p.Validate(); err != nil {
 			return err
 		}
+		o.MaxChunk = p.Max
+	} else {
+		o.MaxChunk = 0 // --max-chunk without --min-chunk has no effect; don't record it
 	}
 	if o.OutDir == "" {
 		o.OutDir = filepath.Join("bench", "results")

--- a/cmd/bench/parity.go
+++ b/cmd/bench/parity.go
@@ -26,6 +26,8 @@ var parityFlags struct {
 	largeCount int
 	smallBytes int64
 	smallCount int
+	minChunk   int
+	maxChunk   int
 	keepRemote bool
 }
 
@@ -70,6 +72,8 @@ bench/scripts/parity-scw.sh (disposable Scaleway VM -> Cubbit / SCW S3).`,
 			LargeFileCount: parityFlags.largeCount,
 			SmallFileBytes: parityFlags.smallBytes,
 			SmallFileCount: parityFlags.smallCount,
+			MinChunk:       parityFlags.minChunk,
+			MaxChunk:       parityFlags.maxChunk,
 			KeepRemote:     parityFlags.keepRemote,
 		}
 		var err error
@@ -134,6 +138,8 @@ func init() {
 	f.IntVar(&parityFlags.largeCount, "large-file-count", 0, "large-file count (default 4; smoke 2)")
 	f.Int64Var(&parityFlags.smallBytes, "small-file-bytes", 0, "small-file size (default 64KiB)")
 	f.IntVar(&parityFlags.smallCount, "small-file-count", 0, "small-file count (default 2048; smoke 128)")
+	f.IntVar(&parityFlags.minChunk, "min-chunk", 0, "dittofs FastCDC min chunk bytes (0=default ~1MiB; lower to cut cold-read amplification, #1569)")
+	f.IntVar(&parityFlags.maxChunk, "max-chunk", 0, "dittofs FastCDC max chunk bytes ceiling (default 16MiB when --min-chunk set)")
 	f.BoolVar(&parityFlags.keepRemote, "keep-remote", false, "skip remote cleanup + meta delete phase (debugging)")
 	rootCmd.AddCommand(parityCmd)
 }


### PR DESCRIPTION
## What

Adds `--min-chunk` / `--max-chunk` to `dfsbench parity` so the FastCDC chunk size (#1569) can be **swept** on WAN and its effect on cold-read amplification measured. This is the Phase-0 measurement follow-up to the shipped per-share chunk-size knob (#1594).

## Why

#1569 shipped the per-share knob but there was no way to *measure* the amplification/throughput curve across chunk sizes. The parity harness already runs a cold-restart download engine (empty local dir → every byte comes through the remote read-through path) and records `RemoteReadBytes` per cell — so it's the right place to sweep chunk size and read the amplification curve off real data.

## How

- `EngineOpts.ChunkParams` threads `chunker.Params` into the rollup chunker via `fs.FSStoreOptions`.
- Applied to the **upload** engine only — reads resolve through the frozen `FileChunk` manifest, so the download engine is intentionally left on the zero value.
- Zero `chunker.Params` is the default-profile signal (FSStore maps it to `DefaultParams()`), so runs without the flags are byte-identical to before.
- `min-chunk`-only resolves `Avg=Max=16 MiB` ceiling; both validated against `chunker.Params.Validate()` at CLI parse time.
- Resolved min/max persist in the scorecard `RunOpts` (JSON/CSV) so each sweep point is self-describing, not label-dependent.

## Test

- `bench/parity/chunkparams_test.go` covers the Min→Params mapping, the default (zero) path, and sub-floor rejection.
- `go build ./cmd/bench ./bench/... && go vet ./... && go test ./bench/parity/...` green; `golangci-lint` 0 issues.

Usage: `dfsbench parity --quadrant download-large --min-chunk 131072 --label chunk-128k`