### PR TITLE
fix(stores): stamp the on-disk format and refuse state from a newer release

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -915,7 +915,7 @@ build would serve the stored files as zeros rather than fail, so the daemon
 stops instead.
 
 Upgrades are one-way. To recover, either:
-  - reinstall the release that wrote this share and start again, or
+  - reinstall the release that wrote this state and start again, or
   - restore the snapshot taken before the upgrade.
 
 No data has been modified.`, err)

--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -20,6 +20,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/adapter/smb"
 	"github.com/marmos91/dittofs/pkg/auth/kerberos"
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/local/fs"
 	"github.com/marmos91/dittofs/pkg/config"
 	"github.com/marmos91/dittofs/pkg/controlplane/api"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
@@ -41,10 +42,10 @@ var isTerminal = func(fd uintptr) bool {
 }
 
 // EX_CONFIG is the exit code per sysexits(3) — "configuration error".
-// Used by the legacy-layout boot guard when a share directory still
-// contains pre-v0.16 `.blk` files without a `.cas-migrated-v1` sentinel.
-// The operator migrates with an older release's migrate-to-cas command
-// before retrying — this release no longer ships it.
+// Used by the format-mismatch boot guard when a share's on-disk state was
+// written by a release this build cannot read, in either direction: newer
+// state after a downgrade, or a pre-journal layout awaiting migration.
+// Serving either would return zeros for stored files, so boot stops instead.
 const EX_CONFIG = 78
 
 // exitFn is the production exit path for the legacy-layout boot guard.
@@ -834,8 +835,8 @@ func handleLoadSharesError(err error, stderr *os.File) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, block.ErrLegacyLayoutDetected) {
-		_, _ = fmt.Fprintln(stderr, formatLegacyLayoutDirective(err))
+	if errors.Is(err, block.ErrFutureFormat) || errors.Is(err, fs.ErrLegacyLocalFormat) {
+		_, _ = fmt.Fprintln(stderr, formatFormatMismatchDirective(err))
 		exitFn(EX_CONFIG)
 		// Unreachable in production (exitFn == os.Exit terminates).
 		// Defensive: in-process tests stub exitFn to NOT terminate.
@@ -871,16 +872,33 @@ func emitAdminPassword(password string) {
 		"or bootstrap with 'dfs start --foreground' in a terminal to have it printed once.")
 }
 
-// formatLegacyLayoutDirective renders the multi-line operator directive
-// printed when LoadSharesFromStore surfaces ErrLegacyLayoutDetected.
-// The full wrapped error message (`share "<name>": share <path>:
-// blockstore: legacy .blk layout detected`)
-// is embedded verbatim so the operator sees BOTH the share name AND
-// the offending path without fragile substring extraction.
-func formatLegacyLayoutDirective(err error) string {
-	return fmt.Sprintf(`Detected legacy .blk layout: %s.
-This release no longer ships the .blk migration tool. Migrate the share
-with dittofs v0.21 or earlier first, using that release's binary:
-    <v0.21 dfs> migrate-to-cas --share <name>
-then upgrade; the cas->blocks conversion runs automatically at startup.`, err)
+// formatFormatMismatchDirective renders the multi-line operator directive
+// printed when a share cannot be opened because its on-disk format does not
+// match this build. The wrapped error is embedded verbatim so the operator sees
+// the share name, the offending path and the two versions without fragile
+// substring extraction.
+//
+// The two directions need different advice, so they get different text: state
+// from a newer release is a downgrade the operator can undo by going forward
+// again, while a pre-journal layout is an upgrade that has not run yet.
+func formatFormatMismatchDirective(err error) string {
+	if errors.Is(err, block.ErrFutureFormat) {
+		return fmt.Sprintf(`Refusing to start: %s.
+
+This share was written by a newer release of DittoFS. Opening it with this
+build would serve the stored files as zeros rather than fail, so the daemon
+stops instead.
+
+Upgrades are one-way. To recover, either:
+  - reinstall the release that wrote this share and start again, or
+  - restore the snapshot taken before the upgrade.
+
+No data has been modified.`, err)
+	}
+	return fmt.Sprintf(`Refusing to start: %s.
+
+This share holds a pre-journal blobs/+logs/ layout that this build cannot read
+directly. The bytes are intact on disk — the migration converts them in place
+at startup once the share is configured with a remote, or re-ingests them from
+the append logs for a local-only share.`, err)
 }

--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -48,9 +48,9 @@ var isTerminal = func(fd uintptr) bool {
 // Serving either would return zeros for stored files, so boot stops instead.
 const EX_CONFIG = 78
 
-// exitFn is the production exit path for the legacy-layout boot guard.
+// exitFn is the production exit path for the format-mismatch boot guard.
 // Indirected through a package-level var so the in-process boot-guard
-// test (start_test.go::TestStart_LegacyLayoutExitCode) can stub it to
+// test (start_test.go::TestStart_FutureFormatExitCode) can stub it to
 // capture the exit code deterministically without spawning a subprocess.
 // Production code MUST NOT reassign exitFn — only the test does, and
 // only via a t.Cleanup-restored override.
@@ -836,7 +836,7 @@ func handleLoadSharesError(err error, stderr *os.File) bool {
 		return false
 	}
 	if errors.Is(err, block.ErrFutureFormat) || errors.Is(err, fs.ErrLegacyLocalFormat) {
-		_, _ = fmt.Fprintln(stderr, formatFormatMismatchDirective(err))
+		_, _ = fmt.Fprintln(stderr, formatMismatchDirective(err))
 		exitFn(EX_CONFIG)
 		// Unreachable in production (exitFn == os.Exit terminates).
 		// Defensive: in-process tests stub exitFn to NOT terminate.
@@ -872,16 +872,16 @@ func emitAdminPassword(password string) {
 		"or bootstrap with 'dfs start --foreground' in a terminal to have it printed once.")
 }
 
-// formatFormatMismatchDirective renders the multi-line operator directive
-// printed when a share cannot be opened because its on-disk format does not
-// match this build. The wrapped error is embedded verbatim so the operator sees
-// the share name, the offending path and the two versions without fragile
-// substring extraction.
+// formatMismatchDirective renders the multi-line operator directive printed
+// when a share cannot be opened because its on-disk format does not match this
+// build. The wrapped error is embedded verbatim so the operator sees the share
+// name, the offending path and the two versions without fragile substring
+// extraction.
 //
-// The two directions need different advice, so they get different text: state
-// from a newer release is a downgrade the operator can undo by going forward
-// again, while a pre-journal layout is an upgrade that has not run yet.
-func formatFormatMismatchDirective(err error) string {
+// The two directions need different advice: state from a newer release is a
+// downgrade the operator can undo by going forward again, while a pre-journal
+// layout is an upgrade that has not run yet.
+func formatMismatchDirective(err error) string {
 	if errors.Is(err, block.ErrFutureFormat) {
 		return fmt.Sprintf(`Refusing to start: %s.
 

--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -169,6 +169,11 @@ func runStart(cmd *cobra.Command, args []string) error {
 	// Initialize runtime from database (loads metadata stores and shares)
 	rt, err := runtime.InitializeFromStore(ctx, cpStore)
 	if err != nil {
+		// A metadata store whose format this build cannot read gets the same
+		// exit code and directive as a block store in that state.
+		if stop := handleFormatMismatch(err, os.Stderr); stop {
+			return nil
+		}
 		return fmt.Errorf("failed to initialize runtime: %w", err)
 	}
 
@@ -822,24 +827,41 @@ func createSMBAdapter(cfg *models.AdapterConfig, kerberosConfig *config.Kerberos
 	return smbAdapter, nil
 }
 
+// handleFormatMismatch prints the operator directive and exits 78 when err
+// reports on-disk state this build cannot read. Returns true when it did, so
+// the caller stops.
+//
+// Both store-opening paths must route through here. Metadata stores open in
+// InitializeFromStore and block stores in LoadSharesFromStore; a mismatch on
+// either one is the same condition to an operator and deserves the same exit
+// code and the same directive, not a bare cobra error.
+//
+// Production code MUST go through this helper — direct termination from
+// runStart would bypass the exitFn indirection the test depends on.
+func handleFormatMismatch(err error, stderr *os.File) bool {
+	if err == nil {
+		return false
+	}
+	if !errors.Is(err, block.ErrFutureFormat) && !errors.Is(err, fs.ErrLegacyLocalFormat) {
+		return false
+	}
+	_, _ = fmt.Fprintln(stderr, formatMismatchDirective(err))
+	exitFn(EX_CONFIG)
+	// Unreachable in production (exitFn == os.Exit terminates).
+	// Defensive: in-process tests stub exitFn to NOT terminate.
+	return true
+}
+
 // handleLoadSharesError centralizes the share-loading error policy so
 // the in-process boot-guard test can exercise the exit-78 path without
 // rebuilding the full daemon setup. Returns true when the caller should
-// stop runStart (legacy-layout branch hit; exitFn called); false
-// otherwise (no error, or a non-legacy warn-and-continue).
-//
-// Production code MUST go through this helper — direct termination
-// from runStart would bypass the exitFn indirection the test depends
-// on.
+// stop runStart (format-mismatch branch hit; exitFn called); false
+// otherwise (no error, or a warn-and-continue).
 func handleLoadSharesError(err error, stderr *os.File) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, block.ErrFutureFormat) || errors.Is(err, fs.ErrLegacyLocalFormat) {
-		_, _ = fmt.Fprintln(stderr, formatMismatchDirective(err))
-		exitFn(EX_CONFIG)
-		// Unreachable in production (exitFn == os.Exit terminates).
-		// Defensive: in-process tests stub exitFn to NOT terminate.
+	if handleFormatMismatch(err, stderr) {
 		return true
 	}
 	logger.Warn("Failed to load some shares", "error", err)
@@ -873,10 +895,13 @@ func emitAdminPassword(password string) {
 }
 
 // formatMismatchDirective renders the multi-line operator directive printed
-// when a share cannot be opened because its on-disk format does not match this
-// build. The wrapped error is embedded verbatim so the operator sees the share
-// name, the offending path and the two versions without fragile substring
+// when a store cannot be opened because its on-disk format does not match this
+// build. The wrapped error is embedded verbatim so the operator sees which
+// store, the offending path and the two versions without fragile substring
 // extraction.
+//
+// It covers metadata stores and block stores alike, so the text says "state"
+// rather than naming either: the wrapped error already identifies which one.
 //
 // The two directions need different advice: state from a newer release is a
 // downgrade the operator can undo by going forward again, while a pre-journal
@@ -885,7 +910,7 @@ func formatMismatchDirective(err error) string {
 	if errors.Is(err, block.ErrFutureFormat) {
 		return fmt.Sprintf(`Refusing to start: %s.
 
-This share was written by a newer release of DittoFS. Opening it with this
+This state was written by a newer release of DittoFS. Opening it with this
 build would serve the stored files as zeros rather than fail, so the daemon
 stops instead.
 

--- a/cmd/dfs/commands/start_test.go
+++ b/cmd/dfs/commands/start_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/marmos91/dittofs/pkg/block"
 )
 
-// TestStart_LegacyLayoutExitCode asserts the boot-guard contract:
+// TestStart_FutureFormatExitCode asserts the boot-guard contract:
 // when LoadSharesFromStore surfaces an error wrapping
-// block.ErrLegacyLayoutDetected, the start command must
+// block.ErrFutureFormat, the start command must
 // (1) print the multi-line operator directive to stderr,
 // (2) exit with code 78 (EX_CONFIG).
 //
@@ -32,8 +32,8 @@ import (
 // runtime.LoadSharesFromStore returns. Capturing the wrap shape
 // (`share "<name>": share <path>: blockstore: legacy ...`) matches
 // what runtime.LoadSharesFromStore produces when AddShare bubbles
-// `ErrLegacyLayoutDetected` from `fs.NewWithOptions`.
-func TestStart_LegacyLayoutExitCode(t *testing.T) {
+// `ErrFutureFormat` from a store constructor.
+func TestStart_FutureFormatExitCode(t *testing.T) {
 	// Stub exitFn to capture the exit code without terminating the process.
 	origExit := exitFn
 	t.Cleanup(func() { exitFn = origExit })
@@ -59,14 +59,14 @@ func TestStart_LegacyLayoutExitCode(t *testing.T) {
 
 	// Synthesize the exact wrap shape runtime.LoadSharesFromStore
 	// produces: `share %q: %w` around the fs.NewWithOptions output, which
-	// is itself `share %s: %w` around block.ErrLegacyLayoutDetected.
+	// is itself `share %s: %w` around block.ErrFutureFormat.
 	sharePath := filepath.Join(t.TempDir(), "share-A")
-	innerErr := fmt.Errorf("share %s: %w", sharePath, block.ErrLegacyLayoutDetected)
+	innerErr := fmt.Errorf("share %s: %w", sharePath, block.ErrFutureFormat)
 	loadErr := fmt.Errorf("share %q: %w", "share-A", innerErr)
 
 	stop := handleLoadSharesError(loadErr, w)
 	if !stop {
-		t.Fatalf("handleLoadSharesError returned stop=false on legacy-layout error")
+		t.Fatalf("handleLoadSharesError returned stop=false on future-format error")
 	}
 
 	// Close the writer so the reader sees EOF, then drain.
@@ -84,7 +84,7 @@ func TestStart_LegacyLayoutExitCode(t *testing.T) {
 	select {
 	case gotCode = <-exitCh:
 	default:
-		t.Fatalf("exitFn was never invoked on legacy-layout error")
+		t.Fatalf("exitFn was never invoked on future-format error")
 	}
 	if gotCode != EX_CONFIG {
 		t.Errorf("captured exit code = %d, want %d", gotCode, EX_CONFIG)
@@ -95,8 +95,9 @@ func TestStart_LegacyLayoutExitCode(t *testing.T) {
 
 	stderr := stderrBuf.String()
 	for _, want := range []string{
-		"Detected legacy .blk layout",
-		"dittofs v0.21 or earlier",
+		"Refusing to start",
+		"written by a newer release",
+		"Upgrades are one-way",
 		sharePath,
 	} {
 		if !strings.Contains(stderr, want) {

--- a/docs/guide/block-store-migration.md
+++ b/docs/guide/block-store-migration.md
@@ -50,6 +50,35 @@ layout (exit code 78) — but the directive now is:
 3. Upgrade to the current release. The automatic cas→blocks conversion
    above finishes the job on first start.
 
+## Upgrading and rolling back
+
+**Every migration above is one-way.** Once a share has been converted, the
+release you upgraded from can no longer read it. There is no downgrade
+command, and there is no partial-downgrade state to repair.
+
+So: **take a snapshot before you upgrade** — the share's local store
+directory and, for remote-backed shares, the bucket/prefix. That snapshot is
+the only way back.
+
+The migrations announce themselves. Each one logs a `WARN` naming what it is
+about to convert before it touches anything, and long-running ones log
+progress every few seconds (payload/chunk counts) so a large store is
+visibly working rather than apparently hung. Nothing blocks on an
+acknowledgement — an unattended upgrade-and-restart completes on its own.
+
+From this release on, starting an **older** binary against state a newer one
+wrote refuses to boot: the server exits **78** (`EX_CONFIG`) and prints the
+share path along with both the on-disk format version and the highest this
+build reads. Earlier releases had no such check and would open the share and
+serve stored files as zeros — right length, no content — which is why the
+guard fails closed instead.
+
+If you hit it, no data has been modified. Either:
+
+- reinstall the newer release and start again (the usual case: an accidental
+  downgrade or a rollback of the wrong component), or
+- restore the pre-upgrade snapshot and start the older release against that.
+
 ## Verifying
 
 After the first post-upgrade start:

--- a/pkg/block/blockstore.go
+++ b/pkg/block/blockstore.go
@@ -6,8 +6,8 @@
 // tier (per-file append log + rollup) used by the fs backend only;
 // s3 and memory backends implement only BlockStore.
 //
-// Sentinel-file conventions (.cas-migrated-v1) and the legacy-layout
-// boot guard (ErrLegacyLayoutDetected) live in doc.go and errors.go.
+// The on-disk format-version stamp and the boot guard that refuses state
+// from a newer release (ErrFutureFormat) live in doc.go and errors.go.
 
 package block
 

--- a/pkg/block/doc.go
+++ b/pkg/block/doc.go
@@ -3,8 +3,7 @@
 // single source of truth for FileChunk, BlockState, ContentHash, BlockSize
 // the BlockStore + BlockStoreAppend interfaces, the minimal Meta struct
 // the error sentinels (ErrStopWalk, ErrFutureFormat
-// ErrChunkNotFound, …), and the on-disk irreversible-state-transition
-// conventions (sentinel marker files).
+// ErrChunkNotFound, …), and the on-disk format-version convention.
 //
 // # Interface roles
 //

--- a/pkg/block/doc.go
+++ b/pkg/block/doc.go
@@ -2,7 +2,7 @@
 // contract DittoFS uses across every storage tier. It is the
 // single source of truth for FileChunk, BlockState, ContentHash, BlockSize
 // the BlockStore + BlockStoreAppend interfaces, the minimal Meta struct
-// the error sentinels (ErrStopWalk, ErrLegacyLayoutDetected
+// the error sentinels (ErrStopWalk, ErrFutureFormat
 // ErrChunkNotFound, …), and the on-disk irreversible-state-transition
 // conventions (sentinel marker files).
 //
@@ -60,72 +60,27 @@
 //
 // See BlockStore.Walk godoc for the full contract.
 //
-// # Sentinel-file convention (.cas-migrated-vN)
+// # On-disk format versions
 //
-// A project-wide pattern for irreversible on-disk state transitions:
-// a dot-prefixed sentinel marker file named .cas-migrated-vN — where
-// N is the layout-schema version — that proves a state transition
-// completed atomically.
+// Every store stamps the format version of the state it writes and checks
+// that stamp when it opens. A stamp NEWER than the running build is refused
+// with ErrFutureFormat: the alternative is not an error but silence, because
+// a record whose layout moved to a sibling key decodes cleanly into a file
+// with the right size and no content, and the store then serves zeros. Boot
+// treats the refusal as fatal for the whole daemon rather than skipping the
+// share, so a downgraded box cannot come up looking healthy.
 //
-// Lifecycle
-//
-//   - Written by the (now-removed, <= v0.21) migration tooling via
-//     atomic rename ONLY at successful completion of the transition.
-//     A crash mid-migration cannot leave the sentinel behind because
-//     the tooling writes <name>.tmp first, fsyncs, then renames into
-//     place and fsyncs the parent directory.
-//
-//   - Read by backend constructors at open time. *fs.FSStore (via
-//     NewWithOptions → newFSStore) stats <baseDir>/.cas-migrated-v1
-//     before any other I/O. Presence is the ground-truth proof of
-//     completion. Cost is O(1).
-//
-//   - On absence, the constructor runs a depth-capped probe for
-//     legacy `.blk` files in baseDir; if any are found and no
-//     sentinel exists, it returns ErrLegacyLayoutDetected. The boot
-//     guard in cmd/dfs/commands/start.go unwraps via errors.Is,
-//     prints an operator directive, and exits 78 (EX_CONFIG per
-//     sysexits(3)). Per-share fail-fast: the first un-migrated share
-//     halts boot.
-//
-// Per-share placement: the sentinel lives at the share root that
-// production passes to fs.NewWithOptions as baseDir. Per-share semantics
-// (not per-storage-dir global) mean `--share <name>` migrations
-// produce per-share sentinels and partial multi-share runs leave
-// already-migrated shares boot-able while unmigrated ones remain
-// refused.
-//
-// Sentinel contents (JSON):
-//
-//	{
-//	    "Version": "v1",
-//	    "CompletedAt": "2026-05-20T14:30:00Z",
-//	    "ToolVersion": "v1.0.0",
-//	    "ShareDir": "/path/to/share"
-//	}
-//
-// Hand-editing the sentinel is a footgun — it bypasses the boot guard
-// without curing the underlying layout mismatch, leaving a partially
-// migrated store that will surface I/O errors on the first legacy
-// FileChunk access. Treat the file as a one-way irreversibility
-// marker. The recovery procedure for a failed migration lives in
-// docs/CONFIGURATION.md §Migration.
-//
-// Future schema bumps: increment N. New constructors stat the highest
-// version they recognize and refuse anything below. A v2 backend
-// reading a v1 sentinel must surface an explicit
-// "downgrade not supported" error rather than silently accepting it.
-//
-// # Migration tooling
+// The reverse direction — state OLDER than the build — is a migration, not a
+// refusal, and runs automatically at share startup. It is one-way: once it
+// has run, the previous release can no longer read the result. The migration
+// warns about that before it starts.
 //
 // The offline .blk-to-CAS migration tool (`dfs migrate-to-cas`) shipped
 // through dittofs v0.21 and has been removed; shares still on the `.blk`
 // layout must be migrated with an older release before upgrading. The
-// constructors keep honoring the .cas-migrated-v1 sentinels those runs
-// left behind. The follow-on cas->blocks conversion (standalone CAS
-// objects into packed blocks/<id> containers, #1493) is automatic: it
-// runs blocking at share startup (engine.Store.Start), is resumable and
-// idempotent, and needs no tooling or sentinel.
+// follow-on cas->blocks conversion (standalone CAS objects into packed
+// blocks/<id> containers) is automatic: it runs in the background from
+// engine.Store.Start, is resumable and idempotent, and needs no tooling.
 //
 // # Error sentinels
 //
@@ -134,8 +89,8 @@
 // mappings.
 //
 // - ErrStopWalk — Walk callback early-exit signal.
-//   - ErrLegacyLayoutDetected — backend constructor refused an
-//     un-migrated `.blk` layout; migrate with dittofs <= v0.21 first.
+//   - ErrFutureFormat — a store refused on-disk state written by a
+//     newer release than this build can read.
 //   - ErrChunkNotFound — content-addressed chunk is absent
 //     from the store (local or remote).
 //   - ErrChunkContentMismatch — recomputed BLAKE3 disagreed with the

--- a/pkg/block/engine/legacy_migration.go
+++ b/pkg/block/engine/legacy_migration.go
@@ -42,9 +42,9 @@ import (
 // standalone locators plus one remote LIST page. Re-running against a
 // migrated share is a no-op.
 
-// migrationProgressInterval is how often the migration reports what it has done
-// so far. Long enough that a small share logs once, short enough that a large
-// one never looks wedged.
+// migrationProgressInterval is how often a migration loop whose cost scales with
+// the data reports what it has done so far: long enough that a small store logs
+// nothing extra, short enough that a large one never looks wedged.
 const migrationProgressInterval = 5 * time.Second
 
 // legacyChunkFileMigrator is implemented by the fs-backed local store; the
@@ -124,10 +124,9 @@ func (m *Syncer) migrateLegacyCASRemote(ctx context.Context) error {
 		if rbs == nil || committer == nil {
 			return fmt.Errorf("cas→blocks migration: %d standalone chunks found but the block substrate is not wired", len(standalone))
 		}
-		logger.Warn("standalone cas chunks detected: re-packing them into blocks and purging the cas/ namespace. "+
-			"The conversion is one-way — the previous release cannot read the re-packed objects. "+
-			"Snapshot the remote bucket before upgrading, and restore that snapshot to go back",
-			"chunks", len(standalone))
+		logger.Warn("cas→blocks migration: re-packing standalone chunks and purging the cas/ namespace — "+
+			"one-way, the previous release cannot read the result; snapshot the remote bucket before upgrading",
+			"chunks_total", len(standalone))
 		if err := m.repackStandaloneChunks(ctx, legacy, hasLegacy, sealer, committer, standalone); err != nil {
 			return err
 		}
@@ -213,13 +212,10 @@ func (m *Syncer) repackStandaloneChunks(
 		return nil
 	}
 
-	// Each chunk costs a remote read, so the loop is logged on a timer: a small
-	// share prints the start line and the completion summary, a large one keeps
-	// reporting instead of leaving the operator unable to tell a slow migration
-	// from a wedged one.
+	// Each chunk costs a remote read, so the caller's announcement is followed by
+	// a heartbeat rather than one line per chunk.
 	started := time.Now()
 	lastLog := started
-	logger.Info("cas→blocks migration: re-packing standalone chunks", "chunks", len(standalone))
 
 	for i, h := range standalone {
 		if err := ctx.Err(); err != nil {
@@ -228,7 +224,7 @@ func (m *Syncer) repackStandaloneChunks(
 		if time.Since(lastLog) >= migrationProgressInterval {
 			lastLog = time.Now()
 			logger.Info("cas→blocks migration: re-packing standalone chunks",
-				"chunks_read", i, "chunks_repacked", repacked,
+				"chunks_done", i, "chunks_total", len(standalone), "chunks_repacked", repacked,
 				"elapsed", time.Since(started).Round(time.Second))
 		}
 		data, err := m.migrationChunkBytes(ctx, legacy, hasLegacy, h)

--- a/pkg/block/engine/legacy_migration.go
+++ b/pkg/block/engine/legacy_migration.go
@@ -42,6 +42,11 @@ import (
 // standalone locators plus one remote LIST page. Re-running against a
 // migrated share is a no-op.
 
+// migrationProgressInterval is how often the migration reports what it has done
+// so far. Long enough that a small share logs once, short enough that a large
+// one never looks wedged.
+const migrationProgressInterval = 5 * time.Second
+
 // legacyChunkFileMigrator is implemented by the fs-backed local store; the
 // memory local store has no per-chunk file layout and skips Phase L.
 type legacyChunkFileMigrator interface {
@@ -119,6 +124,10 @@ func (m *Syncer) migrateLegacyCASRemote(ctx context.Context) error {
 		if rbs == nil || committer == nil {
 			return fmt.Errorf("cas→blocks migration: %d standalone chunks found but the block substrate is not wired", len(standalone))
 		}
+		logger.Warn("standalone cas chunks detected: re-packing them into blocks and purging the cas/ namespace. "+
+			"The conversion is one-way — the previous release cannot read the re-packed objects. "+
+			"Snapshot the remote bucket before upgrading, and restore that snapshot to go back",
+			"chunks", len(standalone))
 		if err := m.repackStandaloneChunks(ctx, legacy, hasLegacy, sealer, committer, standalone); err != nil {
 			return err
 		}
@@ -204,9 +213,23 @@ func (m *Syncer) repackStandaloneChunks(
 		return nil
 	}
 
-	for _, h := range standalone {
+	// Each chunk costs a remote read, so the loop is logged on a timer: a small
+	// share prints the start line and the completion summary, a large one keeps
+	// reporting instead of leaving the operator unable to tell a slow migration
+	// from a wedged one.
+	started := time.Now()
+	lastLog := started
+	logger.Info("cas→blocks migration: re-packing standalone chunks", "chunks", len(standalone))
+
+	for i, h := range standalone {
 		if err := ctx.Err(); err != nil {
 			return err
+		}
+		if time.Since(lastLog) >= migrationProgressInterval {
+			lastLog = time.Now()
+			logger.Info("cas→blocks migration: re-packing standalone chunks",
+				"chunks_read", i, "chunks_repacked", repacked,
+				"elapsed", time.Since(started).Round(time.Second))
 		}
 		data, err := m.migrationChunkBytes(ctx, legacy, hasLegacy, h)
 		if err != nil {

--- a/pkg/block/errors.go
+++ b/pkg/block/errors.go
@@ -193,27 +193,23 @@ var (
 	ErrStopWalk = errors.New("blockstore: stop walk")
 
 	// ErrFutureFormat is returned when a store opens on-disk state that a
-	// NEWER release wrote and this binary cannot read. It is the downgrade
-	// half of the format contract: the legacy sentinels below catch old
-	// state under a new binary, this one catches new state under an old
-	// binary.
-	//
-	// It exists because the alternative is silence. A record whose layout
-	// moved to a sibling key, or a side-log whose name this binary does not
-	// know, decodes "successfully" into a file with the right size and no
-	// content — the store serves zeros and logs nothing. Refusing to open is
-	// the only safe reading of state we do not understand.
+	// NEWER release wrote and this binary cannot read. It exists because the
+	// alternative is silence: a record whose layout moved to a sibling key, or
+	// a side-log whose name this binary does not know, decodes "successfully"
+	// into a file with the right size and no content — the store serves zeros
+	// and logs nothing.
 	//
 	// Wrap it with the versions the operator needs to act
 	//
-	//   return fmt.Errorf("%w: %s is format v%d, this build reads up to v%d",
+	//   return fmt.Errorf("%w: %s is at format version %d, this build reads up to %d",
 	//       block.ErrFutureFormat, dir, onDisk, supported)
 	//
 	// Boot matches via errors.Is and exits 78 (EX_CONFIG per sysexits(3)).
-	// Fail-fast is per-share but fatal: a share that cannot be opened safely
-	// must not leave the daemon looking healthy.
+	// Detection is per-share but the exit is fatal: a share that cannot be
+	// opened safely must not leave the daemon looking healthy.
 	//
-	// Operator action: return to a release that understands the on-disk
-	// format, or restore the pre-upgrade snapshot.
+	// Both block stores and metadata stores return it, so the message carries
+	// no "blockstore:" prefix — unlike the sentinels above, it is not about
+	// blocks.
 	ErrFutureFormat = errors.New("store: on-disk format is newer than this build")
 )

--- a/pkg/block/errors.go
+++ b/pkg/block/errors.go
@@ -192,27 +192,28 @@ var (
 	// See BlockStore.Walk.
 	ErrStopWalk = errors.New("blockstore: stop walk")
 
-	// ErrLegacyLayoutDetected is returned by fs.NewWithOptions when
-	// the share directory contains legacy `.blk` files but no
-	// `.cas-migrated-v1` sentinel marker file. The wrapped target
-	// carries the offending share path
+	// ErrFutureFormat is returned when a store opens on-disk state that a
+	// NEWER release wrote and this binary cannot read. It is the downgrade
+	// half of the format contract: the legacy sentinels below catch old
+	// state under a new binary, this one catches new state under an old
+	// binary.
 	//
-	//   return nil, fmt.Errorf("%w: share path %s", ErrLegacyLayoutDetected, baseDir)
+	// It exists because the alternative is silence. A record whose layout
+	// moved to a sibling key, or a side-log whose name this binary does not
+	// know, decodes "successfully" into a file with the right size and no
+	// content — the store serves zeros and logs nothing. Refusing to open is
+	// the only safe reading of state we do not understand.
 	//
-	// Detection at boot is via errors.Is, not errors.As — the sentinel
-	// is an errors.New value (not a typed struct), so errors.Is is the
-	// idiomatic match
+	// Wrap it with the versions the operator needs to act
 	//
-	//   if errors.Is(err, block.ErrLegacyLayoutDetected) { ... }
+	//   return fmt.Errorf("%w: %s is format v%d, this build reads up to v%d",
+	//       block.ErrFutureFormat, dir, onDisk, supported)
 	//
-	// cmd/dfs/start.go unwraps via errors.Is, prints an operator
-	// directive ("Detected legacy `.blk` layout at <path>. v0.16+
-	// requires CAS migration. Run `dfs migrate-to-cas` before
-	// starting."), and exits 78 (EX_CONFIG from sysexits(3)). Per-share
-	// fail-fast: the first un-migrated share halts boot.
+	// Boot matches via errors.Is and exits 78 (EX_CONFIG per sysexits(3)).
+	// Fail-fast is per-share but fatal: a share that cannot be opened safely
+	// must not leave the daemon looking healthy.
 	//
-	// Operator action: run `dfs migrate-to-cas --share <name>` (or
-	// `dfs migrate-to-cas` for all shares) and retry. See
-	// docs/CONFIGURATION.md §migration..
-	ErrLegacyLayoutDetected = errors.New("blockstore: legacy .blk layout detected (migrate with dittofs <= v0.21 first)")
+	// Operator action: return to a release that understands the on-disk
+	// format, or restore the pre-upgrade snapshot.
+	ErrFutureFormat = errors.New("store: on-disk format is newer than this build")
 )

--- a/pkg/block/errors_test.go
+++ b/pkg/block/errors_test.go
@@ -16,19 +16,19 @@ func TestErrStopWalk_DetectsThroughWrap(t *testing.T) {
 	if !errors.Is(wrapped, block.ErrStopWalk) {
 		t.Fatalf("errors.Is should detect ErrStopWalk through fmt.Errorf wrap; got %v", wrapped)
 	}
-	if errors.Is(wrapped, block.ErrLegacyLayoutDetected) {
+	if errors.Is(wrapped, block.ErrFutureFormat) {
 		t.Fatalf("errors.Is must not cross-match unrelated sentinels")
 	}
 }
 
-// TestErrLegacyLayoutDetected_DetectsThroughWrap pins the boot-guard
-// contract: NewFSStore wraps the sentinel with the
-// share path via fmt.Errorf("%w: share path %s", ...) and cmd/dfs/start
-// matches via errors.Is.
-func TestErrLegacyLayoutDetected_DetectsThroughWrap(t *testing.T) {
-	wrapped := fmt.Errorf("%w: share path %s", block.ErrLegacyLayoutDetected, "/data/share-a")
-	if !errors.Is(wrapped, block.ErrLegacyLayoutDetected) {
-		t.Fatalf("errors.Is should detect ErrLegacyLayoutDetected through fmt.Errorf wrap; got %v", wrapped)
+// TestErrFutureFormat_DetectsThroughWrap pins the boot-guard contract: a
+// store wraps the sentinel with the path and the two format versions via
+// fmt.Errorf("%w: ...", ...) and cmd/dfs/start matches via errors.Is.
+func TestErrFutureFormat_DetectsThroughWrap(t *testing.T) {
+	wrapped := fmt.Errorf("%w: share path %s is format v3, this build reads up to v2",
+		block.ErrFutureFormat, "/data/share-a")
+	if !errors.Is(wrapped, block.ErrFutureFormat) {
+		t.Fatalf("errors.Is should detect ErrFutureFormat through fmt.Errorf wrap; got %v", wrapped)
 	}
 	// The wrapped error must carry the share path in its message — the
 	// boot directive surfaces this verbatim to the operator.
@@ -43,7 +43,6 @@ func TestErrLegacyLayoutDetected_DetectsThroughWrap(t *testing.T) {
 func TestSentinelMessages_HaveBlockstorePrefix(t *testing.T) {
 	for _, e := range []error{
 		block.ErrStopWalk,
-		block.ErrLegacyLayoutDetected,
 	} {
 		if !contains(e.Error(), "blockstore:") {
 			t.Errorf("sentinel %v must use the blockstore: prefix convention", e)

--- a/pkg/block/errors_test.go
+++ b/pkg/block/errors_test.go
@@ -38,8 +38,9 @@ func TestErrFutureFormat_DetectsThroughWrap(t *testing.T) {
 }
 
 // TestSentinelMessages_HaveBlockstorePrefix asserts the existing
-// convention from pkg/block/errors.go (every package sentinel
-// message starts with "blockstore:").
+// convention from pkg/block/errors.go (every block-specific sentinel
+// message starts with "blockstore:"). ErrFutureFormat is excluded on
+// purpose: metadata stores return it too, so it is not about blocks.
 func TestSentinelMessages_HaveBlockstorePrefix(t *testing.T) {
 	for _, e := range []error{
 		block.ErrStopWalk,

--- a/pkg/block/journal/format.go
+++ b/pkg/block/journal/format.go
@@ -1,0 +1,139 @@
+package journal
+
+// format.go stamps the journal directory with the on-disk layout version it was
+// written by, so a binary that finds state it does not understand refuses to
+// open it instead of reading it as empty.
+//
+// The journal directory is not one file: it is a segment stream plus siblings
+// that came later (cold.log). Every one of those additions is invisible to an
+// older binary — it scans the segments it knows, finds no record for a range
+// the sibling described, and serves the range as a POSIX hole. The result of a
+// downgrade is therefore a share that opens cleanly, reports the right sizes
+// and returns zeros. A stamp turns that into a refusal at open.
+//
+// Layout: <dir>/format, a JSON object
+//
+//	{"version":1,"written_by":"v0.30.0","written_at":"2026-07-27T10:00:00Z"}
+//
+// Only version is load-bearing; written_by and written_at exist so an operator
+// staring at a directory can tell which release last touched it. The file is
+// written whole through a temp+rename so a crash never leaves a half-parsed
+// stamp, and it is fsynced because a stamp that does not survive the crash it
+// was meant to describe guards nothing.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+const (
+	// formatVersion is the layout this build reads and writes. It is the first
+	// stamp, so it does not describe any historical format: directories written
+	// before it carry no stamp at all and are adopted at open. Bump it whenever
+	// a change makes state unreadable by the previous release — a new sibling
+	// file, a record field, a renamed key — so that release refuses rather than
+	// reads holes.
+	formatVersion = 1
+
+	formatFileName = "format"
+)
+
+// formatStamp is the on-disk <dir>/format document.
+type formatStamp struct {
+	Version   int    `json:"version"`
+	WrittenBy string `json:"written_by"`
+	WrittenAt string `json:"written_at"`
+}
+
+// CheckFormat verifies that this build understands the journal directory's
+// on-disk layout, and stamps the directory when it is not yet stamped.
+//
+// Three outcomes:
+//
+//   - No stamp: a directory from a release that predates stamping, or a fresh
+//     one. Not an error — it is adopted and stamped, so every later open is
+//     guarded. This is why the guard only bites going forward.
+//   - Stamp newer than this build: returns an error wrapping
+//     block.ErrFutureFormat, which boot turns into a refusal to start.
+//   - Stamp at or below this build: opens normally.
+//
+// Call it before opening the journal: the point is to not touch state whose
+// shape is unknown.
+func CheckFormat(dir string) error {
+	raw, err := os.ReadFile(filepath.Join(dir, formatFileName))
+	if errors.Is(err, os.ErrNotExist) {
+		return writeFormat(dir)
+	}
+	if err != nil {
+		return fmt.Errorf("journal: read format stamp: %w", err)
+	}
+	var st formatStamp
+	if err := json.Unmarshal(raw, &st); err != nil {
+		// A stamp we cannot parse is state we cannot vouch for, and the whole
+		// reason the stamp exists is to not guess about that.
+		return fmt.Errorf("journal: parse format stamp in %s: %w", dir, err)
+	}
+	if st.Version > formatVersion {
+		return fmt.Errorf("%w: %s is format v%d, this build reads up to v%d",
+			block.ErrFutureFormat, dir, st.Version, formatVersion)
+	}
+	return nil
+}
+
+// writeFormat durably records this build's format version in dir. Temp file,
+// fsync, rename, fsync parent: the same shape the cold log's rewrite uses, so a
+// crash leaves either the previous stamp or the new one and never a torn file.
+func writeFormat(dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("journal: mkdir %q for format stamp: %w", dir, err)
+	}
+	buf, err := json.Marshal(formatStamp{
+		Version:   formatVersion,
+		WrittenBy: buildVersion(),
+		WrittenAt: time.Now().UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		return fmt.Errorf("journal: encode format stamp: %w", err)
+	}
+	path := filepath.Join(dir, formatFileName)
+	tmp := path + ".tmp"
+	fd, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("journal: create format stamp temp: %w", err)
+	}
+	if _, err := fd.Write(buf); err != nil {
+		_ = fd.Close()
+		return fmt.Errorf("journal: write format stamp temp: %w", err)
+	}
+	if err := fd.Sync(); err != nil {
+		_ = fd.Close()
+		return fmt.Errorf("journal: fsync format stamp temp: %w", err)
+	}
+	if err := fd.Close(); err != nil {
+		return fmt.Errorf("journal: close format stamp temp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("journal: rename format stamp: %w", err)
+	}
+	if err := fsyncDir(dir); err != nil {
+		return fmt.Errorf("journal: fsync dir after format stamp: %w", err)
+	}
+	return nil
+}
+
+// buildVersion names the release that wrote a stamp, for the operator reading
+// the file by hand. Best-effort: a binary built without module information
+// reports "unknown", which costs nothing since only Version is acted on.
+func buildVersion() string {
+	if bi, ok := debug.ReadBuildInfo(); ok && bi.Main.Version != "" {
+		return bi.Main.Version
+	}
+	return "unknown"
+}

--- a/pkg/block/journal/format.go
+++ b/pkg/block/journal/format.go
@@ -1,25 +1,18 @@
 package journal
 
-// format.go stamps the journal directory with the on-disk layout version it was
-// written by, so a binary that finds state it does not understand refuses to
-// open it instead of reading it as empty.
+// format.go stamps the journal directory with the on-disk layout version that
+// wrote it, so a binary that finds state it does not understand refuses to open
+// it instead of reading it as empty.
 //
 // The journal directory is not one file: it is a segment stream plus siblings
 // that came later (cold.log). Every one of those additions is invisible to an
-// older binary — it scans the segments it knows, finds no record for a range
-// the sibling described, and serves the range as a POSIX hole. The result of a
-// downgrade is therefore a share that opens cleanly, reports the right sizes
-// and returns zeros. A stamp turns that into a refusal at open.
+// older binary — it scans the segments it knows, finds no record for a range a
+// sibling described, and serves the range as a POSIX hole. Without a stamp a
+// downgrade opens cleanly, reports the right sizes, and returns zeros.
 //
 // Layout: <dir>/format, a JSON object
 //
-//	{"version":1,"written_by":"v0.30.0","written_at":"2026-07-27T10:00:00Z"}
-//
-// Only version is load-bearing; written_by and written_at exist so an operator
-// staring at a directory can tell which release last touched it. The file is
-// written whole through a temp+rename so a crash never leaves a half-parsed
-// stamp, and it is fsynced because a stamp that does not survive the crash it
-// was meant to describe guards nothing.
+//	{"version":1,"written_at":"2026-07-27T10:00:00Z"}
 
 import (
 	"encoding/json"
@@ -27,42 +20,32 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime/debug"
 	"time"
 
 	"github.com/marmos91/dittofs/pkg/block"
 )
 
 const (
-	// formatVersion is the layout this build reads and writes. It is the first
-	// stamp, so it does not describe any historical format: directories written
-	// before it carry no stamp at all and are adopted at open. Bump it whenever
+	// formatVersion is the layout this build reads and writes. Bump it whenever
 	// a change makes state unreadable by the previous release — a new sibling
-	// file, a record field, a renamed key — so that release refuses rather than
-	// reads holes.
+	// file, a moved record field, a renamed key — so that release refuses rather
+	// than reads holes.
 	formatVersion = 1
 
 	formatFileName = "format"
 )
 
-// formatStamp is the on-disk <dir>/format document.
+// formatStamp is the on-disk <dir>/format document. Only Version is acted on;
+// WrittenAt is there for an operator reading the file by hand.
 type formatStamp struct {
 	Version   int    `json:"version"`
-	WrittenBy string `json:"written_by"`
 	WrittenAt string `json:"written_at"`
 }
 
 // CheckFormat verifies that this build understands the journal directory's
-// on-disk layout, and stamps the directory when it is not yet stamped.
-//
-// Three outcomes:
-//
-//   - No stamp: a directory from a release that predates stamping, or a fresh
-//     one. Not an error — it is adopted and stamped, so every later open is
-//     guarded. This is why the guard only bites going forward.
-//   - Stamp newer than this build: returns an error wrapping
-//     block.ErrFutureFormat, which boot turns into a refusal to start.
-//   - Stamp at or below this build: opens normally.
+// on-disk layout, and stamps the directory when it is not yet stamped. An
+// unstamped directory predates stamping and is adopted, so every later open is
+// guarded; a stamp above formatVersion fails with block.ErrFutureFormat.
 //
 // Call it before opening the journal: the point is to not touch state whose
 // shape is unknown.
@@ -81,7 +64,7 @@ func CheckFormat(dir string) error {
 		return fmt.Errorf("journal: parse format stamp in %s: %w", dir, err)
 	}
 	if st.Version > formatVersion {
-		return fmt.Errorf("%w: %s is format v%d, this build reads up to v%d",
+		return fmt.Errorf("%w: %s is at format version %d, this build reads up to %d",
 			block.ErrFutureFormat, dir, st.Version, formatVersion)
 	}
 	return nil
@@ -96,7 +79,6 @@ func writeFormat(dir string) error {
 	}
 	buf, err := json.Marshal(formatStamp{
 		Version:   formatVersion,
-		WrittenBy: buildVersion(),
 		WrittenAt: time.Now().UTC().Format(time.RFC3339),
 	})
 	if err != nil {
@@ -126,14 +108,4 @@ func writeFormat(dir string) error {
 		return fmt.Errorf("journal: fsync dir after format stamp: %w", err)
 	}
 	return nil
-}
-
-// buildVersion names the release that wrote a stamp, for the operator reading
-// the file by hand. Best-effort: a binary built without module information
-// reports "unknown", which costs nothing since only Version is acted on.
-func buildVersion() string {
-	if bi, ok := debug.ReadBuildInfo(); ok && bi.Main.Version != "" {
-		return bi.Main.Version
-	}
-	return "unknown"
 }

--- a/pkg/block/local/fs/format_test.go
+++ b/pkg/block/local/fs/format_test.go
@@ -25,14 +25,13 @@ func readStampVersion(t *testing.T, dir string) int {
 	}
 	var st struct {
 		Version   int    `json:"version"`
-		WrittenBy string `json:"written_by"`
 		WrittenAt string `json:"written_at"`
 	}
 	if err := json.Unmarshal(raw, &st); err != nil {
 		t.Fatalf("parse format stamp %q: %v", raw, err)
 	}
-	if st.WrittenBy == "" || st.WrittenAt == "" {
-		t.Errorf("stamp %q missing operator fields", raw)
+	if st.WrittenAt == "" {
+		t.Errorf("stamp %q missing written_at", raw)
 	}
 	return st.Version
 }
@@ -44,7 +43,7 @@ func writeStamp(t *testing.T, dir string, v int) {
 	if err := os.MkdirAll(filepath.Dir(stampPath(dir)), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	raw := fmt.Sprintf(`{"version":%d,"written_by":"test","written_at":"2026-01-01T00:00:00Z"}`, v)
+	raw := fmt.Sprintf(`{"version":%d,"written_at":"2026-01-01T00:00:00Z"}`, v)
 	if err := os.WriteFile(stampPath(dir), []byte(raw), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/block/local/fs/format_test.go
+++ b/pkg/block/local/fs/format_test.go
@@ -1,0 +1,104 @@
+package fs
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+// stampPath is where the journal keeps its on-disk format marker, relative to a
+// store directory.
+func stampPath(dir string) string { return filepath.Join(dir, "journal", "format") }
+
+// readStampVersion returns the version recorded in dir's stamp, failing the test
+// if the stamp is missing or unreadable.
+func readStampVersion(t *testing.T, dir string) int {
+	t.Helper()
+	raw, err := os.ReadFile(stampPath(dir))
+	if err != nil {
+		t.Fatalf("read format stamp: %v", err)
+	}
+	var st struct {
+		Version   int    `json:"version"`
+		WrittenBy string `json:"written_by"`
+		WrittenAt string `json:"written_at"`
+	}
+	if err := json.Unmarshal(raw, &st); err != nil {
+		t.Fatalf("parse format stamp %q: %v", raw, err)
+	}
+	if st.WrittenBy == "" || st.WrittenAt == "" {
+		t.Errorf("stamp %q missing operator fields", raw)
+	}
+	return st.Version
+}
+
+// writeStamp plants a stamp at version v, standing in for a directory a
+// different release left behind.
+func writeStamp(t *testing.T, dir string, v int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(stampPath(dir)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	raw := fmt.Sprintf(`{"version":%d,"written_by":"test","written_at":"2026-01-01T00:00:00Z"}`, v)
+	if err := os.WriteFile(stampPath(dir), []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestOpenRefusesFutureFormat is the regression for a downgrade serving zeros: a
+// directory a newer release wrote must not open at all, because this binary
+// would read every range the newer format holds elsewhere as a hole.
+func TestOpenRefusesFutureFormat(t *testing.T) {
+	dir := t.TempDir()
+	writeStamp(t, dir, 2)
+
+	s, err := New(dir, 1<<30, nil)
+	if err == nil {
+		_ = s.Close()
+		t.Fatal("New on a future-format directory succeeded, want refusal")
+	}
+	if !errors.Is(err, block.ErrFutureFormat) {
+		t.Fatalf("New error = %v, want it to wrap block.ErrFutureFormat", err)
+	}
+}
+
+// TestOpenAcceptsCurrentFormat keeps the guard from firing on state this build
+// wrote itself.
+func TestOpenAcceptsCurrentFormat(t *testing.T) {
+	dir := t.TempDir()
+	writeStamp(t, dir, 1)
+
+	s, err := New(dir, 1<<30, nil)
+	if err != nil {
+		t.Fatalf("New on a current-format directory: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := readStampVersion(t, dir); got != 1 {
+		t.Fatalf("stamp version after open = %d, want 1", got)
+	}
+}
+
+// TestOpenStampsUnstampedDir covers the directories in the field today: they
+// predate stamping, so they must open, and they must come out stamped so the
+// next downgrade is caught.
+func TestOpenStampsUnstampedDir(t *testing.T) {
+	dir := t.TempDir()
+
+	s, err := New(dir, 1<<30, nil)
+	if err != nil {
+		t.Fatalf("New on an unstamped directory: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := readStampVersion(t, dir); got != 1 {
+		t.Fatalf("stamp version after open = %d, want 1", got)
+	}
+}

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -114,13 +114,11 @@ func NewWithOptions(dir string, maxDisk int64, fileChunkStore block.EngineFileCh
 			return nil, err
 		}
 		if legacy {
-			// The archive step rewrites the share's on-disk shape for good: the
-			// previous release looks for blobs/+logs/ where they no longer are
-			// and opens an empty journal, which serves zeros rather than
-			// failing. Say so before it happens, loudly enough to be found in a
-			// log after the fact, but do not block — the daemon must come up
+			// Announce before the archive rewrites the on-disk shape for good,
+			// but do not block on an acknowledgement — the daemon must come up
 			// unattended.
-			logger.Warn("local store: migrating a pre-journal layout — ONE-WAY, the previous release cannot read the result; snapshot this directory before proceeding",
+			logger.Warn("local store: archiving a pre-journal layout aside so the journal opens clean — "+
+				"one-way, the previous release cannot read the result; snapshot this directory before upgrading",
 				"dir", dir)
 			if err := archiveLegacyLayout(dir); err != nil {
 				return nil, err
@@ -145,10 +143,9 @@ func NewWithOptions(dir string, maxDisk int64, fileChunkStore block.EngineFileCh
 		EvictMaxWait:  opts.BackpressureMaxWait,
 		ChunkParams:   opts.ChunkParams,
 	}
-	// Refuse a journal directory a newer release wrote before touching it: this
-	// binary would scan only the state it knows about and read everything the
-	// newer format holds elsewhere as holes. An unstamped directory predates
-	// stamping and is adopted here, so every subsequent open is guarded.
+	// Check the format stamp before touching the journal: a directory a newer
+	// release wrote would otherwise read as holes wherever the newer format
+	// keeps state this binary does not scan.
 	journalDir := filepath.Join(dir, "journal")
 	if err := journal.CheckFormat(journalDir); err != nil {
 		return nil, err

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/chunker"
 	"github.com/marmos91/dittofs/pkg/block/journal"
@@ -113,6 +114,14 @@ func NewWithOptions(dir string, maxDisk int64, fileChunkStore block.EngineFileCh
 			return nil, err
 		}
 		if legacy {
+			// The archive step rewrites the share's on-disk shape for good: the
+			// previous release looks for blobs/+logs/ where they no longer are
+			// and opens an empty journal, which serves zeros rather than
+			// failing. Say so before it happens, loudly enough to be found in a
+			// log after the fact, but do not block — the daemon must come up
+			// unattended.
+			logger.Warn("local store: migrating a pre-journal layout — ONE-WAY, the previous release cannot read the result; snapshot this directory before proceeding",
+				"dir", dir)
 			if err := archiveLegacyLayout(dir); err != nil {
 				return nil, err
 			}
@@ -136,7 +145,15 @@ func NewWithOptions(dir string, maxDisk int64, fileChunkStore block.EngineFileCh
 		EvictMaxWait:  opts.BackpressureMaxWait,
 		ChunkParams:   opts.ChunkParams,
 	}
-	js, err := journal.Open(filepath.Join(dir, "journal"), cfg, nil, journal.SystemClock())
+	// Refuse a journal directory a newer release wrote before touching it: this
+	// binary would scan only the state it knows about and read everything the
+	// newer format holds elsewhere as holes. An unstamped directory predates
+	// stamping and is adopted here, so every subsequent open is guarded.
+	journalDir := filepath.Join(dir, "journal")
+	if err := journal.CheckFormat(journalDir); err != nil {
+		return nil, err
+	}
+	js, err := journal.Open(journalDir, cfg, nil, journal.SystemClock())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/block/local/fs/legacy_migrate.go
+++ b/pkg/block/local/fs/legacy_migrate.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block/journal"
 )
 
@@ -103,6 +104,10 @@ func setupLegacyLocalOnlyMigration(dir string) (*legacyMigration, error) {
 		return nil, refuseLegacyLocalOnly(dir, fmt.Sprintf("%s: %q", reason, badLog))
 	}
 
+	logger.Warn("pre-journal local-only layout detected: archiving it aside and re-ingesting its append logs "+
+		"into the journal. The conversion is one-way — the previous release cannot read the result. "+
+		"Snapshot the store directory before upgrading, and restore that snapshot to go back",
+		"dir", dir)
 	if err := archiveLegacyLayout(dir); err != nil {
 		return nil, err
 	}

--- a/pkg/block/local/fs/legacy_migrate.go
+++ b/pkg/block/local/fs/legacy_migrate.go
@@ -104,9 +104,8 @@ func setupLegacyLocalOnlyMigration(dir string) (*legacyMigration, error) {
 		return nil, refuseLegacyLocalOnly(dir, fmt.Sprintf("%s: %q", reason, badLog))
 	}
 
-	logger.Warn("pre-journal local-only layout detected: archiving it aside and re-ingesting its append logs "+
-		"into the journal. The conversion is one-way — the previous release cannot read the result. "+
-		"Snapshot the store directory before upgrading, and restore that snapshot to go back",
+	logger.Warn("local store: re-ingesting a pre-journal local-only layout's append logs into the journal — "+
+		"one-way, the previous release cannot read the result; snapshot this directory before upgrading",
 		"dir", dir)
 	if err := archiveLegacyLayout(dir); err != nil {
 		return nil, err

--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -10,6 +10,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/internal/pathutil"
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/local/fs"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
 	"github.com/marmos91/dittofs/pkg/metadata"
@@ -262,12 +263,15 @@ func LoadSharesFromStore(ctx context.Context, rt *Runtime, s store.Store) error 
 		}
 
 		if err := rt.AddShare(ctx, shareConfig); err != nil {
-			// Legacy-layout detection is a hard boot stop, not a
-			// per-share warn-and-skip. Surface it so
-			// cmd/dfs/commands/start.go can exit 78 with the operator
-			// directive. Every other AddShare failure stays a
-			// warn-and-skip (preserves existing behavior).
-			if errors.Is(err, block.ErrLegacyLayoutDetected) {
+			// A share whose on-disk format this build cannot read is a hard
+			// boot stop, not a per-share warn-and-skip: both directions of
+			// the mismatch (state from a newer release, or a pre-journal
+			// layout from an older one) serve the stored files as zeros if
+			// opened anyway, and a warn-and-skip leaves the daemon running
+			// and looking healthy with the share silently absent. Surface it
+			// so cmd/dfs/commands/start.go can exit 78 with the operator
+			// directive. Every other AddShare failure stays a warn-and-skip.
+			if errors.Is(err, block.ErrFutureFormat) || errors.Is(err, fs.ErrLegacyLocalFormat) {
 				return fmt.Errorf("share %q: %w", share.Name, err)
 			}
 			logger.Warn("Failed to add share to runtime",

--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -264,13 +264,11 @@ func LoadSharesFromStore(ctx context.Context, rt *Runtime, s store.Store) error 
 
 		if err := rt.AddShare(ctx, shareConfig); err != nil {
 			// A share whose on-disk format this build cannot read is a hard
-			// boot stop, not a per-share warn-and-skip: both directions of
-			// the mismatch (state from a newer release, or a pre-journal
-			// layout from an older one) serve the stored files as zeros if
-			// opened anyway, and a warn-and-skip leaves the daemon running
-			// and looking healthy with the share silently absent. Surface it
-			// so cmd/dfs/commands/start.go can exit 78 with the operator
-			// directive. Every other AddShare failure stays a warn-and-skip.
+			// boot stop, not a per-share warn-and-skip: warn-and-skip leaves
+			// the daemon running and looking healthy with the share silently
+			// absent. Surface it so cmd/dfs/commands/start.go can exit 78 with
+			// the operator directive. Every other AddShare failure stays a
+			// warn-and-skip.
 			if errors.Is(err, block.ErrFutureFormat) || errors.Is(err, fs.ErrLegacyLocalFormat) {
 				return fmt.Errorf("share %q: %w", share.Name, err)
 			}

--- a/pkg/controlplane/runtime/shares/legacy_verify.go
+++ b/pkg/controlplane/runtime/shares/legacy_verify.go
@@ -18,6 +18,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"time"
+
 	"lukechampine.com/blake3"
 
 	"github.com/marmos91/dittofs/internal/logger"
@@ -30,6 +32,11 @@ import (
 // rather than per-file, so a handful of extents is enough to expose it; the
 // point is to have read *something* before claiming success.
 const coldVerifySamples = 8
+
+// migrationProgressInterval is how often a migration loop whose cost scales with
+// the data reports what it has done so far: long enough that a small store logs
+// nothing extra, short enough that a large one never looks wedged.
+const migrationProgressInterval = 5 * time.Second
 
 // coldSample is one manifest extent the migration will read back and hash.
 type coldSample struct {

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1190,6 +1190,10 @@ func (s *Service) createBlockStoreForShare(
 	// ponytail: O(files) manifest scan at startup; a lazy per-read seed is the
 	// upgrade path if this ever bites a share with a huge file count.
 	if m, ok := localStore.(legacyArchiveMigrator); ok && m.MigratedFromLegacy() {
+		logger.Warn("pre-journal local layout detected: converting this share to the journal format. "+
+			"The conversion is one-way — the previous release cannot read the share once it completes. "+
+			"Snapshot the share directory before upgrading, and restore that snapshot to go back",
+			"share", config.Name)
 		if metaStore, ok := fileChunkStore.(metadata.Store); ok {
 			report, serr := SeedColdFromManifest(ctx, bs, metaStore)
 			if serr != nil {
@@ -1220,11 +1224,25 @@ func (s *Service) createBlockStoreForShare(
 			// Detached from the AddShare context, which may be cancelled once the
 			// call returns; the store's own close gate stops the drain on shutdown.
 			bgCtx := context.Background()
-			for _, payloadID := range m.LegacyPendingPayloads() {
+			// The whole work list is known up front, so progress is a fraction.
+			// Logged on a timer so a small share prints once and a large one
+			// keeps reporting instead of going silent for minutes.
+			pending := m.LegacyPendingPayloads()
+			started := time.Now()
+			lastLog := started
+			logger.Info("legacy local-only migration: re-ingesting archived append logs",
+				"share", shareName, "payloads_total", len(pending))
+			for i, payloadID := range pending {
 				if err := m.MaterializeLegacyPayload(payloadID); err != nil {
 					logger.Error("legacy local-only migration: materialize failed; leaving archive for retry on next start",
 						"share", shareName, "payload", payloadID, "error", err)
 					return
+				}
+				if time.Since(lastLog) >= migrationProgressInterval {
+					lastLog = time.Now()
+					logger.Info("legacy local-only migration: re-ingesting archived append logs",
+						"share", shareName, "payloads_done", i+1, "payloads_total", len(pending),
+						"elapsed", time.Since(started).Round(time.Second))
 				}
 			}
 			if err := bs.DrainRollups(bgCtx); err != nil {
@@ -3103,6 +3121,14 @@ func applyDurableOverride(store any, config map[string]any, label, shareName str
 // reports success.
 func SeedColdFromManifest(ctx context.Context, bs *engine.Store, metaStore metadata.Store) (coldSeedReport, error) {
 	var report coldSeedReport
+	// EnumeratePayloads is a callback iteration with no cheap denominator, so
+	// progress is a running count. It is logged on a timer rather than per
+	// payload: a small share prints the start line and the summary, a large one
+	// keeps reporting instead of leaving the operator unable to tell a slow
+	// startup from a wedged one.
+	started := time.Now()
+	lastLog := started
+	logger.Info("seeding cold intervals from the metadata manifest")
 	err := metaStore.EnumeratePayloads(ctx, func(payloadID string) error {
 		rows, err := metaStore.ListFileChunks(ctx, payloadID)
 		if err != nil {
@@ -3145,10 +3171,21 @@ func SeedColdFromManifest(ctx context.Context, bs *engine.Store, metaStore metad
 			return fmt.Errorf("seed cold %s: %w", payloadID, err)
 		}
 		report.payloads++
+		if time.Since(lastLog) >= migrationProgressInterval {
+			lastLog = time.Now()
+			logger.Info("seeding cold intervals from the metadata manifest",
+				"payloads", report.payloads, "chunks", report.chunks,
+				"elapsed", time.Since(started).Round(time.Second))
+		}
 		return nil
 	})
 	return report, err
 }
+
+// migrationProgressInterval is how often a migration loop whose cost scales with
+// the data reports what it has done so far. Long enough that a fast store logs
+// once, short enough that a slow one never looks wedged.
+const migrationProgressInterval = 5 * time.Second
 
 // parseRequireDurableCommit reads the optional per-share "require_durable_commit"
 // bool from the local store config (#1274). Read the same conservative way as

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1190,10 +1190,6 @@ func (s *Service) createBlockStoreForShare(
 	// ponytail: O(files) manifest scan at startup; a lazy per-read seed is the
 	// upgrade path if this ever bites a share with a huge file count.
 	if m, ok := localStore.(legacyArchiveMigrator); ok && m.MigratedFromLegacy() {
-		logger.Warn("pre-journal local layout detected: converting this share to the journal format. "+
-			"The conversion is one-way — the previous release cannot read the share once it completes. "+
-			"Snapshot the share directory before upgrading, and restore that snapshot to go back",
-			"share", config.Name)
 		if metaStore, ok := fileChunkStore.(metadata.Store); ok {
 			report, serr := SeedColdFromManifest(ctx, bs, metaStore)
 			if serr != nil {
@@ -1224,9 +1220,6 @@ func (s *Service) createBlockStoreForShare(
 			// Detached from the AddShare context, which may be cancelled once the
 			// call returns; the store's own close gate stops the drain on shutdown.
 			bgCtx := context.Background()
-			// The whole work list is known up front, so progress is a fraction.
-			// Logged on a timer so a small share prints once and a large one
-			// keeps reporting instead of going silent for minutes.
 			pending := m.LegacyPendingPayloads()
 			started := time.Now()
 			lastLog := started
@@ -3122,10 +3115,7 @@ func applyDurableOverride(store any, config map[string]any, label, shareName str
 func SeedColdFromManifest(ctx context.Context, bs *engine.Store, metaStore metadata.Store) (coldSeedReport, error) {
 	var report coldSeedReport
 	// EnumeratePayloads is a callback iteration with no cheap denominator, so
-	// progress is a running count. It is logged on a timer rather than per
-	// payload: a small share prints the start line and the summary, a large one
-	// keeps reporting instead of leaving the operator unable to tell a slow
-	// startup from a wedged one.
+	// the heartbeat reports a running count rather than a fraction.
 	started := time.Now()
 	lastLog := started
 	logger.Info("seeding cold intervals from the metadata manifest")
@@ -3181,11 +3171,6 @@ func SeedColdFromManifest(ctx context.Context, bs *engine.Store, metaStore metad
 	})
 	return report, err
 }
-
-// migrationProgressInterval is how often a migration loop whose cost scales with
-// the data reports what it has done so far. Long enough that a fast store logs
-// once, short enough that a slow one never looks wedged.
-const migrationProgressInterval = 5 * time.Second
 
 // parseRequireDurableCommit reads the optional per-share "require_durable_commit"
 // bool from the local store config (#1274). Read the same conservative way as

--- a/pkg/metadata/store/badger/encoding.go
+++ b/pkg/metadata/store/badger/encoding.go
@@ -42,6 +42,7 @@ import (
 // Link Counts           "l:"     l:<uuid>                               uint32 (binary)
 // Server Config         "cfg:"   cfg:server                             MetadataServerConfig (JSON)
 // Filesystem Caps       "cap:"   cap:fs                                 FilesystemCapabilities (JSON)
+// Format Version        "fmt:"   fmt:store                              uint32 (big-endian binary)
 
 const (
 	prefixFile         = "f:"
@@ -55,6 +56,7 @@ const (
 	prefixCapabilities = "cap:"
 	prefixObjectID     = "obj:" // ObjectID -> file UUID
 	prefixPayloadID    = "pl:"  // PayloadID (content ID) -> file UUID
+	prefixFormat       = "fmt:" // on-disk format version of this database
 )
 
 // ============================================================================

--- a/pkg/metadata/store/badger/format_version_test.go
+++ b/pkg/metadata/store/badger/format_version_test.go
@@ -1,0 +1,97 @@
+package badger
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	badgerdb "github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+// stampFormatVersion writes fmt:store directly, standing in for the database a
+// different build would have left behind. The store must be closed first —
+// Badger holds a directory lock.
+func stampFormatVersion(t *testing.T, dbPath string, version uint32) {
+	t.Helper()
+	db, err := badgerdb.Open(badgerdb.DefaultOptions(dbPath).WithLogger(nil))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	var buf [4]byte
+	binary.BigEndian.PutUint32(buf[:], version)
+	require.NoError(t, db.Update(func(txn *badgerdb.Txn) error {
+		return txn.Set([]byte(formatVersionKey), buf[:])
+	}))
+}
+
+// readFormatVersion reads fmt:store directly, reporting whether it exists.
+func readFormatVersion(t *testing.T, dbPath string) (uint32, bool) {
+	t.Helper()
+	db, err := badgerdb.Open(badgerdb.DefaultOptions(dbPath).WithLogger(nil))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	var stored uint32
+	var found bool
+	require.NoError(t, db.View(func(txn *badgerdb.Txn) error {
+		item, err := txn.Get([]byte(formatVersionKey))
+		if errors.Is(err, badgerdb.ErrKeyNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		found = true
+		return item.Value(func(v []byte) error {
+			stored = binary.BigEndian.Uint32(v)
+			return nil
+		})
+	}))
+	return stored, found
+}
+
+// TestFormatVersion_UnstampedOpensAndStamps pins that a database written before
+// stamping existed still opens, and comes out of that open guarded.
+func TestFormatVersion_UnstampedOpensAndStamps(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "metadata.db")
+
+	store, err := NewBadgerMetadataStoreWithDefaults(context.Background(), dbPath)
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+
+	stored, found := readFormatVersion(t, dbPath)
+	require.True(t, found, "open must stamp the format version")
+	require.Equal(t, storeFormatVersion, stored)
+}
+
+// TestFormatVersion_CurrentOpens pins that reopening a database this build
+// itself stamped is not mistaken for a future format.
+func TestFormatVersion_CurrentOpens(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "metadata.db")
+
+	store, err := NewBadgerMetadataStoreWithDefaults(context.Background(), dbPath)
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+
+	reopened, err := NewBadgerMetadataStoreWithDefaults(context.Background(), dbPath)
+	require.NoError(t, err)
+	require.NoError(t, reopened.Close())
+}
+
+// TestFormatVersion_FutureRefusesOpen is the downgrade case: a database stamped
+// by a newer release must fail the open with block.ErrFutureFormat rather than
+// serve whatever this build can still decode.
+func TestFormatVersion_FutureRefusesOpen(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "metadata.db")
+	stampFormatVersion(t, dbPath, storeFormatVersion+1)
+
+	store, err := NewBadgerMetadataStoreWithDefaults(context.Background(), dbPath)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, block.ErrFutureFormat), "got %v", err)
+	require.Nil(t, store)
+}

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -359,9 +359,9 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 		return nil, fmt.Errorf("failed to open BadgerDB at %s: %w", config.DBPath, err)
 	}
 
-	// Refuse a database a newer release wrote before anything reads or writes
-	// through it — a format this build does not understand must fail the open,
-	// not surface as missing data once the store is already serving.
+	// Guard the format before anything reads or writes through the database: a
+	// format this build does not understand must fail the open, not surface as
+	// missing data once the store is already serving.
 	if err := ensureFormatVersion(db); err != nil {
 		_ = db.Close()
 		return nil, err
@@ -526,30 +526,23 @@ func (s *BadgerMetadataStore) syncIfRelaxed() error {
 }
 
 // storeFormatVersion is the on-disk format version this build writes and can
-// read. Bump it in any release that changes where existing data lives — moving
-// a field out of a record into a sibling key, renaming a prefix, retiring a
-// key. Those changes are invisible to an older binary: it decodes the record it
-// still recognizes, finds nothing where the moved data used to be, and serves a
-// file with the right size and no content. The stamp is what turns that silent
-// wrong answer into a refusal to open.
+// read. Bump it in any release that moves where existing data lives — a field
+// out of a record into a sibling key, a renamed prefix, a retired key. An older
+// binary decodes the record it still recognizes, finds nothing where the moved
+// data used to be, and serves a file with the right size and no content.
 //
-// Adding a NEW key or a new self-describing record field does not need a bump —
-// an older binary skips what it does not know and loses nothing it had.
+// Adding a NEW key or a new self-describing record field needs no bump — an
+// older binary skips what it does not know and loses nothing it had.
 const storeFormatVersion uint32 = 1
 
 // formatVersionKey is the BadgerDB key holding storeFormatVersion.
 const formatVersionKey = prefixFormat + "store"
 
 // ensureFormatVersion refuses to open a database a newer release wrote, and
-// stamps the current version otherwise.
-//
-// No stamp means the database predates stamping; it is accepted and stamped so
-// every later open is guarded. A stamp above storeFormatVersion means a newer
-// release owns this data and may have put it in keys this build never reads, so
-// the open fails with block.ErrFutureFormat rather than serving whatever is
-// still legible. A stamp below is raised to the current version: this build is
-// about to write records in its own layout, so the database belongs to it from
-// here on and a downgrade past this point is exactly what the guard must catch.
+// stamps the current version otherwise. An unstamped database predates stamping
+// and is adopted, so every later open is guarded; a stamp below the current
+// version is raised, because this build is about to write records in its own
+// layout and a downgrade past that point is what the guard must catch.
 func ensureFormatVersion(db *badger.DB) error {
 	var stored uint32
 	err := db.View(func(txn *badger.Txn) error {
@@ -573,7 +566,7 @@ func ensureFormatVersion(db *badger.DB) error {
 	}
 
 	if stored > storeFormatVersion {
-		return fmt.Errorf("%w: metadata store is format v%d, this build reads up to v%d",
+		return fmt.Errorf("%w: metadata store is at format version %d, this build reads up to %d",
 			block.ErrFutureFormat, stored, storeFormatVersion)
 	}
 	if stored == storeFormatVersion {

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -2,6 +2,7 @@ package badger
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	badger "github.com/dgraph-io/badger/v4"
 	"github.com/oklog/ulid/v2"
 
+	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
 )
@@ -357,6 +359,14 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 		return nil, fmt.Errorf("failed to open BadgerDB at %s: %w", config.DBPath, err)
 	}
 
+	// Refuse a database a newer release wrote before anything reads or writes
+	// through it — a format this build does not understand must fail the open,
+	// not surface as missing data once the store is already serving.
+	if err := ensureFormatVersion(db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+
 	// Bootstrap the engine-persistent store_id before serving requests.
 	// ensureStoreID is idempotent — first open writes a fresh ULID,
 	// subsequent opens read the existing value.
@@ -513,6 +523,71 @@ func (s *BadgerMetadataStore) syncIfRelaxed() error {
 	}
 	s.inlineSyncs.Add(1)
 	return s.db.Sync()
+}
+
+// storeFormatVersion is the on-disk format version this build writes and can
+// read. Bump it in any release that changes where existing data lives — moving
+// a field out of a record into a sibling key, renaming a prefix, retiring a
+// key. Those changes are invisible to an older binary: it decodes the record it
+// still recognizes, finds nothing where the moved data used to be, and serves a
+// file with the right size and no content. The stamp is what turns that silent
+// wrong answer into a refusal to open.
+//
+// Adding a NEW key or a new self-describing record field does not need a bump —
+// an older binary skips what it does not know and loses nothing it had.
+const storeFormatVersion uint32 = 1
+
+// formatVersionKey is the BadgerDB key holding storeFormatVersion.
+const formatVersionKey = prefixFormat + "store"
+
+// ensureFormatVersion refuses to open a database a newer release wrote, and
+// stamps the current version otherwise.
+//
+// No stamp means the database predates stamping; it is accepted and stamped so
+// every later open is guarded. A stamp above storeFormatVersion means a newer
+// release owns this data and may have put it in keys this build never reads, so
+// the open fails with block.ErrFutureFormat rather than serving whatever is
+// still legible. A stamp below is raised to the current version: this build is
+// about to write records in its own layout, so the database belongs to it from
+// here on and a downgrade past this point is exactly what the guard must catch.
+func ensureFormatVersion(db *badger.DB) error {
+	var stored uint32
+	err := db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get([]byte(formatVersionKey))
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		return item.Value(func(v []byte) error {
+			if len(v) != 4 {
+				return fmt.Errorf("malformed value: %d bytes, want 4", len(v))
+			}
+			stored = binary.BigEndian.Uint32(v)
+			return nil
+		})
+	})
+	if err != nil {
+		return fmt.Errorf("read %s: %w", formatVersionKey, err)
+	}
+
+	if stored > storeFormatVersion {
+		return fmt.Errorf("%w: metadata store is format v%d, this build reads up to v%d",
+			block.ErrFutureFormat, stored, storeFormatVersion)
+	}
+	if stored == storeFormatVersion {
+		return nil
+	}
+
+	var buf [4]byte
+	binary.BigEndian.PutUint32(buf[:], storeFormatVersion)
+	if err := db.Update(func(txn *badger.Txn) error {
+		return txn.Set([]byte(formatVersionKey), buf[:])
+	}); err != nil {
+		return fmt.Errorf("write %s: %w", formatVersionKey, err)
+	}
+	return nil
 }
 
 // storeIDKey is the BadgerDB key for the engine-persistent store identifier.

--- a/pkg/metadata/store/postgres/format_version_test.go
+++ b/pkg/metadata/store/postgres/format_version_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata/store/postgres"
+)
+
+// recordFutureMigration records a schema version this build does not ship,
+// standing in for a database a newer release migrated. The row is removed on
+// cleanup — every Postgres test shares one database, so a leftover would make
+// each later open refuse.
+func recordFutureMigration(t *testing.T) {
+	t.Helper()
+	cfg, _ := postgresTestConfig()
+	cfg.ApplyDefaults()
+
+	db, err := sql.Open("pgx", cfg.ConnectionString())
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = db.Exec(`DELETE FROM schema_migrations WHERE version = 999999`)
+		_ = db.Close()
+	})
+
+	if _, err := db.Exec(
+		`INSERT INTO schema_migrations (version, dirty) VALUES (999999, false)`,
+	); err != nil {
+		t.Fatalf("insert future version: %v", err)
+	}
+}
+
+// TestFormatVersion_CurrentSchemaOpens pins that a database at the version this
+// build migrated it to opens without tripping the guard.
+func TestFormatVersion_CurrentSchemaOpens(t *testing.T) {
+	store := newPostgresStore(t)
+	if store == nil {
+		t.Fatal("store must open at the current schema version")
+	}
+}
+
+// TestFormatVersion_FutureSchemaRefusesOpen is the downgrade case, asserted on
+// both AutoMigrate settings. The guard is a safety check rather than a
+// migration, so the default (AutoMigrate off) configuration — which otherwise
+// inspects the schema not at all — must refuse just as loudly.
+func TestFormatVersion_FutureSchemaRefusesOpen(t *testing.T) {
+	// Ensure the schema (and schema_migrations) exists before recording into it.
+	newPostgresStore(t)
+
+	for _, autoMigrate := range []bool{true, false} {
+		name := "auto_migrate_off"
+		if autoMigrate {
+			name = "auto_migrate_on"
+		}
+		t.Run(name, func(t *testing.T) {
+			recordFutureMigration(t)
+
+			cfg, caps := postgresTestConfig()
+			cfg.AutoMigrate = autoMigrate
+			store, err := postgres.NewPostgresMetadataStore(context.Background(), cfg, caps)
+			if err == nil {
+				store.Close()
+				t.Fatal("opening a future schema must fail")
+			}
+			if !errors.Is(err, block.ErrFutureFormat) {
+				t.Fatalf("error must wrap block.ErrFutureFormat; got %v", err)
+			}
+		})
+	}
+}

--- a/pkg/metadata/store/postgres/migrate.go
+++ b/pkg/metadata/store/postgres/migrate.go
@@ -130,14 +130,14 @@ func newestEmbeddedVersion() (int64, error) {
 // checkFormatVersion refuses to open a database migrated past what this build
 // knows how to run against.
 //
-// golang-migrate does surface this today, but only by accident and only
-// halfway: m.Up() fails with "file does not exist" because the recorded version
-// has no counterpart in the embedded source, and that only happens when
-// AutoMigrate is on — which it is not by default. The default configuration
-// therefore inspects nothing, opens a future schema happily, and then fails
-// query by query with raw SQL errors about columns a later migration dropped or
-// renamed. Reading the recorded version directly makes the failure explicit,
-// immediate, and independent of whether migrations are configured to run.
+// schema_migrations already records every applied version, so the newest
+// applied row versus the newest embedded migration is the whole comparison — no
+// second stamp is needed. A row above that ceiling means a newer release
+// migrated this database and may have dropped or renamed columns this build's
+// queries still name. golang-migrate only surfaces that halfway — m.Up() fails
+// with "file does not exist", and only when AutoMigrate is on, which it is not
+// by default — so the database otherwise opens cleanly and then fails query by
+// query with raw SQL errors, long after startup.
 func checkFormatVersion(ctx context.Context, pool *pgxpool.Pool) error {
 	var exists bool
 	if err := pool.QueryRow(ctx,
@@ -168,7 +168,7 @@ func checkFormatVersion(ctx context.Context, pool *pgxpool.Pool) error {
 	}
 
 	if *stored > newest {
-		return fmt.Errorf("%w: metadata database is at schema version %d, this build knows up to version %d",
+		return fmt.Errorf("%w: metadata database is at schema version %d, this build reads up to %d",
 			block.ErrFutureFormat, *stored, newest)
 	}
 	return nil

--- a/pkg/metadata/store/postgres/migrate.go
+++ b/pkg/metadata/store/postgres/migrate.go
@@ -5,13 +5,17 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"strconv"
+	"strings"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib" // PostgreSQL driver for database/sql
 
 	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata/store/postgres/migrations"
 )
 
@@ -92,6 +96,81 @@ func runMigrations(ctx context.Context, connString string, logger *slog.Logger) 
 		}
 	}
 
+	return nil
+}
+
+// newestEmbeddedVersion returns the highest version among the embedded
+// `NNNNNN_*.up.sql` migrations — the newest schema this build ships.
+func newestEmbeddedVersion() (int64, error) {
+	entries, err := migrations.FS.ReadDir(".")
+	if err != nil {
+		return 0, fmt.Errorf("read migrations dir: %w", err)
+	}
+	var newest int64
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".up.sql") {
+			continue
+		}
+		idx := strings.IndexByte(name, '_')
+		if idx <= 0 {
+			continue
+		}
+		v, perr := strconv.ParseInt(name[:idx], 10, 64)
+		if perr != nil {
+			continue
+		}
+		if v > newest {
+			newest = v
+		}
+	}
+	return newest, nil
+}
+
+// checkFormatVersion refuses to open a database migrated past what this build
+// knows how to run against.
+//
+// golang-migrate does surface this today, but only by accident and only
+// halfway: m.Up() fails with "file does not exist" because the recorded version
+// has no counterpart in the embedded source, and that only happens when
+// AutoMigrate is on — which it is not by default. The default configuration
+// therefore inspects nothing, opens a future schema happily, and then fails
+// query by query with raw SQL errors about columns a later migration dropped or
+// renamed. Reading the recorded version directly makes the failure explicit,
+// immediate, and independent of whether migrations are configured to run.
+func checkFormatVersion(ctx context.Context, pool *pgxpool.Pool) error {
+	var exists bool
+	if err := pool.QueryRow(ctx,
+		`SELECT to_regclass('schema_migrations') IS NOT NULL`,
+	).Scan(&exists); err != nil {
+		return fmt.Errorf("probe schema_migrations: %w", err)
+	}
+	if !exists {
+		// A database no migration has ever touched; golang-migrate creates the
+		// table and brings it to the embedded ceiling.
+		return nil
+	}
+
+	var stored *int64
+	if err := pool.QueryRow(ctx, `SELECT MAX(version) FROM schema_migrations`).Scan(&stored); err != nil {
+		return fmt.Errorf("read schema_migrations: %w", err)
+	}
+	if stored == nil {
+		return nil
+	}
+
+	newest, err := newestEmbeddedVersion()
+	if err != nil {
+		return err
+	}
+	if newest == 0 {
+		return nil
+	}
+
+	if *stored > newest {
+		return fmt.Errorf("%w: metadata database is at schema version %d, this build knows up to version %d",
+			block.ErrFutureFormat, *stored, newest)
+	}
 	return nil
 }
 

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -105,6 +105,13 @@ func NewPostgresMetadataStore(
 		return nil, fmt.Errorf("failed to create connection pool: %w", err)
 	}
 
+	// Guard the schema before anything queries it. This is not a migration, so
+	// it runs whether or not AutoMigrate is set.
+	if err := checkFormatVersion(ctx, pool); err != nil {
+		pool.Close()
+		return nil, err
+	}
+
 	// Run migrations if AutoMigrate is enabled
 	if cfg.AutoMigrate {
 		log.Info("AutoMigrate is enabled, running migrations...")

--- a/pkg/metadata/store/sqlite/format_version_test.go
+++ b/pkg/metadata/store/sqlite/format_version_test.go
@@ -1,0 +1,94 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
+)
+
+// migratedDBPath creates a database at the current schema and returns its path.
+func migratedDBPath(t *testing.T) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "format.db")
+	cfg := &sqlite.SQLiteMetadataStoreConfig{Path: dbPath, AutoMigrate: true}
+	store, err := sqlite.NewSQLiteMetadataStore(context.Background(), cfg, sqliteTestCapabilities())
+	if err != nil {
+		t.Fatalf("NewSQLiteMetadataStore() failed: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close() failed: %v", err)
+	}
+	return dbPath
+}
+
+// recordFutureMigration records a schema version this build does not ship,
+// standing in for a database a newer release migrated.
+func recordFutureMigration(t *testing.T, dbPath string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec(`INSERT INTO schema_migrations (version) VALUES (999999)`); err != nil {
+		t.Fatalf("insert future version: %v", err)
+	}
+}
+
+// TestFormatVersion_CurrentSchemaOpens pins that a database at the version this
+// build migrated it to reopens without tripping the guard.
+func TestFormatVersion_CurrentSchemaOpens(t *testing.T) {
+	dbPath := migratedDBPath(t)
+
+	cfg := &sqlite.SQLiteMetadataStoreConfig{Path: dbPath, AutoMigrate: true}
+	store, err := sqlite.NewSQLiteMetadataStore(context.Background(), cfg, sqliteTestCapabilities())
+	if err != nil {
+		t.Fatalf("reopen at current schema version: %v", err)
+	}
+	_ = store.Close()
+}
+
+// TestFormatVersion_FutureSchemaRefusesOpen is the downgrade case, asserted on
+// both AutoMigrate settings. The guard is a safety check rather than a
+// migration, so the default (AutoMigrate off) configuration — which otherwise
+// inspects the schema not at all — must refuse just as loudly.
+func TestFormatVersion_FutureSchemaRefusesOpen(t *testing.T) {
+	for _, autoMigrate := range []bool{true, false} {
+		name := "auto_migrate_off"
+		if autoMigrate {
+			name = "auto_migrate_on"
+		}
+		t.Run(name, func(t *testing.T) {
+			dbPath := migratedDBPath(t)
+			recordFutureMigration(t, dbPath)
+
+			cfg := &sqlite.SQLiteMetadataStoreConfig{Path: dbPath, AutoMigrate: autoMigrate}
+			store, err := sqlite.NewSQLiteMetadataStore(context.Background(), cfg, sqliteTestCapabilities())
+			if err == nil {
+				_ = store.Close()
+				t.Fatal("opening a future schema must fail")
+			}
+			if !errors.Is(err, block.ErrFutureFormat) {
+				t.Fatalf("error must wrap block.ErrFutureFormat; got %v", err)
+			}
+		})
+	}
+}
+
+// TestFormatVersion_FutureSchemaRefusesMigration pins that the manual migration
+// entrypoint refuses too, instead of reporting the database as up to date.
+func TestFormatVersion_FutureSchemaRefusesMigration(t *testing.T) {
+	dbPath := migratedDBPath(t)
+	recordFutureMigration(t, dbPath)
+
+	cfg := &sqlite.SQLiteMetadataStoreConfig{Path: dbPath}
+	err := sqlite.RunMigrations(context.Background(), cfg)
+	if !errors.Is(err, block.ErrFutureFormat) {
+		t.Fatalf("error must wrap block.ErrFutureFormat; got %v", err)
+	}
+}

--- a/pkg/metadata/store/sqlite/migrate.go
+++ b/pkg/metadata/store/sqlite/migrate.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite/migrations"
 )
 
@@ -25,6 +26,13 @@ import (
 // registration while keeping the migrations file-based and versioned.
 func runMigrations(ctx context.Context, db *sql.DB, log *slog.Logger) error {
 	log.Info("Running database migrations...")
+
+	// Migrating a database that is already ahead of this build is not a no-op
+	// worth reporting as "up to date" — refuse it here too, so the manual
+	// migrate path fails as loudly as the open path.
+	if err := checkFormatVersion(ctx, db); err != nil {
+		return err
+	}
 
 	if _, err := db.ExecContext(ctx,
 		`CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER PRIMARY KEY)`,
@@ -61,6 +69,57 @@ func runMigrations(ctx context.Context, db *sql.DB, log *slog.Logger) error {
 		log.Info("No migrations to apply (database is up to date)")
 	} else {
 		log.Info("Migrations completed successfully", "applied", count)
+	}
+	return nil
+}
+
+// checkFormatVersion refuses to open a database migrated past what this build
+// knows how to run against.
+//
+// schema_migrations already records every applied version, so the newest
+// applied row versus the newest embedded migration is the whole comparison — no
+// second stamp is needed. A row above the embedded ceiling means a newer
+// release migrated this database, and its migrations may have dropped or
+// renamed columns this build's queries still name.
+//
+// Without the check that database opens cleanly (runMigrations has nothing to
+// apply, so it reports "up to date") and then fails query by query with raw SQL
+// errors, long after startup. This is a safety check rather than a migration,
+// so it runs on every open regardless of AutoMigrate — the default-off
+// configuration is precisely the one that otherwise inspects nothing at all.
+func checkFormatVersion(ctx context.Context, db *sql.DB) error {
+	var tables int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'schema_migrations'`,
+	).Scan(&tables); err != nil {
+		return fmt.Errorf("probe schema_migrations: %w", err)
+	}
+	if tables == 0 {
+		// A database no migration has ever touched; runMigrations creates the
+		// table and brings it to the embedded ceiling.
+		return nil
+	}
+
+	var stored sql.NullInt64
+	if err := db.QueryRowContext(ctx, `SELECT MAX(version) FROM schema_migrations`).Scan(&stored); err != nil {
+		return fmt.Errorf("read schema_migrations: %w", err)
+	}
+	if !stored.Valid {
+		return nil
+	}
+
+	files, err := upMigrationFiles()
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		return nil
+	}
+	newest := files[len(files)-1].version
+
+	if stored.Int64 > int64(newest) {
+		return fmt.Errorf("%w: metadata database is at schema version %d, this build knows up to version %d",
+			block.ErrFutureFormat, stored.Int64, newest)
 	}
 	return nil
 }

--- a/pkg/metadata/store/sqlite/migrate.go
+++ b/pkg/metadata/store/sqlite/migrate.go
@@ -78,15 +78,11 @@ func runMigrations(ctx context.Context, db *sql.DB, log *slog.Logger) error {
 //
 // schema_migrations already records every applied version, so the newest
 // applied row versus the newest embedded migration is the whole comparison — no
-// second stamp is needed. A row above the embedded ceiling means a newer
-// release migrated this database, and its migrations may have dropped or
-// renamed columns this build's queries still name.
-//
-// Without the check that database opens cleanly (runMigrations has nothing to
-// apply, so it reports "up to date") and then fails query by query with raw SQL
-// errors, long after startup. This is a safety check rather than a migration,
-// so it runs on every open regardless of AutoMigrate — the default-off
-// configuration is precisely the one that otherwise inspects nothing at all.
+// second stamp is needed. A row above that ceiling means a newer release
+// migrated this database and may have dropped or renamed columns this build's
+// queries still name. Without the check the database opens cleanly (there is
+// nothing to apply, so migration reports "up to date") and then fails query by
+// query with raw SQL errors, long after startup.
 func checkFormatVersion(ctx context.Context, db *sql.DB) error {
 	var tables int
 	if err := db.QueryRowContext(ctx,
@@ -118,7 +114,7 @@ func checkFormatVersion(ctx context.Context, db *sql.DB) error {
 	newest := files[len(files)-1].version
 
 	if stored.Int64 > int64(newest) {
-		return fmt.Errorf("%w: metadata database is at schema version %d, this build knows up to version %d",
+		return fmt.Errorf("%w: metadata database is at schema version %d, this build reads up to %d",
 			block.ErrFutureFormat, stored.Int64, newest)
 	}
 	return nil

--- a/pkg/metadata/store/sqlite/store.go
+++ b/pkg/metadata/store/sqlite/store.go
@@ -120,6 +120,13 @@ func NewSQLiteMetadataStore(
 		return nil, fmt.Errorf("failed to ping sqlite database: %w", err)
 	}
 
+	// Guard the schema before anything queries it. This is not a migration, so
+	// it runs whether or not AutoMigrate is set.
+	if err := checkFormatVersion(ctx, db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+
 	if cfg.AutoMigrate {
 		log.Info("AutoMigrate is enabled, running migrations...")
 		if err := runMigrations(ctx, db, log); err != nil {


### PR DESCRIPTION
Closes #1864. Theme 2 of #1843 — upgrade safety and reversibility.

## What prompted this

A field deployment reported that upgrading a data-bearing box was risky: the migration ran on the startup path and looked like a hang on a large store, and after rolling back to the prior binary the share was unreadable. They recovered via snapshots and a disable→enable dance on a live box.

## What I verified in the code

Two defects, both confirmed by grep rather than inference:

1. **The exit-78 boot guard was dead code.** `block.ErrLegacyLayoutDetected` had zero producers — `.cas-migrated` appears nowhere in Go source since the `.blk` migration tool was removed.
2. **The guard that does fire warn-and-continues.** `fs.ErrLegacyLocalFormat` is a different sentinel, so `handleLoadSharesError` fell through to `logger.Warn("Failed to load some shares")` and the daemon booted anyway — healthy-looking, with the share silently absent.

And the gap behind the report: **no on-disk format-version marker gates live store open anywhere.** The `*SchemaVersion` constants in each backend gate backup payload streams only, never `Open`. Formats have moved without a version bump — the badger `fm:` manifest split and the journal `cold.log` both landed with no marker, and `fileVersion` stayed `0x01` across the former.

## What I could NOT reproduce

On a fresh Scaleway VM I ran two rollbacks end to end:

- local-only badger share, v0.28.1 → v0.29.1 → v0.28.1, with files written under each release
- remote-backed share with a small local cache, 300 MiB written and drained to S3, local tier evicted to 104K, v0.29.1 → v0.29.0

**Both read every file back with matching SHA-256.** A local-only share resolves chunks from the journal's own per-payload index, so the metadata manifest is not on that read path; and the evicted remote-backed share still resolved through the manifest. I could not produce the silent-zeros rollback, so this PR does not claim to fix the reporter's exact failure — their jump crossed the pre-journal migration, which is a larger step than either tested here.

What this PR does fix is the class: the two verified defects above, plus the missing contract that let both format changes ship unguarded.

## The change

- **Format stamp per store.** Local journal keeps a `format` file beside `cold.log`; badger uses an `fmt:store` key; sqlite and postgres need no new state — they compare the highest applied `schema_migrations` version against the newest migration the binary embeds. That check now runs **unconditionally**, not only when `AutoMigrate` is set, since it defaults off and left the schema uninspected.
- **Refuse and stop.** State newer than the build wraps `block.ErrFutureFormat`; boot exits 78 with a directive naming both versions and the two recovery paths. `ErrLegacyLocalFormat` now takes the same hard exit.
- **Pre-flight warning** before a one-way migration — what changes, that the previous release cannot read the result, snapshot first. No ack flag: an unattended `apt upgrade && systemctl restart` must not strand a box.
- **Progress heartbeat** (5s) in the three migration loops whose cost scales with stored data. Deliberately no job/REST/`--watch` surface: these run before the API binds, so logs are the only channel that exists when it matters.

## Scope note

The guard is forward-looking. Already-released binaries cannot be made to refuse, so this makes rollbacks safe from the next release onward; for the current generation the levers are the pre-flight warning and the documented snapshot step.

## Verification

`go build ./...`, `go vet ./...`, and `go test ./pkg/... ./cmd/...` all clean. New tests per backend: state stamped one version above the build refuses with `errors.Is(err, block.ErrFutureFormat)`; at or below opens; unstamped opens and gets stamped. sqlite and postgres assert the refusal with `AutoMigrate` both on and off.