### PR TITLE
fix(smb): parse srvsvc NetrShareGetInfo NetName as an inline ref-pointer string

### DIFF
--- a/internal/adapter/smb/rpc/srvsvc.go
+++ b/internal/adapter/smb/rpc/srvsvc.go
@@ -378,15 +378,25 @@ func (h *SRVSVCHandler) buildShareGetInfoError(level, status uint32) []byte {
 }
 
 // parseShareGetInfoRequest extracts the requested share name and info level from
-// a NetrShareGetInfo request stub: [in] ServerName (unique string pointer),
-// [in] NetName (unique string pointer), [in] DWORD Level.
+// a NetrShareGetInfo request stub. Per NDR, top-level pointers marshal their
+// pointee inline in parameter order, so the wire layout is:
+//
+//	[ServerName unique-ptr referent (4 bytes; 0 == null)]
+//	[ServerName conformant/varying string]  -- only when the referent is non-null
+//	[NetName conformant/varying string]     -- no referent id (reference pointer)
+//	[Level (4 bytes)]
+//
+// ServerName is a [unique] pointer (nullable, referent-prefixed). NetName is a
+// [ref] pointer, which carries no referent on the wire — its string follows
+// inline directly.
 func parseShareGetInfoRequest(data []byte) (name string, level uint32, ok bool) {
 	// ServerName is unused for routing; skip its unique-pointer string.
 	_, pos, ok := readUniqueString(data, 0)
 	if !ok {
 		return "", 0, false
 	}
-	name, pos, ok = readUniqueString(data, pos)
+	// NetName is a reference pointer: the string is inline with no referent id.
+	name, pos, ok = readConformantVaryingString(data, pos)
 	if !ok {
 		return "", 0, false
 	}

--- a/internal/adapter/smb/rpc/srvsvc_getinfo_test.go
+++ b/internal/adapter/smb/rpc/srvsvc_getinfo_test.go
@@ -8,16 +8,28 @@ import (
 
 // encodeUniqueString builds the NDR wire form of a unique-pointer-prefixed
 // conformant/varying wide string, matching what a client sends for the
-// ServerName and NetName arguments of NetrShareGetInfo.
+// [unique] ServerName argument of NetrShareGetInfo.
 func encodeUniqueString(referent uint32, s string) []byte {
 	buf := appendUint32(nil, referent)
 	return appendConformantVaryingString(buf, s)
 }
 
+// encodeGetInfoRequest builds a NetrShareGetInfo request stub in real Windows
+// wire order: a [unique] ServerName pointer (referent, then its inline string
+// when non-null), the [ref] NetName string inline with no referent, then Level.
+func encodeGetInfoRequest(serverReferent uint32, serverName, netName string, level uint32) []byte {
+	var stub []byte
+	if serverReferent == 0 {
+		stub = appendUint32(nil, 0) // null ServerName unique pointer
+	} else {
+		stub = encodeUniqueString(serverReferent, serverName)
+	}
+	stub = appendConformantVaryingString(stub, netName) // NetName: inline, no referent
+	return appendUint32(stub, level)
+}
+
 func TestParseShareGetInfoRequest(t *testing.T) {
-	stub := encodeUniqueString(0x00020000, "\\\\SERVER")
-	stub = append(stub, encodeUniqueString(0x00020004, "export")...)
-	stub = appendUint32(stub, 502) // Level
+	stub := encodeGetInfoRequest(0x00020000, "\\\\SERVER", "export", 502)
 
 	name, level, ok := parseShareGetInfoRequest(stub)
 	if !ok {
@@ -51,9 +63,7 @@ func TestConformantVaryingStringRoundTrip_NonASCII(t *testing.T) {
 }
 
 func TestParseShareGetInfoRequest_NullServerName(t *testing.T) {
-	stub := appendUint32(nil, 0) // ServerName: null unique pointer
-	stub = append(stub, encodeUniqueString(0x00020004, "data")...)
-	stub = appendUint32(stub, 502)
+	stub := encodeGetInfoRequest(0, "", "data", 502)
 
 	name, level, ok := parseShareGetInfoRequest(stub)
 	if !ok || name != "data" || level != 502 {
@@ -73,9 +83,7 @@ func TestNetrShareGetInfo502RoundTrip(t *testing.T) {
 		SecurityDescriptor: sd,
 	}})
 
-	stub := encodeUniqueString(0x00020000, "\\\\SERVER")
-	stub = append(stub, encodeUniqueString(0x00020004, "export")...)
-	stub = appendUint32(stub, 502)
+	stub := encodeGetInfoRequest(0x00020000, "\\\\SERVER", "export", 502)
 
 	req := &Request{
 		OpNum:     OpNetrShareGetInfo,
@@ -134,9 +142,7 @@ func TestNetrShareGetInfo502RoundTrip(t *testing.T) {
 func TestNetrShareGetInfo_UnknownShare(t *testing.T) {
 	h := NewSRVSVCHandler([]ShareInfo1{{Name: "export", Type: STYPE_DISKTREE}})
 
-	stub := appendUint32(nil, 0) // null ServerName
-	stub = append(stub, encodeUniqueString(0x00020004, "missing")...)
-	stub = appendUint32(stub, 502)
+	stub := encodeGetInfoRequest(0, "", "missing", 502)
 
 	resp := h.HandleRequest(&Request{OpNum: OpNetrShareGetInfo, StubData: stub, Header: Header{CallID: 1}})
 	body := resp[24:]
@@ -149,9 +155,7 @@ func TestNetrShareGetInfo_UnknownShare(t *testing.T) {
 func TestNetrShareGetInfo_UnsupportedLevel(t *testing.T) {
 	h := NewSRVSVCHandler([]ShareInfo1{{Name: "export", Type: STYPE_DISKTREE}})
 
-	stub := appendUint32(nil, 0)
-	stub = append(stub, encodeUniqueString(0x00020004, "export")...)
-	stub = appendUint32(stub, 2) // level 2, unsupported
+	stub := encodeGetInfoRequest(0, "", "export", 2) // level 2, unsupported
 
 	resp := h.HandleRequest(&Request{OpNum: OpNetrShareGetInfo, StubData: stub, Header: Header{CallID: 1}})
 	body := resp[24:]


### PR DESCRIPTION
Fixes #1839.

## Problem

`parseShareGetInfoRequest` decoded the srvsvc `NetrShareGetInfo` (opnum 16) request stub as two consecutive unique-pointer strings (ServerName, NetName) followed by Level. But per the IDL, NetName is a **reference** pointer, not unique:

    NET_API_STATUS NetrShareGetInfo(
      [in, string, unique] SRVSVC_HANDLE ServerName,  // unique -> 4-byte referent
      [in, string] WCHAR* NetName,                    // ref -> NO referent on the wire
      [in] DWORD Level, ...);

Under NDR, top-level pointers marshal their pointee inline in parameter order, and a `[ref]` pointer carries **no referent id**. So the real wire layout is:

    [ServerName unique-ptr referent (4B; 0 == null)]
    [ServerName conformant/varying string]   -- only when referent != 0
    [NetName conformant/varying string]      -- inline, NO referent id
    [Level (4B)]

The old parser read NetName via `readUniqueString`, which consumes a phantom 4-byte referent first. That treated NetName's MaxCount as a referent and misaligned every following field, so `readConformantVaryingString` rejected the (valid) request and the handler returned `ERROR_INVALID_LEVEL`. Against real Windows clients, Explorer's Advanced Sharing "Permissions" tab therefore stayed empty.

## Fix

Read NetName directly as an inline conformant/varying string (`readConformantVaryingString`), with no referent. ServerName keeps `readUniqueString` (it is genuinely a nullable unique pointer). The response encoder `buildShareGetInfo502Response` is unchanged.

The tests are rewritten so their synthetic request buffers encode the REAL Windows layout (NetName inline, no referent) via a shared `encodeGetInfoRequest` helper, instead of re-encoding the old bug.

## Corroboration

The layout was confirmed against three independent references:
- Samba pull order for `ndr_pull_srvsvc_NetrShareGetInfo`: server_unc pointer, then share_name via `ndr_pull_charset` (inline string), then level.
- impacket `srvs.py`: `NetrShareGetInfo` structure is (ServerName `PSRVSVC_HANDLE`, NetName `WSTR`, Level `DWORD`), where `WSTR` is an inline conformant/varying string (NDRSTRUCT, no referent) and only `LPWSTR` carries a referent.
- MS-SRVS opnum-16 IDL parameter attributes.

## Verification

- go build ./... — clean
- go vet ./internal/adapter/smb/... — clean
- go test ./internal/adapter/smb/rpc/... — 54 passed
- gofmt clean; code-simplifier and code-review passes clean