### PR TITLE
perf(dfsbench): settle block-store sync before warm read pass for fair rand-read

### DIFF
--- a/internal/dfsbench/backend/backend.go
+++ b/internal/dfsbench/backend/backend.go
@@ -68,6 +68,13 @@ type Backend struct {
 	Unmount  func(ctx context.Context, proto Protocol) error
 	Teardown func(ctx context.Context) error
 
+	// WaitSettled blocks until the backend's async post-write digestion has
+	// quiesced, so a warm read measures a settled store rather than one still
+	// carving/uploading/rolling-up the just-written read target. nil for backends
+	// with no background write amplification (a fresh warm read already reflects
+	// steady state). Best-effort: a settle that times out logs and returns.
+	WaitSettled func(ctx context.Context) error
+
 	// FlushFUSE is the cold-read barrier for backends that keep their own cache:
 	// it flushes writeback to S3 and rebuilds on an empty cache, so the next read
 	// is genuinely cold-from-S3. FUSE backends remount empty (flush + fresh mount);

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -484,12 +484,24 @@ func dittofsBlockStats(ctx context.Context) (dittofsBlockTotals, error) {
 // store's async digestion to go idle before giving up and measuring anyway.
 const dittofsSettleTimeout = 120 * time.Second
 
+// dittofsSettleStableWindow is how long UnsyncedBytes must hold flat before the
+// store counts as idle. The block store carves+uploads on a periodic ticker
+// (UploadInterval, default 2s), so UnsyncedBytes only steps down once per tick
+// and is naturally flat between ticks. The window must exceed one tick, or a
+// sample landing in an inter-tick lull would declare idle while a full carve
+// pass is still queued — restarting mid-measurement and re-contaminating the
+// read. Poll spacing is a fraction of the window so several samples cover it.
+const (
+	dittofsSettleStableWindow = 4 * time.Second
+	dittofsSettlePollInterval = 500 * time.Millisecond
+)
+
 // dittofsWaitSettled blocks until the block store's async carve/upload/rollup of
 // freshly-written data goes idle, so the warm read pass measures a settled store
 // (served from the local journal) instead of one still writing CAS chunks to disk
 // and S3 — that concurrent digestion charges the read path for unrelated write
-// I/O and CPU, tanking warm rand-read latency. "Idle" is "no uploads in flight
-// and unsynced bytes no longer shrinking" across consecutive polls, not
+// I/O and CPU, tanking warm rand-read latency. "Idle" is UnsyncedBytes holding
+// flat for longer than one carve/upload tick (see dittofsSettleStableWindow), not
 // unsynced==0: a sub-GiB file's final bytes stay pinned in the unsealed append
 // log indefinitely without another write. Polls passively — it never triggers a
 // drain (which can stall) — and on timeout logs and returns nil so a contaminated
@@ -498,31 +510,30 @@ func dittofsWaitSettled(ctx context.Context) error {
 	start := time.Now()
 	deadline := start.Add(dittofsSettleTimeout)
 	prev := int64(-1)
-	stable := 0
+	var lastChange time.Time
 	for {
 		st, err := dittofsBlockStats(ctx)
 		if err != nil {
 			return err
 		}
-		if st.PendingUploads == 0 && st.UnsyncedBytes == prev {
-			if stable++; stable >= 2 {
-				_, _ = fmt.Fprintf(exec.CmdOut, "settled: waited %dms for block-store sync to go idle (unsynced=%dMiB, pending=0)\n",
-					time.Since(start).Milliseconds(), st.UnsyncedBytes>>20)
-				return nil
-			}
-		} else {
-			stable = 0
+		now := time.Now()
+		if st.UnsyncedBytes != prev {
+			prev = st.UnsyncedBytes
+			lastChange = now
+		} else if now.Sub(lastChange) >= dittofsSettleStableWindow {
+			_, _ = fmt.Fprintf(exec.CmdOut, "settled: waited %dms for block-store sync to go idle (unsynced=%dMiB, flat %s)\n",
+				time.Since(start).Milliseconds(), st.UnsyncedBytes>>20, dittofsSettleStableWindow)
+			return nil
 		}
-		prev = st.UnsyncedBytes
-		if time.Now().After(deadline) {
-			_, _ = fmt.Fprintf(exec.CmdOut, "settle: block store still busy after %s (unsynced=%dMiB, pending=%d) — warm read may be contaminated\n",
-				dittofsSettleTimeout, st.UnsyncedBytes>>20, st.PendingUploads)
+		if now.After(deadline) {
+			_, _ = fmt.Fprintf(exec.CmdOut, "settle: block store still busy after %s (unsynced=%dMiB) — warm read may be contaminated\n",
+				dittofsSettleTimeout, st.UnsyncedBytes>>20)
 			return nil
 		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(250 * time.Millisecond):
+		case <-time.After(dittofsSettlePollInterval):
 		}
 	}
 }

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -236,10 +236,11 @@ func init() {
 				Setup: func(ctx context.Context, env BackendEnv) error {
 					return dittofsSetup(ctx, env, kind, durability, dittofsUnboundedMaxSize)
 				},
-				Mount:    dittofsMount,
-				Evict:    dittofsEvict,
-				Unmount:  func(ctx context.Context, _ Protocol) error { return exec.Sh(ctx, "umount", clientMntDir) },
-				Teardown: dittofsTeardown,
+				Mount:       dittofsMount,
+				Evict:       dittofsEvict,
+				WaitSettled: dittofsWaitSettled,
+				Unmount:     func(ctx context.Context, _ Protocol) error { return exec.Sh(ctx, "umount", clientMntDir) },
+				Teardown:    dittofsTeardown,
 			})
 		}
 	}
@@ -267,10 +268,11 @@ func init() {
 			Setup: func(ctx context.Context, env BackendEnv) error {
 				return dittofsSetup(ctx, env, metaBadger, "writeback", maxSize)
 			},
-			Mount:    dittofsMount,
-			Evict:    dittofsEvict,
-			Unmount:  func(ctx context.Context, _ Protocol) error { return exec.Sh(ctx, "umount", clientMntDir) },
-			Teardown: dittofsTeardown,
+			Mount:       dittofsMount,
+			Evict:       dittofsEvict,
+			WaitSettled: dittofsWaitSettled,
+			Unmount:     func(ctx context.Context, _ Protocol) error { return exec.Sh(ctx, "umount", clientMntDir) },
+			Teardown:    dittofsTeardown,
 		})
 	}
 }
@@ -476,6 +478,53 @@ func dittofsBlockStats(ctx context.Context) (dittofsBlockTotals, error) {
 		return dittofsBlockTotals{}, fmt.Errorf("parse block stats json: %w\n%s", err, out)
 	}
 	return resp.Totals, nil
+}
+
+// dittofsSettleTimeout bounds how long the warm-read settle waits for the block
+// store's async digestion to go idle before giving up and measuring anyway.
+const dittofsSettleTimeout = 120 * time.Second
+
+// dittofsWaitSettled blocks until the block store's async carve/upload/rollup of
+// freshly-written data goes idle, so the warm read pass measures a settled store
+// (served from the local journal) instead of one still writing CAS chunks to disk
+// and S3 — that concurrent digestion charges the read path for unrelated write
+// I/O and CPU, tanking warm rand-read latency. "Idle" is "no uploads in flight
+// and unsynced bytes no longer shrinking" across consecutive polls, not
+// unsynced==0: a sub-GiB file's final bytes stay pinned in the unsealed append
+// log indefinitely without another write. Polls passively — it never triggers a
+// drain (which can stall) — and on timeout logs and returns nil so a contaminated
+// measurement is surfaced rather than failing the cell.
+func dittofsWaitSettled(ctx context.Context) error {
+	start := time.Now()
+	deadline := start.Add(dittofsSettleTimeout)
+	prev := int64(-1)
+	stable := 0
+	for {
+		st, err := dittofsBlockStats(ctx)
+		if err != nil {
+			return err
+		}
+		if st.PendingUploads == 0 && st.UnsyncedBytes == prev {
+			if stable++; stable >= 2 {
+				_, _ = fmt.Fprintf(exec.CmdOut, "settled: waited %dms for block-store sync to go idle (unsynced=%dMiB, pending=0)\n",
+					time.Since(start).Milliseconds(), st.UnsyncedBytes>>20)
+				return nil
+			}
+		} else {
+			stable = 0
+		}
+		prev = st.UnsyncedBytes
+		if time.Now().After(deadline) {
+			_, _ = fmt.Fprintf(exec.CmdOut, "settle: block store still busy after %s (unsynced=%dMiB, pending=%d) — warm read may be contaminated\n",
+				dittofsSettleTimeout, st.UnsyncedBytes>>20, st.PendingUploads)
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
 }
 
 // dittofsDrainDriftFloorBytes is the residual unsynced size the drain loop

--- a/internal/dfsbench/run/managed.go
+++ b/internal/dfsbench/run/managed.go
@@ -138,6 +138,17 @@ func runPlan(ctx context.Context, p backend.Plan, env backend.BackendEnv, wls, s
 		return err
 	}
 
+	// Let the backend's async post-write digestion quiesce before the warm pass.
+	// A writeback block store carves/uploads/rolls-up the read target on background
+	// goroutines; measuring the warm read mid-digestion charges the read path for
+	// concurrent disk writes and CPU, not the read itself. No-op for backends with
+	// no background write amplification. Best-effort — a settle error just warns.
+	if b.WaitSettled != nil {
+		if err := b.WaitSettled(ctx); err != nil {
+			_, _ = fmt.Fprintf(exec.CmdOut, "warn: settle %s: %v\n", p.SystemLabel(), err)
+		}
+	}
+
 	if err := runPass(ctx, p, "warm", wls, sizes, mnt, opts, f); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Problem

The dfsbench **warm** random-read cells measured DittoFS unfairly. In `internal/dfsbench/run/managed.go`, `layoutReadTarget(...)` writes the read-target file (via fio `layout`) and is immediately followed by the warm timed `runPass(..., "warm", ...)` with **no quiesce in between**.

So the warm rand-read ran **concurrently with DittoFS's async carve + upload + rollup** of the file just written — ~39 MB/s of disk writes during the read, ~53% CPU, and p50 latency ~270 ms (vs juicefs ~6 ms). That produced a measurement artifact, not a read-path result: DittoFS's own settled warm rand-read on the same block store is 7,400–24,800 IOPS, so the SMB3 298 IOPS figure was contamination.

A settled warm read of a <=1 GiB file serves purely from the local journal — no S3, no disk writes.

## Fix

Add a backend `WaitSettled(ctx)` hook, called in `runManagedCell` between the read-target layout and the warm pass:

- **DittoFS** polls the existing `dfsctl store block stats -o json` surface (already consumed by the cold-barrier code) for `unsynced_bytes` + `pending_uploads`, and waits until async digestion goes idle: no uploads in flight and unsynced bytes no longer shrinking across consecutive polls. It does **not** require `unsynced == 0` — a sub-GiB file's final bytes stay pinned in the unsealed append log indefinitely without another write. It polls **passively** (never calls `drain-uploads`, which can stall, #1767) and on timeout (120 s) logs a clear "may be contaminated" line and proceeds — a contaminated cell is surfaced, never failed.
- **Competitors** (juicefs/rclone/s3fs/zerofs) leave the hook nil (no-op), preserving their current measurement.

It logs `settled: waited Xms for block-store sync to go idle (...)` so contaminated-vs-clean runs are distinguishable in the harness log.

## Scope

Harness-only. No new stats endpoint was needed — the `unsynced_bytes`/`pending_uploads` surface already exists and dfsbench already reads it. **No DittoFS runtime read-path change.**

## Files
- `internal/dfsbench/backend/backend.go` — add `WaitSettled` hook to `Backend`.
- `internal/dfsbench/backend/dittofs.go` — `dittofsWaitSettled` (passive poll of block stats); wire into both DittoFS registrations.
- `internal/dfsbench/run/managed.go` — call `WaitSettled` between layout and warm pass.

## Validation
`go build ./...`, `go vet`, `gofmt -l`, `go test ./internal/dfsbench/...` (43 passed) all green.