### PR TITLE
docs(bench): 2026-07-14 warm re-run results

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -57,7 +57,7 @@ ops/s). **Bold** = DittoFS. Best *real competitor* per row is marked ✦
 | mixed-rw (IOPS) | **1409** | 1983 ✦ | 125 | 5531 | 4455 | 41634 |
 
 ‡ JuiceFS large rand-read (88 IOPS) is an outlier — its 1 GiB working set thrashes
-its local cache on this box; its medium rand-read (42 380) is representative.
+its local cache on this box; its medium rand-read (42 380 IOPS) is representative.
 
 ## Random & metadata — medium files (1 MiB), warm
 
@@ -92,6 +92,10 @@ of ZeroFS on reads.
 | rand-write | **39 059 / 120 062** | 32 113 / 17 112 760 | 77 070 / 400 556 | 57 934 / 152 044 |
 | rand-read | **11 600 / 67 633** | 54 788 / 103 285 | 1 082 130 / 4 328 522 | 4 178 / 7 635 |
 | seq-read | **3 883 / 16 712** | 90 702 / 2 231 370 | 2 040 / 6 259 | 1 221 / 8 454 |
+
+JuiceFS's ~1 s rand-read p50 is the same 1 GiB cache-thrashing outlier flagged ‡
+above (88 IOPS): on this box every large-file random read misses its local cache
+and pays an S3 round trip. It is not the medium-file figure (42 380 IOPS).
 
 ## Analysis
 
@@ -136,6 +140,12 @@ The harness is `cmd/bench` (`dfsbench`), library code under `internal/dfsbench/`
 
 ```sh
 go build -o dfsbench ./cmd/bench
+
+# Run config: just the S3 bucket + endpoint (credentials come from the env, below).
+cat > bench.yaml <<'EOF'
+bucket: dittofs-bench
+endpoint: https://s3.fr-par.scw.cloud
+EOF
 
 # Cloud run: provision one disposable VM, run the managed matrix, collect, tear down.
 dfsbench setup                              # SCW_* env selects type/zone/image

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,7 +1,7 @@
 # DittoFS Performance Benchmarks
 
 Performance of DittoFS (S3 backend) against the S3-backed network filesystems the
-`dfsbench` harness supports — **JuiceFS, s3ql, rclone, s3fs, and ZeroFS** — plus
+`dfsbench` harness supports — **JuiceFS, rclone, s3fs, and ZeroFS** — plus
 **local-disk** as the raw-hardware ceiling. All systems run on one disposable
 Scaleway VM, driven by the same `fio` workloads over the same protocol.
 
@@ -13,22 +13,33 @@ Scaleway VM, driven by the same `fio` workloads over the same protocol.
 
 | | |
 |---|---|
-| Date | 2026-07-10 |
-| DittoFS | `develop` @ `0d79ede1` |
+| Date | 2026-07-14 |
+| DittoFS | `develop` @ `38679f1c` |
 | Harness | `internal/dfsbench` (fio driver + SCW orchestration) |
 | Host | Scaleway `fr-par-1`, single VM, Ubuntu 24.04 |
-| Protocol | **NFSv3** — the only protocol all seven backends share (ZeroFS is NFSv3-only) |
+| Protocol | **NFSv3** — the only protocol all backends share (ZeroFS is NFSv3-only) |
 | Object store | Scaleway Object Storage, `s3.fr-par.scw.cloud` |
-| fio | 4 threads, 30 s/cell, warm pass (+ cold/post-evict where noted) |
+| fio | 4 threads, 30 s/cell, **warm pass only** this cycle |
 | Sizes | medium = 1 MiB, large = 1 GiB |
-| Result | 7/7 backends set up, **0 workload errors** |
+| Result | 6 systems, 82 cells, **0 workload errors** |
+
+> **Coverage caveats for this run.** Warm-only — the cold/post-evict pass was
+> dropped this cycle to avoid a `drain-uploads` stall on the metadata working
+> set, so the cold column is pending a follow-up. **s3ql** was not run (its SCW
+> setup hit an eventual-consistency flake). The **sqlite** and **postgres**
+> DittoFS metadata backends were excluded after `dittofs-sqlite` hard-wedged on
+> the buffered large-write cell (server RSS → 3.1 GB, fio stuck in `D` state 12
+> min) — tracked in [#1667](https://github.com/marmos91/dittofs/issues/1667).
 
 **A note on durability.** DittoFS and ZeroFS are *native* NFS→S3 servers; the
-others (JuiceFS, s3ql, rclone, s3fs) are FUSE/mount filesystems **re-exported**
-over the kernel NFS server. DittoFS writes through to its local block store
-(measured ~189 MB/s to disk) before acknowledging; several competitors
-acknowledge from a RAM/writeback cache. So DittoFS's lower sequential-write
-throughput is partly the cost of a durable local write, not a like-for-like loss.
+others (JuiceFS, rclone, s3fs) are FUSE/mount filesystems **re-exported** over
+the kernel NFS server, so their warm reads are served from the server-side
+kernel page cache. DittoFS writes through to its local block store before
+acknowledging; several competitors acknowledge from a RAM/writeback cache. So
+DittoFS's lower sequential-write throughput is partly the cost of a durable
+local write, and the re-exports' warm-read lead is partly a kernel-page-cache
+free ride — neither is a like-for-like loss. **The fair comparison is DittoFS vs
+ZeroFS**, the only other native NFS→S3 server.
 
 ## Throughput & IOPS — large files (1 GiB), warm
 
@@ -36,14 +47,17 @@ Sequential rows are MB/s; random / metadata / mixed rows are IOPS (metadata =
 ops/s). **Bold** = DittoFS. Best *real competitor* per row is marked ✦
 (local-disk excluded as the ceiling).
 
-| Workload | **DittoFS-S3** | ZeroFS | s3ql | JuiceFS | rclone | s3fs | local-disk ↑ |
-|---|--:|--:|--:|--:|--:|--:|--:|
-| seq-write (MB/s) | **156** | 204 | 310 | 1336 | 1523 | 1775 ✦ | 3287 |
-| seq-read (MB/s) | **677** | 13 | 552 | 1616 | 1181 | 2876 ✦ | 4774 |
-| rand-write 4k (IOPS) | **2365** | 2133 | 1256 | 826 | 17346 ✦ | 2183 | 40883 |
-| rand-read 4k (IOPS) | **7437** † | 2568 | 39563 ✦ | 12418 | fail | 11101 | — |
-| metadata (ops/s) | **239** | 371 | 700 | 1824 ✦ | — | fail | — |
-| mixed-rw (IOPS) | **1256** | 1776 | 4928 ✦ | 281 | — | 4453 | — |
+| Workload | **DittoFS-S3** | ZeroFS | JuiceFS | rclone | s3fs | local-disk ↑ |
+|---|--:|--:|--:|--:|--:|--:|
+| seq-write (MB/s) | **148** | 121 | 1272 | 1399 | 1699 ✦ | 3177 |
+| seq-read (MB/s) | **805** | 14 | 1502 | 1041 | 2047 ✦ | 4462 |
+| rand-write 4k (IOPS) | **2281** | 166 | 821 | 16554 ✦ | 1995 | 38705 |
+| rand-read 4k (IOPS) | **8171** | 2291 | 88 ‡ | 2691 | 30287 ✦ | 42909 |
+| metadata (ops/s) | **259** | 354 | 1990 | 7330 ✦ | — | 11681 |
+| mixed-rw (IOPS) | **1409** | 1983 ✦ | 125 | 5531 | 4455 | 41634 |
+
+‡ JuiceFS large rand-read (88 IOPS) is an outlier — its 1 GiB working set thrashes
+its local cache on this box; its medium rand-read (42 380) is representative.
 
 ## Random & metadata — medium files (1 MiB), warm
 
@@ -51,77 +65,69 @@ The smaller working set fits the re-export competitors' local page cache, so the
 random-read lead is starkest here. The native-S3 servers (DittoFS, ZeroFS) get no
 such free ride.
 
-| Workload | **DittoFS-S3** | ZeroFS | s3ql | JuiceFS | rclone | s3fs | local-disk ↑ |
-|---|--:|--:|--:|--:|--:|--:|--:|
-| rand-write 4k (IOPS) | **2337** | 2885 | 3844 | 588 | 19231 | 25229 ✦ | 43712 |
-| rand-read 4k (IOPS) | **24862** † | 2548 | 38636 | 45743 | fail | 46500 ✦ | 45835 |
-| metadata (ops/s) | **219** | 235 | 451 | 2597 ✦ | — | — | — |
-
-> † **DittoFS random-read reflects the warm-read fast path** (verify-once cache
-> + ranged sub-chunk reads, #1648/#1651, merged 2026-07-11) — measured in a
-> later same-VM run. Before it, DittoFS was 4010 (large) / 10981 (medium); the
-> fix removed a 256× read amplification (a whole ~1 MiB CAS chunk was read and
-> BLAKE3-verified to serve every 4 KiB), taking DittoFS from ~24–32% of JuiceFS
-> to ~56–58%. Competitor columns are the original full-suite run; JuiceFS
-> random-read varied <7% between the two runs, so the comparison holds. The gap
-> that remains is no longer the block read (20× faster at the engine level) but
-> per-read NFS + metadata overhead — see Analysis.
+| Workload | **DittoFS-S3** | ZeroFS | JuiceFS | rclone | s3fs | local-disk ↑ |
+|---|--:|--:|--:|--:|--:|--:|
+| rand-write 4k (IOPS) | **2144** | 2937 | 1688 | 17993 | 23289 ✦ | 41241 |
+| rand-read 4k (IOPS) | **13498** | 3789 | 42380 | 42187 | 42801 ✦ | 43064 |
+| metadata (ops/s) | **239** | 428 | 1682 | 6563 ✦ | — | 11536 |
 
 ## Cold reads — large files, first byte after cache-evict
 
-The S3-latency-bound axis. DittoFS's evict step (`dfsctl system drain-uploads`)
-errored this run, so its cold numbers are pending a re-run — but note how poorly
-the native-S3 servers do on a cold sequential read.
-
-| Workload | DittoFS-S3 | ZeroFS | JuiceFS |
-|---|--:|--:|--:|
-| seq-read cold (MB/s) | pending | 10 | 56 |
-| rand-read cold (IOPS) | pending | 871 | — |
+The S3-latency-bound axis. **Not collected this cycle** (warm-only run — the
+`dfsctl system drain-uploads` evict barrier stalled on the metadata working set,
+so the cold pass was skipped). Pending a follow-up run now that
+`drain-uploads --timeout` ([#1668](https://github.com/marmos91/dittofs/issues/1668))
+has landed. Prior observation: the native-S3 servers do poorly on a cold
+sequential read (ZeroFS ~10 MB/s, JuiceFS ~56 MB/s).
 
 ## Latency — large files, warm (µs, p50 / p99)
 
 Lower is better. DittoFS's durable local-write path shows in its higher write
-tails; its read latencies are competitive.
+tails; its read latencies are competitive with the native-S3 peer and far ahead
+of ZeroFS on reads.
 
-| Workload | **DittoFS-S3** | ZeroFS | s3ql | JuiceFS | s3fs |
-|---|--:|--:|--:|--:|--:|
-| seq-write | **14 615 / 77 070** | 10 813 / 164 626 | 9 896 / 44 827 | 2 245 / 14 483 | 1 974 / 4 620 |
-| rand-write | **37 487 / 103 285** | 46 924 / 86 508 | 70 779 / 459 276 | 68 682 / 400 556 | 55 312 / 128 451 |
-| rand-read | **15 008 / 147 849** | 49 021 / 88 605 | 2 736 / 10 289 | 9 896 / 15 925 | 10 813 / 33 423 |
-| seq-read | **4 358 / 26 608** | 110 625 / 2 399 142 | 709 / 46 924 | 1 892 / 5 997 | 1 139 / 1 991 |
+| Workload | **DittoFS-S3** | ZeroFS | JuiceFS | s3fs |
+|---|--:|--:|--:|--:|
+| seq-write | **18 219 / 67 633** | — | 2 376 / 14 877 | 2 073 / 4 751 |
+| rand-write | **39 059 / 120 062** | 32 113 / 17 112 760 | 77 070 / 400 556 | 57 934 / 152 044 |
+| rand-read | **11 600 / 67 633** | 54 788 / 103 285 | 1 082 130 / 4 328 522 | 4 178 / 7 635 |
+| seq-read | **3 883 / 16 712** | 90 702 / 2 231 370 | 2 040 / 6 259 | 1 221 / 8 454 |
 
 ## Analysis
 
 **Where DittoFS stands**
 
-1. **Metadata is the clearest deficit** — 239 ops/s, last of all seven backends
-   (ZeroFS 371, s3ql 700, JuiceFS 1824). It is the one axis DittoFS loses to the
-   entire field, and the highest-leverage target. It is directly addressed by the
-   in-flight metadata group-commit work (#1573).
+1. **Metadata is the one deficit, and it has not moved.** 259 ops/s large /
+   239 medium — statistically identical to the 2026-07-10 baseline (239 / 219)
+   and **last of the durable field** (ZeroFS 354, JuiceFS 1990). It is the only
+   axis DittoFS loses to the fair comparison (ZeroFS, the other native server).
+   The 20+ commits of warm-read cache + readahead work since the baseline did
+   **not** touch it — they don't touch the create/`fsync` path. The metadata
+   cells ran at low CPU (10–14 %) with very high context-switch rates: this is
+   **fsync-bound, not compute-bound**. The lever is unchanged: metadata
+   group-commit ([#1573](https://github.com/marmos91/dittofs/issues/1573),
+   unlanded) — coalesce the per-create `fsync` into one durable group commit.
 
-2. **DittoFS leads the durable-write cohort** — on random-write (2365 IOPS) it
-   beats JuiceFS (826), s3ql (1256), s3fs (2183), and ZeroFS (2133); only rclone's
-   RAM-buffered VFS is faster. Sequential write (156 MB/s) is the lowest number,
-   but it is a durable through-to-disk write versus cache-acknowledged competitors.
+2. **DittoFS now leads the durable native-S3 cohort.** Against ZeroFS (the fair,
+   no-page-cache comparison) the warm-read fast path (#1648/#1651) and lock-free
+   readahead (#1653) pay off decisively: rand-read **3.6×** (8171 vs 2291),
+   rand-write **13.7×** (2281 vs 166), seq-read **57×** (805 vs 14). The
+   FUSE re-exports' higher warm IOPS are the kernel-page-cache handicap, not a
+   design loss.
 
-3. **Read throughput is respectable, not dominant** — sequential read (677 MB/s)
-   beats s3ql (552) and dwarfs ZeroFS (13 MB/s, whose native-S3 read path collapses
-   under NFS).
+3. **Warm reads: the data is warm and the engine is fast — the gap is per-read
+   server CPU.** At the block engine a warm 4 KiB CAS read is ~21 µs / ~47k IOPS,
+   yet end-to-end over NFSv3 it lands at 8k–13k IOPS. The ~4× loss is **per-read
+   NFS RPC decode + metadata lookup + allocation**, which the kernel re-exports
+   avoid by serving 4 KiB reads straight from the page cache. It is *not* cold-S3
+   latency (these are warm) and *not* the block store. That server-side per-read
+   path is the next random-read target.
 
-4. **Random-read is much improved but still trails the page-cache re-exports.**
-   The warm-read fast path (#1648/#1651) removed the block store's 256× read
-   amplification — at the engine level a 4 KiB warm CAS read went from ~437 µs to
-   ~21 µs (~20×, ~47k IOPS). End to end over NFSv3 that lands as ~2× (7437 large /
-   24862 medium), moving DittoFS from ~24–32% of JuiceFS to ~56–58%. That the
-   engine's 20× only shows as ~2× on the wire means the block read is no longer the
-   bottleneck: what remains is **per-read NFS RPC + metadata lookup overhead**,
-   which the kernel-NFS re-exports (JuiceFS/s3fs) pay far less of because their
-   4 KiB reads are served straight from the Linux page cache. That per-read
-   server-side path is the next random-read target.
-
-4. **ZeroFS is the instructive comparison** — a fellow native NFS→S3 server whose
-   sequential and random reads are far worse than DittoFS's. Being native-S3 is not
-   the handicap; the read/cache design is.
+4. **Sequential write (148 MB/s) is the secondary gap.** A real durable
+   through-to-disk write versus the competitors' buffered/async acknowledge — but
+   9× behind JuiceFS/rclone is worth closing. It likely shares the same
+   append-log `fsync` serializer as the metadata create path, so the two fixes
+   may share a mechanism.
 
 ## Reproducing
 
@@ -133,13 +139,14 @@ go build -o dfsbench ./cmd/bench
 
 # Cloud run: provision one disposable VM, run the managed matrix, collect, tear down.
 dfsbench setup                              # SCW_* env selects type/zone/image
-dfsbench run --remote \
-  --systems dittofs-s3-nfs3,zerofs-nfs3,s3ql-nfs3,juicefs-nfs3,rclone-nfs3,s3fs-nfs3,local-disk-nfs3 \
+dfsbench run --remote --config bench.yaml \
+  --systems dittofs-s3-nfs3,zerofs-nfs3,juicefs-nfs3,rclone-nfs3,s3fs-nfs3,local-disk-nfs3 \
   --sizes medium,large
 dfsbench report --results ./bench-results   # re-render this comparison table
 dfsbench teardown
 ```
 
 S3 credentials stay in the environment (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`);
-the bucket and endpoint are set in the run config. See `bench/README.md` and
-`dfsbench list` for the full backend / workload / size matrix.
+the bucket and endpoint are set in the run config (`bench.yaml`). See
+`internal/dfsbench/CLAUDE.md` and `dfsbench list` for the full backend / workload
+/ size matrix and run playbook.


### PR DESCRIPTION
Refreshes `docs/BENCHMARKS.md` with the 2026-07-14 warm benchmark re-run — the first clean full matrix since the harness fixes (#1666/#1670/#1676).

## What changed
- Warm large + medium throughput/IOPS/latency tables for 6 systems (DittoFS-S3, ZeroFS, JuiceFS, rclone, s3fs, local-disk).
- Coverage caveats documented: warm-only (cold pass dropped to dodge a `drain-uploads` stall), s3ql not run (SCW eventual-consistency flake), sqlite/postgres excluded (buffered-large wedge, #1667).
- Analysis rewritten around the fair comparison (DittoFS vs ZeroFS).

## Headline
- **Metadata is the one deficit, unmoved**: 259/239 ops/s ≈ the 239/219 baseline. Last of the durable field, loses even to ZeroFS (354). fsync-bound (low CPU, high ctxsw). Lever = metadata group-commit (#1573, unlanded).
- **DittoFS now leads the durable native-S3 cohort** vs ZeroFS: rand-read 3.6×, rand-write 13.7×, seq-read 57× — the warm-read fast path (#1648/#1651) + lock-free readahead (#1653) paid off.
- Warm-read gap to the FUSE re-exports is per-read server RPC/metadata CPU (kernel page-cache free ride), not cold-S3 or the block store.
- seq-write 148 MB/s is the secondary gap; likely shares the append-log fsync serializer with metadata create.