### PR TITLE
fix(dfsbench): isolate per-cell workload failures (tolerate expected competitor limits)

### DIFF
--- a/internal/dfsbench/run/managed.go
+++ b/internal/dfsbench/run/managed.go
@@ -207,7 +207,14 @@ func runPass(ctx context.Context, p backend.Plan, pass string, wls, sizes []stri
 			before := sysstat.Now()
 			m, err := fio.RunFio(ctx, w, mnt, withSize(opts, s))
 			if err != nil {
-				return err
+				// Isolate a single cell's failure: an inherent competitor limit (e.g.
+				// s3fs random-read over a 1 GiB object, or a metadata EIO) must not
+				// abort this backend's remaining cells. Log it and keep going so the
+				// run still records every cell it CAN and the table shows the real
+				// ceiling, not an empty column. Setup/mount failures still skip the
+				// whole backend upstream — there's nothing to measure without a mount.
+				_, _ = fmt.Fprintf(exec.CmdOut, "FAIL cell %s: %v\n", res.Slug(), err)
+				continue
 			}
 			r := before.RatesTo(sysstat.Now())
 			m.CtxSwPerSec, m.CPUPct = r.CtxSwPerSec, r.CPUPct


### PR DESCRIPTION
Closes #1669.

The managed matrix already continues past a backend whose **setup** fails, but a failing **workload cell** (`fio` error) returned up through `runPass`, aborting that backend's *remaining* workloads. So an inherent competitor limitation mid-list — s3fs random-read stalling on a 1 GiB whole-object download, or its metadata EIO — silently dropped every later cell for that backend and read as a broken run.

## Change
`runPass` now logs a failed cell (`FAIL cell <slug>: <err>`) and **continues** to the next workload/size instead of returning the error. Each cell is independent: the run records every cell it can, and the comparison table shows the real ceiling (e.g. s3fs's slow random-read) rather than an empty column. Setup/mount failures still skip the whole backend upstream — there's nothing to measure without a mount, and the run already tolerates that (records it, continues, exits 0 with a summary).

## Not included
Labeling *expected* competitor×workload incompatibilities distinctly from real regressions (a follow-up polish) — the isolation here already achieves the issue's core goal: the run completes and the table shows what each backend can actually do.

Testing: `RunFio` is a direct call with no injection seam, so the failure path isn't cheaply unit-testable without adding mock surface; `dfsbench run --smoke` exercises `runPass`, and `go test ./internal/dfsbench/...` (39) + `go vet` pass.