### PR TITLE
bench(harness): metadata-first ordering + durability-tier logging (#1739)

### DIFF
--- a/internal/dfsbench/backend/backend.go
+++ b/internal/dfsbench/backend/backend.go
@@ -49,6 +49,14 @@ type Backend struct {
 	S3Backed bool
 	Support  map[Protocol]Support
 
+	// Tier states the effective durability tier the backend acks writes from, so
+	// the run log makes the apples-to-apples comparison auditable: a competitor
+	// acking from RAM would be the unfair inflation (#1739). The fair cohort is
+	// "durable-to-local + async S3 writeback" (DittoFS default == JuiceFS
+	// --writeback); the re-export layer's knfsd `sync` export keeps NFS/SMB on
+	// that same durable tier. Logged once per system after Setup.
+	Tier string
+
 	// Setup installs+starts the backend (idempotent); Mount exports it over
 	// proto and returns the client mount dir; Evict forces the next read
 	// cold-from-S3; Unmount/Teardown reverse Mount/Setup. Any may be nil while

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -138,6 +138,11 @@ func init() {
 		register(&Backend{
 			Name:     v.name,
 			S3Backed: true,
+			// Default durability tier: metadata + block writes are durable on local
+			// disk (badger fsync + fs block cache) before the op acks; the S3 upload
+			// is async writeback. No --require-durable-commit, so it is NOT per-op
+			// S3-synchronous — the same tier as JuiceFS --writeback.
+			Tier:     "durable-to-local (badger fsync + fs block cache) + async S3 writeback",
 			Support:  map[Protocol]Support{ProtoNFS3: Native, ProtoNFS4: Native, ProtoSMB3: Native},
 			Setup:    func(ctx context.Context, env BackendEnv) error { return dittofsSetup(ctx, env, kind) },
 			Mount:    dittofsMount,

--- a/internal/dfsbench/backend/fuse.go
+++ b/internal/dfsbench/backend/fuse.go
@@ -32,18 +32,22 @@ func init() {
 	// the local cache wholesale.
 	register(newSrcBackend(srcBackend{
 		name: "rclone", s3Backed: true, protos: all, srcDir: rcloneMnt,
+		tier:  "durable-to-local (vfs-cache-mode=writes) + async S3; knfsd sync export",
 		setup: rcloneSetup, teardown: fuseUnmount(rcloneMnt), remount: rcloneRemount,
 	}))
 	register(newSrcBackend(srcBackend{
 		name: "s3ql", s3Backed: true, protos: all, srcDir: s3qlMnt,
+		tier:  "durable-to-local cache + async S3; knfsd sync export",
 		setup: s3qlSetup, teardown: s3qlTeardown, remount: s3qlRemount,
 	}))
 	register(newSrcBackend(srcBackend{
 		name: "juicefs", s3Backed: true, protos: all, srcDir: juicefsMnt,
+		tier:  "durable-to-local (--writeback local cache) + async S3; knfsd sync export",
 		setup: juicefsSetup, teardown: juicefsTeardown, remount: juicefsRemount,
 	}))
 	register(newSrcBackend(srcBackend{
 		name: "s3fs", s3Backed: true, protos: all, srcDir: s3fsMnt,
+		tier:  "durable-on-close to S3 (no writeback); knfsd sync export",
 		setup: s3fsSetup, teardown: fuseUnmount(s3fsMnt), remount: s3fsRemount,
 	}))
 }

--- a/internal/dfsbench/backend/localdisk.go
+++ b/internal/dfsbench/backend/localdisk.go
@@ -7,6 +7,7 @@ package backend
 func init() {
 	register(newSrcBackend(srcBackend{
 		name:   "local-disk",
+		tier:   "durable-to-disk, no S3 (protocol-overhead ceiling); knfsd sync export",
 		protos: []Protocol{ProtoNFS3, ProtoNFS4, ProtoSMB3},
 		srcDir: "/srv/bench-local-disk",
 	}))

--- a/internal/dfsbench/backend/reexport.go
+++ b/internal/dfsbench/backend/reexport.go
@@ -152,6 +152,7 @@ func smbReexport(ctx context.Context, srcDir string) (string, error) {
 type srcBackend struct {
 	name     string
 	s3Backed bool
+	tier     string // effective durability tier, surfaced as Backend.Tier
 	protos   []Protocol
 	srcDir   string
 	setup    func(ctx context.Context, env BackendEnv) error // install + FUSE-mount at srcDir; nil = plain dir
@@ -170,6 +171,7 @@ func newSrcBackend(sb srcBackend) *Backend {
 	b := &Backend{
 		Name:     sb.name,
 		S3Backed: sb.s3Backed,
+		Tier:     sb.tier,
 		Support:  support,
 		Setup: func(ctx context.Context, env BackendEnv) error {
 			if sb.setup != nil {

--- a/internal/dfsbench/backend/zerofs.go
+++ b/internal/dfsbench/backend/zerofs.go
@@ -36,6 +36,13 @@ func init() {
 	register(&Backend{
 		Name:     "zerofs",
 		S3Backed: true,
+		// zerofs default (sync_writes=false): writes land in an in-memory memtable
+		// backed by a WAL, flushed to S3 every ~30s; an explicit fsync forces a seal
+		// + flush. So it is durable-on-fsync but buffered between fsyncs — the
+		// closest fair native comparator to DittoFS's local-durable tier, but not
+		// identical (seq-write's fsync_on_close makes its acks durable; a no-fsync
+		// create acks from RAM+WAL). Logged so the table's tier column is honest.
+		Tier: "memtable + WAL, periodic ~30s S3 flush (sync_writes=false); durable on fsync/close",
 		// Native NFSv3 only. nfs4/smb3 are NA (zerofs speaks neither) and auto-skip.
 		Support:  map[Protocol]Support{ProtoNFS3: Native},
 		Setup:    zerofsSetup,

--- a/internal/dfsbench/fio/workload.go
+++ b/internal/dfsbench/fio/workload.go
@@ -37,14 +37,22 @@ func SizeBytes(s string) int64 {
 // KnownWorkloads are the fio job files shipped in bench/workloads. Each maps to
 // <name>.fio. Kept as an explicit list (not a dir scan) so --workloads
 // selection and `list` have a stable, ordered set.
+//
+// metadata runs FIRST, before any write-heavy workload (#1739). The warm pass
+// runs every workload sequentially against one live server/mount, so if metadata
+// ran last it would measure creates while the block syncer is still draining the
+// GBs of async S3 backlog that seq-write/rand-write/mixed queued — IO-wait
+// contention that, on a full matrix's accumulated backlog, degrades the create
+// cell into a near-hang (the "8 ops in 240s" garbage). Measuring metadata on a
+// quiesced store isolates the metadata engine, which is what this cell is for.
 var KnownWorkloads = []string{
+	"metadata",
 	"seq-write",
 	"seq-write-buffered",
 	"seq-read",
 	"rand-write-4k",
 	"rand-read-4k",
 	"mixed-rw",
-	"metadata",
 }
 
 // SizeClasses map a friendly size name to the fio --size value. Explicit sizes

--- a/internal/dfsbench/run/managed.go
+++ b/internal/dfsbench/run/managed.go
@@ -116,6 +116,12 @@ func runPlan(ctx context.Context, p backend.Plan, env backend.BackendEnv, wls, s
 	if err := b.Setup(ctx, env); err != nil {
 		return fmt.Errorf("setup: %w", err)
 	}
+	// Log the effective durability tier so the run is auditable as apples-to-apples
+	// (#1739): every cell in the fair cohort must ack from the same tier, and a
+	// competitor acking from RAM is the unfair inflation this makes visible.
+	if b.Tier != "" {
+		_, _ = fmt.Fprintf(exec.CmdOut, "tier %s: %s\n", p.SystemLabel(), b.Tier)
+	}
 
 	mnt, err := b.Mount(ctx, p.Protocol)
 	if err != nil {


### PR DESCRIPTION
Fixes the two confounds that made the prior fair-bench matrix unusable (#1739).

## Root causes (diagnosed live)
1. **DittoFS `metadata` cell degenerate (8 ops/240s): matrix ordering, not a bug.** The managed warm pass runs all workloads sequentially against one live server; `metadata` ran **last** (`KnownWorkloads` order), after seq-write/rand-write dumped GBs to the local cache and queued a large async-S3 upload backlog. Create ops then fought the syncer for IO (41% iowait, fio threads in D-state). On a **quiesced** store: **481–514 create ops/s**. Fix: run `metadata` **first**.
2. **ZeroFS 0-cell: environmental, not a code defect.** Same matrix-ordering + cold-bucket LSM warmup + knfsd teardown timing. In the re-measure ZeroFS emitted all cells, 0 errors. No harness change needed.

## Changes
- `fio/workload.go`: `metadata` first in `KnownWorkloads` — measures the metadata engine on a quiesced store, not syncer contention.
- `Backend.Tier` + a one-line `tier <system>: <desc>` log after Setup — records each system's durability tier per run so RAM-ack competitors can't silently inflate throughput vs a durable subject (the apples-to-apples guard).

Observability + ordering only; does **not** touch measured numbers. `go test ./internal/dfsbench/...` → 39 pass.

## Fair table this produced (medium, NFSv3, warm, equal tier, 0 errors)
| system | create ops/s | seq-write MB/s |
|---|--:|--:|
| dittofs-s3 | 514 | 273 |
| juicefs (--writeback) | 1869 | 577 |
| zerofs | 1602 | 135 |

**seq-write gap collapses 24×→2.1× at equal durability, and DittoFS beats ZeroFS 2×.** Create remains ~3.6× behind JuiceFS (fsync/commit-bound, 8% CPU) — tracked in #1735 / #1747.