### PR TITLE
feat(journal): opt-in per-read integrity + self-heal on durable tiers

### DIFF
--- a/docs/guide/durability.md
+++ b/docs/guide/durability.md
@@ -72,6 +72,62 @@ absent these are honored unchanged:
   [Configuration → require_durable_commit](configuration.md#require_durable_commit)
   for the full semantics.
 
+## Read integrity: per-read verification & self-heal
+
+Warm reads (bytes served from the local journal without a remote round-trip) are
+verified **per durability tier** — there is no separate knob, the tier you pick
+above decides it:
+
+| Tier | Warm-read check | On corruption |
+|---|---|---|
+| **`writeback`** | none (raw fast read) | n/a — integrity comes from startup-recovery CRC + remote cold-fetch BLAKE3 |
+| **`local`** *(default)* / **`remote`** | per-record **CRC32** on every warm read | self-heal (remote) or fail closed with **EIO** (local-only) |
+
+On the durable tiers, every warm read re-reads the covering journal record and
+checks its stored CRC32 before returning the requested bytes:
+
+- **Remote-backed share** — on a CRC mismatch the range is **self-healed**: the
+  covering chunk is re-fetched from the remote (S3) block store, which is
+  BLAKE3-verified on the way in, re-hydrated into the local journal, and the read
+  returns the *correct* bytes. The remote is the source of truth; the local tier
+  is a cache.
+- **Local-only share** — there is no good copy to heal from, so the read **fails
+  closed** with `EIO` (`NFS3ERR_IO` / `STATUS_DATA_CHECKSUM_ERROR`). It never
+  returns silently-wrong or zero-filled bytes.
+
+This catches on-disk corruption of a valid segment that happens *after* startup
+recovery (bit rot, or a bug mutating cached segment bytes) — the case the
+startup-recovery CRC and the remote cold-fetch BLAKE3 don't cover on their own.
+
+**Cost.** Verification reads the *whole covering record* to check its CRC, then
+slices out the requested sub-range. For large sequential reads that is free (you
+would read the record anyway); for **small random reads** it adds read
+amplification (a whole record fetched to return a few KiB) plus the CRC32 CPU.
+That is exactly why it is **off on the fast `writeback` default** and on for the
+durability-sensitive tiers.
+
+### Why opt-in-on-durable-tiers (not always-on, not never)
+
+The local tier is a **cache on disk over a verified remote**, not the primary
+copy — so the right trade mirrors our closest analog rather than a replicated
+primary store:
+
+- **[JuiceFS](https://juicefs.com/docs/cloud/guide/cache/)** — an S3-backed
+  filesystem with a local disk cache, like us — makes cache-checksum verification
+  **opt-in** (`--verify-cache-checksum`) for exactly this reason: "consistency
+  depends on the reliability of the disks — if data is tampered with, clients will
+  read bad data." We match that posture and, like JuiceFS, heal by re-fetching from
+  the object store (the source of truth).
+- **Ceph BlueStore** verifies a CRC32c on *every* read and heals from a replica —
+  but BlueStore is a **primary** store (the truth-holder), so always-on verify is
+  the right default there. We (like JuiceFS) are a cache tier over a verified
+  remote, so opt-in-on-durable-tiers is the better fit and preserves the fast
+  default read path.
+- A **background scrubber** (tracked separately as
+  [#1490](https://github.com/marmos91/dittofs/issues/1490)) is a *complement*, not
+  a substitute — Ceph pairs per-read verify with deep-scrub, and so do we
+  (per-read self-heal now, periodic scrub later).
+
 ## Measured throughput per tier
 
 File-create + 4 KiB write, 8 threads, NFSv3, badger + S3 remote (median ops/s;

--- a/pkg/block/engine/clone_localonly_test.go
+++ b/pkg/block/engine/clone_localonly_test.go
@@ -22,9 +22,7 @@ import (
 func newLocalOnlyEngine(t *testing.T, ms metadata.Store) *engine.Store {
 	t.Helper()
 	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
-		MaxLogBytes:     128 * 1024 * 1024,
-		RollupWorkers:   2,
-		StabilizationMS: 3_600_000, // async rollup never fires; explicit DrainRollups only
+		MaxLogBytes: 128 * 1024 * 1024,
 	})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/journal"
 )
 
 // blockRefHashes extracts the ContentHash slice from a ChunkRef list
@@ -32,6 +33,13 @@ func (bs *Store) readAtInternal(ctx context.Context, payloadID string, data []by
 
 	n, cold, err := bs.local.ReadAt(ctx, payloadID, int64(offset), data)
 	if err != nil {
+		var corrupt *journal.CorruptRangeError
+		if errors.As(err, &corrupt) {
+			// A durable-tier warm read detected on-disk corruption. The local bytes
+			// are untrustworthy, so never return them: heal from the remote or fail
+			// closed.
+			return bs.healCorruptWarmRead(ctx, payloadID, data, offset)
+		}
 		return 0, fmt.Errorf("local read failed: %w", err)
 	}
 	if !cold {
@@ -42,6 +50,24 @@ func (bs *Store) readAtInternal(ctx context.Context, payloadID string, data []by
 	// covering remote chunks, then re-read the now-warm window.
 	if err := bs.ensureAndReadFromLocal(ctx, payloadID, data, offset); err != nil {
 		return 0, err
+	}
+	return len(data), nil
+}
+
+// healCorruptWarmRead recovers from on-disk corruption that a durable-tier warm
+// read detected (journal returned *CorruptRangeError). With a remote store it
+// re-fetches the covering chunks through the standard hydrate path — the fetch
+// is BLAKE3-verified and the fresh Hydrate supersedes the corrupt local interval
+// by version — then re-reads the now-healed bytes. Without a remote there is no
+// good copy to heal from, so it fails closed with ErrIntegrityCheckFailed (maps
+// to NFS3ERR_IO) rather than returning corrupt or zero-filled bytes.
+func (bs *Store) healCorruptWarmRead(ctx context.Context, payloadID string, data []byte, offset uint64) (int, error) {
+	if !bs.HasRemoteStore() {
+		return 0, fmt.Errorf("warm read integrity failure for %s at offset %d (local-only, no remote to heal from): %w",
+			payloadID, offset, block.ErrIntegrityCheckFailed)
+	}
+	if err := bs.ensureAndReadFromLocal(ctx, payloadID, data, offset); err != nil {
+		return 0, fmt.Errorf("heal corrupt warm read for %s at offset %d: %w", payloadID, offset, err)
 	}
 	return len(data), nil
 }

--- a/pkg/block/engine/warm_read_selfheal_test.go
+++ b/pkg/block/engine/warm_read_selfheal_test.go
@@ -1,0 +1,195 @@
+package engine_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/block/local/fs"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// buildSelfHealEngine wires a journal-backed engine with per-read integrity
+// verification turned on (the durable-tier posture). A non-nil mem wires a real
+// remote block store (so a corrupt warm read can self-heal); a nil mem leaves the
+// share local-only (so a corrupt warm read must fail closed). It returns the
+// engine and the FSStore base dir so a test can corrupt a segment on disk.
+func buildSelfHealEngine(t *testing.T, ms metadata.Store, mem *remotememory.Store) (*engine.Store, string) {
+	t.Helper()
+	dir := t.TempDir()
+	localStore, err := fs.NewWithOptions(dir, 100*1024*1024, ms, fs.FSStoreOptions{
+		MaxLogBytes: 128 * 1024 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+	// Durable tier: verify warm reads per-record so on-disk corruption is caught.
+	localStore.SetVerifyReads(true)
+
+	syncedHashStore, ok := ms.(metadata.SyncedHashStore)
+	if !ok {
+		t.Fatalf("metadata store %T does not implement metadata.SyncedHashStore", ms)
+	}
+	coord := &testCoordinator{store: ms}
+	cfg := engine.BlockStoreConfig{
+		Local:           localStore,
+		FileChunkStore:  ms,
+		Coordinator:     coord,
+		SyncedHashStore: syncedHashStore,
+		ReadBufferBytes: 64 * 1024 * 1024,
+	}
+	if mem != nil {
+		syncer := engine.NewSyncer(localStore, mem, ms, engine.DefaultConfig())
+		syncer.SetSyncedHashStore(syncedHashStore)
+		syncer.SetRemoteBlockStore(mem)
+		cfg.Syncer = syncer
+		cfg.Remote = mem
+	} else {
+		syncer := engine.NewSyncer(localStore, nil, ms, engine.DefaultConfig())
+		syncer.SetSyncedHashStore(syncedHashStore)
+		cfg.Syncer = syncer
+	}
+	bs, err := engine.New(cfg)
+	if err != nil {
+		t.Fatalf("engine.New: %v", err)
+	}
+	if err := bs.Start(context.Background()); err != nil {
+		t.Fatalf("engine.Start: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+	return bs, dir
+}
+
+// corruptSegmentByte flips one byte inside the largest journal segment, at an
+// offset that lands in the first record's payload (well past the 64-byte segment
+// header). It writes through a fresh fd; the store's fd sees it via the shared
+// page cache. The flip breaks that record's payload CRC, which a verified warm
+// read must detect.
+func corruptSegmentByte(t *testing.T, journalDir string) {
+	t.Helper()
+	segs, err := filepath.Glob(filepath.Join(journalDir, "*.seg"))
+	if err != nil || len(segs) == 0 {
+		t.Fatalf("no journal segments under %s: %v", journalDir, err)
+	}
+	var path string
+	var best int64
+	for _, p := range segs {
+		fi, statErr := os.Stat(p)
+		if statErr != nil {
+			continue
+		}
+		if fi.Size() > best {
+			best, path = fi.Size(), p
+		}
+	}
+	if path == "" {
+		t.Fatalf("no non-empty segment under %s", journalDir)
+	}
+	const off = 2048 // inside the first record's payload for a multi-MiB write
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open segment: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	var b [1]byte
+	if _, err := f.ReadAt(b[:], off); err != nil {
+		t.Fatalf("read segment byte: %v", err)
+	}
+	b[0] ^= 0xFF
+	if _, err := f.WriteAt(b[:], off); err != nil {
+		t.Fatalf("write corrupt byte: %v", err)
+	}
+}
+
+// TestWarmReadSelfHeal_RemoteHeals writes a file, uploads it to the remote (no
+// eviction — the bytes stay warm locally), corrupts a byte in the local segment,
+// then reads the file back. With a remote present the corrupt warm read must
+// self-heal: re-fetch the covering chunk (BLAKE3-verified) and return the CORRECT
+// bytes, not the corrupt ones.
+func TestWarmReadSelfHeal_RemoteHeals(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	mem := remotememory.New()
+	bs, dir := buildSelfHealEngine(t, ms, mem)
+
+	rootHandle := createShare(t, ms, "heal")
+	pid, _ := createRealFile(t, ms, "heal", "f.bin", rootHandle)
+
+	const size = 2 * 1024 * 1024
+	src := make([]byte, size)
+	rand.New(rand.NewSource(0xC0FFEE)).Read(src) //nolint:gosec // deterministic fixture
+
+	if _, err := bs.WriteAt(ctx, pid, nil, src, 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if _, err := bs.Flush(ctx, pid); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := bs.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups: %v", err)
+	}
+	if err := bs.DrainAllUploads(ctx); err != nil {
+		t.Fatalf("DrainAllUploads: %v", err)
+	}
+
+	corruptSegmentByte(t, filepath.Join(dir, "journal"))
+
+	got := make([]byte, size)
+	n, err := bs.ReadAt(ctx, pid, nil, got, 0)
+	if err != nil {
+		t.Fatalf("ReadAt after corruption should self-heal, got: %v", err)
+	}
+	if n != size {
+		t.Fatalf("short read after heal: n=%d want=%d", n, size)
+	}
+	if !bytes.Equal(got, src) {
+		for i := range got {
+			if got[i] != src[i] {
+				t.Fatalf("self-heal returned wrong bytes: first diff at +%d got=0x%02x want=0x%02x", i, got[i], src[i])
+			}
+		}
+	}
+}
+
+// TestWarmReadSelfHeal_LocalOnlyFailsClosed corrupts a byte in a local-only
+// share's segment and asserts the verified warm read fails closed with
+// ErrIntegrityCheckFailed (maps to NFS3ERR_IO) — never zeros, never garbage.
+// There is no remote to heal from, so detection-only is the correct outcome.
+func TestWarmReadSelfHeal_LocalOnlyFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	bs, dir := buildSelfHealEngine(t, ms, nil) // local-only: no remote
+
+	rootHandle := createShare(t, ms, "heal")
+	pid, _ := createRealFile(t, ms, "heal", "f.bin", rootHandle)
+
+	const size = 2 * 1024 * 1024
+	src := make([]byte, size)
+	rand.New(rand.NewSource(0xBEEF)).Read(src) //nolint:gosec // deterministic fixture
+
+	if _, err := bs.WriteAt(ctx, pid, nil, src, 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if _, err := bs.Flush(ctx, pid); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	corruptSegmentByte(t, filepath.Join(dir, "journal"))
+
+	got := make([]byte, size)
+	_, err := bs.ReadAt(ctx, pid, nil, got, 0)
+	if err == nil {
+		t.Fatalf("local-only corrupt read must fail closed, got nil error")
+	}
+	if !errors.Is(err, block.ErrIntegrityCheckFailed) {
+		t.Fatalf("want ErrIntegrityCheckFailed, got: %v", err)
+	}
+}

--- a/pkg/block/journal/index.go
+++ b/pkg/block/journal/index.go
@@ -234,8 +234,12 @@ type piece struct {
 	dstEnd   int64
 	loc      SegmentLocation
 	subOff   int64
-	hole     bool
-	cold     bool
+	// recOff is the segment offset of the owning record's header, carried from the
+	// interval so a verified read can re-read the whole covering record and check
+	// its CRC without a second index resolve. Only meaningful for a warm piece.
+	recOff int64
+	hole   bool
+	cold   bool
 }
 
 // plan resolves the read [offset, offset+n) into contiguous pieces. Intervals
@@ -263,6 +267,7 @@ func (fi *fileIndex) plan(offset, n int64) []piece {
 		} else {
 			p.loc = iv.loc
 			p.subOff = pos - iv.fileOff
+			p.recOff = iv.recOff
 		}
 		pieces = append(pieces, p)
 		pos = spanEnd
@@ -333,12 +338,44 @@ func (s *Store) ReadAt(ctx context.Context, id FileID, offset int64, dst []byte)
 		default:
 			seg := segs[i]
 			seg.lastAccess.Store(s.clock.Now().UnixNano())
+			if s.verifyReads.Load() {
+				if rerr := s.verifiedRead(seg, p, out, id, offset); rerr != nil {
+					return int(p.dstStart), false, rerr
+				}
+				continue
+			}
 			if _, rerr := seg.fd.ReadAt(out, p.loc.Offset+p.subOff); rerr != nil {
 				return int(p.dstStart), false, fmt.Errorf("journal: read segment %d@%d: %w", p.loc.SegmentID, p.loc.Offset+p.subOff, rerr)
 			}
 		}
 	}
 	return len(dst), cold, nil
+}
+
+// verifiedRead serves a warm piece with integrity verification: it re-reads the
+// whole record that owns the piece (at p.recOff) and validates its header and
+// payload CRCs via readRecordAt, then copies the requested sub-range out of the
+// verified payload. This trades read amplification (the whole record vs the
+// sub-range) for detecting on-disk corruption a raw pread would return silently.
+// A CRC/torn failure — or an index/record extent that no longer agrees — returns
+// a *CorruptRangeError naming the file range so the caller heals from a remote
+// store or fails closed; it never copies unverified bytes into out.
+func (s *Store) verifiedRead(seg *segmentMeta, p piece, out []byte, id FileID, readOff int64) error {
+	corrupt := &CorruptRangeError{FileID: id, Offset: readOff + p.dstStart, Len: p.dstEnd - p.dstStart}
+	rec, _, err := readRecordAt(seg.fd, p.recOff, s.cfg.SegmentSize)
+	if err != nil {
+		return corrupt
+	}
+	// Offset of the piece's first byte within the verified payload: loc.Offset is
+	// the segment byte for the piece start (interval splits advance it), so
+	// subtracting the record's payload start yields the payload-relative index.
+	payloadStart := p.recOff + recordHeaderSize + int64(len(rec.fileID))
+	within := p.loc.Offset + p.subOff - payloadStart
+	if within < 0 || within+int64(len(out)) > int64(len(rec.payload)) {
+		return corrupt
+	}
+	copy(out, rec.payload[within:within+int64(len(out))])
+	return nil
 }
 
 // releaseGuards drops every held read guard, tolerating the nil holes/cold slots.

--- a/pkg/block/journal/index.go
+++ b/pkg/block/journal/index.go
@@ -366,6 +366,13 @@ func (s *Store) verifiedRead(seg *segmentMeta, p piece, out []byte, id FileID, r
 	if err != nil {
 		return corrupt
 	}
+	// The header and payload CRCs do not cover the FileID bytes, so a flipped
+	// FileID (or a stale recOff pointing at another file's record) would pass
+	// readRecordAt yet hand back the wrong file's bytes. Confirm the record we
+	// landed on is this file's before trusting its payload.
+	if string(rec.fileID) != string(id) {
+		return corrupt
+	}
 	// Offset of the piece's first byte within the verified payload: loc.Offset is
 	// the segment byte for the piece start (interval splits advance it), so
 	// subtracting the record's payload start yields the payload-relative index.

--- a/pkg/block/journal/record.go
+++ b/pkg/block/journal/record.go
@@ -134,7 +134,7 @@ type CorruptRangeError struct {
 }
 
 func (e *CorruptRangeError) Error() string {
-	return fmt.Sprintf("journal: corrupt range for %q [%d,%d): record CRC mismatch",
+	return fmt.Sprintf("journal: corrupt range for %q [%d,%d): record integrity check failed",
 		e.FileID, e.Offset, e.Offset+e.Len)
 }
 

--- a/pkg/block/journal/record.go
+++ b/pkg/block/journal/record.go
@@ -120,6 +120,24 @@ func decodeHeader(buf []byte) (recordHeader, error) {
 // surfaces as io.EOF, distinct from corruption.
 var errTornRecord = errors.New("journal: torn record")
 
+// CorruptRangeError reports that a verified warm read found on-disk corruption:
+// the covering record failed its structural/CRC check between recovery and this
+// read (bit rot, or a bug that mutated a valid segment's bytes). It names the
+// file range so the caller can heal it from a remote store or fail closed. The
+// journal is remote-agnostic and never decides heal-vs-fail itself, and it never
+// reports a corrupt range cold — cold zero-fills, which for a local-only read
+// would be a silent-zeros failure.
+type CorruptRangeError struct {
+	FileID FileID
+	Offset int64
+	Len    int64
+}
+
+func (e *CorruptRangeError) Error() string {
+	return fmt.Sprintf("journal: corrupt range for %q [%d,%d): record CRC mismatch",
+		e.FileID, e.Offset, e.Offset+e.Len)
+}
+
 // record is a fully decoded and CRC-verified record read back from a segment.
 type record struct {
 	header  recordHeader

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -159,8 +159,21 @@ type Store struct {
 	// Zero value = enabled, the safe default.
 	evictionDisabled atomic.Bool
 
+	// verifyReads turns on per-read record-CRC verification of warm reads (opt-in
+	// for durable tiers; off for the fast writeback path). When off, ReadAt serves
+	// a warm piece with a single raw pread and does no extra work. Set once before
+	// the store serves reads.
+	verifyReads atomic.Bool
+
 	closed atomic.Bool
 }
+
+// SetVerifyReads enables or disables per-read record-CRC verification of warm
+// reads. Durable tiers turn it on so on-disk corruption between recovery and a
+// warm read is caught (and healed/failed-closed by the caller) instead of
+// returning silently-wrong bytes; the writeback tier leaves it off to keep the
+// raw fast read. Called once at share construction, before the store serves reads.
+func (s *Store) SetVerifyReads(v bool) { s.verifyReads.Store(v) }
 
 // Open opens (or creates) a Store rooted at dir. A fresh directory gets one
 // active segment per shard. A populated directory is recovered: the active

--- a/pkg/block/journal/verify_read_test.go
+++ b/pkg/block/journal/verify_read_test.go
@@ -1,0 +1,104 @@
+package journal
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"testing"
+)
+
+// corruptFirstPayloadByte flips a single payload byte of id's first interval
+// directly in the backing segment file, simulating on-disk corruption of a valid
+// record between recovery and a warm read. It writes through a fresh fd; the
+// store's own fd sees the change via the shared page cache.
+func corruptFirstPayloadByte(t *testing.T, s *Store, id FileID) {
+	t.Helper()
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	fi := sh.index[id]
+	if fi == nil || len(fi.ivs) == 0 {
+		sh.mu.Unlock()
+		t.Fatalf("no interval for %q to corrupt", id)
+	}
+	iv := fi.ivs[0]
+	segID := iv.loc.SegmentID
+	off := iv.loc.Offset // first payload byte of the interval
+	sh.mu.Unlock()
+
+	f, err := os.OpenFile(s.segPath(segID), os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open segment: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	var b [1]byte
+	if _, err := f.ReadAt(b[:], off); err != nil {
+		t.Fatalf("read payload byte: %v", err)
+	}
+	b[0] ^= 0xFF
+	if _, err := f.WriteAt(b[:], off); err != nil {
+		t.Fatalf("write corrupt byte: %v", err)
+	}
+}
+
+// TestVerifiedReadDetectsCorruption asserts that with VerifyReads on, a warm read
+// of a record whose on-disk payload was corrupted after write fails closed with a
+// *CorruptRangeError — never silent bytes, never a cold zero-fill.
+func TestVerifiedReadDetectsCorruption(t *testing.T) {
+	ctx := context.Background()
+	s := testStore(t, Config{})
+	s.SetVerifyReads(true)
+
+	payload := bytes.Repeat([]byte("dittofs-verify-"), 512) // ~7.5 KiB
+	if err := s.WriteAt(ctx, "f1", 0, payload); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+
+	// Baseline: a verified read of the intact record round-trips.
+	got := make([]byte, len(payload))
+	if _, cold, err := s.ReadAt(ctx, "f1", 0, got); err != nil || cold {
+		t.Fatalf("baseline verified read: err=%v cold=%v", err, cold)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("baseline verified read mismatch")
+	}
+
+	corruptFirstPayloadByte(t, s, "f1")
+
+	clear(got)
+	_, cold, err := s.ReadAt(ctx, "f1", 0, got)
+	var cre *CorruptRangeError
+	if !errors.As(err, &cre) {
+		t.Fatalf("want *CorruptRangeError, got err=%v", err)
+	}
+	if cold {
+		t.Fatalf("a corrupt range must never be reported cold (cold zero-fills)")
+	}
+	if cre.FileID != "f1" {
+		t.Fatalf("CorruptRangeError names wrong file: %+v", cre)
+	}
+}
+
+// TestUnverifiedReadReturnsRawBytes documents that the default (writeback) fast
+// path does NOT verify: it serves the corrupted byte verbatim with a single raw
+// read and no error. That the corrupted byte leaks through is the proof the off
+// path took no covering-record read (a verifying read would have CRC-failed).
+func TestUnverifiedReadReturnsRawBytes(t *testing.T) {
+	ctx := context.Background()
+	s := testStore(t, Config{}) // VerifyReads defaults off
+
+	payload := bytes.Repeat([]byte("dittofs-verify-"), 512)
+	if err := s.WriteAt(ctx, "f1", 0, payload); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	corruptFirstPayloadByte(t, s, "f1")
+
+	got := make([]byte, len(payload))
+	n, cold, err := s.ReadAt(ctx, "f1", 0, got)
+	if err != nil || cold || n != len(payload) {
+		t.Fatalf("raw read: err=%v cold=%v n=%d", err, cold, n)
+	}
+	if bytes.Equal(got, payload) {
+		t.Fatalf("expected the corrupted byte to leak through the unverified fast path")
+	}
+}

--- a/pkg/block/journal/verify_read_test.go
+++ b/pkg/block/journal/verify_read_test.go
@@ -79,6 +79,55 @@ func TestVerifiedReadDetectsCorruption(t *testing.T) {
 	}
 }
 
+// TestVerifiedReadDetectsFileIDCorruption asserts that a flipped FileID byte is
+// caught even though neither the header CRC nor the payload CRC covers the FileID
+// bytes. Without the record-belongs-to-this-file check the read would pass CRC
+// and hand back the wrong file's payload silently.
+func TestVerifiedReadDetectsFileIDCorruption(t *testing.T) {
+	ctx := context.Background()
+	s := testStore(t, Config{})
+	s.SetVerifyReads(true)
+
+	payload := bytes.Repeat([]byte("dittofs-verify-"), 512)
+	if err := s.WriteAt(ctx, "f1", 0, payload); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+
+	// Flip a byte inside the record's FileID field (right after the header),
+	// which the CRCs do not cover.
+	sh := s.shardFor("f1")
+	sh.mu.Lock()
+	fi := sh.index["f1"]
+	iv := fi.ivs[0]
+	segID := iv.loc.SegmentID
+	fidOff := iv.recOff + recordHeaderSize // first FileID byte
+	sh.mu.Unlock()
+
+	f, err := os.OpenFile(s.segPath(segID), os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open segment: %v", err)
+	}
+	var b [1]byte
+	if _, err := f.ReadAt(b[:], fidOff); err != nil {
+		t.Fatalf("read fileID byte: %v", err)
+	}
+	b[0] ^= 0xFF
+	if _, err := f.WriteAt(b[:], fidOff); err != nil {
+		t.Fatalf("write corrupt fileID byte: %v", err)
+	}
+	_ = f.Close()
+
+	got := make([]byte, len(payload))
+	_, cold, err := s.ReadAt(ctx, "f1", 0, got)
+	var cre *CorruptRangeError
+	if !errors.As(err, &cre) {
+		t.Fatalf("want *CorruptRangeError for flipped FileID, got err=%v", err)
+	}
+	if cold {
+		t.Fatalf("a corrupt range must never be reported cold")
+	}
+}
+
 // TestUnverifiedReadReturnsRawBytes documents that the default (writeback) fast
 // path does NOT verify: it serves the corrupted byte verbatim with a single raw
 // read and no error. That the corrupted byte leaks through is the proof the off

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1148,6 +1148,12 @@ func (s *Service) createBlockStoreForShare(
 		writeback, requireDurableCommit := resolveDurabilityTier(localStoreCfg, config.Name)
 		bs.SetRequireDurableCommit(requireDurableCommit)
 		share.writeback = writeback
+		// Durable tiers (local-durable and remote) verify warm reads per-record so
+		// on-disk corruption is caught and healed/failed-closed instead of returning
+		// silently-wrong bytes; the writeback tier keeps the raw fast read.
+		if vr, ok := localStore.(interface{ SetVerifyReads(bool) }); ok {
+			vr.SetVerifyReads(!writeback)
+		}
 	} else {
 		logger.Warn("failed to read local block store config for durability tier; defaulting to local",
 			"share", config.Name, "error", cfgErr)


### PR DESCRIPTION
aa
## The gap

`journal.Store.ReadAt` served a warm read piece with a raw `seg.fd.ReadAt(out, loc.Offset+subOff)` — **no per-read integrity check**. Integrity today = startup-recovery CRC + remote cold-fetch BLAKE3. On-disk corruption of a valid segment *between recovery and a warm read* (bit rot, or a bug mutating cached segment bytes) returned silently-wrong bytes — the worst failure mode. The Wall-A switchover dropped the old per-read verify deliberately, for read speed.

## The design (tier-gated CRC32 + typed error + engine heal)

Opt-in, layered so the journal stays remote-agnostic and the default path stays byte-for-byte the current fast raw read.

- **Journal `Store.VerifyReads`** (set at share construction from the resolved durability tier): `writeback → false` (raw fast read, **unchanged**); `local-durable` and `remote → true`.
- When on, `ReadAt`s warm-piece branch reads the **covering record + trailing CRC** (via the existing `readRecordAt`, reachable through the interval `recOff` already carried on the plan — no second resolve), verifies the per-record CRC32, then slices out the requested sub-range. This adds read amplification (whole record vs sub-range) — the accepted cost of the opt-in tiers.
- On mismatch the journal returns a typed **`*CorruptRangeError{FileID, Offset, Len}`** — **never** silent bytes, and **never** `cold` (cold zero-fills, which for a local-only read is the silent-zeros failure mode).
- The **engine** read path catches the typed error: remote present → invalidate + re-fetch the range through the **existing** BLAKE3-verified hydrate path (`ensureAndReadFromLocal`; the fresh `Hydrate` supersedes the corrupt interval by version) → return healed bytes; local-only (`!HasRemoteStore()`) → **fail closed** with `ErrIntegrityCheckFailed` (maps to NFS3ERR_IO). No parallel fetch; the existing cold/hydrate machinery is reused verbatim.

## The default (writeback) path is unchanged

When `VerifyReads` is off, the guard (`s.verifyReads.Load()`) is false and control goes straight to the original raw `seg.fd.ReadAt` — byte-identical, no extra pread/CRC/allocation (only an atomic-bool load). A unit test corrupts a byte and asserts the off path returns the raw corrupt byte with no error (proving it took no covering-record read).

## Tests (real journal store, run under `-race`)

- **remote-backed + verify on** — a warm read of a byte corrupted on disk after upload **self-heals**: re-fetches from remote and returns the correct bytes.
- **local-only + verify on** — the warm read **fails closed** (`ErrIntegrityCheckFailed`), never zeros/garbage.
- **verify off (writeback default)** — the read returns raw (unverified) bytes, documenting the fast path does not verify.
- journal-level: verify-on detection returns `*CorruptRangeError` with `cold=false`.

`go test ./pkg/block/... -race` → 880 passed. Lint/vet/integration build clean.

Part of the Wall-A/three-wall integrity follow-up (does not close it).

> Note: also drops two `FSStoreOptions` knobs (`rollup_workers`/`stabilization_ms`, removed by #1794) still set by the clone local-only test — the engine test package did not build on develop without this.