### PR TITLE
feat(bench): local-disk ceiling baseline atop the scorecard

### DIFF
--- a/internal/dfsbench/report/report.go
+++ b/internal/dfsbench/report/report.go
@@ -36,6 +36,24 @@ func NewReportCmd() *cobra.Command {
 	return cmd
 }
 
+// Baseline holds the reference ceilings printed atop the scorecard, so every FS
+// number reads as a fraction of what the hardware/pipe can do. Zero value =
+// unmeasured (--skip-baseline or a failed measurement) → RenderBaseline emits
+// nothing. The raw-S3 PUT/GET ceiling (warp) lands with its own fields later.
+type Baseline struct {
+	LocalDiskSeqMBps  float64 // fio sequential bandwidth against bare scratch (no FS/S3)
+	LocalDiskRandIOPS float64 // fio random-4k IOPS against bare scratch
+}
+
+// RenderBaseline formats the ceilings header. Empty when nothing was measured.
+func RenderBaseline(b Baseline) string {
+	if b == (Baseline{}) {
+		return ""
+	}
+	return fmt.Sprintf("BASELINES (ceilings)\n  local-disk  seq %.0f MB/s   rand-4k %.0f IOPS\n\n",
+		b.LocalDiskSeqMBps, b.LocalDiskRandIOPS)
+}
+
 // RenderTable produces the markdown comparison table. Columns follow the plan's
 // dictionary; rate columns render "—" when not the workload's headline metric,
 // and CTXSW/s + CPU% dash when unmetered (off Linux / pre-meter runs). S3MB

--- a/internal/dfsbench/report/report_test.go
+++ b/internal/dfsbench/report/report_test.go
@@ -61,3 +61,17 @@ func TestRenderPairing_NothingToPair(t *testing.T) {
 		t.Errorf("want empty pairing when nothing pairs, got:\n%s", out)
 	}
 }
+
+func TestRenderBaseline(t *testing.T) {
+	// Zero value → nothing rendered (skipped/failed baseline).
+	if out := RenderBaseline(Baseline{}); out != "" {
+		t.Errorf("empty baseline should render nothing, got %q", out)
+	}
+	out := RenderBaseline(Baseline{LocalDiskSeqMBps: 2400, LocalDiskRandIOPS: 180000})
+	if !strings.Contains(out, "2400") || !strings.Contains(out, "180000") {
+		t.Errorf("baseline missing values:\n%s", out)
+	}
+	if !strings.Contains(out, "local-disk") {
+		t.Errorf("baseline missing label:\n%s", out)
+	}
+}

--- a/internal/dfsbench/run/baseline.go
+++ b/internal/dfsbench/run/baseline.go
@@ -9,10 +9,12 @@ import (
 	"github.com/marmos91/dittofs/internal/dfsbench/report"
 )
 
-// baselineScratch is where the local-disk ceiling fio runs — a plain dir on the
-// VM's scratch volume, no FS layer and no S3, so its numbers are the "is the
+// baselineScratchRoot is where the local-disk ceiling fio runs — plain dirs on
+// the VM's scratch volume, no FS layer and no S3, so the numbers are the "is the
 // bottleneck the filesystem or the hardware?" anchor every cell is read against.
-const baselineScratch = "/var/tmp/dfsbench-baseline"
+// Each run gets its own subdir (below) so concurrent runs don't interfere and a
+// cleanup only ever removes its own directory.
+const baselineScratchRoot = "/var/tmp/dfsbench-baseline"
 
 // measureLocalDiskCeiling runs fio straight against a scratch dir (no mount, no
 // S3) to get the local-disk bandwidth + IOPS ceiling. size is the run's largest
@@ -23,22 +25,28 @@ const baselineScratch = "/var/tmp/dfsbench-baseline"
 // The raw-S3 PUT/GET ceiling (MinIO warp) is the other half of the plan's
 // baseline; it's added once warp's flags/JSON are pinned on the VM.
 func measureLocalDiskCeiling(ctx context.Context, size string, opts fio.LoadOpts) (report.Baseline, error) {
-	if err := os.MkdirAll(baselineScratch, 0o755); err != nil {
+	if err := os.MkdirAll(baselineScratchRoot, 0o755); err != nil {
 		return report.Baseline{}, err
 	}
-	defer func() { _ = os.RemoveAll(baselineScratch) }()
+	// Per-run subdir: isolates concurrent runs and bounds the cleanup to our own
+	// directory (never a recursive wipe of a shared, possibly-reused path).
+	scratch, err := os.MkdirTemp(baselineScratchRoot, "run-*")
+	if err != nil {
+		return report.Baseline{}, err
+	}
+	defer func() { _ = os.RemoveAll(scratch) }()
 
 	// Lay the file down first so the read passes hit real bytes (mirrors the
 	// matrix's layoutReadTarget), then measure sequential bandwidth and random
 	// 4k IOPS — the two ceiling numbers the scorecard header shows.
-	if _, err := fio.RunFio(ctx, "layout", baselineScratch, withSize(opts, size)); err != nil {
+	if _, err := fio.RunFio(ctx, "layout", scratch, withSize(opts, size)); err != nil {
 		return report.Baseline{}, fmt.Errorf("baseline layout: %w", err)
 	}
-	seq, err := fio.RunFio(ctx, "seq-read", baselineScratch, withSize(opts, size))
+	seq, err := fio.RunFio(ctx, "seq-read", scratch, withSize(opts, size))
 	if err != nil {
 		return report.Baseline{}, fmt.Errorf("baseline seq-read: %w", err)
 	}
-	rnd, err := fio.RunFio(ctx, "rand-read-4k", baselineScratch, withSize(opts, size))
+	rnd, err := fio.RunFio(ctx, "rand-read-4k", scratch, withSize(opts, size))
 	if err != nil {
 		return report.Baseline{}, fmt.Errorf("baseline rand-read-4k: %w", err)
 	}

--- a/internal/dfsbench/run/baseline.go
+++ b/internal/dfsbench/run/baseline.go
@@ -1,0 +1,49 @@
+package run
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/marmos91/dittofs/internal/dfsbench/fio"
+	"github.com/marmos91/dittofs/internal/dfsbench/report"
+)
+
+// baselineScratch is where the local-disk ceiling fio runs — a plain dir on the
+// VM's scratch volume, no FS layer and no S3, so its numbers are the "is the
+// bottleneck the filesystem or the hardware?" anchor every cell is read against.
+const baselineScratch = "/var/tmp/dfsbench-baseline"
+
+// measureLocalDiskCeiling runs fio straight against a scratch dir (no mount, no
+// S3) to get the local-disk bandwidth + IOPS ceiling. size is the run's largest
+// class, so the ceiling is measured at the same scale as the cells it anchors.
+// Best-effort: a failure returns the error for the caller to warn-and-continue —
+// a missing ceiling shouldn't abort the comparison.
+//
+// The raw-S3 PUT/GET ceiling (MinIO warp) is the other half of the plan's
+// baseline; it's added once warp's flags/JSON are pinned on the VM.
+func measureLocalDiskCeiling(ctx context.Context, size string, opts fio.LoadOpts) (report.Baseline, error) {
+	if err := os.MkdirAll(baselineScratch, 0o755); err != nil {
+		return report.Baseline{}, err
+	}
+	defer func() { _ = os.RemoveAll(baselineScratch) }()
+
+	// Lay the file down first so the read passes hit real bytes (mirrors the
+	// matrix's layoutReadTarget), then measure sequential bandwidth and random
+	// 4k IOPS — the two ceiling numbers the scorecard header shows.
+	if _, err := fio.RunFio(ctx, "layout", baselineScratch, withSize(opts, size)); err != nil {
+		return report.Baseline{}, fmt.Errorf("baseline layout: %w", err)
+	}
+	seq, err := fio.RunFio(ctx, "seq-read", baselineScratch, withSize(opts, size))
+	if err != nil {
+		return report.Baseline{}, fmt.Errorf("baseline seq-read: %w", err)
+	}
+	rnd, err := fio.RunFio(ctx, "rand-read-4k", baselineScratch, withSize(opts, size))
+	if err != nil {
+		return report.Baseline{}, fmt.Errorf("baseline rand-read-4k: %w", err)
+	}
+	return report.Baseline{
+		LocalDiskSeqMBps:  seq.ThroughputMBps,
+		LocalDiskRandIOPS: rnd.IOPS,
+	}, nil
+}

--- a/internal/dfsbench/run/cmd.go
+++ b/internal/dfsbench/run/cmd.go
@@ -6,22 +6,23 @@ import (
 
 // runFlags are the `run` command's flags; they override any --config values.
 type runFlags struct {
-	config     string
-	local      bool
-	smoke      bool
-	target     string
-	systems    []string
-	workloads  []string
-	sizes      []string
-	results    string
-	threads    int
-	runtime    int
-	engine     string
-	fioBin     string
-	resume     bool
-	dryRun     bool
-	evictCache bool
-	remote     bool
+	config       string
+	local        bool
+	smoke        bool
+	target       string
+	systems      []string
+	workloads    []string
+	sizes        []string
+	results      string
+	threads      int
+	runtime      int
+	engine       string
+	fioBin       string
+	resume       bool
+	dryRun       bool
+	evictCache   bool
+	remote       bool
+	skipBaseline bool
 }
 
 // NewRunCmd builds the `run` subcommand, which drives fio across the workload ×
@@ -68,5 +69,6 @@ Add --remote to run the managed matrix on a provisioned VM (see 'dfsbench setup'
 	fl.BoolVar(&f.dryRun, "dry-run", false, "print the cell matrix and exit")
 	fl.BoolVar(&f.evictCache, "evict-cache", true, "run a cold (post-evict) read pass in managed mode")
 	fl.BoolVar(&f.remote, "remote", false, "drive the managed run on the provisioned VM from .bench-vm.json (needs `dfsbench setup`)")
+	fl.BoolVar(&f.skipBaseline, "skip-baseline", false, "skip the local-disk ceiling measured before the managed matrix")
 	return cmd
 }

--- a/internal/dfsbench/run/managed.go
+++ b/internal/dfsbench/run/managed.go
@@ -47,6 +47,18 @@ func runManaged(ctx context.Context, f *runFlags, opts fio.LoadOpts, cfg config.
 		want[(fio.CellResult{System: c.System, Workload: c.Workload, Size: c.Size, Protocol: c.Protocol, Pass: c.Pass}).Slug()] = true
 	}
 
+	// Measure the local-disk ceiling once, up front, so the scorecard opens with
+	// the "is the bottleneck the FS or the hardware?" anchor. Best-effort: a
+	// failed/absent baseline warns and the comparison still runs.
+	var baseline report.Baseline
+	if !f.skipBaseline {
+		if b, err := measureLocalDiskCeiling(ctx, maxReadSize(sizes), opts); err != nil {
+			_, _ = fmt.Fprintf(exec.CmdOut, "warn: baseline: %v\n", err)
+		} else {
+			baseline = b
+		}
+	}
+
 	env := backend.BackendEnv{Bucket: cfg.Bucket, Endpoint: cfg.Endpoint}
 	// A comparison shouldn't die because one competitor's recipe breaks — record
 	// the failure and keep going, so one run surfaces every backend's state.
@@ -69,6 +81,7 @@ func runManaged(ctx context.Context, f *runFlags, opts fio.LoadOpts, cfg config.
 		}
 	}
 	_, _ = fmt.Fprintln(exec.CmdOut)
+	_, _ = fmt.Fprint(exec.CmdOut, report.RenderBaseline(baseline))
 	_, _ = fmt.Fprint(exec.CmdOut, report.RenderTable(rows))
 	_, _ = fmt.Fprint(exec.CmdOut, report.RenderPairing(rows))
 	if len(failures) > 0 {

--- a/internal/dfsbench/run/remote.go
+++ b/internal/dfsbench/run/remote.go
@@ -87,6 +87,9 @@ func remoteRunArgs(f *runFlags) string {
 	if f.resume {
 		args = append(args, "--resume")
 	}
+	if f.skipBaseline {
+		args = append(args, "--skip-baseline")
+	}
 	return "/root/dfsbench " + strings.Join(args, " ")
 }
 


### PR DESCRIPTION
Third slice of **PR5** — the reference **ceiling** so every FS number reads as a fraction of what the hardware can do ("is the bottleneck the filesystem or the pipe?").

## What
- `measureLocalDiskCeiling`: runs fio straight against a bare scratch dir on the VM (no mount, no S3) — layout → seq-read (bandwidth) → rand-read-4k (IOPS) — at the run's largest size class, so the ceiling matches the cells' scale.
- `report.Baseline` + `RenderBaseline`: prints `BASELINES (ceilings)` atop the scorecard; zero value (skipped/failed) renders nothing.
- Measured once at the top of the managed run; **best-effort** — a failure warns and the comparison still runs.
- `--skip-baseline` flag, forwarded to `--remote` so it reaches the VM invocation.

## Scope (deliberate)
This is the **safe half** of the plan's baseline. The **raw-S3 PUT/GET ceiling via MinIO warp** is intentionally deferred: warp's exact flags + JSON schema need pinning against the tool *on the VM* (the same "tuned on first run" convention as every recipe) rather than guessed blind — the exact "measure, don't assume" trap. The local-disk half reuses our own fio driver, so its shape is validated here.

## Notes
- The baseline prints to stdout → the VM's `run.log` (pulled locally). Surfacing it in the locally re-rendered table (persist `baseline.json`) is a clean follow-up.
- Independent of #1613 (pairing view) — either can merge first; the second rebases trivially.
- `go build` / `go vet` / `go test ./internal/dfsbench/...` (30 pass) / `golangci-lint` all green.