### PR TITLE
fix(journal): evict force-seals synced actives + write-path backpressures instead of EIO

### DIFF
--- a/pkg/block/journal/evict_test.go
+++ b/pkg/block/journal/evict_test.go
@@ -255,6 +255,159 @@ func TestEnsureSpaceEvictsSyncedUnderPressure(t *testing.T) {
 	}
 }
 
+// TestEvictForceSealsSyncedActive covers a working set smaller than the
+// segment-roll threshold: every synced record sits in the never-sealed active
+// segment, so before the force-seal fall-through an explicit Evict freed nothing.
+// Now Evict seals the fully-synced active and reclaims it.
+func TestEvictForceSealsSyncedActive(t *testing.T) {
+	s, _ := evictStore(t, Config{}) // 1 shard, 1 MiB segment
+	ctx := context.Background()
+
+	// Two synced 256 KiB records (512 KiB total) stay in the active segment: well
+	// under the 1 MiB roll threshold, so nothing seals on its own.
+	buf := bytes.Repeat([]byte{0x3C}, chunk256)
+	if err := s.Hydrate(ctx, "f", 0, buf); err != nil {
+		t.Fatalf("Hydrate: %v", err)
+	}
+	if err := s.Hydrate(ctx, "f", chunk256, buf); err != nil {
+		t.Fatalf("Hydrate: %v", err)
+	}
+	if segs := sealedSegs(s.shardFor("f")); len(segs) != 0 {
+		t.Fatalf("working set below roll threshold must leave 0 sealed segments, got %d", len(segs))
+	}
+
+	before := s.diskBytes.Load()
+	res, err := s.Evict(ctx, 1<<30)
+	if err != nil {
+		t.Fatalf("Evict: %v", err)
+	}
+	if res.SegmentsEvicted < 1 || res.BytesFreed <= 0 {
+		t.Fatalf("force-seal fall-through must reclaim the synced active, got %+v", res)
+	}
+	if s.diskBytes.Load() >= before {
+		t.Fatalf("local disk usage must drop: before=%d after=%d", before, s.diskBytes.Load())
+	}
+	// The reclaimed range must read back cold (remote-backed), never as a hole.
+	dst := make([]byte, chunk256)
+	if _, cold, err := s.ReadAt(ctx, "f", 0, dst); err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	} else if !cold {
+		t.Fatalf("evicted range must report cold, not a hole")
+	}
+}
+
+// TestEvictForceSealSkipsDirtyActive proves the fall-through never seals (and so
+// never strands) unsynced bytes: an active segment holding dirty records is left
+// untouched, and Evict reclaims nothing.
+func TestEvictForceSealSkipsDirtyActive(t *testing.T) {
+	s, _ := evictStore(t, Config{})
+	ctx := context.Background()
+
+	buf := bytes.Repeat([]byte{0xD1}, chunk256)
+	if err := s.WriteAt(ctx, "f", 0, buf); err != nil { // dirty, unsynced
+		t.Fatalf("WriteAt: %v", err)
+	}
+	res, err := s.Evict(ctx, 1<<30)
+	if err != nil {
+		t.Fatalf("Evict: %v", err)
+	}
+	if res.SegmentsEvicted != 0 {
+		t.Fatalf("dirty active must not be sealed-and-evicted, got %+v", res)
+	}
+	if segs := sealedSegs(s.shardFor("f")); len(segs) != 0 {
+		t.Fatalf("dirty active must not be force-sealed, got %d sealed", len(segs))
+	}
+}
+
+// pretendCarveOneSealed models one slow syncer step: it flips the first dirty
+// sealed segment it finds to fully synced (as carve does after uploading its
+// records) and drops the drained bytes from the unsynced counter, so the segment
+// becomes evictable and the write-path backpressure sees drain progress. It
+// returns false when no dirty sealed segment remains.
+func pretendCarveOneSealed(s *Store) bool {
+	for _, sh := range s.shards {
+		sh.mu.Lock()
+		for _, seg := range sh.sealed {
+			if seg.syncedRecords.Load() < seg.records.Load() {
+				seg.syncedRecords.Store(seg.records.Load())
+				drained := seg.liveBytes.Load()
+				sh.mu.Unlock()
+				s.unsynced.Add(-drained)
+				return true
+			}
+		}
+		sh.mu.Unlock()
+	}
+	return false
+}
+
+// TestBackpressureWaitsForSyncer is the BUG 2 positive case: a writer that
+// outpaces a live (slow) syncer under a tight local cap must backpressure and
+// keep succeeding — never return ErrLocalStoreFull — because the syncer keeps
+// draining unsynced bytes and refreshing the wait budget.
+func TestBackpressureWaitsForSyncer(t *testing.T) {
+	s, _ := evictStore(t, Config{MaxLocalBytes: 2 << 20, EvictMaxWait: 200 * time.Millisecond})
+	ctx := context.Background()
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { // slow syncer: drains one sealed segment every few ms
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			case <-time.After(3 * time.Millisecond):
+				pretendCarveOneSealed(s)
+			}
+		}
+	}()
+
+	buf := bytes.Repeat([]byte{0x9E}, chunk256)
+	var off int64
+	for i := 0; i < 60; i++ { // ~15 MiB through a 2 MiB cap
+		if err := s.WriteAt(ctx, "f", off, buf); err != nil {
+			close(done)
+			wg.Wait()
+			t.Fatalf("write %d must backpressure on a live syncer, never fail: %v", i, err)
+		}
+		off += chunk256
+	}
+	close(done)
+	wg.Wait()
+}
+
+// TestBackpressureTerminalWhenNoSyncer is the BUG 2 negative case: with no syncer
+// draining, the unsynced bytes pinning the cap never fall, so the write path must
+// still fail with ErrLocalStoreFull within a bounded budget rather than hang.
+func TestBackpressureTerminalWhenNoSyncer(t *testing.T) {
+	s, _ := evictStore(t, Config{MaxLocalBytes: 2 << 20, EvictMaxWait: 50 * time.Millisecond})
+	ctx := context.Background()
+
+	buf := bytes.Repeat([]byte{0xCD}, chunk256)
+	var off int64
+	var gotFull bool
+	start := time.Now()
+	for i := 0; i < 64; i++ {
+		err := s.WriteAt(ctx, "f", off, buf)
+		if errors.Is(err, ErrLocalStoreFull) {
+			gotFull = true
+			break
+		}
+		if err != nil {
+			t.Fatalf("WriteAt: %v", err)
+		}
+		off += chunk256
+	}
+	if !gotFull {
+		t.Fatalf("expected ErrLocalStoreFull with no syncer to drain the cap")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("backpressure must be bounded, not hang: took %v", elapsed)
+	}
+}
+
 func TestConcurrentWriteEvictRace(t *testing.T) {
 	s, _ := evictStore(t, Config{ShardCount: 4})
 	ctx := context.Background()

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -82,7 +82,11 @@ func (s *Store) evict(ctx context.Context, targetBytes int64, allowActiveSeal bo
 			// (empty) active segment is never sealed in a spin.
 			if allowActiveSeal && !sealedActives {
 				sealedActives = true
-				if s.sealSyncedActives() {
+				sealed, err := s.sealSyncedActives(ctx)
+				if err != nil {
+					return res, err
+				}
+				if sealed {
 					continue
 				}
 			}
@@ -107,10 +111,15 @@ func (s *Store) evict(ctx context.Context, targetBytes int64, allowActiveSeal bo
 // make it evictable and its dirty bytes must stay the local copy), or a pinned
 // active (a live snapshot needs those bytes local). A seal here is the same
 // primitive as a rotation, so it produces an identically valid sealed footer.
-// It returns whether it sealed any segment. Caller holds no lock.
-func (s *Store) sealSyncedActives() bool {
+// It returns whether it sealed any segment and surfaces a seal failure (fsync or
+// next-segment creation) rather than masking it as a no-op, and stops early if
+// ctx is cancelled. Caller holds no lock.
+func (s *Store) sealSyncedActives(ctx context.Context) (bool, error) {
 	sealedAny := false
 	for _, sh := range s.shards {
+		if err := ctx.Err(); err != nil {
+			return sealedAny, err
+		}
 		sh.mu.Lock()
 		act := sh.active
 		// records is frozen while sh.mu is held (appends need it), and carve only
@@ -119,13 +128,17 @@ func (s *Store) sealSyncedActives() bool {
 		if act != nil && act.records.Load() > 0 &&
 			act.syncedRecords.Load() == act.records.Load() &&
 			!act.busy.Load() && !s.pinned(act) {
-			if err := s.sealSegment(sh); err == nil {
-				sealedAny = true
+			err := s.sealSegment(sh)
+			sh.mu.Unlock()
+			if err != nil {
+				return sealedAny, err
 			}
+			sealedAny = true
+			continue
 		}
 		sh.mu.Unlock()
 	}
-	return sealedAny
+	return sealedAny, nil
 }
 
 // claimColdestEvictable finds the coldest sealed, fully-synced, unclaimed segment

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -46,8 +46,22 @@ type EvictResult struct {
 // only copy of dirty bytes (the synced-gate, mirroring logblob.EvictBlob). It
 // evicts until targetBytes have been freed; targetBytes <= 0 evicts a single
 // qualifying segment. It returns what it reclaimed — SegmentsEvicted == 0 means
-// nothing qualified (the caller should backpressure, see ensureSpace).
+// nothing qualified.
+//
+// Evict is the explicit force-evict entrypoint (the shares evict admin's
+// DrainLocalSynced). When the sealed set cannot satisfy the reclaim it force-seals
+// the fully-synced active segments so their bytes become evictable too: a working
+// set smaller than the segment-roll threshold otherwise sits entirely in the
+// never-sealed active segment, where nothing can reclaim it.
 func (s *Store) Evict(ctx context.Context, targetBytes int64) (EvictResult, error) {
+	return s.evict(ctx, targetBytes, true)
+}
+
+// evict is the shared eviction loop. allowActiveSeal enables the force-seal
+// fall-through used by the explicit Evict path; the write-path capacity gate
+// (ensureSpace) passes false so a sustained writer backpressures on its own
+// unsynced bytes instead of sealing the very segment it is appending into.
+func (s *Store) evict(ctx context.Context, targetBytes int64, allowActiveSeal bool) (EvictResult, error) {
 	if err := ctx.Err(); err != nil {
 		return EvictResult{}, err
 	}
@@ -58,9 +72,20 @@ func (s *Store) Evict(ctx context.Context, targetBytes int64) (EvictResult, erro
 		return EvictResult{}, nil
 	}
 	var res EvictResult
+	sealedActives := false
 	for {
 		seg, sh := s.claimColdestEvictable()
 		if seg == nil {
+			// Sealed set exhausted. On an explicit force-evict, seal the
+			// fully-synced active segments once so their bytes become evictable —
+			// the next iteration drains them. Bounded to a single pass so a fresh
+			// (empty) active segment is never sealed in a spin.
+			if allowActiveSeal && !sealedActives {
+				sealedActives = true
+				if s.sealSyncedActives() {
+					continue
+				}
+			}
 			return res, nil
 		}
 		freed, err := s.evictSegment(sh, seg)
@@ -73,6 +98,34 @@ func (s *Store) Evict(ctx context.Context, targetBytes int64) (EvictResult, erro
 			return res, nil
 		}
 	}
+}
+
+// sealSyncedActives force-seals each shard's active segment when it holds only
+// synced (remote-durable) records, moving it into the sealed set so eviction can
+// reclaim it. It never seals an empty active (nothing to gain, and a spin would
+// spew empty segments), an active holding any unsynced record (sealing would not
+// make it evictable and its dirty bytes must stay the local copy), or a pinned
+// active (a live snapshot needs those bytes local). A seal here is the same
+// primitive as a rotation, so it produces an identically valid sealed footer.
+// It returns whether it sealed any segment. Caller holds no lock.
+func (s *Store) sealSyncedActives() bool {
+	sealedAny := false
+	for _, sh := range s.shards {
+		sh.mu.Lock()
+		act := sh.active
+		// records is frozen while sh.mu is held (appends need it), and carve only
+		// ever raises syncedRecords toward records, so the fully-synced check is
+		// stable across the seal.
+		if act != nil && act.records.Load() > 0 &&
+			act.syncedRecords.Load() == act.records.Load() &&
+			!act.busy.Load() && !s.pinned(act) {
+			if err := s.sealSegment(sh); err == nil {
+				sealedAny = true
+			}
+		}
+		sh.mu.Unlock()
+	}
+	return sealedAny
 }
 
 // claimColdestEvictable finds the coldest sealed, fully-synced, unclaimed segment
@@ -165,18 +218,35 @@ func (s *Store) ensureSpace(ctx context.Context, needed int64) error {
 		return nil
 	}
 	deadline := time.Now().Add(s.cfg.EvictMaxWait)
+	lastUnsynced := s.unsynced.Load()
 	warned := false
 	for s.diskBytes.Load()+needed > s.cfg.MaxLocalBytes {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 		overage := s.diskBytes.Load() + needed - s.cfg.MaxLocalBytes
-		res, err := s.Evict(ctx, overage)
+		// Write-path eviction never force-seals the active segment: the bytes
+		// pinning the cap are this writer's own unsynced records, so the fix is to
+		// wait for carve to drain them, not to seal-and-strand them.
+		res, err := s.evict(ctx, overage, false)
 		if err != nil {
 			return err
 		}
 		if res.SegmentsEvicted > 0 {
+			deadline = time.Now().Add(s.cfg.EvictMaxWait) // reclaimed: extend the budget
+			lastUnsynced = s.unsynced.Load()
 			continue
+		}
+		// Nothing evictable. As long as carve keeps draining unsynced bytes to the
+		// remote, backpressure (slow) rather than error: refresh the budget on every
+		// observed drain so a writer that merely outpaces a live syncer waits for it
+		// instead of failing. ErrLocalStoreFull stays reserved for a genuine stall —
+		// the cap is pinned by unsynced bytes and no drain progress happens for the
+		// whole EvictMaxWait budget (no syncer, or sync disabled) — so the wait is
+		// bounded and never hangs.
+		if cur := s.unsynced.Load(); cur < lastUnsynced {
+			lastUnsynced = cur
+			deadline = time.Now().Add(s.cfg.EvictMaxWait)
 		}
 		if !warned {
 			logger.Warn("journal local store full: every segment pinned by unsynced bytes, backpressuring writes until carve drains to remote",


### PR DESCRIPTION
Closes #1766. Fixes Path 2 of #1767 and the `TestBlocksFlipLifecycle` failure in #1728 (Path 1 of #1767 and `TestNFSv42Clone` remain).

Two related defects in journal space reclamation, both stemming from the active (unsealed) segment never being reclaimable.

## BUG 1 — `Evict` is a no-op below the segment-roll threshold
`Evict`/`claimColdestEvictable` only consider **sealed** segments; the active segment seals only on rotation (at `SegmentSize`). A working set smaller than the roll threshold sits entirely in the never-sealed active segment, so `store block evict` / `DrainLocalSynced` frees nothing — failing `require.Less(statsAfterEvict.LocalDiskUsed, statsAfterWrite.LocalDiskUsed)` at `test/e2e/blocks_flip_test.go:196`.

**Fix:** `Evict` now falls through to `sealSyncedActives()` when the sealed set is exhausted — a **single** pass that force-seals each shard's active segment **only** when it is non-empty, fully synced (`syncedRecords == records`), not busy, and not pinned, then retries eviction once. Sealing uses the same `sealSegment` primitive as a rotation, so the on-disk sealed footer/CRC is identical to what recovery already trusts. The write path is unaffected (`allowActiveSeal=false`).

## BUG 2 — writeback saturation returned EIO instead of backpressuring
Under the writeback tier, sustained writes outpace the syncer; when local hits `MaxLocalBytes` and the pinning bytes are **unsynced** (can't be evicted without data loss), `ensureSpace` returned `ErrLocalStoreFull` → EIO. Competitors throttle, never error.

**Fix:** `ensureSpace` refreshes its `EvictMaxWait` budget on real drain progress (a segment evicted, or `unsynced` decreasing), so a writer that merely outpaces a live syncer backpressures (slows) indefinitely. `ErrLocalStoreFull` stays reserved for a genuine stall — no drain progress for the whole budget (no syncer / sync disabled) — so the wait is bounded and never hangs (backoff + ctx honored).

## Invariants preserved
Recovery footer (force-seal == rotation primitive), pinning (pinned actives never sealed), no unsynced-data eviction (fully-synced gate + existing `evictable()` synced gate), GC/refcount (unchanged retire/evict path), lock ordering (`sh.mu` one at a time, same discipline as append-triggered rotation; no new deadlock).

## Tests
New `evict_test.go`: force-seal reclaims a sub-threshold synced set + reads back cold; dirty active never sealed; sustained writes under a tight cap with a slow syncer never `ErrLocalStoreFull`; same pressure with no syncer returns a bounded terminal error.

Verified: `go test ./pkg/block/journal/... -race` (77), `./pkg/block/... -run 'Conformance|Journal|Evict|Reclaim|Backpressure' -race` (163), `./pkg/block/... -race` full tree (873).