### PR TITLE
feat(bench): native-vs-re-export pairing view

### DIFF
--- a/internal/dfsbench/fio/result.go
+++ b/internal/dfsbench/fio/result.go
@@ -42,6 +42,11 @@ type CellResult struct {
 	// CtxSwPerSec is the FUSE-tax indicator; 0 off Linux (local/smoke on macOS).
 	CtxSwPerSec float64 `json:"ctxsw_per_sec,omitempty"`
 	CPUPct      float64 `json:"cpu_pct,omitempty"`
+
+	// AccessMode is how the backend served this cell: "native" (its own server,
+	// e.g. dittofs/zerofs) or "reexport" (a FUSE mount re-served over knfsd/Samba
+	// — the FUSE tax). Empty for direct local/smoke mounts. Drives the pairing view.
+	AccessMode string `json:"access_mode,omitempty"`
 }
 
 // Slug is the stable, filesystem-safe identity of a cell. Two runs of the same

--- a/internal/dfsbench/report/report.go
+++ b/internal/dfsbench/report/report.go
@@ -28,6 +28,7 @@ func NewReportCmd() *cobra.Command {
 				return fmt.Errorf("no results in %q", results)
 			}
 			_, _ = fmt.Fprint(exec.CmdOut, RenderTable(rs))
+			_, _ = fmt.Fprint(exec.CmdOut, RenderPairing(rs))
 			return nil
 		},
 	}
@@ -54,11 +55,11 @@ func RenderTable(rs []fio.CellResult) string {
 		return a.Size < b.Size
 	})
 
-	head := []string{"SYSTEM", "WORKLOAD", "SIZE", "PROTO", "PASS", "IOPS", "MB/s", "p50µs", "p99µs", "S3MB", "CTXSW/s", "CPU%", "err"}
+	head := []string{"SYSTEM", "ACCESS", "WORKLOAD", "SIZE", "PROTO", "PASS", "IOPS", "MB/s", "p50µs", "p99µs", "S3MB", "CTXSW/s", "CPU%", "err"}
 	rows := make([][]string, 0, len(rs))
 	for _, r := range rs {
 		rows = append(rows, []string{
-			r.System, r.Workload, r.Size, r.Protocol, r.Pass,
+			r.System, access(r.AccessMode), r.Workload, r.Size, r.Protocol, r.Pass,
 			rate(r.IOPS, isRandom(r.Workload)),
 			rate(r.ThroughputMBps, !isRandom(r.Workload)),
 			fmt.Sprintf("%.0f", r.LatencyP50Us),
@@ -70,6 +71,103 @@ func RenderTable(rs []fio.CellResult) string {
 		})
 	}
 	return markdownTable(head, rows)
+}
+
+// access formats the access-mode column, dashing an unset mode (direct
+// local/smoke mounts, or pre-meter runs).
+func access(m string) string {
+	if m == "" {
+		return "—"
+	}
+	return m
+}
+
+// pairKey groups results that are directly comparable across access modes — same
+// workload, size, protocol, and pass.
+type pairKey struct{ workload, size, proto, pass string }
+
+// RenderPairing is the FUSE-tax view: for every (workload, size, protocol, pass)
+// that has BOTH a native and a re-exported system, it prints them side by side —
+// native rows first — so the throughput vs CTXSW/s contrast is legible (the
+// architectural thesis: native serving avoids the FUSE context-switch tax).
+// Groups without both modes are skipped; returns "" when nothing pairs.
+func RenderPairing(rs []fio.CellResult) string {
+	groups := map[pairKey][]fio.CellResult{}
+	for _, r := range rs {
+		if r.AccessMode == "" {
+			continue // direct mount — nothing to pair against
+		}
+		k := pairKey{r.Workload, r.Size, r.Protocol, r.Pass}
+		groups[k] = append(groups[k], r)
+	}
+
+	keys := make([]pairKey, 0, len(groups))
+	for k, g := range groups {
+		if hasBothModes(g) {
+			keys = append(keys, k)
+		}
+	}
+	if len(keys) == 0 {
+		return ""
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		a, b := keys[i], keys[j]
+		if a.workload != b.workload {
+			return a.workload < b.workload
+		}
+		if a.size != b.size {
+			return a.size < b.size
+		}
+		if a.proto != b.proto {
+			return a.proto < b.proto
+		}
+		return a.pass < b.pass
+	})
+
+	var b strings.Builder
+	b.WriteString("\nFUSE-tax pairing — native vs re-exported at the same workload/size/protocol/pass.\n")
+	b.WriteString("Higher CTXSW/s on the re-exported rows is the context-switch tax native serving avoids.\n\n")
+	head := []string{"SYSTEM", "ACCESS", "MB/s", "IOPS", "CTXSW/s", "CPU%", "err"}
+	for _, k := range keys {
+		g := groups[k]
+		sort.Slice(g, func(i, j int) bool {
+			if native(g[i]) != native(g[j]) {
+				return native(g[i]) // native rows first
+			}
+			return g[i].System < g[j].System
+		})
+		fmt.Fprintf(&b, "### %s · %s · %s · %s\n", k.workload, k.size, k.proto, k.pass)
+		rows := make([][]string, 0, len(g))
+		for _, r := range g {
+			rows = append(rows, []string{
+				r.System, access(r.AccessMode),
+				rate(r.ThroughputMBps, !isRandom(r.Workload)),
+				rate(r.IOPS, isRandom(r.Workload)),
+				metered(r.CtxSwPerSec), metered(r.CPUPct),
+				fmt.Sprintf("%d", r.Errors),
+			})
+		}
+		b.WriteString(markdownTable(head, rows))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// native reports whether a cell was served by the backend's own server.
+func native(r fio.CellResult) bool { return r.AccessMode == "native" }
+
+// hasBothModes reports whether a group contains at least one native and one
+// re-exported cell — the precondition for a meaningful pairing.
+func hasBothModes(g []fio.CellResult) bool {
+	var haveNative, haveReexport bool
+	for _, r := range g {
+		if native(r) {
+			haveNative = true
+		} else if r.AccessMode == "reexport" {
+			haveReexport = true
+		}
+	}
+	return haveNative && haveReexport
 }
 
 // isRandom reports whether IOPS is the workload's headline metric.

--- a/internal/dfsbench/report/report_test.go
+++ b/internal/dfsbench/report/report_test.go
@@ -8,17 +8,28 @@ import (
 )
 
 func TestRenderTable_HeadlineDashing(t *testing.T) {
+	// AccessMode set so the ACCESS column isn't dashed — then the only "—" left in
+	// each row is its non-headline rate column, so we assert rate-dashing per row
+	// (not a table-wide Contains that any dash would satisfy).
 	rs := []fio.CellResult{
-		{System: "local", Workload: "seq-read", Size: "large", Protocol: "local", Pass: "warm", ThroughputMBps: 2400},
-		{System: "local", Workload: "rand-read-4k", Size: "large", Protocol: "local", Pass: "warm", IOPS: 8940},
+		{System: "local-disk", AccessMode: "reexport", Workload: "seq-read", Size: "large", Protocol: "nfs3", Pass: "warm", ThroughputMBps: 2400},
+		{System: "local-disk", AccessMode: "reexport", Workload: "rand-read-4k", Size: "large", Protocol: "nfs3", Pass: "warm", IOPS: 8940},
 	}
 	out := RenderTable(rs)
-	if !strings.Contains(out, "2400") || !strings.Contains(out, "8940") {
-		t.Errorf("missing values:\n%s", out)
+	var seqLine, randLine string
+	for _, ln := range strings.Split(out, "\n") {
+		if strings.Contains(ln, "seq-read") {
+			seqLine = ln
+		}
+		if strings.Contains(ln, "rand-read-4k") {
+			randLine = ln
+		}
 	}
-	// seq-read: IOPS column dashed; rand: MB/s column dashed.
-	if !strings.Contains(out, "—") {
-		t.Errorf("expected dashed non-headline cells:\n%s", out)
+	if !strings.Contains(seqLine, "2400") || !strings.Contains(seqLine, "—") {
+		t.Errorf("seq-read row should show 2400 MB/s and a dashed IOPS:\n%s", seqLine)
+	}
+	if !strings.Contains(randLine, "8940") || !strings.Contains(randLine, "—") {
+		t.Errorf("rand-read-4k row should show 8940 IOPS and a dashed MB/s:\n%s", randLine)
 	}
 }
 

--- a/internal/dfsbench/report/report_test.go
+++ b/internal/dfsbench/report/report_test.go
@@ -21,3 +21,32 @@ func TestRenderTable_HeadlineDashing(t *testing.T) {
 		t.Errorf("expected dashed non-headline cells:\n%s", out)
 	}
 }
+
+func TestRenderPairing(t *testing.T) {
+	rs := []fio.CellResult{
+		{System: "dittofs-s3", AccessMode: "native", Workload: "seq-read", Size: "medium", Protocol: "nfs3", Pass: "cold", ThroughputMBps: 349, CtxSwPerSec: 18400},
+		{System: "juicefs", AccessMode: "reexport", Workload: "seq-read", Size: "medium", Protocol: "nfs3", Pass: "cold", ThroughputMBps: 437, CtxSwPerSec: 96300},
+		// A group with only a native row must NOT produce a pairing section.
+		{System: "dittofs-s3", AccessMode: "native", Workload: "seq-write", Size: "medium", Protocol: "nfs3", Pass: "warm", ThroughputMBps: 500, CtxSwPerSec: 12000},
+	}
+	out := RenderPairing(rs)
+	if !strings.Contains(out, "seq-read") || !strings.Contains(out, "18400") || !strings.Contains(out, "96300") {
+		t.Errorf("pairing missing the paired seq-read cells:\n%s", out)
+	}
+	if strings.Contains(out, "seq-write") {
+		t.Errorf("single-mode group must not be paired:\n%s", out)
+	}
+	// native row is ordered before the re-exported one.
+	if strings.Index(out, "dittofs-s3") > strings.Index(out, "juicefs") {
+		t.Errorf("native row must precede re-exported row:\n%s", out)
+	}
+}
+
+func TestRenderPairing_NothingToPair(t *testing.T) {
+	rs := []fio.CellResult{
+		{System: "local", Workload: "seq-read", Protocol: "local", Pass: "warm"}, // no AccessMode
+	}
+	if out := RenderPairing(rs); out != "" {
+		t.Errorf("want empty pairing when nothing pairs, got:\n%s", out)
+	}
+}

--- a/internal/dfsbench/run/managed.go
+++ b/internal/dfsbench/run/managed.go
@@ -70,6 +70,7 @@ func runManaged(ctx context.Context, f *runFlags, opts fio.LoadOpts, cfg config.
 	}
 	_, _ = fmt.Fprintln(exec.CmdOut)
 	_, _ = fmt.Fprint(exec.CmdOut, report.RenderTable(rows))
+	_, _ = fmt.Fprint(exec.CmdOut, report.RenderPairing(rows))
 	if len(failures) > 0 {
 		_, _ = fmt.Fprintf(exec.CmdOut, "\n%d backend(s) failed:\n", len(failures))
 		for _, fl := range failures {
@@ -178,6 +179,7 @@ func runPass(ctx context.Context, p backend.Plan, pass string, wls, sizes []stri
 			}
 			r := before.RatesTo(sysstat.Now())
 			m.CtxSwPerSec, m.CPUPct = r.CtxSwPerSec, r.CPUPct
+			m.AccessMode = p.Support.String() // "native" | "reexport" — the pairing axis
 			m.System, m.Workload, m.Size, m.Protocol, m.Pass = res.System, w, s, res.Protocol, pass
 			m.Timestamp = time.Now().UTC()
 			if err := m.Save(f.results); err != nil {

--- a/internal/dfsbench/run/managed.go
+++ b/internal/dfsbench/run/managed.go
@@ -179,7 +179,12 @@ func runPass(ctx context.Context, p backend.Plan, pass string, wls, sizes []stri
 			}
 			r := before.RatesTo(sysstat.Now())
 			m.CtxSwPerSec, m.CPUPct = r.CtxSwPerSec, r.CPUPct
-			m.AccessMode = p.Support.String() // "native" | "reexport" — the pairing axis
+			// "native" | "reexport" — the pairing axis. Guard the Support.String()
+			// "na" sentinel to empty so an unexpected value never leaks into the
+			// ACCESS column or the pairing grouping.
+			if m.AccessMode = p.Support.String(); m.AccessMode == "na" {
+				m.AccessMode = ""
+			}
 			m.System, m.Workload, m.Size, m.Protocol, m.Pass = res.System, w, s, res.Protocol, pass
 			m.Timestamp = time.Now().UTC()
 			if err := m.Save(f.results); err != nil {


### PR DESCRIPTION
Second slice of **PR5**, building on the ctxsw/CPU meter (#1612): turns the per-cell CTXSW/s number into the **thesis payoff** — a side-by-side view of native vs re-exported serving.

## What
- `CellResult.AccessMode` (`native` | `reexport`), stamped from the resolved plan's `Support`; empty for direct local/smoke mounts.
- `report.RenderPairing`: for every `(workload, size, protocol, pass)` that has **both** a native (dittofs/zerofs) and a re-exported (juicefs/s3fs/rclone/s3ql/local-disk) system, prints them adjacent — **native rows first** — with MB/s vs **CTXSW/s** vs CPU%. Groups without both modes are skipped; renders nothing when nothing pairs.
- New **ACCESS** column on the main table. Wired into both `run`'s trailing output and the `report` command.

## Why
The whole harness thesis is *DittoFS's native userspace server avoids the FUSE context-switch tax that FUSE competitors pay when re-exported over knfsd/Samba.* PR5a made ctxsw measurable; this makes the contrast **legible at a glance** — same workload/protocol, native's throughput at a fraction of the re-exported rows' context switches.

## Notes
- Last PR5 piece after this: warp raw-S3 + fio local-disk **baselines/ceilings**. Then the live twin-vs-twin run (dittofs-native vs zerofs-native) produces the complete scorecard.
- `go build` / `go vet` / `go test ./internal/dfsbench/...` (30 pass) / `golangci-lint` all green.