### PR TITLE
bench: isolate cache/data on a dedicated block volume

### DIFF
--- a/internal/dfsbench/CLAUDE.md
+++ b/internal/dfsbench/CLAUDE.md
@@ -76,6 +76,14 @@ smoke 3s), `--results` (`./bench-results`). One JSON per cell, slug-named.
 - **VM**: `scw` CLI must be authed. Knobs (defaults): `SCW_ZONE=fr-par-1`,
   `SCW_INSTANCE_TYPE=POP2-8C-32G`, `SCW_IMAGE=ubuntu_noble`,
   `SCW_ROOT_VOLUME=sbs:100GB:5000`, `SCW_NAME`, `SCW_SSH_KEY`.
+- **Data volume**: `setup` attaches a separate SBS block volume (default 50 GB,
+  `--data-volume-gb`; `0` disables) mounted at `/bench-data` and points every
+  backend's cache/data dir there, so benchmark I/O never contends with the OS
+  root disk under cache-fill load. Its ID is stored in `.bench-vm.json`
+  (`volume_id`) and `teardown` deletes it with the VM (tolerating an
+  already-gone volume) — **let `teardown` own its lifecycle; a manual `scw block
+  volume delete` just drops the handle from `.bench-vm.json`.** With `--data-volume-gb=0`
+  backends fall back to their old root-disk paths (`/var/lib`, `/var/cache`).
 - `setup` cross-builds `dfsbench`/`dfs`/`dfsctl` (CGO-free linux), pushes over
   SSH, apt-installs fio + nfs/samba + s3fs/rclone/s3ql/juicefs on the VM.
 

--- a/internal/dfsbench/backend/backend_test.go
+++ b/internal/dfsbench/backend/backend_test.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"path/filepath"
 	"testing"
 )
 
@@ -291,5 +292,25 @@ func TestBackendNamesSorted(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("got %v, want %v", got, want)
 		}
+	}
+}
+
+// TestBenchPath covers the data-volume fallback: with a volume mounted, cache/
+// data dirs consolidate under it; disabled (--data-volume-gb=0) they keep the
+// exact legacy root-disk path so old behaviour is preserved.
+func TestBenchPath(t *testing.T) {
+	saved := benchDataDir
+	t.Cleanup(func() { benchDataDir = saved })
+
+	benchDataDir = ""
+	if got := benchPath("/var/cache/bench-rclone", "rclone"); got != "/var/cache/bench-rclone" {
+		t.Fatalf("disabled: got %q, want legacy path", got)
+	}
+	benchDataDir = "/bench-data"
+	// Build the expectation the same way benchPath does, so the comparison holds
+	// regardless of the path separator the platform uses.
+	want := filepath.Join("/bench-data", "rclone")
+	if got := benchPath("/var/cache/bench-rclone", "rclone"); got != want {
+		t.Fatalf("enabled: got %q, want %q", got, want)
 	}
 }

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -5,10 +5,42 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/dfsbench/exec"
 )
+
+// benchDataMount is the isolated data volume `dfsbench setup --data-volume-gb`
+// attaches (see cloud.attachAndMountDataVolume). Kept in sync with that const.
+const benchDataMount = "/bench-data"
+
+// benchDataMarker is the file the mount script drops after a successful mount
+// (see cloud.benchDataMarker). Its presence — not the dir's — is what proves the
+// volume is mounted, so a failed mount that left a bare /bench-data dir on the
+// root disk doesn't silently re-contaminate the root disk. Kept in sync.
+const benchDataMarker = ".dfsbench-data-volume"
+
+// benchDataDir is benchDataMount when the data volume is mounted, else "" (fall
+// back to legacy root-disk paths). Resolved once at startup: the remote dfsbench
+// binary can't see setup's --data-volume-gb flag, so it detects the mount via
+// the marker file the mount script wrote.
+var benchDataDir = func() string {
+	if _, err := os.Stat(filepath.Join(benchDataMount, benchDataMarker)); err == nil {
+		return benchDataMount
+	}
+	return ""
+}()
+
+// benchPath returns sub under the isolated data volume when one is mounted, else
+// legacyRoot — the exact root-disk path preserved for --data-volume-gb=0. This
+// keeps all backend cache/data off the OS root disk when a data volume exists.
+func benchPath(legacyRoot, sub string) string {
+	if benchDataDir != "" {
+		return filepath.Join(benchDataDir, sub)
+	}
+	return legacyRoot
+}
 
 // dittofs-s3 is the subject: DittoFS serving badger metadata + an S3 remote
 // block store, mounted over its NATIVE nfs3/nfs4/smb3 servers (no re-export
@@ -23,7 +55,6 @@ const (
 	dittofsNFSPort = "12049"
 	dittofsSMBPort = "12445"
 	dittofsShare   = "bench"
-	dittofsDataDir = "/var/lib/bench-dittofs"
 	dittofsAPIPort = "8080"
 	dittofsAPIURL  = "http://127.0.0.1:" + dittofsAPIPort
 	dittofsMeta    = "bench-meta"
@@ -35,6 +66,11 @@ const (
 	dittofsSecret    = "dfsbench-controlplane-secret-0123456789ab"
 	dittofsAdminPass = "dfsbench-admin-pw"
 )
+
+// dittofsDataDir holds the subject's metadata (/meta, /meta.db) and local block
+// cache (/blocks). It lives on the isolated data volume when one is mounted,
+// else the legacy root-disk path.
+var dittofsDataDir = benchPath("/var/lib/bench-dittofs", "dittofs")
 
 // dittofsMetaKind selects the metadata-store engine. The block store (fs local
 // cache + S3 remote) is identical across all three, so a badger/sqlite/postgres

--- a/internal/dfsbench/backend/fuse.go
+++ b/internal/dfsbench/backend/fuse.go
@@ -17,16 +17,26 @@ import (
 // Recipe flags/URLs are pinned against each tool's installed version on the VM
 // (the first managed run is where they get tuned — measure, don't assume).
 
+// Mountpoints stay on the root disk (they're empty dirs the FUSE tool mounts
+// over); the on-disk *caches* move to the isolated data volume when one exists,
+// so the bulk of read/write I/O stays off the OS root disk (benchPath).
 const (
-	rcloneMnt, rcloneCache   = "/mnt/fuse-rclone", "/var/cache/bench-rclone"
-	s3qlMnt, s3qlCache       = "/mnt/fuse-s3ql", "/var/cache/bench-s3ql"
-	juicefsMnt, juicefsCache = "/mnt/fuse-juicefs", "/var/cache/bench-juicefs"
-	s3fsMnt, s3fsCache       = "/mnt/fuse-s3fs", "/var/cache/bench-s3fs"
+	rcloneMnt  = "/mnt/fuse-rclone"
+	s3qlMnt    = "/mnt/fuse-s3ql"
+	juicefsMnt = "/mnt/fuse-juicefs"
+	s3fsMnt    = "/mnt/fuse-s3fs"
 
 	// juicefsUnboundedCacheMiB is the default --cache-size (MiB): generous headroom
 	// (the tool's own 100 GiB default would exceed the VM disk). The cache-cap
 	// study variants pass a small cache-size instead.
 	juicefsUnboundedCacheMiB = "10240"
+)
+
+var (
+	rcloneCache  = benchPath("/var/cache/bench-rclone", "rclone")
+	s3qlCache    = benchPath("/var/cache/bench-s3ql", "s3ql")
+	juicefsCache = benchPath("/var/cache/bench-juicefs", "juicefs")
+	s3fsCache    = benchPath("/var/cache/bench-s3fs", "s3fs")
 )
 
 func init() {

--- a/internal/dfsbench/cloud/prereqs.go
+++ b/internal/dfsbench/cloud/prereqs.go
@@ -18,20 +18,29 @@ import (
 // the dfsbench binary (plus dfs/dfsctl) to it.
 func NewSetupCmd() *cobra.Command {
 	var provider string
+	var dataVolumeGB int
 	cmd := &cobra.Command{
 		Use:   "setup",
 		Short: "Provision a disposable bench VM and push the dfsbench binary",
 		Long: `setup provisions one disposable VM (default provider: scw; SCW_* env
 overrides type/zone/image), waits for SSH, cross-builds dfsbench for the VM's
 arch, pushes it, and records the VM handle in .bench-vm.json so 'run --remote'
-and 'teardown' reattach.`,
-		RunE: func(cmd *cobra.Command, _ []string) error { return runSetup(cmd.Context(), provider) },
+and 'teardown' reattach.
+
+Unless --data-volume-gb=0, it also attaches a separate block volume mounted at
+` + benchDataMount + ` and points every backend's cache/data dir there, so
+benchmark I/O never contends with the OS root disk. teardown deletes it too.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runSetup(cmd.Context(), provider, dataVolumeGB)
+		},
 	}
 	cmd.Flags().StringVar(&provider, "provider", "scw", "cloud provider for the bench VM (supported: scw)")
+	cmd.Flags().IntVar(&dataVolumeGB, "data-volume-gb", 50,
+		"size (GB) of a separate block volume mounted at "+benchDataMount+" for backend cache/data (0 = disabled, use OS root disk)")
 	return cmd
 }
 
-func runSetup(ctx context.Context, providerName string) error {
+func runSetup(ctx context.Context, providerName string, dataVolumeGB int) error {
 	p, err := newProvider(providerName)
 	if err != nil {
 		return err
@@ -50,6 +59,18 @@ func runSetup(ctx context.Context, providerName string) error {
 	ex := exec.NewSSHExecutor(SSHCfg())
 	if err := waitSSH(ctx, ex, vm); err != nil {
 		return err
+	}
+	// Attach + mount the isolated data volume before anything runs, so backend
+	// cache/data lands on it instead of the OS root disk. Skipped at 0 (backends
+	// then fall back to their root-disk paths — old behaviour).
+	if dataVolumeGB > 0 {
+		if providerName != "" && providerName != "scw" {
+			return fmt.Errorf("--data-volume-gb is only supported on scw (provider %q); pass --data-volume-gb=0", providerName)
+		}
+		if err := attachAndMountDataVolume(ctx, ex, &vm, dataVolumeGB); err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(exec.CmdOut, "attached %dGB data volume %s at %s\n", dataVolumeGB, vm.VolumeID, benchDataMount)
 	}
 	// Build for the VM's real arch (detected over ssh), so this works whatever
 	// instance type the provider hands back — amd64 or arm64.
@@ -81,6 +102,59 @@ func runSetup(ctx context.Context, providerName string) error {
 		return err
 	}
 	_, _ = fmt.Fprintf(exec.CmdOut, "ready: dfsbench run --remote --systems ...  (then dfsbench teardown)\n")
+	return nil
+}
+
+// benchDataMount is where the isolated bench-data volume is mounted. Every
+// backend derives its cache/data dir from this (see backend.benchDataDir) so
+// benchmark I/O stays off the OS root disk. Kept in sync with that constant.
+const benchDataMount = "/bench-data"
+
+// benchDataMarker is dropped on the volume once the mount succeeds; the remote
+// backends key off it (backend.benchDataMarker) so a bare/failed mount dir on
+// the root disk is never mistaken for the isolated volume. Kept in sync.
+const benchDataMarker = ".dfsbench-data-volume"
+
+// attachAndMountDataVolume creates+attaches a data block volume of gb GB, records
+// its ID for teardown, then formats (ext4) and mounts it at benchDataMount over
+// SSH. The volume ID is persisted before the mount so teardown deletes it even if
+// the mount fails.
+func attachAndMountDataVolume(ctx context.Context, ex exec.Executor, vm *VM, gb int) error {
+	volID, err := createDataVolume(ctx, *vm, gb)
+	if err != nil {
+		return err
+	}
+	vm.VolumeID = volID
+	if err := saveVM(*vm); err != nil {
+		return err
+	}
+	if err := attachDataVolume(ctx, *vm, volID); err != nil {
+		return err
+	}
+	// Format+mount the freshly-attached disk. It's the one whole disk (TYPE=disk,
+	// so loop/rom are excluded) with no mountpoints anywhere in its tree — the
+	// root disk is excluded because its partitions are mounted (the inner lsblk,
+	// without -d, sees child mountpoints). Poll: the device takes a few seconds
+	// to surface after attach. The marker file is dropped last so the remote
+	// backends only treat the volume as usable once the mount actually succeeded.
+	script := `set -eu
+mkdir -p ` + benchDataMount + `
+dev=
+for i in $(seq 1 30); do
+  for d in $(lsblk -dpno NAME,TYPE | awk '$2=="disk"{print $1}'); do
+    if [ -z "$(lsblk -no MOUNTPOINTS "$d" | tr -d ' \n')" ]; then dev="$d"; break; fi
+  done
+  [ -n "$dev" ] && break
+  sleep 2
+done
+[ -n "$dev" ] || { echo "no unmounted data disk appeared after attach" >&2; exit 1; }
+mkfs.ext4 -F "$dev"
+mount "$dev" ` + benchDataMount + `
+touch ` + benchDataMount + `/` + benchDataMarker + `
+df -h ` + benchDataMount
+	if _, err := ex.Run(ctx, vm.IP, remoteUser, script); err != nil {
+		return fmt.Errorf("format+mount data volume: %w", err)
+	}
 	return nil
 }
 

--- a/internal/dfsbench/cloud/provider.go
+++ b/internal/dfsbench/cloud/provider.go
@@ -37,6 +37,10 @@ type VM struct {
 	ServerID string `json:"server_id"`
 	IP       string `json:"ip"`
 	Zone     string `json:"zone"`
+	// VolumeID is the separate bench-data block volume attached by setup
+	// (--data-volume-gb>0). Recorded so teardown deletes it too — a leaked
+	// volume is billed indefinitely. Empty when no data volume was attached.
+	VolumeID string `json:"volume_id,omitempty"`
 }
 
 func saveVM(vm VM) error {

--- a/internal/dfsbench/cloud/scw.go
+++ b/internal/dfsbench/cloud/scw.go
@@ -102,18 +102,93 @@ func serverIP(ctx context.Context, vm VM) (string, error) {
 	return "", nil
 }
 
-// terminateVM deletes the server, its IP, and its block volume, retrying to ride
-// out transient states (30 × 4s).
+// terminateVM deletes the server, its IP, and its root block volume, then the
+// separate bench-data volume (if any), retrying to ride out transient states.
 func terminateVM(ctx context.Context, vm VM) error {
 	var last error
+	terminated := false
 	for i := 0; i < 30; i++ {
 		if err := exec.CommandContext(ctx, "scw", "instance", "server", "terminate",
 			vm.ServerID, "zone="+vm.Zone, "with-ip=true", "with-block=true").Run(); err == nil {
-			return nil
+			terminated = true
+			break
 		} else {
 			last = err
 		}
 		time.Sleep(4 * time.Second)
 	}
-	return fmt.Errorf("terminate %s failed after retries: %w", vm.ServerID, last)
+	// Always attempt the data-volume delete, even if terminate kept erroring: the
+	// server may already be gone (a transient CLI error), and a leaked data volume
+	// bills indefinitely. deleteDataVolume tolerates a not-found volume.
+	var delErr error
+	if vm.VolumeID != "" {
+		delErr = deleteDataVolume(ctx, vm)
+	}
+	if !terminated {
+		return fmt.Errorf("terminate %s failed after retries: %w", vm.ServerID, last)
+	}
+	return delErr
+}
+
+// createDataVolume creates an SBS block volume of gb GB in the VM's zone and
+// returns its ID (same 5000-IOPS class as the default root volume).
+func createDataVolume(ctx context.Context, vm VM, gb int) (string, error) {
+	if gb <= 0 {
+		return "", fmt.Errorf("data volume size must be > 0 GB, got %d", gb)
+	}
+	var v struct {
+		ID string `json:"id"`
+	}
+	name := "dfsbench-data-" + time.Now().Format("20060102-150405")
+	// scw's block API requires the size with an explicit G/GB unit — a bare
+	// byte count is rejected ("size must be defined using the G or GB unit").
+	if err := scwJSON(ctx, &v, "block", "volume", "create",
+		"name="+name, "perf-iops=5000",
+		fmt.Sprintf("from-empty.size=%dGB", gb),
+		"zone="+vm.Zone); err != nil {
+		return "", fmt.Errorf("scw block volume create: %w", err)
+	}
+	if v.ID == "" {
+		return "", fmt.Errorf("scw block volume create returned no id")
+	}
+	return v.ID, nil
+}
+
+// attachDataVolume attaches vol to the server, retrying while the freshly-created
+// volume settles into an attachable state (30 × 4s).
+func attachDataVolume(ctx context.Context, vm VM, vol string) error {
+	var last error
+	for i := 0; i < 30; i++ {
+		cmd := exec.CommandContext(ctx, "scw", "instance", "server", "attach-volume",
+			"server-id="+vm.ServerID, "volume-id="+vol, "volume-type=sbs_volume", "zone="+vm.Zone)
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			return nil
+		}
+		last = fmt.Errorf("%w: %s", err, bytes.TrimSpace(out))
+		time.Sleep(4 * time.Second)
+	}
+	return fmt.Errorf("attach volume %s to %s failed after retries: %w", vol, vm.ServerID, last)
+}
+
+// deleteDataVolume deletes the bench-data volume once the server is gone (a
+// volume can't be deleted while in_use). Tolerates a not-found — with-block on
+// terminate may already have removed it, which is the goal either way.
+func deleteDataVolume(ctx context.Context, vm VM) error {
+	var last error
+	for i := 0; i < 30; i++ {
+		// CombinedOutput so a "not found" printed to stdout (not just stderr) is
+		// still recognised as an already-deleted volume rather than a hard error.
+		out, err := exec.CommandContext(ctx, "scw", "block", "volume", "delete", vm.VolumeID, "zone="+vm.Zone).CombinedOutput()
+		if err == nil {
+			return nil
+		}
+		low := bytes.ToLower(out)
+		if bytes.Contains(low, []byte("not found")) || bytes.Contains(low, []byte("does not exist")) {
+			return nil
+		}
+		last = fmt.Errorf("%w: %s", err, bytes.TrimSpace(out))
+		time.Sleep(4 * time.Second)
+	}
+	return fmt.Errorf("delete data volume %s failed after retries: %w", vm.VolumeID, last)
 }


### PR DESCRIPTION
## What

`dfsbench setup` now attaches a **separate SBS block volume** (default 50 GB, flag `--data-volume-gb`; `0` disables), formats it ext4, mounts it at `/bench-data`, and repoints every backend's cache/data dir there. Before, all backend I/O wrote to `/`, so under cache-fill load the OS root disk was starved and the numbers reflected root-disk contention rather than the FS under test.

## How

- **`cloud/scw.go`** — `createDataVolume` (`scw block volume create from-empty.size=<bytes> perf-iops=5000`), `attachDataVolume` (`scw instance server attach-volume <srv> volume-id=<id> volume-type=sbs_volume`), `deleteDataVolume` (`scw block volume delete <id>`, tolerates not-found). `terminateVM` now deletes the data volume after the server (keeps `with-block=true` for the root volume; never relies on it for the data volume).
- **`cloud/prereqs.go`** — `--data-volume-gb` flag; after SSH is up, create+attach the volume, persist its ID to `.bench-vm.json` **before** mounting (so teardown can still clean up a half-set-up volume), then format+mount over SSH. Device is picked as the one whole disk with no mountpoints in its tree (the root disk's partitions are all mounted).
- **`cloud/provider.go`** — `VM.VolumeID` field (`volume_id`, omitempty) persisted in `.bench-vm.json`.
- **`backend/dittofs.go`, `backend/fuse.go`** — one shared base: `benchDataDir` resolves to `/bench-data` when mounted, else `""`. `benchPath(legacyRoot, sub)` returns `/bench-data/<sub>` when a volume is mounted, else the exact legacy root-disk path. Repointed: dittofs `/meta` `/blocks` `/meta.db`, and rclone/juicefs/s3fs/s3ql caches. The remote binary can't see setup's flag, so it detects the mount via `os.Stat` — no flag threading.

## Fallback

`--data-volume-gb=0` → no volume, `benchDataDir==""` → backends keep their old `/var/lib` / `/var/cache` paths byte-for-byte. Old behaviour fully preserved.

## Leak safety

`VolumeID` is recorded in `.bench-vm.json` and `teardown` deletes the volume with the VM. Not deleting it would bill indefinitely — covered by the explicit `deleteDataVolume`, tolerant of the case where `with-block=true` already removed it.

## Tests

`go build ./cmd/bench`, `go vet ./internal/dfsbench/...`, `go test ./internal/dfsbench/...` (42 pass, incl. new `TestBenchPath` covering the fallback), `gofmt -l` clean, `golangci-lint run internal/dfsbench/...` clean.

## Not verified without a live VM

The exact `scw block`/`attach-volume` argument shapes were taken from `scw --help` (v2.58.3) and mirror the existing root-volume idiom, but the create→attach→mkfs→mount→delete round-trip hasn't been exercised against a live Scaleway VM. First `setup` run is where the CLI arg shapes get final confirmation.