### PR TITLE
fix(dfsbench): postgres/zerofs setup for detached harness (#1671)

### DIFF
--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -97,6 +97,12 @@ func dittofsAddMetadataStore(ctx context.Context, kind dittofsMetaKind) error {
 // pg_hba edit needed. dfsctl then connects over TCP (127.0.0.1) as the freshly
 // created role, which the default `host all all 127.0.0.1/32 scram-sha-256` rule
 // admits with the password set below.
+//
+// Every postgres-user command uses `runuser -u postgres --`, never `su - postgres
+// -c`: the harness launches the whole matrix detached (nohup, no controlling tty
+// / login session), where `su -`'s PAM login shell misbehaves (psql exit 2).
+// runuser sets up no PAM/login/tty session, so it works identically detached or
+// interactive (issue #1671).
 func dittofsProvisionPostgres(ctx context.Context) error {
 	script := fmt.Sprintf(`set -eu
 command -v pg_isready >/dev/null 2>&1 || { apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql; }
@@ -104,11 +110,11 @@ service postgresql start 2>/dev/null || systemctl start postgresql 2>/dev/null |
 # Wait on the local socket as the postgres user — the same path the SQL below
 # connects through — for up to 60s. A fresh apt-install has just created the
 # cluster, and a shorter TCP probe raced the cluster still coming up (psql exit 2).
-for i in $(seq 1 60); do su - postgres -c 'pg_isready -q' 2>/dev/null && break; sleep 1; done
+for i in $(seq 1 60); do runuser -u postgres -- pg_isready -q 2>/dev/null && break; sleep 1; done
 # Fail loudly with cluster diagnostics if it never came up, rather than letting
 # the provisioning psql below fail with a cryptic connection error (exit 2).
-su - postgres -c 'pg_isready -q' 2>/dev/null || { echo 'postgres cluster never became ready:'; pg_lsclusters 2>/dev/null; exit 1; }
-su - postgres -c 'psql -v ON_ERROR_STOP=1' <<SQL
+runuser -u postgres -- pg_isready -q 2>/dev/null || { echo 'postgres cluster never became ready:'; pg_lsclusters 2>/dev/null; exit 1; }
+runuser -u postgres -- psql -v ON_ERROR_STOP=1 <<SQL
 DROP DATABASE IF EXISTS %[1]s;
 DO $do$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='%[2]s') THEN CREATE ROLE %[2]s LOGIN PASSWORD '%[3]s'; END IF; END $do$;
 CREATE DATABASE %[1]s OWNER %[2]s;

--- a/internal/dfsbench/backend/zerofs.go
+++ b/internal/dfsbench/backend/zerofs.go
@@ -94,7 +94,13 @@ func zerofsSetup(ctx context.Context, env BackendEnv) error {
 	// `rpc.nfsd 0` is required to actually tear them down; then wait until :2049 is
 	// genuinely free before zerofs tries to claim it. Stop (not disable) the units
 	// so a following re-export backend's zerofsTeardown can start knfsd again.
-	_ = exec.Sh(ctx, "sh", "-c", "pkill -9 -f 'zerofs run' 2>/dev/null; systemctl stop nfs-server nfs-kernel-server nfs-mountd 2>/dev/null; exportfs -ua 2>/dev/null; for i in $(seq 1 20); do rpc.nfsd 0 2>/dev/null; ss -ltn 2>/dev/null | grep -q ':2049 ' || break; sleep 1; done; true")
+	//
+	// Match the leftover zerofs by exact process name (-x zerofs), never
+	// `-f 'zerofs run'`: this cleanup runs in an `sh -c` whose own argv contains
+	// "zerofs run", so `pkill -f 'zerofs run'` would SIGKILL this very shell before
+	// the rpc.nfsd/wait loop runs, reintroducing the :2049 race (same self-kill
+	// pitfall documented for `-x dfs` in dittofs.go).
+	_ = exec.Sh(ctx, "sh", "-c", "pkill -9 -x zerofs 2>/dev/null; systemctl stop nfs-server nfs-kernel-server nfs-mountd 2>/dev/null; exportfs -ua 2>/dev/null; for i in $(seq 1 20); do rpc.nfsd 0 2>/dev/null; ss -ltn 2>/dev/null | grep -q ':2049 ' || break; sleep 1; done; true")
 	return zerofsStart(ctx)
 }
 
@@ -200,9 +206,12 @@ func zerofsStart(ctx context.Context) error {
 // sends the signal, so without the wait a following cache wipe or restart races
 // a process still holding the LSM cache dir open.
 func zerofsStop(ctx context.Context) error {
-	_ = exec.Sh(ctx, "sh", "-c", "pkill -f 'zerofs run' || true")
+	// Match by exact name (-x zerofs), not `-f 'zerofs run'`: the wait shell's own
+	// argv contains "zerofs run", so `pgrep -f` self-matches and the loop would
+	// never confirm exit (hangs the full window). Same self-kill pitfall as -x dfs.
+	_ = exec.Sh(ctx, "sh", "-c", "pkill -x zerofs || true")
 	for i := 0; i < 50; i++ {
-		if exec.Sh(ctx, "sh", "-c", "! pgrep -f 'zerofs run' >/dev/null 2>&1") == nil {
+		if exec.Sh(ctx, "sh", "-c", "! pgrep -x zerofs >/dev/null 2>&1") == nil {
 			return nil
 		}
 		time.Sleep(200 * time.Millisecond)


### PR DESCRIPTION
## Problem

`dfsbench run --remote` launches the matrix detached (`nohup sh /root/driver.sh &` — no controlling tty / login session). Two cells set up fine when the identical commands run over interactive ssh, but fail from the detached driver:

- **postgres** — `su - postgres -c 'psql ...'` fails (psql exit 2). `su -` spins up a PAM login shell that misbehaves without a tty.
- **zerofs** — `systemctl stop nfs-kernel-server` can leave the in-kernel `[nfsd]` threads still holding `:2049`, so zerofs's own userspace NFS server can't bind → mount exit 32.

## Fix

- **postgres**: provision over the local unix socket via `runuser -u postgres -- psql` (no PAM/login/tty setup — works identically detached or interactive), dropping the TCP+trust fallback. The `127.0.0.1/32 trust` HBA line is still appended for `dfs`'s own runtime TCP password connection.
- **zerofs**: add `rpc.nfsd 0` (forces the kernel to drop to zero server threads — what actually releases the socket) and wait for `:2049` to be free before starting zerofs.

Both are harness-side; verify on the next `dfsbench run --remote --systems dittofs-postgres-s3-nfs3,zerofs-nfs3`.

Closes #1671.