### PR TITLE
perf(block): don't block FILE_SYNC writes on a synchronous S3 drain

### DIFF
--- a/pkg/block/engine/durability_test.go
+++ b/pkg/block/engine/durability_test.go
@@ -1,11 +1,59 @@
 package engine
 
 import (
+	"context"
 	"testing"
 
 	localmemory "github.com/marmos91/dittofs/pkg/block/local/memory"
 	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
 )
+
+// TestEngine_Flush_DurableLocalDefault_NoSyncRemote proves the #1621 fix: on a
+// durable local store under the default (async-remote) policy, Flush satisfies
+// durability with the local fsync alone and does NOT block the ack on a
+// synchronous remote carve/upload — that inline S3 PutObject-per-FILE_SYNC-WRITE
+// was the multi-second write stall. A strict share still drains inline.
+//
+// Discriminator: the store's background carve loop is never Start()ed, so the
+// only path to the remote is the synchronous carve inside Flush itself. Rollup
+// is forced first so there are carve-ready chunks; a non-empty remote after
+// Flush therefore means the drain ran synchronously on the ack path.
+func TestEngine_Flush_DurableLocalDefault_NoSyncRemote(t *testing.T) {
+	writeAndFlush := func(t *testing.T, strict bool) int {
+		t.Helper()
+		ctx := context.Background()
+		mem := remotememory.New()
+		mem.SetDurable(true)
+		fx := newCarveFixture(t, mem, DefaultBlockCarveBytes) // durable fs local, ManualSync, wired carve
+		bs, err := New(BlockStoreConfig{
+			Local:           fx.local,
+			Remote:          mem,
+			Syncer:          fx.syncer,
+			FileChunkStore:  fx.ms,
+			SyncedHashStore: fx.ms,
+		})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		t.Cleanup(func() { _ = bs.Close() })
+		bs.SetRequireDurableCommit(strict)
+
+		// Register a carve-ready CAS chunk exactly as the rollup's onChunkComplete
+		// hook would — the state a FILE_SYNC WRITE reaches by the time it flushes.
+		fx.storeChunk(t, ctx, []byte("hello world"))
+		if _, err := bs.Flush(ctx, "share/p1"); err != nil {
+			t.Fatalf("Flush(strict=%v): %v", strict, err)
+		}
+		return countRemoteBlocks(t, ctx, mem)
+	}
+
+	if n := writeAndFlush(t, false); n != 0 {
+		t.Fatalf("default policy: Flush must not synchronously upload to remote, got %d block(s)", n)
+	}
+	if n := writeAndFlush(t, true); n == 0 {
+		t.Fatal("strict policy: Flush must synchronously drain to remote, got 0 blocks")
+	}
+}
 
 func TestEngine_LocalDurable_MemoryDefaultsFalse(t *testing.T) {
 	localStore := localmemory.New()

--- a/pkg/block/engine/flush.go
+++ b/pkg/block/engine/flush.go
@@ -26,6 +26,16 @@ func (bs *Store) Flush(ctx context.Context, payloadID string) (*block.FlushResul
 	if err := bs.local.SyncPayload(ctx, payloadID); err != nil {
 		return nil, err
 	}
+	// A durable local store already makes the payload crash-safe at this point,
+	// so under the default (async-remote) policy the ack must NOT block on the
+	// remote mirror — that is exactly what common.CommitBlockStore documents.
+	// Carving to the remote synchronously here turned every FILE_SYNC/DATA_SYNC
+	// WRITE into an inline S3 PutObject the reply waited on: multi-second per-op
+	// stalls at ~3% CPU (#1621). The background carve loop mirrors the data; a
+	// strict share (require_durable_commit) still drains inline below.
+	if bs.LocalDurable() && !bs.RequireDurableCommit() {
+		return &block.FlushResult{Finalized: false}, nil
+	}
 	// Delegate to the syncer's carve drain.
 	return bs.syncer.Flush(ctx, payloadID)
 }

--- a/pkg/block/engine/flush.go
+++ b/pkg/block/engine/flush.go
@@ -33,7 +33,12 @@ func (bs *Store) Flush(ctx context.Context, payloadID string) (*block.FlushResul
 	// WRITE into an inline S3 PutObject the reply waited on: multi-second per-op
 	// stalls at ~3% CPU (#1621). The background carve loop mirrors the data; a
 	// strict share (require_durable_commit) still drains inline below.
+	//
+	// Still perform the per-payload FileChunk metadata quiesce that syncer.Flush
+	// would (persist queued manifest updates so reads and restart-recovery see
+	// the authoritative manifest) — only the remote carve drain is skipped.
 	if bs.LocalDurable() && !bs.RequireDurableCommit() {
+		bs.local.SyncFileChunksForFile(ctx, payloadID)
 		return &block.FlushResult{Finalized: false}, nil
 	}
 	// Delegate to the syncer's carve drain.


### PR DESCRIPTION
## Problem

`dfsbench` fair-run work (#1619) surfaced a real pathology in the **synchronous** NFS write path (O_DIRECT / per-write FILE_SYNC), distinct from the buffered/UNSTABLE path #1584 optimised. `seq-write.fio` with `direct=1` over native NFSv3 to an S3-backed share stalled at **~1–2.6 MB/s, p50 25 ms – 4.5 s per 1 MB write, ~3% CPU** — the server was *blocked*, not busy. The buffered path ran at 242 MB/s.

## Root cause

A `FILE_SYNC`/`DATA_SYNC` WRITE reaches the shared commit seam per write:

`flushStableWrite` → `common.CommitBlockStore` → `engine.Store.Flush` → `syncer.Flush` → `carveFlush(drainAll=true)` → `wg.Wait()` on an inline `s3.PutObject`.

The local append-log fsync (`SyncPayload`) already makes the payload crash-safe (`localDurable=true` for the fs local store). The subsequent synchronous carve/upload to S3 is what the WRITE reply waited on — a network round-trip per 1 MB write.

`common.CommitBlockStore` already **documents** that in the default policy "the remote mirror stays fully asynchronous" — but `engine.Flush` ran the drain synchronously before that decision, contradicting the contract.

## Fix

In `engine.Store.Flush`, once the local durability barrier is paid, return without the syncer carve drain when `LocalDurable() && !RequireDurableCommit()`. The background carve loop mirrors the data asynchronously (exactly as the fast UNSTABLE path already relies on). A strict share (`require_durable_commit=true`) still drains inline; a volatile local store (memory) still drains inline.

Ruled out: the per-store fsync leader (lone `direct=1` writer hits the inline bypass, no added latency), rollup ticker / upload semaphore (only in the background idle loop), and O_DIRECT read-modify-write (append-log never fetches back).

## Test

`TestEngine_Flush_DurableLocalDefault_NoSyncRemote` — deterministic discriminator with the background carve loop unstarted: a strict flush drains to the remote synchronously (non-empty), the default flush does not (empty). Fails against the unfixed code.

Verified: full `pkg/block/...` (1213) + `internal/adapter/...` (4305) suites pass; `go vet` + `golangci-lint` clean.

Fixes #1621