### PR TITLE
test(smb): sqlite + postgres metadata profiles for smbtorture conformance

### DIFF
--- a/.github/workflows/smb-conformance.yml
+++ b/.github/workflows/smb-conformance.yml
@@ -8,7 +8,8 @@
 #
 #   WPTS BVT     presubmit: memory + postgres-s3; postsubmit/nightly: all 5.
 #   smbtorture   presubmit: memory + badger-fs (run.sh has no *-s3 profile);
-#                postsubmit/nightly: memory + memory-fs + badger-fs.
+#                postsubmit/nightly: memory + memory-fs + badger-fs + sqlite
+#                + postgres (one job per metadata backend).
 #   Kerberos     OFF presubmit — push-to-develop + nightly cron + dispatch only.
 
 name: SMB Conformance Tests
@@ -49,6 +50,8 @@ on:
           - badger-fs
           - badger-s3
           - postgres-s3
+          - sqlite
+          - postgres
 
 concurrency:
   group: smb-conformance-${{ github.ref }}
@@ -137,8 +140,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # smbtorture run.sh supports only memory/memory-fs/badger-fs (no *-s3),
-        # so presubmit pairs memory + badger-fs (parallel ≈ one profile). A
+        # smbtorture run.sh supports memory/memory-fs/badger-fs plus the
+        # metadata-store profiles sqlite and postgres (no *-s3 — they pair the
+        # metadata engine with the memory block store). Presubmit stays fast
+        # (memory + badger-fs); postsubmit/nightly adds memory-fs, sqlite, and
+        # postgres so each metadata backend gets full conformance coverage. A
         # workflow_dispatch with an unsupported (*-s3) profile clamps to memory
         # rather than crashing run.sh.
         profile: >-
@@ -146,11 +152,11 @@ jobs:
             github.event_name == 'pull_request'
               && fromJson('["memory", "badger-fs"]')
             || github.event_name == 'workflow_dispatch'
-              && contains(fromJson('["memory", "memory-fs", "badger-fs"]'), inputs.profile)
+              && contains(fromJson('["memory", "memory-fs", "badger-fs", "sqlite", "postgres"]'), inputs.profile)
               && fromJson(format('["{0}"]', inputs.profile))
             || github.event_name == 'workflow_dispatch'
               && fromJson('["memory"]')
-            || fromJson('["memory", "memory-fs", "badger-fs"]')
+            || fromJson('["memory", "memory-fs", "badger-fs", "sqlite", "postgres"]')
           }}
 
     steps:

--- a/test/smb-conformance/bootstrap.sh
+++ b/test/smb-conformance/bootstrap.sh
@@ -98,6 +98,10 @@ create_metadata_store() {
             $DFSCTL store metadata add --name default --type badger \
                 --config '{"db_path":"/data/metadata"}'
             ;;
+        sqlite*)
+            $DFSCTL store metadata add --name default --type sqlite \
+                --config '{"path":"/data/metadata.db"}'
+            ;;
         postgres*)
             $DFSCTL store metadata add --name default --type postgres \
                 --config '{"host":"postgres","port":5432,"user":"dittofs","password":"dittofs","database":"dittofs_test","sslmode":"disable"}'
@@ -114,7 +118,10 @@ create_block_stores() {
     log_info "Creating block stores for profile: ${PROFILE}"
 
     case "$PROFILE" in
-        memory|memory-kerberos)
+        memory|memory-kerberos|sqlite|postgres)
+            # sqlite/postgres profiles exercise the metadata store only; they
+            # pair it with the memory block store (no S3) so smbtorture stays
+            # self-contained.
             $DFSCTL store block local add --name default --type memory
             ;;
         *-s3-legacy|*-fs)

--- a/test/smb-conformance/configs/postgres.yaml
+++ b/test/smb-conformance/configs/postgres.yaml
@@ -1,0 +1,35 @@
+# DittoFS Configuration for SMB Conformance Testing
+# Profile: postgres (PostgreSQL metadata store + memory block store)
+#
+# Bootstrap creates: PostgreSQL metadata store + memory local block store.
+# Requires the compose "postgres" service (activated via COMPOSE_PROFILES by
+# run.sh). The metadata backend is selected in bootstrap.sh
+# (create_metadata_store); this file only configures the control-plane DB,
+# API, and cache, which are identical across profiles.
+
+logging:
+  level: "DEBUG"
+  format: "text"
+  output: "stdout"
+
+shutdown_timeout: 30s
+
+# Control plane database
+database:
+  type: sqlite
+  sqlite:
+    path: "/data/controlplane.db"
+
+# Control plane API server
+controlplane:
+  host: "0.0.0.0"
+  port: 8080
+  jwt:
+    secret: "smb-conformance-test-secret-key-32ch"
+    access_token_duration: 15m
+    refresh_token_duration: 168h
+
+# Cache configuration
+cache:
+  path: "/data/cache"
+  size: "256MB"

--- a/test/smb-conformance/configs/sqlite.yaml
+++ b/test/smb-conformance/configs/sqlite.yaml
@@ -1,0 +1,34 @@
+# DittoFS Configuration for SMB Conformance Testing
+# Profile: sqlite (SQLite metadata store + memory block store)
+#
+# Bootstrap creates: SQLite metadata store + memory local block store.
+# The metadata backend is selected in bootstrap.sh (create_metadata_store);
+# this file only configures the control-plane DB, API, and cache, which are
+# identical across profiles.
+
+logging:
+  level: "DEBUG"
+  format: "text"
+  output: "stdout"
+
+shutdown_timeout: 30s
+
+# Control plane database
+database:
+  type: sqlite
+  sqlite:
+    path: "/data/controlplane.db"
+
+# Control plane API server
+controlplane:
+  host: "0.0.0.0"
+  port: 8080
+  jwt:
+    secret: "smb-conformance-test-secret-key-32ch"
+    access_token_duration: 15m
+    refresh_token_duration: 168h
+
+# Cache configuration
+cache:
+  path: "/data/cache"
+  size: "256MB"

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFORMANCE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-VALID_PROFILES=("memory" "memory-fs" "badger-fs" "memory-kerberos")
+VALID_PROFILES=("memory" "memory-fs" "badger-fs" "sqlite" "postgres" "memory-kerberos")
 
 # --------------------------------------------------------------------------
 # Colors
@@ -268,6 +268,18 @@ if $KERBEROS; then
     # klist parses the full keytab; only succeeds once kadmin has finished
     # writing and flushing the file, avoiding a partial-read race.
     wait_until "docker compose exec kdc klist -k /keytabs/dittofs.keytab > /dev/null 2>&1" 60 "KDC keytab"
+fi
+
+# Postgres profile: activate the "postgres" compose profile and start the
+# PostgreSQL service first, waiting until it is healthy — DittoFS's metadata
+# store connects to it during bootstrap. Same COMPOSE_PROFILES-via-env reason
+# as the Kerberos block above. (Kerberos and postgres profiles are disjoint.)
+if [[ "$PROFILE" == postgres* ]]; then
+    export COMPOSE_PROFILES="postgres"
+
+    log_step "Starting PostgreSQL..."
+    docker compose up -d postgres
+    wait_until "docker compose exec postgres pg_isready -U dittofs -d dittofs_test > /dev/null 2>&1" 60 "PostgreSQL"
 fi
 
 # Build and start DittoFS


### PR DESCRIPTION
## What
Extends the smbtorture conformance harness to cover the **sqlite** and **postgres** metadata backends, which previously had no smbtorture coverage (sqlite had none anywhere; postgres ran only under WPTS BVT).

- `bootstrap.sh` — sqlite case in `create_metadata_store`; sqlite/postgres pair the metadata engine with the memory block store.
- `configs/sqlite.yaml`, `configs/postgres.yaml`.
- `smbtorture/run.sh` — register `sqlite` + `postgres`; for `postgres*`, activate the `postgres` compose profile and wait for the DB healthy before DittoFS boots (mirrors the Kerberos activation).
- `smb-conformance.yml` — run sqlite + postgres in the smbtorture matrix on **postsubmit/nightly only**; presubmit stays memory + badger-fs (fast).

## Why
The metadata engines differ substantially — badger (SSI/optimistic-retry), sqlite (single-writer + WAL), postgres (MVCC + network round-trips) — and past backend-specific bugs (#1571/#1573 parent-inode SSI conflicts, sqlite deadlock #1552) sit exactly in the create/delete/rename paths smbtorture hammers. Testing only memory + badger left those two engines unguarded. Bonus: the slower metadata ops on postgres/sqlite widen the timing window of the #1658 rename flake, so these jobs may also help reproduce it.

## Validation
Ran locally against both new profiles — each bootstraps its metadata store and passes `smb2.connect` (CI green). Full suites run on the nightly matrix.

Follow-up: matching sqlite/postgres systems for the dfsbench perf harness (separate PR).