### PR TITLE
fix(metadata/sql): FILETIME timestamps + durable ClientGUID for sqlite/postgres conformance

### DIFF
--- a/pkg/metadata/store/postgres/durable_handles.go
+++ b/pkg/metadata/store/postgres/durable_handles.go
@@ -28,12 +28,13 @@ const durableHandleColumns = `
 	username, session_key_hash, is_v2, created_at, disconnected_at,
 	timeout_ms, server_start_time,
 	delete_pending, parent_handle, file_name, is_directory,
-	position_info, original_file_id, requested_alloc_size, is_persistent
+	position_info, original_file_id, requested_alloc_size, is_persistent,
+	client_guid
 `
 
 func scanDurableHandle(row pgx.Row) (*lock.PersistedDurableHandle, error) {
 	var h lock.PersistedDurableHandle
-	var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes []byte
+	var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes, clientGuidBytes []byte
 	var positionInfoSigned, requestedAllocSizeSigned int64
 	var leaseEpochSigned int32
 
@@ -69,6 +70,7 @@ func scanDurableHandle(row pgx.Row) (*lock.PersistedDurableHandle, error) {
 		&originalFileIDBytes,
 		&requestedAllocSizeSigned,
 		&h.IsPersistent,
+		&clientGuidBytes,
 	)
 
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -82,7 +84,7 @@ func scanDurableHandle(row pgx.Row) (*lock.PersistedDurableHandle, error) {
 	h.PositionInfo = uint64(positionInfoSigned)
 	h.RequestedAllocSize = uint64(requestedAllocSizeSigned)
 	copyFixedByteArrays(&h, fileIDBytes, leaseKeyBytes, createGuidBytes,
-		appInstanceIdBytes, sessionKeyHashBytes)
+		appInstanceIdBytes, sessionKeyHashBytes, clientGuidBytes)
 	if len(originalFileIDBytes) == 16 {
 		copy(h.OriginalFileID[:], originalFileIDBytes)
 	}
@@ -95,7 +97,7 @@ func scanDurableHandleRows(rows pgx.Rows) ([]*lock.PersistedDurableHandle, error
 	var result []*lock.PersistedDurableHandle
 	for rows.Next() {
 		var h lock.PersistedDurableHandle
-		var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes []byte
+		var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes, clientGuidBytes []byte
 		var positionInfoSigned, requestedAllocSizeSigned int64
 		var leaseEpochSigned int32
 
@@ -131,6 +133,7 @@ func scanDurableHandleRows(rows pgx.Rows) ([]*lock.PersistedDurableHandle, error
 			&originalFileIDBytes,
 			&requestedAllocSizeSigned,
 			&h.IsPersistent,
+			&clientGuidBytes,
 		)
 		if err != nil {
 			return nil, err
@@ -139,7 +142,7 @@ func scanDurableHandleRows(rows pgx.Rows) ([]*lock.PersistedDurableHandle, error
 		h.LeaseEpoch = uint16(leaseEpochSigned)
 		h.PositionInfo = uint64(positionInfoSigned)
 		h.RequestedAllocSize = uint64(requestedAllocSizeSigned)
-		copyFixedByteArrays(&h, fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes)
+		copyFixedByteArrays(&h, fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, clientGuidBytes)
 		if len(originalFileIDBytes) == 16 {
 			copy(h.OriginalFileID[:], originalFileIDBytes)
 		}
@@ -153,7 +156,7 @@ func scanDurableHandleRows(rows pgx.Rows) ([]*lock.PersistedDurableHandle, error
 	return result, nil
 }
 
-func copyFixedByteArrays(h *lock.PersistedDurableHandle, fileID, leaseKey, createGuid, appInstanceId, sessionKeyHash []byte) {
+func copyFixedByteArrays(h *lock.PersistedDurableHandle, fileID, leaseKey, createGuid, appInstanceId, sessionKeyHash, clientGuid []byte) {
 	if len(fileID) == 16 {
 		copy(h.FileID[:], fileID)
 	}
@@ -168,6 +171,9 @@ func copyFixedByteArrays(h *lock.PersistedDurableHandle, fileID, leaseKey, creat
 	}
 	if len(sessionKeyHash) == 32 {
 		copy(h.SessionKeyHash[:], sessionKeyHash)
+	}
+	if len(clientGuid) == 16 {
+		copy(h.ClientGUID[:], clientGuid)
 	}
 }
 
@@ -190,9 +196,9 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 			timeout_ms, server_start_time,
 			delete_pending, parent_handle, file_name, is_directory,
 			position_info, original_file_id, requested_alloc_size,
-			lease_epoch, is_persistent
+			lease_epoch, is_persistent, client_guid
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32)
 		ON CONFLICT (id) DO UPDATE SET
 			file_id = EXCLUDED.file_id,
 			path = EXCLUDED.path,
@@ -223,7 +229,8 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 			original_file_id = EXCLUDED.original_file_id,
 			requested_alloc_size = EXCLUDED.requested_alloc_size,
 			lease_epoch = EXCLUDED.lease_epoch,
-			is_persistent = EXCLUDED.is_persistent
+			is_persistent = EXCLUDED.is_persistent,
+			client_guid = EXCLUDED.client_guid
 	`
 
 	_, err := s.pool.Exec(ctx, query,
@@ -270,6 +277,12 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 		// IsPersistent marks a persistent durable handle granted on a CA share
 		// (#739) so a reconnect re-echoes the DH2Q PERSISTENT flag.
 		handle.IsPersistent,
+		// ClientGUID binds a lease-backed durable handle to the SMB2 client GUID
+		// that established it; a reconnect from a different GUID must fail
+		// OBJECT_NAME_NOT_FOUND (smbtorture durable-open.reopen1a-lease). Without
+		// persisting it the restored handle had a zero GUID and the mismatch gate
+		// was silently skipped.
+		nullableBytes16(handle.ClientGUID),
 	)
 	return err
 }

--- a/pkg/metadata/store/postgres/encoding.go
+++ b/pkg/metadata/store/postgres/encoding.go
@@ -28,30 +28,48 @@ func encodeFileHandle(shareName string, idStr string) (metadata.FileHandle, erro
 }
 
 // ============================================================================
-// Timestamp Encoding (BIGINT nanoseconds, lossless FILETIME parity)
+// Timestamp Encoding (BIGINT Windows FILETIME, 100ns ticks since 1601)
 // ============================================================================
 //
-// File timestamps are stored as BIGINT unix nanoseconds rather than TIMESTAMPTZ
-// (microsecond) so sub-microsecond FILETIME values round-trip losslessly, on
-// par with the memory/badger backends (#882). A zero time.Time maps to 0 and
-// back, matching the zero-value semantics those backends use.
+// File timestamps are stored as BIGINT Windows FILETIME — 100-nanosecond ticks
+// since 1601-01-01 UTC — rather than TIMESTAMPTZ (microsecond) or unix
+// nanoseconds. This is the native SMB/NTFS unit and, unlike unix nanoseconds,
+// it fits the full FILETIME range in an int64 (year 1601 to ~30828) so extreme
+// values round-trip losslessly (smbtorture smb2.timestamps.time_t_10000000000 /
+// _15032385535 set years 2286/2446, which overflow time.Time.UnixNano —
+// undefined past ~2262). FILETIME also makes the unix epoch (1970) a nonzero
+// value, so it no longer collides with the 0 sentinel for an unset/zero
+// time.Time (fixes smb2.timestamps.time_t_0). Verbatim port of the SQLite
+// store's encoding. The timeToPGNanos/pgNanosToTime names are historical (the
+// columns held unix nanoseconds before this change, migrated in place by the
+// ..._filetime_ts migration); the stored unit is now FILETIME.
 
-// timeToPGNanos converts a time.Time to the BIGINT unix-nanosecond value stored
+// filetimeEpochDelta is the number of 100ns ticks between the FILETIME epoch
+// (1601-01-01) and the unix epoch (1970-01-01). ticksPerSecond is 100ns ticks
+// per second.
+const (
+	filetimeEpochDelta = int64(116444736000000000)
+	ticksPerSecond     = int64(10000000)
+)
+
+// timeToPGNanos converts a time.Time to the BIGINT Windows FILETIME value stored
 // in the files timestamp columns. The zero time maps to 0.
 func timeToPGNanos(t time.Time) int64 {
 	if t.IsZero() {
 		return 0
 	}
-	return t.UnixNano()
+	return t.Unix()*ticksPerSecond + int64(t.Nanosecond())/100 + filetimeEpochDelta
 }
 
-// pgNanosToTime converts a stored BIGINT unix-nanosecond value back to a UTC
-// time.Time. 0 maps to the zero time.Time.
+// pgNanosToTime converts a stored BIGINT Windows FILETIME value back to a UTC
+// time.Time. 0 maps to the zero time.Time. time.Unix normalizes the negative
+// sub-second remainder for pre-1970 FILETIMEs.
 func pgNanosToTime(n int64) time.Time {
 	if n == 0 {
 		return time.Time{}
 	}
-	return time.Unix(0, n).UTC()
+	ticks := n - filetimeEpochDelta
+	return time.Unix(ticks/ticksPerSecond, (ticks%ticksPerSecond)*100).UTC()
 }
 
 // ============================================================================

--- a/pkg/metadata/store/postgres/encoding.go
+++ b/pkg/metadata/store/postgres/encoding.go
@@ -41,8 +41,8 @@ func encodeFileHandle(shareName string, idStr string) (metadata.FileHandle, erro
 // value, so it no longer collides with the 0 sentinel for an unset/zero
 // time.Time (fixes smb2.timestamps.time_t_0). Verbatim port of the SQLite
 // store's encoding. The timeToPGNanos/pgNanosToTime names are historical (the
-// columns held unix nanoseconds before this change, migrated in place by the
-// ..._filetime_ts migration); the stored unit is now FILETIME.
+// columns held unix nanoseconds before this change, migrated in place by
+// 000038_file_timestamps_filetime); the stored unit is now FILETIME.
 
 // filetimeEpochDelta is the number of 100ns ticks between the FILETIME epoch
 // (1601-01-01) and the unix epoch (1970-01-01). ticksPerSecond is 100ns ticks

--- a/pkg/metadata/store/postgres/encoding_test.go
+++ b/pkg/metadata/store/postgres/encoding_test.go
@@ -1,0 +1,45 @@
+package postgres
+
+import (
+	"testing"
+	"time"
+)
+
+// TestTimestampRoundTrip mirrors the SQLite store's test: it locks in
+// FILETIME-encoded timestamp fidelity across the full range and at the sentinel
+// boundary. The extreme cases are the exact values smbtorture
+// smb2.timestamps.time_t_* set — they regressed on the old unix-nanosecond
+// encoding (overflow past year ~2262; unix epoch colliding with the zero-time
+// sentinel). Keeping this in lockstep with the SQLite test guards against the
+// two verbatim-port codecs drifting apart.
+func TestTimestampRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		in   time.Time
+	}{
+		{"unix-epoch-1970 (time_t_0)", time.Unix(0, 0).UTC()},
+		{"year-2286 (time_t_10000000000)", time.Unix(10000000000, 0).UTC()},
+		{"year-2446 (time_t_15032385535)", time.Unix(15032385535, 0).UTC()},
+		{"100ns-aligned (storetest)", time.Unix(1700000001, 100).UTC()},
+		{"sub-second 100ns", time.Unix(1699999998, 999999900).UTC()},
+		{"pre-1970 negative ticks", time.Date(1801, 6, 15, 12, 30, 0, 500, time.UTC)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := pgNanosToTime(timeToPGNanos(c.in))
+			if !got.Equal(c.in) {
+				t.Fatalf("round-trip mismatch: in=%v got=%v", c.in, got)
+			}
+		})
+	}
+
+	if n := timeToPGNanos(time.Time{}); n != 0 {
+		t.Fatalf("zero time should encode to 0 sentinel, got %d", n)
+	}
+	if got := pgNanosToTime(0); !got.IsZero() {
+		t.Fatalf("0 sentinel should decode to zero time, got %v", got)
+	}
+	if timeToPGNanos(time.Unix(0, 0)) == 0 {
+		t.Fatal("unix epoch must not collide with the 0 zero-time sentinel")
+	}
+}

--- a/pkg/metadata/store/postgres/migrations/000037_durable_client_guid.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000037_durable_client_guid.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE durable_handles DROP COLUMN client_guid;

--- a/pkg/metadata/store/postgres/migrations/000037_durable_client_guid.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000037_durable_client_guid.up.sql
@@ -1,0 +1,6 @@
+-- Persist the SMB2 client GUID on durable handles so lease-backed durable
+-- reconnect can be rejected when it comes from a different client GUID
+-- (smbtorture durable-open.reopen1a-lease / durable-v2-open.reopen1a-lease).
+-- Older rows get NULL, which decodes to a zero ClientGUID — the same
+-- backward-compatible "cannot verify → allow" behaviour as before this column.
+ALTER TABLE durable_handles ADD COLUMN client_guid BYTEA;

--- a/pkg/metadata/store/postgres/migrations/000038_file_timestamps_filetime.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000038_file_timestamps_filetime.down.sql
@@ -1,0 +1,8 @@
+-- Revert files timestamps from Windows FILETIME back to unix-nanoseconds.
+-- Sub-100ns precision is not recoverable (the FILETIME unit is 100ns).
+UPDATE inodes SET
+    atime         = CASE WHEN atime         = 0 THEN 0 ELSE (atime         - 116444736000000000) * 100 END,
+    mtime         = CASE WHEN mtime         = 0 THEN 0 ELSE (mtime         - 116444736000000000) * 100 END,
+    ctime         = CASE WHEN ctime         = 0 THEN 0 ELSE (ctime         - 116444736000000000) * 100 END,
+    creation_time = CASE WHEN creation_time = 0 THEN 0 ELSE (creation_time - 116444736000000000) * 100 END,
+    deleted_at    = CASE WHEN deleted_at IS NULL OR deleted_at = 0 THEN deleted_at ELSE (deleted_at - 116444736000000000) * 100 END;

--- a/pkg/metadata/store/postgres/migrations/000038_file_timestamps_filetime.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000038_file_timestamps_filetime.up.sql
@@ -1,0 +1,11 @@
+-- Convert the files timestamp columns from unix-nanoseconds (established by
+-- 000023_file_timestamps_nanos) to Windows FILETIME (100ns ticks since 1601),
+-- matching the encoding.go switch (timeToPGNanos / pgNanosToTime). Zero stays
+-- zero (the unset/zero-time sentinel); a nonzero unix-nanosecond value n becomes
+-- n/100 + 116444736000000000. No-op on a fresh (empty) database.
+UPDATE inodes SET
+    atime         = CASE WHEN atime         = 0 THEN 0 ELSE atime / 100         + 116444736000000000 END,
+    mtime         = CASE WHEN mtime         = 0 THEN 0 ELSE mtime / 100         + 116444736000000000 END,
+    ctime         = CASE WHEN ctime         = 0 THEN 0 ELSE ctime / 100         + 116444736000000000 END,
+    creation_time = CASE WHEN creation_time = 0 THEN 0 ELSE creation_time / 100 + 116444736000000000 END,
+    deleted_at    = CASE WHEN deleted_at IS NULL OR deleted_at = 0 THEN deleted_at ELSE deleted_at / 100 + 116444736000000000 END;

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -361,12 +361,14 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 		objectIDArg = file.ObjectID[:]
 	}
 
-	// deleted_at is a BIGINT unix-nanoseconds column (#190), nullable: NULL marks
-	// a live node, a value records the recycle instant losslessly (like the other
-	// file timestamps). Pass *int64 so a nil DeletedAt writes SQL NULL.
+	// deleted_at is a BIGINT Windows-FILETIME column (#190), nullable: NULL marks
+	// a live node, a value records the recycle instant losslessly (same encoding
+	// as the other file timestamps — must use timeToPGNanos, not UnixNano, so it
+	// decodes back correctly via pgNanosToTime). Pass *int64 so a nil DeletedAt
+	// writes SQL NULL.
 	var deletedAtArg *int64
 	if file.DeletedAt != nil {
-		n := file.DeletedAt.UnixNano()
+		n := timeToPGNanos(*file.DeletedAt)
 		deletedAtArg = &n
 	}
 

--- a/pkg/metadata/store/sqlite/durable_handles.go
+++ b/pkg/metadata/store/sqlite/durable_handles.go
@@ -27,12 +27,13 @@ const durableHandleColumns = `
 	username, session_key_hash, is_v2, created_at, disconnected_at,
 	timeout_ms, server_start_time,
 	delete_pending, parent_handle, file_name, is_directory,
-	position_info, original_file_id, requested_alloc_size, is_persistent
+	position_info, original_file_id, requested_alloc_size, is_persistent,
+	client_guid
 `
 
 func scanDurableHandle(row scanRow) (*lock.PersistedDurableHandle, error) {
 	var h lock.PersistedDurableHandle
-	var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes []byte
+	var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes, clientGuidBytes []byte
 	var positionInfoSigned, requestedAllocSizeSigned int64
 	var leaseEpochSigned int32
 
@@ -68,6 +69,7 @@ func scanDurableHandle(row scanRow) (*lock.PersistedDurableHandle, error) {
 		&originalFileIDBytes,
 		&requestedAllocSizeSigned,
 		&h.IsPersistent,
+		&clientGuidBytes,
 	)
 
 	if errors.Is(err, sql.ErrNoRows) {
@@ -81,7 +83,7 @@ func scanDurableHandle(row scanRow) (*lock.PersistedDurableHandle, error) {
 	h.PositionInfo = uint64(positionInfoSigned)
 	h.RequestedAllocSize = uint64(requestedAllocSizeSigned)
 	copyFixedByteArrays(&h, fileIDBytes, leaseKeyBytes, createGuidBytes,
-		appInstanceIdBytes, sessionKeyHashBytes)
+		appInstanceIdBytes, sessionKeyHashBytes, clientGuidBytes)
 	if len(originalFileIDBytes) == 16 {
 		copy(h.OriginalFileID[:], originalFileIDBytes)
 	}
@@ -94,7 +96,7 @@ func scanDurableHandleRows(rows scanRows) ([]*lock.PersistedDurableHandle, error
 	var result []*lock.PersistedDurableHandle
 	for rows.Next() {
 		var h lock.PersistedDurableHandle
-		var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes []byte
+		var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes, clientGuidBytes []byte
 		var positionInfoSigned, requestedAllocSizeSigned int64
 		var leaseEpochSigned int32
 
@@ -130,6 +132,7 @@ func scanDurableHandleRows(rows scanRows) ([]*lock.PersistedDurableHandle, error
 			&originalFileIDBytes,
 			&requestedAllocSizeSigned,
 			&h.IsPersistent,
+			&clientGuidBytes,
 		)
 		if err != nil {
 			return nil, err
@@ -138,7 +141,7 @@ func scanDurableHandleRows(rows scanRows) ([]*lock.PersistedDurableHandle, error
 		h.LeaseEpoch = uint16(leaseEpochSigned)
 		h.PositionInfo = uint64(positionInfoSigned)
 		h.RequestedAllocSize = uint64(requestedAllocSizeSigned)
-		copyFixedByteArrays(&h, fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes)
+		copyFixedByteArrays(&h, fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, clientGuidBytes)
 		if len(originalFileIDBytes) == 16 {
 			copy(h.OriginalFileID[:], originalFileIDBytes)
 		}
@@ -152,7 +155,7 @@ func scanDurableHandleRows(rows scanRows) ([]*lock.PersistedDurableHandle, error
 	return result, nil
 }
 
-func copyFixedByteArrays(h *lock.PersistedDurableHandle, fileID, leaseKey, createGuid, appInstanceId, sessionKeyHash []byte) {
+func copyFixedByteArrays(h *lock.PersistedDurableHandle, fileID, leaseKey, createGuid, appInstanceId, sessionKeyHash, clientGuid []byte) {
 	if len(fileID) == 16 {
 		copy(h.FileID[:], fileID)
 	}
@@ -167,6 +170,9 @@ func copyFixedByteArrays(h *lock.PersistedDurableHandle, fileID, leaseKey, creat
 	}
 	if len(sessionKeyHash) == 32 {
 		copy(h.SessionKeyHash[:], sessionKeyHash)
+	}
+	if len(clientGuid) == 16 {
+		copy(h.ClientGUID[:], clientGuid)
 	}
 }
 
@@ -189,9 +195,9 @@ func (s *sqliteDurableStore) PutDurableHandle(ctx context.Context, handle *lock.
 			timeout_ms, server_start_time,
 			delete_pending, parent_handle, file_name, is_directory,
 			position_info, original_file_id, requested_alloc_size,
-			lease_epoch, is_persistent
+			lease_epoch, is_persistent, client_guid
 		)
-		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31)
+		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32)
 		ON CONFLICT (id) DO UPDATE SET
 			file_id = EXCLUDED.file_id,
 			path = EXCLUDED.path,
@@ -222,7 +228,8 @@ func (s *sqliteDurableStore) PutDurableHandle(ctx context.Context, handle *lock.
 			original_file_id = EXCLUDED.original_file_id,
 			requested_alloc_size = EXCLUDED.requested_alloc_size,
 			lease_epoch = EXCLUDED.lease_epoch,
-			is_persistent = EXCLUDED.is_persistent
+			is_persistent = EXCLUDED.is_persistent,
+			client_guid = EXCLUDED.client_guid
 	`
 
 	_, err := s.pool.Exec(ctx, query,
@@ -269,6 +276,12 @@ func (s *sqliteDurableStore) PutDurableHandle(ctx context.Context, handle *lock.
 		// IsPersistent marks a persistent durable handle granted on a CA share
 		// (#739) so a reconnect re-echoes the DH2Q PERSISTENT flag.
 		handle.IsPersistent,
+		// ClientGUID binds a lease-backed durable handle to the SMB2 client GUID
+		// that established it; a reconnect from a different GUID must fail
+		// OBJECT_NAME_NOT_FOUND (smbtorture durable-open.reopen1a-lease). Without
+		// persisting it the restored handle had a zero GUID and the mismatch gate
+		// was silently skipped.
+		nullableBytes16(handle.ClientGUID),
 	)
 	return err
 }

--- a/pkg/metadata/store/sqlite/encoding.go
+++ b/pkg/metadata/store/sqlite/encoding.go
@@ -45,8 +45,8 @@ func encodeFileHandle(shareName string, idStr string) (metadata.FileHandle, erro
 // 100ns-aligned) and matches memory/badger fidelity for FILETIME inputs.
 //
 // The timeToNanos/nanosToTime names are historical (the columns held unix
-// nanoseconds before this change, migrated in place by the ..._filetime_ts
-// migration); the stored unit is now FILETIME.
+// nanoseconds before this change, migrated in place by
+// 000005_file_timestamps_filetime); the stored unit is now FILETIME.
 
 // filetimeEpochDelta is the number of 100ns ticks between the FILETIME epoch
 // (1601-01-01) and the unix epoch (1970-01-01). ticksPerSecond is 100ns ticks

--- a/pkg/metadata/store/sqlite/encoding.go
+++ b/pkg/metadata/store/sqlite/encoding.go
@@ -27,30 +27,53 @@ func encodeFileHandle(shareName string, idStr string) (metadata.FileHandle, erro
 }
 
 // ============================================================================
-// Timestamp Encoding (INTEGER nanoseconds, lossless FILETIME parity)
+// Timestamp Encoding (INTEGER Windows FILETIME, 100ns ticks since 1601)
 // ============================================================================
 //
-// File timestamps are stored as INTEGER unix nanoseconds so sub-microsecond
-// FILETIME values round-trip losslessly, on par with the memory/badger
-// backends (#882). A zero time.Time maps to 0 and back, matching the
-// zero-value semantics those backends use.
+// File timestamps are stored as INTEGER Windows FILETIME — 100-nanosecond ticks
+// since 1601-01-01 UTC. This is the native SMB/NTFS timestamp unit and, unlike
+// unix nanoseconds, it fits the full FILETIME range in an int64 (year 1601 to
+// ~30828) so extreme values round-trip losslessly (smbtorture
+// smb2.timestamps.time_t_10000000000 / _15032385535 set timestamps in years
+// 2286/2446, which overflow time.Time.UnixNano — undefined past ~2262).
+//
+// FILETIME also makes the unix epoch (1970) a *nonzero* value
+// (116444736000000000), so it no longer collides with the 0 sentinel used for
+// an unset/zero time.Time (fixes smbtorture smb2.timestamps.time_t_0, which
+// previously read back the zero time instead of 1970). 100ns is exactly the
+// precision the metadata conformance suite requires (storetest values are all
+// 100ns-aligned) and matches memory/badger fidelity for FILETIME inputs.
+//
+// The timeToNanos/nanosToTime names are historical (the columns held unix
+// nanoseconds before this change, migrated in place by the ..._filetime_ts
+// migration); the stored unit is now FILETIME.
 
-// timeToNanos converts a time.Time to the INTEGER unix-nanosecond value stored
-// in the files timestamp columns. The zero time maps to 0.
+// filetimeEpochDelta is the number of 100ns ticks between the FILETIME epoch
+// (1601-01-01) and the unix epoch (1970-01-01). ticksPerSecond is 100ns ticks
+// per second.
+const (
+	filetimeEpochDelta = int64(116444736000000000)
+	ticksPerSecond     = int64(10000000)
+)
+
+// timeToNanos converts a time.Time to the INTEGER Windows FILETIME value stored
+// in the timestamp columns. The zero time maps to 0.
 func timeToNanos(t time.Time) int64 {
 	if t.IsZero() {
 		return 0
 	}
-	return t.UnixNano()
+	return t.Unix()*ticksPerSecond + int64(t.Nanosecond())/100 + filetimeEpochDelta
 }
 
-// nanosToTime converts a stored INTEGER unix-nanosecond value back to a UTC
-// time.Time. 0 maps to the zero time.Time.
+// nanosToTime converts a stored INTEGER Windows FILETIME value back to a UTC
+// time.Time. 0 maps to the zero time.Time. time.Unix normalizes the negative
+// sub-second remainder for pre-1970 FILETIMEs.
 func nanosToTime(n int64) time.Time {
 	if n == 0 {
 		return time.Time{}
 	}
-	return time.Unix(0, n).UTC()
+	ticks := n - filetimeEpochDelta
+	return time.Unix(ticks/ticksPerSecond, (ticks%ticksPerSecond)*100).UTC()
 }
 
 // ============================================================================

--- a/pkg/metadata/store/sqlite/encoding_test.go
+++ b/pkg/metadata/store/sqlite/encoding_test.go
@@ -1,0 +1,46 @@
+package sqlite
+
+import (
+	"testing"
+	"time"
+)
+
+// TestTimestampRoundTrip locks in FILETIME-encoded timestamp fidelity across the
+// full range and at the sentinel boundary. The extreme cases are the exact
+// values smbtorture smb2.timestamps.time_t_* set — they regressed on the old
+// unix-nanosecond encoding (overflow past year ~2262; unix epoch colliding with
+// the zero-time sentinel).
+func TestTimestampRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		in   time.Time
+	}{
+		{"unix-epoch-1970 (time_t_0)", time.Unix(0, 0).UTC()},
+		{"year-2286 (time_t_10000000000)", time.Unix(10000000000, 0).UTC()},
+		{"year-2446 (time_t_15032385535)", time.Unix(15032385535, 0).UTC()},
+		{"100ns-aligned (storetest)", time.Unix(1700000001, 100).UTC()},
+		{"sub-second 100ns", time.Unix(1699999998, 999999900).UTC()},
+		{"pre-1970 negative ticks", time.Date(1801, 6, 15, 12, 30, 0, 500, time.UTC)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := nanosToTime(timeToNanos(c.in))
+			if !got.Equal(c.in) {
+				t.Fatalf("round-trip mismatch: in=%v (unixnano-unsafe) got=%v", c.in, got)
+			}
+		})
+	}
+
+	// The zero time.Time must survive as the unset sentinel (stored as 0) and
+	// must NOT be confused with the unix epoch above.
+	if n := timeToNanos(time.Time{}); n != 0 {
+		t.Fatalf("zero time should encode to 0 sentinel, got %d", n)
+	}
+	if got := nanosToTime(0); !got.IsZero() {
+		t.Fatalf("0 sentinel should decode to zero time, got %v", got)
+	}
+	// Epoch must be distinct from the sentinel.
+	if timeToNanos(time.Unix(0, 0)) == 0 {
+		t.Fatal("unix epoch must not collide with the 0 zero-time sentinel")
+	}
+}

--- a/pkg/metadata/store/sqlite/migrations/000004_durable_client_guid.down.sql
+++ b/pkg/metadata/store/sqlite/migrations/000004_durable_client_guid.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE durable_handles DROP COLUMN client_guid;

--- a/pkg/metadata/store/sqlite/migrations/000004_durable_client_guid.up.sql
+++ b/pkg/metadata/store/sqlite/migrations/000004_durable_client_guid.up.sql
@@ -1,0 +1,6 @@
+-- Persist the SMB2 client GUID on durable handles so lease-backed durable
+-- reconnect can be rejected when it comes from a different client GUID
+-- (smbtorture durable-open.reopen1a-lease / durable-v2-open.reopen1a-lease).
+-- Older rows get NULL, which decodes to a zero ClientGUID — the same
+-- backward-compatible "cannot verify → allow" behaviour as before this column.
+ALTER TABLE durable_handles ADD COLUMN client_guid BLOB;

--- a/pkg/metadata/store/sqlite/migrations/000005_file_timestamps_filetime.down.sql
+++ b/pkg/metadata/store/sqlite/migrations/000005_file_timestamps_filetime.down.sql
@@ -1,0 +1,8 @@
+-- Revert files timestamps from Windows FILETIME back to unix-nanoseconds.
+-- Sub-100ns precision is not recoverable (the FILETIME unit is 100ns).
+UPDATE inodes SET
+    atime         = CASE WHEN atime         = 0 THEN 0 ELSE (atime         - 116444736000000000) * 100 END,
+    mtime         = CASE WHEN mtime         = 0 THEN 0 ELSE (mtime         - 116444736000000000) * 100 END,
+    ctime         = CASE WHEN ctime         = 0 THEN 0 ELSE (ctime         - 116444736000000000) * 100 END,
+    creation_time = CASE WHEN creation_time = 0 THEN 0 ELSE (creation_time - 116444736000000000) * 100 END,
+    deleted_at    = CASE WHEN deleted_at IS NULL OR deleted_at = 0 THEN deleted_at ELSE (deleted_at - 116444736000000000) * 100 END;

--- a/pkg/metadata/store/sqlite/migrations/000005_file_timestamps_filetime.up.sql
+++ b/pkg/metadata/store/sqlite/migrations/000005_file_timestamps_filetime.up.sql
@@ -1,0 +1,12 @@
+-- Convert the files timestamp columns from unix-nanoseconds to Windows FILETIME
+-- (100ns ticks since 1601), matching the encoding.go switch (timeToNanos /
+-- nanosToTime). Zero stays zero (the unset/zero-time sentinel); a nonzero
+-- unix-nanosecond value n becomes n/100 + 116444736000000000. On a fresh
+-- database these tables are empty so this is a no-op; on an existing database it
+-- rewrites the persisted values so they decode correctly under the new codec.
+UPDATE inodes SET
+    atime         = CASE WHEN atime         = 0 THEN 0 ELSE atime / 100         + 116444736000000000 END,
+    mtime         = CASE WHEN mtime         = 0 THEN 0 ELSE mtime / 100         + 116444736000000000 END,
+    ctime         = CASE WHEN ctime         = 0 THEN 0 ELSE ctime / 100         + 116444736000000000 END,
+    creation_time = CASE WHEN creation_time = 0 THEN 0 ELSE creation_time / 100 + 116444736000000000 END,
+    deleted_at    = CASE WHEN deleted_at IS NULL OR deleted_at = 0 THEN deleted_at ELSE deleted_at / 100 + 116444736000000000 END;

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -289,12 +289,14 @@ func (tx *sqliteTransaction) PutFile(ctx context.Context, file *metadata.File) e
 		objectIDArg = file.ObjectID[:]
 	}
 
-	// deleted_at is a BIGINT unix-nanoseconds column (#190), nullable: NULL marks
-	// a live node, a value records the recycle instant losslessly (like the other
-	// file timestamps). Pass *int64 so a nil DeletedAt writes SQL NULL.
+	// deleted_at is a BIGINT Windows-FILETIME column (#190), nullable: NULL marks
+	// a live node, a value records the recycle instant losslessly (same encoding
+	// as the other file timestamps — must use timeToNanos, not UnixNano, so it
+	// decodes back correctly via nanosToTime). Pass *int64 so a nil DeletedAt
+	// writes SQL NULL.
 	var deletedAtArg *int64
 	if file.DeletedAt != nil {
-		n := file.DeletedAt.UnixNano()
+		n := timeToNanos(*file.DeletedAt)
 		deletedAtArg = &n
 	}
 

--- a/pkg/metadata/storetest/trash_conformance.go
+++ b/pkg/metadata/storetest/trash_conformance.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
@@ -185,6 +186,12 @@ func testUnlinkRecyclesIntoBin(t *testing.T, factory StoreFactory) {
 	}
 	if moved.DeletedAt == nil {
 		t.Error("recycled file missing DeletedAt stamp")
+	} else if skew := time.Since(*moved.DeletedAt); skew < -time.Minute || skew > time.Hour {
+		// The stamp must round-trip to ~now. A write/read timestamp-encoding
+		// mismatch (e.g. writing unix-nanos but decoding Windows FILETIME)
+		// stamps a wildly wrong instant, silently breaking retention-based
+		// trash reaping (reaper compares DeletedAt against a cutoff).
+		t.Errorf("DeletedAt = %v, want within ~now (skew %v)", moved.DeletedAt, skew)
 	}
 	if moved.OriginalPath != "doc.txt" {
 		t.Errorf("OriginalPath = %q, want %q", moved.OriginalPath, "doc.txt")


### PR DESCRIPTION
Fixes the 5 smbtorture failures (× sqlite + postgres) that #1659 surfaced when it added those metadata backends to the conformance gate. Both are genuine pre-existing gaps in the SQL metadata stores (which memory/badger didn't have because they JSON-encode the full struct).

## 1. Timestamps → FILETIME (3 failures: `smb2.timestamps.time_t_{0,10000000000,15032385535}`)
The SQL stores encoded file timestamps as int64 **unix nanoseconds**, which:
- overflows `time.Time.UnixNano` past ~year 2262 (undefined) → `time_t_10000000000` (2286) / `time_t_15032385535` (2446) failed;
- conflated the unix epoch (1970 → 0) with the 0 zero-time sentinel → `time_t_0` read back as year 1.

Switched both stores to **Windows FILETIME** (100ns ticks since 1601) — the native SMB/NTFS unit — which fits the full range in int64 and makes the epoch a nonzero value. 100ns is exactly the precision the conformance suite requires (its values are all 100ns-aligned). Columns stay BIGINT; only the encoding + a data migration change. New `encoding_test` round-trips epoch / 2286 / 2446 / 100ns-aligned / pre-1970.

## 2. Durable ClientGUID (2 failures: `durable-open.reopen1a-lease`, `durable-v2-open.reopen1a-lease`)
A lease-backed durable handle is bound to the client GUID that established it — a reconnect from a **different** GUID must fail `OBJECT_NAME_NOT_FOUND` (oplock reconnect tolerates a GUID change, which is why `reopen1a` passed). The SMB layer's `leaseReconnectClientGUIDMismatch` gate is skipped when the persisted `ClientGUID` is zero, and the SQL durable stores **never persisted `client_guid`** → every restored handle had a zero GUID → the gate was silently skipped → reconnect wrongly succeeded. Added a `client_guid` column (BLOB/BYTEA) threaded through INSERT/scan + migrations.

## Validation
- `encoding_test` + sqlite conformance (durable round-trip) pass.
- Live smbtorture `smb2.timestamps` against **sqlite**: all 3 `time_t_*` now PASS (CI green).
- `smb2.durable-open` reproduced the failure pre-fix; full-suite sqlite re-run in progress.
- Postgres uses the identical (verbatim-port) code; its full-suite run validates on CI's nightly matrix.

Refs #1658, #1659.