### PR TITLE
perf(metadata): badger nlink single-source + PutFilesystemMeta error contract

### DIFF
--- a/pkg/metadata/store/badger/encoding.go
+++ b/pkg/metadata/store/badger/encoding.go
@@ -286,7 +286,9 @@ func encodeFile(file *metadata.File) ([]byte, error) {
 	buf = putUvarintField(buf, fMode, uint64(a.Mode))
 	buf = putUvarintField(buf, fUID, uint64(a.UID))
 	buf = putUvarintField(buf, fGID, uint64(a.GID))
-	buf = putUvarintField(buf, fNlink, uint64(a.Nlink))
+	// Nlink is NOT written here — the link count lives in the sibling l:<uuid>
+	// key, which every reader overlays onto the decoded file. The fNlink field
+	// ID survives only in the decoder as a legacy read shim for old records.
 	buf = putUvarintField(buf, fSize, a.Size)
 
 	var err error
@@ -402,6 +404,9 @@ func decodeFileBinary(b []byte) (*metadata.File, error) {
 		case fGID:
 			a.GID = uint32(uvOf(val))
 		case fNlink:
+			// Legacy read shim: current records no longer write this field
+			// (link count lives in the l:<uuid> key and is overlaid on read),
+			// but old records still carry it.
 			a.Nlink = uint32(uvOf(val))
 		case fSize:
 			a.Size = uvOf(val)

--- a/pkg/metadata/store/badger/encoding_test.go
+++ b/pkg/metadata/store/badger/encoding_test.go
@@ -213,6 +213,9 @@ func TestEncodeDecodeFile_AllFields(t *testing.T) {
 	assert.Empty(t, got.Path, "Path must not persist")
 	got.Path = orig.Path // normalize for full-struct compare below
 
+	assert.Zero(t, got.Nlink, "Nlink must not persist (it lives in the l: key)")
+	got.Nlink = orig.Nlink // normalize for full-struct compare below
+
 	// time.Time compares poorly with == across marshal; check each explicitly.
 	for _, tc := range []struct {
 		name string

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -55,6 +55,12 @@ type badgerTransaction struct {
 	// invalidation. A stale entry is a spurious ENOENT (negative) or EEXIST
 	// (positive).
 	dirtyDirents []string
+	// pendingCapabilities holds a filesystem-capabilities value this transaction
+	// wrote to cap:fs. Captured per attempt and applied to the store's in-memory
+	// copy exactly once after a successful commit, like dirtyFiles, so a
+	// conflict-retry or an aborted commit cannot leave GetFilesystemMeta reporting
+	// a value that never reached durable storage.
+	pendingCapabilities *metadata.FilesystemCapabilities
 }
 
 // Maximum number of retries for conflict errors.
@@ -116,6 +122,7 @@ func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx me
 		var dirtyFiles []string
 		var dirtyShares []string
 		var dirtyDirents []string
+		var pendingCapabilities *metadata.FilesystemCapabilities
 		err := s.db.Update(func(txn *badgerdb.Txn) error {
 			tx := &badgerTransaction{store: s, txn: txn}
 			if fnErr := fn(tx); fnErr != nil {
@@ -126,6 +133,7 @@ func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx me
 			dirtyFiles = tx.dirtyFiles
 			dirtyShares = tx.dirtyShares
 			dirtyDirents = tx.dirtyDirents
+			pendingCapabilities = tx.pendingCapabilities
 			return nil
 		})
 
@@ -136,6 +144,12 @@ func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx me
 			}
 			// Apply per-identity usage deltas once, after commit.
 			s.applyQuotaDelta(quotaDelta)
+			// Apply the staged filesystem-capabilities update once, after commit,
+			// so a persist that never committed can't leave the in-memory copy
+			// (read by GetFilesystemMeta) ahead of durable storage.
+			if pendingCapabilities != nil {
+				s.storeCapabilities(*pendingCapabilities)
+			}
 			// Invalidate the read caches for every file / share this transaction
 			// mutated, AFTER the commit so a concurrent reader that saw the
 			// pre-commit value cannot leave it cached (its generation-guarded
@@ -949,9 +963,9 @@ func (tx *badgerTransaction) PutFilesystemMeta(ctx context.Context, shareName st
 	}
 
 	// Persist only the capabilities into the cap:fs singleton; statistics are
-	// dynamic and never stored.
-	tx.SetFilesystemCapabilities(metaSvc.Capabilities)
-	return nil
+	// dynamic and never stored. writeCapabilities updates the in-memory copy so
+	// GetFilesystemMeta stays coherent and returns any encode/persist error.
+	return tx.writeCapabilities(metaSvc.Capabilities)
 }
 
 func (tx *badgerTransaction) GenerateHandle(ctx context.Context, shareName string, path string) (metadata.FileHandle, error) {
@@ -1392,17 +1406,29 @@ func (tx *badgerTransaction) GetFilesystemCapabilities(ctx context.Context, hand
 	return caps, nil
 }
 
+// SetFilesystemCapabilities is the ServerConfig best-effort setter: it persists
+// the capabilities and only logs a failure because the interface is void.
+// Error-sensitive callers use PutFilesystemMeta, which returns the error.
 func (tx *badgerTransaction) SetFilesystemCapabilities(capabilities metadata.FilesystemCapabilities) {
-	tx.store.storeCapabilities(capabilities)
-
-	data, err := encodeFilesystemCapabilities(&capabilities)
-	if err != nil {
-		logger.Error("badger: failed to encode filesystem capabilities", "error", err)
-		return
-	}
-	if err := tx.txn.Set(keyFilesystemCapabilities(), data); err != nil {
+	if err := tx.writeCapabilities(capabilities); err != nil {
 		logger.Error("badger: failed to persist filesystem capabilities", "error", err)
 	}
+}
+
+// writeCapabilities persists the capabilities to the cap:fs singleton and stages
+// the in-memory update, which the enclosing withTransaction applies only after a
+// successful commit so GetFilesystemMeta never reports a value that failed to
+// reach the store. Returns any encode/persist error.
+func (tx *badgerTransaction) writeCapabilities(capabilities metadata.FilesystemCapabilities) error {
+	data, err := encodeFilesystemCapabilities(&capabilities)
+	if err != nil {
+		return fmt.Errorf("encode filesystem capabilities: %w", err)
+	}
+	if err := tx.txn.Set(keyFilesystemCapabilities(), data); err != nil {
+		return fmt.Errorf("persist filesystem capabilities: %w", err)
+	}
+	tx.pendingCapabilities = &capabilities
+	return nil
 }
 
 func (tx *badgerTransaction) GetFilesystemStatistics(ctx context.Context, handle metadata.FileHandle) (*metadata.FilesystemStatistics, error) {


### PR DESCRIPTION
Small badger-metadata hygiene changes from the #1715 Wave 1 cleanup table.

## Commit 1 — item 6: nlink single source of truth
The badger File link count was tracked in BOTH the authoritative `l:<uuid>` key and an `Nlink` field serialized into the `f:` attribute blob — redundant and a divergence risk. `encodeFile` no longer writes `Nlink` into the `f:` blob, so the `l:` key is the single source. The decoder keeps the field as a legacy read shim for existing records.

Every badger reader of `File.Nlink` already overlays the value from the `l:` key (or a default-by-type when the key is absent): `getFile`, `ListChildren`, `GetFileByPayloadID`, `loadEnrichedFileByID`, `loadExistingRoot`/`createNewRoot`, and `CreateRootDirectory`. `fileLinkCountTxn` reads the embedded value only as a corrupt-`l:`-key fallback. The hardlink round-trip is covered by the existing storetest conformance suite (create/link/stat, unlink/stat asserting nlink 2 to 1), which badger runs via TestConformance; the exact round-trip encoding test now asserts `Nlink` no longer persists, mirroring the existing `Path` handling.

## Item 7 — fold SUID/SGID-clear into the deferred flush: SKIPPED
On investigation this does not apply to the badger store. The SUID/SGID clear lives in the shared `pkg/metadata/io.go` write path, not in `pkg/metadata/store/badger/`. In the deferred-commit path it is deliberately a separate immediate write, precisely so a subsequent GETATTR (e.g. an NFSv4 COMPOUND piggybacked GETATTR, whose cache_consistency_bitmask does not include MODE) still shows the cleared bits before the deferred flush runs. Folding it into the pending flush would alter that mode-visibility guarantee. Per the escape hatch, skipped rather than forced. The immediate-commit path already clears the bits inline within its single transaction — nothing to fold there.

## Commit 2 — #1838 Copilot follow-up: PutFilesystemMeta error contract
`PutFilesystemMeta` called the void `SetFilesystemCapabilities` and returned nil even when encode or the underlying `txn.Set` failed, swallowing write errors and breaking the error-returning contract. Both now route through a private `writeCapabilities` helper that persists first and updates the in-memory copy only after the write succeeds, returning any encode/persist error. `PutFilesystemMeta` propagates it; the void `ServerConfig` setter still logs. `GetFilesystemMeta` keeps reading the coherent in-memory copy.

## Verification
- go build ./..., go vet ./pkg/metadata/..., gofmt clean
- go test ./pkg/metadata/... (2657 pass)
- go test -race ./pkg/metadata/store/badger/... (520 pass)
- storetest conformance suite green for badger; memory/sqlite/postgres unaffected

Does not close #1715.