### PR TITLE
fix(block): fetch all covering chunks on cold read + reclaim read-through-staged blobs

### DIFF
--- a/pkg/block/engine/cold_read_subblock_test.go
+++ b/pkg/block/engine/cold_read_subblock_test.go
@@ -1,0 +1,84 @@
+package engine_test
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"lukechampine.com/blake3"
+
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestColdReadIntegrity_SubBlockChunks reproduces the blocks-flip SMB cold-read
+// corruption: a 16 MiB file rolls up into ~1 MiB FastCDC chunks (random data
+// hits breakpoints near MinChunkSize), so each 8 MiB engine block holds several
+// chunks. After DrainLocalSynced evicts the local tier, the whole file is read
+// back in 1 MiB windows (SMB's max-read shape).
+//
+// Before the fix, EnsureAvailableAndRead iterated 8 MiB block indices and
+// resolved only the chunk covering blockIdx*BlockSize, so every read window
+// past a block's first chunk was never fetched — served as zeros/stale bytes
+// (and only the block-aligned chunks were staged locally). SMB exercises this
+// because it has no page cache; NFS's page cache serves the read locally and
+// never drives the server read path, which is why the NFS variant passed.
+func TestColdReadIntegrity_SubBlockChunks(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	mem := remotememory.New()
+	bs := newEngineWithRemote(t, ms, mem)
+
+	rootHandle := createShare(t, ms, "coldsub")
+	pid, _ := createRealFile(t, ms, "coldsub", "big.bin", rootHandle)
+
+	const oneMiB = 1024 * 1024
+	const fileSize = 16 * oneMiB
+	src := make([]byte, fileSize)
+	rand.New(rand.NewSource(0x5EED)).Read(src) //nolint:gosec // deterministic fixture
+
+	for off := 0; off < fileSize; off += oneMiB {
+		if _, err := bs.WriteAt(ctx, pid, nil, src[off:off+oneMiB], uint64(off)); err != nil {
+			t.Fatalf("WriteAt off=%d: %v", off, err)
+		}
+	}
+	if _, err := bs.Flush(ctx, pid); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := bs.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups: %v", err)
+	}
+	if err := bs.DrainAllUploads(ctx); err != nil {
+		t.Fatalf("DrainAllUploads: %v", err)
+	}
+	// Force a genuine cold read: seal + evict every synced local block so the
+	// read path must round-trip to the remote (mirrors the e2e `evict`).
+	if _, err := bs.DrainLocalSynced(ctx); err != nil {
+		t.Fatalf("DrainLocalSynced: %v", err)
+	}
+
+	buf := make([]byte, oneMiB)
+	for i := 0; i < fileSize/oneMiB; i++ {
+		for j := range buf {
+			buf[j] = 0xAA // poison so an unfilled window fails instead of hiding in zeros
+		}
+		off := uint64(i) * oneMiB
+		n, err := bs.ReadAt(ctx, pid, nil, buf, off)
+		if err != nil {
+			t.Fatalf("ReadAt off=%d: %v", off, err)
+		}
+		if n != oneMiB {
+			t.Fatalf("ReadAt off=%d short read n=%d", off, n)
+		}
+		want := src[off : off+oneMiB]
+		if blake3.Sum256(buf) != blake3.Sum256(want) {
+			for j := range buf {
+				if buf[j] != want[j] {
+					t.Fatalf("COLD READ MISMATCH window=%d off=%d +%d got=0x%02x want=0x%02x",
+						i, off, j, buf[j], want[j])
+				}
+			}
+			t.Fatalf("COLD READ MISMATCH window=%d (hash differs, no byte diff?)", i)
+		}
+	}
+}

--- a/pkg/block/engine/engine_dualread_test.go
+++ b/pkg/block/engine/engine_dualread_test.go
@@ -403,15 +403,19 @@ func TestEnsureAvailableAndRead_RelocatedChunkReResolvesOnMiss(t *testing.T) {
 	env.rs.onReadChunk = relocateOnFirstRead(t, env, oldBlockID, newBlockID, hash, data)
 
 	dest := make([]byte, len(data))
-	filled, err := env.syncer.EnsureAvailableAndRead(ctx, payloadID, 0, uint32(len(data)), dest)
-	if err != nil {
+	if _, err := env.syncer.EnsureAvailableAndRead(ctx, payloadID, 0, uint32(len(data)), dest); err != nil {
 		t.Fatalf("EnsureAvailableAndRead: relocated chunk must re-resolve and read through, got %v", err)
 	}
-	if !filled {
-		t.Fatal("EnsureAvailableAndRead filled=false; want the demand read served from the relocated block")
+	// New contract: EnsureAvailableAndRead ensures every covering chunk is LOCAL
+	// and returns (false, nil); it no longer copies into dest (the caller's
+	// readLocalByHash does the correct per-offset assembly). Verify the relocated
+	// bytes were staged locally, byte-identical.
+	staged, err := env.syncer.local.Get(ctx, hash)
+	if err != nil {
+		t.Fatalf("relocated chunk not staged locally after re-resolve: %v", err)
 	}
-	if !bytes.Equal(dest, data) {
-		t.Fatalf("demand read data mismatch: got %q, want %q", dest, data)
+	if !bytes.Equal(staged, data) {
+		t.Fatalf("staged chunk mismatch: got %q, want %q", staged, data)
 	}
 	// One miss + one re-resolved hit: single bounded retry, not a loop.
 	if n := env.rs.readChunkCalls.Load(); n != 2 {

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync/atomic"
 
 	"golang.org/x/sync/errgroup"
 	"lukechampine.com/blake3"
@@ -352,94 +351,92 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 		return false, nil // Local-only: all data must be in local store, no downloads possible
 	}
 
-	startBlockIdx, endBlockIdx := blockRange(offset, length)
+	end := offset + uint64(length)
 
-	// Resolve the covering chunk per block via the indexed lookup
-	// (resolveCovering) rather than enumerating the whole manifest. Each block
-	// is a cheap single-chunk lookup, so the all-local probe and the download
-	// loop each resolve independently; a genuine store error now propagates
-	// (the prior in-memory snapshot could not surface one mid-loop).
+	// Resolve EVERY chunk covering [offset, end), not just the chunk at each
+	// 8 MiB block-aligned offset. FastCDC chunks are typically smaller than
+	// BlockSize, so a block holds several chunks and a read window routinely
+	// spans chunk boundaries. The old loop iterated block indices and resolved
+	// only the chunk covering blockIdx*BlockSize, so every read window past a
+	// block's first chunk went unfetched — served as zeros/stale bytes — and
+	// only the block-aligned chunks were staged locally. Walk the actual
+	// covering chunks (mirrors readLocalByHash / fillFromCASManifest) so the
+	// whole window is downloaded.
+	type pending struct {
+		blockIdx uint64
+		fb       *block.FileChunk
+	}
+	var toFetch []pending
 	allLocal := true
-	for blockIdx := startBlockIdx; blockIdx <= endBlockIdx; blockIdx++ {
-		fb, err := m.resolveFileChunk(ctx, payloadID, blockIdx)
+	for cur := offset; cur < end; {
+		fb, absOff, err := resolveCovering(ctx, m.fileChunkStore, payloadID, cur)
 		if err != nil {
 			return false, err
 		}
+		if fb == nil {
+			// Sparse hole at cur: no chunk covers it. Probe the next block
+			// boundary — real files are fully written (no holes), and this
+			// keeps parity with the old block-strided probe for sparse layouts
+			// that place chunks at block starts. The caller's readLocalByHash
+			// zero-fills any bytes left uncovered.
+			cur = (cur/uint64(BlockSize) + 1) * uint64(BlockSize)
+			continue
+		}
 		if !m.blockIsLocalFromRow(ctx, fb) {
 			allLocal = false
-			break
+			toFetch = append(toFetch, pending{blockIdx: absOff / uint64(BlockSize), fb: fb})
 		}
+		next := absOff + uint64(fb.DataSize)
+		if next <= cur {
+			next = cur + 1 // guard: a zero/short DataSize row must still advance
+		}
+		cur = next
 	}
 	if allLocal {
+		// Every covering chunk is already local — let the caller assemble the
+		// window from the local tier (readLocalByHash) with a correct
+		// per-offset copy.
 		return false, nil
 	}
 
 	// Health gate: fail fast when remote is unreachable
 	if !m.IsRemoteHealthy() {
 		m.offlineReadsBlocked.Add(1)
-		m.logOfflineRead("EnsureAvailableAndRead", payloadID, startBlockIdx)
+		m.logOfflineRead("EnsureAvailableAndRead", payloadID, offset/uint64(BlockSize))
 		return false, m.remoteUnavailableError()
 	}
 
-	var filledFlag, needLocalFlag atomic.Bool
-
-	// Fetch the missing blocks concurrently rather than one S3 round-trip at a
-	// time. A cold sequential read spans many blocks, and a serial demand loop
-	// pins throughput at blockSize/latency (one GET per RTT) — the cold-read
-	// wall. fetchGroup bounds the fan-out by ParallelDownloads (the same knob
-	// and helper the warm path uses). Each block writes a DISJOINT region of
-	// dest, and inlineFetchOrWait's in-flight map dedups concurrent callers, so
-	// the fan-out is race-free; the first error cancels the rest via gctx.
+	// Download the missing chunks concurrently rather than one S3 round-trip at
+	// a time. A cold sequential read spans many chunks, and a serial demand loop
+	// pins throughput at chunkSize/latency (one GET per RTT) — the cold-read
+	// wall. fetchGroup bounds the fan-out by ParallelDownloads; inlineFetchOrWait
+	// stages each chunk into the local tier and dedups concurrent callers (now
+	// keyed per chunk), so the fan-out is race-free and the first error cancels
+	// the rest via gctx. We deliberately do NOT copy to dest here: a chunk can
+	// start mid-window, so a block-relative copy is wrong — the caller's
+	// readLocalByHash does the correct per-offset assembly from the now-local
+	// chunks. The extra local pass is cheap next to the S3 GETs just eliminated.
+	//
+	// Readahead is driven from Store.ReadAt on EVERY read (scheduleReadahead),
+	// so the demand path no longer schedules prefetch here.
 	g, gctx := m.fetchGroup(ctx)
-	for blockIdx := startBlockIdx; blockIdx <= endBlockIdx; blockIdx++ {
+	for _, p := range toFetch {
 		if gctx.Err() != nil {
-			break // first error/cancel: stop scheduling the remaining blocks
+			break // first error/cancel: stop scheduling the remaining chunks
 		}
-		blockIdx := blockIdx
+		p := p
 		g.Go(func() error {
-			fb, err := m.resolveFileChunk(gctx, payloadID, blockIdx)
-			if err != nil {
-				return err
-			}
-			if m.blockIsLocalFromRow(gctx, fb) {
-				needLocalFlag.Store(true)
-				return nil
-			}
-			data, downloaded, err := m.inlineFetchOrWait(gctx, payloadID, blockIdx, fb)
-			if err != nil {
-				return err
-			}
-			if !downloaded {
-				needLocalFlag.Store(true)
-				return nil
-			}
-			if data == nil {
-				zeroBlockRegion(dest, blockIdx, offset, uint64(length))
-				filledFlag.Store(true)
-				return nil
-			}
-			if copyBlockToDest(dest, data, blockIdx, offset, uint64(length)) {
-				filledFlag.Store(true)
-			}
-			return nil
+			_, _, err := m.inlineFetchOrWait(gctx, payloadID, p.blockIdx, p.fb)
+			return err
 		})
 	}
 	if err := g.Wait(); err != nil {
 		return false, err
 	}
-	filled := filledFlag.Load()
-	needLocalReadAt := needLocalFlag.Load()
 
-	// Readahead is driven from Store.ReadAt on EVERY read (scheduleReadahead),
-	// so the demand path no longer schedules prefetch here. The old on-miss
-	// trigger stalled once a sequential reader started hitting the local tier —
-	// EnsureAvailableAndRead is not even reached on a local hit — so the window
-	// stopped advancing exactly when it needed to stay ahead.
-
-	if needLocalReadAt {
-		return false, nil // Some blocks were in local store -- caller should use local store ReadAt
-	}
-	return filled, nil
+	// Bytes are now local (or genuinely sparse); the caller re-reads via
+	// readLocalByHash for the correct assembly.
+	return false, nil
 }
 
 // inlineFetchOrWait downloads a block inline or waits for an in-flight download.
@@ -448,7 +445,16 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 // fb is the caller's already-resolved covering FileChunk for the block; a nil
 // fb is a sparse block (nothing to fetch).
 func (m *Syncer) inlineFetchOrWait(ctx context.Context, payloadID string, blockIdx uint64, fb *block.FileChunk) ([]byte, bool, error) {
+	// Dedup key must be per-CHUNK, not per-block: a read window can span several
+	// chunks that live in the same 8 MiB block (FastCDC chunks are typically
+	// smaller than BlockSize), so keying by blockIdx alone would make the second
+	// chunk piggyback on the first's in-flight slot and never get downloaded.
+	// fb.ID is "<payloadID>/<absOffset>" — unique per chunk — and demand and
+	// prefetch resolve the same fb.ID for the same chunk, so they still dedup.
 	key := inFlightKey(payloadID, blockIdx)
+	if fb != nil {
+		key = fb.ID
+	}
 
 	m.inFlightMu.Lock()
 	if existing, ok := m.inFlight[key]; ok {
@@ -553,45 +559,4 @@ func (m *Syncer) completeInFlight(key string, result *fetchResult, err error) {
 	m.inFlightMu.Lock()
 	delete(m.inFlight, key)
 	m.inFlightMu.Unlock()
-}
-
-// blockRegion computes the source offset within a block and destination offset within
-// the read buffer for a given block, read offset, and read length.
-// Returns (srcOffset, destOffset, copyLen). copyLen=0 means no overlap.
-func blockRegion(blockIdx, readOffset, readLength, blockDataLen uint64) (srcOff, destOff, copyLen uint64) {
-	blockStart := blockIdx * uint64(BlockSize)
-	if readOffset > blockStart {
-		srcOff = readOffset - blockStart
-	}
-	if blockStart > readOffset {
-		destOff = blockStart - readOffset
-	}
-	if srcOff >= blockDataLen || destOff >= readLength {
-		return 0, 0, 0
-	}
-	available := blockDataLen - srcOff
-	remaining := readLength - destOff
-	copyLen = available
-	if remaining < copyLen {
-		copyLen = remaining
-	}
-	return srcOff, destOff, copyLen
-}
-
-// zeroBlockRegion zeroes the portion of dest that corresponds to a sparse block.
-func zeroBlockRegion(dest []byte, blockIdx, offset, length uint64) {
-	_, destOff, n := blockRegion(blockIdx, offset, length, uint64(BlockSize))
-	if n > 0 && int(destOff+n) <= len(dest) {
-		clear(dest[destOff : destOff+n])
-	}
-}
-
-// copyBlockToDest copies the relevant portion of block data into dest.
-func copyBlockToDest(dest, data []byte, blockIdx, offset, length uint64) bool {
-	srcOff, destOff, n := blockRegion(blockIdx, offset, length, uint64(len(data)))
-	if n > 0 && int(destOff+n) <= len(dest) && int(srcOff+n) <= len(data) {
-		copy(dest[destOff:destOff+n], data[srcOff:srcOff+n])
-		return true
-	}
-	return false
 }

--- a/pkg/block/engine/gc.go
+++ b/pkg/block/engine/gc.go
@@ -486,6 +486,20 @@ func collectGarbage(
 	switch {
 	case isLocal:
 		sweepByWalk(ctx, store, gcs, stats, snapshotTime, gracePeriod, dryRunSample, options)
+		// Reclaim the physical bytes of any log blob the sweep just fully
+		// orphaned. sweepByWalk (DeleteChunk) removes a chunk's index entry but
+		// blob bytes are reclaimed only by blob-level eviction, which skips the
+		// still-open ACTIVE blob — so read-through-staged chunks that land in
+		// the active blob would otherwise leak local disk after an unlink.
+		if !options.DryRun {
+			if r, ok := store.(deadBlobReclaimer); ok {
+				if freed, err := r.ReclaimDeadBlobs(ctx); err != nil {
+					recordGCError(stats, "reclaim dead blobs: "+err.Error())
+				} else {
+					stats.BytesFreed += freed
+				}
+			}
+		}
 	case options.SyncedHashIndex != nil:
 		sweepFromSyncedIndex(ctx, gcs, stats, snapshotTime, gracePeriod, dryRunSample, options)
 	default:
@@ -616,6 +630,14 @@ func sharesForReconciler(r MetadataReconciler) []string {
 // per-run counters (scanned/swept/bytes) from inside the callback. The local
 // backend (filepath.WalkDir) honors this; a backend that parallelizes Walk must
 // serialize the callback before satisfying this interface.
+// deadBlobReclaimer is the optional local-store surface the local GC sweep uses
+// to reclaim the physical bytes of log blobs it just fully orphaned (the fs
+// store implements it; other backends do not need it). Kept off sweepable so
+// only the local tier reaches for it.
+type deadBlobReclaimer interface {
+	ReclaimDeadBlobs(ctx context.Context) (int64, error)
+}
+
 type sweepable interface {
 	Walk(ctx context.Context, fn func(block.ContentHash, block.Meta) error) error
 	Delete(ctx context.Context, hash block.ContentHash) error

--- a/pkg/block/local/fs/eviction.go
+++ b/pkg/block/local/fs/eviction.go
@@ -687,6 +687,97 @@ func (bc *FSStore) DrainLocalSynced(ctx context.Context) (int64, error) {
 	}
 }
 
+// ReclaimDeadBlobs reclaims the physical bytes of log blobs whose chunks have
+// all been removed from the local index — e.g. read-through-staged chunks the
+// mark-sweep GC dropped after an unlink. DeleteChunk (the sweep) removes a
+// chunk's index entry, but blob bytes are reclaimed only by blob-level
+// eviction, which skips the still-open ACTIVE blob. A read-through-staged chunk
+// (FSStore.Put) lands in the active blob, so after a GC sweep its bytes would
+// otherwise leak: logBlobDiskUsed stays non-zero and never drains (only an
+// explicit evict/DrainLocalSynced would seal the active blob).
+//
+// This seals a fully-dead active blob so its bytes become evictable, then
+// evicts every SEALED blob that has no live index entry left. A blob with ANY
+// live chunk (synced or not) is left untouched — no live data is dropped here;
+// reclaiming a blob that still holds live chunks is compaction's job under
+// memory pressure (#1497). Safe to call after each local GC sweep.
+func (bc *FSStore) ReclaimDeadBlobs(ctx context.Context) (int64, error) {
+	if bc.logBlob == nil || bc.localChunkIndex == nil {
+		return 0, nil
+	}
+
+	// Seal the active blob when it is now fully dead so blobEvictOne can reclaim
+	// it. Only seal a fully-dead active blob, so we never spin out empty blobs
+	// or churn a blob that still backs live reads.
+	infos, err := bc.logBlob.ListBlobs()
+	if err != nil {
+		return 0, fmt.Errorf("reclaim dead blobs: list blobs: %w", err)
+	}
+	for i := range infos {
+		if infos[i].Active && bc.blobFullyDead(ctx, infos[i].LogBlobID) {
+			if rerr := bc.logBlob.Rotate(); rerr != nil {
+				return 0, fmt.Errorf("reclaim dead blobs: seal active blob: %w", rerr)
+			}
+			break
+		}
+	}
+
+	bc.blobEvictMu.Lock()
+	defer bc.blobEvictMu.Unlock()
+
+	infos, err = bc.logBlob.ListBlobs()
+	if err != nil {
+		return 0, fmt.Errorf("reclaim dead blobs: list blobs: %w", err)
+	}
+	var total int64
+	for i := range infos {
+		if infos[i].Active {
+			continue
+		}
+		id := infos[i].LogBlobID
+		if _, done := bc.blobEvictedIDs[id]; done {
+			continue
+		}
+		if !bc.blobFullyDead(ctx, id) {
+			continue
+		}
+		freed, err := bc.evictBlobLocked(ctx, id, infos[i].Size)
+		if err != nil {
+			if errors.Is(err, errLRUEmpty) {
+				continue // raced to active; skip
+			}
+			return total, fmt.Errorf("reclaim dead blobs: evict %s: %w", id, err)
+		}
+		total += freed
+	}
+	return total, nil
+}
+
+// blobFullyDead reports whether none of blobID's recorded chunks still has a
+// live local-index entry pointing at blobID. A blob predating this process (no
+// blobChunks record) is reported not-dead: without a per-chunk record we cannot
+// prove it holds nothing live, and the coarse whole-blob gate already covers it.
+func (bc *FSStore) blobFullyDead(ctx context.Context, blobID string) bool {
+	bc.blobChunksMu.Lock()
+	recorded, tracked := bc.blobChunks[blobID]
+	hashes := make([]block.ContentHash, len(recorded))
+	copy(hashes, recorded)
+	bc.blobChunksMu.Unlock()
+	if !tracked || len(hashes) == 0 {
+		return false
+	}
+	for _, h := range hashes {
+		loc, present, err := bc.localChunkIndex.GetLocalLocation(ctx, h)
+		if err != nil {
+			return false // uncertain: never evict
+		}
+		if present && loc.LogBlobID == blobID {
+			return false // a live chunk still references this blob
+		}
+	}
+	return true
+}
+
 func (bc *FSStore) reclaimSpace(ctx context.Context) {
 	if bc.maxDisk <= 0 || !bc.evictionEnabled.Load() {
 		return

--- a/pkg/block/local/fs/reclaim_dead_blobs_test.go
+++ b/pkg/block/local/fs/reclaim_dead_blobs_test.go
@@ -1,0 +1,109 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestReclaimDeadBlobs_FreesReadThroughStagedActiveBlob reproduces the SMB
+// blocks-flip local-disk leak: read-through-staged chunks (FSStore.Put) land in
+// the still-open ACTIVE log blob. The mark-sweep GC drops their index entries
+// (DeleteChunk) but blob bytes are reclaimed only by blob-level eviction, which
+// skips the active blob — so DiskUsed stays non-zero after the sweep.
+// ReclaimDeadBlobs seals the now-fully-dead active blob and evicts it → 0.
+func TestReclaimDeadBlobs_FreesReadThroughStagedActiveBlob(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc := newBlobStoreWithLimit(t, dir, 0, mds)
+
+	// Stage chunks via the read-through Put path (what the syncer's inline
+	// fetch / prefetch use) — they append to the active blob.
+	payloads := [][]byte{
+		bytes.Repeat([]byte{0x01}, 1024),
+		bytes.Repeat([]byte{0x02}, 2048),
+		bytes.Repeat([]byte{0x03}, 4096),
+	}
+	var hashes []block.ContentHash
+	var want int64
+	for _, p := range payloads {
+		h := block.ContentHash(blake3.Sum256(p))
+		if err := bc.Put(ctx, h, p); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+		hashes = append(hashes, h)
+		want += int64(len(p))
+	}
+	if got := bc.Stats().DiskUsed; got != want {
+		t.Fatalf("DiskUsed after staging = %d, want %d", got, want)
+	}
+
+	// Simulate the GC mark-sweep dropping the (now-orphaned) chunks' index
+	// entries — exactly what CollectGarbageLocal does via Delete/DeleteChunk.
+	for _, h := range hashes {
+		if err := bc.DeleteChunk(ctx, h); err != nil {
+			t.Fatalf("DeleteChunk: %v", err)
+		}
+	}
+	// The leak: index entries gone, but blob bytes remain (active blob unsealed).
+	if got := bc.Stats().DiskUsed; got != want {
+		t.Fatalf("DiskUsed after sweep = %d, want %d (leak precondition)", got, want)
+	}
+
+	freed, err := bc.ReclaimDeadBlobs(ctx)
+	if err != nil {
+		t.Fatalf("ReclaimDeadBlobs: %v", err)
+	}
+	if freed != want {
+		t.Fatalf("ReclaimDeadBlobs freed = %d, want %d", freed, want)
+	}
+	if got := bc.Stats().DiskUsed; got != 0 {
+		t.Fatalf("DiskUsed after reclaim = %d, want 0 (local leak not freed)", got)
+	}
+}
+
+// TestReclaimDeadBlobs_KeepsBlobWithLiveChunk asserts the reclaim never drops a
+// blob that still has a live index entry (no live-data loss).
+func TestReclaimDeadBlobs_KeepsBlobWithLiveChunk(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	mds := memory.NewMemoryMetadataStoreWithDefaults()
+	bc := newBlobStoreWithLimit(t, dir, 0, mds)
+
+	dead := bytes.Repeat([]byte{0x01}, 1024)
+	live := bytes.Repeat([]byte{0x02}, 2048)
+	hDead := block.ContentHash(blake3.Sum256(dead))
+	hLive := block.ContentHash(blake3.Sum256(live))
+	if err := bc.Put(ctx, hDead, dead); err != nil {
+		t.Fatalf("Put dead: %v", err)
+	}
+	if err := bc.Put(ctx, hLive, live); err != nil {
+		t.Fatalf("Put live: %v", err)
+	}
+	// Sweep only the dead chunk's index entry; the live one stays.
+	if err := bc.DeleteChunk(ctx, hDead); err != nil {
+		t.Fatalf("DeleteChunk: %v", err)
+	}
+
+	freed, err := bc.ReclaimDeadBlobs(ctx)
+	if err != nil {
+		t.Fatalf("ReclaimDeadBlobs: %v", err)
+	}
+	if freed != 0 {
+		t.Fatalf("ReclaimDeadBlobs freed = %d, want 0 (blob has a live chunk)", freed)
+	}
+	// Live chunk must still be readable.
+	got, err := bc.Get(ctx, hLive)
+	if err != nil {
+		t.Fatalf("Get live after reclaim: %v", err)
+	}
+	if !bytes.Equal(got, live) {
+		t.Fatalf("live chunk corrupted after reclaim")
+	}
+}


### PR DESCRIPTION
## Problem

`TestBlocksFlipLifecycle_SMB` was the last remaining e2e failure, with two symptoms; `TestBlocksFlipLifecycle_NFS` on the same code passed:
1. **Warm read-back returns wrong bytes** — deterministic `got=4de3799c...`, right length. #1644's per-chunk blake3 guard didn't catch it (chunks individually valid).
2. **2 MiB local disk not freed** after unlink + GC (`require.Zero(LocalDiskUsed) got 2097152`).

## Root cause (one bug, both symptoms)

`EnsureAvailableAndRead` (`pkg/block/engine/fetch.go`) iterated **8 MiB block indices** and resolved only the chunk covering each block-*aligned* offset (`resolveCovering(blockIdx*BlockSize)`). But FastCDC chunks land near `MinChunkSize` (~1 MiB), so a 16 MiB file rolls up into ~16 × ~1 MiB chunks — **~8 chunks per 8 MiB block**. The loop fetched only each block's first chunk:

1. Every read window past a block's first chunk resolved the block-start chunk, whose `DataSize` doesn't reach the offset → 0 bytes copied → the miss fell through to a `clear(dest)` → **zeros** returned (whole-file sha differs; each staged chunk still passes blake3, which is why #1644 couldn't catch it).
2. Only the 2 block-aligned chunks (chunk@0 + chunk@8MiB = **2,097,152 B**) were staged locally via read-through `Put`. They land in the never-sealed **active** log blob; mark-sweep GC drops their index entries but blob bytes are reclaimed only by blob-level eviction of *sealed* blobs → they survive GC. NFS never re-stages (page cache serves reads client-side), so it frees to 0.

**Not a #1636 readahead bug** — that hypothesis was refuted; `scheduleReadahead` is untouched. This is a pre-existing demand-fetch bug that only the SMB read path (go-smb2, no page cache) exercises.

## Fix

- **`fetch.go`** — walk the *actual covering chunks* across `[offset, end)` (mirrors `readLocalByHash`/`fillFromCASManifest`), download every missing chunk concurrently (fetchGroup preserved), and return `(false, nil)` so the already-correct per-offset `readLocalByHash` assembles the window. Dedup keyed **per-chunk** (`fb.ID`) so two chunks in one block don't collide. Deleted the block-relative `copyBlockToDest`/`blockRegion`/`zeroBlockRegion` (wrong for a chunk starting mid-window).
- **`eviction.go`** — new `ReclaimDeadBlobs`: seal a *fully-dead* active blob, then evict every sealed blob whose recorded chunks have no live index entry. A blob with any live chunk is left untouched (no live data dropped).
- **`gc.go`** — after the local sweep (non-dry-run), call `ReclaimDeadBlobs` via an optional local-only interface; freed bytes counted in `stats.BytesFreed`.

## Tests / verification

- `cold_read_subblock_test.go` — cold read in sub-block windows: fail-before `got=0x00 want=0xc9` at off 1 MiB; pass-after all windows match.
- `reclaim_dead_blobs_test.go` — GC-after-unlink leak: `DiskUsed` stays before, frees to 0 after; proves a blob with a live chunk is never dropped.
- `go build ./...`, `gofmt`, `go vet`, `golangci-lint` clean.
- `go test ./pkg/block/...` all pass; `-race ./pkg/block/engine ./pkg/block/local/fs` clean.
- Two existing tests updated to the new ensure-local contract (`TestColdRead_DemandFetchIsConcurrent` now sees the expected concurrent GETs; relocated-chunk re-resolve #1487 guard preserved).

Last of the `TestBlocksFlipLifecycle` cluster (after #1637 eviction, #1642 GC-decrement, #1644 read verify-guard).