### PR TITLE
fix(block): seal active log blob in DrainLocalSynced so evict frees local disk

### DIFF
--- a/pkg/block/local/fs/eviction.go
+++ b/pkg/block/local/fs/eviction.go
@@ -637,6 +637,9 @@ func (bc *FSStore) relocateSurvivors(ctx context.Context, oldBlobID string, surv
 // store for that reason. Returns the total bytes freed.
 func (bc *FSStore) DrainLocalSynced(ctx context.Context) (int64, error) {
 	var total int64
+	// rotatedActive caps active-blob sealing at one Rotate per call (see the
+	// blobEvictOne fall-through below), mirroring ensureSpace.
+	var rotatedActive bool
 	for {
 		if ctx.Err() != nil {
 			return total, ctx.Err()
@@ -656,17 +659,26 @@ func (bc *FSStore) DrainLocalSynced(ctx context.Context) (int64, error) {
 			// No fully-synced blob to drop whole. Compact a blob pinned by
 			// unsynced survivors (#1497); stop when nothing more can be freed.
 			cfreed, cerr := bc.compactBlobOne(ctx)
-			if cerr != nil {
-				if !errors.Is(cerr, errLRUEmpty) {
-					return total, fmt.Errorf("drain local synced: %w", cerr)
+			if cerr != nil && !errors.Is(cerr, errLRUEmpty) {
+				return total, fmt.Errorf("drain local synced: %w", cerr)
+			}
+			if cfreed > 0 {
+				total += cfreed
+				continue
+			}
+			// CAS-LRU, sealed-blob eviction, and compaction are all exhausted,
+			// yet log-blob bytes remain: they sit in the still-open ACTIVE blob
+			// (a store below the 1 GiB roll threshold never seals — #1465). Seal
+			// it once so the next blobEvictOne can reclaim it. Capped at one
+			// Rotate per call: an active blob of *unsynced* bytes is still
+			// refused by blobEvictOne and must not spin out empty blobs.
+			if !rotatedActive && bc.logBlob != nil && bc.logBlobDiskUsed.Load() > 0 {
+				if rerr := bc.logBlob.Rotate(); rerr == nil {
+					rotatedActive = true
+					continue
 				}
-				return total, nil
 			}
-			if cfreed == 0 {
-				return total, nil
-			}
-			total += cfreed
-			continue
+			return total, nil
 		}
 		if bfreed == 0 {
 			return total, nil

--- a/pkg/block/local/fs/eviction_drain_test.go
+++ b/pkg/block/local/fs/eviction_drain_test.go
@@ -70,6 +70,47 @@ func TestDrainLocalSynced_FreesSealedSyncedBlobOnDemand(t *testing.T) {
 	}
 }
 
+// TestDrainLocalSynced_SealsActiveBlob pins the small-store case (#1465): data
+// below the 1 GiB roll threshold all lives in the still-open ACTIVE blob, which
+// blobEvictOne refuses (sealed-only). Without an active-blob seal step the drain
+// frees nothing and DiskUsed stays put — the exact e2e blocks-flip failure. Note
+// this test does NOT call Rotate: DrainLocalSynced must seal on its own.
+func TestDrainLocalSynced_SealsActiveBlob(t *testing.T) {
+	dir := t.TempDir()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc := newBlobStoreWithLimit(t, dir, 0, mds) // 0 = no maxDisk cap → active blob never rolls
+	ctx := context.Background()
+
+	a := bytes.Repeat([]byte{0xB1}, 400)
+	b := bytes.Repeat([]byte{0xB2}, 350)
+	aH, bH := blake3ContentHash(a), blake3ContentHash(b)
+	for _, kv := range []struct {
+		h block.ContentHash
+		d []byte
+	}{{aH, a}, {bH, b}} {
+		if err := bc.StoreChunk(ctx, kv.h, kv.d); err != nil {
+			t.Fatalf("StoreChunk: %v", err)
+		}
+		if err := mds.MarkSynced(ctx, kv.h, block.ChunkLocator{}); err != nil {
+			t.Fatalf("MarkSynced: %v", err)
+		}
+	}
+	if got := bc.Stats().DiskUsed; got != 750 {
+		t.Fatalf("DiskUsed before drain = %d, want 750", got)
+	}
+
+	freed, err := bc.DrainLocalSynced(ctx)
+	if err != nil {
+		t.Fatalf("DrainLocalSynced: %v", err)
+	}
+	if freed != 750 {
+		t.Fatalf("DrainLocalSynced freed = %d, want 750 (must seal the active blob)", freed)
+	}
+	if got := bc.Stats().DiskUsed; got != 0 {
+		t.Fatalf("DiskUsed after drain = %d, want 0 (active blob sealed + evicted)", got)
+	}
+}
+
 // TestDrainLocalSynced_KeepsUnsyncedSurvivor pins the data-safety invariant: a
 // sealed blob mixing synced (evictable) and unsynced (only copy) chunks is
 // drained via compaction — the synced remainder is reclaimed, the unsynced


### PR DESCRIPTION
## Problem

`TestBlocksFlipLifecycle_{NFS,SMB}` fail consistently on the develop e2e VM run at `blocks_flip_test.go:196`: after a 16 MiB write + `drainUploads`, `store block evict` (`EvictBlocks`) is expected to reduce `LocalDiskUsed`, but it stays flat.

## Root cause

`store block evict` → `EvictBlockStore` → `FSStore.DrainLocalSynced` runs the ladder `lruEvictOne` (CAS chunks) → `blobEvictOne` (sealed synced blobs) → `compactBlobOne`. For a share whose local footprint is under the 1 GiB log-blob roll threshold (`maxLogBytes = 1<<30`), all chunks sit in a single **active, never-sealed** log blob:

- `blobEvictOne` skips the active blob by construction (evicts only *sealed* blobs).
- `compactBlobOne` only reclaims sealed blobs pinned by unsynced survivors.

So the ladder frees 0, `logBlobDiskUsed` is unchanged, `LocalDiskUsed` stays flat, and the `require.Less` fails. `store block evict` was effectively a **no-op for any share under 1 GiB**.

The write-path evictor (`ensureSpace`) already has the missing step — an active-blob `Rotate()` fall-through — but `DrainLocalSynced` (added in #1595) never got it. The two existing #1595 unit tests masked the gap by manually calling `Rotate()` before draining.

## Fix

In `DrainLocalSynced`, when CAS-LRU + sealed-blob eviction + compaction are all exhausted but `logBlobDiskUsed > 0`, seal the active blob once via `logBlob.Rotate()` and retry so the now-sealed synced blob is reclaimed. Capped at one rotation per call (`rotatedActive`) — mirroring `ensureSpace` — so an all-unsynced active blob can't spin out empty blobs. 21-line change.

## Test

`TestDrainLocalSynced_SealsActiveBlob` stores two synced chunks into the active blob **without** calling `Rotate`, then asserts `DrainLocalSynced` frees them and `DiskUsed` drops to 0. Reproduces the e2e failure at the unit tier: **FAILs without the fix** (`freed = 0, want 750`), passes with it.

## Verification

- `go build ./...` clean; `go vet` + `golangci-lint` clean.
- `go test ./pkg/block/...` — 1216 pass across 15 packages.
- New test fails pre-fix, passes post-fix.
- e2e (`TestBlocksFlipLifecycle`) needs the Linux kernel-mount VM for final validation; the unit test exercises the identical `DrainLocalSynced` path the e2e drives.