### PR TITLE
refactor(metadata): share SQL transaction backoff via internal/txretry

### DIFF
--- a/pkg/metadata/store/internal/txretry/txretry.go
+++ b/pkg/metadata/store/internal/txretry/txretry.go
@@ -1,0 +1,77 @@
+// Package txretry holds the transient-conflict backoff shared by the SQL
+// metadata backends (sqlite, postgres).
+//
+// Both backends must backpressure under write contention — block-and-retry
+// until a real time budget elapses — rather than surfacing EIO to the caller
+// after a fixed handful of attempts (#1769). Every competitor (rclone/juicefs)
+// goes slow under the same pressure but never errors; a fixed 3-attempt budget
+// was routinely exceeded on hot rows (usedBytes counter, parent-dir mtime,
+// quota) under concurrent writers, turning contention into NFS3ErrIO. Only the
+// backend's already-classified transient conflicts (sqlite BUSY/LOCKED,
+// postgres 40001/40P01) are retried; that classification stays backend-local.
+//
+// The deadline computation and the jittered exponential backoff between
+// attempts are identical across the two backends, so they live here once. The
+// badger backend uses a structurally different loop (closure-based db.Update,
+// fixed attempt count, no time budget) and deliberately does not share this.
+package txretry
+
+import (
+	"context"
+	"math/rand/v2"
+	"time"
+)
+
+const (
+	// budget bounds how long a caller backpressures on a transient conflict
+	// before giving up and returning the mapped error. Kept in line with the
+	// sqlite busy_timeout (config default 5s) so a genuinely stuck conflict
+	// still eventually surfaces — after a real budget, not 60ms.
+	budget = 5 * time.Second
+	// baseBackoff / maxBackoff bound the jittered exponential backoff between
+	// attempts.
+	baseBackoff = 5 * time.Millisecond
+	maxBackoff  = 200 * time.Millisecond
+)
+
+// Deadline returns the backpressure deadline for a transaction: now+budget,
+// tightened to an earlier ctx deadline when the caller set one, so a caller's
+// own timeout is always honored ahead of the retry budget.
+func Deadline(ctx context.Context) time.Time {
+	deadline := time.Now().Add(budget)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+	return deadline
+}
+
+// Backoff waits a jittered exponential backoff before the next transaction
+// attempt, bounded by deadline and ctx. It returns true if the caller should
+// retry, or false when the retry budget is exhausted or ctx is done.
+func Backoff(ctx context.Context, deadline time.Time, attempt int) bool {
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return false
+	}
+	// Full-jitter exponential backoff: base<<attempt capped at max, then a
+	// uniform random in (0, d]. Spreads retries so contending writers don't
+	// resynchronize into a thundering herd.
+	d := maxBackoff
+	if attempt < 16 {
+		if s := baseBackoff << uint(attempt); s > 0 && s < maxBackoff {
+			d = s
+		}
+	}
+	if d > remaining {
+		d = remaining
+	}
+	wait := time.Duration(rand.Int64N(int64(d)) + 1)
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/pkg/metadata/store/internal/txretry/txretry_test.go
+++ b/pkg/metadata/store/internal/txretry/txretry_test.go
@@ -1,0 +1,54 @@
+package txretry
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestBackoff_ExhaustedBudgetReturnsFalse(t *testing.T) {
+	// A deadline already in the past leaves no budget: no wait, no retry.
+	if Backoff(context.Background(), time.Now().Add(-time.Second), 0) {
+		t.Fatal("Backoff past deadline should return false")
+	}
+}
+
+func TestBackoff_RetriesWithinBudget(t *testing.T) {
+	// A comfortable deadline yields a retry after a bounded wait.
+	start := time.Now()
+	if !Backoff(context.Background(), start.Add(time.Second), 0) {
+		t.Fatal("Backoff within budget should return true")
+	}
+	// attempt 0 caps at baseBackoff (5ms); the actual wait is jittered in
+	// (0, 5ms], so it must not exceed maxBackoff.
+	if waited := time.Since(start); waited > maxBackoff {
+		t.Fatalf("attempt-0 wait %v exceeded maxBackoff %v", waited, maxBackoff)
+	}
+}
+
+func TestBackoff_CtxCancelStopsRetry(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if Backoff(ctx, time.Now().Add(time.Second), 0) {
+		t.Fatal("Backoff with cancelled ctx should return false")
+	}
+}
+
+func TestDeadline_TightensToEarlierCtxDeadline(t *testing.T) {
+	// A ctx deadline sooner than now+budget wins.
+	soon := time.Now().Add(50 * time.Millisecond)
+	ctx, cancel := context.WithDeadline(context.Background(), soon)
+	defer cancel()
+	if got := Deadline(ctx); got.After(soon) {
+		t.Fatalf("Deadline %v should not exceed earlier ctx deadline %v", got, soon)
+	}
+}
+
+func TestDeadline_DefaultsToBudget(t *testing.T) {
+	// No ctx deadline: now+budget, within a small slack.
+	got := Deadline(context.Background())
+	want := time.Now().Add(budget)
+	if diff := got.Sub(want); diff > 100*time.Millisecond || diff < -100*time.Millisecond {
+		t.Fatalf("Deadline %v not ~now+budget %v", got, want)
+	}
+}

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand/v2"
 	"time"
 
 	"github.com/google/uuid"
@@ -18,58 +17,15 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlstat"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/txretry"
 )
 
 // Transaction retry policy (#1769). Under write contention DittoFS must
 // backpressure — block-and-retry until a real budget elapses — not surface EIO
-// to the caller after a fixed handful of attempts. Every competitor
-// (rclone/juicefs) goes slow under the same pressure but never errors; the old
-// 3-attempt / 10-20-30ms budget was routinely exceeded on hot rows (usedBytes
-// counter, parent-dir mtime, quota) under 8 concurrent writers, turning
-// contention into NFS3ErrIO. Only the already-classified transient conflicts
-// (40001 serialization_failure / 40P01 deadlock_detected) are retried;
-// non-transient errors return immediately.
-const (
-	// txRetryBudget bounds how long WithTransaction backpressures on a transient
-	// conflict before giving up and returning the mapped error, so a genuinely
-	// stuck conflict still eventually surfaces — after a real budget, not 60ms.
-	txRetryBudget = 5 * time.Second
-	// txRetryBaseBackoff / txRetryMaxBackoff bound the jittered exponential
-	// backoff between attempts.
-	txRetryBaseBackoff = 5 * time.Millisecond
-	txRetryMaxBackoff  = 200 * time.Millisecond
-)
-
-// txBackoff waits a jittered exponential backoff before the next transaction
-// attempt, bounded by deadline and ctx. It returns true if the caller should
-// retry, or false when the retry budget is exhausted or ctx is done.
-func txBackoff(ctx context.Context, deadline time.Time, attempt int) bool {
-	remaining := time.Until(deadline)
-	if remaining <= 0 {
-		return false
-	}
-	// Full-jitter exponential backoff: base<<attempt capped at max, then a
-	// uniform random in (0, d]. Spreads retries so contending writers don't
-	// resynchronize into a thundering herd.
-	d := txRetryMaxBackoff
-	if attempt < 16 {
-		if s := txRetryBaseBackoff << uint(attempt); s > 0 && s < txRetryMaxBackoff {
-			d = s
-		}
-	}
-	if d > remaining {
-		d = remaining
-	}
-	wait := time.Duration(rand.Int64N(int64(d)) + 1)
-	timer := time.NewTimer(wait)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return false
-	case <-timer.C:
-		return true
-	}
-}
+// to the caller after a fixed handful of attempts. Only the already-classified
+// transient conflicts (40001 serialization_failure / 40P01 deadlock_detected)
+// are retried; non-transient errors return immediately. The deadline and
+// jittered backoff are shared with the sqlite backend in internal/txretry.
 
 // ============================================================================
 // Transaction Support
@@ -140,12 +96,8 @@ func (s *PostgresMetadataStore) withTransaction(ctx context.Context, fn func(tx 
 	relaxCommit := relaxed && s.config.RelaxedDurability
 
 	// Backpressure deadline (#1769): retry transient conflicts until this budget
-	// elapses rather than EIOing after a fixed attempt count. Honor an earlier
-	// caller deadline if the ctx carries one.
-	deadline := time.Now().Add(txRetryBudget)
-	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
-		deadline = d
-	}
+	// elapses rather than EIOing after a fixed attempt count.
+	deadline := txretry.Deadline(ctx)
 
 	var lastErr error
 	for attempt := 0; ; attempt++ {
@@ -195,7 +147,7 @@ func (s *PostgresMetadataStore) withTransaction(ctx context.Context, fn func(tx 
 			rollbackCancel()
 			if isRetryableError(err) {
 				lastErr = err
-				if txBackoff(ctx, deadline, attempt) {
+				if txretry.Backoff(ctx, deadline, attempt) {
 					continue
 				}
 				break
@@ -210,7 +162,7 @@ func (s *PostgresMetadataStore) withTransaction(ctx context.Context, fn func(tx 
 			commitCancel()
 			if isRetryableError(err) {
 				lastErr = err
-				if txBackoff(ctx, deadline, attempt) {
+				if txretry.Backoff(ctx, deadline, attempt) {
 					continue
 				}
 				break

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand/v2"
 	"time"
 
 	"github.com/google/uuid"
@@ -16,58 +15,15 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlstat"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/txretry"
 )
 
 // Transaction retry policy (#1769). Under write contention DittoFS must
 // backpressure — block-and-retry until a real budget elapses — not surface EIO
-// to the caller after a fixed handful of attempts. Every competitor
-// (rclone/juicefs) goes slow under the same pressure but never errors; the old
-// 3-attempt / 10-20-30ms budget was routinely exceeded on hot rows (usedBytes
-// counter, parent-dir mtime, quota) under 8 concurrent writers, turning
-// contention into NFS3ErrIO. Only the already-classified transient conflicts
-// (sqlite BUSY/LOCKED) are retried; non-transient errors return immediately.
-const (
-	// txRetryBudget bounds how long WithTransaction backpressures on a transient
-	// conflict before giving up and returning the mapped error. Kept in line with
-	// the sqlite busy_timeout (config default 5s) so a genuinely stuck conflict
-	// still eventually surfaces — after a real budget, not 60ms.
-	txRetryBudget = 5 * time.Second
-	// txRetryBaseBackoff / txRetryMaxBackoff bound the jittered exponential
-	// backoff between attempts.
-	txRetryBaseBackoff = 5 * time.Millisecond
-	txRetryMaxBackoff  = 200 * time.Millisecond
-)
-
-// txBackoff waits a jittered exponential backoff before the next transaction
-// attempt, bounded by deadline and ctx. It returns true if the caller should
-// retry, or false when the retry budget is exhausted or ctx is done.
-func txBackoff(ctx context.Context, deadline time.Time, attempt int) bool {
-	remaining := time.Until(deadline)
-	if remaining <= 0 {
-		return false
-	}
-	// Full-jitter exponential backoff: base<<attempt capped at max, then a
-	// uniform random in (0, d]. Spreads retries so contending writers don't
-	// resynchronize into a thundering herd.
-	d := txRetryMaxBackoff
-	if attempt < 16 {
-		if s := txRetryBaseBackoff << uint(attempt); s > 0 && s < txRetryMaxBackoff {
-			d = s
-		}
-	}
-	if d > remaining {
-		d = remaining
-	}
-	wait := time.Duration(rand.Int64N(int64(d)) + 1)
-	timer := time.NewTimer(wait)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return false
-	case <-timer.C:
-		return true
-	}
-}
+// to the caller after a fixed handful of attempts. Only the already-classified
+// transient conflicts (sqlite BUSY/LOCKED) are retried; non-transient errors
+// return immediately. The deadline and jittered backoff are shared with the
+// postgres backend in internal/txretry.
 
 // ============================================================================
 // Transaction Support
@@ -106,12 +62,8 @@ func (s *SQLiteMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 	}
 
 	// Backpressure deadline (#1769): retry transient conflicts until this budget
-	// elapses rather than EIOing after a fixed attempt count. Honor an earlier
-	// caller deadline if the ctx carries one.
-	deadline := time.Now().Add(txRetryBudget)
-	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
-		deadline = d
-	}
+	// elapses rather than EIOing after a fixed attempt count.
+	deadline := txretry.Deadline(ctx)
 
 	var lastErr error
 	for attempt := 0; ; attempt++ {
@@ -123,7 +75,7 @@ func (s *SQLiteMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 		if err != nil {
 			if isBusyError(err) {
 				lastErr = err
-				if txBackoff(ctx, deadline, attempt) {
+				if txretry.Backoff(ctx, deadline, attempt) {
 					continue
 				}
 				break
@@ -142,7 +94,7 @@ func (s *SQLiteMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 			_ = rawTx.Rollback()
 			if isBusyError(err) {
 				lastErr = err
-				if txBackoff(ctx, deadline, attempt) {
+				if txretry.Backoff(ctx, deadline, attempt) {
 					continue
 				}
 				break
@@ -153,7 +105,7 @@ func (s *SQLiteMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 		if err := rawTx.Commit(); err != nil {
 			if isBusyError(err) {
 				lastErr = err
-				if txBackoff(ctx, deadline, attempt) {
+				if txretry.Backoff(ctx, deadline, attempt) {
 					continue
 				}
 				break


### PR DESCRIPTION
Final chunk of the #1776 metadata-store dedup cleanup.

## What

The sqlite and postgres backends each carried a **byte-identical** copy of:
- the `txBackoff` full-jitter exponential backoff helper,
- its three backoff constants (`txRetryBudget` / `txRetryBaseBackoff` / `txRetryMaxBackoff`),
- the identical backpressure-deadline computation (`now+budget`, tightened to an earlier ctx deadline).

This extracts them once into `pkg/metadata/store/internal/txretry` (`Deadline(ctx)` + `Backoff(ctx, deadline, attempt)`), mirroring the existing `internal/quota`, `internal/sqlcodec`, `internal/sqlstat` split.

## What is deliberately NOT changed

- Each backend keeps its **own retryable-error classification** (sqlite BUSY/LOCKED vs postgres 40001/40P01) and its own commit loop (`BeginTx` vs pooled `Begin` + connection-acquire timeout + relaxed `synchronous_commit`).
- **Badger is untouched.** Its loop is structurally different — closure-based `db.Update`, a fixed attempt count instead of a time budget, cache-invalidation on commit — so folding it into the shared helper would *change* its retry semantics for no dedup win. Left as-is.

Net: **no behavior change**, ~40 lines of duplication removed, one authoritative backoff.

## Tests

- New `internal/txretry` unit test: budget exhaustion, retry-within-budget wait bound, ctx-cancel stop, deadline tightening/default.
- `go build ./pkg/metadata/...`, `go vet`, sqlite + badger store conformance suites green locally. Postgres conformance runs in CI.

Closes the last item on #1776.