### PR TITLE
feat(bench): add zerofs as a native NFSv3 competitor

### DIFF
--- a/internal/dfsbench/backend/backend.go
+++ b/internal/dfsbench/backend/backend.go
@@ -60,10 +60,12 @@ type Backend struct {
 	Unmount  func(ctx context.Context, proto Protocol) error
 	Teardown func(ctx context.Context) error
 
-	// FlushFUSE flushes a FUSE backend's writeback cache to S3 and remounts it
-	// with an empty cache, so the next read is genuinely cold-from-S3. nil for
-	// non-FUSE backends (the runner falls back to Evict + OS-cache drop). The
-	// runner unmounts the re-export around this, then re-exports the fresh mount.
+	// FlushFUSE is the cold-read barrier for backends that keep their own cache:
+	// it flushes writeback to S3 and rebuilds on an empty cache, so the next read
+	// is genuinely cold-from-S3. FUSE backends remount empty (flush + fresh mount);
+	// the native zerofs restarts its server on a wiped LSM cache dir. nil for
+	// backends where an Evict + OS-cache drop suffices. The runner unmounts around
+	// this, then re-mounts the fresh backend.
 	FlushFUSE func(ctx context.Context) error
 }
 

--- a/internal/dfsbench/backend/backend_test.go
+++ b/internal/dfsbench/backend/backend_test.go
@@ -64,6 +64,25 @@ func TestResolveSystems_BareNameSkipsNAProtocols(t *testing.T) {
 	}
 }
 
+func TestResolveSystems_NativeSingleProtocol(t *testing.T) {
+	withRegistry(t, &Backend{
+		Name:    "zerofs", // native NFSv3 only (no nfs4/smb3)
+		Support: map[Protocol]Support{ProtoNFS3: Native},
+	})
+
+	plans, err := ResolveSystems([]string{"zerofs"})
+	if err != nil {
+		t.Fatalf("resolveSystems: %v", err)
+	}
+	if len(plans) != 1 || plans[0].Protocol != ProtoNFS3 || plans[0].Support != Native {
+		t.Fatalf("want single native nfs3 plan, got %v", plans)
+	}
+	// nfs4/smb3 named explicitly must be rejected, not silently produced.
+	if _, err := ResolveSystems([]string{"zerofs-smb3"}); err == nil {
+		t.Fatal("expected error for zerofs-smb3 (zerofs has no SMB)")
+	}
+}
+
 func TestResolveSystems_ExplicitProtocol(t *testing.T) {
 	withRegistry(t, &Backend{
 		Name:    "dittofs-s3",

--- a/internal/dfsbench/backend/zerofs.go
+++ b/internal/dfsbench/backend/zerofs.go
@@ -1,0 +1,164 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/marmos91/dittofs/internal/dfsbench/exec"
+)
+
+// zerofs is the one competitor that isn't a FUSE-over-knfsd hack: like DittoFS
+// it's an integrated userspace server + S3 storage engine (a log-structured
+// SlateDB/LSM store), serving NFS from its own process — so it mounts NATIVELY,
+// the same head-to-head shape as dittofs-s3. Its NFS server is v3-only (it also
+// speaks 9P/NBD, which aren't on our protocol axis), and it has no SMB, so nfs3
+// is its only cell here — itself a differentiator worth showing in the table.
+//
+// Bringup (install channel, config schema, the cold-restart flush) is pinned
+// against a live zerofs on the VM — the first managed run is where it's tuned,
+// same convention as dittofs.go and the FUSE recipes.
+const (
+	zerofsNFSPort  = "2049" // zerofs default; free because one backend runs at a time
+	zerofsRPCPort  = "7000" // checkpoint/flush/monitor RPC
+	zerofsCacheDir = "/var/cache/bench-zerofs"
+	zerofsConf     = "/etc/bench-zerofs.toml"
+	zerofsPrefix   = "zerofs" // s3://<bucket>/zerofs
+	// Encryption is mandatory in zerofs; this is a throwaway VM + throwaway
+	// bucket prefix, so a fixed bench password is fine. Passed via env (below),
+	// never written into the toml, per the S3-creds-stay-in-env invariant.
+	zerofsPassword = "dfsbench-throwaway"
+)
+
+func init() {
+	register(&Backend{
+		Name:     "zerofs",
+		S3Backed: true,
+		// Native NFSv3 only. nfs4/smb3 are NA (zerofs speaks neither) and auto-skip.
+		Support:  map[Protocol]Support{ProtoNFS3: Native},
+		Setup:    zerofsSetup,
+		Mount:    zerofsMount,
+		Unmount:  func(ctx context.Context, _ Protocol) error { return exec.Sh(ctx, "umount", clientMntDir) },
+		Teardown: zerofsTeardown,
+		// zerofs is native, not FUSE, but it keeps a local LSM block cache of
+		// decrypted SST blocks — so dropping the OS page cache alone still serves
+		// reads warm. The only way to force cold-from-S3 is to flush + restart the
+		// server on an empty cache dir; that requires the unmount→rebuild→remount
+		// bounce, which is exactly what the runner drives through FlushFUSE.
+		FlushFUSE: zerofsColdBarrier,
+	})
+}
+
+func zerofsSetup(ctx context.Context, env BackendEnv) error {
+	// Official install script (verifies the published SHA-256, drops a prebuilt
+	// binary) — zerofs isn't in Ubuntu apt.
+	if err := exec.Sh(ctx, "sh", "-c",
+		"command -v zerofs >/dev/null || curl -sSfL https://sh.zerofs.net | sh"); err != nil {
+		return err
+	}
+	id, secret, err := s3Creds()
+	if err != nil {
+		return err
+	}
+	// zerofs.toml references ${...} and substitutes from the process env at
+	// runtime, so the secret + password never touch the file (env-only invariant).
+	_ = os.Setenv("AWS_ACCESS_KEY_ID", id)
+	_ = os.Setenv("AWS_SECRET_ACCESS_KEY", secret)
+	_ = os.Setenv("ZEROFS_PASSWORD", zerofsPassword)
+	benchEnv = env
+
+	// Own prefix, cleaned so a re-run isn't served stale segment objects. zerofs
+	// writes fresh immutable segments, so a residual-listing miss (SCW's eventual
+	// LIST-after-DELETE) doesn't block bringup — unlike juicefs's format gate.
+	if err := cleanS3Prefix(ctx, zerofsPrefix+"/"); err != nil {
+		return err
+	}
+	if err := os.WriteFile(zerofsConf, []byte(zerofsConfig(env)), 0o644); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(zerofsCacheDir, 0o755); err != nil {
+		return err
+	}
+	return zerofsStart(ctx)
+}
+
+// zerofsConfig renders the TOML. Non-secret fields are filled here; the three
+// ${...} refs stay literal for zerofs to substitute from env at runtime.
+func zerofsConfig(env BackendEnv) string {
+	return fmt.Sprintf(`[storage]
+url = "s3://%s/%s"
+encryption_password = "${ZEROFS_PASSWORD}"
+
+[cache]
+dir = "%s"
+disk_size_gb = 10
+
+[servers.nfs]
+addresses = ["127.0.0.1:%s"]
+
+[servers.rpc]
+addresses = ["127.0.0.1:%s"]
+
+[aws]
+access_key_id = "${AWS_ACCESS_KEY_ID}"
+secret_access_key = "${AWS_SECRET_ACCESS_KEY}"
+endpoint = "%s"
+default_region = "us-east-1"
+`, env.Bucket, zerofsPrefix, zerofsCacheDir, zerofsNFSPort, zerofsRPCPort, env.Endpoint)
+}
+
+func zerofsMount(ctx context.Context, proto Protocol) (string, error) {
+	if proto != ProtoNFS3 {
+		return "", fmt.Errorf("zerofs: unsupported protocol %s (native nfs3 only)", proto)
+	}
+	if err := os.MkdirAll(clientMntDir, 0o755); err != nil {
+		return "", err
+	}
+	// zerofs serves NFSv3 on :2049 from its own userspace server (no knfsd) — the
+	// same native path dittofs-s3 takes. async + nolock to sit on the fastest
+	// durability tier, matching every other cell.
+	opts := "nfsvers=3,tcp,port=" + zerofsNFSPort + ",mountport=" + zerofsNFSPort +
+		",async,nolock,rsize=1048576,wsize=1048576"
+	if err := exec.Sh(ctx, "mount", "-t", "nfs", "-o", opts, "127.0.0.1:/", clientMntDir); err != nil {
+		return "", err
+	}
+	return clientMntDir, nil
+}
+
+// zerofsColdBarrier forces the next read cold-from-S3. NFS COMMIT lets zerofs
+// ack before data reaches S3, so flush the memtable via its RPC first (nothing
+// un-uploaded is lost across the restart), then restart on a wiped cache dir so
+// no decrypted SST block is served from local disk. The runner unmounts before
+// this and remounts after (Mount).
+func zerofsColdBarrier(ctx context.Context) error {
+	// Best-effort flush; exact subcommand pinned on the VM. Data written by the
+	// layout/warm pass should already be draining, so a miss here at worst leaves
+	// the read slightly less cold — it never corrupts.
+	_ = exec.Sh(ctx, "sh", "-c", "zerofs flush 127.0.0.1:"+zerofsRPCPort+" 2>/dev/null || true")
+	_ = zerofsStop(ctx)
+	if err := clearDir(ctx, zerofsCacheDir); err != nil {
+		return err
+	}
+	return zerofsStart(ctx)
+}
+
+func zerofsStart(ctx context.Context) error {
+	if err := exec.Sh(ctx, "sh", "-c",
+		"zerofs run -c "+zerofsConf+" >>/var/log/bench-zerofs.log 2>&1 &"); err != nil {
+		return err
+	}
+	if err := waitPort(ctx, zerofsNFSPort); err != nil {
+		return fmt.Errorf("zerofs did not open NFS port %s: %w", zerofsNFSPort, err)
+	}
+	return nil
+}
+
+func zerofsStop(ctx context.Context) error {
+	return exec.Sh(ctx, "sh", "-c", "pkill -f 'zerofs run' || true")
+}
+
+func zerofsTeardown(ctx context.Context) error {
+	_ = zerofsStop(ctx)
+	_ = cleanS3Prefix(ctx, zerofsPrefix+"/")
+	return os.RemoveAll(zerofsCacheDir)
+}

--- a/internal/dfsbench/backend/zerofs.go
+++ b/internal/dfsbench/backend/zerofs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/marmos91/dittofs/internal/dfsbench/exec"
 )
@@ -115,10 +116,11 @@ func zerofsMount(ctx context.Context, proto Protocol) (string, error) {
 		return "", err
 	}
 	// zerofs serves NFSv3 on :2049 from its own userspace server (no knfsd) — the
-	// same native path dittofs-s3 takes. async + nolock to sit on the fastest
-	// durability tier, matching every other cell.
-	opts := "nfsvers=3,tcp,port=" + zerofsNFSPort + ",mountport=" + zerofsNFSPort +
-		",async,nolock,rsize=1048576,wsize=1048576"
+	// same native path dittofs-s3 takes. Use the IDENTICAL option set as the
+	// dittofs-s3 nfs3 cell (actimeo=0,nolock) so attribute-cache behavior can't
+	// skew the native-vs-native comparison; rsize/wsize negotiate to the kernel
+	// default (1 MiB over TCP) for both.
+	opts := "nfsvers=3,tcp,port=" + zerofsNFSPort + ",mountport=" + zerofsNFSPort + ",actimeo=0,nolock"
 	if err := exec.Sh(ctx, "mount", "-t", "nfs", "-o", opts, "127.0.0.1:/", clientMntDir); err != nil {
 		return "", err
 	}
@@ -143,8 +145,10 @@ func zerofsColdBarrier(ctx context.Context) error {
 }
 
 func zerofsStart(ctx context.Context) error {
+	// Truncate the log each start (single '>') so repeated runs don't interleave
+	// old and new output — matches dittofs.go.
 	if err := exec.Sh(ctx, "sh", "-c",
-		"zerofs run -c "+zerofsConf+" >>/var/log/bench-zerofs.log 2>&1 &"); err != nil {
+		"zerofs run -c "+zerofsConf+" >/var/log/bench-zerofs.log 2>&1 &"); err != nil {
 		return err
 	}
 	if err := waitPort(ctx, zerofsNFSPort); err != nil {
@@ -153,8 +157,18 @@ func zerofsStart(ctx context.Context) error {
 	return nil
 }
 
+// zerofsStop signals the server and waits for it to actually exit — pkill only
+// sends the signal, so without the wait a following cache wipe or restart races
+// a process still holding the LSM cache dir open.
 func zerofsStop(ctx context.Context) error {
-	return exec.Sh(ctx, "sh", "-c", "pkill -f 'zerofs run' || true")
+	_ = exec.Sh(ctx, "sh", "-c", "pkill -f 'zerofs run' || true")
+	for i := 0; i < 50; i++ {
+		if exec.Sh(ctx, "sh", "-c", "! pgrep -f 'zerofs run' >/dev/null 2>&1") == nil {
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return nil
 }
 
 func zerofsTeardown(ctx context.Context) error {


### PR DESCRIPTION
Adds **zerofs** to the dfsbench competitor matrix.

## Why it's different from every other competitor
zerofs is not a FUSE-over-knfsd hack — it's an integrated userspace NFS/9P/NBD server over an S3-backed LSM store (SlateDB), i.e. **architecturally DittoFS's twin**. So it mounts **natively** (like `dittofs-s3`, no re-export layer) and gives us the first true *native-vs-native* NFS-over-S3 head-to-head, with no FUSE tax on either side.

## What this adds
- `internal/dfsbench/backend/zerofs.go` — native backend: install via the official script, `zerofs.toml` rendered with secrets kept `${env}`-only (never in the file), start server, mount its NFSv3 on `:2049`.
- **NFSv3 only.** zerofs serves no NFSv4.1 and no SMB — so `nfs4`/`smb3` are `NA` and auto-skip. That gap is itself a differentiator the table now shows.
- **Cold-read barrier without FUSE:** zerofs keeps a local LSM cache of decrypted SST blocks, so an OS-page-drop alone still serves warm. `zerofsColdBarrier` flushes to S3 (RPC), then restarts on a wiped cache dir — driven through the existing `FlushFUSE` unmount→rebuild→remount hook (doc updated: it's now the cold-read barrier for any self-caching backend, not just FUSE).
- Test: native-single-protocol resolution (bare `zerofs` → one nfs3 plan; explicit `zerofs-smb3` rejected).

## Notes
- Bringup specifics (install channel, exact flush subcommand) are pinned on the live VM on first managed run — same convention as `dittofs.go` and the FUSE recipes.
- `go build` / `go vet` / `go test ./internal/dfsbench/backend/` (10 pass) / `golangci-lint` all green.