### PR TITLE
feat(metadata): flush→relaxed — move metadata fsync off the NFS/SMB write+commit ack path (#1687)

### DIFF
--- a/internal/adapter/nfs/v3/handlers/commit.go
+++ b/internal/adapter/nfs/v3/handlers/commit.go
@@ -211,7 +211,10 @@ func (h *Handler) Commit(
 	authCtx, authErr := h.GetCachedAuthContext(ctx)
 	if authErr == nil {
 		// Flush pending metadata for this specific file
-		flushed, metaErr := metaSvc.FlushPendingWriteForFile(authCtx, handle)
+		// Relaxed metadata commit (#1687): COMMIT already forced the block data
+		// durable above; the size/mtime fsync is deferred to the background syncer,
+		// with the journal size reconcile on restart as the crash-safety net.
+		flushed, metaErr := metaSvc.FlushPendingWriteForFile(authCtx, handle, false)
 		if metaErr != nil {
 			logger.WarnCtx(ctx.Context, "COMMIT: metadata flush failed", "handle", fmt.Sprintf("0x%x", req.Handle), "error", metaErr)
 			// Continue - content is flushed, metadata will be fixed eventually

--- a/internal/adapter/nfs/v3/handlers/write.go
+++ b/internal/adapter/nfs/v3/handlers/write.go
@@ -350,7 +350,10 @@ func (h *Handler) flushStableWrite(
 	if err := common.CommitBlockStore(ctx.Context, blockStore, payloadID); err != nil {
 		return err
 	}
-	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, handle); err != nil {
+	// FILE_SYNC (stable>=2) promised durable metadata → strict inline fsync.
+	// DATA_SYNC/UNSTABLE defer it via the relaxed path (#1687); a later COMMIT or
+	// the journal size reconcile on restart makes the size durable.
+	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, handle, stable >= FileSyncWrite); err != nil {
 		if stable >= FileSyncWrite {
 			// FILE_SYNC requires durable metadata; surface the failure.
 			return err

--- a/internal/adapter/nfs/v4/handlers/close.go
+++ b/internal/adapter/nfs/v4/handlers/close.go
@@ -104,7 +104,9 @@ func (h *Handler) handleClose(ctx *types.CompoundContext, reader io.Reader) *typ
 			"error", metaErr, "client", ctx.ClientAddr)
 	} else {
 		fileHandle := metadata.FileHandle(ctx.CurrentFH)
-		flushed, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, fileHandle)
+		// Relaxed metadata commit (#1687): NFSv4 CLOSE is not an fsync boundary
+		// (clients use COMMIT for durability); defer the metadata fsync.
+		flushed, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, fileHandle, false)
 		if flushErr != nil {
 			logger.Warn("NFSv4 CLOSE metadata flush failed",
 				"error", flushErr, "client", ctx.ClientAddr)

--- a/internal/adapter/nfs/v4/handlers/commit.go
+++ b/internal/adapter/nfs/v4/handlers/commit.go
@@ -138,7 +138,9 @@ func (h *Handler) handleCommit(ctx *types.CompoundContext, reader io.Reader) *ty
 	// Flush pending metadata writes (deferred commit optimization)
 	// This is critical - without this, file size and other metadata changes
 	// are not persisted to the store, causing data loss on server restart.
-	flushed, metaErr := metaSvc.FlushPendingWriteForFile(authCtx, fileHandle)
+	// Relaxed metadata commit (#1687): the size/mtime fsync is deferred; restart
+	// reconciliation against the journal high-water mark prevents truncation.
+	flushed, metaErr := metaSvc.FlushPendingWriteForFile(authCtx, fileHandle, false)
 	if metaErr != nil {
 		logger.Error("NFSv4 COMMIT metadata flush failed",
 			"error", metaErr,

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -243,7 +243,11 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 			logger.Warn("CLOSE: failed to build auth context for metadata flush", "path", openFile.Path, "error", authErr)
 		} else {
 			metaSvc := h.Registry.GetMetadataService()
-			flushed, metaErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle)
+			// STRICT (durable=true): CLOSE is a durability point (MS-SMB2 3.3.5.10,
+			// #1267). The client treats a successful CLOSE as a guarantee its
+			// metadata reached stable storage, so the fsync must stay inline — this
+			// is deliberately NOT relaxed by #1687.
+			flushed, metaErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle, true)
 			if metaErr != nil {
 				logger.Warn("CLOSE: metadata flush failed", "path", openFile.Path, "error", metaErr)
 				// Surface the metadata-flush failure too (#1267): if the

--- a/internal/adapter/smb/handlers/close_mfsymlink_test.go
+++ b/internal/adapter/smb/handlers/close_mfsymlink_test.go
@@ -125,7 +125,7 @@ func setupMFsymlinkShare(t *testing.T, allowMFsymlink bool, target string) (*Han
 	if _, err := metaSvc.CommitWrite(authCtx, writeOp); err != nil {
 		t.Fatalf("CommitWrite: %v", err)
 	}
-	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, fileHandle); err != nil {
+	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, fileHandle, true); err != nil {
 		t.Fatalf("Flush: %v", err)
 	}
 

--- a/internal/adapter/smb/handlers/flush.go
+++ b/internal/adapter/smb/handlers/flush.go
@@ -264,7 +264,9 @@ func (h *Handler) Flush(ctx *SMBHandlerContext, req *FlushRequest) (*FlushRespon
 	if authErr != nil {
 		logger.Warn("FLUSH: failed to build auth context for metadata flush", "path", openFile.Path, "error", authErr)
 	} else {
-		flushed, metaErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle)
+		// STRICT (durable=true): SMB FLUSH is an explicit client fsync request, so
+		// the metadata commit must fsync inline — deliberately NOT relaxed (#1687).
+		flushed, metaErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle, true)
 		if metaErr != nil {
 			logger.Warn("FLUSH: metadata flush failed", "path", openFile.Path, "error", metaErr)
 			// Continue - content is flushed, metadata will be fixed eventually

--- a/internal/adapter/smb/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk.go
@@ -435,7 +435,9 @@ func (h *Handler) executeCopyChunks(
 		if chunksWritten == 0 {
 			return
 		}
-		if _, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, dstOpen.MetadataHandle); flushErr != nil {
+		// Relaxed (#1687): cross-session visibility comes from the metadata write,
+		// durability from the journal reconcile on restart; CLOSE/FLUSH stay strict.
+		if _, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, dstOpen.MetadataHandle, false); flushErr != nil {
 			logger.Debug("COPYCHUNK: deferred metadata flush failed (non-fatal)",
 				"dstPath", dstOpen.Path, "error", flushErr)
 		}

--- a/internal/adapter/smb/handlers/ioctl_copychunk_sparse_integration_test.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk_sparse_integration_test.go
@@ -116,7 +116,7 @@ func TestCopyChunk_SparseDest_LeadingGapReadsZeros(t *testing.T) {
 	if _, err := metaSvc.CommitWrite(authCtx, srcWriteOp); err != nil {
 		t.Fatalf("CommitWrite src: %v", err)
 	}
-	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, srcHandle); err != nil {
+	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, srcHandle, true); err != nil {
 		t.Fatalf("Flush src: %v", err)
 	}
 
@@ -337,7 +337,7 @@ func TestCopyChunk_SparseDest_SurvivesPriorPayloadReuse(t *testing.T) {
 	if _, err := metaSvc.CommitWrite(authCtx, srcWriteOp); err != nil {
 		t.Fatalf("CommitWrite src: %v", err)
 	}
-	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, srcHandle); err != nil {
+	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, srcHandle, true); err != nil {
 		t.Fatalf("Flush src: %v", err)
 	}
 
@@ -558,7 +558,7 @@ func TestPurgeBlockStorePayload_PreservesHardLinkedContent(t *testing.T) {
 	if _, err := metaSvc.CommitWrite(authCtx, wop); err != nil {
 		t.Fatalf("CommitWrite: %v", err)
 	}
-	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, handle); err != nil {
+	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, handle, true); err != nil {
 		t.Fatalf("Flush: %v", err)
 	}
 	if _, err := metaSvc.CreateHardLink(authCtx, rootHandle, "b", handle); err != nil {

--- a/internal/adapter/smb/handlers/ioctl_sparse.go
+++ b/internal/adapter/smb/handlers/ioctl_sparse.go
@@ -478,7 +478,9 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 	// SMB requires immediate cross-session metadata visibility (unlike NFS
 	// which uses explicit COMMIT). Flush deferred metadata so a subsequent
 	// QUERY_INFO sees the new size/timestamps without waiting for CLOSE.
-	if _, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle); flushErr != nil {
+	// Relaxed (#1687): visibility from the metadata write, durability from the
+	// journal size reconcile on restart; CLOSE/FLUSH remain strict.
+	if _, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle, false); flushErr != nil {
 		logger.Debug("IOCTL FSCTL_SET_ZERO_DATA: deferred metadata flush failed (non-fatal)",
 			"path", openFile.Path, "error", flushErr)
 	}

--- a/internal/adapter/smb/handlers/timestamps_delayed_test.go
+++ b/internal/adapter/smb/handlers/timestamps_delayed_test.go
@@ -35,7 +35,7 @@ func TestSmbDelayedWrite_VisibleMtimeUntilWindowExpires(t *testing.T) {
 	if _, err := metaSvc.CommitWrite(authCtx, op); err != nil {
 		t.Fatalf("CommitWrite: %v", err)
 	}
-	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, fh); err != nil {
+	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, fh, true); err != nil {
 		t.Fatalf("Flush: %v", err)
 	}
 	armSmbDelayedWrite(openFile, preWriteMtime, op.NewMtime)
@@ -64,14 +64,14 @@ func TestSmbDelayedWrite_SecondWriteDoesNotAdvanceVisibleMtime(t *testing.T) {
 
 	op1, _ := metaSvc.PrepareWrite(authCtx, fh, 1)
 	_, _ = metaSvc.CommitWrite(authCtx, op1)
-	_, _ = metaSvc.FlushPendingWriteForFile(authCtx, fh)
+	_, _ = metaSvc.FlushPendingWriteForFile(authCtx, fh, true)
 	armSmbDelayedWrite(openFile, pre, op1.NewMtime)
 	openFile.SmbWriteFlushAt = time.Now().Add(-time.Second) // simulate post-window
 
 	time.Sleep(20 * time.Millisecond)
 	op2, _ := metaSvc.PrepareWrite(authCtx, fh, 1)
 	_, _ = metaSvc.CommitWrite(authCtx, op2)
-	_, _ = metaSvc.FlushPendingWriteForFile(authCtx, fh)
+	_, _ = metaSvc.FlushPendingWriteForFile(authCtx, fh, true)
 	armSmbDelayedWrite(openFile, mustGet(t, h, fh, authCtx).Mtime, op2.NewMtime)
 
 	file := mustGet(t, h, fh, authCtx)
@@ -89,7 +89,7 @@ func TestSmbDelayedWrite_FlushCollapsesWindow(t *testing.T) {
 	pre := mustGet(t, h, fh, authCtx).Mtime
 	op, _ := metaSvc.PrepareWrite(authCtx, fh, 1)
 	_, _ = metaSvc.CommitWrite(authCtx, op)
-	_, _ = metaSvc.FlushPendingWriteForFile(authCtx, fh)
+	_, _ = metaSvc.FlushPendingWriteForFile(authCtx, fh, true)
 	armSmbDelayedWrite(openFile, pre, op.NewMtime)
 
 	// Without flush, override returns pre.
@@ -115,7 +115,7 @@ func TestSmbDelayedWrite_StickyWinsOverDelayedWindow(t *testing.T) {
 	pre := mustGet(t, h, fh, authCtx).Mtime
 	op, _ := metaSvc.PrepareWrite(authCtx, fh, 1)
 	_, _ = metaSvc.CommitWrite(authCtx, op)
-	_, _ = metaSvc.FlushPendingWriteForFile(authCtx, fh)
+	_, _ = metaSvc.FlushPendingWriteForFile(authCtx, fh, true)
 	armSmbDelayedWrite(openFile, pre, op.NewMtime)
 
 	future := time.Now().Add(24 * time.Hour).UTC()

--- a/internal/adapter/smb/handlers/timestamps_test.go
+++ b/internal/adapter/smb/handlers/timestamps_test.go
@@ -213,7 +213,7 @@ func TestDelayedWrite_TwoWritesProduceDistinctTimestamps(t *testing.T) {
 	if _, err := metaSvc.CommitWrite(authCtx, op1); err != nil {
 		t.Fatalf("CommitWrite #1: %v", err)
 	}
-	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, fileHandle); err != nil {
+	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, fileHandle, true); err != nil {
 		t.Fatalf("FlushPendingWriteForFile #1: %v", err)
 	}
 
@@ -236,7 +236,7 @@ func TestDelayedWrite_TwoWritesProduceDistinctTimestamps(t *testing.T) {
 	if _, err := metaSvc.CommitWrite(authCtx, op2); err != nil {
 		t.Fatalf("CommitWrite #2: %v", err)
 	}
-	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, fileHandle); err != nil {
+	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, fileHandle, true); err != nil {
 		t.Fatalf("FlushPendingWriteForFile #2: %v", err)
 	}
 
@@ -277,7 +277,7 @@ func TestDelayedWrite_VsFlush(t *testing.T) {
 	if _, err := metaSvc.CommitWrite(authCtx, op); err != nil {
 		t.Fatalf("CommitWrite: %v", err)
 	}
-	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, fileHandle); err != nil {
+	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, fileHandle, true); err != nil {
 		t.Fatalf("first flush: %v", err)
 	}
 
@@ -288,7 +288,7 @@ func TestDelayedWrite_VsFlush(t *testing.T) {
 	writeTime := file1.Mtime
 
 	// FLUSH equivalent — re-flush an empty pending state.
-	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, fileHandle); err != nil {
+	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, fileHandle, true); err != nil {
 		t.Fatalf("second flush: %v", err)
 	}
 
@@ -337,7 +337,7 @@ func TestDelayedWrite_VsSetEOF(t *testing.T) {
 	if _, err := metaSvc.CommitWrite(authCtx, op); err != nil {
 		t.Fatalf("CommitWrite: %v", err)
 	}
-	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, fileHandle); err != nil {
+	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, fileHandle, true); err != nil {
 		t.Fatalf("Flush: %v", err)
 	}
 	preWrite2, err := metaSvc.GetFile(authCtx.Context, fileHandle)

--- a/internal/adapter/smb/handlers/write.go
+++ b/internal/adapter/smb/handlers/write.go
@@ -442,7 +442,11 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// SMB requires immediate metadata visibility across sessions (unlike NFS
 	// which has explicit COMMIT). Flush deferred metadata so that other sessions
 	// reading the same file see updated size/timestamps without a FLUSH command.
-	if _, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle); flushErr != nil {
+	// Relaxed (#1687): visibility comes from the metadata write itself (applied
+	// in-txn), NOT from the fsync — so we can defer the metadata db.Sync off the
+	// per-WRITE ack path. CLOSE and FLUSH remain strict for durability; a crash
+	// before the background fsync is caught by the journal size reconcile.
+	if _, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle, false); flushErr != nil {
 		logger.Debug("WRITE: deferred metadata flush failed (non-fatal)", "path", openFile.Path, "error", flushErr)
 	}
 

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -443,6 +443,11 @@ func (bs *Store) SetMetrics(rec local.MetricsRecorder) {
 // Do not use in production code.
 func (bs *Store) LocalForTest() local.LocalStore { return bs.local }
 
+// Local returns the engine's underlying local store (the journal-backed tier),
+// or nil if the store has no local tier. Used by share startup to reconcile
+// metadata file sizes against the journal's durable high-water mark (#1687).
+func (bs *Store) Local() local.LocalStore { return bs.local }
+
 // LocalStore returns nil: the journal-backed local tier is a per-file byte
 // cache, not a content-addressed block.Store, so there is no hash-namespace to
 // sweep. The journal self-manages local segment reclaim (dead-byte GC +

--- a/pkg/controlplane/runtime/flush_relaxed_crash_test.go
+++ b/pkg/controlplane/runtime/flush_relaxed_crash_test.go
@@ -1,0 +1,90 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/common"
+)
+
+// TestFlushRelaxed_CrashBeforeMetadataFsync_SizeReconciled is THE merge gate for
+// #1687 (flush->relaxed). It proves the reconciliation safety net (piece 2) makes
+// the relaxed metadata-size commit (piece 1) crash-safe: ACK'd bytes are never
+// truncated even if the deferred metadata fsync never ran.
+//
+// Modelled scenario: a client WRITE was ACK'd via the relaxed path — the byte
+// data was fsync'd into the local journal (WriteToBlockStore + CommitBlockStore),
+// but the deferred metadata size commit had NOT yet reached stable storage when
+// the process crashed. So metadata.Size is still the pre-write value (0) while the
+// journal holds N durable bytes. We deliberately do NOT call
+// FlushPendingWriteForFile and do NOT roll up (data stays in the synced append-log
+// segments that recover() rebuilds), so the metadata store is untouched.
+//
+// After simulateRestart (real close+reopen of the metadata store, and a fresh
+// AddShare that runs reconcileMetadataSizeFromJournal before the share is visible)
+// the file's metadata.Size must equal N and the N bytes must read back intact.
+//
+// Gate property: without piece 2 (reconciliation), metadata.Size stays 0 after the
+// restart and the Size assertion below fails — i.e. this test genuinely fails on
+// piece-1-without-piece-2, which is what makes it a real safety proof rather than a
+// hollow green.
+func TestFlushRelaxed_CrashBeforeMetadataFsync_SizeReconciled(t *testing.T) {
+	const n = 256 * 1024 // multi-interval, small enough for the postgres row
+	for _, bk := range byteVerifyBackends(t) {
+		bk := bk
+		t.Run(bk.name, func(t *testing.T) {
+			if bk.skip != "" {
+				t.Skip(bk.skip)
+			}
+			if bk.reopen == nil {
+				t.Skipf("%s cannot survive a restart (no durable reopen)", bk.name)
+			}
+
+			meta, metaType := bk.open(t)
+			fx := newByteVerifyFixture(t, meta, metaType)
+			defer fx.close()
+
+			ctx := context.Background()
+			data := distinctBytes(n, 0x5A)
+
+			// (1) Create the file (metadata Size == 0, durable).
+			pid := fx.createEmptyFile(ctx, "acked.bin")
+
+			// (2) Make the bytes journal-durable WITHOUT touching metadata:
+			// WriteToBlockStore -> CommitBlockStore fsyncs the append-log segment.
+			// No DrainRollups and no FlushPendingWriteForFile: this is exactly the
+			// state after a relaxed WRITE ack whose metadata fsync never ran.
+			if err := common.WriteToBlockStore(ctx, fx.bs, pid, data, 0); err != nil {
+				t.Fatalf("WriteToBlockStore: %v", err)
+			}
+			if err := common.CommitBlockStore(ctx, fx.bs, pid); err != nil {
+				t.Fatalf("CommitBlockStore: %v", err)
+			}
+
+			// (3) Precondition: the crash-window state we are modelling.
+			// metadata.Size is stale (0) while the journal holds N durable bytes.
+			if got := fx.getFile(ctx, "acked.bin").Size; got != 0 {
+				t.Fatalf("precondition: metadata.Size = %d, want 0 (test must model a stale size)", got)
+			}
+			if js, ok := fx.bs.Local().FileSize(ctx, string(pid)); !ok || js != int64(n) {
+				t.Fatalf("precondition: journal FileSize = (%d, %v), want (%d, true) — data not journal-durable", js, ok, n)
+			}
+
+			// (4) Real restart: close+reopen metadata, fresh AddShare runs the
+			// reconciliation hook before the share is visible to any handler.
+			fx.simulateRestart(bk.reopen)
+
+			// (5) The gate: metadata.Size was grown to the journal high-water mark.
+			if got := fx.getFile(ctx, "acked.bin").Size; got != uint64(n) {
+				t.Fatalf("ACK'd data truncated: metadata.Size = %d after restart, want %d "+
+					"(reconcileMetadataSizeFromJournal did not run / did not grow the size)", got, n)
+			}
+
+			// (6) And the ACK'd bytes read back byte-identical.
+			if got := fx.readFile(ctx, pid, n); !bytes.Equal(got, data) {
+				t.Fatalf("ACK'd bytes not intact after restart: %s", firstDiff(data, got))
+			}
+		})
+	}
+}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -678,6 +678,20 @@ func (s *Service) AddShare(
 		}
 	}
 
+	// Phase 2.5: Reconcile metadata file sizes against the local journal's durable
+	// high-water mark (#1687 safety net). WRITE/COMMIT now commit file size via a
+	// relaxed (deferred-fsync) metadata transaction, so a crash between a relaxed
+	// size commit and its background fsync can leave metadata.Size smaller than the
+	// data actually made durable in the journal. This grows metadata.Size up to the
+	// journal size (max-only, never shrinks) BEFORE the share is registered and any
+	// protocol handler can read it, so ACK'd bytes are never truncated.
+	if config.LocalBlockStoreID != "" && share.BlockStore != nil {
+		if err := reconcileMetadataSizeFromJournal(ctx, metadataStore, share.BlockStore); err != nil {
+			cleanupShare()
+			return fmt.Errorf("failed to reconcile metadata sizes for share %q: %w", config.Name, err)
+		}
+	}
+
 	// Phase 3: Register metadata store. Safe to call unconditionally now: the
 	// Phase-0 reservation guarantees no other AddShare for this name is in
 	// flight, so this RegisterStoreForShare cannot be raced into a
@@ -714,6 +728,59 @@ func (s *Service) AddShare(
 
 	s.notifyShareChange()
 
+	return nil
+}
+
+// reconcileMetadataSizeFromJournal grows each file's metadata size up to the
+// local journal's durable high-water mark (#1687 crash-safety net). It is the
+// load-bearing counterpart to the relaxed (deferred-fsync) size commits done on
+// WRITE/COMMIT: if the server crashed after the data was fsync'd into the journal
+// but before the relaxed metadata size fsync ran, metadata.Size is stale/smaller
+// than the durable data. Reading that file would truncate ACK'd bytes (#588
+// class). This runs on share start, before the share is visible to handlers, and
+// only ever GROWS the size — a legitimate shrink (SetAttr/truncate) commits
+// strictly and is never rolled back here.
+//
+// bs.Local.ListFiles/FileSize are served from the journal's in-memory index
+// (populated by recover() at open), so the common no-mismatch case is cheap: a
+// point read of metadata per file, and a strict PutFile only on an actual gap.
+func reconcileMetadataSizeFromJournal(ctx context.Context, metadataStore metadata.Store, bs *engine.Store) error {
+	if bs == nil {
+		return nil
+	}
+	localStore := bs.Local()
+	if localStore == nil {
+		return nil
+	}
+	for _, id := range localStore.ListFiles(ctx) {
+		journalSize, ok := localStore.FileSize(ctx, id)
+		if !ok {
+			continue
+		}
+		f, err := metadataStore.GetFileByPayloadID(ctx, metadata.PayloadID(id))
+		if err != nil {
+			// Orphan journal entry (no metadata file) — nothing to reconcile.
+			continue
+		}
+		if int64(f.Size) >= journalSize {
+			continue
+		}
+		// Grow to the journal high-water mark under a STRICT transaction; re-read
+		// inside the txn so a concurrent legitimate update can't be clobbered.
+		if err := metadataStore.WithTransaction(ctx, func(tx metadata.Transaction) error {
+			cur, err := tx.GetFileByPayloadID(ctx, metadata.PayloadID(id))
+			if err != nil {
+				return err
+			}
+			if int64(cur.Size) >= journalSize {
+				return nil // another writer already caught up; never shrink
+			}
+			cur.Size = uint64(journalSize)
+			return tx.PutFile(ctx, cur)
+		}); err != nil {
+			return fmt.Errorf("reconcile size for payload %s: %w", id, err)
+		}
+	}
 	return nil
 }
 

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -759,10 +759,20 @@ func reconcileMetadataSizeFromJournal(ctx context.Context, metadataStore metadat
 		}
 		f, err := metadataStore.GetFileByPayloadID(ctx, metadata.PayloadID(id))
 		if err != nil {
-			// Orphan journal entry (no metadata file) — nothing to reconcile.
+			if metadata.IsNotFoundError(err) {
+				// Orphan journal entry (no metadata file) — nothing to reconcile.
+				continue
+			}
+			// A real store error (I/O, corruption) must not be silently swallowed —
+			// skipping would leave metadata.Size stale and truncate reads.
+			return fmt.Errorf("reconcile size: lookup payload %s: %w", id, err)
+		}
+		if f == nil {
 			continue
 		}
-		if int64(f.Size) >= journalSize {
+		// max-only, overflow-safe: f.Size is uint64, journalSize a non-negative
+		// offset; compare in uint64 so a huge Size can never cast negative and shrink.
+		if journalSize < 0 || f.Size >= uint64(journalSize) {
 			continue
 		}
 		// Grow to the journal high-water mark under a STRICT transaction; re-read
@@ -772,7 +782,7 @@ func reconcileMetadataSizeFromJournal(ctx context.Context, metadataStore metadat
 			if err != nil {
 				return err
 			}
-			if int64(cur.Size) >= journalSize {
+			if cur == nil || journalSize < 0 || cur.Size >= uint64(journalSize) {
 				return nil // another writer already caught up; never shrink
 			}
 			cur.Size = uint64(journalSize)

--- a/pkg/metadata/io.go
+++ b/pkg/metadata/io.go
@@ -225,7 +225,8 @@ func (s *Service) CommitWrite(ctx *AuthContext, intent *WriteOperation) (*File, 
 }
 
 // deferredCommitWrite records the write in pending state without touching the store.
-// The actual commit happens on FlushPendingWrites (called by NFS COMMIT).
+// The actual commit happens on FlushPendingWriteForFile (called by NFS COMMIT/CLOSE,
+// SMB WRITE/CLOSE/FLUSH, or shutdown).
 func (s *Service) deferredCommitWrite(ctx *AuthContext, intent *WriteOperation) (*File, error) {
 	// Determine if we need to clear setuid/setgid
 	clearSetuid := ctx.Identity != nil && ctx.Identity.UID != nil && *ctx.Identity.UID != 0
@@ -358,35 +359,17 @@ func (s *Service) immediateCommitWrite(ctx *AuthContext, intent *WriteOperation)
 	return resultFile, nil
 }
 
-// FlushPendingWrites commits all pending metadata changes to the store.
-// This should be called on NFS COMMIT or when closing a file.
-// Returns the number of files flushed and any error encountered.
-func (s *Service) FlushPendingWrites(ctx *AuthContext) (int, error) {
-	entries := s.pendingWrites.PopAllPending()
-	if len(entries) == 0 {
-		return 0, nil
-	}
-
-	flushed := 0
-	var lastErr error
-
-	for _, entry := range entries {
-		if err := s.flushPendingWrite(ctx, entry.Handle, entry.State); err != nil {
-			lastErr = err
-			// Continue flushing other files
-		} else {
-			flushed++
-		}
-	}
-
-	return flushed, lastErr
-}
-
 // FlushPendingWriteForFile commits pending metadata for a specific file.
 // Returns true if there was pending data to flush.
 // Uses a per-file mutex to prevent concurrent flushes from causing BadgerDB
 // transaction conflicts (which trigger expensive retry loops with backoff).
-func (s *Service) FlushPendingWriteForFile(ctx *AuthContext, handle FileHandle) (bool, error) {
+//
+// durable controls the metadata commit's durability (#1687). Pass true only from
+// paths that promised the client stable metadata (FILE_SYNC WRITE, SMB
+// CLOSE/FLUSH, shutdown); pass false from the deferrable ack paths (UNSTABLE
+// WRITE, COMMIT, SMB inline WRITE) so the metadata fsync moves off the hot path.
+// See flushPendingWrite for the crash-safety argument (journal size reconcile).
+func (s *Service) FlushPendingWriteForFile(ctx *AuthContext, handle FileHandle, durable bool) (bool, error) {
 	// Serialize flushes per file to avoid BadgerDB conflict retries
 	mu := s.pendingWrites.GetFlushLock(handle)
 	mu.Lock()
@@ -410,7 +393,7 @@ func (s *Service) FlushPendingWriteForFile(ctx *AuthContext, handle FileHandle) 
 		return false, nil
 	}
 
-	if err := s.flushPendingWrite(ctx, handle, state); err != nil {
+	if err := s.flushPendingWrite(ctx, handle, state, durable); err != nil {
 		return true, err
 	}
 
@@ -425,13 +408,23 @@ func (s *Service) FlushPendingWriteForFile(ctx *AuthContext, handle FileHandle) 
 }
 
 // flushPendingWrite applies a single pending write to the store.
-func (s *Service) flushPendingWrite(ctx *AuthContext, handle FileHandle, state *PendingWriteState) error {
+//
+// durable selects the commit's durability. When true the metadata commit fsyncs
+// inline (WithTransaction) — used for FILE_SYNC WRITE, SMB CLOSE/FLUSH, and
+// shutdown, where the client was promised stable metadata. When false the commit
+// routes through withRelaxedTransaction (#1687): the size/mtime write becomes
+// durable with bounded lag instead of an inline fsync, moving the metadata
+// db.Sync off the hot WRITE/COMMIT ack path. A crash after a relaxed size commit
+// but before the background fsync cannot truncate ACK'd data because
+// reconcileMetadataSizeFromJournal grows metadata.Size up to the journal's
+// durable high-water mark on share start (max-only, never shrinks).
+func (s *Service) flushPendingWrite(ctx *AuthContext, handle FileHandle, state *PendingWriteState, durable bool) error {
 	store, err := s.storeForHandle(handle)
 	if err != nil {
 		return err
 	}
 
-	return store.WithTransaction(ctx.Context, func(tx Transaction) error {
+	commit := func(tx Transaction) error {
 		file, err := tx.GetFile(ctx.Context, handle)
 		if err != nil {
 			return err
@@ -454,7 +447,12 @@ func (s *Service) flushPendingWrite(ctx *AuthContext, handle FileHandle, state *
 		}
 
 		return tx.PutFile(ctx.Context, file)
-	})
+	}
+
+	if durable {
+		return store.WithTransaction(ctx.Context, commit)
+	}
+	return withRelaxedTransaction(store, ctx.Context, commit)
 }
 
 // GetPendingSize returns the pending size for a file if there are uncommitted writes.
@@ -472,9 +470,10 @@ func (s *Service) UpdatePendingMtime(handle FileHandle, mtime time.Time) bool {
 }
 
 // FlushAllPendingWritesForShutdown flushes all pending metadata writes during shutdown.
-// Unlike FlushPendingWrites, doesn't require an AuthContext and uses a
-// background context with a timeout. This should be called during graceful shutdown
-// to ensure all metadata changes are persisted before closing stores.
+// Doesn't require an AuthContext and uses a background context with a timeout.
+// This should be called during graceful shutdown to ensure all metadata changes
+// are persisted before closing stores. Flushes are durable (inline fsync): a clean
+// shutdown must leave every pending size/mtime on stable storage.
 func (s *Service) FlushAllPendingWritesForShutdown(timeout time.Duration) (int, error) {
 	entries := s.pendingWrites.PopAllPending()
 	if len(entries) == 0 {
@@ -494,7 +493,7 @@ func (s *Service) FlushAllPendingWritesForShutdown(timeout time.Duration) (int, 
 	var lastErr error
 
 	for _, entry := range entries {
-		if err := s.flushPendingWrite(authCtx, entry.Handle, entry.State); err != nil {
+		if err := s.flushPendingWrite(authCtx, entry.Handle, entry.State, true); err != nil {
 			lastErr = err
 			// Continue flushing other files
 		} else {

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -224,7 +224,7 @@ func (s *Service) ListIdentityQuotas() []ConfiguredQuota {
 }
 
 // SetDeferredCommit enables or disables deferred metadata commits.
-// When enabled, CommitWrite batches updates until FlushPendingWrites is called.
+// When enabled, CommitWrite batches updates until FlushPendingWriteForFile is called.
 // This significantly improves write performance for sequential workloads.
 func (s *Service) SetDeferredCommit(enabled bool) {
 	s.deferredCommit.Store(enabled)

--- a/pkg/metadata/service_test.go
+++ b/pkg/metadata/service_test.go
@@ -1570,8 +1570,8 @@ func TestMetadataService_CommitWrite(t *testing.T) {
 		assert.Equal(t, frozenMtime, fileGet.Mtime, "GetFile must return frozen mtime")
 		assert.Equal(t, frozenMtime, fileGet.Ctime, "GetFile ctime must match frozen mtime")
 
-		// Flush pending writes (simulates COMMIT)
-		flushed, err := fx.service.FlushPendingWriteForFile(fx.rootContext(), handle, true)
+		// Flush pending writes (simulates COMMIT — relaxed durability post-#1687)
+		flushed, err := fx.service.FlushPendingWriteForFile(fx.rootContext(), handle, false)
 		require.NoError(t, err)
 		assert.True(t, flushed)
 

--- a/pkg/metadata/service_test.go
+++ b/pkg/metadata/service_test.go
@@ -1571,7 +1571,7 @@ func TestMetadataService_CommitWrite(t *testing.T) {
 		assert.Equal(t, frozenMtime, fileGet.Ctime, "GetFile ctime must match frozen mtime")
 
 		// Flush pending writes (simulates COMMIT)
-		flushed, err := fx.service.FlushPendingWriteForFile(fx.rootContext(), handle)
+		flushed, err := fx.service.FlushPendingWriteForFile(fx.rootContext(), handle, true)
 		require.NoError(t, err)
 		assert.True(t, flushed)
 

--- a/pkg/metadata/sparse.go
+++ b/pkg/metadata/sparse.go
@@ -52,8 +52,10 @@ func (s *Service) PunchHole(ctx *AuthContext, handle FileHandle, offset, length 
 	}
 
 	// Commit any pending write metadata first so file.Blocks/Size reflect the
-	// latest state before we mutate the block list.
-	if _, err := s.FlushPendingWriteForFile(ctx, handle); err != nil {
+	// latest state before we mutate the block list. Durable: this flush precedes a
+	// strict manifest-mutating PutFile, and DEALLOCATE/ALLOCATE are rare (not the
+	// hot WRITE path), so keep the metadata fsync inline.
+	if _, err := s.FlushPendingWriteForFile(ctx, handle, true); err != nil {
 		return nil, err
 	}
 
@@ -125,7 +127,8 @@ func (s *Service) Allocate(ctx *AuthContext, handle FileHandle, offset, length u
 		return nil, err
 	}
 
-	if _, err := s.FlushPendingWriteForFile(ctx, handle); err != nil {
+	// Durable flush (see PunchHole): precedes a strict PutFile, rare op.
+	if _, err := s.FlushPendingWriteForFile(ctx, handle, true); err != nil {
 		return nil, err
 	}
 

--- a/pkg/metadata/store/badger/relaxed_durability_test.go
+++ b/pkg/metadata/store/badger/relaxed_durability_test.go
@@ -92,6 +92,73 @@ func TestRelaxedDurability_StrictModeNoInlineSync(t *testing.T) {
 		"strict mode must fsync via SyncWrites, never inline db.Sync")
 }
 
+// TestRelaxedDurability_FlushPendingWriteRouting pins the #1687 routing: the
+// metadata Service's FlushPendingWriteForFile must route its size/mtime commit to
+// WithTransactionRelaxed when durable=false (no inline fsync — the deferred hot
+// path) and to WithTransaction when durable=true (inline fsync — FILE_SYNC /
+// CLOSE / FLUSH / shutdown). If a future change inverted or dropped this routing,
+// the inline-sync count deltas below flip and this fails.
+func TestRelaxedDurability_FlushPendingWriteRouting(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "metadata.db")
+	store := openRelaxed(t, dbPath)
+	t.Cleanup(func() { _ = store.Close() })
+
+	const shareName = "/test"
+	root, err := store.CreateRootDirectory(ctx, shareName, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory,
+		Mode: 0o777,
+	})
+	require.NoError(t, err)
+	rootHandle, err := metadata.EncodeShareHandle(shareName, root.ID)
+	require.NoError(t, err)
+
+	svc := metadata.New() // deferred commit is on by default
+	require.NoError(t, svc.RegisterStoreForShare(shareName, store))
+
+	authCtx := &metadata.AuthContext{
+		Context:    ctx,
+		AuthMethod: "unix",
+		Identity: &metadata.Identity{
+			UID:  metadata.Uint32Ptr(0),
+			GID:  metadata.Uint32Ptr(0),
+			GIDs: []uint32{0},
+		},
+	}
+
+	// stagePending creates a file and records a deferred (pending) size write, so
+	// FlushPendingWriteForFile has real work to commit.
+	stagePending := func(name string, size uint64) metadata.FileHandle {
+		_, _, cerr := svc.CreateFile(authCtx, rootHandle, name, &metadata.FileAttr{Mode: 0o644})
+		require.NoError(t, cerr)
+		h, gerr := store.GetChild(ctx, rootHandle, name)
+		require.NoError(t, gerr)
+		intent, perr := svc.PrepareWrite(authCtx, h, size)
+		require.NoError(t, perr)
+		_, cwErr := svc.CommitWrite(authCtx, intent)
+		require.NoError(t, cwErr)
+		return h
+	}
+
+	// durable=false → relaxed commit, NO inline fsync.
+	hRelaxed := stagePending("relaxed.bin", 4096)
+	before := store.InlineSyncCountForTest()
+	flushed, ferr := svc.FlushPendingWriteForFile(authCtx, hRelaxed, false)
+	require.NoError(t, ferr)
+	require.True(t, flushed, "relaxed flush must have pending size to commit")
+	require.Equal(t, before, store.InlineSyncCountForTest(),
+		"durable=false must route through WithTransactionRelaxed (no inline fsync)")
+
+	// durable=true → strict commit, exactly one inline fsync.
+	hDurable := stagePending("durable.bin", 4096)
+	before = store.InlineSyncCountForTest()
+	flushed, ferr = svc.FlushPendingWriteForFile(authCtx, hDurable, true)
+	require.NoError(t, ferr)
+	require.True(t, flushed, "durable flush must have pending size to commit")
+	require.Equal(t, before+1, store.InlineSyncCountForTest(),
+		"durable=true must route through WithTransaction (inline fsync)")
+}
+
 // TestRelaxedDurability_DurableWriteSurvivesReopen confirms a durable write on
 // the relaxed store persists across a clean close+reopen with no loss — the
 // everyday durability the deferred-fsync path must never compromise.

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -197,16 +197,23 @@ type BadgerMetadataStoreConfig struct {
 	// If nil, sensible defaults are used
 	BadgerOptions *badger.Options
 
-	// RelaxedDurability defers the per-transaction fsync for pure-namespace
-	// metadata writes (create/remove/rename/mkdir/attr) to a bounded-lag
+	// RelaxedDurability defers the per-transaction fsync to a bounded-lag
 	// background sync, honoring the same UNSTABLE-style tradeoff the block
-	// append-log took in #1584. Data-paired writes — file size on WRITE, the
-	// block manifest (DefaultCommitBlock), and the rollup offset — stay
-	// synchronous regardless, so this can never resurrect the #588 silent-zeros
-	// bug; only a hard crash can lose the last sub-100ms of namespace ops (the
-	// op vanishes / reappears, never corrupts). When false (the safe default at
-	// the store layer) every commit fsyncs, exactly reproducing pre-#1573
-	// behavior. The server product enables it via config (#1573 Wall 1).
+	// append-log took in #1584. It covers namespace/attr writes
+	// (create/remove/rename/mkdir/attr) and, since #1687, the deferrable file-size
+	// commit on UNSTABLE WRITE / COMMIT / SMB inline WRITE. The block manifest
+	// (DefaultCommitBlock) and the rollup offset still commit synchronously.
+	//
+	// A relaxed file-size commit no longer risks #588 silent-zeros: the byte data
+	// is already fsync'd into the local journal before the WRITE is ACK'd, and on
+	// share start reconcileMetadataSizeFromJournal grows metadata.Size up to the
+	// journal's durable high-water mark (max-only, never shrinks). So a crash
+	// between a relaxed size commit and its background fsync cannot truncate ACK'd
+	// data — the reconcile restores the size. Durability-critical paths (FILE_SYNC
+	// WRITE, SMB CLOSE/FLUSH, shutdown) still pass durable=true and fsync inline.
+	// When false (the safe default at the store layer) every commit fsyncs,
+	// exactly reproducing pre-#1573 behavior. The server product enables it via
+	// config (#1573 Wall 1).
 	RelaxedDurability bool `mapstructure:"relaxed_durability"`
 
 	// BlockCacheSizeMB is BadgerDB's block cache size in MiB. This caches

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -115,11 +115,17 @@ func (s *BadgerMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 // WithTransactionRelaxed runs fn exactly like WithTransaction but, in
 // relaxed-durability mode, does NOT force an inline fsync on commit — the write
 // becomes durable via the background syncer within durabilitySyncInterval
-// instead (#1573 Wall 1). Use ONLY for pure-namespace/attr writes
-// (create/remove/rename/mkdir/mode/owner/times) that are not paired with block
-// data. NEVER use it for file-size, block-manifest, or rollup-offset writes —
-// those are data-paired and must stay synchronous (WithTransaction) or #588
-// silent-zeros can recur. In strict mode this is identical to WithTransaction.
+// instead (#1573 Wall 1). Use for namespace/attr writes
+// (create/remove/rename/mkdir/mode/owner/times) and, since #1687, the deferrable
+// file-size commit on UNSTABLE WRITE / COMMIT / SMB inline WRITE. The relaxed
+// size commit is safe from #588 silent-zeros because the byte data is fsync'd
+// into the local journal before the WRITE is ACK'd, and
+// reconcileMetadataSizeFromJournal grows metadata.Size up to the journal's
+// durable high-water mark on share start (max-only, never shrinks) — a crash
+// before the deferred metadata fsync cannot truncate ACK'd data. NEVER use it for
+// the block-manifest or rollup-offset writes, which have no such reconcile and
+// must stay synchronous (WithTransaction). In strict mode this is identical to
+// WithTransaction.
 func (s *BadgerMetadataStore) WithTransactionRelaxed(ctx context.Context, fn func(tx metadata.Transaction) error) error {
 	return s.withTransaction(ctx, fn, false)
 }

--- a/pkg/metadata/store/sqlite/config.go
+++ b/pkg/metadata/store/sqlite/config.go
@@ -69,6 +69,13 @@ func (c *SQLiteMetadataStoreConfig) Validate() error {
 // crash between checkpoints can lose the last commits, acceptable for this store.
 // The pragmas are passed via the `_pragma` query parameters that
 // modernc.org/sqlite recognises, so they apply to every pooled connection.
+//
+// #1687 note: this store has no strict/relaxed durability split — WAL+NORMAL
+// applies unconditionally and it does not implement RelaxedTransactor, so
+// withRelaxedTransaction falls back to WithTransaction here. A durable=true flush
+// (FILE_SYNC WRITE, SMB CLOSE/FLUSH, shutdown) is therefore only best-effort on
+// sqlite (NORMAL fsyncs at checkpoint, not per commit). This is a pre-existing
+// property of the sqlite backend, documented here — not changed by #1687.
 func (c *SQLiteMetadataStoreConfig) DSN() string {
 	// An in-memory database must be shared across the connection pool, otherwise
 	// each connection would see its own empty database. The "file::memory:" +


### PR DESCRIPTION
Moves the metadata `db.Sync` off the NFS/SMB WRITE+COMMIT ack path (#1687) — the felt-latency win. This is durability-critical: a bug here silently truncates an ACK'd file (#588 class), so the relax ships together with a load-bearing crash-safety net.

The relaxed-transaction machinery already existed (`withRelaxedTransaction` / `RelaxedTransactor`, badger+postgres `WithTransactionRelaxed`, `RelaxedDurability` defaulted on). This PR wires `flushPendingWrite` through it and adds the safety net — no new relaxed-txn plumbing.

## The 3 pieces (none is safe alone)

**Piece 1 — the relax.** `flushPendingWrite` / `FlushPendingWriteForFile` gain a `durable bool`. At commit: `durable` → strict `WithTransaction` (inline fsync); otherwise `withRelaxedTransaction` (bounded-lag background fsync). Shutdown passes `durable=true`. The dead `FlushPendingWrites` (zero callers) is deleted.

**Piece 2 — startup size reconciliation (the safety net).** `reconcileMetadataSizeFromJournal` runs in `AddShare` after the block store is built and BEFORE the share is registered (invisible to handlers). For each `id` in the local journal's `ListFiles`, it grows `metadata.Size` up to `journal.FileSize(id)` — **max-only, never shrinks** — under a strict transaction. A crash between a relaxed size commit and its background fsync therefore cannot truncate ACK'd data: the size is restored from the journal's durable high-water mark. Gated on `LocalBlockStoreID != ""`; the `*journal.Store` is reached via `engine.Store.Local()` (new accessor) whose `ListFiles`/`FileSize` are journal-native interface methods served from the in-memory index post-`recover()`.

**Piece 3 — durability classification (per sign-off).**

| Call site | durable |
|---|---|
| NFS v3 WRITE (`flushStableWrite`) | `stable >= FileSyncWrite` (FILE_SYNC only) |
| NFS v3 COMMIT | `false` |
| NFS v4 COMMIT | `false` |
| NFS v4 CLOSE | `false` |
| SMB WRITE | `false` ← the big win (per-write fsync removed) |
| **SMB CLOSE** | **`true` (STRICT — #1267 / MS-SMB2 3.3.5.10)** |
| **SMB FLUSH** | **`true` (STRICT — explicit client fsync)** |
| SMB copychunk / set-zero-data | `false` |
| metadata DEALLOCATE / ALLOCATE (sparse) | `true` (rare, precedes strict manifest PutFile) |
| Shutdown | `true` |

NFS v4 WRITE always reports UNSTABLE4 and never flushes inline — no change.

## Stayed STRICT (verified)
- SMB CLOSE + FLUSH (table above); the #1267 CLOSE durability comment stays true.
- `file_modify.go` SetAttr/truncate — a shrink is NOT covered by max()-only reconciliation, left strict, untouched.
- FILE_SYNC WRITE.

## The merge gate — crash-safety test
`pkg/controlplane/runtime/flush_relaxed_crash_test.go` models an ACK'd relaxed write that crashed before the metadata fsync: write N bytes journal-durable (`WriteToBlockStore` + `CommitBlockStore`, no rollup, no `FlushPendingWriteForFile`), so `metadata.Size` is still 0 while the journal holds N. After `simulateRestart` (real close+reopen + fresh `AddShare` → reconciliation), it asserts `Size == N` and the N bytes read back intact. Runs on badger + sqlite (memory/postgres skip — no durable reopen / needs integration tag).

This is a genuine gate: with the reconciliation call neutralized, both badger and sqlite FAIL with `ACK'd data truncated: metadata.Size = 0 after restart, want 262144`; with it, both PASS.

A badger store-level unit test (`TestRelaxedDurability_FlushPendingWriteRouting`) pins the routing via `InlineSyncCountForTest`: `durable=false` does not advance the inline-sync count, `durable=true` advances it by one.

## Notes
- **#1718 resolved:** the local-only snapshot-restore path that could have made `journal.ListFiles/FileSize` untrustworthy after a restore landed (#1727) and rebuilds the journal index correctly via re-materialize, so reconciliation-after-restore is fine.
- **sqlite is best-effort:** it has no strict/relaxed split (WAL + `synchronous=NORMAL` unconditionally, no `RelaxedTransactor`), so `durable=true` falls back to `WithTransaction` and fsyncs only at checkpoint. Pre-existing; documented in `sqlite/config.go`, not changed here.

## Verification (all green)
`go build ./...` + `-tags integration`; `go test ./pkg/metadata/... ./pkg/block/... ./internal/adapter/...` (58 ok / 0 fail); `go test -race ./pkg/controlplane/runtime/... ./pkg/metadata/...` (0 fail, no data race); `gofmt -s`; `go vet ./...`; `golangci-lint` (0 issues).

Draft — adversarial review before un-draft.
