### PR TITLE
refactor(badger): centralize badger error mapping in mapBadgerError

### DIFF
--- a/pkg/metadata/store/badger/errors.go
+++ b/pkg/metadata/store/badger/errors.go
@@ -1,0 +1,62 @@
+package badger
+
+import (
+	goerrors "errors"
+	"fmt"
+
+	badgerdb "github.com/dgraph-io/badger/v4"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// mapBadgerError maps a BadgerDB error to a metadata.StoreError, giving the
+// badger backend the same single classification point the SQL backends have in
+// mapDBError (SQLite) and mapPgError (Postgres). Routing the badger sentinels
+// through one helper keeps the conformance suite and the runtime backend-
+// agnostic: a missing key, an SSI abort, and any other failure all surface as
+// the shared metadata codes rather than leaking the raw badger sentinel.
+//
+// op names the entity or operation the error concerns and is woven into the
+// message ("<op> not found" for a missing key), so a routed call reproduces the
+// text the inline literals emitted. path is the caller-facing path, if any.
+func mapBadgerError(err error, op, path string) error {
+	if err == nil {
+		return nil
+	}
+
+	// Already a StoreError (e.g. from a validation helper): pass through so a
+	// classified error keeps its original code, message, and path.
+	var storeErr *metadata.StoreError
+	if goerrors.As(err, &storeErr) {
+		return storeErr
+	}
+
+	switch {
+	// Missing key: the looked-up entity does not exist.
+	case goerrors.Is(err, badgerdb.ErrKeyNotFound):
+		return &metadata.StoreError{
+			Code:    metadata.ErrNotFound,
+			Message: fmt.Sprintf("%s not found", op),
+			Path:    path,
+		}
+
+	// SSI optimistic-concurrency abort. The raw sentinel is preserved via Cause
+	// so codebase-wide conflict detection (errors.Is / IsConflictError) still
+	// recognizes it through the unwrap chain and the transaction layer retries.
+	case goerrors.Is(err, badgerdb.ErrConflict):
+		return &metadata.StoreError{
+			Code:    metadata.ErrConflict,
+			Message: fmt.Sprintf("%s: transaction conflict", op),
+			Path:    path,
+			Cause:   err,
+		}
+
+	// Any other failure is an I/O error; keep the raw error reachable via Cause.
+	default:
+		return &metadata.StoreError{
+			Code:    metadata.ErrIOError,
+			Message: fmt.Sprintf("%s: %v", op, err),
+			Path:    path,
+			Cause:   err,
+		}
+	}
+}

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -37,15 +37,8 @@ func (s *BadgerMetadataStore) GetRootHandle(ctx context.Context, shareName strin
 	var rootHandle metadata.FileHandle
 	err := s.db.View(func(txn *badgerdb.Txn) error {
 		item, err := txn.Get(keyShare(shareName))
-		if err == badgerdb.ErrKeyNotFound {
-			return &metadata.StoreError{
-				Code:    metadata.ErrNotFound,
-				Message: "share not found",
-				Path:    shareName,
-			}
-		}
 		if err != nil {
-			return err
+			return mapBadgerError(err, "share", shareName)
 		}
 
 		return item.Value(func(val []byte) error {
@@ -84,15 +77,8 @@ func (s *BadgerMetadataStore) GetShareOptions(ctx context.Context, shareName str
 	var opts *metadata.ShareOptions
 	err := s.db.View(func(txn *badgerdb.Txn) error {
 		item, err := txn.Get(keyShare(shareName))
-		if err == badgerdb.ErrKeyNotFound {
-			return &metadata.StoreError{
-				Code:    metadata.ErrNotFound,
-				Message: "share not found",
-				Path:    shareName,
-			}
-		}
 		if err != nil {
-			return err
+			return mapBadgerError(err, "share", shareName)
 		}
 
 		return item.Value(func(val []byte) error {
@@ -164,15 +150,8 @@ func (s *BadgerMetadataStore) UpdateShareOptions(ctx context.Context, shareName 
 
 	err := s.db.Update(func(txn *badgerdb.Txn) error {
 		item, err := txn.Get(keyShare(shareName))
-		if err == badgerdb.ErrKeyNotFound {
-			return &metadata.StoreError{
-				Code:    metadata.ErrNotFound,
-				Message: "share not found",
-				Path:    shareName,
-			}
-		}
 		if err != nil {
-			return err
+			return mapBadgerError(err, "share", shareName)
 		}
 
 		var data *shareData
@@ -214,15 +193,8 @@ func (s *BadgerMetadataStore) DeleteShare(ctx context.Context, shareName string)
 	var quotaFreed map[quota.Key]metadata.UsageStat
 	err := s.db.Update(func(txn *badgerdb.Txn) error {
 		_, err := txn.Get(keyShare(shareName))
-		if err == badgerdb.ErrKeyNotFound {
-			return &metadata.StoreError{
-				Code:    metadata.ErrNotFound,
-				Message: "share not found",
-				Path:    shareName,
-			}
-		}
 		if err != nil {
-			return err
+			return mapBadgerError(err, "share", shareName)
 		}
 
 		freed, quota, err := s.deleteShareFiles(txn, shareName)

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -186,24 +186,14 @@ func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx me
 		return err
 	}
 
-	// All retries exhausted. Wrap the raw badgerdb.ErrConflict sentinel into a
-	// recognizable mderrors.StoreError{Code: ErrConflict} (#1245-B). The raw
-	// badger sentinel is badger's SSI optimistic-concurrency abort
-	// ("Transaction Conflict. Please retry"); leaking it bare meant
-	// codebase-wide conflict detection (errors.As(*StoreError) /
-	// mderrors.IsConflictError, the runtime coordinator's mapObjectIDConflict,
-	// and the rollup persister's isObjectIDConflict) could not classify a
-	// hot-key SSI abort as a conflict — so a bulk same-content rollup never
-	// converged to the zero-objectID dedup write and the ticker re-ran the same
-	// payloadID forever. Wrapping (with the raw sentinel reachable via Unwrap
-	// for diagnostics) makes the exhausted SSI conflict recognizable uniformly
-	// with Postgres' 23505 and Memory's StoreError conflict.
+	// All retries exhausted. Classify the raw badgerdb.ErrConflict SSI abort as a
+	// StoreError{Code: ErrConflict} so codebase-wide conflict detection
+	// (errors.As(*StoreError) / IsConflictError, the runtime coordinator's
+	// mapObjectIDConflict, the rollup persister's isObjectIDConflict) recognizes
+	// it uniformly with the SQL backends. The raw sentinel stays reachable via
+	// Cause/Unwrap for diagnostics and errors.Is.
 	if goerrors.Is(lastErr, badgerdb.ErrConflict) {
-		return &mderrors.StoreError{
-			Code:    mderrors.ErrConflict,
-			Message: "badger WithTransaction: transaction conflict (SSI) after exhausting retries",
-			Cause:   lastErr,
-		}
+		return mapBadgerError(lastErr, "badger WithTransaction", "")
 	}
 	return lastErr
 }
@@ -236,14 +226,8 @@ func (tx *badgerTransaction) getFile(ctx context.Context, handle metadata.FileHa
 	}
 
 	item, err := tx.txn.Get(keyFile(fileID))
-	if err == badgerdb.ErrKeyNotFound {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "file not found",
-		}
-	}
 	if err != nil {
-		return nil, err
+		return nil, mapBadgerError(err, "file", "")
 	}
 
 	var file *metadata.File
@@ -501,14 +485,8 @@ func (tx *badgerTransaction) DeleteFile(ctx context.Context, handle metadata.Fil
 
 	// Check if exists first and read for size tracking.
 	item, err := tx.txn.Get(keyFile(fileID))
-	if err == badgerdb.ErrKeyNotFound {
-		return &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "file not found",
-		}
-	}
 	if err != nil {
-		return err
+		return mapBadgerError(err, "file", "")
 	}
 
 	// Subtract size from counter for regular files; capture ObjectID and
@@ -554,14 +532,8 @@ func (tx *badgerTransaction) GetChild(ctx context.Context, dirHandle metadata.Fi
 	}
 
 	item, err := tx.txn.Get(keyChild(dirID, name))
-	if err == badgerdb.ErrKeyNotFound {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "child not found",
-		}
-	}
 	if err != nil {
-		return nil, err
+		return nil, mapBadgerError(err, "child", "")
 	}
 
 	var childID uuid.UUID
@@ -628,14 +600,8 @@ func (tx *badgerTransaction) DeleteChild(ctx context.Context, dirHandle metadata
 	}
 
 	item, err := tx.txn.Get(keyChild(dirID, name))
-	if err == badgerdb.ErrKeyNotFound {
-		return &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "child not found",
-		}
-	}
 	if err != nil {
-		return err
+		return mapBadgerError(err, "child", "")
 	}
 
 	// Capture the child UUID so the reverse edge cn:<parent>:<child> can be torn
@@ -843,14 +809,8 @@ func (tx *badgerTransaction) GetParent(ctx context.Context, handle metadata.File
 	}
 
 	item, err := tx.txn.Get(keyParent(fileID))
-	if err == badgerdb.ErrKeyNotFound {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "parent not found",
-		}
-	}
 	if err != nil {
-		return nil, err
+		return nil, mapBadgerError(err, "parent", "")
 	}
 
 	var parentID uuid.UUID
@@ -1021,15 +981,8 @@ func (tx *badgerTransaction) GetRootHandle(ctx context.Context, shareName string
 	}
 
 	item, err := tx.txn.Get(keyShare(shareName))
-	if err == badgerdb.ErrKeyNotFound {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "share not found",
-			Path:    shareName,
-		}
-	}
 	if err != nil {
-		return nil, err
+		return nil, mapBadgerError(err, "share", shareName)
 	}
 
 	var rootHandle metadata.FileHandle
@@ -1054,15 +1007,8 @@ func (tx *badgerTransaction) GetShareOptions(ctx context.Context, shareName stri
 	}
 
 	item, err := tx.txn.Get(keyShare(shareName))
-	if err == badgerdb.ErrKeyNotFound {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "share not found",
-			Path:    shareName,
-		}
-	}
 	if err != nil {
-		return nil, err
+		return nil, mapBadgerError(err, "share", shareName)
 	}
 
 	var opts *metadata.ShareOptions
@@ -1123,15 +1069,8 @@ func (tx *badgerTransaction) UpdateShareOptions(ctx context.Context, shareName s
 	}
 
 	item, err := tx.txn.Get(keyShare(shareName))
-	if err == badgerdb.ErrKeyNotFound {
-		return &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "share not found",
-			Path:    shareName,
-		}
-	}
 	if err != nil {
-		return err
+		return mapBadgerError(err, "share", shareName)
 	}
 
 	var data *shareData
@@ -1167,15 +1106,8 @@ func (tx *badgerTransaction) DeleteShare(ctx context.Context, shareName string) 
 	}
 
 	_, err := tx.txn.Get(keyShare(shareName))
-	if err == badgerdb.ErrKeyNotFound {
-		return &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "share not found",
-			Path:    shareName,
-		}
-	}
 	if err != nil {
-		return err
+		return mapBadgerError(err, "share", shareName)
 	}
 
 	// Tear down all file metadata on the active txn, identical to the pool


### PR DESCRIPTION
## Summary

Chunk 4 of the error-mapper consistency work (#1776). The badger metadata store had **no centralized error mapper**, unlike sqlite (mapDBError) and postgres (mapPgError) — it classified badger sentinels into metadata.StoreError codes inline at ~14 mechanical sites plus ~22 bespoke ones.

This adds pkg/metadata/store/badger/errors.go with a single mapBadgerError(err, op, path) that mirrors the **shape** of the SQL mappers:

- passthrough for an existing *StoreError
- badger.ErrKeyNotFound -> ErrNotFound
- badger.ErrConflict -> ErrConflict (raw sentinel preserved via Cause so errors.Is / IsConflictError / the retry loop still recognize it)
- default -> ErrIOError (Cause preserved)

This is a **locality/consistency win, not a LOC win** — the value is one place that classifies badger errors, matching the SQL backends, so the conformance suite and runtime stay backend-agnostic.

## What was routed vs left bespoke

Routed **14** mechanical sentinel-mapping sites through mapBadgerError:
- transaction.go: getFile, DeleteFile, GetChild, DeleteChild, GetParent, GetRootHandle, GetShareOptions, UpdateShareOptions, DeleteShare (KeyNotFound -> ErrNotFound), and the SSI conflict-exhaustion wrap in WithTransaction (ErrConflict).
- shares.go: the store-level GetRootHandle / GetShareOptions / UpdateShareOptions / DeleteShare lookups.

Left **22** genuinely bespoke StoreError constructions as-is, because routing them would change their code or message:
- ErrInvalidHandle from DecodeFileHandle (not a badger sentinel).
- locks.go ErrLockNotFound (a distinct code — mapBadgerError would emit ErrNotFound).
- ErrAlreadyExists share-exists (surfaces from a nil Get, i.e. key present — not a sentinel map).
- "root must be a directory" (ErrInvalidArgument domain check).
- "no file found with content ID: %s" (result == nil, carries the payload id).
- create_cache.go "child not found" (dirent-cache negative hit, not a badger sentinel).

## String preservation

op is the entity noun ("file"/"child"/"parent"/"share"), so a routed not-found reproduces the exact prior message ("file not found", "share not found", ...) and Path. No test asserts on the badger store's returned message text (verified repo-wide; the conflict test asserts only Code + that the raw badger.ErrConflict is reachable via errors.Is, both preserved). The not-found lookups collapse the former KeyNotFound + raw-leak branches into a single mapBadgerError call; this is retry-safe because badger surfaces ErrConflict at Commit, never from a Get inside the txn closure.

## Validation

- go build ./... — clean
- go vet ./pkg/metadata/... — clean
- gofmt -l pkg/metadata — clean
- go test ./pkg/metadata/... — 2648 passed (storetest conformance incl. badger)
- go test -race ./pkg/metadata/store/badger/... — 516 passed (incl. transaction_conflict_test, conflict_mechanism_test)