### PR TITLE
fix(journal): persist cold intervals so evicted ranges are not read as holes (#1850)

### DIFF
--- a/pkg/block/engine/flush.go
+++ b/pkg/block/engine/flush.go
@@ -101,28 +101,24 @@ func (bs *Store) DrainRollups(ctx context.Context) error {
 	return err
 }
 
-// ResetLocalState clears the local store's per-payload append-log state so
-// post-restore reads resolve purely through the restored CAS manifest.
-// The snapshot-restore orchestration calls this BEFORE the metadata Reset()
-// + Restore() (not after): clearing the overlay first leaves no dirty
-// intervals for a background rollup worker to flush into the freshly-restored
-// metadata, so a file modified in place after the snapshot is not served from
-// a stale append-log record overlaid on the restored CAS bytes.
-// SeedCold marks [offset, offset+length) of payloadID as remote-durable-but-not-
-// local so a subsequent read faults it in from the remote store rather than
-// zero-filling. Snapshot restore calls it (per restored FileChunk extent, remote
-// shares only) to re-arm cold reads after ResetLocalState wiped the local tier.
-// No-op when the local store has no remote-hydration support (e.g. the in-memory
-// test store), which the caller only hits on non-remote paths anyway.
-func (bs *Store) SeedCold(ctx context.Context, payloadID string, offset, length int64) error {
+// SeedCold marks payloadID's extents — each an {offset, length} pair — as
+// remote-durable-but-not-local so a subsequent read faults them in from the
+// remote store rather than zero-filling. Callers pass a whole file's extents at
+// once: the local tier persists the markers, and one durable write per file beats
+// one per extent when a caller is seeding an entire manifest. Snapshot restore
+// and the pre-journal upgrade both use it (remote-backed shares only) to arm cold
+// reads over a local tier that holds none of the bytes. No-op when the local store
+// has no remote-hydration support (e.g. the in-memory test store), which the
+// caller only hits on non-remote paths anyway.
+func (bs *Store) SeedCold(ctx context.Context, payloadID string, extents [][2]int64) error {
 	type coldSeeder interface {
-		SeedCold(ctx context.Context, id journal.FileID, offset, length int64) error
+		SeedCold(ctx context.Context, id journal.FileID, extents [][2]int64) error
 	}
 	cs, ok := bs.local.(coldSeeder)
 	if !ok {
 		return nil
 	}
-	return cs.SeedCold(ctx, journal.FileID(payloadID), offset, length)
+	return cs.SeedCold(ctx, journal.FileID(payloadID), extents)
 }
 
 // RestoreToVersion rewinds the local journal to a snapshot's version watermark
@@ -167,6 +163,13 @@ func (bs *Store) JournalVersion() uint64 {
 	return 0
 }
 
+// ResetLocalState drops every file's locally cached ranges so post-restore reads
+// resolve purely through the restored manifest. The snapshot-restore
+// orchestration calls it BEFORE the metadata Reset() + Restore(), not after:
+// clearing the local tier first leaves no dirty interval for a background rollup
+// worker to flush into the freshly-restored metadata, so a file modified in place
+// after the snapshot is never served from a stale local record overlaid on the
+// restored bytes.
 func (bs *Store) ResetLocalState(ctx context.Context) error {
 	if err := bs.enter(); err != nil {
 		return err

--- a/pkg/block/journal/cold.go
+++ b/pkg/block/journal/cold.go
@@ -119,9 +119,20 @@ func (s *Store) appendCold(entries []coldEntry) error {
 	s.coldMu.Lock()
 	defer s.coldMu.Unlock()
 	if s.coldFD == nil {
+		_, statErr := os.Stat(s.coldPath())
+		created := errors.Is(statErr, os.ErrNotExist)
 		fd, err := os.OpenFile(s.coldPath(), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
 		if err != nil {
 			return fmt.Errorf("journal: open cold log: %w", err)
+		}
+		// Syncing the file does not make its directory entry durable. Without
+		// this, a crash right after the first eviction can come back to no
+		// cold.log at all — the exact loss this file exists to prevent.
+		if created {
+			if derr := fsyncDir(s.dir); derr != nil {
+				_ = fd.Close()
+				return fmt.Errorf("journal: fsync dir for cold log: %w", derr)
+			}
 		}
 		s.coldFD = fd
 	}
@@ -129,6 +140,11 @@ func (s *Store) appendCold(entries []coldEntry) error {
 	for _, e := range entries {
 		if e.length <= 0 {
 			continue
+		}
+		if len(e.id) > maxFileIDLen {
+			// FileIDLen is uint16 on disk; a longer ID would be silently
+			// truncated and make every following entry unreplayable.
+			return fmt.Errorf("journal: cold log FileID length %d exceeds max %d", len(e.id), maxFileIDLen)
 		}
 		buf = append(buf, encodeColdEntry(e)...)
 	}
@@ -180,10 +196,13 @@ func (s *Store) rewriteCold(entries []coldEntry) error {
 	}
 	path := s.coldPath()
 	if len(entries) == 0 {
-		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := os.Remove(path); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
 			return fmt.Errorf("journal: remove cold log: %w", err)
 		}
-		return nil
+		return fsyncDir(s.dir)
 	}
 	tmp := path + ".tmp"
 	fd, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
@@ -207,6 +226,11 @@ func (s *Store) rewriteCold(entries []coldEntry) error {
 	}
 	if err := os.Rename(tmp, path); err != nil {
 		return fmt.Errorf("journal: rename cold log: %w", err)
+	}
+	// The rename itself needs a directory flush to be durable; without it a
+	// crash can leave the pre-compaction log — or neither file.
+	if err := fsyncDir(s.dir); err != nil {
+		return fmt.Errorf("journal: fsync dir after cold log rewrite: %w", err)
 	}
 	return nil
 }

--- a/pkg/block/journal/cold.go
+++ b/pkg/block/journal/cold.go
@@ -1,0 +1,242 @@
+package journal
+
+// cold.go makes cold intervals survive a restart.
+//
+// A cold interval is a range that is durable on the remote store but holds no
+// local bytes: eviction dropped the segment that held them, or a range was
+// seeded cold because the local tier never had them (an upgrade that archived a
+// pre-journal layout aside, a snapshot restore that wiped the tier). Unlike a
+// warm interval it owns no record, and the interval index is rebuilt purely from
+// segment records — so without a durable side-log every cold interval comes back
+// from a restart as a POSIX hole, and a read zero-fills instead of fetching from
+// the remote. That is a silent-wrong-bytes failure, not a slow read, so the log
+// is fsynced before the eviction that needs it unlinks its segment.
+//
+// The log cannot live in the segment stream itself: a segment holding nothing
+// but cold markers has no live warm interval, so eviction and GC would reclaim
+// it and take the markers with it.
+//
+// Layout: <dir>/cold.log, an append-only entry stream, little-endian
+//
+//	off  size  field
+//	0    1     MagicByte    0xC0, torn-write scan anchor
+//	1    2     FileIDLen
+//	3    8     FileOffset
+//	11   8     Length
+//	19   8     Version
+//	27   4     CRC32        over bytes [0,27) and the FileID bytes
+//	31   var   FileID
+//
+// Entries are replayed at recovery like any other record — inserted by Version,
+// so a later warm write shadows a cold entry, and the tombstone and truncate
+// markers clip them exactly as they clip warm intervals. A torn tail ends the
+// load: only the tail can tear, and every entry before it is intact.
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"os"
+	"path/filepath"
+)
+
+const (
+	coldMagic      = 0xC0
+	coldHeaderSize = 31
+	coldLogName    = "cold.log"
+
+	// coldCompactFloor keeps recovery from rewriting a log that is merely small:
+	// compaction only pays once the dead entries outweigh a few pages of I/O.
+	coldCompactFloor = 1024
+)
+
+// coldEntry is one persisted cold interval.
+type coldEntry struct {
+	id      FileID
+	fileOff int64
+	length  int64
+	version uint64
+}
+
+func (s *Store) coldPath() string { return filepath.Join(s.dir, coldLogName) }
+
+// encodeColdEntry frames one entry.
+func encodeColdEntry(e coldEntry) []byte {
+	buf := make([]byte, coldHeaderSize+len(e.id))
+	buf[0] = coldMagic
+	binary.LittleEndian.PutUint16(buf[1:3], uint16(len(e.id)))
+	binary.LittleEndian.PutUint64(buf[3:11], uint64(e.fileOff))
+	binary.LittleEndian.PutUint64(buf[11:19], uint64(e.length))
+	binary.LittleEndian.PutUint64(buf[19:27], e.version)
+	copy(buf[coldHeaderSize:], e.id)
+	binary.LittleEndian.PutUint32(buf[27:31], coldEntryCRC(buf[:27], buf[coldHeaderSize:]))
+	return buf
+}
+
+// coldEntryCRC checksums an entry's header (excluding the CRC field itself) and
+// its FileID bytes as one stream.
+func coldEntryCRC(head, id []byte) uint32 {
+	return crc32.Update(crc32.Checksum(head, crcTable), crcTable, id)
+}
+
+// decodeColdEntry parses one entry from the head of buf, returning it and the
+// total bytes consumed. A malformed entry (bad magic, short read, CRC mismatch)
+// returns errTornRecord, which ends the load.
+func decodeColdEntry(buf []byte) (coldEntry, int, error) {
+	if len(buf) < coldHeaderSize {
+		return coldEntry{}, 0, fmt.Errorf("%w: short cold entry header", errTornRecord)
+	}
+	if buf[0] != coldMagic {
+		return coldEntry{}, 0, fmt.Errorf("%w: bad cold entry magic 0x%02x", errTornRecord, buf[0])
+	}
+	idLen := int(binary.LittleEndian.Uint16(buf[1:3]))
+	total := coldHeaderSize + idLen
+	if len(buf) < total {
+		return coldEntry{}, 0, fmt.Errorf("%w: cold entry runs past end of log", errTornRecord)
+	}
+	id := buf[coldHeaderSize:total]
+	want := binary.LittleEndian.Uint32(buf[27:31])
+	if got := coldEntryCRC(buf[:27], id); got != want {
+		return coldEntry{}, 0, fmt.Errorf("%w: cold entry CRC mismatch", errTornRecord)
+	}
+	return coldEntry{
+		id:      FileID(id),
+		fileOff: int64(binary.LittleEndian.Uint64(buf[3:11])),
+		length:  int64(binary.LittleEndian.Uint64(buf[11:19])),
+		version: binary.LittleEndian.Uint64(buf[19:27]),
+	}, total, nil
+}
+
+// appendCold durably records entries so a restart still knows the ranges are
+// remote-resident rather than holes. It fsyncs before returning: the caller
+// (eviction) is about to unlink the only local copy of those bytes, and a lost
+// entry means silent zeros, not a slow read.
+func (s *Store) appendCold(entries []coldEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	s.coldMu.Lock()
+	defer s.coldMu.Unlock()
+	if s.coldFD == nil {
+		fd, err := os.OpenFile(s.coldPath(), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+		if err != nil {
+			return fmt.Errorf("journal: open cold log: %w", err)
+		}
+		s.coldFD = fd
+	}
+	var buf []byte
+	for _, e := range entries {
+		if e.length <= 0 {
+			continue
+		}
+		buf = append(buf, encodeColdEntry(e)...)
+	}
+	if len(buf) == 0 {
+		return nil
+	}
+	if _, err := s.coldFD.Write(buf); err != nil {
+		return fmt.Errorf("journal: append cold log: %w", err)
+	}
+	if err := s.coldFD.Sync(); err != nil {
+		return fmt.Errorf("journal: fsync cold log: %w", err)
+	}
+	return nil
+}
+
+// loadCold reads every intact entry from dir's cold log. A missing log is not an
+// error (no eviction or seed has happened yet). It stops at the first torn entry
+// and returns what precedes it.
+func loadCold(dir string) ([]coldEntry, error) {
+	raw, err := os.ReadFile(filepath.Join(dir, coldLogName))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("journal: read cold log: %w", err)
+	}
+	var out []coldEntry
+	for off := 0; off < len(raw); {
+		e, n, derr := decodeColdEntry(raw[off:])
+		if derr != nil {
+			logf("journal: WARN cold log torn at offset %d, keeping %d intact entry(ies): %v", off, len(out), derr)
+			break
+		}
+		out = append(out, e)
+		off += n
+	}
+	return out, nil
+}
+
+// rewriteCold replaces the log with exactly entries, dropping the ones recovery
+// found superseded, deleted or truncated away. Written to a temp file and
+// renamed so a crash mid-rewrite leaves the previous log intact.
+func (s *Store) rewriteCold(entries []coldEntry) error {
+	s.coldMu.Lock()
+	defer s.coldMu.Unlock()
+	if s.coldFD != nil {
+		_ = s.coldFD.Close()
+		s.coldFD = nil
+	}
+	path := s.coldPath()
+	if len(entries) == 0 {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("journal: remove cold log: %w", err)
+		}
+		return nil
+	}
+	tmp := path + ".tmp"
+	fd, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("journal: create cold log temp: %w", err)
+	}
+	var buf []byte
+	for _, e := range entries {
+		buf = append(buf, encodeColdEntry(e)...)
+	}
+	if _, err := fd.Write(buf); err != nil {
+		_ = fd.Close()
+		return fmt.Errorf("journal: write cold log temp: %w", err)
+	}
+	if err := fd.Sync(); err != nil {
+		_ = fd.Close()
+		return fmt.Errorf("journal: fsync cold log temp: %w", err)
+	}
+	if err := fd.Close(); err != nil {
+		return fmt.Errorf("journal: close cold log temp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("journal: rename cold log: %w", err)
+	}
+	return nil
+}
+
+// liveColdEntries collects the cold intervals a recovery ended up with, which is
+// the set a compaction should keep. Called during recovery, before the shards are
+// published, so it needs no locking.
+func liveColdEntries(indexByShard []map[FileID]*fileIndex) []coldEntry {
+	var out []coldEntry
+	for _, idxMap := range indexByShard {
+		for id, fi := range idxMap {
+			for _, iv := range fi.ivs {
+				if !iv.cold {
+					continue
+				}
+				out = append(out, coldEntry{id: id, fileOff: iv.fileOff, length: iv.length, version: iv.version})
+			}
+		}
+	}
+	return out
+}
+
+// closeCold releases the append handle. Idempotent.
+func (s *Store) closeCold() error {
+	s.coldMu.Lock()
+	defer s.coldMu.Unlock()
+	if s.coldFD == nil {
+		return nil
+	}
+	err := s.coldFD.Close()
+	s.coldFD = nil
+	return err
+}

--- a/pkg/block/journal/cold_test.go
+++ b/pkg/block/journal/cold_test.go
@@ -1,0 +1,198 @@
+package journal
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// allZero reports whether b is entirely zero bytes — the shape a silent
+// zero-fill takes when a cold range is mistaken for a POSIX hole.
+func allZero(b []byte) bool {
+	for _, c := range b {
+		if c != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// TestColdIntervalSurvivesReopen is the regression for a share serving all-zeros
+// after a restart. A cold interval owns no record, so if it is only held in
+// memory the reopened store sees a hole, ReadAt zero-fills and reports cold=false
+// — the engine never fetches, and the read silently returns zeros for data that
+// is safe on the remote.
+func TestColdIntervalSurvivesReopen(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
+
+	s, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	// Hydrate (not WriteAt) so every record is born synced and the whole shard is
+	// evictable; two sealed segments plus the active one.
+	fillUntilSealed(t, s, "f", true, 2)
+
+	// Drain the shard: a large target evicts every qualifying segment, including
+	// the force-sealed active, so offset 0 is unambiguously cold afterwards.
+	if _, err := s.Evict(ctx, 1<<30); err != nil {
+		t.Fatalf("Evict: %v", err)
+	}
+
+	dst := make([]byte, chunk256)
+	_, cold, err := s.ReadAt(ctx, "f", 0, dst)
+	if err != nil {
+		t.Fatalf("ReadAt before reopen: %v", err)
+	}
+	if !cold {
+		t.Fatal("ReadAt before reopen: cold=false, want true after evicting the range")
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	s2, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = s2.Close() }()
+
+	dst2 := make([]byte, chunk256)
+	n, cold, err := s2.ReadAt(ctx, "f", 0, dst2)
+	if err != nil {
+		t.Fatalf("ReadAt after reopen: %v", err)
+	}
+	if !cold {
+		t.Errorf("ReadAt after reopen: cold=false — the evicted range reads as a hole, so the caller returns %d zero bytes without fetching from the remote", n)
+	}
+	if !allZero(dst2) {
+		t.Errorf("ReadAt after reopen: cold range should still zero-fill its placeholder bytes")
+	}
+}
+
+// TestSeedColdSurvivesReopen covers the seeded flavor: an upgrade that archives a
+// pre-journal layout aside (or a snapshot restore) seeds cold intervals from the
+// surviving manifest against an otherwise empty journal. Losing them on restart
+// is what left a migrated share serving zeros.
+func TestSeedColdSurvivesReopen(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
+
+	s, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := s.SeedCold(ctx, "f", [][2]int64{{0, 4096}}); err != nil {
+		t.Fatalf("SeedCold: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	s2, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = s2.Close() }()
+
+	dst := make([]byte, 4096)
+	if _, cold, err := s2.ReadAt(ctx, "f", 0, dst); err != nil {
+		t.Fatalf("ReadAt after reopen: %v", err)
+	} else if !cold {
+		t.Error("ReadAt after reopen: cold=false — a seeded cold range reads as a hole, so reads return zeros with no remote fetch")
+	}
+}
+
+// TestColdLogSupersededByLaterWrite checks the version ordering: a cold entry
+// replayed at recovery must not shadow a warm write that landed after it.
+func TestColdLogSupersededByLaterWrite(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
+
+	s, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := s.SeedCold(ctx, "f", [][2]int64{{0, 4096}}); err != nil {
+		t.Fatalf("SeedCold: %v", err)
+	}
+	want := bytes.Repeat([]byte{0x7E}, 4096)
+	if err := s.WriteAt(ctx, "f", 0, want); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.Commit(ctx, "f"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	s2, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = s2.Close() }()
+
+	got := make([]byte, 4096)
+	_, cold, err := s2.ReadAt(ctx, "f", 0, got)
+	if err != nil {
+		t.Fatalf("ReadAt after reopen: %v", err)
+	}
+	if cold {
+		t.Error("ReadAt after reopen: cold=true — the stale cold entry shadowed the newer local write")
+	}
+	if !bytes.Equal(got, want) {
+		t.Error("ReadAt after reopen: did not return the bytes written after the seed")
+	}
+}
+
+// TestColdLogTornTailKeepsIntactEntries checks that a crash mid-append costs only
+// the torn entry: everything written before it still replays.
+func TestColdLogTornTailKeepsIntactEntries(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
+
+	s, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := s.SeedCold(ctx, "f", [][2]int64{{0, 4096}}); err != nil {
+		t.Fatalf("SeedCold: %v", err)
+	}
+	if err := s.SeedCold(ctx, "g", [][2]int64{{0, 4096}}); err != nil {
+		t.Fatalf("SeedCold: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Tear the final entry: drop its last byte so its CRC check fails.
+	path := filepath.Join(dir, coldLogName)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read cold log: %v", err)
+	}
+	if err := os.WriteFile(path, raw[:len(raw)-1], 0o644); err != nil {
+		t.Fatalf("truncate cold log: %v", err)
+	}
+
+	s2, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = s2.Close() }()
+
+	dst := make([]byte, 4096)
+	if _, cold, err := s2.ReadAt(ctx, "f", 0, dst); err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	} else if !cold {
+		t.Error("the entry before the torn tail was dropped; only the torn one should be lost")
+	}
+}

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -192,12 +192,41 @@ func evictable(seg *segmentMeta) bool {
 		seg.syncedRecords.Load() == seg.records.Load()
 }
 
-// evictSegment removes one claimed sealed segment. Under the shard lock it
-// rewrites every interval-tree entry backed by the segment to a cold marker — so
-// a later read of that range fetches from the remote store instead of seeing a
-// false POSIX hole, and DataExtents still reports the range as present — then
-// retires the segment. Caller must have claimed seg.busy.
+// evictSegment removes one claimed sealed segment. Every interval-tree entry
+// backed by the segment becomes a cold marker — so a later read of that range
+// fetches from the remote store instead of seeing a false POSIX hole, and
+// DataExtents still reports the range as present — and only then is the segment
+// retired. Caller must have claimed seg.busy.
+//
+// The markers are persisted to the cold log FIRST, while the segment is still on
+// disk: they are the only remaining record that those ranges hold data, so a
+// crash between marking and unlinking must not be able to lose them. Persisting
+// first can at worst leave a marker for bytes that are still local (the eviction
+// did not complete), which costs a needless remote fetch — the opposite order
+// would serve zeros.
 func (s *Store) evictSegment(sh *shard, seg *segmentMeta) (int64, error) {
+	sh.mu.Lock()
+	var entries []coldEntry
+	for id, fi := range sh.index {
+		for k := range fi.ivs {
+			if fi.ivs[k].loc.SegmentID == seg.id && !fi.ivs[k].cold {
+				entries = append(entries, coldEntry{
+					id:      id,
+					fileOff: fi.ivs[k].fileOff,
+					length:  fi.ivs[k].length,
+					version: fi.ivs[k].version,
+				})
+			}
+		}
+	}
+	sh.mu.Unlock()
+
+	if err := s.appendCold(entries); err != nil {
+		// Without a durable marker the range would come back from a restart as a
+		// hole, so keep the segment (and its bytes) instead of evicting blind.
+		return 0, err
+	}
+
 	sh.mu.Lock()
 	for _, fi := range sh.index {
 		for k := range fi.ivs {

--- a/pkg/block/journal/recovery.go
+++ b/pkg/block/journal/recovery.go
@@ -241,6 +241,38 @@ func (s *Store) recover() error {
 		logf("journal: WARN %d segment(s) missing .idx sidecar, rebuilding from segment scan (recovery slower)", missingIdx)
 	}
 
+	// Replay the cold log (cold.go). A cold interval owns no record — eviction
+	// unlinked the segment that held its bytes, or the range was seeded cold from
+	// a surviving manifest — so this side-log is the only thing that keeps the
+	// range from coming back as a POSIX hole that reads as zeros. Inserted with
+	// each entry's original Version, so a later warm write shadows it and the
+	// tombstone/truncate passes below clip it exactly like a warm interval.
+	coldLoaded, err := loadCold(s.dir)
+	if err != nil {
+		return err
+	}
+	for _, e := range coldLoaded {
+		if e.length <= 0 {
+			continue
+		}
+		if e.version > maxVersion {
+			maxVersion = e.version
+		}
+		idxMap := indexByShard[s.shardIndex(e.id)]
+		fi := idxMap[e.id]
+		if fi == nil {
+			fi = &fileIndex{}
+			idxMap[e.id] = fi
+		}
+		fi.insert(interval{
+			fileOff: e.fileOff,
+			length:  e.length,
+			version: e.version,
+			synced:  true,
+			cold:    true,
+		})
+	}
+
 	s.nextSeg.Store(maxSegID + 1)
 	// nextVersion increments-then-returns, so storing maxVersion makes the next
 	// issued LSN exactly max(observed)+1 — strictly past every replayed record.
@@ -295,6 +327,21 @@ func (s *Store) recover() error {
 			} else {
 				fi.ivs = kept
 			}
+		}
+	}
+
+	// Compact the cold log once the live set has drifted well below what the log
+	// holds: entries superseded by a later hydrate, buried by a tombstone or
+	// clipped by a truncate are dead weight the next recovery would replay again.
+	// Recovery is the only place the surviving set is known, and rewriting is
+	// atomic (temp + rename), so a crash here keeps the previous log.
+	// ponytail: compaction only at open — the log grows within one uptime only as
+	// fast as eviction marks new ranges cold, which is bounded by the local cap.
+	if live := liveColdEntries(indexByShard); len(coldLoaded) > 2*len(live)+coldCompactFloor {
+		if werr := s.rewriteCold(live); werr != nil {
+			// Non-fatal: a stale-but-valid log costs redundant replay, not
+			// correctness, and refusing to open would strand the whole share.
+			logf("journal: WARN cold log compaction failed, keeping the existing log: %v", werr)
 		}
 	}
 

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -192,6 +192,12 @@ type Store struct {
 
 	closed atomic.Bool
 
+	// coldMu guards the cold log's append handle (see cold.go). The log records
+	// every cold interval so a restart still knows those ranges are
+	// remote-resident rather than POSIX holes.
+	coldMu sync.Mutex
+	coldFD *os.File
+
 	// gcCancel/gcDone govern the background dead-ratio GC loop started by
 	// Open: cancel stops the loop, and Close waits on gcDone so no repack is
 	// still in flight when segment files are closed underneath it.
@@ -282,7 +288,7 @@ func (s *Store) Close() error {
 		s.gcCancel()
 		<-s.gcDone
 	}
-	var firstErr error
+	firstErr := s.closeCold()
 	for _, sh := range s.shards {
 		if sh == nil {
 			continue
@@ -356,28 +362,46 @@ func (s *Store) Hydrate(ctx context.Context, id FileID, offset int64, data []byt
 // SeedCold registers a byte range as remote-durable-but-not-local: a read of it
 // reports cold so the engine hydrates it from the remote store instead of
 // zero-filling. Snapshot restore seeds the restored FileChunk manifest's extents
-// this way after ResetLocalState wiped the local tier — the bytes live in remote,
-// addressed by the restored manifest. The caller (restore, remote-backed shares
+// this way after the local tier was wiped, and an upgrade that archives a
+// pre-journal layout aside seeds the surviving manifest the same way — the bytes
+// live in remote, addressed by that manifest. The caller (remote-backed shares
 // only) guarantees the range is remotely backed; a hydrate replaces the seeded
 // cold interval with the fetched warm bytes on first read.
-func (s *Store) SeedCold(_ context.Context, id FileID, offset, length int64) error {
+//
+// The markers are persisted before they are indexed: an in-memory-only seed would
+// be lost on the next restart, turning the ranges back into holes that read as
+// zeros with no fetch. Extents are taken a whole file at a time so seeding a
+// manifest costs one fsync per file rather than one per extent.
+func (s *Store) SeedCold(_ context.Context, id FileID, extents [][2]int64) error {
 	if s.closed.Load() {
 		return errClosed
 	}
-	if length <= 0 {
+	entries := make([]coldEntry, 0, len(extents))
+	for _, e := range extents {
+		if e[1] <= 0 {
+			continue
+		}
+		entries = append(entries, coldEntry{id: id, fileOff: e[0], length: e[1], version: s.nextVersion()})
+	}
+	if len(entries) == 0 {
 		return nil
+	}
+	if err := s.appendCold(entries); err != nil {
+		return err
 	}
 	sh := s.shardFor(id)
 	sh.mu.Lock()
 	defer sh.mu.Unlock()
 	fi := sh.indexFor(id)
-	fi.insert(interval{
-		fileOff: offset,
-		length:  length,
-		version: s.nextVersion(),
-		synced:  true,
-		cold:    true,
-	})
+	for _, e := range entries {
+		fi.insert(interval{
+			fileOff: e.fileOff,
+			length:  e.length,
+			version: e.version,
+			synced:  true,
+			cold:    true,
+		})
+	}
 	return nil
 }
 

--- a/pkg/controlplane/runtime/shares/legacy_migrate_test.go
+++ b/pkg/controlplane/runtime/shares/legacy_migrate_test.go
@@ -55,25 +55,29 @@ func newMigrateEngine(t *testing.T, dir string, ms *metamem.MemoryMetadataStore,
 	return bs
 }
 
-// TestLegacyRemoteMigration_ReadsColdFromRemote is the whole point of the
-// remote-backed upgrade path: a share whose local dir carried the pre-journal
-// blobs/+logs/ layout must, after migration, serve byte-identical data by cold-
-// fetching from the remote via the surviving metadata manifest — not zeros.
-func TestLegacyRemoteMigration_ReadsColdFromRemote(t *testing.T) {
+// legacyShareFiles is the content a pre-journal share was holding before the
+// upgrade. Sizes straddle the sub-chunk and multi-chunk read paths.
+var legacyShareFiles = map[string][]byte{
+	"small-a":  bytes.Repeat([]byte{0x11}, 4096),
+	"small-b":  []byte("the quick brown fox jumps over the lazy dog"),
+	"multi-mb": bytes.Repeat([]byte{0x5A, 0xA5}, 3*1024*1024),
+}
+
+// plantPreJournalShare writes legacyShareFiles through a pre-upgrade engine (so
+// the bytes land in the remote and the FileChunk manifest), then replaces the
+// local journal with the leftover blobs/+logs/ of a pre-journal release. The
+// returned remote and metadata store survive the upgrade intact, exactly as they
+// do in the field — only the local tier is legacy.
+func plantPreJournalShare(t *testing.T) (string, *metamem.MemoryMetadataStore, *remotememory.Store) {
+	t.Helper()
 	ctx := context.Background()
 	dir := t.TempDir()
 	ms := metamem.NewMemoryMetadataStoreWithDefaults()
 	t.Cleanup(func() { _ = ms.Close() })
 	rem := remotememory.New()
 
-	// --- v0.26-era write: data lands in the remote + manifest ---
 	bs1 := newMigrateEngine(t, dir, ms, rem, false)
-	files := map[string][]byte{
-		"small-a":  bytes.Repeat([]byte{0x11}, 4096),
-		"small-b":  []byte("the quick brown fox jumps over the lazy dog"),
-		"multi-mb": bytes.Repeat([]byte{0x5A, 0xA5}, 3*1024*1024),
-	}
-	for id, data := range files {
+	for id, data := range legacyShareFiles {
 		if _, err := bs1.WriteAt(ctx, id, nil, data, 0); err != nil {
 			t.Fatalf("WriteAt %s: %v", id, err)
 		}
@@ -87,9 +91,6 @@ func TestLegacyRemoteMigration_ReadsColdFromRemote(t *testing.T) {
 		t.Fatalf("close bs1: %v", err)
 	}
 
-	// --- simulate the upgrade: wipe the journal, plant a pre-journal layout ---
-	// The remote (rem) and metadata (ms) survive intact — only the local journal
-	// is replaced by leftover v0.26 blobs/+logs/.
 	if err := os.RemoveAll(filepath.Join(dir, "journal")); err != nil {
 		t.Fatalf("wipe journal: %v", err)
 	}
@@ -105,8 +106,33 @@ func TestLegacyRemoteMigration_ReadsColdFromRemote(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "logs", "share", "f.log"), []byte("legacy"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	return dir, ms, rem
+}
 
-	// --- reopen on the new binary: migrate + cold-seed, then read ---
+// readAllLegacyFiles asserts every planted file reads back byte-identical.
+func readAllLegacyFiles(t *testing.T, bs *engine.Store, when string) {
+	t.Helper()
+	ctx := context.Background()
+	for id, want := range legacyShareFiles {
+		got := make([]byte, len(want))
+		n, err := bs.ReadAt(ctx, id, nil, got, 0)
+		if err != nil {
+			t.Fatalf("ReadAt %s %s: %v", id, when, err)
+		}
+		if n != len(want) || !bytes.Equal(got, want) {
+			t.Fatalf("ReadAt %s %s: read %d bytes, byte-identical=%v; served wrong bytes",
+				id, when, n, bytes.Equal(got, want))
+		}
+	}
+}
+
+// TestLegacyRemoteMigration_ReadsColdFromRemote is the whole point of the
+// remote-backed upgrade path: a share whose local dir carried the pre-journal
+// blobs/+logs/ layout must, after migration, serve byte-identical data by cold-
+// fetching from the remote via the surviving metadata manifest — not zeros.
+func TestLegacyRemoteMigration_ReadsColdFromRemote(t *testing.T) {
+	dir, ms, rem := plantPreJournalShare(t)
+
 	bs2 := newMigrateEngine(t, dir, ms, rem, true)
 	t.Cleanup(func() { _ = bs2.Close() })
 
@@ -116,16 +142,28 @@ func TestLegacyRemoteMigration_ReadsColdFromRemote(t *testing.T) {
 			t.Fatalf("legacy %s not archived: %v", sub, err)
 		}
 	}
+	readAllLegacyFiles(t, bs2, "after migration")
+}
 
-	for id, want := range files {
-		got := make([]byte, len(want))
-		n, err := bs2.ReadAt(ctx, id, nil, got, 0)
-		if err != nil {
-			t.Fatalf("ReadAt %s after migration: %v", id, err)
-		}
-		if n != len(want) || !bytes.Equal(got, want) {
-			t.Fatalf("ReadAt %s: read %d bytes, byte-identical=%v; migration served wrong bytes",
-				id, n, bytes.Equal(got, want))
-		}
+// TestLegacyRemoteMigration_ReadsColdAfterRestart is the field failure: the
+// migration completes, the server restarts, and only then is a file read. The
+// cold intervals the migration seeded are what make that read fetch instead of
+// zero-fill, so they must be durable — a restart that loses them turns every
+// range back into a POSIX hole and the share silently serves zeros of the right
+// length with no remote fetch at all. Nothing re-seeds on the second start: the
+// legacy dirs are already archived, so the migration does not run again.
+//
+// No read happens before the restart, deliberately: a read would hydrate the
+// bytes into the journal as warm records and mask the lost markers.
+func TestLegacyRemoteMigration_ReadsColdAfterRestart(t *testing.T) {
+	dir, ms, rem := plantPreJournalShare(t)
+
+	bs2 := newMigrateEngine(t, dir, ms, rem, true)
+	if err := bs2.Close(); err != nil {
+		t.Fatalf("close bs2: %v", err)
 	}
+
+	bs3 := newMigrateEngine(t, dir, ms, rem, false)
+	t.Cleanup(func() { _ = bs3.Close() })
+	readAllLegacyFiles(t, bs3, "after migration + restart")
 }

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -3089,14 +3089,16 @@ func applyDurableOverride(store any, config map[string]any, label, shareName str
 // copy of the data — after a snapshot restore wiped the local tier, or after a
 // pre-journal upgrade archived the legacy local layout aside. Remote-backed
 // shares only (the caller gates on that); the cold fetch it arms is
-// BLAKE3-verified. One ListFileChunks per payload — O(chunks), acceptable for a
-// rare control-plane / startup path.
+// BLAKE3-verified. One ListFileChunks and one SeedCold per payload — O(chunks),
+// acceptable for a rare control-plane / startup path, and seeding a whole file at
+// once keeps the local tier's durable write to one per file.
 func SeedColdFromManifest(ctx context.Context, bs *engine.Store, metaStore metadata.Store) error {
 	return metaStore.EnumeratePayloads(ctx, func(payloadID string) error {
 		rows, err := metaStore.ListFileChunks(ctx, payloadID)
 		if err != nil {
 			return fmt.Errorf("list manifest for %s: %w", payloadID, err)
 		}
+		extents := make([][2]int64, 0, len(rows))
 		for _, row := range rows {
 			if row == nil {
 				continue
@@ -3105,9 +3107,10 @@ func SeedColdFromManifest(ctx context.Context, bs *engine.Store, metaStore metad
 			if !ok {
 				continue
 			}
-			if err := bs.SeedCold(ctx, payloadID, int64(off), int64(row.DataSize)); err != nil {
-				return fmt.Errorf("seed cold %s: %w", row.ID, err)
-			}
+			extents = append(extents, [2]int64{int64(off), int64(row.DataSize)})
+		}
+		if err := bs.SeedCold(ctx, payloadID, extents); err != nil {
+			return fmt.Errorf("seed cold %s: %w", payloadID, err)
 		}
 		return nil
 	})


### PR DESCRIPTION
Fixes #1850.

## What breaks

A cold interval marks a range that is durable on the remote but holds no local bytes. It owns no record, and the interval index is rebuilt purely from segment records at recovery — so every cold interval was lost on restart. The range then came back as a POSIX hole: `journal.ReadAt` zero-filled it and reported `cold=false`, so the engine never hydrated, and the read returned zeros of the right length **with no remote request at all**.

Two ways in, both silent:

- **eviction** (`reclaim.go evictSegment`) flipped a dropped segment's intervals cold *in memory only*;
- the **pre-journal upgrade** (`service.go` → `SeedColdFromManifest`) and **snapshot restore** seed cold intervals from the surviving manifest against an otherwise empty journal.

The field report is the second: a migrated share served ~40 GiB of intact, fully-synced data as zeros after the next restart, because nothing re-seeds once the legacy dirs are archived (`hasLegacyLocalLayout` is false, so `MigratedFromLegacy()` never fires again).

The first is wider than the reported case: any remote-backed share that evicted a segment and restarted read those ranges as zeros.

## Fix

Cold intervals persist in a `cold.log` side-log, fsynced **before** the eviction that needs it unlinks its segment (markers-first: the opposite order can lose them, and a marker for bytes that are still local only costs a needless fetch).

They cannot live in the segment stream itself — a segment holding only cold markers has no live warm interval, so eviction and GC would reclaim it and take the markers with it.

Recovery replays entries by `Version` like any record, so a later warm write shadows a stale entry and the tombstone/truncate passes clip them exactly as they clip warm intervals. Recovery also compacts the log once the live set has drifted below it. A torn tail costs only the torn entry.

`SeedCold` now takes a whole file's extents, so seeding a manifest costs one durable write per file rather than one per extent (~27k fsyncs on the reporter's box otherwise).

## Tests

Each fails without the fix and passes with it:

- `TestColdIntervalSurvivesReopen` — evict, reopen, read: must still report cold.
- `TestSeedColdSurvivesReopen` — the seeded flavor.
- `TestColdLogSupersededByLaterWrite` — a stale entry must not shadow a newer local write.
- `TestColdLogTornTailKeepsIntactEntries` — crash mid-append costs only the torn entry.
- `TestLegacyRemoteMigration_ReadsColdAfterRestart` — the field sequence end to end (migrate → restart → read, with no read before the restart, which would warm the journal and mask it).

`go test ./...` clean with `-race` on `journal`, `engine`, `local/fs`. One unrelated pre-existing failure on this machine, `pkg/discovery/wsd TestResponder_StartStopNoDeadlock`, reproduces identically on clean `develop`.

## Not in this PR

- Recovery guidance for the affected deployment (`dfsctl share warm` rebuilds the local tier from the manifest and is immune to this bug — it never consulted cold intervals).
- The migration still does not verify content before declaring success, nor reap its own `*.pre-journal-backup` archive (the 55 GiB in #1843). Both follow-ups.