### PR TITLE
perf(smb): reuse parent inode across CREATE permission and attr checks

### DIFF
--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -1187,9 +1187,25 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	// does not also block the other — required by smbtorture
 	// smb2.create.mkdir-visible (deny-WORLD-ADD_FILE inherited ACE must
 	// not block subdirectory creation).
+	//
+	// Load the parent inode exactly once here and reuse it for both the
+	// permission gate and the later compression-attribute inheritance in
+	// createNewFile — a single GetFile replaces the separate reloads each
+	// path used to perform. The compression read only runs on a create
+	// disposition, which is precisely when this block loads the parent.
+	var parentFile *metadata.File
 	if req.CreateDisposition != types.FileOpen {
+		var pErr error
+		parentFile, pErr = metaSvc.GetFile(authCtx.Context, parentHandle)
+		if pErr != nil {
+			logger.Debug("CREATE: parent lookup failed",
+				"path", filename,
+				"disposition", req.CreateDisposition,
+				"error", pErr)
+			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(pErr)}}, nil
+		}
 		isDirCreate := req.CreateOptions&types.FileDirectoryFile != 0
-		if err := metaSvc.CheckParentCreateAccess(authCtx, parentHandle, isDirCreate); err != nil {
+		if err := metaSvc.CheckParentCreateAccessFile(authCtx, parentHandle, parentFile, isDirCreate); err != nil {
 			logger.Debug("CREATE: parent DACL denies create",
 				"path", filename,
 				"disposition", req.CreateDisposition,
@@ -1433,6 +1449,7 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 		filename:             filename,
 		baseName:             baseName,
 		parentHandle:         parentHandle,
+		parentFile:           parentFile,
 		existingFile:         existingFile,
 		fileExists:           fileExists,
 		createAction:         createAction,
@@ -2033,6 +2050,7 @@ func (h *Handler) walkPath(
 func (h *Handler) createNewFile(
 	authCtx *metadata.AuthContext,
 	parentHandle metadata.FileHandle,
+	parentFile *metadata.File,
 	name string,
 	req *CreateRequest,
 	isDirectory bool,
@@ -2064,8 +2082,7 @@ func (h *Handler) createNewFile(
 	// Per MS-SMB2 2.2.13: FILE_NO_COMPRESSION in CreateOptions suppresses inheritance.
 	metaSvc := h.Registry.GetMetadataService()
 	if req.CreateOptions&types.FileNoCompression == 0 {
-		parentFile, pErr := metaSvc.GetFile(authCtx.Context, parentHandle)
-		if pErr == nil && parentFile.Mode&modeDOSCompressed != 0 {
+		if parentFile != nil && parentFile.Mode&modeDOSCompressed != 0 {
 			fileAttr.Mode |= modeDOSCompressed
 		}
 	}

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -22,12 +22,17 @@ import (
 // flow can run either inline (sync) or from a resume goroutine (async park on
 // lease break), without rewriting the large post-break block as a closure.
 type createDraft struct {
-	req            *CreateRequest
-	tree           *TreeConnection
-	authCtx        *metadata.AuthContext
-	filename       string
-	baseName       string
-	parentHandle   metadata.FileHandle
+	req          *CreateRequest
+	tree         *TreeConnection
+	authCtx      *metadata.AuthContext
+	filename     string
+	baseName     string
+	parentHandle metadata.FileHandle
+	// parentFile is the parent directory inode loaded once in the pre-break
+	// CREATE path (alongside the parent-create permission gate). createNewFile
+	// reuses it for compression-attribute inheritance instead of re-reading the
+	// same handle. Nil for pure-open dispositions, which never reach createNewFile.
+	parentFile     *metadata.File
 	existingFile   *metadata.File
 	existingHandle metadata.FileHandle
 	fileExists     bool
@@ -718,7 +723,7 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		}
 	case types.FileCreated:
 		var err error
-		file, fileHandle, err = h.createNewFile(authCtx, parentHandle, baseName, req, d.isDirectoryRequest)
+		file, fileHandle, err = h.createNewFile(authCtx, parentHandle, d.parentFile, baseName, req, d.isDirectoryRequest)
 		if err != nil {
 			// Concurrent-create race: another opener won between our
 			// pre-create lookup and the metadata-store transaction. For

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -655,7 +655,7 @@ func (s *Service) CheckParentCreateAccess(ctx *AuthContext, parentHandle FileHan
 // re-reading the parent inode via store.GetFile. A caller that already holds the
 // parent File — e.g. createEntry, which loads it once to validate the directory
 // type — passes it here so a single CreateFile no longer loads the same parent
-// handle three times (#1737). The no-ACL path routes through the file-passing
+// handle three times. The no-ACL path routes through the file-passing
 // checkWritePermissionFile so it too avoids a re-fetch. Semantics are
 // byte-for-byte those of CheckParentCreateAccess (same NFSv4 ADD_FILE vs
 // ADD_SUBDIRECTORY mask, same read-only ordering); only the redundant reads go.


### PR DESCRIPTION
## What

A single SMB CREATE loaded the parent directory inode multiple times. This threads one already-loaded parent `File` through the CREATE path so the redundant reads go away.

## Redundant loads removed

- `CheckParentCreateAccess` (in the CREATE handler) internally called `store.GetFile(parentHandle)`, then delegated to `CheckParentCreateAccessFile` which runs the identical check on an already-loaded parent. The handler now loads the parent once and calls the file-passing seam `CheckParentCreateAccessFile` directly.
- `createNewFile` did a second `GetFile(parentHandle)` purely to read the parent's compression attribute for inheritance. It now reuses the parent `File` already loaded for the permission gate, plumbed via the `createDraft`.

## How

- `Create` loads `parentFile` once, under the same `req.CreateDisposition != types.FileOpen` guard that previously gated the permission check. A `GetFile` error maps through `common.MapToSMB` and returns exactly as before.
- `parentFile` is carried on `createDraft` and passed into `createNewFile`, which uses it for compression inheritance instead of re-fetching. The compression read only runs on the `FileCreated` action, which only occurs on create dispositions, so the parent is always loaded when reached. A nil guard preserves the old best-effort behavior (a failed parent load simply skips compression inheritance).

## Semantics

Unchanged. Same NFSv4 ADD_FILE vs ADD_SUBDIRECTORY permission evaluation (via the existing `CheckParentCreateAccessFile` seam) and same compression-inheritance decision. Pure-open dispositions (`FILE_OPEN`) never load the parent and never reach `createNewFile`.

## Validation

- `go build ./...` clean
- `go vet ./internal/adapter/smb/... ./pkg/metadata/...` clean
- `gofmt -l` clean
- `go test ./internal/adapter/smb/... ./pkg/metadata/...` — 4678 passed across 26 packages (includes the `storetest` conformance suite)