### PR TITLE
fix(metadata): discard pending write state on truncate and remove

### DIFF
--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -548,20 +548,35 @@ func (s *Service) SetFileAttributes(ctx *AuthContext, handle FileHandle, attrs *
 		// deliberately bypassed here in favor of withRelaxedTransaction to
 		// actually defer the write (#1573 Wall 1).
 		if attrs.Size != nil {
-			if err := store.WithTransaction(ctx.Context, func(tx Transaction) error {
+			// A truncate/grow makes the committed size authoritative and
+			// supersedes any buffered WRITE. Hold the per-handle flush lock
+			// across the durable size commit AND the discard so a concurrent
+			// FlushPendingWriteForFile cannot pop a stale MaxSize and re-grow the
+			// file between the two — silently undoing the truncate (#1753).
+			mu := s.pendingWrites.GetFlushLock(handle)
+			mu.Lock()
+			err := store.WithTransaction(ctx.Context, func(tx Transaction) error {
+				return tx.PutFile(ctx.Context, file)
+			})
+			if err == nil {
+				// Discard, don't flush: a buffered MaxSize would resurrect the
+				// pre-truncate size on the next flush.
+				s.pendingWrites.PopPending(handle)
+			}
+			mu.Unlock()
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			if err := withRelaxedTransaction(store, ctx.Context, func(tx Transaction) error {
 				return tx.PutFile(ctx.Context, file)
 			}); err != nil {
 				return nil, err
 			}
-		} else if err := withRelaxedTransaction(store, ctx.Context, func(tx Transaction) error {
-			return tx.PutFile(ctx.Context, file)
-		}); err != nil {
-			return nil, err
+			// Invalidate cached file in pending writes to ensure subsequent
+			// writes use fresh attributes (e.g., mode changes for SUID/SGID clearing)
+			s.pendingWrites.InvalidateCache(handle)
 		}
-
-		// Invalidate cached file in pending writes to ensure subsequent
-		// writes use fresh attributes (e.g., mode changes for SUID/SGID clearing)
-		s.pendingWrites.InvalidateCache(handle)
 	}
 
 	// An explicit directory-timestamp set supersedes any coalesced create/remove

--- a/pkg/metadata/file_remove.go
+++ b/pkg/metadata/file_remove.go
@@ -130,6 +130,21 @@ func (s *Service) RemoveFile(ctx *AuthContext, parentHandle FileHandle, name str
 	wcc.Before = CopyFileAttr(&parent.FileAttr)
 	now := time.Now()
 
+	// lastLink records whether this unlink removed the final name for the inode.
+	// When it did, any buffered WRITE state for the (still-open) file must be
+	// discarded so a later flush cannot resurrect its size/mtime on the removed
+	// inode (#1753). A hard-link decrement leaves the file — and its legitimate
+	// buffered size — intact, so it is left untouched.
+	var lastLink bool
+
+	// Serialize the remove + discard against a concurrent
+	// FlushPendingWriteForFile (e.g. an in-flight COMMIT on the same file):
+	// hold the per-handle flush lock across both so a popped stale MaxSize
+	// cannot be re-applied to the inode after we drop it (#1753).
+	flushMu := s.pendingWrites.GetFlushLock(fileHandle)
+	flushMu.Lock()
+	defer flushMu.Unlock()
+
 	// Execute the child-removing writes in a single transaction. Like create,
 	// this transaction does NOT touch the parent inode — the parent timestamp
 	// bump that used to serialize concurrent same-dir removes on a BadgerDB SSI
@@ -173,6 +188,7 @@ func (s *Service) RemoveFile(ctx *AuthContext, parentHandle FileHandle, name str
 			}
 		} else {
 			// Last link - set nlink=0 but keep metadata for POSIX compliance
+			lastLink = true
 			returnFile.Nlink = 0
 			returnFile.Ctime = now
 
@@ -198,6 +214,12 @@ func (s *Service) RemoveFile(ctx *AuthContext, parentHandle FileHandle, name str
 
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// The unlink is authoritative; drop any buffered WRITE state so a later
+	// flush cannot resurrect size/mtime for the removed file (#1753).
+	if lastLink {
+		s.pendingWrites.PopPending(fileHandle)
 	}
 
 	// Coalesce the parent directory timestamp bump (Mtime/Ctime/Atime per

--- a/pkg/metadata/pending_writes_resurrection_test.go
+++ b/pkg/metadata/pending_writes_resurrection_test.go
@@ -1,0 +1,73 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/stretchr/testify/require"
+)
+
+// recordPendingWrite issues a deferred WRITE that leaves a buffered MaxSize in
+// the pending-writes tracker WITHOUT committing it to the store, mirroring an
+// UNSTABLE NFS WRITE that has not yet been flushed by COMMIT.
+func recordPendingWrite(t *testing.T, fx *testFixture, handle metadata.FileHandle, size uint64) {
+	t.Helper()
+	intent, err := fx.service.PrepareWrite(fx.rootContext(), handle, size)
+	require.NoError(t, err)
+	_, err = fx.service.CommitWrite(fx.rootContext(), intent)
+	require.NoError(t, err)
+	got, ok := fx.service.GetPendingSize(handle)
+	require.True(t, ok, "expected buffered pending write")
+	require.Equal(t, size, got)
+}
+
+// TestTruncateDiscardsPendingWrite asserts a truncate-to-0 SETATTR that lands
+// after an unflushed WRITE cannot be undone by a later pending-write flush that
+// re-grows the file to the buffered MaxSize (#1753).
+func TestTruncateDiscardsPendingWrite(t *testing.T) {
+	fx := newTestFixture(t)
+
+	_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "trunc.txt", &metadata.FileAttr{Mode: 0644})
+	require.NoError(t, err)
+	handle, err := fx.store.GetChild(fx.rootContext().Context, fx.rootHandle, "trunc.txt")
+	require.NoError(t, err)
+
+	// A WRITE buffers MaxSize=4096 without flushing to the store.
+	recordPendingWrite(t, fx, handle, 4096)
+
+	// Truncate to 0 (size-changing SETATTR).
+	_, err = fx.service.SetFileAttributes(fx.rootContext(), handle, &metadata.SetAttrs{Size: metadata.Uint64Ptr(0)})
+	require.NoError(t, err)
+
+	// The buffered pending state must be gone after truncate.
+	_, ok := fx.service.GetPendingSize(handle)
+	require.False(t, ok, "truncate should have discarded pending write state")
+
+	// A flush must not resurrect the pre-truncate size.
+	_, err = fx.service.FlushPendingWriteForFile(fx.rootContext(), handle, true)
+	require.NoError(t, err)
+
+	file, err := fx.store.GetFile(fx.rootContext().Context, handle)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), file.Size, "truncated file must stay size 0, not resurrect to buffered MaxSize")
+}
+
+// TestRemoveFileDiscardsPendingWrite asserts RemoveFile drops buffered
+// pending-write state for the unlinked file so a later flush cannot apply a
+// stale size/mtime to the removed inode (#1753).
+func TestRemoveFileDiscardsPendingWrite(t *testing.T) {
+	fx := newTestFixture(t)
+
+	_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "gone.txt", &metadata.FileAttr{Mode: 0644})
+	require.NoError(t, err)
+	handle, err := fx.store.GetChild(fx.rootContext().Context, fx.rootHandle, "gone.txt")
+	require.NoError(t, err)
+
+	recordPendingWrite(t, fx, handle, 4096)
+
+	_, _, err = fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "gone.txt")
+	require.NoError(t, err)
+
+	_, ok := fx.service.GetPendingSize(handle)
+	require.False(t, ok, "RemoveFile should have discarded pending write state for the unlinked file")
+}


### PR DESCRIPTION
Fixes #1753.

## Problem
A size-changing SETATTR (truncate) and `RemoveFile` left stale pending-write state behind. `InvalidateCache` only cleared `CachedFile`, keeping `MaxSize`/`PreWriteAttr`. If a prior unflushed WRITE buffered `MaxSize = N`, a truncate-to-0 committed `Size=0` durably, but the next `flushPendingWrite` re-grew the file to `N` (`if state.MaxSize > file.Size { file.Size = state.MaxSize }`) — silently undoing the truncate. `RemoveFile` never touched `pendingWrites`, so a buffered size/mtime for a just-unlinked (still-open) file was applied by a later flush.

## Fix
Both paths now DISCARD the handle's buffered pending state (`PopPending`) once the authoritative size/namespace change is committed:
- Truncate holds the per-handle flush lock across the durable size commit and the discard, so a concurrent `FlushPendingWriteForFile` can't pop a stale `MaxSize` and re-grow the file between the two.
- `RemoveFile` discards only on last-link removal (a hard-link decrement leaves the file and its legitimate buffered size intact), guarded by the same per-handle flush lock. The recycle/trash path returns early and is unaffected.

## Tests
Adds `pending_writes_resurrection_test.go`:
1. WRITE (buffers MaxSize=4096) → truncate-to-0 → flush → asserts size stays 0.
2. WRITE (buffered) → RemoveFile → asserts no pending state remains.

`go test` + `go test -race ./pkg/metadata/...` (2631 pass), `go vet`, `golangci-lint` all clean.