### PR TITLE
test(nfs/v4): de-flake TestLeaseExpiry_MultipleClients

### DIFF
--- a/internal/adapter/nfs/v4/state/delegation_test.go
+++ b/internal/adapter/nfs/v4/state/delegation_test.go
@@ -299,8 +299,12 @@ func TestLeaseExpiry_MultipleClients(t *testing.T) {
 	// Renew B once more right before asserting so its lease is fresh at check
 	// time. Without this, a slow runner's sleeps can push the gap since B's last
 	// renewal past the lease and let the timer expire B — the "B stays alive"
-	// intent shouldn't hinge on sub-lease sleep precision.
-	_ = sm.RenewLease(resultB.ClientID)
+	// intent shouldn't hinge on sub-lease sleep precision. A renewal error here
+	// means B was already reaped, which is the exact failure this test guards
+	// against — surface it directly rather than as a downstream "got 0".
+	if err := sm.RenewLease(resultB.ClientID); err != nil {
+		t.Fatalf("client B unexpectedly expired before assertion: %v", err)
+	}
 
 	// Client B's delegation should still exist
 	delegsB := sm.GetDelegationsForFile(fhB)

--- a/internal/adapter/nfs/v4/state/delegation_test.go
+++ b/internal/adapter/nfs/v4/state/delegation_test.go
@@ -246,7 +246,10 @@ func TestLeaseExpiry_CleansDelegations(t *testing.T) {
 }
 
 func TestLeaseExpiry_MultipleClients(t *testing.T) {
-	sm := NewStateManager(100 * time.Millisecond)
+	// 200ms lease so the 30ms renewal cadence below keeps a wide margin: on a
+	// loaded CI runner the sleeps overshoot, and a lease too close to the renewal
+	// interval lets B's timer fire mid-loop and flake the test.
+	sm := NewStateManager(200 * time.Millisecond)
 
 	verifier := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
 	callback := CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "10.0.0.1.8.1"}
@@ -292,6 +295,12 @@ func TestLeaseExpiry_MultipleClients(t *testing.T) {
 	if len(delegsA) != 0 {
 		t.Errorf("client A's delegation should be removed after expiry, got %d", len(delegsA))
 	}
+
+	// Renew B once more right before asserting so its lease is fresh at check
+	// time. Without this, a slow runner's sleeps can push the gap since B's last
+	// renewal past the lease and let the timer expire B — the "B stays alive"
+	// intent shouldn't hinge on sub-lease sleep precision.
+	_ = sm.RenewLease(resultB.ClientID)
 
 	// Client B's delegation should still exist
 	delegsB := sm.GetDelegationsForFile(fhB)


### PR DESCRIPTION
`TestLeaseExpiry_MultipleClients` kept client B alive with 30ms renewals against a 100ms lease, then asserted after a 50ms sleep. On a loaded CI runner (seen red on Windows Build & Test) the sleeps overshoot, pushing the gap since B's last renewal past the lease so B's `time.AfterFunc` timer expires it and removes its delegation — a flaky failure unrelated to any product change.

Fix: widen the lease to 200ms so the 30ms renewal cadence keeps a wide margin, and renew B once more immediately before the assertion so the check no longer races real-clock sleep precision.

Verified: 200x `-race` clean, plus 100x under 8-way CPU load clean.