### PR TITLE
test(block/fs): fix Windows rollup-test flake (force + manifest wiring)

### DIFF
--- a/pkg/block/local/fs/chunkparams_rollup_test.go
+++ b/pkg/block/local/fs/chunkparams_rollup_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/chunker"
 	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
@@ -23,6 +24,14 @@ func TestRollup_ChunkParams_SmallChunksReadBack(t *testing.T) {
 		RollupWorkers:   1,
 		StabilizationMS: 1,
 		RollupStore:     rs,
+		// Persist the rollup manifest into fbs so the post-rollup read resolves
+		// via the CAS-manifest path (fillFromCASManifest → blockStore). Without
+		// it ListFileChunks is empty and the read only succeeds while the bytes
+		// still sit in the un-trimmed append log — a race that flaked on CI once
+		// the rollup won (ReadPayloadAt "file chunk not found").
+		ObjectIDPersister: func(ctx context.Context, payloadID string, blocks []block.ChunkRef, _ block.ObjectID) error {
+			return fbs.persist(ctx, payloadID, blocks)
+		},
 		// 64 KiB floor → effective avg ~94 KiB (see chunker distribution test).
 		ChunkParams: chunker.Params{Min: 64 << 10, Avg: 256 << 10, Max: 512 << 10},
 	})

--- a/pkg/block/local/fs/force_rollup_flake_test.go
+++ b/pkg/block/local/fs/force_rollup_flake_test.go
@@ -1,0 +1,49 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+// TestForceRollupForTest_FlushesUnstableInterval is the Windows-flake
+// regression (a rollup test intermittently failed "file chunk not found" on
+// CI). Root cause: ForceRollupForTest ran the pass with force=false, so it was
+// gated by the stabilization window — a just-written interval is "not stable at
+// this instant", the pass was a silent no-op that returned nil, and the
+// following read found no chunk. On a coarse clock (Windows) or a loaded runner
+// the race surfaced; on fast hardware the background pool usually hid it.
+//
+// The helper must flush deterministically regardless of how recently the data
+// was written. A stabilization window far larger than the test's lifetime makes
+// force=false provably a no-op, so this fails with the old behavior and passes
+// once ForceRollupForTest bypasses the gate (force=true).
+func TestForceRollupForTest_FlushesUnstableInterval(t *testing.T) {
+	// 1h stabilization: the background pool cannot roll this up during the
+	// test, so ForceRollupForTest is the only thing that can — isolating the
+	// helper's determinism from the async pool.
+	bc, rs := newRollupFSStore(t, 1<<30, 3_600_000)
+	ctx := context.Background()
+	const pid = "file-force-flush"
+
+	payload := bytes.Repeat([]byte{0xC7}, 64*1024)
+	if err := bc.AppendWrite(ctx, pid, payload, 0); err != nil {
+		t.Fatalf("AppendWrite: %v", err)
+	}
+	if err := bc.ForceRollupForTest(ctx, pid); err != nil {
+		t.Fatalf("ForceRollupForTest: %v", err)
+	}
+
+	// The write must have reached CAS: at least one chunk exists and
+	// rollup_offset advanced past the header.
+	if n := countLocalChunks(t, bc); n < 1 {
+		t.Fatalf("ForceRollupForTest did not flush the interval: 0 chunks (force=false silent no-op regression)")
+	}
+	off, err := rs.GetRollupOffset(ctx, pid)
+	if err != nil {
+		t.Fatalf("GetRollupOffset: %v", err)
+	}
+	if off <= uint64(logHeaderSize) {
+		t.Fatalf("rollup_offset did not advance: got %d want > %d", off, logHeaderSize)
+	}
+}

--- a/pkg/block/local/fs/rollup_logindex_regression_test.go
+++ b/pkg/block/local/fs/rollup_logindex_regression_test.go
@@ -48,26 +48,20 @@ func TestRollup_OutOfOrderArrivals_AllRecordsRolledUp(t *testing.T) {
 		}
 	}
 
-	// All four intervals must eventually roll up. Wait for the log
-	// budget to decrement (the rollup pool fires the ConsumeUpTo +
-	// logBytesTotal.Add(-reclaimed) sequence once chunks are durable).
-	deadline := time.Now().Add(8 * time.Second)
-	for time.Now().Before(deadline) {
-		off, err := rs.GetRollupOffset(ctx, "file-ooo")
-		if err != nil {
-			t.Fatalf("GetRollupOffset: %v", err)
-		}
-		// Expected end-state rollup_offset: header + 4 * (frame + payload).
-		wantOff := uint64(logHeaderSize) + 4*(uint64(recordFrameOverhead)+uint64(payloadLen))
-		if off >= wantOff {
-			break
-		}
-		time.Sleep(25 * time.Millisecond)
+	// All four intervals must roll up. Drive it deterministically instead of
+	// polling the background pool against a wall-clock deadline — that deadline
+	// flaked on loaded CI runners (the pool goroutines starve and the 8s window
+	// lapses). DrainRollups forces every dirty interval through the identical
+	// rollupFileInner path the pool uses, so it still exercises the Direction-1
+	// out-of-order regression while removing the timing dependency.
+	if err := bc.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups: %v", err)
 	}
 	off, err := rs.GetRollupOffset(ctx, "file-ooo")
 	if err != nil {
 		t.Fatalf("GetRollupOffset: %v", err)
 	}
+	// Expected end-state rollup_offset: header + 4 * (frame + payload).
 	wantOff := uint64(logHeaderSize) + 4*(uint64(recordFrameOverhead)+uint64(payloadLen))
 	if off < wantOff {
 		t.Fatalf("rollup_offset did not advance to EOF: got %d want >= %d (pre-fix bug shape)", off, wantOff)
@@ -83,16 +77,10 @@ func TestRollup_OutOfOrderArrivals_AllRecordsRolledUp(t *testing.T) {
 		t.Fatalf("expected at least 4 chunks in blocks/, found %d — Direction-1 bug-shape regression", n)
 	}
 
-	// logBytesTotal must have dropped to zero (every dirty interval
-	// consumed). A non-zero residue would indicate the log-budget
-	// release missed an interval.
-	deadline = time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if bc.logBytesTotal.Load() == 0 {
-			break
-		}
-		time.Sleep(25 * time.Millisecond)
-	}
+	// logBytesTotal must have dropped to zero (every dirty interval consumed).
+	// DrainRollups drove every interval to completion above, so this is now a
+	// direct assertion — a non-zero residue means the log-budget release missed
+	// an interval.
 	if got := bc.logBytesTotal.Load(); got != 0 {
 		t.Fatalf("logBytesTotal nonzero after full out-of-order rollup: %d", got)
 	}

--- a/pkg/block/local/fs/test_hooks.go
+++ b/pkg/block/local/fs/test_hooks.go
@@ -154,8 +154,16 @@ func (bc *FSStore) HeaderRollupOffsetForTest(payloadID string) uint64 {
 // ForceRollupForTest runs one rollup pass synchronously on payloadID. The
 // conformance suite uses this when the ambient worker pool is disabled or
 // timing would otherwise be flaky.
+//
+// It passes force=true (the snapshot-drain path) so the pass bypasses the
+// stabilization-window gate. With force=false a just-written interval is "not
+// stable at this instant", so the pass was a silent no-op returning nil — and a
+// following read failed "file chunk not found". That raced the background pool
+// and surfaced intermittently on CI (notably Windows, whose coarse clock makes
+// two successive time.Now() calls equal). Callers that need multiple intervals
+// flushed already loop on this helper.
 func (bc *FSStore) ForceRollupForTest(ctx context.Context, payloadID string) error {
-	return bc.rollupFile(ctx, payloadID, false)
+	return bc.rollupFile(ctx, payloadID, true)
 }
 
 // ReopenForTest closes no store — it constructs a fresh FSStore on


### PR DESCRIPTION
## Problem

`pkg/block/local/fs` rollup tests failed intermittently on the **Windows CI runner** — `ReadPayloadAt: file chunk not found` (`TestRollup_ChunkParams_SmallChunksReadBack`) or an 8s rollup deadline (`TestRollup_OutOfOrderArrivals_AllRecordsRolledUp`). Different test each run, always the same package, never reproduced on fast hardware — a classic timing flake. Root-caused two independent bugs, both masked on fast hardware by winning a race.

## Root cause

**1. `ForceRollupForTest` didn't actually force.** It called `rollupFile(ctx, pid, false)`. With `force=false` the pass is gated by the stabilization window (`EarliestStable`): a just-written interval is *"not stable at this instant"* (see `TestIntervalTree_EarliestStable_HonorsTimestamp`), so the pass was a **silent no-op returning nil**. The test then raced the background pool, and on Windows — whose coarse clock makes two successive `time.Now()` equal — the read hit the un-rolled manifest and missed. Fix: pass `force=true` (the snapshot-drain semantics `DrainRollups` already uses). Every other `ForceRollupForTest` caller only becomes more reliable.

**2. `TestRollup_ChunkParams` wired no `ObjectIDPersister`.** So rollup never populated the FileChunk manifest (`if persister != nil` skips it), and the post-rollup read only succeeded *while the bytes still sat in the un-trimmed append log* — a race, not the "CAS-manifest read path" the test claims to verify. Once `force=true` made the rollup deterministic, the missing manifest surfaced the failure every time. Fix: wire `fbs.persist` like every other read-back test. (In production the engine wires both persister and blockStore — this was purely a test-harness gap.)

**3. `TestRollup_OutOfOrderArrivals` polled an 8s wall-clock deadline** for the background pool — which starves on a loaded runner. Drive it via `DrainRollups` (identical `rollupFileInner` path, no timing dependency).

## Verification

- New `TestForceRollupForTest_FlushesUnstableInterval` uses a 1h stabilization window so `force=false` **deterministically** fails (proves the root cause) and passes with the fix.
- The three tests pass **25× under `-race`**; full `pkg/block/local/fs` package green under `-race` and `GOMAXPROCS=1`; `pkg/block/engine` (other `ForceRollupForTest` callers) green.

**Scope:** the only non-`_test.go` edit is `ForceRollupForTest` in `test_hooks.go` — a `*ForTest` hook that ships in the build but is invoked only by tests; no production runtime path changes. Everything else is `_test.go`.