### PR TITLE
feat(smb): emit file owner/group as real AD SID in idmap:rid (#1617)

### DIFF
--- a/internal/adapter/smb/handlers/security.go
+++ b/internal/adapter/smb/handlers/security.go
@@ -238,6 +238,30 @@ func directoryGIDForSID(s *sid.SID) (uint32, bool) {
 	return 0, false
 }
 
+// sameSID reports whether two SIDs are identical. A nil operand never matches.
+// Used by the SET_INFO owner/group gate to recognize a re-set of the file's
+// current owner/group SID as a no-op (#1617).
+func sameSID(a, b *sid.SID) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	return sid.FormatSID(a) == sid.FormatSID(b)
+}
+
+// isCurrentOwnerSID reports whether reqSID equals the SID the server currently
+// emits for a file owned by uid — the machine-domain SID, or the real directory
+// SID when the bridge maps the uid (#1617). The SET_INFO gate uses this to
+// distinguish a no-op owner re-set (accept) from a genuine unmappable chown
+// (reject, #1228), independent of whether the reverse directory lookup is up.
+func isCurrentOwnerSID(reqSID *sid.SID, uid uint32) bool {
+	return sameSID(reqSID, ownerSIDFor(_defaultSIDMapper.Load(), uid))
+}
+
+// isCurrentGroupSID mirrors isCurrentOwnerSID for a file's group GID.
+func isCurrentGroupSID(reqSID *sid.SID, gid uint32) bool {
+	return sameSID(reqSID, groupSIDFor(_defaultSIDMapper.Load(), gid))
+}
+
 // ============================================================================
 // Security Descriptor Building
 // ============================================================================

--- a/internal/adapter/smb/handlers/security.go
+++ b/internal/adapter/smb/handlers/security.go
@@ -137,6 +137,108 @@ func GetSIDMapper() *sid.SIDMapper {
 }
 
 // ============================================================================
+// Directory SID Bridge (#1617)
+// ============================================================================
+
+// DirectorySIDBridge couples a POSIX UID/GID to its real directory (AD) SID in
+// both directions, backing #1617. Emit (SIDForUID/SIDForGID) advertises a file
+// owner/group as the account's actual AD SID instead of the algorithmic
+// machine-domain SID from the SIDMapper; parse (UIDForSID/GIDForSID) recovers
+// the UID/GID when Windows echoes that AD SID back through SET_INFO so an owner
+// emitted this way round-trips instead of tripping the unmappable-owner gate.
+//
+// Every method returns ok=false on a miss (never an error) and the caller falls
+// back to the SIDMapper's machine-domain mapping. Because the bridge only hits
+// on accounts the directory actually holds, a local-only or conformance
+// deployment (no AD provider) is a transparent no-op: SIDForUID/GID always miss
+// and the descriptor stays byte-for-byte what it was before #1617.
+type DirectorySIDBridge interface {
+	// SIDForUID resolves a POSIX UID to its directory user SID string.
+	SIDForUID(uid uint32) (sidStr string, ok bool)
+	// SIDForGID resolves a POSIX GID to its directory group SID string.
+	SIDForGID(gid uint32) (sidStr string, ok bool)
+	// UIDForSID resolves a directory SID string back to its POSIX UID.
+	UIDForSID(sidStr string) (uid uint32, ok bool)
+	// GIDForSID resolves a directory SID string back to its POSIX GID.
+	GIDForSID(sidStr string) (gid uint32, ok bool)
+}
+
+// dirSIDHolder wraps a DirectorySIDBridge so it can live in an atomic.Pointer
+// (an interface value cannot be stored atomically directly).
+type dirSIDHolder struct{ bridge DirectorySIDBridge }
+
+// _directorySIDBridge is the package-level directory-SID bridge, installed by
+// SetDirectorySIDBridge during adapter wiring. Unset means "machine-domain SID
+// only" — the pre-#1617 behavior.
+var _directorySIDBridge atomic.Pointer[dirSIDHolder]
+
+// SetDirectorySIDBridge installs the package-level DirectorySIDBridge used to
+// emit and round-trip real directory (AD) owner/group SIDs (#1617). Passing nil
+// clears it (back to machine-domain SIDs only). Wired alongside SetSIDMapper
+// before any connections are accepted.
+func SetDirectorySIDBridge(b DirectorySIDBridge) {
+	if b == nil {
+		_directorySIDBridge.Store(nil)
+		return
+	}
+	_directorySIDBridge.Store(&dirSIDHolder{bridge: b})
+}
+
+// directoryBridge returns the installed DirectorySIDBridge, or nil when none is
+// configured.
+func directoryBridge() DirectorySIDBridge {
+	if h := _directorySIDBridge.Load(); h != nil {
+		return h.bridge
+	}
+	return nil
+}
+
+// ownerSIDFor returns the SID to advertise for a file owner UID: the real
+// directory (AD) SID when the bridge maps it (#1617), otherwise the algorithmic
+// machine-domain SID from the mapper. A malformed bridge SID string falls back
+// to the machine SID rather than faulting.
+func ownerSIDFor(mapper *sid.SIDMapper, uid uint32) *sid.SID {
+	if b := directoryBridge(); b != nil {
+		if sidStr, ok := b.SIDForUID(uid); ok && sidStr != "" {
+			if s, err := sid.ParseSIDString(sidStr); err == nil {
+				return s
+			}
+		}
+	}
+	return mapper.UserSID(uid)
+}
+
+// groupSIDFor mirrors ownerSIDFor for a file group GID → group SID.
+func groupSIDFor(mapper *sid.SIDMapper, gid uint32) *sid.SID {
+	if b := directoryBridge(); b != nil {
+		if sidStr, ok := b.SIDForGID(gid); ok && sidStr != "" {
+			if s, err := sid.ParseSIDString(sidStr); err == nil {
+				return s
+			}
+		}
+	}
+	return mapper.GroupSID(gid)
+}
+
+// directoryUIDForSID resolves a decoded directory (AD) SID back to its POSIX UID
+// via the bridge, the parse-side inverse of ownerSIDFor (#1617). Returns
+// ok=false when no bridge is configured or the SID is not a directory account.
+func directoryUIDForSID(s *sid.SID) (uint32, bool) {
+	if b := directoryBridge(); b != nil {
+		return b.UIDForSID(sid.FormatSID(s))
+	}
+	return 0, false
+}
+
+// directoryGIDForSID mirrors directoryUIDForSID for a group SID → GID.
+func directoryGIDForSID(s *sid.SID) (uint32, bool) {
+	if b := directoryBridge(); b != nil {
+		return b.GIDForSID(sid.FormatSID(s))
+	}
+	return 0, false
+}
+
+// ============================================================================
 // Security Descriptor Building
 // ============================================================================
 
@@ -186,8 +288,8 @@ func BuildSecurityDescriptorWithGrants(file *metadata.File, additionalSecInfo ui
 	// Build SIDs using the shared mapper. Snapshot the atomic pointer once so
 	// a concurrent SetSIDMapper does not race this read.
 	mapper := _defaultSIDMapper.Load()
-	ownerSID := mapper.UserSID(file.UID)
-	groupSID := mapper.GroupSID(file.GID)
+	ownerSID := ownerSIDFor(mapper, file.UID)
+	groupSID := groupSIDFor(mapper, file.GID)
 
 	// Null DACL: SE_DACL_PRESENT set but no DACL body (daclOffset stays 0)
 	isNullDACL := includeDACL && file.ACL != nil && file.ACL.NullDACL
@@ -318,9 +420,9 @@ func principalToSID(who string, fileUID, fileGID uint32) *sid.SID {
 	mapper := _defaultSIDMapper.Load()
 	switch who {
 	case acl.SpecialOwner:
-		return mapper.UserSID(fileUID)
+		return ownerSIDFor(mapper, fileUID)
 	case acl.SpecialGroup:
-		return mapper.GroupSID(fileGID)
+		return groupSIDFor(mapper, fileGID)
 	case acl.SpecialEveryone:
 		return sid.WellKnownEveryone
 	case acl.SpecialOwnerRights:
@@ -592,21 +694,33 @@ func ParseSecurityDescriptorWithOptions(data []byte, opts ParseSDOptions) (owner
 		return nil, nil, nil, fmt.Errorf("failed to parse SD header: %w", r.Err())
 	}
 
-	// Parse Owner SID — only set ownerUID if the SID is recognized
+	// Parse Owner SID — only set ownerUID if the SID is recognized. The machine
+	// mapper resolves algorithmic machine-domain SIDs; a real directory (AD) SID
+	// we emitted for the owner (#1617) is unknown to the mapper, so fall back to
+	// the directory bridge to recover the same UID. Without this, Windows echoing
+	// back the AD-SID owner would look like a foreign-domain chown and trip the
+	// unmappable-owner gate in SET_INFO.
 	if offsetOwner > 0 && int(offsetOwner) < len(data) {
 		s, _, err := sid.DecodeSID(data[offsetOwner:])
 		if err == nil {
 			if uid, ok := mapper.UIDFromSID(s); ok {
 				ownerUID = &uid
+			} else if uid, ok := directoryUIDForSID(s); ok {
+				ownerUID = &uid
 			}
 		}
 	}
 
-	// Parse Group SID — only set ownerGID if the SID is recognized
+	// Parse Group SID — only set ownerGID if the SID is recognized. Directory
+	// bridge fallback mirrors the owner path (#1617); the trailing user-SID
+	// fallback preserves the pre-existing lenient behavior for a group section
+	// carrying a user SID.
 	if offsetGroup > 0 && int(offsetGroup) < len(data) {
 		s, _, err := sid.DecodeSID(data[offsetGroup:])
 		if err == nil {
 			if gid, ok := mapper.GIDFromSID(s); ok {
+				ownerGID = &gid
+			} else if gid, ok := directoryGIDForSID(s); ok {
 				ownerGID = &gid
 			} else if uid, ok := mapper.UIDFromSID(s); ok {
 				ownerGID = &uid

--- a/internal/adapter/smb/handlers/security_directory_sid_test.go
+++ b/internal/adapter/smb/handlers/security_directory_sid_test.go
@@ -175,3 +175,44 @@ func TestBuildSD_DirectoryBridge_SpecialOwnerACEUsesADSID(t *testing.T) {
 		t.Errorf("OWNER@ SID = %q, want %q", s, ownerSID)
 	}
 }
+
+// A SET_INFO that re-sends the file's CURRENT owner/group AD SID (Windows does
+// this on any DACL edit) must be recognized as a no-op by isCurrentOwnerSID /
+// isCurrentGroupSID — independent of whether the reverse directory lookup is up
+// — so the #1228 foreign-domain gate does not reject it (#1617 finding #2).
+func TestSetInfo_DirectoryBridge_CurrentOwnerGroupSIDIsNoOp(t *testing.T) {
+	const (
+		adUID    = 500
+		adGID    = 512
+		ownerSID = "S-1-5-21-100-200-300-500"
+		groupSID = "S-1-5-21-100-200-300-512"
+	)
+	withDirectoryBridge(t, fakeDirectorySIDBridge{
+		uid: adUID, uidSID: ownerSID, gid: adGID, gidSID: groupSID,
+	})
+
+	reqOwner, err := sid.ParseSIDString(ownerSID)
+	if err != nil {
+		t.Fatalf("ParseSIDString(owner): %v", err)
+	}
+	reqGroup, err := sid.ParseSIDString(groupSID)
+	if err != nil {
+		t.Fatalf("ParseSIDString(group): %v", err)
+	}
+
+	if !isCurrentOwnerSID(reqOwner, adUID) {
+		t.Error("re-set of the file's current AD owner SID must be a no-op")
+	}
+	if !isCurrentGroupSID(reqGroup, adGID) {
+		t.Error("re-set of the file's current AD group SID must be a no-op")
+	}
+
+	// A different SID is a genuine change, not a no-op.
+	other, err := sid.ParseSIDString("S-1-5-21-100-200-300-999")
+	if err != nil {
+		t.Fatalf("ParseSIDString(other): %v", err)
+	}
+	if isCurrentOwnerSID(other, adUID) {
+		t.Error("a different SID must not be treated as the current owner")
+	}
+}

--- a/internal/adapter/smb/handlers/security_directory_sid_test.go
+++ b/internal/adapter/smb/handlers/security_directory_sid_test.go
@@ -1,0 +1,177 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/auth/sid"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+)
+
+// fakeDirectorySIDBridge is a deterministic in-memory DirectorySIDBridge for
+// exercising the #1617 emit/parse paths. It maps a fixed uid/gid to a fixed AD
+// SID string and back; everything else misses (ok=false).
+type fakeDirectorySIDBridge struct {
+	uid    uint32
+	uidSID string
+	gid    uint32
+	gidSID string
+}
+
+func (f fakeDirectorySIDBridge) SIDForUID(uid uint32) (string, bool) {
+	if uid == f.uid {
+		return f.uidSID, true
+	}
+	return "", false
+}
+
+func (f fakeDirectorySIDBridge) SIDForGID(gid uint32) (string, bool) {
+	if gid == f.gid {
+		return f.gidSID, true
+	}
+	return "", false
+}
+
+func (f fakeDirectorySIDBridge) UIDForSID(sidStr string) (uint32, bool) {
+	if sidStr == f.uidSID {
+		return f.uid, true
+	}
+	return 0, false
+}
+
+func (f fakeDirectorySIDBridge) GIDForSID(sidStr string) (uint32, bool) {
+	if sidStr == f.gidSID {
+		return f.gid, true
+	}
+	return 0, false
+}
+
+// withDirectoryBridge installs b for the duration of the test and restores the
+// prior (usually nil) bridge afterward, so tests do not leak the hook.
+func withDirectoryBridge(t *testing.T, b DirectorySIDBridge) {
+	t.Helper()
+	prev := directoryBridge()
+	SetDirectorySIDBridge(b)
+	t.Cleanup(func() { SetDirectorySIDBridge(prev) })
+}
+
+// A file owned by an AD account is emitted with that account's real directory
+// SID for the Owner and Group SD sections (#1617), not the algorithmic
+// machine-domain SID.
+func TestBuildSD_DirectoryBridge_EmitsADOwnerGroupSID(t *testing.T) {
+	const (
+		adUID    = 500
+		adGID    = 512
+		ownerSID = "S-1-5-21-100-200-300-500"
+		groupSID = "S-1-5-21-100-200-300-512"
+	)
+	withDirectoryBridge(t, fakeDirectorySIDBridge{
+		uid: adUID, uidSID: ownerSID, gid: adGID, gidSID: groupSID,
+	})
+
+	file := &metadata.File{FileAttr: metadata.FileAttr{UID: adUID, GID: adGID, Mode: 0o644}}
+
+	data, err := BuildSecurityDescriptor(file, allSecInfo)
+	if err != nil {
+		t.Fatalf("BuildSecurityDescriptor: %v", err)
+	}
+
+	gotOwner, gotGroup, hasOwner, hasGroup := securityDescriptorOwnerGroupSIDs(data)
+	if !hasOwner || !hasGroup {
+		t.Fatalf("owner/group sections missing: hasOwner=%v hasGroup=%v", hasOwner, hasGroup)
+	}
+	if got := sid.FormatSID(gotOwner); got != ownerSID {
+		t.Errorf("owner SID = %q, want %q", got, ownerSID)
+	}
+	if got := sid.FormatSID(gotGroup); got != groupSID {
+		t.Errorf("group SID = %q, want %q", got, groupSID)
+	}
+}
+
+// When the bridge does not map the uid/gid (a local account, or no AD provider),
+// the descriptor falls back to the machine-domain SIDs — byte-identical to the
+// pre-#1617 output. This guards the transparent no-op invariant.
+func TestBuildSD_DirectoryBridge_MissFallsBackToMachineSID(t *testing.T) {
+	file := &metadata.File{FileAttr: metadata.FileAttr{UID: 1000, GID: 1000, Mode: 0o644}}
+
+	baseline, err := BuildSecurityDescriptor(file, allSecInfo)
+	if err != nil {
+		t.Fatalf("BuildSecurityDescriptor(baseline): %v", err)
+	}
+
+	// Bridge that only knows uid/gid 500/512 — 1000 misses.
+	withDirectoryBridge(t, fakeDirectorySIDBridge{
+		uid: 500, uidSID: "S-1-5-21-1-2-3-500", gid: 512, gidSID: "S-1-5-21-1-2-3-512",
+	})
+
+	withBridge, err := BuildSecurityDescriptor(file, allSecInfo)
+	if err != nil {
+		t.Fatalf("BuildSecurityDescriptor(withBridge): %v", err)
+	}
+	if !bytes.Equal(baseline, withBridge) {
+		t.Fatal("bridge miss changed the descriptor; expected byte-identical machine-SID fallback")
+	}
+}
+
+// An owner emitted as an AD SID round-trips: parsing the built descriptor
+// recovers the same UID/GID via the bridge, even though the machine mapper does
+// not recognize the AD SID. Without this the owner would look foreign and trip
+// the SET_INFO unmappable-owner gate.
+func TestParseSD_DirectoryBridge_ADOwnerRoundTrips(t *testing.T) {
+	const (
+		adUID    = 500
+		adGID    = 512
+		ownerSID = "S-1-5-21-100-200-300-500"
+		groupSID = "S-1-5-21-100-200-300-512"
+	)
+	withDirectoryBridge(t, fakeDirectorySIDBridge{
+		uid: adUID, uidSID: ownerSID, gid: adGID, gidSID: groupSID,
+	})
+
+	file := &metadata.File{FileAttr: metadata.FileAttr{UID: adUID, GID: adGID, Mode: 0o644}}
+	data, err := BuildSecurityDescriptor(file, allSecInfo)
+	if err != nil {
+		t.Fatalf("BuildSecurityDescriptor: %v", err)
+	}
+
+	gotUID, gotGID, _, err := ParseSecurityDescriptor(data)
+	if err != nil {
+		t.Fatalf("ParseSecurityDescriptor: %v", err)
+	}
+	if gotUID == nil || *gotUID != adUID {
+		t.Errorf("parsed ownerUID = %v, want %d", gotUID, adUID)
+	}
+	if gotGID == nil || *gotGID != adGID {
+		t.Errorf("parsed ownerGID = %v, want %d", gotGID, adGID)
+	}
+}
+
+// The OWNER@/GROUP@ special ACEs in the DACL also carry the AD SID when the
+// bridge maps the file's owner/group (#1617), matching the Owner/Group SD
+// sections so Windows shows one coherent principal.
+func TestBuildSD_DirectoryBridge_SpecialOwnerACEUsesADSID(t *testing.T) {
+	const (
+		adUID    = 500
+		ownerSID = "S-1-5-21-100-200-300-500"
+	)
+	withDirectoryBridge(t, fakeDirectorySIDBridge{
+		uid: adUID, uidSID: ownerSID, gid: 999, gidSID: "S-1-5-21-100-200-300-999",
+	})
+
+	file := &metadata.File{
+		FileAttr: metadata.FileAttr{
+			UID: adUID, GID: adUID, Mode: 0o644,
+			ACL: &acl.ACL{ACEs: []acl.ACE{{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				AccessMask: 0x001F01FF,
+				Who:        acl.SpecialOwner,
+			}}},
+		},
+	}
+
+	got := principalToSID(acl.SpecialOwner, file.UID, file.GID)
+	if s := sid.FormatSID(got); s != ownerSID {
+		t.Errorf("OWNER@ SID = %q, want %q", s, ownerSID)
+	}
+}

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1854,15 +1854,31 @@ func (h *Handler) setSecurityInfo(
 		reqOwnerSID, reqGroupSID, hasOwnerSID, hasGroupSID := securityDescriptorOwnerGroupSIDs(buffer)
 		mapper := GetSIDMapper()
 
-		if (additionalInfo&OwnerSecurityInformation) != 0 && hasOwnerSID && ownerUID == nil &&
-			mapper.IsForeignDomainSID(reqOwnerSID) {
-			logger.Debug("SET_INFO Security: owner change requested with foreign-domain SID", "path", openFile.Path)
-			return setInfoStatus(types.StatusInvalidOwner), nil
-		}
-		if (additionalInfo&GroupSecurityInformation) != 0 && hasGroupSID && ownerGID == nil &&
-			mapper.IsForeignDomainSID(reqGroupSID) {
-			logger.Debug("SET_INFO Security: group change requested with foreign-domain SID", "path", openFile.Path)
-			return setInfoStatus(types.StatusNoneMapped), nil
+		// A foreign owner/group SID the parse path could not reverse-map (nil
+		// ownerUID/ownerGID) normally means an unmappable chown, which #1228
+		// rejects. But #1617 emits an AD-owned file's owner/group AS a foreign AD
+		// SID, and Windows echoes that exact SID back on unrelated DACL edits — so
+		// a re-set of the file's CURRENT owner/group SID must be accepted as a
+		// no-op even when the reverse directory lookup is momentarily unavailable
+		// (a transient miss must not turn a no-op into StatusInvalidOwner). Fetch
+		// the file's current uid/gid only when we might otherwise reject.
+		ownerReject := (additionalInfo&OwnerSecurityInformation) != 0 && hasOwnerSID && ownerUID == nil &&
+			mapper.IsForeignDomainSID(reqOwnerSID)
+		groupReject := (additionalInfo&GroupSecurityInformation) != 0 && hasGroupSID && ownerGID == nil &&
+			mapper.IsForeignDomainSID(reqGroupSID)
+		if ownerReject || groupReject {
+			var curUID, curGID uint32
+			if cur, gerr := h.Registry.GetMetadataService().GetFile(authCtx.Context, openFile.MetadataHandle); gerr == nil && cur != nil {
+				curUID, curGID = cur.UID, cur.GID
+			}
+			if ownerReject && !isCurrentOwnerSID(reqOwnerSID, curUID) {
+				logger.Debug("SET_INFO Security: owner change requested with foreign-domain SID", "path", openFile.Path)
+				return setInfoStatus(types.StatusInvalidOwner), nil
+			}
+			if groupReject && !isCurrentGroupSID(reqGroupSID, curGID) {
+				logger.Debug("SET_INFO Security: group change requested with foreign-domain SID", "path", openFile.Path)
+				return setInfoStatus(types.StatusNoneMapped), nil
+			}
 		}
 	}
 

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -801,6 +801,13 @@ func (s *Adapter) wireForeignSIDResolver(rt *runtime.Runtime) {
 		newIdentityForeignSIDResolver(resolver, s.handler.NetBIOSDomain),
 	)
 
+	// Wire the directory-SID bridge so file owner/group descriptors carry the
+	// account's real AD SID (and round-trip it back) rather than the algorithmic
+	// machine-domain SID (#1617). Shares the same resolver chain and config-change
+	// re-run as the foreign-SID resolver above; a no-op when no LDAP/AD provider
+	// is configured (the bridge simply never hits).
+	handlers.SetDirectorySIDBridge(newDirectorySIDBridge(resolver))
+
 	if s.foreignSIDProviderUnsub == nil {
 		s.foreignSIDProviderUnsub = rt.OnIdentityProviderConfigChange(func() {
 			s.wireForeignSIDResolver(rt)

--- a/pkg/adapter/smb/directory_sid_bridge.go
+++ b/pkg/adapter/smb/directory_sid_bridge.go
@@ -1,0 +1,80 @@
+package smb
+
+import (
+	"context"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/handlers"
+	"github.com/marmos91/dittofs/pkg/identity"
+)
+
+// directorySIDBridge adapts the centralized identity.Resolver to the handlers
+// package's DirectorySIDBridge, backing #1617: it lets the SMB security
+// descriptor advertise a file owner/group as the account's REAL directory (AD)
+// SID instead of the algorithmic machine-domain SID, and recover the UID/GID
+// when Windows echoes that AD SID back through SET_INFO.
+//
+// Every method is best-effort: a miss (or any infrastructure error) returns
+// ok=false, and the handlers layer falls back to the machine-domain SIDMapper.
+// Because a hit requires the resolver's LDAP/AD provider to actually hold the
+// account, a local-only or conformance deployment never hits — #1617 is a
+// transparent no-op there.
+type directorySIDBridge struct {
+	resolver *identity.Resolver
+	timeout  time.Duration
+}
+
+// directorySIDBridgeTimeout bounds a single directory round-trip triggered by a
+// security-descriptor build/parse. Generous for one cached LDAP search, short
+// enough that a hung directory never wedges the SMB handler.
+const directorySIDBridgeTimeout = 5 * time.Second
+
+// newDirectorySIDBridge builds a handlers.DirectorySIDBridge backed by the given
+// identity.Resolver. Returns nil when the resolver is nil so callers can pass the
+// result straight through to handlers.SetDirectorySIDBridge (which treats nil as
+// "machine-domain SIDs only").
+func newDirectorySIDBridge(resolver *identity.Resolver) handlers.DirectorySIDBridge {
+	if resolver == nil {
+		return nil
+	}
+	return &directorySIDBridge{resolver: resolver, timeout: directorySIDBridgeTimeout}
+}
+
+// SIDForUID resolves a POSIX UID to its directory user SID string (emit path).
+func (b *directorySIDBridge) SIDForUID(uid uint32) (string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), b.timeout)
+	defer cancel()
+	return b.resolver.SIDForUID(ctx, uid)
+}
+
+// SIDForGID resolves a POSIX GID to its directory group SID string (emit path).
+func (b *directorySIDBridge) SIDForGID(gid uint32) (string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), b.timeout)
+	defer cancel()
+	return b.resolver.SIDForGID(ctx, gid)
+}
+
+// UIDForSID resolves a directory SID string back to its POSIX UID (parse path).
+// It issues a SID-keyed credential to the resolver, which routes it to the
+// LDAP/AD provider's objectSid search.
+func (b *directorySIDBridge) UIDForSID(sidStr string) (uint32, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), b.timeout)
+	defer cancel()
+	resolved, err := b.resolver.Resolve(ctx, &identity.Credential{ExternalID: sidStr})
+	if err != nil || resolved == nil || !resolved.Found {
+		return 0, false
+	}
+	return resolved.UID, true
+}
+
+// GIDForSID resolves a directory SID string back to its POSIX GID (parse path).
+// Mirrors UIDForSID for a group SID.
+func (b *directorySIDBridge) GIDForSID(sidStr string) (uint32, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), b.timeout)
+	defer cancel()
+	resolved, err := b.resolver.Resolve(ctx, &identity.Credential{ExternalID: sidStr})
+	if err != nil || resolved == nil || !resolved.Found {
+		return 0, false
+	}
+	return resolved.GID, true
+}

--- a/pkg/adapter/smb/directory_sid_bridge.go
+++ b/pkg/adapter/smb/directory_sid_bridge.go
@@ -55,26 +55,31 @@ func (b *directorySIDBridge) SIDForGID(gid uint32) (string, bool) {
 }
 
 // UIDForSID resolves a directory SID string back to its POSIX UID (parse path).
-// It issues a SID-keyed credential to the resolver, which routes it to the
-// LDAP/AD provider's objectSid search.
 func (b *directorySIDBridge) UIDForSID(sidStr string) (uint32, bool) {
-	ctx, cancel := context.WithTimeout(context.Background(), b.timeout)
-	defer cancel()
-	resolved, err := b.resolver.Resolve(ctx, &identity.Credential{ExternalID: sidStr})
-	if err != nil || resolved == nil || !resolved.Found {
-		return 0, false
+	if resolved, ok := b.resolveSID(sidStr); ok {
+		return resolved.UID, true
 	}
-	return resolved.UID, true
+	return 0, false
 }
 
 // GIDForSID resolves a directory SID string back to its POSIX GID (parse path).
-// Mirrors UIDForSID for a group SID.
 func (b *directorySIDBridge) GIDForSID(sidStr string) (uint32, bool) {
+	if resolved, ok := b.resolveSID(sidStr); ok {
+		return resolved.GID, true
+	}
+	return 0, false
+}
+
+// resolveSID issues a SID-keyed credential to the resolver, which routes it to
+// the LDAP/AD provider's objectSid search. Shared by UIDForSID/GIDForSID (they
+// differ only in which field of the resolved identity they return). Returns
+// ok=false on any error or a not-found result.
+func (b *directorySIDBridge) resolveSID(sidStr string) (*identity.ResolvedIdentity, bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), b.timeout)
 	defer cancel()
 	resolved, err := b.resolver.Resolve(ctx, &identity.Credential{ExternalID: sidStr})
 	if err != nil || resolved == nil || !resolved.Found {
-		return 0, false
+		return nil, false
 	}
-	return resolved.GID, true
+	return resolved, true
 }

--- a/pkg/identity/ldap/provider.go
+++ b/pkg/identity/ldap/provider.go
@@ -351,50 +351,74 @@ func sAMAccountNameFromPrincipal(s string) string {
 // Returns ok=false (never a fatal error) when no object matches or the directory
 // is unreachable, so a miss degrades to the raw SID rather than a fault.
 func (p *Provider) LookupUID(ctx context.Context, uid uint32) (name, domain string, ok bool) {
-	return p.reverseLookup(ctx, "user", "uidNumber", uid)
+	name, domain, _, ok = p.reverseLookup(ctx, "user", "uidNumber", uid)
+	return name, domain, ok
 }
 
 // LookupGID resolves a POSIX GID to an AD group name + realm. Mirrors LookupUID
 // for the GROUP SID on a file (matched on gidNumber in rfc2307, or the
 // reconstructed group SID on objectSid in rid mode).
 func (p *Provider) LookupGID(ctx context.Context, gid uint32) (name, domain string, ok bool) {
-	return p.reverseLookup(ctx, "group", "gidNumber", gid)
+	name, domain, _, ok = p.reverseLookup(ctx, "group", "gidNumber", gid)
+	return name, domain, ok
 }
 
-// reverseLookup maps a POSIX id back to a directory object's sAMAccountName,
-// using the idmap-appropriate filter (see reverseFilter). Infrastructure errors
-// are logged at Debug and folded into ok=false so a directory outage never
-// faults the LSARPC pipe.
-func (p *Provider) reverseLookup(ctx context.Context, objectClass, numAttr string, id uint32) (string, string, bool) {
+// SIDForUID resolves a POSIX UID to its real directory (AD) SID string, when the
+// uid maps to a directory user object. Backs the security-descriptor OWNER-SID
+// projection (#1617): a file owned by an AD user should carry the account's real
+// SID, not the algorithmic machine-domain SID. Returns ok=false for a local /
+// unknown uid so the caller keeps the machine SID.
+func (p *Provider) SIDForUID(ctx context.Context, uid uint32) (string, bool) {
+	_, _, sidStr, ok := p.reverseLookup(ctx, "user", "uidNumber", uid)
+	return sidStr, ok
+}
+
+// SIDForGID mirrors SIDForUID for a group GID → group SID.
+func (p *Provider) SIDForGID(ctx context.Context, gid uint32) (string, bool) {
+	_, _, sidStr, ok := p.reverseLookup(ctx, "group", "gidNumber", gid)
+	return sidStr, ok
+}
+
+// reverseLookup maps a POSIX id back to a directory object, returning its
+// sAMAccountName, realm, and canonical objectSid string, using the
+// idmap-appropriate filter (see reverseFilter). Infrastructure errors are logged
+// at Debug and folded into ok=false so a directory outage never faults the
+// LSARPC pipe.
+func (p *Provider) reverseLookup(ctx context.Context, objectClass, numAttr string, id uint32) (name, domain, sidStr string, ok bool) {
 	c, err := p.connect(ctx, p.cfg)
 	if err != nil {
 		logger.Debug("ldap: reverse lookup connect/bind failed", "attr", numAttr, "id", id, "error", err)
-		return "", "", false
+		return "", "", "", false
 	}
 	defer func() { _ = c.Close() }()
 
-	filter, ok := p.reverseFilter(c, objectClass, numAttr, id)
-	if !ok {
-		return "", "", false
+	filter, fok := p.reverseFilter(c, objectClass, numAttr, id)
+	if !fok {
+		return "", "", "", false
 	}
 	req := ldapv3.NewSearchRequest(
 		p.cfg.BaseDN,
 		ldapv3.ScopeWholeSubtree, ldapv3.NeverDerefAliases, 2, int(p.cfg.Timeout.Seconds()), false,
-		filter, []string{"sAMAccountName"}, nil,
+		filter, []string{"sAMAccountName", "objectSid"}, nil,
 	)
 	res, err := c.Search(req)
 	if err != nil {
 		logger.Debug("ldap: reverse lookup search failed", "filter", filter, "error", err)
-		return "", "", false
+		return "", "", "", false
 	}
 	if len(res.Entries) == 0 {
-		return "", "", false
+		return "", "", "", false
 	}
-	name := res.Entries[0].GetAttributeValue("sAMAccountName")
+	name = res.Entries[0].GetAttributeValue("sAMAccountName")
 	if name == "" {
-		return "", "", false
+		return "", "", "", false
 	}
-	return name, p.cfg.Realm, true
+	if raw := res.Entries[0].GetRawAttributeValue("objectSid"); len(raw) > 0 {
+		if s, _, derr := sid.DecodeSID(raw); derr == nil {
+			sidStr = sid.FormatSID(s)
+		}
+	}
+	return name, p.cfg.Realm, sidStr, true
 }
 
 // reverseFilter builds the LDAP filter that maps a POSIX id back to a directory

--- a/pkg/identity/ldap/provider.go
+++ b/pkg/identity/ldap/provider.go
@@ -370,13 +370,17 @@ func (p *Provider) LookupGID(ctx context.Context, gid uint32) (name, domain stri
 // unknown uid so the caller keeps the machine SID.
 func (p *Provider) SIDForUID(ctx context.Context, uid uint32) (string, bool) {
 	_, _, sidStr, ok := p.reverseLookup(ctx, "user", "uidNumber", uid)
-	return sidStr, ok
+	// ok from reverseLookup means "object found"; for this interface ok must mean
+	// "SID resolved", so an object whose objectSid was missing/undecodable (empty
+	// sidStr) is a miss — the caller then keeps the machine-domain SID rather than
+	// treating "" as a valid SID.
+	return sidStr, ok && sidStr != ""
 }
 
 // SIDForGID mirrors SIDForUID for a group GID → group SID.
 func (p *Provider) SIDForGID(ctx context.Context, gid uint32) (string, bool) {
 	_, _, sidStr, ok := p.reverseLookup(ctx, "group", "gidNumber", gid)
-	return sidStr, ok
+	return sidStr, ok && sidStr != ""
 }
 
 // reverseLookup maps a POSIX id back to a directory object, returning its
@@ -413,10 +417,19 @@ func (p *Provider) reverseLookup(ctx context.Context, objectClass, numAttr strin
 	if name == "" {
 		return "", "", "", false
 	}
+	// Decode objectSid into the canonical SID string. sidStr stays empty on a
+	// missing/undecodable attribute; the SID-returning callers (SIDForUID/GID,
+	// #1617) treat empty as a miss, while the name-only callers (LookupUID/GID)
+	// ignore it. Log the anomaly at Debug so an objectSid read regression (schema
+	// / ACL) is diagnosable rather than a silent fall-back to the machine SID.
 	if raw := res.Entries[0].GetRawAttributeValue("objectSid"); len(raw) > 0 {
 		if s, _, derr := sid.DecodeSID(raw); derr == nil {
 			sidStr = sid.FormatSID(s)
+		} else {
+			logger.Debug("ldap: reverse lookup objectSid decode failed", "name", name, "error", derr)
 		}
+	} else {
+		logger.Debug("ldap: reverse lookup entry has no objectSid", "name", name)
 	}
 	return name, p.cfg.Realm, sidStr, true
 }
@@ -596,6 +609,19 @@ func (p *Provider) deriveUIDGID(entry *ldapv3.Entry) (uint32, uint32, error) {
 				return 0, 0, fmt.Errorf("ldap: parse gidNumber %q: %w", gidStr, err)
 			}
 			return uid, gid, nil
+		}
+		// A group object carries gidNumber but no uidNumber, so the paired guard
+		// above misses it. Honor the stamped gidNumber directly (GID==UID for a
+		// group's own identity) rather than falling through to the RID. Without
+		// this, resolving a group SID (#1617 GIDForSID: SID→GID for a Group SD
+		// round-trip) would recover the group's RID instead of its real gidNumber
+		// and silently rewrite a file's gid on an owner/group re-set.
+		if gidStr != "" && isGroupEntry(entry) {
+			gid, err := parseUint32(gidStr)
+			if err != nil {
+				return 0, 0, fmt.Errorf("ldap: parse gidNumber %q: %w", gidStr, err)
+			}
+			return gid, gid, nil
 		}
 		logger.Debug("ldap: RFC2307 attrs absent, falling back to RID idmap",
 			"dn", entry.DN)

--- a/pkg/identity/ldap/provider_test.go
+++ b/pkg/identity/ldap/provider_test.go
@@ -504,3 +504,28 @@ func TestLookupUID_RIDMode_NoDomainSID(t *testing.T) {
 		t.Error("must not issue an account objectSid search without a domain SID")
 	}
 }
+
+// TestDeriveUIDGID_RFC2307_GroupUsesGidNumber guards the #1617 round-trip fix: a
+// group object carries gidNumber but no uidNumber, so the paired uid+gid guard
+// misses it. deriveUIDGID must honor the stamped gidNumber rather than falling
+// through to the RID — otherwise resolving a group SID back to a GID (Group SD
+// round-trip) would recover the RID and silently rewrite a file's gid.
+func TestDeriveUIDGID_RFC2307_GroupUsesGidNumber(t *testing.T) {
+	p, err := New(baseCfg(), nil, nil) // baseCfg() is IdmapRFC2307
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Group entry: objectClass=group, gidNumber present, NO uidNumber, RID 1105.
+	e := entry("CN=devs,CN=Users,DC=dittofs,DC=ad", map[string][]string{
+		"objectClass": {"top", "group"},
+		"gidNumber":   {"10010"},
+	}, encodeSID(t, 1105))
+
+	_, gid, err := p.deriveUIDGID(e)
+	if err != nil {
+		t.Fatalf("deriveUIDGID: %v", err)
+	}
+	if gid != 10010 {
+		t.Errorf("gid = %d, want 10010 (gidNumber, not RID 1105)", gid)
+	}
+}

--- a/pkg/identity/resolver.go
+++ b/pkg/identity/resolver.go
@@ -165,12 +165,61 @@ type ReverseResolver interface {
 	LookupGID(ctx context.Context, gid uint32) (name, domain string, ok bool)
 }
 
+// SIDReverseResolver is an optional capability a Provider may implement to map a
+// POSIX UID/GID to its real directory (AD) SID. It backs emitting a file
+// owner/group as the account's actual SID rather than the algorithmic
+// machine-domain SID (#1617). A miss returns ok=false and is never an error.
+type SIDReverseResolver interface {
+	// SIDForUID resolves a POSIX UID to its directory user SID string.
+	SIDForUID(ctx context.Context, uid uint32) (sidStr string, ok bool)
+	// SIDForGID resolves a POSIX GID to its directory group SID string.
+	SIDForGID(ctx context.Context, gid uint32) (sidStr string, ok bool)
+}
+
 // reverseUIDKey / reverseGIDKey are synthetic cache keys for reverse lookups.
 // They share the Resolver's cache (positive + negative TTL) with forward
 // resolution but cannot collide with a forward key, which always embeds a
 // provider name and an ExternalID via cacheKey.
-func reverseUIDKey(uid uint32) string { return fmt.Sprintf("ruid:%d", uid) }
-func reverseGIDKey(gid uint32) string { return fmt.Sprintf("rgid:%d", gid) }
+func reverseUIDKey(uid uint32) string    { return fmt.Sprintf("ruid:%d", uid) }
+func reverseGIDKey(gid uint32) string    { return fmt.Sprintf("rgid:%d", gid) }
+func reverseSIDUIDKey(uid uint32) string { return fmt.Sprintf("rsiduid:%d", uid) }
+func reverseSIDGIDKey(gid uint32) string { return fmt.Sprintf("rsidgid:%d", gid) }
+
+// SIDForUID resolves a POSIX UID to its real directory SID via any provider that
+// implements SIDReverseResolver, cached like the other reverse lookups. Returns
+// ok=false for a local/unknown uid so the caller keeps the machine-domain SID.
+func (r *Resolver) SIDForUID(ctx context.Context, uid uint32) (string, bool) {
+	return r.reverseSID(reverseSIDUIDKey(uid), func(sr SIDReverseResolver) (string, bool) {
+		return sr.SIDForUID(ctx, uid)
+	})
+}
+
+// SIDForGID mirrors SIDForUID for a group GID → group SID.
+func (r *Resolver) SIDForGID(ctx context.Context, gid uint32) (string, bool) {
+	return r.reverseSID(reverseSIDGIDKey(gid), func(sr SIDReverseResolver) (string, bool) {
+		return sr.SIDForGID(ctx, gid)
+	})
+}
+
+// reverseSID runs a cached UID/GID → SID lookup against the provider chain,
+// riding the identity cache via ResolvedIdentity.SID.
+func (r *Resolver) reverseSID(key string, query func(SIDReverseResolver) (string, bool)) (string, bool) {
+	if cached, _, hit := r.cache.get(key); hit && cached != nil {
+		return cached.SID, cached.Found
+	}
+	for _, p := range r.providers {
+		sr, capable := p.(SIDReverseResolver)
+		if !capable {
+			continue
+		}
+		if sidStr, ok := query(sr); ok && sidStr != "" {
+			r.cache.put(key, &ResolvedIdentity{SID: sidStr, Found: true}, nil)
+			return sidStr, true
+		}
+	}
+	r.cache.put(key, &ResolvedIdentity{Found: false}, nil)
+	return "", false
+}
 
 // LookupUID resolves a POSIX UID to a directory account name + domain by
 // consulting every registered provider that implements ReverseResolver, in

--- a/pkg/identity/resolver_test.go
+++ b/pkg/identity/resolver_test.go
@@ -347,14 +347,18 @@ func TestResolver_ConcurrentAccess(t *testing.T) {
 	}
 }
 
-// reverseMockProvider is a mockProvider that also implements ReverseResolver,
-// used to exercise the resolver's reverse uid/gid lookup chain.
+// reverseMockProvider is a mockProvider that also implements ReverseResolver and
+// SIDReverseResolver, used to exercise the resolver's reverse uid/gid lookup and
+// uid/gid → SID chains.
 type reverseMockProvider struct {
 	mockProvider
-	uids     map[uint32]string
-	gids     map[uint32]string
-	domain   string
-	uidCalls atomic.Int32
+	uids        map[uint32]string
+	gids        map[uint32]string
+	sidUIDs     map[uint32]string
+	sidGIDs     map[uint32]string
+	domain      string
+	uidCalls    atomic.Int32
+	sidUIDCalls atomic.Int32
 }
 
 func (m *reverseMockProvider) LookupUID(_ context.Context, uid uint32) (string, string, bool) {
@@ -370,6 +374,24 @@ func (m *reverseMockProvider) LookupGID(_ context.Context, gid uint32) (string, 
 		return n, m.domain, true
 	}
 	return "", "", false
+}
+
+// SIDForUID returns ok=true whenever the uid is known — INCLUDING when the mapped
+// SID is empty — so the Resolver's own "empty SID is a miss" guard is exercised
+// rather than short-circuited here.
+func (m *reverseMockProvider) SIDForUID(_ context.Context, uid uint32) (string, bool) {
+	m.sidUIDCalls.Add(1)
+	if s, ok := m.sidUIDs[uid]; ok {
+		return s, true
+	}
+	return "", false
+}
+
+func (m *reverseMockProvider) SIDForGID(_ context.Context, gid uint32) (string, bool) {
+	if s, ok := m.sidGIDs[gid]; ok {
+		return s, true
+	}
+	return "", false
 }
 
 // TestResolver_ReverseLookup_Chain verifies LookupUID/LookupGID consult only
@@ -427,5 +449,74 @@ func TestResolver_ReverseLookup_Cached(t *testing.T) {
 	}
 	if got := dir.uidCalls.Load(); got != 2 {
 		t.Errorf("provider LookupUID called %d times total, want 2 (one hit + one miss, both cached)", got)
+	}
+}
+
+// TestResolver_SIDForUID_Chain verifies SIDForUID/SIDForGID consult only
+// providers implementing SIDReverseResolver (a plain provider in the chain is
+// skipped, not a panic) and that the first hit wins (#1617).
+func TestResolver_SIDForUID_Chain(t *testing.T) {
+	plain := &mockProvider{name: "kerberos"} // no SIDReverseResolver
+	dir := &reverseMockProvider{
+		mockProvider: mockProvider{name: "ldap"},
+		sidUIDs:      map[uint32]string{500: "S-1-5-21-1-2-3-500"},
+		sidGIDs:      map[uint32]string{512: "S-1-5-21-1-2-3-512"},
+	}
+	r := NewResolver(WithProvider(plain), WithProvider(dir))
+
+	if s, ok := r.SIDForUID(context.Background(), 500); !ok || s != "S-1-5-21-1-2-3-500" {
+		t.Fatalf("SIDForUID(500) = (%q, %v), want (S-1-5-21-1-2-3-500, true)", s, ok)
+	}
+	if s, ok := r.SIDForGID(context.Background(), 512); !ok || s != "S-1-5-21-1-2-3-512" {
+		t.Fatalf("SIDForGID(512) = (%q, %v), want (S-1-5-21-1-2-3-512, true)", s, ok)
+	}
+	if _, ok := r.SIDForUID(context.Background(), 999); ok {
+		t.Error("SIDForUID(999) should miss (unknown uid)")
+	}
+}
+
+// TestResolver_SIDForUID_Cached verifies a repeated SID lookup is served from
+// cache — the provider is queried once for a hit and once for a miss — matching
+// the LookupUID cache semantics.
+func TestResolver_SIDForUID_Cached(t *testing.T) {
+	dir := &reverseMockProvider{
+		mockProvider: mockProvider{name: "ldap"},
+		sidUIDs:      map[uint32]string{42: "S-1-5-21-9-9-9-42"},
+	}
+	r := NewResolver(WithProvider(dir))
+
+	for i := 0; i < 3; i++ {
+		if s, ok := r.SIDForUID(context.Background(), 42); !ok || s != "S-1-5-21-9-9-9-42" {
+			t.Fatalf("iter %d: SIDForUID(42) = (%q, %v)", i, s, ok)
+		}
+	}
+	if got := dir.sidUIDCalls.Load(); got != 1 {
+		t.Errorf("provider SIDForUID called %d times, want 1 (cached)", got)
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, ok := r.SIDForUID(context.Background(), 7); ok {
+			t.Fatalf("iter %d: SIDForUID(7) should miss", i)
+		}
+	}
+	if got := dir.sidUIDCalls.Load(); got != 2 {
+		t.Errorf("provider SIDForUID called %d times total, want 2 (one hit + one miss, both cached)", got)
+	}
+}
+
+// TestResolver_SIDForUID_EmptyIsMiss verifies that a provider returning
+// (sidStr="", ok=true) — a directory object with no usable objectSid — is
+// treated as a MISS by the Resolver, so the caller keeps the machine-domain SID
+// rather than an empty string (#1617; also guards the ldap provider's own
+// empty-SID gate at a different layer).
+func TestResolver_SIDForUID_EmptyIsMiss(t *testing.T) {
+	dir := &reverseMockProvider{
+		mockProvider: mockProvider{name: "ldap"},
+		sidUIDs:      map[uint32]string{500: ""}, // known uid, but empty SID
+	}
+	r := NewResolver(WithProvider(dir))
+
+	if s, ok := r.SIDForUID(context.Background(), 500); ok || s != "" {
+		t.Fatalf("SIDForUID(500) = (%q, %v), want (\"\", false) — empty SID must be a miss", s, ok)
 	}
 }


### PR DESCRIPTION
Follow-up to #1610. Closes #1617.

Emits a file's owner/group SID as its **real directory (AD) SID** when the uid/gid maps to a directory account, instead of the algorithmic machine-domain SID — so an AD-owned file's owner uses the same SID its PAC and share grants carry. This also removes the last source of the multi-domain LSARPC crash class (`d06fb7ff` fixed it minimally by deduping referenced domains by SID; emitting the owner as its true AD SID means the owner and the AD grants share one referenced domain to begin with).

Local accounts keep the machine SID; the bridge only hits when the directory actually holds the account, so **non-AD / local-only / smbtorture deployments are a byte-for-byte no-op**.

### Design
Machine SIDs use the Samba algorithmic RID (`uid*2+1000`); AD SIDs in `idmap:rid` use `RID = uid` against the AD domain SID — a separate path. A package-level `DirectorySIDBridge` hook in `handlers` couples uid/gid ↔ AD SID in both directions:

- **Emit** (`ownerSIDFor`/`groupSIDFor`): owner/group SD fields and the `OWNER@`/`GROUP@` special ACEs advertise the AD SID when the bridge maps it, else fall back to the machine SID.
- **Parse** (`directoryUIDForSID`/`directoryGIDForSID`): when Windows echoes the AD-SID owner back through SET_INFO, recover the same uid/gid so the change round-trips instead of tripping the `#1228` unmappable-owner gate.

The bridge (`pkg/adapter/smb/directory_sid_bridge.go`) wraps `identity.Resolver` (`SIDForUID/SIDForGID` emit, `Resolve` by SID for parse) and is wired in `wireForeignSIDResolver` next to the LSARPC foreign-SID resolver — same resolver chain, same config-change re-run.

### Changes
- [x] `ldap.Provider.SIDForUID/SIDForGID` (uid/gid → directory SID; reverse lookup returns objectSid)
- [x] `identity.Resolver.SIDForUID/SIDForGID` (cached, provider-chain delegation)
- [x] `handlers` `DirectorySIDBridge` hook + emit/parse integration in `security.go`
- [x] `pkg/adapter/smb` bridge over `identity.Resolver` + wiring
- [x] Unit tests (emit AD SID, machine-SID fallback no-op, AD-owner round-trip, OWNER@ ACE)
- [x] AD testbed validation — mounted as alice; `admin.txt` owner shows `CUBBITAdministrator` (real AD SID), all rows resolve `CUBBIT...`, no crash, no raw SIDs
