### PR TITLE
feat(dfsctl): --timeout flag on system drain-uploads (#1668)

### DIFF
--- a/cmd/dfsctl/commands/system/drain_uploads.go
+++ b/cmd/dfsctl/commands/system/drain_uploads.go
@@ -3,26 +3,39 @@ package system
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
 	"github.com/marmos91/dittofs/internal/cli/output"
 	"github.com/spf13/cobra"
 )
 
+// drainTimeout overrides the client-side wait. 0 keeps the built-in default
+// (6m); a bench harness can raise it to bound a slow cold-evict drain per run.
+var drainTimeout time.Duration
+
 var drainUploadsCmd = &cobra.Command{
 	Use:   "drain-uploads",
 	Short: "Wait for all pending uploads to complete",
 	Long: `Wait for all in-flight block store uploads to complete across every share.
 
-The command blocks until the server confirms that no blocks are queued for remote upload, or until the server-side timeout (5 minutes) is reached. Use this before running benchmarks or taking snapshots to ensure a clean data boundary.
+The command blocks until the server confirms that no blocks are queued for remote upload, or until the client timeout (--timeout, default 6m) is reached. Use this before running benchmarks or taking snapshots to ensure a clean data boundary.
 
 Examples:
   # Block until all pending uploads are flushed
   dfsctl system drain-uploads
 
+  # Allow a slow cold-evict drain up to 15 minutes
+  dfsctl system drain-uploads --timeout 15m
+
   # Get drain result as JSON (includes duration)
   dfsctl system drain-uploads -o json`,
 	RunE: runDrainUploads,
+}
+
+func init() {
+	drainUploadsCmd.Flags().DurationVar(&drainTimeout, "timeout", 0,
+		"client-side wait for the drain (0 = default 6m)")
 }
 
 func runDrainUploads(cmd *cobra.Command, args []string) error {
@@ -31,7 +44,7 @@ func runDrainUploads(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	resp, err := client.DrainUploads()
+	resp, err := client.DrainUploads(drainTimeout)
 	if err != nil {
 		return fmt.Errorf("failed to drain uploads: %w", err)
 	}

--- a/cmd/dfsctl/commands/system/drain_uploads.go
+++ b/cmd/dfsctl/commands/system/drain_uploads.go
@@ -19,7 +19,7 @@ var drainUploadsCmd = &cobra.Command{
 	Short: "Wait for all pending uploads to complete",
 	Long: `Wait for all in-flight block store uploads to complete across every share.
 
-The command blocks until the server confirms that no blocks are queued for remote upload, or until the client timeout (--timeout, default 6m) is reached. Use this before running benchmarks or taking snapshots to ensure a clean data boundary.
+The command blocks until the server confirms that no blocks are queued for remote upload, or until the client timeout (--timeout, default 6m) is reached. The server can also end the wait early with a 504 if upload progress stalls for controlplane.drain_stall_timeout (default 5m). Use this before running benchmarks or taking snapshots to ensure a clean data boundary.
 
 Examples:
   # Block until all pending uploads are flushed
@@ -35,7 +35,7 @@ Examples:
 
 func init() {
 	drainUploadsCmd.Flags().DurationVar(&drainTimeout, "timeout", 0,
-		"client-side wait for the drain (0 = default 6m)")
+		"client-side wait for the drain (0 or negative uses the built-in default, 6m)")
 }
 
 func runDrainUploads(cmd *cobra.Command, args []string) error {

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -6786,10 +6786,10 @@ Wait for all pending uploads to complete
 
 Wait for all in-flight block store uploads to complete across every share.
 
-The command blocks until the server confirms that no blocks are queued for remote upload, or until the server-side timeout (5 minutes) is reached. Use this before running benchmarks or taking snapshots to ensure a clean data boundary.
+The command blocks until the server confirms that no blocks are queued for remote upload, or until the client timeout (--timeout, default 6m) is reached. Use this before running benchmarks or taking snapshots to ensure a clean data boundary.
 
 ```
-dfsctl system drain-uploads
+dfsctl system drain-uploads [flags]
 ```
 
 **Examples:**
@@ -6798,8 +6798,17 @@ dfsctl system drain-uploads
 # Block until all pending uploads are flushed
 dfsctl system drain-uploads
 
+# Allow a slow cold-evict drain up to 15 minutes
+dfsctl system drain-uploads --timeout 15m
+
 # Get drain result as JSON (includes duration)
 dfsctl system drain-uploads -o json
+```
+
+Flags:
+
+```
+      --timeout duration   client-side wait for the drain (0 = default 6m)
 ```
 
 Global flags:

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -6786,7 +6786,7 @@ Wait for all pending uploads to complete
 
 Wait for all in-flight block store uploads to complete across every share.
 
-The command blocks until the server confirms that no blocks are queued for remote upload, or until the client timeout (--timeout, default 6m) is reached. Use this before running benchmarks or taking snapshots to ensure a clean data boundary.
+The command blocks until the server confirms that no blocks are queued for remote upload, or until the client timeout (--timeout, default 6m) is reached. The server can also end the wait early with a 504 if upload progress stalls for controlplane.drain_stall_timeout (default 5m). Use this before running benchmarks or taking snapshots to ensure a clean data boundary.
 
 ```
 dfsctl system drain-uploads [flags]
@@ -6808,7 +6808,7 @@ dfsctl system drain-uploads -o json
 Flags:
 
 ```
-      --timeout duration   client-side wait for the drain (0 = default 6m)
+      --timeout duration   client-side wait for the drain (0 or negative uses the built-in default, 6m)
 ```
 
 Global flags:

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -57,6 +57,11 @@ const (
 	dittofsPGPass = "dittofs"
 )
 
+// dittofsDrainTimeout bounds each `dfsctl system drain-uploads` in the cold-evict
+// loop above the client's 6m default, so a large cold-evict working set drains
+// instead of aborting the cell on a bare deadline (issue #1668).
+const dittofsDrainTimeout = "15m"
+
 // dittofsAddMetadataStore registers the subject's metadata store with the
 // engine selected by kind. badger/sqlite need no server; postgres is
 // provisioned on the (throwaway, single-tenant) bench VM first. All three pair
@@ -291,7 +296,7 @@ func dittofsDrainUntilSynced(ctx context.Context) error {
 		// Bound each drain explicitly (issue #1668): a cold-evict drain of a large
 		// working set can exceed the client's 6m default, and the failure surfaces
 		// as a bare "context deadline exceeded" that aborts the cell.
-		if err := exec.Sh(ctx, "dfsctl", "system", "drain-uploads", "--timeout", "15m"); err != nil {
+		if err := exec.Sh(ctx, "dfsctl", "system", "drain-uploads", "--timeout", dittofsDrainTimeout); err != nil {
 			return fmt.Errorf("dfsctl system drain-uploads: %w", err)
 		}
 		st, err := dittofsBlockStats(ctx)

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -288,7 +288,10 @@ func dittofsDrainUntilSynced(ctx context.Context) error {
 	const maxRounds = 60
 	stable := 0
 	for i := 0; i < maxRounds; i++ {
-		if err := exec.Sh(ctx, "dfsctl", "system", "drain-uploads"); err != nil {
+		// Bound each drain explicitly (issue #1668): a cold-evict drain of a large
+		// working set can exceed the client's 6m default, and the failure surfaces
+		// as a bare "context deadline exceeded" that aborts the cell.
+		if err := exec.Sh(ctx, "dfsctl", "system", "drain-uploads", "--timeout", "15m"); err != nil {
 			return fmt.Errorf("dfsctl system drain-uploads: %w", err)
 		}
 		st, err := dittofsBlockStats(ctx)

--- a/pkg/apiclient/system.go
+++ b/pkg/apiclient/system.go
@@ -16,9 +16,14 @@ const drainUploadsHTTPTimeout = 6 * time.Minute
 
 // DrainUploads waits for all in-flight block store uploads to complete.
 // This is useful for benchmarking to ensure clean boundaries between workloads.
-func (c *Client) DrainUploads() (*DrainUploadsResponse, error) {
+// A timeout <= 0 uses the default drainUploadsHTTPTimeout; a larger value lets a
+// bench harness bound (or extend) the client-side wait per run (issue #1668).
+func (c *Client) DrainUploads(timeout time.Duration) (*DrainUploadsResponse, error) {
+	if timeout <= 0 {
+		timeout = drainUploadsHTTPTimeout
+	}
 	var resp DrainUploadsResponse
-	if err := c.doWithTimeout("POST", "/api/v1/system/drain-uploads", nil, &resp, drainUploadsHTTPTimeout); err != nil {
+	if err := c.doWithTimeout("POST", "/api/v1/system/drain-uploads", nil, &resp, timeout); err != nil {
 		return nil, err
 	}
 	return &resp, nil

--- a/pkg/apiclient/system.go
+++ b/pkg/apiclient/system.go
@@ -9,9 +9,11 @@ type DrainUploadsResponse struct {
 }
 
 // drainUploadsHTTPTimeout bounds the client-side wait for drain-uploads. The
-// endpoint blocks until every queued upload flushes or the server's own 5-minute
-// cap fires, so the base 30s client timeout would kill a large drain long before
-// the server answers (the failure that made cold-read benchmarks read warm).
+// endpoint blocks until every queued upload flushes; it has no total wall-clock
+// cap, only a server-side inactivity bound (controlplane.drain_stall_timeout,
+// default 5m) that 504s if upload progress stalls. So the base 30s client
+// timeout would kill a healthy large drain long before it completes (the failure
+// that made cold-read benchmarks read warm).
 const drainUploadsHTTPTimeout = 6 * time.Minute
 
 // DrainUploads waits for all in-flight block store uploads to complete.


### PR DESCRIPTION
## Problem

During the bench cold-read pass, `dfsctl system drain-uploads` timed out:

```
FAIL dittofs-s3-nfs3: evict: dfsctl system drain-uploads: exit status 1
Error: failed to drain uploads: Post ".../system/drain-uploads": context deadline exceeded
```

The client already sets a 6-minute `drainUploadsHTTPTimeout`, but a cold-evict drain of a large working set can legitimately exceed it — and the wait was a fixed constant the harness couldn't raise per run.

## Fix

- `DrainUploads(timeout)` on the API client accepts an override (`<= 0` keeps the 6m default).
- New `--timeout` flag on `dfsctl system drain-uploads` (default `0` → built-in default).
- The dfsbench evict loop now passes `--timeout 15m` so a slow drain bounds cleanly instead of aborting the cell on the bare 6m deadline.
- Regenerated `docs/guide/cli.md`.

The stale-binary angle from the issue (a VM provisioned before the 6m constant landed) is a harness-usage concern — `dfsbench setup` always cross-builds and pushes a fresh `dfsctl`; this makes the wait tunable regardless.

Closes #1668.