### PR TITLE
fix(metadata): make Identity.HasGID a pure read so concurrent callers are safe

### DIFF
--- a/pkg/metadata/auth_identity.go
+++ b/pkg/metadata/auth_identity.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"regexp"
+	"slices"
 
 	"github.com/marmos91/dittofs/pkg/metadata/acl"
 )
@@ -166,11 +167,6 @@ type Identity struct {
 	// Empty for anonymous or simple authentication
 	GIDs []uint32
 
-	// gidSet is a cached map for O(1) group membership lookups
-	// Automatically populated from GIDs on first use
-	// Not exported - internal optimization detail
-	gidSet map[uint32]struct{}
-
 	// Windows-style identity
 	// Used by SMB/CIFS and Windows-based protocols
 
@@ -197,35 +193,12 @@ type Identity struct {
 	Domain string
 }
 
-// HasGID checks if the identity has the specified group ID in its supplementary groups.
+// HasGID reports whether gid is among the identity's supplementary groups.
 //
-// Provides O(1) group membership lookup by lazily building and caching
-// a map on first use. For users with many supplementary groups (e.g., 50-100+),
-// this is significantly faster than linear search.
-//
-// Thread safety: NOT thread-safe. Identity objects should not be
-// shared across goroutines, or callers must provide their own synchronization.
-//
-// Parameters:
-//   - gid: The group ID to check for
-//
-// Returns:
-//   - bool: true if the GID is in the supplementary groups list, false otherwise
+// The scan mutates nothing, so it is safe to call concurrently on one Identity —
+// the SMB session layer shares a single *Identity across all requests on a session.
 func (i *Identity) HasGID(gid uint32) bool {
-	if len(i.GIDs) == 0 {
-		return false
-	}
-
-	// Lazy initialization of the GID set
-	if i.gidSet == nil {
-		i.gidSet = make(map[uint32]struct{}, len(i.GIDs))
-		for _, g := range i.GIDs {
-			i.gidSet[g] = struct{}{}
-		}
-	}
-
-	_, exists := i.gidSet[gid]
-	return exists
+	return slices.Contains(i.GIDs, gid)
 }
 
 // IdentityMapping defines how client identities are transformed.

--- a/pkg/metadata/authentication_test.go
+++ b/pkg/metadata/authentication_test.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -56,32 +57,36 @@ func TestIdentity_HasGID(t *testing.T) {
 
 		assert.True(t, identity.HasGID(300))
 	})
+}
 
-	t.Run("lazy map initialization", func(t *testing.T) {
-		t.Parallel()
-		identity := &Identity{GIDs: []uint32{100, 200, 300}}
+// TestIdentity_HasGID_Concurrent asserts HasGID is safe on an Identity shared by
+// several goroutines, as the SMB per-session identity cache does: one *Identity
+// is handed to every concurrent request on the session.
+func TestIdentity_HasGID_Concurrent(t *testing.T) {
+	t.Parallel()
 
-		// Map should be nil initially
-		assert.Nil(t, identity.gidSet)
+	gids := make([]uint32, 64)
+	for i := range gids {
+		gids[i] = uint32(i) + 100
+	}
+	identity := &Identity{GIDs: gids}
 
-		// First call should initialize map
-		_ = identity.HasGID(200)
-
-		// Map should now be populated
-		assert.NotNil(t, identity.gidSet)
-		assert.Len(t, identity.gidSet, 3)
-	})
-
-	t.Run("subsequent calls use cached map", func(t *testing.T) {
-		t.Parallel()
-		identity := &Identity{GIDs: []uint32{100, 200, 300}}
-
-		// Multiple calls should work correctly
-		assert.True(t, identity.HasGID(100))
-		assert.True(t, identity.HasGID(200))
-		assert.True(t, identity.HasGID(300))
-		assert.False(t, identity.HasGID(400))
-	})
+	const goroutines = 16
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for _, want := range gids {
+				assert.True(t, identity.HasGID(want))
+				assert.False(t, identity.HasGID(want+1_000_000))
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
 }
 
 // ============================================================================


### PR DESCRIPTION
Relates to #1895.

## Problem

`Identity.HasGID` lazily built and wrote an unsynchronized `gidSet map[uint32]struct{}` on first call. Its godoc declared the type NOT thread-safe — but the only real caller violates that contract:

- `session.CachedAuthIdentity` / `SetCachedAuthIdentity` memoize **one** `*metadata.Identity` per SMB session, and `handlers/auth_helper.go` hands that same pointer to every request on the session.
- Concurrency on a single session is real: a parked CREATE resumes via `completeCreateAfterBreak` in its own goroutine, alongside the connection dispatch loop.
- Both goroutines reach `HasGID` through `file_access_checker.go`, `auth_permissions.go`, `file_create.go`, `file_modify.go`.

A concurrent map write is a fatal runtime throw, not merely a race-detector hit.

## Fix

Delete the `gidSet` field and scan `GIDs` directly with `slices.Contains`, making `HasGID` a pure read. That leaves `Identity` with no post-construction mutation at all, so the shared pointer is safe without any locking.

Cost is negligible: `HasGID` runs once per permission check (never in a tight loop), and `GIDs` holds tens of entries at most — NFS AUTH_SYS caps at 16, SMB derives from `user.Groups`. Behaviour is unchanged: `slices.Contains` on a nil/empty slice returns false, matching the old early return.

Audited every other `.GIDs` write to confirm none touches a published identity: `buildIdentity` populates before caching, and `ApplyIdentityMapping` / `ApplyAnonymousIdentity` / `ApplyRootIdentity` mutate only a freshly allocated copy.

## Verification

`TestIdentity_HasGID_Concurrent` shares one `*Identity` across 16 goroutines released by a barrier. Confirmed it genuinely regresses — with the fix temporarily reverted:

```
WARNING: DATA RACE
Write at 0x00c0003b0098 by goroutine 19:
  pkg/metadata.(*Identity).HasGID() auth_identity.go:216
Previous read at 0x00c0003b0098 by goroutine 20:
  pkg/metadata.(*Identity).HasGID() auth_identity.go:215
--- FAIL: TestIdentity_HasGID_Concurrent (0.00s)
    testing.go:1712: race detected during execution of test
```

CI already runs `go test -race`, so the guard is live.

With the fix in place:

- `go build ./...`, `go vet ./...`, `gofmt -l .` — all clean
- `go test -race ./pkg/metadata/...` — all 17 packages ok
- `go test ./internal/adapter/smb/...` — all 12 packages ok

Two subtests that asserted on the deleted `gidSet` field are removed; the existing table already covers the lookup semantics.