### PR TITLE
perf(runtime): per-client atomic activity timestamp, drop the per-op registry write lock (Wall C1)

### DIFF
--- a/pkg/controlplane/runtime/clients/service.go
+++ b/pkg/controlplane/runtime/clients/service.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -43,11 +44,23 @@ type SmbDetails struct {
 	Encrypted bool   `json:"encrypted"`
 }
 
+// clientEntry is the map value. It holds the record's structural fields plus a
+// lock-free last-activity timestamp. The timestamp is bumped on every request,
+// so it lives in an atomic instead of under the registry write lock.
+type clientEntry struct {
+	ClientRecord
+	lastActivity atomic.Int64 // Unix nanos; hot path, lock-free
+}
+
 // Registry provides thread-safe client tracking with TTL-based stale cleanup.
 // It follows the same sub-service pattern as mounts.Tracker.
+//
+// mu guards the map structure and each entry's non-atomic fields (Shares).
+// The per-request activity bump does not take mu — it stores into the entry's
+// atomic timestamp, so the highest-fan-in call in the system never contends.
 type Registry struct {
 	mu      sync.RWMutex
-	clients map[string]*ClientRecord // keyed by ClientID
+	clients map[string]*clientEntry // keyed by ClientID
 	ttl     time.Duration
 	stopCh  chan struct{}
 }
@@ -58,7 +71,7 @@ func NewRegistry(ttl time.Duration) *Registry {
 		ttl = DefaultTTL
 	}
 	return &Registry{
-		clients: make(map[string]*ClientRecord),
+		clients: make(map[string]*clientEntry),
 		ttl:     ttl,
 		stopCh:  make(chan struct{}),
 	}
@@ -75,9 +88,12 @@ func (r *Registry) Register(record *ClientRecord) {
 		record.LastActivity = now
 	}
 
+	e := &clientEntry{ClientRecord: *record}
+	e.lastActivity.Store(record.LastActivity.UnixNano())
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.clients[record.ClientID] = record
+	r.clients[record.ClientID] = e
 }
 
 // Deregister removes and returns a client record. Returns nil if not found.
@@ -85,12 +101,12 @@ func (r *Registry) Deregister(clientID string) *ClientRecord {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	rec, ok := r.clients[clientID]
+	e, ok := r.clients[clientID]
 	if !ok {
 		return nil
 	}
 	delete(r.clients, clientID)
-	return rec
+	return copyRecord(e)
 }
 
 // Get returns a deep copy of the client record, or nil if not found.
@@ -98,21 +114,22 @@ func (r *Registry) Get(clientID string) *ClientRecord {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	rec, ok := r.clients[clientID]
+	e, ok := r.clients[clientID]
 	if !ok {
 		return nil
 	}
-	return copyRecord(rec)
+	return copyRecord(e)
 }
 
-// UpdateActivity updates the LastActivity timestamp for a client.
-// No-op if the client does not exist.
+// UpdateActivity bumps the LastActivity timestamp for a client. Called on every
+// NFS/SMB request, so it takes only a read lock (map safety) and stores into the
+// per-client atomic — no write-lock convoy. No-op if the client does not exist.
 func (r *Registry) UpdateActivity(clientID string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 
-	if rec, ok := r.clients[clientID]; ok {
-		rec.LastActivity = time.Now()
+	if e, ok := r.clients[clientID]; ok {
+		e.lastActivity.Store(time.Now().UnixNano())
 	}
 }
 
@@ -122,12 +139,12 @@ func (r *Registry) AddShare(clientID, share string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	rec, ok := r.clients[clientID]
+	e, ok := r.clients[clientID]
 	if !ok {
 		return
 	}
-	if !slices.Contains(rec.Shares, share) {
-		rec.Shares = append(rec.Shares, share)
+	if !slices.Contains(e.Shares, share) {
+		e.Shares = append(e.Shares, share)
 	}
 }
 
@@ -137,13 +154,13 @@ func (r *Registry) RemoveShare(clientID, share string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	rec, ok := r.clients[clientID]
+	e, ok := r.clients[clientID]
 	if !ok {
 		return
 	}
-	for i, s := range rec.Shares {
+	for i, s := range e.Shares {
 		if s == share {
-			rec.Shares = append(rec.Shares[:i], rec.Shares[i+1:]...)
+			e.Shares = append(e.Shares[:i], e.Shares[i+1:]...)
 			return
 		}
 	}
@@ -183,11 +200,11 @@ func (r *Registry) collect(filter func(*ClientRecord) bool) []*ClientRecord {
 	defer r.mu.RUnlock()
 
 	result := make([]*ClientRecord, 0, len(r.clients))
-	for _, rec := range r.clients {
-		if filter != nil && !filter(rec) {
+	for _, e := range r.clients {
+		if filter != nil && !filter(&e.ClientRecord) {
 			continue
 		}
-		result = append(result, copyRecord(rec))
+		result = append(result, copyRecord(e))
 	}
 	return result
 }
@@ -218,9 +235,9 @@ func (r *Registry) sweep() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	now := time.Now()
-	for id, rec := range r.clients {
-		if now.Sub(rec.LastActivity) > r.ttl {
+	now := time.Now().UnixNano()
+	for id, e := range r.clients {
+		if now-e.lastActivity.Load() > int64(r.ttl) {
 			delete(r.clients, id)
 		}
 	}
@@ -236,21 +253,21 @@ func (r *Registry) Stop() {
 	}
 }
 
-// copyRecord creates a deep copy of a ClientRecord, including the Shares
-// slice and protocol detail structs.
-func copyRecord(src *ClientRecord) *ClientRecord {
-	dst := *src
-	// Deep copy Shares slice.
-	if src.Shares != nil {
-		dst.Shares = append([]string(nil), src.Shares...)
+// copyRecord creates a deep copy of an entry's ClientRecord, filling
+// LastActivity from the atomic timestamp and deep-copying the Shares slice and
+// protocol detail structs.
+func copyRecord(e *clientEntry) *ClientRecord {
+	dst := e.ClientRecord
+	dst.LastActivity = time.Unix(0, e.lastActivity.Load())
+	if e.Shares != nil {
+		dst.Shares = append([]string(nil), e.Shares...)
 	}
-	// Deep copy protocol details.
-	if src.NFS != nil {
-		nfsCopy := *src.NFS
+	if e.NFS != nil {
+		nfsCopy := *e.NFS
 		dst.NFS = &nfsCopy
 	}
-	if src.SMB != nil {
-		smbCopy := *src.SMB
+	if e.SMB != nil {
+		smbCopy := *e.SMB
 		dst.SMB = &smbCopy
 	}
 	return &dst

--- a/pkg/controlplane/runtime/clients/service.go
+++ b/pkg/controlplane/runtime/clients/service.go
@@ -56,8 +56,9 @@ type clientEntry struct {
 // It follows the same sub-service pattern as mounts.Tracker.
 //
 // mu guards the map structure and each entry's non-atomic fields (Shares).
-// The per-request activity bump does not take mu — it stores into the entry's
-// atomic timestamp, so the highest-fan-in call in the system never contends.
+// The per-request activity bump (UpdateActivity) takes only a shared read lock
+// for map safety and stores into the entry's atomic timestamp, so the
+// highest-fan-in call in the system no longer serializes on the write lock.
 type Registry struct {
 	mu      sync.RWMutex
 	clients map[string]*clientEntry // keyed by ClientID
@@ -89,6 +90,7 @@ func (r *Registry) Register(record *ClientRecord) {
 	}
 
 	e := &clientEntry{ClientRecord: *record}
+	deepCopyRefs(&e.ClientRecord) // don't alias caller-owned slice/pointers
 	e.lastActivity.Store(record.LastActivity.UnixNano())
 
 	r.mu.Lock()
@@ -201,10 +203,11 @@ func (r *Registry) collect(filter func(*ClientRecord) bool) []*ClientRecord {
 
 	result := make([]*ClientRecord, 0, len(r.clients))
 	for _, e := range r.clients {
-		if filter != nil && !filter(&e.ClientRecord) {
+		rec := copyRecord(e) // snapshot carries the atomic LastActivity
+		if filter != nil && !filter(rec) {
 			continue
 		}
-		result = append(result, copyRecord(e))
+		result = append(result, rec)
 	}
 	return result
 }
@@ -254,21 +257,27 @@ func (r *Registry) Stop() {
 }
 
 // copyRecord creates a deep copy of an entry's ClientRecord, filling
-// LastActivity from the atomic timestamp and deep-copying the Shares slice and
-// protocol detail structs.
+// LastActivity from the atomic timestamp.
 func copyRecord(e *clientEntry) *ClientRecord {
 	dst := e.ClientRecord
 	dst.LastActivity = time.Unix(0, e.lastActivity.Load())
-	if e.Shares != nil {
-		dst.Shares = append([]string(nil), e.Shares...)
-	}
-	if e.NFS != nil {
-		nfsCopy := *e.NFS
-		dst.NFS = &nfsCopy
-	}
-	if e.SMB != nil {
-		smbCopy := *e.SMB
-		dst.SMB = &smbCopy
-	}
+	deepCopyRefs(&dst)
 	return &dst
+}
+
+// deepCopyRefs replaces the reference-typed fields of rec (the Shares slice and
+// the NFS/SMB detail pointers) with independent copies, so the record no longer
+// aliases the caller's or the registry's data.
+func deepCopyRefs(rec *ClientRecord) {
+	if rec.Shares != nil {
+		rec.Shares = append([]string(nil), rec.Shares...)
+	}
+	if rec.NFS != nil {
+		nfsCopy := *rec.NFS
+		rec.NFS = &nfsCopy
+	}
+	if rec.SMB != nil {
+		smbCopy := *rec.SMB
+		rec.SMB = &smbCopy
+	}
 }

--- a/pkg/controlplane/runtime/clients/service_bench_test.go
+++ b/pkg/controlplane/runtime/clients/service_bench_test.go
@@ -1,0 +1,70 @@
+package clients
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+// lockRegistry models the old UpdateActivity: a process-wide write lock taken on
+// every request just to bump a timestamp. It exists only to produce the "before"
+// number for BenchmarkUpdateActivity.
+type lockRegistry struct {
+	mu      sync.RWMutex
+	clients map[string]*ClientRecord
+}
+
+func (r *lockRegistry) updateActivity(clientID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if rec, ok := r.clients[clientID]; ok {
+		rec.LastActivity = time.Now()
+	}
+}
+
+const benchClients = 64
+
+func benchIDs() []string {
+	ids := make([]string, benchClients)
+	for i := range ids {
+		ids[i] = "client-" + strconv.Itoa(i)
+	}
+	return ids
+}
+
+// BenchmarkUpdateActivity_WriteLock is the "before": every bump serializes on a
+// single write lock. Throughput collapses as goroutines contend (lock convoy).
+func BenchmarkUpdateActivity_WriteLock(b *testing.B) {
+	ids := benchIDs()
+	r := &lockRegistry{clients: make(map[string]*ClientRecord, benchClients)}
+	for _, id := range ids {
+		r.clients[id] = &ClientRecord{ClientID: id, LastActivity: time.Now()}
+	}
+
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			r.updateActivity(ids[i%benchClients])
+			i++
+		}
+	})
+}
+
+// BenchmarkUpdateActivity is the "after": a shared read lock plus a per-client
+// atomic store, so concurrent bumps no longer convoy.
+func BenchmarkUpdateActivity(b *testing.B) {
+	ids := benchIDs()
+	r := NewRegistry(time.Hour)
+	for _, id := range ids {
+		r.Register(&ClientRecord{ClientID: id})
+	}
+
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			r.UpdateActivity(ids[i%benchClients])
+			i++
+		}
+	})
+}


### PR DESCRIPTION
## Summary

`clients.Registry.UpdateActivity` ran on **every NFS/SMB request** and took the registry **write lock** (`Registry.mu.Lock()`) just to bump a last-activity timestamp — the highest fan-in lock in the system, serializing 100% of ops behind an exclusive lock convoy.

This moves the timestamp into a per-client `atomic.Int64` (Unix nanos) stored on a new `clientEntry` map value. The per-request bump now takes only a **shared read lock** for map-lookup safety and does a lock-free atomic store — no exclusive-lock convoy. Structural map operations (Register/Deregister/AddShare/RemoveShare/sweep) keep the write lock. `ClientRecord` stays a pure JSON DTO (unchanged wire shape); readers fill `LastActivity` from the atomic in `copyRecord`.

## Before / after micro-benchmark

Concurrent goroutines hammering the timestamp bump (M1 Max, `-cpu=8`, 64 clients, `RunParallel`):

```
BenchmarkUpdateActivity_WriteLock-8    205.2 ns/op   (before: exclusive write lock)
BenchmarkUpdateActivity-8              106.2 ns/op   (after:  read lock + atomic, ~1.9x)
```

The `_WriteLock` variant is a local reference type in the test file modeling the old code path, so the before/after is measured, not asserted.

## Verification

- `gofmt -s -w .`, `go vet`, `golangci-lint run ./pkg/controlplane/...` — clean
- `go build ./...` — clean
- `go test -race ./pkg/controlplane/runtime/clients/...` — 13 pass
- `go test -race ./pkg/adapter/nfs/... ./internal/controlplane/api/handlers/...` (callers) — 265 pass

Part of #1692