### PR TITLE
feat(block): smooth remote-backed upgrade off the pre-journal local layout

### DIFF
--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -31,6 +31,13 @@ type FSStoreOptions struct {
 	BackpressureMaxWait time.Duration
 	MaxLogBytes         int64
 	ChunkParams         chunker.Params
+	// MigrateLegacyLayout, when set, makes NewWithOptions archive a detected
+	// pre-journal blobs/+logs/ layout aside (instead of refusing to open) so the
+	// journal opens clean. Only a remote-backed share should set this: the
+	// authoritative bytes then live in the remote store and are re-materialized
+	// from the surviving metadata manifest via cold seeding. A local-only share
+	// must leave it false so the guardrail stays fatal.
+	MigrateLegacyLayout bool
 }
 
 // FSStore is the journal-backed local store. It embeds *journal.Store and
@@ -39,11 +46,20 @@ type FSStoreOptions struct {
 type FSStore struct {
 	*journal.Store
 
-	dir            string
-	maxDisk        int64
-	maxLogBytes    int64
-	fileChunkStore block.EngineFileChunkStore
-	durable        atomic.Bool
+	dir                string
+	maxDisk            int64
+	maxLogBytes        int64
+	fileChunkStore     block.EngineFileChunkStore
+	durable            atomic.Bool
+	migratedFromLegacy bool
+}
+
+// MigratedFromLegacy reports whether NewWithOptions archived a pre-journal
+// blobs/+logs/ layout aside while opening this store. The caller uses it to
+// trigger a one-time cold-seed of the journal from the surviving metadata
+// manifest so reads fault the bytes back in from the remote store.
+func (s *FSStore) MigratedFromLegacy() bool {
+	return s.migratedFromLegacy
 }
 
 var (
@@ -61,10 +77,25 @@ func New(dir string, maxDisk int64, fileChunkStore block.EngineFileChunkStore) (
 // The remote is nil: cold-read fetch and Hydrate are driven by the engine, so
 // the journal never reaches the remote itself.
 func NewWithOptions(dir string, maxDisk int64, fileChunkStore block.EngineFileChunkStore, opts FSStoreOptions) (*FSStore, error) {
-	// Refuse to open a directory written by a pre-journal release as an empty
-	// journal — that would silently serve every stored file as zeros. Fail loud
-	// instead; the legacy bytes stay on disk for a migration to recover.
-	if err := checkLegacyLayout(dir); err != nil {
+	// A directory written by a pre-journal release (blobs/+logs/) cannot be read
+	// by the journal — opening it as an empty journal would silently serve every
+	// stored file as zeros. A remote-backed share (MigrateLegacyLayout) archives
+	// the legacy dirs aside so the journal opens clean and reads later cold-fetch
+	// from the remote via the surviving manifest; a local-only share fails loud
+	// so its on-disk bytes are not stranded behind an empty journal.
+	migrated := false
+	if opts.MigrateLegacyLayout {
+		legacy, err := hasLegacyLocalLayout(dir)
+		if err != nil {
+			return nil, err
+		}
+		if legacy {
+			if err := archiveLegacyLayout(dir); err != nil {
+				return nil, err
+			}
+			migrated = true
+		}
+	} else if err := checkLegacyLayout(dir); err != nil {
 		return nil, err
 	}
 	cfg := journal.Config{
@@ -77,11 +108,12 @@ func NewWithOptions(dir string, maxDisk int64, fileChunkStore block.EngineFileCh
 		return nil, err
 	}
 	s := &FSStore{
-		Store:          js,
-		dir:            dir,
-		maxDisk:        maxDisk,
-		maxLogBytes:    opts.MaxLogBytes,
-		fileChunkStore: fileChunkStore,
+		Store:              js,
+		dir:                dir,
+		maxDisk:            maxDisk,
+		maxLogBytes:        opts.MaxLogBytes,
+		fileChunkStore:     fileChunkStore,
+		migratedFromLegacy: migrated,
 	}
 	s.durable.Store(true) // fs-local survives a restart
 	return s, nil

--- a/pkg/block/local/fs/legacy.go
+++ b/pkg/block/local/fs/legacy.go
@@ -84,3 +84,40 @@ func checkLegacyLayout(dir string) error {
 	}
 	return nil
 }
+
+// legacyBackupSuffix is appended to a pre-journal subdirectory when it is moved
+// aside so the journal can own the directory cleanly. The archived bytes stay on
+// disk untouched under this name.
+const legacyBackupSuffix = ".pre-journal-backup"
+
+// archiveLegacyLayout renames the pre-journal blobs/ and logs/ subdirectories of
+// dir aside to <name>.pre-journal-backup so an empty journal can open cleanly on
+// top of them. It is NON-destructive: the legacy bytes survive under the backup
+// name, and only the remote store's copy plus the metadata manifest are relied
+// on to re-materialize file contents. It only touches a subdirectory that
+// currently exists; a missing one (e.g. a second start after a partial archive)
+// is skipped. A pre-existing backup target is a hard error rather than an
+// overwrite so the operator can inspect it — the guard that gates this call
+// won't fire again once blobs/ and logs/ are gone, so this only runs on the
+// first upgrade start.
+func archiveLegacyLayout(dir string) error {
+	for _, sub := range []string{"blobs", "logs"} {
+		src := filepath.Join(dir, sub)
+		if _, err := os.Stat(src); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return err
+		}
+		dst := src + legacyBackupSuffix
+		if _, err := os.Stat(dst); err == nil {
+			return fmt.Errorf("archive legacy %q: backup %q already exists; move it aside manually", src, dst)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if err := os.Rename(src, dst); err != nil {
+			return fmt.Errorf("archive legacy %q -> %q: %w", src, dst, err)
+		}
+	}
+	return nil
+}

--- a/pkg/block/local/fs/legacy_test.go
+++ b/pkg/block/local/fs/legacy_test.go
@@ -109,3 +109,44 @@ func TestNewWithOptionsOpensCleanDir(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = s.Close() })
 }
+
+// TestNewWithOptionsMigratesLegacy covers the remote-backed upgrade path: with
+// MigrateLegacyLayout set, a pre-journal dir opens instead of failing, the legacy
+// blobs/+logs/ are archived aside (non-destructively) so the journal owns the dir,
+// and the store reports MigratedFromLegacy. A second open is a normal clean open —
+// the guard no longer fires because the legacy dirs are gone.
+func TestNewWithOptionsMigratesLegacy(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "blobs", "0000000000000000.blob"), 1024)
+	writeFile(t, filepath.Join(dir, "logs", "share", "f.log"), 512)
+
+	s, err := NewWithOptions(dir, 1<<30, nil, FSStoreOptions{MigrateLegacyLayout: true})
+	if err != nil {
+		t.Fatalf("NewWithOptions with MigrateLegacyLayout over legacy dir: %v", err)
+	}
+	if !s.MigratedFromLegacy() {
+		t.Fatal("MigratedFromLegacy = false, want true after archiving a legacy dir")
+	}
+
+	// Legacy dirs archived aside (non-destructive), originals gone.
+	for _, sub := range []string{"blobs", "logs"} {
+		if _, err := os.Stat(filepath.Join(dir, sub)); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("legacy %s/ still present after migration (err=%v)", sub, err)
+		}
+		if _, err := os.Stat(filepath.Join(dir, sub+legacyBackupSuffix)); err != nil {
+			t.Fatalf("archived %s%s missing: %v", sub, legacyBackupSuffix, err)
+		}
+	}
+	_ = s.Close()
+
+	// Second open: dir is now clean (no legacy layout), so a plain open succeeds
+	// and reports no migration — the archive is idempotent across restarts.
+	s2, err := NewWithOptions(dir, 1<<30, nil, FSStoreOptions{MigrateLegacyLayout: true})
+	if err != nil {
+		t.Fatalf("second NewWithOptions after migration: %v", err)
+	}
+	if s2.MigratedFromLegacy() {
+		t.Fatal("MigratedFromLegacy = true on a second open; archive is not idempotent")
+	}
+	_ = s2.Close()
+}

--- a/pkg/controlplane/runtime/shares/create_local_store_test.go
+++ b/pkg/controlplane/runtime/shares/create_local_store_test.go
@@ -46,7 +46,7 @@ func TestCreateLocalStoreFromConfig_AppendLogMandatory(t *testing.T) {
 	mds := metamem.NewMemoryMetadataStoreWithDefaults()
 	t.Cleanup(func() { _ = mds.Close() })
 
-	store, err := CreateLocalStoreFromConfig(ctx, "fs", cfg, "test-share", nil, mds)
+	store, err := CreateLocalStoreFromConfig(ctx, "fs", cfg, "test-share", nil, mds, false)
 	if err != nil {
 		t.Fatalf("CreateLocalStoreFromConfig: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestCreateLocalStoreFromConfig_InvalidTypesIgnored(t *testing.T) {
 	mds := metamem.NewMemoryMetadataStoreWithDefaults()
 	t.Cleanup(func() { _ = mds.Close() })
 
-	store, err := CreateLocalStoreFromConfig(ctx, "fs", cfg, "bad-types", nil, mds)
+	store, err := CreateLocalStoreFromConfig(ctx, "fs", cfg, "bad-types", nil, mds, false)
 	if err != nil {
 		t.Fatalf("CreateLocalStoreFromConfig: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestCreateLocalStoreFromConfig_RollupSurvivesCallerCancel(t *testing.T) {
 	mds := metamem.NewMemoryMetadataStoreWithDefaults()
 	t.Cleanup(func() { _ = mds.Close() })
 
-	store, err := CreateLocalStoreFromConfig(ctx, "fs", cfg, "cancel-share", nil, mds)
+	store, err := CreateLocalStoreFromConfig(ctx, "fs", cfg, "cancel-share", nil, mds, false)
 	if err != nil {
 		t.Fatalf("CreateLocalStoreFromConfig: %v", err)
 	}

--- a/pkg/controlplane/runtime/shares/legacy_migrate_test.go
+++ b/pkg/controlplane/runtime/shares/legacy_migrate_test.go
@@ -1,0 +1,131 @@
+package shares
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/block/local/fs"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	metamem "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// newMigrateEngine builds a full engine.Store over an fs local store rooted at
+// dir + a memory remote + memory metadata, mirroring the engine drain-reset
+// fixture. ManualSync keeps DrainRollups the deterministic carve driver so the
+// remote block sink and FileChunk manifest are populated on demand.
+func newMigrateEngine(t *testing.T, dir string, ms *metamem.MemoryMetadataStore, rem *remotememory.Store, migrate bool) *engine.Store {
+	t.Helper()
+	localStore, err := fs.NewWithOptions(dir, 100*1024*1024, ms, fs.FSStoreOptions{MigrateLegacyLayout: migrate})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+	cfg := engine.DefaultConfig()
+	cfg.ManualSync = true
+	// Wrap the shared memory remote so an engine Close() does not close it — the
+	// remote outlives the first store the same way ref-counting keeps it alive in
+	// production (a second engine reopens over the same remote after the upgrade).
+	engineRemote := &nonClosingRemote{rem}
+	syncer := engine.NewSyncer(localStore, engineRemote, ms, cfg)
+	bs, err := engine.New(engine.BlockStoreConfig{
+		Local:           localStore,
+		Remote:          engineRemote,
+		Syncer:          syncer,
+		FileChunkStore:  ms,
+		SyncedHashStore: ms,
+		ReadBufferBytes: 64 * 1024 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("engine.New: %v", err)
+	}
+	syncer.SetRemoteBlockStore(rem)
+	if err := bs.Start(context.Background()); err != nil {
+		t.Fatalf("engine.Start: %v", err)
+	}
+	// The fs store's migration flag is consumed here, the same way
+	// ConfigureBlockStore does it after bs.Start.
+	if m, ok := any(localStore).(interface{ MigratedFromLegacy() bool }); ok && m.MigratedFromLegacy() {
+		if err := SeedColdFromManifest(context.Background(), bs, ms); err != nil {
+			t.Fatalf("SeedColdFromManifest: %v", err)
+		}
+	}
+	return bs
+}
+
+// TestLegacyRemoteMigration_ReadsColdFromRemote is the whole point of the
+// remote-backed upgrade path: a share whose local dir carried the pre-journal
+// blobs/+logs/ layout must, after migration, serve byte-identical data by cold-
+// fetching from the remote via the surviving metadata manifest — not zeros.
+func TestLegacyRemoteMigration_ReadsColdFromRemote(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	ms := metamem.NewMemoryMetadataStoreWithDefaults()
+	t.Cleanup(func() { _ = ms.Close() })
+	rem := remotememory.New()
+
+	// --- v0.26-era write: data lands in the remote + manifest ---
+	bs1 := newMigrateEngine(t, dir, ms, rem, false)
+	files := map[string][]byte{
+		"small-a":  bytes.Repeat([]byte{0x11}, 4096),
+		"small-b":  []byte("the quick brown fox jumps over the lazy dog"),
+		"multi-mb": bytes.Repeat([]byte{0x5A, 0xA5}, 3*1024*1024),
+	}
+	for id, data := range files {
+		if _, err := bs1.WriteAt(ctx, id, nil, data, 0); err != nil {
+			t.Fatalf("WriteAt %s: %v", id, err)
+		}
+	}
+	// Carve to remote + populate the FileChunk manifest, then close so the local
+	// journal is quiescent.
+	if err := bs1.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups: %v", err)
+	}
+	if err := bs1.Close(); err != nil {
+		t.Fatalf("close bs1: %v", err)
+	}
+
+	// --- simulate the upgrade: wipe the journal, plant a pre-journal layout ---
+	// The remote (rem) and metadata (ms) survive intact — only the local journal
+	// is replaced by leftover v0.26 blobs/+logs/.
+	if err := os.RemoveAll(filepath.Join(dir, "journal")); err != nil {
+		t.Fatalf("wipe journal: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "blobs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "blobs", "0000000000000000.blob"), []byte("legacy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "logs", "share"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "logs", "share", "f.log"), []byte("legacy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// --- reopen on the new binary: migrate + cold-seed, then read ---
+	bs2 := newMigrateEngine(t, dir, ms, rem, true)
+	t.Cleanup(func() { _ = bs2.Close() })
+
+	// Legacy dirs archived aside, not destroyed.
+	for _, sub := range []string{"blobs", "logs"} {
+		if _, err := os.Stat(filepath.Join(dir, sub+".pre-journal-backup")); err != nil {
+			t.Fatalf("legacy %s not archived: %v", sub, err)
+		}
+	}
+
+	for id, want := range files {
+		got := make([]byte, len(want))
+		n, err := bs2.ReadAt(ctx, id, nil, got, 0)
+		if err != nil {
+			t.Fatalf("ReadAt %s after migration: %v", id, err)
+		}
+		if n != len(want) || !bytes.Equal(got, want) {
+			t.Fatalf("ReadAt %s: read %d bytes, byte-identical=%v; migration served wrong bytes",
+				id, n, bytes.Equal(got, want))
+		}
+	}
+}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1028,7 +1028,12 @@ func (s *Service) createBlockStoreForShare(
 	remoteConfigured := config.RemoteBlockStoreID != ""
 	effectiveDefaults := mergeLocalStoreDefaults(localStoreDefaults, config, remoteConfigured)
 
-	localStore, err := CreateLocalStoreFromConfig(ctx, localCfg.Type, localCfg, config.Name, effectiveDefaults, fileChunkStore)
+	// A remote-backed share whose local dir still holds the pre-journal
+	// blobs/+logs/ layout is migrated in place: the local dirs are archived aside
+	// so the journal opens clean, and the bytes are re-materialized from the
+	// remote via a cold seed below. A local-only share passes false so the
+	// guardrail refuses to open a legacy dir (its bytes are the sole copy).
+	localStore, err := CreateLocalStoreFromConfig(ctx, localCfg.Type, localCfg, config.Name, effectiveDefaults, fileChunkStore, remoteConfigured)
 	if err != nil {
 		return fmt.Errorf("failed to create local store: %w", err)
 	}
@@ -1162,6 +1167,29 @@ func (s *Service) createBlockStoreForShare(
 	if err := bs.Start(ctx); err != nil {
 		cleanup()
 		return fmt.Errorf("failed to start BlockStore: %w", err)
+	}
+
+	// If the local dir carried a pre-journal layout that was just archived aside,
+	// the journal opened empty — reads would zero-fill. Seed a cold interval per
+	// manifest extent so reads fault the bytes back in from the remote (cold
+	// fetch is BLAKE3-verified). The metadata manifest survives the upgrade
+	// intact, so this is safe to re-run: a partial seed loses nothing (remote
+	// bytes + manifest are untouched) and a second start finds no legacy dir and
+	// skips straight to a clean open.
+	// ponytail: O(files) manifest scan at startup; a lazy per-read seed is the
+	// upgrade path if this ever bites a share with a huge file count.
+	if m, ok := localStore.(interface{ MigratedFromLegacy() bool }); ok && m.MigratedFromLegacy() {
+		if metaStore, ok := fileChunkStore.(metadata.Store); ok {
+			if serr := SeedColdFromManifest(ctx, bs, metaStore); serr != nil {
+				cleanup()
+				return fmt.Errorf("seed cold intervals after legacy migration: %w", serr)
+			}
+			logger.Info("migrated pre-journal local layout: archived blobs/+logs/ aside and seeded cold intervals from manifest",
+				"share", config.Name)
+		} else {
+			logger.Warn("migrated pre-journal local layout but metadata store is not manifest-capable; reads will zero-fill until rewritten",
+				"share", config.Name)
+		}
 	}
 
 	// Thread the inline metrics recorder into the new store's eviction/
@@ -2824,6 +2852,7 @@ func CreateLocalStoreFromConfig(
 	shareName string,
 	defaults *LocalStoreDefaults,
 	fileChunkStore block.EngineFileChunkStore,
+	migrateLegacy bool,
 ) (local.LocalStore, error) {
 	config, err := cfg.GetConfig()
 	if err != nil {
@@ -2858,6 +2887,11 @@ func CreateLocalStoreFromConfig(
 	// are warned and ignored.
 	var fsOpts fs.FSStoreOptions
 	fsOpts.BackpressureMaxWait = backpressureMaxWait
+	// A remote-backed share may carry a pre-journal blobs/+logs/ layout from an
+	// upgrade; archive it aside so the journal opens clean (the caller then cold-
+	// seeds from the surviving manifest). Local-only shares keep migrateLegacy
+	// false so the guardrail stays fatal.
+	fsOpts.MigrateLegacyLayout = migrateLegacy
 	// Local-cache size-hint default. Precedence (lowest first):
 	// FSStore internal default < global/deduced default (plumbed via
 	// LocalStoreDefaults.MaxLogBytes) < per-store config["max_log_bytes"].
@@ -2997,6 +3031,36 @@ func applyDurableOverride(store any, config map[string]any, label, shareName str
 	}
 	setter.SetDurable(b)
 	logger.Info("block store durability overridden by config", "store", label, "share", shareName, "durable", b)
+}
+
+// SeedColdFromManifest seeds a cold journal interval for every FileChunk in the
+// share's metadata manifest so a subsequent read faults the bytes in from the
+// remote store instead of zero-filling. It is used when the journal has no local
+// copy of the data — after a snapshot restore wiped the local tier, or after a
+// pre-journal upgrade archived the legacy local layout aside. Remote-backed
+// shares only (the caller gates on that); the cold fetch it arms is
+// BLAKE3-verified. One ListFileChunks per payload — O(chunks), acceptable for a
+// rare control-plane / startup path.
+func SeedColdFromManifest(ctx context.Context, bs *engine.Store, metaStore metadata.Store) error {
+	return metaStore.EnumeratePayloads(ctx, func(payloadID string) error {
+		rows, err := metaStore.ListFileChunks(ctx, payloadID)
+		if err != nil {
+			return fmt.Errorf("list manifest for %s: %w", payloadID, err)
+		}
+		for _, row := range rows {
+			if row == nil {
+				continue
+			}
+			off, ok := block.ParseChunkOffset(row.ID)
+			if !ok {
+				continue
+			}
+			if err := bs.SeedCold(ctx, payloadID, int64(off), int64(row.DataSize)); err != nil {
+				return fmt.Errorf("seed cold %s: %w", row.ID, err)
+			}
+		}
+		return nil
+	})
 }
 
 // parseRequireDurableCommit reads the optional per-share "require_durable_commit"

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -1581,7 +1581,7 @@ func (r *Runtime) restoreSnapshot(
 	// Remote-backed shares only — a local-only share has no remote to hydrate from
 	// (that restore path is tracked in #1718).
 	if remoteVerify {
-		if serr := r.seedColdFromManifest(ctx, bs, metaStore); serr != nil {
+		if serr := shares.SeedColdFromManifest(ctx, bs, metaStore); serr != nil {
 			return safetySnapshotID, fmt.Errorf("restore snapshot %q: seed cold intervals (safety-snap=%s): %w: %v",
 				snapID, safetySnapshotID, models.ErrRestoreAborted, serr)
 		}
@@ -1649,33 +1649,6 @@ func (r *Runtime) restoreSnapshot(
 		"restored_count", restoredCount,
 	)
 	return safetySnapshotID, nil
-}
-
-// seedColdFromManifest seeds a cold journal interval for every FileChunk in the
-// restored manifest so post-restore reads fault the bytes in from remote instead
-// of zero-filling (the local tier was just wiped by ResetLocalState). Remote
-// shares only — the caller gates on that. One ListFileChunks per payload; carve
-// steady-state keeps that O(chunks), and restore is a rare control-plane op.
-func (r *Runtime) seedColdFromManifest(ctx context.Context, bs *engine.Store, metaStore metadata.Store) error {
-	return metaStore.EnumeratePayloads(ctx, func(payloadID string) error {
-		rows, err := metaStore.ListFileChunks(ctx, payloadID)
-		if err != nil {
-			return fmt.Errorf("list manifest for %s: %w", payloadID, err)
-		}
-		for _, row := range rows {
-			if row == nil {
-				continue
-			}
-			off, ok := block.ParseChunkOffset(row.ID)
-			if !ok {
-				continue
-			}
-			if err := bs.SeedCold(ctx, payloadID, int64(off), int64(row.DataSize)); err != nil {
-				return fmt.Errorf("seed cold %s: %w", row.ID, err)
-			}
-		}
-		return nil
-	})
 }
 
 // raisePinForLocalOnly bumps a local-only share's journal snapshot pin to jv


### PR DESCRIPTION
## Stacked on #1802

This builds on the guardrail branch `fix/1801-legacy-upgrade-guardrail` (PR #1802), which is **not yet merged**. The base is `develop`, so until #1802 merges this PR shows both commits; rebase onto develop once #1802 lands.

## What

#1802 made a legacy (pre-journal `blobs/`+`logs/`) local dir **fail loud** rather than silently serve zeros. This PR lets a **remote-backed** share upgrade smoothly instead:

- On startup, a remote-backed share whose local dir carries the legacy layout **archives** `blobs/` -> `blobs.pre-journal-backup` and `logs/` -> `logs.pre-journal-backup` (non-destructive), so the journal opens clean.
- It then **seeds a cold interval per FileChunk manifest extent** so a subsequent read faults the bytes back in from the remote (BLAKE3-verified cold fetch). The metadata `File.Blocks` manifest survives the upgrade intact, so no bytes are lost.
- **Local-only shares keep the fatal guardrail** — their on-disk bytes are the sole copy and can't be recovered by an empty journal (that path is a separate follow-up).

## How it's wired

- `fs.FSStoreOptions.MigrateLegacyLayout` gates archive-vs-refuse at the exact site the guardrail checks (same `dir`, no path drift). Only remote-backed callers set it. `FSStore.MigratedFromLegacy()` reports whether an archive happened.
- `shares.ConfigureBlockStore` passes `remoteConfigured` into `CreateLocalStoreFromConfig`, and after `bs.Start` calls `SeedColdFromManifest` when the store migrated.
- `SeedColdFromManifest` is the **same cold-seed loop already used by snapshot restore** — extracted from `runtime.seedColdFromManifest` into the shares package and reused by both. No parallel fetch path, no hash-indexed local read.

## Idempotency / safety

After archiving, a second start finds no legacy dir and opens clean (reads still cold-fetch from the intact manifest). A partial/failed seed loses nothing — the remote bytes + manifest are untouched, worst case is a re-run.

Startup seeding is O(files); marked with a `ponytail:` note — lazy per-read seeding is the upgrade path if it ever bites a huge-file-count share.

## Tests

- **Unit (fs):** `TestNewWithOptionsMigratesLegacy` — archives the legacy dirs, opens clean, reports `MigratedFromLegacy`, and is idempotent across restarts.
- **Integration (shares):** `TestLegacyRemoteMigration_ReadsColdFromRemote` — full engine over a memory remote: write small + multi-MB files, carve to remote, wipe the local journal and plant a legacy layout, reopen with migration + cold-seed, and confirm every file reads back **byte-identical** (cold-fetched, not zeros) with the legacy dirs archived aside.
- VM byte-identical proof (v0.26.0 -> branch on the same dirs) recorded in the PR thread by the coordinator.