### PR TITLE
chore(metadata): remove dead pending_writes table and unused types

### DIFF
--- a/pkg/metadata/store/postgres/migrations/000042_drop_pending_writes.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000042_drop_pending_writes.down.sql
@@ -1,0 +1,17 @@
+-- Re-create the dropped pending_writes table and its indexes (reversibility).
+-- DDL copied from 000001_initial_schema.up.sql.
+CREATE TABLE pending_writes (
+    operation_id    TEXT PRIMARY KEY,
+    file_id         UUID NOT NULL REFERENCES inodes(id) ON DELETE CASCADE,
+    new_size        BIGINT NOT NULL,
+    new_mtime       TIMESTAMPTZ NOT NULL,
+    content_id      TEXT NOT NULL,
+    pre_write_attr  JSONB,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT valid_operation_id CHECK (length(operation_id) > 0),
+    CONSTRAINT valid_new_size CHECK (new_size >= 0)
+);
+
+CREATE INDEX idx_pending_writes_file_id ON pending_writes(file_id);
+CREATE INDEX idx_pending_writes_created_at ON pending_writes(created_at);

--- a/pkg/metadata/store/postgres/migrations/000042_drop_pending_writes.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000042_drop_pending_writes.up.sql
@@ -1,0 +1,6 @@
+-- Remove the dead pending_writes table. It was provisioned for a two-phase
+-- write protocol that was never implemented: no code inserts, selects, or
+-- updates rows, so the table (and its two indexes) has always been empty.
+-- Dropping the table drops idx_pending_writes_file_id and
+-- idx_pending_writes_created_at with it.
+DROP TABLE IF EXISTS pending_writes;

--- a/pkg/metadata/store/postgres/snapshot_store.go
+++ b/pkg/metadata/store/postgres/snapshot_store.go
@@ -43,7 +43,9 @@ const (
 	// file_blocks is in backupTables, so the dumped row shape changes one column.
 	// v8 drops the dead block_store_key column from file_blocks (migration 000041);
 	// file_blocks is in backupTables, so the dumped row shape changes one column.
-	postgresSchemaVersion = uint32(8)
+	// v9 drops the dead pending_writes table (migration 000042), lowering the
+	// backup table count by one.
+	postgresSchemaVersion = uint32(9)
 )
 
 // backupTables lists every metadata table in FK-safe dependency order
@@ -59,7 +61,6 @@ var backupTables = []string{
 	"inodes",
 	"shares",
 	"parent_child_map",
-	"pending_writes",
 	"file_block_refs",
 	"file_blocks",
 	"locks",


### PR DESCRIPTION
Safe dead-code subset of the metadata store cleanup. Deletion only — no behaviour changes, no refactors.

## Removed

**Dead `pending_writes` table (postgres)** — provisioned in the initial schema for a two-phase write protocol that was never implemented. Verified dead: no Go code inserts, selects, updates, or deletes rows (`grep -rniE 'insert into pending_writes|from pending_writes|update pending_writes|delete from pending_writes'` → zero hits). Its only live reference was a name entry in the `backupTables` snapshot list, so the table was always dumped empty.

- New migration `000042_drop_pending_writes` drops the table (its two indexes `idx_pending_writes_file_id` / `idx_pending_writes_created_at` drop with it); reversible `.down.sql` re-creates both. Follows the existing drop-migration convention (000040/000041).
- Removed `"pending_writes"` from `backupTables` in `snapshot_store.go` and bumped `postgresSchemaVersion` 8 → 9, mirroring the prior table-removal bumps (v4/v6).

## Verified but kept (live — NOT removed)

| Candidate | Verdict |
|---|---|
| `pending_writes` DB table (postgres) | **removed** — no query callers |
| `idx_pending_writes_*` indexes | **removed** — drop with the table |
| `FilesystemMeta` type | **kept — live**: `Get/PutFilesystemMeta` are `Store` interface methods implemented by all four backends and exercised by the `storetest` conformance suite (`testFilesystemMetaStatsCaps`) |
| in-memory `pkg/metadata/pending_writes.go` (RestorePending / pop-and-merge) | **untouched** — unrelated live mechanism, not a DB table |

sqlite/badger/memory have no `pending_writes` table — this was postgres-only.

## Checks
`go build ./...`, `go vet ./pkg/metadata/...`, `gofmt -s`, `golangci-lint run` on the changed package, and `go test ./pkg/metadata/... -race` (2647 passed) all green. The postgres snapshot round-trip is DB-gated and runs in CI.

Refs #1715 (umbrella stays open — more waves).