### PR TITLE
docs(internals): refresh block-store data-plane for the journal cache

### DIFF
--- a/docs/guide/block-store-migration.md
+++ b/docs/guide/block-store-migration.md
@@ -19,8 +19,8 @@ standalone-CAS state — pre-flip per-chunk local files, remote `cas/`
 objects, or chunk locators that still point at standalone objects — and
 converts it **before the share starts serving**:
 
-1. Local per-chunk files are imported into the append-only log-blob tier
-   (BLAKE3-verified, deduplicated) and deleted.
+1. Local per-chunk files are imported into the local journal (the append-only
+   write-back cache; BLAKE3-verified, deduplicated) and deleted.
 2. Standalone remote chunks are re-packed into `blocks/<id>` containers.
    Each container's chunk locators and block record commit in a single
    metadata transaction, so a crash can never leave a half-pointed block.

--- a/docs/guide/choosing-stores.md
+++ b/docs/guide/choosing-stores.md
@@ -61,8 +61,9 @@ cache** in front of the remote — it is not the source of truth once a remote i
   Spaces, Alibaba OSS, Oracle OCI, Storj, etc. all work —
   see the verified endpoint snippets in [Configuration § Block Store](configuration.md#6-block-store-configuration).
 - Dedup happens automatically across files in a share; identical content is stored once.
-- Tune append-log pressure (`max_log_bytes`, default ~25% of capacity) and durability
-  (`require_durable_commit`) per store — see [Configuration](configuration.md).
+- Pick a durability tier per store (`require_durable_commit`; see the
+  [durability guide](durability.md)) — it sets how far a write must land before it
+  is acknowledged — and size the local write-back cache to your hot set (above).
 - To migrate a legacy block layout to the content-addressed layout, see
   [Block store migration](block-store-migration.md).
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -291,13 +291,14 @@ Related glossary terms: [TLS / mTLS](glossary.md#authentication).
 
 Per-share block storage is configured via `dfsctl store` / `dfsctl share` commands (not the server config file). Each share owns an isolated local storage directory plus a reference to a remote store (S3 or filesystem). The block store lives in `pkg/block/engine/` and composes a local tier, a remote tier, the unified CAS-keyed in-memory `Cache`, a syncer (async local-to-remote transfer), and a garbage collector.
 
-#### Append-log tier
+#### Local `fs` store tuning
 
-The local filesystem store writes through per-file append-only logs that are
-compacted into content-addressed chunks (`blocks/{hh}/{hh}/{hex}`) and
-garbage-collected by the mark-sweep GC. This is the only local write path —
-pre-v0.16 `{payloadID}/block-{idx}` layouts must be converted with
-dittofs ≤ v0.21 (`dfs migrate-to-cas`) before the server will start.
+The local filesystem store (`fs`) is a thin adapter over the **journal** — an
+append-only, log-structured write-back cache (`pkg/block/journal/`). Writes
+append to the journal and local-ack; a background carve pass packs dirty ranges
+into packed remote blocks (`blocks/<id>`). Pre-v0.16 `{payloadID}/block-{idx}`
+layouts must be converted with dittofs ≤ v0.21 (`dfs migrate-to-cas`) before the
+server will start.
 
 These keys live inside the per-share `local` block store's `config` JSON
 (passed via `dfsctl store block local add --config '{...}'` or the REST API).
@@ -307,10 +308,10 @@ logs a startup warning.)
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `max_log_bytes` | int | deduced (25% of RAM, floor 1 GiB) | **Per-share** append-log pressure budget; writers block (`ErrPressureTimeout`) when the buffered log exceeds it. This per-store value takes **precedence** over the global `blockstore.local.max_log_bytes` and the system-deduced default. Values above 2^53 (~9 PiB) lose precision through JSON parsing. |
-| `rollup_workers` | int | `2` | Number of rollup goroutines (BLAKE3 + FastCDC) per share. |
-| `stabilization_ms` | int | `250` | Dirty-interval stabilization window in milliseconds before rollup. |
-| `orphan_log_min_age_seconds` | int | `3600` (1h) | Minimum log-file mtime age before the boot-time orphan sweep may unlink it. Prevents fresh (not-yet-rolled-up) logs from being swept when metadata is absent. |
+| `max_log_bytes` | int | deduced (25% of RAM, floor 1 GiB) | **Per-share** local-cache size hint. Still accepted and resolved (per-store value takes **precedence** over the global `blockstore.local.max_log_bytes` and the system-deduced default), but it no longer drives write backpressure — the journal caps on-disk usage and evicts on its own budget. Values above 2^53 (~9 PiB) lose precision through JSON parsing. |
+| `rollup_workers` | int | `2` | **Legacy, inert.** Accepted for config compatibility; the journal carves on its own age/size gate, so this no longer starts any goroutines. |
+| `stabilization_ms` | int | `250` | **Legacy, inert.** Accepted for config compatibility; superseded by the journal's carve batching gate. |
+| `orphan_log_min_age_seconds` | int | `3600` (1h) | **Legacy, inert.** Accepted for config compatibility; there is no separate append-log to orphan-sweep under the journal. |
 
 Env-var mapping follows the dot-path convention:
 `DITTOFS_BLOCKSTORE_LOCAL_FS_MAX_LOG_BYTES`,
@@ -318,20 +319,19 @@ Env-var mapping follows the dot-path convention:
 `DITTOFS_BLOCKSTORE_LOCAL_FS_STABILIZATION_MS`,
 `DITTOFS_BLOCKSTORE_LOCAL_FS_ORPHAN_LOG_MIN_AGE_SECONDS`.
 
-The local `fs` store requires a metadata backend that implements
-`metadata.RollupStore` to persist each log's `rollup_offset`; memory, badger,
-and postgres all qualify.
+There is no `metadata.RollupStore` backend requirement any more — the journal
+owns its local-cache state; a metadata backend only needs the block-record and
+synced-hash contracts (see [implementing stores](../internals/implementing-stores.md)).
 
-##### Append-log pressure budget (`max_log_bytes`)
+##### Write backpressure
 
-`max_log_bytes` is **THE** append-log backpressure lever. The on-disk append
-log buffers freshly-written bytes before the async rollup folds them into CAS
-chunks; once the buffered total exceeds this budget, `AppendWrite` stalls and
-eventually returns `ErrPressureTimeout` (surfaced as disk-full to the
-protocol). It is sized **relative to available memory** — the disk-backed
-pre-flush working set scales with how fast the host absorbs writes — at 25% of
-RAM with a 1 GiB floor (the historical fixed default becomes the minimum on
-small machines). Run `dfs config show --deduced` to see the effective value.
+Under the journal, write backpressure comes from the **local on-disk cap**, not
+an append-log budget: when the cache is full and every segment is pinned by
+not-yet-carved (dirty) bytes, a write waits up to the eviction budget and then
+returns `ErrLocalStoreFull` (surfaced as disk-full to the protocol). A healthy
+remote lets the carve pass drain dirty bytes so eviction frees space and the
+writer proceeds. The `max_log_bytes` value below is retained as a size hint and
+still resolves with the precedence shown, but it no longer gates writes.
 
 The effective budget resolves with the following **precedence** (highest
 first):
@@ -348,7 +348,7 @@ and binds to the env var `DITTOFS_BLOCKSTORE_LOCAL_MAX_LOG_BYTES`:
 ```yaml
 blockstore:
   local:
-    max_log_bytes: 2147483648   # 2 GiB global append-log pressure budget.
+    max_log_bytes: 2147483648   # 2 GiB global local-cache size hint (no longer gates writes).
                                 # 0 / unset = system-deduced default
                                 # (25% of RAM, floor 1 GiB). A per-store
                                 # config max_log_bytes overrides this.
@@ -589,7 +589,7 @@ filling the host volume, the local cache is bounded and writes apply
   explicit `--local-store-size` always wins. **Local-only shares are
   unaffected** — they keep their existing system-deduced local size and never
   apply remote-cache backpressure. The cap is enforced **lazily, on the
-  write/rollup path** (it evicts synced blocks to make room for new writes); it
+  write/carve path** (it evicts synced segments to make room for new writes); it
   is **not** a background reaper, so on an idle or read-only workload the
   resident local tier is not shrunk toward the cap. To reclaim local disk — or
   to force cold, remote-served reads for read-path benchmarking — evict on
@@ -631,7 +631,7 @@ blockstore:
                                              # Defaults to 10 GiB if unset.
     backpressure_max_wait: 60s               # Max time a write stalls for the
                                              # syncer to drain before disk-full.
-    max_log_bytes: 2147483648                # Global append-log pressure budget
+    max_log_bytes: 2147483648                # Global local-cache size hint
                                              # (see above). 0/unset = deduced.
 ```
 
@@ -907,7 +907,7 @@ Badger's own defaults are tiny (256 MiB block, index cache disabled), which
 thrashes on a busy server over a large directory tree. The symptom in the logs
 is `Block cache might be too small ... hit-ratio: 0.26 ... sets-rejected`; every
 cold lookup then walks the LSM tree from disk, which also widens the window for
-the dedup transaction-conflict race and the append-log "pressure wait timed out"
+the dedup transaction-conflict race and the local-cache write-path backpressure
 stall.
 
 By default both sizes **auto-scale with the memory available to the process**,
@@ -919,7 +919,7 @@ so no tuning is required:
 | index | 7.5 %                     | 256 MiB | 2 GiB   |
 
 The fractions are deliberately conservative because the same process also holds
-the append-log, the metadata working set, and read buffers. The available-memory
+the local journal cache, the metadata working set, and read buffers. The available-memory
 figure is the cgroup limit inside a container, or physical RAM otherwise (same
 detection used for block-store sizing). Examples:
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -122,7 +122,7 @@ The lack of FUSE overhead and optimized Go implementation provides competitive p
 That message means the BadgerDB metadata engine's in-memory **block cache** is
 undersized for your working set, so it is thrashing: most lookups miss the cache
 and hit disk. A low hit-ratio also widens the window for the dedup
-transaction-conflict race and the append-log "pressure wait timed out" stall, so
+transaction-conflict race and the local-cache write-path backpressure stall, so
 it is worth fixing.
 
 By default the block and index caches **auto-size from the memory available to

--- a/docs/guide/snapshots.md
+++ b/docs/guide/snapshots.md
@@ -502,7 +502,7 @@ Snapshot c12e8d4f removed.
 4. Write a durable **restore-in-progress marker** (see
    [§8.1](#81-automatic-crash-recovery)) naming the safety snapshot,
    immediately before the first destructive step.
-5. Reset the block store's local append-log overlay.
+5. Reset the block store's local journal cache.
 6. Reset the metadata store via its `Resetable` interface.
 7. Replay the snapshot's `metadata.dump` into the empty store.
 8. Walk the restored metadata to build a hash set of every block

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -204,14 +204,14 @@ DittoFS uses a three-tier storage model for block data:
                │ cache miss
                ▼
 ┌─────────────────────────────────────┐
-│  Local Block Store                  │
-│  pkg/block/local/fs/           │
-│  - Filesystem-backed                │
-│  - Fast access (disk I/O)           │
+│  Local Journal (write-back cache)   │
+│  pkg/block/journal/                 │
+│  - Append-only, log-structured      │
+│  - Absorbs writes, local-ack        │
 │  - Persistent across restarts       │
-│  - Per-share isolated directories   │
+│  - Per-share isolated directory     │
 └──────────────┬──────────────────────┘
-               │ block not local
+               │ cold read (range not cached)
                ▼
 ┌─────────────────────────────────────┐
 │  Remote Store                       │
@@ -223,247 +223,127 @@ DittoFS uses a three-tier storage model for block data:
 └─────────────────────────────────────┘
 ```
 
-**Read Path**: Engine.ReadAt receives `[]ChunkRef` from caller, locates the
-covering chunks via `findChunksForRange` (binary search), serves bytes
-from the local log-blob tier or, on a miss, resolves the chunk's remote
-locator and issues a ranged read into its enclosing `blocks/<id>` object,
-decoding and BLAKE3-verifying end-to-end (fail-closed). `Cache.OnRead`
-updates the per-payload sequential tracker for prefetch hints.
+**Read Path**: `Engine.ReadAt` resolves a file's bytes by `(payloadID,
+offset)`. If the range is present in the local journal it is served straight
+from a journal segment. On a cold miss the engine resolves the chunk's remote
+locator from the FileChunk manifest, issues a ranged read into its enclosing
+`blocks/<id>` object, decodes and BLAKE3-verifies the chunk end-to-end
+(fail-closed), then hydrates the bytes back into the journal so subsequent
+reads are warm. A per-payload sequential tracker drives remote prefetch.
 
-**Write Path**: Engine.WriteAt receives `(currentChunks []ChunkRef, data,
-offset)`, FastCDC-rechunks the affected range, returns `newChunks
-[]ChunkRef` to the caller; caller persists newChunks alongside the
-metadata transaction (Mtime, Size, etc.). The syncer's carver packs
-synced-pending chunks into ~16 MiB blocks and uploads each with one PUT,
-committing the block record and per-chunk locators in a single metadata
-transaction.
+**Write Path**: `Engine.WriteAt` appends the dirty range to the local journal
+and acknowledges immediately (write-back) — there is no synchronous chunking,
+hashing, or upload on the client path. A background carve pass later packs the
+accumulated dirty ranges into remote blocks (see below). How durable the ack is
+depends on the configured durability tier (`writeback` / `local-durable` /
+`remote`; see the [durability guide](../guide/durability.md)).
 
 **Eviction**:
-- Cache: LRU eviction when budget reached. No data loss (local CAS has the data). Cache is per-share but cross-file inside a share — the same hash referenced by two files shares one entry.
-- Local store: whole-blob eviction reclaims log-blob bytes once every chunk in a sealed blob is synced to remote; manual eviction via `dfsctl store block evict`. Only synced data is evictable (safety check prevents data loss).
+- Cache: LRU eviction when the RAM budget is reached. No data loss (the journal still holds the bytes). The cache is per-share but cross-file inside a share — the same content hash referenced by two files shares one entry.
+- Journal: whole fully-synced segments are evicted approx-LRU under disk pressure. Only ranges already carved to the remote qualify, so eviction never destroys the only copy of dirty bytes. Manual eviction via `dfsctl store block evict`.
 
-## Block Store -- Local Append-Log Tier
+## Block Store — Local Journal Tier
 
-The local filesystem store (`pkg/block/local/fs/`) writes through an
-append-only log per file. A rollup pool chunks the log via FastCDC, hashes
-each chunk with BLAKE3, and appends the chunk bytes to the local **log-blob**
-tier (`blobs/<id>.blob`), recording each chunk's position in the
-`LocalChunkIndex`. The log-blob substrate is mandatory: every local store is
-constructed with a `LocalChunkIndex`, and rolled-up chunks live only in the
-append-only blob tier. (Pre-flip per-chunk `blocks/{hh}/{hh}/{hex}` files, if
-any survive an upgrade, are imported into the blob tier by the one-shot
-migration at startup — see [Migration](#migration--block-layout-routing) — and
-never read on the live path.) See [Log-Blob Local Tier](#log-blob-local-tier)
-below.
+The per-share local tier is the **journal** (`pkg/block/journal/`): a single
+append-only, log-structured **write-back cache** in front of the remote store.
+It replaces the earlier two-tier design (a per-file append-only log plus a
+separate rolled-up "log-blob" tier) with one substrate. See the journal
+package's own doc comment for the authoritative model; this section covers it
+at architecture altitude.
 
-**New writes are packed into remote blocks.** On every share, the syncer's
-carver batches locally-rolled chunks and uploads them as packed **block
-objects** under the remote `blocks/<id>` prefix — one PUT per block of
-roughly 16 MiB of chunks (`BlockCarveBytes`), or sooner when the writer goes
-idle. It does **not** write one `cas/<hash>` object per chunk. Per-chunk
-deduplication and refcounting are preserved: a
-`ChunkLocator{BlockID, WireOffset, WireLength}` records where each chunk's
-bytes live inside its enclosing block, so identical chunks are still stored
-once and reclaimed by refcount. The remote store exposes only the block-keyed
-surface (`blocks/<id>`); there is no per-chunk `cas/<hash>` remote object on
-the live read or write path.
+A client write (`WriteAt`) appends a dirty record for `(payloadID, offset)` to
+a shared segment file and acknowledges immediately — it never chunks, hashes,
+or uploads on the client path, and it never fsyncs (durability is a separate
+`Commit`, driven by NFS COMMIT / SMB Flush and the configured durability tier).
+Cold-read hydration (`Hydrate`) funnels through the same append primitive, the
+only difference being that a hydrated record is born *clean* (already durable
+in the remote store, so immediately evictable) while a client write is born
+*dirty* (must be carved before it can be evicted). The journal is keyed by
+`(payloadID, offset)`, not by content hash.
 
-This is the only write path. A store still holding standalone-CAS state from a
-v0.16-v0.21 server is converted to packed blocks automatically at startup, and
-a pre-v0.16 `.blk` layout is refused with a directive to migrate with an
-earlier release (see [Migration](#migration--block-layout-routing)).
+`*fs.FSStore` (`pkg/block/local/fs/`) is now a **thin adapter** over
+`*journal.Store`: it bridges the `string`↔`journal.FileID` keyspace and the
+`local.LocalStore` admin surface, and forwards the data-plane calls. The
+journal owns its own segment layout, carve, eviction, and local garbage
+collection. Only `BackpressureMaxWait` and `ChunkParams` remain load-bearing
+knobs; the old rollup/append-log options (`max_log_bytes`, `rollup_workers`,
+`stabilization_ms`, `orphan_log_min_age_seconds`) are vestigial — the journal
+carves on its own age/size gate.
 
-See [Block Lifecycle (three-state)](#block-lifecycle-three-state) and
-[Garbage Collection (mark-sweep)](#garbage-collection-mark-sweep) below.
+### Carve: local → remote
 
-### Pipeline
+A background **carve** pass turns accumulated dirty ranges into remote blocks.
+The engine's carve dispatcher (`pkg/block/engine/carve_dispatch.go`) ticks
+every `UploadInterval` (default 2s) and asks the journal to carve each file;
+the journal applies its own age/size batching gate and serializes carve per
+shard internally. Carving a file FastCDC-chunks its dirty ranges (min 1 MiB /
+avg 4 MiB / max 16 MiB by default), BLAKE3-hashes each chunk, and — via the
+engine-supplied `BlockSink` — dedups against remote-durable chunks, seals each
+chunk (compression/encryption), frames the survivors into a packed block
+(~16 MiB, `BlockCarveBytes`), uploads the block with one `PutBlock`, and
+commits the block record, per-chunk synced markers, and per-file FileChunk
+manifest rows in a single metadata transaction (`metadata.DefaultCommitBlock`).
+`PutBlock` runs before the commit, so a crash in between leaves an orphan block
+object (reclaimed by GC), never an unbacked record; a re-carve targets a fresh
+block ID and never double-commits.
 
-```
-                                                       (log header + records)
-                                                       logs/{payloadID}.log
-  AppendWrite ---> per-file log (append-only)  ---------------+
-  (per-file mutex)   CRC per record                           |
-                                                              v
-                                                       chunkRollup pool
-                                                       (default 2 workers)
-                                                              |
-                                       BLAKE3 + FastCDC       |
-                                       (min 1 MiB / avg 4 MiB / max 16 MiB)
-                                                              |
-                                                              v
-                                                       StoreChunk
-                                                       blobs/<id>.blob (append)
-                                                       + LocalChunkIndex entry
-                                                              |
-                                        CommitChunks atomic:  |
-                                         1. metadata.SetRollupOffset (source of truth)
-                                         2. advanceRollupOffset + fsync log header
-                                         3. tree.ConsumeUpTo + logBytesTotal.Sub
-                                         4. non-blocking signal on pressureCh
-                                                              |
-                                                              v
-                                                       (blocked AppendWrite unblocks)
-```
+Dedup is answered by a durability oracle: a chunk is treated as already remote
+iff its hash is present in the per-share `SyncedHashStore`. A share with **no**
+remote block store still carves — the local block sink records only the
+FileChunk manifest rows (hash + `DataSize`, no remote block key) so clone,
+snapshot, and restore can resolve the file's chunks, but nothing is uploaded.
 
-### Layout
+The carve pass fans out across files: a single sequential pass (one file, one
+block, one `PutBlock` at a time) leaves the uplink almost idle. Concurrency is
+bounded by an **adaptive upload window** (`pkg/block/engine/upload_controller.go`):
+a pinned `--parallel-uploads` fixes the window, while the default (adaptive)
+mode ramps it between a floor and ceiling to track the goodput knee. Files in
+one shard still serialize on the journal's carve lock, so the window overlaps
+distinct shards' upload latency.
 
-```
-<baseDir>/logs/<payloadID>.log        per-file append-only log
-<baseDir>/blobs/<id>.blob             log-blob tier (rolled-up chunk bytes)
-<baseDir>/blocks/<hh>/<hh>/<hex>      pre-flip per-chunk files (imported + removed by startup migration)
-```
+Explicit `Flush` / `SyncNow` force-carve a file's (or all files') dirty ranges
+and serialize against the background dispatcher on the same per-shard lock, so
+the two never pack the same range twice. In `ManualSync` mode the background
+dispatcher is suppressed and `Flush`/`SyncNow` are the sole carve drivers.
 
-Log header (64 bytes): magic `DFLG` | version | `rollup_offset` | flags |
-`created_at` | header CRC | 32 B reserved. Record framing:
-`payload_len` (u32 LE) | `file_offset` (u64 LE) | `crc32c` (u32 LE) |
-payload.
+### Reads and integrity
 
-### Invariants
+`ReadAt` resolves by `(payloadID, offset)`. A range present in the journal is
+served straight from its segment. A range that was written but has since been
+evicted returns `cold=true`; the engine then resolves the chunk's remote
+locator from the FileChunk manifest, ranged-GETs its enclosing `blocks/<id>`
+object, decodes the wire frame, recomputes BLAKE3 over the chunk bytes, and —
+on success — hydrates the verified bytes back into the journal so subsequent
+reads are warm.
 
-- **`rollup_offset` is monotone:** metadata is the source of truth; the
-  filesystem header is idempotent derived state. Recovery reconciles the
-  header from metadata on boot.
-- **Log length is bounded:** `logBytesTotal <= max_log_bytes` per
-  `FSStore`. Writers block on `pressureCh` when the budget is exceeded;
-  rollup drains and non-blocking signals when bytes are reclaimed.
+Integrity is fail-closed: every remote fetch is BLAKE3-verified before the
+bytes reach the caller, and a mismatch is returned as an error (and counted),
+never as data. On the local side, integrity rests on the journal's own
+segment-recovery CRC scan at open — there is no per-read local-hash check, so
+a cold read that fails remote verification cannot be silently self-healed from
+local bytes.
 
-### Crash recovery
+### Eviction and local GC
 
-Recovery (`pkg/block/local/fs/recovery.go`) scans logs from
-`rollup_offset`, truncates at first bad CRC, and rebuilds per-file interval
-trees. Orphan logs (no metadata referrer, no live FileChunk, mtime older
-than `orphan_log_min_age_seconds`) are swept. Log-blob bytes are reclaimed by
-whole-blob eviction (see [Log-Blob Local Tier](#log-blob-local-tier)).
+Under disk pressure the journal evicts whole **fully-synced** segments
+approx-LRU; only ranges already carved to the remote qualify, so eviction
+never destroys the only copy of dirty bytes. Eviction is health-gated: while
+the remote is unhealthy, cold-marking a range would strand unrecoverable
+bytes, so eviction is paused. There is no pin/ttl/lru retention knob
+(`SetRetentionPolicy` is a no-op on the journal-native store).
+
+The journal's own garbage collection (repack) only relocates live cache bytes
+between local segments to reclaim dead space — it **never** touches the remote
+store. Reclaiming remote block objects by refcount stays with the engine's
+block-GC sweep (see [Garbage Collection](#garbage-collection-mark-sweep)),
+whose per-remote serialization is what makes a decrement safe.
 
 ### Per-`FSStore` surface
 
-Because block stores are per-share (see the invariants in `CLAUDE.md`),
-every local-tier field -- log-fd map, per-file mutex map, interval-tree
-map, rollup worker pool, pressure channel, `maxLogBytes` budget,
-stabilization window -- lives inside `*FSStore`. No global state across
-shares.
-
-See `docs/CONFIGURATION.md` (`max_log_bytes`, `rollup_workers`,
-`stabilization_ms`, `orphan_log_min_age_seconds`) for the tunables.
-
-## Log-Blob Local Tier
-
-`pkg/block/local/logblob` is a raw append-only file manager that holds the
-local durable copy of freshly-written chunks. **This substrate is live.**
-Locally-rolled chunks are appended to log-blobs, and the engine carver reads
-them back by position (`LocalChunkLocation{LogBlobID, RawOffset, RawLength}`)
-to pack them into the remote block objects described in
-[Block Store — Local Append-Log Tier](#block-store----local-append-log-tier).
-Reads resolve through the local chunk index first — a positioned `pread(2)`
-against the log-blob — and fall back to the remote block only on a local
-miss (see [Block Reads](#block-reads-verified)).
-
-### Layout
-
-A `Manager` owns a directory of flat binary files called log-blobs (`*.blob`):
-
-```
-<dir>/0000000000000000.blob    ← active blob (accepts appends)
-<dir>/0000000000000001.blob    ← sealed (read-only, eligible for eviction)
-...
-```
-
-Blob IDs are zero-padded 16-digit decimals, giving lexicographic sort order
-matching creation order. Chunks are stored raw — no per-record framing, no
-checksum inside the blob — so the single read primitive is a positioned
-`pread(2)` against a `LocalChunkLocation{LogBlobID, RawOffset, RawLength}`.
-Durability is caller-controlled: call `Sync` at commit boundaries.
-
-### API
-
-```go
-// Open opens (or creates) a Manager rooted at dir.
-// On a fresh directory it creates the first blob. On reopen the
-// highest-numbered blob becomes active and appends resume at its tail.
-func Open(dir string, opts Options) (*Manager, error)
-
-// Append writes p to the tail of the active blob and returns the chunk's
-// position. Rotates automatically when the active blob would exceed SizeCap
-// (default 1 GiB). Empty payloads are rejected.
-func (m *Manager) Append(ctx context.Context, p []byte) (block.LocalChunkLocation, error)
-
-// ReadAt reads loc.RawLength bytes from blob loc.LogBlobID at loc.RawOffset
-// into dst (len(dst) >= loc.RawLength). Safe to call concurrently with Append.
-func (m *Manager) ReadAt(ctx context.Context, loc block.LocalChunkLocation, dst []byte) (int, error)
-
-// Rotate seals the active blob and opens a fresh one. Callers can rotate
-// at application-defined boundaries without waiting for SizeCap.
-func (m *Manager) Rotate() error
-
-// Sync fsyncs the active blob to durable storage.
-func (m *Manager) Sync() error
-
-// ListBlobs returns metadata for every blob, sorted by creation order.
-// Includes the active blob.
-func (m *Manager) ListBlobs() ([]BlobInfo, error)
-
-// EvictBlob removes a sealed blob from disk and the in-memory fd cache.
-// The caller supplies a synced func that reports whether the blob's bytes
-// are durable elsewhere; eviction is refused with ErrUnsyncedBytes if not.
-// Idempotent: a second call on an already-evicted blob returns nil.
-// After eviction, ReadAt on that blob returns ErrEvicted.
-func (m *Manager) EvictBlob(ctx context.Context, logBlobID string, synced func(string) bool) error
-
-// Recover truncates logBlobID to validUpToOffset, discarding torn tail bytes.
-// For the active blob it also updates the in-memory tail pointer.
-// Rejects offset > current blob size to prevent POSIX ftruncate from
-// zero-filling. Callers must quiesce concurrent I/O before calling Recover.
-func (m *Manager) Recover(ctx context.Context, logBlobID string, validUpToOffset int64) error
-```
-
-### Concurrency
-
-`Append` and `Rotate` are mutex-serialized. `ReadAt` acquires the mutex
-briefly to snapshot the active blob's identity and file descriptor, then
-releases it before the `pread(2)` call. Reads and appends on non-overlapping
-byte ranges therefore proceed concurrently. The race detector is clean.
-
-### Sentinel errors
-
-| Error | Condition |
-|---|---|
-| `logblob.ErrClosed` | Operation attempted after `Close` |
-| `logblob.ErrBlobNotFound` | `ReadAt` targets a non-existent blob ID |
-| `logblob.ErrEvicted` | `ReadAt` or `Recover` targets an evicted blob |
-| `logblob.ErrActiveBlob` | `EvictBlob` called on the current active blob |
-| `logblob.ErrUnsyncedBytes` | `EvictBlob` refused because the caller's `synced` func returned false |
-
-### Data flow (once wired in)
-
-```
-Chunk bytes
-    │
-    ▼ logblob.Manager.Append
-LocalChunkLocation{LogBlobID, RawOffset, RawLength}
-    │
-    ├─▶ metadata.LocalChunkIndex.PutLocalLocation  ─┐
-    └─▶ metadata.BlockRecordStore.PutBlockRecord   ─┴─ single transaction
-            via metadata.DefaultCommitBlock            (one fsync per block —
-                                                        the local durable commit)
-            then, after that transaction commits:
-    └─▶ metadata.SyncedHashStore.MarkSynced (per chunk, remote locator)
-            runs as a separate idempotent post-commit phase — SyncedHashStore is
-            on Store but not Transaction, so remote locators are written outside
-            the block transaction and re-driven safely on retry.
-
-Read path:
-    ContentHash
-    │
-    ▼ metadata.LocalChunkIndex.GetLocalLocation
-    LocalChunkLocation
-    │
-    ▼ logblob.Manager.ReadAt
-    chunk bytes
-```
-
-The `metadata.LocalChunkIndex` and `metadata.BlockRecordStore` contracts
-that feed this flow are described in
-[Block Record and Local Chunk Index](implementing-stores.md#block-record-and-local-chunk-index).
+Per the per-share block-store invariants (in `CLAUDE.md`), all journal state —
+segments, interval index, carve/eviction machinery, disk budget — lives inside
+the per-share `*journal.Store` behind `*FSStore`. No global state is shared
+across shares; local storage directories are always isolated.
 
 ## Block Lifecycle (three-state)
 
@@ -495,14 +375,12 @@ requeues any `Syncing` row whose `last_sync_attempt_at` is older than
 content-defined so a duplicate re-upload writes the same bytes to the
 same key — idempotent by construction.
 
-**Known limitation — restart seeding.** Chunks that were appended to the
-local log-blob but not yet carved into a remote block when the process
-crashed are durable on local disk, but they are **not** re-seeded into the
-pending-carve set on restart. They stay local-only — fully readable — until
-the file they belong to is written to again, which re-queues them for
-carving. No data is lost; the only effect is that such chunks are not
-uploaded to the remote until touched again. Re-seeding the carve set from the
-local index on boot is a follow-up item.
+**Restart re-drain.** Ranges written to the journal but not yet carved into a
+remote block when the process crashed are durable on local disk and are
+re-drained automatically on restart: the journal's recovered interval index
+re-marks every not-yet-carved record dirty at `Open`, so the carve dispatcher
+picks them up on its next tick without any separate reconcile walk or
+metadata-side pending set.
 
 **Why a metadata write for every claim?** The Pending → Syncing
 transition is the serialization point against duplicate uploads across
@@ -794,20 +672,19 @@ For the full operator runbook see
 
 ## Block Reads (verified)
 
-Every block read resolves by metadata key — one DB lookup per chunk, not
-remote trial-and-error, so there is no doubled GET cost — and takes one of
-two paths:
+A read resolves by `(payloadID, offset)` — no remote trial-and-error — and
+takes one of two paths:
 
-1. **Local log-blob hit.** If the chunk is still on local disk, its bytes are
-   served straight from the log-blob via a positioned `pread(2)` at its
-   `LocalChunkLocation`. This is the steady-state path for recently-written
-   and recently-read data.
-2. **Remote packed block.** On a local miss, the engine resolves the chunk's
-   `ChunkLocator` (`BlockID` + `[WireOffset, WireOffset+WireLength)`) and
-   issues a ranged GET against the packed remote object `blocks/<BlockID>`,
-   decodes the wire frame, and recomputes BLAKE3 over the chunk bytes. A
-   verified chunk is re-staged into the local tier so subsequent reads take
-   path 1.
+1. **Local journal hit.** If the range is present in the local journal, its
+   bytes are served straight from the journal segment. This is the steady-state
+   path for recently-written and recently-read data.
+2. **Remote packed block.** On a cold miss (the range was written but has been
+   evicted), the engine resolves the chunk's `ChunkLocator`
+   (`BlockID` + `[WireOffset, WireOffset+WireLength)`) from the FileChunk
+   manifest, issues a ranged GET against the packed remote object
+   `blocks/<BlockID>`, decodes the wire frame, and recomputes BLAKE3 over the
+   chunk bytes. A verified chunk is hydrated back into the journal so subsequent
+   reads take path 1.
 
 A synced chunk whose locator is empty (standalone) or missing is
 **post-migration drift** — the startup migration rewrites every standalone
@@ -816,14 +693,10 @@ refused fail-closed rather than read.
 
 **Fail-closed integrity.** Every remote fetch is BLAKE3-verified before the
 bytes reach the caller. A mismatch is never surfaced as data: the read returns
-an error and increments a corruption metric.
-
-**Self-heal.** The two tiers are treated asymmetrically on a verification
-failure. A *local* mismatch (a bit-rotted log-blob) is self-healing — the
-engine discards the bad local pointer, re-fetches the chunk from its remote
-block, verifies it, and re-stages it locally. A *remote* mismatch cannot be
-recovered locally, so it fails closed: the read errors and the corruption is
-recorded rather than papered over.
+an error and increments a corruption metric. Local integrity rests on the
+journal's segment-recovery CRC scan at open; there is no per-read local-hash
+check, so a cold read that fails remote verification is not silently
+self-healed from local bytes — it fails closed and the corruption is recorded.
 
 The pre-v0.16 non-CAS layout (`{payloadID}/block-{N}`) is no longer read at
 runtime. A store directory still on that layout is refused on open, directing
@@ -1081,11 +954,11 @@ dittofs/
 │   │   ├── errors.go             # BlockStore error types
 │   │   ├── chunker/              # FastCDC content-defined chunker
 │   │   │                         # min=1 MiB / avg=4 MiB / max=16 MiB, lvl 2;
-│   │   │                         # BLAKE3 hashing; consumed by local rollup pool
+│   │   │                         # BLAKE3 hashing; consumed by the carve pass
 │   │   ├── engine/               # BlockStore orchestrator + read cache + syncer + GC
+│   │   ├── journal/              # Local write-back cache (append-only segments)
 │   │   ├── local/                # Local store interface
-│   │   │   ├── fs/               # Filesystem-backed local store
-│   │   │   │                     # (append-log + CAS blocks/ tier)
+│   │   │   ├── fs/               # Thin adapter over pkg/block/journal
 │   │   │   └── memory/           # In-memory local store (testing)
 │   │   └── remote/               # Remote store interface
 │   │       ├── s3/               # S3-backed remote store
@@ -1575,7 +1448,7 @@ carrying leftover standalone-CAS state — pre-flip per-chunk local files, remot
 converted at `engine.Store.Start`, blocking until done, by
 `engine.Store.migrateLegacyCAS` (`pkg/block/engine/legacy_migration.go`):
 
-1. **Phase L** imports pre-flip per-chunk local files into the log-blob tier
+1. **Phase L** imports pre-flip per-chunk local files into the local journal
    (BLAKE3-verified, deduplicated) and deletes them
    (`fs.FSStore.MigrateLegacyChunkFiles`).
 2. **Phase R** re-packs every chunk whose synced marker still carries a

--- a/docs/internals/implementing-stores.md
+++ b/docs/internals/implementing-stores.md
@@ -303,17 +303,20 @@ without per-backend `t.Skip` (the `ObjectIDIndexAccessor` capability is
 the only legitimate type-assertion-skip; backends without that accessor
 are still required to pass the functional scenarios).
 
-### Block Record and Local Chunk Index
+### Block Record Store
 
-Two additional metadata interfaces persist the bookkeeping needed by the
-blocks-only storage path. All four backends (memory, badger, sqlite, postgres)
-implement both and pass the corresponding conformance groups.
+`BlockRecordStore` persists the bookkeeping needed by the blocks-only storage
+path. All four backends (memory, badger, sqlite, postgres) implement it and pass
+the corresponding conformance group. (There is no separate local-chunk-index
+metadata contract: the local journal owns its own `(payloadID, offset)`-keyed
+byte cache internally, and the per-file **FileChunk manifest** — written by the
+carve `BlockSink` — is the only metadata record of a carved chunk.)
 
 #### BlockRecordStore
 
-Tracks each log-blob block object: its content hash, byte length, live chunk
-count, and sync state. The syncer uses this to decide which blocks are safe to
-upload; the GC uses it to decide which may be deleted.
+Tracks each packed remote block object: its content hash, byte length, live
+chunk count, and sync state. The carver uses this to decide which blocks are
+safe to upload; the GC uses it to decide which may be deleted.
 
 ```go
 // pkg/block/block_record.go
@@ -354,45 +357,6 @@ Conformance: `storetest` group **BlockRecordOps** covers put/get round-trip,
 missing-key (returns `false`, not an error), delete idempotency, walk, and
 `DecrLiveChunkCount` with floor clamping.
 
-#### LocalChunkIndex
-
-Maps a chunk's content hash to its position in a local log-blob file. It is
-the local-tier analog of `SyncedHashStore`: both are keyed by `ContentHash`,
-both carry a physical locator, and both follow the same idempotent-put /
-safe-miss-on-get / idempotent-delete contract.
-
-| Interface         | Key           | Value                        | Tier   |
-|-------------------|---------------|------------------------------|--------|
-| `SyncedHashStore` | `ContentHash` | `block.ChunkLocator`         | Remote |
-| `LocalChunkIndex` | `ContentHash` | `block.LocalChunkLocation`   | Local  |
-
-```go
-// pkg/block/block_record.go
-type LocalChunkLocation struct {
-    LogBlobID string // blob filename stem, e.g. "0000000000000001"
-    RawOffset int64  // byte offset within that blob
-    RawLength int64  // byte length of the raw chunk
-}
-```
-
-```go
-// pkg/metadata/block_record_store.go
-type LocalChunkIndex interface {
-    // PutLocalLocation records or overwrites the local position for hash.
-    PutLocalLocation(ctx context.Context, hash block.ContentHash, loc block.LocalChunkLocation) error
-
-    // GetLocalLocation returns the local position for hash.
-    // Returns (_, false, nil) when no entry exists.
-    GetLocalLocation(ctx context.Context, hash block.ContentHash) (block.LocalChunkLocation, bool, error)
-
-    // DeleteLocalLocation removes the local position for hash. Idempotent.
-    DeleteLocalLocation(ctx context.Context, hash block.ContentHash) error
-}
-```
-
-Conformance: group **LocalIndexOps** covers put/get round-trip, upsert
-overwrites (second write wins), missing-key, and delete idempotency.
-
 #### DefaultCommitBlock — one fsync per block
 
 `metadata.DefaultCommitBlock` atomically commits an entire block's metadata
@@ -402,12 +366,10 @@ in a single transaction — one fsync per block, not one per chunk:
 // pkg/metadata/block_record_store.go
 func DefaultCommitBlock(
     ctx context.Context,
-    s interface {
-        Transactor
-        SyncedHashStore
-    },
+    s Transactor,
     rec block.BlockRecord,
     chunks []block.BlockChunkCommit,
+    fileChunks []*block.FileChunk,
 ) error
 ```
 
@@ -417,24 +379,25 @@ func DefaultCommitBlock(
 // pkg/block/block_record.go
 type BlockChunkCommit struct {
     Hash   block.ContentHash
-    Remote block.ChunkLocator      // remote locator passed to MarkSynced
-    Local  block.LocalChunkLocation // local locator stored in LocalChunkIndex
+    Remote block.ChunkLocator // remote locator recorded via MarkSynced
 }
 ```
 
-Inside `WithTransaction`, `DefaultCommitBlock`:
+Everything commits in a **single** `WithTransaction`, so either the whole block
+is visible or none of it is — a commit error just propagates to the caller,
+whose requeue logic re-drives the batch. Inside the transaction,
+`DefaultCommitBlock`:
 
 1. Calls `GetBlockRecord` — if the block record already exists the whole
-   function is a no-op (idempotent restart path; no double-counting).
+   function is a no-op (idempotent restart path; no double-counting, locators
+   untouched).
 2. Calls `PutBlockRecord` with `rec`.
-3. Calls `PutLocalLocation` for every chunk in `chunks`.
-
-After the transaction commits, it calls `MarkSynced` on `SyncedHashStore`
-for every chunk, recording the remote locator. `MarkSynced` runs outside
-the transaction and is itself idempotent, so a crash between the committed
-transaction and the last `MarkSynced` call is safe: the next retry skips the
-transaction (block record already exists) and re-runs only the `MarkSynced`
-loop.
+3. Writes each per-file **FileChunk manifest** row in `fileChunks` — the carver
+   passes one per chunk (`ID = {payloadID}/{offset}`, `Hash`, `DataSize`);
+   legacy callers pass `nil` and write no rows.
+4. Records every chunk's synced marker + remote locator. Locator writes are
+   last-wins (delete-then-mark inside the tx), so the cas→blocks migration can
+   rewrite a standalone locator to point into the new block.
 
 Backends expose `CommitBlock` on the `Store` interface and SHOULD delegate to
 `DefaultCommitBlock`:
@@ -469,100 +432,62 @@ Local stores provide fast, per-share block storage. Each share gets an isolated 
 
 ### The LocalStore Interface
 
-The `pkg/block/local.LocalStore` interface defines the contract. Storage is
-**content-addressed** — chunks are keyed by their BLAKE3 `block.ContentHash`,
-not by a block ID + offset. The interface embeds the content-addressed
-`block.BlockStoreAppend` surface and adds lifecycle, per-payload admin,
-rollup-drain, and retention methods. See `pkg/block/local/local.go` for the
-authoritative definition; the embedded CAS contract is:
+The `pkg/block/local.LocalStore` interface defines the contract. The local tier
+is the **journal** (`pkg/block/journal/`) — an append-only, log-structured
+write-back cache — so the surface is keyed by `(payloadID, offset)`, **not** by
+content hash. See `pkg/block/local/local.go` for the authoritative definition
+and per-method contract; the representative methods are:
 
 ```go
-type Store interface { // block.Store, embedded by LocalStore via BlockStoreAppend
-    // Put writes data under the key derived from hash (idempotent for
-    // identical bytes). Returns an error on a zero hash.
-    Put(ctx context.Context, hash ContentHash, data []byte) error
+type LocalStore interface {
+    // --- Data plane (payloadID + offset keyed) ---
+    WriteAt(ctx context.Context, payloadID string, offset int64, data []byte) error
+    ReadAt(ctx context.Context, payloadID string, offset int64, dst []byte) (n int, cold bool, err error)
+    Hydrate(ctx context.Context, payloadID string, offset int64, data []byte) error // fill from remote on cold read
+    Commit(ctx context.Context, payloadID string) error                             // fsync buffered writes
+    FileSize(ctx context.Context, payloadID string) (int64, bool)
+    DataExtents(ctx context.Context, payloadID string, fileSize int64) ([][2]uint64, error)
+    Truncate(ctx context.Context, payloadID string, newSize int64) error
+    Delete(ctx context.Context, payloadID string) error
+    ListFiles(ctx context.Context) []string
 
-    // Get returns the chunk bytes addressed by hash (freshly allocated,
-    // never aliasing internal storage). Returns ErrChunkNotFound if absent.
-    Get(ctx context.Context, hash ContentHash) ([]byte, error)
-
-    // GetRange returns the byte sub-range [offset, offset+length).
-    GetRange(ctx context.Context, hash ContentHash, offset, length int64) ([]byte, error)
-
-    // Has reports whether the store holds the object addressed by hash.
-    Has(ctx context.Context, hash ContentHash) (bool, error)
-
-    // Delete removes the object addressed by hash.
-    Delete(ctx context.Context, hash ContentHash) error
-
-    // Head returns object metadata (size, last-modified) without the body.
-    Head(ctx context.Context, hash ContentHash) (ObjectInfo, error)
-
-    // Walk enumerates every stored object. Return ErrStopWalk to exit early.
-    Walk(ctx context.Context, fn func(ObjectInfo) error) error
+    // --- Carve (local → remote) + eviction ---
+    SetCarveTargets(deduper journal.Deduper, sink journal.BlockSink)
+    Carve(ctx context.Context, opts journal.CarveOptions) (journal.CarveResult, error)
+    UnsyncedBytes() int64
+    Evict(ctx context.Context, targetBytes int64) (journal.EvictResult, error)
+    SetEvictionEnabled(enabled bool)
+    // ... plus lifecycle (Start, Close), Stats, Healthcheck, and a
+    // no-op SetRetentionPolicy retained for admin-path compatibility.
 }
 ```
 
-`BlockStoreAppend` adds `AppendWrite` and `DeleteAppendLog` for the append-log
-write path. `LocalStore` then layers on lifecycle (`Start`, `Close`),
-per-payload admin (`Truncate`, `EvictMemory`, `GetFileSize`, `ListFiles`,
-`ReadPayloadAt`), snapshot drain/reset (`DrainRollups`, `ResetLocalState`),
-and retention policy (`SetRetentionPolicy`, `SetEvictionEnabled`) — consult
-`pkg/block/local/local.go` for the full method set and per-method contract.
+A write buffers a dirty range and local-acks without fsync; `Commit` is the
+durability point. On a cold read `ReadAt` returns `cold=true` and the engine
+`Hydrate`s the range back from the remote store. `Carve` packs a file's dirty
+ranges into remote blocks via the injected `BlockSink` (see the carve pass in
+[the architecture doc](architecture.md#carve-local--remote)); `Evict` frees
+whole fully-synced segments under pressure.
 
 ### Reference Implementation
 
-See `pkg/block/local/fs/` for a complete filesystem-backed local store implementation that handles:
-- Per-share isolated directories
-- Atomic writes
-- Block listing for sync operations
-
-### Append-log + CAS chunk tier
-
-The local filesystem store (`*fs.FSStore`) writes through an append-only
-log per file and rolls it up into content-addressed (CAS) chunks. The
-chunk-tier methods on `*fs.FSStore` are: `AppendWrite`, `StoreChunk`,
-`ReadChunk`, `HasChunk`, `DeleteChunk`, `DeleteAppendLog`,
-`TruncateAppendLog`, and `StartRollup`.
-
-A per-file metadata surface `metadata.RollupStore` (two methods:
-`SetRollupOffset`, `GetRollupOffset`) persists the log's `rollup_offset`.
-The built-in memory, Badger, and Postgres backends all implement it. New
-metadata backends must add equivalent persistence keyed by `payloadID`,
-backed by an atomic upsert (metadata is the source of truth for
-`rollup_offset`; see `docs/ARCHITECTURE.md`).
+The filesystem-backed store `*fs.FSStore` (`pkg/block/local/fs/`) is a thin
+adapter over `*journal.Store`: it bridges the `string`↔`journal.FileID`
+keyspace and forwards the data-plane calls; the journal owns segment layout,
+carve, eviction, and local GC. The in-memory store (`pkg/block/local/memory/`)
+is the other reference. There is no separate append-log or rollup tier and no
+`metadata.RollupStore` contract — those were removed when the journal replaced
+the two-tier local design.
 
 ### Conformance Tests
 
-Test your local store with the conformance suite:
-
-```go
-package mylocal_test
-
-import (
-    "testing"
-
-    "github.com/marmos91/dittofs/pkg/block"
-    "github.com/marmos91/dittofs/pkg/block/blockstoretest"
-)
-
-func TestMyLocalStore(t *testing.T) {
-    // The factory returns a fresh store plus a cleanup closure per subtest.
-    factory := func(t *testing.T) (block.Store, func()) {
-        store, cleanup := createTestStore(t)
-        return store, cleanup
-    }
-    blockstoretest.BlockStoreConformance(t, factory)
-
-    // If your store implements the append-write absorber (block.BlockStoreAppend),
-    // also run the append conformance suite:
-    appendFactory := func(t *testing.T) (block.BlockStoreAppend, func()) {
-        store, cleanup := createTestAppendStore(t)
-        return store, cleanup
-    }
-    blockstoretest.BlockStoreAppendConformance(t, appendFactory)
-}
-```
+The journal-native `LocalStore` surface is `(payloadID, offset)`-keyed, not the
+content-addressed `block.Store` surface, so the `blockstoretest` suites below
+(`BlockStoreConformance` / `BlockStoreAppendConformance`) do **not** apply to a
+local store — they target the CAS `block.Store` surface that remote stores
+implement (see [Implementing a Remote Store](#implementing-a-remote-store)). The
+in-tree local stores are exercised by their own package tests under
+`pkg/block/journal/` and `pkg/block/local/`; model a new local store on those.
 
 ## Implementing a Remote Store
 


### PR DESCRIPTION
## What changed

The per-share local block-store tier was collapsed from the old two-tier design (a per-file append-only **log** rolled up into a separate **log-blob** tier) into a single append-only, log-structured **write-back cache** — the journal (`pkg/block/journal/`). The internals and guide docs still described the removed design as current, giving maintainers a wrong mental model. This is a **docs-only** refresh: no code was touched. Every claim was verified against the current `pkg/block/journal/` and `pkg/block/engine/` sources.

## The corrected model

- The local tier is the journal: writes append and local-ack (write-back); a background **carve** pass (FastCDC + BLAKE3 + dedup) packs dirty ranges into packed remote `blocks/<id>` objects via `PutBlock`, fanning out across files bounded by an adaptive upload window. `PutBlock` runs before the metadata commit, so a crash leaves an orphan block (GC-reclaimed), never an unbacked record.
- `*fs.FSStore` is now a thin adapter over `*journal.Store`; the old rollup/append-log knobs are vestigial.
- Reads resolve by `(payloadID, offset)`: journal hit, or cold-miss → ranged GET of the packed block → BLAKE3-verify (fail-closed) → hydrate back. There is no per-read local-hash self-heal.
- Eviction frees whole fully-synced segments approx-LRU; the journal's GC (repack) never touches the remote. Three durability tiers (writeback / local-durable / remote) gate the write-ack.

## Sections/files corrected

- **docs/internals/architecture.md** — replaced the "Local Append-Log Tier" + "Log-Blob Local Tier" sections with one "Local Journal Tier" section (write/carve/read/eviction/GC at architecture altitude, linking the journal package for evolving internals); fixed the Storage-Tiers diagram + read/write/eviction subsections; corrected "Block Reads (verified)" (journal hit vs cold-miss, removed the local self-heal claim); turned the stale "restart seeding" limitation into the journal's automatic restart re-drain; fixed the directory tree and the migration Phase-L import target.
- **docs/internals/implementing-stores.md** — removed the deleted `LocalChunkIndex`/`LocalChunkLocation` contract; fixed `DefaultCommitBlock` signature (now takes `fileChunks`) and its steps (FileChunk manifest + in-txn synced markers, no `PutLocalLocation`); dropped the `Local` field from `BlockChunkCommit`; rewrote the LocalStore interface to the journal-native `(payloadID, offset)` surface; deleted the "Append-log + CAS chunk tier" / `RollupStore` subsection; corrected the local-store conformance guidance.
- **docs/guide/configuration.md** — reframed the local `fs` knobs: `max_log_bytes` is a size hint that no longer gates writes; `rollup_workers`/`stabilization_ms`/`orphan_log_min_age_seconds` are accepted-but-inert legacy; removed the deleted `metadata.RollupStore` backend requirement; described the real journal disk-cap / `ErrLocalStoreFull` backpressure.
- **docs/guide/choosing-stores.md**, **docs/guide/block-store-migration.md**, **docs/guide/faq.md**, **docs/guide/snapshots.md** — fixed stray log-blob / append-log references.

`docs/guide/durability.md` was already accurate (journal + tiers) and was left unchanged.

Refs #1692