### PR TITLE
perf(runtime): cache per-share store resolution + decode handle once (Wall C2)

### DIFF
--- a/internal/adapter/smb/handlers/flush.go
+++ b/internal/adapter/smb/handlers/flush.go
@@ -211,7 +211,7 @@ func (h *Handler) Flush(ctx *SMBHandlerContext, req *FlushRequest) (*FlushRespon
 	// ========================================================================
 
 	metaSvc := h.Registry.GetMetadataService()
-	blockStore, err := h.Registry.GetBlockStoreForHandle(ctx.Context, openFile.MetadataHandle)
+	blockStore, err := h.Registry.GetBlockStoreForShare(openFile.ShareName)
 	if err != nil {
 		logger.Warn("FLUSH: block store not available for handle", "path", openFile.Path, "error", err)
 		return &FlushResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInternalError}}, nil

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -1876,7 +1876,7 @@ func (h *Handler) flushFileCache(ctx context.Context, openFile *OpenFile) {
 		return
 	}
 
-	blockStore, err := h.Registry.GetBlockStoreForHandle(ctx, openFile.MetadataHandle)
+	blockStore, err := h.Registry.GetBlockStoreForShare(openFile.ShareName)
 	if err != nil {
 		logger.Warn("flushFileCache: block store not available for handle",
 			"path", openFile.Path,

--- a/internal/adapter/smb/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk.go
@@ -360,7 +360,7 @@ func (h *Handler) executeCopyChunks(
 	metaSvc := h.Registry.GetMetadataService()
 
 	// Get source block store and file metadata
-	srcBlockStore, err := h.Registry.GetBlockStoreForHandle(ctx.Context, srcOpen.MetadataHandle)
+	srcBlockStore, err := h.Registry.GetBlockStoreForShare(srcOpen.ShareName)
 	if err != nil {
 		logger.Warn("COPYCHUNK: source block store unavailable", "path", srcOpen.Path, "error", err)
 		return NewErrorResult(types.StatusInternalError), nil
@@ -373,7 +373,7 @@ func (h *Handler) executeCopyChunks(
 	}
 
 	// Get destination block store
-	dstBlockStore, err := h.Registry.GetBlockStoreForHandle(ctx.Context, dstOpen.MetadataHandle)
+	dstBlockStore, err := h.Registry.GetBlockStoreForShare(dstOpen.ShareName)
 	if err != nil {
 		logger.Warn("COPYCHUNK: destination block store unavailable", "path", dstOpen.Path, "error", err)
 		return NewErrorResult(types.StatusInternalError), nil

--- a/internal/adapter/smb/handlers/runtime_iface.go
+++ b/internal/adapter/smb/handlers/runtime_iface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/pkg/block/engine"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
@@ -21,6 +22,10 @@ type smbRuntime interface {
 	// Per-share block-store resolution (used via common.ResolveFor* and
 	// directly for FLUSH / copychunk / scavenger paths).
 	common.BlockStoreRegistry
+
+	// GetBlockStoreForShare resolves the store by share name, skipping the
+	// handle decode when a handler already holds OpenFile.ShareName.
+	GetBlockStoreForShare(name string) (*engine.Store, error)
 
 	// Metadata service access.
 	GetMetadataService() *metadata.Service

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -704,6 +704,14 @@ func (r *Runtime) GetBlockStoreForHandle(ctx context.Context, handle metadata.Fi
 	return r.sharesSvc.GetBlockStoreForHandle(ctx, handle)
 }
 
+// GetBlockStoreForShare resolves the per-share BlockStore by name, skipping the
+// handle decode when the caller already knows the share (e.g. SMB handlers that
+// carry OpenFile.ShareName). Backed by the same lock-free cache as
+// GetBlockStoreForHandle.
+func (r *Runtime) GetBlockStoreForShare(name string) (*engine.Store, error) {
+	return r.sharesSvc.GetBlockStoreForShare(name)
+}
+
 // --- Lifecycle (delegated to lifecycle.Service) ---
 
 func (r *Runtime) SetAPIServer(server AuxiliaryServer) {

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -496,6 +496,16 @@ type Service struct {
 	// share). Self-guarded; runs warm runs on detached contexts cancelled on
 	// RemoveShare. See warm.go.
 	warmJobs *warmRegistry
+
+	// blockStoreCache is a lock-free mirror of registry[name].BlockStore keyed by
+	// share name. Every NFS/SMB data op resolves the per-share store here without
+	// touching s.mu, so the read/write hot path pays no reader-lock contention.
+	// It is written only under s.mu at the three points that change a share's
+	// store — AddShare (publish), RemoveShare (delete), RebindShareBlockStore
+	// (swap) — so it never lags the registry at a lock-release boundary. A miss
+	// falls through to the locked registry, which reproduces the exact
+	// not-found/no-store errors, so the cache holds only non-nil stores.
+	blockStoreCache sync.Map // shareName -> *engine.Store
 }
 
 func New() *Service {
@@ -695,6 +705,9 @@ func (s *Service) AddShare(
 		return fmt.Errorf("share %q already exists", config.Name)
 	}
 	s.registry[config.Name] = share
+	if share.BlockStore != nil {
+		s.blockStoreCache.Store(config.Name, share.BlockStore)
+	}
 	delete(s.reservations, config.Name)
 	reservationHeld = false
 	s.mu.Unlock()
@@ -1211,6 +1224,7 @@ func (s *Service) RebindShareBlockStore(
 		share.remoteConfigID = recovered.remoteConfigID
 		share.gcStateRoot = recovered.gcStateRoot
 		share.localStoreDir = recovered.localStoreDir
+		s.blockStoreCache.Store(name, share.BlockStore)
 		s.mu.Unlock()
 		if oldRemoteConfigID != "" {
 			s.releaseRemoteStore(oldRemoteConfigID)
@@ -1242,6 +1256,7 @@ func (s *Service) RebindShareBlockStore(
 	share.remoteConfigID = rebuilt.remoteConfigID
 	share.gcStateRoot = rebuilt.gcStateRoot
 	share.localStoreDir = rebuilt.localStoreDir
+	s.blockStoreCache.Store(name, share.BlockStore)
 	s.mu.Unlock()
 
 	// Drop the previous remote ref now that the new store holds its own.
@@ -1457,6 +1472,7 @@ func (s *Service) RemoveShare(name string) error {
 	remoteConfigID := share.remoteConfigID
 	localStoreDir := share.localStoreDir
 	delete(s.registry, name)
+	s.blockStoreCache.Delete(name)
 	s.mu.Unlock()
 
 	// Cancel any in-flight warm job for this share so it cannot keep fetching
@@ -2175,25 +2191,15 @@ func (s *Service) CountShares() int {
 }
 
 // GetBlockStoreForHandle decodes a file handle and resolves the per-share
-// BlockStore in a single mutex acquisition, avoiding the two-RLock overhead of
-// calling GetShareNameForHandle followed by GetBlockStoreForShare separately.
-func (s *Service) GetBlockStoreForHandle(ctx context.Context, handle metadata.FileHandle) (*engine.Store, error) {
+// BlockStore. The handle is decoded once for its share name, then the store is
+// read from the lock-free blockStoreCache — the read/write hot path never
+// touches s.mu.
+func (s *Service) GetBlockStoreForHandle(_ context.Context, handle metadata.FileHandle) (*engine.Store, error) {
 	shareName, _, err := metadata.DecodeFileHandle(handle)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode file handle: %w", err)
 	}
-
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	share, exists := s.registry[shareName]
-	if !exists {
-		return nil, fmt.Errorf("share %q not found", shareName)
-	}
-	if share.BlockStore == nil {
-		return nil, fmt.Errorf("share %q has no block store configured", shareName)
-	}
-	return share.BlockStore, nil
+	return s.GetBlockStoreForShare(shareName)
 }
 
 // XattrStreamReader returns a metadata.StreamContentReader that materialises a
@@ -2227,8 +2233,17 @@ func (s *Service) XattrStreamReader() metadata.StreamContentReader {
 	}
 }
 
-// GetBlockStoreForShare returns the BlockStore for a named share.
+// GetBlockStoreForShare returns the BlockStore for a named share. The common
+// case is served from the lock-free blockStoreCache; a miss falls through to
+// the locked registry, which produces the exact not-found / no-store errors.
+// Because the cache is written under s.mu alongside the registry, a miss after
+// RemoveShare always resolves to a not-found error — never a stale or closed
+// store.
 func (s *Service) GetBlockStoreForShare(name string) (*engine.Store, error) {
+	if v, ok := s.blockStoreCache.Load(name); ok {
+		return v.(*engine.Store), nil
+	}
+
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	share, exists := s.registry[name]

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -2241,7 +2241,9 @@ func (s *Service) XattrStreamReader() metadata.StreamContentReader {
 // store.
 func (s *Service) GetBlockStoreForShare(name string) (*engine.Store, error) {
 	if v, ok := s.blockStoreCache.Load(name); ok {
-		return v.(*engine.Store), nil
+		if bs, ok := v.(*engine.Store); ok {
+			return bs, nil
+		}
 	}
 
 	s.mu.RLock()

--- a/pkg/controlplane/runtime/shares/store_resolution_bench_test.go
+++ b/pkg/controlplane/runtime/shares/store_resolution_bench_test.go
@@ -1,0 +1,71 @@
+package shares
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block/engine"
+)
+
+// These benchmarks measure the per-op cost of resolving a share's block store,
+// the path every NFS/SMB read/write takes. "before" is the old RWMutex+map
+// lookup; "after" is the lock-free sync.Map fast path that GetBlockStoreForShare
+// now uses. Run with -cpu to see the contention delta under concurrency:
+//
+//	go test -run x -bench BenchmarkResolveBlockStore -cpu 1,8,32 ./pkg/controlplane/runtime/shares/
+func benchService(shares int) (*Service, []string) {
+	s := New()
+	names := make([]string, shares)
+	for i := range names {
+		name := fmt.Sprintf("share-%d", i)
+		names[i] = name
+		// Sentinel store: resolution never dereferences it.
+		bs := &engine.Store{}
+		s.registry[name] = &Share{Name: name, BlockStore: bs}
+		s.blockStoreCache.Store(name, bs)
+	}
+	return s, names
+}
+
+// resolveLocked replicates the pre-cache implementation so the benchmark shows a
+// true before/after on the same data structure.
+func (s *Service) resolveLocked(name string) (*engine.Store, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	share, ok := s.registry[name]
+	if !ok {
+		return nil, fmt.Errorf("share %q not found", name)
+	}
+	if share.BlockStore == nil {
+		return nil, fmt.Errorf("share %q has no block store configured", name)
+	}
+	return share.BlockStore, nil
+}
+
+func BenchmarkResolveBlockStore_Before_RWMutex(b *testing.B) {
+	s, names := benchService(16)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			if _, err := s.resolveLocked(names[i%len(names)]); err != nil {
+				b.Fatal(err)
+			}
+			i++
+		}
+	})
+}
+
+func BenchmarkResolveBlockStore_After_SyncMap(b *testing.B) {
+	s, names := benchService(16)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			if _, err := s.GetBlockStoreForShare(names[i%len(names)]); err != nil {
+				b.Fatal(err)
+			}
+			i++
+		}
+	})
+}

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -39,6 +39,7 @@ const DefaultLockGracePeriod = 90 * time.Second
 type Service struct {
 	mu                 sync.RWMutex
 	stores             map[string]Store                  // shareName -> store
+	storeCache         sync.Map                          // shareName -> Store; lock-free mirror of stores, read on every metadata op
 	lockManagers       map[string]*LockManager           // shareName -> lock manager (ephemeral, per-share)
 	unifiedViews       map[string]*UnifiedLockView       // shareName -> unified lock view (cross-protocol)
 	dirChangeNotifiers map[string]lock.DirChangeNotifier // shareName -> notifier for directory changes
@@ -292,6 +293,7 @@ func (s *Service) RegisterStoreForShare(shareName string, store Store) error {
 		// This is atomic and visible under the lock we already hold. The lock
 		// manager is ephemeral and intentionally not replaced.
 		s.stores[shareName] = store
+		s.storeCache.Store(shareName, store)
 		s.mu.Unlock()
 		return nil
 	}
@@ -409,6 +411,7 @@ func (s *Service) RegisterStoreForShare(shareName string, store Store) error {
 	// lockManagerForHandle / storeForHandle that arrives during recovery sees
 	// neither and consistently reports the share as not-yet-ready.
 	s.stores[shareName] = store
+	s.storeCache.Store(shareName, store)
 	s.lockManagers[shareName] = lm
 	// Wire LockManager as DirChangeNotifier: mutations on this share will
 	// dispatch directory lease breaks via the lock manager.
@@ -464,6 +467,7 @@ func (s *Service) RemoveStoreForShare(shareName string) {
 	}
 
 	delete(s.stores, shareName)
+	s.storeCache.Delete(shareName)
 	delete(s.lockManagers, shareName)
 	delete(s.unifiedViews, shareName)
 	delete(s.dirChangeNotifiers, shareName)
@@ -616,10 +620,16 @@ func (s *Service) newGraceAwareLockManager(duration time.Duration) *LockManager 
 	return lm
 }
 
-// GetStoreForShare returns the metadata store for a specific share.
-// This is primarily for internal use and testing; protocol handlers
-// should use the high-level methods instead.
+// GetStoreForShare returns the metadata store for a specific share. Every
+// metadata op resolves through here, so the common case is served from the
+// lock-free storeCache without touching s.mu. The cache is written under s.mu
+// alongside s.stores, so a miss after RemoveStoreForShare falls through to the
+// locked map and yields the stale-handle error below — never a stale store.
 func (s *Service) GetStoreForShare(shareName string) (Store, error) {
+	if v, ok := s.storeCache.Load(shareName); ok {
+		return v.(Store), nil
+	}
+
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -627,7 +627,9 @@ func (s *Service) newGraceAwareLockManager(duration time.Duration) *LockManager 
 // locked map and yields the stale-handle error below — never a stale store.
 func (s *Service) GetStoreForShare(shareName string) (Store, error) {
 	if v, ok := s.storeCache.Load(shareName); ok {
-		return v.(Store), nil
+		if store, ok := v.(Store); ok {
+			return store, nil
+		}
 	}
 
 	s.mu.RLock()


### PR DESCRIPTION
## Summary

Every NFS/SMB read/write resolved its per-share **block store** (`GetBlockStoreForHandle`) and **metadata store** (`GetStoreForShare`) under an RWMutex read lock, and decoded the opaque file handle 3–4× per op. Under concurrency the reader-count atomic RMW on the shared mutex cache line is the dominant orchestration tax (Wall C2).

This adds a lock-free `sync.Map` mirror of the per-share store to both `shares.Service` (block) and `metadata.Service` (metadata). Resolution now serves the common case with no `s.mu` acquisition. SMB handlers that already hold `OpenFile.ShareName` resolve via a new `GetBlockStoreForShare(name)`, skipping the redundant handle decode.

The per-share `*engine.Store` is immutable between the lifecycle mutations, so the cache is a strict mirror — not a TTL cache.

## Invalidation / correctness (no stale store after RemoveShare)

The cache is written **only under the same lock that mutates the source map**, at every point a share's store changes:

- **block** (`shares.Service`, under `s.mu`): `AddShare` (publish), `RemoveShare` (delete), `RebindShareBlockStore` (both recovery + rebuilt swaps).
- **metadata** (`metadata.Service`, under `s.mu`): `RegisterStoreForShare` (both the store-replace fast path and the post-recovery publish — placed **after** the `removedMidFlight` abort so a share removed mid-recovery is never resurrected into the cache) and `RemoveStoreForShare` (delete).

Because cache-write and map-write happen inside the same `Lock`/`Unlock`, the cache never lags the source at a lock-release boundary. A lookup **miss** falls through to the locked map and reproduces the exact original errors (`share %q not found` / stale-handle). Therefore after `RemoveShare`/`RemoveStoreForShare` a lookup always resolves to a not-found error — **never a stale or closed `*engine.Store`**. `RemoveShare` also `Close()`s the block store drain-safely (blocks on in-flight ops), and the cache is deleted before that. No raw pointer is stashed on `OpenFile` (which would outlive removal and hit a closed store); SMB re-resolves each op via the lock-free cache using the frozen `ShareName`, giving the same speed without the stale-pointer hazard.

Handle opacity (invariant #3) is preserved — handlers still never parse handles; only the *result* of resolution is cached.

## Before/after micro-benchmark

Resolution path, `RunParallel` (new `store_resolution_bench_test.go`):

| goroutines | before (RWMutex+map) | after (sync.Map) |
|---|---|---|
| 8  | ~84 ns/op  | ~10 ns/op |
| 16 | ~110 ns/op | ~16 ns/op |

~7–8× on the contended path. (Single-threaded, sync.Map is marginally slower — irrelevant for a concurrent server; the win is decontention.)

## Verification

- `gofmt -s`, `go vet`, `golangci-lint` clean on touched packages
- `go build ./...`
- `go test -race ./pkg/controlplane/runtime/... ./pkg/metadata/` → 1046 passed
- `go test ./internal/adapter/smb/handlers/` → 1382 passed

Part of #1692