### PR TITLE
chore(block): drop inert local fs-store rollup/append-log knobs

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -302,22 +302,17 @@ server will start.
 
 These keys live inside the per-share `local` block store's `config` JSON
 (passed via `dfsctl store block local add --config '{...}'` or the REST API).
-They only take effect when the local store type is `fs`. (A legacy
-`use_append_log` key is accepted but ignored — appending is mandatory — and
-logs a startup warning.)
+They only take effect when the local store type is `fs`. Legacy keys from the
+pre-journal design — `use_append_log`, `rollup_workers`, `stabilization_ms`,
+`orphan_log_min_age_seconds` — are no longer parsed; if present they are
+silently ignored.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `max_log_bytes` | int | deduced (25% of RAM, floor 1 GiB) | **Per-share** local-cache size hint. Still accepted and resolved (per-store value takes **precedence** over the global `blockstore.local.max_log_bytes` and the system-deduced default), but it no longer drives write backpressure — the journal caps on-disk usage and evicts on its own budget. Values above 2^53 (~9 PiB) lose precision through JSON parsing. |
-| `rollup_workers` | int | `2` | **Legacy, inert.** Accepted for config compatibility; the journal carves on its own age/size gate, so this no longer starts any goroutines. |
-| `stabilization_ms` | int | `250` | **Legacy, inert.** Accepted for config compatibility; superseded by the journal's carve batching gate. |
-| `orphan_log_min_age_seconds` | int | `3600` (1h) | **Legacy, inert.** Accepted for config compatibility; there is no separate append-log to orphan-sweep under the journal. |
 
 Env-var mapping follows the dot-path convention:
-`DITTOFS_BLOCKSTORE_LOCAL_FS_MAX_LOG_BYTES`,
-`DITTOFS_BLOCKSTORE_LOCAL_FS_ROLLUP_WORKERS`,
-`DITTOFS_BLOCKSTORE_LOCAL_FS_STABILIZATION_MS`,
-`DITTOFS_BLOCKSTORE_LOCAL_FS_ORPHAN_LOG_MIN_AGE_SECONDS`.
+`DITTOFS_BLOCKSTORE_LOCAL_FS_MAX_LOG_BYTES`.
 
 There is no `metadata.RollupStore` backend requirement any more — the journal
 owns its local-cache state; a metadata backend only needs the block-record and

--- a/pkg/block/engine/locator_fetch_test.go
+++ b/pkg/block/engine/locator_fetch_test.go
@@ -22,9 +22,7 @@ func newLocatorFetchSyncer(t *testing.T) (*Syncer, *remotememory.Store, *metadat
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	t.Cleanup(func() { _ = ms.Close() })
 	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
-		MaxLogBytes:     128 * 1024 * 1024,
-		RollupWorkers:   2,
-		StabilizationMS: 5,
+		MaxLogBytes: 128 * 1024 * 1024,
 	})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)

--- a/pkg/block/engine/warm_read_integrity_test.go
+++ b/pkg/block/engine/warm_read_integrity_test.go
@@ -29,9 +29,7 @@ func newEngineWithRemote(t *testing.T, ms metadata.Store, mem *remotememory.Stor
 		t.Fatalf("metadata store %T does not implement metadata.SyncedHashStore", ms)
 	}
 	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
-		MaxLogBytes:     128 * 1024 * 1024,
-		RollupWorkers:   2,
-		StabilizationMS: 3_600_000, // async rollup never fires; explicit DrainRollups only
+		MaxLogBytes: 128 * 1024 * 1024,
 	})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)

--- a/pkg/block/engine/write_bench_test.go
+++ b/pkg/block/engine/write_bench_test.go
@@ -21,11 +21,9 @@ import (
 	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
-// Engine wiring constants. Sized for short-lived benchmark runs:
+// Engine wiring constant. Sized for short-lived benchmark runs:
 // 256 MiB local cache budget.
-const (
-	writeBenchLogBudget = 256 * 1024 * 1024
-)
+const writeBenchLogBudget = 256 * 1024 * 1024
 
 // Default block sizes — match the legacy bench/blockstore shape so
 // historical results stay comparable. Sequential and dedup move 8 MiB

--- a/pkg/block/engine/write_bench_test.go
+++ b/pkg/block/engine/write_bench_test.go
@@ -22,11 +22,9 @@ import (
 )
 
 // Engine wiring constants. Sized for short-lived benchmark runs:
-// 256 MiB rollup log budget, 2 rollup workers, 5 ms stabilization.
+// 256 MiB local cache budget.
 const (
-	writeBenchLogBudget       = 256 * 1024 * 1024
-	writeBenchRollupWorkers   = 2
-	writeBenchStabilizationMS = 5
+	writeBenchLogBudget = 256 * 1024 * 1024
 )
 
 // Default block sizes — match the legacy bench/blockstore shape so

--- a/pkg/block/engine/write_bench_test.go
+++ b/pkg/block/engine/write_bench_test.go
@@ -21,8 +21,8 @@ import (
 	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
-// Engine wiring constant. Sized for short-lived benchmark runs:
-// 256 MiB local cache budget.
+// Engine wiring constant: the fs store's MaxLogBytes Stats size hint (maxDisk
+// is passed 0 = uncapped, so this does not bound the bench).
 const writeBenchLogBudget = 256 * 1024 * 1024
 
 // Default block sizes — match the legacy bench/blockstore shape so

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -23,21 +23,14 @@ import (
 // ErrStoreClosed is returned by operations on a closed store.
 var ErrStoreClosed = block.ErrStoreClosed
 
-// FSStoreOptions tunes a journal-backed store. Only BackpressureMaxWait and
-// ChunkParams are load-bearing; the rollup/append-log knobs are vestigial,
-// retained so the shares config plumbing compiles.
-//
-// ponytail: RollupWorkers/StabilizationMS/SyncEveryWrite/OrphanLogMinAgeSeconds/
-// MaxLogBytes no longer control anything — the journal carves on its own
-// age/size gate. Drop them once the shares service stops reading them.
+// FSStoreOptions tunes a journal-backed store. BackpressureMaxWait and
+// ChunkParams are load-bearing; MaxLogBytes is retained only as a Stats size
+// hint (it does not gate writes — the journal carves and evicts on its own
+// age/size/disk budget).
 type FSStoreOptions struct {
-	BackpressureMaxWait    time.Duration
-	MaxLogBytes            int64
-	ChunkParams            chunker.Params
-	RollupWorkers          int
-	StabilizationMS        int
-	SyncEveryWrite         bool
-	OrphanLogMinAgeSeconds int
+	BackpressureMaxWait time.Duration
+	MaxLogBytes         int64
+	ChunkParams         chunker.Params
 }
 
 // FSStore is the journal-backed local store. It embeds *journal.Store and

--- a/pkg/controlplane/runtime/shares/create_local_store_test.go
+++ b/pkg/controlplane/runtime/shares/create_local_store_test.go
@@ -30,8 +30,8 @@ func (f *fakeBlockStoreConfig) GetConfig() (map[string]any, error) {
 
 // TestCreateLocalStoreFromConfig_AppendLogMandatory exercises the config
 // wiring: append is mandatory on the local tier. CreateLocalStoreFromConfig
-// must build an FSStore via NewWithOptions, start the rollup pool, and return
-// a store whose AppendWrite path succeeds.
+// must build an FSStore via NewWithOptions and return a store whose write
+// path succeeds.
 func TestCreateLocalStoreFromConfig_AppendLogMandatory(t *testing.T) {
 	ctx := context.Background()
 	tmp := t.TempDir()

--- a/pkg/controlplane/runtime/shares/create_local_store_test.go
+++ b/pkg/controlplane/runtime/shares/create_local_store_test.go
@@ -38,11 +38,8 @@ func TestCreateLocalStoreFromConfig_AppendLogMandatory(t *testing.T) {
 
 	cfg := &fakeBlockStoreConfig{
 		cfg: map[string]any{
-			"path":                       tmp,
-			"max_log_bytes":              float64(2_000_000_000), // 2 GB
-			"rollup_workers":             float64(4),
-			"stabilization_ms":           float64(500),
-			"orphan_log_min_age_seconds": float64(7200),
+			"path":          tmp,
+			"max_log_bytes": float64(2_000_000_000), // 2 GB
 		},
 	}
 
@@ -82,12 +79,8 @@ func TestCreateLocalStoreFromConfig_InvalidTypesIgnored(t *testing.T) {
 
 	cfg := &fakeBlockStoreConfig{
 		cfg: map[string]any{
-			"path":                       tmp,
-			"use_append_log":             "not-a-bool", // accepted then warned (no-op)
-			"max_log_bytes":              "not-a-number",
-			"rollup_workers":             float64(-1),
-			"stabilization_ms":           float64(0),
-			"orphan_log_min_age_seconds": "nope",
+			"path":          tmp,
+			"max_log_bytes": "not-a-number",
 		},
 	}
 
@@ -129,10 +122,8 @@ func TestCreateLocalStoreFromConfig_RollupSurvivesCallerCancel(t *testing.T) {
 
 	cfg := &fakeBlockStoreConfig{
 		cfg: map[string]any{
-			"path":             tmp,
-			"max_log_bytes":    float64(2_000_000_000),
-			"rollup_workers":   float64(2),
-			"stabilization_ms": float64(50), // roll up quickly once idle
+			"path":          tmp,
+			"max_log_bytes": float64(2_000_000_000),
 		},
 	}
 

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -2860,9 +2860,6 @@ func CreateLocalStoreFromConfig(
 	if defaults != nil && defaults.MaxLogBytes > 0 {
 		fsOpts.MaxLogBytes = defaults.MaxLogBytes
 	}
-	if _, ok := config["use_append_log"]; ok {
-		logger.Warn("block store config has use_append_log: append is mandatory in v0.16+, flag is ignored")
-	}
 	if v, ok := config["max_log_bytes"]; ok {
 		if n, ok := v.(float64); ok && n > 0 {
 			// FIX-15: JSON-decoded numbers land here as float64. Values above
@@ -2880,34 +2877,6 @@ func CreateLocalStoreFromConfig(
 			}
 		} else {
 			logger.Warn("block store config has max_log_bytes but it is invalid or non-positive; ignoring", "value", v)
-		}
-	}
-	if v, ok := config["rollup_workers"]; ok {
-		if n, ok := v.(float64); ok && n > 0 {
-			fsOpts.RollupWorkers = int(n)
-		} else {
-			logger.Warn("block store config has rollup_workers but it is invalid or non-positive; ignoring", "value", v)
-		}
-	}
-	if v, ok := config["stabilization_ms"]; ok {
-		if n, ok := v.(float64); ok && n > 0 {
-			fsOpts.StabilizationMS = int(n)
-		} else {
-			logger.Warn("block store config has stabilization_ms but it is invalid or non-positive; ignoring", "value", v)
-		}
-	}
-	if v, ok := config["sync_every_write"]; ok {
-		if b, ok := v.(bool); ok {
-			fsOpts.SyncEveryWrite = b
-		} else {
-			logger.Warn("block store config has sync_every_write but it is not a bool; ignoring", "value", v)
-		}
-	}
-	if v, ok := config["orphan_log_min_age_seconds"]; ok {
-		if n, ok := v.(float64); ok && n > 0 {
-			fsOpts.OrphanLogMinAgeSeconds = int(n)
-		} else {
-			logger.Warn("block store config has orphan_log_min_age_seconds but it is invalid or non-positive; ignoring", "value", v)
 		}
 	}
 	// chunk_size sets the FastCDC Min for this share's rollup chunker (#1569) —

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -2852,9 +2852,10 @@ func CreateLocalStoreFromConfig(
 	// are warned and ignored.
 	var fsOpts fs.FSStoreOptions
 	fsOpts.BackpressureMaxWait = backpressureMaxWait
-	// Append-log pressure budget default. Precedence (lowest first):
+	// Local-cache size-hint default. Precedence (lowest first):
 	// FSStore internal default < global/deduced default (plumbed via
 	// LocalStoreDefaults.MaxLogBytes) < per-store config["max_log_bytes"].
+	// max_log_bytes no longer gates writes; it only feeds the Stats size hint.
 	// Seed fsOpts.MaxLogBytes from the global/deduced default here; the
 	// per-store config branch below overrides it when present.
 	if defaults != nil && defaults.MaxLogBytes > 0 {
@@ -2879,7 +2880,7 @@ func CreateLocalStoreFromConfig(
 			logger.Warn("block store config has max_log_bytes but it is invalid or non-positive; ignoring", "value", v)
 		}
 	}
-	// chunk_size sets the FastCDC Min for this share's rollup chunker (#1569) —
+	// chunk_size sets the FastCDC Min for this share's carve chunker (#1569) —
 	// the dominant knob for effective chunk size and thus random-read
 	// amplification. Avg/Max are derived (4x/8x Min) unless chunk_max overrides
 	// the ceiling. Absent => the FSStore default (1M/4M/16M, byte-identical to


### PR DESCRIPTION
Follow-up to the docs refresh (#1792): actually delete the dead local `fs`-store knobs instead of documenting them as "legacy" forever.

The journal write-back cache replaced the old append-log + rollup local tier. These `FSStoreOptions` knobs were left wired up but control nothing — the journal carves and evicts on its own age/size/disk budget:

- `rollup_workers`
- `stabilization_ms`
- `sync_every_write`
- `orphan_log_min_age_seconds`
- `use_append_log` (was already accepted-but-ignored, warn-only)

### What changed
- Removed the four fields from `FSStoreOptions` (`pkg/block/local/fs/fs.go`).
- Removed the config-parsing blocks that read those keys (+ the `use_append_log` warning) in `CreateLocalStoreFromConfig` (`shares/service.go`). The keys are now silently ignored like any unknown config key.
- Updated the test fixtures / config-parsing tests that set them.

Net −70/+17 across 6 files. Build, vet, and the affected package tests (`fs`, `shares`, touched `engine` fixtures) are green.

### Not in this PR
`max_log_bytes` is intentionally kept: unlike the four above it still resolves through the config schema (`blockstore.local.max_log_bytes`), the deduced-defaults machinery, the `dfs config show` / `start` output, a `Stats` size hint, and the `localstore_append_log_limit_bytes` Prometheus metric. Removing it is a bigger, observable-surface change (metric + schema + CLI), tracked in #1793 — it should decide whether to wire it to the journal's `MaxLocalBytes` cap or delete it outright.

Refs #1793