### PR TITLE
perf(smb): cache per-(session,tree) AuthContext, invalidate on re-auth (Wall C5)

### DIFF
--- a/internal/adapter/smb/handlers/auth_helper.go
+++ b/internal/adapter/smb/handlers/auth_helper.go
@@ -146,56 +146,97 @@ func getUserIdentity(user *models.User) (uid, gid uint32) {
 // here — it is set by the WRITE / SET_INFO op handlers from the open handle's
 // GrantedAccess, since SMB write authorization is handle-based.
 func BuildAuthContextFromUser(ctx *SMBHandlerContext, user *models.User) *metadata.AuthContext {
+	// The identity is fixed for the life of a session's authentication, so reuse
+	// the session's memoized one instead of re-deriving it (UID/GID lookup, GID
+	// slice, group-SID concat + dedup) on every op. Handle-bound callers pass the
+	// frozen OpenFile.OpenerUser: after a re-auth that differs from Session.User,
+	// so the pointer-guarded cache misses and the snapshot identity is rebuilt.
+	identity := &metadata.Identity{}
+	if user != nil {
+		if cached := ctx.cachedIdentity(user); cached != nil {
+			identity = cached
+		} else {
+			identity = buildIdentity(ctx, user)
+			ctx.maybeCacheIdentity(user, identity)
+		}
+	}
+
 	authCtx := &metadata.AuthContext{
 		Context:                ctx.Context,
 		ClientAddr:             ctx.ClientAddr,
 		LockClientID:           fmt.Sprintf("smb:%d", ctx.SessionID),
-		Identity:               &metadata.Identity{},
+		Identity:               identity,
 		BypassTraverseChecking: true,
 	}
 
-	if user != nil {
-		uid, gid := getUserIdentity(user)
-		authCtx.Identity.UID = &uid
-		authCtx.Identity.GID = &gid
-		authCtx.Identity.Username = user.Username
-		// Supplementary group IDs: populate Identity.GIDs from every group the
-		// user belongs to so POSIX-mode permission checks (Identity.HasGID)
-		// honor secondary / nested-AD-group membership, not just the primary
-		// GID. Without this an AD user resolved over Kerberos — or any local
-		// user in multiple groups — was granted group access over NFS (which
-		// carries the full set) but denied over SMB. Mirrors the NFS GSS path
-		// (#1327).
-		if len(user.Groups) > 0 {
-			gids := make([]uint32, 0, len(user.Groups))
-			for _, group := range user.Groups {
-				if group.GID != nil {
-					gids = append(gids, *group.GID)
-				}
-			}
-			authCtx.Identity.GIDs = gids
-		}
-		if user.SID != "" {
-			userSID := user.SID
-			authCtx.Identity.SID = &userSID
-		}
-		// Merge the user's persisted named group SIDs with any Kerberos PAC
-		// group SIDs carried on this request's session. For an AD-issued ticket
-		// the PAC delivers the DC-resolved transitive group set, so a DACL ACE
-		// keyed on an AD group matches even when the local user model never
-		// enumerated it. slices.Concat allocates a fresh slice (no aliasing of
-		// user.GroupSIDs); mergeImplicitAuthSIDs then dedups (first occurrence wins).
-		authCtx.Identity.GroupSIDs = mergeImplicitAuthSIDs(
-			slices.Concat(user.GroupSIDs, ctx.PACGroupSIDs),
-		)
-	}
-
-	// Set the share-level read-only ceiling. Per-handle write authorization
-	// (WriteAuthorizedByHandle) is set by the WRITE / SET_INFO op handlers from
-	// OpenFile.GrantedAccess, not here — SMB write authorization is handle-based.
+	// Set the share-level read-only ceiling. This is the only per-(session,tree)
+	// input and is cheap, so it is recomputed per op rather than cached. Per-handle
+	// write authorization (WriteAuthorizedByHandle) is set by the WRITE / SET_INFO
+	// op handlers from OpenFile.GrantedAccess, not here — SMB write authorization
+	// is handle-based.
 	authCtx.ShareReadOnly = ctx.Permission == models.PermissionRead
 
 	return authCtx
+}
+
+// buildIdentity derives the metadata.Identity for user from its UID/GID, group
+// membership, SID, and the request's Kerberos PAC group SIDs. The returned value
+// is treated as immutable — consumers only read it, so it is safe to share via the
+// per-session cache.
+func buildIdentity(ctx *SMBHandlerContext, user *models.User) *metadata.Identity {
+	uid, gid := getUserIdentity(user)
+	identity := &metadata.Identity{
+		UID:      &uid,
+		GID:      &gid,
+		Username: user.Username,
+	}
+	// Supplementary group IDs: populate Identity.GIDs from every group the
+	// user belongs to so POSIX-mode permission checks (Identity.HasGID)
+	// honor secondary / nested-AD-group membership, not just the primary
+	// GID. Without this an AD user resolved over Kerberos — or any local
+	// user in multiple groups — was granted group access over NFS (which
+	// carries the full set) but denied over SMB. Mirrors the NFS GSS path
+	// (#1327).
+	if len(user.Groups) > 0 {
+		gids := make([]uint32, 0, len(user.Groups))
+		for _, group := range user.Groups {
+			if group.GID != nil {
+				gids = append(gids, *group.GID)
+			}
+		}
+		identity.GIDs = gids
+	}
+	if user.SID != "" {
+		userSID := user.SID
+		identity.SID = &userSID
+	}
+	// Merge the user's persisted named group SIDs with any Kerberos PAC
+	// group SIDs carried on this request's session. For an AD-issued ticket
+	// the PAC delivers the DC-resolved transitive group set, so a DACL ACE
+	// keyed on an AD group matches even when the local user model never
+	// enumerated it. slices.Concat allocates a fresh slice (no aliasing of
+	// user.GroupSIDs); mergeImplicitAuthSIDs then dedups (first occurrence wins).
+	identity.GroupSIDs = mergeImplicitAuthSIDs(
+		slices.Concat(user.GroupSIDs, ctx.PACGroupSIDs),
+	)
+	return identity
+}
+
+// cachedIdentity returns the session's memoized identity for user, or nil.
+func (ctx *SMBHandlerContext) cachedIdentity(user *models.User) *metadata.Identity {
+	if ctx.session == nil {
+		return nil
+	}
+	return ctx.session.CachedAuthIdentity(user)
+}
+
+// maybeCacheIdentity memoizes identity on the session only when user is the
+// session's current authenticated user. A handle-frozen opener snapshot (which may
+// differ after a re-auth) is never written back, so it can't poison the cache.
+func (ctx *SMBHandlerContext) maybeCacheIdentity(user *models.User, identity *metadata.Identity) {
+	if ctx.session != nil && user == ctx.session.User {
+		ctx.session.SetCachedAuthIdentity(user, identity)
+	}
 }
 
 // mergeImplicitAuthSIDs returns the union of an authenticated user's named
@@ -254,6 +295,9 @@ func (h *Handler) primeAuthContext(ctx *SMBHandlerContext, treeID uint32, sessio
 		ctx.Permission = tree.Permission
 	}
 	if sess, ok := h.GetSession(sessionID); ok && sess != nil {
+		// Hand the owning session to BuildAuthContextFromUser so it can reuse the
+		// session's memoized identity instead of re-deriving it per op.
+		ctx.session = sess
 		// Propagate guest-ness independent of User: guest sessions seed
 		// User=nil + IsGuest=true and BuildAuthContext relies on IsGuest
 		// to pick the nobody/nogroup (65534) arm instead of root.

--- a/internal/adapter/smb/handlers/auth_helper.go
+++ b/internal/adapter/smb/handlers/auth_helper.go
@@ -231,10 +231,12 @@ func (ctx *SMBHandlerContext) cachedIdentity(user *models.User) *metadata.Identi
 }
 
 // maybeCacheIdentity memoizes identity on the session only when user is the
-// session's current authenticated user. A handle-frozen opener snapshot (which may
-// differ after a re-auth) is never written back, so it can't poison the cache.
+// request's session-current user. ctx.User is primeAuthContext's snapshot of
+// Session.User taken for this request's lifetime, so comparing against it (not
+// Session.User, which other goroutines reassign on re-auth) is race-free and
+// still refuses to cache a handle-frozen opener snapshot.
 func (ctx *SMBHandlerContext) maybeCacheIdentity(user *models.User, identity *metadata.Identity) {
-	if ctx.session != nil && user == ctx.session.User {
+	if ctx.session != nil && user == ctx.User {
 		ctx.session.SetCachedAuthIdentity(user, identity)
 	}
 }

--- a/internal/adapter/smb/handlers/auth_helper_bench_test.go
+++ b/internal/adapter/smb/handlers/auth_helper_bench_test.go
@@ -1,0 +1,66 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/session"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+func benchAuthUser() *models.User {
+	gid := func(v uint32) *uint32 { return &v }
+	uid := uint32(1000)
+	return &models.User{
+		Username:  "alice",
+		UID:       &uid,
+		GID:       gid(1000),
+		SID:       "S-1-5-21-1-2-3-1001",
+		GroupSIDs: []string{"S-1-5-21-1-2-3-513", "S-1-5-21-1-2-3-514", "S-1-5-21-1-2-3-515"},
+		Groups: []models.Group{
+			{Name: "g1", GID: gid(1000)},
+			{Name: "g2", GID: gid(1001)},
+			{Name: "g3", GID: gid(1002)},
+			{Name: "g4", GID: gid(1003)},
+		},
+	}
+}
+
+func benchAuthCtx(user *models.User, sess *session.Session) *SMBHandlerContext {
+	return &SMBHandlerContext{
+		Context:      context.Background(),
+		ClientAddr:   "10.0.0.1:445",
+		SessionID:    1,
+		User:         user,
+		PACGroupSIDs: []string{"S-1-5-21-9-9-9-1", "S-1-5-21-9-9-9-2"},
+		Permission:   models.PermissionReadWrite,
+		session:      sess,
+	}
+}
+
+// BenchmarkBuildAuthContextFromUser_Uncached measures the per-op cost with no
+// session cache: the identity (UID/GID lookup, GID slice, group-SID concat +
+// dedup) is rebuilt on every call — the pre-C5 behaviour.
+func BenchmarkBuildAuthContextFromUser_Uncached(b *testing.B) {
+	user := benchAuthUser()
+	ctx := benchAuthCtx(user, nil) // nil session => never caches, always rebuilds
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = BuildAuthContextFromUser(ctx, user)
+	}
+}
+
+// BenchmarkBuildAuthContextFromUser_Cached measures the per-op cost once the
+// session has memoized the identity (the C5 fast path).
+func BenchmarkBuildAuthContextFromUser_Cached(b *testing.B) {
+	user := benchAuthUser()
+	sess := session.NewSessionWithUser(1, "10.0.0.1:445", user, "")
+	ctx := benchAuthCtx(user, sess)
+	_ = BuildAuthContextFromUser(ctx, user) // prime the cache
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = BuildAuthContextFromUser(ctx, user)
+	}
+}

--- a/internal/adapter/smb/handlers/auth_identity_cache_test.go
+++ b/internal/adapter/smb/handlers/auth_identity_cache_test.go
@@ -1,0 +1,101 @@
+package handlers
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/session"
+)
+
+// reprimePAC mirrors what primeAuthContext does: copy the session's current PAC
+// group SIDs onto the request context before building the auth context.
+func reprimePAC(ctx *SMBHandlerContext, sess *session.Session) {
+	ctx.PACGroupSIDs, _ = sess.PACIdentity()
+}
+
+func TestAuthIdentityCache_HitReturnsSamePointer(t *testing.T) {
+	user := benchAuthUser()
+	sess := session.NewSessionWithUser(1, "10.0.0.1:445", user, "")
+	ctx := benchAuthCtx(user, sess)
+	ctx.PACGroupSIDs = nil // no PAC; identity comes purely from the user
+
+	first := BuildAuthContextFromUser(ctx, user).Identity
+	second := BuildAuthContextFromUser(ctx, user).Identity
+	if first != second {
+		t.Fatalf("expected cache hit to reuse the same *Identity, got distinct pointers")
+	}
+}
+
+func TestAuthIdentityCache_OpenerSnapshotNotCached(t *testing.T) {
+	user := benchAuthUser()
+	sess := session.NewSessionWithUser(1, "10.0.0.1:445", user, "")
+	ctx := benchAuthCtx(user, sess)
+
+	// A handle-bound op passes a different (frozen opener) user than the
+	// session-current ctx.User. It must not hit or populate the session cache.
+	opener := benchAuthUser() // distinct pointer
+	a := BuildAuthContextFromUser(ctx, opener).Identity
+	b := BuildAuthContextFromUser(ctx, opener).Identity
+	if a == b {
+		t.Fatalf("opener snapshot must not be cached on the session")
+	}
+	// And the real session user must still cache normally.
+	c := BuildAuthContextFromUser(ctx, user).Identity
+	d := BuildAuthContextFromUser(ctx, user).Identity
+	if c != d {
+		t.Fatalf("session-current user should cache")
+	}
+}
+
+func TestAuthIdentityCache_InvalidatedOnPACRefresh(t *testing.T) {
+	user := benchAuthUser()
+	sess := session.NewSessionWithUser(1, "10.0.0.1:445", user, "")
+	sess.SetPACIdentity([]string{"S-1-5-21-OLD"}, user.SID)
+	ctx := benchAuthCtx(user, sess)
+	reprimePAC(ctx, sess)
+
+	before := BuildAuthContextFromUser(ctx, user).Identity
+	if !slices.Contains(before.GroupSIDs, "S-1-5-21-OLD") {
+		t.Fatalf("expected old PAC SID before refresh, got %v", before.GroupSIDs)
+	}
+
+	// Kerberos re-auth refreshes the PAC with a new transitive group set.
+	sess.SetPACIdentity([]string{"S-1-5-21-NEW"}, user.SID)
+	reprimePAC(ctx, sess)
+
+	after := BuildAuthContextFromUser(ctx, user).Identity
+	if after == before {
+		t.Fatalf("PAC refresh must invalidate the cached identity")
+	}
+	if slices.Contains(after.GroupSIDs, "S-1-5-21-OLD") {
+		t.Fatalf("stale group SID survived PAC refresh: %v", after.GroupSIDs)
+	}
+	if !slices.Contains(after.GroupSIDs, "S-1-5-21-NEW") {
+		t.Fatalf("expected refreshed PAC SID, got %v", after.GroupSIDs)
+	}
+}
+
+func TestAuthIdentityCache_InvalidatedOnPACClear(t *testing.T) {
+	user := benchAuthUser()
+	sess := session.NewSessionWithUser(1, "10.0.0.1:445", user, "")
+	sess.SetPACIdentity([]string{"S-1-5-21-OLD"}, user.SID)
+	ctx := benchAuthCtx(user, sess)
+	reprimePAC(ctx, sess)
+
+	before := BuildAuthContextFromUser(ctx, user).Identity
+	if !slices.Contains(before.GroupSIDs, "S-1-5-21-OLD") {
+		t.Fatalf("expected old PAC SID before clear, got %v", before.GroupSIDs)
+	}
+
+	// NTLM re-auth clears any Kerberos PAC carried from the prior auth.
+	sess.SetPACIdentity(nil, "")
+	reprimePAC(ctx, sess)
+
+	after := BuildAuthContextFromUser(ctx, user).Identity
+	if after == before {
+		t.Fatalf("PAC clear must invalidate the cached identity")
+	}
+	if slices.Contains(after.GroupSIDs, "S-1-5-21-OLD") {
+		t.Fatalf("stale group SID survived PAC clear: %v", after.GroupSIDs)
+	}
+}

--- a/internal/adapter/smb/handlers/context.go
+++ b/internal/adapter/smb/handlers/context.go
@@ -149,6 +149,13 @@ type SMBHandlerContext struct {
 	// This is set from the session during request handling.
 	User *models.User
 
+	// session is the *session.Session that owns this request, set by
+	// primeAuthContext. It backs the per-session AuthContext identity cache so
+	// BuildAuthContextFromUser can reuse a memoized identity instead of
+	// re-deriving it on every op. Nil on paths that do not prime (the build then
+	// falls back to constructing the identity fresh).
+	session *session.Session
+
 	// PACGroupSIDs carries the Kerberos PAC group SIDs of the request's
 	// session (when it authenticated via Kerberos against AD). Populated from
 	// Session.PACGroupSIDs by primeAuthContext and the Kerberos SESSION_SETUP

--- a/internal/adapter/smb/session/session.go
+++ b/internal/adapter/smb/session/session.go
@@ -46,6 +46,7 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/smb/signing"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
 // Session represents an SMB2 session with both identity and credit tracking.
@@ -90,6 +91,17 @@ type Session struct {
 	// SetPACIdentity / PACIdentity, which copy in and out.
 	pacGroupSIDs []string
 	pacUserSID   string
+
+	// authIdentity memoizes the *metadata.Identity derived from User + the PAC
+	// group SIDs above. That derivation (UID/GID lookup, supplementary-GID slice,
+	// group-SID concat + dedup) is fixed for the life of a session's identity, so
+	// rebuilding it on every READ/WRITE is pure waste. authIdentityUser records
+	// the exact *models.User it was built for: a re-authentication swaps
+	// Session.User for a fresh pointer, so the pointer guard makes a stale entry
+	// miss. SetPACIdentity additionally clears it whenever the PAC set changes.
+	// Guarded by mu (identity is only read, never mutated, by consumers).
+	authIdentity     *metadata.Identity
+	authIdentityUser *models.User
 
 	// cryptoState holds per-session cryptographic state (signing keys, signer,
 	// encryption/decryption keys). Replaces the old Signing field.
@@ -219,6 +231,35 @@ func (s *Session) SetPACIdentity(groupSIDs []string, userSID string) {
 		s.pacGroupSIDs = append([]string(nil), groupSIDs...)
 	}
 	s.pacUserSID = userSID
+	// The memoized identity folds in the PAC group SIDs, so any refresh (or the
+	// NTLM-reauth clear) must drop it. Both re-auth paths call SetPACIdentity, so
+	// this is the single chokepoint that keeps the cache from going stale.
+	s.authIdentity = nil
+	s.authIdentityUser = nil
+}
+
+// CachedAuthIdentity returns the memoized identity for user, or nil when none is
+// cached for that exact *models.User. The pointer guard is deliberate: a
+// re-authentication assigns Session.User a fresh pointer, so a request carrying
+// the old (or a handle-frozen opener) user misses and rebuilds. Safe for
+// concurrent use.
+func (s *Session) CachedAuthIdentity(user *models.User) *metadata.Identity {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.authIdentityUser == user {
+		return s.authIdentity
+	}
+	return nil
+}
+
+// SetCachedAuthIdentity memoizes identity as the built identity for user. Callers
+// must only pass the session's current User; a handle-frozen opener snapshot must
+// not be cached here. Safe for concurrent use.
+func (s *Session) SetCachedAuthIdentity(user *models.User, identity *metadata.Identity) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.authIdentityUser = user
+	s.authIdentity = identity
 }
 
 // PACIdentity returns a copy of the session's Kerberos PAC group SIDs and the


### PR DESCRIPTION
## Summary

`BuildAuthContextFromUser` re-allocated the `metadata.Identity` — UID/GID lookup, supplementary-GID slice, and a `slices.Concat` + dedup of the group SIDs — on **every** SMB read/write. That identity is fixed at SESSION_SETUP, so it was pure per-op waste.

This memoizes the built `*metadata.Identity` on the `Session` and reuses it. The only per-`(session,tree)` input is `ShareReadOnly` (a bool derived from `ctx.Permission`), which stays cheap and is recomputed per op along with the tiny `AuthContext` wrapper. Net effect matches the intent of mirroring the NFS `GetCachedAuthContext`, but keyed on SMB's natural long-lived object (the `Session`) rather than a Handler-side map — which also gives exact re-auth invalidation for free.

## Invalidation & correctness on re-auth

- **Single chokepoint:** both re-auth paths funnel through `Session.SetPACIdentity` (NTLM reauth clears with `(nil, "")`; Kerberos reauth refreshes from the new ticket). The cache is dropped there, so a PAC change can never serve a stale group-SID set.
- **Pointer guard:** the cache records the exact `*models.User` it was built for. A re-auth assigns `Session.User` a fresh pointer, so a request carrying the old user misses and rebuilds.
- **Handle-bound ops untouched:** `buildOpenerAuthContext` passes the frozen `OpenFile.OpenerUser`. After a re-auth that differs from `Session.User`, so it misses the pointer-guarded cache and rebuilds from the snapshot — and it's never written back, so it can't poison the session entry.
- **Immutability:** the cached identity is only ever read by permission checks (never mutated post-build — same invariant the NFS cache already relies on); it's shared as an immutable value. Guest/anonymous (`User==nil`) sessions never touch this path.
- Guarded by the session's existing `mu`; `go test -race ./internal/adapter/smb/...` (2024 tests) is green.

## Before/after micro-benchmark

`BuildAuthContextFromUser` (user with 4 groups + 3 named group SIDs + 2 PAC SIDs):

```
BuildAuthContextFromUser_Uncached-10   1560524   776.2 ns/op   576 B/op   9 allocs/op
BuildAuthContextFromUser_Cached-10     4138393   315.2 ns/op   229 B/op   3 allocs/op
```

~2.5x faster, 9 -> 3 allocs, 576 -> 229 B/op on the SMB read/write hot path.

Part of #1692