### PR TITLE
fix(adapter): resolve Port=0 to default before the unchanged-listener check (#1810 follow-up)

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -722,7 +722,7 @@ func createAdapterFactory(kerberosConfig *config.KerberosConfig, nlAuth *netlogo
 func createNFSAdapter(cfg *models.AdapterConfig, kerberosConfig *config.KerberosConfig) (runtime.ProtocolAdapter, error) {
 	port := cfg.Port
 	if port == 0 {
-		port = 12049
+		port = models.DefaultNFSPort
 	}
 
 	nfsCfg := nfs.NFSConfig{Enabled: true, Port: port}
@@ -759,7 +759,7 @@ func createNFSAdapter(cfg *models.AdapterConfig, kerberosConfig *config.Kerberos
 func createSMBAdapter(cfg *models.AdapterConfig, kerberosConfig *config.KerberosConfig, nlAuth *netlogon.Authenticator) (runtime.ProtocolAdapter, error) {
 	port := cfg.Port
 	if port == 0 {
-		port = 12445
+		port = models.DefaultSMBPort
 	}
 
 	smbCfg := smb.Config{Enabled: true, Port: port}

--- a/cmd/dfsctl/commands/share/mount.go
+++ b/cmd/dfsctl/commands/share/mount.go
@@ -10,12 +10,15 @@ import (
 	"github.com/marmos91/dittofs/internal/cli/credentials"
 	"github.com/marmos91/dittofs/internal/cli/prompt"
 	"github.com/marmos91/dittofs/pkg/apiclient"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/spf13/cobra"
 )
 
+// Default ports the client mounts when the server reports no explicit port.
+// Aliased to the server-side defaults so the value has a single source.
 const (
-	defaultNFSPort = 12049
-	defaultSMBPort = 12445
+	defaultNFSPort = models.DefaultNFSPort
+	defaultSMBPort = models.DefaultSMBPort
 )
 
 var (

--- a/pkg/controlplane/models/adapter.go
+++ b/pkg/controlplane/models/adapter.go
@@ -19,6 +19,28 @@ type AdapterConfig struct {
 	ParsedConfig map[string]any `gorm:"-" json:"config,omitempty"`
 }
 
+// Default ports an adapter binds to when its configured port is 0. The adapter
+// factory and the unchanged-listener check both resolve a zero port through
+// these, so a reload compares resolved-against-resolved rather than a sentinel
+// against a concrete port — keeping this the single source of truth.
+const (
+	DefaultNFSPort = 12049
+	DefaultSMBPort = 12445
+)
+
+// DefaultPort returns the port an adapter of the given type binds to when its
+// configured port is 0, or 0 when the type has no known default.
+func DefaultPort(adapterType string) int {
+	switch adapterType {
+	case "nfs":
+		return DefaultNFSPort
+	case "smb":
+		return DefaultSMBPort
+	default:
+		return 0
+	}
+}
+
 // TableName returns the table name for AdapterConfig.
 func (AdapterConfig) TableName() string {
 	return "adapters"

--- a/pkg/controlplane/runtime/adapters/service.go
+++ b/pkg/controlplane/runtime/adapters/service.go
@@ -159,15 +159,6 @@ func (s *Service) UpdateAdapter(ctx context.Context, cfg *models.AdapterConfig) 
 	return nil
 }
 
-// Default ports an adapter binds to when its configured port is 0. They mirror
-// the ports the adapter factory substitutes for a zero port when it constructs
-// the adapter, so the unchanged-listener check compares resolved against
-// resolved rather than a sentinel against a concrete port.
-const (
-	defaultNFSPort = 12049
-	defaultSMBPort = 12445
-)
-
 // resolvePort returns the port an adapter of the given type binds to, treating
 // a zero port as "use the type's default" — the same substitution the factory
 // applies when it constructs the adapter. Types without a known default keep
@@ -176,14 +167,10 @@ func resolvePort(adapterType string, port int) int {
 	if port != 0 {
 		return port
 	}
-	switch adapterType {
-	case "nfs":
-		return defaultNFSPort
-	case "smb":
-		return defaultSMBPort
-	default:
-		return port
+	if def := models.DefaultPort(adapterType); def != 0 {
+		return def
 	}
+	return port
 }
 
 // sameListenAddr reports whether cfg binds to the same address and port as the

--- a/pkg/controlplane/runtime/adapters/service.go
+++ b/pkg/controlplane/runtime/adapters/service.go
@@ -159,18 +159,43 @@ func (s *Service) UpdateAdapter(ctx context.Context, cfg *models.AdapterConfig) 
 	return nil
 }
 
+// Default ports an adapter binds to when its configured port is 0. They mirror
+// the ports the adapter factory substitutes for a zero port when it constructs
+// the adapter, so the unchanged-listener check compares resolved against
+// resolved rather than a sentinel against a concrete port.
+const (
+	defaultNFSPort = 12049
+	defaultSMBPort = 12445
+)
+
+// resolvePort returns the port an adapter of the given type binds to, treating
+// a zero port as "use the type's default" — the same substitution the factory
+// applies when it constructs the adapter. Types without a known default keep
+// the raw port unchanged.
+func resolvePort(adapterType string, port int) int {
+	if port != 0 {
+		return port
+	}
+	switch adapterType {
+	case "nfs":
+		return defaultNFSPort
+	case "smb":
+		return defaultSMBPort
+	default:
+		return port
+	}
+}
+
 // sameListenAddr reports whether cfg binds to the same address and port as the
-// already-running adapter, so a reload need not recreate the TCP listener.
+// already-running adapter, so a reload need not recreate the TCP listener. A
+// zero port is resolved to its default first, so re-pointing a non-default-port
+// adapter at the default (port 0) is correctly seen as a change and rebinds,
+// keeping the running listener and the persisted config in agreement.
 func sameListenAddr(entry *adapterEntry, cfg *models.AdapterConfig) bool {
 	if adapterBindAddress(entry.config) != adapterBindAddress(cfg) {
 		return false
 	}
-	// A zero port means "keep the adapter's default port", which the running
-	// adapter has already resolved, so treat it as unchanged.
-	if cfg.Port == 0 {
-		return true
-	}
-	return cfg.Port == entry.adapter.Port()
+	return resolvePort(cfg.Type, cfg.Port) == entry.adapter.Port()
 }
 
 // adapterBindAddress returns the configured bind address, or "" when the

--- a/pkg/controlplane/runtime/adapters/service_test.go
+++ b/pkg/controlplane/runtime/adapters/service_test.go
@@ -255,8 +255,8 @@ func TestUpdateAdapter_ZeroPortRebindsFromNonDefault(t *testing.T) {
 	if svc.GetAdapter("smb") != second {
 		t.Fatal("rebind did not swap to the new adapter instance")
 	}
-	if got := second.Port(); got != defaultSMBPort {
-		t.Fatalf("rebound adapter bound to wrong port: got %d, want default %d", got, defaultSMBPort)
+	if got := second.Port(); got != models.DefaultSMBPort {
+		t.Fatalf("rebound adapter bound to wrong port: got %d, want default %d", got, models.DefaultSMBPort)
 	}
 
 	if err := svc.StopAllAdapters(); err != nil {

--- a/pkg/controlplane/runtime/adapters/service_test.go
+++ b/pkg/controlplane/runtime/adapters/service_test.go
@@ -203,3 +203,63 @@ func TestUpdateAdapter_PreservesListenerWhenBindUnchanged(t *testing.T) {
 		t.Fatalf("StopAllAdapters: %v", err)
 	}
 }
+
+// TestUpdateAdapter_ZeroPortRebindsFromNonDefault proves that updating an
+// adapter bound to a non-default port with an explicit port 0 ("use the
+// default") rebinds to the default port instead of silently preserving the old
+// listener — which would leave the running port and the persisted (port 0)
+// config out of sync.
+func TestUpdateAdapter_ZeroPortRebindsFromNonDefault(t *testing.T) {
+	const nonDefaultPort = 14445
+
+	var created []*fakeListenerAdapter
+	var mu sync.Mutex
+
+	svc := New(newFakeAdapterStore(), time.Second)
+	// Mirror the real factory: a zero port resolves to the type's default.
+	svc.SetAdapterFactory(func(cfg *models.AdapterConfig) (ProtocolAdapter, error) {
+		a := newFakeListenerAdapter(cfg.Type, resolvePort(cfg.Type, cfg.Port))
+		mu.Lock()
+		created = append(created, a)
+		mu.Unlock()
+		return a, nil
+	})
+
+	ctx := context.Background()
+	if err := svc.CreateAdapter(ctx, &models.AdapterConfig{Type: "smb", Enabled: true, Port: nonDefaultPort}); err != nil {
+		t.Fatalf("CreateAdapter: %v", err)
+	}
+
+	mu.Lock()
+	first := created[0]
+	mu.Unlock()
+	waitReady(t, first)
+
+	// Update with an explicit port 0: resolves to the SMB default, so the
+	// listen address changes and the adapter must rebind.
+	if err := svc.UpdateAdapter(ctx, &models.AdapterConfig{Type: "smb", Enabled: true, Port: 0}); err != nil {
+		t.Fatalf("UpdateAdapter (port 0): %v", err)
+	}
+
+	if got := first.stopCount.Load(); got != 1 {
+		t.Fatalf("old adapter not stopped on rebind to default: stopCount=%d, want 1", got)
+	}
+	mu.Lock()
+	nCreated := len(created)
+	second := created[len(created)-1]
+	mu.Unlock()
+	if nCreated != 2 {
+		t.Fatalf("port 0 did not rebind: created %d adapters, want 2", nCreated)
+	}
+	waitReady(t, second)
+	if svc.GetAdapter("smb") != second {
+		t.Fatal("rebind did not swap to the new adapter instance")
+	}
+	if got := second.Port(); got != defaultSMBPort {
+		t.Fatalf("rebound adapter bound to wrong port: got %d, want default %d", got, defaultSMBPort)
+	}
+
+	if err := svc.StopAllAdapters(); err != nil {
+		t.Fatalf("StopAllAdapters: %v", err)
+	}
+}


### PR DESCRIPTION
Follow-up to #1810, addressing a Copilot review finding on the listener-preserve change.

## The bug

The listener-preserve reload in #1810 added sameListenAddr so a config reload skips tearing down the TCP listener when the bind address is unchanged. Port 0 is a valid API sentinel meaning "use the adapter's default port": UpdateAdapterRequest.Port is a *int, and createNFSAdapter / createSMBAdapter resolve Port==0 to a concrete default (12049 / 12445).

sameListenAddr treated an explicit Port=0 as always unchanged:

    if cfg.Port == 0 {
        return true
    }

So updating an adapter currently bound to a NON-default port with Port=0 preserved the old listener while persisting port 0. The running listener stayed on the old non-default port, but ListPorts / Get then reported 0 — runtime and persisted config out of sync.

## The fix

Resolve Port==0 to the same concrete default the factory uses BEFORE the unchanged comparison, and compare the resolved port against the running listener's actual port (entry.adapter.Port()). Re-pointing a non-default-port adapter at the default (port 0) is now correctly seen as a change and rebinds, so runtime and persisted config stay consistent. The unchanged-bind fast path (same FD) and explicit-port-change rebind behaviour are unchanged.

## Test

Added TestUpdateAdapter_ZeroPortRebindsFromNonDefault: a running adapter on a non-default port updated with Port=0 stops the old adapter, starts a new one, and ends bound to the default port. Existing preserve/rebind tests still pass.

## Verification

- go build ./... clean
- gofmt -l clean, go vet clean
- golangci-lint run clean on the package
- go test -race ./pkg/controlplane/runtime/adapters/ passes