### PR TITLE
bench: reclaim FUSE competitor cache dirs between systems

### DIFF
--- a/internal/dfsbench/backend/backend_test.go
+++ b/internal/dfsbench/backend/backend_test.go
@@ -314,3 +314,34 @@ func TestBenchPath(t *testing.T) {
 		t.Fatalf("enabled: got %q, want %q", got, want)
 	}
 }
+
+// TestReclaimBenchData_TargetsOnlyDataVolume proves the teardown reclaim only
+// deletes paths inside the isolated data volume: it is a no-op on the legacy
+// root-disk fallback (so it never wipes a real system dir like /var/lib) and
+// refuses the mount root and sibling paths.
+func TestReclaimBenchData_TargetsOnlyDataVolume(t *testing.T) {
+	saved := benchDataDir
+	t.Cleanup(func() { benchDataDir = saved })
+
+	// Legacy fallback: nothing is "under" an unmounted volume, so real dirs are safe.
+	benchDataDir = ""
+	for _, dir := range []string{"/var/lib/bench-dittofs", "/var/cache/bench-rclone", "/bench-data/juicefs"} {
+		if isUnderBenchData(dir) {
+			t.Fatalf("fallback: %q must not be treated as under the data volume", dir)
+		}
+	}
+
+	benchDataDir = "/bench-data"
+	safe := []string{"/bench-data", "/var/lib/bench-dittofs", "/bench-data-other/x"}
+	for _, dir := range safe {
+		if isUnderBenchData(dir) {
+			t.Fatalf("mounted: %q must NOT be reclaimable (root or outside the volume)", dir)
+		}
+	}
+	reclaimable := []string{"/bench-data/juicefs", filepath.Join("/bench-data", "rclone")}
+	for _, dir := range reclaimable {
+		if !isUnderBenchData(dir) {
+			t.Fatalf("mounted: %q should be reclaimable (a backend subdir on the volume)", dir)
+		}
+	}
+}

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/dfsbench/exec"
@@ -40,6 +41,30 @@ func benchPath(legacyRoot, sub string) string {
 		return filepath.Join(benchDataDir, sub)
 	}
 	return legacyRoot
+}
+
+// isUnderBenchData reports whether dir sits strictly inside the isolated data
+// volume. It is false when no data volume is mounted (legacy root-disk fallback)
+// and false for the mount root itself, so a caller can only ever target a
+// backend's own subdir under the volume — never a real system dir.
+func isUnderBenchData(dir string) bool {
+	if benchDataDir == "" {
+		return false
+	}
+	root := filepath.Clean(benchDataDir)
+	return filepath.Clean(dir) != root &&
+		strings.HasPrefix(filepath.Clean(dir), root+string(os.PathSeparator))
+}
+
+// reclaimBenchData deletes a finished backend's cache/data dir so the isolated
+// data volume's usage stays bounded by the largest single system instead of the
+// sum of every system that has run. It only removes a path under the data volume
+// (isUnderBenchData), so it is a no-op on the legacy root-disk fallback and can
+// never wipe a real system dir.
+func reclaimBenchData(dir string) {
+	if isUnderBenchData(dir) {
+		_ = os.RemoveAll(dir)
+	}
 }
 
 // dittofs-s3 is the subject: DittoFS serving badger metadata + an S3 remote

--- a/internal/dfsbench/backend/fuse.go
+++ b/internal/dfsbench/backend/fuse.go
@@ -59,14 +59,14 @@ func init() {
 	} {
 		mode, cacheMax := r.mode, r.cacheMax
 		register(newSrcBackend(srcBackend{
-			name: r.name, s3Backed: true, protos: all, srcDir: rcloneMnt, tier: r.tier,
+			name: r.name, s3Backed: true, protos: all, srcDir: rcloneMnt, cacheDir: rcloneCache, tier: r.tier,
 			setup:    func(ctx context.Context, env BackendEnv) error { return rcloneSetup(ctx, env, mode, cacheMax) },
 			teardown: fuseUnmount(rcloneMnt), remount: rcloneRemount,
 		}))
 	}
 
 	register(newSrcBackend(srcBackend{
-		name: "s3ql", s3Backed: true, protos: all, srcDir: s3qlMnt,
+		name: "s3ql", s3Backed: true, protos: all, srcDir: s3qlMnt, cacheDir: s3qlCache,
 		tier:  "durable-to-local cache + async S3; knfsd sync export",
 		setup: s3qlSetup, teardown: s3qlTeardown, remount: s3qlRemount,
 	}))
@@ -97,7 +97,7 @@ func init() {
 	} {
 		meta, wb, cacheSize := j.meta, j.writeback, j.cacheSize
 		register(newSrcBackend(srcBackend{
-			name: j.name, s3Backed: true, protos: all, srcDir: juicefsMnt, tier: j.tier,
+			name: j.name, s3Backed: true, protos: all, srcDir: juicefsMnt, cacheDir: juicefsCache, tier: j.tier,
 			setup:    func(ctx context.Context, env BackendEnv) error { return juicefsSetup(ctx, env, meta, wb, cacheSize) },
 			teardown: juicefsTeardown, remount: juicefsRemount,
 		}))
@@ -123,7 +123,7 @@ func init() {
 	} {
 		useCache, ensureFreeMB := s.useCache, s.ensureFreeMB
 		register(newSrcBackend(srcBackend{
-			name: s.name, s3Backed: true, protos: all, srcDir: s3fsMnt, tier: s.tier,
+			name: s.name, s3Backed: true, protos: all, srcDir: s3fsMnt, cacheDir: s3fsCache, tier: s.tier,
 			setup:    func(ctx context.Context, env BackendEnv) error { return s3fsSetup(ctx, env, useCache, ensureFreeMB) },
 			teardown: fuseUnmount(s3fsMnt), remount: s3fsRemount,
 		}))

--- a/internal/dfsbench/backend/reexport.go
+++ b/internal/dfsbench/backend/reexport.go
@@ -155,6 +155,7 @@ type srcBackend struct {
 	tier     string // effective durability tier, surfaced as Backend.Tier
 	protos   []Protocol
 	srcDir   string
+	cacheDir string                                          // on-disk cache under the data volume, reclaimed at teardown; "" = none
 	setup    func(ctx context.Context, env BackendEnv) error // install + FUSE-mount at srcDir; nil = plain dir
 	teardown func(ctx context.Context) error                 // FUSE-unmount; nil = none
 	evict    func(ctx context.Context) error                 // clear tool cache; nil = OS-drop only
@@ -197,6 +198,10 @@ func newSrcBackend(sb srcBackend) *Backend {
 				err = sb.teardown(ctx)
 			}
 			_ = os.RemoveAll(sb.srcDir)
+			// Free the on-disk cache once this system's cells are done, so the data
+			// volume stays bounded by the largest single system, not their sum. srcDir
+			// is only the (empty) mountpoint; the bulk bytes live in cacheDir.
+			reclaimBenchData(sb.cacheDir)
 			return err
 		},
 	}


### PR DESCRIPTION
The benchmark matrix could wedge on a full data volume: the FUSE competitors (rclone/s3ql/juicefs/s3fs) removed only their empty mountpoint on Teardown, never their cache dir under `/bench-data` — so juicefs's cache accumulated to ~38 GB and filled a 46 GB volume, stalling every later system on a full disk.

## Fix
- `reclaimBenchData(dir)` deletes a finished backend's cache/data dir, guarded by `isUnderBenchData(dir)` which is true only when a data volume is mounted **and** `dir` is strictly inside it — a no-op on the `--data-volume-gb=0` legacy fallback, and it refuses the mount root and any outside path, so a real system dir (`/var/cache/...`) can never be removed.
- The shared `srcBackend.Teardown` (all four FUSE backends route through it) now reclaims its cache dir after unmount; dittofs/zerofs already cleaned their own dirs.

Disk usage is now bounded by the largest single system, not the sum of all of them.

`internal/dfsbench` only. Verified: gofmt, build, vet, `go test ./internal/dfsbench/... -race` (43 pass), incl. a guard test that it no-ops on legacy fallback and refuses the mount root / outside paths.