### PR TITLE
fix(badger): index legacy rows by payload once, instead of scanning per lookup

### DIFF
--- a/pkg/metadata/store/badger/payload_index_backfill.go
+++ b/pkg/metadata/store/badger/payload_index_backfill.go
@@ -2,6 +2,7 @@ package badger
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -86,9 +87,11 @@ func backfillPayloadIndex(ctx context.Context, db *badgerdb.DB) error {
 					return nil
 				}
 				key := keyPayloadID(file.PayloadID)
-				if _, gErr := txn.Get(key); gErr == nil {
+				_, gErr := txn.Get(key)
+				if gErr == nil {
 					return nil // already indexed
-				} else if gErr != badgerdb.ErrKeyNotFound {
+				}
+				if !errors.Is(gErr, badgerdb.ErrKeyNotFound) {
 					return gErr
 				}
 				id, mErr := file.ID.MarshalBinary()
@@ -133,11 +136,12 @@ func backfillPayloadIndex(ctx context.Context, db *badgerdb.DB) error {
 func payloadIndexBackfillDone(db *badgerdb.DB) (bool, error) {
 	var done bool
 	err := db.View(func(txn *badgerdb.Txn) error {
-		switch _, err := txn.Get(keyPayloadIndexBackfilled); {
+		_, err := txn.Get(keyPayloadIndexBackfilled)
+		switch {
 		case err == nil:
 			done = true
 			return nil
-		case err == badgerdb.ErrKeyNotFound:
+		case errors.Is(err, badgerdb.ErrKeyNotFound):
 			return nil
 		default:
 			return err

--- a/pkg/metadata/store/badger/payload_index_backfill.go
+++ b/pkg/metadata/store/badger/payload_index_backfill.go
@@ -1,0 +1,147 @@
+package badger
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	badgerdb "github.com/dgraph-io/badger/v4"
+
+	"github.com/marmos91/dittofs/internal/logger"
+)
+
+// keyPayloadIndexBackfilled marks that every file row carrying a PayloadID has a
+// pl: index entry. Its presence lets a subsequent open skip the scan below.
+var keyPayloadIndexBackfilled = []byte(prefixConfig + "payload-index-backfilled")
+
+// backfillPayloadIndexProgressInterval bounds how often the scan reports. The
+// scan is linear and usually quick, but a large store predates any log line
+// between open and the first listener, which is the window this fills.
+const backfillPayloadIndexProgressInterval = 5 * time.Second
+
+// backfillPayloadIndex writes a pl:<payloadID> entry for every file row missing
+// one, then records that it has done so.
+//
+// The index turns GetFileByPayloadID into a point lookup. Rows written before it
+// existed have no entry, and the lookup falls back to scanning and decoding the
+// whole file keyspace. That fallback is per-call, so a caller that resolves N
+// payloads in a loop — the journal size reconcile on the startup path does
+// exactly this — costs N full scans, and a store of legacy rows turns an O(N)
+// step into an O(N²) one before any listener binds.
+//
+// Writing the entries on the next write of each row, which is what the index
+// originally relied on, never happens for files that are only ever read. So the
+// entries are written once, here, rather than waited for.
+//
+// The scan is linear and runs once per store: the marker makes later opens skip
+// it. Entries go through a WriteBatch because a single transaction covering
+// every row would exceed Badger's transaction size limit on a large store.
+func backfillPayloadIndex(ctx context.Context, db *badgerdb.DB) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	done, err := payloadIndexBackfillDone(db)
+	if err != nil {
+		return err
+	}
+	if done {
+		return nil
+	}
+
+	started := time.Now()
+	lastLog := started
+	var scanned, written int
+
+	batch := db.NewWriteBatch()
+	defer batch.Cancel()
+
+	err = db.View(func(txn *badgerdb.Txn) error {
+		opts := badgerdb.DefaultIteratorOptions
+		opts.PrefetchSize = 100
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		prefix := []byte(prefixFile)
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			scanned++
+			if time.Since(lastLog) >= backfillPayloadIndexProgressInterval {
+				lastLog = time.Now()
+				logger.Info("indexing files by payload", "scanned", scanned, "written", written,
+					"elapsed", time.Since(started).Round(time.Second))
+			}
+
+			verr := it.Item().Value(func(val []byte) error {
+				file, decErr := decodeFile(val)
+				if decErr != nil {
+					// Consistent with the read paths, which skip a row they cannot
+					// decode rather than failing the whole store open. An
+					// unreadable row has no payload to index either way.
+					return nil
+				}
+				if file == nil || file.PayloadID == "" {
+					return nil
+				}
+				key := keyPayloadID(file.PayloadID)
+				if _, gErr := txn.Get(key); gErr == nil {
+					return nil // already indexed
+				} else if gErr != badgerdb.ErrKeyNotFound {
+					return gErr
+				}
+				id, mErr := file.ID.MarshalBinary()
+				if mErr != nil {
+					return mErr
+				}
+				if sErr := batch.Set(key, id); sErr != nil {
+					return sErr
+				}
+				written++
+				return nil
+			})
+			if verr != nil {
+				return verr
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("scan files to index by payload: %w", err)
+	}
+
+	if err := batch.Flush(); err != nil {
+		return fmt.Errorf("write payload index entries: %w", err)
+	}
+
+	// Only after the entries are durable, so an interrupted run repeats the scan
+	// rather than recording work it did not finish.
+	if err := db.Update(func(txn *badgerdb.Txn) error {
+		return txn.Set(keyPayloadIndexBackfilled, []byte{1})
+	}); err != nil {
+		return fmt.Errorf("record payload index backfill: %w", err)
+	}
+
+	if written > 0 {
+		logger.Info("indexed files by payload", "scanned", scanned, "written", written,
+			"duration", time.Since(started).Round(time.Millisecond))
+	}
+	return nil
+}
+
+func payloadIndexBackfillDone(db *badgerdb.DB) (bool, error) {
+	var done bool
+	err := db.View(func(txn *badgerdb.Txn) error {
+		switch _, err := txn.Get(keyPayloadIndexBackfilled); {
+		case err == nil:
+			done = true
+			return nil
+		case err == badgerdb.ErrKeyNotFound:
+			return nil
+		default:
+			return err
+		}
+	})
+	return done, err
+}

--- a/pkg/metadata/store/badger/payload_index_backfill.go
+++ b/pkg/metadata/store/badger/payload_index_backfill.go
@@ -1,139 +1,31 @@
 package badger
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	badgerdb "github.com/dgraph-io/badger/v4"
 
-	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
 // keyPayloadIndexBackfilled marks that every file row carrying a PayloadID has a
-// pl: index entry. Its presence lets a subsequent open skip the scan below.
+// pl: index entry. Its presence lets a subsequent open skip the work.
 var keyPayloadIndexBackfilled = []byte(prefixConfig + "payload-index-backfilled")
 
-// backfillPayloadIndexProgressInterval bounds how often the scan reports. The
-// scan is linear and usually quick, but a large store predates any log line
-// between open and the first listener, which is the window this fills.
-const backfillPayloadIndexProgressInterval = 5 * time.Second
-
-// backfillPayloadIndex writes a pl:<payloadID> entry for every file row missing
-// one, then records that it has done so.
+// payloadIndexBackfillNeeded reports whether this store still has to be indexed
+// by payload.
 //
-// The index turns GetFileByPayloadID into a point lookup. Rows written before it
-// existed have no entry, and the lookup falls back to scanning and decoding the
-// whole file keyspace. That fallback is per-call, so a caller that resolves N
-// payloads in a loop — the journal size reconcile on the startup path does
-// exactly this — costs N full scans, and a store of legacy rows turns an O(N)
-// step into an O(N²) one before any listener binds.
+// GetFileByPayloadID is a point lookup only when the pl:<payloadID> index has an
+// entry. Rows written before that index existed have none, and each miss falls
+// back to scanning and decoding the whole file keyspace. That fallback is per
+// call, so a caller resolving one payload per file in a loop — the journal size
+// reconcile on the startup path does exactly this — turns an O(N) step into an
+// O(N²) one before any listener binds.
 //
-// Writing the entries on the next write of each row, which is what the index
-// originally relied on, never happens for files that are only ever read. So the
-// entries are written once, here, rather than waited for.
-//
-// The scan is linear and runs once per store: the marker makes later opens skip
-// it. Entries go through a WriteBatch because a single transaction covering
-// every row would exceed Badger's transaction size limit on a large store.
-func backfillPayloadIndex(ctx context.Context, db *badgerdb.DB) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-
-	done, err := payloadIndexBackfillDone(db)
-	if err != nil {
-		return err
-	}
-	if done {
-		return nil
-	}
-
-	started := time.Now()
-	lastLog := started
-	var scanned, written int
-
-	batch := db.NewWriteBatch()
-	defer batch.Cancel()
-
-	err = db.View(func(txn *badgerdb.Txn) error {
-		opts := badgerdb.DefaultIteratorOptions
-		opts.PrefetchSize = 100
-		it := txn.NewIterator(opts)
-		defer it.Close()
-
-		prefix := []byte(prefixFile)
-		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-			scanned++
-			if time.Since(lastLog) >= backfillPayloadIndexProgressInterval {
-				lastLog = time.Now()
-				logger.Info("indexing files by payload", "scanned", scanned, "written", written,
-					"elapsed", time.Since(started).Round(time.Second))
-			}
-
-			verr := it.Item().Value(func(val []byte) error {
-				file, decErr := decodeFile(val)
-				if decErr != nil {
-					// Consistent with the read paths, which skip a row they cannot
-					// decode rather than failing the whole store open. An
-					// unreadable row has no payload to index either way.
-					return nil
-				}
-				if file == nil || file.PayloadID == "" {
-					return nil
-				}
-				key := keyPayloadID(file.PayloadID)
-				_, gErr := txn.Get(key)
-				if gErr == nil {
-					return nil // already indexed
-				}
-				if !errors.Is(gErr, badgerdb.ErrKeyNotFound) {
-					return gErr
-				}
-				id, mErr := file.ID.MarshalBinary()
-				if mErr != nil {
-					return mErr
-				}
-				if sErr := batch.Set(key, id); sErr != nil {
-					return sErr
-				}
-				written++
-				return nil
-			})
-			if verr != nil {
-				return verr
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("scan files to index by payload: %w", err)
-	}
-
-	if err := batch.Flush(); err != nil {
-		return fmt.Errorf("write payload index entries: %w", err)
-	}
-
-	// Only after the entries are durable, so an interrupted run repeats the scan
-	// rather than recording work it did not finish.
-	if err := db.Update(func(txn *badgerdb.Txn) error {
-		return txn.Set(keyPayloadIndexBackfilled, []byte{1})
-	}); err != nil {
-		return fmt.Errorf("record payload index backfill: %w", err)
-	}
-
-	if written > 0 {
-		logger.Info("indexed files by payload", "scanned", scanned, "written", written,
-			"duration", time.Since(started).Round(time.Millisecond))
-	}
-	return nil
-}
-
-func payloadIndexBackfillDone(db *badgerdb.DB) (bool, error) {
+// The entries were expected to appear as rows were rewritten, which never
+// happens for files that are only ever read, so they are written once instead.
+func payloadIndexBackfillNeeded(db *badgerdb.DB) (bool, error) {
 	var done bool
 	err := db.View(func(txn *badgerdb.Txn) error {
 		_, err := txn.Get(keyPayloadIndexBackfilled)
@@ -147,5 +39,67 @@ func payloadIndexBackfillDone(db *badgerdb.DB) (bool, error) {
 			return err
 		}
 	})
-	return done, err
+	return !done, err
+}
+
+// indexFileByPayload stages this file's pl: entry on batch. It is called from
+// the open-time file scan, so it must not do a read of its own: the entry is
+// written unconditionally rather than after checking for one, since rewriting an
+// entry with the value it already holds costs less than the lookup that would
+// avoid it.
+//
+// A batch is used because a single transaction spanning every row would exceed
+// Badger's transaction size limit on a large store.
+func indexFileByPayload(batch *badgerdb.WriteBatch, file *metadata.File) error {
+	if batch == nil || file == nil || file.PayloadID == "" {
+		return nil
+	}
+	id, err := file.ID.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("marshal file id for payload index: %w", err)
+	}
+	return batch.Set(keyPayloadID(file.PayloadID), id)
+}
+
+// recordPayloadIndexBackfilled marks the backfill complete. Called only after
+// the staged entries are durable, so an interrupted run repeats the work rather
+// than recording what it did not finish.
+func recordPayloadIndexBackfilled(db *badgerdb.DB) error {
+	return db.Update(func(txn *badgerdb.Txn) error {
+		return txn.Set(keyPayloadIndexBackfilled, []byte{1})
+	})
+}
+
+// initUsedBytesAndPayloadIndex runs the open-time file scan, extending it to
+// write the pl: index when this store still lacks it.
+//
+// Shared by store open and snapshot restore because both land on a keyspace
+// whose rows may predate the index — a restore from an old dump would otherwise
+// leave every payload lookup scanning until the next restart.
+func (s *BadgerMetadataStore) initUsedBytesAndPayloadIndex() error {
+	need, err := payloadIndexBackfillNeeded(s.db)
+	if err != nil {
+		return fmt.Errorf("check payload index state: %w", err)
+	}
+
+	var batch *badgerdb.WriteBatch
+	if need {
+		batch = s.db.NewWriteBatch()
+		defer batch.Cancel()
+	}
+
+	if err := s.initUsedBytesCounter(batch); err != nil {
+		return err
+	}
+	if !need {
+		return nil
+	}
+
+	if err := batch.Flush(); err != nil {
+		return fmt.Errorf("write payload index entries: %w", err)
+	}
+	if err := recordPayloadIndexBackfilled(s.db); err != nil {
+		return fmt.Errorf("record payload index backfill: %w", err)
+	}
+	return nil
 }

--- a/pkg/metadata/store/badger/payload_index_backfill_test.go
+++ b/pkg/metadata/store/badger/payload_index_backfill_test.go
@@ -11,46 +11,54 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// openRawBadger gives a bare DB so a store can be seeded with rows that predate
-// the pl: index, which the normal constructor would index on the way in.
-func openRawBadger(t *testing.T) *badgerdb.DB {
+// seedLegacyFiles writes file rows straight through a raw Badger handle at dir,
+// with no pl: entry — the shape of every row written before that index existed.
+// The handle is closed before returning so the store can open the same
+// directory.
+func seedLegacyFiles(t *testing.T, dir string, payloads ...metadata.PayloadID) []*metadata.File {
 	t.Helper()
-	db, err := badgerdb.Open(badgerdb.DefaultOptions(t.TempDir()).WithLogger(nil))
+
+	db, err := badgerdb.Open(badgerdb.DefaultOptions(dir).WithLogger(nil))
 	if err != nil {
-		t.Fatalf("open badger: %v", err)
+		t.Fatalf("open raw badger: %v", err)
 	}
-	t.Cleanup(func() { _ = db.Close() })
-	return db
+	defer func() {
+		if cErr := db.Close(); cErr != nil {
+			t.Fatalf("close raw badger: %v", cErr)
+		}
+	}()
+
+	files := make([]*metadata.File, 0, len(payloads))
+	for _, p := range payloads {
+		f := &metadata.File{
+			ID: uuid.New(),
+			FileAttr: metadata.FileAttr{
+				Type:      metadata.FileTypeRegular,
+				PayloadID: p,
+				Size:      4096,
+			},
+		}
+		enc, encErr := encodeFile(f)
+		if encErr != nil {
+			t.Fatalf("encode file: %v", encErr)
+		}
+		if uErr := db.Update(func(txn *badgerdb.Txn) error {
+			return txn.Set(keyFile(f.ID), enc)
+		}); uErr != nil {
+			t.Fatalf("seed file: %v", uErr)
+		}
+		if hasPayloadIndexAt(t, db, p) {
+			t.Fatalf("%q indexed before open; the fixture is not reproducing a legacy row", p)
+		}
+		files = append(files, f)
+	}
+	return files
 }
 
-// seedLegacyFile writes a file row with no pl: entry — the shape of every row
-// written before the index existed.
-func seedLegacyFile(t *testing.T, db *badgerdb.DB, payload metadata.PayloadID) *metadata.File {
-	t.Helper()
-	f := &metadata.File{
-		ID: uuid.New(),
-		FileAttr: metadata.FileAttr{
-			Type:      metadata.FileTypeRegular,
-			PayloadID: payload,
-			Size:      4096,
-		},
-	}
-	enc, err := encodeFile(f)
-	if err != nil {
-		t.Fatalf("encode file: %v", err)
-	}
-	if err := db.Update(func(txn *badgerdb.Txn) error {
-		return txn.Set(keyFile(f.ID), enc)
-	}); err != nil {
-		t.Fatalf("seed file: %v", err)
-	}
-	return f
-}
-
-func hasPayloadIndex(t *testing.T, db *badgerdb.DB, payload metadata.PayloadID) bool {
+func hasPayloadIndexAt(t *testing.T, db *badgerdb.DB, payload metadata.PayloadID) bool {
 	t.Helper()
 	var found bool
-	err := db.View(func(txn *badgerdb.Txn) error {
+	if err := db.View(func(txn *badgerdb.Txn) error {
 		_, err := txn.Get(keyPayloadID(payload))
 		switch {
 		case err == nil:
@@ -61,107 +69,97 @@ func hasPayloadIndex(t *testing.T, db *badgerdb.DB, payload metadata.PayloadID) 
 		default:
 			return err
 		}
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("probe index: %v", err)
 	}
 	return found
 }
 
-// Rows written before the index existed must get an entry, or every lookup for
-// them falls back to a full keyspace scan — which a caller resolving payloads in
-// a loop turns into quadratic work before any listener binds.
-func TestBackfillPayloadIndex_IndexesLegacyRows(t *testing.T) {
-	db := openRawBadger(t)
-	ctx := context.Background()
-
-	want := []metadata.PayloadID{"payload-a", "payload-b", "payload-c"}
-	for _, p := range want {
-		seedLegacyFile(t, db, p)
-		if hasPayloadIndex(t, db, p) {
-			t.Fatalf("%s indexed before backfill; the fixture is not reproducing a legacy row", p)
-		}
-	}
-
-	if err := backfillPayloadIndex(ctx, db); err != nil {
-		t.Fatalf("backfill: %v", err)
-	}
-
-	for _, p := range want {
-		if !hasPayloadIndex(t, db, p) {
-			t.Errorf("%s still unindexed after backfill", p)
-		}
-	}
-}
-
-// The entry must point at the row it was derived from, otherwise the index
-// resolves to the wrong file and the lookup silently returns another file's
-// metadata.
-func TestBackfillPayloadIndex_EntryResolvesToItsFile(t *testing.T) {
-	db := openRawBadger(t)
-
-	f := seedLegacyFile(t, db, "payload-a")
-	seedLegacyFile(t, db, "payload-b")
-
-	if err := backfillPayloadIndex(context.Background(), db); err != nil {
-		t.Fatalf("backfill: %v", err)
-	}
-
-	var got []byte
-	if err := db.View(func(txn *badgerdb.Txn) error {
-		item, err := txn.Get(keyPayloadID("payload-a"))
-		if err != nil {
-			return err
-		}
-		got, err = item.ValueCopy(nil)
-		return err
-	}); err != nil {
-		t.Fatalf("read index: %v", err)
-	}
-
-	wantID, err := f.ID.MarshalBinary()
+func openStore(t *testing.T, dir string) *BadgerMetadataStore {
+	t.Helper()
+	s, err := NewBadgerMetadataStoreWithDefaults(context.Background(), dir)
 	if err != nil {
-		t.Fatalf("marshal id: %v", err)
+		t.Fatalf("open store: %v", err)
 	}
-	if string(got) != string(wantID) {
-		t.Fatalf("index for payload-a points at %x, want %x", got, wantID)
+	return s
+}
+
+// Rows written before the index existed must be indexed at open. Without it
+// every lookup for them falls back to a full keyspace scan, which a caller
+// resolving payloads in a loop turns into quadratic work before any listener
+// binds.
+func TestOpen_IndexesLegacyRowsByPayload(t *testing.T) {
+	dir := t.TempDir()
+	want := seedLegacyFiles(t, dir, "payload-a", "payload-b", "payload-c")
+
+	store := openStore(t, dir)
+	defer func() { _ = store.Close() }()
+
+	for _, f := range want {
+		got, err := store.GetFileByPayloadID(context.Background(), f.PayloadID)
+		if err != nil {
+			t.Fatalf("GetFileByPayloadID(%q): %v", f.PayloadID, err)
+		}
+		if got == nil || got.ID != f.ID {
+			t.Errorf("payload %q resolved to %v, want file %v", f.PayloadID, got, f.ID)
+		}
+		if !hasPayloadIndexAt(t, store.db, f.PayloadID) {
+			t.Errorf("payload %q still unindexed after open", f.PayloadID)
+		}
 	}
 }
 
-// A second open must not re-scan. Without the marker the cost is paid on every
-// restart, which for a large store is the whole problem this is fixing.
-func TestBackfillPayloadIndex_SkipsSecondRun(t *testing.T) {
-	db := openRawBadger(t)
-	ctx := context.Background()
+// A second open must not repeat the scan. Without the marker the cost is paid on
+// every restart, which for a large store is the whole problem being fixed.
+func TestOpen_SkipsPayloadIndexingOnSecondOpen(t *testing.T) {
+	dir := t.TempDir()
+	seedLegacyFiles(t, dir, "payload-a")
 
-	seedLegacyFile(t, db, "payload-a")
-	if err := backfillPayloadIndex(ctx, db); err != nil {
-		t.Fatalf("first backfill: %v", err)
+	first := openStore(t, dir)
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first: %v", err)
 	}
 
-	// A row seeded after the marker is written stays unindexed, which is how the
-	// test observes that the second call did not scan.
-	seedLegacyFile(t, db, "payload-late")
-	if err := backfillPayloadIndex(ctx, db); err != nil {
-		t.Fatalf("second backfill: %v", err)
-	}
-	if hasPayloadIndex(t, db, "payload-late") {
-		t.Fatal("second backfill re-scanned; the completion marker is not being honoured")
+	// Seeded after the marker was written, so it stays unindexed only if the
+	// second open genuinely skipped the pass.
+	seedLegacyFiles(t, dir, "payload-late")
+
+	second := openStore(t, dir)
+	defer func() { _ = second.Close() }()
+
+	if hasPayloadIndexAt(t, second.db, "payload-late") {
+		t.Fatal("second open re-indexed; the completion marker is not being honoured")
 	}
 }
 
 // A row with no PayloadID has nothing to index, and must not produce an entry
-// under the empty key — which would then be returned for every payload-less
-// lookup.
-func TestBackfillPayloadIndex_SkipsRowsWithoutPayload(t *testing.T) {
-	db := openRawBadger(t)
+// under the empty key — which would then be returned for payload-less lookups.
+func TestOpen_SkipsRowsWithoutPayload(t *testing.T) {
+	dir := t.TempDir()
+	seedLegacyFiles(t, dir, "")
 
-	seedLegacyFile(t, db, "")
+	store := openStore(t, dir)
+	defer func() { _ = store.Close() }()
 
-	if err := backfillPayloadIndex(context.Background(), db); err != nil {
-		t.Fatalf("backfill: %v", err)
-	}
-	if hasPayloadIndex(t, db, "") {
+	if hasPayloadIndexAt(t, store.db, "") {
 		t.Fatal("wrote an index entry for an empty PayloadID")
+	}
+}
+
+// The usedBytes counter shares the scan the indexing rides on, so it must still
+// be seeded correctly when that indexing runs.
+func TestOpen_UsedBytesStillSeededWhileIndexing(t *testing.T) {
+	dir := t.TempDir()
+	files := seedLegacyFiles(t, dir, "payload-a", "payload-b")
+
+	store := openStore(t, dir)
+	defer func() { _ = store.Close() }()
+
+	var want int64
+	for _, f := range files {
+		want += int64(f.Size)
+	}
+	if got := store.usedBytes.Load(); got != want {
+		t.Fatalf("usedBytes = %d, want %d", got, want)
 	}
 }

--- a/pkg/metadata/store/badger/payload_index_backfill_test.go
+++ b/pkg/metadata/store/badger/payload_index_backfill_test.go
@@ -1,0 +1,165 @@
+package badger
+
+import (
+	"context"
+	"testing"
+
+	badgerdb "github.com/dgraph-io/badger/v4"
+	"github.com/google/uuid"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// openRawBadger gives a bare DB so a store can be seeded with rows that predate
+// the pl: index, which the normal constructor would index on the way in.
+func openRawBadger(t *testing.T) *badgerdb.DB {
+	t.Helper()
+	db, err := badgerdb.Open(badgerdb.DefaultOptions(t.TempDir()).WithLogger(nil))
+	if err != nil {
+		t.Fatalf("open badger: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// seedLegacyFile writes a file row with no pl: entry — the shape of every row
+// written before the index existed.
+func seedLegacyFile(t *testing.T, db *badgerdb.DB, payload metadata.PayloadID) *metadata.File {
+	t.Helper()
+	f := &metadata.File{
+		ID: uuid.New(),
+		FileAttr: metadata.FileAttr{
+			Type:      metadata.FileTypeRegular,
+			PayloadID: payload,
+			Size:      4096,
+		},
+	}
+	enc, err := encodeFile(f)
+	if err != nil {
+		t.Fatalf("encode file: %v", err)
+	}
+	if err := db.Update(func(txn *badgerdb.Txn) error {
+		return txn.Set(keyFile(f.ID), enc)
+	}); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	return f
+}
+
+func hasPayloadIndex(t *testing.T, db *badgerdb.DB, payload metadata.PayloadID) bool {
+	t.Helper()
+	var found bool
+	err := db.View(func(txn *badgerdb.Txn) error {
+		switch _, err := txn.Get(keyPayloadID(payload)); {
+		case err == nil:
+			found = true
+			return nil
+		case err == badgerdb.ErrKeyNotFound:
+			return nil
+		default:
+			return err
+		}
+	})
+	if err != nil {
+		t.Fatalf("probe index: %v", err)
+	}
+	return found
+}
+
+// Rows written before the index existed must get an entry, or every lookup for
+// them falls back to a full keyspace scan — which a caller resolving payloads in
+// a loop turns into quadratic work before any listener binds.
+func TestBackfillPayloadIndex_IndexesLegacyRows(t *testing.T) {
+	db := openRawBadger(t)
+	ctx := context.Background()
+
+	want := []metadata.PayloadID{"payload-a", "payload-b", "payload-c"}
+	for _, p := range want {
+		seedLegacyFile(t, db, p)
+		if hasPayloadIndex(t, db, p) {
+			t.Fatalf("%s indexed before backfill; the fixture is not reproducing a legacy row", p)
+		}
+	}
+
+	if err := backfillPayloadIndex(ctx, db); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	for _, p := range want {
+		if !hasPayloadIndex(t, db, p) {
+			t.Errorf("%s still unindexed after backfill", p)
+		}
+	}
+}
+
+// The entry must point at the row it was derived from, otherwise the index
+// resolves to the wrong file and the lookup silently returns another file's
+// metadata.
+func TestBackfillPayloadIndex_EntryResolvesToItsFile(t *testing.T) {
+	db := openRawBadger(t)
+
+	f := seedLegacyFile(t, db, "payload-a")
+	seedLegacyFile(t, db, "payload-b")
+
+	if err := backfillPayloadIndex(context.Background(), db); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	var got []byte
+	if err := db.View(func(txn *badgerdb.Txn) error {
+		item, err := txn.Get(keyPayloadID("payload-a"))
+		if err != nil {
+			return err
+		}
+		got, err = item.ValueCopy(nil)
+		return err
+	}); err != nil {
+		t.Fatalf("read index: %v", err)
+	}
+
+	wantID, err := f.ID.MarshalBinary()
+	if err != nil {
+		t.Fatalf("marshal id: %v", err)
+	}
+	if string(got) != string(wantID) {
+		t.Fatalf("index for payload-a points at %x, want %x", got, wantID)
+	}
+}
+
+// A second open must not re-scan. Without the marker the cost is paid on every
+// restart, which for a large store is the whole problem this is fixing.
+func TestBackfillPayloadIndex_SkipsSecondRun(t *testing.T) {
+	db := openRawBadger(t)
+	ctx := context.Background()
+
+	seedLegacyFile(t, db, "payload-a")
+	if err := backfillPayloadIndex(ctx, db); err != nil {
+		t.Fatalf("first backfill: %v", err)
+	}
+
+	// A row seeded after the marker is written stays unindexed, which is how the
+	// test observes that the second call did not scan.
+	seedLegacyFile(t, db, "payload-late")
+	if err := backfillPayloadIndex(ctx, db); err != nil {
+		t.Fatalf("second backfill: %v", err)
+	}
+	if hasPayloadIndex(t, db, "payload-late") {
+		t.Fatal("second backfill re-scanned; the completion marker is not being honoured")
+	}
+}
+
+// A row with no PayloadID has nothing to index, and must not produce an entry
+// under the empty key — which would then be returned for every payload-less
+// lookup.
+func TestBackfillPayloadIndex_SkipsRowsWithoutPayload(t *testing.T) {
+	db := openRawBadger(t)
+
+	seedLegacyFile(t, db, "")
+
+	if err := backfillPayloadIndex(context.Background(), db); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if hasPayloadIndex(t, db, "") {
+		t.Fatal("wrote an index entry for an empty PayloadID")
+	}
+}

--- a/pkg/metadata/store/badger/payload_index_backfill_test.go
+++ b/pkg/metadata/store/badger/payload_index_backfill_test.go
@@ -2,6 +2,7 @@ package badger
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	badgerdb "github.com/dgraph-io/badger/v4"
@@ -50,11 +51,12 @@ func hasPayloadIndex(t *testing.T, db *badgerdb.DB, payload metadata.PayloadID) 
 	t.Helper()
 	var found bool
 	err := db.View(func(txn *badgerdb.Txn) error {
-		switch _, err := txn.Get(keyPayloadID(payload)); {
+		_, err := txn.Get(keyPayloadID(payload))
+		switch {
 		case err == nil:
 			found = true
 			return nil
-		case err == badgerdb.ErrKeyNotFound:
+		case errors.Is(err, badgerdb.ErrKeyNotFound):
 			return nil
 		default:
 			return err

--- a/pkg/metadata/store/badger/snapshot_store.go
+++ b/pkg/metadata/store/badger/snapshot_store.go
@@ -306,7 +306,7 @@ func (s *BadgerMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 	// The DB has been fully repopulated, but the in-memory usedBytes counter
 	// still holds the pre-restore value. Recompute it from the restored rows so
 	// GetUsedBytes / GetFilesystemStatistics report correctly without a restart.
-	if err := s.initUsedBytesCounter(); err != nil {
+	if err := s.initUsedBytesAndPayloadIndex(); err != nil {
 		return fmt.Errorf("restore: reinitialize used-bytes counter: %w", err)
 	}
 

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -405,6 +405,16 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 		return nil, fmt.Errorf("failed to initialize used bytes counter: %w", err)
 	}
 
+	// Give every file row carrying a PayloadID its pl: index entry, once. Rows
+	// written before that index existed have none, and each lookup that misses it
+	// falls back to scanning and decoding the whole file keyspace — which callers
+	// that resolve payloads in a loop turn into quadratic work on the startup
+	// path. One linear pass here retires that for the life of the store.
+	if err := backfillPayloadIndex(ctx, db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("failed to index files by payload: %w", err)
+	}
+
 	// Start the background value-log GC loop. Badger reclaims value-log
 	// space only when RunValueLogGC is called explicitly; without it the
 	// value log grows without bound (unbounded disk growth). The loop is

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -399,20 +399,11 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 		return nil, fmt.Errorf("failed to initialize singletons: %w", err)
 	}
 
-	// Initialize the usedBytes counter from a full file scan.
-	if err := store.initUsedBytesCounter(); err != nil {
+	// Initialize the usedBytes counter from a full file scan, which also writes
+	// the pl: index when this store's rows predate it — one decode pass, not two.
+	if err := store.initUsedBytesAndPayloadIndex(); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("failed to initialize used bytes counter: %w", err)
-	}
-
-	// Give every file row carrying a PayloadID its pl: index entry, once. Rows
-	// written before that index existed have none, and each lookup that misses it
-	// falls back to scanning and decoding the whole file keyspace — which callers
-	// that resolve payloads in a loop turn into quadratic work on the startup
-	// path. One linear pass here retires that for the life of the store.
-	if err := backfillPayloadIndex(ctx, db); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("failed to index files by payload: %w", err)
 	}
 
 	// Start the background value-log GC loop. Badger reclaims value-log
@@ -642,7 +633,10 @@ func (s *BadgerMetadataStore) GetUsedBytes() int64 {
 // groupUsage). Both are reconstructed from the durable file rows, so a store
 // opened from an existing dump (with no separately persisted counters) is always
 // seeded correctly — back-compatible by construction.
-func (s *BadgerMetadataStore) initUsedBytesCounter() error {
+// A non-nil indexBatch also stages a pl: index entry per file, so a store that
+// still needs indexing by payload pays one scan at open rather than two — the
+// decode is the expensive part and this is the only place already doing it.
+func (s *BadgerMetadataStore) initUsedBytesCounter(indexBatch *badger.WriteBatch) error {
 	var totalUsed int64
 	userUsage := make(map[uint32]*metadata.UsageStat)
 	groupUsage := make(map[uint32]*metadata.UsageStat)
@@ -677,7 +671,7 @@ func (s *BadgerMetadataStore) initUsedBytesCounter() error {
 					addUsage(userUsage, file.UID, int64(file.Size))
 					addUsage(groupUsage, file.GID, int64(file.Size))
 				}
-				return nil
+				return indexFileByPayload(indexBatch, file)
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
Fixes #1885 — a user's server never finished starting: 10+ minutes with no listener bound, reproduced on v0.29.0 and v0.29.1, on an 11,442-file store.

## The defect is quadratic, not linear

`GetFileByPayloadID` is a point lookup **only** when the `pl:<payloadID>` index has an entry. Its own doc comment records the rest:

> degrades to an O(n) keyspace scan only for legacy rows written before the index existed (those are indexed on their next write)

That fallback is per call. `reconcileMetadataSizeFromJournal` resolves one payload per journal file in a loop on the startup path, so a store made entirely of legacy rows costs **one full keyspace scan, with a JSON decode per record, per file**.

For the reporter: 11,442 x 11,442 = roughly 131 million decodes, single-goroutine, before anything binds. Their goroutine dump showed goroutine 1 `[runnable]` at exactly `files.go:187` → `encoding.go:357`, sustained 1.4 cores, flat `read_bytes`, silent log. It is slow, not stuck — and it recurs on every restart.

The "indexed on their next write" self-healing never fires for files that are only ever read, so for an archival store it is permanent.

## Fix

Write the missing entries once, at store open, in a single linear pass, and record a marker so later opens skip it. Entries go through a `WriteBatch` — one transaction spanning every row would exceed Badger's transaction size limit on a large store.

The marker is written only after the entries are flushed, so an interrupted run repeats the scan rather than recording work it did not finish.

## Why here rather than at the caller

Inverting that one loop would have fixed that one loop. The missing index is what is actually wrong, and every other caller of `GetFileByPayloadID` on a legacy store pays the same fallback. Backfilling repairs all of them, and only badger has this degradation, so it needs no interface change across the other three backends.

## Tests

`payload_index_backfill_test.go` seeds rows through a raw Badger handle so they genuinely predate the index, then pins: legacy rows get indexed, the entry resolves to the file it came from, a second run does not re-scan, and a row with no PayloadID does not produce an entry under the empty key.

Full `./pkg/metadata/...` green, `-race` green on the badger package, vet and gofmt clean.

## Not covered

The reconcile itself still walks every journal file. That is O(N) and correct — it is the crash-safety net that grows `metadata.Size` to the journal high-water mark before any handler can read. This removes the quadratic factor, not the linear pass.