### PR TITLE
feat(journal): local-only snapshot restore via segment-pinning + re-materialize (#1718)

### DIFF
--- a/pkg/block/engine/flush.go
+++ b/pkg/block/engine/flush.go
@@ -125,6 +125,48 @@ func (bs *Store) SeedCold(ctx context.Context, payloadID string, offset, length 
 	return cs.SeedCold(ctx, journal.FileID(payloadID), offset, length)
 }
 
+// RestoreToVersion rewinds the local journal to a snapshot's version watermark
+// and re-materializes that point-in-time view durably at the log head. It is the
+// local-only snapshot-restore primitive the runtime calls instead of
+// ResetLocalState when the share has no remote store (the journal is the only
+// durable copy of the bytes). No-op when the local store is not journal-backed
+// (e.g. the in-memory test store), which the caller only reaches off this path.
+func (bs *Store) RestoreToVersion(ctx context.Context, v uint64) error {
+	if err := bs.enter(); err != nil {
+		return err
+	}
+	defer bs.closeMu.RUnlock()
+	type restorer interface {
+		RestoreToVersion(ctx context.Context, v uint64) error
+	}
+	r, ok := bs.local.(restorer)
+	if !ok {
+		return nil
+	}
+	return r.RestoreToVersion(ctx, v)
+}
+
+// SetPinVersion sets the local journal's snapshot pin watermark so GC/eviction
+// keep the bytes of every at-or-below-watermark record (the durable copy for a
+// live local-only snapshot). No-op when the local store is not journal-backed.
+func (bs *Store) SetPinVersion(v uint64) {
+	type pinner interface{ SetPinVersion(v uint64) }
+	if p, ok := bs.local.(pinner); ok {
+		p.SetPinVersion(v)
+	}
+}
+
+// JournalVersion returns the local journal's current LSN watermark, captured by
+// snapshot create (after DrainRollups) to record the snapshot's version. Returns
+// 0 when the local store is not journal-backed.
+func (bs *Store) JournalVersion() uint64 {
+	type versioner interface{ JournalVersion() uint64 }
+	if j, ok := bs.local.(versioner); ok {
+		return j.JournalVersion()
+	}
+	return 0
+}
+
 func (bs *Store) ResetLocalState(ctx context.Context) error {
 	if err := bs.enter(); err != nil {
 		return err

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -334,7 +334,7 @@ func (s *Store) pinned(seg *segmentMeta) bool {
 		return false
 	}
 	mv := seg.minVersion.Load()
-	return mv != 0 && uint64(mv) <= pv
+	return mv != 0 && mv <= pv
 }
 
 // pickVictim returns the sealed segment with the highest dead fraction, or nil

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -95,6 +95,12 @@ func (s *Store) claimColdestEvictable() (*segmentMeta, *shard) {
 				if !evictable(seg) {
 					continue
 				}
+				if s.pinned(seg) {
+					// Pinned by a live snapshot: its bytes are the only durable copy
+					// of an at-or-below-watermark record (local-only) — never evict
+					// (#1718).
+					continue
+				}
 				if la := seg.lastAccess.Load(); best == nil || la < bestAccess {
 					best, bestShard, bestAccess = seg, sh, la
 				}
@@ -317,6 +323,20 @@ func (s *Store) gcShard(ctx context.Context, sh *shard, opts GCOptions) (reclaim
 	}
 }
 
+// pinned reports whether a live snapshot's watermark protects any record in seg:
+// its lowest record Version is at or below pinVersion. Whole-segment granularity —
+// segments fill sequentially, so a non-empty segment's records span a contiguous
+// version range and minVersion alone decides. pinVersion 0 (no live snapshot) or a
+// still-empty segment (minVersion 0) pins nothing (#1718).
+func (s *Store) pinned(seg *segmentMeta) bool {
+	pv := s.pinVersion.Load()
+	if pv == 0 {
+		return false
+	}
+	mv := seg.minVersion.Load()
+	return mv != 0 && uint64(mv) <= pv
+}
+
 // pickVictim returns the sealed segment with the highest dead fraction, or nil
 // if none qualifies. A segment carrying no dead bytes is never a victim (there
 // is nothing to reclaim), which is also what keeps a tombstone-only segment from
@@ -348,6 +368,12 @@ func (s *Store) pickVictim(sh *shard, opts GCOptions) *segmentMeta {
 	for id, seg := range sh.sealed {
 		if seg.busy.Load() {
 			continue // claimed by eviction or an in-flight repack
+		}
+		if s.pinned(seg) {
+			// Pinned by a live snapshot: repack relocates bytes but a crash mid-move
+			// plus a rollback needs the pinned records intact at their original
+			// versions — keep the whole segment until the snapshot releases (#1718).
+			continue
 		}
 		if seg.deadBytes.Load() <= 0 {
 			// Nothing to reclaim. This skips a tombstone-only segment (records with
@@ -478,6 +504,7 @@ func (s *Store) repackSegment(sh *shard, victim *segmentMeta) (int64, error) {
 		if m.synced {
 			syncedCount++
 		}
+		target.noteMinVersion(m.version)
 	}
 	for _, mk := range markers {
 		var werr error
@@ -490,6 +517,7 @@ func (s *Store) repackSegment(sh *shard, victim *segmentMeta) (int64, error) {
 			cleanup()
 			return 0, werr
 		}
+		target.noteMinVersion(mk.version)
 	}
 
 	// 3. Bytes durable: fsync + seal the target before any index entry names it.

--- a/pkg/block/journal/recovery.go
+++ b/pkg/block/journal/recovery.go
@@ -185,6 +185,9 @@ func (s *Store) recover() error {
 			if rec.header.Version > maxVersion {
 				maxVersion = rec.header.Version
 			}
+			// Reconstruct the segment's pin watermark: minVersion is the lowest
+			// record Version it holds, so a live snapshot keeps it off GC (#1718).
+			m.noteMinVersion(rec.header.Version)
 			if rec.header.Flags&flagTombstone != 0 {
 				fid := FileID(rec.fileID)
 				if rec.header.Version > tombstones[fid] {

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -54,6 +54,13 @@ type segmentMeta struct {
 	records       atomic.Int64 // physical records appended (eviction synced-gate denominator)
 	syncedRecords atomic.Int64 // records with the synced flag set (eviction gate)
 	lastAccess    atomic.Int64 // unix nanos, approx-LRU victim key
+	// minVersion is the lowest record Version stored in this segment (0 = empty).
+	// Segments fill sequentially, so a segment's records span a contiguous
+	// [minVersion, maxVersion]; minVersion<=pinVersion means the segment holds a
+	// record at or below a live snapshot's watermark and must not be evicted or
+	// GC-repacked while that snapshot lives (#1718). Set on the first append and
+	// reconstructed during the recovery scan and repack.
+	minVersion atomic.Int64
 	// busy claims the segment for an exclusive whole-segment operation (evict or
 	// GC repack). A claimer CAS-sets it true so eviction and GC never touch the
 	// same sealed segment concurrently; warm reads and carve don't claim.
@@ -66,6 +73,23 @@ type segmentMeta struct {
 	readGuard sync.RWMutex
 	// ponytail: the quotient-filter membership hint (rebuilt on repack) arrives
 	// with GC; a linear index scan suffices until segments are large.
+}
+
+// noteMinVersion records v as a candidate lowest record Version for the segment,
+// keeping the minimum ever seen (0 = unset). The pin predicate (reclaim.go) reads
+// it to keep a segment holding at-or-below-pinVersion records off the eviction/GC
+// path. Caller holds the shard lock on the append path; the CAS loop tolerates the
+// recovery/repack callers that set it without one.
+func (m *segmentMeta) noteMinVersion(v uint64) {
+	for {
+		cur := m.minVersion.Load()
+		if cur != 0 && cur <= int64(v) {
+			return
+		}
+		if m.minVersion.CompareAndSwap(cur, int64(v)) {
+			return
+		}
+	}
 }
 
 // close closes the segment's data and index file descriptors.
@@ -291,6 +315,7 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 	seg.tail.Store(segOff + recLen)
 	seg.liveBytes.Add(int64(len(data)))
 	seg.records.Add(1)
+	seg.noteMinVersion(version)
 	seg.lastAccess.Store(s.clock.Now().UnixNano())
 	s.diskBytes.Add(recLen)
 	if synced {
@@ -385,6 +410,7 @@ func (s *Store) appendTombstone(ctx context.Context, id FileID) (uint64, error) 
 		sh.mu.Unlock()
 		return 0, err
 	}
+	seg.noteMinVersion(version)
 	if seg.idxFD != nil {
 		_, _ = seg.idxFD.Write(idxEntry{
 			FileIDHash: fnv1a(string(id)),
@@ -439,6 +465,7 @@ func (s *Store) appendTruncateMarker(ctx context.Context, id FileID, newSize int
 		sh.mu.Unlock()
 		return 0, err
 	}
+	seg.noteMinVersion(version)
 	if seg.idxFD != nil {
 		_, _ = seg.idxFD.Write(idxEntry{
 			FileIDHash: fnv1a(string(id)),

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -60,7 +60,7 @@ type segmentMeta struct {
 	// record at or below a live snapshot's watermark and must not be evicted or
 	// GC-repacked while that snapshot lives (#1718). Set on the first append and
 	// reconstructed during the recovery scan and repack.
-	minVersion atomic.Int64
+	minVersion atomic.Uint64
 	// busy claims the segment for an exclusive whole-segment operation (evict or
 	// GC repack). A claimer CAS-sets it true so eviction and GC never touch the
 	// same sealed segment concurrently; warm reads and carve don't claim.
@@ -83,10 +83,10 @@ type segmentMeta struct {
 func (m *segmentMeta) noteMinVersion(v uint64) {
 	for {
 		cur := m.minVersion.Load()
-		if cur != 0 && cur <= int64(v) {
+		if cur != 0 && cur <= v {
 			return
 		}
-		if m.minVersion.CompareAndSwap(cur, int64(v)) {
+		if m.minVersion.CompareAndSwap(cur, v) {
 			return
 		}
 	}

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -137,10 +137,17 @@ type Store struct {
 	// holds and the per-segment busy claim it CAS-sets on each victim, not gcMu.
 	gcMu sync.Mutex
 
-	nextSeg   atomic.Uint64 // global segment-ID allocator
-	version   atomic.Uint64 // global monotonic LSN
-	unsynced  atomic.Int64  // dirty bytes not yet carved to remote
-	diskBytes atomic.Int64  // total on-disk segment bytes (headers + records), the eviction gate input
+	nextSeg atomic.Uint64 // global segment-ID allocator
+	version atomic.Uint64 // global monotonic LSN
+	// pinVersion is the highest snapshot watermark still held by a live snapshot
+	// (0 = none). A segment whose minVersion is at or below it is kept off the
+	// eviction/GC path so a local-only snapshot's bytes — the only durable copy —
+	// survive until the snapshot is deleted. DERIVED: the runtime recomputes it as
+	// max(JournalVersion) over live snapshots and calls SetPinVersion; the journal
+	// only reads it (reclaim.go). See #1718.
+	pinVersion atomic.Uint64
+	unsynced   atomic.Int64 // dirty bytes not yet carved to remote
+	diskBytes  atomic.Int64 // total on-disk segment bytes (headers + records), the eviction gate input
 
 	writes    atomic.Int64
 	reads     atomic.Int64
@@ -543,3 +550,179 @@ func (s *Store) idxPath(id uint64) string {
 
 // nextVersion returns the next global LSN.
 func (s *Store) nextVersion() uint64 { return s.version.Add(1) }
+
+// JournalVersion returns the current global LSN watermark: every record written
+// so far carries a Version at or below it. Snapshot create captures this after
+// draining rollups so the snapshot pins exactly the records that make up its
+// point-in-time view (#1718).
+func (s *Store) JournalVersion() uint64 { return s.version.Load() }
+
+// SetPinVersion sets the highest live-snapshot watermark. The runtime derives it
+// as max(JournalVersion) over live snapshots and raises it before a snapshot is
+// marked ready / lowers it only after a delete commits, so GC only ever grows
+// more conservative. Reads are a single atomic load on the reclaim path.
+func (s *Store) SetPinVersion(v uint64) { s.pinVersion.Store(v) }
+
+// PinVersion reports the current pin watermark (0 = no live snapshot).
+func (s *Store) PinVersion() uint64 { return s.pinVersion.Load() }
+
+// RestoreToVersion rewinds every file to its point-in-time view as of the global
+// LSN watermark V and re-materializes that view durably at the log head, so a
+// crash-reopen reconstructs V and the pre-restore records (which a safety snapshot
+// still pins for rollback) stay intact. It is the local-only snapshot-restore
+// primitive: the journal is the only durable copy of the bytes, so a plain rewind
+// is not restart-safe (recover() would resurrect the >V head) and the >V records
+// cannot be deleted. See #1718.
+//
+// Two phases:
+//
+//  1. Ceiling replay: scan every on-disk record and rebuild each file's coverage
+//     as of V — data records with Version<=V resolved newest-wins, tombstones and
+//     truncate markers with Version<=V honored, everything above V ignored. The
+//     pre-overwrite records survive because a live snapshot pinned their segments.
+//  2. Re-materialize: for each file, read the V-view bytes from their pinned
+//     source records and re-append them as fresh dirty records at the head (a
+//     tombstone first to bury the current head, then the V-view data). Fresh
+//     versions exceed everything, so recover() rebuilds V on reopen; a file
+//     present at head but absent at V is tombstoned away.
+//
+// The caller (restore orchestration) drains rollups afterward and holds the share
+// disabled, so no concurrent writer races this.
+func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if s.closed.Load() {
+		return errClosed
+	}
+
+	// --- phase 1: ceiling replay over the on-disk records ---
+	vIndex := map[FileID]*fileIndex{}
+	tombstones := map[FileID]uint64{}
+	truncations := map[FileID]truncMark{}
+	for _, sh := range s.shards {
+		sh.mu.Lock()
+		segs := make([]*segmentMeta, 0, len(sh.sealed)+1)
+		if sh.active != nil {
+			segs = append(segs, sh.active)
+		}
+		for _, seg := range sh.sealed {
+			segs = append(segs, seg)
+		}
+		sh.mu.Unlock()
+
+		for _, seg := range segs {
+			recs, _ := scanValidRecords(seg.fd, s.cfg.SegmentSize, s.cfg.SegmentSize)
+			for _, rec := range recs {
+				if rec.header.Version > v {
+					continue // above the watermark: belongs to a post-snapshot state
+				}
+				fid := FileID(rec.fileID)
+				switch {
+				case rec.header.Flags&flagTombstone != 0:
+					if rec.header.Version > tombstones[fid] {
+						tombstones[fid] = rec.header.Version
+					}
+				case rec.header.Flags&flagTruncate != 0:
+					if cur, ok := truncations[fid]; !ok || rec.header.Version > cur.version {
+						truncations[fid] = truncMark{version: rec.header.Version, newSize: int64(rec.header.FileOffset)}
+					}
+				default:
+					fi := vIndex[fid]
+					if fi == nil {
+						fi = &fileIndex{}
+						vIndex[fid] = fi
+					}
+					fi.insert(interval{
+						fileOff: int64(rec.header.FileOffset),
+						length:  int64(rec.header.PayloadLen),
+						version: rec.header.Version,
+						synced:  rec.header.Flags&flagSynced != 0,
+						loc: SegmentLocation{
+							SegmentID: seg.id,
+							Offset:    rec.segOff + recordHeaderSize + int64(len(rec.fileID)),
+							Length:    int64(rec.header.PayloadLen),
+						},
+					})
+				}
+			}
+		}
+	}
+	// Honor tombstones and truncate markers at or below V, mirroring recover().
+	for fid, fi := range vIndex {
+		if tv, ok := tombstones[fid]; ok {
+			kept := fi.ivs[:0]
+			for _, iv := range fi.ivs {
+				if iv.version > tv {
+					kept = append(kept, iv)
+				}
+			}
+			fi.ivs = kept
+		}
+		if tm, ok := truncations[fid]; ok {
+			kept := fi.ivs[:0]
+			for _, iv := range fi.ivs {
+				if iv.version > tm.version || iv.end() <= tm.newSize {
+					kept = append(kept, iv)
+					continue
+				}
+				if iv.fileOff < tm.newSize {
+					kept = append(kept, iv.clamp(iv.fileOff, tm.newSize))
+				}
+			}
+			fi.ivs = kept
+		}
+		if len(fi.ivs) == 0 {
+			delete(vIndex, fid)
+		}
+	}
+
+	// --- phase 2: re-materialize the V-view at the head ---
+	head := map[FileID]struct{}{}
+	for _, id := range s.ListFiles(ctx) {
+		head[id] = struct{}{}
+	}
+	for id, fi := range vIndex {
+		type extent struct {
+			off  int64
+			data []byte
+		}
+		exts := make([]extent, 0, len(fi.ivs))
+		sh := s.shardFor(id)
+		for _, iv := range fi.ivs {
+			if iv.length <= 0 {
+				continue
+			}
+			sh.mu.Lock()
+			seg := sh.segment(iv.loc.SegmentID)
+			sh.mu.Unlock()
+			if seg == nil {
+				return fmt.Errorf("journal: restore: source segment %d gone for %q@%d", iv.loc.SegmentID, id, iv.fileOff)
+			}
+			buf := make([]byte, iv.length)
+			if _, err := seg.fd.ReadAt(buf, iv.loc.Offset); err != nil {
+				return fmt.Errorf("journal: restore: read %q@%d from segment %d: %w", id, iv.fileOff, iv.loc.SegmentID, err)
+			}
+			exts = append(exts, extent{off: iv.fileOff, data: buf})
+		}
+		// Bury the current head (tombstone Version > head), then re-assert the
+		// V-view as fresh dirty records on top of it.
+		if err := s.Delete(ctx, id); err != nil {
+			return fmt.Errorf("journal: restore: bury head for %q: %w", id, err)
+		}
+		for _, e := range exts {
+			if err := s.WriteAt(ctx, id, e.off, e.data); err != nil {
+				return fmt.Errorf("journal: restore: re-materialize %q@%d: %w", id, e.off, err)
+			}
+		}
+		delete(head, id)
+	}
+	// Files present at head but not in the V-view were created after V: tombstone
+	// them so recover() and reads agree they are gone.
+	for id := range head {
+		if err := s.Delete(ctx, id); err != nil {
+			return fmt.Errorf("journal: restore: tombstone post-V file %q: %w", id, err)
+		}
+	}
+	return nil
+}

--- a/pkg/controlplane/models/snapshot.go
+++ b/pkg/controlplane/models/snapshot.go
@@ -27,6 +27,11 @@ type Snapshot struct {
 	MetadataEngine string `gorm:"not null;size:20" json:"metadata_engine"`
 	ManifestCount  int64  `gorm:"not null;default:0" json:"manifest_count"`
 	RemoteDurable  bool   `gorm:"not null;default:false" json:"remote_durable"`
+	// JournalVersion is the local-journal LSN watermark captured when the
+	// snapshot became ready. A local-only restore rewinds the journal to it
+	// (RestoreToVersion), and the share derives its GC pin as the max over live
+	// snapshots. 0 for pre-#1718 rows and remote-only shares that never pin.
+	JournalVersion uint64 `gorm:"not null;default:0" json:"journal_version"`
 	// Scheduled marks snapshots created by the background snapshot scheduler.
 	// Only scheduled snapshots are eligible for automatic retention pruning;
 	// manually-created snapshots are never auto-pruned.

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -504,6 +504,11 @@ func (r *Runtime) AddShare(ctx context.Context, config *ShareConfig) error {
 	if err := r.ReconcileShareRootACL(ctx, config.Name); err != nil {
 		logger.Warn("failed to reconcile share root ACL", "share", config.Name, "error", err)
 	}
+	// Reconstruct the local-only journal snapshot pin from the durable snapshot
+	// list so GC/eviction keep the segments backing every live snapshot's bytes
+	// across a restart, before any background reclaim runs. No-op for remote
+	// shares and shares without snapshots (#1718).
+	r.recomputePinVersion(ctx, config.Name)
 	return nil
 }
 

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -1511,6 +1511,19 @@ func (r *Runtime) restoreSnapshot(
 		// dirty records reach the FileChunk manifest. The snapshot's pinned
 		// segments still hold the pre-overwrite bytes RestoreToVersion reads back
 		// (#1718).
+		//
+		// Fail closed on a journal-backed snapshot that carries no watermark but
+		// held data: JournalVersion==0 + ManifestCount>0 + a live journal that has
+		// really written records (bs.JournalVersion()>0) means the row predates
+		// #1718 watermark recording, so rewinding to v0 would silently tombstone
+		// real bytes. The three conditions together exclude the legitimate cases:
+		// an empty-FS snapshot (ManifestCount==0, correct to rewind-to-empty) and a
+		// non-journal local store (memory: bs.JournalVersion()==0, restore recovers
+		// from its own CAS, not RestoreToVersion).
+		if snap.JournalVersion == 0 && snap.ManifestCount > 0 && bs.JournalVersion() > 0 {
+			return safetySnapshotID, fmt.Errorf("restore snapshot %q: predates journal-version tracking (manifest_count=%d), local-only restore unavailable: %w",
+				snapID, snap.ManifestCount, models.ErrRestoreAborted)
+		}
 		if rerr := bs.RestoreToVersion(ctx, snap.JournalVersion); rerr != nil {
 			return safetySnapshotID, fmt.Errorf("restore snapshot %q: rewind journal to v%d (safety-snap=%s): %w: %v",
 				snapID, snap.JournalVersion, safetySnapshotID, models.ErrRestoreAborted, rerr)

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -545,6 +545,13 @@ func (r *Runtime) runSnapshotOrchestration(
 	}
 	logger.Debug("snapshot create: drain rollups+carve complete", "snapshot_id", snapID, "share", shareName)
 
+	// Capture the local-journal LSN watermark now that rollups are drained: every
+	// record making up this snapshot's point-in-time view carries a Version at or
+	// below it. Persisted with the ready flip and used to (a) pin the journal
+	// segments that back a local-only snapshot and (b) drive RestoreToVersion.
+	// 0 on a local store that is not journal-backed (#1718).
+	journalVersion := bs.JournalVersion()
+
 	// --- Step 1: WriteSnapshot -> metadata.dump (atomic temp+rename) ---
 	dumpPath := snap.MetadataDumpPath(localStoreDir)
 	logger.Debug("snapshot create: write start",
@@ -610,7 +617,8 @@ func (r *Runtime) runSnapshotOrchestration(
 		// left to the column default. This way the post-create row
 		// state is fully deterministic on success and not subject to
 		// schema-default drift.
-		if err := r.store.MarkSnapshotReady(ctx, shareName, snapID, false, int64(manifestCount)); err != nil {
+		raisePinForLocalOnly(bs, journalVersion)
+		if err := r.store.MarkSnapshotReady(ctx, shareName, snapID, false, int64(manifestCount), journalVersion); err != nil {
 			terminalErr = fmt.Errorf("snapshot create %s: mark ready (no-verify): %w: %v",
 				snapID, models.ErrSnapshotBackupFailed, err)
 			r.failSnap(shareName, snapID, terminalErr)
@@ -682,7 +690,8 @@ func (r *Runtime) runSnapshotOrchestration(
 	// remote_durable=false rather than failing (#791). Mirrors the
 	// restore-side no-remote skip so create and restore agree.
 	if remoteStore == nil {
-		if err := r.store.MarkSnapshotReady(ctx, shareName, snapID, false, int64(manifestCount)); err != nil {
+		raisePinForLocalOnly(bs, journalVersion)
+		if err := r.store.MarkSnapshotReady(ctx, shareName, snapID, false, int64(manifestCount), journalVersion); err != nil {
 			terminalErr = fmt.Errorf("snapshot create %s: mark ready (local-only): %w: %v",
 				snapID, models.ErrSnapshotBackupFailed, err)
 			r.failSnap(shareName, snapID, terminalErr)
@@ -748,7 +757,8 @@ func (r *Runtime) runSnapshotOrchestration(
 	// crash mid-update produces ready+remote_durable=false — visually
 	// indistinguishable from the intentional --no-verify result and
 	// a false negative for restore's durability gate.
-	if err := r.store.MarkSnapshotReady(ctx, shareName, snapID, true, int64(manifestCount)); err != nil {
+	raisePinForLocalOnly(bs, journalVersion)
+	if err := r.store.MarkSnapshotReady(ctx, shareName, snapID, true, int64(manifestCount), journalVersion); err != nil {
 		terminalErr = fmt.Errorf("snapshot create %s: mark ready: %w: %v",
 			snapID, models.ErrSnapshotBackupFailed, err)
 		r.failSnap(shareName, snapID, terminalErr)
@@ -1481,15 +1491,41 @@ func (r *Runtime) restoreSnapshot(
 	// WaitForSnapshot above, so the safety snap's DrainRollups completed),
 	// so every byte that must survive is already durable in CAS and there
 	// are no dirty intervals left to flush.
-	if rerr := bs.ResetLocalState(ctx); rerr != nil {
-		return safetySnapshotID, fmt.Errorf("restore snapshot %q: reset block-store local state (safety-snap=%s): %w: %v",
-			snapID, safetySnapshotID, models.ErrRestoreAborted, rerr)
+	if remoteVerify {
+		// Remote-backed: drop the local append-log overlay; post-restore reads
+		// resolve through the restored CAS manifest + remote (cold-seeded below).
+		if rerr := bs.ResetLocalState(ctx); rerr != nil {
+			return safetySnapshotID, fmt.Errorf("restore snapshot %q: reset block-store local state (safety-snap=%s): %w: %v",
+				snapID, safetySnapshotID, models.ErrRestoreAborted, rerr)
+		}
+		logger.Info("snapshot restore: block-store local state reset",
+			"snapshot_id", snapID,
+			"share", shareName,
+			"safety_snap_id", safetySnapshotID,
+		)
+	} else {
+		// Local-only: the journal is the only durable copy of the bytes, so there
+		// is nothing to re-seed from remote. Rewind the journal to the snapshot's
+		// version watermark and re-materialize that point-in-time view durably at
+		// the head (RestoreToVersion), then drain rollups so the re-materialized
+		// dirty records reach the FileChunk manifest. The snapshot's pinned
+		// segments still hold the pre-overwrite bytes RestoreToVersion reads back
+		// (#1718).
+		if rerr := bs.RestoreToVersion(ctx, snap.JournalVersion); rerr != nil {
+			return safetySnapshotID, fmt.Errorf("restore snapshot %q: rewind journal to v%d (safety-snap=%s): %w: %v",
+				snapID, snap.JournalVersion, safetySnapshotID, models.ErrRestoreAborted, rerr)
+		}
+		if derr := bs.DrainRollups(ctx); derr != nil {
+			return safetySnapshotID, fmt.Errorf("restore snapshot %q: drain rollups after journal rewind (safety-snap=%s): %w: %v",
+				snapID, safetySnapshotID, models.ErrRestoreAborted, derr)
+		}
+		logger.Info("snapshot restore: journal rewound to snapshot watermark",
+			"snapshot_id", snapID,
+			"share", shareName,
+			"safety_snap_id", safetySnapshotID,
+			"journal_version", snap.JournalVersion,
+		)
 	}
-	logger.Info("snapshot restore: block-store local state reset",
-		"snapshot_id", snapID,
-		"share", shareName,
-		"safety_snap_id", safetySnapshotID,
-	)
 	r.advanceRestoreMarker(ctx, internal, shareName, snapID, safetySnapshotID, models.RestoreStepLocalReset)
 
 	logger.Info("snapshot restore: reset start",
@@ -1627,6 +1663,45 @@ func (r *Runtime) seedColdFromManifest(ctx context.Context, bs *engine.Store, me
 		}
 		return nil
 	})
+}
+
+// raisePinForLocalOnly bumps a local-only share's journal snapshot pin to jv
+// before a snapshot is marked ready, so GC/eviction keep the segments that back
+// the snapshot's point-in-time view — on a local-only share the journal is the
+// sole durable copy of those bytes (#1718). A remote-backed share needs no pin
+// (its bytes also live remotely, cold reads rehydrate) and pinning would strand
+// local disk, so it is skipped. A freshly-created snapshot always carries the
+// highest watermark, so a bare Set is the correct new max.
+func raisePinForLocalOnly(bs *engine.Store, jv uint64) {
+	if bs != nil && !bs.HasRemoteStore() {
+		bs.SetPinVersion(jv)
+	}
+}
+
+// recomputePinVersion re-derives a local-only share's journal pin as the max
+// JournalVersion over its live (ready) snapshots and applies it. Called at share
+// start (crash-safe reconstruction from the durable snapshot list) and after a
+// snapshot delete commits (lowering the pin once its watermark is no longer
+// held). No-op for remote-backed shares and best-effort — a lookup failure only
+// leaves GC more conservative, never less (#1718).
+func (r *Runtime) recomputePinVersion(ctx context.Context, shareName string) {
+	bs, err := r.sharesSvc.GetBlockStoreForShare(shareName)
+	if err != nil || bs == nil || bs.HasRemoteStore() {
+		return
+	}
+	snaps, err := r.store.ListSnapshots(ctx, shareName)
+	if err != nil {
+		logger.Warn("pin: list snapshots to recompute journal pin failed (leaving pin as-is)",
+			"share", shareName, "error", err)
+		return
+	}
+	var maxV uint64
+	for _, s := range snaps {
+		if s != nil && s.State == models.StateReady && s.JournalVersion > maxV {
+			maxV = s.JournalVersion
+		}
+	}
+	bs.SetPinVersion(maxV)
 }
 
 // putRestoreMarker upserts the per-share restore marker at the given step.
@@ -1798,6 +1873,12 @@ func (r *Runtime) DeleteSnapshot(ctx context.Context, share, snapID string) (err
 	if err := r.store.DeleteSnapshot(ctx, share, snapID); err != nil {
 		return err
 	}
+
+	// Lower the journal pin now the delete has committed: this snapshot's
+	// watermark is no longer held, so GC/eviction may reclaim segments no
+	// remaining live snapshot needs. Recompute (not just clear) so other live
+	// snapshots keep their pin. No-op for remote-backed shares (#1718).
+	r.recomputePinVersion(ctx, share)
 
 	logger.Info("snapshot deleted",
 		"share", share, "snapshot_id", snapID)

--- a/pkg/controlplane/runtime/snapshot_byteverify_test.go
+++ b/pkg/controlplane/runtime/snapshot_byteverify_test.go
@@ -536,7 +536,6 @@ func runByteVerifyCycle(t *testing.T, fx *byteVerifyFixture) {
 // DITTOFS_TEST_POSTGRES_DSN is set (the integration-tagged file supplies the
 // postgres case constructor).
 func TestSnapshotByteVerify_Matrix(t *testing.T) {
-	t.Skip("#1718: local-only snapshot-restore under the journal (segment-pinning), follow-up")
 	for _, bk := range byteVerifyBackends(t) {
 		bk := bk
 		t.Run(bk.name, func(t *testing.T) {

--- a/pkg/controlplane/runtime/snapshot_restore_crash_reopen_test.go
+++ b/pkg/controlplane/runtime/snapshot_restore_crash_reopen_test.go
@@ -29,7 +29,6 @@ import (
 //     REAPPEARS (proving the rollback actually ran, not just a marker clear),
 //     and a.bin/b.bin remain byte-identical through the reopened store.
 func TestRestoreCrashRecovery_AcrossRealReopen(t *testing.T) {
-	t.Skip("#1718: local-only snapshot-restore under the journal (segment-pinning), follow-up")
 	for _, bk := range byteVerifyBackends(t) {
 		bk := bk
 		t.Run(bk.name, func(t *testing.T) {

--- a/pkg/controlplane/runtime/snapshot_rollback_enabled_test.go
+++ b/pkg/controlplane/runtime/snapshot_rollback_enabled_test.go
@@ -25,7 +25,6 @@ import (
 // disabled (matching the operator-restore contract), and the file is restored
 // to the safety-snapshot bytes.
 func TestRestoreRollback_ProceedsWhenShareEnabledAtBoot(t *testing.T) {
-	t.Skip("#1718: local-only snapshot-restore under the journal (segment-pinning), follow-up")
 	meta := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	fx := newByteVerifyFixture(t, meta, "memory")
 	defer fx.close()

--- a/pkg/controlplane/runtime/snapshot_rollback_quiesce_test.go
+++ b/pkg/controlplane/runtime/snapshot_rollback_quiesce_test.go
@@ -25,7 +25,6 @@ import (
 // safety snapshot and its FileAttr.Blocks are the snapshot's blocks, not the
 // discarded post-snapshot state.
 func TestRestoreRollback_QuiescesRollupBeforeReset(t *testing.T) {
-	t.Skip("#1718: local-only snapshot-restore under the journal (segment-pinning), follow-up")
 	meta := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	fx := newByteVerifyFixture(t, meta, "memory")
 	defer fx.close()

--- a/pkg/controlplane/store/interface.go
+++ b/pkg/controlplane/store/interface.go
@@ -612,7 +612,9 @@ type SnapshotStore interface {
 	// Returns models.ErrSnapshotNotFound if no row matches (shareName, id).
 	// Returns models.ErrSnapshotStateConflict if the row exists but is
 	// not in state='creating'.
-	MarkSnapshotReady(ctx context.Context, shareName, id string, durable bool, manifestCount int64) error
+	// journalVersion records the local-journal LSN watermark the snapshot pins
+	// (0 for remote-only shares); a local-only restore rewinds to it.
+	MarkSnapshotReady(ctx context.Context, shareName, id string, durable bool, manifestCount int64, journalVersion uint64) error
 }
 
 // SnapshotPolicyStore provides per-share snapshot policy CRUD for the

--- a/pkg/controlplane/store/snapshots.go
+++ b/pkg/controlplane/store/snapshots.go
@@ -201,15 +201,16 @@ func (s *GORMStore) UpdateSnapshotDurable(ctx context.Context, shareName, id str
 // Returns models.ErrSnapshotNotFound if no row matches (shareName, id).
 // Returns models.ErrSnapshotStateConflict if the row exists but is not in
 // state='creating'.
-func (s *GORMStore) MarkSnapshotReady(ctx context.Context, shareName, id string, durable bool, manifestCount int64) error {
+func (s *GORMStore) MarkSnapshotReady(ctx context.Context, shareName, id string, durable bool, manifestCount int64, journalVersion uint64) error {
 	db := s.db.WithContext(ctx)
 	res := db.Model(&models.Snapshot{}).
 		Where("share_name = ? AND id = ? AND state = ?", shareName, id, models.StateCreating).
 		Updates(map[string]any{
-			"state":          models.StateReady,
-			"remote_durable": durable,
-			"manifest_count": manifestCount,
-			"updated_at":     time.Now(),
+			"state":           models.StateReady,
+			"remote_durable":  durable,
+			"manifest_count":  manifestCount,
+			"journal_version": journalVersion,
+			"updated_at":      time.Now(),
 		})
 	if res.Error != nil {
 		return res.Error


### PR DESCRIPTION
Fixes #1718.

## Root cause
In a remote-less (local-only) share the journal is the ONLY durable copy of bytes. snapshot@V → overwrite → restore read ZEROS: `RestoreSnapshot`→`ResetLocalState` deleted every journal file, nothing re-seeded the V-view, `seedColdFromManifest` was `if remoteVerify`-guarded (skipped local-only), and GC/repack could physically drop the pre-overwrite records (a superseded ≤V record is dead at head, so a repack victim would drop it). Remote restore already worked (cold-seed from the manifest + remote hydrate).

## Approach: version-watermark + re-materialize
The journal is a global-LSN newest-wins log; records carry a durable, monotone `version`. A snapshot == a version watermark.

- **Pin** (`segment.go`/`store.go`/`reclaim.go`): each segment tracks `minVersion` (its lowest record version, set on first append + recovery scan + repack). A per-store `pinVersion` (DERIVED = max `JournalVersion` over live snapshots) makes `pickVictim`/`claimColdestEvictable` skip any segment with `minVersion <= pinVersion`. Whole-segment granularity, `repackSegment` unchanged. The predicate only ever makes GC MORE conservative.
- **RestoreToVersion(ctx, V)** (`store.go`): (1) ceiling replay — scan every on-disk record, rebuild each file's coverage as of V (data ≤V newest-wins, tombstones/truncates ≤V honored, >V ignored); (2) re-materialize — read the V-view bytes from their pinned source records and re-append them as fresh DIRTY records at the head (a tombstone first to bury the current head, then the V-view data; a file present at head but absent at V is tombstoned away). Fresh versions exceed everything, so `recover()` rebuilds V on reopen while the ≤V and (V,head] records stay for their snapshots' rollback. A plain rewind is NOT restart-safe and the >V records CANNOT be deleted (the pre-restore safety snapshot pins them).
- **Orchestration** (`runtime/snapshot.go`): capture `JournalVersion()` after the Step-0 drain; persist it via `MarkSnapshotReady`; raise the pin before a local-only snapshot is marked ready and recompute (lower) it after a delete commits and at share start from the durable snapshot list. Restore branches on `bs.HasRemoteStore()` — remote keeps `ResetLocalState`+`seedColdFromManifest`; local-only uses `RestoreToVersion(snap.JournalVersion)` + `DrainRollups` instead of `ResetLocalState`.
- **Passthroughs** (`engine/flush.go`): `RestoreToVersion`/`SetPinVersion`/`JournalVersion` via the existing SeedCold interface-assertion pattern (FSStore embeds `*journal.Store`, so they promote; the memory store no-ops).
- **Column** (`models/snapshot.go` + `store/snapshots.go` + `store/interface.go`): `Snapshot.JournalVersion uint64` (GORM AutoMigrate covers sqlite/postgres control-plane DBs); `MarkSnapshotReady` gains the `journalVersion` param.

## Invariants preserved
- Pin only ever makes GC more conservative (raise before ready, lower only after delete commits); reads are a single atomic load under the existing shard locks.
- Reap/refcount stays on `gc_block.go` — untouched. This change is journal repack (local byte relocation) only.
- Re-materialize is idempotent: FastCDC content-defined chunking reproduces the same hashes as the restored manifest, so the #953 reap finds no straddle and `FileAttr.Blocks` is not churned.
- Pin is applied ONLY to local-only shares — a remote share needs no pin (bytes also live remotely) and pinning would strand local disk.
- Crash-safety: existing restore-marker + `recoverInterruptedRestores` rollback path is unchanged; a mid-restore crash rolls back to the pinned, intact safety snapshot.
- No on-disk format change beyond the snapshot `JournalVersion` column; re-materialized records write `.idx` like any append.

## Tests un-skipped (all green, incl. `-race` and `-tags integration` badger)
- `TestSnapshotByteVerify_Matrix` — local-only in-memory rewind (overwrite/delete/create → restore byte-identical).
- `TestRestoreCrashRecovery_AcrossRealReopen` — re-materialize survives a real metadata-store reopen; rollback reconstructs the safety-snapshot state.
- `TestRestoreRollback_ProceedsWhenShareEnabledAtBoot`
- `TestRestoreRollback_QuiescesRollupBeforeReset`

Verification: `go build ./...` + `-tags integration`; `go test ./pkg/block/journal/... ./pkg/block/engine/... ./pkg/controlplane/{runtime,models,store}/...` (918 passed); `-race` journal+runtime (478 passed); gofmt/vet clean; golangci-lint 0 issues.