### PR TITLE
perf(block): journal chunk-at-carve — FastCDC+BLAKE3+dedup + in-place synced flip (Wall A PR4)

### DIFF
--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -291,35 +291,97 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 	return flush(run[len(run)-1].end())
 }
 
-// flipUpTo marks every not-yet-flipped record in run whose live range ends at or
-// before watermark as synced: a one-byte pwrite of the synced flag at the
-// record's SegOffset (no fsync — a lost flip just re-carves), then the matching
-// in-memory interval is marked synced. A concurrent overwrite that replaced the
-// record since the snapshot leaves findRecord empty; the physical flip lands on
-// the now-dead record (harmless) and the newer write carves next pass.
+// flipUpTo advances the durable frontier to watermark. It marks each live
+// interval fragment whose range ends there as synced in memory, then flips a
+// physical record's on-disk synced bit — but only once none of that record's
+// live fragments remain dirty.
+//
+// The distinction is load-bearing. A newer overlapping write splits one physical
+// record into several live fragments that can become durable in different
+// flushes, yet the on-disk synced bit is a single record-level flag that
+// recovery replays over the record's whole original range. Flipping it after
+// only the first fragment is durable would, on a crash, make recovery treat the
+// record's still-dirty fragments as synced — silent data loss. So the bit is set
+// strictly after the record has no dirty live coverage left.
+//
+// The flip is a read-modify-write of the flags byte (preserving tombstone / any
+// other bits) with no fsync — a lost flip just re-carves, which dedup makes a
+// no-op. A concurrent overwrite that replaced a fragment since the snapshot
+// leaves findRecord empty; the newer record carves next pass.
 func (s *Store) flipUpTo(sh *shard, id FileID, run []interval, flipIdx *int, watermark int64) error {
 	sh.mu.Lock()
 	defer sh.mu.Unlock()
 	fi := sh.index[id]
+
+	type recKey struct {
+		seg uint64
+		off int64
+	}
+	touched := map[recKey]struct{}{}
 	for *flipIdx < len(run) && run[*flipIdx].end() <= watermark {
 		iv := run[*flipIdx]
 		*flipIdx++
-		seg := sh.segment(iv.loc.SegmentID)
+		if fi == nil {
+			continue
+		}
+		if k := fi.findRecord(iv.fileOff, iv.version); k >= 0 && !fi.ivs[k].synced {
+			fi.ivs[k].synced = true
+			s.unsynced.Add(-fi.ivs[k].length)
+			touched[recKey{iv.loc.SegmentID, iv.recOff}] = struct{}{}
+		}
+	}
+
+	for rk := range touched {
+		if recordHasDirtyFragment(fi, rk.seg, rk.off) {
+			continue // a live fragment of this record is not durable yet
+		}
+		seg := sh.segment(rk.seg)
 		if seg == nil {
 			continue // segment relocated/evicted (later PRs); nothing to flip
 		}
-		if _, err := seg.fd.WriteAt([]byte{flagSynced}, iv.recOff+recordFlagsOffset); err != nil {
-			return fmt.Errorf("journal: flip synced seg %d rec %d: %w", iv.loc.SegmentID, iv.recOff, err)
+		flipped, err := flipRecordSynced(seg, rk.off)
+		if err != nil {
+			return err
 		}
-		if fi != nil {
-			if k := fi.findRecord(iv.fileOff, iv.version); k >= 0 && !fi.ivs[k].synced {
-				fi.ivs[k].synced = true
-				s.unsynced.Add(-fi.ivs[k].length)
-				seg.syncedRecords.Add(1)
-			}
+		if flipped {
+			seg.syncedRecords.Add(1)
 		}
 	}
 	return nil
+}
+
+// recordHasDirtyFragment reports whether any live interval still backed by the
+// given physical record (segment + record offset) is dirty. Caller holds sh.mu.
+func recordHasDirtyFragment(fi *fileIndex, seg uint64, recOff int64) bool {
+	if fi == nil {
+		return false
+	}
+	for k := range fi.ivs {
+		if fi.ivs[k].loc.SegmentID == seg && fi.ivs[k].recOff == recOff &&
+			!fi.ivs[k].synced && !fi.ivs[k].cold {
+			return true
+		}
+	}
+	return false
+}
+
+// flipRecordSynced sets a record's on-disk synced bit with a one-byte
+// read-modify-write, preserving any other flag bits. It returns false without
+// writing when the bit is already set. The header CRC excludes Flags, so no CRC
+// rewrite is needed.
+func flipRecordSynced(seg *segmentMeta, recOff int64) (bool, error) {
+	var b [1]byte
+	if _, err := seg.fd.ReadAt(b[:], recOff+recordFlagsOffset); err != nil {
+		return false, fmt.Errorf("journal: read record flags seg %d off %d: %w", seg.id, recOff, err)
+	}
+	if b[0]&flagSynced != 0 {
+		return false, nil
+	}
+	b[0] |= flagSynced
+	if _, err := seg.fd.WriteAt(b[:], recOff+recordFlagsOffset); err != nil {
+		return false, fmt.Errorf("journal: flip synced seg %d off %d: %w", seg.id, recOff, err)
+	}
+	return true, nil
 }
 
 // maybeResetDirtyClock clears a file's dirty-age marker once no dirty interval

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -1,13 +1,78 @@
 package journal
 
-// Carve packs dirty ranges into fixed-size remote blocks. The flow (not yet
-// implemented): snapshot covering dirty intervals for files whose dirty-byte
-// count crosses CarveBlockSize or whose oldest dirty record exceeds
-// CarveMaxAge; stream those bytes in file-offset order through
-// FastCDC -> BLAKE3 -> per-share dedup; PutBlock the novel chunks; atomically
-// commit the block records; then flip each carved record's synced flag in place
-// with a one-byte pwrite. Flipping strictly after the commit means a crash in
-// between costs one harmless re-carve, never data loss.
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/block/chunker"
+)
+
+// Carve packs a shard's dirty ranges into fixed-size remote blocks and marks the
+// records it moved as synced. The flow, per file:
+//
+//  1. Under the shard lock, snapshot the file's live dirty intervals (synced=false,
+//     non-cold) in file-offset order, then release the lock so the CDC and upload
+//     run without blocking appends.
+//  2. Stream the dirty bytes through FastCDC -> BLAKE3 -> per-share dedup; novel
+//     chunks accumulate into a block-sized batch.
+//  3. At CarveBlockSize (or the end of a contiguous run) hand the novel chunks to
+//     the sink, which seals, frames, uploads and atomically commits them.
+//  4. Only after the commit returns, flip each carved record's synced flag in
+//     place with a one-byte pwrite (the header CRC excludes Flags, so no rewrite).
+//
+// Flipping strictly after the commit is the crash-safety invariant: a crash
+// between the two leaves the records synced=false, so restart re-carves them, and
+// content-addressed dedup makes the re-commit a no-op. The reverse order could
+// mark records durable that never reached the remote — data loss — so it is never
+// done.
+
+// ChunkHash is the BLAKE3-256 content hash of a chunk's plaintext. Carve computes
+// it so the deduper and the sink key on identical bytes without journal importing
+// pkg/block's ContentHash.
+type ChunkHash [32]byte
+
+// Deduper reports whether a chunk is already durable on the remote store. Carve
+// skips packing a chunk it reports present and still marks the covering records
+// synced (the bytes are provably remote). Production wiring backs this with the
+// per-share synced-hash oracle: a true result MUST mean "remote-durable", never
+// merely "seen locally", or a flip could clean bytes that never reached remote.
+type Deduper interface {
+	IsChunkDurable(ctx context.Context, hash ChunkHash) (bool, error)
+}
+
+// CarveChunk is one content-defined chunk handed to the sink for packing.
+type CarveChunk struct {
+	Hash       ChunkHash
+	FileID     FileID
+	FileOffset int64  // logical offset of the chunk within the file
+	Data       []byte // plaintext; the sink seals it before framing
+}
+
+// BlockSink seals, frames, uploads (PutBlock) and atomically commits one block's
+// worth of novel chunks — every step that touches pkg/block, blockcodec and the
+// metadata store, kept behind this interface so journal stays standalone.
+// CommitBlock is atomic: a non-nil error means nothing became durable, so carve
+// leaves the covered records dirty to re-carve next pass. Content-addressed
+// commit makes a re-carve after a crash (or a duplicate concurrent carve) a
+// no-op.
+type BlockSink interface {
+	CommitBlock(ctx context.Context, chunks []CarveChunk) error
+}
+
+// errCarveNotWired is returned by Carve when the dedup/sink collaborators have
+// not been injected via SetCarveTargets.
+var errCarveNotWired = errors.New("journal: carve targets not wired (SetCarveTargets)")
+
+// SetCarveTargets injects the carve collaborators. Call once before the first
+// Carve; the production impls are wired here at PR7, tests pass fakes.
+func (s *Store) SetCarveTargets(d Deduper, sink BlockSink) {
+	s.deduper = d
+	s.sink = sink
+}
 
 // CarveOptions selects what an explicit Carve targets.
 type CarveOptions struct {
@@ -21,4 +86,286 @@ type CarveOptions struct {
 type CarveResult struct {
 	BlocksWritten int
 	BytesCarved   int64
+}
+
+// Carve packs eligible files' dirty ranges into remote blocks and flips their
+// records to synced. A file is eligible when its dirty-byte count crosses
+// CarveBlockSize, its oldest dirty record is older than CarveMaxAge, or opts.Force
+// is set. It returns the first error encountered but continues past a per-file
+// failure so one bad file does not strand the rest; failed files stay dirty.
+func (s *Store) Carve(ctx context.Context, opts CarveOptions) (CarveResult, error) {
+	var res CarveResult
+	if err := ctx.Err(); err != nil {
+		return res, err
+	}
+	if s.closed.Load() {
+		return res, errClosed
+	}
+	if s.sink == nil || s.deduper == nil {
+		return res, errCarveNotWired
+	}
+
+	shards := s.shards
+	if opts.FileID != "" {
+		shards = []*shard{s.shardFor(opts.FileID)}
+	}
+	now := s.clock.Now().UnixNano()
+	maxAge := int64(s.cfg.CarveMaxAge)
+
+	var firstErr error
+	for _, sh := range shards {
+		if err := ctx.Err(); err != nil {
+			return res, err
+		}
+		// Serialize this shard's carve against a concurrent carve pass; appends
+		// still proceed (they take sh.mu, which carve only grabs briefly).
+		sh.carveMu.Lock()
+		for _, id := range s.carveCandidates(sh, opts, now, maxAge) {
+			if err := ctx.Err(); err != nil {
+				sh.carveMu.Unlock()
+				return res, err
+			}
+			if err := s.carveFile(ctx, sh, id, &res); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		sh.carveMu.Unlock()
+	}
+	return res, firstErr
+}
+
+// carveCandidates returns the shard's files that meet the carve trigger. Held
+// under sh.mu; the O(intervals) dirty-byte scan is fine because carve is a
+// background/explicit pass, not a hot path.
+func (s *Store) carveCandidates(sh *shard, opts CarveOptions, now, maxAge int64) []FileID {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+
+	var out []FileID
+	eligible := func(id FileID, fi *fileIndex) {
+		if fi == nil {
+			return
+		}
+		var dirty int64
+		for k := range fi.ivs {
+			if !fi.ivs[k].synced && !fi.ivs[k].cold {
+				dirty += fi.ivs[k].length
+			}
+		}
+		if dirty == 0 {
+			return
+		}
+		aged := fi.firstDirtyNanos != 0 && now-fi.firstDirtyNanos >= maxAge
+		if opts.Force || dirty >= s.cfg.CarveBlockSize || aged {
+			out = append(out, id)
+		}
+	}
+	if opts.FileID != "" {
+		eligible(opts.FileID, sh.index[opts.FileID])
+		return out
+	}
+	for id, fi := range sh.index {
+		eligible(id, fi)
+	}
+	return out
+}
+
+// carveFile snapshots one file's live dirty intervals, splits them into maximal
+// contiguous runs (a hole resets FastCDC), and carves each run.
+func (s *Store) carveFile(ctx context.Context, sh *shard, id FileID, res *CarveResult) error {
+	sh.mu.Lock()
+	fi := sh.index[id]
+	var snap []interval
+	if fi != nil {
+		for _, iv := range fi.ivs {
+			if !iv.synced && !iv.cold {
+				snap = append(snap, iv)
+			}
+		}
+	}
+	sh.mu.Unlock()
+	if len(snap) == 0 {
+		return nil
+	}
+
+	for start := 0; start < len(snap); {
+		end := start + 1
+		for end < len(snap) && snap[end].fileOff == snap[end-1].end() {
+			end++
+		}
+		if err := s.carveRun(ctx, sh, id, snap[start:end], res); err != nil {
+			return err
+		}
+		start = end
+	}
+	s.maybeResetDirtyClock(sh, id)
+	return nil
+}
+
+// carveRun streams one contiguous dirty run through FastCDC, dedups each chunk,
+// packs novel chunks into blocks (flushed at CarveBlockSize and at the run's end),
+// and flips the run's records to synced as the durable frontier advances.
+func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interval, res *CarveResult) error {
+	c := chunker.NewChunker()
+	rr := &runReader{s: s, sh: sh, ivs: run}
+
+	fileOff := run[0].fileOff
+	flipIdx := 0
+	var pending []CarveChunk
+	var pendingBytes int64
+
+	// flush commits the buffered novel chunks (if any) then, since everything up
+	// to watermark is now durable, flips the run's records that end there. The
+	// commit strictly precedes the flip: that is the crash-safety ordering.
+	flush := func(watermark int64) error {
+		if len(pending) > 0 {
+			if err := s.sink.CommitBlock(ctx, pending); err != nil {
+				return err
+			}
+			res.BlocksWritten++
+			pending = nil
+			pendingBytes = 0
+		}
+		return s.flipUpTo(sh, id, run, &flipIdx, watermark)
+	}
+
+	// buf accumulates bytes for the chunker; it never exceeds one max chunk, so
+	// RAM stays at FastCDC-chunk scale even for a multi-GiB run.
+	buf := make([]byte, 0, chunker.MaxChunkSize)
+	readBuf := make([]byte, 256<<10)
+	eof := false
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		for !eof && len(buf) < chunker.MaxChunkSize {
+			n, err := rr.Read(readBuf)
+			if n > 0 {
+				buf = append(buf, readBuf[:n]...)
+			}
+			if errors.Is(err, io.EOF) {
+				eof = true
+				break
+			}
+			if err != nil {
+				return err
+			}
+		}
+		if len(buf) == 0 {
+			break
+		}
+		boundary, _ := c.Next(buf, eof)
+		if boundary == 0 {
+			if !eof {
+				continue // below MinChunkSize and more is coming: read more
+			}
+			boundary = len(buf)
+		}
+
+		h := ChunkHash(blake3.Sum256(buf[:boundary]))
+		durable, err := s.deduper.IsChunkDurable(ctx, h)
+		if err != nil {
+			return err
+		}
+		if !durable {
+			data := make([]byte, boundary)
+			copy(data, buf[:boundary])
+			pending = append(pending, CarveChunk{Hash: h, FileID: id, FileOffset: fileOff, Data: data})
+			pendingBytes += int64(boundary)
+			res.BytesCarved += int64(boundary)
+		}
+		fileOff += int64(boundary)
+		buf = append(buf[:0], buf[boundary:]...)
+
+		if pendingBytes >= s.cfg.CarveBlockSize {
+			if err := flush(fileOff); err != nil {
+				return err
+			}
+		}
+		if eof && len(buf) == 0 {
+			break
+		}
+	}
+	// Tail: commit any remainder and flip through the end of the run (records
+	// covered only by already-durable chunks flip here too).
+	return flush(run[len(run)-1].end())
+}
+
+// flipUpTo marks every not-yet-flipped record in run whose live range ends at or
+// before watermark as synced: a one-byte pwrite of the synced flag at the
+// record's SegOffset (no fsync — a lost flip just re-carves), then the matching
+// in-memory interval is marked synced. A concurrent overwrite that replaced the
+// record since the snapshot leaves findRecord empty; the physical flip lands on
+// the now-dead record (harmless) and the newer write carves next pass.
+func (s *Store) flipUpTo(sh *shard, id FileID, run []interval, flipIdx *int, watermark int64) error {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	fi := sh.index[id]
+	for *flipIdx < len(run) && run[*flipIdx].end() <= watermark {
+		iv := run[*flipIdx]
+		*flipIdx++
+		seg := sh.segment(iv.loc.SegmentID)
+		if seg == nil {
+			continue // segment relocated/evicted (later PRs); nothing to flip
+		}
+		if _, err := seg.fd.WriteAt([]byte{flagSynced}, iv.recOff+recordFlagsOffset); err != nil {
+			return fmt.Errorf("journal: flip synced seg %d rec %d: %w", iv.loc.SegmentID, iv.recOff, err)
+		}
+		if fi != nil {
+			if k := fi.findRecord(iv.fileOff, iv.version); k >= 0 && !fi.ivs[k].synced {
+				fi.ivs[k].synced = true
+				s.unsynced.Add(-fi.ivs[k].length)
+				seg.syncedRecords.Add(1)
+			}
+		}
+	}
+	return nil
+}
+
+// maybeResetDirtyClock clears a file's dirty-age marker once no dirty interval
+// remains, so a later dirty write re-stamps a fresh age.
+func (s *Store) maybeResetDirtyClock(sh *shard, id FileID) {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	fi := sh.index[id]
+	if fi == nil {
+		return
+	}
+	for k := range fi.ivs {
+		if !fi.ivs[k].synced && !fi.ivs[k].cold {
+			return
+		}
+	}
+	fi.firstDirtyNanos = 0
+}
+
+// runReader streams a contiguous run's live bytes in file-offset order by
+// preading each interval's payload. It reuses the store's positioned-read path so
+// reads race nothing (segment fds are stable once created).
+type runReader struct {
+	s   *Store
+	sh  *shard
+	ivs []interval
+	i   int   // current interval
+	off int64 // bytes already read from the current interval
+}
+
+func (rr *runReader) Read(p []byte) (int, error) {
+	for rr.i < len(rr.ivs) {
+		iv := rr.ivs[rr.i]
+		remain := iv.length - rr.off
+		if remain <= 0 {
+			rr.i++
+			rr.off = 0
+			continue
+		}
+		n := int64(len(p))
+		if n > remain {
+			n = remain
+		}
+		got, err := rr.s.readPayload(rr.sh, iv.loc, rr.off, p[:n])
+		rr.off += int64(got)
+		return got, err
+	}
+	return 0, io.EOF
 }

--- a/pkg/block/journal/carve_test.go
+++ b/pkg/block/journal/carve_test.go
@@ -1,0 +1,478 @@
+package journal
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeClock is a settable Clock for the age-gate tests.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock() *fakeClock { return &fakeClock{now: time.Unix(1_000_000, 0)} }
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(d)
+	c.mu.Unlock()
+}
+
+// fakeDeduper models the remote-durable oracle: a hash is durable once a block
+// carrying it has committed. Safe for concurrent use.
+type fakeDeduper struct {
+	mu      sync.Mutex
+	durable map[ChunkHash]bool
+}
+
+func newFakeDeduper() *fakeDeduper { return &fakeDeduper{durable: map[ChunkHash]bool{}} }
+
+func (d *fakeDeduper) IsChunkDurable(_ context.Context, h ChunkHash) (bool, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.durable[h], nil
+}
+
+func (d *fakeDeduper) markDurable(h ChunkHash) {
+	d.mu.Lock()
+	d.durable[h] = true
+	d.mu.Unlock()
+}
+
+// fakeSink records every committed chunk and, on success, marks its hash durable
+// in the paired deduper (so a later carve dedups it). failErr and onCommit let a
+// test force a commit failure or assert store state at commit time.
+type fakeSink struct {
+	mu       sync.Mutex
+	dedup    *fakeDeduper
+	blocks   int
+	chunks   map[int64][]byte // fileOffset -> plaintext
+	failErr  error
+	onCommit func(chunks []CarveChunk)
+}
+
+func newFakeSink(d *fakeDeduper) *fakeSink {
+	return &fakeSink{dedup: d, chunks: map[int64][]byte{}}
+}
+
+func (s *fakeSink) CommitBlock(_ context.Context, chunks []CarveChunk) error {
+	s.mu.Lock()
+	hook := s.onCommit
+	failErr := s.failErr
+	s.mu.Unlock()
+	if hook != nil {
+		hook(chunks)
+	}
+	if failErr != nil {
+		return failErr
+	}
+	s.mu.Lock()
+	s.blocks++
+	for _, c := range chunks {
+		cp := make([]byte, len(c.Data))
+		copy(cp, c.Data)
+		s.chunks[c.FileOffset] = cp
+		s.dedup.markDurable(c.Hash)
+	}
+	s.mu.Unlock()
+	return nil
+}
+
+// carved reassembles every committed chunk in file-offset order.
+func (s *fakeSink) carved() []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	offs := make([]int64, 0, len(s.chunks))
+	for off := range s.chunks {
+		offs = append(offs, off)
+	}
+	// simple insertion sort — a handful of chunks per test
+	for i := 1; i < len(offs); i++ {
+		for j := i; j > 0 && offs[j-1] > offs[j]; j-- {
+			offs[j-1], offs[j] = offs[j], offs[j-1]
+		}
+	}
+	var out []byte
+	for _, off := range offs {
+		out = append(out, s.chunks[off]...)
+	}
+	return out
+}
+
+func (s *fakeSink) blockCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.blocks
+}
+
+// carveStore opens a store with the fakes wired and a controllable clock.
+func carveStore(t *testing.T, cfg Config) (*Store, *fakeDeduper, *fakeSink, *fakeClock) {
+	t.Helper()
+	clk := newFakeClock()
+	s, err := Open(t.TempDir(), cfg, newFakeRemote(), clk)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	dd := newFakeDeduper()
+	sink := newFakeSink(dd)
+	s.SetCarveTargets(dd, sink)
+	return s, dd, sink, clk
+}
+
+func randBytes(n int, seed int64) []byte {
+	b := make([]byte, n)
+	rand.New(rand.NewSource(seed)).Read(b)
+	return b
+}
+
+// recRawFlags reads the on-disk Flags byte of the record covering fileOff.
+func recRawFlags(t *testing.T, s *Store, id FileID, fileOff int64) uint8 {
+	t.Helper()
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	fi := sh.index[id]
+	if fi == nil {
+		t.Fatalf("no index for %q", id)
+	}
+	for _, iv := range fi.ivs {
+		if iv.fileOff <= fileOff && fileOff < iv.end() {
+			seg := sh.segment(iv.loc.SegmentID)
+			var b [1]byte
+			if _, err := seg.fd.ReadAt(b[:], iv.recOff+recordFlagsOffset); err != nil {
+				t.Fatalf("read flags: %v", err)
+			}
+			return b[0]
+		}
+	}
+	t.Fatalf("no interval covering offset %d", fileOff)
+	return 0
+}
+
+// forceDirty simulates a crash between commit and flip: the records go back to
+// synced=false (on disk and in memory) while the deduper keeps the committed
+// hashes, so a re-carve must dedup to a no-op.
+func forceDirty(t *testing.T, s *Store, id FileID) {
+	t.Helper()
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	fi := sh.index[id]
+	for k := range fi.ivs {
+		iv := fi.ivs[k]
+		seg := sh.segment(iv.loc.SegmentID)
+		if _, err := seg.fd.WriteAt([]byte{0}, iv.recOff+recordFlagsOffset); err != nil {
+			t.Fatalf("clear flag: %v", err)
+		}
+		if fi.ivs[k].synced {
+			fi.ivs[k].synced = false
+			s.unsynced.Add(fi.ivs[k].length)
+		}
+	}
+	fi.firstDirtyNanos = s.clock.Now().UnixNano()
+}
+
+func TestCarveRoundTripAndFlip(t *testing.T) {
+	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 1 << 20})
+	ctx := context.Background()
+
+	data := randBytes(3<<20, 1) // ~3 MiB -> several chunks -> multiple blocks
+	if err := s.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if s.UnsyncedBytes() != int64(len(data)) {
+		t.Fatalf("pre-carve unsynced=%d want %d", s.UnsyncedBytes(), len(data))
+	}
+
+	res, err := s.Carve(ctx, CarveOptions{Force: true})
+	if err != nil {
+		t.Fatalf("Carve: %v", err)
+	}
+	if res.BlocksWritten < 1 || res.BytesCarved != int64(len(data)) {
+		t.Fatalf("result=%+v want blocks>=1 bytes=%d", res, len(data))
+	}
+	if got := sink.carved(); string(got) != string(data) {
+		t.Fatalf("carved bytes mismatch: got %d bytes", len(got))
+	}
+	// Records are now synced: counter drained and the on-disk flag is set.
+	if s.UnsyncedBytes() != 0 {
+		t.Fatalf("post-carve unsynced=%d want 0", s.UnsyncedBytes())
+	}
+	if f := recRawFlags(t, s, "f", 0); f&flagSynced == 0 {
+		t.Fatalf("record not flipped synced on disk: flags=%#x", f)
+	}
+	// Warm read still returns the data unchanged.
+	got := make([]byte, len(data))
+	if _, cold, err := s.ReadAt(ctx, "f", 0, got); err != nil || cold {
+		t.Fatalf("ReadAt: err=%v cold=%v", err, cold)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("warm read mismatch after carve")
+	}
+}
+
+func TestCarveCommitStrictlyBeforeFlip(t *testing.T) {
+	// One sub-CarveBlockSize file -> exactly one block, flushed at run end. At the
+	// moment CommitBlock runs, nothing may be flipped yet.
+	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 8 << 20})
+	ctx := context.Background()
+	data := randBytes(512<<10, 2)
+	if err := s.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatal(err)
+	}
+
+	var checked bool
+	sink.onCommit = func(chunks []CarveChunk) {
+		checked = true
+		if s.UnsyncedBytes() != int64(len(data)) {
+			t.Errorf("flip happened before commit: unsynced=%d want %d", s.UnsyncedBytes(), len(data))
+		}
+		if f := recRawFlags(t, s, "f", 0); f&flagSynced != 0 {
+			t.Errorf("record already flipped at commit time: flags=%#x", f)
+		}
+	}
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err != nil {
+		t.Fatalf("Carve: %v", err)
+	}
+	if !checked {
+		t.Fatalf("commit hook never ran")
+	}
+	if s.UnsyncedBytes() != 0 {
+		t.Fatalf("post-carve unsynced=%d want 0", s.UnsyncedBytes())
+	}
+}
+
+func TestCarveSinkErrorLeavesDirty(t *testing.T) {
+	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 1 << 20})
+	ctx := context.Background()
+	data := randBytes(1<<20, 3)
+	if err := s.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatal(err)
+	}
+	sink.failErr = errors.New("boom")
+
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err == nil {
+		t.Fatalf("expected carve error from failing sink")
+	}
+	if s.UnsyncedBytes() != int64(len(data)) {
+		t.Fatalf("failed carve changed unsynced=%d want %d", s.UnsyncedBytes(), len(data))
+	}
+	if f := recRawFlags(t, s, "f", 0); f&flagSynced != 0 {
+		t.Fatalf("record flipped despite commit failure: flags=%#x", f)
+	}
+}
+
+func TestCarveDedupReCarveIsNoOp(t *testing.T) {
+	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 1 << 20})
+	ctx := context.Background()
+	data := randBytes(2<<20, 4)
+	if err := s.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err != nil {
+		t.Fatalf("first carve: %v", err)
+	}
+	first := sink.blockCount()
+	if first < 1 {
+		t.Fatalf("first carve wrote no block")
+	}
+
+	// Simulate a crash between commit and flip: records dirty again, hashes still
+	// durable. The re-carve must upload nothing (dedup no-op) but re-flip.
+	forceDirty(t, s, "f")
+	res, err := s.Carve(ctx, CarveOptions{Force: true})
+	if err != nil {
+		t.Fatalf("re-carve: %v", err)
+	}
+	if res.BlocksWritten != 0 || res.BytesCarved != 0 {
+		t.Fatalf("re-carve was not a dedup no-op: %+v", res)
+	}
+	if sink.blockCount() != first {
+		t.Fatalf("re-carve committed extra blocks: %d -> %d", first, sink.blockCount())
+	}
+	if s.UnsyncedBytes() != 0 {
+		t.Fatalf("re-carve did not re-flip: unsynced=%d", s.UnsyncedBytes())
+	}
+	if f := recRawFlags(t, s, "f", 0); f&flagSynced == 0 {
+		t.Fatalf("re-carve did not re-flip on disk: flags=%#x", f)
+	}
+}
+
+func TestCarveReopenReCarveIsNoOp(t *testing.T) {
+	// Full crash simulation: carve durably (deduper populated), then lose only the
+	// on-disk synced flips, close, reopen, and carve again. Recovery must replay
+	// the records with the correct SegOffset so the re-flip lands on the record —
+	// not the segment header — and dedup must make the re-carve upload-free.
+	dir := t.TempDir()
+	clk := newFakeClock()
+	dd := newFakeDeduper()
+	data := randBytes(2<<20, 11)
+
+	s1, err := Open(dir, Config{CarveBlockSize: 1 << 20}, newFakeRemote(), clk)
+	if err != nil {
+		t.Fatalf("Open s1: %v", err)
+	}
+	s1.SetCarveTargets(dd, newFakeSink(dd))
+	ctx := context.Background()
+	if err := s1.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s1.Carve(ctx, CarveOptions{Force: true}); err != nil {
+		t.Fatalf("carve s1: %v", err)
+	}
+	// Simulate the flip never reaching disk (crash between commit and flip).
+	forceDirty(t, s1, "f")
+	_ = s1.Close()
+
+	// Reopen: recovery rebuilds the index from the (now dirty) records.
+	s2, err := Open(dir, Config{CarveBlockSize: 1 << 20}, newFakeRemote(), clk)
+	if err != nil {
+		t.Fatalf("Open s2: %v", err)
+	}
+	defer func() { _ = s2.Close() }()
+	if s2.UnsyncedBytes() != int64(len(data)) {
+		t.Fatalf("recovered unsynced=%d want %d", s2.UnsyncedBytes(), len(data))
+	}
+	sink2 := newFakeSink(dd)
+	s2.SetCarveTargets(dd, sink2)
+
+	res, err := s2.Carve(ctx, CarveOptions{Force: true})
+	if err != nil {
+		t.Fatalf("re-carve after reopen: %v", err)
+	}
+	if res.BlocksWritten != 0 || res.BytesCarved != 0 || sink2.blockCount() != 0 {
+		t.Fatalf("reopen re-carve was not a dedup no-op: %+v blocks=%d", res, sink2.blockCount())
+	}
+	if s2.UnsyncedBytes() != 0 {
+		t.Fatalf("reopen re-carve did not re-flip: unsynced=%d", s2.UnsyncedBytes())
+	}
+	if f := recRawFlags(t, s2, "f", 0); f&flagSynced == 0 {
+		t.Fatalf("reopen re-carve did not flip record on disk: flags=%#x", f)
+	}
+	// The data is intact and the segment header is unharmed (a mis-targeted flip
+	// at offset 24 would corrupt it and fail the read).
+	got := make([]byte, len(data))
+	if _, _, err := s2.ReadAt(ctx, "f", 0, got); err != nil || string(got) != string(data) {
+		t.Fatalf("data corrupted after reopen re-carve: err=%v", err)
+	}
+}
+
+func TestCarveSizeTrigger(t *testing.T) {
+	// Small, recent write with no Force stays put; crossing CarveBlockSize carves.
+	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 2 << 20, CarveMaxAge: time.Hour})
+	ctx := context.Background()
+
+	if err := s.WriteAt(ctx, "f", 0, randBytes(512<<10, 5)); err != nil {
+		t.Fatal(err)
+	}
+	if res, err := s.Carve(ctx, CarveOptions{}); err != nil || res.BlocksWritten != 0 {
+		t.Fatalf("sub-threshold recent file should not carve: res=%+v err=%v", res, err)
+	}
+	if s.UnsyncedBytes() == 0 {
+		t.Fatalf("sub-threshold file was carved")
+	}
+
+	// Cross the threshold; now it is eligible without Force.
+	if err := s.WriteAt(ctx, "f", 512<<10, randBytes(2<<20, 6)); err != nil {
+		t.Fatal(err)
+	}
+	if res, err := s.Carve(ctx, CarveOptions{}); err != nil || res.BlocksWritten == 0 {
+		t.Fatalf("over-threshold file should carve: res=%+v err=%v", res, err)
+	}
+	if s.UnsyncedBytes() != 0 {
+		t.Fatalf("over-threshold carve left dirty bytes: %d", s.UnsyncedBytes())
+	}
+	if sink.blockCount() == 0 {
+		t.Fatalf("no block committed on size trigger")
+	}
+}
+
+func TestCarveAgeTrigger(t *testing.T) {
+	s, _, _, clk := carveStore(t, Config{CarveBlockSize: 64 << 20, CarveMaxAge: 5 * time.Second})
+	ctx := context.Background()
+
+	if err := s.WriteAt(ctx, "f", 0, randBytes(256<<10, 7)); err != nil {
+		t.Fatal(err)
+	}
+	// Fresh: below size, within age -> no carve.
+	if res, err := s.Carve(ctx, CarveOptions{}); err != nil || res.BlocksWritten != 0 {
+		t.Fatalf("fresh sub-threshold file should not carve: res=%+v err=%v", res, err)
+	}
+	// Age it past CarveMaxAge -> eligible.
+	clk.advance(10 * time.Second)
+	if res, err := s.Carve(ctx, CarveOptions{}); err != nil || res.BlocksWritten == 0 {
+		t.Fatalf("aged file should carve: res=%+v err=%v", res, err)
+	}
+	if s.UnsyncedBytes() != 0 {
+		t.Fatalf("aged carve left dirty bytes: %d", s.UnsyncedBytes())
+	}
+}
+
+func TestCarveNotWired(t *testing.T) {
+	s := testStore(t, Config{})
+	if _, err := s.Carve(context.Background(), CarveOptions{Force: true}); !errors.Is(err, errCarveNotWired) {
+		t.Fatalf("expected errCarveNotWired, got %v", err)
+	}
+}
+
+func TestCarveConcurrentOverwrite(t *testing.T) {
+	s, _, _, _ := carveStore(t, Config{CarveBlockSize: 1 << 20})
+	ctx := context.Background()
+
+	const size = 4 << 20
+	if err := s.WriteAt(ctx, "f", 0, randBytes(size, 8)); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	// Writer: overwrite random 64 KiB windows until told to stop.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		rng := rand.New(rand.NewSource(99))
+		buf := make([]byte, 64<<10)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			off := int64(rng.Intn(size-len(buf))) &^ 0xFFF
+			rng.Read(buf)
+			_ = s.WriteAt(ctx, "f", off, buf)
+		}
+	}()
+	// Carver runs its passes inline against the live writer.
+	for i := 0; i < 50; i++ {
+		if _, err := s.Carve(ctx, CarveOptions{FileID: "f", Force: true}); err != nil {
+			t.Errorf("concurrent carve: %v", err)
+			break
+		}
+	}
+	close(stop)
+	wg.Wait()
+
+	// A final pass drains whatever the last overwrite left dirty.
+	if _, err := s.Carve(ctx, CarveOptions{FileID: "f", Force: true}); err != nil {
+		t.Fatalf("final carve: %v", err)
+	}
+	// Data must still read back at full length without error.
+	got := make([]byte, size)
+	if _, _, err := s.ReadAt(ctx, "f", 0, got); err != nil {
+		t.Fatalf("ReadAt after concurrent carve: %v", err)
+	}
+}

--- a/pkg/block/journal/carve_test.go
+++ b/pkg/block/journal/carve_test.go
@@ -54,12 +54,13 @@ func (d *fakeDeduper) markDurable(h ChunkHash) {
 // in the paired deduper (so a later carve dedups it). failErr and onCommit let a
 // test force a commit failure or assert store state at commit time.
 type fakeSink struct {
-	mu       sync.Mutex
-	dedup    *fakeDeduper
-	blocks   int
-	chunks   map[int64][]byte // fileOffset -> plaintext
-	failErr  error
-	onCommit func(chunks []CarveChunk)
+	mu        sync.Mutex
+	dedup     *fakeDeduper
+	blocks    int
+	chunks    map[int64][]byte // fileOffset -> plaintext
+	failErr   error
+	okCommits int // number of commits allowed before failErr kicks in
+	onCommit  func(chunks []CarveChunk)
 }
 
 func newFakeSink(d *fakeDeduper) *fakeSink {
@@ -69,12 +70,13 @@ func newFakeSink(d *fakeDeduper) *fakeSink {
 func (s *fakeSink) CommitBlock(_ context.Context, chunks []CarveChunk) error {
 	s.mu.Lock()
 	hook := s.onCommit
+	fail := s.failErr != nil && s.blocks >= s.okCommits
 	failErr := s.failErr
 	s.mu.Unlock()
 	if hook != nil {
 		hook(chunks)
 	}
-	if failErr != nil {
+	if fail {
 		return failErr
 	}
 	s.mu.Lock()
@@ -155,6 +157,25 @@ func recRawFlags(t *testing.T, s *Store, id FileID, fileOff int64) uint8 {
 				t.Fatalf("read flags: %v", err)
 			}
 			return b[0]
+		}
+	}
+	t.Fatalf("no interval covering offset %d", fileOff)
+	return 0
+}
+
+// recOffAt returns the SegOffset of the record backing fileOff.
+func recOffAt(t *testing.T, s *Store, id FileID, fileOff int64) int64 {
+	t.Helper()
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	fi := sh.index[id]
+	if fi == nil {
+		t.Fatalf("no index for %q", id)
+	}
+	for _, iv := range fi.ivs {
+		if iv.fileOff <= fileOff && fileOff < iv.end() {
+			return iv.recOff
 		}
 	}
 	t.Fatalf("no interval covering offset %d", fileOff)
@@ -308,6 +329,56 @@ func TestCarveDedupReCarveIsNoOp(t *testing.T) {
 	}
 	if f := recRawFlags(t, s, "f", 0); f&flagSynced == 0 {
 		t.Fatalf("re-carve did not re-flip on disk: flags=%#x", f)
+	}
+}
+
+func TestCarveRecordSplitNoPrematureFlip(t *testing.T) {
+	// A newer overlapping write splits one physical record into two live fragments.
+	// If only the first fragment's block commits (the second fails), the record's
+	// on-disk synced bit must stay clear — flipping it while a live fragment is
+	// still dirty would let a crash make recovery treat that dirty fragment as
+	// synced, and its bytes would never carve (data loss).
+	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 1 << 20})
+	ctx := context.Background()
+
+	if err := s.WriteAt(ctx, "f", 0, randBytes(6<<20, 21)); err != nil { // record R = [0,6MiB)
+		t.Fatal(err)
+	}
+	if err := s.WriteAt(ctx, "f", 1<<20, randBytes(1<<20, 22)); err != nil { // split R at [1MiB,2MiB)
+		t.Fatal(err)
+	}
+	// Both surviving fragments must be the same physical record.
+	if a, b := recOffAt(t, s, "f", 0), recOffAt(t, s, "f", 2<<20); a != b {
+		t.Fatalf("fragments not from one record: %d vs %d", a, b)
+	}
+
+	// Let the first block commit, then fail — the [2MiB,6MiB) fragment stays undurable.
+	sink.okCommits = 1
+	sink.failErr = errors.New("second block fails")
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err == nil {
+		t.Fatalf("expected carve to fail on the second block (need >=2 chunks)")
+	}
+	if sink.blockCount() < 1 {
+		t.Fatalf("first block did not commit")
+	}
+	// The record must NOT be flipped: it still has a dirty live fragment.
+	if f := recRawFlags(t, s, "f", 0); f&flagSynced != 0 {
+		t.Fatalf("record flipped while a live fragment is still dirty: flags=%#x", f)
+	}
+	if s.UnsyncedBytes() == 0 {
+		t.Fatalf("dirty fragment not tracked as unsynced after partial carve")
+	}
+
+	// Completing the carve now flips the record and drains the dirty bytes.
+	sink.failErr = nil
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err != nil {
+		t.Fatalf("completing carve: %v", err)
+	}
+	if s.UnsyncedBytes() != 0 {
+		t.Fatalf("record not fully carved after retry: unsynced=%d", s.UnsyncedBytes())
+	}
+	if f := recRawFlags(t, s, "f", 0); f&flagSynced == 0 {
+		t.Fatalf("record not flipped after full carve: flags=%#x", f)
 	}
 }
 

--- a/pkg/block/journal/index.go
+++ b/pkg/block/journal/index.go
@@ -28,6 +28,14 @@ type interval struct {
 	length  int64
 	version uint64
 	loc     SegmentLocation
+	// recOff is the byte offset of the owning record's header start within its
+	// segment. Carve flips that record's synced flag in place at recOff, so it
+	// survives an interval split (trimming the live range never moves the record).
+	recOff int64
+	// synced is true once the bytes are durable on the remote store (a Hydrate
+	// write, or a carved record whose block committed). A dirty (synced=false,
+	// non-cold) interval is what a carve pass snapshots and packs.
+	synced bool
 	// cold marks a range that was written and is durable remotely but whose
 	// local bytes have been evicted. Distinct from an absent interval (a true
 	// hole): a cold range is served by fetching from the remote store.
@@ -45,6 +53,8 @@ func (iv interval) clamp(lo, hi int64) interval {
 		fileOff: lo,
 		length:  hi - lo,
 		version: iv.version,
+		recOff:  iv.recOff,
+		synced:  iv.synced,
 		cold:    iv.cold,
 		loc: SegmentLocation{
 			SegmentID: iv.loc.SegmentID,
@@ -75,6 +85,22 @@ func (iv interval) without(rs, re int64) []interval {
 // rather than an O(n) version scan.
 type fileIndex struct {
 	ivs []interval
+	// firstDirtyNanos is the clock time the file's first still-dirty interval was
+	// recorded (0 when the file is fully synced). It drives the carve age gate
+	// without a per-interval timestamp; carve clears it once no dirty interval
+	// remains. Approximate by design — it is a batching heuristic, not a deadline.
+	firstDirtyNanos int64
+}
+
+// findRecord returns the index of the live interval that starts at or before
+// fileOff, covers it, and carries the given version, or -1 if no such interval
+// exists (it was superseded by a newer write since the caller sampled it).
+func (fi *fileIndex) findRecord(fileOff int64, version uint64) int {
+	k := sort.Search(len(fi.ivs), func(i int) bool { return fi.ivs[i].end() > fileOff })
+	if k < len(fi.ivs) && fi.ivs[k].fileOff <= fileOff && fi.ivs[k].version == version {
+		return k
+	}
+	return -1
 }
 
 // insert records iv, resolving overlaps by version (highest wins). Existing

--- a/pkg/block/journal/index.go
+++ b/pkg/block/journal/index.go
@@ -106,7 +106,10 @@ func (fi *fileIndex) findRecord(fileOff int64, version uint64) int {
 // insert records iv, resolving overlaps by version (highest wins). Existing
 // intervals with a higher version shadow iv; those with a lower version are
 // trimmed to make room. The result stays sorted and non-overlapping.
-func (fi *fileIndex) insert(iv interval) {
+// It returns the number of still-dirty (unsynced, non-cold) live bytes that this
+// insert superseded, so the caller can keep an unsynced-byte counter accurate
+// (dead bytes must leave the count).
+func (fi *fileIndex) insert(iv interval) (dirtyRemoved int64) {
 	ns, ne := iv.fileOff, iv.end()
 	// First interval that can overlap [ns, ne): end() is strictly increasing
 	// across the non-overlapping sorted set, so the predicate is monotone.
@@ -122,7 +125,13 @@ func (fi *fileIndex) insert(iv interval) {
 			survivors = append(survivors, e)
 			newFrags = subtractAll(newFrags, e.fileOff, e.end())
 		} else {
-			// New wins the overlap: keep only the parts of e outside iv.
+			// New wins the overlap: keep only the parts of e outside iv. The
+			// removed slice of a dirty interval leaves the live dirty coverage.
+			if !e.synced && !e.cold {
+				if ov := min(e.end(), ne) - max(e.fileOff, ns); ov > 0 {
+					dirtyRemoved += ov
+				}
+			}
 			survivors = append(survivors, e.without(ns, ne)...)
 		}
 		hi++
@@ -131,6 +140,7 @@ func (fi *fileIndex) insert(iv interval) {
 	merged := append(survivors, newFrags...)
 	sort.Slice(merged, func(i, j int) bool { return merged[i].fileOff < merged[j].fileOff })
 	fi.ivs = slices.Replace(fi.ivs, lo, hi, merged...)
+	return dirtyRemoved
 }
 
 // subtractAll removes [rs, re) from every fragment, flattening the survivors.

--- a/pkg/block/journal/journal_bench_test.go
+++ b/pkg/block/journal/journal_bench_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"sync"
 	"testing"
+	"time"
 )
 
 // fakeRemote is an in-memory RemoteStore for tests and benchmarks. It buffers
@@ -125,11 +126,42 @@ func BenchmarkReadWarm(b *testing.B) {
 	}
 }
 
-// BenchmarkCarve is a placeholder until the carve path lands; it establishes
-// the benchmark name so the baseline gains a carve column with no rewrite.
+// BenchmarkCarve measures the FastCDC+BLAKE3+dedup+commit carve of an 8 MiB file.
+// The deduper always misses and the sink is a no-op, so every pass does the full
+// chunk-hash-pack work (the worst case) rather than short-circuiting on dedup.
 func BenchmarkCarve(b *testing.B) {
-	s := benchStore(b)
-	if _, err := s.Carve(context.Background(), CarveOptions{Force: true}); errors.Is(err, errNotImplemented) {
-		b.Skip("carve not yet implemented")
+	s, err := Open(b.TempDir(), Config{}, newFakeRemote(), newFakeClock())
+	if err != nil {
+		b.Fatalf("Open: %v", err)
+	}
+	b.Cleanup(func() { _ = s.Close() })
+	s.SetCarveTargets(missDeduper{}, nopSink{})
+
+	ctx := context.Background()
+	data := bytes.Repeat([]byte("dittofs-journal-carve-"), (8<<20)/22)
+
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		id := FileID("carve-" + string(rune('a'+i%26)) + time.Duration(i).String())
+		if err := s.WriteAt(ctx, id, 0, data); err != nil {
+			b.Fatalf("seed WriteAt: %v", err)
+		}
+		b.StartTimer()
+		if _, err := s.Carve(ctx, CarveOptions{FileID: id, Force: true}); err != nil {
+			b.Fatalf("Carve: %v", err)
+		}
 	}
 }
+
+// missDeduper reports every chunk novel, forcing the full pack path each pass.
+type missDeduper struct{}
+
+func (missDeduper) IsChunkDurable(context.Context, ChunkHash) (bool, error) { return false, nil }
+
+// nopSink discards committed chunks — the benchmark measures journal's carve
+// work, not a remote round-trip.
+type nopSink struct{}
+
+func (nopSink) CommitBlock(context.Context, []CarveChunk) error { return nil }

--- a/pkg/block/journal/record.go
+++ b/pkg/block/journal/record.go
@@ -36,6 +36,12 @@ const (
 	headerCRCCovers  = 24 // Magic..Version, excludes Flags
 	payloadCRCSize   = 4
 
+	// recordFlagsOffset is the byte offset of the Flags field within a record
+	// header. Carve flips the synced bit here with a single one-byte pwrite; it
+	// equals headerCRCCovers because the CRC deliberately covers only the bytes
+	// before Flags, so the flip never invalidates the header CRC.
+	recordFlagsOffset = headerCRCCovers
+
 	flagSynced    = 1 << 0
 	flagTombstone = 1 << 1
 )

--- a/pkg/block/journal/recovery.go
+++ b/pkg/block/journal/recovery.go
@@ -204,14 +204,11 @@ func (s *Store) recover() error {
 			m.liveBytes.Add(int64(rec.header.PayloadLen))
 			if synced {
 				m.syncedRecords.Add(1)
-			} else {
-				unsynced += int64(rec.header.PayloadLen)
+			} else if fi.firstDirtyNanos == 0 {
 				// A recovered dirty file gets a fresh dirty-age stamp so the carve
 				// age gate fires after a restart (approximate — the original write
 				// time is not persisted; it is only a batching heuristic).
-				if fi.firstDirtyNanos == 0 {
-					fi.firstDirtyNanos = s.clock.Now().UnixNano()
-				}
+				fi.firstDirtyNanos = s.clock.Now().UnixNano()
 			}
 		}
 	}
@@ -224,6 +221,18 @@ func (s *Store) recover() error {
 	// nextVersion increments-then-returns, so storing maxVersion makes the next
 	// issued LSN exactly max(observed)+1 — strictly past every replayed record.
 	s.version.Store(maxVersion)
+	// Recompute unsynced from the final live coverage rather than the raw
+	// per-record sum: insert resolves overlaps, so a superseded record's bytes are
+	// dead and must not count toward the backpressure signal.
+	for _, idxMap := range indexByShard {
+		for _, fi := range idxMap {
+			for k := range fi.ivs {
+				if !fi.ivs[k].synced && !fi.ivs[k].cold {
+					unsynced += fi.ivs[k].length
+				}
+			}
+		}
+	}
 	s.unsynced.Store(unsynced)
 
 	// Give every shard an active segment: reuse a pooled empty one, else mint a

--- a/pkg/block/journal/recovery.go
+++ b/pkg/block/journal/recovery.go
@@ -186,10 +186,13 @@ func (s *Store) recover() error {
 				fi = &fileIndex{}
 				idxMap[fid] = fi
 			}
+			synced := rec.header.Flags&flagSynced != 0
 			fi.insert(interval{
 				fileOff: int64(rec.header.FileOffset),
 				length:  int64(rec.header.PayloadLen),
 				version: rec.header.Version,
+				recOff:  rec.segOff,
+				synced:  synced,
 				loc: SegmentLocation{
 					SegmentID: id,
 					Offset:    payloadOff,
@@ -199,10 +202,16 @@ func (s *Store) recover() error {
 			// Coarse byte accounting: liveBytes ignores same-segment supersession
 			// (GC recomputes deadBytes on repack). unsynced feeds write backpressure.
 			m.liveBytes.Add(int64(rec.header.PayloadLen))
-			if rec.header.Flags&flagSynced != 0 {
+			if synced {
 				m.syncedRecords.Add(1)
 			} else {
 				unsynced += int64(rec.header.PayloadLen)
+				// A recovered dirty file gets a fresh dirty-age stamp so the carve
+				// age gate fires after a restart (approximate — the original write
+				// time is not persisted; it is only a batching heuristic).
+				if fi.firstDirtyNanos == 0 {
+					fi.firstDirtyNanos = s.clock.Now().UnixNano()
+				}
 			}
 		}
 	}

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -288,7 +288,7 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 	}
 
 	fi := sh.indexFor(id)
-	fi.insert(interval{
+	dirtyRemoved := fi.insert(interval{
 		fileOff: offset,
 		length:  int64(len(data)),
 		version: version,
@@ -298,13 +298,20 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 	})
 
 	s.writes.Add(1)
+	// unsynced tracks live dirty bytes: add this write if dirty, and always drop
+	// the dirty bytes this write superseded (they are dead now, not evictable-
+	// pending). A synced (Hydrate) write adds nothing but can still supersede.
+	dirtyDelta := -dirtyRemoved
 	if !synced {
-		s.unsynced.Add(int64(len(data)))
+		dirtyDelta += int64(len(data))
 		// Stamp the file's dirty age on the first dirty record so carve's age gate
 		// has a reference without a per-interval timestamp.
 		if fi.firstDirtyNanos == 0 {
 			fi.firstDirtyNanos = s.clock.Now().UnixNano()
 		}
+	}
+	if dirtyDelta != 0 {
+		s.unsynced.Add(dirtyDelta)
 	}
 	return nil
 }

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -287,16 +287,24 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 		}.encode())
 	}
 
-	sh.indexFor(id).insert(interval{
+	fi := sh.indexFor(id)
+	fi.insert(interval{
 		fileOff: offset,
 		length:  int64(len(data)),
 		version: version,
+		recOff:  segOff,
+		synced:  synced,
 		loc:     SegmentLocation{SegmentID: seg.id, Offset: payloadOff, Length: int64(len(data))},
 	})
 
 	s.writes.Add(1)
 	if !synced {
 		s.unsynced.Add(int64(len(data)))
+		// Stamp the file's dirty age on the first dirty record so carve's age gate
+		// has a reference without a per-interval timestamp.
+		if fi.firstDirtyNanos == 0 {
+			fi.firstDirtyNanos = s.clock.Now().UnixNano()
+		}
 	}
 	return nil
 }

--- a/pkg/block/journal/shard.go
+++ b/pkg/block/journal/shard.go
@@ -29,6 +29,11 @@ type shard struct {
 	active *segmentMeta
 	sealed map[uint64]*segmentMeta
 	index  map[FileID]*fileIndex
+	// carveMu serializes a shard's carve passes: the background flush and an
+	// explicit Carve() never build a block from the same records twice. It is
+	// distinct from mu, which serializes appends and index mutation — carve holds
+	// carveMu across its whole pass but only grabs mu briefly to snapshot and flip.
+	carveMu sync.Mutex
 }
 
 func newShard(active *segmentMeta) *shard {

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -106,6 +106,13 @@ type Store struct {
 	remote RemoteStore
 	clock  Clock
 
+	// deduper and sink are the carve collaborators, injected via SetCarveTargets
+	// at wiring time. They own every step that touches pkg/block, blockcodec and
+	// the metadata store, so journal imports none of them. Set once before the
+	// first Carve; nil until wired (Carve reports the substrate is unwired).
+	deduper Deduper
+	sink    BlockSink
+
 	shards    []*shard
 	shardMask uint64
 
@@ -260,12 +267,6 @@ func (s *Store) Stats() Stats {
 		sh.mu.Unlock()
 	}
 	return st
-}
-
-// Carve packs dirty ranges into remote blocks and flips their records to
-// synced. Not yet implemented.
-func (s *Store) Carve(ctx context.Context, opts CarveOptions) (CarveResult, error) {
-	return CarveResult{}, errNotImplemented
 }
 
 // Evict frees whole sealed segments under storage pressure. Not yet implemented.


### PR DESCRIPTION
## What

Implements `journal.Store.Carve` — the crux of the Wall A "chunk-at-carve, write-once" design. Per eligible file:

1. **Snapshot** the file's live *dirty* (`synced=false`, non-cold) intervals under the shard lock, in file-offset order, then release the lock.
2. **Stream** the dirty bytes in file-offset order through **FastCDC** (reusing `pkg/block/chunker`, byte-identical 1M/4M/16M profile) → **BLAKE3** → **per-share dedup**; novel chunks accumulate into a `CarveBlockSize` (4 MiB) batch.
3. At the block threshold (or end of a contiguous run) hand the novel chunks to the injected **sink**, which seals + frames (`blockcodec`) + `PutBlock`s + atomically commits one block.
4. **Only after** the commit returns, flip each carved record's `synced` flag in place with a single one-byte `pwrite` at the record's `SegOffset` (the header CRC deliberately excludes `Flags`, so no rewrite, no fsync).

Batching trigger (background/auto path): dirty-byte count ≥ `CarveBlockSize`, oldest dirty record older than `CarveMaxAge`, or `Force` — same Phase split as the old `rollup.go`.

## Injected-interface boundary (the key design decision)

journal must stay **standalone** — it may not import `pkg/block`, `blockcodec`, or `metadata` (that risks an import cycle once the engine wires journal in at PR7). But `blockcodec.Builder`, `ContentHash`, `ChunkLocator`, `DefaultCommitBlock` etc. all live in those packages. So everything that touches them is pushed behind **two narrow, journal-native interfaces** defined in `carve.go`:

- `Deduper.IsChunkDurable(ctx, ChunkHash) (bool, error)` — "is this chunk already durable on the remote store". A hit means journal skips packing it *and* can still flip the covering records (provably remote). Contract is `IsSynced`-shaped, not `GetByHash`-shaped, so a flip never marks merely-seen-locally bytes clean.
- `BlockSink.CommitBlock(ctx, []CarveChunk) error` — seal + frame + `PutBlock` + atomic commit of one block's novel chunks. Atomic: a non-nil error means nothing became durable, so journal leaves the records dirty to re-carve.

`ChunkHash` is a journal-native `[32]byte`; `CarveChunk` carries `{Hash, FileID, FileOffset, Data}`. The concrete impls (adapting `EngineFileChunkStore` / `chunkSealer` / `blockCommitter` / `blockcodec.Builder`) are passed in via `SetCarveTargets` at **PR7** wiring time. journal imports only `pkg/block/chunker` (a verified leaf package, no dittofs deps → no cycle), `blake3`, and stdlib. FastCDC+BLAKE3+dedup+flip stay in journal; seal+pack+PutBlock+commit stay behind the sink. This keeps interface surface minimal (two tiny interfaces, no mirrored `ChunkLocator`/`BlockRecord`/`BlockChunkCommit` types).

> Note for PR7: the blueprint §6 sketched an alternative split (engine keeps packing+PutBlock+commit, journal returns novel batches). This PR follows the task's authoritative split — the whole seal→commit flow lives behind `BlockSink` and the flip stays in journal, because the flip needs the record `SegOffset`.

## Flip-after-commit crash-safety (proven)

- `TestCarveCommitStrictlyBeforeFlip` — the fake sink asserts, *inside* `CommitBlock`, that no record has flipped yet (`UnsyncedBytes` still full, on-disk flag still 0). Proves commit strictly precedes flip.
- `TestCarveSinkErrorLeavesDirty` — a failing commit leaves every record dirty (counter unchanged, on-disk flag unset).
- `TestCarveDedupReCarveIsNoOp` — simulate a crash between commit and flip (records back to dirty, deduper still holds the hashes) → re-carve writes **0 blocks** and re-flips (dedup no-op).
- `TestCarveReopenReCarveIsNoOp` — full crash: carve durably, drop only the on-disk flips, **close + reopen**, carve again → recovery replays the records with the correct `SegOffset`, the re-flip lands on the record (not the segment header at offset 24), 0 blocks uploaded, data intact. This required a recovery-replay fix (replayed intervals now carry `synced` + `recOff`).
- `TestCarveConcurrentOverwrite` (`-race`) — writers overwrite ranges while carve runs; the flip only touches records the snapshot named, overwrites carve next pass.

Plus size/age trigger tests, round-trip (carved bytes reassemble to the original), and not-wired guard.

## Verification

`gofmt -s` · `go vet` · `golangci-lint` (clean) · `go build ./...` · `GOOS=windows go build ./pkg/block/journal/...` · `go test -race ./pkg/block/journal/...` → **41 pass**.

Benchmarks (`-benchtime=100ms`): `BenchmarkCarve` **909 MB/s** (8 MiB, worst-case all-novel FastCDC+BLAKE3+pack); WriteAt 2141 MB/s, ReadWarm 17.8 GB/s unchanged.

Journal is still unwired (PR7 owns who calls `Carve`), so heavy e2e/smbtorture don't exercise this yet.

Part of #1692