### PR TITLE
feat(shares): per-share durability tier enum (#1758)

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -428,9 +428,10 @@ background. Use `require_durable_commit = true` only when you need synchronous
 durability guarantees on a volatile-local + durable-remote share and can accept
 the added latency.
 
-> See [Durability & QoS tiers](durability.md) for how this flag and the metadata
-> `writeback` flag compose into the full durability spectrum, with per-tier
-> throughput numbers.
+> The recommended way to select this is the per-share `durability` enum
+> (`local` | `writeback` | `remote`); `require_durable_commit: true` is equivalent
+> to `durability: remote`. See [Durability & QoS tiers](durability.md) for the full
+> spectrum and per-tier throughput numbers.
 
 `dfsctl store block stats` also shows `Pending Remote (bytes)` — the headline
 data-at-risk gauge (local CAS bytes not yet mirrored to the remote) — which is

--- a/docs/guide/durability.md
+++ b/docs/guide/durability.md
@@ -32,41 +32,45 @@ There is no data-corruption risk in any tier: on restart,
 journal's durable high-water mark, so a relaxed metadata commit can only lose the
 *most recent* size/mtime update — never leave a file inconsistent.
 
-## Knobs available today
+## Selecting a tier
 
-Two independent per-share flags live in the share's **local block-store config**.
-Neither is set by default (both `false` = the local-durable default tier).
-
-### `writeback` — relax metadata durability *(new)*
-
-Downgrades the per-op metadata flush on `FILE_SYNC` writes and `CLOSE` from a
-synchronous `badger.DB.Sync` to the deferred relaxed path (flushed by the 100 ms
-background syncer, `durabilitySyncInterval`). Data is still journalled; only
-metadata (size/mtime/dirent) durability is deferred, bounded to roughly that
-100 ms interval.
+The recommended knob is the per-share **`durability`** enum in the share's
+**local block-store config** — `local` (default), `writeback`, or `remote`:
 
 ```bash
-dfsctl store block local edit <share> --config '{"writeback": true}'
+dfsctl store block local edit <share> --config '{"durability": "remote"}'
 ```
 
-Use it for create/write-heavy workloads that can tolerate losing the last ~100 ms
-of *metadata* on a hard crash (scratch space, CI artifacts, re-derivable data). On
-its own this flag lands in the **local-durable** band (data still journal-`fsync`'d,
-metadata relaxed — ~1680 ops/s below); combined with the journal async-commit half
-([#1758](https://github.com/marmos91/dittofs/issues/1758)) it reaches the full
-writeback tier. It is the single biggest create-throughput lever — see below.
+| `durability` | Ack after | Survives | ~ops/s (create nj=8) |
+|---|---|---|--:|
+| `local` *(default)* | local journal + metadata `fsync` | process/node crash | ~900 |
+| `writeback` | local write, metadata `fsync` deferred ~100 ms | crash, ≤ 100 ms metadata loss | ~1680 |
+| `remote` | data durable in S3 | node/disk loss | slow (by design) |
 
-### `require_durable_commit` — synchronous-to-S3
+- **`local`** — the default; unchanged from earlier releases.
+- **`writeback`** — relaxes the per-op `FILE_SYNC`/`CLOSE` metadata flush from a
+  synchronous `badger.DB.Sync` to the 100 ms deferred syncer
+  (`durabilitySyncInterval`). Data stays journal-`fsync`'d, so today this lands in
+  the **local-durable** band (metadata relaxed only). The full data-writeback tier
+  (~5700 ops/s) additionally needs the journal async-commit half — see
+  [Remaining work](#remaining-work-1758). Use it for create/write-heavy workloads
+  that tolerate losing the last ~100 ms of *metadata* on a hard crash.
+- **`remote`** — makes `CLOSE`/`COMMIT` block until the data is durable in the
+  remote (S3) store, so an acknowledged write survives losing the whole node. Slow
+  by design.
 
-The opposite direction: makes `CLOSE`/`COMMIT` block until the data is durably in
-the remote (S3) store, so an acknowledged write survives losing the whole node.
-Slow by design. See
-[Configuration → require_durable_commit](configuration.md#require_durable_commit)
-for the full CLOSE/COMMIT semantics.
+### Underlying flags (advanced / backward-compatible)
 
-```bash
-dfsctl store block local edit <share> --config '{"require_durable_commit": true}'
-```
+The enum composes two lower-level per-share bools, which still work directly if you
+need finer control. When `durability` is set it takes precedence; when it is
+absent these are honored unchanged:
+
+- **`writeback: true`** — the metadata-relaxed bool on its own (equivalent to
+  `durability: writeback`).
+- **`require_durable_commit: true`** — the strict CLOSE/COMMIT bool (equivalent to
+  `durability: remote`); see
+  [Configuration → require_durable_commit](configuration.md#require_durable_commit)
+  for the full semantics.
 
 ## Measured throughput per tier
 
@@ -75,29 +79,23 @@ full method and competitor comparison in [BENCHMARKS.md](../BENCHMARKS.md#create
 
 | Config | Tier | ops/s |
 |---|---|--:|
-| `writeback: true` + async journal | writeback | ~5700 |
-| `writeback: true` | local-durable (metadata relaxed) | ~1680 |
-| *default* | local-durable | ~900 |
-| `require_durable_commit: true` | synchronous-to-S3 | not yet benchmarked (#1758) |
+| `durability: writeback` + async journal | writeback | ~5700 |
+| `durability: writeback` | local-durable (metadata relaxed) | ~1680 |
+| `durability: local` *(default)* | local-durable | ~900 |
+| `durability: remote` | synchronous-to-S3 | not yet benchmarked |
 
 For context, at a matched writeback guarantee DittoFS sustains **3.0× JuiceFS
-`--writeback`**; the local-durable middle tier is one no S3 filesystem competitor
-offers at all.
+`--writeback`** and **3.6× s3ql**; the local-durable middle tier is one no S3
+filesystem competitor offers at all.
 
-## Planned: named `durability` tier (#1758)
+## Remaining work (#1758)
 
-Today you compose the tier from the two flags above. Two gaps remain:
-
-- The **writeback** row above still needs the journal's async-commit half, which is
-  a diagnostic toggle, not yet a supported config.
-- There is no single, discoverable per-share **`durability`** enum.
-
-[#1758](https://github.com/marmos91/dittofs/issues/1758) folds all of this into one
-per-share setting — `durability: writeback | local | remote` — composing journal
-async-commit, metadata `writeback`, and block `require_durable_commit` into three
-named tiers. The `remote` tier is the productionized synchronous-to-S3 path. Until
-that lands, use the two flags above; the default (neither set) is unchanged and
-remains local-durable.
+The `durability` enum is shipped: **`local`** and **`remote`** are fully functional,
+and **`writeback`** selects the metadata-relaxed path. One piece remains — the full
+**data-writeback** tier (~5700 ops/s) needs the journal async-commit half, still a
+diagnostic toggle rather than a supported config and gated on the journal
+switchover stabilizing. Until it lands, `durability: writeback` delivers the
+metadata-relaxed (local-durable) band; `local` and `remote` are complete.
 
 ## See also
 

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1137,19 +1137,19 @@ func (s *Service) createBlockStoreForShare(
 		return fmt.Errorf("failed to create BlockStore: %w", err)
 	}
 
-	// Apply the per-share strict honest-CLOSE/COMMIT policy (#1274). Read the
-	// optional "require_durable_commit" bool from the local store config the
-	// same way config["durable"] is read; absent or non-bool → false (default:
-	// the commit seam acks once Flush succeeds and the remote mirror stays
-	// async). Set before Start so it governs the very first commit.
+	// Apply the per-share durability tier (#1758), composed from the local store
+	// config. The "durability" enum (local|writeback|remote) selects the tier;
+	// when absent, the raw "require_durable_commit" (#1274) and "writeback"
+	// (#1757) bools are honored for backward compatibility. require_durable_commit
+	// is set before Start so it governs the very first commit; the metadata
+	// writeback flag is stashed and applied to the metadata service in AddShare
+	// (which holds the registrar), after RegisterStoreForShare.
 	if localStoreCfg, cfgErr := localCfg.GetConfig(); cfgErr == nil {
-		applyRequireDurableCommit(bs, localStoreCfg, config.Name)
-		// Stash the metadata writeback-tier flag (#1757) from the same local
-		// config map. It is applied to the metadata service in AddShare (which
-		// holds the registrar), after RegisterStoreForShare.
-		share.writeback = parseWritebackConfig(localStoreCfg, config.Name)
+		writeback, requireDurableCommit := resolveDurabilityTier(localStoreCfg, config.Name)
+		bs.SetRequireDurableCommit(requireDurableCommit)
+		share.writeback = writeback
 	} else {
-		logger.Warn("failed to read local block store config for require_durable_commit; defaulting to false",
+		logger.Warn("failed to read local block store config for durability tier; defaulting to local",
 			"share", config.Name, "error", cfgErr)
 	}
 
@@ -3023,27 +3023,64 @@ func applyDurableOverride(store any, config map[string]any, label, shareName str
 	logger.Info("block store durability overridden by config", "store", label, "share", shareName, "durable", b)
 }
 
-// applyRequireDurableCommit reads the optional per-share
-// "require_durable_commit" bool from the local store config and sets the
-// strict honest-CLOSE/COMMIT policy on the engine Store (#1274). Read the same
-// conservative way as config["durable"]: absent or non-bool → false (default),
-// so the commit seam acks once Flush succeeds and the remote mirror stays
-// async — ordinary NFS/POSIX writes never EIO. When true, CLOSE/COMMIT only
-// succeed once the data is on a durable store.
-func applyRequireDurableCommit(bs *engine.Store, config map[string]any, shareName string) {
+// parseRequireDurableCommit reads the optional per-share "require_durable_commit"
+// bool from the local store config (#1274). Read the same conservative way as
+// config["durable"]: absent or non-bool → false (default), so the commit seam
+// acks once Flush succeeds and the remote mirror stays async — ordinary
+// NFS/POSIX writes never EIO. When true, CLOSE/COMMIT only succeed once the data
+// is on a durable store.
+func parseRequireDurableCommit(config map[string]any, shareName string) bool {
 	v, ok := config["require_durable_commit"]
 	if !ok {
-		return
+		return false
 	}
 	b, ok := v.(bool)
 	if !ok {
 		logger.Warn("block store config has require_durable_commit but it is not a bool; ignoring",
 			"share", shareName, "value", v)
-		return
+		return false
 	}
-	bs.SetRequireDurableCommit(b)
-	if b {
-		logger.Info("strict honest-CLOSE/COMMIT durability enabled by config", "share", shareName)
+	return b
+}
+
+// resolveDurabilityTier composes the per-share durability knobs into the two
+// underlying behaviors (#1758). The optional "durability" enum in the local
+// store config selects a named tier; when absent, the older raw bools
+// ("writeback", "require_durable_commit") are honored unchanged for backward
+// compatibility. When "durability" is present it is authoritative — the raw
+// bools are ignored.
+//
+//	local     (default) — journal + metadata fsync, async S3 (node-crash-safe)
+//	writeback           — per-op FILE_SYNC metadata flush relaxed (deferred to
+//	                      the ticker); data still journal-fsync durable. The full
+//	                      data-writeback tier additionally needs the journal
+//	                      async-commit half, tracked separately.
+//	remote              — CLOSE/COMMIT block until data is durable in the remote
+//	                      (S3) store (require_durable_commit); survives node loss.
+func resolveDurabilityTier(config map[string]any, shareName string) (writeback, requireDurableCommit bool) {
+	v, ok := config["durability"]
+	if !ok {
+		return parseWritebackConfig(config, shareName), parseRequireDurableCommit(config, shareName)
+	}
+	tier, ok := v.(string)
+	if !ok {
+		logger.Warn("block store config has durability but it is not a string; defaulting to local",
+			"share", shareName, "value", v)
+		return false, false
+	}
+	switch strings.ToLower(strings.TrimSpace(tier)) {
+	case "", "local":
+		return false, false
+	case "writeback":
+		logger.Info("durability tier: writeback (metadata flush relaxed)", "share", shareName)
+		return true, false
+	case "remote":
+		logger.Info("durability tier: remote (ack-on-S3, strict CLOSE/COMMIT)", "share", shareName)
+		return false, true
+	default:
+		logger.Warn("unknown durability tier; defaulting to local",
+			"share", shareName, "durability", tier)
+		return false, false
 	}
 }
 

--- a/pkg/controlplane/runtime/shares/writeback_config_test.go
+++ b/pkg/controlplane/runtime/shares/writeback_config_test.go
@@ -23,3 +23,63 @@ func TestParseWritebackConfig(t *testing.T) {
 		})
 	}
 }
+
+// TestParseRequireDurableCommit covers the block strict-CLOSE/COMMIT flag (#1274):
+// absent or non-bool -> false (default), explicit bool honored.
+func TestParseRequireDurableCommit(t *testing.T) {
+	cases := []struct {
+		name   string
+		config map[string]any
+		want   bool
+	}{
+		{"absent", map[string]any{}, false},
+		{"true", map[string]any{"require_durable_commit": true}, true},
+		{"false", map[string]any{"require_durable_commit": false}, false},
+		{"non-bool", map[string]any{"require_durable_commit": 1}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseRequireDurableCommit(tc.config, "/share"); got != tc.want {
+				t.Fatalf("parseRequireDurableCommit(%v) = %v, want %v", tc.config, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveDurabilityTier covers the composed durability enum (#1758): the
+// "durability" tier selects the two underlying knobs; when absent the raw bools
+// are honored; when present it is authoritative (raw bools ignored).
+func TestResolveDurabilityTier(t *testing.T) {
+	cases := []struct {
+		name    string
+		config  map[string]any
+		wantWB  bool
+		wantRDC bool
+	}{
+		// Named tiers.
+		{"local", map[string]any{"durability": "local"}, false, false},
+		{"writeback", map[string]any{"durability": "writeback"}, true, false},
+		{"remote", map[string]any{"durability": "remote"}, false, true},
+		{"empty-string", map[string]any{"durability": ""}, false, false},
+		{"case-and-space", map[string]any{"durability": "  Remote "}, false, true},
+		{"unknown", map[string]any{"durability": "bogus"}, false, false},
+		{"non-string", map[string]any{"durability": 3}, false, false},
+		// durability is authoritative — raw bools ignored when it is present.
+		{"tier-overrides-raw", map[string]any{"durability": "local", "writeback": true, "require_durable_commit": true}, false, false},
+		{"remote-overrides-writeback-bool", map[string]any{"durability": "remote", "writeback": true}, false, true},
+		// Backward compatibility: no durability key -> raw bools honored.
+		{"legacy-writeback", map[string]any{"writeback": true}, true, false},
+		{"legacy-require-durable", map[string]any{"require_durable_commit": true}, false, true},
+		{"legacy-both", map[string]any{"writeback": true, "require_durable_commit": true}, true, true},
+		{"legacy-none", map[string]any{}, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotWB, gotRDC := resolveDurabilityTier(tc.config, "/share")
+			if gotWB != tc.wantWB || gotRDC != tc.wantRDC {
+				t.Fatalf("resolveDurabilityTier(%v) = (wb=%v, rdc=%v), want (wb=%v, rdc=%v)",
+					tc.config, gotWB, gotRDC, tc.wantWB, tc.wantRDC)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a per-share **`durability`** enum to the local block-store config, composing the existing knobs into three named, discoverable tiers.

```bash
dfsctl store block local edit <share> --config '{"durability": "remote"}'
```

| `durability` | Ack after | Survives | ~ops/s (create nj=8) |
|---|---|---|--:|
| `local` *(default)* | local journal + metadata `fsync` | process/node crash | ~900 |
| `writeback` | local write, metadata `fsync` deferred ~100 ms | crash, ≤100 ms metadata loss | ~1680 |
| `remote` | data durable in S3 | node/disk loss | slow (by design) |

## Composition (no new mechanism)

The enum drives the two existing per-share behaviors:
- `local` → neither (today's default, unchanged)
- `writeback` → metadata writeback (#1759)
- `remote` → `require_durable_commit` (#1274, block CLOSE/COMMIT acks on S3)

When `durability` is set it is authoritative; when absent the raw `writeback` / `require_durable_commit` bools are honored unchanged (**backward compatible**). Refactors `applyRequireDurableCommit` into a `parseRequireDurableCommit` helper + explicit set at the `AddShare` seam.

## Scope

`local` and `remote` are fully functional. `writeback` selects the metadata-relaxed path (data stays journal-`fsync`'d); the full data-writeback tier's **journal async-commit half remains tracked separately** — it lives in the journal switchover zone and is deferred until that stabilizes.

Docs: `guide/durability.md` now leads with the enum; `configuration.md` cross-links. 13 table-driven tests cover tier resolution, precedence, and backward-compat. `go test -race` green (88 tests), integration build green.