### PR TITLE
refactor(block): delete legacy per-chunk CAS path, make LocalChunkIndex mandatory

### DIFF
--- a/internal/adapter/common/copy_payload_test.go
+++ b/internal/adapter/common/copy_payload_test.go
@@ -361,8 +361,7 @@ func newCopyTestEngineWithMS(t *testing.T, coord *fakeCoordinator, ms *metadatam
 	t.Helper()
 
 	tmpDir := t.TempDir()
-	localStore, err := fs.NewWithOptions(tmpDir, 100*1024*1024, ms, fs.FSStoreOptions{
-		LocalChunkIndex: ms})
+	localStore, err := fs.NewWithOptions(tmpDir, 100*1024*1024, ms, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions failed: %v", err)
 	}

--- a/internal/adapter/common/write_payload_test.go
+++ b/internal/adapter/common/write_payload_test.go
@@ -27,7 +27,6 @@ func newTestEngine(t *testing.T) *engine.Store {
 	tmpDir := t.TempDir()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	localStore, err := fs.NewWithOptions(tmpDir, 100*1024*1024, ms, fs.FSStoreOptions{
-		LocalChunkIndex: ms,
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 50,

--- a/internal/adapter/nfs/v3/handlers/testing/fixtures.go
+++ b/internal/adapter/nfs/v3/handlers/testing/fixtures.go
@@ -102,7 +102,7 @@ func NewHandlerFixtureWithStore(
 
 	// Create local store, syncer, and block store engine
 	tmpDir := t.TempDir()
-	localStore, err := fs.NewWithOptions(tmpDir, 0, metaStore, fs.FSStoreOptions{LocalChunkIndex: metaStore})
+	localStore, err := fs.NewWithOptions(tmpDir, 0, metaStore, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("Failed to create local store: %v", err)
 	}

--- a/internal/adapter/nfs/v4/handlers/io_test.go
+++ b/internal/adapter/nfs/v4/handlers/io_test.go
@@ -41,8 +41,7 @@ func newIOTestFixture(t *testing.T, shareName string) *ioTestFixture {
 
 	// Create local store, syncer, and block store engine
 	tmpDir := t.TempDir()
-	localStore, err := fs.NewWithOptions(tmpDir, 0, metaStore, fs.FSStoreOptions{
-		LocalChunkIndex: memorymeta.NewMemoryMetadataStoreWithDefaults()})
+	localStore, err := fs.NewWithOptions(tmpDir, 0, metaStore, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("create local store: %v", err)
 	}

--- a/pkg/block/engine/cache_populated_on_rollup_test.go
+++ b/pkg/block/engine/cache_populated_on_rollup_test.go
@@ -40,7 +40,6 @@ func newRollupCacheFixture(t *testing.T) (*Store, *fs.FSStore, *recordingPutCach
 	t.Helper()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
-		LocalChunkIndex: ms,
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 5,

--- a/pkg/block/engine/carver_test.go
+++ b/pkg/block/engine/carver_test.go
@@ -39,9 +39,7 @@ type carveFixture struct {
 func newCarveFixture(t *testing.T, rbs remote.RemoteStore, carveBytes int64) *carveFixture {
 	t.Helper()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	local, err := fs.NewWithOptions(t.TempDir(), 0, nil, fs.FSStoreOptions{
-		LocalChunkIndex: ms,
-	})
+	local, err := fs.NewWithOptions(t.TempDir(), 0, ms, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)
 	}
@@ -284,7 +282,7 @@ func TestCarve_ThroughCompressEncryptRemote(t *testing.T) {
 func TestCarve_UnwiredSubstrateKeepsChunksPending(t *testing.T) {
 	ctx := context.Background()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	local, err := fs.NewWithOptions(t.TempDir(), 0, nil, fs.FSStoreOptions{LocalChunkIndex: ms})
+	local, err := fs.NewWithOptions(t.TempDir(), 0, ms, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)
 	}
@@ -450,9 +448,7 @@ func TestCarve_CommitFailureRollsBackAtomically(t *testing.T) {
 		failOnCall:          2, // second chunk's tx.MarkSynced fails once
 	}
 
-	local, err := fs.NewWithOptions(t.TempDir(), 0, nil, fs.FSStoreOptions{
-		LocalChunkIndex: realMS,
-	})
+	local, err := fs.NewWithOptions(t.TempDir(), 0, realMS, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)
 	}
@@ -578,9 +574,7 @@ func TestCarve_DispatcherIdleFlush(t *testing.T) {
 	const uploadDelay = 100 * time.Millisecond
 
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	local, err := fs.NewWithOptions(t.TempDir(), 0, nil, fs.FSStoreOptions{
-		LocalChunkIndex: ms,
-	})
+	local, err := fs.NewWithOptions(t.TempDir(), 0, ms, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)
 	}

--- a/pkg/block/engine/drain_persist_test.go
+++ b/pkg/block/engine/drain_persist_test.go
@@ -171,7 +171,6 @@ func newEngineOverStore(t *testing.T, ms metadata.Store) *engine.Store {
 		t.Fatalf("metadata store %T does not implement metadata.SyncedHashStore", ms)
 	}
 	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
-		LocalChunkIndex: ms,
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 3_600_000, // 1h — async/ticker rollup can never fire

--- a/pkg/block/engine/drain_reset_test.go
+++ b/pkg/block/engine/drain_reset_test.go
@@ -19,7 +19,6 @@ func newDrainResetFixture(t *testing.T) (*Store, *fs.FSStore) {
 	t.Helper()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
-		LocalChunkIndex: ms,
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 3_600_000, // 1h — async/ticker rollup can never fire

--- a/pkg/block/engine/engine_dualread_test.go
+++ b/pkg/block/engine/engine_dualread_test.go
@@ -72,8 +72,7 @@ func newDualReadEnv(t *testing.T) *dualReadEnv {
 	t.Helper()
 	tmp := t.TempDir()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	bc, err := fs.NewWithOptions(tmp, 0, ms, fs.FSStoreOptions{
-		LocalChunkIndex: ms})
+	bc, err := fs.NewWithOptions(tmp, 0, ms, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)
 	}

--- a/pkg/block/engine/engine_health_test.go
+++ b/pkg/block/engine/engine_health_test.go
@@ -64,7 +64,6 @@ func buildHealthTestEngine(t *testing.T) (*Store, *fakeRemoteStore) {
 	tmpDir := t.TempDir()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	localStore, err := fs.NewWithOptions(tmpDir, 100*1024*1024, ms, fs.FSStoreOptions{
-		LocalChunkIndex: ms,
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 50,

--- a/pkg/block/engine/engine_offline_test.go
+++ b/pkg/block/engine/engine_offline_test.go
@@ -161,7 +161,6 @@ func TestPrefetchSuppressedWhenUnhealthy(t *testing.T) {
 	tmpDir := t.TempDir()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	localStore, err := fs.NewWithOptions(tmpDir, 100*1024*1024, ms, fs.FSStoreOptions{
-		LocalChunkIndex: ms,
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 50,

--- a/pkg/block/engine/loadbyhash_test.go
+++ b/pkg/block/engine/loadbyhash_test.go
@@ -18,8 +18,7 @@ import (
 func newLoadByHashFixture(t *testing.T) (*Store, *fs.FSStore) {
 	t.Helper()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
-		LocalChunkIndex: ms})
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)
 	}

--- a/pkg/block/engine/locator_fetch_test.go
+++ b/pkg/block/engine/locator_fetch_test.go
@@ -22,7 +22,6 @@ func newLocatorFetchSyncer(t *testing.T) (*Syncer, *remotememory.Store, *metadat
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	t.Cleanup(func() { _ = ms.Close() })
 	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
-		LocalChunkIndex: ms,
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 5,

--- a/pkg/block/engine/nil_remotestore_test.go
+++ b/pkg/block/engine/nil_remotestore_test.go
@@ -16,8 +16,7 @@ func newNilRemoteStoreEnv(t *testing.T) (*Syncer, local.LocalStore, func()) {
 	t.Helper()
 	tmpDir := t.TempDir()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	bc, err := fs.NewWithOptions(tmpDir, 0, ms, fs.FSStoreOptions{
-		LocalChunkIndex: ms})
+	bc, err := fs.NewWithOptions(tmpDir, 0, ms, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions() error = %v", err)
 	}

--- a/pkg/block/engine/onchunkcomplete_test.go
+++ b/pkg/block/engine/onchunkcomplete_test.go
@@ -19,8 +19,7 @@ import (
 func newOnChunkCompleteFixture(t *testing.T, readBufferBytes int64) (*Store, *fs.FSStore) {
 	t.Helper()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
-		LocalChunkIndex: ms})
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)
 	}

--- a/pkg/block/engine/pending_set_test.go
+++ b/pkg/block/engine/pending_set_test.go
@@ -31,7 +31,6 @@ func newPendingSetFixture(t *testing.T, startUploader bool, carveBytes int64) (*
 		StabilizationMS: 5,
 		RollupStore:     ms,
 		SyncedHashStore: ms,
-		LocalChunkIndex: ms,
 	})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)
@@ -156,7 +155,6 @@ func TestSyncer_SeedPendingFromDisk_RecoversUnsynced(t *testing.T) {
 		StabilizationMS: 5,
 		RollupStore:     ms,
 		SyncedHashStore: ms,
-		LocalChunkIndex: ms,
 	})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)

--- a/pkg/block/engine/read_cache_bench_test.go
+++ b/pkg/block/engine/read_cache_bench_test.go
@@ -295,8 +295,7 @@ func TestReadThroughCache_BoundedByMaxDisk(t *testing.T) {
 	dir := t.TempDir()
 	// No SyncedHashStore: every fetched chunk is immediately evictable, so the
 	// bound is enforced by Put's ensureSpace alone.
-	loc, err := localfs.NewWithOptions(dir, maxDisk, newStubFileChunkStore(), localfs.FSStoreOptions{
-		LocalChunkIndex: metastore.NewMemoryMetadataStoreWithDefaults()})
+	loc, err := localfs.NewWithOptions(dir, maxDisk, metastore.NewMemoryMetadataStoreWithDefaults(), localfs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("NewWithOptions: %v", err)
 	}

--- a/pkg/block/engine/read_path_test.go
+++ b/pkg/block/engine/read_path_test.go
@@ -133,8 +133,7 @@ func TestReadPath_StandaloneLocatorServedViaFallback(t *testing.T) {
 	mem := remotememory.New()
 
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	local, err := fs.NewWithOptions(t.TempDir(), 0, nil, fs.FSStoreOptions{
-		LocalChunkIndex: metadatamemory.NewMemoryMetadataStoreWithDefaults()})
+	local, err := fs.NewWithOptions(t.TempDir(), 0, metadatamemory.NewMemoryMetadataStoreWithDefaults(), fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)
 	}

--- a/pkg/block/engine/readthrough_torntail_test.go
+++ b/pkg/block/engine/readthrough_torntail_test.go
@@ -33,9 +33,7 @@ func TestReadThrough_TornTail_RecoversFromRemote(t *testing.T) {
 	// agree on a single source of truth (as they do in production).
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 
-	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
-		LocalChunkIndex: ms,
-	})
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)
 	}

--- a/pkg/block/engine/sync_health_integration_test.go
+++ b/pkg/block/engine/sync_health_integration_test.go
@@ -111,7 +111,6 @@ func newHealthTestEnv(t *testing.T) *healthTestEnv {
 		StabilizationMS: 50,
 		RollupStore:     ms,
 		SyncedHashStore: ms,
-		LocalChunkIndex: ms,
 	})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions() error = %v", err)
@@ -361,8 +360,7 @@ func TestHealthCallbackInvocation(t *testing.T) {
 func TestHealthMonitorNilRemoteStore(t *testing.T) {
 	tmpDir := t.TempDir()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	bc, err := fs.NewWithOptions(tmpDir, 0, ms, fs.FSStoreOptions{
-		LocalChunkIndex: ms})
+	bc, err := fs.NewWithOptions(tmpDir, 0, ms, fs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions() error = %v", err)
 	}

--- a/pkg/block/engine/warm_randread_bench_test.go
+++ b/pkg/block/engine/warm_randread_bench_test.go
@@ -95,7 +95,6 @@ func buildWarmFSFixture(tb testing.TB) (*engine.Store, string, []block.ChunkRef,
 
 	// --- fs engine (mirrors newEngineOverStore; nil remote) ---
 	localStore, err := fs.NewWithOptions(tb.TempDir(), 256*1024*1024, ms, fs.FSStoreOptions{
-		LocalChunkIndex: ms,
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 3_600_000, // async rollup never fires; only explicit DrainRollups

--- a/pkg/block/engine/warm_read_integrity_test.go
+++ b/pkg/block/engine/warm_read_integrity_test.go
@@ -33,7 +33,6 @@ func newEngineWithRemote(t *testing.T, ms metadata.Store, mem *remotememory.Stor
 		t.Fatalf("metadata store %T does not implement metadata.SyncedHashStore", ms)
 	}
 	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
-		LocalChunkIndex: ms,
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 3_600_000, // async rollup never fires; explicit DrainRollups only

--- a/pkg/block/local/fs/appendlog_budget_c3_test.go
+++ b/pkg/block/local/fs/appendlog_budget_c3_test.go
@@ -21,7 +21,6 @@ func newC3BudgetStore(t *testing.T, maxLogBytes int64) *FSStore {
 		StabilizationMS: 1,
 		RollupStore:     mem,
 		SyncedHashStore: mem,
-		LocalChunkIndex: mem,
 	})
 	if err != nil {
 		t.Fatalf("NewWithOptions: %v", err)

--- a/pkg/block/local/fs/appendlog_internals_test.go
+++ b/pkg/block/local/fs/appendlog_internals_test.go
@@ -35,12 +35,11 @@ func appendlogFactory(t *testing.T) *fs.FSStore {
 	t.Helper()
 	dir := t.TempDir()
 	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
-	bc, err := fs.NewWithOptions(dir, 1<<30, nil, fs.FSStoreOptions{
+	bc, err := fs.NewWithOptions(dir, 1<<30, rs, fs.FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 50,
 		RollupStore:     rs,
-		LocalChunkIndex: rs,
 	})
 	if err != nil {
 		t.Fatalf("NewWithOptions: %v", err)

--- a/pkg/block/local/fs/appendlog_testhelpers_test.go
+++ b/pkg/block/local/fs/appendlog_testhelpers_test.go
@@ -1,61 +1,17 @@
 package fs
 
 import (
-	"context"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/marmos91/dittofs/pkg/block"
 	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
-// nopFBS is a no-op block.EngineFileChunkStore used by
-// tests. Every read returns ErrFileChunkNotFound; every write is a no-op.
-// Sufficient for the append-log path because AppendWrite does not
-// consult FileChunkStore at all.
-//
-// Shared across /05/06 test files in the fs package.
-// narrowed the public FileChunkStore to 6 methods; this
-// stub satisfies the wider engine-internal surface (the 6 plus
-// GetFileChunk + ListFileChunks).
-type nopFBS struct{}
-
-func (nopFBS) GetByHash(_ context.Context, _ block.ContentHash) (*block.FileChunk, error) {
-	return nil, nil
-}
-func (nopFBS) Put(_ context.Context, _ *block.FileChunk) error { return nil }
-func (nopFBS) Delete(_ context.Context, _ string) error {
-	return block.ErrFileChunkNotFound
-}
-func (nopFBS) IncrementRefCount(_ context.Context, _ string) error { return nil }
-func (nopFBS) DecrementRefCount(_ context.Context, _ string) (uint32, error) {
-	return 0, nil
-}
-func (nopFBS) DecrementRefCountAndReap(_ context.Context, _ string) (uint32, error) {
-	return 0, nil
-}
-func (nopFBS) AddRef(_ context.Context, _ block.ContentHash, _ string, _ block.ChunkRef) error {
-	// tests don't exercise the LRU hit path, so always
-	// returning ErrUnknownHash matches "hash never Put" — production
-	// callers fall back to the full Put path.
-	return block.ErrUnknownHash
-}
-
-// Engine-internal surface (kept off the public FileChunkStore per
-func (nopFBS) GetFileChunk(_ context.Context, _ string) (*block.FileChunk, error) {
-	return nil, block.ErrFileChunkNotFound
-}
-func (nopFBS) ListFileChunks(_ context.Context, _ string) ([]*block.FileChunk, error) {
-	return nil, nil
-}
-func (nopFBS) EnumeratePayloads(_ context.Context, _ func(payloadID string) error) error {
-	return nil
-}
-
 // newFSStoreForTest constructs an FSStore in t.TempDir with the given
-// options and a nopFBS backing store. Registers t.Cleanup to Close the
-// store. Shared by /05/06/07/09 test files in the fs package.
+// options and a memory metadata backend (serving as both the file-chunk
+// store and the mandatory LocalChunkIndex). Registers t.Cleanup to Close
+// the store. Shared by /05/06/07/09 test files in the fs package.
 func newFSStoreForTest(t *testing.T, opts FSStoreOptions) *FSStore {
 	t.Helper()
 	dir, err := os.MkdirTemp("", "fsstore-test-*")

--- a/pkg/block/local/fs/appendlog_testhelpers_test.go
+++ b/pkg/block/local/fs/appendlog_testhelpers_test.go
@@ -58,17 +58,13 @@ func (nopFBS) EnumeratePayloads(_ context.Context, _ func(payloadID string) erro
 // store. Shared by /05/06/07/09 test files in the fs package.
 func newFSStoreForTest(t *testing.T, opts FSStoreOptions) *FSStore {
 	t.Helper()
-	// The log-blob substrate is required for all normal chunk I/O. Default-wire
-	// a memory metadata store as the LocalChunkIndex when the caller did not
-	// supply one, so helper-constructed stores exercise the logblob path.
-	if opts.LocalChunkIndex == nil {
-		opts.LocalChunkIndex = memmeta.NewMemoryMetadataStoreWithDefaults()
-	}
 	dir, err := os.MkdirTemp("", "fsstore-test-*")
 	if err != nil {
 		t.Fatalf("MkdirTemp: %v", err)
 	}
-	bc, err := NewWithOptions(dir, 1<<30, nopFBS{}, opts)
+	// The metadata backend is mandatory: it doubles as the LocalChunkIndex for
+	// the log-blob substrate. A memory store serves both facets.
+	bc, err := NewWithOptions(dir, 1<<30, memmeta.NewMemoryMetadataStoreWithDefaults(), opts)
 	if err != nil {
 		_ = os.RemoveAll(dir)
 		t.Fatalf("NewWithOptions: %v", err)

--- a/pkg/block/local/fs/appendwrite_group_commit_bench_test.go
+++ b/pkg/block/local/fs/appendwrite_group_commit_bench_test.go
@@ -125,11 +125,8 @@ func BenchmarkAppendWrite_GroupCommit(b *testing.B) {
 // refactoring the test-side helper.
 func newBenchFSStore(b *testing.B, opts FSStoreOptions) *FSStore {
 	b.Helper()
-	if opts.LocalChunkIndex == nil {
-		opts.LocalChunkIndex = memmeta.NewMemoryMetadataStoreWithDefaults()
-	}
 	dir := b.TempDir()
-	bc, err := NewWithOptions(dir, 1<<30, nopFBS{}, opts)
+	bc, err := NewWithOptions(dir, 1<<30, memmeta.NewMemoryMetadataStoreWithDefaults(), opts)
 	if err != nil {
 		b.Fatalf("NewWithOptions: %v", err)
 	}

--- a/pkg/block/local/fs/chunkstore.go
+++ b/pkg/block/local/fs/chunkstore.go
@@ -5,28 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/local/logblob"
 )
 
-// chunkPath returns the content-addressed chunk path under baseDir/blocks/.
-// Layout: <baseDir>/blocks/<hex[0:2]>/<hex[2:4]>/<hex> (two-level shard).
-//
-// Path components are derived exclusively from hex.EncodeToString(h[:]) — the
-// characters are constrained to [0-9a-f], so path traversal via crafted hash
-// input is not possible (threat).
-func (bc *FSStore) chunkPath(h block.ContentHash) string {
-	hex := h.String()
-	return filepath.Join(bc.baseDir, "blocks", hex[0:2], hex[2:4], hex)
-}
-
-// StoreChunk writes data under its content-addressed path. Atomic via
-// .tmp + rename; fsyncs the chunk file and the containing directory so the
-// rename is durable (step 1 CAS durability, torn-write safety —
-// threat).
+// StoreChunk appends data to the log-blob substrate and records its location
+// in the local chunk index.
 //
 // Idempotent: if the chunk already exists (HasChunk returns true for h)
 // StoreChunk is a no-op and returns nil. This is what lets the rollup pool
@@ -35,11 +20,6 @@ func (bc *FSStore) chunkPath(h block.ContentHash) string {
 // Caller is responsible for asserting that BLAKE3(data) == h before calling;
 // StoreChunk trusts its inputs (threat accept). The rollup pool
 // is the only production caller.
-//
-// TRANSITIONAL-NEXT-MILESTONE: zstd compression (see #519 "Deferred to
-// v0.17+"). Compression would wrap the data slice before disk write
-// OnChunkComplete still receives the UNCOMPRESSED data so the engine
-// Cache can serve reads without an extra decompress hop.
 func (bc *FSStore) StoreChunk(ctx context.Context, h block.ContentHash, data []byte) error {
 	if bc.isClosed() {
 		return ErrStoreClosed
@@ -54,87 +34,7 @@ func (bc *FSStore) StoreChunk(ctx context.Context, h block.ContentHash, data []b
 	if exists {
 		return nil
 	}
-
-	// Log-blob path: when an index is wired, append the chunk bytes to the
-	// log-blob substrate and record the location in the index instead of
-	// writing a per-chunk cas/<hash> file. Legacy CAS writer below is the
-	// fallback for index-less fixtures (quarantined, not deleted).
-	if bc.logBlob != nil && bc.localChunkIndex != nil {
-		return bc.storeChunkLogBlob(ctx, h, data)
-	}
-
-	path := bc.chunkPath(h)
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return fmt.Errorf("chunkstore: mkdir: %w", err)
-	}
-
-	// Use a unique temp filename per attempt so two concurrent StoreChunk
-	// calls for the same hash (whether on Unix or Windows) do not race on
-	// the same .tmp file. The destination is content-addressed and idempotent
-	// if the rename target already exists from a winning concurrent call
-	// treat that as success after re-stating the destination.
-	f, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
-	if err != nil {
-		return fmt.Errorf("chunkstore: create tmp: %w", err)
-	}
-	tmp := f.Name()
-	if _, err := f.Write(data); err != nil {
-		_ = f.Close()
-		_ = os.Remove(tmp)
-		return fmt.Errorf("chunkstore: write tmp: %w", err)
-	}
-	if err := f.Sync(); err != nil {
-		_ = f.Close()
-		_ = os.Remove(tmp)
-		return fmt.Errorf("chunkstore: fsync tmp: %w", err)
-	}
-	if err := f.Close(); err != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("chunkstore: close tmp: %w", err)
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		// On Windows, os.Rename fails if the destination already exists.
-		// CAS writes are idempotent — if the destination is already there
-		// with the same content (a concurrent winner stored the same hash)
-		// treat that as success and clean up our tmp.
-		if _, statErr := os.Stat(path); statErr == nil {
-			_ = os.Remove(tmp)
-			return nil
-		}
-		_ = os.Remove(tmp)
-		return fmt.Errorf("chunkstore: rename: %w", err)
-	}
-	// Fsync the parent dir so the rename durably reaches stable storage.
-	// Best-effort: a failing dir fsync does not invalidate the data (the file
-	// is fully written + fsynced above); log-free to match flush.go's
-	// syncFile posture on read-only dir handles.
-	if dir, err := os.Open(filepath.Dir(path)); err == nil {
-		_ = dir.Sync()
-		_ = dir.Close()
-	}
-	bc.diskUsed.Add(int64(len(data)))
-	// register the chunk with the in-process LRU so eviction can
-	// reach it. This is the canonical post-write touch — readers use a
-	// separate ReadChunk wiring to promote on cache hits.
-	//
-	// TRANSITIONAL-NEXT-MILESTONE: pinned hot-tail RAM (see #519 "Deferred
-	// to v0.17+"). When pinned hot-tail RAM lands, StoreChunk may bypass
-	// the disk write entirely for recently-rolled-up chunks, requiring
-	// the OnChunkComplete callback to fire from the RAM-tier path instead.
-	bc.lruTouch(h, int64(len(data)), path)
-
-	// Fire the chunk-completion callback after disk store + LRU touch
-	// succeed. Exactly-once-per-successful-touch contract. Nil-safe —
-	// the legacy behavior is preserved when no callback is installed.
-	// Fires OUTSIDE the lruMu lock (lruTouch
-	// released it on return) to avoid widening the hot lock window across
-	// an unrelated lock (the typical consumer is engine.Cache.Put, which
-	// takes its own lock). Error paths above already returned before this
-	// point — the callback is invariant on successful StoreChunk only.
-	if cb := bc.onChunkComplete.Load(); cb != nil && cb.fn != nil {
-		cb.fn(h, data, path)
-	}
-	return nil
+	return bc.storeChunkLogBlob(ctx, h, data)
 }
 
 // storeChunkLogBlob appends data to the log-blob substrate and records the
@@ -226,18 +126,8 @@ type stagedChunk struct {
 //
 // Returns staged=true with the location to commit for a freshly appended
 // log-blob chunk; staged=false when nothing needs a deferred index write — a
-// dedup hit against an already-durable chunk, or the legacy CAS path (index-less
-// fixtures), which fsyncs the cas/<hash> file inline in StoreChunk.
+// dedup hit against an already-durable chunk.
 func (bc *FSStore) stageRollupChunk(ctx context.Context, h block.ContentHash, data []byte) (stagedChunk, error) {
-	// Legacy CAS path: no log-blob / index wired. StoreChunk fsyncs the
-	// cas/<hash> file before returning, so durability needs no deferral.
-	if bc.logBlob == nil || bc.localChunkIndex == nil {
-		if err := bc.StoreChunk(ctx, h, data); err != nil {
-			return stagedChunk{}, err
-		}
-		return stagedChunk{}, nil
-	}
-
 	// Dedup against chunks already made durable by a prior pass. (Intra-pass
 	// duplicate hashes are deduped by the caller's per-pass set, since staged
 	// chunks are not yet in the index.)
@@ -283,9 +173,8 @@ func (bc *FSStore) commitStagedChunk(ctx context.Context, sc stagedChunk) error 
 // ReadChunk returns the bytes of the chunk addressed by h.
 // Returns block.ErrChunkNotFound if the chunk is absent.
 //
-// Dual-mode: a wired local chunk index is consulted first (logblob-resident
-// chunks); on a miss it falls back to the legacy cas/<hash> file so
-// pre-existing CAS data stays readable (back-compat until PR4 migrates it).
+// The local chunk index is consulted for the chunk's log-blob location; an
+// index miss is a clean absent (block.ErrChunkNotFound).
 func (bc *FSStore) ReadChunk(ctx context.Context, h block.ContentHash) ([]byte, error) {
 	if bc.isClosed() {
 		return nil, ErrStoreClosed
@@ -293,95 +182,48 @@ func (bc *FSStore) ReadChunk(ctx context.Context, h block.ContentHash) ([]byte, 
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	if bc.localChunkIndex != nil {
-		loc, ok, err := bc.localChunkIndex.GetLocalLocation(ctx, h)
-		if err != nil {
-			return nil, fmt.Errorf("chunkstore: get local location: %w", err)
-		}
-		if ok {
-			if loc.RawLength == 0 {
-				return []byte{}, nil
-			}
-			dst := make([]byte, loc.RawLength)
-			n, rerr := bc.logBlob.ReadAt(ctx, loc, dst)
-			if rerr != nil {
-				// A short read (io.EOF before RawLength bytes) means the blob
-				// tail was torn by a crash in the append→fsync window: the
-				// durable index entry now points past the bytes that actually
-				// reached disk. Rather than hard-error, drop the dangling index
-				// entry and report the chunk as absent so the engine's
-				// miss→remote-refetch→re-stage path recovers it from the
-				// authoritative remote copy (torn ≡ evicted: both leave no
-				// durable local bytes and no index entry). Any other error is a
-				// genuine I/O failure and surfaces unchanged.
-				if errors.Is(rerr, io.EOF) {
-					return nil, bc.dropTornIndexEntry(ctx, h)
-				}
-				// An evicted or missing blob means the index entry is a
-				// dangling leftover of blob-level eviction (entries for blobs
-				// written by a previous process are cleaned up lazily here,
-				// and eager cleanup in blobEvictOne is best-effort). Same
-				// recovery routing as the torn tail: drop the entry and
-				// report a miss so the engine refetches from the remote.
-				if errors.Is(rerr, logblob.ErrEvicted) || errors.Is(rerr, logblob.ErrBlobNotFound) {
-					return nil, bc.dropTornIndexEntry(ctx, h)
-				}
-				return nil, fmt.Errorf("chunkstore: logblob read: %w", rerr)
-			}
-			if int64(n) < loc.RawLength {
-				// Defensive: nil error but fewer bytes than the index recorded
-				// (a torn tail landing exactly at EOF). Same recovery routing.
-				return nil, bc.dropTornIndexEntry(ctx, h)
-			}
-			return dst[:n], nil
-		}
-	}
-	path := bc.chunkPath(h)
-	f, err := os.Open(path)
+	loc, ok, err := bc.localChunkIndex.GetLocalLocation(ctx, h)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, block.ErrChunkNotFound
+		return nil, fmt.Errorf("chunkstore: get local location: %w", err)
+	}
+	if !ok {
+		return nil, block.ErrChunkNotFound
+	}
+	if loc.RawLength == 0 {
+		return []byte{}, nil
+	}
+	dst := make([]byte, loc.RawLength)
+	n, rerr := bc.logBlob.ReadAt(ctx, loc, dst)
+	if rerr != nil {
+		// A short read (io.EOF before RawLength bytes) means the blob
+		// tail was torn by a crash in the append→fsync window: the
+		// durable index entry now points past the bytes that actually
+		// reached disk. Rather than hard-error, drop the dangling index
+		// entry and report the chunk as absent so the engine's
+		// miss→remote-refetch→re-stage path recovers it from the
+		// authoritative remote copy (torn ≡ evicted: both leave no
+		// durable local bytes and no index entry). Any other error is a
+		// genuine I/O failure and surfaces unchanged.
+		if errors.Is(rerr, io.EOF) {
+			return nil, bc.dropTornIndexEntry(ctx, h)
 		}
-		return nil, fmt.Errorf("chunkstore: open: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-	// .blk chunk files are immutable content-addressed blobs: StoreChunk
-	// writes the full slice then atomically renames into place, so the
-	// on-disk size equals the content size and never changes afterward.
-	// Stat the open fd (not the path) so a concurrent lruEvictOne unlink
-	// can't change the size out from under us — the open fd still reads on
-	// POSIX. A single stat-sized allocation + io.ReadFull avoids the
-	// repeated doubling+copy that io.ReadAll incurs on the big-read path.
-	var data []byte
-	fi, err := f.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("chunkstore: read: %w", err)
-	}
-	if size := fi.Size(); size > 0 {
-		buf := make([]byte, size)
-		if _, err := io.ReadFull(f, buf); err != nil {
-			return nil, fmt.Errorf("chunkstore: read: %w", err)
+		// An evicted or missing blob means the index entry is a
+		// dangling leftover of blob-level eviction (entries for blobs
+		// written by a previous process are cleaned up lazily here,
+		// and eager cleanup in blobEvictOne is best-effort). Same
+		// recovery routing as the torn tail: drop the entry and
+		// report a miss so the engine refetches from the remote.
+		if errors.Is(rerr, logblob.ErrEvicted) || errors.Is(rerr, logblob.ErrBlobNotFound) {
+			return nil, bc.dropTornIndexEntry(ctx, h)
 		}
-		data = buf
-	} else {
-		// Zero-byte stat (or an unexpected non-regular file): fall back to
-		// io.ReadAll, which correctly handles a size we can't trust.
-		data, err = io.ReadAll(f)
-		if err != nil {
-			return nil, fmt.Errorf("chunkstore: read: %w", err)
-		}
+		return nil, fmt.Errorf("chunkstore: logblob read: %w", rerr)
 	}
-	// promote on cache hit so frequently-read chunks survive
-	// eviction. A concurrent lruEvictOne may have unlinked the file
-	// between os.Open and here — the open fd still reads on POSIX, but
-	// re-inserting into the LRU would create a ghost entry that points at
-	// a path that no longer exists. Re-stat before re-inserting; if the
-	// file is gone, skip the touch (the next read will surface
-	// ErrChunkNotFound under the engine's accept-and-refetch posture).
-	if _, statErr := os.Stat(path); statErr == nil {
-		bc.lruTouch(h, int64(len(data)), path)
+	if int64(n) < loc.RawLength {
+		// Defensive: nil error but fewer bytes than the index recorded
+		// (a torn tail landing exactly at EOF). Same recovery routing.
+		return nil, bc.dropTornIndexEntry(ctx, h)
 	}
-	return data, nil
+	return dst[:n], nil
 }
 
 // readChunkRangeInto serves [subOffset, subOffset+len(dst)) of CAS chunk h
@@ -403,7 +245,7 @@ func (bc *FSStore) readChunkRangeInto(ctx context.Context, h block.ContentHash, 
 	if err := ctx.Err(); err != nil {
 		return false, err
 	}
-	if bc.localChunkIndex == nil || len(dst) == 0 {
+	if len(dst) == 0 {
 		return false, nil
 	}
 	loc, ok, err := bc.localChunkIndex.GetLocalLocation(ctx, h)
@@ -453,26 +295,13 @@ func (bc *FSStore) HasChunk(ctx context.Context, h block.ContentHash) (bool, err
 	if err := ctx.Err(); err != nil {
 		return false, err
 	}
-	// Index-resident (logblob) chunks have no cas/<hash> file, so the index
-	// must be consulted first — otherwise a second rollup pass would re-Append
-	// the same bytes. Falls back to the legacy CAS stat for back-compat data.
-	if bc.localChunkIndex != nil {
-		_, ok, err := bc.localChunkIndex.GetLocalLocation(ctx, h)
-		if err != nil {
-			return false, fmt.Errorf("chunkstore: get local location: %w", err)
-		}
-		if ok {
-			return true, nil
-		}
+	// Index-resident (logblob) chunks are located via the local chunk index —
+	// consulting it dedups a second rollup pass from re-Appending the bytes.
+	_, ok, err := bc.localChunkIndex.GetLocalLocation(ctx, h)
+	if err != nil {
+		return false, fmt.Errorf("chunkstore: get local location: %w", err)
 	}
-	_, err := os.Stat(bc.chunkPath(h))
-	if err == nil {
-		return true, nil
-	}
-	if os.IsNotExist(err) {
-		return false, nil
-	}
-	return false, fmt.Errorf("chunkstore: stat: %w", err)
+	return ok, nil
 }
 
 // DeleteChunk removes the chunk file. Treats missing-file as success
@@ -488,33 +317,12 @@ func (bc *FSStore) DeleteChunk(ctx context.Context, h block.ContentHash) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	// Remove the index entry first so a logblob-resident chunk reads as a miss
+	// Remove the index entry so a logblob-resident chunk reads as a miss
 	// afterwards. Idempotent. The blob bytes themselves are reclaimed by
 	// blob-level eviction, handled separately — DeleteChunk does not rewrite
 	// the blob or adjust logBlobDiskUsed here.
-	if bc.localChunkIndex != nil {
-		if err := bc.localChunkIndex.DeleteLocalLocation(ctx, h); err != nil {
-			return fmt.Errorf("chunkstore: delete local location: %w", err)
-		}
+	if err := bc.localChunkIndex.DeleteLocalLocation(ctx, h); err != nil {
+		return fmt.Errorf("chunkstore: delete local location: %w", err)
 	}
-	path := bc.chunkPath(h)
-	st, statErr := os.Stat(path)
-	if err := os.Remove(path); err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("chunkstore: remove: %w", err)
-	}
-	if statErr == nil && st.Size() > 0 {
-		bc.subUsed(&bc.diskUsed, st.Size(), "cas")
-	}
-	// prune from the in-process LRU so a future ensureSpace doesn't
-	// try to unlink a file we just deleted.
-	bc.lruMu.Lock()
-	if el, ok := bc.lruIndex[h]; ok {
-		bc.lruList.Remove(el)
-		delete(bc.lruIndex, h)
-	}
-	bc.lruMu.Unlock()
 	return nil
 }

--- a/pkg/block/local/fs/chunkstore_torntail_test.go
+++ b/pkg/block/local/fs/chunkstore_torntail_test.go
@@ -18,9 +18,7 @@ func newLogBlobStore(t *testing.T) (*FSStore, context.Context) {
 	t.Helper()
 	dir := t.TempDir()
 	idx := memmeta.NewMemoryMetadataStoreWithDefaults()
-	bc, err := NewWithOptions(dir, 0, nil, FSStoreOptions{
-		LocalChunkIndex: idx,
-	})
+	bc, err := NewWithOptions(dir, 0, idx, FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("NewWithOptions: %v", err)
 	}

--- a/pkg/block/local/fs/compaction_test.go
+++ b/pkg/block/local/fs/compaction_test.go
@@ -67,10 +67,9 @@ func TestCompaction_BoundedLogSize(t *testing.T) {
 		RollupWorkers:            2,
 		StabilizationMS:          5,
 		RollupStore:              rs,
-		LocalChunkIndex:          rs,
 		CompactionThresholdBytes: 32 * 1024,
 	}
-	bc := newFSStoreForTest(t, opts)
+	bc := newFSStoreForTestWithFBS(t, rs, opts)
 	if err := bc.StartRollup(context.Background()); err != nil {
 		t.Fatalf("StartRollup: %v", err)
 	}
@@ -125,10 +124,9 @@ func TestCompaction_DisabledByNegativeThreshold(t *testing.T) {
 		RollupWorkers:            2,
 		StabilizationMS:          5,
 		RollupStore:              rs,
-		LocalChunkIndex:          rs,
 		CompactionThresholdBytes: -1,
 	}
-	bc := newFSStoreForTest(t, opts)
+	bc := newFSStoreForTestWithFBS(t, rs, opts)
 	if err := bc.StartRollup(context.Background()); err != nil {
 		t.Fatalf("StartRollup: %v", err)
 	}
@@ -169,10 +167,9 @@ func TestCompaction_RecoveryRebuildsAfterCompact(t *testing.T) {
 		RollupWorkers:            2,
 		StabilizationMS:          5,
 		RollupStore:              rs,
-		LocalChunkIndex:          rs,
 		CompactionThresholdBytes: 16 * 1024,
 	}
-	bc := newFSStoreForTest(t, opts)
+	bc := newFSStoreForTestWithFBS(t, rs, opts)
 	if err := bc.StartRollup(context.Background()); err != nil {
 		t.Fatalf("StartRollup: %v", err)
 	}
@@ -210,7 +207,7 @@ func TestCompaction_RecoveryRebuildsAfterCompact(t *testing.T) {
 		t.Fatalf("compaction did not trim log: size=%d cumulative writes=%d",
 			preReopenSize, phase1Bytes)
 	}
-	bc2, err := NewWithOptions(baseDir, 1<<30, nopFBS{}, opts)
+	bc2, err := NewWithOptions(baseDir, 1<<30, rs, opts)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
@@ -265,10 +262,9 @@ func TestCompaction_HeaderFlagSetAndPreservesCAS(t *testing.T) {
 		RollupWorkers:            2,
 		StabilizationMS:          5,
 		RollupStore:              rs,
-		LocalChunkIndex:          rs,
 		CompactionThresholdBytes: 8 * 1024,
 	}
-	bc := newFSStoreForTest(t, opts)
+	bc := newFSStoreForTestWithFBS(t, rs, opts)
 	if err := bc.StartRollup(context.Background()); err != nil {
 		t.Fatalf("StartRollup: %v", err)
 	}
@@ -345,12 +341,11 @@ func TestCompaction_HeaderFlagSetAndPreservesCAS(t *testing.T) {
 // cleanupCompactTemps sweep.
 func TestCompaction_StaleTempCleanedUpOnRecovery(t *testing.T) {
 	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
-	bc := newFSStoreForTest(t, FSStoreOptions{
+	bc := newFSStoreForTestWithFBS(t, rs, FSStoreOptions{
 		MaxLogBytes:     1 << 20,
 		RollupWorkers:   2,
 		StabilizationMS: 10,
 		RollupStore:     rs,
-		LocalChunkIndex: rs,
 	})
 	ctx := context.Background()
 
@@ -369,12 +364,11 @@ func TestCompaction_StaleTempCleanedUpOnRecovery(t *testing.T) {
 	}
 
 	// Reopen and run recovery.
-	bc2, err := NewWithOptions(baseDir, 1<<30, nopFBS{}, FSStoreOptions{
+	bc2, err := NewWithOptions(baseDir, 1<<30, rs, FSStoreOptions{
 		MaxLogBytes:     1 << 20,
 		RollupWorkers:   2,
 		StabilizationMS: 10,
 		RollupStore:     rs,
-		LocalChunkIndex: rs,
 	})
 	if err != nil {
 		t.Fatalf("reopen: %v", err)

--- a/pkg/block/local/fs/delete_truncate_test.go
+++ b/pkg/block/local/fs/delete_truncate_test.go
@@ -239,12 +239,11 @@ func TestDelete_DuringActiveRollup_NoMetadataZombie(t *testing.T) {
 	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
 	// Tiny stabilization so records become eligible for rollup within
 	// a few ms.
-	bc := newFSStoreForTest(t, FSStoreOptions{
+	bc := newFSStoreForTestWithFBS(t, rs, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 2,
 		RollupStore:     rs,
-		LocalChunkIndex: rs,
 	})
 	ctx := context.Background()
 
@@ -310,12 +309,11 @@ func TestDelete_CrashBetweenMetadataAndUnlink_OrphanSwept(t *testing.T) {
 
 	// First, create an FSStore with append-log on, write one record so
 	// a log file exists, then close.
-	bc1, err := NewWithOptions(dir, 1<<30, nopFBS{}, FSStoreOptions{
+	bc1, err := NewWithOptions(dir, 1<<30, rs, FSStoreOptions{
 		MaxLogBytes:            1 << 30,
 		RollupWorkers:          2,
 		StabilizationMS:        10,
 		RollupStore:            rs,
-		LocalChunkIndex:        rs,
 		OrphanLogMinAgeSeconds: 1, // short window so the test can age past it
 	})
 	if err != nil {
@@ -339,12 +337,11 @@ func TestDelete_CrashBetweenMetadataAndUnlink_OrphanSwept(t *testing.T) {
 	// Crash-recovery pass on a fresh FSStore with the same RollupStore.
 	// rs has no entry for "crashed" (metadata step never committed) and
 	// nopFBS has no block-0 entry — so it qualifies as orphan.
-	bc2, err := NewWithOptions(dir, 1<<30, nopFBS{}, FSStoreOptions{
+	bc2, err := NewWithOptions(dir, 1<<30, rs, FSStoreOptions{
 		MaxLogBytes:            1 << 30,
 		RollupWorkers:          2,
 		StabilizationMS:        10,
 		RollupStore:            rs,
-		LocalChunkIndex:        rs,
 		OrphanLogMinAgeSeconds: 1,
 	})
 	if err != nil {
@@ -465,12 +462,11 @@ func TestTruncate_ClosedStore_ReturnsErrStoreClosed(t *testing.T) {
 // did not error.
 func TestTruncate_Rollup_SkipsBeyondBoundary(t *testing.T) {
 	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
-	bc := newFSStoreForTest(t, FSStoreOptions{
+	bc := newFSStoreForTestWithFBS(t, rs, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 2,
 		RollupStore:     rs,
-		LocalChunkIndex: rs,
 	})
 	ctx := context.Background()
 

--- a/pkg/block/local/fs/disk_used_1527_test.go
+++ b/pkg/block/local/fs/disk_used_1527_test.go
@@ -35,7 +35,6 @@ import (
 func newBlobStoreWithLimit(t *testing.T, dir string, maxDisk int64, mds *memory.MemoryMetadataStore) *FSStore {
 	t.Helper()
 	bc, err := NewWithOptions(dir, maxDisk, mds, FSStoreOptions{
-		LocalChunkIndex: mds,
 		SyncedHashStore: mds,
 	})
 	if err != nil {
@@ -45,21 +44,6 @@ func newBlobStoreWithLimit(t *testing.T, dir string, maxDisk int64, mds *memory.
 	bc.SetRetentionPolicy(block.RetentionLRU, 0)
 	t.Cleanup(func() { _ = bc.Close() })
 	return bc
-}
-
-// writeCASFile writes a legacy per-chunk CAS file directly on disk (bypassing
-// StoreChunk and all accounting), simulating pre-flip data found at startup.
-func writeCASFile(t *testing.T, bc *FSStore, data []byte) block.ContentHash {
-	t.Helper()
-	h := blake3ContentHash(data)
-	path := bc.chunkPath(h)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		t.Fatalf("write CAS file: %v", err)
-	}
-	return h
 }
 
 // sumBlobFiles returns the total size of *.blob files under <dir>/blobs.
@@ -84,71 +68,6 @@ func sumBlobFiles(t *testing.T, dir string) int64 {
 		total += fi.Size()
 	}
 	return total
-}
-
-// TestRecover_SeedsDiskUsedFromLegacyCASFiles asserts that startup recovery
-// counts legacy CAS chunk files into diskUsed — the exact gap that let #1527's
-// counter go negative: seedLRUFromDisk made those files eviction candidates
-// while Recover's .blk-only walk left their bytes out of the seed.
-func TestRecover_SeedsDiskUsedFromLegacyCASFiles(t *testing.T) {
-	dir := t.TempDir()
-	mds := memory.NewMemoryMetadataStoreWithDefaults()
-	bc, err := NewWithOptions(dir, 0, mds, FSStoreOptions{})
-	if err != nil {
-		t.Fatalf("NewWithOptions: %v", err)
-	}
-	t.Cleanup(func() { _ = bc.Close() })
-	ctx := context.Background()
-
-	h1 := writeCASFile(t, bc, bytes.Repeat([]byte{0x01}, 100))
-	h2 := writeCASFile(t, bc, bytes.Repeat([]byte{0x02}, 200))
-	h3 := writeCASFile(t, bc, bytes.Repeat([]byte{0x03}, 300))
-
-	if err := bc.Recover(ctx); err != nil {
-		t.Fatalf("Recover: %v", err)
-	}
-	if got := bc.Stats().DiskUsed; got != 600 {
-		t.Fatalf("post-Recover DiskUsed = %d, want 600 (CAS bytes must be seeded)", got)
-	}
-
-	// GC-style deletes must walk the counter back to exactly zero — before
-	// the fix each delete subtracted from an unseeded counter, driving it
-	// negative and permanently disabling the disk limit.
-	for _, h := range []block.ContentHash{h1, h2, h3} {
-		if err := bc.DeleteChunk(ctx, h); err != nil {
-			t.Fatalf("DeleteChunk: %v", err)
-		}
-		if got := bc.Stats().DiskUsed; got < 0 {
-			t.Fatalf("DiskUsed went NEGATIVE after delete: %d", got)
-		}
-	}
-	if got := bc.Stats().DiskUsed; got != 0 {
-		t.Fatalf("DiskUsed after deleting everything = %d, want 0", got)
-	}
-}
-
-// TestDeleteChunk_UncountedFile_ClampsAtZero asserts the defensive clamp:
-// deleting a CAS file whose bytes were never added (accounting asymmetry)
-// must clamp the counter at 0 instead of underflowing negative.
-func TestDeleteChunk_UncountedFile_ClampsAtZero(t *testing.T) {
-	dir := t.TempDir()
-	mds := memory.NewMemoryMetadataStoreWithDefaults()
-	bc, err := NewWithOptions(dir, 0, mds, FSStoreOptions{})
-	if err != nil {
-		t.Fatalf("NewWithOptions: %v", err)
-	}
-	t.Cleanup(func() { _ = bc.Close() })
-	ctx := context.Background()
-
-	// Written directly on disk: present, evictable, but never counted.
-	h := writeCASFile(t, bc, bytes.Repeat([]byte{0xAA}, 500))
-
-	if err := bc.DeleteChunk(ctx, h); err != nil {
-		t.Fatalf("DeleteChunk: %v", err)
-	}
-	if got := bc.Stats().DiskUsed; got != 0 {
-		t.Fatalf("DiskUsed after uncounted delete = %d, want 0 (clamped, not negative)", got)
-	}
 }
 
 // TestLogBlobBytes_CountedAndSeededAcrossReopen asserts that log-blob bytes

--- a/pkg/block/local/fs/drain_reset_testhelpers_test.go
+++ b/pkg/block/local/fs/drain_reset_testhelpers_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/marmos91/dittofs/pkg/block"
-	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
 // memFBS is a minimal in-memory block.EngineFileChunkStore that
@@ -21,10 +20,14 @@ import (
 type memFBS struct {
 	mu   sync.Mutex
 	rows map[string]map[string]*block.FileChunk // payloadID -> blockID -> row
+	locs map[block.ContentHash]block.LocalChunkLocation
 }
 
 func newMemFileChunkStore() *memFBS {
-	return &memFBS{rows: make(map[string]map[string]*block.FileChunk)}
+	return &memFBS{
+		rows: make(map[string]map[string]*block.FileChunk),
+		locs: make(map[block.ContentHash]block.LocalChunkLocation),
+	}
 }
 
 // persist mirrors the engine's ObjectIDPersister FileChunk-row write loop
@@ -147,16 +150,34 @@ func (m *memFBS) AddRef(_ context.Context, _ block.ContentHash, _ string, _ bloc
 	return block.ErrUnknownHash
 }
 
+// LocalChunkIndex surface — memFBS doubles as the mandatory local chunk index
+// so a single store serves both facets (mirrors production's metadata backend).
+func (m *memFBS) PutLocalLocation(_ context.Context, h block.ContentHash, loc block.LocalChunkLocation) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.locs == nil {
+		m.locs = make(map[block.ContentHash]block.LocalChunkLocation)
+	}
+	m.locs[h] = loc
+	return nil
+}
+func (m *memFBS) GetLocalLocation(_ context.Context, h block.ContentHash) (block.LocalChunkLocation, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	loc, ok := m.locs[h]
+	return loc, ok, nil
+}
+func (m *memFBS) DeleteLocalLocation(_ context.Context, h block.ContentHash) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.locs, h)
+	return nil
+}
+
 // newFSStoreForTestWithFBS is newFSStoreForTest with a caller-supplied
 // FileChunkStore so the CAS-manifest read path can resolve rolled-up bytes.
 func newFSStoreForTestWithFBS(t *testing.T, fbs block.EngineFileChunkStore, opts FSStoreOptions) *FSStore {
 	t.Helper()
-	// The log-blob substrate is required for normal chunk I/O; default-wire a
-	// memory metadata store as the LocalChunkIndex when the caller did not
-	// supply one.
-	if opts.LocalChunkIndex == nil {
-		opts.LocalChunkIndex = memmeta.NewMemoryMetadataStoreWithDefaults()
-	}
 	dir, err := os.MkdirTemp("", "fsstore-drainreset-*")
 	if err != nil {
 		t.Fatalf("MkdirTemp: %v", err)

--- a/pkg/block/local/fs/durability_defer_test.go
+++ b/pkg/block/local/fs/durability_defer_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
 // TestUnstableWriteThenCommit_SurvivesReopen is the PR3 durability gate: an
@@ -13,7 +15,10 @@ import (
 // bytes read back. This is the "UNSTABLE writes + COMMIT → recover → data
 // present" half of the crash contract.
 func TestUnstableWriteThenCommit_SurvivesReopen(t *testing.T) {
-	bc := newFSStoreForTest(t, FSStoreOptions{MaxLogBytes: 1 << 30, StabilizationMS: 100000})
+	// Wire a shared metadata store as FCS/LocalChunkIndex + RollupStore so the
+	// reopen below (ReopenForTest) resolves the same backend.
+	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	bc := newFSStoreForTestWithFBS(t, rs, FSStoreOptions{MaxLogBytes: 1 << 30, StabilizationMS: 100000, RollupStore: rs})
 	ctx := context.Background()
 	const payloadID = "commit-survives"
 	payload := bytes.Repeat([]byte{0x5A}, 4096)
@@ -38,7 +43,6 @@ func TestUnstableWriteThenCommit_SurvivesReopen(t *testing.T) {
 	}
 
 	baseDir := bc.BaseDirForTest()
-	rs := bc.RollupStoreForTest()
 	if err := bc.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}

--- a/pkg/block/local/fs/eviction.go
+++ b/pkg/block/local/fs/eviction.go
@@ -14,32 +14,27 @@ import (
 )
 
 // ensureSpace enforces the local disk-capacity gate for the given number of
-// bytes on the Put (read-through staging) path. When over capacity it attempts
-// to free space via the in-process LRU (lruEvictOne unlinks the
-// least-recently-used evictable chunk and decrements bc.diskUsed); when no
-// evictable candidate remains it applies backpressure or returns ErrDiskFull as
-// described below. Note: with the per-chunk cas-file writer removed, the LRU is
-// not populated in steady state, so eviction frees nothing until blob-level
-// eviction is wired in — the capacity gate itself (diskUsed vs maxDisk) still
-// applies.
+// bytes on the Put (read-through staging) path. When over capacity it frees
+// space via whole-blob eviction of the oldest sealed, fully-synced log blob
+// (blobEvictOne), then compaction of unsynced-pinned blobs (compactBlobOne),
+// then a one-shot active-blob seal via Rotate; when nothing is evictable it
+// applies backpressure or returns ErrDiskFull as described below.
 //
 // Critical invariant (LSL-08): the eviction path must NOT consult the
-// FileChunkStore (the engine-level metadata store). On the write hot
-// path, eviction relies on on-disk presence and the in-process LRU index
-// for its accounting. Future changes to the engine API must not leak
-// FileChunkStore calls back into local storage decisions.
+// FileChunkStore (the engine-level metadata store). Future changes to the
+// engine API must not leak FileChunkStore calls back into local storage
+// decisions.
 //
 // It MAY, however, consult the SyncedHashStore — a distinct, narrow
-// interface that answers only per-hash sync state (IsSynced). lruEvictOne
-// uses it to refuse evicting an unsynced chunk before its first mirror
-// (evicting one destroys the only copy). SyncedHashStore is NOT the
-// FileChunkStore and is not covered by LSL-08; do not collapse the two
+// interface that answers only per-hash sync state (IsSynced). blobEvictOne
+// uses it to refuse evicting a blob holding unsynced chunks before their
+// first mirror (evicting one destroys the only copy). SyncedHashStore is NOT
+// the FileChunkStore and is not covered by LSL-08; do not collapse the two
 // when editing this path.
 //
 // Pin mode and the eviction-disabled flag short-circuit to ErrDiskFull
-// without touching the LRU. Retention TTL with a non-positive duration
-// behaves the same way: retention policy can keep blocks around
-// regardless of LRU position.
+// without evicting. Retention TTL with a non-positive duration behaves the
+// same way: retention policy can keep blocks around regardless.
 //
 // Concurrent ReadChunk that races an evict surfaces as
 // block.ErrChunkNotFound; the engine refetches from CAS
@@ -106,112 +101,98 @@ func (bc *FSStore) ensureSpace(ctx context.Context, needed int64) error {
 	}
 
 	for bc.usedBytes()+needed > bc.maxDisk {
-		freed, err := bc.lruEvictOne(ctx)
-		if errors.Is(err, errLRUEmpty) {
-			// CAS LRU exhausted: fall back to whole-blob eviction of the
-			// oldest sealed, fully-synced log blob (#1527 — post blocks-flip
-			// the bulk of the local tier lives in log blobs, invisible to the
-			// per-chunk LRU). blobEvictOne decrements logBlobDiskUsed itself.
-			// Like the lruEvictOne success path, do NOT release() here — the
-			// stall (if engaged) ends once the loop exits, keeping the
-			// engage/stall bookkeeping to one segment per ensureSpace call.
-			if bfreed, berr := bc.blobEvictOne(ctx); berr == nil && bfreed > 0 {
+		// Whole-blob eviction of the oldest sealed, fully-synced log blob
+		// (#1527 — the local tier lives in log blobs). blobEvictOne decrements
+		// logBlobDiskUsed itself; do NOT release() here — the stall (if
+		// engaged) ends once the loop exits, keeping the engage/stall
+		// bookkeeping to one segment per ensureSpace call.
+		if bfreed, berr := bc.blobEvictOne(ctx); berr == nil && bfreed > 0 {
+			continue
+		} else if berr != nil && !errors.Is(berr, errLRUEmpty) {
+			return fmt.Errorf("ensureSpace: %w", berr)
+		}
+
+		// No fully-synced blob to drop whole. Try compaction (#1497):
+		// relocate a sealed blob's unsynced survivors into the active blob
+		// and reclaim the dead remainder, so a few unsynced chunks no longer
+		// pin a whole blob and --local-store-size stays enforceable.
+		if cfreed, cerr := bc.compactBlobOne(ctx); cerr == nil && cfreed > 0 {
+			continue
+		} else if cerr != nil && !errors.Is(cerr, errLRUEmpty) {
+			return fmt.Errorf("ensureSpace: %w", cerr)
+		}
+
+		// blobEvictOne found no sealed, fully-synced blob to reclaim, yet
+		// log-blob bytes remain — they are sitting in the still-open active
+		// blob. This is the read-through cache case: a small maxDisk fills
+		// one active blob long before it reaches the roll threshold, so
+		// blobEvictOne (sealed-only) can never touch it. Seal it via Rotate
+		// so the next blobEvictOne can reclaim it. Capped at one rotation
+		// per call: an active blob of *unsynced* bytes is still refused by
+		// blobEvictOne and must fall through to backpressure below rather
+		// than spin out empty blobs. (#1497 replaces this whole-blob seal
+		// with finer-grained log-blob compaction.)
+		if !rotatedUnderPressure && bc.logBlob != nil && bc.logBlobDiskUsed.Load() > 0 {
+			if rerr := bc.logBlob.Rotate(); rerr == nil {
+				rotatedUnderPressure = true
 				continue
-			} else if berr != nil && !errors.Is(berr, errLRUEmpty) {
-				return fmt.Errorf("ensureSpace: %w", berr)
 			}
+		}
 
-			// No fully-synced blob to drop whole. Try compaction (#1497):
-			// relocate a sealed blob's unsynced survivors into the active blob
-			// and reclaim the dead remainder, so a few unsynced chunks no longer
-			// pin a whole blob and --local-store-size stays enforceable.
-			if cfreed, cerr := bc.compactBlobOne(ctx); cerr == nil && cfreed > 0 {
-				continue
-			} else if cerr != nil && !errors.Is(cerr, errLRUEmpty) {
-				return fmt.Errorf("ensureSpace: %w", cerr)
-			}
-
-			// blobEvictOne found no sealed, fully-synced blob to reclaim, yet
-			// log-blob bytes remain — they are sitting in the still-open active
-			// blob. This is the read-through cache case: a small maxDisk fills
-			// one active blob long before it reaches the roll threshold, so
-			// blobEvictOne (sealed-only) can never touch it. Seal it via Rotate
-			// so the next blobEvictOne can reclaim it. Capped at one rotation
-			// per call: an active blob of *unsynced* bytes is still refused by
-			// blobEvictOne and must fall through to backpressure below rather
-			// than spin out empty blobs. (#1497 replaces this whole-blob seal
-			// with finer-grained log-blob compaction.)
-			if !rotatedUnderPressure && bc.logBlob != nil && bc.logBlobDiskUsed.Load() > 0 {
-				if rerr := bc.logBlob.Rotate(); rerr == nil {
-					rotatedUnderPressure = true
-					continue
+		// No evictable sealed blob: every remaining byte is still unsynced
+		// (or lives in the active blob).
+		// Branch on whether a remote-backed syncer is wired:
+		//
+		//   - remote-backed (bpSource != nil): the local tier is a
+		//     write-through cache. If the remote is HEALTHY the syncer
+		//     can still drain unsynced chunks and free space, so engage
+		//     backpressure and stall up to the (longer) backpressure
+		//     window. If the remote is UNHEALTHY the syncer cannot
+		//     drain, so fail fast with ErrDiskFull rather than stalling
+		//     a writer that cannot make progress.
+		//   - local-only (bpSource == nil): wait the shorter evictMaxWait
+		//     for new evictable bytes (async rollup) to land.
+		if bc.bpSource != nil {
+			if !bc.bpSource.IsRemoteHealthy() {
+				// Remote cannot drain: fail fast (release if we had
+				// been stalling on a previously-healthy remote).
+				if engaged {
+					release("remote_unhealthy")
 				}
-			}
-
-			// No evictable CAS chunk or sealed blob: every remaining byte is
-			// still unsynced (or lives in the active blob).
-			// Branch on whether a remote-backed syncer is wired:
-			//
-			//   - remote-backed (bpSource != nil): the local tier is a
-			//     write-through cache. If the remote is HEALTHY the syncer
-			//     can still drain unsynced chunks and free space, so engage
-			//     backpressure and stall up to the (longer) backpressure
-			//     window. If the remote is UNHEALTHY the syncer cannot
-			//     drain, so fail fast with ErrDiskFull rather than stalling
-			//     a writer that cannot make progress.
-			//   - local-only (bpSource == nil): keep the legacy behavior —
-			//     wait the shorter evictMaxWait for new evictable chunks
-			//     (async StoreChunk from the rollup pool) to land.
-			if bc.bpSource != nil {
-				if !bc.bpSource.IsRemoteHealthy() {
-					// Remote cannot drain: fail fast (release if we had
-					// been stalling on a previously-healthy remote).
-					if engaged {
-						release("remote_unhealthy")
-					}
-					return ErrDiskFull
-				}
-				if !engaged {
-					// First time stalling on the remote-cache path for this
-					// request: arm the longer deadline, count the engage, and
-					// log it (rate-limited).
-					maxWait := bc.effectiveBackpressureMaxWait()
-					engaged = true
-					stallStart = time.Now()
-					deadline = stallStart.Add(maxWait)
-					bc.bpEngageCount.Add(1)
-					if bc.bpLogLimiter == nil || bc.bpLogLimiter.Allow() {
-						logger.Info("local cache backpressure engaged: waiting for syncer to drain",
-							"store", bc.baseDir,
-							"disk_used", bc.usedBytes(),
-							"max_disk", bc.maxDisk,
-							"needed", needed,
-							"unsynced_bytes", bc.bpSource.UnsyncedBytes(),
-							"remote_healthy", true,
-							"max_wait_ms", maxWait.Milliseconds())
-					}
-				}
-			}
-
-			if time.Now().After(deadline) {
-				release("window_exceeded")
 				return ErrDiskFull
 			}
-			select {
-			case <-ctx.Done():
-				release("ctx_cancelled")
-				return ctx.Err()
-			case <-time.After(100 * time.Millisecond):
-				continue
+			if !engaged {
+				// First time stalling on the remote-cache path for this
+				// request: arm the longer deadline, count the engage, and
+				// log it (rate-limited).
+				maxWait := bc.effectiveBackpressureMaxWait()
+				engaged = true
+				stallStart = time.Now()
+				deadline = stallStart.Add(maxWait)
+				bc.bpEngageCount.Add(1)
+				if bc.bpLogLimiter == nil || bc.bpLogLimiter.Allow() {
+					logger.Info("local cache backpressure engaged: waiting for syncer to drain",
+						"store", bc.baseDir,
+						"disk_used", bc.usedBytes(),
+						"max_disk", bc.maxDisk,
+						"needed", needed,
+						"unsynced_bytes", bc.bpSource.UnsyncedBytes(),
+						"remote_healthy", true,
+						"max_wait_ms", maxWait.Milliseconds())
+				}
 			}
 		}
-		if err != nil {
-			return fmt.Errorf("ensureSpace: %w", err)
+
+		if time.Now().After(deadline) {
+			release("window_exceeded")
+			return ErrDiskFull
 		}
-		bc.subUsed(&bc.diskUsed, freed, "cas")
-		if ctx.Err() != nil {
+		select {
+		case <-ctx.Done():
 			release("ctx_cancelled")
 			return ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+			continue
 		}
 	}
 
@@ -644,13 +625,6 @@ func (bc *FSStore) DrainLocalSynced(ctx context.Context) (int64, error) {
 		if ctx.Err() != nil {
 			return total, ctx.Err()
 		}
-		if freed, err := bc.lruEvictOne(ctx); err == nil {
-			bc.subUsed(&bc.diskUsed, freed, "cas")
-			total += freed
-			continue
-		} else if !errors.Is(err, errLRUEmpty) {
-			return total, fmt.Errorf("drain local synced: %w", err)
-		}
 		bfreed, err := bc.blobEvictOne(ctx)
 		if err != nil {
 			if !errors.Is(err, errLRUEmpty) {
@@ -666,7 +640,7 @@ func (bc *FSStore) DrainLocalSynced(ctx context.Context) (int64, error) {
 				total += cfreed
 				continue
 			}
-			// CAS-LRU, sealed-blob eviction, and compaction are all exhausted,
+			// Sealed-blob eviction and compaction are both exhausted,
 			// yet log-blob bytes remain: they sit in the still-open ACTIVE blob
 			// (a store below the 1 GiB roll threshold never seals — #1465). Seal
 			// it once so the next blobEvictOne can reclaim it. Capped at one
@@ -793,13 +767,6 @@ func (bc *FSStore) reclaimSpace(ctx context.Context) {
 
 	for bc.usedBytes() > bc.maxDisk {
 		if ctx.Err() != nil {
-			return
-		}
-		if freed, err := bc.lruEvictOne(ctx); err == nil {
-			bc.subUsed(&bc.diskUsed, freed, "cas")
-			continue
-		} else if !errors.Is(err, errLRUEmpty) {
-			logger.Warn("reclaimSpace: CAS eviction failed", "dir", bc.baseDir, "error", err)
 			return
 		}
 		if bfreed, err := bc.blobEvictOne(ctx); err != nil {

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -1,15 +1,12 @@
 package fs
 
 import (
-	"container/list"
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	iofs "io/fs"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -112,7 +109,8 @@ var (
 	ErrDiskFull       = errors.New("local store: disk full after eviction")
 	ErrFileNotInStore = errors.New("file not in local store")
 
-	// errLRUEmpty is returned by lruEvictOne when there are no candidates left.
+	// errLRUEmpty is returned by blobEvictOne/compactBlobOne when there is no
+	// evictable (sealed, fully-synced) blob left to reclaim.
 	errLRUEmpty = errors.New("local store: LRU empty, no eviction candidates")
 )
 
@@ -492,32 +490,10 @@ type FSStore struct {
 	persisterMu       sync.RWMutex
 	objectIDPersister ObjectIDPersister
 
-	// ---: in-process LRU for CAS chunks. ---
-	//
-	// Eviction is driven entirely from on-disk presence under
-	// blocks/{hh}/{hh}/{hex}, indexed by ContentHash in lruIndex/lruList.
-	// Eviction = unlink the file directly; no FileChunkStore lookup happens
-	// on the write hot path.
-	//
-	// Population
-	// - StoreChunk(...) -> lruTouch on rename success.
-	// - ReadChunk(...) -> lruTouch on read success (re-promote).
-	//   - seedLRUFromDisk() -> alphabetical scan at New() so warm-started
-	//                          stores have a deterministic LRU position.
-	//
-	// Mutations (Touch / EvictOne) are serialized by lruMu. Disk unlinks
-	// happen under lruMu; concurrent ReadChunk that races an evict surfaces
-	// as ENOENT and falls through to the engine refetch path (T-11-B-08).
-	lruMu    sync.Mutex
-	lruIndex map[block.ContentHash]*list.Element // *lruEntry
-	lruList  *list.List                          // most-recent at front
-
 	// ---: chunk-complete hook. ---
 
-	// onChunkComplete fires once per successful chunkstore.StoreChunk
-	// (immediately after that path's lruTouch). The ReadChunk path also
-	// touches the LRU but does not fire the callback — only the rollup
-	// pool's StoreChunk completion is reported. Install via
+	// onChunkComplete fires once per successful chunkstore.StoreChunk.
+	// Install via
 	// FSStoreOptions at construction or post-hoc via SetOnChunkComplete;
 	// the engine's Cache materializes in BlockStore.Start, AFTER
 	// cfg.Local is constructed, so the setter path is the production
@@ -601,9 +577,6 @@ func newFSStore(baseDir string, maxDisk int64, fileChunkStore block.EngineFileCh
 	// post-construction via SetDurable from the controlplane config["durable"].
 	bc.durable.Store(true)
 
-	// in-process LRU for CAS chunks (see field comments).
-	bc.lruIndex = make(map[block.ContentHash]*list.Element)
-	bc.lruList = list.New()
 	bc.blobChunks = make(map[string][]block.ContentHash)
 	bc.blobEvictedIDs = make(map[string]struct{})
 
@@ -632,36 +605,36 @@ func newFSStore(baseDir string, maxDisk int64, fileChunkStore block.EngineFileCh
 	// on the next scan.
 	bc.rollupCh = make(chan string, bc.rollupWorkers*4)
 
-	// Seed the in-process LRU from any chunks already present on
-	// disk under blocks/{hh}/{hh}/{hex}. Cold-start order is alphabetical
-	// for determinism; subsequent reads/writes promote chunks to the front.
-	bc.seedLRUFromDisk()
+	// LocalChunkIndex is mandatory: chunk persistence routes exclusively to
+	// the log-blob substrate + index. Production and all fixtures wire a
+	// metadata backend (badger/sqlite/postgres/memory) that implements it.
+	lci, ok := fileChunkStore.(metadata.LocalChunkIndex)
+	if !ok {
+		return nil, fmt.Errorf("fs local store: metadata backend must implement metadata.LocalChunkIndex")
+	}
+	bc.localChunkIndex = lci
 
 	applyFSStoreOptions(bc, opts)
 
-	// When a LocalChunkIndex is wired, open the per-store log-blob substrate
-	// at <baseDir>/blobs/. Rolled-up chunks append here (located via the
-	// index) instead of per-chunk cas/<hash> files. Index-less fixtures skip
-	// this and stay on the legacy CAS writer.
-	if bc.localChunkIndex != nil {
-		mgr, err := logblob.Open(filepath.Join(baseDir, "blobs"), logblob.Options{})
-		if err != nil {
-			return nil, fmt.Errorf("local store: open log-blob substrate: %w", err)
-		}
-		bc.logBlob = mgr
-		// Seed the blob byte counter from the physical blob files so the
-		// disk-usage figure survives restarts (#1527). ListBlobs reports the
-		// active blob at its recovered tail and sealed blobs at file size.
-		infos, err := mgr.ListBlobs()
-		if err != nil {
-			return nil, fmt.Errorf("local store: seed log-blob disk usage: %w", err)
-		}
-		var blobBytes int64
-		for _, bi := range infos {
-			blobBytes += bi.Size
-		}
-		bc.logBlobDiskUsed.Store(blobBytes)
+	// Open the per-store log-blob substrate at <baseDir>/blobs/. Rolled-up
+	// chunks append here (located via the index).
+	mgr, err := logblob.Open(filepath.Join(baseDir, "blobs"), logblob.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("local store: open log-blob substrate: %w", err)
 	}
+	bc.logBlob = mgr
+	// Seed the blob byte counter from the physical blob files so the
+	// disk-usage figure survives restarts (#1527). ListBlobs reports the
+	// active blob at its recovered tail and sealed blobs at file size.
+	infos, err := mgr.ListBlobs()
+	if err != nil {
+		return nil, fmt.Errorf("local store: seed log-blob disk usage: %w", err)
+	}
+	var blobBytes int64
+	for _, bi := range infos {
+		blobBytes += bi.Size
+	}
+	bc.logBlobDiskUsed.Store(blobBytes)
 
 	// Shared rollup concurrency budget, sized to the final worker count so
 	// the nudge path and the scanAllFiles fan-out share it (#1411). Floor of
@@ -715,7 +688,6 @@ func applyFSStoreOptions(bc *FSStore, opts FSStoreOptions) {
 	}
 	bc.rollupStore = opts.RollupStore
 	bc.syncedHashStore = opts.SyncedHashStore
-	bc.localChunkIndex = opts.LocalChunkIndex
 	bc.objectIDPersister = opts.ObjectIDPersister
 	if opts.OrphanLogMinAgeSeconds > 0 {
 		bc.orphanLogMinAgeSeconds = opts.OrphanLogMinAgeSeconds
@@ -821,210 +793,6 @@ func checkLegacyLayoutSentinel(baseDir string) error {
 	return fmt.Errorf("share %s: %w", baseDir, block.ErrLegacyLayoutDetected)
 }
 
-// lruEntry is a single LRU-tracked CAS chunk on disk.
-type lruEntry struct {
-	hash block.ContentHash
-	size int64
-	path string // absolute path under <baseDir>/blocks/<hh>/<hh>/<hex>
-}
-
-// lruTouch promotes (or inserts) a chunk to the most-recent end of the LRU.
-// Called from StoreChunk on rename success and from ReadChunk on cache hit.
-// Safe to call from concurrent goroutines.
-func (bc *FSStore) lruTouch(h block.ContentHash, size int64, path string) {
-	bc.lruMu.Lock()
-	defer bc.lruMu.Unlock()
-	if el, ok := bc.lruIndex[h]; ok {
-		bc.lruList.MoveToFront(el)
-		// Update size/path in case the chunk was re-stored (idempotent CAS).
-		entry := el.Value.(*lruEntry)
-		entry.size = size
-		entry.path = path
-		return
-	}
-	el := bc.lruList.PushFront(&lruEntry{hash: h, size: size, path: path})
-	bc.lruIndex[h] = el
-}
-
-// lruEvictOne removes the least-recently-used EVICTABLE chunk from the
-// LRU and unlinks its on-disk file. Returns the freed byte count, or 0 +
-// sentinel when there are no evictable candidates left. Concurrent
-// ReadChunk that races an evict surfaces as block.ErrChunkNotFound
-// (T-11-B-08, accept/refetch posture).
-//
-// A chunk is NOT evictable until it has been mirrored to remote: evicting
-// an unsynced chunk before its first upload silently destroys the only
-// copy. When a SyncedHashStore is wired, each candidate is consulted via
-// IsSynced; an unsynced candidate is moved to the FRONT of the LRU (the
-// most-recent end, away from the eviction tail) so the scan advances to
-// the next-oldest candidate instead of re-popping the same chunk. To
-// avoid spinning forever when every candidate is unsynced, the scan visits
-// at most a one-shot snapshot of the LRU length before giving up with
-// errLRUEmpty (ensureSpace then waits/back-pressures with ErrDiskFull).
-// When no SyncedHashStore is wired (local-only, no remote), every chunk is
-// evictable and the IsSynced step is skipped.
-//
-// IsSynced is called OUTSIDE lruMu: the SyncedHashStore has its own
-// internal mutex, so holding lruMu across the call would invert lock
-// ordering against the StoreChunk/touch path, and IsSynced may be slow on
-// the badger/postgres backends.
-//
-// Race-free design (optimistic peek-recheck): the candidate is NEVER
-// removed from lruIndex during the unlocked IsSynced call. Earlier code
-// popped the tail (list+index) before IsSynced and re-pushed afterwards;
-// during that unlocked window the entry was ABSENT from lruIndex, so a
-// concurrent ReadChunk/StoreChunk lruTouch for the same hash would insert
-// a SECOND list element — leaving lruIndex pointing at only one of two
-// duplicates (ghost entries + wrong disk accounting). Instead this loop:
-//  1. PEEKS the tail under lruMu (reads hash+size+path, leaves it in
-//     list/index), releases lruMu.
-//  2. Calls IsSynced unlocked.
-//  3. Re-acquires lruMu and VERIFIES the tail is still the same entry
-//     (same element, same hash, still indexed). A concurrent lruTouch may
-//     have moved it to the front in the meantime; if so it is no longer a
-//     victim, so we drop it and retry the peek loop. If still the tail and
-//     synced, remove+unlink under the recheck. If still the tail and
-//     unsynced, move it to the front and continue scanning.
-//
-// Because the entry is never absent from lruIndex during the unlocked
-// IsSynced, a concurrent lruTouch always finds it and moves it normally —
-// no ghost entries can form.
-func (bc *FSStore) lruEvictOne(ctx context.Context) (int64, error) {
-	// Snapshot the candidate budget under lruMu: at most this many
-	// unsynced/moved peeks before declaring "no evictable candidates".
-	bc.lruMu.Lock()
-	budget := bc.lruList.Len()
-	bc.lruMu.Unlock()
-
-	for attempts := 0; attempts < budget; attempts++ {
-		// 1. PEEK the tail without removing it from list/index.
-		bc.lruMu.Lock()
-		el := bc.lruList.Back()
-		if el == nil {
-			bc.lruMu.Unlock()
-			return 0, errLRUEmpty
-		}
-		entry := el.Value.(*lruEntry)
-		hash := entry.hash
-		bc.lruMu.Unlock()
-
-		// 2. Consult sync state OUTSIDE lruMu. Skip entirely for
-		//    local-only stores (no SyncedHashStore wired) — every chunk
-		//    is evictable there.
-		evictable := true
-		if bc.syncedHashStore != nil {
-			synced, err := bc.syncedHashStore.IsSynced(ctx, hash)
-			if err != nil {
-				// Treat lookup failures as unsynced: refuse to evict on
-				// uncertainty rather than risk destroying the only copy.
-				logger.Warn("lruEvictOne: IsSynced lookup failed, treating chunk as unsynced",
-					"hash", hash.String(), "error", err)
-				evictable = false
-			} else {
-				evictable = synced
-			}
-		}
-
-		// 3. Re-acquire lruMu and recheck the tail. A concurrent
-		//    lruTouch/StoreChunk may have moved this entry off the tail
-		//    during the unlocked IsSynced call.
-		bc.lruMu.Lock()
-		cur := bc.lruList.Back()
-		idxEl, stillIndexed := bc.lruIndex[hash]
-		if cur != el || !stillIndexed || idxEl != el {
-			// The tail changed (entry was touched/moved/removed): it is no
-			// longer the eviction victim. Drop it and retry the peek loop.
-			bc.lruMu.Unlock()
-			continue
-		}
-
-		if !evictable {
-			// Still the tail but unsynced: move it to the FRONT (away from
-			// the eviction tail) so the scan advances to the next-oldest
-			// candidate instead of re-popping this same chunk.
-			bc.lruList.MoveToFront(el)
-			bc.lruMu.Unlock()
-			continue
-		}
-
-		// Still the tail AND synced: remove from list+index under the
-		// recheck, then unlink the file.
-		path := entry.path
-		size := entry.size
-		bc.lruList.Remove(el)
-		delete(bc.lruIndex, hash)
-		bc.lruMu.Unlock()
-
-		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-			// File system error: re-insert to avoid losing the bookkeeping
-			// (the chunk is still on disk, it just couldn't be unlinked).
-			bc.lruMu.Lock()
-			bc.lruIndex[hash] = bc.lruList.PushBack(entry)
-			bc.lruMu.Unlock()
-			return 0, fmt.Errorf("evict %s: %w", path, err)
-		}
-		if rec := bc.recordMetrics(); rec != nil {
-			rec.RecordEviction(size)
-		}
-		return size, nil
-	}
-
-	// Every candidate within the snapshot budget was unsynced or moved off
-	// the tail (or the LRU was empty to begin with): no evictable chunk.
-	return 0, errLRUEmpty
-}
-
-// seedLRUFromDisk walks <baseDir>/blocks/ at startup and registers every
-// chunk file in the LRU. Order is deterministic (alphabetical hash hex)
-// so repeated startups produce the same cold-start eviction order.
-//
-// Best-effort: any per-file error is silently skipped (the next StoreChunk
-// or ReadChunk will register the chunk on demand).
-func (bc *FSStore) seedLRUFromDisk() {
-	blocksDir := filepath.Join(bc.baseDir, "blocks")
-	if _, err := os.Stat(blocksDir); err != nil {
-		return
-	}
-	type seed struct {
-		hash block.ContentHash
-		size int64
-		path string
-	}
-	var seeds []seed
-	_ = filepath.WalkDir(blocksDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
-			return nil
-		}
-		// Path layout: <baseDir>/blocks/<hh>/<hh>/<hex>.
-		name := d.Name()
-		if len(name) != block.HashSize*2 {
-			return nil
-		}
-		raw, err := hex.DecodeString(name)
-		if err != nil || len(raw) != block.HashSize {
-			return nil
-		}
-		var h block.ContentHash
-		copy(h[:], raw)
-		info, err := d.Info()
-		if err != nil {
-			return nil
-		}
-		seeds = append(seeds, seed{hash: h, size: info.Size(), path: path})
-		return nil
-	})
-	// Sort alphabetically by hash hex for deterministic cold-start order.
-	// Files visited by WalkDir are already lexicographically ordered within
-	// directories, but cross-directory order depends on filesystem
-	// traversal — sort explicitly to be safe.
-	sort.Slice(seeds, func(i, j int) bool {
-		return seeds[i].hash.String() < seeds[j].hash.String()
-	})
-	for _, s := range seeds {
-		bc.lruTouch(s.hash, s.size, s.path)
-	}
-}
-
 // FSStoreOptions configures the append-log path. Append is mandatory in
 // — the UseAppendLog opt-out flag was deleted with the legacy
 // path-keyed writer. MaxLogBytes, RollupWorkers, and StabilizationMS
@@ -1056,13 +824,6 @@ type FSStoreOptions struct {
 	// consumes it via ListUnsynced + MarkSynced). Nil is accepted for
 	// local-only stores; in that case ListUnsynced yields nothing.
 	SyncedHashStore metadata.SyncedHashStore
-	// LocalChunkIndex maps content hash -> position in a local log blob.
-	// When non-nil, chunk persistence routes to the log-blob substrate
-	// (logblob.Append + PutLocalLocation) instead of per-chunk cas/<hash>
-	// files, and local reads resolve index hits via logblob.ReadAt. Nil
-	// keeps the store on the legacy CAS writer/reader (index-less fixtures).
-	// Production wires the metadata store, which implements this interface.
-	LocalChunkIndex metadata.LocalChunkIndex
 	// ObjectIDPersister is the rollup-completion hook that receives the
 	// ChunkRef manifest + computed ObjectID after SetRollupOffset
 	// succeeds. Wire this to the engine coordinator's PersistFileChunks
@@ -1077,12 +838,12 @@ type FSStoreOptions struct {
 	// for the rationale.
 	OrphanLogMinAgeSeconds int
 
-	// OnChunkComplete is invoked once per successful chunkstore.lruTouch
-	// (post-disk-store), with the chunk's content hash, bytes, and on-disk
-	// path. Wire to engine.Cache.Put to populate the read cache at write
-	// time. Nil is accepted: chunkstore behaves identically to the
-	// pre-callback path if absent. Callback MUST be non-blocking on
-	// hot paths.
+	// OnChunkComplete is invoked once per successful chunk store
+	// (storeChunkLogBlob / stageRollupChunk), with the chunk's content hash and
+	// bytes (the path argument is empty on the log-blob path). Wire to
+	// engine.Cache.Put to populate the read cache at write time. Nil is
+	// accepted: chunkstore behaves identically to the pre-callback path if
+	// absent. Callback MUST be non-blocking on hot paths.
 	OnChunkComplete func(hash block.ContentHash, data []byte, path string)
 
 	// PressureMaxWait bounds how long AppendWrite blocks in its pressure

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -610,7 +610,7 @@ func newFSStore(baseDir string, maxDisk int64, fileChunkStore block.EngineFileCh
 	// metadata backend (badger/sqlite/postgres/memory) that implements it.
 	lci, ok := fileChunkStore.(metadata.LocalChunkIndex)
 	if !ok {
-		return nil, fmt.Errorf("fs local store: metadata backend must implement metadata.LocalChunkIndex")
+		return nil, fmt.Errorf("fs local store: metadata backend %T must implement metadata.LocalChunkIndex", fileChunkStore)
 	}
 	bc.localChunkIndex = lci
 

--- a/pkg/block/local/fs/fs_conformance_test.go
+++ b/pkg/block/local/fs/fs_conformance_test.go
@@ -19,12 +19,11 @@ func newFSStoreForConformance(t *testing.T) *fs.FSStore {
 	t.Helper()
 	dir := t.TempDir()
 	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
-	bc, err := fs.NewWithOptions(dir, 1<<30, nil, fs.FSStoreOptions{
+	bc, err := fs.NewWithOptions(dir, 1<<30, rs, fs.FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 50,
 		RollupStore:     rs,
-		LocalChunkIndex: rs,
 	})
 	if err != nil {
 		t.Fatalf("NewWithOptions: %v", err)

--- a/pkg/block/local/fs/healthcheck_test.go
+++ b/pkg/block/local/fs/healthcheck_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -47,6 +48,14 @@ func TestFSStore_Healthcheck_UnhealthyAfterClose(t *testing.T) {
 }
 
 func TestFSStore_Healthcheck_UnhealthyWhenBaseDirRemoved(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The store now always opens a log-blob substrate, so an active
+		// .blob fd is held for the store's lifetime. Removing baseDir out
+		// from under an open store is POSIX unlink-while-open semantics;
+		// Windows locks the open fd and RemoveAll fails, so the scenario
+		// this test exercises cannot occur on Windows.
+		t.Skip("baseDir cannot be removed while the log-blob fd is open on Windows")
+	}
 	dir := t.TempDir()
 	bs, err := NewWithOptions(dir, 0, memmeta.NewMemoryMetadataStoreWithDefaults(), FSStoreOptions{})
 	if err != nil {

--- a/pkg/block/local/fs/healthcheck_test.go
+++ b/pkg/block/local/fs/healthcheck_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/health"
+	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
 // newTestStore creates an FSStore rooted at a fresh tempdir suitable
@@ -15,7 +16,7 @@ import (
 func newTestStore(t *testing.T) *FSStore {
 	t.Helper()
 	dir := t.TempDir()
-	bs, err := NewWithOptions(dir, 0, nil, FSStoreOptions{})
+	bs, err := NewWithOptions(dir, 0, memmeta.NewMemoryMetadataStoreWithDefaults(), FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("NewWithDefaults: %v", err)
 	}
@@ -47,7 +48,7 @@ func TestFSStore_Healthcheck_UnhealthyAfterClose(t *testing.T) {
 
 func TestFSStore_Healthcheck_UnhealthyWhenBaseDirRemoved(t *testing.T) {
 	dir := t.TempDir()
-	bs, err := NewWithOptions(dir, 0, nil, FSStoreOptions{})
+	bs, err := NewWithOptions(dir, 0, memmeta.NewMemoryMetadataStoreWithDefaults(), FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("NewWithDefaults: %v", err)
 	}

--- a/pkg/block/local/fs/legacy_migration.go
+++ b/pkg/block/local/fs/legacy_migration.go
@@ -134,12 +134,6 @@ func (bc *FSStore) importLegacyChunkFile(ctx context.Context, h block.ContentHas
 	if statErr == nil && st.Size() > 0 {
 		bc.diskUsed.Add(-st.Size())
 	}
-	bc.lruMu.Lock()
-	if el, ok := bc.lruIndex[h]; ok {
-		bc.lruList.Remove(el)
-		delete(bc.lruIndex, h)
-	}
-	bc.lruMu.Unlock()
 	return nil
 }
 

--- a/pkg/block/local/fs/legacy_migration_test.go
+++ b/pkg/block/local/fs/legacy_migration_test.go
@@ -184,31 +184,11 @@ func TestMigrateLegacyChunkFiles_IgnoresForeignFiles(t *testing.T) {
 	}
 }
 
-// TestMigrateLegacyChunkFiles_NoSubstrateErrors proves the guard: a store
-// without the log-blob substrate cannot migrate.
-func TestMigrateLegacyChunkFiles_NoSubstrateErrors(t *testing.T) {
-	dir := t.TempDir()
-	writeLegacyChunkFile(t, dir, []byte("stranded"))
-	bc, err := NewWithOptions(dir, 0, nil, FSStoreOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = bc.Close() })
-	if bc.HasLogBlobSubstrate() {
-		t.Fatal("fixture should have no substrate")
-	}
-	if _, err := bc.MigrateLegacyChunkFiles(context.Background()); err == nil {
-		t.Fatal("expected error migrating without substrate")
-	}
-}
-
 // newLogBlobStoreAt mirrors newLogBlobStore but over a caller-owned dir so
 // legacy files can be planted before the store opens.
 func newLogBlobStoreAt(t *testing.T, dir string) (*FSStore, context.Context) {
 	t.Helper()
-	bc, err := NewWithOptions(dir, 0, nil, FSStoreOptions{
-		LocalChunkIndex: memmeta.NewMemoryMetadataStoreWithDefaults(),
-	})
+	bc, err := NewWithOptions(dir, 0, memmeta.NewMemoryMetadataStoreWithDefaults(), FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("NewWithOptions: %v", err)
 	}

--- a/pkg/block/local/fs/readpayload_verify_test.go
+++ b/pkg/block/local/fs/readpayload_verify_test.go
@@ -51,12 +51,7 @@ func runCorruptLocalChunk(t *testing.T, ms metadata.Store) {
 	if !ok {
 		t.Fatalf("metadata store %T does not implement block.EngineFileChunkStore", ms)
 	}
-	lci, ok := ms.(metadata.LocalChunkIndex)
-	if !ok {
-		t.Fatalf("metadata store %T does not implement metadata.LocalChunkIndex", ms)
-	}
-
-	store, err := NewWithOptions(t.TempDir(), 0, fcs, FSStoreOptions{LocalChunkIndex: lci})
+	store, err := NewWithOptions(t.TempDir(), 0, fcs, FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("NewWithOptions: %v", err)
 	}

--- a/pkg/block/local/fs/recovery_test.go
+++ b/pkg/block/local/fs/recovery_test.go
@@ -68,12 +68,11 @@ func reopenFSStore(t *testing.T, bc *FSStore, rs *memmeta.MemoryMetadataStore) *
 	t.Helper()
 	baseDir := bc.baseDir
 	_ = bc.Close()
-	bc2, err := NewWithOptions(baseDir, 1<<30, nopFBS{}, FSStoreOptions{
+	bc2, err := NewWithOptions(baseDir, 1<<30, rs, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 10,
 		RollupStore:     rs,
-		LocalChunkIndex: rs,
 	})
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
@@ -88,12 +87,11 @@ func reopenFSStore(t *testing.T, bc *FSStore, rs *memmeta.MemoryMetadataStore) *
 func newFSStoreWithRS(t *testing.T, rs *memmeta.MemoryMetadataStore) *FSStore {
 	t.Helper()
 	dir := t.TempDir()
-	bc, err := NewWithOptions(dir, 1<<30, nopFBS{}, FSStoreOptions{
+	bc, err := NewWithOptions(dir, 1<<30, rs, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 10,
 		RollupStore:     rs,
-		LocalChunkIndex: rs,
 	})
 	if err != nil {
 		t.Fatalf("new: %v", err)
@@ -265,12 +263,11 @@ func TestRecovery_FreshLogNotSwept(t *testing.T) {
 func TestRecovery_OrphanSweep_UnlinksLog(t *testing.T) {
 	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
 	dir := t.TempDir()
-	bc, err := NewWithOptions(dir, 1<<30, nopFBS{}, FSStoreOptions{
+	bc, err := NewWithOptions(dir, 1<<30, rs, FSStoreOptions{
 		MaxLogBytes:            1 << 30,
 		RollupWorkers:          2,
 		StabilizationMS:        10,
 		RollupStore:            rs,
-		LocalChunkIndex:        rs,
 		OrphanLogMinAgeSeconds: 1, // 1 second — short enough to trip during the test
 	})
 	if err != nil {
@@ -284,12 +281,11 @@ func TestRecovery_OrphanSweep_UnlinksLog(t *testing.T) {
 	// Wait out the configured 1s age gate.
 	time.Sleep(1100 * time.Millisecond)
 
-	bc2, err := NewWithOptions(dir, 1<<30, nopFBS{}, FSStoreOptions{
+	bc2, err := NewWithOptions(dir, 1<<30, rs, FSStoreOptions{
 		MaxLogBytes:            1 << 30,
 		RollupWorkers:          2,
 		StabilizationMS:        10,
 		RollupStore:            rs,
-		LocalChunkIndex:        rs,
 		OrphanLogMinAgeSeconds: 1,
 	})
 	if err != nil {
@@ -518,12 +514,11 @@ func TestRecovery_OrphanAgeFloor_WarnsOnNonPositive(t *testing.T) {
 
 	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
 	dir := t.TempDir()
-	bc, err := NewWithOptions(dir, 1<<30, nopFBS{}, FSStoreOptions{
+	bc, err := NewWithOptions(dir, 1<<30, rs, FSStoreOptions{
 		MaxLogBytes:            1 << 30,
 		RollupWorkers:          2,
 		StabilizationMS:        10,
 		RollupStore:            rs,
-		LocalChunkIndex:        rs,
 		OrphanLogMinAgeSeconds: 1, // pass NewWithOptions normalization
 	})
 	if err != nil {
@@ -544,12 +539,11 @@ func TestRecovery_OrphanAgeFloor_WarnsOnNonPositive(t *testing.T) {
 	}
 	_ = bc.Close()
 
-	bc2, err := NewWithOptions(dir, 1<<30, nopFBS{}, FSStoreOptions{
+	bc2, err := NewWithOptions(dir, 1<<30, rs, FSStoreOptions{
 		MaxLogBytes:            1 << 30,
 		RollupWorkers:          2,
 		StabilizationMS:        10,
 		RollupStore:            rs,
-		LocalChunkIndex:        rs,
 		OrphanLogMinAgeSeconds: 1, // again pass normalization
 	})
 	if err != nil {

--- a/pkg/block/local/fs/restart_seed_sqlite_test.go
+++ b/pkg/block/local/fs/restart_seed_sqlite_test.go
@@ -34,8 +34,7 @@ func TestFSStore_ListUnsynced_SQLiteIndex(t *testing.T) {
 	// SyncedHashStore with nothing marked synced → every logblob chunk is
 	// unsynced. Wire the SQLite store as the LocalChunkIndex so the seed path
 	// must walk a production backend's index, not the memory one.
-	bc := newFSStoreForTest(t, FSStoreOptions{
-		LocalChunkIndex: idx,
+	bc := newFSStoreForTestWithFBS(t, idx, FSStoreOptions{
 		SyncedHashStore: memory.NewMemoryMetadataStoreWithDefaults(),
 	})
 

--- a/pkg/block/local/fs/rollup_index_fence_test.go
+++ b/pkg/block/local/fs/rollup_index_fence_test.go
@@ -76,14 +76,13 @@ func TestRollup_LocalIndex_FencedBehindBlobSync(t *testing.T) {
 	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
 	idx := memmeta.NewMemoryMetadataStoreWithDefaults()
 	opts := FSStoreOptions{
-		LocalChunkIndex: idx,
 		RollupStore:     rs,
 		MaxLogBytes:     1 << 30,
 		StabilizationMS: 1,
 		RollupWorkers:   1,
 	}
 
-	bc, err := NewWithOptions(dir, 0, nil, opts)
+	bc, err := NewWithOptions(dir, 0, idx, opts)
 	if err != nil {
 		t.Fatalf("NewWithOptions: %v", err)
 	}
@@ -139,7 +138,7 @@ func TestRollup_LocalIndex_FencedBehindBlobSync(t *testing.T) {
 	if err := bc.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	bc2, err := NewWithOptions(dir, 0, nil, opts)
+	bc2, err := NewWithOptions(dir, 0, idx, opts)
 	if err != nil {
 		t.Fatalf("NewWithOptions (reopen): %v", err)
 	}
@@ -204,16 +203,15 @@ func TestRollup_TransientSyncFailure_ReadableWithoutRestart(t *testing.T) {
 	ctx := context.Background()
 
 	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
-	idx := memmeta.NewMemoryMetadataStoreWithDefaults()
 	// Real in-memory FileChunk store + persister so ReadPayloadAt's CAS-manifest
 	// path (step 2) can resolve rolled-up bytes after the fence trims the log
-	// index entries — the only read path left once a pass succeeds.
+	// index entries — the only read path left once a pass succeeds. fbs also
+	// serves as the mandatory LocalChunkIndex.
 	fbs := newMemFileChunkStore()
 	persister := func(pctx context.Context, payloadID string, blocks []block.ChunkRef, _ block.ObjectID) error {
 		return fbs.persist(pctx, payloadID, blocks)
 	}
 	opts := FSStoreOptions{
-		LocalChunkIndex:   idx,
 		RollupStore:       rs,
 		ObjectIDPersister: persister,
 		MaxLogBytes:       1 << 30,

--- a/pkg/block/local/fs/rollup_logblob_durability_test.go
+++ b/pkg/block/local/fs/rollup_logblob_durability_test.go
@@ -16,8 +16,7 @@ func newLogBlobStoreWithRollup(t *testing.T) *FSStore {
 	t.Helper()
 	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
 	idx := memmeta.NewMemoryMetadataStoreWithDefaults()
-	bc, err := NewWithOptions(t.TempDir(), 0, nil, FSStoreOptions{
-		LocalChunkIndex: idx,
+	bc, err := NewWithOptions(t.TempDir(), 0, idx, FSStoreOptions{
 		RollupStore:     rs,
 		MaxLogBytes:     1 << 30,
 		StabilizationMS: 1,

--- a/pkg/block/local/fs/test_hooks.go
+++ b/pkg/block/local/fs/test_hooks.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"hash/crc32"
 	"os"
 	"path/filepath"
@@ -172,7 +173,12 @@ func (bc *FSStore) ForceRollupForTest(ctx context.Context, payloadID string) err
 // metadata. Caller MUST have Close()'d any prior FSStore on the same
 // directory first (concurrent opens race on the log fds).
 func ReopenForTest(baseDir string, rs metadata.RollupStore) (*FSStore, error) {
-	bc, err := NewWithOptions(baseDir, 1<<30, nopFBSForTest{}, FSStoreOptions{
+	// The metadata backend doubles as the mandatory FileChunkStore + LocalChunkIndex.
+	fbs, ok := rs.(block.EngineFileChunkStore)
+	if !ok {
+		return nil, fmt.Errorf("ReopenForTest: RollupStore must also implement block.EngineFileChunkStore")
+	}
+	bc, err := NewWithOptions(baseDir, 1<<30, fbs, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 50,
@@ -240,54 +246,4 @@ func (bc *FSStore) FBSCallCountForTest() int {
 		return c.TotalCount()
 	}
 	return 0
-}
-
-// nopFBSForTest is a no-op FileChunkStore used by the ReopenForTest
-// helper. Every read returns ErrFileChunkNotFound; every write is a
-// no-op. Sufficient for the append-log conformance suite because
-// AppendWrite does not consult FileChunkStore at all, and the
-// Recover walk over .blk files finds none in a test tempdir that only
-// holds logs/ + blocks/.
-//
-// This is defined here (not in an _test.go file) so external test
-// packages can call ReopenForTest without exporting the
-// FileChunkStore type separately.
-type nopFBSForTest struct{}
-
-// nopFBSForTest satisfies the wider block.EngineFileChunkStore (the
-// 6 narrowed FileChunkStore methods plus the engine-internal GetFileChunk
-// and ListFileChunks). All operations are no-ops or return
-// ErrFileChunkNotFound.
-func (nopFBSForTest) GetByHash(_ context.Context, _ block.ContentHash) (*block.FileChunk, error) {
-	return nil, nil
-}
-func (nopFBSForTest) Put(_ context.Context, _ *block.FileChunk) error { return nil }
-func (nopFBSForTest) Delete(_ context.Context, _ string) error {
-	return block.ErrFileChunkNotFound
-}
-func (nopFBSForTest) IncrementRefCount(_ context.Context, _ string) error { return nil }
-func (nopFBSForTest) DecrementRefCount(_ context.Context, _ string) (uint32, error) {
-	return 0, nil
-}
-func (nopFBSForTest) DecrementRefCountAndReap(_ context.Context, _ string) (uint32, error) {
-	return 0, nil
-}
-func (nopFBSForTest) AddRef(_ context.Context, _ block.ContentHash, _ string, _ block.ChunkRef) error {
-	// no-op test stub. Every hash is "unknown" so the
-	// LRU hit path in production would always fall back to the full
-	// Put path — but this stub is only used by ReopenForTest scenarios
-	// that don't exercise AddRef at all.
-	return block.ErrUnknownHash
-}
-
-// Legacy engine-internal surface (kept off the
-// public FileChunkStore interface but required by EngineFileChunkStore).
-func (nopFBSForTest) GetFileChunk(_ context.Context, _ string) (*block.FileChunk, error) {
-	return nil, block.ErrFileChunkNotFound
-}
-func (nopFBSForTest) ListFileChunks(_ context.Context, _ string) ([]*block.FileChunk, error) {
-	return nil, nil
-}
-func (nopFBSForTest) EnumeratePayloads(_ context.Context, _ func(payloadID string) error) error {
-	return nil
 }

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -2875,15 +2875,9 @@ func CreateLocalStoreFromConfig(
 		if shs, ok := fileChunkStore.(metadata.SyncedHashStore); ok {
 			fsOpts.SyncedHashStore = shs
 		}
-		// Wire the LocalChunkIndex from the same metadata backend (#1414 object
-		// packing, PR3 global flip). With it set, rollup routes chunk persistence
-		// to the log-blob substrate + PutLocalLocation instead of the legacy CAS
-		// StoreChunk — the local half of the flip that makes the engine carver's
-		// GetLocalLocation→ReadLocalAt path resolvable. A backend that does not
-		// implement LocalChunkIndex leaves the local tier on the legacy CAS path.
-		if lci, ok := fileChunkStore.(metadata.LocalChunkIndex); ok {
-			fsOpts.LocalChunkIndex = lci
-		}
+		// The LocalChunkIndex is derived from the same metadata backend inside
+		// NewWithOptions (mandatory: chunk persistence routes to the log-blob
+		// substrate + PutLocalLocation). All backends implement it.
 		store, err := fs.NewWithOptions(shareDir, maxDisk, fileChunkStore, fsOpts)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## What

The per-chunk `cas/<hash>` writer/reader path in the local block store has been dead in production since the #1493 blocks-only flip: every share wires a metadata backend that implements `LocalChunkIndex`, so chunk persistence always routes to the log-blob substrate. Only index-less test fixtures reached the CAS branch.

This deletes it and makes the invariant explicit.

## Changes

- **`LocalChunkIndex` is now mandatory**, derived from the `fileChunkStore` param inside `newFSStore` (type-assert-or-error). Dropped the redundant `FSStoreOptions.LocalChunkIndex` field and the `if lci, ok` wiring block in `shares/service.go` — production already type-asserted the same object.
- **Deleted cas-only code**: the CAS branch of `StoreChunk` (now just existence-check → `storeChunkLogBlob`), `chunkPath`, the CAS fallbacks in `ReadChunk`/`HasChunk`/`DeleteChunk`, the `stageRollupChunk` legacy fork, and the cas-file LRU (`lruTouch`/`lruEvictOne`/`seedLRUFromDisk` + fields + `container/list`/`encoding/hex`/`sort` imports). Eviction ladder (`ensureSpace`/`reclaimSpace`/`DrainLocalSynced`) now starts blob-first.
- **Migrated index-less fixtures** to wire a memory metadata store; deleted cas-layout tests.

## Not touched

Shared append-log / rollup / compaction infra, the cas→blocks migration readers, and the `.blk` legacy-layout sentinel (`ErrLegacyLayoutDetected`) — those handle *pre-existing* on-disk data and are orthogonal.

## Verification

Net **−661 LOC** (46 files, +280/−941). Gates green: build, `go vet`, `gofmt -s`, `go test ./pkg/block/... ./internal/adapter/...` (5549 pass), `go test -race ./pkg/block/local/fs/... ./pkg/block/engine/...` (642 pass). The block/fs conformance suites pass unchanged — property preservation.