### PR TITLE
fix(bench+client): make cold-read benchmarks actually cold (drain before evict + drain-uploads timeout)

### DIFF
--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -138,7 +138,16 @@ func dittofsMount(ctx context.Context, proto Protocol) (string, error) {
 
 // dittofsEvict drops locally-cached blocks so the next read is cold-from-S3.
 // #1595's DrainLocalSynced is what makes `store block evict` actually force it.
+//
+// Drain queued uploads FIRST: `store block evict` (DrainLocalSynced) only drops
+// blocks already synced to S3. A block whose upload is still in flight is left
+// on local disk, so the "cold" read serves it from cache — the pass reads warm,
+// S3MB stays 0, and cold≈warm. Draining first makes every block synced and
+// therefore evictable, so the next read genuinely comes from S3.
 func dittofsEvict(ctx context.Context) error {
+	if err := exec.Sh(ctx, "dfsctl", "system", "drain-uploads"); err != nil {
+		return err
+	}
 	return exec.Sh(ctx, "dfsctl", "store", "block", "evict")
 }
 

--- a/pkg/apiclient/system.go
+++ b/pkg/apiclient/system.go
@@ -1,16 +1,24 @@
 package apiclient
 
+import "time"
+
 // DrainUploadsResponse represents the response from drain-uploads endpoint.
 type DrainUploadsResponse struct {
 	Status   string `json:"status"`
 	Duration string `json:"duration"`
 }
 
+// drainUploadsHTTPTimeout bounds the client-side wait for drain-uploads. The
+// endpoint blocks until every queued upload flushes or the server's own 5-minute
+// cap fires, so the base 30s client timeout would kill a large drain long before
+// the server answers (the failure that made cold-read benchmarks read warm).
+const drainUploadsHTTPTimeout = 6 * time.Minute
+
 // DrainUploads waits for all in-flight block store uploads to complete.
 // This is useful for benchmarking to ensure clean boundaries between workloads.
 func (c *Client) DrainUploads() (*DrainUploadsResponse, error) {
 	var resp DrainUploadsResponse
-	if err := c.post("/api/v1/system/drain-uploads", nil, &resp); err != nil {
+	if err := c.doWithTimeout("POST", "/api/v1/system/drain-uploads", nil, &resp, drainUploadsHTTPTimeout); err != nil {
 		return nil, err
 	}
 	return &resp, nil


### PR DESCRIPTION
Two coupled fixes so a cold-read benchmark actually reads from S3 instead of local cache.

## 1. Harness: drain uploads before evict (`dittofsEvict`)

The cold barrier ran `store block evict` without draining first. Evict (#1595 `DrainLocalSynced`) only drops blocks **already synced to S3**; a block whose upload is still in flight stays on local disk, so the "cold" read serves it from cache — `S3MB=0`, cold≈warm. Drain first so every block is synced and evictable.

## 2. Client: give `drain-uploads` a timeout above the server's cap (`pkg/apiclient`)

Once (1) was in place, the drain **timed out**: `DrainUploads` used the base 30 s `http.Client` timeout, but the endpoint blocks until all uploads flush or the server's 5-minute cap fires. On a 1 GB drain the client aborted with `context deadline exceeded` before the server answered. Route it through the existing `doWithTimeout` with a 6-minute budget (mirrors the `restore` long-timeout pattern that exists for the same reason).

## Why it matters

Together these are the prerequisite for trusting any cold-read A/B. Verified on live runs (2026-07-10): without them, dittofs cold seq-read reported ~814 MB/s at `S3MB=0` — a warm read in disguise; the drain then timed out. This makes the barrier produce a genuine cold-from-S3 pass.

(Discovered while validating #1625: the demand-fetch parallelization does not move NFS cold seq-read anyway, because the Linux NFS client caps rsize at 1 MB < 8 MiB block size — the real cold-read lever is prefetch pipelining, tracked separately.)