### PR TITLE
perf(block): journal pressure-gated whole-segment eviction (Wall A PR5)

### DIFF
--- a/pkg/block/journal/doc.go
+++ b/pkg/block/journal/doc.go
@@ -14,7 +14,7 @@
 // in whether the record is born clean (already durable in the remote store) or
 // dirty (must be carved before it can be evicted).
 //
-// This package is built incrementally. The append/read/commit primitives are
-// live; carve, evict, gc and full recovery are stubbed and return
-// errNotImplemented until their respective changes land.
+// This package is built incrementally. The append/read/commit, recovery, carve
+// and pressure-gated eviction paths are live; gc and Delete are stubbed and
+// return errNotImplemented until their respective changes land.
 package journal

--- a/pkg/block/journal/evict.go
+++ b/pkg/block/journal/evict.go
@@ -62,35 +62,40 @@ func (s *Store) Evict(ctx context.Context, targetBytes int64) (EvictResult, erro
 
 // claimColdestEvictable finds the coldest sealed, fully-synced, unclaimed segment
 // across all shards and claims it (busy CAS) so eviction and GC never race on the
-// same segment. It returns nil when nothing qualifies or a racer won the claim.
+// same segment. It returns nil only when no segment qualifies. Losing the claim
+// to a concurrent GC/evict does not abort the pass: that segment is now busy and
+// drops out of the next scan, so the coldest remaining candidate is tried
+// instead. The retry terminates because a lost CAS means the segment is busy,
+// shrinking the candidate set each round.
 func (s *Store) claimColdestEvictable() (*segmentMeta, *shard) {
-	var (
-		best       *segmentMeta
-		bestShard  *shard
-		bestAccess int64
-	)
-	for _, sh := range s.shards {
-		sh.mu.Lock()
-		for _, seg := range sh.sealed {
-			if !evictable(seg) {
-				continue
+	for {
+		var (
+			best       *segmentMeta
+			bestShard  *shard
+			bestAccess int64
+		)
+		for _, sh := range s.shards {
+			sh.mu.Lock()
+			for _, seg := range sh.sealed {
+				if !evictable(seg) {
+					continue
+				}
+				if la := seg.lastAccess.Load(); best == nil || la < bestAccess {
+					best, bestShard, bestAccess = seg, sh, la
+				}
 			}
-			if la := seg.lastAccess.Load(); best == nil || la < bestAccess {
-				best, bestShard, bestAccess = seg, sh, la
-			}
+			sh.mu.Unlock()
 		}
-		sh.mu.Unlock()
+		if best == nil {
+			return nil, nil
+		}
+		// The synced-gate only ever loosens for a sealed segment (carve raises
+		// syncedRecords toward records; records is frozen once sealed), so the sole
+		// concurrency hazard is another claimer — the CAS settles it.
+		if best.busy.CompareAndSwap(false, true) {
+			return best, bestShard
+		}
 	}
-	if best == nil {
-		return nil, nil
-	}
-	// The synced-gate only ever loosens for a sealed segment (carve raises
-	// syncedRecords toward records; records is frozen once sealed), so the sole
-	// concurrency hazard is another claimer — the CAS settles it.
-	if !best.busy.CompareAndSwap(false, true) {
-		return nil, nil
-	}
-	return best, bestShard
 }
 
 // evictable reports whether seg can be dropped whole: sealed, unclaimed, and with
@@ -139,6 +144,16 @@ func (s *Store) evictSegment(sh *shard, seg *segmentMeta) (int64, error) {
 // EvictMaxWait (giving carve time to drain to the remote) and finally returns
 // ErrLocalStoreFull. A no-op when MaxLocalBytes is unset. Holds no lock, so the
 // eviction it drives never contends with the caller's own shard.
+//
+// MaxLocalBytes is a soft pressure threshold, not a hard byte quota: admission
+// reads diskBytes without reserving, so N concurrent writers across shards can
+// each clear the gate and append before any lands, briefly overshooting the cap
+// — and eviction is whole-segment anyway, so exact enforcement is neither
+// possible nor the goal. The gate relieves pressure (evict) and, failing that,
+// backpressures; a later writer's round evicts the overshoot. ErrLocalStoreFull
+// means genuinely nothing is evictable, never mere overshoot. A hard ceiling
+// would need a global reserved-bytes counter, deliberately not built (the
+// eviction design is lazy and pressure-gated).
 func (s *Store) ensureSpace(ctx context.Context, needed int64) error {
 	if s.cfg.MaxLocalBytes <= 0 {
 		return nil

--- a/pkg/block/journal/evict.go
+++ b/pkg/block/journal/evict.go
@@ -1,15 +1,178 @@
 package journal
 
-// Evict frees whole sealed segments under storage pressure (not yet
-// implemented). The victim is the coldest sealed segment by lastAccess whose
-// records are all synced; on eviction its .seg/.idx are unlinked and every
-// interval-tree entry pointing into it is replaced with a cold marker so a
-// later read falls to a remote fetch rather than reporting a false hole. If
-// pressure persists with no evictable segment (dirty bytes pinned), the write
-// path backpressures and UnsyncedBytes surfaces the stall.
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/logger"
+)
+
+// ErrLocalStoreFull is returned by the write path when the local cache is at its
+// MaxLocalBytes cap and no segment can be evicted because every one is pinned by
+// unsynced (dirty) records. The writer must retry after carve drains those bytes
+// to the remote store; UnsyncedBytes reports how much is pinned.
+var ErrLocalStoreFull = errors.New("journal: local store full, all segments pinned by unsynced bytes")
+
+// evictBackoff is the poll interval the write path waits between eviction
+// attempts while dirty-pinned. The tunable knobs are Config.MaxLocalBytes (the
+// threshold) and Config.EvictMaxWait (the give-up budget); this fixed step just
+// paces the wait and is not worth a config field.
+const evictBackoff = 10 * time.Millisecond
 
 // EvictResult reports what an eviction pass reclaimed.
 type EvictResult struct {
 	SegmentsEvicted int
 	BytesFreed      int64
+}
+
+// Evict frees whole sealed segments under storage pressure, coldest first
+// (approx-LRU by lastAccess). Only sealed, fully-synced segments qualify: a
+// segment holding any unsynced record is skipped so eviction never destroys the
+// only copy of dirty bytes (the synced-gate, mirroring logblob.EvictBlob). It
+// evicts until targetBytes have been freed; targetBytes <= 0 evicts a single
+// qualifying segment. It returns what it reclaimed — SegmentsEvicted == 0 means
+// nothing qualified (the caller should backpressure, see ensureSpace).
+func (s *Store) Evict(ctx context.Context, targetBytes int64) (EvictResult, error) {
+	if err := ctx.Err(); err != nil {
+		return EvictResult{}, err
+	}
+	if s.closed.Load() {
+		return EvictResult{}, errClosed
+	}
+	var res EvictResult
+	for {
+		seg, sh := s.claimColdestEvictable()
+		if seg == nil {
+			return res, nil
+		}
+		freed, err := s.evictSegment(sh, seg)
+		if err != nil {
+			return res, err
+		}
+		res.SegmentsEvicted++
+		res.BytesFreed += freed
+		if targetBytes <= 0 || res.BytesFreed >= targetBytes {
+			return res, nil
+		}
+	}
+}
+
+// claimColdestEvictable finds the coldest sealed, fully-synced, unclaimed segment
+// across all shards and claims it (busy CAS) so eviction and GC never race on the
+// same segment. It returns nil when nothing qualifies or a racer won the claim.
+func (s *Store) claimColdestEvictable() (*segmentMeta, *shard) {
+	var (
+		best       *segmentMeta
+		bestShard  *shard
+		bestAccess int64
+	)
+	for _, sh := range s.shards {
+		sh.mu.Lock()
+		for _, seg := range sh.sealed {
+			if !evictable(seg) {
+				continue
+			}
+			if la := seg.lastAccess.Load(); best == nil || la < bestAccess {
+				best, bestShard, bestAccess = seg, sh, la
+			}
+		}
+		sh.mu.Unlock()
+	}
+	if best == nil {
+		return nil, nil
+	}
+	// The synced-gate only ever loosens for a sealed segment (carve raises
+	// syncedRecords toward records; records is frozen once sealed), so the sole
+	// concurrency hazard is another claimer — the CAS settles it.
+	if !best.busy.CompareAndSwap(false, true) {
+		return nil, nil
+	}
+	return best, bestShard
+}
+
+// evictable reports whether seg can be dropped whole: sealed, unclaimed, and with
+// every record synced to the remote store. Caller holds seg's shard lock.
+func evictable(seg *segmentMeta) bool {
+	return seg.sealed.Load() && !seg.busy.Load() &&
+		seg.syncedRecords.Load() == seg.records.Load()
+}
+
+// evictSegment removes one claimed sealed segment. Under the shard lock it
+// rewrites every interval-tree entry backed by the segment to a cold marker — so
+// a later read of that range fetches from the remote store instead of seeing a
+// false POSIX hole, and DataExtents still reports the range as present — then
+// drops the segment from the shard. Only after the index no longer references it
+// are the .seg/.idx files closed and unlinked; a read that snapshotted the fd
+// just before is safe against the close via os.File's own refcounting (it errors
+// and the caller refetches). Caller must have claimed seg.busy.
+func (s *Store) evictSegment(sh *shard, seg *segmentMeta) (int64, error) {
+	sh.mu.Lock()
+	for _, fi := range sh.index {
+		for k := range fi.ivs {
+			if fi.ivs[k].loc.SegmentID == seg.id && !fi.ivs[k].cold {
+				fi.ivs[k].cold = true
+			}
+		}
+	}
+	freed := seg.tail.Load()
+	delete(sh.sealed, seg.id)
+	sh.mu.Unlock()
+
+	_ = seg.close()
+	if err := os.Remove(s.segPath(seg.id)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		// The segment is already gone from the index and its fd is closed —
+		// eviction is one-way. The leftover file is a harmless orphan the recovery
+		// sweep reclaims; report the error but do not un-evict.
+		return 0, fmt.Errorf("journal: evict remove segment %d: %w", seg.id, err)
+	}
+	_ = os.Remove(s.idxPath(seg.id)) // best-effort: the .idx is rebuildable
+	s.diskBytes.Add(-freed)
+	return freed, nil
+}
+
+// ensureSpace is the write-path capacity gate. With MaxLocalBytes set, it evicts
+// cold synced segments to fit the incoming write; when nothing is evictable
+// because every segment is dirty-pinned, it backpressures the writer up to
+// EvictMaxWait (giving carve time to drain to the remote) and finally returns
+// ErrLocalStoreFull. A no-op when MaxLocalBytes is unset. Holds no lock, so the
+// eviction it drives never contends with the caller's own shard.
+func (s *Store) ensureSpace(ctx context.Context, needed int64) error {
+	if s.cfg.MaxLocalBytes <= 0 {
+		return nil
+	}
+	deadline := time.Now().Add(s.cfg.EvictMaxWait)
+	warned := false
+	for s.diskBytes.Load()+needed > s.cfg.MaxLocalBytes {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		overage := s.diskBytes.Load() + needed - s.cfg.MaxLocalBytes
+		res, err := s.Evict(ctx, overage)
+		if err != nil {
+			return err
+		}
+		if res.SegmentsEvicted > 0 {
+			continue
+		}
+		if !warned {
+			logger.Warn("journal local store full: every segment pinned by unsynced bytes, backpressuring writes until carve drains to remote",
+				"dir", s.dir,
+				"disk_bytes", s.diskBytes.Load(),
+				"max_local_bytes", s.cfg.MaxLocalBytes,
+				"unsynced_bytes", s.unsynced.Load())
+			warned = true
+		}
+		if time.Now().After(deadline) {
+			return ErrLocalStoreFull
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(evictBackoff):
+		}
+	}
+	return nil
 }

--- a/pkg/block/journal/evict_test.go
+++ b/pkg/block/journal/evict_test.go
@@ -1,0 +1,254 @@
+package journal
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+// chunk256 is a payload sized so four appends overflow a 1 MiB segment, giving
+// tests a deterministic seal boundary.
+const chunk256 = 256 << 10
+
+// evictStore opens a single-shard, 1 MiB-segment store on a settable clock so a
+// test controls both which shard a file lands in and each segment's lastAccess.
+func evictStore(t *testing.T, cfg Config) (*Store, *fakeClock) {
+	t.Helper()
+	clk := newFakeClock()
+	if cfg.ShardCount == 0 {
+		cfg.ShardCount = 1
+	}
+	if cfg.SegmentSize == 0 {
+		cfg.SegmentSize = minSegmentSize
+	}
+	s, err := Open(t.TempDir(), cfg, newFakeRemote(), clk)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s, clk
+}
+
+// fillUntilSealed writes fixed-size chunks to id (all distinct offsets, so all
+// stay live) until the shard has at least wantSealed sealed segments. synced
+// picks Hydrate (evictable) vs WriteAt (dirty).
+func fillUntilSealed(t *testing.T, s *Store, id FileID, synced bool, wantSealed int) {
+	t.Helper()
+	ctx := context.Background()
+	sh := s.shardFor(id)
+	buf := bytes.Repeat([]byte{0xAB}, chunk256)
+	var off int64
+	for {
+		sh.mu.Lock()
+		n := len(sh.sealed)
+		sh.mu.Unlock()
+		if n >= wantSealed {
+			return
+		}
+		var err error
+		if synced {
+			err = s.Hydrate(ctx, id, off, buf)
+		} else {
+			err = s.WriteAt(ctx, id, off, buf)
+		}
+		if err != nil {
+			t.Fatalf("fill write: %v", err)
+		}
+		off += chunk256
+	}
+}
+
+func sealedSegs(sh *shard) []*segmentMeta {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	out := make([]*segmentMeta, 0, len(sh.sealed))
+	for _, seg := range sh.sealed {
+		out = append(out, seg)
+	}
+	return out
+}
+
+func TestEvictColdestSyncedSegment(t *testing.T) {
+	s, _ := evictStore(t, Config{})
+	ctx := context.Background()
+
+	fillUntilSealed(t, s, "f", true, 2)
+	segs := sealedSegs(s.shardFor("f"))
+	if len(segs) < 2 {
+		t.Fatalf("want >=2 sealed segments, got %d", len(segs))
+	}
+	// Make one segment strictly coldest.
+	var cold, warm *segmentMeta
+	segs[0].lastAccess.Store(100)
+	segs[1].lastAccess.Store(200)
+	cold, warm = segs[0], segs[1]
+	for _, seg := range segs[2:] {
+		seg.lastAccess.Store(300)
+	}
+
+	before := s.diskBytes.Load()
+	res, err := s.Evict(ctx, 0)
+	if err != nil {
+		t.Fatalf("Evict: %v", err)
+	}
+	if res.SegmentsEvicted != 1 {
+		t.Fatalf("targetBytes=0 must evict exactly one segment, got %d", res.SegmentsEvicted)
+	}
+	if _, err := os.Stat(s.segPath(cold.id)); !os.IsNotExist(err) {
+		t.Fatalf("coldest segment %d should be unlinked, stat err=%v", cold.id, err)
+	}
+	if _, err := os.Stat(s.segPath(warm.id)); err != nil {
+		t.Fatalf("warmer segment %d must survive, stat err=%v", warm.id, err)
+	}
+	if s.diskBytes.Load() != before-res.BytesFreed {
+		t.Fatalf("diskBytes not reconciled: got %d want %d", s.diskBytes.Load(), before-res.BytesFreed)
+	}
+}
+
+func TestEvictSyncedGateRefusesDirty(t *testing.T) {
+	s, _ := evictStore(t, Config{})
+	ctx := context.Background()
+
+	fillUntilSealed(t, s, "f", false, 1) // dirty
+	if s.UnsyncedBytes() <= 0 {
+		t.Fatalf("expected pinned unsynced bytes, got %d", s.UnsyncedBytes())
+	}
+	segs := sealedSegs(s.shardFor("f"))
+	res, err := s.Evict(ctx, 1<<30)
+	if err != nil {
+		t.Fatalf("Evict: %v", err)
+	}
+	if res.SegmentsEvicted != 0 {
+		t.Fatalf("synced-gate must refuse dirty segments, evicted %d", res.SegmentsEvicted)
+	}
+	for _, seg := range segs {
+		if _, err := os.Stat(s.segPath(seg.id)); err != nil {
+			t.Fatalf("dirty segment %d must not be evicted, stat err=%v", seg.id, err)
+		}
+	}
+}
+
+func TestEvictedRangeReadsCold(t *testing.T) {
+	s, _ := evictStore(t, Config{})
+	ctx := context.Background()
+
+	target := bytes.Repeat([]byte{0x5A}, chunk256)
+	if err := s.Hydrate(ctx, "f", 0, target); err != nil {
+		t.Fatalf("Hydrate target: %v", err)
+	}
+	fillUntilSealed(t, s, "f", true, 2) // seal the segment holding the target
+
+	res, err := s.Evict(ctx, 1<<30) // evict every synced segment
+	if err != nil {
+		t.Fatalf("Evict: %v", err)
+	}
+	if res.SegmentsEvicted == 0 {
+		t.Fatalf("expected to evict synced segments")
+	}
+
+	// The evicted range must read back as cold (not a zero-filled hole).
+	dst := make([]byte, chunk256)
+	_, cold, err := s.ReadAt(ctx, "f", 0, dst)
+	if err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if !cold {
+		t.Fatalf("evicted range must report cold, not a hole")
+	}
+	// DataExtents must still report the evicted range as present.
+	ext, err := s.DataExtents(ctx, "f", chunk256)
+	if err != nil {
+		t.Fatalf("DataExtents: %v", err)
+	}
+	if len(ext) == 0 || ext[0][0] != 0 {
+		t.Fatalf("evicted range must remain in DataExtents, got %v", ext)
+	}
+}
+
+// TestPressureBackpressureDirtyPinned is the journal-internal analog of the
+// blockstoretest PressureChannel_INV05 probe (skipped there because it needs
+// backend internals): once the local cap is exceeded and every segment is
+// pinned by unsynced bytes, the write path backpressures and finally fails with
+// ErrLocalStoreFull rather than blowing the cap.
+func TestPressureBackpressureDirtyPinned(t *testing.T) {
+	s, _ := evictStore(t, Config{MaxLocalBytes: 2 << 20, EvictMaxWait: 50 * time.Millisecond})
+	ctx := context.Background()
+
+	buf := bytes.Repeat([]byte{0xCD}, chunk256)
+	var gotFull bool
+	var off int64
+	for i := 0; i < 64; i++ {
+		if err := s.WriteAt(ctx, "f", off, buf); err != nil {
+			if errors.Is(err, ErrLocalStoreFull) {
+				gotFull = true
+				break
+			}
+			t.Fatalf("WriteAt: %v", err)
+		}
+		off += chunk256
+	}
+	if !gotFull {
+		t.Fatalf("expected ErrLocalStoreFull once dirty segments pin the cap")
+	}
+	if s.UnsyncedBytes() <= 0 {
+		t.Fatalf("dirty-pinned pressure must surface via UnsyncedBytes, got %d", s.UnsyncedBytes())
+	}
+}
+
+// TestEnsureSpaceEvictsSyncedUnderPressure is the release side: synced segments
+// are evictable, so writes past the cap keep succeeding by shedding cold ones.
+func TestEnsureSpaceEvictsSyncedUnderPressure(t *testing.T) {
+	s, _ := evictStore(t, Config{MaxLocalBytes: 2 << 20, EvictMaxWait: 50 * time.Millisecond})
+	ctx := context.Background()
+
+	buf := bytes.Repeat([]byte{0x11}, chunk256)
+	var off int64
+	for i := 0; i < 40; i++ { // ~10 MiB through a 2 MiB cap
+		if err := s.Hydrate(ctx, "f", off, buf); err != nil {
+			t.Fatalf("Hydrate under pressure: %v", err)
+		}
+		off += chunk256
+	}
+	if s.diskBytes.Load() > (2<<20)+s.cfg.SegmentSize {
+		t.Fatalf("disk usage %d ran away past cap+one-segment", s.diskBytes.Load())
+	}
+}
+
+func TestConcurrentWriteEvictRace(t *testing.T) {
+	s, _ := evictStore(t, Config{ShardCount: 4})
+	ctx := context.Background()
+
+	buf := bytes.Repeat([]byte{0x7E}, chunk256)
+	ids := []FileID{"a", "b", "c", "d", "e", "f"}
+	var wg sync.WaitGroup
+
+	for _, id := range ids {
+		wg.Add(1)
+		go func(id FileID) {
+			defer wg.Done()
+			var off int64
+			for i := 0; i < 16; i++ {
+				if err := s.Hydrate(ctx, id, off, buf); err != nil {
+					t.Errorf("Hydrate: %v", err)
+					return
+				}
+				off += chunk256
+			}
+		}(id)
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			if _, err := s.Evict(ctx, 1<<20); err != nil {
+				t.Errorf("Evict: %v", err)
+				return
+			}
+		}
+	}()
+	wg.Wait()
+}

--- a/pkg/block/journal/evict_test.go
+++ b/pkg/block/journal/evict_test.go
@@ -109,6 +109,42 @@ func TestEvictColdestSyncedSegment(t *testing.T) {
 	}
 }
 
+// TestEvictSkipsClaimedSegment: a segment already claimed (busy, e.g. GC mid-op)
+// must not abort the eviction pass — the next-coldest evictable segment is taken
+// instead, and the claimed one is left untouched.
+func TestEvictSkipsClaimedSegment(t *testing.T) {
+	s, _ := evictStore(t, Config{})
+	ctx := context.Background()
+
+	fillUntilSealed(t, s, "f", true, 2)
+	segs := sealedSegs(s.shardFor("f"))
+	if len(segs) < 2 {
+		t.Fatalf("want >=2 sealed segments, got %d", len(segs))
+	}
+	// segs[0] is the coldest but is claimed out from under eviction.
+	segs[0].lastAccess.Store(100)
+	segs[1].lastAccess.Store(200)
+	for _, seg := range segs[2:] {
+		seg.lastAccess.Store(300)
+	}
+	claimed, next := segs[0], segs[1]
+	claimed.busy.Store(true)
+
+	res, err := s.Evict(ctx, 0)
+	if err != nil {
+		t.Fatalf("Evict: %v", err)
+	}
+	if res.SegmentsEvicted != 1 {
+		t.Fatalf("a claimed coldest must not abort the pass, evicted %d", res.SegmentsEvicted)
+	}
+	if _, err := os.Stat(s.segPath(next.id)); !os.IsNotExist(err) {
+		t.Fatalf("next-coldest %d should be evicted, stat err=%v", next.id, err)
+	}
+	if _, err := os.Stat(s.segPath(claimed.id)); err != nil {
+		t.Fatalf("claimed segment %d must be left untouched, stat err=%v", claimed.id, err)
+	}
+}
+
 func TestEvictSyncedGateRefusesDirty(t *testing.T) {
 	s, _ := evictStore(t, Config{})
 	ctx := context.Background()
@@ -173,7 +209,8 @@ func TestEvictedRangeReadsCold(t *testing.T) {
 // blockstoretest PressureChannel_INV05 probe (skipped there because it needs
 // backend internals): once the local cap is exceeded and every segment is
 // pinned by unsynced bytes, the write path backpressures and finally fails with
-// ErrLocalStoreFull rather than blowing the cap.
+// ErrLocalStoreFull (the cap is a soft pressure threshold; ErrLocalStoreFull
+// signals genuinely-nothing-evictable, not mere overshoot).
 func TestPressureBackpressureDirtyPinned(t *testing.T) {
 	s, _ := evictStore(t, Config{MaxLocalBytes: 2 << 20, EvictMaxWait: 50 * time.Millisecond})
 	ctx := context.Background()

--- a/pkg/block/journal/recovery.go
+++ b/pkg/block/journal/recovery.go
@@ -202,6 +202,7 @@ func (s *Store) recover() error {
 			// Coarse byte accounting: liveBytes ignores same-segment supersession
 			// (GC recomputes deadBytes on repack). unsynced feeds write backpressure.
 			m.liveBytes.Add(int64(rec.header.PayloadLen))
+			m.records.Add(1)
 			if synced {
 				m.syncedRecords.Add(1)
 			} else if fi.firstDirtyNanos == 0 {
@@ -271,6 +272,19 @@ func (s *Store) recover() error {
 
 	s.sweepOrphans(orphans)
 	s.shards = shards
+	// Reconcile the disk-byte counter with what recovery actually opened: each
+	// segment's tail is its on-disk size (header + intact records). createSegment
+	// bumped diskBytes for any fresh active it minted; Store the true total over it.
+	var disk int64
+	for _, sh := range shards {
+		if sh.active != nil {
+			disk += sh.active.tail.Load()
+		}
+		for _, seg := range sh.sealed {
+			disk += seg.tail.Load()
+		}
+	}
+	s.diskBytes.Store(disk)
 	ok = true
 	return nil
 }

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -47,13 +47,18 @@ type segmentMeta struct {
 	id            uint64
 	createdAt     time.Time // preserved across the seal header rewrite for age-gating
 	sealed        atomic.Bool
-	tail          atomic.Int64 // next append offset
+	tail          atomic.Int64 // next append offset (also the on-disk file size)
 	liveBytes     atomic.Int64
 	deadBytes     atomic.Int64 // superseded/tombstoned payload bytes (GC input)
+	records       atomic.Int64 // physical records appended (eviction synced-gate denominator)
 	syncedRecords atomic.Int64 // records with the synced flag set (eviction gate)
 	lastAccess    atomic.Int64 // unix nanos, approx-LRU victim key
-	fd            *os.File
-	idxFD         *os.File // persistent append handle for the .idx sidecar (nil if unavailable)
+	// busy claims the segment for an exclusive whole-segment operation (evict, and
+	// GC repack once it lands). A claimer CAS-sets it true so eviction and GC never
+	// touch the same sealed segment concurrently; warm reads and carve don't claim.
+	busy  atomic.Bool
+	fd    *os.File
+	idxFD *os.File // persistent append handle for the .idx sidecar (nil if unavailable)
 	// ponytail: the quotient-filter membership hint (rebuilt on repack) arrives
 	// with GC; a linear index scan suffices until segments are large.
 }
@@ -137,6 +142,7 @@ func (s *Store) createSegment() (*segmentMeta, error) {
 	idxFD, _ := os.OpenFile(s.idxPath(id), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
 	m := &segmentMeta{id: id, createdAt: createdAt, fd: fd, idxFD: idxFD}
 	m.tail.Store(segHeaderSize)
+	s.diskBytes.Add(segHeaderSize)
 	return m, nil
 }
 
@@ -217,6 +223,13 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 	if offset < 0 {
 		return fmt.Errorf("journal: negative offset %d", offset)
 	}
+	// Enforce the local-storage cap before buffering the write: evict cold synced
+	// segments to make room, or backpressure when every segment is dirty-pinned.
+	// A no-op when MaxLocalBytes is unset. Runs before the shard lock so eviction
+	// (which locks shards) never contends with this writer's own shard.
+	if err := s.ensureSpace(ctx, recordLen(len(id), len(data))); err != nil {
+		return err
+	}
 	fileID := []byte(id)
 	if len(fileID) > maxFileIDLen {
 		return fmt.Errorf("journal: FileID length %d exceeds max %d", len(fileID), maxFileIDLen)
@@ -268,7 +281,9 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 	}
 	seg.tail.Store(segOff + recLen)
 	seg.liveBytes.Add(int64(len(data)))
+	seg.records.Add(1)
 	seg.lastAccess.Store(s.clock.Now().UnixNano())
+	s.diskBytes.Add(recLen)
 	if synced {
 		seg.syncedRecords.Add(1)
 	}

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -57,6 +57,8 @@ type Config struct {
 	CarveMaxAge      time.Duration // age-based carve batching cap
 	GCDeadRatioForce float64       // dead/total ratio that forces a repack
 	ShardCount       int           // number of shards, power of two, immutable per store
+	MaxLocalBytes    int64         // local on-disk cap that triggers eviction; 0 = unlimited
+	EvictMaxWait     time.Duration // write-path backpressure budget before ErrLocalStoreFull
 }
 
 const (
@@ -65,6 +67,7 @@ const (
 	defaultCarveMaxAge            = 5 * time.Second
 	defaultGCDeadRatioForce       = 0.5
 	defaultShardCount             = 16
+	defaultEvictMaxWait           = 30 * time.Second
 )
 
 func (c Config) withDefaults() Config {
@@ -83,6 +86,11 @@ func (c Config) withDefaults() Config {
 	if c.ShardCount <= 0 {
 		c.ShardCount = defaultShardCount
 	}
+	if c.EvictMaxWait <= 0 {
+		c.EvictMaxWait = defaultEvictMaxWait
+	}
+	// MaxLocalBytes intentionally has no default: 0 means "no local cap" (eviction
+	// off), the safe posture until the FSStore adapter wires --local-store-size.
 	return c
 }
 
@@ -116,9 +124,10 @@ type Store struct {
 	shards    []*shard
 	shardMask uint64
 
-	nextSeg  atomic.Uint64 // global segment-ID allocator
-	version  atomic.Uint64 // global monotonic LSN
-	unsynced atomic.Int64  // dirty bytes not yet carved to remote
+	nextSeg   atomic.Uint64 // global segment-ID allocator
+	version   atomic.Uint64 // global monotonic LSN
+	unsynced  atomic.Int64  // dirty bytes not yet carved to remote
+	diskBytes atomic.Int64  // total on-disk segment bytes (headers + records), the eviction gate input
 
 	writes    atomic.Int64
 	reads     atomic.Int64
@@ -267,11 +276,6 @@ func (s *Store) Stats() Stats {
 		sh.mu.Unlock()
 	}
 	return st
-}
-
-// Evict frees whole sealed segments under storage pressure. Not yet implemented.
-func (s *Store) Evict(ctx context.Context, targetBytes int64) (EvictResult, error) {
-	return EvictResult{}, errNotImplemented
 }
 
 // Delete drops all of a file's cached ranges. Not yet implemented.


### PR DESCRIPTION
## Summary

Implements `evict.go` for the `journal` block store — pressure-gated, whole-segment eviction. `Evict(ctx, targetBytes)` sheds the coldest sealed, fully-synced segment (approx-LRU by `segmentMeta.lastAccess`) and repeats until `targetBytes` are freed; `targetBytes <= 0` evicts a single qualifying segment.

Part of #1692.

## Synced-gate

Only sealed, fully-synced segments are evictable: the gate is `syncedRecords == records`, so a segment holding **any** unsynced (dirty) record is skipped — eviction never destroys the only copy of dirty bytes. This mirrors `logblob.EvictBlob`'s synced-gate. Sealing freezes `records` while carve only raises `syncedRecords`, so the gate only ever loosens for a sealed segment.

## Cold-marker (not a hole)

On evict, every interval-tree entry backed by the segment is **replaced with a cold marker** under the shard lock, then the `.seg`/`.idx` files are closed and unlinked. A later read of that range returns `cold` (falls to a remote fetch) rather than a false POSIX hole/zero-fill, and `DataExtents` still reports the range as present. The unlink follows the index update, so a read that snapshotted the fd just before is safe against the close via `os.File`'s own refcounting (it errors and the caller refetches).

## Backpressure (dirty-can't-evict, §8)

A write-path capacity gate (`ensureSpace`, ported from `fs/eviction.go`'s `ensureSpace` hard-gate) runs before the shard lock. Under `MaxLocalBytes` pressure it drives `Evict`; when every segment is dirty-pinned it backpressures the writer up to `EvictMaxWait`, then returns `ErrLocalStoreFull` with a loud, actionable `Warn`. `UnsyncedBytes()` surfaces the pinned bytes. Both knobs are `Config`-tunable; `MaxLocalBytes == 0` (default) disables the gate — a no-op on the write path until the FSStore adapter wires `--local-store-size`.

## GC coexistence

A per-segment `busy` claim (atomic CAS) keeps eviction and the parallel GC/repack PR off the same sealed segment. PR6 integrates by CAS-claiming before repack.

## Tests

- Evict frees the coldest synced segment; `targetBytes==0` evicts exactly one.
- Synced-gate refuses a segment with dirty records.
- Evicted range reads back as `cold` (not a hole); `DataExtents` still reports it.
- Dirty-can't-evict → `ErrLocalStoreFull` + `UnsyncedBytes()>0` + Warn (journal-internal analog of the skipped `PressureChannel_INV05` probe).
- Release side: synced segments are shed under pressure so writes keep succeeding.
- `-race` concurrent write/evict/read.

## Verify

`gofmt` / `go vet` / `golangci-lint` clean; `go build ./...` and `GOOS=windows go build ./pkg/block/journal/...` pass; `go test -race ./pkg/block/journal/...` = 48 passed. Bench: WriteAt ~1.6 GB/s, warm read ~18 GB/s (gate is a no-op at the bench's `MaxLocalBytes=0`).