### PR TITLE
fix(metadata): reseed quota cache on memory Reset and RestoreSnapshot

### DIFF
--- a/pkg/metadata/store/badger/reset.go
+++ b/pkg/metadata/store/badger/reset.go
@@ -21,6 +21,6 @@ func (s *BadgerMetadataStore) Reset(ctx context.Context) error {
 	if err := s.db.DropAll(); err != nil {
 		return fmt.Errorf("badger reset: drop all: %w", err)
 	}
-	s.ResetUsage()
+	s.base.ResetUsage()
 	return nil
 }

--- a/pkg/metadata/store/badger/reset.go
+++ b/pkg/metadata/store/badger/reset.go
@@ -21,5 +21,6 @@ func (s *BadgerMetadataStore) Reset(ctx context.Context) error {
 	if err := s.db.DropAll(); err != nil {
 		return fmt.Errorf("badger reset: drop all: %w", err)
 	}
+	s.ResetUsage()
 	return nil
 }

--- a/pkg/metadata/store/badger/server.go
+++ b/pkg/metadata/store/badger/server.go
@@ -152,7 +152,7 @@ func (s *BadgerMetadataStore) GetFilesystemStatistics(ctx context.Context, handl
 	}
 
 	// Read usage from atomic counter (O(1), always fresh).
-	usedSize := uint64(s.usedBytes.Load())
+	usedSize := uint64(s.GetUsedBytes())
 
 	// For file count, check cache first.
 	s.statsCache.mu.RLock()

--- a/pkg/metadata/store/badger/server.go
+++ b/pkg/metadata/store/badger/server.go
@@ -152,7 +152,7 @@ func (s *BadgerMetadataStore) GetFilesystemStatistics(ctx context.Context, handl
 	}
 
 	// Read usage from atomic counter (O(1), always fresh).
-	usedSize := uint64(s.GetUsedBytes())
+	usedSize := uint64(s.base.GetUsedBytes())
 
 	// For file count, check cache first.
 	s.statsCache.mu.RLock()

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -213,9 +213,9 @@ func (s *BadgerMetadataStore) DeleteShare(ctx context.Context, shareName string)
 	s.shareCache.invalidate(shareName)
 	// Apply the usedBytes decrement once, after a successful commit.
 	if freedBytes > 0 {
-		s.AddUsedBytes(-freedBytes)
+		s.base.AddUsedBytes(-freedBytes)
 	}
-	s.ApplyQuotaDelta(quotaFreed)
+	s.base.ApplyQuotaDelta(quotaFreed)
 	return nil
 }
 

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -213,22 +213,10 @@ func (s *BadgerMetadataStore) DeleteShare(ctx context.Context, shareName string)
 	s.shareCache.invalidate(shareName)
 	// Apply the usedBytes decrement once, after a successful commit.
 	if freedBytes > 0 {
-		s.usedBytes.Add(-freedBytes)
+		s.AddUsedBytes(-freedBytes)
 	}
-	s.applyQuotaDelta(quotaFreed)
+	s.ApplyQuotaDelta(quotaFreed)
 	return nil
-}
-
-// applyQuotaDelta folds a per-identity usage delta into the in-memory usage
-// cache. Called post-commit (matching usedBytes). Buckets that drop to zero or
-// below are removed.
-func (s *BadgerMetadataStore) applyQuotaDelta(delta map[quota.Key]metadata.UsageStat) {
-	if len(delta) == 0 {
-		return
-	}
-	s.quotaMu.Lock()
-	defer s.quotaMu.Unlock()
-	s.quota.Apply(delta)
 }
 
 // deleteShareFiles removes every file inode and its dependent keys (parent,

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -147,7 +147,7 @@ type BadgerMetadataStore struct {
 
 	// baseStore embeds the shared usage accounting state for regular files.
 	// This includes total logical bytes used and per-identity usage for quota
-	*basestore.Base
+	base *basestore.Base
 
 	// storeID is the engine-persistent identifier for this store instance,
 	// backed by the cfg:store_id key in BadgerDB. Created on first open of
@@ -375,7 +375,7 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 		storeID:           sid,
 		relaxedDurability: config.RelaxedDurability,
 		syncStop:          make(chan struct{}),
-		Base:              basestore.NewBaseStore(),
+		base:              basestore.NewBaseStore(),
 	}
 
 	// Initialize stats cache with a 5-second TTL for responsive updates
@@ -611,6 +611,12 @@ func ensureStoreID(db *badger.DB) (string, error) {
 	return fresh, nil
 }
 
+// GetUsedBytes returns the current total logical bytes used by regular files.
+// This is an O(1) atomic read, safe for concurrent access without locks.
+func (s *BadgerMetadataStore) GetUsedBytes() int64 {
+	return s.base.GetUsedBytes()
+}
+
 // initUsedBytesCounter scans all file entries once at startup to initialize the
 // store-wide atomic counter and the per-identity usage cache (userUsage /
 // groupUsage). Both are reconstructed from the durable file rows, so a store
@@ -663,10 +669,16 @@ func (s *BadgerMetadataStore) initUsedBytesCounter() error {
 		return err
 	}
 
-	s.SetUsedBytes(totalUsed)
-	s.Seed(userUsage, groupUsage)
+	s.base.SetUsedBytes(totalUsed)
+	s.base.Seed(userUsage, groupUsage)
 
 	return nil
+}
+
+// GetQuotaUsage returns per-identity usage for the given scope and id.
+// O(1) cache read under quotaMu. A missing key returns a zero UsageStat.
+func (s *BadgerMetadataStore) GetQuotaUsage(scope metadata.QuotaScope, id uint32) (metadata.UsageStat, error) {
+	return s.base.GetQuotaUsage(scope, id)
 }
 
 // NewBadgerMetadataStoreWithDefaults creates a new BadgerDB metadata store with sensible defaults.

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/basestore"
 )
 
 // BadgerMetadataStore implements metadata.Store using BadgerDB for persistence.
@@ -145,19 +145,9 @@ type BadgerMetadataStore struct {
 	recoveryStore   *badgerRecoveryStore
 	recoveryStoreMu sync.Mutex
 
-	// usedBytes tracks the total logical bytes used by regular files.
-	// Updated atomically on every size-changing operation (create, update, truncate, delete).
-	// Initialized from a full file scan on startup.
-	usedBytes atomic.Int64
-
-	// quota tracks per-identity usage (bytes + file count) for regular files,
-	// keyed by owner uid / gid. In-memory cache mirroring usedBytes, seeded from
-	// a full file scan on startup (so it is always reconstructed from the durable
-	// file rows — back-compatible with existing dumps). Updated from a
-	// transaction's pending per-identity deltas exactly once on successful
-	// commit. Guarded by quotaMu.
-	quotaMu sync.Mutex
-	quota   *quota.Cache
+	// baseStore embeds the shared usage accounting state for regular files.
+	// This includes total logical bytes used and per-identity usage for quota
+	*basestore.Base
 
 	// storeID is the engine-persistent identifier for this store instance,
 	// backed by the cfg:store_id key in BadgerDB. Created on first open of
@@ -385,7 +375,7 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 		storeID:           sid,
 		relaxedDurability: config.RelaxedDurability,
 		syncStop:          make(chan struct{}),
-		quota:             quota.NewCache(),
+		Base:              basestore.NewBaseStore(),
 	}
 
 	// Initialize stats cache with a 5-second TTL for responsive updates
@@ -621,12 +611,6 @@ func ensureStoreID(db *badger.DB) (string, error) {
 	return fresh, nil
 }
 
-// GetUsedBytes returns the current total logical bytes used by regular files.
-// This is an O(1) atomic read, safe for concurrent access without locks.
-func (s *BadgerMetadataStore) GetUsedBytes() int64 {
-	return s.usedBytes.Load()
-}
-
 // initUsedBytesCounter scans all file entries once at startup to initialize the
 // store-wide atomic counter and the per-identity usage cache (userUsage /
 // groupUsage). Both are reconstructed from the durable file rows, so a store
@@ -679,19 +663,10 @@ func (s *BadgerMetadataStore) initUsedBytesCounter() error {
 		return err
 	}
 
-	s.usedBytes.Store(totalUsed)
-	s.quotaMu.Lock()
-	s.quota.Seed(userUsage, groupUsage)
-	s.quotaMu.Unlock()
-	return nil
-}
+	s.SetUsedBytes(totalUsed)
+	s.Seed(userUsage, groupUsage)
 
-// GetQuotaUsage returns per-identity usage for the given scope and id.
-// O(1) cache read under quotaMu. A missing key returns a zero UsageStat.
-func (s *BadgerMetadataStore) GetQuotaUsage(scope metadata.QuotaScope, id uint32) (metadata.UsageStat, error) {
-	s.quotaMu.Lock()
-	defer s.quotaMu.Unlock()
-	return s.quota.Get(scope, id), nil
+	return nil
 }
 
 // NewBadgerMetadataStoreWithDefaults creates a new BadgerDB metadata store with sensible defaults.

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -140,10 +140,10 @@ func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx me
 		if err == nil {
 			// Apply the accumulated usedBytes delta exactly once, after commit.
 			if pendingDelta != 0 {
-				s.usedBytes.Add(pendingDelta)
+				s.AddUsedBytes(pendingDelta)
 			}
 			// Apply per-identity usage deltas once, after commit.
-			s.applyQuotaDelta(quotaDelta)
+			s.ApplyQuotaDelta(quotaDelta)
 			// Apply the staged filesystem-capabilities update once, after commit,
 			// so a persist that never committed can't leave the in-memory copy
 			// (read by GetFilesystemMeta) ahead of durable storage.

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -140,10 +140,10 @@ func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx me
 		if err == nil {
 			// Apply the accumulated usedBytes delta exactly once, after commit.
 			if pendingDelta != 0 {
-				s.AddUsedBytes(pendingDelta)
+				s.base.AddUsedBytes(pendingDelta)
 			}
 			// Apply per-identity usage deltas once, after commit.
-			s.ApplyQuotaDelta(quotaDelta)
+			s.base.ApplyQuotaDelta(quotaDelta)
 			// Apply the staged filesystem-capabilities update once, after commit,
 			// so a persist that never committed can't leave the in-memory copy
 			// (read by GetFilesystemMeta) ahead of durable storage.

--- a/pkg/metadata/store/internal/basestore/base.go
+++ b/pkg/metadata/store/internal/basestore/base.go
@@ -36,27 +36,27 @@ func NewBaseStore() *Base {
 
 // GetUsedBytes returns the current total logical bytes used by regular files.
 // This is an O(1) atomic read, safe for concurrent access without locks.
-func (s *Base) GetUsedBytes() int64 {
-	return s.usedBytes.Load()
+func (b *Base) GetUsedBytes() int64 {
+	return b.usedBytes.Load()
 }
 
 // GetQuotaUsage returns per-identity usage for the given scope and id.
 // O(1) map read under quotaMu. A missing key returns a zero UsageStat.
-func (s *Base) GetQuotaUsage(scope metadata.QuotaScope, id uint32) (metadata.UsageStat, error) {
-	s.quotaMu.Lock()
-	defer s.quotaMu.Unlock()
-	return s.quota.Get(scope, id), nil
+func (b *Base) GetQuotaUsage(scope metadata.QuotaScope, id uint32) (metadata.UsageStat, error) {
+	b.quotaMu.Lock()
+	defer b.quotaMu.Unlock()
+	return b.quota.Get(scope, id), nil
 }
 
 // ApplyQuotaDelta folds a per-identity usage delta into the in-memory usage
 // cache. Called post-commit (matching usedBytes).
-func (s *Base) ApplyQuotaDelta(delta map[quota.Key]metadata.UsageStat) {
+func (b *Base) ApplyQuotaDelta(delta map[quota.Key]metadata.UsageStat) {
 	if len(delta) == 0 {
 		return
 	}
-	s.quotaMu.Lock()
-	defer s.quotaMu.Unlock()
-	s.quota.Apply(delta)
+	b.quotaMu.Lock()
+	defer b.quotaMu.Unlock()
+	b.quota.Apply(delta)
 }
 
 // AddUsedBytes atomically adds delta (positive or negative) to the used-bytes

--- a/pkg/metadata/store/internal/basestore/base.go
+++ b/pkg/metadata/store/internal/basestore/base.go
@@ -1,0 +1,95 @@
+package basestore
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
+)
+
+// Base holds the usage accounting state shared byte-for-byte across all
+// metadata store backends. The total logical bytes used by regular files, and
+// per-identity (uid/gid) usage for quota enforcement. Each backend
+// embeds Base and is responsible for seeding it at the startup. The seeding
+// mechanism differs per backend (SQL SUM + GROUP BY, KV full scan, or none)
+// and stays outside this type
+type Base struct {
+	// usedBytes tracks the total logical bytes used by regular files. Updated
+	// atomically on every size-changing operation.
+	usedBytes atomic.Int64
+
+	// quota tracks per-identity usage (bytes + file count) for regular files,
+	// keyed by owner uid / gid. Updated from each comitted transaction's deltas
+	// Guarded by quotaMu.
+	quotaMu sync.Mutex
+	quota   *quota.Cache
+}
+
+// NewBaseStore returns a zero usage Base ready to be embedded. Backends still
+// seed it from their own durable state at startup.
+func NewBaseStore() *Base {
+	return &Base{
+		quota: quota.NewCache(),
+	}
+}
+
+// GetUsedBytes returns the current total logical bytes used by regular files.
+// This is an O(1) atomic read, safe for concurrent access without locks.
+func (s *Base) GetUsedBytes() int64 {
+	return s.usedBytes.Load()
+}
+
+// GetQuotaUsage returns per-identity usage for the given scope and id.
+// O(1) map read under quotaMu. A missing key returns a zero UsageStat.
+func (s *Base) GetQuotaUsage(scope metadata.QuotaScope, id uint32) (metadata.UsageStat, error) {
+	s.quotaMu.Lock()
+	defer s.quotaMu.Unlock()
+	return s.quota.Get(scope, id), nil
+}
+
+// ApplyQuotaDelta folds a per-identity usage delta into the in-memory usage
+// cache. Called post-commit (matching usedBytes).
+func (s *Base) ApplyQuotaDelta(delta map[quota.Key]metadata.UsageStat) {
+	if len(delta) == 0 {
+		return
+	}
+	s.quotaMu.Lock()
+	defer s.quotaMu.Unlock()
+	s.quota.Apply(delta)
+}
+
+// AddUsedBytes atomically adds delta (positive or negative) to the used-bytes
+// counter. Called post-commit with a transaction's accumulated size delta.
+func (b *Base) AddUsedBytes(delta int64) {
+	if delta != 0 {
+		b.usedBytes.Add(delta)
+	}
+}
+
+// SetUsedBytes atomically overwrites the used-bytes counter. For backends
+// that recompute the total from durable state (startup seeding, snapshot
+// restore) instead of accumulating deltas.
+func (b *Base) SetUsedBytes(n int64) {
+	b.usedBytes.Store(n)
+}
+
+// ResetUsage clears both the used-bytes counter and the per-identity quota
+// cache. Named to avoid colliding with each backend's own Reset(ctx) (part
+// of metadata.Resetable) a same name method on Base would be shadowed
+// entirely by the backend's Reset, not merged with it.
+func (b *Base) ResetUsage() {
+	b.usedBytes.Store(0)
+	b.quotaMu.Lock()
+	b.quota.Reset()
+	b.quotaMu.Unlock()
+}
+
+// Seed replaces the quota cache with per-identity usage pre-aggregated from
+// durable state. Does not touch usedBytes callers seeding both should also
+// call SetUsedBytes.
+func (b *Base) Seed(user, group map[uint32]*metadata.UsageStat) {
+	b.quotaMu.Lock()
+	defer b.quotaMu.Unlock()
+	b.quota.Seed(user, group)
+}

--- a/pkg/metadata/store/internal/basestore/base_test.go
+++ b/pkg/metadata/store/internal/basestore/base_test.go
@@ -1,0 +1,87 @@
+package basestore_test
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/basestore"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
+)
+
+func TestBaseStore(t *testing.T) {
+	// Create a new BaseStore instance
+	store := basestore.NewBaseStore()
+
+	// Test SetUsedBytes and GetUsedBytes
+	store.SetUsedBytes(100)
+	if store.GetUsedBytes() != 100 {
+		t.Errorf("Expected used bytes to be 100, got %d", store.GetUsedBytes())
+	}
+
+	// Test AddUsedBytes
+	store.AddUsedBytes(50)
+	if store.GetUsedBytes() != 150 {
+		t.Errorf("Expected used bytes to be 150, got %d", store.GetUsedBytes())
+	}
+
+	// Test ResetUsage
+	store.ResetUsage()
+	if store.GetUsedBytes() != 0 {
+		t.Errorf("Expected used bytes to be 0 after reset, got %d", store.GetUsedBytes())
+	}
+
+	// Test Negative values
+	store.SetUsedBytes(-50)
+	if store.GetUsedBytes() != -50 {
+		t.Errorf("Expected used bytes to be -50, got %d", store.GetUsedBytes())
+	}
+
+	store.AddUsedBytes(-200)
+	if store.GetUsedBytes() != -250 {
+		t.Errorf("Expected used bytes to be -250, got %d", store.GetUsedBytes())
+	}
+
+	// Test Adding Zero value
+	store.AddUsedBytes(0)
+	if store.GetUsedBytes() != -250 {
+		t.Errorf("Expected used bytes to remain -250 after adding 0, got %d", store.GetUsedBytes())
+	}
+}
+
+func TestQuotaUsage(t *testing.T) {
+	// Create a new BaseStore instance
+	store := basestore.NewBaseStore()
+
+	// Test GetQuotaUsage for a non-existent key
+	usage, err := store.GetQuotaUsage(0, 1)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if usage.Bytes != 0 || usage.Files != 0 {
+		t.Errorf("Expected zero usage for non-existent key, got %+v", usage)
+	}
+
+	// Test ApplyQuotaDelta and GetQuotaUsage
+	delta := map[quota.Key]metadata.UsageStat{
+		{Scope: metadata.QuotaScopeUser, ID: 1}: {Bytes: 100, Files: 2},
+	}
+	store.ApplyQuotaDelta(delta)
+
+	usage, err = store.GetQuotaUsage(0, 1)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if usage.Bytes != 100 || usage.Files != 2 {
+		t.Errorf("Expected usage to be updated, got %+v", usage)
+	}
+
+	// Test ResetUsage clears the quota
+	store.ResetUsage()
+	usage, err = store.GetQuotaUsage(0, 1)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if usage.Bytes != 0 || usage.Files != 0 {
+		t.Errorf("Expected zero usage after reset, got %+v", usage)
+	}
+}

--- a/pkg/metadata/store/memory/reset.go
+++ b/pkg/metadata/store/memory/reset.go
@@ -42,11 +42,7 @@ func (s *MemoryMetadataStore) Reset(ctx context.Context) error {
 	s.durableStore = nil
 	s.recoveryStore = nil
 
-	s.usedBytes.Store(0)
-
-	s.quotaMu.Lock()
-	s.quota.Reset()
-	s.quotaMu.Unlock()
+	s.ResetUsage()
 
 	s.syncedMu.Lock()
 	s.synced = make(map[block.ContentHash]time.Time)

--- a/pkg/metadata/store/memory/reset.go
+++ b/pkg/metadata/store/memory/reset.go
@@ -44,6 +44,10 @@ func (s *MemoryMetadataStore) Reset(ctx context.Context) error {
 
 	s.usedBytes.Store(0)
 
+	s.quotaMu.Lock()
+	s.quota.Reset()
+	s.quotaMu.Unlock()
+
 	s.syncedMu.Lock()
 	s.synced = make(map[block.ContentHash]time.Time)
 	s.syncedLocators = nil // clear block locators together with synced markers

--- a/pkg/metadata/store/memory/reset.go
+++ b/pkg/metadata/store/memory/reset.go
@@ -42,7 +42,7 @@ func (s *MemoryMetadataStore) Reset(ctx context.Context) error {
 	s.durableStore = nil
 	s.recoveryStore = nil
 
-	s.ResetUsage()
+	s.base.ResetUsage()
 
 	s.syncedMu.Lock()
 	s.synced = make(map[block.ContentHash]time.Time)

--- a/pkg/metadata/store/memory/server.go
+++ b/pkg/metadata/store/memory/server.go
@@ -135,7 +135,7 @@ func (store *MemoryMetadataStore) GetFilesystemStatistics(ctx context.Context, h
 // Must be called with at least a read lock held.
 func (store *MemoryMetadataStore) computeStatistics() metadata.FilesystemStatistics {
 	// Read usage from atomic counter (O(1), no scan needed).
-	totalSize := uint64(store.usedBytes.Load())
+	totalSize := uint64(store.GetUsedBytes())
 	fileCount := uint64(len(store.files))
 
 	// Report storage limits or defaults

--- a/pkg/metadata/store/memory/server.go
+++ b/pkg/metadata/store/memory/server.go
@@ -135,7 +135,7 @@ func (store *MemoryMetadataStore) GetFilesystemStatistics(ctx context.Context, h
 // Must be called with at least a read lock held.
 func (store *MemoryMetadataStore) computeStatistics() metadata.FilesystemStatistics {
 	// Read usage from atomic counter (O(1), no scan needed).
-	totalSize := uint64(store.GetUsedBytes())
+	totalSize := uint64(store.base.GetUsedBytes())
 	fileCount := uint64(len(store.files))
 
 	// Report storage limits or defaults

--- a/pkg/metadata/store/memory/snapshot_store.go
+++ b/pkg/metadata/store/memory/snapshot_store.go
@@ -408,15 +408,41 @@ func (s *MemoryMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 
 	// Re-initialize transient state.
 	s.sessions = make(map[string]*ShareSession)
+	gUID := make(map[uint32]*metadata.UsageStat)
+	uUID := make(map[uint32]*metadata.UsageStat)
 
-	// Recompute usedBytes from files (only regular files count).
+	// Recompute usedBytes from files (only regular files count)
+	// and reconstruct the quota cache from the restored files
+	// since UNIX/NFS stores based on user and groupd, we need to aggregate the usage stats for each user and group.
 	var totalBytes int64
 	for _, fd := range s.files {
 		if fd.Attr != nil && fd.Attr.Type == metadata.FileTypeRegular {
 			totalBytes += int64(fd.Attr.Size)
+
+			u := uUID[fd.Attr.UID]
+			if u == nil {
+				u = &metadata.UsageStat{}
+				uUID[fd.Attr.UID] = u
+			}
+
+			u.Bytes += int64(fd.Attr.Size)
+			u.Files++
+
+			g := gUID[fd.Attr.GID]
+			if g == nil {
+				g = &metadata.UsageStat{}
+				gUID[fd.Attr.GID] = g
+			}
+
+			g.Bytes += int64(fd.Attr.Size)
+			g.Files++
 		}
 	}
 	s.usedBytes.Store(totalBytes)
+
+	s.quotaMu.Lock()
+	s.quota.Seed(uUID, gUID)
+	s.quotaMu.Unlock()
 
 	return nil
 }

--- a/pkg/metadata/store/memory/snapshot_store.go
+++ b/pkg/metadata/store/memory/snapshot_store.go
@@ -439,8 +439,8 @@ func (s *MemoryMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 		}
 	}
 
-	s.SetUsedBytes(totalBytes)
-	s.Seed(userUID, groupUID)
+	s.base.SetUsedBytes(totalBytes)
+	s.base.Seed(userUID, groupUID)
 
 	return nil
 }

--- a/pkg/metadata/store/memory/snapshot_store.go
+++ b/pkg/metadata/store/memory/snapshot_store.go
@@ -408,8 +408,8 @@ func (s *MemoryMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 
 	// Re-initialize transient state.
 	s.sessions = make(map[string]*ShareSession)
-	gUID := make(map[uint32]*metadata.UsageStat)
-	uUID := make(map[uint32]*metadata.UsageStat)
+	groupUID := make(map[uint32]*metadata.UsageStat)
+	userUID := make(map[uint32]*metadata.UsageStat)
 
 	// Recompute usedBytes from files (only regular files count)
 	// and reconstruct the quota cache from the restored files
@@ -419,30 +419,28 @@ func (s *MemoryMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 		if fd.Attr != nil && fd.Attr.Type == metadata.FileTypeRegular {
 			totalBytes += int64(fd.Attr.Size)
 
-			u := uUID[fd.Attr.UID]
+			u := userUID[fd.Attr.UID]
 			if u == nil {
 				u = &metadata.UsageStat{}
-				uUID[fd.Attr.UID] = u
+				userUID[fd.Attr.UID] = u
 			}
 
 			u.Bytes += int64(fd.Attr.Size)
 			u.Files++
 
-			g := gUID[fd.Attr.GID]
+			g := groupUID[fd.Attr.GID]
 			if g == nil {
 				g = &metadata.UsageStat{}
-				gUID[fd.Attr.GID] = g
+				groupUID[fd.Attr.GID] = g
 			}
 
 			g.Bytes += int64(fd.Attr.Size)
 			g.Files++
 		}
 	}
-	s.usedBytes.Store(totalBytes)
 
-	s.quotaMu.Lock()
-	s.quota.Seed(uUID, gUID)
-	s.quotaMu.Unlock()
+	s.SetUsedBytes(totalBytes)
+	s.Seed(userUID, groupUID)
 
 	return nil
 }

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -14,7 +13,7 @@ import (
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/basestore"
 )
 
 // shareData holds the internal representation of a share configuration.
@@ -237,20 +236,9 @@ type MemoryMetadataStore struct {
 	// recovery. Initialized lazily on first use.
 	recoveryStore *memoryRecoveryStore
 
-	// usedBytes tracks the total logical bytes used by regular files.
-	// Updated atomically on every size-changing operation (create, update, truncate, delete).
-	// Only regular files count toward usage; directories, symlinks, etc. do not.
-	usedBytes atomic.Int64
-
-	// quota tracks per-identity usage (bytes + file count) for regular files,
-	// keyed by owner uid / gid. Mirror of usedBytes but keyed by owner identity
-	// for per-user/per-group quota enforcement and reporting. Guarded by quotaMu
-	// (separate from s.mu so the GetQuotaUsage read path and the transaction
-	// commit-apply do not contend with unrelated metadata ops). Applied from a
-	// transaction's pending per-identity deltas exactly once on successful
-	// commit, identical to the usedBytes discipline.
-	quotaMu sync.Mutex
-	quota   *quota.Cache
+	// baseStore embeds the shared usage accounting state for regular files.
+	// This includes total logical bytes used and per-identity usage for quota
+	*basestore.Base
 
 	// storeID is the engine-persistent identifier for this store instance.
 	// Assigned on construction with a fresh ULID and immutable for the life
@@ -363,8 +351,8 @@ func NewMemoryMetadataStore(config MemoryMetadataStoreConfig) *MemoryMetadataSto
 		storeID: ulid.Make().String(),
 		// ObjectID -> handle-key secondary index.
 		objectIndex: make(map[block.ContentHash]string),
+		Base:        basestore.NewBaseStore(),
 		// per-identity quota usage counters.
-		quota: quota.NewCache(),
 		// Block packing record store.
 		blockRecords: make(map[string]*block.BlockRecord),
 	}
@@ -433,20 +421,6 @@ func NewMemoryMetadataStoreWithDefaults() *MemoryMetadataStore {
 		MaxStorageBytes: 0, // Unlimited (reported as 1TB)
 		MaxFiles:        0, // Unlimited (reported as 1 million)
 	})
-}
-
-// GetUsedBytes returns the current total logical bytes used by regular files.
-// This is an O(1) atomic read, safe for concurrent access without locks.
-func (store *MemoryMetadataStore) GetUsedBytes() int64 {
-	return store.usedBytes.Load()
-}
-
-// GetQuotaUsage returns per-identity usage for the given scope and id.
-// O(1) map read under quotaMu. A missing key returns a zero UsageStat.
-func (store *MemoryMetadataStore) GetQuotaUsage(scope metadata.QuotaScope, id uint32) (metadata.UsageStat, error) {
-	store.quotaMu.Lock()
-	defer store.quotaMu.Unlock()
-	return store.quota.Get(scope, id), nil
 }
 
 // GetStoreID returns the engine-persistent store identifier. Assigned on

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -236,9 +236,9 @@ type MemoryMetadataStore struct {
 	// recovery. Initialized lazily on first use.
 	recoveryStore *memoryRecoveryStore
 
-	// baseStore embeds the shared usage accounting state for regular files.
-	// This includes total logical bytes used and per-identity usage for quota
-	*basestore.Base
+	// baseStore holds the shared usage accounting state for regular files.
+	// This includes total logical bytes used and per-identity usage for quota.
+	base *basestore.Base
 
 	// storeID is the engine-persistent identifier for this store instance.
 	// Assigned on construction with a fresh ULID and immutable for the life
@@ -351,7 +351,7 @@ func NewMemoryMetadataStore(config MemoryMetadataStoreConfig) *MemoryMetadataSto
 		storeID: ulid.Make().String(),
 		// ObjectID -> handle-key secondary index.
 		objectIndex: make(map[block.ContentHash]string),
-		Base:        basestore.NewBaseStore(),
+		base:        basestore.NewBaseStore(),
 		// per-identity quota usage counters.
 		// Block packing record store.
 		blockRecords: make(map[string]*block.BlockRecord),
@@ -433,6 +433,18 @@ func (store *MemoryMetadataStore) GetStoreID() string { return store.storeID }
 
 // Compile-time assertion: the memory engine exposes GetStoreID.
 var _ interface{ GetStoreID() string } = (*MemoryMetadataStore)(nil)
+
+// GetUsedBytes returns the current total logical bytes used by regular files.
+// This is an O(1) atomic read, safe for concurrent access without locks.
+func (store *MemoryMetadataStore) GetUsedBytes() int64 {
+	return store.base.GetUsedBytes()
+}
+
+// GetQuotaUsage returns per-identity usage for the given scope and id.
+// O(1) map read under quotaMu. A missing key returns a zero UsageStat.
+func (store *MemoryMetadataStore) GetQuotaUsage(scope metadata.QuotaScope, id uint32) (metadata.UsageStat, error) {
+	return store.base.GetQuotaUsage(scope, id)
+}
 
 // handleToKey converts a FileHandle to a string key for map indexing.
 //

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -193,13 +193,11 @@ func (store *MemoryMetadataStore) WithTransaction(ctx context.Context, fn func(t
 
 	// Commit succeeded — apply the accumulated usedBytes delta once.
 	if tx.pendingDelta != 0 {
-		store.usedBytes.Add(tx.pendingDelta)
+		store.AddUsedBytes(tx.pendingDelta)
 	}
 	// Apply per-identity usage deltas once, under quotaMu.
 	if d := tx.quota.Map(); len(d) > 0 {
-		store.quotaMu.Lock()
-		store.quota.Apply(d)
-		store.quotaMu.Unlock()
+		store.ApplyQuotaDelta(d)
 	}
 	// Apply buffered synced-marker mutations once, under syncedMu. Map writes
 	// cannot fail, so the commit stays all-or-nothing. A concurrent direct

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -193,11 +193,11 @@ func (store *MemoryMetadataStore) WithTransaction(ctx context.Context, fn func(t
 
 	// Commit succeeded — apply the accumulated usedBytes delta once.
 	if tx.pendingDelta != 0 {
-		store.AddUsedBytes(tx.pendingDelta)
+		store.base.AddUsedBytes(tx.pendingDelta)
 	}
 	// Apply per-identity usage deltas once, under quotaMu.
 	if d := tx.quota.Map(); len(d) > 0 {
-		store.ApplyQuotaDelta(d)
+		store.base.ApplyQuotaDelta(d)
 	}
 	// Apply buffered synced-marker mutations once, under syncedMu. Map writes
 	// cannot fail, so the commit stays all-or-nothing. A concurrent direct

--- a/pkg/metadata/store/postgres/reset.go
+++ b/pkg/metadata/store/postgres/reset.go
@@ -46,7 +46,7 @@ func (s *PostgresMetadataStore) Reset(ctx context.Context) error {
 		return fmt.Errorf("reset: commit: %w", err)
 	}
 
-	s.ResetUsage()
+	s.base.ResetUsage()
 
 	return nil
 }

--- a/pkg/metadata/store/postgres/reset.go
+++ b/pkg/metadata/store/postgres/reset.go
@@ -46,5 +46,7 @@ func (s *PostgresMetadataStore) Reset(ctx context.Context) error {
 		return fmt.Errorf("reset: commit: %w", err)
 	}
 
+	s.ResetUsage()
+
 	return nil
 }

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/basestore"
 )
 
 // PostgresMetadataStore implements the metadata.Store interface using PostgreSQL
@@ -63,18 +63,9 @@ type PostgresMetadataStore struct {
 	recoveryStore   *postgresRecoveryStore
 	recoveryStoreMu sync.Mutex
 
-	// usedBytes tracks the total logical bytes used by regular files.
-	// Updated atomically on every size-changing operation (create, update, truncate, delete).
-	// Initialized from a SQL SUM query on startup.
-	usedBytes atomic.Int64
-
-	// quota tracks per-identity usage (bytes + file count) for regular files,
-	// keyed by owner uid / gid. In-memory cache mirroring usedBytes, seeded from
-	// a SQL GROUP BY query on startup (the files table is the source of truth, so
-	// it is always reconstructed correctly). Updated from a transaction's pending
-	// per-identity deltas exactly once on successful commit. Guarded by quotaMu.
-	quotaMu sync.Mutex
-	quota   *quota.Cache
+	// baseStore embeds the shared usage accounting state for regular files.
+	// This includes total logical bytes used and per-identity usage for quota
+	*basestore.Base
 
 	// storeID is the engine-persistent identifier for this store instance,
 	// backed by the server_config.store_id column. Created on first open
@@ -140,7 +131,7 @@ func NewPostgresMetadataStore(
 		logger:       log,
 		ctx:          storeCtx,
 		cancel:       cancel,
-		quota:        quota.NewCache(),
+		Base:         basestore.NewBaseStore(),
 	}
 
 	// Initialize the usedBytes counter from a SQL SUM query.
@@ -173,12 +164,6 @@ func NewPostgresMetadataStore(
 	return store, nil
 }
 
-// GetUsedBytes returns the current total logical bytes used by regular files.
-// This is an O(1) atomic read, safe for concurrent access without locks.
-func (s *PostgresMetadataStore) GetUsedBytes() int64 {
-	return s.usedBytes.Load()
-}
-
 // initUsedBytesCounter initializes the store-wide atomic counter from a SQL SUM
 // query and seeds the per-identity usage cache from GROUP BY aggregates. Both
 // are reconstructed from the inodes table (the source
@@ -192,7 +177,8 @@ func (s *PostgresMetadataStore) initUsedBytesCounter(ctx context.Context) error 
 	if err != nil {
 		return fmt.Errorf("failed to query used bytes: %w", err)
 	}
-	s.usedBytes.Store(totalUsed)
+
+	s.SetUsedBytes(totalUsed)
 
 	userUsage, err := s.seedUsageByColumn(ctx, "uid")
 	if err != nil {
@@ -202,9 +188,9 @@ func (s *PostgresMetadataStore) initUsedBytesCounter(ctx context.Context) error 
 	if err != nil {
 		return err
 	}
-	s.quotaMu.Lock()
-	s.quota.Seed(userUsage, groupUsage)
-	s.quotaMu.Unlock()
+
+	s.Seed(userUsage, groupUsage)
+
 	return nil
 }
 
@@ -234,26 +220,6 @@ func (s *PostgresMetadataStore) seedUsageByColumn(ctx context.Context, col strin
 		return nil, fmt.Errorf("failed iterating %s usage: %w", col, err)
 	}
 	return out, nil
-}
-
-// GetQuotaUsage returns per-identity usage for the given scope and id.
-// O(1) cache read under quotaMu. A missing key returns a zero UsageStat.
-func (s *PostgresMetadataStore) GetQuotaUsage(scope metadata.QuotaScope, id uint32) (metadata.UsageStat, error) {
-	s.quotaMu.Lock()
-	defer s.quotaMu.Unlock()
-	return s.quota.Get(scope, id), nil
-}
-
-// applyQuotaDelta folds a per-identity usage delta into the in-memory usage
-// cache. Called post-commit (matching usedBytes). Buckets that drop to zero or
-// below are removed.
-func (s *PostgresMetadataStore) applyQuotaDelta(delta map[quota.Key]metadata.UsageStat) {
-	if len(delta) == 0 {
-		return
-	}
-	s.quotaMu.Lock()
-	defer s.quotaMu.Unlock()
-	s.quota.Apply(delta)
 }
 
 // ensureStoreID reads the engine-persistent store_id from server_config; if

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -64,8 +64,8 @@ type PostgresMetadataStore struct {
 	recoveryStoreMu sync.Mutex
 
 	// baseStore embeds the shared usage accounting state for regular files.
-	// This includes total logical bytes used and per-identity usage for quota
-	*basestore.Base
+	// This includes total logical bytes used and per-identity usage for quota.
+	base *basestore.Base
 
 	// storeID is the engine-persistent identifier for this store instance,
 	// backed by the server_config.store_id column. Created on first open
@@ -131,7 +131,7 @@ func NewPostgresMetadataStore(
 		logger:       log,
 		ctx:          storeCtx,
 		cancel:       cancel,
-		Base:         basestore.NewBaseStore(),
+		base:         basestore.NewBaseStore(),
 	}
 
 	// Initialize the usedBytes counter from a SQL SUM query.
@@ -164,6 +164,12 @@ func NewPostgresMetadataStore(
 	return store, nil
 }
 
+// GetUsedBytes returns the current total logical bytes used by regular files.
+// This is an O(1) atomic read, safe for concurrent access without locks.
+func (s *PostgresMetadataStore) GetUsedBytes() int64 {
+	return s.base.GetUsedBytes()
+}
+
 // initUsedBytesCounter initializes the store-wide atomic counter from a SQL SUM
 // query and seeds the per-identity usage cache from GROUP BY aggregates. Both
 // are reconstructed from the inodes table (the source
@@ -178,7 +184,7 @@ func (s *PostgresMetadataStore) initUsedBytesCounter(ctx context.Context) error 
 		return fmt.Errorf("failed to query used bytes: %w", err)
 	}
 
-	s.SetUsedBytes(totalUsed)
+	s.base.SetUsedBytes(totalUsed)
 
 	userUsage, err := s.seedUsageByColumn(ctx, "uid")
 	if err != nil {
@@ -189,9 +195,15 @@ func (s *PostgresMetadataStore) initUsedBytesCounter(ctx context.Context) error 
 		return err
 	}
 
-	s.Seed(userUsage, groupUsage)
+	s.base.Seed(userUsage, groupUsage)
 
 	return nil
+}
+
+// GetQuotaUsage returns per-identity usage for the given scope and id.
+// O(1) cache read under quotaMu. A missing key returns a zero UsageStat.
+func (s *PostgresMetadataStore) GetQuotaUsage(scope metadata.QuotaScope, id uint32) (metadata.UsageStat, error) {
+	return s.base.GetQuotaUsage(scope, id)
 }
 
 // seedUsageByColumn aggregates per-identity usage (bytes + count) for regular

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -173,10 +173,10 @@ func (s *PostgresMetadataStore) withTransaction(ctx context.Context, fn func(tx 
 
 		// Apply the accumulated usedBytes delta exactly once, after commit.
 		if ptx.pendingDelta != 0 {
-			s.AddUsedBytes(ptx.pendingDelta)
+			s.base.AddUsedBytes(ptx.pendingDelta)
 		}
 		// Apply per-identity usage deltas once, after commit.
-		s.ApplyQuotaDelta(ptx.quota.Map())
+		s.base.ApplyQuotaDelta(ptx.quota.Map())
 		return nil // Success
 	}
 

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -173,10 +173,10 @@ func (s *PostgresMetadataStore) withTransaction(ctx context.Context, fn func(tx 
 
 		// Apply the accumulated usedBytes delta exactly once, after commit.
 		if ptx.pendingDelta != 0 {
-			s.usedBytes.Add(ptx.pendingDelta)
+			s.AddUsedBytes(ptx.pendingDelta)
 		}
 		// Apply per-identity usage deltas once, after commit.
-		s.applyQuotaDelta(ptx.quota.Map())
+		s.ApplyQuotaDelta(ptx.quota.Map())
 		return nil // Success
 	}
 

--- a/pkg/metadata/store/sqlite/reset.go
+++ b/pkg/metadata/store/sqlite/reset.go
@@ -43,9 +43,7 @@ func (s *SQLiteMetadataStore) Reset(ctx context.Context) error {
 	committed = true
 
 	// Reset the in-memory counters to match the now-empty tables.
-	s.usedBytes.Store(0)
-	s.quotaMu.Lock()
-	s.quota.Reset()
-	s.quotaMu.Unlock()
+	s.ResetUsage()
+
 	return nil
 }

--- a/pkg/metadata/store/sqlite/reset.go
+++ b/pkg/metadata/store/sqlite/reset.go
@@ -43,7 +43,7 @@ func (s *SQLiteMetadataStore) Reset(ctx context.Context) error {
 	committed = true
 
 	// Reset the in-memory counters to match the now-empty tables.
-	s.ResetUsage()
+	s.base.ResetUsage()
 
 	return nil
 }

--- a/pkg/metadata/store/sqlite/store.go
+++ b/pkg/metadata/store/sqlite/store.go
@@ -59,8 +59,8 @@ type SQLiteMetadataStore struct {
 	manifestWrites atomic.Int64
 
 	// baseStore embeds the shared usage accounting state for regular files.
-	// This includes total logical bytes used and per-identity usage for quota
-	*basestore.Base
+	// This includes total logical bytes used and per-identity usage for quota.
+	base *basestore.Base
 
 	// storeID is the engine-persistent identifier, backed by
 	// server_config.store_id. Created on first open with a fresh ULID; read
@@ -144,7 +144,7 @@ func NewSQLiteMetadataStore(
 		logger:       log,
 		ctx:          storeCtx,
 		cancel:       cancel,
-		Base:         basestore.NewBaseStore(),
+		base:         basestore.NewBaseStore(),
 	}
 
 	if err := store.initUsedBytesCounter(ctx); err != nil {
@@ -166,6 +166,11 @@ func NewSQLiteMetadataStore(
 	return store, nil
 }
 
+// GetUsedBytes returns the current total logical bytes used by regular files.
+func (s *SQLiteMetadataStore) GetUsedBytes() int64 {
+	return s.base.GetUsedBytes()
+}
+
 // initUsedBytesCounter initializes the store-wide atomic counter from a SQL SUM
 // query and seeds the per-identity usage cache from GROUP BY aggregates. Both
 // are reconstructed from the inodes table (the source of truth).
@@ -176,7 +181,7 @@ func (s *SQLiteMetadataStore) initUsedBytesCounter(ctx context.Context) error {
 		return fmt.Errorf("failed to query used bytes: %w", err)
 	}
 
-	s.SetUsedBytes(totalUsed)
+	s.base.SetUsedBytes(totalUsed)
 
 	userUsage, err := s.seedUsageByColumn(ctx, "uid")
 	if err != nil {
@@ -187,7 +192,7 @@ func (s *SQLiteMetadataStore) initUsedBytesCounter(ctx context.Context) error {
 		return err
 	}
 
-	s.Seed(userUsage, groupUsage)
+	s.base.Seed(userUsage, groupUsage)
 
 	return nil
 }
@@ -218,6 +223,11 @@ func (s *SQLiteMetadataStore) seedUsageByColumn(ctx context.Context, col string)
 		return nil, fmt.Errorf("failed iterating %s usage: %w", col, err)
 	}
 	return out, nil
+}
+
+// GetQuotaUsage returns per-identity usage for the given scope and id.
+func (s *SQLiteMetadataStore) GetQuotaUsage(scope metadata.QuotaScope, id uint32) (metadata.UsageStat, error) {
+	return s.base.GetQuotaUsage(scope, id)
 }
 
 // ensureStoreID reads the engine-persistent store_id from server_config; if the

--- a/pkg/metadata/store/sqlite/store.go
+++ b/pkg/metadata/store/sqlite/store.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/basestore"
 )
 
 // sqliteDriverName is the database/sql driver name registered by the imported
@@ -51,11 +51,6 @@ type SQLiteMetadataStore struct {
 	// cancel cancels the store context.
 	cancel context.CancelFunc
 
-	// usedBytes tracks the total logical bytes used by regular files. Updated
-	// atomically on every size-changing operation. Initialized from a SQL SUM
-	// query on startup.
-	usedBytes atomic.Int64
-
 	// manifestWrites counts how many times PutFile actually persisted the
 	// file_block_refs manifest (i.e. ran past the BlocksDirty gate). Test-only
 	// observability: it lets the conformance suite prove an attr-only write
@@ -63,11 +58,9 @@ type SQLiteMetadataStore struct {
 	// of the same M rows leaves the same count). Never read in production.
 	manifestWrites atomic.Int64
 
-	// quota tracks per-identity usage (bytes + file count) for regular files,
-	// keyed by owner uid / gid. Seeded from a GROUP BY query on startup and
-	// updated from each committed transaction's deltas. Guarded by quotaMu.
-	quotaMu sync.Mutex
-	quota   *quota.Cache
+	// baseStore embeds the shared usage accounting state for regular files.
+	// This includes total logical bytes used and per-identity usage for quota
+	*basestore.Base
 
 	// storeID is the engine-persistent identifier, backed by
 	// server_config.store_id. Created on first open with a fresh ULID; read
@@ -151,7 +144,7 @@ func NewSQLiteMetadataStore(
 		logger:       log,
 		ctx:          storeCtx,
 		cancel:       cancel,
-		quota:        quota.NewCache(),
+		Base:         basestore.NewBaseStore(),
 	}
 
 	if err := store.initUsedBytesCounter(ctx); err != nil {
@@ -173,11 +166,6 @@ func NewSQLiteMetadataStore(
 	return store, nil
 }
 
-// GetUsedBytes returns the current total logical bytes used by regular files.
-func (s *SQLiteMetadataStore) GetUsedBytes() int64 {
-	return s.usedBytes.Load()
-}
-
 // initUsedBytesCounter initializes the store-wide atomic counter from a SQL SUM
 // query and seeds the per-identity usage cache from GROUP BY aggregates. Both
 // are reconstructed from the inodes table (the source of truth).
@@ -187,7 +175,8 @@ func (s *SQLiteMetadataStore) initUsedBytesCounter(ctx context.Context) error {
 	if err := s.db.QueryRowContext(ctx, query, int(metadata.FileTypeRegular)).Scan(&totalUsed); err != nil {
 		return fmt.Errorf("failed to query used bytes: %w", err)
 	}
-	s.usedBytes.Store(totalUsed)
+
+	s.SetUsedBytes(totalUsed)
 
 	userUsage, err := s.seedUsageByColumn(ctx, "uid")
 	if err != nil {
@@ -197,9 +186,9 @@ func (s *SQLiteMetadataStore) initUsedBytesCounter(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	s.quotaMu.Lock()
-	s.quota.Seed(userUsage, groupUsage)
-	s.quotaMu.Unlock()
+
+	s.Seed(userUsage, groupUsage)
+
 	return nil
 }
 
@@ -229,24 +218,6 @@ func (s *SQLiteMetadataStore) seedUsageByColumn(ctx context.Context, col string)
 		return nil, fmt.Errorf("failed iterating %s usage: %w", col, err)
 	}
 	return out, nil
-}
-
-// GetQuotaUsage returns per-identity usage for the given scope and id.
-func (s *SQLiteMetadataStore) GetQuotaUsage(scope metadata.QuotaScope, id uint32) (metadata.UsageStat, error) {
-	s.quotaMu.Lock()
-	defer s.quotaMu.Unlock()
-	return s.quota.Get(scope, id), nil
-}
-
-// applyQuotaDelta folds a per-identity usage delta into the in-memory usage
-// cache. Called post-commit (matching usedBytes).
-func (s *SQLiteMetadataStore) applyQuotaDelta(delta map[quota.Key]metadata.UsageStat) {
-	if len(delta) == 0 {
-		return
-	}
-	s.quotaMu.Lock()
-	defer s.quotaMu.Unlock()
-	s.quota.Apply(delta)
 }
 
 // ensureStoreID reads the engine-persistent store_id from server_config; if the

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -118,10 +118,11 @@ func (s *SQLiteMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 
 		// Apply the accumulated usedBytes delta exactly once, after commit.
 		if ptx.pendingDelta != 0 {
-			s.usedBytes.Add(ptx.pendingDelta)
+			s.AddUsedBytes(ptx.pendingDelta)
 		}
+
 		// Apply per-identity usage deltas once, after commit.
-		s.applyQuotaDelta(ptx.quota.Map())
+		s.ApplyQuotaDelta(ptx.quota.Map())
 		return nil // Success
 	}
 

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -118,11 +118,11 @@ func (s *SQLiteMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 
 		// Apply the accumulated usedBytes delta exactly once, after commit.
 		if ptx.pendingDelta != 0 {
-			s.AddUsedBytes(ptx.pendingDelta)
+			s.base.AddUsedBytes(ptx.pendingDelta)
 		}
 
 		// Apply per-identity usage deltas once, after commit.
-		s.ApplyQuotaDelta(ptx.quota.Map())
+		s.base.ApplyQuotaDelta(ptx.quota.Map())
 		return nil // Success
 	}
 

--- a/pkg/metadata/storetest/reset_conformance.go
+++ b/pkg/metadata/storetest/reset_conformance.go
@@ -53,6 +53,13 @@ func ResetThenRestoreConformance(t *testing.T, factory SnapshotableStoreFactory)
 		t.Fatalf("Reset: %v", err)
 	}
 
+	// Quota assertion: Reset must clear the per-identity cache, not just the
+	// share/file maps a stale cache here silently keeps enforcing limits
+	// against data that no longer exists.
+	if u, err := store.GetQuotaUsage(metadata.QuotaScopeUser, 1000); err != nil || u.Bytes != 0 || u.Files != 0 {
+		t.Fatalf("post-Reset GetQuotaUsage(user, 1000) = %+v, err=%v, want zero", u, err)
+	}
+
 	// 3. Empty assertion: ListShares returns zero entries post-Reset.
 	shares, err := store.ListShares(ctx)
 	if err != nil {
@@ -67,6 +74,13 @@ func ResetThenRestoreConformance(t *testing.T, factory SnapshotableStoreFactory)
 	//    ErrRestoreDestinationNotEmpty precondition so Restore must succeed.
 	if err := b.RestoreSnapshot(ctx, &dumpBuf); err != nil {
 		t.Fatalf("Restore post-Reset: %v", err)
+	}
+
+	// Quota assertion: Restore must reseed the cache from the restored files,
+	// not leave it at the post-Reset zero state.
+	const wantBytes = int64((8 << 20) + (6 << 20)) // 14 MiB total
+	if u, err := store.GetQuotaUsage(metadata.QuotaScopeUser, 1000); err != nil || u.Bytes != wantBytes || u.Files != 2 {
+		t.Fatalf("post-Restore GetQuotaUsage(user, 1000) = %+v, err=%v, want {Bytes:%d Files:2}", u, err, wantBytes)
 	}
 
 	// 5. Verify shares + representative file survived round-trip.

--- a/pkg/metadata/storetest/snapshot_conformance.go
+++ b/pkg/metadata/storetest/snapshot_conformance.go
@@ -76,6 +76,10 @@ func RunSnapshotConformanceSuite(t *testing.T, factory SnapshotableStoreFactory)
 	t.Run("UsedBytesAfterRestore", func(t *testing.T) {
 		testSnapshot_UsedBytesAfterRestore(t, factory)
 	})
+
+	t.Run("QuotaUsageAfterRestore", func(t *testing.T) {
+		testSnapshot_QuotaUsageAfterRestore(t, factory)
+	})
 }
 
 // testSnapshot_UsedBytesAfterRestore pins the quota-counter invariant: after
@@ -860,5 +864,44 @@ func testSnapshot_HashSet_Dedup(t *testing.T, factory SnapshotableStoreFactory) 
 	}
 	if !gotHS.Contains(sharedHash) {
 		t.Fatalf("HashSet does not contain the shared hash %x", sharedHash[:8])
+	}
+}
+
+// testSnapshot_QuotaUsageAfterRestore pins the same invariant as
+// UsedBytesAfterRestore, but for the per-identity quota cache: after Restore,
+// GetQuotaUsage for the fixture's owner (uid/gid 1000) MUST reflect the
+// restored files, not a stale or zeroed cache. A backend that recomputes
+// usedBytes but not quota (or that Resets the quota cache instead of
+// reseeding it) passes UsedBytesAfterRestore while silently disabling
+// per-identity quota enforcement this test catches that divergence.
+func testSnapshot_QuotaUsageAfterRestore(t *testing.T, factory SnapshotableStoreFactory) {
+	srcStore := factory(t)
+	srcB := asSnapshotable(t, srcStore)
+	ctx := t.Context()
+
+	populateTestData(t, srcStore, "qb")
+	const wantBytes = int64((8 << 20) + (6 << 20)) // 14 MiB
+	const wantFiles = int64(2)
+
+	var buf bytes.Buffer
+	if _, err := srcB.WriteSnapshot(ctx, &buf); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	dstStore := factory(t)
+	dstB := asSnapshotable(t, dstStore)
+	if err := dstB.RestoreSnapshot(ctx, &buf); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	for _, scope := range []metadata.QuotaScope{metadata.QuotaScopeUser, metadata.QuotaScopeGroup} {
+		got, err := dstStore.GetQuotaUsage(scope, 1000)
+		if err != nil {
+			t.Fatalf("GetQuotaUsage(%v, 1000): %v", scope, err)
+		}
+		if got.Bytes != wantBytes || got.Files != wantFiles {
+			t.Fatalf("restored GetQuotaUsage(%v, 1000) = %+v, want {Bytes:%d Files:%d}",
+				scope, got, wantBytes, wantFiles)
+		}
 	}
 }


### PR DESCRIPTION
Reset() never touched the quota cache, it zeroed usedBytes and cleared every other map but left per identity usage stale. Now clears it under quotaMu, alongside usedBytes.
RestoreSnapshot recomputed usedBytes from the restored files but left the quota cache untouched, so GetQuotaUsage kept reporting pre-restore (now-stale) per identity values after a successful restore. Rebuilt the per uid/gid maps from the restored files and reseed via quota.Cache.Seed, mirrorring the usedBytes recompute right above it.

sqlite/postgres/badger already reseed correctly via initUsedBytesCounter on restore, this was memory only.

Adds conformance coverage in storetest (QuotaUsageAfterRestore, plus Reset/Restore assertions in ResetThenRestoreConformance) so the divergence is caught for all four backend going forward.

Found while scoping the basestore extraction in #1828.

# Description

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Changes Made

Please provide a clear list of changes:

- `memory`'s `Reset()` never cleared the per-identity quota cache (only `usedBytes` and the other maps) now clears it under `quotaMu`.
- `memory`'s `RestoreSnapshot` recomputed `usedBytes` from the restored files but left the quota cache stale now rebuilds per uid/gid maps from the restored files and reseeds via `quota.Cache.Seed`, mirroring the `usedBytes` recompute right above it.
- sqlite/postgres/badger already reseed correctly via `initUsedBytesCounter` on restore this was memory-only.
- Added conformance coverage in `storetest`: `QuotaUsageAfterRestore`, plus Reset/Restore assertions in `ResetThenRestoreConformance`, so the divergence is caught for all four backends going forward.

## Testing

- [x] Unit tests pass (`go test ./...`)
- [ ] Manual testing performed
- [ ] Integration testing performed

## Testing Instructions

1. `go build ./...`
2. `go test -race ./pkg/metadata/store/... -run 'TestConformance|TestSnapshotConformance|TestResetThenRestoreConformance' -v`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

This PR is still open/draft the `internal/basestore` extraction (the main scope agreed in #1828) is in progress and will land as follow-up commits here.