### PR TITLE
perf(metadata): coalesce parent-inode mtime out of rmdir/rename txns (#1643)

### DIFF
--- a/pkg/metadata/directory.go
+++ b/pkg/metadata/directory.go
@@ -227,6 +227,7 @@ func (s *Service) RemoveDirectory(ctx *AuthContext, parentHandle FileHandle, nam
 	// rmdir decrements the parent's link-count key (dropping the ".." ref, below).
 	// Serialize that per-parent against concurrent mkdir/rmdir on the same parent
 	// so the shared counter key is never a BadgerDB SSI conflict source (#1571).
+	now := time.Now()
 	defer s.lockParentLink(parentHandle)()
 	txErr := withRelaxedTransaction(store, ctx.Context, func(tx Transaction) error {
 		// Re-read the parent inside the transaction so the pre-op snapshot and
@@ -234,6 +235,10 @@ func (s *Service) RemoveDirectory(ctx *AuthContext, parentHandle FileHandle, nam
 		if txParent, pErr := tx.GetFile(ctx.Context, parentHandle); pErr == nil && txParent != nil {
 			parent = txParent
 		}
+		// Overlay any pending coalesced bump so Before reflects the same mtime a
+		// concurrent GETATTR would see (and that the prior op's After returned),
+		// keeping WCC continuity — the tx read only sees durable state (#1573).
+		s.mergeDirTimes(parentHandle, &parent.FileAttr)
 		wcc.Before = CopyFileAttr(&parent.FileAttr)
 
 		// Remove directory entry
@@ -254,18 +259,23 @@ func (s *Service) RemoveDirectory(ctx *AuthContext, parentHandle FileHandle, nam
 			}
 		}
 
-		// Update parent timestamps (including Atime per MS-FSA 2.1.4.4)
-		now := time.Now()
-		parent.Mtime = now
-		parent.Ctime = now
-		parent.Atime = now
-		wcc.After = CopyFileAttr(&parent.FileAttr)
-		return tx.PutFile(ctx.Context, parent)
+		return nil
 	})
 
 	if txErr != nil {
 		return nil, txErr
 	}
+
+	// Coalesce the parent directory timestamp bump (Mtime/Ctime/Atime per
+	// MS-FSA 2.1.4.4) out of the transaction, same as create/unlink, so the
+	// rmdir transaction touches only disjoint namespace keys and never the
+	// shared parent-inode key that made concurrent same-parent ops serialize
+	// (#1573/#1643). The read overlay (mergeDirTimes) makes the bump visible.
+	s.recordDirTimes(ctx.Context, parentHandle, now)
+	parent.Mtime = now
+	parent.Ctime = now
+	parent.Atime = now
+	wcc.After = CopyFileAttr(&parent.FileAttr)
 
 	// The removed directory can no longer be read; drop any coalesced timestamps
 	// still pending for it so the tracker map does not accumulate dead handles

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -779,6 +779,7 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 	// and inode paths — the moved file's size and block manifest are untouched,
 	// so this is pure namespace. A crash can lose the rename (old name
 	// persists), never corrupt data.
+	now := time.Now()
 	txErr := withRelaxedTransaction(store, ctx.Context, func(tx Transaction) error {
 		// Re-read the source/destination directories inside the transaction so
 		// the pre-op snapshots and the timestamp mutations derive from the same
@@ -786,11 +787,16 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 		if txSrc, sErr := tx.GetFile(ctx.Context, fromDir); sErr == nil && txSrc != nil {
 			srcDir = txSrc
 		}
+		// Overlay any pending coalesced bump so Before reflects the same mtime a
+		// concurrent GETATTR would see (the tx read only sees durable state), so
+		// WCC stays continuous across rapid same-dir mutations (#1573).
+		s.mergeDirTimes(fromDir, &srcDir.FileAttr)
 		rename.FromDir.Before = CopyFileAttr(&srcDir.FileAttr)
 		if !sameDir {
 			if txDst, dErr := tx.GetFile(ctx.Context, toDir); dErr == nil && txDst != nil {
 				dstDir = txDst
 			}
+			s.mergeDirTimes(toDir, &dstDir.FileAttr)
 			rename.ToDir.Before = CopyFileAttr(&dstDir.FileAttr)
 		}
 
@@ -885,26 +891,9 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 		// This is what makes hard links correct: renaming one name can never
 		// stale another name's path. PutFile is tx-critical: a failed ctime
 		// write must roll the whole rename back.
-		now := time.Now()
 		srcFile.Ctime = now
 		if err := tx.PutFile(ctx.Context, srcFile); err != nil {
 			return err
-		}
-
-		srcDir.Mtime = now
-		srcDir.Ctime = now
-		rename.FromDir.After = CopyFileAttr(&srcDir.FileAttr)
-		if err := tx.PutFile(ctx.Context, srcDir); err != nil {
-			return err
-		}
-
-		if !sameDir {
-			dstDir.Mtime = now
-			dstDir.Ctime = now
-			rename.ToDir.After = CopyFileAttr(&dstDir.FileAttr)
-			if err := tx.PutFile(ctx.Context, dstDir); err != nil {
-				return err
-			}
 		}
 
 		return nil
@@ -912,6 +901,21 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 
 	if txErr != nil {
 		return nil, txErr
+	}
+
+	// Coalesce the parent directory mtime/ctime bumps out of the transaction so
+	// a rename never writes the shared source/destination parent-inode keys
+	// inside the txn — the same treatment create/unlink/rmdir already get
+	// (#1573/#1643). The read overlay (mergeDirTimes) keeps the bump visible.
+	s.recordDirTimes(ctx.Context, fromDir, now)
+	srcDir.Mtime = now
+	srcDir.Ctime = now
+	rename.FromDir.After = CopyFileAttr(&srcDir.FileAttr)
+	if !sameDir {
+		s.recordDirTimes(ctx.Context, toDir, now)
+		dstDir.Mtime = now
+		dstDir.Ctime = now
+		rename.ToDir.After = CopyFileAttr(&dstDir.FileAttr)
 	}
 
 	// Notify directory change after successful move


### PR DESCRIPTION
Closes #1643.

## What

`rmdir` and cross-parent `rename` (Move) still wrote the shared parent-inode
key **inside** their transaction (`parent.Mtime = now; tx.PutFile(parent)`),
retaining the pre-#1573 contention profile: concurrent same-parent namespace
ops touch that one key inside the txn and serialize / SSI-retry on it under
BadgerDB.

This routes both paths through the same `DirTimesTracker` coalescing that
`create` and `unlink` already use:

- The parent mtime/ctime/atime bump is recorded **after commit** via
  `recordDirTimes`, not written inside the txn.
- Reads still see the latest timestamp through the `mergeDirTimes` overlay.
- The removal/move transaction now touches only disjoint namespace keys
  (child map, link-count — the latter already serialized per-parent by #1571).

Sibling of #1571 (parent link-count) and #1573 (create parent-mtime).

## Scope / expected impact

This closes a **concurrency/scalability** gap on the rmdir/rename axis. It is
*not* expected to move the `dfsbench` `metadata` workload number, which is
create+small-write only and already benefits from #1573's create-path
coalescing — flagged here so the benchmark delta isn't misread as a regression.

## Tests

- `go test ./pkg/metadata/...` — 2665 pass.
- Existing `TestParentMtimeContention` (create) and
  `TestConcurrentDirRenameNoParentLinkConflict` (rename link-count) stay green;
  WCC pre/post-op attrs for rmdir/rename are unchanged (verified in the
  directory/rename suites).