### PR TITLE
perf(bench): pin parity upload window to conc (rclone-comparable)

### DIFF
--- a/bench/parity/dittofs.go
+++ b/bench/parity/dittofs.go
@@ -62,9 +62,12 @@ func runDittofsConc(ctx context.Context, opts Opts, s3cfg *s3Config, basePrefix 
 			return nil, nil, err
 		}
 		cfg := engine.DefaultConfig()
-		// ponytail: upload concurrency moved off SyncerConfig to the remote's
-		// parallel_uploads config in the blocks-only model (#1493). Re-wire conc
-		// onto the remote config if this bench's upload-concurrency axis matters.
+		// Pin the carver's upload window to this cell's concurrency so the
+		// dittofs upload lane is comparable to rclone --transfers=conc (the
+		// harness's stated intent). Without this the carver runs its adaptive
+		// window (16→64) regardless of conc, so the upload axis is meaningless
+		// and c1/c24 both saturate. conc=1 → serial carver (the #1432 floor).
+		cfg.ParallelUploads = conc
 
 		// Engine 1: upload. Fresh metadata + local dir + metrics registry.
 		// KeepRemoteOpen: the parity runner owns the remote store's lifetime


### PR DESCRIPTION
## What

Pin the dittofs upload lane's carver window (`SyncerConfig.ParallelUploads`) to each cell's concurrency in `dfsbench parity`, so the upload-concurrency axis actually varies and is comparable to rclone `--transfers=conc`.

## Why

The lane used `engine.DefaultConfig()` (`ParallelUploads=0` → adaptive 16→64), so the carver ran a wide window regardless of `conc`. Result: dittofs upload throughput was ~flat across c1 and c24 (both saturating), while rclone scaled with `--transfers` — making the upload comparison apples-to-oranges. The harness docstring already states the intent is to pin upload concurrency to the cell level; that pinning had been lost (a flagged TODO).

## How

One line: `cfg.ParallelUploads = conc` before building the upload engine. `syncer.go:319` reads it directly — `>0` pins a fixed PUT window, so `conc=1` is the serial-carver floor (#1432) and `conc=N` an N-wide window. The download engine is unaffected (`ParallelDownloads` governs reads).

## Impact

Only the `dfsbench parity` benchmark harness; no runtime/data-plane code. Enables a fair upload-scaling curve on the next WAN matrix run (Phase-0 measurement).

## Test

`go build ./cmd/bench ./bench/... && go vet ./bench/... && go test ./bench/parity/...` green.