### PR TITLE
fix(dfsctl): let non-admin users discover adapter ports for mount

### DIFF
--- a/cmd/dfsctl/commands/share/mount.go
+++ b/cmd/dfsctl/commands/share/mount.go
@@ -119,7 +119,7 @@ func runMount(cmd *cobra.Command, args []string) error {
 	// would block a plain share-user before the mount ever touches NFS/SMB.
 	adapters, err := client.ListAdapterPorts()
 	if err != nil {
-		return fmt.Errorf("failed to list adapters: %w\nHint: Is the DittoFS server running?", err)
+		return fmt.Errorf("failed to look up adapter ports: %w\nHint: Is the DittoFS server running?", err)
 	}
 
 	// Resolve server host from current context

--- a/cmd/dfsctl/commands/share/mount.go
+++ b/cmd/dfsctl/commands/share/mount.go
@@ -114,7 +114,10 @@ func runMount(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get authenticated client: %w\nHint: Run 'dfsctl login' first", err)
 	}
 
-	adapters, err := client.ListAdapters()
+	// Discover the adapter port via the lean ports endpoint, which any
+	// authenticated user can call. ListAdapters is admin/operator-only and
+	// would block a plain share-user before the mount ever touches NFS/SMB.
+	adapters, err := client.ListAdapterPorts()
 	if err != nil {
 		return fmt.Errorf("failed to list adapters: %w\nHint: Is the DittoFS server running?", err)
 	}

--- a/internal/controlplane/api/handlers/adapters.go
+++ b/internal/controlplane/api/handlers/adapters.go
@@ -134,6 +134,41 @@ func (h *AdapterHandler) List(w http.ResponseWriter, r *http.Request) {
 	WriteJSONOK(w, response)
 }
 
+// AdapterPortResponse is the lean adapter view returned by ListPorts.
+// It carries only what a client needs to reach an adapter's data plane
+// (protocol type and port) and deliberately omits Config so it can be
+// exposed to any authenticated user without leaking bind addresses or
+// protocol-specific settings.
+type AdapterPortResponse struct {
+	Type    string `json:"type"`
+	Port    int    `json:"port"`
+	Enabled bool   `json:"enabled"`
+	Running bool   `json:"running"`
+}
+
+// ListPorts handles GET /api/v1/adapters/ports.
+// Returns type/port/enabled/running for each adapter, with no Config,
+// so any authenticated user can discover the port to mount a share.
+func (h *AdapterHandler) ListPorts(w http.ResponseWriter, r *http.Request) {
+	adapters, err := h.runtime.Store().ListAdapters(r.Context())
+	if err != nil {
+		InternalServerError(w, "Failed to list adapters")
+		return
+	}
+
+	response := make([]AdapterPortResponse, len(adapters))
+	for i, a := range adapters {
+		response[i] = AdapterPortResponse{
+			Type:    a.Type,
+			Port:    a.Port,
+			Enabled: a.Enabled,
+			Running: h.runtime.IsAdapterRunning(a.Type),
+		}
+	}
+
+	WriteJSONOK(w, response)
+}
+
 // Get handles GET /api/v1/adapters/{type}.
 // Gets an adapter configuration by type (admin only).
 func (h *AdapterHandler) Get(w http.ResponseWriter, r *http.Request) {

--- a/pkg/apiclient/adapters.go
+++ b/pkg/apiclient/adapters.go
@@ -34,6 +34,13 @@ func (c *Client) ListAdapters() ([]Adapter, error) {
 	return listResources[Adapter](c, "/api/v1/adapters")
 }
 
+// ListAdapterPorts returns adapter type/port info without config. Unlike
+// ListAdapters it is reachable by any authenticated user, so it is the
+// right call for port discovery (e.g. before mounting a share).
+func (c *Client) ListAdapterPorts() ([]Adapter, error) {
+	return listResources[Adapter](c, "/api/v1/adapters/ports")
+}
+
 // GetAdapter returns an adapter by type.
 func (c *Client) GetAdapter(adapterType string) (*Adapter, error) {
 	return getResource[Adapter](c, resourcePath("/api/v1/adapters/%s", adapterType))

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -372,6 +372,12 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 				adapterHandler := handlers.NewAdapterHandler(rt)
 				settingsHandler := handlers.NewAdapterSettingsHandler(cpStore, rt)
 
+				// Port discovery: any authenticated user. Returns only
+				// type/port/enabled/running (no adapter Config), so a plain
+				// share-user can find the port to mount without the
+				// admin/operator management view.
+				r.Get("/ports", adapterHandler.ListPorts)
+
 				// Read endpoint: admin + operator (list only)
 				r.Group(func(r chi.Router) {
 					r.Use(apiMiddleware.RequireRole("admin", "operator"))

--- a/pkg/controlplane/api/router_test.go
+++ b/pkg/controlplane/api/router_test.go
@@ -1,18 +1,22 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/controlplane/api/auth"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
 )
 
-// newTestRouter builds a router + JWT service backed by an in-memory store.
-func newTestRouter(t *testing.T, pprofEnabled bool) (http.Handler, *auth.JWTService) {
+// newTestRouter builds a router + JWT service backed by an in-memory store,
+// returning the store so tests can seed fixtures (e.g. adapters).
+func newTestRouter(t *testing.T, pprofEnabled bool) (http.Handler, *auth.JWTService, store.Store) {
 	t.Helper()
 
 	cpStore, err := store.New(&store.Config{
@@ -33,8 +37,8 @@ func newTestRouter(t *testing.T, pprofEnabled bool) (http.Handler, *auth.JWTServ
 		t.Fatalf("create jwt service: %v", err)
 	}
 
-	router := NewRouter(nil, jwtService, cpStore, pprofEnabled, Timeouts{Restore: 30 * time.Minute, DrainStall: 5 * time.Minute})
-	return router, jwtService
+	router := NewRouter(runtime.New(cpStore), jwtService, cpStore, pprofEnabled, Timeouts{Restore: 30 * time.Minute, DrainStall: 5 * time.Minute})
+	return router, jwtService, cpStore
 }
 
 // tokenFor mints an access token for a user with the given role.
@@ -62,7 +66,7 @@ func tokenForUser(t *testing.T, jwtService *auth.JWTService, role models.UserRol
 // unauthenticated and non-admin requests and only serve admins. pprof dumps
 // can leak in-memory secrets and are DoS vectors, so they must not be open.
 func TestPprofRequiresAdminAuth(t *testing.T) {
-	router, jwtService := newTestRouter(t, true)
+	router, jwtService, _ := newTestRouter(t, true)
 
 	cases := []struct {
 		name       string
@@ -96,37 +100,54 @@ func TestPprofRequiresAdminAuth(t *testing.T) {
 // TestAdapterPortsAuthenticatedNonAdmin verifies the authz split on the
 // adapter read routes: the full listing stays admin/operator-only, while the
 // lean port-discovery endpoint is reachable by any authenticated user (so a
-// plain share-user can find the port to mount). The test router uses a nil
-// runtime, so a request that passes the role gate reaches the handler and
-// panics into a 500 via Recoverer — anything other than 403 proves the gate
-// let it through.
+// plain share-user can find the port to mount) and never exposes adapter
+// Config.
 func TestAdapterPortsAuthenticatedNonAdmin(t *testing.T) {
-	router, jwtService := newTestRouter(t, false)
+	router, jwtService, cpStore := newTestRouter(t, false)
+
+	if _, err := cpStore.CreateAdapter(context.Background(), &models.AdapterConfig{
+		ID:        "nfs-adapter",
+		Type:      "nfs",
+		Enabled:   true,
+		Port:      12049,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed adapter: %v", err)
+	}
+
 	userToken := "Bearer " + tokenFor(t, jwtService, models.RoleUser)
 
-	// Full listing: role-gated, plain user is forbidden.
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/adapters/", nil)
+	// Full listing stays role-gated: a plain user is forbidden.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/adapters", nil)
 	req.Header.Set("Authorization", userToken)
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 	if rec.Code != http.StatusForbidden {
-		t.Errorf("GET /adapters/ as user = %d, want %d", rec.Code, http.StatusForbidden)
+		t.Errorf("GET /adapters as user = %d, want %d", rec.Code, http.StatusForbidden)
 	}
 
-	// Port discovery: not role-gated, plain user passes the gate.
+	// Port discovery is open to any authenticated user and returns the port.
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/adapters/ports", nil)
 	req.Header.Set("Authorization", userToken)
 	rec = httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
-	if rec.Code == http.StatusForbidden {
-		t.Errorf("GET /adapters/ports as user = 403, want it to pass the role gate")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /adapters/ports as user = %d, want %d (body=%q)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if body := rec.Body.String(); !strings.Contains(body, `"port":12049`) {
+		t.Errorf("ports response missing port: %q", body)
+	}
+	// Config must never leak through the unprivileged endpoint.
+	if body := rec.Body.String(); strings.Contains(body, `"config"`) {
+		t.Errorf("ports response leaked config: %q", body)
 	}
 }
 
 // TestPprofDisabledNotMounted verifies that with pprof disabled the route is
 // absent entirely (404), not merely auth-gated.
 func TestPprofDisabledNotMounted(t *testing.T) {
-	router, jwtService := newTestRouter(t, false)
+	router, jwtService, _ := newTestRouter(t, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/debug/pprof/goroutine?debug=1", nil)
 	req.Header.Set("Authorization", "Bearer "+tokenFor(t, jwtService, models.RoleAdmin))

--- a/pkg/controlplane/api/router_test.go
+++ b/pkg/controlplane/api/router_test.go
@@ -93,6 +93,36 @@ func TestPprofRequiresAdminAuth(t *testing.T) {
 	}
 }
 
+// TestAdapterPortsAuthenticatedNonAdmin verifies the authz split on the
+// adapter read routes: the full listing stays admin/operator-only, while the
+// lean port-discovery endpoint is reachable by any authenticated user (so a
+// plain share-user can find the port to mount). The test router uses a nil
+// runtime, so a request that passes the role gate reaches the handler and
+// panics into a 500 via Recoverer — anything other than 403 proves the gate
+// let it through.
+func TestAdapterPortsAuthenticatedNonAdmin(t *testing.T) {
+	router, jwtService := newTestRouter(t, false)
+	userToken := "Bearer " + tokenFor(t, jwtService, models.RoleUser)
+
+	// Full listing: role-gated, plain user is forbidden.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/adapters/", nil)
+	req.Header.Set("Authorization", userToken)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("GET /adapters/ as user = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+
+	// Port discovery: not role-gated, plain user passes the gate.
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/adapters/ports", nil)
+	req.Header.Set("Authorization", userToken)
+	rec = httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code == http.StatusForbidden {
+		t.Errorf("GET /adapters/ports as user = 403, want it to pass the role gate")
+	}
+}
+
 // TestPprofDisabledNotMounted verifies that with pprof disabled the route is
 // absent entirely (404), not merely auth-gated.
 func TestPprofDisabledNotMounted(t *testing.T) {


### PR DESCRIPTION
Closes #1809.

## Problem

`dfsctl share mount` called `ListAdapters()` purely to discover the adapter port, but `GET /api/v1/adapters` is gated to admin/operator. A plain share-user was blocked *before* the mount ever touched NFS/SMB — even though the NFS server would authorize them by UID and SMB by credentials. The DittoFS Pro setup wizard hits exactly this dead-end.

The full listing can't just be un-gated: `AdapterResponse` carries `Config` (bind addresses, TLS, protocol settings). The gate is correct for the management view, just too coarse for port discovery.

## Fix (issue's preferred option 1)

Add a lean `GET /api/v1/adapters/ports` endpoint, reachable by any authenticated user, returning only `{type, port, enabled, running}` — no `Config`. The full `GET /adapters` listing stays admin/operator-only; write routes stay admin-only. `mount` uses the new endpoint.

Correct even when an admin has moved the port (unlike a default-port fallback), and no config leak.

## Changes
- `internal/controlplane/api/handlers/adapters.go` — `ListPorts` handler + `AdapterPortResponse` (no `Config`).
- `pkg/controlplane/api/router.go` — route `GET /adapters/ports` in the authenticated scope, outside the role gate.
- `pkg/apiclient/adapters.go` — `ListAdapterPorts()`.
- `cmd/dfsctl/commands/share/mount.go` — use `ListAdapterPorts()` for port discovery.

## Test
`TestAdapterPortsAuthenticatedNonAdmin` asserts the authz split: a plain `user` gets 403 on `/adapters` but passes the gate on `/adapters/ports`.