### PR TITLE
fix(metadata): SQL backends corrupt extreme timestamps + drop durable ClientGUID (#1663)

### DIFF
--- a/pkg/metadata/store/postgres/durable_handles.go
+++ b/pkg/metadata/store/postgres/durable_handles.go
@@ -28,12 +28,13 @@ const durableHandleColumns = `
 	username, session_key_hash, is_v2, created_at, disconnected_at,
 	timeout_ms, server_start_time,
 	delete_pending, parent_handle, file_name, is_directory,
-	position_info, original_file_id, requested_alloc_size, is_persistent
+	position_info, original_file_id, requested_alloc_size, is_persistent,
+	client_guid
 `
 
 func scanDurableHandle(row pgx.Row) (*lock.PersistedDurableHandle, error) {
 	var h lock.PersistedDurableHandle
-	var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes []byte
+	var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes, clientGuidBytes []byte
 	var positionInfoSigned, requestedAllocSizeSigned int64
 	var leaseEpochSigned int32
 
@@ -69,6 +70,7 @@ func scanDurableHandle(row pgx.Row) (*lock.PersistedDurableHandle, error) {
 		&originalFileIDBytes,
 		&requestedAllocSizeSigned,
 		&h.IsPersistent,
+		&clientGuidBytes,
 	)
 
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -82,7 +84,7 @@ func scanDurableHandle(row pgx.Row) (*lock.PersistedDurableHandle, error) {
 	h.PositionInfo = uint64(positionInfoSigned)
 	h.RequestedAllocSize = uint64(requestedAllocSizeSigned)
 	copyFixedByteArrays(&h, fileIDBytes, leaseKeyBytes, createGuidBytes,
-		appInstanceIdBytes, sessionKeyHashBytes)
+		appInstanceIdBytes, sessionKeyHashBytes, clientGuidBytes)
 	if len(originalFileIDBytes) == 16 {
 		copy(h.OriginalFileID[:], originalFileIDBytes)
 	}
@@ -95,7 +97,7 @@ func scanDurableHandleRows(rows pgx.Rows) ([]*lock.PersistedDurableHandle, error
 	var result []*lock.PersistedDurableHandle
 	for rows.Next() {
 		var h lock.PersistedDurableHandle
-		var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes []byte
+		var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes, clientGuidBytes []byte
 		var positionInfoSigned, requestedAllocSizeSigned int64
 		var leaseEpochSigned int32
 
@@ -131,6 +133,7 @@ func scanDurableHandleRows(rows pgx.Rows) ([]*lock.PersistedDurableHandle, error
 			&originalFileIDBytes,
 			&requestedAllocSizeSigned,
 			&h.IsPersistent,
+			&clientGuidBytes,
 		)
 		if err != nil {
 			return nil, err
@@ -139,7 +142,7 @@ func scanDurableHandleRows(rows pgx.Rows) ([]*lock.PersistedDurableHandle, error
 		h.LeaseEpoch = uint16(leaseEpochSigned)
 		h.PositionInfo = uint64(positionInfoSigned)
 		h.RequestedAllocSize = uint64(requestedAllocSizeSigned)
-		copyFixedByteArrays(&h, fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes)
+		copyFixedByteArrays(&h, fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, clientGuidBytes)
 		if len(originalFileIDBytes) == 16 {
 			copy(h.OriginalFileID[:], originalFileIDBytes)
 		}
@@ -153,9 +156,12 @@ func scanDurableHandleRows(rows pgx.Rows) ([]*lock.PersistedDurableHandle, error
 	return result, nil
 }
 
-func copyFixedByteArrays(h *lock.PersistedDurableHandle, fileID, leaseKey, createGuid, appInstanceId, sessionKeyHash []byte) {
+func copyFixedByteArrays(h *lock.PersistedDurableHandle, fileID, leaseKey, createGuid, appInstanceId, sessionKeyHash, clientGuid []byte) {
 	if len(fileID) == 16 {
 		copy(h.FileID[:], fileID)
+	}
+	if len(clientGuid) == 16 {
+		copy(h.ClientGUID[:], clientGuid)
 	}
 	if len(leaseKey) == 16 {
 		copy(h.LeaseKey[:], leaseKey)
@@ -190,9 +196,9 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 			timeout_ms, server_start_time,
 			delete_pending, parent_handle, file_name, is_directory,
 			position_info, original_file_id, requested_alloc_size,
-			lease_epoch, is_persistent
+			lease_epoch, is_persistent, client_guid
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32)
 		ON CONFLICT (id) DO UPDATE SET
 			file_id = EXCLUDED.file_id,
 			path = EXCLUDED.path,
@@ -223,7 +229,8 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 			original_file_id = EXCLUDED.original_file_id,
 			requested_alloc_size = EXCLUDED.requested_alloc_size,
 			lease_epoch = EXCLUDED.lease_epoch,
-			is_persistent = EXCLUDED.is_persistent
+			is_persistent = EXCLUDED.is_persistent,
+			client_guid = EXCLUDED.client_guid
 	`
 
 	_, err := s.pool.Exec(ctx, query,
@@ -270,6 +277,11 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 		// IsPersistent marks a persistent durable handle granted on a CA share
 		// (#739) so a reconnect re-echoes the DH2Q PERSISTENT flag.
 		handle.IsPersistent,
+		// ClientGUID is the 16-byte SMB2 client GUID from NEGOTIATE. It gates
+		// lease-backed durable reconnect (a different client GUID must be
+		// rejected); a missing column left it zero, wrongly allowing the
+		// reconnect (#1663).
+		nullableBytes16(handle.ClientGUID),
 	)
 	return err
 }

--- a/pkg/metadata/store/postgres/encoding.go
+++ b/pkg/metadata/store/postgres/encoding.go
@@ -28,30 +28,46 @@ func encodeFileHandle(shareName string, idStr string) (metadata.FileHandle, erro
 }
 
 // ============================================================================
-// Timestamp Encoding (BIGINT nanoseconds, lossless FILETIME parity)
+// Timestamp Encoding (BIGINT Windows FILETIME: 100ns ticks since 1601)
 // ============================================================================
 //
-// File timestamps are stored as BIGINT unix nanoseconds rather than TIMESTAMPTZ
-// (microsecond) so sub-microsecond FILETIME values round-trip losslessly, on
-// par with the memory/badger backends (#882). A zero time.Time maps to 0 and
-// back, matching the zero-value semantics those backends use.
+// File timestamps are stored as Windows FILETIME — signed 100-nanosecond ticks
+// since 1601-01-01 UTC — in BIGINT columns rather than TIMESTAMPTZ (microsecond)
+// or unix nanoseconds. This spans years 1601–~30828, versus the int64
+// unix-nanosecond window's ~1678–2262, so extreme-but-valid SMB timestamps
+// round-trip losslessly on par with the memory/badger backends. The unix epoch
+// (1970) becomes a distinct non-zero value rather than colliding with the
+// zero-time sentinel — an int64-nanosecond encoding conflates the two and
+// overflows past 2262 (#1663, was #882).
+//
+// ponytail: 100ns is exactly SMB FILETIME granularity and matches every value
+// the storetest conformance suite asserts; only sub-100ns fractional
+// nanoseconds truncate. Switch to a (sec, nsec) column pair only if 1ns
+// NFS-side round-trip parity is ever actually required.
 
-// timeToPGNanos converts a time.Time to the BIGINT unix-nanosecond value stored
-// in the files timestamp columns. The zero time maps to 0.
-func timeToPGNanos(t time.Time) int64 {
+// filetimeEpochOffset is the number of 100ns ticks between the FILETIME epoch
+// (1601-01-01) and the unix epoch (1970-01-01).
+const filetimeEpochOffset = 116444736000000000
+
+// timeToPGFiletime converts a time.Time to the BIGINT FILETIME value stored in
+// the inode timestamp columns. The zero time maps to 0 (the "unset" sentinel;
+// FILETIME 0 is 1601-01-01, which no real filesystem timestamp uses).
+func timeToPGFiletime(t time.Time) int64 {
 	if t.IsZero() {
 		return 0
 	}
-	return t.UnixNano()
+	return t.Unix()*10_000_000 + int64(t.Nanosecond())/100 + filetimeEpochOffset
 }
 
-// pgNanosToTime converts a stored BIGINT unix-nanosecond value back to a UTC
-// time.Time. 0 maps to the zero time.Time.
-func pgNanosToTime(n int64) time.Time {
-	if n == 0 {
+// pgFiletimeToTime converts a stored BIGINT FILETIME value back to a UTC
+// time.Time. 0 maps to the zero time.Time. time.Unix normalizes the (possibly
+// negative) second/nanosecond split for pre-1970 values.
+func pgFiletimeToTime(ft int64) time.Time {
+	if ft == 0 {
 		return time.Time{}
 	}
-	return time.Unix(0, n).UTC()
+	ticks := ft - filetimeEpochOffset
+	return time.Unix(ticks/10_000_000, (ticks%10_000_000)*100).UTC()
 }
 
 // ============================================================================
@@ -152,10 +168,10 @@ func fileRowToFileWithNlinkAndBlocks(row pgx.Row, withBlocks bool) (*metadata.Fi
 			GID:          uint32(gid),
 			Nlink:        uint32(nlink),
 			Size:         uint64(size),
-			Atime:        pgNanosToTime(atime),
-			Mtime:        pgNanosToTime(mtime),
-			Ctime:        pgNanosToTime(ctime),
-			CreationTime: pgNanosToTime(creationTime),
+			Atime:        pgFiletimeToTime(atime),
+			Mtime:        pgFiletimeToTime(mtime),
+			Ctime:        pgFiletimeToTime(ctime),
+			CreationTime: pgFiletimeToTime(creationTime),
 			Hidden:       hidden,
 		},
 	}
@@ -203,12 +219,12 @@ func fileRowToFileWithNlinkAndBlocks(row pgx.Row, withBlocks bool) (*metadata.Fi
 		copy(file.ObjectID[:], objectIDRaw)
 	}
 
-	// Recycle-bin metadata (#190). deleted_at is BIGINT unix-nanoseconds (like
+	// Recycle-bin metadata (#190). deleted_at is BIGINT Windows FILETIME (like
 	// the other file timestamps): NULL -> live node (nil pointer); a valid value
-	// decodes via pgNanosToTime for lossless nanosecond round-trip.
+	// decodes via pgFiletimeToTime for lossless nanosecond round-trip.
 	// original_path / deleted_by default to '' for live nodes.
 	if deletedAt.Valid {
-		t := pgNanosToTime(deletedAt.Int64)
+		t := pgFiletimeToTime(deletedAt.Int64)
 		file.DeletedAt = &t
 	}
 	file.OriginalPath = originalPath

--- a/pkg/metadata/store/postgres/files.go
+++ b/pkg/metadata/store/postgres/files.go
@@ -304,10 +304,10 @@ func (s *PostgresMetadataStore) ListChildren(ctx context.Context, dirHandle meta
 			UID:          uint32(uid),
 			GID:          uint32(gid),
 			Size:         uint64(size),
-			Atime:        pgNanosToTime(atime),
-			Mtime:        pgNanosToTime(mtime),
-			Ctime:        pgNanosToTime(ctime),
-			CreationTime: pgNanosToTime(creationTime),
+			Atime:        pgFiletimeToTime(atime),
+			Mtime:        pgFiletimeToTime(mtime),
+			Ctime:        pgFiletimeToTime(ctime),
+			CreationTime: pgFiletimeToTime(creationTime),
 			Hidden:       hidden,
 		}
 		if len(objectIDRaw) > 0 {
@@ -322,9 +322,9 @@ func (s *PostgresMetadataStore) ListChildren(ctx context.Context, dirHandle meta
 
 		// Recycle-bin metadata (#190): carried on DirEntry.Attr so trash
 		// enumeration via listing reflects recycle state without a re-read.
-		// deleted_at is BIGINT unix-nanoseconds; decode via pgNanosToTime.
+		// deleted_at is BIGINT Windows FILETIME; decode via pgFiletimeToTime.
 		if deletedAt.Valid {
-			t := pgNanosToTime(deletedAt.Int64)
+			t := pgFiletimeToTime(deletedAt.Int64)
 			attr.DeletedAt = &t
 		}
 		attr.OriginalPath = originalPath

--- a/pkg/metadata/store/postgres/migrations/000037_file_timestamps_filetime.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000037_file_timestamps_filetime.down.sql
@@ -1,0 +1,10 @@
+-- Revert inode file timestamps from Windows FILETIME back to unix-nanoseconds.
+-- Lossy only for pre-1678 / post-2262 values the nanosecond encoding cannot
+-- represent (those were unreachable before #1663).
+UPDATE inodes SET
+    atime         = CASE WHEN atime = 0 THEN 0 ELSE (atime - 116444736000000000) * 100 END,
+    mtime         = CASE WHEN mtime = 0 THEN 0 ELSE (mtime - 116444736000000000) * 100 END,
+    ctime         = CASE WHEN ctime = 0 THEN 0 ELSE (ctime - 116444736000000000) * 100 END,
+    creation_time = CASE WHEN creation_time = 0 THEN 0 ELSE (creation_time - 116444736000000000) * 100 END,
+    deleted_at    = CASE WHEN deleted_at IS NULL OR deleted_at = 0 THEN deleted_at
+                         ELSE (deleted_at - 116444736000000000) * 100 END;

--- a/pkg/metadata/store/postgres/migrations/000037_file_timestamps_filetime.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000037_file_timestamps_filetime.up.sql
@@ -1,0 +1,18 @@
+-- Re-encode inode file timestamps from unix-nanoseconds to Windows FILETIME
+-- (signed 100ns ticks since 1601-01-01). BIGINT unix-nanoseconds overflows past
+-- year 2262 and conflates the unix epoch (0 ns) with the zero-time sentinel;
+-- FILETIME spans years 1601–~30828 and keeps epoch distinct, so extreme SMB
+-- timestamps round-trip on par with the memory/badger backends (#1663). This
+-- supersedes the "no SMB-reachable value overflows" range caveat in 000023 —
+-- smbtorture smb2.timestamps.time_t_{10000000000,15032385535} reach the store.
+--
+-- 116444736000000000 = 100ns ticks between 1601-01-01 and 1970-01-01. A stored
+-- 0 stays 0 (the "unset"/zero-time sentinel the Go layer maps to time.Time{}).
+-- Integer division truncates the sub-100ns remainder, matching timeToPGFiletime.
+UPDATE inodes SET
+    atime         = CASE WHEN atime = 0 THEN 0 ELSE atime / 100 + 116444736000000000 END,
+    mtime         = CASE WHEN mtime = 0 THEN 0 ELSE mtime / 100 + 116444736000000000 END,
+    ctime         = CASE WHEN ctime = 0 THEN 0 ELSE ctime / 100 + 116444736000000000 END,
+    creation_time = CASE WHEN creation_time = 0 THEN 0 ELSE creation_time / 100 + 116444736000000000 END,
+    deleted_at    = CASE WHEN deleted_at IS NULL OR deleted_at = 0 THEN deleted_at
+                         ELSE deleted_at / 100 + 116444736000000000 END;

--- a/pkg/metadata/store/postgres/migrations/000038_durable_handle_client_guid.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000038_durable_handle_client_guid.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE durable_handles DROP COLUMN client_guid;

--- a/pkg/metadata/store/postgres/migrations/000038_durable_handle_client_guid.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000038_durable_handle_client_guid.up.sql
@@ -1,0 +1,10 @@
+-- Persist the SMB2 client GUID on durable handles so lease-backed durable
+-- reconnect can reject a reconnect from a different client GUID (#1663).
+--
+-- ClientGUID (#432) was added to the in-memory handle but never given a column
+-- here, so scanDurableHandle always returned a zero ClientGUID. That
+-- short-circuits leaseReconnectClientGUIDMismatch, wrongly returning
+-- NT_STATUS_OK instead of NT_STATUS_OBJECT_NAME_NOT_FOUND for
+-- smb2.durable-open.reopen1a-lease / durable-v2-open.reopen1a-lease. NULL for
+-- pre-existing rows decodes to a zero ClientGUID, matching the prior behavior.
+ALTER TABLE durable_handles ADD COLUMN client_guid BYTEA;

--- a/pkg/metadata/store/postgres/shares.go
+++ b/pkg/metadata/store/postgres/shares.go
@@ -276,7 +276,7 @@ func (s *PostgresMetadataStore) CreateRootDirectory(
 				int32(existingRoot.Mode),
 				int32(existingRoot.UID),
 				int32(existingRoot.GID),
-				timeToPGNanos(now),
+				timeToPGFiletime(now),
 				existingRoot.ID,
 			)
 			if err != nil {
@@ -332,10 +332,10 @@ func (s *PostgresMetadataStore) CreateRootDirectory(
 		int32(uid),                        // uid
 		int32(gid),                        // gid
 		int64(0),                          // size
-		timeToPGNanos(now),                // atime
-		timeToPGNanos(now),                // mtime
-		timeToPGNanos(now),                // ctime
-		timeToPGNanos(now),                // creation_time
+		timeToPGFiletime(now),             // atime
+		timeToPGFiletime(now),             // mtime
+		timeToPGFiletime(now),             // ctime
+		timeToPGFiletime(now),             // creation_time
 		nil,                               // content_id (NULL for directories)
 		nil,                               // link_target (NULL)
 		nil,                               // device_major (NULL)
@@ -450,10 +450,10 @@ func (s *PostgresMetadataStore) getExistingRootDirectory(ctx context.Context, sh
 			UID:          uint32(uid),
 			GID:          uint32(gid),
 			Size:         uint64(size),
-			Atime:        pgNanosToTime(atime),
-			Mtime:        pgNanosToTime(mtime),
-			Ctime:        pgNanosToTime(ctime),
-			CreationTime: pgNanosToTime(creationTime),
+			Atime:        pgFiletimeToTime(atime),
+			Mtime:        pgFiletimeToTime(mtime),
+			Ctime:        pgFiletimeToTime(ctime),
+			CreationTime: pgFiletimeToTime(creationTime),
 			Hidden:       hidden,
 		},
 	}, nil

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -361,12 +361,12 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 		objectIDArg = file.ObjectID[:]
 	}
 
-	// deleted_at is a BIGINT unix-nanoseconds column (#190), nullable: NULL marks
+	// deleted_at is a BIGINT Windows FILETIME column (#190), nullable: NULL marks
 	// a live node, a value records the recycle instant losslessly (like the other
 	// file timestamps). Pass *int64 so a nil DeletedAt writes SQL NULL.
 	var deletedAtArg *int64
 	if file.DeletedAt != nil {
-		n := file.DeletedAt.UnixNano()
+		n := timeToPGFiletime(*file.DeletedAt)
 		deletedAtArg = &n
 	}
 
@@ -380,8 +380,8 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 	updated := true
 	scanErr := tx.tx.QueryRow(ctx, updateQuery,
 		file.Type, file.Mode, file.UID, file.GID, file.Size,
-		timeToPGNanos(file.Atime), timeToPGNanos(file.Mtime),
-		timeToPGNanos(file.Ctime), timeToPGNanos(file.CreationTime),
+		timeToPGFiletime(file.Atime), timeToPGFiletime(file.Mtime),
+		timeToPGFiletime(file.Ctime), timeToPGFiletime(file.CreationTime),
 		payloadIDPtr, linkTargetPtr, deviceMajor, deviceMinor,
 		file.Hidden, aclJSON, easJSON, objectIDArg,
 		deletedAtArg, file.OriginalPath, file.DeletedBy,
@@ -440,8 +440,8 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 		if _, err := tx.tx.Exec(ctx, insertQuery,
 			file.ID, file.ShareName,
 			file.Type, file.Mode, file.UID, file.GID, file.Size,
-			timeToPGNanos(file.Atime), timeToPGNanos(file.Mtime),
-			timeToPGNanos(file.Ctime), timeToPGNanos(file.CreationTime),
+			timeToPGFiletime(file.Atime), timeToPGFiletime(file.Mtime),
+			timeToPGFiletime(file.Ctime), timeToPGFiletime(file.CreationTime),
 			payloadIDPtr, linkTargetPtr, deviceMajor, deviceMinor,
 			file.Hidden, aclJSON, easJSON, objectIDArg,
 			deletedAtArg, file.OriginalPath, file.DeletedBy,
@@ -712,10 +712,10 @@ func (tx *postgresTransaction) ListChildren(ctx context.Context, dirHandle metad
 			UID:          uint32(uid),
 			GID:          uint32(gid),
 			Size:         uint64(size),
-			Atime:        pgNanosToTime(atime),
-			Mtime:        pgNanosToTime(mtime),
-			Ctime:        pgNanosToTime(ctime),
-			CreationTime: pgNanosToTime(creationTime),
+			Atime:        pgFiletimeToTime(atime),
+			Mtime:        pgFiletimeToTime(mtime),
+			Ctime:        pgFiletimeToTime(ctime),
+			CreationTime: pgFiletimeToTime(creationTime),
 			Hidden:       hidden,
 		}
 		if len(objectIDRaw) > 0 {
@@ -730,10 +730,10 @@ func (tx *postgresTransaction) ListChildren(ctx context.Context, dirHandle metad
 
 		// Recycle-bin metadata (#190): carried on DirEntry.Attr so trash
 		// enumeration via listing reflects recycle state without a re-read,
-		// matching the pool-query path. deleted_at is BIGINT unix-nanoseconds;
-		// decode via pgNanosToTime.
+		// matching the pool-query path. deleted_at is BIGINT Windows FILETIME;
+		// decode via pgFiletimeToTime.
 		if deletedAt.Valid {
-			t := pgNanosToTime(deletedAt.Int64)
+			t := pgFiletimeToTime(deletedAt.Int64)
 			attr.DeletedAt = &t
 		}
 		attr.OriginalPath = originalPath
@@ -1186,10 +1186,10 @@ func (tx *postgresTransaction) CreateRootDirectory(ctx context.Context, shareNam
 				UID:          uint32(existingUID),
 				GID:          uint32(existingGID),
 				Size:         uint64(size),
-				Atime:        pgNanosToTime(atime),
-				Mtime:        pgNanosToTime(mtime),
-				Ctime:        pgNanosToTime(ctime),
-				CreationTime: pgNanosToTime(creationTime),
+				Atime:        pgFiletimeToTime(atime),
+				Mtime:        pgFiletimeToTime(mtime),
+				Ctime:        pgFiletimeToTime(ctime),
+				CreationTime: pgFiletimeToTime(creationTime),
 				Hidden:       hidden,
 			},
 		}, nil
@@ -1226,10 +1226,10 @@ func (tx *postgresTransaction) CreateRootDirectory(ctx context.Context, shareNam
 		int32(uid),                        // uid
 		int32(gid),                        // gid
 		int64(0),                          // size
-		timeToPGNanos(now),                // atime
-		timeToPGNanos(now),                // mtime
-		timeToPGNanos(now),                // ctime
-		timeToPGNanos(now),                // creation_time
+		timeToPGFiletime(now),             // atime
+		timeToPGFiletime(now),             // mtime
+		timeToPGFiletime(now),             // ctime
+		timeToPGFiletime(now),             // creation_time
 		nil,                               // content_id (NULL for directories)
 		nil,                               // link_target (NULL)
 		nil,                               // device_major (NULL)

--- a/pkg/metadata/store/sqlite/durable_handles.go
+++ b/pkg/metadata/store/sqlite/durable_handles.go
@@ -27,12 +27,13 @@ const durableHandleColumns = `
 	username, session_key_hash, is_v2, created_at, disconnected_at,
 	timeout_ms, server_start_time,
 	delete_pending, parent_handle, file_name, is_directory,
-	position_info, original_file_id, requested_alloc_size, is_persistent
+	position_info, original_file_id, requested_alloc_size, is_persistent,
+	client_guid
 `
 
 func scanDurableHandle(row scanRow) (*lock.PersistedDurableHandle, error) {
 	var h lock.PersistedDurableHandle
-	var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes []byte
+	var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes, clientGuidBytes []byte
 	var positionInfoSigned, requestedAllocSizeSigned int64
 	var leaseEpochSigned int32
 
@@ -68,6 +69,7 @@ func scanDurableHandle(row scanRow) (*lock.PersistedDurableHandle, error) {
 		&originalFileIDBytes,
 		&requestedAllocSizeSigned,
 		&h.IsPersistent,
+		&clientGuidBytes,
 	)
 
 	if errors.Is(err, sql.ErrNoRows) {
@@ -81,7 +83,7 @@ func scanDurableHandle(row scanRow) (*lock.PersistedDurableHandle, error) {
 	h.PositionInfo = uint64(positionInfoSigned)
 	h.RequestedAllocSize = uint64(requestedAllocSizeSigned)
 	copyFixedByteArrays(&h, fileIDBytes, leaseKeyBytes, createGuidBytes,
-		appInstanceIdBytes, sessionKeyHashBytes)
+		appInstanceIdBytes, sessionKeyHashBytes, clientGuidBytes)
 	if len(originalFileIDBytes) == 16 {
 		copy(h.OriginalFileID[:], originalFileIDBytes)
 	}
@@ -94,7 +96,7 @@ func scanDurableHandleRows(rows scanRows) ([]*lock.PersistedDurableHandle, error
 	var result []*lock.PersistedDurableHandle
 	for rows.Next() {
 		var h lock.PersistedDurableHandle
-		var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes []byte
+		var fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, originalFileIDBytes, clientGuidBytes []byte
 		var positionInfoSigned, requestedAllocSizeSigned int64
 		var leaseEpochSigned int32
 
@@ -130,6 +132,7 @@ func scanDurableHandleRows(rows scanRows) ([]*lock.PersistedDurableHandle, error
 			&originalFileIDBytes,
 			&requestedAllocSizeSigned,
 			&h.IsPersistent,
+			&clientGuidBytes,
 		)
 		if err != nil {
 			return nil, err
@@ -138,7 +141,7 @@ func scanDurableHandleRows(rows scanRows) ([]*lock.PersistedDurableHandle, error
 		h.LeaseEpoch = uint16(leaseEpochSigned)
 		h.PositionInfo = uint64(positionInfoSigned)
 		h.RequestedAllocSize = uint64(requestedAllocSizeSigned)
-		copyFixedByteArrays(&h, fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes)
+		copyFixedByteArrays(&h, fileIDBytes, leaseKeyBytes, createGuidBytes, appInstanceIdBytes, sessionKeyHashBytes, clientGuidBytes)
 		if len(originalFileIDBytes) == 16 {
 			copy(h.OriginalFileID[:], originalFileIDBytes)
 		}
@@ -152,9 +155,12 @@ func scanDurableHandleRows(rows scanRows) ([]*lock.PersistedDurableHandle, error
 	return result, nil
 }
 
-func copyFixedByteArrays(h *lock.PersistedDurableHandle, fileID, leaseKey, createGuid, appInstanceId, sessionKeyHash []byte) {
+func copyFixedByteArrays(h *lock.PersistedDurableHandle, fileID, leaseKey, createGuid, appInstanceId, sessionKeyHash, clientGuid []byte) {
 	if len(fileID) == 16 {
 		copy(h.FileID[:], fileID)
+	}
+	if len(clientGuid) == 16 {
+		copy(h.ClientGUID[:], clientGuid)
 	}
 	if len(leaseKey) == 16 {
 		copy(h.LeaseKey[:], leaseKey)
@@ -189,9 +195,9 @@ func (s *sqliteDurableStore) PutDurableHandle(ctx context.Context, handle *lock.
 			timeout_ms, server_start_time,
 			delete_pending, parent_handle, file_name, is_directory,
 			position_info, original_file_id, requested_alloc_size,
-			lease_epoch, is_persistent
+			lease_epoch, is_persistent, client_guid
 		)
-		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31)
+		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32)
 		ON CONFLICT (id) DO UPDATE SET
 			file_id = EXCLUDED.file_id,
 			path = EXCLUDED.path,
@@ -222,7 +228,8 @@ func (s *sqliteDurableStore) PutDurableHandle(ctx context.Context, handle *lock.
 			original_file_id = EXCLUDED.original_file_id,
 			requested_alloc_size = EXCLUDED.requested_alloc_size,
 			lease_epoch = EXCLUDED.lease_epoch,
-			is_persistent = EXCLUDED.is_persistent
+			is_persistent = EXCLUDED.is_persistent,
+			client_guid = EXCLUDED.client_guid
 	`
 
 	_, err := s.pool.Exec(ctx, query,
@@ -269,6 +276,11 @@ func (s *sqliteDurableStore) PutDurableHandle(ctx context.Context, handle *lock.
 		// IsPersistent marks a persistent durable handle granted on a CA share
 		// (#739) so a reconnect re-echoes the DH2Q PERSISTENT flag.
 		handle.IsPersistent,
+		// ClientGUID is the 16-byte SMB2 client GUID from NEGOTIATE. It gates
+		// lease-backed durable reconnect (a different client GUID must be
+		// rejected); a missing column left it zero, wrongly allowing the
+		// reconnect (#1663).
+		nullableBytes16(handle.ClientGUID),
 	)
 	return err
 }

--- a/pkg/metadata/store/sqlite/encoding.go
+++ b/pkg/metadata/store/sqlite/encoding.go
@@ -27,30 +27,45 @@ func encodeFileHandle(shareName string, idStr string) (metadata.FileHandle, erro
 }
 
 // ============================================================================
-// Timestamp Encoding (INTEGER nanoseconds, lossless FILETIME parity)
+// Timestamp Encoding (INTEGER Windows FILETIME: 100ns ticks since 1601)
 // ============================================================================
 //
-// File timestamps are stored as INTEGER unix nanoseconds so sub-microsecond
-// FILETIME values round-trip losslessly, on par with the memory/badger
-// backends (#882). A zero time.Time maps to 0 and back, matching the
-// zero-value semantics those backends use.
+// File timestamps are stored as Windows FILETIME — signed 100-nanosecond ticks
+// since 1601-01-01 UTC — in the existing INTEGER columns. This spans years
+// 1601–~30828, versus the int64 unix-nanosecond window's ~1678–2262, so
+// extreme-but-valid SMB timestamps round-trip losslessly on par with the
+// memory/badger backends. The unix epoch (1970) becomes a distinct non-zero
+// value rather than colliding with the zero-time sentinel — an int64-nanosecond
+// encoding conflates the two and overflows past 2262 (#1663, was #882).
+//
+// ponytail: 100ns is exactly SMB FILETIME granularity and matches every value
+// the storetest conformance suite asserts; only sub-100ns fractional
+// nanoseconds truncate. Switch to a (sec, nsec) column pair only if 1ns
+// NFS-side round-trip parity is ever actually required.
 
-// timeToNanos converts a time.Time to the INTEGER unix-nanosecond value stored
-// in the files timestamp columns. The zero time maps to 0.
-func timeToNanos(t time.Time) int64 {
+// filetimeEpochOffset is the number of 100ns ticks between the FILETIME epoch
+// (1601-01-01) and the unix epoch (1970-01-01).
+const filetimeEpochOffset = 116444736000000000
+
+// timeToFiletime converts a time.Time to the INTEGER FILETIME value stored in
+// the inode timestamp columns. The zero time maps to 0 (the "unset" sentinel;
+// FILETIME 0 is 1601-01-01, which no real filesystem timestamp uses).
+func timeToFiletime(t time.Time) int64 {
 	if t.IsZero() {
 		return 0
 	}
-	return t.UnixNano()
+	return t.Unix()*10_000_000 + int64(t.Nanosecond())/100 + filetimeEpochOffset
 }
 
-// nanosToTime converts a stored INTEGER unix-nanosecond value back to a UTC
-// time.Time. 0 maps to the zero time.Time.
-func nanosToTime(n int64) time.Time {
-	if n == 0 {
+// filetimeToTime converts a stored INTEGER FILETIME value back to a UTC
+// time.Time. 0 maps to the zero time.Time. time.Unix normalizes the (possibly
+// negative) second/nanosecond split for pre-1970 values.
+func filetimeToTime(ft int64) time.Time {
+	if ft == 0 {
 		return time.Time{}
 	}
-	return time.Unix(0, n).UTC()
+	ticks := ft - filetimeEpochOffset
+	return time.Unix(ticks/10_000_000, (ticks%10_000_000)*100).UTC()
 }
 
 // ============================================================================
@@ -151,10 +166,10 @@ func fileRowToFileWithNlinkAndBlocks(r scanRow, withBlocks bool) (*metadata.File
 			GID:          uint32(gid),
 			Nlink:        uint32(nlink),
 			Size:         uint64(size),
-			Atime:        nanosToTime(atime),
-			Mtime:        nanosToTime(mtime),
-			Ctime:        nanosToTime(ctime),
-			CreationTime: nanosToTime(creationTime),
+			Atime:        filetimeToTime(atime),
+			Mtime:        filetimeToTime(mtime),
+			Ctime:        filetimeToTime(ctime),
+			CreationTime: filetimeToTime(creationTime),
 			Hidden:       hidden,
 		},
 	}
@@ -202,12 +217,12 @@ func fileRowToFileWithNlinkAndBlocks(r scanRow, withBlocks bool) (*metadata.File
 		copy(file.ObjectID[:], objectIDRaw)
 	}
 
-	// Recycle-bin metadata (#190). deleted_at is INTEGER unix-nanoseconds (like
+	// Recycle-bin metadata (#190). deleted_at is INTEGER Windows FILETIME (like
 	// the other file timestamps): NULL -> live node (nil pointer); a valid value
-	// decodes via nanosToTime for lossless nanosecond round-trip.
+	// decodes via filetimeToTime for lossless nanosecond round-trip.
 	// original_path / deleted_by default to '' for live nodes.
 	if deletedAt.Valid {
-		t := nanosToTime(deletedAt.Int64)
+		t := filetimeToTime(deletedAt.Int64)
 		file.DeletedAt = &t
 	}
 	file.OriginalPath = originalPath

--- a/pkg/metadata/store/sqlite/files.go
+++ b/pkg/metadata/store/sqlite/files.go
@@ -303,10 +303,10 @@ func (s *SQLiteMetadataStore) ListChildren(ctx context.Context, dirHandle metada
 			UID:          uint32(uid),
 			GID:          uint32(gid),
 			Size:         uint64(size),
-			Atime:        nanosToTime(atime),
-			Mtime:        nanosToTime(mtime),
-			Ctime:        nanosToTime(ctime),
-			CreationTime: nanosToTime(creationTime),
+			Atime:        filetimeToTime(atime),
+			Mtime:        filetimeToTime(mtime),
+			Ctime:        filetimeToTime(ctime),
+			CreationTime: filetimeToTime(creationTime),
 			Hidden:       hidden,
 		}
 		if len(objectIDRaw) > 0 {
@@ -321,9 +321,9 @@ func (s *SQLiteMetadataStore) ListChildren(ctx context.Context, dirHandle metada
 
 		// Recycle-bin metadata (#190): carried on DirEntry.Attr so trash
 		// enumeration via listing reflects recycle state without a re-read.
-		// deleted_at is BIGINT unix-nanoseconds; decode via nanosToTime.
+		// deleted_at is BIGINT Windows FILETIME; decode via filetimeToTime.
 		if deletedAt.Valid {
-			t := nanosToTime(deletedAt.Int64)
+			t := filetimeToTime(deletedAt.Int64)
 			attr.DeletedAt = &t
 		}
 		attr.OriginalPath = originalPath

--- a/pkg/metadata/store/sqlite/migrations/000004_file_timestamps_filetime.down.sql
+++ b/pkg/metadata/store/sqlite/migrations/000004_file_timestamps_filetime.down.sql
@@ -1,0 +1,10 @@
+-- Revert inode file timestamps from Windows FILETIME back to unix-nanoseconds.
+-- Lossy only for pre-1678 / post-2262 values the nanosecond encoding cannot
+-- represent (those were unreachable before #1663).
+UPDATE inodes SET
+    atime         = CASE WHEN atime = 0 THEN 0 ELSE (atime - 116444736000000000) * 100 END,
+    mtime         = CASE WHEN mtime = 0 THEN 0 ELSE (mtime - 116444736000000000) * 100 END,
+    ctime         = CASE WHEN ctime = 0 THEN 0 ELSE (ctime - 116444736000000000) * 100 END,
+    creation_time = CASE WHEN creation_time = 0 THEN 0 ELSE (creation_time - 116444736000000000) * 100 END,
+    deleted_at    = CASE WHEN deleted_at IS NULL OR deleted_at = 0 THEN deleted_at
+                         ELSE (deleted_at - 116444736000000000) * 100 END;

--- a/pkg/metadata/store/sqlite/migrations/000004_file_timestamps_filetime.up.sql
+++ b/pkg/metadata/store/sqlite/migrations/000004_file_timestamps_filetime.up.sql
@@ -1,0 +1,16 @@
+-- Re-encode inode file timestamps from unix-nanoseconds to Windows FILETIME
+-- (signed 100ns ticks since 1601-01-01). INTEGER unix-nanoseconds overflows past
+-- year 2262 and conflates the unix epoch (0 ns) with the zero-time sentinel;
+-- FILETIME spans years 1601–~30828 and keeps epoch distinct, so extreme SMB
+-- timestamps round-trip on par with the memory/badger backends (#1663).
+--
+-- 116444736000000000 = 100ns ticks between 1601-01-01 and 1970-01-01. A stored
+-- 0 stays 0 (the "unset"/zero-time sentinel the Go layer maps to time.Time{}).
+-- Integer division truncates the sub-100ns remainder, matching timeToFiletime.
+UPDATE inodes SET
+    atime         = CASE WHEN atime = 0 THEN 0 ELSE atime / 100 + 116444736000000000 END,
+    mtime         = CASE WHEN mtime = 0 THEN 0 ELSE mtime / 100 + 116444736000000000 END,
+    ctime         = CASE WHEN ctime = 0 THEN 0 ELSE ctime / 100 + 116444736000000000 END,
+    creation_time = CASE WHEN creation_time = 0 THEN 0 ELSE creation_time / 100 + 116444736000000000 END,
+    deleted_at    = CASE WHEN deleted_at IS NULL OR deleted_at = 0 THEN deleted_at
+                         ELSE deleted_at / 100 + 116444736000000000 END;

--- a/pkg/metadata/store/sqlite/migrations/000005_durable_handle_client_guid.down.sql
+++ b/pkg/metadata/store/sqlite/migrations/000005_durable_handle_client_guid.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE durable_handles DROP COLUMN client_guid;

--- a/pkg/metadata/store/sqlite/migrations/000005_durable_handle_client_guid.up.sql
+++ b/pkg/metadata/store/sqlite/migrations/000005_durable_handle_client_guid.up.sql
@@ -1,0 +1,10 @@
+-- Persist the SMB2 client GUID on durable handles so lease-backed durable
+-- reconnect can reject a reconnect from a different client GUID (#1663).
+--
+-- ClientGUID (#432) was added to the in-memory handle but never given a column
+-- here, so scanDurableHandle always returned a zero ClientGUID. That
+-- short-circuits leaseReconnectClientGUIDMismatch, wrongly returning
+-- NT_STATUS_OK instead of NT_STATUS_OBJECT_NAME_NOT_FOUND for
+-- smb2.durable-open.reopen1a-lease / durable-v2-open.reopen1a-lease. NULL for
+-- pre-existing rows decodes to a zero ClientGUID, matching the prior behavior.
+ALTER TABLE durable_handles ADD COLUMN client_guid BLOB;

--- a/pkg/metadata/store/sqlite/shares.go
+++ b/pkg/metadata/store/sqlite/shares.go
@@ -276,7 +276,7 @@ func (s *SQLiteMetadataStore) CreateRootDirectory(
 				int32(existingRoot.Mode),
 				int32(existingRoot.UID),
 				int32(existingRoot.GID),
-				timeToNanos(now),
+				timeToFiletime(now),
 				existingRoot.ID,
 			)
 			if err != nil {
@@ -338,10 +338,10 @@ func (s *SQLiteMetadataStore) CreateRootDirectory(
 		int32(uid),                        // uid
 		int32(gid),                        // gid
 		int64(0),                          // size
-		timeToNanos(now),                  // atime
-		timeToNanos(now),                  // mtime
-		timeToNanos(now),                  // ctime
-		timeToNanos(now),                  // creation_time
+		timeToFiletime(now),               // atime
+		timeToFiletime(now),               // mtime
+		timeToFiletime(now),               // ctime
+		timeToFiletime(now),               // creation_time
 		nil,                               // content_id (NULL for directories)
 		nil,                               // link_target (NULL)
 		nil,                               // device_major (NULL)
@@ -457,10 +457,10 @@ func (s *SQLiteMetadataStore) getExistingRootDirectory(ctx context.Context, shar
 			UID:          uint32(uid),
 			GID:          uint32(gid),
 			Size:         uint64(size),
-			Atime:        nanosToTime(atime),
-			Mtime:        nanosToTime(mtime),
-			Ctime:        nanosToTime(ctime),
-			CreationTime: nanosToTime(creationTime),
+			Atime:        filetimeToTime(atime),
+			Mtime:        filetimeToTime(mtime),
+			Ctime:        filetimeToTime(ctime),
+			CreationTime: filetimeToTime(creationTime),
 			Hidden:       hidden,
 		},
 	}, nil

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -289,12 +289,12 @@ func (tx *sqliteTransaction) PutFile(ctx context.Context, file *metadata.File) e
 		objectIDArg = file.ObjectID[:]
 	}
 
-	// deleted_at is a BIGINT unix-nanoseconds column (#190), nullable: NULL marks
+	// deleted_at is a BIGINT Windows FILETIME column (#190), nullable: NULL marks
 	// a live node, a value records the recycle instant losslessly (like the other
 	// file timestamps). Pass *int64 so a nil DeletedAt writes SQL NULL.
 	var deletedAtArg *int64
 	if file.DeletedAt != nil {
-		n := file.DeletedAt.UnixNano()
+		n := timeToFiletime(*file.DeletedAt)
 		deletedAtArg = &n
 	}
 
@@ -312,8 +312,8 @@ func (tx *sqliteTransaction) PutFile(ctx context.Context, file *metadata.File) e
 		// Row exists; update it in place.
 		if _, err := tx.tx.Exec(ctx, updateQuery,
 			file.Type, file.Mode, file.UID, file.GID, file.Size,
-			timeToNanos(file.Atime), timeToNanos(file.Mtime),
-			timeToNanos(file.Ctime), timeToNanos(file.CreationTime),
+			timeToFiletime(file.Atime), timeToFiletime(file.Mtime),
+			timeToFiletime(file.Ctime), timeToFiletime(file.CreationTime),
 			payloadIDPtr, linkTargetPtr, deviceMajor, deviceMinor,
 			file.Hidden, aclJSON, easJSON, objectIDArg,
 			deletedAtArg, file.OriginalPath, file.DeletedBy,
@@ -371,8 +371,8 @@ func (tx *sqliteTransaction) PutFile(ctx context.Context, file *metadata.File) e
 		if _, err := tx.tx.Exec(ctx, insertQuery,
 			file.ID, file.ShareName,
 			file.Type, file.Mode, file.UID, file.GID, file.Size,
-			timeToNanos(file.Atime), timeToNanos(file.Mtime),
-			timeToNanos(file.Ctime), timeToNanos(file.CreationTime),
+			timeToFiletime(file.Atime), timeToFiletime(file.Mtime),
+			timeToFiletime(file.Ctime), timeToFiletime(file.CreationTime),
 			payloadIDPtr, linkTargetPtr, deviceMajor, deviceMinor,
 			file.Hidden, aclJSON, easJSON, objectIDArg,
 			deletedAtArg, file.OriginalPath, file.DeletedBy,
@@ -643,10 +643,10 @@ func (tx *sqliteTransaction) ListChildren(ctx context.Context, dirHandle metadat
 			UID:          uint32(uid),
 			GID:          uint32(gid),
 			Size:         uint64(size),
-			Atime:        nanosToTime(atime),
-			Mtime:        nanosToTime(mtime),
-			Ctime:        nanosToTime(ctime),
-			CreationTime: nanosToTime(creationTime),
+			Atime:        filetimeToTime(atime),
+			Mtime:        filetimeToTime(mtime),
+			Ctime:        filetimeToTime(ctime),
+			CreationTime: filetimeToTime(creationTime),
 			Hidden:       hidden,
 		}
 		if len(objectIDRaw) > 0 {
@@ -661,10 +661,10 @@ func (tx *sqliteTransaction) ListChildren(ctx context.Context, dirHandle metadat
 
 		// Recycle-bin metadata (#190): carried on DirEntry.Attr so trash
 		// enumeration via listing reflects recycle state without a re-read,
-		// matching the pool-query path. deleted_at is BIGINT unix-nanoseconds;
-		// decode via nanosToTime.
+		// matching the pool-query path. deleted_at is BIGINT Windows FILETIME;
+		// decode via filetimeToTime.
 		if deletedAt.Valid {
-			t := nanosToTime(deletedAt.Int64)
+			t := filetimeToTime(deletedAt.Int64)
 			attr.DeletedAt = &t
 		}
 		attr.OriginalPath = originalPath
@@ -1116,10 +1116,10 @@ func (tx *sqliteTransaction) CreateRootDirectory(ctx context.Context, shareName 
 				UID:          uint32(existingUID),
 				GID:          uint32(existingGID),
 				Size:         uint64(size),
-				Atime:        nanosToTime(atime),
-				Mtime:        nanosToTime(mtime),
-				Ctime:        nanosToTime(ctime),
-				CreationTime: nanosToTime(creationTime),
+				Atime:        filetimeToTime(atime),
+				Mtime:        filetimeToTime(mtime),
+				Ctime:        filetimeToTime(ctime),
+				CreationTime: filetimeToTime(creationTime),
 				Hidden:       hidden,
 			},
 		}, nil
@@ -1156,10 +1156,10 @@ func (tx *sqliteTransaction) CreateRootDirectory(ctx context.Context, shareName 
 		int32(uid),                        // uid
 		int32(gid),                        // gid
 		int64(0),                          // size
-		timeToNanos(now),                  // atime
-		timeToNanos(now),                  // mtime
-		timeToNanos(now),                  // ctime
-		timeToNanos(now),                  // creation_time
+		timeToFiletime(now),               // atime
+		timeToFiletime(now),               // mtime
+		timeToFiletime(now),               // ctime
+		timeToFiletime(now),               // creation_time
 		nil,                               // content_id (NULL for directories)
 		nil,                               // link_target (NULL)
 		nil,                               // device_major (NULL)

--- a/pkg/metadata/storetest/durable_handles.go
+++ b/pkg/metadata/storetest/durable_handles.go
@@ -122,6 +122,11 @@ func makeDurableHandle(id string, shareName string) *lock.PersistedDurableHandle
 	var appInstanceId [16]byte
 	copy(appInstanceId[:], []byte("appid-"+id))
 
+	// ClientGUID is the SMB2 NEGOTIATE client GUID. It must round-trip so
+	// lease-backed durable reconnect can reject a different client (#1663).
+	var clientGUID [16]byte
+	copy(clientGUID[:], []byte("cliguid-"+id))
+
 	var leaseKey [16]byte
 	copy(leaseKey[:], []byte("lease-"+id))
 
@@ -152,6 +157,7 @@ func makeDurableHandle(id string, shareName string) *lock.PersistedDurableHandle
 		LeaseEpoch:         0x2a,
 		CreateGuid:         createGuid,
 		AppInstanceId:      appInstanceId,
+		ClientGUID:         clientGUID,
 		Username:           "user-" + id,
 		SessionKeyHash:     sessionKeyHash,
 		IsV2:               true,
@@ -220,6 +226,9 @@ func assertDurableHandleEqual(t *testing.T, expected, actual *lock.PersistedDura
 	}
 	if expected.AppInstanceId != actual.AppInstanceId {
 		t.Errorf("AppInstanceId: got %x, want %x", actual.AppInstanceId, expected.AppInstanceId)
+	}
+	if expected.ClientGUID != actual.ClientGUID {
+		t.Errorf("ClientGUID: got %x, want %x", actual.ClientGUID, expected.ClientGUID)
 	}
 	if expected.Username != actual.Username {
 		t.Errorf("Username: got %q, want %q", actual.Username, expected.Username)

--- a/pkg/metadata/storetest/file_ops.go
+++ b/pkg/metadata/storetest/file_ops.go
@@ -83,6 +83,38 @@ func testTimestampPrecision(t *testing.T, factory StoreFactory) {
 	check("Atime", atime, got.Atime)
 	check("Ctime", ctime, got.Ctime)
 	check("CreationTime", creation, got.CreationTime)
+
+	// Edge-of-range values a naive int64-unix-nanosecond encoding corrupts
+	// (#1663). SMB FILETIME spans well beyond the int64-nanosecond window
+	// (~1678–2262), and the unix epoch is a valid, distinct instant — not the
+	// "unset" zero time. memory/badger (JSON time.Time) round-trip these; a SQL
+	// backend storing UnixNano() truncates past 2262 and conflates epoch with a
+	// zero sentinel. Exercised by smbtorture smb2.timestamps.time_t_{0,
+	// 10000000000, 15032385535}.
+	edges := []struct {
+		name string
+		t    time.Time
+	}{
+		{"epoch", time.Unix(0, 0).UTC()},              // time_t_0
+		{"year2286", time.Unix(10000000000, 0).UTC()}, // time_t_10000000000, past int64-nanos overflow
+		{"year2446", time.Unix(15032385535, 0).UTC()}, // time_t_15032385535
+	}
+	for _, e := range edges {
+		file.Mtime = e.t
+		file.Atime = e.t
+		file.Ctime = e.t
+		file.CreationTime = e.t
+		if err := store.PutFile(ctx, file); err != nil {
+			t.Fatalf("PutFile(%s) failed: %v", e.name, err)
+		}
+		got, err := store.GetFile(ctx, handle)
+		if err != nil {
+			t.Fatalf("GetFile(%s) failed: %v", e.name, err)
+		}
+		check(e.name+".Mtime", e.t, got.Mtime)
+		check(e.name+".Ctime", e.t, got.Ctime)
+		check(e.name+".CreationTime", e.t, got.CreationTime)
+	}
 }
 
 // testHighModeBits verifies a file mode carrying high bits above the POSIX


### PR DESCRIPTION
## Problem

develop CI is red (#1663). The smbtorture SMB conformance suite fails **5 tests on the sqlite and postgres metadata backends** that pass on memory/badger. These are pre-existing backend gaps newly *exposed* by #1659 (which added sqlite/postgres to the postsubmit matrix), not regressions.

| Failing test | Root cause |
|---|---|
| `smb2.timestamps.time_t_0` | epoch (1970) collided with the zero-time sentinel |
| `smb2.timestamps.time_t_10000000000` (yr 2286) | `UnixNano()` overflows int64 past ~2262 |
| `smb2.timestamps.time_t_15032385535` (yr 2446) | same overflow |
| `smb2.durable-open.reopen1a-lease` | durable reconnect returned `OK` instead of `OBJECT_NAME_NOT_FOUND` |
| `smb2.durable-v2-open.reopen1a-lease` | same |

## Cluster A — timestamps

sqlite/postgres stored file timestamps as `int64` unix-nanoseconds. That window is only ~1678–2262, and the epoch maps to `0`, colliding with the "unset" zero-time sentinel. memory/badger store `time.Time` (JSON, full range) and pass.

Fix: store **Windows FILETIME** (signed 100ns ticks since 1601) in the existing `INTEGER`/`BIGINT` columns — spans years 1601–~30828, epoch is a distinct non-zero value. This is exactly SMB FILETIME granularity and matches every value the storetest suite asserts (all 100ns-multiples). Migrations \`000037\` (pg) / \`000004\` (sqlite) re-encode existing rows; the arithmetic is provably identical to the Go encoder.

## Cluster B — durable reconnect

The \`durable_handles\` table never got a \`client_guid\` column when ClientGUID (#432) landed, so a scanned \`ClientGUID\` was always zero. That short-circuits \`leaseReconnectClientGUIDMismatch\`, wrongly allowing a lease-backed durable reconnect from a *different* client. Add the column (migrations \`000038\` pg / \`000005\` sqlite); no handler change needed.

## Tests

\`storetest\` (the shared conformance suite, the deterministic CI replacement for these smbtorture asserts) gains:
- extreme-timestamp cases (epoch / 2286 / 2446) in \`testTimestampPrecision\`
- a \`ClientGUID\` round-trip assertion in the durable-handle fixture

Both fail before the fix and pass after. Full conformance verified locally on all four backends: memory (297), badger (527), sqlite (240), postgres (all).