### PR TITLE
fix(block): fetch chunks after a sparse hole instead of skipping to the block boundary

### DIFF
--- a/pkg/block/engine/cold_read_hole_test.go
+++ b/pkg/block/engine/cold_read_hole_test.go
@@ -1,0 +1,123 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	memorylocal "github.com/marmos91/dittofs/pkg/block/local/memory"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// indexedChunkStore gives stubFileChunkStore the two offset-indexed lookups the
+// badger backend implements, so resolveCovering and resolveNextChunkStart take
+// their indexed branches instead of the ListFileChunks fallback. Both answers
+// are derived from the same rows the fallback would walk, so the two store
+// shapes must agree.
+type indexedChunkStore struct{ *stubFileChunkStore }
+
+func (s *indexedChunkStore) GetFileChunkAtOffset(ctx context.Context, payloadID string, off uint64) (*block.FileChunk, error) {
+	rows, err := s.ListFileChunks(ctx, payloadID)
+	if err != nil {
+		return nil, err
+	}
+	rw, err := findRowCoveringOffset(rows, off)
+	if err != nil || rw == nil {
+		return nil, err
+	}
+	return rw.fb, nil
+}
+
+func (s *indexedChunkStore) GetFileChunkAtOrAfterOffset(ctx context.Context, payloadID string, off uint64) (*block.FileChunk, error) {
+	rows, err := s.ListFileChunks(ctx, payloadID)
+	if err != nil {
+		return nil, err
+	}
+	var (
+		best    *block.FileChunk
+		bestOff uint64
+	)
+	for _, fb := range rows {
+		abs, ok := block.ParseChunkOffset(fb.ID)
+		if !ok || abs < off {
+			continue
+		}
+		if best == nil || abs < bestOff {
+			best, bestOff = fb, abs
+		}
+	}
+	return best, nil
+}
+
+// TestEnsureAvailableAndRead_ChunkAfterHoleIsFetched pins the sparse-hole step
+// in the per-window fetch loop. The payload is a hole over [0, 1 MiB) with a
+// real remote-resident chunk at [1 MiB, 3 MiB) — both inside the first 8 MiB
+// block, which is the routine shape because FastCDC chunks average well under
+// BlockSize.
+//
+// Advancing to the next block boundary on the uncovered first byte discards
+// every chunk up to that boundary, so the chunk after the hole is never
+// dispatched and never hydrated; the caller's post-fetch re-read then serves it
+// as zeros. The loop must instead resume at the next chunk start, so the read
+// spanning [0, 4 MiB) leaves the chunk warm in the local tier.
+//
+// Both store shapes are exercised because they resolve the successor by
+// different means — an offset index versus a manifest walk.
+func TestEnsureAvailableAndRead_ChunkAfterHoleIsFetched(t *testing.T) {
+	const (
+		oneMiB     = 1024 * 1024
+		holeEnd    = 1 * oneMiB
+		chunkSize  = 2 * oneMiB
+		readLength = 4 * oneMiB
+	)
+
+	for _, tc := range []struct {
+		name string
+		wrap func(*stubFileChunkStore) block.EngineFileChunkStore
+	}{
+		{"ListFileChunksFallback", func(s *stubFileChunkStore) block.EngineFileChunkStore { return s }},
+		{"OffsetIndexed", func(s *stubFileChunkStore) block.EngineFileChunkStore { return &indexedChunkStore{s} }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			payloadID := "payload-hole-then-chunk"
+
+			chunk := make([]byte, chunkSize)
+			rand.New(rand.NewSource(0xC01D)).Read(chunk) //nolint:gosec // deterministic fixture
+
+			loc := memorylocal.New()
+			rs := remotememory.New()
+			stub := newStubFileChunkStore()
+			mds := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+
+			// Only the post-hole chunk is seeded, so [0, 1 MiB) has no covering row.
+			seedSyncedRemoteChunk(t, stub, rs, mds, payloadID, holeEnd, chunk)
+
+			m := newFetchSyncer(loc, rs, tc.wrap(stub), mds)
+
+			dest := make([]byte, readLength)
+			if _, err := m.EnsureAvailableAndRead(ctx, payloadID, 0, readLength, dest); err != nil {
+				t.Fatalf("EnsureAvailableAndRead: %v", err)
+			}
+
+			// Poison the destination so an unhydrated range fails instead of hiding in zeros.
+			got := bytes.Repeat([]byte{0xAA}, chunkSize)
+			n, cold, err := loc.ReadAt(ctx, payloadID, holeEnd, got)
+			if err != nil {
+				t.Fatalf("local ReadAt after fetch: %v", err)
+			}
+			if cold {
+				t.Fatalf("local ReadAt reports cold after fetch; chunk at %d was never hydrated", holeEnd)
+			}
+			if n != chunkSize {
+				t.Fatalf("local ReadAt n = %d; want %d", n, chunkSize)
+			}
+			if !bytes.Equal(got, chunk) {
+				t.Fatalf("chunk after hole not hydrated: got %x…, want %x…", got[:16], chunk[:16])
+			}
+		})
+	}
+}

--- a/pkg/block/engine/cold_read_hole_test.go
+++ b/pkg/block/engine/cold_read_hole_test.go
@@ -3,6 +3,8 @@ package engine
 import (
 	"bytes"
 	"context"
+	"errors"
+	"math"
 	"math/rand"
 	"testing"
 
@@ -119,5 +121,75 @@ func TestEnsureAvailableAndRead_ChunkAfterHoleIsFetched(t *testing.T) {
 				t.Fatalf("chunk after hole not hydrated: got %x…, want %x…", got[:16], chunk[:16])
 			}
 		})
+	}
+}
+
+// successorStub returns a fixed row from the indexed successor lookup, standing
+// in for a backend whose offset index still points at a row whose ID cannot be
+// placed.
+type successorStub struct {
+	*stubFileChunkStore
+	row *block.FileChunk
+}
+
+func (s *successorStub) GetFileChunkAtOrAfterOffset(_ context.Context, _ string, _ uint64) (*block.FileChunk, error) {
+	return s.row, nil
+}
+
+// TestResolveNextChunkStart_UnplaceableRowIsReported pins the failure mode of a
+// row whose ID carries no offset. Such a row sits at an unknown position, so it
+// may be the very next chunk after the hole being stepped over. Skipping it and
+// returning a later start would hand the caller a wider hole than the file has
+// and the bytes it holds would be zero-filled, so the manifest inconsistency is
+// reported instead.
+//
+// Both lookup branches are covered because neither can lean on the other having
+// run: a backend may index coverage without indexing succession, and the walks
+// are separate snapshots.
+func TestResolveNextChunkStart_UnplaceableRowIsReported(t *testing.T) {
+	ctx := context.Background()
+	const payloadID = "payload-unplaceable"
+	bad := &block.FileChunk{ID: payloadID + "/not-an-offset", DataSize: 4096}
+
+	t.Run("ListFileChunksFallback", func(t *testing.T) {
+		stub := newStubFileChunkStore()
+		if err := stub.Put(ctx, bad); err != nil {
+			t.Fatalf("seed unplaceable row: %v", err)
+		}
+		// A placeable row further out must not become the answer.
+		if err := stub.Put(ctx, &block.FileChunk{ID: payloadID + "/8192", DataSize: 4096}); err != nil {
+			t.Fatalf("seed placeable row: %v", err)
+		}
+		_, _, err := resolveNextChunkStart(ctx, stub, payloadID, 0)
+		if !errors.Is(err, block.ErrManifestInconsistent) {
+			t.Fatalf("resolveNextChunkStart = %v; want ErrManifestInconsistent", err)
+		}
+	})
+
+	t.Run("OffsetIndexed", func(t *testing.T) {
+		store := &successorStub{stubFileChunkStore: newStubFileChunkStore(), row: bad}
+		_, _, err := resolveNextChunkStart(ctx, store, payloadID, 0)
+		if !errors.Is(err, block.ErrManifestInconsistent) {
+			t.Fatalf("resolveNextChunkStart = %v; want ErrManifestInconsistent", err)
+		}
+	})
+}
+
+// TestResolveNextChunkStart_MaxOffsetDoesNotWrap pins the probe-offset guard: at
+// the last representable offset there is no "strictly after", and computing
+// off+1 would wrap to zero and restart the search at the front of the payload.
+func TestResolveNextChunkStart_MaxOffsetDoesNotWrap(t *testing.T) {
+	ctx := context.Background()
+	const payloadID = "payload-max-offset"
+	store := &successorStub{
+		stubFileChunkStore: newStubFileChunkStore(),
+		row:                &block.FileChunk{ID: payloadID + "/0", DataSize: 4096},
+	}
+	got, ok, err := resolveNextChunkStart(ctx, store, payloadID, math.MaxUint64)
+	if err != nil {
+		t.Fatalf("resolveNextChunkStart: %v", err)
+	}
+	if ok {
+		t.Fatalf("resolveNextChunkStart(MaxUint64) = (%d, true); want no successor", got)
 	}
 }

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -370,10 +370,20 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 			return false, err
 		}
 		if fb == nil {
-			// Sparse hole at cur: no chunk covers it. Probe the next block
-			// boundary — real files are fully written (no holes). The caller's
-			// re-read zero-fills any bytes left uncovered.
-			cur = (cur/uint64(BlockSize) + 1) * uint64(BlockSize)
+			// Sparse hole at cur: no chunk covers it. Chunk boundaries do not
+			// align to BlockSize, so a hole can be followed by real data inside
+			// the same block; advance to the next chunk that starts after cur
+			// rather than to the next block boundary. Skipping to the boundary
+			// would drop those chunks from the fetch list and the caller's
+			// re-read would then serve them as zeros.
+			next, ok, err := resolveNextChunkStart(ctx, m.fileChunkStore, payloadID, cur)
+			if err != nil {
+				return false, err
+			}
+			if !ok {
+				break // nothing starts past cur — the rest of the window is hole
+			}
+			cur = next
 			continue
 		}
 		// ponytail: no per-hash local-presence probe (journal is not hash-keyed);

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -182,3 +182,68 @@ func resolveCovering(ctx context.Context, store block.EngineFileChunkStore, payl
 	}
 	return rw.fb, rw.absOffset, nil
 }
+
+// chunkAtOrAfterOffsetResolver is the indexed successor lookup, implemented only
+// by the badger metadata backend. resolveNextChunkStart type-asserts for it and
+// falls back to a ListFileChunks walk otherwise.
+type chunkAtOrAfterOffsetResolver interface {
+	GetFileChunkAtOrAfterOffset(ctx context.Context, payloadID string, off uint64) (*block.FileChunk, error)
+}
+
+// resolveNextChunkStart returns the absolute start offset of the first chunk of
+// payloadID that begins strictly after off, or ok=false when none does — every
+// remaining byte is hole. It is the step a reader takes to cross a hole: off is
+// known to be uncovered, so the next data can only begin later.
+//
+// Asking for off+1 rather than off keeps a zero-length row parked exactly at off
+// from answering with off itself, which would stall a caller that loops on the
+// result.
+//
+// When the store implements chunkAtOrAfterOffsetResolver (badger) the successor
+// comes from the chunk-offset index; a row it names whose ID cannot be placed is
+// an inconsistent manifest, not a hole, so it is reported rather than stepped
+// over — silently skipping it would strand real data and read back as zeros.
+// Other backends fall back to a ListFileChunks walk, which mirrors resolveCovering
+// and is likewise not the profiled hot path. There an unplaceable row needs no
+// separate guard: findRowCoveringOffset already fails resolveCovering for the
+// same payload, so reaching this point proves the manifest holds none.
+func resolveNextChunkStart(ctx context.Context, store block.EngineFileChunkStore, payloadID string, off uint64) (uint64, bool, error) {
+	if store == nil {
+		return 0, false, nil
+	}
+	if r, ok := store.(chunkAtOrAfterOffsetResolver); ok {
+		fb, err := r.GetFileChunkAtOrAfterOffset(ctx, payloadID, off+1)
+		if err != nil || fb == nil {
+			return 0, false, err
+		}
+		abs, ok := block.ParseChunkOffset(fb.ID)
+		if !ok {
+			return 0, false, fmt.Errorf("%w: malformed FileChunk ID %q", block.ErrManifestInconsistent, fb.ID)
+		}
+		return abs, true, nil
+	}
+	rows, err := store.ListFileChunks(ctx, payloadID)
+	if err != nil {
+		if errors.Is(err, block.ErrFileChunkNotFound) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	var (
+		best  uint64
+		found bool
+	)
+	for _, fb := range rows {
+		if fb == nil {
+			continue
+		}
+		abs, parsed := block.ParseChunkOffset(fb.ID)
+		if !parsed || abs <= off {
+			continue
+		}
+		if !found || abs < best {
+			best, found = abs, true
+		}
+	}
+	return best, found, nil
+}

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/journal"
@@ -200,16 +201,23 @@ type chunkAtOrAfterOffsetResolver interface {
 // result.
 //
 // When the store implements chunkAtOrAfterOffsetResolver (badger) the successor
-// comes from the chunk-offset index; a row it names whose ID cannot be placed is
-// an inconsistent manifest, not a hole, so it is reported rather than stepped
-// over — silently skipping it would strand real data and read back as zeros.
-// Other backends fall back to a ListFileChunks walk, which mirrors resolveCovering
-// and is likewise not the profiled hot path. There an unplaceable row needs no
-// separate guard: findRowCoveringOffset already fails resolveCovering for the
-// same payload, so reaching this point proves the manifest holds none.
+// comes from the chunk-offset index; other backends fall back to a ListFileChunks
+// walk, which mirrors resolveCovering and is likewise not the profiled hot path.
+//
+// Either way a row whose ID cannot be placed is reported rather than stepped
+// over. Unlike coverage, the successor answer is not scoped to a single row: an
+// unplaceable row sits at an unknown offset, so it may be the true successor,
+// and returning a later one would silently reclassify the bytes it holds as hole
+// for the caller to zero-fill. The two lookups here and in resolveCovering are
+// independent — a backend may index coverage without indexing succession, and
+// each walk is its own ListFileChunks snapshot — so the guard cannot be borrowed
+// from findRowCoveringOffset having already run.
 func resolveNextChunkStart(ctx context.Context, store block.EngineFileChunkStore, payloadID string, off uint64) (uint64, bool, error) {
 	if store == nil {
 		return 0, false, nil
+	}
+	if off == math.MaxUint64 {
+		return 0, false, nil // nothing can start after the last representable offset
 	}
 	if r, ok := store.(chunkAtOrAfterOffsetResolver); ok {
 		fb, err := r.GetFileChunkAtOrAfterOffset(ctx, payloadID, off+1)
@@ -218,7 +226,8 @@ func resolveNextChunkStart(ctx context.Context, store block.EngineFileChunkStore
 		}
 		abs, ok := block.ParseChunkOffset(fb.ID)
 		if !ok {
-			return 0, false, fmt.Errorf("%w: malformed FileChunk ID %q", block.ErrManifestInconsistent, fb.ID)
+			return 0, false, fmt.Errorf("%w: nothing covers offset %d and the next chunk is unplaceable row %q",
+				block.ErrManifestInconsistent, off, fb.ID)
 		}
 		return abs, true, nil
 	}
@@ -230,20 +239,31 @@ func resolveNextChunkStart(ctx context.Context, store block.EngineFileChunkStore
 		return 0, false, err
 	}
 	var (
-		best  uint64
-		found bool
+		best        uint64
+		found       bool
+		unplaceable string
 	)
 	for _, fb := range rows {
 		if fb == nil {
 			continue
 		}
 		abs, parsed := block.ParseChunkOffset(fb.ID)
-		if !parsed || abs <= off {
+		if !parsed {
+			if unplaceable == "" {
+				unplaceable = fb.ID
+			}
+			continue
+		}
+		if abs <= off {
 			continue
 		}
 		if !found || abs < best {
 			best, found = abs, true
 		}
+	}
+	if unplaceable != "" {
+		return 0, false, fmt.Errorf("%w: nothing covers offset %d and the manifest holds unplaceable row %q",
+			block.ErrManifestInconsistent, off, unplaceable)
 	}
 	return best, found, nil
 }


### PR DESCRIPTION
Relates to #1894.

## Root cause

`EnsureAvailableAndRead` walks a read window resolving the chunk covering each offset. When `resolveCovering` returned nil — a sparse hole — the loop advanced `cur` to the next 8 MiB `BlockSize` boundary, justified in a comment by "real files are fully written (no holes)".

That justification is contradicted by this same package: `read_internal.go` documents that a genuinely sparse hole stays zero-filled, `range.go` that sparse holes are not skipped, and NFSv4.2 sparse is a shipped feature. FastCDC chunks average ~4 MiB against an 8 MiB `BlockSize`, so a block routinely holds two or more. A hole followed by real data inside the same block meant every chunk up to the boundary was dropped from the fetch list — never dispatched, never hydrated. The caller then re-reads via `local.ReadAt` trusting the window is warm, and the range comes back as zeros. Same silent-zeros class as #1879 / #1888.

## Fix

Step to the next actual chunk start instead of the block boundary, via `resolveNextChunkStart` — a sibling of `resolveCovering` in `read_internal.go` that mirrors its optional-interface shape.

The badger backend already had `GetFileChunkAtOrAfterOffset`, purpose-built for exactly this ("skip a hole straight to the next chunk in one indexed keys-only scan"), conformance-tested in `storetest`, but never wired to any caller. It is now the indexed path; other backends fall back to a manifest walk, matching what `resolveCovering` already does for them.

Two details worth flagging:

- The successor is queried at `off+1`, not `off`. A zero-length row parked exactly at `off` would otherwise answer with `off` itself and stall the loop.
- On the indexed path, a successor row whose ID cannot be placed is reported as `ErrManifestInconsistent` rather than skipped. Silently stepping over it would strand real data behind a hole and reintroduce the same silent-zero read. Both paths report `ErrManifestInconsistent` for an unplaceable successor row. An earlier revision guarded only the indexed path, on the reasoning that reaching the fallback proved the manifest held no unplaceable rows. **That reasoning was wrong**, for two independent reasons: the two lookups assert for their interfaces separately (`chunkAtOffsetResolver` vs `chunkAtOrAfterOffsetResolver`), so a backend indexing coverage but not succession takes the indexed branch for the first — never enumerating rows, so the unplaceable check never runs — and the walk for the second; and they are separate `ListFileChunks` snapshots, so a concurrent write or GC between them can introduce a row the first walk never saw. Either way the row would have been skipped and its bytes reclassified as hole — the very silent-zero read this PR closes.

## Test

`TestEnsureAvailableAndRead_ChunkAfterHoleIsFetched` — hole over [0, 1 MiB), real cold/evicted chunk at [1 MiB, 3 MiB), both inside the first block; read spans [0, 4 MiB). It asserts the chunk is hydrated and the real bytes come back, with the destination poisoned to 0xAA so an unhydrated range fails rather than hiding in zeros. It runs over both store shapes, since they resolve the successor by different means.

Verified failing before the fix (`git stash` of the two source files):

```
--- FAIL: TestEnsureAvailableAndRead_ChunkAfterHoleIsFetched
    --- FAIL: .../ListFileChunksFallback
        chunk after hole not hydrated: got 00000000000000000000000000000000…, want 2571fcbfb038cc6e174270550895d96e…
    --- FAIL: .../OffsetIndexed
        chunk after hole not hydrated: got 00000000000000000000000000000000…, want 2571fcbfb038cc6e174270550895d96e…
```

All zeros on both — the reported symptom exactly.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- `go test ./pkg/block/...` all ok
- `go test -race ./pkg/block/engine/...` ok (78.5s)

