### PR TITLE
test(bench): say when the cold barrier could not verify itself

### DIFF
--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -613,8 +613,8 @@ func dittofsEvict(ctx context.Context) error {
 	// would read it from disk — FAIL LOUDLY rather than emit a warm number labelled
 	// "cold". The DiskWr/NetRx columns independently confirm coldness post-hoc.
 	if before.LocalDiskUsed <= dittofsColdBarrierFloorBytes {
-		// Below the floor the drop ratio is noise, so the check above cannot say
-		// whether the evict worked. Say that out loud: a silent return here reads
+		// Below the floor the drop ratio is noise, so the assertion below cannot
+		// say whether the evict worked. Say that out loud: a silent return reads
 		// in the log exactly like a verified barrier, and the cold cell it labels
 		// may have been served warm.
 		_, _ = fmt.Fprintf(exec.CmdOut,

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -612,10 +612,22 @@ func dittofsEvict(ctx context.Context) error {
 	// large remainder survives (>20% of a non-trivial starting size), the cold pass
 	// would read it from disk — FAIL LOUDLY rather than emit a warm number labelled
 	// "cold". The DiskWr/NetRx columns independently confirm coldness post-hoc.
-	if before.LocalDiskUsed > dittofsColdBarrierFloorBytes && after.LocalDiskUsed > before.LocalDiskUsed/5 {
+	if before.LocalDiskUsed <= dittofsColdBarrierFloorBytes {
+		// Below the floor the drop ratio is noise, so the check above cannot say
+		// whether the evict worked. Say that out loud: a silent return here reads
+		// in the log exactly like a verified barrier, and the cold cell it labels
+		// may have been served warm.
+		_, _ = fmt.Fprintf(exec.CmdOut,
+			"warn: cold barrier UNVERIFIED — local disk %dMiB→%dMiB, under the %dMiB floor at which the drop is meaningful; treat this cold cell as unconfirmed\n",
+			before.LocalDiskUsed>>20, after.LocalDiskUsed>>20, dittofsColdBarrierFloorBytes>>20)
+		return nil
+	}
+	if after.LocalDiskUsed > before.LocalDiskUsed/5 {
 		return fmt.Errorf("cold barrier failed: local disk only fell %dMiB→%dMiB (want ≥80%% drop); the cold pass would measure locally-served reads, not S3",
 			before.LocalDiskUsed>>20, after.LocalDiskUsed>>20)
 	}
+	_, _ = fmt.Fprintf(exec.CmdOut, "cold barrier ok: local disk %dMiB→%dMiB\n",
+		before.LocalDiskUsed>>20, after.LocalDiskUsed>>20)
 	return nil
 }
 


### PR DESCRIPTION
Found while re-testing #1767 on a fresh VM.

The cold barrier drains, evicts, then asserts the local tier shed at least 80% of its resident bytes — but only when it started above a 64 MiB floor. Below that, the drop ratio is noise, so the assertion is skipped and the function returns nil.

Nothing is printed on that path. In the run log a barrier that verified nothing looks exactly like one that verified an evict, and the cold cell it precedes may have been served warm.

This is not hypothetical. `medium` is `1m` × 4 jobs — about 4 MiB, far under the floor. **Every medium cold cell we have ever published took the unverified path.**

## Change

- Under the floor: `warn: cold barrier UNVERIFIED — local disk NMiB→NMiB, under the 64MiB floor …`
- Above it and passing: `cold barrier ok: local disk NMiB→NMiB`

Both carry the numbers, so the log says which cold cells are trustworthy instead of leaving it to be inferred from silence. No change to what passes or fails — a cold cell that would have run still runs.

## Why not just fail under the floor

That would kill every small and medium cold cell outright. The measurement is still worth taking; it is the *labelling* that was wrong. Making the caveat visible is the smaller correct fix.

## Verification

Fresh SCW VM, `dittofs-s3-nfs3`, seq-read, runtime 30:

| size | warm | cold | DiskWr | NetRx | barrier |
|---|---|---|---|---|---|
| medium (4 MiB) | 667 MB/s | 22 MB/s | 0 | 7 MB/s | **skipped** — under floor |
| large (4 GiB) | 2143 MB/s | 22 MB/s | 40 MB/s | 41 MB/s | engaged, passed |

The large cold pass is genuinely cold on independent evidence: 41 MB/s off the network and 40 MB/s onto local disk while serving 22 MB/s to fio, against a warm pass that touched neither.

Separately, and worth recording on #1767: both failures in that issue reproduce as **fixed** on current develop. `drain-uploads` completed a 4 GiB working set inside its timeout (the ~9 MB/s ceiling was carve throughput, addressed by #1717/#1798), and the evict dropped the local tier past the 80% bar (#1780). I will close #1767 with the full-matrix evidence rather than on this PR.