### PR TITLE
perf(block): verify-once cache for warm random reads (~3x, skip per-read blake3)

### DIFF
--- a/pkg/block/engine/warm_randread_bench_test.go
+++ b/pkg/block/engine/warm_randread_bench_test.go
@@ -1,0 +1,162 @@
+package engine_test
+
+// Warm local random-read benchmark + regression guard for the verified-chunk
+// cache (skip re-hashing immutable CAS chunks on every 4 KiB read).
+//
+// Unlike BenchmarkRandRead_Phase12 (memory local store, no disk, no blake3),
+// this drives the REAL fs local store: write a multi-MiB payload, DrainRollups
+// so the bytes live as rolled-up CAS chunks (WARM local read, no remote), then
+// do 4 KiB reads at random offsets through engine.Store.ReadAt — the exact
+// production warm path (ReadPayloadAt -> fillFromCASManifest -> ReadChunk ->
+// blake3 verify). Remote is nil so scheduleReadahead early-returns.
+//
+// Run:
+//   go test -run=XXX -bench=BenchmarkWarmRandRead_FS -benchtime=3s \
+//     -cpuprofile=/tmp/rr.prof -memprofile=/tmp/rr.mem ./pkg/block/engine/
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/block/local/fs"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metastore "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+const (
+	warmRRFileSize = 16 * 1024 * 1024 // multi-MiB payload
+	warmRRReadSize = 4096             // 4 KiB random read
+	warmRRSeed     = 42
+)
+
+// setupWarmFSFixture builds a full fs-backed engine over a memory metadata
+// store, writes warmRRFileSize bytes, and DrainRollups so the payload is a warm
+// local CAS read. Returns the store + payloadID + covering ChunkRef manifest.
+func setupWarmFSFixture(b *testing.B) (*engine.Store, string, []block.ChunkRef) {
+	b.Helper()
+	logger.SetLevel("ERROR")
+	b.Cleanup(func() { logger.SetLevel("INFO") })
+	ctx := context.Background()
+
+	ms := metastore.NewMemoryMetadataStoreWithDefaults()
+	shareName := "/warm"
+
+	// --- share + file row (mirrors createShare/createRealFile) ---
+	rootFile, err := ms.CreateRootDirectory(ctx, shareName, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory, Mode: 0o755,
+	})
+	if err != nil {
+		b.Fatalf("CreateRootDirectory: %v", err)
+	}
+	rootHandle, err := metadata.EncodeFileHandle(rootFile)
+	if err != nil {
+		b.Fatalf("EncodeFileHandle: %v", err)
+	}
+	handle, err := ms.GenerateHandle(ctx, shareName, "/data.bin")
+	if err != nil {
+		b.Fatalf("GenerateHandle: %v", err)
+	}
+	_, id, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		b.Fatalf("DecodeFileHandle: %v", err)
+	}
+	payloadID := "warm/" + id.String()
+	if err := ms.PutFile(ctx, &metadata.File{
+		ID: id, ShareName: shareName, Path: "/data.bin",
+		FileAttr: metadata.FileAttr{
+			Type: metadata.FileTypeRegular, Mode: 0o644, UID: 1000, GID: 1000,
+			PayloadID: metadata.PayloadID(payloadID),
+		},
+	}); err != nil {
+		b.Fatalf("PutFile: %v", err)
+	}
+	if err := ms.SetParent(ctx, handle, rootHandle); err != nil {
+		b.Fatalf("SetParent: %v", err)
+	}
+	if err := ms.SetChild(ctx, rootHandle, "data.bin", handle); err != nil {
+		b.Fatalf("SetChild: %v", err)
+	}
+	if err := ms.SetLinkCount(ctx, handle, 1); err != nil {
+		b.Fatalf("SetLinkCount: %v", err)
+	}
+
+	// --- fs engine (mirrors newEngineOverStore; nil remote) ---
+	localStore, err := fs.NewWithOptions(b.TempDir(), 256*1024*1024, ms, fs.FSStoreOptions{
+		LocalChunkIndex: ms,
+		MaxLogBytes:     128 * 1024 * 1024,
+		RollupWorkers:   2,
+		StabilizationMS: 3_600_000, // async rollup never fires; only explicit DrainRollups
+		RollupStore:     ms,
+		SyncedHashStore: ms,
+	})
+	if err != nil {
+		b.Fatalf("fs.NewWithOptions: %v", err)
+	}
+	syncer := engine.NewSyncer(localStore, nil, ms, engine.DefaultConfig())
+	bs, err := engine.New(engine.BlockStoreConfig{
+		Local:           localStore,
+		Remote:          nil,
+		Syncer:          syncer,
+		FileChunkStore:  ms,
+		Coordinator:     &testCoordinator{store: ms},
+		SyncedHashStore: ms,
+		ReadBufferBytes: 64 * 1024 * 1024,
+	})
+	if err != nil {
+		b.Fatalf("engine.New: %v", err)
+	}
+	if err := bs.Start(ctx); err != nil {
+		b.Fatalf("engine.Start: %v", err)
+	}
+	b.Cleanup(func() { _ = bs.Close() })
+
+	// --- write payload, then drain to CAS (warm local) ---
+	rng := rand.New(rand.NewSource(warmRRSeed)) //nolint:gosec // bench fixture
+	buf := make([]byte, warmRRFileSize)
+	if _, err := rng.Read(buf); err != nil {
+		b.Fatalf("rng.Read: %v", err)
+	}
+	if _, err := bs.WriteAt(ctx, payloadID, nil, buf, 0); err != nil {
+		b.Fatalf("WriteAt: %v", err)
+	}
+	if err := bs.DrainRollups(ctx); err != nil {
+		b.Fatalf("DrainRollups: %v", err)
+	}
+
+	f, err := ms.GetFile(ctx, handle)
+	if err != nil {
+		b.Fatalf("GetFile: %v", err)
+	}
+	blocks := f.Blocks
+	avg := warmRRFileSize / 1024
+	if len(blocks) > 0 {
+		avg /= len(blocks)
+	}
+	b.Logf("warm fixture: %d bytes, %d CAS chunks (avg %d KiB)", warmRRFileSize, len(blocks), avg)
+	return bs, payloadID, blocks
+}
+
+// BenchmarkWarmRandRead_FS profiles a 4 KiB random read served from warm local
+// CAS via the fs store. This is the CPU-attribution target.
+func BenchmarkWarmRandRead_FS(b *testing.B) {
+	bs, payloadID, blocks := setupWarmFSFixture(b)
+	ctx := context.Background()
+	dest := make([]byte, warmRRReadSize)
+	rng := rand.New(rand.NewSource(warmRRSeed)) //nolint:gosec // bench
+	maxOffset := warmRRFileSize - warmRRReadSize
+
+	b.SetBytes(warmRRReadSize)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		offset := uint64(rng.Intn(maxOffset))
+		if _, err := bs.ReadAt(ctx, payloadID, blocks, dest, offset); err != nil {
+			b.Fatalf("ReadAt: %v", err)
+		}
+	}
+	b.StopTimer()
+}

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -256,6 +256,11 @@ type FSStore struct {
 	// is SHARED with pendingFBs so queued updates mutate a single instance.
 	diskIndex sync.Map
 
+	// verified tracks CAS chunk hashes already BLAKE3-verified this process, so
+	// the warm read path skips re-hashing the whole covering chunk on every
+	// read of an immutable chunk (see verified_chunks.go / chunkTrusted).
+	verified *verifiedChunkSet
+
 	// fdPool pools open file descriptors for .blk files to avoid
 	// open+close syscalls on every 4KB random write in tryDirectDiskWrite.
 	fdPool *fdPool
@@ -585,6 +590,7 @@ func newFSStore(baseDir string, maxDisk int64, fileChunkStore block.EngineFileCh
 		files:         make(map[string]*fileInfo),
 		fdPool:        newFDPool(defaultFDPoolSize),
 		readFDPool:    newFDPool(defaultFDPoolSize),
+		verified:      newVerifiedChunkSet(verifiedChunkCap),
 		accessTracker: newAccessTracker(),
 		retention:     unsafe.Pointer(defaultRetention),
 		done:          make(chan struct{}),

--- a/pkg/block/local/fs/readpayload.go
+++ b/pkg/block/local/fs/readpayload.go
@@ -10,8 +10,6 @@ import (
 	"slices"
 	"sync"
 
-	"lukechampine.com/blake3"
-
 	"github.com/marmos91/dittofs/pkg/block"
 )
 
@@ -320,7 +318,7 @@ func (bc *FSStore) fillFromCASManifest(ctx context.Context, payloadID string, de
 				// past this chunk; the caller falls back to remote for it.
 				data = nil
 			}
-			if data != nil && block.ContentHash(blake3.Sum256(data)) != fb.Hash {
+			if data != nil && !bc.chunkTrusted(fb.Hash, data) {
 				// Local bytes are corrupt (blake3 of the on-disk chunk does not
 				// match the manifest hash). Do NOT serve them: leave this region
 				// uncovered so ReadPayloadAt returns a miss and the engine routes
@@ -409,7 +407,7 @@ func (bc *FSStore) fillFromCASManifestScan(ctx context.Context, payloadID string
 			}
 			return fmt.Errorf("ReadPayloadAt: Get chunk %s: %w", r.fb.Hash.String(), gerr)
 		}
-		if block.ContentHash(blake3.Sum256(data)) != r.fb.Hash {
+		if !bc.chunkTrusted(r.fb.Hash, data) {
 			// Corrupt local bytes: skip (leave uncovered) so the engine routes
 			// this read to the blake3-verified remote-fetch/heal path rather than
 			// serving silently-wrong data. Mirrors the fast-path guard above and

--- a/pkg/block/local/fs/verified_chunks.go
+++ b/pkg/block/local/fs/verified_chunks.go
@@ -1,0 +1,99 @@
+package fs
+
+import (
+	"sync"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+// verifiedChunkCap bounds one generation of the verified-chunk set. Entries are
+// 32-byte content hashes; two generations at this cap cost ~a few MiB per store
+// and cover a working set far larger than any single payload's chunk count (a
+// 64 GiB file at the ~1 MiB FastCDC average is only ~64k chunks). Per-store, so
+// it does not multiply with concurrent reads, only with shares.
+const verifiedChunkCap = 1 << 16
+
+// verifiedChunkSet is a bounded set of CAS chunk hashes whose on-disk bytes have
+// already been BLAKE3-verified in this process. CAS chunks are content-addressed
+// and immutable: a hash that verified once stays valid for the identical bytes,
+// so re-hashing the whole (~1 MiB) covering chunk on every 4 KiB read — the warm
+// random-read integrity gate — is redundant work. Membership lets the read path
+// verify each chunk once and skip it thereafter.
+//
+// Eviction is two-generation, not per-entry LRU: when the current generation
+// fills, it becomes the previous one and a fresh generation starts, dropping the
+// oldest half wholesale. This keeps add/contains O(1) with no list bookkeeping.
+// A chunk dropped from the set is simply re-verified on its next read.
+//
+// ponytail: two-generation approx-LRU; swap for a real LRU only if a
+// pathological churn pattern shows re-verify thrash in a profile.
+type verifiedChunkSet struct {
+	mu   sync.Mutex
+	cur  map[block.ContentHash]struct{}
+	prev map[block.ContentHash]struct{}
+	max  int
+}
+
+func newVerifiedChunkSet(max int) *verifiedChunkSet {
+	return &verifiedChunkSet{cur: make(map[block.ContentHash]struct{}), max: max}
+}
+
+// contains reports whether h was verified recently enough to still be tracked.
+// A nil set (an FSStore built outside newFSStore, e.g. a bare test literal)
+// always reports false, so callers fall back to a full verify.
+func (v *verifiedChunkSet) contains(h block.ContentHash) bool {
+	if v == nil {
+		return false
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if _, ok := v.cur[h]; ok {
+		return true
+	}
+	_, ok := v.prev[h]
+	return ok
+}
+
+// add records h as verified, rotating generations when the current one is full.
+// A nil set is a no-op (see contains).
+func (v *verifiedChunkSet) add(h block.ContentHash) {
+	if v == nil {
+		return
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if _, ok := v.cur[h]; ok {
+		return
+	}
+	if len(v.cur) >= v.max {
+		v.prev = v.cur
+		v.cur = make(map[block.ContentHash]struct{}, v.max)
+	}
+	v.cur[h] = struct{}{}
+}
+
+// chunkTrusted reports whether data may be served for CAS hash without a fresh
+// integrity check. It short-circuits true when hash is already in the verified
+// set; otherwise it BLAKE3-hashes data, records a match, and returns whether it
+// matched. A false result means the local bytes are corrupt and MUST NOT be
+// served — the caller routes the read to the remote-verified heal path instead.
+//
+// The tradeoff of skipping re-verification: once a chunk verifies, later reads
+// serve it without re-hashing, so on-disk bit-rot that develops after the first
+// read of a still-tracked chunk goes undetected until the entry is evicted (or
+// the chunk re-fetched). In practice the first read pulls the chunk into the OS
+// page cache, so subsequent reads come from RAM rather than re-touching the
+// platter, and competitors serving from page cache verify nothing at all — this
+// keeps a per-chunk first-touch integrity gate they lack.
+func (bc *FSStore) chunkTrusted(hash block.ContentHash, data []byte) bool {
+	if bc.verified.contains(hash) {
+		return true
+	}
+	if block.ContentHash(blake3.Sum256(data)) != hash {
+		return false
+	}
+	bc.verified.add(hash)
+	return true
+}

--- a/pkg/block/local/fs/verified_chunks_test.go
+++ b/pkg/block/local/fs/verified_chunks_test.go
@@ -1,0 +1,70 @@
+package fs
+
+import (
+	"testing"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+func hashOf(b []byte) block.ContentHash { return block.ContentHash(blake3.Sum256(b)) }
+
+func TestVerifiedChunkSet_AddContainsAndTwoGenEviction(t *testing.T) {
+	v := newVerifiedChunkSet(2) // tiny cap so we can force a generation rotation
+
+	a, b, c, d := hashOf([]byte("a")), hashOf([]byte("b")), hashOf([]byte("c")), hashOf([]byte("d"))
+
+	v.add(a)
+	v.add(b)
+	if !v.contains(a) || !v.contains(b) {
+		t.Fatal("a and b should be tracked after add")
+	}
+
+	// cur is full (len 2 == max). Adding c rotates: cur{a,b} -> prev, cur = {c}.
+	v.add(c)
+	if !v.contains(c) {
+		t.Fatal("c should be tracked")
+	}
+	if !v.contains(a) || !v.contains(b) {
+		t.Fatal("a,b should still be reachable in prev generation")
+	}
+
+	// cur now {c}. Fill it then rotate again: adding d then e drops the {a,b} gen.
+	v.add(d) // cur {c,d}
+	e := hashOf([]byte("e"))
+	v.add(e) // cur full -> {c,d} becomes prev, cur = {e}; {a,b} generation dropped
+	if !v.contains(e) || !v.contains(c) || !v.contains(d) {
+		t.Fatal("e (cur) and c,d (prev) should be tracked")
+	}
+	if v.contains(a) || v.contains(b) {
+		t.Fatal("a,b should have been evicted with the oldest generation")
+	}
+}
+
+func TestChunkTrusted_VerifiesOnceThenTrusts(t *testing.T) {
+	bc := &FSStore{verified: newVerifiedChunkSet(verifiedChunkCap)}
+	data := []byte("some immutable CAS chunk bytes")
+	h := hashOf(data)
+
+	// First call: not yet tracked -> hashes, matches, records, returns true.
+	if !bc.chunkTrusted(h, data) {
+		t.Fatal("matching hash should be trusted")
+	}
+	if !bc.verified.contains(h) {
+		t.Fatal("a verified chunk must be recorded so later reads skip re-hashing")
+	}
+	// Second call: served from the set (still true) — the point of the cache.
+	if !bc.chunkTrusted(h, data) {
+		t.Fatal("cached chunk should stay trusted")
+	}
+
+	// A hash that does not match its bytes must never be trusted or recorded.
+	wrong := hashOf([]byte("different bytes"))
+	if bc.chunkTrusted(wrong, data) {
+		t.Fatal("mismatched hash/bytes must not be trusted")
+	}
+	if bc.verified.contains(wrong) {
+		t.Fatal("a failed verify must not be recorded")
+	}
+}


### PR DESCRIPTION
## Problem

Profiling the warm 4 KiB random-read hot path (`engine.Store.ReadAt` → `ReadPayloadAt` → `fillFromCASManifest`) showed **~518 µs per read**, dominated by two halves of one root cause — the engine materializes and BLAKE3-verifies an entire ~1 MiB FastCDC chunk to serve 4 KiB:

1. **BLAKE3 whole-chunk verify — ~116 µs/read**, and its parallel worker-pool fan-out drives **69% of per-read allocations** and most of the goroutine-sync churn. Added by #1644 as the warm-read integrity gate.
2. Full-chunk pread + 1 MiB buffer alloc to serve 4 KiB (256× amplification) — the remaining cost, addressed separately.

This matches the competitor benchmark shape: dittofs rand-read-4k on **large** files (4010 IOPS) is worse than **medium** (10981) precisely because larger files have larger chunks → more per-read hashing.

## Fix

CAS chunks are content-addressed and **immutable** — a chunk that BLAKE3-verifies once stays valid for the identical bytes, so re-hashing it on every read is pure waste. This adds a bounded per-store **verified-chunk set** (`verified_chunks.go`): the read path verifies each chunk once, records the hash, and skips re-hashing on subsequent reads. Two-generation eviction bounds memory (~a few MiB/store) with O(1) ops.

Integrity is preserved where it matters: corrupt bytes still fail the **first** verify and route to the remote-verified heal path; an evicted chunk is simply re-verified next read; and this keeps a per-chunk first-touch gate that page-cache-serving competitors (JuiceFS/s3ql/s3fs) don't have at all. The documented tradeoff: post-verify on-disk bit-rot of a still-tracked chunk goes undetected until eviction — but after first read the chunk is in the OS page cache, so later reads come from RAM, not the platter.

## Measured (engine microbenchmark, 16 MiB payload, 4 KiB random reads, warm local CAS)

| | before | after |
|---|--:|--:|
| ns/op | 437 µs | **148 µs** (~3.0×) |
| allocs/op | 183 | **32** (−83%) |
| MB/s | 9.4 | **27.7** |

`BenchmarkWarmRandRead_FS` is included as a regression guard.

## Tests

- New `verified_chunks_test.go` — two-generation eviction + verify-once/reject-corrupt semantics.
- `go test ./pkg/block/...` — 1228 pass; `-race` on `fs`+`engine` clean; corrupt-chunk integrity tests (`readpayload_verify_test.go`) still green.

## Follow-up

The remaining ~1 MiB read+alloc per 4 KiB (cost #2) needs a ranged sub-chunk read on a verified hit — separate PR. Refs #1225.