### PR TITLE
docs(perf): three-wall NFS/SMB perf plan + Wall A segstore blueprint

### DIFF
--- a/.planning/perf/2026-07-15-nfs-smb-three-walls-PLAN.md
+++ b/.planning/perf/2026-07-15-nfs-smb-three-walls-PLAN.md
@@ -1,0 +1,365 @@
+# Plan: maximize end-user NFS/SMB read+write performance (three walls)
+
+## Context
+
+**Goal:** maximize real end-user NFS/SMB read/write throughput and latency for DittoFS.
+Phase 0 (delete legacy CAS, make `LocalChunkIndex` mandatory, fix the seq-write bench —
+PR #1688) and Phase 1 (collapse facet-interface plumbing — PR #1690) are **shipped**. This
+plan is the perf work they unblocked.
+
+Profiling + eight research/exploration agents (external: WiscKey, RocksDB BlobDB, Titan,
+JuiceFS, Haystack/f4/SeaweedFS, restic, Ceph BlueStore; internal: read/carve path, append-log
+lifecycle, RPC dispatch, Runtime orchestration, auth/authz) identified **three independent
+walls** between the client and the bytes:
+
+- **Wall A — data plane (block store):** each written byte hits disk ~2–3× (append-log →
+  rollup copy to logblob → compaction). This is the seq-write wall (~148 MB/s VM).
+- **Wall B — metadata plane:** badger `db.Sync` serialization gates create/stat/small-file ops
+  (#1687). ~250 ops/s, last of the durable field.
+- **Wall C — RPC/adapter/auth plane:** per-op global locks, uncached share/store resolution,
+  redundant handle decodes, and per-op allocations that touch **100% of ops**.
+
+**Decision locked with the user:** the block store moves to **chunk-at-carve, write-once**
+(WiscKey/JuiceFS key-value separation). The local append blob stores raw written bytes once;
+FastCDC + BLAKE3 + dedup run only when carving fixed-size blocks to S3, streaming from the
+blob. Accepted trade: **local-disk dedup is dropped; remote (S3) dedup is preserved.**
+Encryption already happens at carve today (local is plaintext) — no regression.
+
+**Execution order (settled with the user):**
+- **Wall C runs now, in parallel with Wall A's design session** — cheap, low-risk, independent,
+  touches every op, and de-noises the Wall A benchmarks. All C1–C8, priority-ordered.
+- **Wall A** — first a formal `superpowers:brainstorming` + `code-architect` session to turn the
+  locked §1–§6 decisions into executor-ready specs, then the phased redesign.
+- **Wall B — deferred**: do Wall A, re-profile the metadata cell, build group-commit only if it
+  still walls (Wall A removes ~23.5% of the `db.Sync` load + moves the index off badger).
+
+Each numbered item below is its own PR off `origin/develop`, signed, assignee marmos91,
+conformance-gated.
+
+**Cross-cutting engineering mandate (applies to every PR below — clean as you go, not a
+separate purge).**
+- **Delete dead code + legacy as each area is touched.** Pre-1.0, no prod users: clean cutover,
+  never a dual path or deprecate-in-place. When a PR touches a file, sweep it for
+  dead/never-called code and legacy compat layers and **delete them** — verify with
+  `tokensave_dead_code` + call-graph, then build/test/-race. Legacy on-disk layouts get a
+  one-shot migration, then the reader is deleted. Wall A alone removes rollup, the `logblob/`
+  manager, the two-source read fallback, the `rollup_offset` fence, #953 splicing, and any
+  lingering CAS/migration shims.
+- **Simplify abstractions + structure as part of the change.** The recurring goal: a straighter,
+  easier-to-trace data path. Collapse needless indirection, fold single-use interfaces onto a
+  cohesive one (continuing Phase 1), and prefer the shortest structure that holds — don't leave
+  a refactored area more layered than it needs to be.
+- **Human, minimal comments — less is more.** Comments describe *what the code does / why*, in
+  plain language. No phase/plan/decision IDs, no `FIX-N`/issue-number archaeology carried into
+  rewritten code, no narrating the obvious. When rewriting a heavily-annotated area (e.g.
+  rollup/compaction's dense `FIX-*` blocks), prune the scaffolding down to the load-bearing
+  rationale.
+- **Refresh the docs with the design.** As each wall lands, update `docs/` (esp.
+  `docs/internals/architecture.md`, `docs/internals/implementing-stores.md`, `docs/guide/`
+  config/CLI, `docs/guide/faq.md`) and in-repo `CLAUDE.md`/module docs to describe the new
+  write-back-cache block store, the `dfsctl` eviction control, and the removed legacy paths.
+  Regenerate `docs/guide/cli.md` via `go run ./cmd/gendocs` after any command/flag change. Docs
+  are a user surface — no stale diagrams describing the deleted rollup/logblob design.
+
+---
+
+## Wall C — RPC / adapter / auth quick wins (DO FIRST)
+
+Low-risk, mostly independent, each touches every op. Bank these before the redesign.
+
+**C1. Kill the process-wide activity-timestamp write lock.**
+`clients.Registry.UpdateActivity` takes `Registry.mu.Lock()` (write) on **every** NFS+SMB
+request just to bump a timestamp (`pkg/controlplane/runtime/clients/service.go:110`). Replace
+with a per-client `atomic.Int64` (or sample). Highest fan-in, smallest diff.
+
+**C2. Cache the resolved per-share block/metadata store; decode the handle once.**
+`GetBlockStoreForHandle` decodes the handle + `RLock`s the shares registry + map-lookups on
+every op (`shares/service.go:2181`); the metadata `GetStoreForShare` does the same
+(`runtime/.../service.go:622`). The per-share `*engine.Store` is immutable between
+AddShare/RemoveShare. Add a `sync.Map[shareName]*engine.Store` fast-path (NFSv3, stateless)
+and stash `*engine.Store` on SMB `OpenFile` at CREATE. Thread the already-decoded `ctx.Share`
+down instead of re-decoding 3–4×/op (use existing `*ForShare` variants). Invalidate via the
+existing `OnAuthCacheInvalidate`/share-event hook. Dominant orchestration tax.
+
+**C3. Shard the NFS DRC lock.** `drc.go:105` is a single `sync.Mutex` serializing all cacheable
+ops (WRITE/CREATE/REMOVE/RENAME) adapter-wide. Shard by client/XID bucket.
+
+**C4. Pool the SMB per-request raw message.** `pkg/adapter/smb/connection.go:339` does
+`make + hdr.Encode() + 2×copy` per request on the single-reader loop, unpooled. NFS already
+pools (`connection.go:315`). Reuse `internal/adapter/pool/bufpool.go`.
+
+**C5. Cache the SMB AuthContext per (session,tree).** `BuildAuthContextFromUser` re-allocates
+Identity + GID slice + `slices.Concat`/dedup of group SIDs on **every** SMB read/write
+(`smb/handlers/auth_helper.go:148`). Identity is fixed at SESSION_SETUP. Mirror the NFS
+`GetCachedAuthContext`. Invalidate on re-auth (`tryReauthUpdate`); handle-bound ops keep using
+the frozen `OpenFile.OpenerUser` snapshot.
+
+**C6. Give the NFS auth cache a TTL + user/group-change invalidation** (`nfs/v3/handlers/doc.go`).
+Today it has no TTL and is invalidated only on share-perm events → a UID/group-membership edit
+is stale until restart (a **correctness** gap, not just perf). Add ~5 min TTL aligned with the
+`pkg/identity` cache, or wire an `OnUserChange` hook to `ClearAuthCache`.
+
+**C7. Micro-locks/allocs (one small PR):** `CommitWrite` RLocks only to read the
+`deferredCommit` bool (`io.go:221`) → `atomic.Bool`; per-op oplock-breaker lookup+assert when
+no SMB adapter (`read.go:207`) → `atomic.Value` sentinel; thread the already-loaded `*File`
+through NFS WRITE permission checks (`PrepareWrite`/`CommitWrite` re-`GetFile` 1–2×/op — use the
+existing file-variant `checkFilePermissionsFile`); make `ExtractClientIP` lazy (debug-only).
+
+**C8. Raise the buffer-pool ceiling if rsize/wsize > 1 MB.** `bufpool.go:157` allocates+GCs a
+fresh multi-MB buffer per bulk op above the 1 MB tier. Add a tier matching the negotiated max
+I/O size. (Only if large rsize/wsize is in use — measure first.)
+
+**Wall C — locked decisions / defaults:**
+- **Scope = all C1–C8; runs now, in parallel with Wall A's design session** (independent, cheap).
+- **Independent small PRs, not one mega-PR.** Priority by fan-in: **C1 + C2 first** (touch 100% of
+  ops), then C5/C6 (auth), then C3/C4/C7, C8 last (measure-gated).
+- **C1 = per-client `atomic.Int64` timestamp** (exact, cheap), not sampling.
+- **C6 is also a correctness fix** (unbounded stale group-membership today) — ~5 min TTL aligned
+  with the `pkg/identity` cache **plus** an `OnUserChange`/`OnGroupChange` → `ClearAuthCache` hook.
+  Ship even if perf were neutral.
+- **C3 DRC shard** = power-of-2 buckets keyed by client/XID (start 32); **C2 invalidation** rides
+  the existing share-event/`OnAuthCacheInvalidate` hook; **C5** invalidates on SMB re-auth and
+  handle-bound ops keep using the frozen `OpenFile.OpenerUser` snapshot.
+- Each micro-fix keeps its own before/after micro-benchmark of the contended path (no "trust me"
+  lock removals).
+
+---
+
+## Wall A — data-plane redesign: chunk-at-carve, write-once
+
+Collapse the two local substrates (append-log + logblob) into **one append-only blob store**;
+move chunking/dedup to the carve path. The read/carve seam already routes every consumer
+through `LocalChunkLocation{id,offset,len} → one pread` (`GetLocalLocation` + `localBlobReader`),
+so the read/carve code is largely unchanged — **the work is lifecycle/GC**, not reads.
+
+**Unifying model — the append blob is a log-structured write-back cache over S3.** Client
+writes and cold-read S3 fetches fold into **one primitive**:
+`appendRecord(fileOffset, bytes, synced)` → append a record to the active segment + index it
+(`fileOffset → {segment,offset,len}`) + set `evictable = synced`. Client WRITE →
+`synced=false` (dirty, must carve+upload); cold-read fetch → `synced=true` (clean, mirrors S3).
+Everything downstream is one rule keyed on that bit: **read** = newest-wins reconstruct over
+local records, gap → fetch S3 block → `appendRecord(...,true)` → serve (L0→blob→S3); **carve** =
+scan *dirty* records → chunk/hash/dedup → pack → upload → flip *clean*; **evict** (pressure-
+gated) = drop *clean* records only, never dirty; **GC** = repack dead records. Write-ingest and
+read-cache population are the *same append*. Asymmetry to handle: dirty records can't be evicted
+(only local copy until carved), so if S3 is unreachable and dirty data fills the budget, writes
+apply backpressure (JuiceFS-style).
+
+**Packaging — a standalone, independently-benchmarkable library (design directive).** The block
+store becomes a self-contained Go package owning **all** its persistent state (blob segments +
+per-segment `.idx` + its chunk↔S3-block ref table). Public API keyed by an opaque `fileID`
+(`Open`/`WriteAt`/`ReadAt`/`Commit`/`Carve`/`Evict`/`Close`/`Stats`); only injected deps are
+narrow interfaces — `RemoteStore` (`PutBlock`/`GetBlock`/`GetRange`; memory impl for benches),
+`Config`, `Clock`. **No dependency** on Runtime/adapters/NFS/SMB/metadata-namespace. A
+standalone bench harness drives the API against a memory remote and measures MB/s, warm/cold
+read latency, and true **write-amplification (bytes-to-disk ÷ bytes-ingested)** with no protocol
+stack — prove the numbers in isolation, then wire into the e2e flow. The sidecar-`.idx` §1
+decision is what makes this boundary clean (the store needs no shared metadata KV for its index).
+
+**Design gate before implementation.** This is a "get-it-right-once" rewrite. Before any code,
+run a dedicated **`superpowers:brainstorming` + `feature-dev:code-architect`** session that turns
+the decisions below into an architecture/design doc (package layout, public API + dependency
+interfaces, on-disk formats, the `appendRecord` state machine, PR sequence). This plan is that
+session's input; §1–§6 record the decisions locked so far.
+
+**Decisions locked (this planning session):**
+- **§1 index location = sidecar `.idx` per segment** (Haystack/restic model): index writes bypass
+  badger, so they don't feed the Wall B `db.Sync` bottleneck; recovery rebuilds `.idx` from the
+  blob; fast cold start. The durable metadata store stays lean.
+- **Self-describing, versioned records (foundational):** each blob record embeds the **`fileID`
+  (key)** and a **monotonic `version`** —
+  `⟨fileID, file_offset, len, version, crc, payload, synced⟩` — WiscKey `⟨key,value⟩` / Haystack
+  needle model. `fileID` makes the `.idx` a **rebuildable accelerator** (recovery scans segments,
+  each record self-identifies) and enables self-validating GC; `version` keeps **newest-wins**
+  well-defined after GC/repack reorders physical layout (blob append-order = write-order only
+  until repack). Segments are **shared** (many files packed) — needed for S3 packing + coarse
+  whole-segment eviction; `fileID` is what makes shared segments recoverable.
+- **Random / sparse writes (correctness vs locality):** writes append in arrival order, so a
+  file's bytes scatter physically. **Reads use the interval index** (`fileID+offset → location`),
+  not blob order: reconstruct the range newest-wins, zero-fill holes (NFS sparse). Correctness
+  never needs blob-order = file-order. **A5 defrag** merges a file's scattered records into fewer
+  offset-ordered ones purely for **read locality** + to bound interval-map size (JuiceFS
+  slice-merge) — not for correctness.
+- **§3 carve trigger = batched (age + size):** accumulate dirty records, carve when a fixed block
+  can be filled OR a max-age cap is hit (JuiceFS flush / BlueStore deferred-write). Fixed block
+  size = benchmark parameter, **start 4 MiB**. Per-share dedup (invariant #4). Encrypt at carve.
+- **§5 eviction victim = coldest (approx-LRU):** per-segment last-access timestamp, evict coldest
+  synced segment first (best warm-hit rate). Whole-segment, sealed-immutable. Dead-byte repack
+  with garbage-ratio force trigger (#9235).
+- **§6 migration = drain → discard → re-hydrate:** on upgrade drain/carve pending uploads (all
+  data on S3), discard the old local store, start with an empty append blob that re-hydrates from
+  S3 on demand. No converter code; cold cache post-upgrade only.
+- **§2 `.idx` durability = lazy (rebuildable):** COMMIT fsyncs only the blob; the `.idx` is
+  appended best-effort and rebuilt from the versioned, self-describing records on recovery. One
+  fsync on the write path, no data-safety cost (WiscKey/Haystack). GC/repack updates `.idx`
+  under the bytes-durable-before-index ordering invariant.
+
+**Design rationale — the "why" (record for maintainers; mirror into a `docs/internals/`
+block-store ADR).** Each choice and the alternative it beat:
+- **Chunk-at-carve, not at-ingest** → write-once = fastest possible ingest (no FastCDC/BLAKE3/RMW
+  on the hot path); overwrites become a trivial append; encryption already lived at carve. Cost
+  accepted: local-disk dedup dropped (low value for a bounded cache; S3 dedup preserved).
+- **One append blob = write-back cache over S3** → unifies write-ingest and read-cache population
+  into one `appendRecord`; deletes the rollup copy, the logblob, the two-source read fallback.
+  Simpler *and* faster (the recurring goal). Rejected "keep two substrates" (the copy is the
+  amplification).
+- **Sidecar `.idx`, self-describing + versioned records** → keeps the byte-index OFF the badger
+  `db.Sync` path (helps Wall B), makes the index rebuildable, and keeps newest-wins correct after
+  GC. Rejected "index in the metadata KV" (couples to and worsens Wall B) and "minimal records"
+  (a lost index = lost data — the RocksDB/WiscKey/Haystack answer is to embed the key).
+- **Lazy `.idx`, batched carve, lazy coldest-first eviction** → one fsync/COMMIT; full fixed-size
+  S3 blocks for bandwidth; keep data warm for read-hit rate, reclaim only under real pressure.
+- **Drain→discard→re-hydrate migration** → S3 already holds everything, so no converter code to
+  write-then-delete. **Standalone library** → prove the numbers in isolation before wiring e2e.
+
+Sequenced into reviewable PRs; each must pass `BlockStoreConformance` +
+`BlockStoreAppendConformance` (the property-preservation gate) and `-race`.
+
+**A1. Persist the append-log index + make the blob the store of record.** Today `logIndex`
+(fileOffset → logPos/len) is in-memory, rebuilt on restart by replay. Persist per-record
+locations so warm reads + carve can resolve straight from the blob. Locations become
+offset-based (contiguous per record), never content-defined — sidesteps the FastCDC-scatter
+problem entirely.
+
+**A2. Move FastCDC + BLAKE3 + dedup to carve; stream into fixed-size S3 blocks.** Carver reads
+raw bytes from the blob via the index (streaming, `io.Reader` from `ReadLocalAt`), chunks +
+hashes on the fly, dedups against the remote hash index, packs **novel** chunks into
+fixed-size blocks (restic pack-file shape: chunks ‖ trailing manifest), uploads once. Keep the
+existing `blockcodec.Builder`/packed-block path (#1414). **Fixed block size (1–16 MiB) is a
+benchmark parameter** — tune against Scaleway S3, don't guess (JuiceFS uses 4 MiB). Coalesce
+small/unaligned writes in the blob before carving (BlueStore deferred-write principle) — don't
+cut an object per tiny NFS/SMB write.
+
+**A3. Replace rollup with the carve pipeline; delete the copy.** Remove `rollup.go`
+(reconstruct→chunk→hash→`logBlob.Append`), the `logblob/` manager, the two-source read
+fallback in `readpayload.go`, the `rollup_offset` monotone-fence machinery, and the #953
+straddling-chunk splicing (only needed to re-chunk overwrites, which now just append). Warm
+reads serve raw bytes by offset (no hash-verify — the local bytes are authoritative; #1648
+verify-once becomes moot). Net: large deletion.
+
+**A4. Lazy, pressure-gated eviction + segment GC (the concentrated risk).** The blob holds three
+kinds of bytes: **live-unsynced** (not yet on S3 — must retain), **live-synced/evictable**
+(uploaded, safe to drop, re-fetchable from S3), and **dead** (superseded by overwrite / deleted).
+
+*Eviction policy (retain-warm by default — this is the read-perf win):*
+- **At carve+upload, mark the chunks/bytes `evictable` in the metadata** (durably-on-S3 flag) —
+  this only marks; it does **not** reclaim. Reuse `logblob.EvictBlob`'s synced-gate as the
+  "safe to drop" signal.
+- **Do NOT evict eagerly.** Keep evictable bytes local so reads stay warm. Read path is
+  **L0 (active segment) → sealed blob segments → S3** (cold fallback only when the bytes were
+  actually evicted).
+- **Run eviction/GC ONLY under real pressure:** (a) local disk usage crosses the
+  **user-configured threshold** (`LocalStoreSize`); or (b) an operator runs an explicit
+  **`dfsctl` force-eviction** command (extend the existing `store block evict` / `DrainLocalSynced`
+  path — that becomes the *forced* path, not the default); or (c) the disk is **near-full when no
+  threshold is set**. When triggered, evict whole synced segments (**coldest first**, approx-LRU)
+  until back under the target.
+- **Disk-pressure is loud + actionable:** when pressure triggers eviction (or when dirty data is
+  approaching backpressure), log clearly at `Warn` with the concrete remedy — current vs
+  threshold usage, and the exact `dfsctl store block evict …` command to force reclamation and/or
+  the `LocalStoreSize` knob to raise the budget. Never let the user hit a silent wall.
+
+*Dead-byte GC (garbage from overwrites/deletes), same pressure gate:*
+- Track **per-segment dead bytes** (Titan `discardable_size`); pick the highest-dead-ratio
+  segment (size-tiered, not by age). **Repack** live bytes forward (reuse #1497
+  relocate-survivors) with a garbage-ratio **force trigger** — the RocksDB #9235 space-amp stall
+  (a near-dead segment pinned by a few live bytes) is the trap.
+- Seal segments immutable; serve with concurrent stateless `ReadAt` (reuse logblob's sealed-fd pool).
+- Ordering invariant (WiscKey/restic): **bytes durable before index durable** — `fsync(blob)`
+  → `fsync(dir)` → commit index rows → only then reclaim old bytes. On repack: write new →
+  update index → delete old last.
+- **Shard GC + carve by partition** (HedgeDB `2^N` partitions): key segments/work by a hash
+  partition so GC and carve run **fully in parallel** across partitions with no cross-lock.
+  Reinforces C3 (shard the DRC lock the same way).
+- Note the existing hazard: the union `BlockReclaimer` refcount-decrement is unsafe under
+  concurrent GC (single-sweeper lock is per-`GCStateRoot`, not per-remote) — must be made safe
+  when the blob becomes the reclamation target.
+
+**A5. Local defrag compaction + per-segment read filter (read-perf).** Two read-amp defenses as
+segments accumulate under write-once:
+- Heavy random overwrite → many overlapping records → slow reconstruction. Merge records
+  per-payload when overlap count crosses a threshold (JuiceFS slice-count trigger). Background,
+  rate-limited via the existing rollup-slot throttle.
+- **Per-sealed-segment probabilistic filter** (HedgeDB quotient filter / Bloom): on a warm read,
+  skip segments that can't contain the target so lookup stays ~O(1) as segment count grows.
+
+**A7. I/O-stack techniques (HedgeDB-inspired, later / cross-cutting).** Deferred behind A1–A6
+and measurement, Linux-only:
+- **`O_DIRECT` for background carve + GC bulk reads** so large sequential background I/O does
+  not evict the page-cache-warm bytes that foreground warm reads + the (kept) hash-by-read
+  depend on. Keep foreground ingest/read on buffered I/O.
+- **`io_uring` batched submission** (e.g. an iouring-go binding) on the append + carve paths to
+  cut the ~27% `rawsyscalln` overhead the profile shows. Higher risk, Linux-only, own PR, only
+  if syscall overhead is still dominant after A1–A6.
+
+**A6. Crash recovery + one-shot migration.** Recovery tail-scans the blob past the last
+committed index offset, validates CRC, drops the torn tail, reconciles the chunk index against
+surviving bytes (drop danglers) — adapt `recovery.go`. Migration: one-shot converter from the
+old logblob+rollup layout (pre-1.0, "delete legacy eagerly" — no permanent dual path).
+
+**A8. Cold-read = serve-direct + async hydrate (read-around + fill).** On cold start the local
+blob is empty but the **metadata chunk index survives** (file-offset → chunk hash → S3 block
+ref). Maximize cold-read latency by **never blocking the client on a local disk write**:
+- Resolve file-offset → chunk → S3 block ref (metadata), `GetObject` the fixed-size block
+  (optionally S3 `Range` for a partial block), unpack the needed chunk(s).
+- **Deliver the requested bytes straight to the NFS/SMB adapter first** — the client read
+  responds as soon as the S3 bytes arrive. Then **asynchronously hydrate** the blob off the
+  critical path: `appendRecord(fileOffset, bytes, synced=true)` (clean/evictable immediately —
+  already durable on S3) + `.idx`, so the *next* read is warm (L0 → blob → S3). Hydration is
+  **best-effort**: on failure (disk pressure) the read already succeeded; the chunk stays cold
+  and re-fetches next time.
+- Since a fetched block packs many chunks, hydrate **all unpacked chunks** from that block, not
+  just the requested one — free prefetch for the GET already paid. Bounded by the eviction
+  policy so a cold scan can't blow the local budget.
+- **Singleflight concurrent misses by chunk hash** (dedupe both the S3 fetch and the hydrate).
+  Pin **buffer ownership**: the hydrator takes the pooled buffer only after the adapter has
+  copied to the wire, or gets its own copy — no aliasing the in-flight reply.
+- Reuse the read-through cache (#1362) + cold-read sliding-window readahead (#1625/#1630) —
+  retarget their local write from the deleted logblob to the append blob.
+
+---
+
+## Wall B — metadata plane (#1687), parallel & independent
+
+Execute the **already-approved** sub-plan at
+`.planning/perf/2026-07-14-badger-dbsync-groupcommit-PLAN.md`: a group-commit leader at the
+`syncIfRelaxed` chokepoint in `pkg/metadata/store/badger/` so all concurrent durable
+`db.Sync` calls coalesce onto one fsync (strict group-commit, zero durability change).
+Expected ~2–4× metadata ops/s, clearing ZeroFS. Gated on a Linux A/B (macOS fsync is not a
+full barrier). Badger-only; sqlite/postgres out of scope.
+
+**Locked decisions + Wall-A synergy:**
+- **Group-commit, not per-writer WAL sharding** (HedgeDB's alternative): the profiled contention
+  is badger's single internal Sync RWMutex, which sharding at our layer can't touch — coalescing
+  is the profile-correct fix. Badger-internal; the reverted store-agnostic `SyncDurable` is not
+  reused.
+- **DEFERRED behind Wall A (locked).** The #1687 profile attributed `db.Sync` 76.5% to per-file
+  `withTransaction` commits **+ 23.5% to `SetRollupOffset`**. Wall A **deletes rollup** → the
+  23.5% disappears, and the sidecar `.idx` (§1) keeps the block byte-index off badger entirely.
+  So **do Wall A first, then re-profile the metadata cell**; build the group-commit leader **only
+  if** the remaining create/attr-commit load still walls (last of the field vs ZeroFS 354). This
+  avoids building a fix for load Wall A removes. The approved sub-plan stays on the shelf, ready.
+
+---
+
+## Critical files
+
+- **Wall C:** `pkg/controlplane/runtime/clients/service.go` (C1); `pkg/controlplane/runtime/shares/service.go`, `runtime.go`, `internal/adapter/{nfs,smb}` handlers (C2, C5, C7); `pkg/adapter/nfs/drc.go` (C3); `pkg/adapter/smb/connection.go`, `internal/adapter/pool/bufpool.go` (C4, C8); `internal/adapter/nfs/v3/handlers/doc.go` (C6).
+- **Wall A:** `pkg/block/local/fs/{appendlog,appendwrite,logindex,readpayload,recovery,rollup,compaction,eviction}.go`, `pkg/block/local/logblob/manager.go` (delete), `pkg/block/block_record.go`, `pkg/block/engine/{carver,syncer}.go`, `pkg/controlplane/runtime/shares/service.go` (factory).
+- **Wall B:** `pkg/metadata/store/badger/{store,commit_leader}.go`.
+- **Reuse:** `blockstoretest` conformance suites (property gate), `metadata.NewMemoryMetadataStoreWithDefaults`, existing `syncLeader`/`sync_leader.go`, `pkg/identity` TTL cache, `internal/adapter/pool`.
+
+## Verification
+
+- **Every PR:** `go build ./...`; `go vet`; `gofmt -s -l`; `go test ./...` + `-race` on touched
+  packages; simplifier→reviewer; Copilot/CI green; squash-merge.
+- **Wall C:** micro-benchmark the contended path (e.g. concurrent `UpdateActivity`,
+  store-resolution) before/after; confirm no auth regression via the storetest + SMB-ACL
+  fidelity suites; watch NFS/SMB e2e latency.
+- **Wall A:** `BlockStoreConformance` + `BlockStoreAppendConformance` must stay green (property
+  preservation = dedup, durability, POSIX overwrite/hole, eviction). VM-free A/B on the fixed
+  `BenchmarkSequentialWrite8MB` for write-count deltas; VM `dfsbench` seq-write + warm/cold
+  read cells for absolute MB/s vs the Phase-0 baseline and competitors; e2e NFS/SMB
+  write→read round-trip; kill-after-COMMIT durability + repack-crash tests for A4/A6.
+- **Wall B:** Linux A/B on one SCW VM (binary-swap), metadata cell before/after; target beats
+  ZeroFS (354 ops/s).

--- a/.planning/perf/2026-07-15-wall-a-segstore-BLUEPRINT.md
+++ b/.planning/perf/2026-07-15-wall-a-segstore-BLUEPRINT.md
@@ -1,0 +1,257 @@
+# Wall A — `segstore` local block store redesign: architecture blueprint
+
+> Finalized executor-ready blueprint for Wall A of the three-wall NFS/SMB perf plan
+> (`2026-07-15-nfs-smb-three-walls-PLAN.md`). All design decisions are LOCKED in the plan;
+> this fills in every format / interface / algorithm / PR detail. Self-contained — executors
+> can implement from this without prior conversation context.
+
+Locked spec: `2026-07-15-nfs-smb-three-walls-PLAN.md` (Wall A §1–§6 + Unifying model + rationale).
+
+## 1. Package layout
+
+New standalone package: **`pkg/block/segstore/`** — owns all persistent local-cache state, zero imports from `pkg/controlplane`, `pkg/metadata`, or protocol packages. Only external deps: `pkg/block/remote` (for the `RemoteBlockStore` shape it borrows, not imports directly — see §2) and stdlib.
+
+```
+pkg/block/segstore/
+  segstore.go   // Store struct, Open/Close/Stats, Config, Clock
+  record.go     // record framing, encode/decode, CRC
+  segment.go    // active/sealed segment lifecycle, sealed-fd pool, append primitive
+  index.go      // per-file interval index, SegmentLocation, DataExtents
+  shard.go      // fileID -> shard partitioning (FNV-1a, 2^N)
+  carve.go      // FastCDC+BLAKE3+dedup-at-carve, batching trigger
+  evict.go      // pressure-gated whole-segment eviction
+  gc.go         // dead-byte tracking, size-tiered repack
+  recovery.go   // tail-scan, CRC validate, torn-write truncate, orphan sweep
+  doc.go
+```
+
+Replaces, in `pkg/block/local/fs/`: `rollup.go`, `compaction.go`, `appendlog.go`, `appendwrite.go`, `logindex.go`, `readpayload.go`, `eviction.go`, `recovery.go` — all deleted (§6). Replaces `pkg/block/local/logblob/` entirely (deleted). `pkg/block/local/fs/sync_leader.go` and the shard-hashing idea in `logshard.go` are **ported, not deleted** — they're already format-agnostic (§6).
+
+`FSStore` (surviving, slimmed) becomes a thin adapter: it still implements `block.Store` / `block.BlockStoreAppend` / `DurabilityReporter` (`pkg/block/blockstore.go`) for the rest of the codebase, but every method body delegates to a `*segstore.Store` instance plus the existing `metadata.LocalChunkIndex` bookkeeping on the other side of the seam.
+
+## 2. Public API
+
+```go
+package segstore
+
+type FileID string // == today's payloadID; same value space, same shardFor hash
+
+type Store struct { /* unexported */ }
+
+func Open(dir string, cfg Config, remote RemoteStore, clock Clock) (*Store, error)
+func (s *Store) Close() error
+
+// Client-driven dirty write. Never fsyncs; returns once buffered.
+func (s *Store) WriteAt(ctx context.Context, id FileID, offset int64, data []byte) error
+
+// Cold-read hydration write. Same append primitive as WriteAt, synced=true.
+func (s *Store) Hydrate(ctx context.Context, id FileID, offset int64, data []byte) error
+
+func (s *Store) ReadAt(ctx context.Context, id FileID, offset int64, dst []byte) (n int, cold bool, err error)
+
+// Fsync-durable checkpoint. NFS COMMIT / SMB Flush land here.
+func (s *Store) Commit(ctx context.Context, id FileID) error
+
+// Explicit/forced carve trigger; background loop also calls this per-shard.
+func (s *Store) Carve(ctx context.Context, opts CarveOptions) (CarveResult, error)
+
+// Pressure-gated whole-segment eviction; targetBytes=0 means "one segment if any qualifies".
+func (s *Store) Evict(ctx context.Context, targetBytes int64) (EvictResult, error)
+
+func (s *Store) DataExtents(ctx context.Context, id FileID, fileSize int64) ([][2]uint64, error)
+func (s *Store) Delete(ctx context.Context, id FileID) error
+func (s *Store) UnsyncedBytes() int64
+func (s *Store) Stats() Stats
+```
+
+Injected dependencies:
+
+```go
+// Mirrors pkg/block/remote/remote.go:74 RemoteBlockStore in shape; segstore
+// depends on this narrow interface, not the remote package's concrete type.
+type RemoteStore interface {
+    PutBlock(ctx context.Context, id BlockID, r io.Reader, size int64) error
+    GetBlock(ctx context.Context, id BlockID) (io.ReadCloser, error)
+    GetRange(ctx context.Context, id BlockID, off, length int64) (io.ReadCloser, error)
+}
+
+type Clock interface { Now() time.Time }
+
+type Config struct {
+    SegmentSize      int64         // fixed segment cap before rotation (e.g. 256MiB)
+    CarveBlockSize   int64         // fixed pack size, bench param, START 4 MiB
+    CarveMaxAge      time.Duration // age-based batching cap
+    GCDeadRatioForce float64       // e.g. 0.5, forces repack regardless of scheduling
+    ShardCount       int           // 2^N, immutable per store instance (§8)
+}
+```
+
+`WriteAt` and `Hydrate` are two thin public entry points over one internal `appendRecord(id, offset, data, synced bool)` primitive — the plan's unifying model made concrete: client writes and S3-hydration both funnel through the same append path, differing only in the `synced` bit.
+
+## 3. On-disk formats
+
+**Segment header** (offset 0 of every `.seg` file):
+
+```
+Magic       [8]byte  "DFSSEG1"
+SegmentID   uint64   // matches filename
+CreatedAt   int64    // unix nanos
+Flags       uint32   // bit0 = sealed (immutable; header is truth on recovery)
+HeaderCRC32 uint32
+Reserved    [32]byte // room for future fields without reformatting
+```
+
+Filename: 16-digit zero-padded decimal `SegmentID` + `.seg` — reuses the exact blob-ID naming convention already used by `pkg/block/local/logblob/manager.go`.
+
+**Record** (append-only stream following the header):
+
+```
+MagicByte    uint8   // 0xD5, torn-write scan anchor
+HeaderLen    uint8   // versioned, currently 29
+FileIDLen    uint16
+FileOffset   uint64  // logical offset within the file
+PayloadLen   uint32
+Version      uint64  // global monotonic LSN, assigned at append; NEVER reissued on repack
+Flags        uint8   // bit0=synced (clean/evictable), bit1=tombstone
+HeaderCRC32  uint32  // covers Magic..Version ONLY — deliberately excludes Flags
+FileID       []byte  // FileIDLen bytes
+Payload      []byte  // PayloadLen bytes
+PayloadCRC32 uint32  // covers Payload only; verified on GC/repack/recovery, NOT warm read
+```
+
+`HeaderCRC32` excluding `Flags` is load-bearing: carve-completion flips the synced bit in-place (single `pwrite` at the record's known `SegOffset`) without invalidating the CRC or rewriting the record. `Version` is a store-wide atomic LSN, not a per-segment sequence — this is what makes newest-wins well-defined after GC/repack physically relocates records into a different segment.
+
+Departure from today's per-payload single-log-file model (`fs/logshard.go:19`): today one log file == one payload, so no `FileID` in the frame. The new format packs **many files into one shared segment**, so `FileID`/`Version`/explicit `synced` flag move from implicit to record-resident.
+
+**`.idx` sidecar** (`<segmentID>.idx`, flat array of 40-byte fixed entries, lazy/best-effort — `COMMIT` fsyncs only the `.seg`, never the `.idx`):
+
+```
+FileIDHash  uint64  // FNV-1a of FileID, same hash fs/logshard.go:46-55 already uses
+FileOffset  uint64
+PayloadLen  uint32
+Version     uint64
+SegOffset   uint64  // byte offset of the record in the .seg
+Flags       uint8
+pad         [7]byte // align to 40 bytes
+```
+
+Losing `.idx` is a performance event only: fully rebuildable by re-scanning the sibling `.seg` (§5 Recovery). Record overhead ~69 bytes fixed + variable `FileID` (~36 bytes) — a tiny-scattered-write cost, mitigated (not eliminated) by A5 record-merge.
+
+## 4. In-memory structures
+
+**Per-file interval index** — reuse the existing `intervalTree`/coverage-set shape (`fs/logindex.go`, `fs/logshard.go:22-23`), rekeyed: each node stores `SegmentLocation{SegmentID uint64, Offset int64, Length int64}` instead of `LocalChunkLocation` (`pkg/block/block_record.go`), because entries can no longer assume "this is my own payload's file" — segments are shared. Newest-wins is enforced by node overwrite on WriteAt/Hydrate.
+
+**Per-segment metadata**, one struct per known segment, in `segmentTable map[uint64]*segmentMeta`:
+
+```go
+type segmentMeta struct {
+    id             uint64
+    sealed         atomic.Bool
+    liveBytes      atomic.Int64
+    deadBytes      atomic.Int64 // Titan discardable_size analog
+    syncedRecords  atomic.Int64 // eviction synced-gate check (§5)
+    lastAccess     atomic.Int64 // unix nanos, approx-LRU eviction victim key
+    quotientFilter *qf.Filter   // membership hint, rebuilt on every repack (§8)
+    fd             *os.File     // sealed-fd pool entry, same pattern as logblob.Manager
+}
+```
+
+**Active-vs-sealed model**: exactly one active segment per shard accepts appends. On `SegmentSize` overflow or `CarveMaxAge` the segment is sealed — fsync **before** flipping the header's sealed bit (mirrors `logblob/manager.go` Rotate's durability-boundary) — and a new active segment opens. Sealed segments read-only until GC repacks.
+
+**Partition sharding**: `ShardCount` (2^N, default 16 matching `fs/logshard.go:9`) shards keyed by the identical FNV-1a-masked hash of `FSStore.shardFor` (`fs/logshard.go:45-55`). **Each shard owns its own active segment** — N shards write to N concurrently-appendable segments, no single global active-segment lock. GC and carve iterate shards independently.
+
+## 5. Algorithms
+
+**Write + COMMIT**
+1. `shard := shardFor(fileID)`; acquire shard's single active-segment append mutex.
+2. Frame the record: `Version = atomic global LSN++`, `Flags.synced = false`.
+3. `pwrite` into the shard's active segment at the tracked tail offset (single writer per shard).
+4. Best-effort append the 40-byte `.idx` entry (failure logged Warn, never fails the write).
+5. Update the per-file interval tree: insert/overwrite covering node → new `SegmentLocation`; bump superseded node's segment `deadBytes`.
+6. Return without fsync (dirty/buffered).
+7. On `Commit(fileID)`: route through the existing store-level `syncLeader` (`fs/sync_leader.go:9-22`, ported verbatim — coalesces `fsync()` closures, format-agnostic) for the shard's active fd. Durability is implicit in "fsync happened".
+
+**Carve** (per shard, background worker + explicit `Carve()`)
+1. Snapshot covering dirty intervals for files whose dirty-byte count crosses `CarveBlockSize` or oldest dirty record exceeds `CarveMaxAge`, under the shard lock — same Phase-A/B/C split as `rollup.go`'s `rollupFileInner`.
+2. Lock-free: stream dirty bytes in file-offset order through FastCDC → BLAKE3 → per-share dedup (`block.EngineFileChunkStore`, `pkg/block/filechunk.go:145`, unchanged) → novel chunks accumulate.
+3. At `CarveBlockSize`/`CarveMaxAge`: seal each novel chunk (`chunkSealer`, `engine/syncer.go:139-142`), frame via `blockcodec.Builder` (#1414, reused), `PutBlock`.
+4. On success: atomic commit (block record + locators + synced markers — `blockCommitter`, `engine/syncer.go:179-189`). **Then** flip each carved record's `Flags.synced` in-place (single-byte `pwrite`, CRC untouched). Flip-after-commit means a crash between commit and flip causes one harmless re-carve, never data loss.
+5. Per-shard `carveMu` serializes a shard's flush against a concurrent explicit `Carve()`.
+
+**Warm read**
+1. Look up covering intervals for `[offset, offset+len(dst))`.
+2. For each hit, `pread` from `segmentMeta.fd` or active fd — brief-lock-then-unlocked-pread (same as `logblob.Manager.ReadAt`).
+3. Uncovered: true POSIX hole → zero-fill; known-written-but-evicted → cold read.
+4. **No hash-verify** — record CRC checked only by GC/repack/recovery. Retires #1648 verify-once (moot: no separate CAS-verify step).
+
+**Cold read (serve-direct + async hydrate, A8)**
+1. On an interval-index miss for a range known remote (resolved by the FSStore/engine caller via logical-offset→hash→`ChunkLocator`; segstore has no namespace dependency), the caller does `GetRange`/`GetBlock` and serves the client immediately — never blocks on a local write.
+2. Fetched bytes copied to wire first; only then `segstore.Hydrate` (buffer-ownership discipline).
+3. Hydrate **every** chunk unpacked from the fetched block — free prefetch.
+4. Concurrent cold readers singleflight at the caller's read-through-cache (#1362).
+
+**Eviction** (lazy, pressure-gated only)
+1. Trigger: `LocalStoreSize` threshold, `dfsctl` force, or near-full fallback.
+2. Victim: coldest sealed segment by `lastAccess`, filtered to `syncedRecords == liveRecords`. Reuses `logblob.EvictBlob`'s synced-gate.
+3. On eviction: unlink `.seg`+`.idx`, drop `segmentMeta`, and for every interval-tree entry pointing into it, **replace (not delete)** with a "cold, fetch remote" marker — so a read falls to cold-read, not a false hole.
+4. If pressure persists with no evictable segment (dirty pinned): surface via `UnsyncedBytes()`, backpressure the write path, log loud+actionable Warn.
+
+**GC/repack**
+1. `deadBytes` increments when an interval-tree node is overwritten or a file tombstoned.
+2. Size-tiered victim: highest `deadBytes/SegmentSize`; `GCDeadRatioForce` forces immediate repack (RocksDB #9235 space-amp lesson).
+3. Repack (from `compaction.go`'s `compactLogLocked`): snapshot live records → write into repack-target segment **preserving `Version` and `synced`** (never reissued) → fsync dest → fsync dir → update interval-tree entries → **only then** unlink source.
+4. Ordering: bytes-durable-before-index-durable-before-reclaim (identical to `eviction.go`'s `relocateSurvivors`). Crash before unlink → harmless orphan, swept later.
+
+**Recovery**
+1. Per shard: locate the one unsealed (active) segment (header Flags bit0 unset).
+2. Tail-scan from offset 0 (bounded by `SegmentSize`): validate `HeaderCRC32` then `PayloadCRC32`; truncate + fsync at first invalid/truncated record.
+3. Replay valid records into a fresh interval tree and fresh `.idx`.
+4. Recompute global Version LSN as `max(observed Version)+1`. Sealed segments trusted via header Flags ("header is truth") — no full re-validation each boot; only the active segment gets the tail-scan.
+5. Orphan sweep: age-gated; any on-disk segment unreferenced by bookkeeping is redundant (per GC ordering invariant), safe to delete after the age gate.
+
+**Migration (A6)**
+Drain→discard→re-hydrate, no format converter. Upgrade blocks until `UnsyncedBytes()==0`, then starts segstore with an **empty** local cache — first post-upgrade reads are cold and repopulate via Hydrate. One-shot, deleted the release after it ships (precedent: `fs/legacy_migration.go`).
+
+## 6. Mapping to existing code
+
+**Delete:** `pkg/block/local/fs/{rollup,compaction,appendlog,appendwrite,logindex,readpayload,eviction,recovery}.go`; `pkg/block/local/logblob/` (entire package — reusable patterns reimplemented against the shared-segment format in `segstore/segment.go`).
+
+**Modify:**
+- `pkg/block/local/fs/chunkstore.go`, `blockstore_methods.go` — read/write bodies (`chunkstore.go:185,251,300`) delegate to `segstore.Store.ReadAt`/`WriteAt`/`Hydrate`.
+- `pkg/block/block_record.go` — rename `LocalChunkLocation{LogBlobID,RawOffset,RawLength}` → `SegmentLocation{SegmentID uint64, Offset, Length int64}`; mechanical across callers (`carver.go:293-299`, `eviction.go:381/498/555/744`, `legacy_migration.go:120/270`, `blockstore_methods.go:71/126`).
+- `pkg/block/engine/carver.go`/`syncer.go` — **biggest boundary shift.** Chunk-boundary discovery moves to carve time, inside `segstore.Carve()`. **Delete** `localBlobReader` (`syncer.go:191-198`) + field (`syncer.go:151`); segstore does its own local reads. `engine/syncer.go` keeps only packing+PutBlock+commit: calls `segstore.Carve()`, gets chunked/hashed novel batches, frames via `blockcodec.Builder` + `PutBlock` + `blockCommitter`. Delete `pendingCarveHashes`/`carveQ`/`addPendingHash` (`syncer.go:100-230`) and the `onChunkComplete` ingest hook — no chunk-at-ingest anymore.
+- `pkg/controlplane/runtime/shares/service.go` — `CreateLocalStoreFromConfig` constructs segstore-backed `FSStore`; delete dead `use_append_log` flag.
+- `pkg/block/blockstoretest/conformance.go`, `appendlog.go` — kept; four currently-skipped scenarios (`PressureChannel_INV05`, `TornWriteRecovery_LSL06`, `ConcurrentStorm`, `RollupOffsetMonotone_INV03`) get their fs-internal probes rewritten against segstore internals (PR3/PR8), not dropped.
+
+**Keep unchanged:** `metadata.Transactor`/`SyncedHashStore`/`LocalChunkIndex`; `remote.RemoteBlockStore` (`remote/remote.go:74`); `block.EngineFileChunkStore` (`filechunk.go:145`); `blockcodec.Builder`; `fs/sync_leader.go` (ported as-is). `engine/{gc,gc_block,reclaim,dataextents,readahead,cache,sync_health}.go` — flagged for a targeted read-through to confirm none hide `LocalChunkLocation`-shaped assumptions (open item).
+
+## 7. PR sequence
+
+Each independently reviewable, conformance-gated where applicable, `-race` clean, simplifier→reviewer→lint→PR→CI-green→squash-merge.
+
+0. **PR0 — standalone bench harness.** `pkg/block/segstore/` skeleton + in-package benchmarks vs a fake in-memory `RemoteStore`, no wiring. Acceptance: `go test -bench=.` produces write/read/carve throughput; the baseline every later PR is measured against.
+1. **PR1 — segment format + append primitive.** `record.go`, `segment.go`: header, framing, active/sealed, sealed-fd pool, `.idx` writer, `Open`/`WriteAt`/`ReadAt`/`Commit`/`Close`/`Stats`. Acceptance: random offset/length spans across many `FileID`s byte-identical readback; crash-injection mid-append → clean recovery truncation; `-race`.
+2. **PR2 — interval index.** `index.go`: tree rekeyed to `SegmentLocation`, hole/gap, `DataExtents`. Acceptance: sparse/hole/newest-wins-after-out-of-order conformance.
+3. **PR3 — recovery.** `recovery.go`: tail-scan, CRC, torn-write truncate, Version-LSN recompute, orphan sweep. Acceptance: `TornWriteRecovery_LSL06` becomes a real passing test.
+4. **PR4 — carve.** `carve.go`: FastCDC+BLAKE3+dedup-at-carve, size+age batching, in-place synced-bit flip. Acceptance: chunk boundaries match a reference FastCDC/BLAKE3 run; re-carve-after-crash no double-count; dedup vs fake `EngineFileChunkStore`.
+5. **PR5 — eviction.** `evict.go`: pressure-gated whole-segment, synced-gate, cold-marker invalidation. Acceptance: evicting a synced segment leaves reads on its ranges reporting cold (not hole/error); `DataExtents` still reports range present.
+6. **PR6 — GC/repack.** `gc.go`: dead-byte hooks, size-tiered pick, `GCDeadRatioForce`, fsync-then-unlink. Acceptance: forced repack fires above threshold without idle wait; crash before unlink → harmless orphan, data intact.
+7. **PR7 — engine wiring.** Rework `engine/syncer.go`/`carver.go` (segstore owns chunking); delete `localBlobReader`, `pendingCarveHashes`/`carveQ`, `onChunkComplete`. Acceptance: `carver_test.go` passes new call shape; e2e `BlockStoreConformance` green through the real `Syncer`. **Riskiest interface change — extra reviewer scrutiny.**
+8. **PR8 — FSStore adapter rewrite.** Delegate to segstore; `LocalChunkLocation`→`SegmentLocation` rename; delete the eight `fs/*.go` files + `logblob/`. Acceptance: full conformance green, `-race`, compile-gate on no dangling refs.
+9. **PR9 — share wiring.** `CreateLocalStoreFromConfig` segstore-backed by default (no flag); delete dead `use_append_log`. Acceptance: NFS+SMB e2e green.
+10. **PR10 — migration.** One-shot drain-then-cold-start (A6), deletion-scheduled next release. Acceptance: e2e upgrade test — drain to `UnsyncedBytes()==0`, post-upgrade cold reads correct.
+11. **PR11 (deferred, A7) — O_DIRECT + io_uring** for background carve/GC bulk reads, Linux-only, gated behind post-PR10 profiling.
+
+## 8. Open risks / edge cases
+
+- **Crash mid-append with CRC-coincidence.** A torn record whose `HeaderCRC32` validates while `PayloadLen` points past a plausible stale EOF — guard with a `PayloadLen` sanity ceiling (e.g. `CarveBlockSize`-scale), not CRC alone.
+- **Crash mid-carve, between commit and synced-flip.** Record still reads `synced=false` on restart → harmless re-carve; content-addressed dedup makes the re-commit a no-op. Flip strictly after commit → always errs toward "re-carve", never data loss.
+- **Concurrent overwrite during carve.** A newer-`Version` write mid-scan lands elsewhere; the carve snapshot (under shard lock, released before CDC) packs the range it named by `SegOffset`, flip only touches those records; the overwrite carves next pass. One extra round, no bug — matches `rollup.go` today.
+- **Dirty-can't-evict backpressure.** Threshold/backoff curve left a `Config` tunable; start by porting `eviction.go`'s `ensureSpace` hard-gate rather than inventing a curve.
+- **Quotient-filter false positives.** Safe by construction (no false negatives); a FP costs one wasted pread. The filter **must be rebuilt, not carried, on every repack** — explicit in `gc.go`.
+- **Partition-shard boundaries immutable.** `ShardCount` fixed at `Open()`; changing it misroutes lookups. Online resharding out of scope — document create-time-only; a dedicated rehash-relocate migration if ever needed.
+- **Shared-segment blast radius.** Segments multiplex many files, so a corrupted/lost segment now affects many files, not one. Accepted trade (for S3-packing + coarse eviction) — raises the bar on recovery per-record CRC rigor.
+- **Record header overhead (~69 B/record).** Meaningful for many-tiny-scattered-writes; A5 record-merge mitigates but is rate-gated — a tiny-writes-then-COMMIT burst before merge pays full overhead. Explicit PR0 benchmark case.
+- **Correlated `.idx` loss.** All shards' `.idx` lost at once → recovery re-scans every sealed segment, not just active. Emit loud Warn ("N segments missing .idx, rebuilding, may take a while").
+- **`BlockReclaimer` concurrent-GC hazard (from prior memory).** The union refcount-decrement is unsafe under concurrent GC (single sweeper lock is per-`GCStateRoot`, not per-remote) — must be made safe when the segment store becomes the reclamation target.
+- **`engine/syncer.go` rework (PR7) is the single riskiest step** — changes who calls whom across the carve seam. Own acceptance tests beyond the conformance gate ("minimize interface surface" house rule).


### PR DESCRIPTION
Locked design docs for the NFS/SMB performance effort (Phase 0/1 shipped in #1688/#1690).

- `.planning/perf/2026-07-15-nfs-smb-three-walls-PLAN.md` — the three-wall plan (A data plane, B metadata, C RPC/adapter/auth) with all decisions + rationale.
- `.planning/perf/2026-07-15-wall-a-segstore-BLUEPRINT.md` — executor-ready Wall A architecture (new `pkg/block/segstore/` package, byte-level formats, API, algorithms, keep/modify/delete map, 12-PR sequence).

Planning docs only — no code change.