### PR TITLE
test(dfsbench): retry SMB mount across the adapter hot-reload window

### DIFF
--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -424,10 +424,14 @@ func dittofsMount(ctx context.Context, proto Protocol) (string, error) {
 	// gone). waitPort above only proves the listener was up right after `adapter
 	// enable`, not after the later share-create reload. Retry so the mount rides
 	// out the reload instead of failing the whole cell over a ~few-second gap.
+	const mountAttempts = 8
 	var err error
-	for attempt := 0; attempt < 8; attempt++ {
+	for attempt := 0; attempt < mountAttempts; attempt++ {
 		if err = exec.Sh(ctx, "mount", "-t", typ, "-o", opts, src, clientMntDir); err == nil {
 			return clientMntDir, nil
+		}
+		if attempt == mountAttempts-1 {
+			break // don't sleep after the last try — surface the failure now
 		}
 		select {
 		case <-ctx.Done():

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -418,10 +418,24 @@ func dittofsMount(ctx context.Context, proto Protocol) (string, error) {
 	default:
 		return "", fmt.Errorf("dittofs-s3: unsupported protocol %s", proto)
 	}
-	if err := exec.Sh(ctx, "mount", "-t", typ, "-o", opts, src, clientMntDir); err != nil {
-		return "", err
+	// Adding the metadata/block stores and creating the share hot-reloads the
+	// running adapter, which briefly closes and reopens the SMB listener; a mount
+	// that lands in that window fails "Host is down" (the port is momentarily
+	// gone). waitPort above only proves the listener was up right after `adapter
+	// enable`, not after the later share-create reload. Retry so the mount rides
+	// out the reload instead of failing the whole cell over a ~few-second gap.
+	var err error
+	for attempt := 0; attempt < 8; attempt++ {
+		if err = exec.Sh(ctx, "mount", "-t", typ, "-o", opts, src, clientMntDir); err == nil {
+			return clientMntDir, nil
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
 	}
-	return clientMntDir, nil
+	return "", err
 }
 
 // dittofsEvict drops locally-cached blocks so the next read is cold-from-S3.


### PR DESCRIPTION
## Problem

Every dittofs SMB3 benchmark cell failed at mount (`Server abruptly closed the connection` / `Host is down`, exit 32), so the SMB3 matrix produced zero dittofs results.

## Root cause

Not SSI, not a protocol bug — a **timing race**. The harness enables the SMB adapter and `waitPort`s it, then adds the metadata/block stores and creates the share. That share-create hot-reloads the running adapter, which briefly closes and reopens the port-12445 listener. The harness mounts *immediately* after share-create, landing in that ~few-second down-window. Verified manually: once the adapter settles, the exact same guest/vers=3.0 mount succeeds (full NEGOTIATE/SESSION_SETUP/TREE_CONNECT `STATUS_SUCCESS`).

The server-side listener-drop is tracked separately in #1810; this PR makes the harness robust to it.

## Fix

Retry the mount up to 8× (2s apart, ctx-aware) so it rides out the reload instead of failing the cell. Harmless for NFS (succeeds first try).

## Verification

Manual repro on the bench VM: local-only share mounts first try; a share created right after `adapter enable` fails once then succeeds on retry. Build/vet/gofmt clean.