### PR TITLE
perf(block): offset-based sliding-window readahead for cold-from-S3 reads

### DIFF
--- a/pkg/block/engine/engine_test.go
+++ b/pkg/block/engine/engine_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"strings"
 	"sync"
@@ -233,14 +234,17 @@ func TestReadAt_CacheDisabled(t *testing.T) {
 	}
 }
 
-// TestReadAt_InvokesCacheOnRead — Task 3 behavior 1.
-// engine.ReadAt invokes cache.OnRead with the ChunkRef hashes and a
-// fileSize derived from max(Offset+Size) after a successful read.
+// TestReadAt_DoesNotInvokeCacheOnReadPath guards the Step-1 retirement of the
+// dead cache read-prefetch trigger: readahead is now driven by the offset-based
+// Syncer.scheduleReadahead (covered in readahead_test.go), and the RAM Cache is
+// off the read path entirely (readAtInternal serves from the local store). So a
+// successful ReadAt must NOT call cache.OnRead — even when the caller passes a
+// non-nil []ChunkRef (the argument is opaque to the read path). This prevents
+// silently re-wiring the never-read cache onto the hot path.
 //
-// We swap in the recording cache AFTER WriteAt so the writer's
-// tracker-reset OnRead(nil) doesn't pollute the count we want to
-// assert on.
-func TestReadAt_InvokesCacheOnRead(t *testing.T) {
+// We swap in the recording cache AFTER WriteAt so the writer's tracker-reset
+// OnRead(nil) doesn't pollute the count.
+func TestReadAt_DoesNotInvokeCacheOnReadPath(t *testing.T) {
 	bs := newTestEngine(t, 0, 0) // start with nullCache
 
 	ctx := context.Background()
@@ -251,12 +255,10 @@ func TestReadAt_InvokesCacheOnRead(t *testing.T) {
 		t.Fatalf("WriteAt failed: %v", err)
 	}
 
-	// Swap in recording cache after the write so we observe only the
-	// ReadAt path's OnRead invocation.
 	rec := &recordingCache{}
 	bs.cache = rec
 
-	// Pass a non-empty []ChunkRef so OnRead fires with hashes.
+	// A non-empty []ChunkRef used to force the old OnRead hint; it is now ignored.
 	refs := []block.ChunkRef{
 		{Hash: hashN(0xAA), Offset: 0, Size: uint32(len(data))},
 	}
@@ -264,20 +266,14 @@ func TestReadAt_InvokesCacheOnRead(t *testing.T) {
 	if _, err := bs.ReadAt(ctx, payloadID, refs, buf, 0); err != nil {
 		t.Fatalf("ReadAt failed: %v", err)
 	}
+	if !bytes.Equal(buf, data) {
+		t.Fatalf("ReadAt bytes = %q, want %q", buf, data)
+	}
 
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
-	if rec.onReadCalls != 1 {
-		t.Fatalf("expected 1 OnRead call, got %d", rec.onReadCalls)
-	}
-	if rec.lastPayloadID != payloadID {
-		t.Fatalf("OnRead payloadID = %q, want %q", rec.lastPayloadID, payloadID)
-	}
-	if len(rec.lastHashes) != 1 || rec.lastHashes[0] != refs[0].Hash {
-		t.Fatalf("OnRead hashes mismatch: got %v", rec.lastHashes)
-	}
-	if rec.lastFileSize != uint64(len(data)) {
-		t.Fatalf("OnRead fileSize = %d, want %d", rec.lastFileSize, len(data))
+	if rec.onReadCalls != 0 {
+		t.Fatalf("cache is off the read path: expected 0 OnRead calls, got %d", rec.onReadCalls)
 	}
 }
 

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -74,22 +74,6 @@ func (m *Syncer) listFileChunksSnapshot(ctx context.Context, payloadID string) (
 	return rows, nil
 }
 
-// blockIsLocal reports whether the bytes for (payloadID, blockIdx) are
-// currently held in the unified local CAS chunk store. It resolves the
-// FileChunk row (which carries the BLAKE3 content hash populated by
-// rollup) and asks the local store whether the chunk is present under
-// that hash. Returns false when the FileChunk row is sparse / not yet
-// produced by rollup, when the hash is unknown (pre-CAS migration
-// drift), or when local.Has surfaces an error — the caller treats any
-// non-true outcome as "must round-trip to remote".
-func (m *Syncer) blockIsLocal(ctx context.Context, payloadID string, blockIdx uint64) bool {
-	fb, err := m.resolveFileChunk(ctx, payloadID, blockIdx)
-	if err != nil {
-		return false
-	}
-	return m.blockIsLocalFromRow(ctx, fb)
-}
-
 // blockIsLocalFromRow reports whether the resolved FileChunk's CAS chunk is
 // present in the local store. A nil row, a zero hash (sparse / pre-CAS drift),
 // or a local.Has error all yield false — the caller treats any non-true outcome
@@ -243,9 +227,17 @@ func (m *Syncer) readChunkVerified(ctx context.Context, loc block.ChunkLocator, 
 	return data, nil
 }
 
-// fetchBlock downloads a single block from the remote store and writes it to the local store.
+// fetchBlock downloads a single block from the remote store and writes it to the
+// local store. It backs the SyncQueue's prefetch/download workers, so it is the
+// engine's readahead fetch path (scheduleReadahead).
 // Returns nil data for sparse blocks (no FileChunk entry or missing S3 object).
-// Returns nil data when remoteStore is nil (local-only mode -- no remote data exists).
+// Returns nil data when remoteStore is nil (local-only mode -- no remote data
+// exists) or when the block is already resident locally (nothing to fetch).
+//
+// The fetch is routed through inlineFetchOrWait so it registers in the in-flight
+// dedup map: a concurrent demand read for the same block piggybacks on this
+// prefetch instead of issuing its own S3 GET. That shared budget is what keeps
+// total remote concurrency bounded when the readahead window overlaps demand.
 func (m *Syncer) fetchBlock(ctx context.Context, payloadID string, blockIdx uint64) ([]byte, error) {
 	if !m.canProcess(ctx) {
 		return nil, ErrClosed
@@ -271,7 +263,17 @@ func (m *Syncer) fetchBlock(ctx context.Context, payloadID string, blockIdx uint
 		return nil, nil
 	}
 
-	return m.fetchResolvedBlock(ctx, fb)
+	// Already local: by the time this prefetch worker runs, the block may already
+	// be staged locally by a demand read or an earlier prefetch (each block is
+	// scheduled at most once, but the worker races demand). Skipping it here
+	// avoids a redundant S3 GET. The probe runs in the worker goroutine, off the
+	// read hot path.
+	if m.blockIsLocalFromRow(ctx, fb) {
+		return nil, nil
+	}
+
+	data, _, err := m.inlineFetchOrWait(ctx, payloadID, blockIdx, fb)
+	return data, err
 }
 
 // fetchResolvedBlock downloads the already-resolved FileChunk row from the
@@ -428,14 +430,11 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 	filled := filledFlag.Load()
 	needLocalReadAt := needLocalFlag.Load()
 
-	// Prefetch ahead only as far as the payload's access pattern justifies:
-	// a sequential run ramps the window up to PrefetchBlocks, a random read
-	// prefetches nothing (planReadahead returns 0) so we never spend remote
-	// GETs on blocks a random reader will not touch.
-	depth := m.planReadahead(payloadID, startBlockIdx, endBlockIdx)
-	for i := 0; i < depth; i++ {
-		m.enqueuePrefetch(payloadID, endBlockIdx+1+uint64(i))
-	}
+	// Readahead is driven from Store.ReadAt on EVERY read (scheduleReadahead),
+	// so the demand path no longer schedules prefetch here. The old on-miss
+	// trigger stalled once a sequential reader started hitting the local tier —
+	// EnsureAvailableAndRead is not even reached on a local hit — so the window
+	// stopped advancing exactly when it needed to stay ahead.
 
 	if needLocalReadAt {
 		return false, nil // Some blocks were in local store -- caller should use local store ReadAt
@@ -595,30 +594,4 @@ func copyBlockToDest(dest, data []byte, blockIdx, offset, length uint64) bool {
 		return true
 	}
 	return false
-}
-
-// enqueuePrefetch enqueues a prefetch request (non-blocking, best effort).
-func (m *Syncer) enqueuePrefetch(payloadID string, blockIdx uint64) {
-	if m.blockIsLocal(context.Background(), payloadID, blockIdx) {
-		return
-	}
-
-	// Suppress prefetch when remote is unreachable
-	if !m.IsRemoteHealthy() {
-		return
-	}
-
-	key := inFlightKey(payloadID, blockIdx)
-	m.inFlightMu.Lock()
-	_, inFlight := m.inFlight[key]
-	m.inFlightMu.Unlock()
-	if inFlight {
-		return
-	}
-
-	m.queue.EnqueuePrefetch(TransferRequest{
-		Type:       TransferPrefetch,
-		PayloadID:  payloadID,
-		BlockIndex: blockIdx,
-	})
 }

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -31,20 +31,6 @@ func blockRefHashes(refs []block.ChunkRef) []block.ContentHash {
 	return out
 }
 
-// computeFileSize returns the maximum (Offset + Size) across the
-// ChunkRef list — a conservative upper bound on file size used as
-// the OnRead fileSize hint.
-func computeFileSize(refs []block.ChunkRef) uint64 {
-	var maxEnd uint64
-	for _, r := range refs {
-		end := r.Offset + uint64(r.Size)
-		if end > maxEnd {
-			maxEnd = end
-		}
-	}
-	return maxEnd
-}
-
 // readAtInternal reads from the primary payloadID. Always goes through
 // the local store (with remote-fallback on miss); the cache is hint-only
 // and does not serve bytes here.

--- a/pkg/block/engine/readahead.go
+++ b/pkg/block/engine/readahead.go
@@ -2,32 +2,40 @@ package engine
 
 // maxReadaheadEntries bounds the per-payload readahead state map. Readahead
 // state is disposable — a dropped entry just re-ramps from a cold start (the
-// re-creating read returns 0, the next sequential read reaches depth 1) — so on
-// overflow we evict an arbitrary entry rather than track access order.
+// re-creating read establishes the frontier, the next sequential read schedules
+// the window) — so on overflow we evict an arbitrary entry rather than track
+// access order.
 // ponytail: arbitrary eviction; switch to LRU only if churn across >4096
 // concurrently-hot files ever measurably costs re-ramps.
 const maxReadaheadEntries = 4096
 
-// raState tracks a payload's recent read frontier so prefetch can distinguish
-// sequential runs (ramp the window) from random access (stop prefetching).
+// raState tracks a payload's read frontier so the readahead driver can keep a
+// fixed window of blocks fetched ahead of a sequential reader and schedule each
+// block exactly once.
 type raState struct {
-	lastEnd uint64 // block index the previous read ended at
-	depth   int    // current prefetch window in blocks ahead; 0 = random / no prefetch
-	valid   bool   // false until the first read establishes lastEnd
+	lastEnd       uint64 // block index the previous read ended at
+	scheduledUpTo uint64 // highest block index already scheduled for prefetch
+	valid         bool   // false until the first read establishes lastEnd
 }
 
-// planReadahead updates the payload's access frontier for a read spanning
-// [startBlockIdx, endBlockIdx] and returns how many blocks to prefetch ahead.
+// planWindow advances the payload's read frontier for a read spanning block
+// indices [start, end] and returns the half-open block range (from, to] that
+// should be scheduled for prefetch this call, or fire=false when nothing new
+// should be scheduled.
 //
-// Sequential reads (continuing at or just past the previous frontier) ramp the
-// window 1->2->4->...->PrefetchBlocks, following the Linux readahead pattern.
-// A random jump resets the window to 0: prefetching blocks after a random read
-// only wastes remote GETs on data that will not be read, hurting WAN throughput
-// and object-store cost. The ramp cap is SyncerConfig.PrefetchBlocks.
-func (m *Syncer) planReadahead(payloadID string, startBlockIdx, endBlockIdx uint64) int {
+// Unlike the old geometric planReadahead (which ramped 1->2->4 and only ran on
+// a local miss inside EnsureAvailableAndRead), this keeps a FULL fixed window of
+// config.PrefetchBlocks blocks in flight ahead of the frontier and is driven on
+// EVERY read (local hits included) via scheduleReadahead. A sequential reader
+// serving from the local tier therefore keeps the window sliding forward instead
+// of stalling once reads stop missing. Each block is scheduled exactly once
+// (bounded by scheduledUpTo); the first read of a payload only establishes the
+// frontier, and a random jump resets the anchor so we never prefetch blocks a
+// random reader will not touch.
+func (m *Syncer) planWindow(payloadID string, start, end uint64) (from, to uint64, fire bool) {
 	maxDepth := m.config.PrefetchBlocks
 	if maxDepth <= 0 {
-		return 0 // prefetch disabled
+		return 0, 0, false // prefetch disabled
 	}
 
 	m.readaheadMu.Lock()
@@ -47,19 +55,65 @@ func (m *Syncer) planReadahead(payloadID string, startBlockIdx, endBlockIdx uint
 
 	// Sequential = the new read begins at or immediately after the previous
 	// frontier (tolerates a re-read of the last block and a contiguous advance).
-	sequential := st.valid && startBlockIdx >= st.lastEnd && startBlockIdx <= st.lastEnd+1
-	switch {
-	case !sequential:
-		st.depth = 0
-	case st.depth < 1:
-		st.depth = 1
-	case st.depth < maxDepth:
-		st.depth *= 2
-		if st.depth > maxDepth {
-			st.depth = maxDepth
-		}
-	}
-	st.lastEnd = endBlockIdx
+	sequential := st.valid && start >= st.lastEnd && start <= st.lastEnd+1
+	st.lastEnd = end
 	st.valid = true
-	return st.depth
+
+	// First read of a payload is not a pattern (sequential requires the prior
+	// st.valid, so a first read is never sequential); a random jump resets the
+	// anchor. Either way we re-anchor scheduledUpTo to the current frontier and
+	// prefetch nothing this call.
+	if !sequential {
+		st.scheduledUpTo = end
+		return 0, 0, false
+	}
+
+	// Confirmed sequential run: keep a full window ahead of the frontier. No
+	// geometric ramp — that lagged the reader (the reader consumes a local block
+	// faster than a single S3 fetch completes, so a slow ramp never gets ahead).
+	target := end + uint64(maxDepth)
+	from = st.scheduledUpTo
+	if from < end {
+		from = end
+	}
+	if target <= from {
+		return 0, 0, false // window already scheduled — nothing new
+	}
+	st.scheduledUpTo = target
+	return from, target, true
+}
+
+// scheduleReadahead is the offset-based sliding-window readahead driver, invoked
+// on every read from Store.ReadAt. It keeps the local read-serving tier populated
+// ahead of a sequential reader by enqueuing the next window of blocks onto the
+// SyncQueue's bounded worker pool (config.ParallelDownloads wide). The prefetch
+// workers register in the in-flight map (fetchBlock -> inlineFetchOrWait) so a
+// demand read for an already-in-flight block piggybacks instead of issuing a
+// duplicate S3 GET — the shared budget that bounds total remote concurrency.
+//
+// No-op without a remote, while the remote is unhealthy, or for a zero-length
+// read. The hot-path cost is one in-memory frontier update (planWindow); the
+// per-block local/remote probes happen in the worker pool, off the read path.
+func (m *Syncer) scheduleReadahead(payloadID string, offset uint64, length uint32) {
+	if length == 0 || m.queue == nil {
+		return
+	}
+	if !m.hasRemote.Load() || !m.IsRemoteHealthy() {
+		return
+	}
+	start, end := blockRange(offset, length)
+	from, to, fire := m.planWindow(payloadID, start, end)
+	if !fire {
+		return
+	}
+	// Best-effort enqueue: EnqueuePrefetch drops when the SyncQueue is saturated.
+	// A dropped block is NOT a window hole — the reader's own demand fetch
+	// (EnsureAvailableAndRead) still serves it, just without the prefetch head
+	// start. We deliberately do NOT roll scheduledUpTo back on a drop: under a
+	// saturated queue, degrading prefetch to demand is the correct backpressure,
+	// and re-enqueue churn on every read would only deepen the saturation. The
+	// advancing frontier keeps scheduling fresh blocks regardless.
+	for b := from + 1; b <= to; b++ {
+		m.queue.EnqueuePrefetch(TransferRequest{PayloadID: payloadID, BlockIndex: b})
+	}
 }

--- a/pkg/block/engine/readahead_test.go
+++ b/pkg/block/engine/readahead_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 )
 
+// newRAsyncer builds a Syncer exercising only planWindow (no queue/remote).
 func newRAsyncer(prefetch int) *Syncer {
 	return &Syncer{
 		config:    SyncerConfig{PrefetchBlocks: prefetch},
@@ -12,65 +13,144 @@ func newRAsyncer(prefetch int) *Syncer {
 	}
 }
 
-func TestPlanReadahead_SequentialRamps(t *testing.T) {
-	m := newRAsyncer(64)
-	// First read has no history: depth 0 (Linux-style cold start).
-	if d := m.planReadahead("p", 0, 0); d != 0 {
-		t.Fatalf("first read: got depth %d, want 0", d)
+// window is a test helper: the block indices planWindow schedules for a read
+// spanning [start, end], or nil when it fires nothing.
+func (m *Syncer) window(payloadID string, start, end uint64) []uint64 {
+	from, to, fire := m.planWindow(payloadID, start, end)
+	if !fire {
+		return nil
 	}
-	// Contiguous reads ramp 1 -> 2 -> 4 -> ... capped at PrefetchBlocks.
-	want := []int{1, 2, 4, 8, 16, 32, 64, 64}
-	for i, exp := range want {
-		start := uint64(i + 1)
-		if d := m.planReadahead("p", start, start); d != exp {
-			t.Fatalf("sequential read %d (block %d): got depth %d, want %d", i, start, d, exp)
+	var out []uint64
+	for b := from + 1; b <= to; b++ {
+		out = append(out, b)
+	}
+	return out
+}
+
+func eq(t *testing.T, got, want []uint64) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
 		}
 	}
 }
 
-func TestPlanReadahead_RandomResets(t *testing.T) {
-	m := newRAsyncer(64)
-	// Ramp up on a sequential run.
-	for b := uint64(0); b <= 5; b++ {
-		m.planReadahead("p", b, b)
-	}
-	if got := m.readahead["p"].depth; got == 0 {
-		t.Fatalf("expected ramped depth after sequential run, got 0")
-	}
-	// A random jump backs off to 0 — no wasted prefetch of blocks a random
-	// reader will not touch.
-	if d := m.planReadahead("p", 1000, 1000); d != 0 {
-		t.Fatalf("random jump: got depth %d, want 0", d)
-	}
-	// Re-establishing sequentiality from the new position ramps again.
-	if d := m.planReadahead("p", 1001, 1001); d != 1 {
-		t.Fatalf("resume after random: got depth %d, want 1", d)
-	}
+func TestPlanWindow_FirstReadEstablishesFrontier(t *testing.T) {
+	m := newRAsyncer(4)
+	// A single read is not a pattern — schedule nothing, just anchor the frontier.
+	eq(t, m.window("p", 0, 0), nil)
 }
 
-func TestPlanReadahead_RereadSameBlockIsSequential(t *testing.T) {
-	m := newRAsyncer(64)
-	m.planReadahead("p", 0, 0)                   // depth 0, frontier 0
-	if d := m.planReadahead("p", 0, 0); d != 1 { // start==lastEnd tolerated as sequential
-		t.Fatalf("re-read same block: got depth %d, want 1", d)
-	}
+func TestPlanWindow_SequentialSchedulesFullWindowThenSlides(t *testing.T) {
+	m := newRAsyncer(4)
+	m.window("p", 0, 0)                              // establish frontier at block 0
+	eq(t, m.window("p", 0, 0), []uint64{1, 2, 3, 4}) // full window ahead
+	eq(t, m.window("p", 1, 1), []uint64{5})          // frontier advanced → slide by one
+	eq(t, m.window("p", 2, 2), []uint64{6})          // slides again
 }
 
-func TestPlanReadahead_DisabledWhenZero(t *testing.T) {
+func TestPlanWindow_ScheduleOnce(t *testing.T) {
+	m := newRAsyncer(4)
+	m.window("p", 0, 0)
+	m.window("p", 0, 0) // schedules 1..4
+	// Re-reading the same block does not re-schedule already-queued blocks.
+	eq(t, m.window("p", 0, 0), nil)
+}
+
+func TestPlanWindow_RandomResetsThenResumes(t *testing.T) {
+	m := newRAsyncer(4)
+	for b := uint64(0); b <= 3; b++ {
+		m.window("p", b, b) // ramp up a sequential run
+	}
+	// A random jump prefetches nothing (a random reader won't touch the window).
+	eq(t, m.window("p", 1000, 1000), nil)
+	// Re-establishing sequentiality from the new position schedules a fresh
+	// window anchored at the new frontier.
+	eq(t, m.window("p", 1001, 1001), []uint64{1002, 1003, 1004, 1005})
+}
+
+func TestPlanWindow_DisabledWhenZero(t *testing.T) {
 	m := newRAsyncer(0)
 	for b := uint64(0); b <= 5; b++ {
-		if d := m.planReadahead("p", b, b); d != 0 {
-			t.Fatalf("prefetch disabled: got depth %d, want 0", d)
+		if got := m.window("p", b, b); got != nil {
+			t.Fatalf("prefetch disabled: scheduled %v, want nothing", got)
 		}
 	}
 }
 
-func TestPlanReadahead_MapBounded(t *testing.T) {
-	m := newRAsyncer(64)
+func TestPlanWindow_MapBounded(t *testing.T) {
+	m := newRAsyncer(4)
 	for i := 0; i < maxReadaheadEntries*2; i++ {
-		m.planReadahead("payload-"+strconv.Itoa(i), 0, 0)
+		m.window("payload-"+strconv.Itoa(i), 0, 0)
 	}
 	if got := len(m.readahead); got > maxReadaheadEntries {
 		t.Fatalf("readahead map unbounded: %d entries, cap %d", got, maxReadaheadEntries)
 	}
+}
+
+// newSchedSyncer builds a Syncer with a real (unstarted) SyncQueue so
+// scheduleReadahead enqueues into an inspectable prefetch channel.
+func newSchedSyncer(prefetch int) *Syncer {
+	m := &Syncer{
+		config:    SyncerConfig{PrefetchBlocks: prefetch},
+		readahead: make(map[string]*raState),
+	}
+	m.hasRemote.Store(true) // IsRemoteHealthy() is true with no health monitor
+	m.queue = NewSyncQueue(m, SyncQueueConfig{QueueSize: 1000, DownloadWorkers: 4})
+	return m
+}
+
+func drainPrefetch(q *SyncQueue) []uint64 {
+	var out []uint64
+	for {
+		select {
+		case req := <-q.prefetch:
+			out = append(out, req.BlockIndex)
+		default:
+			return out
+		}
+	}
+}
+
+// TestScheduleReadahead_SlidesOnEveryRead is the core Step-1 guard: the window is
+// computed purely from read offsets and slides forward on EVERY read — it never
+// probes whether a block is local. This is exactly what the two prior refuted
+// attempts lacked (they only advanced on a local MISS, so a sequential reader
+// serving from the local tier stalled). Fails on develop, where readahead was
+// driven from the on-miss path in EnsureAvailableAndRead.
+//
+// NOTE: a structural guard is necessary but NOT sufficient — the throughput win
+// must be confirmed by a real-VM cold-read A/B (see the design doc's method).
+func TestScheduleReadahead_SlidesOnEveryRead(t *testing.T) {
+	m := newSchedSyncer(4)
+	bs := uint64(BlockSize)
+
+	// First read anchors the frontier only.
+	m.scheduleReadahead("p", 0, 1)
+	eq(t, drainPrefetch(m.queue), nil)
+
+	// Second sequential read (still block 0) schedules the full window ahead.
+	m.scheduleReadahead("p", 0, 1)
+	eq(t, drainPrefetch(m.queue), []uint64{1, 2, 3, 4})
+
+	// Advancing into block 1 slides the window by one — even though block 1
+	// would be served locally; readahead never consults local state.
+	m.scheduleReadahead("p", bs, 1)
+	eq(t, drainPrefetch(m.queue), []uint64{5})
+
+	// Re-reading within block 1 schedules nothing (schedule-once frontier).
+	m.scheduleReadahead("p", bs, 1)
+	eq(t, drainPrefetch(m.queue), nil)
+}
+
+func TestScheduleReadahead_NoRemoteIsNoOp(t *testing.T) {
+	m := newSchedSyncer(4)
+	m.hasRemote.Store(false)
+	m.scheduleReadahead("p", 0, 1)
+	m.scheduleReadahead("p", 0, 1)
+	eq(t, drainPrefetch(m.queue), nil)
 }

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -14,10 +14,11 @@ import (
 // a non-nil/non-empty []ChunkRef carries the CAS hashes covering the
 // requested range (zero-filling sparse holes).
 //
-// After a successful read the engine calls cache.OnRead(payloadID
-// blockHashes, fileSize) so the Cache's sequential-detection state
-// machine can fire prefetch on upcoming hashes. The cache is hint-only
-// here; reads always go through local/remote stores.
+// After a successful read the engine drives the offset-based readahead window
+// (Syncer.scheduleReadahead) so a sequential reader keeps the local read-serving
+// tier populated ahead of the read frontier. This fires on EVERY read — the
+// `blocks` argument is ignored here (the hot NFS/SMB path passes nil), so the
+// window is computed purely from offset+len(data).
 func (bs *Store) ReadAt(ctx context.Context, payloadID string, blocks []block.ChunkRef, data []byte, offset uint64) (int, error) {
 	if err := bs.enter(); err != nil {
 		return 0, err
@@ -27,13 +28,8 @@ func (bs *Store) ReadAt(ctx context.Context, payloadID string, blocks []block.Ch
 	if err != nil {
 		return n, err
 	}
-	// Hint-only post-read: pass the ChunkRef hashes and the maximal
-	// file-size estimate so the Cache can decide on prefetch. nullCache
-	// is a no-op so the unconditional call is safe (Null Object).
-	if len(blocks) > 0 {
-		hashes := blockRefHashes(blocks)
-		bs.loadCache().OnRead(payloadID, hashes, computeFileSize(blocks))
-	}
+	_ = blocks // opaque to the readahead driver; kept for interface symmetry
+	bs.syncer.scheduleReadahead(payloadID, offset, uint32(len(data)))
 	return n, nil
 }
 


### PR DESCRIPTION
## Summary

Raises cold-from-S3 sequential-read throughput by keeping the local read-serving tier populated **ahead** of the reader, instead of demand-fetching each block on the S3-GET critical path.

**Measured on a real VM (Scaleway POP2-8C-32G, fr-par S3, seq-read large, genuinely-cold):**

| dfs | cold MB/s | p50 | p99 |
|---|---|---|---|
| develop | 74 | 3.6 ms | **566 ms** |
| this branch | **115** | 4.0 ms | **13 ms** |

**+55% throughput, and the p99 tail collapses 566 ms → 13 ms (43×)** — the reader no longer stalls on the ~566 ms S3-GET tail because the window has already fetched the block.

> Note: the cold measurement is only trustworthy with the eviction fix in #1635 (which makes the "cold" pass actually fetch from S3 instead of the local block volume). Merge that first for reproducibility.

## Root cause

The old read-prefetch only advanced on a local **miss** (inside `EnsureAvailableAndRead`). Once a sequential reader started serving blocks from the local tier, `EnsureAvailableAndRead` was no longer reached, so the window stopped sliding exactly when it needed to stay ahead. The geometric 1→2→4 ramp also never caught up (the reader drains a local block faster than one S3 fetch completes).

## What changed

- **Drive readahead from `Store.ReadAt` on EVERY read** via an offset/frontier-based sliding window (`Syncer.scheduleReadahead` + `planWindow`). Keeps a full fixed window (`PrefetchBlocks`) of blocks fetched ahead of the read frontier, each scheduled exactly once (`scheduledUpTo`); random access schedules nothing.
- **Route the SyncQueue prefetch worker (`fetchBlock`) through `inlineFetchOrWait`** so prefetch registers in the in-flight dedup map: a demand read for an in-flight block piggybacks instead of issuing a duplicate S3 GET. `fetchBlock` also skips already-local blocks.
- **Retire the dead read-prefetch paths**: the geometric on-miss `enqueuePrefetch`, the never-firing `cache.OnRead` read hint (the RAM cache is off the read path), and the now-orphaned `planReadahead`/`enqueuePrefetch`/`blockIsLocal`/`computeFileSize`.

## Tests

Deterministic guards for `planWindow` (schedule-once, slides, random-reset) and `scheduleReadahead` (fires on every read incl. local hits — fails on develop). 334 engine + 1275 block/adapter tests green under `-race`; `go vet` + `golangci-lint` clean.

## Follow-up

~115 MB/s still trails the ~688 MB/s 16-wide S3 ceiling. The next lever is removing the synchronous `local.Put` staging from the fetch path (async bounded write-back / RAM L0, #1626) so S3 bandwidth reaches the reader directly.