### PR TITLE
docs: correct command paths and flags that no longer exist (#1857)

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -505,7 +505,7 @@ dfsctl store block remote add --name r1 --type s3 \
   --parallel-uploads 32          # fixed window of 32; 0 (default) = adaptive
 ```
 
-`dfsctl store block remote edit --name r1 --parallel-uploads 0` returns a remote
+`dfsctl store block remote edit r1 --parallel-uploads 0` returns a remote
 to adaptive mode. Observe the live window via the Prometheus gauge
 `dittofs_datapath_upload_window` (target concurrency) alongside
 `dittofs_datapath_uploads_inflight` (actual in-flight uploads); see
@@ -686,7 +686,7 @@ Add a `compression` block to the remote store's `config` JSON when
 creating it:
 
 ```bash
-./dfsctl store block add --kind remote --name prod-s3 --type s3 \
+./dfsctl store block remote add --name prod-s3 --type s3 \
   --config '{"region":"us-east-1","bucket":"dfs-production","compression":{"algo":"zstd"}}'
 ```
 
@@ -1253,7 +1253,7 @@ dfsctl user create --username bob --email bob@example.com --groups editors,viewe
 # Inspect and edit
 dfsctl user list
 dfsctl user get alice
-dfsctl user update alice --email alice@example.com
+dfsctl user edit alice --email alice@example.com
 dfsctl user remove alice
 
 # Passwords
@@ -2355,7 +2355,7 @@ Then create stores, shares, and enable adapters via CLI:
 
 ```bash
 ./dfsctl store metadata add --name default --type memory
-./dfsctl store block add --kind local --name default --type fs \
+./dfsctl store block local add --name default --type fs \
   --config '{"path":"/tmp/dittofs-blocks"}'
 ./dfsctl share create --name /export --metadata default --local default
 ./dfsctl adapter enable nfs
@@ -2373,7 +2373,7 @@ logging:
 
 ```bash
 ./dfsctl store metadata add --name dev-memory --type memory
-./dfsctl store block add --kind local --name dev-local --type memory
+./dfsctl store block local add --name dev-local --type memory
 ./dfsctl share create --name /export --metadata dev-memory --local dev-local
 ./dfsctl adapter enable nfs --port 12049
 ```
@@ -2406,9 +2406,9 @@ Then create stores, shares, and enable adapters via CLI:
 # Create stores
 ./dfsctl store metadata add --name prod-badger --type badger \
   --config '{"path":"/var/lib/dittofs/metadata"}'
-./dfsctl store block add --kind local --name prod-local --type fs \
+./dfsctl store block local add --name prod-local --type fs \
   --config '{"path":"/var/lib/dittofs/blocks"}'
-./dfsctl store block add --kind remote --name prod-s3 --type s3 \
+./dfsctl store block remote add --name prod-s3 --type s3 \
   --config '{"region":"us-east-1","bucket":"dfs-production"}'
 
 # Create share and grant permissions
@@ -2431,9 +2431,9 @@ Different shares using different storage backends:
   --config '{"path":"/var/lib/dittofs/metadata"}'
 
 # Create block stores
-./dfsctl store block add --kind local --name local-cache --type fs \
+./dfsctl store block local add --name local-cache --type fs \
   --config '{"path":"/var/lib/dittofs/blocks"}'
-./dfsctl store block add --kind remote --name cloud-s3 --type s3 \
+./dfsctl store block remote add --name cloud-s3 --type s3 \
   --config '{"region":"us-east-1","bucket":"my-dfs-bucket"}'
 
 # Create shares with different backends
@@ -2460,11 +2460,11 @@ Multiple shares sharing the same metadata database:
   --config '{"path":"/var/lib/dittofs/shared-metadata"}'
 
 # Create block stores
-./dfsctl store block add --kind local --name local-cache --type fs \
+./dfsctl store block local add --name local-cache --type fs \
   --config '{"path":"/var/lib/dittofs/blocks"}'
-./dfsctl store block add --kind remote --name s3-production --type s3 \
+./dfsctl store block remote add --name s3-production --type s3 \
   --config '{"region":"us-east-1","bucket":"prod-bucket"}'
-./dfsctl store block add --kind remote --name s3-archive --type s3 \
+./dfsctl store block remote add --name s3-archive --type s3 \
   --config '{"region":"us-east-1","bucket":"archive-bucket"}'
 
 # Both shares use the same metadata store, different remote stores

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -434,11 +434,11 @@ Yes! Multiple shares can reference the same store instance for resource efficien
   --config '{"path":"/var/lib/dittofs/shared-metadata"}'
 
 # Create separate remote block stores
-./dfsctl store block add --kind local --name shared-local --type fs \
+./dfsctl store block local add --name shared-local --type fs \
   --config '{"path":"/var/lib/dittofs/blocks"}'
-./dfsctl store block add --kind remote --name s3-prod --type s3 \
+./dfsctl store block remote add --name s3-prod --type s3 \
   --config '{"region":"us-east-1","bucket":"prod-bucket"}'
-./dfsctl store block add --kind remote --name s3-archive --type s3 \
+./dfsctl store block remote add --name s3-archive --type s3 \
   --config '{"region":"us-east-1","bucket":"archive-bucket"}'
 
 # Both shares use the same metadata store; remote stores are ref-counted

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -170,15 +170,15 @@ Signing behavior:
 - **Required** (default `false`): when `true`, the server rejects unsigned messages from
   established sessions.
 
-Configure via `dfsctl`:
+Configure via `dfsctl`, where the two states above are selected by one tri-state flag
+(`disabled` | `enabled` | `required`):
 
 ```bash
-./dfsctl adapter create --type smb --config '{
-  "signing": {
-    "enabled": true,
-    "required": true
-  }
-}'
+# Advertise signing and reject unsigned messages
+./dfsctl adapter settings smb update --signing required
+
+# Advertise signing but still accept unsigned messages (the default)
+./dfsctl adapter settings smb update --signing enabled
 ```
 
 **Recommendation:** set `required: true` for all production deployments to prevent tampering even

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -288,7 +288,7 @@ ls: cannot access 'file.txt': Stale file handle
    ```bash
    ./dfsctl store metadata add --name persistent --type badger \
      --config '{"path":"/var/lib/dittofs/metadata"}'
-   ./dfsctl store block add --kind local --name default --type memory
+   ./dfsctl store block local add --name default --type memory
    ./dfsctl share create --name /export --metadata persistent --local default
    ```
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -799,9 +799,9 @@ Stores, shares, and adapters are managed at runtime via `dfsctl` (persisted in t
   --config '{"path":"/data/metadata"}'
 
 # Create block stores (local per-share, remote shared across shares)
-./dfsctl store block add --kind local --name local-cache --type fs \
+./dfsctl store block local add --name local-cache --type fs \
   --config '{"path":"/data/cache"}'
-./dfsctl store block add --kind remote --name s3-remote --type s3 \
+./dfsctl store block remote add --name s3-remote --type s3 \
   --config '{"region":"us-east-1","bucket":"my-bucket"}'
 
 # Create shares referencing stores by name (each gets its own BlockStore)
@@ -883,7 +883,7 @@ No custom code required - configure via CLI:
 ```bash
 # Create stores
 ./dfsctl store metadata add --name default-meta --type memory  # or badger, postgres
-./dfsctl store block add --kind local --name default-local --type fs \
+./dfsctl store block local add --name default-local --type fs \
   --config '{"path":"/data/blocks"}'
 
 # Create share referencing stores

--- a/docs/internals/contributing.md
+++ b/docs/internals/contributing.md
@@ -73,7 +73,7 @@ go build -o dfs cmd/dfs/main.go
 
 # Run with development settings
 ./dfs init
-./dfs start --log-level DEBUG
+DITTOFS_LOGGING_LEVEL=DEBUG ./dfs start
 ```
 
 ## Development Workflow
@@ -95,7 +95,7 @@ go mod download
 ./dfs start
 
 # Run with debug logging and custom settings
-./dfs start --log-level DEBUG
+DITTOFS_LOGGING_LEVEL=DEBUG ./dfs start
 
 # Use environment variables for quick config overrides
 DITTOFS_LOGGING_LEVEL=DEBUG DITTOFS_ADAPTERS_NFS_PORT=12049 ./dfs start

--- a/docs/internals/implementing-stores.md
+++ b/docs/internals/implementing-stores.md
@@ -867,7 +867,7 @@ func createLocalStore(config LocalStoreConfig) (local.LocalStore, error) {
 Users can then create your store via CLI:
 
 ```bash
-./dfsctl store block add --kind local --name my-store --type mylocal \
+./dfsctl store block local add --name my-store --type mylocal \
   --config '{"path":"/data/blocks"}'
 ```
 

--- a/docs/internals/testing.md
+++ b/docs/internals/testing.md
@@ -126,7 +126,7 @@ go build -o dfs cmd/dfs/main.go
 go build -o dfsctl cmd/dfsctl/main.go
 
 # 2. Initialize config (first time only)
-./dfs config init
+./dfs init
 
 # 3. Start DittoFS
 ./dfs start


### PR DESCRIPTION
Part of #1857. From a user evaluating DittoFS on Proxmox VE: *"the documentation, code help and log messages... link to flags and subcommands which either don't exist at all or have a different command path than suggested."*

I audited every `dfs`/`dfsctl` invocation in `docs/` against the generated CLI reference. They were right:

| Documented | Actual | Uses |
|---|---|---|
| `store block add --kind local\|remote` | `store block <local\|remote> add`, no `--kind` | 18, across 6 files |
| `dfsctl user update` | `dfsctl user edit` | 1 |
| `dfs config init` | `dfs init` — which `dfs config --help` already says | 1 |
| `dfsctl adapter create --type smb --config '{"signing":{...}}'` | `adapter settings smb update --signing disabled\|enabled\|required` | 1 |
| `dfs start --log-level DEBUG` | no such flag; `DITTOFS_LOGGING_LEVEL` | 2 |
| `store block remote edit --name r1` | name is positional | 1 |

The `store block add --kind` family is the one that matters most: it sits in getting-started and configuration, so it is among the first commands someone evaluating DittoFS copies, and it fails immediately. That alone is a plausible explanation for a chunk of the reporter's frustration.

The signing example was wrong twice over — the command does not exist *and* neither does the nested `{"signing": {"enabled", "required"}}` config shape; the CLI models it as one tri-state flag, which the replacement now shows for both states.

Re-running the audit afterwards leaves only `adapter enable <type>`, where the type is a positional argument, not a subcommand — a false positive of the checker, not drift.

Docs only, no code. **Not covered here** (tracked in #1857): the same audit over Cobra `Long`/`Example` strings and over log/error messages, which the reporter also called out. That wants a CI check rather than another manual pass — `cmd/gendocs` already walks the command trees, so the reference side is free; it is hand-written prose that drifts.