### PR TITLE
perf(block): journal dead-byte GC + size-tiered repack (Wall A PR6)

### DIFF
--- a/pkg/block/journal/doc.go
+++ b/pkg/block/journal/doc.go
@@ -14,7 +14,11 @@
 // in whether the record is born clean (already durable in the remote store) or
 // dirty (must be carved before it can be evicted).
 //
-// This package is built incrementally. The append/read/commit, recovery, carve
-// and pressure-gated eviction paths are live; gc and Delete are stubbed and
-// return errNotImplemented until their respective changes land.
+// This package is built incrementally: append/read/commit, recovery, carve,
+// pressure-gated eviction, delete and garbage collection are all live.
+//
+// GC never touches the remote store: repack relocates local cache bytes between
+// segments only. Remote-block refcount reclamation stays with the engine's
+// block-GC sweep, whose per-remote serialization is what makes a decrement safe
+// — journal must not drive one concurrently. See gc.go.
 package journal

--- a/pkg/block/journal/gc.go
+++ b/pkg/block/journal/gc.go
@@ -1,16 +1,407 @@
 package journal
 
-// Garbage collection / repack (not yet implemented).
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+)
+
+// Garbage collection / repack.
 //
-// deadBytes on a segmentMeta increments whenever an interval-tree node is
-// overwritten by a newer version or its file is tombstoned. The victim is the
-// segment with the highest dead/total ratio; GCDeadRatioForce forces an
-// immediate repack regardless of scheduling so space amplification stays
-// bounded.
+// deadBytes on a segmentMeta grows whenever an interval-tree node is superseded
+// by a newer write (segment.go) or a file is tombstoned (store.go Delete). GC
+// picks the sealed segment carrying the most garbage and repacks its still-live
+// records into a fresh sealed segment, then unlinks the source, reclaiming the
+// dead space. GCDeadRatioForce bounds space amplification: any segment at or
+// above that dead fraction is repacked without waiting for a scheduler.
 //
-// Repack copies a segment's live records into a repack-target segment,
-// preserving each record's Version and synced flag (never reissued, so
-// newest-wins survives relocation), fsyncs the destination and the directory,
-// updates the interval index, and only then unlinks the source. A crash before
-// the unlink leaves a harmless orphan that the recovery sweep reclaims. The
-// per-segment membership filter is rebuilt on every repack, never carried.
+// Repack is strictly LOCAL: it relocates cache bytes between segments and never
+// touches the remote store. Remote-block refcount reclamation stays with the
+// engine's block-GC sweep (pkg/block/engine/gc_block.go), whose per-remote
+// serialization is what makes a decrement safe — the union BlockReclaimer
+// decrement is unsafe under a concurrent GC (its sweeper lock is per-GCStateRoot,
+// not per-remote), so journal GC must never drive it. A tombstone here only drops
+// LOCAL records and marks LOCAL space dead; the deleted file's remote blocks are
+// freed later by that sweep, off this path.
+
+// GCOptions selects a GC pass's aggressiveness.
+type GCOptions struct {
+	// Force repacks the single highest-dead-ratio sealed segment in each shard
+	// even when its ratio is below GCDeadRatioForce (an explicit / test trigger).
+	// Without it, a pass repacks every segment at or above the force threshold.
+	Force bool
+}
+
+// GCResult reports what a GC pass reclaimed.
+type GCResult struct {
+	SegmentsRepacked int
+	BytesReclaimed   int64 // net local bytes freed (victim size minus relocated live)
+}
+
+// GC repacks sealed segments whose dead-byte fraction has grown, freeing the
+// space superseded writes and tombstones left behind. It is safe to call from a
+// background loop or explicitly; passes serialize on gcMu.
+func (s *Store) GC(ctx context.Context, opts GCOptions) (GCResult, error) {
+	if err := ctx.Err(); err != nil {
+		return GCResult{}, err
+	}
+	if s.closed.Load() {
+		return GCResult{}, errClosed
+	}
+	s.gcMu.Lock()
+	defer s.gcMu.Unlock()
+
+	var res GCResult
+	for _, sh := range s.shards {
+		reclaimed, count, err := s.gcShard(ctx, sh, opts)
+		res.SegmentsRepacked += count
+		res.BytesReclaimed += reclaimed
+		if err != nil {
+			return res, err
+		}
+	}
+	return res, nil
+}
+
+// gcShard repacks a shard's qualifying sealed segments. It holds the shard's
+// carveMu for the whole pass so carve — which flips synced bits by record offset
+// — never runs against a segment repack is relocating (the same segment-busy
+// discipline eviction takes).
+func (s *Store) gcShard(ctx context.Context, sh *shard, opts GCOptions) (reclaimed int64, count int, err error) {
+	sh.carveMu.Lock()
+	defer sh.carveMu.Unlock()
+
+	// Bounded: each repack removes one victim from the sealed set, and the fresh
+	// target it writes carries no dead bytes, so it is never re-picked.
+	for {
+		if err := ctx.Err(); err != nil {
+			return reclaimed, count, err
+		}
+		victim := s.pickVictim(sh, opts)
+		if victim == nil {
+			return reclaimed, count, nil
+		}
+		// Claim the victim so a concurrent eviction can't drop it mid-repack
+		// (eviction skips busy segments; a lost claim just re-picks the next).
+		if !victim.busy.CompareAndSwap(false, true) {
+			continue
+		}
+		net, err := s.repackSegment(sh, victim)
+		victim.busy.Store(false)
+		if err != nil {
+			return reclaimed, count, err
+		}
+		reclaimed += net
+		count++
+		if opts.Force {
+			// Force targets the single worst offender, not the whole shard.
+			return reclaimed, count, nil
+		}
+	}
+}
+
+// pickVictim returns the sealed segment with the highest dead fraction, or nil
+// if none qualifies. Live bytes are summed authoritatively from the interval
+// index (robust to the recovery-time deadBytes approximation and to the extra
+// dead a crash-during-repack leaves behind); a segment's dead fraction is
+// dead/occupied. Without Force, a victim must reach GCDeadRatioForce.
+func (s *Store) pickVictim(sh *shard, opts GCOptions) *segmentMeta {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if len(sh.sealed) == 0 {
+		return nil
+	}
+	live := make(map[uint64]int64, len(sh.sealed))
+	for _, fi := range sh.index {
+		for _, iv := range fi.ivs {
+			if iv.cold {
+				continue
+			}
+			if _, ok := sh.sealed[iv.loc.SegmentID]; ok {
+				live[iv.loc.SegmentID] += iv.length
+			}
+		}
+	}
+
+	var best *segmentMeta
+	var bestRatio float64
+	for id, seg := range sh.sealed {
+		if seg.busy.Load() {
+			continue // claimed by eviction or an in-flight repack
+		}
+		occupied := seg.liveBytes.Load() // physical payload bytes ever written here
+		var ratio float64
+		if occupied <= 0 {
+			ratio = 1 // empty/overhead-only segment: pure garbage
+		} else {
+			dead := occupied - live[id]
+			if dead <= 0 {
+				continue // fully live: nothing to reclaim
+			}
+			ratio = float64(dead) / float64(occupied)
+		}
+		if ratio > bestRatio {
+			best, bestRatio = seg, ratio
+		}
+	}
+	if best == nil {
+		return nil
+	}
+	if !opts.Force && bestRatio < s.cfg.GCDeadRatioForce {
+		return nil
+	}
+	return best
+}
+
+// liveRec is one still-live interval to relocate out of a repack victim.
+type liveRec struct {
+	id      FileID
+	fileOff int64
+	length  int64
+	version uint64
+	synced  bool
+	srcOff  int64 // payload offset in the victim
+}
+
+// findMove returns the index of the move whose logical range fully contains
+// [lo, hi) at the given version, or -1. A concurrent overwrite may have trimmed
+// or split a victim interval since the snapshot; the trimmed remnant is still a
+// sub-range of exactly one original move, so this repoints it to the right byte.
+func findMove(moves []liveRec, lo, hi int64, ver uint64) int {
+	for i := range moves {
+		m := moves[i]
+		if m.version == ver && m.fileOff <= lo && hi <= m.fileOff+m.length {
+			return i
+		}
+	}
+	return -1
+}
+
+// repackSegment relocates a victim's still-live records (and carries its
+// tombstones forward) into a fresh sealed target, then unlinks the victim.
+//
+// Ordering invariant — bytes-durable-before-index-durable-before-reclaim:
+//  1. write survivors into the target;
+//  2. fsync + seal the target (its dir entry was fsynced at create) — bytes durable;
+//  3. repoint the in-memory index to the target (the index is not itself durable
+//     — recovery rebuilds it from the .seg records, which are now durable);
+//  4. only then unlink the victim.
+//
+// A crash before step 4 leaves the victim as a harmless orphan: its records
+// duplicate the target's with the identical Version, so recovery replays both
+// byte-identically and the next GC pass (seeing the victim fully superseded)
+// reclaims it. Version and the synced flag are copied verbatim, never reissued,
+// so newest-wins survives the physical move.
+func (s *Store) repackSegment(sh *shard, victim *segmentMeta) (int64, error) {
+	// 1a. Snapshot the victim's live intervals under the shard lock.
+	sh.mu.Lock()
+	var moves []liveRec
+	for id, fi := range sh.index {
+		for _, iv := range fi.ivs {
+			if iv.cold || iv.loc.SegmentID != victim.id {
+				continue
+			}
+			moves = append(moves, liveRec{
+				id: id, fileOff: iv.fileOff, length: iv.length,
+				version: iv.version, synced: iv.synced, srcOff: iv.loc.Offset,
+			})
+		}
+	}
+	occupied := victim.liveBytes.Load()
+	sh.mu.Unlock()
+
+	// 1b. Carry forward the victim's tombstones so deletes stay durable until
+	// every shadowed data record is gone.
+	tombs := victimTombstones(victim, s.cfg.SegmentSize)
+
+	if len(moves) == 0 && len(tombs) == 0 {
+		return s.dropVictim(sh, victim, occupied)
+	}
+
+	// 2. Write survivors + tombstones into a fresh target.
+	target, err := s.createSegment()
+	if err != nil {
+		return 0, err
+	}
+	cleanup := func() {
+		_ = target.close()
+		_ = os.Remove(s.segPath(target.id))
+		_ = os.Remove(s.idxPath(target.id))
+	}
+	newOff := make([]int64, len(moves))
+	var relocated, syncedCount int64
+	for i := range moves {
+		m := moves[i]
+		data := make([]byte, m.length) // one interval in RAM at a time
+		if _, rerr := victim.fd.ReadAt(data, m.srcOff); rerr != nil {
+			cleanup()
+			return 0, fmt.Errorf("journal: repack read victim %d@%d: %w", victim.id, m.srcOff, rerr)
+		}
+		poff, werr := writeDataRecord(target, m.id, m.fileOff, m.version, m.synced, data)
+		if werr != nil {
+			cleanup()
+			return 0, werr
+		}
+		newOff[i] = poff
+		relocated += m.length
+		if m.synced {
+			syncedCount++
+		}
+	}
+	for _, t := range tombs {
+		if _, werr := writeTombstoneRecord(target, t.id, t.version); werr != nil {
+			cleanup()
+			return 0, werr
+		}
+	}
+
+	// 3. Bytes durable: fsync + seal the target before any index entry names it.
+	if err := target.sealInPlace(); err != nil {
+		cleanup()
+		return 0, err
+	}
+	target.liveBytes.Store(relocated)
+	target.syncedRecords.Store(syncedCount)
+
+	// 4. Repoint the index, skipping intervals a concurrent write superseded.
+	sh.mu.Lock()
+	remaining := 0
+	for _, fi := range sh.index {
+		for k := range fi.ivs {
+			iv := &fi.ivs[k]
+			if iv.cold || iv.loc.SegmentID != victim.id {
+				continue
+			}
+			mi := findMove(moves, iv.fileOff, iv.end(), iv.version)
+			if mi < 0 {
+				// No source move covers it — must never drop the victim while a
+				// live interval still points into it.
+				remaining++
+				continue
+			}
+			delta := iv.fileOff - moves[mi].fileOff
+			iv.loc.SegmentID = target.id
+			iv.loc.Offset = newOff[mi] + delta
+			iv.recOff = newOff[mi] - recordHeaderSize - int64(len(moves[mi].id))
+		}
+	}
+	sh.sealed[target.id] = target
+	sh.mu.Unlock()
+
+	if remaining != 0 {
+		// Defensive: nothing writes to a sealed segment, so this cannot happen;
+		// keep the victim to preserve those bytes rather than lose data. The
+		// target is a redundant orphan the next pass reclaims.
+		logf("journal: WARN repack left %d live interval(s) in segment %d; keeping it", remaining, victim.id)
+		return 0, nil
+	}
+
+	if testStopBeforeUnlink {
+		// Test seam: model a crash after the target is durable and indexed but
+		// before the victim is reclaimed. On disk the victim's records duplicate
+		// the target's with identical Version, so recovery replays both
+		// byte-identically and the next pass reclaims the orphan.
+		return 0, nil
+	}
+
+	// 5. Reclaim: drop the victim from the set so no new read resolves it, drain
+	// in-flight preads via the exclusive guard, then close and unlink. The guard
+	// is taken WITHOUT holding sh.mu so it can never deadlock against a reader
+	// that holds sh.mu while acquiring the shared guard.
+	sh.mu.Lock()
+	delete(sh.sealed, victim.id)
+	sh.mu.Unlock()
+	victim.readGuard.Lock()
+	_ = victim.close()
+	victim.readGuard.Unlock()
+	_ = os.Remove(s.segPath(victim.id))
+	_ = os.Remove(s.idxPath(victim.id))
+
+	net := occupied - relocated
+	if net < 0 {
+		net = 0
+	}
+	return net, nil
+}
+
+// testStopBeforeUnlink, when set by a test, makes repackSegment return after the
+// target is durable and the index repointed but before the victim is reclaimed,
+// reproducing a crash between those steps. Always false in production.
+var testStopBeforeUnlink bool
+
+// dropVictim reclaims a fully-dead segment: no live records, no tombstones. It
+// re-checks under the shard lock that nothing references it, then unlinks.
+func (s *Store) dropVictim(sh *shard, victim *segmentMeta, occupied int64) (int64, error) {
+	sh.mu.Lock()
+	for _, fi := range sh.index {
+		for _, iv := range fi.ivs {
+			if !iv.cold && iv.loc.SegmentID == victim.id {
+				sh.mu.Unlock()
+				return 0, nil // a concurrent path re-touched it; leave it
+			}
+		}
+	}
+	delete(sh.sealed, victim.id)
+	sh.mu.Unlock()
+	victim.readGuard.Lock()
+	_ = victim.close()
+	victim.readGuard.Unlock()
+	_ = os.Remove(s.segPath(victim.id))
+	_ = os.Remove(s.idxPath(victim.id))
+	return occupied, nil
+}
+
+// tombRec is a tombstone carried forward across a repack.
+type tombRec struct {
+	id      FileID
+	version uint64
+}
+
+// victimTombstones scans a sealed victim's record stream for tombstones. A
+// sealed segment is trusted intact, so a torn tail (should never occur) simply
+// yields the records read so far.
+func victimTombstones(seg *segmentMeta, segSize int64) []tombRec {
+	recs, _ := scanValidRecords(seg.fd, segSize, segSize)
+	var out []tombRec
+	for _, rec := range recs {
+		if rec.header.Flags&flagTombstone != 0 {
+			out = append(out, tombRec{id: FileID(rec.fileID), version: rec.header.Version})
+		}
+	}
+	return out
+}
+
+// writeDataRecord frames one data record at seg's tail, preserving the caller's
+// Version and synced flag, and returns its payload offset. Used only by repack;
+// it never touches the index (repack repoints the index after the target is
+// durable).
+func writeDataRecord(seg *segmentMeta, id FileID, fileOff int64, version uint64, synced bool, data []byte) (payloadOff int64, err error) {
+	fileID := []byte(id)
+	recStart := seg.tail.Load()
+	var flags uint8
+	if synced {
+		flags |= flagSynced
+	}
+	hdr := encodeHeader(recordHeader{
+		FileIDLen:  uint16(len(fileID)),
+		FileOffset: uint64(fileOff),
+		PayloadLen: uint32(len(data)),
+		Version:    version,
+		Flags:      flags,
+	}, fileID)
+	payloadOff = recStart + int64(len(hdr))
+	if _, err = seg.fd.WriteAt(hdr, recStart); err != nil {
+		return 0, fmt.Errorf("journal: repack write header: %w", err)
+	}
+	if _, err = seg.fd.WriteAt(data, payloadOff); err != nil {
+		return 0, fmt.Errorf("journal: repack write payload: %w", err)
+	}
+	var crcBuf [payloadCRCSize]byte
+	binary.LittleEndian.PutUint32(crcBuf[:], crc(data))
+	if _, err = seg.fd.WriteAt(crcBuf[:], payloadOff+int64(len(data))); err != nil {
+		return 0, fmt.Errorf("journal: repack write CRC: %w", err)
+	}
+	seg.tail.Store(recStart + recordLen(len(fileID), len(data)))
+	return payloadOff, nil
+}

--- a/pkg/block/journal/gc.go
+++ b/pkg/block/journal/gc.go
@@ -102,10 +102,13 @@ func (s *Store) gcShard(ctx context.Context, sh *shard, opts GCOptions) (reclaim
 }
 
 // pickVictim returns the sealed segment with the highest dead fraction, or nil
-// if none qualifies. Live bytes are summed authoritatively from the interval
-// index (robust to the recovery-time deadBytes approximation and to the extra
-// dead a crash-during-repack leaves behind); a segment's dead fraction is
-// dead/occupied. Without Force, a victim must reach GCDeadRatioForce.
+// if none qualifies. A segment carrying no dead bytes is never a victim (there
+// is nothing to reclaim), which is also what keeps a tombstone-only segment from
+// being repacked into an identical one forever. Live bytes are summed
+// authoritatively from the interval index (robust to the recovery-time deadBytes
+// approximation and to the extra dead a crash-during-repack leaves behind); a
+// segment's dead fraction is dead/occupied. Without Force, a victim must reach
+// GCDeadRatioForce.
 func (s *Store) pickVictim(sh *shard, opts GCOptions) *segmentMeta {
 	sh.mu.Lock()
 	defer sh.mu.Unlock()
@@ -130,10 +133,17 @@ func (s *Store) pickVictim(sh *shard, opts GCOptions) *segmentMeta {
 		if seg.busy.Load() {
 			continue // claimed by eviction or an in-flight repack
 		}
+		if seg.deadBytes.Load() <= 0 {
+			// Nothing to reclaim. This skips a tombstone-only segment (records with
+			// no payload: liveBytes==0 AND deadBytes==0) — repacking it would just
+			// copy the tombstones into an identical tombstone-only segment and loop
+			// forever reclaiming zero. Only a segment carrying dead payload qualifies.
+			continue
+		}
 		occupied := seg.liveBytes.Load() // physical payload bytes ever written here
 		var ratio float64
 		if occupied <= 0 {
-			ratio = 1 // empty/overhead-only segment: pure garbage
+			ratio = 1 // fully-dead payload (deadBytes>0, no live bytes): pure garbage
 		} else {
 			dead := occupied - live[id]
 			if dead <= 0 {
@@ -233,7 +243,11 @@ func (s *Store) repackSegment(sh *shard, victim *segmentMeta) (int64, error) {
 	var relocated, syncedCount int64
 	for i := range moves {
 		m := moves[i]
-		data := make([]byte, m.length) // one interval in RAM at a time
+		if m.length < 0 || m.length > maxPayloadLen {
+			cleanup()
+			return 0, fmt.Errorf("journal: repack implausible record length %d in segment %d", m.length, victim.id)
+		}
+		data := make([]byte, int(m.length)) // one interval in RAM at a time
 		if _, rerr := victim.fd.ReadAt(data, m.srcOff); rerr != nil {
 			cleanup()
 			return 0, fmt.Errorf("journal: repack read victim %d@%d: %w", victim.id, m.srcOff, rerr)

--- a/pkg/block/journal/gc_test.go
+++ b/pkg/block/journal/gc_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"sync"
 	"testing"
+	"time"
 )
 
 // onlySealed returns the shard's single sealed segment, failing if there isn't
@@ -270,6 +271,106 @@ func TestGCCrashBeforeUnlinkOrphanSwept(t *testing.T) {
 	}
 	if !bytes.Equal(got2, keep) {
 		t.Fatalf("keep corrupted after post-recovery GC")
+	}
+}
+
+// TestGCTombstoneOnlySegmentTerminates guards pickVictim against an infinite
+// repack loop. A fully-dead payload segment that also carries a tombstone gets
+// repacked into a tombstone-only segment (0 live records, 0 dead bytes). That
+// tombstone-only segment must NOT be re-selected — repacking it would only copy
+// the tombstone into another identical segment forever.
+func TestGCTombstoneOnlySegmentTerminates(t *testing.T) {
+	s := testStore(t, Config{SegmentSize: minSegmentSize, ShardCount: 1})
+	ctx := context.Background()
+
+	// "gone" data + its tombstone land in one active segment; "roll" seals it.
+	gone := make([]byte, 700<<10)
+	rand.New(rand.NewSource(7)).Read(gone)
+	if err := s.WriteAt(ctx, "gone", 0, gone); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Delete(ctx, "gone"); err != nil { // tombstone in the same segment
+		t.Fatal(err)
+	}
+	if err := s.WriteAt(ctx, "roll", 0, make([]byte, 400<<10)); err != nil { // force seal
+		t.Fatal(err)
+	}
+
+	// Non-Force GC must terminate. With the bug it repacks the fully-dead segment
+	// into a tombstone-only one, then loops forever repacking that. Bound the pass.
+	done := make(chan error, 1)
+	go func() { _, err := s.GC(ctx, GCOptions{}); done <- err }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("GC did not terminate: tombstone-only segment repack loop")
+	}
+
+	// A second pass finds nothing to reclaim in the tombstone-only segment.
+	res, err := s.GC(ctx, GCOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.SegmentsRepacked != 0 {
+		t.Fatalf("second GC pass repacked a tombstone-only segment: %d", res.SegmentsRepacked)
+	}
+
+	// "gone" stays deleted; "roll" is intact.
+	goneGot := make([]byte, 700<<10)
+	for i := range goneGot {
+		goneGot[i] = 0xFF
+	}
+	if _, _, err := s.ReadAt(ctx, "gone", 0, goneGot); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(goneGot, make([]byte, 700<<10)) {
+		t.Fatalf("deleted file resurrected across GC")
+	}
+}
+
+// TestDeleteFailedTombstoneLeavesIndexIntact verifies Delete's durability-first
+// ordering: if the tombstone append fails, the in-memory index and counters are
+// unchanged, so a failed Delete never makes data disappear.
+func TestDeleteFailedTombstoneLeavesIndexIntact(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+	want := bytes.Repeat([]byte("x"), 100)
+	if err := s.WriteAt(ctx, "f", 0, want); err != nil {
+		t.Fatal(err)
+	}
+	before := s.UnsyncedBytes()
+
+	testFailTombstone = "f"
+	err := s.Delete(ctx, "f")
+	testFailTombstone = ""
+	if err == nil {
+		t.Fatal("Delete: want error from failed tombstone append, got nil")
+	}
+
+	sh := s.shardFor("f")
+	sh.mu.Lock()
+	_, stillIndexed := sh.index["f"]
+	dead := sh.active.deadBytes.Load()
+	sh.mu.Unlock()
+	if !stillIndexed {
+		t.Fatal("file dropped from index despite failed tombstone append")
+	}
+	if dead != 0 {
+		t.Fatalf("deadBytes charged despite failed tombstone append: %d", dead)
+	}
+	if u := s.UnsyncedBytes(); u != before {
+		t.Fatalf("unsynced changed on failed delete: %d -> %d", before, u)
+	}
+	// The file still reads back intact.
+	got := make([]byte, 100)
+	if _, _, err := s.ReadAt(ctx, "f", 0, got); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatal("file data corrupted by failed delete")
 	}
 }
 

--- a/pkg/block/journal/gc_test.go
+++ b/pkg/block/journal/gc_test.go
@@ -1,0 +1,346 @@
+package journal
+
+import (
+	"bytes"
+	"context"
+	"math/rand"
+	"sync"
+	"testing"
+)
+
+// onlySealed returns the shard's single sealed segment, failing if there isn't
+// exactly one.
+func onlySealed(t *testing.T, s *Store, id FileID) *segmentMeta {
+	t.Helper()
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if len(sh.sealed) != 1 {
+		t.Fatalf("want exactly one sealed segment, got %d", len(sh.sealed))
+	}
+	for _, seg := range sh.sealed {
+		return seg
+	}
+	return nil
+}
+
+func TestDeadBytesOnOverwrite(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+
+	if err := s.WriteAt(ctx, "f", 0, bytes.Repeat([]byte("A"), 10)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.WriteAt(ctx, "f", 3, []byte("BBBB")); err != nil { // supersedes 4 bytes
+		t.Fatal(err)
+	}
+	sh := s.shardFor("f")
+	sh.mu.Lock()
+	dead := sh.active.deadBytes.Load()
+	sh.mu.Unlock()
+	if dead != 4 {
+		t.Fatalf("deadBytes = %d, want 4", dead)
+	}
+}
+
+func TestDeadBytesOnTombstone(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+
+	if err := s.WriteAt(ctx, "f", 0, bytes.Repeat([]byte("x"), 100)); err != nil {
+		t.Fatal(err)
+	}
+	before := s.UnsyncedBytes()
+	if before != 100 {
+		t.Fatalf("unsynced before delete = %d, want 100", before)
+	}
+	if err := s.Delete(ctx, "f"); err != nil {
+		t.Fatal(err)
+	}
+	sh := s.shardFor("f")
+	sh.mu.Lock()
+	dead := sh.active.deadBytes.Load()
+	_, stillIndexed := sh.index["f"]
+	sh.mu.Unlock()
+	if dead != 100 {
+		t.Fatalf("deadBytes after delete = %d, want 100", dead)
+	}
+	if stillIndexed {
+		t.Fatalf("file still indexed after delete")
+	}
+	if u := s.UnsyncedBytes(); u != 0 {
+		t.Fatalf("unsynced after delete = %d, want 0", u)
+	}
+	// The deleted file now reads as all holes.
+	got := make([]byte, 100)
+	for i := range got {
+		got[i] = 0xFF
+	}
+	if _, _, err := s.ReadAt(ctx, "f", 0, got); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, make([]byte, 100)) {
+		t.Fatalf("deleted file did not read as holes")
+	}
+}
+
+// seedRepackable builds a store with one sealed segment holding a synced "keep"
+// record and a dirty "gone" record, then deletes "gone" so the sealed segment is
+// 70% dead. It returns the keep payload for byte-identity checks.
+func seedRepackable(t *testing.T, s *Store) []byte {
+	t.Helper()
+	ctx := context.Background()
+	keep := make([]byte, 300<<10)
+	gone := make([]byte, 700<<10)
+	rand.New(rand.NewSource(1)).Read(keep)
+	rand.New(rand.NewSource(2)).Read(gone)
+
+	if err := s.Hydrate(ctx, "keep", 0, keep); err != nil { // synced=true
+		t.Fatal(err)
+	}
+	if err := s.WriteAt(ctx, "gone", 0, gone); err != nil { // synced=false
+		t.Fatal(err)
+	}
+	// Roll the active segment over so keep+gone land in a sealed segment.
+	if err := s.WriteAt(ctx, "trigger", 0, make([]byte, 200<<10)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Delete(ctx, "gone"); err != nil {
+		t.Fatal(err)
+	}
+	return keep
+}
+
+func TestGCForcedRepackPreservesData(t *testing.T) {
+	s := testStore(t, Config{SegmentSize: minSegmentSize, ShardCount: 1})
+	ctx := context.Background()
+	keep := seedRepackable(t, s)
+
+	victim := onlySealed(t, s, "keep")
+	occupied := victim.liveBytes.Load()
+	if occupied != int64(len(keep)+700<<10) {
+		t.Fatalf("occupied = %d, want %d", occupied, len(keep)+700<<10)
+	}
+	if dead := victim.deadBytes.Load(); dead != 700<<10 {
+		t.Fatalf("deadBytes = %d, want %d", dead, 700<<10)
+	}
+
+	// Capture keep's version + synced flag: repack must preserve both.
+	sh := s.shardFor("keep")
+	sh.mu.Lock()
+	preVer := sh.index["keep"].ivs[0].version
+	preSynced := sh.index["keep"].ivs[0].synced
+	sh.mu.Unlock()
+
+	// 0.7 dead ratio >= default GCDeadRatioForce (0.5): an auto pass repacks it.
+	res, err := s.GC(ctx, GCOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.SegmentsRepacked != 1 {
+		t.Fatalf("SegmentsRepacked = %d, want 1", res.SegmentsRepacked)
+	}
+	if res.BytesReclaimed <= 0 {
+		t.Fatalf("BytesReclaimed = %d, want > 0", res.BytesReclaimed)
+	}
+
+	// keep survives byte-identically; gone stays deleted.
+	got := make([]byte, len(keep))
+	if _, cold, err := s.ReadAt(ctx, "keep", 0, got); err != nil || cold {
+		t.Fatalf("ReadAt keep: err=%v cold=%v", err, cold)
+	}
+	if !bytes.Equal(got, keep) {
+		t.Fatalf("keep not byte-identical after repack")
+	}
+
+	sh.mu.Lock()
+	iv := sh.index["keep"].ivs[0]
+	newTarget := sh.sealed[iv.loc.SegmentID]
+	sh.mu.Unlock()
+	if iv.version != preVer {
+		t.Fatalf("version changed by repack: %d -> %d", preVer, iv.version)
+	}
+	if iv.synced != preSynced || !iv.synced {
+		t.Fatalf("synced flag not preserved: %v", iv.synced)
+	}
+	if iv.loc.SegmentID == victim.id {
+		t.Fatalf("interval still points at the reclaimed victim")
+	}
+	if newTarget == nil || newTarget.syncedRecords.Load() != 1 {
+		t.Fatalf("target syncedRecords not preserved")
+	}
+}
+
+func TestGCBelowThresholdNeedsForce(t *testing.T) {
+	s := testStore(t, Config{SegmentSize: minSegmentSize, ShardCount: 1})
+	ctx := context.Background()
+
+	// Sealed segment with a small dead fraction: keep 900KiB, supersede 50KiB.
+	big := make([]byte, 900<<10)
+	rand.New(rand.NewSource(3)).Read(big)
+	if err := s.WriteAt(ctx, "f", 0, big); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.WriteAt(ctx, "f", 0, make([]byte, 50<<10)); err != nil { // 50KiB dead
+		t.Fatal(err)
+	}
+	if err := s.WriteAt(ctx, "roll", 0, make([]byte, 200<<10)); err != nil { // seal it
+		t.Fatal(err)
+	}
+
+	res, err := s.GC(ctx, GCOptions{}) // ~5% dead < 0.5: no-op
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.SegmentsRepacked != 0 {
+		t.Fatalf("auto GC repacked below threshold: %d", res.SegmentsRepacked)
+	}
+	res, err = s.GC(ctx, GCOptions{Force: true}) // Force repacks the worst offender
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.SegmentsRepacked != 1 {
+		t.Fatalf("forced GC did not repack: %d", res.SegmentsRepacked)
+	}
+}
+
+func TestGCCrashBeforeUnlinkOrphanSwept(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{SegmentSize: minSegmentSize, ShardCount: 1}
+	s, err := Open(dir, cfg, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	keep := seedRepackable(t, s)
+
+	// Repack but stop right before reclaiming the victim: on disk the target is
+	// durable while the victim still exists (crash-before-unlink).
+	testStopBeforeUnlink = true
+	if _, err := s.GC(ctx, GCOptions{Force: true}); err != nil {
+		testStopBeforeUnlink = false
+		t.Fatal(err)
+	}
+	testStopBeforeUnlink = false
+
+	// Two .seg files exist now: victim + target. Recovery must dedup them.
+	ids, _ := scanSegmentIDs(dir)
+	segCount := 0
+	for range ids {
+		segCount++
+	}
+	if segCount < 2 {
+		t.Fatalf("expected victim orphan alongside target, got %d segments", segCount)
+	}
+	_ = s.Close()
+
+	// Restart: recovery replays both segments (identical Version -> byte-identical).
+	r, err := Open(dir, cfg, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("recovery after crash-before-unlink: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	got := make([]byte, len(keep))
+	if _, cold, err := r.ReadAt(ctx, "keep", 0, got); err != nil || cold {
+		t.Fatalf("ReadAt keep after recovery: err=%v cold=%v", err, cold)
+	}
+	if !bytes.Equal(got, keep) {
+		t.Fatalf("keep not byte-identical after crash-before-unlink recovery")
+	}
+	// gone stays deleted (its tombstone survived).
+	goneGot := make([]byte, 700<<10)
+	for i := range goneGot {
+		goneGot[i] = 0xFF
+	}
+	if _, _, err := r.ReadAt(ctx, "gone", 0, goneGot); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(goneGot, make([]byte, 700<<10)) {
+		t.Fatalf("deleted file resurrected after recovery")
+	}
+
+	// The redundant orphan is reclaimable: a forced pass frees it, leaving data intact.
+	if _, err := r.GC(ctx, GCOptions{Force: true}); err != nil {
+		t.Fatal(err)
+	}
+	got2 := make([]byte, len(keep))
+	if _, _, err := r.ReadAt(ctx, "keep", 0, got2); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got2, keep) {
+		t.Fatalf("keep corrupted after post-recovery GC")
+	}
+}
+
+// TestGCConcurrentWithWrites stresses the read/GC/write interplay under -race.
+func TestGCConcurrentWithWrites(t *testing.T) {
+	s := testStore(t, Config{SegmentSize: minSegmentSize, ShardCount: 4})
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writers churn overlapping ranges (producing dead bytes) across files.
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			id := FileID(string(rune('a' + w)))
+			buf := make([]byte, 64<<10)
+			for i := 0; ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				off := int64((i % 16) * (64 << 10))
+				if err := s.WriteAt(ctx, id, off, buf); err != nil {
+					t.Errorf("WriteAt: %v", err)
+					return
+				}
+			}
+		}(w)
+	}
+	// Readers race the GC over the same segments.
+	for r := 0; r < 2; r++ {
+		wg.Add(1)
+		go func(r int) {
+			defer wg.Done()
+			dst := make([]byte, 64<<10)
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_, _, _ = s.ReadAt(ctx, FileID(string(rune('a'+r))), 0, dst)
+			}
+		}(r)
+	}
+	// GC loop.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if _, err := s.GC(ctx, GCOptions{Force: true}); err != nil {
+				t.Errorf("GC: %v", err)
+				return
+			}
+		}
+	}()
+
+	// Let them run a bounded number of scheduler ticks.
+	for i := 0; i < 2000; i++ {
+		if err := s.WriteAt(ctx, "driver", int64(i%8)*4096, make([]byte, 4096)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	close(stop)
+	wg.Wait()
+}

--- a/pkg/block/journal/index.go
+++ b/pkg/block/journal/index.go
@@ -103,13 +103,21 @@ func (fi *fileIndex) findRecord(fileOff int64, version uint64) int {
 	return -1
 }
 
+// segDead reports payload bytes in a segment that a newer write just made dead
+// (a superseded, non-cold interval), so the caller can charge them to that
+// segment's deadBytes counter — the size-tiered GC victim signal.
+type segDead struct {
+	seg   uint64
+	bytes int64
+}
+
 // insert records iv, resolving overlaps by version (highest wins). Existing
 // intervals with a higher version shadow iv; those with a lower version are
 // trimmed to make room. The result stays sorted and non-overlapping.
-// It returns the number of still-dirty (unsynced, non-cold) live bytes that this
-// insert superseded, so the caller can keep an unsynced-byte counter accurate
-// (dead bytes must leave the count).
-func (fi *fileIndex) insert(iv interval) (dirtyRemoved int64) {
+// It returns the number of still-dirty (unsynced, non-cold) live bytes this
+// insert superseded (so the caller keeps the unsynced-byte counter accurate) and
+// the per-segment dead bytes it created (so the caller feeds GC victim selection).
+func (fi *fileIndex) insert(iv interval) (dirtyRemoved int64, dead []segDead) {
 	ns, ne := iv.fileOff, iv.end()
 	// First interval that can overlap [ns, ne): end() is strictly increasing
 	// across the non-overlapping sorted set, so the predicate is monotone.
@@ -126,9 +134,11 @@ func (fi *fileIndex) insert(iv interval) (dirtyRemoved int64) {
 			newFrags = subtractAll(newFrags, e.fileOff, e.end())
 		} else {
 			// New wins the overlap: keep only the parts of e outside iv. The
-			// removed slice of a dirty interval leaves the live dirty coverage.
-			if !e.synced && !e.cold {
-				if ov := min(e.end(), ne) - max(e.fileOff, ns); ov > 0 {
+			// removed slice's bytes are now dead in e's segment (a cold interval
+			// holds no local bytes, so it frees none).
+			if ov := min(e.end(), ne) - max(e.fileOff, ns); ov > 0 && !e.cold {
+				dead = append(dead, segDead{seg: e.loc.SegmentID, bytes: ov})
+				if !e.synced {
 					dirtyRemoved += ov
 				}
 			}
@@ -140,7 +150,7 @@ func (fi *fileIndex) insert(iv interval) (dirtyRemoved int64) {
 	merged := append(survivors, newFrags...)
 	sort.Slice(merged, func(i, j int) bool { return merged[i].fileOff < merged[j].fileOff })
 	fi.ivs = slices.Replace(fi.ivs, lo, hi, merged...)
-	return dirtyRemoved
+	return dirtyRemoved, dead
 }
 
 // subtractAll removes [rs, re) from every fragment, flattening the survivors.
@@ -224,24 +234,55 @@ func (s *Store) ReadAt(ctx context.Context, id FileID, offset int64, dst []byte)
 		return len(dst), false, nil
 	}
 	pieces := fi.plan(offset, int64(len(dst)))
+	// Resolve and read-guard each data piece's segment while the index and the
+	// segment set are still consistent under sh.mu. Holding the shared guard
+	// across the unlocked preads keeps a concurrent GC/eviction from reclaiming
+	// (and closing) the segment mid-read; the reclaimer removes it from the set
+	// and then blocks on the exclusive guard until these reads drain.
+	segs := make([]*segmentMeta, len(pieces))
+	for i, p := range pieces {
+		if p.hole || p.cold {
+			continue
+		}
+		seg := sh.segment(p.loc.SegmentID)
+		if seg == nil {
+			sh.mu.Unlock()
+			releaseGuards(segs)
+			return int(p.dstStart), false, fmt.Errorf("journal: unknown segment %d", p.loc.SegmentID)
+		}
+		seg.readGuard.RLock()
+		segs[i] = seg
+	}
 	sh.mu.Unlock()
+	defer releaseGuards(segs)
 
-	for _, p := range pieces {
-		seg := dst[p.dstStart:p.dstEnd]
+	for i, p := range pieces {
+		out := dst[p.dstStart:p.dstEnd]
 		switch {
 		case p.hole:
-			clear(seg)
+			clear(out)
 		case p.cold:
-			clear(seg)
+			clear(out)
 			cold = true
 			s.coldReads.Add(1)
 		default:
-			if _, err := s.readPayload(sh, p.loc, p.subOff, seg); err != nil {
-				return int(p.dstStart), false, err
+			seg := segs[i]
+			seg.lastAccess.Store(s.clock.Now().UnixNano())
+			if _, rerr := seg.fd.ReadAt(out, p.loc.Offset+p.subOff); rerr != nil {
+				return int(p.dstStart), false, fmt.Errorf("journal: read segment %d@%d: %w", p.loc.SegmentID, p.loc.Offset+p.subOff, rerr)
 			}
 		}
 	}
 	return len(dst), cold, nil
+}
+
+// releaseGuards drops every held read guard, tolerating the nil holes/cold slots.
+func releaseGuards(segs []*segmentMeta) {
+	for _, seg := range segs {
+		if seg != nil {
+			seg.readGuard.RUnlock()
+		}
+	}
 }
 
 // DataExtents returns the merged [start, end) byte ranges that hold written data

--- a/pkg/block/journal/recovery.go
+++ b/pkg/block/journal/recovery.go
@@ -75,7 +75,8 @@ func (s *Store) recover() error {
 		maxVersion uint64
 		unsynced   int64
 		missingIdx int
-		opened     []*segmentMeta // every fd we opened, closed on error
+		opened     []*segmentMeta        // every fd we opened, closed on error
+		tombstones = map[FileID]uint64{} // deleted file -> highest tombstone version
 		ok         bool
 	)
 	defer func() {
@@ -177,6 +178,10 @@ func (s *Store) recover() error {
 				maxVersion = rec.header.Version
 			}
 			if rec.header.Flags&flagTombstone != 0 {
+				fid := FileID(rec.fileID)
+				if rec.header.Version > tombstones[fid] {
+					tombstones[fid] = rec.header.Version
+				}
 				continue
 			}
 			payloadOff := rec.segOff + recordHeaderSize + int64(len(rec.fileID))
@@ -222,6 +227,30 @@ func (s *Store) recover() error {
 	// nextVersion increments-then-returns, so storing maxVersion makes the next
 	// issued LSN exactly max(observed)+1 — strictly past every replayed record.
 	s.version.Store(maxVersion)
+
+	// Honor tombstones: a delete's tombstone Version exceeds every prior write to
+	// that file, so drop the file's intervals older than it. A rewrite after the
+	// delete carries a higher Version and survives, recreating the file.
+	for _, idxMap := range indexByShard {
+		for fid, fi := range idxMap {
+			tv, deleted := tombstones[fid]
+			if !deleted {
+				continue
+			}
+			kept := fi.ivs[:0]
+			for _, iv := range fi.ivs {
+				if iv.version > tv {
+					kept = append(kept, iv)
+				}
+			}
+			if len(kept) == 0 {
+				delete(idxMap, fid)
+			} else {
+				fi.ivs = kept
+			}
+		}
+	}
+
 	// Recompute unsynced from the final live coverage rather than the raw
 	// per-record sum: insert resolves overlaps, so a superseded record's bytes are
 	// dead and must not count toward the backpressure signal.

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -348,17 +348,23 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 }
 
 // appendTombstone frames a zero-payload tombstone record for id and fsyncs the
-// shard's active segment. The fsync makes the delete at least as durable as any
-// data record it shadows (which was durable only if fsynced), so recovery can
-// never replay data whose tombstone was lost. Not indexed: a tombstone is not
-// live data; recovery reads it to suppress the file's older records.
-func (s *Store) appendTombstone(ctx context.Context, id FileID) error {
+// shard's active segment, returning the tombstone's Version. The fsync makes the
+// delete at least as durable as any data record it shadows (which was durable
+// only if fsynced), so recovery can never replay data whose tombstone was lost.
+// The record is indexed too (an idxEntry with flagTombstone), so rebuildIdx and
+// recovery suppress the file's older records without rescanning the .seg.
+func (s *Store) appendTombstone(ctx context.Context, id FileID) (uint64, error) {
 	if err := ctx.Err(); err != nil {
-		return err
+		return 0, err
 	}
 	fileID := []byte(id)
 	if len(fileID) > maxFileIDLen {
-		return fmt.Errorf("journal: FileID length %d exceeds max %d", len(fileID), maxFileIDLen)
+		return 0, fmt.Errorf("journal: FileID length %d exceeds max %d", len(fileID), maxFileIDLen)
+	}
+	if testFailTombstone != "" && id == testFailTombstone {
+		// Test seam: model a durability failure (e.g. a failed fsync) before any
+		// state is persisted. Delete must then leave its in-memory index untouched.
+		return 0, fmt.Errorf("journal: injected tombstone failure for %q", id)
 	}
 	recLen := recordLen(len(fileID), 0)
 
@@ -367,7 +373,7 @@ func (s *Store) appendTombstone(ctx context.Context, id FileID) error {
 	if sh.active.tail.Load()+recLen > s.cfg.SegmentSize {
 		if err := s.sealSegment(sh); err != nil {
 			sh.mu.Unlock()
-			return err
+			return 0, err
 		}
 	}
 	seg := sh.active
@@ -375,7 +381,7 @@ func (s *Store) appendTombstone(ctx context.Context, id FileID) error {
 	recStart, err := writeTombstoneRecord(seg, id, version)
 	if err != nil {
 		sh.mu.Unlock()
-		return err
+		return 0, err
 	}
 	if seg.idxFD != nil {
 		_, _ = seg.idxFD.Write(idxEntry{
@@ -388,10 +394,15 @@ func (s *Store) appendTombstone(ctx context.Context, id FileID) error {
 	fd := seg.fd
 	sh.mu.Unlock()
 	if err := fd.Sync(); err != nil {
-		return fmt.Errorf("journal: fsync tombstone: %w", err)
+		return 0, fmt.Errorf("journal: fsync tombstone: %w", err)
 	}
-	return nil
+	return version, nil
 }
+
+// testFailTombstone, when it equals a Delete's FileID, makes appendTombstone
+// return an error before persisting anything, modeling a durability failure.
+// Always empty in production.
+var testFailTombstone FileID
 
 // writeTombstoneRecord frames a zero-payload tombstone at seg's tail and advances
 // it. Shared by the delete path and by repack's tombstone carry-forward.

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -53,12 +54,16 @@ type segmentMeta struct {
 	records       atomic.Int64 // physical records appended (eviction synced-gate denominator)
 	syncedRecords atomic.Int64 // records with the synced flag set (eviction gate)
 	lastAccess    atomic.Int64 // unix nanos, approx-LRU victim key
-	// busy claims the segment for an exclusive whole-segment operation (evict, and
-	// GC repack once it lands). A claimer CAS-sets it true so eviction and GC never
-	// touch the same sealed segment concurrently; warm reads and carve don't claim.
+	// busy claims the segment for an exclusive whole-segment operation (evict or
+	// GC repack). A claimer CAS-sets it true so eviction and GC never touch the
+	// same sealed segment concurrently; warm reads and carve don't claim.
 	busy  atomic.Bool
 	fd    *os.File
 	idxFD *os.File // persistent append handle for the .idx sidecar (nil if unavailable)
+	// readGuard coordinates unlocked preads against a GC/eviction that unlinks the
+	// segment: readers hold it shared across a pread, the reclaimer holds it
+	// exclusive around close+unlink so no read touches a closed fd.
+	readGuard sync.RWMutex
 	// ponytail: the quotient-filter membership hint (rebuilt on repack) arrives
 	// with GC; a linear index scan suffices until segments are large.
 }
@@ -165,37 +170,41 @@ func fsyncDir(dir string) error {
 	return d.Close()
 }
 
-// sealSegment fsyncs the shard's active segment, flips its on-disk sealed bit,
-// fsyncs again, moves it into the sealed set and opens a fresh active segment.
-// Durability boundary: data is fsynced BEFORE the sealed bit is set, so a
-// commit that a size-cap rotation sealed between checkpoints never loses bytes.
+// sealInPlace makes an appended-into segment immutable: fsync its record bytes,
+// set the on-disk sealed bit, fsync again, then close its .idx append handle.
+// Durability boundary: data is fsynced BEFORE the sealed bit so recovery never
+// trusts a header whose records did not reach disk. The caller moves it into the
+// sealed set. Used both by rotation and by GC when it seals a repack target.
+func (m *segmentMeta) sealInPlace() error {
+	if err := m.fd.Sync(); err != nil {
+		return fmt.Errorf("journal: fsync before seal: %w", err)
+	}
+	// Preserve the original CreatedAt so age-gating stays correct.
+	if _, err := m.fd.WriteAt(encodeSegHeader(m.id, m.createdAt, segFlagSealed), 0); err != nil {
+		return fmt.Errorf("journal: set sealed bit: %w", err)
+	}
+	if err := m.fd.Sync(); err != nil {
+		return fmt.Errorf("journal: fsync after seal: %w", err)
+	}
+	if m.idxFD != nil {
+		_ = m.idxFD.Close()
+		m.idxFD = nil
+	}
+	m.sealed.Store(true)
+	return nil
+}
+
+// sealSegment seals the shard's active segment, moves it into the sealed set and
+// opens a fresh active segment. The segment's existing fd stays open and serves
+// warm reads from the sealed set; GC/eviction swap it only under its readGuard,
+// so readPayload's snapshot-then-unlocked-pread never touches a closed fd.
 //
 // Caller must hold sh.mu.
 func (s *Store) sealSegment(sh *shard) error {
 	old := sh.active
-	if err := old.fd.Sync(); err != nil {
-		return fmt.Errorf("journal: fsync before seal: %w", err)
+	if err := old.sealInPlace(); err != nil {
+		return err
 	}
-	// Rewrite the header with the sealed bit set, preserving the original
-	// CreatedAt so age-gating stays correct.
-	if _, err := old.fd.WriteAt(encodeSegHeader(old.id, old.createdAt, segFlagSealed), 0); err != nil {
-		return fmt.Errorf("journal: set sealed bit: %w", err)
-	}
-	if err := old.fd.Sync(); err != nil {
-		return fmt.Errorf("journal: fsync after seal: %w", err)
-	}
-	// A sealed segment is immutable: close its .idx append handle (the file
-	// stays on disk, read-only).
-	if old.idxFD != nil {
-		_ = old.idxFD.Close()
-		old.idxFD = nil
-	}
-	// Keep the segment's existing fd open and hand it to the sealed set — the
-	// same fd serves warm reads. It is set once at creation and never swapped,
-	// so readPayload's snapshot-then-unlocked-pread races nothing (mirrors how
-	// logblob pools the old active fd on rotate rather than reopening it). No
-	// append path touches a sealed segment, so the writable handle is harmless.
-	old.sealed.Store(true)
 	sh.sealed[old.id] = old
 
 	seg, err := s.createSegment()
@@ -303,7 +312,7 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 	}
 
 	fi := sh.indexFor(id)
-	dirtyRemoved := fi.insert(interval{
+	dirtyRemoved, dead := fi.insert(interval{
 		fileOff: offset,
 		length:  int64(len(data)),
 		version: version,
@@ -311,6 +320,13 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 		synced:  synced,
 		loc:     SegmentLocation{SegmentID: seg.id, Offset: payloadOff, Length: int64(len(data))},
 	})
+	// Charge superseded bytes to their segment's dead counter: this is the
+	// size-tiered GC victim signal. sh.segment needs sh.mu, held here.
+	for _, d := range dead {
+		if ds := sh.segment(d.seg); ds != nil {
+			ds.deadBytes.Add(d.bytes)
+		}
+	}
 
 	s.writes.Add(1)
 	// unsynced tracks live dirty bytes: add this write if dirty, and always drop
@@ -331,9 +347,79 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 	return nil
 }
 
+// appendTombstone frames a zero-payload tombstone record for id and fsyncs the
+// shard's active segment. The fsync makes the delete at least as durable as any
+// data record it shadows (which was durable only if fsynced), so recovery can
+// never replay data whose tombstone was lost. Not indexed: a tombstone is not
+// live data; recovery reads it to suppress the file's older records.
+func (s *Store) appendTombstone(ctx context.Context, id FileID) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	fileID := []byte(id)
+	if len(fileID) > maxFileIDLen {
+		return fmt.Errorf("journal: FileID length %d exceeds max %d", len(fileID), maxFileIDLen)
+	}
+	recLen := recordLen(len(fileID), 0)
+
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	if sh.active.tail.Load()+recLen > s.cfg.SegmentSize {
+		if err := s.sealSegment(sh); err != nil {
+			sh.mu.Unlock()
+			return err
+		}
+	}
+	seg := sh.active
+	version := s.nextVersion()
+	recStart, err := writeTombstoneRecord(seg, id, version)
+	if err != nil {
+		sh.mu.Unlock()
+		return err
+	}
+	if seg.idxFD != nil {
+		_, _ = seg.idxFD.Write(idxEntry{
+			FileIDHash: fnv1a(string(id)),
+			Version:    version,
+			SegOffset:  uint64(recStart + recordHeaderSize + int64(len(fileID))),
+			Flags:      flagTombstone,
+		}.encode())
+	}
+	fd := seg.fd
+	sh.mu.Unlock()
+	if err := fd.Sync(); err != nil {
+		return fmt.Errorf("journal: fsync tombstone: %w", err)
+	}
+	return nil
+}
+
+// writeTombstoneRecord frames a zero-payload tombstone at seg's tail and advances
+// it. Shared by the delete path and by repack's tombstone carry-forward.
+func writeTombstoneRecord(seg *segmentMeta, id FileID, version uint64) (recStart int64, err error) {
+	fileID := []byte(id)
+	recStart = seg.tail.Load()
+	hdr := encodeHeader(recordHeader{
+		FileIDLen: uint16(len(fileID)),
+		Version:   version,
+		Flags:     flagTombstone,
+	}, fileID)
+	if _, err = seg.fd.WriteAt(hdr, recStart); err != nil {
+		return 0, fmt.Errorf("journal: write tombstone header: %w", err)
+	}
+	var crcBuf [payloadCRCSize]byte
+	binary.LittleEndian.PutUint32(crcBuf[:], crc(nil))
+	if _, err = seg.fd.WriteAt(crcBuf[:], recStart+int64(len(hdr))); err != nil {
+		return 0, fmt.Errorf("journal: write tombstone CRC: %w", err)
+	}
+	seg.tail.Store(recStart + recordLen(len(fileID), 0))
+	return recStart, nil
+}
+
 // readPayload preads length bytes of a record payload starting subOffset into
 // the payload identified by loc, into dst. It snapshots the segment fd under
-// the shard lock, then preads unlocked.
+// the shard lock, then preads unlocked. Carve is its only caller and holds the
+// shard's carveMu, which GC/eviction also hold before closing a segment, so the
+// fd cannot close under it. (ReadAt does its own resolve-and-guard — see readAt.)
 func (s *Store) readPayload(sh *shard, loc SegmentLocation, subOffset int64, dst []byte) (int, error) {
 	sh.mu.Lock()
 	seg := sh.segment(loc.SegmentID)

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -17,10 +18,6 @@ type FileID string
 
 // BlockID is the opaque key of a packed block in the remote store.
 type BlockID string
-
-// errNotImplemented is returned by operations whose implementation lands in a
-// later change (carve, evict, gc, delete).
-var errNotImplemented = errors.New("journal: not yet implemented")
 
 // errClosed is returned by every operation attempted on a closed Store.
 var errClosed = errors.New("journal: store closed")
@@ -123,6 +120,10 @@ type Store struct {
 
 	shards    []*shard
 	shardMask uint64
+
+	// gcMu serializes GC passes: only one repack runs at a time so two passes
+	// never pick the same victim.
+	gcMu sync.Mutex
 
 	nextSeg   atomic.Uint64 // global segment-ID allocator
 	version   atomic.Uint64 // global monotonic LSN
@@ -278,9 +279,42 @@ func (s *Store) Stats() Stats {
 	return st
 }
 
-// Delete drops all of a file's cached ranges. Not yet implemented.
+// Delete drops all of a file's cached ranges and persists a tombstone so
+// recovery does not resurrect the file from its still-on-disk records (they
+// linger in their segments until GC repacks them away). The tombstone's Version
+// exceeds every prior write to the file, so a rewrite after the delete — with a
+// higher Version — survives, recreating the file (correct create-after-unlink).
 func (s *Store) Delete(ctx context.Context, id FileID) error {
-	return errNotImplemented
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if s.closed.Load() {
+		return errClosed
+	}
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	fi := sh.index[id]
+	var dirty int64
+	if fi != nil {
+		// Every live, non-cold interval's bytes become dead in their segment.
+		for _, iv := range fi.ivs {
+			if iv.cold {
+				continue
+			}
+			if seg := sh.segment(iv.loc.SegmentID); seg != nil {
+				seg.deadBytes.Add(iv.length)
+			}
+			if !iv.synced {
+				dirty += iv.length
+			}
+		}
+		delete(sh.index, id)
+	}
+	sh.mu.Unlock()
+	if dirty != 0 {
+		s.unsynced.Add(-dirty)
+	}
+	return s.appendTombstone(ctx, id)
 }
 
 // segPath returns the on-disk path of a segment by ID.

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -121,8 +121,10 @@ type Store struct {
 	shards    []*shard
 	shardMask uint64
 
-	// gcMu serializes GC passes: only one repack runs at a time so two passes
-	// never pick the same victim.
+	// gcMu serializes GC passes against each other: only one pass runs at a time,
+	// so two passes never pick the same victim. It does NOT exclude Carve or Evict
+	// — a running GC pass keeps them off its segments via the per-shard carveMu it
+	// holds and the per-segment busy claim it CAS-sets on each victim, not gcMu.
 	gcMu sync.Mutex
 
 	nextSeg   atomic.Uint64 // global segment-ID allocator
@@ -291,13 +293,30 @@ func (s *Store) Delete(ctx context.Context, id FileID) error {
 	if s.closed.Load() {
 		return errClosed
 	}
+	// Durability first: persist and fsync the tombstone BEFORE touching the
+	// in-memory index or the counters. If the append fails, the file's ranges are
+	// left intact — a failed Delete never makes data disappear, and a crash can
+	// never resurrect a file whose tombstone is already durable. The returned
+	// Version fences which intervals the delete buries: only those at or below it
+	// (a concurrent rewrite that raced past it carries a higher Version and
+	// survives, recreating the file), mirroring recovery.
+	tombVer, err := s.appendTombstone(ctx, id)
+	if err != nil {
+		return err
+	}
+
 	sh := s.shardFor(id)
 	sh.mu.Lock()
 	fi := sh.index[id]
 	var dirty int64
 	if fi != nil {
-		// Every live, non-cold interval's bytes become dead in their segment.
+		kept := fi.ivs[:0]
 		for _, iv := range fi.ivs {
+			if iv.version > tombVer {
+				kept = append(kept, iv) // raced past the delete: survives
+				continue
+			}
+			// Buried by the tombstone: its bytes become dead in their segment.
 			if iv.cold {
 				continue
 			}
@@ -308,13 +327,17 @@ func (s *Store) Delete(ctx context.Context, id FileID) error {
 				dirty += iv.length
 			}
 		}
-		delete(sh.index, id)
+		if len(kept) == 0 {
+			delete(sh.index, id)
+		} else {
+			fi.ivs = kept
+		}
 	}
 	sh.mu.Unlock()
 	if dirty != 0 {
 		s.unsynced.Add(-dirty)
 	}
-	return s.appendTombstone(ctx, id)
+	return nil
 }
 
 // segPath returns the on-disk path of a segment by ID.


### PR DESCRIPTION
## Summary

Adds `gc.go` to the `journal` local block store: dead-byte tracking, size-tiered victim selection, and a crash-safe repack. Also wires `Delete` (tombstone) and makes warm reads safe against a concurrent reclaimer.

- **Dead-byte tracking.** `deadBytes` increments when an interval-tree node is superseded by a newer write (`appendRecord`) or a file is tombstoned (`Delete`). The superseded-per-segment breakdown flows out of `fileIndex.insert`.
- **Size-tiered victim.** `pickVictim` selects the sealed segment with the highest `dead/occupied` ratio, computing live bytes authoritatively from the interval index. `GCDeadRatioForce` (default 0.5) is the auto-repack threshold; `GCOptions.Force` repacks the single worst offender regardless.
- **Repack.** Live records (and carried-forward tombstones) are rewritten into a fresh sealed target, **preserving each record's `Version` and `synced` bit** (never reissued), then the source is unlinked. Concurrent overwrites during a pass are handled: the index is repointed only for intervals a source move still covers.
- **Delete durability.** `Delete` persists a zero-payload tombstone (fsynced) and recovery prunes a file's pre-tombstone intervals, so a deleted file is not resurrected on restart. A rewrite after delete has a higher `Version` and survives.

## Repack ordering invariant

**bytes-durable → index-durable → reclaim.** The target is fsynced and sealed (its dir entry fsynced at create) *before* the in-memory index is repointed, and the victim is unlinked *only after*. The interval index is not itself durable — recovery rebuilds it from the `.seg` records, which are now durable. A crash before the unlink leaves the victim as a harmless orphan: its records duplicate the target's with the identical `Version`, so recovery replays both byte-identically and the next GC pass (seeing the victim fully superseded via the index-authoritative live count) reclaims it. Proven by `TestGCCrashBeforeUnlinkOrphanSwept` (stop before unlink → reopen → data byte-identical, deleted file stays deleted, orphan reclaimed).

## BlockReclaimer concurrent-GC hazard

Handled by **confinement, not by touching `BlockReclaimer`.** Journal repack is strictly *local*: it relocates cache bytes between segments and never calls the remote store. The union `BlockReclaimer` refcount decrement is unsafe under concurrent GC (its sweeper lock is per-`GCStateRoot`, not per-remote), so journal GC never drives it. Remote-block reclamation stays with the engine's block-GC sweep (`pkg/block/engine/gc_block.go`), whose per-remote serialization is what makes a decrement safe — consistent with that file's own contract ("reclaim is driven by the remote GC sweep, NOT by the unlink refcount cascade"). A tombstone here only drops local records and marks local space dead; the deleted file's remote blocks are freed later, off this path. No boundary was crossed and no unsafe decrement was shipped. Documented in `doc.go` and `gc.go`.

## Concurrency

GC serializes on a store-level `gcMu` (one pass at a time) and holds each shard's `carveMu` for its pass (excludes carve; the same segment-busy discipline eviction will share). A new per-segment `readGuard` (`RWMutex`) lets warm reads run unlocked while GC unlinks segments: `ReadAt` resolves and read-guards each piece's segment inside the plan critical section; the reclaimer removes the victim from the set then blocks on the exclusive guard until in-flight reads drain. Warm-read throughput is unchanged (18 GB/s in-package bench).

## Tests

`gc_test.go`: dead-byte accounting on overwrite/tombstone; size-tiered + `GCDeadRatioForce` threshold (below-threshold no-op, `Force` repacks); repack preserves `Version`+`synced` and data byte-identical; crash-before-unlink orphan swept with no data loss; `-race` concurrent write/read/GC stress (48 tests × race, plus 20× stress). `GOOS=windows go build` clean.

## Coexistence with PR5 (eviction)

PR5's `evict.go` also reclaims sealed segments. On rebase I'll integrate GC with its per-shard/segment-claim mechanism so the two never operate on the same segment — both already funnel through `carveMu` + the segment `readGuard`.

Part of #1692