### PR TITLE
fix(metadata): clear and reseed the quota cache on Reset and RestoreSnapshot

### DIFF
--- a/pkg/metadata/store/badger/reset.go
+++ b/pkg/metadata/store/badger/reset.go
@@ -21,5 +21,9 @@ func (s *BadgerMetadataStore) Reset(ctx context.Context) error {
 	if err := s.db.DropAll(); err != nil {
 		return fmt.Errorf("badger reset: drop all: %w", err)
 	}
+	s.usedBytes.Store(0)
+	s.quotaMu.Lock()
+	s.quota.Reset()
+	s.quotaMu.Unlock()
 	return nil
 }

--- a/pkg/metadata/store/memory/reset.go
+++ b/pkg/metadata/store/memory/reset.go
@@ -44,6 +44,10 @@ func (s *MemoryMetadataStore) Reset(ctx context.Context) error {
 
 	s.usedBytes.Store(0)
 
+	s.quotaMu.Lock()
+	s.quota.Reset()
+	s.quotaMu.Unlock()
+
 	s.syncedMu.Lock()
 	s.synced = make(map[block.ContentHash]time.Time)
 	s.syncedLocators = nil // clear block locators together with synced markers

--- a/pkg/metadata/store/memory/snapshot_store.go
+++ b/pkg/metadata/store/memory/snapshot_store.go
@@ -408,15 +408,41 @@ func (s *MemoryMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 
 	// Re-initialize transient state.
 	s.sessions = make(map[string]*ShareSession)
+	gUID := make(map[uint32]*metadata.UsageStat)
+	uUID := make(map[uint32]*metadata.UsageStat)
 
-	// Recompute usedBytes from files (only regular files count).
+	// Recompute usedBytes from files (only regular files count)
+	// and reconstruct the quota cache from the restored files
+	// since UNIX/NFS stores based on user and groupd, we need to aggregate the usage stats for each user and group.
 	var totalBytes int64
 	for _, fd := range s.files {
 		if fd.Attr != nil && fd.Attr.Type == metadata.FileTypeRegular {
 			totalBytes += int64(fd.Attr.Size)
+
+			u := uUID[fd.Attr.UID]
+			if u == nil {
+				u = &metadata.UsageStat{}
+				uUID[fd.Attr.UID] = u
+			}
+
+			u.Bytes += int64(fd.Attr.Size)
+			u.Files++
+
+			g := gUID[fd.Attr.GID]
+			if g == nil {
+				g = &metadata.UsageStat{}
+				gUID[fd.Attr.GID] = g
+			}
+
+			g.Bytes += int64(fd.Attr.Size)
+			g.Files++
 		}
 	}
 	s.usedBytes.Store(totalBytes)
+
+	s.quotaMu.Lock()
+	s.quota.Seed(uUID, gUID)
+	s.quotaMu.Unlock()
 
 	return nil
 }

--- a/pkg/metadata/store/memory/snapshot_store.go
+++ b/pkg/metadata/store/memory/snapshot_store.go
@@ -408,30 +408,30 @@ func (s *MemoryMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 
 	// Re-initialize transient state.
 	s.sessions = make(map[string]*ShareSession)
-	gUID := make(map[uint32]*metadata.UsageStat)
-	uUID := make(map[uint32]*metadata.UsageStat)
+	groupUsage := make(map[uint32]*metadata.UsageStat)
+	userUsage := make(map[uint32]*metadata.UsageStat)
 
 	// Recompute usedBytes from files (only regular files count)
 	// and reconstruct the quota cache from the restored files
-	// since UNIX/NFS stores based on user and groupd, we need to aggregate the usage stats for each user and group.
+	// since UNIX/NFS stores based on user and group, we need to aggregate the usage stats for each user and group.
 	var totalBytes int64
 	for _, fd := range s.files {
 		if fd.Attr != nil && fd.Attr.Type == metadata.FileTypeRegular {
 			totalBytes += int64(fd.Attr.Size)
 
-			u := uUID[fd.Attr.UID]
+			u := userUsage[fd.Attr.UID]
 			if u == nil {
 				u = &metadata.UsageStat{}
-				uUID[fd.Attr.UID] = u
+				userUsage[fd.Attr.UID] = u
 			}
 
 			u.Bytes += int64(fd.Attr.Size)
 			u.Files++
 
-			g := gUID[fd.Attr.GID]
+			g := groupUsage[fd.Attr.GID]
 			if g == nil {
 				g = &metadata.UsageStat{}
-				gUID[fd.Attr.GID] = g
+				groupUsage[fd.Attr.GID] = g
 			}
 
 			g.Bytes += int64(fd.Attr.Size)
@@ -441,7 +441,7 @@ func (s *MemoryMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 	s.usedBytes.Store(totalBytes)
 
 	s.quotaMu.Lock()
-	s.quota.Seed(uUID, gUID)
+	s.quota.Seed(userUsage, groupUsage)
 	s.quotaMu.Unlock()
 
 	return nil

--- a/pkg/metadata/store/postgres/reset.go
+++ b/pkg/metadata/store/postgres/reset.go
@@ -45,6 +45,9 @@ func (s *PostgresMetadataStore) Reset(ctx context.Context) error {
 	if _, err := pgRaw.Exec(ctx, "COMMIT").ReadAll(); err != nil {
 		return fmt.Errorf("reset: commit: %w", err)
 	}
-
+	s.usedBytes.Store(0)
+	s.quotaMu.Lock()
+	s.quota.Reset()
+	s.quotaMu.Unlock()
 	return nil
 }

--- a/pkg/metadata/storetest/reset_conformance.go
+++ b/pkg/metadata/storetest/reset_conformance.go
@@ -53,6 +53,13 @@ func ResetThenRestoreConformance(t *testing.T, factory SnapshotableStoreFactory)
 		t.Fatalf("Reset: %v", err)
 	}
 
+	// Quota assertion: Reset must clear the per-identity cache, not just the
+	// share/file maps a stale cache here silently keeps enforcing limits
+	// against data that no longer exists.
+	if u, err := store.GetQuotaUsage(metadata.QuotaScopeUser, 1000); err != nil || u.Bytes != 0 || u.Files != 0 {
+		t.Fatalf("post-Reset GetQuotaUsage(user, 1000) = %+v, err=%v, want zero", u, err)
+	}
+
 	// 3. Empty assertion: ListShares returns zero entries post-Reset.
 	shares, err := store.ListShares(ctx)
 	if err != nil {
@@ -67,6 +74,13 @@ func ResetThenRestoreConformance(t *testing.T, factory SnapshotableStoreFactory)
 	//    ErrRestoreDestinationNotEmpty precondition so Restore must succeed.
 	if err := b.RestoreSnapshot(ctx, &dumpBuf); err != nil {
 		t.Fatalf("Restore post-Reset: %v", err)
+	}
+
+	// Quota assertion: Restore must reseed the cache from the restored files,
+	// not leave it at the post-Reset zero state.
+	const wantBytes = int64((8 << 20) + (6 << 20)) // 14 MiB total
+	if u, err := store.GetQuotaUsage(metadata.QuotaScopeUser, 1000); err != nil || u.Bytes != wantBytes || u.Files != 2 {
+		t.Fatalf("post-Restore GetQuotaUsage(user, 1000) = %+v, err=%v, want {Bytes:%d Files:2}", u, err, wantBytes)
 	}
 
 	// 5. Verify shares + representative file survived round-trip.

--- a/pkg/metadata/storetest/reset_conformance.go
+++ b/pkg/metadata/storetest/reset_conformance.go
@@ -54,8 +54,8 @@ func ResetThenRestoreConformance(t *testing.T, factory SnapshotableStoreFactory)
 	}
 
 	// Quota assertion: Reset must clear the per-identity cache, not just the
-	// share/file maps a stale cache here silently keeps enforcing limits
-	// against data that no longer exists.
+	// share/file maps. A stale cache here would silently keep enforcing
+	// limits against data that no longer exists.
 	if u, err := store.GetQuotaUsage(metadata.QuotaScopeUser, 1000); err != nil || u.Bytes != 0 || u.Files != 0 {
 		t.Fatalf("post-Reset GetQuotaUsage(user, 1000) = %+v, err=%v, want zero", u, err)
 	}
@@ -78,7 +78,7 @@ func ResetThenRestoreConformance(t *testing.T, factory SnapshotableStoreFactory)
 
 	// Quota assertion: Restore must reseed the cache from the restored files,
 	// not leave it at the post-Reset zero state.
-	const wantBytes = int64((8 << 20) + (6 << 20)) // 14 MiB total
+	const wantBytes = PopulateTestDataUsedBytes // 14 MiB total
 	if u, err := store.GetQuotaUsage(metadata.QuotaScopeUser, 1000); err != nil || u.Bytes != wantBytes || u.Files != 2 {
 		t.Fatalf("post-Restore GetQuotaUsage(user, 1000) = %+v, err=%v, want {Bytes:%d Files:2}", u, err, wantBytes)
 	}

--- a/pkg/metadata/storetest/snapshot_conformance.go
+++ b/pkg/metadata/storetest/snapshot_conformance.go
@@ -96,7 +96,7 @@ func testSnapshot_UsedBytesAfterRestore(t *testing.T, factory SnapshotableStoreF
 
 	// populateTestData writes two regular files of 8 MiB and 6 MiB.
 	populateTestData(t, srcStore, "ub")
-	const wantBytes = int64((8 << 20) + (6 << 20))
+	const wantBytes = PopulateTestDataUsedBytes
 
 	if got := srcStore.GetUsedBytes(); got != wantBytes {
 		t.Fatalf("source GetUsedBytes() = %d, want %d (fixture sanity)", got, wantBytes)
@@ -266,6 +266,13 @@ func asSnapshotable(t *testing.T, store metadata.Store) metadata.Snapshotable {
 	}
 	return b
 }
+
+// PopulateTestDataUsedBytes is the total logical size (8 MiB + 6 MiB) of the
+// two regular files populateTestData creates, the single source of truth
+// for assertions that depend on that fixture's size, so a future change to
+// the fixture can't silently leave a stale assertion passing for the wrong
+// reason.
+const PopulateTestDataUsedBytes = int64((8 << 20) + (6 << 20))
 
 // populateTestData creates a share with two files carrying ChunkRef hashes.
 // Returns the share name and the list of unique hashes used.
@@ -880,7 +887,7 @@ func testSnapshot_QuotaUsageAfterRestore(t *testing.T, factory SnapshotableStore
 	ctx := t.Context()
 
 	populateTestData(t, srcStore, "qb")
-	const wantBytes = int64((8 << 20) + (6 << 20)) // 14 MiB
+	const wantBytes = PopulateTestDataUsedBytes // 14 MiB
 	const wantFiles = int64(2)
 
 	var buf bytes.Buffer

--- a/pkg/metadata/storetest/snapshot_conformance.go
+++ b/pkg/metadata/storetest/snapshot_conformance.go
@@ -76,6 +76,10 @@ func RunSnapshotConformanceSuite(t *testing.T, factory SnapshotableStoreFactory)
 	t.Run("UsedBytesAfterRestore", func(t *testing.T) {
 		testSnapshot_UsedBytesAfterRestore(t, factory)
 	})
+
+	t.Run("QuotaUsageAfterRestore", func(t *testing.T) {
+		testSnapshot_QuotaUsageAfterRestore(t, factory)
+	})
 }
 
 // testSnapshot_UsedBytesAfterRestore pins the quota-counter invariant: after
@@ -860,5 +864,44 @@ func testSnapshot_HashSet_Dedup(t *testing.T, factory SnapshotableStoreFactory) 
 	}
 	if !gotHS.Contains(sharedHash) {
 		t.Fatalf("HashSet does not contain the shared hash %x", sharedHash[:8])
+	}
+}
+
+// testSnapshot_QuotaUsageAfterRestore pins the same invariant as
+// UsedBytesAfterRestore, but for the per-identity quota cache: after Restore,
+// GetQuotaUsage for the fixture's owner (uid/gid 1000) MUST reflect the
+// restored files, not a stale or zeroed cache. A backend that recomputes
+// usedBytes but not quota (or that Resets the quota cache instead of
+// reseeding it) passes UsedBytesAfterRestore while silently disabling
+// per-identity quota enforcement this test catches that divergence.
+func testSnapshot_QuotaUsageAfterRestore(t *testing.T, factory SnapshotableStoreFactory) {
+	srcStore := factory(t)
+	srcB := asSnapshotable(t, srcStore)
+	ctx := t.Context()
+
+	populateTestData(t, srcStore, "qb")
+	const wantBytes = int64((8 << 20) + (6 << 20)) // 14 MiB
+	const wantFiles = int64(2)
+
+	var buf bytes.Buffer
+	if _, err := srcB.WriteSnapshot(ctx, &buf); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	dstStore := factory(t)
+	dstB := asSnapshotable(t, dstStore)
+	if err := dstB.RestoreSnapshot(ctx, &buf); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	for _, scope := range []metadata.QuotaScope{metadata.QuotaScopeUser, metadata.QuotaScopeGroup} {
+		got, err := dstStore.GetQuotaUsage(scope, 1000)
+		if err != nil {
+			t.Fatalf("GetQuotaUsage(%v, 1000): %v", scope, err)
+		}
+		if got.Bytes != wantBytes || got.Files != wantFiles {
+			t.Fatalf("restored GetQuotaUsage(%v, 1000) = %+v, want {Bytes:%d Files:%d}",
+				scope, got, wantBytes, wantFiles)
+		}
 	}
 }


### PR DESCRIPTION
# Description

`Reset()` and `RestoreSnapshot()` replace a store's durable contents, but three
backends left the in-memory usage mirrors behind — the store-wide `usedBytes`
counter and the per-identity (uid/gid) quota cache. Both are caches over the
durable rows, so a stale one silently reports and enforces quota against data
that no longer exists.

Same gap in three places:

- **memory** `Reset()` cleared every map and zeroed `usedBytes`, but never
  touched the quota cache.
- **memory** `RestoreSnapshot()` recomputed `usedBytes` from the restored
  files but left the quota cache at its pre-restore contents.
- **badger** `Reset()` (`db.DropAll`) wiped every key and left both counters
  untouched.
- **postgres** `Reset()` truncated every table and left both counters
  untouched.

`sqlite` already did this correctly, which is why the divergence went
unnoticed. badger and postgres reseed correctly on *restore* (via
`initUsedBytesCounter`); only their `Reset` path was affected.

Relates to #1828

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Changes Made
- `memory.Reset` clears the quota cache under `quotaMu`, alongside `usedBytes`.
- `memory.RestoreSnapshot` rebuilds the per-owner buckets from the restored
  files and folds them into a freshly-cleared cache, reusing the existing
  `quota.Delta` accumulator rather than hand-rolling the user/group split.
- `badger.Reset` and `postgres.Reset` zero `usedBytes` and clear the quota
  cache after the drop/truncate commits.
- New conformance coverage in `storetest`, so all four backends are held to
  the invariant:
  - `SnapshotConformance/QuotaUsageAfterRestore` — `GetQuotaUsage` after a
    restore must reflect the restored files.
  - `ResetThenRestoreConformance` — post-`Reset` usage must be zero, and
    post-`Restore` must be reseeded.
  - the 14 MiB fixture total is now a named constant shared by both suites,
    so a fixture change can't leave a stale assertion passing.

## Testing
Verified the new assertions are real guards: reverting the three source fixes
and re-running the suites reproduces the bug —

    memory:  QuotaUsageAfterRestore  = {Bytes:0 Files:0}, want {Bytes:14680064 Files:2}
    memory:  post-Reset GetQuotaUsage = {Bytes:14680064 Files:2}, want zero
    badger:  post-Reset GetQuotaUsage = {Bytes:14680064 Files:2}, want zero

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./...` and `go test -race ./pkg/metadata/...`
- [ ] postgres integration suite (build tag `integration`) — not runnable
      locally, left to CI

## Testing Instructions
1. `go build ./...`
2. `go test -race ./pkg/metadata/store/... -run 'Conformance|Snapshot|Reset'`
3. For postgres (build tag `integration`, needs a running Postgres):

```
docker run -d --name dittofs-postgres -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=dittofs_test -p 5432:5432 postgres:16
DITTOFS_TEST_POSTGRES_DSN="host=localhost port=5432 dbname=dittofs_test user=postgres password=postgres sslmode=disable" go test -race -tags=integration ./pkg/metadata/store/postgres/... -v
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes
Split out of #1867 so the bugfix can land on `develop` independently of the
`basestore` extraction; #1867 is superseded and closed, and the extraction it
carried is tracked by #1828.

Not covered here: #1941 is the same class of staleness in a different cache —
badger's `Reset` also leaves the decoded-share cache (`shareCache`) populated,
and nothing invalidates it on restore, so a restored read-only share can keep
serving the destination's stale read-write `ShareOptions`. That is a record
cache, not a usage counter, and is untouched by this PR.
