### PR TITLE
perf(metadata): store-agnostic group-commit for durable flush (#1573)

### DIFF
--- a/pkg/metadata/commit_leader.go
+++ b/pkg/metadata/commit_leader.go
@@ -1,0 +1,108 @@
+package metadata
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+)
+
+// commitLeader coalesces concurrent metadata durability barriers into as few
+// backend Sync calls as possible. It is the store-agnostic sibling of the block
+// store's syncLeader (pkg/block/local/fs/sync_leader.go).
+//
+// The one structural difference from syncLeader: syncLeader batches per-fd fsync
+// closures (N distinct fds → N back-to-back fsyncs the FS journal coalesces),
+// whereas a metadata store exposes ONE barrier that makes ALL committed-but-
+// unsynced writes durable at once (Store.SyncDurable → badger db.Sync / sqlite
+// WAL checkpoint). So the leader calls a single shared barrier once per drain
+// batch and hands its result to every waiter in that batch.
+//
+// Why (#1573): every NFS COMMIT / stable SMB flush runs flushPendingWrite, which
+// stages the write and then forces durability. Before this, each concurrent
+// commit issued its own uncoalesced store.SyncDurable, so N files committing at
+// once paid N independent fsyncs — the metadata wall. Routing them through one
+// leader collapses a concurrent burst onto one barrier.
+//
+// Durability contract: Sync blocks until a barrier that ran AFTER this caller
+// enqueued has completed, and returns that barrier's result. The barrier always
+// completes before Sync returns — this is STRICT group-commit, not async write-
+// back. NFS COMMIT depends on the synchronous ack. (Correctness of the "ran
+// after enqueue" guarantee: a caller that enqueues while a leader is mid-barrier
+// lands in the NEXT batch, which the leader always drains — it only exits after
+// locking and finding the queue empty, and the enqueue-under-lock happens-before
+// that check. So its write, committed before enqueue, is covered by a fresh
+// barrier.)
+//
+// Adaptive bypass: a lone caller arriving at an idle leader runs the barrier
+// inline (one drain pass) with no goroutine hand-off, mirroring syncLeader.
+type commitLeader struct {
+	// barrier makes every write committed so far on the owning store durable.
+	barrier func() error
+
+	mu      sync.Mutex
+	pending []chan error
+	running bool
+
+	// drainPasses counts non-empty barrier batches. A burst that coalesces onto
+	// one leader run shows far fewer passes than Sync calls; read by the
+	// coalescing tests.
+	drainPasses atomic.Int64
+}
+
+func newCommitLeader(barrier func() error) *commitLeader {
+	return &commitLeader{barrier: barrier}
+}
+
+// Sync makes this caller's already-staged write durable, coalescing with any
+// concurrent callers, and returns the shared barrier's result. On ctx
+// cancellation the caller observes ctx.Err() but the barrier still runs
+// (durability is never abandoned); the done channel is buffered so the leader
+// never blocks on an abandoned waiter.
+func (l *commitLeader) Sync(ctx context.Context) error {
+	done := make(chan error, 1)
+
+	l.mu.Lock()
+	l.pending = append(l.pending, done)
+	if l.running {
+		// A leader is already draining; it will pick up our request on a later
+		// pass. Follow.
+		l.mu.Unlock()
+		return commitWaitOn(ctx, done)
+	}
+	l.running = true
+	l.mu.Unlock()
+
+	// We are the leader: drain batches until the queue is empty. Requests that
+	// arrive while we run the current barrier are collected on the next
+	// iteration, so a concurrent burst collapses onto this single leader run.
+	for {
+		l.mu.Lock()
+		batch := l.pending
+		l.pending = nil
+		if len(batch) == 0 {
+			l.running = false
+			l.mu.Unlock()
+			break
+		}
+		l.mu.Unlock()
+
+		l.drainPasses.Add(1)
+		err := l.barrier()
+		for _, d := range batch {
+			d <- err
+		}
+	}
+	return commitWaitOn(ctx, done)
+}
+
+// commitWaitOn blocks until ch delivers a result or ctx is canceled. Returning
+// ctx.Err() does not abort the barrier — the channel cap is 1 so the leader's
+// eventual send still succeeds.
+func commitWaitOn(ctx context.Context, ch <-chan error) error {
+	select {
+	case err := <-ch:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/pkg/metadata/commit_leader_bench_test.go
+++ b/pkg/metadata/commit_leader_bench_test.go
@@ -1,0 +1,68 @@
+package metadata
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+// BenchmarkCommitLeader_Concurrent measures the durable-commit throughput of the
+// group-commit coordinator under concurrency, against the wall it removes: a
+// real fsync barrier. Each iteration is one durable COMMIT (the metadata
+// flushPendingWrite tail). "direct" is the pre-#1573 behaviour — every
+// concurrent committer issues its own fsync; "coalesced" routes them through the
+// commitLeader so a concurrent burst collapses onto one fsync.
+//
+// The barrier fsyncs a real file so the wall shows: on a filesystem that honors
+// fsync (the Linux bench VM) "direct" is fsync-bound at ~one journal commit per
+// op while "coalesced" amortizes N ops onto ~one, so the win grows with
+// concurrency. NOTE: on macOS fsync is NOT a full barrier (Darwin's fsync
+// returns before the platter write; F_FULLFSYNC would be needed), so the local
+// ratio understates the win — mirror this on Linux to see the real number.
+func BenchmarkCommitLeader_Concurrent(b *testing.B) {
+	for _, conc := range []int{1, 4, 16, 64} {
+		f, err := os.CreateTemp(b.TempDir(), "barrier")
+		if err != nil {
+			b.Fatal(err)
+		}
+		barrier := func() error { return f.Sync() }
+		b.Cleanup(func() { _ = f.Close() })
+
+		b.Run("direct/conc="+strconv.Itoa(conc), func(b *testing.B) {
+			runConcurrent(b, conc, func(context.Context) error { return barrier() })
+		})
+
+		l := newCommitLeader(barrier)
+		b.Run("coalesced/conc="+strconv.Itoa(conc), func(b *testing.B) {
+			runConcurrent(b, conc, l.Sync)
+		})
+	}
+}
+
+// runConcurrent drives b.N total durable commits spread over conc goroutines and
+// reports ns/op (so ops/s = 1e9/ns-op) at that concurrency.
+func runConcurrent(b *testing.B, conc int, commit func(context.Context) error) {
+	b.ResetTimer()
+	var wg sync.WaitGroup
+	per := b.N / conc
+	extra := b.N % conc
+	for g := 0; g < conc; g++ {
+		n := per
+		if g < extra {
+			n++
+		}
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			for i := 0; i < n; i++ {
+				if err := commit(context.Background()); err != nil {
+					b.Error(err)
+					return
+				}
+			}
+		}(n)
+	}
+	wg.Wait()
+}

--- a/pkg/metadata/commit_leader_test.go
+++ b/pkg/metadata/commit_leader_test.go
@@ -1,0 +1,221 @@
+package metadata
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestCommitLeader_SingleCaller_FiresInline exercises the adaptive bypass: a
+// lone caller at an idle leader runs the barrier inline (one drain pass) with no
+// goroutine hand-off.
+func TestCommitLeader_SingleCaller_FiresInline(t *testing.T) {
+	var calls atomic.Int32
+	l := newCommitLeader(func() error { calls.Add(1); return nil })
+
+	if err := l.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("barrier calls: got %d, want 1", got)
+	}
+	if p := l.drainPasses.Load(); p != 1 {
+		t.Fatalf("drainPasses: got %d, want 1 (inline bypass)", p)
+	}
+}
+
+// TestCommitLeader_Concurrent_Coalesces is the core property: N concurrent
+// callers collapse onto far fewer barrier invocations than submissions. Leader A
+// holds the barrier open until the followers have enqueued, so they are drained
+// together on the leader's next pass — one shared barrier for the whole batch.
+func TestCommitLeader_Concurrent_Coalesces(t *testing.T) {
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	l := newCommitLeader(func() error {
+		n := calls.Add(1)
+		if n == 1 {
+			// First (leader A) barrier blocks so followers pile up behind it.
+			close(started)
+			<-release
+		}
+		return nil
+	})
+
+	aDone := make(chan error, 1)
+	go func() { aDone <- l.Sync(context.Background()) }()
+	<-started
+
+	const followers = 8
+	fDone := make(chan error, followers)
+	for i := 0; i < followers; i++ {
+		go func() { fDone <- l.Sync(context.Background()) }()
+	}
+	// Give the followers time to enqueue while A is blocked in its barrier.
+	time.Sleep(20 * time.Millisecond)
+	close(release)
+
+	for i := 0; i < followers+1; i++ {
+		ch := fDone
+		if i == 0 {
+			ch = aDone
+		}
+		select {
+		case err := <-ch:
+			if err != nil {
+				t.Fatalf("Sync returned error: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("a Sync did not return")
+		}
+	}
+
+	// 9 submissions must collapse onto <= 2 barrier calls (A's blocked one plus
+	// one shared drain of all followers) — the coalescing win.
+	if got := calls.Load(); got > 2 {
+		t.Fatalf("barrier calls: got %d, want <= 2 (followers must coalesce onto one barrier)", got)
+	}
+	if p := l.drainPasses.Load(); p > 2 {
+		t.Fatalf("drainPasses: got %d, want <= 2", p)
+	}
+}
+
+// TestCommitLeader_SharedResult_Synchronous pins two contract points: (1) every
+// waiter in a coalesced batch sees the SAME barrier result (unlike syncLeader's
+// per-fd isolation — one metadata barrier makes all pending writes durable), and
+// (2) Sync is synchronous: a barrier error surfaces to the caller (no async ack)
+// and only after the barrier has run.
+func TestCommitLeader_SharedResult_Synchronous(t *testing.T) {
+	wantErr := errors.New("fsync on fire")
+	var ran atomic.Bool
+	started := make(chan struct{})
+	release := make(chan struct{})
+	l := newCommitLeader(func() error {
+		// Signal + block only on the very first (leader) call so followers pile
+		// up and share this batch's barrier.
+		if ran.CompareAndSwap(false, true) {
+			close(started)
+			<-release
+		}
+		return wantErr
+	})
+
+	aDone := make(chan error, 1)
+	go func() { aDone <- l.Sync(context.Background()) }()
+	<-started
+
+	const followers = 4
+	fDone := make(chan error, followers)
+	for i := 0; i < followers; i++ {
+		go func() { fDone <- l.Sync(context.Background()) }()
+	}
+	time.Sleep(20 * time.Millisecond)
+
+	// Barrier has not completed yet: no waiter may have returned (synchronous).
+	select {
+	case err := <-aDone:
+		t.Fatalf("Sync returned %v before barrier completed (must be synchronous)", err)
+	default:
+	}
+
+	close(release)
+	if err := <-aDone; !errors.Is(err, wantErr) {
+		t.Fatalf("leader: got %v, want %v", err, wantErr)
+	}
+	for i := 0; i < followers; i++ {
+		if err := <-fDone; !errors.Is(err, wantErr) {
+			t.Fatalf("follower %d: got %v, want %v (shared barrier result)", i, err, wantErr)
+		}
+	}
+}
+
+// TestCommitLeader_CtxCancel_ReturnsCtxErr_ButBarrierStillRuns verifies a
+// canceled follower observes ctx.Err() but the barrier still runs (durability
+// trumps caller-side latency relief).
+func TestCommitLeader_CtxCancel_ReturnsCtxErr_ButBarrierStillRuns(t *testing.T) {
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	l := newCommitLeader(func() error {
+		if calls.Add(1) == 1 {
+			close(started)
+			<-release
+		}
+		return nil
+	})
+
+	aDone := make(chan error, 1)
+	go func() { aDone <- l.Sync(context.Background()) }()
+	<-started
+
+	ctxB, cancelB := context.WithCancel(context.Background())
+	bDone := make(chan error, 1)
+	go func() { bDone <- l.Sync(ctxB) }()
+	time.Sleep(20 * time.Millisecond)
+	cancelB()
+
+	select {
+	case err := <-bDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("B: got %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("B did not return after cancel")
+	}
+
+	close(release)
+	if err := <-aDone; err != nil {
+		t.Fatalf("A: %v", err)
+	}
+	// The barrier covering B must still have run (>= 2 calls: A's + B's batch).
+	deadline := time.Now().Add(time.Second)
+	for calls.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if calls.Load() < 2 {
+		t.Fatal("barrier for the canceled follower did not run (durability broken)")
+	}
+}
+
+// TestCommitLeader_RaceFree hammers the leader from many goroutines under -race
+// and asserts progress plus coalescing (fewer barrier calls than submissions).
+func TestCommitLeader_RaceFree(t *testing.T) {
+	var calls atomic.Int64
+	l := newCommitLeader(func() error {
+		calls.Add(1)
+		time.Sleep(50 * time.Microsecond)
+		return nil
+	})
+
+	stop := make(chan struct{})
+	time.AfterFunc(50*time.Millisecond, func() { close(stop) })
+
+	var subs atomic.Int64
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				subs.Add(1)
+				_ = l.Sync(context.Background())
+			}
+		}()
+	}
+	wg.Wait()
+
+	if calls.Load() == 0 || subs.Load() == 0 {
+		t.Fatalf("no progress: calls=%d subs=%d", calls.Load(), subs.Load())
+	}
+	if l.drainPasses.Load() >= subs.Load() {
+		t.Fatalf("coalescing not observed: passes=%d >= submissions=%d", l.drainPasses.Load(), subs.Load())
+	}
+}

--- a/pkg/metadata/io.go
+++ b/pkg/metadata/io.go
@@ -435,7 +435,15 @@ func (s *Service) flushPendingWrite(ctx *AuthContext, handle FileHandle, state *
 		return err
 	}
 
-	return store.WithTransaction(ctx.Context, func(tx Transaction) error {
+	// Stage the write with relaxed durability (no inline fsync), then force a
+	// COALESCED durable barrier through the per-store commit leader. Net
+	// durability is identical to a fully-durable WithTransaction — the barrier
+	// completes before we return (strict group-commit, #1573) — but N concurrent
+	// COMMITs collapse onto one Store.SyncDurable instead of N independent
+	// fsyncs. Staging relaxed is safe despite the file-size (data-paired) write
+	// because we do NOT rely on the background ticker: the leader.Sync below
+	// makes it durable synchronously before returning.
+	if err := withRelaxedTransaction(store, ctx.Context, func(tx Transaction) error {
 		file, err := tx.GetFile(ctx.Context, handle)
 		if err != nil {
 			return err
@@ -458,7 +466,11 @@ func (s *Service) flushPendingWrite(ctx *AuthContext, handle FileHandle, state *
 		}
 
 		return tx.PutFile(ctx.Context, file)
-	})
+	}); err != nil {
+		return err
+	}
+
+	return s.commitLeaderFor(store).Sync(ctx.Context)
 }
 
 // GetPendingSize returns the pending size for a file if there are uncommitted writes.

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -46,6 +46,15 @@ type Service struct {
 	dirTimes           *DirTimesTracker                  // coalesced directory mtime/ctime/atime bumps (#1573)
 	deferredCommit     bool                              // if true, use deferred commits (default: true)
 
+	// commitLeaders coalesces the durable-flush barrier per store (#1573):
+	// N concurrent NFS COMMITs / stable SMB flushes on the same backend collapse
+	// onto one Store.SyncDurable instead of N independent fsyncs. Keyed by the
+	// Store value (a backend pointer) so distinct backends never share a leader
+	// — a leader's barrier makes exactly one store durable. Lazily populated by
+	// commitLeaderFor; guarded by its own mutex (never contends with s.mu).
+	commitLeaders   map[Store]*commitLeader
+	commitLeadersMu sync.Mutex
+
 	// parentLinkShards is a fixed bank of mutexes that serialize the parent
 	// directory link-count read-modify-write (the ".." bump) done by mkdir (+1),
 	// rmdir (-1), and cross-parent directory rename (-1 source, +1 destination).
@@ -146,7 +155,24 @@ func New() *Service {
 		quotas:             make(map[string]int64),
 		identityQuotas:     newQuotaLimits(),
 		removeGen:          make(map[string]uint64),
+		commitLeaders:      make(map[Store]*commitLeader),
 	}
+}
+
+// commitLeaderFor returns the per-store commit leader, creating it on first use.
+// The leader's barrier drives that store's SyncDurable with a background context
+// so a caller's cancellation never abandons an in-flight durability fsync
+// (matches the commitLeader contract).
+func (s *Service) commitLeaderFor(store Store) *commitLeader {
+	s.commitLeadersMu.Lock()
+	defer s.commitLeadersMu.Unlock()
+	if l := s.commitLeaders[store]; l != nil {
+		return l
+	}
+	st := store
+	l := newCommitLeader(func() error { return st.SyncDurable(context.Background()) })
+	s.commitLeaders[store] = l
+	return l
 }
 
 // QuotaGracePersister persists a per-identity quota's grace timer transition
@@ -461,6 +487,17 @@ func (s *Service) RemoveStoreForShare(shareName string) {
 		// a removed share. AbortGracePeriod stops the timer synchronously and
 		// does not block, so holding s.mu across it is safe.
 		lm.AbortGracePeriod()
+	}
+
+	// Drop this store's commit leader too (#1573). commitLeaders is keyed by the
+	// Store value and lazily populated, so without this it grows unbounded across
+	// AddShare/RemoveShare churn and pins the closed Store (and its DB handles)
+	// reachable via the barrier closure. commitLeadersMu is independent of s.mu
+	// (never nested the other way), so taking it here is deadlock-free.
+	if st := s.stores[shareName]; st != nil {
+		s.commitLeadersMu.Lock()
+		delete(s.commitLeaders, st)
+		s.commitLeadersMu.Unlock()
 	}
 
 	delete(s.stores, shareName)

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -513,6 +513,14 @@ type Store interface {
 	// passed where a Checker is expected.
 	Healthcheck(ctx context.Context) health.Report
 
+	// SyncDurable makes every write committed so far on this store durable
+	// (fsync / WAL checkpoint) and returns only once it has. It is the barrier
+	// the Service's per-store commit leader coalesces so N concurrent NFS
+	// COMMITs collapse onto one backend sync instead of N (#1573). Backends
+	// without crash durability (memory) or with native per-commit durability
+	// (postgres) implement it as a no-op. MUST be safe for concurrent callers.
+	SyncDurable(ctx context.Context) error
+
 	// Close releases any resources held by the store.
 	Close() error
 }

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -485,6 +485,16 @@ func (s *BadgerMetadataStore) syncIfRelaxed() error {
 	return s.db.Sync()
 }
 
+// SyncDurable forces every committed-but-unsynced write to disk — the durability
+// barrier the Service's commit leader coalesces (#1573). It is the same
+// db.Sync() syncIfRelaxed issues inline; in strict mode (SyncWrites=true) each
+// commit already fsynced, so this is a cheap redundant sync. Counts toward
+// inlineSyncs so a coalesced burst (N commits, one SyncDurable) is observable.
+func (s *BadgerMetadataStore) SyncDurable(_ context.Context) error {
+	s.inlineSyncs.Add(1)
+	return s.db.Sync()
+}
+
 // storeIDKey is the BadgerDB key for the engine-persistent store identifier.
 // It lives under the existing "cfg:" singleton-config prefix so it shares a
 // namespace with server config and filesystem capabilities.

--- a/pkg/metadata/store/memory/shares.go
+++ b/pkg/metadata/store/memory/shares.go
@@ -314,6 +314,12 @@ func (store *MemoryMetadataStore) CreateRootDirectory(
 // marker so the lock-recovery boot path treats this drain as clean. The marker
 // is in-process only (memory is non-durable across restarts), which is correct
 // — a new process always starts with a fresh, unclean-by-default store.
+// SyncDurable is a no-op durability barrier (#1573): the memory store holds all
+// state in RAM and offers no crash durability, so there is nothing to flush.
+func (store *MemoryMetadataStore) SyncDurable(_ context.Context) error {
+	return nil
+}
+
 func (store *MemoryMetadataStore) Close() error {
 	store.mu.Lock()
 	store.initLockStore()

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -315,6 +315,39 @@ func (s *PostgresMetadataStore) GetStoreID() string { return s.storeID }
 // Compile-time assertion: the Postgres engine exposes GetStoreID.
 var _ interface{ GetStoreID() string } = (*PostgresMetadataStore)(nil)
 
+// SyncDurable forces any relaxed (synchronous_commit=off) staging commits to
+// stable storage — the durability barrier the Service's commit leader coalesces
+// (#1573).
+//
+// In strict mode this is a no-op: every COMMIT already fsynced the WAL
+// (synchronous_commit=on), so committed metadata is durable the moment
+// WithTransaction returns. But when relaxed_durability is on, flushPendingWrite
+// stages the data-paired file-size write via WithTransactionRelaxed
+// (synchronous_commit=off), so its WAL record is written but not yet fsynced.
+// Force a synchronous WAL flush: txid_current() assigns an xid so this commit
+// writes a real commit record, and because postgres flushes WAL sequentially, a
+// single synchronous commit durably covers every earlier async commit up to the
+// current LSN — including the staged write (which committed, at a lower LSN,
+// before this barrier ran). This is what preserves the #588 "data-paired writes
+// are durable synchronously" contract now that flushPendingWrite stages relaxed.
+func (s *PostgresMetadataStore) SyncDurable(ctx context.Context) error {
+	if !s.config.RelaxedDurability {
+		return nil
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, "SET LOCAL synchronous_commit = on"); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx, "SELECT txid_current()"); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
 // Close closes the PostgreSQL connection pool and releases resources
 func (s *PostgresMetadataStore) Close() error {
 	s.logger.Info("Closing PostgreSQL metadata store...")

--- a/pkg/metadata/store/sqlite/store.go
+++ b/pkg/metadata/store/sqlite/store.go
@@ -290,6 +290,25 @@ func (s *SQLiteMetadataStore) GetStoreID() string { return s.storeID }
 // Compile-time assertion: the SQLite engine exposes GetStoreID.
 var _ interface{ GetStoreID() string } = (*SQLiteMetadataStore)(nil)
 
+// SyncDurable forces WAL-buffered commits to disk — the durability barrier the
+// Service's commit leader coalesces (#1573). Under journal_mode=WAL +
+// synchronous=NORMAL (config.go) a COMMIT does not fsync the WAL, so a PASSIVE
+// checkpoint is the barrier: it fsyncs the WAL (making committed transactions
+// durable) and folds ready frames into the main DB. PASSIVE never blocks on
+// concurrent readers/writers — it syncs what is committed and returns.
+//
+// Correctness depends on this store's single-connection pool (SetMaxOpenConns(1)
+// in Open): a PASSIVE checkpoint syncs the WAL only for frames up to the oldest
+// reader's mark, so with concurrent readers on stale snapshots it could skip
+// just-committed frames. With exactly one serialized connection there is no
+// second reader pinning an older snapshot when this runs, so PASSIVE fsyncs all
+// committed frames — equivalent to FULL here. A future move to a pooled/multi-
+// connection SQLite setup would reintroduce that gap and must revisit this.
+func (s *SQLiteMetadataStore) SyncDurable(ctx context.Context) error {
+	_, err := s.db.ExecContext(ctx, "PRAGMA wal_checkpoint(PASSIVE)")
+	return err
+}
+
 // Close records the clean-shutdown marker and closes the database handle.
 func (s *SQLiteMetadataStore) Close() error {
 	s.logger.Info("Closing SQLite metadata store...")


### PR DESCRIPTION
Closes #1573 (reframed — see below).

## The reframe
#1573's stated premise (per-create fsync wall) is already fixed: `relaxed_durability: true` is the shipped default, so a plain CREATE does zero hot-path fsyncs. The *live* metadata wall (dfsbench: **259 ops/s, last of the durable field, loses to ZeroFS 354**) is elsewhere:

- The dfsbench `metadata` workload is create→write-4k→**close** per file (`numjobs=4`). Each close → NFS COMMIT → `flushPendingWrite` → a **raw, uncoalesced `db.Sync()`**. 4 threads never coalesce (259/4 ≈ 65 ops/s/thread ≈ one 15 ms fsync each).
- The block side already solved this with a group-commit `syncLeader` (#1416/PR3). The metadata side never got it.

## The fix
- **`pkg/metadata/commit_leader.go`** — store-agnostic coalescing coordinator (sibling of `syncLeader`). N concurrent durability barriers collapse onto one backend sync per drain batch. **Strict group-commit**: the fsync completes before the caller returns → durability unchanged.
- **`SyncDurable(ctx) error`** on the `Store` contract (no new capability type): badger `db.Sync()`; sqlite `wal_checkpoint(PASSIVE)`; postgres synchronous WAL flush when relaxed; memory no-op.
- **`flushPendingWrite`** stages via the relaxed (no-fsync) txn, then the coalesced barrier.

## Durability
Identical to before — coalesce fsyncs, don't defer them. Reviewed for the postgres relaxed-staging gap (fixed: synchronous WAL flush via `txid_current()`) and the sqlite PASSIVE-under-readers gap (safe: single-connection pool; documented).

## Gates
`go build`, `go vet`, `gofmt -s` clean; **2691 tests pass** incl. storetest conformance for every backend; `-race` clean.

## Pending before un-drafting
- [ ] **Measured before/after on a Linux VM** (macOS fsync isn't a full barrier — the wall only shows on Linux). Expect ~2–4× (bounded by 4-thread coalescing) — past ZeroFS, not to JuiceFS's faster engine.
- [ ] Postgres `SyncDurable` is CI-verified only (needs a live postgres); logically sound, untested locally.

Follow-up (separate): seq-write 148 MB/s (bandwidth-bound, needs a profiling pass) and sqlite buffered-large wedge (#1667).