### PR TITLE
perf(metadata): narrow the WRITE hot path off GetFile+PutFile

### DIFF
--- a/pkg/metadata/data_write.go
+++ b/pkg/metadata/data_write.go
@@ -1,0 +1,20 @@
+package metadata
+
+import (
+	"context"
+	"time"
+)
+
+// DataWriteApplier is the hot-path metadata update for a data WRITE. A store
+// transaction implements it to collapse the read-modify-write a WRITE performs
+// — grow size to max(old, new), stamp mtime/ctime, optionally clear setuid/setgid
+// — into a single narrow statement, instead of GetFile (full-row read) plus
+// PutFile (full-row rewrite). It returns the resulting size so the caller can
+// synthesize post-op attrs without reading the row back.
+//
+// Optional: transactions that do not implement it fall back to GetFile+PutFile.
+// Only regular files are affected; a missing or non-regular target returns
+// ErrNotFound.
+type DataWriteApplier interface {
+	ApplyDataWrite(ctx context.Context, handle FileHandle, newSize uint64, now time.Time, clearSUID bool) (finalSize uint64, err error)
+}

--- a/pkg/metadata/data_write.go
+++ b/pkg/metadata/data_write.go
@@ -13,8 +13,9 @@ import (
 // synthesize post-op attrs without reading the row back.
 //
 // Optional: transactions that do not implement it fall back to GetFile+PutFile.
-// Only regular files are affected; a missing or non-regular target returns
-// ErrNotFound.
+// Only regular files are affected: a missing target returns ErrNotFound, and a
+// target that exists but is not a regular file returns ErrIsDirectory and is
+// left untouched.
 type DataWriteApplier interface {
 	ApplyDataWrite(ctx context.Context, handle FileHandle, newSize uint64, now time.Time, clearSUID bool) (finalSize uint64, err error)
 }

--- a/pkg/metadata/deferred_flush_applier_test.go
+++ b/pkg/metadata/deferred_flush_applier_test.go
@@ -1,0 +1,95 @@
+package metadata_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
+	"github.com/stretchr/testify/require"
+)
+
+// newApplierFixture builds a Service over a sqlite store. sqlite implements
+// DataWriteApplier, so the deferred pending-write flush takes the narrow
+// single-statement path rather than the GetFile+PutFile fallback. The memory
+// store used by the other service tests does not implement it, so this is the
+// only place the fast path is exercised end to end through the Service.
+func newApplierFixture(t *testing.T) (*metadata.Service, metadata.Store, metadata.FileHandle, string) {
+	t.Helper()
+	ctx := context.Background()
+	store, err := sqlite.NewSQLiteMetadataStore(ctx,
+		&sqlite.SQLiteMetadataStoreConfig{Path: filepath.Join(t.TempDir(), "m.db"), AutoMigrate: true},
+		metadata.FilesystemCapabilities{
+			MaxReadSize: 1048576, PreferredReadSize: 1048576,
+			MaxWriteSize: 1048576, PreferredWriteSize: 1048576,
+			MaxFileSize: 1 << 62, MaxFilenameLen: 255,
+			MaxPathLen: 4096, MaxHardLinkCount: 32767,
+			SupportsHardLinks: true, SupportsSymlinks: true,
+			CaseSensitive: true, CasePreserving: true, TimestampResolution: 1,
+		})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	const share = "/applier"
+	root, err := store.CreateRootDirectory(ctx, share,
+		&metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0777})
+	require.NoError(t, err)
+	rootHandle, err := metadata.EncodeShareHandle(share, root.ID)
+	require.NoError(t, err)
+
+	svc := metadata.New()
+	require.NoError(t, svc.RegisterStoreForShare(share, store))
+	return svc, store, rootHandle, share
+}
+
+// TestDeferredFlushAppliesNarrowWrite covers the default write path: deferred
+// commits are on by default, so a WRITE buffers into the pending-write tracker
+// and only the flush touches the store. It asserts the flush persists what the
+// GetFile+PutFile fallback would have persisted — size grown, times stamped,
+// and no shrink when a later write lands at a lower offset.
+func TestDeferredFlushAppliesNarrowWrite(t *testing.T) {
+	svc, store, rootHandle, _ := newApplierFixture(t)
+	ctx := &metadata.AuthContext{
+		Context:    context.Background(),
+		AuthMethod: "unix",
+		Identity: &metadata.Identity{
+			UID: metadata.Uint32Ptr(0), GID: metadata.Uint32Ptr(0), GIDs: []uint32{0},
+		},
+		ClientAddr: "127.0.0.1",
+	}
+
+	_, _, err := svc.CreateFile(ctx, rootHandle, "w.bin", &metadata.FileAttr{Mode: 0644})
+	require.NoError(t, err)
+	handle, err := store.GetChild(ctx.Context, rootHandle, "w.bin")
+	require.NoError(t, err)
+
+	write := func(size uint64) {
+		intent, err := svc.PrepareWrite(ctx, handle, size)
+		require.NoError(t, err)
+		_, err = svc.CommitWrite(ctx, intent)
+		require.NoError(t, err)
+	}
+
+	before := time.Now().Add(-time.Second)
+	write(4096)
+	flushed, err := svc.FlushPendingWriteForFile(ctx, handle, true)
+	require.NoError(t, err)
+	require.True(t, flushed, "expected a pending write to flush")
+
+	f, err := store.GetFile(ctx.Context, handle)
+	require.NoError(t, err)
+	require.Equal(t, uint64(4096), f.Size, "flush must persist the grown size")
+	require.False(t, f.Mtime.Before(before), "flush must stamp mtime, got %v", f.Mtime)
+	require.False(t, f.Ctime.Before(before), "flush must stamp ctime, got %v", f.Ctime)
+
+	// A later, smaller write must not shrink the file.
+	write(1024)
+	if _, err := svc.FlushPendingWriteForFile(ctx, handle, true); err != nil {
+		require.NoError(t, err)
+	}
+	f, err = store.GetFile(ctx.Context, handle)
+	require.NoError(t, err)
+	require.Equal(t, uint64(4096), f.Size, "an out-of-order smaller write must not shrink the file")
+}

--- a/pkg/metadata/io.go
+++ b/pkg/metadata/io.go
@@ -455,6 +455,16 @@ func (s *Service) flushPendingWrite(ctx *AuthContext, handle FileHandle, state *
 	}
 
 	commit := func(tx Transaction) error {
+		// The narrow applier performs exactly this update — grow-only size,
+		// stamped mtime/ctime, optional setuid/setgid clear — in a single
+		// statement. It always stamps the timestamps, so a state carrying no
+		// recorded mtime (SetCachedFile with a size but no write time) still
+		// takes the read-modify-write path below rather than stamping zero.
+		if applier, ok := tx.(DataWriteApplier); ok && !state.LastMtime.IsZero() {
+			_, err := applier.ApplyDataWrite(ctx.Context, handle, state.MaxSize, state.LastMtime, state.ClearSetuidSetgid)
+			return err
+		}
+
 		file, err := tx.GetFile(ctx.Context, handle)
 		if err != nil {
 			return err

--- a/pkg/metadata/io.go
+++ b/pkg/metadata/io.go
@@ -306,17 +306,44 @@ func (s *Service) immediateCommitWrite(ctx *AuthContext, intent *WriteOperation)
 		return nil, err
 	}
 
-	// Use transaction for atomic read-modify-write
-	// This ensures max(size) is calculated and applied atomically
+	// Apply metadata changes atomically: max(size) so an out-of-order write at a
+	// lower offset never shrinks the file, and a mtime/ctime stamp.
+	now := time.Now()
+	// POSIX: a non-root writer clears setuid/setgid to prevent privilege escalation.
+	clearSUID := ctx.Identity != nil && ctx.Identity.UID != nil && *ctx.Identity.UID != 0
+
 	var resultFile *File
 	err = store.WithTransaction(ctx.Context, func(tx Transaction) error {
-		// Get current file state
+		// Fast path: a single narrow UPDATE (grow size, stamp times, clear suid)
+		// instead of GetFile (aggregate block-refs read) + PutFile (full-row
+		// rewrite), for backends that implement it. Post-op attrs are synthesized
+		// from the pre-write attrs plus the authoritative final size — the same
+		// no-read-back trick the deferred-commit path uses.
+		if applier, ok := tx.(DataWriteApplier); ok {
+			finalSize, err := applier.ApplyDataWrite(ctx.Context, intent.Handle, intent.NewSize, now, clearSUID)
+			if err != nil {
+				return err
+			}
+			attr := *intent.PreWriteAttr
+			attr.Size = finalSize
+			attr.Mtime = now
+			attr.Ctime = now
+			if clearSUID {
+				attr.Mode &= ^uint32(0o6000)
+			}
+			shareName, id, decErr := DecodeFileHandle(intent.Handle)
+			if decErr != nil {
+				return decErr
+			}
+			resultFile = &File{ID: id, ShareName: shareName, FileAttr: attr}
+			return nil
+		}
+
+		// Fallback: full read-modify-write for backends without a narrow path.
 		file, err := tx.GetFile(ctx.Context, intent.Handle)
 		if err != nil {
 			return err
 		}
-
-		// Verify it's still a regular file
 		if file.Type != FileTypeRegular {
 			return &StoreError{
 				Code:    ErrIsDirectory,
@@ -324,30 +351,17 @@ func (s *Service) immediateCommitWrite(ctx *AuthContext, intent *WriteOperation)
 				Path:    file.Path,
 			}
 		}
-
-		// Apply metadata changes
-		now := time.Now()
-
-		// Use max(current_size, new_size) to handle concurrent writes completing out of order
-		// This prevents a write at an earlier offset from shrinking the file
 		if intent.NewSize > file.Size {
 			file.Size = intent.NewSize
 		}
 		file.Mtime = now
 		file.Ctime = now
-
-		// POSIX: Clear setuid/setgid bits when a non-root user writes to a file
-		// This is a security measure to prevent privilege escalation.
-		identity := ctx.Identity
-		if identity != nil && identity.UID != nil && *identity.UID != 0 {
-			file.Mode &= ^uint32(0o6000) // Clear both setuid (04000) and setgid (02000)
+		if clearSUID {
+			file.Mode &= ^uint32(0o6000)
 		}
-
-		// Store updated file
 		if err := tx.PutFile(ctx.Context, file); err != nil {
 			return err
 		}
-
 		resultFile = file
 		return nil
 	})

--- a/pkg/metadata/store/metabench/write_compare_bench_test.go
+++ b/pkg/metadata/store/metabench/write_compare_bench_test.go
@@ -1,0 +1,139 @@
+package metabench
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"path"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/badger"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
+)
+
+// caps is the minimal filesystem-capability set every backend needs to open.
+func caps() metadata.FilesystemCapabilities {
+	return metadata.FilesystemCapabilities{
+		MaxReadSize: 1 << 20, PreferredReadSize: 1 << 20,
+		MaxWriteSize: 1 << 20, PreferredWriteSize: 1 << 20,
+		MaxFileSize: 1<<63 - 1, MaxFilenameLen: 255, MaxPathLen: 4096,
+		CasePreserving: true, TimestampResolution: 1,
+	}
+}
+
+// backend names a metadata store the write-path comparison drives. Durability
+// is equalized to fsync-free across all three (badger SyncWrites=false, sqlite
+// WAL+synchronous=NORMAL, and — for postgres — synchronous_commit=off via the
+// relaxed path) so any gap that remains is access-pattern/round-trip/CPU, i.e.
+// design, not the disk's fsync cost.
+type backend struct {
+	name string
+	open func(b *testing.B) metadata.Store
+}
+
+func backends() []backend {
+	return []backend{
+		{"badger", func(b *testing.B) metadata.Store {
+			s, err := badger.NewBadgerMetadataStoreWithDefaultsAndCaches(
+				context.Background(), b.TempDir(), 0, 0, true /*relaxedDurability*/)
+			if err != nil {
+				b.Fatalf("badger open: %v", err)
+			}
+			return s
+		}},
+		{"sqlite", func(b *testing.B) metadata.Store {
+			s, err := sqlite.NewSQLiteMetadataStore(context.Background(),
+				&sqlite.SQLiteMetadataStoreConfig{Path: filepath.Join(b.TempDir(), "m.db"), AutoMigrate: true},
+				caps())
+			if err != nil {
+				b.Fatalf("sqlite open: %v", err)
+			}
+			return s
+		}},
+	}
+}
+
+// BenchmarkWriteCompare drives the identical data-write metadata op — the RMW a
+// 4k WRITE triggers: GetFile (SELECT) then PutFile (row UPDATE) in one txn —
+// against each backend, scattered over a populated file set, and reports IOPS.
+// Run one backend at a time with its own profile to compare flamegraphs:
+//
+//	DITTOFS_LOGGING_LEVEL=ERROR go test -run '^$' -bench 'WriteCompare/badger' \
+//	  -benchtime 3s -cpuprofile /tmp/badger.prof ./pkg/metadata/store/metabench/
+//	go tool pprof -top /tmp/badger.prof
+func BenchmarkWriteCompare(b *testing.B) {
+	const nFiles = 20000
+	ctx := context.Background()
+	for _, be := range backends() {
+		b.Run(be.name, func(b *testing.B) {
+			store := be.open(b)
+			b.Cleanup(func() { _ = store.Close() })
+
+			const share = "/hot"
+			root, err := store.CreateRootDirectory(ctx, share, &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755})
+			if err != nil {
+				b.Fatalf("CreateRootDirectory: %v", err)
+			}
+			rootHandle, err := store.GetRootHandle(ctx, share)
+			if err != nil {
+				b.Fatalf("GetRootHandle: %v", err)
+			}
+
+			handles := make([]metadata.FileHandle, nFiles)
+			for i := 0; i < nFiles; i++ {
+				name := fmt.Sprintf("f%06d", i)
+				fp := path.Join(root.Path, name)
+				h, err := store.GenerateHandle(ctx, share, fp)
+				if err != nil {
+					b.Fatalf("GenerateHandle: %v", err)
+				}
+				_, id, err := metadata.DecodeFileHandle(h)
+				if err != nil {
+					b.Fatalf("DecodeFileHandle: %v", err)
+				}
+				f := &metadata.File{
+					ShareName: share, Path: fp, ID: id,
+					FileAttr: metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: 1000, GID: 1000},
+				}
+				if err := store.PutFile(ctx, f); err != nil {
+					b.Fatalf("PutFile seed: %v", err)
+				}
+				if err := store.SetParent(ctx, h, rootHandle); err != nil {
+					b.Fatalf("SetParent: %v", err)
+				}
+				if err := store.SetChild(ctx, rootHandle, name, h); err != nil {
+					b.Fatalf("SetChild: %v", err)
+				}
+				handles[i] = h
+			}
+
+			var ops int64
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				rng := rand.New(rand.NewSource(rand.Int63()))
+				for pb.Next() {
+					h := handles[rng.Intn(nFiles)]
+					if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+						f, err := tx.GetFile(ctx, h)
+						if err != nil {
+							return err
+						}
+						f.Mtime = time.Now()
+						return tx.PutFile(ctx, f)
+					}); err != nil {
+						b.Fatalf("write txn: %v", err)
+					}
+					atomic.AddInt64(&ops, 1)
+				}
+			})
+			b.StopTimer()
+			if secs := b.Elapsed().Seconds(); secs > 0 {
+				b.ReportMetric(float64(atomic.LoadInt64(&ops))/secs, "iops")
+			}
+		})
+	}
+}

--- a/pkg/metadata/store/postgres/data_write.go
+++ b/pkg/metadata/store/postgres/data_write.go
@@ -29,7 +29,7 @@ func (tx *postgresTransaction) ApplyDataWrite(
 	if err != nil {
 		return 0, &metadata.StoreError{Code: metadata.ErrInvalidHandle, Message: "invalid file handle"}
 	}
-	var mask int64
+	var mask int32
 	if clearSUID {
 		mask = 0o6000
 	}
@@ -47,19 +47,19 @@ func (tx *postgresTransaction) ApplyDataWrite(
 		),
 		upd AS (
 			UPDATE inodes SET
-				size  = GREATEST(inodes.size, $3),
-				mtime = $4,
-				ctime = $4,
-				mode  = inodes.mode & ~$5
-			WHERE inodes.id = $1 AND inodes.share_name = $2 AND inodes.file_type = $6
+				size  = GREATEST(inodes.size, $3::bigint),
+				mtime = $4::bigint,
+				ctime = $4::bigint,
+				mode  = inodes.mode & ~($5::int)
+			WHERE inodes.id = $1 AND inodes.share_name = $2 AND inodes.file_type = $6::smallint
 			RETURNING inodes.size
 		)
 		SELECT (SELECT size FROM upd), old.size, old.uid, old.gid FROM old
 	`
 	var newSz *int64
 	var oldSize int64
-	var oldUID, oldGID uint32
-	err = tx.tx.QueryRow(ctx, q, id, shareName, int64(newSize), ft, mask, int(metadata.FileTypeRegular)).
+	var oldUID, oldGID int32
+	err = tx.tx.QueryRow(ctx, q, id, shareName, int64(newSize), ft, mask, int16(metadata.FileTypeRegular)).
 		Scan(&newSz, &oldSize, &oldUID, &oldGID)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
@@ -75,7 +75,7 @@ func (tx *postgresTransaction) ApplyDataWrite(
 	finalSize := *newSz
 	if delta := finalSize - oldSize; delta != 0 {
 		tx.pendingDelta += delta
-		tx.quota.Add(oldUID, oldGID, delta, 0)
+		tx.quota.Add(uint32(oldUID), uint32(oldGID), delta, 0)
 	}
 	return uint64(finalSize), nil
 }

--- a/pkg/metadata/store/postgres/data_write.go
+++ b/pkg/metadata/store/postgres/data_write.go
@@ -1,0 +1,81 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
+)
+
+// ApplyDataWrite implements metadata.DataWriteApplier: the hot-path metadata
+// update for a data WRITE, done as a single statement instead of GetFile
+// (aggregate block-refs read) + PutFile (20-column rewrite). Postgres RETURNING
+// can reference the pre-update CTE, so the read of the old size/owner and the
+// in-place update collapse into one round-trip.
+//
+// size grows to max(old, new) — an out-of-order write at a lower offset never
+// shrinks the file — mtime/ctime are stamped to now, and setuid/setgid clear
+// when clearSUID is set. Only regular files are affected. The usedBytes and
+// per-identity quota deltas are accumulated on the tx and applied once after a
+// successful commit, exactly like PutFile.
+func (tx *postgresTransaction) ApplyDataWrite(
+	ctx context.Context, handle metadata.FileHandle, newSize uint64, now time.Time, clearSUID bool,
+) (uint64, error) {
+	shareName, id, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return 0, &metadata.StoreError{Code: metadata.ErrInvalidHandle, Message: "invalid file handle"}
+	}
+	var mask int64
+	if clearSUID {
+		mask = 0o6000
+	}
+	ft := sqlcodec.TimeToFiletime(now)
+
+	// old captures the pre-update size/owner/type; upd performs the guarded
+	// in-place update and returns the new size (NULL when the row exists but is
+	// not a regular file, so it is left untouched); the outer SELECT joins them.
+	// An empty old (missing row) yields zero rows.
+	const q = `
+		WITH old AS (
+			SELECT size, uid, gid, file_type FROM inodes
+			WHERE id = $1 AND share_name = $2
+			FOR UPDATE
+		),
+		upd AS (
+			UPDATE inodes SET
+				size  = GREATEST(inodes.size, $3),
+				mtime = $4,
+				ctime = $4,
+				mode  = inodes.mode & ~$5
+			WHERE inodes.id = $1 AND inodes.share_name = $2 AND inodes.file_type = $6
+			RETURNING inodes.size
+		)
+		SELECT (SELECT size FROM upd), old.size, old.uid, old.gid FROM old
+	`
+	var newSz *int64
+	var oldSize int64
+	var oldUID, oldGID uint32
+	err = tx.tx.QueryRow(ctx, q, id, shareName, int64(newSize), ft, mask, int(metadata.FileTypeRegular)).
+		Scan(&newSz, &oldSize, &oldUID, &oldGID)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return 0, &metadata.StoreError{Code: metadata.ErrNotFound, Message: "file not found"}
+	case err != nil:
+		return 0, mapPgError(err, "ApplyDataWrite", "")
+	}
+	if newSz == nil {
+		// Row exists but is not a regular file: the guarded UPDATE matched nothing.
+		return 0, &metadata.StoreError{Code: metadata.ErrIsDirectory, Message: "not a regular file"}
+	}
+
+	finalSize := *newSz
+	if delta := finalSize - oldSize; delta != 0 {
+		tx.pendingDelta += delta
+		tx.quota.Add(oldUID, oldGID, delta, 0)
+	}
+	return uint64(finalSize), nil
+}

--- a/pkg/metadata/store/postgres/data_write_test.go
+++ b/pkg/metadata/store/postgres/data_write_test.go
@@ -1,0 +1,215 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/postgres"
+)
+
+// pgStore opens the localhost Postgres the other postgres_test.go files use.
+// DITTOFS_TEST_POSTGRES_DSN is a boolean gate, not a parsed DSN.
+func pgStore(tb testing.TB) metadata.Store {
+	tb.Helper()
+	cfg := &postgres.PostgresMetadataStoreConfig{
+		Host:        "localhost",
+		Port:        5432,
+		Database:    "dittofs_test",
+		User:        "postgres",
+		Password:    "postgres",
+		SSLMode:     "disable",
+		AutoMigrate: true,
+	}
+	caps := metadata.FilesystemCapabilities{
+		MaxReadSize: 1048576, PreferredReadSize: 1048576,
+		MaxWriteSize: 1048576, PreferredWriteSize: 1048576,
+		MaxFileSize: 9223372036854775807, MaxFilenameLen: 255,
+		MaxPathLen: 4096, MaxHardLinkCount: 32767,
+		SupportsHardLinks: true, SupportsSymlinks: true,
+		CaseSensitive: true, CasePreserving: true, TimestampResolution: 1,
+	}
+	store, err := postgres.NewPostgresMetadataStore(context.Background(), cfg, caps)
+	if err != nil {
+		tb.Fatalf("NewPostgresMetadataStore: %v", err)
+	}
+	tb.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// uniqueShare keeps repeated runs against the same persistent database from
+// colliding on share names.
+func uniqueShare(prefix string) string {
+	return fmt.Sprintf("/%s-%d", prefix, time.Now().UnixNano())
+}
+
+// TestApplyDataWrite_Sound_Postgres is the Postgres twin of the sqlite
+// soundness test: it drives the DataWriteApplier fast path through a real
+// transaction and asserts the row ends in the state the GetFile+PutFile
+// fallback would have produced.
+func TestApplyDataWrite_Sound_Postgres(t *testing.T) {
+	if os.Getenv("DITTOFS_TEST_POSTGRES_DSN") == "" {
+		t.Skip("DITTOFS_TEST_POSTGRES_DSN not set, skipping PostgreSQL data-write tests")
+	}
+	ctx := context.Background()
+	store := pgStore(t)
+
+	share := uniqueShare("dw")
+	if _, err := store.CreateRootDirectory(ctx, share,
+		&metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755}); err != nil {
+		t.Fatal(err)
+	}
+	rootHandle, err := store.GetRootHandle(ctx, share)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	apply := func(h metadata.FileHandle, newSize uint64, now time.Time, clearSUID bool) (uint64, error) {
+		var final uint64
+		err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+			applier, ok := tx.(metadata.DataWriteApplier)
+			if !ok {
+				t.Fatal("postgres transaction does not implement DataWriteApplier")
+			}
+			var e error
+			final, e = applier.ApplyDataWrite(ctx, h, newSize, now, clearSUID)
+			return e
+		})
+		return final, err
+	}
+
+	mk := func(name string, mode uint32, size uint64) metadata.FileHandle {
+		fp := share + "/" + name
+		h, err := store.GenerateHandle(ctx, share, fp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, id, err := metadata.DecodeFileHandle(h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.PutFile(ctx, &metadata.File{ShareName: share, Path: fp, ID: id,
+			FileAttr: metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: mode, UID: 1000, GID: 1000, Size: size}}); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.SetParent(ctx, h, rootHandle); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.SetChild(ctx, rootHandle, name, h); err != nil {
+			t.Fatal(err)
+		}
+		return h
+	}
+
+	t.Run("grows size and stamps times", func(t *testing.T) {
+		h := mk("grow", 0o644, 100)
+		now := time.Now().Truncate(time.Second).Add(time.Hour)
+		final, err := apply(h, 4096, now, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if final != 4096 {
+			t.Fatalf("final size = %d, want 4096", final)
+		}
+		f, err := store.GetFile(ctx, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if f.Size != 4096 {
+			t.Fatalf("stored size = %d, want 4096", f.Size)
+		}
+		if !f.Mtime.Equal(now) || !f.Ctime.Equal(now) {
+			t.Fatalf("mtime/ctime not stamped: mtime=%v ctime=%v want %v", f.Mtime, f.Ctime, now)
+		}
+	})
+
+	t.Run("never shrinks (out-of-order write)", func(t *testing.T) {
+		h := mk("noshrink", 0o644, 8192)
+		final, err := apply(h, 4096, time.Now(), false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if final != 8192 {
+			t.Fatalf("final size = %d, want 8192 (must not shrink)", final)
+		}
+		f, err := store.GetFile(ctx, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if f.Size != 8192 {
+			t.Fatalf("stored size = %d, want 8192", f.Size)
+		}
+	})
+
+	t.Run("clears setuid/setgid for non-root", func(t *testing.T) {
+		h := mk("suid", 0o6755, 100)
+		if _, err := apply(h, 200, time.Now(), true); err != nil {
+			t.Fatal(err)
+		}
+		f, err := store.GetFile(ctx, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if f.Mode&0o6000 != 0 {
+			t.Fatalf("setuid/setgid not cleared: mode=0%o", f.Mode)
+		}
+		if f.Mode&0o777 != 0o755 {
+			t.Fatalf("permission bits altered: mode=0%o, want low bits 0755", f.Mode)
+		}
+	})
+
+	t.Run("keeps setuid when clearSUID is false", func(t *testing.T) {
+		h := mk("keepsuid", 0o6755, 100)
+		if _, err := apply(h, 200, time.Now(), false); err != nil {
+			t.Fatal(err)
+		}
+		f, err := store.GetFile(ctx, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if f.Mode&0o6000 != 0o6000 {
+			t.Fatalf("setuid/setgid wrongly cleared: mode=0%o", f.Mode)
+		}
+	})
+
+	t.Run("missing file returns ErrNotFound", func(t *testing.T) {
+		h, err := store.GenerateHandle(ctx, share, share+"/ghost")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = apply(h, 100, time.Now(), false)
+		var se *metadata.StoreError
+		if !asPgStoreErr(err, &se) || se.Code != metadata.ErrNotFound {
+			t.Fatalf("want ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("directory returns ErrIsDirectory", func(t *testing.T) {
+		_, err := apply(rootHandle, 100, time.Now(), false)
+		var se *metadata.StoreError
+		if !asPgStoreErr(err, &se) || se.Code != metadata.ErrIsDirectory {
+			t.Fatalf("want ErrIsDirectory, got %v", err)
+		}
+	})
+}
+
+func asPgStoreErr(err error, target **metadata.StoreError) bool {
+	for err != nil {
+		if se, ok := err.(*metadata.StoreError); ok {
+			*target = se
+			return true
+		}
+		type unwrapper interface{ Unwrap() error }
+		u, ok := err.(unwrapper)
+		if !ok {
+			return false
+		}
+		err = u.Unwrap()
+	}
+	return false
+}

--- a/pkg/metadata/store/postgres/write_path_bench_test.go
+++ b/pkg/metadata/store/postgres/write_path_bench_test.go
@@ -1,0 +1,124 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"path"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// benchSeed creates a share holding n regular files and returns their handles.
+// The share name is unique per call so repeated runs against the same database
+// never collide.
+func benchSeed(b *testing.B, store metadata.Store, n int) (string, []metadata.FileHandle) {
+	b.Helper()
+	ctx := context.Background()
+	share := uniqueShare("bench")
+	root, err := store.CreateRootDirectory(ctx, share,
+		&metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755})
+	if err != nil {
+		b.Fatalf("CreateRootDirectory: %v", err)
+	}
+	rootHandle, err := store.GetRootHandle(ctx, share)
+	if err != nil {
+		b.Fatalf("GetRootHandle: %v", err)
+	}
+	hs := make([]metadata.FileHandle, n)
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("f%06d", i)
+		fp := path.Join(root.Path, name)
+		h, err := store.GenerateHandle(ctx, share, fp)
+		if err != nil {
+			b.Fatalf("GenerateHandle: %v", err)
+		}
+		_, id, err := metadata.DecodeFileHandle(h)
+		if err != nil {
+			b.Fatalf("DecodeFileHandle: %v", err)
+		}
+		if err := store.PutFile(ctx, &metadata.File{ShareName: share, Path: fp, ID: id,
+			FileAttr: metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: 1000, GID: 1000}}); err != nil {
+			b.Fatalf("PutFile seed: %v", err)
+		}
+		if err := store.SetParent(ctx, h, rootHandle); err != nil {
+			b.Fatalf("SetParent: %v", err)
+		}
+		if err := store.SetChild(ctx, rootHandle, name, h); err != nil {
+			b.Fatalf("SetChild: %v", err)
+		}
+		hs[i] = h
+	}
+	return share, hs
+}
+
+// BenchmarkPostgresWritePath measures the metadata cost of one data WRITE
+// against a scattered file set, in the two shapes the runtime can take:
+//
+//	getfile_putfile — the fallback: GetFile (row + aggregate block-refs read)
+//	                  then PutFile (full-row UPDATE), two statements per op
+//	applydatawrite  — the DataWriteApplier fast path: one CTE statement that
+//	                  reads the old size/owner and updates size/mtime/ctime in
+//	                  a single round-trip
+//
+// Both run the same concurrency against the same seeded share, so the delta is
+// the per-op SQL access pattern rather than disk or durability.
+//
+//	DITTOFS_TEST_POSTGRES_DSN=1 go test -tags integration -run '^$' \
+//	  -bench BenchmarkPostgresWritePath ./pkg/metadata/store/postgres/
+func BenchmarkPostgresWritePath(b *testing.B) {
+	if os.Getenv("DITTOFS_TEST_POSTGRES_DSN") == "" {
+		b.Skip("DITTOFS_TEST_POSTGRES_DSN not set, skipping PostgreSQL write-path benchmark")
+	}
+	const nFiles = 5000
+	ctx := context.Background()
+
+	run := func(b *testing.B, op func(tx metadata.Transaction, h metadata.FileHandle) error) {
+		store := pgStore(b)
+		_, handles := benchSeed(b, store, nFiles)
+		var ops int64
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			rng := rand.New(rand.NewSource(rand.Int63()))
+			for pb.Next() {
+				h := handles[rng.Intn(nFiles)]
+				if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+					return op(tx, h)
+				}); err != nil {
+					b.Fatalf("write txn: %v", err)
+				}
+				atomic.AddInt64(&ops, 1)
+			}
+		})
+		b.StopTimer()
+		if secs := b.Elapsed().Seconds(); secs > 0 {
+			b.ReportMetric(float64(atomic.LoadInt64(&ops))/secs, "iops")
+		}
+	}
+
+	b.Run("getfile_putfile", func(b *testing.B) {
+		run(b, func(tx metadata.Transaction, h metadata.FileHandle) error {
+			f, err := tx.GetFile(ctx, h)
+			if err != nil {
+				return err
+			}
+			f.Size = 4096
+			f.Mtime = time.Now()
+			f.Ctime = f.Mtime
+			return tx.PutFile(ctx, f)
+		})
+	})
+
+	b.Run("applydatawrite", func(b *testing.B) {
+		run(b, func(tx metadata.Transaction, h metadata.FileHandle) error {
+			_, err := tx.(metadata.DataWriteApplier).ApplyDataWrite(ctx, h, 4096, time.Now(), false)
+			return err
+		})
+	})
+}

--- a/pkg/metadata/store/sqlite/bench_export_test.go
+++ b/pkg/metadata/store/sqlite/bench_export_test.go
@@ -1,0 +1,8 @@
+package sqlite
+
+import "database/sql"
+
+// DBForBench exposes the underlying pool to same-package-adjacent benchmarks so
+// they can prototype alternative write statements against the real schema.
+// Test-only: the file is a _test.go, so it is never compiled into the binary.
+func (s *SQLiteMetadataStore) DBForBench() *sql.DB { return s.db }

--- a/pkg/metadata/store/sqlite/data_write.go
+++ b/pkg/metadata/store/sqlite/data_write.go
@@ -1,0 +1,70 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
+)
+
+// ApplyDataWrite implements metadata.DataWriteApplier: the hot-path metadata
+// update for a data WRITE, done as a narrow SELECT-then-UPDATE instead of the
+// GetFile (aggregate block-refs read) + PutFile (20-column rewrite) pair.
+//
+// It grows size to max(old, new) — so an out-of-order write at a lower offset
+// never shrinks the file — stamps mtime/ctime to now, and clears setuid/setgid
+// when clearSUID is set. Only regular files are affected; the usedBytes and
+// per-identity quota deltas are accumulated on the tx and applied once after a
+// successful commit, exactly like PutFile, so a retry never double-counts.
+func (tx *sqliteTransaction) ApplyDataWrite(
+	ctx context.Context, handle metadata.FileHandle, newSize uint64, now time.Time, clearSUID bool,
+) (uint64, error) {
+	shareName, id, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return 0, &metadata.StoreError{Code: metadata.ErrInvalidHandle, Message: "invalid file handle"}
+	}
+
+	// Pre-update size/owner/type for the max() decision and the quota delta.
+	// SQLite's single writer holds the write lock for the whole tx, so there is
+	// no interleaving between this read and the UPDATE below.
+	var oldSize int64
+	var oldUID, oldGID uint32
+	var oldType int
+	err = tx.tx.QueryRow(ctx,
+		`SELECT size, uid, gid, file_type FROM inodes WHERE id = ?1 AND share_name = ?2`,
+		id, shareName).Scan(&oldSize, &oldUID, &oldGID, &oldType)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return 0, &metadata.StoreError{Code: metadata.ErrNotFound, Message: "file not found"}
+	case err != nil:
+		return 0, mapDBError(err, "ApplyDataWrite", "")
+	}
+	if metadata.FileType(oldType) != metadata.FileTypeRegular {
+		return 0, &metadata.StoreError{Code: metadata.ErrIsDirectory, Message: "not a regular file"}
+	}
+
+	finalSize := oldSize
+	if int64(newSize) > finalSize {
+		finalSize = int64(newSize)
+	}
+	var mask uint32
+	if clearSUID {
+		mask = 0o6000
+	}
+	ft := sqlcodec.TimeToFiletime(now)
+
+	if _, err := tx.tx.Exec(ctx,
+		`UPDATE inodes SET size = ?1, mtime = ?2, ctime = ?2, mode = mode & ~?3 WHERE id = ?4 AND share_name = ?5`,
+		finalSize, ft, mask, id, shareName); err != nil {
+		return 0, mapDBError(err, "ApplyDataWrite", "")
+	}
+
+	if delta := finalSize - oldSize; delta != 0 {
+		tx.pendingDelta += delta
+		tx.quota.Add(oldUID, oldGID, delta, 0)
+	}
+	return uint64(finalSize), nil
+}

--- a/pkg/metadata/store/sqlite/data_write_test.go
+++ b/pkg/metadata/store/sqlite/data_write_test.go
@@ -1,0 +1,154 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
+)
+
+// apply runs ApplyDataWrite through the DataWriteApplier interface inside a real
+// transaction, the same way io.go's fast path does.
+func apply(t *testing.T, store metadata.Store, h metadata.FileHandle, newSize uint64, now time.Time, clearSUID bool) (uint64, error) {
+	t.Helper()
+	var final uint64
+	err := store.WithTransaction(context.Background(), func(tx metadata.Transaction) error {
+		applier, ok := tx.(metadata.DataWriteApplier)
+		if !ok {
+			t.Fatal("sqlite transaction does not implement DataWriteApplier")
+		}
+		var e error
+		final, e = applier.ApplyDataWrite(context.Background(), h, newSize, now, clearSUID)
+		return e
+	})
+	return final, err
+}
+
+func TestApplyDataWrite_Sound(t *testing.T) {
+	ctx := context.Background()
+	store, err := sqlite.NewSQLiteMetadataStore(ctx,
+		&sqlite.SQLiteMetadataStoreConfig{Path: t.TempDir() + "/m.db", AutoMigrate: true}, sqliteTestCapabilities())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const share = "/s"
+	if _, err := store.CreateRootDirectory(ctx, share, &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755}); err != nil {
+		t.Fatal(err)
+	}
+	rootHandle, err := store.GetRootHandle(ctx, share)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A regular file, mode with setuid+setgid set, initial size 100.
+	mk := func(name string, mode uint32, size uint64) metadata.FileHandle {
+		h, err := store.GenerateHandle(ctx, share, "/s/"+name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, id, _ := metadata.DecodeFileHandle(h)
+		if err := store.PutFile(ctx, &metadata.File{ShareName: share, Path: "/s/" + name, ID: id,
+			FileAttr: metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: mode, UID: 1000, GID: 1000, Size: size}}); err != nil {
+			t.Fatal(err)
+		}
+		_ = store.SetParent(ctx, h, rootHandle)
+		_ = store.SetChild(ctx, rootHandle, name, h)
+		return h
+	}
+
+	t.Run("grows size and stamps times", func(t *testing.T) {
+		h := mk("grow", 0o644, 100)
+		now := time.Now().Truncate(time.Second).Add(time.Hour)
+		final, err := apply(t, store, h, 4096, now, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if final != 4096 {
+			t.Fatalf("final size = %d, want 4096", final)
+		}
+		f, _ := store.GetFile(ctx, h)
+		if f.Size != 4096 {
+			t.Fatalf("stored size = %d, want 4096", f.Size)
+		}
+		if !f.Mtime.Equal(now) || !f.Ctime.Equal(now) {
+			t.Fatalf("mtime/ctime not stamped: mtime=%v ctime=%v want %v", f.Mtime, f.Ctime, now)
+		}
+	})
+
+	t.Run("never shrinks (out-of-order write)", func(t *testing.T) {
+		h := mk("noshrink", 0o644, 8192)
+		final, err := apply(t, store, h, 4096, time.Now(), false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if final != 8192 {
+			t.Fatalf("final size = %d, want 8192 (must not shrink)", final)
+		}
+		f, _ := store.GetFile(ctx, h)
+		if f.Size != 8192 {
+			t.Fatalf("stored size = %d, want 8192", f.Size)
+		}
+	})
+
+	t.Run("clears setuid/setgid for non-root", func(t *testing.T) {
+		h := mk("suid", 0o6755, 100)
+		if _, err := apply(t, store, h, 200, time.Now(), true); err != nil {
+			t.Fatal(err)
+		}
+		f, _ := store.GetFile(ctx, h)
+		if f.Mode&0o6000 != 0 {
+			t.Fatalf("setuid/setgid not cleared: mode=0%o", f.Mode)
+		}
+		if f.Mode&0o777 != 0o755 {
+			t.Fatalf("permission bits altered: mode=0%o, want low bits 0755", f.Mode)
+		}
+	})
+
+	t.Run("keeps setuid when clearSUID is false", func(t *testing.T) {
+		h := mk("keepsuid", 0o6755, 100)
+		if _, err := apply(t, store, h, 200, time.Now(), false); err != nil {
+			t.Fatal(err)
+		}
+		f, _ := store.GetFile(ctx, h)
+		if f.Mode&0o6000 != 0o6000 {
+			t.Fatalf("setuid/setgid wrongly cleared: mode=0%o", f.Mode)
+		}
+	})
+
+	t.Run("missing file returns ErrNotFound", func(t *testing.T) {
+		h, _ := store.GenerateHandle(ctx, share, "/s/ghost")
+		_, err := apply(t, store, h, 100, time.Now(), false)
+		var se *metadata.StoreError
+		if !asStoreErr(err, &se) || se.Code != metadata.ErrNotFound {
+			t.Fatalf("want ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("directory returns ErrIsDirectory", func(t *testing.T) {
+		_, err := apply(t, store, rootHandle, 100, time.Now(), false)
+		var se *metadata.StoreError
+		if !asStoreErr(err, &se) || se.Code != metadata.ErrIsDirectory {
+			t.Fatalf("want ErrIsDirectory, got %v", err)
+		}
+	})
+}
+
+func asStoreErr(err error, target **metadata.StoreError) bool {
+	for err != nil {
+		if se, ok := err.(*metadata.StoreError); ok {
+			*target = se
+			return true
+		}
+		type unwrapper interface{ Unwrap() error }
+		u, ok := err.(unwrapper)
+		if !ok {
+			return false
+		}
+		err = u.Unwrap()
+	}
+	return false
+}

--- a/pkg/metadata/store/sqlite/narrow_write_bench_test.go
+++ b/pkg/metadata/store/sqlite/narrow_write_bench_test.go
@@ -80,13 +80,20 @@ func seedHandles(b *testing.B, store metadata.Store, share string, n int) []meta
 		if err != nil {
 			b.Fatalf("GenerateHandle: %v", err)
 		}
-		_, id, _ := metadata.DecodeFileHandle(h)
+		_, id, err := metadata.DecodeFileHandle(h)
+		if err != nil {
+			b.Fatalf("DecodeFileHandle: %v", err)
+		}
 		if err := store.PutFile(ctx, &metadata.File{ShareName: share, Path: fp, ID: id,
 			FileAttr: metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: 1000, GID: 1000}}); err != nil {
 			b.Fatalf("PutFile seed: %v", err)
 		}
-		_ = store.SetParent(ctx, h, rootHandle)
-		_ = store.SetChild(ctx, rootHandle, name, h)
+		if err := store.SetParent(ctx, h, rootHandle); err != nil {
+			b.Fatalf("SetParent: %v", err)
+		}
+		if err := store.SetChild(ctx, rootHandle, name, h); err != nil {
+			b.Fatalf("SetChild: %v", err)
+		}
 		hs[i] = h
 	}
 	return hs

--- a/pkg/metadata/store/sqlite/narrow_write_bench_test.go
+++ b/pkg/metadata/store/sqlite/narrow_write_bench_test.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
@@ -58,6 +59,39 @@ func seedFiles(b *testing.B, store metadata.Store, share string, n int) []string
 	return ids
 }
 
+// seedHandles is seedFiles but returns the file handles (for methods that take a
+// handle rather than a raw id).
+func seedHandles(b *testing.B, store metadata.Store, share string, n int) []metadata.FileHandle {
+	b.Helper()
+	ctx := context.Background()
+	root, err := store.CreateRootDirectory(ctx, share, &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755})
+	if err != nil {
+		b.Fatalf("CreateRootDirectory: %v", err)
+	}
+	rootHandle, err := store.GetRootHandle(ctx, share)
+	if err != nil {
+		b.Fatalf("GetRootHandle: %v", err)
+	}
+	hs := make([]metadata.FileHandle, n)
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("f%06d", i)
+		fp := path.Join(root.Path, name)
+		h, err := store.GenerateHandle(ctx, share, fp)
+		if err != nil {
+			b.Fatalf("GenerateHandle: %v", err)
+		}
+		_, id, _ := metadata.DecodeFileHandle(h)
+		if err := store.PutFile(ctx, &metadata.File{ShareName: share, Path: fp, ID: id,
+			FileAttr: metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: 1000, GID: 1000}}); err != nil {
+			b.Fatalf("PutFile seed: %v", err)
+		}
+		_ = store.SetParent(ctx, h, rootHandle)
+		_ = store.SetChild(ctx, rootHandle, name, h)
+		hs[i] = h
+	}
+	return hs
+}
+
 // BenchmarkNarrowWrite isolates the two SQL write-path levers against the same
 // populated table the GetFile+PutFile path runs at ~5k IOPS:
 //
@@ -91,6 +125,36 @@ func BenchmarkNarrowWrite(b *testing.B) {
 			for pb.Next() {
 				if _, err := db.ExecContext(ctx, narrowUpdate, int64(4096), int64(1_700_000_000), ids[rng.Intn(nFiles)], share); err != nil {
 					b.Fatalf("exec: %v", err)
+				}
+				atomic.AddInt64(&ops, 1)
+			}
+		})
+		b.StopTimer()
+		if s := b.Elapsed().Seconds(); s > 0 {
+			b.ReportMetric(float64(atomic.LoadInt64(&ops))/s, "iops")
+		}
+	})
+
+	// applydatawrite drives the real production fast path — the DataWriteApplier
+	// method through store.WithTransaction, exactly as io.go's immediateCommitWrite
+	// now calls it (SELECT old + narrow UPDATE, one txn, quota-correct).
+	b.Run("applydatawrite", func(b *testing.B) {
+		store, _ := newStore(b)
+		b.Cleanup(func() { _ = store.Close() })
+		ids := seedHandles(b, store, share, nFiles)
+		ctx := context.Background()
+		var ops int64
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			rng := rand.New(rand.NewSource(rand.Int63()))
+			now := time.Now()
+			for pb.Next() {
+				h := ids[rng.Intn(nFiles)]
+				if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+					_, e := tx.(metadata.DataWriteApplier).ApplyDataWrite(ctx, h, 4096, now, false)
+					return e
+				}); err != nil {
+					b.Fatalf("apply: %v", err)
 				}
 				atomic.AddInt64(&ops, 1)
 			}

--- a/pkg/metadata/store/sqlite/narrow_write_bench_test.go
+++ b/pkg/metadata/store/sqlite/narrow_write_bench_test.go
@@ -1,0 +1,130 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math/rand"
+	"path"
+	"sync/atomic"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
+)
+
+// The hot data-write only needs to bump size + timestamps. This is that write as
+// a single narrow statement against the real inodes table — no prior SELECT, no
+// 20-column rewrite, no explicit BEGIN/COMMIT (autocommit = one implicit txn).
+const narrowUpdate = `UPDATE inodes SET size = ?1, mtime = ?2, ctime = ?2 WHERE id = ?3 AND share_name = ?4`
+
+// seedFiles builds a populated inode table and returns the per-file ids.
+func seedFiles(b *testing.B, store metadata.Store, share string, n int) []string {
+	b.Helper()
+	ctx := context.Background()
+	root, err := store.CreateRootDirectory(ctx, share, &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755})
+	if err != nil {
+		b.Fatalf("CreateRootDirectory: %v", err)
+	}
+	rootHandle, err := store.GetRootHandle(ctx, share)
+	if err != nil {
+		b.Fatalf("GetRootHandle: %v", err)
+	}
+	ids := make([]string, n)
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("f%06d", i)
+		fp := path.Join(root.Path, name)
+		h, err := store.GenerateHandle(ctx, share, fp)
+		if err != nil {
+			b.Fatalf("GenerateHandle: %v", err)
+		}
+		_, id, err := metadata.DecodeFileHandle(h)
+		if err != nil {
+			b.Fatalf("DecodeFileHandle: %v", err)
+		}
+		f := &metadata.File{ShareName: share, Path: fp, ID: id,
+			FileAttr: metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: 1000, GID: 1000}}
+		if err := store.PutFile(ctx, f); err != nil {
+			b.Fatalf("PutFile seed: %v", err)
+		}
+		if err := store.SetParent(ctx, h, rootHandle); err != nil {
+			b.Fatalf("SetParent: %v", err)
+		}
+		if err := store.SetChild(ctx, rootHandle, name, h); err != nil {
+			b.Fatalf("SetChild: %v", err)
+		}
+		ids[i] = id.String()
+	}
+	return ids
+}
+
+// BenchmarkNarrowWrite isolates the two SQL write-path levers against the same
+// populated table the GetFile+PutFile path runs at ~5k IOPS:
+//
+//	raw      — narrow single UPDATE, re-parsed each op (isolates: drop SELECT +
+//	           20-col rewrite + explicit txn, but keep per-op SQL compilation)
+//	prepared — same UPDATE via a cached *sql.Stmt (adds: kill per-op compilation)
+//
+// The delta raw→prepared is the prepared-statement win; current→raw is the
+// narrow-single-statement win.
+func BenchmarkNarrowWrite(b *testing.B) {
+	const share = "/hot"
+	const nFiles = 20000
+	newStore := func(b *testing.B) (metadata.Store, *sql.DB) {
+		s, err := sqlite.NewSQLiteMetadataStore(context.Background(),
+			&sqlite.SQLiteMetadataStoreConfig{Path: b.TempDir() + "/m.db", AutoMigrate: true}, sqliteTestCapabilities())
+		if err != nil {
+			b.Fatalf("open: %v", err)
+		}
+		return s, s.DBForBench()
+	}
+
+	b.Run("raw", func(b *testing.B) {
+		store, db := newStore(b)
+		b.Cleanup(func() { _ = store.Close() })
+		ids := seedFiles(b, store, share, nFiles)
+		ctx := context.Background()
+		var ops int64
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			rng := rand.New(rand.NewSource(rand.Int63()))
+			for pb.Next() {
+				if _, err := db.ExecContext(ctx, narrowUpdate, int64(4096), int64(1_700_000_000), ids[rng.Intn(nFiles)], share); err != nil {
+					b.Fatalf("exec: %v", err)
+				}
+				atomic.AddInt64(&ops, 1)
+			}
+		})
+		b.StopTimer()
+		if s := b.Elapsed().Seconds(); s > 0 {
+			b.ReportMetric(float64(atomic.LoadInt64(&ops))/s, "iops")
+		}
+	})
+
+	b.Run("prepared", func(b *testing.B) {
+		store, db := newStore(b)
+		b.Cleanup(func() { _ = store.Close() })
+		ids := seedFiles(b, store, share, nFiles)
+		ctx := context.Background()
+		stmt, err := db.PrepareContext(ctx, narrowUpdate)
+		if err != nil {
+			b.Fatalf("prepare: %v", err)
+		}
+		defer func() { _ = stmt.Close() }()
+		var ops int64
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			rng := rand.New(rand.NewSource(rand.Int63()))
+			for pb.Next() {
+				if _, err := stmt.ExecContext(ctx, int64(4096), int64(1_700_000_000), ids[rng.Intn(nFiles)], share); err != nil {
+					b.Fatalf("exec: %v", err)
+				}
+				atomic.AddInt64(&ops, 1)
+			}
+		})
+		b.StopTimer()
+		if s := b.Elapsed().Seconds(); s > 0 {
+			b.ReportMetric(float64(atomic.LoadInt64(&ops))/s, "iops")
+		}
+	})
+}

--- a/pkg/metadata/store/sqlite/narrow_write_verify_test.go
+++ b/pkg/metadata/store/sqlite/narrow_write_verify_test.go
@@ -1,0 +1,51 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
+)
+
+// TestNarrowUpdateAffectsRow guards the narrow-write benchmark: a narrow UPDATE
+// that matched zero rows would be just as fast and prove nothing. This asserts
+// the id binding the benchmark uses actually hits a seeded row.
+func TestNarrowUpdateAffectsRow(t *testing.T) {
+	ctx := context.Background()
+	store, err := sqlite.NewSQLiteMetadataStore(ctx,
+		&sqlite.SQLiteMetadataStoreConfig{Path: t.TempDir() + "/m.db", AutoMigrate: true}, sqliteTestCapabilities())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const share = "/hot"
+	if _, err := store.CreateRootDirectory(ctx, share, &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755}); err != nil {
+		t.Fatal(err)
+	}
+	h, err := store.GenerateHandle(ctx, share, "/hot/f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, id, err := metadata.DecodeFileHandle(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutFile(ctx, &metadata.File{ShareName: share, Path: "/hot/f", ID: id,
+		FileAttr: metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: 1000, GID: 1000}}); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := store.DBForBench().ExecContext(ctx, narrowUpdate, int64(4096), int64(1_700_000_000), id.String(), share)
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("narrow UPDATE affected %d rows, want 1 — benchmark id binding wrong, results are a no-op", n)
+	}
+}

--- a/pkg/metadata/store/sqlite/write_throughput_bench_test.go
+++ b/pkg/metadata/store/sqlite/write_throughput_bench_test.go
@@ -1,0 +1,217 @@
+package sqlite_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"path"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
+)
+
+// BenchmarkWriteThroughput models the production metadata-write topology behind
+// a 4k random write: ONE SQLiteMetadataStore (MaxOpenConns(1)) driven by many
+// concurrent protocol writers. Each op is the metadata cost the runtime pays
+// per data write — a read-modify-write of the inode row: GetFile (SELECT) then
+// PutFile (full-row UPDATE), inside one WithTransaction (BeginTx + Commit, a WAL
+// frame, no fsync under WAL+synchronous=NORMAL).
+//
+// With a single connection the concurrent writers do not collide at the SQLite
+// level; Go's pool serializes them by blocking to acquire the one connection.
+// So this measures the true single-connection per-op ceiling — the number the
+// ~19x-below-badger field result must be explained by. Run with -cpuprofile to
+// see where the ~ms/op goes (VM per-statement vs BeginTx/Commit vs marshal).
+//
+//	go test -run '^$' -bench BenchmarkWriteThroughput -benchmem -cpu 1,4,8 ./pkg/metadata/store/sqlite/
+func BenchmarkWriteThroughput(b *testing.B) {
+	ctx := context.Background()
+	cfg := &sqlite.SQLiteMetadataStoreConfig{
+		Path:        filepath.Join(b.TempDir(), "wthr.db"),
+		AutoMigrate: true,
+	}
+	store, err := sqlite.NewSQLiteMetadataStore(ctx, cfg, sqliteTestCapabilities())
+	if err != nil {
+		b.Fatalf("NewSQLiteMetadataStore: %v", err)
+	}
+	b.Cleanup(func() { _ = store.Close() })
+
+	const share = "/hot"
+	if _, err := store.CreateRootDirectory(ctx, share, &metadata.FileAttr{Mode: 0o755}); err != nil {
+		b.Fatalf("CreateRootDirectory: %v", err)
+	}
+	root, err := store.GetRootHandle(ctx, share)
+	if err != nil {
+		b.Fatalf("GetRootHandle: %v", err)
+	}
+
+	var ops int64
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+				f, err := tx.GetFile(ctx, root)
+				if err != nil {
+					return err
+				}
+				f.Mtime = time.Now()
+				return tx.PutFile(ctx, f)
+			}); err != nil {
+				b.Fatalf("write txn: %v", err)
+			}
+			atomic.AddInt64(&ops, 1)
+		}
+	})
+	b.StopTimer()
+
+	// IOPS the way the bench rig reports it, so the number is directly
+	// comparable to the ~340 field figure.
+	secs := b.Elapsed().Seconds()
+	if secs > 0 {
+		b.ReportMetric(float64(atomic.LoadInt64(&ops))/secs, "iops")
+	}
+}
+
+// BenchmarkWriteThroughputBatched simulates the ceiling a commit-coalescer
+// would unlock: it folds batch-many inode RMWs into ONE WithTransaction, so the
+// BeginTx + Commit + WAL-frame write is paid once per batch instead of per op.
+// If per-op IOPS climbs with batch size, the per-commit write is the dominant
+// cost and a coalescer is worth building; if it stays flat, it is not.
+func BenchmarkWriteThroughputBatched(b *testing.B) {
+	for _, batch := range []int{1, 8, 32, 128} {
+		b.Run(fmt.Sprintf("batch=%d", batch), func(b *testing.B) {
+			ctx := context.Background()
+			cfg := &sqlite.SQLiteMetadataStoreConfig{
+				Path:        filepath.Join(b.TempDir(), "wthr_batch.db"),
+				AutoMigrate: true,
+			}
+			store, err := sqlite.NewSQLiteMetadataStore(ctx, cfg, sqliteTestCapabilities())
+			if err != nil {
+				b.Fatalf("NewSQLiteMetadataStore: %v", err)
+			}
+			b.Cleanup(func() { _ = store.Close() })
+			const share = "/hot"
+			if _, err := store.CreateRootDirectory(ctx, share, &metadata.FileAttr{Mode: 0o755}); err != nil {
+				b.Fatalf("CreateRootDirectory: %v", err)
+			}
+			root, err := store.GetRootHandle(ctx, share)
+			if err != nil {
+				b.Fatalf("GetRootHandle: %v", err)
+			}
+
+			var ops int64
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+					for j := 0; j < batch; j++ {
+						f, err := tx.GetFile(ctx, root)
+						if err != nil {
+							return err
+						}
+						f.Mtime = time.Now()
+						if err := tx.PutFile(ctx, f); err != nil {
+							return err
+						}
+					}
+					return nil
+				}); err != nil {
+					b.Fatalf("batched txn: %v", err)
+				}
+				atomic.AddInt64(&ops, int64(batch))
+			}
+			b.StopTimer()
+			if secs := b.Elapsed().Seconds(); secs > 0 {
+				b.ReportMetric(float64(atomic.LoadInt64(&ops))/secs, "iops")
+			}
+		})
+	}
+}
+
+// BenchmarkWriteThroughputScattered is the faithful field shape: instead of
+// rewriting one hot inode, it pre-creates a large file set and each op does the
+// RMW against a RANDOM file. This scatters writes across the inodes B-tree,
+// grows the WAL, and drives the periodic checkpoint (which fsyncs the main DB)
+// — the sqlite-specific amplification a single hot row never exercises. If the
+// ~7000-IOPS hot-row ceiling collapses toward the ~340 field number here, the
+// wall is scattered-write/checkpoint cost, not single-writer serialization.
+func BenchmarkWriteThroughputScattered(b *testing.B) {
+	ctx := context.Background()
+	cfg := &sqlite.SQLiteMetadataStoreConfig{
+		Path:        filepath.Join(b.TempDir(), "wthr_scatter.db"),
+		AutoMigrate: true,
+	}
+	store, err := sqlite.NewSQLiteMetadataStore(ctx, cfg, sqliteTestCapabilities())
+	if err != nil {
+		b.Fatalf("NewSQLiteMetadataStore: %v", err)
+	}
+	b.Cleanup(func() { _ = store.Close() })
+
+	const share = "/hot"
+	root, err := store.CreateRootDirectory(ctx, share, &metadata.FileAttr{Mode: 0o755})
+	if err != nil {
+		b.Fatalf("CreateRootDirectory: %v", err)
+	}
+	rootHandle, err := store.GetRootHandle(ctx, share)
+	if err != nil {
+		b.Fatalf("GetRootHandle: %v", err)
+	}
+
+	const nFiles = 20000 // large enough that the inodes B-tree spills many pages
+	handles := make([]metadata.FileHandle, nFiles)
+	for i := 0; i < nFiles; i++ {
+		name := fmt.Sprintf("f%06d", i)
+		fullPath := path.Join(root.Path, name)
+		h, err := store.GenerateHandle(ctx, share, fullPath)
+		if err != nil {
+			b.Fatalf("GenerateHandle: %v", err)
+		}
+		_, id, err := metadata.DecodeFileHandle(h)
+		if err != nil {
+			b.Fatalf("DecodeFileHandle: %v", err)
+		}
+		f := &metadata.File{
+			ShareName: share, Path: fullPath, ID: id,
+			FileAttr: metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: 1000, GID: 1000},
+		}
+		if err := store.PutFile(ctx, f); err != nil {
+			b.Fatalf("PutFile seed: %v", err)
+		}
+		if err := store.SetParent(ctx, h, rootHandle); err != nil {
+			b.Fatalf("SetParent: %v", err)
+		}
+		if err := store.SetChild(ctx, rootHandle, name, h); err != nil {
+			b.Fatalf("SetChild: %v", err)
+		}
+		handles[i] = h
+	}
+
+	var ops int64
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		rng := rand.New(rand.NewSource(rand.Int63()))
+		for pb.Next() {
+			h := handles[rng.Intn(nFiles)]
+			if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+				f, err := tx.GetFile(ctx, h)
+				if err != nil {
+					return err
+				}
+				f.Mtime = time.Now()
+				return tx.PutFile(ctx, f)
+			}); err != nil {
+				b.Fatalf("write txn: %v", err)
+			}
+			atomic.AddInt64(&ops, 1)
+		}
+	})
+	b.StopTimer()
+
+	secs := b.Elapsed().Seconds()
+	if secs > 0 {
+		b.ReportMetric(float64(atomic.LoadInt64(&ops))/secs, "iops")
+	}
+}

--- a/pkg/metadata/store/sqlite/write_throughput_bench_test.go
+++ b/pkg/metadata/store/sqlite/write_throughput_bench_test.go
@@ -41,20 +41,14 @@ func BenchmarkWriteThroughput(b *testing.B) {
 	b.Cleanup(func() { _ = store.Close() })
 
 	const share = "/hot"
-	if _, err := store.CreateRootDirectory(ctx, share, &metadata.FileAttr{Mode: 0o755}); err != nil {
-		b.Fatalf("CreateRootDirectory: %v", err)
-	}
-	root, err := store.GetRootHandle(ctx, share)
-	if err != nil {
-		b.Fatalf("GetRootHandle: %v", err)
-	}
+	hot := seedHandles(b, store, share, 1)[0]
 
 	var ops int64
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
-				f, err := tx.GetFile(ctx, root)
+				f, err := tx.GetFile(ctx, hot)
 				if err != nil {
 					return err
 				}
@@ -95,20 +89,14 @@ func BenchmarkWriteThroughputBatched(b *testing.B) {
 			}
 			b.Cleanup(func() { _ = store.Close() })
 			const share = "/hot"
-			if _, err := store.CreateRootDirectory(ctx, share, &metadata.FileAttr{Mode: 0o755}); err != nil {
-				b.Fatalf("CreateRootDirectory: %v", err)
-			}
-			root, err := store.GetRootHandle(ctx, share)
-			if err != nil {
-				b.Fatalf("GetRootHandle: %v", err)
-			}
+			hot := seedHandles(b, store, share, 1)[0]
 
 			var ops int64
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
 					for j := 0; j < batch; j++ {
-						f, err := tx.GetFile(ctx, root)
+						f, err := tx.GetFile(ctx, hot)
 						if err != nil {
 							return err
 						}


### PR DESCRIPTION
## Problem

The metadata data-write path was an order of magnitude slower on the SQL backends than on badger (field SMB3 rand-write-4k: badger ~7,300, postgres ~1,090–1,765, sqlite ~340). The block store is identical across all three, so this is purely the metadata backend.

## It is not the disk and not durability

Measured in-process, same machine, same disk, durability equalized (badger `SyncWrites=false`, sqlite WAL+`synchronous=NORMAL`), driving the identical write op against a populated inode table:

| backend | IOPS |
|---|---|
| badger | 20,049 |
| sqlite (`GetFile`+`PutFile`) | 5,526 |

Badger runs on the *same fs* and is ~4x faster, so the gap is what SQL does per op. The CPU profile is the tell: sqlite spends ~53% in the SQL bytecode VM (compile + execute) and ~31% in the per-commit WAL write; badger does one key-value put.

## Root cause

A data WRITE only needs to grow `size` and stamp `mtime`/`ctime`. Both commit paths did a full-row read-modify-write instead: `GetFile` (with its aggregate block-refs read) + `PutFile` (a 20-column rewrite). A single narrow `UPDATE` of the columns a write actually changes runs ~10x faster than that pair (53k vs 5.5k IOPS), verified to affect exactly one row.

## Fix

An optional `DataWriteApplier` a store transaction can implement to do the update as a narrow statement — grow `size` to `max(old,new)` so an out-of-order write never shrinks the file, stamp the times, clear setuid/setgid for a non-root writer, keep the `usedBytes`/quota deltas exact. Both write paths use it when present and fall back to the full read-modify-write otherwise, so backends adopt it incrementally.

Applied to **both** commit paths — the immediate one and, importantly, the pending-write flush behind `deferredCommit`, which is the **default** and therefore the path most deployments actually take.

- **sqlite**: `SELECT` old + narrow `UPDATE`, one transaction. **5,526 → 20,341 IOPS (3.7x)** — now level with badger.
- **postgres**: single statement — `RETURNING` references the pre-update CTE, so the old-size read and the guarded in-place update collapse into one round-trip. See the durability caveat below.
- **badger**: unchanged — it is in-process with no SQL-compile or round-trip tax and already at the target rate, so the fallback is its optimal path.

## Postgres: the SQL shape is not its wall

Measured on a co-located postgres 16 (8 vCPU), same op, scattered over 5k inodes:

| `synchronous_commit` | `GetFile`+`PutFile` | `ApplyDataWrite` | gain |
|---|---|---|---|
| `on` (default) | 3,999 | 4,132 | +3% |
| `off` | 9,160 | 13,940 | **+52%** |

At default durability postgres is bound by the per-commit WAL fsync, not by the statement shape — removing the fsync alone is worth 2.3x. Once that barrier is gone the narrow write is worth another ~52%, so the change is the right shape and is kept, but **it does not by itself move postgres at default durability**. Closing the postgres half of #1819 needs a commit-level lever, which is a separate change and not one to take by quietly weakening durability.

## Two real bugs this surfaced

- The postgres `ApplyDataWrite` never planned at all (`~` on an untyped parameter is ambiguous), so it failed every call. CI stayed green because the postgres jobs run with the default `deferredCommit`, which never reached the immediate path — the exact blind spot the new gated tests close.
- The hot-row benchmark targeted the share root, a *directory*. Re-pointed at a regular file it reads 5,526 rather than an inflated ~7,000, which is also much closer to the field baseline.

## Soundness

- Full sqlite conformance suite green; postgres conformance green (two `TestPostgresPutFile_*` failures on the bench box reproduce with all of this PR's files removed — pre-existing, unrelated).
- Dedicated soundness tests green on **both** sqlite and postgres: grows to `max(old,new)`, never shrinks on out-of-order writes, clears/keeps setuid correctly, exact usedBytes/quota delta, correct `ErrNotFound`/`ErrIsDirectory`.
- `-race` clean under concurrent writers across metadata, sqlite, badger, and memory.
- The postgres soundness test and write-path benchmark are gated on `DITTOFS_TEST_POSTGRES_DSN`, matching the existing postgres suites.

Closes #1819 for sqlite; the postgres commit-fsync wall is called out above and needs its own change. The narrow-write primitive carries directly into the SQL-family unification (#1828).
