### PR TITLE
fix(block): refuse a manifest row that cannot be placed, instead of reading it as a hole

### DIFF
--- a/pkg/block/engine/manifest_inconsistent_test.go
+++ b/pkg/block/engine/manifest_inconsistent_test.go
@@ -45,6 +45,24 @@ func TestFindRowCoveringOffset_AbsentRowIsStillAHole(t *testing.T) {
 	}
 }
 
+// An unplaceable row must not cost the reader the rest of the file. Offsets some
+// other row covers still resolve, so a payload with one damaged range stays
+// readable everywhere else.
+func TestFindRowCoveringOffset_UnplaceableRowDoesNotPoisonCoveredOffsets(t *testing.T) {
+	rows := []*block.FileChunk{
+		{ID: "payload-1", DataSize: 4096},         // unplaceable
+		{ID: "payload-1/4096", DataSize: 1 << 20}, // covers 4096..1052672
+	}
+
+	rw, err := findRowCoveringOffset(rows, 8192)
+	if err != nil {
+		t.Fatalf("unexpected error for a covered offset: %v", err)
+	}
+	if rw == nil || rw.absOffset != 4096 {
+		t.Fatalf("rw = %+v, want the row starting at 4096", rw)
+	}
+}
+
 func TestFindRowCoveringOffset_WellFormedRowResolves(t *testing.T) {
 	rows := []*block.FileChunk{
 		{ID: "payload-1/0", DataSize: 4096},

--- a/pkg/block/engine/manifest_inconsistent_test.go
+++ b/pkg/block/engine/manifest_inconsistent_test.go
@@ -1,0 +1,64 @@
+package engine
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+// A manifest row whose ID carries no parseable offset cannot be placed in the
+// file. The bytes it points at are still in the store, so reporting the range as
+// a hole would hand the caller zeros for data that exists — the failure a reader
+// cannot detect, because a zero-filled hole is a legitimate answer for a sparse
+// file and arrives without an error to distinguish it.
+func TestFindRowCoveringOffset_MalformedIDIsNotAHole(t *testing.T) {
+	rows := []*block.FileChunk{
+		{ID: "payload-1", DataSize: 4096},         // no "/offset" suffix
+		{ID: "payload-1/4096", DataSize: 1 << 20}, // well-formed, covers past 4096
+	}
+
+	rw, err := findRowCoveringOffset(rows, 0)
+	if err == nil {
+		t.Fatalf("offset 0 returned rw=%v err=nil; an unplaceable row must not read back as a hole", rw)
+	}
+	if !errors.Is(err, block.ErrManifestInconsistent) {
+		t.Fatalf("err = %v, want it to wrap ErrManifestInconsistent", err)
+	}
+}
+
+// The absence of a row is the real representation of a hole, and stays one: a
+// sparse file must keep reading back as zeros rather than becoming an error.
+func TestFindRowCoveringOffset_AbsentRowIsStillAHole(t *testing.T) {
+	rows := []*block.FileChunk{
+		{ID: "payload-1/0", DataSize: 4096},
+		// nothing covers [4096, 8192)
+		{ID: "payload-1/8192", DataSize: 4096},
+	}
+
+	rw, err := findRowCoveringOffset(rows, 5000)
+	if err != nil {
+		t.Fatalf("unexpected error for a genuine hole: %v", err)
+	}
+	if rw != nil {
+		t.Fatalf("rw = %+v, want nil — no row covers offset 5000", rw)
+	}
+}
+
+func TestFindRowCoveringOffset_WellFormedRowResolves(t *testing.T) {
+	rows := []*block.FileChunk{
+		{ID: "payload-1/0", DataSize: 4096},
+		{ID: "payload-1/4096", DataSize: 1 << 20},
+	}
+
+	rw, err := findRowCoveringOffset(rows, 4096)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rw == nil {
+		t.Fatal("rw = nil, want the row starting at 4096")
+	}
+	if rw.absOffset != 4096 {
+		t.Fatalf("absOffset = %d, want 4096", rw.absOffset)
+	}
+}

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -102,20 +102,27 @@ type rowWithOffset struct {
 // in rows covers it. The walk is O(N) over the per-payload row
 // list — acceptable for the FastCDC steady-state (chunks average ~4 MiB
 // so even a 4 GiB file produces ~1000 rows).
-func findRowCoveringOffset(rows []*block.FileChunk, target uint64) *rowWithOffset {
+//
+// A row whose ID does not parse is reported as an error rather than skipped.
+// Absence of a row means a hole, which the caller zero-fills; a row that exists
+// but cannot be placed means the manifest disagrees with itself, and silently
+// passing it over would render the bytes it points at as zeros with no error
+// anywhere — data the store still holds, reported to the caller as data the file
+// never had.
+func findRowCoveringOffset(rows []*block.FileChunk, target uint64) (*rowWithOffset, error) {
 	for _, fb := range rows {
 		if fb == nil {
 			continue
 		}
 		abs, ok := block.ParseChunkOffset(fb.ID)
 		if !ok {
-			continue
+			return nil, fmt.Errorf("%w: malformed FileChunk ID %q", block.ErrManifestInconsistent, fb.ID)
 		}
 		if target >= abs && target < abs+uint64(fb.DataSize) {
-			return &rowWithOffset{fb: fb, absOffset: abs}
+			return &rowWithOffset{fb: fb, absOffset: abs}, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 // chunkAtOffsetResolver is the indexed covering-chunk lookup, implemented only
@@ -142,7 +149,7 @@ func resolveCovering(ctx context.Context, store block.EngineFileChunkStore, payl
 		}
 		abs, ok := block.ParseChunkOffset(fb.ID)
 		if !ok {
-			return nil, 0, fmt.Errorf("resolveCovering: malformed FileChunk ID %q", fb.ID)
+			return nil, 0, fmt.Errorf("%w: malformed FileChunk ID %q", block.ErrManifestInconsistent, fb.ID)
 		}
 		return fb, abs, nil
 	}
@@ -153,7 +160,10 @@ func resolveCovering(ctx context.Context, store block.EngineFileChunkStore, payl
 		}
 		return nil, 0, err
 	}
-	rw := findRowCoveringOffset(rows, off)
+	rw, err := findRowCoveringOffset(rows, off)
+	if err != nil {
+		return nil, 0, err
+	}
 	if rw == nil {
 		return nil, 0, nil
 	}

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -103,24 +103,37 @@ type rowWithOffset struct {
 // list — acceptable for the FastCDC steady-state (chunks average ~4 MiB
 // so even a 4 GiB file produces ~1000 rows).
 //
-// A row whose ID does not parse is reported as an error rather than skipped.
-// Absence of a row means a hole, which the caller zero-fills; a row that exists
-// but cannot be placed means the manifest disagrees with itself, and silently
-// passing it over would render the bytes it points at as zeros with no error
-// anywhere — data the store still holds, reported to the caller as data the file
-// never had.
+// A row whose ID does not parse cannot be placed, so its range is unknown. That
+// is only fatal to reads it might have covered: if some other row covers target,
+// that answer is unaffected and is returned. Only when nothing covers target does
+// the unplaceable row matter, because then the choice is between reporting a hole
+// — which the caller zero-fills, inventing data the file may never have had — and
+// admitting the manifest is inconsistent. It admits.
+//
+// Scoping it this way keeps one bad row from making a whole payload unreadable.
+// The alternative, refusing the moment such a row is seen at any offset, would
+// take a file that reads correctly apart from one damaged range and make all of
+// it unavailable.
 func findRowCoveringOffset(rows []*block.FileChunk, target uint64) (*rowWithOffset, error) {
+	unplaceable := ""
 	for _, fb := range rows {
 		if fb == nil {
 			continue
 		}
 		abs, ok := block.ParseChunkOffset(fb.ID)
 		if !ok {
-			return nil, fmt.Errorf("%w: malformed FileChunk ID %q", block.ErrManifestInconsistent, fb.ID)
+			if unplaceable == "" {
+				unplaceable = fb.ID
+			}
+			continue
 		}
 		if target >= abs && target < abs+uint64(fb.DataSize) {
 			return &rowWithOffset{fb: fb, absOffset: abs}, nil
 		}
+	}
+	if unplaceable != "" {
+		return nil, fmt.Errorf("%w: nothing covers offset %d and manifest holds unplaceable row %q",
+			block.ErrManifestInconsistent, target, unplaceable)
 	}
 	return nil, nil
 }

--- a/pkg/block/errors.go
+++ b/pkg/block/errors.go
@@ -169,6 +169,15 @@ var (
 	// discarded and this error surfaces — bad bytes never reach the caller.
 	ErrChunkContentMismatch = errors.New("blockstore: chunk content hash mismatch")
 
+	// ErrManifestInconsistent is returned when a payload's manifest holds a row
+	// that cannot be placed in the file — today, a FileChunk ID that does not
+	// carry a parseable "<payloadID>/<offset>". It is deliberately not treated as
+	// a hole: a hole is the *absence* of a row and reads back as zeros by design,
+	// so passing over an unplaceable row would serve zeros for a range the store
+	// still holds bytes for, with nothing logged and no error returned. Reads
+	// refuse instead, which turns silent corruption into a diagnosable one.
+	ErrManifestInconsistent = errors.New("blockstore: file manifest inconsistent")
+
 	// ErrChunkRefMissing is returned by engine.ReadAt when a ChunkRef.Hash
 	// refers to a FileChunk that has been GC'd or never existed. The
 	// adapter layer (internal/adapter/common/errmap.go) maps this to

--- a/pkg/controlplane/runtime/shares/legacy_verify.go
+++ b/pkg/controlplane/runtime/shares/legacy_verify.go
@@ -57,10 +57,11 @@ type coldSeedReport struct {
 	// deleted while this is non-zero.
 	unsynced int
 
-	// unplaceable counts manifest rows whose ID carries no parseable offset, so
-	// the range they describe could not be seeded. Reads of those ranges refuse
-	// rather than zero-fill, but the archive still holds the only placeable copy,
-	// so this is reported alongside unsynced when deciding whether to reap.
+	// unplaceable counts manifest rows whose ID carries no parseable offset. Which
+	// bytes they describe is not recoverable from the row, so nothing could be
+	// seeded for them and no later read can serve them. The archive may hold the
+	// only copy that is still placeable, so this is weighed alongside unsynced
+	// when deciding whether to reap.
 	unplaceable int
 
 	// samples are extents to read back, capped at coldVerifySamples.

--- a/pkg/controlplane/runtime/shares/legacy_verify.go
+++ b/pkg/controlplane/runtime/shares/legacy_verify.go
@@ -57,6 +57,12 @@ type coldSeedReport struct {
 	// deleted while this is non-zero.
 	unsynced int
 
+	// unplaceable counts manifest rows whose ID carries no parseable offset, so
+	// the range they describe could not be seeded. Reads of those ranges refuse
+	// rather than zero-fill, but the archive still holds the only placeable copy,
+	// so this is reported alongside unsynced when deciding whether to reap.
+	unplaceable int
+
 	// samples are extents to read back, capped at coldVerifySamples.
 	samples []coldSample
 }
@@ -136,11 +142,12 @@ func finishLegacyArchiveMigration(
 			"so refusing to serve zeros — restore the archive or investigate before retrying",
 			shareName, verr, archives)
 	}
-	if report.unsynced > 0 {
-		logger.Warn("migrated pre-journal local layout and verified a sample, but some chunks never reached the remote; "+
-			"keeping the archived blobs/+logs/ because those bytes exist nowhere else",
+	if report.unsynced > 0 || report.unplaceable > 0 {
+		logger.Warn("migrated pre-journal local layout and verified a sample, but some chunks are not accounted for; "+
+			"keeping the archived blobs/+logs/ because those bytes may exist nowhere else",
 			"share", shareName, "payloads", report.payloads, "chunks", report.chunks,
-			"chunks_not_remote", report.unsynced, "archive", archives)
+			"chunks_not_remote", report.unsynced, "chunks_unplaceable", report.unplaceable,
+			"archive", archives)
 		return nil
 	}
 	freed := archiveBytes(archives)

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -3131,6 +3131,16 @@ func SeedColdFromManifest(ctx context.Context, bs *engine.Store, metaStore metad
 			}
 			off, ok := block.ParseChunkOffset(row.ID)
 			if !ok {
+				// Report rather than pass over in silence: the range this row
+				// describes will not be seeded, and an unseeded range is
+				// indistinguishable from a hole on later reads. Seeding continues
+				// and the boot is not failed — one unplaceable row in a large store
+				// is not worth stranding every other share, and reads of this range
+				// now refuse with ErrManifestInconsistent instead of serving zeros,
+				// so the damage announces itself at the point it is touched.
+				logger.Error("cold seed: unplaceable manifest row, range will not be seeded",
+					"payload", payloadID, "row", row.ID, "size", row.DataSize)
+				report.unplaceable++
 				continue
 			}
 			extents = append(extents, [2]int64{int64(off), int64(row.DataSize)})

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -3131,13 +3131,13 @@ func SeedColdFromManifest(ctx context.Context, bs *engine.Store, metaStore metad
 			}
 			off, ok := block.ParseChunkOffset(row.ID)
 			if !ok {
-				// Report rather than pass over in silence: the range this row
-				// describes will not be seeded, and an unseeded range is
-				// indistinguishable from a hole on later reads. Seeding continues
-				// and the boot is not failed — one unplaceable row in a large store
-				// is not worth stranding every other share, and reads of this range
-				// now refuse with ErrManifestInconsistent instead of serving zeros,
-				// so the damage announces itself at the point it is touched.
+				// Report rather than pass over in silence. Which range this row
+				// describes cannot be recovered — that is what makes it unplaceable
+				// — so the row is logged verbatim and seeding continues. The boot is
+				// not failed: one such row in a large store is not worth stranding
+				// every other share. A later read that finds nothing covering the
+				// offset it wants, on a payload holding a row like this, refuses with
+				// ErrManifestInconsistent rather than serving zeros.
 				logger.Error("cold seed: unplaceable manifest row, range will not be seeded",
 					"payload", payloadID, "row", row.ID, "size", row.DataSize)
 				report.unplaceable++


### PR DESCRIPTION
Found while investigating #1879 (a user reporting the leading 4 KiB of several files silently zeroed at rest). This does **not** claim to be the root cause of that report — it fixes the mechanism that would make such damage silent, which is a defect on its own terms.

## The defect

`findRowCoveringOffset` skipped any `FileChunk` row whose ID carried no parseable `<payloadID>/<offset>`. With that row skipped, nothing covered its range, the read path concluded there was a hole, and zero-filled it. Bytes the store still holds are handed to the caller as bytes the file never had — no error, nothing logged, and a stable checksum on re-read, so it reads as legitimate data rather than as a fault.

The indexed badger lookup in `resolveCovering` already treated the identical row as a hard error. So the same corrupt manifest was loud on badger and silent zeros on sqlite, postgres and memory. One of those was wrong.

## The distinction being drawn

A hole is the **absence** of a row, and must keep reading back as zeros — sparse files depend on it. A row that **exists but cannot be placed** is the manifest disagreeing with itself, and there is no correct number of bytes to invent for it. Both paths now return `ErrManifestInconsistent`.

## Cold seeding

`SeedColdFromManifest` dropped the same rows with a bare `continue`, which is worse than it looks: an unseeded range is indistinguishable from a hole on every subsequent read, permanently.

It now logs each one at Error with payload, row and size, and counts it. Deliberately **not** fatal — one unplaceable row in a large store should not stop every share on the box from starting, and reads of that range now refuse on their own, so the damage announces itself when touched rather than at boot.

The new count also gates archive reaping alongside `unsynced`: if any row could not be placed, the pre-journal `blobs/+logs/` archive stays, because those bytes may exist nowhere else. Reaping it would destroy the recovery path for exactly the situation this is about.

## Tests

`pkg/block/engine/manifest_inconsistent_test.go` pins all three cases: an unplaceable row errors rather than reading as a hole, a genuinely absent row still reads as a hole, and a well-formed row still resolves.

`go build ./...`, `go vet ./pkg/...`, `gofmt` clean, and `go test -race` green on `pkg/block/...` and `pkg/controlplane/runtime/shares/...`.

## What this does not do

It does not explain why a row would be unplaceable in the first place, or why #1879's damage lands on exactly the first 4 KiB. That investigation is still open and needs a manifest dump from the affected box.