### PR TITLE
fix(ci): treat cancelled conformance runs as benign, not develop-red

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -56,9 +56,12 @@ jobs:
       RUN_URL: ${{ github.event.workflow_run.html_url }}
       RUN_ID: ${{ github.event.workflow_run.id }}
       REPO: ${{ github.repository }}
-      # Any non-success terminal conclusion (failure, timed_out, cancelled,
-      # action_required, …) means develop is not green and must alarm.
-      IS_RED: ${{ github.event.workflow_run.conclusion != 'success' }}
+      # A genuine break surfaces as failure/timed_out/action_required on the
+      # latest commit and must alarm. `cancelled` is excluded: the conformance
+      # workflows set cancel-in-progress, so every newer develop push cancels the
+      # in-flight run — benign, and the superseding run reports the true status.
+      # Alarming on it produced stuck false-positive develop-red issues (#1672).
+      IS_RED: ${{ github.event.workflow_run.conclusion != 'success' && github.event.workflow_run.conclusion != 'cancelled' }}
 
     steps:
       # The alarm builds its email body from a committed Python script, so the
@@ -180,7 +183,9 @@ jobs:
             CONC=$(gh run list --repo "$REPO" --workflow "$wf" --branch develop \
               --status completed -L 1 --json conclusion --jq '.[0].conclusion // "none"')
             echo "  $wf -> $CONC"
-            if [ "$CONC" != "success" ] && [ "$CONC" != "none" ]; then
+            # `cancelled` is benign (concurrency-superseded run) — treat it like
+            # "none" so a stray cancel doesn't wedge the issue open. See IS_RED.
+            if [ "$CONC" != "success" ] && [ "$CONC" != "none" ] && [ "$CONC" != "cancelled" ]; then
               ALL_GREEN=false
             fi
           done

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -134,6 +134,14 @@ jobs:
       - name: Generate summary
         if: always()
         run: |
+          # No log means tests never ran (run cancelled, or build failed first).
+          # Bail cleanly — a bare `cat` on the missing file under `bash -e` would
+          # exit 1 and paint a red step on an otherwise-benign cancelled run.
+          if [ ! -f "$GITHUB_WORKSPACE/e2e.log" ]; then
+            echo "## E2E Test Results" >> $GITHUB_STEP_SUMMARY
+            echo ":grey_question: No test log — run was cancelled or failed before tests ran." >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
           echo "## E2E Test Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           if grep -qE "^ok[[:space:]]" "$GITHUB_WORKSPACE/e2e.log" && ! grep -qE "^FAIL" "$GITHUB_WORKSPACE/e2e.log"; then


### PR DESCRIPTION
## Problem

Issue #1672 (🔴 develop CI is RED) was a **false alarm**. develop was green at `9e45d0c8` — all four monitored conformance workflows passed.

What happened: commit `46749a90`'s E2E run was **cancelled** by `cancel-in-progress` when the newer commit `9e45d0c8` pushed. The develop-red alarm counts any non-`success` conclusion — including `cancelled` — as RED, so the benign superseded run fired a P0. Worse, it fired *after* `9e45d0c8`'s close-on-green had already run, so nothing closed it → the issue stuck open.

## Fix

`cancelled` is never "the code on develop is broken" — a genuine break always resurfaces as `failure`/`timed_out` on the latest commit's completed run. So treat cancelled as benign everywhere in the alarm:

- **`ci-health.yml` `IS_RED`** — exclude `cancelled` (no alarm, no issue).
- **`ci-health.yml` close-on-green loop** — treat `cancelled` like `none` so a stray cancel can't wedge the issue open.
- **`e2e-tests.yml` summary step** — secondary noise: the `always()` step's bare `cat e2e.log` exits 1 under `bash -e` when tests never ran, painting a red step on a cancelled run. Guard on the missing log and bail cleanly.

## Verification

- develop confirmed green at `9e45d0c8` (posix/smb/e2e/nfs-kerberos all `success`).
- Workflow YAML parses.
- Summary-guard logic checked: missing log → exit 0; present log → proceeds.

Closes #1672.