### PR TITLE
perf(journal): group-commit fsync — fix rand-write regression (#1736)

### DIFF
--- a/pkg/block/journal/commit_bench_test.go
+++ b/pkg/block/journal/commit_bench_test.go
@@ -1,0 +1,63 @@
+package journal
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// BenchmarkConcurrentCommit reproduces the fio rand-write-4k shape that #1736
+// regressed on: many concurrent 4 KiB writes each followed by a durability
+// Commit (direct=1 over NFS ⇒ a server-side fsync per write), all landing on
+// one shard's active segment. It measures how a burst of concurrent commits on
+// the SAME segment fd coalesces — or fails to. With an uncoalesced per-shard
+// fsync every commit pays a full disk barrier; a group-commit lets one barrier
+// satisfy the whole in-flight batch.
+//
+// parallelism controls the in-flight depth (fio uses iodepth=32 × numjobs=4).
+// All ops target files that hash to a single shard so the fsync contention is
+// real and not spread across shards.
+func benchConcurrentCommit(b *testing.B, parallelism int) {
+	s := benchStore(b)
+	ctx := context.Background()
+	data := make([]byte, 4<<10)
+
+	// Pick FileIDs that all resolve to shard 0 so every commit fsyncs the same fd.
+	ids := make([]FileID, parallelism)
+	got := 0
+	for i := 0; got < parallelism; i++ {
+		id := FileID(fmt.Sprintf("cc-%d", i))
+		if s.shardIndex(id) == 0 {
+			ids[got] = id
+			got++
+		}
+	}
+
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+
+	var wg sync.WaitGroup
+	perG := b.N / parallelism
+	for g := 0; g < parallelism; g++ {
+		wg.Add(1)
+		go func(id FileID) {
+			defer wg.Done()
+			for i := 0; i < perG; i++ {
+				if err := s.WriteAt(ctx, id, int64(i%256)*int64(len(data)), data); err != nil {
+					b.Errorf("WriteAt: %v", err)
+					return
+				}
+				if err := s.Commit(ctx, id); err != nil {
+					b.Errorf("Commit: %v", err)
+					return
+				}
+			}
+		}(ids[g])
+	}
+	wg.Wait()
+}
+
+func BenchmarkConcurrentCommit1(b *testing.B)   { benchConcurrentCommit(b, 1) }
+func BenchmarkConcurrentCommit32(b *testing.B)  { benchConcurrentCommit(b, 32) }
+func BenchmarkConcurrentCommit128(b *testing.B) { benchConcurrentCommit(b, 128) }

--- a/pkg/block/journal/groupcommit_durability_test.go
+++ b/pkg/block/journal/groupcommit_durability_test.go
@@ -1,0 +1,169 @@
+package journal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"sync/atomic"
+	"testing"
+)
+
+// The group-commit's entire durability guarantee rests on the leader's fsync
+// actually happening and covering the right bytes. The crash-recovery tests
+// reopen from the same tmpfiles, where the OS page cache serves the bytes
+// whether or not fsync ran — so they cannot tell a real fsync from a no-op.
+// These tests use the per-shard segSync seam to assert the fsync directly:
+// removing or breaking it makes them fail, which is what proves they aren't
+// hollow (see #1736 durability review).
+
+// sameShardIDs returns count FileIDs that all hash to shardIdx, so their commits
+// contend on one shard's fsync (the batching the tests need to exercise).
+func sameShardIDs(t *testing.T, s *Store, shardIdx uint64, count int) []FileID {
+	t.Helper()
+	var ids []FileID
+	for i := 0; len(ids) < count; i++ {
+		id := FileID(fmt.Sprintf("gc-%d", i))
+		if s.shardIndex(id) == shardIdx {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// TestGroupCommit_FsyncOnCommit proves a Commit actually issues an fsync. If the
+// group-commit ever stopped fsyncing (the failure the crash tests can't catch),
+// this fails.
+func TestGroupCommit_FsyncOnCommit(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+	sh := s.shardFor("f")
+
+	var syncs int32
+	sh.segSync = func(seg *segmentMeta) error {
+		atomic.AddInt32(&syncs, 1)
+		return seg.fd.Sync()
+	}
+
+	if err := s.WriteAt(ctx, "f", 0, []byte("x")); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.Commit(ctx, "f"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if atomic.LoadInt32(&syncs) == 0 {
+		t.Fatal("Commit did not fsync the segment — durability guarantee is hollow")
+	}
+}
+
+// TestGroupCommit_FsyncErrorPropagates proves a failed fsync surfaces to the
+// caller (leader path), and that the sticky error is scoped to the failed batch —
+// a later commit whose fsync succeeds returns nil.
+func TestGroupCommit_FsyncErrorPropagates(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+	sh := s.shardFor("f")
+
+	injected := errors.New("injected fsync EIO")
+	var fail atomic.Bool
+	fail.Store(true)
+	sh.segSync = func(seg *segmentMeta) error {
+		if fail.Load() {
+			return injected
+		}
+		return seg.fd.Sync()
+	}
+
+	if err := s.WriteAt(ctx, "f", 0, []byte("x")); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.Commit(ctx, "f"); err == nil {
+		t.Fatal("Commit must return an error when the fsync fails")
+	}
+
+	// Recover: a subsequent commit whose fsync succeeds must return nil — the
+	// sticky error watermark cannot poison later commits.
+	fail.Store(false)
+	if err := s.WriteAt(ctx, "f", 0, []byte("y")); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.Commit(ctx, "f"); err != nil {
+		t.Fatalf("commit after a recovered fsync should succeed, got %v", err)
+	}
+}
+
+// TestGroupCommit_ErrorReachesBatchedFollower is the regression test for the
+// review finding: a follower batched onto a leader's fsync must return that
+// fsync's error, and must NOT be able to read a later successful batch's nil.
+// It deterministically builds a 2-member batch whose fsync errors and asserts
+// BOTH the leader and the piggybacking follower fail.
+func TestGroupCommit_ErrorReachesBatchedFollower(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+	ids := sameShardIDs(t, s, 0, 3)
+	sh := s.shardFor(ids[0])
+
+	inSync := make(chan int)    // spy announces it entered (Nth call)
+	release := make(chan error) // test injects each call's result
+	var calls int32
+	sh.segSync = func(seg *segmentMeta) error {
+		inSync <- int(atomic.AddInt32(&calls, 1))
+		return <-release
+	}
+
+	for _, id := range ids {
+		if err := s.WriteAt(ctx, id, 0, []byte("x")); err != nil {
+			t.Fatalf("WriteAt: %v", err)
+		}
+	}
+
+	errC := make(chan error, 3)
+
+	// Leader L: its batch covers only itself; it blocks inside segSync.
+	go func() { errC <- s.Commit(ctx, ids[0]) }()
+	if n := <-inSync; n != 1 {
+		t.Fatalf("expected first sync call, got %d", n)
+	}
+
+	// F1, F2 enqueue as waiters while L holds the fsync. Wait until both have
+	// bumped reqSeq so the next batch is guaranteed to cover both of them.
+	go func() { errC <- s.Commit(ctx, ids[1]) }()
+	go func() { errC <- s.Commit(ctx, ids[2]) }()
+	waitReqSeq(sh, 3)
+
+	// Release L successfully; F1 then leads batch B (covers F1 + F2).
+	release <- nil
+	if err := <-errC; err != nil {
+		t.Fatalf("leader L should have succeeded, got %v", err)
+	}
+
+	// Batch B's fsync errors — both its leader and its batched follower must fail.
+	if n := <-inSync; n != 2 {
+		t.Fatalf("expected second sync call, got %d", n)
+	}
+	release <- errors.New("injected fsync EIO")
+
+	e1, e2 := <-errC, <-errC
+	if e1 == nil || e2 == nil {
+		t.Fatalf("a batched errored fsync must fail BOTH commits: e1=%v e2=%v", e1, e2)
+	}
+
+	// The failed watermark is scoped: a fresh commit with a healthy fsync succeeds.
+	sh.segSync = func(seg *segmentMeta) error { return seg.fd.Sync() }
+	if err := s.Commit(ctx, ids[0]); err != nil {
+		t.Fatalf("commit after the errored batch should succeed, got %v", err)
+	}
+}
+
+// waitReqSeq spins until the shard has enqueued at least target commits.
+func waitReqSeq(sh *shard, target uint64) {
+	for {
+		sh.commitMu.Lock()
+		r := sh.reqSeq
+		sh.commitMu.Unlock()
+		if r >= target {
+			return
+		}
+		runtime.Gosched()
+	}
+}

--- a/pkg/block/journal/index.go
+++ b/pkg/block/journal/index.go
@@ -123,6 +123,37 @@ func (fi *fileIndex) insert(iv interval) (dirtyRemoved, dirtyAdded int64, dead [
 	// across the non-overlapping sorted set, so the predicate is monotone.
 	lo := sort.Search(len(fi.ivs), func(k int) bool { return fi.ivs[k].end() > ns })
 
+	// Fast paths for the two overwhelmingly common write shapes, avoiding the
+	// three per-insert slice allocations (newFrags, survivors, merged) and the
+	// sort.Slice the general punch-and-merge path below pays. These dominate a
+	// random-4K workload: the fill phase is all gap insertions, the steady state
+	// all exact-offset overwrites (#1736).
+	switch {
+	case lo == len(fi.ivs) || fi.ivs[lo].fileOff >= ne:
+		// (a) Gap insertion: [ns, ne) overlaps nothing (the search guarantees the
+		// left neighbour ends at or before ns; the right neighbour starts at or
+		// after ne). A single shift, no allocation, no sort. Supersedes nothing.
+		fi.ivs = slices.Insert(fi.ivs, lo, iv)
+		return 0, 0, nil
+	case fi.ivs[lo].fileOff == ns && fi.ivs[lo].end() == ne &&
+		(lo+1 == len(fi.ivs) || fi.ivs[lo+1].fileOff >= ne):
+		// (b) Exact-range overwrite: iv replaces exactly one existing interval and
+		// overlaps no other. Newer wins in place (zero shift); an older/equal
+		// version (a recovery replay landing under a newer record) is shadowed.
+		e := fi.ivs[lo]
+		if iv.version <= e.version {
+			return 0, 0, nil // iv shadowed: keep the existing interval
+		}
+		if !e.cold {
+			dead = []segDead{{seg: e.loc.SegmentID, bytes: e.length}}
+			if !e.synced {
+				dirtyRemoved = e.length
+			}
+		}
+		fi.ivs[lo] = iv
+		return dirtyRemoved, 0, dead
+	}
+
 	newFrags := []interval{iv}
 	var survivors []interval
 	ivShadowed := false

--- a/pkg/block/journal/randwrite_bench_test.go
+++ b/pkg/block/journal/randwrite_bench_test.go
@@ -1,0 +1,110 @@
+package journal
+
+import (
+	"context"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// diskBytesOnDisk sums the on-disk size of every .seg file under the store dir.
+// It is the write-amplification numerator: total bytes the store persisted
+// (headers + fileIDs + payloads + CRCs), against the payload bytes the caller
+// asked to write.
+func diskBytesOnDisk(b *testing.B, dir string) int64 {
+	b.Helper()
+	var total int64
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		b.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) != segSuffix {
+			continue
+		}
+		fi, err := e.Info()
+		if err != nil {
+			b.Fatalf("Info: %v", err)
+		}
+		total += fi.Size()
+	}
+	return total
+}
+
+// benchWrites drives b.N 4 KiB writes into a single file, picking each offset
+// from offsets[i%len] — a random-shuffled slice for the random case, a strictly
+// increasing slice for the sequential case. Same syscall count and same payload
+// per op in both; the ONLY difference is where each write lands in the file, so
+// any gap between the two isolates the offset-dependent cost (index insertion
+// position). Reports ns/op plus segments and write-amp as custom metrics.
+func benchWrites(b *testing.B, offsets []int64) {
+	dir := b.TempDir()
+	s, err := Open(dir, Config{}, newFakeRemote(), SystemClock())
+	if err != nil {
+		b.Fatalf("Open: %v", err)
+	}
+	b.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+	data := make([]byte, 4<<10)
+
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := s.WriteAt(ctx, "f", offsets[i%len(offsets)], data); err != nil {
+			b.Fatalf("WriteAt: %v", err)
+		}
+	}
+	b.StopTimer()
+
+	disk := diskBytesOnDisk(b, dir)
+	st := s.Stats()
+	b.ReportMetric(float64(st.Segments), "segments")
+	b.ReportMetric(float64(disk)/float64(int64(b.N)*int64(len(data))), "write-amp")
+	b.ReportMetric(float64(len(s.shardFor("f").index["f"].ivs)), "intervals")
+}
+
+const randSpan = 1 << 20 // 1 Mi distinct 4 KiB slots => a 4 GiB address space
+
+// BenchmarkRandWrite4K writes 4 KiB records at pseudo-random distinct offsets:
+// each op inserts into the MIDDLE of the file's sorted interval index.
+func BenchmarkRandWrite4K(b *testing.B) {
+	offs := make([]int64, randSpan)
+	for i := range offs {
+		offs[i] = int64(i) * (4 << 10)
+	}
+	rng := rand.New(rand.NewSource(1))
+	rng.Shuffle(len(offs), func(i, j int) { offs[i], offs[j] = offs[j], offs[i] })
+	benchWrites(b, offs)
+}
+
+// BenchmarkRandWriteBounded models a real fio randwrite: 4 KiB writes at random
+// offsets within a FIXED-size file, so the index fills to fileBlocks intervals
+// and then every further write is an in-place overwrite (the steady state). This
+// is the rig-representative shape — bounded index, mixed fill+overwrite — where
+// the per-insert allocation/sort overhead (not the extreme-N memmove) dominates.
+func BenchmarkRandWriteBounded(b *testing.B) {
+	const fileBlocks = 4096 // 16 MiB working set => a rig-like interval count
+	offs := make([]int64, fileBlocks)
+	for i := range offs {
+		offs[i] = int64(i) * (4 << 10)
+	}
+	rng := rand.New(rand.NewSource(1))
+	rng.Shuffle(len(offs), func(i, j int) { offs[i], offs[j] = offs[j], offs[i] })
+	seq := make([]int64, b.N)
+	for i := range seq {
+		seq[i] = offs[rng.Intn(len(offs))]
+	}
+	benchWrites(b, seq)
+}
+
+// BenchmarkSeqWrite4K writes 4 KiB records at strictly increasing offsets:
+// each op appends to the END of the sorted interval index. Same everything else
+// as BenchmarkRandWrite4K — the control.
+func BenchmarkSeqWrite4K(b *testing.B) {
+	offs := make([]int64, randSpan)
+	for i := range offs {
+		offs[i] = int64(i) * (4 << 10)
+	}
+	benchWrites(b, offs)
+}

--- a/pkg/block/journal/shard.go
+++ b/pkg/block/journal/shard.go
@@ -34,14 +34,31 @@ type shard struct {
 	// distinct from mu, which serializes appends and index mutation — carve holds
 	// carveMu across its whole pass but only grabs mu briefly to snapshot and flip.
 	carveMu sync.Mutex
+
+	// Group-commit state (all under commitMu). Coalesces the burst of concurrent
+	// Commits a high-iodepth durable-write workload issues (fio rand-write-4k runs
+	// iodepth=32 × numjobs=4) into a single fsync: one leader fsyncs the shard's
+	// active fd — which flushes every byte written to it so far — and satisfies
+	// every commit that enqueued before the leader started. Segment rotation is
+	// itself a durability point (sealInPlace fsyncs the sealed segment), so a
+	// commit whose bytes moved to a now-sealed segment is durable regardless of
+	// which fd the leader synced. See Store.Commit (#1736).
+	commitMu   sync.Mutex
+	commitCond *sync.Cond
+	reqSeq     uint64 // commits enqueued so far (monotonic)
+	doneSeq    uint64 // commits made durable by a completed fsync (monotonic)
+	syncing    bool   // a leader is mid-fsync
+	syncErr    error  // error from the most recent completed fsync batch
 }
 
 func newShard(active *segmentMeta) *shard {
-	return &shard{
+	sh := &shard{
 		active: active,
 		sealed: make(map[uint64]*segmentMeta),
 		index:  make(map[FileID]*fileIndex),
 	}
+	sh.commitCond = sync.NewCond(&sh.commitMu)
+	return sh
 }
 
 // segment returns the segment with the given ID, active or sealed, or nil.

--- a/pkg/block/journal/shard.go
+++ b/pkg/block/journal/shard.go
@@ -46,16 +46,31 @@ type shard struct {
 	commitMu   sync.Mutex
 	commitCond *sync.Cond
 	reqSeq     uint64 // commits enqueued so far (monotonic)
-	doneSeq    uint64 // commits made durable by a completed fsync (monotonic)
+	doneSeq    uint64 // commits released by a completed fsync, any outcome (monotonic)
 	syncing    bool   // a leader is mid-fsync
-	syncErr    error  // error from the most recent completed fsync batch
+	// errSeq is the highest batchUpTo whose fsync ERRORED; syncErr is that error.
+	// Both are sticky — never cleared by a later successful batch — so a waiter
+	// covered by an errored batch (its gen < errSeq) always reads the failure
+	// instead of a newer batch's nil. Under Linux fsync-error semantics a post-error
+	// fsync can report success for pages the kernel already dropped, so a false
+	// "success" would be silent data loss; that is the direction we must never take.
+	// The cost is a rare, benign spurious error to a waiter a later success actually
+	// covered (safe direction). See groupCommit (#1736).
+	errSeq  uint64
+	syncErr error
+	// segSync fsyncs a segment's backing file. Per-shard indirection so durability
+	// tests can substitute a spy that counts syncs and can be forced to fail — the
+	// group-commit's whole guarantee rests on this call, so it needs a seam a test
+	// can neutralize. Production uses the real (*os.File).Sync via seg.fd.
+	segSync func(*segmentMeta) error
 }
 
 func newShard(active *segmentMeta) *shard {
 	sh := &shard{
-		active: active,
-		sealed: make(map[uint64]*segmentMeta),
-		index:  make(map[FileID]*fileIndex),
+		active:  active,
+		sealed:  make(map[uint64]*segmentMeta),
+		index:   make(map[FileID]*fileIndex),
+		segSync: func(seg *segmentMeta) error { return seg.fd.Sync() },
 	}
 	sh.commitCond = sync.NewCond(&sh.commitMu)
 	return sh

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -310,9 +310,14 @@ func (sh *shard) groupCommit() error {
 	sh.reqSeq++
 	for {
 		// A fsync that started after this caller enqueued (so after its write
-		// completed) has finished and covered it.
+		// completed) has finished and covered it. Return that batch's outcome:
+		// the error is sticky per errSeq, so a covered waiter can never read a
+		// later batch's nil in place of its own batch's failure (fsyncgate).
 		if sh.doneSeq > myGen {
-			err := sh.syncErr
+			var err error
+			if myGen < sh.errSeq {
+				err = sh.syncErr
+			}
 			sh.commitMu.Unlock()
 			return err
 		}
@@ -325,19 +330,22 @@ func (sh *shard) groupCommit() error {
 	batchUpTo := sh.reqSeq // every commit enqueued so far rides this fsync
 	sh.commitMu.Unlock()
 
-	// Grab the current active fd fresh: if it rotated while we waited, the old fd
-	// was already fsynced by sealInPlace, so fsyncing the new one still leaves the
-	// whole batch durable.
+	// Grab the current active segment fresh: if it rotated while we waited, the old
+	// fd was already fsynced by sealInPlace, so fsyncing the new one still leaves
+	// the whole batch durable.
 	sh.mu.Lock()
-	fd := sh.active.fd
+	seg := sh.active
 	sh.mu.Unlock()
-	err := fd.Sync()
+	err := sh.segSync(seg)
 
 	sh.commitMu.Lock()
 	if err != nil {
 		err = fmt.Errorf("journal: commit fsync: %w", err)
+		// Sticky: mark every commit in this batch as failed so covered waiters
+		// (gen < batchUpTo) read the failure even after a later batch succeeds.
+		sh.errSeq = batchUpTo
+		sh.syncErr = err
 	}
-	sh.syncErr = err
 	sh.doneSeq = batchUpTo
 	sh.syncing = false
 	sh.commitCond.Broadcast()

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -291,16 +291,58 @@ func (s *Store) Commit(ctx context.Context, id FileID) error {
 		return errClosed
 	}
 	sh := s.shardFor(id)
+	return sh.groupCommit()
+}
+
+// groupCommit fsyncs the shard so every write buffered so far is durable, but
+// coalesces concurrent callers: the first to arrive leads and issues one fsync
+// of the active fd (which flushes all its dirty bytes); everyone who enqueued
+// before that fsync started piggybacks on its result instead of issuing their
+// own barrier. Correctness rests on two durability points — a completed active-fd
+// fsync, and segment rotation (sealInPlace fsyncs the segment it seals) — so a
+// caller whose bytes are on a since-sealed segment is durable no matter which fd
+// the leader synced. This is the per-shard sync-leader the fio rand-write-4k
+// burst (iodepth=32 × numjobs=4) needs; without it every one of ~128 in-flight
+// commits pays a full disk barrier (#1736).
+func (sh *shard) groupCommit() error {
+	sh.commitMu.Lock()
+	myGen := sh.reqSeq
+	sh.reqSeq++
+	for {
+		// A fsync that started after this caller enqueued (so after its write
+		// completed) has finished and covered it.
+		if sh.doneSeq > myGen {
+			err := sh.syncErr
+			sh.commitMu.Unlock()
+			return err
+		}
+		if !sh.syncing {
+			break // become the leader for this batch
+		}
+		sh.commitCond.Wait()
+	}
+	sh.syncing = true
+	batchUpTo := sh.reqSeq // every commit enqueued so far rides this fsync
+	sh.commitMu.Unlock()
+
+	// Grab the current active fd fresh: if it rotated while we waited, the old fd
+	// was already fsynced by sealInPlace, so fsyncing the new one still leaves the
+	// whole batch durable.
 	sh.mu.Lock()
 	fd := sh.active.fd
 	sh.mu.Unlock()
-	// ponytail: direct per-shard fsync. syncLeader coalescing (fs/sync_leader.go)
-	// is a throughput optimization for concurrent commits on one shard, not a
-	// correctness requirement; port it here if commit contention shows up.
-	if err := fd.Sync(); err != nil {
-		return fmt.Errorf("journal: commit fsync: %w", err)
+	err := fd.Sync()
+
+	sh.commitMu.Lock()
+	if err != nil {
+		err = fmt.Errorf("journal: commit fsync: %w", err)
 	}
-	return nil
+	sh.syncErr = err
+	sh.doneSeq = batchUpTo
+	sh.syncing = false
+	sh.commitCond.Broadcast()
+	sh.commitMu.Unlock()
+	return err
 }
 
 // UnsyncedBytes reports dirty bytes not yet carved to the remote store. The


### PR DESCRIPTION
Fixes the random-4K-write regression the journal switchover (#1716) introduced (−45% badger / −24% sqlite vs the old logblob store).

## Root cause
`rand-write-4k.fio` is `direct=1, iodepth=32, numjobs=4` → up to 128 concurrent 4K writes, each fsynced on the server. The journal's `Commit` did a direct per-shard `fd.Sync()` with **no coalescing** — the old fs store's sync-leader group-commit was not ported at #1716 (a code comment flagged it). So ~128 in-flight commits each paid a full disk barrier. (The issue's stated hypothesis — index `fileIndex.insert` fragmentation — was refuted: the O(n) memmove only bites past ~256 distinct intervals; the rig's medium case is a 1 MiB file = 256 blocks, write-amp 1.008.)

## Fix
1. **`a6253bda` — group-commit fsync (primary).** Per-shard sync-leader: one leader fsyncs the active fd (flushing all its dirty bytes) and satisfies every commit that enqueued before the fsync started; durability also anchored by segment-rotation fsync (`sealInPlace`). Before→after per-op commit latency: depth-32 **2.76→0.41 ms (6.6×)**, depth-128 **1.93→0.16 ms (12.4×)**, single-thread unchanged. This is **block-store** fsync group-commit (restoring the prior fs-store mechanism) — distinct from the refuted metadata-badger `db.Sync` group-commit.
2. **`66182fb1` — index alloc-free fast paths** for the gap-insert / exact-overwrite shapes random-4K produces (3 allocs/138 B → 1 alloc/50 B per write). Semantics identical.
3. **`896cb9de` — durability review fixes.** An adversarial review found (a) `syncErr` was a single shared field: a follower batched onto a leader whose fsync errored could wake after a later successful batch and read its nil, acking non-durable data (Linux fsync-error-once semantics) → fixed by making the error **sticky per `errSeq`** so a covered waiter always reads its batch's failure; (b) the crash-recovery tests reopen from the same tmpfiles where the page cache serves bytes regardless of fsync, so they **could not tell a real fsync from a no-op** → added a per-shard `segSync` seam + durability tests that assert the fsync happens and that its error reaches both the leader and a batched follower. **Neutralizing the fsync makes the new test fail (verified)** — proving it is not hollow.

## Verification
- `go build ./...`, `go vet`, `gofmt`, `golangci-lint` — clean.
- `go test ./pkg/block/... -race` → 869 pass; journal suite 73 pass `-race`; new group-commit tests 60/60 across `-count=20 -race` (no flakes).
- `go test ./pkg/controlplane/runtime/... -run 'Commit|Flush|Durab|Relaxed|Snapshot'` → 82 pass.
- Single-thread commit + sequential write unchanged (no regression).

Closes #1736.