### PR TITLE
fix(migrate): verify a pre-journal migration can read its data before reaping its archive (#1853)

### DIFF
--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -74,6 +74,15 @@ func (s *FSStore) MigratedFromLegacy() bool {
 	return s.migratedFromLegacy
 }
 
+// LegacyArchivePaths names the directories the archive step moved aside, so a
+// caller that keeps them can tell the operator where they are.
+func (s *FSStore) LegacyArchivePaths() []string { return legacyArchivePaths(s.dir) }
+
+// DiscardLegacyArchive deletes those directories. The caller is responsible for
+// having established that the share can serve the archived content from
+// elsewhere first — the archive is the last local copy until then.
+func (s *FSStore) DiscardLegacyArchive() error { return discardLegacyArchive(s.dir) }
+
 var (
 	_ local.LocalStore         = (*FSStore)(nil)
 	_ block.DurabilityReporter = (*FSStore)(nil)

--- a/pkg/block/local/fs/legacy.go
+++ b/pkg/block/local/fs/legacy.go
@@ -90,6 +90,28 @@ func checkLegacyLayout(dir string) error {
 // disk untouched under this name.
 const legacyBackupSuffix = ".pre-journal-backup"
 
+// legacyArchivePaths lists the archive directories archiveLegacyLayout would
+// have created under dir, whether or not they exist.
+func legacyArchivePaths(dir string) []string {
+	return []string{
+		filepath.Join(dir, "blobs"+legacyBackupSuffix),
+		filepath.Join(dir, "logs"+legacyBackupSuffix),
+	}
+}
+
+// discardLegacyArchive deletes the archived pre-journal directories. Only call it
+// once the share has been shown to serve its own content from the remote: until
+// then these are the last copy of the pre-journal bytes. A missing directory is
+// not an error — the reap is idempotent, and half of it may already be gone.
+func discardLegacyArchive(dir string) error {
+	for _, path := range legacyArchivePaths(dir) {
+		if err := os.RemoveAll(path); err != nil {
+			return fmt.Errorf("discard legacy archive %q: %w", path, err)
+		}
+	}
+	return nil
+}
+
 // archiveLegacyLayout renames the pre-journal blobs/ and logs/ subdirectories of
 // dir aside to <name>.pre-journal-backup so an empty journal can open cleanly on
 // top of them. It is NON-destructive: the legacy bytes survive under the backup
@@ -99,7 +121,8 @@ const legacyBackupSuffix = ".pre-journal-backup"
 // is skipped. A pre-existing backup target is a hard error rather than an
 // overwrite so the operator can inspect it — the guard that gates this call
 // won't fire again once blobs/ and logs/ are gone, so this only runs on the
-// first upgrade start.
+// first upgrade start. discardLegacyArchive removes what this leaves behind,
+// once a verified read proves the share no longer needs it.
 func archiveLegacyLayout(dir string) error {
 	for _, sub := range []string{"blobs", "logs"} {
 		src := filepath.Join(dir, sub)

--- a/pkg/controlplane/runtime/shares/legacy_migrate_test.go
+++ b/pkg/controlplane/runtime/shares/legacy_migrate_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/engine"
 	"github.com/marmos91/dittofs/pkg/block/local/fs"
 	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
@@ -46,10 +48,14 @@ func newMigrateEngine(t *testing.T, dir string, ms *metamem.MemoryMetadataStore,
 		t.Fatalf("engine.Start: %v", err)
 	}
 	// The fs store's migration flag is consumed here, the same way
-	// ConfigureBlockStore does it after bs.Start.
-	if m, ok := any(localStore).(interface{ MigratedFromLegacy() bool }); ok && m.MigratedFromLegacy() {
-		if err := SeedColdFromManifest(context.Background(), bs, ms); err != nil {
+	// ConfigureBlockStore does it after bs.Start: seed, verify, then reap.
+	if m, ok := any(localStore).(legacyArchiveMigrator); ok && m.MigratedFromLegacy() {
+		report, err := SeedColdFromManifest(context.Background(), bs, ms)
+		if err != nil {
 			t.Fatalf("SeedColdFromManifest: %v", err)
+		}
+		if err := finishLegacyArchiveMigration(context.Background(), bs, m, report, "test"); err != nil {
+			t.Fatalf("finishLegacyArchiveMigration: %v", err)
 		}
 	}
 	return bs
@@ -136,13 +142,117 @@ func TestLegacyRemoteMigration_ReadsColdFromRemote(t *testing.T) {
 	bs2 := newMigrateEngine(t, dir, ms, rem, true)
 	t.Cleanup(func() { _ = bs2.Close() })
 
-	// Legacy dirs archived aside, not destroyed.
+	// Every chunk is on the remote and a sample read back matched the manifest,
+	// so the archive the migration made is redundant and it takes it away again.
+	// Leaving it is what stranded 55 GiB on a box at 96% disk.
 	for _, sub := range []string{"blobs", "logs"} {
-		if _, err := os.Stat(filepath.Join(dir, sub+".pre-journal-backup")); err != nil {
-			t.Fatalf("legacy %s not archived: %v", sub, err)
+		if _, err := os.Stat(filepath.Join(dir, sub+".pre-journal-backup")); !os.IsNotExist(err) {
+			t.Fatalf("legacy %s archive survived a verified migration: %v", sub, err)
 		}
 	}
 	readAllLegacyFiles(t, bs2, "after migration")
+}
+
+// newEmptyEngine builds an engine over an empty local dir, for the decision
+// branches that need a block store but no planted content.
+func newEmptyEngine(t *testing.T) *engine.Store {
+	t.Helper()
+	ms := metamem.NewMemoryMetadataStoreWithDefaults()
+	t.Cleanup(func() { _ = ms.Close() })
+	return newMigrateEngine(t, t.TempDir(), ms, remotememory.New(), false)
+}
+
+// fakeArchiveMigrator stands in for the fs store so the three ways a migration
+// can end are exercised without planting a layout on disk for each.
+type fakeArchiveMigrator struct {
+	discarded  bool
+	discardErr error
+}
+
+func (f *fakeArchiveMigrator) MigratedFromLegacy() bool { return true }
+func (f *fakeArchiveMigrator) LegacyArchivePaths() []string {
+	return []string{"/nonexistent/blobs.pre-journal-backup"}
+}
+
+func (f *fakeArchiveMigrator) DiscardLegacyArchive() error {
+	if f.discardErr != nil {
+		return f.discardErr
+	}
+	f.discarded = true
+	return nil
+}
+
+// TestFinishLegacyMigration_KeepsArchiveWhenChunksAreNotRemote covers the case
+// the reap must never get wrong: a chunk the manifest does not call remote
+// exists nowhere but the archive, so deleting the archive would destroy it.
+func TestFinishLegacyMigration_KeepsArchiveWhenChunksAreNotRemote(t *testing.T) {
+	bs := newEmptyEngine(t)
+	t.Cleanup(func() { _ = bs.Close() })
+
+	m := &fakeArchiveMigrator{}
+	report := coldSeedReport{payloads: 1, chunks: 4, unsynced: 1}
+	if err := finishLegacyArchiveMigration(context.Background(), bs, m, report, "test"); err != nil {
+		t.Fatalf("unsynced chunks must not fail the migration: %v", err)
+	}
+	if m.discarded {
+		t.Fatal("archive deleted while a chunk had no remote copy")
+	}
+}
+
+// TestFinishLegacyMigration_RefusesOnContentMismatch is the check that would
+// have caught the field failure: bytes come back, the length is right, and the
+// content is not what the manifest says it should be.
+func TestFinishLegacyMigration_RefusesOnContentMismatch(t *testing.T) {
+	dir, ms, rem := plantPreJournalShare(t)
+	bs := newMigrateEngine(t, dir, ms, rem, true)
+	t.Cleanup(func() { _ = bs.Close() })
+
+	m := &fakeArchiveMigrator{}
+	report := coldSeedReport{
+		payloads: 1,
+		chunks:   1,
+		samples: []coldSample{{
+			payloadID: "small-a",
+			offset:    0,
+			length:    64,
+			hash:      block.ContentHash{0xDE, 0xAD}, // not what is stored
+		}},
+	}
+	err := finishLegacyArchiveMigration(context.Background(), bs, m, report, "test")
+	if err == nil {
+		t.Fatal("migration reported success while serving content the manifest disagrees with")
+	}
+	if !strings.Contains(err.Error(), "cannot serve its own data") {
+		t.Fatalf("error should say the share cannot serve its data, got: %v", err)
+	}
+	if m.discarded {
+		t.Fatal("archive deleted despite a failed verification")
+	}
+}
+
+// TestFinishLegacyMigration_UnreadableSampleKeepsArchive separates "wrong" from
+// "unknown": a remote we cannot reach proves nothing, so the share still serves
+// and the archive stays for a later start to verify against.
+func TestFinishLegacyMigration_UnreadableSampleKeepsArchive(t *testing.T) {
+	bs := newEmptyEngine(t)
+	if err := bs.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	m := &fakeArchiveMigrator{}
+	report := coldSeedReport{
+		payloads: 1,
+		chunks:   1,
+		samples:  []coldSample{{payloadID: "small-a", offset: 0, length: 64}},
+	}
+	// Reads against the closed store fail, which is an unavailable remote as far
+	// as verification can tell.
+	if err := finishLegacyArchiveMigration(context.Background(), bs, m, report, "test"); err != nil {
+		t.Fatalf("an unreadable sample must not fail the migration: %v", err)
+	}
+	if m.discarded {
+		t.Fatal("archive deleted without a successful verification")
+	}
 }
 
 // TestLegacyRemoteMigration_ReadsColdAfterRestart is the field failure: the

--- a/pkg/controlplane/runtime/shares/legacy_verify.go
+++ b/pkg/controlplane/runtime/shares/legacy_verify.go
@@ -1,0 +1,193 @@
+package shares
+
+// legacy_verify.go decides whether a pre-journal migration may believe itself.
+//
+// Archiving blobs/+logs/ aside and seeding cold intervals from the manifest is
+// bookkeeping: it makes the byte *counts* right. Whether a read returns the
+// stored bytes or a zero-fill is a separate question, and answering it wrongly
+// is invisible — the file is the right length and the wrong content. So the
+// migration reads a sample back and hashes it before it reports success, and it
+// only deletes the archive it made once that sample proves the share can serve
+// its own data from the remote.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+)
+
+// coldVerifySamples is how many extents the migration reads back. The failure
+// it guards against — a cold range that comes back as a hole — is systemic
+// rather than per-file, so a handful of extents is enough to expose it; the
+// point is to have read *something* before claiming success.
+const coldVerifySamples = 8
+
+// coldSample is one manifest extent the migration will read back and hash.
+type coldSample struct {
+	payloadID string
+	offset    int64
+	length    int64
+	hash      block.ContentHash
+}
+
+// coldSeedReport is what a manifest seed learned on the way through.
+type coldSeedReport struct {
+	// payloads and chunks are what the manifest described.
+	payloads int
+	chunks   int
+
+	// unsynced counts chunks the manifest does not yet call remote. Their only
+	// copy is in the archived pre-journal layout, so an archive cannot be
+	// deleted while this is non-zero.
+	unsynced int
+
+	// samples are extents to read back, capped at coldVerifySamples.
+	samples []coldSample
+}
+
+// sampledPayload reports whether payloadID has no sample yet, so the sample set
+// spreads over distinct files instead of filling up with one file's chunks.
+// Payloads are enumerated one at a time, so only the newest sample can match.
+func (r *coldSeedReport) sampledPayload(payloadID string) bool {
+	return len(r.samples) == 0 || r.samples[len(r.samples)-1].payloadID != payloadID
+}
+
+// errColdVerifyUnavailable marks a verification that could not be carried out —
+// the remote was unreachable, not wrong. Nothing is proven either way, so the
+// caller keeps the archive and serves the share.
+var errColdVerifyUnavailable = errors.New("cold verification unavailable")
+
+// verifyColdSeed reads each sampled extent back through the block store and
+// compares its BLAKE3 against the manifest. A mismatch is proof the share
+// cannot serve its own data: the read either zero-filled a range it should have
+// fetched or the remote holds something else. A read *error* proves nothing —
+// the remote may simply be unreachable — and comes back wrapped so the caller
+// can tell "wrong" from "unknown".
+func verifyColdSeed(ctx context.Context, bs *engine.Store, report coldSeedReport) error {
+	for _, s := range report.samples {
+		buf := make([]byte, s.length)
+		n, err := bs.ReadAt(ctx, s.payloadID, nil, buf, uint64(s.offset))
+		if err != nil {
+			return fmt.Errorf("%w: read back %s at %d: %w", errColdVerifyUnavailable, s.payloadID, s.offset, err)
+		}
+		if int64(n) != s.length {
+			return fmt.Errorf("read back %s at %d: got %d bytes, manifest says %d",
+				s.payloadID, s.offset, n, s.length)
+		}
+		if got := block.ContentHash(blake3.Sum256(buf)); got != s.hash {
+			return fmt.Errorf("read back %s at %d (%d bytes): content hash %s, manifest says %s",
+				s.payloadID, s.offset, s.length, got, s.hash)
+		}
+	}
+	return nil
+}
+
+// finishLegacyArchiveMigration is the last step of a remote-backed pre-journal
+// migration: prove the share can serve its own data, then take back the disk the
+// migration was holding.
+//
+// Three outcomes, in decreasing order of confidence:
+//
+//   - Verified, and every chunk is remote: the archive is redundant, so delete
+//     it. This is the case that gave the disk back on the deployment that hit
+//     the hole bug — 55 GiB an operator had no way to know was safe to remove.
+//   - Verified, but some chunks never reached the remote: those bytes exist
+//     nowhere else, so keep the archive and name it in the log.
+//   - The sample did not match the manifest: refuse to serve the share. The
+//     archive and the remote are both untouched, so this is recoverable, and
+//     the alternative is handing out zeros that look like real short reads.
+//     A sample that could not be *read* proves nothing — the remote may be
+//     unreachable — so that only warns.
+func finishLegacyArchiveMigration(
+	ctx context.Context,
+	bs *engine.Store,
+	m legacyArchiveMigrator,
+	report coldSeedReport,
+	shareName string,
+) error {
+	archives := m.LegacyArchivePaths()
+	verr := verifyColdSeed(ctx, bs, report)
+	switch {
+	case errors.Is(verr, errColdVerifyUnavailable):
+		logger.Warn("migrated pre-journal local layout but could not read a sample back to verify it; "+
+			"keeping the archived blobs/+logs/ until a later start verifies them",
+			"share", shareName, "payloads", report.payloads, "chunks", report.chunks,
+			"archive", archives, "error", verr)
+		return nil
+	case verr != nil:
+		return fmt.Errorf("pre-journal migration of share %q cannot serve its own data (%w); "+
+			"the archived pre-journal bytes are intact at %v and the remote store is untouched, "+
+			"so refusing to serve zeros — restore the archive or investigate before retrying",
+			shareName, verr, archives)
+	}
+	if report.unsynced > 0 {
+		logger.Warn("migrated pre-journal local layout and verified a sample, but some chunks never reached the remote; "+
+			"keeping the archived blobs/+logs/ because those bytes exist nowhere else",
+			"share", shareName, "payloads", report.payloads, "chunks", report.chunks,
+			"chunks_not_remote", report.unsynced, "archive", archives)
+		return nil
+	}
+	freed := archiveBytes(archives)
+	if err := m.DiscardLegacyArchive(); err != nil {
+		// The migration itself succeeded; only the cleanup did not. Say so and
+		// serve the share — a stale archive costs disk, not correctness.
+		logger.Warn("migrated pre-journal local layout and verified it, but deleting the archived blobs/+logs/ failed; "+
+			"they are safe to remove by hand",
+			"share", shareName, "archive", archives, "error", err)
+		return nil
+	}
+	logger.Info("migrated pre-journal local layout: seeded cold intervals from manifest, verified a sample reads back, "+
+		"and reclaimed the archived blobs/+logs/",
+		"share", shareName, "payloads", report.payloads, "chunks", report.chunks,
+		"samples_verified", len(report.samples), "bytes_reclaimed", freed)
+	return nil
+}
+
+// legacyArchiveMigrator is the local-store surface driven after a remote-backed
+// pre-journal migration: it reports that the migration happened, and it can
+// delete the archive that migration made once the data is shown to be readable.
+// Implemented by the journal-backed fs store; other backends never satisfy it,
+// so the whole block is a no-op for them.
+type legacyArchiveMigrator interface {
+	MigratedFromLegacy() bool
+	LegacyArchivePaths() []string
+	DiscardLegacyArchive() error
+}
+
+// dirBytes totals the file sizes under path, for a log line that tells the
+// operator how much the reap gave back. Best-effort: an unreadable entry is
+// skipped rather than failing a cleanup that has already been decided.
+func dirBytes(path string) int64 {
+	var total int64
+	_ = filepath.WalkDir(path, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil //nolint:nilerr // a partial total still beats no total
+		}
+		if info, ierr := d.Info(); ierr == nil {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total
+}
+
+// archiveBytes totals every archive directory that still exists.
+func archiveBytes(paths []string) int64 {
+	var total int64
+	for _, p := range paths {
+		if _, err := os.Stat(p); err != nil {
+			continue
+		}
+		total += dirBytes(p)
+	}
+	return total
+}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1189,14 +1189,17 @@ func (s *Service) createBlockStoreForShare(
 	// skips straight to a clean open.
 	// ponytail: O(files) manifest scan at startup; a lazy per-read seed is the
 	// upgrade path if this ever bites a share with a huge file count.
-	if m, ok := localStore.(interface{ MigratedFromLegacy() bool }); ok && m.MigratedFromLegacy() {
+	if m, ok := localStore.(legacyArchiveMigrator); ok && m.MigratedFromLegacy() {
 		if metaStore, ok := fileChunkStore.(metadata.Store); ok {
-			if serr := SeedColdFromManifest(ctx, bs, metaStore); serr != nil {
+			report, serr := SeedColdFromManifest(ctx, bs, metaStore)
+			if serr != nil {
 				cleanup()
 				return fmt.Errorf("seed cold intervals after legacy migration: %w", serr)
 			}
-			logger.Info("migrated pre-journal local layout: archived blobs/+logs/ aside and seeded cold intervals from manifest",
-				"share", config.Name)
+			if verr := finishLegacyArchiveMigration(ctx, bs, m, report, config.Name); verr != nil {
+				cleanup()
+				return verr
+			}
 		} else {
 			logger.Warn("migrated pre-journal local layout but metadata store is not manifest-capable; reads will zero-fill until rewritten",
 				"share", config.Name)
@@ -3092,8 +3095,15 @@ func applyDurableOverride(store any, config map[string]any, label, shareName str
 // BLAKE3-verified. One ListFileChunks and one SeedCold per payload — O(chunks),
 // acceptable for a rare control-plane / startup path, and seeding a whole file at
 // once keeps the local tier's durable write to one per file.
-func SeedColdFromManifest(ctx context.Context, bs *engine.Store, metaStore metadata.Store) error {
-	return metaStore.EnumeratePayloads(ctx, func(payloadID string) error {
+//
+// The report it returns is what the seed observed on the way through: how much
+// it covered, how much of it the manifest does not yet call remote, and a few
+// extents to read back. Seeding alone proves nothing about content, so a caller
+// that archived the only local copy aside is expected to verify before it
+// reports success.
+func SeedColdFromManifest(ctx context.Context, bs *engine.Store, metaStore metadata.Store) (coldSeedReport, error) {
+	var report coldSeedReport
+	err := metaStore.EnumeratePayloads(ctx, func(payloadID string) error {
 		rows, err := metaStore.ListFileChunks(ctx, payloadID)
 		if err != nil {
 			return fmt.Errorf("list manifest for %s: %w", payloadID, err)
@@ -3108,12 +3118,36 @@ func SeedColdFromManifest(ctx context.Context, bs *engine.Store, metaStore metad
 				continue
 			}
 			extents = append(extents, [2]int64{int64(off), int64(row.DataSize)})
+			report.chunks++
+			// Whether a chunk reached the remote is answered by the synced-hash
+			// store, not by FileChunk.State: the carve path records synced markers
+			// and leaves the row state at Pending for the life of the payload, so
+			// reading State here would call every chunk unsynced. A lookup failure
+			// counts as unsynced — the archive stays when we cannot tell.
+			synced, serr := metaStore.IsSynced(ctx, row.Hash)
+			if serr != nil || !synced {
+				report.unsynced++
+			}
+			// Sample the first hashed extent of the first few payloads. A
+			// zero-length chunk or one with no hash yet cannot be checked
+			// against anything, so it is not worth a sample slot.
+			if len(report.samples) < coldVerifySamples && row.DataSize > 0 &&
+				row.Hash != (block.ContentHash{}) && report.sampledPayload(payloadID) {
+				report.samples = append(report.samples, coldSample{
+					payloadID: payloadID,
+					offset:    int64(off),
+					length:    int64(row.DataSize),
+					hash:      row.Hash,
+				})
+			}
 		}
 		if err := bs.SeedCold(ctx, payloadID, extents); err != nil {
 			return fmt.Errorf("seed cold %s: %w", payloadID, err)
 		}
+		report.payloads++
 		return nil
 	})
+	return report, err
 }
 
 // parseRequireDurableCommit reads the optional per-share "require_durable_commit"

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -1581,7 +1581,9 @@ func (r *Runtime) restoreSnapshot(
 	// Remote-backed shares only — a local-only share has no remote to hydrate from
 	// (that restore path is tracked in #1718).
 	if remoteVerify {
-		if serr := shares.SeedColdFromManifest(ctx, bs, metaStore); serr != nil {
+		// The report is only of interest to the pre-journal migration, which has an
+		// archive to verify against and delete; a restore has neither.
+		if _, serr := shares.SeedColdFromManifest(ctx, bs, metaStore); serr != nil {
 			return safetySnapshotID, fmt.Errorf("restore snapshot %q: seed cold intervals (safety-snap=%s): %w: %v",
 				snapID, safetySnapshotID, models.ErrRestoreAborted, serr)
 		}


### PR DESCRIPTION
Closes #1853. Follow-up to #1850 / #1851.

## What was wrong

The remote-backed pre-journal migration renamed `blobs/`+`logs/` to `*.pre-journal-backup`, seeded cold intervals from the surviving manifest, and logged success — without ever reading a byte back. That is why #1850 got as far as it did: byte *counts* were right, content was zeros, and the log said the migration worked.

It also never reaped the archive. On the deployment in #1843 that was 55 GiB on a box at 96% disk, with the operator left guessing whether deleting it was safe.

## What this does

`SeedColdFromManifest` now returns a report of what it covered plus a handful of extents to read back. `finishLegacyArchiveMigration` acts on it:

| Outcome | Action |
|---|---|
| Sample verifies, every chunk on the remote | delete the archive, log bytes reclaimed |
| Sample verifies, some chunks never reached the remote | keep the archive — those bytes exist nowhere else — and name its path in the log |
| Sample hash does not match the manifest | refuse to serve the share |
| Sample cannot be read at all | warn only, keep the archive |

The last two are deliberately different. A mismatch is proof the share cannot serve its own data, and both the archive and the remote are untouched, so refusing is recoverable — the alternative is handing out zeros that look like legitimate short reads. A read *error* proves nothing (the remote may just be unreachable), so it must not take a share offline.

## Worth knowing

Chunk remote-residency comes from the **synced-hash store, not `FileChunk.State`**. The carve path records synced markers via `DefaultCommitBlock` and leaves the row state at Pending for the life of the payload, so gating on `IsRemote()` would have called every chunk unsynced and the reap would have been dead code. This showed up as `chunks_not_remote=3` on a share whose three chunks were provably on the remote; `syncer.go:452-460` documents the same thing for `GetFileSize`.

## Tests

Four in `pkg/controlplane/runtime/shares/legacy_migrate_test.go`:

- the existing end-to-end migration now asserts the archive is **gone** after a verified migration (it previously asserted the opposite)
- unsynced chunks keep the archive and do not fail the migration
- a content mismatch fails with "cannot serve its own data" and leaves the archive
- an unreadable sample keeps the archive and does not fail

`go test ./pkg/controlplane/runtime/... ./pkg/block/local/fs/...` green; `golangci-lint` clean on both packages.