### PR TITLE
chore(block): remove dead BlockStoreKey field + legacy IsRemote dual-read

### DIFF
--- a/pkg/block/engine/audit_state_test.go
+++ b/pkg/block/engine/audit_state_test.go
@@ -73,13 +73,12 @@ func seedAuditTestStore(t *testing.T) (store *metadatamemory.MemoryMetadataStore
 			off := uint64(bi) * 4096
 			blockID := payloadID + "/" + jstr(int(off))
 			fb := &block.FileChunk{
-				ID:            blockID,
-				Hash:          h,
-				State:         block.BlockStatePending,
-				BlockStoreKey: "cas/" + h.String()[0:2] + "/" + h.String()[2:4] + "/" + h.String(),
-				DataSize:      4096,
-				LastAccess:    now,
-				CreatedAt:     now,
+				ID:         blockID,
+				Hash:       h,
+				State:      block.BlockStatePending,
+				DataSize:   4096,
+				LastAccess: now,
+				CreatedAt:  now,
 			}
 			if err := store.Put(ctx, fb); err != nil {
 				t.Fatalf("Put block %s: %v", blockID, err)
@@ -247,13 +246,12 @@ func TestAuditRefcounts_DetectsHashMismatch(t *testing.T) {
 		t.Fatal("wrongHash must be non-zero to exercise the mismatch path")
 	}
 	wrongRow := &block.FileChunk{
-		ID:            mismatchID,
-		Hash:          wrongHash,
-		State:         block.BlockStatePending,
-		BlockStoreKey: "cas/" + wrongHash.String()[0:2] + "/" + wrongHash.String()[2:4] + "/" + wrongHash.String(),
-		DataSize:      4096,
-		LastAccess:    now,
-		CreatedAt:     now,
+		ID:         mismatchID,
+		Hash:       wrongHash,
+		State:      block.BlockStatePending,
+		DataSize:   4096,
+		LastAccess: now,
+		CreatedAt:  now,
 	}
 	if err := store.Put(ctx, wrongRow); err != nil {
 		t.Fatalf("Put mismatched row %q: %v", mismatchID, err)

--- a/pkg/block/engine/gc_test.go
+++ b/pkg/block/engine/gc_test.go
@@ -60,14 +60,13 @@ func (r *gcMSReconciler) SharesForGC() []string { return append([]string(nil), r
 func putPendingBlock(t *testing.T, st metadata.Store, id string, h block.ContentHash) {
 	t.Helper()
 	if err := st.Put(t.Context(), &block.FileChunk{
-		ID:            id,
-		Hash:          h,
-		State:         block.BlockStatePending,
-		BlockStoreKey: h.String(),
-		DataSize:      64,
-		RefCount:      0,
-		LastAccess:    time.Now(),
-		CreatedAt:     time.Now(),
+		ID:         id,
+		Hash:       h,
+		State:      block.BlockStatePending,
+		DataSize:   64,
+		RefCount:   0,
+		LastAccess: time.Now(),
+		CreatedAt:  time.Now(),
 	}); err != nil {
 		t.Fatalf("PutFileChunk(%s): %v", id, err)
 	}
@@ -77,14 +76,13 @@ func putPendingBlock(t *testing.T, st metadata.Store, id string, h block.Content
 func putBlock(t *testing.T, st metadata.Store, id string, h block.ContentHash) {
 	t.Helper()
 	if err := st.Put(t.Context(), &block.FileChunk{
-		ID:            id,
-		Hash:          h,
-		State:         block.BlockStateRemote,
-		BlockStoreKey: h.String(),
-		DataSize:      64,
-		RefCount:      1,
-		LastAccess:    time.Now(),
-		CreatedAt:     time.Now(),
+		ID:         id,
+		Hash:       h,
+		State:      block.BlockStateRemote,
+		DataSize:   64,
+		RefCount:   1,
+		LastAccess: time.Now(),
+		CreatedAt:  time.Now(),
 	}); err != nil {
 		t.Fatalf("PutFileChunk(%s): %v", id, err)
 	}

--- a/pkg/block/filechunk.go
+++ b/pkg/block/filechunk.go
@@ -30,7 +30,7 @@ type FileChunkStore interface {
 	// (nil, nil) when absent. The "any" wording matters: legacy data
 	// may have multiple rows per hash; callers (the engine dedup
 	// short-circuit) treat the result as best-effort and proceed with
-	// any one row's BlockStoreKey. Renamed from FindFileChunkByHash.
+	// any one row's chunk. Renamed from FindFileChunkByHash.
 	GetByHash(ctx context.Context, hash ContentHash) (*FileChunk, error)
 
 	// Put creates or replaces a FileChunk by ID.
@@ -57,7 +57,7 @@ type FileChunkStore interface {
 	// hash-already-present-on-another-row case. GetByHash MAY
 	// return either of the colliding rows. Callers (the dedup short-
 	// circuit in engine.uploadOne) treat the lookup as best-effort —
-	// they re-PUT with the donor's BlockStoreKey regardless.
+	// they re-PUT with the donor's chunk regardless.
 	//
 	// The conformance test storetest.testPut_TwoIDsSameHash
 	// pins this contract across all three backends. Renamed from

--- a/pkg/block/filechunk.go
+++ b/pkg/block/filechunk.go
@@ -55,9 +55,9 @@ type FileChunkStore interface {
 	//
 	// The pinned contract: Put returns nil for any
 	// hash-already-present-on-another-row case. GetByHash MAY
-	// return either of the colliding rows. Callers (the dedup short-
-	// circuit in engine.uploadOne) treat the lookup as best-effort —
-	// they re-PUT with the donor's chunk regardless.
+	// return either of the colliding rows. The dedup short-circuit
+	// treats the lookup as best-effort — a miss just means the caller
+	// re-PUTs the chunk, never data loss.
 	//
 	// The conformance test storetest.testPut_TwoIDsSameHash
 	// pins this contract across all three backends. Renamed from

--- a/pkg/block/types.go
+++ b/pkg/block/types.go
@@ -66,7 +66,7 @@ func ParseContentHash(s string) (ContentHash, error) {
 //
 // - Remote (2): PUT + metadata-txn confirmed; eligible for local eviction.
 //
-// Write-after-sync resets Remote -> Pending (clears Hash + BlockStoreKey).
+// Write-after-sync resets Remote -> Pending (clears Hash).
 type BlockState uint8
 
 const (
@@ -233,9 +233,9 @@ func PruneChunkRefsToSize(refs []ChunkRef, size uint64) []ChunkRef {
 // chunks with the same hash are shared across files for dedup.
 //
 // Lifecycle
-// 1. Pending — created on write (BlockStoreKey empty).
+// 1. Pending — created on write.
 // 2. Syncing — claim batch flipped State and stamped LastSyncAttemptAt.
-// 3. Remote — PUT + metadata-txn confirmed (BlockStoreKey set).
+// 3. Remote — PUT + metadata-txn confirmed.
 type FileChunk struct {
 	// ID is a stable UUID for this chunk.
 	ID string
@@ -245,10 +245,6 @@ type FileChunk struct {
 
 	// DataSize is the actual bytes written in this chunk.
 	DataSize uint32
-
-	// BlockStoreKey is the opaque key in the remote block store (S3 key, FS path, etc.).
-	// Empty means not synced to remote.
-	BlockStoreKey string
 
 	// RefCount is the number of files referencing this chunk.
 	RefCount uint32
@@ -270,14 +266,8 @@ type FileChunk struct {
 }
 
 // IsRemote returns true if the chunk has been synced to the remote block store.
-// Dual-read fallback: legacy zero-valued rows (State==Pending) that
-// already carry a BlockStoreKey were uploaded under the legacy non-CAS path
-// and must still be treated as Remote during the dual-read window.
 func (b *FileChunk) IsRemote() bool {
-	if b.State == BlockStateRemote {
-		return true
-	}
-	return b.State == BlockStatePending && b.BlockStoreKey != ""
+	return b.State == BlockStateRemote
 }
 
 // IsFinalized returns true if the chunk's upload is complete (State==Remote).

--- a/pkg/metadata/store/memory/objects_test.go
+++ b/pkg/metadata/store/memory/objects_test.go
@@ -159,11 +159,10 @@ func TestFileChunkStore_FindByHash_Found(t *testing.T) {
 	id := uuid.New().String()
 	hash := sha256.Sum256([]byte("unique content"))
 	block := &metadata.FileChunk{
-		ID:            id,
-		Hash:          hash,
-		DataSize:      2048,
-		RefCount:      1,
-		BlockStoreKey: "s3://bucket/key",
+		ID:       id,
+		Hash:     hash,
+		DataSize: 2048,
+		RefCount: 1,
 		// IsFinalized() now means State==Remote — only
 		// Remote rows enter the hash index for dedup lookups.
 		State: metadata.BlockStateRemote,
@@ -205,12 +204,11 @@ func TestFileChunkStore_DedupFlow(t *testing.T) {
 	// only matches confirmed remote blocks per the collapse).
 	id1 := uuid.New().String()
 	block := &metadata.FileChunk{
-		ID:            id1,
-		Hash:          hash,
-		DataSize:      uint32(len(content)),
-		RefCount:      1,
-		BlockStoreKey: "s3://bucket/key",
-		State:         metadata.BlockStateRemote,
+		ID:       id1,
+		Hash:     hash,
+		DataSize: uint32(len(content)),
+		RefCount: 1,
+		State:    metadata.BlockStateRemote,
 	}
 
 	err := store.Put(ctx, block)

--- a/pkg/metadata/store/postgres/migrations/000041_drop_block_store_key.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000041_drop_block_store_key.down.sql
@@ -1,0 +1,3 @@
+-- Re-add the dropped block_store_key column (reversibility).
+-- DDL copied from 000010_file_blocks.up.sql.
+ALTER TABLE file_blocks ADD COLUMN IF NOT EXISTS block_store_key TEXT;

--- a/pkg/metadata/store/postgres/migrations/000041_drop_block_store_key.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000041_drop_block_store_key.up.sql
@@ -1,0 +1,5 @@
+-- Remove the dead FileChunk.BlockStoreKey column. No current-era code writes a
+-- non-empty value (only DB scan read-back echoed persisted values), and the
+-- legacy IsRemote() dual-read that consumed it has been simplified to
+-- State == Remote. No index references the column.
+ALTER TABLE file_blocks DROP COLUMN IF EXISTS block_store_key;

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -45,7 +45,7 @@ var _ block.FileChunkStore = (*PostgresMetadataStore)(nil)
 // FileChunkStore interface; kept as a backend
 // method for engine-internal callers.
 func (s *PostgresMetadataStore) GetFileChunk(ctx context.Context, id string) (*metadata.FileChunk, error) {
-	query := `SELECT id, hash, data_size, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks WHERE id = $1`
 	row := s.queryRow(ctx, query, id)
 
@@ -77,10 +77,6 @@ func (s *PostgresMetadataStore) Put(ctx context.Context, block *metadata.FileChu
 		h := block.Hash.String()
 		hashStr = &h
 	}
-	var blockStoreKey *string
-	if block.BlockStoreKey != "" {
-		blockStoreKey = &block.BlockStoreKey
-	}
 	// persist LastSyncAttemptAt as NULL when zero so the
 	// janitor's WHERE last_sync_attempt_at < cutoff predicate excludes
 	// never-claimed rows naturally instead of matching every Pending row.
@@ -99,17 +95,16 @@ func (s *PostgresMetadataStore) Put(ctx context.Context, block *metadata.FileChu
 	// Increment/Decrement. hash uses COALESCE so a zero-hash Put never NULLs
 	// a previously-persisted good hash.
 	query := `
-		INSERT INTO file_blocks (id, hash, data_size, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		INSERT INTO file_blocks (id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		ON CONFLICT (id) DO UPDATE SET
 			hash = COALESCE(EXCLUDED.hash, file_blocks.hash),
 			data_size = EXCLUDED.data_size,
-			block_store_key = EXCLUDED.block_store_key,
 			last_access = EXCLUDED.last_access,
 			state = EXCLUDED.state,
 			last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`
 	_, err := s.exec(ctx, query,
-		block.ID, hashStr, block.DataSize, blockStoreKey,
+		block.ID, hashStr, block.DataSize,
 		block.RefCount, block.LastAccess, block.CreatedAt, block.State, lastSyncAttemptAt)
 	if err != nil {
 		return fmt.Errorf("put file chunk: %w", err)
@@ -262,7 +257,7 @@ func (s *PostgresMetadataStore) AddRef(ctx context.Context, hash block.ContentHa
 // Pending or Syncing rows have not been confirmed on the remote and
 // are unsafe dedup targets.
 func (s *PostgresMetadataStore) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileChunk, error) {
-	query := `SELECT id, hash, data_size, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks WHERE hash = $1 AND state = 2 /* Remote */`
 	row := s.queryRow(ctx, query, hash.String())
 
@@ -281,7 +276,7 @@ func (s *PostgresMetadataStore) GetByHash(ctx context.Context, hash metadata.Con
 // Not on the narrowed FileChunkStore interface;
 // kept as a backend method for engine-internal callers.
 func (s *PostgresMetadataStore) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
-	query := `SELECT id, hash, data_size, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks
 		WHERE id LIKE $1
 		ORDER BY id ASC`
@@ -471,10 +466,9 @@ func scanFileChunk(row pgx.Row) (*metadata.FileChunk, error) {
 	var (
 		block             metadata.FileChunk
 		hashStr           sql.NullString
-		blockStoreKey     sql.NullString
 		lastSyncAttemptAt sql.NullTime
 	)
-	if err := row.Scan(&block.ID, &hashStr, &block.DataSize, &blockStoreKey,
+	if err := row.Scan(&block.ID, &hashStr, &block.DataSize,
 		&block.RefCount, &block.LastAccess, &block.CreatedAt, &block.State, &lastSyncAttemptAt); err != nil {
 		return nil, err
 	}
@@ -487,9 +481,6 @@ func scanFileChunk(row pgx.Row) (*metadata.FileChunk, error) {
 				block.ID, hashStr.String, perr)
 		}
 		block.Hash = h
-	}
-	if blockStoreKey.Valid {
-		block.BlockStoreKey = blockStoreKey.String
 	}
 	if lastSyncAttemptAt.Valid {
 		block.LastSyncAttemptAt = lastSyncAttemptAt.Time
@@ -530,7 +521,7 @@ func (tx *postgresTransaction) GetFileChunk(ctx context.Context, id string) (*me
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	query := `SELECT id, hash, data_size, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks WHERE id = $1`
 	row := tx.tx.QueryRow(ctx, query, id)
 	block, err := scanFileChunk(row)
@@ -552,10 +543,6 @@ func (tx *postgresTransaction) Put(ctx context.Context, block *metadata.FileChun
 		h := block.Hash.String()
 		hashStr = &h
 	}
-	var blockStoreKey *string
-	if block.BlockStoreKey != "" {
-		blockStoreKey = &block.BlockStoreKey
-	}
 	var lastSyncAttemptAt *time.Time
 	if !block.LastSyncAttemptAt.IsZero() {
 		t := block.LastSyncAttemptAt
@@ -565,17 +552,16 @@ func (tx *postgresTransaction) Put(ctx context.Context, block *metadata.FileChun
 	// Put). RefCount mutates only via Increment/Decrement. hash uses COALESCE
 	// so a zero-hash Put never NULLs a previously-persisted good hash.
 	query := `
-		INSERT INTO file_blocks (id, hash, data_size, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		INSERT INTO file_blocks (id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		ON CONFLICT (id) DO UPDATE SET
 			hash = COALESCE(EXCLUDED.hash, file_blocks.hash),
 			data_size = EXCLUDED.data_size,
-			block_store_key = EXCLUDED.block_store_key,
 			last_access = EXCLUDED.last_access,
 			state = EXCLUDED.state,
 			last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`
 	_, err := tx.tx.Exec(ctx, query,
-		block.ID, hashStr, block.DataSize, blockStoreKey,
+		block.ID, hashStr, block.DataSize,
 		block.RefCount, block.LastAccess, block.CreatedAt, block.State, lastSyncAttemptAt)
 	if err != nil {
 		return fmt.Errorf("put file chunk: %w", err)
@@ -672,7 +658,7 @@ func (tx *postgresTransaction) GetByHash(ctx context.Context, hash metadata.Cont
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	query := `SELECT id, hash, data_size, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks WHERE hash = $1 AND state = 2 /* Remote */`
 	row := tx.tx.QueryRow(ctx, query, hash.String())
 	block, err := scanFileChunk(row)
@@ -692,7 +678,7 @@ func (tx *postgresTransaction) GetByHash(ctx context.Context, hash metadata.Cont
 // (read-after-write violation; the SQL is otherwise identical to the
 // store-level methods).
 func (tx *postgresTransaction) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
-	query := `SELECT id, hash, data_size, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks
 		WHERE id LIKE $1
 		ORDER BY id ASC`
@@ -759,10 +745,10 @@ func (tx *postgresTransaction) EnumerateFileChunks(ctx context.Context, fn func(
 func (s *PostgresMetadataStore) InjectCorruptHashRow(ctx context.Context, blockID string, badHash string) error {
 	now := time.Now()
 	_, err := s.exec(ctx, `
-		INSERT INTO file_blocks (id, hash, data_size, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		INSERT INTO file_blocks (id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		ON CONFLICT (id) DO UPDATE SET hash = EXCLUDED.hash`,
-		blockID, badHash, uint32(64), nil, uint32(1), now, now, int(block.BlockStateRemote), nil,
+		blockID, badHash, uint32(64), uint32(1), now, now, int(block.BlockStateRemote), nil,
 	)
 	if err != nil {
 		return fmt.Errorf("inject corrupt hash row: %w", err)

--- a/pkg/metadata/store/postgres/snapshot_store.go
+++ b/pkg/metadata/store/postgres/snapshot_store.go
@@ -41,7 +41,9 @@ const (
 	// post-journal-switchover, lowering the backup table count from 17 to 15.
 	// v7 drops the dead cache_path column from file_blocks (migration 000040);
 	// file_blocks is in backupTables, so the dumped row shape changes one column.
-	postgresSchemaVersion = uint32(7)
+	// v8 drops the dead block_store_key column from file_blocks (migration 000041);
+	// file_blocks is in backupTables, so the dumped row shape changes one column.
+	postgresSchemaVersion = uint32(8)
 )
 
 // backupTables lists every metadata table in FK-safe dependency order

--- a/pkg/metadata/store/sqlite/migrations/000008_drop_block_store_key.down.sql
+++ b/pkg/metadata/store/sqlite/migrations/000008_drop_block_store_key.down.sql
@@ -1,0 +1,3 @@
+-- Re-add the dropped block_store_key column (reversibility).
+-- DDL copied from 000001_initial_schema.up.sql.
+ALTER TABLE file_blocks ADD COLUMN block_store_key TEXT;

--- a/pkg/metadata/store/sqlite/migrations/000008_drop_block_store_key.up.sql
+++ b/pkg/metadata/store/sqlite/migrations/000008_drop_block_store_key.up.sql
@@ -1,0 +1,5 @@
+-- Remove the dead FileChunk.BlockStoreKey column. No current-era code writes a
+-- non-empty value (only DB scan read-back echoed persisted values), and the
+-- legacy IsRemote() dual-read that consumed it has been simplified to
+-- State == Remote. No index references the column.
+ALTER TABLE file_blocks DROP COLUMN block_store_key;

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -44,7 +44,7 @@ var _ block.FileChunkStore = (*SQLiteMetadataStore)(nil)
 // FileChunkStore interface; kept as a backend
 // method for engine-internal callers.
 func (s *SQLiteMetadataStore) GetFileChunk(ctx context.Context, id string) (*metadata.FileChunk, error) {
-	query := `SELECT id, hash, data_size, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks WHERE id = ?1`
 	row := s.queryRow(ctx, query, id)
 
@@ -76,10 +76,6 @@ func (s *SQLiteMetadataStore) Put(ctx context.Context, block *metadata.FileChunk
 		h := block.Hash.String()
 		hashStr = &h
 	}
-	var blockStoreKey *string
-	if block.BlockStoreKey != "" {
-		blockStoreKey = &block.BlockStoreKey
-	}
 	// persist LastSyncAttemptAt as NULL when zero so the
 	// janitor's WHERE last_sync_attempt_at < cutoff predicate excludes
 	// never-claimed rows naturally instead of matching every Pending row.
@@ -98,17 +94,16 @@ func (s *SQLiteMetadataStore) Put(ctx context.Context, block *metadata.FileChunk
 	// Increment/Decrement. hash uses COALESCE so a zero-hash Put never NULLs
 	// a previously-persisted good hash.
 	query := `
-		INSERT INTO file_blocks (id, hash, data_size, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at)
-		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+		INSERT INTO file_blocks (id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at)
+		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
 		ON CONFLICT (id) DO UPDATE SET
 			hash = COALESCE(EXCLUDED.hash, file_blocks.hash),
 			data_size = EXCLUDED.data_size,
-			block_store_key = EXCLUDED.block_store_key,
 			last_access = EXCLUDED.last_access,
 			state = EXCLUDED.state,
 			last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`
 	_, err := s.exec(ctx, query,
-		block.ID, hashStr, block.DataSize, blockStoreKey,
+		block.ID, hashStr, block.DataSize,
 		block.RefCount, block.LastAccess, block.CreatedAt, block.State, lastSyncAttemptAt)
 	if err != nil {
 		return fmt.Errorf("put file chunk: %w", err)
@@ -261,7 +256,7 @@ func (s *SQLiteMetadataStore) AddRef(ctx context.Context, hash block.ContentHash
 // Pending or Syncing rows have not been confirmed on the remote and
 // are unsafe dedup targets.
 func (s *SQLiteMetadataStore) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileChunk, error) {
-	query := `SELECT id, hash, data_size, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks WHERE hash = ?1 AND state = 2 /* Remote */`
 	row := s.queryRow(ctx, query, hash.String())
 
@@ -280,7 +275,7 @@ func (s *SQLiteMetadataStore) GetByHash(ctx context.Context, hash metadata.Conte
 // Not on the narrowed FileChunkStore interface;
 // kept as a backend method for engine-internal callers.
 func (s *SQLiteMetadataStore) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
-	query := `SELECT id, hash, data_size, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks
 		WHERE id LIKE ?1
 		ORDER BY id ASC`
@@ -472,10 +467,9 @@ func scanFileChunk(row scanRow) (*metadata.FileChunk, error) {
 	var (
 		block             metadata.FileChunk
 		hashStr           sql.NullString
-		blockStoreKey     sql.NullString
 		lastSyncAttemptAt sql.NullTime
 	)
-	if err := row.Scan(&block.ID, &hashStr, &block.DataSize, &blockStoreKey,
+	if err := row.Scan(&block.ID, &hashStr, &block.DataSize,
 		&block.RefCount, &block.LastAccess, &block.CreatedAt, &block.State, &lastSyncAttemptAt); err != nil {
 		return nil, err
 	}
@@ -488,9 +482,6 @@ func scanFileChunk(row scanRow) (*metadata.FileChunk, error) {
 				block.ID, hashStr.String, perr)
 		}
 		block.Hash = h
-	}
-	if blockStoreKey.Valid {
-		block.BlockStoreKey = blockStoreKey.String
 	}
 	if lastSyncAttemptAt.Valid {
 		block.LastSyncAttemptAt = lastSyncAttemptAt.Time
@@ -531,7 +522,7 @@ func (tx *sqliteTransaction) GetFileChunk(ctx context.Context, id string) (*meta
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	query := `SELECT id, hash, data_size, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks WHERE id = ?1`
 	row := tx.tx.QueryRow(ctx, query, id)
 	block, err := scanFileChunk(row)
@@ -553,10 +544,6 @@ func (tx *sqliteTransaction) Put(ctx context.Context, block *metadata.FileChunk)
 		h := block.Hash.String()
 		hashStr = &h
 	}
-	var blockStoreKey *string
-	if block.BlockStoreKey != "" {
-		blockStoreKey = &block.BlockStoreKey
-	}
 	var lastSyncAttemptAt *time.Time
 	if !block.LastSyncAttemptAt.IsZero() {
 		t := block.LastSyncAttemptAt
@@ -566,17 +553,16 @@ func (tx *sqliteTransaction) Put(ctx context.Context, block *metadata.FileChunk)
 	// Put). RefCount mutates only via Increment/Decrement. hash uses COALESCE
 	// so a zero-hash Put never NULLs a previously-persisted good hash.
 	query := `
-		INSERT INTO file_blocks (id, hash, data_size, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at)
-		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+		INSERT INTO file_blocks (id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at)
+		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
 		ON CONFLICT (id) DO UPDATE SET
 			hash = COALESCE(EXCLUDED.hash, file_blocks.hash),
 			data_size = EXCLUDED.data_size,
-			block_store_key = EXCLUDED.block_store_key,
 			last_access = EXCLUDED.last_access,
 			state = EXCLUDED.state,
 			last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`
 	_, err := tx.tx.Exec(ctx, query,
-		block.ID, hashStr, block.DataSize, blockStoreKey,
+		block.ID, hashStr, block.DataSize,
 		block.RefCount, block.LastAccess, block.CreatedAt, block.State, lastSyncAttemptAt)
 	if err != nil {
 		return fmt.Errorf("put file chunk: %w", err)
@@ -673,7 +659,7 @@ func (tx *sqliteTransaction) GetByHash(ctx context.Context, hash metadata.Conten
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	query := `SELECT id, hash, data_size, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks WHERE hash = ?1 AND state = 2 /* Remote */`
 	row := tx.tx.QueryRow(ctx, query, hash.String())
 	block, err := scanFileChunk(row)
@@ -694,7 +680,7 @@ func (tx *sqliteTransaction) GetByHash(ctx context.Context, hash metadata.Conten
 // store-level methods).
 
 func (tx *sqliteTransaction) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
-	query := `SELECT id, hash, data_size, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at
+	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks
 		WHERE id LIKE ?1
 		ORDER BY id ASC`
@@ -761,10 +747,10 @@ func (tx *sqliteTransaction) EnumerateFileChunks(ctx context.Context, fn func(bl
 func (s *SQLiteMetadataStore) InjectCorruptHashRow(ctx context.Context, blockID string, badHash string) error {
 	now := time.Now()
 	_, err := s.exec(ctx, `
-		INSERT INTO file_blocks (id, hash, data_size, block_store_key, ref_count, last_access, created_at, state, last_sync_attempt_at)
-		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+		INSERT INTO file_blocks (id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at)
+		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
 		ON CONFLICT (id) DO UPDATE SET hash = EXCLUDED.hash`,
-		blockID, badHash, uint32(64), nil, uint32(1), now, now, int(block.BlockStateRemote), nil,
+		blockID, badHash, uint32(64), uint32(1), now, now, int(block.BlockStateRemote), nil,
 	)
 	if err != nil {
 		return fmt.Errorf("inject corrupt hash row: %w", err)

--- a/pkg/metadata/store/sqlite/snapshot_store.go
+++ b/pkg/metadata/store/sqlite/snapshot_store.go
@@ -25,7 +25,9 @@ const sqliteEngineTag = "sqlite"
 // does not change the sqlite snapshot payload and only rollup_offsets bumps this.
 // v3 drops the dead cache_path column from file_blocks (migration 000007);
 // file_blocks IS in backupTables, so the dumped row shape changes one column.
-const sqliteSchemaVersion uint32 = 3
+// v4 drops the dead block_store_key column from file_blocks (migration 000008);
+// file_blocks IS in backupTables, so the dumped row shape changes one column.
+const sqliteSchemaVersion uint32 = 4
 
 // backupTables lists every table dumped by WriteSnapshot and reloaded by RestoreSnapshot, in a
 // FK-safe order for restore (parents before children). inodes must precede

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -244,14 +244,13 @@ func testDecrementRefCountAndReap(t *testing.T, factory StoreFactory) {
 
 		hash := hashOfSeed("reap-at-zero")
 		fb := &block.FileChunk{
-			ID:            "file-reap/0",
-			Hash:          hash,
-			State:         block.BlockStateRemote,
-			BlockStoreKey: "cas/" + hash.String()[0:2] + "/" + hash.String()[2:4] + "/" + hash.String(),
-			DataSize:      4096,
-			RefCount:      1,
-			LastAccess:    time.Now(),
-			CreatedAt:     time.Now(),
+			ID:         "file-reap/0",
+			Hash:       hash,
+			State:      block.BlockStateRemote,
+			DataSize:   4096,
+			RefCount:   1,
+			LastAccess: time.Now(),
+			CreatedAt:  time.Now(),
 		}
 		if err := store.Put(ctx, fb); err != nil {
 			t.Fatalf("Put: %v", err)
@@ -288,14 +287,13 @@ func testDecrementRefCountAndReap(t *testing.T, factory StoreFactory) {
 
 		hash := hashOfSeed("reap-survives")
 		fb := &block.FileChunk{
-			ID:            "file-survive/0",
-			Hash:          hash,
-			State:         block.BlockStateRemote,
-			BlockStoreKey: "cas/" + hash.String()[0:2] + "/" + hash.String()[2:4] + "/" + hash.String(),
-			DataSize:      4096,
-			RefCount:      1,
-			LastAccess:    time.Now(),
-			CreatedAt:     time.Now(),
+			ID:         "file-survive/0",
+			Hash:       hash,
+			State:      block.BlockStateRemote,
+			DataSize:   4096,
+			RefCount:   1,
+			LastAccess: time.Now(),
+			CreatedAt:  time.Now(),
 		}
 		if err := store.Put(ctx, fb); err != nil {
 			t.Fatalf("Put: %v", err)
@@ -576,7 +574,7 @@ func testListFileChunks(t *testing.T, factory StoreFactory) {
 	blocks := []*block.FileChunk{
 		{ID: "file-A/0", State: block.BlockStatePending, DataSize: 100, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
 		{ID: "file-A/1", State: block.BlockStatePending, DataSize: 200, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
-		{ID: "file-A/2", State: block.BlockStateRemote, BlockStoreKey: "s3://a2", DataSize: 300, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
+		{ID: "file-A/2", State: block.BlockStateRemote, DataSize: 300, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
 		{ID: "file-B/0", State: block.BlockStatePending, DataSize: 400, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
 		{ID: "file-B/1", State: block.BlockStatePending, DataSize: 500, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
 	}
@@ -681,9 +679,6 @@ func testListFileChunksMixedStates(t *testing.T, factory StoreFactory) {
 			ID: fmt.Sprintf("file-mix/%d", i), State: state,
 			DataSize: uint32((i + 1) * 100),
 			RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now(),
-		}
-		if state == block.BlockStateRemote {
-			b.BlockStoreKey = "s3://mix"
 		}
 		if err := store.Put(ctx, b); err != nil {
 			t.Fatalf("Put(%s) failed: %v", b.ID, err)
@@ -908,28 +903,24 @@ func testPut_TwoIDsSameHash(t *testing.T, factory StoreFactory) {
 	ctx := t.Context()
 
 	hash := hashOfSeed("shared-content")
-	keyA := "cas/" + hash.String()[0:2] + "/" + hash.String()[2:4] + "/" + hash.String()
-	keyB := keyA // CAS keys are identical for the same hash; that's the point
 
 	a := &block.FileChunk{
-		ID:            "file-A/0",
-		Hash:          hash,
-		State:         block.BlockStateRemote,
-		BlockStoreKey: keyA,
-		DataSize:      4096,
-		RefCount:      1,
-		LastAccess:    time.Now(),
-		CreatedAt:     time.Now(),
+		ID:         "file-A/0",
+		Hash:       hash,
+		State:      block.BlockStateRemote,
+		DataSize:   4096,
+		RefCount:   1,
+		LastAccess: time.Now(),
+		CreatedAt:  time.Now(),
 	}
 	b := &block.FileChunk{
-		ID:            "file-B/0",
-		Hash:          hash, // SAME content hash, different ID
-		State:         block.BlockStateRemote,
-		BlockStoreKey: keyB,
-		DataSize:      4096,
-		RefCount:      1,
-		LastAccess:    time.Now(),
-		CreatedAt:     time.Now(),
+		ID:         "file-B/0",
+		Hash:       hash, // SAME content hash, different ID
+		State:      block.BlockStateRemote,
+		DataSize:   4096,
+		RefCount:   1,
+		LastAccess: time.Now(),
+		CreatedAt:  time.Now(),
 	}
 
 	if err := store.Put(ctx, a); err != nil {
@@ -1069,14 +1060,13 @@ func testEnumerateFileChunks_SingleFile(t *testing.T, factory StoreFactory) {
 		h := hashOfSeed(fmt.Sprintf("single-%d", i))
 		want[h] = true
 		b := &block.FileChunk{
-			ID:            fmt.Sprintf("file-single/%d", i),
-			Hash:          h,
-			State:         block.BlockStateRemote,
-			BlockStoreKey: "cas/" + h.String()[0:2] + "/" + h.String()[2:4] + "/" + h.String(),
-			DataSize:      128,
-			RefCount:      1,
-			LastAccess:    time.Now(),
-			CreatedAt:     time.Now(),
+			ID:         fmt.Sprintf("file-single/%d", i),
+			Hash:       h,
+			State:      block.BlockStateRemote,
+			DataSize:   128,
+			RefCount:   1,
+			LastAccess: time.Now(),
+			CreatedAt:  time.Now(),
 		}
 		if err := store.Put(ctx, b); err != nil {
 			t.Fatalf("Put(%s) failed: %v", b.ID, err)
@@ -1116,14 +1106,13 @@ func testEnumerateFileChunks_LargeFanout(t *testing.T, factory StoreFactory) {
 			h := hashOfSeed(fmt.Sprintf("fanout-%d-%d", f, i))
 			want[h]++
 			b := &block.FileChunk{
-				ID:            fmt.Sprintf("file-fan-%d/%d", f, i),
-				Hash:          h,
-				State:         block.BlockStateRemote,
-				BlockStoreKey: "cas/" + h.String()[0:2] + "/" + h.String()[2:4] + "/" + h.String(),
-				DataSize:      64,
-				RefCount:      1,
-				LastAccess:    time.Now(),
-				CreatedAt:     time.Now(),
+				ID:         fmt.Sprintf("file-fan-%d/%d", f, i),
+				Hash:       h,
+				State:      block.BlockStateRemote,
+				DataSize:   64,
+				RefCount:   1,
+				LastAccess: time.Now(),
+				CreatedAt:  time.Now(),
 			}
 			if err := store.Put(ctx, b); err != nil {
 				t.Fatalf("Put(%s) failed: %v", b.ID, err)
@@ -1273,14 +1262,13 @@ func testEnumerateFileChunks_ZeroHashEmitted(t *testing.T, factory StoreFactory)
 		t.Fatalf("Put(zero) failed: %v", err)
 	}
 	finalized := &block.FileChunk{
-		ID:            "file-zero/1",
-		Hash:          hashOfSeed("non-zero"),
-		State:         block.BlockStateRemote,
-		BlockStoreKey: "cas/12/34/" + hashOfSeed("non-zero").String(),
-		DataSize:      64,
-		RefCount:      1,
-		LastAccess:    time.Now(),
-		CreatedAt:     time.Now(),
+		ID:         "file-zero/1",
+		Hash:       hashOfSeed("non-zero"),
+		State:      block.BlockStateRemote,
+		DataSize:   64,
+		RefCount:   1,
+		LastAccess: time.Now(),
+		CreatedAt:  time.Now(),
 	}
 	if err := store.Put(ctx, finalized); err != nil {
 		t.Fatalf("Put(finalized) failed: %v", err)
@@ -1334,14 +1322,13 @@ func testEnumerateFileChunks_CorruptHashFailsClosed(t *testing.T, factory StoreF
 	// Seed one well-formed Remote block so enumeration has something to walk
 	// past before reaching the corrupt row.
 	good := &block.FileChunk{
-		ID:            "file-corrupt/0",
-		Hash:          hashOfSeed("good"),
-		State:         block.BlockStateRemote,
-		BlockStoreKey: "cas/aa/bb/" + hashOfSeed("good").String(),
-		DataSize:      64,
-		RefCount:      1,
-		LastAccess:    time.Now(),
-		CreatedAt:     time.Now(),
+		ID:         "file-corrupt/0",
+		Hash:       hashOfSeed("good"),
+		State:      block.BlockStateRemote,
+		DataSize:   64,
+		RefCount:   1,
+		LastAccess: time.Now(),
+		CreatedAt:  time.Now(),
 	}
 	if err := store.Put(ctx, good); err != nil {
 		t.Fatalf("Put(good) failed: %v", err)
@@ -1464,14 +1451,13 @@ func testTx_ListReadAfterWrite(t *testing.T, factory StoreFactory) {
 		}
 
 		fb := &block.FileChunk{
-			ID:            payloadID + "/0",
-			Hash:          hash,
-			State:         block.BlockStateRemote,
-			BlockStoreKey: "cas/a1/b2/" + hash.String(),
-			DataSize:      4096,
-			RefCount:      1,
-			LastAccess:    time.Now(),
-			CreatedAt:     time.Now(),
+			ID:         payloadID + "/0",
+			Hash:       hash,
+			State:      block.BlockStateRemote,
+			DataSize:   4096,
+			RefCount:   1,
+			LastAccess: time.Now(),
+			CreatedAt:  time.Now(),
 		}
 		if putErr := tx.Put(ctx, fb); putErr != nil {
 			return fmt.Errorf("tx.Put: %w", putErr)
@@ -1536,16 +1522,14 @@ func testAddRef_ExistingHash_BumpsRefCount(t *testing.T, factory StoreFactory) {
 	ctx := t.Context()
 
 	hash := hashOfSeed("addref-existing-hash")
-	casKey := "cas/" + hash.String()[0:2] + "/" + hash.String()[2:4] + "/" + hash.String()
 	seed := &block.FileChunk{
-		ID:            "file-addref/0",
-		Hash:          hash,
-		State:         block.BlockStateRemote,
-		BlockStoreKey: casKey,
-		DataSize:      4096,
-		RefCount:      1,
-		LastAccess:    time.Now(),
-		CreatedAt:     time.Now(),
+		ID:         "file-addref/0",
+		Hash:       hash,
+		State:      block.BlockStateRemote,
+		DataSize:   4096,
+		RefCount:   1,
+		LastAccess: time.Now(),
+		CreatedAt:  time.Now(),
 	}
 	if err := store.Put(ctx, seed); err != nil {
 		t.Fatalf("seed Put: %v", err)
@@ -1619,16 +1603,14 @@ func testAddRef_Concurrent_With_DecrementRefCountCascade(t *testing.T, factory S
 	ctx := t.Context()
 
 	hash := hashOfSeed("addref-concurrent-cascade")
-	casKey := "cas/" + hash.String()[0:2] + "/" + hash.String()[2:4] + "/" + hash.String()
 	seed := &block.FileChunk{
-		ID:            "file-addref-conc/0",
-		Hash:          hash,
-		State:         block.BlockStateRemote,
-		BlockStoreKey: casKey,
-		DataSize:      4096,
-		RefCount:      10,
-		LastAccess:    time.Now(),
-		CreatedAt:     time.Now(),
+		ID:         "file-addref-conc/0",
+		Hash:       hash,
+		State:      block.BlockStateRemote,
+		DataSize:   4096,
+		RefCount:   10,
+		LastAccess: time.Now(),
+		CreatedAt:  time.Now(),
 	}
 	if err := store.Put(ctx, seed); err != nil {
 		t.Fatalf("seed Put: %v", err)

--- a/pkg/metadata/storetest/inv02_durable_regression_test.go
+++ b/pkg/metadata/storetest/inv02_durable_regression_test.go
@@ -40,14 +40,13 @@ func TestReconcileINV02_DuplicateHashRowsVisible(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		blockID := payloadID + "/" + string(rune('0'+i))
 		fb := &block.FileChunk{
-			ID:            blockID,
-			Hash:          sharedHash,
-			State:         block.BlockStateRemote,
-			BlockStoreKey: "cas/shared/" + sharedHash.String(),
-			DataSize:      4096,
-			RefCount:      3,
-			LastAccess:    now,
-			CreatedAt:     now,
+			ID:         blockID,
+			Hash:       sharedHash,
+			State:      block.BlockStateRemote,
+			DataSize:   4096,
+			RefCount:   3,
+			LastAccess: now,
+			CreatedAt:  now,
 		}
 		if err := store.Put(ctx, fb); err != nil {
 			t.Fatalf("Put(%s): %v", blockID, err)

--- a/pkg/metadata/storetest/inv02_fuzz.go
+++ b/pkg/metadata/storetest/inv02_fuzz.go
@@ -273,14 +273,13 @@ func fuzzCreateFile(ctx context.Context, store metadata.Store, shareName string,
 		h := hashOfSeed(hashSeed)
 		blockID := fmt.Sprintf("%s/%d", payloadID, i)
 		fb := &block.FileChunk{
-			ID:            blockID,
-			Hash:          h,
-			State:         block.BlockStateRemote,
-			BlockStoreKey: "cas/" + h.String()[0:2] + "/" + h.String()[2:4] + "/" + h.String(),
-			DataSize:      4096,
-			RefCount:      1,
-			LastAccess:    now,
-			CreatedAt:     now,
+			ID:         blockID,
+			Hash:       h,
+			State:      block.BlockStateRemote,
+			DataSize:   4096,
+			RefCount:   1,
+			LastAccess: now,
+			CreatedAt:  now,
 		}
 		if err := store.Put(ctx, fb); err != nil {
 			return fmt.Errorf("put block %s: %w", blockID, err)


### PR DESCRIPTION
## What

Removes the dead `FileChunk.BlockStoreKey` field + `block_store_key` column, and simplifies `IsRemote()` to `State == BlockStateRemote` (now identical to `IsFinalized()`).

## Why this is safe

`IsRemote()` was `State==Remote || (State==Pending && BlockStoreKey != "")` — a legacy dual-read. Findings:

- **Only 3 production callers** of `IsRemote()`, all the by-hash dedup-donor lookup (`memory/objects.go:493`, `badger/objects.go:390`, `badger/objects.go:1141`).
- **pg/sqlite `GetByHash` already filter `WHERE state=2` in SQL** and never call `IsRemote()`, so they already ignored the Pending clause.
- **Eviction / GC never use `IsRemote()`.**
- **No current-era code assigns a non-empty `BlockStoreKey`** — grep confirms every writer was test scaffolding; production only echoed persisted values back on DB scan.
- **Documented legacy rows are zero-Hash** → unreachable by `GetByHash` (keyed on real BLAKE3).

**Accepted risk (bounded, non-corrupting):** a hypothetical intermediate-era badger row (`state=Pending` + non-empty key + non-zero Hash) becomes a dedup MISS → ONE redundant re-upload (a self-consistent CAS write). Not corruption, not an eviction change. Given no prod users + delete-eagerly, we accept it. No promote-migration: SQL already ignores the clause, badger has no SQL migration path, and the blast radius is non-corrupting.

## Changes

- `pkg/block/types.go` — drop `BlockStoreKey` field, simplify `IsRemote()`, update lifecycle doc comments.
- `pkg/block/filechunk.go` — comment-only updates.
- pg/sqlite `objects.go` — drop `block_store_key` from SELECT lists, INSERT column list + VALUES (placeholders renumbered $9->$8 / ?9->?8), ON CONFLICT, scan target, and nullable guard.
- **Migrations:** pg `000041_drop_block_store_key`, sqlite `000008_drop_block_store_key` (up drops, down re-adds; no index references the column).
- **Snapshot schema-version bumps** (file_blocks is a backup table): pg `postgresSchemaVersion` 7->8, sqlite `sqliteSchemaVersion` 3->4.
- Tests — removed `BlockStoreKey` scaffolding fields; kept all `State` / `IsRemote` / `LastSyncAttemptAt` assertions.

`badger`/`memory` need no store change: JSON round-trip auto-drops the removed Go field, and old blobs carrying `"BlockStoreKey"` are ignored on unmarshal.

## Verification

- `go build ./...` and `go build -tags integration ./...` green.
- `go test ./pkg/block/... ./pkg/metadata/...` — 3492 passed, 27 packages (sqlite migration applies via conformance suite).
- `gofmt -s -w .`, `go vet ./...`, `golangci-lint run` — 0 issues.
- Placeholder alignment re-verified: both stores now 8 columns -> 8 placeholders -> 8 args in every INSERT.