### PR TITLE
fix(metadata): backpressure on write contention instead of EIO (#1769)

### DIFF
--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"time"
 
 	"github.com/google/uuid"
@@ -16,8 +17,56 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/acl"
 )
 
-// Maximum number of retries for retryable errors (deadlock, serialization failure)
-const maxTransactionRetries = 3
+// Transaction retry policy (#1769). Under write contention DittoFS must
+// backpressure — block-and-retry until a real budget elapses — not surface EIO
+// to the caller after a fixed handful of attempts. Every competitor
+// (rclone/juicefs) goes slow under the same pressure but never errors; the old
+// 3-attempt / 10-20-30ms budget was routinely exceeded on hot rows (usedBytes
+// counter, parent-dir mtime, quota) under 8 concurrent writers, turning
+// contention into NFS3ErrIO. Only the already-classified transient conflicts
+// (40001 serialization_failure / 40P01 deadlock_detected) are retried;
+// non-transient errors return immediately.
+const (
+	// txRetryBudget bounds how long WithTransaction backpressures on a transient
+	// conflict before giving up and returning the mapped error, so a genuinely
+	// stuck conflict still eventually surfaces — after a real budget, not 60ms.
+	txRetryBudget = 5 * time.Second
+	// txRetryBaseBackoff / txRetryMaxBackoff bound the jittered exponential
+	// backoff between attempts.
+	txRetryBaseBackoff = 5 * time.Millisecond
+	txRetryMaxBackoff  = 200 * time.Millisecond
+)
+
+// txBackoff waits a jittered exponential backoff before the next transaction
+// attempt, bounded by deadline and ctx. It returns true if the caller should
+// retry, or false when the retry budget is exhausted or ctx is done.
+func txBackoff(ctx context.Context, deadline time.Time, attempt int) bool {
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return false
+	}
+	// Full-jitter exponential backoff: base<<attempt capped at max, then a
+	// uniform random in (0, d]. Spreads retries so contending writers don't
+	// resynchronize into a thundering herd.
+	d := txRetryMaxBackoff
+	if attempt < 16 {
+		if s := txRetryBaseBackoff << uint(attempt); s > 0 && s < txRetryMaxBackoff {
+			d = s
+		}
+	}
+	if d > remaining {
+		d = remaining
+	}
+	wait := time.Duration(rand.Int64N(int64(d)) + 1)
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
 
 // ============================================================================
 // Transaction Support
@@ -128,8 +177,20 @@ func (s *PostgresMetadataStore) withTransaction(ctx context.Context, fn func(tx 
 	// resets at COMMIT and never leaks across pooled connections.
 	relaxCommit := relaxed && s.config.RelaxedDurability
 
+	// Backpressure deadline (#1769): retry transient conflicts until this budget
+	// elapses rather than EIOing after a fixed attempt count. Honor an earlier
+	// caller deadline if the ctx carries one.
+	deadline := time.Now().Add(txRetryBudget)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+
 	var lastErr error
-	for attempt := 0; attempt < maxTransactionRetries; attempt++ {
+	for attempt := 0; ; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		// Use a timeout for connection acquisition to prevent indefinite blocking
 		// when the pool is exhausted. This is critical under high concurrent load
 		// (e.g., POSIX compliance tests) where all connections might be in use.
@@ -172,9 +233,10 @@ func (s *PostgresMetadataStore) withTransaction(ctx context.Context, fn func(tx 
 			rollbackCancel()
 			if isRetryableError(err) {
 				lastErr = err
-				// Small backoff before retry
-				time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
-				continue
+				if txBackoff(ctx, deadline, attempt) {
+					continue
+				}
+				break
 			}
 			return err
 		}
@@ -186,8 +248,10 @@ func (s *PostgresMetadataStore) withTransaction(ctx context.Context, fn func(tx 
 			commitCancel()
 			if isRetryableError(err) {
 				lastErr = err
-				time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
-				continue
+				if txBackoff(ctx, deadline, attempt) {
+					continue
+				}
+				break
 			}
 			return err
 		}
@@ -202,7 +266,10 @@ func (s *PostgresMetadataStore) withTransaction(ctx context.Context, fn func(tx 
 		return nil // Success
 	}
 
-	// All retries exhausted
+	// Budget exhausted (or ctx done) while backing off on a transient conflict.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	return mapPgError(lastErr, "WithTransaction", "")
 }
 

--- a/pkg/metadata/store/sqlite/backpressure_test.go
+++ b/pkg/metadata/store/sqlite/backpressure_test.go
@@ -27,7 +27,10 @@ import (
 // directory row across all of them with a tiny busy_timeout. All mutations
 // must succeed.
 func TestSQLite_ConcurrentWritesBackpressureNoEIO(t *testing.T) {
-	ctx := context.Background()
+	// Bound the whole test: if the retry loop ever fails to terminate, fail
+	// with a clear deadline error instead of hanging until `go test -timeout`.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 	dbPath := filepath.Join(t.TempDir(), "backpressure.db")
 
 	newStore := func(autoMigrate bool) metadata.Store {

--- a/pkg/metadata/store/sqlite/backpressure_test.go
+++ b/pkg/metadata/store/sqlite/backpressure_test.go
@@ -1,0 +1,118 @@
+package sqlite_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
+)
+
+// TestSQLite_ConcurrentWritesBackpressureNoEIO is the #1769 regression guard.
+//
+// Under concurrent writers contending on a single hot row (the shared parent
+// directory inode), the metadata store must backpressure — block and retry
+// until the transaction succeeds — never surface metadata.ErrIOError (which
+// maps to NFS3ErrIO / EIO) to the caller. Before the fix, WithTransaction gave
+// up after 3 attempts (10/20/30ms) and returned ErrIOError.
+//
+// A single sqlite store pins MaxOpenConns(1), so writers through one store
+// already serialize at the Go pool and never collide. Real SQLITE_BUSY
+// contention needs multiple connections to the same file, so this test opens
+// several store handles against one on-disk database and hammers the same
+// directory row across all of them with a tiny busy_timeout. All mutations
+// must succeed.
+func TestSQLite_ConcurrentWritesBackpressureNoEIO(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "backpressure.db")
+
+	newStore := func(autoMigrate bool) metadata.Store {
+		t.Helper()
+		cfg := &sqlite.SQLiteMetadataStoreConfig{
+			Path:        dbPath,
+			AutoMigrate: autoMigrate,
+			// A tiny busy_timeout makes colliding writers surface SQLITE_BUSY
+			// almost immediately instead of queueing inside the driver — that is
+			// exactly the transient conflict WithTransaction must backpressure
+			// over, not EIO. With the pre-fix 3-attempt / 10-20-30ms budget this
+			// reliably EIO'd under cross-connection contention.
+			BusyTimeout: 1 * time.Millisecond,
+		}
+		store, err := sqlite.NewSQLiteMetadataStore(ctx, cfg, sqliteTestCapabilities())
+		if err != nil {
+			t.Fatalf("NewSQLiteMetadataStore() failed: %v", err)
+		}
+		t.Cleanup(func() { _ = store.Close() })
+		return store
+	}
+
+	// First handle owns migration + creates the shared share/root row.
+	const share = "/hot"
+	primary := newStore(true)
+	if _, err := primary.CreateRootDirectory(ctx, share, &metadata.FileAttr{Mode: 0o755}); err != nil {
+		t.Fatalf("CreateRootDirectory(%q): %v", share, err)
+	}
+
+	// Several independent connections (one per store handle) to the SAME file so
+	// concurrent writers genuinely collide on the sqlite write lock.
+	const (
+		stores          = 4
+		writersPerStore = 4
+		iters           = 60
+	)
+	handles := []metadata.Store{primary}
+	for i := 1; i < stores; i++ {
+		handles = append(handles, newStore(false))
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, stores*writersPerStore*iters)
+	start := make(chan struct{})
+
+	for _, store := range handles {
+		for w := 0; w < writersPerStore; w++ {
+			wg.Add(1)
+			go func(store metadata.Store) {
+				defer wg.Done()
+				rootHandle, err := store.GetRootHandle(ctx, share)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				<-start // release all writers together to maximize contention
+				for i := 0; i < iters; i++ {
+					err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+						// Read + rewrite the SAME parent-directory inode: a genuine
+						// hot-row write conflict across all connections.
+						f, err := tx.GetFile(ctx, rootHandle)
+						if err != nil {
+							return err
+						}
+						f.Mtime = time.Now()
+						return tx.PutFile(ctx, f)
+					})
+					if err != nil {
+						errCh <- err
+						return
+					}
+				}
+			}(store)
+		}
+	}
+
+	close(start)
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		var se *metadata.StoreError
+		if errors.As(err, &se) && se.Code == metadata.ErrIOError {
+			t.Fatalf("write returned EIO under contention (should backpressure, #1769): %v", err)
+		}
+		t.Fatalf("unexpected error under contention: %v", err)
+	}
+}

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -166,6 +166,12 @@ func (s *SQLiteMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 				}
 				break
 			}
+			// A non-busy error may be the ctx's own cancellation/deadline
+			// surfacing through BeginTx; surface that verbatim rather than
+			// masking it as an I/O error.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
 			return mapDBError(err, "WithTransaction", "")
 		}
 
@@ -189,6 +195,9 @@ func (s *SQLiteMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 					continue
 				}
 				break
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
 			}
 			return mapDBError(err, "WithTransaction", "")
 		}

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"time"
 
 	"github.com/google/uuid"
@@ -14,8 +15,56 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/acl"
 )
 
-// maxTransactionRetries bounds retries on a busy/locked condition.
-const maxTransactionRetries = 3
+// Transaction retry policy (#1769). Under write contention DittoFS must
+// backpressure — block-and-retry until a real budget elapses — not surface EIO
+// to the caller after a fixed handful of attempts. Every competitor
+// (rclone/juicefs) goes slow under the same pressure but never errors; the old
+// 3-attempt / 10-20-30ms budget was routinely exceeded on hot rows (usedBytes
+// counter, parent-dir mtime, quota) under 8 concurrent writers, turning
+// contention into NFS3ErrIO. Only the already-classified transient conflicts
+// (sqlite BUSY/LOCKED) are retried; non-transient errors return immediately.
+const (
+	// txRetryBudget bounds how long WithTransaction backpressures on a transient
+	// conflict before giving up and returning the mapped error. Kept in line with
+	// the sqlite busy_timeout (config default 5s) so a genuinely stuck conflict
+	// still eventually surfaces — after a real budget, not 60ms.
+	txRetryBudget = 5 * time.Second
+	// txRetryBaseBackoff / txRetryMaxBackoff bound the jittered exponential
+	// backoff between attempts.
+	txRetryBaseBackoff = 5 * time.Millisecond
+	txRetryMaxBackoff  = 200 * time.Millisecond
+)
+
+// txBackoff waits a jittered exponential backoff before the next transaction
+// attempt, bounded by deadline and ctx. It returns true if the caller should
+// retry, or false when the retry budget is exhausted or ctx is done.
+func txBackoff(ctx context.Context, deadline time.Time, attempt int) bool {
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return false
+	}
+	// Full-jitter exponential backoff: base<<attempt capped at max, then a
+	// uniform random in (0, d]. Spreads retries so contending writers don't
+	// resynchronize into a thundering herd.
+	d := txRetryMaxBackoff
+	if attempt < 16 {
+		if s := txRetryBaseBackoff << uint(attempt); s > 0 && s < txRetryMaxBackoff {
+			d = s
+		}
+	}
+	if d > remaining {
+		d = remaining
+	}
+	wait := time.Duration(rand.Int64N(int64(d)) + 1)
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
 
 // ============================================================================
 // Transaction Support
@@ -94,14 +143,28 @@ func (s *SQLiteMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 		return err
 	}
 
+	// Backpressure deadline (#1769): retry transient conflicts until this budget
+	// elapses rather than EIOing after a fixed attempt count. Honor an earlier
+	// caller deadline if the ctx carries one.
+	deadline := time.Now().Add(txRetryBudget)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+
 	var lastErr error
-	for attempt := 0; attempt < maxTransactionRetries; attempt++ {
+	for attempt := 0; ; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		rawTx, err := s.db.BeginTx(ctx, nil)
 		if err != nil {
 			if isBusyError(err) {
 				lastErr = err
-				time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
-				continue
+				if txBackoff(ctx, deadline, attempt) {
+					continue
+				}
+				break
 			}
 			return mapDBError(err, "WithTransaction", "")
 		}
@@ -111,8 +174,10 @@ func (s *SQLiteMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 			_ = rawTx.Rollback()
 			if isBusyError(err) {
 				lastErr = err
-				time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
-				continue
+				if txBackoff(ctx, deadline, attempt) {
+					continue
+				}
+				break
 			}
 			return err
 		}
@@ -120,8 +185,10 @@ func (s *SQLiteMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 		if err := rawTx.Commit(); err != nil {
 			if isBusyError(err) {
 				lastErr = err
-				time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
-				continue
+				if txBackoff(ctx, deadline, attempt) {
+					continue
+				}
+				break
 			}
 			return mapDBError(err, "WithTransaction", "")
 		}
@@ -135,7 +202,10 @@ func (s *SQLiteMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 		return nil // Success
 	}
 
-	// All retries exhausted
+	// Budget exhausted (or ctx done) while backing off on a transient conflict.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	return mapDBError(lastErr, "WithTransaction", "")
 }
 


### PR DESCRIPTION
Fixes #1769.

## Problem

Under concurrent writes (8 writers), the sqlite/postgres metadata stores were the only systems in the QoS matrix to return `Input/output error` (EIO) to the client (~50–68 per cell). Competitors (rclone, juicefs, s3fs, zerofs, …) go *slow* under the same pressure but never error — they block/backpressure the writer. Handing an application EIO means the write **failed**, a correctness/data-loss hazard, not a throughput issue.

Root cause: `WithTransaction` in `pkg/metadata/store/{sqlite,postgres}/transaction.go` retried an already-classified transient conflict (sqlite `BUSY`/`LOCKED`; postgres `40001` serialization_failure / `40P01` deadlock_detected) only **3× with a fixed 10/20/30ms backoff**, then mapped to `metadata.ErrIOError` → `NFS3ErrIO`. On hot rows (global `usedBytes` counter, parent-dir mtime, quota) under 8 concurrent writers, that ~60ms budget is routinely exceeded.

## The fix

Replace the fixed 3-attempt loop with a **deadline-bounded backpressure loop** in both stores:

- Loop until a deadline `now + txRetryBudget` (5s default, aligned with the sqlite `busy_timeout`), capped by an earlier `ctx` deadline if one is set; exits immediately on `ctx.Err()`.
- **Jittered exponential backoff** between attempts (5ms base, 200ms cap, full jitter) instead of the fixed 10/20/30ms.
- Retries **only** the already-classified transient conflicts. Non-transient errors return immediately (mapping unchanged).
- On deadline exhaustion, returns the mapped error as before — so a genuinely stuck conflict still eventually EIOs, after a real budget rather than 60ms.
- Error classification, mapping, transaction bodies, and the `usedBytes`/quota schema are all unchanged — this is a retry-policy change only. Journal (#1766) is untouched.

This aligns DittoFS with rclone/juicefs: block-and-succeed under contention rather than surface EIO.

## Tests

- New sqlite concurrency regression test `TestSQLite_ConcurrentWritesBackpressureNoEIO`: opens multiple store handles to one on-disk DB (a single sqlite store pins `MaxOpenConns(1)` and serializes internally, so real `SQLITE_BUSY` needs multiple connections) with a tiny `busy_timeout`, then hammers the same parent-dir row from 16 writers. It **EIOs on the old logic and passes on the new one**; verified stable at `-race -count=8`.
- `go test ./pkg/metadata/storetest/...` and the full sqlite package pass under `-race`.
- Postgres is symmetric; its live-DB concurrency coverage runs in CI.
- `gofmt -s`, `go vet`, `golangci-lint` clean on both changed packages.

Badger (its own test-tunable retry mechanism, ~4 EIO/cell) is intentionally left untouched, per the issue scope.