### PR TITLE
diag(smb): pinpoint the offending holder on rename SHARING_VIOLATION (#1652)

### DIFF
--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -2419,7 +2419,7 @@ func adsBasePath(filePath string) string {
 func (h *Handler) checkShareDeleteConflict(renameFile *OpenFile) bool {
 	const fileShareDelete = uint32(0x04) // FILE_SHARE_DELETE
 
-	conflict := false
+	var culprit *OpenFile
 	h.files.Range(func(key, value any) bool {
 		other := value.(*OpenFile)
 		// Skip the handle being renamed
@@ -2435,12 +2435,45 @@ func (h *Handler) checkShareDeleteConflict(renameFile *OpenFile) bool {
 		}
 		// If this other handle does not allow delete sharing, conflict
 		if other.ShareAccess&fileShareDelete == 0 {
-			conflict = true
+			culprit = other
 			return false // Stop iterating
 		}
 		return true
 	})
-	return conflict
+	if culprit != nil {
+		// #1652: dump the offending holder so a spurious/intermittent
+		// SHARING_VIOLATION on rename is diagnosable — the call-site log only
+		// records the renamer. The conflict is expected only when a live
+		// sibling open lacks FILE_SHARE_DELETE; a holder on a different
+		// session/tree, a durable handle, or a delete-pending stub pointing
+		// here is the fingerprint of a leaked/stale open.
+		logRenameConflictHolder("source-file share-delete gate", renameFile, culprit)
+		return true
+	}
+	return false
+}
+
+// logRenameConflictHolder emits (at Debug) the full identity of the open handle
+// that tripped a rename share-mode gate, alongside the renamer. Fields chosen to
+// answer "is this a legitimate live sibling, or a stale/cross-connection leak?":
+// session/tree locate the owning connection, ShareAccess/DesiredAccess show why
+// it conflicted, IsDurable/DeletePending flag reconnect/teardown stubs. #1652.
+func logRenameConflictHolder(gate string, renamer, holder *OpenFile) {
+	logger.Debug("SET_INFO rename conflict holder",
+		"gate", gate,
+		"renamerFileID", fmt.Sprintf("%x", renamer.FileID),
+		"renamerPath", renamer.Path,
+		"renamerSession", renamer.SessionID,
+		"renamerTree", renamer.TreeID,
+		"holderFileID", fmt.Sprintf("%x", holder.FileID),
+		"holderPath", holder.Path,
+		"holderShare", holder.ShareName,
+		"holderSession", holder.SessionID,
+		"holderTree", holder.TreeID,
+		"holderShareAccess", fmt.Sprintf("0x%x", holder.ShareAccess),
+		"holderDesiredAccess", fmt.Sprintf("0x%x", holder.DesiredAccess),
+		"holderIsDurable", holder.IsDurable,
+		"holderDeletePending", holder.DeletePending)
 }
 
 // checkParentDirRenameConflict applies the destination-parent share-mode
@@ -2459,7 +2492,7 @@ func (h *Handler) checkParentDirRenameConflict(renamerFileID [16]byte, dstParent
 	if len(dstParent) == 0 {
 		return false
 	}
-	conflict := false
+	var culprit *OpenFile
 	h.files.Range(func(_, value any) bool {
 		other := value.(*OpenFile)
 		if other.FileID == renamerFileID {
@@ -2481,12 +2514,19 @@ func (h *Handler) checkParentDirRenameConflict(renamerFileID [16]byte, dstParent
 			return true
 		}
 		if other.ShareAccess&fileShareDelete == 0 || hasDeleteAccess(other.DesiredAccess) {
-			conflict = true
+			culprit = other
 			return false
 		}
 		return true
 	})
-	return conflict
+	if culprit != nil {
+		// #1652: dump the dst-parent holder that tripped the gate. renamerFileID
+		// is only an ID here, so pass a minimal renamer view for the log.
+		logRenameConflictHolder("dst-parent share-mode gate",
+			&OpenFile{FileID: renamerFileID}, culprit)
+		return true
+	}
+	return false
 }
 
 // snapshotOpenChildren returns the metadata handles of every open file whose


### PR DESCRIPTION
## What

Adds Debug-level instrumentation to the two SMB rename share-mode gates
(`checkShareDeleteConflict`, `checkParentDirRenameConflict`) so that when a
rename returns `SHARING_VIOLATION`, the log names the **exact open handle that
tripped the gate** — its session/tree, path, share-access, desired-access, and
durable/delete-pending state — not just the renamer.

Diagnostic only. Return values are unchanged; no behavior change.

## Why (#1652)

`develop` CI goes intermittently red on the `smbtorture / memory` job with
`smb2.rename.rename_dir_bench` + `smb2.rename.close-full-information` failing
`NT_STATUS_SHARING_VIOLATION` (and, in other runs, `dirlease.unlink_*`).

Investigation established it is **not a regression** (the same pair failed in a
pre-suspect-commit run) and **not the metadata layer** (no metadata error maps
to `SharingViolation`). `close-full-information` opens all its handles with full
share access (incl. `FILE_SHARE_DELETE`) and requests no lease — so by
share-mode logic neither gate can match its own handles. The `SHARING_VIOLATION`
can therefore only be a gate matching a **stale/foreign handle** in `h.files`.

The flake **does not reproduce in isolation** (`smb2.rename` passed 70+/70
locally under CPU-throttle and 16-way host-stress); it only surfaces in the
full multi-suite conformance run, i.e. from cross-suite accumulated state under
runner contention. Rather than blind-patch this delicate lease/rename path (it
satisfies 30+ smbtorture tests via carefully-ordered mutexes), this PR makes the
next occurrence — CI or local — capture the offending handle so the real fix can
be targeted and verified.

## Next

Once develop CI trips this again with the new log line
(`SET_INFO rename conflict holder ...`), the offending handle's origin points
directly at the leak, and the fix follows.

Refs #1652.