### PR TITLE
perf(metadata): dedup parent-inode reads in the create path (#1737)

### DIFF
--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -647,10 +647,32 @@ func (s *Service) CheckParentCreateAccess(ctx *AuthContext, parentHandle FileHan
 		return err
 	}
 
+	return s.CheckParentCreateAccessFile(ctx, parentHandle, file, isDirectory)
+}
+
+// CheckParentCreateAccessFile is CheckParentCreateAccess on an already-loaded
+// parent directory: it runs the identical create-permission evaluation without
+// re-reading the parent inode via store.GetFile. A caller that already holds the
+// parent File — e.g. createEntry, which loads it once to validate the directory
+// type — passes it here so a single CreateFile no longer loads the same parent
+// handle three times (#1737). The no-ACL path routes through the file-passing
+// checkWritePermissionFile so it too avoids a re-fetch. Semantics are
+// byte-for-byte those of CheckParentCreateAccess (same NFSv4 ADD_FILE vs
+// ADD_SUBDIRECTORY mask, same read-only ordering); only the redundant reads go.
+func (s *Service) CheckParentCreateAccessFile(ctx *AuthContext, parentHandle FileHandle, file *File, isDirectory bool) error {
+	store, err := s.storeForHandle(parentHandle)
+	if err != nil {
+		return err
+	}
+	if err := ctx.Context.Err(); err != nil {
+		return err
+	}
+
 	// Without an ACL there's nothing to refine — fall back to the generic
-	// POSIX-write check so mode bits / share-level grants apply uniformly.
+	// POSIX-write check so mode bits / share-level grants apply uniformly. Reuse
+	// the already-loaded parent so the write check does not re-fetch the inode.
 	if file.ACL == nil {
-		return s.checkWritePermission(ctx, parentHandle)
+		return s.checkWritePermissionFile(ctx, parentHandle, file)
 	}
 
 	shareOpts, _ := store.GetShareOptions(ctx.Context, file.ShareName)

--- a/pkg/metadata/file_create.go
+++ b/pkg/metadata/file_create.go
@@ -227,7 +227,7 @@ func (s *Service) createEntry(
 	// child being created (ADD_FILE vs ADD_SUBDIRECTORY) so a DACL that
 	// denies only one variant does not also block the other — required by
 	// MS-FSA 2.1.5.1.1 and smbtorture smb2.create.mkdir-visible.
-	if err := s.CheckParentCreateAccess(ctx, parentHandle, fileType == FileTypeDirectory); err != nil {
+	if err := s.CheckParentCreateAccessFile(ctx, parentHandle, parent, fileType == FileTypeDirectory); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/metadata/file_create_dedup_test.go
+++ b/pkg/metadata/file_create_dedup_test.go
@@ -1,0 +1,146 @@
+package metadata_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+	"github.com/stretchr/testify/require"
+)
+
+// countingStore wraps the memory store and counts GetFile calls, keyed by the
+// requested handle. It embeds *memory.MemoryMetadataStore so it satisfies the
+// full metadata.Store interface while overriding only GetFile — the Service
+// holds it via the Store interface (RegisterStoreForShare), so the override is
+// actually dispatched. Note: it observes store.GetFile only; parent reads that
+// went through tx.GetFile inside a transaction would not be counted here. The
+// create path deliberately does not read the parent inode inside its
+// transaction (#1573), so every parent read is a store.GetFile and is caught.
+type countingStore struct {
+	*memory.MemoryMetadataStore
+	total  atomic.Int64
+	perKey map[string]int64 // guarded by seq: create path is single-goroutine
+}
+
+func (c *countingStore) GetFile(ctx context.Context, h metadata.FileHandle) (*metadata.File, error) {
+	c.total.Add(1)
+	c.perKey[string(h)]++
+	return c.MemoryMetadataStore.GetFile(ctx, h)
+}
+
+// TestCreateFile_ParentGetFileDedup pins the parent-inode read dedup (#1737):
+// a single CreateFile must load the parent handle exactly once, not three times.
+func TestCreateFile_ParentGetFileDedup(t *testing.T) {
+	t.Parallel()
+
+	inner := memory.NewMemoryMetadataStoreWithDefaults()
+	ctx := context.Background()
+	shareName := "/test"
+
+	rootFile, err := inner.CreateRootDirectory(ctx, shareName, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory,
+		Mode: 0o777,
+		UID:  0,
+		GID:  0,
+	})
+	require.NoError(t, err)
+	rootHandle, err := metadata.EncodeShareHandle(shareName, rootFile.ID)
+	require.NoError(t, err)
+
+	cs := &countingStore{MemoryMetadataStore: inner, perKey: make(map[string]int64)}
+	svc := metadata.New()
+	require.NoError(t, svc.RegisterStoreForShare(shareName, cs))
+
+	rootCtx := &metadata.AuthContext{
+		Context:    ctx,
+		AuthMethod: "unix",
+		Identity: &metadata.Identity{
+			UID:  metadata.Uint32Ptr(0),
+			GID:  metadata.Uint32Ptr(0),
+			GIDs: []uint32{0},
+		},
+		ClientAddr: "127.0.0.1",
+	}
+
+	// A real subdirectory to create children into.
+	dir, _, err := svc.CreateDirectory(rootCtx, rootHandle, "sub", &metadata.FileAttr{Mode: 0o777})
+	require.NoError(t, err)
+	dirHandle, err := metadata.EncodeShareHandle(shareName, dir.ID)
+	require.NoError(t, err)
+
+	// Reset counters; measure exactly one CreateFile into the subdirectory.
+	cs.total.Store(0)
+	cs.perKey = make(map[string]int64)
+
+	_, _, err = svc.CreateFile(rootCtx, dirHandle, "child.txt", &metadata.FileAttr{Mode: 0o644})
+	require.NoError(t, err)
+
+	parentReads := cs.perKey[string(dirHandle)]
+	t.Logf("CreateFile: total GetFile=%d, parent GetFile=%d", cs.total.Load(), parentReads)
+
+	// After the dedup the parent inode is loaded exactly once. Before #1737 it
+	// was loaded three times (createEntry + CheckParentCreateAccess +
+	// checkWritePermission). Guard against silent regression.
+	require.Equal(t, int64(1), parentReads,
+		"parent inode must be loaded exactly once per CreateFile (was 3 before #1737)")
+}
+
+// BenchmarkCreateFile creates children in one directory via the fixture,
+// reporting ns/op and allocs/op as a secondary before/after signal.
+func BenchmarkCreateFile(b *testing.B) {
+	inner := memory.NewMemoryMetadataStoreWithDefaults()
+	ctx := context.Background()
+	shareName := "/test"
+
+	rootFile, err := inner.CreateRootDirectory(ctx, shareName, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory,
+		Mode: 0o777,
+	})
+	require.NoError(b, err)
+	rootHandle, err := metadata.EncodeShareHandle(shareName, rootFile.ID)
+	require.NoError(b, err)
+
+	svc := metadata.New()
+	require.NoError(b, svc.RegisterStoreForShare(shareName, inner))
+
+	rootCtx := &metadata.AuthContext{
+		Context:    ctx,
+		AuthMethod: "unix",
+		Identity: &metadata.Identity{
+			UID:  metadata.Uint32Ptr(0),
+			GID:  metadata.Uint32Ptr(0),
+			GIDs: []uint32{0},
+		},
+		ClientAddr: "127.0.0.1",
+	}
+	dir, _, err := svc.CreateDirectory(rootCtx, rootHandle, "bench", &metadata.FileAttr{Mode: 0o777})
+	require.NoError(b, err)
+	dirHandle, err := metadata.EncodeShareHandle(shareName, dir.ID)
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		name := "f" + itoa(i)
+		if _, _, err := svc.CreateFile(rootCtx, dirHandle, name, &metadata.FileAttr{Mode: 0o644}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// itoa is a tiny allocation-light int->string for unique bench names.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}


### PR DESCRIPTION
## What

A single `Service.CreateFile` loaded the **same parent-directory handle three times** via `store.GetFile`:

1. `createEntry` — validate the parent is a directory (`parent.Type`, `parent.Path`, `parent.ShareName`)
2. `CheckParentCreateAccess` — re-load to inspect the parent ACL
3. its write-permission fan-out (`checkWritePermission` → `checkFilePermissions`) — re-load again

`createEntry` already holds the loaded `parent` at the first read. This threads it through a new `CheckParentCreateAccessFile(ctx, parentHandle, parent, isDirectory)` variant (the no-ACL path now routes through the already-existing file-passing `checkWritePermissionFile`), so the parent is read once. `CheckParentCreateAccess(handle, …)` stays as a thin wrapper that loads then delegates, so other callers are untouched.

## Measurement (gate)

A deterministic GetFile-counting test (`countingStore` embedding the memory store, registered via the `Store` interface so the override dispatches) creates one child into a subdirectory and counts reads of that parent handle:

| | parent `GetFile` / create | total `GetFile` / create |
|---|---|---|
| before | **3** | 3 |
| after | **1** | 1 |

`BenchmarkCreateFile` (memory store, `-count=5`, best-of):

| | ns/op | allocs/op |
|---|---|---|
| before | 160999 | **129** |
| after | 158024 | **122** |

allocs/op drops by 7. Timing is within memory-store noise — in the memory store `GetFile` is a cheap map hit, so wall-time barely moves; the payoff lands on real backends (Badger/SQLite/Postgres) where each avoided `GetFile` is a DB read + `derivePath` + JSON decode.

## Semantics unchanged

The NFSv4 create-mask logic (ADD_FILE vs ADD_SUBDIRECTORY per MS-FSA 2.1.5.1.1 / smbtorture `smb2.create.mkdir-visible`), the read-only ordering, and the `GetShareOptions`/ACL evaluation are byte-for-byte identical — only *how many times* the parent is loaded changed. Full `pkg/metadata` permission suite (`auth_permissions_parent_check`, `_file_access`, `_maximal_access`, mkdir-visible, ACL-deny) passes with `-race`; `go vet` and `golangci-lint` clean.

Closes #1737