### PR TITLE
perf(block): parallelize the cold-read demand fetch

### DIFF
--- a/pkg/block/engine/cold_read_demand_concurrency_test.go
+++ b/pkg/block/engine/cold_read_demand_concurrency_test.go
@@ -1,0 +1,59 @@
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	memorylocal "github.com/marmos91/dittofs/pkg/block/local/memory"
+	metastore "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestColdRead_DemandFetchIsConcurrent pins the cold-read fix: a single read
+// spanning many not-local blocks must fetch them from the remote CONCURRENTLY,
+// not one blocking S3 GET per block. Before the fix the demand loop in
+// EnsureAvailableAndRead was serial, which pinned cold-read throughput at
+// blockSize/latency (one GET per round-trip — the ~159 MB/s wall).
+//
+// The assertion is STRUCTURAL, not wall-clock timing: the latency-injecting
+// remote records the peak number of GETs in flight at once. Serial fetching
+// pins that at 1; the bounded parallel fan-out drives it up to nBlocks. This
+// keeps the test deterministic and free of timing flakes.
+func TestColdRead_DemandFetchIsConcurrent(t *testing.T) {
+	const nBlocks = 8
+	ctx := context.Background()
+
+	loc := memorylocal.New()
+	rs := newLatencyRemote(20 * time.Millisecond) // injected per-GET WAN latency
+	fbs := newStubFileChunkStore()
+	mds := metastore.NewMemoryMetadataStoreWithDefaults()
+
+	// Seed nBlocks remote-only chunks, one per block stride, so a single read
+	// over [0, nBlocks*BlockSize) must fetch every one from the remote. Each
+	// block gets DISTINCT bytes (distinct CAS hash) — identical content would
+	// dedup to local after the first fetch and hide the serial-vs-parallel
+	// difference behind CAS, not the loop.
+	for i := 0; i < nBlocks; i++ {
+		chunk := make([]byte, 4096)
+		for j := range chunk {
+			chunk[j] = byte(i*7 + j)
+		}
+		seedSyncedRemoteChunk(t, fbs, rs, mds, "p", uint64(i)*uint64(BlockSize), chunk)
+	}
+
+	m := newFetchSyncer(loc, rs, fbs, mds)
+	m.config.PrefetchBlocks = 0 // isolate the demand loop from the prefetch pump
+
+	dest := make([]byte, nBlocks*BlockSize)
+	if _, err := m.EnsureAvailableAndRead(ctx, "p", 0, uint32(len(dest)), dest); err != nil {
+		t.Fatalf("EnsureAvailableAndRead: %v", err)
+	}
+
+	if got := rs.gets.Load(); got != nBlocks {
+		t.Fatalf("expected %d remote GETs (one per not-local block), got %d", nBlocks, got)
+	}
+	if peak := rs.maxInFlight.Load(); peak < 2 {
+		t.Fatalf("cold demand fetch ran serially (peak in-flight GETs = %d); "+
+			"the serial fetch loop is the cold-read throughput wall", peak)
+	}
+}

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 
+	"golang.org/x/sync/errgroup"
 	"lukechampine.com/blake3"
 
 	"github.com/marmos91/dittofs/internal/logger"
@@ -16,6 +18,21 @@ import (
 // block.FormatStoreKey was removed.
 func inFlightKey(payloadID string, blockIdx uint64) string {
 	return fmt.Sprintf("%s/%d", payloadID, blockIdx)
+}
+
+// fetchGroup returns an errgroup bounded to ParallelDownloads — the single
+// limit on how many block fetches hit the remote at once. Both fetch fan-outs
+// (the cold-read demand loop and WarmAll) share it so there is one place that
+// decides remote-download concurrency. g.Go blocks once the limit is reached;
+// the first task error cancels the rest via the returned context.
+func (m *Syncer) fetchGroup(ctx context.Context) (*errgroup.Group, context.Context) {
+	parallel := m.config.ParallelDownloads
+	if parallel < 1 {
+		parallel = 1
+	}
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(parallel)
+	return g, gctx
 }
 
 // resolveFileChunk returns the FileChunk whose chunk range covers the
@@ -349,39 +366,51 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 		return false, m.remoteUnavailableError()
 	}
 
-	filled := false
-	needLocalReadAt := false
+	var filledFlag, needLocalFlag atomic.Bool
 
+	// Fetch the missing blocks concurrently rather than one S3 round-trip at a
+	// time. A cold sequential read spans many blocks, and a serial demand loop
+	// pins throughput at blockSize/latency (one GET per RTT) — the cold-read
+	// wall. fetchGroup bounds the fan-out by ParallelDownloads (the same knob
+	// and helper the warm path uses). Each block writes a DISJOINT region of
+	// dest, and inlineFetchOrWait's in-flight map dedups concurrent callers, so
+	// the fan-out is race-free; the first error cancels the rest via gctx.
+	g, gctx := m.fetchGroup(ctx)
 	for blockIdx := startBlockIdx; blockIdx <= endBlockIdx; blockIdx++ {
-		fb, err := m.resolveFileChunk(ctx, payloadID, blockIdx)
-		if err != nil {
-			return false, err
-		}
-		if m.blockIsLocalFromRow(ctx, fb) {
-			needLocalReadAt = true
-			continue
-		}
-
-		data, downloaded, err := m.inlineFetchOrWait(ctx, payloadID, blockIdx, fb)
-		if err != nil {
-			return false, err
-		}
-
-		if !downloaded {
-			needLocalReadAt = true
-			continue
-		}
-
-		if data == nil {
-			zeroBlockRegion(dest, blockIdx, offset, uint64(length))
-			filled = true
-			continue
-		}
-
-		if copyBlockToDest(dest, data, blockIdx, offset, uint64(length)) {
-			filled = true
-		}
+		blockIdx := blockIdx
+		g.Go(func() error {
+			fb, err := m.resolveFileChunk(gctx, payloadID, blockIdx)
+			if err != nil {
+				return err
+			}
+			if m.blockIsLocalFromRow(gctx, fb) {
+				needLocalFlag.Store(true)
+				return nil
+			}
+			data, downloaded, err := m.inlineFetchOrWait(gctx, payloadID, blockIdx, fb)
+			if err != nil {
+				return err
+			}
+			if !downloaded {
+				needLocalFlag.Store(true)
+				return nil
+			}
+			if data == nil {
+				zeroBlockRegion(dest, blockIdx, offset, uint64(length))
+				filledFlag.Store(true)
+				return nil
+			}
+			if copyBlockToDest(dest, data, blockIdx, offset, uint64(length)) {
+				filledFlag.Store(true)
+			}
+			return nil
+		})
 	}
+	if err := g.Wait(); err != nil {
+		return false, err
+	}
+	filled := filledFlag.Load()
+	needLocalReadAt := needLocalFlag.Load()
 
 	// Prefetch ahead only as far as the payload's access pattern justifies:
 	// a sequential run ramps the window up to PrefetchBlocks, a random read

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -20,11 +20,12 @@ func inFlightKey(payloadID string, blockIdx uint64) string {
 	return fmt.Sprintf("%s/%d", payloadID, blockIdx)
 }
 
-// fetchGroup returns an errgroup bounded to ParallelDownloads — the single
-// limit on how many block fetches hit the remote at once. Both fetch fan-outs
-// (the cold-read demand loop and WarmAll) share it so there is one place that
-// decides remote-download concurrency. g.Go blocks once the limit is reached;
-// the first task error cancels the rest via the returned context.
+// fetchGroup returns an errgroup bounded to ParallelDownloads — the per-call
+// limit on concurrent remote block fetches. The two synchronous fan-out
+// fetchers (the cold-read demand loop and WarmAll) share it so they bound
+// download concurrency the same way; the background SyncQueue prefetch pool is
+// separate. g.Go blocks once the limit is reached; the first task error cancels
+// the rest via the returned context.
 func (m *Syncer) fetchGroup(ctx context.Context) (*errgroup.Group, context.Context) {
 	parallel := m.config.ParallelDownloads
 	if parallel < 1 {
@@ -377,6 +378,9 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 	// the fan-out is race-free; the first error cancels the rest via gctx.
 	g, gctx := m.fetchGroup(ctx)
 	for blockIdx := startBlockIdx; blockIdx <= endBlockIdx; blockIdx++ {
+		if gctx.Err() != nil {
+			break // first error/cancel: stop scheduling the remaining blocks
+		}
 		blockIdx := blockIdx
 		g.Go(func() error {
 			fb, err := m.resolveFileChunk(gctx, payloadID, blockIdx)

--- a/pkg/block/engine/read_cache_bench_test.go
+++ b/pkg/block/engine/read_cache_bench_test.go
@@ -30,7 +30,7 @@ type latencyRemote struct {
 	getLatency  time.Duration
 	gets        atomic.Int64
 	puts        atomic.Int64
-	inFlight    atomic.Int64 // ReadChunks currently in their injected-latency window
+	inFlight    atomic.Int64 // ReadChunk calls currently in their injected-latency window
 	maxInFlight atomic.Int64 // high-water mark of inFlight — the fetch concurrency
 }
 

--- a/pkg/block/engine/read_cache_bench_test.go
+++ b/pkg/block/engine/read_cache_bench_test.go
@@ -27,9 +27,11 @@ import (
 // #1362 fix.
 type latencyRemote struct {
 	*remotememory.Store
-	getLatency time.Duration
-	gets       atomic.Int64
-	puts       atomic.Int64
+	getLatency  time.Duration
+	gets        atomic.Int64
+	puts        atomic.Int64
+	inFlight    atomic.Int64 // ReadChunks currently in their injected-latency window
+	maxInFlight atomic.Int64 // high-water mark of inFlight — the fetch concurrency
 }
 
 func newLatencyRemote(getLatency time.Duration) *latencyRemote {
@@ -38,6 +40,16 @@ func newLatencyRemote(getLatency time.Duration) *latencyRemote {
 
 func (r *latencyRemote) ReadChunk(ctx context.Context, blockID string, offset, length int64, hash block.ContentHash) ([]byte, error) {
 	r.gets.Add(1)
+	// Track peak concurrency: hold the in-flight count across the injected
+	// latency so overlapping GETs register. Serial fetching pins this at 1.
+	cur := r.inFlight.Add(1)
+	for {
+		mx := r.maxInFlight.Load()
+		if cur <= mx || r.maxInFlight.CompareAndSwap(mx, cur) {
+			break
+		}
+	}
+	defer r.inFlight.Add(-1)
 	if r.getLatency > 0 {
 		time.Sleep(r.getLatency)
 	}

--- a/pkg/block/engine/warm.go
+++ b/pkg/block/engine/warm.go
@@ -142,6 +142,9 @@ func (m *Syncer) WarmAll(ctx context.Context, progress func(done, total int64)) 
 	g, gctx := m.fetchGroup(ctx)
 
 	for _, t := range targets {
+		if gctx.Err() != nil {
+			break // first error/cancel: stop scheduling the remaining fetches
+		}
 		t := t
 		g.Go(func() error {
 			data, err := m.fetchResolvedBlock(gctx, t.fb)

--- a/pkg/block/engine/warm.go
+++ b/pkg/block/engine/warm.go
@@ -7,8 +7,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/local/fs"
 )
@@ -110,11 +108,6 @@ func (m *Syncer) WarmAll(ctx context.Context, progress func(done, total int64)) 
 		return WarmResult{BlocksAlreadyLocal: alreadyLocal}, nil
 	}
 
-	parallel := m.config.ParallelDownloads
-	if parallel < 1 {
-		parallel = 1
-	}
-
 	var (
 		blocksFetched atomic.Int64
 		bytesFetched  atomic.Int64
@@ -143,22 +136,14 @@ func (m *Syncer) WarmAll(ctx context.Context, progress func(done, total int64)) 
 		progress(done, total)
 	}
 
-	g, gctx := errgroup.WithContext(ctx)
-	sem := make(chan struct{}, parallel)
+	// Bound remote-download concurrency via the shared fetchGroup helper (same
+	// ParallelDownloads limit the cold-read demand loop uses). g.Go blocks once
+	// the limit is reached and the first error cancels the rest via gctx.
+	g, gctx := m.fetchGroup(ctx)
 
 	for _, t := range targets {
 		t := t
-		// Block for a slot, but stop dispatching the moment the group is
-		// failing/cancelled (a fetch returned an error or ctx was cancelled).
-		select {
-		case <-gctx.Done():
-		case sem <- struct{}{}:
-		}
-		if gctx.Err() != nil {
-			break
-		}
 		g.Go(func() error {
-			defer func() { <-sem }()
 			data, err := m.fetchResolvedBlock(gctx, t.fb)
 			if err != nil {
 				if errors.Is(err, fs.ErrDiskFull) {


### PR DESCRIPTION
## Problem

A cold read — one that needs CAS blocks not in the local cache — fetched them from the S3 remote **one blocking GET at a time** in the caller's goroutine (`Syncer.EnsureAvailableAndRead`). Throughput pinned at `blockSize / latency`: one round-trip per 8 MiB block ≈ **159 MB/s** at ~50 ms RTT (measured, and the arithmetic matches exactly). Competitors saturate S3 with many parallel GETs.

## Fix

Fan the missing-block fetches out with bounded concurrency. Rather than add a *fourth* copy of the errgroup+semaphore pattern (WarmAll, the download pool, the prefetch pool, the upload limiter already exist), extract one shared helper:

```go
func (m *Syncer) fetchGroup(ctx) (*errgroup.Group, context.Context) // bounded by ParallelDownloads
```

Both fan-out-and-wait fetchers — the cold-read demand loop **and** `WarmAll` — use it, so there's a single place that decides download concurrency. This also **replaces WarmAll's hand-rolled semaphore**, making the change a net simplification (warm.go shrinks). The background queue-drain pools and the *resizable* upload limiter keep their own primitives on purpose — they have a different shape.

Safety: each block writes a **disjoint** region of `dest`, and `inlineFetchOrWait`'s in-flight map already dedups concurrent callers, so the fan-out is race-free (verified under `-race`).

## Test

`TestColdRead_DemandFetchIsConcurrent` asserts the **peak in-flight GET count** structurally via a latency-injecting fake remote — deterministic, no wall-clock timing (which the bench rig has proven too noisy to trust). Serial code ⇒ maxInFlight=1 (the test fails); the fix ⇒ concurrent GETs. Uses distinct per-block content so CAS dedup can't mask the loop behavior.

Verified: `pkg/block/...` (1211) + `internal/adapter/...` (4305) pass, `-race` clean, `go vet` + `golangci-lint` clean.

## Follow-ups (not in this PR)
- Async bounded cache write-back (the inline 8 MiB `local.Put` per block) — separate issue.
- The geometric prefetch ramp / doubled per-block metadata resolve.