### PR TITLE
fix(block): run cas→blocks repack in background, serve standalone chunks via fallback

### DIFF
--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -138,6 +138,13 @@ type Store struct {
 	closed   bool  // guarded by closeMu; true once teardown has run
 	closeErr error // memoized result of the first Close (idempotent)
 
+	// migrateCancel/migrateDone govern the background cas→blocks migration
+	// goroutine spawned by Start. Close cancels the context and waits on the
+	// channel so the goroutine's in-flight remote I/O never races the store
+	// teardown below it. Both nil/zero until Start runs.
+	migrateCancel context.CancelFunc
+	migrateDone   chan struct{}
+
 	// requireDurableCommit gates the strict honest-CLOSE/COMMIT rule (#1274).
 	// When false (the default), CommitBlockStore acks once engine.Flush
 	// succeeds regardless of local/remote durability — the remote mirror
@@ -570,15 +577,24 @@ func (bs *Store) Start(ctx context.Context) error {
 	// Use background context so these outlive the calling request context.
 	bs.local.Start(context.Background())
 
-	// One-shot cas→blocks migration (#1493 PR4): import pre-flip local
-	// per-chunk files into the log-blob substrate and re-pack standalone
-	// remote objects into packed blocks. Blocking by design — the share must
-	// not serve until the legacy layout is gone — and a no-op on migrated
-	// (or fresh) stores. Runs BEFORE the syncer starts so no mirror/carve
-	// activity races the rewrite.
-	if err := bs.migrateLegacyCAS(ctx); err != nil {
-		return fmt.Errorf("cas→blocks migration: %w", err)
-	}
+	// One-shot cas→blocks migration: import pre-flip local per-chunk files
+	// into the log-blob substrate and re-pack standalone remote objects into
+	// packed blocks. Runs in the background so a slow/stalled remote or a
+	// near-full disk can't wedge startup — the share serves immediately and any
+	// not-yet-repacked standalone chunk is read through the legacy fallback
+	// (resolveAndReadChunk). Idempotent and resumable: a failed or cancelled
+	// pass is a no-op retry on the next start. Uses a detached context so it
+	// outlives Start; Close cancels it and waits on migrateDone before tearing
+	// down the stores it uses.
+	migrateCtx, cancel := context.WithCancel(context.Background())
+	bs.migrateCancel = cancel
+	bs.migrateDone = make(chan struct{})
+	go func() {
+		defer close(bs.migrateDone)
+		if err := bs.migrateLegacyCAS(migrateCtx); err != nil && migrateCtx.Err() == nil {
+			logger.Warn("cas→blocks migration: background pass failed; will retry next start", "error", err)
+		}
+	}()
 
 	// Wire the health callback BEFORE starting the syncer. The health monitor
 	// captures the callback at Start time (startHealthMonitor reads
@@ -691,6 +707,16 @@ func (bs *Store) Close() error {
 		return bs.closeErr
 	}
 	bs.closed = true
+
+	// Stop the background cas→blocks migration before tearing down the local,
+	// remote, and syncer stores it uses. Cancel unblocks any in-flight remote
+	// PutBlock/GET; the receive waits for the goroutine to fully exit so it
+	// never races the closes below. Safe from under closeMu: the migration
+	// goroutine does not take closeMu.
+	if bs.migrateCancel != nil {
+		bs.migrateCancel()
+		<-bs.migrateDone
+	}
 
 	// Cache is never nil thanks to the Null Object pattern. Swap in the
 	// Null Object under cacheMu so any concurrent OnChunkComplete read sees

--- a/pkg/block/engine/engine_dualread_test.go
+++ b/pkg/block/engine/engine_dualread_test.go
@@ -167,13 +167,14 @@ func TestDualRead_BlockRowRoutesToVerifiedChunkRead(t *testing.T) {
 // contract: a FileChunk row with a non-zero Hash but NO recorded locator (the
 // startup migration repacked every synced hash, so this is post-migration
 // drift) must be refused without touching the remote — never silent zeros.
-// TestDualRead_SyncedStandaloneLocatorRefused: a row whose hash IS synced but
-// carries an empty-BlockID (standalone) locator is post-#1493 drift — the
-// migration rewrites every standalone locator to a block locator before
-// serving — and must be refused fail-closed. (A hash with NO marker is the
-// benign "not uploaded yet" case, covered by
-// TestDispatchRemoteFetch_UnsyncedChunkFallsBackToLocal.)
-func TestDualRead_SyncedStandaloneLocatorRefused(t *testing.T) {
+// TestDualRead_SyncedStandaloneLocatorMissingFailsClosed: a row whose hash IS
+// synced but carries an empty-BlockID (standalone) locator with no bytes
+// anywhere (no local copy, no legacy cas/ object) must fail closed with
+// ErrChunkNotFound — never silent zeros. (When the legacy object exists, the
+// read-path fallback serves it; that path is covered in read_path_test.go and
+// locator_fetch_test.go. A hash with NO marker is the benign "not uploaded yet"
+// case, covered by TestDispatchRemoteFetch_UnsyncedChunkFallsBackToLocal.)
+func TestDualRead_SyncedStandaloneLocatorMissingFailsClosed(t *testing.T) {
 	env := newDualReadEnv(t)
 	ctx := context.Background()
 
@@ -199,17 +200,14 @@ func TestDualRead_SyncedStandaloneLocatorRefused(t *testing.T) {
 	}
 
 	got, err := env.syncer.fetchBlock(ctx, payloadID, 0)
-	if err == nil {
-		t.Fatalf("fetchBlock: want post-migration drift refusal, got nil with data=%v", got)
-	}
-	if !contains(err.Error(), "post-migration drift") {
-		t.Fatalf("fetchBlock err = %v, want post-migration drift refusal", err)
+	if !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("fetchBlock err = %v, want ErrChunkNotFound (standalone bytes resident nowhere)", err)
 	}
 	if got != nil {
-		t.Errorf("fetchBlock data = %v, want nil on refusal", got)
+		t.Errorf("fetchBlock data = %v, want nil on miss", got)
 	}
 	if env.rs.readChunkCalls.Load() != 0 {
-		t.Errorf("ReadChunk calls = %d, want 0 (refusal happens before the remote)", env.rs.readChunkCalls.Load())
+		t.Errorf("ReadChunk calls = %d, want 0 (block-range read never runs for a standalone locator)", env.rs.readChunkCalls.Load())
 	}
 }
 

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -140,10 +140,10 @@ func (m *Syncer) dispatchRemoteFetch(ctx context.Context, fb *block.FileChunk) (
 //     yet, so it has no remote copy. NOT drift — the bytes are still local-only
 //     (a read that raced the async carve). Returns ("", nil, nil) so the caller
 //     falls back to the local read path rather than failing closed.
-//   - Synced marker present but empty BlockID: post-#1493 every synced hash
-//     carries a block locator (the startup migration repacked all legacy
-//     standalone chunks), so a synced hash with no BlockID is genuine metadata
-//     drift. Refuse the read.
+//   - Synced marker present but empty BlockID: a pre-flip standalone chunk the
+//     background cas→blocks migration has not repacked yet. Served through the
+//     legacy CAS fallback (readStandaloneChunk); only a chunk that is resident
+//     nowhere yields an error.
 func (m *Syncer) resolveAndReadChunk(ctx context.Context, fb *block.FileChunk) (string, []byte, error) {
 	loc, synced, err := m.resolveLocator(ctx, fb.Hash)
 	if err != nil {
@@ -153,10 +153,22 @@ func (m *Syncer) resolveAndReadChunk(ctx context.Context, fb *block.FileChunk) (
 		return "", nil, nil // not on remote yet — caller serves from local
 	}
 	if loc.BlockID == "" {
-		logger.Error("synced chunk has no block locator — refusing remote fetch (post-migration drift)",
-			"block_id", fb.ID,
-			"hash", fb.Hash.String())
-		return "", nil, fmt.Errorf("blockstore: no block locator recorded for synced chunk %s (post-migration drift)", fb.Hash)
+		// Pre-flip standalone locator: the cas→blocks repack runs as a
+		// background pass, so a synced hash can still carry the legacy layout
+		// while the repack is in flight. Serve it from the legacy CAS objects
+		// (local-first, then remote, BLAKE3-verified); the background migration
+		// repacks it and rewrites the locator. Only when the chunk is resident
+		// nowhere is this genuine drift / live-data-loss — surfaced (as
+		// ErrChunkNotFound) so the caller fails closed rather than serving zeros.
+		data, rerr := m.readStandaloneChunk(ctx, fb.Hash)
+		if rerr != nil {
+			logger.Error("standalone chunk unreadable (no local copy, no legacy object)",
+				"block_id", fb.ID, "hash", fb.Hash.String(), "error", rerr)
+			return "", nil, rerr
+		}
+		// Non-empty key so the caller persists the bytes (an empty key is its
+		// sparse/never-uploaded sentinel); the hash is the natural CAS key here.
+		return fb.Hash.String(), data, nil
 	}
 	key := block.FormatBlockKey(loc.BlockID)
 	data, perr := m.readChunkVerified(ctx, loc, fb.Hash)

--- a/pkg/block/engine/legacy_migration.go
+++ b/pkg/block/engine/legacy_migration.go
@@ -19,9 +19,10 @@ import (
 // This file is the one-shot cas→blocks migration (#1493 PR4): the ONLY code
 // outside the remote.LegacyCASStore implementations that still understands the
 // legacy standalone-CAS layout (one sealed object per chunk under "cas/",
-// located by a synced marker with an empty BlockID). It runs synchronously
-// from Store.Start — blocking, before the share serves — and is resumable and
-// idempotent by construction:
+// located by a synced marker with an empty BlockID). Start runs it in the
+// background — the share serves immediately and reads any not-yet-repacked
+// standalone chunk through the read-path fallback (readStandaloneChunk) — and
+// it is resumable and idempotent by construction:
 //
 //   - Phase L imports pre-flip per-chunk local files into the log-blob
 //     substrate (FSStore.MigrateLegacyChunkFiles).
@@ -284,6 +285,38 @@ func (m *Syncer) migrationChunkBytes(
 		return nil, zero, err
 	}
 	return data, zero, nil
+}
+
+// legacyCAS returns the migration-only legacy CAS accessor derived from the
+// remote block store, and whether the backend exposes it. Local-only shares and
+// backends without the legacy surface report (nil, false).
+func (m *Syncer) legacyCAS() (remote.LegacyCASStore, bool) {
+	m.mu.RLock()
+	rbs := m.remoteBlockStore
+	m.mu.RUnlock()
+	if rbs == nil {
+		return nil, false
+	}
+	legacy, ok := rbs.(remote.LegacyCASStore)
+	return legacy, ok
+}
+
+// readStandaloneChunk serves a pre-flip standalone (empty-BlockID) chunk while
+// the background cas→blocks migration is still in flight: local-first
+// (BLAKE3-verified), then a verified legacy remote read. Returns
+// block.ErrChunkNotFound when the chunk is resident nowhere. Read-path twin of
+// migrationChunkBytes, without the local-location lookup the repacker needs.
+func (m *Syncer) readStandaloneChunk(ctx context.Context, h block.ContentHash) ([]byte, error) {
+	if has, err := m.local.Has(ctx, h); err == nil && has {
+		if data, gerr := m.local.Get(ctx, h); gerr == nil && block.ContentHash(blake3.Sum256(data)) == h {
+			return data, nil
+		}
+	}
+	legacy, ok := m.legacyCAS()
+	if !ok {
+		return nil, fmt.Errorf("chunk %s: %w", h, block.ErrChunkNotFound)
+	}
+	return legacy.ReadLegacyChunkVerified(ctx, h)
 }
 
 // getBlockCommitter returns the wired block committer under the syncer lock.

--- a/pkg/block/engine/locator_fetch_test.go
+++ b/pkg/block/engine/locator_fetch_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"strings"
 	"testing"
 
 	"lukechampine.com/blake3"
@@ -41,24 +40,26 @@ func newLocatorFetchSyncer(t *testing.T) (*Syncer, *remotememory.Store, *metadat
 	return syncer, rem, ms
 }
 
-// TestDispatchRemoteFetch_StandaloneLocatorRefused pins the post-#1493
-// fail-closed contract: the startup migration repacked every legacy standalone
-// chunk into a block, so a synced hash whose recorded locator is still
-// standalone (BlockID == "") is post-migration drift. dispatchRemoteFetch must
-// REFUSE the read — even when the legacy cas/ object still exists on the
-// remote — instead of silently falling back or returning zeros.
-func TestDispatchRemoteFetch_StandaloneLocatorRefused(t *testing.T) {
+// TestDispatchRemoteFetch_StandaloneLocatorServedViaFallback: the cas→blocks
+// repack runs as a background pass, so a synced hash whose recorded locator is
+// still standalone (BlockID == "") is served
+// through the legacy CAS fallback — byte-identical — instead of being refused.
+// This is what lets a share serve immediately while the migration repacks in
+// the background.
+func TestDispatchRemoteFetch_StandaloneLocatorServedViaFallback(t *testing.T) {
 	ctx := context.Background()
 	syncer, rem, ms := newLocatorFetchSyncer(t)
+	// Wire the block-keyed remote like production so the fallback can reach the
+	// legacy cas/ namespace through it.
+	syncer.SetRemoteBlockStore(rem)
 
 	data := bytes.Repeat([]byte{0xAB}, 4096)
 	hash := block.ContentHash(blake3.Sum256(data))
-	// Plant the legacy standalone cas/ object so the refusal below is
-	// provably a policy decision, not a missing-object accident.
-	if err := rem.Put(ctx, hash, data); err != nil {
-		t.Fatalf("remote Put: %v", err)
+	// Plant the legacy standalone cas/ object plus a standalone locator — the
+	// exact pre-flip state a not-yet-repacked synced hash carries.
+	if err := rem.PutLegacyChunk(ctx, hash, data); err != nil {
+		t.Fatalf("PutLegacyChunk: %v", err)
 	}
-	// A pre-#1493 write path recorded a standalone locator on MarkSynced.
 	if err := ms.MarkSynced(ctx, hash, block.ChunkLocator{WireLength: int64(len(data))}); err != nil {
 		t.Fatalf("MarkSynced: %v", err)
 	}
@@ -72,17 +73,14 @@ func TestDispatchRemoteFetch_StandaloneLocatorRefused(t *testing.T) {
 	}
 
 	key, got, err := syncer.dispatchRemoteFetch(ctx, &block.FileChunk{Hash: hash})
-	if err == nil {
-		t.Fatalf("dispatchRemoteFetch: want post-migration drift refusal, got nil (data=%d bytes)", len(got))
+	if err != nil {
+		t.Fatalf("dispatchRemoteFetch: want standalone fallback to serve, got err=%v", err)
 	}
-	if !strings.Contains(err.Error(), "post-migration drift") {
-		t.Fatalf("dispatchRemoteFetch err = %v, want post-migration drift refusal", err)
+	if !bytes.Equal(got, data) {
+		t.Fatalf("dispatchRemoteFetch standalone fallback returned %d bytes, want the planted payload", len(got))
 	}
-	if got != nil {
-		t.Fatalf("dispatchRemoteFetch data = %d bytes, want nil on refusal", len(got))
-	}
-	if key != "" {
-		t.Fatalf("dispatchRemoteFetch key = %q, want empty on refusal", key)
+	if key == "" {
+		t.Fatal("dispatchRemoteFetch key is empty; want a non-empty CAS key so the caller persists the bytes")
 	}
 }
 
@@ -107,30 +105,29 @@ func TestDispatchRemoteFetch_UnsyncedChunkFallsBackToLocal(t *testing.T) {
 	}
 }
 
-// TestDispatchRemoteFetch_SyncedStandaloneLocatorRefused verifies that a chunk
-// that IS synced but whose recorded locator has an empty BlockID (post-#1493
-// drift — the migration should have rewritten every standalone locator) is
-// refused fail-closed.
-func TestDispatchRemoteFetch_SyncedStandaloneLocatorRefused(t *testing.T) {
+// TestDispatchRemoteFetch_SyncedStandaloneLocatorMissingFailsClosed verifies
+// the genuine data-loss case is still fail-closed: a synced hash with a
+// standalone (empty-BlockID) locator whose bytes are resident nowhere — no
+// local copy, no legacy cas/ object — surfaces ErrChunkNotFound rather than
+// serving zeros.
+func TestDispatchRemoteFetch_SyncedStandaloneLocatorMissingFailsClosed(t *testing.T) {
 	ctx := context.Background()
-	syncer, _, ms := newLocatorFetchSyncer(t)
+	syncer, rem, ms := newLocatorFetchSyncer(t)
+	syncer.SetRemoteBlockStore(rem)
 
 	data := bytes.Repeat([]byte{0xCD}, 2048)
 	hash := block.ContentHash(blake3.Sum256(data))
-	// Synced marker with an empty-BlockID (standalone) locator = drift.
+	// Standalone marker but no bytes anywhere (nothing planted locally or in cas/).
 	if err := ms.MarkSynced(ctx, hash, block.ChunkLocator{}); err != nil {
 		t.Fatalf("MarkSynced: %v", err)
 	}
 
 	key, got, err := syncer.dispatchRemoteFetch(ctx, &block.FileChunk{Hash: hash})
-	if err == nil {
-		t.Fatalf("dispatchRemoteFetch: want post-migration drift refusal, got nil (data=%d bytes)", len(got))
-	}
-	if !strings.Contains(err.Error(), "post-migration drift") {
-		t.Fatalf("dispatchRemoteFetch err = %v, want post-migration drift refusal", err)
+	if !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("dispatchRemoteFetch err = %v, want ErrChunkNotFound", err)
 	}
 	if got != nil || key != "" {
-		t.Fatalf("dispatchRemoteFetch: want empty result on refusal, got key=%q data=%d bytes", key, len(got))
+		t.Fatalf("dispatchRemoteFetch: want empty result on miss, got key=%q data=%d bytes", key, len(got))
 	}
 }
 

--- a/pkg/block/engine/read_path_test.go
+++ b/pkg/block/engine/read_path_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"strings"
 	"testing"
 
 	"lukechampine.com/blake3"
@@ -122,15 +121,14 @@ func TestReadPath_BlockLocator_ThroughCompressEncrypt(t *testing.T) {
 	}
 }
 
-// TestReadPath_StandaloneLocatorRefused pins the post-#1493 inversion of the
-// old CAS back-compat contract: a synced hash whose recorded locator is still
-// standalone (BlockID == "") is post-migration drift — the one-shot startup
-// migration repacked every legacy standalone chunk into a block, so
-// fetchResolvedBlock must refuse the read (no silent zeros, no legacy
-// fallback), even though the legacy cas/ object still exists on the remote.
-// The positive round-trip contract lives in TestReadPath_BlockLocator_Plaintext
-// above, which seeds through the carve path and reads back byte-identical.
-func TestReadPath_StandaloneLocatorRefused(t *testing.T) {
+// TestReadPath_StandaloneLocatorServedViaFallback: a synced hash whose recorded
+// locator is still standalone (BlockID == "") — a chunk the now-background
+// cas→blocks migration has not repacked yet — is served
+// through the legacy CAS fallback, byte-identical, instead of being refused.
+// This is what lets the share serve immediately while the migration runs in the
+// background. The genuine-data-loss case (bytes resident nowhere) is covered by
+// TestReadPath_StandaloneLocatorMissingEverywhere below.
+func TestReadPath_StandaloneLocatorServedViaFallback(t *testing.T) {
 	ctx := context.Background()
 	mem := remotememory.New()
 
@@ -144,29 +142,54 @@ func TestReadPath_StandaloneLocatorRefused(t *testing.T) {
 
 	syncer := NewSyncer(local, mem, ms, DefaultConfig())
 	syncer.SetSyncedHashStore(ms)
+	// Wire the block-keyed remote like production (shares/service.go) and
+	// carveFixture do — it's the object the legacy-CAS fallback reads through.
+	syncer.SetRemoteBlockStore(mem)
 
 	data := []byte("cas-back-compat-payload")
 	h := block.ContentHash(blake3.Sum256(data))
 
-	// Plant the legacy standalone cas/ object (a pre-#1414 upload shape) so
-	// the refusal below is provably fail-closed policy, not a missing object.
-	if err := mem.Put(ctx, h, data); err != nil {
-		t.Fatalf("mem.Put: %v", err)
+	// Plant the legacy standalone cas/ object (a pre-#1414 upload shape) plus a
+	// standalone locator (BlockID == "") — the exact pre-flip state a synced
+	// hash carries before the background migration repacks it.
+	if err := mem.PutLegacyChunk(ctx, h, data); err != nil {
+		t.Fatalf("PutLegacyChunk: %v", err)
 	}
-	// Record a standalone locator (BlockID == "") — post-migration drift.
 	if err := ms.MarkSynced(ctx, h, block.ChunkLocator{}); err != nil {
 		t.Fatalf("MarkSynced: %v", err)
 	}
 
 	got, err := syncer.fetchResolvedBlock(ctx, &block.FileChunk{ID: "share/standalone/0", Hash: h})
-	if err == nil {
-		t.Fatalf("fetchResolvedBlock: want post-migration drift refusal, got nil (data=%d bytes)", len(got))
+	if err != nil {
+		t.Fatalf("fetchResolvedBlock: want standalone fallback to serve, got err=%v", err)
 	}
-	if !strings.Contains(err.Error(), "post-migration drift") {
-		t.Fatalf("fetchResolvedBlock err = %v, want post-migration drift refusal", err)
+	if !bytes.Equal(got, data) {
+		t.Fatalf("fetchResolvedBlock standalone fallback returned %d bytes, want the planted payload", len(got))
+	}
+}
+
+// TestReadPath_StandaloneLocatorMissingEverywhere proves the genuine
+// data-loss case is still fail-closed: a standalone (empty-BlockID) marker whose
+// bytes are resident nowhere — no local copy, no legacy cas/ object — surfaces
+// ErrChunkNotFound rather than serving zeros.
+func TestReadPath_StandaloneLocatorMissingEverywhere(t *testing.T) {
+	ctx := context.Background()
+	mem := remotememory.New()
+	f := newCarveFixture(t, mem, DefaultBlockCarveBytes)
+
+	// A standalone marker with no bytes anywhere (nothing planted on the remote,
+	// nothing stored locally).
+	h := block.ContentHash(blake3.Sum256([]byte("vanished-standalone")))
+	if err := f.ms.MarkSynced(ctx, h, block.ChunkLocator{}); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+
+	got, err := f.syncer.fetchResolvedBlock(ctx, &block.FileChunk{ID: "share/lost/0", Hash: h})
+	if !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("fetchResolvedBlock: want ErrChunkNotFound, got err=%v", err)
 	}
 	if got != nil {
-		t.Fatalf("fetchResolvedBlock data = %d bytes, want nil on refusal", len(got))
+		t.Fatalf("fetchResolvedBlock data = %d bytes, want nil on missing chunk", len(got))
 	}
 }
 

--- a/pkg/block/engine/selfheal_test.go
+++ b/pkg/block/engine/selfheal_test.go
@@ -184,6 +184,11 @@ func TestReadLocalByHash_LocalCorruption_SyncedSelfHeals(t *testing.T) {
 	// Build engine with the corrupting local store. Start runs the migration.
 	bs := newTestEngineWithRemoteAndSHS(t, corruptLocal, remoteRS, shs)
 
+	// The cas→blocks migration now runs in the background; wait for it before
+	// asserting its side effects — and before corrupting the local copy, since
+	// the migration reads the clean local bytes to repack them.
+	<-bs.migrateDone
+
 	// Sanity: the migration rewrote the standalone locator to a block locator.
 	loc, synced, err := shs.GetLocator(ctx, correctHash)
 	if err != nil || !synced {

--- a/pkg/block/engine/sqlite_startup_deadlock_test.go
+++ b/pkg/block/engine/sqlite_startup_deadlock_test.go
@@ -279,6 +279,11 @@ func TestSQLiteStartup_MigrationDetectionIsSinglePass(t *testing.T) {
 
 	runBounded(t, "Store.Start (migration detection)", bs.Start)
 
+	// The migration detection scan now runs in a background goroutine; wait for
+	// it to finish before reading the call counters (avoids a race on
+	// countingMetaView and asserts on the completed scan).
+	<-bs.migrateDone
+
 	if view.enumerateCalls < 1 {
 		t.Errorf("EnumerateSynced calls = %d; want >=1 (migration detection scan ran)", view.enumerateCalls)
 	}


### PR DESCRIPTION
## Problem

Fixes #1622. Upgrading a real deployment (`8e376d36` → `dd65d16b`) hangs on startup: the control plane never binds, NFS/SMB never bind, `/health` returns nothing, process sits at 0% CPU. A SIGQUIT dump shows `goroutine 1` (startup) blocked in an S3 `PutObject` driven by `repackStandaloneChunks` → the cas→blocks legacy migration ran **synchronously on the critical startup path**, and one stalled upload wedged the whole server with no operator recourse.

## Fix — online (background) migration with a read fallback

This is the standard online-migration pattern (dual-read + migrate in the background), the same shape #1479 used for async GC:

1. **Async migration** (`engine.go`) — `migrateLegacyCAS` now runs in a background goroutine spawned in `Store.Start` instead of blocking. `Store.Close` cancels its (detached) context and waits on `migrateDone` before tearing down the local/remote/syncer stores it uses. A slow/stalled remote or near-full disk no longer wedges startup — the pass is idempotent/resumable and simply retries next start.

2. **Read-path fallback** (`fetch.go`, `legacy_migration.go`) — the read path previously *refused* a synced chunk with an empty `BlockID` ("post-migration drift"), which is why the migration had to be a blocking startup gate. Making it async requires the reader to still understand the legacy layout, so `resolveAndReadChunk` now serves standalone chunks via new `readStandaloneChunk` (local-first BLAKE3-verified, then `legacyCAS().ReadLegacyChunkVerified`). A chunk resident **nowhere** still fails closed with `ErrChunkNotFound` (no silent zeros). The pre-existing single re-resolve-on-`ErrChunkNotFound` retry in `dispatchRemoteFetch` absorbs the migration's commit-then-delete window.

Net effect: the share serves immediately; the repack (and `cas/` purge) happen lazily in the background.

## Testing

- `go build ./...`, `go vet ./pkg/block/...`, `gofmt -s` — clean
- `go test -race ./pkg/block/engine/` and full `./pkg/block/...` — green
- Updated the tests that encoded the old blocking/refuse invariants; added `TestReadPath_StandaloneLocatorServedViaFallback` + `…MissingEverywhere` (serve vs. fail-closed) and the dispatch-layer equivalents.

## Notes

- Read semantics reversal is deliberate: the legacy-CAS read path (removed in #1493 PR4) is re-added as the fallback — inherent to any correct online migration (you can't lazily migrate a format you can't still read).
- Per-`PutBlock` timeout (issue suggestion #2) intentionally skipped: the async move already removes the "hangs forever" failure mode. Easy follow-up if we want the repack itself to give up faster.