### PR TITLE
fix(journal): serialize per-file carve metadata commits (SSI conflict / EDEADLK)

### DIFF
--- a/pkg/block/engine/blocksink.go
+++ b/pkg/block/engine/blocksink.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync"
 
 	"lukechampine.com/blake3"
 
@@ -14,6 +15,42 @@ import (
 	"github.com/marmos91/dittofs/pkg/block/remote"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
+
+// numCarveCommitStripes must be a power of two so the stripe index is a mask.
+const numCarveCommitStripes = 256
+
+// carveCommitLocks serializes a payloadID's metadata commit so the within-file
+// carve dispatcher's concurrent CommitBlock calls do not read-modify-write the
+// same File row at once. Each commit re-projects File.Blocks (a PutFile), so two
+// overlapping commits for one file abort under badger's SSI as a transaction
+// conflict; enough contention exhausts the retry budget and surfaces to the
+// carver (the SMB/NFS client sees EDEADLK). The block upload runs OUTSIDE this
+// lock, so overlapping successive blocks' uploads — the point of the concurrent
+// dispatcher — is preserved. Distinct payloadIDs take distinct stripes and still
+// commit concurrently; two that collide on a stripe serialize briefly, which is
+// harmless (the commit transaction is short).
+//
+// A fixed stripe array bounds memory: a long-lived share carving many files
+// never accumulates one mutex per file the way a keyed map would.
+type carveCommitLocks struct {
+	stripes [numCarveCommitStripes]sync.Mutex
+}
+
+// forKey returns the stripe mutex for payloadID, or nil when no stripes are
+// wired (test fixtures that never exercise the concurrent dispatcher). A nil
+// receiver makes the lock a no-op so those callers keep their prior behaviour.
+func (c *carveCommitLocks) forKey(payloadID string) *sync.Mutex {
+	if c == nil {
+		return nil
+	}
+	// FNV-1a over the payloadID, masked to the stripe count (power of two).
+	var h uint32 = 2166136261
+	for i := 0; i < len(payloadID); i++ {
+		h ^= uint32(payloadID[i])
+		h *= 16777619
+	}
+	return &c.stripes[h&(numCarveCommitStripes-1)]
+}
 
 // engineDeduper answers journal's carve dedup oracle from the per-share
 // synced-hash store: a chunk is durable once its hash has been mirrored to the
@@ -49,7 +86,8 @@ func (localDeduper) IsChunkDurable(context.Context, journal.ChunkHash) (bool, er
 // clone fixture has no committer, but its source has no dirty data so CommitBlock
 // never fires — a nil committer there is inert.
 type localBlockSink struct {
-	committer blockCommitter
+	committer   blockCommitter
+	commitLocks *carveCommitLocks
 }
 
 func (s localBlockSink) CommitBlock(ctx context.Context, chunks []journal.CarveChunk) error {
@@ -69,6 +107,12 @@ func (s localBlockSink) CommitBlock(ctx context.Context, chunks []journal.CarveC
 			DataSize: uint32(len(c.Data)),
 			State:    block.BlockStatePending,
 		})
+	}
+	// Serialize this file's commits so overlapping dispatcher calls don't abort
+	// on the shared File-row projection under SSI.
+	if mu := s.commitLocks.forKey(payloadID); mu != nil {
+		mu.Lock()
+		defer mu.Unlock()
 	}
 	return s.committer.WithTransaction(ctx, func(tx metadata.Transaction) error {
 		for _, fc := range fileChunks {
@@ -110,9 +154,10 @@ func (s engineBlockSink) ReapSupersededManifest(ctx context.Context, id journal.
 // rows. It mirrors Syncer.carveAndCommitBlock minus the local-byte resolution —
 // journal hands the plaintext in-hand on each CarveChunk.
 type engineBlockSink struct {
-	sealer    remote.ChunkSealer
-	rbs       remote.RemoteBlockStore
-	committer blockCommitter
+	sealer      remote.ChunkSealer
+	rbs         remote.RemoteBlockStore
+	committer   blockCommitter
+	commitLocks *carveCommitLocks
 }
 
 func (s engineBlockSink) CommitBlock(ctx context.Context, chunks []journal.CarveChunk) error {
@@ -189,7 +234,17 @@ func (s engineBlockSink) CommitBlock(ctx context.Context, chunks []journal.Carve
 		LiveChunkCount: uint32(len(commits)),
 		SyncState:      block.BlockStateRemote,
 	}
-	if err := metadata.DefaultCommitBlock(ctx, s.committer, rec, commits, fileChunks); err != nil {
+	// Only the metadata commit is serialized per file (the shared File-row
+	// projection under SSI); the PutBlock upload above ran concurrently with the
+	// next block's, which is the whole point of the overlapping dispatcher.
+	commit := func() error {
+		if mu := s.commitLocks.forKey(string(chunks[0].FileID)); mu != nil {
+			mu.Lock()
+			defer mu.Unlock()
+		}
+		return metadata.DefaultCommitBlock(ctx, s.committer, rec, commits, fileChunks)
+	}
+	if err := commit(); err != nil {
 		return fmt.Errorf("carve: commit block %s: %w", blockID, err)
 	}
 	return nil

--- a/pkg/block/engine/blocksink.go
+++ b/pkg/block/engine/blocksink.go
@@ -19,6 +19,11 @@ import (
 // numCarveCommitStripes must be a power of two so the stripe index is a mask.
 const numCarveCommitStripes = 256
 
+// Compile-time guard: forKey masks with (numCarveCommitStripes-1), which only
+// yields a valid index when the count is a power of two. If it is not, the
+// unsigned subtraction below underflows and the build fails.
+const _ = uint(-(numCarveCommitStripes & (numCarveCommitStripes - 1)))
+
 // carveCommitLocks serializes a payloadID's metadata commit so the within-file
 // carve dispatcher's concurrent CommitBlock calls do not read-modify-write the
 // same File row at once. Each commit re-projects File.Blocks (a PutFile), so two

--- a/pkg/block/engine/blocksink_ssi_test.go
+++ b/pkg/block/engine/blocksink_ssi_test.go
@@ -1,0 +1,101 @@
+package engine
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/block/journal"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatabadger "github.com/marmos91/dittofs/pkg/metadata/store/badger"
+)
+
+// newBadgerCommitter builds a badger metadata store with one regular file whose
+// PayloadID is returned, so a carve sink commit for that PayloadID projects onto
+// a real File row (the only cross-commit shared key). Badger uses SSI, so its
+// conflict counter is the disk-speed-independent contention fingerprint the
+// memory store fixture cannot provide.
+func newBadgerCommitter(t *testing.T) (*metadatabadger.BadgerMetadataStore, metadata.PayloadID) {
+	t.Helper()
+	ctx := context.Background()
+	store, err := metadatabadger.NewBadgerMetadataStoreWithDefaults(ctx, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	const shareName = "s1"
+	require.NoError(t, store.CreateShare(ctx, &metadata.Share{Name: shareName}))
+	root, err := store.CreateRootDirectory(ctx, shareName, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory, Mode: 0o755,
+	})
+	require.NoError(t, err)
+	dir, err := metadata.EncodeFileHandle(root)
+	require.NoError(t, err)
+
+	pid := metadata.PayloadID(shareName + "/" + uuid.NewString())
+	handle, err := store.GenerateHandle(ctx, shareName, "/f.bin")
+	require.NoError(t, err)
+	_, id, err := metadata.DecodeFileHandle(handle)
+	require.NoError(t, err)
+
+	file := &metadata.File{
+		ShareName: shareName,
+		Path:      "/f.bin",
+		FileAttr: metadata.FileAttr{
+			Type: metadata.FileTypeRegular, Mode: 0o600, UID: 1000, GID: 1000,
+			PayloadID: pid,
+		},
+	}
+	file.ID = id
+	require.NoError(t, store.PutFile(ctx, file))
+	require.NoError(t, store.SetParent(ctx, handle, dir))
+	require.NoError(t, store.SetChild(ctx, dir, "f.bin", handle))
+	return store, pid
+}
+
+// TestLocalBlockSink_ConcurrentSameFileCommit_NoSSIConflict reproduces the carve
+// SSI wall: the within-file carve dispatcher (CarveUploadConcurrency) fires
+// several CommitBlock calls for one file concurrently, and each re-projects
+// File.Blocks (PutFile) on the SAME File row. Under badger's SSI that read-write
+// on a shared row aborts as ErrConflict; enough contention exhausts the retry
+// budget and surfaces the conflict to the carver (the client sees EDEADLK).
+//
+// The commits touch disjoint offsets/hashes/blocks, so a correct implementation
+// serializes only the shared File-row write and leaves the conflict counter at
+// zero.
+func TestLocalBlockSink_ConcurrentSameFileCommit_NoSSIConflict(t *testing.T) {
+	ctx := context.Background()
+	store, pid := newBadgerCommitter(t)
+	sink := localBlockSink{committer: store, commitLocks: &carveCommitLocks{}}
+
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			data := []byte{byte(i), byte(i >> 8), 0xab, 0xcd}
+			chunk := journal.CarveChunk{
+				FileID:     journal.FileID(pid),
+				FileOffset: int64(i) * 4096,
+				Hash:       journal.ChunkHash(blake3.Sum256(data)),
+				Data:       data,
+			}
+			<-start
+			errs[i] = sink.CommitBlock(ctx, []journal.CarveChunk{chunk})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "concurrent CommitBlock %d surfaced an error", i)
+	}
+	require.Zero(t, store.TransactionConflictsForTest(),
+		"concurrent same-file carve commits must not serialize on the File row (SSI conflict)")
+}

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -780,7 +780,7 @@ func (m *Syncer) wireCarveTargets() {
 			return // remote configured but deps not fully wired yet
 		}
 		deduper := engineDeduper{synced: m.syncedHashStore}
-		sink := engineBlockSink{sealer: m.chunkSealer, rbs: m.remoteBlockStore, committer: m.blockCommitter}
+		sink := engineBlockSink{sealer: m.chunkSealer, rbs: m.remoteBlockStore, committer: m.blockCommitter, commitLocks: &carveCommitLocks{}}
 		m.local.SetCarveTargets(deduper, sink)
 		m.carveTargetsWired = true
 		return
@@ -792,7 +792,7 @@ func (m *Syncer) wireCarveTargets() {
 	// remote is coming — never from recomputeCarveActive (which gates on a
 	// present remote). blockCommitter is nil only for the clone fixture, whose
 	// source has no dirty data so CommitBlock never fires.
-	m.local.SetCarveTargets(localDeduper{}, localBlockSink{committer: m.blockCommitter})
+	m.local.SetCarveTargets(localDeduper{}, localBlockSink{committer: m.blockCommitter, commitLocks: &carveCommitLocks{}})
 	m.carveTargetsWired = true
 }
 


### PR DESCRIPTION
## Problem

The within-file carve dispatcher (#1717, `CarveUploadConcurrency`) fires `CommitBlock` concurrently for a single file's carve run. Each commit re-projects `File.Blocks` via `ProjectManifestToBlocks` → `PutFile` on the **same File row**. Under badger's SSI, two overlapping read-modify-writes of one row abort as a transaction conflict; under real load the retry budget exhausts and the raw `ErrConflict` surfaces to the carver — the SMB/NFS client sees `EDEADLK` (`Resource deadlock avoided`) on create-heavy and seq-write workloads. This blocked the SMB3 write/metadata benchmark cells (all DittoFS write cells stalled).

## Root cause

Confirmed by a new reproduction test: 8 concurrent same-file commits produce 22 SSI conflicts. The File row is the *only* shared key — per-payloadID serialization drops conflicts to exactly zero, proving no other hot row.

## Fix

A fixed **striped mutex** (`carveCommitLocks`, 256 stripes) serializes a payloadID's metadata commit. Key properties:

- The `PutBlock` upload stays **outside** the lock, so successive blocks' uploads still overlap — the entire point of the #1717 dispatcher is preserved.
- Distinct files take distinct stripes and commit concurrently; a stripe collision only serializes two unrelated files' short commit txns (harmless).
- Fixed array bounds memory — a long-lived share carving many files never accumulates a per-file mutex the way a keyed map would.

This mirrors the existing house pattern (`PendingWritesTracker.GetFlushLock`, which serializes concurrent same-file NFS COMMITs for the same reason).

## Verification

- New regression test `TestLocalBlockSink_ConcurrentSameFileCommit_NoSSIConflict`: fails before (22 conflicts), passes after (0), green under `-race`.
- `go test -race ./pkg/block/engine/... ./pkg/block/journal/...` — 358 pass.
- `go test ./pkg/metadata/...` — 2648 pass.
- `go build ./...`, `go vet`, `gofmt` clean.

Unblocks re-running the SMB3 write/metadata benchmark.