### PR TITLE
fix(clone): materialize whole-file clone on local-only shares

### DIFF
--- a/internal/adapter/common/clone.go
+++ b/internal/adapter/common/clone.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/marmos91/dittofs/pkg/block/engine"
@@ -56,6 +57,17 @@ func CloneWholeFile(
 	// manifest rather than an empty/partial one.
 	if err := blockStore.DrainRollups(ctx); err != nil {
 		return fmt.Errorf("drain source rollups: %w", err)
+	}
+
+	// Local-only shares have no remote content-addressed tier to hydrate from,
+	// and the destination payload owns no journal intervals of its own, so a
+	// manifest-only reflink (engine.CopyPayload) would leave the destination
+	// pointing at hashes whose bytes live only in the SOURCE's journal — a read
+	// of the clone then finds no destination interval and zero-fills. Materialize
+	// real bytes into the destination's own journal instead. Remote shares keep
+	// the O(1) reflink below (their shared blocks are cold-hydratable).
+	if !blockStore.HasRemoteStore() {
+		return materializeLocalClone(ctx, blockStore, metadataStore, cache, srcHandle, dstHandle, dstPayloadID)
 	}
 
 	selfClone := false
@@ -112,6 +124,114 @@ func CloneWholeFile(
 	// entries. Files that still reference the shared CAS hashes via dedup keep
 	// their entries warm (nil removedHashes => key off dstPayloadID only).
 	if cache != nil && !selfClone {
+		cache.InvalidateFile(dstPayloadID, nil)
+	}
+	return nil
+}
+
+// materializeLocalClone is the local-only (no remote store) clone path: it
+// copies the source payload's bytes into the destination payload's OWN journal
+// via the normal write path, then lets the normal carve build the destination's
+// FileChunk manifest and derived File.Blocks. The reflink path cannot serve a
+// local-only clone because the destination would carry manifest rows whose bytes
+// live only in the source's journal, with no destination interval to read — a
+// read of the clone would zero-fill.
+//
+// Cost: O(n) work AND O(n) local storage. The journal append-log local tier does
+// not content-dedup, so this is a real byte copy, not a reflink — a strict
+// improvement over silently reading zeros, but not O(1). Remote-backed shares
+// keep the O(1) reflink (see the caller). This path touches no CAS RefCount, so
+// there is no refcount-under-GC concern for it.
+//
+// It runs ENTIRELY OUTSIDE any metadata transaction: WriteAt / Flush /
+// DrainRollups persist destination rows through the per-share coordinator under
+// a non-reentrant metadata lock, so nesting them inside a held transaction would
+// self-deadlock. Only the trailing size/mtime stamp opens its own short txn,
+// after the block writes have committed.
+func materializeLocalClone(
+	ctx context.Context,
+	blockStore *engine.Store,
+	metadataStore metadata.Store,
+	cache CacheInvalidator,
+	srcHandle, dstHandle metadata.FileHandle,
+	dstPayloadID metadata.PayloadID,
+) error {
+	// Re-read the source AFTER the caller's DrainRollups so Size and the source
+	// journal intervals reflect the fully-materialized post-rollup view.
+	srcFile, err := metadataStore.GetFile(ctx, srcHandle)
+	if err != nil {
+		return fmt.Errorf("materialize clone: fetch src file: %w", err)
+	}
+
+	// Self-clone (source and destination share a payload) is a no-op: the
+	// destination content is unchanged, so skip the copy and the cache drop.
+	if srcFile.PayloadID == dstPayloadID {
+		return nil
+	}
+
+	// Copy the source bytes into the destination payload's own journal, chunked
+	// to bound the transient buffer. ReadAt resolves the source's local journal
+	// intervals (zero-filling any sparse hole); WriteAt appends real intervals to
+	// the destination journal so a later read of the destination resolves bytes
+	// rather than a hole.
+	const copyChunk = 1 << 20 // 1 MiB
+	buf := make([]byte, copyChunk)
+	for off := uint64(0); off < srcFile.Size; {
+		want := srcFile.Size - off
+		if want > copyChunk {
+			want = copyChunk
+		}
+		n, rerr := blockStore.ReadAt(ctx, string(srcFile.PayloadID), nil, buf[:want], off)
+		if n > 0 {
+			if _, werr := blockStore.WriteAt(ctx, string(dstPayloadID), nil, buf[:n], off); werr != nil {
+				return fmt.Errorf("materialize clone: write dst payload: %w", werr)
+			}
+			off += uint64(n)
+		}
+		if rerr != nil {
+			if rerr == io.EOF || rerr == io.ErrUnexpectedEOF {
+				break
+			}
+			return fmt.Errorf("materialize clone: read src payload: %w", rerr)
+		}
+		if n == 0 {
+			break
+		}
+	}
+
+	// Durability barrier + carve: Flush fsyncs the destination's appended
+	// records; DrainRollups seals them into the destination's FileChunk manifest
+	// and derived File.Blocks — the same path a normal write + commit drives.
+	if _, err := blockStore.Flush(ctx, string(dstPayloadID)); err != nil {
+		return fmt.Errorf("materialize clone: flush dst payload: %w", err)
+	}
+	if err := blockStore.DrainRollups(ctx); err != nil {
+		return fmt.Errorf("materialize clone: drain dst rollups: %w", err)
+	}
+
+	// Block-level WriteAt does not set File.Size / Mtime / Ctime — stamp them on
+	// the destination to match the source and record the content change. The
+	// carve above already populated File.Blocks, so re-read inside the txn and
+	// leave it intact.
+	err = metadataStore.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		dstFile, err := tx.GetFile(ctx, dstHandle)
+		if err != nil {
+			return fmt.Errorf("fetch dst file: %w", err)
+		}
+		dstFile.Size = srcFile.Size
+		dstFile.Mtime = time.Now()
+		dstFile.Ctime = dstFile.Mtime // content change is also a metadata change
+		if err := tx.PutFile(ctx, dstFile); err != nil {
+			return fmt.Errorf("persist dst file: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// POST-txn: the destination content changed wholesale; drop its cache entries.
+	if cache != nil {
 		cache.InvalidateFile(dstPayloadID, nil)
 	}
 	return nil

--- a/internal/adapter/common/copy_payload.go
+++ b/internal/adapter/common/copy_payload.go
@@ -46,6 +46,17 @@ func CopyPayload(
 	srcFileHandle, dstFileHandle metadata.FileHandle,
 	srcPayloadID, dstPayloadID metadata.PayloadID,
 ) error {
+	// Local-only shares cannot serve a manifest-only reflink (the destination
+	// would carry rows whose bytes live only in the source's journal, so a read
+	// zero-fills). Materialize real bytes into the destination's own journal
+	// instead; remote shares keep the O(1) reflink below.
+	if !blockStore.HasRemoteStore() {
+		if err := blockStore.DrainRollups(ctx); err != nil {
+			return fmt.Errorf("CopyPayload: drain source rollups: %w", err)
+		}
+		return materializeLocalClone(ctx, blockStore, metadataStore, cache, srcFileHandle, dstFileHandle, dstPayloadID)
+	}
+
 	srcFile, err := metadataStore.GetFile(ctx, srcFileHandle)
 	if err != nil {
 		return fmt.Errorf("CopyPayload: fetch src file attr: %w", err)

--- a/internal/adapter/common/copy_payload_test.go
+++ b/internal/adapter/common/copy_payload_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/engine"
 	"github.com/marmos91/dittofs/pkg/block/local/fs"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
@@ -366,14 +367,26 @@ func newCopyTestEngineWithMS(t *testing.T, coord *fakeCoordinator, ms *metadatam
 		t.Fatalf("fs.NewWithOptions failed: %v", err)
 	}
 
-	syncer := engine.NewSyncer(localStore, nil, ms, engine.DefaultConfig())
+	// Wire a remote store so HasRemoteStore() is true: the O(1) manifest-row
+	// reflink these tests assert is the remote-share path. A local-only share
+	// (no remote) materializes real bytes instead — covered separately by the
+	// journal-backed engine test.
+	mem := remotememory.New()
+	syncedHashStore, ok := metadata.Store(ms).(metadata.SyncedHashStore)
+	if !ok {
+		t.Fatalf("metadata store %T does not implement metadata.SyncedHashStore", ms)
+	}
+	syncer := engine.NewSyncer(localStore, mem, ms, engine.DefaultConfig())
+	syncer.SetSyncedHashStore(syncedHashStore)
+	syncer.SetRemoteBlockStore(mem)
 
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:           localStore,
-		Remote:          nil,
+		Remote:          mem,
 		Syncer:          syncer,
 		FileChunkStore:  ms,
 		Coordinator:     coord,
+		SyncedHashStore: syncedHashStore,
 		ReadBufferBytes: 0,
 		PrefetchWorkers: 0,
 	})

--- a/pkg/block/engine/clone_localonly_test.go
+++ b/pkg/block/engine/clone_localonly_test.go
@@ -1,0 +1,155 @@
+package engine_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/block/local/fs"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// newLocalOnlyEngine builds an engine over a real journal-backed local store
+// with NO remote store (HasRemoteStore() == false). This is the configuration
+// that surfaces the local-only CLONE-reads-zeros bug: the journal owns the only
+// copy of the bytes, so a manifest-only reflink leaves the destination with no
+// resolvable interval. An in-memory local store would mask the bug, so this
+// fixture deliberately uses the fs (journal) store.
+func newLocalOnlyEngine(t *testing.T, ms metadata.Store) *engine.Store {
+	t.Helper()
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
+		MaxLogBytes:     128 * 1024 * 1024,
+		RollupWorkers:   2,
+		StabilizationMS: 3_600_000, // async rollup never fires; explicit DrainRollups only
+	})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+	syncedHashStore, ok := ms.(metadata.SyncedHashStore)
+	if !ok {
+		t.Fatalf("metadata store %T does not implement metadata.SyncedHashStore", ms)
+	}
+	coord := &testCoordinator{store: ms}
+	syncer := engine.NewSyncer(localStore, nil, ms, engine.DefaultConfig())
+	// No remote block store: the journal owns the bytes and the local carve sink
+	// records the FileChunk manifest via the SyncedHashStore committer.
+	bs, err := engine.New(engine.BlockStoreConfig{
+		Local:           localStore,
+		Syncer:          syncer,
+		FileChunkStore:  ms,
+		Coordinator:     coord,
+		SyncedHashStore: syncedHashStore,
+		ReadBufferBytes: 64 * 1024 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("engine.New: %v", err)
+	}
+	if err := bs.Start(context.Background()); err != nil {
+		t.Fatalf("engine.Start: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+	return bs
+}
+
+// readWhole reads exactly len(dst) bytes of payloadID from offset 0.
+func readWhole(t *testing.T, bs *engine.Store, payloadID string, size int) []byte {
+	t.Helper()
+	out := make([]byte, size)
+	n, err := bs.ReadAt(context.Background(), payloadID, nil, out, 0)
+	if err != nil && err != io.EOF {
+		t.Fatalf("ReadAt(%s): %v", payloadID, err)
+	}
+	return out[:n]
+}
+
+// TestCloneWholeFile_LocalOnly_MaterializesContent guards the residual #1784
+// bug: on a share with no remote store, CLONE used to copy only the source's
+// manifest rows (hash + size) to the destination, which carries no journal
+// interval of its own — so a read of the clone found no interval and zero-filled
+// (silent corruption). The fix materializes the source bytes into the
+// destination's own journal, so the clone reads back byte-identical.
+func TestCloneWholeFile_LocalOnly_MaterializesContent(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	bs := newLocalOnlyEngine(t, ms)
+
+	root := createShare(t, ms, "clone")
+	srcPID, srcHandle := createRealFile(t, ms, "clone", "src.bin", root)
+	dstPID, dstHandle := createRealFile(t, ms, "clone", "dst.bin", root)
+
+	// 3 MiB of deterministic but non-trivial content so a byte copy spans
+	// multiple carve chunks and any accidental zero-fill is obvious.
+	const size = 3 << 20
+	src := make([]byte, size)
+	for i := range src {
+		src[i] = byte(i*131 + 7)
+	}
+	if _, err := bs.WriteAt(ctx, srcPID, nil, src, 0); err != nil {
+		t.Fatalf("WriteAt src: %v", err)
+	}
+	if _, err := bs.Flush(ctx, srcPID); err != nil {
+		t.Fatalf("Flush src: %v", err)
+	}
+	// Persist the source size the way a real WRITE path would; CloneWholeFile
+	// reads it to bound the materialize copy.
+	srcFile, err := ms.GetFile(ctx, srcHandle)
+	if err != nil {
+		t.Fatalf("GetFile src: %v", err)
+	}
+	srcFile.Size = size
+	if err := ms.PutFile(ctx, srcFile); err != nil {
+		t.Fatalf("PutFile src size: %v", err)
+	}
+
+	// CLONE over a local-only share.
+	if err := common.CloneWholeFile(ctx, bs, ms, nil, srcHandle, dstHandle, metadata.PayloadID(dstPID)); err != nil {
+		t.Fatalf("CloneWholeFile: %v", err)
+	}
+
+	// The destination reads back byte-identical (would be all zeros before the
+	// fix).
+	got := readWhole(t, bs, dstPID, size)
+	if len(got) != size {
+		t.Fatalf("clone read size = %d, want %d", len(got), size)
+	}
+	if !bytes.Equal(got, src) {
+		if bytes.Equal(got, make([]byte, size)) {
+			t.Fatalf("clone read back all zeros — local-only CLONE did not materialize bytes")
+		}
+		t.Fatalf("clone content differs from source")
+	}
+
+	// The destination's File.Size was stamped from the source.
+	dstFile, err := ms.GetFile(ctx, dstHandle)
+	if err != nil {
+		t.Fatalf("GetFile dst: %v", err)
+	}
+	if dstFile.Size != size {
+		t.Fatalf("dst File.Size = %d, want %d", dstFile.Size, size)
+	}
+
+	// Copy-on-write: overwriting the destination head must not disturb the
+	// source (each file owns an independent payload/journal).
+	patch := bytes.Repeat([]byte{0x55}, 64<<10)
+	if _, err := bs.WriteAt(ctx, dstPID, nil, patch, 0); err != nil {
+		t.Fatalf("WriteAt dst patch: %v", err)
+	}
+	if _, err := bs.Flush(ctx, dstPID); err != nil {
+		t.Fatalf("Flush dst: %v", err)
+	}
+	srcAfter := readWhole(t, bs, srcPID, size)
+	if !bytes.Equal(srcAfter, src) {
+		t.Fatalf("source mutated after writing the clone — COW violated")
+	}
+	dstAfter := readWhole(t, bs, dstPID, size)
+	if !bytes.Equal(dstAfter[:len(patch)], patch) {
+		t.Fatalf("clone head did not reflect the new write")
+	}
+	if !bytes.Equal(dstAfter[len(patch):], src[len(patch):]) {
+		t.Fatalf("clone tail lost the cloned content after the head write")
+	}
+}


### PR DESCRIPTION
## The bug (residual #1784)

The snapshot-restore-to-zeros family had one open case: **local-only CLONE reads zeros.**

On a share with no remote store the journal owns the only copy of the bytes and there is no content-addressed local tier. Whole-file CLONE (`CloneWholeFile` / `CopyPayload`) did an O(1) reflink that copied the source's manifest rows (hash + `DataSize`) onto the destination payload. But the destination payload owns no journal interval, so `blockStore.ReadAt(dstPayloadID)` found nothing and zero-filled — silent corruption. On a remote-backed share the same rows resolve to shared CAS chunks that cold-hydrate, so the reflink is correct there.

This surfaced as `TestNFSv42Clone` CLONE-01/02 and `TestBlocksFlipLifecycle_SMB` failing on develop.

## The fix — materialize on local-only shares

Gate the clone on `blockStore.HasRemoteStore()`:

- **Remote share** (`HasRemoteStore()==true`): keep the existing O(1) reflink path, unchanged.
- **Local-only** (`HasRemoteStore()==false`): materialize — copy the source bytes into the destination's OWN payload via the normal write path (`ReadAt(src)` → `WriteAt(dst)` in 1 MiB passes), then `Flush(dst)` + `DrainRollups` so the normal carve builds the destination's FileChunk manifest and derived `File.Blocks`. The destination now owns resolvable journal intervals and reads back byte-identical.

Correctness details:
- The materialize runs **entirely outside** the caller's metadata transaction. `WriteAt`/`Flush`/`DrainRollups` persist destination rows through the per-share coordinator under a non-reentrant metadata lock, so nesting them inside a held txn would self-deadlock. Only the trailing `Size`/`Mtime`/`Ctime` stamp opens its own short metadata-only txn.
- Block-level `WriteAt` does not set `File.Size`/`Mtime`/`Ctime`, so the destination's size/times are stamped from the (post-`DrainRollups`) source; `File.Blocks` is left as the carve projected it.
- Self-clone (`srcPayloadID == dstPayloadID`) stays a no-op.
- No CAS refcount is touched on this path (no reflink), so there is no refcount-under-GC concern for it.

## Cost honesty

This is **O(n) work AND O(n) local storage** — the journal append-log local tier does not content-dedup, so it is a real byte copy, not a reflink. That is a strict improvement over silently reading zeros; remote shares keep the O(1) reflink.

## Tests

- `pkg/block/engine/clone_localonly_test.go` — new test over the **real journal-backed** local store (an in-memory store masks the bug): clones a local-only file with real content, asserts the destination reads back equal to the source (would be all zeros before this fix), the source is unchanged, and a write to the destination does not mutate the source (COW).
- `TestNFSv42Clone` CLONE-01/02 already drive `cp --reflink` over a local fs store; they now pass.
- Updated the shared `CopyPayload`/`Clone` unit fixture to wire a remote store, since the O(1) reflink those tests assert is the remote-share path.

Closes #1784