### PR TITLE
fix(journal): reclaim emptied local segments on unlink

### DIFF
--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -312,6 +312,76 @@ func (s *Store) retireSegment(sh *shard, seg *segmentMeta) (int64, error) {
 	return freed, nil
 }
 
+// reclaimEmptied retires every segment in sh that now holds no live (non-cold)
+// interval and has every record synced — the state a just-completed tombstone
+// leaves behind when the removed file was a segment's only occupant. The most
+// visible case is the ACTIVE segment after a cold read hydrated the removed
+// file's bytes back into the local tier: eviction and GC only ever reclaim the
+// SEALED set, so without this an unlink-after-cold-read strands those bytes on
+// disk until the next rotation or an explicit force-evict.
+//
+// It only touches segments that back no live data, so it frees dead space
+// without evicting any warm read-cache and can never drop live bytes. A pinned
+// segment (a live snapshot's watermark) is left for the snapshot to release. A
+// fully-dead, fully-synced active segment is sealed first — the same force-seal
+// primitive the explicit evict path uses — so the reclaim tail can drop it.
+// carveMu is held so a concurrent carve can't flip synced bits on a segment
+// mid-retire; sealed victims are claimed via busy so eviction/GC never race the
+// same retire. Best-effort: a retire failure is returned (and its disk stays
+// counted, reclaimed later by the recovery sweep) but never wedges the unlink.
+func (s *Store) reclaimEmptied(sh *shard) error {
+	sh.carveMu.Lock()
+	defer sh.carveMu.Unlock()
+
+	sh.mu.Lock()
+	// Segments still backing at least one live (non-cold) interval must survive.
+	liveSegs := make(map[uint64]struct{})
+	for _, fi := range sh.index {
+		for _, iv := range fi.ivs {
+			if !iv.cold {
+				liveSegs[iv.loc.SegmentID] = struct{}{}
+			}
+		}
+	}
+	// Seal a fully-dead, fully-synced active segment so the retire below can drop
+	// it. records raises monotonically and syncedRecords only rises toward it, so
+	// the fully-synced check is stable under the shard lock.
+	if act := sh.active; act != nil && act.records.Load() > 0 &&
+		act.syncedRecords.Load() == act.records.Load() &&
+		!act.busy.Load() && !s.pinned(act) {
+		if _, live := liveSegs[act.id]; !live {
+			if err := s.sealSegment(sh); err != nil {
+				sh.mu.Unlock()
+				return err
+			}
+		}
+	}
+	// Collect the sealed segments this shard can now drop whole.
+	var victims []*segmentMeta
+	for id, seg := range sh.sealed {
+		if _, live := liveSegs[id]; live {
+			continue
+		}
+		if !evictable(seg) || s.pinned(seg) {
+			continue
+		}
+		victims = append(victims, seg)
+	}
+	sh.mu.Unlock()
+
+	for _, seg := range victims {
+		if !seg.busy.CompareAndSwap(false, true) {
+			continue // claimed by a concurrent eviction/GC — it will retire it
+		}
+		if _, err := s.retireSegment(sh, seg); err != nil {
+			seg.busy.Store(false)
+			logger.Warn("journal: reclaim emptied segment", "segment", seg.id, "err", err)
+			return err
+		}
+	}
+	return nil
+}
+
 // Garbage collection / repack.
 //
 // deadBytes on a segmentMeta grows whenever an interval-tree node is superseded

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -451,6 +451,13 @@ func (s *Store) Delete(ctx context.Context, id FileID) error {
 	if dirty != 0 {
 		s.unsynced.Add(-dirty)
 	}
+	// A tombstone can leave a segment holding no live bytes — most visibly the
+	// active segment after a cold read hydrated the just-removed file's bytes
+	// locally. Reclaim those now-dead segments so the unlink frees the local tier
+	// immediately instead of stranding it until the next rotation or force-evict.
+	// Best-effort: a reclaim failure never wedges the delete (the file is already
+	// tombstoned and the recovery sweep reclaims any orphan).
+	_ = s.reclaimEmptied(sh)
 	return nil
 }
 

--- a/pkg/controlplane/runtime/coldread_delete_reclaim_test.go
+++ b/pkg/controlplane/runtime/coldread_delete_reclaim_test.go
@@ -1,0 +1,122 @@
+package runtime
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	cpstore "github.com/marmos91/dittofs/pkg/controlplane/store"
+)
+
+// TestColdReadThenDeleteReclaimsLocal reproduces the blocks-flip SMB local-disk
+// leak: after a file is carved+synced to the remote, evicted, and then
+// COLD-READ (which hydrates its bytes back into the local journal), deleting
+// the file must free the local tier back to zero.
+//
+// The NFS variant of the E2E stays green because a kernel NFS client serves the
+// post-evict read from its own page cache, so the server never hydrates and has
+// nothing local to reclaim on unlink. The pure-Go SMB client does not cache, so
+// its read drives a real server-side hydration — exercised directly here without
+// any protocol.
+func TestColdReadThenDeleteReclaimsLocal(t *testing.T) {
+	ctx := context.Background()
+	cp, err := cpstore.New(&cpstore.Config{
+		Type:   cpstore.DatabaseTypeSQLite,
+		SQLite: cpstore.SQLiteConfig{Path: ":memory:"},
+	})
+	if err != nil {
+		t.Fatalf("cpstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cp.Close() })
+
+	rt := New(cp)
+	metaStore := registerSQLiteMeta(t, rt, cp, "sqlite-meta")
+	localID := createFSLocalBlockStore(t, cp, "fs-local")
+	t.Cleanup(func() {
+		for _, name := range rt.ListShares() {
+			_ = rt.RemoveShare(name)
+		}
+	})
+
+	remoteCfg := &models.BlockStoreConfig{Name: "mem-remote", Kind: models.BlockStoreKindRemote, Type: "memory"}
+	remoteID, err := cp.CreateBlockStore(ctx, remoteCfg)
+	if err != nil {
+		t.Fatalf("CreateBlockStore(remote): %v", err)
+	}
+
+	shareName := "/coldread-reclaim"
+	if err := rt.AddShare(ctx, &ShareConfig{
+		Name:               shareName,
+		MetadataStore:      "sqlite-meta",
+		LocalBlockStoreID:  localID,
+		RemoteBlockStoreID: remoteID,
+		Enabled:            true,
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+
+	bs, err := rt.sharesSvc.GetBlockStoreForShare(shareName)
+	if err != nil {
+		t.Fatalf("GetBlockStoreForShare: %v", err)
+	}
+
+	payload, handle := createFileForPayload(t, ctx, metaStore, shareName, "flip.bin")
+
+	const fileSize = 16 * 1024 * 1024
+	data := make([]byte, fileSize)
+	rand.New(rand.NewSource(0xF11B)).Read(data) //nolint:gosec // deterministic fixture
+
+	if err := common.WriteToBlockStore(ctx, bs, payload, data, 0); err != nil {
+		t.Fatalf("WriteToBlockStore: %v", err)
+	}
+	if err := common.CommitBlockStore(ctx, bs, payload); err != nil {
+		t.Fatalf("CommitBlockStore: %v", err)
+	}
+	if err := bs.DrainAllUploads(ctx); err != nil {
+		t.Fatalf("DrainAllUploads: %v", err)
+	}
+	t.Logf("after carve: local DiskUsed=%d", bs.LocalStats().DiskUsed)
+
+	// Evict the synced local tier: bytes now live only on the remote.
+	if _, err := bs.DrainLocalSynced(ctx); err != nil {
+		t.Fatalf("DrainLocalSynced: %v", err)
+	}
+	t.Logf("after evict: local DiskUsed=%d", bs.LocalStats().DiskUsed)
+
+	// Cold read the whole file: hydrates the covering chunks back into the
+	// local journal.
+	res, err := common.ReadFromBlockStore(ctx, bs, payload, 0, uint32(fileSize))
+	if err != nil {
+		t.Fatalf("cold ReadFromBlockStore: %v", err)
+	}
+	if len(res.Data) != fileSize {
+		t.Fatalf("cold read returned %d bytes, want %d", len(res.Data), fileSize)
+	}
+	t.Logf("after cold read (hydrate): local DiskUsed=%d", bs.LocalStats().DiskUsed)
+
+	// Unlink: the file-removal contract must reclaim the local tier eagerly —
+	// with no further eviction pass.
+	if err := bs.Delete(ctx, string(payload), nil); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	_ = handle
+	afterDelete := bs.LocalStats().DiskUsed
+	t.Logf("after delete: local DiskUsed=%d", afterDelete)
+
+	// The file's bytes must be gone (a read now zero-fills).
+	res2, rerr := common.ReadFromBlockStore(ctx, bs, payload, 0, uint32(fileSize))
+	if rerr != nil {
+		t.Fatalf("read-after-delete: %v", rerr)
+	}
+	for i, b := range res2.Data {
+		if b != 0 {
+			t.Fatalf("read-after-delete: byte %d = %d, want 0 (file should be gone)", i, b)
+		}
+	}
+
+	if afterDelete != 0 {
+		t.Fatalf("local DiskUsed after delete = %d, want 0 (cold-read hydration leaked on unlink)", afterDelete)
+	}
+}


### PR DESCRIPTION
## Problem

The blocks-flip E2E `TestBlocksFlipLifecycle_SMB` fails at the final step —
after unlink + GC over SMB, `require.Zero(statsAfterGC.Totals.LocalDiskUsed)`
sees a nonzero value — while the NFS variant passes. Only the **local** tier
leaks; the file is removed and the remote is reclaimed.

## Root cause

A cold read hydrates a file's remote-durable ("synced") bytes back into the
journal's **active** segment. On unlink, the tombstone marks those intervals
dead (a subsequent read correctly zero-fills), but the now-dead segment stays
on disk: journal reclamation — both eviction and GC/repack — only ever operates
on the **sealed** set. A fully-dead **active** segment is reclaimed only by a
later write rotation or an explicit force-evict, neither of which the unlink
path triggers, so the local bytes are stranded.

The NFS variant is masked because a kernel NFS client serves the post-evict read
from its page cache — the server never hydrates, so there is nothing local to
reclaim. The pure-Go SMB client does not cache, so it drives a real server-side
hydration and then exposes the leak.

## Fix

`journal.Store.Delete` now retires every segment its tombstone leaves with no
live (non-cold) interval and every record synced, sealing a fully-dead active
segment first (the same force-seal primitive the explicit evict path uses). It
touches only segments backing no live data, so it frees dead space without
evicting warm read-cache and never drops live bytes; a pinned (snapshot) segment
is left for the snapshot to release. Best-effort — a reclaim failure never wedges
the unlink.

## Verification

- New regression test `pkg/controlplane/runtime/coldread_delete_reclaim_test.go`
  reproduces the leak without Docker (memory metadata + fs journal + memory
  remote): write -> carve -> evict -> cold-read (hydrate) -> delete. Before the
  fix, local disk after delete was nonzero (transiently double the file size);
  after the fix it is 0, and a read-after-delete zero-fills.
- `go test -race ./pkg/block/journal/` and `go test ./pkg/block/engine/ ./pkg/controlplane/runtime/` green.
- `go build ./...`, `go vet`, `golangci-lint run` clean.

Unblocks the blocks-flip SMB E2E for the develop-green effort.