### PR TITLE
fix(dfsbench): create --target dir + suppress fio ETA on non-TTY (#1565)

### DIFF
--- a/internal/dfsbench/fio/fio_test.go
+++ b/internal/dfsbench/fio/fio_test.go
@@ -1,10 +1,31 @@
 package fio
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestCheckTarget_CreatesMissingDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "does", "not", "exist")
+	if err := CheckTarget(dir); err != nil {
+		t.Fatalf("CheckTarget should mkdir -p a fresh path: %v", err)
+	}
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		t.Fatalf("target not created as a dir: err=%v", err)
+	}
+}
+
+func TestCheckTarget_ExistingFileErrors(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "afile")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := CheckTarget(file); err == nil {
+		t.Fatal("CheckTarget should error when the target is an existing file")
+	}
+}
 
 // a trimmed but real-shaped fio --output-format=json report (rand-read-4k).
 const fioRandReadJSON = `{

--- a/internal/dfsbench/fio/run.go
+++ b/internal/dfsbench/fio/run.go
@@ -1,8 +1,8 @@
 package fio
 
 import (
+	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -13,11 +13,12 @@ import (
 // LoadOpts are the per-cell fio knobs the harness overrides on top of the .fio
 // template. Zero values mean "use the job file's own value".
 type LoadOpts struct {
-	Size    string // fio --size (e.g. "64k", "1g")
-	Threads int    // BENCH_THREADS
-	Runtime int    // BENCH_RUNTIME seconds
-	Engine  string // FIO_ENGINE (defaults per-OS)
-	FioBin  string // fio binary (default "fio")
+	Size         string // fio --size (e.g. "64k", "1g")
+	Threads      int    // BENCH_THREADS
+	Runtime      int    // BENCH_RUNTIME seconds
+	Engine       string // FIO_ENGINE (defaults per-OS)
+	FioBin       string // fio binary (default "fio")
+	LiveProgress bool   // let fio's live ETA line reach stdout (set on a TTY)
 }
 
 // defaultEngine picks a portable fio ioengine. libaio is Linux-only; local dev
@@ -69,14 +70,37 @@ func RunFio(ctx context.Context, workload, targetDir string, opts LoadOpts) (Cel
 		return CellResult{}, closeErr
 	}
 
+	// --output routes the JSON report to a file so fio's stdout is free for its
+	// live ETA line. On a TTY (LiveProgress) we let that reach the terminal;
+	// otherwise fio's stdout is discarded and it auto-suppresses the ETA, keeping
+	// piped/captured output clean.
+	outFile, err := os.CreateTemp("", "dfsbench-out-*.json")
+	if err != nil {
+		return CellResult{}, err
+	}
+	outPath := outFile.Name()
+	_ = outFile.Close()
+	defer func() { _ = os.Remove(outPath) }()
+
 	// directory/size/threads/runtime are baked into the rendered job file (see
 	// jobDefaults) because job-file options beat fio's global CLI flags.
-	cmd := exec.CommandContext(ctx, bin, "--output-format=json", jobPath)
-	out, err := cmd.Output()
-	if err != nil {
-		return CellResult{}, fmt.Errorf("run %s (%s): %w\n%s", bin, workload, err, fioStderr(err))
+	cmd := exec.CommandContext(ctx, bin, "--output="+outPath, "--output-format=json", jobPath)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if opts.LiveProgress {
+		cmd.Stdout = os.Stdout
+	}
+	if err := cmd.Run(); err != nil {
+		return CellResult{}, fmt.Errorf("run %s (%s): %w\n%s", bin, workload, err, stderr.Bytes())
+	}
+	if opts.LiveProgress {
+		_, _ = fmt.Fprintln(os.Stdout) // close fio's in-place ETA line
 	}
 
+	out, err := os.ReadFile(outPath)
+	if err != nil {
+		return CellResult{}, err
+	}
 	res, err := parseFioJSON(out)
 	if err != nil {
 		return CellResult{}, fmt.Errorf("%s: %w", workload, err)
@@ -84,24 +108,12 @@ func RunFio(ctx context.Context, workload, targetDir string, opts LoadOpts) (Cel
 	return res, nil
 }
 
-// fioStderr surfaces a failed fio invocation's stderr, if any.
-func fioStderr(err error) []byte {
-	var ee *exec.ExitError
-	if errors.As(err, &ee) {
-		return ee.Stderr
-	}
-	return nil
-}
-
-// CheckTarget verifies the target directory exists and is writable — fio's own
-// error on a bad dir is opaque, so fail early and clearly.
+// CheckTarget makes the target directory (mkdir -p, 0755) if absent and verifies
+// it is writable — fio's own error on a bad dir is opaque, so fail early and
+// clearly. An existing non-directory makes MkdirAll fail with a clear error.
 func CheckTarget(dir string) error {
-	info, err := os.Stat(dir)
-	if err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("target %q: %w", dir, err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("target %q is not a directory", dir)
 	}
 	probe := filepath.Join(dir, ".dfsbench-write-probe")
 	if err := os.WriteFile(probe, []byte("x"), 0o644); err != nil {

--- a/internal/dfsbench/run/bench.go
+++ b/internal/dfsbench/run/bench.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"time"
+
+	"golang.org/x/term"
 
 	"github.com/marmos91/dittofs/internal/dfsbench/backend"
 	"github.com/marmos91/dittofs/internal/dfsbench/config"
@@ -13,6 +16,13 @@ import (
 	"github.com/marmos91/dittofs/internal/dfsbench/fio"
 	"github.com/marmos91/dittofs/internal/dfsbench/report"
 )
+
+// isInteractive reports whether w is a terminal. On a non-terminal (pipe, file,
+// CI) we keep progress sparse and let fio suppress its per-percent ETA.
+func isInteractive(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	return ok && term.IsTerminal(int(f.Fd()))
+}
 
 func runBench(ctx context.Context, f *runFlags) error {
 	cfg, err := config.LoadConfig(f.config)
@@ -33,11 +43,13 @@ func runBench(ctx context.Context, f *runFlags) error {
 	if f.smoke && f.local {
 		return fmt.Errorf("--smoke and --local are mutually exclusive")
 	}
+	live := isInteractive(exec.CmdOut)
 	opts := fio.LoadOpts{
-		Threads: f.threads,
-		Runtime: f.runtime,
-		Engine:  f.engine,
-		FioBin:  f.fioBin,
+		Threads:      f.threads,
+		Runtime:      f.runtime,
+		Engine:       f.engine,
+		FioBin:       f.fioBin,
+		LiveProgress: live,
 	}
 
 	// Managed mode: the harness itself sets up/mounts each --systems backend

--- a/internal/dfsbench/run/bench_test.go
+++ b/internal/dfsbench/run/bench_test.go
@@ -1,0 +1,14 @@
+package run
+
+import (
+	"bytes"
+	"testing"
+)
+
+// A non-terminal writer (pipe, file, CI) must read as non-interactive so
+// progress stays sparse and fio's per-percent ETA is suppressed.
+func TestIsInteractive_NonTTY(t *testing.T) {
+	if isInteractive(&bytes.Buffer{}) {
+		t.Fatal("a bytes.Buffer is not a terminal")
+	}
+}


### PR DESCRIPTION
## What

Two small QoL fixes to `dfsbench run` (formerly `dfsctl bench run`, relocated during the #1602 harness consolidation — it now lives in `internal/dfsbench/`).

### 1. Create the target dir instead of erroring
`dfsbench run --local --target /path/that/does/not/exist` used to fail with `stat ...: no such file or directory`. `fio.CheckTarget` now does `os.MkdirAll(dir, 0o755)` (mkdir -p) so a fresh path just works. An existing regular file still fails clearly (MkdirAll returns ENOTDIR).

### 2. Suppress per-percent fio progress on a non-TTY
fio's live ETA line spams one line per update when piped/captured. The JSON report is now routed to a temp file via `--output`, freeing fio's stdout for its ETA line. `run` detects whether output is a terminal (`golang.org/x/term`, already a dependency) and only lets the ETA reach stdout on a TTY — piped/CI runs stay clean. The ETA-closing newline lives in `RunFio` so it covers the local, managed, and baseline paths uniformly.

## Files
- `internal/dfsbench/fio/run.go` — `CheckTarget` mkdir -p; `RunFio` `--output` temp file + TTY-gated live ETA.
- `internal/dfsbench/run/bench.go` — `isInteractive` TTY check wired to `LoadOpts.LiveProgress`.
- Tests: `CheckTarget` mkdir-p + existing-file error; `isInteractive` non-TTY.

## Verification
- `go build ./...`, `go vet ./internal/dfsbench/...`, `golangci-lint run` — clean.
- `go test ./internal/dfsbench/...` — 39 passed.
- Manual: fresh `--target` now creates the dir and runs; a file `--target` errors; piped smoke output is a handful of lines (no ETA spam).

No Cobra flags/help changed, so `docs/guide/cli.md` needs no regen.

Closes #1565. Note: `develop` is not the default branch, so merging this will not auto-close #1565 — please close it manually on merge.