### PR TITLE
fix(snapshot): verify decryptability, not mere presence (#1681)

### DIFF
--- a/pkg/controlplane/runtime/snapshot_encryption_integration_test.go
+++ b/pkg/controlplane/runtime/snapshot_encryption_integration_test.go
@@ -186,17 +186,36 @@ func (f *encryptedFixture) seedEncrypted(payloads [][]byte) []block.ContentHash 
 		if err := f.enc.Put(context.Background(), h, p); err != nil {
 			f.t.Fatalf("encrypted Put: %v", err)
 		}
-		// Post-#1493 durability is block-only: also seed a packed block per
-		// hash (BlockID = hash string) so the verify gate's GetBlockRange probe
-		// against the encrypted remote finds it. setBackupHashes marks each
-		// hash synced to that block locator.
-		if err := f.enc.PutBlock(context.Background(), h.String(), bytes.NewReader(p)); err != nil {
-			f.t.Fatalf("encrypted PutBlock: %v", err)
-		}
+		// Post-#1493 durability is block-only: seed a real sealed frame as the
+		// packed block so the verify gate's ReadChunk probe deframes and
+		// decrypt-verifies it. seedBlockFrame records the frame's wire extent
+		// on the hash's locator.
+		f.seedBlockFrame(h, p)
 		hashes = append(hashes, h)
 	}
-	f.setBackupHashes(hashes)
+	f.backup.setHashes(hashes)
 	return hashes
+}
+
+// seedBlockFrame seals plaintext into an encryption frame, stores it as the
+// packed block object under blockID = hash, and marks the hash synced to a
+// locator carrying the frame's wire extent (WireLength) so the verify gate
+// reads the chunk back through ReadChunk rather than a bare presence probe.
+func (f *encryptedFixture) seedBlockFrame(h block.ContentHash, plaintext []byte) {
+	f.t.Helper()
+	wire, err := f.enc.SealChunk(context.Background(), h, plaintext)
+	if err != nil {
+		f.t.Fatalf("SealChunk: %v", err)
+	}
+	if err := f.inner.PutBlock(context.Background(), h.String(), bytes.NewReader(wire)); err != nil {
+		f.t.Fatalf("PutBlock (frame): %v", err)
+	}
+	if err := f.backup.MarkSynced(context.Background(), h, block.ChunkLocator{
+		BlockID:    h.String(),
+		WireLength: int64(len(wire)),
+	}); err != nil {
+		f.t.Fatalf("MarkSynced: %v", err)
+	}
 }
 
 func testEncryptionManifestAndVerify(t *testing.T) {
@@ -309,13 +328,13 @@ func testEncryptionUnframedFailsVerify(t *testing.T) {
 	fx := newEncryptedFixture(t)
 	defer fx.close()
 
-	// Seed two real encrypted blocks, then inject a THIRD block whose body
-	// was written straight to the inner remote WITHOUT the encryption frame
-	// (simulating an externally-mutated / pre-encryption block). The
-	// manifest lists its plaintext hash, but the verify HEAD-probe must
-	// reject it: EncryptedRemote.Head parses the wire frame and returns a
-	// non-NotFound error for an unframed body, so verify fails rather than
-	// reporting hollow durability over a block it cannot decrypt.
+	// Seed two real encrypted blocks, then inject a THIRD packed block whose
+	// body was written WITHOUT the encryption frame (simulating an externally-
+	// mutated / pre-encryption block) under a valid block locator. The manifest
+	// lists its hash, but the verify gate reads each chunk back through
+	// ReadChunk: deframing the raw body fails (ErrCiphertextWithoutFrame), so
+	// verify fails rather than reporting hollow durability over a block it
+	// cannot decrypt.
 	good := [][]byte{
 		bytes.Repeat([]byte{0xa1}, 2048),
 		bytes.Repeat([]byte{0xb2}, 2048),
@@ -324,13 +343,20 @@ func testEncryptionUnframedFailsVerify(t *testing.T) {
 
 	unframed := bytes.Repeat([]byte{0xc3}, 2048)
 	unframedHash := block.ContentHash(blake3.Sum256(unframed))
-	if err := fx.inner.Put(context.Background(), unframedHash, unframed); err != nil {
-		t.Fatalf("inner Put (unframed): %v", err)
+	// Present in the PACKED keyspace under a valid locator, but not a frame.
+	if err := fx.inner.PutBlock(context.Background(), unframedHash.String(), bytes.NewReader(unframed)); err != nil {
+		t.Fatalf("inner PutBlock (unframed): %v", err)
+	}
+	if err := fx.backup.MarkSynced(context.Background(), unframedHash, block.ChunkLocator{
+		BlockID:    unframedHash.String(),
+		WireLength: int64(len(unframed)),
+	}); err != nil {
+		t.Fatalf("MarkSynced (unframed): %v", err)
 	}
 
 	// Manifest = two framed blocks + the unframed one.
 	allHashes := append(append([]block.ContentHash{}, hashes...), unframedHash)
-	fx.setBackupHashes(allHashes)
+	fx.backup.setHashes(allHashes)
 
 	ctx := fx.ctx()
 	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{})

--- a/pkg/controlplane/runtime/snapshot_encryption_integration_test.go
+++ b/pkg/controlplane/runtime/snapshot_encryption_integration_test.go
@@ -27,7 +27,7 @@ import (
 // manifest / verify / restore path against an encryption-enabled remote
 // (issue #816). The encryption decorator stores framed CIPHERTEXT in the
 // inner remote but keeps the PLAINTEXT BLAKE3 as the CAS storage key:
-// dedup, GC, the snapshot manifest, and the verify HEAD-probe must all
+// dedup, GC, the snapshot manifest, and the verify probe must all
 // operate on the plaintext content hash, never on a ciphertext-derived
 // key.
 //
@@ -36,16 +36,16 @@ import (
 //
 //   - Manifest entries are the plaintext content hashes used to Put, so
 //     the hashes recorded on disk address the encrypted blocks correctly.
-//   - The verify gate's per-hash Head probe resolves every manifest hash
-//     against the encrypted remote (Head parses the wire frame to derive
-//     plaintext size) and the snapshot reaches ready + remote-durable.
+//   - The verify gate's per-hash probe reads every manifest chunk back
+//     through ReadChunk (deframe + authenticated decrypt) against the
+//     encrypted remote, and the snapshot reaches ready + remote-durable.
 //   - Multi-chunk blocks round-trip byte-for-byte back through the
 //     decorator's authenticated decrypt — the restore-time read path
 //     reconstructs the exact plaintext.
-//   - A manifest hash whose block is present in the inner store but
+//   - A manifest hash whose block is present in the packed keyspace but
 //     UNFRAMED (e.g. written bypassing the encryption decorator) fails
-//     verify rather than masquerading as durable — the probe really hits
-//     the encrypted identity, not a raw presence check.
+//     verify rather than masquerading as durable — the probe decrypt-
+//     verifies the chunk, it is not a raw presence check.
 func TestSnapshot_EncryptionInteraction(t *testing.T) {
 	t.Run("ManifestHashesArePlaintextAndVerifyProbesEncryptedRemote", testEncryptionManifestAndVerify)
 	t.Run("MultiChunkRoundTripBytesCorrect", testEncryptionMultiChunkRoundTrip)

--- a/pkg/snapshot/verify.go
+++ b/pkg/snapshot/verify.go
@@ -22,7 +22,9 @@ type HashLocatorResolver interface {
 }
 
 // probeHashDurable proves hash is durable by resolving its block locator and
-// issuing a one-byte GetBlockRange against the packed blocks/<id> object. Post
+// reading its chunk back out of the packed blocks/<id> object — via ReadChunk
+// (deframe + decrypt-verify) when the wire extent is known, else a one-byte
+// GetBlockRange presence probe. Post
 // storage flip (#1493) durability is block-only: a hash whose locator is
 // standalone (BlockID == "") or absent from the resolver is not block-resident
 // and is reported as block.ErrChunkNotFound — it cannot be proven durable. A
@@ -40,6 +42,19 @@ func probeHashDurable(ctx context.Context, locators HashLocatorResolver, rbs rem
 	if !ok || loc.IsStandalone() {
 		return fmt.Errorf("hash %s has no block locator (standalone or absent): %w",
 			hash, block.ErrChunkNotFound)
+	}
+	// Prove recoverability, not mere presence. When the chunk's wire extent is
+	// known (the carve path always sets it on block-keyed locators) and the
+	// remote can invert its transform, read the chunk through ReadChunk: an
+	// encrypted remote deframes and AEAD-verifies against the hash, so a
+	// present-but-undecryptable block (unframed / externally mutated) fails
+	// verify instead of masquerading as durable. A 1-byte GetBlockRange only
+	// proves the object exists — hollow durability over bytes we can't decrypt.
+	// Fall back to that presence probe when the extent is unknown (WireLength
+	// == 0) or the remote is not a chunk reader.
+	if cr, ok := rbs.(remote.ChunkReader); ok && loc.WireLength > 0 {
+		_, err := cr.ReadChunk(ctx, loc.BlockID, loc.WireOffset, loc.WireLength, hash)
+		return err
 	}
 	_, berr := rbs.GetBlockRange(ctx, loc.BlockID, 0, 1)
 	return berr

--- a/pkg/snapshot/verify.go
+++ b/pkg/snapshot/verify.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"sync"
 
+	"lukechampine.com/blake3"
+
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/remote"
@@ -23,8 +25,8 @@ type HashLocatorResolver interface {
 
 // probeHashDurable proves hash is durable by resolving its block locator and
 // reading its chunk back out of the packed blocks/<id> object — via ReadChunk
-// (deframe + decrypt-verify) when the wire extent is known, else a one-byte
-// GetBlockRange presence probe. Post
+// (deframe + decrypt + BLAKE3 content-verify) when the wire extent is known,
+// else a one-byte GetBlockRange presence probe. Post
 // storage flip (#1493) durability is block-only: a hash whose locator is
 // standalone (BlockID == "") or absent from the resolver is not block-resident
 // and is reported as block.ErrChunkNotFound — it cannot be proven durable. A
@@ -53,8 +55,19 @@ func probeHashDurable(ctx context.Context, locators HashLocatorResolver, rbs rem
 	// Fall back to that presence probe when the extent is unknown (WireLength
 	// == 0) or the remote is not a chunk reader.
 	if cr, ok := rbs.(remote.ChunkReader); ok && loc.WireLength > 0 {
-		_, err := cr.ReadChunk(ctx, loc.BlockID, loc.WireOffset, loc.WireLength, hash)
-		return err
+		plain, rerr := cr.ReadChunk(ctx, loc.BlockID, loc.WireOffset, loc.WireLength, hash)
+		if rerr != nil {
+			return rerr
+		}
+		// ReadChunk does not verify BLAKE3 — the base stores and the
+		// compression layer ignore hash (only encryption binds it as AEAD AAD).
+		// Recompute here so "remote durable" means recoverable AND correct:
+		// a plain/compressed remote returning wrong-but-present bytes must fail.
+		if got := block.ContentHash(blake3.Sum256(plain)); got != hash {
+			return fmt.Errorf("hash %s: %w (remote returned %s)",
+				hash, block.ErrChunkContentMismatch, got)
+		}
+		return nil
 	}
 	_, berr := rbs.GetBlockRange(ctx, loc.BlockID, 0, 1)
 	return berr

--- a/pkg/snapshot/verify_test.go
+++ b/pkg/snapshot/verify_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"lukechampine.com/blake3"
+
 	"github.com/marmos91/dittofs/pkg/block"
 	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
 	"github.com/marmos91/dittofs/pkg/snapshot"
@@ -74,6 +76,45 @@ func TestVerifyRemoteDurability_BlockResidentProbesBlock(t *testing.T) {
 	err := snapshot.VerifyRemoteDurability(ctx, res2, rs, hs, 4)
 	if !errors.Is(err, block.ErrChunkNotFound) {
 		t.Fatalf("missing block: errors.Is(ErrChunkNotFound)=false; err=%v", err)
+	}
+}
+
+// TestVerifyRemoteDurability_ContentMismatchFailsWhenExtentKnown: when the
+// locator carries a wire extent (WireLength>0), the probe reads the chunk back
+// via ReadChunk and recomputes BLAKE3. A plain remote returning wrong-but-
+// present bytes (ReadChunk ignores hash on base stores) must fail with
+// ErrChunkContentMismatch, not pass as durable. Correct bytes under their true
+// hash still pass.
+func TestVerifyRemoteDurability_ContentMismatchFailsWhenExtentKnown(t *testing.T) {
+	ctx := context.Background()
+	rs := remotememory.New()
+	t.Cleanup(func() { _ = rs.Close() })
+
+	body := []byte("the-actual-stored-bytes")
+	trueHash := block.ContentHash(blake3.Sum256(body))
+	if err := rs.PutBlock(ctx, "blk", bytes.NewReader(body)); err != nil {
+		t.Fatalf("PutBlock: %v", err)
+	}
+
+	// A hash that does NOT match the stored content.
+	claimed := gateHash(42)
+	if claimed == trueHash {
+		t.Fatal("test setup: claimed hash collided with content hash")
+	}
+	hs := block.NewHashSet(1)
+	hs.Add(claimed)
+	res := fakeLocators{claimed: block.ChunkLocator{BlockID: "blk", WireLength: int64(len(body))}}
+	err := snapshot.VerifyRemoteDurability(ctx, res, rs, hs, 4)
+	if !errors.Is(err, block.ErrChunkContentMismatch) {
+		t.Fatalf("content mismatch: errors.Is(ErrChunkContentMismatch)=false; err=%v", err)
+	}
+
+	// Correct content under its true hash passes.
+	hs2 := block.NewHashSet(1)
+	hs2.Add(trueHash)
+	res2 := fakeLocators{trueHash: block.ChunkLocator{BlockID: "blk", WireLength: int64(len(body))}}
+	if err := snapshot.VerifyRemoteDurability(ctx, res2, rs, hs2, 4); err != nil {
+		t.Fatalf("correct content: got %v, want nil", err)
 	}
 }
 


### PR DESCRIPTION
Closes #1681.

## Problem

The snapshot remote-durability verify gate probed each manifest hash with a **1-byte `GetBlockRange`** — a *presence* check only. `EncryptedRemote.GetBlockRange` is a verbatim passthrough (no deframe/decrypt), so a block that is **present but undecryptable** (unframed / externally mutated / stale policy) passed verify and the snapshot was reported `RemoteDurable=true`. That is hollow durability: green over bytes we cannot recover.

This also caused a develop-red flake: `TestSnapshot_EncryptionInteraction/UnframedBlockUnderManifestHashFailsVerify` passed only by an **incidental keyspace separation** (the unframed body was `inner.Put` into the standalone-CAS `blocks` map while the probe reads the packed `blocksByID` map). When the background CAS→blocks migration (#1493) copies the object into `blocksByID` before verify runs — timing-dependent, CI-only — the presence probe finds it and verify wrongly passes (`WaitForSnapshot err = <nil>`). Confirmed empirically by seeding the unframed bytes into the packed keyspace, which reproduces the failure locally & deterministically. (`#1680`, the commit it landed on, is unrelated — a block/fs test-hook change.)

## Fix

`probeHashDurable` now reads the chunk back through `remote.ChunkReader.ReadChunk` (deframe + AEAD decrypt-verify against the hash) when the locator carries a wire extent (`WireLength > 0`, always set by the carve path), falling back to the 1-byte presence probe when the extent is unknown or the remote is not a chunk reader. An encrypted remote then rejects an undecryptable block (`encryption: stored block is not framed`) → verify fails closed → `ErrSnapshotVerifyFailed`.

The test now seeds a **present** unframed block in the packed keyspace under a valid locator, exercising the real guarantee deterministically (no keyspace accident). Framed blocks are seeded via real `SealChunk` frames with recorded `WireLength`.

## Trade-off (non-blocking)

For **plain** (non-encrypted) remotes with `WireLength > 0`, the probe now reads a full chunk instead of 1 byte. Same number of remote ops per hash, larger payloads — but a *stronger* durability check (proves the whole object is retrievable, not just its first byte, catching truncation the 1-byte peek missed). For encrypted/compressed remotes reading the bytes back is the whole point. If plain-remote verify bandwidth becomes a concern, scoping the deframe-read to transform-applying remotes is a clean follow-up.

## Testing

- `TestSnapshot_EncryptionInteraction` (all subtests) — pass ×3, incl. the previously-flaky unframed case now deterministic
- Full `pkg/controlplane/runtime/...` — green (plain-remote snapshot tests unaffected via the presence fallback)
- `pkg/snapshot/...`, `pkg/block/encryption/...`, `pkg/block/remote/memory/...` — green under `-race`
- `gofmt -s`, `go vet`, `golangci-lint` — clean