### PR TITLE
fix(block): materialize legacy payload before writes/deletes/truncates during local-only migration

### DIFF
--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -153,7 +153,7 @@ func NewWithOptions(dir string, maxDisk int64, fileChunkStore block.EngineFileCh
 // before an access touches it, so the access observes (and, for a mutation,
 // lands after) the replayed legacy bytes rather than racing them: a later
 // background drain replays the SAME records idempotently and cannot clobber a
-// client write, resurrect a deleted/truncated payload, or serve a read zeros.
+// client write, resurrect a deleted/truncated payload, or serve zeros to a read.
 // A no-op once the migration is done, for any payload not under migration, or
 // when no migration is in flight.
 func (s *FSStore) materializeLegacy(payloadID string) error {

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -149,19 +149,30 @@ func NewWithOptions(dir string, maxDisk int64, fileChunkStore block.EngineFileCh
 
 // --- string↔FileID data-plane shims (shadow the embedded FileID methods) ---
 
+// materializeLegacy drains payloadID's archived pre-journal log into the journal
+// before an access touches it, so the access observes (and, for a mutation,
+// lands after) the replayed legacy bytes rather than racing them: a later
+// background drain replays the SAME records idempotently and cannot clobber a
+// client write, resurrect a deleted/truncated payload, or serve a read zeros.
+// A no-op once the migration is done, for any payload not under migration, or
+// when no migration is in flight.
+func (s *FSStore) materializeLegacy(payloadID string) error {
+	if s.legacyMig == nil {
+		return nil
+	}
+	return s.legacyMig.materialize(payloadID)
+}
+
 func (s *FSStore) WriteAt(ctx context.Context, payloadID string, offset int64, data []byte) error {
+	if err := s.materializeLegacy(payloadID); err != nil {
+		return err
+	}
 	return s.Store.WriteAt(ctx, journal.FileID(payloadID), offset, data)
 }
 
 func (s *FSStore) ReadAt(ctx context.Context, payloadID string, offset int64, dst []byte) (int, bool, error) {
-	// During an async local-only migration a read may arrive before the payload
-	// has been drained from the archived legacy log; fault that one payload in
-	// first so the read never observes a zero-filled hole. A no-op once the
-	// migration is done or for any payload not under migration.
-	if s.legacyMig != nil {
-		if err := s.legacyMig.materialize(payloadID); err != nil {
-			return 0, false, err
-		}
+	if err := s.materializeLegacy(payloadID); err != nil {
+		return 0, false, err
 	}
 	return s.Store.ReadAt(ctx, journal.FileID(payloadID), offset, dst)
 }
@@ -175,10 +186,16 @@ func (s *FSStore) Commit(ctx context.Context, payloadID string) error {
 }
 
 func (s *FSStore) Delete(ctx context.Context, payloadID string) error {
+	if err := s.materializeLegacy(payloadID); err != nil {
+		return err
+	}
 	return s.Store.Delete(ctx, journal.FileID(payloadID))
 }
 
 func (s *FSStore) Truncate(ctx context.Context, payloadID string, newSize int64) error {
+	if err := s.materializeLegacy(payloadID); err != nil {
+		return err
+	}
 	return s.Store.Truncate(ctx, journal.FileID(payloadID), newSize)
 }
 

--- a/pkg/block/local/fs/legacy_migrate.go
+++ b/pkg/block/local/fs/legacy_migrate.go
@@ -95,12 +95,12 @@ func setupLegacyLocalOnlyMigration(dir string) (*legacyMigration, error) {
 	if dirHasEntries(blobsDir) && !dirHasEntries(logsDir) {
 		return nil, refuseLegacyLocalOnly(dir, "blob data has no covering append logs")
 	}
-	migratable, err := legacyLogsMigratable(logsDir)
+	reason, badLog, err := firstUnmigratableLog(logsDir)
 	if err != nil {
 		return nil, err
 	}
-	if !migratable {
-		return nil, refuseLegacyLocalOnly(dir, "an append log was compacted, so some bytes live only in unrecoverable blobs")
+	if reason != "" {
+		return nil, refuseLegacyLocalOnly(dir, fmt.Sprintf("%s: %q", reason, badLog))
 	}
 
 	if err := archiveLegacyLayout(dir); err != nil {

--- a/pkg/block/local/fs/legacy_migrate_test.go
+++ b/pkg/block/local/fs/legacy_migrate_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"hash/crc32"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -226,6 +227,125 @@ func TestLegacyLocalOnly_ConcurrentReadAndDrain(t *testing.T) {
 		}
 	}
 	<-done
+}
+
+// TestLegacyLocalOnly_MutationBeforeMaterializeWins proves the write path
+// materializes the archived legacy log BEFORE applying a client mutation, so a
+// later background drain (replaying the same records) cannot clobber the newer
+// mutation. Each sub-case mutates a payload while it is still pending, then runs
+// the drain and asserts the mutation — not the legacy bytes — is what survives.
+func TestLegacyLocalOnly_MutationBeforeMaterializeWins(t *testing.T) {
+	ctx := context.Background()
+
+	// drain runs every still-pending payload through the background path; after a
+	// mutation already fired the shared sync.Once, this must be an idempotent
+	// no-op that leaves the mutation final.
+	drain := func(t *testing.T, s *FSStore) {
+		t.Helper()
+		for _, pid := range s.LegacyPendingPayloads() {
+			if err := s.MaterializeLegacyPayload(pid); err != nil {
+				t.Fatalf("drain MaterializeLegacyPayload(%s): %v", pid, err)
+			}
+		}
+	}
+
+	t.Run("write", func(t *testing.T) {
+		dir := t.TempDir()
+		pid := "share/w.bin"
+		writeLegacyLog(t, filepath.Join(dir, "logs", pid+".log"), 0, []legacyRec{
+			{off: 0, payload: []byte("AAAAAAAAAAAA")},
+		})
+		s, err := NewWithOptions(dir, 1<<30, nil, FSStoreOptions{MigrateLegacyLocalOnly: true})
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		defer func() { _ = s.Close() }()
+
+		// Client writes over the head while the legacy log is still pending.
+		if err := s.WriteAt(ctx, pid, 0, []byte("NEW")); err != nil {
+			t.Fatalf("WriteAt: %v", err)
+		}
+		drain(t, s)
+
+		want := []byte("NEWAAAAAAAAA")
+		if b := journalRead(t, s, pid, len(want)); !bytes.Equal(b, want) {
+			t.Fatalf("legacy replay clobbered the client write: got %q, want %q", b, want)
+		}
+	})
+
+	t.Run("truncate", func(t *testing.T) {
+		dir := t.TempDir()
+		pid := "share/t.bin"
+		writeLegacyLog(t, filepath.Join(dir, "logs", pid+".log"), 0, []legacyRec{
+			{off: 0, payload: []byte("head")},
+			{off: 32, payload: []byte("tail")},
+		})
+		s, err := NewWithOptions(dir, 1<<30, nil, FSStoreOptions{MigrateLegacyLocalOnly: true})
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		defer func() { _ = s.Close() }()
+
+		// Truncate away the tail before the legacy log is drained.
+		if err := s.Truncate(ctx, pid, 4); err != nil {
+			t.Fatalf("Truncate: %v", err)
+		}
+		drain(t, s)
+
+		// A resurrected tail would push the size back out to 36.
+		if size, ok := s.Store.FileSize(ctx, journal.FileID(pid)); !ok || size != 4 {
+			t.Fatalf("legacy replay undid the truncate: size=%d ok=%v, want 4", size, ok)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		dir := t.TempDir()
+		pid := "share/d.bin"
+		writeLegacyLog(t, filepath.Join(dir, "logs", pid+".log"), 0, []legacyRec{
+			{off: 0, payload: []byte("doomed bytes")},
+		})
+		s, err := NewWithOptions(dir, 1<<30, nil, FSStoreOptions{MigrateLegacyLocalOnly: true})
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		defer func() { _ = s.Close() }()
+
+		// Delete the payload before the legacy log is drained.
+		if err := s.Delete(ctx, pid); err != nil {
+			t.Fatalf("Delete: %v", err)
+		}
+		drain(t, s)
+
+		// A resurrected payload would report a non-zero size.
+		if size, ok := s.Store.FileSize(ctx, journal.FileID(pid)); ok && size != 0 {
+			t.Fatalf("legacy replay resurrected a deleted payload: size=%d ok=%v", size, ok)
+		}
+	})
+}
+
+// TestLegacyReplay_StopsOnOffsetOverflow proves a record whose end would overflow
+// int64 is treated as a torn tail: replay stops at it (never wrapping to a
+// negative offset) and only the records before it are emitted.
+func TestLegacyReplay_StopsOnOffsetOverflow(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "overflow.log")
+	writeLegacyLog(t, logPath, 0, []legacyRec{
+		{off: 0, payload: []byte("good")},
+		{off: math.MaxUint64 - 1, payload: []byte("overflow")},
+		{off: 8, payload: []byte("unreached")},
+	})
+
+	var got []legacyRec
+	err := replayLegacyLog(logPath, func(off uint64, payload []byte) error {
+		got = append(got, legacyRec{off: off, payload: append([]byte(nil), payload...)})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("replayLegacyLog: %v", err)
+	}
+	if len(got) != 1 || got[0].off != 0 || !bytes.Equal(got[0].payload, []byte("good")) {
+		t.Fatalf("replay did not stop at the overflow record: emitted %+v", got)
+	}
 }
 
 // TestLegacyLocalOnly_RefusesCompacted proves the safety gate: a compacted log

--- a/pkg/block/local/fs/legacy_reader.go
+++ b/pkg/block/local/fs/legacy_reader.go
@@ -32,6 +32,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -106,14 +107,17 @@ func classifyLegacyLog(path string) (legacyLogState, error) {
 	return legacyLogOK, nil
 }
 
-// legacyLogsMigratable walks logsDir and reports whether every real append log
-// is complete (uncompacted). A compacted or torn header means some bytes are
-// only in the unrecoverable blobs, so the share must not be auto-migrated.
-func legacyLogsMigratable(logsDir string) (bool, error) {
-	migratable := true
-	walkErr := filepath.WalkDir(logsDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
+// firstUnmigratableLog walks logsDir for the first append log that blocks
+// auto-migration and returns a human reason plus that log's path; it returns
+// ("", "", nil) when every real log is complete and replayable. A compacted log
+// means rolled-up bytes now live only in the unrecoverable blobs; a torn or
+// invalid header means the log itself cannot be replayed. Either way the share
+// must not be auto-migrated, and naming the two cases apart keeps the refusal
+// from blaming "compaction" for a log that is merely corrupt.
+func firstUnmigratableLog(logsDir string) (reason, offendingLog string, err error) {
+	walkErr := filepath.WalkDir(logsDir, func(path string, d os.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
 		}
 		if d.IsDir() || !strings.HasSuffix(d.Name(), ".log") {
 			return nil
@@ -122,16 +126,20 @@ func legacyLogsMigratable(logsDir string) (bool, error) {
 		if cerr != nil {
 			return cerr
 		}
-		if state == legacyLogCompacted || state == legacyLogUnreadable {
-			migratable = false
+		switch state {
+		case legacyLogCompacted:
+			reason, offendingLog = "an append log was compacted, so some bytes live only in unrecoverable blobs", path
+			return filepath.SkipAll
+		case legacyLogUnreadable:
+			reason, offendingLog = "an append log is torn or has an invalid header, so it cannot be replayed", path
 			return filepath.SkipAll
 		}
 		return nil
 	})
 	if walkErr != nil {
-		return false, walkErr
+		return "", "", walkErr
 	}
-	return migratable, nil
+	return reason, offendingLog, nil
 }
 
 // scanLegacyPayloads walks logsDir and returns a map of payloadID -> absolute
@@ -220,6 +228,12 @@ func readLegacyRecord(r io.Reader) (uint64, []byte, bool, error) {
 	fileOffset := binary.LittleEndian.Uint64(frame[4:12])
 	wantCRC := binary.LittleEndian.Uint32(frame[12:16])
 	if payloadLen > legacyMaxRecordPayload {
+		return 0, nil, false, nil
+	}
+	// The offset and end of the record must fit int64: replay hands the offset
+	// to a WriteAt that takes an int64, and a wider value would wrap negative.
+	// Such a record is unreplayable, so stop the log here like a torn tail.
+	if fileOffset > math.MaxInt64-uint64(payloadLen) {
 		return 0, nil, false, nil
 	}
 	payload := make([]byte, payloadLen)


### PR DESCRIPTION
## What

The async local-only pre-journal migration (added in #1801, shipped in v0.28.0) faults a payload's archived append log into the journal on ReadAt so reads never observe zeros. But the **mutating** FSStore shims did not fault-in first, opening a last-write-wins hole across the upgrade boundary:

- **Write before materialize:** a client WriteAt to a not-yet-drained payload wrote new bytes; the later background drain then replayed the OLD legacy records via Store.WriteAt and **overwrote the client's newer bytes** — a lost write.
- **Delete/Truncate before materialize:** a delete/truncate could be undone — a later replay resurrected bytes past the truncate or after the delete.

## Fix

Every payload-mutating shim (WriteAt, Delete, Truncate) now calls a shared materialize-first helper before applying the mutation, mirroring ReadAt. The client mutation always lands **after** the legacy replay, and the per-payload sync.Once makes the subsequent background drain an idempotent no-op — so last-write-wins holds and deletes/truncates win.

Two related fixes from the same review:

- **Offset overflow:** a legacy record whose file_offset (uint64) or file_offset+len would overflow int64 is now rejected as a torn tail (replay stops there, same as a bad CRC), instead of wrapping to a negative offset when cast for the int64 WriteAt.
- **Refusal message:** the legacy-log gate now distinguishes a *compacted* log from a *torn/unreadable* one and names the offending log, so operators are not told a corrupt log was 'compacted'.

## Tests

- Write / truncate / delete a payload **before** it is materialized, run the background drain, assert the client mutation survives (verified failing without the guard: legacy replay clobbered the write).
- An offset-overflow record → replay stops at it rather than wrapping negative.

Scope: pkg/block/local/fs only. Verified: go build (+integration), gofmt clean, go vet, golangci-lint clean, go test -race green.