### PR TITLE
refactor(metadata): remove dead badger keyspace and relocate ShareSession (#1715)

### DIFF
--- a/pkg/metadata/store/badger/encoding.go
+++ b/pkg/metadata/store/badger/encoding.go
@@ -38,7 +38,6 @@ import (
 // Children Map          "c:"     c:<parentUUID>:<childName>             childUUID (bytes)
 // Shares                "s:"     s:<shareName>                          shareData (JSON)
 // Link Counts           "l:"     l:<uuid>                               uint32 (binary)
-// Device Numbers        "d:"     d:<uuid>                               deviceNumber (JSON)
 // Server Config         "cfg:"   cfg:server                             MetadataServerConfig (JSON)
 // Filesystem Caps       "cap:"   cap:fs                                 FilesystemCapabilities (JSON)
 
@@ -49,7 +48,6 @@ const (
 	prefixChildName    = "cn:" // (parentUUID, childUUID) -> child name (reverse edge)
 	prefixShare        = "s:"
 	prefixLinkCount    = "l:"
-	prefixDeviceNumber = "d:"
 	prefixConfig       = "cfg:"
 	prefixCapabilities = "cap:"
 	prefixObjectID     = "obj:" // ObjectID -> file UUID

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -2,7 +2,6 @@ package badger
 
 import (
 	"context"
-	"encoding/json"
 	goerrors "errors"
 	"fmt"
 	"strings"
@@ -909,26 +908,12 @@ func (tx *badgerTransaction) GetFilesystemMeta(ctx context.Context, shareName st
 		return nil, err
 	}
 
-	item, err := tx.txn.Get(keyFilesystemMeta(shareName))
-	if err == badgerdb.ErrKeyNotFound {
-		// Return defaults
-		return &metadata.FilesystemMeta{
-			Capabilities: tx.store.loadCapabilities(),
-		}, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	var metaSvc metadata.FilesystemMeta
-	err = item.Value(func(val []byte) error {
-		return json.Unmarshal(val, &metaSvc)
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return &metaSvc, nil
+	// Capabilities are the only persisted part of the filesystem metadata and
+	// live in the cap:fs singleton; statistics are computed on demand via
+	// GetFilesystemStatistics.
+	return &metadata.FilesystemMeta{
+		Capabilities: tx.store.loadCapabilities(),
+	}, nil
 }
 
 func (tx *badgerTransaction) PutFilesystemMeta(ctx context.Context, shareName string, metaSvc *metadata.FilesystemMeta) error {
@@ -936,12 +921,10 @@ func (tx *badgerTransaction) PutFilesystemMeta(ctx context.Context, shareName st
 		return err
 	}
 
-	data, err := json.Marshal(metaSvc)
-	if err != nil {
-		return err
-	}
-
-	return tx.txn.Set(keyFilesystemMeta(shareName), data)
+	// Persist only the capabilities into the cap:fs singleton; statistics are
+	// dynamic and never stored.
+	tx.SetFilesystemCapabilities(metaSvc.Capabilities)
+	return nil
 }
 
 func (tx *badgerTransaction) GenerateHandle(ctx context.Context, shareName string, path string) (metadata.FileHandle, error) {
@@ -956,20 +939,12 @@ func (tx *badgerTransaction) GenerateHandle(ctx context.Context, shareName strin
 // Key Helper Functions
 // ============================================================================
 
-func keyFilesystemMeta(shareName string) []byte {
-	return []byte(prefixFilesystemMeta + shareName)
-}
-
 func extractNameFromChildKey(key, prefix []byte) string {
 	if len(key) <= len(prefix) {
 		return ""
 	}
 	return string(key[len(prefix):])
 }
-
-const (
-	prefixFilesystemMeta = "fsmeta:"
-)
 
 // ============================================================================
 // Transaction Shares Operations

--- a/pkg/metadata/store/memory/reset.go
+++ b/pkg/metadata/store/memory/reset.go
@@ -32,7 +32,7 @@ func (s *MemoryMetadataStore) Reset(ctx context.Context) error {
 	s.linkCounts = make(map[string]uint32)
 	s.deviceNumbers = make(map[string]*deviceNumber)
 	s.pendingWrites = make(map[string]*metadata.WriteOperation)
-	s.sessions = make(map[string]*metadata.ShareSession)
+	s.sessions = make(map[string]*ShareSession)
 	s.objectIndex = make(map[block.ContentHash]string)
 	s.serverConfig = metadata.MetadataServerConfig{}
 

--- a/pkg/metadata/store/memory/snapshot_store.go
+++ b/pkg/metadata/store/memory/snapshot_store.go
@@ -407,7 +407,7 @@ func (s *MemoryMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 	}
 
 	// Re-initialize transient state.
-	s.sessions = make(map[string]*metadata.ShareSession)
+	s.sessions = make(map[string]*ShareSession)
 
 	// Recompute usedBytes from files (only regular files count).
 	var totalBytes int64

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -51,6 +51,20 @@ type deviceNumber struct {
 	Minor uint32
 }
 
+// ShareSession represents an active client session on a share. Sessions are
+// informational only (monitoring and DUMP) and do not affect access control;
+// the memory store is the only backend that tracks them.
+type ShareSession struct {
+	// ShareName is the name of the mounted share
+	ShareName string
+
+	// ClientAddr is the network address of the client
+	ClientAddr string
+
+	// MountedAt is the time when the share was mounted
+	MountedAt time.Time
+}
+
 // MemoryMetadataStore implements MetadataStore using in-memory storage.
 //
 // This implementation provides a fully functional metadata repository backed
@@ -201,7 +215,7 @@ type MemoryMetadataStore struct {
 	// Key: composite key "shareName|clientAddr"
 	// Value: ShareSession with mount timestamp
 	// Note: Sessions are informational only and don't affect access control
-	sessions map[string]*metadata.ShareSession
+	sessions map[string]*ShareSession
 
 	// fileChunkData holds content-addressed file chunk tracking data.
 	// Initialized lazily on first use.
@@ -341,7 +355,7 @@ func NewMemoryMetadataStore(config MemoryMetadataStoreConfig) *MemoryMetadataSto
 		capabilities:    config.Capabilities,
 		maxStorageBytes: config.MaxStorageBytes,
 		maxFiles:        config.MaxFiles,
-		sessions:        make(map[string]*metadata.ShareSession),
+		sessions:        make(map[string]*ShareSession),
 		// Assign a fresh ULID on construction so every live instance
 		// advertises its own non-empty identity at the API surface. Even
 		// though memory-backed stores do not survive restart, the

--- a/pkg/metadata/types.go
+++ b/pkg/metadata/types.go
@@ -158,18 +158,6 @@ type ShareOptions struct {
 	IdentityMapping *IdentityMapping
 }
 
-// ShareSession represents an active client session on a share.
-type ShareSession struct {
-	// ShareName is the name of the mounted share
-	ShareName string
-
-	// ClientAddr is the network address of the client
-	ClientAddr string
-
-	// MountedAt is the time when the share was mounted
-	MountedAt time.Time
-}
-
 // ============================================================================
 // Server Configuration
 // ============================================================================


### PR DESCRIPTION
Low-risk Wave-1 hygiene subset of #1715 (metadata store cleanup). Three self-contained changes, all deletion-heavy (net -25 lines), verified against current develop before touching:

## Changes

**1. Delete dead `d:` device-number key prefix** (badger `encoding.go`)
`prefixDeviceNumber = "d:"` had no key builder, reader, or writer anywhere in the codebase — only the constant and a doc-table line. Removed both. (The memory store's unrelated `deviceNumbers` map is untouched.)

**2. Relocate `ShareSession` into the memory store package**
`ShareSession` lived in the core `pkg/metadata/types.go` but is used only by the memory backend (sessions are informational, for monitoring/DUMP). Moved the struct into `pkg/metadata/store/memory/store.go` and updated its 4 in-package references.

**3. Fold badger's `fsmeta:` keyspace into the `cap:fs` singleton** (badger `transaction.go`)
The per-share `fsmeta:` `FilesystemMeta` blob was redundant with the `cap:fs` capabilities singleton and never written in production (no caller invokes `PutFilesystemMeta`). `GetFilesystemMeta` now derives capabilities from `loadCapabilities()`/`cap:fs`; `PutFilesystemMeta` persists capabilities via the existing `SetFilesystemCapabilities`. Statistics remain computed on demand via `GetFilesystemStatistics` (the statfs read-path). Removed `keyFilesystemMeta`, `prefixFilesystemMeta`, and the now-unused `encoding/json` import. This matches how the memory backend already behaves, and the storetest conformance suite already documents that `GetFilesystemMeta` does not round-trip a prior `PutFilesystemMeta`.

## Out of scope
Items 6 (Nlink), 7 (SUID/SGID), and 8/8b (attr-vs-manifest seam) from the Wave-1 plan are intentionally left for separate PRs.

## Verification
- `go build ./...`, `go vet ./pkg/metadata/...` clean
- `go test ./pkg/metadata/...` — 2653 passed (16 packages), including the storetest conformance suite (badger/sqlite/memory) covering `FilesystemMeta`/statistics/statfs
- code-simplifier + code-reviewer: no findings