### PR TITLE
perf(metadata): read cache for badger GetShareOptions

### DIFF
--- a/pkg/metadata/store/badger/read_cache.go
+++ b/pkg/metadata/store/badger/read_cache.go
@@ -59,6 +59,15 @@ func (c *fileReadCache) store(key string, file *metadata.File, genAtRead uint64)
 			c.pruneToHalf()
 		}
 	}
+	// The guard above and the Swap are not atomic: a write could commit and
+	// invalidate() (bump gen + delete) in between, leaving our now-stale entry
+	// live. Re-check the generation; if it moved, drop our entry — but only if a
+	// newer reader hasn't already replaced it (CompareAndDelete on our pointer).
+	if c.gen.Load() != genAtRead {
+		if c.m.CompareAndDelete(key, file) {
+			c.n.Add(-1)
+		}
+	}
 }
 
 // invalidate drops key and advances the generation so any in-flight populate for

--- a/pkg/metadata/store/badger/share_read_cache.go
+++ b/pkg/metadata/store/badger/share_read_cache.go
@@ -1,0 +1,113 @@
+package badger
+
+import (
+	"slices"
+	"sync"
+	"sync/atomic"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// shareReadCache is a lock-free cache of decoded ShareOptions keyed by share
+// name, so the permission hot path (CheckReadPermissionFile → GetShareOptions)
+// skips BOTH the BadgerDB read transaction AND the JSON decode of the share
+// record on every NFS read. Server pprof of warm random-read showed
+// GetShareOptions → decodeShareData at 17.4% of server CPU, and the badger
+// read-transaction the top mutex contender at 14.5% — every read re-decodes a
+// config record that changes only on a rare admin reconfigure.
+//
+// Shares are FEW and rarely written, so unlike fileReadCache this needs no
+// prune/cap logic. The correctness discipline is identical (single-node badger
+// is single-writer, cf. fileReadCache):
+//   - invalidate() runs AFTER a write commits and both deletes the entry and
+//     advances `gen`. A reader that observed the pre-commit value cannot leave
+//     it cached because its store() is generation-guarded (below). A stale
+//     entry here is a WRONG permission decision, so every share-record write
+//     site must invalidate.
+//   - store() writes only when `gen` is unchanged from the value snapshotted
+//     before the backing read; any racing write moves `gen` and the stale
+//     populate is dropped (a cache miss, never a stale hit).
+type shareReadCache struct {
+	m   sync.Map // shareName string -> *metadata.ShareOptions (held read-only)
+	gen atomic.Uint64
+}
+
+// generation snapshots the invalidation counter; pass the result to store.
+func (c *shareReadCache) generation() uint64 { return c.gen.Load() }
+
+// get returns the cached ShareOptions for shareName, or (nil,false). The
+// returned pointer is the shared cache entry — callers MUST copy before
+// returning it to a mutator (see cloneShareOptions).
+func (c *shareReadCache) get(shareName string) (*metadata.ShareOptions, bool) {
+	v, ok := c.m.Load(shareName)
+	if !ok {
+		return nil, false
+	}
+	return v.(*metadata.ShareOptions), true
+}
+
+// store caches opts under shareName only if no write raced the backing read
+// (the generation is unchanged since genAtRead). opts MUST NOT be mutated
+// afterwards — it becomes the shared cache entry.
+func (c *shareReadCache) store(shareName string, opts *metadata.ShareOptions, genAtRead uint64) {
+	if c.gen.Load() != genAtRead {
+		return
+	}
+	c.m.Store(shareName, opts)
+	// The guard above and the Store are not atomic: a write could commit and
+	// invalidate() (bump gen + delete) in between, leaving our now-stale entry
+	// live. Re-check the generation; if it moved, drop our entry — but only if a
+	// newer reader hasn't already replaced it (CompareAndDelete on our pointer).
+	// A stale share entry is a wrong permission decision, so this must be tight.
+	if c.gen.Load() != genAtRead {
+		c.m.CompareAndDelete(shareName, opts)
+	}
+}
+
+// invalidate drops shareName and advances the generation so any in-flight
+// populate for a now-superseded value is rejected. MUST be called AFTER the
+// write commits. Order matters: bump gen BEFORE delete (see fileReadCache) so a
+// concurrent reader that snapshotted the old generation cannot re-insert a
+// pre-write value after the delete.
+func (c *shareReadCache) invalidate(shareName string) {
+	c.gen.Add(1)
+	c.m.Delete(shareName)
+}
+
+// cloneShareOptions returns a caller-owned deep copy of opts: the struct is
+// copied and every reference-bearing field (three string slices and the
+// IdentityMapping pointee, itself holding *uint32/*uint32/*string) is cloned so
+// neither the caller nor a concurrent reader can mutate the shared cache entry.
+// A shallow *opts would alias those slices/pointers into the cache.
+func cloneShareOptions(opts *metadata.ShareOptions) *metadata.ShareOptions {
+	if opts == nil {
+		return nil
+	}
+	cp := *opts
+	cp.AllowedClients = slices.Clone(opts.AllowedClients)
+	cp.DeniedClients = slices.Clone(opts.DeniedClients)
+	cp.AllowedAuthMethods = slices.Clone(opts.AllowedAuthMethods)
+	cp.IdentityMapping = cloneIdentityMapping(opts.IdentityMapping)
+	return &cp
+}
+
+// cloneIdentityMapping deep-copies the mapping and its pointer fields.
+func cloneIdentityMapping(m *metadata.IdentityMapping) *metadata.IdentityMapping {
+	if m == nil {
+		return nil
+	}
+	cp := *m
+	if m.AnonymousUID != nil {
+		v := *m.AnonymousUID
+		cp.AnonymousUID = &v
+	}
+	if m.AnonymousGID != nil {
+		v := *m.AnonymousGID
+		cp.AnonymousGID = &v
+	}
+	if m.AnonymousSID != nil {
+		v := *m.AnonymousSID
+		cp.AnonymousSID = &v
+	}
+	return &cp
+}

--- a/pkg/metadata/store/badger/share_read_cache_test.go
+++ b/pkg/metadata/store/badger/share_read_cache_test.go
@@ -1,0 +1,164 @@
+package badger
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/stretchr/testify/require"
+)
+
+// newShareCacheStore spins up a throwaway badger store for the share-cache tests.
+func newShareCacheStore(t *testing.T) *BadgerMetadataStore {
+	t.Helper()
+	store, err := NewBadgerMetadataStoreWithDefaults(context.Background(), filepath.Join(t.TempDir(), "metadata.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// TestShareCache_NoStalePermissionAfterUpdate proves the cache never serves a
+// stale permission decision: an UpdateShareOptions after a populating read must
+// be reflected on the next GetShareOptions. A miss here is a security bug.
+func TestShareCache_NoStalePermissionAfterUpdate(t *testing.T) {
+	ctx := context.Background()
+	store := newShareCacheStore(t)
+
+	require.NoError(t, store.CreateShare(ctx, &metadata.Share{
+		Name:    "s1",
+		Options: metadata.ShareOptions{ReadOnly: false},
+	}))
+
+	// Populate the cache and confirm the pre-update value.
+	got, err := store.GetShareOptions(ctx, "s1")
+	require.NoError(t, err)
+	require.False(t, got.ReadOnly)
+
+	// Flip ReadOnly true; the cached false must not survive.
+	require.NoError(t, store.UpdateShareOptions(ctx, "s1", &metadata.ShareOptions{ReadOnly: true}))
+	got, err = store.GetShareOptions(ctx, "s1")
+	require.NoError(t, err)
+	require.True(t, got.ReadOnly, "cache served a stale ReadOnly=false after update")
+
+	// Same guarantee for a reference-bearing slice field.
+	require.NoError(t, store.UpdateShareOptions(ctx, "s1", &metadata.ShareOptions{
+		ReadOnly:       true,
+		AllowedClients: []string{"10.0.0.0/8"},
+	}))
+	got, err = store.GetShareOptions(ctx, "s1")
+	require.NoError(t, err)
+	require.Equal(t, []string{"10.0.0.0/8"}, got.AllowedClients)
+}
+
+// TestShareCache_InvalidateOnDelete proves a deleted share is not still served
+// from the cache.
+func TestShareCache_InvalidateOnDelete(t *testing.T) {
+	ctx := context.Background()
+	store := newShareCacheStore(t)
+
+	require.NoError(t, store.CreateShare(ctx, &metadata.Share{Name: "s1"}))
+	_, err := store.GetShareOptions(ctx, "s1") // populate
+	require.NoError(t, err)
+
+	require.NoError(t, store.DeleteShare(ctx, "s1"))
+	_, err = store.GetShareOptions(ctx, "s1")
+	require.Error(t, err, "cache served options for a deleted share")
+}
+
+// TestShareCache_CopySafety proves the returned *ShareOptions is a deep copy:
+// mutating it (including appending to its slice) cannot corrupt the cache.
+func TestShareCache_CopySafety(t *testing.T) {
+	ctx := context.Background()
+	store := newShareCacheStore(t)
+
+	sid := "S-1-5-7"
+	uid := uint32(65534)
+	require.NoError(t, store.CreateShare(ctx, &metadata.Share{
+		Name: "s1",
+		Options: metadata.ShareOptions{
+			AllowedClients:  []string{"192.168.1.0/24"},
+			IdentityMapping: &metadata.IdentityMapping{AnonymousUID: &uid, AnonymousSID: &sid},
+		},
+	}))
+
+	first, err := store.GetShareOptions(ctx, "s1") // populate
+	require.NoError(t, err)
+
+	// Vandalize the returned copy every way a caller could.
+	first.ReadOnly = true
+	first.AllowedClients = append(first.AllowedClients, "0.0.0.0/0")
+	first.AllowedClients[0] = "mutated"
+	*first.IdentityMapping.AnonymousUID = 0
+	*first.IdentityMapping.AnonymousSID = "mutated"
+
+	second, err := store.GetShareOptions(ctx, "s1")
+	require.NoError(t, err)
+	require.False(t, second.ReadOnly)
+	require.Equal(t, []string{"192.168.1.0/24"}, second.AllowedClients)
+	require.Equal(t, uint32(65534), *second.IdentityMapping.AnonymousUID)
+	require.Equal(t, "S-1-5-7", *second.IdentityMapping.AnonymousSID)
+}
+
+// TestShareCache_TxUpdateInvalidates covers the withTransaction dirtyShares
+// hook: an UpdateShareOptions run through the transaction path must invalidate
+// the cache just like the direct db.Update path.
+func TestShareCache_TxUpdateInvalidates(t *testing.T) {
+	ctx := context.Background()
+	store := newShareCacheStore(t)
+
+	require.NoError(t, store.CreateShare(ctx, &metadata.Share{Name: "s1"}))
+	got, err := store.GetShareOptions(ctx, "s1") // populate
+	require.NoError(t, err)
+	require.False(t, got.ReadOnly)
+
+	require.NoError(t, store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.(*badgerTransaction).UpdateShareOptions(ctx, "s1", &metadata.ShareOptions{ReadOnly: true})
+	}))
+
+	got, err = store.GetShareOptions(ctx, "s1")
+	require.NoError(t, err)
+	require.True(t, got.ReadOnly, "tx-path update did not invalidate the cache")
+}
+
+func BenchmarkGetShareOptions_Cached(b *testing.B) {
+	ctx := context.Background()
+	store, err := NewBadgerMetadataStoreWithDefaults(ctx, filepath.Join(b.TempDir(), "metadata.db"))
+	require.NoError(b, err)
+	defer func() { _ = store.Close() }()
+	require.NoError(b, store.CreateShare(ctx, &metadata.Share{
+		Name:    "s1",
+		Options: metadata.ShareOptions{AllowedClients: []string{"10.0.0.0/8"}},
+	}))
+	_, _ = store.GetShareOptions(ctx, "s1") // warm the cache
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := store.GetShareOptions(ctx, "s1"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkGetShareOptions_Uncached forces a cache miss each iteration to
+// measure the badger View + decode cost the cache eliminates.
+func BenchmarkGetShareOptions_Uncached(b *testing.B) {
+	ctx := context.Background()
+	store, err := NewBadgerMetadataStoreWithDefaults(ctx, filepath.Join(b.TempDir(), "metadata.db"))
+	require.NoError(b, err)
+	defer func() { _ = store.Close() }()
+	require.NoError(b, store.CreateShare(ctx, &metadata.Share{
+		Name:    "s1",
+		Options: metadata.ShareOptions{AllowedClients: []string{"10.0.0.0/8"}},
+	}))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		store.shareCache.invalidate("s1")
+		if _, err := store.GetShareOptions(ctx, "s1"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -70,6 +70,16 @@ func (s *BadgerMetadataStore) GetShareOptions(ctx context.Context, shareName str
 		return nil, err
 	}
 
+	// Cache fast path: skip the badger View txn + share-record decode on a hit.
+	// Return a deep copy so callers can never mutate the shared cache entry.
+	if cached, ok := s.shareCache.get(shareName); ok {
+		return cloneShareOptions(cached), nil
+	}
+
+	// Snapshot the invalidation generation BEFORE the backing read so a write
+	// that races this read cannot leave a stale value cached (store() checks it).
+	gen := s.shareCache.generation()
+
 	var opts *metadata.ShareOptions
 	err := s.db.View(func(txn *badgerdb.Txn) error {
 		item, err := txn.Get(keyShare(shareName))
@@ -99,7 +109,8 @@ func (s *BadgerMetadataStore) GetShareOptions(ctx context.Context, shareName str
 		return nil, err
 	}
 
-	return opts, nil
+	s.shareCache.store(shareName, opts, gen)
+	return cloneShareOptions(opts), nil
 }
 
 // ============================================================================
@@ -112,7 +123,7 @@ func (s *BadgerMetadataStore) CreateShare(ctx context.Context, share *metadata.S
 		return err
 	}
 
-	return s.db.Update(func(txn *badgerdb.Txn) error {
+	err := s.db.Update(func(txn *badgerdb.Txn) error {
 		_, err := txn.Get(keyShare(share.Name))
 		if err == nil {
 			return &metadata.StoreError{
@@ -138,6 +149,10 @@ func (s *BadgerMetadataStore) CreateShare(ctx context.Context, share *metadata.S
 
 		return txn.Set(keyShare(share.Name), encoded)
 	})
+	if err == nil {
+		s.shareCache.invalidate(share.Name)
+	}
+	return err
 }
 
 // UpdateShareOptions updates the share configuration options.
@@ -146,7 +161,7 @@ func (s *BadgerMetadataStore) UpdateShareOptions(ctx context.Context, shareName 
 		return err
 	}
 
-	return s.db.Update(func(txn *badgerdb.Txn) error {
+	err := s.db.Update(func(txn *badgerdb.Txn) error {
 		item, err := txn.Get(keyShare(shareName))
 		if err == badgerdb.ErrKeyNotFound {
 			return &metadata.StoreError{
@@ -182,6 +197,10 @@ func (s *BadgerMetadataStore) UpdateShareOptions(ctx context.Context, shareName 
 
 		return txn.Set(keyShare(shareName), updatedData)
 	})
+	if err == nil {
+		s.shareCache.invalidate(shareName)
+	}
+	return err
 }
 
 // DeleteShare removes a share and all its metadata.
@@ -217,6 +236,8 @@ func (s *BadgerMetadataStore) DeleteShare(ctx context.Context, shareName string)
 	if err != nil {
 		return err
 	}
+	// Drop any cached options for the removed share, after a successful commit.
+	s.shareCache.invalidate(shareName)
 	// Apply the usedBytes decrement once, after a successful commit.
 	if freedBytes > 0 {
 		s.usedBytes.Add(-freedBytes)
@@ -476,6 +497,10 @@ func (s *BadgerMetadataStore) CreateRootDirectory(ctx context.Context, shareName
 	if err != nil {
 		return nil, err
 	}
+
+	// Both branches (createNewRoot / loadExistingRoot) rewrite the share record,
+	// so drop any cached options for it after the commit.
+	s.shareCache.invalidate(shareName)
 
 	return rootFile, nil
 }

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -93,6 +93,12 @@ type BadgerMetadataStore struct {
 	// 0 means unlimited (constrained only by available disk space).
 	maxFiles uint64
 
+	// shareCache caches decoded ShareOptions for the permission hot path so
+	// GetShareOptions (17.4% of server CPU on warm random-read) skips the
+	// badger View txn + JSON decode. Invalidated after every committed
+	// share-record write; a stale entry is a wrong permission decision.
+	shareCache shareReadCache
+
 	// statsCache caches filesystem statistics to avoid expensive database scans.
 	// Filesystem statistics require scanning all file entries, which can be slow.
 	// This cache stores the result with a timestamp and TTL to serve repeated

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -42,6 +42,12 @@ type badgerTransaction struct {
 	// commit, identical to pendingDelta (so a conflict-retry cannot
 	// double-count).
 	quotaDelta map[badgerQuotaKey]metadata.UsageStat
+	// dirtyShares collects share names whose stored share record this
+	// transaction mutated. Captured per attempt and, after a successful commit,
+	// used to invalidate the share read cache (see withTransaction). Reset per
+	// attempt like pendingDelta so a conflict-retry cannot leak a phantom
+	// invalidation. A stale entry is a wrong permission decision.
+	dirtyShares []string
 }
 
 // badgerQuotaKey identifies a per-identity usage bucket inside a transaction's
@@ -136,6 +142,7 @@ func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx me
 		var pendingDelta int64
 		var quotaDelta map[badgerQuotaKey]metadata.UsageStat
 		var dirtyFiles []string
+		var dirtyShares []string
 		err := s.db.Update(func(txn *badgerdb.Txn) error {
 			tx := &badgerTransaction{store: s, txn: txn}
 			if fnErr := fn(tx); fnErr != nil {
@@ -144,6 +151,7 @@ func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx me
 			pendingDelta = tx.pendingDelta
 			quotaDelta = tx.quotaDelta
 			dirtyFiles = tx.dirtyFiles
+			dirtyShares = tx.dirtyShares
 			return nil
 		})
 
@@ -154,11 +162,15 @@ func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx me
 			}
 			// Apply per-identity usage deltas once, after commit.
 			s.applyQuotaDelta(quotaDelta)
-			// Invalidate the read cache for every file this transaction mutated,
-			// AFTER the commit so a concurrent reader that saw the pre-commit
-			// value cannot leave it cached (its generation-guarded store loses).
+			// Invalidate the read caches for every file / share this transaction
+			// mutated, AFTER the commit so a concurrent reader that saw the
+			// pre-commit value cannot leave it cached (its generation-guarded
+			// store loses). A stale share entry is a wrong permission decision.
 			for _, id := range dirtyFiles {
 				s.readCache.invalidate(id)
+			}
+			for _, name := range dirtyShares {
+				s.shareCache.invalidate(name)
 			}
 			// Durable (data-paired) commit in relaxed mode: fsync now so the
 			// write survives a crash. A sync failure must not falsely ack a
@@ -1102,7 +1114,11 @@ func (tx *badgerTransaction) CreateShare(ctx context.Context, share *metadata.Sh
 		return err
 	}
 
-	return tx.txn.Set(keyShare(share.Name), encoded)
+	if err := tx.txn.Set(keyShare(share.Name), encoded); err != nil {
+		return err
+	}
+	tx.dirtyShares = append(tx.dirtyShares, share.Name)
+	return nil
 }
 
 func (tx *badgerTransaction) UpdateShareOptions(ctx context.Context, shareName string, options *metadata.ShareOptions) error {
@@ -1142,7 +1158,11 @@ func (tx *badgerTransaction) UpdateShareOptions(ctx context.Context, shareName s
 		return err
 	}
 
-	return tx.txn.Set(keyShare(shareName), updatedData)
+	if err := tx.txn.Set(keyShare(shareName), updatedData); err != nil {
+		return err
+	}
+	tx.dirtyShares = append(tx.dirtyShares, shareName)
+	return nil
 }
 
 func (tx *badgerTransaction) DeleteShare(ctx context.Context, shareName string) error {
@@ -1176,7 +1196,11 @@ func (tx *badgerTransaction) DeleteShare(ctx context.Context, shareName string) 
 		tx.addQuota2(k, d)
 	}
 
-	return tx.txn.Delete(keyShare(shareName))
+	if err := tx.txn.Delete(keyShare(shareName)); err != nil {
+		return err
+	}
+	tx.dirtyShares = append(tx.dirtyShares, shareName)
+	return nil
 }
 
 func (tx *badgerTransaction) ListShares(ctx context.Context) ([]string, error) {
@@ -1355,6 +1379,7 @@ func (tx *badgerTransaction) CreateRootDirectory(ctx context.Context, shareName 
 	if err := tx.txn.Set(keyShare(shareName), shareBytes); err != nil {
 		return nil, err
 	}
+	tx.dirtyShares = append(tx.dirtyShares, shareName)
 
 	return rootFile, nil
 }


### PR DESCRIPTION
## Problem

A fresh server-pprof of warm NFS random-read (dittofs-s3, badger metadata) shows every NFS read runs a permission check that badger-`View`s and JSON-decodes the share-config record:

- `CheckReadPermissionFile -> GetShareOptions -> decodeShareData` = **17.4% of server CPU**
- The badger read-transaction (`(*DB).View`/`readTs`) is also the **top mutex contender at 14.5%**

Share config changes only on a rare admin reconfigure, so caching the decoded `*metadata.ShareOptions` per share eliminates this entirely. Mirrors the just-shipped `GetFileForRead` read cache.

## Change

- New `shareReadCache` (`sync.Map` + `atomic.Uint64` generation), keyed by share name. Shares are few and rarely written, so no prune/cap logic is needed.
- `GetShareOptions` fast path: return a **deep copy** of the cached options on a hit; on miss, snapshot the generation, do the existing `db.View` + `decodeShareData`, generation-guarded `store`, return a deep copy.
- Deep copy clones all three string slices (`AllowedClients`, `DeniedClients`, `AllowedAuthMethods`) **and** the `IdentityMapping` pointee (its `*uint32` / `*uint32` / `*string`), so no caller or concurrent reader ever aliases the cached object.

## Security: invalidation completeness

A stale cache entry is a **wrong permission decision**, so every share-record write site invalidates after the write commits. All 8 sites (grep-verified: `Set(keyShare` / `Delete(keyShare`):

Direct `s.db.Update` sites (`shares.go`, invalidate immediately after `Update` returns nil):
1. `shares.go` CreateShare
2. `shares.go` UpdateShareOptions
3. `shares.go` DeleteShare
4. `shares.go` CreateRootDirectory (covers `createNewRoot`'s `Set(keyShare)`)

Transaction sites (`transaction.go` `*badgerTransaction` methods -> `dirtyShares` -> post-commit loop in `withTransaction`, mirroring `dirtyFiles`):
5. `transaction.go` CreateShare
6. `transaction.go` UpdateShareOptions
7. `transaction.go` DeleteShare
8. `transaction.go` CreateRootDirectory `Set(keyShare)`

`dirtyShares` is captured inside `db.Update` (reset per attempt like `pendingDelta`) so a conflict-retry cannot leak a phantom invalidation; invalidation runs only after commit succeeds. Generation guard: `invalidate` bumps `gen` before deleting, and `store` writes only if `gen` is unchanged since the snapshot taken before the backing read, so a racing populate can never re-insert a stale value.

## Verification

- `go build ./...`, `go vet ./pkg/metadata/...`: clean
- `gofmt -s -l` on changed files: empty
- `golangci-lint run ./pkg/metadata/...`: 0 issues
- `go test -race ./pkg/metadata/store/badger/...`: 525 passed (incl. store conformance)
- New tests: no-stale-permission-after-update (ReadOnly + slice), invalidate-on-delete, deep-copy safety (mutate + append), tx-path (`dirtyShares`) invalidation
- `BenchmarkGetShareOptions`: **cached 83 ns/op (2 allocs)** vs **uncached 6072 ns/op (26 allocs)** — ~73x