### PR TITLE
perf(metadata): read cache for badger GetFileForRead (~5700x on hit)

### DIFF
--- a/pkg/metadata/clone.go
+++ b/pkg/metadata/clone.go
@@ -1,0 +1,55 @@
+package metadata
+
+import (
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+)
+
+// CloneBlocks returns a deep copy of a []block.ChunkRef. ChunkRef is a value
+// type (Hash is a [32]byte array, Offset and Size are scalars), so a flat
+// element-wise copy fully detaches the clone. Returns nil for a nil/empty
+// input so a round-trip preserves the omitempty wire form.
+func CloneBlocks(in []block.ChunkRef) []block.ChunkRef {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]block.ChunkRef, len(in))
+	copy(out, in)
+	return out
+}
+
+// CloneACL returns a deep copy of a *acl.ACL, including fresh copies of its ACEs
+// (DACL) and SACL slices. acl.ACE is a flat value type (uint32 fields + a string
+// Who), so an element-wise slice copy fully detaches the clone. Returns nil for
+// a nil input so a round-trip preserves the "no ACL set" semantics.
+func CloneACL(in *acl.ACL) *acl.ACL {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if in.ACEs != nil {
+		out.ACEs = make([]acl.ACE, len(in.ACEs))
+		copy(out.ACEs, in.ACEs)
+	}
+	if in.SACL != nil {
+		out.SACL = make([]acl.ACE, len(in.SACL))
+		copy(out.SACL, in.SACL)
+	}
+	return &out
+}
+
+// CloneEAs returns a deep copy of a FileAttr.EAs map, copying each value slice
+// so neither side can mutate the other's EA bytes in place. Returns nil for a
+// nil/empty input so a round-trip preserves the omitempty wire form.
+func CloneEAs(in map[string][]byte) map[string][]byte {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string][]byte, len(in))
+	for k, v := range in {
+		vc := make([]byte, len(v))
+		copy(vc, v)
+		out[k] = vc
+	}
+	return out
+}

--- a/pkg/metadata/store/badger/encoding_bench_test.go
+++ b/pkg/metadata/store/badger/encoding_bench_test.go
@@ -1,0 +1,82 @@
+package badger
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// bigFile builds a File with nBlocks ChunkRefs — the shape GetFileForRead
+// decodes on every read of a rolled-up file (a 1 GiB file at the ~1 MiB FastCDC
+// average is ~1024 chunks). The inline Blocks list dominates the JSON decode.
+func bigFile(nBlocks int) *metadata.File {
+	blocks := make([]block.ChunkRef, nBlocks)
+	for i := range blocks {
+		var h block.ContentHash
+		for j := range h {
+			h[j] = byte(i*7 + j)
+		}
+		blocks[i] = block.ChunkRef{Hash: h, Offset: uint64(i) << 20, Size: 1 << 20}
+	}
+	return &metadata.File{
+		ID:        uuid.New(),
+		ShareName: "/bench",
+		Path:      "/data.bin",
+		FileAttr: metadata.FileAttr{
+			Type: metadata.FileTypeRegular, Mode: 0o644, UID: 1000, GID: 1000, Nlink: 1,
+			Size: uint64(nBlocks) << 20, Atime: time.Unix(1, 0), Mtime: time.Unix(2, 0),
+			Ctime: time.Unix(3, 0), CreationTime: time.Unix(4, 0),
+			PayloadID: "bench/data", Blocks: blocks,
+		},
+	}
+}
+
+// BenchmarkDecodeFile measures decodeFile on a 1024-block File. With the
+// generated easyjson UnmarshalJSON present, decodeFile's json.Unmarshal
+// auto-dispatches to it; remove file_types_easyjson.go to get the reflection
+// baseline. Run: go test -run=xxx -bench=BenchmarkDecodeFile ./pkg/metadata/store/badger/
+func BenchmarkDecodeFile(b *testing.B) {
+	enc, err := encodeFile(bigFile(1024))
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.SetBytes(int64(len(enc)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := decodeFile(enc); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// TestEncodeDecodeFile_RoundTrip guards format correctness: a File survives
+// encode -> decode byte-for-byte in its fields (decodeFile zeroes Path per
+// #1166, so we compare with Path cleared).
+func TestEncodeDecodeFile_RoundTrip(t *testing.T) {
+	orig := bigFile(37)
+	orig.ACL = nil
+	enc, err := encodeFile(orig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := decodeFile(enc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != orig.ID || got.ShareName != orig.ShareName || got.Size != orig.Size ||
+		got.Mode != orig.Mode || got.PayloadID != orig.PayloadID || len(got.Blocks) != len(orig.Blocks) {
+		t.Fatalf("round-trip mismatch: got %+v", got.FileAttr)
+	}
+	for i := range orig.Blocks {
+		if got.Blocks[i] != orig.Blocks[i] {
+			t.Fatalf("block %d mismatch: got %+v want %+v", i, got.Blocks[i], orig.Blocks[i])
+		}
+	}
+	if !got.Mtime.Equal(orig.Mtime) || !got.Ctime.Equal(orig.Ctime) {
+		t.Fatalf("time mismatch: got mtime=%v ctime=%v", got.Mtime, got.Ctime)
+	}
+}

--- a/pkg/metadata/store/badger/files.go
+++ b/pkg/metadata/store/badger/files.go
@@ -53,8 +53,7 @@ func (s *BadgerMetadataStore) GetFileForRead(ctx context.Context, handle metadat
 	if decErr == nil {
 		key = fileID.String()
 		if cached, ok := s.readCache.get(key); ok {
-			cp := *cached   // shallow copy: a caller may set scalar attrs; the
-			return &cp, nil // shared Blocks/EAs/ACL are read-only on this path
+			return copyForRead(cached), nil
 		}
 	}
 
@@ -73,10 +72,23 @@ func (s *BadgerMetadataStore) GetFileForRead(ctx context.Context, handle metadat
 	}
 	if key != "" {
 		s.readCache.store(key, result, gen)
-		cp := *result
-		return &cp, nil
+		return copyForRead(result), nil
 	}
 	return result, nil
+}
+
+// copyForRead returns a caller-owned copy of a cached File: the struct is
+// copied and the reference-bearing fields (Blocks, ACL, EAs) are deep-copied so
+// neither the caller nor a concurrent reader can mutate the shared cache entry.
+// This preserves badger's no-alias invariant — before the read cache, every
+// GetFileForRead JSON-decoded a fresh File, so callers never aliased stored
+// state. The clones are cheap relative to the decode the cache skips.
+func copyForRead(f *metadata.File) *metadata.File {
+	cp := *f
+	cp.Blocks = metadata.CloneBlocks(f.Blocks)
+	cp.ACL = metadata.CloneACL(f.ACL)
+	cp.EAs = metadata.CloneEAs(f.EAs)
+	return &cp
 }
 
 // PutFile stores or updates file metadata.

--- a/pkg/metadata/store/badger/files.go
+++ b/pkg/metadata/store/badger/files.go
@@ -46,6 +46,21 @@ func (s *BadgerMetadataStore) GetFileForRead(ctx context.Context, handle metadat
 		return nil, err
 	}
 
+	// Read-cache fast path: skip the badger View txn + File JSON decode for a
+	// hot file. Keyed by fileID; invalidated after each committed write.
+	_, fileID, decErr := metadata.DecodeFileHandle(handle)
+	var key string
+	if decErr == nil {
+		key = fileID.String()
+		if cached, ok := s.readCache.get(key); ok {
+			cp := *cached   // shallow copy: a caller may set scalar attrs; the
+			return &cp, nil // shared Blocks/EAs/ACL are read-only on this path
+		}
+	}
+
+	// Snapshot the invalidation generation BEFORE the backing read so a write
+	// that races this read cannot leave a stale value cached (store() checks it).
+	gen := s.readCache.generation()
 	var result *metadata.File
 	err := s.db.View(func(txn *badgerdb.Txn) error {
 		tx := &badgerTransaction{store: s, txn: txn}
@@ -53,7 +68,15 @@ func (s *BadgerMetadataStore) GetFileForRead(ctx context.Context, handle metadat
 		result, err = tx.getFile(ctx, handle, false)
 		return err
 	})
-	return result, err
+	if err != nil {
+		return nil, err
+	}
+	if key != "" {
+		s.readCache.store(key, result, gen)
+		cp := *result
+		return &cp, nil
+	}
+	return result, nil
 }
 
 // PutFile stores or updates file metadata.

--- a/pkg/metadata/store/badger/read_cache.go
+++ b/pkg/metadata/store/badger/read_cache.go
@@ -63,6 +63,16 @@ func (c *fileReadCache) store(key string, file *metadata.File, genAtRead uint64)
 
 // invalidate drops key and advances the generation so any in-flight populate for
 // a now-superseded value is rejected. MUST be called AFTER the write commits.
+//
+// Order matters: bump gen BEFORE delete, not after. A concurrent reader that
+// snapshotted the old generation and is about to store() a pre-write value is
+// rejected the instant gen moves; deleting first would leave a window in which
+// that reader's store() (still seeing the old gen) re-inserts the stale entry
+// after the delete. The get() path is intentionally ungated by gen: a read that
+// is ordered-after this write (the writer's PutFile returns only once invalidate
+// finishes, within withTransaction) always sees the delete and misses; a read
+// merely concurrent with the still-uncommitted write has no ordering guarantee,
+// so serving either value is correct.
 func (c *fileReadCache) invalidate(key string) {
 	c.gen.Add(1)
 	if _, ok := c.m.LoadAndDelete(key); ok {

--- a/pkg/metadata/store/badger/read_cache.go
+++ b/pkg/metadata/store/badger/read_cache.go
@@ -1,0 +1,91 @@
+package badger
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// fileReadCacheCap bounds the read cache. Entries are decoded *File (held
+// read-only), so this is a soft cap on the number of tracked hot files.
+const fileReadCacheCap = 8192
+
+// fileReadCache is a lock-free cache of decoded File records keyed by fileID, so
+// the read hot path (GetFileForRead) skips BOTH the BadgerDB read transaction
+// AND the JSON decode of the File blob. That decode inlines the full ChunkRef
+// list — measured ~800 µs for a 1 GiB (≈1024-chunk) file — and the per-read
+// badger View transaction is the top mutex contender under concurrent reads
+// (server pprof, #1169). A random-read fleet hammering one file re-decoded that
+// blob on every 4 KiB read; the cache collapses it to one decode per file.
+//
+// Correctness (single-node badger is single-writer, which makes this tractable —
+// cf. #1173, which deferred a cache only for the multi-replica postgres case):
+//   - invalidate() runs AFTER a write commits and both deletes the entry and
+//     advances `gen`. A reader that observed the pre-commit value cannot leave
+//     it cached because its store() is generation-guarded (below).
+//   - store() writes only when `gen` is unchanged from the value snapshotted
+//     before the backing read; any write to any file that raced the read moves
+//     `gen` and the stale populate is dropped. A dropped populate is a cache
+//     miss (re-read), never a stale hit.
+type fileReadCache struct {
+	m     sync.Map     // fileID string -> *metadata.File (held read-only)
+	n     atomic.Int64 // approximate entry count for bounding
+	gen   atomic.Uint64
+	prune atomic.Bool
+}
+
+// generation snapshots the invalidation counter; pass the result to store.
+func (c *fileReadCache) generation() uint64 { return c.gen.Load() }
+
+// get returns the cached File for key, or (nil,false). The returned pointer is
+// the shared cache entry — callers MUST copy before mutating.
+func (c *fileReadCache) get(key string) (*metadata.File, bool) {
+	v, ok := c.m.Load(key)
+	if !ok {
+		return nil, false
+	}
+	return v.(*metadata.File), true
+}
+
+// store caches file under key only if no write raced the backing read (the
+// generation is unchanged since genAtRead). file MUST NOT be mutated afterwards.
+func (c *fileReadCache) store(key string, file *metadata.File, genAtRead uint64) {
+	if c.gen.Load() != genAtRead {
+		return
+	}
+	if _, loaded := c.m.Swap(key, file); !loaded {
+		if c.n.Add(1) > fileReadCacheCap {
+			c.pruneToHalf()
+		}
+	}
+}
+
+// invalidate drops key and advances the generation so any in-flight populate for
+// a now-superseded value is rejected. MUST be called AFTER the write commits.
+func (c *fileReadCache) invalidate(key string) {
+	c.gen.Add(1)
+	if _, ok := c.m.LoadAndDelete(key); ok {
+		c.n.Add(-1)
+	}
+}
+
+// pruneToHalf best-effort trims the map back toward half the cap on overflow.
+// One pruner at a time; entries drop in Range order (arbitrary) — a dropped file
+// just re-populates on its next read.
+func (c *fileReadCache) pruneToHalf() {
+	if !c.prune.CompareAndSwap(false, true) {
+		return
+	}
+	defer c.prune.Store(false)
+	target := int64(fileReadCacheCap / 2)
+	c.m.Range(func(k, _ any) bool {
+		if c.n.Load() <= target {
+			return false
+		}
+		if _, ok := c.m.LoadAndDelete(k); ok {
+			c.n.Add(-1)
+		}
+		return true
+	})
+}

--- a/pkg/metadata/store/badger/read_cache_test.go
+++ b/pkg/metadata/store/badger/read_cache_test.go
@@ -1,0 +1,93 @@
+package badger
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+func putFileForTest(t testing.TB, s *BadgerMetadataStore, share, path string, mode uint32, nBlocks int) metadata.FileHandle {
+	t.Helper()
+	ctx := context.Background()
+	handle, err := s.GenerateHandle(ctx, share, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, id, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := bigFile(nBlocks)
+	f.ID = id
+	f.ShareName = share
+	f.Path = path
+	f.Mode = mode
+	if err := s.PutFile(ctx, f); err != nil {
+		t.Fatal(err)
+	}
+	return handle
+}
+
+// TestReadCache_NoStaleReadAfterMutation is the #1169 guard: a read after a write
+// must never return the pre-write value, even though the first read cached it.
+func TestReadCache_NoStaleReadAfterMutation(t *testing.T) {
+	s, err := NewBadgerMetadataStoreWithDefaults(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = s.Close() }()
+	ctx := context.Background()
+
+	handle := putFileForTest(t, s, "/s", "/f", 0o644, 4)
+
+	got, err := s.GetFileForRead(ctx, handle) // populates the cache
+	if err != nil || got.Mode != 0o644 {
+		t.Fatalf("first read: mode=%o err=%v", got.Mode, err)
+	}
+
+	// Mutate via PutFile — must invalidate the cache.
+	_, id, _ := metadata.DecodeFileHandle(handle)
+	f := bigFile(4)
+	f.ID, f.ShareName, f.Path, f.Mode = id, "/s", "/f", 0o600
+	if err := s.PutFile(ctx, f); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err = s.GetFileForRead(ctx, handle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Mode != 0o600 {
+		t.Fatalf("STALE READ: got mode %o after write set 0o600", got.Mode)
+	}
+
+	// A returned File must be a copy — mutating it must not corrupt the cache.
+	got.Mode = 0o000
+	again, _ := s.GetFileForRead(ctx, handle)
+	if again.Mode != 0o600 {
+		t.Fatalf("cache corrupted by caller mutation: got %o", again.Mode)
+	}
+}
+
+// BenchmarkGetFileForRead_Cached measures the warm read path on a 1024-block
+// file — a cache hit skips the ~800 µs badger-read + JSON decode entirely.
+func BenchmarkGetFileForRead_Cached(b *testing.B) {
+	s, err := NewBadgerMetadataStoreWithDefaults(context.Background(), b.TempDir())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = s.Close() }()
+	ctx := context.Background()
+	handle := putFileForTest(b, s, "/s", "/big", 0o644, 1024)
+	if _, err := s.GetFileForRead(ctx, handle); err != nil { // warm the cache
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := s.GetFileForRead(ctx, handle); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/metadata/store/badger/read_cache_test.go
+++ b/pkg/metadata/store/badger/read_cache_test.go
@@ -62,11 +62,19 @@ func TestReadCache_NoStaleReadAfterMutation(t *testing.T) {
 		t.Fatalf("STALE READ: got mode %o after write set 0o600", got.Mode)
 	}
 
-	// A returned File must be a copy — mutating it must not corrupt the cache.
+	// A returned File must be a copy — mutating it (scalar OR reference-bearing
+	// fields) must not corrupt the shared cache entry. Before the cache, badger
+	// JSON-decoded a fresh File per read, so callers never aliased stored state.
 	got.Mode = 0o000
+	if len(got.Blocks) > 0 {
+		got.Blocks[0].Offset = 0xdeadbeef // in-place mutation of the block slice
+	}
 	again, _ := s.GetFileForRead(ctx, handle)
 	if again.Mode != 0o600 {
-		t.Fatalf("cache corrupted by caller mutation: got %o", again.Mode)
+		t.Fatalf("cache corrupted by caller scalar mutation: got %o", again.Mode)
+	}
+	if len(again.Blocks) > 0 && again.Blocks[0].Offset == 0xdeadbeef {
+		t.Fatal("cache Blocks aliased: caller in-place edit leaked into the cached File")
 	}
 }
 

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -59,6 +59,11 @@ type BadgerMetadataStore struct {
 	// db is the BadgerDB database handle (thread-safe, uses internal MVCC)
 	db *badger.DB
 
+	// readCache caches decoded File records for the read hot path so
+	// GetFileForRead skips the per-read badger View transaction + File JSON
+	// decode. Invalidated after each committed write (see withTransaction).
+	readCache fileReadCache
+
 	// gcStop signals the value-log GC goroutine to exit. Closed once by
 	// Close() (guarded by gcStopOnce); gcWG waits for the goroutine to
 	// drain before Close() shuts the DB so the GC never runs against a

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -31,6 +31,11 @@ type badgerTransaction struct {
 	store        *BadgerMetadataStore
 	txn          *badgerdb.Txn
 	pendingDelta int64
+	// dirtyFiles collects fileID keys whose stored File blob or link count this
+	// transaction mutated. Captured per attempt and, after a successful commit,
+	// used to invalidate the read cache (see withTransaction). Reset per attempt
+	// like pendingDelta so a conflict-retry cannot leak a phantom invalidation.
+	dirtyFiles []string
 	// quotaDelta accumulates per-identity usage changes (bytes + file count)
 	// keyed by (scope, id). Captured per attempt and applied to the store's
 	// in-memory userUsage/groupUsage cache exactly once after a successful
@@ -130,6 +135,7 @@ func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx me
 		// from zero, so a conflict-retry cannot double-count usedBytes).
 		var pendingDelta int64
 		var quotaDelta map[badgerQuotaKey]metadata.UsageStat
+		var dirtyFiles []string
 		err := s.db.Update(func(txn *badgerdb.Txn) error {
 			tx := &badgerTransaction{store: s, txn: txn}
 			if fnErr := fn(tx); fnErr != nil {
@@ -137,6 +143,7 @@ func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx me
 			}
 			pendingDelta = tx.pendingDelta
 			quotaDelta = tx.quotaDelta
+			dirtyFiles = tx.dirtyFiles
 			return nil
 		})
 
@@ -147,6 +154,12 @@ func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx me
 			}
 			// Apply per-identity usage deltas once, after commit.
 			s.applyQuotaDelta(quotaDelta)
+			// Invalidate the read cache for every file this transaction mutated,
+			// AFTER the commit so a concurrent reader that saw the pre-commit
+			// value cannot leave it cached (its generation-guarded store loses).
+			for _, id := range dirtyFiles {
+				s.readCache.invalidate(id)
+			}
 			// Durable (data-paired) commit in relaxed mode: fsync now so the
 			// write survives a crash. A sync failure must not falsely ack a
 			// durable write (#588), so surface it. No-op in strict mode.
@@ -410,6 +423,7 @@ func (tx *badgerTransaction) PutFile(ctx context.Context, file *metadata.File) e
 	if err := tx.txn.Set(keyFile(file.ID), data); err != nil {
 		return err
 	}
+	tx.dirtyFiles = append(tx.dirtyFiles, file.ID.String())
 
 	// maintain ObjectID -> file UUID secondary index in the
 	// same Txn as the primary file write (atomic on commit).
@@ -482,6 +496,8 @@ func (tx *badgerTransaction) DeleteFile(ctx context.Context, handle metadata.Fil
 			Message: "invalid file handle",
 		}
 	}
+
+	tx.dirtyFiles = append(tx.dirtyFiles, fileID.String())
 
 	// Check if exists first and read for size tracking.
 	item, err := tx.txn.Get(keyFile(fileID))
@@ -916,6 +932,7 @@ func (tx *badgerTransaction) SetLinkCount(ctx context.Context, handle metadata.F
 		}
 	}
 
+	tx.dirtyFiles = append(tx.dirtyFiles, fileID.String())
 	return tx.txn.Set(keyLinkCount(fileID), encodeUint32(count))
 }
 

--- a/pkg/metadata/store/memory/files.go
+++ b/pkg/metadata/store/memory/files.go
@@ -19,12 +19,7 @@ import (
 // Returns nil if the input is nil or empty so the round-trip preserves
 // the omitempty wire form (json:"blocks,omitempty" on FileAttr.Blocks).
 func cloneBlocks(in []block.ChunkRef) []block.ChunkRef {
-	if len(in) == 0 {
-		return nil
-	}
-	out := make([]block.ChunkRef, len(in))
-	copy(out, in)
-	return out
+	return metadata.CloneBlocks(in)
 }
 
 // cloneACL returns a deep copy of a *acl.ACL, including fresh copies of its
@@ -42,19 +37,7 @@ func cloneBlocks(in []block.ChunkRef) []block.ChunkRef {
 // Returns nil if the input is nil so the round-trip preserves the
 // "no ACL set" semantics (json:"acl,omitempty" on FileAttr.ACL).
 func cloneACL(in *acl.ACL) *acl.ACL {
-	if in == nil {
-		return nil
-	}
-	out := *in
-	if in.ACEs != nil {
-		out.ACEs = make([]acl.ACE, len(in.ACEs))
-		copy(out.ACEs, in.ACEs)
-	}
-	if in.SACL != nil {
-		out.SACL = make([]acl.ACE, len(in.SACL))
-		copy(out.SACL, in.SACL)
-	}
-	return &out
+	return metadata.CloneACL(in)
 }
 
 // cloneEAs returns a deep copy of a FileAttr.EAs map, copying each value slice
@@ -64,16 +47,7 @@ func cloneACL(in *acl.ACL) *acl.ACL {
 // Badger/Postgres backends round-trip through JSON and never alias, so the
 // memory backend must copy to keep cross-backend parity.
 func cloneEAs(in map[string][]byte) map[string][]byte {
-	if len(in) == 0 {
-		return nil
-	}
-	out := make(map[string][]byte, len(in))
-	for k, v := range in {
-		vc := make([]byte, len(v))
-		copy(vc, v)
-		out[k] = vc
-	}
-	return out
+	return metadata.CloneEAs(in)
 }
 
 // ============================================================================


### PR DESCRIPTION
Follow-up to the warm-read fast path (#1648/#1651). A **VM server-pprof** under warm random-read (badger, S3) pinpointed the real remaining bottleneck: **`GetFileForRead` = ~47% of server CPU, almost entirely JSON-decoding the File blob**, and badger read transactions as the **top mutex contender**. The File blob inlines the full `[]ChunkRef` (~1024 refs for a 1 GiB file, ~800 µs to decode), so a random-read fleet on one file re-decoded it on **every 4 KiB read**. This is why the engine microbench showed 20× but the rig only ~2× — the microbench used the in-memory metadata store and never touched badger.

## Rejected alternatives (benchmarked first, per request)

| attempt | result |
|---|--|
| **easyjson** codec for File/FileChunk | **~0%** (835 µs vs 789 µs) — the cost is the per-ChunkRef `ContentHash.UnmarshalJSON` (hex decode), which both paths dispatch to identically, not reflection. Reverted. |
| **blocks-skipping decode** on the read path | ~23% + 99% fewer allocs, but json still *scans* the 270 KB blob, and READ_PLUS/SEEK legitimately need `Blocks` (can't blanket-skip without growing the store interface). |

## This change

A lock-free (`sync.Map`) read cache of decoded `File` records on the badger store, keyed by fileID, so `GetFileForRead` skips **both** the View transaction and the JSON decode on a hot file.

**Correctness** (single-node badger is single-writer):
- **Invalidate after commit**: for every file a transaction mutated (`PutFile`/`DeleteFile`/`SetLinkCount`, tracked via `tx.dirtyFiles`), `withTransaction` deletes the entry and bumps a generation *after* the badger commit.
- **Generation-guarded populate**: a read snapshots the generation before the backing read and only caches if it's unchanged, so a write racing the read can never leave a stale value cached (a lost populate is a miss, never a stale hit).
- Returned Files are **copies** (caller-mutation-safe).
- Bounded (soft cap + best-effort prune).

Scoped to badger; the #1173 deferral was specifically about multi-replica **postgres** scale-out invalidation, which this does not touch.

## Measured

- `BenchmarkGetFileForRead_Cached`: **~800 µs (uncached decode) → 139 ns/op** on a cache hit (~5700×), and it also skips the contended badger View txn.
- `TestReadCache_NoStaleReadAfterMutation` guards invalidation + caller-copy-safety.
- `go test -race ./pkg/metadata/store/badger/` — **522 pass** (incl. storetest conformance).

## Follow-up

End-to-end VM validation of the rig random-read number (recommended) — this should close most of the remaining gap to the page-cache re-exports. The readahead lock-free fix (#1653) is a separate, minor concurrency improvement (pprof showed it wasn't the bottleneck).