### PR TITLE
fix(sqlite,postgres): propagate GetLinkCount query errors instead of reporting zero links

### DIFF
--- a/pkg/metadata/file_create.go
+++ b/pkg/metadata/file_create.go
@@ -176,8 +176,13 @@ func (s *Service) CreateHardLink(ctx *AuthContext, dirHandle FileHandle, name st
 			return err
 		}
 
-		// Increment target's link count
-		linkCount, _ := tx.GetLinkCount(ctx.Context, targetHandle)
+		// Increment target's link count. A failed read must abort: writing an
+		// nlink below the number of directory entries pointing at the file lets
+		// a later unlink free content that is still referenced.
+		linkCount, err := tx.GetLinkCount(ctx.Context, targetHandle)
+		if err != nil {
+			return err
+		}
 		if err := tx.SetLinkCount(ctx.Context, targetHandle, linkCount+1); err != nil {
 			return err
 		}

--- a/pkg/metadata/store/postgres/files.go
+++ b/pkg/metadata/store/postgres/files.go
@@ -182,9 +182,13 @@ func (s *PostgresMetadataStore) GetLinkCount(ctx context.Context, handle metadat
 
 	var count uint32
 	err = s.queryRow(ctx, `SELECT nlink FROM inodes WHERE id = $1`, fileID).Scan(&count)
-	if err != nil {
+	if errors.Is(err, pgx.ErrNoRows) {
 		// Not found means count is 0
 		return 0, nil
+	}
+	if err != nil {
+		// A fabricated 0 would let callers treat live content as unreferenced.
+		return 0, mapPgError(err, "GetLinkCount", "")
 	}
 
 	return count, nil

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -821,9 +821,13 @@ func (tx *postgresTransaction) GetLinkCount(ctx context.Context, handle metadata
 
 	var count uint32
 	err = tx.tx.QueryRow(ctx, `SELECT nlink FROM inodes WHERE id = $1`, fileID).Scan(&count)
-	if err != nil {
+	if errors.Is(err, pgx.ErrNoRows) {
 		// Not found means count is 0
 		return 0, nil
+	}
+	if err != nil {
+		// A fabricated 0 would let callers treat live content as unreferenced.
+		return 0, mapPgError(err, "GetLinkCount", "")
 	}
 
 	return count, nil

--- a/pkg/metadata/store/sqlite/files.go
+++ b/pkg/metadata/store/sqlite/files.go
@@ -181,9 +181,13 @@ func (s *SQLiteMetadataStore) GetLinkCount(ctx context.Context, handle metadata.
 
 	var count uint32
 	err = s.queryRow(ctx, `SELECT nlink FROM inodes WHERE id = ?1`, fileID).Scan(&count)
-	if err != nil {
+	if errors.Is(err, sql.ErrNoRows) {
 		// Not found means count is 0
 		return 0, nil
+	}
+	if err != nil {
+		// A fabricated 0 would let callers treat live content as unreferenced.
+		return 0, mapDBError(err, "GetLinkCount", "")
 	}
 
 	return count, nil

--- a/pkg/metadata/store/sqlite/link_count_test.go
+++ b/pkg/metadata/store/sqlite/link_count_test.go
@@ -1,0 +1,57 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
+)
+
+// TestSQLite_GetLinkCountPropagatesQueryFailure pins that GetLinkCount reports
+// only a missing row as zero links and surfaces every other query failure.
+// Callers branch on the count to decide whether a file's content is still
+// referenced, so a fabricated 0 makes the removal path free live content.
+//
+// The failure is injected by dropping the inodes table out from under the
+// store, so the SELECT fails with "no such table" rather than sql.ErrNoRows.
+// That is safe here because each sqlite test store is a private database file.
+// The postgres store carries the identical branch, but its tests share one
+// database, so the same DDL would strand every test after it.
+func TestSQLite_GetLinkCountPropagatesQueryFailure(t *testing.T) {
+	ctx := context.Background()
+	store := newSQLiteStoreFactory()(t)
+
+	handle, err := metadata.EncodeShareHandle("testshare", uuid.New())
+	if err != nil {
+		t.Fatalf("EncodeShareHandle: %v", err)
+	}
+
+	// An absent row is not an error: the count is genuinely zero.
+	count, err := store.GetLinkCount(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetLinkCount on a missing row must return (0, nil); got err %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("GetLinkCount on a missing row = %d, want 0", count)
+	}
+
+	db := store.(*sqlite.SQLiteMetadataStore).DBForBench()
+	if _, err := db.ExecContext(ctx, `DROP TABLE inodes`); err != nil {
+		t.Fatalf("dropping inodes to inject a query failure: %v", err)
+	}
+
+	if _, err := store.GetLinkCount(ctx, handle); err == nil {
+		t.Error("pool GetLinkCount reported success on a failing query")
+	}
+
+	txErr := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		_, err := tx.GetLinkCount(ctx, handle)
+		return err
+	})
+	if txErr == nil {
+		t.Error("transaction GetLinkCount reported success on a failing query")
+	}
+}

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -763,9 +763,13 @@ func (tx *sqliteTransaction) GetLinkCount(ctx context.Context, handle metadata.F
 
 	var count uint32
 	err = tx.tx.QueryRow(ctx, `SELECT nlink FROM inodes WHERE id = ?1`, fileID).Scan(&count)
-	if err != nil {
+	if errors.Is(err, sql.ErrNoRows) {
 		// Not found means count is 0
 		return 0, nil
+	}
+	if err != nil {
+		// A fabricated 0 would let callers treat live content as unreferenced.
+		return 0, mapDBError(err, "GetLinkCount", "")
 	}
 
 	return count, nil


### PR DESCRIPTION
Relates to #1897.

## Problem

`GetLinkCount` treated **every** query error as a missing row and returned `(0, nil)`:

```go
err = s.queryRow(ctx, `SELECT nlink FROM inodes WHERE id = ?1`, fileID).Scan(&count)
if err != nil {
    // Not found means count is 0
    return 0, nil
}
```

Callers branch on the returned count to decide whether a file`s content is still referenced, so any transient fault read as `nlink=0`:

- `pkg/metadata/file_remove.go:171-175` has an explicit do-not-free-the-payload fallback (`if lcErr != nil { linkCount = 1 }`). It was unreachable, so a failed read fell into the `linkCount > 1` check as 0, took the last-link branch, and marked live content deletable.
- `CreateHardLink` in `pkg/metadata/file_create.go` discarded the error entirely and fed the fabricated 0 into `SetLinkCount(count+1)`.

Data-loss class, on the delete and hardlink write paths.

## Fix

Branch on the driver no-rows sentinel for the genuine zero case, and map every other error - matching how `GetChild` / `GetParent` / `SetLinkCount` already behave in the same files:

```go
if errors.Is(err, sql.ErrNoRows) {
    // Not found means count is 0
    return 0, nil
}
if err != nil {
    // A fabricated 0 would let callers treat live content as unreferenced.
    return 0, mapDBError(err, "GetLinkCount", "")
}
```

Applied to all four affected methods: the pool method and the transaction method in **both** sqlite and postgres. `CreateHardLink` now propagates the read error instead of discarding it.

## Siblings checked

| Backend | State |
|---|---|
| sqlite | **had the defect** (files.go + transaction.go) - fixed |
| postgres | **had the identical defect** (files.go + transaction.go) - fixed in this PR |
| badger | already propagates (`transaction.go:913`) - no change |
| memory | reads a map, no error path - no change |

Every non-store caller of `GetLinkCount` was grepped: `file_create.go:182` was the only one discarding the error. `file_modify.go`, `file_remove.go`, and `directory.go` all already propagate.

`CreateHardLink` is not a behaviour regression: it already resolves the target via `GetFile` and fails on a missing target *before* entering the transaction, so the only way the new error path fires is a genuine DB fault or a cancelled context.

## Test

`TestSQLite_GetLinkCountPropagatesQueryFailure` asserts a missing row still yields `(0, nil)`, then drops the `inodes` table out from under the store so the SELECT fails with `no such table` rather than `sql.ErrNoRows`, and pins that both the pool and transaction methods surface an error. Verified it fails on the pre-fix code:

```
--- FAIL: TestSQLite_GetLinkCountPropagatesQueryFailure
    link_count_test.go:52: pool GetLinkCount reported success on a failing query
    link_count_test.go:61: transaction GetLinkCount reported success on a failing query
```

Kept sqlite-local rather than in `pkg/metadata/storetest/`: the fault injection is destructive DDL, which badger and memory cannot express, and each sqlite test store is a private database file so the drop is contained. The postgres conformance harness deliberately shares one database across subtests, so the same DDL there would strand every later test.

## Verification

```
go build ./... && go vet ./... && gofmt -l .   # clean
go vet -tags integration ./pkg/metadata/store/postgres/   # clean
go test ./pkg/metadata/...                     # 15/15 ok
```