### PR TITLE
fix(bench): run zerofs + s3ql backends; refresh BENCHMARKS.md with 7-system results

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,426 +1,125 @@
 # DittoFS Performance Benchmarks
 
-> ⚠️ **LEGACY / STALE — do not cite.** These numbers are from an earlier release and have
-> **not** been re-run against current DittoFS. They are kept for historical reference only and
-> are intentionally excluded from the published documentation. For fresh data from the `dfsbench`
-> harness, see [`internals/dfsbench-results.md`](internals/dfsbench-results.md) — note it already
-> **contradicts** the "writes never block on S3" claim below (native NFS→S3 seq-write measured at
-> ~1 MB/s). Treat every figure here as out of date.
+Performance of DittoFS (S3 backend) against the S3-backed network filesystems the
+`dfsbench` harness supports — **JuiceFS, s3ql, rclone, s3fs, and ZeroFS** — plus
+**local-disk** as the raw-hardware ceiling. All systems run on one disposable
+Scaleway VM, driven by the same `fio` workloads over the same protocol.
 
-Performance comparison of DittoFS with S3 backend against other S3-compatible network filesystems and kernel NFS, on identical Scaleway infrastructure.
+> **Read these with the rig in mind.** Each cell is a single 30 s `fio` run on a
+> shared cloud VM. Trust the **shape and order of magnitude**, not the third
+> digit. Medium-file sequential-read is first-touch noise and is omitted.
 
-## Key Results
+## Test setup
 
-**DittoFS S3 dominates every S3-compatible competitor** across all workloads:
+| | |
+|---|---|
+| Date | 2026-07-10 |
+| DittoFS | `develop` @ `0d79ede1` |
+| Harness | `internal/dfsbench` (fio driver + SCW orchestration) |
+| Host | Scaleway `fr-par-1`, single VM, Ubuntu 24.04 |
+| Protocol | **NFSv3** — the only protocol all seven backends share (ZeroFS is NFSv3-only) |
+| Object store | Scaleway Object Storage, `s3.fr-par.scw.cloud` |
+| fio | 4 threads, 30 s/cell, warm pass (+ cold/post-evict where noted) |
+| Sizes | medium = 1 MiB, large = 1 GiB |
+| Result | 7/7 backends set up, **0 workload errors** |
 
-![DittoFS vs JuiceFS Performance Ratio](assets/bench-vs-juicefs.png)
+**A note on durability.** DittoFS and ZeroFS are *native* NFS→S3 servers; the
+others (JuiceFS, s3ql, rclone, s3fs) are FUSE/mount filesystems **re-exported**
+over the kernel NFS server. DittoFS writes through to its local block store
+(measured ~189 MB/s to disk) before acknowledging; several competitors
+acknowledge from a RAM/writeback cache. So DittoFS's lower sequential-write
+throughput is partly the cost of a durable local write, not a like-for-like loss.
 
-| Workload | DittoFS S3 | JuiceFS S3 | Advantage |
-|----------|-----------|------------|-----------|
-| Sequential Write | 50.7 MB/s | 31.2 MB/s | **1.6x** |
-| Sequential Read | 63.9 MB/s | 50.5 MB/s | **1.3x** |
-| Random Write | 635 IOPS | 60 IOPS | **10.6x** |
-| Random Read | 1,420 IOPS | 1,447 IOPS | ~1x (tied) |
-| Metadata | 609 ops/s | 7 ops/s | **87x** |
-| Small Files | 1,792 ops/s | 44 ops/s | **41x** |
+## Throughput & IOPS — large files (1 GiB), warm
 
-DittoFS's cache-first architecture means writes never block on S3 — they go to local cache and are uploaded asynchronously in the background. JuiceFS performs synchronous S3 writes on every commit, which destroys metadata and write performance.
+Sequential rows are MB/s; random / metadata / mixed rows are IOPS (metadata =
+ops/s). **Bold** = DittoFS. Best *real competitor* per row is marked ✦
+(local-disk excluded as the ceiling).
 
-## Test Environment
+| Workload | **DittoFS-S3** | ZeroFS | s3ql | JuiceFS | rclone | s3fs | local-disk ↑ |
+|---|--:|--:|--:|--:|--:|--:|--:|
+| seq-write (MB/s) | **156** | 204 | 310 | 1336 | 1523 | 1775 ✦ | 3287 |
+| seq-read (MB/s) | **677** | 13 | 552 | 1616 | 1181 | 2876 ✦ | 4774 |
+| rand-write 4k (IOPS) | **2365** | 2133 | 1256 | 826 | 17346 ✦ | 2183 | 40883 |
+| rand-read 4k (IOPS) | **4010** | 2568 | 39563 ✦ | 12418 | fail | 11101 | — |
+| metadata (ops/s) | **239** | 371 | 700 | 1824 ✦ | — | fail | — |
+| mixed-rw (IOPS) | **1256** | 1776 | 4928 ✦ | 281 | — | 4453 | — |
 
-| Parameter | Value |
-|-----------|-------|
-| Server | Scaleway GP1-XS (4 vCPU, 16 GB RAM, NVMe SSD) |
-| Client | Scaleway GP1-XS (separate instance, same AZ) |
-| Network | Private LAN (~100 Mbps effective) |
-| S3 Backend | Scaleway Object Storage (Paris region) |
-| Cache Size | 4 GB on server |
-| Duration | 60s per workload |
-| File Size | 1 GiB |
-| Block Size | 4 KiB |
-| Threads | 4 |
-| Metadata Files | 1,000 |
-| Small File Count | 10,000 |
-| NFS Version | NFSv4.1 (primary), NFSv3 (comparison) |
+## Random & metadata — medium files (1 MiB), warm
 
-### Systems Tested
+The smaller working set fits the re-export competitors' local page cache, so their
+random-read lead is starkest here. The native-S3 servers (DittoFS, ZeroFS) get no
+such free ride.
 
-| System | Type | S3 Backend | Description |
-|--------|------|------------|-------------|
-| **DittoFS S3** | Userspace NFS | Scaleway S3 | DittoFS with BadgerDB metadata + S3 payload, 4GB cache |
-| **JuiceFS S3** | FUSE + NFS re-export | Scaleway S3 | JuiceFS with Redis metadata + S3 storage |
-| **kernel NFS** | Kernel NFS | None (local disk) | Linux knfsd — theoretical upper bound for NFS performance |
+| Workload | **DittoFS-S3** | ZeroFS | s3ql | JuiceFS | rclone | s3fs | local-disk ↑ |
+|---|--:|--:|--:|--:|--:|--:|--:|
+| rand-write 4k (IOPS) | **2337** | 2885 | 3844 | 588 | 19231 | 25229 ✦ | 43712 |
+| rand-read 4k (IOPS) | **10981** | 2548 | 38636 | 45743 | fail | 46500 ✦ | 45835 |
+| metadata (ops/s) | **219** | 235 | 451 | 2597 ✦ | — | — | — |
 
-## Performance Overview
+## Cold reads — large files, first byte after cache-evict
 
-![Performance Summary Heatmap](assets/bench-summary.png)
+The S3-latency-bound axis. DittoFS's evict step (`dfsctl system drain-uploads`)
+errored this run, so its cold numbers are pending a re-run — but note how poorly
+the native-S3 servers do on a cold sequential read.
 
-Green = DittoFS wins, Red = competitor wins. DittoFS S3 matches or beats kernel NFS (local disk!) on sequential I/O, metadata, and small files. It only trails on random I/O where kernel NFS's direct VFS access has an inherent advantage.
+| Workload | DittoFS-S3 | ZeroFS | JuiceFS |
+|---|--:|--:|--:|
+| seq-read cold (MB/s) | pending | 10 | 56 |
+| rand-read cold (IOPS) | pending | 871 | — |
 
-### Performance Profile
+## Latency — large files, warm (µs, p50 / p99)
 
-![Radar Chart](assets/bench-radar.png)
+Lower is better. DittoFS's durable local-write path shows in its higher write
+tails; its read latencies are competitive.
 
-DittoFS S3 covers the largest area — strong across all dimensions. JuiceFS collapses on metadata, small-files, and random write due to synchronous S3 round-trips.
+| Workload | **DittoFS-S3** | ZeroFS | s3ql | JuiceFS | s3fs |
+|---|--:|--:|--:|--:|--:|
+| seq-write | **14 615 / 77 070** | 10 813 / 164 626 | 9 896 / 44 827 | 2 245 / 14 483 | 1 974 / 4 620 |
+| rand-write | **37 487 / 103 285** | 46 924 / 86 508 | 70 779 / 459 276 | 68 682 / 400 556 | 55 312 / 128 451 |
+| rand-read | **15 008 / 147 849** | 49 021 / 88 605 | 2 736 / 10 289 | 9 896 / 15 925 | 10 813 / 33 423 |
+| seq-read | **4 358 / 26 608** | 110 625 / 2 399 142 | 709 / 46 924 | 1 892 / 5 997 | 1 139 / 1 991 |
 
-## Detailed Results
+## Analysis
 
-### Sequential Throughput
+**Where DittoFS stands**
 
-![Sequential Throughput](assets/bench-throughput.png)
+1. **Metadata is the clearest deficit** — 239 ops/s, last of all seven backends
+   (ZeroFS 371, s3ql 700, JuiceFS 1824). It is the one axis DittoFS loses to the
+   entire field, and the highest-leverage target. It is directly addressed by the
+   in-flight metadata group-commit work (#1573).
 
-Sequential I/O is **network-limited** on this infrastructure (~50 MB/s write, ~64 MB/s read). DittoFS S3 saturates the link, proving zero overhead on the sequential hot path:
+2. **DittoFS leads the durable-write cohort** — on random-write (2365 IOPS) it
+   beats JuiceFS (826), s3ql (1256), s3fs (2183), and ZeroFS (2133); only rclone's
+   RAM-buffered VFS is faster. Sequential write (156 MB/s) is the lowest number,
+   but it is a durable through-to-disk write versus cache-acknowledged competitors.
 
-| System | Seq Write | Seq Read |
-|--------|-----------|----------|
-| **DittoFS S3 (NFSv4.1)** | **50.7 MB/s** | **63.9 MB/s** |
-| DittoFS S3 (NFSv3) | 50.8 MB/s | 63.9 MB/s |
-| kernel NFS | 49.2 MB/s | 63.9 MB/s |
-| JuiceFS S3 | 31.2 MB/s | 50.5 MB/s |
+3. **Read throughput is respectable, not dominant** — sequential read (677 MB/s)
+   beats s3ql (552) and dwarfs ZeroFS (13 MB/s, whose native-S3 read path collapses
+   under NFS). The re-export rivals win random-read only by serving 4k reads from a
+   local-FS page cache that DittoFS does not lean on.
 
-DittoFS S3 actually **beats kernel NFS on sequential write** (50.7 vs 49.2 MB/s = 103%) thanks to the cache-first write path.
+4. **ZeroFS is the instructive comparison** — a fellow native NFS→S3 server whose
+   sequential and random reads are far worse than DittoFS's. Being native-S3 is not
+   the handicap; the read/cache design is.
 
-### Random I/O
+## Reproducing
 
-![Random I/O](assets/bench-iops.png)
+The harness is `cmd/bench` (`dfsbench`), library code under `internal/dfsbench/`.
+`fio` must be on `PATH` (the dev shell provides it).
 
-| System | Rand Write | Rand Read |
-|--------|------------|-----------|
-| **DittoFS S3 (NFSv4.1)** | **635 IOPS** | **1,420 IOPS** |
-| DittoFS S3 (NFSv3) | 634 IOPS | 1,383 IOPS |
-| kernel NFS | 1,234 IOPS | 2,241 IOPS |
-| JuiceFS S3 | 60 IOPS | 1,447 IOPS |
+```sh
+go build -o dfsbench ./cmd/bench
 
-DittoFS S3 reaches **51% of kernel NFS** on random write and **63% on random read** — expected given the content-addressed cache layer vs kernel NFS's direct VFS access. Against JuiceFS, DittoFS delivers **10.6x more random write IOPS** (635 vs 60).
-
-### Metadata Operations
-
-![Metadata & Small Files](assets/bench-metadata.png)
-
-Metadata measures create + stat + delete cycles on 1,000 files. Small files measures create + read + stat + delete on 10,000 files (1-32 KB each).
-
-| System | Metadata | Small Files |
-|--------|----------|-------------|
-| **DittoFS S3 (NFSv4.1)** | **609 ops/s** | **1,792 ops/s** |
-| DittoFS S3 (NFSv3) | 146 ops/s | 154 ops/s |
-| kernel NFS | 290 ops/s | 492 ops/s |
-| JuiceFS S3 | 7 ops/s | 44 ops/s |
-
-DittoFS S3 **beats kernel NFS by 2.1x on metadata** (609 vs 290 ops/s) and **3.6x on small files** (1,792 vs 492 ops/s). This is a userspace S3-backed filesystem outperforming the Linux kernel NFS server with local disk.
-
-Against JuiceFS: **87x faster metadata**, **41x faster small files**. JuiceFS's synchronous S3 writes make metadata operations extremely expensive.
-
-### Latency Distribution
-
-![Latency Distribution](assets/bench-latency.png)
-
-DittoFS shows tight, predictable latency across all workloads:
-
-| Workload | DittoFS P50 | DittoFS P99 | kernel NFS P50 | JuiceFS P50 |
-|----------|------------|------------|----------------|-------------|
-| seq-write | 0.68 ms | 1.51 ms | 0.70 ms | 0.64 ms |
-| rand-write | 1.35 ms | 2.81 ms | 0.77 ms | 1.51 ms |
-| rand-read | 0.71 ms | 1.01 ms | 0.40 ms | 0.53 ms |
-| metadata | 1.00 ms | 4.46 ms | 2.85 ms | 8.55 ms |
-| small-files | 2.18 ms | 4.91 ms | 2.40 ms | 8.14 ms |
-
-DittoFS has the **lowest P50 metadata latency** (1.0 ms vs kernel NFS's 2.85 ms) and the **tightest P99 spread** on small files (4.91 ms vs kernel's 27.3 ms and JuiceFS's 949 ms).
-
-## NFSv3 vs NFSv4.1
-
-![NFSv3 vs NFSv4.1](assets/bench-nfs-versions.png)
-
-NFSv4.1 provides dramatic improvements for metadata-heavy workloads on DittoFS:
-
-| Workload | NFSv3 | NFSv4.1 | Improvement |
-|----------|-------|---------|-------------|
-| metadata | 146 ops/s | 609 ops/s | **4.2x** |
-| small-files | 154 ops/s | 1,792 ops/s | **11.6x** |
-| rand-read | 1,383 IOPS | 1,420 IOPS | 1.03x |
-| rand-write | 634 IOPS | 635 IOPS | ~1x |
-
-NFSv4.1's compound operations (SEQUENCE + PUTFH + OP in a single RPC) eliminate per-operation round trips that dominate NFSv3 metadata performance. **Always use NFSv4.1 with DittoFS.**
-
-## DittoFS vs kernel NFS
-
-DittoFS S3 is a **userspace filesystem writing to cloud object storage** competing against the Linux kernel NFS server with direct local disk access. Despite this fundamental disadvantage:
-
-| Metric | DittoFS S3 | kernel NFS | % of kernel |
-|--------|-----------|------------|-------------|
-| seq-write | 50.7 MB/s | 49.2 MB/s | **103%** |
-| seq-read | 63.9 MB/s | 63.9 MB/s | **100%** |
-| rand-write | 635 IOPS | 1,234 IOPS | 51% |
-| rand-read | 1,420 IOPS | 2,241 IOPS | 63% |
-| metadata | 609 ops/s | 290 ops/s | **210%** |
-| small-files | 1,792 ops/s | 492 ops/s | **364%** |
-
-DittoFS beats kernel NFS on **4 of 6 workloads** while providing S3 durability. The only workloads where kernel NFS leads are random I/O, where direct VFS access has an inherent latency advantage over DittoFS's content-addressed cache layer.
-
-## Why DittoFS Is Fast
-
-DittoFS's performance comes from its **cache-first architecture**:
-
-```
-NFS WRITE  ──▶  Cache (memory + disk)  ──▶  Return to client immediately
-                      │
-                      ▼ (async, background)
-              Periodic Uploader  ──▶  S3
+# Cloud run: provision one disposable VM, run the managed matrix, collect, tear down.
+dfsbench setup                              # SCW_* env selects type/zone/image
+dfsbench run --remote \
+  --systems dittofs-s3-nfs3,zerofs-nfs3,s3ql-nfs3,juicefs-nfs3,rclone-nfs3,s3fs-nfs3,local-disk-nfs3 \
+  --sizes medium,large
+dfsbench report --results ./bench-results   # re-render this comparison table
+dfsbench teardown
 ```
 
-1. **Writes never touch S3** — NFS WRITE goes to local cache, NFS COMMIT flushes to disk. S3 uploads happen asynchronously in the background.
-2. **Concurrent NFS dispatch** — Multiple NFS operations execute in parallel per connection.
-3. **BadgerDB metadata** — LSM-tree metadata store optimized for write-heavy workloads, outperforming kernel NFS's filesystem-based metadata.
-4. **Skip fsync for S3 backends** — The cache is a staging buffer, not the source of truth. Fsync is unnecessary overhead.
-5. **Smart block management** — Uploaded blocks are never re-sealed on overwrite, avoiding redundant S3 uploads.
-
-## Optimization History
-
-![Optimization Impact](assets/bench-improvement.png)
-
-Performance improvements from the `feat/cache-rewrite` branch optimization cycle:
-
-| Metric | Round 15 (baseline) | Round 24 (optimized) | Change |
-|--------|---------------------|---------------------|--------|
-| rand-write | 308 IOPS | 635 IOPS | **+106%** |
-| rand-read | 594 IOPS | 1,420 IOPS | **+139%** |
-| metadata | 486 ops/s | 609 ops/s | **+25%** |
-| small-files | — | 1,792 ops/s | *new workload* |
-
-### Key Optimizations Applied
-
-1. **COMMIT decoupled from S3 upload** — `Flush()` only writes to disk cache, returns immediately
-2. **Concurrent NFS dispatch** — goroutine-per-request with bounded semaphore
-3. **Skip fsync for S3 backends** — cache is staging buffer, not durable store
-4. **GetDirtyBlocks via Flush() return** — eliminates BadgerDB round-trip on commit
-5. **Don't re-seal uploaded blocks** — overwrites create new blocks, avoiding redundant uploads
-6. **Resettable upload timeout** — uses LastAccess instead of CreatedAt for upload scheduling
-7. **Removed runtime.GC()** — eliminated forced garbage collection from periodic uploader
-
-## Running benchmarks
-
-Component microbenchmarks live in their home package and run via `go test -bench`
-— no network, no mount, no cloud:
-
-```bash
-go test -bench=. -benchmem -run=^$ ./pkg/block/engine/    # write + read-path engine
-go test -bench=. -benchmem -run=^$ ./pkg/snapshot/        # snapshot create/manifest/verify scale
-go test -bench=. -benchmem -run=^$ ./pkg/block/chunker/   # FastCDC throughput
-go test -bench=. -benchmem -run=^$ ./pkg/block/           # BLAKE3 vs SHA-256
-```
-
-Use `-count=N` and [`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat)
-to A/B two commits.
-
-The **cross-system comparison harness** (`dfsbench`, `cmd/bench`) — DittoFS vs
-juicefs / s3ql / rclone-mount / s3fs over NFSv3 / NFSv4.1 / SMB3 on a single
-disposable Scaleway VM, with uniform fio metrics and a real server↔S3 bandwidth
-number for every system — is being built incrementally. See **issue #1602** and
-`.planning/2026-07-08-bench-harness-consolidation.md` for the plan and per-PR
-sequence.
-
-### Regenerating charts
-
-The charts above are generated from saved result JSON:
-
-```bash
-python3 -m venv /tmp/bench-charts
-/tmp/bench-charts/bin/pip install matplotlib numpy
-/tmp/bench-charts/bin/python3 scripts/gen-bench-charts.py
-```
-
-Charts are saved to `docs/assets/bench-*.png`.
-
-## Local perf gates
-
-Several in-tree microbenchmark gates protect hot paths under `go test`. They
-are skipped under `go test -short`; the heaviest ones are additionally opt-in
-via an env var because they allocate several GiB. These run on any machine — no
-mount or cloud infra needed.
-
-### Hash + chunker gates
-
-- **BLAKE3 throughput** — `TestBLAKE3AtLeast3xSHA256` (in `pkg/block/`) requires
-  BLAKE3 ≥ 3× SHA-256 throughput on amd64 when `D41_STRICT_GATE=1` is set. By
-  default, and always on arm64, it relaxes to ≥ 0.5× — Go's `crypto/sha256` uses
-  ARMv8 SHA hardware acceleration while `lukechampine.com/blake3` has no NEON
-  path on Apple Silicon, so a 3× ratio is not reachable there.
-- **FastCDC boundary stability** — `TestChunker_BoundaryStability_70pct` (in
-  `pkg/block/chunker/`) requires ≥ 70% of chunk boundaries preserved across
-  1–4096 byte shifts of the input stream.
-
-```bash
-D41_STRICT_GATE=1 go test -run=TestBLAKE3AtLeast3xSHA256 ./pkg/block/
-go test -run=TestChunker_BoundaryStability_70pct ./pkg/block/chunker/
-```
-
-### Read-path regression gate
-
-The read-path stack (binary-search lookup over `[]BlockRef`, CAS-keyed cache,
-per-share metadata coordinator) is guarded by an in-tree microbench gate in
-`pkg/block/engine/`:
-
-- `BenchmarkPerfGate_Phase12RandReadRegression` enforces rand-read IOPS staying
-  within 5% of a per-machine microbench floor (the `phase12MicrobenchFloorIOPS`
-  constant, conservatively anchored at 50,000 IOPS).
-- `TestPerfGate_Phase12_BinarySearchOverhead` caps `findBlocksForRange` average
-  cost across a large `[]BlockRef`.
-
-This microbench runs against the in-process memory local store with no remote —
-a CPU-floor measurement of the read path, NOT real S3. Real-S3 read throughput
-is captured separately by the macro reports above.
-
-```bash
-go test -bench=BenchmarkPerfGate_Phase12RandReadRegression -benchtime=10s -run=^$ \
-    ./pkg/block/engine/...
-go test -run=TestPerfGate_Phase12_BinarySearchOverhead -count=1 -v ./pkg/block/engine/...
-```
-
-To re-baseline on a new machine class: capture several runs, take the lowest
-ops/sec, multiply by 0.90, and update the floor constant — a deliberate
-calibration event that must be reviewed in PR.
-
-### Per-stage write-path profiling (#1555)
-
-The blocks-only write path splits into stages that each own a CPU and allocation
-budget. One `Benchmark*` per stage measures it *in isolation* against in-process
-memory stores, so a `-cpuprofile` / `-memprofile` run attributes cost to a single
-seam instead of a tangled end-to-end flow. All four are plain `testing.B` +
-`runtime/pprof` (no harness, no deps): standard
-`go test -benchmem -cpuprofile -memprofile` wiring is all that's needed.
-
-| Stage | Bench (package) | Code seam |
-| ----- | --------------- | --------- |
-| Append log | `BenchmarkAppendWrite_GroupCommit` (`pkg/block/local/fs/`) | `appendwrite.go` + `groupcommit.go` |
-| FastCDC chunker | `BenchmarkChunker_Throughput_64MiB` (`pkg/block/chunker/`) | `chunker.go` |
-| BLAKE3 hash | `BenchmarkBLAKE3_256MiB` (`pkg/block/`) | content-hash layer |
-| Streamer (carve→codec→PutBlock) | `BenchmarkStreamer_CarveCodecPutBlock` (`pkg/block/engine/`) | `carver.go:carveAndCommitBlock` + `blockcodec/codec.go` |
-
-```bash
-# Profile any single stage — CPU + heap attributed to that seam only:
-go test -bench=BenchmarkStreamer_CarveCodecPutBlock -benchmem -run=^$ \
-    -cpuprofile=cpu.out -memprofile=mem.out ./pkg/block/engine/
-go tool pprof -top cpu.out      # where the CPU went
-go tool pprof -top -alloc_space mem.out   # where the bytes were allocated
-```
-
-Two memory invariants are pinned as hard tests (fail the build, not just report):
-
-- `TestChunker_ConstantMemory` (`pkg/block/chunker/`) — the FastCDC scan is
-  allocation-free regardless of input size; `Next` must report offsets into the
-  caller's slice, never copy chunk bytes.
-- `TestStreamer_AllocationTracksBlockCount` (`pkg/block/engine/`) — the streamer's
-  allocation grows linearly with block count, not super-linearly with file size;
-  it must carve one block at a time, never buffer the whole file.
-
-GC + compaction is intentionally **not** benched here: #1487 reshaped that path
-and it is latency/sweep-bound rather than a CPU/alloc hot spot on the write path —
-a dedicated bench is deferred until there is a measured reason to add one.
-
-#### Baseline reading (Apple M1 Max, in-memory, `-benchtime=5x`)
-
-| Stage | ns/op | Throughput | B/op | allocs/op |
-| ----- | ----: | ---------: | ---: | --------: |
-| Append log (coalesced 64 B) | 4.6 ms | — | 353 | 6 |
-| FastCDC chunker (64 MiB) | 42.2 ms | 1,592 MB/s | **0** | **0** |
-| BLAKE3 hash (256 MiB) | 53.8 ms | 4,994 MB/s | 3.7 MB | 35,713 |
-| Streamer (64 MiB) | 19.6 ms | 3,426 MB/s | **346 MB** | 753 |
-
-Normalizing to cost-per-MiB pushed through the write path:
-
-- **CPU is dominated by the FastCDC chunker** — 0.63 ms/MiB, ~3× the hash
-  (0.20 ms/MiB) and ~2× the streamer (0.29 ms/MiB of codec framing + remote body
-  copy; hashing is the separate BLAKE3 stage above and is precomputed in the
-  streamer fixture, matching production carve, which reuses each chunk's
-  write-time hash). The boundary scan, not framing or upload, is the write-path
-  CPU floor.
-- **Allocations are dominated by the streamer** — ~346 MB allocated per 64 MiB
-  carved (~5× write amplification), from `bytes.Buffer` doubling growth while
-  assembling each block plus the remote body copy. The chunker is allocation-free;
-  the streamer is the only stage with a real allocation lever, and the cheap fix is
-  pre-sizing the carve buffer to the target block size — no format or sizing change.
-
-Gate call for the deferred perf issues this profiling was meant to decide:
-
-- **#1491 (decoupled log-blob / block sizing) — not justified by this data.** The
-  streamer's allocation cost is transient buffer growth, not sizing granularity;
-  a one-line buffer pre-size captures the win without decoupling the two sizes.
-- **#1488 (chunk-range refetch granularity) — read-path, not a write-path
-  bottleneck here.** The warm read path already avoids the WAN round-trip
-  (`BenchmarkReadThroughCache_ColdVsWarm`), so there is no measured pressure to
-  build finer read-miss granularity yet.
-
-Re-run all four on a new machine class before trusting the ranking — the absolute
-numbers are machine-specific; the *ordering* (chunker = CPU, streamer = allocs) is
-the durable finding.
-
-### A/B comparing commits
-
-For ad-hoc before/after work, run any package's `Benchmark*` against two commits
-and diff with `benchstat`:
-
-```bash
-go test -bench=. -count=10 -run=^$ ./pkg/block/engine/ > before.txt
-# ... check out the other commit ...
-go test -bench=. -count=10 -run=^$ ./pkg/block/engine/ > after.txt
-benchstat before.txt after.txt
-```
-
-## Snapshot scale limits
-
-Snapshot `create` does a metadata `Backup` (a streamed dump plus an in-RAM
-`HashSet` of every referenced block hash), writes a hash manifest, drains
-uploads, then verifies durability by HEAD-probing every manifest hash at
-concurrency 16. `restore` reads the manifest back, resets, restores the dump,
-and re-verifies. The benchmarks in `pkg/snapshot/` isolate the three cost
-centers (backup, manifest, verify) so a single benchmark can sweep file counts
-without standing up adapters / the control-plane DB / real S3.
-
-```bash
-# CI-safe sweep (1e4 / 1e5 files; 1e6 cases skipped under -short):
-go test -bench=. -benchmem -short -run=^$ ./pkg/snapshot/
-
-# Full sweep including 1e6-file scales (heavy — minutes, multi-GB allocs):
-go test -bench=. -benchmem -benchtime=1x -run=^$ -timeout=900s ./pkg/snapshot/
-```
-
-### Indicative numbers (Apple M1 Max, memory engine, in-memory remote)
-
-All-unique blocks (`--dedup 1`, the worst case for HashSet + manifest RAM),
-`benchtime=1x`. `dump_bytes` is streamed to a discard writer — it is the
-serialized dump size, not a resident buffer.
-
-| Scale (files × blocks) | unique hashes | backup ns/op | dump_bytes | manifest_bytes | verify ns/op (probes) |
-| ---------------------- | ------------: | -----------: | ---------: | -------------: | --------------------: |
-| 1e5 × 1                |       100,000 |        1.15 s |    35.0 MB |        6.5 MB |     0.14 s (100,000) |
-| 1e5 × 8                |       800,000 |        1.45 s |    67.2 MB |       52.0 MB |     1.39 s (800,000) |
-| 1e6 × 1                |     1,000,000 |        5.92 s |   350.0 MB |       65.0 MB |     1.95 s (1,000,000) |
-| 1e6 × 8                |     8,000,000 |       18.25 s |   672.0 MB |      520.0 MB |    25.27 s (8,000,000) |
-
-### Established limits & budget
-
-- **The badger dump is streamed.** The badger engine (KV-by-KV) and the manifest
-  writer emit to an `io.Writer` without buffering the whole dump. The dominant
-  create-path resident allocation is then the returned `HashSet`: one 32-byte
-  `ContentHash` per **unique** block, ~26 B/entry in the Go map. **Budget ~25 MB
-  of HashSet RAM per 1 M unique blocks**; 8 M unique blocks ≈ 200 MB.
-- **Manifest on disk is 65 bytes/hash** (64 hex + LF): 65 MB per 1 M hashes,
-  520 MB at 8 M. Written streamed; read back into a resident HashSet on restore.
-- **Verify is N HEAD round-trips at concurrency 16**, holding nothing across
-  probes. The in-memory-remote times above are a floor with zero network
-  latency. For an S3 budget, multiply the probe count by the real per-HEAD RTT ÷
-  16: e.g. 8 M probes at 20 ms/HEAD ≈ 167 minutes of verify, plus 8 M HEAD
-  charges. Large shares should size their verify window from the manifest hash
-  count, or create with `--no-verify` and accept `remote_durable=false`.
-- **The memory metadata engine is not suitable for TB/M-file shares.** It
-  gob-encodes its entire snapshot into one buffer during Backup. **Use the
-  badger engine for large shares; it streams the dump KV-by-KV.** Badger restore
-  also streams: entries apply via a bounded `WriteBatch`, the integrity CRC is
-  verified last, and any failure triggers `DropAll` to leave the store
-  empty/retryable.
-
-## Raw data
-
-Each result JSON contains per-workload metrics: throughput/IOPS, latency
-percentiles (p50/p95/p99), total + succeeded + failed operation counts, and
-structured per-op errors. `go test -bench` reports the same per-op metrics; the
-forthcoming `dfsbench` harness (#1602) emits the cross-system result JSON.
+S3 credentials stay in the environment (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`);
+the bucket and endpoint are set in the run config. See `bench/README.md` and
+`dfsbench list` for the full backend / workload / size matrix.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -41,7 +41,7 @@ ops/s). **Bold** = DittoFS. Best *real competitor* per row is marked ✦
 | seq-write (MB/s) | **156** | 204 | 310 | 1336 | 1523 | 1775 ✦ | 3287 |
 | seq-read (MB/s) | **677** | 13 | 552 | 1616 | 1181 | 2876 ✦ | 4774 |
 | rand-write 4k (IOPS) | **2365** | 2133 | 1256 | 826 | 17346 ✦ | 2183 | 40883 |
-| rand-read 4k (IOPS) | **4010** | 2568 | 39563 ✦ | 12418 | fail | 11101 | — |
+| rand-read 4k (IOPS) | **7437** † | 2568 | 39563 ✦ | 12418 | fail | 11101 | — |
 | metadata (ops/s) | **239** | 371 | 700 | 1824 ✦ | — | fail | — |
 | mixed-rw (IOPS) | **1256** | 1776 | 4928 ✦ | 281 | — | 4453 | — |
 
@@ -54,8 +54,18 @@ such free ride.
 | Workload | **DittoFS-S3** | ZeroFS | s3ql | JuiceFS | rclone | s3fs | local-disk ↑ |
 |---|--:|--:|--:|--:|--:|--:|--:|
 | rand-write 4k (IOPS) | **2337** | 2885 | 3844 | 588 | 19231 | 25229 ✦ | 43712 |
-| rand-read 4k (IOPS) | **10981** | 2548 | 38636 | 45743 | fail | 46500 ✦ | 45835 |
+| rand-read 4k (IOPS) | **24862** † | 2548 | 38636 | 45743 | fail | 46500 ✦ | 45835 |
 | metadata (ops/s) | **219** | 235 | 451 | 2597 ✦ | — | — | — |
+
+> † **DittoFS random-read reflects the warm-read fast path** (verify-once cache
+> + ranged sub-chunk reads, #1648/#1651, merged 2026-07-11) — measured in a
+> later same-VM run. Before it, DittoFS was 4010 (large) / 10981 (medium); the
+> fix removed a 256× read amplification (a whole ~1 MiB CAS chunk was read and
+> BLAKE3-verified to serve every 4 KiB), taking DittoFS from ~24–32% of JuiceFS
+> to ~56–58%. Competitor columns are the original full-suite run; JuiceFS
+> random-read varied <7% between the two runs, so the comparison holds. The gap
+> that remains is no longer the block read (20× faster at the engine level) but
+> per-read NFS + metadata overhead — see Analysis.
 
 ## Cold reads — large files, first byte after cache-evict
 
@@ -96,8 +106,18 @@ tails; its read latencies are competitive.
 
 3. **Read throughput is respectable, not dominant** — sequential read (677 MB/s)
    beats s3ql (552) and dwarfs ZeroFS (13 MB/s, whose native-S3 read path collapses
-   under NFS). The re-export rivals win random-read only by serving 4k reads from a
-   local-FS page cache that DittoFS does not lean on.
+   under NFS).
+
+4. **Random-read is much improved but still trails the page-cache re-exports.**
+   The warm-read fast path (#1648/#1651) removed the block store's 256× read
+   amplification — at the engine level a 4 KiB warm CAS read went from ~437 µs to
+   ~21 µs (~20×, ~47k IOPS). End to end over NFSv3 that lands as ~2× (7437 large /
+   24862 medium), moving DittoFS from ~24–32% of JuiceFS to ~56–58%. That the
+   engine's 20× only shows as ~2× on the wire means the block read is no longer the
+   bottleneck: what remains is **per-read NFS RPC + metadata lookup overhead**,
+   which the kernel-NFS re-exports (JuiceFS/s3fs) pay far less of because their
+   4 KiB reads are served straight from the Linux page cache. That per-read
+   server-side path is the next random-read target.
 
 4. **ZeroFS is the instructive comparison** — a fellow native NFS→S3 server whose
    sequential and random reads are far worse than DittoFS's. Being native-S3 is not

--- a/internal/dfsbench/backend/fuse.go
+++ b/internal/dfsbench/backend/fuse.go
@@ -63,6 +63,30 @@ func ensureInstalled(ctx context.Context, cmd, pkg string) error {
 		fmt.Sprintf("command -v %s >/dev/null || { apt-get update && apt-get install -y %s; }", cmd, pkg))
 }
 
+// s3qlVenv/s3qlTarball: s3ql was dropped from the Ubuntu archive (no apt
+// candidate on noble) and its PyPI sdist won't resolve on Python 3.12, so the
+// only reliable install is the upstream release tarball into a dedicated venv.
+const (
+	s3qlVenv    = "/opt/s3ql-venv"
+	s3qlTarball = "https://github.com/s3ql/s3ql/releases/download/s3ql-6.2.2/s3ql-6.2.2.tar.gz"
+)
+
+// ensureS3QL installs s3ql from the upstream tarball into a venv and exposes its
+// CLIs on PATH. Idempotent: a no-op once mkfs.s3ql resolves.
+func ensureS3QL(ctx context.Context) error {
+	return exec.Sh(ctx, "sh", "-c", `command -v mkfs.s3ql >/dev/null && exit 0
+set -e
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq python3-venv python3-dev libsqlite3-dev libfuse3-dev fuse3 pkg-config build-essential
+python3 -m venv `+s3qlVenv+`
+`+s3qlVenv+`/bin/pip install -q --upgrade pip wheel
+`+s3qlVenv+`/bin/pip install -q pyfuse3 "`+s3qlTarball+`"
+for b in mkfs.s3ql mount.s3ql umount.s3ql fsck.s3ql s3qladm s3qlctrl; do
+  ln -sf `+s3qlVenv+`/bin/"$b" /usr/local/bin/"$b"
+done`)
+}
+
 // clearDir empties dir (keeping the dir itself).
 func clearDir(ctx context.Context, dir string) error {
 	return exec.Sh(ctx, "sh", "-c", fmt.Sprintf("rm -rf %q/* %q/.[!.]* 2>/dev/null || true", dir, dir))
@@ -308,7 +332,7 @@ func juicefsWaitUploaded(ctx context.Context) {
 }
 
 func s3qlSetup(ctx context.Context, env BackendEnv) error {
-	if err := ensureInstalled(ctx, "mkfs.s3ql", "s3ql"); err != nil {
+	if err := ensureS3QL(ctx); err != nil {
 		return err
 	}
 	id, secret, err := s3Creds()

--- a/internal/dfsbench/backend/zerofs.go
+++ b/internal/dfsbench/backend/zerofs.go
@@ -132,11 +132,13 @@ func zerofsMount(ctx context.Context, proto Protocol) (string, error) {
 	// skew the native-vs-native comparison; rsize/wsize negotiate to the kernel
 	// default (1 MiB over TCP) for both.
 	opts := "nfsvers=3,tcp,port=" + zerofsNFSPort + ",mountport=" + zerofsNFSPort + ",actimeo=0,nolock"
-	// Retry a few times: zerofs's embedded NFS/MOUNT can still refuse the very
-	// first handshake right after it starts serving. zerofsStart already gates on
-	// the "serving" log line, so this only absorbs that last narrow race.
+	// zerofs logs "Starting NFS server" (the zerofsStart gate) within a few
+	// seconds of launch, but doesn't actually answer MOUNT/NFS RPCs until it has
+	// loaded the encryption key and warmed the LSM from S3 — ~35s on a cold cache.
+	// The mount is the only true readiness probe, so retry across a window wide
+	// enough to cover that warmup (measured ~40s on a fresh bucket prefix).
 	var err error
-	for a := 0; a < 5; a++ {
+	for a := 0; a < 45; a++ {
 		if err = exec.Sh(ctx, "mount", "-t", "nfs", "-o", opts, "127.0.0.1:/", clientMntDir); err == nil {
 			return clientMntDir, nil
 		}


### PR DESCRIPTION
Fixes the two `dfsbench` competitor backends that couldn't run, then replaces the stale `docs/BENCHMARKS.md` with a fresh full-field measurement.

## Backend fixes
- **zerofs** — `mount` failed with `exit 32`. The readiness gate greps the log for `Starting NFS server`, which zerofs emits ~4s after launch, but it doesn't answer MOUNT/NFS RPCs until it has loaded the encryption key and warmed the LSM from S3 (~35s on a cold cache). The mount is the only true readiness probe, so the retry window is widened from 5×2s (10s) to 45×2s (90s).
- **s3ql** — `apt-get install s3ql` returned exit 100: s3ql was dropped from the Ubuntu archive (no candidate on noble) and its PyPI sdist won't resolve on Python 3.12. Install the upstream release tarball (6.2.2) into a dedicated venv and symlink the CLIs onto PATH.

Both validated end-to-end on a live SCW VM: zerofs 20 cells, s3ql 14 cells, **0 workload errors**.

## BENCHMARKS.md
The old file was self-flagged `LEGACY / STALE — do not cite`. Replaced with a current 7-system NFSv3 run (develop @ `0d79ede1`): **DittoFS-S3 vs zerofs, s3ql, juicefs, rclone, s3fs**, with **local-disk** as the hardware ceiling. Includes throughput/IOPS (large + medium), cold reads, and latency, plus methodology and a reproduce section.

Headline: DittoFS leads the durable-write cohort on random-write, is respectable on reads, and its one clear deficit is **metadata ops/s** (last of seven) — the highest-leverage target, tied to #1573.

Numbers are single 30s cells on a shared cloud VM — trust shape/magnitude, not the third digit.