### PR TITLE
perf(metadata): per-share writeback tier relaxes FILE_SYNC metadata durability

### DIFF
--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -140,6 +140,12 @@ type Share struct {
 	// stores at share creation; empty for in-memory backends — the status
 	// handler treats "" as "no journal available" rather than an error.
 	localStoreDir string
+
+	// writeback records whether this share opted into the metadata writeback
+	// tier (#1757) via the local store config's "writeback" bool. When true,
+	// AddShare tells the metadata service to relax the per-op FILE_SYNC flush
+	// for this share's handles. Default false (durable).
+	writeback bool
 }
 
 // GCStateRoot returns the per-share gc-state directory used by the GC
@@ -258,6 +264,13 @@ type MetadataServiceRegistrar interface {
 // share it refuses to finalize.
 type MetadataServiceDeregistrar interface {
 	RemoveStoreForShare(shareName string)
+}
+
+// MetadataWritebackSetter opts a share into the metadata writeback tier (#1757).
+// The concrete *metadata.Service satisfies it. AddShare calls it after
+// registering the store when the share's local config sets "writeback": true.
+type MetadataWritebackSetter interface {
+	SetShareWriteback(shareName string, writeback bool)
 }
 
 // BlockStoreConfigProvider resolves block store configurations from the control plane DB.
@@ -701,6 +714,14 @@ func (s *Service) AddShare(
 		return fmt.Errorf("failed to configure metadata for share: %w", err)
 	}
 
+	// Apply the per-share metadata writeback tier (#1757) parsed from the local
+	// store config in createBlockStoreForShare. Set explicitly (true or false) so
+	// a re-add that toggles writeback off is honored. Only the concrete
+	// *metadata.Service implements the setter.
+	if wb, ok := metadataSvc.(MetadataWritebackSetter); ok {
+		wb.SetShareWriteback(config.Name, share.writeback)
+	}
+
 	// Phase 4: Convert the reservation into a registry entry under s.mu.
 	// Only now is the share visible to protocol handlers. The reservation has
 	// held the name exclusively since Phase 0, so registry[name] cannot already
@@ -1123,6 +1144,10 @@ func (s *Service) createBlockStoreForShare(
 	// async). Set before Start so it governs the very first commit.
 	if localStoreCfg, cfgErr := localCfg.GetConfig(); cfgErr == nil {
 		applyRequireDurableCommit(bs, localStoreCfg, config.Name)
+		// Stash the metadata writeback-tier flag (#1757) from the same local
+		// config map. It is applied to the metadata service in AddShare (which
+		// holds the registrar), after RegisterStoreForShare.
+		share.writeback = parseWritebackConfig(localStoreCfg, config.Name)
 	} else {
 		logger.Warn("failed to read local block store config for require_durable_commit; defaulting to false",
 			"share", config.Name, "error", cfgErr)
@@ -3020,6 +3045,28 @@ func applyRequireDurableCommit(bs *engine.Store, config map[string]any, shareNam
 	if b {
 		logger.Info("strict honest-CLOSE/COMMIT durability enabled by config", "share", shareName)
 	}
+}
+
+// parseWritebackConfig reads the optional per-share "writeback" bool from the
+// local store config (#1757). Read the same conservative way as
+// config["require_durable_commit"]: absent or non-bool → false (default,
+// durable). When true, the share's per-op FILE_SYNC metadata flush takes the
+// relaxed deferred-fsync path (see metadata.Service.SetShareWriteback).
+func parseWritebackConfig(config map[string]any, shareName string) bool {
+	v, ok := config["writeback"]
+	if !ok {
+		return false
+	}
+	b, ok := v.(bool)
+	if !ok {
+		logger.Warn("block store config has writeback but it is not a bool; ignoring",
+			"share", shareName, "value", v)
+		return false
+	}
+	if b {
+		logger.Info("metadata writeback tier enabled by config", "share", shareName)
+	}
+	return b
 }
 
 // CreateRemoteStoreFromConfig creates a remote store from type and dynamic config.

--- a/pkg/controlplane/runtime/shares/writeback_config_test.go
+++ b/pkg/controlplane/runtime/shares/writeback_config_test.go
@@ -1,0 +1,25 @@
+package shares
+
+import "testing"
+
+// TestParseWritebackConfig covers the per-share metadata writeback flag (#1757):
+// absent or non-bool -> false (durable default), explicit bool honored.
+func TestParseWritebackConfig(t *testing.T) {
+	cases := []struct {
+		name   string
+		config map[string]any
+		want   bool
+	}{
+		{"absent", map[string]any{}, false},
+		{"true", map[string]any{"writeback": true}, true},
+		{"false", map[string]any{"writeback": false}, false},
+		{"non-bool", map[string]any{"writeback": "yes"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseWritebackConfig(tc.config, "/share"); got != tc.want {
+				t.Fatalf("parseWritebackConfig(%v) = %v, want %v", tc.config, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/metadata/io.go
+++ b/pkg/metadata/io.go
@@ -370,6 +370,17 @@ func (s *Service) immediateCommitWrite(ctx *AuthContext, intent *WriteOperation)
 // WRITE, COMMIT, SMB inline WRITE) so the metadata fsync moves off the hot path.
 // See flushPendingWrite for the crash-safety argument (journal size reconcile).
 func (s *Service) FlushPendingWriteForFile(ctx *AuthContext, handle FileHandle, durable bool) (bool, error) {
+	// Writeback tier (#1757): if the share owning this handle opted in, downgrade
+	// an otherwise durable per-op flush to the relaxed (deferred-fsync) path even
+	// for FILE_SYNC WRITE / SMB CLOSE/FLUSH, moving the metadata db.Sync off the
+	// hot path. Bounded loss: a crash before the background fsync cannot truncate
+	// ACK'd data because reconcileMetadataSizeFromJournal grows metadata.Size up
+	// to the journal's durable high-water mark on share start. Only the
+	// FlushPendingWriteForFile entrypoint is downgraded; the shutdown flush calls
+	// flushPendingWrite directly with durable=true and stays durable.
+	if durable && s.shareWriteback(shareNameForHandle(handle)) {
+		durable = false
+	}
 	// Serialize flushes per file to avoid BadgerDB conflict retries
 	mu := s.pendingWrites.GetFlushLock(handle)
 	mu.Lock()

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -46,6 +46,7 @@ type Service struct {
 	dirChangeNotifiers map[string]lock.DirChangeNotifier // shareName -> notifier for directory changes
 	pendingWrites      *PendingWritesTracker             // deferred metadata commits for performance
 	dirTimes           *DirTimesTracker                  // coalesced directory mtime/ctime/atime bumps (#1573)
+	writebackShares    map[string]bool                   // shareName -> writeback tier (#1757): relax FILE_SYNC metadata flush
 	deferredCommit     atomic.Bool                       // if true, use deferred commits (default: true); read lock-free on the write hot path
 
 	// parentLinkShards is a fixed bank of mutexes that serialize the parent
@@ -147,6 +148,7 @@ func New() *Service {
 		quotas:             make(map[string]int64),
 		identityQuotas:     newQuotaLimits(),
 		removeGen:          make(map[string]uint64),
+		writebackShares:    make(map[string]bool),
 	}
 	s.deferredCommit.Store(true) // Enable deferred commits by default
 	return s
@@ -265,6 +267,28 @@ func (s *Service) SetByteRangeReleaseHook(fn func(handleKey string)) {
 // SetTrashPolicy installs the per-share recycle-bin policy. A nil policy
 // (the default) disables trash: deletes destroy content as before.
 func (s *Service) SetTrashPolicy(p TrashPolicy) { s.trashPolicy = p }
+
+// SetShareWriteback opts a share into (or out of) the metadata writeback tier
+// (#1757). When enabled, FlushPendingWriteForFile downgrades an otherwise
+// durable per-op flush (FILE_SYNC WRITE, SMB CLOSE/FLUSH) to the relaxed
+// deferred-fsync path, moving the metadata db.Sync off the request hot path.
+// Default (not set) is durable. Set at AddShare; cleared by RemoveStoreForShare.
+func (s *Service) SetShareWriteback(shareName string, writeback bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if writeback {
+		s.writebackShares[shareName] = true
+	} else {
+		delete(s.writebackShares, shareName)
+	}
+}
+
+// shareWriteback reports whether a share is in the writeback tier.
+func (s *Service) shareWriteback(shareName string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.writebackShares[shareName]
+}
 
 // RegisterStoreForShare associates a metadata store with a share.
 // Each share must have exactly one store. Calling this again for the same
@@ -472,6 +496,7 @@ func (s *Service) RemoveStoreForShare(shareName string) {
 	delete(s.unifiedViews, shareName)
 	delete(s.dirChangeNotifiers, shareName)
 	delete(s.quotas, shareName)
+	delete(s.writebackShares, shareName)
 
 	// Bump this share's removal generation so any RegisterStoreForShare recovering
 	// it outside s.mu declines to publish: the register snapshots removeGen before

--- a/pkg/metadata/writeback_tier_test.go
+++ b/pkg/metadata/writeback_tier_test.go
@@ -1,0 +1,145 @@
+package metadata_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+	"github.com/stretchr/testify/require"
+)
+
+// transactorSpy wraps a memory store and records whether a flush committed
+// through the durable (WithTransaction) or relaxed (WithTransactionRelaxed)
+// path. The bare memory store does NOT implement RelaxedTransactor, so
+// withRelaxedTransaction would otherwise fall back to WithTransaction and hide
+// the split; the spy implements both to make the choice observable (#1757).
+type transactorSpy struct {
+	*memory.MemoryMetadataStore
+	durable int
+	relaxed int
+}
+
+func (s *transactorSpy) WithTransaction(ctx context.Context, fn func(tx metadata.Transaction) error) error {
+	s.durable++
+	return s.MemoryMetadataStore.WithTransaction(ctx, fn)
+}
+
+func (s *transactorSpy) WithTransactionRelaxed(ctx context.Context, fn func(tx metadata.Transaction) error) error {
+	s.relaxed++
+	// Memory has no separate relaxed commit; delegate the actual write durably.
+	return s.MemoryMetadataStore.WithTransaction(ctx, fn)
+}
+
+func (s *transactorSpy) reset() { s.durable, s.relaxed = 0, 0 }
+
+// newWritebackFixture builds a Service backed by a transactorSpy for one share.
+func newWritebackFixture(t *testing.T) (*metadata.Service, *transactorSpy, metadata.FileHandle, *metadata.AuthContext) {
+	t.Helper()
+
+	spy := &transactorSpy{MemoryMetadataStore: memory.NewMemoryMetadataStoreWithDefaults()}
+	ctx := context.Background()
+	const shareName = "/wb"
+
+	rootFile, err := spy.CreateRootDirectory(ctx, shareName, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory,
+		Mode: 0777,
+	})
+	require.NoError(t, err)
+	rootHandle, err := metadata.EncodeShareHandle(shareName, rootFile.ID)
+	require.NoError(t, err)
+
+	svc := metadata.New()
+	require.NoError(t, svc.RegisterStoreForShare(shareName, spy))
+
+	authCtx := &metadata.AuthContext{
+		Context:    ctx,
+		AuthMethod: "unix",
+		Identity: &metadata.Identity{
+			UID:  metadata.Uint32Ptr(0),
+			GID:  metadata.Uint32Ptr(0),
+			GIDs: []uint32{0},
+		},
+		ClientAddr: "127.0.0.1",
+	}
+	return svc, spy, rootHandle, authCtx
+}
+
+// bufferPendingWrite records a deferred WRITE that leaves a buffered MaxSize in
+// the pending-writes tracker without committing it (an UNSTABLE NFS WRITE).
+func bufferPendingWrite(t *testing.T, svc *metadata.Service, authCtx *metadata.AuthContext, handle metadata.FileHandle, size uint64) {
+	t.Helper()
+	intent, err := svc.PrepareWrite(authCtx, handle, size)
+	require.NoError(t, err)
+	_, err = svc.CommitWrite(authCtx, intent)
+	require.NoError(t, err)
+	got, ok := svc.GetPendingSize(handle)
+	require.True(t, ok, "expected buffered pending write")
+	require.Equal(t, size, got)
+}
+
+func createChild(t *testing.T, svc *metadata.Service, spy *transactorSpy, authCtx *metadata.AuthContext, root metadata.FileHandle, name string) metadata.FileHandle {
+	t.Helper()
+	_, _, err := svc.CreateFile(authCtx, root, name, &metadata.FileAttr{Mode: 0644})
+	require.NoError(t, err)
+	handle, err := spy.GetChild(authCtx.Context, root, name)
+	require.NoError(t, err)
+	return handle
+}
+
+// TestWritebackTier_DurableFlushRelaxedWhenEnabled asserts that a FILE_SYNC
+// (durable=true) flush for a writeback share commits through the relaxed
+// deferred-fsync path, not the inline durable transaction.
+func TestWritebackTier_DurableFlushRelaxedWhenEnabled(t *testing.T) {
+	svc, spy, root, authCtx := newWritebackFixture(t)
+	svc.SetShareWriteback("/wb", true)
+
+	handle := createChild(t, svc, spy, authCtx, root, "f.txt")
+	bufferPendingWrite(t, svc, authCtx, handle, 4096)
+
+	spy.reset()
+	flushed, err := svc.FlushPendingWriteForFile(authCtx, handle, true) // durable request
+	require.NoError(t, err)
+	require.True(t, flushed)
+
+	require.Equal(t, 1, spy.relaxed, "writeback share must downgrade a durable flush to the relaxed path")
+	require.Equal(t, 0, spy.durable, "writeback share must not take the inline durable path")
+}
+
+// TestWritebackTier_DurableFlushStaysDurableByDefault asserts the default
+// (no writeback) keeps the inline durable transaction for a FILE_SYNC flush.
+func TestWritebackTier_DurableFlushStaysDurableByDefault(t *testing.T) {
+	svc, spy, root, authCtx := newWritebackFixture(t)
+	// No SetShareWriteback -> default durable.
+
+	handle := createChild(t, svc, spy, authCtx, root, "f.txt")
+	bufferPendingWrite(t, svc, authCtx, handle, 4096)
+
+	spy.reset()
+	flushed, err := svc.FlushPendingWriteForFile(authCtx, handle, true)
+	require.NoError(t, err)
+	require.True(t, flushed)
+
+	require.Equal(t, 1, spy.durable, "default share must keep the inline durable path for a durable flush")
+	require.Equal(t, 0, spy.relaxed, "default share must not take the relaxed path")
+}
+
+// TestWritebackTier_ShutdownFlushStaysDurable asserts the shutdown flush stays
+// durable even for a writeback share: FlushAllPendingWritesForShutdown calls
+// flushPendingWrite directly with durable=true, bypassing the downgrade.
+func TestWritebackTier_ShutdownFlushStaysDurable(t *testing.T) {
+	svc, spy, root, authCtx := newWritebackFixture(t)
+	svc.SetShareWriteback("/wb", true)
+
+	handle := createChild(t, svc, spy, authCtx, root, "f.txt")
+	bufferPendingWrite(t, svc, authCtx, handle, 4096)
+
+	spy.reset()
+	n, err := svc.FlushAllPendingWritesForShutdown(5 * time.Second)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+
+	require.Equal(t, 1, spy.durable, "shutdown flush must stay durable even for a writeback share")
+	require.Equal(t, 0, spy.relaxed, "shutdown flush must not be downgraded to the relaxed path")
+}


### PR DESCRIPTION
## Per-share `writeback` durability tier (metadata half)

Opt-in per-share config that relaxes the **metadata** flush: when `writeback: true`, a share's FILE_SYNC/CLOSE metadata commits take the relaxed deferred-fsync path (background `runDurabilitySync` ticker) instead of an inline `badger.DB.Sync`, moving the per-op metadata sync off the request hot path. **Default is unchanged (durable), byte-identical.**

### Why
Profiling the create+4k-write plateau (#1735/#1757) found **91% of the delay is per-op durable metadata `DB.Sync`** on the FILE_SYNC path. Deferring it (validated env-gated A/B) took create throughput **1154 → 5856 ops/s (5.1×)**, mutex delay 62s → 5.3s. This is the productionized, per-share form of that lever. Distinct from the refuted group-commit family (#1742/#1747): it **defers** the sync, it does not coalesce non-overlapping commits.

### Design
Service-level `writebackShares map[string]bool` (guarded by `s.mu`), set at `AddShare` from the `writeback` config key (parsed like `require_durable_commit`), resolved by handle in `FlushPendingWriteForFile`. Chosen over a `Store`-interface setter to avoid widening the 4-backend metadata `Store` interface (minimize-interface-surface).

### Safety
- Downgrade lives **only** in `FlushPendingWriteForFile`; `FlushAllPendingWritesForShutdown` calls `flushPendingWrite` directly with `durable=true` → **shutdown stays durable** (regression test).
- Unknown/invalid handle and absent/non-bool config → **durable** (safe default).
- Bounded loss = ticker window, backstopped by `reconcileMetadataSizeFromJournal` (size ≤ journal-durable high-water on restart). No corruption.
- Cleaned up in `RemoveStoreForShare`.

Passed code-simplifier (no changes) + a durability/concurrency-focused code-reviewer (clean). Tests: 2714 pass (13 pkgs), race 2645 pass; `go vet`/`golangci-lint` clean.

### Scope
Metadata-only (`pkg/metadata` + share-config plumbing) — no touch to `pkg/block/journal`, `engine`, `snapshot.go`, or `File.Blocks`. The **journal-async** half of the writeback tier (for the full 5×) and the `remote`/commit-on-S3 QoS tier are tracked in #1758.

Refs #1757, #1758.
