### PR TITLE
perf(smb): pool per-request raw message buffer on the read loop (Wall C4)

### DIFF
--- a/pkg/adapter/smb/connection.go
+++ b/pkg/adapter/smb/connection.go
@@ -351,10 +351,12 @@ func (c *Connection) Serve(ctx context.Context) {
 		// race with the LOGOFF handler, causing the signing verifier to
 		// return STATUS_ACCESS_DENIED instead of STATUS_USER_SESSION_DELETED.
 		if hdr.Command == types.CommandLogoff && len(remainingCompound) == 0 {
-			if err := smb.ProcessSingleRequest(ctx, hdr, body, rawMessage, ci, isEncrypted, nil); err != nil {
-				logger.Debug("Error processing LOGOFF request", "address", clientAddr, "messageID", hdr.MessageID, "error", err)
-			}
-			pool.Put(rawMessage)
+			func() {
+				defer pool.Put(rawMessage)
+				if err := smb.ProcessSingleRequest(ctx, hdr, body, rawMessage, ci, isEncrypted, nil); err != nil {
+					logger.Debug("Error processing LOGOFF request", "address", clientAddr, "messageID", hdr.MessageID, "error", err)
+				}
+			}()
 			continue
 		}
 

--- a/pkg/adapter/smb/connection.go
+++ b/pkg/adapter/smb/connection.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/marmos91/dittofs/internal/adapter/pool"
 	smb "github.com/marmos91/dittofs/internal/adapter/smb"
 	"github.com/marmos91/dittofs/internal/adapter/smb/encryption"
 	"github.com/marmos91/dittofs/internal/adapter/smb/handlers"
@@ -335,8 +336,12 @@ func (c *Connection) Serve(ctx context.Context) {
 		ci.DecryptFailures.Store(0)
 
 		// Reconstruct raw message (header + body) for dispatch hooks.
-		// The hooks need the original wire bytes for preauth integrity hash computation.
-		rawMessage := make([]byte, header.HeaderSize+len(body))
+		// The hooks need the original wire bytes for preauth integrity hash
+		// computation. The buffer is pooled: the owning goroutine (or the
+		// synchronous LOGOFF path) returns it via pool.Put once dispatch
+		// completes. Dispatch consumes these bytes synchronously (SHA-512
+		// preauth chaining into a [64]byte), so no reference outlives the call.
+		rawMessage := pool.Get(header.HeaderSize + len(body))
 		copy(rawMessage, hdr.Encode())
 		copy(rawMessage[header.HeaderSize:], body)
 
@@ -349,6 +354,7 @@ func (c *Connection) Serve(ctx context.Context) {
 			if err := smb.ProcessSingleRequest(ctx, hdr, body, rawMessage, ci, isEncrypted, nil); err != nil {
 				logger.Debug("Error processing LOGOFF request", "address", clientAddr, "messageID", hdr.MessageID, "error", err)
 			}
+			pool.Put(rawMessage)
 			continue
 		}
 
@@ -386,12 +392,14 @@ func (c *Connection) Serve(ctx context.Context) {
 			copy(compoundData, remainingCompound)
 
 			go func(reqHeader *header.SMB2Header, reqBody, raw []byte, encrypted bool) {
+				defer pool.Put(raw)
 				defer c.handleRequestPanic(clientAddr, reqHeader.MessageID)
 				asyncCallback := c.makeAsyncNotifyCallback(ci)
 				smb.ProcessCompoundRequest(ctx, reqHeader, reqBody, raw, compoundData, ci, encrypted, asyncCallback)
 			}(hdr, body, rawMessage, isEncrypted)
 		} else {
 			go func(reqHeader *header.SMB2Header, reqBody, raw []byte, encrypted bool, release func()) {
+				defer pool.Put(raw)
 				if release != nil {
 					defer release()
 				}

--- a/pkg/adapter/smb/connection_bench_test.go
+++ b/pkg/adapter/smb/connection_bench_test.go
@@ -1,0 +1,44 @@
+package smb
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/pool"
+	"github.com/marmos91/dittofs/internal/adapter/smb/header"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// benchRawMessage models the read-loop per-request raw-message reconstruct
+// (header + body) exercised in Connection.handleRequests. It compares the
+// pooled path against a fresh allocation per request.
+func benchRawMessage(b *testing.B, bodyLen int, pooled bool) {
+	b.Helper()
+	hdr := &header.SMB2Header{Command: types.CommandWrite, MessageID: 42}
+	body := make([]byte, bodyLen)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var raw []byte
+		if pooled {
+			raw = pool.Get(header.HeaderSize + len(body))
+		} else {
+			raw = make([]byte, header.HeaderSize+len(body))
+		}
+		copy(raw, hdr.Encode())
+		copy(raw[header.HeaderSize:], body)
+		if pooled {
+			pool.Put(raw)
+		}
+	}
+}
+
+func BenchmarkRawMessageUnpooled(b *testing.B) {
+	b.Run("512B", func(b *testing.B) { benchRawMessage(b, 512, false) })
+	b.Run("64KB", func(b *testing.B) { benchRawMessage(b, 64<<10, false) })
+}
+
+func BenchmarkRawMessagePooled(b *testing.B) {
+	b.Run("512B", func(b *testing.B) { benchRawMessage(b, 512, true) })
+	b.Run("64KB", func(b *testing.B) { benchRawMessage(b, 64<<10, true) })
+}

--- a/pkg/adapter/smb/connection_bench_test.go
+++ b/pkg/adapter/smb/connection_bench_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // benchRawMessage models the read-loop per-request raw-message reconstruct
-// (header + body) exercised in Connection.handleRequests. It compares the
+// (header + body) exercised in Connection.Serve. It compares the
 // pooled path against a fresh allocation per request.
 func benchRawMessage(b *testing.B, bodyLen int, pooled bool) {
 	b.Helper()


### PR DESCRIPTION
## Summary

The SMB single-reader loop (`pkg/adapter/smb/connection.go`) reconstructed the raw wire message (header + body) for dispatch hooks with a fresh `make(...)` per request — unpooled — allocating a new buffer (up to the negotiated max I/O size) on every SMB request. The NFS read path already pools this.

This reuses the existing tiered `internal/adapter/pool/bufpool.go` for that buffer, mirroring NFS. The buffer is returned to the pool by the owning goroutine (compound / single) via `defer pool.Put`, and by the synchronous LOGOFF path directly after dispatch.

## Buffer-lifetime safety

The reconstructed bytes are consumed **synchronously** within the dispatch call chain:
- `RunBeforeHooks` → `UpdatePreauthHash` → `chainHash` → `sha512.Write(message)` — hashes into a `[64]byte` value, no slice retention.
- `handlerCtx.RawRequest` → SESSION_SETUP `InitSessionPreauthHash` → same `chainHash` — no slice retention.

No reference to the buffer outlives the dispatch call, so returning it to the pool once the owning goroutine finishes is safe. Compound sub-command `subRaw` slices point into a separate `compoundData` copy, not this buffer. `defer pool.Put` fires even on panic (via `handleRequestPanic` recovery), so the buffer is never leaked. Verified under `go test -race`.

## Before/after (micro-benchmark, `-benchmem`)

Models the read-loop reconstruct (header + body, `pool.Get`/copy/copy/`pool.Put` vs `make`/copy/copy):

```
BenchmarkRawMessageUnpooled/512B    371.9 ns/op     640 B/op    2 allocs/op
BenchmarkRawMessagePooled/512B      162.3 ns/op      88 B/op    2 allocs/op
BenchmarkRawMessageUnpooled/64KB   26754   ns/op   73792 B/op    2 allocs/op
BenchmarkRawMessagePooled/64KB      1169   ns/op      89 B/op    2 allocs/op
```

Bytes/op drop: 640→88 (-86%) small, 73792→89 (-99.9%) for bulk-sized messages. The residual 2 allocs are the out-of-scope 64B `hdr.Encode()` and sync.Pool's pointer box; the multi-KB message buffer is eliminated.

Verify: `gofmt -s`, `go vet`, `golangci-lint`, `go build ./...`, `go test -race ./pkg/adapter/smb/...` (65) and `./internal/adapter/smb/...` (2024) all pass.

Part of #1692