### PR TITLE
fix(smb): NETLOGON pass-through on SMB2 session-bind (multichannel) for domain users (#1632)

### DIFF
--- a/internal/adapter/smb/handlers/session_setup.go
+++ b/internal/adapter/smb/handlers/session_setup.go
@@ -765,6 +765,28 @@ func (h *Handler) handleNTLMNegotiateBinding(ctx *SMBHandlerContext, req *Sessio
 	), nil
 }
 
+// bindIdentityMatchesSession reports whether the identity authenticated on a
+// SESSION_SETUP bind is the same principal that owns the existing session
+// (MS-SMB2 §3.3.5.5.2). A bind must attach the SAME user to the session; a
+// different identity is a security boundary violation the caller rejects with
+// STATUS_ACCESS_DENIED.
+//
+// Matching prefers the Windows SID — the authoritative, globally-unique identity
+// for a directory-resolved / NETLOGON pass-through domain user, stamped by
+// synthUserFromResolved onto both the primary session's user and this bind's
+// user. When either side lacks a SID (e.g. a purely local control-plane
+// account) it falls back to the username, matching the convention of the
+// Kerberos bind path (completeKerberosBind) and the pre-#1632 NTLM bind check.
+func bindIdentityMatchesSession(sess *session.Session, authUser *models.User) bool {
+	if authUser == nil || sess == nil || sess.User == nil {
+		return false
+	}
+	if authUser.SID != "" && sess.User.SID != "" {
+		return authUser.SID == sess.User.SID
+	}
+	return authUser.Username == sess.User.Username
+}
+
 // completeSessionBind finalizes an SMB2 session bind after NTLM auth proved
 // identity on the new connection. Instead of creating a new session (normal
 // completeNTLMAuth path), it registers a session.Channel on the existing
@@ -796,7 +818,9 @@ func (h *Handler) completeSessionBind(
 	// user (MS-SMB2 §3.3.5.5.2: "If the user represented by
 	// Session.SecurityContext is not the same as the user authenticated by
 	// the security subsystem, the server MUST return STATUS_ACCESS_DENIED").
-	if authUser == nil || sess.User == nil || authUser.Username != sess.User.Username {
+	// A mismatch is a security boundary — a bind must never attach a different
+	// identity to an existing session — so log it at Warn.
+	if !bindIdentityMatchesSession(sess, authUser) {
 		sessUser := "<nil>"
 		if sess.User != nil {
 			sessUser = sess.User.Username
@@ -805,7 +829,7 @@ func (h *Handler) completeSessionBind(
 		if authUser != nil {
 			authUserName = authUser.Username
 		}
-		logger.Info("SESSION_SETUP bind: identity mismatch",
+		logger.Warn("SESSION_SETUP bind: identity mismatch",
 			"sessionID", pending.BindingSessionID,
 			"sessionUser", sessUser,
 			"bindUser", authUserName,
@@ -1272,19 +1296,33 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 		// User not found or disabled
 		if err != nil || user == nil {
 			logger.Debug("User not found in UserStore", "username", resolvedUsername, "error", err)
-			// NETLOGON domain-user fallback (#1314): a domain user with no local
+			// NETLOGON domain-user fallback: a domain user with no local
 			// control-plane account may still be authenticated by forwarding the
 			// NTLM response to a Domain Controller over a NETLOGON secure channel.
 			// Mirrors the Kerberos directory-resolved-identity path (#1317): the DC
 			// returns the SIDs + session base key, the resolver maps the SID to a
-			// UID/GID, and a transient session is synthesized. Only attempted on a
-			// fresh, non-binding SESSION_SETUP — a bind must match the existing
-			// session's identity, and a re-auth must not resurrect a passed-through
-			// identity. Fails closed: on a missing authenticator or any DC error,
+			// UID/GID.
+			//
+			// Re-auth is ALWAYS excluded (a re-auth must not resurrect a
+			// passed-through identity in place of the original). The two other
+			// paths differ only in what they build:
+			//   - fresh, non-binding SESSION_SETUP (#1314): synthesize a new
+			//     session for the resolved identity (tryNetlogonFallback);
+			//   - session bind / multichannel (#1632): validate the SAME domain
+			//     user on an additional connection and register a channel on the
+			//     existing session (tryNetlogonBind). completeSessionBind enforces
+			//     that the DC-resolved identity matches the bound session's user,
+			//     rejecting a mismatch with STATUS_ACCESS_DENIED.
+			//
+			// Both fail closed: on a missing authenticator or any DC error,
 			// execution falls through to the LOGON_FAILURE / reauth-destroy paths
-			// below (never guest, never partial session).
-			if !pending.IsBinding && !pending.IsReauth {
-				if res, handled := h.tryNetlogonFallback(ctx, pending, authMsg); handled {
+			// below (never guest, never partial session, never a replaced session).
+			if !pending.IsReauth {
+				if pending.IsBinding {
+					if res, handled := h.tryNetlogonBind(ctx, pending, authMsg); handled {
+						return res, nil
+					}
+				} else if res, handled := h.tryNetlogonFallback(ctx, pending, authMsg); handled {
 					return res, nil
 				}
 			}
@@ -1415,6 +1453,90 @@ func (h *Handler) tryNetlogonFallback(ctx *SMBHandlerContext, pending *PendingAu
 		"isGuest", sess.IsGuest, "signingEnabled", sess.ShouldSign(), "encryptData", sess.ShouldEncrypt())
 
 	return h.buildAuthenticatedResponse(pending, signingKey[:], authMsg.NegotiateFlags, sess.ShouldEncrypt()), true
+}
+
+// tryNetlogonBind validates a domain user that has no local control-plane
+// account on an SMB2 session-bind (multichannel) path (#1632) and, when the
+// DC-resolved identity matches the bound session's existing user, registers a
+// new signing channel on that session.
+//
+// It mirrors tryNetlogonFallback's DC exchange and SID resolution but, instead
+// of synthesizing a fresh session, completes a channel bind via
+// completeSessionBind. The channel signing key is derived from the DC-returned
+// SessionBaseKey exactly as the fresh-session and local-user bind paths do
+// (auth.DeriveSigningKey honors KEY_EXCH by RC4-unwrapping the client's
+// EncryptedRandomSessionKey when NTLMSSP_NEGOTIATE_KEY_EXCH is set);
+// completeSessionBind then feeds that key into session.DeriveChannelSigningKey.
+// The identity match against the existing session's user is enforced inside
+// completeSessionBind, which returns STATUS_ACCESS_DENIED on a mismatch — a bind
+// must never attach a different identity to an existing session.
+//
+// Returns (result, true) when this path produced a terminal verdict: a
+// registered channel (STATUS_SUCCESS) on success, or STATUS_ACCESS_DENIED on an
+// identity mismatch. Returns (nil, false) when the fallback is unavailable or
+// could not complete (no authenticator, DC error, or unresolvable SID) so the
+// caller falls through to STATUS_LOGON_FAILURE. It NEVER creates, replaces, or
+// downgrades the existing session.
+//
+// Only called on a binding (IsBinding), non-reauth SESSION_SETUP (enforced by
+// the caller): a re-auth must not resurrect a passed-through identity.
+func (h *Handler) tryNetlogonBind(ctx *SMBHandlerContext, pending *PendingAuth, authMsg *auth.AuthenticateMessage) (*HandlerResult, bool) {
+	// Disabled (no authenticator injected): behave exactly as before — the
+	// caller returns STATUS_LOGON_FAILURE for the unknown domain user, leaving
+	// the existing session untouched.
+	if h.NetlogonAuth == nil {
+		return nil, false
+	}
+
+	res, err := h.NetlogonAuth.NetworkLogon(ctx.Context, netlogon.NetworkLogonRequest{
+		Username:        authMsg.Username,
+		Domain:          authMsg.Domain,
+		ServerChallenge: pending.ServerChallenge,
+		NTResponse:      authMsg.NtChallengeResponse,
+		LMResponse:      authMsg.LmChallengeResponse,
+	})
+	if err != nil {
+		// Fail closed: the DC rejected the credential or the channel failed.
+		// Fall through to STATUS_LOGON_FAILURE in the caller — the primary
+		// channel keeps working, only this bind attempt fails.
+		logger.Debug("NETLOGON bind pass-through authentication failed",
+			"username", authMsg.Username, "domain", authMsg.Domain, "error", err)
+		return nil, false
+	}
+	if res == nil {
+		logger.Debug("NETLOGON bind returned a nil result without error", "username", authMsg.Username)
+		return nil, false
+	}
+
+	// Resolve the DC-returned SID to a DittoFS identity, mirroring the
+	// fresh-session path. Without a resolved identity we cannot compare against
+	// the session's user, so fail closed.
+	resolved := h.resolveNetlogonIdentity(ctx, res)
+	if resolved == nil || !resolved.Found {
+		logger.Info("NETLOGON bind pass-through succeeded but identity could not be resolved (fail closed)",
+			"username", authMsg.Username, "userSID", res.UserSID)
+		return nil, false
+	}
+	user := synthUserFromResolved(resolved)
+
+	// Derive the channel signing key from the DC-provided session base key,
+	// honoring KEY_EXCH exactly as tryNetlogonFallback and the local-user bind
+	// path do. completeSessionBind consumes this as the bind's session key.
+	signingKey := auth.DeriveSigningKey(
+		res.SessionBaseKey,
+		authMsg.NegotiateFlags,
+		authMsg.EncryptedRandomSessionKey,
+	)
+
+	ctx.IsGuest = false
+
+	logger.Info("NETLOGON bind pass-through: validated directory-resolved domain user (no local account)",
+		"username", user.Username, "userSID", res.UserSID, "domain", res.DomainName)
+
+	// completeSessionBind verifies the resolved identity matches the existing
+	// session's user (STATUS_ACCESS_DENIED on mismatch) before registering the
+	// channel, and derives the per-channel key from signingKey.
+	return h.completeSessionBind(ctx, pending, user, h.sessionDomain(authMsg.Domain), signingKey[:], authMsg.NegotiateFlags), true
 }
 
 // resolveNetlogonIdentity maps a NETLOGON LogonResult to a DittoFS identity,

--- a/internal/adapter/smb/handlers/session_setup.go
+++ b/internal/adapter/smb/handlers/session_setup.go
@@ -771,20 +771,27 @@ func (h *Handler) handleNTLMNegotiateBinding(ctx *SMBHandlerContext, req *Sessio
 // different identity is a security boundary violation the caller rejects with
 // STATUS_ACCESS_DENIED.
 //
-// Matching prefers the Windows SID — the authoritative, globally-unique identity
+// Matching is by the Windows SID — the authoritative, globally-unique identity
 // for a directory-resolved / NETLOGON pass-through domain user, stamped by
 // synthUserFromResolved onto both the primary session's user and this bind's
-// user. When either side lacks a SID (e.g. a purely local control-plane
-// account) it falls back to the username, matching the convention of the
-// Kerberos bind path (completeKerberosBind) and the pre-#1632 NTLM bind check.
+// user. If EITHER identity carries a SID (i.e. is a directory/domain principal),
+// the bind MUST match by SID; the username fallback is reserved for pure-local
+// sessions where NEITHER side has a SID. Allowing the fallback when only one
+// side has a SID would let a SID-less local account named "alice" bind onto
+// DOMAIN\alice's session and inherit her authorization context (a privilege
+// escalation — control-plane accounts may legitimately have an empty SID). The
+// fallback is case-insensitive, matching Windows username semantics.
 func bindIdentityMatchesSession(sess *session.Session, authUser *models.User) bool {
 	if authUser == nil || sess == nil || sess.User == nil {
 		return false
 	}
-	if authUser.SID != "" && sess.User.SID != "" {
+	if authUser.SID != "" || sess.User.SID != "" {
+		// Equal only when both are the same non-empty SID: a SID-vs-empty
+		// comparison is unequal, so a SID-less identity can never bind onto a
+		// SID-bearing session (and vice versa).
 		return authUser.SID == sess.User.SID
 	}
-	return authUser.Username == sess.User.Username
+	return strings.EqualFold(authUser.Username, sess.User.Username)
 }
 
 // completeSessionBind finalizes an SMB2 session bind after NTLM auth proved

--- a/internal/adapter/smb/handlers/session_setup_netlogon_bind_test.go
+++ b/internal/adapter/smb/handlers/session_setup_netlogon_bind_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/marmos91/dittofs/internal/adapter/smb/session"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/internal/auth/netlogon"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
@@ -289,5 +290,39 @@ func TestReauth_DoesNotUseNetlogonFallback(t *testing.T) {
 	}
 	if nl.called {
 		t.Fatal("NETLOGON fallback was consulted on a re-auth (must be excluded)")
+	}
+}
+
+// TestBindIdentityMatchesSession covers the identity match that guards channel
+// binding. The security-critical case is the SID-vs-empty escalation: a SID-less
+// local account must never bind onto a SID-bearing (domain) session by matching
+// on username alone.
+func TestBindIdentityMatchesSession(t *testing.T) {
+	const sidA = "S-1-5-21-1-2-3-1107"
+	const sidB = "S-1-5-21-1-2-3-1200"
+	mk := func(username, sid string) *session.Session {
+		return &session.Session{User: &models.User{Username: username, SID: sid}}
+	}
+	tests := []struct {
+		name string
+		sess *session.Session
+		auth *models.User
+		want bool
+	}{
+		{"same SID matches", mk("alice", sidA), &models.User{Username: "alice", SID: sidA}, true},
+		{"different SID rejected", mk("alice", sidA), &models.User{Username: "alice", SID: sidB}, false},
+		{"SID session vs SID-less local same name rejected (escalation)", mk("alice", sidA), &models.User{Username: "alice", SID: ""}, false},
+		{"SID-less bind onto SID session rejected regardless of name", mk("alice", sidA), &models.User{Username: "ALICE", SID: ""}, false},
+		{"SID bind onto SID-less session rejected", mk("alice", ""), &models.User{Username: "alice", SID: sidA}, false},
+		{"local-vs-local same name (case-insensitive) matches", mk("alice", ""), &models.User{Username: "ALICE", SID: ""}, true},
+		{"local-vs-local different name rejected", mk("alice", ""), &models.User{Username: "bob", SID: ""}, false},
+		{"nil auth user rejected", mk("alice", sidA), nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bindIdentityMatchesSession(tt.sess, tt.auth); got != tt.want {
+				t.Fatalf("bindIdentityMatchesSession = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/adapter/smb/handlers/session_setup_netlogon_bind_test.go
+++ b/internal/adapter/smb/handlers/session_setup_netlogon_bind_test.go
@@ -1,0 +1,293 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/internal/auth/netlogon"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	pkgidentity "github.com/marmos91/dittofs/pkg/identity"
+)
+
+// seedPassthroughSession creates a primary session for a directory-resolved
+// (NETLOGON pass-through) domain user — one with no local control-plane account
+// but a stamped Windows SID — mirroring what tryNetlogonFallback produces on the
+// origin channel. This is the session an additional multichannel connection
+// binds to.
+func seedPassthroughSession(t *testing.T, h *Handler, sessionID uint64, username, sid string) {
+	t.Helper()
+	uid := uint32(10001)
+	user := &models.User{
+		Username: username,
+		UID:      &uid,
+		SID:      sid,
+		Enabled:  true,
+	}
+	sess := h.CreateSessionWithUser(sessionID, "127.0.0.1:1", user, "CORP")
+	sess.OriginConnID = 1
+	sess.Dialect = types.Dialect0311
+}
+
+// driveBindTYPE3 stores a binding PendingAuth (IsBinding, non-reauth) targeting
+// an existing session and drives completeNTLMAuth with an NTLM TYPE_3 for a
+// domain user that has no local account, exercising the #1632 bind pass-through
+// path. Returns the handler result and the connection's ConnID.
+func driveBindTYPE3(t *testing.T, h *Handler, sessionID uint64, username, domain string) (*HandlerResult, uint64) {
+	t.Helper()
+	ctx := newTestContext(sessionID)
+	ctx.ConnCryptoState = &mockCryptoState{dialect: types.Dialect0311}
+
+	var challenge [8]byte
+	copy(challenge[:], []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88})
+	h.StorePendingAuth(&PendingAuth{
+		SessionID:        sessionID,
+		ConnID:           ctx.ConnID,
+		ClientAddr:       ctx.ClientAddr,
+		CreatedAt:        time.Now(),
+		ServerChallenge:  challenge,
+		IsBinding:        true,
+		BindingSessionID: sessionID,
+	})
+
+	ntResp := make([]byte, 24)
+	for i := range ntResp {
+		ntResp[i] = byte(i + 1)
+	}
+	token := buildNTLMAuthenticateForTest(username, domain, ntResp)
+	result, err := h.completeNTLMAuth(ctx, token)
+	if err != nil {
+		t.Fatalf("bind TYPE_3 returned error: %v", err)
+	}
+	return result, ctx.ConnID
+}
+
+// TestSessionBind_DomainUserPassthrough (Test A): a domain pass-through user
+// (no local account) can bind an additional SMB3 channel. On a local miss the
+// binding TYPE_3 is validated via NETLOGON, the DC-resolved identity matches the
+// existing session's user, and a signing channel is registered — no
+// STATUS_LOGON_FAILURE on the spare connection.
+func TestSessionBind_DomainUserPassthrough(t *testing.T) {
+	const sessionID = uint64(0x0bad0bad)
+	const sid = "S-1-5-21-1111111111-2222222222-3333333333-1001"
+	groupSIDs := []string{"S-1-5-21-1111111111-2222222222-3333333333-513"}
+
+	var baseKey [16]byte
+	for i := range baseKey {
+		baseKey[i] = byte(0xA0 + i)
+	}
+
+	nl := &fakeNetlogon{res: &netlogon.LogonResult{
+		SessionBaseKey: baseKey,
+		UserSID:        sid,
+		GroupSIDs:      groupSIDs,
+		Username:       "alice",
+		DomainName:     "CORP",
+	}}
+	provider := &fakeIdentityProvider{
+		name:    "netlogon",
+		wantSID: sid,
+		resolved: &pkgidentity.ResolvedIdentity{
+			Username:  "alice",
+			UID:       10001,
+			GID:       10001,
+			SID:       sid,
+			GroupSIDs: groupSIDs,
+			Found:     true,
+		},
+	}
+	h := newNetlogonFallbackHandler(t, nl, provider)
+	seedPassthroughSession(t, h, sessionID, "alice", sid)
+
+	result, connID := driveBindTYPE3(t, h, sessionID, "alice", "CORP")
+
+	if result.Status.IsError() {
+		t.Fatalf("expected bind success, got status 0x%08x", uint32(result.Status))
+	}
+	if !result.IsBinding {
+		t.Error("result.IsBinding = false, want true (channel bind response)")
+	}
+	if !nl.called {
+		t.Fatal("NETLOGON authenticator was never called on the bind local miss")
+	}
+
+	// A channel must have been registered on the existing session for this conn.
+	sess, ok := h.GetSession(sessionID)
+	if !ok {
+		t.Fatalf("session 0x%x vanished", sessionID)
+	}
+	if ch := sess.GetChannel(connID); ch == nil {
+		t.Fatalf("no channel registered for connID %d after bind", connID)
+	} else if ch.Signer == nil || len(ch.SigningKey) == 0 {
+		t.Error("bound channel has no signing key derived from the DC SessionBaseKey")
+	}
+	// The bind must not have replaced the session's identity.
+	if sess.User == nil || sess.User.SID != sid {
+		t.Errorf("session user SID = %v, want %q (identity must be preserved)", sess.User, sid)
+	}
+}
+
+// TestSessionBind_DomainUserIdentityMismatch (Test B): when the DC resolves the
+// bind to a DIFFERENT identity than the one that owns the session, the bind is
+// rejected with STATUS_ACCESS_DENIED and no channel is registered. This is the
+// security boundary — a bind must not attach a different identity.
+func TestSessionBind_DomainUserIdentityMismatch(t *testing.T) {
+	const sessionID = uint64(0x0bad0bad)
+	const sessSID = "S-1-5-21-1111111111-2222222222-3333333333-1001" // session owner
+	const bindSID = "S-1-5-21-1111111111-2222222222-3333333333-2002" // different user
+
+	var baseKey [16]byte
+	for i := range baseKey {
+		baseKey[i] = byte(0xB0 + i)
+	}
+
+	// DC authenticates the bind as a different SID than the session owner.
+	nl := &fakeNetlogon{res: &netlogon.LogonResult{
+		SessionBaseKey: baseKey,
+		UserSID:        bindSID,
+		Username:       "mallory",
+		DomainName:     "CORP",
+	}}
+	provider := &fakeIdentityProvider{
+		name:    "netlogon",
+		wantSID: bindSID,
+		resolved: &pkgidentity.ResolvedIdentity{
+			Username: "mallory",
+			UID:      20002,
+			GID:      20002,
+			SID:      bindSID,
+			Found:    true,
+		},
+	}
+	h := newNetlogonFallbackHandler(t, nl, provider)
+	seedPassthroughSession(t, h, sessionID, "alice", sessSID)
+
+	result, connID := driveBindTYPE3(t, h, sessionID, "mallory", "CORP")
+
+	if result.Status != types.StatusAccessDenied {
+		t.Fatalf("status = 0x%08x, want STATUS_ACCESS_DENIED", uint32(result.Status))
+	}
+	if !nl.called {
+		t.Fatal("NETLOGON authenticator was never called")
+	}
+	sess, ok := h.GetSession(sessionID)
+	if !ok {
+		t.Fatalf("session 0x%x vanished", sessionID)
+	}
+	if ch := sess.GetChannel(connID); ch != nil {
+		t.Fatal("a channel was registered despite an identity mismatch (security boundary violated)")
+	}
+	// The original session identity must be untouched.
+	if sess.User == nil || sess.User.SID != sessSID {
+		t.Errorf("session user SID = %v, want %q (must be preserved after rejected bind)", sess.User, sessSID)
+	}
+}
+
+// TestSessionBind_DomainUserFailClosed: a NETLOGON error on the bind path must
+// yield STATUS_LOGON_FAILURE with no channel registered — the primary session
+// is left intact and the spare connection simply fails.
+func TestSessionBind_DomainUserFailClosed(t *testing.T) {
+	const sessionID = uint64(0x0bad0bad)
+	const sid = "S-1-5-21-1111111111-2222222222-3333333333-1001"
+
+	nl := &fakeNetlogon{err: context.DeadlineExceeded}
+	h := newNetlogonFallbackHandler(t, nl, &fakeIdentityProvider{name: "netlogon"})
+	seedPassthroughSession(t, h, sessionID, "alice", sid)
+
+	result, connID := driveBindTYPE3(t, h, sessionID, "alice", "CORP")
+
+	if result.Status != types.StatusLogonFailure {
+		t.Fatalf("status = 0x%08x, want STATUS_LOGON_FAILURE", uint32(result.Status))
+	}
+	if !nl.called {
+		t.Fatal("NETLOGON authenticator was never called")
+	}
+	sess, ok := h.GetSession(sessionID)
+	if !ok {
+		t.Fatalf("session 0x%x vanished (bind must not destroy the session)", sessionID)
+	}
+	if ch := sess.GetChannel(connID); ch != nil {
+		t.Fatal("a channel was registered on NETLOGON failure (fail-closed violated)")
+	}
+}
+
+// TestSessionBind_NetlogonDisabled: with no authenticator injected, a domain
+// user that misses locally on the bind path yields STATUS_LOGON_FAILURE with no
+// channel (no fallback attempted at all).
+func TestSessionBind_NetlogonDisabled(t *testing.T) {
+	const sessionID = uint64(0x0bad0bad)
+	const sid = "S-1-5-21-1111111111-2222222222-3333333333-1001"
+
+	h := newNetlogonFallbackHandler(t, nil, nil)
+	seedPassthroughSession(t, h, sessionID, "alice", sid)
+
+	result, connID := driveBindTYPE3(t, h, sessionID, "alice", "CORP")
+
+	if result.Status != types.StatusLogonFailure {
+		t.Fatalf("status = 0x%08x, want STATUS_LOGON_FAILURE", uint32(result.Status))
+	}
+	if sess, ok := h.GetSession(sessionID); ok {
+		if ch := sess.GetChannel(connID); ch != nil {
+			t.Fatal("a channel was registered with no NETLOGON authenticator")
+		}
+	}
+}
+
+// TestReauth_DoesNotUseNetlogonFallback (Test C): a re-authentication for a
+// domain user with no local account must NOT consult the NETLOGON fallback (a
+// re-auth must not resurrect a passed-through identity). It fails closed with
+// STATUS_LOGON_FAILURE and the authenticator is never called.
+func TestReauth_DoesNotUseNetlogonFallback(t *testing.T) {
+	const sessionID = uint64(0x0bad0bad)
+	const sid = "S-1-5-21-1111111111-2222222222-3333333333-1001"
+
+	var baseKey [16]byte
+	nl := &fakeNetlogon{res: &netlogon.LogonResult{
+		SessionBaseKey: baseKey,
+		UserSID:        sid,
+		Username:       "alice",
+		DomainName:     "CORP",
+	}}
+	provider := &fakeIdentityProvider{
+		name:    "netlogon",
+		wantSID: sid,
+		resolved: &pkgidentity.ResolvedIdentity{
+			Username: "alice", UID: 10001, GID: 10001, SID: sid, Found: true,
+		},
+	}
+	h := newNetlogonFallbackHandler(t, nl, provider)
+	// An existing authenticated session that the re-auth targets.
+	seedPassthroughSession(t, h, sessionID, "alice", sid)
+
+	ctx := newTestContext(sessionID)
+	ctx.ConnCryptoState = &mockCryptoState{dialect: types.Dialect0311}
+
+	var challenge [8]byte
+	copy(challenge[:], []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88})
+	h.StorePendingAuth(&PendingAuth{
+		SessionID:       sessionID,
+		ConnID:          ctx.ConnID,
+		ClientAddr:      ctx.ClientAddr,
+		CreatedAt:       time.Now(),
+		ServerChallenge: challenge,
+		IsReauth:        true,
+	})
+
+	ntResp := make([]byte, 24)
+	for i := range ntResp {
+		ntResp[i] = byte(i + 1)
+	}
+	token := buildNTLMAuthenticateForTest("alice", "CORP", ntResp)
+	result, err := h.completeNTLMAuth(ctx, token)
+	if err != nil {
+		t.Fatalf("reauth TYPE_3 returned error: %v", err)
+	}
+
+	if result.Status != types.StatusLogonFailure {
+		t.Fatalf("status = 0x%08x, want STATUS_LOGON_FAILURE", uint32(result.Status))
+	}
+	if nl.called {
+		t.Fatal("NETLOGON fallback was consulted on a re-auth (must be excluded)")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1632. Follow-up to #1629 (NTLM↔AD pass-through). NTLM pass-through worked for a fresh SMB2 `SESSION_SETUP` but **SMB2 session-bind** (multichannel; request `Flags & SMB2_SESSION_FLAG_BINDING`) failed for a pass-through **domain** user with no local DittoFS account — the bind's TYPE_3 logged `STATUS_LOGON_FAILURE` and the Windows client dropped the spare connection. Browse/mount were unaffected (primary channel kept working); this restores the multichannel optimization for pass-through users, matching Kerberos behavior.

## Root cause

`completeNTLMAuth` (`internal/adapter/smb/handlers/session_setup.go`) gated the NETLOGON fallback on `!pending.IsBinding && !pending.IsReauth`, so a domain user with no local account could only be validated on the fresh-session path, never on a bind.

## Change

- Re-gate the dispatch: **re-auth stays excluded** (a re-auth must not resurrect a passed-through identity); **binding** now routes to a new `tryNetlogonBind` while the fresh path keeps using `tryNetlogonFallback`.
- `tryNetlogonBind` mirrors the fresh path's DC exchange + SID resolution, but instead of minting a new session it derives the channel signing key from the DC-returned `SessionBaseKey` (honoring KEY_EXCH exactly like the fresh/local paths) and registers a `session.Channel` via `completeSessionBind`. **Fails closed** — no authenticator / DC error / unresolvable SID all return `(nil,false)` → the caller's `LOGON_FAILURE`; the existing session is never created, replaced, or downgraded.
- Identity match extracted to `bindIdentityMatchesSession` and enforced in `completeSessionBind`: a bind that resolves to a different principal is rejected with `STATUS_ACCESS_DENIED`.

## Security hardening (from code review)

The identity match now requires a **SID match whenever either identity carries a SID**; the username fallback is reserved for pure-local sessions where neither side has one. This closes an escalation where a SID-less local account named `alice` could bind onto `DOMAIN\alice`'s session via a username-only match and inherit her authorization context. Fallback is case-insensitive per Windows semantics.

## Tests

New `session_setup_netlogon_bind_test.go`: bind pass-through success (channel registered, signing key derived), identity-mismatch → `ACCESS_DENIED` (no channel, session preserved), re-auth exclusion, fail-closed on DC error, netlogon-disabled, and `TestBindIdentityMatchesSession` covering the SID-vs-empty escalation. `go build ./...`, `go vet ./...`, `go test ./internal/adapter/smb/...` all green.

## Validation

Live-validated on a real Windows AD DC (cubbit.local): a domain user (`bob@cubbit.local`, no local account) mounted **by IP** (forcing NTLM pass-through) with heavy I/O produced a real multichannel bind — the server log shows `SESSION_SETUP flags=0x01` (binding) → `NETLOGON bind pass-through: validated ... userSID=...-1107` → `channel registered ... totalChannels=2 dialect=0x0311`, `STATUS_SUCCESS`, **zero `LOGON_FAILURE`**.

## Note / follow-up

The Kerberos bind path (`completeKerberosBind`) still uses a username-only match — a separate, pre-existing parity gap not touched here. Worth a fast-follow to apply the same SID-mandatory hardening there.
