### PR TITLE
feat(dfsctl): add --squash to share create (#1566)

### DIFF
--- a/cmd/dfsctl/commands/share/acl_canon_test.go
+++ b/cmd/dfsctl/commands/share/acl_canon_test.go
@@ -69,6 +69,7 @@ func resetCreateFlags() {
 	createReadOnly = false
 	createEncryptData = false
 	createDefaultPermission = "read-write"
+	createSquash = ""
 	createDescription = ""
 	createRetention = ""
 	createRetentionTTL = ""

--- a/cmd/dfsctl/commands/share/create.go
+++ b/cmd/dfsctl/commands/share/create.go
@@ -7,6 +7,7 @@ import (
 	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
 	"github.com/marmos91/dittofs/internal/cli/prompt"
 	"github.com/marmos91/dittofs/pkg/apiclient"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/spf13/cobra"
 )
 
@@ -18,6 +19,7 @@ var (
 	createReadOnly          bool
 	createEncryptData       bool
 	createDefaultPermission string
+	createSquash            string
 	createOwner             string
 	createDescription       string
 	createRetention         string
@@ -72,7 +74,10 @@ Examples:
   dfsctl share create --name /bigdata --metadata default --local fs-cache --local-store-size 10GiB --read-buffer-size 2GiB
 
   # Create with per-share quota
-  dfsctl share create --name /limited --metadata default --local fs-cache --quota-bytes 10GiB`,
+  dfsctl share create --name /limited --metadata default --local fs-cache --quota-bytes 10GiB
+
+  # Create an export that does not squash root (e.g. for root-mounted/benchmark clients)
+  dfsctl share create --name /export --metadata default --local fs-cache --squash none`,
 	RunE: runCreate,
 }
 
@@ -84,6 +89,7 @@ func init() {
 	createCmd.Flags().BoolVar(&createReadOnly, "read-only", false, "Make share read-only")
 	createCmd.Flags().BoolVar(&createEncryptData, "encrypt-data", false, "Require SMB3 encryption for this share")
 	createCmd.Flags().StringVar(&createDefaultPermission, "default-permission", "none", "Default permission for unmapped UIDs (none|read|read-write|admin)")
+	createCmd.Flags().StringVar(&createSquash, "squash", "", "NFS export squash mode (none|root_to_admin|root_to_guest|all_to_admin|all_to_guest). Default root_to_guest (root_squash); use none or root_to_admin so a root-mounted client is not squashed to guest.")
 	createCmd.Flags().StringVar(&createOwner, "owner", "", "Username that owns the share's root directory (defaults to root). The owner can write at the share root; other principals are governed by POSIX mode plus their share permission grant.")
 	createCmd.Flags().StringVar(&createDescription, "description", "", "Share description")
 	createCmd.Flags().StringVar(&createRetention, "retention", "", "Retention policy (pin|ttl|lru)")
@@ -233,9 +239,22 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		req.TrashExcludePatterns = createTrashExclude
 	}
 
+	// Squash lives on the NFS adapter config endpoint, not the share record.
+	// Validate up front so we don't create a share and then fail to apply a
+	// bogus squash mode, leaving it half-configured.
+	if cmd.Flags().Changed("squash") && !models.SquashMode(createSquash).IsValid() {
+		return fmt.Errorf("--squash: invalid value %q, must be one of none|root_to_admin|root_to_guest|all_to_admin|all_to_guest", createSquash)
+	}
+
 	share, err := client.CreateShare(req)
 	if err != nil {
 		return fmt.Errorf("failed to create share: %w", err)
+	}
+
+	if cmd.Flags().Changed("squash") {
+		if _, err := client.PatchShareNFSConfig(share.Name, &apiclient.PatchShareNFSConfigRequest{Squash: &createSquash}); err != nil {
+			return fmt.Errorf("share '%s' created, but failed to set NFS squash mode: %w", share.Name, err)
+		}
 	}
 
 	return cmdutil.PrintResourceWithSuccess(os.Stdout, share, fmt.Sprintf("Share '%s' created successfully", share.Name))

--- a/cmd/dfsctl/commands/share/squash_flags_test.go
+++ b/cmd/dfsctl/commands/share/squash_flags_test.go
@@ -1,0 +1,68 @@
+package share
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// Refs #1566 — dfsctl flag plumbing for --squash on `share create`.
+// Squash targets the per-share NFS adapter config endpoint, so a create with
+// --squash must fire a PATCH to /adapters/nfs/config after the share POST.
+
+func TestCreateCmd_Squash_PatchesNFSConfig(t *testing.T) {
+	s := newShareJSONBodyServer(t)
+	defer s.Close()
+	withTestServer(t, s.URL)
+
+	resetCreateFlags()
+	createName = "/x"
+	createMetadata = "meta"
+	createLocal = "bs"
+	createSquash = "none"
+	if err := createCmd.Flags().Set("squash", "none"); err != nil {
+		t.Fatalf("Flags.Set: %v", err)
+	}
+
+	_ = captureStdout(t, func() {
+		if err := runCreate(createCmd, nil); err != nil {
+			t.Fatalf("runCreate: %v", err)
+		}
+	})
+
+	// The last request is the squash PATCH, following the share POST.
+	if s.lastVerb != http.MethodPatch {
+		t.Fatalf("last verb = %q, want PATCH", s.lastVerb)
+	}
+	if !strings.HasSuffix(s.lastPath, "/adapters/nfs/config") {
+		t.Fatalf("last path = %q, want .../adapters/nfs/config", s.lastPath)
+	}
+	if !strings.Contains(string(s.lastBody), `"squash":"none"`) {
+		t.Errorf("squash PATCH body missing squash:none; got %s", s.lastBody)
+	}
+}
+
+func TestCreateCmd_Squash_InvalidRejectedBeforeAnyRequest(t *testing.T) {
+	s := newShareJSONBodyServer(t)
+	defer s.Close()
+	withTestServer(t, s.URL)
+
+	resetCreateFlags()
+	createName = "/x"
+	createMetadata = "meta"
+	createLocal = "bs"
+	createSquash = "bogus"
+	if err := createCmd.Flags().Set("squash", "bogus"); err != nil {
+		t.Fatalf("Flags.Set: %v", err)
+	}
+
+	var runErr error
+	_ = captureStdout(t, func() { runErr = runCreate(createCmd, nil) })
+
+	if runErr == nil || !strings.Contains(runErr.Error(), "--squash") {
+		t.Fatalf("want --squash validation error, got %v", runErr)
+	}
+	if s.lastVerb != "" {
+		t.Errorf("no request should fire on invalid squash; got %s %s", s.lastVerb, s.lastPath)
+	}
+}

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -3890,6 +3890,9 @@ dfsctl share create --name /bigdata --metadata default --local fs-cache --local-
 
 # Create with per-share quota
 dfsctl share create --name /limited --metadata default --local fs-cache --quota-bytes 10GiB
+
+# Create an export that does not squash root (e.g. for root-mounted/benchmark clients)
+dfsctl share create --name /export --metadata default --local fs-cache --squash none
 ```
 
 Flags:
@@ -3915,6 +3918,7 @@ Flags:
       --remote string                   Remote block store name (optional)
       --retention string                Retention policy (pin|ttl|lru)
       --retention-ttl string            Retention TTL duration (e.g., 72h, 24h)
+      --squash string                   NFS export squash mode (none|root_to_admin|root_to_guest|all_to_admin|all_to_guest). Default root_to_guest (root_squash); use none or root_to_admin so a root-mounted client is not squashed to guest.
       --streams-disabled                Reject SMB2 Alternate Data Stream opens with STATUS_OBJECT_NAME_INVALID on this share (mirrors Samba 'smbd:streams = no').
       --trash-exclude strings           Glob patterns whose deletions bypass the recycle bin (repeatable).
       --trash-max-size int              Max bytes the recycle bin may hold before the reaper evicts oldest items (0 = unbounded).
@@ -4243,8 +4247,8 @@ mkdir -p ~/mnt/dittofs && dfsctl share mount /export --protocol smb ~/mnt/dittof
 Flags:
 
 ```
-      --dir-mode string      Directory permissions for SMB mount (octal)
-      --file-mode string     File permissions (not applicable on Windows)
+      --dir-mode string      Directory permissions for SMB mount (octal) (default "0777")
+      --file-mode string     File permissions for SMB mount (octal, default 0777 on macOS since uid/gid not supported) (default "0777")
       --nfs-version string   NFS protocol version for NFS mounts (3, 4, 4.0, 4.1, 4.2). v4 carries locking in-protocol; v3 locking needs the server UDP transport + portmapper (default "3")
   -P, --password string      Password for SMB mount (will prompt if not provided)
   -p, --protocol string      Protocol to use (nfs or smb) (required)


### PR DESCRIPTION
## Summary

Closes #1566. Adds `--squash <mode>` to `dfsctl share create` for the per-share NFS export squash mode.

The squash mode was already settable via `dfsctl share nfs-config set --squash` (and the raw `PATCH /api/v1/shares/{name}/adapters/nfs/config` API), so the issue's "API-only" framing was partly stale. The real remaining gap: a share could not be created **non-root-squashed in one step**, so any root-mounted client (benchmarks, kernel NFS) hits `permission denied` writes until reconfigured out of band.

## Changes

- `share create --squash <mode>` — applies squash right after the share is created (matches how NFS exports carry `no_root_squash` in the export definition).
- Plumbs to the existing `PatchShareNFSConfig` endpoint. The value is validated client-side via `models.SquashMode.IsValid()` **before any mutation**, so a bogus mode never leaves a half-configured share.
- Regenerated `docs/guide/cli.md` (`go run ./cmd/gendocs`).

Editing squash after creation stays on `dfsctl share nfs-config set --squash` — no overlapping second path on `share edit`.

## Testing

- New `squash_flags_test.go`: create fires the NFS-config PATCH after the share POST; invalid `--squash` is rejected before any HTTP request.
- Full `cmd/dfsctl/commands/share` package: 40 pass. `go vet`, `gofmt -s`, `golangci-lint` clean.
- `--help` smoke: flag + example render on `share create`.