### PR TITLE
fix(smb): don't block CREATE on parent-dir lease-break ACK (#1768)

### DIFF
--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -694,8 +694,8 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		// Dispatch the break fire-and-forget, WITHOUT waiting for the holder's
 		// LEASE_BREAK_ACK inline (#1768). A new-file CREATE never async-parks, so
 		// waiting here would block the CREATE reply on an ACK the creating client
-		// can only send over the same credit-limited connection — under an fio
-		// create storm the SMB credit window collapses and Linux cifs.ko returns
+		// can only send over the same credit-limited connection — under sustained
+		// fio create load the SMB credit window collapses and Linux cifs.ko returns
 		// EDEADLK. The break notification is still sent (same
 		// BreakLeasesOnOpenConflict dispatch); the holder acks on its own
 		// schedule. Mirrors Samba contend_dirleases → send_break_to_none.

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -691,7 +691,15 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 				hasExcludeKey = true
 			}
 		}
-		if breakErr := h.LeaseManager.BreakParentDirLeasesOnDestructiveCreate(authCtx.Context, parentLockHandle, tree.ShareName, "", excludeParentKey, hasExcludeKey); breakErr != nil {
+		// Dispatch the break fire-and-forget, WITHOUT waiting for the holder's
+		// LEASE_BREAK_ACK inline (#1768). A new-file CREATE never async-parks, so
+		// waiting here would block the CREATE reply on an ACK the creating client
+		// can only send over the same credit-limited connection — under an fio
+		// create storm the SMB credit window collapses and Linux cifs.ko returns
+		// EDEADLK. The break notification is still sent (same
+		// BreakLeasesOnOpenConflict dispatch); the holder acks on its own
+		// schedule. Mirrors Samba contend_dirleases → send_break_to_none.
+		if breakErr := h.LeaseManager.BreakParentDirLeasesOnContentChangeAsync(parentLockHandle, tree.ShareName, "", excludeParentKey, hasExcludeKey); breakErr != nil {
 			logger.Debug("CREATE: parent directory lease break failed", "error", breakErr)
 		}
 	}


### PR DESCRIPTION
Fixes #1768.

## Symptom

Under the benchmark's native-SMB3 create/write workloads, fio fails with `EDEADLK` ("Resource deadlock avoided", errno 35) on fstat/open. Reproduces on every SMB3 create workload; never on NFS.

## Root cause

A brand-new file CREATE never async-parks (`create_post_break.go:221` returns early for new files), so **Step 6e** takes the synchronous path: `BreakParentDirLeasesOnDestructiveCreate` breaks the parent-directory lease and then **blocks inline** in `WaitForBreakCompletion` (up to `parentLeaseBreakWaitTimeout = 5s`) for the holder's `LEASE_BREAK_ACK`.

The holder is the **same client** that is waiting for the CREATE reply — and it can only send the ACK over the same credit-limited SMB connection. Under an fio create storm, every in-flight CREATE pins its credits for the full 5s force-complete window; the client's credit window collapses, it can't send ACKs, and Linux `cifs.ko` returns `-EDEADLK` from `wait_for_free_credits()`. The server emits no deadlock NT status (it has none), which is why this is client-side and SMB-only (NFS has no lease-break-ACK/credit round-trip).

## Fix

Swap the blocking call for the existing fire-and-forget `BreakParentDirLeasesOnContentChangeAsync` (same `BreakLeasesOnOpenConflict` dispatch, no inline ACK-wait). Its docstring already documents that inline waiting "causes a server-side timeout" — it exists for exactly this class of path. The break notification is still sent; the holder ACKs on its own schedule. Mirrors Samba `contend_dirleases → send_break_to_none`.

One-line change (+ rationale comment). Builds clean; 1412 SMB lease+handler unit tests pass.

## Validation

The wire-semantics change (sync→async break on CREATE) must be validated by the **`smb2.dirlease.*` smbtorture profiles** and **WPTS DirectoryLeasing BVT** in CI — those assert the break notification is dispatched (still true here) and exercise the same-client / ParentLeaseKey suppression rules. Not self-merging: wants CI-green + review.

Note: touches the SMB create-break path, which has in-flight refactoring elsewhere — rebase may be needed.