### PR TITLE
fix(smb): return FiletimeToTime in UTC, not local time

### DIFF
--- a/internal/adapter/smb/types/filetime.go
+++ b/internal/adapter/smb/types/filetime.go
@@ -39,7 +39,7 @@ func FiletimeToTime(ft uint64) time.Time {
 	ticks := int64(ft) - int64(filetimeUnixDiff)
 	sec := ticks / ticksPerSecond
 	rem := ticks % ticksPerSecond
-	return time.Unix(sec, rem*100)
+	return time.Unix(sec, rem*100).UTC()
 }
 
 // NowFiletime returns the current time as a Windows FILETIME


### PR DESCRIPTION
# Description

`time.Unix()` in Go returns local time, not UTC. `FiletimeToTime` computed
the seconds correctly relative to the Windows FILETIME epoch (1601-01-01
UTC) but returned it interpreted in the machine's local timezone on any
runner/machine with a negative UTC offset, timestamps near the epoch roll
back a day. Deterministic, not flaky; invisible on UTC-based CI, which is
why it went unnoticed. Reported and confirmed by @marmos91 on #1867.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- `FiletimeToTime` (`internal/adapter/smb/types/filetime.go`) now calls `.UTC()` on the returned `time.Time`, matching the function's documented epoch (1601-01-01 **UTC**).

## Testing
- [x] Unit tests pass (`go test ./...`)

## Testing Instructions
1. `TZ="America/Sao_Paulo" go test ./internal/adapter/smb/types/... -run TestFiletimeToTime_WindowsEpoch -v` — failed before this fix, passes after.
2. `TZ="UTC" go test ./internal/adapter/smb/types/... -run TestFiletimeToTime_WindowsEpoch -v` — passed before and after (why CI never caught it).
3. `go test -race ./internal/adapter/smb/types/... -v`

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes
One-line fix, no behavior change outside of the timezone the returned
`time.Time` is expressed in — callers comparing/formatting via UTC-aware
paths are unaffected; any caller relying on the (incidental, undocumented)
local-time return would now see UTC instead.