### PR TITLE
fix(smb): resolve serverino ESTALE on the share root (answer QFid + grant root dir lease)

### DIFF
--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -1865,6 +1865,48 @@ func (h *Handler) handleOpenRootCreate(
 		// No metadata service available: fall back to the resolved mask.
 		grantedAccess = resolveAccessFlags(req.DesiredAccess)
 	}
+	// Grant a directory lease when the open requests one, mirroring the
+	// fresh directory-open path. The root is always a directory, so this
+	// only ever grants a directory lease (never a traditional oplock).
+	// Without a granted lease the client cannot cache the root directory's
+	// identity at mount, so a later stat re-fetches the real inode number
+	// and, under serverino, the mismatch surfaces as a stale-handle error.
+	var grantedOplock uint8
+	var leaseResponse *LeaseResponseContext
+	if req.OplockLevel == OplockLevelLease && h.LeaseManager != nil {
+		if leaseCtx := FindCreateContext(req.CreateContexts, LeaseContextTagRequest); leaseCtx != nil {
+			var newLeaseKey [16]byte
+			if parsed, decErr := DecodeLeaseCreateContext(leaseCtx.Data); decErr == nil && parsed != nil {
+				newLeaseKey = parsed.LeaseKey
+			}
+			disallowWriteLease := h.disallowWriteLeaseForFile(
+				authCtx.Context, rootHandle, newLeaseKey, smbFileID, connClientGUID(ctx),
+			)
+			statOpenLease := isStatOnlyOpen(req.DesiredAccess) &&
+				!isDestructiveDisposition(req.CreateDisposition)
+			var leaseErr error
+			leaseResponse, leaseErr = ProcessLeaseCreateContext(
+				authCtx.Context,
+				h.LeaseManager,
+				leaseCtx.Data,
+				lock.FileHandle(rootHandle),
+				ctx.SessionID,
+				connClientGUID(ctx),
+				fmt.Sprintf("smb:%d", ctx.SessionID),
+				tree.ShareName,
+				true, // the share root is always a directory
+				disallowWriteLease,
+				statOpenLease,
+			)
+			if leaseErr != nil {
+				logger.Debug("CREATE: share-root lease context processing failed", "error", leaseErr)
+			}
+			if leaseResponse != nil {
+				grantedOplock = OplockLevelLease
+			}
+		}
+	}
+
 	openFile := &OpenFile{
 		FileID:         smbFileID,
 		TreeID:         ctx.TreeID,
@@ -1876,6 +1918,17 @@ func (h *Handler) handleOpenRootCreate(
 		GrantedAccess:  grantedAccess,
 		IsDirectory:    true,
 		MetadataHandle: rootHandle,
+		OplockLevel:    grantedOplock,
+	}
+	if leaseResponse != nil && leaseResponse.LeaseState != lock.LeaseStateNone {
+		openFile.LeaseKey = leaseResponse.LeaseKey
+	}
+	// Record the RqLs parent-lease-key linkage so break coordination on this
+	// handle can apply the parent-key suppression rule, matching the non-root
+	// directory-open path.
+	if leaseResponse != nil && leaseResponse.HasParent {
+		openFile.ParentLeaseKey = leaseResponse.ParentLeaseKey
+		openFile.HasParentLeaseKey = true
 	}
 	// Snapshot opener identity so handle-bound ops survive re-auth (#772).
 	h.CaptureOpenerIdentity(ctx, openFile)
@@ -1883,9 +1936,9 @@ func (h *Handler) handleOpenRootCreate(
 
 	creation, access, write, change := FileAttrToSMBTimes(&rootFile.FileAttr)
 
-	return &CreateResponse{
+	resp := &CreateResponse{
 		SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},
-		OplockLevel:     0,
+		OplockLevel:     grantedOplock,
 		CreateAction:    types.FileOpened,
 		CreationTime:    creation,
 		LastAccessTime:  access,
@@ -1895,7 +1948,14 @@ func (h *Handler) handleOpenRootCreate(
 		EndOfFile:       0,
 		FileAttributes:  types.FileAttributeDirectory,
 		FileID:          smbFileID,
-	}, nil
+	}
+	if leaseResponse != nil {
+		resp.CreateContexts = append(resp.CreateContexts, CreateContext{
+			Name: LeaseContextTagResponse,
+			Data: leaseResponse.Encode(),
+		})
+	}
+	return resp, nil
 }
 
 // walkPath walks a path from a starting handle, returning the final handle.

--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -1955,6 +1955,21 @@ func (h *Handler) handleOpenRootCreate(
 			Data: leaseResponse.Encode(),
 		})
 	}
+	// Answer the on-disk-id (QFid) request with the root's stable file ID, the
+	// same value FILE_ALL reports as the inode number. A serverino client that
+	// asks for the on-disk id at mount (instead of a separate query) uses it as
+	// the root inode identity; without this response it derives a fabricated
+	// number that every later stat then contradicts, yielding a stale handle.
+	if FindCreateContext(req.CreateContexts, "QFid") != nil {
+		qfidFileID := h.baseFileUUID(authCtx, nil, "", rootFile.ID)
+		qfidResp := make([]byte, 32)
+		copy(qfidResp[0:16], qfidFileID[:16])
+		copy(qfidResp[16:32], h.ServerGUID[:])
+		resp.CreateContexts = append(resp.CreateContexts, CreateContext{
+			Name: "QFid",
+			Data: qfidResp,
+		})
+	}
 	return resp, nil
 }
 

--- a/internal/adapter/smb/handlers/create_test.go
+++ b/internal/adapter/smb/handlers/create_test.go
@@ -6,10 +6,12 @@ import (
 	"path"
 	"testing"
 
+	"github.com/marmos91/dittofs/internal/adapter/smb/lease"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/acl"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
 	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
@@ -469,6 +471,59 @@ func setupWalkPathTest(t *testing.T) (*Handler, *metadata.AuthContext, metadata.
 	h.Registry = rt
 
 	return h, authCtx, rootHandle
+}
+
+// TestHandleOpenRootCreate_GrantsRequestedDirLease verifies that opening the
+// share root with an RqLs directory-lease request returns OplockLevel=Lease
+// (0xFF) and a lease response context carrying a read-caching state. Without a
+// granted lease a Linux CIFS client cannot cache the root directory's identity
+// at mount, which surfaces later as a stale-handle error under serverino.
+func TestHandleOpenRootCreate_GrantsRequestedDirLease(t *testing.T) {
+	h, authCtx, rootHandle := setupWalkPathTest(t)
+	h.LeaseManager = lease.NewLeaseManager(&staticLockResolver{mgr: lock.NewManager()}, nil)
+
+	leaseKey := [16]byte{0xDE, 0xAD, 0xBE, 0xEF}
+	req := &CreateRequest{
+		OplockLevel:       OplockLevelLease,
+		DesiredAccess:     0x00000080, // FILE_READ_ATTRIBUTES (stat-only open)
+		CreateDisposition: types.FileOpen,
+		CreateContexts: []CreateContext{
+			{
+				Name: LeaseContextTagRequest,
+				Data: encodeV2LeaseContext(
+					leaseKey,
+					lock.LeaseStateRead|lock.LeaseStateHandle,
+					0,
+				),
+			},
+		},
+	}
+	ctx := &SMBHandlerContext{Context: context.Background(), SessionID: 1, TreeID: 1}
+	tree := &TreeConnection{ShareName: "/test"}
+
+	resp, err := h.handleOpenRootCreate(ctx, req, authCtx, rootHandle, tree)
+	if err != nil {
+		t.Fatalf("handleOpenRootCreate returned error: %v", err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("status = 0x%08x, want STATUS_SUCCESS", resp.Status)
+	}
+	if resp.OplockLevel != OplockLevelLease {
+		t.Fatalf("OplockLevel = 0x%02x, want 0x%02x (Lease)", resp.OplockLevel, OplockLevelLease)
+	}
+
+	leaseResp := FindCreateContext(resp.CreateContexts, LeaseContextTagResponse)
+	if leaseResp == nil {
+		t.Fatal("response missing RqLs lease response context")
+	}
+	granted := binary.LittleEndian.Uint32(leaseResp.Data[16:20])
+	if granted&lock.LeaseStateRead == 0 {
+		t.Errorf("granted lease state = 0x%x (%s), want a read-caching lease",
+			granted, lock.LeaseStateToString(granted))
+	}
+	if granted&lock.LeaseStateWrite != 0 {
+		t.Errorf("granted lease state = 0x%x carries Write bit; directories must not get W", granted)
+	}
 }
 
 func TestWalkPath_ParentNavigation(t *testing.T) {

--- a/internal/adapter/smb/handlers/create_test.go
+++ b/internal/adapter/smb/handlers/create_test.go
@@ -526,6 +526,43 @@ func TestHandleOpenRootCreate_GrantsRequestedDirLease(t *testing.T) {
 	}
 }
 
+// The on-disk id (QFid) the root open reports must equal the inode number a
+// later FILE_ALL query reports for the root; both derive from the root file's
+// ID. A serverino client latches the QFid value at mount and compares it on
+// every stat, so a mismatch surfaces as a stale handle.
+func TestHandleOpenRootCreate_AnswersQFidWithStableRootID(t *testing.T) {
+	h, authCtx, rootHandle := setupWalkPathTest(t)
+
+	rootFile, err := h.Registry.GetMetadataService().GetFile(authCtx.Context, rootHandle)
+	if err != nil {
+		t.Fatalf("GetFile(root): %v", err)
+	}
+	wantID := h.baseFileUUID(authCtx, nil, "", rootFile.ID)
+
+	req := &CreateRequest{
+		DesiredAccess:     0x00000080, // FILE_READ_ATTRIBUTES
+		CreateDisposition: types.FileOpen,
+		CreateContexts:    []CreateContext{{Name: "QFid"}},
+	}
+	ctx := &SMBHandlerContext{Context: context.Background(), SessionID: 1, TreeID: 1}
+	tree := &TreeConnection{ShareName: "/test"}
+
+	resp, err := h.handleOpenRootCreate(ctx, req, authCtx, rootHandle, tree)
+	if err != nil {
+		t.Fatalf("handleOpenRootCreate: %v", err)
+	}
+	qfid := FindCreateContext(resp.CreateContexts, "QFid")
+	if qfid == nil {
+		t.Fatal("root open did not answer the QFid (on-disk-id) request")
+	}
+	if len(qfid.Data) < 8 {
+		t.Fatalf("QFid response too short: %d bytes", len(qfid.Data))
+	}
+	if got, want := binary.LittleEndian.Uint64(qfid.Data[:8]), binary.LittleEndian.Uint64(wantID[:8]); got != want {
+		t.Errorf("QFid inode = 0x%x, want 0x%x (must match the FILE_ALL IndexNumber source)", got, want)
+	}
+}
+
 func TestWalkPath_ParentNavigation(t *testing.T) {
 	h, authCtx, rootHandle := setupWalkPathTest(t)
 


### PR DESCRIPTION
Fixes #1813.

## Problem

Mounting a DittoFS SMB share from a Linux client with the **default** options (`serverino`) returned **ESTALE / "Stale file handle"** on `stat`/`ls` of the mount root — while writing new files worked. This is the "SMB mounts work only intermittently" symptom: a fresh mount can create files but listing the directory fails.

## Root cause

The share-root open is special-cased in `handleOpenRootCreate`, which built its own CREATE response and skipped the create-context handling the normal open path performs. Two things were missing on the root open:

1. It never answered the client's **`QFid` (SMB2_CREATE_QUERY_ON_DISK_ID)** request. cifs uses that on-disk id as the root inode identity it latches **at mount** (kernel `fs/smb/client/smb2pdu.c`: `buf->IndexNumber = pdisk_id->DiskFileId`, consumed by `smb2_get_srv_inum`). With no response, cifs fabricated a root inode number (`simple_hashstr(tree_name)`) that every later `stat` — which does report the real IndexNumber — contradicted, so the serverino identity check (`fs/smb/client/inode.c` `update_inode_info`) returned `-ESTALE`. `noserverino` sidestepped it; that's why it looked intermittent.
2. It ignored the client's requested directory lease (`RqLs`), granting no oplock — so cifs could not cache the root directory the way it does for every other directory.

Non-root files were unaffected because they flow through the normal open path, which already answers QFid and grants leases.

## Fix

Make `handleOpenRootCreate` behave like a normal directory open:

- **QFid**: return the on-disk-id context with `DiskFileId = baseFileUUID(root)` — the exact value FILE_ALL reports as the inode number — so what cifs latches at mount matches what every later query returns.
- **Directory lease**: grant the requested `RqLs` lease via the same `LeaseManager`/`ProcessLeaseCreateContext` path used for non-root directories (break coordination unchanged; no synthetic-oplock file-id registration, which is lease-key-based).

Both reuse existing helpers; no new lease logic.

## Verification

- Reproduced and fixed on a Linux client (kernel 6.8) against a live DittoFS SMB3 share. With the fix, under **default serverino**: `mount`, `stat`, `ls`, `mkdir`, write, and an `fio` layout pass all succeed (previously ESTALE). Confirmed on the wire that the root CREATE now returns a QFid context whose DiskFileId equals the FILE_ALL IndexNumber.
- New regression tests: `TestHandleOpenRootCreate_AnswersQFidWithStableRootID` (QFid ⇔ FILE_ALL parity) and `TestHandleOpenRootCreate_GrantsRequestedDirLease`.
- `go test ./internal/adapter/smb/...` green (including the directory-lease and close-dirlease-break suites); `go vet` / `gofmt` clean.
