### PR TITLE
perf(sqlite): skip file_block_refs rewrite when chunk manifest is unchanged

### DIFF
--- a/pkg/metadata/store/sqlite/file_block_refs.go
+++ b/pkg/metadata/store/sqlite/file_block_refs.go
@@ -1,8 +1,10 @@
 package sqlite
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/google/uuid"
@@ -64,6 +66,60 @@ func putFileChunkRefs(ctx context.Context, tx execer, fileID uuid.UUID, blocks [
 		}
 	}
 	return nil
+}
+
+// fileChunkRefsUnchanged reports whether the file_block_refs rows already
+// stored for fileID exactly match blocks — same count, offsets, sizes, and
+// hashes. When true, a PutFile carrying an identical manifest can skip the
+// DELETE+INSERT rewrite: the stored rows are already correct. This is the
+// common case for an in-place overwrite that reuses the same chunk
+// boundaries and re-projects the same manifest.
+//
+// Any difference (count, offset, size, or hash) returns false, so the
+// caller performs the full rewrite — false is the safe default: a spurious
+// false only costs a rewrite that was already the previous behaviour, while
+// a spurious true would drop a real change. The incoming list is compared in
+// offset order (offsets are unique under the (file_id, "offset") PK, giving a
+// total order that matches the stored rows' ORDER BY "offset").
+func fileChunkRefsUnchanged(ctx context.Context, tx execer, fileID uuid.UUID, blocks []block.ChunkRef) (bool, error) {
+	// Canonicalise the incoming list into offset order without reordering the
+	// caller's slice.
+	want := make([]block.ChunkRef, len(blocks))
+	copy(want, blocks)
+	sort.Slice(want, func(i, j int) bool { return want[i].Offset < want[j].Offset })
+
+	rows, err := tx.Query(ctx,
+		`SELECT "offset", size, hash FROM file_block_refs WHERE file_id = ?1 ORDER BY "offset" ASC`,
+		fileID,
+	)
+	if err != nil {
+		return false, fmt.Errorf("query file_block_refs for %s: %w", fileID, err)
+	}
+	defer rows.Close()
+
+	i := 0
+	for rows.Next() {
+		var off int64
+		var sz int32
+		var raw []byte
+		if err := rows.Scan(&off, &sz, &raw); err != nil {
+			return false, fmt.Errorf("scan file_block_ref: %w", err)
+		}
+		if i >= len(want) {
+			// More stored rows than incoming — the manifest shrank.
+			return false, nil
+		}
+		w := want[i]
+		if uint64(off) != w.Offset || uint32(sz) != w.Size || !bytes.Equal(raw, w.Hash[:]) {
+			return false, nil
+		}
+		i++
+	}
+	if err := rows.Err(); err != nil {
+		return false, fmt.Errorf("iterate file_block_refs: %w", err)
+	}
+	// Equal only when every incoming ref was matched by a stored row.
+	return i == len(want), nil
 }
 
 // PutFileChunkRefsCallCount returns how many times PutFile persisted the

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -447,9 +447,24 @@ func (tx *sqliteTransaction) PutFile(ctx context.Context, file *metadata.File) e
 	// regular files carry ChunkRef payloads; empty/nil Blocks under a dirty
 	// flag performs a DELETE-only pass so no stale rows survive a drop.
 	if file.Type == metadata.FileTypeRegular && file.BlocksDirty {
-		tx.store.manifestWrites.Add(1)
-		if err := putFileChunkRefs(ctx, tx.tx, file.ID, file.Blocks); err != nil {
-			return mapDBError(err, "PutFile", "blocks")
+		// On an in-place data overwrite the projected manifest is frequently
+		// identical to what is already stored (same chunk hashes/offsets), so
+		// the DELETE+INSERT is pure write amplification. Skip it when the rows
+		// already match. Freshly-inserted rows (!updated) have no prior refs,
+		// so the compare is skipped and the rewrite always runs.
+		rewrite := true
+		if updated {
+			unchanged, err := fileChunkRefsUnchanged(ctx, tx.tx, file.ID, file.Blocks)
+			if err != nil {
+				return mapDBError(err, "PutFile", "blocks")
+			}
+			rewrite = !unchanged
+		}
+		if rewrite {
+			tx.store.manifestWrites.Add(1)
+			if err := putFileChunkRefs(ctx, tx.tx, file.ID, file.Blocks); err != nil {
+				return mapDBError(err, "PutFile", "blocks")
+			}
 		}
 	}
 


### PR DESCRIPTION
## What

Addresses issue #1819 (sqlite metadata backend ~19x slower than badger on random 4k writes). This targets one of the three named root causes: **per-op write amplification** on the data-write path. The other two (single-writer `SetMaxOpenConns(1)`, pure-Go driver overhead) are architectural and left untouched.

On a data WRITE, `sqliteTransaction.PutFile` re-projects the chunk manifest and, gated by `file.BlocksDirty`, calls `putFileChunkRefs`, which does a full `DELETE FROM file_block_refs` + multi-row `INSERT`. For an in-place overwrite that reuses the same chunk boundaries, the re-projected manifest is byte-for-byte identical to what is already stored, so that DELETE+INSERT is pure waste.

## Change

Before rewriting, compare the incoming chunk list to the rows already stored (`fileChunkRefsUnchanged`). When they match exactly — same count, offsets, sizes, and hashes — skip the DELETE+INSERT. The comparison is one indexed `SELECT ... WHERE file_id = ? ORDER BY "offset"` against the same transaction, which is far cheaper than the write it avoids.

The check is skipped entirely when the inode row was just INSERTed (`!updated`): a brand-new file provably has no prior refs, so there is nothing to compare and the rewrite always runs.

## Correctness

- The incoming list is copied and sorted by offset before comparison; offsets are unique under the `(file_id, "offset")` primary key, so offset order is a total order that matches the stored rows' `ORDER BY "offset"`. Comparison is therefore order-independent.
- Any difference — different count (grow or shrink), offset, size, or hash — returns `false` and the full rewrite runs. `false` is the safe default: a spurious `false` only costs the rewrite that was the previous behaviour, whereas a spurious `true` could drop a real change. When in doubt, it rewrites.
- Empty incoming manifest with stored rows present -> mismatch -> rewrite (the DELETE clears stale rows, unchanged from before). Empty incoming with no stored rows -> match -> nothing to do.

## Not changed

- Concurrency model: no change to `SetMaxOpenConns`, pragmas, or the driver. The added read runs inside the existing write transaction under the same single-writer lock.
- Durability semantics: unchanged. When the manifest actually changes, the exact same DELETE+INSERT runs as before; the commit/fsync path is untouched.
- The `manifestWrites` counter now increments only when a rewrite actually happens, matching its documented meaning ("persisted the manifest").

The optional hot-path `UPDATE inodes` column narrowing was intentionally skipped: `PutFile` is the shared entrypoint for create/rename/xattr/setattr, all of which mutate other columns, so narrowing safely would require a separate attr-only method — invasive for a secondary win.

## Follow-up

The larger lever remains a write coalescer / group-commit that batches multiple mutations into a single transaction+fsync; that is a separate design and out of scope here.

## Tests

- `go build ./...` clean
- `go vet ./pkg/metadata/...` clean
- `gofmt -l pkg/metadata` clean
- `go test ./pkg/metadata/...` -> 2648 passed (includes the storetest conformance suite)
- `go test -race ./pkg/metadata/store/sqlite/...` -> 227 passed