### PR TITLE
perf(block): journal carve adapters + ChunkParams + gap methods (Wall A switchover S1)

### DIFF
--- a/pkg/block/engine/blocksink.go
+++ b/pkg/block/engine/blocksink.go
@@ -1,0 +1,119 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/blockcodec"
+	"github.com/marmos91/dittofs/pkg/block/journal"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// engineDeduper answers journal's carve dedup oracle from the per-share
+// synced-hash store: a chunk is durable once its hash has been mirrored to the
+// remote at least once. A true result therefore means "remote-durable", the
+// contract journal.Deduper requires before a record's synced bit may flip.
+type engineDeduper struct {
+	synced metadata.SyncedHashStore
+}
+
+func (d engineDeduper) IsChunkDurable(ctx context.Context, hash journal.ChunkHash) (bool, error) {
+	return d.synced.IsSynced(ctx, block.ContentHash(hash))
+}
+
+// engineBlockSink is journal's production BlockSink: it seals each carved chunk,
+// frames them into one block via blockcodec, uploads the block with PutBlock,
+// and atomically commits the block record + synced locators + per-file manifest
+// rows. It mirrors Syncer.carveAndCommitBlock minus the local-byte resolution —
+// journal hands the plaintext in-hand on each CarveChunk.
+type engineBlockSink struct {
+	sealer    remote.ChunkSealer
+	rbs       remote.RemoteBlockStore
+	committer blockCommitter
+}
+
+func (s engineBlockSink) CommitBlock(ctx context.Context, chunks []journal.CarveChunk) error {
+	if len(chunks) == 0 {
+		return nil
+	}
+
+	blockID, err := newBlockID()
+	if err != nil {
+		return err
+	}
+
+	var rawBytes int64
+	for i := range chunks {
+		rawBytes += int64(len(chunks[i].Data))
+	}
+	var buf bytes.Buffer
+	// Pre-size so the block lands in one backing array: raw bytes plus per-chunk
+	// codec/seal headroom. Best-effort — skipped on an absurd size rather than
+	// risk a negative int conversion.
+	if grow := rawBytes + int64(len(chunks))*256 + 512; grow > 0 && grow <= math.MaxInt {
+		buf.Grow(int(grow))
+	}
+	// nil header-sealer: bodies are sealed per-chunk below, matching the carver.
+	builder, err := blockcodec.NewBuilder(&buf, blockID, nil)
+	if err != nil {
+		return fmt.Errorf("carve: new builder: %w", err)
+	}
+
+	commits := make([]block.BlockChunkCommit, 0, len(chunks))
+	fileChunks := make([]*block.FileChunk, 0, len(chunks))
+	for i := range chunks {
+		c := chunks[i]
+		h := block.ContentHash(c.Hash)
+
+		wire := c.Data
+		if s.sealer != nil {
+			wire, err = s.sealer.SealChunk(ctx, h, c.Data)
+			if err != nil {
+				return fmt.Errorf("carve: seal chunk %s: %w", h, err)
+			}
+		}
+		chunkLoc, err := builder.Add(h, wire)
+		if err != nil {
+			return fmt.Errorf("carve: frame chunk %s: %w", h, err)
+		}
+		// Local stays zero — the journal owns the local bytes, so there is no
+		// log-blob location to record (DefaultCommitBlock treats zero as "none").
+		commits = append(commits, block.BlockChunkCommit{Hash: h, Remote: chunkLoc})
+		fileChunks = append(fileChunks, &block.FileChunk{
+			ID:       fmt.Sprintf("%s/%d", c.FileID, c.FileOffset),
+			Hash:     h,
+			DataSize: uint32(len(c.Data)),
+			State:    block.BlockStatePending,
+		})
+	}
+	if _, err := builder.Finish(); err != nil {
+		return fmt.Errorf("carve: finish block: %w", err)
+	}
+
+	blockBytes := buf.Bytes()
+	blockHash := block.ContentHash(blake3.Sum256(blockBytes))
+
+	// PutBlock first: a crash before the commit leaves an orphan block (GC
+	// reclaims it), never an unbacked record.
+	if err := s.rbs.PutBlock(ctx, blockID, bytes.NewReader(blockBytes)); err != nil {
+		return fmt.Errorf("carve: put block %s: %w", blockID, err)
+	}
+
+	rec := block.BlockRecord{
+		BlockID:        blockID,
+		BlockHash:      blockHash,
+		Length:         int64(len(blockBytes)),
+		LiveChunkCount: uint32(len(commits)),
+		SyncState:      block.BlockStateRemote,
+	}
+	if err := metadata.DefaultCommitBlock(ctx, s.committer, rec, commits, fileChunks); err != nil {
+		return fmt.Errorf("carve: commit block %s: %w", blockID, err)
+	}
+	return nil
+}

--- a/pkg/block/engine/blocksink_test.go
+++ b/pkg/block/engine/blocksink_test.go
@@ -1,0 +1,214 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"io"
+	"math/rand"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/journal"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// stubJournalRemote satisfies journal.RemoteStore for a Store whose cold-read
+// path is never exercised (carve drives the injected sink, not this remote).
+type stubJournalRemote struct{}
+
+func (stubJournalRemote) PutBlock(context.Context, journal.BlockID, io.Reader, int64) error {
+	return errors.New("stub: PutBlock unused")
+}
+func (stubJournalRemote) GetBlock(context.Context, journal.BlockID) (io.ReadCloser, error) {
+	return nil, errors.New("stub: GetBlock unused")
+}
+func (stubJournalRemote) GetRange(context.Context, journal.BlockID, int64, int64) (io.ReadCloser, error) {
+	return nil, errors.New("stub: GetRange unused")
+}
+
+// seamFixture wires a live journal.Store to the production engineDeduper +
+// engineBlockSink, a memory metadata store (committer + synced oracle) and a
+// memory block-keyed remote.
+type seamFixture struct {
+	dir  string
+	ms   *metadatamemory.MemoryMetadataStore
+	mem  *remotememory.Store
+	jrnl *journal.Store
+}
+
+func newSeamFixture(t *testing.T, dir string, ms *metadatamemory.MemoryMetadataStore, mem *remotememory.Store, sink journal.BlockSink) *seamFixture {
+	t.Helper()
+	j, err := journal.Open(dir, journal.Config{CarveBlockSize: 1 << 20}, stubJournalRemote{}, journal.SystemClock())
+	if err != nil {
+		t.Fatalf("journal.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = j.Close() })
+	j.SetCarveTargets(engineDeduper{synced: ms}, sink)
+	return &seamFixture{dir: dir, ms: ms, mem: mem, jrnl: j}
+}
+
+func realSink(ms *metadatamemory.MemoryMetadataStore, mem *remotememory.Store) engineBlockSink {
+	return engineBlockSink{sealer: nil, rbs: mem, committer: ms}
+}
+
+func countBlocks(t *testing.T, ctx context.Context, mem *remotememory.Store) int {
+	t.Helper()
+	n := 0
+	if err := mem.WalkBlocks(ctx, func(string, block.Meta) error { n++; return nil }); err != nil {
+		t.Fatalf("WalkBlocks: %v", err)
+	}
+	return n
+}
+
+func seamRandBytes(n int, seed int64) []byte {
+	b := make([]byte, n)
+	rand.New(rand.NewSource(seed)).Read(b)
+	return b
+}
+
+func TestJournalCarveSeam_CommitsBlocksAndFileChunkRows(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	mem := remotememory.New()
+	f := newSeamFixture(t, t.TempDir(), ms, mem, realSink(ms, mem))
+
+	data := seamRandBytes(3<<20, 1)
+	if err := f.jrnl.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if _, err := f.jrnl.Carve(ctx, journal.CarveOptions{Force: true}); err != nil {
+		t.Fatalf("Carve: %v", err)
+	}
+
+	// A block object landed on the remote.
+	if got := countBlocks(t, ctx, mem); got < 1 {
+		t.Fatalf("remote blocks = %d, want >= 1", got)
+	}
+	// One FileChunk manifest row per carved chunk; DataSize tiles the whole file.
+	rows, err := ms.ListFileChunks(ctx, "f")
+	if err != nil {
+		t.Fatalf("ListFileChunks: %v", err)
+	}
+	if len(rows) == 0 {
+		t.Fatalf("no FileChunk rows written")
+	}
+	var total int
+	for _, r := range rows {
+		if r.State != block.BlockStatePending {
+			t.Fatalf("row %s state = %v, want Pending", r.ID, r.State)
+		}
+		if r.DataSize == 0 || r.Hash == (block.ContentHash{}) {
+			t.Fatalf("row %s missing DataSize/Hash", r.ID)
+		}
+		total += int(r.DataSize)
+	}
+	if total != len(data) {
+		t.Fatalf("FileChunk DataSize sum = %d, want %d", total, len(data))
+	}
+	// Carve flipped the records synced (block committed => durable frontier moved).
+	if u := f.jrnl.UnsyncedBytes(); u != 0 {
+		t.Fatalf("post-carve unsynced = %d, want 0 (flip after commit)", u)
+	}
+}
+
+func TestJournalCarveSeam_DuplicateIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	mem := remotememory.New()
+	f := newSeamFixture(t, t.TempDir(), ms, mem, realSink(ms, mem))
+
+	data := seamRandBytes(2<<20, 2)
+	if err := f.jrnl.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.jrnl.Carve(ctx, journal.CarveOptions{Force: true}); err != nil {
+		t.Fatalf("carve f: %v", err)
+	}
+	blocksAfterF := countBlocks(t, ctx, mem)
+
+	// A second file with identical content: every chunk is already remote-durable,
+	// so carve dedups to a no-op — no new block object is uploaded.
+	if err := f.jrnl.WriteAt(ctx, "g", 0, data); err != nil {
+		t.Fatal(err)
+	}
+	res, err := f.jrnl.Carve(ctx, journal.CarveOptions{Force: true})
+	if err != nil {
+		t.Fatalf("carve g: %v", err)
+	}
+	if res.BlocksWritten != 0 || res.BytesCarved != 0 {
+		t.Fatalf("duplicate carve was not a no-op: %+v", res)
+	}
+	if got := countBlocks(t, ctx, mem); got != blocksAfterF {
+		t.Fatalf("duplicate carve uploaded new blocks: %d -> %d", blocksAfterF, got)
+	}
+	// The duplicate's records still flip synced (bytes are provably remote).
+	if u := f.jrnl.UnsyncedBytes(); u != 0 {
+		t.Fatalf("duplicate carve left dirty bytes: %d", u)
+	}
+}
+
+// failOnceSink commits for real, then returns an injected error on the first
+// call — modeling a crash after the metadata commit but before journal flips its
+// records synced. The ms is left fully committed; the journal records stay dirty.
+type failOnceSink struct {
+	inner  engineBlockSink
+	failed bool
+}
+
+func (s *failOnceSink) CommitBlock(ctx context.Context, chunks []journal.CarveChunk) error {
+	if err := s.inner.CommitBlock(ctx, chunks); err != nil {
+		return err
+	}
+	if !s.failed {
+		s.failed = true
+		return errors.New("injected crash after commit, before flip")
+	}
+	return nil
+}
+
+func TestJournalCarveSeam_CrashMidCommitReCarveIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	mem := remotememory.New()
+
+	// First carve: the sink commits (block + rows + synced markers) then errors,
+	// so the journal leaves its records dirty even though the commit is durable.
+	fail := &failOnceSink{inner: realSink(ms, mem)}
+	f := newSeamFixture(t, dir, ms, mem, fail)
+	data := seamRandBytes(1<<20, 3)
+	if err := f.jrnl.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.jrnl.Carve(ctx, journal.CarveOptions{Force: true}); err == nil {
+		t.Fatalf("expected carve to surface the injected commit failure")
+	}
+	if f.jrnl.UnsyncedBytes() == 0 {
+		t.Fatalf("records flipped despite the failed carve")
+	}
+	blocksAfter := countBlocks(t, ctx, mem)
+	rowsAfter, _ := ms.ListFileChunks(ctx, "f")
+	_ = f.jrnl.Close()
+
+	// Reopen: recovery replays the still-dirty records. Re-carve with a healthy
+	// sink dedups every chunk (already remote-durable) — no new block, no new
+	// rows, and the records finally flip synced.
+	f2 := newSeamFixture(t, dir, ms, mem, realSink(ms, mem))
+	res, err := f2.jrnl.Carve(ctx, journal.CarveOptions{Force: true})
+	if err != nil {
+		t.Fatalf("re-carve after reopen: %v", err)
+	}
+	if res.BlocksWritten != 0 {
+		t.Fatalf("re-carve re-uploaded a block: %+v", res)
+	}
+	if got := countBlocks(t, ctx, mem); got != blocksAfter {
+		t.Fatalf("re-carve changed block count %d -> %d", blocksAfter, got)
+	}
+	if rows, _ := ms.ListFileChunks(ctx, "f"); len(rows) != len(rowsAfter) {
+		t.Fatalf("re-carve changed row count %d -> %d", len(rowsAfter), len(rows))
+	}
+	if u := f2.jrnl.UnsyncedBytes(); u != 0 {
+		t.Fatalf("re-carve did not flip records: unsynced = %d", u)
+	}
+}

--- a/pkg/block/engine/carver.go
+++ b/pkg/block/engine/carver.go
@@ -483,7 +483,7 @@ func (m *Syncer) carveAndCommitBlock(ctx context.Context, batch []block.ContentH
 	// committed. Just return it — the caller's existing requeue logic
 	// (requeueCarveBatch) re-drives the whole batch, and the uploaded block
 	// object becomes an orphan the GC sweep reclaims.
-	if err := metadata.DefaultCommitBlock(ctx, committer, rec, commits); err != nil {
+	if err := metadata.DefaultCommitBlock(ctx, committer, rec, commits, nil); err != nil {
 		return fmt.Errorf("carve: commit block %s: %w", blockID, err)
 	}
 

--- a/pkg/block/engine/compaction.go
+++ b/pkg/block/engine/compaction.go
@@ -312,7 +312,7 @@ func compactOneBlock(
 		LiveChunkCount: uint32(len(commits)),
 		SyncState:      block.BlockStateRemote,
 	}
-	if err := metadata.DefaultCommitBlock(ctx, v, newRec, commits); err != nil {
+	if err := metadata.DefaultCommitBlock(ctx, v, newRec, commits, nil); err != nil {
 		// New block is an orphan object (no record) — reconcile class 3; the old
 		// block is untouched and still resolves. Safe to abandon this attempt.
 		slog.Warn("compaction: commit new block failed — old block kept, new object orphaned for reconcile", "block_id", blockID, "new_block_id", newID, "err", err)

--- a/pkg/block/engine/legacy_migration.go
+++ b/pkg/block/engine/legacy_migration.go
@@ -392,7 +392,7 @@ func (m *Syncer) packAndCommitMigrated(
 		LiveChunkCount: uint32(len(commits)),
 		SyncState:      block.BlockStateRemote,
 	}
-	if err := metadata.DefaultCommitBlock(ctx, committer, rec, commits); err != nil {
+	if err := metadata.DefaultCommitBlock(ctx, committer, rec, commits, nil); err != nil {
 		return fmt.Errorf("migration: commit block %s: %w", blockID, err)
 	}
 	return nil

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -206,7 +206,7 @@ func (s *Store) carveFile(ctx context.Context, sh *shard, id FileID, res *CarveR
 // packs novel chunks into blocks (flushed at CarveBlockSize and at the run's end),
 // and flips the run's records to synced as the durable frontier advances.
 func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interval, res *CarveResult) error {
-	c := chunker.NewChunker()
+	c := chunker.NewChunkerWithParams(s.cfg.ChunkParams)
 	rr := &runReader{s: s, sh: sh, ivs: run}
 
 	fileOff := run[0].fileOff

--- a/pkg/block/journal/chunkparams_test.go
+++ b/pkg/block/journal/chunkparams_test.go
@@ -1,0 +1,67 @@
+package journal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block/chunker"
+)
+
+func TestConfigChunkParamsDefaulting(t *testing.T) {
+	// Unset (zero) params degrade to the historical default profile.
+	if got := (Config{}).withDefaults().ChunkParams; got != chunker.DefaultParams() {
+		t.Fatalf("unset ChunkParams = %+v, want default %+v", got, chunker.DefaultParams())
+	}
+	// Invalid params (Min below the floor) also degrade to default, never a hard
+	// error — mirroring the fs store.
+	invalid := Config{ChunkParams: chunker.Params{Min: 100, Avg: 200, Max: 300}}
+	if got := invalid.withDefaults().ChunkParams; got != chunker.DefaultParams() {
+		t.Fatalf("invalid ChunkParams = %+v, want default", got)
+	}
+	// A valid custom profile is kept verbatim.
+	valid := chunker.Params{Min: 128 << 10, Avg: 512 << 10, Max: 1 << 20}
+	if got := (Config{ChunkParams: valid}).withDefaults().ChunkParams; got != valid {
+		t.Fatalf("valid ChunkParams = %+v, want %+v", got, valid)
+	}
+}
+
+// directChunkCount runs the chunker over data exactly as carveRun does (whole
+// buffer, final) so the test can assert carve honored the configured params.
+func directChunkCount(data []byte, p chunker.Params) int {
+	c := chunker.NewChunkerWithParams(p)
+	rem := data
+	count := 0
+	for len(rem) > 0 {
+		b, _ := c.Next(rem, true)
+		if b == 0 {
+			b = len(rem)
+		}
+		count++
+		rem = rem[b:]
+	}
+	return count
+}
+
+func TestCarveHonorsChunkParams(t *testing.T) {
+	ctx := context.Background()
+	data := randBytes(3<<20, 42) // < MaxChunkSize so carveRun feeds it in one pass
+
+	small := chunker.Params{Min: 128 << 10, Avg: 512 << 10, Max: 1 << 20}
+	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 64 << 20, ChunkParams: small})
+	if err := s.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err != nil {
+		t.Fatalf("Carve: %v", err)
+	}
+
+	wantSmall := directChunkCount(data, small)
+	if got := len(sink.chunks); got != wantSmall {
+		t.Fatalf("carve produced %d chunks, want %d (params not applied)", got, wantSmall)
+	}
+	// The custom profile must chunk finer than the default, else the test proves
+	// nothing about the params taking effect.
+	if wantDefault := directChunkCount(data, chunker.DefaultParams()); wantSmall <= wantDefault {
+		t.Fatalf("small params (%d chunks) not finer than default (%d)", wantSmall, wantDefault)
+	}
+}

--- a/pkg/block/journal/gap_methods_test.go
+++ b/pkg/block/journal/gap_methods_test.go
@@ -1,0 +1,95 @@
+package journal
+
+import (
+	"context"
+	"testing"
+)
+
+func TestFileSize(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+
+	// Unknown file: no index entry.
+	if sz, ok := s.FileSize(ctx, "missing"); ok || sz != 0 {
+		t.Fatalf("FileSize(missing) = (%d,%v), want (0,false)", sz, ok)
+	}
+
+	_ = s.WriteAt(ctx, "f", 0, make([]byte, 100))
+	_ = s.WriteAt(ctx, "f", 500, make([]byte, 50)) // high-water mark = 550
+	if sz, ok := s.FileSize(ctx, "f"); !ok || sz != 550 {
+		t.Fatalf("FileSize = (%d,%v), want (550,true)", sz, ok)
+	}
+
+	// After deleting the file the entry is gone.
+	if err := s.Delete(ctx, "f"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if sz, ok := s.FileSize(ctx, "f"); ok || sz != 0 {
+		t.Fatalf("FileSize after delete = (%d,%v), want (0,false)", sz, ok)
+	}
+}
+
+func TestListFiles(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+
+	if got := s.ListFiles(ctx); len(got) != 0 {
+		t.Fatalf("empty store ListFiles = %v, want none", got)
+	}
+
+	for _, id := range []FileID{"a", "b", "c"} {
+		if err := s.WriteAt(ctx, id, 0, []byte("x")); err != nil {
+			t.Fatalf("WriteAt %q: %v", id, err)
+		}
+	}
+	set := func() map[FileID]bool {
+		m := map[FileID]bool{}
+		for _, id := range s.ListFiles(ctx) {
+			m[id] = true
+		}
+		return m
+	}
+	got := set()
+	for _, id := range []FileID{"a", "b", "c"} {
+		if !got[id] {
+			t.Fatalf("ListFiles missing %q: %v", id, got)
+		}
+	}
+
+	if err := s.Delete(ctx, "b"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if got := set(); got["b"] || len(got) != 2 {
+		t.Fatalf("ListFiles after delete = %v, want {a,c}", got)
+	}
+}
+
+func TestSetEvictionEnabledGatesEvict(t *testing.T) {
+	// A sealed, fully-synced segment is evictable; the gate must suppress it while
+	// eviction is disabled and release it once re-enabled.
+	s, _ := evictStore(t, Config{})
+	ctx := context.Background()
+	fillUntilSealed(t, s, "f", true, 1) // Hydrate => synced => evictable
+	before := len(sealedSegs(s.shardFor("f")))
+	if before < 1 {
+		t.Fatalf("want a sealed segment to evict, got %d", before)
+	}
+
+	s.SetEvictionEnabled(false)
+	res, err := s.Evict(ctx, 1)
+	if err != nil {
+		t.Fatalf("Evict (disabled): %v", err)
+	}
+	if res.SegmentsEvicted != 0 {
+		t.Fatalf("eviction disabled but evicted %d segments", res.SegmentsEvicted)
+	}
+
+	s.SetEvictionEnabled(true)
+	res, err = s.Evict(ctx, 1)
+	if err != nil {
+		t.Fatalf("Evict (enabled): %v", err)
+	}
+	if res.SegmentsEvicted == 0 {
+		t.Fatalf("eviction enabled but nothing evicted")
+	}
+}

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -54,6 +54,9 @@ func (s *Store) Evict(ctx context.Context, targetBytes int64) (EvictResult, erro
 	if s.closed.Load() {
 		return EvictResult{}, errClosed
 	}
+	if s.evictionDisabled.Load() {
+		return EvictResult{}, nil
+	}
 	var res EvictResult
 	for {
 		seg, sh := s.claimColdestEvictable()
@@ -434,11 +437,11 @@ func (s *Store) repackSegment(sh *shard, victim *segmentMeta) (int64, error) {
 	occupied := victim.liveBytes.Load()
 	sh.mu.Unlock()
 
-	// 1b. Carry forward the victim's tombstones so deletes stay durable until
-	// every shadowed data record is gone.
-	tombs := victimTombstones(victim, s.cfg.SegmentSize)
+	// 1b. Carry forward the victim's tombstones and truncate markers so deletes
+	// and size-downs stay durable until every record they fence is gone.
+	markers := victimMarkers(victim, s.cfg.SegmentSize)
 
-	if len(moves) == 0 && len(tombs) == 0 {
+	if len(moves) == 0 && len(markers) == 0 {
 		return s.dropVictim(sh, victim, occupied)
 	}
 
@@ -476,8 +479,14 @@ func (s *Store) repackSegment(sh *shard, victim *segmentMeta) (int64, error) {
 			syncedCount++
 		}
 	}
-	for _, t := range tombs {
-		if _, werr := writeTombstoneRecord(target, t.id, t.version); werr != nil {
+	for _, mk := range markers {
+		var werr error
+		if mk.flags&flagTruncate != 0 {
+			_, werr = writeTruncateRecord(target, mk.id, mk.version, mk.newSize)
+		} else {
+			_, werr = writeTombstoneRecord(target, mk.id, mk.version)
+		}
+		if werr != nil {
 			cleanup()
 			return 0, werr
 		}
@@ -572,21 +581,34 @@ func (s *Store) dropVictim(sh *shard, victim *segmentMeta, occupied int64) (int6
 	return occupied, nil
 }
 
-// tombRec is a tombstone carried forward across a repack.
-type tombRec struct {
+// markRec is a tombstone or truncate marker carried forward across a repack.
+// newSize is meaningful only for truncate markers (flags&flagTruncate != 0).
+type markRec struct {
 	id      FileID
 	version uint64
+	flags   uint8
+	newSize int64
 }
 
-// victimTombstones scans a sealed victim's record stream for tombstones. A
-// sealed segment is trusted intact, so a torn tail (should never occur) simply
-// yields the records read so far.
-func victimTombstones(seg *segmentMeta, segSize int64) []tombRec {
+// victimMarkers scans a sealed victim's record stream for the non-data records
+// (tombstones and truncate markers) a repack must carry forward so the deletes
+// and size-downs they encode survive the source segment's reclamation. A sealed
+// segment is trusted intact, so a torn tail (should never occur) simply yields
+// the records read so far.
+func victimMarkers(seg *segmentMeta, segSize int64) []markRec {
 	recs, _ := scanValidRecords(seg.fd, segSize, segSize)
-	var out []tombRec
+	var out []markRec
 	for _, rec := range recs {
-		if rec.header.Flags&flagTombstone != 0 {
-			out = append(out, tombRec{id: FileID(rec.fileID), version: rec.header.Version})
+		switch {
+		case rec.header.Flags&flagTombstone != 0:
+			out = append(out, markRec{id: FileID(rec.fileID), version: rec.header.Version, flags: flagTombstone})
+		case rec.header.Flags&flagTruncate != 0:
+			out = append(out, markRec{
+				id:      FileID(rec.fileID),
+				version: rec.header.Version,
+				flags:   flagTruncate,
+				newSize: int64(rec.header.FileOffset),
+			})
 		}
 	}
 	return out

--- a/pkg/block/journal/record.go
+++ b/pkg/block/journal/record.go
@@ -44,6 +44,11 @@ const (
 
 	flagSynced    = 1 << 0
 	flagTombstone = 1 << 1
+	// flagTruncate marks a zero-payload record whose FileOffset carries a file's
+	// new size. Recovery clips/drops every live interval past that size whose
+	// Version is at or below the marker's, mirroring how flagTombstone buries a
+	// file's records — a durable size-down that a crash cannot resurrect.
+	flagTruncate = 1 << 2
 )
 
 var crcTable = crc32.MakeTable(crc32.Castagnoli)

--- a/pkg/block/journal/recovery.go
+++ b/pkg/block/journal/recovery.go
@@ -23,6 +23,13 @@ const orphanMinAge = 5 * time.Minute
 // index sidecar, a swept orphan).
 var logf = log.Printf
 
+// truncMark records the highest-Version truncate marker seen for a file during
+// recovery: the new size and the Version that fences which intervals it clips.
+type truncMark struct {
+	version uint64
+	newSize int64
+}
+
 // scanSegmentIDs returns the IDs of every well-formed <id>.seg file in dir.
 func scanSegmentIDs(dir string) ([]uint64, error) {
 	entries, err := os.ReadDir(dir)
@@ -69,15 +76,16 @@ func (s *Store) recover() error {
 	}
 
 	var (
-		emptyPool  []*segmentMeta // empty unsealed segments, reusable as any shard's active
-		orphans    []uint64       // unattachable segment ids, candidates for the age-gated sweep
-		maxSegID   uint64
-		maxVersion uint64
-		unsynced   int64
-		missingIdx int
-		opened     []*segmentMeta        // every fd we opened, closed on error
-		tombstones = map[FileID]uint64{} // deleted file -> highest tombstone version
-		ok         bool
+		emptyPool   []*segmentMeta // empty unsealed segments, reusable as any shard's active
+		orphans     []uint64       // unattachable segment ids, candidates for the age-gated sweep
+		maxSegID    uint64
+		maxVersion  uint64
+		unsynced    int64
+		missingIdx  int
+		opened      []*segmentMeta           // every fd we opened, closed on error
+		tombstones  = map[FileID]uint64{}    // deleted file -> highest tombstone version
+		truncations = map[FileID]truncMark{} // truncated file -> highest truncate marker
+		ok          bool
 	)
 	defer func() {
 		if !ok {
@@ -184,6 +192,13 @@ func (s *Store) recover() error {
 				}
 				continue
 			}
+			if rec.header.Flags&flagTruncate != 0 {
+				fid := FileID(rec.fileID)
+				if cur, ok := truncations[fid]; !ok || rec.header.Version > cur.version {
+					truncations[fid] = truncMark{version: rec.header.Version, newSize: int64(rec.header.FileOffset)}
+				}
+				continue
+			}
 			payloadOff := rec.segOff + recordHeaderSize + int64(len(rec.fileID))
 			fid := FileID(rec.fileID)
 			fi := idxMap[fid]
@@ -242,6 +257,35 @@ func (s *Store) recover() error {
 				if iv.version > tv {
 					kept = append(kept, iv)
 				}
+			}
+			if len(kept) == 0 {
+				delete(idxMap, fid)
+			} else {
+				fi.ivs = kept
+			}
+		}
+	}
+
+	// Honor truncate markers: a size-down's marker Version exceeds every write it
+	// buries, so drop the file's intervals past newSize (and clip a straddling
+	// one) for every interval at or below the marker. A write that raced past the
+	// truncate carries a higher Version and survives, re-extending the file.
+	for _, idxMap := range indexByShard {
+		for fid, fi := range idxMap {
+			tm, ok := truncations[fid]
+			if !ok {
+				continue
+			}
+			kept := fi.ivs[:0]
+			for _, iv := range fi.ivs {
+				if iv.version > tm.version || iv.end() <= tm.newSize {
+					kept = append(kept, iv)
+					continue
+				}
+				if iv.fileOff < tm.newSize {
+					kept = append(kept, iv.clamp(iv.fileOff, tm.newSize))
+				}
+				// else entirely past newSize: drop it.
 			}
 			if len(kept) == 0 {
 				delete(idxMap, fid)

--- a/pkg/block/journal/recovery.go
+++ b/pkg/block/journal/recovery.go
@@ -297,13 +297,34 @@ func (s *Store) recover() error {
 
 	// Recompute unsynced from the final live coverage rather than the raw
 	// per-record sum: insert resolves overlaps, so a superseded record's bytes are
-	// dead and must not count toward the backpressure signal.
-	for _, idxMap := range indexByShard {
+	// dead and must not count toward the backpressure signal. In the same pass,
+	// reconstruct each segment's deadBytes from the authoritative live coverage
+	// (occupied liveBytes − currently-live): replay charges only physical records,
+	// so tombstones, same-segment overlaps, and truncate clips leave dead payload
+	// that never touched the counter. Without this, pickVictim's deadBytes<=0 gate
+	// skips every recovered segment and GC can never reclaim pre-restart dead space.
+	// Skip cold intervals exactly as pickVictim does so the live totals agree.
+	for i, idxMap := range indexByShard {
+		live := make(map[uint64]int64)
 		for _, fi := range idxMap {
 			for k := range fi.ivs {
-				if !fi.ivs[k].synced && !fi.ivs[k].cold {
+				if fi.ivs[k].cold {
+					continue
+				}
+				if !fi.ivs[k].synced {
 					unsynced += fi.ivs[k].length
 				}
+				live[fi.ivs[k].loc.SegmentID] += fi.ivs[k].length
+			}
+		}
+		for id, seg := range sealedByShard[i] {
+			if dead := seg.liveBytes.Load() - live[id]; dead > 0 {
+				seg.deadBytes.Store(dead)
+			}
+		}
+		if a := actives[i]; a != nil {
+			if dead := a.liveBytes.Load() - live[a.id]; dead > 0 {
+				a.deadBytes.Store(dead)
 			}
 		}
 	}

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -404,6 +404,85 @@ func (s *Store) appendTombstone(ctx context.Context, id FileID) (uint64, error) 
 // Always empty in production.
 var testFailTombstone FileID
 
+// appendTruncateMarker frames a zero-payload truncate marker for id (FileOffset
+// carries newSize) and fsyncs the shard's active segment, returning the marker's
+// Version. Like appendTombstone, the fsync makes the truncation at least as
+// durable as any data record it clips, so recovery can never replay bytes past
+// newSize whose marker was lost.
+func (s *Store) appendTruncateMarker(ctx context.Context, id FileID, newSize int64) (uint64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	fileID := []byte(id)
+	if len(fileID) > maxFileIDLen {
+		return 0, fmt.Errorf("journal: FileID length %d exceeds max %d", len(fileID), maxFileIDLen)
+	}
+	if testFailTruncate != "" && id == testFailTruncate {
+		return 0, fmt.Errorf("journal: injected truncate failure for %q", id)
+	}
+	recLen := recordLen(len(fileID), 0)
+
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	if sh.active.tail.Load()+recLen > s.cfg.SegmentSize {
+		if err := s.sealSegment(sh); err != nil {
+			sh.mu.Unlock()
+			return 0, err
+		}
+	}
+	seg := sh.active
+	version := s.nextVersion()
+	recStart, err := writeTruncateRecord(seg, id, version, newSize)
+	if err != nil {
+		sh.mu.Unlock()
+		return 0, err
+	}
+	if seg.idxFD != nil {
+		_, _ = seg.idxFD.Write(idxEntry{
+			FileIDHash: fnv1a(string(id)),
+			FileOffset: uint64(newSize),
+			Version:    version,
+			SegOffset:  uint64(recStart + recordHeaderSize + int64(len(fileID))),
+			Flags:      flagTruncate,
+		}.encode())
+	}
+	fd := seg.fd
+	sh.mu.Unlock()
+	if err := fd.Sync(); err != nil {
+		return 0, fmt.Errorf("journal: fsync truncate marker: %w", err)
+	}
+	return version, nil
+}
+
+// testFailTruncate, when it equals a Truncate's FileID, makes
+// appendTruncateMarker return an error before persisting anything, modeling a
+// durability failure. Always empty in production.
+var testFailTruncate FileID
+
+// writeTruncateRecord frames a zero-payload truncate marker at seg's tail, with
+// FileOffset carrying newSize, and advances the tail. Shared by the live
+// truncate path and repack's marker carry-forward.
+func writeTruncateRecord(seg *segmentMeta, id FileID, version uint64, newSize int64) (recStart int64, err error) {
+	fileID := []byte(id)
+	recStart = seg.tail.Load()
+	hdr := encodeHeader(recordHeader{
+		FileIDLen:  uint16(len(fileID)),
+		FileOffset: uint64(newSize),
+		Version:    version,
+		Flags:      flagTruncate,
+	}, fileID)
+	if _, err = seg.fd.WriteAt(hdr, recStart); err != nil {
+		return 0, fmt.Errorf("journal: write truncate header: %w", err)
+	}
+	var crcBuf [payloadCRCSize]byte
+	binary.LittleEndian.PutUint32(crcBuf[:], crc(nil))
+	if _, err = seg.fd.WriteAt(crcBuf[:], recStart+int64(len(hdr))); err != nil {
+		return 0, fmt.Errorf("journal: write truncate CRC: %w", err)
+	}
+	seg.tail.Store(recStart + recordLen(len(fileID), 0))
+	return recStart, nil
+}
+
 // writeTombstoneRecord frames a zero-payload tombstone at seg's tail and advances
 // it. Shared by the delete path and by repack's tombstone carry-forward.
 func writeTombstoneRecord(seg *segmentMeta, id FileID, version uint64) (recStart int64, err error) {

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/marmos91/dittofs/pkg/block/chunker"
 )
 
 // FileID identifies a file's byte stream inside the cache. It is the same
@@ -56,6 +58,11 @@ type Config struct {
 	ShardCount       int           // number of shards, power of two, immutable per store
 	MaxLocalBytes    int64         // local on-disk cap that triggers eviction; 0 = unlimited
 	EvictMaxWait     time.Duration // write-path backpressure budget before ErrLocalStoreFull
+	// ChunkParams sets the per-share FastCDC sizing carve feeds the chunker
+	// (#1569). The zero value (or any params that fail Validate) degrades to
+	// chunker.DefaultParams — the historical 1M/4M/16M profile — so a
+	// misconfiguration is never a hard error, matching the fs store.
+	ChunkParams chunker.Params
 }
 
 const (
@@ -85,6 +92,9 @@ func (c Config) withDefaults() Config {
 	}
 	if c.EvictMaxWait <= 0 {
 		c.EvictMaxWait = defaultEvictMaxWait
+	}
+	if c.ChunkParams.Validate() != nil {
+		c.ChunkParams = chunker.DefaultParams()
 	}
 	// MaxLocalBytes intentionally has no default: 0 means "no local cap" (eviction
 	// off), the safe posture until the FSStore adapter wires --local-store-size.
@@ -135,6 +145,12 @@ type Store struct {
 	writes    atomic.Int64
 	reads     atomic.Int64
 	coldReads atomic.Int64
+
+	// evictionDisabled gates Evict (and thus the write-path ensureSpace that
+	// drives it). Health-driven: while the remote is unhealthy, cold-marking a
+	// segment would strand bytes that can't be refetched, so eviction is paused.
+	// Zero value = enabled, the safe default.
+	evictionDisabled atomic.Bool
 
 	closed atomic.Bool
 }
@@ -317,6 +333,153 @@ func (s *Store) Delete(ctx context.Context, id FileID) error {
 				continue
 			}
 			// Buried by the tombstone: its bytes become dead in their segment.
+			if iv.cold {
+				continue
+			}
+			if seg := sh.segment(iv.loc.SegmentID); seg != nil {
+				seg.deadBytes.Add(iv.length)
+			}
+			if !iv.synced {
+				dirty += iv.length
+			}
+		}
+		if len(kept) == 0 {
+			delete(sh.index, id)
+		} else {
+			fi.ivs = kept
+		}
+	}
+	sh.mu.Unlock()
+	if dirty != 0 {
+		s.unsynced.Add(-dirty)
+	}
+	return nil
+}
+
+// FileSize reports a file's data high-water mark: the maximum end offset over
+// all its live intervals (dirty or cold). The second result is false when the
+// file has no index entry. It is the fileSize input DataExtents needs — the
+// journal tracks data extents, not the logical size (a grow's trailing hole
+// lives in the metadata store, not here).
+func (s *Store) FileSize(_ context.Context, id FileID) (int64, bool) {
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	fi := sh.index[id]
+	if fi == nil {
+		return 0, false
+	}
+	var size int64
+	for _, iv := range fi.ivs {
+		if e := iv.end(); e > size {
+			size = e
+		}
+	}
+	return size, true
+}
+
+// SetEvictionEnabled toggles whole-segment eviction. Disabling it pauses Evict
+// (and the write-path ensureSpace that drives it) so a health monitor can stop
+// the store shedding local bytes while the remote is unreachable — a cold-marked
+// range would otherwise be unrecoverable until the remote returns.
+func (s *Store) SetEvictionEnabled(enabled bool) {
+	s.evictionDisabled.Store(!enabled)
+}
+
+// ListFiles returns every FileID with a live index entry across all shards, in
+// no guaranteed order. It lets a caller drive a bulk reset (Delete every file)
+// without tracking IDs itself.
+func (s *Store) ListFiles(_ context.Context) []FileID {
+	var out []FileID
+	for _, sh := range s.shards {
+		sh.mu.Lock()
+		for id := range sh.index {
+			out = append(out, id)
+		}
+		sh.mu.Unlock()
+	}
+	return out
+}
+
+// Truncate shrinks a file to newSize: every live interval past newSize is
+// dropped and an interval straddling newSize is clipped to end there, the freed
+// bytes becoming dead in their segments (GC reclaims them). Growing a file —
+// newSize at or past the current high-water mark — is a no-op here; a grow's
+// trailing hole lives in the metadata store, not the journal.
+//
+// Crash-safety mirrors Delete. A durable, fsynced truncate marker is persisted
+// BEFORE the in-memory index is touched, so a failed marker write leaves the
+// file intact and a crash after the marker can never resurrect the truncated
+// bytes: the on-disk data records past newSize linger until GC repacks them
+// away, and recovery re-applies the clip from the marker. The marker's Version
+// fences the clip — only intervals at or below it are affected, so a write that
+// raced past the truncate (a higher Version) survives, re-extending the file.
+// An in-flight carve of a clipped range is harmless: its post-upload flip
+// re-resolves the interval by (offset, version) and simply skips a fragment the
+// truncate dropped or clipped, exactly as it skips a concurrent overwrite.
+func (s *Store) Truncate(ctx context.Context, id FileID, newSize int64) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if s.closed.Load() {
+		return errClosed
+	}
+	if newSize < 0 {
+		return fmt.Errorf("journal: negative truncate size %d", newSize)
+	}
+
+	sh := s.shardFor(id)
+	// Peek: with nothing past newSize this is a grow or no-op, so skip the marker
+	// fsync entirely. A write that lands past newSize after this peek carries a
+	// higher Version than any marker we would issue and is meant to survive, so
+	// not fencing it is correct.
+	sh.mu.Lock()
+	fi := sh.index[id]
+	past := false
+	if fi != nil {
+		for _, iv := range fi.ivs {
+			if iv.end() > newSize {
+				past = true
+				break
+			}
+		}
+	}
+	sh.mu.Unlock()
+	if !past {
+		return nil
+	}
+
+	// Durability first: the marker must be on disk before the index is clipped.
+	truncVer, err := s.appendTruncateMarker(ctx, id, newSize)
+	if err != nil {
+		return err
+	}
+
+	sh.mu.Lock()
+	fi = sh.index[id]
+	var dirty int64
+	if fi != nil {
+		kept := fi.ivs[:0]
+		for _, iv := range fi.ivs {
+			if iv.version > truncVer || iv.end() <= newSize {
+				kept = append(kept, iv) // raced past the truncate, or already within
+				continue
+			}
+			if iv.fileOff < newSize {
+				// Straddles newSize: clip to [fileOff, newSize); the tail dies.
+				dead := iv.end() - newSize
+				if !iv.cold {
+					if seg := sh.segment(iv.loc.SegmentID); seg != nil {
+						seg.deadBytes.Add(dead)
+					}
+				}
+				if !iv.synced {
+					dirty += dead
+				}
+				kept = append(kept, iv.clamp(iv.fileOff, newSize))
+				continue
+			}
+			// Entirely past newSize: drop it; its bytes become dead.
 			if iv.cold {
 				continue
 			}

--- a/pkg/block/journal/truncate_test.go
+++ b/pkg/block/journal/truncate_test.go
@@ -1,0 +1,239 @@
+package journal
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+// zeroFilled reports whether every byte in b is zero.
+func zeroFilled(b []byte) bool {
+	for _, x := range b {
+		if x != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func TestTruncateShrinksFileSizeAndExtents(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+
+	data := randBytes(1000, 1)
+	if err := s.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Truncate(ctx, "f", 400); err != nil {
+		t.Fatalf("Truncate: %v", err)
+	}
+
+	if sz, ok := s.FileSize(ctx, "f"); !ok || sz != 400 {
+		t.Fatalf("FileSize after truncate = (%d,%v), want (400,true)", sz, ok)
+	}
+	ext, err := s.DataExtents(ctx, "f", 400)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ext) != 1 || ext[0] != [2]uint64{0, 400} {
+		t.Fatalf("DataExtents = %v, want [{0 400}]", ext)
+	}
+
+	// Read across the new EOF: kept bytes match, bytes past newSize zero-fill.
+	got := make([]byte, 600)
+	for i := range got {
+		got[i] = 0xFF
+	}
+	if _, _, err := s.ReadAt(ctx, "f", 0, got); err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if !bytes.Equal(got[:400], data[:400]) {
+		t.Fatalf("kept bytes mismatch after truncate")
+	}
+	if !zeroFilled(got[400:]) {
+		t.Fatalf("bytes past newSize not zero-filled: %x", got[400:])
+	}
+}
+
+func TestTruncatePartialIntervalClip(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+
+	// A single record straddling newSize must be clipped (not dropped) and its
+	// tail charged as dead bytes to its segment.
+	data := randBytes(1000, 2)
+	if err := s.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Truncate(ctx, "f", 400); err != nil {
+		t.Fatal(err)
+	}
+
+	sh := s.shardFor("f")
+	sh.mu.Lock()
+	fi := sh.index["f"]
+	nivs := len(fi.ivs)
+	iv := fi.ivs[0]
+	dead := sh.segment(iv.loc.SegmentID).deadBytes.Load()
+	sh.mu.Unlock()
+
+	if nivs != 1 || iv.fileOff != 0 || iv.length != 400 {
+		t.Fatalf("clipped interval = {off:%d len:%d} (ivs=%d), want {0 400}", iv.fileOff, iv.length, nivs)
+	}
+	if dead != 600 {
+		t.Fatalf("dead bytes after clip = %d, want 600", dead)
+	}
+}
+
+func TestTruncateGrowIsNoOp(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+
+	if err := s.WriteAt(ctx, "f", 0, randBytes(100, 3)); err != nil {
+		t.Fatal(err)
+	}
+	before := s.UnsyncedBytes()
+	if err := s.Truncate(ctx, "f", 500); err != nil { // grow past the high-water mark
+		t.Fatalf("Truncate grow: %v", err)
+	}
+	if sz, _ := s.FileSize(ctx, "f"); sz != 100 {
+		t.Fatalf("grow-truncate changed FileSize to %d, want 100", sz)
+	}
+	if u := s.UnsyncedBytes(); u != before {
+		t.Fatalf("grow-truncate changed unsynced %d -> %d", before, u)
+	}
+}
+
+func TestTruncateVersionFenceWriteAfterSurvives(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+
+	if err := s.WriteAt(ctx, "f", 0, randBytes(1000, 4)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Truncate(ctx, "f", 400); err != nil {
+		t.Fatal(err)
+	}
+	// A write past newSize AFTER the truncate carries a higher Version and must
+	// re-extend the file.
+	tail := randBytes(100, 5)
+	if err := s.WriteAt(ctx, "f", 500, tail); err != nil {
+		t.Fatal(err)
+	}
+	if sz, _ := s.FileSize(ctx, "f"); sz != 600 {
+		t.Fatalf("FileSize after post-truncate write = %d, want 600", sz)
+	}
+	got := make([]byte, 100)
+	if _, _, err := s.ReadAt(ctx, "f", 500, got); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, tail) {
+		t.Fatalf("post-truncate write not readable")
+	}
+}
+
+func TestTruncateFailureLeavesStateIntact(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+
+	data := randBytes(1000, 6)
+	if err := s.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatal(err)
+	}
+	before := s.UnsyncedBytes()
+
+	testFailTruncate = "f"
+	defer func() { testFailTruncate = "" }()
+	if err := s.Truncate(ctx, "f", 400); err == nil {
+		t.Fatalf("expected injected truncate failure")
+	}
+
+	// A failed truncate must not mutate the index or the counters.
+	if sz, _ := s.FileSize(ctx, "f"); sz != 1000 {
+		t.Fatalf("failed truncate changed FileSize to %d, want 1000", sz)
+	}
+	if u := s.UnsyncedBytes(); u != before {
+		t.Fatalf("failed truncate changed unsynced %d -> %d", before, u)
+	}
+	got := make([]byte, 1000)
+	if _, _, err := s.ReadAt(ctx, "f", 0, got); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("failed truncate corrupted data")
+	}
+}
+
+func TestTruncateSurvivesReopen(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	s, err := Open(dir, Config{}, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	data := randBytes(1000, 7)
+	if err := s.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Truncate(ctx, "f", 400); err != nil {
+		t.Fatal(err)
+	}
+	_ = s.Close()
+
+	// Recovery replays the still-full on-disk record, then re-applies the durable
+	// truncate marker so the truncated bytes never resurrect.
+	r, err := Open(dir, Config{}, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	if sz, ok := r.FileSize(ctx, "f"); !ok || sz != 400 {
+		t.Fatalf("recovered FileSize = (%d,%v), want (400,true)", sz, ok)
+	}
+	got := make([]byte, 600)
+	for i := range got {
+		got[i] = 0xFF
+	}
+	if _, _, err := r.ReadAt(ctx, "f", 0, got); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got[:400], data[:400]) {
+		t.Fatalf("recovered kept bytes mismatch")
+	}
+	if !zeroFilled(got[400:]) {
+		t.Fatalf("recovered bytes past newSize not zero: %x", got[400:])
+	}
+}
+
+func TestVictimMarkersCollectsTruncate(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+
+	// Write then truncate so the active segment carries a truncate marker.
+	if err := s.WriteAt(ctx, "f", 0, randBytes(1000, 8)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.appendTruncateMarker(ctx, "f", 400); err != nil {
+		t.Fatalf("appendTruncateMarker: %v", err)
+	}
+	sh := s.shardFor("f")
+	sh.mu.Lock()
+	seg := sh.active
+	sh.mu.Unlock()
+
+	markers := victimMarkers(seg, s.cfg.SegmentSize)
+	var found bool
+	for _, m := range markers {
+		if m.flags&flagTruncate != 0 && m.id == "f" {
+			found = true
+			if m.newSize != 400 {
+				t.Fatalf("carried truncate newSize = %d, want 400", m.newSize)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("victimMarkers did not collect the truncate marker: %+v", markers)
+	}
+}

--- a/pkg/block/journal/truncate_test.go
+++ b/pkg/block/journal/truncate_test.go
@@ -207,6 +207,34 @@ func TestTruncateSurvivesReopen(t *testing.T) {
 	}
 }
 
+// TestTruncateDeadBytesReconstructedOnReopen guards the recovery deadBytes
+// rebuild: replay charges only physical records, so a truncate's clipped tail
+// leaves dead payload the counter never saw. Without reconstruction, pickVictim's
+// deadBytes<=0 gate skips the segment forever and GC can't reclaim the space.
+func TestTruncateDeadBytesReconstructedOnReopen(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	s, err := Open(dir, Config{}, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := s.WriteAt(ctx, "f", 0, randBytes(1000, 9)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Truncate(ctx, "f", 400); err != nil {
+		t.Fatal(err)
+	}
+	if d := s.Stats().DeadBytes; d != 600 {
+		t.Fatalf("pre-reopen DeadBytes = %d, want 600", d)
+	}
+
+	r := reopen(t, s)
+	if d := r.Stats().DeadBytes; d != 600 {
+		t.Fatalf("recovered DeadBytes = %d, want 600 (deadBytes not reconstructed)", d)
+	}
+}
+
 func TestVictimMarkersCollectsTruncate(t *testing.T) {
 	s := testStore(t, Config{})
 	ctx := context.Background()

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -74,6 +74,7 @@ func DefaultCommitBlock(
 	s Transactor,
 	rec block.BlockRecord,
 	chunks []block.BlockChunkCommit,
+	fileChunks []*block.FileChunk,
 ) error {
 	return s.WithTransaction(ctx, func(tx Transaction) error {
 		_, exists, err := tx.GetBlockRecord(ctx, rec.BlockID)
@@ -85,6 +86,17 @@ func DefaultCommitBlock(
 		}
 		if err := tx.PutBlockRecord(ctx, rec); err != nil {
 			return err
+		}
+		// Per-file manifest rows: the block carver passes one FileChunk per chunk
+		// (ID={FileID}/{FileOffset}, Hash, DataSize, State=Pending); legacy callers
+		// pass nil and write no rows.
+		for _, fc := range fileChunks {
+			if fc == nil {
+				continue
+			}
+			if err := tx.Put(ctx, fc); err != nil {
+				return err
+			}
 		}
 		for _, c := range chunks {
 			if c.Local != (block.LocalChunkLocation{}) {

--- a/pkg/metadata/store/badger/block_record_store.go
+++ b/pkg/metadata/store/badger/block_record_store.go
@@ -528,7 +528,7 @@ func hashFromLocalChunkKey(key []byte) (block.ContentHash, error) {
 // within a single transaction (via DefaultCommitBlock), then marks each chunk
 // synced. Idempotent: a second call for an already-committed block is a no-op.
 func (s *BadgerMetadataStore) CommitBlock(ctx context.Context, rec block.BlockRecord, chunks []block.BlockChunkCommit) error {
-	return metadata.DefaultCommitBlock(ctx, s, rec, chunks)
+	return metadata.DefaultCommitBlock(ctx, s, rec, chunks, nil)
 }
 
 // Compile-time guards: both the store and its transaction implement the new

--- a/pkg/metadata/store/memory/block_record_store.go
+++ b/pkg/metadata/store/memory/block_record_store.go
@@ -172,5 +172,5 @@ func (s *MemoryMetadataStore) WalkLocalLocations(_ context.Context, fn func(bloc
 // CommitBlock atomically writes rec and all chunk local locations, then marks
 // each chunk synced. Delegates to DefaultCommitBlock for idempotency logic.
 func (s *MemoryMetadataStore) CommitBlock(ctx context.Context, rec block.BlockRecord, chunks []block.BlockChunkCommit) error {
-	return metadata.DefaultCommitBlock(ctx, s, rec, chunks)
+	return metadata.DefaultCommitBlock(ctx, s, rec, chunks, nil)
 }

--- a/pkg/metadata/store/postgres/block_record_store.go
+++ b/pkg/metadata/store/postgres/block_record_store.go
@@ -280,7 +280,7 @@ func (s *PostgresMetadataStore) WalkLocalLocations(ctx context.Context, fn func(
 // Delegates to DefaultCommitBlock for idempotency logic — identical to the
 // memory and badger backends.
 func (s *PostgresMetadataStore) CommitBlock(ctx context.Context, rec block.BlockRecord, chunks []block.BlockChunkCommit) error {
-	return metadata.DefaultCommitBlock(ctx, s, rec, chunks)
+	return metadata.DefaultCommitBlock(ctx, s, rec, chunks, nil)
 }
 
 // ============================================================================

--- a/pkg/metadata/store/sqlite/block_record_store.go
+++ b/pkg/metadata/store/sqlite/block_record_store.go
@@ -212,7 +212,7 @@ func (s *SQLiteMetadataStore) WalkLocalLocations(ctx context.Context, fn func(bl
 // CommitBlock atomically writes rec and all chunk local locations within a
 // single transaction, then marks each chunk synced.  Idempotent on BlockID.
 func (s *SQLiteMetadataStore) CommitBlock(ctx context.Context, rec block.BlockRecord, chunks []block.BlockChunkCommit) error {
-	return metadata.DefaultCommitBlock(ctx, s, rec, chunks)
+	return metadata.DefaultCommitBlock(ctx, s, rec, chunks, nil)
 }
 
 // ============================================================================

--- a/pkg/metadata/storetest/commit_block_ops.go
+++ b/pkg/metadata/storetest/commit_block_ops.go
@@ -34,7 +34,7 @@ func (f *faultyLocalLocationStore) WithTransaction(ctx context.Context, fn func(
 }
 
 func (f *faultyLocalLocationStore) CommitBlock(ctx context.Context, rec block.BlockRecord, chunks []block.BlockChunkCommit) error {
-	return metadata.DefaultCommitBlock(ctx, f, rec, chunks)
+	return metadata.DefaultCommitBlock(ctx, f, rec, chunks, nil)
 }
 
 type faultyLocalLocationTx struct {
@@ -70,7 +70,7 @@ func (f *faultyMarkSyncedStore) WithTransaction(ctx context.Context, fn func(met
 }
 
 func (f *faultyMarkSyncedStore) CommitBlock(ctx context.Context, rec block.BlockRecord, chunks []block.BlockChunkCommit) error {
-	return metadata.DefaultCommitBlock(ctx, f, rec, chunks)
+	return metadata.DefaultCommitBlock(ctx, f, rec, chunks, nil)
 }
 
 type faultyMarkSyncedTx struct {


### PR DESCRIPTION
## What this is

**Stage 1 (S1)** of the journal switchover: additive, green-in-isolation groundwork that wires up the production carve collaborators and journal's missing methods **without routing anything through them yet**. The engine still uses the old carve path; **S2** (a later PR) does the atomic switch.

`Part of #1692`

## What S1 adds

1. **`journal.Config.ChunkParams` (#1569)** — `carveRun` now uses `chunker.NewChunkerWithParams`, falling back to `DefaultParams` when unset or invalid (invalid degrades to default, never a hard error — matches the fs store). Normalized in `withDefaults`, so existing `Config{}` callers stay byte-identical to the historical 1M/4M/16M profile.

2. **Four gap journal methods** (each shard-lock-shaped, each unit-tested):
   - `FileSize(ctx, id) (int64, bool)` — data high-water mark over live intervals.
   - `SetEvictionEnabled(bool)` — atomic gate on `Evict` (and the write-path `ensureSpace` that drives it).
   - `ListFiles(ctx) []FileID` — index keys across shards.
   - `Truncate(ctx, id, newSize)` — see the crash-safety design below.

3. **`metadata.DefaultCommitBlock`** gains a `fileChunks []*block.FileChunk` param; it writes one `tx.Put(fc)` per non-nil row inside the existing transaction. All existing callers (engine carve/compaction/migration + the four store delegators + storetest) pass `nil` — **zero behavior change**. Only the new sink passes real rows.

4. **New `pkg/block/engine/blocksink.go`** — `engineDeduper` (backs journal's dedup oracle with `SyncedHashStore.IsSynced`) and `engineBlockSink` (seal → `blockcodec.Builder` → `PutBlock` → `DefaultCommitBlock` incl. FileChunk rows). Mirrors `carveAndCommitBlock` minus local-byte resolution (data is in-hand on each `CarveChunk`); `BlockChunkCommit.Local` stays zero per §D2.

5. **Carve-seam acceptance test** — live `journal.Store` + the real adapters + fake remote + memory metadata store: asserts dirty→carve→block committed + FileChunk rows written; a duplicate file dedups to a no-op (no new block); and a crash mid-commit (commit durable, flip lost) → reopen → re-carve is a dedup no-op that re-flips.

## Truncate crash-safety design (risk #1)

Mirrors `Delete`'s tombstone-first discipline:

- A durable, fsynced **truncate marker** record (`flagTruncate`, `FileOffset` carries `newSize`, zero payload) is persisted **before** the in-memory index is touched. A failed marker write leaves the file intact; a crash after the marker can never resurrect truncated bytes.
- In-memory clip: intervals entirely past `newSize` are dropped; an interval **straddling** `newSize` is **clipped** (not dropped) via `interval.clamp`; freed bytes are charged as dead to their segments (GC reclaims them).
- **Version fence**: only intervals at or below the marker's Version are affected, so a write that raced past the truncate (higher Version) survives and re-extends the file — same semantics as `Delete`.
- **Recovery** re-applies the clip from the marker (on-disk data records past `newSize` linger until GC repacks them away, so recovery must re-truncate).
- **Repack carry-forward**: `victimMarkers` carries both tombstones and truncate markers into the relocation target, so a size-down stays durable even if the marker's segment is GC'd before the records it fences.
- A **grow** (or no-op) is skipped after a peek — no marker fsync.
- An in-flight carve of a clipped range is harmless: its post-upload flip re-resolves by (offset, version) and skips a fragment the truncate dropped/clipped, exactly as it skips a concurrent overwrite.

## Live path untouched

`syncer.go`, `carver.go`'s logic, and `local/fs`/`FSStore` are unchanged — the only engine-file edits are the `, nil` arg on `DefaultCommitBlock`. The new adapters exist but are not wired into the write/read/carve path. Every adapter and journal method is exercised by the S1 unit/acceptance tests, so nothing is dead.

## Verification

- `gofmt -s` clean, `go vet` clean, `golangci-lint run` clean, `go build ./...` + `GOOS=windows go build ./...` clean.
- `go test -race ./pkg/block/journal/... ./pkg/metadata/... ./pkg/block/engine/...` — 3098 pass.