### PR TITLE
fix(block): decouple GC decrement idempotency from local-index entry

### DIFF
--- a/pkg/block/engine/gc_block.go
+++ b/pkg/block/engine/gc_block.go
@@ -35,10 +35,13 @@ type BlockReclaimer interface {
 	ReclaimDeadChunk(ctx context.Context, hash block.ContentHash) (handled bool, bytesFreed int64, err error)
 }
 
-// blockLocatorResolver resolves a chunk hash to its remote locator. Satisfied by
-// the per-share metadata store (metadata.SyncedHashStore.GetLocator).
-type blockLocatorResolver interface {
+// blockSyncedMarkerGC is the synced-marker surface the reclaimer needs: resolve
+// a chunk hash to its remote locator, then clear the marker. The marker doubles
+// as the decrement's per-hash idempotency token (see ReclaimDeadChunk). Satisfied
+// by the per-share metadata store (metadata.SyncedHashStore).
+type blockSyncedMarkerGC interface {
 	GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error)
+	DeleteSynced(ctx context.Context, hash block.ContentHash) error
 }
 
 // blockRecordGC is the block-record bookkeeping the reclaimer mutates. Satisfied
@@ -50,10 +53,9 @@ type blockRecordGC interface {
 }
 
 // localChunkIndexGC is the narrow LocalChunkIndex surface the block reclaimer
-// needs: read-then-delete under the idempotency protocol. Satisfied by the
+// needs: an idempotent delete of a chunk's local-index entry. Satisfied by the
 // per-share metadata store (metadata.LocalChunkIndex).
 type localChunkIndexGC interface {
-	GetLocalLocation(ctx context.Context, hash block.ContentHash) (block.LocalChunkLocation, bool, error)
 	DeleteLocalLocation(ctx context.Context, hash block.ContentHash) error
 }
 
@@ -63,7 +65,7 @@ type localChunkIndexGC interface {
 // runtime constructs one per remote-store sweep scope and sets it on
 // engine.Options.BlockReclaimer.
 type BlockGCReclaimer struct {
-	Locators     blockLocatorResolver
+	Locators     blockSyncedMarkerGC
 	Records      blockRecordGC
 	LocalIndex   localChunkIndexGC
 	RemoteBlocks remote.RemoteBlockStore
@@ -71,17 +73,34 @@ type BlockGCReclaimer struct {
 
 // ReclaimDeadChunk implements BlockReclaimer. See the interface contract.
 //
-// Ordering is chosen for crash-safety and exactly-once decrement semantics.
-// DeleteLocalLocation runs BEFORE DecrLiveChunkCount so the local-index entry
-// serves as a per-hash idempotency token for the decrement: if the process is
-// killed after DeleteLocalLocation commits but before DecrLiveChunkCount, the
-// next sweep re-visits the hash (its synced marker was not cleared), finds the
-// local entry already gone, and skips the decrement. This fails toward over-count
-// (a remote leak, reclaimed by the deferred orphan-object sweep) rather than
-// under-count (premature block free = data loss for live siblings).
+// Ordering is chosen for crash-safety and exactly-once decrement semantics. The
+// SYNCED MARKER — not the local-index entry — is the decrement's per-hash
+// idempotency token: once cleared, GetLocator reports the hash unsynced on any
+// re-visit and this reclaimer is a no-op, so DecrLiveChunkCount can never run
+// twice for the same hash. The marker is the token because EVICTION drops a
+// chunk's local-index entry WITHOUT decrementing (pkg/block/local/fs/eviction.go
+// dropBlobIndexEntries), so under the old local-index token an evicted-then-
+// orphaned chunk looked "already reclaimed", its decrement was skipped, and its
+// block leaked forever (#1637). The marker is untouched by eviction.
 //
-// The remote DeleteBlock precedes DeleteBlockRecord so a crash between them
-// leaves a record-less orphan object (reclaimed by the deferred orphan-object
+// The marker is cleared at one of two points, keyed off whether this is the
+// block's LAST live chunk (its record count is about to floor to 0):
+//
+//   - NOT the last chunk (a live sibling remains): clear the marker BEFORE the
+//     decrement. A double decrement here would drop LiveChunkCount below the
+//     true live count and could free a block a live dedup sibling still needs
+//     (data loss), so the marker must gate the decrement. A crash after the
+//     clear but before the decrement fails toward over-count: a record with no
+//     live locator and a stale count > 0 — a class-2 "leaked" record the
+//     reconcile sweep reaps (reclaim.go). Never toward a premature free.
+//
+//   - the LAST chunk (count floors to 0): clear the marker LAST, after the
+//     remote object and record are freed. A re-visit before that re-decrements
+//     0 → 0 (harmless floor), so gating is unnecessary; deferring the clear lets
+//     a transient DeleteBlock failure keep the marker so the next sweep retries.
+//
+// DeleteBlock precedes DeleteBlockRecord so a crash between them leaves a
+// record-less orphan object (class 3, reclaimed by the deferred orphan-object
 // sweep) rather than a record pointing at deleted bytes.
 func (r *BlockGCReclaimer) ReclaimDeadChunk(ctx context.Context, hash block.ContentHash) (bool, int64, error) {
 	loc, synced, err := r.Locators.GetLocator(ctx, hash)
@@ -89,10 +108,12 @@ func (r *BlockGCReclaimer) ReclaimDeadChunk(ctx context.Context, hash block.Cont
 		return false, 0, fmt.Errorf("block reclaim: get locator %s: %w", hash, err)
 	}
 	if !synced || loc.BlockID == "" {
-		// No block locator recorded in THIS share's store. Another share on
-		// the same remote may still resolve it (the runtime unions per-share
-		// reclaimers); if none does, the caller records the drift and keeps
-		// the marker fail-closed.
+		// Either no block locator recorded in THIS share's store (another share
+		// on the same remote may still resolve it — the runtime unions per-share
+		// reclaimers; if none does, the caller records the drift and keeps the
+		// marker fail-closed), OR a crash-recovery re-visit whose marker this
+		// reclaimer already cleared alongside its committed decrement. Nothing
+		// left to reclaim here.
 		return false, 0, nil
 	}
 	blockID := loc.BlockID
@@ -105,50 +126,54 @@ func (r *BlockGCReclaimer) ReclaimDeadChunk(ctx context.Context, hash block.Cont
 	}
 	if !ok {
 		// Orphan locator pointing at an already-freed block: drop its local entry
-		// and report handled — the block bookkeeping for this hash is complete.
+		// and report handled — the block bookkeeping for this hash is complete
+		// (the sweep clears the marker).
 		if derr := r.LocalIndex.DeleteLocalLocation(ctx, hash); derr != nil {
 			return false, 0, fmt.Errorf("block reclaim: delete local location %s: %w", hash, derr)
 		}
 		return true, 0, nil
 	}
 
-	// Check the local-index entry BEFORE deleting it: the entry serves as an
-	// idempotency token for DecrLiveChunkCount. If it is already gone a previous
-	// run already applied the decrement and we must not decrement again.
-	_, localExisted, err := r.LocalIndex.GetLocalLocation(ctx, hash)
-	if err != nil {
-		return false, 0, fmt.Errorf("block reclaim: get local location %s: %w", hash, err)
-	}
+	// The GC sweep and reconcile serialize on the per-remote lock, so this count
+	// cannot change under us: it reliably tells the last-chunk case (marker
+	// cleared last, retryable) from a partial one (marker cleared first, gated).
+	lastChunk := rec.LiveChunkCount <= 1
 
-	// Delete the local-index entry first (idempotent). A crash here leaves an
-	// orphan entry reclaimed by the periodic local reconcile — safe direction.
-	if derr := r.LocalIndex.DeleteLocalLocation(ctx, hash); derr != nil {
-		return false, 0, fmt.Errorf("block reclaim: delete local location %s: %w", hash, derr)
-	}
-
-	if !localExisted {
-		// Crash-recovery re-entry: DeleteLocalLocation already ran in a prior
-		// pass, so DecrLiveChunkCount was either already applied or will be
-		// skipped here. Either way, the count is at least as high as the true
-		// live count — no premature free possible. Report handled: the block
-		// bookkeeping for this hash is complete.
-		return true, 0, nil
+	if !lastChunk {
+		// Partial: clear the marker BEFORE decrementing so a re-visit resolves
+		// synced=false above and cannot double-decrement a live sibling's block.
+		if derr := r.Locators.DeleteSynced(ctx, hash); derr != nil {
+			return false, 0, fmt.Errorf("block reclaim: delete synced marker %s: %w", hash, derr)
+		}
 	}
 
 	remaining, err := r.Records.DecrLiveChunkCount(ctx, blockID, 1)
 	if err != nil {
 		return false, 0, fmt.Errorf("block reclaim: decr live chunk count %s: %w", blockID, err)
 	}
-	if remaining > 0 {
-		return true, 0, nil // block still has live chunks — keep it
+
+	// Drop the local-index entry (idempotent — eviction may already have removed
+	// it). A crash before this leaves an orphan entry the local reconcile reaps.
+	if derr := r.LocalIndex.DeleteLocalLocation(ctx, hash); derr != nil {
+		return false, 0, fmt.Errorf("block reclaim: delete local location %s: %w", hash, derr)
 	}
 
-	// Last live chunk gone: free the remote object, then the record.
+	if remaining > 0 {
+		return true, 0, nil // block still has live chunks — keep it (marker cleared above)
+	}
+
+	// Last live chunk gone: free the remote object, then the record, then clear
+	// the marker. A DeleteBlock failure returns here with the marker still set,
+	// so the next sweep retries; the record + object are retained for it (and for
+	// the reconcile class-1 zero-ref backstop) — never dropped on a failed delete.
 	if derr := r.RemoteBlocks.DeleteBlock(ctx, blockID); derr != nil {
 		return false, 0, fmt.Errorf("block reclaim: delete block %s: %w", blockID, derr)
 	}
 	if derr := r.Records.DeleteBlockRecord(ctx, blockID); derr != nil {
 		return false, 0, fmt.Errorf("block reclaim: delete record %s: %w", blockID, derr)
+	}
+	if derr := r.Locators.DeleteSynced(ctx, hash); derr != nil {
+		return false, 0, fmt.Errorf("block reclaim: delete synced marker %s: %w", hash, derr)
 	}
 	return true, rec.Length, nil
 }

--- a/pkg/block/engine/gc_block_test.go
+++ b/pkg/block/engine/gc_block_test.go
@@ -349,16 +349,18 @@ func TestGCBlockSweep_LocatorlessMarkerFailsClosed(t *testing.T) {
 }
 
 // TestBlockReclaimer_RerunAfterCrashNoDoubleDecrement is the critical
-// data-loss regression test for the partial-reclaim re-entry bug. If the GC
-// is killed or DeleteSynced fails between ReclaimDeadChunk and its caller
-// clearing the synced marker, the next sweep re-visits the same hash (the
-// synced marker is still present). Without the fix, a second call to
-// ReclaimDeadChunk decrements live_chunk_count a second time — driving it to
-// 0 for a block that still has a live sibling → DeleteBlock fires → the
-// sibling chunk's reads break permanently (silent data loss).
+// data-loss regression test for the partial-reclaim re-entry bug. If the GC is
+// killed between ReclaimDeadChunk's committed decrement and the sweep's own
+// marker-clear, the next sweep could re-visit the same hash. A second decrement
+// would drive live_chunk_count to 0 for a block that still has a live sibling →
+// DeleteBlock fires → the sibling chunk's reads break permanently (silent data
+// loss).
 //
-// The fix: DeleteLocalLocation runs FIRST as an idempotency token; the decrement
-// is skipped on re-entry (the local location is already gone).
+// The fix makes the SYNCED MARKER the decrement's idempotency token: DeleteSynced
+// runs BEFORE (and thus commits with) the decrement, so on re-entry GetLocator
+// reports the hash unsynced and the reclaimer is a no-op (handled=false) — no
+// second decrement. (In the real sweep a cleared marker also drops the hash from
+// EnumerateSynced, so it is never re-visited at all.)
 func TestBlockReclaimer_RerunAfterCrashNoDoubleDecrement(t *testing.T) {
 	ctx := t.Context()
 	st := metadatamemory.NewMemoryMetadataStoreWithDefaults()
@@ -372,9 +374,8 @@ func TestBlockReclaimer_RerunAfterCrashNoDoubleDecrement(t *testing.T) {
 
 	reclaimer := newBlockGCReclaimer(st, rbs)
 
-	// First reclaim of h1: normal path — decrements count, deletes local location.
-	// DeleteSynced is NOT called (simulating crash between ReclaimDeadChunk and
-	// its caller clearing the synced marker).
+	// First reclaim of h1: normal path — clears h1's marker, decrements count,
+	// deletes h1's local location.
 	handled, freed, err := reclaimer.ReclaimDeadChunk(ctx, h1)
 	if err != nil {
 		t.Fatalf("first ReclaimDeadChunk: %v", err)
@@ -386,25 +387,27 @@ func TestBlockReclaimer_RerunAfterCrashNoDoubleDecrement(t *testing.T) {
 		t.Errorf("first pass bytesFreed=%d, want 0 (block still alive, one chunk remains)", freed)
 	}
 
-	// Verify intermediate state: count decremented to 1, h1 local gone, h2 intact.
+	// Verify intermediate state: count decremented to 1, h1 marker+local gone.
 	rec, ok, _ := st.GetBlockRecord(ctx, "blk-crash")
 	if !ok || rec.LiveChunkCount != 1 {
 		t.Fatalf("after first pass: ok=%v LiveChunkCount=%d, want 1", ok, rec.LiveChunkCount)
 	}
+	if ok, _ := st.IsSynced(ctx, h1); ok {
+		t.Fatalf("after first pass: h1 marker still present; it is the re-entry token and must be cleared")
+	}
 
-	// Simulate crash: DeleteSynced was skipped, so h1's synced marker remains.
-	// The next sweep re-visits h1 (it's still absent from the live FileChunk set).
-	// This is the crash-recovery re-entry — must NOT decrement again.
+	// Crash-recovery re-entry: the marker was cleared with the decrement, so the
+	// reclaimer must be a no-op — NOT a second decrement.
 	handled, freed, err = reclaimer.ReclaimDeadChunk(ctx, h1)
 	if err != nil {
 		t.Fatalf("second ReclaimDeadChunk (crash recovery): %v", err)
 	}
-	if !handled {
-		t.Fatalf("second ReclaimDeadChunk: handled=false, want true")
+	if handled {
+		t.Errorf("second ReclaimDeadChunk: handled=true, want false (marker already cleared → nothing to reclaim)")
 	}
 
-	// CRITICAL: the block must NOT have been freed. Without the fix, the second
-	// decrement drives live_chunk_count to 0 → DeleteBlock → data loss for h2.
+	// CRITICAL: the block must NOT have been freed. A second decrement would
+	// drive live_chunk_count to 0 → DeleteBlock → data loss for h2.
 	if _, err := rbs.GetBlock(ctx, "blk-crash"); err != nil {
 		t.Errorf("block prematurely freed on crash-recovery reclaim (DATA LOSS): GetBlock: %v", err)
 	}
@@ -417,16 +420,68 @@ func TestBlockReclaimer_RerunAfterCrashNoDoubleDecrement(t *testing.T) {
 	if freed != 0 {
 		t.Errorf("crash-recovery bytesFreed=%d, want 0 (block must not be freed)", freed)
 	}
-	// h2's local location must remain intact — it is still live.
+	// h2's local location and marker must remain intact — it is still live.
 	if _, ok, _ := st.GetLocalLocation(ctx, h2); !ok {
 		t.Errorf("h2 local location wrongly deleted during crash-recovery reclaim")
+	}
+	if ok, _ := st.IsSynced(ctx, h2); !ok {
+		t.Errorf("h2 synced marker wrongly cleared during crash-recovery reclaim (still live)")
+	}
+}
+
+// TestBlockReclaimer_ReclaimsAfterEviction is the #1637 regression guard. It
+// proves the reclaimer still frees a block whose chunks' LOCAL-index entries
+// were already dropped by EVICTION (pkg/block/local/fs/eviction.go
+// dropBlobIndexEntries deletes them WITHOUT decrementing LiveChunkCount) before
+// the GC sweep reached them. The synced marker — untouched by eviction — is the
+// decrement's idempotency token, so the decrement runs, LiveChunkCount reaches
+// 0, and both the block record AND the remote blocks/<id> object are reclaimed.
+//
+// Before the fix the reclaimer used the local-index entry as its token: the
+// evicted (now-absent) entry made it treat the chunk as already reclaimed, skip
+// the decrement, and leak the block object forever ("1 survived" in
+// TestBlocksFlipLifecycle step 3).
+func TestBlockReclaimer_ReclaimsAfterEviction(t *testing.T) {
+	ctx := t.Context()
+	st := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	rbs := remotememory.New()
+	defer func() { _ = rbs.Close() }()
+
+	h := hashFromString("evicted-only-chunk")
+	seedPackedBlock(t, st, rbs, "blk-evicted", []block.ContentHash{h})
+
+	// Simulate eviction of the sealed log blob: the local-index entry is dropped
+	// WITHOUT decrementing the block's LiveChunkCount; the synced marker stays.
+	if err := st.DeleteLocalLocation(ctx, h); err != nil {
+		t.Fatalf("simulate eviction DeleteLocalLocation: %v", err)
+	}
+	if ok, _ := st.IsSynced(ctx, h); !ok {
+		t.Fatalf("precondition: synced marker must survive eviction")
+	}
+
+	handled, freed, err := newBlockGCReclaimer(st, rbs).ReclaimDeadChunk(ctx, h)
+	if err != nil {
+		t.Fatalf("ReclaimDeadChunk: %v", err)
+	}
+	if !handled {
+		t.Fatalf("handled = false, want true for an evicted block-resident chunk")
+	}
+	if freed <= 0 {
+		t.Errorf("bytesFreed = %d, want the block Length (last chunk freed)", freed)
+	}
+	// The block record AND the remote object must be reclaimed — the whole bug.
+	if _, ok, _ := st.GetBlockRecord(ctx, "blk-evicted"); ok {
+		t.Errorf("block record survived reclaim after eviction (#1637: GC leaks the blocks/<id> object)")
+	}
+	if _, err := rbs.GetBlock(ctx, "blk-evicted"); err == nil {
+		t.Errorf("remote block object survived reclaim after eviction (#1637: 1 survived)")
 	}
 }
 
 // compile-time: the memory metadata store satisfies the reclaimer surfaces.
 var (
-	_ blockLocatorResolver = (*metadatamemory.MemoryMetadataStore)(nil)
-	_ blockRecordGC        = (*metadatamemory.MemoryMetadataStore)(nil)
-	_ localChunkIndexGC    = (*metadatamemory.MemoryMetadataStore)(nil)
-	_ context.Context      = nil
+	_ blockSyncedMarkerGC = (*metadatamemory.MemoryMetadataStore)(nil)
+	_ blockRecordGC       = (*metadatamemory.MemoryMetadataStore)(nil)
+	_ localChunkIndexGC   = (*metadatamemory.MemoryMetadataStore)(nil)
+	_ context.Context     = nil
 )


### PR DESCRIPTION
## Problem

`TestBlocksFlipLifecycle_{NFS,SMB}` step 3 fails on the develop e2e VM run: after `evict → unlink → block GC (grace-period 0)`, one remote packed block survives instead of being reaped:

```
GC must reap every blocks/ object after unlink; 1 survived: [blocks/bed8f0e1...]
```

Uncovered by #1637 — before that fix the active log blob wasn't evicted, so its chunks kept their local-index entry; #1637's more-thorough eviction exposed this latent reclaimer bug.

## Root cause

`BlockGCReclaimer.ReclaimDeadChunk` used the presence of a **local-index entry** as its per-hash idempotency token for `DecrLiveChunkCount` (`!localExisted → skip decrement`, assuming a prior GC pass already ran it). But eviction (`DrainLocalSynced → dropBlobIndexEntries → DeleteLocalLocation`) legitimately deletes that entry **without** decrementing. So an evicted-then-orphaned chunk hit the skip branch, its block's `LiveChunkCount` never reached 0, and `DeleteBlock`/`DeleteBlockRecord` never fired → the `blocks/<id>` S3 object leaked. Deterministic (stable over the test's 30 s poll).

## Fix

Switch the once-token to the **GC-owned synced marker** (untouched by eviction), which the reclaimer already resolves first via `GetLocator`:

- Drop the `GetLocalLocation` / `!localExisted → skip` branch; the decrement always runs.
- Clear the marker at one of two points, keyed on whether this is the block's last live chunk (`LiveChunkCount <= 1`):
  - **Non-last chunk** — clear the marker **before** the decrement, so a re-entry resolves `synced=false` and cannot double-decrement (a double-decrement could free a block a live dedup sibling still needs = data loss).
  - **Last chunk** — clear the marker **after** `DeleteBlock` + `DeleteBlockRecord`, so a transient delete failure keeps the marker and the next sweep retries.
- `DeleteBlock` still precedes `DeleteBlockRecord` (crash leaves a record-less orphan object, reaped by the reconcile object sweep — unchanged safety direction).

Crash between marker-clear and decrement fails toward **over-count** (class-2 "leaked" record, reaped by reconcile), never toward premature free.

## Test

`TestBlockReclaimer_ReclaimsAfterEviction` (`gc_block_test.go`): seed a single-chunk packed block, `DeleteLocalLocation` to simulate eviction (marker left intact), run `ReclaimDeadChunk`, assert the block record **and** remote object are reclaimed. Fails before the fix (`bytesFreed=0`, "block/object survived, 1 survived"), passes after. The existing `RerunAfterCrashNoDoubleDecrement` test was updated to the marker token and still proves the data-loss guard.

## Verification

- `go build ./...` clean; `go vet`, `gofmt`, `golangci-lint` clean.
- `go test ./pkg/block/... ./pkg/controlplane/...` — **1846 passed**, 0 failed (31 packages), including the poison-block retain-on-delete-failure test unchanged.
- `-race` on all `TestBlockReclaimer*` / `TestGCBlockSweep*` — clean.
- The e2e (`TestBlocksFlipLifecycle`) needs the Linux VM; the unit test reproduces its step-3 mechanism deterministically.

Fixes the NFS variant fully. The SMB variant has a **separate** warm-read integrity bug (unverified local CAS read path, likely a #1636 readahead race) tracked separately.