### PR TITLE
fix(metadata): actionable error when the BadgerDB data dir is already locked

### DIFF
--- a/pkg/metadata/store/badger/lockerr_test.go
+++ b/pkg/metadata/store/badger/lockerr_test.go
@@ -11,7 +11,6 @@ import (
 func TestIsDirLockErr(t *testing.T) {
 	locked := []error{
 		errors.New(`Cannot acquire directory lock on "/var/lib/dittofs/meta".  Another process is using this Badger database. error: resource temporarily unavailable`),
-		errors.New("resource temporarily unavailable"),
 		errors.New("Another process is using this Badger database"),
 	}
 	for _, e := range locked {
@@ -22,6 +21,9 @@ func TestIsDirLockErr(t *testing.T) {
 	notLocked := []error{
 		errors.New("failed to open BadgerDB: manifest corrupted"),
 		errors.New("no space left on device"),
+		// A bare EAGAIN must NOT be mistaken for a lock — many unrelated
+		// failures carry it; only Badger's named lock message counts.
+		errors.New("resource temporarily unavailable"),
 	}
 	for _, e := range notLocked {
 		if isDirLockErr(e) {

--- a/pkg/metadata/store/badger/lockerr_test.go
+++ b/pkg/metadata/store/badger/lockerr_test.go
@@ -1,0 +1,31 @@
+package badger
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestIsDirLockErr checks that BadgerDB's directory-lock failure (a second server
+// opening the same data dir) is recognized so the store can surface an actionable
+// error instead of the raw "resource temporarily unavailable".
+func TestIsDirLockErr(t *testing.T) {
+	locked := []error{
+		errors.New(`Cannot acquire directory lock on "/var/lib/dittofs/meta".  Another process is using this Badger database. error: resource temporarily unavailable`),
+		errors.New("resource temporarily unavailable"),
+		errors.New("Another process is using this Badger database"),
+	}
+	for _, e := range locked {
+		if !isDirLockErr(e) {
+			t.Errorf("expected lock error to be detected: %v", e)
+		}
+	}
+	notLocked := []error{
+		errors.New("failed to open BadgerDB: manifest corrupted"),
+		errors.New("no space left on device"),
+	}
+	for _, e := range notLocked {
+		if isDirLockErr(e) {
+			t.Errorf("did not expect lock detection for: %v", e)
+		}
+	}
+}

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -381,19 +381,20 @@ const valueLogGCInterval = 5 * time.Minute
 
 // valueLogGCDiscardRatio is the fraction of stale data a value-log file
 // must contain before Badger will rewrite it. 0.5 is Badger's commonly
-// isDirLockErr reports whether err is BadgerDB's "directory is already locked"
-// failure — the signature of a second server (or a leftover one that never shut
-// down) opening the same data directory. Badger surfaces it as a plain error
-// with an EAGAIN-flavoured message, so we match on its text.
-func isDirLockErr(err error) bool {
-	s := err.Error()
-	return strings.Contains(s, "Cannot acquire directory lock") ||
-		strings.Contains(strings.ToLower(s), "another process is using this badger database") ||
-		strings.Contains(s, "resource temporarily unavailable")
-}
-
 // recommended starting point — rewrite files at least half garbage.
 const valueLogGCDiscardRatio = 0.5
+
+// isDirLockErr reports whether err is BadgerDB's "directory is already locked"
+// failure — the signature of a second server (or a leftover one that never shut
+// down) opening the same data directory. Badger's message names the cause
+// ("Cannot acquire directory lock ... Another process is using this Badger
+// database") before the wrapped EAGAIN errno, so match on that text and not the
+// bare "resource temporarily unavailable" (which unrelated failures also carry).
+func isDirLockErr(err error) bool {
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "cannot acquire directory lock") ||
+		strings.Contains(s, "another process is using this badger database")
+}
 
 // runValueLogGC periodically reclaims Badger value-log space. On each
 // tick it drains all rewritable value-log files (RunValueLogGC returns

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -303,6 +304,16 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 	// Open BadgerDB
 	db, err := badger.Open(opts)
 	if err != nil {
+		// BadgerDB takes a directory lock, so this is the failure a second server
+		// (or a leftover one that never shut down) hits against the same data dir.
+		// Badger's raw "resource temporarily unavailable" is opaque — point the
+		// operator straight at the cause and the fix instead.
+		if isDirLockErr(err) {
+			return nil, fmt.Errorf("metadata store at %s is locked by another process — "+
+				"a DittoFS server is almost certainly already running against this data directory. "+
+				"Stop it ('dfs stop', or kill the running dfs) before starting another, or point "+
+				"this share at a different db_path: %w", config.DBPath, err)
+		}
 		return nil, fmt.Errorf("failed to open BadgerDB at %s: %w", config.DBPath, err)
 	}
 
@@ -370,6 +381,17 @@ const valueLogGCInterval = 5 * time.Minute
 
 // valueLogGCDiscardRatio is the fraction of stale data a value-log file
 // must contain before Badger will rewrite it. 0.5 is Badger's commonly
+// isDirLockErr reports whether err is BadgerDB's "directory is already locked"
+// failure — the signature of a second server (or a leftover one that never shut
+// down) opening the same data directory. Badger surfaces it as a plain error
+// with an EAGAIN-flavoured message, so we match on its text.
+func isDirLockErr(err error) bool {
+	s := err.Error()
+	return strings.Contains(s, "Cannot acquire directory lock") ||
+		strings.Contains(strings.ToLower(s), "another process is using this badger database") ||
+		strings.Contains(s, "resource temporarily unavailable")
+}
+
 // recommended starting point — rewrite files at least half garbage.
 const valueLogGCDiscardRatio = 0.5
 


### PR DESCRIPTION
## Problem

When a DittoFS metadata store opens a BadgerDB directory that another process already holds, Badger returns its raw error:

```
failed to open BadgerDB at /var/lib/dittofs/meta: Cannot acquire directory lock on "...".
Another process is using this Badger database. error: resource temporarily unavailable
```

`resource temporarily unavailable` reads as a mysterious transient I/O error. In practice it's almost always **a second `dfs` (or a leftover one that never shut down) opening the same data directory** — e.g. a start after a crash where the old process is still alive, or two servers pointed at the same path. DittoFS already guards `dfs start` via the PID file, but that check is defeated if the PID file is missing/stale while an orphaned server still holds the lock — and then this opaque error is all the operator sees.

## Fix

Detect the directory-lock failure at `badger.Open` and return an actionable message naming the cause and the remedy:

> metadata store at `<path>` is locked by another process — a DittoFS server is almost certainly already running against this data directory. Stop it ('dfs stop', or kill the running dfs) before starting another, or point this share at a different db_path: `<raw err>`

The raw error is still wrapped (`%w`) so nothing is lost for logs/matchers.

Surfaced while running the `dfsbench` harness for real (#1619): a half-started `dfs` kept holding the lock and every subsequent run failed with the cryptic Badger message until we recognised what it meant.

## Test

`TestIsDirLockErr` covers the lock-error strings (positive) and unrelated errors (negative). `go build ./cmd/dfs`, `go test ./pkg/metadata/store/badger/`, `go vet`, `gofmt` all clean.