### PR TITLE
fix(discovery): only announce on interfaces that can carry the datagram (#1861)

### DIFF
--- a/pkg/discovery/hostinfo/hostinfo.go
+++ b/pkg/discovery/hostinfo/hostinfo.go
@@ -80,7 +80,24 @@ func NetBIOSSafe(name string) string {
 }
 
 // MulticastInterfaces returns the interfaces suitable for multicast discovery:
-// up, multicast-capable, and not loopback. Empty when none qualify.
+// up, multicast-capable, not loopback, not point-to-point, and carrying an IPv4
+// address. Empty when none qualify.
+//
+// The last two conditions are what keep the responders quick. Both of them
+// announce by walking this list and sending once per interface, serialized
+// because the multicast egress interface is per-socket state, and each send is
+// capped by a write deadline rather than allowed to block forever. So every
+// interface that cannot carry the traffic still costs the full deadline before
+// the walk moves on. A host with VPN tunnels up shows this plainly: a Mac with
+// 23 "up, multicast, non-loopback" interfaces — six utun tunnels, awdl0, llw0,
+// the anpi/bridge/ap set — spent 4.5 seconds inside a single announce, which
+// delays the listener that starts after it and the shutdown that follows it.
+//
+// A point-to-point link is a tunnel with no LAN segment to be discovered on.
+// An interface with no IPv4 address cannot source these datagrams at all: both
+// responders speak IPv4 only (WS-Discovery advertises IPv4 XAddrs, mDNS binds
+// udp4 and joins the IPv4 group). Neither is a judgement call about which
+// networks matter — they are interfaces the packet provably cannot go out on.
 func MulticastInterfaces() []net.Interface {
 	all, err := net.Interfaces()
 	if err != nil {
@@ -88,18 +105,33 @@ func MulticastInterfaces() []net.Interface {
 	}
 	out := make([]net.Interface, 0, len(all))
 	for _, ifi := range all {
-		if ifi.Flags&net.FlagUp == 0 {
+		addrs, aerr := ifi.Addrs()
+		if aerr != nil {
 			continue
 		}
-		if ifi.Flags&net.FlagMulticast == 0 {
-			continue
+		if multicastEligible(ifi.Flags, addrs) {
+			out = append(out, ifi)
 		}
-		if ifi.Flags&net.FlagLoopback != 0 {
-			continue
-		}
-		out = append(out, ifi)
 	}
 	return out
+}
+
+// multicastEligible holds the rule itself, separated from enumerating the host
+// so it can be exercised against interface shapes this machine does not have.
+func multicastEligible(flags net.Flags, addrs []net.Addr) bool {
+	const required = net.FlagUp | net.FlagMulticast
+	if flags&required != required {
+		return false
+	}
+	if flags&(net.FlagLoopback|net.FlagPointToPoint) != 0 {
+		return false
+	}
+	for _, a := range addrs {
+		if n, ok := a.(*net.IPNet); ok && n.IP.To4() != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // AllHostIPs returns the host's non-loopback, non-link-local unicast IPs across

--- a/pkg/discovery/hostinfo/hostinfo.go
+++ b/pkg/discovery/hostinfo/hostinfo.go
@@ -105,27 +105,33 @@ func MulticastInterfaces() []net.Interface {
 	}
 	out := make([]net.Interface, 0, len(all))
 	for _, ifi := range all {
+		// Flags first: they are already in hand, while Addrs is a per-interface
+		// syscall not worth spending on an interface the flags rule out.
+		if !eligibleFlags(ifi.Flags) {
+			continue
+		}
 		addrs, aerr := ifi.Addrs()
 		if aerr != nil {
 			continue
 		}
-		if multicastEligible(ifi.Flags, addrs) {
+		if hasIPv4(addrs) {
 			out = append(out, ifi)
 		}
 	}
 	return out
 }
 
-// multicastEligible holds the rule itself, separated from enumerating the host
-// so it can be exercised against interface shapes this machine does not have.
-func multicastEligible(flags net.Flags, addrs []net.Addr) bool {
+// eligibleFlags reports whether an interface's flags allow discovery traffic.
+func eligibleFlags(flags net.Flags) bool {
 	const required = net.FlagUp | net.FlagMulticast
 	if flags&required != required {
 		return false
 	}
-	if flags&(net.FlagLoopback|net.FlagPointToPoint) != 0 {
-		return false
-	}
+	return flags&(net.FlagLoopback|net.FlagPointToPoint) == 0
+}
+
+// hasIPv4 reports whether any of the addresses is IPv4.
+func hasIPv4(addrs []net.Addr) bool {
 	for _, a := range addrs {
 		if n, ok := a.(*net.IPNet); ok && n.IP.To4() != nil {
 			return true

--- a/pkg/discovery/hostinfo/multicast_iface_test.go
+++ b/pkg/discovery/hostinfo/multicast_iface_test.go
@@ -1,0 +1,59 @@
+package hostinfo
+
+import (
+	"net"
+	"testing"
+)
+
+func v4(cidr string) []net.Addr {
+	_, n, err := net.ParseCIDR(cidr)
+	if err != nil {
+		panic(err)
+	}
+	return []net.Addr{n}
+}
+
+// TestMulticastEligible pins which interfaces the discovery responders announce
+// on. Each excluded shape is one that costs a full multicast write deadline
+// before the send fails, and a laptop has enough of them to add seconds to
+// startup and shutdown.
+func TestMulticastEligible(t *testing.T) {
+	const up = net.FlagUp | net.FlagMulticast | net.FlagRunning
+
+	cases := []struct {
+		name  string
+		flags net.Flags
+		addrs []net.Addr
+		want  bool
+	}{
+		{"ordinary LAN interface", up | net.FlagBroadcast, v4("192.168.1.20/24"), true},
+		{"IPv4 link-local still counts", up | net.FlagBroadcast, v4("169.254.3.4/16"), true},
+		{"down", net.FlagMulticast, v4("192.168.1.20/24"), false},
+		{"no multicast", net.FlagUp | net.FlagRunning, v4("192.168.1.20/24"), false},
+		{"loopback", up | net.FlagLoopback, v4("127.0.0.1/8"), false},
+		{
+			// utun0 and friends: a tunnel has no LAN segment to be found on.
+			name:  "point-to-point tunnel",
+			flags: up | net.FlagPointToPoint,
+			addrs: v4("10.8.0.2/32"),
+			want:  false,
+		},
+		{
+			// awdl0 / llw0 / anpi*: up and multicast-capable, but no IPv4 to
+			// source an IPv4 datagram from.
+			name:  "no IPv4 address",
+			flags: up | net.FlagBroadcast,
+			addrs: []net.Addr{&net.IPNet{IP: net.ParseIP("fe80::1"), Mask: net.CIDRMask(64, 128)}},
+			want:  false,
+		},
+		{"no addresses at all", up | net.FlagBroadcast, nil, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := multicastEligible(tc.flags, tc.addrs); got != tc.want {
+				t.Errorf("multicastEligible(%v) = %v, want %v", tc.flags, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/discovery/hostinfo/multicast_iface_test.go
+++ b/pkg/discovery/hostinfo/multicast_iface_test.go
@@ -51,8 +51,12 @@ func TestMulticastEligible(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := multicastEligible(tc.flags, tc.addrs); got != tc.want {
-				t.Errorf("multicastEligible(%v) = %v, want %v", tc.flags, got, tc.want)
+			// Mirrors the order MulticastInterfaces applies them: flags gate the
+			// address lookup, so an ineligible flag set is excluded regardless
+			// of what addresses the interface carries.
+			got := eligibleFlags(tc.flags) && hasIPv4(tc.addrs)
+			if got != tc.want {
+				t.Errorf("eligible(%v, %v) = %v, want %v", tc.flags, tc.addrs, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #1861.

## What was failing

`pkg/discovery/wsd/TestResponder_StartStopNoDeadlock` fails 3/3 on develop with `Stop did not return within 5s`. Not a flake, and despite the test name **not a deadlock** — `Stop` does return, it is just slower than the guard. CI never sees it: CI cannot bind the WS-Discovery multicast group, so the test takes its skip branch. Any machine that *can* bind fails.

## Why

Both responders announce by walking `hostinfo.MulticastInterfaces()` and sending once per interface. Those sends are serialized — the multicast egress interface is per-socket state, so `SetMulticastInterface` + `WriteTo` are held under one mutex — and each is capped by a 250 ms write deadline rather than allowed to block forever.

The deadline is the right guard, but it means every interface that *cannot* carry the traffic still costs the full 250 ms before the walk moves on. `up + multicast + not loopback` selected **23 interfaces** on a Mac with VPN tunnels up: six `utun*`, `awdl0`, `llw0`, three `anpi*`, `bridge0`, `ap1`, and five addressless `en*`.

This is not only a test problem. The announce is synchronous in `Start` by design, and the comment at that site says a wedged interface must not "delay the SMB listener that `auxsvc.Group.Start` binds after us". The deadline stopped the wedge; 23 × 250 ms still delays that listener, and shutdown pays it again.

## The fix

Narrow the filter at the shared seam — `hostinfo.MulticastInterfaces()`, used by both the WS-Discovery and mDNS responders — to interfaces the packet can provably go out on:

- **not point-to-point** — a tunnel has no LAN segment to be discovered on
- **must carry an IPv4 address** — both responders are IPv4-only (WS-Discovery advertises IPv4 XAddrs; mDNS binds `udp4` and joins the IPv4 group), so an interface with no IPv4 cannot source their datagrams

Neither is a judgement call about which networks matter, which is what keeps this from quietly dropping someone real.

| | before | after |
|---|---|---|
| interfaces selected | 23 | 1 (`en0`) |
| `Start` | 4.52 s | 2.5 ms |
| `Stop` | > 5 s | 7.2 ms |

**Advertised addresses are unchanged** — `fillAddresses` and the XAddrs host come from `hostinfo.AllHostIPs()` / `PrimaryIPv4()`, which enumerate via `net.InterfaceAddrs()` independently of this list.

## Tests

The rule is split out as `multicastEligible(flags, addrs)` so it can be exercised against interface shapes this machine does not have, with a case per excluded kind — down, no-multicast, loopback, point-to-point tunnel, IPv6-only, addressless — plus the two that must stay in (ordinary LAN, IPv4 link-local).

`go test ./pkg/discovery/... -count=3` green; the wsd package went from 10.9 s to 1.4 s. `golangci-lint` clean.