### PR TITLE
perf(block): ranged sub-chunk reads for warm random reads (~20x cumulative)

### DIFF
--- a/pkg/block/engine/warm_randread_bench_test.go
+++ b/pkg/block/engine/warm_randread_bench_test.go
@@ -1,20 +1,21 @@
 package engine_test
 
-// Warm local random-read benchmark + regression guard for the verified-chunk
-// cache (skip re-hashing immutable CAS chunks on every 4 KiB read).
+// Warm local random-read benchmark + regression guard for the warm-read fast
+// path (verify-once cache + ranged sub-chunk reads).
 //
 // Unlike BenchmarkRandRead_Phase12 (memory local store, no disk, no blake3),
 // this drives the REAL fs local store: write a multi-MiB payload, DrainRollups
 // so the bytes live as rolled-up CAS chunks (WARM local read, no remote), then
 // do 4 KiB reads at random offsets through engine.Store.ReadAt — the exact
-// production warm path (ReadPayloadAt -> fillFromCASManifest -> ReadChunk ->
-// blake3 verify). Remote is nil so scheduleReadahead early-returns.
+// production warm path (ReadPayloadAt -> fillFromCASManifest -> ReadChunk).
+// Remote is nil so scheduleReadahead early-returns.
 //
 // Run:
 //   go test -run=XXX -bench=BenchmarkWarmRandRead_FS -benchtime=3s \
 //     -cpuprofile=/tmp/rr.prof -memprofile=/tmp/rr.mem ./pkg/block/engine/
 
 import (
+	"bytes"
 	"context"
 	"math/rand"
 	"testing"
@@ -37,9 +38,17 @@ const (
 // store, writes warmRRFileSize bytes, and DrainRollups so the payload is a warm
 // local CAS read. Returns the store + payloadID + covering ChunkRef manifest.
 func setupWarmFSFixture(b *testing.B) (*engine.Store, string, []block.ChunkRef) {
-	b.Helper()
+	bs, payloadID, blocks, _ := buildWarmFSFixture(b)
+	return bs, payloadID, blocks
+}
+
+// buildWarmFSFixture is the shared fixture builder used by the benchmark and the
+// ranged-read correctness test. It also returns the source bytes so the test can
+// assert reads are byte-identical. tb is *testing.B or *testing.T.
+func buildWarmFSFixture(tb testing.TB) (*engine.Store, string, []block.ChunkRef, []byte) {
+	tb.Helper()
 	logger.SetLevel("ERROR")
-	b.Cleanup(func() { logger.SetLevel("INFO") })
+	tb.Cleanup(func() { logger.SetLevel("INFO") })
 	ctx := context.Background()
 
 	ms := metastore.NewMemoryMetadataStoreWithDefaults()
@@ -50,19 +59,19 @@ func setupWarmFSFixture(b *testing.B) (*engine.Store, string, []block.ChunkRef) 
 		Type: metadata.FileTypeDirectory, Mode: 0o755,
 	})
 	if err != nil {
-		b.Fatalf("CreateRootDirectory: %v", err)
+		tb.Fatalf("CreateRootDirectory: %v", err)
 	}
 	rootHandle, err := metadata.EncodeFileHandle(rootFile)
 	if err != nil {
-		b.Fatalf("EncodeFileHandle: %v", err)
+		tb.Fatalf("EncodeFileHandle: %v", err)
 	}
 	handle, err := ms.GenerateHandle(ctx, shareName, "/data.bin")
 	if err != nil {
-		b.Fatalf("GenerateHandle: %v", err)
+		tb.Fatalf("GenerateHandle: %v", err)
 	}
 	_, id, err := metadata.DecodeFileHandle(handle)
 	if err != nil {
-		b.Fatalf("DecodeFileHandle: %v", err)
+		tb.Fatalf("DecodeFileHandle: %v", err)
 	}
 	payloadID := "warm/" + id.String()
 	if err := ms.PutFile(ctx, &metadata.File{
@@ -72,20 +81,20 @@ func setupWarmFSFixture(b *testing.B) (*engine.Store, string, []block.ChunkRef) 
 			PayloadID: metadata.PayloadID(payloadID),
 		},
 	}); err != nil {
-		b.Fatalf("PutFile: %v", err)
+		tb.Fatalf("PutFile: %v", err)
 	}
 	if err := ms.SetParent(ctx, handle, rootHandle); err != nil {
-		b.Fatalf("SetParent: %v", err)
+		tb.Fatalf("SetParent: %v", err)
 	}
 	if err := ms.SetChild(ctx, rootHandle, "data.bin", handle); err != nil {
-		b.Fatalf("SetChild: %v", err)
+		tb.Fatalf("SetChild: %v", err)
 	}
 	if err := ms.SetLinkCount(ctx, handle, 1); err != nil {
-		b.Fatalf("SetLinkCount: %v", err)
+		tb.Fatalf("SetLinkCount: %v", err)
 	}
 
 	// --- fs engine (mirrors newEngineOverStore; nil remote) ---
-	localStore, err := fs.NewWithOptions(b.TempDir(), 256*1024*1024, ms, fs.FSStoreOptions{
+	localStore, err := fs.NewWithOptions(tb.TempDir(), 256*1024*1024, ms, fs.FSStoreOptions{
 		LocalChunkIndex: ms,
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
@@ -94,7 +103,7 @@ func setupWarmFSFixture(b *testing.B) (*engine.Store, string, []block.ChunkRef) 
 		SyncedHashStore: ms,
 	})
 	if err != nil {
-		b.Fatalf("fs.NewWithOptions: %v", err)
+		tb.Fatalf("fs.NewWithOptions: %v", err)
 	}
 	syncer := engine.NewSyncer(localStore, nil, ms, engine.DefaultConfig())
 	bs, err := engine.New(engine.BlockStoreConfig{
@@ -107,41 +116,35 @@ func setupWarmFSFixture(b *testing.B) (*engine.Store, string, []block.ChunkRef) 
 		ReadBufferBytes: 64 * 1024 * 1024,
 	})
 	if err != nil {
-		b.Fatalf("engine.New: %v", err)
+		tb.Fatalf("engine.New: %v", err)
 	}
 	if err := bs.Start(ctx); err != nil {
-		b.Fatalf("engine.Start: %v", err)
+		tb.Fatalf("engine.Start: %v", err)
 	}
-	b.Cleanup(func() { _ = bs.Close() })
+	tb.Cleanup(func() { _ = bs.Close() })
 
 	// --- write payload, then drain to CAS (warm local) ---
 	rng := rand.New(rand.NewSource(warmRRSeed)) //nolint:gosec // bench fixture
 	buf := make([]byte, warmRRFileSize)
 	if _, err := rng.Read(buf); err != nil {
-		b.Fatalf("rng.Read: %v", err)
+		tb.Fatalf("rng.Read: %v", err)
 	}
 	if _, err := bs.WriteAt(ctx, payloadID, nil, buf, 0); err != nil {
-		b.Fatalf("WriteAt: %v", err)
+		tb.Fatalf("WriteAt: %v", err)
 	}
 	if err := bs.DrainRollups(ctx); err != nil {
-		b.Fatalf("DrainRollups: %v", err)
+		tb.Fatalf("DrainRollups: %v", err)
 	}
 
 	f, err := ms.GetFile(ctx, handle)
 	if err != nil {
-		b.Fatalf("GetFile: %v", err)
+		tb.Fatalf("GetFile: %v", err)
 	}
-	blocks := f.Blocks
-	avg := warmRRFileSize / 1024
-	if len(blocks) > 0 {
-		avg /= len(blocks)
-	}
-	b.Logf("warm fixture: %d bytes, %d CAS chunks (avg %d KiB)", warmRRFileSize, len(blocks), avg)
-	return bs, payloadID, blocks
+	return bs, payloadID, f.Blocks, buf
 }
 
 // BenchmarkWarmRandRead_FS profiles a 4 KiB random read served from warm local
-// CAS via the fs store. This is the CPU-attribution target.
+// CAS via the fs store.
 func BenchmarkWarmRandRead_FS(b *testing.B) {
 	bs, payloadID, blocks := setupWarmFSFixture(b)
 	ctx := context.Background()
@@ -159,4 +162,46 @@ func BenchmarkWarmRandRead_FS(b *testing.B) {
 		}
 	}
 	b.StopTimer()
+}
+
+// TestWarmRandRead_RangedReadByteIdentical guards the ranged sub-chunk fast
+// path: the SECOND read of a chunk (after the first read verifies + caches its
+// hash) is served by a ranged pread rather than a whole-chunk read, and must
+// return bytes byte-identical to the source. It exercises varied offsets and
+// lengths, including reads that straddle chunk boundaries, and reads every
+// offset twice so both the verify-and-cache path and the ranged path are hit.
+func TestWarmRandRead_RangedReadByteIdentical(t *testing.T) {
+	bs, payloadID, blocks, src := buildWarmFSFixture(t)
+	ctx := context.Background()
+
+	rng := rand.New(rand.NewSource(warmRRSeed + 1)) //nolint:gosec // test
+	sizes := []int{1, 100, 4096, 65537, 1 << 20}    // last spans multiple ~1 MiB chunks
+	for _, sz := range sizes {
+		if sz > len(src) {
+			continue
+		}
+		maxOffset := len(src) - sz
+		for iter := 0; iter < 50; iter++ {
+			off := 0
+			if maxOffset > 0 {
+				off = rng.Intn(maxOffset)
+			}
+			dest := make([]byte, sz)
+			// Read twice: first primes the verified set (whole-chunk verify),
+			// second is served by the ranged fast path.
+			for pass := 0; pass < 2; pass++ {
+				clear(dest)
+				n, err := bs.ReadAt(ctx, payloadID, blocks, dest, uint64(off))
+				if err != nil {
+					t.Fatalf("ReadAt(off=%d sz=%d pass=%d): %v", off, sz, pass, err)
+				}
+				if n != sz {
+					t.Fatalf("short read off=%d sz=%d pass=%d: got %d", off, sz, pass, n)
+				}
+				if !bytes.Equal(dest, src[off:off+sz]) {
+					t.Fatalf("byte mismatch off=%d sz=%d pass=%d", off, sz, pass)
+				}
+			}
+		}
+	}
 }

--- a/pkg/block/local/fs/chunkstore.go
+++ b/pkg/block/local/fs/chunkstore.go
@@ -384,6 +384,45 @@ func (bc *FSStore) ReadChunk(ctx context.Context, h block.ContentHash) ([]byte, 
 	return data, nil
 }
 
+// readChunkRangeInto serves [subOffset, subOffset+len(dst)) of CAS chunk h
+// directly into dst via a ranged pread, avoiding the whole-chunk allocation and
+// read that ReadChunk performs. It is a best-effort fast path for the warm read
+// path: it returns served=true only when every requested byte was delivered from
+// the local logblob tier. On any miss — chunk not in the local index (legacy
+// .blk tier or evicted), torn tail, or short read — it returns (false, nil) so
+// the caller falls back to the whole-chunk ReadChunk/Get path, which owns the
+// miss -> remote-refetch -> re-stage recovery (and drops any torn index entry).
+//
+// It performs NO integrity check: the ranged bytes cannot be BLAKE3-verified in
+// isolation, so callers MUST only use it for chunks already known-good (present
+// in the verified set), whose whole body was verified on an earlier read.
+func (bc *FSStore) readChunkRangeInto(ctx context.Context, h block.ContentHash, dst []byte, subOffset int64) (bool, error) {
+	if bc.isClosed() {
+		return false, ErrStoreClosed
+	}
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	if bc.localChunkIndex == nil || len(dst) == 0 {
+		return false, nil
+	}
+	loc, ok, err := bc.localChunkIndex.GetLocalLocation(ctx, h)
+	if err != nil {
+		return false, fmt.Errorf("chunkstore: get local location: %w", err)
+	}
+	if !ok || subOffset < 0 || subOffset+int64(len(dst)) > loc.RawLength {
+		return false, nil
+	}
+	n, rerr := bc.logBlob.ReadAtRange(ctx, loc, dst, subOffset)
+	if rerr != nil || n < len(dst) {
+		// Torn/evicted/missing/short: fall back to the whole-chunk path rather
+		// than error — ReadChunk hits the same condition and drops the dangling
+		// index entry, routing the read to the remote refetch.
+		return false, nil
+	}
+	return true, nil
+}
+
 // dropTornIndexEntry removes the dangling local-index entry for a chunk whose
 // log-blob bytes were lost to a torn tail, then reports the chunk as absent.
 // After this the chunk reads as a clean miss (HasChunk consults the index),

--- a/pkg/block/local/fs/readpayload.go
+++ b/pkg/block/local/fs/readpayload.go
@@ -231,6 +231,34 @@ func copyRecordIntoDest(recOff uint64, payload, dest []byte, reqStart, reqEnd ui
 	}
 }
 
+// serveVerifiedRange attempts the ranged-read fast path for one chunk covering
+// [copyStart, copyEnd) of the request window (chunk data begins at absOffset in
+// the payload). It serves those bytes straight into dest via a ranged pread —
+// skipping the whole-chunk allocation, read, and re-hash — but ONLY when hash is
+// already in the verified set (so the bytes were BLAKE3-verified on an earlier
+// read and need no fresh integrity check). Returns served=true and marks the
+// bytes covered on success; served=false means the caller must fall back to the
+// whole-chunk read+verify path (first touch, unverified, or a ranged miss).
+func (bc *FSStore) serveVerifiedRange(ctx context.Context, hash block.ContentHash, absOffset, copyStart, copyEnd, reqStart uint64, dest []byte, covered []bool) (bool, error) {
+	if copyEnd <= copyStart || !bc.verified.contains(hash) {
+		return false, nil
+	}
+	destIdx := copyStart - reqStart
+	subOff := copyStart - absOffset
+	n := copyEnd - copyStart
+	served, err := bc.readChunkRangeInto(ctx, hash, dest[destIdx:destIdx+n], int64(subOff))
+	if err != nil {
+		return false, err
+	}
+	if !served {
+		return false, nil
+	}
+	for i := destIdx; i < destIdx+n; i++ {
+		covered[i] = true
+	}
+	return true, nil
+}
+
 // coveringChunkResolver is the indexed covering + successor lookup,
 // implemented only by the badger metadata backend. fillFromCASManifest
 // type-asserts for it to resolve just the chunks a read touches (plus one
@@ -309,6 +337,18 @@ func (bc *FSStore) fillFromCASManifest(ctx context.Context, payloadID string, de
 			return nil
 		}
 		if !fb.Hash.IsZero() {
+			// Fast path: an already-verified immutable chunk needs no re-read of
+			// its whole (~1 MiB) body — pread only the covered window straight
+			// into dest. Falls through to the whole-chunk read+verify on a miss.
+			served, rerr := bc.serveVerifiedRange(ctx, fb.Hash, absOffset, cur, min(absOffset+uint64(fb.DataSize), reqEnd), reqStart, dest, covered)
+			if rerr != nil {
+				return fmt.Errorf("ReadPayloadAt: ranged read chunk %s: %w", fb.Hash.String(), rerr)
+			}
+			if served {
+				cur = chunkEnd
+				continue
+			}
+
 			data, gerr := bc.Get(ctx, fb.Hash)
 			if gerr != nil {
 				if !errors.Is(gerr, block.ErrChunkNotFound) {
@@ -395,6 +435,20 @@ func (bc *FSStore) fillFromCASManifestScan(ctx context.Context, payloadID string
 		chunkStart := r.absOffset
 		chunkEnd := r.absOffset + uint64(r.fb.DataSize)
 		if chunkEnd <= reqStart || chunkStart >= reqEnd {
+			continue
+		}
+		// Fast path: an already-verified chunk needs no whole-chunk read+verify —
+		// pread only the intersecting window straight into dest.
+		fpStart := max(chunkStart, reqStart)
+		fpEnd := min(chunkStart+uint64(r.fb.DataSize), reqEnd)
+		served, rerr := bc.serveVerifiedRange(ctx, r.fb.Hash, chunkStart, fpStart, fpEnd, reqStart, dest, covered)
+		if rerr != nil {
+			return fmt.Errorf("ReadPayloadAt: ranged read chunk %s: %w", r.fb.Hash.String(), rerr)
+		}
+		if served {
+			if allCovered(covered) {
+				return nil
+			}
 			continue
 		}
 		// Fetch the chunk lazily — only when it intersects.

--- a/pkg/block/local/logblob/manager.go
+++ b/pkg/block/local/logblob/manager.go
@@ -250,6 +250,39 @@ func (m *Manager) ReadAt(ctx context.Context, loc block.LocalChunkLocation, dst 
 	return n, nil
 }
 
+// ReadAtRange reads len(dst) bytes from the chunk at loc starting subOffset
+// bytes into the chunk body, i.e. the on-disk range
+// [loc.RawOffset+subOffset, loc.RawOffset+subOffset+len(dst)). It lets the read
+// path serve a small window of a large packed chunk without materializing the
+// whole chunk. subOffset and len(dst) must stay within loc.RawLength.
+//
+// Concurrency and error semantics match ReadAt: a brief mutex to snapshot the
+// blob fd, then an unlocked pread(2); ErrEvicted / ErrBlobNotFound / io.EOF from
+// the underlying blob surface unchanged so callers can route recovery.
+func (m *Manager) ReadAtRange(ctx context.Context, loc block.LocalChunkLocation, dst []byte, subOffset int64) (int, error) {
+	if ctx.Err() != nil {
+		return 0, ctx.Err()
+	}
+	if len(dst) == 0 {
+		return 0, nil
+	}
+	if subOffset < 0 || subOffset+int64(len(dst)) > loc.RawLength {
+		return 0, fmt.Errorf("logblob: ReadAtRange: range [%d,%d) out of chunk bounds (RawLength %d)",
+			subOffset, subOffset+int64(len(dst)), loc.RawLength)
+	}
+
+	fd, err := m.fdForBlob(loc.LogBlobID)
+	if err != nil {
+		return 0, err
+	}
+
+	n, err := fd.ReadAt(dst, loc.RawOffset+subOffset)
+	if err != nil {
+		return n, fmt.Errorf("logblob: ReadAtRange %s@%d+%d: %w", loc.LogBlobID, loc.RawOffset, subOffset, err)
+	}
+	return n, nil
+}
+
 // Rotate seals the current active blob and creates a fresh one. Subsequent
 // Appends will target the new blob starting at offset 0.
 //


### PR DESCRIPTION
Follow-up to #1648 (verify-once cache). Together they turn warm 4 KiB random reads from ~437 µs into ~21 µs — competitive with page-cache-served re-export filesystems.

## Problem

After #1648 removed the per-read BLAKE3 verify, a warm read still **allocated and read the whole covering CAS chunk** (~1 MiB at the FastCDC average) just to copy out a 4 KiB window — 256× read/alloc amplification, and the last remaining cost (`bc.Get` whole-chunk + the 1 MiB buffer alloc = 92% of per-read bytes).

## Fix

For a chunk already in the **verified set** (its bytes were proven good on an earlier read, and CAS chunks are immutable), serve the requested window with a **ranged pread straight into the destination buffer** — no whole-chunk materialization:

- `logblob.Manager.ReadAtRange` — pread at `RawOffset + subOffset` (no compression/encryption at rest locally, so a byte range maps directly).
- `FSStore.readChunkRangeInto` — best-effort local ranged read; on **any** miss (chunk not in the local index, evicted, torn tail, short read) returns `served=false` so the caller falls back to the existing whole-chunk `ReadChunk`/`Get` path, which owns the miss → remote-refetch → re-stage recovery. No integrity duplication.
- `serveVerifiedRange` — shared helper routing **both** manifest paths (badger covering resolver *and* the scan fallback) through the fast path, so every metadata backend benefits.

First touch is unchanged: it reads and BLAKE3-verifies the whole chunk, then caches the hash. Only proven-good chunks take the ranged path.

## Measured (engine microbenchmark, 16 MiB payload, 4 KiB random reads, warm local CAS)

| | ns/op | B/op | allocs/op | MB/s |
|---|--:|--:|--:|--:|
| develop | 437 µs | 1.14 MB | 183 | 9.4 |
| #1648 verify-once | 148 µs | 1.05 MB | 32 | 27.7 |
| **+ ranged (this PR)** | **21 µs** | **8.3 KB** | **31** | **190** |

~21 µs/read ≈ **47k IOPS single-thread**, in the range of the competitor benchmark's page-cache-served re-export filesystems (JuiceFS/s3ql/s3fs ~40–46k), which DittoFS previously trailed at 4–11k.

## Tests

- New `TestWarmRandRead_RangedReadByteIdentical`: reads every offset **twice** (verify-and-cache pass, then ranged pass) across sizes `{1, 100, 4 KiB, 64 KiB+1, 1 MiB}` including reads that straddle chunk boundaries, asserting byte-identity to the source.
- `go test ./pkg/block/...` — pass; `-race` on `fs`/`logblob`/`engine` clean; existing corrupt-chunk integrity tests still green.

Refs #1225.