### PR TITLE
perf(smb): cut per-op allocations in request labeling and compound assembly

### DIFF
--- a/internal/adapter/smb/compound.go
+++ b/internal/adapter/smb/compound.go
@@ -375,30 +375,37 @@ func sendCompoundResponses(responses []compoundResponse, connInfo *ConnInfo, req
 	// replaces per-command signing).
 	willEncrypt := compoundShouldEncrypt(connInfo, responses[0].respHeader, requestEncrypted)
 
-	var payload []byte
+	// Sum every sub-response's 8-byte-aligned on-wire length up front so the
+	// composed frame is allocated once, then write each header+body+padding
+	// into place rather than growing the payload per command.
+	total := 0
+	for i := range responses {
+		cmdLen := header.HeaderSize + len(responses[i].body)
+		total += cmdLen + (8-cmdLen%8)%8
+	}
+
+	payload := make([]byte, total)
+	offset := 0
 	for i := range responses {
 		body := responses[i].body
+		cmdLen := header.HeaderSize + len(body)
+		cmdLen += (8 - cmdLen%8) % 8
 
-		// Pad body to 8-byte boundary
-		totalLen := header.HeaderSize + len(body)
-		if padding := (8 - totalLen%8) % 8; padding > 0 {
-			body = append(body, make([]byte, padding)...)
-		}
-
-		// Set NextCommand offset for non-last responses
+		// Set NextCommand offset for non-last responses (points past this
+		// command's padded bytes). Must be set before Encode serializes it.
 		if i < len(responses)-1 {
-			responses[i].respHeader.NextCommand = uint32(header.HeaderSize + len(body))
+			responses[i].respHeader.NextCommand = uint32(cmdLen)
 		}
 
-		// Encode header (after setting NextCommand) and build full command bytes
+		// Write header then body into place; the trailing pad bytes stay zero
+		// (payload came from make, which zero-fills).
 		encoded := responses[i].respHeader.Encode()
-		cmdBytes := make([]byte, len(encoded)+len(body))
-		copy(cmdBytes, encoded)
-		copy(cmdBytes[len(encoded):], body)
+		copy(payload[offset:], encoded)
+		copy(payload[offset+len(encoded):], body)
 
-		// Sign this command individually (encrypted sessions use AEAD instead).
-		// If the sub-response's SessionID doesn't map to a known session,
-		// fall back to the first response's session for signing.
+		// Sign this command's slice individually (encrypted sessions use AEAD
+		// instead). If the sub-response's SessionID doesn't map to a known
+		// session, fall back to the first response's session for signing.
 		if sid := responses[i].respHeader.SessionID; sid != 0 {
 			sess, ok := connInfo.Handler.GetSession(sid)
 			if !ok && firstSession != nil {
@@ -407,11 +414,11 @@ func sendCompoundResponses(responses []compoundResponse, connInfo *ConnInfo, req
 			}
 			// Skip per-command signing when the whole frame will be AEAD-encrypted.
 			if ok && sess.ShouldSign() && !willEncrypt {
-				sess.SignMessageOnChannel(connInfo.ConnID, cmdBytes)
+				sess.SignMessageOnChannel(connInfo.ConnID, payload[offset:offset+cmdLen])
 			}
 		}
 
-		payload = append(payload, cmdBytes...)
+		offset += cmdLen
 	}
 
 	// Handle encryption for the whole compound (decision computed above).

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -28,7 +28,28 @@ func recordRequest(connInfo *ConnInfo, op string, isError bool, start time.Time)
 	if isError {
 		status = "error"
 	}
-	connInfo.Metrics.RecordRequest("smb", strings.ToLower(op), status, time.Since(start))
+	// Dispatch-table op names are a static bounded set, so their lower-cased
+	// labels are precomputed once (metricLabels) instead of lower-casing every
+	// request. Only unknown commands (types.Command.String() fallback) miss the
+	// map and take the rare per-call lower-case.
+	label, ok := metricLabels[op]
+	if !ok {
+		label = strings.ToLower(op)
+	}
+	connInfo.Metrics.RecordRequest("smb", label, status, time.Since(start))
+}
+
+// metricLabels maps each dispatch-table command name to its lower-cased RED
+// metric label. Populated once from DispatchTable so recordRequest avoids a
+// per-request allocation. Built in init because DispatchTable is itself
+// populated in an init (dispatch.go), which runs before this file's init.
+var metricLabels map[string]string
+
+func init() {
+	metricLabels = make(map[string]string, len(DispatchTable))
+	for _, c := range DispatchTable {
+		metricLabels[c.Name] = strings.ToLower(c.Name)
+	}
 }
 
 // commandName resolves a bounded operation label for an SMB2 command code.
@@ -1409,10 +1430,15 @@ func TrackSessionLifecycle(command types.Command, reqSessionID, ctxSessionID uin
 	}
 }
 
-// MakeErrorBody creates a minimal error response body per MS-SMB2 2.2.2.
-// Layout (9 bytes): StructureSize (2) + ErrorContextCount (1) + Reserved (1) + ByteCount (4) + ErrorData (1 padding).
+// errorBody is the shared immutable SMB2 ERROR response body per MS-SMB2 2.2.2.
+// Layout (9 bytes): StructureSize (2, =9) + ErrorContextCount (1) + Reserved (1)
+// + ByteCount (4) + ErrorData (1 padding). Every caller copies it into the
+// outgoing frame (via append or copy) and never mutates it in place, so one
+// backing slice is reused rather than allocating a fresh body per call.
+var errorBody = []byte{9, 0, 0, 0, 0, 0, 0, 0, 0}
+
+// MakeErrorBody returns the shared immutable SMB2 ERROR response body. Callers
+// must only read or copy the returned bytes, never mutate them in place.
 func MakeErrorBody() []byte {
-	body := make([]byte, 9)
-	binary.LittleEndian.PutUint16(body[0:2], 9) // StructureSize
-	return body
+	return errorBody
 }


### PR DESCRIPTION
Three self-contained micro-optimizations on the SMB per-op hot path. Wire output is unchanged; the SMB adapter unit tests (including compound/credit wiring) stay green.

## Changes

1. **Request labeling (`response.go`, `recordRequest`)** — `recordRequest` called `strings.ToLower(op)` on every request and every compound sub-command, allocating a new string each time. Op names come from the static `DispatchTable`, so their lower-cased labels are now precomputed once into a package-level `metricLabels` map (built in `init`, after `DispatchTable` is populated). The hot path (known commands) hits the map with zero allocation; only the rare unknown-command fallback (`types.Command.String()`) still lower-cases per call.

2. **Compound assembly (`compound.go`, `sendCompoundResponses`)** — the per-sub-response buffer growth (`append(body, make([]byte, padding)...)`, `make([]byte, len(encoded)+len(body))`, and `payload = append(payload, cmdBytes...)`) is replaced by summing the total 8-byte-aligned size up front and allocating `payload` once, writing each header+body+padding into place. Padding bytes come from the zero-filled `make`, NextCommand offsets and per-command in-place signing are preserved, so the composed frame is byte-for-byte identical.

3. **Error body (`response.go`, `MakeErrorBody`)** — each call allocated a fresh fixed 9-byte SMB2 ERROR body. Replaced with a single package-level immutable backing slice returned by reference. All callers copy it into the outgoing frame via `append`/`copy` and none mutate it in place (verified across `response.go`, `compound.go`, and the credit-wiring test), so sharing is safe.

## Validation

- `go build ./...` — ok
- `go vet ./internal/adapter/smb/...` — ok
- `gofmt -l internal/adapter/smb` — clean
- `go test ./internal/adapter/smb/...` — 2030 passed in 12 packages