### PR TITLE
test(cli): scope the drift scan to the visible tree, and prove it scanned it

### DIFF
--- a/cmd/gendocs/helpref_test.go
+++ b/cmd/gendocs/helpref_test.go
@@ -298,6 +298,10 @@ func TestHelpTextCommandReferences(t *testing.T) {
 	reportProblems(t, problems)
 }
 
+// sourceRoot is the repository root relative to this package's directory, which
+// is where the test binary runs.
+const sourceRoot = "../.."
+
 // TestSourceStringCommandReferences checks the command references in log lines,
 // error messages and any other string literal in the tree. A message that tells
 // an operator to run a command that does not exist is the same drift as a stale
@@ -305,13 +309,29 @@ func TestHelpTextCommandReferences(t *testing.T) {
 func TestSourceStringCommandReferences(t *testing.T) {
 	var problems []string
 	fset := token.NewFileSet()
-	err := filepath.WalkDir("../..", func(path string, d fs.DirEntry, err error) error {
+	scanned := 0
+	err := filepath.WalkDir(sourceRoot, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil //nolint:nilerr // an unreadable dir is not this test's business
 		}
 		if d.IsDir() {
+			// The walk root is named ".." — skipping it would skip everything and
+			// leave the check passing vacuously.
+			if path == sourceRoot {
+				return nil
+			}
+			// Skip dot-directories wholesale, not just .git. A checked-out tree
+			// can hold nested git worktrees under .claude/, each a full copy of
+			// the repo at some other commit — scanning those reports drift
+			// against branches that are not this one, in files that may not even
+			// exist here any more. Named skips would miss the next such
+			// directory; the rule is that the source under test is the visible
+			// tree.
+			if strings.HasPrefix(d.Name(), ".") {
+				return fs.SkipDir
+			}
 			switch d.Name() {
-			case ".git", "vendor", "node_modules", "testdata", ".planning", "docs":
+			case "vendor", "node_modules", "testdata", "docs":
 				return fs.SkipDir
 			}
 			return nil
@@ -319,6 +339,7 @@ func TestSourceStringCommandReferences(t *testing.T) {
 		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return nil
 		}
+		scanned++
 		file, perr := parser.ParseFile(fset, path, nil, 0)
 		if perr != nil {
 			return nil //nolint:nilerr // a file that does not parse fails the build, not this test
@@ -332,7 +353,7 @@ func TestSourceStringCommandReferences(t *testing.T) {
 			if uerr != nil {
 				return true
 			}
-			where := filepath.ToSlash(strings.TrimPrefix(path, "../../")) + ":" +
+			where := filepath.ToSlash(strings.TrimPrefix(path, sourceRoot+"/")) + ":" +
 				strconv.Itoa(fset.Position(lit.Pos()).Line)
 			for _, inv := range findInvocations(text, where) {
 				problems = append(problems, checkInvocation(inv)...)
@@ -343,6 +364,12 @@ func TestSourceStringCommandReferences(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("walk source tree: %v", err)
+	}
+	// A directory filter that accidentally matches the walk root skips the whole
+	// tree, and a check that scans nothing passes. Assert it actually looked.
+	if scanned < 500 {
+		t.Fatalf("scanned only %d source files from %s — the walk is being skipped, "+
+			"so this check is passing without looking at anything", scanned, sourceRoot)
 	}
 	reportProblems(t, problems)
 }

--- a/cmd/gendocs/helpref_test.go
+++ b/cmd/gendocs/helpref_test.go
@@ -299,8 +299,9 @@ func TestHelpTextCommandReferences(t *testing.T) {
 }
 
 // sourceRoot is the repository root relative to this package's directory, which
-// is where the test binary runs.
-const sourceRoot = "../.."
+// is where the test binary runs. filepath.Clean gives it the host separator so
+// the walk root compares and trims equal to the paths WalkDir reports.
+var sourceRoot = filepath.Clean("../..")
 
 // TestSourceStringCommandReferences checks the command references in log lines,
 // error messages and any other string literal in the tree. A message that tells
@@ -353,7 +354,7 @@ func TestSourceStringCommandReferences(t *testing.T) {
 			if uerr != nil {
 				return true
 			}
-			where := filepath.ToSlash(strings.TrimPrefix(path, sourceRoot+"/")) + ":" +
+			where := filepath.ToSlash(strings.TrimPrefix(path, sourceRoot+string(filepath.Separator))) + ":" +
 				strconv.Itoa(fset.Position(lit.Pos()).Line)
 			for _, inv := range findInvocations(text, where) {
 				problems = append(problems, checkInvocation(inv)...)


### PR DESCRIPTION
Fixes a defect in the check merged in #1860, found by running `go test ./...` on develop right after the merge.

## What broke

The source-string scan walked from the repo root into `.claude/worktrees/`, where nested git worktrees hold full copies of the repository at other commits. It reported **54 findings against branches that are not develop**, in files that no longer exist here — one of them in a `pkg/blockstore` package that has since been deleted.

CI never saw it: a CI checkout has no such directories. A local `go test ./...` does, so the check was red on develop for anyone running it locally while green in CI.

## The part worth reading

My first fix — skip any directory whose name starts with `.` — was worse than the bug. `WalkDir` starts at `"../.."`, and `".."` starts with a dot, so it returned `SkipDir` **on the walk root**. The entire tree was skipped and the check passed having read nothing at all.

It looked fixed. Everything was green. I only caught it because I planted a deliberately broken reference to confirm the check still fired, and it did not.

So this PR does two things:

1. Skips dot-directories, but never the walk root (compared by path, not by name).
2. **Asserts the scan actually scanned.** A directory filter that accidentally matches the root turns this check into a no-op, and a no-op check reports success forever. It now fails loudly if it sees implausibly few files, because the failure mode of a silent guard is that nobody ever learns it stopped guarding.

## Verification

- With a planted `dfsctl user bogus` in a real source file: **caught** — `pkg/config/zz_probe.go:3: dfsctl user has no subcommand "bogus"`.
- Probe removed: all four checks pass against the real tree.
- `golangci-lint` clean.

Worth noting the same trap does not apply to the docs check, which walks `../../docs` explicitly, or to the help-text check, which walks the command trees in memory.