### PR TITLE
fix(metadata/sqlite): synchronous=NORMAL to unblock write-heavy flush (#1667)

### DIFF
--- a/pkg/metadata/store/sqlite/config.go
+++ b/pkg/metadata/store/sqlite/config.go
@@ -61,7 +61,13 @@ func (c *SQLiteMetadataStoreConfig) Validate() error {
 // per connection. busy_timeout (milliseconds) lets writers queue behind the
 // single-writer lock instead of failing immediately. journal_mode=WAL improves
 // read/write concurrency for the embedded single-binary workload this store
-// targets. The pragmas are passed via the `_pragma` query parameters that
+// targets. synchronous=NORMAL is the documented WAL pairing: it drops the
+// per-commit fsync to a checkpoint-only fsync, which is what makes a large
+// write-heavy flush (e.g. a multi-GiB buffered write draining thousands of
+// block-record commits) sustainable instead of fsync-bound — modernc.org/sqlite
+// otherwise defaults to FULL. It stays durable across app crashes; only an OS
+// crash between checkpoints can lose the last commits, acceptable for this store.
+// The pragmas are passed via the `_pragma` query parameters that
 // modernc.org/sqlite recognises, so they apply to every pooled connection.
 func (c *SQLiteMetadataStoreConfig) DSN() string {
 	// An in-memory database must be shared across the connection pool, otherwise
@@ -82,7 +88,7 @@ func (c *SQLiteMetadataStoreConfig) DSN() string {
 		busyMS = 5000
 	}
 	return fmt.Sprintf(
-		"%s%s_pragma=foreign_keys(1)&_pragma=busy_timeout(%d)&_pragma=journal_mode(WAL)",
+		"%s%s_pragma=foreign_keys(1)&_pragma=busy_timeout(%d)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)",
 		path, sep, busyMS,
 	)
 }

--- a/pkg/metadata/store/sqlite/config_test.go
+++ b/pkg/metadata/store/sqlite/config_test.go
@@ -1,0 +1,25 @@
+package sqlite
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDSNPragmas locks in the per-connection pragmas. synchronous(NORMAL) in
+// particular is load-bearing for write-heavy flushes (issue #1667): without it
+// modernc.org/sqlite defaults to FULL and fsyncs every commit.
+func TestDSNPragmas(t *testing.T) {
+	c := &SQLiteMetadataStoreConfig{Path: "/tmp/x.db", BusyTimeout: 5 * time.Second}
+	dsn := c.DSN()
+	for _, want := range []string{
+		"_pragma=foreign_keys(1)",
+		"_pragma=busy_timeout(5000)",
+		"_pragma=journal_mode(WAL)",
+		"_pragma=synchronous(NORMAL)",
+	} {
+		if !strings.Contains(dsn, want) {
+			t.Errorf("DSN missing %q\n got: %s", want, dsn)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`dittofs-sqlite-s3` fails the `seq-write-buffered` bench workload (4×1g buffered write, single fsync at close) with `end_fsync ... EIO`, while the badger backend passes. Same S3 block store — the only axis that moves is the metadata engine.

## Root cause

The sqlite store pins `MaxOpenConns(1)`, so intra-process lock contention isn't the issue. The DSN sets `journal_mode(WAL)` but omits `synchronous`, so modernc.org/sqlite defaults to **FULL** — an fsync on *every* commit. A 4 GiB buffered flush drains thousands of block-record commits at close, making the metadata write path fsync-bound (the "append-log / write-path backpressure" from the issue). Badger doesn't fsync per record, so it sustains the same flush.

## Fix

Add `_pragma=synchronous(NORMAL)` to the DSN. `NORMAL` is the documented WAL pairing: it drops per-commit fsyncs to a checkpoint-only fsync, and stays durable across application crashes (only an OS/power crash between checkpoints can lose the last few commits — acceptable for this embedded store). One-pragma change; verify on the next bench matrix rerun.

Closes #1667.