### PR TITLE
perf(journal): within-file carve upload concurrency

### DIFF
--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math"
 	"sync"
+	"sync/atomic"
 
 	"lukechampine.com/blake3"
 
@@ -238,9 +239,31 @@ func (s *Store) carveFile(ctx context.Context, sh *shard, id FileID, res *CarveR
 	return nil
 }
 
+// carveUploadConcurrency is the in-flight upload window for one run, at least 1.
+func (s *Store) carveUploadConcurrency() int {
+	if n := s.cfg.CarveUploadConcurrency; n >= 1 {
+		return n
+	}
+	return 1
+}
+
 // carveRun streams one contiguous dirty run through FastCDC, dedups each chunk,
-// packs novel chunks into blocks (flushed at CarveBlockSize and at the run's end),
-// and flips the run's records to synced as the durable frontier advances.
+// packs novel chunks into blocks (dispatched at CarveBlockSize and at the run's
+// end), and flips the run's records to synced as the durable frontier advances.
+//
+// Packing stays strictly sequential (the chunker reads the run's bytes in order),
+// but each packed block's CommitBlock (PutBlock + metadata commit) runs in its own
+// goroutine, so up to CarveUploadConcurrency block uploads overlap within one file
+// — the lever a single large file's drain needs. The flips stay ordered and
+// crash-safe: block K's flipUpTo runs only after block K-1's flip and after block
+// K's own CommitBlock returned nil (an ordered handoff over prevFlipped). The first
+// CommitBlock error cancels the run and stops the watermark advancing past that
+// block; blocks that already uploaded past it are left as GC-reclaimable orphans.
+//
+// Dedup visibility stays commit-gated: IsChunkDurable is consulted only from this
+// packing goroutine and a hash becomes durable solely inside CommitBlock, so block
+// K never dedups against block K-1's not-yet-committed hashes — the ordered flip
+// then cannot clean bytes that never reached the remote.
 func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interval, res *CarveResult) error {
 	c := chunker.NewChunkerWithParams(s.cfg.ChunkParams)
 	rr := &runReader{s: s, sh: sh, ivs: run}
@@ -253,11 +276,12 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 	// reap keeps this run's own rows and deletes only superseded ones (#953).
 	newOffsets := make(map[int64]struct{})
 
-	// arena backs every pending chunk copy in one recycled block-sized buffer, so
-	// a run allocates no per-chunk scratch. It holds at most one block's worth of
-	// pending bytes: pendingBytes flushes at CarveBlockSize and one appended chunk
-	// is at most MaxChunkSize, so CarveBlockSize + MaxChunkSize bounds it.
-	// arenaOff resets after each flush, once CommitBlock has consumed the copies.
+	// Each packed block gets its OWN block-sized buffer (not one recycled arena):
+	// a block's Data slices are read by its upload goroutine while packing already
+	// fills the next block, so the buffers cannot alias. Peak carve RAM is thus
+	// CarveUploadConcurrency block buffers. A buffer holds at most one block's
+	// pending bytes: pendingBytes dispatches at CarveBlockSize and one appended
+	// chunk is at most MaxChunkSize, so CarveBlockSize + MaxChunkSize bounds it.
 	// Compute in int64 and clamp before the int conversion so a pathological
 	// CarveBlockSize can't silently wrap on 32-bit platforms.
 	arenaCap64 := s.cfg.CarveBlockSize + int64(chunker.MaxChunkSize)
@@ -265,32 +289,94 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 		arenaCap64 = math.MaxInt
 	}
 	arenaCap := int(arenaCap64)
-	arenap := carveArenaPool.Get().(*[]byte)
-	arena := *arenap
-	if cap(arena) < arenaCap {
-		arena = make([]byte, arenaCap)
-	}
-	arena = arena[:cap(arena)]
-	arenaOff := 0
-	defer func() {
-		*arenap = arena
-		carveArenaPool.Put(arenap)
-	}()
 
-	// flush commits the buffered novel chunks (if any) then, since everything up
-	// to watermark is now durable, flips the run's records that end there. The
-	// commit strictly precedes the flip: that is the crash-safety ordering.
-	flush := func(watermark int64) error {
-		if len(pending) > 0 {
-			if err := s.sink.CommitBlock(ctx, pending); err != nil {
-				return err
-			}
-			res.BlocksWritten++
-			pending = nil
-			pendingBytes = 0
-			arenaOff = 0
+	var (
+		blockp   *[]byte // current block's pooled backing; nil until the first novel chunk
+		block    []byte
+		blockOff int
+	)
+	getBlock := func() {
+		blockp = carveArenaPool.Get().(*[]byte)
+		block = *blockp
+		if cap(block) < arenaCap {
+			block = make([]byte, arenaCap)
 		}
-		return s.flipUpTo(sh, id, run, &flipIdx, watermark)
+		block = block[:cap(block)]
+		blockOff = 0
+	}
+
+	// runCtx cancels queued/in-flight uploads on the first CommitBlock error so the
+	// packing loop and the other workers stop promptly.
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// sem bounds in-flight uploads; wg joins them; blocksWritten counts committed
+	// blocks (workers race, so it is atomic and folded into res after the join).
+	sem := make(chan struct{}, s.carveUploadConcurrency())
+	var (
+		wg            sync.WaitGroup
+		errMu         sync.Mutex
+		firstErr      error
+		blocksWritten atomic.Int64
+	)
+	setErr := func(e error) {
+		errMu.Lock()
+		if firstErr == nil {
+			firstErr = e
+			cancel()
+		}
+		errMu.Unlock()
+	}
+	hadErr := func() bool {
+		errMu.Lock()
+		defer errMu.Unlock()
+		return firstErr != nil
+	}
+
+	// prevFlipped chains the ordered flip: a block waits on the previous block's
+	// channel before flipping and closes its own for the next. Seeded closed so the
+	// first block proceeds immediately.
+	prevFlipped := make(chan struct{})
+	close(prevFlipped)
+
+	// dispatch hands one packed block to an upload goroutine and returns the channel
+	// the next block waits on. It transfers ownership of bp (returned to the pool
+	// once CommitBlock has consumed the chunk copies). The flip runs strictly after
+	// this block's commit succeeds AND the previous block's flip completed.
+	dispatch := func(chunks []CarveChunk, watermark int64, bp *[]byte, prev chan struct{}) chan struct{} {
+		mine := make(chan struct{})
+		sem <- struct{}{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer close(mine) // release the next block's flip turn, success or not
+			err := s.sink.CommitBlock(runCtx, chunks)
+			carveArenaPool.Put(bp) // CommitBlock consumed the copies; recycle
+			<-sem
+			if err != nil {
+				setErr(err)
+			} else {
+				blocksWritten.Add(1)
+			}
+			<-prev // flip in submission order, strictly after the previous block
+			if err != nil || hadErr() {
+				return // this block failed, or an earlier one did: do not flip
+			}
+			if e := s.flipUpTo(sh, id, run, &flipIdx, watermark); e != nil {
+				setErr(e)
+			}
+		}()
+		return mine
+	}
+	dispatchPending := func(watermark int64) {
+		if len(pending) == 0 {
+			return
+		}
+		*blockp = block // hand back the possibly-grown buffer so the pool recycles it
+		prevFlipped = dispatch(pending, watermark, blockp, prevFlipped)
+		pending = nil
+		pendingBytes = 0
+		blockp = nil // the dispatched buffer is now owned by its worker
 	}
 
 	// buf accumulates bytes for the chunker; it never exceeds one max chunk, so
@@ -303,10 +389,9 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 		carveScratchPool.Put(bufp)
 	}()
 	eof := false
-	for {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
+	// Loop while the run is live: an upload failure (or the caller) cancels runCtx,
+	// which stops packing so the join below can surface the error.
+	for runCtx.Err() == nil {
 		for !eof && len(buf) < chunker.MaxChunkSize {
 			n, err := rr.Read(buf[len(buf):cap(buf)])
 			if n > 0 {
@@ -317,7 +402,8 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 				break
 			}
 			if err != nil {
-				return err
+				setErr(err)
+				break
 			}
 		}
 		if len(buf) == 0 {
@@ -332,24 +418,28 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 		}
 
 		h := ChunkHash(blake3.Sum256(buf[:boundary]))
-		durable, err := s.deduper.IsChunkDurable(ctx, h)
+		durable, err := s.deduper.IsChunkDurable(runCtx, h)
 		if err != nil {
-			return err
+			setErr(err)
+			break
 		}
 		if !durable {
+			if blockp == nil {
+				getBlock()
+			}
 			// Bound proof: pendingBytes < CarveBlockSize before this append (else
-			// the prior iteration flushed and reset arenaOff), and boundary <=
-			// MaxChunkSize, so arenaOff+boundary <= CarveBlockSize-1+MaxChunkSize <
+			// the prior iteration dispatched and reset the buffer), and boundary <=
+			// MaxChunkSize, so blockOff+boundary <= CarveBlockSize-1+MaxChunkSize <
 			// cap. The grow is a fail-loud belt: if that invariant ever breaks (e.g.
 			// a config change), realloc rather than slice out of bounds. Already-
 			// pending Data slices keep pointing at the old backing (still live), so
-			// no copy is needed — the new chunk just lands in the larger arena.
-			if arenaOff+boundary > cap(arena) {
-				arena = make([]byte, arenaOff+boundary)
+			// no copy is needed — the new chunk just lands in the larger buffer.
+			if blockOff+boundary > cap(block) {
+				block = make([]byte, blockOff+boundary)
 			}
-			data := arena[arenaOff : arenaOff+boundary : arenaOff+boundary]
+			data := block[blockOff : blockOff+boundary : blockOff+boundary]
 			copy(data, buf[:boundary])
-			arenaOff += boundary
+			blockOff += boundary
 			pending = append(pending, CarveChunk{Hash: h, FileID: id, FileOffset: fileOff, Data: data})
 			pendingBytes += int64(boundary)
 			res.BytesCarved += int64(boundary)
@@ -359,17 +449,30 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 		buf = append(buf[:0], buf[boundary:]...)
 
 		if pendingBytes >= s.cfg.CarveBlockSize {
-			if err := flush(fileOff); err != nil {
-				return err
-			}
+			dispatchPending(fileOff)
 		}
 		if eof && len(buf) == 0 {
 			break
 		}
 	}
-	// Tail: commit any remainder and flip through the end of the run (records
-	// covered only by already-durable chunks flip here too).
-	if err := flush(run[len(run)-1].end()); err != nil {
+	// Tail: dispatch any remainder; its watermark is the run end, so its flip
+	// covers every record up to there. Skip when the run was cancelled (an upload
+	// error, or the caller) — the join below surfaces the reason.
+	if runCtx.Err() == nil {
+		dispatchPending(run[len(run)-1].end())
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return firstErr
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	res.BlocksWritten += int(blocksWritten.Load())
+	// Flip any trailing records covered only by already-durable (deduped) chunks:
+	// no block carried their watermark, so advance the frontier to the run end now
+	// that every block committed. A no-op when the tail block already reached it.
+	if err := s.flipUpTo(sh, id, run, &flipIdx, run[len(run)-1].end()); err != nil {
 		return err
 	}
 	// #953: with every row this run produced now committed, reap the manifest rows

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -304,6 +304,15 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 		block = block[:cap(block)]
 		blockOff = 0
 	}
+	// If packing exits early (error/cancel) holding an undispatched block, return
+	// its buffer to the pool. dispatchPending sets blockp = nil once a block is
+	// handed to its worker, so a dispatched buffer is never double-put here.
+	defer func() {
+		if blockp != nil {
+			*blockp = block
+			carveArenaPool.Put(blockp)
+		}
+	}()
 
 	// runCtx cancels queued/in-flight uploads on the first CommitBlock error so the
 	// packing loop and the other workers stop promptly.

--- a/pkg/block/journal/carve_test.go
+++ b/pkg/block/journal/carve_test.go
@@ -7,7 +7,23 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/marmos91/dittofs/pkg/block/chunker"
 )
+
+// pollUntil spins on cond until it holds or the timeout elapses. Called from the
+// test goroutine only (it uses t.Fatalf).
+func pollUntil(t *testing.T, cond func() bool, timeout time.Duration, what string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for %s", what)
+}
 
 // fakeClock is a settable Clock for the age-gate tests.
 type fakeClock struct {
@@ -338,7 +354,10 @@ func TestCarveRecordSplitNoPrematureFlip(t *testing.T) {
 	// on-disk synced bit must stay clear — flipping it while a live fragment is
 	// still dirty would let a crash make recovery treat that dirty fragment as
 	// synced, and its bytes would never carve (data loss).
-	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 1 << 20})
+	//
+	// Pin the upload window to 1 so the two blocks commit in submission order and
+	// the "first succeeds, second fails" injection (okCommits) is deterministic.
+	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 1 << 20, CarveUploadConcurrency: 1})
 	ctx := context.Background()
 
 	if err := s.WriteAt(ctx, "f", 0, randBytes(6<<20, 21)); err != nil { // record R = [0,6MiB)
@@ -379,6 +398,170 @@ func TestCarveRecordSplitNoPrematureFlip(t *testing.T) {
 	}
 	if f := recRawFlags(t, s, "f", 0); f&flagSynced == 0 {
 		t.Fatalf("record not flipped after full carve: flags=%#x", f)
+	}
+}
+
+func TestCarveUploadConcurrencyWindow(t *testing.T) {
+	// Packing is sequential, but up to CarveUploadConcurrency block uploads overlap.
+	// Hold every CommitBlock inside onCommit so the window fills, then assert exactly
+	// that many uploads were simultaneously in flight — never more (the sem bound).
+	const window = 4
+	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 256 << 10, CarveUploadConcurrency: window})
+	ctx := context.Background()
+	// Default ~1 MiB min-chunk >= CarveBlockSize, so each chunk is its own block:
+	// 8 MiB -> ~8 blocks, comfortably more than the window.
+	if err := s.WriteAt(ctx, "f", 0, randBytes(8<<20, 40)); err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		mu       sync.Mutex
+		inflight int
+		maxSeen  int
+	)
+	release := make(chan struct{})
+	sink.onCommit = func(_ []CarveChunk) {
+		mu.Lock()
+		inflight++
+		if inflight > maxSeen {
+			maxSeen = inflight
+		}
+		mu.Unlock()
+		<-release // hold the upload so successive blocks pile up against the window
+		mu.Lock()
+		inflight--
+		mu.Unlock()
+	}
+
+	done := make(chan error, 1)
+	go func() { _, err := s.Carve(ctx, CarveOptions{Force: true}); done <- err }()
+
+	pollUntil(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return maxSeen == window
+	}, 5*time.Second, "upload window to fill")
+	// Give any (buggy) unbounded fan-out a moment to overshoot the window.
+	time.Sleep(20 * time.Millisecond)
+	mu.Lock()
+	got := maxSeen
+	mu.Unlock()
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("carve: %v", err)
+	}
+	if got != window {
+		t.Fatalf("peak in-flight uploads = %d, want exactly the window %d", got, window)
+	}
+}
+
+func TestCarveFlipsInWatermarkOrder(t *testing.T) {
+	// A later block's upload finishing first must NOT let its flip jump ahead: the
+	// flip is crash-safety ordering. Hold block0 uncommitted while block1 commits,
+	// then assert nothing has flipped until block0 lands.
+	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 1 << 20, CarveUploadConcurrency: 4})
+	ctx := context.Background()
+	if err := s.WriteAt(ctx, "f", 0, randBytes(2<<20, 41)); err != nil {
+		t.Fatal(err)
+	}
+	total := s.UnsyncedBytes()
+
+	gate0 := make(chan struct{})
+	sink.onCommit = func(chunks []CarveChunk) {
+		if chunks[0].FileOffset == 0 {
+			<-gate0 // the first block's upload finishes last
+		}
+	}
+
+	done := make(chan error, 1)
+	go func() { _, err := s.Carve(ctx, CarveOptions{Force: true}); done <- err }()
+
+	// A later block commits while block0 is gated. Its flip must wait its turn, so
+	// no bytes may drain until block0 is durable.
+	pollUntil(t, func() bool { return sink.blockCount() >= 1 }, 5*time.Second, "a later block to commit")
+	if u := s.UnsyncedBytes(); u != total {
+		t.Fatalf("flip applied out of watermark order: unsynced=%d want %d (nothing may flip before block0)", u, total)
+	}
+	close(gate0)
+	if err := <-done; err != nil {
+		t.Fatalf("carve: %v", err)
+	}
+	if u := s.UnsyncedBytes(); u != 0 {
+		t.Fatalf("post-carve unsynced=%d want 0", u)
+	}
+}
+
+func TestCarveConcurrentCommitErrorStopsWatermark(t *testing.T) {
+	// The first block commits; the second's upload fails. The watermark must stop at
+	// the failed block: block0's bytes drain, block1's stay dirty, and the error
+	// surfaces. Two separate 1 MiB writes give two records so the frontier is exact.
+	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 1 << 20, CarveUploadConcurrency: 4})
+	ctx := context.Background()
+	if err := s.WriteAt(ctx, "f", 0, randBytes(1<<20, 42)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.WriteAt(ctx, "f", 1<<20, randBytes(1<<20, 43)); err != nil {
+		t.Fatal(err)
+	}
+
+	sink.okCommits = 1
+	sink.failErr = errors.New("second block upload fails")
+	// Serialize the two commits so okCommits is deterministic under the window: the
+	// non-first block only reaches the (failing) commit path after block0 committed.
+	sink.onCommit = func(chunks []CarveChunk) {
+		if chunks[0].FileOffset != 0 {
+			for sink.blockCount() < 1 {
+				time.Sleep(time.Millisecond)
+			}
+		}
+	}
+
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err == nil {
+		t.Fatalf("expected the second block's commit error to surface")
+	}
+	if u := s.UnsyncedBytes(); u != 1<<20 {
+		t.Fatalf("watermark did not stop at the failed block: unsynced=%d want %d", u, 1<<20)
+	}
+}
+
+func TestCarveDedupVisibilityCommitGated(t *testing.T) {
+	// Block K must not dedup against block K-1's not-yet-committed hash: a durable
+	// verdict on an uncommitted sibling would flip records whose bytes never reached
+	// the remote. Two identical chunks land in two blocks; hold block0 uncommitted
+	// while block1 packs the twin. Block1 must still upload its own block.
+	const chunkSize = 64 << 10
+	fixed := chunker.Params{Min: chunkSize, Avg: chunkSize, Max: chunkSize} // deterministic, twin chunks
+	s, _, sink, _ := carveStore(t, Config{
+		CarveBlockSize:         chunkSize,
+		CarveUploadConcurrency: 4,
+		ChunkParams:            fixed,
+	})
+	ctx := context.Background()
+	x := randBytes(chunkSize, 44)
+	data := append(append([]byte{}, x...), x...) // X ++ X -> two chunks, same hash
+	if err := s.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatal(err)
+	}
+
+	gate0 := make(chan struct{})
+	sink.onCommit = func(chunks []CarveChunk) {
+		if chunks[0].FileOffset == 0 {
+			<-gate0 // keep block0's hash uncommitted while block1 packs the twin
+		}
+	}
+
+	done := make(chan error, 1)
+	go func() { _, err := s.Carve(ctx, CarveOptions{Force: true}); done <- err }()
+
+	// block1 commits its own block while block0 is uncommitted. If the twin hash were
+	// visible as durable early, block1 would dedup it away and never reach the sink.
+	pollUntil(t, func() bool { return sink.blockCount() >= 1 }, 5*time.Second, "block1 to commit while block0 gated")
+	close(gate0)
+	if err := <-done; err != nil {
+		t.Fatalf("carve: %v", err)
+	}
+	if n := sink.blockCount(); n != 2 {
+		t.Fatalf("committed %d blocks, want 2: block1 must not dedup on block0's uncommitted hash", n)
 	}
 }
 

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -58,6 +58,11 @@ type Config struct {
 	ShardCount       int           // number of shards, power of two, immutable per store
 	MaxLocalBytes    int64         // local on-disk cap that triggers eviction; 0 = unlimited
 	EvictMaxWait     time.Duration // write-path backpressure budget before ErrLocalStoreFull
+	// CarveUploadConcurrency bounds how many of one file's packed blocks upload
+	// (sink.CommitBlock) at once. Packing stays sequential; only the per-block
+	// uploads overlap, so a single large file's carve is not throttled to one
+	// PutBlock at a time. Peak carve RAM is this many CarveBlockSize buffers.
+	CarveUploadConcurrency int
 	// ChunkParams sets the per-share FastCDC sizing carve feeds the chunker
 	// (#1569). The zero value (or any params that fail Validate) degrades to
 	// chunker.DefaultParams — the historical 1M/4M/16M profile — so a
@@ -72,6 +77,9 @@ const (
 	defaultGCDeadRatioForce       = 0.5
 	defaultShardCount             = 16
 	defaultEvictMaxWait           = 30 * time.Second
+	// defaultCarveUploadConcurrency overlaps a single file's block uploads without
+	// unbounded fan-out. Peak carve RAM is this many CarveBlockSize buffers.
+	defaultCarveUploadConcurrency = 8
 )
 
 func (c Config) withDefaults() Config {
@@ -92,6 +100,9 @@ func (c Config) withDefaults() Config {
 	}
 	if c.EvictMaxWait <= 0 {
 		c.EvictMaxWait = defaultEvictMaxWait
+	}
+	if c.CarveUploadConcurrency <= 0 {
+		c.CarveUploadConcurrency = defaultCarveUploadConcurrency
 	}
 	if c.ChunkParams.Validate() != nil {
 		c.ChunkParams = chunker.DefaultParams()


### PR DESCRIPTION
## What

Overlaps the block uploads of a single file's carve. Today `carveRun` calls `sink.CommitBlock` (PutBlock + metadata commit) synchronously per block, then flips — so one large file drains at ~one PutBlock RTT per block (~9 MiB/s), regardless of link bandwidth. The per-file fan-out from #1785 doesn't help a single large file (it's one carve goroutine). This is the within-file lever.

Implements **Option A** (journal-owned bounded pool) from `.planning/perf/2026-07-19-within-file-carve-concurrency-DESIGN.md`. Packing (FastCDC) stays strictly sequential; only `CommitBlock` is dispatched to a bounded worker pool sized by a new journal `Config.CarveUploadConcurrency` (default 8). Peak carve RAM is bounded to that many `CarveBlockSize` buffers — each packed block gets its own buffer instead of one recycled arena.

Closes the throughput half of #1717 / task #36.

## Invariants preserved

- **commit strictly precedes flip (crash-safety).** Each block's flip runs in an ordered handoff (`prevFlipped` channel chain): block K's `flipUpTo` runs only after block K-1's flip **and** after block K's own `CommitBlock` returned nil. Flips therefore apply in watermark order even when a later block's upload finishes first.
- **first error stops the watermark.** The first `CommitBlock` error cancels the run's context, sets `firstErr`, and no block at or past it flips (its records stay dirty → re-carved next pass, dedup makes the re-commit a no-op). Blocks that already uploaded past the failure become GC-reclaimable orphans — matches the PutBlock-first ordering in `engine/blocksink.go`.
- **dedup visibility is commit-gated.** `IsChunkDurable` is consulted only from the (sequential) packing goroutine, and a hash becomes durable solely inside `CommitBlock`. So block K can never observe block K-1's not-yet-committed hash as durable and flip records whose bytes never reached the remote. New test asserts this directly.

## Tests (deterministic, `-race`)

- `TestCarveUploadConcurrencyWindow` — exactly `window` uploads run concurrently, never more.
- `TestCarveFlipsInWatermarkOrder` — a later block committing first flips nothing until the earlier block lands.
- `TestCarveConcurrentCommitErrorStopsWatermark` — mid-run error stops the watermark and surfaces.
- `TestCarveDedupVisibilityCommitGated` — block K packs its own block rather than dedup on a sibling's uncommitted hash.

`go test ./pkg/block/journal/... -race` passes (81 tests, 5x for the timing tests, no flakes). `go build -tags integration ./...` passes. `golangci-lint run ./pkg/block/journal/` clean.

## Notes for the reviewer

- **Two limiters don't compose (accepted, per design).** The engine's `carvePass` (#1785) already bounds *per-file* carves with its adaptive `uploadLimiter`; this adds an independent *within-file* window, so worst-case in-flight PutBlocks is `files-in-flight × CarveUploadConcurrency`. Option B (async `BlockSink` so the engine's adaptive window governs both) is the design's preferred long-term shape but changes the `BlockSink` contract — deliberately out of scope here.
- `TestCarveRecordSplitNoPrematureFlip` is pinned to `CarveUploadConcurrency: 1` — its `okCommits` error injection assumes sequential commit order.
- **VM single-4GiB drain A/B is pending** — a separate benchmarking workstream owns that run; not executed here.
- **CI is green on all code checks** (Format & Vet, golangci-lint, Unit, Integration, Build Binaries). A stale `pkg/block/engine` test artifact in my local worktree tripped a `RollupWorkers` build error locally, but it is not in this PR's diff and CI's Unit Tests (which compile the engine test package) pass — so it was purely a local checkout artifact, not a real develop issue.
