### PR TITLE
fix(test): use 8-char password for bob in SMB Kerberos e2e

### DIFF
--- a/test/e2e/smb3_kerberos_test.go
+++ b/test/e2e/smb3_kerberos_test.go
@@ -50,7 +50,7 @@ func TestSMB3_KerberosFeatureMatrix(t *testing.T) {
 
 	// Add user principals
 	kdc.AddPrincipal(t, "alice", "alice123")
-	kdc.AddPrincipal(t, "bob", "bob123")
+	kdc.AddPrincipal(t, "bob", "bob12345")
 
 	// Add service principals for both NFS and SMB (cifs)
 	kdc.AddServicePrincipal(t, "nfs", "localhost")
@@ -88,7 +88,7 @@ func TestSMB3_KerberosFeatureMatrix(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create control plane user "bob"
-	_, err = runner.CreateUser("bob", "bob123")
+	_, err = runner.CreateUser("bob", "bob12345")
 	require.NoError(t, err)
 	err = runner.GrantUserPermission("/export", "bob", "read-write")
 	require.NoError(t, err)

--- a/test/e2e/smb_kerberos_test.go
+++ b/test/e2e/smb_kerberos_test.go
@@ -46,7 +46,7 @@ func TestSMBKerberos(t *testing.T) {
 
 	// Add user principals
 	kdc.AddPrincipal(t, "alice", "alice123")
-	kdc.AddPrincipal(t, "bob", "bob123")
+	kdc.AddPrincipal(t, "bob", "bob12345")
 
 	// Add service principals for both NFS and SMB (cifs)
 	kdc.AddServicePrincipal(t, "nfs", "localhost")
@@ -82,7 +82,7 @@ func TestSMBKerberos(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create control plane user "bob"
-	_, err = runner.CreateUser("bob", "bob123")
+	_, err = runner.CreateUser("bob", "bob12345")
 	require.NoError(t, err)
 	err = runner.GrantUserPermission("/export", "bob", "read-write")
 	require.NoError(t, err)


### PR DESCRIPTION
## Problem

On the develop e2e VM run, `TestSMBKerberos` and `TestSMB3_KerberosFeatureMatrix` hard-FAIL — but **not** at any Kerberos mount. They die during user setup:

```
create user failed: user create --username bob --password bob123 failed: exit status 1
stderr: Error: failed to create user: Failed to hash password
```

## Root cause

The control-plane password policy requires `MinPasswordLength = 8` (`pkg/controlplane/models/credential.go`). `ValidatePassword` rejects anything shorter, `HashPassword` propagates it, and the API surfaces it as an opaque 500 `"Failed to hash password"`.

The tests create `alice`/`alice123` (8 chars — OK) then `bob`/`bob123` (**6 chars — rejected**), which is exactly why they fail on `bob` and not `alice`. The revived e2e suite (#1456) hadn't exercised these since the min-length policy tightened, so the stale 6-char password went unnoticed. The KDC Docker container starts fine and the mounts already skip gracefully when unavailable — password validation was the only hard failure.

## Fix

Bump `bob`'s KDC principal + control-plane password from `bob123` to `bob12345` (kept matched) in `smb_kerberos_test.go` and `smb3_kerberos_test.go`. `bob123` was the only sub-8-char `CreateUser` password in the entire e2e suite. Test-only, 4 lines.

With a KDC present (as in CI) these now run to completion; without one they skip at the mount step as before — no hard-fail path remains.

## Follow-up (not in this PR)

The API returns a generic 500 `"Failed to hash password"` for what is really a 400-class validation error (password too short). That masking is what made this failure look like a Kerberos-infra problem. Worth surfacing the validation error as a 400 with a clear message — separate change.

## Verification

`gofmt` clean; `go vet -tags e2e ./test/e2e/` clean. The e2e itself needs the Linux VM + KDC to run.