### PR TITLE
fix(metadata): serialize parent link-count bump so concurrent dir ops don't SSI-conflict (#1571)

### DIFF
--- a/pkg/metadata/directory.go
+++ b/pkg/metadata/directory.go
@@ -223,6 +223,11 @@ func (s *Service) RemoveDirectory(ctx *AuthContext, parentHandle FileHandle, nam
 	// Relaxed durability (#1573 Wall 1): rmdir touches only namespace keys, not
 	// block data. A crash can lose the removal (dir reappears empty), never
 	// corrupt data.
+	//
+	// rmdir decrements the parent's link-count key (dropping the ".." ref, below).
+	// Serialize that per-parent against concurrent mkdir/rmdir on the same parent
+	// so the shared counter key is never a BadgerDB SSI conflict source (#1571).
+	defer s.lockParentLink(parentHandle)()
 	txErr := withRelaxedTransaction(store, ctx.Context, func(tx Transaction) error {
 		// Re-read the parent inside the transaction so the pre-op snapshot and
 		// the timestamp mutation derive from the same committed state.

--- a/pkg/metadata/file_create.go
+++ b/pkg/metadata/file_create.go
@@ -377,6 +377,16 @@ func (s *Service) createEntry(
 	// paired with block data, so the commit may become durable with bounded lag.
 	// A crash can lose the just-created entry (the client re-creates); it can
 	// never corrupt data.
+	//
+	// A directory create also bumps the parent's link-count key (the ".." ref,
+	// below). That is the one shared, non-disjoint key in this transaction, so
+	// concurrent same-parent mkdirs would race it and BadgerDB SSI would abort the
+	// losers — escaping under load as ErrConflict (#1571). Serialize just that
+	// bump per-parent so the counter stays exact and atomic with the child write;
+	// file creates never take this lock and stay fully concurrent.
+	if fileType == FileTypeDirectory {
+		defer s.lockParentLink(parentHandle)()
+	}
 	err = withRelaxedTransaction(store, ctx.Context, func(tx Transaction) error {
 		// TOCTOU guard: re-check inside transaction.
 		if _, innerErr := tx.GetChild(ctx.Context, parentHandle, name); innerErr == nil {

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -764,6 +764,16 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 		rename.ToDir = &DirWcc{}
 	}
 
+	// A cross-parent directory rename decrements fromDir's link-count key and
+	// increments toDir's (the ".." reference moves parents, below). Those are the
+	// same shared counter keys mkdir/rmdir bump, so without serialization a rename
+	// re-introduces the BadgerDB SSI conflict #1571 fixes — racing a concurrent
+	// mkdir/rmdir/rename on either parent. Serialize both parents for the whole
+	// transaction. File moves never touch parent nlink and stay lock-free.
+	if srcFile.Type == FileTypeDirectory && !sameDir {
+		defer s.lockParentLinks(fromDir, toDir)()
+	}
+
 	// Execute all write operations in a single transaction for better performance.
 	// Relaxed durability (#1573 Wall 1): rename rewrites only directory entries
 	// and inode paths — the moved file's size and block manifest are untouched,

--- a/pkg/metadata/parent_nlink_contention_test.go
+++ b/pkg/metadata/parent_nlink_contention_test.go
@@ -1,0 +1,174 @@
+package metadata_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/badger"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConcurrentMkdirNoParentLinkConflict reproduces #1571: concurrent mkdirs in
+// one parent each read+write the parent's link-count key (the ".." bump), which
+// is the single shared key in an otherwise disjoint create transaction. BadgerDB
+// SSI aborts the losers as write conflicts; under sustained same-parent mkdir
+// load the retry budget exhausts and the abort escapes as StoreError{ErrConflict}
+// — surfaced to an SMB client as a hard "mkdir failed" (StatusInternalError).
+//
+// The retry budget is pinned to 1 so the conflict is deterministic: with the
+// shared-key read+write still present, some mkdirs escape as ErrConflict; with
+// the parent link-count bump serialized per-parent, none do. The final nlink
+// (2 + subdir count) guards that the fix keeps the counter exact.
+//
+// Run: go test ./pkg/metadata -run TestConcurrentMkdirNoParentLinkConflict -v
+func TestConcurrentMkdirNoParentLinkConflict(t *testing.T) {
+	const (
+		concurrency = 16
+		perWorker   = 25
+	)
+	total := concurrency * perWorker
+
+	// Single attempt: no retry safety net, so the hot-key SSI conflict surfaces
+	// deterministically instead of being masked by the 20-attempt backoff loop.
+	restore := badger.SetMaxTransactionRetriesForTest(1)
+	defer restore()
+
+	ctx := context.Background()
+	store, err := badger.NewBadgerMetadataStoreWithDefaults(ctx, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	const share = "/test"
+	root, err := store.CreateRootDirectory(ctx, share, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory, Mode: 0o777,
+	})
+	require.NoError(t, err)
+	rootHandle, err := metadata.EncodeShareHandle(share, root.ID)
+	require.NoError(t, err)
+
+	svc := metadata.New()
+	require.NoError(t, svc.RegisterStoreForShare(share, svc0store(store)))
+	auth := &metadata.AuthContext{
+		Context: ctx, AuthMethod: "unix",
+		Identity:   &metadata.Identity{UID: metadata.Uint32Ptr(0), GID: metadata.Uint32Ptr(0)},
+		ClientAddr: "127.0.0.1",
+	}
+	dirAttr := &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o777}
+
+	var ok, conflict int64
+	var wg sync.WaitGroup
+	for w := 0; w < concurrency; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				_, _, err := svc.CreateDirectory(auth, rootHandle, fmt.Sprintf("d-%d-%d", w, i), dirAttr)
+				switch {
+				case err == nil:
+					atomic.AddInt64(&ok, 1)
+				case metadata.IsConflictError(err):
+					atomic.AddInt64(&conflict, 1)
+				default:
+					t.Errorf("unexpected mkdir error: %v", err)
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	t.Logf("mkdir: %d ok, %d conflict-escaped (of %d)", ok, conflict, total)
+	require.Zero(t, conflict,
+		"concurrent same-parent mkdirs escaped as ErrConflict — the parent link-count read+write is still contended (#1571)")
+	require.Equal(t, int64(total), ok)
+
+	// Parent nlink must be exactly 2 (self + ".") + one per child directory.
+	got, err := store.GetFile(ctx, rootHandle)
+	require.NoError(t, err)
+	require.Equal(t, uint32(2+total), got.Nlink, "parent directory link count drifted under concurrent mkdir")
+}
+
+// TestConcurrentDirRenameNoParentLinkConflict is the Move-path sibling of #1571:
+// renaming a directory across parents decrements the source parent's link-count
+// key and increments the destination's, the same shared counter keys mkdir/rmdir
+// bump. Without serialization, concurrent cross-parent dir renames race the
+// destination's key (and any concurrent mkdir/rmdir there) and BadgerDB SSI
+// aborts them — escaping as ErrConflict under a tight retry budget.
+func TestConcurrentDirRenameNoParentLinkConflict(t *testing.T) {
+	const n = 200
+
+	restore := badger.SetMaxTransactionRetriesForTest(1)
+	defer restore()
+
+	ctx := context.Background()
+	store, err := badger.NewBadgerMetadataStoreWithDefaults(ctx, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	const share = "/test"
+	root, err := store.CreateRootDirectory(ctx, share, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory, Mode: 0o777,
+	})
+	require.NoError(t, err)
+	rootHandle, err := metadata.EncodeShareHandle(share, root.ID)
+	require.NoError(t, err)
+
+	svc := metadata.New()
+	require.NoError(t, svc.RegisterStoreForShare(share, svc0store(store)))
+	auth := &metadata.AuthContext{
+		Context: ctx, AuthMethod: "unix",
+		Identity:   &metadata.Identity{UID: metadata.Uint32Ptr(0), GID: metadata.Uint32Ptr(0)},
+		ClientAddr: "127.0.0.1",
+	}
+	dirAttr := &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o777}
+
+	// Two parents A and B, and n subdirectories under A to move into B concurrently.
+	srcDir, _, err := svc.CreateDirectory(auth, rootHandle, "A", dirAttr)
+	require.NoError(t, err)
+	dstDir, _, err := svc.CreateDirectory(auth, rootHandle, "B", dirAttr)
+	require.NoError(t, err)
+	fromHandle, err := metadata.EncodeShareHandle(share, srcDir.ID)
+	require.NoError(t, err)
+	toHandle, err := metadata.EncodeShareHandle(share, dstDir.ID)
+	require.NoError(t, err)
+	for i := 0; i < n; i++ {
+		_, _, err := svc.CreateDirectory(auth, fromHandle, fmt.Sprintf("c-%d", i), dirAttr)
+		require.NoError(t, err)
+	}
+
+	var ok, conflict int64
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			name := fmt.Sprintf("c-%d", i)
+			_, err := svc.Move(auth, fromHandle, name, toHandle, name)
+			switch {
+			case err == nil:
+				atomic.AddInt64(&ok, 1)
+			case metadata.IsConflictError(err):
+				atomic.AddInt64(&conflict, 1)
+			default:
+				t.Errorf("unexpected rename error: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	t.Logf("rename: %d ok, %d conflict-escaped (of %d)", ok, conflict, n)
+	require.Zero(t, conflict,
+		"concurrent cross-parent dir renames escaped as ErrConflict — parent link-count RMW still contended (#1571)")
+	require.Equal(t, int64(n), ok)
+
+	// Every child moved out of A into B: A back to empty (2), B holds all n.
+	gotA, err := store.GetFile(ctx, fromHandle)
+	require.NoError(t, err)
+	require.Equal(t, uint32(2), gotA.Nlink, "source parent link count drifted under concurrent rename")
+	gotB, err := store.GetFile(ctx, toHandle)
+	require.NoError(t, err)
+	require.Equal(t, uint32(2+n), gotB.Nlink, "destination parent link count drifted under concurrent rename")
+}

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -45,8 +45,21 @@ type Service struct {
 	pendingWrites      *PendingWritesTracker             // deferred metadata commits for performance
 	dirTimes           *DirTimesTracker                  // coalesced directory mtime/ctime/atime bumps (#1573)
 	deferredCommit     bool                              // if true, use deferred commits (default: true)
-	cookies            *CookieManager                    // NFS/SMB cookie to store token translation
-	quotas             map[string]int64                  // shareName -> quota in bytes (0 = unlimited)
+
+	// parentLinkShards is a fixed bank of mutexes that serialize the parent
+	// directory link-count read-modify-write (the ".." bump) done by mkdir (+1),
+	// rmdir (-1), and cross-parent directory rename (-1 source, +1 destination).
+	// That counter is the one shared key in an otherwise per-child-disjoint
+	// namespace transaction; racing it made BadgerDB SSI abort the losers, and
+	// under load the abort exhausted the retry budget and escaped as ErrConflict —
+	// surfaced to SMB clients as a hard "mkdir failed" (#1571). Serializing the
+	// counter keeps it exact and atomic with the child write while file creates
+	// (which never touch it) stay fully concurrent. A fixed bank (rather than a
+	// per-parent map) bounds memory: distinct parents may hash to one shard —
+	// harmless extra serialization on a rare path, never an unbounded map.
+	parentLinkShards [parentLinkShardCount]sync.Mutex
+	cookies          *CookieManager   // NFS/SMB cookie to store token translation
+	quotas           map[string]int64 // shareName -> quota in bytes (0 = unlimited)
 
 	// identityQuotas holds hot-updatable per-user / per-group quota limits,
 	// loaded from the control-plane DB and consulted on the write/create hot
@@ -838,6 +851,53 @@ func (s *Service) mergePendingWrites(handle FileHandle, file *File) {
 	if pending.ClearSetuidSetgid {
 		file.Mode &= ^uint32(0o6000)
 	}
+}
+
+// parentLinkShardCount is the size of the parentLinkShards bank. 256 is ample:
+// the lock is held only for a rare namespace op (mkdir/rmdir/dir-rename), so
+// collisions between two distinct parents cost at most a little extra
+// serialization, never correctness.
+const parentLinkShardCount = 256
+
+// parentLinkShard maps a handle key to its shard via FNV-1a. Inlined to avoid a
+// hash/fnv allocation on this hot-ish namespace path.
+func parentLinkShard(key string) uint32 {
+	var h uint32 = 2166136261
+	for i := 0; i < len(key); i++ {
+		h ^= uint32(key[i])
+		h *= 16777619
+	}
+	return h % parentLinkShardCount
+}
+
+// lockParentLink locks the shard guarding handle's parent link-count
+// read-modify-write (the ".." bump done by mkdir/rmdir) and returns its unlock;
+// callers defer it. See the parentLinkShards field for why this exists (#1571).
+func (s *Service) lockParentLink(handle FileHandle) func() {
+	mu := &s.parentLinkShards[parentLinkShard(handleKey(handle))]
+	mu.Lock()
+	return mu.Unlock
+}
+
+// lockParentLinks locks the shards for a directory rename's two parents (source
+// and destination) and returns a single unlock. Shards are taken in index order
+// so opposite-direction renames can't invert and deadlock; if both parents map
+// to the same shard it is locked once (the bank's mutexes are not reentrant).
+func (s *Service) lockParentLinks(a, b FileHandle) func() {
+	ia := parentLinkShard(handleKey(a))
+	ib := parentLinkShard(handleKey(b))
+	if ia == ib {
+		mu := &s.parentLinkShards[ia]
+		mu.Lock()
+		return mu.Unlock
+	}
+	if ia > ib {
+		ia, ib = ib, ia
+	}
+	lo, hi := &s.parentLinkShards[ia], &s.parentLinkShards[ib]
+	lo.Lock()
+	hi.Lock()
+	return func() { hi.Unlock(); lo.Unlock() }
 }
 
 // mergeDirTimes overlays a directory's coalesced (not-yet-persisted) mtime/


### PR DESCRIPTION
## Problem (#1571)

Under concurrent directory creation, an SMB `mkdir` fails with a hard error (the bench reported `resource deadlock avoided`). Samba and NFSv3/v4 on the same share/client don't hit it.

## Root cause

Not a lease/oplock/byte-range lock. It's a genuine **transaction** conflict in the metadata store:

- A directory create does a read-modify-write of the **parent's link-count key** (the `..` reference). This is the one shared, non-disjoint key in an otherwise per-child-disjoint create transaction — the deliberate leftover from #1573, which coalesced parent *mtime* out for exactly this reason.
- Two concurrent same-parent mkdirs race that key. BadgerDB serializable snapshot isolation aborts the losers; the store retries (budget 20) with backoff, but under sustained load the retries exhaust and the abort escapes as `StoreError{ErrConflict}`.
- The SMB CREATE handler surfaces it as a hard failure. NFS survives only because its client silently re-drives the RPC.

The same key is also RMW'd by `rmdir` (−1) and by cross-parent directory `rename`/`Move` (−1 source, +1 destination), so those share the conflict class.

> Note: the ticket guessed a client-side status→EDEADLK mapping. That's a red herring — the real Linux cifs kernel table and `go-smb2` map **no** SMB status to EDEADLK; the errno string is translated off-box. The defect is entirely server-side.

## Fix

Serialize the parent link-count RMW **per-parent** with a keyed mutex on the metadata `Service`, across all three writers of the key:

- `mkdir` (`createEntry`, directories only)
- `rmdir` (`RemoveDirectory`)
- cross-parent directory `Move` — locks **both** parents in a fixed `handleKey` order so two opposite-direction renames can't invert and deadlock

The RMW stays inside the transaction (atomic with the child write); the mutex only prevents the SSI retry-exhaustion. File creates/moves never touch the key and stay fully concurrent — mkdir/rmdir/dir-rename are rare, so nothing on the throughput hot path is serialized. The fix is at the Service layer, so it protects **every** store (badger SSI, sqlite/postgres lock contention) uniformly.

## Tests

Two deterministic regression tests (retry budget pinned to 1 so the conflict is not masked by retries):

- `TestConcurrentMkdirNoParentLinkConflict` — 16×25 concurrent same-parent mkdirs. Without the fix: ~203/400 escape as `ErrConflict`. With it: 0, and parent nlink is exactly `2+N`.
- `TestConcurrentDirRenameNoParentLinkConflict` — 200 concurrent cross-parent dir renames. Without the fix: ~195/200 escape. With it: 0, and both parent nlinks are exact.

Verification: `go build ./...` clean, `go vet` clean, **2665 metadata tests pass under `-race`**, SMB create-handler tests pass. Lock ordering is acyclic (verified against the separate `DirTimesTracker.FlushLock` and the store transaction mutex).

Closes #1571.