### PR TITLE
perf(adapters): hot-path micro-locks and per-op alloc cleanup (Wall C7)

### DIFF
--- a/internal/adapter/nfs/v3/handlers/access.go
+++ b/internal/adapter/nfs/v3/handlers/access.go
@@ -80,7 +80,7 @@ func (h *Handler) Access(
 	}
 
 	// Extract client IP for logging
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
 	logger.InfoCtx(ctx.Context, "ACCESS",
 		"handle", fmt.Sprintf("%x", req.Handle),

--- a/internal/adapter/nfs/v3/handlers/commit.go
+++ b/internal/adapter/nfs/v3/handlers/commit.go
@@ -84,7 +84,7 @@ func (h *Handler) Commit(
 	req *CommitRequest,
 ) (*CommitResponse, error) {
 	// Extract client IP for logging
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
 	logger.InfoCtx(ctx.Context, "COMMIT", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP, "auth", ctx.AuthFlavor)
 

--- a/internal/adapter/nfs/v3/handlers/create.go
+++ b/internal/adapter/nfs/v3/handlers/create.go
@@ -90,7 +90,7 @@ func (h *Handler) Create(
 	}
 
 	// Extract client IP for logging
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
 	logger.InfoCtx(ctx.Context, "CREATE", "file", req.Filename, "dir", fmt.Sprintf("0x%x", req.DirHandle), "mode", createModeName(req.Mode), "client", clientIP, "auth", ctx.AuthFlavor)
 

--- a/internal/adapter/nfs/v3/handlers/doc.go
+++ b/internal/adapter/nfs/v3/handlers/doc.go
@@ -179,7 +179,7 @@ func (h *Handler) getFileOrError(
 	operationName string,
 	handleBytes []byte,
 ) (*metadata.File, uint32, error) {
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 	metaSvc := h.Registry.GetMetadataService()
 
 	// GetFileForRead: NFS is handle-addressed, so no v3 handler reads
@@ -227,7 +227,7 @@ func (h *Handler) buildAuthContextWithWCCError(
 	filename string,
 	dirHandleBytes []byte,
 ) (*metadata.AuthContext, *types.NFSFileAttr, uint32, error) {
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
 	authCtx, err := BuildAuthContextWithMapping(ctx, h.Registry, ctx.Share)
 	if err != nil {
@@ -254,7 +254,8 @@ func (h *Handler) getOplockBreaker() adapter.OplockBreaker {
 	if h.Registry == nil {
 		return nil
 	}
-	provider := h.Registry.GetAdapterProvider(adapter.OplockBreakerProviderKey)
+	// Lock-free atomic load; nil when no SMB adapter registered (common case).
+	provider := h.Registry.OplockBreakerProvider()
 	if provider == nil {
 		return nil
 	}

--- a/internal/adapter/nfs/v3/handlers/getattr.go
+++ b/internal/adapter/nfs/v3/handlers/getattr.go
@@ -66,7 +66,7 @@ func (h *Handler) GetAttr(
 	}
 
 	// Extract client IP for logging
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
 	logger.DebugCtx(ctx.Context, "GETATTR",
 		"handle", fmt.Sprintf("%x", req.Handle),

--- a/internal/adapter/nfs/v3/handlers/link.go
+++ b/internal/adapter/nfs/v3/handlers/link.go
@@ -76,7 +76,7 @@ func (h *Handler) Link(
 	req *LinkRequest,
 ) (*LinkResponse, error) {
 	// Extract client IP for logging
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
 	logger.InfoCtx(ctx.Context, "LINK", "file_handle", fmt.Sprintf("%x", req.FileHandle), "name", req.Name, "dir_handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "auth", ctx.AuthFlavor)
 

--- a/internal/adapter/nfs/v3/handlers/lookup.go
+++ b/internal/adapter/nfs/v3/handlers/lookup.go
@@ -77,7 +77,7 @@ func (h *Handler) Lookup(
 	req *LookupRequest,
 ) (*LookupResponse, error) {
 	// Extract client IP for logging
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
 	logger.InfoCtx(ctx.Context, "LOOKUP",
 		"name", req.Filename,

--- a/internal/adapter/nfs/v3/handlers/mkdir.go
+++ b/internal/adapter/nfs/v3/handlers/mkdir.go
@@ -100,7 +100,7 @@ func (h *Handler) Mkdir(
 	}
 
 	// Extract client IP for logging
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
 	var mode uint32 = 0755 // Default
 	if req.Attr != nil && req.Attr.Mode != nil {

--- a/internal/adapter/nfs/v3/handlers/mknod.go
+++ b/internal/adapter/nfs/v3/handlers/mknod.go
@@ -135,7 +135,7 @@ func (h *Handler) Mknod(
 	}
 
 	// Extract client IP for logging
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
 	var mode uint32 = 0644 // Default
 	if req.Attr != nil && req.Attr.Mode != nil {

--- a/internal/adapter/nfs/v3/handlers/pathconf.go
+++ b/internal/adapter/nfs/v3/handlers/pathconf.go
@@ -98,7 +98,7 @@ func (h *Handler) PathConf(
 	req *PathConfRequest,
 ) (*PathConfResponse, error) {
 	// Extract client IP for logging
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
 	logger.InfoCtx(ctx.Context, "PATHCONF", "handle", fmt.Sprintf("%x", req.Handle), "client", clientIP, "auth", ctx.AuthFlavor)
 

--- a/internal/adapter/nfs/v3/handlers/read.go
+++ b/internal/adapter/nfs/v3/handlers/read.go
@@ -111,7 +111,7 @@ func (h *Handler) Read(
 	}
 
 	// Extract client IP for logging
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
 	logger.DebugCtx(ctx.Context, "READ", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", bytesize.ByteSize(req.Offset), "count", bytesize.ByteSize(req.Count), "client", clientIP, "auth", ctx.AuthFlavor)
 

--- a/internal/adapter/nfs/v3/handlers/readdir.go
+++ b/internal/adapter/nfs/v3/handlers/readdir.go
@@ -104,7 +104,7 @@ func (h *Handler) ReadDir(
 	}
 
 	// Extract client IP for logging
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
 	logger.InfoCtx(ctx.Context, "READDIR", "handle", fmt.Sprintf("%x", req.DirHandle), "cookie", req.Cookie, "count", req.Count, "client", clientIP, "auth", ctx.AuthFlavor)
 

--- a/internal/adapter/nfs/v3/handlers/readdirplus.go
+++ b/internal/adapter/nfs/v3/handlers/readdirplus.go
@@ -158,7 +158,7 @@ func (h *Handler) ReadDirPlus(
 	req *ReadDirPlusRequest,
 ) (*ReadDirPlusResponse, error) {
 	// Extract client IP for logging
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
 	logger.InfoCtx(ctx.Context, "READDIRPLUS", "handle", fmt.Sprintf("%x", req.DirHandle), "cookie", req.Cookie, "dircount", req.DirCount, "maxcount", req.MaxCount, "client", clientIP, "auth", ctx.AuthFlavor)
 

--- a/internal/adapter/nfs/v3/handlers/readlink.go
+++ b/internal/adapter/nfs/v3/handlers/readlink.go
@@ -77,7 +77,7 @@ func (h *Handler) ReadLink(
 	}
 
 	// Extract client IP for logging
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
 	logger.InfoCtx(ctx.Context, "READLINK", "handle", fmt.Sprintf("%x", req.Handle), "client", clientIP, "auth", ctx.AuthFlavor)
 

--- a/internal/adapter/nfs/v3/handlers/remove.go
+++ b/internal/adapter/nfs/v3/handlers/remove.go
@@ -77,7 +77,7 @@ func (h *Handler) Remove(
 	}
 
 	// Extract client IP for logging
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
 	logger.InfoCtx(ctx.Context, "REMOVE", "name", req.Filename, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "auth", ctx.AuthFlavor)
 
@@ -171,7 +171,7 @@ func (h *Handler) Remove(
 		}
 
 		// Map store errors to NFS status codes
-		nfsStatus := xdr.MapStoreErrorToNFSStatus(err, clientIP, "REMOVE")
+		nfsStatus := xdr.MapStoreErrorToNFSStatus(err, clientIP.String(), "REMOVE")
 
 		// Get updated directory attributes for WCC data (best effort)
 		var wccAfter *types.NFSFileAttr

--- a/internal/adapter/nfs/v3/handlers/rename.go
+++ b/internal/adapter/nfs/v3/handlers/rename.go
@@ -93,7 +93,7 @@ func (h *Handler) Rename(
 	}
 
 	// Extract client IP for logging
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
 	logger.InfoCtx(ctx.Context, "RENAME", "from", req.FromName, "from_dir", fmt.Sprintf("0x%x", req.FromDirHandle), "to", req.ToName, "to_dir", fmt.Sprintf("0x%x", req.ToDirHandle), "client", clientIP, "auth", ctx.AuthFlavor)
 
@@ -315,7 +315,7 @@ func (h *Handler) Rename(
 		}
 
 		// Map store errors to NFS status codes
-		status := xdr.MapStoreErrorToNFSStatus(err, clientIP, "rename")
+		status := xdr.MapStoreErrorToNFSStatus(err, clientIP.String(), "rename")
 
 		return &RenameResponse{
 			NFSResponseBase:  NFSResponseBase{Status: status},

--- a/internal/adapter/nfs/v3/handlers/rmdir.go
+++ b/internal/adapter/nfs/v3/handlers/rmdir.go
@@ -72,7 +72,7 @@ func (h *Handler) Rmdir(
 	req *RmdirRequest,
 ) (*RmdirResponse, error) {
 	// Extract client IP for logging
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
 	logger.InfoCtx(ctx.Context, "RMDIR", "name", req.Name, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "auth", ctx.AuthFlavor)
 

--- a/internal/adapter/nfs/v3/handlers/runtime_iface.go
+++ b/internal/adapter/nfs/v3/handlers/runtime_iface.go
@@ -28,6 +28,11 @@ type nfsRuntime interface {
 
 	// Adapter-provided extensions (e.g. GSS processor) keyed by name.
 	GetAdapterProvider(key string) any
+
+	// OplockBreakerProvider is the lock-free fast path for the cross-protocol
+	// oplock breaker, checked on every read/write op. Returns nil when no SMB
+	// adapter is registered.
+	OplockBreakerProvider() any
 }
 
 var _ nfsRuntime = (*runtime.Runtime)(nil)

--- a/internal/adapter/nfs/v3/handlers/setattr.go
+++ b/internal/adapter/nfs/v3/handlers/setattr.go
@@ -95,7 +95,7 @@ func (h *Handler) SetAttr(
 	}
 
 	// Extract client IP for logging
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
 	logger.InfoCtx(ctx.Context, "SETATTR",
 		"handle", fmt.Sprintf("%x", req.Handle),
@@ -259,7 +259,7 @@ func (h *Handler) SetAttr(
 				wccAfter = h.convertFileAttrToNFS(fileHandle, &file.FileAttr)
 			}
 
-			status := xdr.MapStoreErrorToNFSStatus(err, clientIP, "SETATTR")
+			status := xdr.MapStoreErrorToNFSStatus(err, clientIP.String(), "SETATTR")
 			return &SetAttrResponse{
 				NFSResponseBase: NFSResponseBase{Status: status},
 				AttrBefore:      wccBefore,
@@ -309,7 +309,7 @@ func (h *Handler) SetAttr(
 		}
 
 		// Map store errors to NFS status codes
-		status := xdr.MapStoreErrorToNFSStatus(err, clientIP, "SETATTR")
+		status := xdr.MapStoreErrorToNFSStatus(err, clientIP.String(), "SETATTR")
 
 		return &SetAttrResponse{
 			NFSResponseBase: NFSResponseBase{Status: status},
@@ -428,7 +428,7 @@ func validateSetAttrRequest(req *SetAttrRequest) *validationError {
 
 // logSetAttrRequest logs which attributes are being set in a SETATTR request.
 // This provides detailed debugging information about the operation.
-func logSetAttrRequest(req *SetAttrRequest, clientIP string) {
+func logSetAttrRequest(req *SetAttrRequest, clientIP fmt.Stringer) {
 	attrs := make([]string, 0, 6)
 
 	if req.NewAttr.Mode != nil {

--- a/internal/adapter/nfs/v3/handlers/symlink.go
+++ b/internal/adapter/nfs/v3/handlers/symlink.go
@@ -100,7 +100,7 @@ func (h *Handler) Symlink(
 	}
 
 	// Extract client IP for logging
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
 	logger.InfoCtx(ctx.Context, "SYMLINK", "name", req.Name, "target", req.Target, "dir", fmt.Sprintf("0x%x", req.DirHandle), "client", clientIP, "auth", ctx.AuthFlavor)
 
@@ -217,7 +217,7 @@ func (h *Handler) Symlink(
 		}
 
 		// Map store errors to NFS status codes
-		status := xdr.MapStoreErrorToNFSStatus(err, clientIP, "SYMLINK")
+		status := xdr.MapStoreErrorToNFSStatus(err, clientIP.String(), "SYMLINK")
 
 		return &SymlinkResponse{
 			NFSResponseBase: NFSResponseBase{Status: status},

--- a/internal/adapter/nfs/v3/handlers/write.go
+++ b/internal/adapter/nfs/v3/handlers/write.go
@@ -122,7 +122,7 @@ func (h *Handler) Write(
 	req *WriteRequest,
 ) (*WriteResponse, error) {
 	// Extract client IP for logging
-	clientIP := xdr.ExtractClientIP(ctx.ClientAddr)
+	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
 	logger.DebugCtx(ctx.Context, "WRITE", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", bytesize.ByteSize(req.Offset), "count", bytesize.ByteSize(req.Count), "stable", req.Stable, "client", clientIP, "auth", ctx.AuthFlavor)
 

--- a/internal/adapter/nfs/xdr/clientip_bench_test.go
+++ b/internal/adapter/nfs/xdr/clientip_bench_test.go
@@ -1,0 +1,54 @@
+package xdr
+
+import (
+	"log/slog"
+	"testing"
+)
+
+// BenchmarkClientIP compares the old eager per-op ExtractClientIP (which runs
+// net.SplitHostPort on every NFS op regardless of log level) against building
+// a LazyClientIP whose SplitHostPort is deferred to log-emit time. "lazy_dropped"
+// models the common case: the log line is filtered out, so LogValue is never
+// called and the split never runs.
+func BenchmarkClientIP(b *testing.B) {
+	const addr = "192.168.1.100:2049"
+
+	b.Run("eager", func(b *testing.B) {
+		b.ReportAllocs()
+		var sink string
+		for i := 0; i < b.N; i++ {
+			sink = ExtractClientIP(addr)
+		}
+		_ = sink
+	})
+	b.Run("lazy_dropped", func(b *testing.B) {
+		b.ReportAllocs()
+		var sink LazyClientIP
+		for i := 0; i < b.N; i++ {
+			sink = LazyClientIP(addr) // built per op; String/LogValue never called
+		}
+		_ = sink
+	})
+	b.Run("lazy_emitted", func(b *testing.B) {
+		b.ReportAllocs()
+		var sink slog.Value
+		for i := 0; i < b.N; i++ {
+			sink = LazyClientIP(addr).LogValue() // cost paid only when actually logged
+		}
+		_ = sink
+	})
+}
+
+// TestLazyClientIPMatchesEager guards that the lazy paths return exactly what
+// the eager helper does, across host:port, bare-host, and empty inputs.
+func TestLazyClientIPMatchesEager(t *testing.T) {
+	for _, addr := range []string{"192.168.1.100:2049", "10.0.0.1", "", "[::1]:2049"} {
+		want := ExtractClientIP(addr)
+		if got := LazyClientIP(addr).String(); got != want {
+			t.Errorf("String(%q) = %q, want %q", addr, got, want)
+		}
+		if got := LazyClientIP(addr).LogValue().String(); got != want {
+			t.Errorf("LogValue(%q) = %q, want %q", addr, got, want)
+		}
+	}
+}

--- a/internal/adapter/nfs/xdr/network.go
+++ b/internal/adapter/nfs/xdr/network.go
@@ -1,19 +1,34 @@
 package xdr
 
-import "net"
+import (
+	"log/slog"
+	"net"
+)
+
+// LazyClientIP wraps a raw "host:port" client address and defers the
+// net.SplitHostPort extraction to log-emit time via slog.LogValuer. NFS
+// handlers build one per op, but most ops never emit at their log level, so
+// the split is skipped entirely on the hot path. It formats identically to
+// ExtractClientIP in both text and JSON output.
+type LazyClientIP string
+
+// LogValue implements slog.LogValuer so the IP is resolved only when a record
+// is actually emitted (skipped for filtered-out levels).
+func (c LazyClientIP) LogValue() slog.Value {
+	return slog.StringValue(ExtractClientIP(string(c)))
+}
+
+// String extracts the IP eagerly, for the rare non-logging callers (error
+// paths passing the client into MapStoreErrorToNFSStatus).
+func (c LazyClientIP) String() string {
+	return ExtractClientIP(string(c))
+}
 
 // ExtractClientIP extracts the IP address from a client address string.
 //
-// Expected format: "IP:port" (e.g., "192.168.1.100:45678")
-// Falls back to returning the original string if parsing fails.
-//
-// This is used for audit logging and access control decisions.
-//
-// Parameters:
-//   - clientAddr: Client address string from network connection
-//
-// Returns:
-//   - string: IP address portion, or original string if parsing fails
+// Expected format: "IP:port" (e.g., "192.168.1.100:45678"). Falls back to
+// returning the original string if parsing fails. Prefer LazyClientIP on hot
+// per-op paths where the result only feeds logging.
 func ExtractClientIP(clientAddr string) string {
 	if clientAddr == "" {
 		return "unknown"

--- a/pkg/controlplane/runtime/oplock_provider_bench_test.go
+++ b/pkg/controlplane/runtime/oplock_provider_bench_test.go
@@ -1,0 +1,51 @@
+package runtime
+
+import "testing"
+
+// BenchmarkOplockBreakerLookup compares the old per-op RWMutex+map provider
+// lookup (GetAdapterProvider) against the atomic.Value fast path
+// (OplockBreakerProvider) that the NFS read/write hot path now uses. Both the
+// no-SMB (nil) and registered cases are measured; RunParallel exposes the
+// RWMutex read contention that the atomic load avoids.
+func BenchmarkOplockBreakerLookup(b *testing.B) {
+	newRT := func(register bool) *Runtime {
+		r := &Runtime{adapterProviders: make(map[string]any)}
+		if register {
+			r.SetAdapterProvider(oplockBreakerProviderKey, struct{}{})
+		}
+		return r
+	}
+
+	b.Run("map_noSMB", func(b *testing.B) {
+		r := newRT(false)
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				_ = r.GetAdapterProvider(oplockBreakerProviderKey)
+			}
+		})
+	})
+	b.Run("atomic_noSMB", func(b *testing.B) {
+		r := newRT(false)
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				_ = r.OplockBreakerProvider()
+			}
+		})
+	})
+	b.Run("map_registered", func(b *testing.B) {
+		r := newRT(true)
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				_ = r.GetAdapterProvider(oplockBreakerProviderKey)
+			}
+		})
+	})
+	b.Run("atomic_registered", func(b *testing.B) {
+		r := newRT(true)
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				_ = r.OplockBreakerProvider()
+			}
+		})
+	})
+}

--- a/pkg/controlplane/runtime/oplock_provider_bench_test.go
+++ b/pkg/controlplane/runtime/oplock_provider_bench_test.go
@@ -2,6 +2,25 @@ package runtime
 
 import "testing"
 
+// TestOplockBreakerProviderStoreSafety guards that registering a nil provider,
+// then re-registering with a different concrete type, never panics the
+// atomic.Value (Store panics on a nil interface or a changing concrete type).
+func TestOplockBreakerProviderStoreSafety(t *testing.T) {
+	r := &Runtime{adapterProviders: make(map[string]any)}
+	if got := r.OplockBreakerProvider(); got != nil {
+		t.Fatalf("unregistered = %v, want nil", got)
+	}
+	r.SetAdapterProvider(oplockBreakerProviderKey, nil) // nil interface
+	if got := r.OplockBreakerProvider(); got != nil {
+		t.Fatalf("after nil register = %v, want nil", got)
+	}
+	r.SetAdapterProvider(oplockBreakerProviderKey, struct{ a int }{1})
+	r.SetAdapterProvider(oplockBreakerProviderKey, "different-type") // type changes
+	if got := r.OplockBreakerProvider(); got != "different-type" {
+		t.Fatalf("after re-register = %v, want different-type", got)
+	}
+}
+
 // BenchmarkOplockBreakerLookup compares the old per-op RWMutex+map provider
 // lookup (GetAdapterProvider) against the atomic.Value fast path
 // (OplockBreakerProvider) that the NFS read/write hot path now uses. Both the

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/auth/netlogon"
@@ -104,6 +105,11 @@ type Runtime struct {
 
 	adapterProviders   map[string]any
 	adapterProvidersMu sync.RWMutex
+	// oplockBreaker mirrors the "oplock_breaker" adapter provider for the NFS
+	// read/write hot path: every op checks it, but it is set at most once (when
+	// SMB registers). An atomic load replaces the RWMutex+map lookup, so the
+	// common no-SMB case is a single nil-check instead of a locked map access.
+	oplockBreaker atomic.Value
 
 	// snapInFlight tracks per-share in-flight snapshot orchestration
 	// goroutines so RemoveShare and Runtime.Shutdown can
@@ -1180,8 +1186,27 @@ func (r *Runtime) GetSMBSettings() *models.SMBAdapterSettings {
 
 func (r *Runtime) SetAdapterProvider(key string, p any) {
 	r.adapterProvidersMu.Lock()
-	defer r.adapterProvidersMu.Unlock()
 	r.adapterProviders[key] = p
+	r.adapterProvidersMu.Unlock()
+
+	// Mirror the oplock breaker into an atomic for the NFS hot path. Keyed by
+	// the literal to avoid importing pkg/adapter (which imports runtime).
+	if key == oplockBreakerProviderKey {
+		r.oplockBreaker.Store(p)
+	}
+}
+
+// oplockBreakerProviderKey mirrors adapter.OplockBreakerProviderKey. It is
+// duplicated (not imported) because pkg/adapter imports this package; a
+// mismatch would surface immediately in cross-protocol oplock e2e tests.
+const oplockBreakerProviderKey = "oplock_breaker"
+
+// OplockBreakerProvider returns the registered cross-protocol oplock breaker
+// (as an opaque any the NFS handlers type-assert), or nil if none is
+// registered. A lock-free atomic load: the NFS read/write path calls this per
+// op and the no-SMB case must stay cheap.
+func (r *Runtime) OplockBreakerProvider() any {
+	return r.oplockBreaker.Load()
 }
 
 func (r *Runtime) GetAdapterProvider(key string) any {

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -1191,8 +1191,11 @@ func (r *Runtime) SetAdapterProvider(key string, p any) {
 
 	// Mirror the oplock breaker into an atomic for the NFS hot path. Keyed by
 	// the literal to avoid importing pkg/adapter (which imports runtime).
+	// Wrap in a stable holder: atomic.Value.Store panics on a nil interface or
+	// a changing concrete type, but SetAdapterProvider accepts nil and may be
+	// called more than once — the holder keeps the stored type constant.
 	if key == oplockBreakerProviderKey {
-		r.oplockBreaker.Store(p)
+		r.oplockBreaker.Store(oplockProviderHolder{p: p})
 	}
 }
 
@@ -1201,12 +1204,17 @@ func (r *Runtime) SetAdapterProvider(key string, p any) {
 // mismatch would surface immediately in cross-protocol oplock e2e tests.
 const oplockBreakerProviderKey = "oplock_breaker"
 
+// oplockProviderHolder gives the oplockBreaker atomic.Value a single, stable
+// concrete type so nil providers and repeat registrations never panic Store.
+type oplockProviderHolder struct{ p any }
+
 // OplockBreakerProvider returns the registered cross-protocol oplock breaker
 // (as an opaque any the NFS handlers type-assert), or nil if none is
 // registered. A lock-free atomic load: the NFS read/write path calls this per
 // op and the no-SMB case must stay cheap.
 func (r *Runtime) OplockBreakerProvider() any {
-	return r.oplockBreaker.Load()
+	h, _ := r.oplockBreaker.Load().(oplockProviderHolder)
+	return h.p
 }
 
 func (r *Runtime) GetAdapterProvider(key string) any {

--- a/pkg/metadata/deferred_commit_bench_test.go
+++ b/pkg/metadata/deferred_commit_bench_test.go
@@ -1,0 +1,34 @@
+package metadata
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// BenchmarkDeferredCommitGate compares the old RWMutex-guarded bool read that
+// CommitWrite performed on every write op against the atomic.Bool load that
+// replaced it. Run with -cpu=8 (or higher) to see the RWMutex read serialize
+// under concurrent writers while the atomic load stays flat.
+func BenchmarkDeferredCommitGate(b *testing.B) {
+	b.Run("mutex", func(b *testing.B) {
+		var mu sync.RWMutex
+		flag := true
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				mu.RLock()
+				_ = flag
+				mu.RUnlock()
+			}
+		})
+	})
+	b.Run("atomic", func(b *testing.B) {
+		var flag atomic.Bool
+		flag.Store(true)
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				_ = flag.Load()
+			}
+		})
+	})
+}

--- a/pkg/metadata/io.go
+++ b/pkg/metadata/io.go
@@ -217,12 +217,8 @@ func (s *Service) PrepareWrite(ctx *AuthContext, handle FileHandle, newSize uint
 // This prevents race conditions where concurrent writes would result in
 // the smaller size being stored if it commits last.
 func (s *Service) CommitWrite(ctx *AuthContext, intent *WriteOperation) (*File, error) {
-	// Check if deferred commits are enabled
-	s.mu.RLock()
-	deferredCommit := s.deferredCommit
-	s.mu.RUnlock()
-
-	if deferredCommit {
+	// Check if deferred commits are enabled (lock-free read on the hot path).
+	if s.deferredCommit.Load() {
 		return s.deferredCommitWrite(ctx, intent)
 	}
 	return s.immediateCommitWrite(ctx, intent)

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
@@ -45,7 +46,7 @@ type Service struct {
 	dirChangeNotifiers map[string]lock.DirChangeNotifier // shareName -> notifier for directory changes
 	pendingWrites      *PendingWritesTracker             // deferred metadata commits for performance
 	dirTimes           *DirTimesTracker                  // coalesced directory mtime/ctime/atime bumps (#1573)
-	deferredCommit     bool                              // if true, use deferred commits (default: true)
+	deferredCommit     atomic.Bool                       // if true, use deferred commits (default: true); read lock-free on the write hot path
 
 	// parentLinkShards is a fixed bank of mutexes that serialize the parent
 	// directory link-count read-modify-write (the ".." bump) done by mkdir (+1),
@@ -135,19 +136,20 @@ type GraceCoordinator interface {
 // Use RegisterStoreForShare to configure stores for each share.
 // By default, deferred commits are enabled for better write performance.
 func New() *Service {
-	return &Service{
+	s := &Service{
 		stores:             make(map[string]Store),
 		lockManagers:       make(map[string]*LockManager),
 		unifiedViews:       make(map[string]*UnifiedLockView),
 		dirChangeNotifiers: make(map[string]lock.DirChangeNotifier),
 		pendingWrites:      NewPendingWritesTracker(),
 		dirTimes:           NewDirTimesTracker(),
-		deferredCommit:     true, // Enable deferred commits by default
 		cookies:            NewCookieManager(),
 		quotas:             make(map[string]int64),
 		identityQuotas:     newQuotaLimits(),
 		removeGen:          make(map[string]uint64),
 	}
+	s.deferredCommit.Store(true) // Enable deferred commits by default
+	return s
 }
 
 // QuotaGracePersister persists a per-identity quota's grace timer transition
@@ -225,9 +227,7 @@ func (s *Service) ListIdentityQuotas() []ConfiguredQuota {
 // When enabled, CommitWrite batches updates until FlushPendingWrites is called.
 // This significantly improves write performance for sequential workloads.
 func (s *Service) SetDeferredCommit(enabled bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.deferredCommit = enabled
+	s.deferredCommit.Store(enabled)
 }
 
 // SetLockGracePeriod sets the grace period applied to per-share lock managers


### PR DESCRIPTION
Four independent NFS/metadata hot-path micro-optimizations, each with a before/after microbenchmark (no trust-me lock removals). One commit per fix.

- **`deferredCommit` RLock → `atomic.Bool`.** `CommitWrite` took an RWMutex RLock on every write op just to read the `deferredCommit` bool. Now an `atomic.Bool`; `SetDeferredCommit` stores atomically. Bench (`RunParallel -cpu=8`): RWMutex read **55.0 ns/op → 0.39 ns/op**.

- **Oplock-breaker lookup → `atomic.Value` sentinel.** The read/write/remove/rename path resolved the cross-protocol oplock breaker every op via `GetAdapterProvider` (RWMutex + map + type-assert), even with no SMB adapter. The provider is now mirrored into an `atomic.Value` at registration and read lock-free. Bench (`RunParallel -cpu=8`): no-SMB **58.2 ns/op → 0.36 ns/op**; registered **101.8 ns/op → 0.49 ns/op**.

- **Lazy `ExtractClientIP` (debug-only work).** `ExtractClientIP` ran `net.SplitHostPort` per op but the result only feeds logging. Wrapped in a `LazyClientIP` (`slog.LogValuer`) so the split runs only when a record is actually emitted; filtered-out levels skip it (works for both text and JSON handlers). Bench: eager **16.9 ns/op → 0.35 ns/op** when dropped (0 allocs); emitted path unchanged (18.2 ns/op).

- **Thread already-loaded `*File` through WRITE perm checks — already in place.** `PrepareWrite` already routes the fresh-fetch path through `checkWritePermissionFile` (no redundant `GetFile`); the remaining cache-hit re-fetch through `checkWritePermission` is a deliberate security decision (cached file may be stale vs a concurrent chmod). No change made — noting it so it isn't re-attempted.

Verify: `gofmt -s`, `go vet`, `golangci-lint` clean; `go build ./...`; `go test -race` green across `internal/adapter/nfs/...`, `internal/adapter/smb/...`, `pkg/metadata/...`, `pkg/controlplane/runtime/...` (7300+ tests).

Part of #1692