### PR TITLE
ci(health): retry conformance run once before opening develop-red

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -34,6 +34,8 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
+  # Needed for the retry-before-alarm step to re-run the failed conformance jobs.
+  actions: write
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -62,16 +64,33 @@ jobs:
       # in-flight run — benign, and the superseding run reports the true status.
       # Alarming on it produced stuck false-positive develop-red issues (#1672).
       IS_RED: ${{ github.event.workflow_run.conclusion != 'success' && github.event.workflow_run.conclusion != 'cancelled' }}
+      # Retry-before-alarm: transient conformance flakes (slow-runner timeouts ->
+      # smbtorture exit 124, docker 502s, OOM-killed containers) surface as a
+      # `failure` conclusion and used to page a P0 on the first attempt. Instead,
+      # on attempt 1 we re-run the failed jobs once and stay silent; only if the
+      # re-run (attempt >= 2) is still red do we alarm. A genuine break fails
+      # twice and still pages; a flake self-heals with no issue opened.
+      SHOULD_RETRY: ${{ github.event.workflow_run.conclusion != 'success' && github.event.workflow_run.conclusion != 'cancelled' && github.event.workflow_run.run_attempt == 1 }}
+      SHOULD_ALARM: ${{ github.event.workflow_run.conclusion != 'success' && github.event.workflow_run.conclusion != 'cancelled' && github.event.workflow_run.run_attempt > 1 }}
 
     steps:
+      - name: Retry failed jobs once before alarming
+        if: env.SHOULD_RETRY == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Attempt 1 of ${WORKFLOW} is red; re-running failed jobs before alarming."
+          echo "A genuine break fails again on attempt 2 and pages; a flake self-heals."
+          gh run rerun "$RUN_ID" --repo "$REPO" --failed
+
       # The alarm builds its email body from a committed Python script, so the
       # repo must be on the runner. workflow_run has no implicit checkout.
       - name: Check out repo
-        if: env.IS_RED == 'true'
+        if: env.SHOULD_ALARM == 'true'
         uses: actions/checkout@v4
 
       - name: Ensure develop-red label exists
-        if: env.IS_RED == 'true'
+        if: env.SHOULD_ALARM == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -85,7 +104,7 @@ jobs:
       # email (HTML + text), subject, and issue markdown. The Python script is
       # committed + unit-testable, which keeps fragile body templating out of YAML.
       - name: Collect failure details
-        if: env.IS_RED == 'true'
+        if: env.SHOULD_ALARM == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
@@ -119,7 +138,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Send failure email
-        if: env.IS_RED == 'true' && env.HAS_SMTP == 'true'
+        if: env.SHOULD_ALARM == 'true' && env.HAS_SMTP == 'true'
         uses: dawidd6/action-send-mail@v3
         with:
           server_address: ${{ secrets.SMTP_SERVER }}
@@ -137,7 +156,7 @@ jobs:
           body: ${{ env.MAIL_TEXT }}
 
       - name: Open or update develop-red issue
-        if: env.IS_RED == 'true'
+        if: env.SHOULD_ALARM == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -34,8 +34,6 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
-  # Needed for the retry-before-alarm step to re-run the failed conformance jobs.
-  actions: write
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -50,6 +48,14 @@ jobs:
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.head_branch == 'develop' &&
       (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'schedule')
+    # Scoped here (not workflow-level) so the pull_request `warn-on-pr` job never
+    # gets `actions: write`. Job-level permissions replace the workflow default,
+    # so re-list what this job needs: checkout (contents), open issue (issues),
+    # and re-run failed jobs (actions).
+    permissions:
+      contents: read
+      issues: write
+      actions: write
     env:
       HAS_SMTP: ${{ secrets.SMTP_PASSWORD != '' }}
       WORKFLOW: ${{ github.event.workflow_run.name }}
@@ -81,7 +87,15 @@ jobs:
         run: |
           echo "Attempt 1 of ${WORKFLOW} is red; re-running failed jobs before alarming."
           echo "A genuine break fails again on attempt 2 and pages; a flake self-heals."
-          gh run rerun "$RUN_ID" --repo "$REPO" --failed
+          if gh run rerun "$RUN_ID" --repo "$REPO" --failed; then
+            echo "Re-run queued; attempt 2 will alarm if it is still red."
+          else
+            # If the re-run cannot be queued (gh/API outage, run not rerunnable),
+            # no attempt-2 event will ever fire — so don't swallow the signal.
+            # Alarm now by promoting this attempt to the alarm path.
+            echo "Re-run could not be queued; alarming on this attempt instead."
+            echo "SHOULD_ALARM=true" >> "$GITHUB_ENV"
+          fi
 
       # The alarm builds its email body from a committed Python script, so the
       # repo must be on the runner. workflow_run has no implicit checkout.


### PR DESCRIPTION
## Problem

`develop-red` P0 issues (e.g. #1685) are opened for **transient conformance flakes**, not real breakage. In the run that triggered #1685, the exact same heavy smbtorture tests (`maxfid`, `lease`, `oplock`, `notify`, `replay`) hit `smbtorture infrastructure failure (exit code 124)` — a per-suite **timeout** — across *every* profile (badger-fs, sqlite, memory, memory-fs, postgres). The blamed commit (#1682, snapshot decryptability) doesn't touch SMB. Classic slow-runner flake, but it still paged.

## Fix

Retry-before-alarm in `ci-health.yml`:

- **Attempt 1 red** → re-run the failed jobs once (`gh run rerun --failed`), open **no** issue.
- **Attempt ≥ 2 red** → open/append the `develop-red` P0 as before.

A genuine break fails attempt 1 **and** 2, so it still pages. A flake passes on attempt 2 and self-heals silently. Bounded to a single retry (attempt ≥ 2 never re-runs). No test-grading changes — real assertion failures are unaffected.

Adds `actions: write` (needed for the rerun) and gates all alarm steps on `SHOULD_ALARM` (attempt > 1); attempt 1 hits the new `SHOULD_RETRY` step. Close-on-green path is untouched.