### PR TITLE
feat(block): async log-only migration for uncompacted local-only pre-journal shares (#1801)

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -355,6 +355,26 @@ dittofs v0.21 or earlier (`dfs migrate-to-cas`, removed in later
 releases); the boot guard refuses `.blk` layouts with exit code 78. See
 [the migration guide](block-store-migration.md) for the full runbook.
 
+A share's pre-journal local cache (the `blobs/` + `logs/` on-disk layout
+from v0.26 and earlier) is also migrated automatically on first start:
+
+- **Remote-backed shares** re-materialize their bytes from the remote store
+  using the surviving metadata manifest — always safe.
+- **Local-only shares** (no remote) re-ingest their bytes from the append
+  logs in the background; reads that arrive mid-migration fault their file in
+  on demand, and the old on-disk data is deleted only once every file has
+  been re-ingested (a crash mid-migration simply resumes on the next start).
+
+  This only works when the append logs are complete. A local cache large
+  enough to have *compacted* its logs moved some bytes into the packed
+  `blobs/` substrate, and the index that located them (`local_chunk_index`)
+  is dropped by the metadata schema upgrade — so those bytes cannot be
+  recovered. When any log was compacted, the boot guard refuses to open the
+  share (exit code 78) and leaves every byte on disk untouched. Recover such
+  a share by restoring the metadata store from a **pre-upgrade backup** and
+  reading it with the matching older dittofs release, or by rebuilding the
+  share's contents from its authoritative source.
+
 ## Usage Questions
 
 ### Can I use this with Windows clients?

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -38,6 +38,15 @@ type FSStoreOptions struct {
 	// from the surviving metadata manifest via cold seeding. A local-only share
 	// must leave it false so the guardrail stays fatal.
 	MigrateLegacyLayout bool
+	// MigrateLegacyLocalOnly, when set, makes NewWithOptions attempt an async,
+	// non-blocking migration of a pre-journal blobs/+logs/ layout on a LOCAL-ONLY
+	// share (no remote): if the append logs are complete (none compacted) the
+	// dirs are archived aside, the journal opens clean, and the bytes are
+	// re-ingested from the logs in the background (with per-payload fault-in on
+	// read). If any log was compacted the guardrail stays fatal (its rolled-up
+	// bytes live only in unrecoverable blobs). Ignored when MigrateLegacyLayout
+	// is set (remote-backed shares take that path instead).
+	MigrateLegacyLocalOnly bool
 }
 
 // FSStore is the journal-backed local store. It embeds *journal.Store and
@@ -52,6 +61,9 @@ type FSStore struct {
 	fileChunkStore     block.EngineFileChunkStore
 	durable            atomic.Bool
 	migratedFromLegacy bool
+	// legacyMig drives an async local-only migration off the pre-journal layout;
+	// nil when there is nothing to migrate. ReadAt faults a payload in through it.
+	legacyMig *legacyMigration
 }
 
 // MigratedFromLegacy reports whether NewWithOptions archived a pre-journal
@@ -84,7 +96,9 @@ func NewWithOptions(dir string, maxDisk int64, fileChunkStore block.EngineFileCh
 	// from the remote via the surviving manifest; a local-only share fails loud
 	// so its on-disk bytes are not stranded behind an empty journal.
 	migrated := false
-	if opts.MigrateLegacyLayout {
+	var legacyMig *legacyMigration
+	switch {
+	case opts.MigrateLegacyLayout:
 		legacy, err := hasLegacyLocalLayout(dir)
 		if err != nil {
 			return nil, err
@@ -95,8 +109,18 @@ func NewWithOptions(dir string, maxDisk int64, fileChunkStore block.EngineFileCh
 			}
 			migrated = true
 		}
-	} else if err := checkLegacyLayout(dir); err != nil {
-		return nil, err
+	case opts.MigrateLegacyLocalOnly:
+		// Gate + archive before opening the journal: a refusal must leave no
+		// empty journal behind, and the journal is bound into the migration
+		// once it is open (below).
+		var err error
+		if legacyMig, err = setupLegacyLocalOnlyMigration(dir); err != nil {
+			return nil, err
+		}
+	default:
+		if err := checkLegacyLayout(dir); err != nil {
+			return nil, err
+		}
 	}
 	cfg := journal.Config{
 		MaxLocalBytes: maxDisk,
@@ -107,6 +131,9 @@ func NewWithOptions(dir string, maxDisk int64, fileChunkStore block.EngineFileCh
 	if err != nil {
 		return nil, err
 	}
+	if legacyMig != nil {
+		legacyMig.store = js
+	}
 	s := &FSStore{
 		Store:              js,
 		dir:                dir,
@@ -114,6 +141,7 @@ func NewWithOptions(dir string, maxDisk int64, fileChunkStore block.EngineFileCh
 		maxLogBytes:        opts.MaxLogBytes,
 		fileChunkStore:     fileChunkStore,
 		migratedFromLegacy: migrated,
+		legacyMig:          legacyMig,
 	}
 	s.durable.Store(true) // fs-local survives a restart
 	return s, nil
@@ -126,6 +154,15 @@ func (s *FSStore) WriteAt(ctx context.Context, payloadID string, offset int64, d
 }
 
 func (s *FSStore) ReadAt(ctx context.Context, payloadID string, offset int64, dst []byte) (int, bool, error) {
+	// During an async local-only migration a read may arrive before the payload
+	// has been drained from the archived legacy log; fault that one payload in
+	// first so the read never observes a zero-filled hole. A no-op once the
+	// migration is done or for any payload not under migration.
+	if s.legacyMig != nil {
+		if err := s.legacyMig.materialize(payloadID); err != nil {
+			return 0, false, err
+		}
+	}
 	return s.Store.ReadAt(ctx, journal.FileID(payloadID), offset, dst)
 }
 

--- a/pkg/block/local/fs/legacy_migrate.go
+++ b/pkg/block/local/fs/legacy_migrate.go
@@ -1,0 +1,200 @@
+package fs
+
+// Async, non-blocking migration of a pre-journal LOCAL-ONLY layout into the
+// journal. Opening the store archives the legacy dirs aside (readable, not the
+// terminal backup used by remote-backed shares) and returns immediately; the
+// bytes are re-ingested lazily:
+//
+//   - a background goroutine (driven by the shares service, which owns the
+//     engine needed for the final rollup) replays every archived log into the
+//     journal, then deletes the archived dirs;
+//   - a read that arrives before its payload has been drained faults that ONE
+//     payload in synchronously, so a read never observes zeros.
+//
+// Both paths funnel through the same per-payload sync.Once, so a read and the
+// background drain can race a payload without double-writing. The legacy bytes
+// stay on disk (under the archive) until the whole share is drained, so a crash
+// mid-migration re-runs cleanly on the next open (idempotent: replaying the same
+// records overwrites the same journal intervals).
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+
+	"github.com/marmos91/dittofs/pkg/block/journal"
+)
+
+// legacyMigration holds the state for draining one share's archived pre-journal
+// logs into its journal. Nil on FSStore when there is nothing to migrate.
+type legacyMigration struct {
+	store       *journal.Store
+	logsBackup  string            // <dir>/logs.pre-journal-backup
+	blobsBackup string            // <dir>/blobs.pre-journal-backup
+	payloads    map[string]string // payloadID -> archived log path (immutable after setup)
+	onces       sync.Map          // payloadID -> *legacyMigrateOnce
+	done        atomic.Bool
+}
+
+type legacyMigrateOnce struct {
+	once sync.Once
+	err  error
+}
+
+// dirHasEntries reports whether path is a directory holding at least one entry.
+// A missing directory reports false.
+func dirHasEntries(path string) bool {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false
+	}
+	return len(entries) > 0
+}
+
+// setupLegacyLocalOnlyMigration inspects dir for a pre-journal local-only
+// layout and, when it can be recovered from the append logs alone, archives it
+// aside and returns a ready-to-drain migration (with a nil store — the caller
+// binds the journal once it is open). It returns (nil, nil) when there is
+// nothing to migrate, and a wrapped ErrLegacyLocalFormat when a legacy layout
+// exists but is NOT safely recoverable (any compacted/torn log, or blob data
+// with no covering logs) — in that case nothing is moved, so the bytes stay on
+// disk for manual recovery.
+func setupLegacyLocalOnlyMigration(dir string) (*legacyMigration, error) {
+	logsBackup := filepath.Join(dir, "logs"+legacyBackupSuffix)
+	blobsBackup := filepath.Join(dir, "blobs"+legacyBackupSuffix)
+
+	// Resume a run that archived the dirs but crashed before finishing: the
+	// archive already passed the gate on the first open, so re-scan and drain.
+	if _, err := os.Stat(logsBackup); err == nil {
+		payloads, serr := scanLegacyPayloads(logsBackup)
+		if serr != nil {
+			return nil, serr
+		}
+		return &legacyMigration{logsBackup: logsBackup, blobsBackup: blobsBackup, payloads: payloads}, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+
+	// Fresh legacy layout?
+	legacy, err := hasLegacyLocalLayout(dir)
+	if err != nil {
+		return nil, err
+	}
+	if !legacy {
+		return nil, nil
+	}
+
+	logsDir := filepath.Join(dir, "logs")
+	blobsDir := filepath.Join(dir, "blobs")
+	// Blob data with no logs to cover it is rolled-up-and-compacted bytes whose
+	// only index is gone: unrecoverable. Refuse rather than serve zeros.
+	if dirHasEntries(blobsDir) && !dirHasEntries(logsDir) {
+		return nil, refuseLegacyLocalOnly(dir, "blob data has no covering append logs")
+	}
+	migratable, err := legacyLogsMigratable(logsDir)
+	if err != nil {
+		return nil, err
+	}
+	if !migratable {
+		return nil, refuseLegacyLocalOnly(dir, "an append log was compacted, so some bytes live only in unrecoverable blobs")
+	}
+
+	if err := archiveLegacyLayout(dir); err != nil {
+		return nil, err
+	}
+	payloads, err := scanLegacyPayloads(logsBackup)
+	if err != nil {
+		return nil, err
+	}
+	return &legacyMigration{logsBackup: logsBackup, blobsBackup: blobsBackup, payloads: payloads}, nil
+}
+
+// refuseLegacyLocalOnly builds the guardrail error that keeps the legacy bytes
+// on disk when a local-only layout cannot be safely auto-migrated.
+func refuseLegacyLocalOnly(dir, why string) error {
+	return fmt.Errorf("%w: %q holds pre-journal local-only data that cannot be auto-migrated (%s); "+
+		"the bytes are intact on disk — restore from a pre-upgrade backup or migrate manually", ErrLegacyLocalFormat, dir, why)
+}
+
+// materialize replays payloadID's archived log into the journal exactly once.
+// It is a no-op once the migration is done or for a payload with no archived
+// log. Reconstruction uses a background context so a caller's read deadline
+// cannot leave a payload half-drained.
+func (m *legacyMigration) materialize(payloadID string) error {
+	if m.done.Load() {
+		return nil
+	}
+	logPath, ok := m.payloads[payloadID]
+	if !ok {
+		return nil
+	}
+	oi, _ := m.onces.LoadOrStore(payloadID, &legacyMigrateOnce{})
+	mo := oi.(*legacyMigrateOnce)
+	mo.once.Do(func() {
+		ctx := context.Background()
+		fid := journal.FileID(payloadID)
+		mo.err = replayLegacyLog(logPath, func(off uint64, payload []byte) error {
+			return m.store.WriteAt(ctx, fid, int64(off), payload)
+		})
+		if mo.err == nil {
+			mo.err = m.store.Commit(ctx, fid)
+		}
+	})
+	return mo.err
+}
+
+// pendingPayloads returns every payloadID the migration must drain.
+func (m *legacyMigration) pendingPayloads() []string {
+	out := make([]string, 0, len(m.payloads))
+	for id := range m.payloads {
+		out = append(out, id)
+	}
+	return out
+}
+
+// finish marks the migration complete and deletes the archived legacy dirs.
+// Callers must have drained every payload first. done is set before removal so
+// concurrent reads stop faulting in.
+func (m *legacyMigration) finish() error {
+	m.done.Store(true)
+	if err := os.RemoveAll(m.logsBackup); err != nil {
+		return err
+	}
+	return os.RemoveAll(m.blobsBackup)
+}
+
+// --- FSStore surface used by the shares service to drive the drain ---
+
+// MigratedFromLegacyLocalOnly reports whether opening this store archived (or
+// resumed) a pre-journal local-only layout that a background drain must finish.
+func (s *FSStore) MigratedFromLegacyLocalOnly() bool { return s.legacyMig != nil }
+
+// LegacyPendingPayloads lists the payloads the background drain must materialize.
+func (s *FSStore) LegacyPendingPayloads() []string {
+	if s.legacyMig == nil {
+		return nil
+	}
+	return s.legacyMig.pendingPayloads()
+}
+
+// MaterializeLegacyPayload drains one payload's archived log into the journal.
+// Idempotent and safe to call from the background drain and a faulting read
+// concurrently.
+func (s *FSStore) MaterializeLegacyPayload(payloadID string) error {
+	if s.legacyMig == nil {
+		return nil
+	}
+	return s.legacyMig.materialize(payloadID)
+}
+
+// FinishLegacyMigration deletes the archived legacy dirs after a full drain.
+func (s *FSStore) FinishLegacyMigration() error {
+	if s.legacyMig == nil {
+		return nil
+	}
+	return s.legacyMig.finish()
+}

--- a/pkg/block/local/fs/legacy_migrate_test.go
+++ b/pkg/block/local/fs/legacy_migrate_test.go
@@ -1,0 +1,308 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"hash/crc32"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block/journal"
+)
+
+// legacyRec is one (file_offset, payload) append-log record for a fixture.
+type legacyRec struct {
+	off     uint64
+	payload []byte
+}
+
+// writeLegacyLog fabricates a real v0.26.0 append log at path: a 64-byte header
+// (with flags, so LogFlagCompacted can be set) followed by framed records in
+// the exact on-disk format the reader parses.
+func writeLegacyLog(t *testing.T, path string, flags uint32, recs []legacyRec) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tbl := crc32.MakeTable(crc32.Castagnoli)
+
+	var buf bytes.Buffer
+	hdr := make([]byte, legacyLogHeaderSize)
+	copy(hdr[0:4], legacyLogMagic[:])
+	binary.LittleEndian.PutUint32(hdr[4:8], legacyLogVersion)
+	binary.LittleEndian.PutUint64(hdr[8:16], legacyLogHeaderSize) // RollupOffset
+	binary.LittleEndian.PutUint32(hdr[16:20], flags)
+	binary.LittleEndian.PutUint32(hdr[28:32], crc32.Checksum(hdr[0:28], tbl))
+	buf.Write(hdr)
+
+	for _, r := range recs {
+		frame := make([]byte, legacyRecordFrameOverhead)
+		binary.LittleEndian.PutUint32(frame[0:4], uint32(len(r.payload)))
+		binary.LittleEndian.PutUint64(frame[4:12], r.off)
+		var offBuf [8]byte
+		binary.LittleEndian.PutUint64(offBuf[:], r.off)
+		c := crc32.Update(0, tbl, offBuf[:])
+		c = crc32.Update(c, tbl, r.payload)
+		binary.LittleEndian.PutUint32(frame[12:16], c)
+		buf.Write(frame)
+		buf.Write(r.payload)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// allZero reports whether b is entirely zero bytes.
+func allZero(b []byte) bool {
+	for _, x := range b {
+		if x != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// journalRead reads directly from the journal, bypassing the ReadAt fault-in,
+// so a test can observe what the journal holds independently of migration.
+func journalRead(t *testing.T, s *FSStore, payloadID string, size int) []byte {
+	t.Helper()
+	out := make([]byte, size)
+	if _, _, err := s.Store.ReadAt(context.Background(), journal.FileID(payloadID), 0, out); err != nil {
+		t.Fatalf("journal ReadAt(%s): %v", payloadID, err)
+	}
+	return out
+}
+
+// TestLegacyLocalOnly_MigratesFaultsInAndFinishes covers the whole async path:
+// open returns without materializing (non-blocking), a read faults its payload
+// in (never zeros), a background-style drain materializes the rest, the
+// archived legacy dirs are deleted, and a re-open is a clean idempotent open
+// that still serves the migrated bytes.
+func TestLegacyLocalOnly_MigratesFaultsInAndFinishes(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	// payload1: overlapping records prove last-write-wins ("hello world" then
+	// "HELLO" over the head => "HELLO world"), plus a gap+tail prove sparseness.
+	p1 := "share/file.bin"
+	writeLegacyLog(t, filepath.Join(dir, "logs", p1+".log"), 0, []legacyRec{
+		{off: 0, payload: []byte("hello world")},
+		{off: 0, payload: []byte("HELLO")},
+		{off: 32, payload: []byte("tail")},
+	})
+	want1 := make([]byte, 36)
+	copy(want1[0:], "HELLO world")
+	copy(want1[32:], "tail")
+
+	// payload2 is never read during migration; it is drained by the background
+	// loop and must still come back correct.
+	p2 := "share/nested/other.bin"
+	writeLegacyLog(t, filepath.Join(dir, "logs", p2+".log"), 0, []legacyRec{
+		{off: 0, payload: []byte("second payload contents")},
+	})
+	want2 := []byte("second payload contents")
+
+	// A non-empty (redundant) blobs/ dir must be ignored, not block migration.
+	writeFile(t, filepath.Join(dir, "blobs", "0000000000000000.blob"), 2048)
+
+	s, err := NewWithOptions(dir, 1<<30, nil, FSStoreOptions{MigrateLegacyLocalOnly: true})
+	if err != nil {
+		t.Fatalf("NewWithOptions(MigrateLegacyLocalOnly): %v", err)
+	}
+	if !s.MigratedFromLegacyLocalOnly() {
+		t.Fatal("MigratedFromLegacyLocalOnly = false, want true")
+	}
+
+	// Non-blocking proof: open returned with both payloads still pending and
+	// NOTHING written into the journal yet (a direct journal read is all zeros).
+	if got := len(s.LegacyPendingPayloads()); got != 2 {
+		t.Fatalf("LegacyPendingPayloads = %d, want 2 (open must not drain)", got)
+	}
+	if b := journalRead(t, s, p1, len(want1)); !allZero(b) {
+		t.Fatalf("journal already holds p1 bytes at open; migration was not deferred: %q", b)
+	}
+
+	// Fault-in: a read of p1 materializes just that payload and returns the real
+	// bytes (would be zeros before the fix).
+	got1 := make([]byte, len(want1))
+	n, cold, err := s.ReadAt(ctx, p1, 0, got1)
+	if err != nil {
+		t.Fatalf("ReadAt(p1): %v", err)
+	}
+	if cold {
+		t.Fatal("ReadAt(p1) reported cold on a local-only store")
+	}
+	if n < len(want1) || !bytes.Equal(got1, want1) {
+		t.Fatalf("ReadAt(p1) = %q (n=%d), want %q", got1, n, want1)
+	}
+	// p2 must still be untouched in the journal (fault-in is per-payload only).
+	if b := journalRead(t, s, p2, len(want2)); !allZero(b) {
+		t.Fatalf("reading p1 materialized p2 too; fault-in is not per-payload: %q", b)
+	}
+
+	// Background-style drain: materialize every pending payload, then finish.
+	for _, pid := range s.LegacyPendingPayloads() {
+		if err := s.MaterializeLegacyPayload(pid); err != nil {
+			t.Fatalf("MaterializeLegacyPayload(%s): %v", pid, err)
+		}
+	}
+	if b := journalRead(t, s, p2, len(want2)); !bytes.Equal(b, want2) {
+		t.Fatalf("after drain p2 = %q, want %q", b, want2)
+	}
+	if err := s.FinishLegacyMigration(); err != nil {
+		t.Fatalf("FinishLegacyMigration: %v", err)
+	}
+
+	// Archived legacy dirs are deleted after the drain.
+	for _, sub := range []string{"logs", "blobs"} {
+		if _, err := os.Stat(filepath.Join(dir, sub+legacyBackupSuffix)); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("archived %s%s still present after finish (err=%v)", sub, legacyBackupSuffix, err)
+		}
+	}
+	_ = s.Close()
+
+	// Idempotent re-open: no legacy layout remains, so it opens clean and still
+	// serves the migrated bytes from the journal.
+	s2, err := NewWithOptions(dir, 1<<30, nil, FSStoreOptions{MigrateLegacyLocalOnly: true})
+	if err != nil {
+		t.Fatalf("second NewWithOptions: %v", err)
+	}
+	defer func() { _ = s2.Close() }()
+	if s2.MigratedFromLegacyLocalOnly() {
+		t.Fatal("second open reports a migration; not idempotent")
+	}
+	if b := journalRead(t, s2, p1, len(want1)); !bytes.Equal(b, want1) {
+		t.Fatalf("after re-open p1 = %q, want %q", b, want1)
+	}
+}
+
+// TestLegacyLocalOnly_ConcurrentReadAndDrain runs many faulting reads against
+// the background drain for the same payload; the shared sync.Once must let
+// exactly one materialize win and every reader observe the real bytes. Run
+// under -race to exercise the fault-in/drain interleaving.
+func TestLegacyLocalOnly_ConcurrentReadAndDrain(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	pid := "share/race.bin"
+	writeLegacyLog(t, filepath.Join(dir, "logs", pid+".log"), 0, []legacyRec{
+		{off: 0, payload: bytes.Repeat([]byte("ABCD"), 4096)},
+	})
+	want := bytes.Repeat([]byte("ABCD"), 4096)
+
+	s, err := NewWithOptions(dir, 1<<30, nil, FSStoreOptions{MigrateLegacyLocalOnly: true})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	done := make(chan struct{})
+	go func() { // background drain
+		defer close(done)
+		for _, p := range s.LegacyPendingPayloads() {
+			_ = s.MaterializeLegacyPayload(p)
+		}
+	}()
+	errs := make(chan error, 8)
+	for i := 0; i < 8; i++ {
+		go func() {
+			got := make([]byte, len(want))
+			if _, _, rerr := s.ReadAt(ctx, pid, 0, got); rerr != nil {
+				errs <- rerr
+				return
+			}
+			if !bytes.Equal(got, want) {
+				errs <- errors.New("concurrent read returned wrong bytes")
+				return
+			}
+			errs <- nil
+		}()
+	}
+	for i := 0; i < 8; i++ {
+		if e := <-errs; e != nil {
+			t.Fatal(e)
+		}
+	}
+	<-done
+}
+
+// TestLegacyLocalOnly_RefusesCompacted proves the safety gate: a compacted log
+// means some bytes live only in the unrecoverable blobs, so the open refuses
+// (guardrail) and leaves every legacy byte on disk untouched.
+func TestLegacyLocalOnly_RefusesCompacted(t *testing.T) {
+	dir := t.TempDir()
+	writeLegacyLog(t, filepath.Join(dir, "logs", "share/f.log"), legacyLogFlagCompacted, []legacyRec{
+		{off: 0, payload: []byte("survivor")},
+	})
+	writeFile(t, filepath.Join(dir, "blobs", "0000000000000000.blob"), 1024)
+
+	_, err := NewWithOptions(dir, 1<<30, nil, FSStoreOptions{MigrateLegacyLocalOnly: true})
+	if !errors.Is(err, ErrLegacyLocalFormat) {
+		t.Fatalf("open over compacted legacy layout: got %v, want ErrLegacyLocalFormat", err)
+	}
+	// Nothing archived, nothing deleted — bytes preserved on disk.
+	for _, sub := range []string{"logs", "blobs"} {
+		if _, err := os.Stat(filepath.Join(dir, sub)); err != nil {
+			t.Fatalf("legacy %s/ was disturbed on refusal: %v", sub, err)
+		}
+		if _, err := os.Stat(filepath.Join(dir, sub+legacyBackupSuffix)); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("refusal created an archive for %s; it must not touch disk", sub)
+		}
+	}
+}
+
+// TestLegacyLocalOnly_ResumesAfterCrash proves crash-safety: a run that
+// archived the dirs but never finished resumes on the next open and still
+// serves the bytes; the legacy data is untouched until the drain completes.
+func TestLegacyLocalOnly_ResumesAfterCrash(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	pid := "share/resume.bin"
+	writeLegacyLog(t, filepath.Join(dir, "logs", pid+".log"), 0, []legacyRec{
+		{off: 0, payload: []byte("resume me")},
+	})
+	want := []byte("resume me")
+
+	// First open archives the dirs, then we "crash" (close) without finishing.
+	s1, err := NewWithOptions(dir, 1<<30, nil, FSStoreOptions{MigrateLegacyLocalOnly: true})
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	if !s1.MigratedFromLegacyLocalOnly() {
+		t.Fatal("first open did not start a migration")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "logs"+legacyBackupSuffix)); err != nil {
+		t.Fatalf("archive not created on first open: %v", err)
+	}
+	_ = s1.Close()
+
+	// Second open resumes from the archive.
+	s2, err := NewWithOptions(dir, 1<<30, nil, FSStoreOptions{MigrateLegacyLocalOnly: true})
+	if err != nil {
+		t.Fatalf("resume open: %v", err)
+	}
+	defer func() { _ = s2.Close() }()
+	if !s2.MigratedFromLegacyLocalOnly() {
+		t.Fatal("resume open did not detect the incomplete migration")
+	}
+	got := make([]byte, len(want))
+	if _, _, err := s2.ReadAt(ctx, pid, 0, got); err != nil {
+		t.Fatalf("resume ReadAt: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("resume ReadAt = %q, want %q", got, want)
+	}
+	for _, pid := range s2.LegacyPendingPayloads() {
+		if err := s2.MaterializeLegacyPayload(pid); err != nil {
+			t.Fatalf("resume materialize: %v", err)
+		}
+	}
+	if err := s2.FinishLegacyMigration(); err != nil {
+		t.Fatalf("resume finish: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "logs"+legacyBackupSuffix)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("archive not cleaned after resume finish: %v", err)
+	}
+}

--- a/pkg/block/local/fs/legacy_reader.go
+++ b/pkg/block/local/fs/legacy_reader.go
@@ -1,0 +1,240 @@
+package fs
+
+// Read-only reconstruction of a pre-journal ("v0.26.0") local-only layout.
+//
+// A pre-journal local store kept two on-disk kinds: per-payload append logs
+// (logs/<payloadID>.log) and packed content-addressed chunks (blobs/*.blob).
+// The journal cannot read either, so opening such a directory as an empty
+// journal would serve every file as zeros. For a REMOTE-backed share the
+// authoritative bytes live in the remote and are re-materialized from the
+// surviving manifest; for a LOCAL-ONLY share the on-disk bytes are the sole
+// copy, and only the append logs are recoverable — the blob substrate stored
+// bytes raw with no framing and was located solely through a hash->location
+// index that is gone (the index table is dropped on upgrade and the blobs are
+// unframed, so their contents cannot be resolved).
+//
+// This file therefore reconstructs LOCAL-ONLY payloads from the append logs
+// alone, gated on a proof that the logs are complete: a rollup that moved
+// records into blobs leaves the original records in the log until a compaction
+// pass rewrites the log and sets LogFlagCompacted in its header. So if NO log
+// is flagged compacted, every byte still lives in some log and the blobs are
+// redundant. Any compacted log means some bytes live only in the unrecoverable
+// blobs, and migration is refused (the guardrail keeps the bytes on disk).
+//
+// Everything here is READ-ONLY over the legacy bytes and self-contained (the
+// framing constants are vendored, not shared) so the whole file can be deleted
+// once the upgrade window closes.
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// legacyLogHeaderSize is the fixed append-log header length.
+	legacyLogHeaderSize = 64
+	// legacyRecordFrameOverhead is payload_len(4) + file_offset(8) + crc(4).
+	legacyRecordFrameOverhead = 16
+	// legacyLogVersion is the only append-log version ever written.
+	legacyLogVersion = uint32(1)
+	// legacyMaxRecordPayload clamps a per-record payload allocation so a torn
+	// or hostile frame cannot drive a multi-GiB allocation. Matches the writer's
+	// cap (chunker hard max 16 MiB + slack).
+	legacyMaxRecordPayload = 17 * 1024 * 1024
+	// legacyLogFlagCompacted marks a log whose rolled-up records were physically
+	// dropped by a compaction pass. Its presence means some bytes live only in
+	// the (unrecoverable) blob substrate.
+	legacyLogFlagCompacted uint32 = 1 << 0
+)
+
+// legacyLogMagic is the 4-byte append-log prefix 'DFLG'.
+var legacyLogMagic = [4]byte{'D', 'F', 'L', 'G'}
+
+// legacyCRCTable is the Castagnoli CRC32 table used for record and header CRCs.
+var legacyCRCTable = crc32.MakeTable(crc32.Castagnoli)
+
+// legacyLogState classifies a candidate .log file's 64-byte header.
+type legacyLogState int
+
+const (
+	legacyLogNotALog    legacyLogState = iota // bad magic: not one of our logs
+	legacyLogOK                               // valid header, not compacted
+	legacyLogCompacted                        // valid header with the compacted flag set
+	legacyLogUnreadable                       // our magic but a torn/invalid header
+)
+
+// classifyLegacyLog reads and validates a log's 64-byte header. It never reads
+// past the header, so it is cheap enough to run over every log during the gate.
+func classifyLegacyLog(path string) (legacyLogState, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return legacyLogNotALog, err
+	}
+	defer func() { _ = f.Close() }()
+
+	var hdr [legacyLogHeaderSize]byte
+	if _, err := io.ReadFull(f, hdr[:]); err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			// Shorter than a header: cannot be a valid log we wrote.
+			return legacyLogUnreadable, nil
+		}
+		return legacyLogNotALog, err
+	}
+	var magic [4]byte
+	copy(magic[:], hdr[0:4])
+	if magic != legacyLogMagic {
+		return legacyLogNotALog, nil
+	}
+	if binary.LittleEndian.Uint32(hdr[4:8]) != legacyLogVersion {
+		return legacyLogUnreadable, nil
+	}
+	wantCRC := binary.LittleEndian.Uint32(hdr[28:32])
+	if crc32.Checksum(hdr[0:28], legacyCRCTable) != wantCRC {
+		return legacyLogUnreadable, nil
+	}
+	flags := binary.LittleEndian.Uint32(hdr[16:20])
+	if flags&legacyLogFlagCompacted != 0 {
+		return legacyLogCompacted, nil
+	}
+	return legacyLogOK, nil
+}
+
+// legacyLogsMigratable walks logsDir and reports whether every real append log
+// is complete (uncompacted). A compacted or torn header means some bytes are
+// only in the unrecoverable blobs, so the share must not be auto-migrated.
+func legacyLogsMigratable(logsDir string) (bool, error) {
+	migratable := true
+	walkErr := filepath.WalkDir(logsDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".log") {
+			return nil
+		}
+		state, cerr := classifyLegacyLog(path)
+		if cerr != nil {
+			return cerr
+		}
+		if state == legacyLogCompacted || state == legacyLogUnreadable {
+			migratable = false
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return false, walkErr
+	}
+	return migratable, nil
+}
+
+// scanLegacyPayloads walks logsDir and returns a map of payloadID -> absolute
+// log path for every valid, uncompacted log. The payloadID is the log's path
+// relative to logsDir with the .log suffix removed (pre-journal payloadIDs are
+// path-keyed and may nest, e.g. logs/<share>/<file>.log), slash-normalized to
+// match the keyspace the journal and metadata use.
+func scanLegacyPayloads(logsDir string) (map[string]string, error) {
+	payloads := make(map[string]string)
+	walkErr := filepath.WalkDir(logsDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".log") {
+			return nil
+		}
+		state, cerr := classifyLegacyLog(path)
+		if cerr != nil {
+			return cerr
+		}
+		if state != legacyLogOK {
+			// legacyLogNotALog: stray file, skip. Compacted/unreadable can't
+			// happen here (the gate refused before we ever scan), but skip them
+			// defensively rather than reconstruct a partial payload.
+			return nil
+		}
+		rel, rerr := filepath.Rel(logsDir, path)
+		if rerr != nil {
+			return rerr
+		}
+		payloadID := filepath.ToSlash(strings.TrimSuffix(rel, ".log"))
+		payloads[payloadID] = path
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return payloads, nil
+}
+
+// replayLegacyLog reads logPath and calls emit(fileOffset, payload) for every
+// intact record in log order. Reconstruction is "replay in order": applying
+// records in arrival order reproduces last-write-wins (a later write at an
+// offset supersedes an earlier one) and never touches unwritten holes, exactly
+// as the writer intended. Reading stops at the first torn/short record or bad
+// CRC (a crash-truncated tail), mirroring the writer's own recovery.
+func replayLegacyLog(logPath string, emit func(fileOffset uint64, payload []byte) error) error {
+	f, err := os.Open(logPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := f.Seek(legacyLogHeaderSize, io.SeekStart); err != nil {
+		return fmt.Errorf("legacy log %q: seek past header: %w", logPath, err)
+	}
+	r := bufio.NewReader(f)
+	for {
+		off, payload, ok, rerr := readLegacyRecord(r)
+		if rerr != nil {
+			return fmt.Errorf("legacy log %q: %w", logPath, rerr)
+		}
+		if !ok {
+			return nil // clean EOF or crash-truncated tail
+		}
+		if err := emit(off, payload); err != nil {
+			return err
+		}
+	}
+}
+
+// readLegacyRecord reads one framed record: payload_len(u32 LE) |
+// file_offset(u64 LE) | crc(u32 LE) | payload. The CRC is Castagnoli over
+// (file_offset_8LE || payload). Returns ok=false (no error) on clean EOF, a
+// short/torn frame, an over-cap length, or a CRC mismatch — the caller treats
+// all of those as end-of-log. Returns an error only on a hard I/O failure.
+func readLegacyRecord(r io.Reader) (uint64, []byte, bool, error) {
+	var frame [legacyRecordFrameOverhead]byte
+	if _, err := io.ReadFull(r, frame[:]); err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return 0, nil, false, nil
+		}
+		return 0, nil, false, fmt.Errorf("read frame: %w", err)
+	}
+	payloadLen := binary.LittleEndian.Uint32(frame[0:4])
+	fileOffset := binary.LittleEndian.Uint64(frame[4:12])
+	wantCRC := binary.LittleEndian.Uint32(frame[12:16])
+	if payloadLen > legacyMaxRecordPayload {
+		return 0, nil, false, nil
+	}
+	payload := make([]byte, payloadLen)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return 0, nil, false, nil
+		}
+		return 0, nil, false, fmt.Errorf("read payload: %w", err)
+	}
+	var offBuf [8]byte
+	binary.LittleEndian.PutUint64(offBuf[:], fileOffset)
+	gotCRC := crc32.Update(0, legacyCRCTable, offBuf[:])
+	gotCRC = crc32.Update(gotCRC, legacyCRCTable, payload)
+	if gotCRC != wantCRC {
+		return 0, nil, false, nil
+	}
+	return fileOffset, payload, true, nil
+}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1002,6 +1002,17 @@ func mergeLocalStoreDefaults(defaults *LocalStoreDefaults, config *ShareConfig, 
 	return &merged
 }
 
+// legacyLocalOnlyMigrator is the local-store surface the shares service drives
+// to finish an async pre-journal local-only migration in the background.
+// Implemented by the journal-backed fs store; other backends never satisfy it,
+// so the drive block is a no-op for them.
+type legacyLocalOnlyMigrator interface {
+	MigratedFromLegacyLocalOnly() bool
+	LegacyPendingPayloads() []string
+	MaterializeLegacyPayload(payloadID string) error
+	FinishLegacyMigration() error
+}
+
 // createBlockStoreForShare creates and starts a per-share BlockStore.
 func (s *Service) createBlockStoreForShare(
 	ctx context.Context,
@@ -1190,6 +1201,42 @@ func (s *Service) createBlockStoreForShare(
 			logger.Warn("migrated pre-journal local layout but metadata store is not manifest-capable; reads will zero-fill until rewritten",
 				"share", config.Name)
 		}
+	}
+
+	// A local-only share (no remote to re-fetch from) that carried a complete
+	// pre-journal layout re-ingests its bytes from the surviving append logs in
+	// the BACKGROUND — AddShare must not block on O(total-bytes) work. Reads that
+	// arrive before a payload is drained fault it in per-payload (never zero-
+	// fill). When every payload is drained the archived legacy dirs are deleted;
+	// a crash before then leaves them on disk and the next open resumes. The
+	// final rollup is done here (outside any metadata txn — the coordinator is
+	// non-reentrant), never from inside a read.
+	if m, ok := localStore.(legacyLocalOnlyMigrator); ok && m.MigratedFromLegacyLocalOnly() {
+		shareName := config.Name
+		go func() {
+			// Detached from the AddShare context, which may be cancelled once the
+			// call returns; the store's own close gate stops the drain on shutdown.
+			bgCtx := context.Background()
+			for _, payloadID := range m.LegacyPendingPayloads() {
+				if err := m.MaterializeLegacyPayload(payloadID); err != nil {
+					logger.Error("legacy local-only migration: materialize failed; leaving archive for retry on next start",
+						"share", shareName, "payload", payloadID, "error", err)
+					return
+				}
+			}
+			if err := bs.DrainRollups(bgCtx); err != nil {
+				logger.Error("legacy local-only migration: rollup drain failed; leaving archive for retry on next start",
+					"share", shareName, "error", err)
+				return
+			}
+			if err := m.FinishLegacyMigration(); err != nil {
+				logger.Error("legacy local-only migration: cleanup of archived legacy dirs failed",
+					"share", shareName, "error", err)
+				return
+			}
+			logger.Info("migrated pre-journal local-only layout: re-ingested bytes from append logs and removed the archive",
+				"share", shareName)
+		}()
 	}
 
 	// Thread the inline metrics recorder into the new store's eviction/
@@ -2889,9 +2936,12 @@ func CreateLocalStoreFromConfig(
 	fsOpts.BackpressureMaxWait = backpressureMaxWait
 	// A remote-backed share may carry a pre-journal blobs/+logs/ layout from an
 	// upgrade; archive it aside so the journal opens clean (the caller then cold-
-	// seeds from the surviving manifest). Local-only shares keep migrateLegacy
-	// false so the guardrail stays fatal.
+	// seeds from the surviving manifest). A local-only share has no remote to
+	// re-fetch from, so it takes the async log-only migration path instead: the
+	// bytes are re-ingested from the surviving append logs when they are complete
+	// (no compacted log), and the guardrail stays fatal otherwise.
 	fsOpts.MigrateLegacyLayout = migrateLegacy
+	fsOpts.MigrateLegacyLocalOnly = !migrateLegacy
 	// Local-cache size-hint default. Precedence (lowest first):
 	// FSStore internal default < global/deduced default (plumbed via
 	// LocalStoreDefaults.MaxLogBytes) < per-store config["max_log_bytes"].


### PR DESCRIPTION
## What

Residual of #1801: migrate a **local-only** pre-journal share (the `blobs/` + `logs/` on-disk layout from v0.26 and earlier) into the journal, instead of leaving it stuck behind the #1802 fatal guardrail.

Remote-backed shares (#1803) already migrate by cold-seeding from the surviving manifest against S3. A local-only share has no remote to re-fetch from — the on-disk bytes are the sole copy.

## The format reality (why this is partial coverage)

- `logs/<payloadID>.log` — per-payload append logs, framed `len | file_offset | crc32c | payload`. Replayable read-only.
- `blobs/*.blob` — the log-blob substrate stores chunk bytes **raw, no framing**. A chunk was locatable only via `LocalChunkLocation{LogBlobID, RawOffset, RawLength}` held in the metadata `local_chunk_index` table.
- On develop that table is **dropped** by the metadata upgrade (`000006/000039_drop_local_bookkeeping`), the `logblob` package and `LocalChunkIndex` type are deleted, and the surviving `block.FileChunk` manifest carries hash+size but **not** the blob offset. So blob-resident bytes are unrecoverable, and resurrecting a hash to location side-map was already rejected in #1718.

Therefore this migrates from the **append logs alone**. That is complete unless a log was **compacted**: rollup copies records into `blobs/` but leaves them in the log until a compaction pass rewrites the log and sets `LogFlagCompacted`. So if no log is flagged compacted, every byte is still in some log and `blobs/` is redundant.

## Design

**Gate** (never silent data loss): a local-only legacy share is migratable iff no `logs/*.log` header has `LogFlagCompacted` set (and there is no blob data without covering logs). Any compacted/torn log → the guardrail stays fatal (exit 78), bytes untouched on disk.

**Async / non-blocking** (hard invariant): `NewWithOptions` gates + archives the dirs aside and returns immediately — no O(total-bytes) work on the open path. Re-ingest is lazy:
- a background goroutine (driven by the shares service, which owns the engine) replays each archived log into the journal via `WriteAt` (the journal handles last-write-wins and sparseness), runs the final `DrainRollups`, then deletes the archive;
- a read that arrives before its payload is drained faults that **one** payload in synchronously, so a read never observes zeros.

Both paths funnel through the same per-payload `sync.Once`. Materialize/fault-in go through the **local store directly**, never engine `Flush`/`DrainRollups` from inside `ReadAt` — those take `closeMu.RLock` and re-entering it from a read risks the Go RWMutex writer-starvation deadlock.

**Completion / crash-safety**: the archive is deleted only after a full drain; a crash mid-migration leaves the archive on disk and the next open resumes from it (re-ingest is idempotent — replaying the same records overwrites the same journal intervals). A second clean start finds no legacy dir and opens normally.

The reader (`legacy_reader.go`, ~230 LOC incl. the migration driver in `legacy_migrate.go`) vendors only the record framing + header parse, is read-only over the legacy bytes, and is isolated so the whole thing can be deleted once the upgrade window closes.

## Coverage (stated honestly)

Uncompacted local-only shares only. Compacted local-only shares cannot be auto-migrated (blob bytes unrecoverable — dropped index, #1718 rejected the side-map); they refuse to open and must be recovered from a pre-upgrade metadata backup. Documented in `docs/guide/faq.md`.

## Tests

`pkg/block/local/fs/legacy_migrate_test.go` (fabricates real v0.26 log framing):
- migrate + fault-in + finish: open returns with payloads still pending and the journal untouched (non-blocking proof via a direct journal read that shows zeros); a read faults its payload in and returns the real bytes (last-write-wins + sparse gap verified); a background-style drain materializes the rest; the archive is deleted; idempotent re-open still serves the bytes.
- concurrent readers racing the drain (under -race).
- compacted layout → open refuses with `ErrLegacyLocalFormat`, nothing archived/deleted.
- crash mid-migration → next open resumes from the archive and serves the bytes.

Verification: `go build ./...` + `-tags integration`; `gofmt -l` clean; `go vet` clean; `golangci-lint` 0 issues; `go test -race ./pkg/block/local/fs/` 14 pass; `go test ./pkg/controlplane/runtime/shares/ ./pkg/block/engine/` 364 pass.

References #1801.
