### PR TITLE
feat(bench): universal server-side ctxsw/CPU meter

### DIFF
--- a/internal/dfsbench/fio/result.go
+++ b/internal/dfsbench/fio/result.go
@@ -37,6 +37,11 @@ type CellResult struct {
 	DurationS  float64 `json:"duration_s"`
 
 	S3Bytes int64 `json:"s3_bytes"` // server↔S3 bytes; populated in a later PR
+
+	// Server-side resource use during the fio pass (system-wide, from /proc/stat).
+	// CtxSwPerSec is the FUSE-tax indicator; 0 off Linux (local/smoke on macOS).
+	CtxSwPerSec float64 `json:"ctxsw_per_sec,omitempty"`
+	CPUPct      float64 `json:"cpu_pct,omitempty"`
 }
 
 // Slug is the stable, filesystem-safe identity of a cell. Two runs of the same

--- a/internal/dfsbench/report/report.go
+++ b/internal/dfsbench/report/report.go
@@ -36,8 +36,9 @@ func NewReportCmd() *cobra.Command {
 }
 
 // RenderTable produces the markdown comparison table. Columns follow the plan's
-// dictionary; rate columns render "—" when not the workload's headline metric
-// (S3MB/CTXSW land once their meters exist — carried, shown as 0/— for now).
+// dictionary; rate columns render "—" when not the workload's headline metric,
+// and CTXSW/s + CPU% dash when unmetered (off Linux / pre-meter runs). S3MB
+// stays 0 until the S3 network meter lands.
 func RenderTable(rs []fio.CellResult) string {
 	if len(rs) == 0 {
 		return "no results\n"

--- a/internal/dfsbench/report/report.go
+++ b/internal/dfsbench/report/report.go
@@ -53,7 +53,7 @@ func RenderTable(rs []fio.CellResult) string {
 		return a.Size < b.Size
 	})
 
-	head := []string{"SYSTEM", "WORKLOAD", "SIZE", "PROTO", "PASS", "IOPS", "MB/s", "p50µs", "p99µs", "S3MB", "err"}
+	head := []string{"SYSTEM", "WORKLOAD", "SIZE", "PROTO", "PASS", "IOPS", "MB/s", "p50µs", "p99µs", "S3MB", "CTXSW/s", "CPU%", "err"}
 	rows := make([][]string, 0, len(rs))
 	for _, r := range rs {
 		rows = append(rows, []string{
@@ -63,6 +63,8 @@ func RenderTable(rs []fio.CellResult) string {
 			fmt.Sprintf("%.0f", r.LatencyP50Us),
 			fmt.Sprintf("%.0f", r.LatencyP99Us),
 			fmt.Sprintf("%d", r.S3Bytes/fio.Mib),
+			metered(r.CtxSwPerSec),
+			metered(r.CPUPct),
 			fmt.Sprintf("%d", r.Errors),
 		})
 	}
@@ -77,6 +79,15 @@ func isRandom(w string) bool {
 // rate formats a rate column, dashing it when it isn't this workload's headline.
 func rate(v float64, headline bool) string {
 	if !headline {
+		return "—"
+	}
+	return fmt.Sprintf("%.0f", v)
+}
+
+// metered formats a server-resource column, dashing an unmeasured 0 (off Linux,
+// or a run predating the meter) rather than printing a misleading zero.
+func metered(v float64) string {
+	if v == 0 {
 		return "—"
 	}
 	return fmt.Sprintf("%.0f", v)

--- a/internal/dfsbench/run/managed.go
+++ b/internal/dfsbench/run/managed.go
@@ -10,6 +10,7 @@ import (
 	"github.com/marmos91/dittofs/internal/dfsbench/exec"
 	"github.com/marmos91/dittofs/internal/dfsbench/fio"
 	"github.com/marmos91/dittofs/internal/dfsbench/report"
+	"github.com/marmos91/dittofs/internal/dfsbench/sysstat"
 )
 
 // runManaged drives the backend-provisioning path: resolve --systems into
@@ -167,10 +168,16 @@ func runPass(ctx context.Context, p backend.Plan, pass string, wls, sizes []stri
 				continue
 			}
 			_, _ = fmt.Fprintf(exec.CmdOut, "run: %s\n", res.Slug())
+			// Meter server-side ctxsw + CPU across just the fio pass — the FUSE-tax
+			// evidence (system-wide; on the single-tenant bench VM that's the
+			// serving stack). Zero off Linux.
+			before := sysstat.Now()
 			m, err := fio.RunFio(ctx, w, mnt, withSize(opts, s))
 			if err != nil {
 				return err
 			}
+			r := before.RatesTo(sysstat.Now())
+			m.CtxSwPerSec, m.CPUPct = r.CtxSwPerSec, r.CPUPct
 			m.System, m.Workload, m.Size, m.Protocol, m.Pass = res.System, w, s, res.Protocol, pass
 			m.Timestamp = time.Now().UTC()
 			if err := m.Save(f.results); err != nil {

--- a/internal/dfsbench/sysstat/sysstat.go
+++ b/internal/dfsbench/sysstat/sysstat.go
@@ -61,9 +61,11 @@ func parseStat(data string) (Sample, bool) {
 		switch fields[0] {
 		case "cpu": // aggregate line: "cpu user nice system idle iowait irq softirq steal ..."
 			var total, idle uint64
+			valid := true
 			for i, f := range fields[1:] {
 				v, err := strconv.ParseUint(f, 10, 64)
-				if err != nil {
+				if err != nil { // corrupt /proc line — reject the whole sample, don't keep partial counters
+					valid = false
 					break
 				}
 				total += v
@@ -71,7 +73,9 @@ func parseStat(data string) (Sample, bool) {
 					idle += v
 				}
 			}
-			s.CPUTotal, s.CPUBusy, haveCPU = total, total-idle, true
+			if valid {
+				s.CPUTotal, s.CPUBusy, haveCPU = total, total-idle, true
+			}
 		case "ctxt":
 			if v, err := strconv.ParseUint(fields[1], 10, 64); err == nil {
 				s.CtxSwitches, haveCtxt = v, true

--- a/internal/dfsbench/sysstat/sysstat.go
+++ b/internal/dfsbench/sysstat/sysstat.go
@@ -1,0 +1,106 @@
+// Package sysstat samples system-wide CPU and context-switch counters from
+// /proc/stat, so each benchmark cell can report the serving stack's context
+// switches per second — the measured evidence for the "DittoFS's native server
+// avoids the FUSE context-switch tax" thesis.
+//
+// It is deliberately system-wide, not per-process: the one number that's
+// comparable across every server type in the matrix — userspace (DittoFS,
+// zerofs, the FUSE daemons) AND kernel-thread (knfsd) — is total ctxsw, which
+// per-process /proc/<pid>/status can't give for kernel servers. On the
+// disposable, single-tenant bench VM only the one backend + fio run, so the
+// system-wide rate tracks the serving stack. It does include fio's own switches,
+// but that load-generator cost is ~constant across cells at a fixed workload, so
+// the cross-cell delta (native vs FUSE-over-knfsd) is still the FUSE tax.
+package sysstat
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Sample is a point-in-time snapshot of /proc/stat's aggregate counters. The
+// zero value has ok=false; off Linux (no /proc/stat) Now returns it, and RatesTo
+// then yields zero rates — so the meter degrades to empty columns rather than
+// erroring on a dev macOS --local/--smoke run.
+type Sample struct {
+	T           time.Time
+	CtxSwitches uint64 // /proc/stat "ctxt": cumulative context switches since boot
+	CPUBusy     uint64 // non-idle jiffies (user+nice+system+irq+softirq+steal)
+	CPUTotal    uint64 // all jiffies, incl. idle+iowait
+	ok          bool
+}
+
+// Now snapshots /proc/stat. On any read/parse failure it returns a not-ok
+// Sample (rates from it are zero) — the caller never has to handle an error.
+func Now() Sample {
+	data, err := os.ReadFile("/proc/stat")
+	if err != nil {
+		return Sample{}
+	}
+	s, ok := parseStat(string(data))
+	if !ok {
+		return Sample{}
+	}
+	s.T = time.Now()
+	s.ok = true
+	return s
+}
+
+// parseStat extracts the aggregate "cpu" and "ctxt" lines. Split out for
+// testing without a live /proc.
+func parseStat(data string) (Sample, bool) {
+	var s Sample
+	var haveCPU, haveCtxt bool
+	for _, line := range strings.Split(data, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		switch fields[0] {
+		case "cpu": // aggregate line: "cpu user nice system idle iowait irq softirq steal ..."
+			var total, idle uint64
+			for i, f := range fields[1:] {
+				v, err := strconv.ParseUint(f, 10, 64)
+				if err != nil {
+					break
+				}
+				total += v
+				if i == 3 || i == 4 { // idle, iowait
+					idle += v
+				}
+			}
+			s.CPUTotal, s.CPUBusy, haveCPU = total, total-idle, true
+		case "ctxt":
+			if v, err := strconv.ParseUint(fields[1], 10, 64); err == nil {
+				s.CtxSwitches, haveCtxt = v, true
+			}
+		}
+	}
+	return s, haveCPU && haveCtxt
+}
+
+// Rates are per-cell derived metrics over the interval between two Samples.
+type Rates struct {
+	CtxSwPerSec float64 // Δctxt ÷ wall-seconds
+	CPUPct      float64 // busy jiffies as % of total over the interval, 0..100
+}
+
+// RatesTo computes rates from a (earlier) to b (later). Returns zeros unless
+// both samples are ok and the interval and CPU-jiffy denominator are positive —
+// so a missing/degenerate sample can't produce NaN or a bogus spike.
+func (a Sample) RatesTo(b Sample) Rates {
+	if !a.ok || !b.ok {
+		return Rates{}
+	}
+	dt := b.T.Sub(a.T).Seconds()
+	var r Rates
+	if dt > 0 && b.CtxSwitches >= a.CtxSwitches {
+		r.CtxSwPerSec = float64(b.CtxSwitches-a.CtxSwitches) / dt
+	}
+	if dTotal := b.CPUTotal - a.CPUTotal; b.CPUTotal > a.CPUTotal && b.CPUBusy >= a.CPUBusy {
+		r.CPUPct = float64(b.CPUBusy-a.CPUBusy) / float64(dTotal) * 100
+	}
+	return r
+}

--- a/internal/dfsbench/sysstat/sysstat_test.go
+++ b/internal/dfsbench/sysstat/sysstat_test.go
@@ -35,6 +35,14 @@ func TestParseStat_MissingFields(t *testing.T) {
 	}
 }
 
+func TestParseStat_MalformedCPU(t *testing.T) {
+	// A non-numeric cpu field must reject the whole sample, not return ok=true
+	// with partial/bogus counters.
+	if _, ok := parseStat("cpu 100 0 bad 800 50\nctxt 42000\n"); ok {
+		t.Error("want ok=false when a cpu field is non-numeric")
+	}
+}
+
 func TestRatesTo(t *testing.T) {
 	t0 := time.Unix(0, 0)
 	a := Sample{T: t0, CtxSwitches: 1000, CPUBusy: 100, CPUTotal: 1000, ok: true}

--- a/internal/dfsbench/sysstat/sysstat_test.go
+++ b/internal/dfsbench/sysstat/sysstat_test.go
@@ -1,0 +1,67 @@
+package sysstat
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestParseStat(t *testing.T) {
+	// user=100 nice=0 system=50 idle=800 iowait=50 irq=0 softirq=0 steal=0
+	// → total=1000, idle+iowait=850, busy=150.
+	const data = "cpu  100 0 50 800 50 0 0 0 0 0\n" +
+		"cpu0 100 0 50 800 50 0 0 0 0 0\n" +
+		"intr 12345\n" +
+		"ctxt 42000\n" +
+		"btime 1600000000\n"
+	s, ok := parseStat(data)
+	if !ok {
+		t.Fatal("parseStat: ok=false, want true")
+	}
+	if s.CtxSwitches != 42000 {
+		t.Errorf("ctxt = %d, want 42000", s.CtxSwitches)
+	}
+	if s.CPUTotal != 1000 || s.CPUBusy != 150 {
+		t.Errorf("cpu total/busy = %d/%d, want 1000/150", s.CPUTotal, s.CPUBusy)
+	}
+}
+
+func TestParseStat_MissingFields(t *testing.T) {
+	if _, ok := parseStat("ctxt 5\n"); ok { // no cpu line
+		t.Error("want ok=false when cpu line absent")
+	}
+	if _, ok := parseStat("cpu 1 2 3 4 5\n"); ok { // no ctxt line
+		t.Error("want ok=false when ctxt line absent")
+	}
+}
+
+func TestRatesTo(t *testing.T) {
+	t0 := time.Unix(0, 0)
+	a := Sample{T: t0, CtxSwitches: 1000, CPUBusy: 100, CPUTotal: 1000, ok: true}
+	// 2s later: +4000 ctxsw → 2000/s; busy +300 of total +400 → 75% CPU.
+	b := Sample{T: t0.Add(2 * time.Second), CtxSwitches: 5000, CPUBusy: 400, CPUTotal: 1400, ok: true}
+	r := a.RatesTo(b)
+	if math.Abs(r.CtxSwPerSec-2000) > 1e-9 {
+		t.Errorf("ctxsw/s = %v, want 2000", r.CtxSwPerSec)
+	}
+	if math.Abs(r.CPUPct-75) > 1e-9 {
+		t.Errorf("cpu%% = %v, want 75", r.CPUPct)
+	}
+}
+
+func TestRatesTo_Degenerate(t *testing.T) {
+	ok := Sample{T: time.Unix(0, 0), CtxSwitches: 10, CPUBusy: 1, CPUTotal: 10, ok: true}
+	// not-ok sample → zero rates (off-Linux path).
+	if r := (Sample{}).RatesTo(ok); r != (Rates{}) {
+		t.Errorf("not-ok source: got %+v, want zero", r)
+	}
+	if r := ok.RatesTo(Sample{}); r != (Rates{}) {
+		t.Errorf("not-ok dest: got %+v, want zero", r)
+	}
+	// same timestamp → dt=0 → no divide-by-zero, zero ctxsw rate.
+	same := ok
+	same.CtxSwitches = 999
+	if r := ok.RatesTo(same); r.CtxSwPerSec != 0 {
+		t.Errorf("dt=0: ctxsw/s = %v, want 0", r.CtxSwPerSec)
+	}
+}


### PR DESCRIPTION
First slice of **PR5 (baselines + instrumentation)** from the harness-consolidation roadmap.

## What
- New `internal/dfsbench/sysstat` package: snapshots system-wide `/proc/stat` counters (`ctxt` + aggregate cpu jiffies) and derives **ctxsw/s** + **CPU%** over an interval. Pure `parseStat` → unit-tested with a fixture (no live `/proc`).
- Metered across **just the fio pass** in `runPass`; stored on `CellResult` (`ctxsw_per_sec`, `cpu_pct`).
- Two new report columns: **CTXSW/s**, **CPU%** (an unmeasured 0 dashes as `—`, matching the table convention).

## Why system-wide (not per-process)
Total ctxsw is the **only** number comparable across every server type in the matrix — userspace (dittofs/zerofs/the FUSE daemons) *and* kernel-thread (knfsd), which per-process `/proc/<pid>/status` can't cover. On the single-tenant disposable bench VM only the one backend + fio run, so the system-wide rate tracks the serving stack; fio's own switches are ~constant across cells at a fixed workload, so the native-vs-FUSE **delta** is the tax.

## Safety / degradation
Off Linux (dev macOS `--local`/`--smoke`) `/proc/stat` is absent → not-ok sample → **zero rates**, columns show `—`. No error path for the caller.

## Notes
- Follow-ups in PR5: warp raw-S3 + fio local-disk **baselines/ceilings**, DittoFS **pprof + Prometheus datapath** snapshot per cell, and the **native-vs-re-export pairing view** in the report.
- `go build` / `go vet` / `go test ./internal/dfsbench/...` (27 pass) / `golangci-lint` all green.