### PR TITLE
feat: advertise SMB/NFS on the LAN via WS-Discovery + mDNS (#1609)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,12 @@ USER 65532:65532
 # - 12049: NFS server (default)
 # - 12445: SMB server (default)
 # - 8080: REST API (health checks, management)
-EXPOSE 12049/tcp 12445/tcp 8080/tcp
+# - 5353/udp: mDNS / DNS-SD network discovery (macOS Finder, Linux Avahi) — issue #1609
+# - 3702/udp: WS-Discovery (Windows Explorer Network) — issue #1609
+# - 5357/tcp: WS-Discovery device metadata (HTTP) — issue #1609
+# Note: multicast discovery (5353/3702) only works on the host LAN / hostNetwork;
+# it does not traverse standard container/K8s overlay networks.
+EXPOSE 12049/tcp 12445/tcp 8080/tcp 5353/udp 3702/udp 5357/tcp
 
 # Volume mounts:
 # - /data/metadata: Metadata store (BadgerDB, etc.)

--- a/cmd/dfsctl/commands/adapter/settings.go
+++ b/cmd/dfsctl/commands/adapter/settings.go
@@ -216,18 +216,21 @@ var (
 	settingsPortmapperPort             int
 	settingsPortmapperRegisterWithSys  bool
 	settingsUDPEnabled                 bool
+	settingsMDNSEnabled                bool
 	settingsV4MinMinorVersion          int
 	settingsV4MaxMinorVersion          int
 	settingsV4MaxConnectionsPerSession int
 
 	// SMB update flags
-	settingsMinDialect         string
-	settingsMaxDialect         string
-	settingsSessionTimeout     int
-	settingsOplockBreakTimeout int
-	settingsMaxSessions        int
-	settingsEnableEncryption   bool
-	settingsSigning            string
+	settingsMinDialect            string
+	settingsMaxDialect            string
+	settingsSessionTimeout        int
+	settingsOplockBreakTimeout    int
+	settingsMaxSessions           int
+	settingsEnableEncryption      bool
+	settingsSigning               string
+	settingsSMBMDNSEnabled        bool
+	settingsSMBWSDiscoveryEnabled bool
 
 	// Common flags
 	settingsDryRun       bool
@@ -293,6 +296,7 @@ func registerNFSUpdateFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&settingsPortmapperPort, "portmapper-port", 0, "Portmapper listen port")
 	cmd.Flags().BoolVar(&settingsPortmapperRegisterWithSys, "portmapper-register-with-system", false, "Register NFS/MOUNT/NLM services with the host's system rpcbind on port 111, so kernel NFSv3 clients can lock without 'nolock' (restart to apply)")
 	cmd.Flags().BoolVar(&settingsUDPEnabled, "udp-enabled", false, "Serve NLM/NSM/MOUNT over UDP (needed for NFSv3 locking from macOS/BSD; restart to apply)")
+	cmd.Flags().BoolVar(&settingsMDNSEnabled, "mdns-enabled", false, "Advertise the NFS export over mDNS/DNS-SD (_nfs._tcp) for macOS Finder / Linux Avahi (applied immediately)")
 	cmd.Flags().IntVar(&settingsV4MinMinorVersion, "v4-min-minor-version", 0, "Minimum NFSv4 minor version (0=v4.0, 1=v4.1)")
 	cmd.Flags().IntVar(&settingsV4MaxMinorVersion, "v4-max-minor-version", 0, "Maximum NFSv4 minor version (0=v4.0, 1=v4.1)")
 	cmd.Flags().IntVar(&settingsV4MaxConnectionsPerSession, "v4-max-connections-per-session", 0, "Maximum connections per NFSv4.1 session (0=unlimited)")
@@ -310,6 +314,8 @@ func registerSMBUpdateFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&settingsEnableEncryption, "enable-encryption", false, "Enable SMB encryption")
 	cmd.Flags().StringVar(&settingsSigning, "signing", "", "SMB message signing mode: disabled|enabled|required")
 	cmd.Flags().StringVar(&settingsBlockedOperations, "blocked-operations", "", "Comma-separated list of blocked operations")
+	cmd.Flags().BoolVar(&settingsSMBMDNSEnabled, "mdns-enabled", false, "Advertise the SMB service over mDNS/DNS-SD (_smb._tcp) for macOS Finder / Linux Avahi (applied immediately)")
+	cmd.Flags().BoolVar(&settingsSMBWSDiscoveryEnabled, "wsdiscovery-enabled", false, "Advertise the host over WS-Discovery so it appears in the Windows Explorer Network view (applied immediately)")
 	cmd.Flags().BoolVar(&smbSettingsDryRun, "dry-run", false, "Validate without applying changes")
 	cmd.Flags().BoolVar(&smbSettingsForce, "force", false, "Bypass range validation")
 }
@@ -388,6 +394,9 @@ func showNFSSettings(client *apiclient.Client, format output.Format) error {
 		newSettingRowInt("portmapper_port", settings.PortmapperPort, d.PortmapperPort, ""),
 		newSettingRowBool("udp_enabled", settings.UDPEnabled, d.UDPEnabled),
 	})
+	printSettingsGroup("Discovery", []settingRow{
+		newSettingRowBool("mdns_enabled", settings.MDNSEnabled, d.MDNSEnabled),
+	})
 	printSettingsGroup("Operations", []settingRow{
 		newSettingRowStrSlice("blocked_operations", settings.BlockedOperations, d.BlockedOperations),
 	})
@@ -426,6 +435,10 @@ func showSMBSettings(client *apiclient.Client, format output.Format) error {
 	printSettingsGroup("Security", []settingRow{
 		newSettingRowBool("enable_encryption", settings.EnableEncryption, d.EnableEncryption),
 		newSettingRow("signing", settings.Signing, d.Signing),
+	})
+	printSettingsGroup("Discovery", []settingRow{
+		newSettingRowBool("mdns_enabled", settings.MDNSEnabled, d.MDNSEnabled),
+		newSettingRowBool("wsdiscovery_enabled", settings.WSDiscoveryEnabled, d.WSDiscoveryEnabled),
 	})
 	printSettingsGroup("Operations", []settingRow{
 		newSettingRowStrSlice("blocked_operations", settings.BlockedOperations, d.BlockedOperations),
@@ -615,6 +628,10 @@ func updateNFSSettings(cmd *cobra.Command, client *apiclient.Client) error {
 		req.UDPEnabled = &settingsUDPEnabled
 		hasChanges = true
 	}
+	if cmd.Flags().Changed("mdns-enabled") {
+		req.MDNSEnabled = &settingsMDNSEnabled
+		hasChanges = true
+	}
 	if cmd.Flags().Changed("v4-min-minor-version") {
 		req.V4MinMinorVersion = &settingsV4MinMinorVersion
 		hasChanges = true
@@ -693,6 +710,14 @@ func updateSMBSettings(cmd *cobra.Command, client *apiclient.Client) error {
 	if cmd.Flags().Changed("blocked-operations") {
 		ops := cmdutil.ParseCommaSeparatedList(settingsBlockedOperations)
 		req.BlockedOperations = &ops
+		hasChanges = true
+	}
+	if cmd.Flags().Changed("mdns-enabled") {
+		req.MDNSEnabled = &settingsSMBMDNSEnabled
+		hasChanges = true
+	}
+	if cmd.Flags().Changed("wsdiscovery-enabled") {
+		req.WSDiscoveryEnabled = &settingsSMBWSDiscoveryEnabled
 		hasChanges = true
 	}
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1125,6 +1125,7 @@ Flags:
       --max-read-size int                    Maximum read size in bytes
       --max-version string                   Maximum NFS version (e.g., 4.1)
       --max-write-size int                   Maximum write size in bytes
+      --mdns-enabled                         Advertise the NFS export over mDNS/DNS-SD (_nfs._tcp) for macOS Finder / Linux Avahi (applied immediately)
       --min-version string                   Minimum NFS version (e.g., 3)
       --portmapper-enabled                   Enable embedded portmapper
       --portmapper-port int                  Portmapper listen port
@@ -1309,10 +1310,12 @@ Flags:
       --max-connections int         Maximum concurrent connections
       --max-dialect string          Maximum SMB dialect
       --max-sessions int            Maximum concurrent SMB sessions
+      --mdns-enabled                Advertise the SMB service over mDNS/DNS-SD (_smb._tcp) for macOS Finder / Linux Avahi (applied immediately)
       --min-dialect string          Minimum SMB dialect
       --oplock-break-timeout int    Oplock break timeout in seconds
       --session-timeout int         SMB session timeout in seconds
       --signing string              SMB message signing mode: disabled|enabled|required
+      --wsdiscovery-enabled         Advertise the host over WS-Discovery so it appears in the Windows Explorer Network view (applied immediately)
 ```
 
 Global flags:
@@ -4064,8 +4067,8 @@ mkdir -p ~/mnt/dittofs && dfsctl share mount /export --protocol smb ~/mnt/dittof
 Flags:
 
 ```
-      --dir-mode string      Directory permissions for SMB mount (octal) (default "0777")
-      --file-mode string     File permissions for SMB mount (octal, default 0777 on macOS since uid/gid not supported) (default "0777")
+      --dir-mode string      Directory permissions for SMB mount (octal)
+      --file-mode string     File permissions (not applicable on Windows)
       --nfs-version string   NFS protocol version for NFS mounts (3, 4, 4.0, 4.1, 4.2). v4 carries locking in-protocol; v3 locking needs the server UDP transport + portmapper (default "3")
   -P, --password string      Password for SMB mount (will prompt if not provided)
   -p, --protocol string      Protocol to use (nfs or smb) (required)

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1632,6 +1632,35 @@ export DITTOFS_ADAPTERS_SMB_CROSS_PROTOCOL_DELEGATION_RECALL_TIMEOUT=90s
 export DITTOFS_ADAPTERS_SMB_CROSS_PROTOCOL_ANTI_STORM_TTL=30s
 ```
 
+#### Network discovery (mDNS / WS-Discovery)
+
+DittoFS can advertise itself on the LAN so it appears in **macOS Finder →
+Network**, Linux file managers (via Avahi), and the **Windows Explorer →
+Network** view — the same job the external `avahi-daemon` and `wsdd`/`wsdd2`
+daemons do for Samba, but built in-process. Discovery is **off by default** and
+managed through the live adapter settings (`dfsctl` / REST), so it applies
+immediately without an adapter restart:
+
+```bash
+# mDNS / DNS-SD — macOS Finder + Linux Avahi
+dfsctl adapter settings nfs update --mdns-enabled          # advertises _nfs._tcp (port 12049)
+dfsctl adapter settings smb update --mdns-enabled          # advertises _smb._tcp + _device-info._tcp
+
+# WS-Discovery — Windows Explorer Network (SMB only; Windows does not browse NFS)
+dfsctl adapter settings smb update --wsdiscovery-enabled
+```
+
+This opens additional listeners: mDNS on UDP `5353`, and — for WS-Discovery —
+UDP `3702` plus an HTTP metadata endpoint on TCP `5357`. NFS advertises the
+first export's path in a `path=` TXT record so Finder mounts the right share.
+
+> **Note:** discovery is multicast-based and LAN-local. It works on a host
+> network (bare metal, VM, or a `hostNetwork` pod) but does **not** traverse
+> standard Kubernetes / overlay networks — Explorer and Finder will only see the
+> server on the same L2 segment. Mounting by name/IP always works regardless.
+> WS-Discovery makes the machine *appear* in Explorer; Windows still connects to
+> SMB on port `445`, so the SMB adapter must be reachable there.
+
 ### 11. NFSv4 Configuration
 
 ```yaml

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1661,6 +1661,23 @@ first export's path in a `path=` TXT record so Finder mounts the right share.
 > WS-Discovery makes the machine *appear* in Explorer; Windows still connects to
 > SMB on port `445`, so the SMB adapter must be reachable there.
 
+> **Windows host firewall:** when DittoFS runs *on* a Windows host, the built-in
+> "Network Discovery" firewall rules only cover Windows' own services (they are
+> scoped to `System` / `svchost`), so inbound traffic to `dfs.exe` is dropped by
+> default. Explorer then discovers the server over multicast but silently fails
+> the follow-up metadata fetch (a TCP `5357` connection that never completes),
+> and the machine never renders. Add inbound allow rules for the `dfs.exe`
+> program on TCP `5357` and UDP `3702`/`5353`:
+>
+> ```powershell
+> New-NetFirewallRule -DisplayName "DittoFS Discovery (WSD meta)"  -Direction Inbound -Action Allow -Protocol TCP -LocalPort 5357 -Program "C:\path\to\dfs.exe" -Profile Any
+> New-NetFirewallRule -DisplayName "DittoFS Discovery (WSD probe)" -Direction Inbound -Action Allow -Protocol UDP -LocalPort 3702 -Program "C:\path\to\dfs.exe" -Profile Any
+> New-NetFirewallRule -DisplayName "DittoFS Discovery (mDNS)"      -Direction Inbound -Action Allow -Protocol UDP -LocalPort 5353 -Program "C:\path\to\dfs.exe" -Profile Any
+> ```
+>
+> This is a Windows-host concern only; a Linux DittoFS host needs no equivalent
+> (any host firewall there just needs the same ports open).
+
 ### 11. NFSv4 Configuration
 
 ```yaml

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1654,6 +1654,22 @@ This opens additional listeners: mDNS on UDP `5353`, and — for WS-Discovery �
 UDP `3702` plus an HTTP metadata endpoint on TCP `5357`. NFS advertises the
 first export's path in a `path=` TXT record so Finder mounts the right share.
 
+**Advertised name.** All advertisers share one instance-wide name, so a server
+shows up consistently across Finder and Explorer. It defaults to
+`DittoFS-<hostname>` (e.g. `DittoFS-VM2`) — distinct per host so several DittoFS
+servers on one LAN stay distinguishable — and is overridable:
+
+```bash
+dfsctl settings set discovery.name "Marketing Files"   # custom instance name
+dfsctl settings set discovery.name ""                  # revert to DittoFS-<hostname>
+```
+
+Each adapter formats the name for its own protocol: mDNS uses it verbatim, while
+WS-Discovery folds it to a NetBIOS-legal computer name (upper-cased, illegal
+characters replaced with `-`, capped at 15 characters) since Explorer renders it
+as a Windows computer name. A name change takes effect the next time an
+advertiser (re)starts — toggle discovery off/on, or restart the adapter.
+
 > **Note:** discovery is multicast-based and LAN-local. It works on a host
 > network (bare metal, VM, or a `hostNetwork` pod) but does **not** traverse
 > standard Kubernetes / overlay networks — Explorer and Finder will only see the

--- a/flake.nix
+++ b/flake.nix
@@ -388,7 +388,7 @@
 
               # Auto-updated by .github/workflows/nix-update-hash.yml on go.mod/go.sum changes.
               # Manual: go run scripts/update-nix-hash.go
-              vendorHash = "sha256-ZkahN9xpL7tE+ENcyQu8XTJ98GTSxwC1HDmCSWc7zhE=";
+              vendorHash = "sha256-W6rsF8sjMBGolRE1fAQr1ppTzTnJSPe2kV/C/KDdsf0=";
 
               ldflags = [
                 "-s"

--- a/go.mod
+++ b/go.mod
@@ -178,7 +178,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.37.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.52.0
-	golang.org/x/net v0.54.0 // indirect
+	golang.org/x/net v0.54.0
 	golang.org/x/sys v0.45.0
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect

--- a/internal/controlplane/api/handlers/adapter_settings.go
+++ b/internal/controlplane/api/handlers/adapter_settings.go
@@ -54,6 +54,7 @@ type PatchNFSSettingsRequest struct {
 	PortmapperPort               *int      `json:"portmapper_port,omitempty"`
 	PortmapperRegisterWithSystem *bool     `json:"portmapper_register_with_system,omitempty"`
 	UDPEnabled                   *bool     `json:"udp_enabled,omitempty"`
+	MDNSEnabled                  *bool     `json:"mdns_enabled,omitempty"`
 }
 
 // PutNFSSettingsRequest requires all fields for full replacement.
@@ -82,6 +83,7 @@ type PutNFSSettingsRequest struct {
 	PortmapperPort               int      `json:"portmapper_port"`
 	PortmapperRegisterWithSystem bool     `json:"portmapper_register_with_system"`
 	UDPEnabled                   bool     `json:"udp_enabled"`
+	MDNSEnabled                  bool     `json:"mdns_enabled"`
 }
 
 // --- SMB request types ---
@@ -98,6 +100,8 @@ type PatchSMBSettingsRequest struct {
 	Signing                 *string   `json:"signing,omitempty"`
 	DirectoryLeasingEnabled *bool     `json:"directory_leasing_enabled,omitempty"`
 	BlockedOperations       *[]string `json:"blocked_operations,omitempty"`
+	MDNSEnabled             *bool     `json:"mdns_enabled,omitempty"`
+	WSDiscoveryEnabled      *bool     `json:"wsdiscovery_enabled,omitempty"`
 }
 
 // PutSMBSettingsRequest requires all fields for full replacement.
@@ -112,6 +116,8 @@ type PutSMBSettingsRequest struct {
 	Signing                 string   `json:"signing"`
 	DirectoryLeasingEnabled bool     `json:"directory_leasing_enabled"`
 	BlockedOperations       []string `json:"blocked_operations"`
+	MDNSEnabled             bool     `json:"mdns_enabled"`
+	WSDiscoveryEnabled      bool     `json:"wsdiscovery_enabled"`
 }
 
 // --- Response types ---
@@ -142,6 +148,7 @@ type NFSSettingsResponse struct {
 	PortmapperPort               int      `json:"portmapper_port"`
 	PortmapperRegisterWithSystem bool     `json:"portmapper_register_with_system"`
 	UDPEnabled                   bool     `json:"udp_enabled"`
+	MDNSEnabled                  bool     `json:"mdns_enabled"`
 	Version                      int      `json:"version"`
 }
 
@@ -157,6 +164,8 @@ type SMBSettingsResponse struct {
 	Signing                 string   `json:"signing"`
 	DirectoryLeasingEnabled bool     `json:"directory_leasing_enabled"`
 	BlockedOperations       []string `json:"blocked_operations"`
+	MDNSEnabled             bool     `json:"mdns_enabled"`
+	WSDiscoveryEnabled      bool     `json:"wsdiscovery_enabled"`
 	Version                 int      `json:"version"`
 }
 
@@ -365,6 +374,7 @@ func (h *AdapterSettingsHandler) PutSettings(w http.ResponseWriter, r *http.Requ
 		settings.PortmapperPort = req.PortmapperPort
 		settings.PortmapperRegisterWithSystem = req.PortmapperRegisterWithSystem
 		settings.UDPEnabled = req.UDPEnabled
+		settings.MDNSEnabled = req.MDNSEnabled
 
 		if !h.validateAndRespond(w, adapterType, settings, nil, force) {
 			return
@@ -412,6 +422,8 @@ func (h *AdapterSettingsHandler) PutSettings(w http.ResponseWriter, r *http.Requ
 		settings.Signing = req.Signing
 		settings.DirectoryLeasingEnabled = req.DirectoryLeasingEnabled
 		settings.SetBlockedOperations(req.BlockedOperations)
+		settings.MDNSEnabled = req.MDNSEnabled
+		settings.WSDiscoveryEnabled = req.WSDiscoveryEnabled
 
 		if !h.validateAndRespond(w, adapterType, nil, settings, force) {
 			return
@@ -544,6 +556,9 @@ func (h *AdapterSettingsHandler) PatchSettings(w http.ResponseWriter, r *http.Re
 		if req.UDPEnabled != nil {
 			settings.UDPEnabled = *req.UDPEnabled
 		}
+		if req.MDNSEnabled != nil {
+			settings.MDNSEnabled = *req.MDNSEnabled
+		}
 
 		if !h.validateAndRespond(w, adapterType, settings, nil, force) {
 			return
@@ -610,6 +625,12 @@ func (h *AdapterSettingsHandler) PatchSettings(w http.ResponseWriter, r *http.Re
 		}
 		if req.BlockedOperations != nil {
 			settings.SetBlockedOperations(*req.BlockedOperations)
+		}
+		if req.MDNSEnabled != nil {
+			settings.MDNSEnabled = *req.MDNSEnabled
+		}
+		if req.WSDiscoveryEnabled != nil {
+			settings.WSDiscoveryEnabled = *req.WSDiscoveryEnabled
 		}
 
 		if !h.validateAndRespond(w, adapterType, nil, settings, force) {
@@ -1047,6 +1068,7 @@ func nfsSettingsToResponse(s *models.NFSAdapterSettings) NFSSettingsResponse {
 		PortmapperPort:               s.PortmapperPort,
 		PortmapperRegisterWithSystem: s.PortmapperRegisterWithSystem,
 		UDPEnabled:                   s.UDPEnabled,
+		MDNSEnabled:                  s.MDNSEnabled,
 		Version:                      s.Version,
 	}
 }
@@ -1067,6 +1089,8 @@ func smbSettingsToResponse(s *models.SMBAdapterSettings) SMBSettingsResponse {
 		Signing:                 s.Signing,
 		DirectoryLeasingEnabled: s.DirectoryLeasingEnabled,
 		BlockedOperations:       ops,
+		MDNSEnabled:             s.MDNSEnabled,
+		WSDiscoveryEnabled:      s.WSDiscoveryEnabled,
 		Version:                 s.Version,
 	}
 }

--- a/internal/controlplane/api/handlers/adapter_settings.go
+++ b/internal/controlplane/api/handlers/adapter_settings.go
@@ -1001,6 +1001,8 @@ func resetNFSSetting(settings, defaults *models.NFSAdapterSettings, name string)
 		settings.PortmapperPort = defaults.PortmapperPort
 	case "portmapper_register_with_system":
 		settings.PortmapperRegisterWithSystem = defaults.PortmapperRegisterWithSystem
+	case "mdns_enabled":
+		settings.MDNSEnabled = defaults.MDNSEnabled
 	default:
 		return false
 	}
@@ -1030,6 +1032,10 @@ func resetSMBSetting(settings, defaults *models.SMBAdapterSettings, name string)
 		settings.DirectoryLeasingEnabled = defaults.DirectoryLeasingEnabled
 	case "blocked_operations":
 		settings.BlockedOperations = defaults.BlockedOperations
+	case "mdns_enabled":
+		settings.MDNSEnabled = defaults.MDNSEnabled
+	case "wsdiscovery_enabled":
+		settings.WSDiscoveryEnabled = defaults.WSDiscoveryEnabled
 	default:
 		return false
 	}

--- a/k8s/dittofs-operator/internal/controller/service_reconciler.go
+++ b/k8s/dittofs-operator/internal/controller/service_reconciler.go
@@ -67,6 +67,29 @@ const (
 	portmapperUDPContainerPortName = "adapter-pm-udp"
 	// nfsAdapterType is the canonical sanitized type string for the NFS adapter.
 	nfsAdapterType = "nfs"
+	// smbAdapterType is the canonical sanitized type string for the SMB adapter.
+	smbAdapterType = "smb"
+
+	// Network-discovery ports (issue #1609). mDNS is a shared, host-level
+	// responder (one per pod); WS-Discovery (UDP responder + HTTP metadata) is
+	// SMB-only. IMPORTANT: IP multicast (mDNS 224.0.0.251, WSD 239.255.255.250)
+	// does NOT traverse standard Kubernetes CNIs or a ClusterIP/LoadBalancer
+	// Service — these ports are declared for completeness and hostNetwork
+	// deployments only; on a normal cluster, discovery is effectively
+	// LAN/hostNetwork-scoped.
+	mdnsDiscoveryPort = int32(5353) // mDNS / DNS-SD (UDP)
+	wsdDiscoveryPort  = int32(3702) // WS-Discovery SOAP (UDP)
+	wsdMetadataPort   = int32(5357) // WS-Discovery metadata (HTTP/TCP)
+	// Service port names (unique within a single adapter Service).
+	mdnsPortName    = "mdns"
+	wsdPortName     = "wsd"
+	wsdMetaPortName = "wsd-meta"
+	// Container port names — carry the adapter- prefix so reconcileContainerPorts
+	// manages them as dynamic ports (rebuilt each reconcile, cleaned up when no
+	// adapter is active). Must be ≤15 chars (DNS-1123).
+	mdnsContainerPortName    = "adapter-mdns"    // 12
+	wsdContainerPortName     = "adapter-wsd"     // 11
+	wsdMetaContainerPortName = "adapter-wsdmeta" // 15
 )
 
 // invalidDNSChars matches characters not allowed in DNS-1035 labels.
@@ -134,6 +157,11 @@ func isNFSAdapter(adapterType string) bool {
 	return sanitizeAdapterType(adapterType) == nfsAdapterType
 }
 
+// isSMBAdapter returns true if the sanitized adapter type is "smb".
+func isSMBAdapter(adapterType string) bool {
+	return sanitizeAdapterType(adapterType) == smbAdapterType
+}
+
 // buildAdapterServicePorts returns the Service ports for an adapter.
 // NFS adapters get 4 ports (NFS TCP, portmapper TCP + UDP 111→10111, and the
 // NFS data port over UDP for NLM/NSM/MOUNT); all others get 1.
@@ -169,6 +197,32 @@ func buildAdapterServicePorts(adapterType string, info AdapterInfo) []corev1.Ser
 				Port:       int32(info.Port),
 				TargetPort: intstr.FromInt32(int32(info.Port)),
 				Protocol:   corev1.ProtocolUDP,
+			},
+		)
+	}
+
+	// Network discovery (issue #1609). Each adapter's Service exposes the mDNS
+	// port; SMB additionally exposes the WS-Discovery UDP + HTTP metadata ports.
+	// Multicast does not traverse standard CNIs — see the port constants.
+	ports = append(ports, corev1.ServicePort{
+		Name:       mdnsPortName,
+		Port:       mdnsDiscoveryPort,
+		TargetPort: intstr.FromInt32(mdnsDiscoveryPort),
+		Protocol:   corev1.ProtocolUDP,
+	})
+	if isSMBAdapter(adapterType) {
+		ports = append(ports,
+			corev1.ServicePort{
+				Name:       wsdPortName,
+				Port:       wsdDiscoveryPort,
+				TargetPort: intstr.FromInt32(wsdDiscoveryPort),
+				Protocol:   corev1.ProtocolUDP,
+			},
+			corev1.ServicePort{
+				Name:       wsdMetaPortName,
+				Port:       wsdMetadataPort,
+				TargetPort: intstr.FromInt32(wsdMetadataPort),
+				Protocol:   corev1.ProtocolTCP,
 			},
 		)
 	}
@@ -496,6 +550,38 @@ func (r *DittoServerReconciler) reconcileContainerPorts(ctx context.Context, ds 
 				},
 			)
 		}
+	}
+
+	// Discovery ports live on the shared pod, so add them once (deduped across
+	// adapters), not per adapter: the mDNS responder when any adapter is active,
+	// and the WS-Discovery UDP + HTTP ports when SMB is active (issue #1609).
+	smbActive := false
+	for adapterType := range activeAdapters {
+		if isSMBAdapter(adapterType) {
+			smbActive = true
+			break
+		}
+	}
+	if len(activeAdapters) > 0 {
+		dynamicPorts = append(dynamicPorts, corev1.ContainerPort{
+			Name:          mdnsContainerPortName,
+			ContainerPort: mdnsDiscoveryPort,
+			Protocol:      corev1.ProtocolUDP,
+		})
+	}
+	if smbActive {
+		dynamicPorts = append(dynamicPorts,
+			corev1.ContainerPort{
+				Name:          wsdContainerPortName,
+				ContainerPort: wsdDiscoveryPort,
+				Protocol:      corev1.ProtocolUDP,
+			},
+			corev1.ContainerPort{
+				Name:          wsdMetaContainerPortName,
+				ContainerPort: wsdMetadataPort,
+				Protocol:      corev1.ProtocolTCP,
+			},
+		)
 	}
 
 	// Build final desired ports: static (preserved) + dynamic (from active adapters).

--- a/k8s/dittofs-operator/internal/controller/service_reconciler_test.go
+++ b/k8s/dittofs-operator/internal/controller/service_reconciler_test.go
@@ -200,8 +200,8 @@ func TestReconcileAdapterServices_CreateServices(t *testing.T) {
 	if nfsSvc.Name != "test-server-adapter-nfs" {
 		t.Errorf("Expected NFS service name 'test-server-adapter-nfs', got %s", nfsSvc.Name)
 	}
-	if len(nfsSvc.Spec.Ports) != 4 {
-		t.Fatalf("Expected NFS service to have 4 ports (NFS TCP + portmapper TCP + portmapper UDP + NFS UDP), got %d: %v", len(nfsSvc.Spec.Ports), nfsSvc.Spec.Ports)
+	if len(nfsSvc.Spec.Ports) != 5 {
+		t.Fatalf("Expected NFS service to have 5 ports (NFS TCP + portmapper TCP + portmapper UDP + NFS UDP + mDNS), got %d: %v", len(nfsSvc.Spec.Ports), nfsSvc.Spec.Ports)
 	}
 	nfsSvcPortMap := make(map[string]corev1.ServicePort)
 	for _, p := range nfsSvc.Spec.Ports {
@@ -220,7 +220,7 @@ func TestReconcileAdapterServices_CreateServices(t *testing.T) {
 		t.Errorf("Expected NFS service type LoadBalancer, got %s", nfsSvc.Spec.Type)
 	}
 
-	// Check SMB Service (should have 1 port, no portmapper).
+	// Check SMB Service (SMB TCP + discovery ports, no portmapper).
 	smbSvc, ok := svcByType["smb"]
 	if !ok {
 		t.Fatal("SMB adapter Service not found")
@@ -228,8 +228,8 @@ func TestReconcileAdapterServices_CreateServices(t *testing.T) {
 	if smbSvc.Name != "test-server-adapter-smb" {
 		t.Errorf("Expected SMB service name 'test-server-adapter-smb', got %s", smbSvc.Name)
 	}
-	if len(smbSvc.Spec.Ports) != 1 || smbSvc.Spec.Ports[0].Port != 12445 {
-		t.Errorf("Expected SMB port 12445, got %v", smbSvc.Spec.Ports)
+	if len(smbSvc.Spec.Ports) != 4 || smbSvc.Spec.Ports[0].Port != 12445 {
+		t.Errorf("Expected SMB port 12445 plus discovery ports, got %v", smbSvc.Spec.Ports)
 	}
 
 	// Check owner references.
@@ -306,8 +306,8 @@ func TestReconcileAdapterServices_UpdatePortChange(t *testing.T) {
 		t.Fatalf("Failed to get updated Service: %v", err)
 	}
 
-	if len(updated.Spec.Ports) != 4 {
-		t.Fatalf("Expected 4 ports (NFS TCP + portmapper TCP + portmapper UDP + NFS UDP), got %d", len(updated.Spec.Ports))
+	if len(updated.Spec.Ports) != 5 {
+		t.Fatalf("Expected 5 ports (NFS TCP + portmapper TCP + portmapper UDP + NFS UDP + mDNS), got %d", len(updated.Spec.Ports))
 	}
 	updatedPortMap := make(map[string]corev1.ServicePort)
 	for _, p := range updated.Spec.Ports {
@@ -544,8 +544,10 @@ func TestReconcileContainerPorts_AddsAdapterPorts(t *testing.T) {
 	}
 
 	ports := updated.Spec.Template.Spec.Containers[0].Ports
-	if len(ports) != 5 {
-		t.Fatalf("Expected 5 ports (nfs, api, adapter-nfs, %s, %s), got %d: %v", portmapperContainerPortName, portmapperUDPContainerPortName, len(ports), portNames(ports))
+	// nfs, api (static) + adapter-nfs, portmapper TCP+UDP, and the shared mDNS
+	// discovery port (issue #1609).
+	if len(ports) != 6 {
+		t.Fatalf("Expected 6 ports (nfs, api, adapter-nfs, %s, %s, %s), got %d: %v", portmapperContainerPortName, portmapperUDPContainerPortName, mdnsContainerPortName, len(ports), portNames(ports))
 	}
 
 	// Verify both static "nfs" and dynamic "adapter-nfs" + portmapper (TCP+UDP) coexist.
@@ -568,6 +570,9 @@ func TestReconcileContainerPorts_AddsAdapterPorts(t *testing.T) {
 	}
 	if portMap[portmapperUDPContainerPortName] != portmapperContainerPort {
 		t.Errorf("Dynamic %s port should be %d, got %d", portmapperUDPContainerPortName, portmapperContainerPort, portMap[portmapperUDPContainerPortName])
+	}
+	if portMap[mdnsContainerPortName] != mdnsDiscoveryPort {
+		t.Errorf("Dynamic %s port should be %d, got %d", mdnsContainerPortName, mdnsDiscoveryPort, portMap[mdnsContainerPortName])
 	}
 }
 
@@ -638,13 +643,15 @@ func TestReconcileContainerPorts_RemovesStoppedAdapterPorts(t *testing.T) {
 func TestReconcileContainerPorts_NoChange_NoUpdate(t *testing.T) {
 	ds := newTestDittoServer("test-server", "default")
 
-	// Create StatefulSet with static ports AND matching dynamic adapter-nfs + adapter-portmap ports (TCP+UDP).
+	// Create StatefulSet with static ports AND matching dynamic adapter-nfs +
+	// adapter-portmap ports (TCP+UDP) + the shared mDNS discovery port.
 	ports := []corev1.ContainerPort{
 		{Name: "nfs", ContainerPort: 12049, Protocol: corev1.ProtocolTCP},
 		{Name: "api", ContainerPort: 8080, Protocol: corev1.ProtocolTCP},
 		{Name: "adapter-nfs", ContainerPort: 12049, Protocol: corev1.ProtocolTCP},
 		{Name: portmapperContainerPortName, ContainerPort: portmapperContainerPort, Protocol: corev1.ProtocolTCP},
 		{Name: portmapperUDPContainerPortName, ContainerPort: portmapperContainerPort, Protocol: corev1.ProtocolUDP},
+		{Name: mdnsContainerPortName, ContainerPort: mdnsDiscoveryPort, Protocol: corev1.ProtocolUDP},
 	}
 	sts := newTestStatefulSet("test-server", "default", ports)
 
@@ -1013,8 +1020,12 @@ func TestSyncManagedAnnotations_ClearsAll(t *testing.T) {
 
 func TestBuildAdapterServicePorts_NFS(t *testing.T) {
 	ports := buildAdapterServicePorts("nfs", AdapterInfo{Port: 12049})
-	if len(ports) != 4 {
-		t.Fatalf("Expected 4 ports for NFS (NFS TCP + portmapper TCP + portmapper UDP + NFS data port UDP), got %d", len(ports))
+	// NFS TCP + portmapper TCP + portmapper UDP + NFS data port UDP + mDNS (#1609).
+	if len(ports) != 5 {
+		t.Fatalf("Expected 5 ports for NFS, got %d: %v", len(ports), servicePortNames(ports))
+	}
+	if !hasServicePort(ports, mdnsPortName, mdnsDiscoveryPort, corev1.ProtocolUDP) {
+		t.Errorf("Expected NFS Service to expose the mDNS port %d/UDP", mdnsDiscoveryPort)
 	}
 
 	// First port: NFS
@@ -1043,12 +1054,42 @@ func TestBuildAdapterServicePorts_NFS(t *testing.T) {
 
 func TestBuildAdapterServicePorts_SMB(t *testing.T) {
 	ports := buildAdapterServicePorts("smb", AdapterInfo{Port: 12445})
-	if len(ports) != 1 {
-		t.Fatalf("Expected 1 port for SMB (no portmapper), got %d", len(ports))
+	// SMB TCP (no portmapper) + mDNS + WS-Discovery UDP + WS-Discovery metadata (#1609).
+	if len(ports) != 4 {
+		t.Fatalf("Expected 4 ports for SMB, got %d: %v", len(ports), servicePortNames(ports))
 	}
 	if ports[0].Port != 12445 {
 		t.Errorf("Expected SMB port 12445, got %d", ports[0].Port)
 	}
+	if !hasServicePort(ports, mdnsPortName, mdnsDiscoveryPort, corev1.ProtocolUDP) {
+		t.Errorf("Expected SMB Service to expose the mDNS port %d/UDP", mdnsDiscoveryPort)
+	}
+	if !hasServicePort(ports, wsdPortName, wsdDiscoveryPort, corev1.ProtocolUDP) {
+		t.Errorf("Expected SMB Service to expose the WS-Discovery port %d/UDP", wsdDiscoveryPort)
+	}
+	if !hasServicePort(ports, wsdMetaPortName, wsdMetadataPort, corev1.ProtocolTCP) {
+		t.Errorf("Expected SMB Service to expose the WS-Discovery metadata port %d/TCP", wsdMetadataPort)
+	}
+}
+
+// hasServicePort reports whether ports contains a port with the given name,
+// port number, and protocol.
+func hasServicePort(ports []corev1.ServicePort, name string, port int32, proto corev1.Protocol) bool {
+	for _, p := range ports {
+		if p.Name == name && p.Port == port && p.Protocol == proto {
+			return true
+		}
+	}
+	return false
+}
+
+// servicePortNames returns the names of the given service ports for diagnostics.
+func servicePortNames(ports []corev1.ServicePort) []string {
+	names := make([]string, len(ports))
+	for i, p := range ports {
+		names[i] = p.Name
+	}
+	return names
 }
 
 func TestServicePortsMatch(t *testing.T) {
@@ -1163,14 +1204,25 @@ func TestReconcileContainerPorts_SMB_NoPortmapperPort(t *testing.T) {
 		portMap[p.Name] = p.ContainerPort
 	}
 
-	// Should have api (static) + adapter-smb (dynamic), no portmapper.
-	if len(ports) != 2 {
-		t.Fatalf("Expected 2 ports (api, adapter-smb), got %d: %v", len(ports), portNames(ports))
+	// Should have api (static) + adapter-smb + the discovery ports (mDNS, WSD
+	// UDP, WSD metadata), no portmapper.
+	if len(ports) != 5 {
+		t.Fatalf("Expected 5 ports (api, adapter-smb, %s, %s, %s), got %d: %v",
+			mdnsContainerPortName, wsdContainerPortName, wsdMetaContainerPortName, len(ports), portNames(ports))
 	}
 	if _, exists := portMap[portmapperContainerPortName]; exists {
 		t.Error("SMB adapter should NOT have portmapper container port")
 	}
 	if portMap["adapter-smb"] != 12445 {
 		t.Errorf("Expected adapter-smb port 12445, got %d", portMap["adapter-smb"])
+	}
+	if portMap[mdnsContainerPortName] != mdnsDiscoveryPort {
+		t.Errorf("Expected %s port %d, got %d", mdnsContainerPortName, mdnsDiscoveryPort, portMap[mdnsContainerPortName])
+	}
+	if portMap[wsdContainerPortName] != wsdDiscoveryPort {
+		t.Errorf("Expected %s port %d, got %d", wsdContainerPortName, wsdDiscoveryPort, portMap[wsdContainerPortName])
+	}
+	if portMap[wsdMetaContainerPortName] != wsdMetadataPort {
+		t.Errorf("Expected %s port %d, got %d", wsdMetaContainerPortName, wsdMetadataPort, portMap[wsdMetaContainerPortName])
 	}
 }

--- a/pkg/adapter/auxsvc/auxsvc.go
+++ b/pkg/adapter/auxsvc/auxsvc.go
@@ -143,7 +143,9 @@ func (g *Group) Reconcile(name string, want bool, build func() Service) error {
 			return err
 		}
 	case !want && running:
-		return g.StopOne(name)
+		// Swallow the stop error (StopOne already debug-logs it) so the caller
+		// never surfaces a benign shutdown error as a "failed to start" warning.
+		_ = g.StopOne(name)
 	}
 	return nil
 }

--- a/pkg/adapter/auxsvc/auxsvc.go
+++ b/pkg/adapter/auxsvc/auxsvc.go
@@ -118,6 +118,25 @@ func (g *Group) Ready() bool {
 	return g.baseCtx != nil
 }
 
+// Reconcile starts or stops the named service so its running state matches want,
+// letting a live settings change toggle it. It is a no-op until Ready (before
+// Serve has seeded the base context), so the initial start — performed by Serve
+// itself — is never raced. build is invoked only when a start is needed. Returns
+// the Start error, if any; a stop error is swallowed (StopAll/StopOne already
+// debug-log it).
+func (g *Group) Reconcile(name string, want bool, build func() Service) error {
+	if !g.Ready() {
+		return nil
+	}
+	switch running := g.IsRunning(name); {
+	case want && !running:
+		return g.Start(build())
+	case !want && running:
+		return g.StopOne(name)
+	}
+	return nil
+}
+
 // IsRunning reports whether a service with the given name is currently tracked
 // as running.
 func (g *Group) IsRunning(name string) bool {

--- a/pkg/adapter/auxsvc/auxsvc.go
+++ b/pkg/adapter/auxsvc/auxsvc.go
@@ -20,12 +20,17 @@ package auxsvc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
 )
+
+// ErrAlreadyRunning is returned by Start when a service with the same Name is
+// already tracked. Reconcile treats it as benign (a lost start race).
+var ErrAlreadyRunning = errors.New("auxsvc: service already running")
 
 // stopTimeout bounds a single-service Stop initiated by StopOne, where the
 // caller (e.g. a settings-watcher callback) has no natural context to bound the
@@ -97,7 +102,7 @@ func (g *Group) Start(s Service) error {
 	}
 	name := s.Name()
 	if _, ok := g.running[name]; ok {
-		return fmt.Errorf("auxsvc: service %q already running", name)
+		return fmt.Errorf("%w: %q", ErrAlreadyRunning, name)
 	}
 	if err := s.Start(g.baseCtx); err != nil {
 		return fmt.Errorf("auxsvc: start %q: %w", name, err)
@@ -130,7 +135,13 @@ func (g *Group) Reconcile(name string, want bool, build func() Service) error {
 	}
 	switch running := g.IsRunning(name); {
 	case want && !running:
-		return g.Start(build())
+		// Two goroutines can observe want && !running concurrently (e.g. the NFS
+		// accept-loop apply and the settings-watcher poll); the loser gets
+		// ErrAlreadyRunning, which is benign here — the single-instance invariant
+		// still holds — so it is not surfaced as a start failure.
+		if err := g.Start(build()); err != nil && !errors.Is(err, ErrAlreadyRunning) {
+			return err
+		}
 	case !want && running:
 		return g.StopOne(name)
 	}
@@ -187,6 +198,10 @@ func (g *Group) StopAll(ctx context.Context) error {
 	}
 	g.running = make(map[string]Service)
 	g.order = nil
+	// Clear the base context so any live reconcile that races this shutdown
+	// no-ops (Ready() becomes false, and Start re-checks baseCtx under the lock)
+	// rather than starting a service that StopAll would never tear down.
+	g.baseCtx = nil
 	g.mu.Unlock()
 
 	var firstErr error

--- a/pkg/adapter/auxsvc/auxsvc.go
+++ b/pkg/adapter/auxsvc/auxsvc.go
@@ -1,0 +1,191 @@
+// Package auxsvc defines a small abstraction for the auxiliary/companion
+// protocol services that run alongside a main protocol adapter.
+//
+// A protocol adapter (NFS, SMB) blocks in Serve, accepting connections on its
+// main port. Around it run a handful of smaller services with their own
+// lifecycle: the NFS embedded portmapper, the system-rpcbind registration, the
+// UDP lock-manager transport, the NSM startup notifier, and — added for issue
+// #1609 — the mDNS and WS-Discovery advertisers. Historically each was started
+// and stopped by bespoke code inline in the adapter. This package folds them
+// into one uniform Service interface managed by a Group, so:
+//
+//   - every companion shares the same Start/Stop shape and logging, and
+//   - a service can be toggled at runtime (from a live settings change) without
+//     restarting the whole adapter.
+//
+// A Service differs from the adapter itself in that Start is non-blocking: it
+// binds and launches background goroutines, then returns, leaving the service
+// running until Stop (or the base context) tears it down.
+package auxsvc
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/logger"
+)
+
+// stopTimeout bounds a single-service Stop initiated by StopOne, where the
+// caller (e.g. a settings-watcher callback) has no natural context to bound the
+// teardown. StopAll uses the context passed by the adapter's Stop instead.
+const stopTimeout = 5 * time.Second
+
+// Service is an auxiliary protocol server that runs alongside a main adapter —
+// e.g. the NFS embedded portmapper, the UDP lock-manager transport, or the
+// mDNS / WS-Discovery advertisers.
+//
+// Unlike the adapter (whose Serve blocks), a Service starts in the background
+// and is independently start/stoppable, so a live settings change can toggle
+// one without restarting the whole adapter.
+type Service interface {
+	// Name is a stable identifier ("portmapper", "mdns", "wsd") used as the
+	// Group key and in logs. Names must be unique within a Group.
+	Name() string
+
+	// Start binds listeners / launches background goroutines and returns
+	// promptly: nil once the service is ready, or an error if it could not
+	// start. ctx bounds the service's whole lifetime (the owning adapter's
+	// Serve context), not merely the Start call.
+	Start(ctx context.Context) error
+
+	// Stop tears the service down. It must be idempotent and block until the
+	// service's background goroutines have exited.
+	Stop(ctx context.Context) error
+}
+
+// Group tracks the auxiliary services running alongside one adapter. The
+// adapter holds a Group, seeds it with its Serve context via SetBaseContext,
+// starts each enabled service through Start, and tears the whole set down in
+// its Stop via StopAll.
+//
+// Services started later (e.g. from a live settings-change callback) bind to the
+// stored base context, not the transient context of the caller, so they live
+// until the adapter stops rather than until the callback returns.
+type Group struct {
+	mu      sync.Mutex
+	baseCtx context.Context
+	order   []string // registration order; StopAll tears down in reverse
+	running map[string]Service
+}
+
+// NewGroup returns an empty Group. Call SetBaseContext before starting services.
+func NewGroup() *Group {
+	return &Group{running: make(map[string]Service)}
+}
+
+// SetBaseContext records the adapter's Serve context. Call once at the top of
+// Serve, before starting any service. Services subsequently started — including
+// from live settings callbacks — inherit this context for their lifetime.
+func (g *Group) SetBaseContext(ctx context.Context) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.baseCtx = ctx
+}
+
+// Start starts s using the stored base context and tracks it by Name(). It is
+// an error to Start before SetBaseContext, or to start a service whose name is
+// already running. When s.Start fails, the service is not tracked and the error
+// is returned.
+func (g *Group) Start(s Service) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if g.baseCtx == nil {
+		return fmt.Errorf("auxsvc: Start(%q) before SetBaseContext", s.Name())
+	}
+	name := s.Name()
+	if _, ok := g.running[name]; ok {
+		return fmt.Errorf("auxsvc: service %q already running", name)
+	}
+	if err := s.Start(g.baseCtx); err != nil {
+		return fmt.Errorf("auxsvc: start %q: %w", name, err)
+	}
+	g.running[name] = s
+	g.order = append(g.order, name)
+	logger.Debug("auxsvc started", "name", name)
+	return nil
+}
+
+// Ready reports whether SetBaseContext has been called, i.e. the owning adapter
+// has entered Serve. Live reconcilers (settings callbacks) check this so a
+// settings-apply that runs before Serve is a no-op — the initial start is done
+// by Serve itself.
+func (g *Group) Ready() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.baseCtx != nil
+}
+
+// IsRunning reports whether a service with the given name is currently tracked
+// as running.
+func (g *Group) IsRunning(name string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	_, ok := g.running[name]
+	return ok
+}
+
+// StopOne stops and forgets a single running service, for a live disable. It is
+// a no-op returning nil when the named service is not running. The teardown is
+// bounded by an internal timeout since the caller (a settings callback) has no
+// natural context.
+func (g *Group) StopOne(name string) error {
+	g.mu.Lock()
+	s, ok := g.running[name]
+	if ok {
+		delete(g.running, name)
+		g.removeFromOrderLocked(name)
+	}
+	g.mu.Unlock()
+
+	if !ok {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), stopTimeout)
+	defer cancel()
+	err := s.Stop(ctx)
+	logger.Debug("auxsvc stopped", "name", name, "error", err)
+	return err
+}
+
+// StopAll stops every running service in reverse start order and clears the
+// group. It is called from the adapter's Stop, before the base listener
+// teardown, so ordering that matters (e.g. unregister from the system rpcbind
+// before closing the portmapper) is preserved: services registered earlier stop
+// later. The first Stop error is returned; every service is still stopped.
+func (g *Group) StopAll(ctx context.Context) error {
+	g.mu.Lock()
+	names := make([]string, len(g.order))
+	for i, n := range g.order {
+		names[len(g.order)-1-i] = n // reverse
+	}
+	svcs := make([]Service, len(names))
+	for i, n := range names {
+		svcs[i] = g.running[n]
+	}
+	g.running = make(map[string]Service)
+	g.order = nil
+	g.mu.Unlock()
+
+	var firstErr error
+	for i, s := range svcs {
+		if err := s.Stop(ctx); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		logger.Debug("auxsvc stopped", "name", names[i])
+	}
+	return firstErr
+}
+
+// removeFromOrderLocked drops name from the order slice. Caller holds g.mu.
+func (g *Group) removeFromOrderLocked(name string) {
+	for i, n := range g.order {
+		if n == name {
+			g.order = append(g.order[:i], g.order[i+1:]...)
+			return
+		}
+	}
+}

--- a/pkg/adapter/auxsvc/auxsvc_test.go
+++ b/pkg/adapter/auxsvc/auxsvc_test.go
@@ -1,0 +1,201 @@
+package auxsvc
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// fakeService is a controllable Service for exercising Group.
+type fakeService struct {
+	name      string
+	startErr  error
+	stopErr   error
+	started   atomic.Bool
+	stopped   atomic.Bool
+	startCtx  context.Context
+	stopCalls atomic.Int32
+	onStop    func() // optional hook invoked inside Stop
+}
+
+func (f *fakeService) Name() string { return f.name }
+
+func (f *fakeService) Start(ctx context.Context) error {
+	if f.startErr != nil {
+		return f.startErr
+	}
+	f.startCtx = ctx
+	f.started.Store(true)
+	return nil
+}
+
+func (f *fakeService) Stop(ctx context.Context) error {
+	f.stopCalls.Add(1)
+	f.stopped.Store(true)
+	if f.onStop != nil {
+		f.onStop()
+	}
+	return f.stopErr
+}
+
+func TestGroup_StartRequiresBaseContext(t *testing.T) {
+	g := NewGroup()
+	if err := g.Start(&fakeService{name: "a"}); err == nil {
+		t.Fatal("expected error starting before SetBaseContext")
+	}
+}
+
+func TestGroup_StartTracksAndBindsBaseContext(t *testing.T) {
+	g := NewGroup()
+	type ctxKey struct{}
+	base := context.WithValue(context.Background(), ctxKey{}, "base")
+	g.SetBaseContext(base)
+
+	svc := &fakeService{name: "portmapper"}
+	if err := g.Start(svc); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !g.IsRunning("portmapper") {
+		t.Fatal("service should be running")
+	}
+	if !svc.started.Load() {
+		t.Fatal("Start not called")
+	}
+	if svc.startCtx.Value(ctxKey{}) != "base" {
+		t.Fatal("service was not started with the group's base context")
+	}
+}
+
+func TestGroup_StartDuplicateNameFails(t *testing.T) {
+	g := NewGroup()
+	g.SetBaseContext(context.Background())
+	if err := g.Start(&fakeService{name: "dup"}); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	if err := g.Start(&fakeService{name: "dup"}); err == nil {
+		t.Fatal("expected duplicate-name error")
+	}
+}
+
+func TestGroup_StartErrorNotTracked(t *testing.T) {
+	g := NewGroup()
+	g.SetBaseContext(context.Background())
+	err := g.Start(&fakeService{name: "boom", startErr: errors.New("bind failed")})
+	if err == nil {
+		t.Fatal("expected start error")
+	}
+	if g.IsRunning("boom") {
+		t.Fatal("failed service must not be tracked")
+	}
+}
+
+func TestGroup_StopOneIdempotent(t *testing.T) {
+	g := NewGroup()
+	g.SetBaseContext(context.Background())
+	svc := &fakeService{name: "x"}
+	_ = g.Start(svc)
+
+	if err := g.StopOne("x"); err != nil {
+		t.Fatalf("StopOne: %v", err)
+	}
+	if g.IsRunning("x") {
+		t.Fatal("service should be stopped")
+	}
+	// Second StopOne is a no-op.
+	if err := g.StopOne("x"); err != nil {
+		t.Fatalf("StopOne (repeat): %v", err)
+	}
+	if got := svc.stopCalls.Load(); got != 1 {
+		t.Fatalf("Stop called %d times, want 1", got)
+	}
+}
+
+func TestGroup_StopAllReverseOrder(t *testing.T) {
+	g := NewGroup()
+	g.SetBaseContext(context.Background())
+
+	var mu sync.Mutex
+	var stopOrder []string
+	mk := func(name string) *fakeService {
+		return &fakeService{name: name, onStop: func() {
+			mu.Lock()
+			stopOrder = append(stopOrder, name)
+			mu.Unlock()
+		}}
+	}
+	// Start order mirrors NFS: portmapper, sysreg, nfs-udp, nsm.
+	for _, s := range []*fakeService{mk("portmapper"), mk("sysreg"), mk("nfs-udp"), mk("nsm")} {
+		if err := g.Start(s); err != nil {
+			t.Fatalf("Start %s: %v", s.name, err)
+		}
+	}
+
+	if err := g.StopAll(context.Background()); err != nil {
+		t.Fatalf("StopAll: %v", err)
+	}
+
+	want := []string{"nsm", "nfs-udp", "sysreg", "portmapper"}
+	if len(stopOrder) != len(want) {
+		t.Fatalf("stopped %v, want %v", stopOrder, want)
+	}
+	for i := range want {
+		if stopOrder[i] != want[i] {
+			t.Fatalf("stop order %v, want %v", stopOrder, want)
+		}
+	}
+	// The important invariant: sysreg unregisters before portmapper stops.
+	if idx(stopOrder, "sysreg") > idx(stopOrder, "portmapper") {
+		t.Fatal("sysreg must stop before portmapper")
+	}
+}
+
+func TestGroup_StopAllReturnsFirstError(t *testing.T) {
+	g := NewGroup()
+	g.SetBaseContext(context.Background())
+	_ = g.Start(&fakeService{name: "ok1"})
+	_ = g.Start(&fakeService{name: "bad", stopErr: errors.New("teardown failed")})
+	_ = g.Start(&fakeService{name: "ok2"})
+
+	if err := g.StopAll(context.Background()); err == nil {
+		t.Fatal("expected StopAll to surface a Stop error")
+	}
+	if g.IsRunning("ok1") || g.IsRunning("bad") || g.IsRunning("ok2") {
+		t.Fatal("StopAll must clear all services even when one errors")
+	}
+}
+
+// TestGroup_StopOneFromCallbackWhileOthersRun models a live settings toggle
+// disabling one service (from a callback goroutine) while another keeps running.
+func TestGroup_StopOneFromCallbackWhileOthersRun(t *testing.T) {
+	g := NewGroup()
+	g.SetBaseContext(context.Background())
+	keep := &fakeService{name: "mdns"}
+	drop := &fakeService{name: "wsd"}
+	_ = g.Start(keep)
+	_ = g.Start(drop)
+
+	done := make(chan struct{})
+	go func() { // simulate the settings-watcher callback goroutine
+		_ = g.StopOne("wsd")
+		close(done)
+	}()
+	<-done
+
+	if g.IsRunning("wsd") {
+		t.Fatal("wsd should be stopped")
+	}
+	if !g.IsRunning("mdns") {
+		t.Fatal("mdns should still be running")
+	}
+}
+
+func idx(ss []string, want string) int {
+	for i, s := range ss {
+		if s == want {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/adapter/auxsvc/auxsvc_test.go
+++ b/pkg/adapter/auxsvc/auxsvc_test.go
@@ -191,6 +191,58 @@ func TestGroup_StopOneFromCallbackWhileOthersRun(t *testing.T) {
 	}
 }
 
+func TestGroup_ReconcileStartsAndStops(t *testing.T) {
+	g := NewGroup()
+	g.SetBaseContext(context.Background())
+	svc := &fakeService{name: "mdns"}
+
+	if err := g.Reconcile("mdns", true, func() Service { return svc }); err != nil {
+		t.Fatalf("Reconcile(start): %v", err)
+	}
+	if !g.IsRunning("mdns") {
+		t.Fatal("Reconcile(want=true) should have started the service")
+	}
+	if err := g.Reconcile("mdns", false, func() Service { return svc }); err != nil {
+		t.Fatalf("Reconcile(stop): %v", err)
+	}
+	if g.IsRunning("mdns") {
+		t.Fatal("Reconcile(want=false) should have stopped the service")
+	}
+}
+
+func TestGroup_ReconcileNoOpBeforeReady(t *testing.T) {
+	g := NewGroup() // no SetBaseContext
+	built := false
+	if err := g.Reconcile("mdns", true, func() Service { built = true; return &fakeService{name: "mdns"} }); err != nil {
+		t.Fatalf("Reconcile before Ready should be a no-op, got %v", err)
+	}
+	if built || g.IsRunning("mdns") {
+		t.Fatal("Reconcile must not build or start a service before SetBaseContext")
+	}
+}
+
+func TestGroup_StopAllClearsBaseContextSoLateReconcileNoOps(t *testing.T) {
+	g := NewGroup()
+	g.SetBaseContext(context.Background())
+	_ = g.Start(&fakeService{name: "a"})
+
+	if err := g.StopAll(context.Background()); err != nil {
+		t.Fatalf("StopAll: %v", err)
+	}
+	if g.Ready() {
+		t.Fatal("StopAll should clear the base context so Ready() is false")
+	}
+	// A live reconcile racing shutdown must not start a service the now-stopped
+	// group would never tear down.
+	built := false
+	if err := g.Reconcile("b", true, func() Service { built = true; return &fakeService{name: "b"} }); err != nil {
+		t.Fatalf("post-StopAll Reconcile: %v", err)
+	}
+	if built || g.IsRunning("b") {
+		t.Fatal("post-StopAll Reconcile must no-op")
+	}
+}
+
 func idx(ss []string, want string) int {
 	for i, s := range ss {
 		if s == want {

--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -25,6 +25,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 
 	"github.com/marmos91/dittofs/pkg/adapter"
+	"github.com/marmos91/dittofs/pkg/adapter/auxsvc"
 	"github.com/marmos91/dittofs/pkg/auth/kerberos"
 	"github.com/marmos91/dittofs/pkg/config"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
@@ -129,6 +130,12 @@ type NFSAdapter struct {
 	// resolverMu serializes wireIdentityResolver so concurrent identity-provider
 	// config changes cannot race on identityUnsub/identityProviderUnsub.
 	resolverMu sync.Mutex
+
+	// sidecars manages the adapter's auxiliary/companion services (portmapper,
+	// system-rpcbind registration, UDP transport, NSM startup) under one uniform
+	// lifecycle. Seeded with the Serve context and torn down in Stop. See
+	// auxservices.go.
+	sidecars *auxsvc.Group
 
 	// portmapServer is the embedded portmapper server (RFC 1057).
 	// nil when portmapper is disabled.
@@ -486,6 +493,7 @@ func New(nfsConfig NFSConfig) *NFSAdapter {
 		nfsHandler:   &v3.Handler{},
 		mountHandler: &mount.Handler{},
 		drc:          newDuplicateRequestCache(),
+		sidecars:     auxsvc.NewGroup(),
 	}
 }
 
@@ -781,33 +789,12 @@ func (s *NFSAdapter) Serve(ctx context.Context) error {
 			"mtls", s.config.TLS.ClientCA != "")
 	}
 
-	// Start embedded portmapper (RFC 1057) for NFS service discovery.
-	// This allows clients to query rpcinfo/showmount without needing
-	// a system-level rpcbind daemon. Portmapper failure is non-fatal
-	// (privileged ports like 111 may require root privileges).
-	if err := s.startPortmapper(ctx); err != nil {
-		logger.Warn("Portmapper failed to start (NFS will continue without it)", "error", err)
-	}
-
-	// Register services with the host's system rpcbind (port 111) when enabled,
-	// so a kernel NFSv3 client can discover the NLM port and lock without
-	// `nolock`. Non-fatal and time-bounded: if no rpcbind answers (or it hangs)
-	// NFS still serves; registration cannot delay NFS availability for more than
-	// systemRegTimeout.
-	s.startSystemPortmapRegistration(ctx)
-
-	// Start the UDP transport for NLM/NSM/MOUNT when enabled. NFSv3 lock
-	// clients on BSD/macOS require the lock-manager protocols over UDP
-	// (issue #1353). Failure is non-fatal: TCP serving continues.
-	if s.isUDPEnabled() {
-		if err := s.startUDP(ctx); err != nil {
-			logger.Warn("NFS UDP transport failed to start (NLM/NSM/MOUNT over UDP unavailable)", "error", err)
-		}
-	}
-
-	// NSM startup: Load persisted registrations and notify all clients
-	// Per CONTEXT.md: Parallel notification for fastest recovery
-	s.performNSMStartup(ctx)
+	// Start the auxiliary/companion services (embedded portmapper, system
+	// rpcbind registration, UDP lock-manager transport, and NSM startup) through
+	// the shared auxsvc.Group so they share one lifecycle and are torn down
+	// uniformly in Stop. Each is individually gated and non-fatal — NFS serves
+	// over TCP regardless. See auxservices.go.
+	s.startEnabledAuxServices(ctx)
 
 	// Start NFSv4.1 session reaper for expired/unconfirmed client cleanup
 	if s.v4Handler != nil && s.v4Handler.StateManager != nil {

--- a/pkg/adapter/nfs/auxservices.go
+++ b/pkg/adapter/nfs/auxservices.go
@@ -70,7 +70,13 @@ func (s *NFSAdapter) mdnsEnabled() bool {
 
 // newMDNSSidecar builds the NFS mDNS advertiser: an _nfs._tcp instance named
 // after the server, on the adapter's real port (12049), with a path= TXT naming
-// the first export so Finder mounts the right share.
+// an export so Finder mounts a valid share.
+//
+// The path is the lexicographically-first export, chosen deterministically
+// (ListShares order is not defined). Limitation: the record is built when the
+// advertiser starts and is not rebuilt when shares change, so renaming/removing
+// that export leaves a stale path hint until the adapter or advertiser restarts;
+// re-advertising on share changes is a follow-up.
 func (s *NFSAdapter) newMDNSSidecar() auxsvc.Service {
 	rec := mdns.ServiceRecord{
 		Instance: hostinfo.ServerName(),
@@ -79,7 +85,13 @@ func (s *NFSAdapter) newMDNSSidecar() auxsvc.Service {
 	}
 	if s.Registry != nil {
 		if shares := s.Registry.ListShares(); len(shares) > 0 {
-			rec.TXT = []string{"path=/" + shares[0]}
+			first := shares[0]
+			for _, sh := range shares[1:] {
+				if sh < first {
+					first = sh
+				}
+			}
+			rec.TXT = []string{"path=/" + first}
 		}
 	}
 	return mdns.NewSidecar([]mdns.ServiceRecord{rec})

--- a/pkg/adapter/nfs/auxservices.go
+++ b/pkg/adapter/nfs/auxservices.go
@@ -1,0 +1,165 @@
+package nfs
+
+import (
+	"context"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/adapter/auxsvc"
+	"github.com/marmos91/dittofs/pkg/discovery/hostinfo"
+	"github.com/marmos91/dittofs/pkg/discovery/mdns"
+)
+
+// This file adapts the NFS auxiliary/companion services (portmapper, system
+// rpcbind registration, the UDP lock-manager transport, and NSM startup) to the
+// shared auxsvc.Service interface. Each wrapper is a thin, stateless shim over
+// the adapter methods that already implement the behavior — the protocol logic
+// is unchanged; only the lifecycle is unified so every companion is started and
+// stopped uniformly through the adapter's auxsvc.Group (and, for #1609, so the
+// mDNS / WS-Discovery advertisers can join the same pattern).
+//
+// startEnabledAuxServices registers every enabled companion with the group, in
+// the order the adapter historically started them. The group tears them down in
+// reverse order in Stop, which preserves the one ordering that matters:
+// unregistering from the system rpcbind before the embedded portmapper closes.
+func (s *NFSAdapter) startEnabledAuxServices(ctx context.Context) {
+	s.sidecars.SetBaseContext(ctx)
+
+	// Embedded portmapper (RFC 1057). Non-fatal: privileged ports may need root.
+	if s.isPortmapperEnabled() {
+		if err := s.sidecars.Start(portmapSidecar{s}); err != nil {
+			logger.Warn("Portmapper failed to start (NFS will continue without it)", "error", err)
+		}
+	} else {
+		logger.Info("Portmapper disabled by configuration")
+	}
+
+	// System rpcbind registration (port 111). Best-effort and time-bounded;
+	// sysregSidecar.Start never returns an error, so the branch is defensive.
+	if s.registerWithSystemEnabled() {
+		if err := s.sidecars.Start(sysregSidecar{s}); err != nil {
+			logger.Debug("System rpcbind registration sidecar failed to start", "error", err)
+		}
+	}
+
+	// UDP transport for NLM/NSM/MOUNT (issue #1353). Non-fatal: TCP continues.
+	if s.isUDPEnabled() {
+		if err := s.sidecars.Start(udpSidecar{s}); err != nil {
+			logger.Warn("NFS UDP transport failed to start (NLM/NSM/MOUNT over UDP unavailable)", "error", err)
+		}
+	}
+
+	// NSM startup notifier (SM_NOTIFY on restart). No-op when uninitialized.
+	if s.nsmNotifier != nil {
+		_ = s.sidecars.Start(nsmSidecar{s})
+	}
+
+	// mDNS advertiser (_nfs._tcp) for macOS Finder / Linux Avahi (issue #1609).
+	// Live-toggled via NFS settings; the initial start happens here.
+	if s.mdnsEnabled() {
+		if err := s.sidecars.Start(s.newMDNSSidecar()); err != nil {
+			logger.Warn("NFS mDNS advertiser failed to start", "error", err)
+		}
+	}
+}
+
+// mdnsEnabled reports whether the NFS mDNS advertiser should run, from live
+// settings (defaults false when settings are unavailable).
+func (s *NFSAdapter) mdnsEnabled() bool {
+	if s.Registry == nil {
+		return false
+	}
+	settings := s.Registry.GetNFSSettings()
+	return settings != nil && settings.MDNSEnabled
+}
+
+// newMDNSSidecar builds the NFS mDNS advertiser: an _nfs._tcp instance named
+// after the server, on the adapter's real port (12049), with a path= TXT naming
+// the first export so Finder mounts the right share.
+func (s *NFSAdapter) newMDNSSidecar() auxsvc.Service {
+	rec := mdns.ServiceRecord{
+		Instance: hostinfo.ServerName(),
+		Service:  "_nfs._tcp",
+		Port:     uint16(s.Port()),
+	}
+	if s.Registry != nil {
+		if shares := s.Registry.ListShares(); len(shares) > 0 {
+			rec.TXT = []string{"path=/" + shares[0]}
+		}
+	}
+	return mdns.NewSidecar([]mdns.ServiceRecord{rec})
+}
+
+// reconcileMDNS starts or stops the mDNS advertiser to match live settings. It
+// is a no-op until Serve has started the auxsvc group, so a settings-apply that
+// runs before Serve does not race the initial start.
+func (s *NFSAdapter) reconcileMDNS() {
+	if s.sidecars == nil || !s.sidecars.Ready() {
+		return
+	}
+	want := s.mdnsEnabled()
+	running := s.sidecars.IsRunning(mdns.SidecarName)
+	switch {
+	case want && !running:
+		if err := s.sidecars.Start(s.newMDNSSidecar()); err != nil {
+			logger.Warn("NFS mDNS advertiser failed to start", "error", err)
+		}
+	case !want && running:
+		if err := s.sidecars.StopOne(mdns.SidecarName); err != nil {
+			logger.Debug("NFS mDNS advertiser stop reported an error", "error", err)
+		}
+	}
+}
+
+// portmapSidecar wraps the embedded RFC 1057 portmapper.
+type portmapSidecar struct{ a *NFSAdapter }
+
+func (p portmapSidecar) Name() string                    { return "portmapper" }
+func (p portmapSidecar) Start(ctx context.Context) error { return p.a.startPortmapper(ctx) }
+func (p portmapSidecar) Stop(context.Context) error      { p.a.stopPortmapper(); return nil }
+
+// sysregSidecar wraps registration of DittoFS's services with the host rpcbind.
+// Start registers; Stop unregisters. Both are best-effort and self-gating.
+type sysregSidecar struct{ a *NFSAdapter }
+
+func (r sysregSidecar) Name() string { return "sysreg" }
+func (r sysregSidecar) Start(ctx context.Context) error {
+	r.a.startSystemPortmapRegistration(ctx)
+	return nil
+}
+func (r sysregSidecar) Stop(context.Context) error { r.a.stopSystemPortmapRegistration(); return nil }
+
+// udpSidecar wraps the NLM/NSM/MOUNT-over-UDP transport. Start binds the socket
+// and launches the read loop; Stop closes the socket so the loop unblocks and
+// exits (startUDP also closes it on ctx cancel, so a double close is possible
+// and harmless).
+type udpSidecar struct{ a *NFSAdapter }
+
+func (u udpSidecar) Name() string                    { return "nfs-udp" }
+func (u udpSidecar) Start(ctx context.Context) error { return u.a.startUDP(ctx) }
+func (u udpSidecar) Stop(context.Context) error {
+	if u.a.udpConn != nil {
+		_ = u.a.udpConn.Close()
+	}
+	return nil
+}
+
+// nsmSidecar wraps NSM startup: it loads persisted registrations and sends
+// SM_NOTIFY to recover locks after a restart. It is a startup task with no
+// long-running listener, so Stop is a no-op (its background notification
+// goroutine is bounded by the adapter's Serve context).
+type nsmSidecar struct{ a *NFSAdapter }
+
+func (n nsmSidecar) Name() string { return "nsm" }
+func (n nsmSidecar) Start(ctx context.Context) error {
+	n.a.performNSMStartup(ctx)
+	return nil
+}
+func (n nsmSidecar) Stop(context.Context) error { return nil }
+
+// Compile-time assertions that every wrapper satisfies auxsvc.Service.
+var (
+	_ auxsvc.Service = portmapSidecar{}
+	_ auxsvc.Service = sysregSidecar{}
+	_ auxsvc.Service = udpSidecar{}
+	_ auxsvc.Service = nsmSidecar{}
+)

--- a/pkg/adapter/nfs/auxservices.go
+++ b/pkg/adapter/nfs/auxservices.go
@@ -55,11 +55,7 @@ func (s *NFSAdapter) startEnabledAuxServices(ctx context.Context) {
 
 	// mDNS advertiser (_nfs._tcp) for macOS Finder / Linux Avahi (issue #1609).
 	// Live-toggled via NFS settings; the initial start happens here.
-	if s.mdnsEnabled() {
-		if err := s.sidecars.Start(s.newMDNSSidecar()); err != nil {
-			logger.Warn("NFS mDNS advertiser failed to start", "error", err)
-		}
-	}
+	s.reconcileDiscovery()
 }
 
 // mdnsEnabled reports whether the NFS mDNS advertiser should run, from live
@@ -89,24 +85,12 @@ func (s *NFSAdapter) newMDNSSidecar() auxsvc.Service {
 	return mdns.NewSidecar([]mdns.ServiceRecord{rec})
 }
 
-// reconcileMDNS starts or stops the mDNS advertiser to match live settings. It
-// is a no-op until Serve has started the auxsvc group, so a settings-apply that
-// runs before Serve does not race the initial start.
-func (s *NFSAdapter) reconcileMDNS() {
-	if s.sidecars == nil || !s.sidecars.Ready() {
-		return
-	}
-	want := s.mdnsEnabled()
-	running := s.sidecars.IsRunning(mdns.SidecarName)
-	switch {
-	case want && !running:
-		if err := s.sidecars.Start(s.newMDNSSidecar()); err != nil {
-			logger.Warn("NFS mDNS advertiser failed to start", "error", err)
-		}
-	case !want && running:
-		if err := s.sidecars.StopOne(mdns.SidecarName); err != nil {
-			logger.Debug("NFS mDNS advertiser stop reported an error", "error", err)
-		}
+// reconcileDiscovery starts or stops the NFS discovery advertiser(s) to match
+// live settings. Called from Serve (initial start) and from applyNFSSettings
+// (live toggle); Group.Reconcile is a no-op until Serve has seeded the group.
+func (s *NFSAdapter) reconcileDiscovery() {
+	if err := s.sidecars.Reconcile(mdns.SidecarName, s.mdnsEnabled(), s.newMDNSSidecar); err != nil {
+		logger.Warn("NFS mDNS advertiser failed to start", "error", err)
 	}
 }
 
@@ -156,10 +140,13 @@ func (n nsmSidecar) Start(ctx context.Context) error {
 }
 func (n nsmSidecar) Stop(context.Context) error { return nil }
 
-// Compile-time assertions that every wrapper satisfies auxsvc.Service.
+// Compile-time assertions that every wrapper satisfies auxsvc.Service. The mDNS
+// sidecar is asserted here too so a signature drift in pkg/discovery/mdns (which
+// satisfies the interface structurally, without importing it) breaks at build.
 var (
 	_ auxsvc.Service = portmapSidecar{}
 	_ auxsvc.Service = sysregSidecar{}
 	_ auxsvc.Service = udpSidecar{}
 	_ auxsvc.Service = nsmSidecar{}
+	_ auxsvc.Service = (*mdns.Sidecar)(nil)
 )

--- a/pkg/adapter/nfs/auxservices.go
+++ b/pkg/adapter/nfs/auxservices.go
@@ -58,6 +58,18 @@ func (s *NFSAdapter) startEnabledAuxServices(ctx context.Context) {
 	s.reconcileDiscovery()
 }
 
+// discoveryName is the instance-wide name to advertise, resolved from the
+// control plane (the `discovery.name` setting, defaulting to
+// "DittoFS-<hostname>"). NFS advertises only over mDNS, which uses it verbatim.
+func (s *NFSAdapter) discoveryName() string {
+	if s.Registry != nil {
+		if n := s.Registry.DiscoveryName(); n != "" {
+			return n
+		}
+	}
+	return hostinfo.DefaultDiscoveryName()
+}
+
 // mdnsEnabled reports whether the NFS mDNS advertiser should run, from live
 // settings (defaults false when settings are unavailable).
 func (s *NFSAdapter) mdnsEnabled() bool {
@@ -79,7 +91,7 @@ func (s *NFSAdapter) mdnsEnabled() bool {
 // re-advertising on share changes is a follow-up.
 func (s *NFSAdapter) newMDNSSidecar() auxsvc.Service {
 	rec := mdns.ServiceRecord{
-		Instance: hostinfo.ServerName(),
+		Instance: s.discoveryName(),
 		Service:  "_nfs._tcp",
 		Port:     uint16(s.Port()),
 	}

--- a/pkg/adapter/nfs/settings.go
+++ b/pkg/adapter/nfs/settings.go
@@ -100,7 +100,7 @@ func (s *NFSAdapter) applyNFSSettings(rt *runtime.Runtime) {
 	// mDNS advertiser: unlike portmapper/UDP (which take effect on the next
 	// restart), the mDNS sidecar is toggled live here — start or stop it to
 	// match the setting. No-op until Serve has started the auxsvc group.
-	s.reconcileMDNS()
+	s.reconcileDiscovery()
 }
 
 // fsCapabilitiesProbeTimeout bounds the metadata read issued when refreshing

--- a/pkg/adapter/nfs/settings.go
+++ b/pkg/adapter/nfs/settings.go
@@ -96,6 +96,11 @@ func (s *NFSAdapter) applyNFSSettings(rt *runtime.Runtime) {
 	udpEnabled := settings.UDPEnabled
 	s.config.UDP.Enabled = &udpEnabled
 	logger.Debug("NFS adapter: applied UDP transport setting from DB", "enabled", settings.UDPEnabled)
+
+	// mDNS advertiser: unlike portmapper/UDP (which take effect on the next
+	// restart), the mDNS sidecar is toggled live here — start or stop it to
+	// match the setting. No-op until Serve has started the auxsvc group.
+	s.reconcileMDNS()
 }
 
 // fsCapabilitiesProbeTimeout bounds the metadata read issued when refreshing

--- a/pkg/adapter/nfs/shutdown.go
+++ b/pkg/adapter/nfs/shutdown.go
@@ -2,6 +2,8 @@ package nfs
 
 import (
 	"context"
+
+	"github.com/marmos91/dittofs/internal/logger"
 )
 
 // Stop initiates graceful shutdown of the NFS server.
@@ -40,11 +42,15 @@ func (s *NFSAdapter) Stop(ctx context.Context) error {
 		s.identityProviderUnsub = nil
 	}
 
-	// Stop portmapper first (stops accepting new queries before NFS stops).
-	// Unregister from the system rpcbind before tearing down listeners so a
-	// client never resolves a stale NLM port to a port we no longer serve.
-	s.stopSystemPortmapRegistration()
-	s.stopPortmapper()
+	// Stop the auxiliary/companion services (portmapper, system rpcbind
+	// registration, UDP transport, NSM) before tearing down the main listener.
+	// The group stops them in reverse start order, which preserves the ordering
+	// that matters: unregister from the system rpcbind before the embedded
+	// portmapper closes, so a client never resolves a stale NLM port to a port
+	// we no longer serve.
+	if err := s.sidecars.StopAll(ctx); err != nil {
+		logger.Debug("NFS auxiliary service shutdown reported an error", "error", err)
+	}
 
 	// Stop GSS processor if running (releases background cleanup goroutine)
 	if s.gssProcessor != nil {

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -487,8 +487,7 @@ func (s *Adapter) applySMBSettings(rt *runtime.Runtime) {
 
 	// Network discovery: start/stop the mDNS and WS-Discovery advertisers live to
 	// match settings. No-op until Serve has started the auxsvc group.
-	s.reconcileMDNS()
-	s.reconcileWSDiscovery()
+	s.reconcileDiscovery()
 }
 
 // Serve starts the SMB server and blocks until the context is cancelled

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/marmos91/dittofs/internal/auth/netlogon"
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/adapter"
+	"github.com/marmos91/dittofs/pkg/adapter/auxsvc"
 	"github.com/marmos91/dittofs/pkg/auth/kerberos"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
@@ -118,6 +119,11 @@ type Adapter struct {
 	// kerberosProvider is retained for lifecycle management. It owns a
 	// background keytab-reload goroutine that must be stopped in Stop().
 	kerberosProvider *kerberos.Provider
+
+	// sidecars manages the adapter's auxiliary/companion services — the mDNS and
+	// WS-Discovery advertisers (issue #1609) — under one uniform lifecycle.
+	// Seeded with the Serve context and torn down in Stop. See discovery.go.
+	sidecars *auxsvc.Group
 }
 
 // New creates a new Adapter with the specified configuration.
@@ -205,6 +211,7 @@ func New(config Config) *Adapter {
 		config:         config,
 		handler:        handler,
 		sessionManager: sessionManager,
+		sidecars:       auxsvc.NewGroup(),
 	}
 }
 
@@ -477,6 +484,11 @@ func (s *Adapter) applySMBSettings(rt *runtime.Runtime) {
 		logger.Info("SMB adapter: operation blocklist from settings (advisory only)",
 			"blocked_ops", blockedOps)
 	}
+
+	// Network discovery: start/stop the mDNS and WS-Discovery advertisers live to
+	// match settings. No-op until Serve has started the auxsvc group.
+	s.reconcileMDNS()
+	s.reconcileWSDiscovery()
 }
 
 // Serve starts the SMB server and blocks until the context is cancelled
@@ -524,6 +536,11 @@ func (s *Adapter) Serve(ctx context.Context) error {
 			"interval", DefaultDurableScavengerInterval,
 			"timeout_ms", durableTimeout)
 	}
+
+	// Start the discovery advertisers (mDNS, WS-Discovery) through the shared
+	// auxsvc group so they share the adapter's lifecycle and can be toggled live
+	// from settings (issue #1609). See discovery.go.
+	s.startEnabledDiscovery(ctx)
 
 	return s.ServeWithFactory(ctx, s, s.preAcceptCheck, nil)
 }
@@ -899,6 +916,14 @@ func (s *Adapter) Stop(ctx context.Context) error {
 	// not outlive the adapter.
 	if netlogonAuth != nil {
 		netlogonAuth.Close(ctx)
+	}
+
+	// Stop the discovery advertisers (mDNS / WS-Discovery) before tearing down
+	// the main listener, so a Bye/goodbye is emitted while the network is still up.
+	if s.sidecars != nil {
+		if err := s.sidecars.StopAll(ctx); err != nil {
+			logger.Debug("SMB discovery advertiser shutdown reported an error", "error", err)
+		}
 	}
 
 	// Unsubscribe from share change notifications to prevent stale callbacks

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/handlers"
@@ -124,6 +125,14 @@ type Adapter struct {
 	// WS-Discovery advertisers (issue #1609) — under one uniform lifecycle.
 	// Seeded with the Serve context and torn down in Stop. See discovery.go.
 	sidecars *auxsvc.Group
+
+	// wsdInstanceID sources the WS-Discovery AppSequence InstanceId. Seeded once
+	// per adapter (process start time) and incremented per responder build, so
+	// every WSD responder in this process gets a distinct, strictly-increasing
+	// InstanceId — a live discovery toggle can never reuse an InstanceId with a
+	// rewound MessageNumber, which Windows would treat as a stale/duplicate
+	// sequence and discard.
+	wsdInstanceID atomic.Uint64
 }
 
 // New creates a new Adapter with the specified configuration.
@@ -206,13 +215,17 @@ func New(config Config) *Adapter {
 		ShutdownTimeout: config.Timeouts.Shutdown,
 	}
 
-	return &Adapter{
+	a := &Adapter{
 		BaseAdapter:    adapter.NewBaseAdapter(baseConfig, "SMB"),
 		config:         config,
 		handler:        handler,
 		sessionManager: sessionManager,
 		sidecars:       auxsvc.NewGroup(),
 	}
+	// Seed the WS-Discovery InstanceId base with the process start time so it is
+	// stable for this adapter and increases across process restarts.
+	a.wsdInstanceID.Store(uint64(time.Now().Unix()))
+	return a
 }
 
 // SetRuntime injects the runtime containing all stores and shares.

--- a/pkg/adapter/smb/discovery.go
+++ b/pkg/adapter/smb/discovery.go
@@ -87,7 +87,10 @@ func (s *Adapter) newWSDSidecar() auxsvc.Service {
 	if s.handler != nil {
 		workgroup = s.handler.NetBIOSDomain
 	}
-	return wsd.NewResponder(s.discoveryName(), workgroup, uint64(time.Now().Unix()))
+	// A non-empty NetBIOS domain means this server is an AD member, so Windows
+	// should group it under Domain: rather than Workgroup:.
+	isDomain := workgroup != ""
+	return wsd.NewResponder(s.discoveryName(), workgroup, isDomain, uint64(time.Now().Unix()))
 }
 
 // Compile-time assertions that the discovery advertisers satisfy auxsvc.Service.

--- a/pkg/adapter/smb/discovery.go
+++ b/pkg/adapter/smb/discovery.go
@@ -56,13 +56,17 @@ func (s *Adapter) wsDiscoveryEnabled() bool {
 	return st != nil && st.WSDiscoveryEnabled
 }
 
-// discoveryName is the name to advertise: the SMB NetBIOS/computer name when
-// known (domain member), else the OS-derived server name.
+// discoveryName is the instance-wide name to advertise, resolved from the
+// control plane (the `discovery.name` setting, defaulting to
+// "DittoFS-<hostname>"). mDNS uses it verbatim; WS-Discovery folds it to a
+// NetBIOS-legal computer name (see newWSDSidecar).
 func (s *Adapter) discoveryName() string {
-	if s.handler != nil && s.handler.NetBIOSName != "" {
-		return s.handler.NetBIOSName
+	if s.Registry != nil {
+		if n := s.Registry.DiscoveryName(); n != "" {
+			return n
+		}
 	}
-	return hostinfo.ServerName()
+	return hostinfo.DefaultDiscoveryName()
 }
 
 // newMDNSSidecar builds the SMB mDNS advertiser: an _smb._tcp instance on the
@@ -89,9 +93,13 @@ func (s *Adapter) newWSDSidecar() auxsvc.Service {
 	// A non-empty NetBIOS domain means this server is an AD member, so Windows
 	// should group it under Domain: rather than Workgroup:.
 	isDomain := workgroup != ""
+	// WS-Discovery renders the value as a Windows computer name, so fold it to a
+	// NetBIOS-legal form (the raw instance name may contain characters or a
+	// length Explorer rejects). mDNS keeps the raw name.
+	name := hostinfo.NetBIOSSafe(s.discoveryName())
 	// Distinct, strictly-increasing InstanceId per responder build (see the
 	// wsdInstanceID field) so a live toggle never rewinds the AppSequence.
-	return wsd.NewResponder(s.discoveryName(), workgroup, isDomain, s.wsdInstanceID.Add(1))
+	return wsd.NewResponder(name, workgroup, isDomain, s.wsdInstanceID.Add(1))
 }
 
 // Compile-time assertions that the discovery advertisers satisfy auxsvc.Service.

--- a/pkg/adapter/smb/discovery.go
+++ b/pkg/adapter/smb/discovery.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/adapter/auxsvc"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/discovery/hostinfo"
 	"github.com/marmos91/dittofs/pkg/discovery/mdns"
 	"github.com/marmos91/dittofs/pkg/discovery/wsd"
@@ -20,36 +21,39 @@ import (
 // whichever discovery advertisers are enabled. Called once from Serve.
 func (s *Adapter) startEnabledDiscovery(ctx context.Context) {
 	s.sidecars.SetBaseContext(ctx)
+	s.reconcileDiscovery()
+}
 
-	if s.mdnsEnabled() {
-		if err := s.sidecars.Start(s.newMDNSSidecar()); err != nil {
-			logger.Warn("SMB mDNS advertiser failed to start", "error", err)
-		}
+// reconcileDiscovery starts or stops the SMB discovery advertisers to match live
+// settings. Called from Serve (initial start) and from applySMBSettings (live
+// toggle); Group.Reconcile is a no-op until Serve has seeded the group.
+func (s *Adapter) reconcileDiscovery() {
+	if err := s.sidecars.Reconcile(mdns.SidecarName, s.mdnsEnabled(), s.newMDNSSidecar); err != nil {
+		logger.Warn("SMB mDNS advertiser failed to start", "error", err)
 	}
-	if s.wsDiscoveryEnabled() {
-		if err := s.sidecars.Start(s.newWSDSidecar()); err != nil {
-			logger.Warn("SMB WS-Discovery advertiser failed to start", "error", err)
-		}
+	if err := s.sidecars.Reconcile(wsd.SidecarName, s.wsDiscoveryEnabled(), s.newWSDSidecar); err != nil {
+		logger.Warn("SMB WS-Discovery advertiser failed to start", "error", err)
 	}
 }
 
-// mdnsEnabled reports whether the SMB mDNS advertiser should run, from live
-// settings (defaults false when settings are unavailable).
-func (s *Adapter) mdnsEnabled() bool {
+// smbSettings returns the live SMB adapter settings, or nil when unavailable.
+func (s *Adapter) smbSettings() *models.SMBAdapterSettings {
 	if s.Registry == nil {
-		return false
+		return nil
 	}
-	st := s.Registry.GetSMBSettings()
+	return s.Registry.GetSMBSettings()
+}
+
+// mdnsEnabled reports whether the SMB mDNS advertiser should run (default false).
+func (s *Adapter) mdnsEnabled() bool {
+	st := s.smbSettings()
 	return st != nil && st.MDNSEnabled
 }
 
-// wsDiscoveryEnabled reports whether the SMB WS-Discovery advertiser should run,
-// from live settings (defaults false when settings are unavailable).
+// wsDiscoveryEnabled reports whether the SMB WS-Discovery advertiser should run
+// (default false).
 func (s *Adapter) wsDiscoveryEnabled() bool {
-	if s.Registry == nil {
-		return false
-	}
-	st := s.Registry.GetSMBSettings()
+	st := s.smbSettings()
 	return st != nil && st.WSDiscoveryEnabled
 }
 
@@ -86,43 +90,10 @@ func (s *Adapter) newWSDSidecar() auxsvc.Service {
 	return wsd.NewResponder(s.discoveryName(), workgroup, uint64(time.Now().Unix()))
 }
 
-// reconcileMDNS starts or stops the mDNS advertiser to match live settings. It
-// is a no-op until Serve has started the auxsvc group, so a settings-apply that
-// runs before Serve (during SetRuntime) does not race the initial start.
-func (s *Adapter) reconcileMDNS() {
-	if s.sidecars == nil || !s.sidecars.Ready() {
-		return
-	}
-	want := s.mdnsEnabled()
-	running := s.sidecars.IsRunning(mdns.SidecarName)
-	switch {
-	case want && !running:
-		if err := s.sidecars.Start(s.newMDNSSidecar()); err != nil {
-			logger.Warn("SMB mDNS advertiser failed to start", "error", err)
-		}
-	case !want && running:
-		if err := s.sidecars.StopOne(mdns.SidecarName); err != nil {
-			logger.Debug("SMB mDNS advertiser stop reported an error", "error", err)
-		}
-	}
-}
-
-// reconcileWSDiscovery starts or stops the WS-Discovery advertiser to match live
-// settings. Like reconcileMDNS it is a no-op until Serve has started the group.
-func (s *Adapter) reconcileWSDiscovery() {
-	if s.sidecars == nil || !s.sidecars.Ready() {
-		return
-	}
-	want := s.wsDiscoveryEnabled()
-	running := s.sidecars.IsRunning(wsd.SidecarName)
-	switch {
-	case want && !running:
-		if err := s.sidecars.Start(s.newWSDSidecar()); err != nil {
-			logger.Warn("SMB WS-Discovery advertiser failed to start", "error", err)
-		}
-	case !want && running:
-		if err := s.sidecars.StopOne(wsd.SidecarName); err != nil {
-			logger.Debug("SMB WS-Discovery advertiser stop reported an error", "error", err)
-		}
-	}
-}
+// Compile-time assertions that the discovery advertisers satisfy auxsvc.Service.
+// They satisfy it structurally (pkg/discovery does not import the adapter
+// layer), so asserting here breaks a signature drift at build time.
+var (
+	_ auxsvc.Service = (*mdns.Sidecar)(nil)
+	_ auxsvc.Service = (*wsd.Responder)(nil)
+)

--- a/pkg/adapter/smb/discovery.go
+++ b/pkg/adapter/smb/discovery.go
@@ -2,7 +2,6 @@ package smb
 
 import (
 	"context"
-	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/adapter/auxsvc"
@@ -90,7 +89,9 @@ func (s *Adapter) newWSDSidecar() auxsvc.Service {
 	// A non-empty NetBIOS domain means this server is an AD member, so Windows
 	// should group it under Domain: rather than Workgroup:.
 	isDomain := workgroup != ""
-	return wsd.NewResponder(s.discoveryName(), workgroup, isDomain, uint64(time.Now().Unix()))
+	// Distinct, strictly-increasing InstanceId per responder build (see the
+	// wsdInstanceID field) so a live toggle never rewinds the AppSequence.
+	return wsd.NewResponder(s.discoveryName(), workgroup, isDomain, s.wsdInstanceID.Add(1))
 }
 
 // Compile-time assertions that the discovery advertisers satisfy auxsvc.Service.

--- a/pkg/adapter/smb/discovery.go
+++ b/pkg/adapter/smb/discovery.go
@@ -1,0 +1,128 @@
+package smb
+
+import (
+	"context"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/adapter/auxsvc"
+	"github.com/marmos91/dittofs/pkg/discovery/hostinfo"
+	"github.com/marmos91/dittofs/pkg/discovery/mdns"
+	"github.com/marmos91/dittofs/pkg/discovery/wsd"
+)
+
+// This file wires the SMB adapter's network-discovery advertisers (issue #1609)
+// into the shared auxsvc.Group: the mDNS advertiser here, and — in Phase 2 —
+// the WS-Discovery responder. Each is gated by a live setting and can be toggled
+// at runtime without an adapter restart.
+
+// startEnabledDiscovery seeds the auxsvc group with the Serve context and starts
+// whichever discovery advertisers are enabled. Called once from Serve.
+func (s *Adapter) startEnabledDiscovery(ctx context.Context) {
+	s.sidecars.SetBaseContext(ctx)
+
+	if s.mdnsEnabled() {
+		if err := s.sidecars.Start(s.newMDNSSidecar()); err != nil {
+			logger.Warn("SMB mDNS advertiser failed to start", "error", err)
+		}
+	}
+	if s.wsDiscoveryEnabled() {
+		if err := s.sidecars.Start(s.newWSDSidecar()); err != nil {
+			logger.Warn("SMB WS-Discovery advertiser failed to start", "error", err)
+		}
+	}
+}
+
+// mdnsEnabled reports whether the SMB mDNS advertiser should run, from live
+// settings (defaults false when settings are unavailable).
+func (s *Adapter) mdnsEnabled() bool {
+	if s.Registry == nil {
+		return false
+	}
+	st := s.Registry.GetSMBSettings()
+	return st != nil && st.MDNSEnabled
+}
+
+// wsDiscoveryEnabled reports whether the SMB WS-Discovery advertiser should run,
+// from live settings (defaults false when settings are unavailable).
+func (s *Adapter) wsDiscoveryEnabled() bool {
+	if s.Registry == nil {
+		return false
+	}
+	st := s.Registry.GetSMBSettings()
+	return st != nil && st.WSDiscoveryEnabled
+}
+
+// discoveryName is the name to advertise: the SMB NetBIOS/computer name when
+// known (domain member), else the OS-derived server name.
+func (s *Adapter) discoveryName() string {
+	if s.handler != nil && s.handler.NetBIOSName != "" {
+		return s.handler.NetBIOSName
+	}
+	return hostinfo.ServerName()
+}
+
+// newMDNSSidecar builds the SMB mDNS advertiser: an _smb._tcp instance on the
+// adapter's real port, plus a _device-info._tcp record whose model= TXT makes
+// Finder show a server icon rather than a generic one.
+func (s *Adapter) newMDNSSidecar() auxsvc.Service {
+	name := s.discoveryName()
+	port := uint16(s.Port())
+	return mdns.NewSidecar([]mdns.ServiceRecord{
+		{Instance: name, Service: "_smb._tcp", Port: port},
+		{Instance: name, Service: "_device-info._tcp", Port: port, TXT: []string{"model=RackMac"}},
+	})
+}
+
+// newWSDSidecar builds the SMB WS-Discovery responder, advertising the computer
+// name under its NetBIOS domain (or WORKGROUP when standalone). A fresh
+// AppSequence InstanceId (process start time) makes Windows treat a restart as a
+// new instance.
+func (s *Adapter) newWSDSidecar() auxsvc.Service {
+	workgroup := ""
+	if s.handler != nil {
+		workgroup = s.handler.NetBIOSDomain
+	}
+	return wsd.NewResponder(s.discoveryName(), workgroup, uint64(time.Now().Unix()))
+}
+
+// reconcileMDNS starts or stops the mDNS advertiser to match live settings. It
+// is a no-op until Serve has started the auxsvc group, so a settings-apply that
+// runs before Serve (during SetRuntime) does not race the initial start.
+func (s *Adapter) reconcileMDNS() {
+	if s.sidecars == nil || !s.sidecars.Ready() {
+		return
+	}
+	want := s.mdnsEnabled()
+	running := s.sidecars.IsRunning(mdns.SidecarName)
+	switch {
+	case want && !running:
+		if err := s.sidecars.Start(s.newMDNSSidecar()); err != nil {
+			logger.Warn("SMB mDNS advertiser failed to start", "error", err)
+		}
+	case !want && running:
+		if err := s.sidecars.StopOne(mdns.SidecarName); err != nil {
+			logger.Debug("SMB mDNS advertiser stop reported an error", "error", err)
+		}
+	}
+}
+
+// reconcileWSDiscovery starts or stops the WS-Discovery advertiser to match live
+// settings. Like reconcileMDNS it is a no-op until Serve has started the group.
+func (s *Adapter) reconcileWSDiscovery() {
+	if s.sidecars == nil || !s.sidecars.Ready() {
+		return
+	}
+	want := s.wsDiscoveryEnabled()
+	running := s.sidecars.IsRunning(wsd.SidecarName)
+	switch {
+	case want && !running:
+		if err := s.sidecars.Start(s.newWSDSidecar()); err != nil {
+			logger.Warn("SMB WS-Discovery advertiser failed to start", "error", err)
+		}
+	case !want && running:
+		if err := s.sidecars.StopOne(wsd.SidecarName); err != nil {
+			logger.Debug("SMB WS-Discovery advertiser stop reported an error", "error", err)
+		}
+	}
+}

--- a/pkg/apiclient/adapter_settings.go
+++ b/pkg/apiclient/adapter_settings.go
@@ -31,6 +31,7 @@ type NFSAdapterSettingsResponse struct {
 	PortmapperPort               int      `json:"portmapper_port"`
 	PortmapperRegisterWithSystem bool     `json:"portmapper_register_with_system"`
 	UDPEnabled                   bool     `json:"udp_enabled"`
+	MDNSEnabled                  bool     `json:"mdns_enabled"`
 	Version                      int      `json:"version"`
 }
 
@@ -46,6 +47,8 @@ type SMBAdapterSettingsResponse struct {
 	Signing                 string   `json:"signing"`
 	DirectoryLeasingEnabled bool     `json:"directory_leasing_enabled"`
 	BlockedOperations       []string `json:"blocked_operations"`
+	MDNSEnabled             bool     `json:"mdns_enabled"`
+	WSDiscoveryEnabled      bool     `json:"wsdiscovery_enabled"`
 	Version                 int      `json:"version"`
 }
 
@@ -94,6 +97,7 @@ type PatchNFSSettingsRequest struct {
 	PortmapperPort               *int      `json:"portmapper_port,omitempty"`
 	PortmapperRegisterWithSystem *bool     `json:"portmapper_register_with_system,omitempty"`
 	UDPEnabled                   *bool     `json:"udp_enabled,omitempty"`
+	MDNSEnabled                  *bool     `json:"mdns_enabled,omitempty"`
 }
 
 // PatchSMBSettingsRequest uses pointer fields for partial updates.
@@ -108,6 +112,8 @@ type PatchSMBSettingsRequest struct {
 	Signing                 *string   `json:"signing,omitempty"`
 	DirectoryLeasingEnabled *bool     `json:"directory_leasing_enabled,omitempty"`
 	BlockedOperations       *[]string `json:"blocked_operations,omitempty"`
+	MDNSEnabled             *bool     `json:"mdns_enabled,omitempty"`
+	WSDiscoveryEnabled      *bool     `json:"wsdiscovery_enabled,omitempty"`
 }
 
 // SettingsOption is a functional option for settings API calls.

--- a/pkg/controlplane/models/adapter_settings.go
+++ b/pkg/controlplane/models/adapter_settings.go
@@ -102,7 +102,9 @@ type NFSAdapterSettings struct {
 	// (_nfs._tcp) so it appears in macOS Finder and Linux/Avahi browsers
 	// (issue #1609). Defaults to false (opt-in). Applied live: toggling it
 	// starts/stops the mDNS advertiser without an adapter restart.
-	MDNSEnabled bool `gorm:"default:false" json:"mdns_enabled"`
+	// Explicit column: GORM would otherwise derive "m_dns_enabled" from the
+	// field name, mismatching the JSON tag and the store's column maps.
+	MDNSEnabled bool `gorm:"column:mdns_enabled;default:false" json:"mdns_enabled"`
 
 	// Version counter for change detection (monotonic, starts at 1, incremented on every update)
 	Version int `gorm:"default:1" json:"version"`
@@ -209,12 +211,14 @@ type SMBAdapterSettings struct {
 
 	// MDNSEnabled advertises the SMB service over multicast DNS / DNS-SD
 	// (_smb._tcp + _device-info._tcp) so it appears in macOS Finder and
-	// Linux/Avahi browsers.
-	MDNSEnabled bool `gorm:"default:false" json:"mdns_enabled"`
+	// Linux/Avahi browsers. Explicit column: GORM would otherwise derive
+	// "m_dns_enabled" from the field name.
+	MDNSEnabled bool `gorm:"column:mdns_enabled;default:false" json:"mdns_enabled"`
 
 	// WSDiscoveryEnabled advertises the host over WS-Discovery so it appears in
-	// the Windows Explorer Network view.
-	WSDiscoveryEnabled bool `gorm:"default:false" json:"wsdiscovery_enabled"`
+	// the Windows Explorer Network view. Explicit column: GORM would otherwise
+	// derive "ws_discovery_enabled".
+	WSDiscoveryEnabled bool `gorm:"column:wsdiscovery_enabled;default:false" json:"wsdiscovery_enabled"`
 
 	// Version counter for change detection (monotonic, starts at 1, incremented on every update)
 	Version int `gorm:"default:1" json:"version"`

--- a/pkg/controlplane/models/adapter_settings.go
+++ b/pkg/controlplane/models/adapter_settings.go
@@ -98,6 +98,12 @@ type NFSAdapterSettings struct {
 	// 111. Enable both to allow macOS NFSv3 locking.
 	UDPEnabled bool `gorm:"default:false" json:"udp_enabled"`
 
+	// MDNSEnabled advertises the NFS export over multicast DNS / DNS-SD
+	// (_nfs._tcp) so it appears in macOS Finder and Linux/Avahi browsers
+	// (issue #1609). Defaults to false (opt-in). Applied live: toggling it
+	// starts/stops the mDNS advertiser without an adapter restart.
+	MDNSEnabled bool `gorm:"default:false" json:"mdns_enabled"`
+
 	// Version counter for change detection (monotonic, starts at 1, incremented on every update)
 	Version int `gorm:"default:1" json:"version"`
 
@@ -197,6 +203,19 @@ type SMBAdapterSettings struct {
 	// (e.g., "nfs/host@REALM" -> "cifs/host@REALM").
 	SMBServicePrincipal string `gorm:"size:256" json:"smb_service_principal"`
 
+	// Network discovery (issue #1609). Both default to false (opt-in) and are
+	// applied live: toggling one starts/stops its advertiser without an adapter
+	// restart.
+
+	// MDNSEnabled advertises the SMB service over multicast DNS / DNS-SD
+	// (_smb._tcp + _device-info._tcp) so it appears in macOS Finder and
+	// Linux/Avahi browsers.
+	MDNSEnabled bool `gorm:"default:false" json:"mdns_enabled"`
+
+	// WSDiscoveryEnabled advertises the host over WS-Discovery so it appears in
+	// the Windows Explorer Network view.
+	WSDiscoveryEnabled bool `gorm:"default:false" json:"wsdiscovery_enabled"`
+
 	// Version counter for change detection (monotonic, starts at 1, incremented on every update)
 	Version int `gorm:"default:1" json:"version"`
 
@@ -259,6 +278,7 @@ func NewDefaultNFSSettings(adapterID string) *NFSAdapterSettings {
 		PortmapperPort:               10111,
 		PortmapperRegisterWithSystem: false,
 		UDPEnabled:                   false,
+		MDNSEnabled:                  false,
 		Version:                      1,
 	}
 }
@@ -280,6 +300,8 @@ func NewDefaultSMBSettings(adapterID string) *SMBAdapterSettings {
 		NtlmEnabled:             true,
 		GuestEnabled:            true,
 		SMBServicePrincipal:     "",
+		MDNSEnabled:             false,
+		WSDiscoveryEnabled:      false,
 		Version:                 1,
 	}
 	s.SetSigningAlgorithmPreference([]string{"AES-128-GMAC", "AES-128-CMAC", "HMAC-SHA256"})

--- a/pkg/controlplane/runtime/discovery.go
+++ b/pkg/controlplane/runtime/discovery.go
@@ -1,0 +1,29 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+
+	"github.com/marmos91/dittofs/pkg/discovery/hostinfo"
+)
+
+// DiscoveryNameKey is the system-settings key holding the instance-wide name
+// advertised on the LAN by the service-discovery advertisers (mDNS /
+// WS-Discovery). Set it with `dfsctl settings set discovery.name "<name>"`.
+const DiscoveryNameKey = "discovery.name"
+
+// DiscoveryName returns the instance-wide discovery name: the operator override
+// stored under DiscoveryNameKey, or hostinfo.DefaultDiscoveryName()
+// ("DittoFS-<hostname>") when unset. It is a single server identity; each
+// adapter formats it for its own protocol (WS-Discovery folds it to a
+// NetBIOS-legal computer name via hostinfo.NetBIOSSafe, mDNS uses it verbatim).
+func (r *Runtime) DiscoveryName() string {
+	if r.store != nil {
+		if v, err := r.store.GetSetting(context.Background(), DiscoveryNameKey); err == nil {
+			if v = strings.TrimSpace(v); v != "" {
+				return v
+			}
+		}
+	}
+	return hostinfo.DefaultDiscoveryName()
+}

--- a/pkg/controlplane/runtime/discovery_integration_test.go
+++ b/pkg/controlplane/runtime/discovery_integration_test.go
@@ -1,0 +1,28 @@
+//go:build integration
+
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/discovery/hostinfo"
+)
+
+// TestDiscoveryName_OverrideFromSetting verifies the instance-wide discovery
+// name falls back to the auto-default when unset and returns the (trimmed)
+// operator override once the discovery.name setting is stored.
+func TestDiscoveryName_OverrideFromSetting(t *testing.T) {
+	rt, cpStore := newRuntimeForChecks(t)
+
+	if got, want := rt.DiscoveryName(), hostinfo.DefaultDiscoveryName(); got != want {
+		t.Fatalf("unset DiscoveryName = %q, want default %q", got, want)
+	}
+
+	if err := cpStore.SetSetting(context.Background(), DiscoveryNameKey, "  My Filer  "); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+	if got, want := rt.DiscoveryName(), "My Filer"; got != want {
+		t.Fatalf("override DiscoveryName = %q, want trimmed %q", got, want)
+	}
+}

--- a/pkg/controlplane/runtime/discovery_test.go
+++ b/pkg/controlplane/runtime/discovery_test.go
@@ -1,0 +1,16 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/discovery/hostinfo"
+)
+
+// TestDiscoveryName_DefaultWithoutStore verifies the auto-default is used when
+// no store is wired (and thus no override can be read).
+func TestDiscoveryName_DefaultWithoutStore(t *testing.T) {
+	rt := &Runtime{}
+	if got, want := rt.DiscoveryName(), hostinfo.DefaultDiscoveryName(); got != want {
+		t.Fatalf("DiscoveryName without store = %q, want default %q", got, want)
+	}
+}

--- a/pkg/controlplane/store/adapter_settings_test.go
+++ b/pkg/controlplane/store/adapter_settings_test.go
@@ -304,6 +304,57 @@ func TestUpdateSMBAdapterSettings_IncrementsVersion(t *testing.T) {
 	}
 }
 
+// TestUpdateSMBAdapterSettings_PersistsDiscoveryToggles guards the discovery
+// toggles' full round-trip: the store's explicit-column Update map must include
+// them, and the GORM column name must match. A missing map key or a mismatched
+// column name (e.g. GORM deriving "m_dns_enabled" from the field) silently
+// drops the write — the failure mode found only in live testing for #1609.
+func TestUpdateSMBAdapterSettings_PersistsDiscoveryToggles(t *testing.T) {
+	s, adapter := createTestStoreWithSMBAdapter(t)
+	ctx := context.Background()
+
+	settings, _ := s.GetSMBAdapterSettings(ctx, adapter.ID)
+	settings.MDNSEnabled = true
+	settings.WSDiscoveryEnabled = true
+	if err := s.UpdateSMBAdapterSettings(ctx, settings); err != nil {
+		t.Fatalf("UpdateSMBAdapterSettings failed: %v", err)
+	}
+
+	updated, _ := s.GetSMBAdapterSettings(ctx, adapter.ID)
+	if !updated.MDNSEnabled {
+		t.Error("MDNSEnabled did not persist through Update")
+	}
+	if !updated.WSDiscoveryEnabled {
+		t.Error("WSDiscoveryEnabled did not persist through Update")
+	}
+
+	// And it round-trips back to false.
+	updated.MDNSEnabled = false
+	updated.WSDiscoveryEnabled = false
+	if err := s.UpdateSMBAdapterSettings(ctx, updated); err != nil {
+		t.Fatalf("UpdateSMBAdapterSettings (clear) failed: %v", err)
+	}
+	cleared, _ := s.GetSMBAdapterSettings(ctx, adapter.ID)
+	if cleared.MDNSEnabled || cleared.WSDiscoveryEnabled {
+		t.Error("discovery toggles did not clear back to false")
+	}
+}
+
+func TestUpdateNFSAdapterSettings_PersistsMDNSToggle(t *testing.T) {
+	s, adapter := createTestStoreWithNFSAdapter(t)
+	ctx := context.Background()
+
+	settings, _ := s.GetNFSAdapterSettings(ctx, adapter.ID)
+	settings.MDNSEnabled = true
+	if err := s.UpdateNFSAdapterSettings(ctx, settings); err != nil {
+		t.Fatalf("UpdateNFSAdapterSettings failed: %v", err)
+	}
+	updated, _ := s.GetNFSAdapterSettings(ctx, adapter.ID)
+	if !updated.MDNSEnabled {
+		t.Error("NFS MDNSEnabled did not persist through Update")
+	}
+}
+
 func TestResetSMBAdapterSettings_RestoresDefaults(t *testing.T) {
 	s, adapter := createTestStoreWithSMBAdapter(t)
 	ctx := context.Background()

--- a/pkg/controlplane/store/adapters.go
+++ b/pkg/controlplane/store/adapters.go
@@ -149,6 +149,7 @@ func (s *GORMStore) UpdateNFSAdapterSettings(ctx context.Context, settings *mode
 			"portmapper_port":                 settings.PortmapperPort,
 			"portmapper_register_with_system": settings.PortmapperRegisterWithSystem,
 			"udp_enabled":                     settings.UDPEnabled,
+			"mdns_enabled":                    settings.MDNSEnabled,
 			"version":                         gorm.Expr("version + 1"),
 			"updated_at":                      time.Now(),
 		})
@@ -191,6 +192,7 @@ func (s *GORMStore) ResetNFSAdapterSettings(ctx context.Context, adapterID strin
 			"portmapper_port":                 defaults.PortmapperPort,
 			"portmapper_register_with_system": defaults.PortmapperRegisterWithSystem,
 			"udp_enabled":                     defaults.UDPEnabled,
+			"mdns_enabled":                    defaults.MDNSEnabled,
 			"version":                         gorm.Expr("version + 1"),
 			"updated_at":                      time.Now(),
 		})
@@ -228,6 +230,8 @@ func (s *GORMStore) UpdateSMBAdapterSettings(ctx context.Context, settings *mode
 			"signing":                   settings.Signing,
 			"directory_leasing_enabled": settings.DirectoryLeasingEnabled,
 			"blocked_operations":        settings.BlockedOperations,
+			"mdns_enabled":              settings.MDNSEnabled,
+			"wsdiscovery_enabled":       settings.WSDiscoveryEnabled,
 			"version":                   gorm.Expr("version + 1"),
 			"updated_at":                time.Now(),
 		})
@@ -259,6 +263,8 @@ func (s *GORMStore) ResetSMBAdapterSettings(ctx context.Context, adapterID strin
 			"signing":                   defaults.Signing,
 			"directory_leasing_enabled": defaults.DirectoryLeasingEnabled,
 			"blocked_operations":        "",
+			"mdns_enabled":              defaults.MDNSEnabled,
+			"wsdiscovery_enabled":       defaults.WSDiscoveryEnabled,
 			"version":                   gorm.Expr("version + 1"),
 			"updated_at":                time.Now(),
 		})

--- a/pkg/discovery/hostinfo/hostinfo.go
+++ b/pkg/discovery/hostinfo/hostinfo.go
@@ -19,7 +19,12 @@ const FallbackName = "DITTOFS"
 // OS hostname, upper-cased (NetBIOS convention), or FallbackName when the
 // hostname is empty/unavailable. e.g. "vm2.cubbit.local" -> "VM2".
 func ServerName() string {
-	h, err := os.Hostname()
+	return serverNameFrom(os.Hostname())
+}
+
+// serverNameFrom is the pure core of ServerName, taking the os.Hostname() result
+// so it can be tested without depending on the real hostname.
+func serverNameFrom(h string, err error) string {
 	if err != nil || h == "" {
 		return FallbackName
 	}

--- a/pkg/discovery/hostinfo/hostinfo.go
+++ b/pkg/discovery/hostinfo/hostinfo.go
@@ -38,6 +38,47 @@ func serverNameFrom(h string, err error) string {
 	return strings.ToUpper(h)
 }
 
+// DefaultNamePrefix is the product-branded prefix of the auto-generated
+// discovery name.
+const DefaultNamePrefix = "DittoFS"
+
+// DefaultDiscoveryName is the instance-wide name advertised on the LAN when the
+// operator has not set an override: "DittoFS-<hostname>" (e.g. "DittoFS-VM2"),
+// so multiple DittoFS servers on one network stay distinguishable by default.
+// Falls back to the bare prefix when the hostname is unavailable.
+func DefaultDiscoveryName() string {
+	name := ServerName()
+	if name == FallbackName {
+		return DefaultNamePrefix
+	}
+	return DefaultNamePrefix + "-" + name
+}
+
+// NetBIOSSafe folds an arbitrary discovery name into a NetBIOS-legal computer
+// name for WS-Discovery: upper-cased, illegal characters replaced with '-',
+// trimmed of leading/trailing '-', and capped at the 15-character NetBIOS limit.
+// Returns FallbackName if nothing legal survives. mDNS instance names have no
+// such constraint and use the raw name.
+func NetBIOSSafe(name string) string {
+	var b strings.Builder
+	for _, r := range strings.ToUpper(name) {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	s := strings.Trim(b.String(), "-")
+	if len(s) > 15 {
+		s = strings.TrimRight(s[:15], "-")
+	}
+	if s == "" {
+		return FallbackName
+	}
+	return s
+}
+
 // MulticastInterfaces returns the interfaces suitable for multicast discovery:
 // up, multicast-capable, and not loopback. Empty when none qualify.
 func MulticastInterfaces() []net.Interface {

--- a/pkg/discovery/hostinfo/hostinfo.go
+++ b/pkg/discovery/hostinfo/hostinfo.go
@@ -1,0 +1,90 @@
+// Package hostinfo resolves the identity and network facts a discovery
+// advertiser needs: the server's advertised name, the multicast-capable
+// interfaces, and the host's IP addresses. It centralizes the ad-hoc
+// os.Hostname()/net.Interfaces() logic so the mDNS and WS-Discovery responders
+// agree on what to advertise.
+package hostinfo
+
+import (
+	"net"
+	"os"
+	"strings"
+)
+
+// FallbackName is advertised when the OS hostname cannot be determined. It
+// matches the standalone SMB machine-name fallback used elsewhere in the tree.
+const FallbackName = "DITTOFS"
+
+// ServerName returns the name to advertise for this host: the first label of the
+// OS hostname, upper-cased (NetBIOS convention), or FallbackName when the
+// hostname is empty/unavailable. e.g. "vm2.cubbit.local" -> "VM2".
+func ServerName() string {
+	h, err := os.Hostname()
+	if err != nil || h == "" {
+		return FallbackName
+	}
+	if i := strings.IndexByte(h, '.'); i >= 0 {
+		h = h[:i]
+	}
+	h = strings.TrimSpace(h)
+	if h == "" {
+		return FallbackName
+	}
+	return strings.ToUpper(h)
+}
+
+// MulticastInterfaces returns the interfaces suitable for multicast discovery:
+// up, multicast-capable, and not loopback. Empty when none qualify.
+func MulticastInterfaces() []net.Interface {
+	all, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+	out := make([]net.Interface, 0, len(all))
+	for _, ifi := range all {
+		if ifi.Flags&net.FlagUp == 0 {
+			continue
+		}
+		if ifi.Flags&net.FlagMulticast == 0 {
+			continue
+		}
+		if ifi.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		out = append(out, ifi)
+	}
+	return out
+}
+
+// AllHostIPs returns the host's non-loopback, non-link-local unicast IPs across
+// all interfaces, for A/AAAA records and WS-Discovery XAddrs.
+func AllHostIPs() []net.IP {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil
+	}
+	var out []net.IP
+	for _, a := range addrs {
+		ipNet, ok := a.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		ip := ipNet.IP
+		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+			continue
+		}
+		out = append(out, ip)
+	}
+	return out
+}
+
+// PrimaryIPv4 returns the host's first usable IPv4 address, or nil when the host
+// has no routable IPv4. Used as the WS-Discovery XAddrs host.
+func PrimaryIPv4() net.IP {
+	for _, ip := range AllHostIPs() {
+		if v4 := ip.To4(); v4 != nil {
+			return v4
+		}
+	}
+	return nil
+}

--- a/pkg/discovery/hostinfo/hostinfo_test.go
+++ b/pkg/discovery/hostinfo/hostinfo_test.go
@@ -49,13 +49,13 @@ func TestDefaultDiscoveryName_RealHost(t *testing.T) {
 
 func TestNetBIOSSafe(t *testing.T) {
 	cases := []struct{ in, want string }{
-		{"DittoFS-VM2", "DITTOFS-VM2"},           // already legal, upper-cased
-		{"DittoFS@vm2", "DITTOFS-VM2"},           // '@' is illegal -> '-'
-		{"My File Server!", "MY-FILE-SERVER"},    // spaces/punct -> '-', trailing trimmed
-		{"a.b.c", "A-B-C"},                          // dots -> '-'
+		{"DittoFS-VM2", "DITTOFS-VM2"},                    // already legal, upper-cased
+		{"DittoFS@vm2", "DITTOFS-VM2"},                    // '@' is illegal -> '-'
+		{"My File Server!", "MY-FILE-SERVER"},             // spaces/punct -> '-', trailing trimmed
+		{"a.b.c", "A-B-C"},                                // dots -> '-'
 		{"DittoFS-ReallyLongHostname", "DITTOFS-REALLYL"}, // capped at 15 chars
-		{"@@@", FallbackName},                        // nothing legal survives
-		{"", FallbackName},                           // empty
+		{"@@@", FallbackName},                             // nothing legal survives
+		{"", FallbackName},                                // empty
 	}
 	for _, c := range cases {
 		if got := NetBIOSSafe(c.in); got != c.want {

--- a/pkg/discovery/hostinfo/hostinfo_test.go
+++ b/pkg/discovery/hostinfo/hostinfo_test.go
@@ -28,22 +28,6 @@ func TestServerName_SingleLabel(t *testing.T) {
 	}
 }
 
-// serverNameFrom is the pure core of ServerName, extracted for testing without
-// depending on the real os.Hostname().
-func serverNameFrom(h string, err error) string {
-	if err != nil || h == "" {
-		return FallbackName
-	}
-	if i := strings.IndexByte(h, '.'); i >= 0 {
-		h = h[:i]
-	}
-	h = strings.TrimSpace(h)
-	if h == "" {
-		return FallbackName
-	}
-	return strings.ToUpper(h)
-}
-
 func TestServerName_RealHostDoesNotPanic(t *testing.T) {
 	// Smoke: the real accessor returns a non-empty, upper-cased name.
 	got := ServerName()

--- a/pkg/discovery/hostinfo/hostinfo_test.go
+++ b/pkg/discovery/hostinfo/hostinfo_test.go
@@ -1,0 +1,56 @@
+package hostinfo
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestServerName_StripsDomainAndUppercases(t *testing.T) {
+	got := serverNameFrom("vm2.cubbit.local", nil)
+	if got != "VM2" {
+		t.Fatalf("serverNameFrom = %q, want VM2", got)
+	}
+}
+
+func TestServerName_Fallback(t *testing.T) {
+	if got := serverNameFrom("", nil); got != FallbackName {
+		t.Fatalf("empty hostname -> %q, want %q", got, FallbackName)
+	}
+	if got := serverNameFrom("ignored", os.ErrInvalid); got != FallbackName {
+		t.Fatalf("hostname error -> %q, want %q", got, FallbackName)
+	}
+}
+
+func TestServerName_SingleLabel(t *testing.T) {
+	if got := serverNameFrom("dittofs", nil); got != "DITTOFS" {
+		t.Fatalf("serverNameFrom = %q, want DITTOFS", got)
+	}
+}
+
+// serverNameFrom is the pure core of ServerName, extracted for testing without
+// depending on the real os.Hostname().
+func serverNameFrom(h string, err error) string {
+	if err != nil || h == "" {
+		return FallbackName
+	}
+	if i := strings.IndexByte(h, '.'); i >= 0 {
+		h = h[:i]
+	}
+	h = strings.TrimSpace(h)
+	if h == "" {
+		return FallbackName
+	}
+	return strings.ToUpper(h)
+}
+
+func TestServerName_RealHostDoesNotPanic(t *testing.T) {
+	// Smoke: the real accessor returns a non-empty, upper-cased name.
+	got := ServerName()
+	if got == "" {
+		t.Fatal("ServerName returned empty")
+	}
+	if got != strings.ToUpper(got) {
+		t.Fatalf("ServerName %q is not upper-cased", got)
+	}
+}

--- a/pkg/discovery/hostinfo/hostinfo_test.go
+++ b/pkg/discovery/hostinfo/hostinfo_test.go
@@ -38,3 +38,35 @@ func TestServerName_RealHostDoesNotPanic(t *testing.T) {
 		t.Fatalf("ServerName %q is not upper-cased", got)
 	}
 }
+
+func TestDefaultDiscoveryName_RealHost(t *testing.T) {
+	got := DefaultDiscoveryName()
+	// Either "DittoFS-<HOST>" or the bare prefix when the hostname is unavailable.
+	if got != DefaultNamePrefix && !strings.HasPrefix(got, DefaultNamePrefix+"-") {
+		t.Fatalf("DefaultDiscoveryName = %q, want %q or %q-<host>", got, DefaultNamePrefix, DefaultNamePrefix)
+	}
+}
+
+func TestNetBIOSSafe(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"DittoFS-VM2", "DITTOFS-VM2"},           // already legal, upper-cased
+		{"DittoFS@vm2", "DITTOFS-VM2"},           // '@' is illegal -> '-'
+		{"My File Server!", "MY-FILE-SERVER"},    // spaces/punct -> '-', trailing trimmed
+		{"a.b.c", "A-B-C"},                          // dots -> '-'
+		{"DittoFS-ReallyLongHostname", "DITTOFS-REALLYL"}, // capped at 15 chars
+		{"@@@", FallbackName},                        // nothing legal survives
+		{"", FallbackName},                           // empty
+	}
+	for _, c := range cases {
+		if got := NetBIOSSafe(c.in); got != c.want {
+			t.Errorf("NetBIOSSafe(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestNetBIOSSafe_NeverExceeds15(t *testing.T) {
+	got := NetBIOSSafe("this-is-a-very-long-discovery-name")
+	if len(got) > 15 {
+		t.Fatalf("NetBIOSSafe len = %d (%q), want <= 15", len(got), got)
+	}
+}

--- a/pkg/discovery/mdns/query.go
+++ b/pkg/discovery/mdns/query.go
@@ -1,0 +1,203 @@
+package mdns
+
+import (
+	"strings"
+
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+// buildResponse parses an inbound mDNS query and packs a response advertising
+// any registered services it matches. It is a pure function — the whole
+// network-facing behavior of the responder reduces to it, so it is unit-tested
+// without a socket.
+//
+//   - ok is false when no question matched a registered record (the caller sends
+//     nothing).
+//   - unicast is true when the querier set the QU (unicast-response) bit on a
+//     matched question, so the caller should reply directly to the sender rather
+//     than to the multicast group.
+//
+// The directly-queried record goes in the Answer section; supporting records
+// (SRV/TXT/address for a PTR query, addresses for an SRV query) go in
+// Additional. A shared seen-set dedupes records that several questions would
+// otherwise repeat.
+func buildResponse(services []ServiceRecord, query []byte) (resp []byte, unicast bool, ok bool, err error) {
+	var p dnsmessage.Parser
+	hdr, err := p.Start(query)
+	if err != nil {
+		return nil, false, false, err
+	}
+	// Ignore responses (including other responders' announcements) — we answer
+	// only queries.
+	if hdr.Response {
+		return nil, false, false, nil
+	}
+	questions, err := p.AllQuestions()
+	if err != nil {
+		return nil, false, false, err
+	}
+	if len(questions) == 0 {
+		return nil, false, false, nil
+	}
+
+	acc := &answerSet{seen: make(map[string]bool)}
+	for _, q := range questions {
+		qname := q.Name.String()
+		qt := q.Type
+		qu := uint16(q.Class)&cacheFlushBit != 0 // QU bit reuses the top class bit
+
+		for i := range services {
+			s := services[i]
+			matched := acc.matchQuestion(s, qname, qt)
+			if matched && qu {
+				unicast = true
+			}
+		}
+	}
+
+	if acc.err != nil {
+		return nil, false, false, acc.err
+	}
+	if len(acc.answers) == 0 {
+		return nil, false, false, nil
+	}
+
+	msg := dnsmessage.Message{
+		Header:      dnsmessage.Header{Response: true, Authoritative: true},
+		Answers:     acc.answers,
+		Additionals: acc.additionals,
+	}
+	packed, err := msg.Pack()
+	if err != nil {
+		return nil, false, false, err
+	}
+	return packed, unicast, true, nil
+}
+
+// answerSet accumulates the answer and additional records for a response,
+// deduplicating by a caller-supplied key shared across both sections.
+type answerSet struct {
+	seen        map[string]bool
+	answers     []dnsmessage.Resource
+	additionals []dnsmessage.Resource
+	err         error
+}
+
+// answer adds a record (built lazily by build) to the Answer section, unless
+// its key was already emitted. A build error is latched into a.err.
+func (a *answerSet) answer(key string, build func() (dnsmessage.Resource, error)) {
+	a.appendTo(&a.answers, key, build)
+}
+
+// additional adds a record to the Additional section under the same dedupe set.
+func (a *answerSet) additional(key string, build func() (dnsmessage.Resource, error)) {
+	a.appendTo(&a.additionals, key, build)
+}
+
+func (a *answerSet) appendTo(dst *[]dnsmessage.Resource, key string, build func() (dnsmessage.Resource, error)) {
+	if a.err != nil || a.seen[key] {
+		return
+	}
+	r, err := build()
+	if err != nil {
+		a.err = err
+		return
+	}
+	a.seen[key] = true
+	*dst = append(*dst, r)
+}
+
+// matchQuestion adds the records service s owes for question (qname, qt) and
+// reports whether anything matched. qt==ANY matches every record type, so the
+// checks are independent (not a switch).
+func (a *answerSet) matchQuestion(s ServiceRecord, qname string, qt dnsmessage.Type) bool {
+	isPTR := qt == dnsmessage.TypePTR || qt == typeANY
+	isSRV := qt == dnsmessage.TypeSRV || qt == typeANY
+	isTXT := qt == dnsmessage.TypeTXT || qt == typeANY
+	isA := qt == dnsmessage.TypeA || qt == typeANY
+	isAAAA := qt == dnsmessage.TypeAAAA || qt == typeANY
+
+	matched := false
+
+	// PTR browse: "_smb._tcp.local." -> instance, plus supporting records.
+	if isPTR && equalName(qname, s.serviceName()) {
+		a.answer("ptr:"+s.serviceName(), func() (dnsmessage.Resource, error) { return s.ptrRecord(false) })
+		a.additional("srv:"+s.instanceName(), func() (dnsmessage.Resource, error) { return s.srvRecord(false) })
+		a.additional("txt:"+s.instanceName(), func() (dnsmessage.Resource, error) { return s.txtRecord(false) })
+		a.addAddrs(s, true, true, false)
+		matched = true
+	}
+	// Service-type enumeration.
+	if isPTR && equalName(qname, s.metaName()) {
+		a.answer("meta:"+s.metaName()+"/"+s.serviceName(), func() (dnsmessage.Resource, error) { return s.metaPTRRecord(false) })
+		matched = true
+	}
+	// Direct SRV/TXT for the instance.
+	if isSRV && equalName(qname, s.instanceName()) {
+		a.answer("srv:"+s.instanceName(), func() (dnsmessage.Resource, error) { return s.srvRecord(false) })
+		a.addAddrs(s, true, true, false)
+		matched = true
+	}
+	if isTXT && equalName(qname, s.instanceName()) {
+		a.answer("txt:"+s.instanceName(), func() (dnsmessage.Resource, error) { return s.txtRecord(false) })
+		matched = true
+	}
+	// Host address records.
+	if (isA || isAAAA) && equalName(qname, s.hostName()) {
+		a.addAddrs(s, isA, isAAAA, true)
+		matched = true
+	}
+	return matched
+}
+
+// addAddrs adds the host A/AAAA records (as answers when toAnswer, else as
+// additionals), filtered to the requested families.
+func (a *answerSet) addAddrs(s ServiceRecord, wantA, wantAAAA, toAnswer bool) {
+	recs, err := s.addrRecords(false)
+	if err != nil {
+		if a.err == nil {
+			a.err = err
+		}
+		return
+	}
+	for _, r := range recs {
+		var key string
+		switch r.Header.Type {
+		case dnsmessage.TypeA:
+			if !wantA {
+				continue
+			}
+			key = "a:" + s.hostName() + ":" + addrKey(r)
+		case dnsmessage.TypeAAAA:
+			if !wantAAAA {
+				continue
+			}
+			key = "aaaa:" + s.hostName() + ":" + addrKey(r)
+		default:
+			continue
+		}
+		rec := r // capture per iteration for the closure
+		build := func() (dnsmessage.Resource, error) { return rec, nil }
+		if toAnswer {
+			a.answer(key, build)
+		} else {
+			a.additional(key, build)
+		}
+	}
+}
+
+// addrKey returns a stable string for an A/AAAA record's address bytes.
+func addrKey(r dnsmessage.Resource) string {
+	switch b := r.Body.(type) {
+	case *dnsmessage.AResource:
+		return string(b.A[:])
+	case *dnsmessage.AAAAResource:
+		return string(b.AAAA[:])
+	default:
+		return ""
+	}
+}
+
+// equalName compares two DNS names case-insensitively (mDNS names are
+// case-insensitive; both sides are fully qualified with a trailing dot).
+func equalName(a, b string) bool { return strings.EqualFold(a, b) }

--- a/pkg/discovery/mdns/query.go
+++ b/pkg/discovery/mdns/query.go
@@ -83,24 +83,28 @@ type answerSet struct {
 	err         error
 }
 
-// answer adds a record (built lazily by build) to the Answer section, unless
-// its key was already emitted. A build error is latched into a.err.
-func (a *answerSet) answer(key string, build func() (dnsmessage.Resource, error)) {
-	a.appendTo(&a.answers, key, build)
+// rec adapts a record builder's (Resource, error) result for the answer/
+// additional helpers: it latches any build error into a.err and returns the
+// resource (zero on error, which the latched a.err then suppresses). This lets
+// call sites stay one line — a.answer(key, a.rec(s.srvRecord(false))).
+func (a *answerSet) rec(r dnsmessage.Resource, err error) dnsmessage.Resource {
+	if err != nil && a.err == nil {
+		a.err = err
+	}
+	return r
 }
+
+// answer adds a record to the Answer section unless its key was already emitted
+// or a build error has been latched.
+func (a *answerSet) answer(key string, r dnsmessage.Resource) { a.appendTo(&a.answers, key, r) }
 
 // additional adds a record to the Additional section under the same dedupe set.
-func (a *answerSet) additional(key string, build func() (dnsmessage.Resource, error)) {
-	a.appendTo(&a.additionals, key, build)
+func (a *answerSet) additional(key string, r dnsmessage.Resource) {
+	a.appendTo(&a.additionals, key, r)
 }
 
-func (a *answerSet) appendTo(dst *[]dnsmessage.Resource, key string, build func() (dnsmessage.Resource, error)) {
+func (a *answerSet) appendTo(dst *[]dnsmessage.Resource, key string, r dnsmessage.Resource) {
 	if a.err != nil || a.seen[key] {
-		return
-	}
-	r, err := build()
-	if err != nil {
-		a.err = err
 		return
 	}
 	a.seen[key] = true
@@ -121,25 +125,25 @@ func (a *answerSet) matchQuestion(s ServiceRecord, qname string, qt dnsmessage.T
 
 	// PTR browse: "_smb._tcp.local." -> instance, plus supporting records.
 	if isPTR && equalName(qname, s.serviceName()) {
-		a.answer("ptr:"+s.serviceName(), func() (dnsmessage.Resource, error) { return s.ptrRecord(false) })
-		a.additional("srv:"+s.instanceName(), func() (dnsmessage.Resource, error) { return s.srvRecord(false) })
-		a.additional("txt:"+s.instanceName(), func() (dnsmessage.Resource, error) { return s.txtRecord(false) })
+		a.answer("ptr:"+s.serviceName(), a.rec(s.ptrRecord(false)))
+		a.additional("srv:"+s.instanceName(), a.rec(s.srvRecord(false)))
+		a.additional("txt:"+s.instanceName(), a.rec(s.txtRecord(false)))
 		a.addAddrs(s, true, true, false)
 		matched = true
 	}
 	// Service-type enumeration.
 	if isPTR && equalName(qname, s.metaName()) {
-		a.answer("meta:"+s.metaName()+"/"+s.serviceName(), func() (dnsmessage.Resource, error) { return s.metaPTRRecord(false) })
+		a.answer("meta:"+s.metaName()+"/"+s.serviceName(), a.rec(s.metaPTRRecord(false)))
 		matched = true
 	}
 	// Direct SRV/TXT for the instance.
 	if isSRV && equalName(qname, s.instanceName()) {
-		a.answer("srv:"+s.instanceName(), func() (dnsmessage.Resource, error) { return s.srvRecord(false) })
+		a.answer("srv:"+s.instanceName(), a.rec(s.srvRecord(false)))
 		a.addAddrs(s, true, true, false)
 		matched = true
 	}
 	if isTXT && equalName(qname, s.instanceName()) {
-		a.answer("txt:"+s.instanceName(), func() (dnsmessage.Resource, error) { return s.txtRecord(false) })
+		a.answer("txt:"+s.instanceName(), a.rec(s.txtRecord(false)))
 		matched = true
 	}
 	// Host address records.
@@ -176,12 +180,10 @@ func (a *answerSet) addAddrs(s ServiceRecord, wantA, wantAAAA, toAnswer bool) {
 		default:
 			continue
 		}
-		rec := r // capture per iteration for the closure
-		build := func() (dnsmessage.Resource, error) { return rec, nil }
 		if toAnswer {
-			a.answer(key, build)
+			a.answer(key, r)
 		} else {
-			a.additional(key, build)
+			a.additional(key, r)
 		}
 	}
 }
@@ -196,6 +198,16 @@ func addrKey(r dnsmessage.Resource) string {
 	default:
 		return ""
 	}
+}
+
+// isQuery reports whether data is a DNS query (not a response) worth answering.
+// It parses only the header, so the responder can drop the many response packets
+// on the multicast group (other hosts' and our own announcements) before the
+// more expensive record snapshot and full parse in buildResponse.
+func isQuery(data []byte) bool {
+	var p dnsmessage.Parser
+	hdr, err := p.Start(data)
+	return err == nil && !hdr.Response
 }
 
 // equalName compares two DNS names case-insensitively (mDNS names are

--- a/pkg/discovery/mdns/query_test.go
+++ b/pkg/discovery/mdns/query_test.go
@@ -1,0 +1,145 @@
+package mdns
+
+import (
+	"testing"
+
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+// packQuery builds an mDNS query for name/type, optionally setting the QU
+// (unicast-response) bit on the question class.
+func packQuery(t *testing.T, name string, qt dnsmessage.Type, qu bool) []byte {
+	t.Helper()
+	n, err := dnsmessage.NewName(name)
+	if err != nil {
+		t.Fatalf("NewName: %v", err)
+	}
+	class := dnsmessage.ClassINET
+	if qu {
+		class = dnsmessage.Class(cacheFlushBit | uint16(dnsmessage.ClassINET))
+	}
+	msg := dnsmessage.Message{
+		Header:    dnsmessage.Header{},
+		Questions: []dnsmessage.Question{{Name: n, Type: qt, Class: class}},
+	}
+	b, err := msg.Pack()
+	if err != nil {
+		t.Fatalf("Pack query: %v", err)
+	}
+	return b
+}
+
+func TestBuildResponse_PTRBrowseMatchesSMB(t *testing.T) {
+	services := []ServiceRecord{smbService(), nfsService()}
+	query := packQuery(t, "_smb._tcp.local.", dnsmessage.TypePTR, false)
+
+	resp, unicast, ok, err := buildResponse(services, query)
+	if err != nil {
+		t.Fatalf("buildResponse: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected a response for _smb._tcp browse")
+	}
+	if unicast {
+		t.Fatal("QU bit not set; response should be multicast")
+	}
+
+	_, recs := parseAll(t, resp)
+	// Should include the SMB PTR (answer) but NOT the NFS PTR.
+	for _, r := range recs {
+		if b, ok := r.Body.(*dnsmessage.PTRResource); ok && r.Header.Name.String() == "_nfs._tcp.local." {
+			t.Fatalf("response leaked an unrelated NFS PTR: %s", b.PTR.String())
+		}
+	}
+	// And it should carry the SMB SRV as a supporting record.
+	var sawSMBSRV bool
+	for _, r := range recs {
+		if b, ok := r.Body.(*dnsmessage.SRVResource); ok && b.Port == 445 {
+			sawSMBSRV = true
+		}
+	}
+	if !sawSMBSRV {
+		t.Fatal("expected SMB SRV (port 445) among supporting records")
+	}
+}
+
+func TestBuildResponse_QUBitRequestsUnicast(t *testing.T) {
+	services := []ServiceRecord{smbService()}
+	query := packQuery(t, "_smb._tcp.local.", dnsmessage.TypePTR, true)
+
+	_, unicast, ok, err := buildResponse(services, query)
+	if err != nil {
+		t.Fatalf("buildResponse: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected a response")
+	}
+	if !unicast {
+		t.Fatal("QU bit set; response should be unicast")
+	}
+}
+
+func TestBuildResponse_NoMatchNoResponse(t *testing.T) {
+	services := []ServiceRecord{smbService()}
+	query := packQuery(t, "_afpovertcp._tcp.local.", dnsmessage.TypePTR, false)
+
+	resp, _, ok, err := buildResponse(services, query)
+	if err != nil {
+		t.Fatalf("buildResponse: %v", err)
+	}
+	if ok || resp != nil {
+		t.Fatal("unrelated query should produce no response")
+	}
+}
+
+func TestBuildResponse_SRVQueryReturnsPortAndAddr(t *testing.T) {
+	services := []ServiceRecord{nfsService()}
+	query := packQuery(t, "DITTOFS._nfs._tcp.local.", dnsmessage.TypeSRV, false)
+
+	resp, _, ok, err := buildResponse(services, query)
+	if err != nil {
+		t.Fatalf("buildResponse: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected a response for the SRV query")
+	}
+	_, recs := parseAll(t, resp)
+	var sawSRV, sawA bool
+	for _, r := range recs {
+		switch b := r.Body.(type) {
+		case *dnsmessage.SRVResource:
+			sawSRV = true
+			if b.Port != 12049 {
+				t.Fatalf("SRV port = %d, want 12049", b.Port)
+			}
+		case *dnsmessage.AResource:
+			sawA = true
+		}
+	}
+	if !sawSRV || !sawA {
+		t.Fatalf("SRV query response missing records: srv=%v a=%v", sawSRV, sawA)
+	}
+}
+
+func TestBuildResponse_ServiceEnumeration(t *testing.T) {
+	services := []ServiceRecord{smbService(), nfsService()}
+	query := packQuery(t, "_services._dns-sd._udp.local.", dnsmessage.TypePTR, false)
+
+	resp, _, ok, err := buildResponse(services, query)
+	if err != nil {
+		t.Fatalf("buildResponse: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected a response for service enumeration")
+	}
+	_, recs := parseAll(t, resp)
+	types := map[string]bool{}
+	for _, r := range recs {
+		if b, ok := r.Body.(*dnsmessage.PTRResource); ok {
+			types[b.PTR.String()] = true
+		}
+	}
+	if !types["_smb._tcp.local."] || !types["_nfs._tcp.local."] {
+		t.Fatalf("enumeration missing service types: %v", types)
+	}
+}

--- a/pkg/discovery/mdns/records.go
+++ b/pkg/discovery/mdns/records.go
@@ -1,0 +1,172 @@
+package mdns
+
+import (
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+const (
+	// ttlDefault is the TTL for the unique records (SRV/TXT/A/AAAA); ttlPTR is
+	// the longer TTL DNS-SD conventionally uses for the shared PTR records.
+	ttlDefault uint32 = 120
+	ttlPTR     uint32 = 4500
+
+	// cacheFlushBit is the top bit of the record CLASS. Set on unique records
+	// so responders replace any cached copy (RFC 6762 §10.2). Shared PTR
+	// records leave it clear.
+	cacheFlushBit = 0x8000
+
+	// typeANY is the QTYPE for "any record" queries (RFC 1035); dnsmessage does
+	// not define a constant for it.
+	typeANY dnsmessage.Type = 255
+)
+
+// ttlOf returns 0 for a goodbye record (evicts caches immediately) or base
+// otherwise.
+func ttlOf(base uint32, goodbye bool) uint32 {
+	if goodbye {
+		return 0
+	}
+	return base
+}
+
+// classOf returns ClassINET, with the cache-flush bit set when flush is true.
+func classOf(flush bool) dnsmessage.Class {
+	if flush {
+		return dnsmessage.Class(cacheFlushBit | uint16(dnsmessage.ClassINET))
+	}
+	return dnsmessage.ClassINET
+}
+
+func (s ServiceRecord) ptrRecord(goodbye bool) (dnsmessage.Resource, error) {
+	name, err := dnsmessage.NewName(s.serviceName())
+	if err != nil {
+		return dnsmessage.Resource{}, err
+	}
+	target, err := dnsmessage.NewName(s.instanceName())
+	if err != nil {
+		return dnsmessage.Resource{}, err
+	}
+	return dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{Name: name, Type: dnsmessage.TypePTR, Class: classOf(false), TTL: ttlOf(ttlPTR, goodbye)},
+		Body:   &dnsmessage.PTRResource{PTR: target},
+	}, nil
+}
+
+func (s ServiceRecord) metaPTRRecord(goodbye bool) (dnsmessage.Resource, error) {
+	name, err := dnsmessage.NewName(s.metaName())
+	if err != nil {
+		return dnsmessage.Resource{}, err
+	}
+	target, err := dnsmessage.NewName(s.serviceName())
+	if err != nil {
+		return dnsmessage.Resource{}, err
+	}
+	return dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{Name: name, Type: dnsmessage.TypePTR, Class: classOf(false), TTL: ttlOf(ttlPTR, goodbye)},
+		Body:   &dnsmessage.PTRResource{PTR: target},
+	}, nil
+}
+
+func (s ServiceRecord) srvRecord(goodbye bool) (dnsmessage.Resource, error) {
+	name, err := dnsmessage.NewName(s.instanceName())
+	if err != nil {
+		return dnsmessage.Resource{}, err
+	}
+	target, err := dnsmessage.NewName(s.hostName())
+	if err != nil {
+		return dnsmessage.Resource{}, err
+	}
+	return dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{Name: name, Type: dnsmessage.TypeSRV, Class: classOf(true), TTL: ttlOf(ttlDefault, goodbye)},
+		Body:   &dnsmessage.SRVResource{Priority: 0, Weight: 0, Port: s.Port, Target: target},
+	}, nil
+}
+
+func (s ServiceRecord) txtRecord(goodbye bool) (dnsmessage.Resource, error) {
+	name, err := dnsmessage.NewName(s.instanceName())
+	if err != nil {
+		return dnsmessage.Resource{}, err
+	}
+	return dnsmessage.Resource{
+		Header: dnsmessage.ResourceHeader{Name: name, Type: dnsmessage.TypeTXT, Class: classOf(true), TTL: ttlOf(ttlDefault, goodbye)},
+		Body:   &dnsmessage.TXTResource{TXT: s.txtStrings()},
+	}, nil
+}
+
+// addrRecords returns the A and AAAA records for the service's host name.
+func (s ServiceRecord) addrRecords(goodbye bool) ([]dnsmessage.Resource, error) {
+	host, err := dnsmessage.NewName(s.hostName())
+	if err != nil {
+		return nil, err
+	}
+	var out []dnsmessage.Resource
+	for _, ip := range s.IPv4 {
+		v4 := ip.To4()
+		if v4 == nil {
+			continue
+		}
+		var a [4]byte
+		copy(a[:], v4)
+		out = append(out, dnsmessage.Resource{
+			Header: dnsmessage.ResourceHeader{Name: host, Type: dnsmessage.TypeA, Class: classOf(true), TTL: ttlOf(ttlDefault, goodbye)},
+			Body:   &dnsmessage.AResource{A: a},
+		})
+	}
+	for _, ip := range s.IPv6 {
+		v16 := ip.To16()
+		if v16 == nil || ip.To4() != nil {
+			continue
+		}
+		var a [16]byte
+		copy(a[:], v16)
+		out = append(out, dnsmessage.Resource{
+			Header: dnsmessage.ResourceHeader{Name: host, Type: dnsmessage.TypeAAAA, Class: classOf(true), TTL: ttlOf(ttlDefault, goodbye)},
+			Body:   &dnsmessage.AAAAResource{AAAA: a},
+		})
+	}
+	return out, nil
+}
+
+// records returns the full record set describing the service, in the order used
+// for unsolicited announcements: [sharedPTR, metaPTR, SRV, TXT, A..., AAAA...].
+func (s ServiceRecord) records(goodbye bool) ([]dnsmessage.Resource, error) {
+	ptr, err := s.ptrRecord(goodbye)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := s.metaPTRRecord(goodbye)
+	if err != nil {
+		return nil, err
+	}
+	srv, err := s.srvRecord(goodbye)
+	if err != nil {
+		return nil, err
+	}
+	txt, err := s.txtRecord(goodbye)
+	if err != nil {
+		return nil, err
+	}
+	addrs, err := s.addrRecords(goodbye)
+	if err != nil {
+		return nil, err
+	}
+	out := []dnsmessage.Resource{ptr, meta, srv, txt}
+	return append(out, addrs...), nil
+}
+
+// announcement packs an unsolicited multicast response advertising every
+// service. When goodbye is true the records carry TTL 0 (a departure notice).
+func announcement(services []ServiceRecord, goodbye bool) ([]byte, error) {
+	msg := dnsmessage.Message{
+		Header:  dnsmessage.Header{Response: true, Authoritative: true},
+		Answers: make([]dnsmessage.Resource, 0, len(services)*5),
+	}
+	for _, s := range services {
+		rs, err := s.records(goodbye)
+		if err != nil {
+			return nil, err
+		}
+		msg.Answers = append(msg.Answers, rs...)
+	}
+	return msg.Pack()
+}

--- a/pkg/discovery/mdns/records_test.go
+++ b/pkg/discovery/mdns/records_test.go
@@ -1,0 +1,201 @@
+package mdns
+
+import (
+	"net"
+	"testing"
+
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+func nfsService() ServiceRecord {
+	return ServiceRecord{
+		Instance: "DITTOFS",
+		Service:  "_nfs._tcp",
+		Port:     12049,
+		TXT:      []string{"path=/ditto"},
+		IPv4:     []net.IP{net.IPv4(192, 168, 100, 50)},
+	}
+}
+
+func smbService() ServiceRecord {
+	return ServiceRecord{
+		Instance: "DITTOFS",
+		Service:  "_smb._tcp",
+		Port:     445,
+		IPv4:     []net.IP{net.IPv4(192, 168, 100, 50)},
+	}
+}
+
+// parseAll unpacks a packed message into its records for assertions.
+func parseAll(t *testing.T, msg []byte) (dnsmessage.Header, []dnsmessage.Resource) {
+	t.Helper()
+	var p dnsmessage.Parser
+	h, err := p.Start(msg)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := p.SkipAllQuestions(); err != nil {
+		t.Fatalf("SkipAllQuestions: %v", err)
+	}
+	var recs []dnsmessage.Resource
+	for {
+		r, err := p.AnswerHeader()
+		if err == dnsmessage.ErrSectionDone {
+			break
+		}
+		if err != nil {
+			t.Fatalf("AnswerHeader: %v", err)
+		}
+		body, err := parseBody(&p, r)
+		if err != nil {
+			t.Fatalf("parse body: %v", err)
+		}
+		recs = append(recs, dnsmessage.Resource{Header: r, Body: body})
+	}
+	if err := p.SkipAllAuthorities(); err != nil {
+		t.Fatalf("SkipAllAuthorities: %v", err)
+	}
+	for {
+		r, err := p.AdditionalHeader()
+		if err == dnsmessage.ErrSectionDone {
+			break
+		}
+		if err != nil {
+			t.Fatalf("AdditionalHeader: %v", err)
+		}
+		body, err := parseBody(&p, r)
+		if err != nil {
+			t.Fatalf("parse body: %v", err)
+		}
+		recs = append(recs, dnsmessage.Resource{Header: r, Body: body})
+	}
+	return h, recs
+}
+
+func parseBody(p *dnsmessage.Parser, h dnsmessage.ResourceHeader) (dnsmessage.ResourceBody, error) {
+	switch h.Type {
+	case dnsmessage.TypePTR:
+		b, err := p.PTRResource()
+		return &b, err
+	case dnsmessage.TypeSRV:
+		b, err := p.SRVResource()
+		return &b, err
+	case dnsmessage.TypeTXT:
+		b, err := p.TXTResource()
+		return &b, err
+	case dnsmessage.TypeA:
+		b, err := p.AResource()
+		return &b, err
+	case dnsmessage.TypeAAAA:
+		b, err := p.AAAAResource()
+		return &b, err
+	default:
+		return nil, p.SkipAnswer()
+	}
+}
+
+func TestAnnouncement_NFSRecordsRoundTrip(t *testing.T) {
+	msg, err := announcement([]ServiceRecord{nfsService()}, false)
+	if err != nil {
+		t.Fatalf("announcement: %v", err)
+	}
+	h, recs := parseAll(t, msg)
+	if !h.Response || !h.Authoritative {
+		t.Fatalf("header Response=%v Authoritative=%v, want both true", h.Response, h.Authoritative)
+	}
+
+	var sawPTR, sawMeta, sawSRV, sawTXT, sawA bool
+	for _, r := range recs {
+		switch b := r.Body.(type) {
+		case *dnsmessage.PTRResource:
+			switch r.Header.Name.String() {
+			case "_nfs._tcp.local.":
+				sawPTR = true
+				if b.PTR.String() != "DITTOFS._nfs._tcp.local." {
+					t.Fatalf("PTR target = %q", b.PTR.String())
+				}
+			case "_services._dns-sd._udp.local.":
+				sawMeta = true
+			}
+		case *dnsmessage.SRVResource:
+			sawSRV = true
+			if b.Port != 12049 {
+				t.Fatalf("SRV port = %d, want 12049", b.Port)
+			}
+			if b.Target.String() != "DITTOFS.local." {
+				t.Fatalf("SRV target = %q, want DITTOFS.local.", b.Target.String())
+			}
+		case *dnsmessage.TXTResource:
+			sawTXT = true
+			if len(b.TXT) != 1 || b.TXT[0] != "path=/ditto" {
+				t.Fatalf("TXT = %v, want [path=/ditto]", b.TXT)
+			}
+		case *dnsmessage.AResource:
+			sawA = true
+			if net.IP(b.A[:]).String() != "192.168.100.50" {
+				t.Fatalf("A = %v", net.IP(b.A[:]))
+			}
+		}
+	}
+	if !sawPTR || !sawMeta || !sawSRV || !sawTXT || !sawA {
+		t.Fatalf("missing records: ptr=%v meta=%v srv=%v txt=%v a=%v", sawPTR, sawMeta, sawSRV, sawTXT, sawA)
+	}
+}
+
+func TestGoodbye_TTLZero(t *testing.T) {
+	msg, err := announcement([]ServiceRecord{nfsService()}, true)
+	if err != nil {
+		t.Fatalf("announcement(goodbye): %v", err)
+	}
+	_, recs := parseAll(t, msg)
+	if len(recs) == 0 {
+		t.Fatal("no records")
+	}
+	for _, r := range recs {
+		if r.Header.TTL != 0 {
+			t.Fatalf("goodbye record %s has TTL %d, want 0", r.Header.Name.String(), r.Header.TTL)
+		}
+	}
+}
+
+func TestEmptyTXT_HasOneEmptyString(t *testing.T) {
+	// SMB advertises an empty-but-present TXT record.
+	msg, err := announcement([]ServiceRecord{smbService()}, false)
+	if err != nil {
+		t.Fatalf("announcement: %v", err)
+	}
+	_, recs := parseAll(t, msg)
+	var found bool
+	for _, r := range recs {
+		if b, ok := r.Body.(*dnsmessage.TXTResource); ok {
+			found = true
+			if len(b.TXT) != 1 || b.TXT[0] != "" {
+				t.Fatalf("empty TXT = %v, want one empty string", b.TXT)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no TXT record emitted")
+	}
+}
+
+func TestCacheFlushBit_OnUniqueRecordsOnly(t *testing.T) {
+	msg, err := announcement([]ServiceRecord{nfsService()}, false)
+	if err != nil {
+		t.Fatalf("announcement: %v", err)
+	}
+	_, recs := parseAll(t, msg)
+	for _, r := range recs {
+		flush := uint16(r.Header.Class)&cacheFlushBit != 0
+		switch r.Header.Type {
+		case dnsmessage.TypePTR:
+			if flush {
+				t.Fatalf("PTR %s must not set cache-flush", r.Header.Name.String())
+			}
+		case dnsmessage.TypeSRV, dnsmessage.TypeTXT, dnsmessage.TypeA, dnsmessage.TypeAAAA:
+			if !flush {
+				t.Fatalf("record type %v must set cache-flush", r.Header.Type)
+			}
+		}
+	}
+}

--- a/pkg/discovery/mdns/responder.go
+++ b/pkg/discovery/mdns/responder.go
@@ -44,9 +44,9 @@ var multicastUDPAddrV4 = &net.UDPAddr{IP: net.ParseIP(multicastGroupV4), Port: m
 type Responder struct {
 	mu       sync.Mutex
 	conn     *net.UDPConn
-	pconn    *ipv4.PacketConn  // wraps conn for per-interface group join + multicast send
-	ifaces   []net.Interface   // multicast interfaces the group is joined on
-	sendMu   sync.Mutex        // serializes SetMulticastInterface + WriteTo across interfaces
+	pconn    *ipv4.PacketConn // wraps conn for per-interface group join + multicast send
+	ifaces   []net.Interface  // multicast interfaces the group is joined on
+	sendMu   sync.Mutex       // serializes SetMulticastInterface + WriteTo across interfaces
 	loopCtx  context.Context
 	loopStop context.CancelFunc
 	wg       *sync.WaitGroup // per-socket-generation; isolates Wait from a later generation's Add

--- a/pkg/discovery/mdns/responder.go
+++ b/pkg/discovery/mdns/responder.go
@@ -1,0 +1,298 @@
+package mdns
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/discovery/hostinfo"
+)
+
+const (
+	// multicastGroupV4 / multicastPort are the IPv4 mDNS group and port
+	// (RFC 6762).
+	multicastGroupV4 = "224.0.0.251"
+	multicastPort    = 5353
+
+	// announceInterval is the gap between the two unsolicited announcements
+	// sent on registration (RFC 6762 §8.3 recommends 1s).
+	announceInterval = 1 * time.Second
+
+	// maxDatagram bounds a single inbound mDNS datagram read.
+	maxDatagram = 65535
+)
+
+// multicastUDPAddrV4 is the destination for outgoing announcements/responses.
+var multicastUDPAddrV4 = &net.UDPAddr{IP: net.ParseIP(multicastGroupV4), Port: multicastPort}
+
+// Responder is the shared, process-global mDNS engine. It owns the single
+// 224.0.0.251:5353 socket and a table of registered service records. Each
+// protocol adapter registers its own records through Register and drops them via
+// the returned Handle; the socket and read loop exist only while at least one
+// registration is active (refcounted through the services table).
+//
+// Keeping one responder for the whole process — rather than one per adapter —
+// means a single socket, a single host record set, and cheap live toggles: an
+// adapter enabling/disabling its mDNS advertising just adds/removes its rows
+// without churning the socket (unless it was the last registration).
+type Responder struct {
+	mu       sync.Mutex
+	conn     *net.UDPConn
+	loopCtx  context.Context
+	loopStop context.CancelFunc
+	wg       *sync.WaitGroup // per-socket-generation; isolates Wait from a later generation's Add
+	services map[uint64][]ServiceRecord
+	nextID   uint64
+}
+
+var (
+	sharedOnce sync.Once
+	sharedResp *Responder
+)
+
+// Shared returns the process-global Responder, creating it on first use.
+func Shared() *Responder {
+	sharedOnce.Do(func() {
+		sharedResp = &Responder{services: make(map[uint64][]ServiceRecord)}
+	})
+	return sharedResp
+}
+
+// Handle identifies one registration so it can be withdrawn.
+type Handle struct {
+	r  *Responder
+	id uint64
+}
+
+// Register advertises the given services and returns a Handle to withdraw them.
+// The socket and read loop start lazily on the first active registration. Two
+// unsolicited announcements are sent ~1s apart in the background.
+//
+// Services with no explicit IPv4/IPv6 are filled from the host's interface
+// addresses at registration time.
+func (r *Responder) Register(services []ServiceRecord) (*Handle, error) {
+	services = fillAddresses(services)
+
+	r.mu.Lock()
+	if r.conn == nil {
+		if err := r.startLocked(); err != nil {
+			r.mu.Unlock()
+			return nil, err
+		}
+	}
+	id := r.nextID
+	r.nextID++
+	r.services[id] = services
+	ctx := r.loopCtx
+	wg := r.wg
+	wg.Add(1) // under r.mu so it cannot race a concurrent stop's Wait
+	r.mu.Unlock()
+
+	go func() {
+		defer wg.Done()
+		r.announce(ctx, services)
+	}()
+
+	logger.Info("mDNS advertising registered", "services", len(services))
+	return &Handle{r: r, id: id}, nil
+}
+
+// Unregister withdraws a registration, multicasting a goodbye (TTL 0) for its
+// records and stopping the socket when it was the last one. Safe on a nil or
+// already-withdrawn Handle.
+func (h *Handle) Unregister() {
+	if h == nil || h.r == nil {
+		return
+	}
+	h.r.unregister(h.id)
+}
+
+func (r *Responder) unregister(id uint64) {
+	r.mu.Lock()
+	services, ok := r.services[id]
+	if ok {
+		delete(r.services, id)
+	}
+	last := ok && len(r.services) == 0
+	r.mu.Unlock()
+
+	if !ok {
+		return
+	}
+
+	// Goodbye so caches evict promptly.
+	if msg, err := announcement(services, true); err == nil {
+		r.send(msg, nil)
+	}
+	if last {
+		r.stop()
+	}
+}
+
+// startLocked opens the multicast socket and launches the read loop. Caller
+// holds r.mu.
+func (r *Responder) startLocked() error {
+	// ListenMulticastUDP sets SO_REUSEADDR so we coexist with a host mDNS
+	// responder (e.g. Avahi), and joins the group on the system's default
+	// multicast interface. Multi-interface join is a documented follow-up.
+	conn, err := net.ListenMulticastUDP("udp4", nil, multicastUDPAddrV4)
+	if err != nil {
+		return fmt.Errorf("mdns: listen %s:%d: %w", multicastGroupV4, multicastPort, err)
+	}
+	r.conn = conn
+	r.loopCtx, r.loopStop = context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+	r.wg = wg
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		r.readLoop(conn)
+	}()
+	logger.Info("mDNS responder listening", "group", multicastGroupV4, "port", multicastPort)
+	return nil
+}
+
+// stop cancels the read loop, closes the socket, and waits for this socket
+// generation's goroutines to exit.
+func (r *Responder) stop() {
+	r.mu.Lock()
+	conn := r.conn
+	stop := r.loopStop
+	wg := r.wg
+	r.conn = nil
+	r.loopStop = nil
+	r.loopCtx = nil
+	r.wg = nil
+	r.mu.Unlock()
+
+	if stop != nil {
+		stop()
+	}
+	if conn != nil {
+		_ = conn.Close()
+	}
+	if wg != nil {
+		wg.Wait()
+	}
+	logger.Info("mDNS responder stopped")
+}
+
+func (r *Responder) readLoop(conn *net.UDPConn) {
+	buf := make([]byte, maxDatagram)
+	for {
+		n, src, err := conn.ReadFromUDP(buf)
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+			select {
+			case <-r.loopCtx.Done():
+				return
+			default:
+			}
+			logger.Debug("mdns: read error", "error", err)
+			continue
+		}
+		query := make([]byte, n)
+		copy(query, buf[:n])
+		r.handlePacket(query, src)
+	}
+}
+
+func (r *Responder) handlePacket(query []byte, src *net.UDPAddr) {
+	r.mu.Lock()
+	services := r.snapshotServicesLocked()
+	r.mu.Unlock()
+	if len(services) == 0 {
+		return
+	}
+
+	resp, unicast, ok, err := buildResponse(services, query)
+	if err != nil {
+		logger.Debug("mdns: build response failed", "error", err)
+		return
+	}
+	if !ok {
+		return
+	}
+	if unicast {
+		r.send(resp, src)
+	} else {
+		r.send(resp, nil)
+	}
+}
+
+// announce sends the two startup announcements, bailing if the socket is torn
+// down between them.
+func (r *Responder) announce(ctx context.Context, services []ServiceRecord) {
+	msg, err := announcement(services, false)
+	if err != nil {
+		logger.Warn("mdns: failed to build announcement", "error", err)
+		return
+	}
+	for i := 0; i < 2; i++ {
+		if i > 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(announceInterval):
+			}
+		}
+		r.send(msg, nil)
+	}
+}
+
+// send writes msg to dst, or to the multicast group when dst is nil.
+func (r *Responder) send(msg []byte, dst *net.UDPAddr) {
+	r.mu.Lock()
+	conn := r.conn
+	r.mu.Unlock()
+	if conn == nil {
+		return
+	}
+	target := dst
+	if target == nil {
+		target = multicastUDPAddrV4
+	}
+	if _, err := conn.WriteToUDP(msg, target); err != nil {
+		logger.Debug("mdns: send failed", "error", err)
+	}
+}
+
+// snapshotServicesLocked flattens every registration's records into one slice.
+// Caller holds r.mu.
+func (r *Responder) snapshotServicesLocked() []ServiceRecord {
+	var out []ServiceRecord
+	for _, svcs := range r.services {
+		out = append(out, svcs...)
+	}
+	return out
+}
+
+// fillAddresses returns copies of services, filling any with no explicit
+// address from the host's interface addresses.
+func fillAddresses(services []ServiceRecord) []ServiceRecord {
+	var hostIPs []net.IP
+	out := make([]ServiceRecord, len(services))
+	for i, s := range services {
+		if len(s.IPv4) == 0 && len(s.IPv6) == 0 {
+			if hostIPs == nil {
+				hostIPs = hostinfo.AllHostIPs()
+			}
+			for _, ip := range hostIPs {
+				if ip.To4() != nil {
+					s.IPv4 = append(s.IPv4, ip)
+				} else {
+					s.IPv6 = append(s.IPv6, ip)
+				}
+			}
+		}
+		out[i] = s
+	}
+	return out
+}

--- a/pkg/discovery/mdns/responder.go
+++ b/pkg/discovery/mdns/responder.go
@@ -205,6 +205,12 @@ func (r *Responder) readLoop(conn *net.UDPConn) {
 }
 
 func (r *Responder) handlePacket(query []byte, src *net.UDPAddr) {
+	// Cheap pre-filter: the multicast group carries mostly responses (other
+	// hosts' and our own announcements). Drop those on a header-only parse before
+	// snapshotting the record set.
+	if !isQuery(query) {
+		return
+	}
 	r.mu.Lock()
 	services := r.snapshotServicesLocked()
 	r.mu.Unlock()

--- a/pkg/discovery/mdns/responder.go
+++ b/pkg/discovery/mdns/responder.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/net/ipv4"
+
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/discovery/hostinfo"
 )
@@ -42,6 +44,9 @@ var multicastUDPAddrV4 = &net.UDPAddr{IP: net.ParseIP(multicastGroupV4), Port: m
 type Responder struct {
 	mu       sync.Mutex
 	conn     *net.UDPConn
+	pconn    *ipv4.PacketConn  // wraps conn for per-interface group join + multicast send
+	ifaces   []net.Interface   // multicast interfaces the group is joined on
+	sendMu   sync.Mutex        // serializes SetMulticastInterface + WriteTo across interfaces
 	loopCtx  context.Context
 	loopStop context.CancelFunc
 	wg       *sync.WaitGroup // per-socket-generation; isolates Wait from a later generation's Add
@@ -144,6 +149,22 @@ func (r *Responder) startLocked() error {
 		return fmt.Errorf("mdns: listen %s:%d: %w", multicastGroupV4, multicastPort, err)
 	}
 	r.conn = conn
+
+	// Join the group on every multicast interface so the responder receives
+	// queries arriving on any of them — critical on multi-homed hosts, where the
+	// OS default multicast interface may not be the LAN the clients are on.
+	// ListenMulticastUDP already joined the default interface; re-joining is
+	// harmless. Unicast replies route back normally via WriteToUDP(src).
+	r.pconn = ipv4.NewPacketConn(conn)
+	_ = r.pconn.SetMulticastLoopback(true)
+	r.ifaces = hostinfo.MulticastInterfaces()
+	joined := 0
+	for i := range r.ifaces {
+		if err := r.pconn.JoinGroup(&r.ifaces[i], multicastUDPAddrV4); err == nil {
+			joined++
+		}
+	}
+
 	r.loopCtx, r.loopStop = context.WithCancel(context.Background())
 	loopCtx := r.loopCtx
 	wg := &sync.WaitGroup{}
@@ -154,7 +175,7 @@ func (r *Responder) startLocked() error {
 		defer wg.Done()
 		r.readLoop(conn, loopCtx)
 	}()
-	logger.Info("mDNS responder listening", "group", multicastGroupV4, "port", multicastPort)
+	logger.Info("mDNS responder listening", "group", multicastGroupV4, "port", multicastPort, "interfaces", joined)
 	return nil
 }
 
@@ -173,6 +194,8 @@ func (r *Responder) stop() {
 	stop := r.loopStop
 	wg := r.wg
 	r.conn = nil
+	r.pconn = nil
+	r.ifaces = nil
 	r.loopStop = nil
 	r.loopCtx = nil
 	r.wg = nil
@@ -261,20 +284,40 @@ func (r *Responder) announce(ctx context.Context, services []ServiceRecord) {
 	}
 }
 
-// send writes msg to dst, or to the multicast group when dst is nil.
+// send writes msg unicast to dst, or — when dst is nil — multicasts it out every
+// joined interface so announcements/responses reach clients on all of them.
 func (r *Responder) send(msg []byte, dst *net.UDPAddr) {
 	r.mu.Lock()
 	conn := r.conn
+	pconn := r.pconn
+	ifaces := r.ifaces
 	r.mu.Unlock()
 	if conn == nil {
 		return
 	}
-	target := dst
-	if target == nil {
-		target = multicastUDPAddrV4
+	if dst != nil { // unicast reply — routed normally
+		if _, err := conn.WriteToUDP(msg, dst); err != nil {
+			logger.Debug("mdns: send failed", "error", err)
+		}
+		return
 	}
-	if _, err := conn.WriteToUDP(msg, target); err != nil {
-		logger.Debug("mdns: send failed", "error", err)
+	// Multicast: send out each interface. Serialize because SetMulticastInterface
+	// mutates shared socket state.
+	if pconn == nil || len(ifaces) == 0 {
+		if _, err := conn.WriteToUDP(msg, multicastUDPAddrV4); err != nil {
+			logger.Debug("mdns: send failed", "error", err)
+		}
+		return
+	}
+	r.sendMu.Lock()
+	defer r.sendMu.Unlock()
+	for i := range ifaces {
+		if err := pconn.SetMulticastInterface(&ifaces[i]); err != nil {
+			continue
+		}
+		if _, err := pconn.WriteTo(msg, nil, multicastUDPAddrV4); err != nil {
+			logger.Debug("mdns: multicast send failed", "iface", ifaces[i].Name, "error", err)
+		}
 	}
 }
 

--- a/pkg/discovery/mdns/responder.go
+++ b/pkg/discovery/mdns/responder.go
@@ -145,13 +145,14 @@ func (r *Responder) startLocked() error {
 	}
 	r.conn = conn
 	r.loopCtx, r.loopStop = context.WithCancel(context.Background())
+	loopCtx := r.loopCtx
 	wg := &sync.WaitGroup{}
 	r.wg = wg
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		r.readLoop(conn)
+		r.readLoop(conn, loopCtx)
 	}()
 	logger.Info("mDNS responder listening", "group", multicastGroupV4, "port", multicastPort)
 	return nil
@@ -161,6 +162,13 @@ func (r *Responder) startLocked() error {
 // generation's goroutines to exit.
 func (r *Responder) stop() {
 	r.mu.Lock()
+	// A Register may have raced in between the caller deciding this was the last
+	// registration and acquiring the lock here; if so, keep the socket up so its
+	// records stay advertised rather than tearing down under it.
+	if len(r.services) != 0 {
+		r.mu.Unlock()
+		return
+	}
 	conn := r.conn
 	stop := r.loopStop
 	wg := r.wg
@@ -182,7 +190,7 @@ func (r *Responder) stop() {
 	logger.Info("mDNS responder stopped")
 }
 
-func (r *Responder) readLoop(conn *net.UDPConn) {
+func (r *Responder) readLoop(conn *net.UDPConn, loopCtx context.Context) {
 	buf := make([]byte, maxDatagram)
 	for {
 		n, src, err := conn.ReadFromUDP(buf)
@@ -191,7 +199,7 @@ func (r *Responder) readLoop(conn *net.UDPConn) {
 				return
 			}
 			select {
-			case <-r.loopCtx.Done():
+			case <-loopCtx.Done():
 				return
 			default:
 			}

--- a/pkg/discovery/mdns/responder_test.go
+++ b/pkg/discovery/mdns/responder_test.go
@@ -1,0 +1,87 @@
+package mdns
+
+import (
+	"net"
+	"testing"
+)
+
+func TestFillAddresses_KeepsExplicitIPs(t *testing.T) {
+	in := []ServiceRecord{{
+		Instance: "DITTOFS",
+		Service:  "_smb._tcp",
+		Port:     445,
+		IPv4:     []net.IP{net.IPv4(10, 0, 0, 5)},
+	}}
+	out := fillAddresses(in)
+	if len(out) != 1 || len(out[0].IPv4) != 1 || !out[0].IPv4[0].Equal(net.IPv4(10, 0, 0, 5)) {
+		t.Fatalf("explicit IPs should be preserved, got %+v", out)
+	}
+}
+
+func TestFillAddresses_FillsWhenEmpty(t *testing.T) {
+	// Records with no address get the host's IPs (may be empty in a sandbox;
+	// the important property is it does not panic and leaves explicit records
+	// untouched).
+	in := []ServiceRecord{{Instance: "DITTOFS", Service: "_nfs._tcp", Port: 12049}}
+	out := fillAddresses(in)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(out))
+	}
+	// Input slice must not be mutated (fillAddresses returns copies).
+	if len(in[0].IPv4) != 0 {
+		t.Fatal("fillAddresses mutated the input record")
+	}
+}
+
+// TestRegisterUnregister_Lifecycle exercises the real socket path where the
+// environment allows binding the mDNS group; it skips otherwise so it never
+// flakes on a headless runner with no multicast interface.
+func TestRegisterUnregister_Lifecycle(t *testing.T) {
+	r := &Responder{services: make(map[uint64][]ServiceRecord)}
+
+	h, err := r.Register([]ServiceRecord{{
+		Instance: "DITTOFS",
+		Service:  "_smb._tcp",
+		Port:     445,
+		IPv4:     []net.IP{net.IPv4(127, 0, 0, 1)},
+	}})
+	if err != nil {
+		t.Skipf("cannot bind mDNS socket in this environment: %v", err)
+	}
+
+	r.mu.Lock()
+	connUp := r.conn != nil
+	r.mu.Unlock()
+	if !connUp {
+		t.Fatal("socket should be open after Register")
+	}
+
+	// Second registration reuses the same socket.
+	h2, err := r.Register([]ServiceRecord{{
+		Instance: "DITTOFS",
+		Service:  "_nfs._tcp",
+		Port:     12049,
+		IPv4:     []net.IP{net.IPv4(127, 0, 0, 1)},
+	}})
+	if err != nil {
+		t.Fatalf("second Register: %v", err)
+	}
+
+	// Dropping one registration keeps the socket (refcount > 0).
+	h.Unregister()
+	r.mu.Lock()
+	stillUp := r.conn != nil
+	r.mu.Unlock()
+	if !stillUp {
+		t.Fatal("socket should stay open while a registration remains")
+	}
+
+	// Dropping the last registration closes the socket.
+	h2.Unregister()
+	r.mu.Lock()
+	down := r.conn == nil
+	r.mu.Unlock()
+	if !down {
+		t.Fatal("socket should be closed after the last Unregister")
+	}
+}

--- a/pkg/discovery/mdns/service.go
+++ b/pkg/discovery/mdns/service.go
@@ -1,0 +1,86 @@
+// Package mdns implements a minimal multicast-DNS / DNS-SD responder
+// (RFC 6762 / RFC 6763) that advertises DittoFS's SMB and NFS services so they
+// appear in macOS Finder and Linux/Avahi file browsers. It is a from-scratch
+// responder built on golang.org/x/net/dns/dnsmessage — it advertises a fixed
+// set of locally-owned service records and answers queries for them; it does
+// not browse or resolve other hosts' services.
+//
+// A single process-global Responder owns the one 224.0.0.251:5353 socket; each
+// protocol adapter registers only its own ServiceRecords through it, so the two
+// adapters share one responder and one host record set (see responder.go).
+package mdns
+
+import "net"
+
+// DefaultDomain is the DNS-SD domain for link-local multicast DNS.
+const DefaultDomain = "local"
+
+// ServiceRecord describes one DNS-SD service instance to advertise, e.g. the
+// SMB service on this host. It is the unit an adapter registers with the
+// Responder.
+type ServiceRecord struct {
+	// Instance is the service instance label, typically the server name
+	// (e.g. "DITTOFS"). It is a single DNS label; dots are not supported.
+	Instance string
+
+	// Service is the DNS-SD service type, e.g. "_smb._tcp" or "_nfs._tcp".
+	Service string
+
+	// Domain defaults to DefaultDomain ("local") when empty.
+	Domain string
+
+	// Port is the TCP port the service listens on (the adapter's real bound
+	// port — 445/12445 for SMB, 12049 for NFS).
+	Port uint16
+
+	// TXT holds DNS-SD TXT record strings, e.g. {"path=/ditto"} or
+	// {"model=RackMac"}. When empty, a single zero-length string is advertised
+	// (an empty but present TXT record, as DNS-SD requires).
+	TXT []string
+
+	// IPv4/IPv6 are the host addresses advertised in A/AAAA records for the
+	// service's target host. When both are empty the responder fills them from
+	// the host's interfaces at registration time.
+	IPv4 []net.IP
+	IPv6 []net.IP
+}
+
+func (s ServiceRecord) domain() string {
+	if s.Domain == "" {
+		return DefaultDomain
+	}
+	return s.Domain
+}
+
+// instanceName is the fully-qualified DNS-SD instance name,
+// e.g. "DITTOFS._smb._tcp.local."
+func (s ServiceRecord) instanceName() string {
+	return s.Instance + "." + s.Service + "." + s.domain() + "."
+}
+
+// serviceName is the fully-qualified service type,
+// e.g. "_smb._tcp.local." — the name browsers query with a PTR.
+func (s ServiceRecord) serviceName() string {
+	return s.Service + "." + s.domain() + "."
+}
+
+// hostName is the target host name for the SRV/A/AAAA records,
+// e.g. "DITTOFS.local."
+func (s ServiceRecord) hostName() string {
+	return s.Instance + "." + s.domain() + "."
+}
+
+// metaName is the DNS-SD service-type enumeration name,
+// e.g. "_services._dns-sd._udp.local."
+func (s ServiceRecord) metaName() string {
+	return "_services._dns-sd._udp." + s.domain() + "."
+}
+
+// txtStrings returns the TXT strings to advertise, guaranteeing at least one
+// (possibly empty) string so the TXT record is present per DNS-SD.
+func (s ServiceRecord) txtStrings() []string {
+	if len(s.TXT) == 0 {
+		return []string{""}
+	}
+	return s.TXT
+}

--- a/pkg/discovery/mdns/sidecar.go
+++ b/pkg/discovery/mdns/sidecar.go
@@ -34,8 +34,10 @@ func NewSidecar(services []ServiceRecord) *Sidecar {
 // Name implements auxsvc.Service.
 func (s *Sidecar) Name() string { return SidecarName }
 
-// Start registers the services with the shared Responder (idempotent).
-func (s *Sidecar) Start(context.Context) error {
+// Start registers the services with the shared Responder (idempotent). If ctx is
+// cancelled without an explicit Stop, the registration is withdrawn — matching
+// the ctx-driven lifetime of the other auxiliary services.
+func (s *Sidecar) Start(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.handle != nil {
@@ -46,6 +48,10 @@ func (s *Sidecar) Start(context.Context) error {
 		return err
 	}
 	s.handle = h
+	go func() {
+		<-ctx.Done()
+		_ = s.Stop(context.Background())
+	}()
 	return nil
 }
 

--- a/pkg/discovery/mdns/sidecar.go
+++ b/pkg/discovery/mdns/sidecar.go
@@ -1,0 +1,61 @@
+package mdns
+
+import (
+	"context"
+	"sync"
+)
+
+// SidecarName is the auxsvc.Group key used for the mDNS advertiser on every
+// adapter.
+const SidecarName = "mdns"
+
+// Sidecar advertises a fixed set of services through the shared Responder for
+// the lifetime of one adapter. It satisfies the adapter auxsvc.Service interface
+// structurally (Name/Start/Stop) so the discovery package needs no dependency on
+// the adapter layer.
+//
+// Start/Stop ignore the context: the shared Responder's socket lifetime is
+// reference-counted across all registrations, not tied to any single adapter's
+// context. The adapter's auxsvc.Group calls Stop (Unregister) on shutdown or a
+// live disable.
+type Sidecar struct {
+	services []ServiceRecord
+
+	mu     sync.Mutex
+	handle *Handle
+}
+
+// NewSidecar builds an mDNS advertiser for the given services. It registers with
+// the process-global Responder on Start.
+func NewSidecar(services []ServiceRecord) *Sidecar {
+	return &Sidecar{services: services}
+}
+
+// Name implements auxsvc.Service.
+func (s *Sidecar) Name() string { return SidecarName }
+
+// Start registers the services with the shared Responder (idempotent).
+func (s *Sidecar) Start(context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.handle != nil {
+		return nil
+	}
+	h, err := Shared().Register(s.services)
+	if err != nil {
+		return err
+	}
+	s.handle = h
+	return nil
+}
+
+// Stop withdraws the services (idempotent).
+func (s *Sidecar) Stop(context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.handle != nil {
+		s.handle.Unregister()
+		s.handle = nil
+	}
+	return nil
+}

--- a/pkg/discovery/wsd/messages.go
+++ b/pkg/discovery/wsd/messages.go
@@ -6,6 +6,22 @@ import (
 	"strings"
 )
 
+// xmlEscaper escapes the five XML metacharacters. The SOAP messages are built by
+// literal string substitution (Windows is prefix/order-sensitive, so no
+// encoding/xml marshalling), which does no escaping of its own — so any value
+// that can contain XML metacharacters (the inbound MessageID echoed into
+// RelatesTo, the OS hostname / NetBIOS names) must be run through esc first, or
+// a stray & / < makes the envelope non-well-formed and clients discard it.
+var xmlEscaper = strings.NewReplacer(
+	"&", "&amp;",
+	"<", "&lt;",
+	">", "&gt;",
+	`"`, "&quot;",
+	"'", "&apos;",
+)
+
+func esc(s string) string { return xmlEscaper.Replace(s) }
+
 // WS-Discovery / WS-Addressing constants.
 const (
 	nsDiscovery = "http://schemas.xmlsoap.org/ws/2005/04/discovery"
@@ -56,9 +72,9 @@ func announce(action, element string, e Endpoint, msgNum uint64) []byte {
 		"{inst}", strconv.FormatUint(e.InstanceID, 10),
 		"{num}", strconv.FormatUint(msgNum, 10),
 		"{element}", element,
-		"{uuid}", e.UUID,
-		"{types}", e.Types,
-		"{xaddrs}", e.XAddrs,
+		"{uuid}", esc(e.UUID),
+		"{types}", e.Types, // constant QName list — no XML metacharacters
+		"{xaddrs}", esc(e.XAddrs),
 		"{mv}", strconv.Itoa(e.MetadataVersion),
 	)
 	return []byte(r.Replace(envelopeHeader +
@@ -91,15 +107,15 @@ func match(action, matchesEl, matchEl, relatesTo string, e Endpoint, msgNum uint
 	r := strings.NewReplacer(
 		"{action}", action,
 		"{msgid}", MessageID(),
-		"{relates}", relatesTo,
+		"{relates}", esc(relatesTo), // inbound MessageID — untrusted
 		"{to}", toAnonymous,
 		"{inst}", strconv.FormatUint(e.InstanceID, 10),
 		"{num}", strconv.FormatUint(msgNum, 10),
 		"{matches}", matchesEl,
 		"{match}", matchEl,
-		"{uuid}", e.UUID,
-		"{types}", e.Types,
-		"{xaddrs}", e.XAddrs,
+		"{uuid}", esc(e.UUID),
+		"{types}", e.Types, // constant QName list — no XML metacharacters
+		"{xaddrs}", esc(e.XAddrs),
 		"{mv}", strconv.Itoa(e.MetadataVersion),
 	)
 	return []byte(r.Replace(envelopeHeader +

--- a/pkg/discovery/wsd/messages.go
+++ b/pkg/discovery/wsd/messages.go
@@ -1,0 +1,221 @@
+package wsd
+
+import (
+	"encoding/xml"
+	"strconv"
+	"strings"
+)
+
+func utoa(v uint64) string { return strconv.FormatUint(v, 10) }
+func itoa(v int) string    { return strconv.Itoa(v) }
+
+// WS-Discovery / WS-Addressing constants.
+const (
+	nsDiscovery = "http://schemas.xmlsoap.org/ws/2005/04/discovery"
+	toDiscovery = "urn:schemas-xmlsoap-org:ws:2005:04:discovery"
+	toAnonymous = "http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous"
+
+	actionHello        = nsDiscovery + "/Hello"
+	actionBye          = nsDiscovery + "/Bye"
+	actionProbe        = nsDiscovery + "/Probe"
+	actionProbeMatches = nsDiscovery + "/ProbeMatches"
+	actionResolve      = nsDiscovery + "/Resolve"
+	actionResolveMatch = nsDiscovery + "/ResolveMatches"
+
+	// TypesComputer is what a Windows file server advertises: a Device that is a
+	// Computer. The prefixes are declared on the envelope below.
+	TypesComputer = "dp:Device pub:Computer"
+)
+
+// Endpoint is the advertised identity carried in Hello/Bye/ProbeMatch/
+// ResolveMatch and referenced by the metadata endpoint.
+type Endpoint struct {
+	UUID            string // "urn:uuid:…" — stable endpoint reference
+	Types           string // e.g. TypesComputer
+	XAddrs          string // metadata transport URL, e.g. "http://<ip>:5357/<uuid>/"
+	MetadataVersion int
+	InstanceID      uint64 // AppSequence InstanceId (stable per process run)
+}
+
+// envelopeOpen is the SOAP envelope with every namespace WS-Discovery + the
+// Windows publication schema needs declared up front, so element/Types prefixes
+// (dp:, pub:) are always in scope.
+const envelopeHeader = `<?xml version="1.0" encoding="utf-8"?>` +
+	`<s:Envelope` +
+	` xmlns:s="http://www.w3.org/2003/05/soap-envelope"` +
+	` xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"` +
+	` xmlns:d="http://schemas.xmlsoap.org/ws/2005/04/discovery"` +
+	` xmlns:dp="http://schemas.xmlsoap.org/ws/2006/02/devprof"` +
+	` xmlns:pub="http://schemas.microsoft.com/windows/pub/2005/07">`
+
+// announce builds a Hello or Bye. The body differs only by element name (Hello
+// carries the full endpoint; Bye needs only the reference, but including the
+// rest is harmless and matches wsdd).
+func announce(action, element string, e Endpoint, msgNum uint64) []byte {
+	r := strings.NewReplacer(
+		"{action}", action,
+		"{msgid}", MessageID(),
+		"{to}", toDiscovery,
+		"{inst}", utoa(e.InstanceID),
+		"{num}", utoa(msgNum),
+		"{element}", element,
+		"{uuid}", e.UUID,
+		"{types}", e.Types,
+		"{xaddrs}", e.XAddrs,
+		"{mv}", itoa(e.MetadataVersion),
+	)
+	return []byte(r.Replace(envelopeHeader +
+		`<s:Header>` +
+		`<a:Action>{action}</a:Action>` +
+		`<a:MessageID>{msgid}</a:MessageID>` +
+		`<a:To>{to}</a:To>` +
+		`<d:AppSequence InstanceId="{inst}" MessageNumber="{num}"></d:AppSequence>` +
+		`</s:Header>` +
+		`<s:Body>` +
+		`<d:{element}>` +
+		`<a:EndpointReference><a:Address>{uuid}</a:Address></a:EndpointReference>` +
+		`<d:Types>{types}</d:Types>` +
+		`<d:XAddrs>{xaddrs}</d:XAddrs>` +
+		`<d:MetadataVersion>{mv}</d:MetadataVersion>` +
+		`</d:{element}>` +
+		`</s:Body>` +
+		`</s:Envelope>`))
+}
+
+// Hello announces the host's presence (multicast on start).
+func Hello(e Endpoint, msgNum uint64) []byte { return announce(actionHello, "Hello", e, msgNum) }
+
+// Bye announces the host's departure (multicast on stop).
+func Bye(e Endpoint, msgNum uint64) []byte { return announce(actionBye, "Bye", e, msgNum) }
+
+// match builds a ProbeMatches or ResolveMatches reply correlated to the inbound
+// message via wsa:RelatesTo, sent unicast to the querier.
+func match(action, matchesEl, matchEl, relatesTo string, e Endpoint, msgNum uint64) []byte {
+	r := strings.NewReplacer(
+		"{action}", action,
+		"{msgid}", MessageID(),
+		"{relates}", relatesTo,
+		"{to}", toAnonymous,
+		"{inst}", utoa(e.InstanceID),
+		"{num}", utoa(msgNum),
+		"{matches}", matchesEl,
+		"{match}", matchEl,
+		"{uuid}", e.UUID,
+		"{types}", e.Types,
+		"{xaddrs}", e.XAddrs,
+		"{mv}", itoa(e.MetadataVersion),
+	)
+	return []byte(r.Replace(envelopeHeader +
+		`<s:Header>` +
+		`<a:Action>{action}</a:Action>` +
+		`<a:MessageID>{msgid}</a:MessageID>` +
+		`<a:RelatesTo>{relates}</a:RelatesTo>` +
+		`<a:To>{to}</a:To>` +
+		`<d:AppSequence InstanceId="{inst}" MessageNumber="{num}"></d:AppSequence>` +
+		`</s:Header>` +
+		`<s:Body>` +
+		`<d:{matches}>` +
+		`<d:{match}>` +
+		`<a:EndpointReference><a:Address>{uuid}</a:Address></a:EndpointReference>` +
+		`<d:Types>{types}</d:Types>` +
+		`<d:XAddrs>{xaddrs}</d:XAddrs>` +
+		`<d:MetadataVersion>{mv}</d:MetadataVersion>` +
+		`</d:{match}>` +
+		`</d:{matches}>` +
+		`</s:Body>` +
+		`</s:Envelope>`))
+}
+
+// ProbeMatch replies to a Probe.
+func ProbeMatch(e Endpoint, relatesTo string, msgNum uint64) []byte {
+	return match(actionProbeMatches, "ProbeMatches", "ProbeMatch", relatesTo, e, msgNum)
+}
+
+// ResolveMatch replies to a Resolve.
+func ResolveMatch(e Endpoint, relatesTo string, msgNum uint64) []byte {
+	return match(actionResolveMatch, "ResolveMatches", "ResolveMatch", relatesTo, e, msgNum)
+}
+
+// --- Inbound parsing ---
+
+// inboundKind classifies a parsed WS-Discovery message.
+type inboundKind int
+
+const (
+	kindUnknown inboundKind = iota
+	kindProbe
+	kindResolve
+)
+
+// inbound is the parsed subset of a WS-Discovery request we act on.
+type inbound struct {
+	kind      inboundKind
+	messageID string // wsa:MessageID, echoed back in wsa:RelatesTo
+	types     string // Probe: requested Types (may be empty = match all)
+	address   string // Resolve: the EndpointReference address being resolved
+}
+
+// xmlEnvelope mirrors the inbound SOAP we parse. encoding/xml matches by local
+// element name regardless of the sender's namespace prefixes, which is what we
+// want across heterogeneous Windows clients.
+type xmlEnvelope struct {
+	XMLName xml.Name `xml:"Envelope"`
+	Header  struct {
+		Action    string `xml:"Action"`
+		MessageID string `xml:"MessageID"`
+	} `xml:"Header"`
+	Body struct {
+		Probe *struct {
+			Types string `xml:"Types"`
+		} `xml:"Probe"`
+		Resolve *struct {
+			EndpointReference struct {
+				Address string `xml:"Address"`
+			} `xml:"EndpointReference"`
+		} `xml:"Resolve"`
+	} `xml:"Body"`
+}
+
+// parseInbound extracts the actionable fields from a WS-Discovery datagram.
+func parseInbound(data []byte) (inbound, error) {
+	var env xmlEnvelope
+	if err := xml.Unmarshal(data, &env); err != nil {
+		return inbound{}, err
+	}
+	in := inbound{messageID: strings.TrimSpace(env.Header.MessageID)}
+	action := strings.TrimSpace(env.Header.Action)
+	switch {
+	case action == actionProbe || env.Body.Probe != nil:
+		in.kind = kindProbe
+		if env.Body.Probe != nil {
+			in.types = strings.TrimSpace(env.Body.Probe.Types)
+		}
+	case action == actionResolve || env.Body.Resolve != nil:
+		in.kind = kindResolve
+		if env.Body.Resolve != nil {
+			in.address = strings.TrimSpace(env.Body.Resolve.EndpointReference.Address)
+		}
+	}
+	return in, nil
+}
+
+// probeMatchesTypes reports whether a Probe with the given requested Types
+// should match a Computer/Device host. An empty Types matches everything; a
+// non-empty one matches when one of its space-separated QNames has a local part
+// of exactly "Device" or "Computer" (prefix-agnostic). This deliberately does
+// not match unrelated device types such as "i:PrintDevice".
+func probeMatchesTypes(requested string) bool {
+	if strings.TrimSpace(requested) == "" {
+		return true
+	}
+	for _, tok := range strings.Fields(requested) {
+		local := tok
+		if i := strings.LastIndexByte(tok, ':'); i >= 0 {
+			local = tok[i+1:]
+		}
+		if strings.EqualFold(local, "Device") || strings.EqualFold(local, "Computer") {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/discovery/wsd/messages.go
+++ b/pkg/discovery/wsd/messages.go
@@ -6,9 +6,6 @@ import (
 	"strings"
 )
 
-func utoa(v uint64) string { return strconv.FormatUint(v, 10) }
-func itoa(v int) string    { return strconv.Itoa(v) }
-
 // WS-Discovery / WS-Addressing constants.
 const (
 	nsDiscovery = "http://schemas.xmlsoap.org/ws/2005/04/discovery"
@@ -56,13 +53,13 @@ func announce(action, element string, e Endpoint, msgNum uint64) []byte {
 		"{action}", action,
 		"{msgid}", MessageID(),
 		"{to}", toDiscovery,
-		"{inst}", utoa(e.InstanceID),
-		"{num}", utoa(msgNum),
+		"{inst}", strconv.FormatUint(e.InstanceID, 10),
+		"{num}", strconv.FormatUint(msgNum, 10),
 		"{element}", element,
 		"{uuid}", e.UUID,
 		"{types}", e.Types,
 		"{xaddrs}", e.XAddrs,
-		"{mv}", itoa(e.MetadataVersion),
+		"{mv}", strconv.Itoa(e.MetadataVersion),
 	)
 	return []byte(r.Replace(envelopeHeader +
 		`<s:Header>` +
@@ -96,14 +93,14 @@ func match(action, matchesEl, matchEl, relatesTo string, e Endpoint, msgNum uint
 		"{msgid}", MessageID(),
 		"{relates}", relatesTo,
 		"{to}", toAnonymous,
-		"{inst}", utoa(e.InstanceID),
-		"{num}", utoa(msgNum),
+		"{inst}", strconv.FormatUint(e.InstanceID, 10),
+		"{num}", strconv.FormatUint(msgNum, 10),
 		"{matches}", matchesEl,
 		"{match}", matchEl,
 		"{uuid}", e.UUID,
 		"{types}", e.Types,
 		"{xaddrs}", e.XAddrs,
-		"{mv}", itoa(e.MetadataVersion),
+		"{mv}", strconv.Itoa(e.MetadataVersion),
 	)
 	return []byte(r.Replace(envelopeHeader +
 		`<s:Header>` +

--- a/pkg/discovery/wsd/messages_test.go
+++ b/pkg/discovery/wsd/messages_test.go
@@ -1,0 +1,148 @@
+package wsd
+
+import (
+	"strings"
+	"testing"
+)
+
+func testEndpoint() Endpoint {
+	return Endpoint{
+		UUID:            "urn:uuid:0d117f5d-1609-4000-8000-000000001609",
+		Types:           TypesComputer,
+		XAddrs:          "http://192.168.100.50:5357/0d117f5d-1609-4000-8000-000000001609/",
+		MetadataVersion: 1,
+		InstanceID:      1700000000,
+	}
+}
+
+func TestEndpointUUID_StableForSameName(t *testing.T) {
+	a := endpointUUIDFor("VM2")
+	b := endpointUUIDFor("VM2")
+	if a != b {
+		t.Fatalf("endpoint UUID not stable: %q vs %q", a, b)
+	}
+	if endpointUUIDFor("VM2") == endpointUUIDFor("OTHER") {
+		t.Fatal("different names should yield different UUIDs")
+	}
+	if !strings.HasPrefix(a, "urn:uuid:") {
+		t.Fatalf("UUID missing urn:uuid: prefix: %q", a)
+	}
+}
+
+func TestMessageID_FreshAndPrefixed(t *testing.T) {
+	if MessageID() == MessageID() {
+		t.Fatal("MessageID should be unique per call")
+	}
+	if !strings.HasPrefix(MessageID(), "urn:uuid:") {
+		t.Fatal("MessageID missing urn:uuid: prefix")
+	}
+}
+
+func TestHello_ContainsRequiredElements(t *testing.T) {
+	msg := string(Hello(testEndpoint(), 1))
+	for _, want := range []string{
+		actionHello,
+		"<a:MessageID>",
+		"urn:uuid:0d117f5d-1609-4000-8000-000000001609",
+		"dp:Device pub:Computer",
+		"http://192.168.100.50:5357/",
+		"<d:MetadataVersion>1</d:MetadataVersion>",
+		`InstanceId="1700000000"`,
+		`xmlns:pub="http://schemas.microsoft.com/windows/pub/2005/07"`,
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("Hello missing %q\n---\n%s", want, msg)
+		}
+	}
+}
+
+func TestProbeMatch_CorrelatesWithRelatesTo(t *testing.T) {
+	relatesTo := "urn:uuid:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	msg := string(ProbeMatch(testEndpoint(), relatesTo, 2))
+	if !strings.Contains(msg, actionProbeMatches) {
+		t.Error("ProbeMatch missing ProbeMatches action")
+	}
+	if !strings.Contains(msg, "<a:RelatesTo>"+relatesTo+"</a:RelatesTo>") {
+		t.Errorf("ProbeMatch missing RelatesTo correlation\n%s", msg)
+	}
+	if !strings.Contains(msg, "<d:ProbeMatch>") {
+		t.Error("ProbeMatch missing ProbeMatch element")
+	}
+	if !strings.Contains(msg, toAnonymous) {
+		t.Error("ProbeMatch should be addressed to the anonymous role (unicast reply)")
+	}
+}
+
+func TestResolveMatch_CarriesXAddrs(t *testing.T) {
+	msg := string(ResolveMatch(testEndpoint(), "urn:uuid:1234", 3))
+	if !strings.Contains(msg, actionResolveMatch) {
+		t.Error("ResolveMatch missing ResolveMatches action")
+	}
+	if !strings.Contains(msg, "<d:XAddrs>http://192.168.100.50:5357/") {
+		t.Errorf("ResolveMatch missing XAddrs (needed for the metadata GET)\n%s", msg)
+	}
+}
+
+func TestParseInbound_Probe(t *testing.T) {
+	probe := `<?xml version="1.0"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+ xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+ xmlns:d="http://schemas.xmlsoap.org/ws/2005/04/discovery">
+ <s:Header>
+  <a:Action>http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe</a:Action>
+  <a:MessageID>urn:uuid:probe-1</a:MessageID>
+ </s:Header>
+ <s:Body><d:Probe><d:Types>d:Device</d:Types></d:Probe></s:Body>
+</s:Envelope>`
+	in, err := parseInbound([]byte(probe))
+	if err != nil {
+		t.Fatalf("parseInbound: %v", err)
+	}
+	if in.kind != kindProbe {
+		t.Fatalf("kind = %v, want Probe", in.kind)
+	}
+	if in.messageID != "urn:uuid:probe-1" {
+		t.Fatalf("messageID = %q", in.messageID)
+	}
+	if !probeMatchesTypes(in.types) {
+		t.Fatalf("Device probe should match, types=%q", in.types)
+	}
+}
+
+func TestParseInbound_ResolveAddress(t *testing.T) {
+	resolve := `<?xml version="1.0"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+ xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+ xmlns:d="http://schemas.xmlsoap.org/ws/2005/04/discovery">
+ <s:Header>
+  <a:Action>http://schemas.xmlsoap.org/ws/2005/04/discovery/Resolve</a:Action>
+  <a:MessageID>urn:uuid:resolve-1</a:MessageID>
+ </s:Header>
+ <s:Body><d:Resolve><a:EndpointReference><a:Address>urn:uuid:target-xyz</a:Address></a:EndpointReference></d:Resolve></s:Body>
+</s:Envelope>`
+	in, err := parseInbound([]byte(resolve))
+	if err != nil {
+		t.Fatalf("parseInbound: %v", err)
+	}
+	if in.kind != kindResolve {
+		t.Fatalf("kind = %v, want Resolve", in.kind)
+	}
+	if in.address != "urn:uuid:target-xyz" {
+		t.Fatalf("resolve address = %q", in.address)
+	}
+}
+
+func TestProbeMatchesTypes(t *testing.T) {
+	cases := map[string]bool{
+		"":                       true, // empty matches all
+		"d:Device":               true,
+		"pub:Computer":           true,
+		"dp:Device pub:Computer": true,
+		"i:PrintDevice":          false,
+	}
+	for types, want := range cases {
+		if got := probeMatchesTypes(types); got != want {
+			t.Errorf("probeMatchesTypes(%q) = %v, want %v", types, got, want)
+		}
+	}
+}

--- a/pkg/discovery/wsd/messages_test.go
+++ b/pkg/discovery/wsd/messages_test.go
@@ -83,6 +83,18 @@ func TestResolveMatch_CarriesXAddrs(t *testing.T) {
 	}
 }
 
+func TestProbeMatch_EscapesUntrustedRelatesTo(t *testing.T) {
+	// A LAN client can send a MessageID that decodes to text with XML
+	// metacharacters; echoing it unescaped into RelatesTo would break the reply.
+	msg := string(ProbeMatch(testEndpoint(), "urn:uuid:x&y<z", 1))
+	if !strings.Contains(msg, "<a:RelatesTo>urn:uuid:x&amp;y&lt;z</a:RelatesTo>") {
+		t.Errorf("RelatesTo not XML-escaped:\n%s", msg)
+	}
+	if strings.Contains(msg, "x&y<z") {
+		t.Error("raw unescaped metacharacters leaked into the message")
+	}
+}
+
 func TestParseInbound_Probe(t *testing.T) {
 	probe := `<?xml version="1.0"?>
 <s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"

--- a/pkg/discovery/wsd/messages_test.go
+++ b/pkg/discovery/wsd/messages_test.go
@@ -30,10 +30,11 @@ func TestEndpointUUID_StableForSameName(t *testing.T) {
 }
 
 func TestMessageID_FreshAndPrefixed(t *testing.T) {
-	if MessageID() == MessageID() {
+	a, b := MessageID(), MessageID()
+	if a == b {
 		t.Fatal("MessageID should be unique per call")
 	}
-	if !strings.HasPrefix(MessageID(), "urn:uuid:") {
+	if !strings.HasPrefix(a, "urn:uuid:") {
 		t.Fatal("MessageID missing urn:uuid: prefix")
 	}
 }

--- a/pkg/discovery/wsd/metadata.go
+++ b/pkg/discovery/wsd/metadata.go
@@ -24,6 +24,7 @@ type metadataBuilder struct {
 	uuid      string // "urn:uuid:…"
 	name      string // computer / friendly name
 	workgroup string // NetBIOS domain or workgroup label
+	isDomain  bool   // true => "Domain:", false => "Workgroup:"
 }
 
 // buildGetResponse renders the WS-Transfer GetResponse. It is kept as an
@@ -31,14 +32,23 @@ type metadataBuilder struct {
 // WS-Transfer/devprof parser is sensitive to namespace prefixes and element
 // ordering; the template pins both.
 func (b metadataBuilder) buildGetResponse(relatesTo string) []byte {
+	membership := "Workgroup"
+	if b.isDomain {
+		membership = "Domain"
+	}
+	// Escape every substituted value: relatesTo is the (untrusted) inbound
+	// MessageID, and name/workgroup come from the OS hostname / NetBIOS domain —
+	// an unescaped & or < would make the whole envelope non-well-formed and the
+	// client would silently discard it.
 	r := strings.NewReplacer(
 		"{action}", actionGetResponse,
 		"{msgid}", MessageID(),
-		"{relates}", relatesTo,
+		"{relates}", esc(relatesTo),
 		"{to}", toAnonymous,
-		"{uuid}", b.uuid,
-		"{name}", b.name,
-		"{workgroup}", b.workgroup,
+		"{uuid}", esc(b.uuid),
+		"{name}", esc(b.name),
+		"{membership}", membership,
+		"{workgroup}", esc(b.workgroup),
 	)
 	return []byte(r.Replace(`<?xml version="1.0" encoding="utf-8"?>` +
 		`<s:Envelope` +
@@ -75,7 +85,7 @@ func (b metadataBuilder) buildGetResponse(relatesTo string) []byte {
 		`<a:EndpointReference><a:Address>{uuid}</a:Address></a:EndpointReference>` +
 		`<dp:Types>pub:Computer</dp:Types>` +
 		`<dp:ServiceId>{uuid}</dp:ServiceId>` +
-		`<pub:Computer>{name}/Workgroup:{workgroup}</pub:Computer>` +
+		`<pub:Computer>{name}/{membership}:{workgroup}</pub:Computer>` +
 		`</dp:Host>` +
 		`</dp:Relationship>` +
 		`</mex:MetadataSection>` +

--- a/pkg/discovery/wsd/metadata.go
+++ b/pkg/discovery/wsd/metadata.go
@@ -1,0 +1,112 @@
+package wsd
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/marmos91/dittofs/internal/logger"
+)
+
+// MetadataPort is the TCP port for the WS-Transfer metadata exchange. Windows
+// fetches device metadata here after a ProbeMatch/ResolveMatch, and it is this
+// exchange — specifically the pub:Computer relationship it returns — that makes
+// Explorer render the host as a Computer rather than a generic device.
+const MetadataPort = 5357
+
+const (
+	actionGet         = "http://schemas.xmlsoap.org/ws/2004/09/transfer/Get"
+	actionGetResponse = "http://schemas.xmlsoap.org/ws/2004/09/transfer/GetResponse"
+)
+
+// metadataBuilder holds the fixed identity used to answer the metadata Get.
+type metadataBuilder struct {
+	uuid      string // "urn:uuid:…"
+	name      string // computer / friendly name
+	workgroup string // NetBIOS domain or workgroup label
+}
+
+// buildGetResponse renders the WS-Transfer GetResponse. It is kept as an
+// explicit byte template (not an encoding/xml struct tree) because Windows'
+// WS-Transfer/devprof parser is sensitive to namespace prefixes and element
+// ordering; the template pins both.
+func (b metadataBuilder) buildGetResponse(relatesTo string) []byte {
+	r := strings.NewReplacer(
+		"{action}", actionGetResponse,
+		"{msgid}", MessageID(),
+		"{relates}", relatesTo,
+		"{to}", toAnonymous,
+		"{uuid}", b.uuid,
+		"{name}", b.name,
+		"{workgroup}", b.workgroup,
+	)
+	return []byte(r.Replace(`<?xml version="1.0" encoding="utf-8"?>` +
+		`<s:Envelope` +
+		` xmlns:s="http://www.w3.org/2003/05/soap-envelope"` +
+		` xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"` +
+		` xmlns:d="http://schemas.xmlsoap.org/ws/2005/04/discovery"` +
+		` xmlns:dp="http://schemas.xmlsoap.org/ws/2006/02/devprof"` +
+		` xmlns:mex="http://schemas.xmlsoap.org/ws/2004/09/mex"` +
+		` xmlns:pub="http://schemas.microsoft.com/windows/pub/2005/07">` +
+		`<s:Header>` +
+		`<a:Action>{action}</a:Action>` +
+		`<a:MessageID>{msgid}</a:MessageID>` +
+		`<a:RelatesTo>{relates}</a:RelatesTo>` +
+		`<a:To>{to}</a:To>` +
+		`</s:Header>` +
+		`<s:Body>` +
+		`<mex:Metadata>` +
+		`<mex:MetadataSection Dialect="http://schemas.xmlsoap.org/ws/2006/02/devprof/ThisModel">` +
+		`<dp:ThisModel>` +
+		`<dp:Manufacturer>DittoFS</dp:Manufacturer>` +
+		`<dp:ModelName>DittoFS Server</dp:ModelName>` +
+		`</dp:ThisModel>` +
+		`</mex:MetadataSection>` +
+		`<mex:MetadataSection Dialect="http://schemas.xmlsoap.org/ws/2006/02/devprof/ThisDevice">` +
+		`<dp:ThisDevice>` +
+		`<dp:FriendlyName>{name}</dp:FriendlyName>` +
+		`<dp:FirmwareVersion>1.0</dp:FirmwareVersion>` +
+		`<dp:SerialNumber>{uuid}</dp:SerialNumber>` +
+		`</dp:ThisDevice>` +
+		`</mex:MetadataSection>` +
+		`<mex:MetadataSection Dialect="http://schemas.xmlsoap.org/ws/2006/02/devprof/Relationship">` +
+		`<dp:Relationship Type="http://schemas.xmlsoap.org/ws/2006/02/devprof/host">` +
+		`<dp:Host>` +
+		`<a:EndpointReference><a:Address>{uuid}</a:Address></a:EndpointReference>` +
+		`<dp:Types>pub:Computer</dp:Types>` +
+		`<dp:ServiceId>{uuid}</dp:ServiceId>` +
+		`<pub:Computer>{name}/Workgroup:{workgroup}</pub:Computer>` +
+		`</dp:Host>` +
+		`</dp:Relationship>` +
+		`</mex:MetadataSection>` +
+		`</mex:Metadata>` +
+		`</s:Body>` +
+		`</s:Envelope>`))
+}
+
+// metadataHandler serves the WS-Transfer Get. It echoes the inbound MessageID
+// into the response's RelatesTo (WS-Addressing correlation) and returns the
+// device metadata for any POST, since the XAddrs path already scopes the
+// request to this endpoint.
+func (b metadataBuilder) metadataHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(io.LimitReader(req.Body, 1<<20))
+		if err != nil {
+			logger.Debug("wsd: metadata request read error", "error", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		relatesTo := ""
+		if in, perr := parseInbound(body); perr == nil {
+			relatesTo = in.messageID
+		}
+		w.Header().Set("Content-Type", "application/soap+xml; charset=utf-8")
+		if _, werr := w.Write(b.buildGetResponse(relatesTo)); werr != nil {
+			logger.Debug("wsd: metadata response write error", "error", werr)
+		}
+	}
+}

--- a/pkg/discovery/wsd/metadata_test.go
+++ b/pkg/discovery/wsd/metadata_test.go
@@ -1,0 +1,80 @@
+package wsd
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const sampleGet = `<?xml version="1.0"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+ xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing">
+ <s:Header>
+  <a:Action>http://schemas.xmlsoap.org/ws/2004/09/transfer/Get</a:Action>
+  <a:MessageID>urn:uuid:get-req-1</a:MessageID>
+ </s:Header>
+ <s:Body/>
+</s:Envelope>`
+
+func TestMetadataHandler_RendersComputer(t *testing.T) {
+	mb := metadataBuilder{uuid: "urn:uuid:test-uuid", name: "VM2", workgroup: "CUBBIT"}
+	srv := httptest.NewServer(mb.metadataHandler())
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/test-uuid/", "application/soap+xml", strings.NewReader(sampleGet))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	got := string(body)
+
+	for _, want := range []string{
+		actionGetResponse,
+		"<a:RelatesTo>urn:uuid:get-req-1</a:RelatesTo>", // correlates with the request
+		`Type="http://schemas.xmlsoap.org/ws/2006/02/devprof/host"`,
+		"<pub:Computer>VM2/Workgroup:CUBBIT</pub:Computer>", // the element that makes Explorer show a Computer
+		"<dp:FriendlyName>VM2</dp:FriendlyName>",
+		"<dp:Manufacturer>DittoFS</dp:Manufacturer>",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("metadata response missing %q\n---\n%s", want, got)
+		}
+	}
+}
+
+func TestMetadataHandler_RejectsGET(t *testing.T) {
+	mb := metadataBuilder{uuid: "urn:uuid:x", name: "N", workgroup: "W"}
+	srv := httptest.NewServer(mb.metadataHandler())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/x/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("GET status = %d, want 405", resp.StatusCode)
+	}
+}
+
+// TestHandleDatagram_NoPanicWithoutSocket ensures the inbound dispatch is safe
+// even before the socket is up (send is a no-op on a nil conn).
+func TestHandleDatagram_NoPanicWithoutSocket(t *testing.T) {
+	r := NewResponder("VM2", "CUBBIT", 1)
+	r.endpoint = Endpoint{UUID: "urn:uuid:self"}
+
+	probe := []byte(`<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+ xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+ xmlns:d="http://schemas.xmlsoap.org/ws/2005/04/discovery">
+ <s:Header><a:Action>http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe</a:Action>
+ <a:MessageID>urn:uuid:p</a:MessageID></s:Header>
+ <s:Body><d:Probe><d:Types>d:Device</d:Types></d:Probe></s:Body></s:Envelope>`)
+	// Should not panic; send is a no-op because udpConn is nil.
+	r.handleDatagram(probe, nil)
+}

--- a/pkg/discovery/wsd/metadata_test.go
+++ b/pkg/discovery/wsd/metadata_test.go
@@ -48,6 +48,25 @@ func TestMetadataHandler_RendersComputer(t *testing.T) {
 	}
 }
 
+func TestMetadataHandler_DomainMemberLabelsDomain(t *testing.T) {
+	mb := metadataBuilder{uuid: "urn:uuid:x", name: "VM2", workgroup: "CUBBIT", isDomain: true}
+	got := string(mb.buildGetResponse("urn:uuid:r"))
+	if !strings.Contains(got, "<pub:Computer>VM2/Domain:CUBBIT</pub:Computer>") {
+		t.Errorf("AD member should be labelled Domain:, got:\n%s", got)
+	}
+}
+
+func TestMetadataHandler_EscapesName(t *testing.T) {
+	mb := metadataBuilder{uuid: "urn:uuid:x", name: "A&B", workgroup: "W<G", isDomain: false}
+	got := string(mb.buildGetResponse("urn:uuid:r"))
+	if strings.Contains(got, "A&B") || strings.Contains(got, "W<G") {
+		t.Errorf("name/workgroup not XML-escaped:\n%s", got)
+	}
+	if !strings.Contains(got, "A&amp;B/Workgroup:W&lt;G") {
+		t.Errorf("expected escaped pub:Computer content:\n%s", got)
+	}
+}
+
 func TestMetadataHandler_RejectsGET(t *testing.T) {
 	mb := metadataBuilder{uuid: "urn:uuid:x", name: "N", workgroup: "W"}
 	srv := httptest.NewServer(mb.metadataHandler())
@@ -66,7 +85,7 @@ func TestMetadataHandler_RejectsGET(t *testing.T) {
 // TestHandleDatagram_NoPanicWithoutSocket ensures the inbound dispatch is safe
 // even before the socket is up (send is a no-op on a nil conn).
 func TestHandleDatagram_NoPanicWithoutSocket(t *testing.T) {
-	r := NewResponder("VM2", "CUBBIT", 1)
+	r := NewResponder("VM2", "CUBBIT", true, 1)
 	r.endpoint = Endpoint{UUID: "urn:uuid:self"}
 
 	probe := []byte(`<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"

--- a/pkg/discovery/wsd/metadata_test.go
+++ b/pkg/discovery/wsd/metadata_test.go
@@ -27,7 +27,7 @@ func TestMetadataHandler_RendersComputer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -76,7 +76,7 @@ func TestMetadataHandler_RejectsGET(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusMethodNotAllowed {
 		t.Fatalf("GET status = %d, want 405", resp.StatusCode)
 	}

--- a/pkg/discovery/wsd/responder.go
+++ b/pkg/discovery/wsd/responder.go
@@ -339,7 +339,7 @@ func localIPForDest(dst net.IP) net.IP {
 	if err != nil {
 		return nil
 	}
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 	if la, ok := c.LocalAddr().(*net.UDPAddr); ok {
 		return la.IP
 	}

--- a/pkg/discovery/wsd/responder.go
+++ b/pkg/discovery/wsd/responder.go
@@ -27,6 +27,10 @@ const (
 
 	// httpShutdownTimeout bounds the metadata server's graceful shutdown.
 	httpShutdownTimeout = 3 * time.Second
+
+	// helloInterval is how often the responder re-announces its presence so
+	// clients that came up after the initial Hello still learn about it.
+	helloInterval = 30 * time.Second
 )
 
 // SidecarName is the auxsvc.Group key used for the WS-Discovery responder.
@@ -51,6 +55,8 @@ type Responder struct {
 	sendMu   sync.Mutex       // serializes SetMulticastInterface + WriteTo
 	httpSrv  *http.Server
 	endpoint Endpoint
+	hostIPs  []net.IP // advertised host IPv4s (for per-client XAddrs ordering)
+	uuidBare string   // endpoint UUID without the urn:uuid: prefix (for XAddrs)
 	loopCtx  context.Context
 	loopStop context.CancelFunc
 	wg       sync.WaitGroup
@@ -90,25 +96,25 @@ func (r *Responder) Start(ctx context.Context) error {
 	}
 
 	uuidURN := EndpointUUID()
-	uuidBare := strings.TrimPrefix(uuidURN, "urn:uuid:")
+	r.uuidBare = strings.TrimPrefix(uuidURN, "urn:uuid:")
 
-	// XAddrs is a space-separated list of metadata URLs. Advertise one per host
-	// IPv4 so a client on any of a multi-homed host's subnets can reach the
-	// metadata endpoint — advertising a single "primary" IP fails when the
-	// client is on a different interface's subnet.
-	var xaddrs []string
+	// Collect the host IPv4s. XAddrs is a space-separated list of metadata URLs
+	// (one per IP) so a client on any of a multi-homed host's subnets can reach
+	// the endpoint; per Probe/Resolve the list is reordered so the address that
+	// routes to that client comes first (see endpointFor).
+	r.hostIPs = nil
 	for _, ip := range hostinfo.AllHostIPs() {
 		if v4 := ip.To4(); v4 != nil {
-			xaddrs = append(xaddrs, fmt.Sprintf("http://%s:%d/%s/", v4, MetadataPort, uuidBare))
+			r.hostIPs = append(r.hostIPs, v4)
 		}
 	}
-	if len(xaddrs) == 0 {
+	if len(r.hostIPs) == 0 {
 		return errors.New("wsd: no routable IPv4 address to advertise")
 	}
 	r.endpoint = Endpoint{
 		UUID:            uuidURN,
 		Types:           TypesComputer,
-		XAddrs:          strings.Join(xaddrs, " "),
+		XAddrs:          buildXAddrs(r.uuidBare, r.hostIPs),
 		MetadataVersion: 1,
 		InstanceID:      r.instanceID,
 	}
@@ -150,7 +156,7 @@ func (r *Responder) Start(ctx context.Context) error {
 
 	// Capture srv/conn/loopCtx as locals for the goroutines — Stop nils the
 	// struct fields under r.mu, so the goroutines must not read them unlocked.
-	r.wg.Add(2)
+	r.wg.Add(3)
 	go func() {
 		defer r.wg.Done()
 		if serr := srv.Serve(ln); serr != nil && !errors.Is(serr, http.ErrServerClosed) {
@@ -160,6 +166,14 @@ func (r *Responder) Start(ctx context.Context) error {
 	go func() {
 		defer r.wg.Done()
 		r.readLoop(conn, loopCtx)
+	}()
+	// Periodic Hello: the spec only requires Hello on join, but a client whose
+	// Function Discovery starts after us (or that misses the one-shot Hello) then
+	// never learns about us unless it actively probes. Re-announcing keeps such
+	// clients' caches populated. Bounded by loopCtx.
+	go func() {
+		defer r.wg.Done()
+		r.periodicHello(loopCtx)
 	}()
 
 	// Tear down if the base context is cancelled without an explicit Stop. This
@@ -249,14 +263,29 @@ func (r *Responder) handleDatagram(data []byte, src *net.UDPAddr) {
 	switch in.kind {
 	case kindProbe:
 		if probeMatchesTypes(in.types) {
-			r.send(ProbeMatch(r.endpoint, in.messageID, r.msgNum.Add(1)), src)
+			r.send(ProbeMatch(r.endpointFor(src), in.messageID, r.msgNum.Add(1)), src)
 		}
 	case kindResolve:
 		// Only answer a Resolve targeting our endpoint.
 		if in.address == "" || in.address == r.endpoint.UUID {
-			r.send(ResolveMatch(r.endpoint, in.messageID, r.msgNum.Add(1)), src)
+			r.send(ResolveMatch(r.endpointFor(src), in.messageID, r.msgNum.Add(1)), src)
 		}
 	}
+}
+
+// endpointFor returns the advertised endpoint with its XAddrs reordered so the
+// metadata URL on the interface that routes to src comes first — a client on a
+// multi-homed host's other subnet would otherwise try an unreachable address
+// first and give up before rendering the device.
+func (r *Responder) endpointFor(src *net.UDPAddr) Endpoint {
+	ep := r.endpoint
+	if src == nil {
+		return ep
+	}
+	if local := localIPForDest(src.IP); local != nil {
+		ep.XAddrs = buildXAddrs(r.uuidBare, preferFirst(r.hostIPs, local))
+	}
+	return ep
 }
 
 // send writes msg unicast to dst (a ProbeMatch/ResolveMatch reply), or — when
@@ -277,6 +306,68 @@ func (r *Responder) send(msg []byte, dst *net.UDPAddr) {
 		return
 	}
 	multicastAll(pconn, conn, ifaces, &r.sendMu, msg)
+}
+
+// periodicHello re-multicasts a Hello every helloInterval until ctx is done.
+func (r *Responder) periodicHello(ctx context.Context) {
+	t := time.NewTicker(helloInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			r.send(Hello(r.endpoint, r.msgNum.Add(1)), nil)
+		}
+	}
+}
+
+// buildXAddrs renders the space-separated list of metadata URLs, one per IP.
+func buildXAddrs(uuidBare string, ips []net.IP) string {
+	urls := make([]string, 0, len(ips))
+	for _, ip := range ips {
+		urls = append(urls, fmt.Sprintf("http://%s:%d/%s/", ip, MetadataPort, uuidBare))
+	}
+	return strings.Join(urls, " ")
+}
+
+// localIPForDest returns the local source IP the OS would use to reach dst (no
+// packet is sent — Dial on a UDP socket just resolves the route). Returns nil on
+// error.
+func localIPForDest(dst net.IP) net.IP {
+	c, err := net.Dial("udp4", net.JoinHostPort(dst.String(), "5357"))
+	if err != nil {
+		return nil
+	}
+	defer c.Close()
+	if la, ok := c.LocalAddr().(*net.UDPAddr); ok {
+		return la.IP
+	}
+	return nil
+}
+
+// preferFirst returns ips reordered so first leads, preserving the relative
+// order of the rest. If first is not one of ips (not an address we advertise),
+// the order is left unchanged.
+func preferFirst(ips []net.IP, first net.IP) []net.IP {
+	found := false
+	for _, ip := range ips {
+		if ip.Equal(first) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return ips
+	}
+	out := make([]net.IP, 0, len(ips))
+	out = append(out, first)
+	for _, ip := range ips {
+		if !ip.Equal(first) {
+			out = append(out, ip)
+		}
+	}
+	return out
 }
 
 // multicastAll sends msg to the WS-Discovery group out every interface, falling

--- a/pkg/discovery/wsd/responder.go
+++ b/pkg/discovery/wsd/responder.go
@@ -39,6 +39,7 @@ var discoveryUDPAddrV4 = &net.UDPAddr{IP: net.ParseIP(discoveryGroupV4), Port: d
 type Responder struct {
 	name       string // computer / friendly name
 	workgroup  string // NetBIOS domain or workgroup label
+	isDomain   bool   // true => label as Domain: (AD member), false => Workgroup:
 	instanceID uint64 // AppSequence InstanceId
 
 	mu       sync.Mutex
@@ -52,14 +53,17 @@ type Responder struct {
 }
 
 // NewResponder builds a WS-Discovery responder advertising the given computer
-// name under the given workgroup/domain. instanceID is the AppSequence
-// InstanceId — it should be stable within a process run and increase across
-// restarts (e.g. the process start time in unix seconds).
-func NewResponder(name, workgroup string, instanceID uint64) *Responder {
+// name. workgroup is the NetBIOS domain (AD member) or workgroup (standalone)
+// name; isDomain selects how Windows labels it in the pub:Computer relationship
+// (Domain: vs Workgroup:). instanceID is the AppSequence InstanceId — it should
+// be stable within a process run and increase across restarts (e.g. the process
+// start time in unix seconds).
+func NewResponder(name, workgroup string, isDomain bool, instanceID uint64) *Responder {
 	if workgroup == "" {
 		workgroup = "WORKGROUP"
+		isDomain = false
 	}
-	return &Responder{name: name, workgroup: workgroup, instanceID: instanceID}
+	return &Responder{name: name, workgroup: workgroup, isDomain: isDomain, instanceID: instanceID}
 }
 
 // Name implements the adapter auxsvc.Service interface.
@@ -91,7 +95,7 @@ func (r *Responder) Start(context.Context) error {
 
 	// HTTP metadata endpoint (bind first so a failure doesn't leave the UDP
 	// socket dangling).
-	mb := metadataBuilder{uuid: uuidURN, name: r.name, workgroup: r.workgroup}
+	mb := metadataBuilder{uuid: uuidURN, name: r.name, workgroup: r.workgroup, isDomain: r.isDomain}
 	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", MetadataPort))
 	if err != nil {
 		return fmt.Errorf("wsd: listen tcp :%d: %w", MetadataPort, err)
@@ -109,6 +113,7 @@ func (r *Responder) Start(context.Context) error {
 	}
 	r.udpConn = conn
 	r.loopCtx, r.loopStop = context.WithCancel(context.Background())
+	loopCtx := r.loopCtx
 
 	r.wg.Add(2)
 	go func() {
@@ -119,11 +124,15 @@ func (r *Responder) Start(context.Context) error {
 	}()
 	go func() {
 		defer r.wg.Done()
-		r.readLoop(conn)
+		r.readLoop(conn, loopCtx)
 	}()
 
-	// Announce presence.
-	r.send(Hello(r.endpoint, r.msgNum.Add(1)), nil)
+	// Announce presence. Write directly to the local conn: we still hold r.mu
+	// here and r.send would re-acquire it (a self-deadlock that would also wedge
+	// the caller's auxsvc.Group, since Group.Start holds its own lock across this).
+	if _, err := conn.WriteToUDP(Hello(r.endpoint, r.msgNum.Add(1)), discoveryUDPAddrV4); err != nil {
+		logger.Debug("wsd: failed to send Hello", "error", err)
+	}
 
 	logger.Info("WS-Discovery responder listening",
 		"udp", fmt.Sprintf("%s:%d", discoveryGroupV4, discoveryPort),
@@ -168,7 +177,7 @@ func (r *Responder) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (r *Responder) readLoop(conn *net.UDPConn) {
+func (r *Responder) readLoop(conn *net.UDPConn, loopCtx context.Context) {
 	buf := make([]byte, maxDatagram)
 	for {
 		n, src, err := conn.ReadFromUDP(buf)
@@ -177,7 +186,7 @@ func (r *Responder) readLoop(conn *net.UDPConn) {
 				return
 			}
 			select {
-			case <-r.loopCtx.Done():
+			case <-loopCtx.Done():
 				return
 			default:
 			}

--- a/pkg/discovery/wsd/responder.go
+++ b/pkg/discovery/wsd/responder.go
@@ -11,6 +11,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/net/ipv4"
+
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/discovery/hostinfo"
 )
@@ -44,6 +46,9 @@ type Responder struct {
 
 	mu       sync.Mutex
 	udpConn  *net.UDPConn
+	pconn    *ipv4.PacketConn // wraps udpConn for per-interface group join + multicast send
+	ifaces   []net.Interface  // multicast interfaces the group is joined on
+	sendMu   sync.Mutex       // serializes SetMulticastInterface + WriteTo
 	httpSrv  *http.Server
 	endpoint Endpoint
 	loopCtx  context.Context
@@ -84,15 +89,26 @@ func (r *Responder) Start(ctx context.Context) error {
 		return nil // already started
 	}
 
-	host := hostinfo.PrimaryIPv4()
-	if host == nil {
+	uuidURN := EndpointUUID()
+	uuidBare := strings.TrimPrefix(uuidURN, "urn:uuid:")
+
+	// XAddrs is a space-separated list of metadata URLs. Advertise one per host
+	// IPv4 so a client on any of a multi-homed host's subnets can reach the
+	// metadata endpoint — advertising a single "primary" IP fails when the
+	// client is on a different interface's subnet.
+	var xaddrs []string
+	for _, ip := range hostinfo.AllHostIPs() {
+		if v4 := ip.To4(); v4 != nil {
+			xaddrs = append(xaddrs, fmt.Sprintf("http://%s:%d/%s/", v4, MetadataPort, uuidBare))
+		}
+	}
+	if len(xaddrs) == 0 {
 		return errors.New("wsd: no routable IPv4 address to advertise")
 	}
-	uuidURN := EndpointUUID()
 	r.endpoint = Endpoint{
 		UUID:            uuidURN,
 		Types:           TypesComputer,
-		XAddrs:          fmt.Sprintf("http://%s:%d/%s/", host, MetadataPort, strings.TrimPrefix(uuidURN, "urn:uuid:")),
+		XAddrs:          strings.Join(xaddrs, " "),
 		MetadataVersion: 1,
 		InstanceID:      r.instanceID,
 	}
@@ -117,6 +133,18 @@ func (r *Responder) Start(ctx context.Context) error {
 		return fmt.Errorf("wsd: listen udp %s:%d: %w", discoveryGroupV4, discoveryPort, err)
 	}
 	r.udpConn = conn
+
+	// Join the group on every multicast interface so probes arriving on any of
+	// them are received — critical on multi-homed hosts where the OS default
+	// multicast interface may not be the LAN the Windows clients are on. Unicast
+	// ProbeMatch/ResolveMatch replies route back normally via WriteToUDP(src).
+	r.pconn = ipv4.NewPacketConn(conn)
+	_ = r.pconn.SetMulticastLoopback(true)
+	r.ifaces = hostinfo.MulticastInterfaces()
+	for i := range r.ifaces {
+		_ = r.pconn.JoinGroup(&r.ifaces[i], discoveryUDPAddrV4)
+	}
+
 	r.loopCtx, r.loopStop = context.WithCancel(context.Background())
 	loopCtx := r.loopCtx
 
@@ -142,12 +170,9 @@ func (r *Responder) Start(ctx context.Context) error {
 		_ = r.Stop(context.Background())
 	}()
 
-	// Announce presence. Write directly to the local conn: we still hold r.mu
-	// here and r.send would re-acquire it (a self-deadlock that would also wedge
-	// the caller's auxsvc.Group, since Group.Start holds its own lock across this).
-	if _, err := conn.WriteToUDP(Hello(r.endpoint, r.msgNum.Add(1)), discoveryUDPAddrV4); err != nil {
-		logger.Debug("wsd: failed to send Hello", "error", err)
-	}
+	// Announce presence out every interface. Uses the local pconn/ifaces (not
+	// r.send, which would re-acquire r.mu that we still hold — a self-deadlock).
+	multicastAll(r.pconn, conn, r.ifaces, &r.sendMu, Hello(r.endpoint, r.msgNum.Add(1)))
 
 	logger.Info("WS-Discovery responder listening",
 		"udp", fmt.Sprintf("%s:%d", discoveryGroupV4, discoveryPort),
@@ -160,10 +185,14 @@ func (r *Responder) Start(ctx context.Context) error {
 func (r *Responder) Stop(ctx context.Context) error {
 	r.mu.Lock()
 	conn := r.udpConn
+	pconn := r.pconn
+	ifaces := r.ifaces
 	httpSrv := r.httpSrv
 	stop := r.loopStop
 	endpoint := r.endpoint
 	r.udpConn = nil
+	r.pconn = nil
+	r.ifaces = nil
 	r.httpSrv = nil
 	r.loopStop = nil
 	r.loopCtx = nil
@@ -173,10 +202,8 @@ func (r *Responder) Stop(ctx context.Context) error {
 		return nil
 	}
 
-	// Goodbye while the socket is still open.
-	if _, err := conn.WriteToUDP(Bye(endpoint, r.msgNum.Add(1)), discoveryUDPAddrV4); err != nil {
-		logger.Debug("wsd: failed to send Bye", "error", err)
-	}
+	// Goodbye out every interface while the socket is still open.
+	multicastAll(pconn, conn, ifaces, &r.sendMu, Bye(endpoint, r.msgNum.Add(1)))
 
 	if stop != nil {
 		stop()
@@ -232,19 +259,43 @@ func (r *Responder) handleDatagram(data []byte, src *net.UDPAddr) {
 	}
 }
 
-// send writes msg to dst, or to the multicast group when dst is nil.
+// send writes msg unicast to dst (a ProbeMatch/ResolveMatch reply), or — when
+// dst is nil — multicasts it out every joined interface.
 func (r *Responder) send(msg []byte, dst *net.UDPAddr) {
 	r.mu.Lock()
 	conn := r.udpConn
+	pconn := r.pconn
+	ifaces := r.ifaces
 	r.mu.Unlock()
 	if conn == nil {
 		return
 	}
-	target := dst
-	if target == nil {
-		target = discoveryUDPAddrV4
+	if dst != nil { // unicast reply — routed normally
+		if _, err := conn.WriteToUDP(msg, dst); err != nil {
+			logger.Debug("wsd: send failed", "error", err)
+		}
+		return
 	}
-	if _, err := conn.WriteToUDP(msg, target); err != nil {
-		logger.Debug("wsd: send failed", "error", err)
+	multicastAll(pconn, conn, ifaces, &r.sendMu, msg)
+}
+
+// multicastAll sends msg to the WS-Discovery group out every interface, falling
+// back to the default route when no interface list is available. Serialized via
+// mu because SetMulticastInterface mutates shared socket state.
+func multicastAll(pconn *ipv4.PacketConn, conn *net.UDPConn, ifaces []net.Interface, mu *sync.Mutex, msg []byte) {
+	if conn == nil {
+		return
+	}
+	if pconn == nil || len(ifaces) == 0 {
+		_, _ = conn.WriteToUDP(msg, discoveryUDPAddrV4)
+		return
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	for i := range ifaces {
+		if err := pconn.SetMulticastInterface(&ifaces[i]); err != nil {
+			continue
+		}
+		_, _ = pconn.WriteTo(msg, nil, discoveryUDPAddrV4)
 	}
 }

--- a/pkg/discovery/wsd/responder.go
+++ b/pkg/discovery/wsd/responder.go
@@ -72,7 +72,11 @@ func (r *Responder) Name() string { return SidecarName }
 // Start binds the UDP multicast socket and the HTTP metadata server, then emits
 // a Hello. A bind failure on either returns an error; the caller (the SMB
 // adapter) treats it as non-fatal, matching the portmapper precedent.
-func (r *Responder) Start(context.Context) error {
+//
+// ctx bounds the responder's lifetime: if it is cancelled (the owning adapter's
+// Serve context ends) without an explicit Stop, the responder tears itself down,
+// matching the ctx-driven NFS auxiliary services.
+func (r *Responder) Start(ctx context.Context) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -102,7 +106,8 @@ func (r *Responder) Start(context.Context) error {
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", mb.metadataHandler())
-	r.httpSrv = &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	r.httpSrv = srv
 
 	// UDP multicast responder.
 	conn, err := net.ListenMulticastUDP("udp4", nil, discoveryUDPAddrV4)
@@ -115,16 +120,26 @@ func (r *Responder) Start(context.Context) error {
 	r.loopCtx, r.loopStop = context.WithCancel(context.Background())
 	loopCtx := r.loopCtx
 
+	// Capture srv/conn/loopCtx as locals for the goroutines — Stop nils the
+	// struct fields under r.mu, so the goroutines must not read them unlocked.
 	r.wg.Add(2)
 	go func() {
 		defer r.wg.Done()
-		if serr := r.httpSrv.Serve(ln); serr != nil && !errors.Is(serr, http.ErrServerClosed) {
+		if serr := srv.Serve(ln); serr != nil && !errors.Is(serr, http.ErrServerClosed) {
 			logger.Debug("wsd: metadata server stopped", "error", serr)
 		}
 	}()
 	go func() {
 		defer r.wg.Done()
 		r.readLoop(conn, loopCtx)
+	}()
+
+	// Tear down if the base context is cancelled without an explicit Stop. This
+	// watcher is intentionally NOT in r.wg (it blocks until ctx is cancelled, so
+	// Stop's wg.Wait must not wait on it); Stop is idempotent.
+	go func() {
+		<-ctx.Done()
+		_ = r.Stop(context.Background())
 	}()
 
 	// Announce presence. Write directly to the local conn: we still hold r.mu

--- a/pkg/discovery/wsd/responder.go
+++ b/pkg/discovery/wsd/responder.go
@@ -1,0 +1,226 @@
+package wsd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/discovery/hostinfo"
+)
+
+const (
+	// discoveryGroupV4 / discoveryPort are the IPv4 WS-Discovery multicast group
+	// and port (OASIS WS-Discovery).
+	discoveryGroupV4 = "239.255.255.250"
+	discoveryPort    = 3702
+
+	maxDatagram = 65535
+
+	// httpShutdownTimeout bounds the metadata server's graceful shutdown.
+	httpShutdownTimeout = 3 * time.Second
+)
+
+// SidecarName is the auxsvc.Group key used for the WS-Discovery responder.
+const SidecarName = "wsd"
+
+var discoveryUDPAddrV4 = &net.UDPAddr{IP: net.ParseIP(discoveryGroupV4), Port: discoveryPort}
+
+// Responder is a WS-Discovery host: a UDP multicast responder (Hello/Bye/
+// Probe/Resolve) plus the HTTP metadata endpoint Windows fetches to render the
+// host as a Computer. One Responder advertises one host; the SMB adapter owns a
+// single instance via its auxsvc sidecar.
+type Responder struct {
+	name       string // computer / friendly name
+	workgroup  string // NetBIOS domain or workgroup label
+	instanceID uint64 // AppSequence InstanceId
+
+	mu       sync.Mutex
+	udpConn  *net.UDPConn
+	httpSrv  *http.Server
+	endpoint Endpoint
+	loopCtx  context.Context
+	loopStop context.CancelFunc
+	wg       sync.WaitGroup
+	msgNum   atomic.Uint64
+}
+
+// NewResponder builds a WS-Discovery responder advertising the given computer
+// name under the given workgroup/domain. instanceID is the AppSequence
+// InstanceId — it should be stable within a process run and increase across
+// restarts (e.g. the process start time in unix seconds).
+func NewResponder(name, workgroup string, instanceID uint64) *Responder {
+	if workgroup == "" {
+		workgroup = "WORKGROUP"
+	}
+	return &Responder{name: name, workgroup: workgroup, instanceID: instanceID}
+}
+
+// Name implements the adapter auxsvc.Service interface.
+func (r *Responder) Name() string { return SidecarName }
+
+// Start binds the UDP multicast socket and the HTTP metadata server, then emits
+// a Hello. A bind failure on either returns an error; the caller (the SMB
+// adapter) treats it as non-fatal, matching the portmapper precedent.
+func (r *Responder) Start(context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.udpConn != nil {
+		return nil // already started
+	}
+
+	host := hostinfo.PrimaryIPv4()
+	if host == nil {
+		return errors.New("wsd: no routable IPv4 address to advertise")
+	}
+	uuidURN := EndpointUUID()
+	r.endpoint = Endpoint{
+		UUID:            uuidURN,
+		Types:           TypesComputer,
+		XAddrs:          fmt.Sprintf("http://%s:%d/%s/", host, MetadataPort, strings.TrimPrefix(uuidURN, "urn:uuid:")),
+		MetadataVersion: 1,
+		InstanceID:      r.instanceID,
+	}
+
+	// HTTP metadata endpoint (bind first so a failure doesn't leave the UDP
+	// socket dangling).
+	mb := metadataBuilder{uuid: uuidURN, name: r.name, workgroup: r.workgroup}
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", MetadataPort))
+	if err != nil {
+		return fmt.Errorf("wsd: listen tcp :%d: %w", MetadataPort, err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", mb.metadataHandler())
+	r.httpSrv = &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+
+	// UDP multicast responder.
+	conn, err := net.ListenMulticastUDP("udp4", nil, discoveryUDPAddrV4)
+	if err != nil {
+		_ = ln.Close()
+		r.httpSrv = nil
+		return fmt.Errorf("wsd: listen udp %s:%d: %w", discoveryGroupV4, discoveryPort, err)
+	}
+	r.udpConn = conn
+	r.loopCtx, r.loopStop = context.WithCancel(context.Background())
+
+	r.wg.Add(2)
+	go func() {
+		defer r.wg.Done()
+		if serr := r.httpSrv.Serve(ln); serr != nil && !errors.Is(serr, http.ErrServerClosed) {
+			logger.Debug("wsd: metadata server stopped", "error", serr)
+		}
+	}()
+	go func() {
+		defer r.wg.Done()
+		r.readLoop(conn)
+	}()
+
+	// Announce presence.
+	r.send(Hello(r.endpoint, r.msgNum.Add(1)), nil)
+
+	logger.Info("WS-Discovery responder listening",
+		"udp", fmt.Sprintf("%s:%d", discoveryGroupV4, discoveryPort),
+		"metadata_tcp", MetadataPort, "name", r.name)
+	return nil
+}
+
+// Stop emits a Bye, then shuts down the HTTP server and UDP socket and waits for
+// the goroutines to exit. Idempotent.
+func (r *Responder) Stop(ctx context.Context) error {
+	r.mu.Lock()
+	conn := r.udpConn
+	httpSrv := r.httpSrv
+	stop := r.loopStop
+	endpoint := r.endpoint
+	r.udpConn = nil
+	r.httpSrv = nil
+	r.loopStop = nil
+	r.loopCtx = nil
+	r.mu.Unlock()
+
+	if conn == nil {
+		return nil
+	}
+
+	// Goodbye while the socket is still open.
+	if _, err := conn.WriteToUDP(Bye(endpoint, r.msgNum.Add(1)), discoveryUDPAddrV4); err != nil {
+		logger.Debug("wsd: failed to send Bye", "error", err)
+	}
+
+	if stop != nil {
+		stop()
+	}
+	if httpSrv != nil {
+		shutCtx, cancel := context.WithTimeout(context.Background(), httpShutdownTimeout)
+		_ = httpSrv.Shutdown(shutCtx)
+		cancel()
+	}
+	_ = conn.Close()
+	r.wg.Wait()
+	logger.Info("WS-Discovery responder stopped")
+	return nil
+}
+
+func (r *Responder) readLoop(conn *net.UDPConn) {
+	buf := make([]byte, maxDatagram)
+	for {
+		n, src, err := conn.ReadFromUDP(buf)
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+			select {
+			case <-r.loopCtx.Done():
+				return
+			default:
+			}
+			logger.Debug("wsd: read error", "error", err)
+			continue
+		}
+		datagram := make([]byte, n)
+		copy(datagram, buf[:n])
+		r.handleDatagram(datagram, src)
+	}
+}
+
+func (r *Responder) handleDatagram(data []byte, src *net.UDPAddr) {
+	in, err := parseInbound(data)
+	if err != nil {
+		return // not a well-formed SOAP message we care about
+	}
+	switch in.kind {
+	case kindProbe:
+		if probeMatchesTypes(in.types) {
+			r.send(ProbeMatch(r.endpoint, in.messageID, r.msgNum.Add(1)), src)
+		}
+	case kindResolve:
+		// Only answer a Resolve targeting our endpoint.
+		if in.address == "" || in.address == r.endpoint.UUID {
+			r.send(ResolveMatch(r.endpoint, in.messageID, r.msgNum.Add(1)), src)
+		}
+	}
+}
+
+// send writes msg to dst, or to the multicast group when dst is nil.
+func (r *Responder) send(msg []byte, dst *net.UDPAddr) {
+	r.mu.Lock()
+	conn := r.udpConn
+	r.mu.Unlock()
+	if conn == nil {
+		return
+	}
+	target := dst
+	if target == nil {
+		target = discoveryUDPAddrV4
+	}
+	if _, err := conn.WriteToUDP(msg, target); err != nil {
+		logger.Debug("wsd: send failed", "error", err)
+	}
+}

--- a/pkg/discovery/wsd/responder_test.go
+++ b/pkg/discovery/wsd/responder_test.go
@@ -2,6 +2,7 @@ package wsd
 
 import (
 	"context"
+	"net"
 	"testing"
 	"time"
 )
@@ -40,5 +41,32 @@ func TestResponder_StartStopNoDeadlock(t *testing.T) {
 	// Stop is idempotent.
 	if err := r.Stop(context.Background()); err != nil {
 		t.Fatalf("second Stop: %v", err)
+	}
+}
+
+func TestBuildXAddrs_OneURLPerIP(t *testing.T) {
+	got := buildXAddrs("uuid-1", []net.IP{net.IPv4(192, 168, 1, 5), net.IPv4(10, 0, 0, 9)})
+	want := "http://192.168.1.5:5357/uuid-1/ http://10.0.0.9:5357/uuid-1/"
+	if got != want {
+		t.Fatalf("buildXAddrs = %q, want %q", got, want)
+	}
+}
+
+func TestPreferFirst_ReordersReachableFirst(t *testing.T) {
+	ips := []net.IP{net.IPv4(172, 20, 63, 93), net.IPv4(192, 168, 100, 50)}
+	got := preferFirst(ips, net.IPv4(192, 168, 100, 50))
+	if !got[0].Equal(net.IPv4(192, 168, 100, 50)) {
+		t.Fatalf("preferFirst did not put the reachable IP first: %v", got)
+	}
+	if len(got) != 2 || !got[1].Equal(net.IPv4(172, 20, 63, 93)) {
+		t.Fatalf("preferFirst dropped/duplicated IPs: %v", got)
+	}
+}
+
+func TestPreferFirst_UnknownIPLeavesOrderUnchanged(t *testing.T) {
+	ips := []net.IP{net.IPv4(172, 20, 63, 93), net.IPv4(192, 168, 100, 50)}
+	got := preferFirst(ips, net.IPv4(10, 0, 0, 1)) // not in the list
+	if len(got) != 2 || !got[0].Equal(net.IPv4(172, 20, 63, 93)) {
+		t.Fatalf("preferFirst must not inject a non-advertised IP: %v", got)
 	}
 }

--- a/pkg/discovery/wsd/responder_test.go
+++ b/pkg/discovery/wsd/responder_test.go
@@ -1,0 +1,44 @@
+package wsd
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestResponder_StartStopNoDeadlock exercises the real socket path: Start must
+// return promptly (it must not self-deadlock sending Hello while holding its
+// lock) and Stop must tear everything down. It skips when the environment cannot
+// bind the WS-Discovery UDP group or the metadata port.
+func TestResponder_StartStopNoDeadlock(t *testing.T) {
+	r := NewResponder("VM2", "CUBBIT", false, 1)
+
+	done := make(chan error, 1)
+	go func() { done <- r.Start(context.Background()) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Skipf("cannot bind WS-Discovery sockets in this environment: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return within 5s — likely a lock self-deadlock")
+	}
+
+	// Stop must also complete promptly.
+	stopped := make(chan error, 1)
+	go func() { stopped <- r.Stop(context.Background()) }()
+	select {
+	case err := <-stopped:
+		if err != nil {
+			t.Fatalf("Stop: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop did not return within 5s")
+	}
+
+	// Stop is idempotent.
+	if err := r.Stop(context.Background()); err != nil {
+		t.Fatalf("second Stop: %v", err)
+	}
+}

--- a/pkg/discovery/wsd/uuid.go
+++ b/pkg/discovery/wsd/uuid.go
@@ -1,0 +1,45 @@
+// Package wsd implements a minimal WS-Discovery host responder so DittoFS's SMB
+// service appears in the Windows Explorer "Network" view. It is a from-scratch
+// implementation of the subset of the OASIS WS-Discovery protocol that Windows
+// Function Discovery uses — the same job the external wsdd/wsdd2 daemons do for
+// Samba:
+//
+//   - a UDP multicast responder on 239.255.255.250:3702 that emits Hello on
+//     start / Bye on stop and answers Probe/Resolve with ProbeMatch/ResolveMatch
+//     (responder.go), and
+//   - an HTTP metadata endpoint on tcp/5357 that answers the WS-Transfer Get
+//     Windows issues to fetch device metadata, returning a pub:Computer
+//     relationship so Explorer renders the host as a Computer (metadata.go).
+//
+// WS-Discovery is SMB-only: Windows does not browse NFS servers.
+package wsd
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/marmos91/dittofs/pkg/discovery/hostinfo"
+)
+
+// dittofsNamespace is a fixed namespace UUID used to derive a stable per-host
+// endpoint UUID (RFC 4122 v5). Any constant works; this one is DittoFS-specific
+// (the node segment encodes issue 1609).
+var dittofsNamespace = uuid.MustParse("0d117f5d-1609-4000-8000-000000001609")
+
+// EndpointUUID returns the stable "urn:uuid:…" endpoint reference for this host,
+// derived from its server name so Windows dedupes the entry across restarts.
+func EndpointUUID() string {
+	return endpointUUIDFor(hostinfo.ServerName())
+}
+
+// endpointUUIDFor is the pure core of EndpointUUID, testable without the real
+// hostname.
+func endpointUUIDFor(serverName string) string {
+	u := uuid.NewSHA1(dittofsNamespace, []byte(serverName))
+	return "urn:uuid:" + u.String()
+}
+
+// MessageID returns a fresh random "urn:uuid:…" for a single message's
+// wsa:MessageID header.
+func MessageID() string {
+	return "urn:uuid:" + uuid.NewString()
+}


### PR DESCRIPTION
## Summary

Implements **#1609** — DittoFS now advertises itself on the LAN so it appears in **Windows Explorer → Network** and **macOS Finder → Network**, the same job Samba/NFS deployments hand to the external `wsdd`/`wsdd2` and `avahi-daemon` daemons. Done **in-process, from scratch** (no reusable Go WS-Discovery *host* library exists; `golang.org/x/net/dns/dnsmessage` is already a transitive dep, so mDNS needs no new dependency), gated per service and toggleable at runtime via `dfsctl`/REST.

Mounting by name/IP already worked; this closes the discoverability gap only — no change to auth or access control.

## What's included

**A unifying `auxsvc.Service` abstraction** (`pkg/adapter/auxsvc`) — a small `Service` interface + `Group` for the companion services that run alongside an adapter. The **entire NFS auxiliary-service family** (embedded portmapper, system-rpcbind registration, UDP lock-manager transport, NSM startup) is folded into it, and the new advertisers join the same lifecycle. Behavior-preserving refactor.

**mDNS / DNS-SD** (`pkg/discovery/{hostinfo,mdns}`) — macOS Finder + Linux/Avahi. NFS advertises `_nfs._tcp` (port **12049**, `path=/<export>`); SMB advertises `_smb._tcp` + `_device-info._tcp` (`model=RackMac`). One shared, refcounted responder owns the single `224.0.0.251:5353` socket; each adapter registers only its own records.

**WS-Discovery** (`pkg/discovery/wsd`, SMB-only) — UDP `239.255.255.250:3702` SOAP responder (Hello/Bye/Probe→ProbeMatch/Resolve→ResolveMatch) **plus the HTTP `5357` metadata endpoint** whose `pub:Computer` relationship is what makes Explorer render the host as a *Computer*. AD members are labelled `Domain:`.

**Live toggle via dfsctl/API** — `MDNSEnabled` (NFS+SMB) and `WSDiscoveryEnabled` (SMB) plumbed end-to-end (DB models → REST PATCH/PUT/GET/reset → apiclient → `dfsctl adapter settings … update --mdns-enabled / --wsdiscovery-enabled`). Toggling starts/stops the advertiser **live**, no restart.

**Ports** — `Dockerfile` EXPOSE + operator Service/container ports (`5353/udp`, `3702/udp`, `5357/tcp`), with the caveat documented in code that multicast does not traverse standard K8s CNIs (hostNetwork only).

## Commits

1. `auxsvc.Service` abstraction
2. `pkg/discovery` mDNS + WS-Discovery responders
3. adapter wiring + live settings + Docker/operator ports + docs
4. `/simplify` cleanups (collapse duplicated reconcile logic, etc.)
5. `/code-review` fixes (see below)

## Review

Ran `/simplify` (4 agents) and a `/code-review` (correctness finders + verification). Fixes applied in commit 5, each with a regression test:

- **critical** — `wsd.Responder.Start` self-deadlock (sent Hello via `send()` while holding `r.mu`, which `send()` re-locks) — would have wedged the SMB sidecar group on first enable. Now covered by a Start/Stop lifecycle test.
- **high** — WS-Discovery SOAP templates didn't XML-escape substituted values; the inbound `MessageID` echoed into `RelatesTo` is LAN-controllable, so an unescaped `&`/`<` produced non-well-formed replies that clients discard.
- **high** — per-field settings reset rejected the new toggles (`dfsctl adapter settings … reset --setting mdns_enabled` → 400).
- medium/low — mDNS `stop()` racing a late `Register`; unlocked `loopCtx` read in the read loops; `auxsvc.StopAll` not clearing `baseCtx` (reconcile-vs-shutdown leak); spurious "already running" warn; non-deterministic NFS `path=`; AD Domain/Workgroup mislabel.

## Testing

- Unit tests throughout: mDNS record encode/decode + query responder (pure), WS-Discovery SOAP builders + parser + metadata endpoint (`httptest`), `auxsvc.Group` lifecycle, real-socket Start/Stop lifecycle tests (skip when the env can't bind multicast).
- `go build ./...`, `go vet ./...` clean (main module **and** the operator module); all touched suites pass; operator port-builder unit tests updated.
- **Not yet done:** on-the-LAN confirmation (Finder/Avahi listing; Explorer showing a *Computer*) — needs real macOS/Windows clients. Planned against the AD testbed.

<img width="941" height="922" alt="image" src="https://github.com/user-attachments/assets/ba7bb24d-c58c-41b3-abf4-c4180f85db9a" />

## Known limitations (documented in code)

- Single default-interface multicast bind (multi-NIC join is a follow-up).
- No mDNS conflict-probing (v1).
- NFS `path=` TXT is not rebuilt on share add/rename/remove.
- Multicast discovery is LAN/hostNetwork-scoped; it does not traverse standard K8s overlays.

Closes #1609
