### PR TITLE
perf(block): lock-free readahead frontier — end the read-path mutex convoy

### DIFF
--- a/pkg/block/engine/readahead.go
+++ b/pkg/block/engine/readahead.go
@@ -1,5 +1,7 @@
 package engine
 
+import "sync/atomic"
+
 // maxReadaheadEntries bounds the per-payload readahead state map. Readahead
 // state is disposable — a dropped entry just re-ramps from a cold start (the
 // re-creating read establishes the frontier, the next sequential read schedules
@@ -11,11 +13,14 @@ const maxReadaheadEntries = 4096
 
 // raState tracks a payload's read frontier so the readahead driver can keep a
 // fixed window of blocks fetched ahead of a sequential reader and schedule each
-// block exactly once.
+// block exactly once. Fields are atomic so planWindow updates the frontier
+// without a lock; concurrent reads of one payload may race here, but the state
+// is a disposable heuristic (a stale frontier only mis-sizes prefetch), so the
+// races are benign.
 type raState struct {
-	lastEnd       uint64 // block index the previous read ended at
-	scheduledUpTo uint64 // highest block index already scheduled for prefetch
-	valid         bool   // false until the first read establishes lastEnd
+	lastEnd       atomic.Uint64 // block index the previous read ended at
+	scheduledUpTo atomic.Uint64 // highest block index already scheduled for prefetch
+	valid         atomic.Bool   // false until the first read establishes lastEnd
 }
 
 // planWindow advances the payload's read frontier for a read spanning block
@@ -38,33 +43,30 @@ func (m *Syncer) planWindow(payloadID string, start, end uint64) (from, to uint6
 		return 0, 0, false // prefetch disabled
 	}
 
-	m.readaheadMu.Lock()
-	defer m.readaheadMu.Unlock()
-
-	st, ok := m.readahead[payloadID]
-	if !ok {
-		if len(m.readahead) >= maxReadaheadEntries {
-			for k := range m.readahead { // evict one arbitrary disposable entry
-				delete(m.readahead, k)
-				break
-			}
-		}
-		st = &raState{}
-		m.readahead[payloadID] = st
+	// Lock-free per-payload lookup. A gosync.Map keeps the read hot path free of
+	// the global mutex that previously serialized every read here.
+	v, loaded := m.readahead.LoadOrStore(payloadID, &raState{})
+	if !loaded && m.readaheadN.Add(1) > maxReadaheadEntries {
+		m.pruneReadahead()
 	}
+	st := v.(*raState)
 
 	// Sequential = the new read begins at or immediately after the previous
 	// frontier (tolerates a re-read of the last block and a contiguous advance).
-	sequential := st.valid && start >= st.lastEnd && start <= st.lastEnd+1
-	st.lastEnd = end
-	st.valid = true
+	// Load lastEnd once; a concurrent same-payload read may interleave, but the
+	// frontier is a disposable heuristic so a mis-detected pattern only affects
+	// prefetch sizing, never correctness.
+	last := st.lastEnd.Load()
+	sequential := st.valid.Load() && start >= last && start <= last+1
+	st.lastEnd.Store(end)
+	st.valid.Store(true)
 
 	// First read of a payload is not a pattern (sequential requires the prior
-	// st.valid, so a first read is never sequential); a random jump resets the
+	// valid, so a first read is never sequential); a random jump resets the
 	// anchor. Either way we re-anchor scheduledUpTo to the current frontier and
 	// prefetch nothing this call.
 	if !sequential {
-		st.scheduledUpTo = end
+		st.scheduledUpTo.Store(end)
 		return 0, 0, false
 	}
 
@@ -72,15 +74,36 @@ func (m *Syncer) planWindow(payloadID string, start, end uint64) (from, to uint6
 	// geometric ramp — that lagged the reader (the reader consumes a local block
 	// faster than a single S3 fetch completes, so a slow ramp never gets ahead).
 	target := end + uint64(maxDepth)
-	from = st.scheduledUpTo
+	from = st.scheduledUpTo.Load()
 	if from < end {
 		from = end
 	}
 	if target <= from {
 		return 0, 0, false // window already scheduled — nothing new
 	}
-	st.scheduledUpTo = target
+	st.scheduledUpTo.Store(target)
 	return from, target, true
+}
+
+// pruneReadahead best-effort trims the disposable readahead map back toward
+// half of maxReadaheadEntries when it overflows. Only one goroutine prunes at a
+// time; entries are dropped in gosync.Map.Range order (arbitrary) — a dropped
+// payload just re-ramps from a cold frontier on its next read. readaheadN is
+// approximate under concurrent inserts, which is fine for a soft bound.
+func (m *Syncer) pruneReadahead() {
+	if !m.readaheadPruning.CompareAndSwap(false, true) {
+		return // another goroutine is already pruning
+	}
+	defer m.readaheadPruning.Store(false)
+	target := int64(maxReadaheadEntries / 2)
+	m.readahead.Range(func(k, _ any) bool {
+		if m.readaheadN.Load() <= target {
+			return false
+		}
+		m.readahead.Delete(k)
+		m.readaheadN.Add(-1)
+		return true
+	})
 }
 
 // scheduleReadahead is the offset-based sliding-window readahead driver, invoked

--- a/pkg/block/engine/readahead_contention_bench_test.go
+++ b/pkg/block/engine/readahead_contention_bench_test.go
@@ -1,0 +1,43 @@
+package engine
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// BenchmarkPlanWindow_SinglePayloadConcurrent reproduces the rig's warm
+// random-read contention: many concurrent reads of the SAME payload (fio's
+// single-file random-read shape) all funnel through planWindow's global
+// readaheadMu on every read (scheduleReadahead runs it whenever a remote is
+// configured — i.e. always for dittofs-s3). The only shared state exercised is
+// readaheadMu, so ns/op here IS the per-read frontier-update cost under
+// contention. Run with -mutexprofile to confirm the lock, -cpuprofile for CPU.
+func BenchmarkPlanWindow_SinglePayloadConcurrent(b *testing.B) {
+	m := &Syncer{config: SyncerConfig{PrefetchBlocks: 8}}
+	b.RunParallel(func(pb *testing.PB) {
+		rng := rand.New(rand.NewSource(1)) //nolint:gosec // bench offsets
+		for pb.Next() {
+			start := uint64(rng.Intn(1 << 18))
+			m.planWindow("payload", start, start)
+		}
+	})
+}
+
+// BenchmarkPlanWindow_MultiPayloadConcurrent is the multi-file shape: concurrent
+// reads spread across many payloads. A per-payload/sharded lock removes the
+// cross-payload contention this has today (all payloads share one readaheadMu).
+func BenchmarkPlanWindow_MultiPayloadConcurrent(b *testing.B) {
+	m := &Syncer{config: SyncerConfig{PrefetchBlocks: 8}}
+	payloads := make([]string, 256)
+	for i := range payloads {
+		payloads[i] = "payload-" + string(rune('a'+i%26)) + string(rune('a'+i/26))
+	}
+	b.RunParallel(func(pb *testing.PB) {
+		rng := rand.New(rand.NewSource(2)) //nolint:gosec // bench offsets
+		for pb.Next() {
+			p := payloads[rng.Intn(len(payloads))]
+			start := uint64(rng.Intn(1 << 18))
+			m.planWindow(p, start, start)
+		}
+	})
+}

--- a/pkg/block/engine/readahead_test.go
+++ b/pkg/block/engine/readahead_test.go
@@ -7,10 +7,7 @@ import (
 
 // newRAsyncer builds a Syncer exercising only planWindow (no queue/remote).
 func newRAsyncer(prefetch int) *Syncer {
-	return &Syncer{
-		config:    SyncerConfig{PrefetchBlocks: prefetch},
-		readahead: make(map[string]*raState),
-	}
+	return &Syncer{config: SyncerConfig{PrefetchBlocks: prefetch}}
 }
 
 // window is a test helper: the block indices planWindow schedules for a read
@@ -87,7 +84,9 @@ func TestPlanWindow_MapBounded(t *testing.T) {
 	for i := 0; i < maxReadaheadEntries*2; i++ {
 		m.window("payload-"+strconv.Itoa(i), 0, 0)
 	}
-	if got := len(m.readahead); got > maxReadaheadEntries {
+	got := 0
+	m.readahead.Range(func(_, _ any) bool { got++; return true })
+	if got > maxReadaheadEntries {
 		t.Fatalf("readahead map unbounded: %d entries, cap %d", got, maxReadaheadEntries)
 	}
 }
@@ -95,10 +94,7 @@ func TestPlanWindow_MapBounded(t *testing.T) {
 // newSchedSyncer builds a Syncer with a real (unstarted) SyncQueue so
 // scheduleReadahead enqueues into an inspectable prefetch channel.
 func newSchedSyncer(prefetch int) *Syncer {
-	m := &Syncer{
-		config:    SyncerConfig{PrefetchBlocks: prefetch},
-		readahead: make(map[string]*raState),
-	}
+	m := &Syncer{config: SyncerConfig{PrefetchBlocks: prefetch}}
 	m.hasRemote.Store(true) // IsRemoteHealthy() is true with no health monitor
 	m.queue = NewSyncQueue(m, SyncQueueConfig{QueueSize: 1000, DownloadWorkers: 4})
 	return m

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -70,10 +70,17 @@ type Syncer struct {
 	inFlight   map[string]*fetchResult // In-flight download dedup (store key -> broadcast)
 	inFlightMu gosync.Mutex
 
-	// readahead holds per-payload sequential-access state so remote prefetch
-	// ramps on sequential runs and backs off on random access (see readahead.go).
-	readahead   map[string]*raState
-	readaheadMu gosync.Mutex
+	// readahead holds per-payload sequential-access frontier state so remote
+	// prefetch ramps on sequential runs and backs off on random access (see
+	// readahead.go). A gosync.Map + atomic raState fields keep the read hot path
+	// lock-free: planWindow previously took a single global mutex on EVERY read
+	// (whenever a remote is configured), so a concurrent 4k random-read fleet on
+	// one payload serialized there. Readahead state is a disposable heuristic, so
+	// the atomic load-decide-store races are benign (a stale frontier only
+	// mis-sizes prefetch, never affects correctness).
+	readahead        gosync.Map   // payloadID(string) -> *raState
+	readaheadN       atomic.Int64 // approximate entry count, for bounding
+	readaheadPruning atomic.Bool  // single-pruner guard for the bound
 
 	stopCh chan struct{} // Signals periodic uploader to stop
 	closed bool
@@ -328,7 +335,6 @@ func NewSyncer(local local.LocalStore, remoteStore remote.RemoteStore, fileChunk
 		fileChunkStore: fileChunkStore,
 		config:         config,
 		inFlight:       make(map[string]*fetchResult),
-		readahead:      make(map[string]*raState),
 		stopCh:         make(chan struct{}),
 
 		uploadLimiter:    newDynamicSemaphore(startWindow),


### PR DESCRIPTION
Next round after the warm-read fast path (#1648/#1651). Those got the block read to ~21 µs at the engine level (20×), but the same fix showed only ~2× end-to-end on the rig, and dittofs-s3 warm random-read trails the page-cache re-exports (juicefs) at **<100% CPU** — a sign of contention, not CPU.

## Root cause

`Store.ReadAt` calls `scheduleReadahead` on **every** read, which runs `planWindow` whenever a remote is configured (i.e. always for an S3-backed share). `planWindow` took a **single global mutex** (`readaheadMu`) guarding the per-payload frontier map. A concurrent 4 KiB random-read fleet on **one file** therefore serializes on that one lock every read. This is invisible to the nil-remote engine microbenchmark (it early-returns before the lock — which is exactly why that bench showed 20× but the rig didn't) and present on every real deployment. For random reads the lock does *useless* work: `planWindow` returns `fire=false` and schedules nothing.

## Fix

Replace `map[string]*raState` + `readaheadMu` with a `gosync.Map` keyed by payloadID and **atomic `raState` fields**, so the frontier update is lock-free. Readahead state is a disposable heuristic (a stale frontier only mis-sizes prefetch, never affects correctness), so the atomic load-decide-store races are benign; a best-effort pruner keeps the map bounded to `maxReadaheadEntries`.

## Measured — `planWindow` contention microbench (ns/op, 1→8 cores)

| shape | before (map+mutex) | after (lock-free) |
|---|--|--|
| single-payload (fio single-file) | 17 → **124** (7.4× convoy) | 69 → **61** (flat) |
| multi-payload | 33 → **174** | 85 → **31** (scales) |

The convoy is gone; a shared single-file frontier stays flat under concurrency instead of degrading, and multi-file now scales with cores. Atomics cost ~50 ns more uncontended — negligible vs the per-read budget.

## Tests

- New `BenchmarkPlanWindow_{Single,Multi}PayloadConcurrent` (contention guard).
- Existing readahead tests updated for the `sync.Map` (bound + scheduling behavior unchanged); `go test -race ./pkg/block/engine/` — 340 pass.

## Honest scope

This removes a **confirmed** read-path lock convoy. Whether it fully closes the ~1.8× rig random-read gap needs a VM server-pprof (CPU + mutex) run to confirm and to rank any remaining per-read cost (badger covering lookup, `GetFile`, NFS dispatch) — recommended as the follow-up.