### PR TITLE
perf(smb): coalesce per-READ atime updates instead of writing metadata on every read

### DIFF
--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -263,6 +263,26 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 				logger.Debug("CLOSE: metadata flushed", "path", openFile.Path)
 			}
 
+			// READ coalesces its LastAccessTime bumps, so the newest access time
+			// may still only live on the handle. Persist it before the
+			// frozen-timestamp restore below, which stays authoritative.
+			//
+			// Only ever advance it: another handle on the same file (or an NFS
+			// client) may have set a newer LastAccessTime since this handle's
+			// last READ, and SetFileAttributes assigns Atime directly, so an
+			// unconditional flush would move it backwards. The compare is a plain
+			// read-then-write — openFile.mu is per-handle and the store offers no
+			// compare-and-set for a single attribute — so it narrows that window
+			// rather than closing it. Losing the race costs at most
+			// smbAtimeUpdateWindow of access-time precision.
+			if pending := takeSmbPendingAtime(openFile); !pending.IsZero() && !openFile.IsAtimeFrozen() {
+				if cur, curErr := metaSvc.GetFile(authCtx.Context, openFile.MetadataHandle); curErr == nil && cur.Atime.Before(pending) {
+					if _, atimeErr := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{Atime: &pending}); atimeErr != nil {
+						logger.Warn("CLOSE: LastAccessTime flush failed", "path", openFile.Path, "error", atimeErr)
+					}
+				}
+			}
+
 			// Per MS-FSA 2.1.5.14.2: After flushing pending writes (which may overwrite
 			// frozen timestamps), restore any timestamps that were frozen via SET_INFO -1.
 			// The deferred commit flush sets Mtime/Ctime to the WRITE time, but if the

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -558,6 +558,13 @@ type OpenFile struct {
 	SmbWriteFlushAt    time.Time  // wall-clock when the 2s window expires (zero ⇒ already flushed)
 	SmbStickyWriteTime *time.Time // explicit SetBasic write_time — wins over any pending update
 
+	// READ-driven LastAccessTime coalescing: a READ pushes the access time to
+	// the metadata store at most once per smbAtimeUpdateWindow. In between the
+	// newest access time lives on the handle, surfaced by QUERY_INFO and
+	// persisted at CLOSE.
+	SmbAtimeWrittenAt time.Time // when the last READ-driven atime reached the store
+	SmbPendingAtime   time.Time // newest access time not yet written to the store (zero ⇒ none)
+
 	// Oplock state
 	// OplockLevel is the current oplock level for this handle.
 	// Thread safety: This field is written during CREATE (before storing in sync.Map)

--- a/internal/adapter/smb/handlers/query_info.go
+++ b/internal/adapter/smb/handlers/query_info.go
@@ -295,6 +295,11 @@ func (h *Handler) QueryInfo(ctx *SMBHandlerContext, req *QueryInfoRequest) (*Que
 		return &QueryInfoResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}, nil
 	}
 
+	// READ coalesces its LastAccessTime bumps, so the newest access may still be
+	// held on the handle rather than in the store. The frozen-timestamp override
+	// below still wins.
+	applySmbPendingAtime(openFile, file)
+
 	// Per MS-FSA 2.1.5.14.2: Apply frozen timestamp overrides.
 	// When SET_INFO(-1) freezes a timestamp, subsequent operations (WRITE,
 	// child CREATE/DELETE for directories, truncate) may update the store

--- a/internal/adapter/smb/handlers/read.go
+++ b/internal/adapter/smb/handlers/read.go
@@ -437,9 +437,15 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// LastAccessTime to the current system time, unless frozen via SET_INFO -1.
 	// IsAtimeFrozen takes openFile.mu (read) so we observe a consistent value
 	// against a concurrent SET_INFO freeze/thaw on the same handle (#606).
+	//
+	// Successive READs on one handle coalesce: the store write happens at most
+	// once per smbAtimeUpdateWindow, and the newest access time is held on the
+	// handle until QUERY_INFO reads it or CLOSE persists it.
 	if !openFile.IsAtimeFrozen() {
 		now := time.Now()
-		_, _ = metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{Atime: &now})
+		if noteSmbAccess(openFile, now) {
+			_, _ = metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{Atime: &now})
+		}
 	}
 
 	// ========================================================================

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -631,6 +631,12 @@ func (h *Handler) setFileInfoFromStore(
 		// write_time also makes the value sticky until close. We still hold
 		// openFile.mu (write) here, so use the *Locked helpers.
 		flushSmbDelayedWriteLocked(openFile)
+		// Any LastAccessTime action on this handle — an explicit value or a
+		// freeze/thaw sentinel — makes the client's value authoritative, so drop
+		// the coalesced READ access time CLOSE would otherwise flush over it.
+		if atimeFT != 0 {
+			openFile.SmbPendingAtime = time.Time{}
+		}
 		if setAttrs.Mtime != nil && mtimeFT != 0 && !isFiletimeSentinel(mtimeFT) {
 			setSmbStickyWriteTimeLocked(openFile, *setAttrs.Mtime)
 		}

--- a/internal/adapter/smb/handlers/timestamps.go
+++ b/internal/adapter/smb/handlers/timestamps.go
@@ -29,6 +29,71 @@ import (
 // smbDelayedWriteWindow is Samba's WRITE_TIME_UPDATE_USEC_DELAY (2 s).
 const smbDelayedWriteWindow = 2 * time.Second
 
+// smbAtimeUpdateWindow bounds how often a READ-driven LastAccessTime bump
+// reaches the metadata store on one handle. Without it every READ RPC costs a
+// read-modify-write of the file's metadata.
+const smbAtimeUpdateWindow = 2 * time.Second
+
+// noteSmbAccess records an access at t on the handle and reports whether it has
+// to reach the metadata store now. When it returns false the time is held on
+// the handle instead, for applySmbPendingAtime / takeSmbPendingAtime. The first
+// access on a handle always writes.
+//
+// Takes openFile.mu (write) — concurrent READ pipelines on the same handle must
+// serialize so exactly one of them takes the store write.
+func noteSmbAccess(openFile *OpenFile, t time.Time) bool {
+	if openFile == nil {
+		return false
+	}
+	openFile.mu.Lock()
+	defer openFile.mu.Unlock()
+	if !openFile.SmbAtimeWrittenAt.IsZero() && t.Sub(openFile.SmbAtimeWrittenAt) < smbAtimeUpdateWindow {
+		// Latest access wins: concurrent READ pipelines on one handle can reach
+		// the lock out of sample order, and an older sample must not lower the
+		// access time the overlay reports or CLOSE persists.
+		if t.After(openFile.SmbPendingAtime) && t.After(openFile.SmbAtimeWrittenAt) {
+			openFile.SmbPendingAtime = t
+		}
+		return false
+	}
+	openFile.SmbAtimeWrittenAt = t
+	openFile.SmbPendingAtime = time.Time{}
+	return true
+}
+
+// takeSmbPendingAtime removes and returns the access time held on the handle
+// since the last store write, or the zero time when there is none. Called at
+// CLOSE so a coalesced bump is not lost with the handle.
+//
+// Takes openFile.mu (write).
+func takeSmbPendingAtime(openFile *OpenFile) time.Time {
+	if openFile == nil {
+		return time.Time{}
+	}
+	openFile.mu.Lock()
+	defer openFile.mu.Unlock()
+	pending := openFile.SmbPendingAtime
+	openFile.SmbPendingAtime = time.Time{}
+	return pending
+}
+
+// applySmbPendingAtime overlays the coalesced access time on top of a
+// freshly-read metadata.File so QUERY_INFO reports the newest access rather
+// than the last one that reached the store. A newer stored value (another
+// handle's explicit set) wins.
+//
+// Takes openFile.mu (read).
+func applySmbPendingAtime(openFile *OpenFile, file *metadata.File) {
+	if openFile == nil || file == nil {
+		return
+	}
+	openFile.mu.RLock()
+	defer openFile.mu.RUnlock()
+	if file.Atime.Before(openFile.SmbPendingAtime) {
+		file.Atime = openFile.SmbPendingAtime
+	}
+}
+
 // armSmbDelayedWriteLocked is the lock-free body of armSmbDelayedWrite.
 // Callers must hold openFile.mu (write).
 func armSmbDelayedWriteLocked(openFile *OpenFile, preMtime time.Time, writeTime time.Time) {

--- a/internal/adapter/smb/handlers/timestamps_atime_test.go
+++ b/internal/adapter/smb/handlers/timestamps_atime_test.go
@@ -1,0 +1,242 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// atimeReader mirrors the READ handler's LastAccessTime step (read.go step 12)
+// and the CLOSE flush (close.go step 4) against a real metadata service, so the
+// tests below observe the store writes those paths actually issue. The SMB READ
+// handler itself needs session/tree/blockstore plumbing that these tests do not
+// exercise.
+type atimeReader struct {
+	t        *testing.T
+	meta     *metadata.Service
+	authCtx  *metadata.AuthContext
+	handle   metadata.FileHandle
+	openFile *OpenFile
+	writes   int // store writes issued so far
+}
+
+func newAtimeReader(t *testing.T) *atimeReader {
+	t.Helper()
+	h, authCtx, handle, openFile := setupTimestampTest(t)
+	return &atimeReader{
+		t:        t,
+		meta:     h.Registry.GetMetadataService(),
+		authCtx:  authCtx,
+		handle:   handle,
+		openFile: openFile,
+	}
+}
+
+// setAtime writes an access time straight to the metadata store.
+func (r *atimeReader) setAtime(t time.Time) {
+	r.t.Helper()
+	if _, err := r.meta.SetFileAttributes(r.authCtx, r.handle, &metadata.SetAttrs{Atime: &t}); err != nil {
+		r.t.Fatalf("SetFileAttributes: %v", err)
+	}
+}
+
+// read performs the atime bump a successful READ at time now would perform.
+func (r *atimeReader) read(now time.Time) {
+	r.t.Helper()
+	if r.openFile.IsAtimeFrozen() {
+		return
+	}
+	if noteSmbAccess(r.openFile, now) {
+		r.setAtime(now)
+		r.writes++
+	}
+}
+
+// closeHandle performs the CLOSE-time flush of a coalesced access time.
+func (r *atimeReader) closeHandle() {
+	r.t.Helper()
+	if pending := takeSmbPendingAtime(r.openFile); !pending.IsZero() && !r.openFile.IsAtimeFrozen() {
+		if !r.file().Atime.Before(pending) {
+			return // the store already holds a newer access time
+		}
+		r.setAtime(pending)
+		r.writes++
+	}
+}
+
+func (r *atimeReader) file() *metadata.File {
+	r.t.Helper()
+	file, err := r.meta.GetFile(r.authCtx.Context, r.handle)
+	if err != nil {
+		r.t.Fatalf("GetFile: %v", err)
+	}
+	return file
+}
+
+// storedAtime is the LastAccessTime that actually reached the metadata store.
+func (r *atimeReader) storedAtime() time.Time {
+	r.t.Helper()
+	return r.file().Atime
+}
+
+// visibleAtime is the LastAccessTime QUERY_INFO reports: the stored value with
+// the handle's coalesced access time overlaid.
+func (r *atimeReader) visibleAtime() time.Time {
+	r.t.Helper()
+	file := r.file()
+	applySmbPendingAtime(r.openFile, file)
+	return file.Atime
+}
+
+// TestSmbAtime_ReadsWithinWindowWriteOnce asserts a burst of READs on one handle
+// costs a single metadata store write instead of one per READ.
+func TestSmbAtime_ReadsWithinWindowWriteOnce(t *testing.T) {
+	r := newAtimeReader(t)
+
+	base := time.Now()
+	for i := range 8 {
+		r.read(base.Add(time.Duration(i) * 10 * time.Millisecond))
+	}
+
+	if r.writes != 1 {
+		t.Fatalf("store writes = %d, want 1 for 8 reads inside the window", r.writes)
+	}
+	// The store holds only the first read's time: the other seven were elided,
+	// not merely overwritten.
+	if got := r.storedAtime(); !got.Equal(base) {
+		t.Fatalf("stored atime = %v, want the first read's time %v", got, base)
+	}
+}
+
+// TestSmbAtime_NewestAccessIsVisible asserts a coalesced access time is still
+// reported by QUERY_INFO even though it has not reached the store.
+func TestSmbAtime_NewestAccessIsVisible(t *testing.T) {
+	r := newAtimeReader(t)
+
+	base := time.Now()
+	last := base.Add(50 * time.Millisecond)
+	r.read(base)
+	r.read(last)
+
+	if got := r.visibleAtime(); !got.Equal(last) {
+		t.Fatalf("visible atime = %v, want the newest read %v", got, last)
+	}
+	// A newer stored value (another handle's explicit set) still wins.
+	newer := last.Add(time.Hour)
+	r.setAtime(newer)
+	if got := r.visibleAtime(); !got.Equal(newer) {
+		t.Fatalf("visible atime = %v, want the newer stored value %v", got, newer)
+	}
+}
+
+// TestSmbAtime_FlushedOnClose asserts the coalesced access time is persisted
+// when the handle goes away, so it is not silently lost.
+func TestSmbAtime_FlushedOnClose(t *testing.T) {
+	r := newAtimeReader(t)
+
+	base := time.Now()
+	last := base.Add(100 * time.Millisecond)
+	r.read(base)
+	r.read(last)
+	if got := r.storedAtime(); !got.Equal(base) {
+		t.Fatalf("stored atime before close = %v, want %v", got, base)
+	}
+
+	r.closeHandle()
+	if got := r.storedAtime(); !got.Equal(last) {
+		t.Fatalf("stored atime after close = %v, want the newest read %v", got, last)
+	}
+	// Nothing left to flush, so a second close writes nothing.
+	writesAfterClose := r.writes
+	r.closeHandle()
+	if r.writes != writesAfterClose {
+		t.Fatalf("store writes = %d after a second close, want %d", r.writes, writesAfterClose)
+	}
+}
+
+// TestSmbAtime_WindowExpiryWritesAgain asserts atime keeps advancing durably on
+// a long-lived handle rather than being pinned to the first read.
+func TestSmbAtime_WindowExpiryWritesAgain(t *testing.T) {
+	r := newAtimeReader(t)
+
+	base := time.Now()
+	r.read(base)
+	r.read(base.Add(smbAtimeUpdateWindow / 2))
+	later := base.Add(smbAtimeUpdateWindow + time.Second)
+	r.read(later)
+
+	if r.writes != 2 {
+		t.Fatalf("store writes = %d, want 2 (one per elapsed window)", r.writes)
+	}
+	if got := r.storedAtime(); !got.Equal(later) {
+		t.Fatalf("stored atime = %v, want the post-window read %v", got, later)
+	}
+	// The window write cleared the pending time, so CLOSE has nothing to add.
+	r.closeHandle()
+	if r.writes != 2 {
+		t.Fatalf("store writes = %d after close, want 2", r.writes)
+	}
+}
+
+// TestSmbAtime_OutOfOrderAccessDoesNotLowerAtime asserts a READ whose sampled
+// time lands out of order (concurrent pipelines on one handle) cannot move the
+// access time backwards.
+func TestSmbAtime_OutOfOrderAccessDoesNotLowerAtime(t *testing.T) {
+	r := newAtimeReader(t)
+
+	base := time.Now()
+	newest := base.Add(500 * time.Millisecond)
+	r.read(base)
+	r.read(newest)
+	r.read(base.Add(100 * time.Millisecond)) // sampled earlier, arrives later
+
+	if got := r.visibleAtime(); !got.Equal(newest) {
+		t.Fatalf("visible atime = %v, want the newest access %v", got, newest)
+	}
+	r.closeHandle()
+	if got := r.storedAtime(); !got.Equal(newest) {
+		t.Fatalf("stored atime after close = %v, want %v", got, newest)
+	}
+}
+
+// TestSmbAtime_CloseDoesNotLowerAnotherHandlesAtime asserts the CLOSE flush
+// cannot move LastAccessTime backwards over a newer value another handle (or an
+// NFS client) persisted while this handle was coalescing.
+func TestSmbAtime_CloseDoesNotLowerAnotherHandlesAtime(t *testing.T) {
+	r := newAtimeReader(t)
+
+	base := time.Now()
+	r.read(base)
+	r.read(base.Add(50 * time.Millisecond)) // held on the handle, not in the store
+
+	// Another handle explicitly sets a newer LastAccessTime.
+	other := base.Add(time.Hour)
+	r.setAtime(other)
+
+	r.closeHandle()
+	if got := r.storedAtime(); !got.Equal(other) {
+		t.Fatalf("stored atime after close = %v, want the other handle's newer value %v", got, other)
+	}
+}
+
+// TestSmbAtime_FrozenSuppressesEverything asserts SET_INFO(-1) still stops
+// READ-driven LastAccessTime updates, including the CLOSE flush.
+func TestSmbAtime_FrozenSuppressesEverything(t *testing.T) {
+	r := newAtimeReader(t)
+
+	base := time.Now()
+	r.read(base)
+	r.read(base.Add(10 * time.Millisecond))
+
+	r.openFile.AtimeFrozen = true
+	r.read(base.Add(time.Hour))
+	r.closeHandle()
+
+	if r.writes != 1 {
+		t.Fatalf("store writes = %d, want 1 (only the pre-freeze read)", r.writes)
+	}
+	if got := r.storedAtime(); !got.Equal(base) {
+		t.Fatalf("stored atime = %v, want %v", got, base)
+	}
+}


### PR DESCRIPTION
Relates to #1892.

## Problem

Every successful SMB READ called `metaSvc.SetFileAttributes(Atime)` synchronously unless the handle had a frozen LastAccessTime, with no throttle. `Service.SetFileAttributes` does a `GetFile` plus permission checks plus a persisting store write, so a sequential read cost one metadata read-modify-write per READ RPC on the data plane. The existing `DirTimesTracker` coalescing in the metadata service covers directories only.

## Fix

Coalesce the bumps per open handle, in the SMB adapter, next to the existing per-handle timestamp state:

- the first access on a handle still writes through, so open/read/close clients see unchanged store traffic;
- further accesses inside a 2s window are held in `OpenFile.SmbPendingAtime`;
- QUERY_INFO overlays the held value, so the newest access time stays observable via GETINFO/stat (a newer stored value from another handle still wins);
- SET_INFO touching LastAccessTime drops the held value, so a client's explicit set is never flushed over;
- CLOSE persists the held value, so a coalesced bump is not lost with the handle;
- `IsAtimeFrozen` still suppresses both the bump and the CLOSE flush;
- out-of-order samples from concurrent READ pipelines on one handle cannot lower the access time.

## Why not reuse an existing mechanism

- `DirTimesTracker` (pkg/metadata) is the closest analogue, but its pending map has no evictor. That is fine for a bounded set of directories and unbounded for files. It also lives below the point where the distinction matters: an explicit client `touch -a` reaches `Service.SetFileAttributes` with the same `SetAttrs{Atime}` as an implicit read bump, so the metadata layer cannot tell them apart.
- `smbDelayedWriteWindow` / sticky-write-time is the same shape of per-handle state and lives in the same file, which is where the new helpers were added, but it serves a different semantic (show the pre-write Mtime until the window expires) so folding them together would add conditionals rather than remove them.
- The FlushPendingWrite deferred path is keyed to write coordination and would not avoid the read-modify-write.

## Tests

New `internal/adapter/smb/handlers/timestamps_atime_test.go` drives the READ and CLOSE atime steps against a real metadata service and counts the `SetFileAttributes` calls that actually reach the store:

- 8 reads inside the window produce exactly 1 store write, and the store holds the first read's time (the other seven were elided, not overwritten);
- the newest access is still visible through the QUERY_INFO overlay, and a newer stored value wins;
- CLOSE persists the coalesced time, and a second CLOSE writes nothing;
- crossing the window writes again, so atime keeps advancing durably on long-lived handles;
- a frozen LastAccessTime suppresses the bump and the CLOSE flush;
- an out-of-order sample does not lower the access time.

Both behaviours were mutation-checked: with `noteSmbAccess` forced to always write (the pre-fix behaviour) the write-count test reports 8 writes instead of 1, and without the monotonic guard the out-of-order test reports the earlier time.

```
go build ./... && go vet ./... && gofmt -l .   # clean
go test ./internal/adapter/smb/... ./pkg/metadata/...   # all ok
go test -race ./internal/adapter/smb/...                # all ok
```