### PR TITLE
perf(block): journal crash recovery — tail-scan + rebuild (Wall A PR3)

### DIFF
--- a/pkg/block/journal/journal_test.go
+++ b/pkg/block/journal/journal_test.go
@@ -172,15 +172,27 @@ func TestShardForDeterministicAndMasked(t *testing.T) {
 	}
 }
 
-func TestReopenPopulatedDirRefused(t *testing.T) {
+func TestReopenPopulatedDirRecovers(t *testing.T) {
 	dir := t.TempDir()
 	s, err := Open(dir, Config{}, newFakeRemote(), SystemClock())
 	if err != nil {
 		t.Fatalf("first Open: %v", err)
 	}
+	if err := s.WriteAt(context.Background(), "f", 0, []byte("hello")); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
 	_ = s.Close()
-	if _, err := Open(dir, Config{}, newFakeRemote(), SystemClock()); err == nil {
-		t.Fatalf("expected reopen to be refused")
+	r, err := Open(dir, Config{}, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("reopen should recover, got: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+	got := make([]byte, 5)
+	if _, _, err := r.ReadAt(context.Background(), "f", 0, got); err != nil {
+		t.Fatalf("ReadAt after recovery: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("recovered data mismatch: %q", got)
 	}
 }
 

--- a/pkg/block/journal/recovery.go
+++ b/pkg/block/journal/recovery.go
@@ -2,23 +2,26 @@ package journal
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
-// Crash recovery (tail-scan, CRC validation, torn-write truncation, Version-LSN
-// recompute, orphan sweep) is not yet implemented. Until it lands, Open refuses
-// to reopen a directory that already holds segments rather than silently
-// starting a fresh cache over stale data.
-//
-// The eventual flow: per shard locate the one unsealed (active) segment, tail-
-// scan it from offset 0 validating each record's header then payload CRC, and
-// truncate + fsync at the first invalid or torn record; replay the valid
-// records into a fresh interval index and .idx; recompute the global Version
-// LSN as max(observed)+1. Sealed segments are trusted via their header's sealed
-// bit ("header is truth") without a full re-scan. An age-gated orphan sweep
-// deletes any on-disk segment unreferenced by the rebuilt bookkeeping.
+// orphanMinAge gates the recovery orphan sweep: a segment file that recovery
+// cannot attach to any shard (a torn create with an unreadable header, or an
+// empty active segment left over beyond what the shards need) is only unlinked
+// once it is at least this old. The gate mirrors the fs store's fsync-then-
+// unlink ordering, where a crash before unlink leaves a harmless orphan — young
+// enough that it might belong to an operation still in flight is left in place.
+const orphanMinAge = 5 * time.Minute
+
+// logf is recovery's warning sink, overridable in tests. Recovery is otherwise
+// silent; it only speaks up for events an operator should notice (a rebuilt
+// index sidecar, a swept orphan).
+var logf = log.Printf
 
 // scanSegmentIDs returns the IDs of every well-formed <id>.seg file in dir.
 func scanSegmentIDs(dir string) ([]uint64, error) {
@@ -39,4 +42,283 @@ func scanSegmentIDs(dir string) ([]uint64, error) {
 		ids = append(ids, id)
 	}
 	return ids, nil
+}
+
+// recover rebuilds in-memory state from the segments already on disk. Sealed
+// segments are trusted via their header's sealed bit ("header is truth") and
+// only replayed; the one active (unsealed) segment per shard is tail-scanned and
+// its torn tail truncated. All valid records feed a fresh interval index — order
+// does not matter because insert resolves overlaps by Version — and the global
+// LSN resumes at max(observed Version)+1.
+func (s *Store) recover() error {
+	segIDs, err := scanSegmentIDs(s.dir)
+	if err != nil {
+		return err
+	}
+	// Deterministic, ascending replay. Version still decides newest-wins, but a
+	// stable order keeps recovery reproducible and eases debugging.
+	sort.Slice(segIDs, func(i, j int) bool { return segIDs[i] < segIDs[j] })
+
+	n := s.cfg.ShardCount
+	actives := make([]*segmentMeta, n) // data-bearing unsealed segment per shard
+	sealedByShard := make([]map[uint64]*segmentMeta, n)
+	indexByShard := make([]map[FileID]*fileIndex, n)
+	for i := 0; i < n; i++ {
+		sealedByShard[i] = make(map[uint64]*segmentMeta)
+		indexByShard[i] = make(map[FileID]*fileIndex)
+	}
+
+	var (
+		emptyPool  []*segmentMeta // empty unsealed segments, reusable as any shard's active
+		orphans    []uint64       // unattachable segment ids, candidates for the age-gated sweep
+		maxSegID   uint64
+		maxVersion uint64
+		unsynced   int64
+		missingIdx int
+		opened     []*segmentMeta // every fd we opened, closed on error
+		ok         bool
+	)
+	defer func() {
+		if !ok {
+			for _, m := range opened {
+				_ = m.close()
+			}
+		}
+	}()
+
+	for _, id := range segIDs {
+		if id > maxSegID {
+			maxSegID = id
+		}
+		path := s.segPath(id)
+		fd, err := os.OpenFile(path, os.O_RDWR, 0o644)
+		if err != nil {
+			return fmt.Errorf("journal: open segment %q: %w", path, err)
+		}
+		var hdr [segHeaderSize]byte
+		if _, rerr := fd.ReadAt(hdr[:], 0); rerr != nil {
+			// A header that will not even read back is a torn create; sweep it.
+			_ = fd.Close()
+			orphans = append(orphans, id)
+			continue
+		}
+		hdrID, createdAt, flags, hdrOK := decodeSegHeader(hdr[:])
+		if !hdrOK || hdrID != id {
+			_ = fd.Close()
+			orphans = append(orphans, id)
+			continue
+		}
+		sealed := flags&segFlagSealed != 0
+
+		// SegmentSize is the ceiling for a single record's PayloadLen (the append
+		// path enforces it), so it doubles as the sanity ceiling that stops a
+		// CRC-coincidence torn header from making the scanner trust a bogus length.
+		recs, validUpTo := scanValidRecords(fd, s.cfg.SegmentSize, s.cfg.SegmentSize)
+
+		m := &segmentMeta{id: id, createdAt: createdAt, fd: fd}
+		m.tail.Store(validUpTo)
+		if sealed {
+			m.sealed.Store(true)
+		}
+		opened = append(opened, m)
+
+		if !sealed && len(recs) == 0 {
+			// Empty active segment: no records name its shard. Hold it as a reuse
+			// pool entry rather than a data-bearing active.
+			emptyPool = append(emptyPool, m)
+			continue
+		}
+		if !sealed && validUpTo < fileSize(fd) {
+			// Drop the torn tail and make the truncation durable before it is read.
+			if terr := fd.Truncate(validUpTo); terr != nil {
+				return fmt.Errorf("journal: truncate torn tail %q: %w", path, terr)
+			}
+			if serr := fd.Sync(); serr != nil {
+				return fmt.Errorf("journal: fsync truncated segment %q: %w", path, serr)
+			}
+		}
+
+		// Every record in a segment belongs to files that hash to one shard, so
+		// the first record names the segment's shard.
+		sh := s.shardIndex(FileID(recs[0].fileID))
+
+		if !sealed {
+			m.idxFD, _ = os.OpenFile(s.idxPath(id), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+			if actives[sh] == nil {
+				actives[sh] = m
+			} else {
+				// Defensive: two data-bearing unsealed segments for one shard should
+				// never happen (one active per shard). Keep the higher id active and
+				// demote the other to a sealed, still-readable segment.
+				if id > actives[sh].id {
+					actives[sh], m = m, actives[sh]
+				}
+				m.sealed.Store(true)
+				if m.idxFD != nil {
+					_ = m.idxFD.Close()
+					m.idxFD = nil
+				}
+				sealedByShard[sh][m.id] = m
+			}
+		} else {
+			sealedByShard[sh][id] = m
+		}
+
+		if s.idxMissing(id) {
+			if rerr := s.rebuildIdx(id, recs); rerr != nil {
+				return rerr
+			}
+			missingIdx++
+		}
+
+		idxMap := indexByShard[sh]
+		for _, rec := range recs {
+			if rec.header.Version > maxVersion {
+				maxVersion = rec.header.Version
+			}
+			if rec.header.Flags&flagTombstone != 0 {
+				continue
+			}
+			payloadOff := rec.segOff + recordHeaderSize + int64(len(rec.fileID))
+			fid := FileID(rec.fileID)
+			fi := idxMap[fid]
+			if fi == nil {
+				fi = &fileIndex{}
+				idxMap[fid] = fi
+			}
+			fi.insert(interval{
+				fileOff: int64(rec.header.FileOffset),
+				length:  int64(rec.header.PayloadLen),
+				version: rec.header.Version,
+				loc: SegmentLocation{
+					SegmentID: id,
+					Offset:    payloadOff,
+					Length:    int64(rec.header.PayloadLen),
+				},
+			})
+			// Coarse byte accounting: liveBytes ignores same-segment supersession
+			// (GC recomputes deadBytes on repack). unsynced feeds write backpressure.
+			m.liveBytes.Add(int64(rec.header.PayloadLen))
+			if rec.header.Flags&flagSynced != 0 {
+				m.syncedRecords.Add(1)
+			} else {
+				unsynced += int64(rec.header.PayloadLen)
+			}
+		}
+	}
+
+	if missingIdx > 0 {
+		logf("journal: WARN %d segment(s) missing .idx sidecar, rebuilding from segment scan (recovery slower)", missingIdx)
+	}
+
+	s.nextSeg.Store(maxSegID + 1)
+	// nextVersion increments-then-returns, so storing maxVersion makes the next
+	// issued LSN exactly max(observed)+1 — strictly past every replayed record.
+	s.version.Store(maxVersion)
+	s.unsynced.Store(unsynced)
+
+	// Give every shard an active segment: reuse a pooled empty one, else mint a
+	// fresh one (nextSeg is now set past every recovered id). Build into a local
+	// slice and publish it only on success so a mid-build error path never leaves
+	// half-open fds double-closed by both the defer and the caller's Close.
+	poolPos := 0
+	shards := make([]*shard, n)
+	for i := 0; i < n; i++ {
+		active := actives[i]
+		if active == nil {
+			if poolPos < len(emptyPool) {
+				active = emptyPool[poolPos]
+				poolPos++
+				active.idxFD, _ = os.OpenFile(s.idxPath(active.id), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+			} else {
+				seg, cerr := s.createSegment()
+				if cerr != nil {
+					return cerr
+				}
+				opened = append(opened, seg)
+				active = seg
+			}
+		}
+		sh := newShard(active)
+		sh.sealed = sealedByShard[i]
+		sh.index = indexByShard[i]
+		shards[i] = sh
+	}
+
+	// Any pooled empty segment we did not adopt is an orphan.
+	for ; poolPos < len(emptyPool); poolPos++ {
+		orphans = append(orphans, emptyPool[poolPos].id)
+		_ = emptyPool[poolPos].close()
+	}
+
+	s.sweepOrphans(orphans)
+	s.shards = shards
+	ok = true
+	return nil
+}
+
+// idxMissing reports whether a segment's .idx sidecar is absent.
+func (s *Store) idxMissing(id uint64) bool {
+	_, err := os.Stat(s.idxPath(id))
+	return os.IsNotExist(err)
+}
+
+// rebuildIdx rewrites a segment's .idx sidecar from its scanned records. The
+// sidecar is only ever rebuilt from the .seg, so a lost or partial one is
+// regenerated in full and fsynced.
+func (s *Store) rebuildIdx(id uint64, recs []record) error {
+	path := s.idxPath(id)
+	fd, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("journal: rebuild idx %q: %w", path, err)
+	}
+	for _, rec := range recs {
+		payloadOff := rec.segOff + recordHeaderSize + int64(len(rec.fileID))
+		if _, werr := fd.Write(idxEntry{
+			FileIDHash: fnv1a(string(rec.fileID)),
+			FileOffset: rec.header.FileOffset,
+			PayloadLen: rec.header.PayloadLen,
+			Version:    rec.header.Version,
+			SegOffset:  uint64(payloadOff),
+			Flags:      rec.header.Flags,
+		}.encode()); werr != nil {
+			_ = fd.Close()
+			return fmt.Errorf("journal: write rebuilt idx %q: %w", path, werr)
+		}
+	}
+	if serr := fd.Sync(); serr != nil {
+		_ = fd.Close()
+		return fmt.Errorf("journal: fsync rebuilt idx %q: %w", path, serr)
+	}
+	return fd.Close()
+}
+
+// sweepOrphans age-gates the deletion of unattachable segment files. Recovery
+// rebuilds all bookkeeping from the segments themselves, so an orphan is a
+// genuinely unreferenced file; the age gate only spares one young enough to
+// belong to an operation that crashed mid-flight. Deletion is best-effort — a
+// leftover file is harmless and retried on the next Open.
+func (s *Store) sweepOrphans(ids []uint64) {
+	now := s.clock.Now()
+	for _, id := range ids {
+		path := s.segPath(id)
+		age := orphanMinAge
+		if fi, err := os.Stat(path); err == nil {
+			age = now.Sub(fi.ModTime())
+		}
+		if age < orphanMinAge {
+			continue
+		}
+		_ = os.Remove(path)
+		_ = os.Remove(s.idxPath(id))
+	}
+}
+
+// fileSize returns the current size of an open file, or 0 if it cannot be
+// stat'd (a scan that read nothing already treats the segment as empty).
+func fileSize(fd *os.File) int64 {
+	if fi, err := fd.Stat(); err == nil {
+		return fi.Size()
+	}
+	return 0
 }

--- a/pkg/block/journal/recovery_test.go
+++ b/pkg/block/journal/recovery_test.go
@@ -1,0 +1,379 @@
+package journal
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+// reopen closes s and opens a fresh Store over the same directory, exercising
+// the recovery path.
+func reopen(t *testing.T, s *Store) *Store {
+	t.Helper()
+	dir := s.dir
+	cfg := s.cfg
+	clock := s.clock
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	r, err := Open(dir, cfg, newFakeRemote(), clock)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+	return r
+}
+
+func readAll(t *testing.T, s *Store, id FileID, n int) []byte {
+	t.Helper()
+	got := make([]byte, n)
+	if _, _, err := s.ReadAt(context.Background(), id, 0, got); err != nil {
+		t.Fatalf("ReadAt %s: %v", id, err)
+	}
+	return got
+}
+
+// TestRecoveryRoundTrip writes across several files and shards, reopens, and
+// asserts every byte survives recovery unchanged.
+func TestRecoveryRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(dir, Config{ShardCount: 4}, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ctx := context.Background()
+
+	want := map[FileID][]byte{
+		"alpha":   bytes.Repeat([]byte("A"), 5000),
+		"beta":    bytes.Repeat([]byte("B"), 12345),
+		"gamma":   []byte("short"),
+		"delta-x": bytes.Repeat([]byte("D"), 40000),
+	}
+	for id, data := range want {
+		if err := s.WriteAt(ctx, id, 0, data); err != nil {
+			t.Fatalf("WriteAt %s: %v", id, err)
+		}
+	}
+	// Overwrite a middle range so newest-wins must survive replay too.
+	copy(want["alpha"][1000:1004], []byte("ZZZZ"))
+	if err := s.WriteAt(ctx, "alpha", 1000, []byte("ZZZZ")); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	if err := s.Commit(ctx, "alpha"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	r := reopen(t, s)
+	for id, data := range want {
+		if got := readAll(t, r, id, len(data)); !bytes.Equal(got, data) {
+			t.Fatalf("file %s mismatch after recovery", id)
+		}
+	}
+}
+
+// segTail returns the on-disk size of a segment file.
+func segTail(t *testing.T, s *Store, id uint64) int64 {
+	t.Helper()
+	fi, err := os.Stat(s.segPath(id))
+	if err != nil {
+		t.Fatalf("stat seg %d: %v", id, err)
+	}
+	return fi.Size()
+}
+
+// TestTornWriteRecoveryLSL06 appends a valid prefix, then a torn (truncated
+// payload) final record, and asserts recovery drops the torn tail, keeps the
+// prefix, and truncates the segment at the boundary. Single shard keeps every
+// record in segment 0.
+func TestTornWriteRecoveryLSL06(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ctx := context.Background()
+
+	good := bytes.Repeat([]byte("valid-prefix-"), 100)
+	if err := s.WriteAt(ctx, "f", 0, good); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.Commit(ctx, "f"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	// Boundary offset after the last good record.
+	cleanTail := s.shards[0].active.tail.Load()
+
+	// Hand-append a torn record: a valid header (correct header CRC) followed by
+	// only part of its declared payload — exactly a crash mid-append.
+	seg := s.shards[0].active
+	fileID := []byte("f")
+	hdr := encodeHeader(recordHeader{
+		FileIDLen:  uint16(len(fileID)),
+		FileOffset: 9999,
+		PayloadLen: 4096, // claims 4096 bytes...
+		Version:    999,
+	}, fileID)
+	if _, err := seg.fd.WriteAt(hdr, cleanTail); err != nil {
+		t.Fatalf("write torn header: %v", err)
+	}
+	// ...but only 10 payload bytes actually reach disk.
+	if _, err := seg.fd.WriteAt(bytes.Repeat([]byte("x"), 10), cleanTail+int64(len(hdr))); err != nil {
+		t.Fatalf("write torn payload: %v", err)
+	}
+	_ = seg.fd.Sync()
+
+	r := reopen(t, s)
+	if got := readAll(t, r, "f", len(good)); !bytes.Equal(got, good) {
+		t.Fatalf("valid prefix corrupted after torn recovery")
+	}
+	// The torn tail was truncated: segment size is back to the clean boundary.
+	if sz := segTail(t, r, 0); sz != cleanTail {
+		t.Fatalf("segment not truncated at torn boundary: size=%d want=%d", sz, cleanTail)
+	}
+}
+
+// TestCRCCoincidenceTornRecordGuarded writes a torn record whose header CRC is
+// perfectly valid but whose PayloadLen is absurd. The PayloadLen ceiling must
+// reject it before any allocation, so recovery treats it as the torn boundary.
+func TestCRCCoincidenceTornRecordGuarded(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ctx := context.Background()
+
+	good := []byte("keep-me")
+	if err := s.WriteAt(ctx, "f", 0, good); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.Commit(ctx, "f"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	cleanTail := s.shards[0].active.tail.Load()
+
+	fileID := []byte("f")
+	// Header CRC is valid (encodeHeader computes it), PayloadLen is way over the
+	// SegmentSize ceiling — the classic CRC-coincidence torn tail.
+	hdr := encodeHeader(recordHeader{
+		FileIDLen:  uint16(len(fileID)),
+		PayloadLen: uint32(s.cfg.SegmentSize) + 1<<20,
+		Version:    12345,
+	}, fileID)
+	if _, err := s.shards[0].active.fd.WriteAt(hdr, cleanTail); err != nil {
+		t.Fatalf("write bogus header: %v", err)
+	}
+	_ = s.shards[0].active.fd.Sync()
+
+	r := reopen(t, s)
+	if got := readAll(t, r, "f", len(good)); !bytes.Equal(got, good) {
+		t.Fatalf("valid prefix corrupted")
+	}
+	if sz := segTail(t, r, 0); sz != cleanTail {
+		t.Fatalf("bogus record not truncated: size=%d want=%d", sz, cleanTail)
+	}
+}
+
+// TestVersionLSNMonotonicAfterReopen asserts the global LSN resumes strictly
+// past every replayed record and never reissues an observed version.
+func TestVersionLSNMonotonicAfterReopen(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		if err := s.WriteAt(ctx, "f", int64(i*10), []byte("data")); err != nil {
+			t.Fatalf("WriteAt: %v", err)
+		}
+	}
+	maxObserved := s.version.Load() // last issued version
+
+	r := reopen(t, s)
+	// Next write must get a version strictly greater than any observed before.
+	if err := r.WriteAt(ctx, "f", 100, []byte("post")); err != nil {
+		t.Fatalf("post-reopen WriteAt: %v", err)
+	}
+	if got := r.version.Load(); got <= maxObserved {
+		t.Fatalf("LSN not monotonic: post-reopen version %d <= observed %d", got, maxObserved)
+	}
+}
+
+// TestMissingIdxRebuilt deletes a sealed segment's .idx sidecar, then asserts
+// recovery rebuilds it, warns, and serves the data intact.
+func TestMissingIdxRebuilt(t *testing.T) {
+	dir := t.TempDir()
+	// Small segment + single shard forces a seal after ~1 MiB of writes.
+	s, err := Open(dir, Config{ShardCount: 1, SegmentSize: minSegmentSize}, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ctx := context.Background()
+
+	chunk := bytes.Repeat([]byte("payload-"), 8192) // 64 KiB
+	var written int
+	for off := 0; off < int(minSegmentSize)+128<<10; off += len(chunk) {
+		if err := s.WriteAt(ctx, "big", int64(off), chunk); err != nil {
+			t.Fatalf("WriteAt: %v", err)
+		}
+		written = off + len(chunk)
+	}
+	if err := s.Commit(ctx, "big"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	// Segment 0 should now be sealed with an .idx sidecar.
+	if len(s.shards[0].sealed) == 0 {
+		t.Fatalf("expected at least one sealed segment")
+	}
+	if err := os.Remove(s.idxPath(0)); err != nil {
+		t.Fatalf("remove sealed .idx: %v", err)
+	}
+
+	var warned bool
+	prev := logf
+	logf = func(format string, args ...any) { warned = true }
+	defer func() { logf = prev }()
+
+	r := reopen(t, s)
+	if !warned {
+		t.Fatalf("expected a Warn for the missing .idx")
+	}
+	if _, err := os.Stat(r.idxPath(0)); err != nil {
+		t.Fatalf("sealed .idx not rebuilt: %v", err)
+	}
+	// Data still intact across the sealed + active segments.
+	got := make([]byte, len(chunk))
+	if _, _, err := r.ReadAt(ctx, "big", 0, got); err != nil {
+		t.Fatalf("ReadAt after rebuild: %v", err)
+	}
+	if !bytes.Equal(got, chunk) {
+		t.Fatalf("data corrupted after .idx rebuild")
+	}
+	_ = written
+}
+
+// fixedClock is a Clock pinned to a fixed instant, used to drive the age gate.
+type fixedClock struct{ t time.Time }
+
+func (c fixedClock) Now() time.Time { return c.t }
+
+// TestOrphanSweepAgeGated asserts an unattachable, aged segment file is
+// unlinked on reopen, while the store's real data is untouched.
+func TestOrphanSweepAgeGated(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ctx := context.Background()
+	if err := s.WriteAt(ctx, "f", 0, []byte("real-data")); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.Commit(ctx, "f"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Drop a stray, empty, valid but excess segment file with an old header.
+	orphanID := uint64(9999)
+	old := time.Now().Add(-time.Hour)
+	if err := os.WriteFile(s.segPath(orphanID), encodeSegHeader(orphanID, old, 0), 0o644); err != nil {
+		t.Fatalf("write orphan seg: %v", err)
+	}
+	// Backdate its mtime past the age gate.
+	if err := os.Chtimes(s.segPath(orphanID), old, old); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	r, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), fixedClock{t: time.Now()})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	if _, err := os.Stat(r.segPath(orphanID)); !os.IsNotExist(err) {
+		t.Fatalf("aged orphan segment not swept: err=%v", err)
+	}
+	if got := readAll(t, r, "f", len("real-data")); string(got) != "real-data" {
+		t.Fatalf("real data lost during orphan sweep: %q", got)
+	}
+}
+
+// TestOrphanSweepSparesYoung asserts a fresh (young) orphan is left in place.
+func TestOrphanSweepSparesYoung(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := s.WriteAt(context.Background(), "f", 0, []byte("x")); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// A stray segment that is unreadable garbage but freshly written stays put.
+	orphanID := uint64(4242)
+	if err := os.WriteFile(s.segPath(orphanID), []byte("not a segment header at all!!!"), 0o644); err != nil {
+		t.Fatalf("write orphan: %v", err)
+	}
+	r, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+	if _, err := os.Stat(s.segPath(orphanID)); err != nil {
+		t.Fatalf("young orphan should be spared, got: %v", err)
+	}
+}
+
+// TestConcurrentReadWriteAfterRecovery exercises the recovered store under the
+// race detector with concurrent readers and writers.
+func TestConcurrentReadWriteAfterRecovery(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(dir, Config{ShardCount: 4}, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ctx := context.Background()
+	seed := bytes.Repeat([]byte("seed"), 1024)
+	for i := 0; i < 8; i++ {
+		if err := s.WriteAt(ctx, FileID([]byte{byte('a' + i)}), 0, seed); err != nil {
+			t.Fatalf("seed WriteAt: %v", err)
+		}
+	}
+	r := reopen(t, s)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		id := FileID([]byte{byte('a' + i)})
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				_ = r.WriteAt(ctx, id, int64(len(seed)+j*4), []byte("more"))
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			buf := make([]byte, len(seed))
+			for j := 0; j < 50; j++ {
+				_, _, _ = r.ReadAt(ctx, id, 0, buf)
+			}
+		}()
+	}
+	wg.Wait()
+
+	for i := 0; i < 8; i++ {
+		id := FileID([]byte{byte('a' + i)})
+		if got := readAll(t, r, id, len(seed)); !bytes.Equal(got, seed) {
+			t.Fatalf("seed data corrupted for %s", id)
+		}
+	}
+}

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -75,6 +75,26 @@ func (m *segmentMeta) close() error {
 	return firstErr
 }
 
+// decodeSegHeader validates and parses a segment header. It checks the magic
+// and header CRC; a failure means the file is not a well-formed segment (a torn
+// create or unrelated file) and recovery treats it as an orphan.
+func decodeSegHeader(buf []byte) (id uint64, createdAt time.Time, flags uint32, ok bool) {
+	if len(buf) < segHeaderSize {
+		return 0, time.Time{}, 0, false
+	}
+	if [8]byte(buf[0:8]) != segMagic {
+		return 0, time.Time{}, 0, false
+	}
+	want := binary.LittleEndian.Uint32(buf[28:32])
+	if crc(buf[:segHeaderCRCCovers]) != want {
+		return 0, time.Time{}, 0, false
+	}
+	id = binary.LittleEndian.Uint64(buf[8:16])
+	createdAt = time.Unix(0, int64(binary.LittleEndian.Uint64(buf[16:24])))
+	flags = binary.LittleEndian.Uint32(buf[24:28])
+	return id, createdAt, flags, true
+}
+
 func encodeSegHeader(id uint64, createdAt time.Time, flags uint32) []byte {
 	buf := make([]byte, segHeaderSize)
 	copy(buf[0:8], segMagic[:])

--- a/pkg/block/journal/shard.go
+++ b/pkg/block/journal/shard.go
@@ -59,8 +59,12 @@ func (sh *shard) indexFor(id FileID) *fileIndex {
 	return fi
 }
 
+// shardIndex returns the shard slot owning id. Recovery needs the slot before
+// s.shards is populated, so it is factored out of shardFor.
+func (s *Store) shardIndex(id FileID) uint64 { return fnv1a(string(id)) & s.shardMask }
+
 // shardFor returns the shard owning id: FNV-1a masked to the power-of-two
 // shard count.
 func (s *Store) shardFor(id FileID) *shard {
-	return s.shards[fnv1a(string(id))&s.shardMask]
+	return s.shards[s.shardIndex(id)]
 }

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -19,7 +19,7 @@ type FileID string
 type BlockID string
 
 // errNotImplemented is returned by operations whose implementation lands in a
-// later change (carve, evict, gc, delete, reopen recovery).
+// later change (carve, evict, gc, delete).
 var errNotImplemented = errors.New("journal: not yet implemented")
 
 // errClosed is returned by every operation attempted on a closed Store.
@@ -121,8 +121,10 @@ type Store struct {
 }
 
 // Open opens (or creates) a Store rooted at dir. A fresh directory gets one
-// active segment per shard. Reopen of a populated directory (crash recovery
-// replay) is not yet implemented; callers currently start from an empty cache.
+// active segment per shard. A populated directory is recovered: the active
+// segment of each shard is tail-scanned and its torn tail truncated, every
+// valid record is replayed into a fresh interval index, and the global Version
+// LSN is resumed past the highest observed record. See recover.
 func Open(dir string, cfg Config, remote RemoteStore, clock Clock) (*Store, error) {
 	cfg = cfg.withDefaults()
 	if cfg.ShardCount&(cfg.ShardCount-1) != 0 {
@@ -137,13 +139,6 @@ func Open(dir string, cfg Config, remote RemoteStore, clock Clock) (*Store, erro
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("journal: mkdir %q: %w", dir, err)
 	}
-	if ids, err := scanSegmentIDs(dir); err != nil {
-		return nil, err
-	} else if len(ids) > 0 {
-		// Crash-recovery replay is not yet implemented; refuse to start a fresh
-		// cache over stale segments rather than silently lose their data.
-		return nil, fmt.Errorf("journal: %w: reopen of populated dir %q", errNotImplemented, dir)
-	}
 
 	s := &Store{
 		dir:       dir,
@@ -152,6 +147,19 @@ func Open(dir string, cfg Config, remote RemoteStore, clock Clock) (*Store, erro
 		clock:     clock,
 		shardMask: uint64(cfg.ShardCount - 1),
 	}
+
+	ids, err := scanSegmentIDs(dir)
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) > 0 {
+		if err := s.recover(); err != nil {
+			_ = s.Close()
+			return nil, err
+		}
+		return s, nil
+	}
+
 	s.shards = make([]*shard, cfg.ShardCount)
 	for i := range s.shards {
 		seg, err := s.createSegment()


### PR DESCRIPTION
## Summary

`Open` now recovers a populated `pkg/block/journal/` directory instead of refusing it (the PR0 placeholder). This is Wall A PR3 — crash recovery — building on PR1's segment format + torn-write scan primitive and PR2's interval index.

## Recovery algorithm (§5 of the blueprint)

1. **Locate the active segment per shard** — sealed segments carry a header sealed bit ("header is truth") and are trusted without re-validation; only the one unsealed segment per shard is tail-scanned.
2. **Tail-scan + torn-write truncate** — the active segment is scanned from offset 0 via PR1's `scanValidRecords` (validates HeaderCRC32 + PayloadCRC32). At the first invalid/truncated/torn record the segment is `Truncate`d to that boundary and fsynced, dropping the torn tail.
3. **Replay** — every valid record (active scan + sealed segments, same read primitive) replays into a fresh interval index. Newest-wins is resolved by `Version`, so replay order is irrelevant.
4. **Version-LSN recompute** — the global LSN resumes at `max(observed Version)+1`, strictly past every replayed record; never reissued.
5. **Orphan sweep** — empty unsealed segments form a reuse pool for shards that lack an active; anything left over (or a torn-create file with an unreadable header) is unlinked, age-gated.
6. **`.idx` loss** — a sealed segment missing its `.idx` sidecar is rebuilt from the segment scan, with a loud actionable Warn.

## Torn-write / CRC-coincidence handling

A torn final record (valid header, truncated payload) fails `scanValidRecords` at the payload read; recovery truncates there and keeps the valid prefix (`TestTornWriteRecoveryLSL06`, the blueprint's `TornWriteRecovery_LSL06` scenario realized against journal internals, mirroring the fs backend's `appendlog_internals_test.go`). A **CRC-coincidence** torn header (perfectly valid HeaderCRC32 but absurd `PayloadLen`) is rejected by the `SegmentSize` PayloadLen ceiling **before any allocation** (`TestCRCCoincidenceTornRecordGuarded`), so a coincidental CRC match can never make the scanner trust a bogus length.

## Tests

`recovery_test.go`: round-trip reopen (byte-identical across files/shards), torn-write recovery + segment-truncation-at-boundary, CRC-coincidence guard, monotonic LSN after reopen, missing-`.idx` rebuild + Warn, age-gated orphan sweep (swept when aged, spared when young), and concurrent post-recovery read/write under `-race`.

## Verification

`gofmt -s`, `go vet`, `golangci-lint`, `go build ./...`, `GOOS=windows go build ./pkg/block/journal/...`, and `go test -race ./pkg/block/journal/...` (32 pass) all green locally. The journal package is still unwired, so heavy e2e/smbtorture suites don't exercise it.

Part of #1692