### PR TITLE
fix(block/engine): stop and join syncer workers before closing the metadata store

### DIFF
--- a/pkg/block/engine/cold_read_overwrite_test.go
+++ b/pkg/block/engine/cold_read_overwrite_test.go
@@ -162,7 +162,9 @@ func TestBadgerColdRead_ShrinkToZeros(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
 	}
-	defer func() { _ = ms.Close() }()
+	// Cleanup (not defer) so bs.Close() joins the syncer workers before the
+	// metadata store closes -- see #1722.
+	t.Cleanup(func() { _ = ms.Close() })
 	runShrinkToZeros(t, ms)
 }
 
@@ -171,6 +173,8 @@ func TestBadgerColdRead_BoundaryShiftStale(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
 	}
-	defer func() { _ = ms.Close() }()
+	// Cleanup (not defer) so bs.Close() joins the syncer workers before the
+	// metadata store closes -- see #1722.
+	t.Cleanup(func() { _ = ms.Close() })
 	runBoundaryShiftStale(t, ms)
 }

--- a/pkg/block/engine/syncer_shutdown_test.go
+++ b/pkg/block/engine/syncer_shutdown_test.go
@@ -1,0 +1,123 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	memorylocal "github.com/marmos91/dittofs/pkg/block/local/memory"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+)
+
+// gatedChunkStore wraps a stubFileChunkStore so a download worker can be pinned
+// mid-lookup inside GetFileChunkAtOffset (the exact call that panicked with
+// "DB Closed" in #1722 when the badger metadata store was closed out from under
+// a live prefetch worker). It also records any access that arrives AFTER the
+// store is closed, which is what the real backend would turn into a panic.
+type gatedChunkStore struct {
+	*stubFileChunkStore
+
+	entered   chan struct{} // signalled once a worker enters GetFileChunkAtOffset
+	release   chan struct{} // closed by the test to let the pinned worker proceed
+	enterOnce sync.Once
+
+	closed         atomic.Bool // set by Close()
+	accessedClosed atomic.Bool // set if the store is touched after Close()
+}
+
+func newGatedChunkStore() *gatedChunkStore {
+	return &gatedChunkStore{
+		stubFileChunkStore: newStubFileChunkStore(),
+		entered:            make(chan struct{}),
+		release:            make(chan struct{}),
+	}
+}
+
+// GetFileChunkAtOffset makes gatedChunkStore satisfy chunkAtOffsetResolver, so
+// resolveCovering routes the download worker through here. It gates the first
+// caller until the test releases it, and flags any post-Close access.
+func (g *gatedChunkStore) GetFileChunkAtOffset(_ context.Context, _ string, _ uint64) (*block.FileChunk, error) {
+	if g.closed.Load() {
+		// A real badger store panics ("DB Closed") here; record it so the test
+		// fails deterministically instead of crashing the process.
+		g.accessedClosed.Store(true)
+		return nil, errors.New("gatedChunkStore: accessed after Close")
+	}
+	g.enterOnce.Do(func() { close(g.entered) })
+	<-g.release
+	return nil, nil // resolve as a hole -> fetchBlock returns cleanly, no remote GET
+}
+
+func (g *gatedChunkStore) Close() error {
+	g.closed.Store(true)
+	return nil
+}
+
+// TestSyncerClose_JoinsInFlightDownloadWorker pins the shutdown ordering that
+// #1722 violated: Syncer.Close() (via SyncQueue.Stop) must block until every
+// in-flight download worker has left the metadata store, so the store can then
+// be closed with no worker still reading it.
+//
+// It is fully deterministic (no reliance on CI slowness): a download worker is
+// forced to block inside GetFileChunkAtOffset, and the test asserts Close() does
+// not return while the worker is pinned, then returns once it is released, and
+// that no store access occurs after the store is finally closed.
+func TestSyncerClose_JoinsInFlightDownloadWorker(t *testing.T) {
+	gs := newGatedChunkStore()
+
+	cfg := DefaultConfig()
+	cfg.ParallelDownloads = 2
+	// A non-nil remote is required for fetchBlock to reach resolveFileChunk;
+	// a nil remote short-circuits before the store lookup. No HealthMonitor is
+	// started (we never call Syncer.Start), so IsRemoteHealthy() is true.
+	syncer := NewSyncer(memorylocal.New(), remotememory.New(), gs, cfg)
+
+	syncer.Queue().Start(context.Background())
+
+	if !syncer.Queue().EnqueueDownload(TransferRequest{PayloadID: "payload", BlockIndex: 0}) {
+		t.Fatal("EnqueueDownload returned false (queue full)")
+	}
+
+	// Wait until a worker is pinned inside GetFileChunkAtOffset.
+	select {
+	case <-gs.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("download worker never reached GetFileChunkAtOffset")
+	}
+
+	closeDone := make(chan struct{})
+	go func() {
+		_ = syncer.Close()
+		close(closeDone)
+	}()
+
+	// Close() must NOT return while the worker is still inside the store. If it
+	// did, the metadata store could be closed under a live worker -> #1722.
+	select {
+	case <-closeDone:
+		t.Fatal("Syncer.Close returned before the in-flight download worker finished — SyncQueue.Stop did not join workers (regression of #1722)")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	// Let the pinned worker finish; the store is still open, so this access is
+	// legal and must not set the post-Close flag.
+	close(gs.release)
+
+	select {
+	case <-closeDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Syncer.Close did not return after the worker was released")
+	}
+
+	// Only now — after Close() has joined all workers — is it safe to close the
+	// metadata store, matching the corrected engine/test teardown ordering.
+	_ = gs.Close()
+
+	if gs.accessedClosed.Load() {
+		t.Fatal("metadata store was accessed after Close — download worker outlived Syncer.Close (#1722)")
+	}
+}

--- a/pkg/block/engine/warm_read_integrity_test.go
+++ b/pkg/block/engine/warm_read_integrity_test.go
@@ -77,7 +77,12 @@ func TestWarmReadIntegrity_AfterDrainUploads(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
 		}
-		defer func() { _ = ms.Close() }()
+		// Register ms.Close BEFORE building the engine so cleanups run LIFO:
+		// bs.Close() (registered inside newEngineWithRemote) joins the syncer's
+		// download/prefetch workers first, then the metadata store closes. A
+		// plain `defer ms.Close()` runs before t.Cleanup and closed badger out
+		// from under an in-flight prefetch worker -> "DB Closed" panic (#1722).
+		t.Cleanup(func() { _ = ms.Close() })
 		runWarmReadIntegrity(t, ms)
 	})
 }


### PR DESCRIPTION
## The race

Under `-race` on slow CI, `pkg/block/engine` panicked `DB Closed`:

```
badger.(*Txn).NewIterator
 → BadgerMetadataStore.GetFileChunkAtOffset (objects.go:463)
 → engine.resolveCovering (read_internal.go:113)
 → engine.(*Syncer).resolveFileChunk (fetch.go:57)
 → engine.(*Syncer).fetchBlock (fetch.go:262)
 → engine.(*SyncQueue).processDownload (sync_queue.go:300)
 → engine.(*SyncQueue).downloadWorker (sync_queue.go:205)
```

A background `SyncQueue.downloadWorker` (spawned by the readahead prefetch driver during warm/cold reads) read the badger metadata store *after* the store was closed.

## Root cause: teardown ordering, not the engine

The engine shutdown is already correct: `Store.Close` → `Syncer.Close` → `SyncQueue.Stop` joins the download/prefetch workers (waits on the worker `WaitGroup` via `stoppedCh`) before returning.

The bug was in the tests. The badger subtests closed the metadata store with `defer ms.Close()`, and Go runs test-body `defer`s **before** `t.Cleanup` callbacks. The engine fixture (`newEngineWithRemote`) registers `t.Cleanup(bs.Close())`, so the actual order was:

1. `ms.Close()` (badger) — from the `defer`
2. `bs.Close()` (joins syncer workers) — from `t.Cleanup`

i.e. the metadata store was closed while prefetch workers were still in flight → `DB Closed`.

## Fix

Register `ms.Close()` via `t.Cleanup` **before** the engine is built, so cleanups run LIFO: `bs.Close()` joins the syncer workers first, then the metadata store closes. Applied to `warm_read_integrity_test.go` and both badger cold-read tests.

## Deterministic regression test

`TestSyncerClose_JoinsInFlightDownloadWorker` pins a download worker inside `GetFileChunkAtOffset` via a gate, then asserts:
- `Syncer.Close()` does **not** return while the worker is pinned (proving the join), and
- no store access occurs after the store is closed.

No reliance on CI slowness. Passes 20/20 under `-race`; would go red if `SyncQueue.Stop` ever stopped joining workers (the exact regression class of this bug).

## Prod relevance

Same ordering — join workers, then close the metadata store — is what protects server shutdown and share removal.

## Verification

- `go test ./pkg/block/engine/... -race -count=3` → 810 passed
- `gofmt -l`, `go vet`, `golangci-lint run` → clean
- `GOOS=windows go build ./...` → ok

Fixes #1722