### PR TITLE
fix(dfsbench): repair postgres/zerofs/s3ql/rclone/juicefs cell setup

### DIFF
--- a/bench/workloads/mixed-rw.fio
+++ b/bench/workloads/mixed-rw.fio
@@ -11,4 +11,8 @@ runtime=${BENCH_RUNTIME:-60}
 time_based
 size=${BENCH_SIZE:-1g}
 directory=${BENCH_DIR:-/mnt/bench}
+# Read/write the file layout.fio pre-wrote (shared filename_format): the 70/30
+# mix hits real, full-size data and never ftruncate-extends a fresh file, which
+# EIOs on writeback FUSE re-exports (rclone --vfs-cache-mode writes, juicefs).
+filename_format=bench.$jobnum
 group_reporting

--- a/bench/workloads/rand-read-4k.fio
+++ b/bench/workloads/rand-read-4k.fio
@@ -10,4 +10,8 @@ runtime=${BENCH_RUNTIME:-60}
 time_based
 size=${BENCH_SIZE:-1g}
 directory=${BENCH_DIR:-/mnt/bench}
+# Read the file layout.fio pre-wrote (shared filename_format), so random reads hit
+# real, durably-uploaded data — and never ftruncate-extend a fresh file, which EIOs
+# on writeback FUSE re-exports (rclone --vfs-cache-mode writes, juicefs --writeback).
+filename_format=bench.$jobnum
 group_reporting

--- a/internal/dfsbench/CLAUDE.md
+++ b/internal/dfsbench/CLAUDE.md
@@ -1,0 +1,116 @@
+# CLAUDE.md — `dfsbench` benchmark harness
+
+Run playbook for the DittoFS-vs-competitors benchmark. The *design* is in
+`.planning/2026-07-08-bench-harness-consolidation.md` (#1602); this file is the
+"how do I actually run it and read the result" that isn't in the code.
+
+Harness = `cmd/bench` (binary `dfsbench`), library here in `internal/dfsbench/`.
+`fio` is the **only** load generator; competitors are mounted FUSE filesystems
+re-exported over kernel NFS/Samba so fio hits them identically. Latest published
+run: `docs/BENCHMARKS.md`.
+
+## Where we stand (2026-07-10, `develop@0d79ede1`, NFSv3, 7 systems)
+
+- **Metadata is THE deficit** — DittoFS **239 ops/s, dead last** (ZeroFS 371,
+  s3ql 700, JuiceFS 1824). Only axis we lose to the whole field. Fix in flight:
+  metadata group-commit **#1573** (per-create fsync is the wall).
+- Random-read **much improved** post #1648/#1651 (warm fast path, −256× amp):
+  7437 large / 24862 medium IOPS, ~56–58% of JuiceFS. Remaining gap is per-read
+  **NFS RPC + metadata lookup**, not the block store (engine is 20× faster).
+- We **lead the durable-write cohort** on random-write (2365 IOPS); seq-write is
+  low (156 MB/s) because it's a real through-to-disk durable write.
+- **Cold-read DittoFS = pending** — `dfsctl system drain-uploads` evict errored
+  that run. Re-run needed for the cold column.
+
+## Commands
+
+```sh
+go build -o dfsbench ./cmd/bench      # fio must be on PATH (use `nix develop`)
+
+dfsbench list                          # backend × workload × size matrix
+dfsbench run --smoke                   # tiny self-contained CI run on a temp dir
+dfsbench run --local --target /mnt/x   # fio an already-mounted FS
+dfsbench run --dry-run ...             # print the cell matrix, run nothing
+
+# Full cloud run: provision one disposable VM → managed matrix → tear down
+dfsbench setup                         # SCW_* env picks type/zone/image; writes .bench-vm.json
+dfsbench run --remote --config bench.yaml \
+  --systems dittofs-s3-nfs3,dittofs-sqlite-s3-nfs3,dittofs-postgres-s3-nfs3,zerofs-nfs3,s3ql-nfs3,juicefs-nfs3,rclone-nfs3,s3fs-nfs3,local-disk-nfs3 \
+  --sizes medium,large
+dfsbench report --results ./bench-results   # re-render the comparison table
+dfsbench teardown                      # terminate the VM in .bench-vm.json
+```
+
+**GOTCHA — `--config` is REQUIRED for any S3 backend.** `bucket`/`endpoint`
+have no CLI flags; without a config every S3 system fails setup with
+`Custom endpoint \`\` was not a valid URI` and only `local-disk` runs. Minimal
+config (creds still come from env):
+
+```yaml
+# bench.yaml
+bucket: dittofs-bench                    # canonical SCW bench bucket (per-backend prefixes, auto-wiped)
+endpoint: https://s3.fr-par.scw.cloud
+```
+
+`--remote` launches the matrix **detached on the VM and polls** — no interim
+local result files; they're pulled back only at the end. `--resume` skips cells
+whose JSON already exists (e.g. `local-disk` from a prior partial run). The three
+`dittofs-{s3,sqlite-s3,postgres-s3}` backends give the badger-vs-sqlite-vs-postgres
+metadata comparison. **`run` exits 0 even if 8/9 systems fail setup** — always
+check `ls bench-results/ | sed 's/__.*//' | sort -u` covers every system before
+trusting the report.
+
+Key `run` flags: `--resume` (skip cells whose result JSON exists — crash-safe),
+`--evict-cache` (default true; adds the cold post-evict read pass),
+`--skip-baseline` (skip local-disk ceiling), `--threads` (4), `--runtime` (60s;
+smoke 3s), `--results` (`./bench-results`). One JSON per cell, slug-named.
+
+## Environment
+
+- **S3 creds**: `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (`_SESSION_TOKEN`
+  optional) in the env. Bucket + endpoint (`s3.fr-par.scw.cloud`) are in run config.
+  Use **`scw` CLI**-issued S3 keys, **not** Pulumi outputs (Pulumi keys 403 on S3).
+  The `scw` CLI's own object-storage keys work — pull them at run time so no
+  secret is stored: prefix the run with
+  `AWS_ACCESS_KEY_ID=$(scw config get access-key) AWS_SECRET_ACCESS_KEY=$(scw config get secret-key)`.
+- **VM**: `scw` CLI must be authed. Knobs (defaults): `SCW_ZONE=fr-par-1`,
+  `SCW_INSTANCE_TYPE=POP2-8C-32G`, `SCW_IMAGE=ubuntu_noble`,
+  `SCW_ROOT_VOLUME=sbs:100GB:5000`, `SCW_NAME`, `SCW_SSH_KEY`.
+- `setup` cross-builds `dfsbench`/`dfs`/`dfsctl` (CGO-free linux), pushes over
+  SSH, apt-installs fio + nfs/samba + s3fs/rclone/s3ql/juicefs on the VM.
+
+## Operational gotchas (learned the slow way)
+
+- **`--runtime` defaults to 60s/cell** → the full 9-system × 2-size matrix (~180
+  cells) is ~4h. Pass **`--runtime 30`** to match the published baseline and
+  halve it (~1.5–2h). Don't `--resume` across a runtime change — wipe
+  `bench-results/` first so you don't mix 30s and 60s cells.
+- **Aborting a `--remote` run needs TWO kills.** The local `dfsbench run` only
+  polls; the matrix runs as the **`dfsbench` binary detached on the VM**
+  (`/root/dfsbench run …`, log `/root/run.log`, sentinel `/root/DONE`). Kill both:
+  `pkill -f 'dfsbench run'` locally, then on the VM
+  `pkill -9 -x dfsbench; pkill -9 -x fio` — use **`-x` (exact name)**, because a
+  `pkill -f dfsbench` also matches your own ssh shell (its cmdline contains the
+  word) and kills the session (ssh exits 255) before finishing.
+- **Manual SSH to the bench VM:** user is `root`; the SCW key lives in the
+  **1Password agent**, not the default macOS agent —
+  `export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"`.
+  SCW reuses IPs, so a stale `known_hosts` entry triggers "HOST KEY CHANGED";
+  add `-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no` (disposable VM).
+
+## Reading results — the rig lies, so don't trust it blindly
+
+- Each cell is **one short fio run on a shared cloud VM** (`--runtime`, default
+  60s; the published baselines pass `--runtime 30`). Trust **shape and order of
+  magnitude, not the third digit**. Read-IOPS especially is noisy (±70% seen).
+  For a real A/B on the read path, trust **pprof + unit/engine benchmarks**, not
+  rig IOPS — the rig has confounds (rollup CPU, restart re-seed, pin-can't-force-
+  S3-only) that defeat clean comparisons.
+- Native-S3 servers (DittoFS, ZeroFS) get **no page-cache free ride**; the FUSE
+  re-exports do. Compare DittoFS to ZeroFS (the other native server) to isolate
+  design from the native-S3 handicap.
+- **Cold-read barrier runs before EACH read cell** (`managed.go` `coldBarrier`),
+  not once — a single evict warms later cells and inflates cold rand-read.
+- Superseded: `bench/results/*.json` + `bench/orchestrator/` are the **old**
+  harness (March 2026, dittofs 47 ops/s). Ignore them; current truth is
+  `internal/dfsbench` + `docs/BENCHMARKS.md`.

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -83,20 +83,27 @@ func dittofsAddMetadataStore(ctx context.Context, kind dittofsMetaKind) error {
 	}
 }
 
-// dittofsProvisionPostgres installs, configures (trust auth on loopback — the
-// bench VM is throwaway and single-tenant), starts PostgreSQL, and (re)creates
-// a clean bench role+database. Idempotent; mirrors the apt install-on-demand
-// idiom the re-export backends use. Debian/Ubuntu bench image assumed.
+// dittofsProvisionPostgres installs, starts PostgreSQL, and (re)creates a clean
+// bench role+database. Idempotent; mirrors the apt install-on-demand idiom the
+// re-export backends use. Debian/Ubuntu bench image assumed.
+//
+// The provisioning SQL runs as the `postgres` OS user over the local socket,
+// which the default pg_hba `local all postgres peer` rule always admits — no
+// pg_hba edit needed. dfsctl then connects over TCP (127.0.0.1) as the freshly
+// created role, which the default `host all all 127.0.0.1/32 scram-sha-256` rule
+// admits with the password set below.
 func dittofsProvisionPostgres(ctx context.Context) error {
 	script := fmt.Sprintf(`set -eu
 command -v pg_isready >/dev/null 2>&1 || { apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql; }
-hba="$(ls /etc/postgresql/*/main/pg_hba.conf 2>/dev/null | head -1)"
-if [ -n "$hba" ]; then
-  grep -q '127.0.0.1/32 trust' "$hba" || echo 'host all all 127.0.0.1/32 trust' >> "$hba"
-fi
-service postgresql restart 2>/dev/null || systemctl restart postgresql 2>/dev/null || pg_ctlcluster "$(ls /etc/postgresql 2>/dev/null | head -1)" main restart 2>/dev/null || true
-for i in $(seq 1 30); do pg_isready -h 127.0.0.1 -p 5432 >/dev/null 2>&1 && break; sleep 1; done
-psql -h 127.0.0.1 -U postgres -v ON_ERROR_STOP=1 <<SQL || su - postgres -c 'psql -v ON_ERROR_STOP=1' <<SQL
+service postgresql start 2>/dev/null || systemctl start postgresql 2>/dev/null || pg_ctlcluster "$(ls /etc/postgresql 2>/dev/null | head -1)" main start 2>/dev/null || true
+# Wait on the local socket as the postgres user — the same path the SQL below
+# connects through — for up to 60s. A fresh apt-install has just created the
+# cluster, and a shorter TCP probe raced the cluster still coming up (psql exit 2).
+for i in $(seq 1 60); do su - postgres -c 'pg_isready -q' 2>/dev/null && break; sleep 1; done
+# Fail loudly with cluster diagnostics if it never came up, rather than letting
+# the provisioning psql below fail with a cryptic connection error (exit 2).
+su - postgres -c 'pg_isready -q' 2>/dev/null || { echo 'postgres cluster never became ready:'; pg_lsclusters 2>/dev/null; exit 1; }
+su - postgres -c 'psql -v ON_ERROR_STOP=1' <<SQL
 DROP DATABASE IF EXISTS %[1]s;
 DO $do$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='%[2]s') THEN CREATE ROLE %[2]s LOGIN PASSWORD '%[3]s'; END IF; END $do$;
 CREATE DATABASE %[1]s OWNER %[2]s;

--- a/internal/dfsbench/backend/fuse.go
+++ b/internal/dfsbench/backend/fuse.go
@@ -353,8 +353,20 @@ func s3qlSetup(ctx context.Context, env BackendEnv) error {
 	if err := os.MkdirAll(s3qlCache, 0o755); err != nil {
 		return err
 	}
-	// mkfs is a no-op if the filesystem already exists (--force off).
-	_ = exec.Sh(ctx, "mkfs.s3ql", "--authfile", "/etc/bench-s3ql-authinfo2", "--plain", url)
+	// mkfs.s3ql refuses to overwrite an existing filesystem, and SCW's eventual
+	// LIST-after-DELETE can still surface a prior run's fs to mkfs even after
+	// cleanS3Prefix (the same object-store quirk zerofsSetup notes). Force-clear
+	// first — best-effort, since a truly empty prefix has nothing to clear. Global
+	// options (--authfile) must precede the `clear` action, and its "yes" prompt is
+	// answered on stdin. (When SCW rate-limits the clear's object walk this can
+	// still fail; s3ql then just produces no cells and the rest of the matrix runs.)
+	_ = exec.Sh(ctx, "sh", "-c", fmt.Sprintf("printf 'yes\\n' | s3qladm --authfile /etc/bench-s3ql-authinfo2 clear %s 2>/dev/null; true", url))
+	// Fresh prefix, so mkfs creates the filesystem. Surface its error instead of
+	// swallowing it — a silent mkfs failure otherwise resurfaces as an opaque
+	// `mount.s3ql` exit 31 ("not an s3ql filesystem") that hides the real cause.
+	if err := exec.Sh(ctx, "mkfs.s3ql", "--authfile", "/etc/bench-s3ql-authinfo2", "--plain", url); err != nil {
+		return fmt.Errorf("mkfs.s3ql: %w", err)
+	}
 	return s3qlMountFUSE(ctx)
 }
 

--- a/internal/dfsbench/backend/zerofs.go
+++ b/internal/dfsbench/backend/zerofs.go
@@ -90,7 +90,11 @@ func zerofsSetup(ctx context.Context, env BackendEnv) error {
 	// 2049 (resilience against a dirty VM). Stop both unit names — the re-export
 	// backends restart nfs-kernel-server, and nfs-server is only an alias on some
 	// distros — so we reliably free the port the same server later reclaims.
-	_ = exec.Sh(ctx, "sh", "-c", "pkill -9 -f 'zerofs run' 2>/dev/null; systemctl stop nfs-server nfs-kernel-server nfs-mountd 2>/dev/null; exportfs -ua 2>/dev/null; true")
+	// `systemctl stop` alone leaves the in-kernel [nfsd] threads bound to :2049, so
+	// `rpc.nfsd 0` is required to actually tear them down; then wait until :2049 is
+	// genuinely free before zerofs tries to claim it. Stop (not disable) the units
+	// so a following re-export backend's zerofsTeardown can start knfsd again.
+	_ = exec.Sh(ctx, "sh", "-c", "pkill -9 -f 'zerofs run' 2>/dev/null; systemctl stop nfs-server nfs-kernel-server nfs-mountd 2>/dev/null; exportfs -ua 2>/dev/null; for i in $(seq 1 20); do rpc.nfsd 0 2>/dev/null; ss -ltn 2>/dev/null | grep -q ':2049 ' || break; sleep 1; done; true")
 	return zerofsStart(ctx)
 }
 
@@ -172,14 +176,22 @@ func zerofsStart(ctx context.Context) error {
 		"zerofs run -c "+zerofsConf+" >"+zerofsLog+" 2>&1 &"); err != nil {
 		return err
 	}
-	// Wait for zerofs to actually be SERVING, not just listening. It binds the TCP
-	// socket immediately but only starts answering NFS ~35s later, after loading
-	// the encryption key and warming the LSM from S3 — a plain port probe returns
-	// too early and the first mount races a not-yet-serving server (mount.nfs:
-	// "Protocol family not supported").
-	if err := exec.Sh(ctx, "sh", "-c",
-		"for i in $(seq 1 120); do grep -qa 'Starting NFS server' "+zerofsLog+" 2>/dev/null && exit 0; sleep 1; done; exit 1"); err != nil {
-		return fmt.Errorf("zerofs NFS server did not begin serving (see %s): %w", zerofsLog, err)
+	// Readiness = zerofs is alive AND actually OWNS :<port>, not just that it logged
+	// a serving line. Two failure modes the old log-only grep missed: (1) zerofs
+	// crashes on startup (bad config / S3 auth) yet the mount loop still retries 90s
+	// against nothing; (2) leftover knfsd still holds :<port>, so zerofs never binds,
+	// the mount hits knfsd — which has no export for "/" — and fails with exit 32.
+	// `ss` attributes the listener to a pid, so we can tell zerofs from knfsd. The
+	// mount retries (zerofsMount) still cover the ~35s serve-warmup after the bind.
+	// Echo the log tail + listener owner on failure — exec.Sh folds a command's
+	// combined output into the returned error, so it lands in run.log.
+	probe := "for i in $(seq 1 120); do " +
+		"pgrep -x zerofs >/dev/null 2>&1 || { echo 'zerofs exited during startup'; tail -30 " + zerofsLog + " 2>/dev/null; exit 1; }; " +
+		"ss -ltnp 2>/dev/null | grep ':" + zerofsNFSPort + "' | grep -q zerofs && grep -qa 'Starting NFS server' " + zerofsLog + " 2>/dev/null && exit 0; " +
+		"sleep 1; done; " +
+		"echo 'zerofs did not bind :" + zerofsNFSPort + " within window — knfsd may still hold it:'; ss -ltnp 2>/dev/null | grep ':" + zerofsNFSPort + "'; tail -30 " + zerofsLog + " 2>/dev/null; exit 1"
+	if err := exec.Sh(ctx, "sh", "-c", probe); err != nil {
+		return fmt.Errorf("zerofs not serving on :%s (see %s): %w", zerofsNFSPort, zerofsLog, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Repairs the managed cross-system bench matrix, which was failing setup/workload for almost every backend except `dittofs-s3` and `local-disk`.

## Validated (live)
- **rclone + juicefs `rand-read-4k` / `mixed-rw`** — these `.fio` jobs lacked `filename_format=bench.$jobnum`, so fio `ftruncate`-extended a fresh file, which EIOs on writeback FUSE re-exports. Now they read the pre-laid `bench.$jobnum` file. **Confirmed on a live run — both pass all cells.**

## Correct-in-isolation, blocked by a separate bug
Root-caused via live VM debugging; each command was proven correct by hand, but `dittofs-postgres-s3` and `zerofs` still fail **when run from the harness's detached process** (works over interactive ssh) — tracked separately (see the detached-execution-context issue). These changes are strictly better than develop and are prerequisites for those cells:
- **postgres** — provision over the local socket as the `postgres` user (peer auth) + wait on cluster readiness; drop the dead pg_hba/double-heredoc.
- **zerofs** — `rpc.nfsd 0` (kernel `[nfsd]` threads that `systemctl stop` leaves on :2049) + real `ss` port-ownership readiness with diagnostics.
- **s3ql** — surface `mkfs.s3ql` errors (were masked as mount exit 31) + force-clear the SCW eventual-consistency-stale fs (still rate-limit-flaky on SCW; a unique-prefix follow-up is the real fix).

Plus `internal/dfsbench/CLAUDE.md` — the run playbook.

Pairs with #1670 (tolerate per-cell failures), which makes the matrix complete regardless of individual competitor flakiness.