### PR TITLE
fix(dfsctl): render nfs-config show instead of crashing on a nil table renderer (#1854)

### DIFF
--- a/cmd/dfsctl/commands/share/nfs_config.go
+++ b/cmd/dfsctl/commands/share/nfs_config.go
@@ -3,6 +3,7 @@ package share
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
@@ -94,6 +95,43 @@ func init() {
 	nfsConfigCmd.AddCommand(nfsConfigSetCmd)
 }
 
+// NFSConfigDetail renders a share's NFS adapter config as a field/value table.
+type NFSConfigDetail struct {
+	cfg *apiclient.ShareNFSConfig
+}
+
+// Headers implements TableRenderer.
+func (d NFSConfigDetail) Headers() []string {
+	return []string{"FIELD", "VALUE"}
+}
+
+// Rows implements TableRenderer.
+func (d NFSConfigDetail) Rows() [][]string {
+	c := d.cfg
+	netgroup := c.Netgroup
+	if netgroup == "" {
+		netgroup = "(none - all clients allowed)"
+	}
+	rows := [][]string{
+		{"Netgroup", netgroup},
+		{"Squash", c.Squash},
+	}
+	// The anonymous IDs only apply to a squash mode that maps to them, and are
+	// server defaults when unset — show them only when the export overrides them.
+	if c.AnonymousUID != nil {
+		rows = append(rows, []string{"Anonymous UID", fmt.Sprintf("%d", *c.AnonymousUID)})
+	}
+	if c.AnonymousGID != nil {
+		rows = append(rows, []string{"Anonymous GID", fmt.Sprintf("%d", *c.AnonymousGID)})
+	}
+	return append(rows,
+		[]string{"Allow AUTH_SYS", strconv.FormatBool(c.AllowAuthSys)},
+		[]string{"Require Kerberos", strconv.FormatBool(c.RequireKerberos)},
+		[]string{"Min Kerberos level", c.MinKerberosLevel},
+		[]string{"READDIRPLUS", strconv.FormatBool(!c.DisableReaddirplus)},
+	)
+}
+
 func runNFSConfigShow(_ *cobra.Command, args []string) error {
 	client, err := cmdutil.GetAuthenticatedClient()
 	if err != nil {
@@ -105,7 +143,7 @@ func runNFSConfigShow(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get NFS config: %w", err)
 	}
 
-	return cmdutil.PrintResource(os.Stdout, cfg, nil)
+	return cmdutil.PrintResource(os.Stdout, cfg, NFSConfigDetail{cfg: cfg})
 }
 
 func runNFSConfigSet(cmd *cobra.Command, args []string) error {

--- a/cmd/dfsctl/commands/share/nfs_config_test.go
+++ b/cmd/dfsctl/commands/share/nfs_config_test.go
@@ -1,0 +1,66 @@
+package share
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/apiclient"
+)
+
+// rowValue returns the value column for field, or "" when the row is absent.
+func rowValue(rows [][]string, field string) string {
+	for _, r := range rows {
+		if len(r) == 2 && r[0] == field {
+			return r[1]
+		}
+	}
+	return ""
+}
+
+func TestNFSConfigDetail_Rows_Defaults(t *testing.T) {
+	rows := NFSConfigDetail{cfg: &apiclient.ShareNFSConfig{
+		Squash:       "none",
+		AllowAuthSys: true,
+	}}.Rows()
+
+	// An unset netgroup means every client is allowed; say so rather than
+	// rendering an empty cell the reader has to interpret.
+	if got := rowValue(rows, "Netgroup"); got == "" || got == "(none)" {
+		t.Errorf("Netgroup = %q, want an explicit all-clients-allowed value", got)
+	}
+	// DisableReaddirplus is stored negated, so a zero value must read as enabled.
+	if got := rowValue(rows, "READDIRPLUS"); got != "true" {
+		t.Errorf("READDIRPLUS = %q, want true when DisableReaddirplus is false", got)
+	}
+	// Unset anonymous IDs are server defaults, not export settings: omitted.
+	if got := rowValue(rows, "Anonymous UID"); got != "" {
+		t.Errorf("Anonymous UID rendered as %q despite being unset", got)
+	}
+}
+
+func TestNFSConfigDetail_Rows_Overrides(t *testing.T) {
+	uid, gid := uint32(65534), uint32(65533)
+	rows := NFSConfigDetail{cfg: &apiclient.ShareNFSConfig{
+		Squash:             "all_to_guest",
+		AnonymousUID:       &uid,
+		AnonymousGID:       &gid,
+		RequireKerberos:    true,
+		MinKerberosLevel:   "krb5p",
+		Netgroup:           "office",
+		DisableReaddirplus: true,
+	}}.Rows()
+
+	for field, want := range map[string]string{
+		"Netgroup":           "office",
+		"Squash":             "all_to_guest",
+		"Anonymous UID":      "65534",
+		"Anonymous GID":      "65533",
+		"Allow AUTH_SYS":     "false",
+		"Require Kerberos":   "true",
+		"Min Kerberos level": "krb5p",
+		"READDIRPLUS":        "false",
+	} {
+		if got := rowValue(rows, field); got != want {
+			t.Errorf("%s = %q, want %q", field, got, want)
+		}
+	}
+}

--- a/internal/cli/output/table.go
+++ b/internal/cli/output/table.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"errors"
 	"io"
 
 	"github.com/olekukonko/tablewriter"
@@ -15,7 +16,16 @@ type TableRenderer interface {
 }
 
 // PrintTable writes data as a formatted table to the writer.
+//
+// A nil renderer is a bug in the calling command, but it must not take the
+// process down: reaching Headers() through a nil interface panics, so a `show`
+// command that forgot its renderer crashes the CLI with a stack trace instead of
+// printing anything. Report it as an error and let the command surface it like
+// any other failure.
 func PrintTable(w io.Writer, data TableRenderer) error {
+	if data == nil {
+		return errors.New("no table renderer for this resource; retry with -o json")
+	}
 	table := tablewriter.NewWriter(w)
 	table.SetHeader(data.Headers())
 

--- a/internal/cli/output/table_test.go
+++ b/internal/cli/output/table_test.go
@@ -41,6 +41,18 @@ func TestPrintTable(t *testing.T) {
 	assert.Contains(t, output, "value2")
 }
 
+// TestPrintTableNilRenderer covers the crash a `show` command hit in the field:
+// it passed no renderer, and reaching Headers() through a nil interface took the
+// whole CLI down with a SIGSEGV stack trace. A missing renderer must surface as
+// an ordinary error, and write nothing.
+func TestPrintTableNilRenderer(t *testing.T) {
+	var buf bytes.Buffer
+	err := PrintTable(&buf, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "json", "the error should point the user at -o json")
+	assert.Empty(t, buf.String())
+}
+
 func TestSimpleTable(t *testing.T) {
 	pairs := [][2]string{
 		{"Key1", "Value1"},


### PR DESCRIPTION
Fixes #1854. Reported by a user evaluating DittoFS on Proxmox VE, on the v0.29.0 release binary.

`dfsctl share nfs-config show <name>` crashed with a SIGSEGV on every invocation that did not pass `-o json`/`-o yaml`: it called `PrintResource(os.Stdout, cfg, nil)` unconditionally, and in table format that nil `TableRenderer` reached `Headers()` through a nil interface inside `PrintTable`.

Two fixes, because there are two defects:

- **The command had no renderer.** Added `NFSConfigDetail`, a field/value table matching the `NetgroupDetail` idiom: netgroup (spelled out as all-clients-allowed when unset), squash, the anonymous UID/GID only when the export overrides them, the auth flavors, and READDIRPLUS un-negated from the stored `DisableReaddirplus`.
- **`PrintTable` could not survive a nil renderer.** It now returns an error pointing at `-o json`. A missing renderer is a caller bug, but it should not take down the CLI. Four other call sites (`netgroup show`, `adapter settings` x2, `share show`) pass nil too and are only safe because they check the output format first — nothing structural was stopping the next one from crashing the same way.

## Tests

- `TestPrintTableNilRenderer` — verified to reproduce the reported SIGSEGV without the guard.
- `TestNFSConfigDetail_Rows_Defaults` / `_Overrides` — cover the nil-pointer anonymous IDs and the negated READDIRPLUS bool.

No command or flag definitions changed, so `docs/guide/cli.md` does not need regenerating.

Same reporter also raised docs/help/log text referencing flags and subcommands that do not exist, and NFS interop trouble with Proxmox VE (`showmount`-based probing plus our non-standard default port). Both tracked separately.