### PR TITLE
test(nfs): harden READDIR verifier test against coarse Windows clock

### DIFF
--- a/internal/adapter/nfs/v3/handlers/readdir_test.go
+++ b/internal/adapter/nfs/v3/handlers/readdir_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v3/handlers"
@@ -393,8 +394,14 @@ func TestReadDir_StaleVerifierBadCookie(t *testing.T) {
 	require.NotZero(t, resumeCookie, "resume cookie must be non-zero to exercise the verifier check path")
 	require.NotZero(t, savedVerifier, "saved verifier must be non-zero to exercise the verifier check path")
 
-	// Modify the directory (changes mtime, invalidates verifier)
+	// Modify the directory (changes mtime, invalidates verifier). Force the
+	// directory mtime strictly forward so the verifier provably changes even on
+	// coarse-resolution clocks (e.g. Windows ~15ms), where two rapid mutations
+	// can share an identical mtime and thus an identical verifier.
 	fx.CreateFile("stale/file3.txt", []byte("3"))
+	dir := fx.GetFile("stale")
+	require.NotNil(t, dir, "directory must exist to advance its mtime")
+	fx.SetMtime(dirHandle, dir.Mtime.Add(time.Second))
 
 	// Second read with old verifier and a real non-zero cookie — must return BAD_COOKIE.
 	resp2, err := fx.Handler.ReadDir(fx.Context(), &handlers.ReadDirRequest{

--- a/internal/adapter/nfs/v3/handlers/readdirplus_test.go
+++ b/internal/adapter/nfs/v3/handlers/readdirplus_test.go
@@ -3,6 +3,7 @@ package handlers_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v3/handlers"
@@ -116,8 +117,14 @@ func TestReadDirPlus_StaleVerifierBadCookie(t *testing.T) {
 	require.NotZero(t, resumeCookie, "resume cookie must be non-zero to exercise the verifier check path")
 	require.NotZero(t, savedVerifier, "saved verifier must be non-zero to exercise the verifier check path")
 
-	// Modify the directory (changes mtime, invalidates verifier)
+	// Modify the directory (changes mtime, invalidates verifier). Force the
+	// directory mtime strictly forward so the verifier provably changes even on
+	// coarse-resolution clocks (e.g. Windows ~15ms), where two rapid mutations
+	// can share an identical mtime and thus an identical verifier.
 	fx.CreateFile("stale/file3.txt", []byte("3"))
+	dir := fx.GetFile("stale")
+	require.NotNil(t, dir, "directory must exist to advance its mtime")
+	fx.SetMtime(dirHandle, dir.Mtime.Add(time.Second))
 
 	// Second read with old verifier and a real non-zero cookie — must return BAD_COOKIE.
 	resp2, err := fx.Handler.ReadDirPlus(fx.Context(), &handlers.ReadDirPlusRequest{

--- a/internal/adapter/nfs/v3/handlers/testing/fixtures.go
+++ b/internal/adapter/nfs/v3/handlers/testing/fixtures.go
@@ -348,7 +348,7 @@ func (f *HandlerTestFixture) SetMtime(handle metadata.FileHandle, mtime time.Tim
 	if _, err := f.MetadataService.SetFileAttributes(f.authContext(), handle, &metadata.SetAttrs{
 		Mtime: &mtime,
 	}); err != nil {
-		f.t.Fatalf("Failed to set mtime for handle: %v", err)
+		f.t.Fatalf("SetMtime(handle=%x, mtime=%s): %v", handle, mtime.Format(time.RFC3339Nano), err)
 	}
 }
 

--- a/internal/adapter/nfs/v3/handlers/testing/fixtures.go
+++ b/internal/adapter/nfs/v3/handlers/testing/fixtures.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v3/handlers"
 	"github.com/marmos91/dittofs/pkg/block/engine"
@@ -333,6 +334,22 @@ func (f *HandlerTestFixture) CreateFile(path string, content []byte) metadata.Fi
 	}
 
 	return mustEncodeHandle(f.t, file)
+}
+
+// SetMtime sets the mtime of the file or directory identified by handle to the
+// given time. It is used to deterministically advance a directory's mtime — and
+// therefore its READDIR/READDIRPLUS cookie verifier, which is derived from the
+// directory mtime — without depending on wall-clock resolution. Coarse clocks
+// (e.g. Windows ~15ms) can leave two rapid mutations sharing an identical mtime,
+// which would otherwise make verifier-change assertions flaky.
+func (f *HandlerTestFixture) SetMtime(handle metadata.FileHandle, mtime time.Time) {
+	f.t.Helper()
+
+	if _, err := f.MetadataService.SetFileAttributes(f.authContext(), handle, &metadata.SetAttrs{
+		Mtime: &mtime,
+	}); err != nil {
+		f.t.Fatalf("Failed to set mtime for handle: %v", err)
+	}
 }
 
 // CreateSymlink creates a symbolic link at the given path pointing to target.


### PR DESCRIPTION
## Root cause

The READDIR/READDIRPLUS cookie verifier is a pure function of the directory mtime:

```go
func directoryMtimeVerifier(mtime time.Time) uint64 { return uint64(mtime.UnixNano()) }
```

`TestReadDir_StaleVerifierBadCookie` and `TestReadDirPlus_StaleVerifierBadCookie` read a directory (saving the verifier), then modify it and re-read, asserting `NFS3ERR_BAD_COOKIE` because the verifier changed. They relied on the two rapid mutations landing on distinct mtimes.

On Windows the clock resolution is ~15ms, so two rapid directory mutations can share an **identical** mtime → identical verifier → no `BAD_COOKIE` → the assert fails. On Linux the ns clock always advances, so it's green. This surfaced as a flake on #1716's Windows CI, but is pre-existing latent fragility — that PR does not touch this code, and the rerun passed on identical code, confirming nondeterminism.

## Fix

Test/fixture layer only; production code untouched.

- Add a `SetMtime(handle, time)` helper to the handler test fixture (wraps `SetFileAttributes` with an explicit `Mtime`).
- In both stale-verifier tests, after the directory mutation, advance the directory mtime by a known delta (`dir.Mtime.Add(time.Second)`) so the verifier provably differs regardless of clock granularity. No `time.Sleep`.

The sibling `ZeroCookieIgnoresVerifierMismatch` tests use junk/zero verifiers on the bypass path and do not depend on an mtime change — left unchanged.

## Verification

- `go test ./internal/adapter/nfs/v3/handlers/...` green, run 5x for determinism
- `go build ./...`, `GOOS=windows go build ./...`
- `gofmt -s`, `go vet`, `golangci-lint run` on touched packages — clean