### PR TITLE
Report what the drain observed, and assert a carve leaves nothing unsynced

### DIFF
--- a/internal/controlplane/api/handlers/system.go
+++ b/internal/controlplane/api/handlers/system.go
@@ -80,7 +80,7 @@ func NewSystemHandler(rt *runtime.Runtime, drainStallTimeout time.Duration) *Sys
 //     slow link a single chunk finishes well inside any sane idle window.
 //
 // What a trip actually means is narrower than "the remote is wedged": the
-// watchdog observes only that no block reached the remote for the window. A
+// watchdog observes only that no upload attempt concluded during the window. A
 // stuck carve, a stuck remote, and a drain that never had anything to do are
 // indistinguishable from here, so the 504 reports the observation and how much
 // landed before it, and leaves the diagnosis to the reader.
@@ -121,17 +121,19 @@ func (h *SystemHandler) DrainUploads(w http.ResponseWriter, r *http.Request) {
 	err, stalled := h.runWithIdleWatchdog(ctx, cancel)
 	if err != nil {
 		// Report what was observed, not what it implies. The watchdog knows only
-		// that the block count stopped moving; whether the remote is wedged, the
+		// that the attempt count stopped moving; whether the remote is wedged, the
 		// carve is stuck, or nothing was ever queued reads identically from here,
 		// and a message that picks one sends the reader after the wrong thing.
-		// How much did land, and over how long, is what narrows it.
-		committed := h.runtime.UploadProgress() - startProgress
+		// How much concluded, and over how long, is what narrows it. Note the
+		// count includes failed attempts — a retrying upload is activity, not
+		// progress towards durability, so this must not be called blocks stored.
+		attempts := h.runtime.UploadProgress() - startProgress
 		logger.Error("Drain uploads failed", "error", err, "duration", time.Since(start),
-			"stalled", stalled, "blocks_committed", committed)
+			"stalled", stalled, "upload_attempts_concluded", attempts)
 		if stalled {
 			GatewayTimeout(w, fmt.Sprintf(
-				"drain uploads: no block reached the remote for %s; %d committed over the preceding %s: %v",
-				h.drainStallTimeout, committed, time.Since(start).Round(time.Second), err))
+				"drain uploads: no upload attempt concluded for %s; %d concluded (including retries) over the preceding %s: %v",
+				h.drainStallTimeout, attempts, time.Since(start).Round(time.Second), err))
 		} else {
 			InternalServerError(w, "drain uploads failed: "+err.Error())
 		}

--- a/internal/controlplane/api/handlers/system.go
+++ b/internal/controlplane/api/handlers/system.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -76,8 +77,13 @@ func NewSystemHandler(rt *runtime.Runtime, drainStallTimeout time.Duration) *Sys
 //     This mirrors rclone's --timeout (an idle, progress-resetting timeout) and
 //     matches how juicefs/s3ql treat a forced flush — block until done, give up
 //     only on a genuine stall. CAS chunks are at most a few MiB, so even on a
-//     slow link a single chunk finishes well inside any sane idle window; only
-//     a truly wedged remote keeps progress flat long enough to trip it.
+//     slow link a single chunk finishes well inside any sane idle window.
+//
+// What a trip actually means is narrower than "the remote is wedged": the
+// watchdog observes only that no block reached the remote for the window. A
+// stuck carve, a stuck remote, and a drain that never had anything to do are
+// indistinguishable from here, so the 504 reports the observation and how much
+// landed before it, and leaves the diagnosis to the reader.
 //
 // A genuine client disconnect (request context Canceled, as opposed to the
 // deadline-exceeded fired by middleware.Timeout) still aborts the drain.
@@ -110,13 +116,22 @@ func (h *SystemHandler) DrainUploads(w http.ResponseWriter, r *http.Request) {
 
 	logger.Info("Drain uploads requested", "idle_timeout", h.drainStallTimeout)
 	start := time.Now()
+	startProgress := h.runtime.UploadProgress()
 
 	err, stalled := h.runWithIdleWatchdog(ctx, cancel)
 	if err != nil {
-		logger.Error("Drain uploads failed", "error", err, "duration", time.Since(start), "stalled", stalled)
+		// Report what was observed, not what it implies. The watchdog knows only
+		// that the block count stopped moving; whether the remote is wedged, the
+		// carve is stuck, or nothing was ever queued reads identically from here,
+		// and a message that picks one sends the reader after the wrong thing.
+		// How much did land, and over how long, is what narrows it.
+		committed := h.runtime.UploadProgress() - startProgress
+		logger.Error("Drain uploads failed", "error", err, "duration", time.Since(start),
+			"stalled", stalled, "blocks_committed", committed)
 		if stalled {
-			GatewayTimeout(w, "drain uploads stalled: no upload progress within "+
-				h.drainStallTimeout.String()+": "+err.Error())
+			GatewayTimeout(w, fmt.Sprintf(
+				"drain uploads: no block reached the remote for %s; %d committed over the preceding %s: %v",
+				h.drainStallTimeout, committed, time.Since(start).Round(time.Second), err))
 		} else {
 			InternalServerError(w, "drain uploads failed: "+err.Error())
 		}

--- a/pkg/block/engine/blocksink_test.go
+++ b/pkg/block/engine/blocksink_test.go
@@ -262,3 +262,64 @@ func TestJournalCarveSeam_ReportsEachBlockAsItLands(t *testing.T) {
 		}
 	}
 }
+
+// TestJournalCarveSeam_ScatteredRunsAllFlipSynced pins the contract that matters
+// most about a carve: when it returns, every range it covered is marked synced.
+//
+// The shape is what makes it bite — many small, non-contiguous, mutually novel
+// runs against a block size several of them fit inside, so blocks straddle run
+// boundaries and watermarks have to advance across them. A carve can commit
+// every block and still fail to advance the durable frontier, which leaves the
+// records dirty so the next carve re-carves the same ranges, uploading forever
+// without ever converging. Byte counts and block counts both look healthy while
+// that happens; only the synced state shows it.
+func TestJournalCarveSeam_ScatteredRunsAllFlipSynced(t *testing.T) {
+	const (
+		runs      = 400
+		runSize   = 4 << 10
+		gap       = 8 << 10  // stride > runSize keeps every run non-contiguous
+		blockSize = 64 << 10 // several runs per block, so blocks straddle them
+	)
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	mem := remotememory.New()
+
+	j, err := journal.Open(t.TempDir(),
+		journal.Config{CarveBlockSize: blockSize, CarveUploadConcurrency: 4},
+		stubJournalRemote{}, journal.SystemClock())
+	if err != nil {
+		t.Fatalf("journal.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = j.Close() })
+	j.SetCarveTargets(engineDeduper{synced: ms}, realSink(ms, mem))
+
+	// Distinct bytes per run, so nearly every chunk is novel and the carve has to
+	// pack and commit for real rather than dedup its way to the end.
+	for i := 0; i < runs; i++ {
+		if err := j.WriteAt(ctx, "f", int64(i)*gap, seamRandBytes(runSize, int64(i)+1)); err != nil {
+			t.Fatalf("WriteAt %d: %v", i, err)
+		}
+	}
+	want := int64(runs * runSize)
+	if got := j.UnsyncedBytes(); got != want {
+		t.Fatalf("pre-carve unsynced = %d, want %d", got, want)
+	}
+
+	if _, err := j.Carve(ctx, journal.CarveOptions{Force: true}); err != nil {
+		t.Fatalf("Carve: %v", err)
+	}
+
+	if got := j.UnsyncedBytes(); got != 0 {
+		t.Fatalf("post-carve unsynced = %d of %d, want 0 — ranges the carve covered were "+
+			"not flipped synced, so the next carve re-carves them and a drain never converges",
+			got, want)
+	}
+	// A second forced carve must find nothing left to do.
+	res, err := j.Carve(ctx, journal.CarveOptions{Force: true})
+	if err != nil {
+		t.Fatalf("second Carve: %v", err)
+	}
+	if res.BytesCarved != 0 {
+		t.Fatalf("second carve moved %d bytes, want 0 — the first carve left ranges dirty", res.BytesCarved)
+	}
+}


### PR DESCRIPTION
Two small changes, both from the same lesson out of #1767: a diagnostic that named a cause it could not observe, and a test suite that measured the wrong property.

## 1. The 504 named a cause it does not know

`drain uploads stalled: no upload progress within 5m0s` reads as "the uploader is stuck". The watchdog knows only that no block reached the remote for the window — a stuck carve, a stuck remote, and a drain with nothing queued all reach it identically.

This cost real time. #1767 was filed as "the async uploader appears stuck" on the strength of that wording, and it was never true: the uploader was working and its supervisor could not see it (#1873, fixed in #1874). I then spent a while chasing upload throughput because I believed the message.

Now it reports the observation and how much landed first:

```
drain uploads: no block reached the remote for 5m0s; 3182 committed over the preceding 12m4s: ...
```

`0 committed` and `3182 committed` point at completely different problems, and the message no longer picks one for you. The doc comment made the same over-claim ("only a truly wedged remote keeps progress flat long enough to trip it") and is corrected too.

## 2. Assert the synced state, not the byte count

The carve tests assert bytes moved and blocks written. Both look healthy when a carve commits every block and still fails to advance the durable frontier — which leaves records dirty, so the next carve re-carves the same ranges and a drain never converges. `TestJournalCarveSeam_ScatteredRunsAllFlipSynced` drives the production sink and dedup oracle with many small non-contiguous runs against a block size several of them fit inside, then asserts `UnsyncedBytes() == 0` and that a second forced carve moves nothing.

**Honest limit on this test.** It does **not** reproduce the regression in the draft #1875, which I confirmed by running it against that branch — it passes there. I tried two shapes (32 x 64 KiB dedup-heavy, then 400 x 4 KiB mutually novel across straddling blocks) and neither wedges in-process with the memory metadata store and memory remote. Whatever #1875 hits needs the production environment. So this is a useful invariant to hold, not a guard against that specific bug, and I would rather say so than let it look like one.

`go test ./pkg/block/engine ./pkg/block/journal` and the handler suite are green.