### PR TITLE
fix(metadata): retain pending write state when flush fails

### DIFF
--- a/pkg/metadata/io.go
+++ b/pkg/metadata/io.go
@@ -405,6 +405,11 @@ func (s *Service) FlushPendingWriteForFile(ctx *AuthContext, handle FileHandle, 
 	}
 
 	if err := s.flushPendingWrite(ctx, handle, state, durable); err != nil {
+		// The state was popped before the flush; a caller that treats this error
+		// as non-fatal would otherwise permanently lose the size/mtime update and
+		// leave metadata stale until the next share-start reconcile. Restore it so
+		// a later flush or COMMIT retries, merging with any write that raced in.
+		s.pendingWrites.RestorePending(handle, state)
 		return true, err
 	}
 

--- a/pkg/metadata/pending_writes.go
+++ b/pkg/metadata/pending_writes.go
@@ -201,6 +201,44 @@ func (t *PendingWritesTracker) PopPending(handle FileHandle) (*PendingWriteState
 	return state, true
 }
 
+// RestorePending merges a previously popped state back into the tracker after a
+// flush failed, so a later flush retries it instead of the size/mtime update
+// being lost. If a write arrived after the pop (RecordWrite runs without the
+// flush lock), the popped state is merged into that newer entry rather than
+// overwriting it: the size grows to the max, the setuid-clear latches on, and
+// the restored mtime/pre-write attrs/cache fill in only where the newer entry
+// has none. If nothing is present, the popped state is reinstated as-is.
+func (t *PendingWritesTracker) RestorePending(handle FileHandle, state *PendingWriteState) {
+	if state == nil {
+		return
+	}
+	key := handleKey(handle)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	cur, exists := t.pending[key]
+	if !exists {
+		t.pending[key] = state
+		return
+	}
+	if state.MaxSize > cur.MaxSize {
+		cur.MaxSize = state.MaxSize
+	}
+	if cur.LastMtime.IsZero() && !state.LastMtime.IsZero() {
+		cur.LastMtime = state.LastMtime
+	}
+	if state.ClearSetuidSetgid {
+		cur.ClearSetuidSetgid = true
+	}
+	if cur.PreWriteAttr == nil {
+		cur.PreWriteAttr = state.PreWriteAttr
+	}
+	if cur.CachedFile == nil {
+		cur.CachedFile = state.CachedFile
+	}
+}
+
 // PendingEntry pairs a handle with its pending state.
 type PendingEntry struct {
 	Handle FileHandle

--- a/pkg/metadata/pending_writes_test.go
+++ b/pkg/metadata/pending_writes_test.go
@@ -71,3 +71,45 @@ func TestPopAllPending_ReturnsAllEntries(t *testing.T) {
 		t.Fatalf("pending count = %d after pop, want 0", c)
 	}
 }
+
+// TestRestorePending_ReinstatesAndMergesRacingWrite asserts that a state popped
+// for a flush is put back by RestorePending when the flush fails (so the buffered
+// size is not lost), and that a write which raced in after the pop is not
+// clobbered: the size keeps the max and the setuid-clear latches on.
+func TestRestorePending_ReinstatesAndMergesRacingWrite(t *testing.T) {
+	tr := NewPendingWritesTracker()
+	h := FileHandle("share:restore")
+
+	// A deferred write buffers size 100; the flush pops it, then fails.
+	tr.RecordWrite(h, &WriteOperation{Handle: h, NewSize: 100}, true)
+	state, ok := tr.PopPending(h)
+	if !ok {
+		t.Fatal("PopPending: expected buffered state")
+	}
+	if _, ok := tr.GetPending(h); ok {
+		t.Fatal("state must be gone immediately after pop")
+	}
+
+	// No racing write: the state is reinstated verbatim so a later flush retries.
+	tr.RestorePending(h, state)
+	got, ok := tr.GetPending(h)
+	if !ok || got.MaxSize != 100 {
+		t.Fatalf("restore: got %+v ok=%v, want MaxSize=100", got, ok)
+	}
+
+	// Racing write: pop again, a newer write (size 200) lands before the failed
+	// flush restores the old state. The newer size must win; setuid-clear latches.
+	old, _ := tr.PopPending(h)
+	tr.RecordWrite(h, &WriteOperation{Handle: h, NewSize: 200}, false)
+	tr.RestorePending(h, old)
+	merged, ok := tr.GetPending(h)
+	if !ok {
+		t.Fatal("merged state missing after restore")
+	}
+	if merged.MaxSize != 200 {
+		t.Fatalf("merged MaxSize = %d, want 200 (racing write must not be clobbered)", merged.MaxSize)
+	}
+	if !merged.ClearSetuidSetgid {
+		t.Fatal("restored setuid-clear must latch onto the merged state")
+	}
+}


### PR DESCRIPTION
Closes #1734.

`FlushPendingWriteForFile` popped the pending-write state before attempting the flush and, on a flush error, returned without restoring it. Call sites that treat a flush error as non-fatal therefore permanently lost the buffered size/mtime update, leaving `metadata.Size`/mtime stale until the next share-start reconcile — which can truncate reads while the server stays up.

## Fix
- New `PendingWritesTracker.RestorePending(handle, state)` reinstates a popped state after a failed flush so a later flush/COMMIT retries it.
- `FlushPendingWriteForFile` calls it in the flush-error branch before returning.

## Concurrency
`RecordWrite` runs without the per-file flush lock, so a write can create a fresh entry between the pop and the restore. `RestorePending` takes the tracker mutex and **merges** into whatever is present rather than overwriting: `MaxSize` grows to the max, `ClearSetuidSetgid` latches on, and mtime/pre-write-attr/cache fill in only where the newer entry has none — so neither the failed flush's update nor the racing write is lost. If nothing is present it reinstates verbatim. Lock order is flush-lock → tracker-mutex (no inverse path).

Scope: in-session `FlushPendingWriteForFile` only; shutdown bulk flush stays best-effort (restart reconcile backstops durability). Does not touch `pkg/block/journal/`.

Verified: `gofmt -s`, `go build ./...`, `go vet ./pkg/metadata/...`, `go test ./pkg/metadata/ -run 'RestorePending|PopAllPending|PendingWrite|Truncate|RemoveFileDiscards' -race -count=3`.