### PR TITLE
bench: cache-cap backend variants for cache-fill study

### DIFF
--- a/internal/dfsbench/backend/backend_test.go
+++ b/internal/dfsbench/backend/backend_test.go
@@ -193,6 +193,22 @@ func TestDittofsDurabilityTiers(t *testing.T) {
 		}
 		tiers[b.Tier] = true
 	}
+
+	// Cache-cap writeback variants (cache-fill study) must also register with
+	// native support. They share the writeback tier semantics, so they are not
+	// part of the distinct-Tier check above.
+	for _, name := range []string{"dittofs-s3-writeback-cap256m", "dittofs-s3-writeback-cap2g"} {
+		b, ok := registry[name]
+		if !ok {
+			t.Errorf("backend %q not registered", name)
+			continue
+		}
+		for _, p := range managedProtocols {
+			if b.Support[p] != Native {
+				t.Errorf("%s: protocol %s support = %s, want native", name, p, b.Support[p])
+			}
+		}
+	}
 }
 
 // TestCompetitorVariants asserts the expanded competitor matrix (juicefs 6,
@@ -220,6 +236,13 @@ func TestCompetitorVariants(t *testing.T) {
 		"zerofs":                   nfs3Native,
 		"zerofs-sync":              nfs3Native,
 		"ganesha":                  nfs34Native,
+		// cache-cap variants (3-scenario cache-fill study)
+		"rclone-cap256m":   all,
+		"rclone-cap2g":     all,
+		"juicefs-cap256m":  all,
+		"juicefs-cap2g":    all,
+		"s3fs-cap256m":     all,
+		"s3fs-cap2g":       all,
 	}
 	for name, sup := range want {
 		b, ok := registry[name]

--- a/internal/dfsbench/backend/backend_test.go
+++ b/internal/dfsbench/backend/backend_test.go
@@ -237,12 +237,12 @@ func TestCompetitorVariants(t *testing.T) {
 		"zerofs-sync":              nfs3Native,
 		"ganesha":                  nfs34Native,
 		// cache-cap variants (3-scenario cache-fill study)
-		"rclone-cap256m":   all,
-		"rclone-cap2g":     all,
-		"juicefs-cap256m":  all,
-		"juicefs-cap2g":    all,
-		"s3fs-cap256m":     all,
-		"s3fs-cap2g":       all,
+		"rclone-cap256m":  all,
+		"rclone-cap2g":    all,
+		"juicefs-cap256m": all,
+		"juicefs-cap2g":   all,
+		"s3fs-cap256m":    all,
+		"s3fs-cap2g":      all,
 	}
 	for name, sup := range want {
 		b, ok := registry[name]

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -62,6 +62,11 @@ const (
 // instead of aborting the cell on a bare deadline (issue #1668).
 const dittofsDrainTimeout = "15m"
 
+// dittofsUnboundedMaxSize is the default local-journal cap: generous headroom so
+// a sustained write burst measures the tier's throughput, not its saturation
+// cliff (see dittofsSetup). The cache-cap study variants pass a small cap instead.
+const dittofsUnboundedMaxSize = int64(32) * 1024 * 1024 * 1024
+
 // dittofsAddMetadataStore registers the subject's metadata store with the
 // engine selected by kind. badger/sqlite need no server; postgres is
 // provisioned on the (throwaway, single-tenant) bench VM first. All three pair
@@ -167,7 +172,9 @@ func init() {
 				S3Backed: true,
 				Tier:     fmt.Sprintf(t.behavior, e.desc),
 				Support:  map[Protocol]Support{ProtoNFS3: Native, ProtoNFS4: Native, ProtoSMB3: Native},
-				Setup:    func(ctx context.Context, env BackendEnv) error { return dittofsSetup(ctx, env, kind, durability) },
+				Setup: func(ctx context.Context, env BackendEnv) error {
+					return dittofsSetup(ctx, env, kind, durability, dittofsUnboundedMaxSize)
+				},
 				Mount:    dittofsMount,
 				Evict:    dittofsEvict,
 				Unmount:  func(ctx context.Context, _ Protocol) error { return exec.Sh(ctx, "umount", clientMntDir) },
@@ -175,9 +182,39 @@ func init() {
 			})
 		}
 	}
+
+	// Cache-cap variants for the cache-fill study: on the writeback tier the
+	// local-ack journal is what fills, so hard-cap max_size below the write
+	// working set and observe whether the journal applies backpressure or errors.
+	// badger engine + writeback tier only (the write path under test); the 32 GiB
+	// rows above are the unbounded scenario. Names don't end in a protocol, so
+	// splitSystemLabel won't mis-peel them.
+	for _, c := range []struct {
+		suffix  string
+		maxSize int64
+		cap     string // human cap for the Tier string
+	}{
+		{"-cap256m", 256 * 1024 * 1024, "256 MiB"},
+		{"-cap2g", 2 * 1024 * 1024 * 1024, "2 GiB"},
+	} {
+		maxSize := c.maxSize
+		register(&Backend{
+			Name:     "dittofs-s3-writeback" + c.suffix,
+			S3Backed: true,
+			Tier:     "local-ack (badger, metadata flush relaxed) + async S3 writeback; local cache capped at " + c.cap,
+			Support:  map[Protocol]Support{ProtoNFS3: Native, ProtoNFS4: Native, ProtoSMB3: Native},
+			Setup: func(ctx context.Context, env BackendEnv) error {
+				return dittofsSetup(ctx, env, metaBadger, "writeback", maxSize)
+			},
+			Mount:    dittofsMount,
+			Evict:    dittofsEvict,
+			Unmount:  func(ctx context.Context, _ Protocol) error { return exec.Sh(ctx, "umount", clientMntDir) },
+			Teardown: dittofsTeardown,
+		})
+	}
 }
 
-func dittofsSetup(ctx context.Context, env BackendEnv, kind dittofsMetaKind, durability string) error {
+func dittofsSetup(ctx context.Context, env BackendEnv, kind dittofsMetaKind, durability string, maxSize int64) error {
 	id, secret, err := s3Creds()
 	if err != nil {
 		return err
@@ -256,17 +293,19 @@ func dittofsSetup(ctx context.Context, env BackendEnv, kind dittofsMetaKind, dur
 	// "durability" enum (local|writeback|remote) is read by resolveDurabilityTier
 	// at share create; "local" is the default so it's harmless to set explicitly.
 	//
-	// max_size gives the local journal generous headroom. The writeback tier
-	// relaxes the metadata fsync that otherwise paces writes, so a sustained
-	// fio write burst outruns the async S3 syncer; with the small default
-	// capacity the journal saturates ("all segments pinned by unsynced bytes")
-	// and writes fail EIO. A realistic writeback cache is sized for the working
-	// set (JuiceFS --writeback does the same), so 32 GiB here measures the tier
-	// at throughput instead of at its saturation cliff.
+	// max_size caps the local journal. The unbounded default (dittofsUnboundedMaxSize,
+	// 32 GiB) gives the writeback tier generous headroom: writeback relaxes the
+	// metadata fsync that otherwise paces writes, so a sustained fio write burst
+	// outruns the async S3 syncer; with a small capacity the journal saturates
+	// ("all segments pinned by unsynced bytes") and writes fail EIO. A realistic
+	// writeback cache is sized for the working set (JuiceFS --writeback does the
+	// same), so the default measures the tier at throughput instead of its
+	// saturation cliff. The cache-cap study variants pass a small maxSize on
+	// purpose, to measure exactly that cliff (backpressure vs error) when it fills.
 	localCfg, err := json.Marshal(map[string]any{
 		"path":       dittofsDataDir + "/blocks",
 		"durability": durability,
-		"max_size":   int64(32) * 1024 * 1024 * 1024,
+		"max_size":   maxSize,
 	})
 	if err != nil {
 		return err

--- a/internal/dfsbench/backend/fuse.go
+++ b/internal/dfsbench/backend/fuse.go
@@ -22,6 +22,11 @@ const (
 	s3qlMnt, s3qlCache       = "/mnt/fuse-s3ql", "/var/cache/bench-s3ql"
 	juicefsMnt, juicefsCache = "/mnt/fuse-juicefs", "/var/cache/bench-juicefs"
 	s3fsMnt, s3fsCache       = "/mnt/fuse-s3fs", "/var/cache/bench-s3fs"
+
+	// juicefsUnboundedCacheMiB is the default --cache-size (MiB): generous headroom
+	// (the tool's own 100 GiB default would exceed the VM disk). The cache-cap
+	// study variants pass a small cache-size instead.
+	juicefsUnboundedCacheMiB = "10240"
 )
 
 func init() {
@@ -32,16 +37,20 @@ func init() {
 	// the local cache wholesale.
 
 	// rclone: two vfs-cache-mode tiers. writes = writeback (local-ack, async S3);
-	// full also caches reads locally. One backend runs at a time, so the mode is
-	// stashed in a package var (rcloneVfsMode) for remount to reuse.
-	for _, r := range []struct{ name, mode, tier string }{
-		{"rclone", "writes", "durable-to-local (vfs-cache-mode=writes) + async S3; knfsd sync export"},
-		{"rclone-cachefull", "full", "durable-to-local (vfs-cache-mode=full, reads cached) + async S3; knfsd sync export"},
+	// full also caches reads locally. The -cap* rows add a vfs cache size cap
+	// (--vfs-cache-max-size) on the writeback tier for the cache-fill study.
+	// One backend runs at a time, so mode + cap are stashed in package vars
+	// (rcloneVfsMode, rcloneVfsCacheMax) for remount to reuse.
+	for _, r := range []struct{ name, mode, cacheMax, tier string }{
+		{"rclone", "writes", "", "durable-to-local (vfs-cache-mode=writes) + async S3; knfsd sync export"},
+		{"rclone-cachefull", "full", "", "durable-to-local (vfs-cache-mode=full, reads cached) + async S3; knfsd sync export"},
+		{"rclone-cap256m", "writes", "256M", "durable-to-local (vfs-cache-mode=writes) + async S3; vfs cache capped at 256 MiB; knfsd sync export"},
+		{"rclone-cap2g", "writes", "2G", "durable-to-local (vfs-cache-mode=writes) + async S3; vfs cache capped at 2 GiB; knfsd sync export"},
 	} {
-		mode := r.mode
+		mode, cacheMax := r.mode, r.cacheMax
 		register(newSrcBackend(srcBackend{
 			name: r.name, s3Backed: true, protos: all, srcDir: rcloneMnt, tier: r.tier,
-			setup:    func(ctx context.Context, env BackendEnv) error { return rcloneSetup(ctx, env, mode) },
+			setup:    func(ctx context.Context, env BackendEnv) error { return rcloneSetup(ctx, env, mode, cacheMax) },
 			teardown: fuseUnmount(rcloneMnt), remount: rcloneRemount,
 		}))
 	}
@@ -60,42 +69,52 @@ func init() {
 		jfsWBTier  = "durable-to-local (--writeback local cache) + async S3; knfsd sync export"
 		jfsDurTier = "durable-on-S3 per fsync/close (no writeback); knfsd sync export"
 	)
+	// cacheSize is --cache-size in MiB; juicefsUnboundedCacheMiB is the default
+	// headroom. The -cap* rows cap it (256 / 2048 MiB) on the writeback tier for
+	// the cache-fill study. Stashed in a package var so remount rebuilds identically.
 	for _, j := range []struct {
-		name, meta string
-		writeback  bool
+		name, meta, cacheSize, tier string
+		writeback                   bool
 	}{
-		{"juicefs", "sqlite", true},
-		{"juicefs-durable", "sqlite", false},
-		{"juicefs-postgres", "postgres", true},
-		{"juicefs-postgres-durable", "postgres", false},
-		{"juicefs-redis", "redis", true},
-		{"juicefs-redis-durable", "redis", false},
+		{"juicefs", "sqlite", juicefsUnboundedCacheMiB, jfsWBTier, true},
+		{"juicefs-durable", "sqlite", juicefsUnboundedCacheMiB, jfsDurTier, false},
+		{"juicefs-postgres", "postgres", juicefsUnboundedCacheMiB, jfsWBTier, true},
+		{"juicefs-postgres-durable", "postgres", juicefsUnboundedCacheMiB, jfsDurTier, false},
+		{"juicefs-redis", "redis", juicefsUnboundedCacheMiB, jfsWBTier, true},
+		{"juicefs-redis-durable", "redis", juicefsUnboundedCacheMiB, jfsDurTier, false},
+		{"juicefs-cap256m", "sqlite", "256", jfsWBTier + "; local cache capped at 256 MiB", true},
+		{"juicefs-cap2g", "sqlite", "2048", jfsWBTier + "; local cache capped at 2 GiB", true},
 	} {
-		meta, wb, tier := j.meta, j.writeback, jfsDurTier
-		if wb {
-			tier = jfsWBTier
-		}
+		meta, wb, cacheSize := j.meta, j.writeback, j.cacheSize
 		register(newSrcBackend(srcBackend{
-			name: j.name, s3Backed: true, protos: all, srcDir: juicefsMnt, tier: tier,
-			setup:    func(ctx context.Context, env BackendEnv) error { return juicefsSetup(ctx, env, meta, wb) },
+			name: j.name, s3Backed: true, protos: all, srcDir: juicefsMnt, tier: j.tier,
+			setup:    func(ctx context.Context, env BackendEnv) error { return juicefsSetup(ctx, env, meta, wb, cacheSize) },
 			teardown: juicefsTeardown, remount: juicefsRemount,
 		}))
 	}
 
 	// s3fs: durable-on-close either way; the difference is whether a local read
-	// cache (use_cache) is kept. useCache is stashed in a package var for remount.
+	// cache (use_cache) is kept. useCache + ensureFreeMB are stashed in package
+	// vars for remount. The -cap* rows pass -o ensure_diskfree=MB — but note s3fs
+	// has NO cache-size knob: ensure_diskfree bounds free-space-KEPT, not cache
+	// size, so on a big cache disk it does not enforce a true 256 MiB / 2 GiB cap
+	// (it only evicts once the backing disk nears full). It's the closest s3fs
+	// offers; a hard cap would need a size-bounded backing filesystem.
 	for _, s := range []struct {
-		name     string
-		useCache bool
-		tier     string
+		name         string
+		useCache     bool
+		ensureFreeMB string
+		tier         string
 	}{
-		{"s3fs", true, "durable-on-close to S3 (no writeback); knfsd sync export"},
-		{"s3fs-nocache", false, "durable-on-close to S3, no local cache; knfsd sync export"},
+		{"s3fs", true, "", "durable-on-close to S3 (no writeback); knfsd sync export"},
+		{"s3fs-nocache", false, "", "durable-on-close to S3, no local cache; knfsd sync export"},
+		{"s3fs-cap256m", true, "256", "durable-on-close to S3; cache ensure_diskfree=256 MiB (see note); knfsd sync export"},
+		{"s3fs-cap2g", true, "2048", "durable-on-close to S3; cache ensure_diskfree=2048 MiB (see note); knfsd sync export"},
 	} {
-		useCache := s.useCache
+		useCache, ensureFreeMB := s.useCache, s.ensureFreeMB
 		register(newSrcBackend(srcBackend{
 			name: s.name, s3Backed: true, protos: all, srcDir: s3fsMnt, tier: s.tier,
-			setup:    func(ctx context.Context, env BackendEnv) error { return s3fsSetup(ctx, env, useCache) },
+			setup:    func(ctx context.Context, env BackendEnv) error { return s3fsSetup(ctx, env, useCache, ensureFreeMB) },
 			teardown: fuseUnmount(s3fsMnt), remount: s3fsRemount,
 		}))
 	}
@@ -158,15 +177,20 @@ func fuseUnmount(mnt string) func(context.Context) error {
 // every one. The rest are the current backend's mode, stashed at setup so the
 // remount (cold-read barrier) rebuilds the identical mount without re-threading:
 // juicefsVol is the current juicefs volume name; juicefsMetaURL/juicefsWriteback
-// the juicefs meta engine + tier; rcloneVfsMode the rclone vfs-cache-mode;
-// s3fsUseCache whether s3fs keeps a local read cache.
+// the juicefs meta engine + tier; juicefsCacheSize the --cache-size (MiB);
+// rcloneVfsMode the rclone vfs-cache-mode; rcloneVfsCacheMax the vfs cache cap
+// ("" = uncapped); s3fsUseCache whether s3fs keeps a local read cache;
+// s3fsEnsureFreeMB the s3fs ensure_diskfree bound ("" = none).
 var (
-	benchEnv         BackendEnv
-	juicefsVol       string
-	juicefsMetaURL   string
-	juicefsWriteback bool
-	rcloneVfsMode    string
-	s3fsUseCache     bool
+	benchEnv          BackendEnv
+	juicefsVol        string
+	juicefsMetaURL    string
+	juicefsWriteback  bool
+	juicefsCacheSize  string
+	rcloneVfsMode     string
+	rcloneVfsCacheMax string
+	s3fsUseCache      bool
+	s3fsEnsureFreeMB  string
 )
 
 // flushUnmount unmounts a FUSE mountpoint non-lazily, so the tool flushes its
@@ -223,8 +247,8 @@ func waitMounted(ctx context.Context, mnt string) error {
 	return fmt.Errorf("mount %s not ready after wait", mnt)
 }
 
-func rcloneSetup(ctx context.Context, env BackendEnv, mode string) error {
-	rcloneVfsMode = mode // stash for remount's rebuild
+func rcloneSetup(ctx context.Context, env BackendEnv, mode, cacheMax string) error {
+	rcloneVfsMode, rcloneVfsCacheMax = mode, cacheMax // stash for remount's rebuild
 	if err := ensureInstalled(ctx, "rclone", "rclone"); err != nil {
 		return err
 	}
@@ -250,9 +274,16 @@ func rcloneSetup(ctx context.Context, env BackendEnv, mode string) error {
 }
 
 func rcloneMountFUSE(ctx context.Context) error {
-	return exec.Sh(ctx, "rclone", "mount", "bench:"+benchEnv.Bucket+"/rclone", rcloneMnt,
+	args := []string{"mount", "bench:" + benchEnv.Bucket + "/rclone", rcloneMnt,
 		"--config", "/etc/bench-rclone.conf", "--cache-dir", rcloneCache,
-		"--vfs-cache-mode", rcloneVfsMode, "--daemon")
+		"--vfs-cache-mode", rcloneVfsMode}
+	// Cap the vfs cache (cache-fill study): rclone evicts the oldest cached files
+	// once the cache exceeds this, applying backpressure rather than erroring.
+	if rcloneVfsCacheMax != "" {
+		args = append(args, "--vfs-cache-max-size", rcloneVfsCacheMax)
+	}
+	args = append(args, "--daemon")
+	return exec.Sh(ctx, "rclone", args...)
 }
 
 // rcloneRemount flushes rclone's vfs write cache to S3 (non-lazy unmount waits
@@ -278,8 +309,8 @@ func rcloneRemount(ctx context.Context) error {
 	return nil
 }
 
-func s3fsSetup(ctx context.Context, env BackendEnv, useCache bool) error {
-	s3fsUseCache = useCache // stash for remount's rebuild
+func s3fsSetup(ctx context.Context, env BackendEnv, useCache bool, ensureFreeMB string) error {
+	s3fsUseCache, s3fsEnsureFreeMB = useCache, ensureFreeMB // stash for remount's rebuild
 	if err := ensureInstalled(ctx, "s3fs", "s3fs"); err != nil {
 		return err
 	}
@@ -314,6 +345,12 @@ func s3fsMountFUSE(ctx context.Context) error {
 	// measure s3fs with no disk cache at all (still durable-on-close to S3).
 	if s3fsUseCache {
 		args = append(args, "-o", "use_cache="+s3fsCache)
+		// ensure_diskfree=MB (cache-cap study): s3fs purges cache to keep MB free
+		// on the cache disk. NOTE this bounds free-space-kept, not cache size — it
+		// is not a true absolute cache cap on a large disk (see the -cap* comment).
+		if s3fsEnsureFreeMB != "" {
+			args = append(args, "-o", "ensure_diskfree="+s3fsEnsureFreeMB)
+		}
 	}
 	return exec.Sh(ctx, "s3fs", args...)
 }
@@ -332,7 +369,8 @@ func s3fsRemount(ctx context.Context) error {
 // metadata engine (sqlite | postgres | redis); writeback gates --writeback on
 // the mount (local-ack + async S3 vs. durable-on-fsync/close). Both are stashed
 // in package vars so remount rebuilds the identical mount.
-func juicefsSetup(ctx context.Context, env BackendEnv, metaKind string, writeback bool) error {
+func juicefsSetup(ctx context.Context, env BackendEnv, metaKind string, writeback bool, cacheSize string) error {
+	juicefsCacheSize = cacheSize // stash for remount's rebuild
 	// juicefs isn't in apt — use its install script (idempotent).
 	if err := exec.Sh(ctx, "sh", "-c",
 		"command -v juicefs >/dev/null || curl -sSL https://d.juicefs.com/install | sh -"); err != nil {
@@ -415,9 +453,9 @@ func juicefsMountFUSE(ctx context.Context) error {
 	// --writeback (gated by juicefsWriteback): local-ack writes + async upload,
 	// matching DittoFS's local store + syncer and rclone's --vfs-cache-mode writes.
 	// Off in the -durable variants so the write pass compares the JuiceFS default
-	// (flush to S3 on fsync/close). --cache-size caps the on-disk cache (default
-	// 100 GiB would exceed the VM disk).
-	args := []string{"mount", "-d", "--cache-dir", juicefsCache, "--cache-size", "10240"}
+	// (flush to S3 on fsync/close). --cache-size (MiB) caps the on-disk cache; the
+	// cache-cap study variants pass a small size (juicefsCacheSize) to fill it.
+	args := []string{"mount", "-d", "--cache-dir", juicefsCache, "--cache-size", juicefsCacheSize}
 	if juicefsWriteback {
 		args = append(args, "--writeback")
 	}

--- a/internal/dfsbench/backend/fuse.go
+++ b/internal/dfsbench/backend/fuse.go
@@ -108,8 +108,8 @@ func init() {
 	}{
 		{"s3fs", true, "", "durable-on-close to S3 (no writeback); knfsd sync export"},
 		{"s3fs-nocache", false, "", "durable-on-close to S3, no local cache; knfsd sync export"},
-		{"s3fs-cap256m", true, "256", "durable-on-close to S3; cache ensure_diskfree=256 MiB (see note); knfsd sync export"},
-		{"s3fs-cap2g", true, "2048", "durable-on-close to S3; cache ensure_diskfree=2048 MiB (see note); knfsd sync export"},
+		{"s3fs-cap256m", true, "256", "durable-on-close to S3; cache ensure_diskfree=256 MB (see note); knfsd sync export"},
+		{"s3fs-cap2g", true, "2048", "durable-on-close to S3; cache ensure_diskfree=2048 MB (see note); knfsd sync export"},
 	} {
 		useCache, ensureFreeMB := s.useCache, s.ensureFreeMB
 		register(newSrcBackend(srcBackend{


### PR DESCRIPTION
## What

Adds **cache-cap** backend variants to the `dfsbench` harness so it can measure how each system behaves when its local cache fills — backpressure (block/throttle) vs. error (EIO). Three apples-to-apples scenarios per system: **unbounded** (existing writeback/cachefull variants), **cap256m**, **cap2g**.

New variants (8):

| System | 256 MiB cap | 2 GiB cap | Cap mechanism |
|---|---|---|---|
| dittofs (writeback) | `dittofs-s3-writeback-cap256m` | `dittofs-s3-writeback-cap2g` | local block store config `max_size` (bytes) |
| rclone (writes tier) | `rclone-cap256m` | `rclone-cap2g` | `--vfs-cache-max-size 256M` / `2G` |
| juicefs (writeback) | `juicefs-cap256m` | `juicefs-cap2g` | `--cache-size 256` / `2048` (MiB) |
| s3fs | `s3fs-cap256m` | `s3fs-cap2g` | `-o ensure_diskfree=256` / `2048` (MB) |

The unbounded scenario reuses the existing `dittofs-s3-writeback` / `rclone` / `juicefs` / `s3fs` variants (max_size 32 GiB, cache-size 10240 MiB, uncapped vfs, no ensure_diskfree) — no duplication.

## Caveat — s3fs can't cap cleanly

s3fs has **no cache-size knob**. `ensure_diskfree=MB` bounds *free space kept on the cache disk*, not cache size, so on a large VM disk it does not enforce a true 256 MiB / 2 GiB cap (it only evicts as the backing disk nears full). It is the closest s3fs offers; a hard cap would require a size-bounded backing filesystem. Flagged in both code comments and the variant `Tier` strings ("see note"). The other three systems cap cleanly.

## Implementation

Mirrors the existing per-tool variant pattern exactly (loop with a per-variant axis field → package var stashed at setup → consumed in the mount helper). No new abstractions.

## Verification

- `go build ./cmd/bench` ✅
- `go vet ./internal/dfsbench/...` ✅
- `go test ./internal/dfsbench/...` — 41 passed ✅
- `golangci-lint run internal/dfsbench/...` — no issues ✅
- `dfsbench list` shows all 8 new variants across nfs3/nfs4/smb3 ✅