### PR TITLE
fix(block): verify local CAS chunks on warm read, route corruption to remote heal

### DIFF
--- a/pkg/block/engine/warm_read_integrity_test.go
+++ b/pkg/block/engine/warm_read_integrity_test.go
@@ -1,0 +1,202 @@
+package engine_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/block/local/fs"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatabadger "github.com/marmos91/dittofs/pkg/metadata/store/badger"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// newEngineWithRemote mirrors newEngineOverStore but wires a real (memory)
+// remote + block store + synced-hash store, so the #1636 readahead driver
+// actually fires (scheduleReadahead no-ops without a healthy remote). This is
+// the faithful warm-read shape: data lives locally AND is uploaded to the
+// remote, no eviction.
+func newEngineWithRemote(t *testing.T, ms metadata.Store, mem *remotememory.Store) *engine.Store {
+	t.Helper()
+	rollupStore, ok := ms.(metadata.RollupStore)
+	if !ok {
+		t.Fatalf("metadata store %T does not implement metadata.RollupStore", ms)
+	}
+	syncedHashStore, ok := ms.(metadata.SyncedHashStore)
+	if !ok {
+		t.Fatalf("metadata store %T does not implement metadata.SyncedHashStore", ms)
+	}
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
+		LocalChunkIndex: ms,
+		MaxLogBytes:     128 * 1024 * 1024,
+		RollupWorkers:   2,
+		StabilizationMS: 3_600_000, // async rollup never fires; explicit DrainRollups only
+		RollupStore:     rollupStore,
+		SyncedHashStore: syncedHashStore,
+	})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+	coord := &testCoordinator{store: ms}
+	syncer := engine.NewSyncer(localStore, mem, ms, engine.DefaultConfig())
+	syncer.SetSyncedHashStore(syncedHashStore)
+	syncer.SetRemoteBlockStore(mem)
+	bs, err := engine.New(engine.BlockStoreConfig{
+		Local:           localStore,
+		Syncer:          syncer,
+		FileChunkStore:  ms,
+		Coordinator:     coord,
+		SyncedHashStore: syncedHashStore,
+		ReadBufferBytes: 64 * 1024 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("engine.New: %v", err)
+	}
+	if err := bs.Start(context.Background()); err != nil {
+		t.Fatalf("engine.Start: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+	return bs
+}
+
+// TestWarmReadIntegrity_AfterDrainUploads reproduces the blocks-only warm-read
+// data-integrity bug: write ~16 MiB, roll up + upload to the remote (NO
+// eviction), then read the whole file back in 1 MiB windows via the local warm
+// read path (Store.ReadAt) and compare each window's blake3 to the source.
+//
+// The #1636 readahead driver fires on every ReadAt with a healthy remote wired,
+// so demand reads run concurrently with prefetch workers. Run under -race.
+func TestWarmReadIntegrity_AfterDrainUploads(t *testing.T) {
+	t.Run("memory", func(t *testing.T) {
+		runWarmReadIntegrity(t, metadatamemory.NewMemoryMetadataStoreWithDefaults())
+	})
+	t.Run("badger", func(t *testing.T) {
+		ms, err := metadatabadger.NewBadgerMetadataStoreWithDefaults(context.Background(), t.TempDir())
+		if err != nil {
+			t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
+		}
+		defer func() { _ = ms.Close() }()
+		runWarmReadIntegrity(t, ms)
+	})
+}
+
+func runWarmReadIntegrity(t *testing.T, ms metadata.Store) {
+	ctx := context.Background()
+	mem := remotememory.New()
+	bs := newEngineWithRemote(t, ms, mem)
+
+	rootHandle := createShare(t, ms, "warmread")
+	pid, _ := createRealFile(t, ms, "warmread", "big.bin", rootHandle)
+
+	const oneMiB = 1024 * 1024
+	const fileSize = 16 * oneMiB
+	src := make([]byte, fileSize)
+	rng := rand.New(rand.NewSource(0x5EED)) //nolint:gosec // deterministic test fixture
+	rng.Read(src)
+
+	// Write in 1 MiB windows to mimic SMB's sequential 1 MiB WRITE RPCs.
+	for off := 0; off < fileSize; off += oneMiB {
+		if _, err := bs.WriteAt(ctx, pid, nil, src[off:off+oneMiB], uint64(off)); err != nil {
+			t.Fatalf("WriteAt off=%d: %v", off, err)
+		}
+	}
+	if _, err := bs.Flush(ctx, pid); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	// Roll up (append log -> CAS + manifest) then upload to the remote. NO evict.
+	if err := bs.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups: %v", err)
+	}
+	if err := bs.DrainAllUploads(ctx); err != nil {
+		t.Fatalf("DrainAllUploads: %v", err)
+	}
+
+	// Per-window expected blake3.
+	nWin := fileSize / oneMiB
+	wantHash := make([][32]byte, nWin)
+	for i := 0; i < nWin; i++ {
+		wantHash[i] = blake3.Sum256(src[i*oneMiB : (i+1)*oneMiB])
+	}
+
+	// Read the whole file back in 1 MiB sliding windows, several passes,
+	// concurrently, to drive the readahead sliding window hard.
+	const passes = 20
+	const readers = 4
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
+	fail := func(format string, args ...interface{}) {
+		mu.Lock()
+		if firstErr == nil {
+			firstErr = fmt.Errorf(format, args...)
+		}
+		mu.Unlock()
+	}
+
+	// verify reads [off,off+len) and checks it byte-matches src, poisoning the
+	// buffer first so any offset the local assembly leaves uncovered (the
+	// recycled-non-zeroed-buffer amplifier) surfaces as a mismatch rather than
+	// hiding behind zeros.
+	verify := func(buf []byte, off uint64) {
+		for i := range buf {
+			buf[i] = 0xAA // poison
+		}
+		n, err := bs.ReadAt(ctx, pid, nil, buf, off)
+		if err != nil {
+			fail("ReadAt off=%d len=%d: %v", off, len(buf), err)
+			return
+		}
+		if n != len(buf) {
+			fail("ReadAt off=%d short read n=%d want=%d", off, n, len(buf))
+			return
+		}
+		want := src[off : off+uint64(len(buf))]
+		if blake3.Sum256(buf) != blake3.Sum256(want) {
+			// Find first mismatch for a precise message.
+			for j := range buf {
+				if buf[j] != want[j] {
+					fail("WARM READ MISMATCH off=%d len=%d: first bad byte at +%d got=0x%02x want=0x%02x (poison=0xAA)",
+						off, len(buf), j, buf[j], want[j])
+					return
+				}
+			}
+			fail("WARM READ MISMATCH off=%d len=%d (hash differs, no byte diff?)", off, len(buf))
+		}
+	}
+
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			buf1 := make([]byte, oneMiB)
+			// Odd, non-MiB-aligned window like a real SMB max-read (drives the
+			// sliding readahead window across chunk boundaries at odd offsets).
+			const odd = 512*1024 + 7
+			bufOdd := make([]byte, odd)
+			whole := make([]byte, fileSize)
+			for p := 0; p < passes; p++ {
+				// Pass A: sequential 1 MiB windows.
+				for i := 0; i < nWin; i++ {
+					verify(buf1, uint64(i)*oneMiB)
+				}
+				// Pass B: odd-sized sequential windows.
+				for off := uint64(0); off+odd <= fileSize; off += odd {
+					verify(bufOdd, off)
+				}
+				// Pass C: one big whole-file read.
+				verify(whole, 0)
+			}
+			_ = seed
+		}(r)
+	}
+	wg.Wait()
+	if firstErr != nil {
+		t.Fatal(firstErr)
+	}
+}

--- a/pkg/block/local/fs/readpayload.go
+++ b/pkg/block/local/fs/readpayload.go
@@ -10,6 +10,8 @@ import (
 	"slices"
 	"sync"
 
+	"lukechampine.com/blake3"
+
 	"github.com/marmos91/dittofs/pkg/block"
 )
 
@@ -318,6 +320,18 @@ func (bc *FSStore) fillFromCASManifest(ctx context.Context, payloadID string, de
 				// past this chunk; the caller falls back to remote for it.
 				data = nil
 			}
+			if data != nil && block.ContentHash(blake3.Sum256(data)) != fb.Hash {
+				// Local bytes are corrupt (blake3 of the on-disk chunk does not
+				// match the manifest hash). Do NOT serve them: leave this region
+				// uncovered so ReadPayloadAt returns a miss and the engine routes
+				// the read to the blake3-verified remote-fetch/heal path
+				// (readLocalByHash -> healLocalChunk / ensureAndReadFromLocal).
+				// Mirrors the verify readLocalByHash already does on the sibling
+				// CAS-hash walk — without it silent local corruption reaches the
+				// client (warm reads have no integrity gate; the cold/remote path
+				// does).
+				data = nil
+			}
 			if data != nil {
 				// Clamp visible data to DataSize so a padded on-disk chunk
 				// does not leak garbage past the rollup-emitted byte count.
@@ -394,6 +408,13 @@ func (bc *FSStore) fillFromCASManifestScan(ctx context.Context, payloadID string
 				continue
 			}
 			return fmt.Errorf("ReadPayloadAt: Get chunk %s: %w", r.fb.Hash.String(), gerr)
+		}
+		if block.ContentHash(blake3.Sum256(data)) != r.fb.Hash {
+			// Corrupt local bytes: skip (leave uncovered) so the engine routes
+			// this read to the blake3-verified remote-fetch/heal path rather than
+			// serving silently-wrong data. Mirrors the fast-path guard above and
+			// readLocalByHash's verify.
+			continue
 		}
 		// Clamp the visible data to DataSize so a padded on-disk chunk
 		// does not leak garbage past the rollup-emitted byte count.

--- a/pkg/block/local/fs/readpayload_verify_test.go
+++ b/pkg/block/local/fs/readpayload_verify_test.go
@@ -1,0 +1,98 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatabadger "github.com/marmos91/dittofs/pkg/metadata/store/badger"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestReadPayloadAt_CorruptLocalChunk_DoesNotServeSilently is the warm-read
+// data-integrity guard's fail-before/pass-after gate.
+//
+// It plants a CORRUPT local chunk (garbage bytes stored under a hash that is
+// the blake3 of DIFFERENT, correct bytes) plus a FileChunk manifest row that
+// references that hash, then reads through ReadPayloadAt — the local warm read
+// path. Before the guard, fillFromCASManifest / fillFromCASManifestScan copy the
+// unverified local bytes straight into dest and return (len, nil): the client
+// receives silently-wrong data (the SMB warm-read bug). After the guard, the
+// blake3 mismatch leaves the region uncovered so ReadPayloadAt returns a miss
+// (block.ErrFileChunkNotFound), which the engine routes to the blake3-verified
+// remote-fetch/heal path instead of serving corruption.
+//
+// Runs over memory (fillFromCASManifestScan) and badger (the indexed
+// coveringChunkResolver fast path) so both local CAS read sites are gated.
+func TestReadPayloadAt_CorruptLocalChunk_DoesNotServeSilently(t *testing.T) {
+	t.Run("memory_scan", func(t *testing.T) {
+		runCorruptLocalChunk(t, metadatamemory.NewMemoryMetadataStoreWithDefaults())
+	})
+	t.Run("badger_covering", func(t *testing.T) {
+		ms, err := metadatabadger.NewBadgerMetadataStoreWithDefaults(context.Background(), t.TempDir())
+		if err != nil {
+			t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
+		}
+		defer func() { _ = ms.Close() }()
+		runCorruptLocalChunk(t, ms)
+	})
+}
+
+func runCorruptLocalChunk(t *testing.T, ms metadata.Store) {
+	t.Helper()
+	ctx := context.Background()
+
+	fcs, ok := ms.(block.EngineFileChunkStore)
+	if !ok {
+		t.Fatalf("metadata store %T does not implement block.EngineFileChunkStore", ms)
+	}
+	lci, ok := ms.(metadata.LocalChunkIndex)
+	if !ok {
+		t.Fatalf("metadata store %T does not implement metadata.LocalChunkIndex", ms)
+	}
+
+	store, err := NewWithOptions(t.TempDir(), 0, fcs, FSStoreOptions{LocalChunkIndex: lci})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	// The hash addresses the CORRECT bytes; the local store holds GARBAGE under
+	// that hash (models on-disk / logblob corruption of a warm chunk).
+	correct := bytes.Repeat([]byte("correct-payload-bytes!"), 64)
+	h := block.ContentHash(blake3.Sum256(correct))
+	garbage := bytes.Repeat([]byte{0xEE}, len(correct))
+	if bytes.Equal(garbage, correct) {
+		t.Fatal("test setup: garbage must differ from correct")
+	}
+
+	if err := store.StoreChunk(ctx, h, garbage); err != nil {
+		t.Fatalf("StoreChunk (plant corrupt local bytes): %v", err)
+	}
+	// Manifest row for payload "p" at offset 0 referencing the (correct) hash.
+	fb := &block.FileChunk{
+		ID:       "p/0",
+		Hash:     h,
+		DataSize: uint32(len(correct)),
+		State:    block.BlockStatePending,
+	}
+	if err := fcs.Put(ctx, fb); err != nil {
+		t.Fatalf("FileChunk Put: %v", err)
+	}
+
+	dest := make([]byte, len(correct))
+	n, err := store.ReadPayloadAt(ctx, "p", dest, 0)
+
+	// After the guard: the blake3 mismatch is detected, the region is left
+	// uncovered, and ReadPayloadAt surfaces a miss. The corrupt bytes must NOT
+	// reach dest as a successful read.
+	if !errors.Is(err, block.ErrFileChunkNotFound) {
+		t.Fatalf("corrupt local chunk was served silently: ReadPayloadAt returned n=%d err=%v (dest==garbage: %v); want block.ErrFileChunkNotFound so the engine routes to the verified remote path",
+			n, err, bytes.Equal(dest, garbage))
+	}
+}


### PR DESCRIPTION
## Problem

`TestBlocksFlipLifecycle_SMB` step-1 warm read-back returns wrong bytes (right length): `want=84ebb262... got=4de3799c...`. The step-2 **cold** read (from S3) is correct, so the write and remote manifest are fine — the corruption is in the **local warm-read path**. NFS doesn't show it because the kernel client's page cache serves the warm read locally and never hits the server; SMB (go-smb2, no page cache) issues real READ RPCs and exercises the server warm-read path. The server read path is identical for both protocols — this is not SMB-specific.

## Root cause (of the silent-corruption *channel*)

The local CAS warm-read path — `fillFromCASManifest` (badger fast path) and `fillFromCASManifestScan` (memory/sqlite/postgres) in `pkg/block/local/fs/readpayload.go` — copied `bc.Get(hash)` bytes with **no blake3 verification**, unlike the sibling `engine/read_internal.go readLocalByHash`, which verifies and heals. So a locally corrupt or mis-indexed chunk reached the client silently at full length (a non-zeroed pooled buffer makes it "wrong bytes, right length"). The cold/remote path is blake3-verified, hence correct.

## Fix

Add the same blake3 verify at both local CAS copy sites: after `bc.Get`, if `blake3(data) != manifestHash`, leave the region uncovered (fast path `data = nil`, scan path `continue`). `ReadPayloadAt` then returns `ErrFileChunkNotFound`, which `readAtInternal` routes to the blake3-verified `readLocalByHash → healLocalChunk` / `ensureAndReadFromLocal` path. One guard where all warm-read callers route. +21 lines.

Defense-in-depth: corruption can no longer be *served* — it's caught and healed from the verified remote — regardless of what corrupts the local bytes.

## Honest caveat

The **upstream corruptor is unconfirmed.** A faithful engine-tier `-race` repro (`warm_read_integrity_test.go`: full engine over fs local + in-memory remote, write 16 MiB, drain rollups with no eviction, 4 concurrent readers × 20 passes, buffers poisoned with 0xAA, memory + badger backends) did **not** reproduce a race or a mismatch — the #1636 readahead prefetch skips already-local chunks in the warm/no-evict state, so it never re-stages or races a demand read. So the suspected #1636 readahead race was **left untouched** (no fabricated fix). Whatever produces the bad local bytes in the full SMB/S3 e2e lives above/beside this tier (adapter pool buffer, carve/pack, or something the in-memory remote doesn't model). This guard closes the channel; the next develop e2e run will show whether SMB now heals (green) or at least fails-closed instead of returning wrong bytes.

## Tests / verification

- `TestReadPayloadAt_CorruptLocalChunk_DoesNotServeSilently` (memory scan + badger covering): plants garbage under a valid hash + manifest row. Without guard: **FAIL** ("corrupt local chunk served silently"). With guard: returns `ErrFileChunkNotFound`. **PASS.**
- `warm_read_integrity_test.go`: concurrent warm-read regression guard (passes; documents the #1636 race does not reproduce at this tier).
- `go build ./...`, `gofmt`, `go vet` clean. `go test ./pkg/block/... ./internal/adapter/common/...` — 1282 passed. `-race` on `pkg/block/local/fs` and `pkg/block/engine` read tests — clean.