### PR TITLE
feat(smb): serve share SD via srvsvc NetrShareGetInfo level 502 (#1616)

### DIFF
--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	pkgidentity "github.com/marmos91/dittofs/pkg/identity"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
@@ -2693,9 +2694,10 @@ func (h *Handler) getCachedShares() []rpc.ShareInfo1 {
 		}
 		displayName := strings.TrimPrefix(name, "/")
 		shares = append(shares, rpc.ShareInfo1{
-			Name:    displayName,
-			Type:    rpc.STYPE_DISKTREE,
-			Comment: "DittoFS share",
+			Name:               displayName,
+			Type:               rpc.STYPE_DISKTREE,
+			Comment:            "DittoFS share",
+			SecurityDescriptor: h.shareSecurityDescriptor(name),
 		})
 	}
 
@@ -2703,6 +2705,41 @@ func (h *Handler) getCachedShares() []rpc.ShareInfo1 {
 	h.sharesCacheValid = true
 
 	return shares
+}
+
+// shareSecurityDescriptor builds the self-relative security descriptor served
+// for a share at srvsvc info level 502, so Windows Explorer's Advanced Sharing
+// "Permissions" tab is populated. It mirrors the file Security tab: the share's
+// control-plane grants are projected via ShareRootGrantACL and merged into a
+// synthesized owner+SYSTEM descriptor, surfacing the AD/SID principals that
+// govern the share. Best-effort — a lookup or build failure yields a nil
+// descriptor (a level-502 reply with a null SD) rather than failing the pipe.
+func (h *Handler) shareSecurityDescriptor(shareName string) []byte {
+	if h.Registry == nil {
+		return nil
+	}
+
+	var grantACEs []acl.ACE
+	if grantACL, err := h.Registry.ShareRootGrantACL(context.Background(), shareName); err != nil {
+		logger.Debug("share SD: grant ACL lookup failed (non-fatal)", "share", shareName, "error", err)
+	} else if grantACL != nil {
+		grantACEs = grantACL.ACEs
+	}
+
+	// The share root is owned by uid/gid 0 and carries no explicitly-stored
+	// ACL, so BuildSecurityDescriptorWithGrants synthesizes the owner+SYSTEM
+	// default and merges in the direct AD/SID grants (see buildDACL).
+	root := &metadata.File{}
+	sd, err := BuildSecurityDescriptorWithGrants(
+		root,
+		OwnerSecurityInformation|GroupSecurityInformation|DACLSecurityInformation,
+		grantACEs,
+	)
+	if err != nil {
+		logger.Debug("share SD: build failed (non-fatal)", "share", shareName, "error", err)
+		return nil
+	}
+	return sd
 }
 
 // invalidateShareCache marks the share list cache as stale.

--- a/internal/adapter/smb/rpc/srvsvc.go
+++ b/internal/adapter/smb/rpc/srvsvc.go
@@ -7,6 +7,8 @@ package rpc
 
 import (
 	"encoding/binary"
+	"strings"
+	"unicode/utf16"
 
 	"github.com/marmos91/dittofs/internal/logger"
 )
@@ -52,20 +54,28 @@ const (
 
 // Status Codes
 const (
-	NERR_Success        uint32 = 0x00000000
-	ERROR_MORE_DATA     uint32 = 0x000000EA
-	ERROR_ACCESS_DENIED uint32 = 0x00000005
+	NERR_Success         uint32 = 0x00000000
+	ERROR_MORE_DATA      uint32 = 0x000000EA
+	ERROR_ACCESS_DENIED  uint32 = 0x00000005
+	ERROR_INVALID_LEVEL  uint32 = 0x0000007C // Requested info level is not supported
+	NERR_NetNameNotFound uint32 = 0x00000906 // The share name does not exist
 )
 
 // =============================================================================
 // Share Information Structures
 // =============================================================================
 
-// ShareInfo1 represents SHARE_INFO_1 structure [MS-SRVS Section 2.2.4.23]
+// ShareInfo1 represents SHARE_INFO_1 structure [MS-SRVS Section 2.2.4.23].
+//
+// SecurityDescriptor carries the self-relative share security descriptor served
+// at info level 502 (SHARE_INFO_502.shi502_security_descriptor). It is computed
+// once from the share's control-plane grants when the share list is populated;
+// an empty slice yields a level-502 reply with a null descriptor.
 type ShareInfo1 struct {
-	Name    string
-	Type    uint32
-	Comment string
+	Name               string
+	Type               uint32
+	Comment            string
+	SecurityDescriptor []byte
 }
 
 // =============================================================================
@@ -116,6 +126,8 @@ func (h *SRVSVCHandler) HandleRequest(req *Request) []byte {
 	switch req.OpNum {
 	case OpNetrShareEnum:
 		return h.handleNetrShareEnum(req)
+	case OpNetrShareGetInfo:
+		return h.handleNetrShareGetInfo(req)
 	default:
 		// Return fault for unsupported operations
 		return h.buildFault(req.Header.CallID, ncaSOpRngError)
@@ -252,6 +264,199 @@ func (h *SRVSVCHandler) buildShareEnumLevel1Response() []byte {
 	// Return status (NERR_Success)
 	buf = appendUint32(buf, NERR_Success)
 
+	return buf
+}
+
+// handleNetrShareGetInfo handles NetrShareGetInfo (opnum 16) [MS-SRVS Section 3.1.4.17].
+//
+// Windows populates the Advanced Sharing "Permissions" (Share) tab by requesting
+// info level 502, whose SHARE_INFO_502 carries the share security descriptor.
+// Only level 502 is served; any other level returns ERROR_INVALID_LEVEL so the
+// client falls back gracefully instead of faulting.
+func (h *SRVSVCHandler) handleNetrShareGetInfo(req *Request) []byte {
+	shareName, level, ok := parseShareGetInfoRequest(req.StubData)
+	if !ok {
+		return h.encodeGetInfoResponse(req, h.buildShareGetInfoError(level, ERROR_INVALID_LEVEL))
+	}
+
+	logger.Debug("NetrShareGetInfo", "share", shareName, "level", level)
+
+	if level != 502 {
+		return h.encodeGetInfoResponse(req, h.buildShareGetInfoError(level, ERROR_INVALID_LEVEL))
+	}
+
+	share, found := h.findShare(shareName)
+	if !found {
+		return h.encodeGetInfoResponse(req, h.buildShareGetInfoError(level, NERR_NetNameNotFound))
+	}
+
+	return h.encodeGetInfoResponse(req, h.buildShareGetInfo502Response(share))
+}
+
+// encodeGetInfoResponse wraps NDR stub data in a DCE/RPC response PDU.
+func (h *SRVSVCHandler) encodeGetInfoResponse(req *Request, stubData []byte) []byte {
+	resp := &Response{
+		AllocHint:   uint32(len(stubData)),
+		ContextID:   req.ContextID,
+		CancelCount: 0,
+		StubData:    stubData,
+	}
+	return resp.Encode(req.Header.CallID)
+}
+
+// findShare locates a share by its wire name, tolerating a leading path
+// separator and matching case-insensitively (SMB share names are case-folded).
+func (h *SRVSVCHandler) findShare(name string) (ShareInfo1, bool) {
+	name = strings.TrimLeft(name, "\\/")
+	for _, s := range h.shares {
+		if strings.EqualFold(s.Name, name) {
+			return s, true
+		}
+	}
+	return ShareInfo1{}, false
+}
+
+// buildShareGetInfo502Response builds the NDR-encoded NetrShareGetInfo response
+// for level 502. The returned InfoStruct is a SHARE_INFO (Level + non-encapsulated
+// union) whose 502 arm points at a SHARE_INFO_502 carrying the netname, remark,
+// and the self-relative security descriptor sized by the reserved field.
+func (h *SRVSVCHandler) buildShareGetInfo502Response(share ShareInfo1) []byte {
+	buf := make([]byte, 0, 512)
+
+	sd := share.SecurityDescriptor
+
+	// SHARE_INFO: Level, then the non-encapsulated union re-emits its
+	// discriminant (mirroring the enum container encoding), then the pointer
+	// to the SHARE_INFO_502 body.
+	buf = appendUint32(buf, 502)        // Level
+	buf = appendUint32(buf, 502)        // union discriminant
+	buf = appendUint32(buf, 0x00020000) // SHARE_INFO_502 referent
+
+	// SHARE_INFO_502 fixed part: referent ids for the deferred members, scalars
+	// inline. path and passwd are null; reserved carries the SD byte length.
+	buf = appendUint32(buf, 0x00020004) // shi502_netname
+	buf = appendUint32(buf, share.Type) // shi502_type
+	buf = appendUint32(buf, 0x00020008) // shi502_remark
+	buf = appendUint32(buf, 0)          // shi502_permissions
+	buf = appendUint32(buf, 0xFFFFFFFF) // shi502_max_uses (unlimited)
+	buf = appendUint32(buf, 0)          // shi502_current_uses
+	buf = appendUint32(buf, 0)          // shi502_path (null)
+	buf = appendUint32(buf, 0)          // shi502_passwd (null)
+	buf = appendUint32(buf, uint32(len(sd)))
+	if len(sd) > 0 {
+		buf = appendUint32(buf, 0x0002000C) // shi502_security_descriptor
+	} else {
+		buf = appendUint32(buf, 0)
+	}
+
+	// Deferred members in declaration order: netname, remark, then the
+	// [size_is(reserved)] security-descriptor conformant array.
+	buf = appendConformantVaryingString(buf, share.Name)
+	buf = appendConformantVaryingString(buf, share.Comment)
+	if len(sd) > 0 {
+		buf = appendUint32(buf, uint32(len(sd))) // conformant array max count
+		buf = append(buf, sd...)
+		for len(buf)%4 != 0 {
+			buf = append(buf, 0)
+		}
+	}
+
+	// Return status.
+	buf = appendUint32(buf, NERR_Success)
+	return buf
+}
+
+// buildShareGetInfoError builds a SHARE_INFO with a null union arm and the given
+// return status, for the invalid-level and share-not-found paths.
+func (h *SRVSVCHandler) buildShareGetInfoError(level, status uint32) []byte {
+	buf := make([]byte, 0, 16)
+	buf = appendUint32(buf, level)  // Level
+	buf = appendUint32(buf, level)  // union discriminant
+	buf = appendUint32(buf, 0)      // null union arm pointer
+	buf = appendUint32(buf, status) // return status
+	return buf
+}
+
+// parseShareGetInfoRequest extracts the requested share name and info level from
+// a NetrShareGetInfo request stub: [in] ServerName (unique string pointer),
+// [in] NetName (unique string pointer), [in] DWORD Level.
+func parseShareGetInfoRequest(data []byte) (name string, level uint32, ok bool) {
+	// ServerName is unused for routing; skip its unique-pointer string.
+	_, pos, ok := readUniqueString(data, 0)
+	if !ok {
+		return "", 0, false
+	}
+	name, pos, ok = readUniqueString(data, pos)
+	if !ok {
+		return "", 0, false
+	}
+	if pos+4 > len(data) {
+		return "", 0, false
+	}
+	level = binary.LittleEndian.Uint32(data[pos:])
+	return name, level, true
+}
+
+// readUniqueString reads a unique-pointer-prefixed conformant/varying wide
+// string. A null referent yields an empty string.
+func readUniqueString(data []byte, pos int) (s string, next int, ok bool) {
+	if pos+4 > len(data) {
+		return "", pos, false
+	}
+	referent := binary.LittleEndian.Uint32(data[pos:])
+	pos += 4
+	if referent == 0 {
+		return "", pos, true
+	}
+	return readConformantVaryingString(data, pos)
+}
+
+// readConformantVaryingString reads an NDR conformant/varying wide string
+// (MaxCount, Offset, ActualCount, UTF-16LE chars) and advances past its 4-byte
+// alignment padding. The trailing NUL is stripped from the result.
+func readConformantVaryingString(data []byte, pos int) (s string, next int, ok bool) {
+	if pos+12 > len(data) {
+		return "", pos, false
+	}
+	pos += 4 // MaxCount (unused)
+	pos += 4 // Offset (assumed 0)
+	actual := binary.LittleEndian.Uint32(data[pos:])
+	pos += 4
+	if actual > 0xFFFF {
+		return "", pos, false // implausible length; reject rather than over-read
+	}
+	byteLen := int(actual) * 2
+	if pos+byteLen > len(data) {
+		return "", pos, false
+	}
+	units := make([]uint16, actual)
+	for i := range units {
+		units[i] = binary.LittleEndian.Uint16(data[pos+i*2:])
+	}
+	pos += byteLen
+	for pos%4 != 0 { // 4-byte alignment padding
+		pos++
+	}
+	return strings.TrimRight(string(utf16.Decode(units)), "\x00"), pos, true
+}
+
+// appendConformantVaryingString appends an NDR conformant/varying wide string
+// (MaxCount, Offset, ActualCount, UTF-16LE chars + NUL, padded to 4 bytes). The
+// counts are UTF-16 code-unit counts (including the NUL), so a name outside the
+// BMP or with multi-byte runes stays consistent with the reader.
+func appendConformantVaryingString(buf []byte, s string) []byte {
+	units := utf16.Encode([]rune(s))
+	n := len(units) + 1                // include the NUL terminator in the counts
+	buf = appendUint32(buf, uint32(n)) // MaxCount
+	buf = appendUint32(buf, 0)         // Offset
+	buf = appendUint32(buf, uint32(n)) // ActualCount
+	for _, u := range units {
+		buf = append(buf, byte(u), byte(u>>8))
+	}
+	buf = append(buf, 0, 0) // NUL terminator
+	for len(buf)%4 != 0 {
+		buf = append(buf, 0)
+	}
 	return buf
 }
 

--- a/internal/adapter/smb/rpc/srvsvc_getinfo_test.go
+++ b/internal/adapter/smb/rpc/srvsvc_getinfo_test.go
@@ -1,0 +1,161 @@
+package rpc
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// encodeUniqueString builds the NDR wire form of a unique-pointer-prefixed
+// conformant/varying wide string, matching what a client sends for the
+// ServerName and NetName arguments of NetrShareGetInfo.
+func encodeUniqueString(referent uint32, s string) []byte {
+	buf := appendUint32(nil, referent)
+	return appendConformantVaryingString(buf, s)
+}
+
+func TestParseShareGetInfoRequest(t *testing.T) {
+	stub := encodeUniqueString(0x00020000, "\\\\SERVER")
+	stub = append(stub, encodeUniqueString(0x00020004, "export")...)
+	stub = appendUint32(stub, 502) // Level
+
+	name, level, ok := parseShareGetInfoRequest(stub)
+	if !ok {
+		t.Fatal("parseShareGetInfoRequest: unexpected failure")
+	}
+	if name != "export" {
+		t.Errorf("share name = %q, want %q", name, "export")
+	}
+	if level != 502 {
+		t.Errorf("level = %d, want 502", level)
+	}
+}
+
+// TestConformantVaryingStringRoundTrip_NonASCII guards the NDR count against the
+// UTF-8-bytes-vs-UTF-16-units mismatch: the encoded MaxCount/ActualCount must
+// match what the reader consumes, or every following field misaligns.
+func TestConformantVaryingStringRoundTrip_NonASCII(t *testing.T) {
+	for _, s := range []string{"café", "共有", "plain"} {
+		buf := appendConformantVaryingString(nil, s)
+		got, next, ok := readConformantVaryingString(buf, 0)
+		if !ok {
+			t.Fatalf("readConformantVaryingString(%q): failed", s)
+		}
+		if got != s {
+			t.Errorf("round-trip = %q, want %q", got, s)
+		}
+		if next != len(buf) {
+			t.Errorf("reader consumed %d bytes, encoder wrote %d for %q", next, len(buf), s)
+		}
+	}
+}
+
+func TestParseShareGetInfoRequest_NullServerName(t *testing.T) {
+	stub := appendUint32(nil, 0) // ServerName: null unique pointer
+	stub = append(stub, encodeUniqueString(0x00020004, "data")...)
+	stub = appendUint32(stub, 502)
+
+	name, level, ok := parseShareGetInfoRequest(stub)
+	if !ok || name != "data" || level != 502 {
+		t.Fatalf("parse = (%q, %d, %v), want (data, 502, true)", name, level, ok)
+	}
+}
+
+// TestNetrShareGetInfo502RoundTrip drives a full NetrShareGetInfo request through
+// the handler and decodes the response, verifying the SHARE_INFO_502 carries the
+// share's netname, remark, and security descriptor intact.
+func TestNetrShareGetInfo502RoundTrip(t *testing.T) {
+	sd := []byte{0x01, 0x00, 0x14, 0x80, 0xDE, 0xAD, 0xBE, 0xEF, 0x11, 0x22} // opaque SD bytes
+	h := NewSRVSVCHandler([]ShareInfo1{{
+		Name:               "export",
+		Type:               STYPE_DISKTREE,
+		Comment:            "DittoFS share",
+		SecurityDescriptor: sd,
+	}})
+
+	stub := encodeUniqueString(0x00020000, "\\\\SERVER")
+	stub = append(stub, encodeUniqueString(0x00020004, "export")...)
+	stub = appendUint32(stub, 502)
+
+	req := &Request{
+		OpNum:     OpNetrShareGetInfo,
+		ContextID: 0,
+		StubData:  stub,
+		Header:    Header{CallID: 7},
+	}
+
+	resp := h.HandleRequest(req)
+	// Response PDU: 16-byte header + alloc_hint(4) + context(2) + cancel(1) +
+	// reserved(1), so the NDR stub starts at offset 24.
+	if len(resp) < 24 {
+		t.Fatalf("response too short: %d bytes", len(resp))
+	}
+	body := resp[24:]
+
+	if got := binary.LittleEndian.Uint32(body[0:]); got != 502 {
+		t.Errorf("Level = %d, want 502", got)
+	}
+	if got := binary.LittleEndian.Uint32(body[4:]); got != 502 {
+		t.Errorf("union discriminant = %d, want 502", got)
+	}
+	if got := binary.LittleEndian.Uint32(body[8:]); got == 0 {
+		t.Error("SHARE_INFO_502 referent is null, want non-null")
+	}
+
+	// SHARE_INFO_502 fixed part begins at offset 12.
+	reserved := binary.LittleEndian.Uint32(body[12+32:]) // reserved is the 9th DWORD
+	if int(reserved) != len(sd) {
+		t.Errorf("shi502_reserved = %d, want SD length %d", reserved, len(sd))
+	}
+
+	// Deferred members start after the 10-DWORD fixed part (offset 12 + 40 = 52):
+	// netname, remark, then the SD conformant array.
+	pos := 12 + 40
+	netname, pos, ok := readConformantVaryingString(body, pos)
+	if !ok || netname != "export" {
+		t.Fatalf("netname = %q (ok=%v), want %q", netname, ok, "export")
+	}
+	remark, pos, ok := readConformantVaryingString(body, pos)
+	if !ok || remark != "DittoFS share" {
+		t.Fatalf("remark = %q (ok=%v), want %q", remark, ok, "DittoFS share")
+	}
+
+	// SD conformant array: max count then the raw bytes.
+	maxCount := binary.LittleEndian.Uint32(body[pos:])
+	pos += 4
+	if int(maxCount) != len(sd) {
+		t.Fatalf("SD array max count = %d, want %d", maxCount, len(sd))
+	}
+	if got := body[pos : pos+len(sd)]; !bytes.Equal(got, sd) {
+		t.Errorf("SD bytes = %x, want %x", got, sd)
+	}
+}
+
+func TestNetrShareGetInfo_UnknownShare(t *testing.T) {
+	h := NewSRVSVCHandler([]ShareInfo1{{Name: "export", Type: STYPE_DISKTREE}})
+
+	stub := appendUint32(nil, 0) // null ServerName
+	stub = append(stub, encodeUniqueString(0x00020004, "missing")...)
+	stub = appendUint32(stub, 502)
+
+	resp := h.HandleRequest(&Request{OpNum: OpNetrShareGetInfo, StubData: stub, Header: Header{CallID: 1}})
+	body := resp[24:]
+	// Error form: Level, discriminant, null arm pointer, status.
+	if status := binary.LittleEndian.Uint32(body[12:]); status != NERR_NetNameNotFound {
+		t.Errorf("status = %#x, want NERR_NetNameNotFound (%#x)", status, NERR_NetNameNotFound)
+	}
+}
+
+func TestNetrShareGetInfo_UnsupportedLevel(t *testing.T) {
+	h := NewSRVSVCHandler([]ShareInfo1{{Name: "export", Type: STYPE_DISKTREE}})
+
+	stub := appendUint32(nil, 0)
+	stub = append(stub, encodeUniqueString(0x00020004, "export")...)
+	stub = appendUint32(stub, 2) // level 2, unsupported
+
+	resp := h.HandleRequest(&Request{OpNum: OpNetrShareGetInfo, StubData: stub, Header: Header{CallID: 1}})
+	body := resp[24:]
+	if status := binary.LittleEndian.Uint32(body[12:]); status != ERROR_INVALID_LEVEL {
+		t.Errorf("status = %#x, want ERROR_INVALID_LEVEL (%#x)", status, ERROR_INVALID_LEVEL)
+	}
+}


### PR DESCRIPTION
## What

Implements `NetrShareGetInfo` (srvsvc opnum 16) at info level **502** (`SHARE_INFO_502`), which carries the share-level Windows security descriptor. DittoFS's srvsvc handler previously only served `NetrShareEnum` (opnum 15); `NetrShareGetInfo` faulted, so the share SD was never returned.

## What Explorer shows now

Right-click a folder on a DittoFS SMB share -> Properties -> Sharing -> Advanced Sharing -> **Permissions**. That tab (fed by `NetrShareGetInfo` level 502) is now **populated** instead of showing "The requested security information is either unavailable or can't be displayed". It lists the AD/SID principals that govern the share, mirroring what the file **Security** tab shows (#1608).

## How

- **SD source (reused, not hand-rolled):** the share SD is built by the existing `BuildSecurityDescriptorWithGrants` path in `internal/adapter/smb/handlers/security.go`, fed by `Runtime.ShareRootGrantACL` — the same projection the file Security tab uses. A synthesized owner+SYSTEM descriptor is merged with the share's direct AD/SID grants. Computed once per share in `getCachedShares()` (best-effort; a lookup/build failure yields a null descriptor rather than failing the pipe) and carried on `rpc.ShareInfo1.SecurityDescriptor`.
- **NDR encoding:** `buildShareGetInfo502Response` emits the `SHARE_INFO` (Level + non-encapsulated union) with the 502 arm pointing at a `SHARE_INFO_502` (netname, remark, `reserved` = SD byte length, and the `[size_is(reserved)]` security-descriptor conformant array), following the same hand-rolled NDR conventions already used by the enum encoder.
- **Request parsing** is bounds-checked against truncated/malformed stub data. String counts are UTF-16 code units (not UTF-8 bytes), so non-ASCII share names/comments stay aligned.
- Other levels return `ERROR_INVALID_LEVEL`; an unknown share returns `NERR_NetNameNotFound`.

## Tests

`internal/adapter/smb/rpc/srvsvc_getinfo_test.go`: request-parse round-trip (incl. null ServerName), full 502 response round-trip verifying netname/remark/SD bytes and the `reserved` length, non-ASCII conformant-string round-trip, and the invalid-level / unknown-share error paths. `go vet`, `go build ./...`, and the rpc + handlers package tests all pass.

Closes #1616