### PR TITLE
fix(block): re-seed cold intervals a share lost under an earlier build

### DIFF
--- a/pkg/block/journal/cold.go
+++ b/pkg/block/journal/cold.go
@@ -46,6 +46,10 @@ const (
 	coldHeaderSize = 31
 	coldLogName    = "cold.log"
 
+	// coldSeededName is the marker recording that this journal's cold log has
+	// been seeded from the caller's manifest. See ColdSeeded.
+	coldSeededName = "cold-seeded"
+
 	// coldCompactFloor keeps recovery from rewriting a log that is merely small:
 	// compaction only pays once the dead entries outweigh a few pages of I/O.
 	coldCompactFloor = 1024
@@ -251,6 +255,37 @@ func liveColdEntries(indexByShard []map[FileID]*fileIndex) []coldEntry {
 		}
 	}
 	return out
+}
+
+// ColdSeeded reports whether a caller has already seeded this journal's cold
+// log from its manifest and said so with MarkColdSeeded.
+//
+// A journal that opened empty over data living only on a remote store — an
+// upgrade that archived the previous local layout aside, a restore that wiped
+// the local tier — holds no interval for those ranges, so a read zero-fills
+// instead of fetching. The repair is a manifest scan, which is O(files) and
+// worth doing once rather than on every open. A store whose marker cannot be
+// read is reported unseeded: repeating the scan costs time, skipping it serves
+// zeros.
+func (s *Store) ColdSeeded() bool {
+	_, err := os.Stat(filepath.Join(s.dir, coldSeededName))
+	return err == nil
+}
+
+// MarkColdSeeded records that the cold log has been seeded from a manifest.
+// Call it only once the seed's entries are durable: an open interrupted before
+// this point leaves no marker and seeds again, whereas a marker written early
+// would let an incomplete seed be mistaken for a finished one.
+func (s *Store) MarkColdSeeded() error {
+	fd, err := os.OpenFile(filepath.Join(s.dir, coldSeededName), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("journal: create cold seed marker: %w", err)
+	}
+	if err := fd.Close(); err != nil {
+		return fmt.Errorf("journal: close cold seed marker: %w", err)
+	}
+	// The marker is an empty file, so only the directory entry has to reach disk.
+	return fsyncDir(s.dir)
 }
 
 // closeCold releases the append handle. Idempotent.

--- a/pkg/block/journal/cold_test.go
+++ b/pkg/block/journal/cold_test.go
@@ -196,3 +196,118 @@ func TestColdLogTornTailKeepsIntactEntries(t *testing.T) {
 		t.Error("the entry before the torn tail was dropped; only the torn one should be lost")
 	}
 }
+
+// TestSeedColdLeavesLocalBytesAlone is what makes a re-seed safe to run against a
+// store that is only partly missing its markers. A cold interval carries a fresh
+// version, so seeding a range the journal already holds would shadow those bytes
+// — and a chunk not yet on the remote cannot be fetched back, so the read would
+// fail or return zeros for data that exists only locally.
+func TestSeedColdLeavesLocalBytesAlone(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
+
+	s, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	// A locally-written range in the middle of what the manifest describes.
+	want := bytes.Repeat([]byte{0x3C}, 4096)
+	if err := s.WriteAt(ctx, "f", 4096, want); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.SeedCold(ctx, "f", [][2]int64{{0, 12288}}); err != nil {
+		t.Fatalf("SeedCold: %v", err)
+	}
+
+	got := make([]byte, 4096)
+	_, cold, err := s.ReadAt(ctx, "f", 4096, got)
+	if err != nil {
+		t.Fatalf("ReadAt over the written range: %v", err)
+	}
+	if cold {
+		t.Error("the seed shadowed a range the journal holds locally; the read now needs a remote copy that may not exist")
+	}
+	if !bytes.Equal(got, want) {
+		t.Error("the seed replaced locally-written bytes")
+	}
+	// The ranges on either side had nothing local, so they must be cold.
+	for _, off := range []int64{0, 8192} {
+		if _, cold, err := s.ReadAt(ctx, "f", off, make([]byte, 4096)); err != nil {
+			t.Fatalf("ReadAt at %d: %v", off, err)
+		} else if !cold {
+			t.Errorf("range at %d was not seeded, so it reads as a hole and returns zeros with no remote fetch", off)
+		}
+	}
+}
+
+// TestSeedColdIsIdempotent covers a seed that is interrupted and repeated: the
+// second pass must add nothing, so an open that dies mid-seed can simply run the
+// whole thing again.
+func TestSeedColdIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
+
+	s, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	extents := [][2]int64{{0, 4096}, {4096, 4096}}
+	if err := s.SeedCold(ctx, "f", extents); err != nil {
+		t.Fatalf("SeedCold: %v", err)
+	}
+	first, err := os.Stat(filepath.Join(dir, coldLogName))
+	if err != nil {
+		t.Fatalf("stat cold log: %v", err)
+	}
+	if err := s.SeedCold(ctx, "f", extents); err != nil {
+		t.Fatalf("SeedCold again: %v", err)
+	}
+	second, err := os.Stat(filepath.Join(dir, coldLogName))
+	if err != nil {
+		t.Fatalf("stat cold log: %v", err)
+	}
+	if second.Size() != first.Size() {
+		t.Errorf("re-seeding appended %d bytes for ranges already covered; the log grows on every open",
+			second.Size()-first.Size())
+	}
+}
+
+// TestColdSeededMarkerSurvivesReopen: the marker is what keeps a repaired store
+// from paying for the manifest scan on every start, so it has to be on disk
+// rather than in memory.
+func TestColdSeededMarkerSurvivesReopen(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
+
+	s, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if s.ColdSeeded() {
+		t.Fatal("a fresh journal reports it has already been seeded, so the repair scan never runs")
+	}
+	if err := s.MarkColdSeeded(); err != nil {
+		t.Fatalf("MarkColdSeeded: %v", err)
+	}
+	if !s.ColdSeeded() {
+		t.Fatal("the marker was written but is not reported")
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	s2, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = s2.Close() }()
+	if !s2.ColdSeeded() {
+		t.Error("the marker did not survive a reopen, so every start rescans the manifest")
+	}
+}

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -372,27 +372,51 @@ func (s *Store) Hydrate(ctx context.Context, id FileID, offset int64, data []byt
 // be lost on the next restart, turning the ranges back into holes that read as
 // zeros with no fetch. Extents are taken a whole file at a time so seeding a
 // manifest costs one fsync per file rather than one per extent.
+//
+// Only the parts of each extent the file index does not already cover are
+// seeded. A cold interval carries a fresh version, so seeding over a range the
+// journal holds locally would shadow those bytes — including bytes not yet on
+// the remote, which a cold read cannot fetch back. Skipping covered ranges makes
+// the call idempotent and safe to repeat against a store that is only partly
+// missing its markers, at the cost of nothing on a store that has none.
 func (s *Store) SeedCold(_ context.Context, id FileID, extents [][2]int64) error {
 	if s.closed.Load() {
 		return errClosed
 	}
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	fi := sh.index[id]
 	entries := make([]coldEntry, 0, len(extents))
 	for _, e := range extents {
 		if e[1] <= 0 {
 			continue
 		}
-		entries = append(entries, coldEntry{id: id, fileOff: e[0], length: e[1], version: s.nextVersion()})
+		if fi == nil { // unknown file: the whole extent is a hole
+			entries = append(entries, coldEntry{id: id, fileOff: e[0], length: e[1], version: s.nextVersion()})
+			continue
+		}
+		for _, p := range fi.plan(e[0], e[1]) {
+			if !p.hole {
+				continue
+			}
+			entries = append(entries, coldEntry{
+				id:      id,
+				fileOff: e[0] + p.dstStart,
+				length:  p.dstEnd - p.dstStart,
+				version: s.nextVersion(),
+			})
+		}
 	}
+	sh.mu.Unlock()
 	if len(entries) == 0 {
 		return nil
 	}
 	if err := s.appendCold(entries); err != nil {
 		return err
 	}
-	sh := s.shardFor(id)
 	sh.mu.Lock()
 	defer sh.mu.Unlock()
-	fi := sh.indexFor(id)
+	fi = sh.indexFor(id)
 	for _, e := range entries {
 		fi.insert(interval{
 			fileOff: e.fileOff,

--- a/pkg/controlplane/runtime/shares/legacy_migrate_test.go
+++ b/pkg/controlplane/runtime/shares/legacy_migrate_test.go
@@ -47,16 +47,11 @@ func newMigrateEngine(t *testing.T, dir string, ms *metamem.MemoryMetadataStore,
 	if err := bs.Start(context.Background()); err != nil {
 		t.Fatalf("engine.Start: %v", err)
 	}
-	// The fs store's migration flag is consumed here, the same way
-	// ConfigureBlockStore does it after bs.Start: seed, verify, then reap.
-	if m, ok := any(localStore).(legacyArchiveMigrator); ok && m.MigratedFromLegacy() {
-		report, err := SeedColdFromManifest(context.Background(), bs, ms)
-		if err != nil {
-			t.Fatalf("SeedColdFromManifest: %v", err)
-		}
-		if err := finishLegacyArchiveMigration(context.Background(), bs, m, report, "test"); err != nil {
-			t.Fatalf("finishLegacyArchiveMigration: %v", err)
-		}
+	// The cold seed runs here the same way createBlockStoreForShare runs it after
+	// bs.Start: seed what the manifest covers and the journal does not, then
+	// verify and reap an archive if this open made one.
+	if err := seedColdIfNeeded(context.Background(), bs, localStore, ms, true, "test"); err != nil {
+		t.Fatalf("seedColdIfNeeded: %v", err)
 	}
 	return bs
 }
@@ -276,4 +271,57 @@ func TestLegacyRemoteMigration_ReadsColdAfterRestart(t *testing.T) {
 	bs3 := newMigrateEngine(t, dir, ms, rem, false)
 	t.Cleanup(func() { _ = bs3.Close() })
 	readAllLegacyFiles(t, bs3, "after migration + restart")
+}
+
+// stripPreJournalLayout leaves the local dir in the state a build that migrated
+// the share and only seeded its cold intervals in memory left behind: the legacy
+// blobs/+logs/ are gone, the manifest and the remote are intact, and the journal
+// holds nothing at all. Nothing about the directory says a migration ever
+// happened, so the flag that drove the one-shot seed reads false forever.
+func stripPreJournalLayout(t *testing.T, dir string) {
+	t.Helper()
+	for _, sub := range []string{"blobs", "logs"} {
+		if err := os.RemoveAll(filepath.Join(dir, sub)); err != nil {
+			t.Fatalf("remove %s: %v", sub, err)
+		}
+	}
+}
+
+// TestColdReseed_AfterMigrationUnderAnEarlierBuild is the cohort the one-shot
+// migration flag cannot reach: the share was migrated by a build whose seeded
+// intervals did not survive the restart, so its manifest ranges are now ordinary
+// POSIX holes. A read of them zero-fills with no fetch and no error — the file is
+// the right length and the wrong content — and no later start repairs it, because
+// the archive rename that used to trigger the seed happened once, under the old
+// build. Opening it must notice the local tier has never been seeded and seed it.
+func TestColdReseed_AfterMigrationUnderAnEarlierBuild(t *testing.T) {
+	dir, ms, rem := plantPreJournalShare(t)
+	stripPreJournalLayout(t, dir)
+
+	bs := newMigrateEngine(t, dir, ms, rem, false)
+	t.Cleanup(func() { _ = bs.Close() })
+	readAllLegacyFiles(t, bs, "after re-seeding a share migrated by an earlier build")
+}
+
+// TestColdReseed_SurvivesRestartAndIsRecordedOnce pins the two halves of the
+// repair that are not about the bytes: the re-seeded intervals are durable (a
+// restart must not put the holes back), and the local tier records that it has
+// been seeded so later starts skip the O(files) manifest scan.
+func TestColdReseed_SurvivesRestartAndIsRecordedOnce(t *testing.T) {
+	dir, ms, rem := plantPreJournalShare(t)
+	stripPreJournalLayout(t, dir)
+
+	bs := newMigrateEngine(t, dir, ms, rem, false)
+	if err := bs.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	// Deliberately no read before the restart: a read would hydrate the bytes
+	// into the journal as warm records and mask a seed that was never persisted.
+	if _, err := os.Stat(filepath.Join(dir, "journal", "cold-seeded")); err != nil {
+		t.Fatalf("the re-seed left no durable record, so every start rescans the manifest: %v", err)
+	}
+
+	bs2 := newMigrateEngine(t, dir, ms, rem, false)
+	t.Cleanup(func() { _ = bs2.Close() })
+	readAllLegacyFiles(t, bs2, "after a re-seed + restart")
 }

--- a/pkg/controlplane/runtime/shares/legacy_verify.go
+++ b/pkg/controlplane/runtime/shares/legacy_verify.go
@@ -25,6 +25,8 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/block/local"
+	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
 // coldVerifySamples is how many extents the migration reads back. The failure
@@ -165,6 +167,81 @@ func finishLegacyArchiveMigration(
 		"share", shareName, "payloads", report.payloads, "chunks", report.chunks,
 		"samples_verified", len(report.samples), "bytes_reclaimed", freed)
 	return nil
+}
+
+// seedColdIfNeeded gives a local tier the cold intervals its manifest says it is
+// missing, once per local tier.
+//
+// A journal that opened empty over data that lives on the remote — the open that
+// archived a pre-journal layout aside, or any earlier open that did the same
+// under a build that only seeded in memory — holds no interval for those ranges.
+// They are then indistinguishable from POSIX holes: a read zero-fills, does not
+// fetch, and reports no error. So the trigger is not "this open migrated
+// something" (a one-shot the affected stores have already spent) but "this local
+// tier has never been seeded", which stays true until a seed finishes.
+//
+// The marker is written last. An interrupted seed leaves none and repeats on the
+// next open, which costs a rescan and nothing else: seeding skips the ranges the
+// journal already covers, and the remote bytes and the manifest are untouched
+// throughout.
+//
+// Remote-backed shares only. Seeding a cold interval on a share with no remote
+// would point a read at a store that cannot serve it.
+//
+// ponytail: O(files) manifest scan, once per local tier; a lazy per-read seed is
+// the upgrade path if this ever bites a share with a huge file count.
+func seedColdIfNeeded(
+	ctx context.Context,
+	bs *engine.Store,
+	localStore local.LocalStore,
+	fileChunkStore block.EngineFileChunkStore,
+	remoteConfigured bool,
+	shareName string,
+) error {
+	if !remoteConfigured {
+		return nil
+	}
+	tracker, ok := localStore.(coldSeedTracker)
+	if !ok {
+		return nil
+	}
+	m, isMigrator := localStore.(legacyArchiveMigrator)
+	migrated := isMigrator && m.MigratedFromLegacy()
+	if !migrated && tracker.ColdSeeded() {
+		return nil
+	}
+	metaStore, ok := fileChunkStore.(metadata.Store)
+	if !ok {
+		logger.Warn("local tier has no record of a manifest seed but the metadata store cannot enumerate one; "+
+			"ranges held only by the remote will read as zeros",
+			"share", shareName)
+		return nil
+	}
+	report, err := SeedColdFromManifest(ctx, bs, metaStore)
+	if err != nil {
+		return fmt.Errorf("seed cold intervals from manifest: %w", err)
+	}
+	if migrated {
+		if err := finishLegacyArchiveMigration(ctx, bs, m, report, shareName); err != nil {
+			return err
+		}
+	}
+	if err := tracker.MarkColdSeeded(); err != nil {
+		// The seed itself is durable; only the record of it is missing, so the
+		// next open pays for the scan again and reaches the same state.
+		logger.Warn("seeded cold intervals from the manifest but could not record it; the next start will seed again",
+			"share", shareName, "error", err)
+	}
+	return nil
+}
+
+// coldSeedTracker is the local-store surface that remembers, across restarts,
+// whether this local tier has been seeded from the metadata manifest.
+// Implemented by the journal-backed fs store; other backends never satisfy it,
+// so seeding is skipped for them entirely.
+type coldSeedTracker interface {
+	ColdSeeded() bool
+	MarkColdSeeded() error
 }
 
 // legacyArchiveMigrator is the local-store surface driven after a remote-backed

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1180,30 +1180,9 @@ func (s *Service) createBlockStoreForShare(
 		return fmt.Errorf("failed to start BlockStore: %w", err)
 	}
 
-	// If the local dir carried a pre-journal layout that was just archived aside,
-	// the journal opened empty — reads would zero-fill. Seed a cold interval per
-	// manifest extent so reads fault the bytes back in from the remote (cold
-	// fetch is BLAKE3-verified). The metadata manifest survives the upgrade
-	// intact, so this is safe to re-run: a partial seed loses nothing (remote
-	// bytes + manifest are untouched) and a second start finds no legacy dir and
-	// skips straight to a clean open.
-	// ponytail: O(files) manifest scan at startup; a lazy per-read seed is the
-	// upgrade path if this ever bites a share with a huge file count.
-	if m, ok := localStore.(legacyArchiveMigrator); ok && m.MigratedFromLegacy() {
-		if metaStore, ok := fileChunkStore.(metadata.Store); ok {
-			report, serr := SeedColdFromManifest(ctx, bs, metaStore)
-			if serr != nil {
-				cleanup()
-				return fmt.Errorf("seed cold intervals after legacy migration: %w", serr)
-			}
-			if verr := finishLegacyArchiveMigration(ctx, bs, m, report, config.Name); verr != nil {
-				cleanup()
-				return verr
-			}
-		} else {
-			logger.Warn("migrated pre-journal local layout but metadata store is not manifest-capable; reads will zero-fill until rewritten",
-				"share", config.Name)
-		}
+	if err := seedColdIfNeeded(ctx, bs, localStore, fileChunkStore, remoteConfigured, config.Name); err != nil {
+		cleanup()
+		return err
 	}
 
 	// A local-only share (no remote to re-fetch from) that carried a complete


### PR DESCRIPTION
Fixes #1887.

## The defect

`SeedColdFromManifest` was gated on `MigratedFromLegacy()`, which is true only for the one open that actually performed the pre-journal archive rename. A share migrated by v0.28.x or v0.29.0 returns false on every subsequent start, forever. Those builds seeded the cold intervals in memory only (#1850), so the intervals were lost on the next restart and the ranges became ordinary POSIX holes: `ReadAt` zero-fills with `cold=false`, no hydrate, no error, stable checksum on re-read. Upgrading did not repair it — the newer binary has a durable `cold.log` and nothing writes the missing intervals into it.

## The fix

Two halves, both load-bearing.

**1. A durable completion marker, modelled on `cfg:payload-index-backfilled` from #1886.** `journal.Store` gains `ColdSeeded()` / `MarkColdSeeded()`, backed by an empty `<journal-dir>/cold-seeded` file fsynced through the directory. The seed trigger is no longer "this open migrated something" (a one-shot the affected stores have already spent) but "this local tier has never been seeded", which stays true until a seed finishes. The marker is written **last** — after the seed's `cold.log` entries are durable and after the archive verify/reap — so an interrupted open repeats rather than skips. The marker lives next to the `cold.log` it certifies, so a wiped journal re-seeds.

The decision itself moved out of `createBlockStoreForShare` into `seedColdIfNeeded` (`legacy_verify.go`), which is what the tests drive.

**2. `SeedCold` now seeds only the ranges the file index does not already cover.** This is required, not cleanup: a cold interval carries a fresh version, so seeding over a range the journal holds locally would *shadow* those bytes — including bytes not yet on the remote, which a cold read cannot fetch back. Without it, the once-per-store re-seed would be a data-loss regression on every healthy remote-backed share. With it, the seed is idempotent, safe to repeat, and safe on a store that is only partly missing its markers.

Cost: one manifest scan per local tier, once, on the first start after upgrade — not per restart.

## Scope

- **Reaping is not extended to this path.** `finishLegacyArchiveMigration` stays behind `MigratedFromLegacy()`: seeding is safe on a share that already migrated, deleting the archive is not. A re-seeded share therefore also skips the sample read-back verification, which only exists to decide whether the archive may be deleted. If we want the re-seed to verify (there is a case for it — it would catch a share whose remote cannot serve what the manifest claims), that is a separate change with its own failure policy, since there is no archive to fall back to.
- **`RestoreSnapshot` is unaffected and must stay that way.** It calls `SeedColdFromManifest` directly, not through `seedColdIfNeeded`, so the marker never makes a restore skip re-seeding — a restore legitimately needs to re-seed a share that was seeded before. `ResetLocalState` deletes each file from the journal index, so after a reset every manifest range is a hole and the new gap-only seed covers all of it, exactly as the old unconditional one did. Deliberately not routed through the marker path.
- **One-time `IsSynced` cost not addressed.** `SeedColdFromManifest` does one `IsSynced` round-trip per chunk to build the report, and the report is only consumed by the archive reap. On the re-seed path that work is dead. Cutting it means a signature change and belongs with #1868; it is a one-time cost per store here, not a per-restart one.

## Tests

Both new `shares` tests fail on `develop` with this change reverted:

- `TestColdReseed_AfterMigrationUnderAnEarlierBuild` — plants a pre-journal share, then strips `blobs/`+`logs/` by hand so nothing on disk says a migration happened (`MigratedFromLegacy()` false, manifest and remote intact, journal empty). Without the fix: `read 4096 bytes, byte-identical=false; served wrong bytes`. With it, every file reads back byte-identical.
- `TestColdReseed_SurvivesRestartAndIsRecordedOnce` — no read before the restart (a read would hydrate the bytes as warm records and mask a seed that was never persisted); asserts the marker exists and the re-seeded intervals survive a reopen.

Journal-level:

- `TestSeedColdLeavesLocalBytesAlone` — a seed spanning a locally-written range must not turn it cold or replace it; the ranges either side must still be seeded.
- `TestSeedColdIsIdempotent` — a repeated seed appends nothing.
- `TestColdSeededMarkerSurvivesReopen`.

`go build`, `go vet`, `gofmt -l`, `go test ./...`, `go test -race ./pkg/controlplane/... ./pkg/block/...` and `golangci-lint run` (0 issues) all pass.
