### PR TITLE
fix(block): report the physical segment footprint as local disk_used

### DIFF
--- a/pkg/block/journal/disk_bytes_test.go
+++ b/pkg/block/journal/disk_bytes_test.go
@@ -4,11 +4,17 @@ import (
 	"bytes"
 	"context"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"testing"
 )
 
 // segFileBytes sums the physical size of every .seg file under dir.
+//
+// The size is read from an open handle rather than from the directory entry:
+// the store appends to its active segment without flushing, and a directory
+// entry's cached size may lag those appends until the file is closed, so
+// walking the entries would under-count the segment still being written.
 func segFileBytes(t *testing.T, dir string) int64 {
 	t.Helper()
 	var total int64
@@ -16,13 +22,19 @@ func segFileBytes(t *testing.T, dir string) int64 {
 		if err != nil {
 			return err
 		}
-		if !d.IsDir() && filepath.Ext(path) == ".seg" {
-			info, ierr := d.Info()
-			if ierr != nil {
-				return ierr
-			}
-			total += info.Size()
+		if d.IsDir() || filepath.Ext(path) != ".seg" {
+			return nil
 		}
+		f, oerr := os.Open(path)
+		if oerr != nil {
+			return oerr
+		}
+		defer func() { _ = f.Close() }()
+		info, ierr := f.Stat()
+		if ierr != nil {
+			return ierr
+		}
+		total += info.Size()
 		return nil
 	})
 	if err != nil {

--- a/pkg/block/journal/disk_bytes_test.go
+++ b/pkg/block/journal/disk_bytes_test.go
@@ -1,0 +1,89 @@
+package journal
+
+import (
+	"bytes"
+	"context"
+	"io/fs"
+	"path/filepath"
+	"testing"
+)
+
+// segFileBytes sums the physical size of every .seg file under dir.
+func segFileBytes(t *testing.T, dir string) int64 {
+	t.Helper()
+	var total int64
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && filepath.Ext(path) == ".seg" {
+			info, ierr := d.Info()
+			if ierr != nil {
+				return ierr
+			}
+			total += info.Size()
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %q: %v", dir, err)
+	}
+	return total
+}
+
+// Stats().DiskBytes must equal the segment bytes on disk after a reopen, and a
+// store whose seeded footprint already exceeds its cap must evict down to it on
+// the next write rather than refuse the write or spin without reclaiming.
+func TestDiskBytesSeededOverCapConvergesDown(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
+
+	first, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	// Hydrate writes land synced, so every sealed segment is evictable after the
+	// reopen without a carve pass.
+	buf := bytes.Repeat([]byte{0xCD}, chunk256)
+	for i := range 24 {
+		if err := first.Hydrate(ctx, "f", int64(i)*chunk256, buf); err != nil {
+			t.Fatalf("Hydrate: %v", err)
+		}
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	onDisk := segFileBytes(t, dir)
+	// Cap well below the footprint the previous run left behind.
+	capBytes := onDisk / 4
+	reopened := Config{ShardCount: 1, SegmentSize: minSegmentSize, MaxLocalBytes: capBytes}
+
+	s, err := Open(dir, reopened, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	if got := s.Stats().DiskBytes; got != onDisk {
+		t.Fatalf("DiskBytes after reopen = %d, want %d (bytes physically on disk)", got, onDisk)
+	}
+	if onDisk <= capBytes {
+		t.Fatalf("fixture is not over cap: on disk %d, cap %d", onDisk, capBytes)
+	}
+
+	// The write-path gate now sees the real footprint and reclaims down to the
+	// cap instead of concluding there is headroom.
+	if err := s.Hydrate(ctx, "f", 64<<20, buf); err != nil {
+		t.Fatalf("write over seeded cap: %v", err)
+	}
+	// Eviction is whole-segment and admission does not reserve, so the cap is a
+	// pressure threshold: allow one segment of overshoot.
+	if got, limit := s.Stats().DiskBytes, capBytes+minSegmentSize; got > limit {
+		t.Fatalf("DiskBytes = %d, want <= %d (cap %d plus one segment of overshoot)", got, limit, capBytes)
+	}
+	if got := s.Stats().DiskBytes; got != segFileBytes(t, dir) {
+		t.Fatalf("DiskBytes = %d, drifted from on-disk %d after eviction", got, segFileBytes(t, dir))
+	}
+}

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -128,7 +128,16 @@ func (c Config) withDefaults() Config {
 
 // Stats is a coarse snapshot of store state, cheap to compute.
 type Stats struct {
-	Segments      int
+	Segments int
+	// DiskBytes is the physical footprint of the segment files: segment headers
+	// plus record framing plus payload, seeded at recovery from the segments
+	// already on disk and maintained by every append and retire. It is the
+	// figure the eviction gate compares against MaxLocalBytes.
+	DiskBytes int64
+	// LiveBytes and DeadBytes are payload-only accounting, both derived from
+	// record PayloadLen. LiveBytes counts every payload byte a segment has ever
+	// been charged for and DeadBytes the share of those since superseded, so
+	// they overlap and must not be summed into a footprint.
 	LiveBytes     int64
 	DeadBytes     int64
 	UnsyncedBytes int64
@@ -508,6 +517,7 @@ func (s *Store) UnsyncedBytes() int64 { return s.unsynced.Load() }
 // Stats returns a coarse snapshot of store state.
 func (s *Store) Stats() Stats {
 	st := Stats{
+		DiskBytes:     s.diskBytes.Load(),
 		UnsyncedBytes: s.unsynced.Load(),
 		Writes:        s.writes.Load(),
 		Reads:         s.reads.Load(),

--- a/pkg/block/local/fs/disk_used_test.go
+++ b/pkg/block/local/fs/disk_used_test.go
@@ -1,0 +1,83 @@
+package fs
+
+import (
+	"context"
+	"io/fs"
+	"path/filepath"
+	"testing"
+)
+
+// segmentBytesOnDisk sums the physical size of every journal segment file under
+// dir — the footprint an operator sees with du, and what DiskUsed must report.
+func segmentBytesOnDisk(t *testing.T, dir string) int64 {
+	t.Helper()
+	var total int64
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".seg" {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		total += info.Size()
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %q: %v", dir, err)
+	}
+	if total == 0 {
+		t.Fatalf("fixture wrote no segment bytes under %q", dir)
+	}
+	return total
+}
+
+// A store opened over blocks a previous process wrote must report the footprint
+// that is actually on disk. An incrementally-maintained counter that only ever
+// saw this session's writes would report a fraction of it, leaving the evictor
+// convinced there is headroom while the volume fills.
+func TestStats_DiskUsedReportsPreExistingFootprint(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	// First process: write a payload, then overwrite part of it so the store
+	// holds superseded records too — payload-length accounting charges those
+	// twice (once live, once dead) and so cannot stand in for the footprint.
+	first, err := New(dir, 0, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	data := make([]byte, 1<<20)
+	for i := range 4 {
+		if err := first.WriteAt(ctx, "payload-a", int64(i)<<20, data); err != nil {
+			t.Fatalf("WriteAt: %v", err)
+		}
+	}
+	for range 3 {
+		if err := first.WriteAt(ctx, "payload-a", 0, data); err != nil {
+			t.Fatalf("overwrite: %v", err)
+		}
+	}
+	if err := first.Commit(ctx, "payload-a"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	want := segmentBytesOnDisk(t, dir)
+
+	// Second process: opens the same directory and writes nothing.
+	second, err := New(dir, 0, nil)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = second.Close() }()
+
+	if got := second.Stats().DiskUsed; got != want {
+		t.Fatalf("DiskUsed after fresh open = %d, want %d (bytes physically on disk)", got, want)
+	}
+}

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -261,10 +261,16 @@ func (s *FSStore) Durable() bool { return s.durable.Load() }
 func (s *FSStore) SetDurable(v bool) { s.durable.Store(v) }
 
 // Stats maps the journal's coarse stats onto the local.Stats admin shape.
+//
+// DiskUsed reports the journal's physical segment footprint — the same counter
+// the eviction gate compares against the disk limit, seeded at open from the
+// segments already on disk — so the reported usage cannot disagree with the
+// figure eviction acts on, and a store filled by an earlier run reports what it
+// holds rather than only what this process wrote.
 func (s *FSStore) Stats() local.Stats {
 	js := s.Store.Stats()
 	return local.Stats{
-		DiskUsed:    js.LiveBytes + js.DeadBytes,
+		DiskUsed:    js.DiskBytes,
 		MaxDisk:     s.maxDisk,
 		MaxLogBytes: s.maxLogBytes,
 		FileCount:   len(s.Store.ListFiles(context.Background())),

--- a/pkg/controlplane/runtime/coldread_delete_reclaim_test.go
+++ b/pkg/controlplane/runtime/coldread_delete_reclaim_test.go
@@ -13,7 +13,7 @@ import (
 // TestColdReadThenDeleteReclaimsLocal reproduces the blocks-flip SMB local-disk
 // leak: after a file is carved+synced to the remote, evicted, and then
 // COLD-READ (which hydrates its bytes back into the local journal), deleting
-// the file must free the local tier back to zero.
+// the file must free the hydrated bytes from the local tier.
 //
 // The NFS variant of the E2E stays green because a kernel NFS client serves the
 // post-evict read from its own page cache, so the server never hydrates and has
@@ -116,7 +116,12 @@ func TestColdReadThenDeleteReclaimsLocal(t *testing.T) {
 		}
 	}
 
-	if afterDelete != 0 {
-		t.Fatalf("local DiskUsed after delete = %d, want 0 (cold-read hydration leaked on unlink)", afterDelete)
+	// DiskUsed reports the physical segment footprint, so the delete leaves the
+	// tombstone record and its segment header behind — real bytes, but framing
+	// only. What must be gone is the hydrated payload.
+	const framingAllowance = 64 << 10
+	if afterDelete > framingAllowance {
+		t.Fatalf("local DiskUsed after delete = %d, want <= %d (cold-read hydration leaked on unlink)",
+			afterDelete, framingAllowance)
 	}
 }


### PR DESCRIPTION
Refs #1527. Do not merge yet — the reporter offered to test a patched build first.

## What #1539 actually did (correcting my closure comment)

My closure comment on #1527 said #1539 added a "startup reconcile against on-disk state". That was true of the code #1539 shipped, but it no longer exists: #1539 landed on 2026-07-04 against the pre-journal `blobs/`+`logs/` layout, and the Wall-A journal switchover (48959441, 2026-07-16) replaced that whole store. Concretely, #1539 added:

- `Recover` counting legacy CAS chunk files into the `diskUsed` seed
- `newFSStore` seeding `logBlobDiskUsed` from `ListBlobs`
- `usedBytes() = diskUsed + logBlobDiskUsed` as the figure both `Stats()` and `ensureSpace` read
- `subUsed` underflow clamp, whole-blob eviction

`diskUsed`, `logBlobDiskUsed`, `usedBytes`, `seedLRUFromDisk` and `blobEvictOne` are all gone. So the accurate statement for #1527 is **present but not wired to the reported counter**: the journal does reconcile at startup, and the counter the *evictor* gates on is correctly seeded — but the counter the *metric* reports is a different, payload-derived figure that is not the on-disk footprint.

## Where the accounting lives at the tip

Two counters, and they were not the same number:

| | seeded at open? | what it measures | who reads it |
|---|---|---|---|
| `journal.Store.diskBytes` | yes — `recover()` sums every recovered segment's `tail` (`recovery.go:421-431`) | physical `.seg` bytes: segment headers + record framing + payload | `ensureSpace` (`reclaim.go:265`), the eviction gate |
| `Stats().LiveBytes + DeadBytes` | yes, but as payload lengths | payload only | `FSStore.Stats().DiskUsed` → `LocalDiskUsed` → `dittofs_localstore_disk_used_bytes` |

The reported figure was wrong in both directions:

- **Over**, because `LiveBytes` and `DeadBytes` overlap. `LiveBytes` is "physical payload bytes ever written here" (see `reclaim.go:567`) and `DeadBytes` is the share of those since superseded, so summing them charges every superseded record twice. Measured: 8 x 1 MiB overwrites of one range reported 15,728,640 against 8,390,337 actually on disk.
- **Under**, because payload lengths ignore the segment header and per-record framing, and — the case that matters for a share whose data predates the running build — anything on disk that is not a journal record at all.

So an operator reading `disk_used_bytes` against `disk_limit_bytes` was not reading the number eviction acts on.

## The change

Report the journal's `diskBytes` as `DiskUsed`. Three lines plus doc comments:

- `journal.Stats` gains `DiskBytes` (`s.diskBytes.Load()`), documented as the physical footprint, with `LiveBytes`/`DeadBytes` documented as overlapping payload accounting that must not be summed into a footprint.
- `FSStore.Stats()` reports `js.DiskBytes` instead of `js.LiveBytes + js.DeadBytes`.

No new walk. The parent counter is already seeded by the walk `recover()` performs anyway, which is why this is a re-wire rather than a second startup pass.

## Tests

`TestStats_DiskUsedReportsPreExistingFootprint` (`pkg/block/local/fs/disk_used_test.go`) — one process writes 4 MiB and then overwrites part of it, closes; a second process opens the same directory and writes nothing; `Stats().DiskUsed` must equal the `.seg` bytes physically on disk. On develop: `DiskUsed = 10485760, want 7341350`.

`TestDiskBytesSeededOverCapConvergesDown` (`pkg/block/journal/disk_bytes_test.go`) — covers the over-cap case: a directory filled by a previous run is reopened with `MaxLocalBytes` at a quarter of its footprint. The seeded counter reports the true footprint, and the next write drives `ensureSpace` down to the cap (whole-segment eviction, so one segment of overshoot is allowed) rather than refusing or spinning. This passes on develop too — the evictor's own counter was never the broken one — but it pins the property the fix is claimed to restore.

`TestColdReadThenDeleteReclaimsLocal` asserted `DiskUsed == 0` after an unlink, which only held for a payload-only counter. A delete leaves a tombstone record and its segment header on disk — real bytes. Relaxed to a 64 KiB framing allowance, which still fails loudly if the 16 MiB of hydrated payload leaks.

## Snapshot restore

Checked, no change needed. `engine.ResetLocalState` deletes per payload through `local.Delete`, and `journal.RestoreToVersion` re-materializes through the ordinary `Delete`/`WriteAt` path — both maintain `diskBytes` through the normal append/retire bookkeeping. Neither reinitialises a counter of its own, so there is no second site to route through the same helper. This is a consequence of reporting the journal's own counter rather than a parallel one: there is now a single figure, so a path that goes through the journal cannot leave it unseeded.

## What this does not fix

The reporter's headline ratio — 3.76 GB counted against ~63 GiB present on v0.28.1 — is only partly this. Their share is remote-backed (Cubbit DS3), so the upgrade took the `MigrateLegacyLayout` path, which renames the pre-journal `blobs/` and `logs/` aside to `*.pre-journal-backup` and lets the journal open clean. Those archived directories are inside the store dir, so `du -sh /var/lib/dittofs/blocks` counts them, and nothing in the block store does — they are not journal segments. The bulk of their 63 GiB is almost certainly sitting there.

That archive is reaped by the verify-then-discard path added in #1859 (v0.29.2), so a current build should release it. Deliberately not adding archive bytes to `DiskUsed`: the evictor gates on that number, and charging it for bytes it has no way to free would make it evict live segments to chase a total it can never reach — thrash, and the opposite of the convergence the second test pins. If the reporter's build still shows a large `du`/`disk_used` gap after the archive is reaped, that is a separate report and the archive paths are already listed by `LegacyArchivePaths()`.

## Gates

`go build ./...`, `go vet ./...`, `gofmt -l .` (empty), `go test ./...`, `go test -race ./pkg/block/...`, `golangci-lint run` (0 issues) — all green.
