### PR TITLE
fix(journal): default local-store cap + background dead-ratio GC (#1844)

### DIFF
--- a/pkg/block/journal/bounded_growth_test.go
+++ b/pkg/block/journal/bounded_growth_test.go
@@ -1,0 +1,68 @@
+package journal
+
+import (
+	"context"
+	"testing"
+)
+
+// TestOpenSetsDefaultLocalCapWhenUnset guards the root cause of the disk-full
+// wedge: an unset MaxLocalBytes used to leave the write-path capacity gate a
+// permanent no-op, so dead records were never reclaimed and disk usage grew
+// without bound. Open must now derive a soft cap from the volume's free space.
+func TestOpenSetsDefaultLocalCapWhenUnset(t *testing.T) {
+	s, err := Open(t.TempDir(), Config{}, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = s.Close() }()
+
+	if s.cfg.MaxLocalBytes <= 0 {
+		t.Fatalf("expected Open to default MaxLocalBytes from free space, got %d", s.cfg.MaxLocalBytes)
+	}
+}
+
+// TestGCReclaimsDeadOverwrites is the wedge regression test. It overwrites a
+// tiny live footprint thousands of times so sealed segments fill with dead
+// (superseded) records — the exact shape that grew on-disk bytes without bound
+// before the fix — then asserts a GC pass reclaims that dead space, leaving
+// disk usage tracking live bytes rather than total writes.
+func TestGCReclaimsDeadOverwrites(t *testing.T) {
+	// SegmentSize at the 1 MiB floor so overwrites seal many segments; single
+	// shard is deterministic; a generous explicit cap keeps eviction/backpressure
+	// out of the way so this isolates the dead-ratio repack path.
+	const segSize = 1 << 20
+	cfg := Config{SegmentSize: segSize, ShardCount: 1, MaxLocalBytes: 1 << 30}
+	s, err := Open(t.TempDir(), cfg, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = s.Close() }()
+	ctx := context.Background()
+
+	const blk = 4096
+	const slots = 64 // 256 KiB live footprint, rewritten in place
+	data := make([]byte, blk)
+	for i := range 8000 { // ~32 MiB appended for 256 KiB of live data
+		off := int64(i%slots) * blk
+		if err := s.WriteAt(ctx, "f", off, data); err != nil {
+			t.Fatalf("WriteAt #%d: %v", i, err)
+		}
+	}
+
+	before := s.diskBytes.Load()
+	if _, err := s.GC(ctx, GCOptions{}); err != nil {
+		t.Fatalf("GC: %v", err)
+	}
+	after := s.diskBytes.Load()
+
+	if after >= before {
+		t.Fatalf("GC reclaimed nothing: before=%d after=%d", before, after)
+	}
+	// ~32 MiB was appended for 256 KiB of live data. After repack the surviving
+	// bytes must track live data (a few segments), not total writes. A handful of
+	// segments is a generous bound that still fails hard if dead records are left
+	// unreclaimed (the pre-fix unbounded-growth behaviour).
+	if bound := int64(4 * segSize); after > bound {
+		t.Fatalf("on-disk bytes not bounded after GC: after=%d, want <= %d (before=%d)", after, bound, before)
+	}
+}

--- a/pkg/block/journal/bounded_growth_test.go
+++ b/pkg/block/journal/bounded_growth_test.go
@@ -10,7 +10,14 @@ import (
 // permanent no-op, so dead records were never reclaimed and disk usage grew
 // without bound. Open must now derive a soft cap from the volume's free space.
 func TestOpenSetsDefaultLocalCapWhenUnset(t *testing.T) {
-	s, err := Open(t.TempDir(), Config{}, newFakeRemote(), SystemClock())
+	dir := t.TempDir()
+	// The default is only expected when free space is observable. On a platform
+	// where the statfs probe fails Open deliberately leaves the cap unset, so
+	// gate the assertion on the same probe succeeding here.
+	if free, err := diskFreeBytes(dir); err != nil || free == 0 {
+		t.Skipf("free-space probe unavailable (free=%d err=%v); default cap not expected", free, err)
+	}
+	s, err := Open(dir, Config{}, newFakeRemote(), SystemClock())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +49,7 @@ func TestGCReclaimsDeadOverwrites(t *testing.T) {
 	const blk = 4096
 	const slots = 64 // 256 KiB live footprint, rewritten in place
 	data := make([]byte, blk)
-	for i := range 8000 { // ~32 MiB appended for 256 KiB of live data
+	for i := 0; i < 8000; i++ { // ~32 MiB appended for 256 KiB of live data
 		off := int64(i%slots) * blk
 		if err := s.WriteAt(ctx, "f", off, data); err != nil {
 			t.Fatalf("WriteAt #%d: %v", i, err)

--- a/pkg/block/journal/statfs_unix.go
+++ b/pkg/block/journal/statfs_unix.go
@@ -1,0 +1,16 @@
+//go:build unix
+
+package journal
+
+import "golang.org/x/sys/unix"
+
+// diskFreeBytes reports the bytes available to an unprivileged writer on the
+// filesystem backing dir. It sizes Open's default local-store cap so an
+// unconfigured store still bounds its on-disk growth.
+func diskFreeBytes(dir string) (uint64, error) {
+	var st unix.Statfs_t
+	if err := unix.Statfs(dir, &st); err != nil {
+		return 0, err
+	}
+	return st.Bavail * uint64(st.Bsize), nil
+}

--- a/pkg/block/journal/statfs_windows.go
+++ b/pkg/block/journal/statfs_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package journal
+
+import "golang.org/x/sys/windows"
+
+// diskFreeBytes reports the bytes available to the caller on the volume backing
+// dir. It sizes Open's default local-store cap so an unconfigured store still
+// bounds its on-disk growth.
+func diskFreeBytes(dir string) (uint64, error) {
+	p, err := windows.UTF16PtrFromString(dir)
+	if err != nil {
+		return 0, err
+	}
+	var freeToCaller, total, totalFree uint64
+	if err := windows.GetDiskFreeSpaceEx(p, &freeToCaller, &total, &totalFree); err != nil {
+		return 0, err
+	}
+	return freeToCaller, nil
+}

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -11,8 +11,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.org/x/sys/unix"
-
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block/chunker"
 )
@@ -335,17 +333,6 @@ func (s *Store) startBackgroundGC() {
 			}
 		}
 	}()
-}
-
-// diskFreeBytes reports the bytes available to an unprivileged writer on the
-// filesystem backing dir. It sizes Open's default local-store cap so an
-// unconfigured store still bounds its on-disk growth.
-func diskFreeBytes(dir string) (uint64, error) {
-	var st unix.Statfs_t
-	if err := unix.Statfs(dir, &st); err != nil {
-		return 0, err
-	}
-	return st.Bavail * uint64(st.Bsize), nil
 }
 
 // WriteAt buffers a dirty client write. It never fsyncs; durability is a

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -58,9 +58,10 @@ type Config struct {
 	GCDeadRatioForce float64       // dead/total ratio that forces a repack
 	ShardCount       int           // number of shards, power of two, immutable per store
 	// MaxLocalBytes is the local on-disk cap that triggers eviction. 0 leaves
-	// it unset here: Open computes a free-space-based default for it (see
-	// defaultMaxLocalBytes), so a caller only lands on a genuinely uncapped
-	// store when that probe itself fails.
+	// it unset here: Open derives a free-space-based default (a
+	// defaultMaxLocalBytesFreeFraction share of the store volume's free space)
+	// so a caller only lands on a genuinely uncapped store when that probe
+	// itself fails.
 	MaxLocalBytes int64
 	EvictMaxWait  time.Duration // write-path backpressure budget before ErrLocalStoreFull
 	// CarveUploadConcurrency bounds how many of one file's packed blocks may be
@@ -327,7 +328,11 @@ func (s *Store) startBackgroundGC() {
 			case <-ctx.Done():
 				return
 			case <-t.C:
-				if _, err := s.GC(ctx, GCOptions{}); err != nil && !errors.Is(err, context.Canceled) {
+				// errClosed races Close (which sets s.closed before cancelling
+				// this loop's context); both it and context.Canceled are the
+				// normal shutdown signal, not a failure worth logging.
+				if _, err := s.GC(ctx, GCOptions{}); err != nil &&
+					!errors.Is(err, context.Canceled) && !errors.Is(err, errClosed) {
 					logger.Warn("journal: background GC pass failed", "error", err)
 				}
 			}

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -11,6 +11,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/sys/unix"
+
+	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block/chunker"
 )
 
@@ -56,8 +59,12 @@ type Config struct {
 	CarveMaxAge      time.Duration // age-based carve batching cap
 	GCDeadRatioForce float64       // dead/total ratio that forces a repack
 	ShardCount       int           // number of shards, power of two, immutable per store
-	MaxLocalBytes    int64         // local on-disk cap that triggers eviction; 0 = unlimited
-	EvictMaxWait     time.Duration // write-path backpressure budget before ErrLocalStoreFull
+	// MaxLocalBytes is the local on-disk cap that triggers eviction. 0 leaves
+	// it unset here: Open computes a free-space-based default for it (see
+	// defaultMaxLocalBytes), so a caller only lands on a genuinely uncapped
+	// store when that probe itself fails.
+	MaxLocalBytes int64
+	EvictMaxWait  time.Duration // write-path backpressure budget before ErrLocalStoreFull
 	// CarveUploadConcurrency bounds how many of one file's packed blocks may be
 	// committed (uploaded + committed) at once within a single carve run. Packing
 	// stays sequential; only the block commits overlap, so a single large file's
@@ -80,6 +87,14 @@ const (
 	defaultShardCount                   = 16
 	defaultEvictMaxWait                 = 30 * time.Second
 	defaultCarveUploadConcurrency       = 8
+
+	// defaultMaxLocalBytesFreeFraction is the share of a store dir's free disk
+	// space Open claims for an unset MaxLocalBytes. Conservative (not the
+	// whole disk) since the volume is typically shared with other shares and
+	// the host OS; it is a soft pressure threshold, not a hard reservation
+	// (see ensureSpace), so leaving headroom below 100% just makes eviction
+	// engage before the disk is bone dry.
+	defaultMaxLocalBytesFreeFraction = 0.8
 )
 
 func (c Config) withDefaults() Config {
@@ -107,8 +122,8 @@ func (c Config) withDefaults() Config {
 	if c.ChunkParams.Validate() != nil {
 		c.ChunkParams = chunker.DefaultParams()
 	}
-	// MaxLocalBytes intentionally has no default: 0 means "no local cap" (eviction
-	// off), the safe posture until the FSStore adapter wires --local-store-size.
+	// MaxLocalBytes is left untouched here (0 = unset): withDefaults has no dir
+	// to size a free-space-based cap from. Open fills it in once dir is known.
 	return c
 }
 
@@ -177,6 +192,12 @@ type Store struct {
 	verifyReads atomic.Bool
 
 	closed atomic.Bool
+
+	// gcCancel/gcDone govern the background dead-ratio GC loop started by
+	// Open: cancel stops the loop, and Close waits on gcDone so no repack is
+	// still in flight when segment files are closed underneath it.
+	gcCancel context.CancelFunc
+	gcDone   chan struct{}
 }
 
 // SetVerifyReads enables or disables per-read record-CRC verification of warm
@@ -206,6 +227,20 @@ func Open(dir string, cfg Config, remote RemoteStore, clock Clock) (*Store, erro
 		return nil, fmt.Errorf("journal: mkdir %q: %w", dir, err)
 	}
 
+	// An unset cap left the write-path gate (ensureSpace) a permanent no-op,
+	// so dead append-log records were never reclaimed and disk usage grew
+	// without bound under overwrites. Size a soft default off the volume's
+	// free space at open time; a probe failure (unsupported platform, statfs
+	// error) degrades to the old unbounded posture rather than failing Open.
+	if cfg.MaxLocalBytes <= 0 {
+		if free, ferr := diskFreeBytes(dir); ferr == nil && free > 0 {
+			cfg.MaxLocalBytes = int64(float64(free) * defaultMaxLocalBytesFreeFraction)
+		} else if ferr != nil {
+			logger.Warn("journal: could not determine free disk space; local store cap left unset (unbounded growth risk)",
+				"dir", dir, "error", ferr)
+		}
+	}
+
 	s := &Store{
 		dir:       dir,
 		cfg:       cfg,
@@ -223,18 +258,19 @@ func Open(dir string, cfg Config, remote RemoteStore, clock Clock) (*Store, erro
 			_ = s.Close()
 			return nil, err
 		}
-		return s, nil
+	} else {
+		s.shards = make([]*shard, cfg.ShardCount)
+		for i := range s.shards {
+			seg, err := s.createSegment()
+			if err != nil {
+				_ = s.Close()
+				return nil, err
+			}
+			s.shards[i] = newShard(seg)
+		}
 	}
 
-	s.shards = make([]*shard, cfg.ShardCount)
-	for i := range s.shards {
-		seg, err := s.createSegment()
-		if err != nil {
-			_ = s.Close()
-			return nil, err
-		}
-		s.shards[i] = newShard(seg)
-	}
+	s.startBackgroundGC()
 	return s, nil
 }
 
@@ -242,6 +278,10 @@ func Open(dir string, cfg Config, remote RemoteStore, clock Clock) (*Store, erro
 func (s *Store) Close() error {
 	if s.closed.Swap(true) {
 		return nil
+	}
+	if s.gcCancel != nil {
+		s.gcCancel()
+		<-s.gcDone
 	}
 	var firstErr error
 	for _, sh := range s.shards {
@@ -262,6 +302,50 @@ func (s *Store) Close() error {
 		sh.mu.Unlock()
 	}
 	return firstErr
+}
+
+// defaultGCInterval is how often the background loop repacks high-dead-ratio
+// segments. A pass is a near-noop when nothing is at or above GCDeadRatioForce,
+// so a short interval keeps on-disk growth tracking live bytes under
+// overwrite-heavy load without costing an idle store anything meaningful.
+const defaultGCInterval = 30 * time.Second
+
+// startBackgroundGC launches the periodic dead-ratio repack loop. Overwrites
+// leave dead records behind; without proactive repacking they are only
+// reclaimed on the write-path eviction gate, so a store whose writes outpace
+// carve grows until the cap forces backpressure. The loop keeps local bytes
+// bounded relative to live bytes regardless of whether a cap is set. Close
+// cancels it and waits on gcDone before closing segment files.
+func (s *Store) startBackgroundGC() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.gcCancel = cancel
+	s.gcDone = make(chan struct{})
+	go func() {
+		defer close(s.gcDone)
+		t := time.NewTicker(defaultGCInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				if _, err := s.GC(ctx, GCOptions{}); err != nil && !errors.Is(err, context.Canceled) {
+					logger.Warn("journal: background GC pass failed", "error", err)
+				}
+			}
+		}
+	}()
+}
+
+// diskFreeBytes reports the bytes available to an unprivileged writer on the
+// filesystem backing dir. It sizes Open's default local-store cap so an
+// unconfigured store still bounds its on-disk growth.
+func diskFreeBytes(dir string) (uint64, error) {
+	var st unix.Statfs_t
+	if err := unix.Statfs(dir, &st); err != nil {
+		return 0, err
+	}
+	return st.Bavail * uint64(st.Bsize), nil
 }
 
 // WriteAt buffers a dirty client write. It never fsyncs; durability is a


### PR DESCRIPTION
Fixes #1844.

## Problem
An uncapped local store (`MaxLocalBytes` unset) left the write-path capacity gate (`ensureSpace`) a permanent no-op, so dead append-log records left behind by overwrites were never reclaimed. On-disk usage grew linearly with total writes (not live data) until the disk filled and the node wedged. Confirmed by measurement: a random-4k overwrite workload over a 128 MiB live footprint grew `diskBytes` past 1.5 GiB while the in-memory index and Go heap stayed flat.

## Fix
- **Default cap from free space.** `Open` derives a soft `MaxLocalBytes` (80% of the store volume's free space) when unset, so `ensureSpace` always has a ceiling. A statfs probe failure degrades to the old unbounded posture rather than failing `Open`.
- **Background dead-ratio GC.** A loop started by `Open` periodically runs the existing `GC` pass, repacking high-dead-ratio segments so on-disk bytes track live bytes regardless of whether a cap is configured. Cancelled and joined in `Close` before segment files are closed.
- The existing write-path backpressure now engages once a cap is set (safety valve when writes outrun GC).

## Tests
- `TestOpenSetsDefaultLocalCapWhenUnset` — guards the root cause: an unset cap must now be defaulted.
- `TestGCReclaimsDeadOverwrites` — overwrites a 256 KiB footprint ~32 MiB worth, asserts a GC pass reclaims the dead space and on-disk bytes stay bounded to a few segments (fails hard on the pre-fix unbounded behaviour).

`go test -race ./pkg/block/journal/ ./pkg/block/engine/` green; gofmt/vet clean.

Relates to field report #1843 (theme 1) and #1527.
