### PR TITLE
perf(metadata): warm read cache across create/write + negative dirent cache

### DIFF
--- a/pkg/metadata/create_readcache_test.go
+++ b/pkg/metadata/create_readcache_test.go
@@ -1,0 +1,91 @@
+package metadata_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/badger"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateFile_ConcurrentSameName_NoOrphan is the constraint-A guard for the
+// #1735 dirent cache: the negative dirent cache accelerates only the OUTER
+// pre-transaction existence check; the authoritative in-transaction recheck
+// still hits the real badger txn and joins Badger's SSI conflict read-set. So N
+// concurrent creates of the SAME (parent,name) must resolve to exactly ONE
+// winner, the rest AlreadyExists, and — critically — NO orphaned inode (a
+// double-create would PutFile a second inode whose dirent lost, inflating the
+// file count).
+//
+// If the dirent cache ever served the in-txn recheck, both racers would see
+// ABSENT, both would commit, and UsedFiles would exceed the single-winner count.
+func TestCreateFile_ConcurrentSameName_NoOrphan(t *testing.T) {
+	const concurrency = 24
+
+	ctx := context.Background()
+	store, err := badger.NewBadgerMetadataStoreWithDefaults(ctx, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	const share = "/test"
+	root, err := store.CreateRootDirectory(ctx, share, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory, Mode: 0o777,
+	})
+	require.NoError(t, err)
+	rootHandle, err := metadata.EncodeShareHandle(share, root.ID)
+	require.NoError(t, err)
+
+	svc := metadata.New()
+	require.NoError(t, svc.RegisterStoreForShare(share, metadata.Store(store)))
+	auth := &metadata.AuthContext{
+		Context: ctx, AuthMethod: "unix",
+		Identity:   &metadata.Identity{UID: metadata.Uint32Ptr(0), GID: metadata.Uint32Ptr(0)},
+		ClientAddr: "127.0.0.1",
+	}
+	attr := &metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644}
+
+	var okCount, existsCount int64
+	var wg sync.WaitGroup
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, cErr := svc.CreateFile(auth, rootHandle, "collide", attr)
+			switch {
+			case cErr == nil:
+				atomic.AddInt64(&okCount, 1)
+			case isAlreadyExists(cErr):
+				atomic.AddInt64(&existsCount, 1)
+			default:
+				t.Errorf("unexpected create error: %v", cErr)
+			}
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, int64(1), okCount, "exactly one concurrent create must win")
+	require.Equal(t, int64(concurrency-1), existsCount, "all losers must get AlreadyExists")
+
+	// Orphan check: UsedFiles counts every inode. root + the single "collide"
+	// child = 2. A double-create would leave an extra orphaned inode (3+).
+	stats, err := store.GetFilesystemStatistics(ctx, rootHandle)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), stats.UsedFiles,
+		"orphaned inode detected: a concurrent create double-committed under one name")
+
+	// The surviving name resolves to a single, live regular-file inode.
+	h, err := store.GetChild(ctx, rootHandle, "collide")
+	require.NoError(t, err)
+	f, err := store.GetFile(ctx, h)
+	require.NoError(t, err)
+	require.Equal(t, metadata.FileTypeRegular, f.Type)
+}
+
+func isAlreadyExists(err error) bool {
+	var se *metadata.StoreError
+	return errors.As(err, &se) && se.Code == metadata.ErrAlreadyExists
+}

--- a/pkg/metadata/file_create.go
+++ b/pkg/metadata/file_create.go
@@ -1,11 +1,26 @@
 package metadata
 
 import (
+	"context"
 	"time"
 
 	"github.com/marmos91/dittofs/pkg/metadata/acl"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
+
+// createCacheStore is the optional create-path fast path implemented by the
+// badger backend (#1735). It supplies cached, generation-guarded reads for the
+// two PRE-transaction lookups on the create path — the parent directory
+// (GetFileForCreate) and the outer existence check (GetChildForCreate) — plus
+// read-cache warming for a just-created file (WarmFileReadCache) so the trailing
+// WRITE/GETATTR/ACCESS hit warm. Backends that do not implement it fall back to
+// the plain Store methods, so behaviour is identical either way. None of these
+// is ever used for the authoritative in-transaction TOCTOU recheck.
+type createCacheStore interface {
+	GetFileForCreate(ctx context.Context, handle FileHandle) (*File, error)
+	GetChildForCreate(ctx context.Context, dirHandle FileHandle, name string) (FileHandle, error)
+	WarmFileReadCache(file *File)
+}
 
 // CreateFile creates a new regular file in a directory. The returned DirWcc
 // carries the parent's pre/post attributes captured atomically with the create
@@ -202,8 +217,17 @@ func (s *Service) createEntry(
 		return nil, nil, err
 	}
 
-	// Get parent entry
-	parent, err := store.GetFile(ctx.Context, parentHandle)
+	cc, hasCreateCache := store.(createCacheStore)
+
+	// Get parent entry. GetFileForCreate serves it from the path-carrying
+	// parentCache when warm (#1735); it returns a caller-owned copy with Path
+	// populated (needed below for the PATH_MAX check), identical to GetFile.
+	var parent *File
+	if hasCreateCache {
+		parent, err = cc.GetFileForCreate(ctx.Context, parentHandle)
+	} else {
+		parent, err = store.GetFile(ctx.Context, parentHandle)
+	}
 	if err != nil {
 		return nil, nil, err
 	}
@@ -231,8 +255,16 @@ func (s *Service) createEntry(
 		return nil, nil, err
 	}
 
-	// Check if name already exists
-	_, err = store.GetChild(ctx.Context, parentHandle, name)
+	// Check if name already exists. This OUTER check is advisory only — the
+	// authoritative TOCTOU guard is the in-transaction recheck below (:~410),
+	// which MUST hit the real badger txn. So it is safe to serve this one from the
+	// dirent cache (GetChildForCreate) when warm (#1735); a stale answer at worst
+	// costs a wasted transaction that the in-txn recheck then rejects.
+	if hasCreateCache {
+		_, err = cc.GetChildForCreate(ctx.Context, parentHandle, name)
+	} else {
+		_, err = store.GetChild(ctx.Context, parentHandle, name)
+	}
 	if err == nil {
 		return nil, nil, &StoreError{
 			Code:    ErrAlreadyExists,
@@ -434,6 +466,15 @@ func (s *Service) createEntry(
 
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// Warm the read cache with the just-created inode so the immediately
+	// following WRITE/GETATTR/ACCESS on this new handle hit warm instead of
+	// re-decoding it from badger (#1735). Runs AFTER commit (and after the
+	// commit's own read-cache invalidation), so the generation captured inside
+	// WarmFileReadCache is post-commit and the populate is correctly ordered.
+	if hasCreateCache {
+		cc.WarmFileReadCache(newFile)
 	}
 
 	// Coalesce the parent directory timestamp bump. Per MS-FSA 2.1.4.4 a

--- a/pkg/metadata/store/badger/create_cache.go
+++ b/pkg/metadata/store/badger/create_cache.go
@@ -1,0 +1,244 @@
+package badger
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	badgerdb "github.com/dgraph-io/badger/v4"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// direntCacheCap bounds the dirent cache (positive + negative entries).
+const direntCacheCap = 8192
+
+// direntCache is a lock-free, generation-guarded cache of directory-entry
+// lookups keyed by (parentID, name): a positive entry records the child handle,
+// a negative entry records ABSENT. It accelerates the *pre-transaction*
+// existence check on the create hot path (createEntry / CheckParentCreateAccess)
+// and is usable by LOOKUP, so a directory repeatedly probed for the same
+// (mostly-absent) names skips the per-probe badger View transaction.
+//
+// It is a read-only / populate-after-commit cache, NEVER a write-back cache: the
+// authoritative c:/cn: dirent keys are always written inside the create
+// transaction, and the in-transaction TOCTOU recheck (file_create.go) reads the
+// real badger txn — it is NEVER served from here, so it still builds Badger's SSI
+// conflict read-set and two concurrent same-name creates still conflict (one
+// wins, the loser aborts). Serving that recheck from a cache would let both
+// commit and orphan an inode.
+//
+// Correctness mirrors fileReadCache exactly (single-node badger is single-writer,
+// which makes this tractable):
+//   - invalidate() runs AFTER a SetChild/DeleteChild commits, bumping gen then
+//     deleting, so a reader that observed the pre-commit state cannot leave it
+//     cached (its generation-guarded store loses). Without the gen guard a reader
+//     that missed, fell through to a not-found badger read, and cached ABSENT
+//     while a concurrent create committed that name would pin a permanently-stale
+//     negative entry -> spurious ENOENT for a file that exists.
+//   - store() writes only when gen is unchanged since the snapshot taken before
+//     the backing read; any racing dirent write moves gen and the populate drops.
+//     A dropped populate is a cache miss (re-read), never a stale hit.
+type direntCache struct {
+	m     sync.Map // key string -> direntEntry
+	n     atomic.Int64
+	gen   atomic.Uint64
+	prune atomic.Bool
+}
+
+// direntEntry is a cached lookup result. present=false is a negative (ABSENT)
+// entry; present=true carries the resolved child handle as a string so the
+// entry stays comparable (FileHandle is a []byte slice) for sync.Map's
+// CompareAndDelete.
+type direntEntry struct {
+	handle  string
+	present bool
+}
+
+// direntKey builds the map key for a (parentID, name) pair. The parent UUID
+// string and name are separated by a NUL, which ValidateName forbids inside a
+// name, so distinct (parent, name) pairs never collide.
+func direntKey(parentID, name string) string {
+	return parentID + "\x00" + name
+}
+
+// generation snapshots the invalidation counter; pass the result to store.
+func (c *direntCache) generation() uint64 { return c.gen.Load() }
+
+func (c *direntCache) get(key string) (direntEntry, bool) {
+	v, ok := c.m.Load(key)
+	if !ok {
+		return direntEntry{}, false
+	}
+	return v.(direntEntry), true
+}
+
+// store caches e under key only if no dirent write raced the backing read (the
+// generation is unchanged since genAtRead).
+func (c *direntCache) store(key string, e direntEntry, genAtRead uint64) {
+	if c.gen.Load() != genAtRead {
+		return
+	}
+	if _, loaded := c.m.Swap(key, e); !loaded {
+		if c.n.Add(1) > direntCacheCap {
+			c.pruneToHalf()
+		}
+	}
+	// The guard and the Swap are not atomic: a dirent write could commit and
+	// invalidate() (bump gen + delete) in between, leaving our now-stale entry
+	// live. Re-check the generation; if it moved, drop our entry — but only if a
+	// newer reader hasn't already replaced it (CompareAndDelete on our value).
+	if c.gen.Load() != genAtRead {
+		if c.m.CompareAndDelete(key, e) {
+			c.n.Add(-1)
+		}
+	}
+}
+
+// invalidate drops key and advances the generation so any in-flight populate for
+// a now-superseded value is rejected. MUST be called AFTER the write commits.
+// Order matters: bump gen BEFORE delete (see fileReadCache.invalidate).
+func (c *direntCache) invalidate(key string) {
+	c.gen.Add(1)
+	if _, ok := c.m.LoadAndDelete(key); ok {
+		c.n.Add(-1)
+	}
+}
+
+// pruneToHalf best-effort trims the map back toward half the cap on overflow.
+func (c *direntCache) pruneToHalf() {
+	if !c.prune.CompareAndSwap(false, true) {
+		return
+	}
+	defer c.prune.Store(false)
+	target := int64(direntCacheCap / 2)
+	c.m.Range(func(k, _ any) bool {
+		if c.n.Load() <= target {
+			return false
+		}
+		if _, ok := c.m.LoadAndDelete(k); ok {
+			c.n.Add(-1)
+		}
+		return true
+	})
+}
+
+// ============================================================================
+// Create-path cached store reads
+// ============================================================================
+
+// WarmFileReadCache seeds the shared read cache with a just-created File so the
+// trailing WRITE/GETATTR/ACCESS on the new handle hit warm instead of
+// re-decoding the inode from badger (#1735). Called by createEntry AFTER the
+// create transaction commits — so after that commit's own dirtyFiles
+// invalidation has already bumped gen — meaning the generation captured here is
+// post-commit. A concurrent write to any OTHER file that races this populate
+// moves gen and the store is dropped (a miss, never a stale hit); a concurrent
+// write to THIS brand-new inode is impossible until createEntry returns the
+// handle to the caller. The entry is stored path-less: readCache is shared with
+// every handle-addressed reader, which derive Path fresh (#1166), so a baked
+// path must never leak in.
+func (s *BadgerMetadataStore) WarmFileReadCache(file *metadata.File) {
+	if file == nil {
+		return
+	}
+	gen := s.readCache.generation()
+	cp := copyForRead(file)
+	cp.Path = "" // never cache a path in the shared read cache (#1166)
+	s.readCache.store(file.ID.String(), cp, gen)
+}
+
+// GetFileForCreate loads the parent directory for a create with File.Path
+// populated (createEntry needs it for the PATH_MAX check), backed by the
+// dedicated path-carrying parentCache so repeated creates in one directory skip
+// the per-create badger View txn + decode + parent-edge path walk (#1735).
+//
+// Invalidated in lockstep with readCache on the parent's own mutation (parentID
+// in dirtyFiles): a chmod/chown/rename of the parent PutFiles it, so the
+// security-relevant fields (Mode, ACL, GID, Type) served here are always fresh.
+// Only File.Path can lag, and only when an ANCESTOR is renamed (which PutFiles
+// the ancestor, not this parent). That lag is benign here: the stale path feeds
+// only the soft PATH_MAX guard and newFile.Path — a stored field that is
+// #1166-untrusted and re-derived on every read, never served to clients.
+// ponytail: parentID-targeted invalidation; ancestor-rename path lag is benign.
+func (s *BadgerMetadataStore) GetFileForCreate(ctx context.Context, handle metadata.FileHandle) (*metadata.File, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	_, fileID, decErr := metadata.DecodeFileHandle(handle)
+	var key string
+	if decErr == nil {
+		key = fileID.String()
+		if cached, ok := s.parentCache.get(key); ok {
+			return copyForRead(cached), nil
+		}
+	}
+
+	// Snapshot the generation BEFORE the backing read so a mutation racing this
+	// read cannot leave a stale value cached (store() checks it).
+	gen := s.parentCache.generation()
+	var result *metadata.File
+	err := s.db.View(func(txn *badgerdb.Txn) error {
+		tx := &badgerTransaction{store: s, txn: txn}
+		var err error
+		result, err = tx.getFile(ctx, handle, true) // withPath: createEntry needs Path
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	if key != "" {
+		s.parentCache.store(key, result, gen)
+		return copyForRead(result), nil
+	}
+	return result, nil
+}
+
+// GetChildForCreate resolves a name in a directory for the PRE-transaction
+// existence check on the create path (and usable by LOOKUP), backed by the
+// dirent cache so a directory repeatedly probed for the same (mostly-absent)
+// names skips the per-probe badger View txn (#1735). A cached-ABSENT name
+// returns ErrNotFound.
+//
+// NEVER call this for the in-transaction TOCTOU recheck: that MUST go through the
+// transaction-level GetChild so the probe joins Badger's SSI conflict read-set
+// (two concurrent same-name creates must conflict — one wins, the loser aborts).
+// This store-level helper is advisory only; the in-txn recheck is authoritative.
+func (s *BadgerMetadataStore) GetChildForCreate(ctx context.Context, dirHandle metadata.FileHandle, name string) (metadata.FileHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	_, dirID, decErr := metadata.DecodeFileHandle(dirHandle)
+	var key string
+	if decErr == nil {
+		key = direntKey(dirID.String(), name)
+		if e, ok := s.direntCache.get(key); ok {
+			if e.present {
+				return metadata.FileHandle(e.handle), nil
+			}
+			return nil, &metadata.StoreError{Code: metadata.ErrNotFound, Message: "child not found"}
+		}
+	}
+
+	// Snapshot the generation BEFORE the backing read (store() checks it).
+	gen := s.direntCache.generation()
+	var result metadata.FileHandle
+	err := s.db.View(func(txn *badgerdb.Txn) error {
+		tx := &badgerTransaction{store: s, txn: txn}
+		var gErr error
+		result, gErr = tx.GetChild(ctx, dirHandle, name)
+		return gErr
+	})
+	if err != nil {
+		if key != "" && metadata.IsNotFoundError(err) {
+			s.direntCache.store(key, direntEntry{present: false}, gen)
+		}
+		return nil, err
+	}
+	if key != "" {
+		s.direntCache.store(key, direntEntry{handle: string(result), present: true}, gen)
+	}
+	return result, nil
+}

--- a/pkg/metadata/store/badger/create_cache_test.go
+++ b/pkg/metadata/store/badger/create_cache_test.go
@@ -1,0 +1,236 @@
+package badger
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// newCreateCacheStore builds a store with a share + root directory so the dirent
+// and parent caches operate against a realistic keyspace (derivePath needs the
+// parent edges).
+func newCreateCacheStore(t *testing.T) (*BadgerMetadataStore, metadata.FileHandle) {
+	t.Helper()
+	ctx := context.Background()
+	s, err := NewBadgerMetadataStoreWithDefaults(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	const share = "/s"
+	if err := s.CreateShare(ctx, &metadata.Share{Name: share}); err != nil {
+		t.Fatal(err)
+	}
+	root, err := s.CreateRootDirectory(ctx, share, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory, Mode: 0o755,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootHandle, err := metadata.EncodeFileHandle(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s, rootHandle
+}
+
+// putDir writes a directory inode under parent linked as name, returning its
+// handle. Mirrors what createEntry persists (file row + parent + child edges).
+func putDir(t *testing.T, s *BadgerMetadataStore, share string, parent metadata.FileHandle, name string) metadata.FileHandle {
+	t.Helper()
+	ctx := context.Background()
+	h, err := s.GenerateHandle(ctx, share, "/"+name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, id, err := metadata.DecodeFileHandle(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PutFile(ctx, &metadata.File{
+		ID: id, ShareName: share,
+		FileAttr: metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetParent(ctx, h, parent); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetChild(ctx, parent, name, h); err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
+// TestWarmFileReadCache_HitAndPathless proves WarmFileReadCache populates the
+// shared read cache (so the trailing read hits warm) and NEVER bakes File.Path
+// into the shared cache (constraint D / #1166): the cached entry is path-less.
+func TestWarmFileReadCache_HitAndPathless(t *testing.T) {
+	s, _ := newCreateCacheStore(t)
+	ctx := context.Background()
+
+	// A just-created file carries a Path; warming must strip it.
+	f := bigFile(2)
+	f.ShareName = "/s"
+	f.Path = "/dir/created.txt"
+	f.Mode = 0o644
+	if err := s.PutFile(ctx, f); err != nil { // persist so a real read would succeed
+		t.Fatal(err)
+	}
+	handle, err := metadata.EncodeShareHandle("/s", f.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s.WarmFileReadCache(f)
+
+	cached, ok := s.readCache.get(f.ID.String())
+	if !ok {
+		t.Fatal("WarmFileReadCache did not populate the read cache")
+	}
+	if cached.Path != "" {
+		t.Fatalf("read cache holds a path %q; shared cache must be path-less (#1166)", cached.Path)
+	}
+
+	// The warm read returns the correct file (Path is derived at the service
+	// layer, so the store cache being path-less is correct).
+	got, err := s.GetFileForRead(ctx, handle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Mode != 0o644 {
+		t.Fatalf("warm read mode=%o, want 0644", got.Mode)
+	}
+
+	// Caller mutation of the warmed value must not corrupt the shared entry.
+	got.Mode = 0
+	again, ok := s.readCache.get(f.ID.String())
+	if !ok || again.Mode != 0o644 {
+		t.Fatal("warm cache entry aliased or evicted by caller mutation")
+	}
+}
+
+// TestDirentCache_NegativeThenInvalidate proves the negative dirent cache
+// (constraint C): a miss caches ABSENT, a subsequent SetChild for the same name
+// invalidates it, and the next lookup returns the child — never a stale ENOENT.
+func TestDirentCache_NegativeThenInvalidate(t *testing.T) {
+	s, root := newCreateCacheStore(t)
+	ctx := context.Background()
+	_, rootID, _ := metadata.DecodeFileHandle(root)
+	key := direntKey(rootID.String(), "foo")
+
+	// Miss -> caches ABSENT.
+	if _, err := s.GetChildForCreate(ctx, root, "foo"); !metadata.IsNotFoundError(err) {
+		t.Fatalf("first lookup err=%v, want NotFound", err)
+	}
+	if e, ok := s.direntCache.get(key); !ok || e.present {
+		t.Fatalf("expected a cached ABSENT entry, got ok=%v entry=%+v", ok, e)
+	}
+
+	// Create "foo": SetChild must invalidate the negative entry after commit.
+	child := putDir(t, s, "/s", root, "foo")
+	if _, ok := s.direntCache.get(key); ok {
+		t.Fatal("SetChild did not invalidate the negative dirent entry")
+	}
+
+	// The next lookup must find the child, not serve a stale ENOENT.
+	got, err := s.GetChildForCreate(ctx, root, "foo")
+	if err != nil {
+		t.Fatalf("post-create lookup err=%v; stale negative entry would give ENOENT", err)
+	}
+	if string(got) != string(child) {
+		t.Fatal("lookup returned the wrong child handle")
+	}
+
+	// Deleting the child must invalidate the now-positive entry.
+	if err := s.DeleteChild(ctx, root, "foo"); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := s.direntCache.get(key); ok {
+		t.Fatal("DeleteChild did not invalidate the positive dirent entry")
+	}
+	if _, err := s.GetChildForCreate(ctx, root, "foo"); !metadata.IsNotFoundError(err) {
+		t.Fatalf("post-delete lookup err=%v, want NotFound", err)
+	}
+}
+
+// TestDirentCache_NegativeGenGuard is the constraint-C race guard: a populate
+// that snapshots an OLD generation (as if it read badger just before a
+// concurrent create committed) must be rejected, so no permanently-stale ABSENT
+// entry is pinned.
+func TestDirentCache_NegativeGenGuard(t *testing.T) {
+	var c direntCache
+	key := direntKey("parent", "foo")
+
+	genBefore := c.generation()            // reader snapshots gen, then "reads" badger (absent)
+	c.invalidate(key)                      // concurrent create commits + invalidates
+	c.store(key, direntEntry{}, genBefore) // stale populate must be dropped
+
+	if _, ok := c.get(key); ok {
+		t.Fatal("stale ABSENT entry pinned despite a racing invalidation (gen guard failed)")
+	}
+}
+
+// TestGetFileForCreate_PathFreshAfterRename proves the parent cache never serves
+// a stale path across the parent's own rename (constraint D): renaming the
+// directory PutFiles it, which invalidates the parent cache, so the next
+// create-path parent read derives the current path.
+func TestGetFileForCreate_PathFreshAfterRename(t *testing.T) {
+	s, root := newCreateCacheStore(t)
+	ctx := context.Background()
+
+	dir := putDir(t, s, "/s", root, "dirA")
+
+	got, err := s.GetFileForCreate(ctx, dir) // caches path /dirA
+	if err != nil || got.Path != "/dirA" {
+		t.Fatalf("initial parent read: path=%q err=%v", got.Path, err)
+	}
+
+	// Rename /dirA -> /dirB exactly as Move does: repoint the edges AND PutFile
+	// the moved directory (its ctime changes), which drives the cache invalidation.
+	if err := s.DeleteChild(ctx, root, "dirA"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetChild(ctx, root, "dirB", dir); err != nil {
+		t.Fatal(err)
+	}
+	moved, err := s.GetFile(ctx, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PutFile(ctx, moved); err != nil { // ctime bump -> dirtyFiles -> invalidate
+		t.Fatal(err)
+	}
+
+	got, err = s.GetFileForCreate(ctx, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Path != "/dirB" {
+		t.Fatalf("STALE PARENT PATH: got %q after rename to /dirB", got.Path)
+	}
+}
+
+// TestGetChildForCreate_Concurrent is a race-detector smoke test: concurrent
+// lookups + writes on the dirent cache must not race (run under -race).
+func TestGetChildForCreate_Concurrent(t *testing.T) {
+	s, root := newCreateCacheStore(t)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				_, _ = s.GetChildForCreate(ctx, root, "foo")
+				_ = s.SetChild(ctx, root, "foo", root)
+				_ = s.DeleteChild(ctx, root, "foo")
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -64,6 +64,21 @@ type BadgerMetadataStore struct {
 	// decode. Invalidated after each committed write (see withTransaction).
 	readCache fileReadCache
 
+	// parentCache caches decoded parent-directory File records (WITH derived
+	// Path) for the create hot path so repeated creates in one directory skip the
+	// per-create badger View txn + decode + parent-edge path walk (#1735). Kept
+	// SEPARATE from readCache because it holds path-carrying entries, which must
+	// never pollute the shared readCache (whose consumers derive Path fresh,
+	// #1166). Invalidated in lockstep with readCache on the parent's own mutation
+	// (parentID in dirtyFiles) — see GetFileForCreate and withTransaction.
+	parentCache fileReadCache
+
+	// direntCache caches (parentID,name) -> childHandle|ABSENT for the
+	// pre-transaction existence check on the create path and LOOKUP (#1735).
+	// Populate-after-commit, generation-guarded; NEVER consulted for the in-txn
+	// TOCTOU recheck. Invalidated after each committed SetChild/DeleteChild.
+	direntCache direntCache
+
 	// gcStop signals the value-log GC goroutine to exit. Closed once by
 	// Close() (guarded by gcStopOnce); gcWG waits for the goroutine to
 	// drain before Close() shuts the DB so the GC never runs against a

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -48,6 +48,14 @@ type badgerTransaction struct {
 	// attempt like pendingDelta so a conflict-retry cannot leak a phantom
 	// invalidation. A stale entry is a wrong permission decision.
 	dirtyShares []string
+	// dirtyDirents collects (parentID,name) dirent-cache keys whose forward
+	// c:<parent>:<name> edge this transaction wrote (SetChild) or deleted
+	// (DeleteChild). Captured per attempt and, after a successful commit, used to
+	// invalidate the negative dirent cache (see withTransaction). Reset per
+	// attempt like dirtyFiles so a conflict-retry cannot leak a phantom
+	// invalidation. A stale entry is a spurious ENOENT (negative) or EEXIST
+	// (positive).
+	dirtyDirents []string
 }
 
 // badgerQuotaKey identifies a per-identity usage bucket inside a transaction's
@@ -149,6 +157,7 @@ func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx me
 		var quotaDelta map[badgerQuotaKey]metadata.UsageStat
 		var dirtyFiles []string
 		var dirtyShares []string
+		var dirtyDirents []string
 		err := s.db.Update(func(txn *badgerdb.Txn) error {
 			tx := &badgerTransaction{store: s, txn: txn}
 			if fnErr := fn(tx); fnErr != nil {
@@ -158,6 +167,7 @@ func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx me
 			quotaDelta = tx.quotaDelta
 			dirtyFiles = tx.dirtyFiles
 			dirtyShares = tx.dirtyShares
+			dirtyDirents = tx.dirtyDirents
 			return nil
 		})
 
@@ -174,9 +184,19 @@ func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx me
 			// store loses). A stale share entry is a wrong permission decision.
 			for _, id := range dirtyFiles {
 				s.readCache.invalidate(id)
+				// The parentCache is keyed by the same fileID string; a mutation
+				// to an inode that is cached as some create's parent (chmod/chown/
+				// rename PutFiles it) must drop that stale parent entry too (#1735).
+				s.parentCache.invalidate(id)
 			}
 			for _, name := range dirtyShares {
 				s.shareCache.invalidate(name)
+			}
+			// Drop dirent-cache entries for every (parentID,name) whose forward
+			// edge this transaction wrote or deleted, so a subsequent existence
+			// check re-reads instead of serving a stale ABSENT/present (#1735).
+			for _, k := range dirtyDirents {
+				s.direntCache.invalidate(k)
 			}
 			// Durable (data-paired) commit in relaxed mode: fsync now so the
 			// write survives a crash. A sync failure must not falsely ack a
@@ -618,6 +638,10 @@ func (tx *badgerTransaction) SetChild(ctx context.Context, dirHandle metadata.Fi
 		}
 	}
 
+	// Record the dirent-cache key so the negative dirent cache is invalidated
+	// after this write commits (see withTransaction). Never served in-txn.
+	tx.dirtyDirents = append(tx.dirtyDirents, direntKey(dirID.String(), name))
+
 	// Store child UUID bytes plus the reverse edge cn:<parent>:<child> -> name
 	// so derivePath resolves the child's name under this parent in O(1) instead
 	// of scanning every c:<parent>:* entry (#1166).
@@ -662,6 +686,10 @@ func (tx *badgerTransaction) DeleteChild(ctx context.Context, dirHandle metadata
 	}); vErr != nil {
 		return vErr
 	}
+
+	// Record the dirent-cache key so a cached present/ABSENT entry for this
+	// (parent,name) is invalidated after the delete commits (see withTransaction).
+	tx.dirtyDirents = append(tx.dirtyDirents, direntKey(dirID.String(), name))
 
 	if err := tx.txn.Delete(keyChild(dirID, name)); err != nil {
 		return err


### PR DESCRIPTION
Refs #1735. CREATE populates fileReadCache so trailing WRITE/GETATTR/ACCESS hit warm; adds a generation-guarded negative dirent cache for the outer existence check only (the in-txn SSI recheck still hits badger). Read-only/populate-after-commit; synchronous invalidation on SetChild/DeleteChild. Includes concurrent-create, negative-cache-invalidation, and rename-path-safety tests.

## What
Three cross-operation caches on the create/write hot path, all in the badger backend:

1. **Warm read cache on create commit** — `createEntry` calls `WarmFileReadCache(newFile)` after the transaction commits, storing a **path-less** copy into the shared `fileReadCache` so the immediately-following WRITE/GETATTR/ACCESS on the new handle skip the badger View txn + inode decode.
2. **Cached parent read** — the create-path parent lookup (`GetFileForCreate`) is served from a **separate** path-carrying `parentCache` (never the shared read cache), so repeated creates in one directory skip the per-create txn + decode + parent-edge path walk.
3. **Negative dirent cache** — `(parentID,name) -> childHandle | ABSENT`, generation-guarded, serves **only** the outer pre-transaction existence check (`GetChildForCreate`); usable by LOOKUP.

## Correctness
- The in-transaction TOCTOU recheck still calls the transaction-level `GetChild` (untouched) so it joins Badger's SSI conflict read-set — two concurrent same-name creates still conflict, one wins.
- Dirent cache is read-only/populate-after-commit; the real `c:`/`cn:` writes stay inside the create txn. Invalidated synchronously after commit on `SetChild`/`DeleteChild` via the existing dirty-set mechanism.
- Generation-guarded populate (bump-on-invalidate, store-only-if-unchanged) prevents a racing create from pinning a stale ABSENT entry.
- Path-carrying entries are kept out of the shared read cache (`File.Path` is #1166-untrusted); `parentCache` is invalidated on the parent's own mutation.

## Tests
- `TestCreateFile_ConcurrentSameName_NoOrphan` — 24 racers, exactly one winner, no orphaned inode (UsedFiles check).
- `TestDirentCache_NegativeThenInvalidate` + `TestDirentCache_NegativeGenGuard` — negative-cache invalidation and gen-guard.
- `TestWarmFileReadCache_HitAndPathless` — warm hit + path-less invariant.
- `TestGetFileForCreate_PathFreshAfterRename` — no stale path after parent rename.

Full `go test ./pkg/metadata/...` (2635 tests) green, including under `-race`.