### PR TITLE
fix(block): refuse to open a pre-journal local store as an empty journal

### DIFF
--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -61,6 +61,12 @@ func New(dir string, maxDisk int64, fileChunkStore block.EngineFileChunkStore) (
 // The remote is nil: cold-read fetch and Hydrate are driven by the engine, so
 // the journal never reaches the remote itself.
 func NewWithOptions(dir string, maxDisk int64, fileChunkStore block.EngineFileChunkStore, opts FSStoreOptions) (*FSStore, error) {
+	// Refuse to open a directory written by a pre-journal release as an empty
+	// journal — that would silently serve every stored file as zeros. Fail loud
+	// instead; the legacy bytes stay on disk for a migration to recover.
+	if err := checkLegacyLayout(dir); err != nil {
+		return nil, err
+	}
 	cfg := journal.Config{
 		MaxLocalBytes: maxDisk,
 		EvictMaxWait:  opts.BackpressureMaxWait,

--- a/pkg/block/local/fs/legacy.go
+++ b/pkg/block/local/fs/legacy.go
@@ -1,0 +1,86 @@
+package fs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// legacySegHeaderSize is the size of a freshly created journal segment file:
+// header only, no records. It mirrors the journal's own segHeaderSize (kept in
+// sync deliberately — the journal keeps that constant unexported). A journal
+// that has taken over a directory therefore leaves at least one .seg file larger
+// than this once it holds real data.
+const legacySegHeaderSize = 64
+
+// ErrLegacyLocalFormat reports that a local store directory holds a pre-journal
+// on-disk layout (blobs/ + logs/) the journal cannot read. Opening such a
+// directory as a journal would silently start empty and serve every stored file
+// as zeros, so the store refuses to open. The legacy bytes are left untouched on
+// disk for a migration to recover.
+var ErrLegacyLocalFormat = errors.New("legacy pre-journal local block store layout")
+
+// hasLegacyLocalLayout reports whether dir was written by a pre-journal release:
+// a populated blobs/ or logs/ subdirectory with no journal segment yet holding
+// data. Post-switchover the journal writes only journal/*.seg (+ .idx), so a
+// non-empty blobs/ or logs/ can only be pre-journal data. Once the journal owns
+// the directory (any .seg file past the bare header) those subdirectories are
+// just orphans a migration left behind, so their presence alone no longer counts
+// as legacy.
+func hasLegacyLocalLayout(dir string) (bool, error) {
+	legacy := false
+	for _, sub := range []string{"blobs", "logs"} {
+		entries, err := os.ReadDir(filepath.Join(dir, sub))
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return false, err
+		}
+		if len(entries) > 0 {
+			legacy = true
+			break
+		}
+	}
+	if !legacy {
+		return false, nil
+	}
+	// A journal that already holds data supersedes the legacy dirs: an in-place
+	// upgrade that has genuinely migrated (or a native store that happens to keep
+	// an orphaned blobs/) is not legacy. Empty header-only segments (a develop
+	// binary that started once over legacy data and inited an empty journal) do
+	// not count as data, so the guard still fires on the second start.
+	segs, err := filepath.Glob(filepath.Join(dir, "journal", "*.seg"))
+	if err != nil {
+		return false, err
+	}
+	for _, seg := range segs {
+		fi, err := os.Stat(seg)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return false, err
+		}
+		if fi.Size() > legacySegHeaderSize {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// checkLegacyLayout returns a descriptive ErrLegacyLocalFormat when dir holds a
+// pre-journal layout, so the caller refuses to open it as an empty journal.
+func checkLegacyLayout(dir string) error {
+	legacy, err := hasLegacyLocalLayout(dir)
+	if err != nil {
+		return err
+	}
+	if legacy {
+		return fmt.Errorf("%w: %q holds blobs/+logs/ from a pre-journal release; "+
+			"refusing to open it as an empty journal, which would serve the stored files as zeros. "+
+			"The data is intact on disk — migrate it before upgrading", ErrLegacyLocalFormat, dir)
+	}
+	return nil
+}

--- a/pkg/block/local/fs/legacy_test.go
+++ b/pkg/block/local/fs/legacy_test.go
@@ -1,0 +1,111 @@
+package fs
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeFile creates parent dirs and writes n bytes at path.
+func writeFile(t *testing.T, path string, n int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, make([]byte, n), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHasLegacyLocalLayout(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(dir string)
+		want  bool
+	}{
+		{
+			name:  "empty dir is not legacy",
+			setup: func(string) {},
+			want:  false,
+		},
+		{
+			name: "populated blobs is legacy",
+			setup: func(dir string) {
+				writeFile(t, filepath.Join(dir, "blobs", "0000000000000000.blob"), 1024)
+			},
+			want: true,
+		},
+		{
+			name: "populated logs is legacy",
+			setup: func(dir string) {
+				writeFile(t, filepath.Join(dir, "logs", "share", "f.log"), 512)
+			},
+			want: true,
+		},
+		{
+			name: "legacy dirs plus only header-only segments still legacy",
+			setup: func(dir string) {
+				writeFile(t, filepath.Join(dir, "blobs", "0000000000000000.blob"), 1024)
+				// A develop binary that started once over legacy data inits empty
+				// header-only segments; those are not data, so the guard must fire.
+				writeFile(t, filepath.Join(dir, "journal", "0000000000000000.seg"), legacySegHeaderSize)
+			},
+			want: true,
+		},
+		{
+			name: "journal segment with data supersedes orphan blobs",
+			setup: func(dir string) {
+				writeFile(t, filepath.Join(dir, "blobs", "0000000000000000.blob"), 1024)
+				writeFile(t, filepath.Join(dir, "journal", "0000000000000000.seg"), legacySegHeaderSize+1)
+			},
+			want: false,
+		},
+		{
+			name: "empty blobs dir is not legacy",
+			setup: func(dir string) {
+				if err := os.MkdirAll(filepath.Join(dir, "blobs"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tc.setup(dir)
+			got, err := hasLegacyLocalLayout(dir)
+			if err != nil {
+				t.Fatalf("hasLegacyLocalLayout: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("hasLegacyLocalLayout = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNewWithOptionsRefusesLegacy is the guardrail's whole point: opening a
+// pre-journal directory must fail with ErrLegacyLocalFormat rather than start an
+// empty journal that serves the stored files as zeros.
+func TestNewWithOptionsRefusesLegacy(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "blobs", "0000000000000000.blob"), 1024)
+	writeFile(t, filepath.Join(dir, "logs", "share", "f.log"), 512)
+
+	_, err := NewWithOptions(dir, 1<<30, nil, FSStoreOptions{})
+	if !errors.Is(err, ErrLegacyLocalFormat) {
+		t.Fatalf("NewWithOptions over legacy dir: got %v, want ErrLegacyLocalFormat", err)
+	}
+}
+
+// TestNewWithOptionsOpensCleanDir confirms the guard does not false-positive on a
+// fresh directory: a store with no legacy layout opens normally.
+func TestNewWithOptionsOpensCleanDir(t *testing.T) {
+	s, err := NewWithOptions(t.TempDir(), 1<<30, nil, FSStoreOptions{})
+	if err != nil {
+		t.Fatalf("NewWithOptions on clean dir: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+}


### PR DESCRIPTION
Closes the silent-data-loss half of #1801 (the release-gating guardrail).

## Problem
Upgrading from v0.26.0 (pre journal-switchover) to develop **silently loses all local block data** on every share type — empirically confirmed on a Linux VM. v0.26.0 stores bytes in `blobs/*.blob` + `logs/<share>/*.log`; develop's journal recovery scans only `journal/*.seg`, finds none, and starts an empty journal, so every stored file reads back as zeros. No error, no warning.

## This PR (the safe floor)
`FSStore.NewWithOptions` now detects a pre-journal layout (a populated `blobs/` or `logs/` with no journal segment holding data) and refuses to open, returning a typed `ErrLegacyLocalFormat` with a clear operator message, instead of silently serving zeros. The legacy bytes are left **untouched** on disk for a migration to recover.

Detection is robust to a develop binary that started once over legacy data (header-only 64-byte segments do not count as data, so the guard still fires on the next start), and does not false-positive once the journal genuinely holds data (any `.seg` past the bare header) or on a clean directory.

## Tests
`pkg/block/local/fs/legacy_test.go`: table-driven detection (empty / blobs / logs / header-only-segments / real-segment-supersedes / empty-blobs-dir) + `NewWithOptions` refuses a legacy dir and opens a clean one. `go test ./pkg/block/local/fs/` green, `gofmt`/`go vet`/`golangci-lint` clean.

## Follow-ups (tracked in #1801, not this PR)
- Remote-backed **auto-migrate**: archive the legacy dirs and seed cold intervals from the surviving metadata manifest so reads hydrate from S3 (smooth upgrade for S3-backed shares).
- Local-only migrate: read the legacy `blobs/`+`logs/` format and re-ingest into the journal.