### PR TITLE
fix(gc): reap completed gc-state run directories (#1852)

### DIFF
--- a/pkg/block/engine/gc.go
+++ b/pkg/block/engine/gc.go
@@ -456,7 +456,14 @@ func collectGarbage(
 	// Destroy, not Close: the mark set is scratch for this run only, so the run
 	// directory goes with it whether the run succeeded or failed. Leaving it
 	// behind grows the local store without bound.
-	defer func() { _ = gcs.Destroy() }()
+	// A failure here leaves the directory on disk, so say so: the next sweep
+	// reclaims it an hour later, but silence would make the growth this
+	// removes look like it came back on its own.
+	defer func() {
+		if err := gcs.Destroy(); err != nil {
+			slog.Warn("GC: run dir cleanup failed", "run_id", runID, "err", err)
+		}
+	}()
 
 	snapshotTime := time.Now()
 	slog.Info("GC: mark phase starting",

--- a/pkg/block/engine/gc.go
+++ b/pkg/block/engine/gc.go
@@ -453,7 +453,10 @@ func collectGarbage(
 		_ = PersistLastRunSummary(options.GCStateRoot, gcRunSummaryFromStats(stats, started, time.Now()))
 		return stats
 	}
-	defer func() { _ = gcs.Close() }()
+	// Destroy, not Close: the mark set is scratch for this run only, so the run
+	// directory goes with it whether the run succeeded or failed. Leaving it
+	// behind grows the local store without bound.
+	defer func() { _ = gcs.Destroy() }()
 
 	snapshotTime := time.Now()
 	slog.Info("GC: mark phase starting",

--- a/pkg/block/engine/gcstate.go
+++ b/pkg/block/engine/gcstate.go
@@ -6,10 +6,12 @@
 // file blocks would OOM if we held the entire live set in a Go map.
 //
 // Each run creates an `incomplete.flag` marker on entry and removes
-// it via MarkComplete() on success. CleanStaleGCStateDirs reclaims
-// any directory whose marker is still present (a crashed prior run).
-// Mark is idempotent; we do not resume a crashed run, we discard and
-// start fresh.
+// it via MarkComplete() on success. Mark is idempotent; we do not
+// resume a crashed run, we discard and start fresh — so a run's
+// directory is worthless the moment the run ends, and Destroy() removes
+// it. CleanStaleGCStateDirs is the backstop for directories no Destroy
+// ever reached: a crashed run (marker still present) or one left behind
+// by a release that did not clean up after itself.
 //
 // last-run.json is written under the gc-state root after a
 // successful run with aggregate counts that the operator and `dfsctl
@@ -32,6 +34,17 @@ import (
 const (
 	gcStateIncompleteFlag = "incomplete.flag"
 	gcStateLastRunFile    = "last-run.json"
+
+	// gcStateCompletedTTL is how long a completed (unflagged) run directory
+	// must have sat untouched before the backstop sweep reclaims it. Destroy
+	// removes a run's own directory, so anything the sweep finds unflagged was
+	// left by an older release or a process that died between MarkComplete and
+	// Destroy. The delay keeps the sweep off a directory another process may
+	// still be sweeping with: same-process runs serialize on the GC root lock,
+	// but cross-process safety needs an OS-level flock this package does not
+	// have yet, and an hour is far longer than the window between MarkComplete
+	// and the end of a sweep.
+	gcStateCompletedTTL = time.Hour
 )
 
 // GCState persists the GC mark-phase live set to disk under a per-runID
@@ -201,11 +214,29 @@ func (g *GCState) Close() error {
 // writes last-run.json under the parent rootDir) use this for diagnostics.
 func (g *GCState) RunDir() string { return g.runDir }
 
-// CleanStaleGCStateDirs removes any per-runID directory under rootDir
-// whose incomplete.flag still exists. Mark is idempotent so we
-// do not resume; we discard and start fresh. Completed dirs (no flag)
-// are left alone — the caller decides retention. The last-run.json file
-// at rootDir's top level is also left alone.
+// Destroy releases the Badger handle and removes the run directory. The mark
+// set is scratch space for one run — a crashed run is discarded rather than
+// resumed, so there is nothing to keep once the run ends, whether it succeeded
+// or failed. Without this the directories accumulate for the life of the
+// deployment; one field box reached 7.2 GiB of them. The run summary the
+// operator actually reads lives in last-run.json at the parent root, which is
+// untouched.
+func (g *GCState) Destroy() error {
+	err := g.Close()
+	if rerr := os.RemoveAll(g.runDir); rerr != nil && err == nil {
+		err = fmt.Errorf("gcstate: remove run dir %s: %w", g.runDir, rerr)
+	}
+	return err
+}
+
+// CleanStaleGCStateDirs reclaims per-runID directories under rootDir that no
+// run still needs: one whose incomplete.flag survives (a crashed run — mark is
+// idempotent, so we discard rather than resume), and one with no flag that has
+// sat untouched for gcStateCompletedTTL (a completed run whose Destroy never
+// ran, either because the process died first or because it predates Destroy).
+// A recently-completed directory is left alone in case another process is still
+// sweeping with it. The last-run.json file at rootDir's top level is never
+// touched.
 func CleanStaleGCStateDirs(rootDir string) error {
 	if rootDir == "" {
 		return nil
@@ -221,14 +252,28 @@ func CleanStaleGCStateDirs(rootDir string) error {
 		if !e.IsDir() {
 			continue
 		}
-		flag := filepath.Join(rootDir, e.Name(), gcStateIncompleteFlag)
-		if _, err := os.Stat(flag); err == nil {
-			if err := os.RemoveAll(filepath.Join(rootDir, e.Name())); err != nil {
-				return fmt.Errorf("gcstate: clean stale dir %s: %w", e.Name(), err)
-			}
+		dir := filepath.Join(rootDir, e.Name())
+		if !gcStateDirReclaimable(dir) {
+			continue
+		}
+		if err := os.RemoveAll(dir); err != nil {
+			return fmt.Errorf("gcstate: clean stale dir %s: %w", e.Name(), err)
 		}
 	}
 	return nil
+}
+
+// gcStateDirReclaimable reports whether a run directory is no longer needed:
+// flagged (crashed mid-mark) or unflagged and older than gcStateCompletedTTL.
+func gcStateDirReclaimable(dir string) bool {
+	if _, err := os.Stat(filepath.Join(dir, gcStateIncompleteFlag)); err == nil {
+		return true
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return false
+	}
+	return time.Since(info.ModTime()) > gcStateCompletedTTL
 }
 
 // GCRunSummary is the persisted last-run.json shape.

--- a/pkg/block/engine/gcstate_test.go
+++ b/pkg/block/engine/gcstate_test.go
@@ -127,8 +127,69 @@ func TestGCState_MarkComplete(t *testing.T) {
 	}
 }
 
+// TestGCState_DestroyRemovesRunDir: a finished run leaves nothing behind. The
+// mark set is scratch for one run, and directories that outlive their run grew
+// a field deployment's local store by gigabytes.
+func TestGCState_DestroyRemovesRunDir(t *testing.T) {
+	root := t.TempDir()
+	gcs, err := NewGCState(root, "test-run")
+	if err != nil {
+		t.Fatalf("NewGCState: %v", err)
+	}
+	runDir := gcs.RunDir()
+	if err := gcs.MarkComplete(); err != nil {
+		t.Fatalf("MarkComplete: %v", err)
+	}
+	if err := gcs.Destroy(); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+	if _, err := os.Stat(runDir); !os.IsNotExist(err) {
+		t.Errorf("run dir survived Destroy: stat err=%v", err)
+	}
+	// Destroy on an already-destroyed state must not error (deferred twice, or
+	// after an explicit call on the success path).
+	if err := gcs.Destroy(); err != nil {
+		t.Errorf("second Destroy: %v", err)
+	}
+}
+
+// TestGCState_CleanStaleGCStateDirs_ReapsOldCompletedDirs: the backstop for
+// directories no Destroy ever reached — a completed run from a release that did
+// not clean up, or a process that died after MarkComplete. Only once they are
+// past the TTL, so a run another process may still be sweeping with survives.
+func TestGCState_CleanStaleGCStateDirs_ReapsOldCompletedDirs(t *testing.T) {
+	root := t.TempDir()
+
+	for _, name := range []string{"old-complete", "fresh-complete"} {
+		gcs, err := NewGCState(root, name)
+		if err != nil {
+			t.Fatalf("NewGCState(%s): %v", name, err)
+		}
+		if err := gcs.MarkComplete(); err != nil {
+			t.Fatalf("MarkComplete(%s): %v", name, err)
+		}
+		_ = gcs.Close()
+	}
+	// Backdate one past the TTL.
+	old := filepath.Join(root, "old-complete")
+	past := time.Now().Add(-2 * gcStateCompletedTTL)
+	if err := os.Chtimes(old, past, past); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	if err := CleanStaleGCStateDirs(root); err != nil {
+		t.Fatalf("CleanStaleGCStateDirs: %v", err)
+	}
+	if _, err := os.Stat(old); !os.IsNotExist(err) {
+		t.Errorf("completed dir past the TTL was not reclaimed: stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "fresh-complete")); err != nil {
+		t.Errorf("recently completed dir was reclaimed: %v", err)
+	}
+}
+
 // TestGCState_CleanStaleGCStateDirs: removes every <runID>/ dir whose
-// incomplete.flag is still present; leaves complete dirs alone.
+// incomplete.flag is still present; leaves recently completed dirs alone.
 func TestGCState_CleanStaleGCStateDirs(t *testing.T) {
 	root := t.TempDir()
 


### PR DESCRIPTION
Fixes #1852. Surfaced by the field report in #1843.

Every GC run gets a `gc-state/<runID>/` directory holding a Badger store for its live-hash set. Only *crashed* runs were ever reclaimed — they leave an `incomplete.flag` behind, which is what `CleanStaleGCStateDirs` looks for. A run that completed removed its own flag, and its directory then survived forever ("completed dirs are left alone — the caller decides retention", and no caller ever decided). `Close()`'s doc already said it released the Badger handle "so the runDir can be removed"; nothing removed it.

On the reporting deployment that reached **7.2 GiB**, including a month-old run with a 769 MB DISCARD plus a 769 MB KEYREGISTRY, on a box wedged at 96% disk.

## Fix

- **`Destroy()`** — releases Badger and removes the run directory; `CollectGarbage` defers it instead of `Close()`. The mark set is scratch for a single run and a crashed run is discarded rather than resumed, so there is nothing worth keeping once the run ends, success or failure.
- **`CleanStaleGCStateDirs` becomes the backstop** — it now also reclaims unflagged directories older than an hour. That is what clears the ones already sitting on disk from earlier releases; without it, existing deployments would need a manual `rm`.

The hour keeps the sweep off a directory another process might still be sweeping with. Same-process runs already serialize on the GC root lock; cross-process safety needs an OS-level flock that this package documents as a TODO, and an hour is far longer than the window between `MarkComplete` and the end of a sweep.

`last-run.json` lives at the parent root, so `dfsctl store block gc-status` is unaffected.

## Tests

- `TestGCState_DestroyRemovesRunDir` — a finished run leaves nothing behind; `Destroy` is idempotent.
- `TestGCState_CleanStaleGCStateDirs_ReapsOldCompletedDirs` — a backdated completed dir is reclaimed, a fresh one survives.
- The existing `TestGCState_CleanStaleGCStateDirs` still passes unchanged: a recently completed dir is deliberately left alone.