### PR TITLE
fix(nfs): TTL + user/group-change invalidation for the auth-context cache (Wall C6)

### DIFF
--- a/internal/adapter/nfs/v3/handlers/auth_cache_ttl_test.go
+++ b/internal/adapter/nfs/v3/handlers/auth_cache_ttl_test.go
@@ -20,39 +20,39 @@ func TestAuthCacheDefaultTTL(t *testing.T) {
 // TestAuthCacheTTLExpiry verifies a cached entry is served while fresh and
 // treated as a miss once its TTL has elapsed, so an out-of-band UID/group
 // change can't stay effective past the TTL even without an invalidation event.
+// Expiry is forced by backdating cachedAt (no sleep) so the test is
+// deterministic under load.
 func TestAuthCacheTTLExpiry(t *testing.T) {
 	const key = "/export:1:1000:1000"
-	h := &Handler{authCacheTTL: 20 * time.Millisecond}
+	h := &Handler{authCacheTTL: time.Minute}
 
 	h.authCache.Store(key, &authCacheEntry{
 		authCtx:  &metadata.AuthContext{AuthMethod: "unix"},
 		cachedAt: time.Now(),
 	})
-
 	if got := h.loadLiveAuthCtx(key); got == nil {
 		t.Fatal("fresh entry should be served from cache")
 	}
 
-	time.Sleep(30 * time.Millisecond)
-
+	// Backdate past the TTL: the entry must now be treated as a miss.
+	h.authCache.Store(key, &authCacheEntry{
+		authCtx:  &metadata.AuthContext{AuthMethod: "unix"},
+		cachedAt: time.Now().Add(-2 * time.Minute),
+	})
 	if got := h.loadLiveAuthCtx(key); got != nil {
 		t.Fatal("entry past its TTL should be treated as a miss")
 	}
-
-	// A backdated entry is expired regardless of sleep timing.
-	h.authCache.Store(key, &authCacheEntry{
-		authCtx:  &metadata.AuthContext{AuthMethod: "unix"},
-		cachedAt: time.Now().Add(-time.Hour),
-	})
-	if got := h.loadLiveAuthCtx(key); got != nil {
-		t.Fatal("backdated entry should be expired")
+	// And the expired entry must have been evicted, not left in the map.
+	if _, ok := h.authCache.Load(key); ok {
+		t.Fatal("expired entry should be deleted from the cache")
 	}
 }
 
-// TestAuthCacheClearOnIdentityChange verifies the effect of the
-// OnIdentityMappingChange hook wired in the NFS adapter: ClearAuthCache drops a
-// still-fresh entry so a user/group-membership edit takes effect immediately.
-func TestAuthCacheClearOnIdentityChange(t *testing.T) {
+// TestClearAuthCacheDropsLiveEntry verifies ClearAuthCache drops a still-fresh
+// entry. This is the effect the adapter's OnIdentityMappingChange callback
+// relies on so a user/group-membership edit takes effect immediately; the
+// adapter wiring itself is not exercised here.
+func TestClearAuthCacheDropsLiveEntry(t *testing.T) {
 	const key = "/export:1:1000:1000"
 	h := &Handler{} // default (long) TTL — entry would otherwise stay live
 
@@ -61,13 +61,12 @@ func TestAuthCacheClearOnIdentityChange(t *testing.T) {
 		cachedAt: time.Now(),
 	})
 	if got := h.loadLiveAuthCtx(key); got == nil {
-		t.Fatal("entry should be live before the identity-change event")
+		t.Fatal("entry should be live before ClearAuthCache")
 	}
 
-	// This is what the OnIdentityMappingChange callback invokes.
 	h.ClearAuthCache()
 
 	if got := h.loadLiveAuthCtx(key); got != nil {
-		t.Fatal("identity-change invalidation should drop the cached entry")
+		t.Fatal("ClearAuthCache should drop the cached entry")
 	}
 }

--- a/internal/adapter/nfs/v3/handlers/auth_cache_ttl_test.go
+++ b/internal/adapter/nfs/v3/handlers/auth_cache_ttl_test.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/identity"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// TestAuthCacheDefaultTTL confirms an unset TTL falls back to the pkg/identity
+// positive cache TTL so the NFS auth cache and identity cache age out together.
+func TestAuthCacheDefaultTTL(t *testing.T) {
+	h := &Handler{}
+	if got := h.authCacheEntryTTL(); got != identity.DefaultCacheTTL {
+		t.Fatalf("default auth-cache TTL = %v, want %v (aligned with identity cache)", got, identity.DefaultCacheTTL)
+	}
+}
+
+// TestAuthCacheTTLExpiry verifies a cached entry is served while fresh and
+// treated as a miss once its TTL has elapsed, so an out-of-band UID/group
+// change can't stay effective past the TTL even without an invalidation event.
+func TestAuthCacheTTLExpiry(t *testing.T) {
+	const key = "/export:1:1000:1000"
+	h := &Handler{authCacheTTL: 20 * time.Millisecond}
+
+	h.authCache.Store(key, &authCacheEntry{
+		authCtx:  &metadata.AuthContext{AuthMethod: "unix"},
+		cachedAt: time.Now(),
+	})
+
+	if got := h.loadLiveAuthCtx(key); got == nil {
+		t.Fatal("fresh entry should be served from cache")
+	}
+
+	time.Sleep(30 * time.Millisecond)
+
+	if got := h.loadLiveAuthCtx(key); got != nil {
+		t.Fatal("entry past its TTL should be treated as a miss")
+	}
+
+	// A backdated entry is expired regardless of sleep timing.
+	h.authCache.Store(key, &authCacheEntry{
+		authCtx:  &metadata.AuthContext{AuthMethod: "unix"},
+		cachedAt: time.Now().Add(-time.Hour),
+	})
+	if got := h.loadLiveAuthCtx(key); got != nil {
+		t.Fatal("backdated entry should be expired")
+	}
+}
+
+// TestAuthCacheClearOnIdentityChange verifies the effect of the
+// OnIdentityMappingChange hook wired in the NFS adapter: ClearAuthCache drops a
+// still-fresh entry so a user/group-membership edit takes effect immediately.
+func TestAuthCacheClearOnIdentityChange(t *testing.T) {
+	const key = "/export:1:1000:1000"
+	h := &Handler{} // default (long) TTL — entry would otherwise stay live
+
+	h.authCache.Store(key, &authCacheEntry{
+		authCtx:  &metadata.AuthContext{AuthMethod: "unix"},
+		cachedAt: time.Now(),
+	})
+	if got := h.loadLiveAuthCtx(key); got == nil {
+		t.Fatal("entry should be live before the identity-change event")
+	}
+
+	// This is what the OnIdentityMappingChange callback invokes.
+	h.ClearAuthCache()
+
+	if got := h.loadLiveAuthCtx(key); got != nil {
+		t.Fatal("identity-change invalidation should drop the cached entry")
+	}
+}

--- a/internal/adapter/nfs/v3/handlers/doc.go
+++ b/internal/adapter/nfs/v3/handlers/doc.go
@@ -5,11 +5,13 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr"
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/adapter"
+	"github.com/marmos91/dittofs/pkg/identity"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -23,8 +25,21 @@ type Handler struct {
 
 	// authCache caches auth contexts per (share, UID, GID) to avoid
 	// repeated registry lookups on every WRITE request.
-	// Key: "share:uid:gid", Value: *metadata.AuthContext
+	// Key: "share:uid:gid", Value: *authCacheEntry
 	authCache sync.Map
+
+	// authCacheTTL bounds how long a cached auth context is served before it
+	// is rebuilt. It caps how long an out-of-band UID/group-membership change
+	// can stay effective when no invalidation event fires. A zero value means
+	// identity.DefaultCacheTTL (aligned with the pkg/identity positive cache).
+	authCacheTTL time.Duration
+}
+
+// authCacheEntry is a cached auth context plus the time it was built, so
+// GetCachedAuthContext can expire it once authCacheTTL has elapsed.
+type authCacheEntry struct {
+	authCtx  *metadata.AuthContext
+	cachedAt time.Time
 }
 
 // authCacheKey generates a cache key for auth context caching.
@@ -62,6 +77,31 @@ func appendUint(b *strings.Builder, n uint64) {
 	b.WriteString(strconv.FormatUint(n, 10))
 }
 
+// authCacheEntryTTL returns the configured cache TTL, defaulting to the
+// pkg/identity positive cache TTL so a stale entry can't outlive an identity
+// change indefinitely.
+func (h *Handler) authCacheEntryTTL() time.Duration {
+	if h.authCacheTTL > 0 {
+		return h.authCacheTTL
+	}
+	return identity.DefaultCacheTTL
+}
+
+// loadLiveAuthCtx returns the cached auth context for key when present and
+// not past authCacheEntryTTL, otherwise nil (miss or expired). Splitting the
+// TTL check out keeps it unit-testable without a registry.
+func (h *Handler) loadLiveAuthCtx(key string) *metadata.AuthContext {
+	cached, ok := h.authCache.Load(key)
+	if !ok {
+		return nil
+	}
+	entry := cached.(*authCacheEntry)
+	if time.Since(entry.cachedAt) >= h.authCacheEntryTTL() {
+		return nil
+	}
+	return entry.authCtx
+}
+
 // GetCachedAuthContext returns a cached auth context or builds a new one.
 // This avoids repeated BuildAuthContextWithMapping calls for the same client.
 func (h *Handler) GetCachedAuthContext(
@@ -69,10 +109,9 @@ func (h *Handler) GetCachedAuthContext(
 ) (*metadata.AuthContext, error) {
 	key := authCacheKey(ctx)
 
-	// Fast path: check cache
-	if cached, ok := h.authCache.Load(key); ok {
-		authCtx := cached.(*metadata.AuthContext)
-		// Return a copy with the current request's context
+	// Fast path: serve a live (non-expired) cache entry, returning a copy with
+	// the current request's context.
+	if authCtx := h.loadLiveAuthCtx(key); authCtx != nil {
 		return &metadata.AuthContext{
 			Context:       ctx.Context,
 			ClientAddr:    ctx.ClientAddr,
@@ -92,20 +131,25 @@ func (h *Handler) GetCachedAuthContext(
 	// pin the first request's Context (and any values/cancellation attached to
 	// it) and ClientAddr for the lifetime of the entry; the hit path always
 	// re-derives those from the current request anyway.
-	h.authCache.Store(key, &metadata.AuthContext{
-		AuthMethod:    authCtx.AuthMethod,
-		Identity:      authCtx.Identity,
-		ShareReadOnly: authCtx.ShareReadOnly,
+	h.authCache.Store(key, &authCacheEntry{
+		authCtx: &metadata.AuthContext{
+			AuthMethod:    authCtx.AuthMethod,
+			Identity:      authCtx.Identity,
+			ShareReadOnly: authCtx.ShareReadOnly,
+		},
+		cachedAt: time.Now(),
 	})
 
 	return authCtx, nil
 }
 
 // ClearAuthCache drops all cached auth contexts. Called when share permission
-// state changes (grants, default-permission, squash) so active clients pick up
-// the new policy without a server restart. Config changes are rare admin
-// operations, so clearing the whole (small) cache is preferred over fragile
-// per-share key-prefix matching; entries repopulate on the next op.
+// state changes (grants, default-permission, squash) or when a user/group
+// identity mapping changes, so active clients pick up the new policy without a
+// server restart. These are rare admin operations, so clearing the whole
+// (small) cache is preferred over fragile per-key matching; entries repopulate
+// on the next op. The TTL in GetCachedAuthContext is the backstop for changes
+// that arrive without an explicit invalidation event.
 func (h *Handler) ClearAuthCache() {
 	h.authCache.Range(func(key, _ any) bool {
 		h.authCache.Delete(key)

--- a/internal/adapter/nfs/v3/handlers/doc.go
+++ b/internal/adapter/nfs/v3/handlers/doc.go
@@ -23,9 +23,9 @@ type Handler struct {
 	// Exported to allow injection by the NFS adapter
 	Registry nfsRuntime
 
-	// authCache caches auth contexts per (share, UID, GID) to avoid
-	// repeated registry lookups on every WRITE request.
-	// Key: "share:uid:gid", Value: *authCacheEntry
+	// authCache caches auth contexts to avoid rebuilding them on every op.
+	// Key: authCacheKey(ctx) — "share:authflavor:uid:gid[:gid...]" covering the
+	// full credential set (see authCacheKey). Value: *authCacheEntry.
 	authCache sync.Map
 
 	// authCacheTTL bounds how long a cached auth context is served before it
@@ -95,8 +95,11 @@ func (h *Handler) loadLiveAuthCtx(key string) *metadata.AuthContext {
 	if !ok {
 		return nil
 	}
-	entry := cached.(*authCacheEntry)
-	if time.Since(entry.cachedAt) >= h.authCacheEntryTTL() {
+	entry, ok := cached.(*authCacheEntry)
+	if !ok || time.Since(entry.cachedAt) >= h.authCacheEntryTTL() {
+		// Expired or an unexpected value type: drop it so the slow path
+		// rebuilds a fresh entry instead of re-checking a dead one each op.
+		h.authCache.Delete(key)
 		return nil
 	}
 	return entry.authCtx

--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -615,6 +615,15 @@ func (s *NFSAdapter) SetRuntime(rtAny any) {
 	})
 	s.shareUnsubscribers = append(s.shareUnsubscribers, unsubAuthInvalidate)
 
+	// Drop cached v3 auth contexts when a user/group identity mapping changes
+	// (a UID or group-membership edit alters who a credential resolves to) so
+	// the change takes effect immediately instead of lingering until the entry
+	// TTL expires or the server restarts.
+	unsubIdentityChange := rt.OnIdentityMappingChange(func() {
+		s.nfsHandler.ClearAuthCache()
+	})
+	s.shareUnsubscribers = append(s.shareUnsubscribers, unsubIdentityChange)
+
 	// Create blocking queue for NLM lock operations
 	s.blockingQueue = blocking.NewBlockingQueue(nlm_handlers.DefaultBlockingQueueSize)
 


### PR DESCRIPTION
## Correctness gap closed

The NFSv3 auth-context cache (`GetCachedAuthContext`) had **no TTL** and was invalidated only on share-permission events. A UID change or group-membership edit therefore stayed effective until the server restarted — a correctness gap, not just a perf detail.

## Change

- **~5 min TTL** on each cache entry, aligned with `pkg/identity.DefaultCacheTTL` (the identity resolver's positive cache TTL). A zero value falls back to that default; the TTL is the backstop so a stale entry can't outlive an identity change indefinitely.
- **Immediate invalidation hook**: the handler's `ClearAuthCache` is now subscribed to `rt.OnIdentityMappingChange` — the existing user/group identity-mapping change event that the NLM/SMB adapters already use to invalidate their identity resolver caches. This mirrors how share-perm events already invalidate the cache via `OnAuthCacheInvalidate`. No new subsystem.

Reuses the existing invalidation plumbing; the hit path adds one `time.Since` check, same allocs.

## Tests / bench

- New unit tests: default-TTL alignment, TTL expiry (fresh served, expired treated as miss), and clear-on-identity-change.
- Existing `BenchmarkBuildAuthContext_Cached` (cached-hit path): before ~423 ns/op median, after ~434 ns/op median (within noise), identical 184 B/op / 7 allocs — perf-neutral.

`gofmt -s`, `go vet`, `golangci-lint`, `go build ./...`, `go test -race ./internal/adapter/nfs/... ./pkg/identity/...` all green.

Part of #1692