### PR TITLE
fix(smb): Windows Security tab — stop hangs/crashes and surface AD grants (#1607, #1608)

### DIFF
--- a/internal/adapter/smb/handlers/pipe_write_read_race_test.go
+++ b/internal/adapter/smb/handlers/pipe_write_read_race_test.go
@@ -1,0 +1,156 @@
+package handlers
+
+// Regression test for #1607: the lost-wakeup race between the async-parking
+// pipe READ path (handlePipeRead) and the write-side completion path
+// (handlePipeWrite). Because every SMB2 request is dispatched in its own
+// goroutine, a client's WRITE (carrying the LsarLookupSids2 PDU) and its READ
+// (waiting for the response) run concurrently. Before the fix, the RPC response
+// could be written into the pipe buffer while the parked READ registered a
+// moment later — with nobody left to wake it — hanging Explorer's Security tab.
+//
+// This drives handlePipeWrite and handlePipeRead concurrently on the same pipe
+// handle for many iterations under -race, asserting the LookupSids2 response is
+// delivered exactly once every time (synchronously or via the async callback),
+// and never lost.
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/rpc"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/auth/sid"
+)
+
+// buildRaceBindPDU builds a minimal LSA bind PDU (mirrors the rpc package's
+// internal test builder, which is not importable here).
+func buildRaceBindPDU(callID uint32) []byte {
+	buf := make([]byte, 72)
+	buf[0] = 5 // version major
+	buf[2] = rpc.PDUBind
+	buf[3] = rpc.FlagFirstFrag | rpc.FlagLastFrag
+	buf[4] = 0x10                                     // little-endian data rep
+	binary.LittleEndian.PutUint16(buf[8:10], 72)      // frag length
+	binary.LittleEndian.PutUint32(buf[12:16], callID) // call ID
+	binary.LittleEndian.PutUint16(buf[16:18], 4280)   // max xmit
+	binary.LittleEndian.PutUint16(buf[18:20], 4280)   // max recv
+	buf[24] = 1                                       // num contexts
+	binary.LittleEndian.PutUint16(buf[28:30], 0)      // context ID
+	buf[30] = 1                                       // num transfer syntaxes
+	copy(buf[32:48], rpc.LSAInterfaceUUID[:])
+	copy(buf[52:68], rpc.NDRTransferSyntaxUUID[:])
+	binary.LittleEndian.PutUint32(buf[68:72], 2) // transfer syntax version
+	return buf
+}
+
+// buildRaceLookupSids2PDU builds an LsarLookupSids2 (opnum 57) request PDU for a
+// single SID.
+func buildRaceLookupSids2PDU(callID uint32, s *sid.SID) []byte {
+	var stub bytes.Buffer
+	stub.Write(make([]byte, 20)) // 20-byte policy handle
+	_ = binary.Write(&stub, binary.LittleEndian, uint32(1))          // Count
+	_ = binary.Write(&stub, binary.LittleEndian, uint32(0x00020000)) // array pointer
+	_ = binary.Write(&stub, binary.LittleEndian, uint32(1))          // conformant max
+	_ = binary.Write(&stub, binary.LittleEndian, uint32(0x00020004)) // SID pointer
+	_ = binary.Write(&stub, binary.LittleEndian, uint32(s.SubAuthorityCount))
+	sid.EncodeSID(&stub, s)
+	stubData := stub.Bytes()
+
+	fragLen := rpc.HeaderSize + 8 + len(stubData)
+	buf := make([]byte, fragLen)
+	buf[0] = 5
+	buf[2] = rpc.PDURequest
+	buf[3] = rpc.FlagFirstFrag | rpc.FlagLastFrag
+	buf[4] = 0x10
+	binary.LittleEndian.PutUint16(buf[8:10], uint16(fragLen))
+	binary.LittleEndian.PutUint32(buf[12:16], callID)
+	binary.LittleEndian.PutUint32(buf[16:20], uint32(len(stubData))) // alloc hint
+	binary.LittleEndian.PutUint16(buf[22:24], rpc.OpLsarLookupSids2)
+	copy(buf[24:], stubData)
+	return buf
+}
+
+func TestHandlePipe_WriteReadRace_DeliversResponseOnce(t *testing.T) {
+	const iterations = 300
+
+	h := NewHandler()
+	h.PipeManager = rpc.NewPipeManager()
+	h.PipeReadRegistry = NewPipeReadRegistry()
+
+	for i := 0; i < iterations; i++ {
+		var fileID [16]byte
+		binary.LittleEndian.PutUint64(fileID[:8], uint64(i)+1)
+
+		// Register and bind the pipe, then drain the bind_ack so the buffer is
+		// empty before the racing LookupSids2 exchange.
+		pipe := h.PipeManager.CreatePipe(fileID, "lsarpc")
+		if err := pipe.ProcessWrite(buildRaceBindPDU(1)); err != nil {
+			t.Fatalf("iter %d: bind: %v", i, err)
+		}
+		if ack := pipe.ProcessRead(65536); len(ack) == 0 {
+			t.Fatalf("iter %d: no bind_ack buffered", i)
+		}
+
+		// Capture an async-callback delivery, if the READ parks.
+		cbCh := make(chan []byte, 1)
+		ctx := NewSMBHandlerContext(context.TODO(), "race-client", 1, 1, uint64(i))
+		ctx.TryReserveAsync = func() bool { return true }
+		ctx.ReleaseAsync = func() {}
+		ctx.AsyncPipeReadCallback = func(_, _, _ uint64, status types.Status, data []byte) error {
+			cbCh <- data
+			return nil
+		}
+
+		writeReq := &WriteRequest{FileID: fileID, Data: buildRaceLookupSids2PDU(2, sid.WellKnownEveryone)}
+		readReq := &ReadRequest{FileID: fileID, Length: 4096}
+		writeOpen := &OpenFile{IsPipe: true, PipeName: "lsarpc"}
+		readOpen := &OpenFile{IsPipe: true, PipeName: "lsarpc"}
+
+		var wg sync.WaitGroup
+		var readResp *ReadResponse
+		var readErr error
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			if _, err := h.handlePipeWrite(ctx, writeReq, writeOpen); err != nil {
+				t.Errorf("iter %d: handlePipeWrite: %v", i, err)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			readResp, readErr = h.handlePipeRead(ctx, readReq, readOpen)
+		}()
+		wg.Wait()
+
+		if readErr != nil {
+			t.Fatalf("iter %d: handlePipeRead: %v", i, readErr)
+		}
+
+		switch readResp.Status {
+		case types.StatusSuccess:
+			// Delivered synchronously (either the normal ordering or the
+			// lost-wakeup recheck reclaimed the response).
+			if len(readResp.Data) == 0 {
+				t.Fatalf("iter %d: synchronous READ success carried no data", i)
+			}
+		case types.StatusPending:
+			// Parked: the WRITE-side completion must have delivered via callback.
+			select {
+			case data := <-cbCh:
+				if len(data) == 0 {
+					t.Fatalf("iter %d: async callback delivered empty data", i)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatalf("iter %d: READ parked (STATUS_PENDING) but response was never delivered — lost wakeup", i)
+			}
+		default:
+			t.Fatalf("iter %d: unexpected READ status %v", i, readResp.Status)
+		}
+
+		h.PipeManager.ClosePipe(fileID)
+	}
+}

--- a/internal/adapter/smb/handlers/pipe_write_read_race_test.go
+++ b/internal/adapter/smb/handlers/pipe_write_read_race_test.go
@@ -51,7 +51,7 @@ func buildRaceBindPDU(callID uint32) []byte {
 // single SID.
 func buildRaceLookupSids2PDU(callID uint32, s *sid.SID) []byte {
 	var stub bytes.Buffer
-	stub.Write(make([]byte, 20)) // 20-byte policy handle
+	stub.Write(make([]byte, 20))                                     // 20-byte policy handle
 	_ = binary.Write(&stub, binary.LittleEndian, uint32(1))          // Count
 	_ = binary.Write(&stub, binary.LittleEndian, uint32(0x00020000)) // array pointer
 	_ = binary.Write(&stub, binary.LittleEndian, uint32(1))          // conformant max

--- a/internal/adapter/smb/handlers/query_info.go
+++ b/internal/adapter/smb/handlers/query_info.go
@@ -387,13 +387,15 @@ func (h *Handler) QueryInfo(ctx *SMBHandlerContext, req *QueryInfoRequest) (*Que
 				}
 			}
 		}
-		// Merge the share's control-plane grants into the DACL so Windows'
-		// Security tab lists the AD principals (users, groups, direct SID
-		// grants) that actually govern the share — not just the file's
-		// synthesized owner+SYSTEM descriptor (#1608). Best-effort: a lookup
-		// failure (or a partially-wired runtime returning nil) falls back to the
-		// per-file descriptor so QUERY_INFO stays robust. Only worth doing when
-		// the DACL section is requested.
+		// Surface the share's direct AD/SID grants in the DACL so Windows'
+		// Security tab lists the AD principals that govern the share — not just
+		// the file's synthesized owner+SYSTEM descriptor (#1608). The projection
+		// is narrowed in buildDACL (sid: grants only, synthesized descriptors
+		// only) so it never perturbs an explicitly-set ACL or breaks SMB
+		// ACL-inheritance conformance. Best-effort: a lookup failure (or a
+		// partially-wired runtime returning nil) falls back to the per-file
+		// descriptor so QUERY_INFO stays robust. Only worth doing when the DACL
+		// section is requested.
 		var grantACEs []acl.ACE
 		if req.AdditionalInfo&DACLSecurityInformation != 0 && h.Registry != nil {
 			if grantACL, gerr := h.Registry.ShareRootGrantACL(ctx.Context, openFile.ShareName); gerr != nil {

--- a/internal/adapter/smb/handlers/query_info.go
+++ b/internal/adapter/smb/handlers/query_info.go
@@ -13,6 +13,7 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
 )
 
 // ============================================================================
@@ -386,7 +387,23 @@ func (h *Handler) QueryInfo(ctx *SMBHandlerContext, req *QueryInfoRequest) (*Que
 				}
 			}
 		}
-		info, err = BuildSecurityDescriptor(file, req.AdditionalInfo)
+		// Merge the share's control-plane grants into the DACL so Windows'
+		// Security tab lists the AD principals (users, groups, direct SID
+		// grants) that actually govern the share — not just the file's
+		// synthesized owner+SYSTEM descriptor (#1608). Best-effort: a lookup
+		// failure (or a partially-wired runtime returning nil) falls back to the
+		// per-file descriptor so QUERY_INFO stays robust. Only worth doing when
+		// the DACL section is requested.
+		var grantACEs []acl.ACE
+		if req.AdditionalInfo&DACLSecurityInformation != 0 && h.Registry != nil {
+			if grantACL, gerr := h.Registry.ShareRootGrantACL(ctx.Context, openFile.ShareName); gerr != nil {
+				logger.Debug("QUERY_INFO: share-grant ACL lookup failed (non-fatal)",
+					"share", openFile.ShareName, "error", gerr)
+			} else if grantACL != nil {
+				grantACEs = grantACL.ACEs
+			}
+		}
+		info, err = BuildSecurityDescriptorWithGrants(file, req.AdditionalInfo, grantACEs)
 	default:
 		return &QueryInfoResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 	}

--- a/internal/adapter/smb/handlers/read.go
+++ b/internal/adapter/smb/handlers/read.go
@@ -591,6 +591,45 @@ func (h *Handler) handlePipeRead(ctx *SMBHandlerContext, req *ReadRequest, openF
 			}, nil
 		}
 
+		// Lost-wakeup guard (#1607). A concurrent WRITE goroutine
+		// (handlePipeWrite) may have filled the pipe's ReadBuffer AND run its
+		// UnregisterByFileID completion sweep in the window between our
+		// ProcessRead above (which observed an empty buffer) and our Register
+		// here — finding no pending entry and thus never delivering the
+		// response. The buffer (PipeState.mu) and the registry use disjoint
+		// locks, so that interleaving strands the RPC response with nobody to
+		// wake this parked read, hanging Explorer's Security tab.
+		//
+		// Now that we are registered, re-check the buffer. If data is present and
+		// we can still reclaim our own pending entry (i.e. the WRITE path has not
+		// already grabbed it to deliver via callback), complete the read
+		// synchronously instead of parking. UnregisterByFileID is the atomic
+		// arbiter: whoever removes the pending entry owns delivery, so this can
+		// never double-deliver.
+		if pipe.HasData() {
+			if reclaimed := h.PipeReadRegistry.UnregisterByFileID(req.FileID); reclaimed != nil {
+				data := pipe.ProcessRead(int(req.Length))
+				if len(data) > 0 {
+					if ctx.ReleaseAsync != nil {
+						ctx.ReleaseAsync() // completing synchronously; return the reserved slot
+					}
+					logger.Debug("READ from pipe successful (lost-wakeup recheck)",
+						"pipeName", openFile.PipeName,
+						"bytesRead", len(data))
+					return &ReadResponse{
+						SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},
+						DataOffset:      0x50,
+						Data:            data,
+						DataRemaining:   0,
+					}, nil
+				}
+				// Buffer emptied out from under us despite HasData (we own the
+				// only pending read for this handle, so this should not happen).
+				// Re-register to preserve the wakeup contract and stay pending.
+				h.PipeReadRegistry.Register(reclaimed)
+			}
+		}
+
 		return &ReadResponse{
 			SMBResponseBase: SMBResponseBase{Status: types.StatusPending},
 			AsyncId:         asyncId,

--- a/internal/adapter/smb/handlers/runtime_iface.go
+++ b/internal/adapter/smb/handlers/runtime_iface.go
@@ -1,11 +1,14 @@
 package handlers
 
 import (
+	"context"
+
 	"github.com/marmos91/dittofs/internal/adapter/common"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
 	"github.com/marmos91/dittofs/pkg/metrics"
 )
 
@@ -26,6 +29,12 @@ type smbRuntime interface {
 	GetShare(name string) (*runtime.Share, error)
 	GetRootHandle(shareName string) (metadata.FileHandle, error)
 	ListShares() []string
+
+	// ShareRootGrantACL returns the allow-only ACL projecting the share's
+	// control-plane grants (user/group/SID + default) into Windows ACE form.
+	// The SMB Security-tab path merges these into file/dir descriptors (#1608).
+	// Returns (nil, nil) for a partially-wired runtime.
+	ShareRootGrantACL(ctx context.Context, shareName string) (*acl.ACL, error)
 
 	// Share-change notification (tree-connect cache invalidation).
 	OnShareChange(callback func(shares []string)) func()

--- a/internal/adapter/smb/handlers/security.go
+++ b/internal/adapter/smb/handlers/security.go
@@ -311,6 +311,23 @@ type windowsACE struct {
 	sid        *sid.SID
 }
 
+// ridFromSIDWho returns the trailing RID of a "sid:<SID>" ACE principal (the
+// last sub-authority of the SID). ok is false for any Who that is not a
+// well-formed "sid:" principal. Used to pair a share grant's SMB "sid:" ACE with
+// its NFS "{rid}@localdomain" numeric twin so the duplicate can be collapsed for
+// display.
+func ridFromSIDWho(who string) (uint32, bool) {
+	rest, ok := strings.CutPrefix(who, "sid:")
+	if !ok {
+		return 0, false
+	}
+	s, err := sid.ParseSIDString(rest)
+	if err != nil || s.SubAuthorityCount == 0 || len(s.SubAuthorities) == 0 {
+		return 0, false
+	}
+	return s.SubAuthorities[len(s.SubAuthorities)-1], true
+}
+
 // principalToSID maps an NFSv4 ACE principal identifier to a binary SID.
 // Handles special identifiers (OWNER@, GROUP@, EVERYONE@, SYSTEM@,
 // ADMINISTRATORS@) and falls back to SIDMapper.PrincipalToSID for others.
@@ -410,7 +427,29 @@ func buildDACL(buf *smbenc.Writer, file *metadata.File, grantACEs []acl.ACE) *ac
 		}, true
 	}
 
+	// A control-plane share-grant ACL (the reconciled share-root DACL) carries
+	// each AD principal TWICE: a "sid:<SID>" ACE matched over SMB/PAC, and a
+	// "{id}@localdomain" numeric ACE matched over NFS (which has no SID on the
+	// wire). The Windows Security tab resolves both to the same account, so the
+	// numeric twin shows as a duplicate row — and a group's numeric twin
+	// (matched via the user-only reverse lookup) resolves to a bogus
+	// "unix_user:<rid>". Suppress the numeric form when a sid: ACE for the same
+	// principal (RID == id) is present. Only share-grant ACLs carry this dual
+	// pattern; client-set ACLs are emitted verbatim (guarded by Source), and a
+	// pure local grant that has no sid: twin is kept.
+	suppressWho := map[string]struct{}{}
+	if fileACL.Source == acl.ACLSourceShareGrant {
+		for _, ace := range fileACL.ACEs {
+			if rid, ok := ridFromSIDWho(ace.Who); ok {
+				suppressWho[acl.LocalDomainPrincipal(rid)] = struct{}{}
+			}
+		}
+	}
+
 	for _, ace := range fileACL.ACEs {
+		if _, skip := suppressWho[ace.Who]; skip {
+			continue
+		}
 		wace, ok := toWindowsACE(ace)
 		if !ok {
 			continue

--- a/internal/adapter/smb/handlers/security.go
+++ b/internal/adapter/smb/handlers/security.go
@@ -311,23 +311,6 @@ type windowsACE struct {
 	sid        *sid.SID
 }
 
-// ridFromSIDWho returns the trailing RID of a "sid:<SID>" ACE principal (the
-// last sub-authority of the SID). ok is false for any Who that is not a
-// well-formed "sid:" principal. Used to pair a share grant's SMB "sid:" ACE with
-// its NFS "{rid}@localdomain" numeric twin so the duplicate can be collapsed for
-// display.
-func ridFromSIDWho(who string) (uint32, bool) {
-	rest, ok := strings.CutPrefix(who, "sid:")
-	if !ok {
-		return 0, false
-	}
-	s, err := sid.ParseSIDString(rest)
-	if err != nil || s.SubAuthorityCount == 0 || len(s.SubAuthorities) == 0 {
-		return 0, false
-	}
-	return s.SubAuthorities[len(s.SubAuthorities)-1], true
-}
-
 // principalToSID maps an NFSv4 ACE principal identifier to a binary SID.
 // Handles special identifiers (OWNER@, GROUP@, EVERYONE@, SYSTEM@,
 // ADMINISTRATORS@) and falls back to SIDMapper.PrincipalToSID for others.
@@ -427,27 +410,17 @@ func buildDACL(buf *smbenc.Writer, file *metadata.File, grantACEs []acl.ACE) *ac
 		}, true
 	}
 
-	// A control-plane share-grant ACL (the reconciled share-root DACL) carries
-	// each AD principal TWICE: a "sid:<SID>" ACE matched over SMB/PAC, and a
-	// "{id}@localdomain" numeric ACE matched over NFS (which has no SID on the
-	// wire). The Windows Security tab resolves both to the same account, so the
-	// numeric twin shows as a duplicate row — and a group's numeric twin
-	// (matched via the user-only reverse lookup) resolves to a bogus
-	// "unix_user:<rid>". Suppress the numeric form when a sid: ACE for the same
-	// principal (RID == id) is present. Only share-grant ACLs carry this dual
-	// pattern; client-set ACLs are emitted verbatim (guarded by Source), and a
-	// pure local grant that has no sid: twin is kept.
-	suppressWho := map[string]struct{}{}
-	if fileACL.Source == acl.ACLSourceShareGrant {
-		for _, ace := range fileACL.ACEs {
-			if rid, ok := ridFromSIDWho(ace.Who); ok {
-				suppressWho[acl.LocalDomainPrincipal(rid)] = struct{}{}
-			}
-		}
-	}
-
 	for _, ace := range fileACL.ACEs {
-		if _, skip := suppressWho[ace.Who]; skip {
+		// Hide a share-grant NFS numeric twin: a "{id}@localdomain" ACE that
+		// duplicates a "sid:<SID>" ACE for the same AD principal and exists only
+		// for NFS numeric matching (acl.ACE.NFSNumericTwin, set by
+		// BuildShareRootACL where the SID↔id pairing is known — correct in every
+		// idmap mode). Without this the Windows Security tab lists the principal
+		// twice, and a group's numeric twin resolves via the user-only reverse
+		// path to a bogus "unix_user:<id>". Enforcement is unaffected: the ACL
+		// evaluator still honors the twin for NFS. Client-set ACLs never carry
+		// the flag, so their ACEs are always emitted verbatim.
+		if ace.NFSNumericTwin {
 			continue
 		}
 		wace, ok := toWindowsACE(ace)

--- a/internal/adapter/smb/handlers/security.go
+++ b/internal/adapter/smb/handlers/security.go
@@ -18,6 +18,7 @@ package handlers
 
 import (
 	"fmt"
+	"strings"
 	"sync/atomic"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
@@ -166,12 +167,16 @@ func BuildSecurityDescriptor(file *metadata.File, additionalSecInfo uint32) ([]b
 }
 
 // BuildSecurityDescriptorWithGrants is BuildSecurityDescriptor plus a set of
-// share-grant ACEs to merge into the DACL so Windows' Security tab lists the
-// AD principals (users, groups, direct SID grants) that govern the share, not
-// just the file's synthesized owner+SYSTEM descriptor (#1608). grantACEs is the
-// output of Runtime.ShareRootGrantACL for the share owning the file; pass nil to
-// build a descriptor from per-file metadata only. Merging affects only the
-// displayed descriptor — server-side access enforcement is unchanged.
+// share-grant ACEs (the output of Runtime.ShareRootGrantACL for the share owning
+// the file) to surface in the DACL so Windows' Security tab lists the direct
+// AD/SID principals (#1528) that govern the share, not just the file's
+// synthesized owner+SYSTEM descriptor (#1608). Pass nil to build a descriptor
+// from per-file metadata only.
+//
+// The projection is intentionally narrow (see buildDACL): only direct "sid:"
+// grants are surfaced, and only onto files that have no explicitly-stored ACL.
+// Merging affects only the displayed descriptor — server-side access enforcement
+// is unchanged.
 func BuildSecurityDescriptorWithGrants(file *metadata.File, additionalSecInfo uint32, grantACEs []acl.ACE) ([]byte, error) {
 	includeOwner := (additionalSecInfo & OwnerSecurityInformation) != 0
 	includeGroup := (additionalSecInfo & GroupSecurityInformation) != 0
@@ -350,11 +355,25 @@ func principalToSID(who string, fileUID, fileGID uint32) *sid.SID {
 // POSIX semantics so Unix mode bits stay authoritative on the server.
 //
 // grantACEs, when non-nil, are share-level grant ACEs (Runtime.ShareRootGrantACL)
-// merged into the DACL so Windows' Security tab lists the AD principals that
-// govern the share (#1608). They are appended after the file's own ACEs and
-// deduped by resolved SID, so the always-on OWNER@/SYSTEM@ that both the
-// synthesized default and the grant ACL emit are not shown twice. This changes
-// only the displayed descriptor, never server-side enforcement.
+// surfaced in the DACL so Windows' Security tab lists the AD principals that
+// govern the share (#1608). The projection is deliberately narrow so it can
+// never alter a descriptor a client set or that a conformance client round-trips
+// against:
+//
+//   - Only files with NO explicitly-stored ACL (file.ACL == nil → synthesized
+//     default) are decorated. A client that SET a file's ACL — or one that reads
+//     a NULL DACL back — sees exactly what was stored, unperturbed.
+//   - Only direct AD/SID grants (#1528, Who has the "sid:" prefix) are surfaced.
+//     A direct SID grant has no other way to appear in Windows (it maps to no
+//     local file owner/group). The always-on OWNER@/SYSTEM@/ADMINISTRATORS@
+//     trustees, local user/group grants, and the EVERYONE@ default already reach
+//     Windows through the reconciled share-root ACL and the owner/group SIDs, and
+//     injecting them into every child descriptor breaks SMB ACL-inheritance
+//     conformance (smbtorture smb2.create.aclfile/acldir create a child with no
+//     SD and assert its default is exactly owner+SYSTEM).
+//
+// Surfaced grants are appended after the file's own ACEs and deduped by resolved
+// SID. This changes only the displayed descriptor, never server-side enforcement.
 //
 // Returns the source ACL used for SD control flag computation.
 func buildDACL(buf *smbenc.Writer, file *metadata.File, grantACEs []acl.ACE) *acl.ACL {
@@ -364,6 +383,12 @@ func buildDACL(buf *smbenc.Writer, file *metadata.File, grantACEs []acl.ACE) *ac
 		fileACL = file.ACL
 	} else {
 		fileACL = acl.SynthesizeWindowsDefault()
+	}
+
+	// Only a synthesized default is decorated with share grants (see the doc
+	// comment above). A file carrying an explicit ACL is emitted verbatim.
+	if file.ACL != nil {
+		grantACEs = nil
 	}
 
 	aces := make([]windowsACE, 0, len(fileACL.ACEs)+len(grantACEs))
@@ -395,10 +420,16 @@ func buildDACL(buf *smbenc.Writer, file *metadata.File, grantACEs []acl.ACE) *ac
 		}
 		aces = append(aces, wace)
 	}
-	// Merge share-grant trustees, skipping any whose SID the file already carries
-	// (the always-on OWNER@/SYSTEM@ that both the synthesized default and the
-	// grant ACL emit) so the Security tab does not show duplicate rows (#1608).
+	// Surface direct AD/SID grants only (see the doc comment): the always-on
+	// OWNER@/SYSTEM@/ADMINISTRATORS@ trustees, local "{id}@localdomain" grants,
+	// and the EVERYONE@ default already reach Windows via the reconciled share
+	// root and the owner/group SIDs. Skipping them here keeps child descriptors
+	// conformance-clean. Any surviving grant whose SID the file already carries is
+	// also skipped so the Security tab does not show duplicate rows (#1608).
 	for _, ace := range grantACEs {
+		if !strings.HasPrefix(ace.Who, "sid:") {
+			continue
+		}
 		wace, ok := toWindowsACE(ace)
 		if !ok {
 			continue

--- a/internal/adapter/smb/handlers/security.go
+++ b/internal/adapter/smb/handlers/security.go
@@ -162,6 +162,17 @@ func GetSIDMapper() *sid.SIDMapper {
 //
 // Returns the binary Security Descriptor or an error.
 func BuildSecurityDescriptor(file *metadata.File, additionalSecInfo uint32) ([]byte, error) {
+	return BuildSecurityDescriptorWithGrants(file, additionalSecInfo, nil)
+}
+
+// BuildSecurityDescriptorWithGrants is BuildSecurityDescriptor plus a set of
+// share-grant ACEs to merge into the DACL so Windows' Security tab lists the
+// AD principals (users, groups, direct SID grants) that govern the share, not
+// just the file's synthesized owner+SYSTEM descriptor (#1608). grantACEs is the
+// output of Runtime.ShareRootGrantACL for the share owning the file; pass nil to
+// build a descriptor from per-file metadata only. Merging affects only the
+// displayed descriptor — server-side access enforcement is unchanged.
+func BuildSecurityDescriptorWithGrants(file *metadata.File, additionalSecInfo uint32, grantACEs []acl.ACE) ([]byte, error) {
 	includeOwner := (additionalSecInfo & OwnerSecurityInformation) != 0
 	includeGroup := (additionalSecInfo & GroupSecurityInformation) != 0
 	includeDACL := (additionalSecInfo & DACLSecurityInformation) != 0
@@ -180,7 +191,7 @@ func BuildSecurityDescriptor(file *metadata.File, additionalSecInfo uint32) ([]b
 	daclBuf := smbenc.NewWriter(64)
 	var fileACL *acl.ACL
 	if includeDACL && !isNullDACL {
-		fileACL = buildDACL(daclBuf, file)
+		fileACL = buildDACL(daclBuf, file, grantACEs)
 	}
 
 	// Build SACL. When the file has stored SACL ACEs, serialize them;
@@ -338,9 +349,15 @@ func principalToSID(who string, fileUID, fileGID uint32) *sid.SID {
 // here is what the client sees; actual access enforcement keeps the legacy
 // POSIX semantics so Unix mode bits stay authoritative on the server.
 //
+// grantACEs, when non-nil, are share-level grant ACEs (Runtime.ShareRootGrantACL)
+// merged into the DACL so Windows' Security tab lists the AD principals that
+// govern the share (#1608). They are appended after the file's own ACEs and
+// deduped by resolved SID, so the always-on OWNER@/SYSTEM@ that both the
+// synthesized default and the grant ACL emit are not shown twice. This changes
+// only the displayed descriptor, never server-side enforcement.
+//
 // Returns the source ACL used for SD control flag computation.
-func buildDACL(buf *smbenc.Writer, file *metadata.File) *acl.ACL {
-	var aces []windowsACE
+func buildDACL(buf *smbenc.Writer, file *metadata.File, grantACEs []acl.ACE) *acl.ACL {
 	var fileACL *acl.ACL
 
 	if file.ACL != nil {
@@ -349,19 +366,51 @@ func buildDACL(buf *smbenc.Writer, file *metadata.File) *acl.ACL {
 		fileACL = acl.SynthesizeWindowsDefault()
 	}
 
-	aces = make([]windowsACE, 0, len(fileACL.ACEs))
-	for _, ace := range fileACL.ACEs {
+	aces := make([]windowsACE, 0, len(fileACL.ACEs)+len(grantACEs))
+	// SIDs already present from the file's own ACEs. Used ONLY to dedup the
+	// merged share-grant trustees below — the file's own ACL is emitted verbatim
+	// (a file may legitimately carry several ACEs for one SID, e.g. a DENY then
+	// an ALLOW, and their order is significant).
+	fileSIDs := make(map[string]struct{}, len(fileACL.ACEs))
+	toWindowsACE := func(ace acl.ACE) (windowsACE, bool) {
 		aceType, ok := nfsToWindowsACEType(ace.Type)
 		if !ok {
-			continue
+			return windowsACE{}, false
 		}
-
-		aces = append(aces, windowsACE{
+		return windowsACE{
 			aceType:    aceType,
 			aceFlags:   acl.NFSv4FlagsToWindowsFlags(ace.Flag),
 			accessMask: ace.AccessMask,
 			sid:        principalToSID(ace.Who, file.UID, file.GID),
-		})
+		}, true
+	}
+
+	for _, ace := range fileACL.ACEs {
+		wace, ok := toWindowsACE(ace)
+		if !ok {
+			continue
+		}
+		if wace.sid != nil {
+			fileSIDs[sid.FormatSID(wace.sid)] = struct{}{}
+		}
+		aces = append(aces, wace)
+	}
+	// Merge share-grant trustees, skipping any whose SID the file already carries
+	// (the always-on OWNER@/SYSTEM@ that both the synthesized default and the
+	// grant ACL emit) so the Security tab does not show duplicate rows (#1608).
+	for _, ace := range grantACEs {
+		wace, ok := toWindowsACE(ace)
+		if !ok {
+			continue
+		}
+		if wace.sid != nil {
+			key := sid.FormatSID(wace.sid)
+			if _, dup := fileSIDs[key]; dup {
+				continue
+			}
+			fileSIDs[key] = struct{}{}
+		}
+		aces = append(aces, wace)
 	}
 
 	// Compute total ACL size

--- a/internal/adapter/smb/handlers/security_test.go
+++ b/internal/adapter/smb/handlers/security_test.go
@@ -172,11 +172,13 @@ func TestBuildSD_NilACL_SynthesizesWindowsDefault(t *testing.T) {
 	}
 }
 
-// TestBuildSD_MergesShareGrantACEs verifies that BuildSecurityDescriptorWithGrants
-// projects the share's control-plane grant trustees (a direct AD SID grant plus
-// the always-on Administrators@) into the file DACL so Windows' Security tab can
-// list them, while deduping the OWNER@/SYSTEM@ that both the synthesized default
-// and the grant ACL emit (#1608).
+// TestBuildSD_MergesShareGrantACEs verifies the narrowed #1608 projection: on a
+// file with no stored ACL, BuildSecurityDescriptorWithGrants surfaces the share's
+// direct AD/SID grant (Who="sid:…") so Windows' Security tab can resolve it, but
+// does NOT inject the always-on ADMINISTRATORS@ or a local "{id}@localdomain"
+// grant — those reach Windows via the reconciled share-root ACL and would break
+// SMB ACL-inheritance conformance if stamped onto every child descriptor. OWNER@
+// and SYSTEM@ come from the synthesized default and appear exactly once.
 func TestBuildSD_MergesShareGrantACEs(t *testing.T) {
 	file := &metadata.File{
 		FileAttr: metadata.FileAttr{
@@ -188,7 +190,10 @@ func TestBuildSD_MergesShareGrantACEs(t *testing.T) {
 	}
 
 	const aliceSID = "S-1-5-21-188294588-3368521931-100232490-1106"
+	// A realistic share grant set: the always-on trustees (OWNER@, SYSTEM@,
+	// ADMINISTRATORS@), a local user grant (uid 4242), and a direct AD/SID grant.
 	grantACL := acl.BuildShareRootACL(acl.GrantNone, []acl.RootGrant{
+		{ID: 4242, Level: acl.GrantReadWrite},
 		{SID: aliceSID, Level: acl.GrantRead},
 	})
 
@@ -223,17 +228,62 @@ func TestBuildSD_MergesShareGrantACEs(t *testing.T) {
 	if whoCount["sid:"+aliceSID] != 1 {
 		t.Errorf("merged DACL missing the AD SID grant %q (Who counts: %v)", aliceSID, whoCount)
 	}
-	// The always-on Administrators@ grant (BUILTIN\Administrators) must appear.
-	if whoCount["sid:S-1-5-32-544"] != 1 {
-		t.Errorf("merged DACL missing Administrators grant (Who counts: %v)", whoCount)
+	// The always-on ADMINISTRATORS@ trustee must NOT be stamped onto the child —
+	// it is not a direct SID grant and would regress smbtorture acls/create.
+	if whoCount["sid:S-1-5-32-544"] != 0 {
+		t.Errorf("Administrators@ leaked into child DACL (Who counts: %v)", whoCount)
 	}
-	// OWNER@ / SYSTEM@ are shared between the file default and the grant ACL —
-	// each must appear exactly once (deduped by SID).
+	// A local user grant must NOT be stamped onto the child either.
+	if whoCount["4242@localdomain"] != 0 {
+		t.Errorf("local user grant leaked into child DACL (Who counts: %v)", whoCount)
+	}
+	// OWNER@ / SYSTEM@ come from the synthesized default only — one each.
 	if whoCount["1000@localdomain"] != 1 {
-		t.Errorf("owner ACE not deduped: appears %d times (want 1)", whoCount["1000@localdomain"])
+		t.Errorf("owner ACE count = %d (want 1)", whoCount["1000@localdomain"])
 	}
 	if whoCount["sid:S-1-5-18"] != 1 {
-		t.Errorf("SYSTEM ACE not deduped: appears %d times (want 1)", whoCount["sid:S-1-5-18"])
+		t.Errorf("SYSTEM ACE count = %d (want 1)", whoCount["sid:S-1-5-18"])
+	}
+}
+
+// TestBuildSD_ExplicitACL_IgnoresGrants verifies that a file carrying an
+// explicitly-stored ACL is emitted verbatim even when share grants (including a
+// direct SID grant) are supplied: a client that SET a file's ACL, or reads it
+// back, must see exactly what was stored. This is what keeps smbtorture
+// smb2.acls / smb2.create round-trips byte-exact after #1608.
+func TestBuildSD_ExplicitACL_IgnoresGrants(t *testing.T) {
+	file := &metadata.File{
+		FileAttr: metadata.FileAttr{
+			UID:  1000,
+			GID:  1000,
+			Mode: 0o755,
+			ACL: &acl.ACL{
+				ACEs: []acl.ACE{
+					{
+						Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+						AccessMask: acl.ACE4_READ_DATA | acl.ACE4_EXECUTE,
+						Who:        "EVERYONE@",
+					},
+				},
+			},
+		},
+	}
+
+	const aliceSID = "S-1-5-21-188294588-3368521931-100232490-1106"
+	grantACL := acl.BuildShareRootACL(acl.GrantNone, []acl.RootGrant{
+		{SID: aliceSID, Level: acl.GrantRead},
+	})
+
+	plain, err := BuildSecurityDescriptor(file, allSecInfo)
+	if err != nil {
+		t.Fatalf("BuildSecurityDescriptor: %v", err)
+	}
+	withGrants, err := BuildSecurityDescriptorWithGrants(file, allSecInfo, grantACL.ACEs)
+	if err != nil {
+		t.Fatalf("BuildSecurityDescriptorWithGrants: %v", err)
+	}
+	if !bytes.Equal(plain, withGrants) {
+		t.Fatal("explicit-ACL descriptor changed when share grants were supplied; grants must not touch a stored ACL")
 	}
 }
 

--- a/internal/adapter/smb/handlers/security_test.go
+++ b/internal/adapter/smb/handlers/security_test.go
@@ -295,11 +295,12 @@ func TestBuildSD_ExplicitACL_IgnoresGrants(t *testing.T) {
 // unix_user:<rid>). A pure local grant, which has no sid: twin, is kept.
 func TestBuildSD_ShareGrant_SuppressesNumericTwin(t *testing.T) {
 	const aliceSID = "S-1-5-21-188294588-3368521931-100232490-1106"
-	// alice: an AD/SID grant that carries a resolved Unix id (1106) → emits BOTH
-	// sid:…-1106 and 1106@localdomain. localUID 4242: a local grant → only the
-	// numeric form.
+	// alice: an AD/SID grant whose resolved Unix id (99001) DIFFERS from the SID's
+	// RID (1106) — the idmap:rfc2307 shape the old RID-keyed suppression missed.
+	// It emits BOTH sid:…-1106 and 99001@localdomain (flagged NFSNumericTwin).
+	// localUID 4242: a plain local grant → only the numeric form, unflagged.
 	rootACL := acl.BuildShareRootACL(acl.GrantNone, []acl.RootGrant{
-		{ID: 1106, SID: aliceSID, Level: acl.GrantRead},
+		{ID: 99001, SID: aliceSID, Level: acl.GrantRead},
 		{ID: 4242, Level: acl.GrantReadWrite},
 	})
 	if rootACL.Source != acl.ACLSourceShareGrant {
@@ -322,12 +323,13 @@ func TestBuildSD_ShareGrant_SuppressesNumericTwin(t *testing.T) {
 		whoCount[ace.Who]++
 	}
 
-	// alice's sid: form survives; her numeric twin is suppressed.
+	// alice's sid: form survives; her numeric twin (99001@localdomain, id != RID)
+	// is suppressed regardless of idmap mode.
 	if whoCount["sid:"+aliceSID] != 1 {
 		t.Errorf("alice sid: ACE count = %d, want 1 (Who counts: %v)", whoCount["sid:"+aliceSID], whoCount)
 	}
-	if n := whoCount["1106@localdomain"]; n != 0 {
-		t.Errorf("alice numeric twin not suppressed: 1106@localdomain count = %d, want 0", n)
+	if n := whoCount["99001@localdomain"]; n != 0 {
+		t.Errorf("alice numeric twin not suppressed: 99001@localdomain count = %d, want 0", n)
 	}
 	// The local grant (no sid: twin) is kept.
 	if whoCount["4242@localdomain"] != 1 {

--- a/internal/adapter/smb/handlers/security_test.go
+++ b/internal/adapter/smb/handlers/security_test.go
@@ -172,6 +172,91 @@ func TestBuildSD_NilACL_SynthesizesWindowsDefault(t *testing.T) {
 	}
 }
 
+// TestBuildSD_MergesShareGrantACEs verifies that BuildSecurityDescriptorWithGrants
+// projects the share's control-plane grant trustees (a direct AD SID grant plus
+// the always-on Administrators@) into the file DACL so Windows' Security tab can
+// list them, while deduping the OWNER@/SYSTEM@ that both the synthesized default
+// and the grant ACL emit (#1608).
+func TestBuildSD_MergesShareGrantACEs(t *testing.T) {
+	file := &metadata.File{
+		FileAttr: metadata.FileAttr{
+			UID:  1000,
+			GID:  1000,
+			Mode: 0o755,
+			// nil ACL → synthesized default (owner@ + SYSTEM@).
+		},
+	}
+
+	const aliceSID = "S-1-5-21-188294588-3368521931-100232490-1106"
+	grantACL := acl.BuildShareRootACL(acl.GrantNone, []acl.RootGrant{
+		{SID: aliceSID, Level: acl.GrantRead},
+	})
+
+	// Baseline without grants: the synthesized default is exactly owner + SYSTEM.
+	baseline, err := BuildSecurityDescriptor(file, allSecInfo)
+	if err != nil {
+		t.Fatalf("BuildSecurityDescriptor: %v", err)
+	}
+	_, _, baseACL, err := ParseSecurityDescriptor(baseline)
+	if err != nil {
+		t.Fatalf("ParseSecurityDescriptor(baseline): %v", err)
+	}
+	if len(baseACL.ACEs) != 2 {
+		t.Fatalf("baseline DACL = %d ACEs, want 2 (owner + SYSTEM)", len(baseACL.ACEs))
+	}
+
+	data, err := BuildSecurityDescriptorWithGrants(file, allSecInfo, grantACL.ACEs)
+	if err != nil {
+		t.Fatalf("BuildSecurityDescriptorWithGrants: %v", err)
+	}
+	_, _, mergedACL, err := ParseSecurityDescriptor(data)
+	if err != nil {
+		t.Fatalf("ParseSecurityDescriptor(merged): %v", err)
+	}
+
+	whoCount := map[string]int{}
+	for _, ace := range mergedACL.ACEs {
+		whoCount[ace.Who]++
+	}
+
+	// The AD SID grant must be present so Explorer can resolve it to alice.
+	if whoCount["sid:"+aliceSID] != 1 {
+		t.Errorf("merged DACL missing the AD SID grant %q (Who counts: %v)", aliceSID, whoCount)
+	}
+	// The always-on Administrators@ grant (BUILTIN\Administrators) must appear.
+	if whoCount["sid:S-1-5-32-544"] != 1 {
+		t.Errorf("merged DACL missing Administrators grant (Who counts: %v)", whoCount)
+	}
+	// OWNER@ / SYSTEM@ are shared between the file default and the grant ACL —
+	// each must appear exactly once (deduped by SID).
+	if whoCount["1000@localdomain"] != 1 {
+		t.Errorf("owner ACE not deduped: appears %d times (want 1)", whoCount["1000@localdomain"])
+	}
+	if whoCount["sid:S-1-5-18"] != 1 {
+		t.Errorf("SYSTEM ACE not deduped: appears %d times (want 1)", whoCount["sid:S-1-5-18"])
+	}
+}
+
+// TestBuildSD_NilGrants_MatchesBaseline verifies that passing nil grantACEs is
+// identical to the plain BuildSecurityDescriptor (no behavior change for the
+// non-grant path).
+func TestBuildSD_NilGrants_MatchesBaseline(t *testing.T) {
+	file := &metadata.File{
+		FileAttr: metadata.FileAttr{UID: 1000, GID: 1000, Mode: 0o755},
+	}
+	plain, err := BuildSecurityDescriptor(file, allSecInfo)
+	if err != nil {
+		t.Fatalf("BuildSecurityDescriptor: %v", err)
+	}
+	withNil, err := BuildSecurityDescriptorWithGrants(file, allSecInfo, nil)
+	if err != nil {
+		t.Fatalf("BuildSecurityDescriptorWithGrants: %v", err)
+	}
+	if !bytes.Equal(plain, withNil) {
+		t.Fatal("BuildSecurityDescriptorWithGrants(nil) differs from BuildSecurityDescriptor")
+	}
+}
+
 // TestBuildSD_ZeroSecInfo_ReturnsEmptySD verifies that additionalSecInfo==0
 // produces a minimal 20-byte header-only SD with control=SE_SELF_RELATIVE
 // and no owner/group/DACL/SACL. Matches Windows behavior exercised by

--- a/internal/adapter/smb/handlers/security_test.go
+++ b/internal/adapter/smb/handlers/security_test.go
@@ -287,6 +287,54 @@ func TestBuildSD_ExplicitACL_IgnoresGrants(t *testing.T) {
 	}
 }
 
+// TestBuildSD_ShareGrant_SuppressesNumericTwin verifies that when a share-grant
+// ACL (the reconciled share-root DACL) carries a principal in both its SMB
+// "sid:" form and its NFS "{id}@localdomain" numeric form, the SMB descriptor
+// shows only the sid: form — so the Windows Security tab does not list the same
+// AD principal twice (and a group's numeric twin does not surface as
+// unix_user:<rid>). A pure local grant, which has no sid: twin, is kept.
+func TestBuildSD_ShareGrant_SuppressesNumericTwin(t *testing.T) {
+	const aliceSID = "S-1-5-21-188294588-3368521931-100232490-1106"
+	// alice: an AD/SID grant that carries a resolved Unix id (1106) → emits BOTH
+	// sid:…-1106 and 1106@localdomain. localUID 4242: a local grant → only the
+	// numeric form.
+	rootACL := acl.BuildShareRootACL(acl.GrantNone, []acl.RootGrant{
+		{ID: 1106, SID: aliceSID, Level: acl.GrantRead},
+		{ID: 4242, Level: acl.GrantReadWrite},
+	})
+	if rootACL.Source != acl.ACLSourceShareGrant {
+		t.Fatalf("BuildShareRootACL source = %v, want share-grant", rootACL.Source)
+	}
+	file := &metadata.File{
+		FileAttr: metadata.FileAttr{UID: 0, GID: 0, Mode: 0o755, ACL: rootACL},
+	}
+
+	data, err := BuildSecurityDescriptor(file, allSecInfo)
+	if err != nil {
+		t.Fatalf("BuildSecurityDescriptor: %v", err)
+	}
+	_, _, dacl, err := ParseSecurityDescriptor(data)
+	if err != nil {
+		t.Fatalf("ParseSecurityDescriptor: %v", err)
+	}
+	whoCount := map[string]int{}
+	for _, ace := range dacl.ACEs {
+		whoCount[ace.Who]++
+	}
+
+	// alice's sid: form survives; her numeric twin is suppressed.
+	if whoCount["sid:"+aliceSID] != 1 {
+		t.Errorf("alice sid: ACE count = %d, want 1 (Who counts: %v)", whoCount["sid:"+aliceSID], whoCount)
+	}
+	if n := whoCount["1106@localdomain"]; n != 0 {
+		t.Errorf("alice numeric twin not suppressed: 1106@localdomain count = %d, want 0", n)
+	}
+	// The local grant (no sid: twin) is kept.
+	if whoCount["4242@localdomain"] != 1 {
+		t.Errorf("local grant dropped: 4242@localdomain count = %d, want 1", whoCount["4242@localdomain"])
+	}
+}
+
 // TestBuildSD_NilGrants_MatchesBaseline verifies that passing nil grantACEs is
 // identical to the plain BuildSecurityDescriptor (no behavior change for the
 // non-grant path).

--- a/internal/adapter/smb/rpc/dcerpc.go
+++ b/internal/adapter/smb/rpc/dcerpc.go
@@ -152,7 +152,7 @@ func ParseBindRequest(data []byte) (*BindRequest, error) {
 	if hdr.PacketType != PDUBind {
 		return nil, fmt.Errorf("not a bind PDU: type %d", hdr.PacketType)
 	}
-	return parseBindLike(data)
+	return parseBindLike(data, hdr)
 }
 
 // ParseAlterContext parses an Alter_Context PDU. Its body layout is identical
@@ -166,19 +166,15 @@ func ParseAlterContext(data []byte) (*BindRequest, error) {
 	if hdr.PacketType != PDUAlterContext {
 		return nil, fmt.Errorf("not an alter_context PDU: type %d", hdr.PacketType)
 	}
-	return parseBindLike(data)
+	return parseBindLike(data, hdr)
 }
 
 // parseBindLike parses the shared Bind / Alter_Context body without asserting a
-// specific PDU type (the caller validates the type).
-func parseBindLike(data []byte) (*BindRequest, error) {
+// specific PDU type (the caller validates the type). hdr is the already-parsed
+// header for data, threaded in so the header is parsed exactly once per PDU.
+func parseBindLike(data []byte, hdr *Header) (*BindRequest, error) {
 	if len(data) < HeaderSize+9 {
 		return nil, fmt.Errorf("bind/alter request too short")
-	}
-
-	hdr, err := ParseHeader(data)
-	if err != nil {
-		return nil, err
 	}
 
 	req := &BindRequest{

--- a/internal/adapter/smb/rpc/dcerpc.go
+++ b/internal/adapter/smb/rpc/dcerpc.go
@@ -143,19 +143,42 @@ type SyntaxID struct {
 	Version uint32
 }
 
-// ParseBindRequest parses a Bind PDU
+// ParseBindRequest parses a Bind PDU.
 func ParseBindRequest(data []byte) (*BindRequest, error) {
+	hdr, err := ParseHeader(data)
+	if err != nil {
+		return nil, err
+	}
+	if hdr.PacketType != PDUBind {
+		return nil, fmt.Errorf("not a bind PDU: type %d", hdr.PacketType)
+	}
+	return parseBindLike(data)
+}
+
+// ParseAlterContext parses an Alter_Context PDU. Its body layout is identical
+// to a Bind PDU (max_xmit/max_recv/assoc_group + presentation-context list), so
+// it shares the Bind parser; only the PDU type differs on the wire.
+func ParseAlterContext(data []byte) (*BindRequest, error) {
+	hdr, err := ParseHeader(data)
+	if err != nil {
+		return nil, err
+	}
+	if hdr.PacketType != PDUAlterContext {
+		return nil, fmt.Errorf("not an alter_context PDU: type %d", hdr.PacketType)
+	}
+	return parseBindLike(data)
+}
+
+// parseBindLike parses the shared Bind / Alter_Context body without asserting a
+// specific PDU type (the caller validates the type).
+func parseBindLike(data []byte) (*BindRequest, error) {
 	if len(data) < HeaderSize+9 {
-		return nil, fmt.Errorf("bind request too short")
+		return nil, fmt.Errorf("bind/alter request too short")
 	}
 
 	hdr, err := ParseHeader(data)
 	if err != nil {
 		return nil, err
-	}
-
-	if hdr.PacketType != PDUBind {
-		return nil, fmt.Errorf("not a bind PDU: type %d", hdr.PacketType)
 	}
 
 	req := &BindRequest{
@@ -370,5 +393,41 @@ func (r *Response) Encode(callID uint32) []byte {
 
 	copy(buf[24:], r.StubData)
 
+	return buf
+}
+
+// =============================================================================
+// Fault PDU
+// =============================================================================
+
+// DCE/RPC reject status codes [C706 §14.6 / MS-RPCE]. Returned in a FAULT PDU.
+const (
+	// NcaSProtoError is nca_s_proto_error — a protocol error, e.g. a Request PDU
+	// arriving before a successful Bind established a presentation context.
+	NcaSProtoError uint32 = 0x1C01000B
+)
+
+// EncodeFaultPDU builds a DCE/RPC FAULT PDU carrying the given reject status.
+// It is used to answer a request that cannot be dispatched so the client's
+// paired pipe READ always completes instead of starving (#1607).
+func EncodeFaultPDU(callID uint32, status uint32) []byte {
+	fragLen := HeaderSize + 16
+
+	hdr := Header{
+		VersionMajor: 5,
+		VersionMinor: 0,
+		PacketType:   PDUFault,
+		Flags:        FlagFirstFrag | FlagLastFrag,
+		DataRep:      [4]byte{0x10, 0x00, 0x00, 0x00},
+		FragLength:   uint16(fragLen),
+		AuthLength:   0,
+		CallID:       callID,
+	}
+
+	buf := make([]byte, fragLen)
+	copy(buf[0:16], hdr.Encode())
+	// alloc_hint(4) + context_id(2) + cancel_count(1) + reserved(1) stay zero.
+	binary.LittleEndian.PutUint32(buf[24:28], status) // status
+	binary.LittleEndian.PutUint32(buf[28:32], 0)      // reserved
 	return buf
 }

--- a/internal/adapter/smb/rpc/lsarpc.go
+++ b/internal/adapter/smb/rpc/lsarpc.go
@@ -652,13 +652,16 @@ func (h *LSARPCHandler) buildLookupSidsResponse(
 			refID += 4
 		}
 
-		// Deferred string data for each domain
+		// Deferred pointee data for each domain, in POINTER-APPEARANCE order: for
+		// every entry its Name buffer THEN its SID (matching the interleaved
+		// referent IDs assigned above). NDR decoders read deferred referents
+		// positionally in appearance order, NOT grouped as all-names-then-all-SIDs
+		// — with ≥2 domains, grouping makes the client read domain[i+1]'s name
+		// bytes as domain[i]'s SID, corrupting the parse (raw SIDs / client crash).
+		// With a single domain the two orders coincide, which is why single-SID
+		// lookups never hit this.
 		for _, d := range domains {
 			writeNDRUnicodeString(&buf, d.name)
-		}
-
-		// Deferred SID data for each domain
-		for _, d := range domains {
 			if d.sid != nil {
 				writeNDRSID(&buf, d.sid)
 			} else {

--- a/internal/adapter/smb/rpc/lsarpc.go
+++ b/internal/adapter/smb/rpc/lsarpc.go
@@ -784,27 +784,5 @@ func appendUint32Buf(buf *bytes.Buffer, v uint32) {
 
 // buildFault builds a DCE/RPC fault response.
 func (h *LSARPCHandler) buildFault(callID uint32, status uint32) []byte {
-	fragLen := HeaderSize + 16
-
-	hdr := Header{
-		VersionMajor: 5,
-		VersionMinor: 0,
-		PacketType:   PDUFault,
-		Flags:        FlagFirstFrag | FlagLastFrag,
-		DataRep:      [4]byte{0x10, 0x00, 0x00, 0x00},
-		FragLength:   uint16(fragLen),
-		AuthLength:   0,
-		CallID:       callID,
-	}
-
-	buf := make([]byte, fragLen)
-	copy(buf[0:16], hdr.Encode())
-	binary.LittleEndian.PutUint32(buf[16:20], 0)      // alloc_hint
-	binary.LittleEndian.PutUint16(buf[20:22], 0)      // context_id
-	buf[22] = 0                                       // cancel_count
-	buf[23] = 0                                       // reserved
-	binary.LittleEndian.PutUint32(buf[24:28], status) // status
-	binary.LittleEndian.PutUint32(buf[28:32], 0)      // reserved
-
-	return buf
+	return EncodeFaultPDU(callID, status)
 }

--- a/internal/adapter/smb/rpc/lsarpc.go
+++ b/internal/adapter/smb/rpc/lsarpc.go
@@ -672,9 +672,21 @@ func (h *LSARPCHandler) buildLookupSidsResponse(
 	// Count
 	appendUint32Buf(&buf, uint32(len(resolved)))
 
-	// Pointer to array
+	// Pointer to array.
+	//
+	// NDR referent IDs must be UNIQUE across the whole response. The referenced-
+	// domain entries above consume referents from 0x00020008 upward, TWO per
+	// domain (name string + SID) — so with N domains they span up to
+	// 0x00020008+8*N. A hardcoded 0x00020010 here collides with the SECOND
+	// domain's name referent as soon as there are ≥2 referenced domains (e.g. a
+	// LookupSids batch mixing a machine-domain owner with AD-domain grants),
+	// which corrupts NDR pointer resolution — the client then fails the whole
+	// batch (raw SIDs) and Explorer can crash. Use a base well past the domain
+	// and per-name referent ranges (per-name referents below start at
+	// 0x00030000; the parser caps the batch at 100 SIDs) so no overlap is
+	// possible.
 	if len(resolved) > 0 {
-		appendUint32Buf(&buf, 0x00020010) // non-null pointer
+		appendUint32Buf(&buf, 0x00040000) // non-null pointer, disjoint from domain/name referents
 	} else {
 		appendUint32Buf(&buf, 0)
 	}

--- a/internal/adapter/smb/rpc/lsarpc.go
+++ b/internal/adapter/smb/rpc/lsarpc.go
@@ -488,8 +488,18 @@ func (h *LSARPCHandler) handleLookupSids(req *Request) []byte {
 		}
 	}
 
-	// Build domain list (deduplicated)
-	domainMap := make(map[string]int) // domain name -> index
+	// Build the referenced-domain list, deduplicated by domain SID — NOT by name.
+	// Two domains can legitimately share a NetBIOS name yet have different SIDs:
+	// a file owned by an AD user carries the algorithmic MACHINE-domain SID but
+	// resolves (by uidNumber/rid) to the AD account name + AD NetBIOS domain, so
+	// it reports e.g. name "CUBBIT" with the machine domain SID, while an AD SID
+	// grant reports the SAME name "CUBBIT" with the real AD domain SID. Deduping
+	// by name would collapse them to one entry with a single SID, leaving every
+	// account whose SID does not match that SID inconsistent with its referenced
+	// domain (relative-id vs domain-SID mismatch) — which the client rejects,
+	// showing raw SIDs and crashing Explorer. Keying on the SID keeps each domain
+	// distinct so every account's RID pairs with the correct domain SID.
+	domainMap := make(map[string]int) // domain SID key -> index
 	var domains []domainEntry
 
 	for i := range resolved {
@@ -497,8 +507,9 @@ func (h *LSARPCHandler) handleLookupSids(req *Request) []byte {
 		if r.domainName == "" {
 			continue
 		}
-		if _, exists := domainMap[r.domainName]; !exists {
-			domainMap[r.domainName] = len(domains)
+		key := domainKeyOf(r)
+		if _, exists := domainMap[key]; !exists {
+			domainMap[key] = len(domains)
 			domains = append(domains, domainEntry{name: r.domainName, sid: r.domainSID})
 		}
 	}
@@ -597,6 +608,17 @@ func (h *LSARPCHandler) parseSIDsFromRequest(data []byte, opnum uint16) []*sid.S
 type domainEntry struct {
 	name string
 	sid  *sid.SID
+}
+
+// domainKeyOf is the referenced-domain dedup/index key for a resolved SID. It
+// keys on the domain SID (identity), NOT the display name, so two domains that
+// share a NetBIOS name but differ in SID stay distinct (see handleLookupSids).
+// Falls back to the name when no domain SID is known.
+func domainKeyOf(r *resolvedSID) string {
+	if r.domainSID == nil {
+		return "name:" + r.domainName
+	}
+	return "sid:" + sid.FormatSID(r.domainSID)
 }
 
 // buildLookupSidsResponse builds the NDR-encoded LookupSids response.
@@ -710,10 +732,12 @@ func (h *LSARPCHandler) buildLookupSidsResponse(
 			_ = binary.Write(&buf, binary.LittleEndian, nameUTF16Len) // MaximumLength (bytes, no NUL)
 			appendUint32Buf(&buf, nameRefID)                          // unique pointer
 			nameRefID += 4
-			// Domain index (int32)
+			// Domain index (int32). Look up by the SID-based key so each account
+			// references the domain entry whose SID matches its own (see
+			// handleLookupSids / domainKeyOf) — not merely one that shares a name.
 			domIdx := int32(-1) // -1 = no domain
 			if r.domainName != "" {
-				if idx, ok := domainMap[r.domainName]; ok {
+				if idx, ok := domainMap[domainKeyOf(&r)]; ok {
 					domIdx = int32(idx)
 				}
 			}

--- a/internal/adapter/smb/rpc/lsarpc_test.go
+++ b/internal/adapter/smb/rpc/lsarpc_test.go
@@ -1626,3 +1626,48 @@ func TestLSARPC_TranslatedName_ExactLengths_AllOpnums(t *testing.T) {
 		})
 	}
 }
+
+// TestLookupSids_MultiDomain_NoReferentCollision guards against the NDR
+// referent-ID collision that crashed Explorer: with ≥2 referenced domains (a
+// LookupSids batch mixing a machine-domain owner with AD-domain grants), the
+// translated-names array pointer must not reuse a domain entry's referent ID.
+// A collision corrupts pointer resolution, the client fails the whole batch
+// (raw SIDs), and Explorer can crash.
+func TestLookupSids_MultiDomain_NoReferentCollision(t *testing.T) {
+	domains := []domainEntry{
+		{name: "DITTOFS", sid: sid.ParseSIDMust("S-1-5-21-1-2-3")},
+		{name: "CUBBIT", sid: sid.ParseSIDMust("S-1-5-21-4-5-6")},
+	}
+	domainMap := map[string]int{"DITTOFS": 0, "CUBBIT": 1}
+	resolved := []resolvedSID{
+		{name: "admin", sidType: SidTypeUser, domainName: "DITTOFS", domainSID: domains[0].sid},
+		{name: "alice", sidType: SidTypeUser, domainName: "CUBBIT", domainSID: domains[1].sid},
+		{name: "Domain Admins", sidType: SidTypeGroup, domainName: "CUBBIT", domainSID: domains[1].sid},
+	}
+
+	h := &LSARPCHandler{}
+	out := h.buildLookupSidsResponse(resolved, domains, domainMap, true, true)
+
+	// The second domain's name referent is 0x00020010 (0x00020008 + 1*8). It must
+	// appear exactly ONCE in the response — reused as the translated-names array
+	// pointer, it would appear twice (the pre-fix collision).
+	if n := countLEUint32(out, 0x00020010); n != 1 {
+		t.Errorf("referent 0x00020010 appears %d times, want 1 (collision regressed)", n)
+	}
+	// The translated-names array pointer now lives in a disjoint range.
+	if n := countLEUint32(out, 0x00040000); n != 1 {
+		t.Errorf("translated-names array pointer 0x00040000 appears %d times, want 1", n)
+	}
+}
+
+// countLEUint32 counts non-overlapping 4-byte-aligned little-endian occurrences
+// of v in b.
+func countLEUint32(b []byte, v uint32) int {
+	n := 0
+	for i := 0; i+4 <= len(b); i += 4 {
+		if binary.LittleEndian.Uint32(b[i:i+4]) == v {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/adapter/smb/rpc/lsarpc_test.go
+++ b/internal/adapter/smb/rpc/lsarpc_test.go
@@ -1696,7 +1696,7 @@ func TestLookupSids_ReferencedDomains_DeferredOrder(t *testing.T) {
 	if iName0 < 0 || iName1 < 0 || iSid0 < 0 {
 		t.Fatalf("missing bytes: name0=%d name1=%d sid0=%d", iName0, iName1, iSid0)
 	}
-	if !(iName0 < iSid0 && iSid0 < iName1) {
+	if iName0 >= iSid0 || iSid0 >= iName1 {
 		t.Errorf("referenced-domain deferred order wrong: name0@%d sid0@%d name1@%d; want name0 < sid0 < name1",
 			iName0, iSid0, iName1)
 	}

--- a/internal/adapter/smb/rpc/lsarpc_test.go
+++ b/internal/adapter/smb/rpc/lsarpc_test.go
@@ -1093,8 +1093,8 @@ func TestBuildLookupSidsResponse_TwoDomains(t *testing.T) {
 	var domains []domainEntry
 	for i := range resolved {
 		r := &resolved[i]
-		if _, ok := domainMap[r.domainName]; !ok {
-			domainMap[r.domainName] = len(domains)
+		if _, ok := domainMap[domainKeyOf(r)]; !ok {
+			domainMap[domainKeyOf(r)] = len(domains)
 			domains = append(domains, domainEntry{name: r.domainName, sid: r.domainSID})
 		}
 	}
@@ -1119,6 +1119,51 @@ func TestBuildLookupSidsResponse_TwoDomains(t *testing.T) {
 	}
 	if res.status != statusSuccess {
 		t.Errorf("status = 0x%08x, want success", res.status)
+	}
+}
+
+// TestBuildLookupSidsResponse_SameNameDifferentSID reproduces the crash where an
+// AD-owned file's owner (algorithmic MACHINE-domain SID, resolved to the AD
+// account name + AD NetBIOS domain) shares a NetBIOS name with an AD SID grant
+// (real AD domain SID). Deduping the referenced-domain list by NAME collapsed
+// them, leaving the grant's SID inconsistent with the referenced domain SID —
+// the client rejected the batch (raw SIDs) and Explorer crashed. The two domains
+// must stay distinct so each account's RID pairs with the correct domain SID.
+func TestBuildLookupSidsResponse_SameNameDifferentSID(t *testing.T) {
+	h := newTestLSAHandler()
+	machineDom := sid.ParseSIDMust("S-1-5-21-9-9-9")
+	adDom := sid.ParseSIDMust("S-1-5-21-1-2-3")
+	resolved := []resolvedSID{
+		{name: "Administrator", sidType: SidTypeUser, domainName: "CUBBIT", domainSID: machineDom}, // owner, machine SID
+		{name: "alice", sidType: SidTypeUser, domainName: "CUBBIT", domainSID: adDom},              // AD grant, AD SID
+	}
+
+	domainMap := make(map[string]int)
+	var domains []domainEntry
+	for i := range resolved {
+		r := &resolved[i]
+		if _, ok := domainMap[domainKeyOf(r)]; !ok {
+			domainMap[domainKeyOf(r)] = len(domains)
+			domains = append(domains, domainEntry{name: r.domainName, sid: r.domainSID})
+		}
+	}
+	if len(domains) != 2 {
+		t.Fatalf("domains = %d, want 2 (same name, different SID must NOT collapse)", len(domains))
+	}
+
+	stub := h.buildLookupSidsResponse(resolved, domains, domainMap, true, true)
+	response := append(make([]byte, 24), stub...)
+	res := parseLookupSidsResponse(t, response, true)
+
+	if res.names[0].domainIdx == res.names[1].domainIdx {
+		t.Errorf("owner and grant share domain index %d; must differ (distinct SIDs)", res.names[0].domainIdx)
+	}
+	if res.names[0].domainIdx < 0 || res.names[1].domainIdx < 0 {
+		t.Fatalf("unmapped domain index: %d, %d", res.names[0].domainIdx, res.names[1].domainIdx)
+	}
+	if res.domains[res.names[0].domainIdx] != "CUBBIT" || res.domains[res.names[1].domainIdx] != "CUBBIT" {
+		t.Errorf("both entries should display as CUBBIT; got %q, %q",
+			res.domains[res.names[0].domainIdx], res.domains[res.names[1].domainIdx])
 	}
 }
 

--- a/internal/adapter/smb/rpc/lsarpc_test.go
+++ b/internal/adapter/smb/rpc/lsarpc_test.go
@@ -898,14 +898,12 @@ func parseLookupSidsResponse(t *testing.T, response []byte, withFlags bool) look
 			_ = u32()       // SID pointer
 			domFixeds = append(domFixeds, domFixed{nameUTF16Bytes: length})
 		}
-		// Deferred domain name strings.
+		// Deferred domain pointees in NDR appearance order: each entry's Name
+		// buffer THEN its SID (interleaved), not all-names-then-all-SIDs.
 		for _, d := range domFixeds {
 			name := readNDRUnicodeString(t, stub, &off)
 			_ = d
 			res.domains = append(res.domains, name)
-		}
-		// Deferred domain SIDs.
-		for range domCount {
 			skipNDRSID(t, stub, &off)
 		}
 	}
@@ -1670,4 +1668,36 @@ func countLEUint32(b []byte, v uint32) int {
 		}
 	}
 	return n
+}
+
+// TestLookupSids_ReferencedDomains_DeferredOrder validates that the referenced-
+// domain deferred pointees are emitted in NDR appearance order (name0, sid0,
+// name1, sid1) rather than grouped (name0, name1, sid0, sid1). With ≥2 domains
+// the grouped order makes the client read domain1's name as domain0's SID,
+// corrupting the parse (raw SIDs / Explorer crash). Asserts domain0's SID sits
+// BETWEEN the two domain names in the wire bytes.
+func TestLookupSids_ReferencedDomains_DeferredOrder(t *testing.T) {
+	d0 := sid.ParseSIDMust("S-1-5-21-1-2-3")
+	d1 := sid.ParseSIDMust("S-1-5-21-4-5-6")
+	domains := []domainEntry{{name: "DITTOFS", sid: d0}, {name: "CUBBIT", sid: d1}}
+	domainMap := map[string]int{"DITTOFS": 0, "CUBBIT": 1}
+	resolved := []resolvedSID{
+		{name: "admin", sidType: SidTypeUser, domainName: "DITTOFS", domainSID: d0},
+		{name: "alice", sidType: SidTypeUser, domainName: "CUBBIT", domainSID: d1},
+	}
+
+	out := (&LSARPCHandler{}).buildLookupSidsResponse(resolved, domains, domainMap, true, true)
+
+	var sidBuf bytes.Buffer
+	sid.EncodeSID(&sidBuf, d0)
+	iName0 := bytes.Index(out, encodeUTF16LE("DITTOFS"))
+	iName1 := bytes.Index(out, encodeUTF16LE("CUBBIT"))
+	iSid0 := bytes.Index(out, sidBuf.Bytes())
+	if iName0 < 0 || iName1 < 0 || iSid0 < 0 {
+		t.Fatalf("missing bytes: name0=%d name1=%d sid0=%d", iName0, iName1, iSid0)
+	}
+	if !(iName0 < iSid0 && iSid0 < iName1) {
+		t.Errorf("referenced-domain deferred order wrong: name0@%d sid0@%d name1@%d; want name0 < sid0 < name1",
+			iName0, iSid0, iName1)
+	}
 }

--- a/internal/adapter/smb/rpc/pipe.go
+++ b/internal/adapter/smb/rpc/pipe.go
@@ -66,13 +66,33 @@ func (p *PipeState) dispatchRPC(data []byte) ([]byte, error) {
 		p.Bound = true
 		return response, nil
 
-	case PDURequest:
-		if !p.Bound {
-			return nil, nil
+	case PDUAlterContext:
+		// Alter_Context shares the Bind body layout and elicits an
+		// alter_context_resp that is byte-identical to a bind_ack except for the
+		// PDU type. Windows' RPC runtime issues this to (re)negotiate a
+		// presentation context / transfer syntax after the initial bind; dropping
+		// it silently starves the client's follow-up READ (#1607).
+		altReq, err := ParseAlterContext(data)
+		if err != nil {
+			return nil, err
 		}
+		response := p.Handler.HandleBind(altReq)
+		if len(response) > 2 {
+			response[2] = PDUAlterContextR // bind_ack (12) -> alter_context_resp (15)
+		}
+		p.Bound = true
+		return response, nil
+
+	case PDURequest:
 		rpcReq, err := ParseRequest(data)
 		if err != nil {
 			return nil, err
+		}
+		if !p.Bound {
+			// A request before a successful bind cannot be dispatched. Return a
+			// DCE/RPC fault (rather than nothing) so the client's paired READ
+			// always completes instead of parking forever (#1607).
+			return EncodeFaultPDU(rpcReq.Header.CallID, NcaSProtoError), nil
 		}
 		return p.Handler.HandleRequest(rpcReq), nil
 
@@ -87,13 +107,39 @@ func (p *PipeState) ProcessWrite(data []byte) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	response, err := p.dispatchRPC(data)
-	if err != nil {
-		return err
-	}
+	// A single named-pipe WRITE may carry more than one complete DCE/RPC PDU
+	// (e.g. a client that coalesces BIND+request, or OpenPolicy+LookupSids, into
+	// one write). Dispatch every complete PDU and enqueue each response, so no
+	// PDU — and therefore no client READ waiting on its response — is silently
+	// dropped (#1607).
+	for len(data) >= HeaderSize {
+		hdr, err := ParseHeader(data)
+		if err != nil {
+			return err
+		}
+		// Trailing bytes that are not a DCE/RPC v5 PDU (e.g. write padding) are
+		// not misparsed as a bogus request — stop rather than fault the write.
+		if hdr.VersionMajor != 5 {
+			break
+		}
+		// Advance by the declared fragment length. Guard a malformed/zero
+		// FragLength (which would not advance the loop) and a fragment that
+		// claims more bytes than we received — there is no cross-write
+		// reassembly, so treat the remainder as this final PDU.
+		fragLen := int(hdr.FragLength)
+		if fragLen < HeaderSize || fragLen > len(data) {
+			fragLen = len(data)
+		}
 
-	if len(response) > 0 {
-		p.ReadBuffer.Write(response)
+		response, err := p.dispatchRPC(data[:fragLen])
+		if err != nil {
+			return err
+		}
+		if len(response) > 0 {
+			p.ReadBuffer.Write(response)
+		}
+
+		data = data[fragLen:]
 	}
 
 	return nil

--- a/internal/adapter/smb/rpc/pipe_test.go
+++ b/internal/adapter/smb/rpc/pipe_test.go
@@ -1,0 +1,187 @@
+package rpc
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/auth/sid"
+)
+
+// buildTestAlterContext creates an alter_context PDU for the LSA interface. Its
+// body layout is identical to a bind, so it reuses buildTestBindRequest and only
+// rewrites the PDU type byte.
+func buildTestAlterContext(callID uint32) []byte {
+	buf := buildTestBindRequest(callID)
+	buf[2] = PDUAlterContext
+	return buf
+}
+
+// newTestPipe creates a PipeState backed by a deterministic LSA handler.
+func newTestPipe() *PipeState {
+	return NewPipeState("lsarpc", newTestLSAHandler())
+}
+
+// drainResponse runs ProcessRead and fails the test if no bytes are buffered —
+// the exact starvation symptom of #1607 (a WRITE that produces no response for
+// the client's subsequent READ to drain).
+func drainResponse(t *testing.T, p *PipeState) []byte {
+	t.Helper()
+	data := p.ProcessRead(65536)
+	if len(data) == 0 {
+		t.Fatal("ProcessRead returned no data: the WRITE enqueued no response " +
+			"(the parked async READ would starve forever)")
+	}
+	return data
+}
+
+// TestPipeState_BindThenLookupSids2 drives the full WRITE->dispatch->buffer path
+// end to end: a bind followed by a LookupSids2 request must each enqueue a
+// response for the client's READ.
+func TestPipeState_BindThenLookupSids2(t *testing.T) {
+	p := newTestPipe()
+
+	if err := p.ProcessWrite(buildTestBindRequest(1)); err != nil {
+		t.Fatalf("ProcessWrite(bind): %v", err)
+	}
+	bindAck := drainResponse(t, p)
+	if hdr, err := ParseHeader(bindAck); err != nil {
+		t.Fatalf("ParseHeader(bindAck): %v", err)
+	} else if hdr.PacketType != PDUBindAck {
+		t.Fatalf("bind response type = %d, want %d (BindAck)", hdr.PacketType, PDUBindAck)
+	}
+
+	stub := buildLookupSids2StubData([]*sid.SID{sid.WellKnownEveryone})
+	if err := p.ProcessWrite(buildTestRequest(2, OpLsarLookupSids2, stub)); err != nil {
+		t.Fatalf("ProcessWrite(lookupsids2): %v", err)
+	}
+	resp := drainResponse(t, p)
+	hdr, err := ParseHeader(resp)
+	if err != nil {
+		t.Fatalf("ParseHeader(response): %v", err)
+	}
+	if hdr.PacketType != PDUResponse {
+		t.Fatalf("lookup response type = %d, want %d (Response)", hdr.PacketType, PDUResponse)
+	}
+	if hdr.CallID != 2 {
+		t.Fatalf("lookup response CallID = %d, want 2", hdr.CallID)
+	}
+}
+
+// TestPipeState_RequestBeforeBind_ReturnsFault verifies a request that arrives
+// before a successful bind no longer silently drops (which stranded the READ);
+// it now yields a DCE/RPC FAULT so the paired READ always completes.
+func TestPipeState_RequestBeforeBind_ReturnsFault(t *testing.T) {
+	p := newTestPipe()
+
+	stub := buildLookupSids2StubData([]*sid.SID{sid.WellKnownEveryone})
+	if err := p.ProcessWrite(buildTestRequest(7, OpLsarLookupSids2, stub)); err != nil {
+		t.Fatalf("ProcessWrite(unbound request): %v", err)
+	}
+
+	resp := drainResponse(t, p)
+	hdr, err := ParseHeader(resp)
+	if err != nil {
+		t.Fatalf("ParseHeader(fault): %v", err)
+	}
+	if hdr.PacketType != PDUFault {
+		t.Fatalf("unbound-request response type = %d, want %d (Fault)", hdr.PacketType, PDUFault)
+	}
+	if hdr.CallID != 7 {
+		t.Fatalf("fault CallID = %d, want 7", hdr.CallID)
+	}
+	if status := binary.LittleEndian.Uint32(resp[24:28]); status != NcaSProtoError {
+		t.Fatalf("fault status = 0x%x, want 0x%x (nca_s_proto_error)", status, NcaSProtoError)
+	}
+}
+
+// TestPipeState_AlterContext_Answered verifies an alter_context PDU (previously
+// dropped by the default arm of dispatchRPC, starving the client's READ) is now
+// answered with an alter_context_resp.
+func TestPipeState_AlterContext_Answered(t *testing.T) {
+	p := newTestPipe()
+
+	if err := p.ProcessWrite(buildTestAlterContext(9)); err != nil {
+		t.Fatalf("ProcessWrite(alter_context): %v", err)
+	}
+	resp := drainResponse(t, p)
+	hdr, err := ParseHeader(resp)
+	if err != nil {
+		t.Fatalf("ParseHeader(alter_context_resp): %v", err)
+	}
+	if hdr.PacketType != PDUAlterContextR {
+		t.Fatalf("alter_context response type = %d, want %d (AlterContextResp)", hdr.PacketType, PDUAlterContextR)
+	}
+	if hdr.CallID != 9 {
+		t.Fatalf("alter_context response CallID = %d, want 9", hdr.CallID)
+	}
+	if !p.Bound {
+		t.Fatal("alter_context should mark the pipe bound")
+	}
+}
+
+// TestPipeState_CoalescedPDUs_BothDispatched verifies that when a client packs a
+// bind and a request into a single WRITE, both PDUs are dispatched and both
+// responses are enqueued (previously only the first PDU was handled and the
+// trailing request was silently discarded, hanging the READ).
+func TestPipeState_CoalescedPDUs_BothDispatched(t *testing.T) {
+	p := newTestPipe()
+
+	bind := buildTestBindRequest(11)
+	stub := buildLookupSids2StubData([]*sid.SID{sid.WellKnownEveryone})
+	req := buildTestRequest(12, OpLsarLookupSids2, stub)
+
+	coalesced := append(append([]byte(nil), bind...), req...)
+	if err := p.ProcessWrite(coalesced); err != nil {
+		t.Fatalf("ProcessWrite(coalesced): %v", err)
+	}
+
+	all := drainResponse(t, p)
+
+	// First response: bind_ack.
+	hdr1, err := ParseHeader(all)
+	if err != nil {
+		t.Fatalf("ParseHeader(first): %v", err)
+	}
+	if hdr1.PacketType != PDUBindAck {
+		t.Fatalf("first response type = %d, want %d (BindAck)", hdr1.PacketType, PDUBindAck)
+	}
+	// Second response: the request response follows immediately.
+	off := int(hdr1.FragLength)
+	if off <= 0 || off >= len(all) {
+		t.Fatalf("no second response after bind_ack (fragLen=%d, total=%d): the coalesced request was dropped", off, len(all))
+	}
+	hdr2, err := ParseHeader(all[off:])
+	if err != nil {
+		t.Fatalf("ParseHeader(second): %v", err)
+	}
+	if hdr2.PacketType != PDUResponse {
+		t.Fatalf("second response type = %d, want %d (Response)", hdr2.PacketType, PDUResponse)
+	}
+	if hdr2.CallID != 12 {
+		t.Fatalf("second response CallID = %d, want 12", hdr2.CallID)
+	}
+}
+
+// TestPipeState_TrailingPadding_Ignored verifies a WRITE that carries a complete
+// bind PDU followed by trailing zero padding dispatches only the bind and does
+// not fault on the padding.
+func TestPipeState_TrailingPadding_Ignored(t *testing.T) {
+	p := newTestPipe()
+
+	padded := append(buildTestBindRequest(3), make([]byte, 32)...)
+	if err := p.ProcessWrite(padded); err != nil {
+		t.Fatalf("ProcessWrite(padded bind): %v", err)
+	}
+	resp := drainResponse(t, p)
+	hdr, err := ParseHeader(resp)
+	if err != nil {
+		t.Fatalf("ParseHeader: %v", err)
+	}
+	if hdr.PacketType != PDUBindAck {
+		t.Fatalf("response type = %d, want %d (BindAck)", hdr.PacketType, PDUBindAck)
+	}
+	// Exactly one response — nothing else buffered from the padding.
+	if extra := p.ProcessRead(65536); len(extra) != 0 {
+		t.Fatalf("unexpected %d extra response bytes buffered from trailing padding", len(extra))
+	}
+}

--- a/pkg/adapter/smb/lsarpc_foreign.go
+++ b/pkg/adapter/smb/lsarpc_foreign.go
@@ -62,9 +62,14 @@ func (r *identityForeignSIDResolver) LookupSID(sidString string) (name, domain s
 		return "", "", 0, false
 	}
 
-	// The forward directory resolve matches objectClass=user, so a hit is an
-	// account (user) rather than a group.
-	return resolved.Username, r.netbiosOrDerive(resolved.Domain), smbrpc.SidTypeUser, true
+	// The forward directory resolve matches users AND groups by objectSid; report
+	// the SID_NAME_USE that fits so Explorer shows a group (e.g. "Domain Admins")
+	// with the correct kind/icon rather than as a user.
+	sidType = smbrpc.SidTypeUser
+	if resolved.IsGroup {
+		sidType = smbrpc.SidTypeGroup
+	}
+	return resolved.Username, r.netbiosOrDerive(resolved.Domain), sidType, true
 }
 
 // LookupUID resolves a POSIX UID to its directory account name + NetBIOS

--- a/pkg/controlplane/runtime/share_root_acl.go
+++ b/pkg/controlplane/runtime/share_root_acl.go
@@ -33,6 +33,102 @@ func grantLevelFor(permission string) acl.GrantLevel {
 	}
 }
 
+// ShareRootGrantACL builds the allow-only ACL that projects the share's full
+// current set of control-plane grants (user, group, and direct AD/SID grants,
+// plus the default permission) into Windows ACE form, using the level→mask
+// mapping in the acl package. It is the single source of truth for both the
+// root-directory reconcile (ReconcileShareRootACL) and the SMB Security-tab
+// projection (#1608), which merges these ACEs into each file/dir descriptor so
+// Windows admins can see the AD principals that govern access.
+//
+// It returns (nil, nil) for a partially-wired runtime (no control-plane store or
+// shares service) so callers can treat share-grant projection as best-effort.
+// A dangling grant (user/group deleted out from under it) is skipped; a
+// transient store error aborts so a partial ACL is never produced.
+func (r *Runtime) ShareRootGrantACL(ctx context.Context, shareName string) (*acl.ACL, error) {
+	if r.store == nil || r.sharesSvc == nil {
+		return nil, nil
+	}
+
+	share, err := r.sharesSvc.GetShare(shareName)
+	if err != nil {
+		return nil, fmt.Errorf("share root grant ACL for %q: %w", shareName, err)
+	}
+
+	userPerms, err := r.store.GetShareUserPermissions(ctx, shareName)
+	if err != nil {
+		return nil, fmt.Errorf("share root grant ACL for %q: list user permissions: %w", shareName, err)
+	}
+	groupPerms, err := r.store.GetShareGroupPermissions(ctx, shareName)
+	if err != nil {
+		return nil, fmt.Errorf("share root grant ACL for %q: list group permissions: %w", shareName, err)
+	}
+
+	grants := make([]acl.RootGrant, 0, len(userPerms)+len(groupPerms))
+	for _, p := range userPerms {
+		level := grantLevelFor(p.Permission)
+		if level == acl.GrantNone {
+			continue
+		}
+		user, err := r.store.GetUserByID(ctx, p.UserID)
+		if err != nil {
+			if errors.Is(err, models.ErrUserNotFound) {
+				// Dangling grant (user removed out from under it): skip
+				// rather than abort the whole projection.
+				continue
+			}
+			// Transient error (DB hiccup, context deadline): abort before
+			// building a partial ACL that would drop valid grantees.
+			return nil, fmt.Errorf("share root grant ACL for %q: get user %q: %w", shareName, p.UserID, err)
+		}
+		uid := smbDefaultUID
+		if user.UID != nil {
+			uid = *user.UID
+		}
+		grants = append(grants, acl.RootGrant{ID: uid, Level: level})
+	}
+	for _, p := range groupPerms {
+		level := grantLevelFor(p.Permission)
+		if level == acl.GrantNone {
+			continue
+		}
+		group, err := r.store.GetGroupByID(ctx, p.GroupID)
+		if err != nil {
+			if errors.Is(err, models.ErrGroupNotFound) {
+				// Dangling grant: skip rather than abort.
+				continue
+			}
+			// Transient error: abort before building a partial ACL (see the
+			// user-grant path above for the rationale).
+			return nil, fmt.Errorf("share root grant ACL for %q: get group %q: %w", shareName, p.GroupID, err)
+		}
+		if group.GID == nil {
+			// A group without an assigned GID cannot be projected onto a
+			// numeric ACE; the share-level grant still applies at mount.
+			continue
+		}
+		grants = append(grants, acl.RootGrant{ID: *group.GID, IsGroup: true, Level: level})
+	}
+
+	// Direct AD/SID grants (#1528): project a "sid:<SID>" ACE (matched against a
+	// login's PAC SIDs on the SMB path) and, when the grant carries a resolved
+	// Unix id, an additional "{id}@localdomain" numeric ACE so NFS — which has no
+	// SID on the wire — matches by UID/GID. No local object to resolve.
+	sidPerms, err := r.store.GetShareSIDPermissions(ctx, shareName)
+	if err != nil {
+		return nil, fmt.Errorf("share root grant ACL for %q: list SID permissions: %w", shareName, err)
+	}
+	for _, p := range sidPerms {
+		level := grantLevelFor(p.Permission)
+		if level == acl.GrantNone {
+			continue
+		}
+		grants = append(grants, acl.RootGrant{ID: p.UnixID, SID: p.SID, IsGroup: p.IsGroup, Level: level})
+	}
+
+	return acl.BuildShareRootACL(grantLevelFor(share.DefaultPermission), grants), nil
+}
+
 // ReconcileShareRootACL rebuilds the share root directory's ACL from the full
 // current set of control-plane share-permission grants, so the filesystem
 // permission layer agrees with the share-level access control plane. Without
@@ -57,79 +153,14 @@ func (r *Runtime) ReconcileShareRootACL(ctx context.Context, shareName string) e
 		return fmt.Errorf("reconcile root ACL for %q: %w", shareName, err)
 	}
 
-	userPerms, err := r.store.GetShareUserPermissions(ctx, shareName)
+	dacl, err := r.ShareRootGrantACL(ctx, shareName)
 	if err != nil {
-		return fmt.Errorf("reconcile root ACL for %q: list user permissions: %w", shareName, err)
+		return fmt.Errorf("reconcile root ACL for %q: %w", shareName, err)
 	}
-	groupPerms, err := r.store.GetShareGroupPermissions(ctx, shareName)
-	if err != nil {
-		return fmt.Errorf("reconcile root ACL for %q: list group permissions: %w", shareName, err)
+	if dacl == nil {
+		// Partially-wired runtime — nothing to project.
+		return nil
 	}
-
-	grants := make([]acl.RootGrant, 0, len(userPerms)+len(groupPerms))
-	for _, p := range userPerms {
-		level := grantLevelFor(p.Permission)
-		if level == acl.GrantNone {
-			continue
-		}
-		user, err := r.store.GetUserByID(ctx, p.UserID)
-		if err != nil {
-			if errors.Is(err, models.ErrUserNotFound) {
-				// Dangling grant (user removed out from under it): skip
-				// rather than abort the whole reconcile.
-				continue
-			}
-			// Transient error (DB hiccup, context deadline): abort before
-			// writing a partial ACL that would drop valid grantees and
-			// reintroduce filesystem-layer denials until the next reconcile.
-			return fmt.Errorf("reconcile root ACL for %q: get user %q: %w", shareName, p.UserID, err)
-		}
-		uid := smbDefaultUID
-		if user.UID != nil {
-			uid = *user.UID
-		}
-		grants = append(grants, acl.RootGrant{ID: uid, Level: level})
-	}
-	for _, p := range groupPerms {
-		level := grantLevelFor(p.Permission)
-		if level == acl.GrantNone {
-			continue
-		}
-		group, err := r.store.GetGroupByID(ctx, p.GroupID)
-		if err != nil {
-			if errors.Is(err, models.ErrGroupNotFound) {
-				// Dangling grant: skip rather than abort.
-				continue
-			}
-			// Transient error: abort before writing a partial ACL (see the
-			// user-grant path above for the rationale).
-			return fmt.Errorf("reconcile root ACL for %q: get group %q: %w", shareName, p.GroupID, err)
-		}
-		if group.GID == nil {
-			// A group without an assigned GID cannot be projected onto a
-			// numeric ACE; the share-level grant still applies at mount.
-			continue
-		}
-		grants = append(grants, acl.RootGrant{ID: *group.GID, IsGroup: true, Level: level})
-	}
-
-	// Direct AD/SID grants (#1528): project a "sid:<SID>" ACE (matched against a
-	// login's PAC SIDs on the SMB path) and, when the grant carries a resolved
-	// Unix id, an additional "{id}@localdomain" numeric ACE so NFS — which has no
-	// SID on the wire — matches by UID/GID. No local object to resolve.
-	sidPerms, err := r.store.GetShareSIDPermissions(ctx, shareName)
-	if err != nil {
-		return fmt.Errorf("reconcile root ACL for %q: list SID permissions: %w", shareName, err)
-	}
-	for _, p := range sidPerms {
-		level := grantLevelFor(p.Permission)
-		if level == acl.GrantNone {
-			continue
-		}
-		grants = append(grants, acl.RootGrant{ID: p.UnixID, SID: p.SID, IsGroup: p.IsGroup, Level: level})
-	}
-
-	dacl := acl.BuildShareRootACL(grantLevelFor(share.DefaultPermission), grants)
 
 	// The root directory is owned by uid 0; only a superuser context may
 	// rewrite its ACL. The system context bypasses permission checks.

--- a/pkg/controlplane/runtime/share_root_acl_test.go
+++ b/pkg/controlplane/runtime/share_root_acl_test.go
@@ -1,0 +1,67 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// TestShareRootGrantACL_ProjectsSIDGrant verifies the grant-collection method
+// extracted for #1608 projects a direct AD/SID share grant into an allow ACE
+// (Who="sid:<SID>") that the SMB Security-tab path then merges into file
+// descriptors. Uses DefaultPermission=none so only the always-on trustees and
+// the configured SID grant appear.
+func TestShareRootGrantACL_ProjectsSIDGrant(t *testing.T) {
+	rt, s := setupTestRuntime(t)
+	ctx := context.Background()
+
+	localID := createLocalBlockStoreConfig(t, s, "grant-local")
+	metaStores, _ := s.ListMetadataStores(ctx)
+	share := &models.Share{
+		Name:              "/grants",
+		MetadataStoreID:   metaStores[0].ID,
+		LocalBlockStoreID: localID,
+		DefaultPermission: string(models.PermissionNone),
+	}
+	if _, err := s.CreateShare(ctx, share); err != nil {
+		t.Fatalf("CreateShare: %v", err)
+	}
+	if err := LoadSharesFromStore(ctx, rt, s); err != nil {
+		t.Fatalf("LoadSharesFromStore: %v", err)
+	}
+
+	dbShare, err := s.GetShare(ctx, "/grants")
+	if err != nil {
+		t.Fatalf("GetShare(db): %v", err)
+	}
+
+	const aliceSID = "S-1-5-21-188294588-3368521931-100232490-1106"
+	if err := s.SetSIDSharePermission(ctx, &models.SIDSharePermission{
+		SID:        aliceSID,
+		ShareID:    dbShare.ID,
+		ShareName:  "/grants",
+		Permission: string(models.PermissionRead),
+	}); err != nil {
+		t.Fatalf("SetSIDSharePermission: %v", err)
+	}
+
+	dacl, err := rt.ShareRootGrantACL(ctx, "/grants")
+	if err != nil {
+		t.Fatalf("ShareRootGrantACL: %v", err)
+	}
+	if dacl == nil {
+		t.Fatal("ShareRootGrantACL returned nil for a fully-wired runtime")
+	}
+
+	found := false
+	for _, ace := range dacl.ACEs {
+		if ace.Who == "sid:"+aliceSID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("grant ACL missing the AD SID grant sid:%s; got ACEs %+v", aliceSID, dacl.ACEs)
+	}
+}

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -53,6 +53,14 @@ type ResolvedIdentity struct {
 
 	// GroupSIDs is the list of Windows group SIDs for the user, when known.
 	GroupSIDs []string
+
+	// IsGroup marks a resolution whose subject is a group object rather than a
+	// user account. It is set when a directory SID lookup matches a group (e.g.
+	// resolving "Domain Admins" for the SMB Security-tab display of a group
+	// share grant), so the LSARPC path can report SID_NAME_USE = SidTypeGroup
+	// instead of SidTypeUser. Login/authz paths always resolve a user and leave
+	// this false.
+	IsGroup bool
 }
 
 // IdentityProvider resolves external credentials to DittoFS users.

--- a/pkg/identity/ldap/provider.go
+++ b/pkg/identity/ldap/provider.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 
 	ldapv3 "github.com/go-ldap/ldap/v3"
 
@@ -57,6 +58,14 @@ type Provider struct {
 	// external-ID → username link before querying the directory.
 	store      identity.LinkStore
 	userLookup identity.UserLookup
+
+	// domainSIDMu guards the lazily-discovered AD domain SID (S-1-5-21-a-b-c, no
+	// RID) used by the idmap:rid reverse lookup to reconstruct an account's full
+	// SID from its RID. Discovered once from the directory and cached for the
+	// Provider's lifetime (a config reload builds a fresh Provider). Only a
+	// successful discovery is cached, so a transient directory outage retries.
+	domainSIDMu  sync.Mutex
+	domainSIDVal string
 }
 
 // New constructs an LDAP identity provider from a validated Config.
@@ -331,40 +340,32 @@ func sAMAccountNameFromPrincipal(s string) string {
 	return strings.TrimSpace(s)
 }
 
-// LookupUID resolves a POSIX UID to an AD account name + realm via an
-// RFC2307 reverse search (&(objectClass=user)(uidNumber=N)). It backs the
+// LookupUID resolves a POSIX UID to an AD account name + realm. It backs the
 // LSARPC owner-SID display path: the machine-domain SID decodes to a UID that
-// has no local DittoFS account (the owner is an AD-only user such as alice),
-// so the name is recovered from the directory instead.
+// has no local DittoFS account (the owner is an AD-only user such as alice or
+// the domain Administrator), so the name is recovered from the directory. The
+// reverse search matches uidNumber in rfc2307 mode, or the reconstructed
+// account SID (domain SID + UID-as-RID) on objectSid in rid mode — so owners
+// render as DOMAIN\name in both idmap modes rather than a synthetic unix_user:N.
 //
-// Returns ok=false (no error logged as fatal) when no object matches or the
-// directory is unreachable, so a miss degrades to a raw SID rather than a
-// fault. Only meaningful in the rfc2307 idmap mode; in rid mode the UID is the
-// RID and is matched on objectSid by the forward path instead, so this returns
-// ok=false.
+// Returns ok=false (never a fatal error) when no object matches or the directory
+// is unreachable, so a miss degrades to the raw SID rather than a fault.
 func (p *Provider) LookupUID(ctx context.Context, uid uint32) (name, domain string, ok bool) {
 	return p.reverseLookup(ctx, "user", "uidNumber", uid)
 }
 
-// LookupGID resolves a POSIX GID to an AD group name + realm via an RFC2307
-// reverse search (&(objectClass=group)(gidNumber=N)). Mirrors LookupUID for
-// the GROUP SID on a file. Returns ok=false on a miss or in rid mode.
+// LookupGID resolves a POSIX GID to an AD group name + realm. Mirrors LookupUID
+// for the GROUP SID on a file (matched on gidNumber in rfc2307, or the
+// reconstructed group SID on objectSid in rid mode).
 func (p *Provider) LookupGID(ctx context.Context, gid uint32) (name, domain string, ok bool) {
 	return p.reverseLookup(ctx, "group", "gidNumber", gid)
 }
 
-// reverseLookup performs a single RFC2307 reverse search for the given object
-// class and POSIX-number attribute, returning the object's sAMAccountName and
-// the configured realm. Infrastructure errors are logged at Debug and folded
-// into ok=false so a directory outage never faults the LSARPC pipe.
+// reverseLookup maps a POSIX id back to a directory object's sAMAccountName,
+// using the idmap-appropriate filter (see reverseFilter). Infrastructure errors
+// are logged at Debug and folded into ok=false so a directory outage never
+// faults the LSARPC pipe.
 func (p *Provider) reverseLookup(ctx context.Context, objectClass, numAttr string, id uint32) (string, string, bool) {
-	// Only RFC2307 stamps uidNumber/gidNumber. In rid mode the POSIX id is the
-	// object's RID; there is no number attribute to match on, so report a miss
-	// and let the caller fall back to the raw SID.
-	if p.cfg.Idmap != IdmapRFC2307 {
-		return "", "", false
-	}
-
 	c, err := p.connect(ctx, p.cfg)
 	if err != nil {
 		logger.Debug("ldap: reverse lookup connect/bind failed", "attr", numAttr, "id", id, "error", err)
@@ -372,7 +373,10 @@ func (p *Provider) reverseLookup(ctx context.Context, objectClass, numAttr strin
 	}
 	defer func() { _ = c.Close() }()
 
-	filter := fmt.Sprintf("(&(objectClass=%s)(%s=%d))", objectClass, numAttr, id)
+	filter, ok := p.reverseFilter(c, objectClass, numAttr, id)
+	if !ok {
+		return "", "", false
+	}
 	req := ldapv3.NewSearchRequest(
 		p.cfg.BaseDN,
 		ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 2, int(p.cfg.Timeout.Seconds()), false,
@@ -391,6 +395,115 @@ func (p *Provider) reverseLookup(ctx context.Context, objectClass, numAttr strin
 		return "", "", false
 	}
 	return name, p.cfg.Realm, true
+}
+
+// reverseFilter builds the LDAP filter that maps a POSIX id back to a directory
+// object, per idmap mode:
+//   - rfc2307: match the stamped uidNumber/gidNumber attribute directly.
+//   - rid: the POSIX id IS the object's RID, so reconstruct its full account SID
+//     (domain SID + RID) and match objectSid. This makes the LSARPC owner/group
+//     display resolve to DOMAIN\name in rid mode too, instead of a synthetic
+//     unix_user:N / unix_group:N. Requires the domain SID (discovered + cached).
+//
+// Returns ok=false when the rid-mode domain SID is unavailable so the caller
+// degrades to the raw SID rather than issuing a malformed search.
+func (p *Provider) reverseFilter(c conn, objectClass, numAttr string, id uint32) (string, bool) {
+	if p.cfg.Idmap == IdmapRFC2307 {
+		return fmt.Sprintf("(&(objectClass=%s)(%s=%d))", objectClass, numAttr, id), true
+	}
+	domSID, ok := p.domainSID(c)
+	if !ok {
+		logger.Debug("ldap: rid-mode reverse lookup skipped — domain SID unavailable", "id", id)
+		return "", false
+	}
+	s, err := sid.ParseSIDString(fmt.Sprintf("%s-%d", domSID, id))
+	if err != nil {
+		logger.Debug("ldap: rid-mode reverse lookup — bad reconstructed SID",
+			"domainSID", domSID, "rid", id, "error", err)
+		return "", false
+	}
+	return fmt.Sprintf("(&(objectClass=%s)(objectSid=%s))", objectClass, sidToLDAPFilter(s)), true
+}
+
+// domainSID returns the AD domain SID (S-1-5-21-a-b-c, no RID), discovering it
+// from the directory on first use and caching the result. Only a successful
+// discovery is cached; a failure returns ok=false and is retried on the next
+// call so a transient outage does not permanently disable rid-mode reverse
+// resolution.
+func (p *Provider) domainSID(c conn) (string, bool) {
+	p.domainSIDMu.Lock()
+	defer p.domainSIDMu.Unlock()
+	if p.domainSIDVal != "" {
+		return p.domainSIDVal, true
+	}
+	val := p.discoverDomainSID(c)
+	if val != "" {
+		p.domainSIDVal = val
+	}
+	return val, val != ""
+}
+
+// discoverDomainSID reads the domain SID from the directory. The domain object
+// carries it as its objectSid; when the configured base DN IS the domain root
+// (the common case) a base-scoped read of the base DN suffices. If the base DN
+// is an OU below the domain (no objectSid), fall back to the RootDSE's
+// defaultNamingContext to locate the domain object. Returns "" on any failure.
+func (p *Provider) discoverDomainSID(c conn) string {
+	if s := p.domainSIDFromDN(c, p.cfg.BaseDN); s != "" {
+		return s
+	}
+	if dnc := p.rootDSEAttr(c, "defaultNamingContext"); dnc != "" && dnc != p.cfg.BaseDN {
+		if s := p.domainSIDFromDN(c, dnc); s != "" {
+			return s
+		}
+	}
+	logger.Debug("ldap: could not discover domain SID for rid-mode reverse lookup", "base", p.cfg.BaseDN)
+	return ""
+}
+
+// domainSIDFromDN base-reads objectSid at dn and returns it as a SID string,
+// but only when it is a bare domain SID (S-1-5-21-a-b-c, four sub-authorities —
+// no account RID) so it is safe to append a RID to. Returns "" otherwise.
+func (p *Provider) domainSIDFromDN(c conn, dn string) string {
+	req := ldapv3.NewSearchRequest(
+		dn,
+		ldapv3.ScopeBaseObject, ldapv3.NeverDerefAliases, 1, int(p.cfg.Timeout.Seconds()), false,
+		"(objectClass=*)", []string{"objectSid"}, nil,
+	)
+	res, err := c.Search(req)
+	if err != nil || len(res.Entries) == 0 {
+		return ""
+	}
+	raw := res.Entries[0].GetRawAttributeValue("objectSid")
+	if len(raw) == 0 {
+		return ""
+	}
+	s, _, err := sid.DecodeSID(raw)
+	if err != nil {
+		return ""
+	}
+	// A domain SID has exactly four sub-authorities (21 + three domain
+	// identifiers); an account/group SID has a fifth (its RID) and must not be
+	// mistaken for a domain prefix.
+	if s.SubAuthorityCount != 4 {
+		return ""
+	}
+	return sid.FormatSID(s)
+}
+
+// rootDSEAttr reads a single attribute from the anonymous RootDSE (base "",
+// base scope). Returns "" on any failure.
+func (p *Provider) rootDSEAttr(c conn, attr string) string {
+	req := ldapv3.NewSearchRequest(
+		"",
+		ldapv3.ScopeBaseObject, ldapv3.NeverDerefAliases, 1, int(p.cfg.Timeout.Seconds()), false,
+		"(objectClass=*)", []string{attr}, nil,
+	)
+	res, err := c.Search(req)
+	if err != nil || len(res.Entries) == 0 {
+		return ""
+	}
+	return res.Entries[0].GetAttributeValue(attr)
 }
 
 // userFilter builds an LDAP filter matching the credential. SIDs are matched on

--- a/pkg/identity/ldap/provider.go
+++ b/pkg/identity/ldap/provider.go
@@ -432,15 +432,28 @@ func (p *Provider) reverseFilter(c conn, objectClass, numAttr string, id uint32)
 // resolution.
 func (p *Provider) domainSID(c conn) (string, bool) {
 	p.domainSIDMu.Lock()
-	defer p.domainSIDMu.Unlock()
-	if p.domainSIDVal != "" {
-		return p.domainSIDVal, true
+	cached := p.domainSIDVal
+	p.domainSIDMu.Unlock()
+	if cached != "" {
+		return cached, true
 	}
+
+	// Discover OUTSIDE the lock: discoverDomainSID issues blocking LDAP searches,
+	// and holding domainSIDMu across them would serialize (head-of-line block)
+	// every concurrent rid-mode reverse lookup behind the first one for up to the
+	// directory timeout. Concurrent first-callers may each discover — that is
+	// idempotent and cheap, and the result is cached from then on.
 	val := p.discoverDomainSID(c)
-	if val != "" {
+	if val == "" {
+		return "", false
+	}
+	p.domainSIDMu.Lock()
+	if p.domainSIDVal == "" {
 		p.domainSIDVal = val
 	}
-	return val, val != ""
+	cached = p.domainSIDVal
+	p.domainSIDMu.Unlock()
+	return cached, true
 }
 
 // discoverDomainSID reads the domain SID from the directory. The domain object

--- a/pkg/identity/ldap/provider.go
+++ b/pkg/identity/ldap/provider.go
@@ -159,7 +159,7 @@ func (p *Provider) Resolve(ctx context.Context, cred *identity.Credential) (*ide
 		return nil, err
 	}
 
-	attrs := []string{"sAMAccountName", "uidNumber", "gidNumber", "objectSid", "primaryGroupID", "memberOf", "distinguishedName"}
+	attrs := []string{"sAMAccountName", "uidNumber", "gidNumber", "objectSid", "objectClass", "primaryGroupID", "memberOf", "distinguishedName"}
 	req := ldapv3.NewSearchRequest(
 		p.cfg.BaseDN,
 		ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 2, int(p.cfg.Timeout.Seconds()), false,
@@ -186,6 +186,21 @@ func (p *Provider) Resolve(ctx context.Context, cred *identity.Credential) (*ide
 	uid, gid, err := p.deriveUIDGID(entry)
 	if err != nil {
 		return nil, err
+	}
+
+	// A group object (matched by objectSid when resolving a group share grant for
+	// the LSARPC Security-tab display, e.g. "Domain Admins") has no meaningful
+	// primary/supplementary group set of its own — return its identity and type
+	// directly, skipping the user-only group-membership expansion below.
+	if isGroupEntry(entry) {
+		return &identity.ResolvedIdentity{
+			Username: username,
+			UID:      uid,
+			GID:      gid,
+			Domain:   p.cfg.Realm,
+			Found:    true,
+			IsGroup:  true,
+		}, nil
 	}
 
 	gids, err := p.resolveGroupGIDs(ctx, c, entry, gid)
@@ -379,20 +394,37 @@ func (p *Provider) reverseLookup(ctx context.Context, objectClass, numAttr strin
 }
 
 // userFilter builds an LDAP filter matching the credential. SIDs are matched on
-// objectSid; principals on the configured user attribute (sAMAccountName).
+// objectSid across both users AND groups — a SID uniquely identifies one object,
+// and a group SID (e.g. "Domain Admins", or a directly-granted AD group) must
+// resolve to its name for the SMB Security-tab display, not fall through to
+// "Account Unknown". Principals (non-SID) still match the configured user
+// attribute (sAMAccountName).
 func (p *Provider) userFilter(cred *identity.Credential) (string, error) {
 	if strings.HasPrefix(cred.ExternalID, "S-1-") {
 		s, err := sid.ParseSIDString(cred.ExternalID)
 		if err != nil {
 			return "", fmt.Errorf("ldap: parse SID %q: %w", cred.ExternalID, err)
 		}
-		return fmt.Sprintf("(&(objectClass=user)(objectSid=%s))", sidToLDAPFilter(s)), nil
+		return fmt.Sprintf("(&(|(objectClass=user)(objectClass=group))(objectSid=%s))", sidToLDAPFilter(s)), nil
 	}
 	name, _ := splitPrincipal(cred.ExternalID)
 	if name == "" {
 		name = cred.ExternalID
 	}
 	return fmt.Sprintf("(&(objectClass=user)(%s=%s))", p.cfg.UserAttr, ldapv3.EscapeFilter(name)), nil
+}
+
+// isGroupEntry reports whether a directory entry is a group object (objectClass
+// contains "group"). Used to tag a SID resolution as a group so the LSARPC path
+// reports SidTypeGroup. AD's objectClass is multi-valued (e.g. top, group), so
+// this scans all values case-insensitively.
+func isGroupEntry(entry *ldapv3.Entry) bool {
+	for _, oc := range entry.GetAttributeValues("objectClass") {
+		if strings.EqualFold(oc, "group") {
+			return true
+		}
+	}
+	return false
 }
 
 // deriveUIDGID returns the user's POSIX UID/GID according to the idmap mode.

--- a/pkg/identity/ldap/provider_test.go
+++ b/pkg/identity/ldap/provider_test.go
@@ -44,6 +44,22 @@ func encodeSID(t *testing.T, rid uint32) []byte {
 	return buf.Bytes()
 }
 
+// encodeDomainSID returns the binary objectSid for the domain object
+// "S-1-5-21-1-2-3" (four sub-authorities, no RID) — what a base read of the
+// domain root returns, and the prefix rid-mode reverse lookup appends a RID to.
+func encodeDomainSID(t *testing.T) []byte {
+	t.Helper()
+	s := &sid.SID{
+		Revision:            1,
+		SubAuthorityCount:   4,
+		IdentifierAuthority: [6]byte{0, 0, 0, 0, 0, 5},
+		SubAuthorities:      []uint32{21, 1, 2, 3},
+	}
+	var buf bytes.Buffer
+	sid.EncodeSID(&buf, s)
+	return buf.Bytes()
+}
+
 func entry(dn string, attrs map[string][]string, sidBytes []byte) *ldapv3.Entry {
 	e := ldapv3.NewEntry(dn, attrs)
 	if sidBytes != nil {
@@ -390,22 +406,101 @@ func TestLookupGID_RFC2307(t *testing.T) {
 	}
 }
 
-// TestLookupUID_RIDMode confirms reverse lookup is a no-op (miss) in rid mode,
-// where the POSIX id is the RID and there is no uidNumber attribute to match.
+// TestLookupUID_RIDMode confirms reverse lookup RESOLVES in rid mode by
+// reconstructing the account SID (discovered domain SID + UID-as-RID) and
+// matching objectSid — so a file owner (e.g. the domain Administrator, RID 500)
+// renders as DOMAIN\name in the LSARPC Security-tab display instead of a
+// synthetic unix_user:N. The domain SID is discovered once (base read of the
+// domain root) and cached across lookups.
 func TestLookupUID_RIDMode(t *testing.T) {
 	cfg := baseCfg()
 	cfg.Idmap = IdmapRID
-	searched := false
-	fc := &fakeConn{search: func(*ldapv3.SearchRequest) ([]*ldapv3.Entry, error) {
-		searched = true
+	// The exact objectSid filter fragment for the reconstructed RID-500 SID, so
+	// the mock only "finds" Administrator for RID 500 (a different RID misses).
+	want500 := sidToLDAPFilter(sid.ParseSIDMust("S-1-5-21-1-2-3-500"))
+	var acctFilter string
+	domainReads := 0
+	fc := &fakeConn{search: func(req *ldapv3.SearchRequest) ([]*ldapv3.Entry, error) {
+		switch {
+		// Account search by the reconstructed objectSid (domain SID + RID).
+		case strings.Contains(req.Filter, "objectClass=user") && strings.Contains(req.Filter, want500):
+			acctFilter = req.Filter
+			return []*ldapv3.Entry{entry("CN=Administrator,CN=Users,DC=dittofs,DC=ad",
+				map[string][]string{"sAMAccountName": {"Administrator"}}, encodeSID(t, 500))}, nil
+		// Domain SID discovery: a base-scoped read of the base DN (the domain root).
+		case req.Scope == ldapv3.ScopeBaseObject && req.BaseDN == cfg.BaseDN:
+			domainReads++
+			return []*ldapv3.Entry{entry(cfg.BaseDN, nil, encodeDomainSID(t))}, nil
+		}
 		return nil, nil
 	}}
 	p := newTestProvider(t, cfg, fc)
 
-	if _, _, ok := p.LookupUID(context.Background(), 1234); ok {
-		t.Error("LookupUID in rid mode should miss")
+	name, domain, ok := p.LookupUID(context.Background(), 500)
+	if !ok || name != "Administrator" || domain != "DITTOFS.AD" {
+		t.Fatalf("LookupUID(500) = (%q, %q, %v), want (Administrator, DITTOFS.AD, true)", name, domain, ok)
 	}
-	if searched {
-		t.Error("rid mode must not issue a directory search for reverse uid lookup")
+	if !strings.Contains(acctFilter, "objectClass=user") || !strings.Contains(acctFilter, "objectSid=") {
+		t.Errorf("account filter = %q, want objectClass=user + objectSid=", acctFilter)
+	}
+
+	// A second lookup must reuse the cached domain SID (no second base read).
+	if _, _, ok := p.LookupUID(context.Background(), 500); !ok {
+		t.Error("second LookupUID(500) should still resolve")
+	}
+	if domainReads != 1 {
+		t.Errorf("domain SID read %d times, want 1 (cached after first)", domainReads)
+	}
+
+	// An unknown RID still misses cleanly.
+	if _, _, ok := p.LookupUID(context.Background(), 99999); ok {
+		t.Error("LookupUID(99999) should miss in rid mode")
+	}
+}
+
+// TestLookupGID_RIDMode mirrors the UID path for a group RID (e.g. Domain
+// Admins, RID 512) so a file's group owner resolves in rid mode too.
+func TestLookupGID_RIDMode(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Idmap = IdmapRID
+	fc := &fakeConn{search: func(req *ldapv3.SearchRequest) ([]*ldapv3.Entry, error) {
+		switch {
+		case strings.Contains(req.Filter, "objectSid=") && strings.Contains(req.Filter, "objectClass=group"):
+			return []*ldapv3.Entry{entry("CN=Domain Admins,CN=Users,DC=dittofs,DC=ad",
+				map[string][]string{"sAMAccountName": {"Domain Admins"}}, encodeSID(t, 512))}, nil
+		case req.Scope == ldapv3.ScopeBaseObject && req.BaseDN == cfg.BaseDN:
+			return []*ldapv3.Entry{entry(cfg.BaseDN, nil, encodeDomainSID(t))}, nil
+		}
+		return nil, nil
+	}}
+	p := newTestProvider(t, cfg, fc)
+
+	name, _, ok := p.LookupGID(context.Background(), 512)
+	if !ok || name != "Domain Admins" {
+		t.Fatalf("LookupGID(512) = (%q, %v), want (Domain Admins, true)", name, ok)
+	}
+}
+
+// TestLookupUID_RIDMode_NoDomainSID confirms that when the domain SID cannot be
+// discovered, rid-mode reverse lookup degrades to a clean miss (raw SID) rather
+// than issuing a malformed objectSid search.
+func TestLookupUID_RIDMode_NoDomainSID(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Idmap = IdmapRID
+	acctSearched := false
+	fc := &fakeConn{search: func(req *ldapv3.SearchRequest) ([]*ldapv3.Entry, error) {
+		if strings.Contains(req.Filter, "objectSid=") {
+			acctSearched = true
+		}
+		// No domain object and no RootDSE defaultNamingContext: every search misses.
+		return nil, nil
+	}}
+	p := newTestProvider(t, cfg, fc)
+
+	if _, _, ok := p.LookupUID(context.Background(), 500); ok {
+		t.Error("LookupUID should miss when the domain SID is undiscoverable")
+	}
+	if acctSearched {
+		t.Error("must not issue an account objectSid search without a domain SID")
 	}
 }

--- a/pkg/identity/ldap/provider_test.go
+++ b/pkg/identity/ldap/provider_test.go
@@ -219,6 +219,48 @@ func TestResolve_BySID(t *testing.T) {
 	}
 }
 
+// TestResolve_BySID_Group verifies that a group SID (e.g. "Domain Admins",
+// RID 512) resolves by objectSid across both object classes and is tagged
+// IsGroup, so the LSARPC Security-tab path reports SidTypeGroup instead of
+// leaving it "Account Unknown" (the pre-fix user-only filter missed groups).
+func TestResolve_BySID_Group(t *testing.T) {
+	dn := "CN=Domain Admins,CN=Users,DC=dittofs,DC=ad"
+	var gotFilter string
+	fc := &fakeConn{
+		search: func(req *ldapv3.SearchRequest) ([]*ldapv3.Entry, error) {
+			gotFilter = req.Filter
+			if strings.Contains(req.Filter, "objectSid=") {
+				return []*ldapv3.Entry{entry(dn, map[string][]string{
+					"sAMAccountName": {"Domain Admins"},
+					"objectClass":    {"top", "group"},
+				}, encodeSID(t, 512))}, nil
+			}
+			return nil, nil
+		},
+	}
+	cfg := baseCfg()
+	cfg.NestedGroups = false
+	p := newTestProvider(t, cfg, fc)
+	res, err := p.Resolve(context.Background(), &identity.Credential{ExternalID: "S-1-5-21-1-2-3-512"})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !res.Found || res.Username != "Domain Admins" {
+		t.Fatalf("group by-SID resolve failed: %+v", res)
+	}
+	if !res.IsGroup {
+		t.Error("expected IsGroup=true for a group SID resolution")
+	}
+	// The filter must admit group objects, not just users.
+	if !strings.Contains(gotFilter, "objectClass=group") {
+		t.Errorf("SID filter does not match groups: %q", gotFilter)
+	}
+	// idmap:rid → UID/GID derive from the RID (512).
+	if res.UID != 512 || res.GID != 512 {
+		t.Errorf("UID/GID = %d/%d, want 512/512 (RID)", res.UID, res.GID)
+	}
+}
+
 func TestCanResolve(t *testing.T) {
 	p := newTestProvider(t, baseCfg(), &fakeConn{search: func(*ldapv3.SearchRequest) ([]*ldapv3.Entry, error) { return nil, nil }})
 	cases := []struct {

--- a/pkg/metadata/acl/share_grant.go
+++ b/pkg/metadata/acl/share_grant.go
@@ -135,6 +135,17 @@ func BuildShareRootACL(defaultLevel GrantLevel, grants []RootGrant) *ACL {
 	// A pure SID grant (SID set, no allocated Unix id) is excluded — it projects
 	// only the "sid:" ACE above. A SID grant that carries a numeric GID for NFS
 	// (#1528) has ID != 0 and IS merged here so it also gets a numeric ACE.
+	// Numeric ids that also carry a SID grant: their "{id}@localdomain" ACE is a
+	// twin of a "sid:<SID>" ACE for the same AD principal, so it is flagged
+	// NFSNumericTwin (still enforced for NFS, hidden from the SMB Security tab to
+	// avoid a duplicate row — see ACE.NFSNumericTwin).
+	sidCompanionIDs := make(map[uint32]struct{})
+	for _, g := range grants {
+		if g.SID != "" && g.ID != 0 {
+			sidCompanionIDs[g.ID] = struct{}{}
+		}
+	}
+
 	merged := make(map[uint32]RootGrant, len(grants))
 	for _, g := range grants {
 		if g.SID != "" && g.ID == 0 {
@@ -168,7 +179,11 @@ func BuildShareRootACL(defaultLevel GrantLevel, grants []RootGrant) *ACL {
 	})
 	for _, g := range sorted {
 		if mask := maskForLevel(g.Level); mask != 0 { // GrantNone → no ACE
-			aces = append(aces, allow(LocalDomainPrincipal(g.ID), mask))
+			ace := allow(LocalDomainPrincipal(g.ID), mask)
+			if _, isTwin := sidCompanionIDs[g.ID]; isTwin {
+				ace.NFSNumericTwin = true
+			}
+			aces = append(aces, ace)
 		}
 	}
 

--- a/pkg/metadata/acl/share_grant_sid_test.go
+++ b/pkg/metadata/acl/share_grant_sid_test.go
@@ -38,6 +38,28 @@ func TestBuildShareRootACL_SIDGrant(t *testing.T) {
 		}
 	})
 
+	t.Run("numeric twin of a SID grant is flagged NFSNumericTwin; a local grant is not", func(t *testing.T) {
+		const gid uint32 = 99001 // deliberately != the SID RID (1104): idmap:rfc2307 shape
+		a := BuildShareRootACL(GrantNone, []RootGrant{
+			{ID: gid, SID: groupSID, IsGroup: true, Level: GrantRead}, // AD grant → twin
+			{ID: 4242, Level: GrantReadWrite},                         // local grant → not a twin
+		})
+		twin := allowACE(a, LocalDomainPrincipal(gid))
+		if twin == nil {
+			t.Fatalf("missing numeric ACE for the SID grant")
+		}
+		if !twin.NFSNumericTwin {
+			t.Errorf("SID grant's numeric ACE not flagged NFSNumericTwin")
+		}
+		local := allowACE(a, LocalDomainPrincipal(4242))
+		if local == nil {
+			t.Fatalf("missing numeric ACE for the local grant")
+		}
+		if local.NFSNumericTwin {
+			t.Errorf("plain local grant's numeric ACE wrongly flagged NFSNumericTwin")
+		}
+	})
+
 	t.Run("highest level wins on duplicate SID", func(t *testing.T) {
 		a := BuildShareRootACL(GrantNone, []RootGrant{
 			{SID: groupSID, IsGroup: true, Level: GrantRead},

--- a/pkg/metadata/acl/types.go
+++ b/pkg/metadata/acl/types.go
@@ -130,6 +130,18 @@ type ACE struct {
 	Flag       uint32 `json:"flag"`        // aceflag4
 	AccessMask uint32 `json:"access_mask"` // acemask4
 	Who        string `json:"who"`         // utf8str_mixed: "user@domain", "OWNER@", etc.
+
+	// NFSNumericTwin marks a share-grant "{id}@localdomain" ACE that exists ONLY
+	// to let NFS (which carries no SID) match an AD principal by its numeric
+	// Unix id — it shadows a "sid:<SID>" ACE for the same principal (see
+	// BuildShareRootACL). It is a full participant in access checks (both NFS and
+	// SMB), but the SMB security-descriptor builder hides it so the Windows
+	// Security tab does not list the principal twice. Keying suppression on this
+	// flag (set where the SID↔id pairing is known) rather than reconstructing it
+	// from the SID's RID makes it correct in every idmap mode — the RID equals
+	// the Unix id only in idmap:rid, not rfc2307. Never set on client-supplied
+	// ACLs (SET_INFO parses to plain ACEs), so it is a reliable display marker.
+	NFSNumericTwin bool `json:"nfs_numeric_twin,omitempty"`
 }
 
 // ACLSource indicates how an ACL was created. The zero value (empty string)


### PR DESCRIPTION
## Summary

Fixes the Windows **Security tab** experience over SMB for AD-joined shares. Closes **#1607** (Security tab hangs / owner shows raw SID) and **#1608** (share-level SID grants not visible). Manually validated end-to-end on a live AD testbed (Kerberos, `idmap:rid`, direct AD/SID grants from #1528).

## #1607 — Security tab no longer hangs, and multi-principal SDs no longer crash Explorer

- **Stranded pipe read (the hang):** `handlePipeRead` (register a pending async read under the registry lock) and `handlePipeWrite` (enqueue the RPC response, then complete the read) coordinate through **two disjoint locks**, and every SMB2 request runs on its own goroutine — so an enqueued LSARPC response could strand a parked read forever. Added a re-check/reclaim after `Register` in `read.go`; `UnregisterByFileID` is the atomic arbiter (delivered exactly once, never stranded, never double-delivered).
- **DCERPC dispatch hardening** (`pipe.go`/`dcerpc.go`): answer `alter_context`, FAULT a request-before-bind (so the paired READ completes instead of hanging), and dispatch **coalesced multi-PDU** writes instead of silently dropping all but the first.
- **Multi-domain `LookupSids` response corruption (crashed Explorer):** once owner/group resolution pulled a *second* referenced domain into a batched `LookupSids`, two NDR bugs surfaced in `buildLookupSidsResponse`:
  1. a **referent-ID collision** — the translated-names array pointer reused the 2nd domain's name referent;
  2. **deferred pointees emitted grouped** (all names, then all SIDs) instead of interleaved (name0, sid0, name1, sid1) as NDR requires.
  Both corrupt pointer resolution on ≥2 domains → raw SIDs + Explorer crash. Single-domain batches were unaffected, which is why single-SID lookups always worked. (The in-repo test decoder had mirrored the buggy grouped layout — corrected too, with byte-order + referent-uniqueness regression tests.)

## #1608 — AD principals visible (and correctly named) in the Security tab

- **Surface share grants** in the DACL via `Runtime.ShareRootGrantACL` (extracted from the root-reconcile path). Deliberately narrow so it can never regress SMB ACL conformance: only **`sid:` (direct AD) grants**, and only on files with **no explicitly-stored ACL** (synthesized default). This was tightened after the first cut regressed 8 `smbtorture` ACL tests by injecting the always-on `Administrators@`/local grants into every child descriptor.
- **Group SIDs resolve** (e.g. `CUBBIT\Domain Admins`): the LDAP `objectSid` lookup matched `objectClass=user` only; broadened to users **or** groups, threaded `ResolvedIdentity.IsGroup`, and report `SidTypeGroup`.
- **File owner/group names resolve in `idmap:rid`**: the reverse UID/GID→name lookup was a no-op in rid mode (no `uidNumber`/`gidNumber` to match), so owners rendered as `unix_user:<rid>`. Reconstruct the account SID (discovered domain SID + id-as-RID) and match `objectSid`, so owners show `DOMAIN\name` in both idmap modes.
- **No duplicate rows:** the reconciled share-root ACL stores each AD grant twice — a `sid:` ACE (SMB/PAC) and a `{id}@localdomain` numeric ACE (NFS). The numeric twin is flagged (`acl.ACE.NFSNumericTwin`, set where the SID↔id pairing is known) and hidden from the SMB descriptor — correct in **every idmap mode** (the RID equals the Unix id only under `rid`). Still fully enforced for NFS.

Always-on `OWNER@`/`SYSTEM@`/`BUILTIN\Administrators` are kept on the share root for Windows-default coherence (display-only; enforcement stays explicit-grant / superuser based).

## Review

- **Copilot** and a code-review pass flagged a redundant double `ParseHeader` in the bind/alter path — fixed.
- Code review also caught the `idmap:rfc2307` twin-suppression gap (now fixed via the `NFSNumericTwin` flag) and a mutex-held-across-LDAP head-of-line block in domain-SID discovery (now discovered outside the lock).

## Testing

- Unit/integration: `rpc`, `handlers`, `pkg/metadata/acl`, `pkg/controlplane/runtime`, `pkg/identity/...` suites pass; `go vet` + `gofmt -s` clean; CI green (incl. WPTS BVT, Windows, golangci-lint).
- Manual (AD testbed, mounted as `alice`): Security tab opens with no hang/crash; `CUBBIT\alice`, `CUBBIT\bob`, `CUBBIT\Domain Admins`, `SYSTEM`, `BUILTIN\Administrators` and the file owner each appear once, resolved to names.

## Not addressed

#1609 (network discovery / WS-Discovery) is out of scope.
