### PR TITLE
feat(netlogon): dfsctl netlogon status + rotate (#1631)

### DIFF
--- a/cmd/dfs/commands/netlogon.go
+++ b/cmd/dfs/commands/netlogon.go
@@ -45,6 +45,11 @@ func (m *machineSecretStore) SetMachineSecret(ctx context.Context, secret string
 // It also returns a *netlogon.RotationManager when the online-join provider is
 // active (nil otherwise); the caller starts it and stops it on shutdown.
 //
+// The third return is a *netlogon.Controller (nil when passthrough is disabled):
+// the runtime handle the caller registers with the Runtime so the admin API can
+// report `netlogon status` and force `netlogon rotate` against this running
+// authenticator (#1631).
+//
 // The offline path is backed by a netlogon.MutableProvider so the machine
 // credential / DC binding can be hot-reloaded over the API without a restart
 // (#1325). The online-join path (#1323) owns its own credential lifecycle via
@@ -58,9 +63,9 @@ func (m *machineSecretStore) SetMachineSecret(ctx context.Context, secret string
 // ReloadCredential/Close methods for the #1325 hot-reload and shutdown. The
 // disabled path returns a nil *Authenticator, so callers can test `auth == nil`
 // directly.
-func buildNetlogonAuthenticator(k config.KerberosConfig, secret netlogon.SecretStore) (*netlogon.Authenticator, *netlogon.RotationManager) {
+func buildNetlogonAuthenticator(k config.KerberosConfig, secret netlogon.SecretStore) (*netlogon.Authenticator, *netlogon.RotationManager, *netlogon.Controller) {
 	if !k.MachineAccount.Enabled {
-		return nil, nil
+		return nil, nil, nil
 	}
 	ma := k.MachineAccount
 
@@ -70,15 +75,15 @@ func buildNetlogonAuthenticator(k config.KerberosConfig, secret netlogon.SecretS
 	if ma.OnlineJoin.Enabled {
 		if ma.AccountName == "" {
 			slog.Warn("NETLOGON machine account is enabled but AccountName is not set; NTLM passthrough disabled")
-			return nil, nil
+			return nil, nil, nil
 		}
 		if k.NetBIOSDomain == "" {
 			slog.Warn("NETLOGON machine account is enabled but kerberos.netbios_domain (DomainName) is not set; NTLM passthrough disabled")
-			return nil, nil
+			return nil, nil, nil
 		}
 		if k.Realm == "" {
 			slog.Warn("NETLOGON machine account is enabled but kerberos.realm is not set (required for the Kerberos SMB session to the DC and for DNS SRV discovery); NTLM passthrough disabled")
-			return nil, nil
+			return nil, nil, nil
 		}
 
 		// Derive the NetBIOS workstation name. MS-NRPC §3.1.4.1 requires the short
@@ -112,20 +117,24 @@ func buildNetlogonAuthenticator(k config.KerberosConfig, secret netlogon.SecretS
 		provider := netlogon.NewOnlineProvider(cfg, secret)
 		auth := netlogon.NewAuthenticator(provider)
 		rot := netlogon.NewRotationManager(provider, auth, oj.RotationInterval)
+		ctrl := netlogon.NewController(netlogon.ProviderOnlineJoin, auth, provider, rot)
 		slog.Info("NETLOGON machine account: online-join provider active",
 			"account", ma.AccountName, "ldap_url", oj.LDAPURL, "rotation_interval", oj.RotationInterval)
-		return auth, rot
+		return auth, rot, ctrl
 	}
 
 	// Offline path: a static admin-supplied secret, wrapped in a MutableProvider so
 	// the credential can be hot-reloaded over the API without a restart (#1325).
 	cred, ok := netlogonCredentialFromConfig(k)
 	if !ok {
-		return nil, nil
+		return nil, nil, nil
 	}
+	provider := netlogon.NewMutableProvider(cred)
+	auth := netlogon.NewAuthenticator(provider)
+	ctrl := netlogon.NewController(netlogon.ProviderOffline, auth, provider, nil)
 	slog.Info("NETLOGON machine account: offline provider active",
 		"account", ma.AccountName, "dc_addresses", ma.DCAddresses)
-	return netlogon.NewAuthenticator(netlogon.NewMutableProvider(cred)), nil
+	return auth, nil, ctrl
 }
 
 // netlogonCredentialFromConfig validates the machine-account sub-block and, when

--- a/cmd/dfs/commands/netlogon_cmd.go
+++ b/cmd/dfs/commands/netlogon_cmd.go
@@ -79,7 +79,7 @@ func runNetlogonTest(cmd *cobra.Command, _ []string) error {
 	// nil secret store: the offline path reads the static secret from config and
 	// never touches the control-plane store, so this is safe to run alongside a
 	// running server (it makes only an outbound probe to the DC, binds no ports).
-	auth, _ := buildNetlogonAuthenticator(k, nil)
+	auth, _, _ := buildNetlogonAuthenticator(k, nil)
 	if auth == nil {
 		return fmt.Errorf("machine-account configuration is incomplete (see the warnings above); NTLM pass-through is disabled")
 	}

--- a/cmd/dfs/commands/netlogon_test.go
+++ b/cmd/dfs/commands/netlogon_test.go
@@ -12,7 +12,7 @@ func TestBuildNetlogonAuthenticator_Disabled(t *testing.T) {
 	k := config.KerberosConfig{
 		MachineAccount: config.MachineAccountConfig{Enabled: false},
 	}
-	got, _ := buildNetlogonAuthenticator(k, nil)
+	got, _, _ := buildNetlogonAuthenticator(k, nil)
 	if got != nil {
 		t.Fatalf("expected nil for disabled machine account, got %v", got)
 	}
@@ -29,7 +29,7 @@ func TestBuildNetlogonAuthenticator_Enabled(t *testing.T) {
 			DCAddresses: []string{"192.168.1.1"},
 		},
 	}
-	got, _ := buildNetlogonAuthenticator(k, nil)
+	got, _, _ := buildNetlogonAuthenticator(k, nil)
 	if got == nil {
 		t.Fatal("expected non-nil authenticator for enabled machine account")
 	}
@@ -46,7 +46,7 @@ func TestBuildNetlogonAuthenticator_EnabledMissingSecret(t *testing.T) {
 			DCAddresses: []string{"192.168.1.1"},
 		},
 	}
-	got, _ := buildNetlogonAuthenticator(k, nil)
+	got, _, _ := buildNetlogonAuthenticator(k, nil)
 	if got != nil {
 		t.Fatal("expected nil when Secret is missing")
 	}
@@ -64,7 +64,7 @@ func TestBuildNetlogonAuthenticator_EnabledKeytabOnly(t *testing.T) {
 			DCAddresses: []string{"192.168.1.1"},
 		},
 	}
-	got, _ := buildNetlogonAuthenticator(k, nil)
+	got, _, _ := buildNetlogonAuthenticator(k, nil)
 	if got != nil {
 		t.Fatal("expected nil when only KeytabPath is set (not yet supported)")
 	}
@@ -81,7 +81,7 @@ func TestBuildNetlogonAuthenticator_EnabledMissingDomain(t *testing.T) {
 			DCAddresses: []string{"192.168.1.1"},
 		},
 	}
-	got, _ := buildNetlogonAuthenticator(k, nil)
+	got, _, _ := buildNetlogonAuthenticator(k, nil)
 	if got != nil {
 		t.Fatal("expected nil when NetBIOSDomain is missing")
 	}
@@ -100,7 +100,7 @@ func TestBuildNetlogonAuthenticator_EnabledMissingDCAddressesUsesDiscovery(t *te
 			// DCAddresses intentionally empty — located from the realm.
 		},
 	}
-	got, _ := buildNetlogonAuthenticator(k, nil)
+	got, _, _ := buildNetlogonAuthenticator(k, nil)
 	if got == nil {
 		t.Fatal("expected non-nil authenticator when realm is set (DC located via DNS SRV)")
 	}
@@ -119,7 +119,7 @@ func TestBuildNetlogonAuthenticator_EnabledMissingRealm(t *testing.T) {
 			DCAddresses: []string{"192.168.1.1"},
 		},
 	}
-	got, _ := buildNetlogonAuthenticator(k, nil)
+	got, _, _ := buildNetlogonAuthenticator(k, nil)
 	if got != nil {
 		t.Fatal("expected nil when realm is missing")
 	}
@@ -147,12 +147,30 @@ func TestBuildNetlogonAuthenticator_OnlineJoinNoSecretNeeded(t *testing.T) {
 			},
 		},
 	}
-	got, rot := buildNetlogonAuthenticator(k, &fakeSecretStore{})
+	got, rot, ctrl := buildNetlogonAuthenticator(k, &fakeSecretStore{})
 	if got == nil {
 		t.Fatal("expected non-nil authenticator for online-join (no static secret required)")
 	}
 	if rot != nil {
 		t.Fatal("expected nil rotation manager when rotation_interval is 0")
+	}
+	if ctrl == nil {
+		t.Fatal("expected non-nil controller for online-join")
+	}
+	// Status must not trigger the lazy join (no DC/LDAP I/O) and must report the
+	// online-join provider identity from config.
+	st := ctrl.Status(context.Background())
+	if st.Provider != netlogon.ProviderOnlineJoin {
+		t.Errorf("provider = %q, want online-join", st.Provider)
+	}
+	if st.AccountName != "DITTOFS$" || st.Realm != "EXAMPLE.COM" || st.NetBIOSDomain != "EXAMPLE" {
+		t.Errorf("unexpected status identity: %+v", st)
+	}
+	if st.Joined {
+		t.Error("Status must not perform the lazy join (joined should be false before first logon)")
+	}
+	if st.RotationEnabled {
+		t.Error("rotation should be disabled when interval is 0")
 	}
 }
 

--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -296,7 +296,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 	// control-plane settings store, so it survives restarts. nlAuth is nil when
 	// machine_account is disabled. nlRotation drives periodic password rotation
 	// and is started below / stopped on shutdown.
-	nlAuth, nlRotation := buildNetlogonAuthenticator(effectiveKerberos, newMachineSecretStore(cpStore))
+	nlAuth, nlRotation, nlController := buildNetlogonAuthenticator(effectiveKerberos, newMachineSecretStore(cpStore))
 	nlRotation.Start()
 	// Single defer with deterministic ordering: stop the rotation loop FIRST so
 	// no rotation can re-establish (and leak) the secure channel after Close, then
@@ -307,6 +307,13 @@ func runStart(cmd *cobra.Command, args []string) error {
 			nlAuth.Close(context.Background())
 		}
 	}()
+
+	// Expose the machine-account controller to the Runtime so the admin API can
+	// report `netlogon status` and force `netlogon rotate` against this running
+	// authenticator (#1631). nil when passthrough is disabled.
+	if nlController != nil {
+		rt.SetNetlogonController(nlController)
+	}
 
 	rt.SetAdapterFactory(createAdapterFactory(&effectiveKerberos, nlAuth))
 

--- a/cmd/dfsctl/commands/netlogon/netlogon.go
+++ b/cmd/dfsctl/commands/netlogon/netlogon.go
@@ -6,6 +6,7 @@ package netlogon
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
 	"github.com/marmos91/dittofs/pkg/apiclient"
@@ -78,7 +79,7 @@ func (r statusRenderer) Rows() [][]string {
 		{"Account", cmdutil.EmptyOr(s.AccountName, "-")},
 		{"Realm", cmdutil.EmptyOr(s.Realm, "-")},
 		{"NetBIOS domain", cmdutil.EmptyOr(s.NetBIOSDomain, "-")},
-		{"DC addresses", cmdutil.EmptyOr(joinDCs(s.DCAddresses), "(discover via DNS SRV)")},
+		{"DC addresses", cmdutil.EmptyOr(strings.Join(s.DCAddresses, ", "), "(discover via DNS SRV)")},
 		{"Channel connected", cmdutil.BoolToYesNo(s.ChannelConnected)},
 	}
 	// "Joined" is only meaningful for the online-join provider (the offline
@@ -97,17 +98,6 @@ func (r statusRenderer) Rows() [][]string {
 		rows = append(rows, []string{"Joined", "n/a (offline provider)"})
 	}
 	return rows
-}
-
-func joinDCs(dcs []string) string {
-	out := ""
-	for i, dc := range dcs {
-		if i > 0 {
-			out += ", "
-		}
-		out += dc
-	}
-	return out
 }
 
 func runStatus(cmd *cobra.Command, args []string) error {

--- a/cmd/dfsctl/commands/netlogon/netlogon.go
+++ b/cmd/dfsctl/commands/netlogon/netlogon.go
@@ -1,0 +1,156 @@
+// Package netlogon implements the `dfsctl netlogon` command group for inspecting
+// and controlling the NETLOGON machine-account (SMB NTLM pass-through) subsystem
+// on a running DittoFS server.
+package netlogon
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
+	"github.com/marmos91/dittofs/pkg/apiclient"
+	"github.com/spf13/cobra"
+)
+
+// Cmd is the parent `netlogon` command.
+var Cmd = &cobra.Command{
+	Use:   "netlogon",
+	Short: "Inspect and control the NETLOGON machine account (SMB NTLM pass-through)",
+	Long: `Inspect and control the NETLOGON machine account used for SMB NTLM pass-through
+of Active Directory domain users on the running DittoFS server.
+
+When a client connects by a name with no Kerberos SPN (an IP, or the Explorer →
+Network discovery name), Windows falls back to NTLM; DittoFS validates that NTLM
+response against a domain controller over a NETLOGON secure channel using a
+machine account. These commands report the live machine-account / secure-channel
+state and force a machine-password rotation.
+
+Unlike 'dfs netlogon test' (a self-contained probe run from the config file),
+these talk to the RUNNING server over the API and require admin credentials.
+
+Examples:
+  # Show live machine-account and secure-channel state
+  dfsctl netlogon status
+
+  # Force a machine-password rotation now (online-join only)
+  dfsctl netlogon rotate`,
+}
+
+func init() {
+	Cmd.AddCommand(statusCmd)
+	Cmd.AddCommand(rotateCmd)
+}
+
+// --- status ---
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show live NETLOGON machine-account and secure-channel state",
+	Long: `Report the live state of the NETLOGON machine account on the running server:
+the active provider (offline or online-join), the machine-account name, the
+realm / NetBIOS domain / DC binding, whether the account is joined, whether the
+secure channel is currently established, and the automatic-rotation schedule.
+
+Examples:
+  # Show status as a table
+  dfsctl netlogon status
+
+  # Show status as JSON
+  dfsctl netlogon status -o json`,
+	Args: cobra.NoArgs,
+	RunE: runStatus,
+}
+
+// statusRenderer renders a NetlogonStatus as a key/value table.
+type statusRenderer struct {
+	s *apiclient.NetlogonStatus
+}
+
+// Headers implements output.TableRenderer.
+func (r statusRenderer) Headers() []string { return []string{"FIELD", "VALUE"} }
+
+// Rows implements output.TableRenderer.
+func (r statusRenderer) Rows() [][]string {
+	s := r.s
+	rows := [][]string{
+		{"Enabled", cmdutil.BoolToYesNo(s.Enabled)},
+		{"Provider", cmdutil.EmptyOr(s.Provider, "-")},
+		{"Account", cmdutil.EmptyOr(s.AccountName, "-")},
+		{"Realm", cmdutil.EmptyOr(s.Realm, "-")},
+		{"NetBIOS domain", cmdutil.EmptyOr(s.NetBIOSDomain, "-")},
+		{"DC addresses", cmdutil.EmptyOr(joinDCs(s.DCAddresses), "(discover via DNS SRV)")},
+		{"Channel connected", cmdutil.BoolToYesNo(s.ChannelConnected)},
+	}
+	// "Joined" is only meaningful for the online-join provider (the offline
+	// provider has no provisioning step), so present it as n/a otherwise.
+	if s.Provider == "online-join" {
+		rows = append(rows, []string{"Joined", cmdutil.BoolToYesNo(s.Joined)})
+		rows = append(rows, []string{"Rotation enabled", cmdutil.BoolToYesNo(s.RotationEnabled)})
+		if s.RotationEnabled {
+			rows = append(rows,
+				[]string{"Rotation interval", cmdutil.EmptyOr(s.RotationInterval, "-")},
+				[]string{"Next rotation", cmdutil.EmptyOr(s.NextRotation, "-")},
+			)
+		}
+		rows = append(rows, []string{"Last rotation", cmdutil.EmptyOr(s.LastRotation, "never")})
+	} else {
+		rows = append(rows, []string{"Joined", "n/a (offline provider)"})
+	}
+	return rows
+}
+
+func joinDCs(dcs []string) string {
+	out := ""
+	for i, dc := range dcs {
+		if i > 0 {
+			out += ", "
+		}
+		out += dc
+	}
+	return out
+}
+
+func runStatus(cmd *cobra.Command, args []string) error {
+	client, err := cmdutil.GetAuthenticatedClient()
+	if err != nil {
+		return err
+	}
+	status, err := client.GetNetlogonStatus()
+	if err != nil {
+		return fmt.Errorf("failed to get netlogon status: %w", err)
+	}
+	return cmdutil.PrintOutput(os.Stdout, status, false, "", statusRenderer{s: status})
+}
+
+// --- rotate ---
+
+var rotateCmd = &cobra.Command{
+	Use:   "rotate",
+	Short: "Force a machine-account password rotation now",
+	Long: `Force an immediate rotation of the machine-account password on the running server.
+
+Rotation applies only to the online-join provider, which owns the machine-password
+lifecycle: the new password is set on the domain controller (NetrServerPasswordSet2),
+switched in memory, and persisted — keeping the stored secret in sync with the DC.
+The offline/static provider owns no password lifecycle, so this command returns an
+error there; rotate that secret by updating the machine-account configuration.
+
+Examples:
+  # Rotate the machine password now
+  dfsctl netlogon rotate`,
+	Args: cobra.NoArgs,
+	RunE: runRotate,
+}
+
+func runRotate(cmd *cobra.Command, args []string) error {
+	client, err := cmdutil.GetAuthenticatedClient()
+	if err != nil {
+		return err
+	}
+	result, err := client.RotateNetlogon()
+	if err != nil {
+		return fmt.Errorf("failed to rotate machine password: %w", err)
+	}
+	cmdutil.PrintSuccess("Machine-account password rotated.")
+	return cmdutil.PrintOutput(os.Stdout, result.Status, false, "", statusRenderer{s: &result.Status})
+}

--- a/cmd/dfsctl/commands/root.go
+++ b/cmd/dfsctl/commands/root.go
@@ -13,6 +13,7 @@ import (
 	idpcmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/identityprovider"
 	idmapcmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/idmap"
 	netgroupcmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/netgroup"
+	netlogoncmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/netlogon"
 	quotacmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/quota"
 	settingscmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/settings"
 	sharecmd "github.com/marmos91/dittofs/cmd/dfsctl/commands/share"
@@ -100,6 +101,7 @@ func init() {
 	rootCmd.AddCommand(clientcmd.Cmd)
 	rootCmd.AddCommand(gracecmd.Cmd)
 	rootCmd.AddCommand(netgroupcmd.Cmd)
+	rootCmd.AddCommand(netlogoncmd.Cmd)
 	rootCmd.AddCommand(idmapcmd.Cmd)
 	rootCmd.AddCommand(idpcmd.Cmd)
 	rootCmd.AddCommand(settingscmd.Cmd)

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -655,6 +655,9 @@ Global flags:
     - [`dfsctl netgroup remove`](#dfsctl-netgroup-remove) — Remove a netgroup
     - [`dfsctl netgroup remove-member`](#dfsctl-netgroup-remove-member) — Remove a member from a netgroup
     - [`dfsctl netgroup show`](#dfsctl-netgroup-show) — Show netgroup details
+  - [`dfsctl netlogon`](#dfsctl-netlogon) — Inspect and control the NETLOGON machine account (SMB NTLM pass-through)
+    - [`dfsctl netlogon rotate`](#dfsctl-netlogon-rotate) — Force a machine-account password rotation now
+    - [`dfsctl netlogon status`](#dfsctl-netlogon-status) — Show live NETLOGON machine-account and secure-channel state
   - [`dfsctl quota`](#dfsctl-quota) — Per-identity quota management
     - [`dfsctl quota list`](#dfsctl-quota-list) — List all quotas on a share
     - [`dfsctl quota remove`](#dfsctl-quota-remove) — Remove a per-identity quota
@@ -3328,6 +3331,120 @@ dfsctl netgroup show office-network -o json
 
 # Output as YAML
 dfsctl netgroup show office-network -o yaml
+```
+
+Global flags:
+
+```
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
+```
+
+### `dfsctl netlogon`
+
+Inspect and control the NETLOGON machine account (SMB NTLM pass-through)
+
+Inspect and control the NETLOGON machine account used for SMB NTLM pass-through
+of Active Directory domain users on the running DittoFS server.
+
+When a client connects by a name with no Kerberos SPN (an IP, or the Explorer →
+Network discovery name), Windows falls back to NTLM; DittoFS validates that NTLM
+response against a domain controller over a NETLOGON secure channel using a
+machine account. These commands report the live machine-account / secure-channel
+state and force a machine-password rotation.
+
+Unlike 'dfs netlogon test' (a self-contained probe run from the config file),
+these talk to the RUNNING server over the API and require admin credentials.
+
+**Examples:**
+
+```bash
+# Show live machine-account and secure-channel state
+dfsctl netlogon status
+
+# Force a machine-password rotation now (online-join only)
+dfsctl netlogon rotate
+```
+
+Global flags:
+
+```
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
+```
+
+### `dfsctl netlogon rotate`
+
+Force a machine-account password rotation now
+
+Force an immediate rotation of the machine-account password on the running server.
+
+Rotation applies only to the online-join provider, which owns the machine-password
+lifecycle: the new password is set on the domain controller (NetrServerPasswordSet2),
+switched in memory, and persisted — keeping the stored secret in sync with the DC.
+The offline/static provider owns no password lifecycle, so this command returns an
+error there; rotate that secret by updating the machine-account configuration.
+
+```
+dfsctl netlogon rotate
+```
+
+**Examples:**
+
+```bash
+# Rotate the machine password now
+dfsctl netlogon rotate
+```
+
+Global flags:
+
+```
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
+```
+
+### `dfsctl netlogon status`
+
+Show live NETLOGON machine-account and secure-channel state
+
+Report the live state of the NETLOGON machine account on the running server:
+the active provider (offline or online-join), the machine-account name, the
+realm / NetBIOS domain / DC binding, whether the account is joined, whether the
+secure channel is currently established, and the automatic-rotation schedule.
+
+```
+dfsctl netlogon status
+```
+
+**Examples:**
+
+```bash
+# Show status as a table
+dfsctl netlogon status
+
+# Show status as JSON
+dfsctl netlogon status -o json
 ```
 
 Global flags:

--- a/docs/guide/windows-ad-setup.md
+++ b/docs/guide/windows-ad-setup.md
@@ -305,6 +305,31 @@ secure channel (no user logon), so it isolates a machine-account/DC/Kerberos
 problem from an NTLM-logon problem. It probes the **offline** machine account;
 online join provisions on the first logon (check the server log).
 
+**Inspecting / rotating against the running server.** `dfs netlogon test` runs
+from the config file; to interrogate the **live** server instead use `dfsctl`
+(admin credentials required):
+
+```bash
+# Live machine-account and secure-channel state
+dfsctl netlogon status
+#   Provider           online-join
+#   Account            DITTOFS$
+#   Realm              CUBBIT.LOCAL
+#   Channel connected  yes
+#   Joined             yes
+#   Next rotation      2026-07-17T09:00:00Z
+
+# Force a machine-password rotation now (online-join only)
+dfsctl netlogon rotate
+```
+
+`netlogon rotate` performs the complete rotation — it sets the new password on
+the DC (NetrServerPasswordSet2), switches the in-memory credential, and persists
+the new secret — so the stored secret never drifts from the DC. It applies only
+to the **online-join** provider (which owns the password lifecycle); for the
+offline/static provider rotate the secret by updating the machine-account
+configuration instead.
+
 **Step 3 — test the NTLM path.** From a domain member, connect by **IP** (forces
 NTLM) or double-click the server in Explorer → Network:
 

--- a/internal/auth/netlogon/authenticator.go
+++ b/internal/auth/netlogon/authenticator.go
@@ -355,6 +355,19 @@ func (a *Authenticator) Close(ctx context.Context) {
 	a.reset(ctx)
 }
 
+// Connected reports whether a secure channel is currently established (cached).
+// It is best-effort introspection for `netlogon status`: the channel connects
+// lazily on the first domain logon and is torn down on reload/rotation, so a
+// false result means "no channel is cached right now", NOT "the DC is
+// unreachable". `netlogon test` (an active probe) remains the way to prove the
+// channel can be established. ensureChannel drops a channel that failed to
+// connect, so a non-nil cached channel is one that connected successfully.
+func (a *Authenticator) Connected() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.chan_ != nil
+}
+
 // ensureChannel returns the cached secureChannel, creating and connecting it if
 // needed. connect is idempotent and self-locking; a concurrent reset that clears
 // a.chan_ just causes the next call to build a fresh channel.

--- a/internal/auth/netlogon/credential.go
+++ b/internal/auth/netlogon/credential.go
@@ -100,6 +100,17 @@ func (p *MutableProvider) Credential(ctx context.Context) (*MachineCredential, e
 	return &cp, nil
 }
 
+// snapshot returns a copy of the current credential WITHOUT validation, for
+// status introspection: `netlogon status` must report the account/realm/domain
+// even when the credential is incomplete (e.g. after an API hot-reload disabled
+// passthrough by installing an empty credential), where Credential would instead
+// return a validation error.
+func (p *MutableProvider) snapshot() MachineCredential {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.cred
+}
+
 // Set atomically replaces the credential. The next Credential call (and thus the
 // next secure-channel rebuild) uses the new value. It does not itself tear down
 // any cached channel — callers that want the change to take effect immediately

--- a/internal/auth/netlogon/online.go
+++ b/internal/auth/netlogon/online.go
@@ -42,9 +42,43 @@ type onlineProvider struct {
 	secret SecretStore
 	dial   ldapDialer // swapped in tests; defaults to dialAndBindJoin
 
-	mu       sync.Mutex
-	password string // current machine password (loaded or generated)
-	joined   bool   // true once the account is provisioned + password persisted
+	mu           sync.Mutex
+	password     string    // current machine password (loaded or generated)
+	joined       bool      // true once the account is provisioned + password persisted
+	lastRotation time.Time // zero until the first successful rotation this run
+
+	// rotateMu serializes rotations so a manual `netlogon rotate` cannot race the
+	// scheduled RotationManager and set two different passwords on the DC at once
+	// (which would leave the persisted secret out of sync with whichever set won).
+	rotateMu sync.Mutex
+}
+
+// onlineSnapshot is a side-effect-free view of an onlineProvider's introspectable
+// state, used by the Controller to build a Status without triggering the lazy AD
+// join (which a Credential() call would).
+type onlineSnapshot struct {
+	account      string
+	realm        string
+	domain       string
+	dc           []string
+	joined       bool
+	lastRotation time.Time
+}
+
+// snapshot returns the provider's current introspectable state under its lock.
+// It performs no directory or DC I/O — in particular it does NOT provision the
+// account — so it is safe to call for `netlogon status` at any time.
+func (p *onlineProvider) snapshot() onlineSnapshot {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return onlineSnapshot{
+		account:      p.cfg.AccountName,
+		realm:        p.cfg.Realm,
+		domain:       p.cfg.DomainName,
+		dc:           p.cfg.DCAddresses,
+		joined:       p.joined,
+		lastRotation: p.lastRotation,
+	}
 }
 
 // NewOnlineProvider creates an online-join provider. The provider is lazy: no
@@ -136,6 +170,11 @@ func (p *onlineProvider) ensureJoinedLocked(ctx context.Context) error {
 // the DC must accept the new password before we persist/switch, or a crash
 // between steps would leave the persisted secret out of sync with the DC.
 func (p *onlineProvider) rotate(ctx context.Context, auth *Authenticator) error {
+	// Serialize concurrent rotations (scheduled timer vs. a forced `netlogon
+	// rotate`) so only one PasswordSet2 → persist sequence runs at a time.
+	p.rotateMu.Lock()
+	defer p.rotateMu.Unlock()
+
 	newPassword, err := generateMachinePassword()
 	if err != nil {
 		return err
@@ -152,6 +191,7 @@ func (p *onlineProvider) rotate(ctx context.Context, auth *Authenticator) error 
 	// expects — keeping the old one would break all NTLM passthrough).
 	p.mu.Lock()
 	p.password = newPassword
+	p.lastRotation = time.Now()
 	p.mu.Unlock()
 
 	// Then persist so the new secret survives a restart.
@@ -185,6 +225,9 @@ type RotationManager struct {
 	startOnce sync.Once
 	stopOnce  sync.Once
 	started   atomic.Bool
+	// startedAt is the UnixNano at which the ticker started, so nextRotation can
+	// project the fixed-cadence firing schedule for `netlogon status`.
+	startedAt atomic.Int64
 }
 
 // NewRotationManager wires an online provider to its authenticator for periodic
@@ -211,9 +254,26 @@ func (m *RotationManager) Start() {
 		return
 	}
 	m.startOnce.Do(func() {
+		m.startedAt.Store(time.Now().UnixNano())
 		m.started.Store(true)
 		go m.run()
 	})
+}
+
+// nextRotation projects the next scheduled rotation time from the ticker's fixed
+// cadence (startedAt + k*interval). It returns the zero time when the manager is
+// nil or was never started, so `netlogon status` can report "not scheduled".
+func (m *RotationManager) nextRotation() time.Time {
+	if m == nil || !m.started.Load() {
+		return time.Time{}
+	}
+	start := time.Unix(0, m.startedAt.Load())
+	now := time.Now()
+	if !now.After(start) {
+		return start.Add(m.interval)
+	}
+	n := now.Sub(start) / m.interval
+	return start.Add((n + 1) * m.interval)
 }
 
 func (m *RotationManager) run() {

--- a/internal/auth/netlogon/status.go
+++ b/internal/auth/netlogon/status.go
@@ -133,5 +133,13 @@ func (c *Controller) Rotate(ctx context.Context) error {
 	if !ok {
 		return ErrRotateNotOnlineJoin
 	}
+	// Detach from the caller's context so a client-side cancellation — a dropped
+	// connection or the apiclient's 30s deadline — cannot abort the rotation
+	// *between* PasswordSet2 on the DC and persisting the new secret, which would
+	// leave the stored secret out of sync with the DC (the exact desync this path
+	// exists to prevent). Mirror the scheduled rotation's own fresh 2-minute
+	// context (RotationManager.run).
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
+	defer cancel()
 	return op.rotate(ctx, c.auth)
 }

--- a/internal/auth/netlogon/status.go
+++ b/internal/auth/netlogon/status.go
@@ -1,0 +1,137 @@
+package netlogon
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ProviderKind identifies which machine-credential provider backs a running
+// NETLOGON authenticator, as reported by `dfsctl netlogon status`.
+type ProviderKind string
+
+const (
+	// ProviderOffline is the static, admin-supplied machine secret (hot-reloadable
+	// over the API, #1325). It owns no password lifecycle, so rotation does not
+	// apply — the admin rotates it by updating the machine-account config.
+	ProviderOffline ProviderKind = "offline"
+	// ProviderOnlineJoin provisions the computer object in AD and owns the
+	// machine-password lifecycle (generate, persist, rotate), so rotation applies.
+	ProviderOnlineJoin ProviderKind = "online-join"
+)
+
+// ErrRotateNotOnlineJoin is returned by Controller.Rotate for a provider that
+// does not own the machine password (the offline/static provider). Rotation is
+// only meaningful for the online-join provider, which generates and persists the
+// password it sets on the DC; for the offline provider the admin owns the secret
+// and rotates it by updating the machine-account configuration instead.
+var ErrRotateNotOnlineJoin = errors.New("netlogon: machine-password rotation is only supported for the online-join provider")
+
+// Status is a point-in-time snapshot of the NETLOGON machine-account and
+// secure-channel state on the running server, surfaced by `dfsctl netlogon
+// status`. It is built without directory or DC I/O.
+type Status struct {
+	// Provider is the active machine-credential provider ("offline" or
+	// "online-join").
+	Provider ProviderKind
+	// AccountName is the machine-account sAMAccountName (e.g. "DITTOFS$").
+	AccountName string
+	// Realm is the Kerberos realm.
+	Realm string
+	// NetBIOSDomain is the short NetBIOS domain name.
+	NetBIOSDomain string
+	// DCAddresses are the configured DC addresses (empty means "discover via DNS
+	// SRV from the realm").
+	DCAddresses []string
+	// Joined reports, for the online-join provider, whether the computer object
+	// has been provisioned and its password persisted this run. It is always
+	// false for the offline provider (which has no provisioning step).
+	Joined bool
+	// ChannelConnected reports whether a NETLOGON secure channel is currently
+	// established (cached). Best-effort — see Authenticator.Connected.
+	ChannelConnected bool
+	// RotationEnabled reports whether automatic machine-password rotation is
+	// scheduled (online-join with a positive rotation interval).
+	RotationEnabled bool
+	// RotationInterval is the configured automatic-rotation period (zero when
+	// disabled).
+	RotationInterval time.Duration
+	// LastRotation is when the machine password last rotated this run; zero when
+	// it has not rotated since startup.
+	LastRotation time.Time
+	// NextRotation is the next scheduled automatic rotation; zero when automatic
+	// rotation is disabled.
+	NextRotation time.Time
+}
+
+// Controller is the runtime handle for the NETLOGON machine-account subsystem.
+// The wiring layer registers it with the Runtime (SetAdapterProvider "netlogon")
+// so the admin API can introspect machine-account / secure-channel state and
+// force a machine-password rotation on the running server — without reaching into
+// the SMB adapter or the process-local authenticator.
+//
+// It bundles the pieces the API needs but that live in different places: the
+// Authenticator (channel health), the credential provider (account identity /
+// join state), and the optional RotationManager (rotation schedule).
+type Controller struct {
+	kind     ProviderKind
+	auth     *Authenticator
+	provider MachineCredentialProvider
+	rot      *RotationManager // nil for offline, or online-join with rotation disabled
+}
+
+// NewController builds the runtime handle. kind must match provider's concrete
+// type; rot may be nil (offline, or online-join with automatic rotation
+// disabled). auth and provider must be non-nil.
+func NewController(kind ProviderKind, auth *Authenticator, provider MachineCredentialProvider, rot *RotationManager) *Controller {
+	return &Controller{kind: kind, auth: auth, provider: provider, rot: rot}
+}
+
+// Status returns a non-intrusive snapshot of the current machine-account and
+// secure-channel state. It performs no directory or DC I/O: in particular it
+// never calls the online provider's Credential (which would trigger the lazy AD
+// join as a side effect), reading the provider's cached fields via snapshot
+// instead.
+func (c *Controller) Status(context.Context) Status {
+	s := Status{Provider: c.kind}
+	if c.auth != nil {
+		s.ChannelConnected = c.auth.Connected()
+	}
+	switch p := c.provider.(type) {
+	case *onlineProvider:
+		snap := p.snapshot()
+		s.AccountName = snap.account
+		s.Realm = snap.realm
+		s.NetBIOSDomain = snap.domain
+		s.DCAddresses = snap.dc
+		s.Joined = snap.joined
+		s.LastRotation = snap.lastRotation
+		if c.rot != nil {
+			s.RotationEnabled = true
+			s.RotationInterval = c.rot.interval
+			s.NextRotation = c.rot.nextRotation()
+		}
+	case *MutableProvider:
+		cred := p.snapshot()
+		s.AccountName = cred.AccountName
+		s.Realm = cred.Realm
+		s.NetBIOSDomain = cred.DomainName
+		s.DCAddresses = cred.DCAddresses
+	}
+	return s
+}
+
+// Rotate forces a machine-password rotation now. It is valid only for the
+// online-join provider, which owns the password lifecycle: it runs the COMPLETE
+// rotation (PasswordSet2 on the DC → switch the in-memory credential → persist),
+// keeping the persisted secret in sync with the DC. Rotating the DC password
+// alone (Authenticator.RotatePassword) would desync the persisted secret, so this
+// deliberately routes through the provider's rotate. For the offline/static
+// provider it returns ErrRotateNotOnlineJoin.
+func (c *Controller) Rotate(ctx context.Context) error {
+	op, ok := c.provider.(*onlineProvider)
+	if !ok {
+		return ErrRotateNotOnlineJoin
+	}
+	return op.rotate(ctx, c.auth)
+}

--- a/internal/auth/netlogon/status_test.go
+++ b/internal/auth/netlogon/status_test.go
@@ -1,0 +1,165 @@
+package netlogon
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestController_OfflineStatusAndRotate verifies the offline provider's status
+// snapshot reflects the static credential, tracks channel connectivity, and that
+// Rotate is rejected (the admin owns the static secret).
+func TestController_OfflineStatusAndRotate(t *testing.T) {
+	st := &fakeState{}
+	withFakeChannels(t, st)
+
+	prov := NewMutableProvider(validCred("DITTOFS$"))
+	auth := NewAuthenticator(prov)
+	ctrl := NewController(ProviderOffline, auth, prov, nil)
+	ctx := context.Background()
+
+	s := ctrl.Status(ctx)
+	if s.Provider != ProviderOffline {
+		t.Errorf("provider = %q, want offline", s.Provider)
+	}
+	if s.AccountName != "DITTOFS$" || s.Realm != "DITTOFS.AD" || s.NetBIOSDomain != "DITTOFS" {
+		t.Errorf("unexpected status identity: %+v", s)
+	}
+	if s.ChannelConnected {
+		t.Error("no channel should be connected before the first logon")
+	}
+	if s.RotationEnabled {
+		t.Error("offline provider must never report rotation enabled")
+	}
+
+	// A logon establishes the cached channel; status must then report connected.
+	if _, err := auth.NetworkLogon(ctx, NetworkLogonRequest{Username: "alice", Domain: "DITTOFS"}); err != nil {
+		t.Fatalf("logon: %v", err)
+	}
+	if !ctrl.Status(ctx).ChannelConnected {
+		t.Error("channel should be reported connected after a successful logon")
+	}
+
+	// Rotate is not applicable to the static provider.
+	if err := ctrl.Rotate(ctx); !errors.Is(err, ErrRotateNotOnlineJoin) {
+		t.Errorf("Rotate() error = %v, want ErrRotateNotOnlineJoin", err)
+	}
+}
+
+// TestController_OfflineStatusReportsIncompleteCredential proves Status reads the
+// live MutableProvider snapshot WITHOUT validation, so a passthrough-disabling
+// hot-reload (empty credential) is still introspectable rather than erroring.
+func TestController_OfflineStatusReportsIncompleteCredential(t *testing.T) {
+	prov := NewMutableProvider(MachineCredential{}) // incomplete: Credential() would error
+	ctrl := NewController(ProviderOffline, NewAuthenticator(prov), prov, nil)
+
+	s := ctrl.Status(context.Background())
+	if s.Provider != ProviderOffline {
+		t.Errorf("provider = %q, want offline", s.Provider)
+	}
+	if s.AccountName != "" {
+		t.Errorf("account = %q, want empty for a disabled/incomplete credential", s.AccountName)
+	}
+}
+
+// TestController_OnlineStatusDoesNotJoin proves Status never triggers the lazy AD
+// join: a fresh online provider reports joined=false and performs no dial.
+func TestController_OnlineStatusDoesNotJoin(t *testing.T) {
+	fake := &fakeLDAP{}
+	var dialN int
+	prov := &onlineProvider{cfg: onlineCfg(), secret: &memSecretStore{}, dial: countingDial(fake, &dialN)}
+	ctrl := NewController(ProviderOnlineJoin, NewAuthenticator(prov), prov, nil)
+
+	s := ctrl.Status(context.Background())
+	if s.Provider != ProviderOnlineJoin {
+		t.Errorf("provider = %q, want online-join", s.Provider)
+	}
+	if s.AccountName != "DITTOFS$" || s.Realm != "DITTOFS.AD" || s.NetBIOSDomain != "DITTOFS" {
+		t.Errorf("unexpected status identity: %+v", s)
+	}
+	if s.Joined {
+		t.Error("Status must not perform the lazy join")
+	}
+	if dialN != 0 {
+		t.Errorf("Status must not dial LDAP; dialed %d times", dialN)
+	}
+	if !s.LastRotation.IsZero() {
+		t.Error("LastRotation should be zero before any rotation")
+	}
+}
+
+// TestController_OnlineRotatePersistsAndSwitches verifies the COMPLETE rotation
+// through the Controller: the DC set succeeds, the in-memory password switches,
+// the secret is persisted, and status reflects the last-rotation time.
+func TestController_OnlineRotatePersistsAndSwitches(t *testing.T) {
+	st := &fakeState{}
+	withFakeChannels(t, st)
+
+	fake := &fakeLDAP{}
+	secret := &memSecretStore{}
+	var dialN int
+	prov := &onlineProvider{cfg: onlineCfg(), secret: secret, dial: countingDial(fake, &dialN)}
+	auth := NewAuthenticator(prov)
+	ctrl := NewController(ProviderOnlineJoin, auth, prov, nil)
+	ctx := context.Background()
+
+	// Join first (persists the initial generated password).
+	cred, err := prov.Credential(ctx)
+	if err != nil {
+		t.Fatalf("initial join: %v", err)
+	}
+	initialPass := cred.Password
+	if secret.val != initialPass {
+		t.Fatalf("persisted secret %q != initial password %q", secret.val, initialPass)
+	}
+	if !ctrl.Status(ctx).Joined {
+		t.Fatal("expected joined=true after the initial Credential call")
+	}
+
+	before := time.Now()
+	if err := ctrl.Rotate(ctx); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+
+	// The in-memory credential must now be the NEW password, and the persisted
+	// secret must match it (no desync between the DC-set value and the store).
+	rotated, err := prov.Credential(ctx)
+	if err != nil {
+		t.Fatalf("post-rotate Credential: %v", err)
+	}
+	if rotated.Password == initialPass {
+		t.Error("password did not change after rotation")
+	}
+	if secret.val != rotated.Password {
+		t.Errorf("persisted secret %q != rotated in-memory password %q (desync)", secret.val, rotated.Password)
+	}
+
+	s := ctrl.Status(ctx)
+	if s.LastRotation.IsZero() || s.LastRotation.Before(before) {
+		t.Errorf("LastRotation not updated: %v", s.LastRotation)
+	}
+}
+
+// TestRotationManager_NextRotationSchedule verifies nextRotation projects the
+// ticker cadence once started, and is zero before Start.
+func TestRotationManager_NextRotationSchedule(t *testing.T) {
+	online := NewOnlineProvider(onlineCfg(), &memSecretStore{})
+	m := NewRotationManager(online, NewAuthenticator(online), time.Hour)
+	if m == nil {
+		t.Fatal("expected non-nil rotation manager for a positive interval")
+	}
+	if !m.nextRotation().IsZero() {
+		t.Error("nextRotation must be zero before Start")
+	}
+	m.Start()
+	defer m.Stop()
+	next := m.nextRotation()
+	if next.IsZero() {
+		t.Fatal("nextRotation must be set after Start")
+	}
+	// The next fire is within one interval of now.
+	if d := time.Until(next); d <= 0 || d > time.Hour+time.Second {
+		t.Errorf("next rotation %v is not within one interval (%v from now)", next, d)
+	}
+}

--- a/internal/controlplane/api/handlers/netlogon.go
+++ b/internal/controlplane/api/handlers/netlogon.go
@@ -83,9 +83,15 @@ func (h *NetlogonHandler) Rotate(w http.ResponseWriter, r *http.Request) {
 
 // netlogonStatusToDTO maps the domain Status onto the wire DTO, formatting times
 // as RFC3339 (empty when zero) and the interval as a Go duration string.
+//
+// Enabled is derived from a non-empty account name rather than hard-coded: a
+// controller is only registered when pass-through is configured, but the offline
+// MutableProvider can be cleared to an empty MachineCredential via #1325
+// hot-reload, which effectively disables pass-through — that must surface as
+// enabled=false, not a stale true.
 func netlogonStatusToDTO(s netlogon.Status) netlogonStatusDTO {
 	dto := netlogonStatusDTO{
-		Enabled:          true,
+		Enabled:          s.AccountName != "",
 		Provider:         string(s.Provider),
 		AccountName:      s.AccountName,
 		Realm:            s.Realm,

--- a/internal/controlplane/api/handlers/netlogon.go
+++ b/internal/controlplane/api/handlers/netlogon.go
@@ -1,0 +1,108 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/auth/netlogon"
+)
+
+// NetlogonHandler serves the admin-only NETLOGON machine-account API: it reports
+// live machine-account / secure-channel state and forces a machine-password
+// rotation on the running server (#1631). It is backed by the netlogon.Controller
+// the wiring layer registers with the Runtime, so it never reaches into the SMB
+// adapter or the process-local authenticator.
+type NetlogonHandler struct {
+	ctrl *netlogon.Controller
+}
+
+// NewNetlogonHandler constructs a NetlogonHandler. Returns nil when ctrl is nil
+// (NTLM pass-through not configured), so the router can skip mounting the routes
+// and the API cleanly 404s instead of exposing a dead surface.
+func NewNetlogonHandler(ctrl *netlogon.Controller) *NetlogonHandler {
+	if ctrl == nil {
+		return nil
+	}
+	return &NetlogonHandler{ctrl: ctrl}
+}
+
+// netlogonStatusDTO is the wire shape of `netlogon status`. Times are RFC3339
+// strings, omitted when zero (never rotated / rotation disabled), so a client
+// renders "-" rather than the Go zero time.
+type netlogonStatusDTO struct {
+	Enabled          bool     `json:"enabled"`
+	Provider         string   `json:"provider"`
+	AccountName      string   `json:"account_name,omitempty"`
+	Realm            string   `json:"realm,omitempty"`
+	NetBIOSDomain    string   `json:"netbios_domain,omitempty"`
+	DCAddresses      []string `json:"dc_addresses,omitempty"`
+	Joined           bool     `json:"joined"`
+	ChannelConnected bool     `json:"channel_connected"`
+	RotationEnabled  bool     `json:"rotation_enabled"`
+	RotationInterval string   `json:"rotation_interval,omitempty"`
+	LastRotation     string   `json:"last_rotation,omitempty"`
+	NextRotation     string   `json:"next_rotation,omitempty"`
+}
+
+// netlogonRotateResultDTO is the wire shape of a successful `netlogon rotate`: it
+// echoes the post-rotation status so the operator sees the new state in one call.
+type netlogonRotateResultDTO struct {
+	OK      bool              `json:"ok"`
+	Message string            `json:"message"`
+	Status  netlogonStatusDTO `json:"status"`
+}
+
+// Status reports live machine-account and secure-channel state. It performs no
+// DC I/O (in particular it never provisions the online-join account).
+func (h *NetlogonHandler) Status(w http.ResponseWriter, r *http.Request) {
+	WriteJSONOK(w, netlogonStatusToDTO(h.ctrl.Status(r.Context())))
+}
+
+// Rotate forces a correct (PasswordSet2 → switch → persist) machine-password
+// rotation now. It applies only to the online-join provider; for the offline
+// provider it returns 409 Conflict with a clear message.
+func (h *NetlogonHandler) Rotate(w http.ResponseWriter, r *http.Request) {
+	if err := h.ctrl.Rotate(r.Context()); err != nil {
+		if errors.Is(err, netlogon.ErrRotateNotOnlineJoin) {
+			// Expected, caller-actionable condition: not a server fault.
+			Conflict(w, err.Error())
+			return
+		}
+		// Unexpected: the DC rejected the set, or persistence failed.
+		InternalServerError(w, fmt.Sprintf("machine-password rotation failed: %v", err))
+		return
+	}
+	WriteJSONOK(w, netlogonRotateResultDTO{
+		OK:      true,
+		Message: "machine-account password rotated",
+		Status:  netlogonStatusToDTO(h.ctrl.Status(r.Context())),
+	})
+}
+
+// netlogonStatusToDTO maps the domain Status onto the wire DTO, formatting times
+// as RFC3339 (empty when zero) and the interval as a Go duration string.
+func netlogonStatusToDTO(s netlogon.Status) netlogonStatusDTO {
+	dto := netlogonStatusDTO{
+		Enabled:          true,
+		Provider:         string(s.Provider),
+		AccountName:      s.AccountName,
+		Realm:            s.Realm,
+		NetBIOSDomain:    s.NetBIOSDomain,
+		DCAddresses:      s.DCAddresses,
+		Joined:           s.Joined,
+		ChannelConnected: s.ChannelConnected,
+		RotationEnabled:  s.RotationEnabled,
+	}
+	if s.RotationInterval > 0 {
+		dto.RotationInterval = s.RotationInterval.String()
+	}
+	if !s.LastRotation.IsZero() {
+		dto.LastRotation = s.LastRotation.UTC().Format(time.RFC3339)
+	}
+	if !s.NextRotation.IsZero() {
+		dto.NextRotation = s.NextRotation.UTC().Format(time.RFC3339)
+	}
+	return dto
+}

--- a/internal/controlplane/api/handlers/netlogon_test.go
+++ b/internal/controlplane/api/handlers/netlogon_test.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/auth/netlogon"
+)
+
+// TestNewNetlogonHandler_NilController verifies the constructor returns nil when
+// no controller is registered, so the router can skip mounting the routes.
+func TestNewNetlogonHandler_NilController(t *testing.T) {
+	if h := NewNetlogonHandler(nil); h != nil {
+		t.Fatalf("expected nil handler for nil controller, got %v", h)
+	}
+}
+
+// TestNetlogonHandler_StatusOffline verifies the status endpoint reports the
+// offline provider identity and marks pass-through enabled.
+func TestNetlogonHandler_StatusOffline(t *testing.T) {
+	prov := netlogon.NewMutableProvider(netlogon.BuildMachineCredential("DITTOFS$", "s3cr3t", "DITTOFS", "DITTOFS.AD", nil))
+	ctrl := netlogon.NewController(netlogon.ProviderOffline, netlogon.NewAuthenticator(prov), prov, nil)
+	h := NewNetlogonHandler(ctrl)
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	h.Status(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want 200", w.Code)
+	}
+	var dto netlogonStatusDTO
+	if err := json.Unmarshal(w.Body.Bytes(), &dto); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !dto.Enabled || dto.Provider != "offline" {
+		t.Errorf("unexpected status: %+v", dto)
+	}
+	if dto.AccountName != "DITTOFS$" || dto.Realm != "DITTOFS.AD" || dto.NetBIOSDomain != "DITTOFS" {
+		t.Errorf("unexpected identity: %+v", dto)
+	}
+	if dto.RotationEnabled {
+		t.Error("offline provider must not report rotation enabled")
+	}
+}
+
+// TestNetlogonHandler_RotateOfflineConflict verifies rotating the offline
+// provider yields a 409 Conflict (rotation is only valid for online-join).
+func TestNetlogonHandler_RotateOfflineConflict(t *testing.T) {
+	prov := netlogon.NewMutableProvider(netlogon.BuildMachineCredential("DITTOFS$", "s3cr3t", "DITTOFS", "DITTOFS.AD", nil))
+	ctrl := netlogon.NewController(netlogon.ProviderOffline, netlogon.NewAuthenticator(prov), prov, nil)
+	h := NewNetlogonHandler(ctrl)
+
+	r := httptest.NewRequest(http.MethodPost, "/", nil)
+	w := httptest.NewRecorder()
+	h.Rotate(w, r)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status code = %d, want 409", w.Code)
+	}
+}

--- a/pkg/apiclient/netlogon.go
+++ b/pkg/apiclient/netlogon.go
@@ -1,0 +1,49 @@
+package apiclient
+
+// NetlogonStatus reports the live NETLOGON machine-account and secure-channel
+// state as returned by GetNetlogonStatus. Times are RFC3339 strings and are
+// empty when not applicable (never rotated / rotation disabled).
+type NetlogonStatus struct {
+	Enabled          bool     `json:"enabled"`
+	Provider         string   `json:"provider"` // "offline" | "online-join"
+	AccountName      string   `json:"account_name,omitempty"`
+	Realm            string   `json:"realm,omitempty"`
+	NetBIOSDomain    string   `json:"netbios_domain,omitempty"`
+	DCAddresses      []string `json:"dc_addresses,omitempty"`
+	Joined           bool     `json:"joined"`
+	ChannelConnected bool     `json:"channel_connected"`
+	RotationEnabled  bool     `json:"rotation_enabled"`
+	RotationInterval string   `json:"rotation_interval,omitempty"`
+	LastRotation     string   `json:"last_rotation,omitempty"`
+	NextRotation     string   `json:"next_rotation,omitempty"`
+}
+
+// NetlogonRotateResult is the outcome of a forced machine-password rotation,
+// carrying the post-rotation status.
+type NetlogonRotateResult struct {
+	OK      bool           `json:"ok"`
+	Message string         `json:"message"`
+	Status  NetlogonStatus `json:"status"`
+}
+
+// GetNetlogonStatus returns the live NETLOGON machine-account / secure-channel
+// state (admin only). Returns a 404 APIError when NTLM pass-through is not
+// configured on the server.
+func (c *Client) GetNetlogonStatus() (*NetlogonStatus, error) {
+	var out NetlogonStatus
+	if err := c.get("/api/v1/netlogon/status", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// RotateNetlogon forces a machine-password rotation now (admin only). It is only
+// valid for the online-join provider; for the offline/static provider the server
+// returns a 409 APIError.
+func (c *Client) RotateNetlogon() (*NetlogonRotateResult, error) {
+	var out NetlogonRotateResult
+	if err := c.post("/api/v1/netlogon/rotate", nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -499,6 +499,20 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 				r.Post("/{type}/test", idpHandler.Test)
 			})
 
+			// NETLOGON machine-account (NTLM pass-through) status + rotation
+			// against the running server — admin only. Mounted only when
+			// pass-through is configured (the controller is registered at
+			// startup); otherwise the routes cleanly 404.
+			if rt != nil {
+				if nlHandler := handlers.NewNetlogonHandler(rt.NetlogonController()); nlHandler != nil {
+					r.Route("/netlogon", func(r chi.Router) {
+						r.Use(apiMiddleware.RequireAdmin())
+						r.Get("/status", nlHandler.Status)
+						r.Post("/rotate", nlHandler.Rotate)
+					})
+				}
+			}
+
 			// Unified client listing and disconnect (admin only) - all protocols
 			if clientHandler := handlers.NewClientHandler(rt); clientHandler != nil {
 				r.Route("/clients", func(r chi.Router) {

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -1069,6 +1069,25 @@ func (r *Runtime) NetlogonCredential() *netlogon.MachineCredential {
 	return r.netlogonCredential
 }
 
+// netlogonControllerKey is the adapter-provider key under which the NETLOGON
+// machine-account controller is registered (#1631).
+const netlogonControllerKey = "netlogon"
+
+// SetNetlogonController registers the NETLOGON machine-account controller so the
+// admin API (`netlogon status` / `netlogon rotate`) can introspect and rotate the
+// machine account on the running server. Set once at startup when passthrough is
+// configured; a nil-controller process simply never registers one.
+func (r *Runtime) SetNetlogonController(c *netlogon.Controller) {
+	r.SetAdapterProvider(netlogonControllerKey, c)
+}
+
+// NetlogonController returns the registered NETLOGON machine-account controller,
+// or nil when passthrough is not configured on this server.
+func (r *Runtime) NetlogonController() *netlogon.Controller {
+	c, _ := r.GetAdapterProvider(netlogonControllerKey).(*netlogon.Controller)
+	return c
+}
+
 // OnIdentityMappingChange registers a callback invoked when identity mappings
 // are created or deleted via the API. Adapters use this to invalidate their
 // identity resolver caches. Returns an unsubscribe function.


### PR DESCRIPTION
## Summary

Closes #1631. Follow-up to #1629. Adds the operator surface for the NETLOGON machine account against the **running** server: `dfsctl netlogon status` and `dfsctl netlogon rotate`. Previously the machine-account join/rotation was invisible at runtime (online-join fires lazily on the first domain logon; the password rotates on a timer) with no way to inspect state or force a rotation without reading the server log.

## Commands

```
$ dfsctl netlogon status          # enabled, provider (offline/online-join), account,
                                  # realm/NetBIOS/DC, joined?, channel health, last/next rotation
$ dfsctl netlogon rotate          # force a correct (PasswordSet2 + persist) machine-password rotation
```

`status` is **non-intrusive** — it reads cached provider state and never calls `Credential()`, so it cannot trigger the lazy AD join. `rotate` is valid only for the online-join provider (which owns the password lifecycle); the offline/static provider returns a clear error (HTTP 409).

## Wiring (full stack)

- **netlogon introspection** (`internal/auth/netlogon`): `Authenticator.Connected()`, side-effect-free `onlineProvider.snapshot()` / `MutableProvider.snapshot()`, `RotationManager.nextRotation()`, and a `Controller` (status.go) bundling auth + provider + rotation.
- `online.go`: `rotate()` records `lastRotation` under a new `rotateMu` so a manual rotate can't race the scheduled timer into a DC/persist desync.
- **Runtime exposure**: `buildNetlogonAuthenticator` returns a `*Controller`; `start.go` registers it via `rt.SetNetlogonController(...)` → `SetAdapterProvider("netlogon", ...)` (mirrors the NFS-client-provider pattern).
- **Admin API**: `GET /api/v1/netlogon/status`, `POST /api/v1/netlogon/rotate` under `RequireAdmin()` (mounted only when a controller is registered); apiclient DTOs; dfsctl commands. CLI docs regenerated.

## Rotate correctness

`Controller.Rotate` routes through `onlineProvider.rotate` — the COMPLETE rotation (PasswordSet2 on the DC → switch the in-memory credential → persist) — never the bare `Authenticator.RotatePassword` (which would set the DC password without persisting, desyncing the stored secret). Per code review, the rotation now also runs under a **detached context** (`context.WithoutCancel` + a 2-minute timeout, mirroring the scheduler) so a client-side cancellation (dropped connection / the apiclient 30s deadline) can't abort it between the DC set and the persist and leave the stored secret out of sync.

## Tests

`status_test.go` (offline/online status, the no-join guarantee, complete-rotation persist+switch, next-rotation schedule) and `handlers/netlogon_test.go` (nil-controller 404, offline status, offline rotate → 409). `go build ./...`, `go vet ./...`, and the netlogon / api-handler / dfsctl / apiclient test suites all green.

## Validation

Live-validated on a real Windows AD DC (cubbit.local, online-join provider): `dfsctl netlogon status` showed `provider=online-join`, `Joined=no` **before** any logon (proving the non-intrusive read), and `dfsctl netlogon rotate` performed a real online-join (`DITTOFS-OJ$` provisioned + persisted) followed by `NetrServerPasswordSet2` — HTTP 200, `Last rotation` stamped, repeatable across restarts.
