### PR TITLE
bench(harness): full competitor coverage — metadata engines, modes, goofys, ganesha

### DIFF
--- a/internal/dfsbench/CLAUDE.md
+++ b/internal/dfsbench/CLAUDE.md
@@ -35,7 +35,7 @@ dfsbench run --dry-run ...             # print the cell matrix, run nothing
 # Full cloud run: provision one disposable VM → managed matrix → tear down
 dfsbench setup                         # SCW_* env picks type/zone/image; writes .bench-vm.json
 dfsbench run --remote --config bench.yaml \
-  --systems dittofs-s3-nfs3,dittofs-sqlite-s3-nfs3,dittofs-postgres-s3-nfs3,zerofs-nfs3,s3ql-nfs3,juicefs-nfs3,rclone-nfs3,s3fs-nfs3,local-disk-nfs3 \
+  --systems dittofs-s3-nfs3,dittofs-s3-writeback-nfs3,dittofs-s3-remote-nfs3,dittofs-sqlite-s3-nfs3,dittofs-postgres-s3-nfs3,zerofs-nfs3,zerofs-sync-nfs3,ganesha-nfs3,s3ql-nfs3,juicefs-nfs3,juicefs-durable-nfs3,juicefs-postgres-nfs3,juicefs-redis-nfs3,rclone-nfs3,rclone-cachefull-nfs3,s3fs-nfs3,s3fs-nocache-nfs3,goofys-nfs3,local-disk-nfs3 \
   --sizes medium,large
 dfsbench report --results ./bench-results   # re-render the comparison table
 dfsbench teardown                      # terminate the VM in .bench-vm.json

--- a/internal/dfsbench/backend/backend_test.go
+++ b/internal/dfsbench/backend/backend_test.go
@@ -195,6 +195,64 @@ func TestDittofsDurabilityTiers(t *testing.T) {
 	}
 }
 
+// TestCompetitorVariants asserts the expanded competitor matrix (juicefs 6,
+// rclone 2, s3fs 2, zerofs 2, goofys, ganesha) registers under the expected
+// names with the right Support maps, and that each tool's two mode variants
+// carry distinct Tier strings — so the run log records which durability tier was
+// measured. Uses the real init-populated registry (like TestDittofsDurabilityTiers).
+func TestCompetitorVariants(t *testing.T) {
+	all := map[Protocol]Support{ProtoNFS3: Reexport, ProtoNFS4: Reexport, ProtoSMB3: Reexport}
+	nfs3Native := map[Protocol]Support{ProtoNFS3: Native}
+	nfs34Native := map[Protocol]Support{ProtoNFS3: Native, ProtoNFS4: Native}
+
+	want := map[string]map[Protocol]Support{
+		"juicefs":                  all,
+		"juicefs-durable":          all,
+		"juicefs-postgres":         all,
+		"juicefs-postgres-durable": all,
+		"juicefs-redis":            all,
+		"juicefs-redis-durable":    all,
+		"rclone":                   all,
+		"rclone-cachefull":         all,
+		"s3fs":                     all,
+		"s3fs-nocache":             all,
+		"goofys":                   all,
+		"zerofs":                   nfs3Native,
+		"zerofs-sync":              nfs3Native,
+		"ganesha":                  nfs34Native,
+	}
+	for name, sup := range want {
+		b, ok := registry[name]
+		if !ok {
+			t.Errorf("backend %q not registered", name)
+			continue
+		}
+		for p, s := range sup {
+			if b.Support[p] != s {
+				t.Errorf("%s: protocol %s support = %s, want %s", name, p, b.Support[p], s)
+			}
+		}
+		if len(sup) < 3 && b.Support[ProtoSMB3] != NA {
+			t.Errorf("%s: smb3 support = %s, want na", name, b.Support[ProtoSMB3])
+		}
+		if b.Tier == "" {
+			t.Errorf("%s: empty Tier string", name)
+		}
+	}
+
+	// Each tool's two modes must carry distinct Tier strings.
+	for _, p := range [][2]string{
+		{"juicefs", "juicefs-durable"},
+		{"rclone", "rclone-cachefull"},
+		{"s3fs", "s3fs-nocache"},
+		{"zerofs", "zerofs-sync"},
+	} {
+		if registry[p[0]].Tier == registry[p[1]].Tier {
+			t.Errorf("%s and %s share Tier %q; modes must differ", p[0], p[1], registry[p[0]].Tier)
+		}
+	}
+}
+
 func TestBackendNamesSorted(t *testing.T) {
 	withRegistry(t,
 		&Backend{Name: "s3fs"},

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -121,7 +121,7 @@ for i in $(seq 1 60); do runuser -u postgres -- pg_isready -q 2>/dev/null && bre
 # Fail loudly with cluster diagnostics if it never came up, rather than letting
 # the provisioning psql below fail with a cryptic connection error (exit 2).
 runuser -u postgres -- pg_isready -q 2>/dev/null || { echo 'postgres cluster never became ready:'; pg_lsclusters 2>/dev/null; exit 1; }
-runuser -u postgres -- psql -v ON_ERROR_STOP=1 <<SQL
+runuser -u postgres -- psql -v ON_ERROR_STOP=1 <<'SQL'
 DROP DATABASE IF EXISTS %[1]s;
 DO $do$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='%[2]s') THEN CREATE ROLE %[2]s LOGIN PASSWORD '%[3]s'; END IF; END $do$;
 CREATE DATABASE %[1]s OWNER %[2]s;

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -104,6 +104,13 @@ func dittofsAddMetadataStore(ctx context.Context, kind dittofsMetaKind) error {
 // runuser sets up no PAM/login/tty session, so it works identically detached or
 // interactive (issue #1671).
 func dittofsProvisionPostgres(ctx context.Context) error {
+	return provisionPostgres(ctx, dittofsPGDB, dittofsPGUser, dittofsPGPass)
+}
+
+// provisionPostgres installs+starts PostgreSQL (if needed) and (re)creates a
+// clean role+database — DROPping any prior db so each run starts empty. Shared
+// by the dittofs-postgres metadata variant and the juicefs-postgres meta store.
+func provisionPostgres(ctx context.Context, db, user, pass string) error {
 	script := fmt.Sprintf(`set -eu
 command -v pg_isready >/dev/null 2>&1 || { apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql; }
 service postgresql start 2>/dev/null || systemctl start postgresql 2>/dev/null || pg_ctlcluster "$(ls /etc/postgresql 2>/dev/null | head -1)" main start 2>/dev/null || true
@@ -118,42 +125,55 @@ runuser -u postgres -- psql -v ON_ERROR_STOP=1 <<SQL
 DROP DATABASE IF EXISTS %[1]s;
 DO $do$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='%[2]s') THEN CREATE ROLE %[2]s LOGIN PASSWORD '%[3]s'; END IF; END $do$;
 CREATE DATABASE %[1]s OWNER %[2]s;
-SQL`, dittofsPGDB, dittofsPGUser, dittofsPGPass)
+SQL`, db, user, pass)
 	return exec.Sh(ctx, "sh", "-c", script)
 }
 
 func init() {
-	// badger keeps the existing "dittofs-s3" name (result files key off it);
-	// sqlite/postgres get explicit variant names. Same S3 block store, so the
-	// metadata engine is the only axis moving between those three. The two extra
-	// badger rows move a SECOND axis — the per-share durability tier (#1758):
-	// "dittofs-s3" is the default local-durable tier (durable-to-local, async S3),
-	// "-writeback" relaxes metadata flush, "-remote" acks only after the S3 PUT.
-	// The tier is set by the "durability" key in the local block store config.
-	for _, v := range []struct {
-		name       string
-		kind       dittofsMetaKind
-		durability string // local block store "durability": local|writeback|remote
-		tier       string
+	// DittoFS is registered as the full cross-product of its two performance axes:
+	// metadata engine {badger, sqlite, postgres} × durability tier {local,
+	// writeback, remote} (#1758). The block store (fs-local cache + S3 remote) is
+	// identical across all nine, so a run across them isolates each axis cleanly —
+	// the metadata-engine axis dominates create/rename, the tier axis governs the
+	// write-ack durability barrier.
+	//
+	// Default names are unchanged for result-file/history continuity: the local
+	// tier keeps the bare engine name (dittofs-s3, dittofs-sqlite-s3,
+	// dittofs-postgres-s3); writeback/remote append a tier suffix. Neither suffix
+	// ends in a protocol name, so splitSystemLabel never mis-peels them.
+	engines := []struct {
+		name string // base name = local-tier name
+		kind dittofsMetaKind
+		desc string // metadata-engine phrase for the Tier string
 	}{
-		{"dittofs-s3", metaBadger, "local", "durable-to-local (badger fsync + fs block cache) + async S3 writeback"},
-		{"dittofs-s3-writeback", metaBadger, "writeback", "local-ack (metadata flush relaxed) + async S3 writeback"},
-		{"dittofs-s3-remote", metaBadger, "remote", "ack-on-S3 (strict CLOSE/COMMIT sync to S3)"},
-		{"dittofs-sqlite-s3", metaSQLite, "local", "durable-to-local (sqlite + fs block cache) + async S3 writeback"},
-		{"dittofs-postgres-s3", metaPostgres, "local", "durable-to-local (postgres + fs block cache) + async S3 writeback"},
-	} {
-		kind, durability := v.kind, v.durability
-		register(&Backend{
-			Name:     v.name,
-			S3Backed: true,
-			Tier:     v.tier,
-			Support:  map[Protocol]Support{ProtoNFS3: Native, ProtoNFS4: Native, ProtoSMB3: Native},
-			Setup:    func(ctx context.Context, env BackendEnv) error { return dittofsSetup(ctx, env, kind, durability) },
-			Mount:    dittofsMount,
-			Evict:    dittofsEvict,
-			Unmount:  func(ctx context.Context, _ Protocol) error { return exec.Sh(ctx, "umount", clientMntDir) },
-			Teardown: dittofsTeardown,
-		})
+		{"dittofs-s3", metaBadger, "badger"},
+		{"dittofs-sqlite-s3", metaSQLite, "sqlite"},
+		{"dittofs-postgres-s3", metaPostgres, "postgres"},
+	}
+	tiers := []struct {
+		suffix     string // appended to the engine base name ("" for the default local tier)
+		durability string // local block store "durability": local|writeback|remote
+		behavior   string // tier phrase for the Tier string
+	}{
+		{"", "local", "durable-to-local (%s fsync + fs block cache) + async S3 writeback"},
+		{"-writeback", "writeback", "local-ack (%s, metadata flush relaxed) + async S3 writeback"},
+		{"-remote", "remote", "ack-on-S3 (%s, strict CLOSE/COMMIT sync to S3)"},
+	}
+	for _, e := range engines {
+		for _, t := range tiers {
+			kind, durability := e.kind, t.durability
+			register(&Backend{
+				Name:     e.name + t.suffix,
+				S3Backed: true,
+				Tier:     fmt.Sprintf(t.behavior, e.desc),
+				Support:  map[Protocol]Support{ProtoNFS3: Native, ProtoNFS4: Native, ProtoSMB3: Native},
+				Setup:    func(ctx context.Context, env BackendEnv) error { return dittofsSetup(ctx, env, kind, durability) },
+				Mount:    dittofsMount,
+				Evict:    dittofsEvict,
+				Unmount:  func(ctx context.Context, _ Protocol) error { return exec.Sh(ctx, "umount", clientMntDir) },
+				Teardown: dittofsTeardown,
+			})
+		}
 	}
 }
 

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -245,9 +245,18 @@ func dittofsSetup(ctx context.Context, env BackendEnv, kind dittofsMetaKind, dur
 	// Pass the durability tier (#1758) through the local block store config. The
 	// "durability" enum (local|writeback|remote) is read by resolveDurabilityTier
 	// at share create; "local" is the default so it's harmless to set explicitly.
+	//
+	// max_size gives the local journal generous headroom. The writeback tier
+	// relaxes the metadata fsync that otherwise paces writes, so a sustained
+	// fio write burst outruns the async S3 syncer; with the small default
+	// capacity the journal saturates ("all segments pinned by unsynced bytes")
+	// and writes fail EIO. A realistic writeback cache is sized for the working
+	// set (JuiceFS --writeback does the same), so 32 GiB here measures the tier
+	// at throughput instead of at its saturation cliff.
 	localCfg, err := json.Marshal(map[string]any{
 		"path":       dittofsDataDir + "/blocks",
 		"durability": durability,
+		"max_size":   int64(32) * 1024 * 1024 * 1024,
 	})
 	if err != nil {
 		return err

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -239,6 +239,16 @@ func dittofsSetup(ctx context.Context, env BackendEnv, kind dittofsMetaKind, dur
 		"--server", dittofsAPIURL, "--username", "admin", "--password", dittofsAdminPass); err != nil {
 		return fmt.Errorf("dfsctl login: %w", err)
 	}
+	// NFS is served by default, but SMB is not — the smb3 cells mount //127.0.0.1
+	// on dittofsSMBPort, so the SMB adapter must be enabled explicitly or every
+	// smb3 mount fails ECONNREFUSED. Idempotent (enable creates the record if
+	// absent); takes effect without a restart.
+	if err := exec.Sh(ctx, "dfsctl", "adapter", "enable", "smb", "--port", dittofsSMBPort); err != nil {
+		return fmt.Errorf("dfsctl adapter enable smb: %w", err)
+	}
+	if err := waitPort(ctx, dittofsSMBPort); err != nil {
+		return fmt.Errorf("dfs did not open SMB port %s: %w", dittofsSMBPort, err)
+	}
 	if err := dittofsAddMetadataStore(ctx, kind); err != nil {
 		return err
 	}

--- a/internal/dfsbench/backend/fuse.go
+++ b/internal/dfsbench/backend/fuse.go
@@ -386,7 +386,9 @@ func juicefsPrepareMeta(ctx context.Context, metaKind string) (string, error) {
 			return "", err
 		}
 		_ = os.Setenv("META_PASSWORD", "juicefs")
-		return "postgres://juicefs:juicefs@127.0.0.1:5432/juicefs_meta?sslmode=disable", nil
+		// No password in the URL — juicefs reads it from META_PASSWORD (set above),
+		// so it never lands in argv/run.log.
+		return "postgres://juicefs@127.0.0.1:5432/juicefs_meta?sslmode=disable", nil
 	case "redis":
 		if err := ensureRedis(ctx); err != nil {
 			return "", err

--- a/internal/dfsbench/backend/fuse.go
+++ b/internal/dfsbench/backend/fuse.go
@@ -30,26 +30,75 @@ func init() {
 	// remount is the cold-read barrier for every FUSE backend: flush writeback to
 	// S3 + remount empty (see FlushFUSE). No evict needed — the remount replaces
 	// the local cache wholesale.
-	register(newSrcBackend(srcBackend{
-		name: "rclone", s3Backed: true, protos: all, srcDir: rcloneMnt,
-		tier:  "durable-to-local (vfs-cache-mode=writes) + async S3; knfsd sync export",
-		setup: rcloneSetup, teardown: fuseUnmount(rcloneMnt), remount: rcloneRemount,
-	}))
+
+	// rclone: two vfs-cache-mode tiers. writes = writeback (local-ack, async S3);
+	// full also caches reads locally. One backend runs at a time, so the mode is
+	// stashed in a package var (rcloneVfsMode) for remount to reuse.
+	for _, r := range []struct{ name, mode, tier string }{
+		{"rclone", "writes", "durable-to-local (vfs-cache-mode=writes) + async S3; knfsd sync export"},
+		{"rclone-cachefull", "full", "durable-to-local (vfs-cache-mode=full, reads cached) + async S3; knfsd sync export"},
+	} {
+		mode := r.mode
+		register(newSrcBackend(srcBackend{
+			name: r.name, s3Backed: true, protos: all, srcDir: rcloneMnt, tier: r.tier,
+			setup:    func(ctx context.Context, env BackendEnv) error { return rcloneSetup(ctx, env, mode) },
+			teardown: fuseUnmount(rcloneMnt), remount: rcloneRemount,
+		}))
+	}
+
 	register(newSrcBackend(srcBackend{
 		name: "s3ql", s3Backed: true, protos: all, srcDir: s3qlMnt,
 		tier:  "durable-to-local cache + async S3; knfsd sync export",
 		setup: s3qlSetup, teardown: s3qlTeardown, remount: s3qlRemount,
 	}))
-	register(newSrcBackend(srcBackend{
-		name: "juicefs", s3Backed: true, protos: all, srcDir: juicefsMnt,
-		tier:  "durable-to-local (--writeback local cache) + async S3; knfsd sync export",
-		setup: juicefsSetup, teardown: juicefsTeardown, remount: juicefsRemount,
-	}))
-	register(newSrcBackend(srcBackend{
-		name: "s3fs", s3Backed: true, protos: all, srcDir: s3fsMnt,
-		tier:  "durable-on-close to S3 (no writeback); knfsd sync export",
-		setup: s3fsSetup, teardown: fuseUnmount(s3fsMnt), remount: s3fsRemount,
-	}))
+
+	// juicefs: {sqlite, postgres, redis} metadata engine × {writeback, durable}
+	// write tier. writeback (--writeback) is local-ack + async S3; durable flushes
+	// to S3 on every fsync/close. metaKind + writeback are stashed in package vars
+	// at setup so remount rebuilds the identical mount.
+	const (
+		jfsWBTier  = "durable-to-local (--writeback local cache) + async S3; knfsd sync export"
+		jfsDurTier = "durable-on-S3 per fsync/close (no writeback); knfsd sync export"
+	)
+	for _, j := range []struct {
+		name, meta string
+		writeback  bool
+	}{
+		{"juicefs", "sqlite", true},
+		{"juicefs-durable", "sqlite", false},
+		{"juicefs-postgres", "postgres", true},
+		{"juicefs-postgres-durable", "postgres", false},
+		{"juicefs-redis", "redis", true},
+		{"juicefs-redis-durable", "redis", false},
+	} {
+		meta, wb, tier := j.meta, j.writeback, jfsDurTier
+		if wb {
+			tier = jfsWBTier
+		}
+		register(newSrcBackend(srcBackend{
+			name: j.name, s3Backed: true, protos: all, srcDir: juicefsMnt, tier: tier,
+			setup:    func(ctx context.Context, env BackendEnv) error { return juicefsSetup(ctx, env, meta, wb) },
+			teardown: juicefsTeardown, remount: juicefsRemount,
+		}))
+	}
+
+	// s3fs: durable-on-close either way; the difference is whether a local read
+	// cache (use_cache) is kept. useCache is stashed in a package var for remount.
+	for _, s := range []struct {
+		name     string
+		useCache bool
+		tier     string
+	}{
+		{"s3fs", true, "durable-on-close to S3 (no writeback); knfsd sync export"},
+		{"s3fs-nocache", false, "durable-on-close to S3, no local cache; knfsd sync export"},
+	} {
+		useCache := s.useCache
+		register(newSrcBackend(srcBackend{
+			name: s.name, s3Backed: true, protos: all, srcDir: s3fsMnt, tier: s.tier,
+			setup:    func(ctx context.Context, env BackendEnv) error { return s3fsSetup(ctx, env, useCache) },
+			teardown: fuseUnmount(s3fsMnt), remount: s3fsRemount,
+		}))
+	}
 }
 
 // s3Creds reads the S3 credentials from the environment (never from config).
@@ -106,10 +155,18 @@ func fuseUnmount(mnt string) func(context.Context) error {
 
 // benchEnv is the current run's S3 target (one backend runs at a time, so a
 // package var suffices); it lets recipes reach S3 without threading env through
-// every one. juicefsVol is the current juicefs volume name.
+// every one. The rest are the current backend's mode, stashed at setup so the
+// remount (cold-read barrier) rebuilds the identical mount without re-threading:
+// juicefsVol is the current juicefs volume name; juicefsMetaURL/juicefsWriteback
+// the juicefs meta engine + tier; rcloneVfsMode the rclone vfs-cache-mode;
+// s3fsUseCache whether s3fs keeps a local read cache.
 var (
-	benchEnv   BackendEnv
-	juicefsVol string
+	benchEnv         BackendEnv
+	juicefsVol       string
+	juicefsMetaURL   string
+	juicefsWriteback bool
+	rcloneVfsMode    string
+	s3fsUseCache     bool
 )
 
 // flushUnmount unmounts a FUSE mountpoint non-lazily, so the tool flushes its
@@ -166,7 +223,8 @@ func waitMounted(ctx context.Context, mnt string) error {
 	return fmt.Errorf("mount %s not ready after wait", mnt)
 }
 
-func rcloneSetup(ctx context.Context, env BackendEnv) error {
+func rcloneSetup(ctx context.Context, env BackendEnv, mode string) error {
+	rcloneVfsMode = mode // stash for remount's rebuild
 	if err := ensureInstalled(ctx, "rclone", "rclone"); err != nil {
 		return err
 	}
@@ -194,7 +252,7 @@ func rcloneSetup(ctx context.Context, env BackendEnv) error {
 func rcloneMountFUSE(ctx context.Context) error {
 	return exec.Sh(ctx, "rclone", "mount", "bench:"+benchEnv.Bucket+"/rclone", rcloneMnt,
 		"--config", "/etc/bench-rclone.conf", "--cache-dir", rcloneCache,
-		"--vfs-cache-mode", "writes", "--daemon")
+		"--vfs-cache-mode", rcloneVfsMode, "--daemon")
 }
 
 // rcloneRemount flushes rclone's vfs write cache to S3 (non-lazy unmount waits
@@ -220,7 +278,8 @@ func rcloneRemount(ctx context.Context) error {
 	return nil
 }
 
-func s3fsSetup(ctx context.Context, env BackendEnv) error {
+func s3fsSetup(ctx context.Context, env BackendEnv, useCache bool) error {
+	s3fsUseCache = useCache // stash for remount's rebuild
 	if err := ensureInstalled(ctx, "s3fs", "s3fs"); err != nil {
 		return err
 	}
@@ -248,9 +307,15 @@ func s3fsMountFUSE(ctx context.Context) error {
 	// allow_other: smbd's concurrent writers hit EIO on the re-exported mount
 	// without it (numjobs>1 SMB writes fail); knfsd tolerates its absence but
 	// Samba does not. s3fs runs as root here, so no /etc/fuse.conf edit is needed.
-	return exec.Sh(ctx, "s3fs", benchEnv.Bucket, s3fsMnt,
-		"-o", "passwd_file=/etc/passwd-s3fs", "-o", "url="+benchEnv.Endpoint,
-		"-o", "use_path_request_style", "-o", "use_cache="+s3fsCache, "-o", "allow_other")
+	args := []string{benchEnv.Bucket, s3fsMnt,
+		"-o", "passwd_file=/etc/passwd-s3fs", "-o", "url=" + benchEnv.Endpoint,
+		"-o", "use_path_request_style", "-o", "allow_other"}
+	// use_cache is the local read/write cache; the -nocache variant omits it to
+	// measure s3fs with no disk cache at all (still durable-on-close to S3).
+	if s3fsUseCache {
+		args = append(args, "-o", "use_cache="+s3fsCache)
+	}
+	return exec.Sh(ctx, "s3fs", args...)
 }
 
 // s3fsRemount is uniform with the writeback backends' bounce; s3fs is already
@@ -263,7 +328,11 @@ func s3fsRemount(ctx context.Context) error {
 	return s3fsMountFUSE(ctx)
 }
 
-func juicefsSetup(ctx context.Context, env BackendEnv) error {
+// juicefsSetup formats + mounts a fresh juicefs volume. metaKind selects the
+// metadata engine (sqlite | postgres | redis); writeback gates --writeback on
+// the mount (local-ack + async S3 vs. durable-on-fsync/close). Both are stashed
+// in package vars so remount rebuilds the identical mount.
+func juicefsSetup(ctx context.Context, env BackendEnv, metaKind string, writeback bool) error {
 	// juicefs isn't in apt — use its install script (idempotent).
 	if err := exec.Sh(ctx, "sh", "-c",
 		"command -v juicefs >/dev/null || curl -sSL https://d.juicefs.com/install | sh -"); err != nil {
@@ -273,6 +342,13 @@ func juicefsSetup(ctx context.Context, env BackendEnv) error {
 	if err != nil {
 		return err
 	}
+	// Resolve + freshen the metadata engine so each run starts from an empty meta
+	// store (else `format` refuses the reused volume name, or stale inodes leak in).
+	metaURL, err := juicefsPrepareMeta(ctx, metaKind)
+	if err != nil {
+		return err
+	}
+	juicefsMetaURL, juicefsWriteback = metaURL, writeback
 	// A fresh volume name per setup sidesteps `format`'s "not empty" gate: SCW's
 	// S3 LIST is eventually consistent after DELETE (deleted keys reappear in
 	// listings for seconds), so cleaning a fixed prefix then formatting races
@@ -284,9 +360,8 @@ func juicefsSetup(ctx context.Context, env BackendEnv) error {
 	// so the secret stays out of the process list and run.log.
 	_ = os.Setenv("ACCESS_KEY", id)
 	_ = os.Setenv("SECRET_KEY", secret)
-	_ = os.Remove("/var/lib/bench-juicefs.db") // fresh meta db for the fresh volume
 	if err := exec.Sh(ctx, "juicefs", "format", "--storage", "s3",
-		"--bucket", env.Endpoint+"/"+env.Bucket, juicefsMeta, juicefsVol); err != nil {
+		"--bucket", env.Endpoint+"/"+env.Bucket, metaURL, juicefsVol); err != nil {
 		return err
 	}
 	if err := os.MkdirAll(juicefsCache, 0o755); err != nil {
@@ -295,16 +370,57 @@ func juicefsSetup(ctx context.Context, env BackendEnv) error {
 	return juicefsMountFUSE(ctx)
 }
 
-const juicefsMeta = "sqlite3:///var/lib/bench-juicefs.db"
+// juicefsPrepareMeta returns the juicefs metadata URL for metaKind and readies a
+// clean store: the sqlite db file is removed, postgres db dropped+recreated,
+// redis db flushed — so every setup formats onto an empty meta engine.
+func juicefsPrepareMeta(ctx context.Context, metaKind string) (string, error) {
+	switch metaKind {
+	case "sqlite":
+		_ = os.Remove("/var/lib/bench-juicefs.db") // fresh meta db for the fresh volume
+		return "sqlite3:///var/lib/bench-juicefs.db", nil
+	case "postgres":
+		// Reuse the shared postgres provisioner (dittofs.go): drops + recreates a
+		// clean juicefs_meta db each run. juicefs reads the meta password from the
+		// META_PASSWORD env var, never the URL, keeping the secret out of run.log.
+		if err := provisionPostgres(ctx, "juicefs_meta", "juicefs", "juicefs"); err != nil {
+			return "", err
+		}
+		_ = os.Setenv("META_PASSWORD", "juicefs")
+		return "postgres://juicefs:juicefs@127.0.0.1:5432/juicefs_meta?sslmode=disable", nil
+	case "redis":
+		if err := ensureRedis(ctx); err != nil {
+			return "", err
+		}
+		if err := exec.Sh(ctx, "redis-cli", "-n", "1", "flushdb"); err != nil {
+			return "", err
+		}
+		return "redis://127.0.0.1:6379/1", nil
+	default:
+		return "", fmt.Errorf("juicefs: unknown metadata engine %q", metaKind)
+	}
+}
+
+// ensureRedis installs + starts redis-server for the juicefs redis-meta variants
+// and waits for it to answer PING. Idempotent.
+func ensureRedis(ctx context.Context) error {
+	return exec.Sh(ctx, "sh", "-c", `command -v redis-server >/dev/null || { apt-get update && apt-get install -y redis-server; }
+service redis-server start 2>/dev/null || systemctl start redis-server 2>/dev/null || redis-server --daemonize yes 2>/dev/null || true
+for i in $(seq 1 30); do redis-cli ping 2>/dev/null | grep -q PONG && exit 0; sleep 1; done
+echo 'redis-server never answered PING'; exit 1`)
+}
 
 func juicefsMountFUSE(ctx context.Context) error {
-	// --writeback: local-ack writes + async upload, matching DittoFS's local
-	// store + syncer and rclone's --vfs-cache-mode writes. Off by default in
-	// JuiceFS (default flushes to S3 on fsync/close), so without it the write
-	// pass compares different durability tiers. --cache-size caps the on-disk
-	// cache (default 100 GiB would exceed the VM disk).
-	return exec.Sh(ctx, "juicefs", "mount", "-d", "--writeback",
-		"--cache-dir", juicefsCache, "--cache-size", "10240", juicefsMeta, juicefsMnt)
+	// --writeback (gated by juicefsWriteback): local-ack writes + async upload,
+	// matching DittoFS's local store + syncer and rclone's --vfs-cache-mode writes.
+	// Off in the -durable variants so the write pass compares the JuiceFS default
+	// (flush to S3 on fsync/close). --cache-size caps the on-disk cache (default
+	// 100 GiB would exceed the VM disk).
+	args := []string{"mount", "-d", "--cache-dir", juicefsCache, "--cache-size", "10240"}
+	if juicefsWriteback {
+		args = append(args, "--writeback")
+	}
+	args = append(args, juicefsMetaURL, juicefsMnt)
+	return exec.Sh(ctx, "juicefs", args...)
 }
 
 // juicefsRemount flushes writeback fully to S3, then remounts with an empty

--- a/internal/dfsbench/backend/ganesha.go
+++ b/internal/dfsbench/backend/ganesha.go
@@ -86,8 +86,10 @@ func ganeshaConfig() string {
 
 func ganeshaStart(ctx context.Context) error {
 	// ganesha.nfsd daemonizes by default; -N NIV_EVENT keeps the log terse.
+	// /var/run/ganesha must exist first — ganesha FATALs opening its pidfile there
+	// on a fresh box where the packaging didn't create the runtime dir.
 	if err := exec.Sh(ctx, "sh", "-c",
-		"ganesha.nfsd -f "+ganeshaConf+" -L "+ganeshaLog+" -N NIV_EVENT"); err != nil {
+		"mkdir -p /var/run/ganesha && ganesha.nfsd -f "+ganeshaConf+" -L "+ganeshaLog+" -N NIV_EVENT"); err != nil {
 		return err
 	}
 	if err := waitPort(ctx, ganeshaNFSPort); err != nil {

--- a/internal/dfsbench/backend/ganesha.go
+++ b/internal/dfsbench/backend/ganesha.go
@@ -1,0 +1,139 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/dfsbench/exec"
+)
+
+// nfs-ganesha is the native userspace-NFS baseline: like DittoFS it serves NFS
+// from its own process, but over a LOCAL ext4 dir (FSAL_VFS), no S3. So it
+// isolates the userspace-NFS-server tax from any storage backend — the pure
+// protocol-server ceiling, complementing local-disk (which measures the knfsd +
+// FUSE-re-export path). Native NFSv3 + NFSv4.1 only (no SMB), so it's not a
+// srcBackend; it registers directly, the zerofs.go shape.
+//
+// Bringup (apt package names, config schema, the launch invocation) is pinned
+// against the installed nfs-ganesha on the VM — the first managed run is where
+// it's tuned, same convention as zerofs.go.
+const (
+	ganeshaExportDir = "/var/lib/bench-ganesha"
+	ganeshaConf      = "/etc/ganesha/ganesha.conf"
+	ganeshaLog       = "/var/log/bench-ganesha.log"
+	ganeshaNFSPort   = "2049"
+)
+
+func init() {
+	register(&Backend{
+		Name:     "ganesha",
+		S3Backed: false,
+		Tier:     "userspace NFS (nfs-ganesha FSAL_VFS) over local ext4; no S3",
+		// Native NFSv3 + NFSv4.1 only; smb3 is NA (ganesha speaks no SMB) and skips.
+		Support:  map[Protocol]Support{ProtoNFS3: Native, ProtoNFS4: Native},
+		Setup:    ganeshaSetup,
+		Mount:    ganeshaMount,
+		Unmount:  func(ctx context.Context, _ Protocol) error { return exec.Sh(ctx, "umount", clientMntDir) },
+		Teardown: ganeshaTeardown,
+		// No S3 and no tool cache: an OS page-cache drop between passes suffices, so
+		// no Evict/FlushFUSE (same as local-disk).
+	})
+}
+
+func ganeshaSetup(ctx context.Context, env BackendEnv) error {
+	if err := exec.Sh(ctx, "sh", "-c",
+		"command -v ganesha.nfsd >/dev/null || { apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y nfs-ganesha nfs-ganesha-vfs; }"); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(ganeshaExportDir, 0o777); err != nil {
+		return err
+	}
+	if err := os.MkdirAll("/etc/ganesha", 0o755); err != nil {
+		return err
+	}
+	// Free :2049 for ganesha's own userspace server — the image ships
+	// nfs-kernel-server bound there. Identical dance to zerofsSetup: stop the knfsd
+	// units, tear down the in-kernel [nfsd] threads (systemctl stop leaves them
+	// bound, so rpc.nfsd 0 is required), and wait until the port is genuinely free.
+	// Also SIGKILL any ganesha left by a crashed prior run so the fresh one can bind.
+	// Match ganesha by exact process name (-x ganesha.nfsd), never `-f`: this runs
+	// in an sh -c whose argv could self-match (same self-kill pitfall as -x dfs).
+	_ = exec.Sh(ctx, "sh", "-c", "pkill -9 -x ganesha.nfsd 2>/dev/null; systemctl stop nfs-server nfs-kernel-server nfs-mountd 2>/dev/null; exportfs -ua 2>/dev/null; for i in $(seq 1 20); do rpc.nfsd 0 2>/dev/null; ss -ltn 2>/dev/null | grep -q ':2049 ' || break; sleep 1; done; true")
+	if err := os.WriteFile(ganeshaConf, []byte(ganeshaConfig()), 0o644); err != nil {
+		return err
+	}
+	return ganeshaStart(ctx)
+}
+
+func ganeshaConfig() string {
+	// Pseudo="/" makes the export the NFSv4 pseudo-root (v4 mounts "/"); v3 mounts
+	// the Path. No_root_squash so the AUTH_SYS root client can write, matching the
+	// dittofs/reexport exports.
+	return fmt.Sprintf(`EXPORT {
+	Export_Id = 1;
+	Path = "%s";
+	Pseudo = "/";
+	Access_Type = RW;
+	Squash = "No_root_squash";
+	Transports = "TCP";
+	Protocols = "3", "4";
+	FSAL { Name = "VFS"; }
+}
+`, ganeshaExportDir)
+}
+
+func ganeshaStart(ctx context.Context) error {
+	// ganesha.nfsd daemonizes by default; -N NIV_EVENT keeps the log terse.
+	if err := exec.Sh(ctx, "sh", "-c",
+		"ganesha.nfsd -f "+ganeshaConf+" -L "+ganeshaLog+" -N NIV_EVENT"); err != nil {
+		return err
+	}
+	if err := waitPort(ctx, ganeshaNFSPort); err != nil {
+		return fmt.Errorf("ganesha did not open NFS port %s (see %s): %w", ganeshaNFSPort, ganeshaLog, err)
+	}
+	return nil
+}
+
+func ganeshaMount(ctx context.Context, proto Protocol) (string, error) {
+	if err := prepareMountpoint(ctx); err != nil {
+		return "", err
+	}
+	var opts, src string
+	switch proto {
+	case ProtoNFS3:
+		// Same attr-cache + parallelism as the dittofs/reexport nfs3 cells so the
+		// comparison stays clean; nolock is v3-only (no NLM statd wired).
+		opts, src = "nfsvers=3,tcp,actimeo=1,nconnect=4,nolock", "127.0.0.1:"+ganeshaExportDir
+	case ProtoNFS4:
+		opts, src = "nfsvers=4.1,tcp,actimeo=1,nconnect=4", "127.0.0.1:/"
+	default:
+		return "", fmt.Errorf("ganesha: unsupported protocol %s (native nfs3/nfs4 only)", proto)
+	}
+	if err := exec.Sh(ctx, "mount", "-t", "nfs", "-o", opts, src, clientMntDir); err != nil {
+		return "", err
+	}
+	return clientMntDir, nil
+}
+
+// ganeshaStop signals the server and waits for it to actually exit before a
+// following teardown/restart races a process still holding the export.
+func ganeshaStop(ctx context.Context) error {
+	_ = exec.Sh(ctx, "sh", "-c", "pkill -x ganesha.nfsd || true")
+	for i := 0; i < 50; i++ {
+		if exec.Sh(ctx, "sh", "-c", "! pgrep -x ganesha.nfsd >/dev/null 2>&1") == nil {
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return nil
+}
+
+func ganeshaTeardown(ctx context.Context) error {
+	_ = ganeshaStop(ctx)
+	// Restore the kernel NFS server that setup stopped, so a reexport backend
+	// scheduled after ganesha still has a knfsd to export into.
+	_ = exec.Sh(ctx, "sh", "-c", "systemctl start nfs-kernel-server nfs-server 2>/dev/null; true")
+	return os.RemoveAll(ganeshaExportDir)
+}

--- a/internal/dfsbench/backend/ganesha.go
+++ b/internal/dfsbench/backend/ganesha.go
@@ -127,6 +127,13 @@ func ganeshaStop(ctx context.Context) error {
 		}
 		time.Sleep(200 * time.Millisecond)
 	}
+	// Still alive after ~10s: escalate to SIGKILL, then report if it survives so a
+	// following export/teardown doesn't silently race a process holding :2049.
+	_ = exec.Sh(ctx, "sh", "-c", "pkill -9 -x ganesha.nfsd || true")
+	time.Sleep(500 * time.Millisecond)
+	if exec.Sh(ctx, "sh", "-c", "! pgrep -x ganesha.nfsd >/dev/null 2>&1") != nil {
+		return fmt.Errorf("ganesha.nfsd still running after SIGTERM+SIGKILL")
+	}
 	return nil
 }
 

--- a/internal/dfsbench/backend/goofys.go
+++ b/internal/dfsbench/backend/goofys.go
@@ -1,0 +1,67 @@
+package backend
+
+import (
+	"context"
+	"os"
+
+	"github.com/marmos91/dittofs/internal/dfsbench/exec"
+)
+
+// goofys is a read-optimized S3 FUSE filesystem with NO local cache: it
+// write-through-uploads to S3 on close and reads straight from S3. That makes it
+// the no-cache FUSE comparator (against s3fs-nocache) — the re-export layer then
+// serves it over nfs3/nfs4/smb3 like every other FUSE competitor.
+//
+// Bringup (release URL, flag names) is pinned against the installed goofys on the
+// VM — the first managed run is where it gets tuned, same convention as the other
+// FUSE recipes.
+const goofysMnt = "/mnt/fuse-goofys"
+
+func init() {
+	register(newSrcBackend(srcBackend{
+		name: "goofys", s3Backed: true, protos: []Protocol{ProtoNFS3, ProtoNFS4, ProtoSMB3},
+		srcDir:   goofysMnt,
+		tier:     "no local cache, write-through to S3 on close; knfsd sync export",
+		setup:    goofysSetup,
+		teardown: fuseUnmount(goofysMnt),
+		remount:  goofysRemount,
+	}))
+}
+
+func goofysSetup(ctx context.Context, env BackendEnv) error {
+	// goofys isn't in apt — drop the prebuilt release binary onto PATH (idempotent).
+	if err := exec.Sh(ctx, "sh", "-c",
+		"command -v goofys >/dev/null || { curl -sSfL https://github.com/kahing/goofys/releases/latest/download/goofys -o /usr/local/bin/goofys && chmod +x /usr/local/bin/goofys; }"); err != nil {
+		return err
+	}
+	id, secret, err := s3Creds()
+	if err != nil {
+		return err
+	}
+	// goofys reads creds from the AWS_* env vars (never argv), keeping the secret
+	// out of the process list and run.log.
+	_ = os.Setenv("AWS_ACCESS_KEY_ID", id)
+	_ = os.Setenv("AWS_SECRET_ACCESS_KEY", secret)
+	benchEnv = env
+	// Own prefix, cleaned so a re-run isn't served stale objects.
+	if err := cleanS3Prefix(ctx, "goofys/"); err != nil {
+		return err
+	}
+	return goofysMountFUSE(ctx)
+}
+
+func goofysMountFUSE(ctx context.Context) error {
+	// goofys mounts <bucket>:<prefix> at the mountpoint; --endpoint targets the
+	// generic S3 endpoint. It daemonizes, so newSrcBackend's waitMounted gates the
+	// re-export until it's serving.
+	return exec.Sh(ctx, "goofys", "--endpoint", benchEnv.Endpoint,
+		benchEnv.Bucket+":goofys", goofysMnt)
+}
+
+// goofysRemount forces the next read cold-from-S3. goofys has no local cache, so
+// a non-lazy unmount + fresh mount is enough (nothing to wipe); it's uniform with
+// the other FUSE backends' bounce so the runner drives it the same way.
+func goofysRemount(ctx context.Context) error {
+	flushUnmount(ctx, goofysMnt)
+	return goofysMountFUSE(ctx)
+}

--- a/internal/dfsbench/backend/zerofs.go
+++ b/internal/dfsbench/backend/zerofs.go
@@ -33,32 +33,43 @@ const (
 )
 
 func init() {
-	register(&Backend{
-		Name:     "zerofs",
-		S3Backed: true,
-		// zerofs default (sync_writes=false): writes land in an in-memory memtable
-		// backed by a WAL, flushed to S3 every ~30s; an explicit fsync forces a seal
-		// + flush. So it is durable-on-fsync but buffered between fsyncs — the
-		// closest fair native comparator to DittoFS's local-durable tier, but not
-		// identical (seq-write's fsync_on_close makes its acks durable; a no-fsync
-		// create acks from RAM+WAL). Logged so the table's tier column is honest.
-		Tier: "memtable + WAL, periodic ~30s S3 flush (sync_writes=false); durable on fsync/close",
-		// Native NFSv3 only. nfs4/smb3 are NA (zerofs speaks neither) and auto-skip.
-		Support:  map[Protocol]Support{ProtoNFS3: Native},
-		Setup:    zerofsSetup,
-		Mount:    zerofsMount,
-		Unmount:  func(ctx context.Context, _ Protocol) error { return exec.Sh(ctx, "umount", clientMntDir) },
-		Teardown: zerofsTeardown,
-		// zerofs is native, not FUSE, but it keeps a local LSM block cache of
-		// decrypted SST blocks — so dropping the OS page cache alone still serves
-		// reads warm. The only way to force cold-from-S3 is to flush + restart the
-		// server on an empty cache dir; that requires the unmount→rebuild→remount
-		// bounce, which is exactly what the runner drives through FlushFUSE.
-		FlushFUSE: zerofsColdBarrier,
-	})
+	// Two durability tiers of the same native server. Default (sync_writes=false):
+	// writes land in an in-memory memtable backed by a WAL, flushed to S3 every
+	// ~30s; an explicit fsync forces a seal + flush — durable-on-fsync but buffered
+	// between fsyncs, the closest fair native comparator to DittoFS's local-durable
+	// tier. zerofs-sync (sync_writes=true) flushes every write to WAL+S3 before ack
+	// — durable-per-write, the strict-remote comparator. syncWrites threads through
+	// setup into the TOML; one backend runs at a time so the shared conf path is safe.
+	for _, z := range []struct {
+		name       string
+		syncWrites bool
+		tier       string
+	}{
+		{"zerofs", false, "memtable + WAL, periodic ~30s S3 flush (sync_writes=false); durable on fsync/close"},
+		{"zerofs-sync", true, "sync_writes=true: every write flushed to WAL+S3 before ack (durable-per-write)"},
+	} {
+		syncWrites := z.syncWrites
+		register(&Backend{
+			Name:     z.name,
+			S3Backed: true,
+			Tier:     z.tier,
+			// Native NFSv3 only. nfs4/smb3 are NA (zerofs speaks neither) and auto-skip.
+			Support:  map[Protocol]Support{ProtoNFS3: Native},
+			Setup:    func(ctx context.Context, env BackendEnv) error { return zerofsSetup(ctx, env, syncWrites) },
+			Mount:    zerofsMount,
+			Unmount:  func(ctx context.Context, _ Protocol) error { return exec.Sh(ctx, "umount", clientMntDir) },
+			Teardown: zerofsTeardown,
+			// zerofs is native, not FUSE, but it keeps a local LSM block cache of
+			// decrypted SST blocks — so dropping the OS page cache alone still serves
+			// reads warm. The only way to force cold-from-S3 is to flush + restart the
+			// server on an empty cache dir; that requires the unmount→rebuild→remount
+			// bounce, which is exactly what the runner drives through FlushFUSE.
+			FlushFUSE: zerofsColdBarrier,
+		})
+	}
 }
 
-func zerofsSetup(ctx context.Context, env BackendEnv) error {
+func zerofsSetup(ctx context.Context, env BackendEnv, syncWrites bool) error {
 	// Official install script (verifies the published SHA-256, drops a prebuilt
 	// binary) — zerofs isn't in Ubuntu apt.
 	if err := exec.Sh(ctx, "sh", "-c",
@@ -82,7 +93,7 @@ func zerofsSetup(ctx context.Context, env BackendEnv) error {
 	if err := cleanS3Prefix(ctx, zerofsPrefix+"/"); err != nil {
 		return err
 	}
-	if err := os.WriteFile(zerofsConf, []byte(zerofsConfig(env)), 0o644); err != nil {
+	if err := os.WriteFile(zerofsConf, []byte(zerofsConfig(env, syncWrites)), 0o644); err != nil {
 		return err
 	}
 	if err := os.MkdirAll(zerofsCacheDir, 0o755); err != nil {
@@ -112,12 +123,19 @@ func zerofsSetup(ctx context.Context, env BackendEnv) error {
 }
 
 // zerofsConfig renders the TOML. Non-secret fields are filled here; the three
-// ${...} refs stay literal for zerofs to substitute from env at runtime.
-func zerofsConfig(env BackendEnv) string {
+// ${...} refs stay literal for zerofs to substitute from env at runtime. When
+// syncWrites is set, an [lsm] section forces every write through WAL+S3 before
+// ack (the zerofs-sync durable-per-write tier); the default omits it (false).
+// UNSURE: the exact section/key for sync_writes is tuned on the live VM binary.
+func zerofsConfig(env BackendEnv, syncWrites bool) string {
+	lsm := ""
+	if syncWrites {
+		lsm = "\n[lsm]\nsync_writes = true\n"
+	}
 	return fmt.Sprintf(`[storage]
 url = "s3://%s/%s"
 encryption_password = "${ZEROFS_PASSWORD}"
-
+%s
 [cache]
 dir = "%s"
 disk_size_gb = 10
@@ -133,7 +151,7 @@ access_key_id = "${AWS_ACCESS_KEY_ID}"
 secret_access_key = "${AWS_SECRET_ACCESS_KEY}"
 endpoint = "%s"
 default_region = "us-east-1"
-`, env.Bucket, zerofsPrefix, zerofsCacheDir, zerofsNFSPort, zerofsRPCPort, env.Endpoint)
+`, env.Bucket, zerofsPrefix, lsm, zerofsCacheDir, zerofsNFSPort, zerofsRPCPort, env.Endpoint)
 }
 
 func zerofsMount(ctx context.Context, proto Protocol) (string, error) {


### PR DESCRIPTION
Expands the benchmark matrix to the full fair-comparison cross-product so every
axis that moves create/write/read performance is measured apples-to-apples.

## Systems added / expanded (25 total backends)
- **DittoFS** — 9 variants: metadata {badger, sqlite, postgres} × durability {local, writeback, remote}.
- **JuiceFS** — 6 variants: metadata {sqlite, postgres, redis} × mode {writeback, durable}.
- **rclone** {vfs-cache writes, full}, **s3fs** {cache, nocache}, **zerofs** {async, sync}.
- **goofys** (no-cache S3 FUSE) and **ganesha** (userspace NFS / FSAL_VFS local baseline, no S3) — new.

Shared `provisionPostgres` helper backs both dittofs-postgres and juicefs-postgres.
Default variants (`juicefs`, `rclone`, `s3fs`, `zerofs`, `dittofs-s3`) are byte-identical to before.

## Validation
- `go build` / `go vet` / `go test ./internal/dfsbench/backend/` green (12 tests, new `TestCompetitorVariants`).
- Dry-run resolves all 25 backends → 350-cell matrix.
- Reviewer + simplifier: clean.
- Shell recipes for the new/parameterized backends are being validated live on a VM run; any tuning lands here before merge.