### PR TITLE
fix(bench): trustworthy same-VM cold-read A/B — robustness + disk/net metering + real cold barrier

### DIFF
--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -61,9 +61,9 @@ func dittofsSetup(ctx context.Context, env BackendEnv) error {
 	// metadata-store create fail "cannot acquire directory lock"; worse, the rm
 	// deleted SST files out from under the live process (badger "no such file"
 	// spam) while the new `dfs start` reported "DittoFS is already running". So kill
-	// by both cmdline and exact name, free the NFS port, and if dfs still refuses to
-	// die, ABORT the cell rather than wipe state under it — a clean FAIL beats
-	// corrupting the store and mis-attributing the result to the binary under test.
+	// by exact name, free the NFS port, and if dfs still refuses to die, ABORT the
+	// cell rather than wipe state under it — a clean FAIL beats corrupting the store
+	// and mis-attributing the result to the binary under test.
 	//
 	// Match dfs by EXACT process name (-x dfs), never by `-f 'dfs start'`: the -f
 	// pattern is matched against every process's full cmdline, and THIS cleanup
@@ -259,7 +259,7 @@ func dittofsEvict(ctx context.Context) error {
 	// large remainder survives (>20% of a non-trivial starting size), the cold pass
 	// would read it from disk — FAIL LOUDLY rather than emit a warm number labelled
 	// "cold". The DiskWr/NetRx columns independently confirm coldness post-hoc.
-	if before.LocalDiskUsed > dittofsColdBarrierFloorBytes && after.LocalDiskUsed*5 > before.LocalDiskUsed {
+	if before.LocalDiskUsed > dittofsColdBarrierFloorBytes && after.LocalDiskUsed > before.LocalDiskUsed/5 {
 		return fmt.Errorf("cold barrier failed: local disk only fell %dMiB→%dMiB (want ≥80%% drop); the cold pass would measure locally-served reads, not S3",
 			before.LocalDiskUsed>>20, after.LocalDiskUsed>>20)
 	}
@@ -269,13 +269,20 @@ func dittofsEvict(ctx context.Context) error {
 func dittofsTeardown(ctx context.Context) error {
 	// SIGKILL + wait for the process to actually exit so a subsequent same-VM run
 	// (e.g. an A/B binary swap) starts clean instead of tripping dfs's "already
-	// running" guard. Best-effort: a wedged dfs is caught+failed by the next
-	// Setup's pre-start cleanup rather than silently wiped under.
-	// Match by exact name (-x dfs); a `-f 'dfs start'` pattern would self-match the
-	// shell running it (its argv contains the literal). See dittofsSetup's cleanup.
-	_ = exec.Sh(ctx, "sh", "-c",
+	// running" guard. Match by exact name (-x dfs); a `-f 'dfs start'` pattern would
+	// self-match the shell running it (its argv contains the literal). See
+	// dittofsSetup's cleanup.
+	//
+	// Only wipe the data dir once dfs is confirmed dead: RemoveAll under a live dfs
+	// deletes Badger SSTs out from under it and corrupts the store — the exact
+	// failure Setup hardens against. If dfs survives SIGKILL, leave the dir intact
+	// and let the next Setup's pre-start guard catch it and FAIL loudly.
+	if err := exec.Sh(ctx, "sh", "-c",
 		"pkill -9 -x dfs 2>/dev/null; "+
-			"for i in $(seq 1 20); do pgrep -x dfs >/dev/null 2>&1 || break; sleep 0.5; done; true")
+			"for i in $(seq 1 20); do pgrep -x dfs >/dev/null 2>&1 || break; sleep 0.5; done; "+
+			"pgrep -x dfs >/dev/null 2>&1 && { echo 'dfs survived SIGKILL — leaving data dir for next Setup to catch' >&2; exit 1; }; true"); err != nil {
+		return nil // best-effort teardown; don't wipe state under a wedged process
+	}
 	return os.RemoveAll(dittofsDataDir)
 }
 

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -2,8 +2,10 @@ package backend
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/marmos91/dittofs/internal/dfsbench/exec"
 )
@@ -158,11 +160,110 @@ func dittofsMount(ctx context.Context, proto Protocol) (string, error) {
 // on local disk, so the "cold" read serves it from cache — the pass reads warm,
 // S3MB stays 0, and cold≈warm. Draining first makes every block synced and
 // therefore evictable, so the next read genuinely comes from S3.
+// dittofsColdBarrierFloorBytes is the resident-bytes threshold below which the
+// cold-barrier verification stops caring about an exact drop ratio — small
+// datasets and metadata slack shouldn't fail the check.
+const dittofsColdBarrierFloorBytes = 64 << 20 // 64 MiB
+
+// dittofsBlockTotals is the subset of `dfsctl store block stats -o json` the
+// cold barrier needs: how much is resident locally, and how much is not yet
+// durable on the remote (so DrainLocalSynced can't drop it).
+type dittofsBlockTotals struct {
+	LocalDiskUsed  int64 `json:"local_disk_used"`
+	UnsyncedBytes  int64 `json:"unsynced_bytes"`
+	PendingUploads int   `json:"pending_uploads"`
+}
+
+func dittofsBlockStats(ctx context.Context) (dittofsBlockTotals, error) {
+	out, err := exec.Out(ctx, "dfsctl", "store", "block", "stats", "-o", "json")
+	if err != nil {
+		return dittofsBlockTotals{}, fmt.Errorf("dfsctl store block stats: %w", err)
+	}
+	var resp struct {
+		Totals dittofsBlockTotals `json:"totals"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return dittofsBlockTotals{}, fmt.Errorf("parse block stats json: %w\n%s", err, out)
+	}
+	return resp.Totals, nil
+}
+
+// dittofsDrainDriftFloorBytes is the residual unsynced size the drain loop
+// tolerates as "done". A freshly-written file's final bytes sit in the append log
+// until the next rollup boundary, so a few chunks stay un-carved/un-synced
+// indefinitely without another write — requiring EXACTLY 0 loops forever. A few
+// MiB out of a multi-GiB file is <0.1% and does not meaningfully warm the cold
+// pass (the post-evict ≥80%-drop check is the real cold gate).
+const dittofsDrainDriftFloorBytes = 32 << 20 // 32 MiB
+
+// dittofsDrainUntilSynced loops `dfsctl system drain-uploads` until the store's
+// unsynced bytes fall to the drift floor, stable across two polls. A single drain
+// is not enough: rollup is async and carveFlush is snapshot-at-claim, so one pass
+// misses chunks that roll up mid-drain — leaving them locally resident and
+// un-evictable, so the "cold" pass silently reads them from local disk (the
+// confound that made several cold-read A/Bs meaningless). The short settle between
+// rounds lets the async rollup produce the next batch of CAS chunks for the
+// following drain to upload.
+func dittofsDrainUntilSynced(ctx context.Context) error {
+	const maxRounds = 60
+	stable := 0
+	for i := 0; i < maxRounds; i++ {
+		if err := exec.Sh(ctx, "dfsctl", "system", "drain-uploads"); err != nil {
+			return fmt.Errorf("dfsctl system drain-uploads: %w", err)
+		}
+		st, err := dittofsBlockStats(ctx)
+		if err != nil {
+			return err
+		}
+		if st.UnsyncedBytes <= dittofsDrainDriftFloorBytes {
+			if stable++; stable >= 2 {
+				return nil
+			}
+		} else {
+			stable = 0
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+	st, _ := dittofsBlockStats(ctx)
+	return fmt.Errorf("drain-uploads never fell below %dMiB unsynced after %d rounds (unsynced=%dMiB pending_uploads=%d) — cannot force a cold read",
+		dittofsDrainDriftFloorBytes>>20, maxRounds, st.UnsyncedBytes>>20, st.PendingUploads)
+}
+
 func dittofsEvict(ctx context.Context) error {
-	if err := exec.Sh(ctx, "dfsctl", "system", "drain-uploads"); err != nil {
+	// Cold-read barrier. Force the whole warm-written file durable on S3, evict the
+	// local tier, then VERIFY it actually emptied — otherwise the cold pass reads
+	// locally-resident bytes and silently measures a warm read (the confound the
+	// DiskWr/NetRx meter exposed: cold pulled only ~15-33 MB/s from S3 while the
+	// data sat on the block volume).
+	before, err := dittofsBlockStats(ctx)
+	if err != nil {
 		return err
 	}
-	return exec.Sh(ctx, "dfsctl", "store", "block", "evict")
+	if err := dittofsDrainUntilSynced(ctx); err != nil {
+		return err
+	}
+	// Evict local blocks + read buffer. DrainLocalSynced drops only synced blocks;
+	// now that everything is synced it can drop the whole file.
+	if err := exec.Sh(ctx, "dfsctl", "store", "block", "evict"); err != nil {
+		return fmt.Errorf("dfsctl store block evict: %w", err)
+	}
+	after, err := dittofsBlockStats(ctx)
+	if err != nil {
+		return err
+	}
+	// Verify: the local tier must have shed the bulk of its resident bytes. If a
+	// large remainder survives (>20% of a non-trivial starting size), the cold pass
+	// would read it from disk — FAIL LOUDLY rather than emit a warm number labelled
+	// "cold". The DiskWr/NetRx columns independently confirm coldness post-hoc.
+	if before.LocalDiskUsed > dittofsColdBarrierFloorBytes && after.LocalDiskUsed*5 > before.LocalDiskUsed {
+		return fmt.Errorf("cold barrier failed: local disk only fell %dMiB→%dMiB (want ≥80%% drop); the cold pass would measure locally-served reads, not S3",
+			before.LocalDiskUsed>>20, after.LocalDiskUsed>>20)
+	}
+	return nil
 }
 
 func dittofsTeardown(ctx context.Context) error {

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -52,15 +52,29 @@ func dittofsSetup(ctx context.Context, env BackendEnv) error {
 	if err != nil {
 		return err
 	}
-	// Kill any dfs left over by a crashed prior run and WAIT for it to actually
-	// die before wiping state: a still-live old dfs holds the BadgerDB directory
-	// lock and keeps rewriting controlplane.db, so racing rm+start against it made
-	// the metadata-store create fail "cannot acquire directory lock". Only after
-	// it's gone do we wipe control-plane + client state, so bootstrap (admin user,
-	// stores, share) is deterministic and re-runnable. Resilience: survive a dirty VM.
-	_ = exec.Sh(ctx, "sh", "-c",
-		"pkill -9 -f 'dfs start' 2>/dev/null; for i in $(seq 1 30); do pgrep -x dfs >/dev/null 2>&1 || break; sleep 0.5; done; "+
-			"rm -rf ~/.config/dittofs ~/.local/state/dittofs ~/.config/dfsctl "+dittofsDataDir+"; true")
+	// Kill any dfs left over by a prior run and WAIT for it to actually die before
+	// wiping state. This is what makes a same-VM re-run — e.g. an A/B binary swap —
+	// safe. A still-live old dfs holds the BadgerDB directory lock and keeps
+	// rewriting controlplane.db, so racing rm+start against it made the
+	// metadata-store create fail "cannot acquire directory lock"; worse, the rm
+	// deleted SST files out from under the live process (badger "no such file"
+	// spam) while the new `dfs start` reported "DittoFS is already running". So kill
+	// by both cmdline and exact name, free the NFS port, and if dfs still refuses to
+	// die, ABORT the cell rather than wipe state under it — a clean FAIL beats
+	// corrupting the store and mis-attributing the result to the binary under test.
+	//
+	// Match dfs by EXACT process name (-x dfs), never by `-f 'dfs start'`: the -f
+	// pattern is matched against every process's full cmdline, and THIS cleanup
+	// shell's own argv contains the literal "dfs start", so `pkill -f 'dfs start'`
+	// SIGKILLs its own parent shell before the rm runs ("signal: killed"). -x dfs
+	// matches the server's comm ("dfs") and can't self-match the "sh" running this.
+	clean := "pkill -9 -x dfs 2>/dev/null; " +
+		"for i in $(seq 1 40); do pgrep -x dfs >/dev/null 2>&1 || break; sleep 0.5; done; " +
+		"if pgrep -x dfs >/dev/null 2>&1; then echo 'dfs still alive after SIGKILL — refusing to wipe state under it' >&2; exit 1; fi; " +
+		"rm -rf ~/.config/dittofs ~/.local/state/dittofs ~/.config/dfsctl " + dittofsDataDir
+	if err := exec.Sh(ctx, "sh", "-c", clean); err != nil {
+		return fmt.Errorf("dittofs setup: pre-start cleanup failed (stale dfs?): %w", err)
+	}
 	if err := os.MkdirAll(dittofsDataDir+"/meta", 0o755); err != nil {
 		return err
 	}
@@ -152,7 +166,15 @@ func dittofsEvict(ctx context.Context) error {
 }
 
 func dittofsTeardown(ctx context.Context) error {
-	_ = exec.Sh(ctx, "sh", "-c", "pkill -f 'dfs start' || true")
+	// SIGKILL + wait for the process to actually exit so a subsequent same-VM run
+	// (e.g. an A/B binary swap) starts clean instead of tripping dfs's "already
+	// running" guard. Best-effort: a wedged dfs is caught+failed by the next
+	// Setup's pre-start cleanup rather than silently wiped under.
+	// Match by exact name (-x dfs); a `-f 'dfs start'` pattern would self-match the
+	// shell running it (its argv contains the literal). See dittofsSetup's cleanup.
+	_ = exec.Sh(ctx, "sh", "-c",
+		"pkill -9 -x dfs 2>/dev/null; "+
+			"for i in $(seq 1 20); do pgrep -x dfs >/dev/null 2>&1 || break; sleep 0.5; done; true")
 	return os.RemoveAll(dittofsDataDir)
 }
 

--- a/internal/dfsbench/exec/local.go
+++ b/internal/dfsbench/exec/local.go
@@ -20,6 +20,19 @@ func Sh(ctx context.Context, name string, args ...string) error {
 	return nil
 }
 
+// Out runs a command on the local host and returns its stdout. On failure it
+// returns an error carrying stderr so a broken step is legible. Used to read
+// `dfsctl ... -o json` for the cold-barrier drain/verify polling.
+func Out(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	var out, errb bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &out, &errb
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("%s %v: %w\n%s", name, args, err, errb.String())
+	}
+	return out.Bytes(), nil
+}
+
 // DropOSCache flushes and drops the kernel page cache so the next read pass is
 // genuinely cold, not served from RAM. Universal across backends (runs after a
 // backend's own Evict). Linux/root-only; best-effort — the caller warns on error

--- a/internal/dfsbench/fio/result.go
+++ b/internal/dfsbench/fio/result.go
@@ -43,6 +43,14 @@ type CellResult struct {
 	CtxSwPerSec float64 `json:"ctxsw_per_sec,omitempty"`
 	CPUPct      float64 `json:"cpu_pct,omitempty"`
 
+	// Server-side I/O throughput during the pass (Linux only; 0 off Linux). For a
+	// cold read these discriminate the fill bottleneck: DiskWrMBps is the local
+	// tier's write rate (block volume), NetRxMBps the S3 download rate (non-loopback
+	// NIC; NFS/SMB run over loopback here). If cold MB/s ≈ DiskWrMBps ≪ NetRxMBps
+	// the read is disk-write bound; if cold MB/s ≈ NetRxMBps it is S3-network bound.
+	DiskWrMBps float64 `json:"disk_wr_mbps,omitempty"`
+	NetRxMBps  float64 `json:"net_rx_mbps,omitempty"`
+
 	// AccessMode is how the backend served this cell: "native" (its own server,
 	// e.g. dittofs/zerofs) or "reexport" (a FUSE mount re-served over knfsd/Samba
 	// — the FUSE tax). Empty for direct local/smoke mounts. Drives the pairing view.

--- a/internal/dfsbench/fio/result.go
+++ b/internal/dfsbench/fio/result.go
@@ -50,6 +50,9 @@ type CellResult struct {
 	// the read is disk-write bound; if cold MB/s ≈ NetRxMBps it is S3-network bound.
 	DiskWrMBps float64 `json:"disk_wr_mbps,omitempty"`
 	NetRxMBps  float64 `json:"net_rx_mbps,omitempty"`
+	// Metered is true when the server-resource columns above were actually
+	// sampled (Linux), so a measured 0 renders as "0" not "—" (unmetered).
+	Metered bool `json:"metered,omitempty"`
 
 	// AccessMode is how the backend served this cell: "native" (its own server,
 	// e.g. dittofs/zerofs) or "reexport" (a FUSE mount re-served over knfsd/Samba

--- a/internal/dfsbench/report/report.go
+++ b/internal/dfsbench/report/report.go
@@ -83,10 +83,10 @@ func RenderTable(rs []fio.CellResult) string {
 			fmt.Sprintf("%.0f", r.LatencyP50Us),
 			fmt.Sprintf("%.0f", r.LatencyP99Us),
 			fmt.Sprintf("%d", r.S3Bytes/fio.Mib),
-			metered(r.DiskWrMBps),
-			metered(r.NetRxMBps),
-			metered(r.CtxSwPerSec),
-			metered(r.CPUPct),
+			metered(r.DiskWrMBps, r.Metered),
+			metered(r.NetRxMBps, r.Metered),
+			metered(r.CtxSwPerSec, r.Metered),
+			metered(r.CPUPct, r.Metered),
 			fmt.Sprintf("%d", r.Errors),
 		})
 	}
@@ -163,7 +163,7 @@ func RenderPairing(rs []fio.CellResult) string {
 				r.System, access(r.AccessMode),
 				rate(r.ThroughputMBps, !isRandom(r.Workload)),
 				rate(r.IOPS, isRandom(r.Workload)),
-				metered(r.CtxSwPerSec), metered(r.CPUPct),
+				metered(r.CtxSwPerSec, r.Metered), metered(r.CPUPct, r.Metered),
 				fmt.Sprintf("%d", r.Errors),
 			})
 		}
@@ -203,10 +203,11 @@ func rate(v float64, headline bool) string {
 	return fmt.Sprintf("%.0f", v)
 }
 
-// metered formats a server-resource column, dashing an unmeasured 0 (off Linux,
-// or a run predating the meter) rather than printing a misleading zero.
-func metered(v float64) string {
-	if v == 0 {
+// metered formats a server-resource column, dashing it when the meter didn't run
+// (off Linux, or a run predating the meter) so a genuine measured 0 — e.g. a warm
+// read with no S3 download — still prints as "0" rather than the unmeasured dash.
+func metered(v float64, on bool) string {
+	if !on {
 		return "—"
 	}
 	return fmt.Sprintf("%.0f", v)

--- a/internal/dfsbench/report/report.go
+++ b/internal/dfsbench/report/report.go
@@ -73,7 +73,7 @@ func RenderTable(rs []fio.CellResult) string {
 		return a.Size < b.Size
 	})
 
-	head := []string{"SYSTEM", "ACCESS", "WORKLOAD", "SIZE", "PROTO", "PASS", "IOPS", "MB/s", "p50µs", "p99µs", "S3MB", "CTXSW/s", "CPU%", "err"}
+	head := []string{"SYSTEM", "ACCESS", "WORKLOAD", "SIZE", "PROTO", "PASS", "IOPS", "MB/s", "p50µs", "p99µs", "S3MB", "DiskWrMB/s", "NetRxMB/s", "CTXSW/s", "CPU%", "err"}
 	rows := make([][]string, 0, len(rs))
 	for _, r := range rs {
 		rows = append(rows, []string{
@@ -83,6 +83,8 @@ func RenderTable(rs []fio.CellResult) string {
 			fmt.Sprintf("%.0f", r.LatencyP50Us),
 			fmt.Sprintf("%.0f", r.LatencyP99Us),
 			fmt.Sprintf("%d", r.S3Bytes/fio.Mib),
+			metered(r.DiskWrMBps),
+			metered(r.NetRxMBps),
 			metered(r.CtxSwPerSec),
 			metered(r.CPUPct),
 			fmt.Sprintf("%d", r.Errors),

--- a/internal/dfsbench/report/report_test.go
+++ b/internal/dfsbench/report/report_test.go
@@ -35,10 +35,10 @@ func TestRenderTable_HeadlineDashing(t *testing.T) {
 
 func TestRenderPairing(t *testing.T) {
 	rs := []fio.CellResult{
-		{System: "dittofs-s3", AccessMode: "native", Workload: "seq-read", Size: "medium", Protocol: "nfs3", Pass: "cold", ThroughputMBps: 349, CtxSwPerSec: 18400},
-		{System: "juicefs", AccessMode: "reexport", Workload: "seq-read", Size: "medium", Protocol: "nfs3", Pass: "cold", ThroughputMBps: 437, CtxSwPerSec: 96300},
+		{System: "dittofs-s3", AccessMode: "native", Workload: "seq-read", Size: "medium", Protocol: "nfs3", Pass: "cold", ThroughputMBps: 349, CtxSwPerSec: 18400, Metered: true},
+		{System: "juicefs", AccessMode: "reexport", Workload: "seq-read", Size: "medium", Protocol: "nfs3", Pass: "cold", ThroughputMBps: 437, CtxSwPerSec: 96300, Metered: true},
 		// A group with only a native row must NOT produce a pairing section.
-		{System: "dittofs-s3", AccessMode: "native", Workload: "seq-write", Size: "medium", Protocol: "nfs3", Pass: "warm", ThroughputMBps: 500, CtxSwPerSec: 12000},
+		{System: "dittofs-s3", AccessMode: "native", Workload: "seq-write", Size: "medium", Protocol: "nfs3", Pass: "warm", ThroughputMBps: 500, CtxSwPerSec: 12000, Metered: true},
 	}
 	out := RenderPairing(rs)
 	if !strings.Contains(out, "seq-read") || !strings.Contains(out, "18400") || !strings.Contains(out, "96300") {
@@ -50,6 +50,17 @@ func TestRenderPairing(t *testing.T) {
 	// native row is ordered before the re-exported one.
 	if strings.Index(out, "dittofs-s3") > strings.Index(out, "juicefs") {
 		t.Errorf("native row must precede re-exported row:\n%s", out)
+	}
+}
+
+func TestMetered_ZeroVsUnmetered(t *testing.T) {
+	// A genuine measured 0 (metered warm read, no S3 download) must render "0";
+	// an unmetered run (off Linux) dashes even when the value is 0.
+	if got := metered(0, true); got != "0" {
+		t.Errorf("measured 0 should render 0, got %q", got)
+	}
+	if got := metered(0, false); got != "—" {
+		t.Errorf("unmetered should dash, got %q", got)
 	}
 }
 

--- a/internal/dfsbench/run/managed.go
+++ b/internal/dfsbench/run/managed.go
@@ -212,6 +212,7 @@ func runPass(ctx context.Context, p backend.Plan, pass string, wls, sizes []stri
 			r := before.RatesTo(sysstat.Now())
 			m.CtxSwPerSec, m.CPUPct = r.CtxSwPerSec, r.CPUPct
 			m.DiskWrMBps, m.NetRxMBps = r.DiskWrMBps, r.NetRxMBps
+			m.Metered = r.Metered
 			// "native" | "reexport" — the pairing axis. Guard the Support.String()
 			// "na" sentinel to empty so an unexpected value never leaks into the
 			// ACCESS column or the pairing grouping.

--- a/internal/dfsbench/run/managed.go
+++ b/internal/dfsbench/run/managed.go
@@ -211,6 +211,7 @@ func runPass(ctx context.Context, p backend.Plan, pass string, wls, sizes []stri
 			}
 			r := before.RatesTo(sysstat.Now())
 			m.CtxSwPerSec, m.CPUPct = r.CtxSwPerSec, r.CPUPct
+			m.DiskWrMBps, m.NetRxMBps = r.DiskWrMBps, r.NetRxMBps
 			// "native" | "reexport" — the pairing axis. Guard the Support.String()
 			// "na" sentinel to empty so an unexpected value never leaks into the
 			// ACCESS column or the pairing grouping.

--- a/internal/dfsbench/sysstat/sysstat.go
+++ b/internal/dfsbench/sysstat/sysstat.go
@@ -152,6 +152,10 @@ type Rates struct {
 	CPUPct      float64 // busy jiffies as % of total over the interval, 0..100
 	DiskWrMBps  float64 // whole-disk bytes written ÷ wall-seconds ÷ 1e6
 	NetRxMBps   float64 // non-lo bytes received ÷ wall-seconds ÷ 1e6
+	// Metered is true when both samples were ok (Linux /proc read+parsed), so a
+	// genuine measured 0 (e.g. a warm read with no S3 download) can be told apart
+	// from an unmetered run (macOS/local smoke), which the report dashes instead.
+	Metered bool
 }
 
 // RatesTo computes rates from a (earlier) to b (later). Returns zeros unless
@@ -162,7 +166,7 @@ func (a Sample) RatesTo(b Sample) Rates {
 		return Rates{}
 	}
 	dt := b.T.Sub(a.T).Seconds()
-	var r Rates
+	r := Rates{Metered: true}
 	if dt > 0 && b.CtxSwitches >= a.CtxSwitches {
 		r.CtxSwPerSec = float64(b.CtxSwitches-a.CtxSwitches) / dt
 	}

--- a/internal/dfsbench/sysstat/sysstat.go
+++ b/internal/dfsbench/sysstat/sysstat.go
@@ -15,6 +15,7 @@ package sysstat
 
 import (
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -29,11 +30,29 @@ type Sample struct {
 	CtxSwitches uint64 // /proc/stat "ctxt": cumulative context switches since boot
 	CPUBusy     uint64 // non-idle jiffies (user+nice+system+irq+softirq+steal)
 	CPUTotal    uint64 // all jiffies, incl. idle+iowait
-	ok          bool
+	// DiskWrBytes is the cumulative bytes written across whole-disk block devices
+	// (/proc/diskstats sectors-written × 512). On the bench VM this is dominated by
+	// the block volume holding the DittoFS local tier, so its rate is the tier's
+	// fill throughput — the discriminator for "is a cold read disk-write bound?".
+	DiskWrBytes uint64
+	// NetRxBytes is cumulative bytes received across non-loopback interfaces
+	// (/proc/net/dev). NFS/SMB to the fio client run over loopback here, so the
+	// non-lo rate isolates the S3 DOWNLOAD rate — the "is a cold read S3-network
+	// bound?" discriminator that pairs with DiskWrBytes.
+	NetRxBytes uint64
+	ok         bool
 }
 
-// Now snapshots /proc/stat. On any read/parse failure it returns a not-ok
-// Sample (rates from it are zero) — the caller never has to handle an error.
+// wholeDiskRe matches whole-disk device names in /proc/diskstats (sda, vda,
+// xvdb, nvme0n1) but not their partitions (sda1, nvme0n1p1) — summing both would
+// double-count the same writes.
+var wholeDiskRe = regexp.MustCompile(`^(sd[a-z]+|vd[a-z]+|xvd[a-z]+|nvme\d+n\d+)$`)
+
+// Now snapshots /proc/stat (required) plus /proc/diskstats and /proc/net/dev
+// (best-effort). On a /proc/stat read/parse failure it returns a not-ok Sample
+// (rates from it are zero) — the caller never has to handle an error. Missing
+// disk/net files (macOS) leave those counters zero, so they degrade to empty
+// columns exactly like the CPU/ctxsw pair.
 func Now() Sample {
 	data, err := os.ReadFile("/proc/stat")
 	if err != nil {
@@ -45,7 +64,49 @@ func Now() Sample {
 	}
 	s.T = time.Now()
 	s.ok = true
+	if d, err := os.ReadFile("/proc/diskstats"); err == nil {
+		s.DiskWrBytes = parseDiskWriteBytes(string(d))
+	}
+	if n, err := os.ReadFile("/proc/net/dev"); err == nil {
+		s.NetRxBytes = parseNetRxBytes(string(n))
+	}
 	return s
+}
+
+// parseDiskWriteBytes sums sectors-written (field 10, 512-byte sectors) across
+// whole-disk devices in /proc/diskstats. Split out for testing without /proc.
+func parseDiskWriteBytes(data string) uint64 {
+	var total uint64
+	for _, line := range strings.Split(data, "\n") {
+		f := strings.Fields(line)
+		if len(f) < 10 || !wholeDiskRe.MatchString(f[2]) {
+			continue
+		}
+		if sectors, err := strconv.ParseUint(f[9], 10, 64); err == nil {
+			total += sectors * 512
+		}
+	}
+	return total
+}
+
+// parseNetRxBytes sums rx-bytes across non-loopback interfaces in /proc/net/dev.
+// Split out for testing without /proc.
+func parseNetRxBytes(data string) uint64 {
+	var total uint64
+	for _, line := range strings.Split(data, "\n") {
+		iface, rest, found := strings.Cut(line, ":")
+		if !found || strings.TrimSpace(iface) == "lo" {
+			continue
+		}
+		f := strings.Fields(rest)
+		if len(f) < 1 {
+			continue
+		}
+		if rx, err := strconv.ParseUint(f[0], 10, 64); err == nil {
+			total += rx
+		}
+	}
+	return total
 }
 
 // parseStat extracts the aggregate "cpu" and "ctxt" lines. Split out for
@@ -89,6 +150,8 @@ func parseStat(data string) (Sample, bool) {
 type Rates struct {
 	CtxSwPerSec float64 // Δctxt ÷ wall-seconds
 	CPUPct      float64 // busy jiffies as % of total over the interval, 0..100
+	DiskWrMBps  float64 // whole-disk bytes written ÷ wall-seconds ÷ 1e6
+	NetRxMBps   float64 // non-lo bytes received ÷ wall-seconds ÷ 1e6
 }
 
 // RatesTo computes rates from a (earlier) to b (later). Returns zeros unless
@@ -105,6 +168,12 @@ func (a Sample) RatesTo(b Sample) Rates {
 	}
 	if dTotal := b.CPUTotal - a.CPUTotal; b.CPUTotal > a.CPUTotal && b.CPUBusy >= a.CPUBusy {
 		r.CPUPct = float64(b.CPUBusy-a.CPUBusy) / float64(dTotal) * 100
+	}
+	if dt > 0 && b.DiskWrBytes >= a.DiskWrBytes {
+		r.DiskWrMBps = float64(b.DiskWrBytes-a.DiskWrBytes) / dt / 1e6
+	}
+	if dt > 0 && b.NetRxBytes >= a.NetRxBytes {
+		r.NetRxMBps = float64(b.NetRxBytes-a.NetRxBytes) / dt / 1e6
 	}
 	return r
 }

--- a/internal/dfsbench/sysstat/sysstat_test.go
+++ b/internal/dfsbench/sysstat/sysstat_test.go
@@ -43,6 +43,46 @@ func TestParseStat_MalformedCPU(t *testing.T) {
 	}
 }
 
+func TestParseDiskWriteBytes(t *testing.T) {
+	// Whole disks sda (200 sectors written) + nvme0n1 (300) count; the sda1
+	// partition (999) must NOT (double-count) and loop0 must not. field 10 =
+	// sectors written; ×512 bytes.
+	// field 10 (0-based index 9) is sectors-written.
+	const data = "   8       0 sda 10 0 100 5 0 0 200 8 0 4 12\n" +
+		"   8       1 sda1 1 0 10 1 0 0 999 2 0 1 3\n" +
+		" 259       0 nvme0n1 5 0 50 2 0 0 300 4 0 2 6\n" +
+		"   7       0 loop0 0 0 0 0 0 0 500 0 0 0 0\n"
+	got := parseDiskWriteBytes(data)
+	if want := uint64((200 + 300) * 512); got != want {
+		t.Errorf("disk write bytes = %d, want %d (sda+nvme0n1 only)", got, want)
+	}
+}
+
+func TestParseNetRxBytes(t *testing.T) {
+	// Sum rx-bytes (first field after "iface:") over non-lo interfaces.
+	const data = "Inter-|   Receive                                                |  Transmit\n" +
+		" face |bytes    packets errs drop fifo frame compressed multicast|bytes\n" +
+		"    lo: 5000 10 0 0 0 0 0 0 5000 10 0 0 0 0 0 0\n" +
+		"  eth0: 1000000 900 0 0 0 0 0 0 2000 30 0 0 0 0 0 0\n"
+	if got := parseNetRxBytes(data); got != 1000000 {
+		t.Errorf("net rx bytes = %d, want 1000000 (eth0 only, lo excluded)", got)
+	}
+}
+
+func TestRatesTo_DiskAndNet(t *testing.T) {
+	t0 := time.Unix(0, 0)
+	a := Sample{T: t0, DiskWrBytes: 0, NetRxBytes: 0, ok: true}
+	// 2s later: +200MB disk → 100 MB/s; +226MB net → 113 MB/s.
+	b := Sample{T: t0.Add(2 * time.Second), DiskWrBytes: 200e6, NetRxBytes: 226e6, ok: true}
+	r := a.RatesTo(b)
+	if math.Abs(r.DiskWrMBps-100) > 1e-6 {
+		t.Errorf("disk MB/s = %v, want 100", r.DiskWrMBps)
+	}
+	if math.Abs(r.NetRxMBps-113) > 1e-6 {
+		t.Errorf("net MB/s = %v, want 113", r.NetRxMBps)
+	}
+}
+
 func TestRatesTo(t *testing.T) {
 	t0 := time.Unix(0, 0)
 	a := Sample{T: t0, CtxSwitches: 1000, CPUBusy: 100, CPUTotal: 1000, ok: true}


### PR DESCRIPTION
## Why

A same-VM cold-read A/B (swap the `dfs` binary between two runs on one VM) kept producing misleading numbers. This branch makes the `dfsbench` harness produce **trustworthy cold-read measurements** — and in the process exposed that our "cold" reads weren't cold at all (they were served from the local block volume, not S3), which had silently defeated multiple cold-read investigations.

## What

**1. Robust same-VM re-runs** (`backend/dittofs.go`)
The dittofs backend wiped its data dir even when a wedged old `dfs` survived the pre-start kill, deleting badger SST files under the live process (`no such file` spam) while the new `dfs` reported "already running". Now:
- kill dfs by **exact process name** (`pkill -9 -x dfs`) — never `-f 'dfs start'`, which matches by full cmdline and SIGKILLs the cleanup shell itself (its argv contains the literal `dfs start`);
- if dfs refuses to die, **abort the cell** instead of wiping state under it;
- teardown SIGKILLs + waits so the next run starts clean.

**2. Disk/net metering** (`sysstat/`, `fio/result.go`, `report/report.go`, `run/managed.go`)
`sysstat` now samples `/proc/diskstats` (whole-disk bytes written) and `/proc/net/dev` (non-loopback rx bytes) alongside ctxsw/CPU, surfaced as `DiskWrMB/s` + `NetRxMB/s` columns. NFS/SMB run over loopback, so `NetRxMB/s` is the **pure S3 download rate** and `DiskWrMB/s` the local-tier write rate — together they tell you whether a cold read is disk-bound or S3-bound, and **whether a "cold" run is actually cold** (net-rx ≈ read rate).

**3. Real cold barrier** (`backend/dittofs.go`, `exec/local.go`)
The metering showed the cold pass pulled only ~15–33 MB/s from S3 while serving ~115–173 MB/s — ~80% came off the local block volume. Root cause: one `dfsctl system drain-uploads` doesn't fully sync a freshly-written file (rollup is async and `carveFlush` is snapshot-at-claim, so chunks that roll up mid-drain are missed and stay locally resident, and `DrainLocalSynced` only drops *synced* blocks). `dittofsEvict` now:
- loops `drain-uploads` until unsynced bytes fall below a small drift floor (append-log tail), stable across two polls;
- evicts;
- **verifies `local_disk_used` dropped ≥80%**, else fails the cell loudly instead of emitting a warm number mislabelled "cold".

## Impact

With a genuinely-cold barrier, a cold-read A/B finally reads true. New unit tests cover the `/proc` parsers and rate math. All `internal/dfsbench/...` tests, `go vet`, and `golangci-lint` (0 issues) pass.