### PR TITLE
feat(bench): dfsbench harness skeleton — fio LoadGen, result schema, local/smoke run (#1602 PR2)

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -11,6 +11,29 @@ competitors (juicefs, s3ql, rclone-mount, s3fs) over NFSv3 / NFSv4.1 / SMB3 on a
 single disposable Scaleway VM, with uniform fio metrics and a real server↔S3
 bandwidth number for every system.
 
+## Using `dfsbench` (local mode)
+
+The harness runs `fio` (must be installed and on `PATH`) against a mounted
+filesystem and prints a comparison table; each cell's metrics are written as a
+JSON file under `--results` so `--resume` re-runs skip completed cells.
+
+```sh
+go build -o dfsbench ./cmd/bench
+
+./dfsbench list                                   # workloads + size classes
+./dfsbench run --smoke                            # self-contained tiny run (CI, no secrets)
+./dfsbench run --local --target /mnt/dittofs      # fio a filesystem you mounted
+./dfsbench run --local --target /mnt/juicefs \
+    --workloads rand-read-4k --sizes large        # one cell
+./dfsbench run --local --target /mnt/x --resume   # skip cells already recorded
+./dfsbench report --results ./bench-results       # re-render the table from saved JSON
+```
+
+Size classes: `small` = 64 KiB, `medium` = 1 MiB, `large` = 1 GiB. Sequential
+workloads use a 1 MiB block, so they need `medium` or larger (fio requires file
+size ≥ block size). Cloud provisioning, competitor backends, protocol
+re-export, and S3-byte/ctxsw metering land in follow-up PRs (see #1602).
+
 ## Component microbenchmarks live with their code
 
 Per-package `Benchmark*` functions (chunker, hash, block engine, metadata,

--- a/bench/README.md
+++ b/bench/README.md
@@ -13,9 +13,13 @@ bandwidth number for every system.
 
 ## Using `dfsbench` (local mode)
 
-The harness runs `fio` (must be installed and on `PATH`) against a mounted
-filesystem and prints a comparison table; each cell's metrics are written as a
-JSON file under `--results` so `--resume` re-runs skip completed cells.
+The harness runs `fio` against a mounted filesystem and prints a comparison
+table; each cell's metrics are written as a JSON file under `--results` so
+`--resume` re-runs skip completed cells.
+
+`fio` must be installed and on `PATH`. The dev shell provides it — `nix develop`
+(fio is in `commonBuildInputs`) — otherwise install it yourself (`brew install
+fio`, `apt-get install fio`, …).
 
 ```sh
 go build -o dfsbench ./cmd/bench

--- a/bench/workloads/embed.go
+++ b/bench/workloads/embed.go
@@ -1,0 +1,12 @@
+// Package workloads exposes the fio job files as an embedded filesystem so the
+// dfsbench harness (cmd/bench) can materialize them on any target without the
+// files needing to live next to the binary. The .fio files remain the single
+// source of truth for access patterns; embed.go only makes them reachable.
+package workloads
+
+import "embed"
+
+// FS holds every fio job file in this directory.
+//
+//go:embed *.fio
+var FS embed.FS

--- a/bench/workloads/metadata.fio
+++ b/bench/workloads/metadata.fio
@@ -10,5 +10,5 @@ ioengine=${FIO_ENGINE:-libaio}
 numjobs=${BENCH_THREADS:-4}
 runtime=${BENCH_RUNTIME:-60}
 time_based
-directory=/mnt/bench
+directory=${BENCH_DIR:-/mnt/bench}
 group_reporting

--- a/bench/workloads/mixed-rw.fio
+++ b/bench/workloads/mixed-rw.fio
@@ -9,6 +9,6 @@ ioengine=${FIO_ENGINE:-libaio}
 numjobs=${BENCH_THREADS:-4}
 runtime=${BENCH_RUNTIME:-60}
 time_based
-size=1g
-directory=/mnt/bench
+size=${BENCH_SIZE:-1g}
+directory=${BENCH_DIR:-/mnt/bench}
 group_reporting

--- a/bench/workloads/rand-read-4k.fio
+++ b/bench/workloads/rand-read-4k.fio
@@ -8,6 +8,6 @@ ioengine=${FIO_ENGINE:-libaio}
 numjobs=${BENCH_THREADS:-4}
 runtime=${BENCH_RUNTIME:-60}
 time_based
-size=1g
-directory=/mnt/bench
+size=${BENCH_SIZE:-1g}
+directory=${BENCH_DIR:-/mnt/bench}
 group_reporting

--- a/bench/workloads/rand-write-4k.fio
+++ b/bench/workloads/rand-write-4k.fio
@@ -9,6 +9,6 @@ ioengine=${FIO_ENGINE:-libaio}
 numjobs=${BENCH_THREADS:-4}
 runtime=${BENCH_RUNTIME:-60}
 time_based
-size=1g
-directory=/mnt/bench
+size=${BENCH_SIZE:-1g}
+directory=${BENCH_DIR:-/mnt/bench}
 group_reporting

--- a/bench/workloads/seq-read.fio
+++ b/bench/workloads/seq-read.fio
@@ -7,6 +7,6 @@ ioengine=${FIO_ENGINE:-libaio}
 numjobs=${BENCH_THREADS:-4}
 runtime=${BENCH_RUNTIME:-60}
 time_based
-size=1g
-directory=/mnt/bench
+size=${BENCH_SIZE:-1g}
+directory=${BENCH_DIR:-/mnt/bench}
 group_reporting

--- a/bench/workloads/seq-write.fio
+++ b/bench/workloads/seq-write.fio
@@ -8,6 +8,6 @@ ioengine=${FIO_ENGINE:-libaio}
 numjobs=${BENCH_THREADS:-4}
 runtime=${BENCH_RUNTIME:-60}
 time_based
-size=1g
-directory=/mnt/bench
+size=${BENCH_SIZE:-1g}
+directory=${BENCH_DIR:-/mnt/bench}
 group_reporting

--- a/cmd/bench/config.go
+++ b/cmd/bench/config.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config declares a run. It is the file form of the `run` flags; CLI flags
+// override any field set here. Credentials are never read from config — they
+// stay in the environment (plan invariant).
+type Config struct {
+	Systems   []string `yaml:"systems"`   // system labels; local/smoke default to one
+	Workloads []string `yaml:"workloads"` // subset of knownWorkloads; empty = all
+	Sizes     []string `yaml:"sizes"`     // size classes or explicit fio sizes; empty = medium
+
+	Target  string `yaml:"target"`  // already-mounted path (--local)
+	Results string `yaml:"results"` // results dir
+	Threads int    `yaml:"threads"` // fio numjobs
+	Runtime int    `yaml:"runtime"` // fio runtime seconds
+	Engine  string `yaml:"engine"`  // fio ioengine
+	FioBin  string `yaml:"fio_bin"` // fio binary path
+}
+
+// loadConfig reads a dfsbench YAML config. A missing path is not an error only
+// when path is empty (no --config given).
+func loadConfig(path string) (Config, error) {
+	if path == "" {
+		return Config{}, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, fmt.Errorf("read config: %w", err)
+	}
+	var c Config
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		return Config{}, fmt.Errorf("parse config: %w", err)
+	}
+	return c, nil
+}

--- a/cmd/bench/fio_json.go
+++ b/cmd/bench/fio_json.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// fioOutput is the subset of `fio --output-format=json` we consume. fio has no
+// canonical Go type, so we decode only the fields the scorecard needs.
+type fioOutput struct {
+	Jobs []fioJob `json:"jobs"`
+}
+
+type fioJob struct {
+	Jobname    string     `json:"jobname"`
+	Error      int64      `json:"error"`
+	JobRuntime int64      `json:"job_runtime"` // milliseconds
+	Read       fioDirStat `json:"read"`
+	Write      fioDirStat `json:"write"`
+}
+
+type fioDirStat struct {
+	IOBytes  int64    `json:"io_bytes"`
+	BWBytes  int64    `json:"bw_bytes"` // bytes/sec
+	IOPS     float64  `json:"iops"`
+	TotalIOS int64    `json:"total_ios"`
+	ClatNS   fioLatNS `json:"clat_ns"`
+}
+
+type fioLatNS struct {
+	Mean       float64            `json:"mean"`
+	Percentile map[string]float64 `json:"percentile"`
+}
+
+const mib = 1 << 20
+
+// parseFioJSON turns one fio JSON report into a CellResult's metric fields. It
+// combines the read and write directions (a mixed workload populates both; a
+// pure read/write leaves the other side zero) and takes latency percentiles
+// from whichever direction did more ops — the workload's headline op.
+func parseFioJSON(data []byte) (CellResult, error) {
+	// fio prepends free-text "note:" lines to stdout (and even to --output
+	// files) before the JSON object, so scrape from the first brace.
+	if i := bytes.IndexByte(data, '{'); i > 0 {
+		data = data[i:]
+	}
+	var out fioOutput
+	if err := json.Unmarshal(data, &out); err != nil {
+		return CellResult{}, fmt.Errorf("decode fio json: %w", err)
+	}
+	if len(out.Jobs) == 0 {
+		return CellResult{}, fmt.Errorf("fio json has no jobs")
+	}
+	// group_reporting collapses to a single job entry.
+	j := out.Jobs[0]
+
+	var r CellResult
+	r.ThroughputMBps = float64(j.Read.BWBytes+j.Write.BWBytes) / mib
+	r.IOPS = j.Read.IOPS + j.Write.IOPS
+	r.TotalOps = j.Read.TotalIOS + j.Write.TotalIOS
+	r.TotalBytes = j.Read.IOBytes + j.Write.IOBytes
+	r.Errors = j.Error
+	r.DurationS = float64(j.JobRuntime) / 1000
+
+	headline := j.Read
+	if j.Write.TotalIOS > j.Read.TotalIOS {
+		headline = j.Write
+	}
+	r.LatencyAvgUs = headline.ClatNS.Mean / 1000
+	r.LatencyP50Us = headline.ClatNS.Percentile["50.000000"] / 1000
+	r.LatencyP95Us = headline.ClatNS.Percentile["95.000000"] / 1000
+	r.LatencyP99Us = headline.ClatNS.Percentile["99.000000"] / 1000
+	return r, nil
+}

--- a/cmd/bench/harness_test.go
+++ b/cmd/bench/harness_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// a trimmed but real-shaped fio --output-format=json report (rand-read-4k).
+const fioRandReadJSON = `{
+  "jobs": [
+    {
+      "jobname": "rand-read-4k",
+      "error": 0,
+      "job_runtime": 3000,
+      "read": {
+        "io_bytes": 104857600,
+        "bw_bytes": 34952533,
+        "iops": 8533.2,
+        "total_ios": 25600,
+        "clat_ns": { "mean": 112000, "percentile": {
+          "50.000000": 98000, "95.000000": 1870000, "99.000000": 2310000 } }
+      },
+      "write": { "io_bytes": 0, "bw_bytes": 0, "iops": 0, "total_ios": 0,
+        "clat_ns": { "mean": 0, "percentile": {} } }
+    }
+  ]
+}`
+
+func TestParseFioJSON_RandRead(t *testing.T) {
+	r, err := parseFioJSON([]byte(fioRandReadJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.IOPS != 8533.2 {
+		t.Errorf("iops=%v want 8533.2", r.IOPS)
+	}
+	if want := 34952533.0 / mib; r.ThroughputMBps != want {
+		t.Errorf("mbps=%v want %v", r.ThroughputMBps, want)
+	}
+	if r.LatencyP99Us != 2310 { // 2310000 ns → µs
+		t.Errorf("p99=%v want 2310", r.LatencyP99Us)
+	}
+	if r.LatencyP50Us != 98 {
+		t.Errorf("p50=%v want 98", r.LatencyP50Us)
+	}
+	if r.TotalOps != 25600 || r.Errors != 0 {
+		t.Errorf("ops=%d err=%d", r.TotalOps, r.Errors)
+	}
+}
+
+// mixed workload: latency percentiles come from the busier (write) direction.
+const fioMixedJSON = `{"jobs":[{"jobname":"mixed-rw","error":0,"job_runtime":1000,
+  "read":{"io_bytes":100,"bw_bytes":100,"iops":10,"total_ios":10,
+    "clat_ns":{"mean":1000,"percentile":{"99.000000":1000}}},
+  "write":{"io_bytes":900,"bw_bytes":900,"iops":90,"total_ios":90,
+    "clat_ns":{"mean":5000,"percentile":{"99.000000":9000}}}}]}`
+
+func TestParseFioJSON_MixedUsesBusierSide(t *testing.T) {
+	r, err := parseFioJSON([]byte(fioMixedJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.IOPS != 100 { // 10 read + 90 write
+		t.Errorf("iops=%v want 100", r.IOPS)
+	}
+	if r.LatencyP99Us != 9 { // write side wins (more ops)
+		t.Errorf("p99=%v want 9 (write side)", r.LatencyP99Us)
+	}
+}
+
+func TestParseFioJSON_SkipsNotePrefix(t *testing.T) {
+	noisy := "note: queue depth will be capped at 1\nnote: another line\n" + fioRandReadJSON
+	r, err := parseFioJSON([]byte(noisy))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.IOPS != 8533.2 {
+		t.Errorf("iops=%v want 8533.2 (note prefix not skipped)", r.IOPS)
+	}
+}
+
+func TestParseFioJSON_NoJobs(t *testing.T) {
+	if _, err := parseFioJSON([]byte(`{"jobs":[]}`)); err == nil {
+		t.Fatal("want error on empty jobs")
+	}
+}
+
+func TestExpandJob_DefaultsAndOverrides(t *testing.T) {
+	tmpl := "ioengine=${FIO_ENGINE:-libaio}\nnumjobs=${BENCH_THREADS:-4}\nx=${UNSET}"
+	got := expandJob(tmpl, map[string]string{"FIO_ENGINE": "psync"})
+	if !strings.Contains(got, "ioengine=psync") {
+		t.Errorf("override not applied: %q", got)
+	}
+	if !strings.Contains(got, "numjobs=4") {
+		t.Errorf("default not applied: %q", got)
+	}
+	if !strings.Contains(got, "x=\n") && !strings.HasSuffix(got, "x=") {
+		t.Errorf("unset var should be empty: %q", got)
+	}
+}
+
+func TestLoadJob_AllWorkloadsEmbedded(t *testing.T) {
+	for _, w := range knownWorkloads {
+		body, err := loadJob(w, jobDefaults("psync", "/mnt/bench", "64k", 4, 60))
+		if err != nil {
+			t.Errorf("%s: %v", w, err)
+		}
+		if !strings.Contains(body, "[") { // fio job header
+			t.Errorf("%s: not a fio job: %q", w, body)
+		}
+		if strings.Contains(body, "${") {
+			t.Errorf("%s: unexpanded var remains: %q", w, body)
+		}
+	}
+}
+
+func TestResume_SkipsExistingResult(t *testing.T) {
+	dir := t.TempDir()
+	c := CellResult{System: "local", Workload: "seq-read", Size: "small", Protocol: "local", Pass: "warm"}
+	if resultExists(dir, c.slug()) {
+		t.Fatal("should not exist yet")
+	}
+	if err := c.save(dir); err != nil {
+		t.Fatal(err)
+	}
+	if !resultExists(dir, c.slug()) {
+		t.Fatal("should exist after save")
+	}
+	// .tmp partials must not count as completed cells.
+	rs, err := loadResults(dir)
+	if err != nil || len(rs) != 1 {
+		t.Fatalf("loadResults: %v n=%d", err, len(rs))
+	}
+	if filepath.Base(rs[0].System) != "local" {
+		t.Errorf("bad load: %+v", rs[0])
+	}
+}
+
+func TestRenderTable_HeadlineDashing(t *testing.T) {
+	rs := []CellResult{
+		{System: "local", Workload: "seq-read", Size: "large", Protocol: "local", Pass: "warm", ThroughputMBps: 2400},
+		{System: "local", Workload: "rand-read-4k", Size: "large", Protocol: "local", Pass: "warm", IOPS: 8940},
+	}
+	out := renderTable(rs)
+	if !strings.Contains(out, "2400") || !strings.Contains(out, "8940") {
+		t.Errorf("missing values:\n%s", out)
+	}
+	// seq-read: IOPS column dashed; rand: MB/s column dashed.
+	if !strings.Contains(out, "—") {
+		t.Errorf("expected dashed non-headline cells:\n%s", out)
+	}
+}

--- a/cmd/bench/loadgen.go
+++ b/cmd/bench/loadgen.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+// LoadOpts are the per-cell fio knobs the harness overrides on top of the .fio
+// template. Zero values mean "use the job file's own value".
+type LoadOpts struct {
+	Size    string // fio --size (e.g. "64k", "1g")
+	Threads int    // BENCH_THREADS
+	Runtime int    // BENCH_RUNTIME seconds
+	Engine  string // FIO_ENGINE (defaults per-OS)
+	FioBin  string // fio binary (default "fio")
+}
+
+// defaultEngine picks a portable fio ioengine. libaio is Linux-only; local dev
+// on macOS needs psync. Overridable via LoadOpts.Engine / --fio-engine.
+func defaultEngine() string {
+	if runtime.GOOS == "linux" {
+		return "libaio"
+	}
+	return "psync"
+}
+
+// runFio executes workload against targetDir and fills the metric fields of a
+// CellResult. The caller stamps identity/pass fields.
+func runFio(ctx context.Context, workload, targetDir string, opts LoadOpts) (CellResult, error) {
+	engine := opts.Engine
+	if engine == "" {
+		engine = defaultEngine()
+	}
+	threads := opts.Threads
+	if threads == 0 {
+		threads = 4
+	}
+	runtimeSec := opts.Runtime
+	if runtimeSec == 0 {
+		runtimeSec = 60
+	}
+	bin := opts.FioBin
+	if bin == "" {
+		bin = "fio"
+	}
+
+	body, err := loadJob(workload, jobDefaults(engine, targetDir, opts.Size, threads, runtimeSec))
+	if err != nil {
+		return CellResult{}, err
+	}
+
+	jobFile, err := os.CreateTemp("", "dfsbench-*.fio")
+	if err != nil {
+		return CellResult{}, err
+	}
+	jobPath := jobFile.Name()
+	defer func() { _ = os.Remove(jobPath) }()
+	_, writeErr := jobFile.WriteString(body)
+	closeErr := jobFile.Close()
+	if writeErr != nil {
+		return CellResult{}, writeErr
+	}
+	if closeErr != nil {
+		return CellResult{}, closeErr
+	}
+
+	// directory/size/threads/runtime are baked into the rendered job file (see
+	// jobDefaults) because job-file options beat fio's global CLI flags.
+	cmd := exec.CommandContext(ctx, bin, "--output-format=json", jobPath)
+	out, err := cmd.Output()
+	if err != nil {
+		return CellResult{}, fmt.Errorf("run %s (%s): %w\n%s", bin, workload, err, fioStderr(err))
+	}
+
+	res, err := parseFioJSON(out)
+	if err != nil {
+		return CellResult{}, fmt.Errorf("%s: %w", workload, err)
+	}
+	return res, nil
+}
+
+// fioStderr surfaces a failed fio invocation's stderr, if any.
+func fioStderr(err error) []byte {
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return ee.Stderr
+	}
+	return nil
+}
+
+// checkTarget verifies the target directory exists and is writable — fio's own
+// error on a bad dir is opaque, so fail early and clearly.
+func checkTarget(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("target %q: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("target %q is not a directory", dir)
+	}
+	probe := filepath.Join(dir, ".dfsbench-write-probe")
+	if err := os.WriteFile(probe, []byte("x"), 0o644); err != nil {
+		return fmt.Errorf("target %q not writable: %w", dir, err)
+	}
+	return os.Remove(probe)
+}

--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -1,27 +1,57 @@
 // Command dfsbench is the DittoFS-vs-competitors benchmark harness.
 //
-// The fio-based comparison, provisioning, and reporting commands land in
-// follow-up PRs (see issue #1602). This binary currently establishes the
-// entrypoint and carries the salvaged SSH executor (exec.go) the provisioning
-// path will drive; running it with no subcommand prints help.
+// This PR wires the core: a fio load-generator driver, a per-cell result schema with
+// crash-safe resume, and a comparison-table report — driven locally via
+// `run --local`/`run --smoke` (no cloud). Cloud provisioning, the competitor
+// backend registry, protocol re-export, and ceiling baselines land in
+// follow-up PRs (see issue #1602). exec.go carries the salvaged SSH executor
+// the provisioning path will drive.
 package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
 )
 
-func main() {
+// cmdOut is where commands write their human-facing output. A package var keeps
+// the plumbing out of every function signature; tests point it at a buffer.
+var cmdOut io.Writer = os.Stdout
+
+func newRootCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:           "dfsbench",
-		Short:         "DittoFS benchmark harness (fio comparison — under construction, see #1602)",
+		Short:         "DittoFS benchmark harness — fio across DittoFS and competitors (#1602)",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	if err := root.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+	root.AddCommand(newRunCmd(), newReportCmd(), newListCmd())
+	return root
+}
+
+func newListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List available workloads and size classes",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			_, _ = fmt.Fprintln(cmdOut, "workloads:")
+			for _, w := range knownWorkloads {
+				_, _ = fmt.Fprintf(cmdOut, "  %s\n", w)
+			}
+			_, _ = fmt.Fprintln(cmdOut, "sizes:")
+			for _, s := range sizeClassOrder() {
+				_, _ = fmt.Fprintf(cmdOut, "  %-7s %s\n", s, sizeClasses[s])
+			}
+			return nil
+		},
+	}
+}
+
+func main() {
+	if err := newRootCmd().Execute(); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/cmd/bench/report.go
+++ b/cmd/bench/report.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newReportCmd() *cobra.Command {
+	var results string
+	cmd := &cobra.Command{
+		Use:     "report",
+		Short:   "Re-render the comparison table from a results directory",
+		Example: "  dfsbench report --results ./bench-results",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			rs, err := loadResults(results)
+			if err != nil {
+				return err
+			}
+			if len(rs) == 0 {
+				return fmt.Errorf("no results in %q", results)
+			}
+			_, _ = fmt.Fprint(cmdOut, renderTable(rs))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&results, "results", "./bench-results", "results directory")
+	return cmd
+}
+
+// renderTable produces the markdown comparison table. Columns follow the plan's
+// dictionary; rate columns render "—" when not the workload's headline metric
+// (S3MB/CTXSW land once their meters exist — carried, shown as 0/— for now).
+func renderTable(rs []CellResult) string {
+	if len(rs) == 0 {
+		return "no results\n"
+	}
+	sort.Slice(rs, func(i, j int) bool {
+		a, b := rs[i], rs[j]
+		if a.System != b.System {
+			return a.System < b.System
+		}
+		if a.Workload != b.Workload {
+			return a.Workload < b.Workload
+		}
+		return a.Size < b.Size
+	})
+
+	head := []string{"SYSTEM", "WORKLOAD", "SIZE", "PROTO", "PASS", "IOPS", "MB/s", "p50µs", "p99µs", "S3MB", "err"}
+	rows := make([][]string, 0, len(rs))
+	for _, r := range rs {
+		rows = append(rows, []string{
+			r.System, r.Workload, r.Size, r.Protocol, r.Pass,
+			rate(r.IOPS, isRandom(r.Workload)),
+			rate(r.ThroughputMBps, !isRandom(r.Workload)),
+			fmt.Sprintf("%.0f", r.LatencyP50Us),
+			fmt.Sprintf("%.0f", r.LatencyP99Us),
+			fmt.Sprintf("%d", r.S3Bytes/mib),
+			fmt.Sprintf("%d", r.Errors),
+		})
+	}
+	return markdownTable(head, rows)
+}
+
+// isRandom reports whether IOPS is the workload's headline metric.
+func isRandom(w string) bool {
+	return strings.HasPrefix(w, "rand-") || w == "mixed-rw" || w == "metadata"
+}
+
+// rate formats a rate column, dashing it when it isn't this workload's headline.
+func rate(v float64, headline bool) string {
+	if !headline {
+		return "—"
+	}
+	return fmt.Sprintf("%.0f", v)
+}
+
+// markdownTable renders a GitHub-flavored markdown table with aligned columns.
+func markdownTable(head []string, rows [][]string) string {
+	w := make([]int, len(head))
+	for i, h := range head {
+		w[i] = len(h)
+	}
+	for _, r := range rows {
+		for i, c := range r {
+			if len(c) > w[i] {
+				w[i] = len(c)
+			}
+		}
+	}
+	var b strings.Builder
+	writeRow := func(cells []string) {
+		b.WriteString("|")
+		for i, c := range cells {
+			fmt.Fprintf(&b, " %-*s |", w[i], c)
+		}
+		b.WriteString("\n")
+	}
+	writeRow(head)
+	b.WriteString("|")
+	for i := range head {
+		b.WriteString(" " + strings.Repeat("-", w[i]) + " |")
+	}
+	b.WriteString("\n")
+	for _, r := range rows {
+		writeRow(r)
+	}
+	return b.String()
+}

--- a/cmd/bench/result.go
+++ b/cmd/bench/result.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// CellResult is one benchmark cell: a single (system, workload, size, protocol,
+// pass) measurement. Metric field names mirror the retired pkg/bench
+// WorkloadResult so downstream tooling that already parsed those keys keeps
+// working. S3Bytes is carried here but only populated once the S3 network meter
+// lands (plan PR5) — it stays 0 in local/smoke runs.
+type CellResult struct {
+	System    string    `json:"system"`   // backend[-protocol], e.g. "local" or "dittofs-s3-nfs3"
+	Workload  string    `json:"workload"` // fio job name, e.g. "seq-read"
+	Size      string    `json:"size"`     // size class: small|medium|large (or explicit like "64k")
+	Protocol  string    `json:"protocol"` // nfs3|nfs4|smb3|local
+	Pass      string    `json:"pass"`     // warm|cold
+	Timestamp time.Time `json:"timestamp"`
+
+	ThroughputMBps float64 `json:"throughput_mbps,omitempty"`
+	IOPS           float64 `json:"iops,omitempty"`
+	OpsPerSec      float64 `json:"ops_per_sec,omitempty"`
+
+	LatencyP50Us float64 `json:"latency_p50_us"`
+	LatencyP95Us float64 `json:"latency_p95_us"`
+	LatencyP99Us float64 `json:"latency_p99_us"`
+	LatencyAvgUs float64 `json:"latency_avg_us"`
+
+	TotalOps   int64   `json:"total_ops"`
+	TotalBytes int64   `json:"total_bytes"`
+	Errors     int64   `json:"errors"`
+	DurationS  float64 `json:"duration_s"`
+
+	S3Bytes int64 `json:"s3_bytes"` // server↔S3 bytes; populated in a later PR
+}
+
+// slug is the stable, filesystem-safe identity of a cell. Two runs of the same
+// cell produce the same slug, which is what makes --resume idempotent (skip if
+// the result file already exists).
+func (c CellResult) slug() string {
+	return fmt.Sprintf("%s__%s__%s__%s__%s", c.System, c.Workload, c.Size, c.Protocol, c.Pass)
+}
+
+func (c CellResult) filename() string { return c.slug() + ".json" }
+
+// save writes the cell result JSON atomically into dir.
+func (c CellResult) save(dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+	final := filepath.Join(dir, c.filename())
+	tmp := final + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, final)
+}
+
+// loadResults reads every *.json cell result from dir (ignoring .tmp partials),
+// used by `report` and by `--resume` skip checks.
+func loadResults(dir string) ([]CellResult, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []CellResult
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			return nil, err
+		}
+		var r CellResult
+		if err := json.Unmarshal(data, &r); err != nil {
+			return nil, fmt.Errorf("%s: %w", e.Name(), err)
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+// resultExists reports whether a completed result file for slug is on disk.
+func resultExists(dir, slug string) bool {
+	_, err := os.Stat(filepath.Join(dir, slug+".json"))
+	return err == nil
+}

--- a/cmd/bench/run.go
+++ b/cmd/bench/run.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// runFlags are the `run` command's flags; they override any --config values.
+type runFlags struct {
+	config    string
+	local     bool
+	smoke     bool
+	target    string
+	systems   []string
+	workloads []string
+	sizes     []string
+	results   string
+	threads   int
+	runtime   int
+	engine    string
+	fioBin    string
+	resume    bool
+	dryRun    bool
+}
+
+func newRunCmd() *cobra.Command {
+	f := &runFlags{}
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Run fio workloads against a mounted filesystem and record results",
+		Long: `Run drives fio across a workload × size matrix and writes one JSON result
+per cell under --results, then prints a comparison table.
+
+This PR wires the local paths (no cloud):
+  --local --target PATH   fio an already-mounted filesystem you supply
+  --smoke                 self-contained tiny matrix on a temp dir (CI, secret-free)
+
+fio must be installed and on PATH. Provisioning and competitor backends land in
+follow-up PRs (see issue #1602).`,
+		Example: `  dfsbench run --local --target /mnt/dittofs
+  dfsbench run --local --target /mnt/juicefs --workloads rand-read-4k --sizes large
+  dfsbench run --smoke
+  dfsbench run --config dfsbench.yaml --resume`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runBench(cmd.Context(), f)
+		},
+	}
+	fl := cmd.Flags()
+	fl.StringVar(&f.config, "config", "", "dfsbench YAML config (CLI flags override)")
+	fl.BoolVar(&f.local, "local", false, "benchmark an already-mounted FS at --target")
+	fl.BoolVar(&f.smoke, "smoke", false, "self-contained tiny run on a temp dir (CI)")
+	fl.StringVar(&f.target, "target", "", "mounted path to benchmark (with --local)")
+	fl.StringSliceVar(&f.systems, "systems", nil, "system labels (default: one, from mode)")
+	fl.StringSliceVar(&f.workloads, "workloads", nil, "workloads to run (default: all)")
+	fl.StringSliceVar(&f.sizes, "sizes", nil, "sizes: small|medium|large or explicit (default: medium)")
+	fl.StringVar(&f.results, "results", "./bench-results", "results directory")
+	fl.IntVar(&f.threads, "threads", 0, "fio numjobs (default 4)")
+	fl.IntVar(&f.runtime, "runtime", 0, "fio runtime seconds (default 60; smoke uses 3)")
+	fl.StringVar(&f.engine, "fio-engine", "", "fio ioengine (default libaio on Linux, psync elsewhere)")
+	fl.StringVar(&f.fioBin, "fio-bin", "", "fio binary (default: fio on PATH)")
+	fl.BoolVar(&f.resume, "resume", false, "skip cells whose result JSON already exists")
+	fl.BoolVar(&f.dryRun, "dry-run", false, "print the cell matrix and exit")
+	return cmd
+}
+
+// cell is one unit of work in the matrix.
+type cell struct {
+	system   string
+	workload string
+	size     string // selector (class name or explicit)
+	protocol string
+	pass     string
+	target   string // mount/target dir for this cell
+}
+
+func runBench(ctx context.Context, f *runFlags) error {
+	cfg, err := loadConfig(f.config)
+	if err != nil {
+		return err
+	}
+	f.applyConfig(cfg)
+
+	if f.smoke && f.local {
+		return fmt.Errorf("--smoke and --local are mutually exclusive")
+	}
+	if !f.smoke && !f.local {
+		return fmt.Errorf("choose a mode: --local --target PATH (or --smoke). Cloud provisioning lands in a later PR")
+	}
+
+	opts := LoadOpts{
+		Threads: f.threads,
+		Runtime: f.runtime,
+		Engine:  f.engine,
+		FioBin:  f.fioBin,
+	}
+
+	system := "local"
+	if len(f.systems) > 0 {
+		system = f.systems[0]
+	}
+	target := f.target
+
+	if f.smoke {
+		dir, err := os.MkdirTemp("", "dfsbench-smoke-")
+		if err != nil {
+			return err
+		}
+		defer func() { _ = os.RemoveAll(dir) }()
+		target = dir
+		system = "smoke"
+		if opts.Runtime == 0 {
+			opts.Runtime = 3 // keep CI fast
+		}
+		if len(f.workloads) == 0 {
+			f.workloads = []string{"seq-write", "rand-read-4k"} // tiny but exercises both metric shapes
+		}
+		if len(f.sizes) == 0 {
+			// medium (1 MiB) is the smallest class valid for both the 1 MiB-block
+			// sequential jobs and the 4k random jobs (fio: file size ≥ block size).
+			f.sizes = []string{"medium"}
+		}
+	}
+
+	if target == "" {
+		return fmt.Errorf("--target is required with --local")
+	}
+	if err := checkTarget(target); err != nil {
+		return err
+	}
+
+	cells, err := f.buildMatrix(system, target)
+	if err != nil {
+		return err
+	}
+	if f.dryRun {
+		printMatrix(cells)
+		return nil
+	}
+
+	want := make(map[string]bool, len(cells))
+	for _, c := range cells {
+		res := CellResult{
+			System: c.system, Workload: c.workload, Size: c.size,
+			Protocol: c.protocol, Pass: c.pass,
+		}
+		want[res.slug()] = true
+		if f.resume && resultExists(f.results, res.slug()) {
+			_, _ = fmt.Fprintf(cmdOut, "skip (resume): %s\n", res.slug())
+			continue
+		}
+		_, _ = fmt.Fprintf(cmdOut, "run: %s\n", res.slug())
+		m, err := runFio(ctx, c.workload, c.target, withSize(opts, c.size))
+		if err != nil {
+			return err
+		}
+		m.System, m.Workload, m.Size, m.Protocol, m.Pass = c.system, c.workload, c.size, c.protocol, c.pass
+		m.Timestamp = time.Now().UTC()
+		if err := m.save(f.results); err != nil {
+			return err
+		}
+	}
+
+	// Render from disk so skipped (resumed) cells appear alongside fresh ones;
+	// filter to this run's matrix so unrelated saved results don't leak in.
+	all, err := loadResults(f.results)
+	if err != nil {
+		return err
+	}
+	rows := all[:0]
+	for _, r := range all {
+		if want[r.slug()] {
+			rows = append(rows, r)
+		}
+	}
+	_, _ = fmt.Fprintln(cmdOut)
+	_, _ = fmt.Fprint(cmdOut, renderTable(rows))
+	return nil
+}
+
+// withSize resolves the size selector to fio's --size for this cell.
+func withSize(o LoadOpts, sizeSel string) LoadOpts {
+	o.Size = resolveSize(sizeSel)
+	return o
+}
+
+func (f *runFlags) buildMatrix(system, target string) ([]cell, error) {
+	wls := f.workloads
+	if len(wls) == 0 {
+		wls = knownWorkloads
+	}
+	for _, w := range wls {
+		if !validWorkload(w) {
+			return nil, fmt.Errorf("unknown workload %q (see `dfsbench list`)", w)
+		}
+	}
+	sizes := f.sizes
+	if len(sizes) == 0 {
+		sizes = []string{"medium"}
+	}
+	var cells []cell
+	for _, w := range wls {
+		for _, s := range sizes {
+			cells = append(cells, cell{
+				system: system, workload: w, size: s,
+				protocol: "local", pass: "warm", target: target,
+			})
+		}
+	}
+	return cells, nil
+}
+
+// applyConfig fills unset flags from the config file (flags win).
+func (f *runFlags) applyConfig(c Config) {
+	if f.target == "" {
+		f.target = c.Target
+	}
+	if f.results == "./bench-results" && c.Results != "" {
+		f.results = c.Results
+	}
+	if len(f.systems) == 0 {
+		f.systems = c.Systems
+	}
+	if len(f.workloads) == 0 {
+		f.workloads = c.Workloads
+	}
+	if len(f.sizes) == 0 {
+		f.sizes = c.Sizes
+	}
+	if f.threads == 0 {
+		f.threads = c.Threads
+	}
+	if f.runtime == 0 {
+		f.runtime = c.Runtime
+	}
+	if f.engine == "" {
+		f.engine = c.Engine
+	}
+	if f.fioBin == "" {
+		f.fioBin = c.FioBin
+	}
+}
+
+func printMatrix(cells []cell) {
+	_, _ = fmt.Fprintf(cmdOut, "matrix (%d cells):\n", len(cells))
+	for _, c := range cells {
+		_, _ = fmt.Fprintf(cmdOut, "  %s | %s | %s | %s | %s\n", c.system, c.workload, c.size, c.protocol, c.pass)
+	}
+}

--- a/cmd/bench/workloads.go
+++ b/cmd/bench/workloads.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/marmos91/dittofs/bench/workloads"
+)
+
+// knownWorkloads are the fio job files shipped in bench/workloads. Each maps to
+// <name>.fio. Kept as an explicit list (not a dir scan) so --workloads
+// selection and `list` have a stable, ordered set.
+var knownWorkloads = []string{
+	"seq-write",
+	"seq-read",
+	"rand-write-4k",
+	"rand-read-4k",
+	"mixed-rw",
+	"metadata",
+}
+
+// sizeClasses map a friendly size name to the fio --size value. Explicit sizes
+// (e.g. "512m") are also accepted and passed through verbatim.
+var sizeClasses = map[string]string{
+	"small":  "64k",
+	"medium": "1m",
+	"large":  "1g",
+}
+
+func sizeClassOrder() []string { return []string{"small", "medium", "large"} }
+
+// resolveSize returns the fio --size string for a size selector, accepting
+// either a named class or an explicit fio size literal.
+func resolveSize(sel string) string {
+	if v, ok := sizeClasses[sel]; ok {
+		return v
+	}
+	return sel
+}
+
+// jobDefaults are the ${VAR:-default} substitutions applied to a .fio template.
+// The .fio files use bash-style default syntax that fio itself does not
+// understand, so we expand them before handing the file to fio. dir/size are
+// expanded here rather than passed as fio CLI flags because a job-file option
+// (directory=/size=) overrides a global --directory/--size, so CLI overrides
+// silently don't take. An empty size falls back to the template default.
+func jobDefaults(engine, dir, size string, threads, runtime int) map[string]string {
+	p := map[string]string{
+		"FIO_ENGINE":    engine,
+		"BENCH_THREADS": fmt.Sprintf("%d", threads),
+		"BENCH_RUNTIME": fmt.Sprintf("%d", runtime),
+		"BENCH_DIR":     dir,
+	}
+	if size != "" {
+		p["BENCH_SIZE"] = size
+	}
+	return p
+}
+
+var varRe = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}`)
+
+// expandJob renders a .fio template, replacing ${VAR} and ${VAR:-default} with
+// values from params, falling back to the template's own default. Unset vars
+// with no default expand to empty (matching shell).
+func expandJob(tmpl string, params map[string]string) string {
+	return varRe.ReplaceAllStringFunc(tmpl, func(m string) string {
+		g := varRe.FindStringSubmatch(m)
+		name, def := g[1], g[2]
+		if v, ok := params[name]; ok {
+			return v
+		}
+		return def
+	})
+}
+
+// loadJob returns the expanded fio job file body for a workload.
+func loadJob(name string, params map[string]string) (string, error) {
+	raw, err := workloads.FS.ReadFile(name + ".fio")
+	if err != nil {
+		return "", fmt.Errorf("unknown workload %q: %w", name, err)
+	}
+	return expandJob(string(raw), params), nil
+}
+
+// validWorkload reports whether name is a shipped workload.
+func validWorkload(name string) bool {
+	for _, w := range knownWorkloads {
+		if w == name {
+			return true
+		}
+	}
+	return false
+}

--- a/flake.nix
+++ b/flake.nix
@@ -270,6 +270,9 @@
           gettext # envsubst for ptfconfig template rendering
           xmlstarlet # TRX result parsing
           curl # health checks in bootstrap/local mode
+
+          # Benchmark load generator for the dfsbench harness (bench/, cmd/bench)
+          fio
         ];
 
         # Platform-specific inputs


### PR DESCRIPTION
PR2 of the benchmark-suite consolidation (#1602, plan `.planning/2026-07-08-bench-harness-consolidation.md`). Fills the `cmd/bench` stub PR1 left with the **local-mode core** of the single fio comparison harness — no cloud, no secrets.

## What lands

- **fio driver** (`loadgen.go`, `fio_json.go`) — renders the `${VAR:-default}` `.fio` templates, runs `fio --output-format=json`, scrapes past fio's `note:` stdout preamble, maps read/write directions → metrics (bw→MiB/s, ns→µs).
- **Per-cell result schema** (`result.go`) — `CellResult` reuses the retired `pkg/bench` `WorkloadResult` field shape + `s3_bytes`; atomic `.tmp`-then-rename saves; one JSON file per `(system, workload, size, protocol, pass)` cell.
- **Commands** (`run.go`, `report.go`, `main.go`):
  - `run --local --target PATH` — fio an already-mounted filesystem you supply.
  - `run --smoke` — self-contained tiny matrix on a temp dir (CI-safe, secret-free).
  - `run --resume` — skip cells whose result JSON already exists (crash-safe).
  - `report --results DIR` — re-render the table from saved JSON.
  - `list` — workloads + size classes.
- **YAML `--config`** with CLI-flag override (creds stay env-only).
- **Comparison table** with headline-metric dashing (seq→MB/s, rand→IOPS).
- **`bench/workloads/embed.go`** embeds the `.fio` jobs; `directory`/`size` parameterized so any target dir/size class works.

## Two real bugs caught by running fio (not just unit tests)

1. A job-file `directory=`/`size=` **silently overrides** fio's global `--directory`/`--size` CLI flags → parameterized both as `${VAR:-default}` in the templates and expand in Go instead.
2. fio prepends free-text `note:` lines to stdout even with `--output-format=json` → parser scrapes from the first `{`.

## Scope / deferred (per the plan)

- `--smoke` runs against a **local temp dir**, not a stood-up MinIO+DittoFS — that needs the PR3 backend registry to have anything to stand up on MinIO, so it folds into PR3.
- `S3MB` / `CTXSW` columns are carried in the schema but **0** until their meters land in PR5.
- SCW provisioning uses the salvaged `exec.go` SSH executor in PR4.

## Verification

- `gofmt -s` clean · `go build ./... ` · `go vet` · `go test ./cmd/bench/` (9 tests) · `golangci-lint` clean.
- Real `fio` smoke end-to-end: both cells run, JSON parsed, results saved, table renders; `--resume` re-run skips both and still prints the full table; `report` re-renders from disk.
- code-simplifier pass (removed a speculative one-impl `LoadGen` interface) + code-reviewer pass (no high-confidence bugs), gates re-run green after each.