### PR TITLE
perf(journal): overlap within-file carve block commits (#1717)

### DIFF
--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -401,9 +401,12 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 		}
 	}
 
-	if packErr != nil {
-		// Abandon the half-packed block (return its slot/buffer) and drain the
-		// blocks already in flight; do not advance the watermark to the run end.
+	if packErr != nil || disp.aborted() {
+		// A read/dedup error (packErr) or an in-flight commit failure (aborted)
+		// ends the run. Abandon the half-packed block (return its slot/buffer) and
+		// drain the blocks already in flight, but submit nothing more: advancing
+		// the watermark or committing the tail past a failure only adds orphan
+		// uploads. disp.wait returns the commit error in watermark order.
 		disp.discard(arenap, arena)
 		if err := disp.wait(); err != nil {
 			return err

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -21,11 +21,12 @@ var carveScratchPool = sync.Pool{New: func() any {
 	return &b
 }}
 
-// carveArenaPool recycles the arena backing the pending chunk copies handed to the
-// sink. Both production sinks consume CarveChunk.Data synchronously inside
-// CommitBlock (localBlockSink reads only len; engineBlockSink seals/frames into its
-// own buffer before returning) — neither retains it — so the arena is safe to reuse
-// once flush's CommitBlock returns and pending is cleared.
+// carveArenaPool recycles the per-block arenas backing the pending chunk copies
+// handed to the sink. Both production sinks consume CarveChunk.Data synchronously
+// inside CommitBlock (localBlockSink reads only len; engineBlockSink seals/frames
+// into its own buffer before returning) — neither retains it — so a block's arena
+// is safe to return to the pool once its CommitBlock has returned. Each concurrent
+// block owns a distinct arena so overlapping commits never share backing bytes.
 var carveArenaPool = sync.Pool{New: func() any {
 	var b []byte
 	return &b
@@ -40,9 +41,14 @@ var carveArenaPool = sync.Pool{New: func() any {
 //  2. Stream the dirty bytes through FastCDC -> BLAKE3 -> per-share dedup; novel
 //     chunks accumulate into a block-sized batch.
 //  3. At CarveBlockSize (or the end of a contiguous run) hand the novel chunks to
-//     the sink, which seals, frames, uploads and atomically commits them.
-//  4. Only after the commit returns, flip each carved record's synced flag in
-//     place with a one-byte pwrite (the header CRC excludes Flags, so no rewrite).
+//     the sink, which seals, frames, uploads and atomically commits them. Successive
+//     blocks of one file commit concurrently through a bounded worker pool
+//     (CarveUploadConcurrency) so a single large file's carve is not one PutBlock
+//     at a time; packing itself stays sequential.
+//  4. Only after a block's commit returns — and after every earlier block flipped —
+//     flip each carved record's synced flag in place with a one-byte pwrite (the
+//     header CRC excludes Flags, so no rewrite). The dispatcher applies the flips in
+//     submission order regardless of which upload finishes first.
 //
 // Flipping strictly after the commit is the crash-safety invariant: a crash
 // between the two leaves the records synced=false, so restart re-carves them, and
@@ -247,17 +253,18 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 
 	fileOff := run[0].fileOff
 	flipIdx := 0
-	var pending []CarveChunk
-	var pendingBytes int64
 	// Offsets of every chunk this run tiles (novel or deduped), so the run-end
 	// reap keeps this run's own rows and deletes only superseded ones (#953).
 	newOffsets := make(map[int64]struct{})
 
-	// arena backs every pending chunk copy in one recycled block-sized buffer, so
-	// a run allocates no per-chunk scratch. It holds at most one block's worth of
-	// pending bytes: pendingBytes flushes at CarveBlockSize and one appended chunk
-	// is at most MaxChunkSize, so CarveBlockSize + MaxChunkSize bounds it.
-	// arenaOff resets after each flush, once CommitBlock has consumed the copies.
+	// disp overlaps successive blocks' CommitBlock (upload + commit) while packing
+	// stays sequential. It owns the bounded worker pool, the per-block buffers and
+	// the ordered flip chain; flush hands it a completed block or a bare watermark.
+	disp := newCarveDispatcher(ctx, s, sh, id, run, res, &flipIdx)
+
+	// Each packed block gets its OWN buffer (cap one block plus one overhang chunk)
+	// so its bytes stay live while its CommitBlock runs concurrently with the next
+	// block's packing — the recycled arena of the sequential path can't do that.
 	// Compute in int64 and clamp before the int conversion so a pathological
 	// CarveBlockSize can't silently wrap on 32-bit platforms.
 	arenaCap64 := s.cfg.CarveBlockSize + int64(chunker.MaxChunkSize)
@@ -265,32 +272,36 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 		arenaCap64 = math.MaxInt
 	}
 	arenaCap := int(arenaCap64)
-	arenap := carveArenaPool.Get().(*[]byte)
-	arena := *arenap
-	if cap(arena) < arenaCap {
-		arena = make([]byte, arenaCap)
-	}
-	arena = arena[:cap(arena)]
-	arenaOff := 0
-	defer func() {
-		*arenap = arena
-		carveArenaPool.Put(arenap)
-	}()
 
-	// flush commits the buffered novel chunks (if any) then, since everything up
-	// to watermark is now durable, flips the run's records that end there. The
-	// commit strictly precedes the flip: that is the crash-safety ordering.
-	flush := func(watermark int64) error {
-		if len(pending) > 0 {
-			if err := s.sink.CommitBlock(ctx, pending); err != nil {
-				return err
-			}
-			res.BlocksWritten++
-			pending = nil
-			pendingBytes = 0
-			arenaOff = 0
+	// The block currently being packed. arena is its private buffer (nil until the
+	// first novel chunk claims a pool buffer and a concurrency slot); arenaOff is
+	// the fill cursor. On any early exit these are returned to disp so the slot and
+	// buffer are not leaked.
+	var (
+		pending  []CarveChunk
+		arenap   *[]byte
+		arena    []byte
+		arenaOff int
+	)
+	ensureArena := func() error {
+		if arenap != nil {
+			return nil
 		}
-		return s.flipUpTo(sh, id, run, &flipIdx, watermark)
+		p, err := disp.acquire(arenaCap)
+		if err != nil {
+			return err
+		}
+		arenap, arena, arenaOff = p, *p, 0
+		return nil
+	}
+
+	// flush hands the packed block (if any) and the watermark to the dispatcher,
+	// which commits then flips in submission order. Packing continues immediately;
+	// the commit and flip happen on the pool. Ownership of the buffer moves to the
+	// dispatcher, so the local arena state resets to "no block".
+	flush := func(watermark int64) {
+		disp.submit(pending, arenap, arena, watermark)
+		pending, arenap, arena, arenaOff = nil, nil, nil, 0
 	}
 
 	// buf accumulates bytes for the chunker; it never exceeds one max chunk, so
@@ -302,10 +313,21 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 		*bufp = buf
 		carveScratchPool.Put(bufp)
 	}()
+
+	// packErr is the first error hit while packing (read/dedup/context). It stops
+	// packing but the already-dispatched blocks still drain via disp.wait so no
+	// goroutine or buffer leaks; disp.wait folds it together with any commit error.
+	var packErr error
 	eof := false
 	for {
 		if err := ctx.Err(); err != nil {
-			return err
+			packErr = err
+			break
+		}
+		// A commit already failed: stop packing so the watermark can't advance past
+		// the failed block. In-flight commits drain in disp.wait.
+		if disp.aborted() {
+			break
 		}
 		for !eof && len(buf) < chunker.MaxChunkSize {
 			n, err := rr.Read(buf[len(buf):cap(buf)])
@@ -317,8 +339,12 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 				break
 			}
 			if err != nil {
-				return err
+				packErr = err
+				break
 			}
+		}
+		if packErr != nil {
+			break
 		}
 		if len(buf) == 0 {
 			break
@@ -332,18 +358,28 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 		}
 
 		h := ChunkHash(blake3.Sum256(buf[:boundary]))
+		// Dedup consults the committed synced-hash oracle. A block being committed
+		// concurrently has NOT yet marked its hashes durable, so this never observes
+		// a sibling block's uncommitted hash as durable — at worst a duplicate chunk
+		// is re-packed, which the content-addressed commit collapses to a no-op.
 		durable, err := s.deduper.IsChunkDurable(ctx, h)
 		if err != nil {
-			return err
+			packErr = err
+			break
 		}
 		if !durable {
-			// Bound proof: pendingBytes < CarveBlockSize before this append (else
-			// the prior iteration flushed and reset arenaOff), and boundary <=
-			// MaxChunkSize, so arenaOff+boundary <= CarveBlockSize-1+MaxChunkSize <
-			// cap. The grow is a fail-loud belt: if that invariant ever breaks (e.g.
-			// a config change), realloc rather than slice out of bounds. Already-
-			// pending Data slices keep pointing at the old backing (still live), so
-			// no copy is needed — the new chunk just lands in the larger arena.
+			if err := ensureArena(); err != nil {
+				packErr = err
+				break
+			}
+			// Bound proof: this block's bytes < CarveBlockSize before this append
+			// (else the prior iteration flushed and started a fresh arena), and
+			// boundary <= MaxChunkSize, so arenaOff+boundary <= CarveBlockSize-1+
+			// MaxChunkSize <= cap. The grow is a fail-loud belt: if that invariant
+			// ever breaks (e.g. a config change), realloc rather than slice out of
+			// bounds. Already-pending Data slices keep pointing at the old backing
+			// (still live), so no copy is needed — the new chunk lands in the larger
+			// arena and the grown slice ships to the dispatcher.
 			if arenaOff+boundary > cap(arena) {
 				arena = make([]byte, arenaOff+boundary)
 			}
@@ -351,25 +387,34 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 			copy(data, buf[:boundary])
 			arenaOff += boundary
 			pending = append(pending, CarveChunk{Hash: h, FileID: id, FileOffset: fileOff, Data: data})
-			pendingBytes += int64(boundary)
 			res.BytesCarved += int64(boundary)
 		}
 		newOffsets[fileOff] = struct{}{}
 		fileOff += int64(boundary)
 		buf = append(buf[:0], buf[boundary:]...)
 
-		if pendingBytes >= s.cfg.CarveBlockSize {
-			if err := flush(fileOff); err != nil {
-				return err
-			}
+		if int64(arenaOff) >= s.cfg.CarveBlockSize {
+			flush(fileOff)
 		}
 		if eof && len(buf) == 0 {
 			break
 		}
 	}
+
+	if packErr != nil {
+		// Abandon the half-packed block (return its slot/buffer) and drain the
+		// blocks already in flight; do not advance the watermark to the run end.
+		disp.discard(arenap, arena)
+		if err := disp.wait(); err != nil {
+			return err
+		}
+		return packErr
+	}
+
 	// Tail: commit any remainder and flip through the end of the run (records
-	// covered only by already-durable chunks flip here too).
-	if err := flush(run[len(run)-1].end()); err != nil {
+	// covered only by already-durable chunks flip here too, via the bare watermark).
+	flush(run[len(run)-1].end())
+	if err := disp.wait(); err != nil {
 		return err
 	}
 	// #953: with every row this run produced now committed, reap the manifest rows

--- a/pkg/block/journal/carve_dispatch.go
+++ b/pkg/block/journal/carve_dispatch.go
@@ -1,0 +1,164 @@
+package journal
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+)
+
+// carveDispatcher overlaps the CommitBlock (upload + commit) of one file's
+// successive packed blocks while preserving the crash-safety ordering. Packing
+// stays sequential in carveRun; the dispatcher only parallelizes the commits and
+// then applies each block's synced flip in submission order.
+//
+// Two invariants make this safe to run concurrently:
+//
+//  1. Commit strictly precedes flip, per block. A worker calls flipUpTo only
+//     after its own CommitBlock returned nil, so a record flips to synced only
+//     once its block is durable remotely.
+//  2. Flips apply in submission (watermark) order even if a later block's upload
+//     finishes first. Each worker waits on its predecessor's completion channel
+//     before flipping, so flipIdx advances monotonically and a mid-run commit
+//     failure stops the watermark at the failed block: every later worker sees
+//     proceed=false and skips its flip (its already-uploaded block becomes a
+//     GC-reclaimable orphan, matching the PutBlock-first semantics).
+//
+// Concurrency and peak RAM are bounded by sem: a block holds a slot (and its own
+// buffer) from the moment it starts packing until its flip completes, so at most
+// cap(sem) blocks — and thus CommitBlocks — are in flight, and peak carve RAM is
+// cap(sem) x (CarveBlockSize + one overhang chunk).
+type carveDispatcher struct {
+	ctx     context.Context
+	s       *Store
+	sh      *shard
+	id      FileID
+	run     []interval
+	res     *CarveResult
+	flipIdx *int // advanced only by the flipping worker, one at a time via the chain
+
+	sem  chan struct{} // bounds in-flight blocks (buffers + concurrent commits)
+	prev chan bool     // completion of the last-submitted block; feeds the next worker
+	wg   sync.WaitGroup
+
+	mu       sync.Mutex
+	firstErr error
+	abort    atomic.Bool
+}
+
+func newCarveDispatcher(ctx context.Context, s *Store, sh *shard, id FileID, run []interval, res *CarveResult, flipIdx *int) *carveDispatcher {
+	// A pre-satisfied predecessor so the first block flips as soon as it commits.
+	prev := make(chan bool, 1)
+	prev <- true
+	return &carveDispatcher{
+		ctx:     ctx,
+		s:       s,
+		sh:      sh,
+		id:      id,
+		run:     run,
+		res:     res,
+		flipIdx: flipIdx,
+		sem:     make(chan struct{}, s.cfg.CarveUploadConcurrency),
+		prev:    prev,
+	}
+}
+
+// acquire reserves a concurrency slot and returns a pooled buffer with capacity
+// at least arenaCap for the next block being packed. It blocks while the window
+// is full and returns the context error if it is cancelled meanwhile. The slot
+// is released by the block's worker (or by discard for a block never submitted).
+func (d *carveDispatcher) acquire(arenaCap int) (*[]byte, error) {
+	select {
+	case d.sem <- struct{}{}:
+	case <-d.ctx.Done():
+		return nil, d.ctx.Err()
+	}
+	p := carveArenaPool.Get().(*[]byte)
+	a := *p
+	if cap(a) < arenaCap {
+		a = make([]byte, arenaCap)
+	}
+	*p = a[:cap(a)]
+	return p, nil
+}
+
+// submit hands a packed block to the pool. chunks may be empty and arenap nil,
+// which submits a bare watermark advance (records covered only by already-durable
+// chunks flip there) — that carries no buffer and holds no slot. arena is the
+// block's final backing slice (it may have grown past the pooled buffer while
+// packing), stored back into the pool on completion.
+func (d *carveDispatcher) submit(chunks []CarveChunk, arenap *[]byte, arena []byte, watermark int64) {
+	mine := make(chan bool, 1)
+	prev := d.prev
+	d.prev = mine
+	d.wg.Add(1)
+	go d.commitAndFlip(chunks, arenap, arena, watermark, prev, mine)
+}
+
+func (d *carveDispatcher) commitAndFlip(chunks []CarveChunk, arenap *[]byte, arena []byte, watermark int64, prev, mine chan bool) {
+	defer d.wg.Done()
+	if arenap != nil {
+		// Free the buffer and the slot only after CommitBlock has consumed the
+		// Data slices (the sink copies them before returning) and the flip ran.
+		defer func() {
+			*arenap = arena
+			carveArenaPool.Put(arenap)
+			<-d.sem
+		}()
+	}
+
+	var commitErr error
+	if len(chunks) > 0 {
+		commitErr = d.s.sink.CommitBlock(d.ctx, chunks)
+	}
+
+	// Wait for the predecessor before flipping so flips apply in watermark order.
+	proceed := <-prev
+	ok := proceed && commitErr == nil
+	switch {
+	case ok:
+		if err := d.s.flipUpTo(d.sh, d.id, d.run, d.flipIdx, watermark); err != nil {
+			d.setErr(err)
+			ok = false
+		} else if len(chunks) > 0 {
+			d.res.BlocksWritten++
+		}
+	case proceed && commitErr != nil:
+		// This block is the first failure on the ordered chain: record it. Its
+		// predecessors already flipped; the watermark stops here.
+		d.setErr(commitErr)
+	}
+	mine <- ok
+}
+
+// discard returns an acquired-but-never-submitted buffer and its slot, used when
+// packing aborts mid-block.
+func (d *carveDispatcher) discard(arenap *[]byte, arena []byte) {
+	if arenap == nil {
+		return
+	}
+	*arenap = arena
+	carveArenaPool.Put(arenap)
+	<-d.sem
+}
+
+// wait blocks until every submitted block has committed and flipped (or drained
+// after a failure) and returns the first error observed, if any.
+func (d *carveDispatcher) wait() error {
+	d.wg.Wait()
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.firstErr
+}
+
+// aborted reports whether a commit or flip has already failed, so packing can
+// stop feeding new blocks past the failed watermark.
+func (d *carveDispatcher) aborted() bool { return d.abort.Load() }
+
+func (d *carveDispatcher) setErr(err error) {
+	d.mu.Lock()
+	if d.firstErr == nil {
+		d.firstErr = err
+	}
+	d.mu.Unlock()
+	d.abort.Store(true)
+}

--- a/pkg/block/journal/carve_dispatch.go
+++ b/pkg/block/journal/carve_dispatch.go
@@ -109,6 +109,13 @@ func (d *carveDispatcher) commitAndFlip(chunks []CarveChunk, arenap *[]byte, are
 	var commitErr error
 	if len(chunks) > 0 {
 		commitErr = d.s.sink.CommitBlock(d.ctx, chunks)
+		if commitErr != nil {
+			// Stop packing as soon as any commit fails, even if this block is not
+			// yet the head of the flip chain, so no further blocks are packed and
+			// uploaded past a known failure. firstErr is still recorded in watermark
+			// order below (only the earliest-watermark failure reaches setErr).
+			d.abort.Store(true)
+		}
 	}
 
 	// Wait for the predecessor before flipping so flips apply in watermark order.

--- a/pkg/block/journal/carve_dispatch_test.go
+++ b/pkg/block/journal/carve_dispatch_test.go
@@ -1,0 +1,305 @@
+package journal
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block/chunker"
+)
+
+var errCtrlCommit = errors.New("ctrl sink: forced commit failure")
+
+// ctrlSink is a BlockSink that parks each CommitBlock on a per-block gate so a
+// test can observe and control when uploads complete. It counts in-flight commits
+// (to bound concurrency), can fail a chosen block, and marks committed hashes
+// durable on the paired deduper. It deliberately does NOT implement
+// supersededReaper, so carve skips the manifest reap.
+type ctrlSink struct {
+	dedup *fakeDeduper
+
+	mu          sync.Mutex
+	inFlight    int
+	maxInFlight int
+	blocks      int
+	openAll     bool                    // once set, commits no longer park on a gate
+	gates       map[int64]chan struct{} // block first-offset -> release gate
+	failOff     int64                   // first-offset of the block to fail; -1 = none
+
+	arrived chan int64 // first-offset of each block as its CommitBlock starts
+}
+
+func newCtrlSink(d *fakeDeduper) *ctrlSink {
+	return &ctrlSink{
+		dedup:   d,
+		gates:   map[int64]chan struct{}{},
+		failOff: -1,
+		arrived: make(chan int64, 512),
+	}
+}
+
+func (s *ctrlSink) CommitBlock(_ context.Context, chunks []CarveChunk) error {
+	off := chunks[0].FileOffset
+	s.mu.Lock()
+	s.inFlight++
+	if s.inFlight > s.maxInFlight {
+		s.maxInFlight = s.inFlight
+	}
+	var gate chan struct{}
+	if !s.openAll {
+		gate = make(chan struct{})
+		s.gates[off] = gate
+	}
+	s.mu.Unlock()
+
+	s.arrived <- off
+	if gate != nil {
+		<-gate
+	}
+
+	s.mu.Lock()
+	s.inFlight--
+	fail := off == s.failOff
+	if !fail {
+		s.blocks++
+		for _, c := range chunks {
+			s.dedup.markDurable(c.Hash)
+		}
+	}
+	s.mu.Unlock()
+	if fail {
+		return errCtrlCommit
+	}
+	return nil
+}
+
+// release unblocks one parked block by its first-offset.
+func (s *ctrlSink) release(off int64) {
+	s.mu.Lock()
+	g := s.gates[off]
+	delete(s.gates, off)
+	s.mu.Unlock()
+	if g != nil {
+		close(g)
+	}
+}
+
+// releaseAll unblocks every parked block and lets any later commit run ungated.
+func (s *ctrlSink) releaseAll() {
+	s.mu.Lock()
+	s.openAll = true
+	gs := make([]chan struct{}, 0, len(s.gates))
+	for off, g := range s.gates {
+		gs = append(gs, g)
+		delete(s.gates, off)
+	}
+	s.mu.Unlock()
+	for _, g := range gs {
+		close(g)
+	}
+}
+
+func (s *ctrlSink) peak() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.maxInFlight
+}
+
+// ctrlStore wires a store with a ctrlSink and returns both.
+func ctrlStore(t *testing.T, window int) (*Store, *ctrlSink) {
+	t.Helper()
+	cfg := Config{
+		CarveBlockSize:         32 << 10,
+		CarveUploadConcurrency: window,
+		ChunkParams:            chunker.Params{Min: 4 << 10, Avg: 8 << 10, Max: 16 << 10},
+	}
+	s, err := Open(t.TempDir(), cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	dd := newFakeDeduper()
+	sink := newCtrlSink(dd)
+	s.SetCarveTargets(dd, sink)
+	return s, sink
+}
+
+// writeAdjacent lays down nWrites adjacent chunkBytes-sized writes so the file is
+// one contiguous run of many intervals — the granularity flipUpTo advances at, so
+// a mid-run watermark flips a subset of intervals (a single big write would be one
+// interval that only flips at run end).
+func writeAdjacent(t *testing.T, s *Store, id FileID, nWrites, chunkBytes int) []byte {
+	t.Helper()
+	ctx := context.Background()
+	data := make([]byte, 0, nWrites*chunkBytes)
+	for i := 0; i < nWrites; i++ {
+		b := randBytes(chunkBytes, int64(i)+1)
+		if err := s.WriteAt(ctx, id, int64(i*chunkBytes), b); err != nil {
+			t.Fatalf("WriteAt %d: %v", i, err)
+		}
+		data = append(data, b...)
+	}
+	return data
+}
+
+func carveAsync(s *Store) <-chan error {
+	ch := make(chan error, 1)
+	go func() {
+		_, err := s.Carve(context.Background(), CarveOptions{Force: true})
+		ch <- err
+	}()
+	return ch
+}
+
+func drainArrivals(sink *ctrlSink, quiet time.Duration) []int64 {
+	var offs []int64
+	for {
+		select {
+		case off := <-sink.arrived:
+			offs = append(offs, off)
+		case <-time.After(quiet):
+			return offs
+		}
+	}
+}
+
+func minOffset(offs []int64) int64 {
+	m := offs[0]
+	for _, o := range offs[1:] {
+		if o < m {
+			m = o
+		}
+	}
+	return m
+}
+
+// TestCarveConcurrencyBounded proves successive blocks of one file commit
+// concurrently up to the window, and never beyond it.
+func TestCarveConcurrencyBounded(t *testing.T) {
+	const window = 4
+	s, sink := ctrlStore(t, window)
+	// 512 KiB across 4 KiB writes -> ~16 blocks at CarveBlockSize 32 KiB, well
+	// above the window so the bound is actually exercised.
+	writeAdjacent(t, s, "f", 128, 4<<10)
+
+	done := carveAsync(s)
+
+	// Exactly window commits should start and then block: drain window arrivals,
+	// then assert no (window+1)th commit is in flight while all window are held.
+	for i := 0; i < window; i++ {
+		select {
+		case <-sink.arrived:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("only %d of %d commits reached the sink", i, window)
+		}
+	}
+	select {
+	case off := <-sink.arrived:
+		t.Fatalf("more than window=%d commits in flight (extra at off %d)", window, off)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	sink.releaseAll()
+	if err := <-done; err != nil {
+		t.Fatalf("carve: %v", err)
+	}
+	if got := sink.peak(); got != window {
+		t.Fatalf("peak in-flight commits = %d, want exactly the window %d", got, window)
+	}
+	if s.UnsyncedBytes() != 0 {
+		t.Fatalf("post-carve unsynced=%d want 0", s.UnsyncedBytes())
+	}
+}
+
+// TestCarveFlipsInWatermarkOrder proves a later block whose upload finishes first
+// cannot flip ahead of an earlier, still-uploading block: while the first block is
+// held, no record flips even though every later block has committed.
+func TestCarveFlipsInWatermarkOrder(t *testing.T) {
+	const window = 64 // >= block count, so every block is in flight at once
+	s, sink := ctrlStore(t, window)
+	data := writeAdjacent(t, s, "f", 128, 4<<10)
+	full := int64(len(data))
+
+	done := carveAsync(s)
+
+	offs := drainArrivals(sink, 300*time.Millisecond)
+	if len(offs) < 2 {
+		t.Fatalf("expected multiple blocks in flight, got %d", len(offs))
+	}
+	first := minOffset(offs)
+
+	// Release every block except the first (lowest watermark). They commit, but
+	// the ordered flip gate holds their flips behind the first block.
+	for _, off := range offs {
+		if off != first {
+			sink.release(off)
+		}
+	}
+	// Give the freed commits time to finish; nothing may flip yet.
+	time.Sleep(200 * time.Millisecond)
+	if u := s.UnsyncedBytes(); u != full {
+		t.Fatalf("records flipped before the earliest block committed: unsynced=%d want %d", u, full)
+	}
+
+	// Releasing the first block lets the whole chain flip in order.
+	sink.release(first)
+	if err := <-done; err != nil {
+		t.Fatalf("carve: %v", err)
+	}
+	if u := s.UnsyncedBytes(); u != 0 {
+		t.Fatalf("post-carve unsynced=%d want 0", u)
+	}
+	if f := recRawFlags(t, s, "f", 0); f&flagSynced == 0 {
+		t.Fatalf("record not flipped synced on disk: flags=%#x", f)
+	}
+}
+
+// TestCarveConcurrentCommitErrorStopsWatermark proves a mid-run commit failure
+// surfaces the error and stops the watermark: blocks before the failure flip,
+// the failed block and everything after it stay dirty.
+func TestCarveConcurrentCommitErrorStopsWatermark(t *testing.T) {
+	const window = 64
+	s, sink := ctrlStore(t, window)
+	data := writeAdjacent(t, s, "f", 128, 4<<10)
+	full := int64(len(data))
+
+	done := carveAsync(s)
+
+	offs := drainArrivals(sink, 300*time.Millisecond)
+	if len(offs) < 3 {
+		t.Fatalf("need at least 3 blocks to fail a middle one, got %d", len(offs))
+	}
+	// Fail the second block (by watermark order). The first block must still flip;
+	// the failed one and its successors must not.
+	sorted := append([]int64(nil), offs...)
+	for i := 1; i < len(sorted); i++ {
+		for j := i; j > 0 && sorted[j-1] > sorted[j]; j-- {
+			sorted[j-1], sorted[j] = sorted[j], sorted[j-1]
+		}
+	}
+	failAt := sorted[1]
+	sink.mu.Lock()
+	sink.failOff = failAt
+	sink.mu.Unlock()
+
+	sink.releaseAll()
+	err := <-done
+	if !errors.Is(err, errCtrlCommit) {
+		t.Fatalf("carve returned %v, want the commit failure", err)
+	}
+	// The first block flipped (watermark advanced), but the failed block stopped
+	// it: some dirty bytes remain.
+	if u := s.UnsyncedBytes(); u == 0 || u >= full {
+		t.Fatalf("watermark did not stop at the failed block: unsynced=%d full=%d", u, full)
+	}
+	// A record before the failure flipped; the failed block's own records must not
+	// — its bytes never reached the remote.
+	if f := recRawFlags(t, s, "f", 0); f&flagSynced == 0 {
+		t.Fatalf("record before the failure did not flip: flags=%#x", f)
+	}
+	if f := recRawFlags(t, s, "f", failAt); f&flagSynced != 0 {
+		t.Fatalf("failed block's record flipped synced: off=%d flags=%#x", failAt, f)
+	}
+}

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -58,6 +58,13 @@ type Config struct {
 	ShardCount       int           // number of shards, power of two, immutable per store
 	MaxLocalBytes    int64         // local on-disk cap that triggers eviction; 0 = unlimited
 	EvictMaxWait     time.Duration // write-path backpressure budget before ErrLocalStoreFull
+	// CarveUploadConcurrency bounds how many of one file's packed blocks may be
+	// committed (uploaded + committed) at once within a single carve run. Packing
+	// stays sequential; only the block commits overlap, so a single large file's
+	// carve is no longer one PutBlock at a time. Peak carve RAM scales with this
+	// window (window x CarveBlockSize), so keep it modest. Zero falls back to the
+	// default via withDefaults.
+	CarveUploadConcurrency int
 	// ChunkParams sets the per-share FastCDC sizing carve feeds the chunker
 	// (#1569). The zero value (or any params that fail Validate) degrades to
 	// chunker.DefaultParams — the historical 1M/4M/16M profile — so a
@@ -66,12 +73,13 @@ type Config struct {
 }
 
 const (
-	defaultSegmentSize      int64 = 256 << 20
-	defaultCarveBlockSize   int64 = 4 << 20
-	defaultCarveMaxAge            = 5 * time.Second
-	defaultGCDeadRatioForce       = 0.5
-	defaultShardCount             = 16
-	defaultEvictMaxWait           = 30 * time.Second
+	defaultSegmentSize            int64 = 256 << 20
+	defaultCarveBlockSize         int64 = 4 << 20
+	defaultCarveMaxAge                  = 5 * time.Second
+	defaultGCDeadRatioForce             = 0.5
+	defaultShardCount                   = 16
+	defaultEvictMaxWait                 = 30 * time.Second
+	defaultCarveUploadConcurrency       = 8
 )
 
 func (c Config) withDefaults() Config {
@@ -92,6 +100,9 @@ func (c Config) withDefaults() Config {
 	}
 	if c.EvictMaxWait <= 0 {
 		c.EvictMaxWait = defaultEvictMaxWait
+	}
+	if c.CarveUploadConcurrency <= 0 {
+		c.CarveUploadConcurrency = defaultCarveUploadConcurrency
 	}
 	if c.ChunkParams.Validate() != nil {
 		c.ChunkParams = chunker.DefaultParams()


### PR DESCRIPTION
## Why

Closes #1717 / #36 — the single-file sequential-write throughput lever.

A single large file's carve committed **one block at a time**: `carveRun`'s flush closure called `sink.CommitBlock` (PutBlock to S3 + metadata commit) synchronously, then flipped, before the next block was flushed. Consecutive blocks therefore uploaded serially at ~one S3 PUT RTT each (~9 MiB/s) regardless of link bandwidth. The per-file carve fan-out (#1785) does nothing for the common single-file seq-write case, because one large file is a single carve goroutine.

## What (Option A from the design)

Packing stays **sequential** (the single-buffered chunker reads the run in order). Only the `CommitBlock` (upload + commit) of successive packed blocks now overlaps, via a bounded per-run worker pool owned by the journal:

- New journal `Config.CarveUploadConcurrency` (default 8, falls back via `withDefaults`). Peak carve RAM is `window x (CarveBlockSize + one overhang chunk)` — kept modest.
- Each packed block gets its **own** buffer (from the arena pool) so its bytes stay live while its upload runs concurrently with the next block's packing.
- A small ordered-completion chain (`carve_dispatch.go`) applies the synced flips in submission/watermark order.

New file `carve_dispatch.go` holds the `carveDispatcher`; `carveRun` is rewritten to pack → `submit` → `wait`.

## How the three critical invariants are preserved

1. **Commit strictly precedes flip, per block.** A worker calls `flipUpTo` only after its own `CommitBlock` returned `nil`. A record flips to `synced` only once its block is durable remotely — unchanged from the sequential path, just moved into the worker.

2. **Flips apply in watermark order even if a later block's upload finishes first.** Each worker waits on its predecessor's completion channel (`prev`) before flipping, so `flipIdx` advances monotonically. A later block whose upload finishes first still blocks on the chain until every earlier block has flipped. Test `TestCarveFlipsInWatermarkOrder`: with the earliest block held and every later block committed, **no** record flips until the earliest block is released.

3. **Dedup visibility restricted to committed state.** `engineDeduper.IsChunkDurable` reads the synced-hash store, which is only written inside `CommitBlock`'s metadata transaction (after PutBlock). Packing stays sequential and consults that same committed oracle, so a block being committed concurrently has **not** yet marked its hashes durable — block K can never observe block K-1's uncommitted hash as durable. Worst case a duplicate chunk is re-packed, which the content-addressed commit collapses to a no-op. No optimistic in-flight dedup was added.

Mid-run failure: the first `CommitBlock` error records the error and stops the watermark at that block; every later worker sees `proceed=false` and skips its flip. Already-uploaded later blocks become GC-reclaimable orphans, matching the existing PutBlock-first semantics. In-flight uploads drain (no forced cancel of earlier, still-committing blocks).

## Tests (deterministic, `-race`)

`carve_dispatch_test.go`, a gated fake sink with per-block release:
- `TestCarveConcurrencyBounded` — up to `window` (and never more than) CommitBlocks run concurrently.
- `TestCarveFlipsInWatermarkOrder` — flips apply in watermark order; holding the earliest block blocks all flips even though later blocks committed (also covers the crash-safety "no record flips whose block hasn't committed").
- `TestCarveConcurrentCommitErrorStopsWatermark` — a mid-run commit error surfaces and stops the watermark; blocks before the failure flip, the failed block's records stay dirty.

All existing carve/journal tests pass unchanged.

## Verification

- `go test ./pkg/block/... -race` — 884 passed.
- New concurrency tests pass `-count=3 -race`.
- `gofmt -s`, `go vet ./...`, `golangci-lint run ./pkg/block/journal/...` (0 issues), `go build -tags integration ./...` all clean.