### PR TITLE
fix(adapter): preserve TCP listener across hot-reload when bind addr unchanged (#1810)

### DIFF
--- a/pkg/controlplane/runtime/adapters/service.go
+++ b/pkg/controlplane/runtime/adapters/service.go
@@ -124,10 +124,29 @@ func (s *Service) DeleteAdapter(ctx context.Context, adapterType string) error {
 	return nil
 }
 
-// UpdateAdapter updates the persisted config, then restarts the adapter.
+// UpdateAdapter updates the persisted config, then reloads the adapter.
+//
+// The reload preserves the running adapter — and with it the live TCP
+// listener and any in-flight connections — when the new config keeps the
+// same listen address (bind address + port) and the adapter stays enabled.
+// A stop/start is only performed when the listen address actually changes or
+// the enabled state flips; other configuration is applied by the live
+// settings reload path or on the next rebind. This keeps a config change
+// (e.g. re-enabling an already-running adapter) from momentarily dropping the
+// accept socket and cutting existing sessions.
 func (s *Service) UpdateAdapter(ctx context.Context, cfg *models.AdapterConfig) error {
 	if err := s.store.UpdateAdapter(ctx, cfg); err != nil {
 		return fmt.Errorf("failed to update adapter config: %w", err)
+	}
+
+	s.mu.RLock()
+	entry, running := s.entries[cfg.Type]
+	s.mu.RUnlock()
+
+	if running && cfg.Enabled && sameListenAddr(entry, cfg) {
+		logger.Info("Adapter listen address unchanged; preserving listener across reload",
+			"type", cfg.Type, "port", entry.adapter.Port())
+		return nil
 	}
 
 	_ = s.stopAdapter(cfg.Type)
@@ -138,6 +157,34 @@ func (s *Service) UpdateAdapter(ctx context.Context, cfg *models.AdapterConfig) 
 	}
 
 	return nil
+}
+
+// sameListenAddr reports whether cfg binds to the same address and port as the
+// already-running adapter, so a reload need not recreate the TCP listener.
+func sameListenAddr(entry *adapterEntry, cfg *models.AdapterConfig) bool {
+	if adapterBindAddress(entry.config) != adapterBindAddress(cfg) {
+		return false
+	}
+	// A zero port means "keep the adapter's default port", which the running
+	// adapter has already resolved, so treat it as unchanged.
+	if cfg.Port == 0 {
+		return true
+	}
+	return cfg.Port == entry.adapter.Port()
+}
+
+// adapterBindAddress returns the configured bind address, or "" when the
+// adapter binds all interfaces (the default).
+func adapterBindAddress(cfg *models.AdapterConfig) string {
+	if cfg == nil {
+		return ""
+	}
+	parsed, err := cfg.GetConfig()
+	if err != nil {
+		return ""
+	}
+	addr, _ := parsed["bind_address"].(string)
+	return addr
 }
 
 func (s *Service) EnableAdapter(ctx context.Context, adapterType string) error {

--- a/pkg/controlplane/runtime/adapters/service_test.go
+++ b/pkg/controlplane/runtime/adapters/service_test.go
@@ -1,0 +1,205 @@
+package adapters
+
+import (
+	"context"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/store"
+	"github.com/marmos91/dittofs/pkg/health"
+)
+
+// fakeAdapterStore is a minimal in-memory store.AdapterStore. Only the CRUD
+// methods the Service touches are implemented; the rest are never called and
+// would nil-panic via the embedded interface, which is the intent.
+type fakeAdapterStore struct {
+	store.AdapterStore
+	mu     sync.Mutex
+	byType map[string]*models.AdapterConfig
+}
+
+func newFakeAdapterStore() *fakeAdapterStore {
+	return &fakeAdapterStore{byType: make(map[string]*models.AdapterConfig)}
+}
+
+func (f *fakeAdapterStore) CreateAdapter(_ context.Context, a *models.AdapterConfig) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cp := *a
+	f.byType[a.Type] = &cp
+	return a.Type, nil
+}
+
+func (f *fakeAdapterStore) UpdateAdapter(_ context.Context, a *models.AdapterConfig) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cp := *a
+	f.byType[a.Type] = &cp
+	return nil
+}
+
+func (f *fakeAdapterStore) DeleteAdapter(_ context.Context, t string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.byType, t)
+	return nil
+}
+
+// fakeListenerAdapter binds a real loopback TCP listener in Serve so a test can
+// assert the socket (and its FD) survives a reload untouched.
+type fakeListenerAdapter struct {
+	protocol string
+	port     int
+
+	mu        sync.Mutex
+	ln        net.Listener
+	ready     chan struct{}
+	stopCount atomic.Int32
+}
+
+func newFakeListenerAdapter(protocol string, port int) *fakeListenerAdapter {
+	return &fakeListenerAdapter{protocol: protocol, port: port, ready: make(chan struct{})}
+}
+
+func (a *fakeListenerAdapter) Serve(ctx context.Context) error {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return err
+	}
+	a.mu.Lock()
+	a.ln = ln
+	a.mu.Unlock()
+	close(a.ready)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (a *fakeListenerAdapter) Stop(context.Context) error {
+	a.stopCount.Add(1)
+	a.mu.Lock()
+	ln := a.ln
+	a.mu.Unlock()
+	if ln != nil {
+		return ln.Close()
+	}
+	return nil
+}
+
+func (a *fakeListenerAdapter) Protocol() string                          { return a.protocol }
+func (a *fakeListenerAdapter) Port() int                                 { return a.port }
+func (a *fakeListenerAdapter) Healthcheck(context.Context) health.Report { return health.Report{} }
+
+func (a *fakeListenerAdapter) listener() net.Listener {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.ln
+}
+
+func listenerFD(t *testing.T, ln net.Listener) uintptr {
+	t.Helper()
+	raw, err := ln.(*net.TCPListener).SyscallConn()
+	if err != nil {
+		t.Fatalf("SyscallConn: %v", err)
+	}
+	var fd uintptr
+	if err := raw.Control(func(f uintptr) { fd = f }); err != nil {
+		t.Fatalf("Control: %v", err)
+	}
+	return fd
+}
+
+func waitReady(t *testing.T, a *fakeListenerAdapter) {
+	t.Helper()
+	select {
+	case <-a.ready:
+	case <-time.After(2 * time.Second):
+		t.Fatal("adapter did not start listening in time")
+	}
+}
+
+// TestUpdateAdapter_PreservesListenerWhenBindUnchanged proves that reloading an
+// adapter with an unchanged listen address keeps the exact same listener
+// socket (same FD) — the running adapter is never stopped — and that a real
+// listen-address change still rebinds.
+func TestUpdateAdapter_PreservesListenerWhenBindUnchanged(t *testing.T) {
+	const port = 14445
+
+	var created []*fakeListenerAdapter
+	var mu sync.Mutex
+
+	svc := New(newFakeAdapterStore(), time.Second)
+	svc.SetAdapterFactory(func(cfg *models.AdapterConfig) (ProtocolAdapter, error) {
+		a := newFakeListenerAdapter(cfg.Type, cfg.Port)
+		mu.Lock()
+		created = append(created, a)
+		mu.Unlock()
+		return a, nil
+	})
+
+	ctx := context.Background()
+	cfg := &models.AdapterConfig{Type: "smb", Enabled: true, Port: port}
+	if err := svc.CreateAdapter(ctx, cfg); err != nil {
+		t.Fatalf("CreateAdapter: %v", err)
+	}
+
+	mu.Lock()
+	first := created[0]
+	mu.Unlock()
+	waitReady(t, first)
+
+	fdBefore := listenerFD(t, first.listener())
+
+	// Reload with the same listen address: the listener must survive.
+	if err := svc.UpdateAdapter(ctx, &models.AdapterConfig{Type: "smb", Enabled: true, Port: port}); err != nil {
+		t.Fatalf("UpdateAdapter (unchanged): %v", err)
+	}
+
+	mu.Lock()
+	nCreated := len(created)
+	mu.Unlock()
+	if nCreated != 1 {
+		t.Fatalf("factory called again on unchanged reload: created %d adapters, want 1", nCreated)
+	}
+	if got := first.stopCount.Load(); got != 0 {
+		t.Fatalf("running adapter was stopped on unchanged reload: stopCount=%d, want 0", got)
+	}
+	if svc.GetAdapter("smb") != first {
+		t.Fatal("running adapter instance was swapped on unchanged reload")
+	}
+	if fdAfter := listenerFD(t, first.listener()); fdAfter != fdBefore {
+		t.Fatalf("listener FD changed across reload: before=%d after=%d", fdBefore, fdAfter)
+	}
+	// The socket is still live and accepting.
+	c, err := net.DialTimeout("tcp", first.listener().Addr().String(), time.Second)
+	if err != nil {
+		t.Fatalf("listener not accepting after reload: %v", err)
+	}
+	_ = c.Close()
+
+	// A genuine listen-address change must rebind: stop the old, start a new.
+	if err := svc.UpdateAdapter(ctx, &models.AdapterConfig{Type: "smb", Enabled: true, Port: port + 1}); err != nil {
+		t.Fatalf("UpdateAdapter (port change): %v", err)
+	}
+	if got := first.stopCount.Load(); got != 1 {
+		t.Fatalf("old adapter not stopped on port change: stopCount=%d, want 1", got)
+	}
+	mu.Lock()
+	nCreated = len(created)
+	second := created[len(created)-1]
+	mu.Unlock()
+	if nCreated != 2 {
+		t.Fatalf("port change did not rebind: created %d adapters, want 2", nCreated)
+	}
+	waitReady(t, second)
+	if svc.GetAdapter("smb") != second {
+		t.Fatal("port change did not swap to the new adapter instance")
+	}
+
+	if err := svc.StopAllAdapters(); err != nil {
+		t.Fatalf("StopAllAdapters: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #1810.

## Problem
`adapters.Service.UpdateAdapter` always did a full stop+start on reload, tearing down and recreating the adapter's TCP accept socket. A config change that does not move the listen address — for example re-enabling an already-running adapter, or any PUT /api/v1/adapters/{type} that leaves the port unchanged — briefly refused new connections (mount.cifs "Host is down") and dropped in-flight SMB sessions.

## Root cause
pkg/controlplane/runtime/adapters/service.go: UpdateAdapter unconditionally called stopAdapter (which cancels the Serve ctx, closing the listener in BaseAdapter.initiateShutdown) followed by startAdapter (which recreates the listener via net.Listen). The reload never checked whether the listen address actually changed.

## Fix
UpdateAdapter now preserves the running adapter — and with it the live listener and its connections — when the bind address and port are unchanged and the adapter stays enabled. It only performs a stop/start when the listen address actually changes or the enabled state flips. Other configuration continues to be applied through the existing live settings reload path (TLS certs hot-reload from disk, SMB settings via the SettingsWatcher). Scoped entirely to the shared reload path, no per-caller changes.

## Test
Added pkg/controlplane/runtime/adapters/service_test.go: a fake adapter binds a real loopback listener; the test asserts that an unchanged-bind reload keeps the exact same socket FD (adapter never stopped, factory not re-invoked, socket still accepting) and that a genuine port change still rebinds to a new adapter instance.

## Verification
- go build ./... and go build -tags integration ./...
- gofmt clean, go vet clean, golangci-lint 0 issues on the package
- go test -race ./pkg/controlplane/... : 662 passed