### PR TITLE
fix(metadata): make exclusive create atomic under READ COMMITTED (smb2.create.multi)

### DIFF
--- a/pkg/metadata/create_name_lock_test.go
+++ b/pkg/metadata/create_name_lock_test.go
@@ -6,10 +6,12 @@ import (
 )
 
 // TestLockCreateName_SameKeySerializes verifies that lockCreateName mutually
-// excludes concurrent creators of the same (parent, name): many goroutines
-// increment a plain (unsynchronized) counter under the lock and the result must
-// be exact. Run under -race, a broken shard mapping that handed out different
-// mutexes for the same key would both trip the race detector and skew the count.
+// excludes concurrent creators of the same (parent, name): many goroutines each
+// increment a plain (unsynchronized) counter under the lock, many times, and the
+// total must be exact. All goroutines block on a start barrier so they contend
+// from the same instant, and each loops the guarded increment so a broken shard
+// mapping (different mutexes for the same key) loses updates and skews the count
+// even without the race detector; -race also flags it directly.
 // (Distinct names may share a shard by design, so no non-serialization property
 // is asserted here — only the correctness-critical same-key exclusion.)
 func TestLockCreateName_SameKeySerializes(t *testing.T) {
@@ -18,21 +20,29 @@ func TestLockCreateName_SameKeySerializes(t *testing.T) {
 	s := New()
 	parent := FileHandle("parent-handle")
 
-	const n = 200
+	const (
+		goroutines = 100
+		iters      = 50
+	)
+	start := make(chan struct{})
 	var counter int
 	var wg sync.WaitGroup
-	wg.Add(n)
-	for i := 0; i < n; i++ {
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
 		go func() {
 			defer wg.Done()
-			unlock := s.lockCreateName(parent, "same")
-			defer unlock()
-			counter++ // guarded solely by lockCreateName
+			<-start // release all goroutines together to maximize contention
+			for j := 0; j < iters; j++ {
+				unlock := s.lockCreateName(parent, "same")
+				counter++ // guarded solely by lockCreateName
+				unlock()
+			}
 		}()
 	}
+	close(start)
 	wg.Wait()
 
-	if counter != n {
-		t.Fatalf("lockCreateName did not serialize same (parent,name): got %d, want %d", counter, n)
+	if want := goroutines * iters; counter != want {
+		t.Fatalf("lockCreateName did not serialize same (parent,name): got %d, want %d", counter, want)
 	}
 }

--- a/pkg/metadata/create_name_lock_test.go
+++ b/pkg/metadata/create_name_lock_test.go
@@ -1,0 +1,38 @@
+package metadata
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestLockCreateName_SameKeySerializes verifies that lockCreateName mutually
+// excludes concurrent creators of the same (parent, name): many goroutines
+// increment a plain (unsynchronized) counter under the lock and the result must
+// be exact. Run under -race, a broken shard mapping that handed out different
+// mutexes for the same key would both trip the race detector and skew the count.
+// (Distinct names may share a shard by design, so no non-serialization property
+// is asserted here — only the correctness-critical same-key exclusion.)
+func TestLockCreateName_SameKeySerializes(t *testing.T) {
+	t.Parallel()
+
+	s := New()
+	parent := FileHandle("parent-handle")
+
+	const n = 200
+	var counter int
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			unlock := s.lockCreateName(parent, "same")
+			defer unlock()
+			counter++ // guarded solely by lockCreateName
+		}()
+	}
+	wg.Wait()
+
+	if counter != n {
+		t.Fatalf("lockCreateName did not serialize same (parent,name): got %d, want %d", counter, n)
+	}
+}

--- a/pkg/metadata/file_create.go
+++ b/pkg/metadata/file_create.go
@@ -88,6 +88,11 @@ func (s *Service) CreateHardLink(ctx *AuthContext, dirHandle FileHandle, name st
 		return nil, err
 	}
 
+	// Serialize concurrent links onto this exact (dir, name) so the
+	// in-transaction existence recheck below stays atomic on a READ COMMITTED
+	// store, matching the create path.
+	defer s.lockCreateName(dirHandle, name)()
+
 	// Get directory entry
 	dir, err := store.GetFile(ctx.Context, dirHandle)
 	if err != nil {
@@ -216,6 +221,13 @@ func (s *Service) createEntry(
 	if err := ValidateName(name); err != nil {
 		return nil, nil, err
 	}
+
+	// Serialize concurrent creates of this exact (parent, name) so the
+	// in-transaction existence recheck below is atomic even on a store whose
+	// create transaction runs at READ COMMITTED. Held across the whole create,
+	// including the commit, so a losing racer observes the committed entry and
+	// returns ErrAlreadyExists. Distinct names stay concurrent.
+	defer s.lockCreateName(parentHandle, name)()
 
 	cc, hasCreateCache := store.(createCacheStore)
 

--- a/pkg/metadata/file_create.go
+++ b/pkg/metadata/file_create.go
@@ -88,11 +88,6 @@ func (s *Service) CreateHardLink(ctx *AuthContext, dirHandle FileHandle, name st
 		return nil, err
 	}
 
-	// Serialize concurrent links onto this exact (dir, name) so the
-	// in-transaction existence recheck below stays atomic on a READ COMMITTED
-	// store, matching the create path.
-	defer s.lockCreateName(dirHandle, name)()
-
 	// Get directory entry
 	dir, err := store.GetFile(ctx.Context, dirHandle)
 	if err != nil {
@@ -147,6 +142,11 @@ func (s *Service) CreateHardLink(ctx *AuthContext, dirHandle FileHandle, name st
 	// captured inside the transaction below (H9).
 	wcc := &DirWcc{}
 
+	// Serialize concurrent links onto this exact (dir, name) so the
+	// in-transaction existence recheck stays atomic on a READ COMMITTED store,
+	// matching the create path. Released once the commit returns.
+	unlockCreateName := s.lockCreateName(dirHandle, name)
+
 	// Execute all write operations in a single transaction for better performance.
 	// Relaxed durability (#1573 Wall 1): a create writes only child keys (+
 	// parent nlink for mkdir) — pure namespace, not paired with block data — so
@@ -194,6 +194,7 @@ func (s *Service) CreateHardLink(ctx *AuthContext, dirHandle FileHandle, name st
 		wcc.After = CopyFileAttr(&dir.FileAttr)
 		return tx.PutFile(ctx.Context, dir)
 	})
+	unlockCreateName()
 	if err != nil {
 		return nil, err
 	}
@@ -221,13 +222,6 @@ func (s *Service) createEntry(
 	if err := ValidateName(name); err != nil {
 		return nil, nil, err
 	}
-
-	// Serialize concurrent creates of this exact (parent, name) so the
-	// in-transaction existence recheck below is atomic even on a store whose
-	// create transaction runs at READ COMMITTED. Held across the whole create,
-	// including the commit, so a losing racer observes the committed entry and
-	// returns ErrAlreadyExists. Distinct names stay concurrent.
-	defer s.lockCreateName(parentHandle, name)()
 
 	cc, hasCreateCache := store.(createCacheStore)
 
@@ -428,6 +422,13 @@ func (s *Service) createEntry(
 	// losers — escaping under load as ErrConflict (#1571). Serialize just that
 	// bump per-parent so the counter stays exact and atomic with the child write;
 	// file creates never take this lock and stay fully concurrent.
+	// Serialize concurrent creates of this exact (parent, name) so the
+	// in-transaction existence recheck below is atomic even on a store whose
+	// create transaction runs at READ COMMITTED. Held across the recheck and the
+	// commit — a losing racer then rechecks against the committed row and returns
+	// ErrAlreadyExists — and released once the commit returns, before the
+	// post-commit cache/timestamp work. Distinct names stay concurrent.
+	unlockCreateName := s.lockCreateName(parentHandle, name)
 	if fileType == FileTypeDirectory {
 		defer s.lockParentLink(parentHandle)()
 	}
@@ -475,6 +476,7 @@ func (s *Service) createEntry(
 		}
 		return nil
 	})
+	unlockCreateName()
 
 	if err != nil {
 		return nil, nil, err

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -948,14 +948,34 @@ func (s *Service) lockParentLinks(a, b FileHandle) func() {
 	return func() { hi.Unlock(); lo.Unlock() }
 }
 
+// createNameShard maps a (parent, name) pair to a shard via FNV-1a over the
+// parent handle key, a separator byte, and the name — computed without
+// allocating the concatenated string. Uses the same FNV constants as
+// parentLinkShard so the distribution is identical.
+func createNameShard(parentHandle FileHandle, name string) uint32 {
+	key := handleKey(parentHandle)
+	var h uint32 = 2166136261
+	for i := 0; i < len(key); i++ {
+		h ^= uint32(key[i])
+		h *= 16777619
+	}
+	h *= 16777619 // separator byte 0x00: XOR is a no-op, only the FNV mix applies
+	for i := 0; i < len(name); i++ {
+		h ^= uint32(name[i])
+		h *= 16777619
+	}
+	return h % parentLinkShardCount
+}
+
 // lockCreateName serializes creation of one (parent, name) so two concurrent
 // creates of the same name in the same directory cannot both pass the
 // in-transaction existence recheck and each insert a distinct inode. Creates of
 // different names hash to (likely) different shards and stay fully concurrent.
 // See the createNameShards field for why the recheck alone is insufficient on a
-// READ COMMITTED store. Callers defer the returned unlock.
+// READ COMMITTED store. The returned unlock is released right after the create
+// transaction commits (covering the recheck and commit), not at function end.
 func (s *Service) lockCreateName(parentHandle FileHandle, name string) func() {
-	mu := &s.createNameShards[parentLinkShard(handleKey(parentHandle)+"\x00"+name)]
+	mu := &s.createNameShards[createNameShard(parentHandle, name)]
 	mu.Lock()
 	return mu.Unlock
 }

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -61,8 +61,19 @@ type Service struct {
 	// per-parent map) bounds memory: distinct parents may hash to one shard —
 	// harmless extra serialization on a rare path, never an unbounded map.
 	parentLinkShards [parentLinkShardCount]sync.Mutex
-	cookies          *CookieManager   // NFS/SMB cookie to store token translation
-	quotas           map[string]int64 // shareName -> quota in bytes (0 = unlimited)
+
+	// createNameShards serializes concurrent creation of the same (parent, name)
+	// entry. The in-transaction existence recheck in the create path is only
+	// atomic on a store that aborts read-write conflicts (BadgerDB SSI); a store
+	// running the create transaction at READ COMMITTED (PostgreSQL) lets two
+	// racers both read the name as absent and both commit, so the SetChild upsert
+	// re-links the last writer and orphans the loser's inode — surfacing as
+	// several successful exclusive creates of one name. This bank closes that
+	// window uniformly. See lockCreateName.
+	createNameShards [parentLinkShardCount]sync.Mutex
+
+	cookies *CookieManager   // NFS/SMB cookie to store token translation
+	quotas  map[string]int64 // shareName -> quota in bytes (0 = unlimited)
 
 	// identityQuotas holds hot-updatable per-user / per-group quota limits,
 	// loaded from the control-plane DB and consulted on the write/create hot
@@ -935,6 +946,18 @@ func (s *Service) lockParentLinks(a, b FileHandle) func() {
 	lo.Lock()
 	hi.Lock()
 	return func() { hi.Unlock(); lo.Unlock() }
+}
+
+// lockCreateName serializes creation of one (parent, name) so two concurrent
+// creates of the same name in the same directory cannot both pass the
+// in-transaction existence recheck and each insert a distinct inode. Creates of
+// different names hash to (likely) different shards and stay fully concurrent.
+// See the createNameShards field for why the recheck alone is insufficient on a
+// READ COMMITTED store. Callers defer the returned unlock.
+func (s *Service) lockCreateName(parentHandle FileHandle, name string) func() {
+	mu := &s.createNameShards[parentLinkShard(handleKey(parentHandle)+"\x00"+name)]
+	mu.Lock()
+	return mu.Unlock
 }
 
 // mergeDirTimes overlays a directory's coalesced (not-yet-persisted) mtime/


### PR DESCRIPTION
## What

Serialize concurrent creation of the same `(parent, name)` in the metadata Service so exactly one exclusive create (`FILE_CREATE` / `O_EXCL`) wins and the rest get `ErrAlreadyExists`, uniformly across all metadata backends.

## Root cause

`smb2.create.multi` (three connections open the same file concurrently with `NTCREATEX_DISP_CREATE`; smbtorture asserts exactly **1** `NT_STATUS_OK` + 2 `OBJECT_NAME_COLLISION`) intermittently fails **only on the postgres shard** — all three returned `NT_STATUS_OK`. It passes on badger-fs / memory / memory-fs / sqlite in the same run.

The create path guards exclusivity with an in-transaction existence recheck (`tx.GetChild` before `tx.SetChild`). That recheck is only atomic on a store that aborts read-write conflicts (BadgerDB SSI). The postgres store begins transactions at the driver default **READ COMMITTED**, where concurrent creators each read the name as absent, each `PutFile` a **distinct** inode, and `SetChild`'s `INSERT ... ON CONFLICT (parent_id, child_name) DO UPDATE` swallows the unique-key collision — re-linking the last writer and orphaning the losers' inodes. Result: multiple "successful" exclusive creates of one name.

`SetChild`'s documented contract is deliberately upsert/overwrite (rename relies on it after deleting the target first), so the fix does **not** touch `SetChild`. Instead it closes the window at the shared root — the single `createEntry` / `CreateHardLink` path all creates route through — mirroring the existing per-parent `lockParentLink` sharded-mutex pattern.

## Change

- `createNameShards`: a sharded mutex bank + `lockCreateName(parent, name)`.
- `createEntry` and `CreateHardLink` hold it across the whole create (including commit) so a losing racer observes the committed entry and returns `ErrAlreadyExists`.
- Creates of **different** names hash to (likely) different shards and stay fully concurrent — no regression to same-directory create throughput. DittoFS is single-node, so a process-local mutex is sufficient.

## Test

`TestLockCreateName_SameKeySerializes` (`-race`) pins same-key exclusion. The integration proof is the postgres `smb2.create.multi` shard going green in CI.

Refs #1781