### PR TITLE
perf(metadata): self-describing binary inode codec (JSON read-fallback)

### DIFF
--- a/pkg/metadata/store/badger/encoding.go
+++ b/pkg/metadata/store/badger/encoding.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/marmos91/dittofs/pkg/metadata"
@@ -32,7 +33,7 @@ import (
 //
 // Data Type             Prefix   Key Format                              Value Type
 // ==================================================================================
-// File Data             "f:"     f:<uuid>                               File (JSON)
+// File Data             "f:"     f:<uuid>                               File (binary; JSON read-fallback)
 // Parent Relationships  "p:"     p:<childUUID>                          parentUUID (bytes)
 // Children Map          "c:"     c:<parentUUID>:<childName>             childUUID (bytes)
 // Shares                "s:"     s:<shareName>                          shareData (JSON)
@@ -147,29 +148,307 @@ type shareData struct {
 // JSON Encoding/Decoding
 // ============================================================================
 
-func encodeFile(file *metadata.File) ([]byte, error) {
-	// Path is always derived from parent edges on read (#1166), never trusted
-	// from storage. Zero it before serializing so no badger row persists a
-	// stale/misleading path (e.g. the pre-move path on a rename). decodeFile
-	// tolerates the absent field; GetFile overwrites Path via derivePath.
-	if file.Path != "" {
-		clone := *file
-		clone.Path = ""
-		file = &clone
-	}
-	bytes, err := json.Marshal(file)
-	if err != nil {
-		return nil, fmt.Errorf("failed to encode file: %w", err)
-	}
-	return bytes, nil
+// ---------------------------------------------------------------------------
+// Inode (File) codec: self-describing length-prefixed binary, JSON read-fallback
+// ---------------------------------------------------------------------------
+//
+// New writes use a compact binary format; json.Unmarshal was ~13% of flat CPU
+// on the create/write hot path (an inode is decoded 4-5x per op), and it does
+// reflection + field-name scanning + map allocation that a hand-written codec
+// skips entirely (#1735).
+//
+// Format:
+//
+//	[0xD5 0xF5]  magic  (first byte != '{'/0x7b so the reader can tell binary
+//	                     records from legacy JSON ones)
+//	[0x01]       version
+//	repeated fields, each:
+//	  uvarint fieldID
+//	  uvarint length
+//	  length bytes of payload
+//
+// Self-describing / schema-evolution: every field is length-delimited and keyed
+// by a stable fieldID. A decoder skips fieldIDs it does not know, and leaves the
+// zero value for fieldIDs a record does not carry. So a new field is added by
+// appending a new fieldID constant and its encode/decode arm -- old records
+// (which lack it) still decode, and old binaries (which don't know it) skip it.
+// Never renumber or reuse a retired fieldID.
+//
+// Aggregates (ACL, EAs, Blocks) keep JSON as their payload so their exact
+// round-trip is inherited from the previous format, and they are only emitted
+// when non-empty -- on the hot create/write path (nil ACL, no EAs, no Blocks)
+// no JSON is touched at all.
+const (
+	fileMagic0  = 0xD5
+	fileMagic1  = 0xF5
+	fileVersion = 0x01
+)
+
+// File field IDs. Append-only; never reuse a number.
+const (
+	fID         = 1  // ID uuid.UUID (16 raw bytes)
+	fShareName  = 2  // string
+	fType       = 3  // FileType (uvarint)
+	fMode       = 4  // uint32 (uvarint)
+	fUID        = 5  // uint32 (uvarint)
+	fGID        = 6  // uint32 (uvarint)
+	fNlink      = 7  // uint32 (uvarint)
+	fSize       = 8  // uint64 (uvarint)
+	fAtime      = 9  // time.Time (MarshalBinary)
+	fMtime      = 10 // time.Time
+	fCtime      = 11 // time.Time
+	fCreation   = 12 // time.Time
+	fPayloadID  = 13 // string
+	fLinkTarget = 14 // string
+	fRdev       = 15 // uint64 (uvarint)
+	fHidden     = 16 // bool (1 byte)
+	fACL        = 17 // *acl.ACL (JSON)
+	fEAs        = 18 // map[string][]byte (JSON)
+	fIdempotenc = 19 // uint64 (uvarint)
+	fBlocks     = 20 // []block.ChunkRef (JSON)
+	fObjectID   = 21 // block.ObjectID (32 raw bytes)
+	fDeletedAt  = 22 // *time.Time (MarshalBinary)
+	fOrigPath   = 23 // string
+	fDeletedBy  = 24 // string
+	// Path (File.Path) is intentionally NOT encoded: it is derived from parent
+	// edges on read (#1166). BlocksDirty is transient (json:"-"), also not stored.
+)
+
+func putField(dst []byte, id uint64, val []byte) []byte {
+	dst = binary.AppendUvarint(dst, id)
+	dst = binary.AppendUvarint(dst, uint64(len(val)))
+	return append(dst, val...)
 }
 
-func decodeFile(bytes []byte) (*metadata.File, error) {
+func putUvarintField(dst []byte, id, v uint64) []byte {
+	return putField(dst, id, binary.AppendUvarint(nil, v))
+}
+
+func putStringField(dst []byte, id uint64, s string) []byte {
+	if s == "" {
+		return dst
+	}
+	return putField(dst, id, []byte(s))
+}
+
+func putTimeField(dst []byte, id uint64, t time.Time) ([]byte, error) {
+	if t.IsZero() {
+		return dst, nil
+	}
+	b, err := t.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	return putField(dst, id, b), nil
+}
+
+func putJSONField(dst []byte, id uint64, v any) ([]byte, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return putField(dst, id, b), nil
+}
+
+func encodeFile(file *metadata.File) ([]byte, error) {
+	a := &file.FileAttr
+	buf := make([]byte, 0, 256)
+	buf = append(buf, fileMagic0, fileMagic1, fileVersion)
+
+	idBytes := file.ID // uuid.UUID is [16]byte
+	buf = putField(buf, fID, idBytes[:])
+	buf = putStringField(buf, fShareName, file.ShareName)
+	// Path is derived on read (#1166); never stored.
+	buf = putUvarintField(buf, fType, uint64(a.Type))
+	buf = putUvarintField(buf, fMode, uint64(a.Mode))
+	buf = putUvarintField(buf, fUID, uint64(a.UID))
+	buf = putUvarintField(buf, fGID, uint64(a.GID))
+	buf = putUvarintField(buf, fNlink, uint64(a.Nlink))
+	buf = putUvarintField(buf, fSize, a.Size)
+
+	var err error
+	if buf, err = putTimeField(buf, fAtime, a.Atime); err != nil {
+		return nil, fmt.Errorf("encode atime: %w", err)
+	}
+	if buf, err = putTimeField(buf, fMtime, a.Mtime); err != nil {
+		return nil, fmt.Errorf("encode mtime: %w", err)
+	}
+	if buf, err = putTimeField(buf, fCtime, a.Ctime); err != nil {
+		return nil, fmt.Errorf("encode ctime: %w", err)
+	}
+	if buf, err = putTimeField(buf, fCreation, a.CreationTime); err != nil {
+		return nil, fmt.Errorf("encode creation time: %w", err)
+	}
+
+	buf = putStringField(buf, fPayloadID, string(a.PayloadID))
+	buf = putStringField(buf, fLinkTarget, a.LinkTarget)
+	buf = putUvarintField(buf, fRdev, a.Rdev)
+	if a.Hidden {
+		buf = putField(buf, fHidden, []byte{1})
+	}
+	if a.ACL != nil {
+		if buf, err = putJSONField(buf, fACL, a.ACL); err != nil {
+			return nil, fmt.Errorf("encode acl: %w", err)
+		}
+	}
+	if len(a.EAs) > 0 {
+		if buf, err = putJSONField(buf, fEAs, a.EAs); err != nil {
+			return nil, fmt.Errorf("encode eas: %w", err)
+		}
+	}
+	buf = putUvarintField(buf, fIdempotenc, a.IdempotencyToken)
+	if len(a.Blocks) > 0 {
+		if buf, err = putJSONField(buf, fBlocks, a.Blocks); err != nil {
+			return nil, fmt.Errorf("encode blocks: %w", err)
+		}
+	}
+	if !a.ObjectID.IsZero() {
+		oid := a.ObjectID // [32]byte
+		buf = putField(buf, fObjectID, oid[:])
+	}
+	if a.DeletedAt != nil {
+		if buf, err = putTimeField(buf, fDeletedAt, *a.DeletedAt); err != nil {
+			return nil, fmt.Errorf("encode deleted_at: %w", err)
+		}
+	}
+	buf = putStringField(buf, fOrigPath, a.OriginalPath)
+	buf = putStringField(buf, fDeletedBy, a.DeletedBy)
+	return buf, nil
+}
+
+// decodeFile dispatches on the first byte: legacy records are JSON (they start
+// with '{' == 0x7b), new records carry the binary magic (0xD5). The JSON arm is
+// a removable dual-read shim (modelled on the #1622 CAS->blocks read fallback):
+// once every store has been rewritten with binary records it can be deleted.
+func decodeFile(b []byte) (*metadata.File, error) {
+	if len(b) > 0 && b[0] == '{' {
+		return decodeFileJSON(b)
+	}
+	return decodeFileBinary(b)
+}
+
+// decodeFileJSON is the legacy read path. Removable once all badger stores hold
+// binary records (#1735 dual-read shim).
+func decodeFileJSON(b []byte) (*metadata.File, error) {
 	var file metadata.File
-	if err := json.Unmarshal(bytes, &file); err != nil {
-		return nil, fmt.Errorf("failed to decode file: %w", err)
+	if err := json.Unmarshal(b, &file); err != nil {
+		return nil, fmt.Errorf("failed to decode file (json): %w", err)
 	}
 	return &file, nil
+}
+
+func decodeFileBinary(b []byte) (*metadata.File, error) {
+	if len(b) < 3 || b[0] != fileMagic0 || b[1] != fileMagic1 {
+		return nil, fmt.Errorf("failed to decode file: bad binary header")
+	}
+	if b[2] != fileVersion {
+		return nil, fmt.Errorf("failed to decode file: unsupported version %d", b[2])
+	}
+	r := b[3:]
+	var file metadata.File
+	a := &file.FileAttr
+	for len(r) > 0 {
+		id, n := binary.Uvarint(r)
+		if n <= 0 {
+			return nil, fmt.Errorf("failed to decode file: bad field id")
+		}
+		r = r[n:]
+		l, n := binary.Uvarint(r)
+		if n <= 0 {
+			return nil, fmt.Errorf("failed to decode file: bad field length")
+		}
+		r = r[n:]
+		if uint64(len(r)) < l {
+			return nil, fmt.Errorf("failed to decode file: truncated field %d", id)
+		}
+		val := r[:l]
+		r = r[l:]
+
+		switch id {
+		case fID:
+			if len(val) != len(file.ID) {
+				return nil, fmt.Errorf("failed to decode file: bad id length %d", len(val))
+			}
+			copy(file.ID[:], val)
+		case fShareName:
+			file.ShareName = string(val)
+		case fType:
+			a.Type = metadata.FileType(uvOf(val))
+		case fMode:
+			a.Mode = uint32(uvOf(val))
+		case fUID:
+			a.UID = uint32(uvOf(val))
+		case fGID:
+			a.GID = uint32(uvOf(val))
+		case fNlink:
+			a.Nlink = uint32(uvOf(val))
+		case fSize:
+			a.Size = uvOf(val)
+		case fAtime:
+			if err := a.Atime.UnmarshalBinary(val); err != nil {
+				return nil, fmt.Errorf("decode atime: %w", err)
+			}
+		case fMtime:
+			if err := a.Mtime.UnmarshalBinary(val); err != nil {
+				return nil, fmt.Errorf("decode mtime: %w", err)
+			}
+		case fCtime:
+			if err := a.Ctime.UnmarshalBinary(val); err != nil {
+				return nil, fmt.Errorf("decode ctime: %w", err)
+			}
+		case fCreation:
+			if err := a.CreationTime.UnmarshalBinary(val); err != nil {
+				return nil, fmt.Errorf("decode creation time: %w", err)
+			}
+		case fPayloadID:
+			a.PayloadID = metadata.PayloadID(val)
+		case fLinkTarget:
+			a.LinkTarget = string(val)
+		case fRdev:
+			a.Rdev = uvOf(val)
+		case fHidden:
+			a.Hidden = len(val) > 0 && val[0] != 0
+		case fACL:
+			if err := json.Unmarshal(val, &a.ACL); err != nil {
+				return nil, fmt.Errorf("decode acl: %w", err)
+			}
+		case fEAs:
+			if err := json.Unmarshal(val, &a.EAs); err != nil {
+				return nil, fmt.Errorf("decode eas: %w", err)
+			}
+		case fIdempotenc:
+			a.IdempotencyToken = uvOf(val)
+		case fBlocks:
+			if err := json.Unmarshal(val, &a.Blocks); err != nil {
+				return nil, fmt.Errorf("decode blocks: %w", err)
+			}
+		case fObjectID:
+			if len(val) != len(a.ObjectID) {
+				return nil, fmt.Errorf("failed to decode file: bad object_id length %d", len(val))
+			}
+			copy(a.ObjectID[:], val)
+		case fDeletedAt:
+			var t time.Time
+			if err := t.UnmarshalBinary(val); err != nil {
+				return nil, fmt.Errorf("decode deleted_at: %w", err)
+			}
+			a.DeletedAt = &t
+		case fOrigPath:
+			a.OriginalPath = string(val)
+		case fDeletedBy:
+			a.DeletedBy = string(val)
+		default:
+			// Unknown field from a newer writer: skip it (already consumed).
+		}
+	}
+	return &file, nil
+}
+
+// uvOf decodes a uvarint payload; a malformed payload yields 0, which for the
+// scalar fields that use it is the correct zero value.
+func uvOf(b []byte) uint64 {
+	v, _ := binary.Uvarint(b)
+	return v
 }
 
 func encodeShareData(data *shareData) ([]byte, error) {

--- a/pkg/metadata/store/badger/encoding_bench_test.go
+++ b/pkg/metadata/store/badger/encoding_bench_test.go
@@ -1,6 +1,7 @@
 package badger
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -8,6 +9,82 @@ import (
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
+
+// hotFile is the shape of an inode on the create/write hot path: a plain regular
+// file with no ACL, no EAs, no Blocks yet. This is the record decoded 4-5x per
+// create+write op — the one #1735 targets.
+func hotFile() *metadata.File {
+	return &metadata.File{
+		ID:        uuid.New(),
+		ShareName: "/bench",
+		Path:      "/data.bin",
+		FileAttr: metadata.FileAttr{
+			Type: metadata.FileTypeRegular, Mode: 0o644, UID: 1000, GID: 1000, Nlink: 1,
+			Size: 4096, Atime: time.Unix(1, 0), Mtime: time.Unix(2, 0),
+			Ctime: time.Unix(3, 0), CreationTime: time.Unix(4, 0),
+			PayloadID: "bench/data",
+		},
+	}
+}
+
+// BenchmarkDecodeFileJSON is the reflection-JSON baseline for the hot-path file,
+// the format decodeFile replaced. Compare ns/op against BenchmarkDecodeFileHot.
+func BenchmarkDecodeFileJSON(b *testing.B) {
+	f := hotFile()
+	f.Path = ""
+	enc, err := json.Marshal(f)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.SetBytes(int64(len(enc)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var out metadata.File
+		if err := json.Unmarshal(enc, &out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkDecodeFileHot is the new binary decode on the same hot-path file.
+func BenchmarkDecodeFileHot(b *testing.B) {
+	enc, err := encodeFile(hotFile())
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.SetBytes(int64(len(enc)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := decodeFile(enc); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncodeFileJSON(b *testing.B) {
+	f := hotFile()
+	f.Path = ""
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := json.Marshal(f); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncodeFileHot(b *testing.B) {
+	f := hotFile()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := encodeFile(f); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
 
 // bigFile builds a File with nBlocks ChunkRefs — the shape GetFileForRead
 // decodes on every read of a rolled-up file (a 1 GiB file at the ~1 MiB FastCDC

--- a/pkg/metadata/store/badger/encoding_test.go
+++ b/pkg/metadata/store/badger/encoding_test.go
@@ -3,7 +3,6 @@ package badger
 import (
 	"bytes"
 	"encoding/json"
-	"strings"
 	"testing"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
 )
 
 // TestBadgerEncodeFile_BlocksRoundTrip verifies that FileAttr.Blocks
@@ -116,9 +116,10 @@ func TestBadgerEncodeFile_LegacyBlobNoBlocks(t *testing.T) {
 	assert.Equal(t, uint64(42), decoded.Size)
 }
 
-// TestBadgerEncodeFile_NilBlocksOmitted asserts the omitempty tag on
-// FileAttr.Blocks so encoding a file with nil Blocks does NOT emit a
-// "blocks" key — keeps legacy/zero-value blobs free of churn.
+// TestBadgerEncodeFile_NilBlocksOmitted asserts a file with nil Blocks does not
+// emit the Blocks field (no churn) and round-trips back to nil. The codec is now
+// the binary format (0xD5 magic), so we assert the binary invariant rather than
+// a JSON "blocks" key.
 func TestBadgerEncodeFile_NilBlocksOmitted(t *testing.T) {
 	file := &metadata.File{
 		ID:        uuid.MustParse("11111111-2222-3333-4444-555555555555"),
@@ -134,12 +135,189 @@ func TestBadgerEncodeFile_NilBlocksOmitted(t *testing.T) {
 	encoded, err := encodeFile(file)
 	require.NoError(t, err)
 
-	// json.Marshal must omit the "blocks" key entirely.
-	assert.False(t, strings.Contains(string(encoded), `"blocks"`),
-		"nil Blocks must be omitted from JSON via omitempty (got %s)", string(encoded))
+	// New writes are binary, not JSON.
+	require.GreaterOrEqual(t, len(encoded), 3)
+	assert.Equal(t, byte(fileMagic0), encoded[0], "binary magic byte 0")
+	assert.NotEqual(t, byte('{'), encoded[0], "must not be JSON")
 
-	// Sanity: it should still be valid JSON for a File (round-trip).
-	var roundtrip metadata.File
-	require.NoError(t, json.Unmarshal(encoded, &roundtrip))
-	assert.Nil(t, roundtrip.Blocks)
+	roundtrip, err := decodeFile(encoded)
+	require.NoError(t, err)
+	assert.Nil(t, roundtrip.Blocks, "nil Blocks must round-trip to nil")
+}
+
+// TestEncodeDecodeFile_AllFields exercises every persisted FileAttr field
+// (including ACL, EAs, ObjectID, DeletedAt, unicode names, empty/nil maps and a
+// zero-length EA value) through encode -> binary decode. Path and BlocksDirty
+// are intentionally not persisted.
+func TestEncodeDecodeFile_AllFields(t *testing.T) {
+	var oid block.ContentHash
+	for i := range oid {
+		oid[i] = byte(i + 1)
+	}
+	del := time.Unix(1700009999, 500).UTC()
+	orig := &metadata.File{
+		ID:        uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+		ShareName: "/share-π",
+		Path:      "/should/not/persist",
+		FileAttr: metadata.FileAttr{
+			Type:         metadata.FileTypeSymlink,
+			Mode:         0o4755,
+			UID:          4294967295, // max uint32
+			GID:          123,
+			Nlink:        7,
+			Size:         1<<40 + 3,
+			Atime:        time.Unix(1700000001, 111).UTC(),
+			Mtime:        time.Unix(1700000002, 222).UTC(),
+			Ctime:        time.Unix(1700000003, 333).UTC(),
+			CreationTime: time.Unix(1700000004, 444).UTC(),
+			PayloadID:    "share-π/файл",
+			LinkTarget:   "../targ€t/文件",
+			Rdev:         0xDEADBEEF,
+			Hidden:       true,
+			ACL: &acl.ACL{
+				ACEs: []acl.ACE{{
+					Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+					Flag:       0,
+					AccessMask: 0x00000003,
+					Who:        acl.SpecialOwner,
+				}},
+				Source: acl.ACLSourceNFSExplicit,
+			},
+			EAs: map[string][]byte{
+				"user.comment":  []byte("héllo"),
+				"user.emptyval": {}, // zero-length EA must round-trip as present
+				"user.binary":   {0x00, 0xFF, 0x7B, 0xD5},
+			},
+			IdempotencyToken: 0x1122334455667788,
+			ObjectID:         oid,
+			DeletedAt:        &del,
+			OriginalPath:     "documents/старый.txt",
+			DeletedBy:        "user€",
+		},
+	}
+
+	enc, err := encodeFile(orig)
+	require.NoError(t, err)
+	require.NotEqual(t, byte('{'), enc[0], "must be binary")
+
+	got, err := decodeFile(enc)
+	require.NoError(t, err)
+
+	assert.Empty(t, got.Path, "Path must not persist")
+	got.Path = orig.Path // normalize for full-struct compare below
+
+	// time.Time compares poorly with == across marshal; check each explicitly.
+	for _, tc := range []struct {
+		name string
+		a, b time.Time
+	}{
+		{"atime", got.Atime, orig.Atime}, {"mtime", got.Mtime, orig.Mtime},
+		{"ctime", got.Ctime, orig.Ctime}, {"creation", got.CreationTime, orig.CreationTime},
+	} {
+		assert.True(t, tc.a.Equal(tc.b), "%s: got %v want %v", tc.name, tc.a, tc.b)
+	}
+	require.NotNil(t, got.DeletedAt)
+	assert.True(t, got.DeletedAt.Equal(del))
+
+	// Zero the times so ObjectsAreEqual on the rest is exact.
+	z := func(f *metadata.File) {
+		f.Atime, f.Mtime, f.Ctime, f.CreationTime = time.Time{}, time.Time{}, time.Time{}, time.Time{}
+		f.DeletedAt = nil
+	}
+	gc, oc := *got, *orig
+	z(&gc)
+	z(&oc)
+	assert.Equal(t, oc, gc, "all non-time fields must round-trip exactly")
+
+	// Zero-length EA distinguishable from absent.
+	v, ok := got.LookupEA("user.emptyval")
+	assert.True(t, ok)
+	assert.NotNil(t, v)
+	assert.Len(t, v, 0)
+}
+
+// TestDecodeFile_NilAndEmptyMaps verifies nil ACL/EAs/Blocks and empty EAs map
+// all round-trip to nil (the omit-when-empty invariant), and an explicit
+// non-nil empty ACL stays non-nil (it denies all access — a real distinction).
+func TestDecodeFile_NilAndEmptyMaps(t *testing.T) {
+	base := &metadata.File{ID: uuid.New(), ShareName: "/s", FileAttr: metadata.FileAttr{Mode: 0o644}}
+	base.EAs = map[string][]byte{} // empty, not nil
+	enc, err := encodeFile(base)
+	require.NoError(t, err)
+	got, err := decodeFile(enc)
+	require.NoError(t, err)
+	assert.Nil(t, got.ACL)
+	assert.Nil(t, got.EAs, "empty EAs map must not persist")
+	assert.Nil(t, got.Blocks)
+	assert.True(t, got.ObjectID.IsZero())
+	assert.Nil(t, got.DeletedAt)
+
+	// Explicit empty (non-nil) ACL: the deny-all case must survive as non-nil.
+	base.ACL = &acl.ACL{}
+	enc, err = encodeFile(base)
+	require.NoError(t, err)
+	got, err = decodeFile(enc)
+	require.NoError(t, err)
+	require.NotNil(t, got.ACL, "explicit empty ACL must stay non-nil (deny-all)")
+}
+
+// TestDecodeFile_JSONFallback proves a real JSON-encoded record (produced by
+// the pre-#1735 encoder) still decodes via decodeFile. This is the dual-read
+// migration path.
+func TestDecodeFile_JSONFallback(t *testing.T) {
+	orig := &metadata.File{
+		ID:        uuid.New(),
+		ShareName: "/legacy",
+		FileAttr: metadata.FileAttr{
+			Type: metadata.FileTypeRegular, Mode: 0o600, UID: 1, GID: 2, Nlink: 1,
+			Size: 99, Mtime: time.Unix(1700000000, 0).UTC(), PayloadID: "legacy/pl",
+			EAs: map[string][]byte{"user.x": []byte("y")},
+		},
+	}
+	// Emulate the old encoder: JSON with Path zeroed.
+	clone := *orig
+	clone.Path = ""
+	jsonBlob, err := json.Marshal(&clone)
+	require.NoError(t, err)
+	require.Equal(t, byte('{'), jsonBlob[0], "legacy blob must start with 0x7b")
+
+	got, err := decodeFile(jsonBlob)
+	require.NoError(t, err)
+	assert.Equal(t, orig.ID, got.ID)
+	assert.Equal(t, orig.Size, got.Size)
+	assert.Equal(t, []byte("y"), got.EAs["user.x"])
+}
+
+// TestDecodeFile_SchemaEvolution demonstrates the self-describing property: a
+// binary record written by a HYPOTHETICAL future writer that appended an unknown
+// field still decodes on this (older) reader — the unknown field is skipped and
+// known fields survive.
+func TestDecodeFile_SchemaEvolution(t *testing.T) {
+	orig := &metadata.File{ID: uuid.New(), ShareName: "/s", FileAttr: metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0o644, Size: 5, PayloadID: "s/p",
+	}}
+	enc, err := encodeFile(orig)
+	require.NoError(t, err)
+
+	// Splice in an unknown future field (id 250, 4-byte payload) at the end.
+	future := putField(enc, 250, []byte{0xCA, 0xFE, 0xBA, 0xBE})
+
+	got, err := decodeFile(future)
+	require.NoError(t, err, "unknown future field must be skipped, not fatal")
+	assert.Equal(t, orig.ID, got.ID)
+	assert.Equal(t, orig.Size, got.Size)
+	assert.Equal(t, orig.PayloadID, got.PayloadID)
+}
+
+// TestDecodeFile_Corruption guards that a truncated/garbled binary record errors
+// instead of panicking.
+func TestDecodeFile_Corruption(t *testing.T) {
+	orig := &metadata.File{ID: uuid.New(), ShareName: "/s", FileAttr: metadata.FileAttr{Size: 5}}
+	enc, err := encodeFile(orig)
+	require.NoError(t, err)
+	for cut := 3; cut < len(enc); cut++ {
+		_, _ = decodeFile(enc[:cut]) // must not panic; error is acceptable
+	}
+	_, err = decodeFile([]byte{fileMagic0, fileMagic1, 0xFF}) // bad version
+	require.Error(t, err)
 }

--- a/pkg/metadata/store/badger/snapshot_store.go
+++ b/pkg/metadata/store/badger/snapshot_store.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -118,9 +117,11 @@ func (s *BadgerMetadataStore) WriteSnapshot(ctx context.Context, w io.Writer) (*
 			}
 
 			// Hash extraction: decode f: prefix entries for block hashes.
+			// decodeFile handles both the binary codec (new writes) and the
+			// legacy JSON records (dual-read, #1735).
 			if bytes.HasPrefix(key, filePrefix) {
-				var file metadata.File
-				if err := json.Unmarshal(val, &file); err != nil {
+				file, err := decodeFile(val)
+				if err != nil {
 					logger.Warn("backup: malformed f: entry, skipping hash extraction",
 						"key", string(key), "error", err)
 					continue
@@ -132,7 +133,7 @@ func (s *BadgerMetadataStore) WriteSnapshot(ctx context.Context, w io.Writer) (*
 				// (l: key), not the embedded File.Nlink which SetLinkCount does
 				// not rewrite. The raw f: record is still dumped verbatim above so
 				// a restore stays consistent (the file remains nlink=0, invisible).
-				if fileLinkCountTxn(txn, &file) == 0 {
+				if fileLinkCountTxn(txn, file) == 0 {
 					continue
 				}
 				for _, br := range file.Blocks {


### PR DESCRIPTION
Refs #1735.

Replaces per-inode JSON encoding in the badger metadata store with a length-prefixed, self-describing binary codec. `json.Unmarshal` was ~13% of flat CPU on the create/write hot path (an inode is decoded 4-5x per op).

## Format
- Magic `0xD5 0xF5` + version byte, then repeated `uvarint(fieldID) uvarint(len) payload`.
- First byte `0xD5` is disjoint from JSON's `0x7b` (`{`), so `decodeFile` dispatches on the first byte: legacy JSON records still decode (dual-read migration, modelled on the #1622 CAS->blocks read fallback; removable once all stores are rewritten). New writes are binary.
- Self-describing: every field is length-delimited and keyed by a stable fieldID. Unknown fieldIDs are skipped; absent ones leave the zero value. Adding a field later = append a new fieldID constant — old records still decode, old binaries skip new fields. No fixed byte offsets.
- Scalars are uvarints; timestamps use `time.MarshalBinary`; aggregates (ACL, EAs, Blocks) keep JSON as their payload for exact round-trip and are emitted only when non-empty, so the hot path (nil ACL/EAs/Blocks) touches no JSON at all.

## Correctness
Every persisted `File`/`FileAttr` field round-trips exactly (ID, ownership, mode, nlink, timestamps, PayloadID, LinkTarget, Rdev, Hidden, ACL, EAs incl. zero-length values, IdempotencyToken, Blocks, ObjectID, DeletedAt, OriginalPath, DeletedBy). `Path` is still derived-on-read (not persisted); `BlocksDirty` is transient.

`snapshot_store.go` block-hash extraction now decodes via `decodeFile` (handles both formats) instead of a raw `json.Unmarshal` — otherwise binary `f:` records would be skipped and backup manifests would drop hashes.

## Benchmark (decode, hot-path file: no ACL/EAs/Blocks)
| | ns/op | allocs/op |
|---|---|---|
| JSON (reflection, prior) | 3618 | 10 |
| binary (this PR) | 179 | 3 |

~20x faster decode, ~8x faster encode.

## Tests
Round-trip of all fields (unicode names, empty/nil maps, zero-length EA, explicit empty ACL), JSON-fallback of a legacy record, schema-evolution (unknown future field skipped), corruption/truncation guard. Full `go test ./pkg/metadata/...` (2634) + `-race` on badger (511) green.