### PR TITLE
fix(block): report upload progress per block, not per carve pass

### DIFF
--- a/pkg/block/engine/blocksink.go
+++ b/pkg/block/engine/blocksink.go
@@ -163,6 +163,12 @@ type engineBlockSink struct {
 	rbs         remote.RemoteBlockStore
 	committer   blockCommitter
 	commitLocks *carveCommitLocks
+	// onBlockCommitted reports each block as it lands, carrying the block's
+	// uploaded byte count. Reporting here rather than after a carve pass returns
+	// is what makes the count advance *during* a long carve: the drain path
+	// force-carves in one call that can run for many minutes, and its supervisor
+	// reads these counters as a liveness signal. Nil in fixtures that don't care.
+	onBlockCommitted func(bytes int64)
 }
 
 func (s engineBlockSink) CommitBlock(ctx context.Context, chunks []journal.CarveChunk) error {
@@ -251,6 +257,9 @@ func (s engineBlockSink) CommitBlock(ctx context.Context, chunks []journal.Carve
 	}
 	if err := commit(); err != nil {
 		return fmt.Errorf("carve: commit block %s: %w", blockID, err)
+	}
+	if s.onBlockCommitted != nil {
+		s.onBlockCommitted(int64(len(blockBytes)))
 	}
 	return nil
 }

--- a/pkg/block/engine/blocksink_test.go
+++ b/pkg/block/engine/blocksink_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"math/rand"
+	"sync"
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/block"
@@ -210,5 +211,54 @@ func TestJournalCarveSeam_CrashMidCommitReCarveIsNoOp(t *testing.T) {
 	}
 	if u := f2.jrnl.UnsyncedBytes(); u != 0 {
 		t.Fatalf("re-carve did not flip records: unsynced = %d", u)
+	}
+}
+
+// TestJournalCarveSeam_ReportsEachBlockAsItLands pins that the sink reports
+// every block at the moment it commits, rather than the pass reporting a total
+// once it returns. The drain force-carves in a single call that can run for
+// minutes, and its supervisor treats a flat count as a stalled upload — so a
+// count that only moves when the call returns gets a working drain aborted.
+func TestJournalCarveSeam_ReportsEachBlockAsItLands(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	mem := remotememory.New()
+
+	sink := realSink(ms, mem)
+	var (
+		mu       sync.Mutex
+		reported []int64 // one entry per block, in landing order
+	)
+	sink.onBlockCommitted = func(bytes int64) {
+		mu.Lock()
+		reported = append(reported, bytes)
+		mu.Unlock()
+	}
+	f := newSeamFixture(t, t.TempDir(), ms, mem, sink)
+
+	// Several times CarveBlockSize (1 MiB here) so one carve lands many blocks.
+	data := seamRandBytes(5<<20, 7)
+	if err := f.jrnl.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if _, err := f.jrnl.Carve(ctx, journal.CarveOptions{Force: true}); err != nil {
+		t.Fatalf("Carve: %v", err)
+	}
+
+	mu.Lock()
+	got := append([]int64(nil), reported...)
+	mu.Unlock()
+
+	if blocks := countBlocks(t, ctx, mem); len(got) != blocks {
+		t.Fatalf("reported %d blocks, remote holds %d — the report must fire once per block",
+			len(got), blocks)
+	}
+	if len(got) < 2 {
+		t.Fatalf("only %d block(s) landed; the fixture needs a multi-block carve to be meaningful", len(got))
+	}
+	for i, n := range got {
+		if n <= 0 {
+			t.Fatalf("block %d reported %d bytes, want > 0", i, n)
+		}
 	}
 }

--- a/pkg/block/engine/carve_dispatch.go
+++ b/pkg/block/engine/carve_dispatch.go
@@ -114,18 +114,13 @@ func (m *Syncer) carvePass(ctx context.Context) {
 			if m.uploadLimiter != nil {
 				defer m.uploadLimiter.Release()
 			}
-			res, err := m.local.Carve(ctx, journal.CarveOptions{FileID: journal.FileID(fileID)})
-			if err != nil {
+			// Success needs no bookkeeping here: the sink feeds the goodput sample
+			// and the completed-sync counter as each block lands, which keeps both
+			// advancing during a pass rather than only at its end.
+			if _, err := m.local.Carve(ctx, journal.CarveOptions{FileID: journal.FileID(fileID)}); err != nil {
 				m.uploadErrWindow.Add(1)
 				m.failedSyncs.Add(1)
 				logger.Warn("carve dispatcher: file carve failed", "file", fileID, "error", err)
-				return
-			}
-			if res.BytesCarved > 0 {
-				// Feed the adaptive-upload goodput sample and the lifetime
-				// completed-sync counter (blocks committed for this file).
-				m.uploadedBytesWindow.Add(res.BytesCarved)
-				m.completedSyncs.Add(int64(res.BlocksWritten))
 			}
 		}(id)
 	}

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -420,10 +420,20 @@ func (m *Syncer) dataplaneMetrics() DataplaneMetrics {
 	return nil
 }
 
-// SyncCounts returns lifetime (completed, failed) sync counts: chunks that
+// SyncCounts returns lifetime (completed, failed) sync counts: blocks that
 // reached remote and failed carve upload attempts.
 func (m *Syncer) SyncCounts() (completed, failed int) {
 	return int(m.completedSyncs.Load()), int(m.failedSyncs.Load())
+}
+
+// noteBlockCommitted records one block reaching the remote. Every carve routes
+// its commits through the same sink, so counting here covers both the
+// background dispatcher and the drain's force-carve — the latter runs as a
+// single call that can span minutes, and counting only on its return would
+// leave the progress signal flat for that whole time.
+func (m *Syncer) noteBlockCommitted(bytes int64) {
+	m.completedSyncs.Add(1)
+	m.uploadedBytesWindow.Add(bytes)
 }
 
 // DrainAllUploads performs an immediate synchronous upload of every local
@@ -783,7 +793,7 @@ func (m *Syncer) wireCarveTargets() {
 			return // remote configured but deps not fully wired yet
 		}
 		deduper := engineDeduper{synced: m.syncedHashStore}
-		sink := engineBlockSink{sealer: m.chunkSealer, rbs: m.remoteBlockStore, committer: m.blockCommitter, commitLocks: &carveCommitLocks{}}
+		sink := engineBlockSink{sealer: m.chunkSealer, rbs: m.remoteBlockStore, committer: m.blockCommitter, commitLocks: &carveCommitLocks{}, onBlockCommitted: m.noteBlockCommitted}
 		m.local.SetCarveTargets(deduper, sink)
 		m.carveTargetsWired = true
 		return


### PR DESCRIPTION
Closes #1873.

## The defect

`Store.DrainAllUploads` does its work with a direct `bs.local.Carve(ctx, CarveOptions{Force: true})`. The drain-uploads handler supervises that with an idle watchdog that aborts after `drain_stall_timeout` (default 5m) of flat `UploadProgress()`, which reads `completedSyncs` / `failedSyncs`.

Those counters were incremented in exactly one place: inside the syncer background dispatchers per-file goroutine, after its carve returned. The drain never goes through that goroutine, so for the entire duration of the force-carve — where a large drain spends all of its time — the progress signal was frozen by construction, and the watchdog aborted a drain that was working.

## The fix

Report each block from `engineBlockSink.CommitBlock` as it lands. That is the point both carve paths share, so the count advances during a pass instead of only at its end, and the post-pass bookkeeping in the dispatcher becomes duplicate and is dropped.

## Verified

Measured on a bench VM before the fix (`dittofs-s3-writeback`, sampling the store every 30s while a drain ran):

```
drain round 0: unsynced=1385MiB
drain round 0: unsynced=1383MiB
drain round 0: unsynced=1381MiB
drain round 0: unsynced=1379MiB
drain round 0: unsynced=1377MiB
drain round 0: unsynced=1375MiB
```

Unsynced fell on every sample and `ens2` TX held ~84 KiB/s throughout. The drain still died with `drain uploads stalled: no upload progress within 5m0s` — the exact error reported in #1767.

New test `TestJournalCarveSeam_ReportsEachBlockAsItLands` pins the contract that matters: the report fires once per block, matching the block count on the remote. Counting a total once per pass — the old behaviour — fails it. `go test -race ./pkg/block/...` green.

I have **not** yet re-measured the drain on hardware with this fix in place; that happens in the same rig run as #1872, and I will report the result rather than assume it.

## Note on two behaviour changes

- `uploadedBytesWindow` (adaptive-upload goodput sample) now receives the framed/sealed block size rather than raw carved bytes. That is what actually crosses the wire, so it should make the goodput signal more accurate, but it is a real change to that controllers input.
- `completedSyncs` totals are unchanged (previously the sum of `BlocksWritten` per pass, now +1 per block); only the timing moves earlier.

This fix alone does not make the writeback tiers cold-readable — #1872 is the other half.