### PR TITLE
perf(nfs): route mutation handlers through the auth cache (#1735)

### DIFF
--- a/internal/adapter/nfs/v3/handlers/doc.go
+++ b/internal/adapter/nfs/v3/handlers/doc.go
@@ -248,7 +248,7 @@ func (h *Handler) getFileOrError(
 
 // buildAuthContextWithWCCError builds an auth context or returns WCC error data.
 // This helper consolidates the common pattern in mutation handlers of:
-//  1. Calling BuildAuthContextWithMapping
+//  1. Resolving the auth context via the cache (GetCachedAuthContext)
 //  2. Checking for context cancellation
 //  3. Logging appropriate error messages
 //  4. Constructing WCC after attributes for error responses

--- a/internal/adapter/nfs/v3/handlers/doc.go
+++ b/internal/adapter/nfs/v3/handlers/doc.go
@@ -276,7 +276,12 @@ func (h *Handler) buildAuthContextWithWCCError(
 ) (*metadata.AuthContext, *types.NFSFileAttr, uint32, error) {
 	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
-	authCtx, err := BuildAuthContextWithMapping(ctx, h.Registry, ctx.Share)
+	// Route through the resolved-permission cache (shared with the READ family):
+	// mutation handlers were resolving share permission against the control-plane
+	// store on every op (GetShare + GetUserByUID), the CREATE-path serialization
+	// wall (#1735). The cache is keyed Share+AuthFlavor+uid+gid+GIDs and cleared
+	// via ClearAuthCache on any share/identity change, so policy stays correct.
+	authCtx, err := h.GetCachedAuthContext(ctx)
 	if err != nil {
 		// Check if the error is due to context cancellation
 		if ctx.Context.Err() != nil {


### PR DESCRIPTION
## What

Redirect the NFS mutation handlers (CREATE/MKDIR/MKNOD/REMOVE/RMDIR/RENAME/SETATTR/SYMLINK) through the resolved-permission auth cache the READ family already uses.

## Why

Linux `pprof` (#1735) localized the CREATE wall: it is **not fsync** (CREATE issues 0 inline fsyncs) and **not the NFS adapter** (XDR decode ~0.6%). It is per-op GORM SQL against the control-plane store — `ResolveSharePermission` runs `GetShare` (7-preload) + `GetUserByUID` on **every** mutation op, serialized on the control-plane SQLite. Throughput plateaus at ~380 creates/s from 2 threads up while dfs uses <22% of one core — a single-writer serialization wall, not CPU/round-trip.

All eight mutation handlers funnel through `buildAuthContextWithWCCError`, which called `BuildAuthContextWithMapping` directly, bypassing the cache. The READ handlers already go through `GetCachedAuthContext`. This wires the mutation path into that same seam — one call-site redirect.

## Safety

No durability/contract change (CREATE writes no fsync, no data-paired state). The cache is:
- keyed `Share + AuthFlavor + uid + gid + GIDs` (a squash/guest op can't collide with a privileged one),
- TTL-aged with the identity cache,
- cleared via `ClearAuthCache` on any share/identity/mapping change.

So permission decisions keep the **same correctness + staleness envelope the READ path already has**.

## Test

`go test ./internal/adapter/nfs/v3/handlers/` → 292 pass (create/mkdir/setattr etc. now drive the cached path). Cache mechanics (TTL, clear, fast/slow path) covered by existing `auth_cache_ttl_test.go` + `clear_auth_cache_test.go`.

## Proof measurement

`ResolveSharePermission` SQL per CREATE → **0 on cache hit**. CREATE ops/s validated on a Linux rig alongside the #1735 follow-up (CREATE read/decode-waste cleanup).

Part of #1692 metadata write-path plan (L1). Refs #1735.