### PR TITLE
fix(netlogon): make NTLM pass-through work on real Windows AD (#1629)

### DIFF
--- a/cmd/dfs/commands/netlogon.go
+++ b/cmd/dfs/commands/netlogon.go
@@ -140,11 +140,16 @@ func netlogonCredentialFromConfig(k config.KerberosConfig) (netlogon.MachineCred
 
 	ma := k.MachineAccount
 
-	// Online-join owns the machine-credential lifecycle (it generates, persists,
-	// and rotates the password), so there is legitimately no static Secret to seed
-	// the offline hot-reload credential from. Return quietly: passthrough is NOT
-	// disabled here (the online provider handles it), so the "Secret is not set"
-	// warnings below would be misleading.
+	// Online-join is wired separately in buildNetlogonAuthenticator, where its own
+	// provider generates, persists, and rotates the machine password. This function
+	// derives only the OFFLINE static credential, so for online-join it returns
+	// (zero, false) meaning "no offline credential to seed" — NOT "pass-through
+	// disabled". The caller (start.go) consequently seeds a nil runtime hot-reload
+	// credential, which is correct: that credential drives the MutableProvider
+	// hot-reload path, and online-join does not use it (its provider is not a
+	// MutableProvider — a ReloadCredential just drops the cached channel and the
+	// online provider re-supplies the password). Returning quietly here also avoids
+	// the misleading "Secret is not set" warnings below.
 	if ma.OnlineJoin.Enabled {
 		return netlogon.MachineCredential{}, false
 	}

--- a/cmd/dfs/commands/netlogon.go
+++ b/cmd/dfs/commands/netlogon.go
@@ -138,8 +138,18 @@ func netlogonCredentialFromConfig(k config.KerberosConfig) (netlogon.MachineCred
 		return netlogon.MachineCredential{}, false
 	}
 
-	// Validate required fields before constructing a doomed credential.
 	ma := k.MachineAccount
+
+	// Online-join owns the machine-credential lifecycle (it generates, persists,
+	// and rotates the password), so there is legitimately no static Secret to seed
+	// the offline hot-reload credential from. Return quietly: passthrough is NOT
+	// disabled here (the online provider handles it), so the "Secret is not set"
+	// warnings below would be misleading.
+	if ma.OnlineJoin.Enabled {
+		return netlogon.MachineCredential{}, false
+	}
+
+	// Validate required fields before constructing a doomed credential.
 	if ma.AccountName == "" {
 		slog.Warn("NETLOGON machine account is enabled but AccountName is not set; NTLM passthrough disabled")
 		return netlogon.MachineCredential{}, false

--- a/cmd/dfs/commands/netlogon_cmd.go
+++ b/cmd/dfs/commands/netlogon_cmd.go
@@ -1,0 +1,105 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+// netlogonCmd groups NETLOGON machine-account (NTLM pass-through) operator
+// subcommands. Today it holds `test`; richer status/rotation against the running
+// server is tracked as a follow-up (it needs control-plane API wiring).
+var netlogonCmd = &cobra.Command{
+	Use:   "netlogon",
+	Short: "Inspect and test NETLOGON machine-account (NTLM pass-through) setup",
+	Long: `NETLOGON machine-account tooling for SMB NTLM pass-through of AD domain users.
+
+When a client connects by a name with no Kerberos SPN (an IP, or the Explorer →
+Network discovery name), Windows falls back to NTLM. DittoFS validates that NTLM
+response against a domain controller over a NETLOGON secure channel, using a
+machine (computer) account configured under 'kerberos.machine_account'. Use these
+subcommands to verify that setup.`,
+}
+
+var netlogonTestCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Probe the NETLOGON secure channel to the domain controller",
+	Long: `Validate that the configured machine account can establish a NETLOGON secure
+channel to a domain controller — the channel NTLM pass-through for AD domain users
+rides.
+
+It authenticates the machine account and brings up the sealed secure channel (the
+same handshake a real domain-user NTLM logon triggers), then tears it down. No user
+logon (NetrLogonSamLogon) is performed. Use it to verify machine-account
+credentials, DC reachability, and Kerberos configuration before relying on Explorer
+double-click / NTLM logons.
+
+This probes the OFFLINE machine-account channel (kerberos.machine_account with an
+account_name + secret). Online join provisions the computer object lazily on the
+first domain logon against the running server — start the server and check its log
+for the join result instead.
+
+Examples:
+  # Probe using the default config location
+  dfs netlogon test
+
+  # Probe using an explicit config file
+  dfs netlogon test --config /etc/dittofs/config.yaml`,
+	Args: cobra.NoArgs,
+	RunE: runNetlogonTest,
+}
+
+func init() {
+	netlogonCmd.AddCommand(netlogonTestCmd)
+}
+
+// runNetlogonTest loads the config, builds the offline NETLOGON authenticator, and
+// probes the secure channel to the DC, reporting the outcome. It refuses the
+// online-join path (which would provision the account as a side effect) and points
+// the operator at the running server instead.
+func runNetlogonTest(cmd *cobra.Command, _ []string) error {
+	cfg, err := config.Load(GetConfigFile())
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	k := cfg.Kerberos
+	ma := k.MachineAccount
+
+	if !ma.Enabled {
+		return fmt.Errorf("kerberos.machine_account.enabled is false — NTLM pass-through is not configured")
+	}
+	if ma.OnlineJoin.Enabled {
+		return fmt.Errorf("`netlogon test` probes the offline machine-account channel; online join provisions the computer object on the first domain logon against the running server — start the server and check its log for the join result")
+	}
+
+	// nil secret store: the offline path reads the static secret from config and
+	// never touches the control-plane store, so this is safe to run alongside a
+	// running server (it makes only an outbound probe to the DC, binds no ports).
+	auth, _ := buildNetlogonAuthenticator(k, nil)
+	if auth == nil {
+		return fmt.Errorf("machine-account configuration is incomplete (see the warnings above); NTLM pass-through is disabled")
+	}
+	defer auth.Close(context.Background())
+
+	dc := "(discover via DNS SRV)"
+	if len(ma.DCAddresses) > 0 {
+		dc = strings.Join(ma.DCAddresses, ", ")
+	}
+	cmd.Printf("Probing NETLOGON secure channel to the domain controller...\n")
+	cmd.Printf("  account: %s\n  realm:   %s\n  domain:  %s\n  dc:      %s\n\n", ma.AccountName, k.Realm, k.NetBIOSDomain, dc)
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+	defer cancel()
+
+	if err := auth.Probe(ctx); err != nil {
+		return fmt.Errorf("secure channel probe FAILED: %w", err)
+	}
+
+	cmd.Printf("OK — NETLOGON secure channel established and torn down successfully.\n")
+	cmd.Printf("The machine account can validate AD domain-user NTLM logons.\n")
+	return nil
+}

--- a/cmd/dfs/commands/root.go
+++ b/cmd/dfs/commands/root.go
@@ -52,6 +52,7 @@ func init() {
 	rootCmd.AddCommand(stopCmd)
 	rootCmd.AddCommand(statusCmd)
 	rootCmd.AddCommand(logsCmd)
+	rootCmd.AddCommand(netlogonCmd)
 	rootCmd.AddCommand(config.Cmd)
 	rootCmd.AddCommand(completionCmd)
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -19,6 +19,8 @@ This page is generated from the command definitions (`go run ./cmd/gendocs`). Do
   - [`dfs init`](#dfs-init) — Initialize a sample configuration file
   - [`dfs logs`](#dfs-logs) — Tail server logs
   - [`dfs migrate`](#dfs-migrate) — Run database migrations
+  - [`dfs netlogon`](#dfs-netlogon) — Inspect and test NETLOGON machine-account (NTLM pass-through) setup
+    - [`dfs netlogon test`](#dfs-netlogon-test) — Probe the NETLOGON secure channel to the domain controller
   - [`dfs start`](#dfs-start) — Start the DittoFS server
   - [`dfs status`](#dfs-status) — Show server status
   - [`dfs stop`](#dfs-stop) — Stop the DittoFS server
@@ -357,6 +359,63 @@ dfs migrate
 
 # Run migrations with a custom config file
 dfs migrate --config /etc/dittofs/config.yaml
+```
+
+Global flags:
+
+```
+      --config string   config file (default: $XDG_CONFIG_HOME/dittofs/config.yaml)
+```
+
+### `dfs netlogon`
+
+Inspect and test NETLOGON machine-account (NTLM pass-through) setup
+
+NETLOGON machine-account tooling for SMB NTLM pass-through of AD domain users.
+
+When a client connects by a name with no Kerberos SPN (an IP, or the Explorer →
+Network discovery name), Windows falls back to NTLM. DittoFS validates that NTLM
+response against a domain controller over a NETLOGON secure channel, using a
+machine (computer) account configured under 'kerberos.machine_account'. Use these
+subcommands to verify that setup.
+
+Global flags:
+
+```
+      --config string   config file (default: $XDG_CONFIG_HOME/dittofs/config.yaml)
+```
+
+### `dfs netlogon test`
+
+Probe the NETLOGON secure channel to the domain controller
+
+Validate that the configured machine account can establish a NETLOGON secure
+channel to a domain controller — the channel NTLM pass-through for AD domain users
+rides.
+
+It authenticates the machine account and brings up the sealed secure channel (the
+same handshake a real domain-user NTLM logon triggers), then tears it down. No user
+logon (NetrLogonSamLogon) is performed. Use it to verify machine-account
+credentials, DC reachability, and Kerberos configuration before relying on Explorer
+double-click / NTLM logons.
+
+This probes the OFFLINE machine-account channel (kerberos.machine_account with an
+account_name + secret). Online join provisions the computer object lazily on the
+first domain logon against the running server — start the server and check its log
+for the join result instead.
+
+```
+dfs netlogon test
+```
+
+**Examples:**
+
+```bash
+# Probe using the default config location
+dfs netlogon test
+
+# Probe using an explicit config file
+dfs netlogon test --config /etc/dittofs/config.yaml
 ```
 
 Global flags:

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1759,9 +1759,76 @@ samba-tool domain exportkeytab /etc/dittofs/dittofs.keytab \
 
 Point `kerberos.keytab_path` at the combined keytab. The SMB handler selects
 the `cifs/` principal (deriving it from the NFS `service_principal`, or via an
-explicit override); NFS RPCSEC_GSS uses the `nfs/` principal. Online
-`net ads join` + machine-password rotation is out of scope (deferred — see
-#1231).
+explicit override); NFS RPCSEC_GSS uses the `nfs/` principal.
+
+#### NTLM pass-through for AD domain users (NETLOGON machine account)
+
+The keytab above authenticates AD users over **Kerberos** (mounting by the SPN
+FQDN, e.g. `\\server.example.com\share`). But when a client connects by a name
+that has **no Kerberos SPN** — an IP address, or the LAN-discovery name a user
+gets by **double-clicking the server in Explorer → Network** (§10) — Windows
+falls back to **NTLM**, which the KDC never sees. To let AD domain users
+authenticate on that path, DittoFS validates their NTLM response against a
+Domain Controller via **NETLOGON pass-through** (MS-NRPC `NetrLogonSamLogon`).
+
+This is **opt-in** and requires a dedicated **machine (computer) account** —
+distinct from the `cifs/` service account in the keytab, because NETLOGON needs
+a *workstation-trust* secure channel that only a machine account can establish.
+The secure channel rides a Kerberos-authenticated SMB session to the DC's
+`\PIPE\netlogon` (reusing the same `krb5_conf` / realm as above). On success the
+DC returns the user's SID **and group SIDs**, which resolve to a UID/GID through
+the directory idmap (§13 / the LDAP identity provider, or `idmap_rid`) and are
+matched against share grants — the **same SID-based authorization** as the
+Kerberos/PAC path, so a domain user or **group** (e.g. `Domain Admins`) granted
+on a share is authorized identically over NTLM.
+
+```yaml
+kerberos:
+  # ... realm / netbios_domain / keytab_path as above ...
+
+  machine_account:
+    enabled: true                 # opt-in; false (default) => no NTLM pass-through
+    account_name: "DITTOFS$"      # the machine account sAMAccountName (trailing '$')
+    dc_address:                   # optional; empty => discover the DC via DNS SRV
+      - "10.0.0.10"
+
+    # Provisioning — pick ONE:
+
+    # (A) OFFLINE: you pre-create the computer account and give DittoFS its
+    #     password. Nothing is written to AD at runtime.
+    secret: "the-machine-account-password"
+
+    # (B) ONLINE JOIN: DittoFS creates the computer object itself over LDAPS on
+    #     first domain logon, owns the password, and rotates it. Requires a
+    #     privileged bind account that can create computer objects. Omit
+    #     `secret` when using this. LDAPS (or ldap:// + start_tls) is mandatory —
+    #     AD refuses a machine-password write over an unencrypted connection.
+    online_join:
+      enabled: true
+      ldap_url: "ldaps://dc.example.com"
+      bind_dn: "CN=Administrator,CN=Users,DC=example,DC=com"
+      bind_password: "..."
+      base_dn: "DC=example,DC=com"
+      # ou: "OU=Servers,DC=example,DC=com"   # default: CN=Computers,<base_dn>
+      rotation_interval: 168h                 # 0 disables rotation (AD max age ~30d)
+      # ca_cert_file: /etc/dittofs/dc-ca.pem  # pin the DC cert (recommended)
+      # insecure_skip_verify: false           # lab only; exposes the password to MITM
+```
+
+| Key | Env var | Default |
+|---|---|---|
+| `kerberos.machine_account.enabled` | `DITTOFS_KERBEROS_MACHINE_ACCOUNT_ENABLED` | `false` |
+| `kerberos.machine_account.account_name` | `DITTOFS_KERBEROS_MACHINE_ACCOUNT_ACCOUNT_NAME` | (empty) |
+| `kerberos.machine_account.secret` | `DITTOFS_KERBEROS_MACHINE_ACCOUNT_SECRET` | (empty; offline path) |
+| `kerberos.machine_account.dc_address` | `DITTOFS_KERBEROS_MACHINE_ACCOUNT_DC_ADDRESS` | (empty → DNS SRV discovery) |
+| `kerberos.machine_account.online_join.enabled` | `DITTOFS_KERBEROS_MACHINE_ACCOUNT_ONLINE_JOIN_ENABLED` | `false` |
+| `kerberos.machine_account.online_join.ldap_url` | `DITTOFS_KERBEROS_MACHINE_ACCOUNT_ONLINE_JOIN_LDAP_URL` | (empty) |
+
+`realm` and `netbios_domain` are **required** for pass-through (the secure
+channel and NTLM `TargetInfo` both need them). The `secret` / `bind_password`
+are redacted in `dfs config show`. For a full walkthrough — pre-creating the
+`DITTOFS$` account and testing the Explorer double-click — see
+[docs/guide/windows-ad-setup.md](windows-ad-setup.md).
 
 ### 13. Identity Mapping Configuration
 

--- a/docs/guide/identity.md
+++ b/docs/guide/identity.md
@@ -613,9 +613,13 @@ so domain users authenticate against the correct domain (see Part C / docs/SMB.m
 
 A real Windows client gets the cleanest experience by **joining the domain** and
 authenticating to DittoFS over **Kerberos** — the server side is fully proven
-(SMB SPNEGO/PAC + AES keytab, Part C). A non-domain-joined Windows box would need
-NTLM passthrough (NETLOGON), which is a separate track (see #1314 / #1345). For
-acceptance testing, domain-join is the path with no extra server dependency.
+(SMB SPNEGO/PAC + AES keytab, Part C). Connecting by a name with no Kerberos SPN
+(an IP, or the Explorer → Network discovery name) falls back to **NTLM**, which
+is now supported for AD domain users via **NETLOGON pass-through** — configure a
+machine account (`kerberos.machine_account`, see
+[configuration.md](configuration.md#12-kerberos-configuration) and
+[windows-ad-setup.md](windows-ad-setup.md)). For Kerberos acceptance testing,
+domain-join is still the path with no extra server dependency.
 
 The in-cluster AD-DC is not publicly reachable by default. To let an external
 test VM join, expose the directory roles via the **scoped** dev LoadBalancer
@@ -687,5 +691,11 @@ icacls \\<dittofs-smb-ip>\<share>\<file>     # CLI equivalent of the Security ta
   `unix_user:*` / `unix_group:*`). See [docs/ACLS.md](access-control.md).
 - **RC4-only keytabs are rejected by Windows 11 (#1318).** Ensure the keytab
   carries AES256/AES128 keys for the SPNs (Part A).
-- Online `net ads join` + machine-password rotation is out of scope; supply the
-  keytab offline.
+- **Machine account (NETLOGON) for NTLM pass-through:** the keytab covers
+  Kerberos; for AD domain users authenticating over **NTLM** (Explorer
+  double-click / connect by IP, no SPN) configure `kerberos.machine_account`.
+  Both **offline** (pre-created computer account + supplied secret) and **online
+  `net ads join`** (DittoFS creates the computer object over LDAPS and rotates
+  the password) are supported. See
+  [configuration.md](configuration.md#12-kerberos-configuration) and
+  [windows-ad-setup.md](windows-ad-setup.md).

--- a/docs/guide/windows-ad-setup.md
+++ b/docs/guide/windows-ad-setup.md
@@ -314,13 +314,36 @@ net use \\192.168.100.50\ditto /user:CUBBIT\alice P4ssword!
 ```
 
 The debug log shows `NETLOGON pass-through: authenticated directory-resolved
-domain user`, then the usual SID-grant match at TREE_CONNECT. For the
-**double-click** experience specifically, LAN discovery (§10 of
-[configuration.md](configuration.md)) must be enabled and, on a Windows host, the
-discovery ports must be allowed **for the dfs.exe program** (Windows' built-in
-Network-Discovery rules are scoped to `System`/`svchost`, so a third-party binary
-is dropped by default — add inbound allow rules for 5357/TCP, 3702/UDP, 5353/UDP
-pointing at your exact `dfs.exe` path).
+domain user`, then the usual SID-grant match at TREE_CONNECT.
+
+### Ports and firewall
+
+This feature is **server-OS-agnostic** — the DittoFS server can run on **Linux or
+Windows**; the AD/Kerberos/NETLOGON setup is identical and only the host firewall
+differs. Pass-through needs the DittoFS host to reach the **DC outbound** on
+Kerberos `88`, LDAP `389`/`636`, SMB `445`, and DNS `53`, and to accept SMB `445`
+**inbound** from clients. The Explorer **double-click** additionally needs LAN
+discovery (see [configuration.md](configuration.md) → *Network discovery*):
+inbound WS-Discovery UDP `3702`, mDNS UDP `5353`, and the metadata fetch on TCP
+`5357`.
+
+- **DittoFS on Windows** — the built-in "Network Discovery" rules are scoped to
+  `System`/`svchost`, so inbound discovery traffic to a third-party `dfs.exe` is
+  dropped by default. Add **program-scoped** inbound rules:
+  ```powershell
+  $dfs = "C:\path\to\dfs.exe"
+  New-NetFirewallRule -DisplayName "DittoFS Discovery (WSD meta)"  -Direction Inbound -Action Allow -Protocol TCP -LocalPort 5357 -Program $dfs -Profile Any
+  New-NetFirewallRule -DisplayName "DittoFS Discovery (WSD probe)" -Direction Inbound -Action Allow -Protocol UDP -LocalPort 3702 -Program $dfs -Profile Any
+  New-NetFirewallRule -DisplayName "DittoFS Discovery (mDNS)"      -Direction Inbound -Action Allow -Protocol UDP -LocalPort 5353 -Program $dfs -Profile Any
+  ```
+- **DittoFS on Linux** — no program-scoping quirk; just open the ports (e.g. with
+  firewalld):
+  ```bash
+  firewall-cmd --permanent --add-port=445/tcp --add-port=5357/tcp --add-port=3702/udp --add-port=5353/udp
+  firewall-cmd --reload
+  ```
+  Outbound to the DC is usually already permitted; if you restrict egress, allow
+  `88`, `389`/`636`, `445`, and `53` to the DC.
 
 > **Known limitation:** SMB multichannel **session-bind** for pass-through domain
 > users is not yet supported — a client that opens extra channels logs a benign

--- a/docs/guide/windows-ad-setup.md
+++ b/docs/guide/windows-ad-setup.md
@@ -242,7 +242,94 @@ directory is configured (step 3); without it they show as raw `S-1-5-21-…`.
 
 ---
 
-## 6. Verify and troubleshoot
+## 6. NTLM pass-through: Explorer double-click for AD users (optional)
+
+Everything above authenticates over **Kerberos**, which needs a service ticket
+for the SPN — so it works when you mount by the FQDN (`\\vm2.cubbit.local\ditto`).
+But when a user **double-clicks the server in Explorer → Network** (LAN
+discovery), or connects by **IP**, Windows connects by a name with **no SPN** and
+falls back to **NTLM** — which the KDC never sees. Without extra setup, an AD
+domain user fails that path with `STATUS_LOGON_FAILURE` (only local DittoFS users
+with a stored password work over NTLM).
+
+To make double-click work for **domain** users, enable **NETLOGON pass-through**:
+DittoFS forwards the client's NTLM response to a DC (`NetrLogonSamLogon`) over a
+secure channel, gets back the user + group SIDs, and authorizes them with the
+**same SID grants** from step 4 (so `Domain Admins` etc. apply unchanged).
+
+This needs a dedicated **machine (computer) account** — *not* the `svc-dittofs`
+service account, because NETLOGON requires a workstation-trust secure channel
+that only a machine account can establish.
+
+**Step 1 — create the machine account (offline).** On a DC, elevated PowerShell:
+
+```powershell
+New-ADComputer -Name DITTOFS `
+  -AccountPassword (ConvertTo-SecureString 'M4chine!Pass2026' -AsPlainText -Force) `
+  -Enabled $true `
+  -OtherAttributes @{'msDS-SupportedEncryptionTypes'=31}   # 31 = advertise AES
+```
+
+Don't set a `dNSHostName`/SPN on it — the host already owns `HOST/vm2…` via its
+own computer account, and this account is only a NETLOGON client identity.
+(Alternatively, skip this step and let DittoFS create + rotate the account itself
+with `online_join` — see [configuration.md](configuration.md#12-kerberos-configuration).)
+
+**Step 2 — add the machine account to the server config** (under `kerberos:`):
+
+```yaml
+kerberos:
+  enabled: true
+  realm: "CUBBIT.LOCAL"
+  netbios_domain: "CUBBIT"
+  # ... keytab_path etc. as in step 2 ...
+  machine_account:
+    enabled: true
+    account_name: "DITTOFS$"
+    secret: "M4chine!Pass2026"
+    dc_address: ["192.168.100.70"]   # optional; empty => DNS SRV discovery
+```
+
+Restart the server. The log should show
+`NETLOGON machine account: offline provider active account=DITTOFS$`.
+
+Verify the machine account can reach the DC before testing a real logon:
+
+```bash
+dfs netlogon test --config /etc/dittofs/config.yaml
+# OK — NETLOGON secure channel established and torn down successfully.
+```
+
+`dfs netlogon test` authenticates the machine account and brings up the NETLOGON
+secure channel (no user logon), so it isolates a machine-account/DC/Kerberos
+problem from an NTLM-logon problem. It probes the **offline** machine account;
+online join provisions on the first logon (check the server log).
+
+**Step 3 — test the NTLM path.** From a domain member, connect by **IP** (forces
+NTLM) or double-click the server in Explorer → Network:
+
+```powershell
+net use * /delete /y
+net use \\192.168.100.50\ditto /user:CUBBIT\alice P4ssword!
+```
+
+The debug log shows `NETLOGON pass-through: authenticated directory-resolved
+domain user`, then the usual SID-grant match at TREE_CONNECT. For the
+**double-click** experience specifically, LAN discovery (§10 of
+[configuration.md](configuration.md)) must be enabled and, on a Windows host, the
+discovery ports must be allowed **for the dfs.exe program** (Windows' built-in
+Network-Discovery rules are scoped to `System`/`svchost`, so a third-party binary
+is dropped by default — add inbound allow rules for 5357/TCP, 3702/UDP, 5353/UDP
+pointing at your exact `dfs.exe` path).
+
+> **Known limitation:** SMB multichannel **session-bind** for pass-through domain
+> users is not yet supported — a client that opens extra channels logs a benign
+> `LOGON_FAILURE` on the spare connection and keeps working on the primary. It
+> does not affect browsing or mounting.
+
+---
+
+## 7. Verify and troubleshoot
 
 **Prove no local users are needed:** you never ran `dfsctl user create` for alice
 or bob — they mount purely as AD principals.

--- a/internal/auth/netlogon/authenticator.go
+++ b/internal/auth/netlogon/authenticator.go
@@ -323,6 +323,33 @@ func (a *Authenticator) RotatePassword(ctx context.Context, newPassword string) 
 	return err
 }
 
+// Probe establishes the NETLOGON secure channel to the DC and immediately tears
+// it down, returning nil when the machine account authenticated and the sealed
+// channel came up. It runs the same connect handshake a real domain-user NTLM
+// logon triggers (Kerberos SMB session to \PIPE\netlogon + schannel
+// ServerAuthenticate) but issues no NetrLogonSamLogon, so it validates
+// machine-account credentials, DC reachability, and Kerberos configuration
+// without a user logon.
+//
+// It backs the operator "dfs netlogon test" command: a nil return means the
+// channel is ready for pass-through; an error names what failed (a wrong machine
+// password, an unreachable DC, or a Kerberos misconfiguration). Note that for an
+// online-join provider the Credential() call performs the AD join as a side
+// effect, so callers that must avoid provisioning should probe only the offline
+// provider.
+func (a *Authenticator) Probe(ctx context.Context) error {
+	mc, err := a.provider.Credential(ctx)
+	if err != nil {
+		return err
+	}
+	if _, err := a.ensureChannel(ctx, mc); err != nil {
+		return err
+	}
+	// Connected — drop the channel so a probe never leaves a live schannel behind.
+	a.reset(ctx)
+	return nil
+}
+
 // Close shuts down the cached secure channel connection.
 func (a *Authenticator) Close(ctx context.Context) {
 	a.reset(ctx)

--- a/internal/auth/netlogon/join.go
+++ b/internal/auth/netlogon/join.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"unicode/utf16"
 
@@ -19,6 +20,16 @@ import (
 // set: the account always carries a strong password we generate.
 const (
 	uacWorkstationTrustAccount = 0x1000
+
+	// uacAccountDisable (ADS_UF_ACCOUNTDISABLE) marks the account disabled. The
+	// computer object is CREATED disabled (WORKSTATION_TRUST | ACCOUNTDISABLE)
+	// because AD refuses to create an ENABLED account that has no valid password
+	// yet — the initial Add carries no unicodePwd (that write needs the object to
+	// exist first), so creating it enabled fails with a Constraint Violation
+	// (LDAP result 19, AtrErr on userAccountControl). joinDirectory sets the
+	// password next, then reasserts userAccountControl WITHOUT this flag to enable
+	// it — the standard create-disabled → set-password → enable join sequence.
+	uacAccountDisable = 0x0002
 
 	// supportedEncTypes advertises the Kerberos enctypes the machine account
 	// supports via msDS-SupportedEncryptionTypes (MS-KILE 2.2.7). 0x1F =
@@ -184,18 +195,73 @@ func joinDirectory(ctx context.Context, dial ldapDialer, cfg *JoinConfig, newPas
 		return fmt.Errorf("netlogon join: set machine password on %q: %w", dn, err)
 	}
 
-	// Ensure the account is enabled with the workstation-trust UAC and advertises
-	// AES enctypes. A freshly created object may be disabled until the password is
-	// set, and an existing object from a prior (pre-AES) join may lack the enctype
-	// attribute; reasserting both here makes the join converge regardless of the
-	// create path, so the NETLOGON channel negotiates AES.
-	mod := ldapv3.NewModifyRequest(dn, nil)
-	mod.Replace("userAccountControl", []string{fmt.Sprintf("%d", uacWorkstationTrustAccount)})
-	mod.Replace("msDS-SupportedEncryptionTypes", []string{fmt.Sprintf("%d", supportedEncTypes)})
-	if err := conn.Modify(mod); err != nil {
-		return fmt.Errorf("netlogon join: enable computer %q (uac + enctypes): %w", dn, err)
+	// Enable the account now that it exists and carries a password (created
+	// disabled above). This is critical — a still-disabled machine account cannot
+	// establish the NETLOGON secure channel.
+	if err := enableComputer(conn, cfg, dn, !exists); err != nil {
+		return fmt.Errorf("netlogon join: enable computer %q: %w", dn, err)
+	}
+
+	// Advertise AES enctypes (msDS-SupportedEncryptionTypes) so the NETLOGON
+	// channel negotiates AES. Best-effort: a machine-account-quota (non-admin)
+	// creator may lack write access to this attribute, so a failure here must NOT
+	// fail an otherwise complete join. It is logged at Warn (not silenced) because
+	// the consequence is real: on a DC hardened to reject RC4 (AES-only), a machine
+	// account that never got AES advertised can fail later Kerberos with
+	// KDC_ERR_ETYPE_NOSUPP — the message names the remediation.
+	encMod := ldapv3.NewModifyRequest(dn, nil)
+	encMod.Replace("msDS-SupportedEncryptionTypes", []string{fmt.Sprintf("%d", supportedEncTypes)})
+	if err := conn.Modify(encMod); err != nil {
+		slog.Default().Warn("netlogon join: could not set msDS-SupportedEncryptionTypes; the machine account keeps the DC's default enctypes — if the DC rejects RC4 (AES-only), advertise AES on the computer object manually or re-run the join with a bind account that can write this attribute",
+			"dn", dn, "error", err)
 	}
 	return nil
+}
+
+// enableComputer clears ACCOUNTDISABLE so the machine account can establish the
+// secure channel. On the object we just created (created=true) it was created
+// with exactly WORKSTATION_TRUST|ACCOUNTDISABLE, so a plain WORKSTATION_TRUST is
+// the correct enabled value. On a pre-existing account (a reconciling re-join) it
+// reads the current userAccountControl and clears ONLY ACCOUNTDISABLE, preserving
+// any other flags the account carries (TRUSTED_FOR_DELEGATION, DONT_EXPIRE_PASSWORD,
+// …) so the join never silently strips them.
+func enableComputer(conn ldapConn, cfg *JoinConfig, dn string, created bool) error {
+	uac := uint32(uacWorkstationTrustAccount)
+	if !created {
+		current, err := readUserAccountControl(conn, dn)
+		if err != nil {
+			return err
+		}
+		uac = (current &^ uacAccountDisable) | uacWorkstationTrustAccount
+	}
+	mod := ldapv3.NewModifyRequest(dn, nil)
+	mod.Replace("userAccountControl", []string{fmt.Sprintf("%d", uac)})
+	return conn.Modify(mod)
+}
+
+// readUserAccountControl fetches the current userAccountControl of the computer
+// object at dn (base-scoped read), so a re-join can clear ACCOUNTDISABLE without
+// clobbering the account's other UAC flags.
+func readUserAccountControl(conn ldapConn, dn string) (uint32, error) {
+	req := ldapv3.NewSearchRequest(
+		dn,
+		ldapv3.ScopeBaseObject, ldapv3.NeverDerefAliases, 1, 0, false,
+		"(objectClass=computer)",
+		[]string{"userAccountControl"}, nil,
+	)
+	res, err := conn.Search(req)
+	if err != nil {
+		return 0, fmt.Errorf("netlogon join: read userAccountControl for %q: %w", dn, err)
+	}
+	if len(res.Entries) == 0 {
+		return 0, fmt.Errorf("netlogon join: computer %q vanished before enable", dn)
+	}
+	raw := strings.TrimSpace(res.Entries[0].GetAttributeValue("userAccountControl"))
+	v, err := strconv.ParseUint(raw, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("netlogon join: parse userAccountControl %q for %q: %w", raw, dn, err)
+	}
+	return uint32(v), nil
 }
 
 // computerExists reports whether a computer object with the given
@@ -214,14 +280,19 @@ func computerExists(conn ldapConn, cfg *JoinConfig, sam string) (bool, error) {
 	return len(res.Entries) > 0, nil
 }
 
-// addComputerObject creates the computer object with the workstation-trust UAC
-// and optional dNSHostName / SPNs.
+// addComputerObject creates the computer object DISABLED (workstation-trust UAC +
+// ACCOUNTDISABLE) with optional dNSHostName / SPNs. It is created disabled — and
+// WITHOUT msDS-SupportedEncryptionTypes — because the initial Add carries no
+// password: AD rejects an enabled, password-less create with a Constraint
+// Violation, and a non-privileged (machine-account-quota) creator may likewise be
+// unable to set the enctype attribute before the object exists. joinDirectory
+// sets unicodePwd next, then reasserts userAccountControl (enabled) and
+// msDS-SupportedEncryptionTypes on the now-existing, password-bearing object.
 func addComputerObject(conn ldapConn, cfg *JoinConfig, dn, sam string) error {
 	add := ldapv3.NewAddRequest(dn, nil)
 	add.Attribute("objectClass", []string{"top", "person", "organizationalPerson", "user", "computer"})
 	add.Attribute("sAMAccountName", []string{sam})
-	add.Attribute("userAccountControl", []string{fmt.Sprintf("%d", uacWorkstationTrustAccount)})
-	add.Attribute("msDS-SupportedEncryptionTypes", []string{fmt.Sprintf("%d", supportedEncTypes)})
+	add.Attribute("userAccountControl", []string{fmt.Sprintf("%d", uacWorkstationTrustAccount|uacAccountDisable)})
 	if cfg.DNSHostName != "" {
 		add.Attribute("dNSHostName", []string{cfg.DNSHostName})
 	}

--- a/internal/auth/netlogon/join_test.go
+++ b/internal/auth/netlogon/join_test.go
@@ -2,6 +2,7 @@ package netlogon
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"unicode/utf16"
@@ -12,20 +13,30 @@ import (
 // fakeLDAP is an in-memory ldapConn that records the operations the join
 // performs so tests can assert on the computer object and password write.
 type fakeLDAP struct {
-	existing  bool // computer already present on Search
-	adds      []*ldapv3.AddRequest
-	modifies  []*ldapv3.ModifyRequest
-	bindErr   error
-	addErr    error
-	modifyErr error
-	closed    bool
+	existing    bool   // computer already present on Search
+	existingUAC uint32 // userAccountControl returned for the existing computer
+	adds        []*ldapv3.AddRequest
+	modifies    []*ldapv3.ModifyRequest
+	bindErr     error
+	addErr      error
+	modifyErr   error
+	closed      bool
 }
 
 func (f *fakeLDAP) Bind(string, string) error { return f.bindErr }
 func (f *fakeLDAP) Search(*ldapv3.SearchRequest) (*ldapv3.SearchResult, error) {
 	res := &ldapv3.SearchResult{}
 	if f.existing {
-		res.Entries = []*ldapv3.Entry{{DN: "CN=DITTOFS,CN=Computers,DC=dittofs,DC=ad"}}
+		uac := f.existingUAC
+		if uac == 0 {
+			uac = uacWorkstationTrustAccount // sensible default: an enabled workstation
+		}
+		res.Entries = []*ldapv3.Entry{{
+			DN: "CN=DITTOFS,CN=Computers,DC=dittofs,DC=ad",
+			Attributes: []*ldapv3.EntryAttribute{
+				{Name: "userAccountControl", Values: []string{fmt.Sprintf("%d", uac)}},
+			},
+		}}
 	}
 	return res, nil
 }
@@ -73,22 +84,42 @@ func TestJoinDirectory_CreatesComputerAndSetsPassword(t *testing.T) {
 	if !hasAttr(add, "sAMAccountName", "DITTOFS$") {
 		t.Errorf("sAMAccountName not set to DITTOFS$: %+v", add.Attributes)
 	}
-	if !hasAttr(add, "userAccountControl", "4096") {
-		t.Errorf("userAccountControl not WORKSTATION_TRUST_ACCOUNT (4096): %+v", add.Attributes)
+	// Created DISABLED (WORKSTATION_TRUST | ACCOUNTDISABLE = 4098): AD rejects an
+	// enabled, password-less create with a Constraint Violation. The password and
+	// enable steps follow.
+	if !hasAttr(add, "userAccountControl", "4098") {
+		t.Errorf("userAccountControl not WORKSTATION_TRUST|ACCOUNTDISABLE (4098): %+v", add.Attributes)
+	}
+	// enctypes must NOT be set at create time — it is written after the password,
+	// on the now-existing object (best-effort for a non-admin creator).
+	for _, a := range add.Attributes {
+		if a.Type == "msDS-SupportedEncryptionTypes" {
+			t.Errorf("msDS-SupportedEncryptionTypes should not be set on the Add: %+v", add.Attributes)
+		}
 	}
 
-	// Two modifies: unicodePwd + userAccountControl reassertion.
-	if len(fake.modifies) != 2 {
-		t.Fatalf("expected 2 Modify (unicodePwd + uac), got %d", len(fake.modifies))
+	// Three modifies: unicodePwd, enable (uac=4096), enctypes.
+	if len(fake.modifies) != 3 {
+		t.Fatalf("expected 3 Modify (unicodePwd + enable + enctypes), got %d", len(fake.modifies))
 	}
 	assertUnicodePwd(t, fake.modifies[0], "Sup3rSecret!")
+	if !modReplaces(fake.modifies[1], "userAccountControl", "4096") {
+		t.Errorf("second Modify should enable the account (userAccountControl=4096): %+v", fake.modifies[1].Changes)
+	}
+	if !modReplaces(fake.modifies[2], "msDS-SupportedEncryptionTypes", "31") {
+		t.Errorf("third Modify should set msDS-SupportedEncryptionTypes=31: %+v", fake.modifies[2].Changes)
+	}
 	if !fake.closed {
 		t.Error("expected connection to be closed")
 	}
 }
 
 func TestJoinDirectory_IdempotentWhenComputerExists(t *testing.T) {
-	fake := &fakeLDAP{existing: true}
+	// Pre-existing account carries WORKSTATION_TRUST | DONT_EXPIRE_PASSWORD (0x10000)
+	// and is already enabled. A reconciling re-join must preserve the extra flag,
+	// not clobber userAccountControl down to a bare 4096.
+	const dontExpirePassword = 0x10000
+	fake := &fakeLDAP{existing: true, existingUAC: uacWorkstationTrustAccount | dontExpirePassword}
 	dial := func(context.Context, *JoinConfig) (ldapConn, error) { return fake, nil }
 
 	if err := joinDirectory(context.Background(), dial, baseJoinConfig(), "NewPass1!"); err != nil {
@@ -97,11 +128,16 @@ func TestJoinDirectory_IdempotentWhenComputerExists(t *testing.T) {
 	if len(fake.adds) != 0 {
 		t.Errorf("expected no Add when computer exists, got %d", len(fake.adds))
 	}
-	// Still resets the password (re-join after lost secret) + reasserts uac.
-	if len(fake.modifies) != 2 {
-		t.Fatalf("expected 2 Modify on existing computer, got %d", len(fake.modifies))
+	// Still resets the password (re-join after lost secret) + enable + enctypes.
+	if len(fake.modifies) != 3 {
+		t.Fatalf("expected 3 Modify on existing computer, got %d", len(fake.modifies))
 	}
 	assertUnicodePwd(t, fake.modifies[0], "NewPass1!")
+	// Enable must preserve the pre-existing flags: 0x11000 = 69632, not 4096.
+	want := fmt.Sprintf("%d", uint32(uacWorkstationTrustAccount|dontExpirePassword))
+	if !modReplaces(fake.modifies[1], "userAccountControl", want) {
+		t.Errorf("enable Modify should preserve existing UAC flags (want userAccountControl=%s): %+v", want, fake.modifies[1].Changes)
+	}
 }
 
 func TestJoinDirectory_UsesOUWhenSet(t *testing.T) {
@@ -166,6 +202,20 @@ func hasAttr(add *ldapv3.AddRequest, name, value string) bool {
 	for _, a := range add.Attributes {
 		if a.Type == name {
 			for _, v := range a.Vals {
+				if v == value {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// modReplaces reports whether mod carries a Replace of attribute name to value.
+func modReplaces(mod *ldapv3.ModifyRequest, name, value string) bool {
+	for _, ch := range mod.Changes {
+		if ch.Modification.Type == name {
+			for _, v := range ch.Modification.Vals {
 				if v == value {
 					return true
 				}

--- a/internal/auth/netlogon/securechannel.go
+++ b/internal/auth/netlogon/securechannel.go
@@ -3,7 +3,6 @@ package netlogon
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 	"sync"
 
@@ -33,8 +32,8 @@ import (
 var gssapiMechRegister sync.Once
 
 // registerGSSAPIMechanisms registers the SPNEGO/NTLM/KRB5/Netlogon mechanisms
-// with go-msrpc exactly once (process-global). The initial GetDCName/ReqChallenge
-// bind inside NewSecureChannelClient authenticates the machine account via
+// with go-msrpc exactly once (process-global). The initial ReqChallenge bind
+// inside NewSecureChannelClient authenticates the machine account via
 // NTLM/SPNEGO (the netlogon schannel config does not exist yet at that point);
 // the Netlogon mechanism is used only for the sealed secure channel afterward.
 // KRB5 authenticates the NETLOGON named-pipe SMB session: Samba rejects a
@@ -97,7 +96,7 @@ type SecureChannel struct {
 	mu     sync.Mutex
 	cc     dcerpc.Conn
 	cli    logon.LogonSecureChannelClient
-	dcName string // UNC DC computer name (e.g. \\DC01); populated by connect() via GetDCName
+	dcName string // UNC DC name (e.g. \\DC01) for the LogonServer; derived locally by connect() (see deriveLogonServer)
 }
 
 // connect establishes the NETLOGON schannel connection to the given DC. It is
@@ -199,22 +198,49 @@ func (sc *SecureChannel) connect(ctx context.Context, mc MachineCredential) erro
 	sc.cc = cc
 	sc.cli = cli
 
-	// Discover the DC's computer name via GetDCName so samLogon can use the
-	// correct UNC LogonServer (MS-NRPC requires the DC name, not the domain name).
-	// Failure is non-fatal: we fall back to the domain-name form.
-	dcResp, err := cli.GetDCName(gctx, &logon.GetDCNameRequest{
-		ComputerName: mc.Workstation,
-		DomainName:   mc.DomainName,
-	})
-	if err != nil || dcResp == nil || dcResp.DomainControllerInfo == nil || dcResp.DomainControllerInfo.DomainControllerName == "" {
-		slog.Default().Debug("netlogon: GetDCName failed or returned empty name, falling back to domain name", "error", err)
-		sc.dcName = "\\\\" + mc.DomainName
-	} else {
-		// DomainControllerName is already UNC-prefixed (e.g. \\DC01) per MS-NRPC.
-		sc.dcName = dcResp.DomainControllerInfo.DomainControllerName
-	}
+	// LogonServer / PrimaryName for the NETLOGON RPCs (samLogon, setPassword) is
+	// derived LOCALLY from the Kerberos SPN (cifs/<dc-fqdn>) of the DC we dialed —
+	// we deliberately do NOT issue DsrGetDcName over the sealed channel.
+	//
+	// Why not GetDCName: against a real Windows DC that call's response fails to
+	// decode in go-msrpc AND the decode error tears down the shared DCERPC
+	// transport, so the very next NetrLogonSamLogon on this channel fails with
+	// "transport is closed" — the passthrough never validates the user (#1629). The
+	// earlier comment that GetDCName failure is "non-fatal" held only against Samba
+	// (which returned a decodable response); on Windows it is fatal to the channel.
+	//
+	// MS-NRPC treats LogonServer loosely: the DC authenticates the caller by the
+	// secure-channel authenticator (established above), not by this string, and both
+	// Windows and Samba accept the short DC label. So the local derivation is
+	// sufficient and removes a fragile, inessential round-trip.
+	sc.dcName = deriveLogonServer(spn, mc.DomainName)
 
 	return nil
+}
+
+// deriveLogonServer builds the UNC "\\<DCNAME>" used as the NETLOGON LogonServer
+// (NetrLogonSamLogon) / PrimaryName (NetrServerPasswordSet2). It takes the short
+// host label of the DC's Kerberos SPN (cifs/<fqdn>), so a dialed cifs/dc01.example.com
+// yields "\\DC01". When no host can be derived it falls back to the NetBIOS domain
+// name.
+//
+// This assumes the DC's NetBIOS/computer name equals the uppercased leftmost DNS
+// label — the AD default. It can diverge for a renamed DC or a DNS label longer
+// than the 15-char NetBIOS limit; that is tolerated because the DC authenticates
+// the caller by the secure-channel authenticator (established in connect), not by
+// this string, which MS-NRPC treats as informational. Deriving it locally is what
+// avoids the DsrGetDcName round-trip whose response decode tears down the shared
+// DCERPC transport on a real Windows DC (#1629).
+func deriveLogonServer(spn, domainName string) string {
+	host := strings.TrimPrefix(spn, "cifs/")
+	if i := strings.IndexByte(host, '.'); i > 0 {
+		host = host[:i]
+	}
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return "\\\\" + domainName
+	}
+	return "\\\\" + strings.ToUpper(host)
 }
 
 // setPassword changes the machine account's password on the DC via
@@ -247,16 +273,10 @@ func (sc *SecureChannel) setPassword(ctx context.Context, mc MachineCredential, 
 		return err
 	}
 
-	// PrimaryName is the DC's UNC name. Mirror samLogon's fallback so a failed
-	// GetDCName in connect() (which leaves sc.dcName empty) does not send an empty
-	// PrimaryName that the DC would reject.
-	primaryName := sc.dcName
-	if primaryName == "" {
-		primaryName = "\\\\" + mc.DomainName
-	}
-
+	// PrimaryName is the DC's UNC name, derived locally in connect()
+	// (deriveLogonServer) and therefore always non-empty.
 	req := &logon.PasswordSet2Request{
-		PrimaryName:       primaryName,
+		PrimaryName:       sc.dcName,
 		AccountName:       mc.AccountName,
 		SecureChannelType: logon.SecureChannelTypeWorkstationSecureChannel,
 		ComputerName:      mc.Workstation,
@@ -316,15 +336,10 @@ func (sc *SecureChannel) samLogon(ctx context.Context, mc MachineCredential, req
 	}
 
 	cli := sc.cli
-	dcName := sc.dcName
 
-	// Use the DC's computer name as LogonServer per MS-NRPC.
-	// dcName is already UNC-prefixed (\\DC01) and set in connect(); fall back
-	// to domain name if it was not discovered.
-	logonServer := dcName
-	if logonServer == "" {
-		logonServer = "\\\\" + mc.DomainName
-	}
+	// LogonServer is the DC's UNC name (\\DC01) per MS-NRPC, derived locally in
+	// connect() (deriveLogonServer) and therefore always non-empty.
+	logonServer := sc.dcName
 
 	out, err := cli.SAMLogon(ctx, &logon.SAMLogonRequest{
 		LogonServer:  logonServer,

--- a/internal/auth/netlogon/securechannel_test.go
+++ b/internal/auth/netlogon/securechannel_test.go
@@ -14,3 +14,64 @@ func TestNetworkLogonRequiresCredential(t *testing.T) {
 		t.Fatal("expected error when machine credential is incomplete")
 	}
 }
+
+// TestProbe verifies that Probe connects a secure channel and tears it down,
+// leaving no cached channel behind (backing `dfs netlogon test`, #1629).
+func TestProbe(t *testing.T) {
+	st := &fakeState{}
+	withFakeChannels(t, st)
+
+	a := NewAuthenticator(NewOfflineProvider(validCred("DITTOFS$")))
+	if err := a.Probe(context.Background()); err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+
+	st.mu.Lock()
+	built := st.built
+	st.mu.Unlock()
+	if built != 1 {
+		t.Errorf("expected exactly 1 channel connected, got %d", built)
+	}
+	// Probe must not leave a live channel cached on the authenticator.
+	a.mu.Lock()
+	leftover := a.chan_
+	a.mu.Unlock()
+	if leftover != nil {
+		t.Error("Probe should tear down the channel, but one is still cached")
+	}
+}
+
+// TestProbeRequiresCredential ensures Probe surfaces a credential error (e.g. an
+// incomplete machine account) rather than dialing.
+func TestProbeRequiresCredential(t *testing.T) {
+	a := NewAuthenticator(NewOfflineProvider(MachineCredential{})) // incomplete
+	if err := a.Probe(context.Background()); err == nil {
+		t.Fatal("expected Probe to error on an incomplete machine credential")
+	}
+}
+
+// TestDeriveLogonServer covers the LogonServer name derived locally from the DC's
+// Kerberos SPN (the GetDCName replacement, #1629): the short host label, uppercased
+// and UNC-prefixed, with a domain-name fallback when no host is present.
+func TestDeriveLogonServer(t *testing.T) {
+	tests := []struct {
+		name   string
+		spn    string
+		domain string
+		want   string
+	}{
+		{"fqdn spn", "cifs/dc01.example.com", "EXAMPLE", `\\DC01`},
+		{"short spn", "cifs/dc01", "EXAMPLE", `\\DC01`},
+		{"already upper", "cifs/DC01.example.com", "EXAMPLE", `\\DC01`},
+		{"no cifs prefix", "dc01.example.com", "EXAMPLE", `\\DC01`},
+		{"empty spn falls back to domain", "", "EXAMPLE", `\\EXAMPLE`},
+		{"cifs-only falls back to domain", "cifs/", "EXAMPLE", `\\EXAMPLE`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deriveLogonServer(tt.spn, tt.domain); got != tt.want {
+				t.Errorf("deriveLogonServer(%q, %q) = %q, want %q", tt.spn, tt.domain, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Makes SMB **NTLM pass-through for AD domain users** (issue #1629) actually work
against a **real Windows Server 2025 DC**. The feature was already implemented on
`develop` (the netlogon PR chain #1314/#1324/#1345/#1357/#1369/#1370/#1323) but had
only ever been exercised against Samba/fakes. Enabling it against a live Windows AD
surfaced two real bugs, fixed here, plus a misleading log and a missing operator
command.

Double-clicking a discovered DittoFS server in **Explorer → Network** (or connecting
by IP — anything with no Kerberos SPN) now authenticates AD domain users over NTLM,
resolves their SID via LDAP, and authorizes them by share grant — no Kerberos SPN /
FQDN required. Validated end-to-end on the AD testbed as `CUBBIT\alice` (direct
grant) and `CUBBIT\Administrator` (via the `Domain Admins` group grant).

## Bug fixes (both required for real Windows AD)

1. **`DsrGetDcName` poisons the DCERPC transport** (`securechannel.go`). `connect()`
   issued `DsrGetDcName` over the sealed channel as a best-effort LogonServer-name
   lookup. Against a real Windows DC the response fails to decode in go-msrpc **and
   the decode error tears down the shared DCERPC transport**, so the very next
   `NetrLogonSamLogon` fails with `transport is closed` → the logon never validates
   (client sees `System error 86`). The "GetDCName failure is non-fatal" assumption
   held only for Samba. Fix: **remove the RPC**; derive the LogonServer UNC locally
   from the DC's Kerberos SPN (`deriveLogonServer`). MS-NRPC treats LogonServer
   loosely — the DC authenticates by the secure-channel authenticator, not this
   string.

2. **Online join creates the computer account enabled-without-password**
   (`join.go`). `addComputerObject` set `userAccountControl=0x1000` (enabled) in the
   initial LDAP `Add`, but the password (`unicodePwd`) is written in a later step,
   and AD refuses to create an enabled, password-less account (`Constraint Violation`).
   Fix: create **disabled** (`WORKSTATION_TRUST | ACCOUNTDISABLE`), set the password,
   then enable — the standard join sequence — and make the `msDS-SupportedEncryptionTypes`
   write **best-effort** (a non-admin machine-account-quota creator may lack write
   access; modern DCs default to AES anyway).

## Also

- **Quiet the misleading online-join WARN** (`cmd/dfs/commands/netlogon.go`):
  `netlogonCredentialFromConfig` logged `Secret is not set; NTLM passthrough disabled`
  even in online-join mode, where there's legitimately no static secret and
  passthrough is fully active. Returns quietly for online join now.

- **New `dfs netlogon test` command** (`cmd/dfs/commands/netlogon_cmd.go`): probes the
  NETLOGON secure channel to the DC using the offline machine account (the same
  handshake a real logon triggers, minus the user logon), so an operator can verify
  machine-account credentials / DC reachability / Kerberos config before relying on
  NTLM logons. Adds `Authenticator.Probe`.

- **Docs**: documents `kerberos.machine_account` (offline + online-join) in
  `configuration.md`, adds a NETLOGON / Explorer-double-click section to
  `windows-ad-setup.md`, and corrects the now-false "online `net ads join` is out of
  scope (deferred)" statements in `configuration.md` / `identity.md`. `cli.md`
  regenerated.

## Validation (real Windows Server 2025 DC, cubbit.local)

- Offline machine account (`DITTOFS$`): NTLM logon as `CUBBIT\alice` by IP and via the
  Explorer discovery name → `NetrLogonSamLogon` OK → SID→LDAP→uid/gid → `/ditto`
  read-write grant.
- Online join (`DITTOFS-OJ$`): first logon provisioned the computer object over LDAPS,
  authenticated the user, and the `NetrServerPasswordSet2` rotation fired on schedule.
- `dfs netlogon test` → `OK — NETLOGON secure channel established`.

## Follow-ups
- #1631 — `dfsctl netlogon status`/`rotate` against the running server (needs API/Runtime wiring).
- #1632 — SMB2 session-bind (multichannel) for pass-through domain users.

Closes #1629
