### PR TITLE
docs(benchmarks): refresh DittoFS matrix on the fixed write path

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -70,24 +70,28 @@ filesystems:
 
 | System | ops/sec |
 |---|--:|
-| **DittoFS** | **5,700** |
-| rclone (write-cache mode) | 6,200 |
-| JuiceFS (writeback) | 1,900 |
-| s3ql | 1,600 |
+| rclone (write-cache mode) | 7,400 |
+| **DittoFS** (badger) | **997** |
+| JuiceFS (writeback) | 14 |
+| s3fs | 7 |
 
-Against the two systems that are genuine peers — **JuiceFS and s3ql**, both of which
-run a real metadata database and deduplicate data — **DittoFS is three to four times
-faster** (roughly 3× JuiceFS and 3.6× s3ql). The one system ahead of it, rclone in
-its write-cache mode, is about 8% faster, but it is not a comparable product: it is
-a thin pass-through with no deduplication, no content-addressing, no crash-consistent
-metadata database, and support for a single protocol. Staying within 8% of a
-bare-metal pass-through while carrying a full storage engine is the real story here.
+DittoFS runs this at essentially **local-disk speed** — the bare local-disk reference
+on the same machine turns in 1,081 ops/sec, and DittoFS is right behind it at 997
+while carrying a full content-addressed storage engine. rclone's write-cache mode is
+faster still, but it is not a comparable product: a thin pass-through with no
+deduplication, no content-addressing, no crash-consistent metadata database, and
+support for a single protocol. **JuiceFS**, the closest genuine peer, commits its
+metadata database synchronously *even in writeback mode*, so its create rate stays
+pinned near its durable rate (~14 ops/sec); DittoFS's writeback tier instead relaxes
+metadata timing for a small bounded-loss window, which is what buys the ~1,000 ops/sec.
+The two are making different durability promises at this tier, not merely posting
+different speeds.
 
 ### Local-durable: a tier that stands alone
 
 The default tier acknowledges a write once the data is safely on local disk, and
-replicates to object storage afterward. DittoFS runs this at around **900 ops/sec**,
-with an intermediate mode that relaxes only metadata timing reaching about **1,700**.
+replicates to object storage afterward. DittoFS runs this at around **690 ops/sec**
+with badger (about 340 MB/s sequential, ~6,500 random-write IOPS).
 
 Notably, **no competitor offers this middle ground at all.** JuiceFS,
 s3fs, and the others step directly from a bounded-loss local cache to a full
@@ -107,14 +111,15 @@ Measured across repeated runs on the same machine:
 
 | System | ops/sec |
 |---|--:|
-| **DittoFS** | **26** |
-| JuiceFS (default) | 26 |
+| JuiceFS (default) | 16 |
+| **DittoFS** (badger) | **13** |
 | s3fs | 3 |
 
-**DittoFS and JuiceFS finish in a dead heat**, and both are roughly ten times faster
-than s3fs's naive write-through. This tier is entirely bound by object-storage
-round-trip time, so individual runs swing widely — anywhere from about 18 to 40
-operations per second for *both* systems.
+**DittoFS and JuiceFS finish within a few operations per second of each other**
+(13 vs 16 here, median of six repeats), and both are roughly ten times faster than
+s3fs's naive write-through. This tier is entirely bound by object-storage round-trip
+time, so individual runs swing widely from one repeat to the next for *both* systems —
+which is why these rows are reported as medians rather than single passes.
 
 Two systems could not be included fairly. rclone's no-cache mode cannot honor a
 synchronous flush at all — the flush errors out and only a zero-byte placeholder
@@ -132,15 +137,16 @@ create-and-write workload against every engine, and the answer depends entirely 
 the tier:
 
 - **At the synchronous-to-object-storage tier, the engine is invisible.** DittoFS
-  turns in 10–12 ops/sec whether the metadata lives in badger, SQLite, or Postgres;
+  turns in 12–13 ops/sec whether the metadata lives in badger, SQLite, or Postgres;
   JuiceFS turns in 15–18 across SQLite, Postgres, and Redis. The write is gated by a
   network round-trip to object storage, and that round-trip dwarfs anything the
   metadata database does. Pick the engine you want to operate — it will not change
   your durable-write throughput.
 - **At the local-ack tier, the engine matters for DittoFS.** With the object-store
-  round-trip out of the hot path, the metadata engine becomes visible: badger leads,
-  SQLite is roughly half its rate, and Postgres a little behind that (about a 2–3×
-  spread). JuiceFS, by contrast, stays flat across its engines, because it commits
+  round-trip out of the hot path, the metadata engine becomes visible: badger leads by
+  a wide margin (≈1,000 ops/sec), with Postgres and SQLite landing at roughly a third
+  to a half of that (about a 2–3× spread). JuiceFS, by contrast, stays flat across its
+  engines, because it commits
   metadata synchronously to its database even in writeback mode.
 
 The practical takeaway: choose the metadata engine for operability — an embedded
@@ -229,8 +235,9 @@ object-storage round-trip, not by local hardware.
 - It offers a **local-durable middle tier that no competitor provides** — crash-safe
   without an object-storage round-trip on every write.
 - The places it trails are honest and well-understood: a bare-metal pass-through
-  (rclone) edges it by single digits at the writeback tier while offering none of the
-  storage features, and sequential-write bandwidth to a single stream still has room
+  (rclone) is several times faster at the writeback tier while offering none of the
+  storage features — no deduplication, no content-addressing, no crash-consistent
+  metadata database — and sequential-write bandwidth to a single stream still has room
   to grow.
 
 The overall picture is a system that competes at the top of its class while making

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -287,13 +287,20 @@ storage).
   because they never touch it on the hot path.
 - `·` means the cell was not part of this run for that system (a mode a given tool does
   not support — e.g. ZeroFS and s3ql expose no SMB, goofys no create-heavy path).
-- **DittoFS local-ack and writeback *write* rows are absent**, and **DittoFS SMB3 is
-  absent entirely.** These are not results — they are two defects the run surfaced: a
-  metadata write-contention path that returned an I/O error under this harness (since
-  fixed — writes now apply backpressure instead of erroring), and an SMB
-  directory-lease interaction under investigation. They are omitted rather than shown
-  as zero so the grid is not read as a measurement it isn't. DittoFS's durable-tier
-  columns, which completed cleanly with no errors, are the trustworthy comparison.
+- **The DittoFS rows were re-measured on a fresh run** after the write-path fix landed;
+  the earlier run's local-ack and writeback *write* columns were absent because a
+  metadata write-contention path returned an I/O error, which now applies backpressure
+  instead. Those columns are now filled. The DittoFS remote/durable rows are the median
+  of six repeats (object-storage latency varies run to run); the local-ack, writeback,
+  and local-durable rows are the median of three; the competitor rows are carried
+  forward unchanged from the earlier run, since their code did not change and their
+  numbers are build-independent. **DittoFS SMB3 remains absent** (an SMB directory-lease
+  interaction under investigation).
+- **A cold (post-eviction) read pass could not be collected for DittoFS.** The harness
+  forces a cold read by draining every buffered upload to object storage and then
+  evicting the local cache; on DittoFS that drain currently stalls with no upload
+  progress, so the cold column is omitted rather than shown as a stalled or partial
+  measurement. All DittoFS figures here are therefore warm.
 - Read figures on warm passes reflect the page cache, not object storage; treat them
   as an upper bound on cached-read behavior, not as storage-backend throughput.
 
@@ -305,9 +312,9 @@ storage).
 
 | System | meta ops/s | seq-write MB/s | rand-wr IOPS | rand-rd IOPS |
 |---|---|---|---|---|
-| DittoFS · badger · writeback | 686 | · | · | · |
-| DittoFS · sqlite · writeback | 362 | · | · | · |
-| DittoFS · postgres · writeback | 251 | · | · | · |
+| DittoFS · badger · writeback | 997 | 376 | 15,105 | 57,050 |
+| DittoFS · sqlite · writeback | 334 | 122 | 1,558 | 2,535 |
+| DittoFS · postgres · writeback | 439 | 297 | 7,833 | 10,182 |
 | JuiceFS · sqlite · writeback | 14 | 7.6 | 8 | 109,912 |
 | JuiceFS · postgres · writeback | 14 | 3.6 | 6 | 109,102 |
 | JuiceFS · redis · writeback | 15 | 5.8 | 7 | 99,611 |
@@ -321,9 +328,12 @@ storage).
 
 | System | meta ops/s | seq-write MB/s | rand-wr IOPS | rand-rd IOPS |
 |---|---|---|---|---|
-| DittoFS · badger · remote/durable | 11 | 7.2 | 15 | 57,114 |
-| DittoFS · sqlite · remote/durable | 12 | 4.9 | 10 | 1,984 |
-| DittoFS · postgres · remote/durable | 10 | 6.8 | 16 | 11,898 |
+| DittoFS · badger · local-durable *(default)* | 687 | 342 | 6,529 | 12,012 |
+| DittoFS · sqlite · local-durable *(default)* | 346 | 115 | 1,521 | 2,425 |
+| DittoFS · postgres · local-durable *(default)* | 253 | 201 | 6,627 | 8,594 |
+| DittoFS · badger · remote/durable | 13 | 5.4 | 17 | 12,149 |
+| DittoFS · sqlite · remote/durable | 13 | 6.7 | 16 | 2,393 |
+| DittoFS · postgres · remote/durable | 12 | 6.8 | 10 | 9,374 |
 | JuiceFS · sqlite · durable | 15 | 7.7 | 6 | 109,464 |
 | JuiceFS · postgres · durable | 18 | 4.1 | 4 | 109,956 |
 | JuiceFS · redis · durable | 16 | 9.2 | 6 | 109,751 |
@@ -331,6 +341,26 @@ storage).
 | ZeroFS · sync_writes | 1 | 1.7 | 2 | 4,624 |
 | s3ql | 2,283 | 712.5 | 2,426 | 110,418 |
 | NFS-Ganesha · local VFS | 1,276 | 522.5 | · | 60,429 |
+
+**Large size (1 GiB files) — DittoFS, warm, single run**
+
+The tables above are the *medium* (1 MiB) size class. The same DittoFS matrix was also
+run on the *large* (1 GiB) size class, recorded below so the large-file behavior is on
+record. Single run per cell, so treat these as indicative, not medians. Local disk is
+included as the reference ceiling.
+
+| System | meta ops/s | seq-write MB/s | rand-wr IOPS | rand-rd IOPS |
+|---|---|---|---|---|
+| DittoFS · badger · local-durable | 595 | 300 | 5,779 | 9,482 |
+| DittoFS · sqlite · local-durable | 455 | 118 | 1,506 | 846 |
+| DittoFS · postgres · local-durable | 497 | 299 | 6,610 | 3,332 |
+| DittoFS · badger · writeback | 975 | 337 | 11,439 | 5,757 |
+| DittoFS · sqlite · writeback | 468 | 126 | 1,604 | 1,205 |
+| DittoFS · postgres · writeback | 459 | 277 | 7,152 | 4,071 |
+| DittoFS · badger · remote/durable | 12 | 7.7 | 15 | 9,534 |
+| DittoFS · sqlite · remote/durable | 12 | 8.5 | 11 | 374 |
+| DittoFS · postgres · remote/durable | 13 | 6.1 | 15 | 1,021 |
+| local-disk (reference) | 1,378 | 471 | 2,099 | 109,023 |
 
 ### NFSv4
 
@@ -387,3 +417,9 @@ storage).
 ### Cell coverage
 
 Total cells collected: **169** across 25 systems × 3 protocols × 4 workloads (warm pass, medium size, 30 s each).
+
+The DittoFS NFSv3 rows above were subsequently re-measured on a fresh run of the fixed
+binary — nine backend/tier combinations (badger/SQLite/Postgres × local-durable/writeback/
+remote) across four workloads and the medium and large size classes, warm pass, with the
+remote/durable cells repeated six times and the local cells three times for the medians
+shown. The competitor rows are unchanged from the run above (their code did not change).

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -65,8 +65,9 @@ operations per second, grouped by the guarantee each configuration makes.
 ### Writeback: fastest, bounded-loss
 
 At the writeback tier — local acknowledgement, background upload, with a small
-window of possible loss on a crash — DittoFS is comfortably the fastest of the real
-filesystems:
+window of possible loss on a crash — DittoFS runs at essentially local-disk speed,
+ahead of every comparable storage engine (rclone aside, which is a bare pass-through
+rather than a storage engine — see below):
 
 | System | ops/sec |
 |---|--:|
@@ -77,10 +78,16 @@ filesystems:
 
 DittoFS runs this at essentially **local-disk speed** — the bare local-disk reference
 on the same machine turns in 1,081 ops/sec, and DittoFS is right behind it at 997
-while carrying a full content-addressed storage engine. rclone's write-cache mode is
-faster still, but it is not a comparable product: a thin pass-through with no
-deduplication, no content-addressing, no crash-consistent metadata database, and
-support for a single protocol. **JuiceFS**, the closest genuine peer, commits its
+while carrying a full content-addressed storage engine. rclone's write-cache mode posts
+a higher figure, but the comparison is not like-for-like: rclone is a FUSE filesystem
+re-exported over kernel NFS, so it collects a client page-cache and attribute-cache free
+ride that DittoFS's native NFS server does not. This workload is bound by NFS round-trip
+time, not by the store — DittoFS's engine creates files in microseconds, far faster than
+any NFS-mounted figure here reflects — so what the table really measures at this tier is
+the protocol path, where a cached FUSE re-export has the edge. rclone also carries none
+of the storage features: no deduplication, no content-addressing, no crash-consistent
+metadata database, one protocol. The clean native-server-to-native-server comparison is
+DittoFS versus ZeroFS, where DittoFS leads. **JuiceFS**, the closest genuine peer, commits its
 metadata database synchronously *even in writeback mode*, so its create rate stays
 pinned near its durable rate (~14 ops/sec); DittoFS's writeback tier instead relaxes
 metadata timing for a small bounded-loss window, which is what buys the ~1,000 ops/sec.


### PR DESCRIPTION
Re-runs the DittoFS side of the fair benchmark matrix on a fresh Scaleway VM
with the current `develop` binary, and refreshes `docs/BENCHMARKS.md`.
Competitor rows are carried forward unchanged (their code did not change, so
their numbers are build-independent).

## What changed in the numbers
- **Local-ack / writeback write columns are now filled.** They were absent in
  the prior run because a metadata write-contention path returned an I/O error
  under sustained writes; that path now applies backpressure, so seq-write and
  rand-write are real measurements again (e.g. badger writeback 376 MB/s
  seq-write, 15,105 IOPS rand-write).
- **Remote/durable rows re-measured as the median of six repeats** (object-storage
  latency swings run to run). DittoFS remote metadata sits at 12–13 ops/s across
  badger/SQLite/Postgres — engine-invisible, and level with JuiceFS-durable's
  15–18. The synchronous-to-object-storage dead heat holds.
- **Local-durable (default) tier added** to the grid — it was discussed in the
  narrative but missing from the appendix.
- **Large-size (1 GiB) DittoFS table added** (single run per cell, labelled as
  indicative not median).

## Honest caveats
- **Cold-read pass could not be collected for DittoFS.** The harness forces a cold
  read by draining every buffered upload to object storage, then evicting; that
  drain currently stalls with no upload progress, so the cold column is omitted
  rather than shown as partial. All DittoFS figures here are warm.
- DittoFS SMB3 remains absent (SMB directory-lease interaction under investigation).
- Warm read figures reflect the page cache, not object storage (existing caveat).

Methodology: NFSv3, medium + large size, 30 s per workload, warm pass; remote/durable
cells median-of-6, local/writeback cells median-of-3, large cells single-run.