### PR TITLE
perf(adapter): demote per-op NFS/SMB traces from INFO to DEBUG

### DIFF
--- a/internal/adapter/nfs/v3/handlers/access.go
+++ b/internal/adapter/nfs/v3/handlers/access.go
@@ -82,7 +82,7 @@ func (h *Handler) Access(
 	// Extract client IP for logging
 	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
-	logger.InfoCtx(ctx.Context, "ACCESS",
+	logger.DebugCtx(ctx.Context, "ACCESS",
 		"handle", fmt.Sprintf("%x", req.Handle),
 		"requested", fmt.Sprintf("0x%x", req.Access),
 		"client", clientIP,
@@ -184,7 +184,7 @@ func (h *Handler) Access(
 	// Generate file ID from handle for NFS attributes
 	nfsAttr := h.convertFileAttrToNFS(fileHandle, &file.FileAttr)
 
-	logger.InfoCtx(ctx.Context, "ACCESS successful",
+	logger.DebugCtx(ctx.Context, "ACCESS successful",
 		"handle", fmt.Sprintf("%x", req.Handle),
 		"granted", fmt.Sprintf("0x%x", grantedAccess),
 		"requested", fmt.Sprintf("0x%x", req.Access),

--- a/internal/adapter/nfs/v3/handlers/commit.go
+++ b/internal/adapter/nfs/v3/handlers/commit.go
@@ -86,7 +86,7 @@ func (h *Handler) Commit(
 	// Extract client IP for logging
 	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
-	logger.InfoCtx(ctx.Context, "COMMIT", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP, "auth", ctx.AuthFlavor)
+	logger.DebugCtx(ctx.Context, "COMMIT", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP, "auth", ctx.AuthFlavor)
 
 	if ctx.isContextCancelled() {
 		logger.WarnCtx(ctx.Context, "COMMIT cancelled", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP, "error", ctx.Context.Err())
@@ -157,7 +157,7 @@ func (h *Handler) Commit(
 	// Check if there's content to flush
 	if file.PayloadID == "" {
 		logger.DebugCtx(ctx.Context, "COMMIT: no content to flush")
-		logger.InfoCtx(ctx.Context, "COMMIT successful (no content)", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP)
+		logger.DebugCtx(ctx.Context, "COMMIT successful (no content)", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP)
 		return &CommitResponse{
 			NFSResponseBase: NFSResponseBase{Status: types.NFS3OK},
 			AttrBefore:      wccBefore,
@@ -166,7 +166,7 @@ func (h *Handler) Commit(
 		}, nil
 	}
 
-	logger.InfoCtx(ctx.Context, "COMMIT: flushing data", "share", ctx.Share)
+	logger.DebugCtx(ctx.Context, "COMMIT: flushing data", "share", ctx.Share)
 
 	blockStore, err := common.ResolveForWrite(ctx.Context, h.Registry, handle)
 	if err != nil {
@@ -227,7 +227,7 @@ func (h *Handler) Commit(
 	// writes merged (size, mtime applied). FlushPendingWriteForFile persists those
 	// same values to BadgerDB -- no need to read them back.
 
-	logger.InfoCtx(ctx.Context, "COMMIT successful", "file", file.PayloadID, "offset", req.Offset, "count", req.Count, "client", clientIP)
+	logger.DebugCtx(ctx.Context, "COMMIT successful", "file", file.PayloadID, "offset", req.Offset, "count", req.Count, "client", clientIP)
 	return &CommitResponse{
 		NFSResponseBase: NFSResponseBase{Status: types.NFS3OK},
 		AttrBefore:      wccBefore,

--- a/internal/adapter/nfs/v3/handlers/create.go
+++ b/internal/adapter/nfs/v3/handlers/create.go
@@ -92,7 +92,7 @@ func (h *Handler) Create(
 	// Extract client IP for logging
 	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
-	logger.InfoCtx(ctx.Context, "CREATE", "file", req.Filename, "dir", fmt.Sprintf("0x%x", req.DirHandle), "mode", createModeName(req.Mode), "client", clientIP, "auth", ctx.AuthFlavor)
+	logger.DebugCtx(ctx.Context, "CREATE", "file", req.Filename, "dir", fmt.Sprintf("0x%x", req.DirHandle), "mode", createModeName(req.Mode), "client", clientIP, "auth", ctx.AuthFlavor)
 
 	if err := validateCreateRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "CREATE validation failed", "file", req.Filename, "client", clientIP, "error", err)
@@ -205,7 +205,7 @@ func (h *Handler) Create(
 			// rather than being mis-flagged as a conflict.
 			if existingFile.IdempotencyToken == req.Verf {
 				// Token matches - this is a retry of a successful create
-				logger.InfoCtx(ctx.Context, "CREATE EXCLUSIVE retry detected",
+				logger.DebugCtx(ctx.Context, "CREATE EXCLUSIVE retry detected",
 					"file", req.Filename, "token", fmt.Sprintf("0x%016x", req.Verf), "client", clientIP)
 
 				existingHandle, err := metadata.EncodeFileHandle(existingFile)
@@ -327,7 +327,7 @@ func (h *Handler) Create(
 	// unchanged, so dirWccPair falls back to a fresh read.
 	dirWccBefore, nfsDirAttr := h.dirWccPair(ctx, metaSvc, parentHandle, createDirWcc, dirWccBefore)
 
-	logger.InfoCtx(ctx.Context, "CREATE successful", "file", req.Filename, "handle", fmt.Sprintf("0x%x", fileHandle), "mode", fmt.Sprintf("0%o", fileAttr.Mode), "size", fileAttr.Size, "client", clientIP)
+	logger.DebugCtx(ctx.Context, "CREATE successful", "file", req.Filename, "handle", fmt.Sprintf("0x%x", fileHandle), "mode", fmt.Sprintf("0%o", fileAttr.Mode), "size", fileAttr.Size, "client", clientIP)
 
 	return &CreateResponse{
 		NFSResponseBase: NFSResponseBase{Status: types.NFS3OK},

--- a/internal/adapter/nfs/v3/handlers/fsinfo.go
+++ b/internal/adapter/nfs/v3/handlers/fsinfo.go
@@ -181,7 +181,7 @@ func (h *Handler) FsInfo(
 	// Build NFS properties bitmask from capabilities
 	properties := buildNFSProperties(capabilities)
 
-	logger.InfoCtx(ctx.Context, "FSINFO successful", "client", ctx.ClientAddr, "rtmax", bytesize.ByteSize(capabilities.MaxReadSize), "wtmax", bytesize.ByteSize(capabilities.MaxWriteSize), "maxfilesize", bytesize.ByteSize(capabilities.MaxFileSize), "properties", fmt.Sprintf("0x%x", properties))
+	logger.DebugCtx(ctx.Context, "FSINFO successful", "client", ctx.ClientAddr, "rtmax", bytesize.ByteSize(capabilities.MaxReadSize), "wtmax", bytesize.ByteSize(capabilities.MaxWriteSize), "maxfilesize", bytesize.ByteSize(capabilities.MaxFileSize), "properties", fmt.Sprintf("0x%x", properties))
 
 	// Build response with data from store
 	// Map the standardized FilesystemCapabilities to NFS wire format

--- a/internal/adapter/nfs/v3/handlers/fsstat.go
+++ b/internal/adapter/nfs/v3/handlers/fsstat.go
@@ -164,7 +164,7 @@ func (h *Handler) FsStat(
 	// Convert ValidFor duration to seconds for Invarsec
 	invarsec := uint32(stats.ValidFor.Seconds())
 
-	logger.InfoCtx(ctx.Context, "FSSTAT successful", "client", ctx.ClientAddr, "total", bytesize.ByteSize(stats.TotalBytes), "used", bytesize.ByteSize(stats.UsedBytes), "avail", bytesize.ByteSize(stats.AvailableBytes), "tfiles", stats.TotalFiles, "ffiles", stats.UsedFiles, "afiles", stats.AvailableFiles)
+	logger.DebugCtx(ctx.Context, "FSSTAT successful", "client", ctx.ClientAddr, "total", bytesize.ByteSize(stats.TotalBytes), "used", bytesize.ByteSize(stats.UsedBytes), "avail", bytesize.ByteSize(stats.AvailableBytes), "tfiles", stats.TotalFiles, "ffiles", stats.UsedFiles, "afiles", stats.AvailableFiles)
 
 	// Build response with data from store.
 	// Note: NFS uses "free bytes" while the interface tracks "used bytes".

--- a/internal/adapter/nfs/v3/handlers/link.go
+++ b/internal/adapter/nfs/v3/handlers/link.go
@@ -78,7 +78,7 @@ func (h *Handler) Link(
 	// Extract client IP for logging
 	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
-	logger.InfoCtx(ctx.Context, "LINK", "file_handle", fmt.Sprintf("%x", req.FileHandle), "name", req.Name, "dir_handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "auth", ctx.AuthFlavor)
+	logger.DebugCtx(ctx.Context, "LINK", "file_handle", fmt.Sprintf("%x", req.FileHandle), "name", req.Name, "dir_handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "auth", ctx.AuthFlavor)
 
 	// LINK involves multiple operations, so respect cancellation to avoid
 	// wasting resources on abandoned requests
@@ -246,7 +246,7 @@ func (h *Handler) Link(
 	// H9: use the directory attributes captured atomically with the link.
 	dirWccBefore, nfsDirAttr := h.dirWccPair(ctx, metaSvc, dirHandle, dirWcc, dirWccBefore)
 
-	logger.InfoCtx(ctx.Context, "LINK successful", "name", req.Name, "file_handle", fmt.Sprintf("%x", req.FileHandle), "nlink", nfsFileAttr.Nlink, "client", clientIP)
+	logger.DebugCtx(ctx.Context, "LINK successful", "name", req.Name, "file_handle", fmt.Sprintf("%x", req.FileHandle), "nlink", nfsFileAttr.Nlink, "client", clientIP)
 
 	return &LinkResponse{
 		NFSResponseBase: NFSResponseBase{Status: types.NFS3OK},

--- a/internal/adapter/nfs/v3/handlers/lookup.go
+++ b/internal/adapter/nfs/v3/handlers/lookup.go
@@ -79,7 +79,7 @@ func (h *Handler) Lookup(
 	// Extract client IP for logging
 	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
-	logger.InfoCtx(ctx.Context, "LOOKUP",
+	logger.DebugCtx(ctx.Context, "LOOKUP",
 		"name", req.Filename,
 		"handle", fmt.Sprintf("%x", req.DirHandle),
 		"client", clientIP,
@@ -239,7 +239,7 @@ func (h *Handler) Lookup(
 	nfsChildAttr := h.convertFileAttrToNFS(childHandle, &childFile.FileAttr)
 	nfsDirAttr := h.convertFileAttrToNFS(dirHandle, &dirFile.FileAttr)
 
-	logger.InfoCtx(ctx.Context, "LOOKUP successful",
+	logger.DebugCtx(ctx.Context, "LOOKUP successful",
 		"name", req.Filename,
 		"handle", fmt.Sprintf("%x", childHandle),
 		"type", nfsChildAttr.Type,

--- a/internal/adapter/nfs/v3/handlers/mkdir.go
+++ b/internal/adapter/nfs/v3/handlers/mkdir.go
@@ -107,7 +107,7 @@ func (h *Handler) Mkdir(
 		mode = *req.Attr.Mode
 	}
 
-	logger.InfoCtx(ctx.Context, "MKDIR", "name", req.Name, "handle", fmt.Sprintf("%x", req.DirHandle), "mode", fmt.Sprintf("%o", mode), "client", clientIP, "auth", ctx.AuthFlavor)
+	logger.DebugCtx(ctx.Context, "MKDIR", "name", req.Name, "handle", fmt.Sprintf("%x", req.DirHandle), "mode", fmt.Sprintf("%o", mode), "client", clientIP, "auth", ctx.AuthFlavor)
 
 	if err := validateMkdirRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "MKDIR validation failed", "name", req.Name, "client", clientIP, "error", err)
@@ -299,7 +299,7 @@ func (h *Handler) Mkdir(
 	// H9: use the parent attributes captured atomically with the create.
 	wccBefore, wccAfter = h.dirWccPair(ctx, metaSvc, parentHandle, dirWcc, wccBefore)
 
-	logger.InfoCtx(ctx.Context, "MKDIR successful", "name", req.Name, "handle", fmt.Sprintf("%x", newHandle), "mode", fmt.Sprintf("%o", newDirFile.Mode), "size", newDirFile.Size, "client", clientIP)
+	logger.DebugCtx(ctx.Context, "MKDIR successful", "name", req.Name, "handle", fmt.Sprintf("%x", newHandle), "mode", fmt.Sprintf("%o", newDirFile.Mode), "size", newDirFile.Size, "client", clientIP)
 
 	logger.DebugCtx(ctx.Context, "MKDIR details", "handle", fmt.Sprintf("%x", newHandle), "uid", newDirFile.UID, "gid", newDirFile.GID, "parent_handle", fmt.Sprintf("%x", parentHandle))
 

--- a/internal/adapter/nfs/v3/handlers/mknod.go
+++ b/internal/adapter/nfs/v3/handlers/mknod.go
@@ -142,7 +142,7 @@ func (h *Handler) Mknod(
 		mode = *req.Attr.Mode
 	}
 
-	logger.InfoCtx(ctx.Context, "MKNOD", "name", req.Name, "type", specialFileTypeName(req.Type), "handle", fmt.Sprintf("%x", req.DirHandle), "mode", fmt.Sprintf("%o", mode), "client", clientIP, "auth", ctx.AuthFlavor)
+	logger.DebugCtx(ctx.Context, "MKNOD", "name", req.Name, "type", specialFileTypeName(req.Type), "handle", fmt.Sprintf("%x", req.DirHandle), "mode", fmt.Sprintf("%o", mode), "client", clientIP, "auth", ctx.AuthFlavor)
 
 	if err := validateMknodRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "MKNOD validation failed", "name", req.Name, "type", req.Type, "client", clientIP, "error", err)
@@ -298,7 +298,7 @@ func (h *Handler) Mknod(
 	// H9: use the parent attributes captured atomically with the create.
 	wccBefore, wccAfter = h.dirWccPair(ctx, metaSvc, parentHandle, dirWcc, wccBefore)
 
-	logger.InfoCtx(ctx.Context, "MKNOD successful", "name", req.Name, "type", specialFileTypeName(req.Type), "handle", fmt.Sprintf("%x", newHandle), "mode", fmt.Sprintf("%o", newFile.Mode), "major", req.Spec.SpecData1, "minor", req.Spec.SpecData2, "client", clientIP)
+	logger.DebugCtx(ctx.Context, "MKNOD successful", "name", req.Name, "type", specialFileTypeName(req.Type), "handle", fmt.Sprintf("%x", newHandle), "mode", fmt.Sprintf("%o", newFile.Mode), "major", req.Spec.SpecData1, "minor", req.Spec.SpecData2, "client", clientIP)
 
 	logger.DebugCtx(ctx.Context, "MKNOD details", "handle", fmt.Sprintf("%x", newHandle), "uid", newFile.UID, "gid", newFile.GID, "parent", fmt.Sprintf("%x", parentHandle))
 

--- a/internal/adapter/nfs/v3/handlers/pathconf.go
+++ b/internal/adapter/nfs/v3/handlers/pathconf.go
@@ -100,7 +100,7 @@ func (h *Handler) PathConf(
 	// Extract client IP for logging
 	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
-	logger.InfoCtx(ctx.Context, "PATHCONF", "handle", fmt.Sprintf("%x", req.Handle), "client", clientIP, "auth", ctx.AuthFlavor)
+	logger.DebugCtx(ctx.Context, "PATHCONF", "handle", fmt.Sprintf("%x", req.Handle), "client", clientIP, "auth", ctx.AuthFlavor)
 
 	if ctx.isContextCancelled() {
 		logger.WarnCtx(ctx.Context, "PATHCONF cancelled", "handle", fmt.Sprintf("%x", req.Handle), "client", clientIP, "error", ctx.Context.Err())
@@ -150,7 +150,7 @@ func (h *Handler) PathConf(
 
 	nfsAttr := h.convertFileAttrToNFS(fileHandle, &file.FileAttr)
 
-	logger.InfoCtx(ctx.Context, "PATHCONF successful", "handle", fmt.Sprintf("%x", req.Handle), "client", clientIP)
+	logger.DebugCtx(ctx.Context, "PATHCONF successful", "handle", fmt.Sprintf("%x", req.Handle), "client", clientIP)
 	logger.DebugCtx(ctx.Context, "PATHCONF properties", "linkmax", caps.MaxHardLinkCount, "namemax", caps.MaxFilenameLen, "no_trunc", !caps.TruncatesLongNames, "chown_restricted", caps.ChownRestricted, "case_insensitive", !caps.CaseSensitive, "case_preserving", caps.CasePreserving)
 
 	// Map FilesystemCapabilities fields to PATHCONF response fields

--- a/internal/adapter/nfs/v3/handlers/readdir.go
+++ b/internal/adapter/nfs/v3/handlers/readdir.go
@@ -106,7 +106,7 @@ func (h *Handler) ReadDir(
 	// Extract client IP for logging
 	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
-	logger.InfoCtx(ctx.Context, "READDIR", "handle", fmt.Sprintf("%x", req.DirHandle), "cookie", req.Cookie, "count", req.Count, "client", clientIP, "auth", ctx.AuthFlavor)
+	logger.DebugCtx(ctx.Context, "READDIR", "handle", fmt.Sprintf("%x", req.DirHandle), "cookie", req.Cookie, "count", req.Count, "client", clientIP, "auth", ctx.AuthFlavor)
 
 	if err := validateReadDirRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "READDIR validation failed", "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "error", err)
@@ -262,7 +262,7 @@ func (h *Handler) ReadDir(
 	// EOF is true when there are no more pages
 	eof := !page.HasMore
 
-	logger.InfoCtx(ctx.Context, "READDIR successful", "handle", fmt.Sprintf("%x", req.DirHandle), "entries", len(nfsEntries), "eof", eof, "client", clientIP)
+	logger.DebugCtx(ctx.Context, "READDIR successful", "handle", fmt.Sprintf("%x", req.DirHandle), "entries", len(nfsEntries), "eof", eof, "client", clientIP)
 
 	logger.DebugCtx(ctx.Context, "READDIR details", "cookie_start", req.Cookie, "cookie_end", getLastCookie(nfsEntries), "count_limit", req.Count)
 

--- a/internal/adapter/nfs/v3/handlers/readdirplus.go
+++ b/internal/adapter/nfs/v3/handlers/readdirplus.go
@@ -160,7 +160,7 @@ func (h *Handler) ReadDirPlus(
 	// Extract client IP for logging
 	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
-	logger.InfoCtx(ctx.Context, "READDIRPLUS", "handle", fmt.Sprintf("%x", req.DirHandle), "cookie", req.Cookie, "dircount", req.DirCount, "maxcount", req.MaxCount, "client", clientIP, "auth", ctx.AuthFlavor)
+	logger.DebugCtx(ctx.Context, "READDIRPLUS", "handle", fmt.Sprintf("%x", req.DirHandle), "cookie", req.Cookie, "dircount", req.DirCount, "maxcount", req.MaxCount, "client", clientIP, "auth", ctx.AuthFlavor)
 
 	if ctx.isContextCancelled() {
 		logger.WarnCtx(ctx.Context, "READDIRPLUS cancelled", "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "error", ctx.Context.Err())
@@ -414,7 +414,7 @@ func (h *Handler) ReadDirPlus(
 	// client resumes from the last emitted cookie (RFC 1813 Section 3.3.17).
 	eof := !page.HasMore && !budgetExhausted && len(entries) == len(page.Entries)
 
-	logger.InfoCtx(ctx.Context, "READDIRPLUS successful", "handle", fmt.Sprintf("%x", req.DirHandle), "entries", len(entries), "eof", eof, "client", clientIP)
+	logger.DebugCtx(ctx.Context, "READDIRPLUS successful", "handle", fmt.Sprintf("%x", req.DirHandle), "entries", len(entries), "eof", eof, "client", clientIP)
 
 	logger.DebugCtx(ctx.Context, "READDIRPLUS details", "handle", fmt.Sprintf("%x", dirHandle), "total_entries", len(page.Entries), "eof", eof)
 

--- a/internal/adapter/nfs/v3/handlers/readlink.go
+++ b/internal/adapter/nfs/v3/handlers/readlink.go
@@ -79,7 +79,7 @@ func (h *Handler) ReadLink(
 	// Extract client IP for logging
 	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
-	logger.InfoCtx(ctx.Context, "READLINK", "handle", fmt.Sprintf("%x", req.Handle), "client", clientIP, "auth", ctx.AuthFlavor)
+	logger.DebugCtx(ctx.Context, "READLINK", "handle", fmt.Sprintf("%x", req.Handle), "client", clientIP, "auth", ctx.AuthFlavor)
 
 	if err := validateReadLinkRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "READLINK validation failed", "handle", fmt.Sprintf("%x", req.Handle), "client", clientIP, "error", err)
@@ -130,7 +130,7 @@ func (h *Handler) ReadLink(
 		// (SMB-created symlink not yet converted on CLOSE)
 		mfsResult := h.checkMFsymlinkByHandle(ctx, fileHandle)
 		if mfsResult.IsMFsymlink {
-			logger.InfoCtx(ctx.Context, "READLINK successful (MFsymlink)",
+			logger.DebugCtx(ctx.Context, "READLINK successful (MFsymlink)",
 				"handle", fmt.Sprintf("%x", req.Handle),
 				"target", mfsResult.Target,
 				"client", clientIP)
@@ -153,7 +153,7 @@ func (h *Handler) ReadLink(
 
 	nfsAttr := h.convertFileAttrToNFS(fileHandle, &file.FileAttr)
 
-	logger.InfoCtx(ctx.Context, "READLINK successful", "handle", fmt.Sprintf("%x", req.Handle), "target", target, "target_len", len(target), "client", clientIP)
+	logger.DebugCtx(ctx.Context, "READLINK successful", "handle", fmt.Sprintf("%x", req.Handle), "target", target, "target_len", len(target), "client", clientIP)
 
 	logger.DebugCtx(ctx.Context, "READLINK details", "handle", fmt.Sprintf("%x", fileHandle), "mode", fmt.Sprintf("%o", file.Mode), "uid", file.UID, "gid", file.GID, "size", file.Size)
 

--- a/internal/adapter/nfs/v3/handlers/remove.go
+++ b/internal/adapter/nfs/v3/handlers/remove.go
@@ -79,7 +79,7 @@ func (h *Handler) Remove(
 	// Extract client IP for logging
 	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
-	logger.InfoCtx(ctx.Context, "REMOVE", "name", req.Filename, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "auth", ctx.AuthFlavor)
+	logger.DebugCtx(ctx.Context, "REMOVE", "name", req.Filename, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "auth", ctx.AuthFlavor)
 
 	if err := validateRemoveRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "REMOVE validation failed", "name", req.Filename, "client", clientIP, "error", err)
@@ -213,7 +213,7 @@ func (h *Handler) Remove(
 	// falling back to a fresh read only if the store did not return them.
 	wccBefore, wccAfter = h.dirWccPair(ctx, metaSvc, dirHandle, dirWcc, wccBefore)
 
-	logger.InfoCtx(ctx.Context, "REMOVE successful", "name", req.Filename, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP)
+	logger.DebugCtx(ctx.Context, "REMOVE successful", "name", req.Filename, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP)
 
 	// Convert internal type to NFS type for logging
 	nfsType := uint32(removedFileAttr.Type) + 1 // Internal types are 0-based, NFS types are 1-based

--- a/internal/adapter/nfs/v3/handlers/rename.go
+++ b/internal/adapter/nfs/v3/handlers/rename.go
@@ -95,7 +95,7 @@ func (h *Handler) Rename(
 	// Extract client IP for logging
 	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
-	logger.InfoCtx(ctx.Context, "RENAME", "from", req.FromName, "from_dir", fmt.Sprintf("0x%x", req.FromDirHandle), "to", req.ToName, "to_dir", fmt.Sprintf("0x%x", req.ToDirHandle), "client", clientIP, "auth", ctx.AuthFlavor)
+	logger.DebugCtx(ctx.Context, "RENAME", "from", req.FromName, "from_dir", fmt.Sprintf("0x%x", req.FromDirHandle), "to", req.ToName, "to_dir", fmt.Sprintf("0x%x", req.ToDirHandle), "client", clientIP, "auth", ctx.AuthFlavor)
 
 	if err := validateRenameRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "RENAME validation failed", "from", req.FromName, "to", req.ToName, "client", clientIP, "error", err)
@@ -337,7 +337,7 @@ func (h *Handler) Rename(
 	fromDirWccBefore, fromDirWccAfter = h.dirWccPair(ctx, metaSvc, fromDirHandle, fromWcc, fromDirWccBefore)
 	toDirWccBefore, toDirWccAfter := h.dirWccPair(ctx, metaSvc, toDirHandle, toWcc, toDirWccBefore)
 
-	logger.InfoCtx(ctx.Context, "RENAME successful", "from", req.FromName, "to", req.ToName, "client", clientIP)
+	logger.DebugCtx(ctx.Context, "RENAME successful", "from", req.FromName, "to", req.ToName, "client", clientIP)
 
 	// Extract IDs for debug logging
 	fromDirID := xdr.ExtractFileID(fromDirHandle)

--- a/internal/adapter/nfs/v3/handlers/rmdir.go
+++ b/internal/adapter/nfs/v3/handlers/rmdir.go
@@ -74,7 +74,7 @@ func (h *Handler) Rmdir(
 	// Extract client IP for logging
 	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
-	logger.InfoCtx(ctx.Context, "RMDIR", "name", req.Name, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "auth", ctx.AuthFlavor)
+	logger.DebugCtx(ctx.Context, "RMDIR", "name", req.Name, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "auth", ctx.AuthFlavor)
 
 	if ctx.isContextCancelled() {
 		logger.WarnCtx(ctx.Context, "RMDIR cancelled", "name", req.Name, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP, "error", ctx.Context.Err())
@@ -182,7 +182,7 @@ func (h *Handler) Rmdir(
 	// H9: use the parent attributes captured atomically with the removal.
 	wccBefore, wccAfter = h.dirWccPair(ctx, metaSvc, parentHandle, dirWcc, wccBefore)
 
-	logger.InfoCtx(ctx.Context, "RMDIR successful", "name", req.Name, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP)
+	logger.DebugCtx(ctx.Context, "RMDIR successful", "name", req.Name, "handle", fmt.Sprintf("%x", req.DirHandle), "client", clientIP)
 
 	logger.DebugCtx(ctx.Context, "RMDIR details", "parent_handle", fmt.Sprintf("%x", parentHandle))
 

--- a/internal/adapter/nfs/v3/handlers/setattr.go
+++ b/internal/adapter/nfs/v3/handlers/setattr.go
@@ -97,7 +97,7 @@ func (h *Handler) SetAttr(
 	// Extract client IP for logging
 	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
-	logger.InfoCtx(ctx.Context, "SETATTR",
+	logger.DebugCtx(ctx.Context, "SETATTR",
 		"handle", fmt.Sprintf("%x", req.Handle),
 		"guard", req.Guard.Check,
 		"client", clientIP,
@@ -338,7 +338,7 @@ func (h *Handler) SetAttr(
 	// actually transitioned from. The WCC subject for SETATTR is the file itself.
 	wccBefore, wccAfter = h.dirWccPair(ctx, metaSvc, fileHandle, setWcc, wccBefore)
 
-	logger.InfoCtx(ctx.Context, "SETATTR successful",
+	logger.DebugCtx(ctx.Context, "SETATTR successful",
 		"handle", fmt.Sprintf("%x", req.Handle),
 		"client", clientIP)
 

--- a/internal/adapter/nfs/v3/handlers/symlink.go
+++ b/internal/adapter/nfs/v3/handlers/symlink.go
@@ -102,7 +102,7 @@ func (h *Handler) Symlink(
 	// Extract client IP for logging
 	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
-	logger.InfoCtx(ctx.Context, "SYMLINK", "name", req.Name, "target", req.Target, "dir", fmt.Sprintf("0x%x", req.DirHandle), "client", clientIP, "auth", ctx.AuthFlavor)
+	logger.DebugCtx(ctx.Context, "SYMLINK", "name", req.Name, "target", req.Target, "dir", fmt.Sprintf("0x%x", req.DirHandle), "client", clientIP, "auth", ctx.AuthFlavor)
 
 	if err := validateSymlinkRequest(req); err != nil {
 		logger.WarnCtx(ctx.Context, "SYMLINK validation failed", "name", req.Name, "target", req.Target, "client", clientIP, "error", err)
@@ -239,7 +239,7 @@ func (h *Handler) Symlink(
 	// H9: use the directory attributes captured atomically with the create.
 	wccBefore, wccAfter := h.dirWccPair(ctx, metaSvc, dirHandle, dirWcc, wccBefore)
 
-	logger.InfoCtx(ctx.Context, "SYMLINK successful", "name", req.Name, "target", req.Target, "dir", fmt.Sprintf("0x%x", req.DirHandle), "handle", fmt.Sprintf("0x%x", symlinkHandle), "client", clientIP)
+	logger.DebugCtx(ctx.Context, "SYMLINK successful", "name", req.Name, "target", req.Target, "dir", fmt.Sprintf("0x%x", req.DirHandle), "handle", fmt.Sprintf("0x%x", symlinkHandle), "client", clientIP)
 
 	logger.DebugCtx(ctx.Context, "SYMLINK details", "symlink_handle", fmt.Sprintf("0x%x", symlinkHandle), "mode", fmt.Sprintf("%o", createdSymlink.Mode), "uid", createdSymlink.UID, "gid", createdSymlink.GID, "size", createdSymlink.Size, "target_len", len(req.Target))
 


### PR DESCRIPTION
## What

A server-side pprof trace of the NFS CREATE path found that the two per-operation `logger.InfoCtx` calls in `internal/adapter/nfs/v3/handlers/create.go` (the `CREATE` request line and the `CREATE ... successful` line) accounted for **~14% of CREATE-path server CPU** under concurrent load.

Root cause: each `InfoCtx` is a **synchronous write to a rotating log file**, and lumberjack holds a mutex around the write — so every per-op INFO log **serializes the data plane**. This same per-op INFO pattern spans every NFS v3 handler.

This PR demotes those verbose per-request/per-procedure traces from `InfoCtx` to `DebugCtx`.

## Scope

**38 sites across 18 files**, all in `internal/adapter/nfs/v3/handlers/`. Demoted handler families (request-entry lines + their `... successful`/completion counterparts):

`ACCESS`, `COMMIT`, `CREATE` (incl. `CREATE EXCLUSIVE`), `FSINFO`, `FSSTAT`, `LINK`, `LOOKUP`, `MKDIR`, `MKNOD`, `PATHCONF`, `READDIR`, `READDIRPLUS`, `READLINK`, `REMOVE`, `RENAME`, `RMDIR`, `SETATTR`, `SYMLINK`.

Every one of these fires on a per-client-operation basis, so they belong at Debug on a filesystem server.

**SMB:** no changes needed. The SMB command handlers (`SMB2 CREATE/READ/WRITE/CLOSE/...`) already log per-op at Debug — they contain zero `logger.Info`/`InfoCtx` calls. The only `logger.Info` calls under `internal/adapter/smb/` are genuine lifecycle/security events (session setup/teardown, Kerberos/NTLM auth outcomes, channel bind, durable-handle scavenger, FileID seeding), which are correctly kept at INFO.

## Kept at INFO (not touched)

No per-op INFO logs remain; no NFS lifecycle `InfoCtx` exists in this dir. Server-lifecycle/session/auth events (SMB session + Kerberos, listener/adapter events) stay at INFO as before. `WarnCtx`/`ErrorCtx`/existing `DebugCtx` untouched.

## Nature of change

**Level-only.** `logger.InfoCtx(...)` → `logger.DebugCtx(...)`. No message text or key/value args changed (diff is exactly 38 insertions / 38 deletions, all `Info`→`Debug`).

## Perf impact

This lifts the server's **throughput ceiling under concurrent load** by removing the lumberjack mutex from the hot data-plane path. It does **not** change single-client benchmark-rig numbers — the server is ~97% idle at rig load, so per-op logging isn't visible there; this raises the saturation ceiling that matters under real multi-client concurrency.

## Verification

- `go build ./...` — passes
- `gofmt -s -w .` — clean
- `go vet ./...` — passes
- `go test ./internal/adapter/nfs/... ./internal/adapter/smb/...` — 4235 passed across 47 packages