### PR TITLE
test(smb-conformance): raise replay/durable suite timeout on badger-fs profile (#1781)

### DIFF
--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -635,7 +635,21 @@ else
         else
             log_info "  Running: ${suite}"
         fi
-        run_smbtorture "$suite" 120 "$prefix" "${share:-}" || record_rc $?
+        # Durable-handle and replay suites drive many durable open/
+        # disconnect/reconnect cycles. On the badger-fs profile each of
+        # those persists/consumes a durable handle with a synchronous,
+        # non-coalescing fsync, so the cycles run far slower than on the
+        # memory backend and the default per-suite budget is too tight
+        # under the emulated CI runner (inflated per-fsync latency),
+        # timing the suite out mid-run. Give just those suites more head
+        # room on badger-fs; every other suite/profile keeps 120s.
+        suite_timeout=120
+        if [[ "$PROFILE" == "badger-fs" ]]; then
+            case "$suite" in
+                smb2.replay|smb2.durable-*) suite_timeout=300 ;;
+            esac
+        fi
+        run_smbtorture "$suite" "$suite_timeout" "$prefix" "${share:-}" || record_rc $?
     done
 
     # NOTE: Skipped interactive hold tests:


### PR DESCRIPTION
Fixes #1781.

## What
Raise the per-suite smbtorture timeout for `smb2.replay` and `smb2.durable-*` to **300s** on the **badger-fs** profile only. Every other suite and every other profile keeps the existing **120s**.

## Why (budget-vs-reality, not a code bug)
Investigated the flaky exit-124 on the badger-fs shard around `replay.dhv2`. It is **not a server deadlock**:

- Ran the durable/replay/reconnect/scavenger handler tests under `-race -count=30`: 2940 pass, no hang.
- Ran the badger durable-handle store tests under `-race -count=20`: 60 pass, no hang.
- Audited the durable-reconnect + badger serving path: the scavenger is a ticker loop with an in-flight guard, and `durablePurgeMu` is only ever held across a badger op and released promptly — no lock held across a blocking wait, no badger conflict livelock.

The real cause is throughput. `replay.dhv2` (and the durable-* suites) drive many durable open/disconnect/reconnect cycles. On badger each cycle persists and consumes a durable handle via `db.Update` with SyncWrites=true (forced for metadata crash-consistency), and those commits do not coalesce — so every cycle is 2 synchronous fsyncs. On the emulated CI runner (linux/amd64 via QEMU + Docker overlay fs) per-fsync latency is inflated 10-100x, so the suite overruns the 120s budget mid-run (exit 124). The scattered singleton casualties (twrp, timestamp_resolution, session.reauth5) are later suites killed when the shard exhausts its overall wall-clock — not distinct failures.

Code-level speedups (badger metadata group-commit / relaxed durability on the durable path) were already explored and refuted, and relaxing SyncWrites would break the crash-consistency guarantee. Giving the two slow suites more head room on the one slow backend is the correct, contained fix.

## Test
- `bash -n run.sh` parses clean.
- Verified the 300s bump applies only when `PROFILE=badger-fs` AND the suite is `smb2.replay` or `smb2.durable-*`; all other profile/suite combinations resolve to 120s.