### PR TITLE
refactor(metadata): extract shared quota/usage accounting

### DIFF
--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
 )
 
 // ============================================================================
@@ -210,7 +211,7 @@ func (s *BadgerMetadataStore) DeleteShare(ctx context.Context, shareName string)
 	}
 
 	var freedBytes int64
-	var quotaFreed map[badgerQuotaKey]metadata.UsageStat
+	var quotaFreed map[quota.Key]metadata.UsageStat
 	err := s.db.Update(func(txn *badgerdb.Txn) error {
 		_, err := txn.Get(keyShare(shareName))
 		if err == badgerdb.ErrKeyNotFound {
@@ -249,36 +250,13 @@ func (s *BadgerMetadataStore) DeleteShare(ctx context.Context, shareName string)
 // applyQuotaDelta folds a per-identity usage delta into the in-memory usage
 // cache. Called post-commit (matching usedBytes). Buckets that drop to zero or
 // below are removed.
-func (s *BadgerMetadataStore) applyQuotaDelta(delta map[badgerQuotaKey]metadata.UsageStat) {
+func (s *BadgerMetadataStore) applyQuotaDelta(delta map[quota.Key]metadata.UsageStat) {
 	if len(delta) == 0 {
 		return
 	}
 	s.quotaMu.Lock()
 	defer s.quotaMu.Unlock()
-	for k, d := range delta {
-		m := s.userUsage
-		if k.scope == metadata.QuotaScopeGroup {
-			m = s.groupUsage
-		}
-		cur := m[k.id]
-		if cur == nil {
-			cur = &metadata.UsageStat{}
-			m[k.id] = cur
-		}
-		cur.Bytes += d.Bytes
-		cur.Files += d.Files
-		// Negative values indicate accounting drift (should never happen):
-		// clamp to zero so the enforcer never reads a too-permissive total.
-		if cur.Bytes < 0 {
-			cur.Bytes = 0
-		}
-		if cur.Files < 0 {
-			cur.Files = 0
-		}
-		if cur.Bytes == 0 && cur.Files == 0 {
-			delete(m, k.id)
-		}
-	}
+	s.quota.Apply(delta)
 }
 
 // deleteShareFiles removes every file inode and its dependent keys (parent,
@@ -296,7 +274,7 @@ func (s *BadgerMetadataStore) applyQuotaDelta(delta map[badgerQuotaKey]metadata.
 // pendingDelta and the pool-path applies it after db.Update returns nil — so a
 // conflict/serialization retry that re-runs the enclosing Update never
 // double-counts. The counter is statfs-only, not quota-enforcing.
-func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName string) (freedBytes int64, quota map[badgerQuotaKey]metadata.UsageStat, err error) {
+func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName string) (freedBytes int64, quotaFreed map[quota.Key]metadata.UsageStat, err error) {
 	type doomed struct {
 		id        uuid.UUID
 		objectID  metadata.ContentHash
@@ -342,7 +320,7 @@ func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName stri
 	}
 	it.Close()
 
-	quota = make(map[badgerQuotaKey]metadata.UsageStat)
+	quotaFreed = make(map[quota.Key]metadata.UsageStat)
 	for _, v := range victims {
 		if delErr := deleteFileKeys(txn, v.id, v.objectID, v.payloadID); delErr != nil {
 			return 0, nil, delErr
@@ -358,20 +336,20 @@ func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName stri
 			if v.size > 0 {
 				freedBytes += int64(v.size)
 			}
-			uk := badgerQuotaKey{metadata.QuotaScopeUser, v.uid}
-			us := quota[uk]
+			uk := quota.Key{Scope: metadata.QuotaScopeUser, ID: v.uid}
+			us := quotaFreed[uk]
 			us.Bytes -= int64(v.size)
 			us.Files--
-			quota[uk] = us
-			gk := badgerQuotaKey{metadata.QuotaScopeGroup, v.gid}
-			gs := quota[gk]
+			quotaFreed[uk] = us
+			gk := quota.Key{Scope: metadata.QuotaScopeGroup, ID: v.gid}
+			gs := quotaFreed[gk]
 			gs.Bytes -= int64(v.size)
 			gs.Files--
-			quota[gk] = gs
+			quotaFreed[gk] = gs
 		}
 	}
 
-	return freedBytes, quota, nil
+	return freedBytes, quotaFreed, nil
 }
 
 // deleteFileKeys removes the primary file row plus its parent, link-count, and

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/oklog/ulid/v2"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
 )
 
 // BadgerMetadataStore implements metadata.Store using BadgerDB for persistence.
@@ -147,15 +148,14 @@ type BadgerMetadataStore struct {
 	// Initialized from a full file scan on startup.
 	usedBytes atomic.Int64
 
-	// userUsage / groupUsage track per-identity usage (bytes + file count) for
-	// regular files, keyed by owner uid / gid. In-memory cache mirroring
-	// usedBytes, seeded from a full file scan on startup (so it is always
-	// reconstructed from the durable file rows — back-compatible with existing
-	// dumps). Updated from a transaction's pending per-identity deltas exactly
-	// once on successful commit. Guarded by quotaMu.
-	quotaMu    sync.Mutex
-	userUsage  map[uint32]*metadata.UsageStat
-	groupUsage map[uint32]*metadata.UsageStat
+	// quota tracks per-identity usage (bytes + file count) for regular files,
+	// keyed by owner uid / gid. In-memory cache mirroring usedBytes, seeded from
+	// a full file scan on startup (so it is always reconstructed from the durable
+	// file rows — back-compatible with existing dumps). Updated from a
+	// transaction's pending per-identity deltas exactly once on successful
+	// commit. Guarded by quotaMu.
+	quotaMu sync.Mutex
+	quota   *quota.Cache
 
 	// storeID is the engine-persistent identifier for this store instance,
 	// backed by the cfg:store_id key in BadgerDB. Created on first open of
@@ -368,6 +368,7 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 		storeID:           sid,
 		relaxedDurability: config.RelaxedDurability,
 		syncStop:          make(chan struct{}),
+		quota:             quota.NewCache(),
 	}
 
 	// Initialize stats cache with a 5-second TTL for responsive updates
@@ -605,8 +606,7 @@ func (s *BadgerMetadataStore) initUsedBytesCounter() error {
 
 	s.usedBytes.Store(totalUsed)
 	s.quotaMu.Lock()
-	s.userUsage = userUsage
-	s.groupUsage = groupUsage
+	s.quota.Seed(userUsage, groupUsage)
 	s.quotaMu.Unlock()
 	return nil
 }
@@ -616,14 +616,7 @@ func (s *BadgerMetadataStore) initUsedBytesCounter() error {
 func (s *BadgerMetadataStore) GetQuotaUsage(scope metadata.QuotaScope, id uint32) (metadata.UsageStat, error) {
 	s.quotaMu.Lock()
 	defer s.quotaMu.Unlock()
-	m := s.userUsage
-	if scope == metadata.QuotaScopeGroup {
-		m = s.groupUsage
-	}
-	if u, ok := m[id]; ok {
-		return *u, nil
-	}
-	return metadata.UsageStat{}, nil
+	return s.quota.Get(scope, id), nil
 }
 
 // NewBadgerMetadataStoreWithDefaults creates a new BadgerDB metadata store with sensible defaults.

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -14,6 +14,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	mderrors "github.com/marmos91/dittofs/pkg/metadata/errors"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
 )
 
 // ============================================================================
@@ -36,12 +37,11 @@ type badgerTransaction struct {
 	// used to invalidate the read cache (see withTransaction). Reset per attempt
 	// like pendingDelta so a conflict-retry cannot leak a phantom invalidation.
 	dirtyFiles []string
-	// quotaDelta accumulates per-identity usage changes (bytes + file count)
-	// keyed by (scope, id). Captured per attempt and applied to the store's
-	// in-memory userUsage/groupUsage cache exactly once after a successful
-	// commit, identical to pendingDelta (so a conflict-retry cannot
-	// double-count).
-	quotaDelta map[badgerQuotaKey]metadata.UsageStat
+	// quota accumulates per-identity usage changes (bytes + file count) keyed by
+	// (scope, id). Captured per attempt and applied to the store's quota cache
+	// exactly once after a successful commit, identical to pendingDelta (so a
+	// conflict-retry cannot double-count).
+	quota quota.Delta
 	// dirtyShares collects share names whose stored share record this
 	// transaction mutated. Captured per attempt and, after a successful commit,
 	// used to invalidate the share read cache (see withTransaction). Reset per
@@ -56,47 +56,6 @@ type badgerTransaction struct {
 	// invalidation. A stale entry is a spurious ENOENT (negative) or EEXIST
 	// (positive).
 	dirtyDirents []string
-}
-
-// badgerQuotaKey identifies a per-identity usage bucket inside a transaction's
-// accumulated delta.
-type badgerQuotaKey struct {
-	scope metadata.QuotaScope
-	id    uint32
-}
-
-// addQuota records a usage delta for the file's owner identity (both user and
-// group scopes). See memory store addQuota for the create/resize/chown cases.
-func (tx *badgerTransaction) addQuota(uid, gid uint32, bytes, files int64) {
-	if bytes == 0 && files == 0 {
-		return
-	}
-	if tx.quotaDelta == nil {
-		tx.quotaDelta = make(map[badgerQuotaKey]metadata.UsageStat)
-	}
-	u := tx.quotaDelta[badgerQuotaKey{metadata.QuotaScopeUser, uid}]
-	u.Bytes += bytes
-	u.Files += files
-	tx.quotaDelta[badgerQuotaKey{metadata.QuotaScopeUser, uid}] = u
-	g := tx.quotaDelta[badgerQuotaKey{metadata.QuotaScopeGroup, gid}]
-	g.Bytes += bytes
-	g.Files += files
-	tx.quotaDelta[badgerQuotaKey{metadata.QuotaScopeGroup, gid}] = g
-}
-
-// addQuota2 merges a single pre-keyed usage delta (used when folding the
-// per-identity totals returned by deleteShareFiles).
-func (tx *badgerTransaction) addQuota2(k badgerQuotaKey, d metadata.UsageStat) {
-	if d.Bytes == 0 && d.Files == 0 {
-		return
-	}
-	if tx.quotaDelta == nil {
-		tx.quotaDelta = make(map[badgerQuotaKey]metadata.UsageStat)
-	}
-	cur := tx.quotaDelta[k]
-	cur.Bytes += d.Bytes
-	cur.Files += d.Files
-	tx.quotaDelta[k] = cur
 }
 
 // Maximum number of retries for conflict errors.
@@ -154,7 +113,7 @@ func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx me
 		// successful commit and reset per attempt (a retried attempt starts
 		// from zero, so a conflict-retry cannot double-count usedBytes).
 		var pendingDelta int64
-		var quotaDelta map[badgerQuotaKey]metadata.UsageStat
+		var quotaDelta map[quota.Key]metadata.UsageStat
 		var dirtyFiles []string
 		var dirtyShares []string
 		var dirtyDirents []string
@@ -164,7 +123,7 @@ func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx me
 				return fnErr
 			}
 			pendingDelta = tx.pendingDelta
-			quotaDelta = tx.quotaDelta
+			quotaDelta = tx.quota.Map()
 			dirtyFiles = tx.dirtyFiles
 			dirtyShares = tx.dirtyShares
 			dirtyDirents = tx.dirtyDirents
@@ -443,13 +402,13 @@ func (tx *badgerTransaction) PutFile(ctx context.Context, file *metadata.File) e
 
 		switch {
 		case !hadOldRegular:
-			tx.addQuota(file.UID, file.GID, int64(file.Size), 1)
+			tx.quota.Add(file.UID, file.GID, int64(file.Size), 1)
 		case oldUID == file.UID && oldGID == file.GID:
-			tx.addQuota(file.UID, file.GID, int64(file.Size)-int64(oldSize), 0)
+			tx.quota.Add(file.UID, file.GID, int64(file.Size)-int64(oldSize), 0)
 		default:
 			// Chown: move bytes + inode from old owner to new owner.
-			tx.addQuota(oldUID, oldGID, -int64(oldSize), -1)
-			tx.addQuota(file.UID, file.GID, int64(file.Size), 1)
+			tx.quota.Add(oldUID, oldGID, -int64(oldSize), -1)
+			tx.quota.Add(file.UID, file.GID, int64(file.Size), 1)
 		}
 	}
 
@@ -560,7 +519,7 @@ func (tx *badgerTransaction) DeleteFile(ctx context.Context, handle metadata.Fil
 				if file.Size > 0 {
 					tx.pendingDelta -= int64(file.Size)
 				}
-				tx.addQuota(file.UID, file.GID, -int64(file.Size), -1)
+				tx.quota.Add(file.UID, file.GID, -int64(file.Size), -1)
 			}
 			existingObjectID = file.ObjectID
 			existingPayloadID = file.PayloadID
@@ -1219,15 +1178,15 @@ func (tx *badgerTransaction) DeleteShare(ctx context.Context, shareName string) 
 	// Tear down all file metadata on the active txn, identical to the pool
 	// path — deleting only the share key would orphan every file/parent/
 	// linkcount/child/objectID entry (store.go:161 contract).
-	freed, quota, err := tx.store.deleteShareFiles(tx.txn, shareName)
+	freed, quotaFreed, err := tx.store.deleteShareFiles(tx.txn, shareName)
 	if err != nil {
 		return err
 	}
 	// Accumulate into the tx pending delta; applied once after a successful
 	// commit so a conflict-retry never double-counts.
 	tx.pendingDelta -= freed
-	for k, d := range quota {
-		tx.addQuota2(k, d)
+	for k, d := range quotaFreed {
+		tx.quota.AddKeyed(k, d)
 	}
 
 	if err := tx.txn.Delete(keyShare(shareName)); err != nil {

--- a/pkg/metadata/store/internal/quota/quota.go
+++ b/pkg/metadata/store/internal/quota/quota.go
@@ -1,0 +1,136 @@
+// Package quota holds the shared per-identity usage accounting used by every
+// metadata store backend. Each backend keeps a Cache of per-user/per-group
+// byte and file counts (for statfs and quota enforcement) and accumulates
+// changes made inside a transaction in a Delta, folding the Delta into the
+// Cache exactly once after the transaction commits so a conflict-retry never
+// double-counts.
+//
+// Cache performs no locking of its own; callers guard it with their existing
+// mutex.
+package quota
+
+import "github.com/marmos91/dittofs/pkg/metadata"
+
+// Key identifies a per-identity usage bucket: an owner id within a scope
+// (user or group).
+type Key struct {
+	Scope metadata.QuotaScope
+	ID    uint32
+}
+
+// Cache holds per-identity usage split into user and group scopes. It does no
+// locking; callers hold their own mutex across Get/Apply/Seed/Reset.
+type Cache struct {
+	user  map[uint32]*metadata.UsageStat
+	group map[uint32]*metadata.UsageStat
+}
+
+// NewCache returns an empty, ready-to-use Cache.
+func NewCache() *Cache {
+	return &Cache{
+		user:  make(map[uint32]*metadata.UsageStat),
+		group: make(map[uint32]*metadata.UsageStat),
+	}
+}
+
+// Reset empties the cache.
+func (c *Cache) Reset() {
+	c.user = make(map[uint32]*metadata.UsageStat)
+	c.group = make(map[uint32]*metadata.UsageStat)
+}
+
+// Seed replaces the cache contents with per-identity usage pre-aggregated from
+// durable rows at startup. The maps are adopted as-is.
+func (c *Cache) Seed(user, group map[uint32]*metadata.UsageStat) {
+	c.user = user
+	c.group = group
+}
+
+// Get returns the usage for one identity. A missing key returns a zero
+// UsageStat.
+func (c *Cache) Get(scope metadata.QuotaScope, id uint32) metadata.UsageStat {
+	m := c.user
+	if scope == metadata.QuotaScopeGroup {
+		m = c.group
+	}
+	if u, ok := m[id]; ok {
+		return *u
+	}
+	return metadata.UsageStat{}
+}
+
+// Apply folds a per-identity usage delta into the cache. Buckets that drop to
+// zero or below are removed; a negative accumulation is clamped to zero so a
+// quota enforcer never reads a too-permissive total.
+func (c *Cache) Apply(delta map[Key]metadata.UsageStat) {
+	for k, d := range delta {
+		m := c.user
+		if k.Scope == metadata.QuotaScopeGroup {
+			m = c.group
+		}
+		cur := m[k.ID]
+		if cur == nil {
+			cur = &metadata.UsageStat{}
+			m[k.ID] = cur
+		}
+		cur.Bytes += d.Bytes
+		cur.Files += d.Files
+		if cur.Bytes < 0 {
+			cur.Bytes = 0
+		}
+		if cur.Files < 0 {
+			cur.Files = 0
+		}
+		if cur.Bytes == 0 && cur.Files == 0 {
+			delete(m, k.ID)
+		}
+	}
+}
+
+// Delta accumulates per-identity usage changes made inside a single
+// transaction, keyed by owner identity. It is folded into a Cache exactly once
+// after the transaction commits. The zero value is ready to use.
+type Delta struct {
+	m map[Key]metadata.UsageStat
+}
+
+// Add records a usage change for a file's owner identity across both the user
+// and group scopes. bytes is the size delta; files is the inode delta (+1 on
+// create, -1 on delete, 0 for an in-place resize). A no-op change is dropped.
+func (d *Delta) Add(uid, gid uint32, bytes, files int64) {
+	if bytes == 0 && files == 0 {
+		return
+	}
+	if d.m == nil {
+		d.m = make(map[Key]metadata.UsageStat)
+	}
+	u := d.m[Key{metadata.QuotaScopeUser, uid}]
+	u.Bytes += bytes
+	u.Files += files
+	d.m[Key{metadata.QuotaScopeUser, uid}] = u
+	g := d.m[Key{metadata.QuotaScopeGroup, gid}]
+	g.Bytes += bytes
+	g.Files += files
+	d.m[Key{metadata.QuotaScopeGroup, gid}] = g
+}
+
+// AddKeyed merges a single pre-keyed usage change (used when folding the
+// per-identity totals freed by a share delete). A no-op change is dropped.
+func (d *Delta) AddKeyed(k Key, s metadata.UsageStat) {
+	if s.Bytes == 0 && s.Files == 0 {
+		return
+	}
+	if d.m == nil {
+		d.m = make(map[Key]metadata.UsageStat)
+	}
+	cur := d.m[k]
+	cur.Bytes += s.Bytes
+	cur.Files += s.Files
+	d.m[k] = cur
+}
+
+// Map returns the accumulated per-identity deltas for folding into a Cache.
+// It may be nil when nothing was accumulated.
+func (d *Delta) Map() map[Key]metadata.UsageStat {
+	return d.m
+}

--- a/pkg/metadata/store/internal/quota/quota_test.go
+++ b/pkg/metadata/store/internal/quota/quota_test.go
@@ -1,0 +1,59 @@
+package quota
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// TestDeltaApplyAndGet exercises the accumulate → apply → read round-trip that
+// every store shares: a Delta records owner changes across user and group
+// scopes, the Cache folds them, and Get reports the result.
+func TestDeltaApplyAndGet(t *testing.T) {
+	c := NewCache()
+	var d Delta
+
+	// Create a 1000-byte file owned by uid 7 / gid 3.
+	d.Add(7, 3, 1000, 1)
+	c.Apply(d.Map())
+
+	if got := c.Get(metadata.QuotaScopeUser, 7); got.Bytes != 1000 || got.Files != 1 {
+		t.Fatalf("user usage = %+v, want {1000 1}", got)
+	}
+	if got := c.Get(metadata.QuotaScopeGroup, 3); got.Bytes != 1000 || got.Files != 1 {
+		t.Fatalf("group usage = %+v, want {1000 1}", got)
+	}
+	// Missing identity reads back zero.
+	if got := c.Get(metadata.QuotaScopeUser, 99); got != (metadata.UsageStat{}) {
+		t.Fatalf("missing usage = %+v, want zero", got)
+	}
+}
+
+// TestApplyDeletesAtZero verifies the clamp-to-zero / delete-if-zero defensive
+// logic: removing the file empties the bucket, and an over-decrement never
+// leaves a negative total.
+func TestApplyDeletesAtZero(t *testing.T) {
+	c := NewCache()
+
+	var create Delta
+	create.Add(7, 3, 1000, 1)
+	c.Apply(create.Map())
+
+	// Delete the file: bucket reaches zero and is removed.
+	var del Delta
+	del.Add(7, 3, -1000, -1)
+	c.Apply(del.Map())
+
+	if got := c.Get(metadata.QuotaScopeUser, 7); got != (metadata.UsageStat{}) {
+		t.Fatalf("usage after delete = %+v, want zero (bucket removed)", got)
+	}
+
+	// Over-decrement (accounting drift) clamps to zero rather than going
+	// negative.
+	c.Apply(map[Key]metadata.UsageStat{
+		{metadata.QuotaScopeUser, 7}: {Bytes: -500, Files: -1},
+	})
+	if got := c.Get(metadata.QuotaScopeUser, 7); got.Bytes < 0 || got.Files < 0 {
+		t.Fatalf("usage clamped negative = %+v", got)
+	}
+}

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
 )
 
 // shareData holds the internal representation of a share configuration.
@@ -227,16 +228,15 @@ type MemoryMetadataStore struct {
 	// Only regular files count toward usage; directories, symlinks, etc. do not.
 	usedBytes atomic.Int64
 
-	// userUsage / groupUsage track per-identity usage (bytes + file count) for
-	// regular files, keyed by owner uid / gid. Mirror of usedBytes but keyed by
-	// owner identity for per-user/per-group quota enforcement and reporting.
-	// Guarded by quotaMu (separate from s.mu so the GetQuotaUsage read path and
-	// the transaction commit-apply do not contend with unrelated metadata ops).
-	// Applied from a transaction's pending per-identity deltas exactly once on
-	// successful commit, identical to the usedBytes discipline.
-	quotaMu    sync.Mutex
-	userUsage  map[uint32]*metadata.UsageStat
-	groupUsage map[uint32]*metadata.UsageStat
+	// quota tracks per-identity usage (bytes + file count) for regular files,
+	// keyed by owner uid / gid. Mirror of usedBytes but keyed by owner identity
+	// for per-user/per-group quota enforcement and reporting. Guarded by quotaMu
+	// (separate from s.mu so the GetQuotaUsage read path and the transaction
+	// commit-apply do not contend with unrelated metadata ops). Applied from a
+	// transaction's pending per-identity deltas exactly once on successful
+	// commit, identical to the usedBytes discipline.
+	quotaMu sync.Mutex
+	quota   *quota.Cache
 
 	// storeID is the engine-persistent identifier for this store instance.
 	// Assigned on construction with a fresh ULID and immutable for the life
@@ -350,8 +350,7 @@ func NewMemoryMetadataStore(config MemoryMetadataStoreConfig) *MemoryMetadataSto
 		// ObjectID -> handle-key secondary index.
 		objectIndex: make(map[block.ContentHash]string),
 		// per-identity quota usage counters.
-		userUsage:  make(map[uint32]*metadata.UsageStat),
-		groupUsage: make(map[uint32]*metadata.UsageStat),
+		quota: quota.NewCache(),
 		// Block packing record store.
 		blockRecords: make(map[string]*block.BlockRecord),
 	}
@@ -433,14 +432,7 @@ func (store *MemoryMetadataStore) GetUsedBytes() int64 {
 func (store *MemoryMetadataStore) GetQuotaUsage(scope metadata.QuotaScope, id uint32) (metadata.UsageStat, error) {
 	store.quotaMu.Lock()
 	defer store.quotaMu.Unlock()
-	m := store.userUsage
-	if scope == metadata.QuotaScopeGroup {
-		m = store.groupUsage
-	}
-	if u, ok := m[id]; ok {
-		return *u, nil
-	}
-	return metadata.UsageStat{}, nil
+	return store.quota.Get(scope, id), nil
 }
 
 // GetStoreID returns the engine-persistent store identifier. Assigned on

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -9,6 +9,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	mderrors "github.com/marmos91/dittofs/pkg/metadata/errors"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
 )
 
 // ============================================================================
@@ -27,10 +28,10 @@ import (
 type memoryTransaction struct {
 	store        *MemoryMetadataStore
 	pendingDelta int64
-	// quotaDelta accumulates per-identity usage changes (bytes + file count)
-	// keyed by (scope, id). Applied to the store's userUsage/groupUsage maps
-	// exactly once after a successful commit, identical to pendingDelta.
-	quotaDelta map[quotaKey]metadata.UsageStat
+	// quota accumulates per-identity usage changes (bytes + file count) keyed by
+	// (scope, id). Applied to the store's quota cache exactly once after a
+	// successful commit, identical to pendingDelta.
+	quota quota.Delta
 	// syncedOps buffers SyncedHashStore mutations made inside the closure.
 	// The synced maps live under their own mutex (syncedMu), NOT store.mu, so
 	// they cannot participate in the snapshot/restore rollback: instead the
@@ -45,33 +46,6 @@ type memoryTransaction struct {
 type syncedTxState struct {
 	deleted bool
 	loc     block.ChunkLocator
-}
-
-// quotaKey identifies a per-identity usage bucket inside a transaction's
-// accumulated delta.
-type quotaKey struct {
-	scope metadata.QuotaScope
-	id    uint32
-}
-
-// addQuota records a usage delta for the file's owner identity (both user and
-// group scopes). bytes is the size delta; files is the inode delta (+1 create,
-// -1 delete, 0 for in-place size change).
-func (tx *memoryTransaction) addQuota(uid, gid uint32, bytes, files int64) {
-	if bytes == 0 && files == 0 {
-		return
-	}
-	if tx.quotaDelta == nil {
-		tx.quotaDelta = make(map[quotaKey]metadata.UsageStat)
-	}
-	u := tx.quotaDelta[quotaKey{metadata.QuotaScopeUser, uid}]
-	u.Bytes += bytes
-	u.Files += files
-	tx.quotaDelta[quotaKey{metadata.QuotaScopeUser, uid}] = u
-	g := tx.quotaDelta[quotaKey{metadata.QuotaScopeGroup, gid}]
-	g.Bytes += bytes
-	g.Files += files
-	tx.quotaDelta[quotaKey{metadata.QuotaScopeGroup, gid}] = g
 }
 
 // txSnapshot captures the mutable state of the memory store so a failed
@@ -222,32 +196,9 @@ func (store *MemoryMetadataStore) WithTransaction(ctx context.Context, fn func(t
 		store.usedBytes.Add(tx.pendingDelta)
 	}
 	// Apply per-identity usage deltas once, under quotaMu.
-	if len(tx.quotaDelta) > 0 {
+	if d := tx.quota.Map(); len(d) > 0 {
 		store.quotaMu.Lock()
-		for k, d := range tx.quotaDelta {
-			m := store.userUsage
-			if k.scope == metadata.QuotaScopeGroup {
-				m = store.groupUsage
-			}
-			cur := m[k.id]
-			if cur == nil {
-				cur = &metadata.UsageStat{}
-				m[k.id] = cur
-			}
-			cur.Bytes += d.Bytes
-			cur.Files += d.Files
-			// Negative values indicate accounting drift (should never happen):
-			// clamp to zero so the enforcer never reads a too-permissive total.
-			if cur.Bytes < 0 {
-				cur.Bytes = 0
-			}
-			if cur.Files < 0 {
-				cur.Files = 0
-			}
-			if cur.Bytes == 0 && cur.Files == 0 {
-				delete(m, k.id)
-			}
-		}
+		store.quota.Apply(d)
 		store.quotaMu.Unlock()
 	}
 	// Apply buffered synced-marker mutations once, under syncedMu. Map writes
@@ -346,15 +297,15 @@ func (tx *memoryTransaction) PutFile(ctx context.Context, file *metadata.File) e
 		case !hadOldRegular:
 			// New regular file (create or type change to regular): charge full
 			// size + 1 inode to the new owner.
-			tx.addQuota(file.UID, file.GID, int64(file.Size), 1)
+			tx.quota.Add(file.UID, file.GID, int64(file.Size), 1)
 		case oldUID == file.UID && oldGID == file.GID:
 			// Same owner: only the byte delta moves.
-			tx.addQuota(file.UID, file.GID, int64(file.Size)-int64(oldSize), 0)
+			tx.quota.Add(file.UID, file.GID, int64(file.Size)-int64(oldSize), 0)
 		default:
 			// Chown: remove old size + inode from the previous owner, add new
 			// size + inode to the new owner.
-			tx.addQuota(oldUID, oldGID, -int64(oldSize), -1)
-			tx.addQuota(file.UID, file.GID, int64(file.Size), 1)
+			tx.quota.Add(oldUID, oldGID, -int64(oldSize), -1)
+			tx.quota.Add(file.UID, file.GID, int64(file.Size), 1)
 		}
 	}
 
@@ -434,7 +385,7 @@ func (tx *memoryTransaction) DeleteFile(ctx context.Context, handle metadata.Fil
 		if existing.Attr.Size > 0 {
 			tx.pendingDelta -= int64(existing.Attr.Size)
 		}
-		tx.addQuota(existing.Attr.UID, existing.Attr.GID, -int64(existing.Attr.Size), -1)
+		tx.quota.Add(existing.Attr.UID, existing.Attr.GID, -int64(existing.Attr.Size), -1)
 	}
 
 	// drop ObjectID secondary entry. The "only if mapped
@@ -795,7 +746,7 @@ func (tx *memoryTransaction) DeleteShare(ctx context.Context, shareName string) 
 				if fd.Attr.Size > 0 {
 					tx.pendingDelta -= int64(fd.Attr.Size)
 				}
-				tx.addQuota(fd.Attr.UID, fd.Attr.GID, -int64(fd.Attr.Size), -1)
+				tx.quota.Add(fd.Attr.UID, fd.Attr.GID, -int64(fd.Attr.Size), -1)
 			}
 			// drop ObjectID secondary entry too.
 			if fd.Attr != nil && !fd.Attr.ObjectID.IsZero() {

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
 )
 
 // PostgresMetadataStore implements the metadata.Store interface using PostgreSQL
@@ -67,15 +68,13 @@ type PostgresMetadataStore struct {
 	// Initialized from a SQL SUM query on startup.
 	usedBytes atomic.Int64
 
-	// userUsage / groupUsage track per-identity usage (bytes + file count) for
-	// regular files, keyed by owner uid / gid. In-memory cache mirroring
-	// usedBytes, seeded from a SQL GROUP BY query on startup (the files table is
-	// the source of truth, so it is always reconstructed correctly). Updated
-	// from a transaction's pending per-identity deltas exactly once on
-	// successful commit. Guarded by quotaMu.
-	quotaMu    sync.Mutex
-	userUsage  map[uint32]*metadata.UsageStat
-	groupUsage map[uint32]*metadata.UsageStat
+	// quota tracks per-identity usage (bytes + file count) for regular files,
+	// keyed by owner uid / gid. In-memory cache mirroring usedBytes, seeded from
+	// a SQL GROUP BY query on startup (the files table is the source of truth, so
+	// it is always reconstructed correctly). Updated from a transaction's pending
+	// per-identity deltas exactly once on successful commit. Guarded by quotaMu.
+	quotaMu sync.Mutex
+	quota   *quota.Cache
 
 	// storeID is the engine-persistent identifier for this store instance,
 	// backed by the server_config.store_id column. Created on first open
@@ -134,6 +133,7 @@ func NewPostgresMetadataStore(
 		logger:       log,
 		ctx:          storeCtx,
 		cancel:       cancel,
+		quota:        quota.NewCache(),
 	}
 
 	// Initialize the usedBytes counter from a SQL SUM query.
@@ -173,8 +173,8 @@ func (s *PostgresMetadataStore) GetUsedBytes() int64 {
 }
 
 // initUsedBytesCounter initializes the store-wide atomic counter from a SQL SUM
-// query and seeds the per-identity usage cache (userUsage / groupUsage) from
-// GROUP BY aggregates. Both are reconstructed from the inodes table (the source
+// query and seeds the per-identity usage cache from GROUP BY aggregates. Both
+// are reconstructed from the inodes table (the source
 // of truth), so a store opened against an existing database is always seeded
 // correctly. The inodes(uid) / inodes(gid) indexes (migration 000033) keep the
 // GROUP BY scans cheap.
@@ -196,8 +196,7 @@ func (s *PostgresMetadataStore) initUsedBytesCounter(ctx context.Context) error 
 		return err
 	}
 	s.quotaMu.Lock()
-	s.userUsage = userUsage
-	s.groupUsage = groupUsage
+	s.quota.Seed(userUsage, groupUsage)
 	s.quotaMu.Unlock()
 	return nil
 }
@@ -235,49 +234,19 @@ func (s *PostgresMetadataStore) seedUsageByColumn(ctx context.Context, col strin
 func (s *PostgresMetadataStore) GetQuotaUsage(scope metadata.QuotaScope, id uint32) (metadata.UsageStat, error) {
 	s.quotaMu.Lock()
 	defer s.quotaMu.Unlock()
-	m := s.userUsage
-	if scope == metadata.QuotaScopeGroup {
-		m = s.groupUsage
-	}
-	if u, ok := m[id]; ok {
-		return *u, nil
-	}
-	return metadata.UsageStat{}, nil
+	return s.quota.Get(scope, id), nil
 }
 
 // applyQuotaDelta folds a per-identity usage delta into the in-memory usage
 // cache. Called post-commit (matching usedBytes). Buckets that drop to zero or
 // below are removed.
-func (s *PostgresMetadataStore) applyQuotaDelta(delta map[pgQuotaKey]metadata.UsageStat) {
+func (s *PostgresMetadataStore) applyQuotaDelta(delta map[quota.Key]metadata.UsageStat) {
 	if len(delta) == 0 {
 		return
 	}
 	s.quotaMu.Lock()
 	defer s.quotaMu.Unlock()
-	for k, d := range delta {
-		m := s.userUsage
-		if k.scope == metadata.QuotaScopeGroup {
-			m = s.groupUsage
-		}
-		cur := m[k.id]
-		if cur == nil {
-			cur = &metadata.UsageStat{}
-			m[k.id] = cur
-		}
-		cur.Bytes += d.Bytes
-		cur.Files += d.Files
-		// Negative values indicate accounting drift (should never happen):
-		// clamp to zero so the enforcer never reads a too-permissive total.
-		if cur.Bytes < 0 {
-			cur.Bytes = 0
-		}
-		if cur.Files < 0 {
-			cur.Files = 0
-		}
-		if cur.Bytes == 0 && cur.Files == 0 {
-			delete(m, k.id)
-		}
-	}
+	s.quota.Apply(delta)
 }
 
 // ensureStoreID reads the engine-persistent store_id from server_config; if

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -15,6 +15,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/acl"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
 )
 
 // Transaction retry policy (#1769). Under write contention DittoFS must
@@ -83,52 +84,11 @@ type postgresTransaction struct {
 	store        *PostgresMetadataStore
 	tx           pgx.Tx
 	pendingDelta int64
-	// quotaDelta accumulates per-identity usage changes (bytes + file count)
-	// keyed by (scope, id). Applied to the store's in-memory userUsage/
-	// groupUsage cache exactly once after a successful commit, identical to
-	// pendingDelta (so a serialization/deadlock retry never double-counts).
-	quotaDelta map[pgQuotaKey]metadata.UsageStat
-}
-
-// pgQuotaKey identifies a per-identity usage bucket inside a transaction's
-// accumulated delta.
-type pgQuotaKey struct {
-	scope metadata.QuotaScope
-	id    uint32
-}
-
-// addQuota records a usage delta for the file's owner identity (both user and
-// group scopes). See memory store addQuota for the create/resize/chown cases.
-func (tx *postgresTransaction) addQuota(uid, gid uint32, bytes, files int64) {
-	if bytes == 0 && files == 0 {
-		return
-	}
-	if tx.quotaDelta == nil {
-		tx.quotaDelta = make(map[pgQuotaKey]metadata.UsageStat)
-	}
-	u := tx.quotaDelta[pgQuotaKey{metadata.QuotaScopeUser, uid}]
-	u.Bytes += bytes
-	u.Files += files
-	tx.quotaDelta[pgQuotaKey{metadata.QuotaScopeUser, uid}] = u
-	g := tx.quotaDelta[pgQuotaKey{metadata.QuotaScopeGroup, gid}]
-	g.Bytes += bytes
-	g.Files += files
-	tx.quotaDelta[pgQuotaKey{metadata.QuotaScopeGroup, gid}] = g
-}
-
-// addQuotaKeyed merges a single pre-keyed usage delta (used when folding the
-// per-identity totals freed by DeleteShare).
-func (tx *postgresTransaction) addQuotaKeyed(k pgQuotaKey, d metadata.UsageStat) {
-	if d.Bytes == 0 && d.Files == 0 {
-		return
-	}
-	if tx.quotaDelta == nil {
-		tx.quotaDelta = make(map[pgQuotaKey]metadata.UsageStat)
-	}
-	cur := tx.quotaDelta[k]
-	cur.Bytes += d.Bytes
-	cur.Files += d.Files
-	tx.quotaDelta[k] = cur
+	// quota accumulates per-identity usage changes (bytes + file count) keyed by
+	// (scope, id). Applied to the store's quota cache exactly once after a
+	// successful commit, identical to pendingDelta (so a serialization/deadlock
+	// retry never double-counts).
+	quota quota.Delta
 }
 
 // isRetryableError checks if a PostgreSQL error is retryable (deadlock or serialization failure)
@@ -262,7 +222,7 @@ func (s *PostgresMetadataStore) withTransaction(ctx context.Context, fn func(tx 
 			s.usedBytes.Add(ptx.pendingDelta)
 		}
 		// Apply per-identity usage deltas once, after commit.
-		s.applyQuotaDelta(ptx.quotaDelta)
+		s.applyQuotaDelta(ptx.quota.Map())
 		return nil // Success
 	}
 
@@ -482,13 +442,13 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 		oldGID := uint32(oldGIDVal.Int64)
 		switch {
 		case !oldWasRegular:
-			tx.addQuota(file.UID, file.GID, int64(file.Size), 1)
+			tx.quota.Add(file.UID, file.GID, int64(file.Size), 1)
 		case oldUID == file.UID && oldGID == file.GID:
-			tx.addQuota(file.UID, file.GID, int64(file.Size)-int64(oldSize), 0)
+			tx.quota.Add(file.UID, file.GID, int64(file.Size)-int64(oldSize), 0)
 		default:
 			// Chown: move bytes + inode from old owner to new owner.
-			tx.addQuota(oldUID, oldGID, -int64(oldSize), -1)
-			tx.addQuota(file.UID, file.GID, int64(file.Size), 1)
+			tx.quota.Add(oldUID, oldGID, -int64(oldSize), -1)
+			tx.quota.Add(file.UID, file.GID, int64(file.Size), 1)
 		}
 	}
 
@@ -523,7 +483,7 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 			if file.Size > 0 {
 				tx.pendingDelta += int64(file.Size)
 			}
-			tx.addQuota(file.UID, file.GID, int64(file.Size), 1)
+			tx.quota.Add(file.UID, file.GID, int64(file.Size), 1)
 		}
 
 		// Debug logging for new file inserts
@@ -598,7 +558,7 @@ func (tx *postgresTransaction) DeleteFile(ctx context.Context, handle metadata.F
 		if fileSize > 0 {
 			tx.pendingDelta -= fileSize
 		}
-		tx.addQuota(uint32(fileUID), uint32(fileGID), -fileSize, -1)
+		tx.quota.Add(uint32(fileUID), uint32(fileGID), -fileSize, -1)
 	}
 
 	return nil
@@ -1159,7 +1119,7 @@ func (tx *postgresTransaction) collectShareQuotaFreed(ctx context.Context, share
 		if err := rows.Scan(&id, &bytes, &files); err != nil {
 			return mapPgError(err, "DeleteShare", shareName)
 		}
-		tx.addQuotaKeyed(pgQuotaKey{scope, uint32(id)}, metadata.UsageStat{Bytes: -bytes, Files: -files})
+		tx.quota.AddKeyed(quota.Key{Scope: scope, ID: uint32(id)}, metadata.UsageStat{Bytes: -bytes, Files: -files})
 	}
 	if err := rows.Err(); err != nil {
 		return mapPgError(err, "DeleteShare", shareName)

--- a/pkg/metadata/store/sqlite/reset.go
+++ b/pkg/metadata/store/sqlite/reset.go
@@ -45,8 +45,7 @@ func (s *SQLiteMetadataStore) Reset(ctx context.Context) error {
 	// Reset the in-memory counters to match the now-empty tables.
 	s.usedBytes.Store(0)
 	s.quotaMu.Lock()
-	s.userUsage = make(map[uint32]*metadata.UsageStat)
-	s.groupUsage = make(map[uint32]*metadata.UsageStat)
+	s.quota.Reset()
 	s.quotaMu.Unlock()
 	return nil
 }

--- a/pkg/metadata/store/sqlite/store.go
+++ b/pkg/metadata/store/sqlite/store.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
 )
 
 // sqliteDriverName is the database/sql driver name registered by the imported
@@ -62,13 +63,11 @@ type SQLiteMetadataStore struct {
 	// of the same M rows leaves the same count). Never read in production.
 	manifestWrites atomic.Int64
 
-	// userUsage / groupUsage track per-identity usage (bytes + file count) for
-	// regular files, keyed by owner uid / gid. Seeded from a GROUP BY query on
-	// startup and updated from each committed transaction's deltas. Guarded by
-	// quotaMu.
-	quotaMu    sync.Mutex
-	userUsage  map[uint32]*metadata.UsageStat
-	groupUsage map[uint32]*metadata.UsageStat
+	// quota tracks per-identity usage (bytes + file count) for regular files,
+	// keyed by owner uid / gid. Seeded from a GROUP BY query on startup and
+	// updated from each committed transaction's deltas. Guarded by quotaMu.
+	quotaMu sync.Mutex
+	quota   *quota.Cache
 
 	// storeID is the engine-persistent identifier, backed by
 	// server_config.store_id. Created on first open with a fresh ULID; read
@@ -145,6 +144,7 @@ func NewSQLiteMetadataStore(
 		logger:       log,
 		ctx:          storeCtx,
 		cancel:       cancel,
+		quota:        quota.NewCache(),
 	}
 
 	if err := store.initUsedBytesCounter(ctx); err != nil {
@@ -191,8 +191,7 @@ func (s *SQLiteMetadataStore) initUsedBytesCounter(ctx context.Context) error {
 		return err
 	}
 	s.quotaMu.Lock()
-	s.userUsage = userUsage
-	s.groupUsage = groupUsage
+	s.quota.Seed(userUsage, groupUsage)
 	s.quotaMu.Unlock()
 	return nil
 }
@@ -229,46 +228,18 @@ func (s *SQLiteMetadataStore) seedUsageByColumn(ctx context.Context, col string)
 func (s *SQLiteMetadataStore) GetQuotaUsage(scope metadata.QuotaScope, id uint32) (metadata.UsageStat, error) {
 	s.quotaMu.Lock()
 	defer s.quotaMu.Unlock()
-	m := s.userUsage
-	if scope == metadata.QuotaScopeGroup {
-		m = s.groupUsage
-	}
-	if u, ok := m[id]; ok {
-		return *u, nil
-	}
-	return metadata.UsageStat{}, nil
+	return s.quota.Get(scope, id), nil
 }
 
 // applyQuotaDelta folds a per-identity usage delta into the in-memory usage
 // cache. Called post-commit (matching usedBytes).
-func (s *SQLiteMetadataStore) applyQuotaDelta(delta map[sqQuotaKey]metadata.UsageStat) {
+func (s *SQLiteMetadataStore) applyQuotaDelta(delta map[quota.Key]metadata.UsageStat) {
 	if len(delta) == 0 {
 		return
 	}
 	s.quotaMu.Lock()
 	defer s.quotaMu.Unlock()
-	for k, d := range delta {
-		m := s.userUsage
-		if k.scope == metadata.QuotaScopeGroup {
-			m = s.groupUsage
-		}
-		cur := m[k.id]
-		if cur == nil {
-			cur = &metadata.UsageStat{}
-			m[k.id] = cur
-		}
-		cur.Bytes += d.Bytes
-		cur.Files += d.Files
-		if cur.Bytes < 0 {
-			cur.Bytes = 0
-		}
-		if cur.Files < 0 {
-			cur.Files = 0
-		}
-		if cur.Bytes == 0 && cur.Files == 0 {
-			delete(m, k.id)
-		}
-	}
+	s.quota.Apply(delta)
 }
 
 // ensureStoreID reads the engine-persistent store_id from server_config; if the

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -13,6 +13,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/acl"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
 )
 
 // Transaction retry policy (#1769). Under write contention DittoFS must
@@ -84,52 +85,11 @@ type sqliteTransaction struct {
 	store        *SQLiteMetadataStore
 	tx           execer
 	pendingDelta int64
-	// quotaDelta accumulates per-identity usage changes (bytes + file count)
-	// keyed by (scope, id). Applied to the store's in-memory userUsage/
-	// groupUsage cache exactly once after a successful commit, identical to
-	// pendingDelta (so a serialization/deadlock retry never double-counts).
-	quotaDelta map[sqQuotaKey]metadata.UsageStat
-}
-
-// sqQuotaKey identifies a per-identity usage bucket inside a transaction's
-// accumulated delta.
-type sqQuotaKey struct {
-	scope metadata.QuotaScope
-	id    uint32
-}
-
-// addQuota records a usage delta for the file's owner identity (both user and
-// group scopes). See memory store addQuota for the create/resize/chown cases.
-func (tx *sqliteTransaction) addQuota(uid, gid uint32, bytes, files int64) {
-	if bytes == 0 && files == 0 {
-		return
-	}
-	if tx.quotaDelta == nil {
-		tx.quotaDelta = make(map[sqQuotaKey]metadata.UsageStat)
-	}
-	u := tx.quotaDelta[sqQuotaKey{metadata.QuotaScopeUser, uid}]
-	u.Bytes += bytes
-	u.Files += files
-	tx.quotaDelta[sqQuotaKey{metadata.QuotaScopeUser, uid}] = u
-	g := tx.quotaDelta[sqQuotaKey{metadata.QuotaScopeGroup, gid}]
-	g.Bytes += bytes
-	g.Files += files
-	tx.quotaDelta[sqQuotaKey{metadata.QuotaScopeGroup, gid}] = g
-}
-
-// addQuotaKeyed merges a single pre-keyed usage delta (used when folding the
-// per-identity totals freed by DeleteShare).
-func (tx *sqliteTransaction) addQuotaKeyed(k sqQuotaKey, d metadata.UsageStat) {
-	if d.Bytes == 0 && d.Files == 0 {
-		return
-	}
-	if tx.quotaDelta == nil {
-		tx.quotaDelta = make(map[sqQuotaKey]metadata.UsageStat)
-	}
-	cur := tx.quotaDelta[k]
-	cur.Bytes += d.Bytes
-	cur.Files += d.Files
-	tx.quotaDelta[k] = cur
+	// quota accumulates per-identity usage changes (bytes + file count) keyed by
+	// (scope, id). Applied to the store's quota cache exactly once after a
+	// successful commit, identical to pendingDelta (so a serialization/deadlock
+	// retry never double-counts).
+	quota quota.Delta
 }
 
 // WithTransaction executes fn within a SQLite transaction.
@@ -207,7 +167,7 @@ func (s *SQLiteMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 			s.usedBytes.Add(ptx.pendingDelta)
 		}
 		// Apply per-identity usage deltas once, after commit.
-		s.applyQuotaDelta(ptx.quotaDelta)
+		s.applyQuotaDelta(ptx.quota.Map())
 		return nil // Success
 	}
 
@@ -425,13 +385,13 @@ func (tx *sqliteTransaction) PutFile(ctx context.Context, file *metadata.File) e
 		oldGID := uint32(oldGIDVal.Int64)
 		switch {
 		case !oldWasRegular:
-			tx.addQuota(file.UID, file.GID, int64(file.Size), 1)
+			tx.quota.Add(file.UID, file.GID, int64(file.Size), 1)
 		case oldUID == file.UID && oldGID == file.GID:
-			tx.addQuota(file.UID, file.GID, int64(file.Size)-int64(oldSize), 0)
+			tx.quota.Add(file.UID, file.GID, int64(file.Size)-int64(oldSize), 0)
 		default:
 			// Chown: move bytes + inode from old owner to new owner.
-			tx.addQuota(oldUID, oldGID, -int64(oldSize), -1)
-			tx.addQuota(file.UID, file.GID, int64(file.Size), 1)
+			tx.quota.Add(oldUID, oldGID, -int64(oldSize), -1)
+			tx.quota.Add(file.UID, file.GID, int64(file.Size), 1)
 		}
 	}
 
@@ -466,7 +426,7 @@ func (tx *sqliteTransaction) PutFile(ctx context.Context, file *metadata.File) e
 			if file.Size > 0 {
 				tx.pendingDelta += int64(file.Size)
 			}
-			tx.addQuota(file.UID, file.GID, int64(file.Size), 1)
+			tx.quota.Add(file.UID, file.GID, int64(file.Size), 1)
 		}
 
 		// Debug logging for new file inserts
@@ -541,7 +501,7 @@ func (tx *sqliteTransaction) DeleteFile(ctx context.Context, handle metadata.Fil
 		if fileSize > 0 {
 			tx.pendingDelta -= fileSize
 		}
-		tx.addQuota(uint32(fileUID), uint32(fileGID), -fileSize, -1)
+		tx.quota.Add(uint32(fileUID), uint32(fileGID), -fileSize, -1)
 	}
 
 	return nil
@@ -1101,7 +1061,7 @@ func (tx *sqliteTransaction) collectShareQuotaFreed(ctx context.Context, shareNa
 		if err := rows.Scan(&id, &bytes, &files); err != nil {
 			return mapDBError(err, "DeleteShare", shareName)
 		}
-		tx.addQuotaKeyed(sqQuotaKey{scope, uint32(id)}, metadata.UsageStat{Bytes: -bytes, Files: -files})
+		tx.quota.AddKeyed(quota.Key{Scope: scope, ID: uint32(id)}, metadata.UsageStat{Bytes: -bytes, Files: -files})
 	}
 	if err := rows.Err(); err != nil {
 		return mapDBError(err, "DeleteShare", shareName)


### PR DESCRIPTION
## What

Chunk 1 of #1776: extract the per-identity quota/usage accounting, which was byte-identical across all four metadata stores (only the map-key type name differed), into a new shared `pkg/metadata/store/internal/quota` package.

The package provides:
- `quota.Key{Scope, ID}` — the per-identity bucket key (replaces the per-store `quotaKey`/`sqQuotaKey`/`pgQuotaKey`/`badgerQuotaKey`).
- `quota.Cache` — a lock-free holder of the user/group usage maps with `Get` / `Apply` / `Seed` / `Reset`. `Apply` carries the clamp-to-zero / delete-if-zero defensive fold. Callers keep their existing `quotaMu`; the cache adds no lock layer.
- `quota.Delta` — the per-transaction accumulator embedded in each `*xTransaction`, with `Add` (both scopes) / `AddKeyed` (pre-keyed fold) / `Map`.

All four stores now use these instead of their private copies of `GetQuotaUsage`, `applyQuotaDelta`, the `addQuota`/`addQuotaKeyed` accumulator, and the key struct.

Net **-73 LOC** (12 files): ~195 LOC of shared code + test replace ~290 LOC of per-store duplication.

## Per-store adoption

| Store | Unified |
|-------|---------|
| memory | Key, Delta (`addQuota` → `Delta.Add`), inline commit fold → `Cache.Apply`, `GetQuotaUsage` → `Cache.Get` |
| sqlite | Key, Delta (`addQuota`/`addQuotaKeyed`), `applyQuotaDelta` fold → `Cache.Apply`, `Get`, `Seed`, `Reset` |
| postgres | same as sqlite (verbatim mirror) |
| badger | Key, Delta (`addQuota`/`addQuota2`), `applyQuotaDelta` (pool + tx paths) → `Cache.Apply`, `Get`, `Seed`; `deleteShareFiles` raw map now keyed by `quota.Key` |

No store was left as-is — all four were equivalent. The per-store `applyQuotaDelta` wrapper (the `len==0` short-circuit + `quotaMu` lock boundary) stays per-store by design, delegating the fold to `Cache.Apply`.

## Equivalence / verification

- `Delta.Add`/`AddKeyed`, `Cache.Apply` (clamp/delete), and `Cache.Get` are line-for-line ports of the originals; each call site is a symbol swap.
- memory `Reset` still does not clear the quota cache (pre-existing behavior, preserved).
- New unit test covers the accumulate → apply → read round-trip plus the clamp-to-zero / delete-at-zero path.
- `go test -race ./pkg/metadata/...` green (badger/sqlite/memory locally; postgres compiles, DB-gated in CI). `go vet` + `golangci-lint` clean.

Refs #1776 (chunks 2–5 remain).