### PR TITLE
fix(block): bound demand cold-read fetch to fail fast on a stalled remote

### DIFF
--- a/pkg/block/engine/cold_read_demand_timeout_test.go
+++ b/pkg/block/engine/cold_read_demand_timeout_test.go
@@ -1,0 +1,100 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	memorylocal "github.com/marmos91/dittofs/pkg/block/local/memory"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	metastore "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// blockingRemote models a remote whose GET has stalled after the pre-check
+// health gate passed: ReadChunk parks until its context is cancelled, then
+// reports the cancellation. A real S3 client eventually gives up only after its
+// per-request timeout times its retry budget (minutes); this fake stands in for
+// "the fetch does not return on any timescale a protocol client tolerates". A
+// safety valve caps the park so a regression cannot wedge the whole suite.
+type blockingRemote struct {
+	*remotememory.Store
+	started chan struct{}
+	once    sync.Once
+}
+
+func newBlockingRemote() *blockingRemote {
+	return &blockingRemote{Store: remotememory.New(), started: make(chan struct{})}
+}
+
+func (r *blockingRemote) ReadChunk(ctx context.Context, _ string, _, _ int64, _ block.ContentHash) ([]byte, error) {
+	r.once.Do(func() { close(r.started) })
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(30 * time.Second):
+		return nil, errors.New("blockingRemote safety valve fired")
+	}
+}
+
+var (
+	_ remote.RemoteStore      = (*blockingRemote)(nil)
+	_ remote.RemoteBlockStore = (*blockingRemote)(nil)
+	_ remote.ChunkReader      = (*blockingRemote)(nil)
+)
+
+// TestNewSyncer_DefaultsDemandFetchTimeout guards against the bound being dead
+// in production: a config that leaves DemandFetchTimeout unset (every path that
+// does not thread the field, e.g. pkg/config) must still get the default, or
+// EnsureAvailableAndRead would run unbounded and the hang would return.
+func TestNewSyncer_DefaultsDemandFetchTimeout(t *testing.T) {
+	fbs := newStubFileChunkStore()
+	m := NewSyncer(memorylocal.New(), remotememory.New(), fbs, SyncerConfig{})
+	if m.config.DemandFetchTimeout != DefaultDemandFetchTimeout {
+		t.Fatalf("NewSyncer left DemandFetchTimeout = %v; want default %v",
+			m.config.DemandFetchTimeout, DefaultDemandFetchTimeout)
+	}
+}
+
+// TestColdRead_DemandFetchFailsFastWhenRemoteStalls pins the fix for the
+// client-visible hang: a demand cold read must not block indefinitely on a
+// stalled remote just because the caller's context carries no sub-deadline.
+// EnsureAvailableAndRead bounds its own hydration to DemandFetchTimeout and
+// surfaces ErrRemoteUnavailable when that budget is exceeded, so the protocol
+// layer returns a fast error instead of the mount wedging. Before the fix the
+// demand fan-out ran on the caller's unbounded context, so with a background
+// context the read never returned.
+func TestColdRead_DemandFetchFailsFastWhenRemoteStalls(t *testing.T) {
+	ctx := context.Background() // no sub-deadline, as a protocol read effectively has
+
+	loc := memorylocal.New()
+	rs := newBlockingRemote()
+	fbs := newStubFileChunkStore()
+	mds := metastore.NewMemoryMetadataStoreWithDefaults()
+
+	chunk := make([]byte, 4096)
+	seedSyncedRemoteChunk(t, fbs, rs, mds, "p", 0, chunk)
+
+	m := newFetchSyncer(loc, rs, fbs, mds)
+	m.config.PrefetchBlocks = 0                          // isolate the demand loop
+	m.config.DemandFetchTimeout = 200 * time.Millisecond // short fail-fast budget under test
+
+	dest := make([]byte, 4096)
+	done := make(chan error, 1)
+	go func() {
+		_, err := m.EnsureAvailableAndRead(ctx, "p", 0, uint32(len(dest)), dest)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, block.ErrRemoteUnavailable) {
+			t.Fatalf("demand read returned %v; want ErrRemoteUnavailable (fail-fast on stalled remote)", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("demand read did not return within 5s while remote stalled — client-visible hang reproduced")
+	}
+}

--- a/pkg/block/engine/cold_read_demand_timeout_test.go
+++ b/pkg/block/engine/cold_read_demand_timeout_test.go
@@ -68,7 +68,7 @@ func TestNewSyncer_DefaultsDemandFetchTimeout(t *testing.T) {
 // demand fan-out ran on the caller's unbounded context, so with a background
 // context the read never returned.
 func TestColdRead_DemandFetchFailsFastWhenRemoteStalls(t *testing.T) {
-	ctx := context.Background() // no sub-deadline, as a protocol read effectively has
+	ctx := context.Background() // a protocol read's context carries no sub-deadline
 
 	loc := memorylocal.New()
 	rs := newBlockingRemote()

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -412,7 +412,23 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 	//
 	// Readahead is driven from Store.ReadAt on EVERY read (scheduleReadahead),
 	// so the demand path no longer schedules prefetch here.
-	g, gctx := m.fetchGroup(ctx)
+	//
+	// Bound the client-blocking fan-out to DemandFetchTimeout. The health gate
+	// above is only a pre-check: a remote can stall AFTER it passes, and the
+	// remote client's own retry budget (per-request timeout times max attempts)
+	// runs to minutes — far past a protocol client's "server not responding"
+	// deadline, so an unbounded fetch here wedges the mount. The bound derives
+	// from the caller's context, so a real client cancel still wins; only when
+	// our budget fires while the caller is still live do we treat it as an
+	// outage. Background prefetch and explicit warm are NOT bounded by this —
+	// they never block a client.
+	fetchCtx := ctx
+	if d := m.config.DemandFetchTimeout; d > 0 {
+		var cancel context.CancelFunc
+		fetchCtx, cancel = context.WithTimeout(ctx, d)
+		defer cancel()
+	}
+	g, gctx := m.fetchGroup(fetchCtx)
 	for _, p := range toFetch {
 		if gctx.Err() != nil {
 			break // first error/cancel: stop scheduling the remaining chunks
@@ -424,6 +440,16 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 		})
 	}
 	if err := g.Wait(); err != nil {
+		// Our demand budget fired while the caller's own context is still live:
+		// the remote stalled mid-fetch. Surface it as unavailability so the
+		// client fails fast, rather than letting a deadline error bubble up as a
+		// generic read failure. A caller-initiated cancel (ctx already done) is
+		// returned unchanged.
+		if ctx.Err() == nil && errors.Is(err, context.DeadlineExceeded) {
+			m.offlineReadsBlocked.Add(1)
+			m.logOfflineRead("EnsureAvailableAndRead", payloadID, offset/uint64(BlockSize))
+			return false, m.remoteUnavailableError()
+		}
 		return false, err
 	}
 

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -440,12 +440,16 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 		})
 	}
 	if err := g.Wait(); err != nil {
-		// Our demand budget fired while the caller's own context is still live:
-		// the remote stalled mid-fetch. Surface it as unavailability so the
-		// client fails fast, rather than letting a deadline error bubble up as a
-		// generic read failure. A caller-initiated cancel (ctx already done) is
-		// returned unchanged.
-		if ctx.Err() == nil && errors.Is(err, context.DeadlineExceeded) {
+		// Distinguish "our demand budget fired" from every other failure by the
+		// DERIVED context, not by matching the error: fetchCtx.Err() is non-nil
+		// only when the budget deadline (or a parent cancel) tripped, and pairing
+		// it with a still-live caller context isolates the budget case from a
+		// caller-initiated cancel. Matching errors.Is(err, DeadlineExceeded)
+		// instead would also catch a deadline surfaced from inside the remote
+		// client and mislabel its origin. When our budget fired the remote
+		// stalled mid-fetch, so surface it as unavailability (fast client error)
+		// rather than a generic read failure; anything else is returned unchanged.
+		if fetchCtx.Err() != nil && ctx.Err() == nil {
 			m.offlineReadsBlocked.Add(1)
 			m.logOfflineRead("EnsureAvailableAndRead", payloadID, offset/uint64(BlockSize))
 			return false, m.remoteUnavailableError()

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -175,6 +175,9 @@ func NewSyncer(local local.LocalStore, remoteStore remote.RemoteStore, fileChunk
 	if config.PrefetchBlocks <= 0 {
 		config.PrefetchBlocks = DefaultPrefetchBlocks
 	}
+	if config.DemandFetchTimeout <= 0 {
+		config.DemandFetchTimeout = DefaultDemandFetchTimeout
+	}
 	// — apply CAS-path defaults.
 	if config.ClaimTimeout <= 0 {
 		config.ClaimTimeout = 10 * time.Minute

--- a/pkg/block/engine/types.go
+++ b/pkg/block/engine/types.go
@@ -42,6 +42,14 @@ const (
 // resizes the upload window (#1407).
 const uploadControlInterval = 500 * time.Millisecond
 
+// DefaultDemandFetchTimeout bounds a single client-blocking cold read's remote
+// hydration. It is well under a protocol client's "server not responding"
+// window (SMB2/CIFS treats ~180s of silence as a dead server) so a stalled
+// remote surfaces as a fast ErrRemoteUnavailable rather than a wedged mount,
+// yet generous enough that a legitimately slow WAN fetch of a read window
+// still completes.
+const DefaultDemandFetchTimeout = 60 * time.Second
+
 // DefaultPrefetchBlocks is the default number of blocks to prefetch.
 // 64 blocks = 512MB lookahead at 8MB block size.
 const DefaultPrefetchBlocks = 64
@@ -107,6 +115,18 @@ type SyncerConfig struct {
 	// bounds, crash-replay).
 	ManualSync bool
 
+	// DemandFetchTimeout bounds a single client-blocking cold read's remote
+	// hydration. A demand read (ReadAt over not-local bytes) fetches every
+	// covering chunk from the remote inline; if the remote stalls after the
+	// pre-check health gate passed, that fetch would otherwise block for the
+	// remote client's full per-request timeout times its retry budget — minutes,
+	// far past a protocol client's "server not responding" deadline, so the
+	// mount wedges. Bounding the demand fan-out to this budget makes the read
+	// fail fast with ErrRemoteUnavailable instead of hanging. Background
+	// prefetch and explicit warm are NOT bounded by this (they never block a
+	// client). <= 0 falls back to DefaultDemandFetchTimeout.
+	DemandFetchTimeout time.Duration
+
 	// Health check configuration for remote store monitoring.
 	HealthCheckInterval         time.Duration // Probe interval when healthy (default: 30s)
 	HealthCheckFailureThreshold int           // Consecutive failures to mark unhealthy (default: 3)
@@ -130,6 +150,7 @@ func DefaultConfig() SyncerConfig {
 		UploadDelay:                 10 * time.Second,
 		BlockCarveBytes:             DefaultBlockCarveBytes,
 		ParallelUploads:             AdaptiveUploadDefault,
+		DemandFetchTimeout:          DefaultDemandFetchTimeout,
 		HealthCheckInterval:         30 * time.Second,
 		HealthCheckFailureThreshold: 3,
 		UnhealthyCheckInterval:      5 * time.Second,


### PR DESCRIPTION
## Problem

A cold read (`Store.ReadAt` over bytes no longer in the local tier) hydrates every covering chunk from the remote **inline**, while the protocol client blocks. `EnsureAvailableAndRead` is that demand path. It ran the fetch fan-out on the **caller's context**, which for an SMB/NFS read carries no sub-deadline.

The health gate (`IsRemoteHealthy()`) before the fan-out is only a **pre-check**. If the remote stalls *after* it passes, the fetch blocks for the S3 client's per-request timeout (2m) × retry budget (10) = **minutes** — far past a protocol client's "server not responding" deadline (SMB2/CIFS ~180s). The mount wedges. This matches the field reports in #1843 (theme 4) and the SMB3 large-read benchmark cell that hung.

## Fix

Bound **only** the client-blocking demand fan-out with a `DemandFetchTimeout` budget (default `60s`, well under the ~180s SMB window):

- On timeout, the fetch is cancelled and the read fails fast with `ErrRemoteUnavailable` (which `content_errmap.go` maps to a proper SMB/NFS error) instead of hanging.
- A **real caller cancel still wins** — the discriminator is `ctx.Err() == nil && errors.Is(err, context.DeadlineExceeded)`, so only our own budget firing (not a client cancel) is treated as an outage.
- Background prefetch (`SyncQueue`) and explicit `WarmAll` are **not** bounded — they never block a client.
- `NewSyncer` defaults the field so **no construction path can silently disable the bound** (the same lesson as the wedge fix's `MaxLocalBytes` default).

## Reproduce-first

`cold_read_demand_timeout_test.go` was written **before** the fix with a `blockingRemote` (a GET that parks): it confirmed the demand read never returns on the old code ("client-visible hang reproduced"), then the fix makes it fail fast. A second test pins the `NewSyncer` default so the bound can't regress to disabled.

All 276 engine tests pass with `-race`.

Closes #1845.
