### PR TITLE
fix(api): clear write deadline in drain-uploads so a multi-GiB flush isn't cut off

### DIFF
--- a/internal/controlplane/api/handlers/system.go
+++ b/internal/controlplane/api/handlers/system.go
@@ -90,6 +90,18 @@ func (h *SystemHandler) DrainUploads(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Clear this connection's write deadline. A multi-GiB flush legitimately runs
+	// for minutes, far longer than http.Server.WriteTimeout (10s by default, 120s
+	// under pprof); without this the transport tears the connection down mid-drain
+	// and the client sees a bare EOF — not the 200/504 this handler returns. The
+	// request-deadline detachment below handles chi middleware.Timeout; this
+	// handles the separate transport-level write deadline. Best-effort: the stdlib
+	// server's ResponseWriter supports it; a wrapper that does not just keeps its
+	// deadline (#1627 fixed the symmetric client-side timeout).
+	if err := http.NewResponseController(w).SetWriteDeadline(time.Time{}); err != nil {
+		logger.Warn("drain-uploads: could not clear write deadline; a long drain may be cut off", "error", err)
+	}
+
 	// Detach from the request deadline (total <= 0 → no wall-clock cap); the
 	// idle watchdog below is the only bound. A real client disconnect still
 	// cancels via the helper. cancel doubles as the watchdog's abort handle.

--- a/internal/controlplane/api/handlers/system_writedeadline_test.go
+++ b/internal/controlplane/api/handlers/system_writedeadline_test.go
@@ -1,0 +1,61 @@
+package handlers
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// slowDrainRuntime is a drainRuntime whose flush deliberately outlasts the
+// server's WriteTimeout, modelling a multi-GiB backlog draining to a WAN remote.
+type slowDrainRuntime struct {
+	drainDelay time.Duration
+	progress   atomic.Int64
+}
+
+func (s *slowDrainRuntime) DrainAllUploads(ctx context.Context) error {
+	select {
+	case <-time.After(s.drainDelay):
+		s.progress.Add(1)
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *slowDrainRuntime) UploadProgress() int64 { return s.progress.Load() }
+
+// TestDrainUploads_SurvivesServerWriteTimeout guards the cold-read benchmark
+// blocker: a drain legitimately runs longer than http.Server.WriteTimeout, so
+// the handler must clear this connection's write deadline. Without the clear the
+// transport tears the connection down mid-drain and the client sees a bare EOF
+// (which is exactly what broke `dfsctl system drain-uploads` and, with it, every
+// cold-from-S3 read benchmark). Here the drain (400ms) outlasts the server's
+// 150ms WriteTimeout; the POST must still return 200, not error out.
+func TestDrainUploads_SurvivesServerWriteTimeout(t *testing.T) {
+	const writeTimeout = 150 * time.Millisecond
+	h := &SystemHandler{
+		runtime:           &slowDrainRuntime{drainDelay: 400 * time.Millisecond},
+		drainStallTimeout: time.Minute,
+	}
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(h.DrainUploads))
+	srv.Config.WriteTimeout = writeTimeout
+	srv.Start()
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL, "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST failed — connection torn down mid-drain (write deadline not cleared?): %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
+	}
+}


### PR DESCRIPTION
## Problem

`POST /api/v1/system/drain-uploads` detaches its work from the *request* deadline (so chi `middleware.Timeout` can't cancel a long flush) but never clears the connection's **transport write deadline**. `http.Server.WriteTimeout` (10s by default, 120s under pprof) therefore tears the connection down mid-drain, and the client sees a bare `EOF` instead of the 200/504 the handler returns.

Any real drain trips this: a read benchmark lays out its file first (uploading GBs to S3), so the pre-read drain always outruns the write timeout. This silently broke `dfsctl system drain-uploads` and, with it, every cold-from-S3 read measurement built on it. #1627 fixed only the symmetric *client-side* timeout.

Observed on a live SCW bench VM (pprof on → 120s write timeout):
```
FAIL dittofs-s3-nfs3: evict: dfsctl [system drain-uploads]: exit status 1
Error: failed to drain uploads: Post "http://127.0.0.1:8080/api/v1/system/drain-uploads": EOF
```
(The badger `sst: no such file or directory` cascade that follows is a *symptom* — the harness `rm -rf`s the data dir on backend failure while the server is still in graceful shutdown.)

## Fix

Clear the write deadline at the top of the handler (idiomatic long-poll via `http.NewResponseController`). Best-effort: the stdlib server's `ResponseWriter` supports it; a wrapper that doesn't just keeps its deadline.

## Test

`TestDrainUploads_SurvivesServerWriteTimeout` drives a slow drain (400ms) through a real `httptest` server with a 150ms `WriteTimeout` and asserts the POST returns 200, not `EOF`. Verified it fails without the fix (reproduces the exact `Post …: EOF`) and passes with it.