### PR TITLE
fix(smb): honor WRITE_THROUGH by flushing durably before acking the write

### DIFF
--- a/internal/adapter/smb/handlers/close_flush_error_test.go
+++ b/internal/adapter/smb/handlers/close_flush_error_test.go
@@ -28,12 +28,13 @@ import (
 	metamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
-// setupFlushErrorShare wires a handler + runtime + memory metadata + memory
-// block store with a single read-write share, writes a small payload to a file
-// named "data" under the share root, and registers an OpenFile for it. Returns
-// the handler, a primed SMBHandlerContext, the file's metadata handle, and the
-// FileID of the registered OpenFile.
-func setupFlushErrorShare(t *testing.T) (*Handler, *SMBHandlerContext, metadata.FileHandle, [16]byte) {
+// setupWriteTestShare wires a handler + runtime + the caller's metadata store +
+// a memory block store with a single read-write share, writes a small payload to
+// a file named "data" under the share root, and registers an OpenFile for it. A
+// nil metaStore uses a plain memory metadata store. Returns the handler, a
+// primed SMBHandlerContext, the file's metadata handle, and the FileID of the
+// registered OpenFile.
+func setupWriteTestShare(t *testing.T, metaStore metadata.Store) (*Handler, *SMBHandlerContext, metadata.FileHandle, [16]byte) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -49,7 +50,9 @@ func setupFlushErrorShare(t *testing.T) (*Handler, *SMBHandlerContext, metadata.
 	if _, err := cps.CreateMetadataStore(ctx, &models.MetadataStoreConfig{Name: "flushmeta", Type: "memory"}); err != nil {
 		t.Fatalf("CreateMetadataStore: %v", err)
 	}
-	metaStore := metamemory.NewMemoryMetadataStoreWithDefaults()
+	if metaStore == nil {
+		metaStore = metamemory.NewMemoryMetadataStoreWithDefaults()
+	}
 	if err := rt.RegisterMetadataStore("flushmeta", metaStore); err != nil {
 		t.Fatalf("RegisterMetadataStore: %v", err)
 	}
@@ -173,7 +176,7 @@ func setupFlushErrorShare(t *testing.T) (*Handler, *SMBHandlerContext, metadata.
 // engine.ErrStoreClosed (the same mapping seam fs.ErrPressureTimeout and the
 // other block-store content errors travel through).
 func TestClose_FlushFailure_SurfacedAsNonSuccess(t *testing.T) {
-	h, smbCtx, fileHandle, fileID := setupFlushErrorShare(t)
+	h, smbCtx, fileHandle, fileID := setupWriteTestShare(t, nil)
 
 	// Force the durable flush to fail: close the share's block store so the
 	// CLOSE-time engine.Flush short-circuits with engine.ErrStoreClosed.
@@ -224,7 +227,7 @@ func TestClose_FlushFailure_SurfacedAsNonSuccess(t *testing.T) {
 // returns ErrNoEntity → STATUS_OBJECT_NAME_NOT_FOUND. The two map to distinct
 // statuses, so the assertion proves which one wins.
 func TestClose_FlushFailure_WinsOverDeleteFailure(t *testing.T) {
-	h, smbCtx, fileHandle, fileID := setupFlushErrorShare(t)
+	h, smbCtx, fileHandle, fileID := setupWriteTestShare(t, nil)
 
 	// Arm delete-on-close on the registered handle so the CLOSE delete path runs.
 	openFile, ok := h.GetOpenFile(fileID)

--- a/internal/adapter/smb/handlers/write.go
+++ b/internal/adapter/smb/handlers/write.go
@@ -17,6 +17,19 @@ import (
 // Request and Response Structures
 // ============================================================================
 
+// SMB2 WRITE request Flags [MS-SMB2] 2.2.21. Undefined bits are ignored.
+const (
+	// writeFlagWriteThrough (SMB2_WRITEFLAG_WRITE_THROUGH) asks the server to
+	// put the written bytes on stable storage before it answers the request.
+	// Not valid for the 2.0.2 dialect, where the bit is ignored.
+	writeFlagWriteThrough uint32 = 0x00000001
+
+	// writeFlagWriteUnbuffered (SMB2_WRITEFLAG_WRITE_UNBUFFERED) asks the server
+	// not to cache the written bytes at intermediate layers. Not valid for the
+	// 2.0.2, 2.1 and 3.0 dialects.
+	writeFlagWriteUnbuffered uint32 = 0x00000002
+)
+
 // WriteRequest represents an SMB2 WRITE request from a client [MS-SMB2] 2.2.21.
 // The client specifies a FileID, offset, and data to write to a file.
 // The fixed wire format is exactly 49 bytes, followed by the variable-length data buffer.
@@ -44,11 +57,8 @@ type WriteRequest struct {
 	// RemainingBytes is a hint about remaining bytes to write (usually 0).
 	RemainingBytes uint32
 
-	// Flags controls write behavior.
-	// Common values:
-	//   - 0x00000000: Normal buffered write
-	//   - 0x00000001: Write-through (bypass server cache)
-	//   - 0x00000002: Unbuffered write
+	// Flags controls write behavior; see writeFlagWriteThrough and
+	// writeFlagWriteUnbuffered.
 	Flags uint32
 
 	// Data contains the bytes to write to the file.
@@ -439,15 +449,46 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}, nil
 	}
 
-	// SMB requires immediate metadata visibility across sessions (unlike NFS
-	// which has explicit COMMIT). Flush deferred metadata so that other sessions
-	// reading the same file see updated size/timestamps without a FLUSH command.
-	// Relaxed (#1687): visibility comes from the metadata write itself (applied
-	// in-txn), NOT from the fsync — so we can defer the metadata db.Sync off the
-	// per-WRITE ack path. CLOSE and FLUSH remain strict for durability; a crash
-	// before the background fsync is caught by the journal size reconcile.
-	if _, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle, false); flushErr != nil {
-		logger.Debug("WRITE: deferred metadata flush failed (non-fatal)", "path", openFile.Path, "error", flushErr)
+	// Per MS-SMB2 2.2.21 the write-through bit is undefined for the 2.0.2 dialect,
+	// so it is ignored there. A connection with no recorded dialect honors the
+	// bit: over-flushing is safe, silently dropping a requested durability point
+	// is not.
+	writeThrough := req.Flags&writeFlagWriteThrough != 0 &&
+		(ctx.ConnCryptoState == nil || ctx.ConnCryptoState.GetDialect() != types.Dialect0202)
+
+	// A failed durability step must not be acked as success, but it also cannot
+	// return early: CommitWrite has already applied the size/mtime mutation to
+	// the pending-write state, so other sessions can observe the change through
+	// GETINFO whether or not the fsync landed. The post-write bookkeeping below
+	// — frozen-timestamp restore and the change notification — describes a
+	// change that is already visible, so it still has to run. The failure is
+	// carried to the response instead.
+	writeStatus := types.StatusSuccess
+
+	if writeThrough {
+		// Per MS-SMB2 3.3.5.13, a write-through WRITE is its own durability
+		// point, so the deferred-commit optimization below does not apply: take
+		// the same strict pair FLUSH takes — block store commit, then an inline
+		// metadata fsync — and fail the request rather than ack a durability
+		// guarantee that does not hold.
+		if _, flushErr := blockStore.Flush(authCtx.Context, string(writeOp.PayloadID)); flushErr != nil {
+			logger.Warn("WRITE: write-through content flush failed", "path", openFile.Path, "error", flushErr)
+			writeStatus = common.MapContentToSMB(flushErr)
+		} else if _, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle, true); flushErr != nil {
+			logger.Warn("WRITE: write-through metadata flush failed", "path", openFile.Path, "error", flushErr)
+			writeStatus = common.MapToSMB(flushErr)
+		}
+	} else {
+		// SMB requires immediate metadata visibility across sessions (unlike NFS
+		// which has explicit COMMIT). Flush deferred metadata so that other sessions
+		// reading the same file see updated size/timestamps without a FLUSH command.
+		// Relaxed: visibility comes from the metadata write itself (applied
+		// in-txn), NOT from the fsync — so we can defer the metadata db.Sync off the
+		// per-WRITE ack path. CLOSE and FLUSH remain strict for durability; a crash
+		// before the background fsync is caught by the journal size reconcile.
+		if _, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle, false); flushErr != nil {
+			logger.Debug("WRITE: deferred metadata flush failed (non-fatal)", "path", openFile.Path, "error", flushErr)
+		}
 	}
 
 	// Per MS-FSA 2.1.5.14.2: If timestamps are frozen via SET_INFO with -1,
@@ -508,14 +549,18 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 		}
 	}
 
+	// ========================================================================
+	// Step 12: Return response
+	// ========================================================================
+
+	if writeStatus != types.StatusSuccess {
+		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: writeStatus}}, nil
+	}
+
 	logger.Debug("WRITE successful",
 		"path", openFile.Path,
 		"offset", req.Offset,
 		"bytes", len(req.Data))
-
-	// ========================================================================
-	// Step 12: Return success response
-	// ========================================================================
 
 	return &WriteResponse{
 		SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},
@@ -529,6 +574,19 @@ func (h *Handler) handlePipeWrite(ctx *SMBHandlerContext, req *WriteRequest, ope
 	logger.Debug("WRITE to named pipe",
 		"pipeName", openFile.PipeName,
 		"dataLen", len(req.Data))
+
+	// Per MS-SMB2 3.3.5.13, a server that implements the SMB 3.x dialect family
+	// MUST reject WRITE_THROUGH/WRITE_UNBUFFERED on a named pipe with
+	// STATUS_INVALID_PARAMETER. The condition is on what the server implements,
+	// not on the dialect this connection negotiated, so it keys off the
+	// configured maximum dialect; a server capped below 3.0 keeps ignoring the
+	// bits as the 2.x dialects require.
+	if h.MaxDialect >= types.Dialect0300 && req.Flags&(writeFlagWriteThrough|writeFlagWriteUnbuffered) != 0 {
+		logger.Debug("WRITE: write-through/unbuffered flags are invalid on a named pipe",
+			"pipeName", openFile.PipeName,
+			"flags", req.Flags)
+		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
+	}
 
 	// Get pipe state
 	pipe := h.PipeManager.GetPipe(req.FileID)

--- a/internal/adapter/smb/handlers/write_through_test.go
+++ b/internal/adapter/smb/handlers/write_through_test.go
@@ -1,0 +1,221 @@
+// Coverage for the SMB2 WRITE Flags field [MS-SMB2] 2.2.21 / 3.3.5.13.
+//
+// SMB2_WRITEFLAG_WRITE_THROUGH makes an individual WRITE its own durability
+// point, while the default WRITE path deliberately defers the block-store
+// commit and the metadata fsync off the ack path. The two paths are therefore
+// only distinguishable by the durability calls they make, not by the status
+// they return, so these tests count real commits: the metadata store is
+// wrapped so that the durable (WithTransaction) and relaxed
+// (WithTransactionRelaxed) commit entrypoints are tallied separately, with
+// both wrappers delegating to a real memory store.
+//
+// The block-store half of the pair is the same engine.Store.Flush call FLUSH
+// and CLOSE make; it has no injection seam reachable from a handler test, and
+// is covered by the block-store conformance suites plus the CLOSE tests for
+// error surfacing.
+package handlers
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// txCountingMetaStore delegates every operation to a real memory metadata
+// store while tallying which commit entrypoint the metadata service chose.
+// Providing WithTransactionRelaxed is what makes the two countable: the plain
+// memory store does not implement metadata.RelaxedTransactor, so without this
+// wrapper the relaxed path silently collapses onto WithTransaction.
+type txCountingMetaStore struct {
+	*metamemory.MemoryMetadataStore
+	durable atomic.Int64
+	relaxed atomic.Int64
+}
+
+var _ metadata.RelaxedTransactor = (*txCountingMetaStore)(nil)
+
+func (s *txCountingMetaStore) WithTransaction(ctx context.Context, fn func(tx metadata.Transaction) error) error {
+	s.durable.Add(1)
+	return s.MemoryMetadataStore.WithTransaction(ctx, fn)
+}
+
+func (s *txCountingMetaStore) WithTransactionRelaxed(ctx context.Context, fn func(tx metadata.Transaction) error) error {
+	s.relaxed.Add(1)
+	return s.MemoryMetadataStore.WithTransaction(ctx, fn)
+}
+
+// countWriteCommits issues one WRITE with the given Flags over a connection
+// negotiated at the given dialect (the zero dialect leaves the connection
+// without crypto state) and reports how many durable and relaxed metadata
+// commits that single WRITE performed.
+func countWriteCommits(t *testing.T, flags uint32, dialect types.Dialect) (status types.Status, durable, relaxed int64) {
+	t.Helper()
+
+	store := &txCountingMetaStore{MemoryMetadataStore: metamemory.NewMemoryMetadataStoreWithDefaults()}
+	h, smbCtx, _, fileID := setupWriteTestShare(t, store)
+	if dialect != 0 {
+		smbCtx.ConnCryptoState = &mockCryptoState{dialect: dialect}
+	}
+
+	data := []byte("write-through-payload")
+	// Only the WRITE under test may contribute to the tally.
+	beforeDurable, beforeRelaxed := store.durable.Load(), store.relaxed.Load()
+
+	resp, err := h.Write(smbCtx, &WriteRequest{
+		FileID: fileID,
+		Length: uint32(len(data)),
+		Data:   data,
+		Flags:  flags,
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	return resp.GetStatus(),
+		store.durable.Load() - beforeDurable,
+		store.relaxed.Load() - beforeRelaxed
+}
+
+// writeCommitDelta reports how many more durable and relaxed metadata commits a
+// WRITE carrying the given flags performs than an otherwise identical WRITE
+// carrying none.
+//
+// Measuring a difference rather than an absolute count is what keeps this
+// pinned to the durability decision: both runs drive the same handler over the
+// same fixture and differ only in the flag, so any metadata write the WRITE
+// path performs for its own reasons — file atime, parent-directory atime — lands
+// in both tallies and cancels. Should that surrounding traffic ever start or
+// stop routing through the transaction entrypoints, the delta is unaffected.
+func writeCommitDelta(t *testing.T, flags uint32, dialect types.Dialect) (durable, relaxed int64) {
+	t.Helper()
+
+	_, baseDurable, baseRelaxed := countWriteCommits(t, 0, dialect)
+	status, gotDurable, gotRelaxed := countWriteCommits(t, flags, dialect)
+	if status != types.StatusSuccess {
+		t.Fatalf("WRITE(flags=0x%X) status = 0x%08X, want STATUS_SUCCESS", flags, uint32(status))
+	}
+	return gotDurable - baseDurable, gotRelaxed - baseRelaxed
+}
+
+// TestWrite_WriteThrough_CommitsMetadataDurably proves a write-through WRITE
+// takes the strict metadata commit inline, before the response is produced,
+// in place of the deferred one the default path takes.
+func TestWrite_WriteThrough_CommitsMetadataDurably(t *testing.T) {
+	durable, relaxed := writeCommitDelta(t, writeFlagWriteThrough, 0)
+
+	if durable != 1 {
+		t.Fatalf("write-through added %d durable metadata commit(s) over a plain WRITE, want 1: "+
+			"the requested durability point was dropped", durable)
+	}
+	if relaxed != -1 {
+		t.Errorf("write-through changed the relaxed commit count by %d, want -1: the durable "+
+			"commit must replace the deferred flush, not run alongside it", relaxed)
+	}
+}
+
+// TestWrite_Default_StaysDeferred proves the default WRITE path is unchanged:
+// no durable commit is added to the ack path.
+//
+// This one asserts an absolute count rather than a delta on purpose. "Nothing
+// on the default ack path fsyncs" is the invariant itself, so anything that
+// starts taking the durable entrypoint during a plain WRITE — whatever its
+// reason — should fail here. It is also what gives the write-through delta its
+// meaning: the baseline it subtracts is a measured zero, not an assumed one.
+func TestWrite_Default_StaysDeferred(t *testing.T) {
+	status, durable, relaxed := countWriteCommits(t, 0, 0)
+
+	if status != types.StatusSuccess {
+		t.Fatalf("default WRITE status = 0x%08X, want STATUS_SUCCESS", uint32(status))
+	}
+	if durable != 0 {
+		t.Errorf("default WRITE performed %d durable metadata commit(s); the deferred "+
+			"ack path must not fsync", durable)
+	}
+	if relaxed == 0 {
+		t.Errorf("default WRITE performed no relaxed metadata commit; expected a deferred flush")
+	}
+}
+
+// TestWrite_UnbufferedAlone_StaysDeferred pins WRITE_UNBUFFERED as a caching
+// hint, not a durability request: on its own it must not pull the strict
+// commit onto the ack path.
+func TestWrite_UnbufferedAlone_StaysDeferred(t *testing.T) {
+	durable, relaxed := writeCommitDelta(t, writeFlagWriteUnbuffered, 0)
+
+	if durable != 0 || relaxed != 0 {
+		t.Errorf("unbuffered-only WRITE shifted the commit tally by durable=%+d relaxed=%+d; "+
+			"want no change from a plain WRITE", durable, relaxed)
+	}
+}
+
+// TestWrite_WriteThrough_IgnoredOnDialect202 pins that the bit is undefined on
+// SMB 2.0.2 and is ignored there rather than forcing a commit.
+func TestWrite_WriteThrough_IgnoredOnDialect202(t *testing.T) {
+	durable, relaxed := writeCommitDelta(t, writeFlagWriteThrough, types.Dialect0202)
+
+	if durable != 0 || relaxed != 0 {
+		t.Errorf("2.0.2 write-through shifted the commit tally by durable=%+d relaxed=%+d; the "+
+			"bit is undefined on that dialect and must be ignored", durable, relaxed)
+	}
+}
+
+// TestPipeWrite_WriteThroughFlags covers the named-pipe rule: a server that
+// implements the SMB 3.x dialect family MUST reject WRITE_THROUGH and
+// WRITE_UNBUFFERED on a pipe, while a server capped below 3.0 keeps ignoring
+// them.
+func TestPipeWrite_WriteThroughFlags(t *testing.T) {
+	cases := []struct {
+		name       string
+		maxDialect types.Dialect
+		flags      uint32
+		wantReject bool
+	}{
+		{"3.1.1 server rejects write-through", types.Dialect0311, writeFlagWriteThrough, true},
+		{"3.1.1 server rejects unbuffered", types.Dialect0311, writeFlagWriteUnbuffered, true},
+		{"3.0 server rejects both bits", types.Dialect0300, writeFlagWriteThrough | writeFlagWriteUnbuffered, true},
+		{"3.1.1 server accepts no flags", types.Dialect0311, 0, false},
+		{"2.1 server ignores write-through", types.Dialect0210, writeFlagWriteThrough, false},
+		{"2.0.2 server ignores unbuffered", types.Dialect0202, writeFlagWriteUnbuffered, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, smbCtx, _, _ := setupWriteTestShare(t, nil)
+			h.MaxDialect = tc.maxDialect
+
+			pipeID := [16]byte{9}
+			h.StoreOpenFile(&OpenFile{
+				FileID:   pipeID,
+				IsPipe:   true,
+				PipeName: "srvsvc",
+				Path:     "srvsvc",
+			})
+
+			resp, err := h.Write(smbCtx, &WriteRequest{
+				FileID: pipeID,
+				Length: 4,
+				Data:   []byte("ping"),
+				Flags:  tc.flags,
+			})
+			if err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+
+			got := resp.GetStatus()
+			if tc.wantReject {
+				if got != types.StatusInvalidParameter {
+					t.Fatalf("status = 0x%08X, want STATUS_INVALID_PARAMETER", uint32(got))
+				}
+				return
+			}
+			// The flags must not be the reason the request fails; anything
+			// past this gate (no pipe registered) reports a different status.
+			if got == types.StatusInvalidParameter {
+				t.Fatalf("status = STATUS_INVALID_PARAMETER; the flags must be ignored here")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

SMB2 WRITE decoded the request `Flags` field but never read it again, so a client setting `SMB2_WRITEFLAG_WRITE_THROUGH` (databases, Hyper-V over SMB, `FILE_FLAG_WRITE_THROUGH` opens) was acknowledged exactly like a cached write. Both halves of durability stayed deferred off the ack path — the block-store commit and the metadata fsync — silently dropping the crash-durability guarantee the client explicitly asked for.

Three changes:

1. **Write-through takes a synchronous durability path.** On `SMB2_WRITEFLAG_WRITE_THROUGH`, WRITE now runs the same strict pair the FLUSH handler runs — `blockStore.Flush(payloadID)` then `FlushPendingWriteForFile(..., durable=true)` — before the response is produced, and returns a mapped error instead of acking a guarantee that does not hold. No new primitives; both calls are the ones `flush.go` already uses.

2. **Named-pipe writes reject the bits.** `handlePipeWrite` returns `STATUS_INVALID_PARAMETER` for `WRITE_THROUGH`/`WRITE_UNBUFFERED`.

3. **The default path is untouched.** The non-write-through branch is byte-identical to before; the only added cost is one bit test that short-circuits before any dereference.

## Spec basis

- **MS-SMB2 2.2.21** — `SMB2_WRITEFLAG_WRITE_THROUGH` (0x1) "is not valid for the SMB 2.0.2 dialect"; `SMB2_WRITEFLAG_WRITE_UNBUFFERED` (0x2) "is not valid for the SMB 2.0.2, 2.1, and 3.0 dialects". Undefined bits are ignored.
- **MS-SMB2 3.3.5.13** — "If Connection.Dialect is not 2.0.2, and SMB2_WRITEFLAG_WRITE_THROUGH is set ... the server SHOULD indicate to the underlying object store that the write is to be written to underlying storage before completion is returned." Also: "If the server implements the SMB 3.x dialect family, if the write is executed on a named pipe and the Flags field is set to SMB2_WRITEFLAG_WRITE_UNBUFFERED or SMB2_WRITEFLAG_WRITE_THROUGH, the server MUST fail the request with STATUS_INVALID_PARAMETER."

## The two dialect gates (deliberately different)

They key off different things because the spec words them differently:

- **Honor gate** (write-through durability) is on **`Connection.Dialect`** — skipped only when the negotiated dialect is 2.0.2, where the bit is undefined. A connection with no recorded dialect honors the bit: over-flushing is safe, silently dropping a requested durability point is not.
- **Pipe reject gate** is on **what the server implements**, not what the connection negotiated, so it keys off the configured `MaxDialect` (`>= Dialect0300`). This is not a blanket reject: the repo default `MaxDialect` is `0x0210`, so a default-configured server keeps ignoring the bits exactly as the 2.x dialects require.

`WRITE_UNBUFFERED` on a regular file is treated as the caching hint it is, not a durability request — on its own it does not pull the strict commit onto the ack path.

## Tests

The repo has been burned before by durability tests that pass against a fake sink while never exercising real durability, so these assert on **the durability calls actually made**, not on the returned status. The metadata store is wrapped so the durable (`WithTransaction`) and relaxed (`WithTransactionRelaxed`) commit entrypoints are tallied separately, with both wrappers delegating to a real memory store. Supplying `WithTransactionRelaxed` is what makes the two countable — the plain memory store does not implement `metadata.RelaxedTransactor`, so without the wrapper the relaxed path silently collapses onto `WithTransaction` and the test would measure nothing.

- write-through → durable commit > 0, relaxed == 0
- default → durable == 0, relaxed > 0 (the deferred path, unchanged)
- unbuffered alone → durable == 0
- write-through on 2.0.2 → durable == 0 (bit ignored)
- pipe writes → table over six server/flag combinations, asserting reject on 3.0/3.1.1 and no flag-caused failure on 2.0.2/2.1

## Known boundaries

- The **block-store half** of the durability pair (`engine.Store.Flush`) has no injection seam reachable from a handler test: the engine resolves its local tier at share start, and closing the store fails the earlier `WriteAt` rather than the flush. It is the identical call FLUSH and CLOSE make, covered by the block-store conformance suites. Noted in the test file header.
- A share that opts into the **writeback tier** downgrades `durable=true` to `false` in `FlushPendingWriteForFile`. Write-through therefore inherits exactly the same metadata semantics as an explicit SMB FLUSH on such a share — pre-existing and deliberate, not introduced here. The block-store commit still runs.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` all clean. `go test ./internal/adapter/smb/... ./pkg/block/...` and `go test -race ./internal/adapter/smb/...` all pass.

Relates to #1899


## Error path

A failed durability step does not return early. `CommitWrite` has already applied the size/mtime mutation to the pending-write state, so other sessions can observe the change through GETINFO whether or not the fsync landed. Returning early would skip the post-write bookkeeping — frozen-timestamp restore and the CHANGE_NOTIFY change notification — leaving watchers unaware of a modification they can already see, and dropping a SET_INFO(-1) timestamp freeze. The bookkeeping therefore still runs and the failure status is carried to the response instead.
