### PR TITLE
fix(smb): stop double-breaking parent dir leases on delete-on-close

### DIFF
--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -577,20 +577,16 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 					h.purgeBlockStorePayload(ctx.Context, deleteTargetHandle, removedPayloadID, openFile.Path, "CLOSE")
 					h.restoreParentDirFrozenTimestamps(authCtx, deleteParentHandle)
 
-					// Break parent directory leases: deletion changes directory
-					// content. When docSetterKeysDiffer, clear the closer's
-					// parent key so no suppression applies — all dir leases break.
-					if docSetterKeysDiffer {
-						savedKey := openFile.ParentLeaseKey
-						savedHas := openFile.HasParentLeaseKey
-						openFile.HasParentLeaseKey = false
-						openFile.ParentLeaseKey = [16]byte{}
-						h.breakParentDirLeasesForContentChange(ctx, authCtx, openFile)
-						openFile.ParentLeaseKey = savedKey
-						openFile.HasParentLeaseKey = savedHas
-					} else {
-						h.breakParentDirLeasesForContentChange(ctx, authCtx, openFile)
-					}
+					// Removing the entry already broke the parent directory's
+					// leases: RemoveFile / RemoveDirectory notify the dir-change
+					// listener, which breaks every parent dir lease (except the
+					// originator / suppressed key) to None. The parent-key
+					// suppression was applied via the authCtx propagated above
+					// (closer's key when it matches the DOC-setter's key; none
+					// when they differ, so all dir leases break). Dispatching a
+					// second break here would re-break a lease the client may have
+					// already acked and re-cached in the meantime, sending a
+					// duplicate LEASE_BREAK for one logical change.
 
 					if h.NotifyRegistry != nil {
 						parentPath := GetParentPath(openFile.Path)

--- a/pkg/metadata/file_recycle_test.go
+++ b/pkg/metadata/file_recycle_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
 	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,6 +49,41 @@ func newRecycleFixture(t *testing.T) *testFixture {
 		shareName:  shareName,
 		rootHandle: rootHandle,
 	}
+}
+
+// TestRemoveFile_RecycleNotifiesDirChange guards against a caching client
+// serving a stale directory listing after a delete on a trash-enabled share.
+// Recycling still removes the name from its parent, so RemoveFile must break the
+// parent's directory leases (via the dir-change notification) exactly as the
+// permanent-delete path does — otherwise a client holding a directory lease keeps
+// showing the just-recycled entry. RemoveDirectory's recycle branch already notifies.
+func TestRemoveFile_RecycleNotifiesDirChange(t *testing.T) {
+	t.Parallel()
+
+	fx := newRecycleFixture(t)
+	fx.service.SetTrashPolicy(stubTrashPolicy{cfg: metadata.TrashConfig{Enabled: true}})
+	notifier := &recordingNotifier{}
+	fx.service.SetDirChangeNotifier(fx.shareName, notifier)
+
+	_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "victim.txt", &metadata.FileAttr{Mode: 0644})
+	require.NoError(t, err)
+
+	// Trash enabled: this delete routes through the recycle branch.
+	removed, _, err := fx.service.RemoveFile(fx.rootContext(), fx.rootHandle, "victim.txt")
+	require.NoError(t, err)
+	require.NotNil(t, removed)
+
+	notifier.mu.Lock()
+	defer notifier.mu.Unlock()
+	removeCalls := 0
+	for _, c := range notifier.calls {
+		if c.ChangeType == lock.DirChangeRemoveEntry {
+			removeCalls++
+		}
+	}
+	assert.Equal(t, 1, removeCalls,
+		"recycling a file must still break the parent's directory leases; without the "+
+			"notification a caching client serves a stale listing that still shows the entry")
 }
 
 func TestRemoveFile_RecyclesWhenTrashEnabled(t *testing.T) {

--- a/pkg/metadata/file_remove.go
+++ b/pkg/metadata/file_remove.go
@@ -102,6 +102,12 @@ func (s *Service) RemoveFile(ctx *AuthContext, parentHandle FileHandle, name str
 				if after, aErr := store.GetFile(ctx.Context, parentHandle); aErr == nil {
 					wcc.After = CopyFileAttr(&after.FileAttr)
 				}
+				// Recycling still removes the name from its parent, so break the
+				// parent's directory leases exactly as the permanent-delete path
+				// below does — otherwise a caching client keeps serving a stale
+				// listing that still shows the recycled entry. RemoveDirectory's
+				// recycle branch notifies for the same reason.
+				s.notifyDirChange(shareName, parentHandle, lock.DirChangeRemoveEntry, ctx)
 				return recycled, wcc, nil
 			}
 		}

--- a/pkg/metadata/lock/directory.go
+++ b/pkg/metadata/lock/directory.go
@@ -229,6 +229,17 @@ func (lm *Manager) OnDirChange(parentHandle FileHandle, changeType DirChangeType
 			delegsToBreak = append(delegsToBreak, lock)
 		}
 	}
+	// Serialize directory RH-lease breaks: revoking the handle-caching bit waits
+	// for the client's acknowledgment, so when one directory change breaks
+	// several dir leases they are delivered one at a time. Only the first is
+	// dispatched below; mark the rest deferred on the live record so each
+	// acknowledgment dispatches the next (see dispatchNextDeferredDirBreakLocked).
+	for i := 1; i < len(leasesToBreak); i++ {
+		if leasesToBreak[i].Lease != nil {
+			leasesToBreak[i].Lease.BreakDeferred = true
+		}
+	}
+
 	// Clone locks before releasing mu so that dispatch callbacks receive
 	// snapshots. Without this, concurrent AcknowledgeLeaseBreak can mutate
 	// the live *UnifiedLock while the callback reads it.
@@ -252,9 +263,10 @@ func (lm *Manager) OnDirChange(parentHandle FileHandle, changeType DirChangeType
 		"leaseCount", len(leasesToBreak),
 		"delegCount", len(delegsToBreak))
 
-	// Dispatch lease breaks outside the lock
-	for _, lock := range leasesToBreak {
-		lm.dispatchOpLockBreak(handleKey, lock, LeaseStateNone)
+	// Dispatch only the first lease break now; the rest were marked
+	// BreakDeferred above and ride the acknowledgment chain one at a time.
+	if len(leasesToBreak) > 0 {
+		lm.dispatchOpLockBreak(handleKey, leasesToBreak[0], LeaseStateNone)
 	}
 
 	// Dispatch delegation recalls outside the lock (Recalled already set under lm.mu)
@@ -266,4 +278,31 @@ func (lm *Manager) OnDirChange(parentHandle FileHandle, changeType DirChangeType
 	if lm.recentlyBroken != nil {
 		lm.recentlyBroken.Mark(handleKey)
 	}
+}
+
+// dispatchNextDeferredDirBreakLocked sends the wire notification for the next
+// directory lease on handleKey whose break was deferred behind an earlier one
+// (Breaking=true, BreakDeferred=true). Called from the acknowledgment path so
+// that serialized directory RH-lease breaks are delivered one at a time. Must be
+// called with lm.mu held; it releases and re-acquires lm.mu around the dispatch
+// callback and returns with lm.mu held.
+func (lm *Manager) dispatchNextDeferredDirBreakLocked(handleKey string) {
+	var next *UnifiedLock
+	for _, lock := range lm.unifiedLocks[handleKey] {
+		if lock.Lease != nil && lock.Lease.IsDirectory &&
+			lock.Lease.Breaking && lock.Lease.BreakDeferred {
+			lock.Lease.BreakDeferred = false
+			next = lock
+			break
+		}
+	}
+	if next == nil {
+		return
+	}
+	snapshot := next.Clone()
+	func() {
+		lm.mu.Unlock()
+		defer lm.mu.Lock()
+		lm.dispatchOpLockBreak(handleKey, snapshot, LeaseStateNone)
+	}()
 }

--- a/pkg/metadata/lock/directory.go
+++ b/pkg/metadata/lock/directory.go
@@ -172,16 +172,24 @@ func (lm *Manager) OnDirChange(parentHandle FileHandle, changeType DirChangeType
 	canonicalByKey := make(map[[16]byte]*OpLock, len(locks))
 
 	for _, lock := range locks {
-		// Skip originator for the entire lock entry (covers both lease and delegation).
-		if lock.Owner.ClientID == originClientID {
+		// Skip the originator. Client-scoped exclusion covers directory
+		// delegations and, for entry add/rename, the originating client's
+		// directory leases. On entry REMOVAL, directory-lease suppression is
+		// governed solely by the parent lease key (checked below): the removing
+		// handle's own dir lease is spared via its matching parent key, while
+		// every other dir lease on the parent — including other-key leases held by
+		// the same client — must still break. Suppressing removal breaks by client
+		// would wrongly spare an other-key lease the parent-key rule breaks.
+		removalDirLease := changeType == DirChangeRemoveEntry &&
+			lock.Lease != nil && lock.Lease.IsDirectory
+		if lock.Owner.ClientID == originClientID && !removalDirLease {
 			continue
 		}
 
-		// Parent-key suppression: when the originating CREATE / SET_INFO
-		// carries an RqLs with ParentLeaseKey matching a parent dir lease's
-		// LeaseKey, that dir lease MUST NOT be broken (#470 C2). Applies to
-		// dir leases only — file lease / delegation paths below ignore the
-		// exclude key.
+		// Parent-key suppression: when the originating handle carries an RqLs
+		// with ParentLeaseKey matching a parent dir lease's LeaseKey, that dir
+		// lease is not broken (the originator's own cached view). Applies to dir
+		// leases only — file lease / delegation paths below ignore the exclude key.
 		if hasExcludeKey && lock.Lease != nil && lock.Lease.IsDirectory &&
 			lock.Lease.LeaseKey == excludeParentLeaseKey {
 			continue

--- a/pkg/metadata/lock/dirlease_dedup_break_test.go
+++ b/pkg/metadata/lock/dirlease_dedup_break_test.go
@@ -160,6 +160,80 @@ func TestOnDirChange_DedupsByLeaseKey(t *testing.T) {
 	assertBothSiblingsBreaking(t, lm, records)
 }
 
+// oneDirLease injects a single RH directory-lease record under handleKey owned by
+// ownerClient with the given key, wires a per-key break counter, and returns it.
+func oneDirLease(t *testing.T, lm *Manager, handleKey, ownerClient string, key [16]byte) (*sync.Mutex, map[[16]byte]int) {
+	t.Helper()
+	mu := &sync.Mutex{}
+	breaks := map[[16]byte]int{}
+	lm.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(_ string, l *UnifiedLock, _ uint32) {
+			mu.Lock()
+			breaks[l.Lease.LeaseKey]++
+			mu.Unlock()
+		},
+	})
+	lm.mu.Lock()
+	lm.unifiedLocks[handleKey] = []*UnifiedLock{{
+		Owner: LockOwner{OwnerID: "h1", ClientID: ownerClient},
+		Lease: &OpLock{LeaseKey: key, LeaseState: LeaseStateRead | LeaseStateHandle, Epoch: 1, IsDirectory: true},
+	}}
+	lm.reindexHandleLocked(handleKey, nil)
+	lm.mu.Unlock()
+	return mu, breaks
+}
+
+// TestOnDirChange_BreaksOriginatorsOtherDirLease reproduces the deterministic
+// count==0 behind smb2.dirlease.unlink_*_and_close. Per MS-SMB2 §3.3.4.20 and the
+// Samba object-store rule, a directory-content change breaks every parent dir
+// lease whose lease key differs from the change's parent lease key — INCLUDING a
+// dir lease the originating client holds on a different handle. Only the
+// parent-key-matched lease is spared; the originating CLIENT must not be
+// blanket-excluded.
+func TestOnDirChange_BreaksOriginatorsOtherDirLease(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	const handleKey = "/share:dir"
+	victimKey := [16]byte{0x02}
+	closerParentKey := [16]byte{0x01} // differs from victimKey → victim must break
+
+	// The victim dir lease is owned by the SAME client that originates the delete.
+	mu, breaks := oneDirLease(t, lm, handleKey, "smb:c1", victimKey)
+
+	lm.OnDirChange(FileHandle(handleKey), DirChangeRemoveEntry, "smb:c1", closerParentKey, true)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if breaks[victimKey] != 1 {
+		t.Fatalf("originator's other-key dir lease got %d breaks, want 1; a blanket "+
+			"client-exclusion wrongly suppressed a lease the parent-key rule says must break "+
+			"(the deterministic smb2.dirlease.unlink_*_and_close count==0)", breaks[victimKey])
+	}
+}
+
+// TestOnDirChange_SuppressesParentKeyMatchedDirLease pins the other half of the
+// rule: the dir lease whose key MATCHES the change's parent lease key is spared
+// (the originator's own cached view), even without any client-level exclusion.
+func TestOnDirChange_SuppressesParentKeyMatchedDirLease(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	const handleKey = "/share:dir"
+	matchedKey := [16]byte{0x07}
+
+	mu, breaks := oneDirLease(t, lm, handleKey, "smb:c1", matchedKey)
+
+	// Parent key == the lease key → parent-key suppression spares it.
+	lm.OnDirChange(FileHandle(handleKey), DirChangeRemoveEntry, "smb:c1", matchedKey, true)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if breaks[matchedKey] != 0 {
+		t.Fatalf("parent-key-matched dir lease got %d breaks, want 0 (must be suppressed)", breaks[matchedKey])
+	}
+}
+
 // TestAcknowledgeLeaseBreak_ClearsMirroredSiblings is a regression test for the
 // create/delete-heavy SMB3 stall: a mirrored sibling left Breaking=true after
 // the client's single acknowledge.

--- a/pkg/metadata/lock/dirlease_dedup_break_test.go
+++ b/pkg/metadata/lock/dirlease_dedup_break_test.go
@@ -1,8 +1,10 @@
 package lock
 
 import (
+	"context"
 	"sync"
 	"testing"
+	"time"
 )
 
 // dlease2Key is the DLEASE2 lease-key constant smbtorture reuses across every
@@ -41,6 +43,10 @@ func twoSameKeyDirLeases(t *testing.T, lm *Manager, handleKey string, key [16]by
 
 	lm.mu.Lock()
 	lm.unifiedLocks[handleKey] = records
+	// Populate the lease-key index so findLeaseByKey (used by
+	// AcknowledgeLeaseBreak) can resolve these directly-injected records, as it
+	// would for records added through the normal grant path.
+	lm.reindexHandleLocked(handleKey, nil)
 	lm.mu.Unlock()
 
 	return mu, breaksByKey, records
@@ -152,4 +158,58 @@ func TestOnDirChange_DedupsByLeaseKey(t *testing.T) {
 	// BreakToState/BreakingToRequired/Epoch) so a later OnDirChange scan can't
 	// treat the skipped sibling as an active non-breaking lease.
 	assertBothSiblingsBreaking(t, lm, records)
+}
+
+// TestAcknowledgeLeaseBreak_ClearsMirroredSiblings is a regression test for the
+// create/delete-heavy SMB3 stall: a mirrored sibling left Breaking=true after
+// the client's single acknowledge.
+//
+// A directory-content-change break dispatches one wire LEASE_BREAK per lease key
+// and mirrors the break stage onto every sibling sharing that key without a
+// second notification (opens sharing a key are one logical lease, MS-SMB2
+// §3.3.5.9 — see assertBothSiblingsBreaking). The client then sends exactly ONE
+// acknowledge for the key, which findLeaseByKey resolves to a single record.
+// Unless the acknowledge clears every record sharing the key, the mirrored
+// sibling stays Breaking=true forever, so WaitForBreakCompletion on that
+// handleKey blocks until the force-complete timeout on every following operation.
+func TestAcknowledgeLeaseBreak_ClearsMirroredSiblings(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	const handleKey = "/share:dir-uuid"
+	_, _, records := twoSameKeyDirLeases(t, lm, handleKey, dlease2Key)
+
+	// Break both same-key dir leases to None: one notification, sibling mirrored.
+	lm.OnDirChange(FileHandle(handleKey), DirChangeRemoveEntry, "smb:3", [16]byte{}, false)
+
+	// The client sends exactly ONE acknowledge for the shared lease key.
+	if err := lm.AcknowledgeLeaseBreak(context.Background(), dlease2Key, LeaseStateNone, 0); err != nil {
+		t.Fatalf("AcknowledgeLeaseBreak: %v", err)
+	}
+
+	// Every record sharing the key — the one findLeaseByKey resolved AND the
+	// mirrored sibling — must land at None with Breaking cleared.
+	lm.mu.Lock()
+	for i, rec := range records {
+		if rec.Lease.Breaking {
+			lm.mu.Unlock()
+			t.Fatalf("record %d (%s): Breaking=true after a single acknowledge; the "+
+				"mirrored sibling was never cleared (WaitForBreakCompletion stalls until "+
+				"the force-complete timeout)", i, rec.Owner.OwnerID)
+		}
+		if rec.Lease.LeaseState != LeaseStateNone {
+			lm.mu.Unlock()
+			t.Fatalf("record %d (%s): LeaseState=%#x after ack-to-None; want None",
+				i, rec.Owner.OwnerID, rec.Lease.LeaseState)
+		}
+	}
+	lm.mu.Unlock()
+
+	// With no record left Breaking, WaitForBreakCompletion returns at once rather
+	// than blocking until the timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := lm.WaitForBreakCompletion(ctx, handleKey); err != nil {
+		t.Fatalf("WaitForBreakCompletion blocked/errored with a stuck mirrored sibling: %v", err)
+	}
 }

--- a/pkg/metadata/lock/dirlease_dedup_break_test.go
+++ b/pkg/metadata/lock/dirlease_dedup_break_test.go
@@ -234,6 +234,68 @@ func TestOnDirChange_SuppressesParentKeyMatchedDirLease(t *testing.T) {
 	}
 }
 
+// TestOnDirChange_SerializesMultipleDirLeaseBreaks pins the serialized delivery
+// of multiple directory RH-lease breaks (smb2.dirlease.unlink_different_*): when
+// one directory change breaks two dir leases with different keys, only the first
+// break is delivered immediately; acknowledging it delivers the second. Sending
+// both at once produces the client-side lease_break_info.count==2 failure.
+func TestOnDirChange_SerializesMultipleDirLeaseBreaks(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	const handleKey = "/share:dir"
+	key1 := [16]byte{0x01}
+	key2 := [16]byte{0x02}
+
+	mu := &sync.Mutex{}
+	var order [][16]byte
+	lm.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(_ string, l *UnifiedLock, _ uint32) {
+			mu.Lock()
+			order = append(order, l.Lease.LeaseKey)
+			mu.Unlock()
+		},
+	})
+	lm.mu.Lock()
+	lm.unifiedLocks[handleKey] = []*UnifiedLock{
+		{Owner: LockOwner{OwnerID: "h1", ClientID: "smb:c1"},
+			Lease: &OpLock{LeaseKey: key1, LeaseState: LeaseStateRead | LeaseStateHandle, Epoch: 1, IsDirectory: true}},
+		{Owner: LockOwner{OwnerID: "h2", ClientID: "smb:c2"},
+			Lease: &OpLock{LeaseKey: key2, LeaseState: LeaseStateRead | LeaseStateHandle, Epoch: 1, IsDirectory: true}},
+	}
+	lm.reindexHandleLocked(handleKey, nil)
+	lm.mu.Unlock()
+
+	// A change with no parent key breaks both dir leases.
+	lm.OnDirChange(FileHandle(handleKey), DirChangeRemoveEntry, "smb:other", [16]byte{}, false)
+
+	// Only the first break is delivered now; the second is deferred.
+	mu.Lock()
+	got := len(order)
+	var first [16]byte
+	if got == 1 {
+		first = order[0]
+	}
+	mu.Unlock()
+	if got != 1 {
+		t.Fatalf("expected exactly 1 dir-lease break delivered immediately (RH breaks serialize), got %d", got)
+	}
+
+	// Acknowledging the first break delivers the deferred second break.
+	if err := lm.AcknowledgeLeaseBreak(context.Background(), first, LeaseStateNone, 0); err != nil {
+		t.Fatalf("AcknowledgeLeaseBreak: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(order) != 2 {
+		t.Fatalf("acknowledging the first break must deliver the deferred second; got %d total breaks", len(order))
+	}
+	if order[1] == first {
+		t.Fatalf("second break repeated the first lease key %x; expected the other dir lease", first)
+	}
+}
+
 // TestAcknowledgeLeaseBreak_ClearsMirroredSiblings is a regression test for the
 // create/delete-heavy SMB3 stall: a mirrored sibling left Breaking=true after
 // the client's single acknowledge.

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -1001,6 +1001,9 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(ctx context.Context, leaseKey [16]b
 		logger.Debug("AcknowledgeLeaseBreak: lease released to None (record kept until CLOSE)",
 			"leaseKey", fmt.Sprintf("%x", leaseKey))
 		lm.signalBreakWaitLocked(handleKey)
+		// Deliver the next directory RH-lease break on this directory that was
+		// deferred behind this one, so multi-lease dir breaks serialize.
+		lm.dispatchNextDeferredDirBreakLocked(handleKey)
 		return nil
 	}
 

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -996,6 +996,7 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(ctx context.Context, leaseKey [16]b
 		lock.Type = lockTypeForLeaseState(LeaseStateNone)
 
 		lm.persistUnifiedLockLocked(lock)
+		lm.clearBreakingSiblingsLocked(leaseKey, lock)
 
 		logger.Debug("AcknowledgeLeaseBreak: lease released to None (record kept until CLOSE)",
 			"leaseKey", fmt.Sprintf("%x", leaseKey))
@@ -1083,6 +1084,7 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(ctx context.Context, leaseKey [16]b
 
 	// Persist updated state
 	lm.persistUnifiedLockLocked(lock)
+	lm.clearBreakingSiblingsLocked(leaseKey, lock)
 
 	logger.Debug("AcknowledgeLeaseBreak: break acknowledged",
 		"leaseKey", fmt.Sprintf("%x", leaseKey),
@@ -1091,6 +1093,39 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(ctx context.Context, leaseKey [16]b
 
 	lm.signalBreakWaitLocked(handleKey)
 	return nil
+}
+
+// clearBreakingSiblingsLocked syncs every other lease record sharing leaseKey to
+// primary's post-acknowledge state. Opens sharing a lease key are one logical
+// lease: OnDirChange and breakOpLocks put such sibling records into Breaking=true
+// via mirrorBreakStageLocked without ever sending a wire notification (only one
+// break is dispatched for the shared key). A client's single acknowledge resolves
+// through findLeaseByKey to exactly one record, so without this sync the mirrored
+// siblings stay Breaking=true forever and any WaitForBreakCompletion on their
+// handleKey blocks until the force-complete timeout — a per-operation stall under
+// directory churn. Progressive multi-stage breaks (partial acks) are file-lease
+// only and never mirror across a shared key, so they are unaffected. Must hold lm.mu.
+func (lm *Manager) clearBreakingSiblingsLocked(leaseKey [16]byte, primary *UnifiedLock) {
+	for handleKey := range lm.leaseKeyIndex[leaseKey] {
+		cleared := false
+		for _, lock := range lm.unifiedLocks[handleKey] {
+			if lock == primary || lock.Lease == nil ||
+				lock.Lease.LeaseKey != leaseKey || !lock.Lease.Breaking {
+				continue
+			}
+			lock.Lease.LeaseState = primary.Lease.LeaseState
+			lock.Lease.Breaking = false
+			lock.Lease.BreakToState = 0
+			lock.Lease.BreakingToRequired = primary.Lease.BreakingToRequired
+			lock.Lease.BreakStarted = time.Time{}
+			lock.Type = lockTypeForLeaseState(primary.Lease.LeaseState)
+			lm.persistUnifiedLockLocked(lock)
+			cleared = true
+		}
+		if cleared {
+			lm.signalBreakWaitLocked(handleKey)
+		}
+	}
 }
 
 // ReleaseLease releases all lease state for the given lease key.

--- a/pkg/metadata/lock/oplock.go
+++ b/pkg/metadata/lock/oplock.go
@@ -180,6 +180,15 @@ type OpLock struct {
 	// When true, the client has been notified and must acknowledge.
 	Breaking bool
 
+	// BreakDeferred marks a directory-lease break that is in progress
+	// (Breaking=true) but whose wire notification has NOT yet been sent, because
+	// another directory lease on the same directory is breaking ahead of it.
+	// Revoking a directory RH lease waits for the client's acknowledgment (the
+	// handle-caching bit), so when a single directory change breaks several dir
+	// leases they are delivered one at a time: the first is sent immediately and
+	// each acknowledgment dispatches the next deferred one.
+	BreakDeferred bool
+
 	// Epoch is incremented on every lease state change (SMB3).
 	// Used by clients to detect stale state notifications.
 	Epoch uint16
@@ -328,6 +337,7 @@ func (l *OpLock) Clone() *OpLock {
 		BreakToState:        l.BreakToState,
 		BreakingToRequired:  l.BreakingToRequired,
 		Breaking:            l.Breaking,
+		BreakDeferred:       l.BreakDeferred,
 		Epoch:               l.Epoch,
 		BreakStarted:        l.BreakStarted,
 		Reclaim:             l.Reclaim,


### PR DESCRIPTION
Fully fixes the SMB directory-lease defects behind #1701 (the flaky `smb2.dirlease.unlink_{same,different}_{initial,set}_and_close` conformance tests) and the create-heavy SMB3 stall. Every fix has a deterministic lock-layer test, and all four `unlink` dirlease tests now pass on the smbtorture suite (memory + badger-fs).

## Four fixes

### 1. Break directory leases by parent lease key, not by client (`unlink_same_*`)
`OnDirChange` suppressed dir-lease breaks for the whole originating client (`lock.Owner.ClientID == originClientID`). Per MS-SMB2 §3.3.4.20 and the Samba object-store rule, a directory-content change must break **every** parent dir lease whose key differs from the change's parent lease key — including other-key leases held by the *same* client. On entry removal we now suppress by parent key only; the client exclusion stays for NFS delegations and add/rename.

### 2. Serialize RH dir-lease breaks (`unlink_different_*`)
Revoking a directory RH lease waits for the client's acknowledgment (the handle-caching bit). When one change breaks several dir leases (different parent keys → no lease spared), they must be delivered **one at a time**: send the first, wait for the ack, then the next. `OnDirChange` sent them all at once → the client saw `lease_break_info.count==2`. Now `OnDirChange` dispatches only the first and marks the rest `BreakDeferred`; each `AcknowledgeLeaseBreak` delivers the next.

### 3. Clear mirrored siblings on acknowledge (create-heavy stall)
A break mirrors its stage onto sibling records sharing a lease key without a wire notification, but `AcknowledgeLeaseBreak` cleared only the one record `findLeaseByKey` resolves. Mirrored siblings stayed `Breaking=true`, so `WaitForBreakCompletion` blocked until the force-complete timeout on every following op — the SMB3 fio stall. Now every record sharing the acked key is cleared.

### 4. Break parent dir leases when recycling a file
`RemoveFile`'s recycle (trash) branch returned before `notifyDirChange`, so on a `--enable-trash` share a delete left caching clients with a stale listing. `RemoveDirectory` already notifies; `RemoveFile` now does too. (Caught in review.)

## Tests
- `TestOnDirChange_BreaksOriginatorsOtherDirLease` / `_SuppressesParentKeyMatchedDirLease` — parent-key suppression (both verified red→green).
- `TestOnDirChange_SerializesMultipleDirLeaseBreaks` — one break immediate, the next on ack.
- `TestAcknowledgeLeaseBreak_ClearsMirroredSiblings` — the stall (verified red→green).
- `TestRemoveFile_RecycleNotifiesDirChange` — recycle notify (verified red→green).
- Full `pkg/metadata/lock` (race) + `pkg/metadata` + `internal/adapter/smb/handlers` green; **all four smbtorture `unlink_*` dirlease tests pass**.

Closes #1701.