### PR TITLE
perf(block): fan out carve so the uploader runs more than one block in flight

### DIFF
--- a/pkg/block/engine/carve_dispatch.go
+++ b/pkg/block/engine/carve_dispatch.go
@@ -75,6 +75,19 @@ func (m *Syncer) carvePass(ctx context.Context) {
 	if len(files) == 0 {
 		return
 	}
+	// stopCh is not observed once blocked inside uploadLimiter.Acquire or a
+	// file's Carve, so derive a pass context that a stop cancels — otherwise a
+	// shutdown while the window is full (or a carve is stuck on a slow PutBlock)
+	// would hang the dispatcher until the slot frees.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() {
+		select {
+		case <-m.stopCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
 	var wg sync.WaitGroup
 	for _, id := range files {
 		stop := false

--- a/pkg/block/engine/carve_dispatch.go
+++ b/pkg/block/engine/carve_dispatch.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
@@ -51,21 +52,71 @@ func (m *Syncer) carveDispatcher(ctx context.Context) {
 			if !m.carveActive.Load() || !m.IsRemoteHealthy() {
 				continue
 			}
-			res, err := m.local.Carve(ctx, journal.CarveOptions{})
+			m.carvePass(ctx)
+		}
+	}
+}
+
+// carvePass packs every file with local data into remote blocks, carving files
+// concurrently so multiple blocks are uploaded at once. A single sequential
+// pass (one file, one block, one PutBlock at a time) leaves the uplink almost
+// idle — the block-upload latency, not the link or CPU, caps throughput.
+//
+// Concurrency is bounded by the adaptive upload window: the loop acquires
+// uploadLimiter before starting each file's carve and releases it when that
+// file's blocks are committed, so at most Limit() carves — and thus block
+// PUTs — are in flight. Acquiring the window is also what lets the goodput
+// controller observe real in-flight concurrency (TakePeak) and ramp the window;
+// without it the window is never consumed and stays pinned at the floor. Files
+// in one shard still serialize on the journal's internal carve lock, so the
+// concurrency here overlaps distinct shards' upload latency.
+func (m *Syncer) carvePass(ctx context.Context) {
+	files := m.local.ListFiles(ctx)
+	if len(files) == 0 {
+		return
+	}
+	var wg sync.WaitGroup
+	for _, id := range files {
+		stop := false
+		select {
+		case <-ctx.Done():
+			stop = true
+		case <-m.stopCh:
+			stop = true
+		default:
+		}
+		if stop {
+			break
+		}
+		if m.uploadLimiter != nil {
+			// Blocks here when the window is full, throttling both concurrency
+			// and goroutine spawn to the current limit; released by the worker.
+			if err := m.uploadLimiter.Acquire(ctx); err != nil {
+				break // context cancelled
+			}
+		}
+		wg.Add(1)
+		go func(fileID string) {
+			defer wg.Done()
+			if m.uploadLimiter != nil {
+				defer m.uploadLimiter.Release()
+			}
+			res, err := m.local.Carve(ctx, journal.CarveOptions{FileID: journal.FileID(fileID)})
 			if err != nil {
 				m.uploadErrWindow.Add(1)
 				m.failedSyncs.Add(1)
-				logger.Warn("carve dispatcher: carve pass failed", "error", err)
-				continue
+				logger.Warn("carve dispatcher: file carve failed", "file", fileID, "error", err)
+				return
 			}
 			if res.BytesCarved > 0 {
 				// Feed the adaptive-upload goodput sample and the lifetime
-				// completed-sync counter (blocks committed this pass).
+				// completed-sync counter (blocks committed for this file).
 				m.uploadedBytesWindow.Add(res.BytesCarved)
 				m.completedSyncs.Add(int64(res.BlocksWritten))
 			}
-		}
+		}(id)
 	}
+	wg.Wait()
 }
 
 // newBlockID returns a fresh, unguessable block object key. crypto/rand keeps it

--- a/pkg/block/engine/carve_dispatch_test.go
+++ b/pkg/block/engine/carve_dispatch_test.go
@@ -1,0 +1,97 @@
+package engine
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/marmos91/dittofs/pkg/block/journal"
+	"github.com/marmos91/dittofs/pkg/block/local"
+)
+
+// carveFanoutLocal is a minimal LocalStore that records per-file Carve calls and
+// synchronizes on channels so a test can observe how many carves run at once.
+// Only ListFiles + Carve are exercised by carvePass; the rest of the interface
+// is embedded (nil) and never called.
+type carveFanoutLocal struct {
+	local.LocalStore
+	files    []string
+	started  chan string   // one send per Carve entry
+	release  chan struct{} // closed to let every held Carve return
+	inFlight atomic.Int32
+	mu       sync.Mutex
+	carved   map[string]int // FileID -> completed count
+}
+
+func (f *carveFanoutLocal) ListFiles(context.Context) []string { return f.files }
+
+func (f *carveFanoutLocal) Carve(_ context.Context, opts journal.CarveOptions) (journal.CarveResult, error) {
+	f.inFlight.Add(1)
+	f.started <- string(opts.FileID)
+	<-f.release
+	f.inFlight.Add(-1)
+	f.mu.Lock()
+	f.carved[string(opts.FileID)]++
+	f.mu.Unlock()
+	return journal.CarveResult{BytesCarved: 1, BlocksWritten: 1}, nil
+}
+
+// TestCarvePass_FansOutBoundedByUploadWindow proves carvePass carves every file
+// (with its FileID set), runs them concurrently, and never exceeds the upload
+// window — the fix that gives the uploader more than one block in flight.
+func TestCarvePass_FansOutBoundedByUploadWindow(t *testing.T) {
+	fl := &carveFanoutLocal{
+		files:   []string{"a", "b", "c", "d", "e"},
+		started: make(chan string, 5),
+		release: make(chan struct{}),
+		carved:  map[string]int{},
+	}
+	const window = 3
+	m := &Syncer{
+		local:         fl,
+		uploadLimiter: newDynamicSemaphore(window),
+		stopCh:        make(chan struct{}),
+		config:        DefaultConfig(),
+	}
+
+	done := make(chan struct{})
+	go func() { m.carvePass(context.Background()); close(done) }()
+
+	// Exactly `window` carves start; the loop's Acquire blocks the rest.
+	seen := map[string]bool{}
+	for i := 0; i < window; i++ {
+		seen[<-fl.started] = true
+	}
+	require.Equal(t, int32(window), fl.inFlight.Load(), "in-flight carves should fill the window")
+
+	// A further carve must NOT start until a slot frees.
+	select {
+	case id := <-fl.started:
+		t.Fatalf("carve %q started before the upload window freed", id)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Let everything drain; the remaining files carve as slots free.
+	close(fl.release)
+	for i := 0; i < len(fl.files)-window; i++ {
+		seen[<-fl.started] = true
+	}
+	<-done
+
+	require.Len(t, seen, len(fl.files), "every file should have been carved")
+	for _, id := range fl.files {
+		require.Equal(t, 1, fl.carved[id], "file %q carved exactly once", id)
+	}
+}
+
+// TestCarvePass_NoFilesIsNoop guards the empty working-set path.
+func TestCarvePass_NoFilesIsNoop(t *testing.T) {
+	fl := &carveFanoutLocal{started: make(chan string, 1), release: make(chan struct{}), carved: map[string]int{}}
+	m := &Syncer{local: fl, uploadLimiter: newDynamicSemaphore(4), stopCh: make(chan struct{}), config: DefaultConfig()}
+	m.carvePass(context.Background()) // returns immediately, acquires nothing
+	require.Equal(t, int32(0), fl.inFlight.Load())
+}


### PR DESCRIPTION
Addresses #1717 (and the write-throughput lever behind #1767 Path 1 / #1432).

## Root cause (profiled)
DittoFS writeback uploads at ~9 MB/s while the same VM→bucket path does 93 MB/s single-stream / 204 MB/s parallel. Not bandwidth, not a stall: the carve→upload path is a **single serial goroutine, one block in flight**, and the `uploadLimiter` semaphore that `goodputController` sizes was **never acquired** (`dynsem.go` `Acquire()` had zero callers) — so the controller always saw "app-limited" (`TakePeak()==0`) and held the window at the floor. Throughput = one `PutBlock` round-trip at a time.

## Fix (engine-only, no `pkg/block/journal` changes)
`carvePass` replaces the single `Carve(CarveOptions{})` with a per-file fan-out: enumerate `local.ListFiles`, carve each file via `Carve(CarveOptions{FileID})` across workers **bounded by `uploadLimiter`**, acquiring it per file. This (a) puts up to `Limit()` blocks in flight, and (b) makes `TakePeak()` reflect real concurrency so the goodput controller can finally ramp the window. Same-shard files still serialize on the journal's internal `carveMu` (safe, unchanged); cross-shard uploads overlap.

## Ceiling / follow-up
Per-file fan-out wins multi-file writes (the common case; the 9 MB/s number was measured on `numjobs=4`). A **single** huge file stays serial → follow-up is within-`CommitBlock` concurrent PutBlocks (bigger; touches the carve→commit→synced-flip seam).

## Verification
- Deterministic unit tests (`carve_dispatch_test.go`): every file carved once with its FileID; concurrency reaches but never exceeds the window; empty working-set no-ops. `-race -count=5` green.
- Full `go test ./pkg/block/... -race` → 875 pass.
- Throughput gain should be confirmed with a metrics-enabled VM repro (in-flight PutBlock count > 1, goodput climbing toward link rate) — tracked in the roadmap.