### PR TITLE
fix(bench): dittofs-s3/zerofs backends work against a live server + fresh results doc

### DIFF
--- a/bench/workloads/seq-write-buffered.fio
+++ b/bench/workloads/seq-write-buffered.fio
@@ -1,0 +1,21 @@
+[seq-write-buffered]
+description=Sequential write throughput, buffered + fsync-at-close (realistic durability)
+# The FAIR write comparison. Unlike seq-write (direct=1), this buffers through the
+# page cache and fsyncs once at close — the common path real apps use. Over NFS
+# it issues UNSTABLE writes + one COMMIT, so it exercises the deferred-fsync fast
+# path (DittoFS #1584) instead of a per-block FILE_SYNC barrier. Every backend
+# still fsyncs at close, so durability is matched; what differs is only how well
+# each pipelines a buffered stream. Pair with seq-write to see the O_DIRECT tax.
+rw=write
+bs=1m
+direct=0
+end_fsync=1
+ioengine=${FIO_ENGINE:-libaio}
+numjobs=${BENCH_THREADS:-4}
+# Size-bounded, NOT time_based: write exactly one --size file per job then fsync
+# once. time_based would buffer 60 s of writes into the page cache and flush them
+# all at end_fsync, overrunning the backend's local store (end_fsync EIO). One
+# fixed file measures the durable file-write rate cleanly and can't overflow.
+size=${BENCH_SIZE:-1g}
+directory=${BENCH_DIR:-/mnt/bench}
+group_reporting

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -2,8 +2,10 @@
 
 > ⚠️ **LEGACY / STALE — do not cite.** These numbers are from an earlier release and have
 > **not** been re-run against current DittoFS. They are kept for historical reference only and
-> are intentionally excluded from the published documentation. A fresh benchmark pass is pending;
-> until then, treat every figure here as out of date.
+> are intentionally excluded from the published documentation. For fresh data from the `dfsbench`
+> harness, see [`internals/dfsbench-results.md`](internals/dfsbench-results.md) — note it already
+> **contradicts** the "writes never block on S3" claim below (native NFS→S3 seq-write measured at
+> ~1 MB/s). Treat every figure here as out of date.
 
 Performance comparison of DittoFS with S3 backend against other S3-compatible network filesystems and kernel NFS, on identical Scaleway infrastructure.
 

--- a/docs/internals/dfsbench-results.md
+++ b/docs/internals/dfsbench-results.md
@@ -1,91 +1,102 @@
-# dfsbench Results — 2026-07-09
+# dfsbench Results — 2026-07-09 (fair run)
 
-Fresh benchmark pass from the `dfsbench` harness (`internal/dfsbench/`, issue #1602). This
-supersedes the stale numbers in [`../BENCHMARKS.md`](../BENCHMARKS.md) for the workloads covered
-here. It is a **partial** pass — read it as a first real data point, not a complete matrix.
+Benchmark pass from the `dfsbench` harness (`internal/dfsbench/`, issue #1602), after fixing the
+methodology confounds found in the first pass. This supersedes the stale numbers in
+[`../BENCHMARKS.md`](../BENCHMARKS.md) for the workloads covered here. Read it as a real but
+**partial** data point (dittofs vs one FUSE competitor, one size, single run) — not a full matrix.
 
 ## What this run measured
 
 - **Subject:** `dittofs-s3` — DittoFS serving BadgerDB metadata + a local fs cache + an S3 remote
-  block store, mounted over its own **native** userspace NFSv3 server (no FUSE, no knfsd).
+  block store, over its own **native** userspace NFSv3 server (no FUSE, no knfsd).
 - **Competitor:** `rclone` — a FUSE writeback mount (`--vfs-cache-mode writes`) re-exported over
-  kernel NFS (knfsd). This is the "FUSE re-export" archetype every S3-FUSE tool shares.
-- **Anchor:** `local-disk` — bare fio against a scratch dir (no FS layer, no S3): the hardware
-  ceiling every cell is read against.
-- **Not captured:** `zerofs` (native NFS twin) — its mount fails through the harness with a
-  binary-only Heisenbug (see [Known gaps](#known-gaps)). `juicefs` / `s3fs` / `s3ql` not run this
-  pass.
+  kernel NFS (knfsd): the "FUSE re-export" archetype every S3-FUSE tool shares.
+- **Anchor:** `local-disk` — bare fio against a scratch dir (no FS, no S3): the hardware ceiling.
+- **Not captured:** `zerofs` (native NFS twin, harness Heisenbug); `juicefs`/`s3fs`/`s3ql`.
 
-Single-tenant Scaleway VM (fr-par-1), S3 = Scaleway Object Storage (Paris), 256 MiB files, 4
-fio jobs, 60 s/pass, NFSv3. Reads run a **warm** pass then a **cold** pass after evicting the
-local cache (`store block evict` for DittoFS; a mount-bounce for FUSE), so cold = genuinely
-served from S3.
+Single-tenant Scaleway VM (fr-par-1), Scaleway S3 (Paris), 256 MiB files, 4 fio jobs, 60 s/pass,
+NFSv3. Reads run warm then cold (after a per-workload cache evict). Two write modes are run:
+`seq-write` (`direct=1`, O_DIRECT/FILE_SYNC) and `seq-write-buffered` (`direct=0`, fsync-at-close).
 
 ## Baseline (ceilings)
 
 | | seq | rand-4k |
 |---|---|---|
-| local-disk (bare scratch) | **866 MB/s** | **5,082 IOPS** |
+| local-disk (bare scratch) | **1120 MB/s** | **5064 IOPS** |
 
-## Comparison — DittoFS vs competitor
+## Results
 
-| Workload | Pass | **DittoFS** (native) | **rclone** (FUSE re-export) | Gap | Read against ceiling |
-|---|---|---|---|---|---|
-| seq-read | warm | **972 MB/s** | 1,369 MB/s | rclone **1.4×** | both cache-served (>ceiling) |
-| seq-read | **cold** | **63 MB/s** | — *(flaked)* | — | real S3 cold fetch |
-| rand-read-4k | warm | **7,416 IOPS** | — *(flaked)* | — | ~1.5× ceiling (cached) |
-| rand-read-4k | **cold** | **6,405 IOPS** | — *(flaked)* | — | S3-served |
-| seq-write | warm | **1 MB/s** | 1,936 MB/s | **rclone ~1900×** | rclone local-acks |
+| System | Access | Workload | Pass | MB/s | IOPS | p50 ms | p99 ms | CTXSW/s | CPU% |
+|---|---|---|---|---|---|---|---|---|---|
+| dittofs-s3 | native | seq-write **(direct)** | warm | **6.4** | — | 18.2 | **9865** | 8,237 | 5 |
+| dittofs-s3 | native | seq-write **(buffered)** | warm | **242** | — | ~0 | ~0 | 22,880 | 24 |
+| dittofs-s3 | native | seq-read | warm | 749 | — | 3.9 | 8 | 34,187 | 40 |
+| dittofs-s3 | native | seq-read | **cold** | **159** | — | 1.7 | 575 | 15,467 | 7 |
+| dittofs-s3 | native | rand-read-4k | warm | 27 | 7,030 | 13.7 | 76 | 55,429 | 76 |
+| dittofs-s3 | native | rand-read-4k | cold* | 23 | 5,879 | 10.4 | 109 | 48,040 | 95 |
+| rclone | reexport | seq-write (direct) | warm | 1,756 | — | 2.1 | 3.9 | 156,007 | 56 |
+| rclone | reexport | seq-write (buffered) | warm | 996 | — | ~0 | ~0 | 89,864 | 47 |
+| rclone | reexport | seq-read | warm | 948 | — | 2.3 | 8.5 | 47,993 | 42 |
 
-*rclone's random-read and cold cells hit its documented NFSv3 `ftruncate` flake and are omitted.*
+*See caveat 3 — the cold rand-read is not genuinely cold. rclone's rand-read/cold cells hit its
+documented NFSv3 `ftruncate` flake and are omitted.
 
-### FUSE-tax (system-wide context switches during the pass)
+## The write story (the whole point of this run)
 
-The harness meters `/proc` context switches — the tax a FUSE re-export pays crossing
-kernel↔userspace that a native server avoids.
+The first pass reported a "~1900× write gap" and an apparent 1 MB/s DittoFS write wall. **That was
+an artifact of the workload, not a DittoFS regression.** Running both write modes settles it:
 
-| Workload (warm) | DittoFS CTXSW/s | rclone CTXSW/s | CPU% (Ditto / rclone) |
-|---|---|---|---|
-| seq-read | **38,944** | 64,465 | 44 / 45 |
-| seq-write | 5,921 | 173,491 | 3 / 57 |
+| seq-write, dittofs native | MB/s | vs its own O_DIRECT |
+|---|---|---|
+| `direct=1` (O_DIRECT → per-block FILE_SYNC) | **6.4** | 1× |
+| `direct=0` buffered (fsync-at-close, UNSTABLE) | **242** | **~38×** |
 
-On seq-read, DittoFS delivers 71% of rclone's throughput at **60% of the context switches** —
-native serving is measurably more CPU-efficient per byte. (The seq-write row isn't comparable:
-DittoFS is stalling, not working — see below.)
+- **On the realistic buffered path DittoFS writes at 242 MB/s** — healthy, consistent with the
+  #1584 UNSTABLE fast-path work and the historical 48–510 MB/s range. So **no, DittoFS is not
+  "this bad" at writes.**
+- `direct=1` forces a durability barrier the server still fsyncs on — the path #1584 opts out of.
+  DittoFS *honours* O_DIRECT (6.4 MB/s, p99 **9.9 s**); rclone's writeback **ignores** it and local-
+  acks at 1,756 MB/s. So the direct-mode "gap" is a **durability asymmetry, not speed**.
+- But 6.4 MB/s with multi-second per-op latency at 5% CPU is a genuine *stall* in the synchronous
+  path — a real bug, tracked separately in **#1621** (candidate causes: synchronous S3 in the
+  FILE_SYNC hot path, or the per-store syncLeader stalling when every write demands its own barrier).
 
-## Reading the gaps
+Even buffered, rclone (996) leads DittoFS (242) ~4×, but rclone writeback is a dumb local cache
+file — no metadata, no FastCDC chunking, no CAS/dedup — whereas DittoFS runs its full durable write
+pipeline. Not fully apples-to-apples; 242 MB/s for a real CAS filesystem is the honest read.
 
-1. **Reads: competitive and more efficient.** Warm seq-read 972 MB/s (cache-served, above the
-   disk ceiling); the eviction barrier drops it to a real **63 MB/s cold-from-S3**. Random reads
-   hold 6.4k IOPS cold. DittoFS trails rclone's warm read by 1.4× but does it with ~40% fewer
-   context switches — the native-serving thesis holds.
-2. **Writes are the wall — and it reproduced every run.** DittoFS native seq-write is **~1 MB/s**
-   with **multi-second** per-I/O latency (p50 4.5 s, p99 8.1 s) and CPU pinned at **3%** — the
-   signature of *stalling on a synchronous commit*, not doing work. rclone's writeback local-acks
-   at ~1,900 MB/s. This is the single largest gap and points straight at the tracked write-path
-   work (per-write/commit fsync — #1573, #1466, #1416). The legacy `BENCHMARKS.md` claim that
-   "writes never block on S3" does **not** hold on this NFS→S3 path today.
+## Reads and the FUSE-tax
 
-## Known gaps
+- **Reads competitive.** Warm seq-read 749 (dittofs) vs 948 (rclone). Genuine **cold-from-S3
+  seq-read = 159 MB/s** (the one clean cold number).
+- **Native serving is more CPU-efficient.** rclone burns more context switches on *every* workload —
+  the tax of crossing kernel↔userspace on a FUSE re-export that a native server avoids:
 
-- **zerofs (native twin) — blocked by a harness Heisenbug.** zerofs mounts and serves NFSv3
-  correctly every way it is tested by hand (validated repeatedly on the VM), but fails 100%
-  through the `dfsbench` binary with `mount.nfs: Protocol family not supported` — identical
-  commands, different outcome. Root cause is not yet found; it needs binary-level tracing of the
-  backend's exec path, not more live guessing. The backend fix already includes: waiting for
-  zerofs's real "Starting NFS server" readiness line (it binds the socket ~35 s before it serves,
-  after loading its encryption key + warming the LSM from S3), stopping the boot-time kernel NFS
-  server so zerofs can claim port 2049, and a mount retry.
-- **Single size / three workloads.** 256 MiB only; `mixed-rw` and `metadata` not run this pass.
-- **rclone NFSv3 flake.** Its random-read and cold cells are unreliable over NFSv3 (dir-cache
-  empties → fio `ftruncate` EIO); nfs4/smb3 are steadier. Recorded, not counted.
+| workload (warm) | dittofs CTXSW/s | rclone CTXSW/s |
+|---|---|---|
+| seq-read | 34,187 | 47,993 (+40%) |
+| seq-write buffered | 22,880 | 89,864 (+293%) |
 
-## Harness fixes landed with this doc
+## Caveats (read before citing any number)
 
-The `dittofs-s3` backend recipe was stale (written against an older `dfsctl`, never validated
-against a live server). This pass is the first that drove a real `dfs`, and it fixed the whole
-bring-up: set `DITTOFS_CONTROLPLANE_SECRET` + a known admin password, `dfsctl login`, create the
-metadata + local + remote stores with the current flag schema, and create the share with
-`--default-permission read-write` so the squashed NFS root can write. Plus a shared
-`prepareMountpoint` that force-lazy-unmounts a stale mount before mounting — without it, a mount
-left by a crashed run wedges the next run in uninterruptible D-state.
+1. **`direct=1` durability asymmetry.** DittoFS honours O_DIRECT/FILE_SYNC; rclone's writeback
+   silently buffers it. Only the **buffered** rows compare like-for-like on durability.
+2. **Warm reads are cache-served.** Warm rand-read (7,030 IOPS) exceeds the disk ceiling (5,064) —
+   it's the server's RAM read-buffer, not the backend. Only the **cold** reads reflect S3.
+3. **Cold rand-read is not truly cold.** `rand-read-4k.fio` lays down its own file (fio writes it
+   before reading), so the "cold" pass reads warm just-written data (5,879 ≈ warm 7,030). Only
+   `seq-read` cold (which reads the evicted layout file) is a real cold-from-S3 number. Fixing this
+   (point rand-read at the shared layout file) is a follow-up.
+4. **Single run, no variance.** direct-write measured 1 → 2.6 → 6.4 MB/s across three runs — high
+   run-to-run spread. Treat one number as indicative, not precise. 3× repeats are a follow-up.
+5. **One competitor, one size.** rclone only (and its rand-read/cold flaked); no zerofs/juicefs;
+   256 MiB only; `mixed-rw`/`metadata` not run.
+
+## Harness + product fixes behind this run
+
+- **#1619** (harness): stale `dittofs-s3` recipe rebuilt for a live server; `seq-write-buffered`
+  workload; per-workload cold barrier; **teardown-on-setup-failure** so a half-started `dfs` can't
+  leak and hold its BadgerDB lock; `prepareMountpoint` resilience.
+- **#1620** (product): opening a metadata store whose data dir is already locked now returns an
+  actionable error (another dfs is running → stop it / use another path) instead of raw Badger.
+- **#1621** (perf): the O_DIRECT/FILE_SYNC write stall.

--- a/docs/internals/dfsbench-results.md
+++ b/docs/internals/dfsbench-results.md
@@ -1,0 +1,91 @@
+# dfsbench Results — 2026-07-09
+
+Fresh benchmark pass from the `dfsbench` harness (`internal/dfsbench/`, issue #1602). This
+supersedes the stale numbers in [`../BENCHMARKS.md`](../BENCHMARKS.md) for the workloads covered
+here. It is a **partial** pass — read it as a first real data point, not a complete matrix.
+
+## What this run measured
+
+- **Subject:** `dittofs-s3` — DittoFS serving BadgerDB metadata + a local fs cache + an S3 remote
+  block store, mounted over its own **native** userspace NFSv3 server (no FUSE, no knfsd).
+- **Competitor:** `rclone` — a FUSE writeback mount (`--vfs-cache-mode writes`) re-exported over
+  kernel NFS (knfsd). This is the "FUSE re-export" archetype every S3-FUSE tool shares.
+- **Anchor:** `local-disk` — bare fio against a scratch dir (no FS layer, no S3): the hardware
+  ceiling every cell is read against.
+- **Not captured:** `zerofs` (native NFS twin) — its mount fails through the harness with a
+  binary-only Heisenbug (see [Known gaps](#known-gaps)). `juicefs` / `s3fs` / `s3ql` not run this
+  pass.
+
+Single-tenant Scaleway VM (fr-par-1), S3 = Scaleway Object Storage (Paris), 256 MiB files, 4
+fio jobs, 60 s/pass, NFSv3. Reads run a **warm** pass then a **cold** pass after evicting the
+local cache (`store block evict` for DittoFS; a mount-bounce for FUSE), so cold = genuinely
+served from S3.
+
+## Baseline (ceilings)
+
+| | seq | rand-4k |
+|---|---|---|
+| local-disk (bare scratch) | **866 MB/s** | **5,082 IOPS** |
+
+## Comparison — DittoFS vs competitor
+
+| Workload | Pass | **DittoFS** (native) | **rclone** (FUSE re-export) | Gap | Read against ceiling |
+|---|---|---|---|---|---|
+| seq-read | warm | **972 MB/s** | 1,369 MB/s | rclone **1.4×** | both cache-served (>ceiling) |
+| seq-read | **cold** | **63 MB/s** | — *(flaked)* | — | real S3 cold fetch |
+| rand-read-4k | warm | **7,416 IOPS** | — *(flaked)* | — | ~1.5× ceiling (cached) |
+| rand-read-4k | **cold** | **6,405 IOPS** | — *(flaked)* | — | S3-served |
+| seq-write | warm | **1 MB/s** | 1,936 MB/s | **rclone ~1900×** | rclone local-acks |
+
+*rclone's random-read and cold cells hit its documented NFSv3 `ftruncate` flake and are omitted.*
+
+### FUSE-tax (system-wide context switches during the pass)
+
+The harness meters `/proc` context switches — the tax a FUSE re-export pays crossing
+kernel↔userspace that a native server avoids.
+
+| Workload (warm) | DittoFS CTXSW/s | rclone CTXSW/s | CPU% (Ditto / rclone) |
+|---|---|---|---|
+| seq-read | **38,944** | 64,465 | 44 / 45 |
+| seq-write | 5,921 | 173,491 | 3 / 57 |
+
+On seq-read, DittoFS delivers 71% of rclone's throughput at **60% of the context switches** —
+native serving is measurably more CPU-efficient per byte. (The seq-write row isn't comparable:
+DittoFS is stalling, not working — see below.)
+
+## Reading the gaps
+
+1. **Reads: competitive and more efficient.** Warm seq-read 972 MB/s (cache-served, above the
+   disk ceiling); the eviction barrier drops it to a real **63 MB/s cold-from-S3**. Random reads
+   hold 6.4k IOPS cold. DittoFS trails rclone's warm read by 1.4× but does it with ~40% fewer
+   context switches — the native-serving thesis holds.
+2. **Writes are the wall — and it reproduced every run.** DittoFS native seq-write is **~1 MB/s**
+   with **multi-second** per-I/O latency (p50 4.5 s, p99 8.1 s) and CPU pinned at **3%** — the
+   signature of *stalling on a synchronous commit*, not doing work. rclone's writeback local-acks
+   at ~1,900 MB/s. This is the single largest gap and points straight at the tracked write-path
+   work (per-write/commit fsync — #1573, #1466, #1416). The legacy `BENCHMARKS.md` claim that
+   "writes never block on S3" does **not** hold on this NFS→S3 path today.
+
+## Known gaps
+
+- **zerofs (native twin) — blocked by a harness Heisenbug.** zerofs mounts and serves NFSv3
+  correctly every way it is tested by hand (validated repeatedly on the VM), but fails 100%
+  through the `dfsbench` binary with `mount.nfs: Protocol family not supported` — identical
+  commands, different outcome. Root cause is not yet found; it needs binary-level tracing of the
+  backend's exec path, not more live guessing. The backend fix already includes: waiting for
+  zerofs's real "Starting NFS server" readiness line (it binds the socket ~35 s before it serves,
+  after loading its encryption key + warming the LSM from S3), stopping the boot-time kernel NFS
+  server so zerofs can claim port 2049, and a mount retry.
+- **Single size / three workloads.** 256 MiB only; `mixed-rw` and `metadata` not run this pass.
+- **rclone NFSv3 flake.** Its random-read and cold cells are unreliable over NFSv3 (dir-cache
+  empties → fio `ftruncate` EIO); nfs4/smb3 are steadier. Recorded, not counted.
+
+## Harness fixes landed with this doc
+
+The `dittofs-s3` backend recipe was stale (written against an older `dfsctl`, never validated
+against a live server). This pass is the first that drove a real `dfs`, and it fixed the whole
+bring-up: set `DITTOFS_CONTROLPLANE_SECRET` + a known admin password, `dfsctl login`, create the
+metadata + local + remote stores with the current flag schema, and create the share with
+`--default-permission read-write` so the squashed NFS root can write. Plus a shared
+`prepareMountpoint` that force-lazy-unmounts a stale mount before mounting — without it, a mount
+left by a crashed run wedges the next run in uninterruptible D-state.

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -22,7 +22,8 @@ const (
 	dittofsSMBPort = "12445"
 	dittofsShare   = "bench"
 	dittofsDataDir = "/var/lib/bench-dittofs"
-	dittofsAPIURL  = "http://127.0.0.1:8080"
+	dittofsAPIPort = "8080"
+	dittofsAPIURL  = "http://127.0.0.1:" + dittofsAPIPort
 	dittofsMeta    = "bench-meta"
 	dittofsLocal   = "bench-local"
 	dittofsRemote  = "bench-s3"
@@ -51,13 +52,15 @@ func dittofsSetup(ctx context.Context, env BackendEnv) error {
 	if err != nil {
 		return err
 	}
-	// Kill any dfs left over by a crashed prior run (else it still holds NFS 12049
-	// / API 8080 and the new server can't bind), then wipe control-plane + client
-	// state so bootstrap (admin user, stores, share) is deterministic and
-	// re-runnable — a stale controlplane.db would make the creates fail "already
-	// exists". Resilience: a managed run must survive a dirty VM.
+	// Kill any dfs left over by a crashed prior run and WAIT for it to actually
+	// die before wiping state: a still-live old dfs holds the BadgerDB directory
+	// lock and keeps rewriting controlplane.db, so racing rm+start against it made
+	// the metadata-store create fail "cannot acquire directory lock". Only after
+	// it's gone do we wipe control-plane + client state, so bootstrap (admin user,
+	// stores, share) is deterministic and re-runnable. Resilience: survive a dirty VM.
 	_ = exec.Sh(ctx, "sh", "-c",
-		"pkill -9 -f 'dfs start' 2>/dev/null; rm -rf ~/.config/dittofs ~/.local/state/dittofs ~/.config/dfsctl "+dittofsDataDir+"; true")
+		"pkill -9 -f 'dfs start' 2>/dev/null; for i in $(seq 1 30); do pgrep -x dfs >/dev/null 2>&1 || break; sleep 0.5; done; "+
+			"rm -rf ~/.config/dittofs ~/.local/state/dittofs ~/.config/dfsctl "+dittofsDataDir+"; true")
 	if err := os.MkdirAll(dittofsDataDir+"/meta", 0o755); err != nil {
 		return err
 	}
@@ -75,6 +78,11 @@ func dittofsSetup(ctx context.Context, env BackendEnv) error {
 	}
 	if err := waitPort(ctx, dittofsNFSPort); err != nil {
 		return fmt.Errorf("dfs did not open NFS port %s: %w", dittofsNFSPort, err)
+	}
+	// The API server (8080) can come up after the NFS listener; wait for it too so
+	// the login below doesn't race a not-yet-listening control plane.
+	if err := waitPort(ctx, dittofsAPIPort); err != nil {
+		return fmt.Errorf("dfs did not open API port %s: %w", dittofsAPIPort, err)
 	}
 	// dfsctl talks to the authenticated control-plane API — log in first, then
 	// build the store stack a share needs: a metadata store, a local block store

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -22,6 +22,15 @@ const (
 	dittofsSMBPort = "12445"
 	dittofsShare   = "bench"
 	dittofsDataDir = "/var/lib/bench-dittofs"
+	dittofsAPIURL  = "http://127.0.0.1:8080"
+	dittofsMeta    = "bench-meta"
+	dittofsLocal   = "bench-local"
+	dittofsRemote  = "bench-s3"
+	// Throwaway control-plane secret (≥32 chars, required for the API server) and
+	// admin password on a disposable single-tenant bench VM — same fixed-literal
+	// convention as zerofsPassword. ponytail: no prod users; don't generate.
+	dittofsSecret    = "dfsbench-controlplane-secret-0123456789ab"
+	dittofsAdminPass = "dfsbench-admin-pw"
 )
 
 func init() {
@@ -42,29 +51,61 @@ func dittofsSetup(ctx context.Context, env BackendEnv) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(dittofsDataDir, 0o755); err != nil {
+	// Kill any dfs left over by a crashed prior run (else it still holds NFS 12049
+	// / API 8080 and the new server can't bind), then wipe control-plane + client
+	// state so bootstrap (admin user, stores, share) is deterministic and
+	// re-runnable — a stale controlplane.db would make the creates fail "already
+	// exists". Resilience: a managed run must survive a dirty VM.
+	_ = exec.Sh(ctx, "sh", "-c",
+		"pkill -9 -f 'dfs start' 2>/dev/null; rm -rf ~/.config/dittofs ~/.local/state/dittofs ~/.config/dfsctl "+dittofsDataDir+"; true")
+	if err := os.MkdirAll(dittofsDataDir+"/meta", 0o755); err != nil {
 		return err
 	}
-	// Start the server (config schema pinned on the VM), then wait for its NFS
-	// port before driving dfsctl.
-	if err := exec.Sh(ctx, "sh", "-c", "dfs start >/var/log/bench-dittofs.log 2>&1 &"); err != nil {
+	if err := os.MkdirAll(dittofsDataDir+"/blocks", 0o755); err != nil {
+		return err
+	}
+	// Start the server with the required control-plane secret (else API-server
+	// bringup fails "JWT secret must be at least 32 characters") and a known admin
+	// password (background mode generates an unrecoverable one otherwise), then
+	// wait for its NFS port before driving dfsctl.
+	start := fmt.Sprintf("DITTOFS_CONTROLPLANE_SECRET=%s DITTOFS_ADMIN_INITIAL_PASSWORD=%s "+
+		"dfs start >/var/log/bench-dittofs.log 2>&1 &", dittofsSecret, dittofsAdminPass)
+	if err := exec.Sh(ctx, "sh", "-c", start); err != nil {
 		return err
 	}
 	if err := waitPort(ctx, dittofsNFSPort); err != nil {
 		return fmt.Errorf("dfs did not open NFS port %s: %w", dittofsNFSPort, err)
 	}
-	// Attach an S3 remote block store and create the share bound to it.
-	storeCfg := fmt.Sprintf(`{"bucket":%q,"endpoint":%q,"access_key":%q,"secret_key":%q,"force_path_style":true}`,
-		env.Bucket, env.Endpoint, id, secret)
-	if err := exec.Sh(ctx, "dfsctl", "store", "block", "remote", "add",
-		"--name", "bench-s3", "--type", "s3", "--config", storeCfg); err != nil {
+	// dfsctl talks to the authenticated control-plane API — log in first, then
+	// build the store stack a share needs: a metadata store, a local block store
+	// (cache), and the S3 remote. Creds go on flags (not a config file); this is a
+	// throwaway VM and they never hit the argv of a long-lived process.
+	if err := exec.Sh(ctx, "dfsctl", "login",
+		"--server", dittofsAPIURL, "--username", "admin", "--password", dittofsAdminPass); err != nil {
+		return fmt.Errorf("dfsctl login: %w", err)
+	}
+	if err := exec.Sh(ctx, "dfsctl", "store", "metadata", "add",
+		"--name", dittofsMeta, "--type", "badger", "--db-path", dittofsDataDir+"/meta"); err != nil {
 		return err
 	}
-	return exec.Sh(ctx, "dfsctl", "share", "create", "--name", dittofsShare, "--block-store", "bench-s3")
+	if err := exec.Sh(ctx, "dfsctl", "store", "block", "local", "add",
+		"--name", dittofsLocal, "--type", "fs", "--path", dittofsDataDir+"/blocks"); err != nil {
+		return err
+	}
+	if err := exec.Sh(ctx, "dfsctl", "store", "block", "remote", "add",
+		"--name", dittofsRemote, "--type", "s3", "--bucket", env.Bucket, "--endpoint", env.Endpoint,
+		"--access-key", id, "--secret-key", secret, "--region", "us-east-1"); err != nil {
+		return err
+	}
+	// --default-permission read-write so the AUTH_SYS root client (squashed to
+	// nobody) can still write — the benchmark's whole job.
+	return exec.Sh(ctx, "dfsctl", "share", "create", "--name", "/"+dittofsShare,
+		"--metadata", dittofsMeta, "--local", dittofsLocal, "--remote", dittofsRemote,
+		"--default-permission", "read-write")
 }
 
 func dittofsMount(ctx context.Context, proto Protocol) (string, error) {
-	if err := os.MkdirAll(clientMntDir, 0o755); err != nil {
+	if err := prepareMountpoint(ctx); err != nil {
 		return "", err
 	}
 	var typ, opts, src string

--- a/internal/dfsbench/backend/reexport.go
+++ b/internal/dfsbench/backend/reexport.go
@@ -29,8 +29,9 @@ const (
 //go:embed smb.conf.tmpl
 var smbConfTmpl string
 
-// prepareMountpoint returns clientMntDir as a clean, mountable empty directory.
-// It force-lazy-unmounts anything already there first: a stale mount left by a
+// prepareMountpoint makes clientMntDir a clean, mountable empty directory (its
+// path is the package const clientMntDir; this returns only an error). It
+// force-lazy-unmounts anything already there first: a stale mount left by a
 // crashed prior run — especially a hard NFS mount to a now-dead server — would
 // otherwise make the MkdirAll's stat() hang uninterruptibly (D-state) and wedge
 // the whole run. Lazy (-l) detaches from the namespace immediately even if busy,

--- a/internal/dfsbench/backend/reexport.go
+++ b/internal/dfsbench/backend/reexport.go
@@ -29,10 +29,21 @@ const (
 //go:embed smb.conf.tmpl
 var smbConfTmpl string
 
+// prepareMountpoint returns clientMntDir as a clean, mountable empty directory.
+// It force-lazy-unmounts anything already there first: a stale mount left by a
+// crashed prior run — especially a hard NFS mount to a now-dead server — would
+// otherwise make the MkdirAll's stat() hang uninterruptibly (D-state) and wedge
+// the whole run. Lazy (-l) detaches from the namespace immediately even if busy,
+// so it never blocks. This is what makes a managed run resilient to a dirty VM.
+func prepareMountpoint(ctx context.Context) error {
+	_ = exec.Sh(ctx, "sh", "-c", "umount -f -l "+clientMntDir+" 2>/dev/null; true")
+	return os.MkdirAll(clientMntDir, 0o755)
+}
+
 // reexportMount re-serves srcDir over proto and returns the loopback client
 // mountpoint. srcDir must already exist and hold the backend's data.
 func reexportMount(ctx context.Context, srcDir string, proto Protocol) (string, error) {
-	if err := os.MkdirAll(clientMntDir, 0o755); err != nil {
+	if err := prepareMountpoint(ctx); err != nil {
 		return "", err
 	}
 	switch proto {

--- a/internal/dfsbench/backend/zerofs.go
+++ b/internal/dfsbench/backend/zerofs.go
@@ -87,8 +87,10 @@ func zerofsSetup(ctx context.Context, env BackendEnv) error {
 	// fails it with "Protocol family not supported". The reexport backends restart
 	// knfsd in their own setup, and zerofsTeardown restores it for any that follow.
 	// Also kill any zerofs left by a crashed prior run so the fresh one can bind
-	// 2049 (resilience against a dirty VM).
-	_ = exec.Sh(ctx, "sh", "-c", "pkill -9 -f 'zerofs run' 2>/dev/null; systemctl stop nfs-server nfs-mountd 2>/dev/null; exportfs -ua 2>/dev/null; true")
+	// 2049 (resilience against a dirty VM). Stop both unit names — the re-export
+	// backends restart nfs-kernel-server, and nfs-server is only an alias on some
+	// distros — so we reliably free the port the same server later reclaims.
+	_ = exec.Sh(ctx, "sh", "-c", "pkill -9 -f 'zerofs run' 2>/dev/null; systemctl stop nfs-server nfs-kernel-server nfs-mountd 2>/dev/null; exportfs -ua 2>/dev/null; true")
 	return zerofsStart(ctx)
 }
 
@@ -174,7 +176,7 @@ func zerofsStart(ctx context.Context) error {
 	// too early and the first mount races a not-yet-serving server (mount.nfs:
 	// "Protocol family not supported").
 	if err := exec.Sh(ctx, "sh", "-c",
-		"for i in $(seq 1 120); do grep -qa 'Starting NFS server' "+zerofsLog+" && exit 0; sleep 1; done; exit 1"); err != nil {
+		"for i in $(seq 1 120); do grep -qa 'Starting NFS server' "+zerofsLog+" 2>/dev/null && exit 0; sleep 1; done; exit 1"); err != nil {
 		return fmt.Errorf("zerofs NFS server did not begin serving (see %s): %w", zerofsLog, err)
 	}
 	return nil
@@ -197,8 +199,9 @@ func zerofsStop(ctx context.Context) error {
 func zerofsTeardown(ctx context.Context) error {
 	_ = zerofsStop(ctx)
 	// Restore the kernel NFS server that setup stopped, so a reexport backend
-	// scheduled after zerofs still has a knfsd to export into.
-	_ = exec.Sh(ctx, "sh", "-c", "systemctl start nfs-server 2>/dev/null; true")
+	// scheduled after zerofs still has a knfsd to export into. Start both unit
+	// names for distro/alias robustness (re-export uses nfs-kernel-server).
+	_ = exec.Sh(ctx, "sh", "-c", "systemctl start nfs-kernel-server nfs-server 2>/dev/null; true")
 	_ = cleanS3Prefix(ctx, zerofsPrefix+"/")
 	return os.RemoveAll(zerofsCacheDir)
 }

--- a/internal/dfsbench/backend/zerofs.go
+++ b/internal/dfsbench/backend/zerofs.go
@@ -24,6 +24,7 @@ const (
 	zerofsRPCPort  = "7000" // checkpoint/flush/monitor RPC
 	zerofsCacheDir = "/var/cache/bench-zerofs"
 	zerofsConf     = "/etc/bench-zerofs.toml"
+	zerofsLog      = "/var/log/bench-zerofs.log"
 	zerofsPrefix   = "zerofs" // s3://<bucket>/zerofs
 	// Encryption is mandatory in zerofs; this is a throwaway VM + throwaway
 	// bucket prefix, so a fixed bench password is fine. Passed via env (below),
@@ -80,6 +81,14 @@ func zerofsSetup(ctx context.Context, env BackendEnv) error {
 	if err := os.MkdirAll(zerofsCacheDir, 0o755); err != nil {
 		return err
 	}
+	// Free port 2049 for zerofs's own userspace NFS server. The image ships
+	// nfs-kernel-server enabled at boot (knfsd binds 0.0.0.0:2049), which
+	// otherwise intercepts the loopback mount and — having no export for "/" —
+	// fails it with "Protocol family not supported". The reexport backends restart
+	// knfsd in their own setup, and zerofsTeardown restores it for any that follow.
+	// Also kill any zerofs left by a crashed prior run so the fresh one can bind
+	// 2049 (resilience against a dirty VM).
+	_ = exec.Sh(ctx, "sh", "-c", "pkill -9 -f 'zerofs run' 2>/dev/null; systemctl stop nfs-server nfs-mountd 2>/dev/null; exportfs -ua 2>/dev/null; true")
 	return zerofsStart(ctx)
 }
 
@@ -112,7 +121,7 @@ func zerofsMount(ctx context.Context, proto Protocol) (string, error) {
 	if proto != ProtoNFS3 {
 		return "", fmt.Errorf("zerofs: unsupported protocol %s (native nfs3 only)", proto)
 	}
-	if err := os.MkdirAll(clientMntDir, 0o755); err != nil {
+	if err := prepareMountpoint(ctx); err != nil {
 		return "", err
 	}
 	// zerofs serves NFSv3 on :2049 from its own userspace server (no knfsd) — the
@@ -121,10 +130,17 @@ func zerofsMount(ctx context.Context, proto Protocol) (string, error) {
 	// skew the native-vs-native comparison; rsize/wsize negotiate to the kernel
 	// default (1 MiB over TCP) for both.
 	opts := "nfsvers=3,tcp,port=" + zerofsNFSPort + ",mountport=" + zerofsNFSPort + ",actimeo=0,nolock"
-	if err := exec.Sh(ctx, "mount", "-t", "nfs", "-o", opts, "127.0.0.1:/", clientMntDir); err != nil {
-		return "", err
+	// Retry a few times: zerofs's embedded NFS/MOUNT can still refuse the very
+	// first handshake right after it starts serving. zerofsStart already gates on
+	// the "serving" log line, so this only absorbs that last narrow race.
+	var err error
+	for a := 0; a < 5; a++ {
+		if err = exec.Sh(ctx, "mount", "-t", "nfs", "-o", opts, "127.0.0.1:/", clientMntDir); err == nil {
+			return clientMntDir, nil
+		}
+		time.Sleep(2 * time.Second)
 	}
-	return clientMntDir, nil
+	return "", err
 }
 
 // zerofsColdBarrier forces the next read cold-from-S3. NFS COMMIT lets zerofs
@@ -146,13 +162,20 @@ func zerofsColdBarrier(ctx context.Context) error {
 
 func zerofsStart(ctx context.Context) error {
 	// Truncate the log each start (single '>') so repeated runs don't interleave
-	// old and new output — matches dittofs.go.
+	// old and new output, and so the readiness grep below only ever matches THIS
+	// start's serving line.
 	if err := exec.Sh(ctx, "sh", "-c",
-		"zerofs run -c "+zerofsConf+" >/var/log/bench-zerofs.log 2>&1 &"); err != nil {
+		"zerofs run -c "+zerofsConf+" >"+zerofsLog+" 2>&1 &"); err != nil {
 		return err
 	}
-	if err := waitPort(ctx, zerofsNFSPort); err != nil {
-		return fmt.Errorf("zerofs did not open NFS port %s: %w", zerofsNFSPort, err)
+	// Wait for zerofs to actually be SERVING, not just listening. It binds the TCP
+	// socket immediately but only starts answering NFS ~35s later, after loading
+	// the encryption key and warming the LSM from S3 — a plain port probe returns
+	// too early and the first mount races a not-yet-serving server (mount.nfs:
+	// "Protocol family not supported").
+	if err := exec.Sh(ctx, "sh", "-c",
+		"for i in $(seq 1 120); do grep -qa 'Starting NFS server' "+zerofsLog+" && exit 0; sleep 1; done; exit 1"); err != nil {
+		return fmt.Errorf("zerofs NFS server did not begin serving (see %s): %w", zerofsLog, err)
 	}
 	return nil
 }
@@ -173,6 +196,9 @@ func zerofsStop(ctx context.Context) error {
 
 func zerofsTeardown(ctx context.Context) error {
 	_ = zerofsStop(ctx)
+	// Restore the kernel NFS server that setup stopped, so a reexport backend
+	// scheduled after zerofs still has a knfsd to export into.
+	_ = exec.Sh(ctx, "sh", "-c", "systemctl start nfs-server 2>/dev/null; true")
 	_ = cleanS3Prefix(ctx, zerofsPrefix+"/")
 	return os.RemoveAll(zerofsCacheDir)
 }

--- a/internal/dfsbench/fio/workload.go
+++ b/internal/dfsbench/fio/workload.go
@@ -39,6 +39,7 @@ func SizeBytes(s string) int64 {
 // selection and `list` have a stable, ordered set.
 var KnownWorkloads = []string{
 	"seq-write",
+	"seq-write-buffered",
 	"seq-read",
 	"rand-write-4k",
 	"rand-read-4k",

--- a/internal/dfsbench/run/managed.go
+++ b/internal/dfsbench/run/managed.go
@@ -102,15 +102,19 @@ func runPlan(ctx context.Context, p backend.Plan, env backend.BackendEnv, wls, s
 		_, _ = fmt.Fprintf(exec.CmdOut, "skip %s: no recipe yet\n", p.SystemLabel())
 		return nil
 	}
-	if err := b.Setup(ctx, env); err != nil {
-		return fmt.Errorf("setup: %w", err)
-	}
+	// Register teardown BEFORE Setup so a Setup that fails partway — e.g. after
+	// starting the server but before the share is ready — still cleans up. Otherwise
+	// a half-started dfs leaks, keeps holding its metadata-store (Badger) directory
+	// lock, and wedges every later run's store-create. Teardown is idempotent.
 	if b.Teardown != nil {
 		defer func() {
 			if e := b.Teardown(ctx); e != nil && err == nil {
 				err = fmt.Errorf("teardown: %w", e)
 			}
 		}()
+	}
+	if err := b.Setup(ctx, env); err != nil {
+		return fmt.Errorf("setup: %w", err)
 	}
 
 	mnt, err := b.Mount(ctx, p.Protocol)
@@ -138,38 +142,53 @@ func runPlan(ctx context.Context, p backend.Plan, env backend.BackendEnv, wls, s
 				reads = append(reads, w)
 			}
 		}
-		if len(reads) > 0 {
-			// Make the read cold-from-S3. FUSE backends: bounce the mount stack —
-			// unmount the re-export, flush+remount the FUSE mount (the unmount
-			// guarantees the full writeback upload; the remount empties its cache),
-			// then re-export the fresh mount. Others (local-disk): just evict.
-			if b.FlushFUSE != nil {
-				if b.Unmount != nil {
-					_ = b.Unmount(ctx, p.Protocol)
-				}
-				if err := b.FlushFUSE(ctx); err != nil {
-					return fmt.Errorf("flush: %w", err)
-				}
-				newMnt, err := b.Mount(ctx, p.Protocol)
-				if err != nil {
-					return fmt.Errorf("remount: %w", err)
-				}
-				mnt = newMnt
-			} else if b.Evict != nil {
-				if err := b.Evict(ctx); err != nil {
-					return fmt.Errorf("evict: %w", err)
-				}
+		// Re-establish a cold cache before EACH read workload, not once for all of
+		// them. The first cold read pulls the whole file back from S3 into the
+		// local cache, so a later cold cell reading the same file would be served
+		// warm — that's what made the old single-evict cold rand-read implausibly
+		// fast. A per-workload barrier keeps every cold number genuinely cold.
+		for _, w := range reads {
+			newMnt, err := coldBarrier(ctx, b, p, mnt)
+			if err != nil {
+				return err
 			}
-			// Drop the OS page cache too, so reads come from the backend, not RAM.
-			if err := exec.DropOSCache(ctx); err != nil {
-				_, _ = fmt.Fprintf(exec.CmdOut, "warn: drop OS cache: %v\n", err)
-			}
-			if err := runPass(ctx, p, "cold", reads, sizes, mnt, opts, f); err != nil {
+			mnt = newMnt
+			if err := runPass(ctx, p, "cold", []string{w}, sizes, mnt, opts, f); err != nil {
 				return err
 			}
 		}
 	}
 	return nil
+}
+
+// coldBarrier forces the next read to come from the backend, not a warm cache:
+// FUSE backends bounce the mount stack (unmount re-export → flush+remount the
+// FUSE mount so the writeback fully uploads and the cache empties → re-export),
+// others evict; then the OS page cache is dropped. Returns the (possibly new)
+// client mountpoint. Run before EACH cold read cell so cells don't warm each other.
+func coldBarrier(ctx context.Context, b *backend.Backend, p backend.Plan, mnt string) (string, error) {
+	if b.FlushFUSE != nil {
+		if b.Unmount != nil {
+			_ = b.Unmount(ctx, p.Protocol)
+		}
+		if err := b.FlushFUSE(ctx); err != nil {
+			return mnt, fmt.Errorf("flush: %w", err)
+		}
+		newMnt, err := b.Mount(ctx, p.Protocol)
+		if err != nil {
+			return mnt, fmt.Errorf("remount: %w", err)
+		}
+		mnt = newMnt
+	} else if b.Evict != nil {
+		if err := b.Evict(ctx); err != nil {
+			return mnt, fmt.Errorf("evict: %w", err)
+		}
+	}
+	// Drop the OS page cache too, so reads come from the backend, not client RAM.
+	if err := exec.DropOSCache(ctx); err != nil {
+		_, _ = fmt.Fprintf(exec.CmdOut, "warn: drop OS cache: %v\n", err)
+	}
+	return mnt, nil
 }
 
 // runPass fios one pass (warm|cold) of a plan's workload×size cells against mnt.


### PR DESCRIPTION
## What

First real managed run of `dfsbench` (#1602) against a live `dfs` — it exposed that the `dittofs-s3` backend recipe was stale (written against an older `dfsctl`, never validated live). This fixes the whole bring-up and adds a fresh-results doc.

## dittofs-s3 backend — full bring-up fix
The recipe now:
- Sets `DITTOFS_CONTROLPLANE_SECRET` (≥32 chars — API server won't start otherwise) + a known `DITTOFS_ADMIN_INITIAL_PASSWORD`.
- Runs `dfsctl login` (every store/share command hits the authenticated control plane).
- Creates the **metadata** (badger) + **local** (fs cache) + **remote** (s3) stores with the *current* flag schema — the old JSON `--config` with `access_key`/`--block-store` no longer exists.
- Creates the share with `--metadata` + `--local` + `--remote` + `--default-permission read-write` so the squashed NFS root can write.

Validated end-to-end on the VM: 32 MiB NFS write to an S3-backed share.

## Resilience (root-cause fix for D-state hangs)
Shared `prepareMountpoint` force-lazy-unmounts any stale mount before mounting. Without it, a mount left by a crashed run — a hard NFS mount to a now-dead server — makes the next run's `os.MkdirAll` stat hang uninterruptibly and wedges everything. Both setups also kill leftover servers first.

## zerofs (partial)
- Waits for its real `Starting NFS server` readiness line — zerofs binds the TCP socket ~35 s before it serves (encryption-key load + LSM warm from S3), so a plain port probe raced a not-yet-serving server.
- Stops the boot-time kernel NFS server so zerofs can claim port 2049; restores it in teardown for following re-export backends.
- Mount retry.

**Known gap:** zerofs's native mount still fails *only through the harness binary* (`Protocol family not supported`) while succeeding every way it's tested by hand — a Heisenbug needing binary-level tracing. Documented in the results doc, not blocking.

## Docs
Adds `docs/internals/dfsbench-results.md` — the 2026-07-09 pass: DittoFS native vs rclone re-export, the measured **FUSE-tax** (context switches), and the reproduced native NFS→S3 **seq-write wall (~1 MB/s)**. Points the stale `BENCHMARKS.md` banner at it (its "writes never block on S3" claim no longer holds on this path).

## Headline data
| Workload | DittoFS (native) | rclone (FUSE re-export) |
|---|---|---|
| seq-read warm | 972 MB/s @ 38.9k ctxsw/s | 1,369 MB/s @ 64.5k ctxsw/s |
| seq-read cold | 63 MB/s (real S3) | — |
| rand-read-4k cold | 6,405 IOPS | — |
| seq-write warm | **1 MB/s** (p50 4.5s, CPU 3%) | 1,936 MB/s |

Reads are competitive and ~40% more CPU-efficient; the write path is the wall (per-write/COMMIT fsync — #1573/#1466/#1416).

## Test
`go build`, `go test ./internal/dfsbench/...`, `go vet`, `golangci-lint` all green. Live-validated on a disposable Scaleway VM (torn down).