### PR TITLE
refactor(block/fs): derive RollupStore + SyncedHashStore facets from backend

### DIFF
--- a/internal/adapter/common/write_payload_test.go
+++ b/internal/adapter/common/write_payload_test.go
@@ -30,8 +30,6 @@ func newTestEngine(t *testing.T) *engine.Store {
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 50,
-		RollupStore:     ms,
-		SyncedHashStore: ms,
 	})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions failed: %v", err)

--- a/pkg/block/engine/cache_populated_on_rollup_test.go
+++ b/pkg/block/engine/cache_populated_on_rollup_test.go
@@ -43,8 +43,6 @@ func newRollupCacheFixture(t *testing.T) (*Store, *fs.FSStore, *recordingPutCach
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 5,
-		RollupStore:     ms,
-		SyncedHashStore: ms,
 	})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)

--- a/pkg/block/engine/drain_persist_test.go
+++ b/pkg/block/engine/drain_persist_test.go
@@ -162,8 +162,7 @@ func (c *testCoordinator) GetFileObjectID(ctx context.Context, payloadID string)
 // DrainRollups (the snapshot-create primitive).
 func newEngineOverStore(t *testing.T, ms metadata.Store) *engine.Store {
 	t.Helper()
-	rollupStore, ok := ms.(metadata.RollupStore)
-	if !ok {
+	if _, ok := ms.(metadata.RollupStore); !ok {
 		t.Fatalf("metadata store %T does not implement metadata.RollupStore", ms)
 	}
 	syncedHashStore, ok := ms.(metadata.SyncedHashStore)
@@ -174,8 +173,6 @@ func newEngineOverStore(t *testing.T, ms metadata.Store) *engine.Store {
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 3_600_000, // 1h — async/ticker rollup can never fire
-		RollupStore:     rollupStore,
-		SyncedHashStore: syncedHashStore,
 	})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)

--- a/pkg/block/engine/drain_reset_test.go
+++ b/pkg/block/engine/drain_reset_test.go
@@ -22,8 +22,6 @@ func newDrainResetFixture(t *testing.T) (*Store, *fs.FSStore) {
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 3_600_000, // 1h — async/ticker rollup can never fire
-		RollupStore:     ms,
-		SyncedHashStore: ms,
 	})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)

--- a/pkg/block/engine/engine_health_test.go
+++ b/pkg/block/engine/engine_health_test.go
@@ -67,8 +67,6 @@ func buildHealthTestEngine(t *testing.T) (*Store, *fakeRemoteStore) {
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 50,
-		RollupStore:     ms,
-		SyncedHashStore: ms,
 	})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions() error = %v", err)

--- a/pkg/block/engine/engine_offline_test.go
+++ b/pkg/block/engine/engine_offline_test.go
@@ -164,8 +164,6 @@ func TestPrefetchSuppressedWhenUnhealthy(t *testing.T) {
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 50,
-		RollupStore:     ms,
-		SyncedHashStore: ms,
 	})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions() error = %v", err)

--- a/pkg/block/engine/locator_fetch_test.go
+++ b/pkg/block/engine/locator_fetch_test.go
@@ -25,8 +25,6 @@ func newLocatorFetchSyncer(t *testing.T) (*Syncer, *remotememory.Store, *metadat
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 5,
-		RollupStore:     ms,
-		SyncedHashStore: ms,
 	})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)

--- a/pkg/block/engine/pending_set_test.go
+++ b/pkg/block/engine/pending_set_test.go
@@ -29,8 +29,6 @@ func newPendingSetFixture(t *testing.T, startUploader bool, carveBytes int64) (*
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 5,
-		RollupStore:     ms,
-		SyncedHashStore: ms,
 	})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)
@@ -153,8 +151,6 @@ func TestSyncer_SeedPendingFromDisk_RecoversUnsynced(t *testing.T) {
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 5,
-		RollupStore:     ms,
-		SyncedHashStore: ms,
 	})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)

--- a/pkg/block/engine/read_cache_bench_test.go
+++ b/pkg/block/engine/read_cache_bench_test.go
@@ -17,6 +17,16 @@ import (
 	metastore "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
+// backendNoSyncedHashStore adapts a metadata store to the local FSStore backend
+// surface (EngineFileChunkStore + the mandatory LocalChunkIndex) while omitting
+// the SyncedHashStore facet, so the soft derivation in NewWithOptions leaves
+// bc.syncedHashStore nil. Embedding the interfaces (not the concrete store)
+// keeps IsSynced/MarkSynced off the method set.
+type backendNoSyncedHashStore struct {
+	block.EngineFileChunkStore
+	metadata.LocalChunkIndex
+}
+
 // latencyRemote wraps a remotememory.Store and (a) injects a fixed per-read
 // WAN latency into the block-read path the engine fetch code actually calls
 // (dispatchRemoteFetch → readChunkVerified → ReadChunk), and (b) counts
@@ -293,9 +303,11 @@ func TestReadThroughCache_BoundedByMaxDisk(t *testing.T) {
 	ctx := context.Background()
 
 	dir := t.TempDir()
-	// No SyncedHashStore: every fetched chunk is immediately evictable, so the
-	// bound is enforced by Put's ensureSpace alone.
-	loc, err := localfs.NewWithOptions(dir, maxDisk, metastore.NewMemoryMetadataStoreWithDefaults(), localfs.FSStoreOptions{})
+	// A backend WITHOUT the SyncedHashStore facet so bc.syncedHashStore derives
+	// to nil: every fetched chunk is immediately evictable and the bound is
+	// enforced by Put's ensureSpace alone.
+	mds0 := metastore.NewMemoryMetadataStoreWithDefaults()
+	loc, err := localfs.NewWithOptions(dir, maxDisk, backendNoSyncedHashStore{EngineFileChunkStore: mds0, LocalChunkIndex: mds0}, localfs.FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("NewWithOptions: %v", err)
 	}

--- a/pkg/block/engine/sync_health_integration_test.go
+++ b/pkg/block/engine/sync_health_integration_test.go
@@ -109,8 +109,6 @@ func newHealthTestEnv(t *testing.T) *healthTestEnv {
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 50,
-		RollupStore:     ms,
-		SyncedHashStore: ms,
 	})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions() error = %v", err)

--- a/pkg/block/engine/warm_randread_bench_test.go
+++ b/pkg/block/engine/warm_randread_bench_test.go
@@ -98,8 +98,6 @@ func buildWarmFSFixture(tb testing.TB) (*engine.Store, string, []block.ChunkRef,
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 3_600_000, // async rollup never fires; only explicit DrainRollups
-		RollupStore:     ms,
-		SyncedHashStore: ms,
 	})
 	if err != nil {
 		tb.Fatalf("fs.NewWithOptions: %v", err)

--- a/pkg/block/engine/warm_read_integrity_test.go
+++ b/pkg/block/engine/warm_read_integrity_test.go
@@ -24,8 +24,7 @@ import (
 // remote, no eviction.
 func newEngineWithRemote(t *testing.T, ms metadata.Store, mem *remotememory.Store) *engine.Store {
 	t.Helper()
-	rollupStore, ok := ms.(metadata.RollupStore)
-	if !ok {
+	if _, ok := ms.(metadata.RollupStore); !ok {
 		t.Fatalf("metadata store %T does not implement metadata.RollupStore", ms)
 	}
 	syncedHashStore, ok := ms.(metadata.SyncedHashStore)
@@ -36,8 +35,6 @@ func newEngineWithRemote(t *testing.T, ms metadata.Store, mem *remotememory.Stor
 		MaxLogBytes:     128 * 1024 * 1024,
 		RollupWorkers:   2,
 		StabilizationMS: 3_600_000, // async rollup never fires; explicit DrainRollups only
-		RollupStore:     rollupStore,
-		SyncedHashStore: syncedHashStore,
 	})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)

--- a/pkg/block/engine/write_bench_test.go
+++ b/pkg/block/engine/write_bench_test.go
@@ -61,8 +61,6 @@ func newWriteBenchEngine(tb testing.TB) *Store {
 		MaxLogBytes:     writeBenchLogBudget,
 		RollupWorkers:   writeBenchRollupWorkers,
 		StabilizationMS: writeBenchStabilizationMS,
-		RollupStore:     ms,
-		SyncedHashStore: ms,
 	})
 	if err != nil {
 		tb.Fatalf("fs.NewWithOptions: %v", err)

--- a/pkg/block/local/fs/appendlog_budget_c3_test.go
+++ b/pkg/block/local/fs/appendlog_budget_c3_test.go
@@ -19,8 +19,6 @@ func newC3BudgetStore(t *testing.T, maxLogBytes int64) *FSStore {
 		MaxLogBytes:     maxLogBytes,
 		RollupWorkers:   1,
 		StabilizationMS: 1,
-		RollupStore:     mem,
-		SyncedHashStore: mem,
 	})
 	if err != nil {
 		t.Fatalf("NewWithOptions: %v", err)

--- a/pkg/block/local/fs/appendlog_internals_test.go
+++ b/pkg/block/local/fs/appendlog_internals_test.go
@@ -39,7 +39,6 @@ func appendlogFactory(t *testing.T) *fs.FSStore {
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 50,
-		RollupStore:     rs,
 	})
 	if err != nil {
 		t.Fatalf("NewWithOptions: %v", err)

--- a/pkg/block/local/fs/blockstore_methods_test.go
+++ b/pkg/block/local/fs/blockstore_methods_test.go
@@ -84,7 +84,7 @@ func hashSetEqual(a, b []block.ContentHash) bool {
 func TestFSStore_ListUnsynced(t *testing.T) {
 	t.Run("EmptyStore", func(t *testing.T) {
 		shs := memory.NewMemoryMetadataStoreWithDefaults()
-		bc := newFSStoreForTest(t, FSStoreOptions{SyncedHashStore: shs})
+		bc := newFSStoreForTestWithFBS(t, shs, FSStoreOptions{})
 
 		got, errs := collectIter(bc.ListUnsynced(context.Background()))
 		if len(got) != 0 {
@@ -98,9 +98,10 @@ func TestFSStore_ListUnsynced(t *testing.T) {
 	})
 
 	t.Run("NilSyncedHashStore", func(t *testing.T) {
-		// No SyncedHashStore wired — strict-subset invariant says
-		// "no synced markers" collapses to empty iterator.
-		bc := newFSStoreForTest(t, FSStoreOptions{})
+		// Backend without a SyncedHashStore facet — the soft derivation
+		// leaves bc.syncedHashStore nil, and the strict-subset invariant
+		// says "no synced markers" collapses to an empty iterator.
+		bc := newFSStoreForTestWithFBS(t, newMemFileChunkStore(), FSStoreOptions{})
 		_ = seedChunks(t, bc, 5)
 
 		got, errs := collectIter(bc.ListUnsynced(context.Background()))
@@ -116,7 +117,7 @@ func TestFSStore_ListUnsynced(t *testing.T) {
 
 	t.Run("AllSynced", func(t *testing.T) {
 		shs := memory.NewMemoryMetadataStoreWithDefaults()
-		bc := newFSStoreForTest(t, FSStoreOptions{SyncedHashStore: shs})
+		bc := newFSStoreForTestWithFBS(t, shs, FSStoreOptions{})
 		hashes := seedChunks(t, bc, 4)
 		ctx := context.Background()
 		for _, h := range hashes {
@@ -138,7 +139,7 @@ func TestFSStore_ListUnsynced(t *testing.T) {
 
 	t.Run("AllUnsynced", func(t *testing.T) {
 		shs := memory.NewMemoryMetadataStoreWithDefaults()
-		bc := newFSStoreForTest(t, FSStoreOptions{SyncedHashStore: shs})
+		bc := newFSStoreForTestWithFBS(t, shs, FSStoreOptions{})
 		hashes := seedChunks(t, bc, 4)
 
 		got, errs := collectIter(bc.ListUnsynced(context.Background()))
@@ -154,7 +155,7 @@ func TestFSStore_ListUnsynced(t *testing.T) {
 
 	t.Run("Partial", func(t *testing.T) {
 		shs := memory.NewMemoryMetadataStoreWithDefaults()
-		bc := newFSStoreForTest(t, FSStoreOptions{SyncedHashStore: shs})
+		bc := newFSStoreForTestWithFBS(t, shs, FSStoreOptions{})
 		hashes := seedChunks(t, bc, 5)
 		ctx := context.Background()
 
@@ -180,7 +181,7 @@ func TestFSStore_ListUnsynced(t *testing.T) {
 
 	t.Run("CtxCancelMidIter", func(t *testing.T) {
 		shs := memory.NewMemoryMetadataStoreWithDefaults()
-		bc := newFSStoreForTest(t, FSStoreOptions{SyncedHashStore: shs})
+		bc := newFSStoreForTestWithFBS(t, shs, FSStoreOptions{})
 		_ = seedChunks(t, bc, 10)
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/block/local/fs/chunkparams_rollup_test.go
+++ b/pkg/block/local/fs/chunkparams_rollup_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/chunker"
-	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
 // TestRollup_ChunkParams_SmallChunksReadBack is the #1569 threading guard: an
@@ -17,13 +16,11 @@ import (
 // reaches the rollup chunker), and (b) read that data back byte-for-byte
 // (proving small chunks round-trip through rollup + the CAS-manifest read path).
 func TestRollup_ChunkParams_SmallChunksReadBack(t *testing.T) {
-	fbs := newMemFileChunkStore()
-	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	fbs := newRollupMemFileChunkStore()
 	bc := newFSStoreForTestWithFBS(t, fbs, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   1,
 		StabilizationMS: 1,
-		RollupStore:     rs,
 		// Persist the rollup manifest into fbs so the post-rollup read resolves
 		// via the CAS-manifest path (fillFromCASManifest → blockStore). Without
 		// it ListFileChunks is empty and the read only succeeds while the bytes

--- a/pkg/block/local/fs/compaction_test.go
+++ b/pkg/block/local/fs/compaction_test.go
@@ -66,7 +66,6 @@ func TestCompaction_BoundedLogSize(t *testing.T) {
 		MaxLogBytes:              1 << 30,
 		RollupWorkers:            2,
 		StabilizationMS:          5,
-		RollupStore:              rs,
 		CompactionThresholdBytes: 32 * 1024,
 	}
 	bc := newFSStoreForTestWithFBS(t, rs, opts)
@@ -123,7 +122,6 @@ func TestCompaction_DisabledByNegativeThreshold(t *testing.T) {
 		MaxLogBytes:              1 << 30,
 		RollupWorkers:            2,
 		StabilizationMS:          5,
-		RollupStore:              rs,
 		CompactionThresholdBytes: -1,
 	}
 	bc := newFSStoreForTestWithFBS(t, rs, opts)
@@ -166,7 +164,6 @@ func TestCompaction_RecoveryRebuildsAfterCompact(t *testing.T) {
 		MaxLogBytes:              1 << 30,
 		RollupWorkers:            2,
 		StabilizationMS:          5,
-		RollupStore:              rs,
 		CompactionThresholdBytes: 16 * 1024,
 	}
 	bc := newFSStoreForTestWithFBS(t, rs, opts)
@@ -261,7 +258,6 @@ func TestCompaction_HeaderFlagSetAndPreservesCAS(t *testing.T) {
 		MaxLogBytes:              1 << 30,
 		RollupWorkers:            2,
 		StabilizationMS:          5,
-		RollupStore:              rs,
 		CompactionThresholdBytes: 8 * 1024,
 	}
 	bc := newFSStoreForTestWithFBS(t, rs, opts)
@@ -345,7 +341,6 @@ func TestCompaction_StaleTempCleanedUpOnRecovery(t *testing.T) {
 		MaxLogBytes:     1 << 20,
 		RollupWorkers:   2,
 		StabilizationMS: 10,
-		RollupStore:     rs,
 	})
 	ctx := context.Background()
 
@@ -368,7 +363,6 @@ func TestCompaction_StaleTempCleanedUpOnRecovery(t *testing.T) {
 		MaxLogBytes:     1 << 20,
 		RollupWorkers:   2,
 		StabilizationMS: 10,
-		RollupStore:     rs,
 	})
 	if err != nil {
 		t.Fatalf("reopen: %v", err)

--- a/pkg/block/local/fs/delete_truncate_test.go
+++ b/pkg/block/local/fs/delete_truncate_test.go
@@ -243,7 +243,6 @@ func TestDelete_DuringActiveRollup_NoMetadataZombie(t *testing.T) {
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 2,
-		RollupStore:     rs,
 	})
 	ctx := context.Background()
 
@@ -313,7 +312,6 @@ func TestDelete_CrashBetweenMetadataAndUnlink_OrphanSwept(t *testing.T) {
 		MaxLogBytes:            1 << 30,
 		RollupWorkers:          2,
 		StabilizationMS:        10,
-		RollupStore:            rs,
 		OrphanLogMinAgeSeconds: 1, // short window so the test can age past it
 	})
 	if err != nil {
@@ -341,7 +339,6 @@ func TestDelete_CrashBetweenMetadataAndUnlink_OrphanSwept(t *testing.T) {
 		MaxLogBytes:            1 << 30,
 		RollupWorkers:          2,
 		StabilizationMS:        10,
-		RollupStore:            rs,
 		OrphanLogMinAgeSeconds: 1,
 	})
 	if err != nil {
@@ -466,7 +463,6 @@ func TestTruncate_Rollup_SkipsBeyondBoundary(t *testing.T) {
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 2,
-		RollupStore:     rs,
 	})
 	ctx := context.Background()
 

--- a/pkg/block/local/fs/disk_used_1527_test.go
+++ b/pkg/block/local/fs/disk_used_1527_test.go
@@ -34,9 +34,7 @@ import (
 // post-flip configuration.
 func newBlobStoreWithLimit(t *testing.T, dir string, maxDisk int64, mds *memory.MemoryMetadataStore) *FSStore {
 	t.Helper()
-	bc, err := NewWithOptions(dir, maxDisk, mds, FSStoreOptions{
-		SyncedHashStore: mds,
-	})
+	bc, err := NewWithOptions(dir, maxDisk, mds, FSStoreOptions{})
 	if err != nil {
 		t.Fatalf("NewWithOptions: %v", err)
 	}

--- a/pkg/block/local/fs/drain_reset_test.go
+++ b/pkg/block/local/fs/drain_reset_test.go
@@ -37,11 +37,12 @@ func TestDrainRollups_ForcesManifestPopulation(t *testing.T) {
 
 	// Stabilization window is enormous (1 hour) so the ticker/stable path
 	// can NEVER consume the interval; only a forced drain can.
-	bc := newFSStoreForTest(t, FSStoreOptions{
+	// rs doubles as the backing FileChunkStore so the derived RollupStore
+	// is the same store this test reads for rollup-offset progress.
+	bc := newFSStoreForTestWithFBS(t, rs, FSStoreOptions{
 		MaxLogBytes:       1 << 30,
 		RollupWorkers:     2,
 		StabilizationMS:   3_600_000,
-		RollupStore:       rs,
 		ObjectIDPersister: persister,
 	})
 	// NOTE: intentionally NOT calling StartRollup — mirrors the snapshot
@@ -103,7 +104,6 @@ func TestDrainRollups_RealResidualReturnsErrDrainIncomplete(t *testing.T) {
 	bc := newFSStoreForTest(t, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		StabilizationMS: 1,
-		RollupStore:     memmeta.NewMemoryMetadataStoreWithDefaults(),
 	})
 	ctx := context.Background()
 	const payloadID = "file-real-residual"
@@ -137,7 +137,6 @@ func TestDrainRollups_TombstonedResidualSucceeds(t *testing.T) {
 	bc := newFSStoreForTest(t, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		StabilizationMS: 1,
-		RollupStore:     memmeta.NewMemoryMetadataStoreWithDefaults(),
 	})
 	ctx := context.Background()
 	const payloadID = "file-tombstoned-residual"
@@ -171,7 +170,6 @@ func TestDrainRollups_DivergentResidualSucceeds(t *testing.T) {
 	bc := newFSStoreForTest(t, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		StabilizationMS: 1,
-		RollupStore:     memmeta.NewMemoryMetadataStoreWithDefaults(),
 	})
 	ctx := context.Background()
 	const payloadID = "file-divergent-residual"
@@ -212,11 +210,9 @@ func TestDrainRollups_DivergentResidualSucceeds(t *testing.T) {
 // ("last record wins"), returning the MUTATED bytes. ResetLocalState must
 // drop the stale log so reads go purely through CAS.
 func TestResetLocalState_DropsStaleLog(t *testing.T) {
-	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
-
 	// Real FileChunk store so ReadPayloadAt's CAS manifest path resolves
 	// post-rollup bytes.
-	fbs := newMemFileChunkStore()
+	fbs := newRollupMemFileChunkStore()
 	persister := func(ctx context.Context, payloadID string, blocks []block.ChunkRef, _ block.ObjectID) error {
 		return fbs.persist(ctx, payloadID, blocks)
 	}
@@ -225,7 +221,6 @@ func TestResetLocalState_DropsStaleLog(t *testing.T) {
 		MaxLogBytes:       1 << 30,
 		RollupWorkers:     2,
 		StabilizationMS:   3_600_000,
-		RollupStore:       rs,
 		ObjectIDPersister: persister,
 	})
 
@@ -286,8 +281,7 @@ func TestResetLocalState_DropsStaleLog(t *testing.T) {
 // log files in place after a restore. After ResetLocalState, no .log
 // files must exist anywhere under the logs/ directory tree.
 func TestResetLocalState_DropsNestedLog(t *testing.T) {
-	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
-	fbs := newMemFileChunkStore()
+	fbs := newRollupMemFileChunkStore()
 	persister := func(ctx context.Context, payloadID string, blocks []block.ChunkRef, _ block.ObjectID) error {
 		return fbs.persist(ctx, payloadID, blocks)
 	}
@@ -296,7 +290,6 @@ func TestResetLocalState_DropsNestedLog(t *testing.T) {
 		MaxLogBytes:       1 << 30,
 		RollupWorkers:     2,
 		StabilizationMS:   3_600_000,
-		RollupStore:       rs,
 		ObjectIDPersister: persister,
 	})
 

--- a/pkg/block/local/fs/drain_reset_testhelpers_test.go
+++ b/pkg/block/local/fs/drain_reset_testhelpers_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
 // memFBS is a minimal in-memory block.EngineFileChunkStore that
@@ -172,6 +173,43 @@ func (m *memFBS) DeleteLocalLocation(_ context.Context, h block.ContentHash) err
 	defer m.mu.Unlock()
 	delete(m.locs, h)
 	return nil
+}
+
+// rollupMemFBS extends memFBS with the RollupStore facet so a single backend
+// serves FileChunkStore + LocalChunkIndex + RollupStore (mirrors production's
+// metadata backend, where all three are the same object derived from the
+// fileChunkStore inside NewWithOptions). Kept separate from memFBS so the plain
+// double still lacks RollupStore — the nil-RollupStore guardrail test relies on
+// a backend that does NOT implement it.
+type rollupMemFBS struct {
+	*memFBS
+	rollupMu sync.Mutex
+	rollups  map[string]uint64 // payloadID -> rollup_offset
+}
+
+func newRollupMemFileChunkStore() *rollupMemFBS {
+	return &rollupMemFBS{memFBS: newMemFileChunkStore(), rollups: make(map[string]uint64)}
+}
+
+func (m *rollupMemFBS) SetRollupOffset(_ context.Context, payloadID string, newOffset uint64) (uint64, error) {
+	m.rollupMu.Lock()
+	defer m.rollupMu.Unlock()
+	prev := m.rollups[payloadID]
+	if newOffset == 0 { // sentinel: unconditional reset
+		delete(m.rollups, payloadID)
+		return prev, nil
+	}
+	if newOffset < prev {
+		return prev, metadata.ErrRollupOffsetRegression
+	}
+	m.rollups[payloadID] = newOffset
+	return prev, nil
+}
+
+func (m *rollupMemFBS) GetRollupOffset(_ context.Context, payloadID string) (uint64, error) {
+	m.rollupMu.Lock()
+	defer m.rollupMu.Unlock()
+	return m.rollups[payloadID], nil
 }
 
 // newFSStoreForTestWithFBS is newFSStoreForTest with a caller-supplied

--- a/pkg/block/local/fs/durability_defer_test.go
+++ b/pkg/block/local/fs/durability_defer_test.go
@@ -18,7 +18,7 @@ func TestUnstableWriteThenCommit_SurvivesReopen(t *testing.T) {
 	// Wire a shared metadata store as FCS/LocalChunkIndex + RollupStore so the
 	// reopen below (ReopenForTest) resolves the same backend.
 	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
-	bc := newFSStoreForTestWithFBS(t, rs, FSStoreOptions{MaxLogBytes: 1 << 30, StabilizationMS: 100000, RollupStore: rs})
+	bc := newFSStoreForTestWithFBS(t, rs, FSStoreOptions{MaxLogBytes: 1 << 30, StabilizationMS: 100000})
 	ctx := context.Background()
 	const payloadID = "commit-survives"
 	payload := bytes.Repeat([]byte{0x5A}, 4096)

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -614,6 +614,14 @@ func newFSStore(baseDir string, maxDisk int64, fileChunkStore block.EngineFileCh
 	}
 	bc.localChunkIndex = lci
 
+	// RollupStore and SyncedHashStore are the same backend object, derived
+	// softly (not mandatory here). RollupStore is nil-tolerant: the caller
+	// may not start the rollup pool (service.go enforces the production
+	// guardrail). SyncedHashStore is nil-tolerant: local-only stores have no
+	// remote to mirror, so ListUnsynced yields nothing.
+	bc.rollupStore, _ = fileChunkStore.(metadata.RollupStore)
+	bc.syncedHashStore, _ = fileChunkStore.(metadata.SyncedHashStore)
+
 	applyFSStoreOptions(bc, opts)
 
 	// Open the per-store log-blob substrate at <baseDir>/blobs/. Rolled-up
@@ -686,8 +694,6 @@ func applyFSStoreOptions(bc *FSStore, opts FSStoreOptions) {
 	if opts.RollupDrainGrace > 0 {
 		bc.rollupDrainGraceDur = opts.RollupDrainGrace
 	}
-	bc.rollupStore = opts.RollupStore
-	bc.syncedHashStore = opts.SyncedHashStore
 	bc.objectIDPersister = opts.ObjectIDPersister
 	if opts.OrphanLogMinAgeSeconds > 0 {
 		bc.orphanLogMinAgeSeconds = opts.OrphanLogMinAgeSeconds
@@ -815,15 +821,6 @@ type FSStoreOptions struct {
 	// never issue COMMIT and expect per-write durability. See
 	// FSStore.syncEveryWrite.
 	SyncEveryWrite bool
-	// RollupStore persists per-file rollup_offset. Required
-	// when StartRollup will be called. Nil is accepted when the caller
-	// will not start the rollup pool.
-	RollupStore metadata.RollupStore
-	// SyncedHashStore persists per-CAS-hash local→remote sync state.
-	// Required when a remote store is configured (the engine's Syncer
-	// consumes it via ListUnsynced + MarkSynced). Nil is accepted for
-	// local-only stores; in that case ListUnsynced yields nothing.
-	SyncedHashStore metadata.SyncedHashStore
 	// ObjectIDPersister is the rollup-completion hook that receives the
 	// ChunkRef manifest + computed ObjectID after SetRollupOffset
 	// succeeds. Wire this to the engine coordinator's PersistFileChunks

--- a/pkg/block/local/fs/fs_conformance_test.go
+++ b/pkg/block/local/fs/fs_conformance_test.go
@@ -23,7 +23,6 @@ func newFSStoreForConformance(t *testing.T) *fs.FSStore {
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 50,
-		RollupStore:     rs,
 	})
 	if err != nil {
 		t.Fatalf("NewWithOptions: %v", err)

--- a/pkg/block/local/fs/lockorder_test.go
+++ b/pkg/block/local/fs/lockorder_test.go
@@ -5,8 +5,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
 // TestAppendWrite_DeleteRace_NoDeadlock is a regression guard for FIX-2
@@ -28,12 +26,10 @@ import (
 // intent. The actual ceiling lives in the select { case <-time.After(...)
 // } at the bottom — that is the genuine wall-clock guard.
 func TestAppendWrite_DeleteRace_NoDeadlock(t *testing.T) {
-	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
 	bc := newFSStoreForTest(t, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 10,
-		RollupStore:     rs,
 	})
 	ctx := context.Background()
 

--- a/pkg/block/local/fs/logshard_test.go
+++ b/pkg/block/local/fs/logshard_test.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"sync"
 	"testing"
-
-	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
 // TestShardFor_Deterministic verifies shardFor is stable per payloadID and
@@ -44,12 +42,10 @@ func TestShardFor_Deterministic(t *testing.T) {
 // cross-shard mistake would deadlock (caught by the test timeout) or trip the
 // race detector. It asserts every payload ends fully torn down.
 func TestLogShards_ConcurrentCreateDelete(t *testing.T) {
-	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
 	bc := newFSStoreForTest(t, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   3,
 		StabilizationMS: 2,
-		RollupStore:     rs,
 	})
 	if err := bc.StartRollup(context.Background()); err != nil {
 		t.Fatalf("StartRollup: %v", err)

--- a/pkg/block/local/fs/readpayload_covering_test.go
+++ b/pkg/block/local/fs/readpayload_covering_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/block"
-	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
 // memFBS must satisfy the fast-path resolver so ReadPayloadAt drives the
@@ -19,8 +18,7 @@ var _ coveringChunkResolver = (*memFBS)(nil)
 // fillFromCASManifest's indexed fast path.
 func newCoveringTestStore(t *testing.T) (*FSStore, context.Context) {
 	t.Helper()
-	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
-	fbs := newMemFileChunkStore()
+	fbs := newRollupMemFileChunkStore()
 	persister := func(ctx context.Context, payloadID string, blocks []block.ChunkRef, _ block.ObjectID) error {
 		return fbs.persist(ctx, payloadID, blocks)
 	}
@@ -28,7 +26,6 @@ func newCoveringTestStore(t *testing.T) (*FSStore, context.Context) {
 		MaxLogBytes:       1 << 30,
 		RollupWorkers:     2,
 		StabilizationMS:   3_600_000,
-		RollupStore:       rs,
 		ObjectIDPersister: persister,
 	})
 	return bc, context.Background()

--- a/pkg/block/local/fs/recovery_test.go
+++ b/pkg/block/local/fs/recovery_test.go
@@ -72,7 +72,6 @@ func reopenFSStore(t *testing.T, bc *FSStore, rs *memmeta.MemoryMetadataStore) *
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 10,
-		RollupStore:     rs,
 	})
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
@@ -91,7 +90,6 @@ func newFSStoreWithRS(t *testing.T, rs *memmeta.MemoryMetadataStore) *FSStore {
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 10,
-		RollupStore:     rs,
 	})
 	if err != nil {
 		t.Fatalf("new: %v", err)
@@ -267,7 +265,6 @@ func TestRecovery_OrphanSweep_UnlinksLog(t *testing.T) {
 		MaxLogBytes:            1 << 30,
 		RollupWorkers:          2,
 		StabilizationMS:        10,
-		RollupStore:            rs,
 		OrphanLogMinAgeSeconds: 1, // 1 second — short enough to trip during the test
 	})
 	if err != nil {
@@ -285,7 +282,6 @@ func TestRecovery_OrphanSweep_UnlinksLog(t *testing.T) {
 		MaxLogBytes:            1 << 30,
 		RollupWorkers:          2,
 		StabilizationMS:        10,
-		RollupStore:            rs,
 		OrphanLogMinAgeSeconds: 1,
 	})
 	if err != nil {
@@ -518,7 +514,6 @@ func TestRecovery_OrphanAgeFloor_WarnsOnNonPositive(t *testing.T) {
 		MaxLogBytes:            1 << 30,
 		RollupWorkers:          2,
 		StabilizationMS:        10,
-		RollupStore:            rs,
 		OrphanLogMinAgeSeconds: 1, // pass NewWithOptions normalization
 	})
 	if err != nil {
@@ -543,7 +538,6 @@ func TestRecovery_OrphanAgeFloor_WarnsOnNonPositive(t *testing.T) {
 		MaxLogBytes:            1 << 30,
 		RollupWorkers:          2,
 		StabilizationMS:        10,
-		RollupStore:            rs,
 		OrphanLogMinAgeSeconds: 1, // again pass normalization
 	})
 	if err != nil {

--- a/pkg/block/local/fs/restart_seed_sqlite_test.go
+++ b/pkg/block/local/fs/restart_seed_sqlite_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
 	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
 )
 
@@ -34,9 +33,7 @@ func TestFSStore_ListUnsynced_SQLiteIndex(t *testing.T) {
 	// SyncedHashStore with nothing marked synced → every logblob chunk is
 	// unsynced. Wire the SQLite store as the LocalChunkIndex so the seed path
 	// must walk a production backend's index, not the memory one.
-	bc := newFSStoreForTestWithFBS(t, idx, FSStoreOptions{
-		SyncedHashStore: memory.NewMemoryMetadataStoreWithDefaults(),
-	})
+	bc := newFSStoreForTestWithFBS(t, idx, FSStoreOptions{})
 
 	want := seedChunks(t, bc, 3)
 

--- a/pkg/block/local/fs/rollup.go
+++ b/pkg/block/local/fs/rollup.go
@@ -50,7 +50,7 @@ type consumedExt struct {
 // Workers join on Close() via bc.rollupWg; see Close in fs.go.
 func (bc *FSStore) StartRollup(ctx context.Context) error {
 	if bc.rollupStore == nil {
-		return fmt.Errorf("rollup: nil RollupStore (set opts.RollupStore in NewWithOptions)")
+		return fmt.Errorf("rollup: nil RollupStore (backend passed to NewWithOptions must implement metadata.RollupStore)")
 	}
 	if !bc.rollupStarted.CompareAndSwap(false, true) {
 		return nil

--- a/pkg/block/local/fs/rollup_c1_test.go
+++ b/pkg/block/local/fs/rollup_c1_test.go
@@ -7,8 +7,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
 // TestConsumeUpToStable_PreservesTouchedAfter is the unit-level guard for the
@@ -66,12 +64,10 @@ func TestConsumeUpToStable_EqualTimestampConsumed(t *testing.T) {
 func TestRollup_C1_WriteDuringPhaseB_NotConsumed(t *testing.T) {
 	// Mutates the package-global rollupPhaseBHook — must not run in parallel
 	// with other rollup tests and must restore the hook on exit.
-	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
 	bc := newFSStoreForTest(t, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   1,
 		StabilizationMS: 1,
-		RollupStore:     rs,
 	})
 	// Deliberately do NOT StartRollup: ForceRollupForTest drives the pass
 	// synchronously so the hook fires on this goroutine.
@@ -158,12 +154,10 @@ func TestRollup_C1_WriteDuringPhaseB_NotConsumed(t *testing.T) {
 // offset's bytes are already in CAS; only a leftover dirty marker is dropped).
 // It does not fail the test and is not a lost write.
 func TestRollup_C1_ConcurrentOverwriteStorm(t *testing.T) {
-	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
 	bc := newFSStoreForTest(t, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   3,
 		StabilizationMS: 2,
-		RollupStore:     rs,
 	})
 	if err := bc.StartRollup(context.Background()); err != nil {
 		t.Fatalf("StartRollup: %v", err)

--- a/pkg/block/local/fs/rollup_crashsafe_test.go
+++ b/pkg/block/local/fs/rollup_crashsafe_test.go
@@ -38,11 +38,12 @@ func TestRollupFile_ShutdownCancellationIsBenign(t *testing.T) {
 		return nil
 	}
 
-	bc := newFSStoreForTest(t, FSStoreOptions{
+	// rs is the backend so its derived RollupStore is the one this test reads
+	// to assert the fence advances only on the committed (fresh-context) pass.
+	bc := newFSStoreForTestWithFBS(t, rs, FSStoreOptions{
 		MaxLogBytes:       1 << 30,
 		RollupWorkers:     2,
 		StabilizationMS:   1, // tiny so force isn't required for the fresh pass
-		RollupStore:       rs,
 		ObjectIDPersister: persister,
 	})
 	// Intentionally do NOT StartRollup — we drive rollupFile directly.
@@ -98,7 +99,6 @@ func TestRollupFile_ShutdownCancellationIsBenign(t *testing.T) {
 // hard failure. A cancelled drain is a benign abort: the rollup resumes on a
 // later (fresh-context) pass.
 func TestDrainRollups_ShutdownCancellationIsBenign(t *testing.T) {
-	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
 
 	// Persister gate: signal when the rollup pass has entered Phase B (so the
 	// cancellation lands MID-FLIGHT, not before the drain starts), then block
@@ -117,7 +117,6 @@ func TestDrainRollups_ShutdownCancellationIsBenign(t *testing.T) {
 		MaxLogBytes:       1 << 30,
 		RollupWorkers:     2,
 		StabilizationMS:   3_600_000,
-		RollupStore:       rs,
 		ObjectIDPersister: persister,
 	})
 
@@ -177,11 +176,12 @@ func TestGracefulStopRollup_DrainsInFlight(t *testing.T) {
 	// Large stabilization window so the steady-state worker/ticker never
 	// consumes the interval on its own — only the graceful-stop FORCED drain
 	// can flush it. This isolates the drain behaviour.
-	bc := newFSStoreForTest(t, FSStoreOptions{
+	// rs is the backend so its derived RollupStore is the one this test reads
+	// to prove the in-flight drain completed on a fresh context.
+	bc := newFSStoreForTestWithFBS(t, rs, FSStoreOptions{
 		MaxLogBytes:       1 << 30,
 		RollupWorkers:     2,
 		StabilizationMS:   3_600_000,
-		RollupStore:       rs,
 		ObjectIDPersister: persister,
 	})
 

--- a/pkg/block/local/fs/rollup_divergence_test.go
+++ b/pkg/block/local/fs/rollup_divergence_test.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
 // TestRollup_DivergentInterval_DroppedNoLoop is the #668 regression for
@@ -23,7 +21,6 @@ func TestRollup_DivergentInterval_DroppedNoLoop(t *testing.T) {
 	bc := newFSStoreForTest(t, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		StabilizationMS: 5,
-		RollupStore:     memmeta.NewMemoryMetadataStoreWithDefaults(),
 	})
 	ctx := context.Background()
 	const payloadID = "file-divergent"
@@ -103,7 +100,6 @@ func TestRollup_DivergentInterval_NoErrorReturned(t *testing.T) {
 	bc := newFSStoreForTest(t, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		StabilizationMS: 1,
-		RollupStore:     memmeta.NewMemoryMetadataStoreWithDefaults(),
 	})
 	ctx := context.Background()
 	const payloadID = "file-divergent-unit"

--- a/pkg/block/local/fs/rollup_index_fence_test.go
+++ b/pkg/block/local/fs/rollup_index_fence_test.go
@@ -70,13 +70,11 @@ func TestRollup_LocalIndex_FencedBehindBlobSync(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
 
-	// Memory stores stand in for the (durable) production LocalChunkIndex and
-	// RollupStore; sharing the SAME instances across the reopen models their
-	// durability surviving a crash.
-	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
+	// A memory store stands in for the (durable) production backend that
+	// serves both the LocalChunkIndex and RollupStore facets; sharing the SAME
+	// instance across the reopen models its durability surviving a crash.
 	idx := memmeta.NewMemoryMetadataStoreWithDefaults()
 	opts := FSStoreOptions{
-		RollupStore:     rs,
 		MaxLogBytes:     1 << 30,
 		StabilizationMS: 1,
 		RollupWorkers:   1,
@@ -202,17 +200,15 @@ func TestRollup_LocalIndex_FencedBehindBlobSync(t *testing.T) {
 func TestRollup_TransientSyncFailure_ReadableWithoutRestart(t *testing.T) {
 	ctx := context.Background()
 
-	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
 	// Real in-memory FileChunk store + persister so ReadPayloadAt's CAS-manifest
 	// path (step 2) can resolve rolled-up bytes after the fence trims the log
 	// index entries — the only read path left once a pass succeeds. fbs also
-	// serves as the mandatory LocalChunkIndex.
-	fbs := newMemFileChunkStore()
+	// serves as the mandatory LocalChunkIndex and RollupStore.
+	fbs := newRollupMemFileChunkStore()
 	persister := func(pctx context.Context, payloadID string, blocks []block.ChunkRef, _ block.ObjectID) error {
 		return fbs.persist(pctx, payloadID, blocks)
 	}
 	opts := FSStoreOptions{
-		RollupStore:       rs,
 		ObjectIDPersister: persister,
 		MaxLogBytes:       1 << 30,
 		StabilizationMS:   1,

--- a/pkg/block/local/fs/rollup_logblob_durability_test.go
+++ b/pkg/block/local/fs/rollup_logblob_durability_test.go
@@ -14,10 +14,8 @@ import (
 // passes). Used by logblob durability tests only.
 func newLogBlobStoreWithRollup(t *testing.T) *FSStore {
 	t.Helper()
-	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
 	idx := memmeta.NewMemoryMetadataStoreWithDefaults()
 	bc, err := NewWithOptions(t.TempDir(), 0, idx, FSStoreOptions{
-		RollupStore:     rs,
 		MaxLogBytes:     1 << 30,
 		StabilizationMS: 1,
 		RollupWorkers:   1,

--- a/pkg/block/local/fs/rollup_parallel_test.go
+++ b/pkg/block/local/fs/rollup_parallel_test.go
@@ -7,8 +7,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	memmeta "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
 // TestScanAllFiles_DispatchesConcurrently proves the ticker/backlog drain path
@@ -24,13 +22,11 @@ import (
 // single dispatch goroutine is parked inside the first rollup), so fewer than
 // `workers` arrivals land within the timeout and the test fails.
 func TestScanAllFiles_DispatchesConcurrently(t *testing.T) {
-	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
 	const workers = 4
 	bc := newFSStoreForTest(t, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   workers,
 		StabilizationMS: 1,
-		RollupStore:     rs,
 	})
 	// Deliberately do NOT StartRollup: this test drives scanAllFiles directly
 	// so the only concurrency under observation is its own dispatch fan-out.

--- a/pkg/block/local/fs/rollup_test.go
+++ b/pkg/block/local/fs/rollup_test.go
@@ -25,9 +25,10 @@ func newRollupFSStore(t *testing.T, maxLogBytes int64, stabilizationMS int) (*FS
 		MaxLogBytes:     maxLogBytes,
 		RollupWorkers:   2,
 		StabilizationMS: stabilizationMS,
-		RollupStore:     rs,
 	}
-	bc := newFSStoreForTest(t, opts)
+	// rs doubles as the backing FileChunkStore so the derived RollupStore
+	// is the same store the caller observes for rollup-offset progress.
+	bc := newFSStoreForTestWithFBS(t, rs, opts)
 	if err := bc.StartRollup(context.Background()); err != nil {
 		t.Fatalf("StartRollup: %v", err)
 	}
@@ -158,11 +159,12 @@ func TestRollup_PressureReleasesAppendWrite(t *testing.T) {
 // becomes stable within a few ms.
 func TestRollup_CommitChunks_MonotoneEnforced(t *testing.T) {
 	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
-	bc := newFSStoreForTest(t, FSStoreOptions{
+	// rs is the backend so its derived RollupStore is the one this test
+	// pre-seeds and reads back to exercise the monotone-regression branch.
+	bc := newFSStoreForTestWithFBS(t, rs, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 1, // 1 ms — record stabilizes almost immediately
-		RollupStore:     rs,
 	})
 	ctx := context.Background()
 
@@ -208,9 +210,9 @@ func TestRollup_CommitChunks_MonotoneEnforced(t *testing.T) {
 // TestRollup_StartRollup_NilStore: StartRollup with a nil RollupStore must
 // return a descriptive error so misconfiguration fails loudly.
 func TestRollup_StartRollup_NilStore(t *testing.T) {
-	bc := newFSStoreForTest(t, FSStoreOptions{
-		// RollupStore intentionally nil.
-	})
+	// A backend WITHOUT the RollupStore facet → the soft derivation leaves
+	// bc.rollupStore nil, so StartRollup must reject it.
+	bc := newFSStoreForTestWithFBS(t, newMemFileChunkStore(), FSStoreOptions{})
 	if err := bc.StartRollup(context.Background()); err == nil {
 		t.Fatalf("StartRollup with nil RollupStore: want error, got nil")
 	}
@@ -359,11 +361,12 @@ func TestRollup_ReconstructStream_DoSCeiling_FIX5(t *testing.T) {
 // past the dropped record.
 func TestRollup_TruncateMidWindow_DoesNotAdvancePastUncommittedTail(t *testing.T) {
 	rs := memmeta.NewMemoryMetadataStoreWithDefaults()
-	bc := newFSStoreForTest(t, FSStoreOptions{
+	// rs is the backend so its derived RollupStore is the one this test reads
+	// back to assert the fence stopped at the last surviving record.
+	bc := newFSStoreForTestWithFBS(t, rs, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 1,
-		RollupStore:     rs,
 	})
 	ctx := context.Background()
 
@@ -465,7 +468,6 @@ func runRollupOnceErr(bc *FSStore, payloadID string, payload []byte) error {
 //	   errors.Is so callers can distinguish it from neighbour errors.
 func TestRollup_CommitChunks_PersistsObjectID(t *testing.T) {
 	t.Run("PersistsObjectIDOnCommit", func(t *testing.T) {
-		rs := memmeta.NewMemoryMetadataStoreWithDefaults()
 
 		var mu sync.Mutex
 		var captures []capturedPersist
@@ -488,7 +490,6 @@ func TestRollup_CommitChunks_PersistsObjectID(t *testing.T) {
 			MaxLogBytes:       1 << 30,
 			RollupWorkers:     2,
 			StabilizationMS:   1,
-			RollupStore:       rs,
 			ObjectIDPersister: persister,
 		})
 
@@ -531,11 +532,12 @@ func TestRollup_CommitChunks_PersistsObjectID(t *testing.T) {
 
 	t.Run("NilPersisterIsBenign", func(t *testing.T) {
 		rs := memmeta.NewMemoryMetadataStoreWithDefaults()
-		bc := newFSStoreForTest(t, FSStoreOptions{
+		// rs is the backend so its derived RollupStore is the one this test
+		// reads to confirm the fence advanced despite a nil persister.
+		bc := newFSStoreForTestWithFBS(t, rs, FSStoreOptions{
 			MaxLogBytes:     1 << 30,
 			RollupWorkers:   2,
 			StabilizationMS: 1,
-			RollupStore:     rs,
 			// ObjectIDPersister left nil — local-only fixture.
 		})
 
@@ -554,7 +556,6 @@ func TestRollup_CommitChunks_PersistsObjectID(t *testing.T) {
 	})
 
 	t.Run("PersisterErrorPropagates", func(t *testing.T) {
-		rs := memmeta.NewMemoryMetadataStoreWithDefaults()
 
 		simulated := errors.New("simulated persister failure")
 		persister := func(_ context.Context, _ string, _ []block.ChunkRef, _ block.ObjectID) error {
@@ -565,7 +566,6 @@ func TestRollup_CommitChunks_PersistsObjectID(t *testing.T) {
 			MaxLogBytes:       1 << 30,
 			RollupWorkers:     2,
 			StabilizationMS:   1,
-			RollupStore:       rs,
 			ObjectIDPersister: persister,
 		})
 
@@ -601,12 +601,10 @@ func TestRollup_CommitChunks_PersistsObjectID(t *testing.T) {
 // content-addressed and idempotent, so the second payload re-stores the
 // same chunk harmlessly; the manifest must not drift.
 func TestRollup_ComputeObjectID_StableAcrossPayloads(t *testing.T) {
-	mem := memmeta.NewMemoryMetadataStoreWithDefaults()
 	bc := newFSStoreForTest(t, FSStoreOptions{
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 1,
-		RollupStore:     mem,
 	})
 
 	payload := bytes.Repeat([]byte{0xF1}, 256*1024)

--- a/pkg/block/local/fs/test_hooks.go
+++ b/pkg/block/local/fs/test_hooks.go
@@ -182,7 +182,6 @@ func ReopenForTest(baseDir string, rs metadata.RollupStore) (*FSStore, error) {
 		MaxLogBytes:     1 << 30,
 		RollupWorkers:   2,
 		StabilizationMS: 50,
-		RollupStore:     rs,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -2856,28 +2856,15 @@ func CreateLocalStoreFromConfig(
 			return nil, fmt.Errorf("failed to create share directory: %w", err)
 		}
 
-		// Append is mandatory. Wire a RollupStore from the metadata
-		// backend and start the rollup worker pool. The type assertion
-		// couples the block-store factory to a metadata-layer interface
-		// via runtime type check — accepted because memory / badger /
-		// postgres all implement both FileChunkStore and RollupStore on
-		// the same Store type.
-		rs, ok := fileChunkStore.(metadata.RollupStore)
-		if !ok {
+		// Append is mandatory. Enforce the production guardrail that the
+		// metadata backend implements RollupStore so the rollup worker pool
+		// can be started below. The RollupStore, SyncedHashStore, and
+		// LocalChunkIndex are all derived from this same fileChunkStore
+		// backend inside NewWithOptions — accepted because memory / badger /
+		// postgres all implement them on the same Store type.
+		if _, ok := fileChunkStore.(metadata.RollupStore); !ok {
 			return nil, fmt.Errorf("fs local store: metadata backend must implement metadata.RollupStore for the mandatory append-log path")
 		}
-		fsOpts.RollupStore = rs
-		// Wire the SyncedHashStore from the same metadata backend so
-		// the local store's ListUnsynced surface can filter the Walk-
-		// collected CAS hash set down to the still-unmirrored subset.
-		// Required when a remote store is configured; harmless when no
-		// remote is wired (mirror loop early-exits in that case).
-		if shs, ok := fileChunkStore.(metadata.SyncedHashStore); ok {
-			fsOpts.SyncedHashStore = shs
-		}
-		// The LocalChunkIndex is derived from the same metadata backend inside
-		// NewWithOptions (mandatory: chunk persistence routes to the log-blob
-		// substrate + PutLocalLocation). All backends implement it.
 		store, err := fs.NewWithOptions(shareDir, maxDisk, fileChunkStore, fsOpts)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## What

Phase 1 of the block-store simplification. Collapses the redundant `RollupStore` and `SyncedHashStore` `FSStoreOptions` fields by **deriving** them from the `fileChunkStore` param inside `newFSStore` — the same pattern already applied to `LocalChunkIndex` in Phase 0 (#1688). All three facets are the one per-share metadata backend object; plumbing them as separate options was redundant.

Interfaces are **not** merged — kept narrow. This is plumbing removal only, to make the data path straighter and easier to trace.

## Changes

- `pkg/block/local/fs/fs.go` — soft-derive `bc.rollupStore` / `bc.syncedHashStore` from `fileChunkStore` (both nil-tolerant); drop the two `FSStoreOptions` fields + their `applyFSStoreOptions` assignments. `ObjectIDPersister` kept (engine callback, not derivable).
- `pkg/controlplane/runtime/shares/service.go` — the mandatory-RollupStore production guardrail (hard-fail if absent) is preserved as a bare assertion; the now-redundant field assignments are dropped.
- Test fixtures migrated to the derived-backend pattern (single backend serves all facets; thin wrappers where a fixture needs a facet-less backend to exercise a nil-tolerance guardrail).

Net production diff: **+15 / −31**.

## Gates (all green)

- `go build ./...`, `go vet`, `gofmt -s -l` clean
- `go test ./pkg/block/... ./internal/adapter/...` — 5549 passed / 0 failed
- `go test -race ./pkg/block/local/fs/... ./pkg/block/engine/...` — 642 passed
- Conformance suites (`BlockStoreConformance` + append) green — property preservation