### PR TITLE
fix(nix): refresh stale vendorHash and stop the hash bot failing on tag pushes

### DIFF
--- a/.github/workflows/nix-update-hash.yml
+++ b/.github/workflows/nix-update-hash.yml
@@ -2,6 +2,11 @@ name: nix-update-hash
 
 on:
   push:
+    # Branches only — a tag push checks out a detached HEAD, so the bot's
+    # commit+push step cannot push and the job fails. The hash is refreshed on
+    # the branch push that changed the deps; tags inherit the already-correct hash.
+    branches:
+      - "**"
     paths:
       - go.mod
       - go.sum

--- a/flake.nix
+++ b/flake.nix
@@ -388,7 +388,7 @@
 
               # Auto-updated by .github/workflows/nix-update-hash.yml on go.mod/go.sum changes.
               # Manual: go run scripts/update-nix-hash.go
-              vendorHash = "sha256-W6rsF8sjMBGolRE1fAQr1ppTzTnJSPe2kV/C/KDdsf0=";
+              vendorHash = "sha256-fxL3E1mkr7ziaxaphdDbKdJt3U6MW7FyWH7fuoVBNlw=";
 
               ldflags = [
                 "-s"


### PR DESCRIPTION
Two fixes to the nix-update-hash flow, surfaced by the v0.28.1 tag push.

1. **Stale vendorHash** — flake.nix carried sha256-W6rs... but the correct hash for the current go.mod/go.sum is sha256-fxL3... (verified locally: `go run scripts/update-nix-hash.go` reports up-to-date after the change; it runs the nix build and extracts the same hash). Without this, `nix build` of dittofs fails on a hash mismatch. The value only depends on go.mod/go.sum, so it is identical on develop and the tag.

2. **Bot fails on every tag push** — nix-update-hash has failed on every release tag since v0.27.0 (v0.27.0/v0.28.0/v0.28.1). A tag push checks out a detached HEAD, so the bot's `git push` step exits 128 ("You are not currently on a branch"). Restricting the trigger to branch pushes (`branches: ['**']`) stops tags from triggering it; the hash is refreshed on the branch push that changes the deps, and tags inherit the already-correct hash. Does not affect release.yml.