### PR TITLE
fix(postgres): guard the manual migrate path against a future schema

### DIFF
--- a/pkg/metadata/store/postgres/format_version_test.go
+++ b/pkg/metadata/store/postgres/format_version_test.go
@@ -46,6 +46,23 @@ func TestFormatVersion_CurrentSchemaOpens(t *testing.T) {
 	}
 }
 
+// TestFormatVersion_FutureSchemaRefusesManualMigrate covers the same downgrade
+// through the other door: an operator running migrations by hand after rolling
+// a binary back. Without the guard golang-migrate finds nothing to apply and
+// reports success, which reads as "this database is fine" moments before the
+// open path refuses it.
+func TestFormatVersion_FutureSchemaRefusesManualMigrate(t *testing.T) {
+	newPostgresStore(t)
+	recordFutureMigration(t)
+
+	cfg, _ := postgresTestConfig()
+	if err := postgres.RunMigrations(context.Background(), cfg); err == nil {
+		t.Fatal("migrating a future schema must fail")
+	} else if !errors.Is(err, block.ErrFutureFormat) {
+		t.Fatalf("error must wrap block.ErrFutureFormat; got %v", err)
+	}
+}
+
 // TestFormatVersion_FutureSchemaRefusesOpen is the downgrade case, asserted on
 // both AutoMigrate settings. The guard is a safety check rather than a
 // migration, so the default (AutoMigrate off) configuration — which otherwise

--- a/pkg/metadata/store/postgres/migrate.go
+++ b/pkg/metadata/store/postgres/migrate.go
@@ -36,6 +36,13 @@ func runMigrations(ctx context.Context, connString string, logger *slog.Logger) 
 		return fmt.Errorf("failed to ping database: %w", err)
 	}
 
+	// Migrating a database that is already ahead of this build is not a no-op
+	// worth reporting as "up to date" — refuse it here too, so the manual
+	// migrate path fails as loudly as the open path.
+	if err := checkFormatVersionDB(ctx, db); err != nil {
+		return err
+	}
+
 	// Create postgres driver instance for migrations
 	driver, err := postgres.WithInstance(db, &postgres.Config{
 		MigrationsTable: "schema_migrations",
@@ -138,11 +145,26 @@ func newestEmbeddedVersion() (int64, error) {
 // with "file does not exist", and only when AutoMigrate is on, which it is not
 // by default — so the database otherwise opens cleanly and then fails query by
 // query with raw SQL errors, long after startup.
+// The open path holds a pgx pool and the manual migrate path holds a
+// database/sql handle, so the guard reads through whichever the caller has
+// rather than opening a second connection to ask two questions.
 func checkFormatVersion(ctx context.Context, pool *pgxpool.Pool) error {
+	return checkFormatVersionWith(ctx, func(ctx context.Context, query string, dest any) error {
+		return pool.QueryRow(ctx, query).Scan(dest)
+	})
+}
+
+func checkFormatVersionDB(ctx context.Context, db *sql.DB) error {
+	return checkFormatVersionWith(ctx, func(ctx context.Context, query string, dest any) error {
+		return db.QueryRowContext(ctx, query).Scan(dest)
+	})
+}
+
+func checkFormatVersionWith(ctx context.Context, scan func(context.Context, string, any) error) error {
 	var exists bool
-	if err := pool.QueryRow(ctx,
-		`SELECT to_regclass('schema_migrations') IS NOT NULL`,
-	).Scan(&exists); err != nil {
+	if err := scan(ctx,
+		`SELECT to_regclass('schema_migrations') IS NOT NULL`, &exists,
+	); err != nil {
 		return fmt.Errorf("probe schema_migrations: %w", err)
 	}
 	if !exists {
@@ -152,7 +174,7 @@ func checkFormatVersion(ctx context.Context, pool *pgxpool.Pool) error {
 	}
 
 	var stored *int64
-	if err := pool.QueryRow(ctx, `SELECT MAX(version) FROM schema_migrations`).Scan(&stored); err != nil {
+	if err := scan(ctx, `SELECT MAX(version) FROM schema_migrations`, &stored); err != nil {
 		return fmt.Errorf("read schema_migrations: %w", err)
 	}
 	if stored == nil {


### PR DESCRIPTION
Closes #1869.

#1865 gave every store a format check that refuses state written by a newer release. Postgres got it on the open path only. Its `RunMigrations` — the public wrapper for running migrations by hand — had no check, so a database whose `schema_migrations` sits above this build's embedded ceiling would go through golang-migrate, find nothing to apply, and exit clean.

That is the same downgrade the guard exists for, reached through a different door, and the quiet success is the worse half: an operator gets "no change" from the migrate command and then a refusal from the daemon a moment later.

## Change

- `checkFormatVersionDB` reads the guard through a `*sql.DB`, which is what `runMigrations` already holds. Rather than duplicate the two probe queries, both entry points pass a scan closure into one shared body — the open path keeps its pgx pool, the migrate path uses its existing handle, and neither opens a second connection.
- `runMigrations` calls it right after the ping, mirroring where sqlite does the same.

sqlite already had this (its guard sits inside `runMigrations`, covering both paths); this brings postgres level.

## Verification

- `go build ./...`, `go vet` clean on both tag sets.
- New integration case `TestFormatVersion_FutureSchemaRefusesManualMigrate` records version 999999 and asserts `RunMigrations` returns an error wrapping `block.ErrFutureFormat`, alongside the existing open-path assertions.
- **The integration test has not run locally** — no postgres or docker on this machine. It runs in `integration-tests.yml`, which is where I am relying on it; worth a glance at that job before merge rather than taking the unit run as coverage.