### PR TITLE
perf(metadata): split badger block manifest into fm: key (#1715)

### DIFF
--- a/pkg/metadata/store/badger/encoding.go
+++ b/pkg/metadata/store/badger/encoding.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -33,7 +34,8 @@ import (
 //
 // Data Type             Prefix   Key Format                              Value Type
 // ==================================================================================
-// File Data             "f:"     f:<uuid>                               File (binary; JSON read-fallback)
+// File Data             "f:"     f:<uuid>                               File attrs (binary; JSON read-fallback)
+// File Manifest         "fm:"    fm:<uuid>                              []block.ChunkRef (JSON)
 // Parent Relationships  "p:"     p:<childUUID>                          parentUUID (bytes)
 // Children Map          "c:"     c:<parentUUID>:<childName>             childUUID (bytes)
 // Shares                "s:"     s:<shareName>                          shareData (JSON)
@@ -43,6 +45,7 @@ import (
 
 const (
 	prefixFile         = "f:"
+	prefixFileManifest = "fm:" // file UUID -> block manifest ([]block.ChunkRef, JSON)
 	prefixParent       = "p:"
 	prefixChild        = "c:"
 	prefixChildName    = "cn:" // (parentUUID, childUUID) -> child name (reverse edge)
@@ -61,6 +64,28 @@ const (
 // keyFile generates a key for file data: "f:<uuid>"
 func keyFile(id uuid.UUID) []byte {
 	return []byte(prefixFile + id.String())
+}
+
+// keyFileManifest generates the block-manifest key: "fm:<uuid>". The manifest
+// (File.Blocks) lives here rather than in the f: attribute blob so an attr-only
+// write (chmod/utimes/close/rename/xattr) does not rewrite the chunk list.
+func keyFileManifest(id uuid.UUID) []byte {
+	return []byte(prefixFileManifest + id.String())
+}
+
+// encodeManifest serializes a block manifest for the fm:<uuid> value. JSON keeps
+// it self-describing and matches the bytes the legacy embedded field carried.
+func encodeManifest(blocks []block.ChunkRef) ([]byte, error) {
+	return json.Marshal(blocks)
+}
+
+// decodeManifest parses an fm:<uuid> value back into a block manifest.
+func decodeManifest(b []byte) ([]block.ChunkRef, error) {
+	var blocks []block.ChunkRef
+	if err := json.Unmarshal(b, &blocks); err != nil {
+		return nil, fmt.Errorf("decode manifest: %w", err)
+	}
+	return blocks, nil
 }
 
 // keyParent generates a key for parent relationship: "p:<childUUID>"
@@ -295,11 +320,9 @@ func encodeFile(file *metadata.File) ([]byte, error) {
 		}
 	}
 	buf = putUvarintField(buf, fIdempotenc, a.IdempotencyToken)
-	if len(a.Blocks) > 0 {
-		if buf, err = putJSONField(buf, fBlocks, a.Blocks); err != nil {
-			return nil, fmt.Errorf("encode blocks: %w", err)
-		}
-	}
+	// Blocks (the chunk manifest) are NOT written here — they live in the
+	// sibling fm:<uuid> key so an attr-only write never rewrites the manifest.
+	// The fBlocks field ID survives only in the decoder as a legacy read shim.
 	if !a.ObjectID.IsZero() {
 		oid := a.ObjectID // [32]byte
 		buf = putField(buf, fObjectID, oid[:])
@@ -417,6 +440,9 @@ func decodeFileBinary(b []byte) (*metadata.File, error) {
 		case fIdempotenc:
 			a.IdempotencyToken = uvOf(val)
 		case fBlocks:
+			// Legacy read shim: blobs written before the fm: manifest split
+			// still embed the chunk list. Newer blobs never carry this field;
+			// their manifest is loaded from fm:<uuid> (see loadManifest).
 			if err := json.Unmarshal(val, &a.Blocks); err != nil {
 				return nil, fmt.Errorf("decode blocks: %w", err)
 			}

--- a/pkg/metadata/store/badger/encoding_bench_test.go
+++ b/pkg/metadata/store/badger/encoding_bench_test.go
@@ -86,9 +86,9 @@ func BenchmarkEncodeFileHot(b *testing.B) {
 	}
 }
 
-// bigFile builds a File with nBlocks ChunkRefs — the shape GetFileForRead
-// decodes on every read of a rolled-up file (a 1 GiB file at the ~1 MiB FastCDC
-// average is ~1024 chunks). The inline Blocks list dominates the JSON decode.
+// bigFile builds a File with nBlocks ChunkRefs. The manifest is now split out of
+// the f: attribute blob into fm:, so encodeFile drops these blocks; bigFile is
+// kept to exercise the attr-blob encode/decode with a realistic attribute set.
 func bigFile(nBlocks int) *metadata.File {
 	blocks := make([]block.ChunkRef, nBlocks)
 	for i := range blocks {
@@ -111,10 +111,12 @@ func bigFile(nBlocks int) *metadata.File {
 	}
 }
 
-// BenchmarkDecodeFile measures decodeFile on a 1024-block File. With the
-// generated easyjson UnmarshalJSON present, decodeFile's json.Unmarshal
-// auto-dispatches to it; remove file_types_easyjson.go to get the reflection
-// baseline. Run: go test -run=xxx -bench=BenchmarkDecodeFile ./pkg/metadata/store/badger/
+// BenchmarkDecodeFile measures decodeFile on the attr blob of a 1024-block File.
+// The manifest is split into fm:, so the decoded blob no longer carries the
+// chunk list; this now measures the attr-only decode. With the generated
+// easyjson UnmarshalJSON present, decodeFile's json.Unmarshal auto-dispatches to
+// it; remove file_types_easyjson.go to get the reflection baseline. Run:
+// go test -run=xxx -bench=BenchmarkDecodeFile ./pkg/metadata/store/badger/
 func BenchmarkDecodeFile(b *testing.B) {
 	enc, err := encodeFile(bigFile(1024))
 	if err != nil {
@@ -130,9 +132,11 @@ func BenchmarkDecodeFile(b *testing.B) {
 	}
 }
 
-// TestEncodeDecodeFile_RoundTrip guards format correctness: a File survives
-// encode -> decode byte-for-byte in its fields (decodeFile zeroes Path per
-// #1166, so we compare with Path cleared).
+// TestEncodeDecodeFile_RoundTrip guards format correctness: a File's attributes
+// survive encode -> decode (decodeFile zeroes Path per #1166). The chunk
+// manifest is split out to the fm: key and is NOT carried in the blob, so a
+// decoded record has empty Blocks; the manifest codec is covered separately by
+// TestBadgerEncodeFile_ManifestSplit and the store round-trip test.
 func TestEncodeDecodeFile_RoundTrip(t *testing.T) {
 	orig := bigFile(37)
 	orig.ACL = nil
@@ -145,13 +149,11 @@ func TestEncodeDecodeFile_RoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 	if got.ID != orig.ID || got.ShareName != orig.ShareName || got.Size != orig.Size ||
-		got.Mode != orig.Mode || got.PayloadID != orig.PayloadID || len(got.Blocks) != len(orig.Blocks) {
+		got.Mode != orig.Mode || got.PayloadID != orig.PayloadID {
 		t.Fatalf("round-trip mismatch: got %+v", got.FileAttr)
 	}
-	for i := range orig.Blocks {
-		if got.Blocks[i] != orig.Blocks[i] {
-			t.Fatalf("block %d mismatch: got %+v want %+v", i, got.Blocks[i], orig.Blocks[i])
-		}
+	if len(got.Blocks) != 0 {
+		t.Fatalf("manifest must not ride the attr blob: got %d blocks", len(got.Blocks))
 	}
 	if !got.Mtime.Equal(orig.Mtime) || !got.Ctime.Equal(orig.Ctime) {
 		t.Fatalf("time mismatch: got mtime=%v ctime=%v", got.Mtime, got.Ctime)

--- a/pkg/metadata/store/badger/encoding_test.go
+++ b/pkg/metadata/store/badger/encoding_test.go
@@ -15,16 +15,22 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/acl"
 )
 
-// TestBadgerEncodeFile_BlocksRoundTrip verifies that FileAttr.Blocks
-// round-trips through the Badger JSON encoder
-// (encodeFile/decodeFile) without loss, including ContentHash bytes.
-func TestBadgerEncodeFile_BlocksRoundTrip(t *testing.T) {
+// TestBadgerEncodeFile_ManifestSplit verifies that the chunk manifest is NOT
+// carried in the f: attribute blob (it lives in the sibling fm: key), while the
+// manifest codec round-trips Blocks — including ContentHash bytes — without loss.
+func TestBadgerEncodeFile_ManifestSplit(t *testing.T) {
 	// Build three deterministic content hashes.
 	var h1, h2, h3 block.ContentHash
 	for i := range h1 {
 		h1[i] = byte(i)
 		h2[i] = byte(0xff - i)
 		h3[i] = byte(0xaa)
+	}
+
+	blocks := []block.ChunkRef{
+		{Hash: h1, Offset: 0, Size: 4 * 1024 * 1024},
+		{Hash: h2, Offset: 4 * 1024 * 1024, Size: 4 * 1024 * 1024},
+		{Hash: h3, Offset: 8 * 1024 * 1024, Size: 4 * 1024 * 1024},
 	}
 
 	original := &metadata.File{
@@ -41,11 +47,7 @@ func TestBadgerEncodeFile_BlocksRoundTrip(t *testing.T) {
 			Ctime:        time.Unix(1700000000, 0).UTC(),
 			Atime:        time.Unix(1700000000, 0).UTC(),
 			CreationTime: time.Unix(1700000000, 0).UTC(),
-			Blocks: []block.ChunkRef{
-				{Hash: h1, Offset: 0, Size: 4 * 1024 * 1024},
-				{Hash: h2, Offset: 4 * 1024 * 1024, Size: 4 * 1024 * 1024},
-				{Hash: h3, Offset: 8 * 1024 * 1024, Size: 4 * 1024 * 1024},
-			},
+			Blocks:       blocks,
 		},
 	}
 
@@ -56,21 +58,26 @@ func TestBadgerEncodeFile_BlocksRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, decoded)
 
-	require.Len(t, decoded.Blocks, 3)
-	assert.Equal(t, original.Blocks[0], decoded.Blocks[0])
-	assert.Equal(t, original.Blocks[1], decoded.Blocks[1])
-	assert.Equal(t, original.Blocks[2], decoded.Blocks[2])
+	// The manifest is split out of the attribute blob: encodeFile drops it.
+	assert.Empty(t, decoded.Blocks, "encodeFile must not embed the chunk manifest")
 
-	// Hash bytes preserved exactly.
-	assert.True(t, bytes.Equal(original.Blocks[0].Hash[:], decoded.Blocks[0].Hash[:]))
-	assert.True(t, bytes.Equal(original.Blocks[1].Hash[:], decoded.Blocks[1].Hash[:]))
-	assert.True(t, bytes.Equal(original.Blocks[2].Hash[:], decoded.Blocks[2].Hash[:]))
-
-	// Non-Blocks fields preserved.
+	// Non-Blocks fields still round-trip.
 	assert.Equal(t, original.ID, decoded.ID)
 	assert.Equal(t, original.ShareName, decoded.ShareName)
 	assert.Equal(t, original.Size, decoded.Size)
 	assert.Equal(t, original.Mode, decoded.Mode)
+
+	// The manifest codec (fm: value) round-trips the chunk list exactly.
+	mEnc, err := encodeManifest(blocks)
+	require.NoError(t, err)
+	mDec, err := decodeManifest(mEnc)
+	require.NoError(t, err)
+	require.Len(t, mDec, 3)
+	assert.Equal(t, blocks[0], mDec[0])
+	assert.Equal(t, blocks[1], mDec[1])
+	assert.Equal(t, blocks[2], mDec[2])
+	assert.True(t, bytes.Equal(blocks[0].Hash[:], mDec[0].Hash[:]))
+	assert.True(t, bytes.Equal(blocks[2].Hash[:], mDec[2].Hash[:]))
 
 	// Path is intentionally NOT persisted (#1166): it is always derived from
 	// parent edges on read, so encodeFile zeroes it before serializing. This

--- a/pkg/metadata/store/badger/files.go
+++ b/pkg/metadata/store/badger/files.go
@@ -91,6 +91,50 @@ func copyForRead(f *metadata.File) *metadata.File {
 	return &cp
 }
 
+// loadManifest populates file.Blocks from the fm:<uuid> manifest key. A legacy
+// f: blob that still embeds the manifest arrives with Blocks already set and is
+// left untouched (the next write migrates it to fm:); new-format blobs carry no
+// inline manifest, so the chunk list is read from its sibling key. A missing
+// fm: key means an empty manifest (directory, symlink, or empty regular file).
+func loadManifest(txn *badgerdb.Txn, file *metadata.File) error {
+	if len(file.Blocks) > 0 {
+		return nil // legacy embedded manifest — authoritative for this row
+	}
+	item, err := txn.Get(keyFileManifest(file.ID))
+	if errors.Is(err, badgerdb.ErrKeyNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return item.Value(func(val []byte) error {
+		blocks, derr := decodeManifest(val)
+		if derr != nil {
+			return derr
+		}
+		file.Blocks = blocks
+		return nil
+	})
+}
+
+// putManifest persists (or, when empty, removes) the fm:<uuid> block manifest.
+// An empty manifest — a truncated/empty regular file, a directory, or a symlink
+// — carries no key, so loadManifest reads a missing key as "no blocks". This
+// keeps the manifest coherent when a truncate prunes every chunk.
+func (tx *badgerTransaction) putManifest(id uuid.UUID, blocks []block.ChunkRef) error {
+	if len(blocks) == 0 {
+		if err := tx.txn.Delete(keyFileManifest(id)); err != nil && !errors.Is(err, badgerdb.ErrKeyNotFound) {
+			return err
+		}
+		return nil
+	}
+	data, err := encodeManifest(blocks)
+	if err != nil {
+		return err
+	}
+	return tx.txn.Set(keyFileManifest(id), data)
+}
+
 // PutFile stores or updates file metadata.
 func (s *BadgerMetadataStore) PutFile(ctx context.Context, file *metadata.File) error {
 	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
@@ -170,6 +214,9 @@ func (s *BadgerMetadataStore) GetFileByPayloadID(ctx context.Context, payloadID 
 					// rename/relink can never surface a stale stored path.
 					btx := &badgerTransaction{store: s, txn: txn}
 					file.Path = btx.derivePath(file.ID)
+					if err := loadManifest(txn, file); err != nil {
+						return err
+					}
 					result = file
 					return errFound
 				}
@@ -254,6 +301,9 @@ func (s *BadgerMetadataStore) FindByObjectID(ctx context.Context, objectID block
 
 		f, err := decodeFile(rawFile)
 		if err != nil {
+			return err
+		}
+		if err := loadManifest(txn, f); err != nil {
 			return err
 		}
 

--- a/pkg/metadata/store/badger/manifest_split_test.go
+++ b/pkg/metadata/store/badger/manifest_split_test.go
@@ -1,0 +1,209 @@
+package badger
+
+import (
+	"context"
+	"testing"
+
+	badgerdb "github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// readManifest reads the fm:<uuid> manifest key directly: its badger commit
+// version (which advances on every write, even a same-value rewrite), the
+// decoded block list, and whether the key exists. The version is what proves an
+// attr-only write did NOT touch the manifest.
+func readManifest(t *testing.T, s *BadgerMetadataStore, id [16]byte) (version uint64, blocks []block.ChunkRef, exists bool) {
+	t.Helper()
+	require.NoError(t, s.db.View(func(txn *badgerdb.Txn) error {
+		item, err := txn.Get(keyFileManifest(id))
+		if err == badgerdb.ErrKeyNotFound {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		exists = true
+		version = item.Version()
+		return item.Value(func(val []byte) error {
+			blocks, err = decodeManifest(val)
+			return err
+		})
+	}))
+	return version, blocks, exists
+}
+
+// mkChunkedFile creates a regular file carrying nChunks 1 MiB blocks and returns
+// its handle. The manifest is marked dirty so PutFile persists it to fm:.
+func mkChunkedFile(t *testing.T, store *BadgerMetadataStore, share string, dir metadata.FileHandle, name, path string, nChunks int) metadata.FileHandle {
+	t.Helper()
+	ctx := context.Background()
+	handle, err := store.GenerateHandle(ctx, share, path)
+	require.NoError(t, err)
+	_, id, err := metadata.DecodeFileHandle(handle)
+	require.NoError(t, err)
+
+	blocks := make([]block.ChunkRef, nChunks)
+	for i := range blocks {
+		var h block.ContentHash
+		h[0], h[1] = byte(i), byte(i>>8)
+		blocks[i] = block.ChunkRef{Hash: h, Offset: uint64(i) << 20, Size: 1 << 20}
+	}
+
+	file := &metadata.File{
+		ShareName: share,
+		Path:      path,
+		FileAttr: metadata.FileAttr{
+			Type: metadata.FileTypeRegular, Mode: 0o600, UID: 1000, GID: 1000,
+			Size:        uint64(nChunks) << 20,
+			PayloadID:   metadata.PayloadID(path),
+			Blocks:      blocks,
+			BlocksDirty: true,
+		},
+	}
+	file.ID = id
+	require.NoError(t, store.PutFile(ctx, file))
+	require.NoError(t, store.SetParent(ctx, handle, dir))
+	require.NoError(t, store.SetChild(ctx, dir, name, handle))
+	return handle
+}
+
+// TestManifestSplit_AttrOnlyWriteLeavesManifestUntouched is the load-bearing
+// assertion of the fm: split: a chmod / utimes on a multi-chunk file must not
+// rewrite the manifest. The fm: key's commit version is byte-identical before
+// and after, and the block list is unchanged.
+func TestManifestSplit_AttrOnlyWriteLeavesManifestUntouched(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewBadgerMetadataStoreWithDefaults(ctx, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	root := mkPayloadShare(t, store, "/s")
+	handle := mkChunkedFile(t, store, "/s", root, "big.bin", "/big.bin", 64)
+	_, id, err := metadata.DecodeFileHandle(handle)
+	require.NoError(t, err)
+
+	v0, blocks0, ok := readManifest(t, store, id)
+	require.True(t, ok, "manifest must be persisted for a carved file")
+	require.Len(t, blocks0, 64)
+
+	// Round-trip: GetFile returns the same manifest that was stored.
+	got, err := store.GetFile(ctx, handle)
+	require.NoError(t, err)
+	require.Equal(t, blocks0, got.Blocks, "manifest must round-trip through the split")
+
+	// chmod: attr-only mutation, BlocksDirty stays false.
+	got.Mode = 0o644
+	require.NoError(t, store.PutFile(ctx, got))
+
+	v1, blocks1, ok := readManifest(t, store, id)
+	require.True(t, ok)
+	require.Equal(t, v0, v1, "chmod must not rewrite the manifest (fm: version unchanged)")
+	require.Equal(t, blocks0, blocks1)
+
+	// utimes: another attr-only mutation.
+	got2, err := store.GetFile(ctx, handle)
+	require.NoError(t, err)
+	got2.Mtime = got2.Mtime.Add(1)
+	require.NoError(t, store.PutFile(ctx, got2))
+
+	v2, _, ok := readManifest(t, store, id)
+	require.True(t, ok)
+	require.Equal(t, v0, v2, "utimes must not rewrite the manifest")
+}
+
+// TestManifestSplit_GetByPayloadIDReturnsManifest guards the flush coordinator's
+// contract: badger's GetFileByPayloadID returns the manifest inline, including on
+// the pl: secondary-index fast path.
+func TestManifestSplit_GetByPayloadIDReturnsManifest(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewBadgerMetadataStoreWithDefaults(ctx, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	root := mkPayloadShare(t, store, "/s")
+	mkChunkedFile(t, store, "/s", root, "big.bin", "/big.bin", 12)
+
+	got, err := store.GetFileByPayloadID(ctx, metadata.PayloadID("/big.bin"))
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, got.Blocks, 12, "GetFileByPayloadID must return the manifest inline")
+}
+
+// TestManifestSplit_CarveWritesManifest confirms the gate still persists a
+// genuinely changed manifest (a re-carve marks BlocksDirty).
+func TestManifestSplit_CarveWritesManifest(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewBadgerMetadataStoreWithDefaults(ctx, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	root := mkPayloadShare(t, store, "/s")
+	handle := mkChunkedFile(t, store, "/s", root, "big.bin", "/big.bin", 8)
+	_, id, err := metadata.DecodeFileHandle(handle)
+	require.NoError(t, err)
+
+	v0, _, ok := readManifest(t, store, id)
+	require.True(t, ok)
+
+	got, err := store.GetFile(ctx, handle)
+	require.NoError(t, err)
+	var h block.ContentHash
+	h[0] = 0xEE
+	got.Blocks = append(got.Blocks, block.ChunkRef{Hash: h, Offset: 8 << 20, Size: 1 << 20})
+	got.Size = 9 << 20
+	got.BlocksDirty = true
+	require.NoError(t, store.PutFile(ctx, got))
+
+	v1, blocks1, ok := readManifest(t, store, id)
+	require.True(t, ok)
+	require.NotEqual(t, v0, v1, "a carve must rewrite the manifest")
+	require.Len(t, blocks1, 9)
+
+	reloaded, err := store.GetFile(ctx, handle)
+	require.NoError(t, err)
+	require.Equal(t, blocks1, reloaded.Blocks)
+}
+
+// TestManifestSplit_TruncatePrunes confirms a truncate prunes the manifest, and
+// truncating to zero removes the fm: key entirely.
+func TestManifestSplit_TruncatePrunes(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewBadgerMetadataStoreWithDefaults(ctx, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	root := mkPayloadShare(t, store, "/s")
+	handle := mkChunkedFile(t, store, "/s", root, "big.bin", "/big.bin", 16)
+	_, id, err := metadata.DecodeFileHandle(handle)
+	require.NoError(t, err)
+
+	// Truncate to 4 MiB: prune to the first 4 chunks.
+	got, err := store.GetFile(ctx, handle)
+	require.NoError(t, err)
+	got.Blocks = block.PruneChunkRefsToSize(got.Blocks, 4<<20)
+	got.Size = 4 << 20
+	got.BlocksDirty = true
+	require.NoError(t, store.PutFile(ctx, got))
+
+	_, blocks, ok := readManifest(t, store, id)
+	require.True(t, ok)
+	require.Len(t, blocks, 4, "truncate must prune the manifest")
+
+	// Truncate to zero: the manifest key must be removed.
+	got, err = store.GetFile(ctx, handle)
+	require.NoError(t, err)
+	got.Blocks = block.PruneChunkRefsToSize(got.Blocks, 0)
+	got.Size = 0
+	got.BlocksDirty = true
+	require.NoError(t, store.PutFile(ctx, got))
+
+	_, _, ok = readManifest(t, store, id)
+	require.False(t, ok, "truncate-to-zero must delete the fm: key")
+
+	reloaded, err := store.GetFile(ctx, handle)
+	require.NoError(t, err)
+	require.Empty(t, reloaded.Blocks)
+}

--- a/pkg/metadata/store/badger/manifest_split_test.go
+++ b/pkg/metadata/store/badger/manifest_split_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	badgerdb "github.com/dgraph-io/badger/v4"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/marmos91/dittofs/pkg/block"
@@ -15,7 +16,7 @@ import (
 // version (which advances on every write, even a same-value rewrite), the
 // decoded block list, and whether the key exists. The version is what proves an
 // attr-only write did NOT touch the manifest.
-func readManifest(t *testing.T, s *BadgerMetadataStore, id [16]byte) (version uint64, blocks []block.ChunkRef, exists bool) {
+func readManifest(t *testing.T, s *BadgerMetadataStore, id uuid.UUID) (version uint64, blocks []block.ChunkRef, exists bool) {
 	t.Helper()
 	require.NoError(t, s.db.View(func(txn *badgerdb.Txn) error {
 		item, err := txn.Get(keyFileManifest(id))

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -804,6 +804,12 @@ func enumeratePrefixFileChunks(ctx context.Context, txn *badger.Txn, fn func(blo
 		}); err != nil {
 			return fmt.Errorf("enumerate file chunks: decode file: %w", err)
 		}
+		// The manifest lives in fm:<uuid> (legacy blobs embed it); the GC live
+		// set is fail-closed, so a missed load would let the sweep reap a live
+		// chunk. loadManifest errors must abort the walk, not skip the file.
+		if err := loadManifest(txn, file); err != nil {
+			return fmt.Errorf("enumerate file chunks: load manifest: %w", err)
+		}
 		// nlink=0 (unlinked) inodes keep their f: record but the file is dead.
 		// Excluding their manifest blocks from the GC live set is what lets the
 		// sweep reclaim orphaned chunks (#1433). Snapshot-held blocks are

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -331,6 +331,7 @@ func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName stri
 func deleteFileKeys(txn *badgerdb.Txn, id uuid.UUID, objectID metadata.ContentHash, payloadID metadata.PayloadID) error {
 	keys := [][]byte{
 		keyFile(id),
+		keyFileManifest(id),
 		keyParent(id),
 		keyLinkCount(id),
 	}

--- a/pkg/metadata/store/badger/snapshot_store.go
+++ b/pkg/metadata/store/badger/snapshot_store.go
@@ -126,6 +126,13 @@ func (s *BadgerMetadataStore) WriteSnapshot(ctx context.Context, w io.Writer) (*
 						"key", string(key), "error", err)
 					continue
 				}
+				// The manifest lives in fm:<uuid> (legacy blobs embed it). It
+				// feeds the durability HashSet, so a missed load would ship an
+				// incomplete snapshot — abort rather than silently under-count.
+				if err := loadManifest(txn, file); err != nil {
+					return fmt.Errorf("%w: load manifest for %s: %v",
+						metadata.ErrSnapshotAborted, string(key), err)
+				}
 				// Skip unlinked (nlink=0) files: they are dead and GC may have
 				// already reclaimed their blocks, so adding them would make the
 				// snapshot manifest reference hashes absent from remote and fail

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -242,6 +242,12 @@ func (tx *badgerTransaction) getFile(ctx context.Context, handle metadata.FileHa
 		return nil, err
 	}
 
+	// The chunk manifest lives in the sibling fm:<uuid> key (or, for legacy
+	// blobs, is already embedded and left in place by loadManifest).
+	if err := loadManifest(tx.txn, file); err != nil {
+		return nil, err
+	}
+
 	// Look up the link count and set Nlink on the returned file
 	// The link count is stored separately to support hard links
 	linkItem, linkErr := tx.txn.Get(keyLinkCount(fileID))
@@ -407,6 +413,27 @@ func (tx *badgerTransaction) PutFile(ctx context.Context, file *metadata.File) e
 		return err
 	}
 	tx.dirtyFiles = append(tx.dirtyFiles, file.ID.String())
+
+	// Persist the chunk manifest to fm:<uuid> only when it changed. BlocksDirty
+	// is set by the sites that mutate the manifest (carve/truncate/punch); an
+	// attr-only write leaves it false and skips the rewrite — the write-
+	// amplification fix. When the flag is unset but the file carries blocks with
+	// no manifest key yet, the manifest is still written: this covers a fresh
+	// create and migrates a legacy f: blob off its embedded manifest (the new f:
+	// encoding no longer carries it) without rewriting an already-materialized one.
+	writeManifest := file.BlocksDirty
+	if !writeManifest && len(file.Blocks) > 0 {
+		if _, err := tx.txn.Get(keyFileManifest(file.ID)); goerrors.Is(err, badgerdb.ErrKeyNotFound) {
+			writeManifest = true
+		} else if err != nil {
+			return err
+		}
+	}
+	if writeManifest {
+		if err := tx.putManifest(file.ID, file.Blocks); err != nil {
+			return err
+		}
+	}
 
 	// maintain ObjectID -> file UUID secondary index in the
 	// same Txn as the primary file write (atomic on commit).
@@ -1497,6 +1524,12 @@ func (tx *badgerTransaction) loadEnrichedFileByID(fileID uuid.UUID) (*metadata.F
 			}
 			return nil
 		})
+	}
+
+	// GetFileByPayloadID returns the manifest inline (callers such as the flush
+	// coordinator read File.Blocks off it); load it from fm: like GetFile does.
+	if err := loadManifest(tx.txn, file); err != nil {
+		return nil, err
 	}
 
 	file.Path = tx.derivePath(fileID)


### PR DESCRIPTION
## What

Badger half of #1715 item 8: **separate attribute-write from manifest-write** in the metadata store.

Today a chmod/utimes/close/rename on a many-chunk file rewrites the file's entire block manifest, because encodeFile serializes the whole File — including FileAttr.Blocks — into one f:<uuid> blob, and PutFile re-encodes that blob on every call. For a large file the manifest dominates the blob, so an attr-only change amplifies into a full manifest rewrite.

This PR moves the manifest out of the f: attribute blob into a sibling key.

The SQL half already shipped in #1820 (skip file_block_refs rewrite when the chunk manifest is unchanged, gated on the same BlocksDirty signal). This is the badger half; sqlite/postgres/memory are untouched.

## How

- New badger key **fm:<uuid>** holds the manifest as JSON of []block.ChunkRef. (fb: was already taken by the FileChunk keyspace in objects.go, so fm:.)
- encodeFile no longer writes Blocks into f:. The fBlocks field id survives only as a legacy read shim in decodeFile.
- PutFile writes fm: only when the manifest changed — file.BlocksDirty (set at the carve/truncate/punch sites) — or when the file has blocks but no fm: key yet (fresh create, and lazy migration of a legacy f: blob off its embedded manifest). An attr-only write leaves BlocksDirty false and hits an existing fm: key, so it writes zero manifest bytes.
- Every badger reader of File.Blocks now loads it from fm: (with the legacy-embedded blob taking precedence when present): getFile (backs GetFile/GetFileForRead), GetFileByPayloadID including the pl: index fast path (loadEnrichedFileByID — the flush coordinator reads Blocks off this), FindByObjectID, the fail-closed GC live-set walk (enumeratePrefixFileChunks), and snapshot WriteSnapshot.
- DeleteFile/DeleteShare drop the fm: key (deleteFileKeys); truncate-to-zero prunes it (putManifest deletes on empty). rename/hardlink keep the same inode UUID, so the fm: key rides along untouched.

## Legacy data

Existing f: blobs still embed the manifest. decodeFile keeps a minimal legacy arm that surfaces those blocks; loadManifest leaves them in place; the next PutFile migrates them to fm: (blocks present + no fm: key). Files never rewritten stay legacy-readable — the one migration seam, mirroring the existing decodeFileJSON dual-read shim.

## Verification

New badger tests (manifest_split_test.go) assert, via the fm: key's badger commit version:
- **chmod / utimes on a 64-chunk file writes NO manifest** — the fm: version is byte-identical before and after (the load-bearing assertion). The carve test asserting the version DOES change proves the version mechanism detects real writes, so the equal-version assertion is meaningful.
- a **carve** (BlocksDirty) still writes the new manifest;
- a **truncate** still prunes the manifest, and truncate-to-zero deletes the fm: key;
- **round-trip**: an M-chunk file stores and loads Blocks identically through the split;
- **GetFileByPayloadID returns the manifest inline** (guards the flush-coordinator contract on the pl: fast path).

Green: go build ./..., go vet, go test ./pkg/metadata/... (2657) and ./pkg/block/engine/... (275), go test -race ./pkg/metadata/store/badger/... (520), gofmt clean. The storetest conformance suite passes for badger; memory is unaffected.

Ran the code-simplifier (no changes — already a tight diff) and a code-review pass (no correctness findings; it independently corroborated the GetFileByPayloadID fast-path reader coverage).

Does not close #1715 (multi-wave tracker).
