### PR TITLE
perf(metadata): project committed chunks incrementally instead of re-listing the manifest

### DIFF
--- a/pkg/block/engine/blocksink.go
+++ b/pkg/block/engine/blocksink.go
@@ -125,9 +125,11 @@ func (s localBlockSink) CommitBlock(ctx context.Context, chunks []journal.CarveC
 				return fmt.Errorf("local carve: put manifest row %s: %w", fc.ID, err)
 			}
 		}
-		// Materialize File.Blocks from the manifest — same txn (R). Superseded-row
-		// reaping runs once at run end (ReapSupersededManifest), not per batch.
-		return metadata.ProjectManifestToBlocks(ctx, tx, payloadID)
+		// Materialize File.Blocks from the manifest — same txn (R), merging only
+		// this batch's rows so a multi-batch carve does not re-list and re-sort
+		// the whole growing manifest per batch. Superseded-row reaping runs once
+		// at run end (ReapSupersededManifest), not per batch.
+		return metadata.ProjectCommittedChunks(ctx, tx, payloadID, fileChunks)
 	})
 }
 

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -32,11 +32,90 @@ func ManifestToChunkRefs(rows []*block.FileChunk) []block.ChunkRef {
 	return refs
 }
 
+// mergeCommittedRefs folds just-written manifest rows into refs — the
+// offset-sorted projection of the manifest as it stood before those rows — and
+// returns what ManifestToChunkRefs would produce over the manifest they landed
+// in. A manifest holds exactly one row per offset, so a row whose offset refs
+// already carries replaces that entry and every other row lands at its sorted
+// position. Rows are applied in slice order, so a batch repeating an offset
+// keeps the last one — the single row the store retains. Rows with an
+// unparseable ID, or addressing another payload, are skipped, matching what the
+// full projection's list-and-sort ignores.
+func mergeCommittedRefs(refs []block.ChunkRef, payloadID string, rows []*block.FileChunk) []block.ChunkRef {
+	byOffset := make(map[uint64]block.ChunkRef, len(rows))
+	for _, r := range rows {
+		if r == nil {
+			continue
+		}
+		off, ok := block.ParseChunkOffset(r.ID)
+		if !ok || chunkPayloadID(r.ID) != payloadID {
+			continue
+		}
+		byOffset[off] = block.ChunkRef{Hash: r.Hash, Offset: off, Size: r.DataSize}
+	}
+	if len(byOffset) == 0 {
+		return refs
+	}
+	added := make([]block.ChunkRef, 0, len(byOffset))
+	for _, ref := range byOffset {
+		added = append(added, ref)
+	}
+	// Offsets are unique here, so this total order is the one the full
+	// projection's sort produces.
+	sort.Slice(added, func(i, j int) bool { return added[i].Offset < added[j].Offset })
+
+	merged := make([]block.ChunkRef, 0, len(refs)+len(added))
+	i, j := 0, 0
+	for i < len(refs) && j < len(added) {
+		switch {
+		case refs[i].Offset < added[j].Offset:
+			merged = append(merged, refs[i])
+			i++
+		case added[j].Offset < refs[i].Offset:
+			merged = append(merged, added[j])
+			j++
+		default: // this batch rewrote the offset — its row wins
+			merged = append(merged, added[j])
+			i++
+			j++
+		}
+	}
+	return append(append(merged, refs[i:]...), added[j:]...)
+}
+
+// ProjectCommittedChunks folds the manifest rows a caller just wrote into
+// File.Blocks, within that same txn, without re-listing the manifest: Blocks
+// already holds the projection of every earlier row, so merging the new rows in
+// at their sorted position yields exactly what ProjectManifestToBlocks
+// re-derives, at the cost of the batch rather than of the whole file — carving
+// one file into many block objects would otherwise re-list and re-sort the whole
+// growing manifest once per object.
+//
+// rows must be exactly the rows just written for payloadID in this txn. An empty
+// Blocks list carries no projection to merge into, so that case re-derives from
+// the manifest — which is also what makes the first commit of a file correct.
+func ProjectCommittedChunks(ctx context.Context, tx Transaction, payloadID string, rows []*block.FileChunk) error {
+	if payloadID == "" {
+		return nil
+	}
+	file, err := fileToProject(ctx, tx, payloadID)
+	if err != nil || file == nil {
+		return err
+	}
+	if len(file.Blocks) == 0 {
+		return reprojectFile(ctx, tx, file, payloadID)
+	}
+	return putProjection(ctx, tx, file, mergeCommittedRefs(file.Blocks, payloadID, rows))
+}
+
 // ProjectManifestToBlocks re-materializes File.Blocks for payloadID from the
 // current FileChunk manifest, within the caller's txn. Every manifest mutation
-// (carve commit, #953 reap + re-carve straddle, truncate) must call this in the
+// (carve commit, reap + re-carve straddle, truncate) must project in the
 // SAME txn that changed the rows, so File.Blocks == projection(rows) always and
 // the raw-row readers (snapshot WriteSnapshot, refcount audit) never see drift.
+// A caller that knows which rows it changed holds that invariant far more
+// cheaply through ProjectCommittedChunks; this full re-derivation is for the
+// ones that don't (a reap, or rows of unknown provenance).
 // A missing file (deleted concurrently) is a no-op. ponytail: this is the
 // switchover bridge; the #1715 fb-split removes File.Blocks from the row entirely
 // and derives at read time, retiring this projection.
@@ -44,40 +123,68 @@ func ProjectManifestToBlocks(ctx context.Context, tx Transaction, payloadID stri
 	if payloadID == "" {
 		return nil
 	}
+	file, err := fileToProject(ctx, tx, payloadID)
+	if err != nil || file == nil {
+		return err
+	}
+	return reprojectFile(ctx, tx, file, payloadID)
+}
+
+// fileToProject resolves the File row the projection writes onto. A missing row
+// (block-layer fixtures with synthetic payloadIDs, or a file deleted between
+// carve and commit) yields (nil, nil) — nothing to project onto.
+func fileToProject(ctx context.Context, tx Transaction, payloadID string) (*File, error) {
+	file, err := tx.GetFileByPayloadID(ctx, PayloadID(payloadID))
+	if err != nil {
+		if IsNotFoundError(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("project blocks: get file for %s: %w", payloadID, err)
+	}
+	return file, nil
+}
+
+func reprojectFile(ctx context.Context, tx Transaction, file *File, payloadID string) error {
 	rows, err := tx.ListFileChunks(ctx, payloadID)
 	if err != nil {
 		return fmt.Errorf("project blocks: list manifest for %s: %w", payloadID, err)
 	}
-	file, err := tx.GetFileByPayloadID(ctx, PayloadID(payloadID))
-	if err != nil {
-		// No File row (block-layer fixtures with synthetic payloadIDs, or a file
-		// deleted between carve and commit) → nothing to project onto, no-op.
-		if IsNotFoundError(err) {
-			return nil
-		}
-		return fmt.Errorf("project blocks: get file for %s: %w", payloadID, err)
-	}
-	if file == nil {
-		return nil
-	}
-	file.Blocks = ManifestToChunkRefs(rows)
-	// Re-projection from the manifest IS a manifest write — persist it. This
+	return putProjection(ctx, tx, file, ManifestToChunkRefs(rows))
+}
+
+func putProjection(ctx context.Context, tx Transaction, file *File, refs []block.ChunkRef) error {
+	file.Blocks = refs
+	// A projection from the manifest IS a manifest write — persist it. This
 	// funnels carve/rollup commit (DefaultCommitBlock), the #953 reap+re-carve
 	// (ReapSupersededManifest), and coordinator.ReprojectBlocks.
 	file.BlocksDirty = true
 	return tx.PutFile(ctx, file)
 }
 
+// chunkPayloadID returns the payload prefix of a manifest row ID — everything
+// before the last '/' — or "" when there is no prefix to take. The offset that
+// follows is not validated here, so an ID carrying an empty or non-numeric
+// offset still yields its prefix: callers parse the offset themselves and drop
+// that row, whereas answering "" would skip the projection of the whole batch
+// the row arrived in rather than the one bad row.
+func chunkPayloadID(id string) string {
+	if i := strings.LastIndexByte(id, '/'); i > 0 {
+		return id[:i]
+	}
+	return ""
+}
+
 // payloadIDFromChunks extracts the shared payloadID from a carve pass's FileChunk
 // rows (all rows of one carve belong to one file). Returns "" when the rows are
-// nil/empty or malformed, which callers treat as "skip projection".
+// nil/empty or none of them carries a payload prefix, which callers treat as
+// "skip projection".
 func payloadIDFromChunks(fileChunks []*block.FileChunk) string {
 	for _, fc := range fileChunks {
 		if fc == nil {
 			continue
 		}
-		if i := strings.LastIndexByte(fc.ID, '/'); i > 0 {
-			return fc.ID[:i]
+		if pid := chunkPayloadID(fc.ID); pid != "" {
+			return pid
 		}
 	}
 	return ""
@@ -168,10 +275,12 @@ func DefaultCommitBlock(
 			}
 		}
 		// Materialize File.Blocks from the manifest in this same txn so raw-row
-		// readers (snapshot, audit) stay coherent. Skipped for legacy callers
-		// that pass no fileChunks (nil payloadID). Superseded-row reaping happens
-		// once per carve run (ReapSupersededManifest), not per batch — see below.
-		return ProjectManifestToBlocks(ctx, tx, payloadIDFromChunks(fileChunks))
+		// readers (snapshot, audit) stay coherent — merging only this batch's
+		// rows, since re-deriving from the whole manifest costs a full list and
+		// sort per committed block object. Skipped for legacy callers that pass
+		// no fileChunks (empty payloadID). Superseded-row reaping happens once
+		// per carve run (ReapSupersededManifest), not per batch — see below.
+		return ProjectCommittedChunks(ctx, tx, payloadIDFromChunks(fileChunks), fileChunks)
 	})
 }
 

--- a/pkg/metadata/manifest_projection_test.go
+++ b/pkg/metadata/manifest_projection_test.go
@@ -1,0 +1,312 @@
+package metadata
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/stretchr/testify/require"
+)
+
+// projTestChunkSpan is the offset grid batches draw from — small enough that a
+// run keeps landing on offsets earlier batches already wrote.
+const projTestChunkSpan = 1 << 12
+
+// manifestTx models the manifest half of a metadata transaction: FileChunk rows
+// keyed by ID (upsert semantics) plus the single File row a projection writes
+// onto. ListFileChunks hands rows back in lexicographic ID order, which stops
+// matching offset order as soon as a file passes ten chunks, so a projection
+// that leans on list order instead of sorting fails here.
+type manifestTx struct {
+	Transaction
+	rows    map[string]*block.FileChunk
+	file    *File
+	records map[string]struct{}
+}
+
+func newManifestTx(payloadID string) *manifestTx {
+	return &manifestTx{
+		rows:    map[string]*block.FileChunk{},
+		file:    &File{FileAttr: FileAttr{PayloadID: PayloadID(payloadID)}},
+		records: map[string]struct{}{},
+	}
+}
+
+func (t *manifestTx) Put(_ context.Context, fc *block.FileChunk) error {
+	t.rows[fc.ID] = fc
+	return nil
+}
+
+func (t *manifestTx) deleteRow(id string) { delete(t.rows, id) }
+
+func (t *manifestTx) ListFileChunks(_ context.Context, payloadID string) ([]*block.FileChunk, error) {
+	ids := make([]string, 0, len(t.rows))
+	for id := range t.rows {
+		if chunkPayloadID(id) == payloadID {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	out := make([]*block.FileChunk, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, t.rows[id])
+	}
+	return out, nil
+}
+
+// GetFileByPayloadID hands back a copy, as the real backends do, so a projection
+// cannot fake coherence by mutating the stored row's slice in place.
+func (t *manifestTx) GetFileByPayloadID(_ context.Context, pid PayloadID) (*File, error) {
+	if t.file.PayloadID != pid {
+		return nil, &StoreError{Code: ErrNotFound, Message: "no file for payload"}
+	}
+	return copyFileRow(t.file), nil
+}
+
+func (t *manifestTx) PutFile(_ context.Context, f *File) error {
+	t.file = copyFileRow(f)
+	return nil
+}
+
+func (t *manifestTx) GetBlockRecord(_ context.Context, blockID string) (block.BlockRecord, bool, error) {
+	_, ok := t.records[blockID]
+	return block.BlockRecord{BlockID: blockID}, ok, nil
+}
+
+func (t *manifestTx) PutBlockRecord(_ context.Context, rec block.BlockRecord) error {
+	t.records[rec.BlockID] = struct{}{}
+	return nil
+}
+
+func (t *manifestTx) WithTransaction(_ context.Context, fn func(tx Transaction) error) error {
+	return fn(t)
+}
+
+func copyFileRow(f *File) *File {
+	cp := *f
+	if f.Blocks != nil {
+		cp.Blocks = append([]block.ChunkRef(nil), f.Blocks...)
+	}
+	return &cp
+}
+
+// fullProjection is what File.Blocks would hold if it were re-derived from the
+// whole manifest — the reference the incremental projection must reproduce.
+func (t *manifestTx) fullProjection(tb testing.TB, payloadID string) []block.ChunkRef {
+	tb.Helper()
+	rows, err := t.ListFileChunks(context.Background(), payloadID)
+	require.NoError(tb, err)
+	return ManifestToChunkRefs(rows)
+}
+
+func testHash(seed int) block.ContentHash {
+	var h block.ContentHash
+	binary.LittleEndian.PutUint64(h[:], uint64(seed))
+	return h
+}
+
+func chunkID(payloadID string, offset uint64) string {
+	return fmt.Sprintf("%s/%d", payloadID, offset)
+}
+
+func chunkRow(payloadID string, offset uint64, seed int, size uint32) *block.FileChunk {
+	return &block.FileChunk{
+		ID:       chunkID(payloadID, offset),
+		Hash:     testHash(seed),
+		DataSize: size,
+		State:    block.BlockStatePending,
+	}
+}
+
+// randomBatch mimics one carved block object's manifest rows. Offsets are drawn
+// from a window that widens with the run, so a batch mixes fresh appends with
+// rewrites of offsets earlier batches wrote, in arbitrary order. Every fifth
+// batch also carries an entry the commit path must tolerate: a nil, a second row
+// for an offset already in the batch, a row whose offset does not parse, and a
+// row belonging to another payload.
+func randomBatch(rng *rand.Rand, payloadID string, batchNo int) []*block.FileChunk {
+	window := 8 + batchNo*2
+	// The first row must be well-formed: the payload the batch projects onto is
+	// read off it.
+	rows := make([]*block.FileChunk, 0, 9)
+	for i := range 1 + rng.Intn(6) {
+		rows = append(rows, chunkRow(payloadID, uint64(rng.Intn(window))*projTestChunkSpan, batchNo*100+i, uint32(1+rng.Intn(1<<20))))
+	}
+	switch batchNo % 5 {
+	case 1:
+		rows = append(rows, nil)
+	case 2:
+		dup := *rows[0]
+		dup.Hash = testHash(batchNo*100 + 99)
+		dup.DataSize = dup.DataSize + 1
+		rows = append(rows, &dup)
+	case 3:
+		rows = append(rows, &block.FileChunk{ID: payloadID + "/not-an-offset", Hash: testHash(batchNo)})
+	case 4:
+		rows = append(rows, chunkRow("other-payload", uint64(batchNo)*projTestChunkSpan, batchNo, 4096))
+	}
+	return rows
+}
+
+// TestCommitBlockProjectionMatchesFullReprojection drives a long, adversarial
+// commit sequence through the carve-commit path and asserts File.Blocks is, after
+// every batch, exactly what re-deriving the projection from the whole manifest
+// would produce.
+func TestCommitBlockProjectionMatchesFullReprojection(t *testing.T) {
+	const payloadID = "payload-1"
+	ctx := context.Background()
+	tx := newManifestTx(payloadID)
+	rng := rand.New(rand.NewSource(20260805))
+
+	for batchNo := range 300 {
+		rows := randomBatch(rng, payloadID, batchNo)
+		rec := block.BlockRecord{BlockID: fmt.Sprintf("block-%d", batchNo), LiveChunkCount: uint32(len(rows))}
+		require.NoError(t, DefaultCommitBlock(ctx, tx, rec, nil, rows))
+
+		want := tx.fullProjection(t, payloadID)
+		require.Equal(t, want, tx.file.Blocks, "projection after batch %d", batchNo)
+		require.True(t, tx.file.BlocksDirty, "batch %d must mark the block list dirty", batchNo)
+
+		// Re-committing the same block object is a no-op, projection included.
+		require.NoError(t, DefaultCommitBlock(ctx, tx, rec, nil, rows))
+		require.Equal(t, want, tx.file.Blocks, "re-commit of batch %d", batchNo)
+	}
+	require.Greater(t, len(tx.file.Blocks), 100, "the run must have built a substantial manifest")
+}
+
+// TestProjectCommittedChunksEdgeCases covers the boundaries the random run only
+// reaches by luck.
+func TestProjectCommittedChunksEdgeCases(t *testing.T) {
+	const payloadID = "payload-1"
+	ctx := context.Background()
+
+	t.Run("first commit bootstraps from the manifest", func(t *testing.T) {
+		tx := newManifestTx(payloadID)
+		rows := []*block.FileChunk{
+			chunkRow(payloadID, 8192, 2, 4096),
+			chunkRow(payloadID, 0, 1, 4096),
+		}
+		for _, r := range rows {
+			require.NoError(t, tx.Put(ctx, r))
+		}
+		require.NoError(t, ProjectCommittedChunks(ctx, tx, payloadID, rows))
+		require.Equal(t, tx.fullProjection(t, payloadID), tx.file.Blocks)
+	})
+
+	t.Run("no rows for this payload leaves the projection alone", func(t *testing.T) {
+		tx := newManifestTx(payloadID)
+		seed := []*block.FileChunk{chunkRow(payloadID, 0, 1, 4096), chunkRow(payloadID, 4096, 2, 4096)}
+		for _, r := range seed {
+			require.NoError(t, tx.Put(ctx, r))
+		}
+		require.NoError(t, ProjectManifestToBlocks(ctx, tx, payloadID))
+		before := tx.file.Blocks
+
+		foreign := []*block.FileChunk{chunkRow("other-payload", 0, 9, 4096)}
+		require.NoError(t, tx.Put(ctx, foreign[0]))
+		require.NoError(t, ProjectCommittedChunks(ctx, tx, payloadID, foreign))
+		require.Equal(t, before, tx.file.Blocks)
+		require.Equal(t, tx.fullProjection(t, payloadID), tx.file.Blocks)
+	})
+
+	// The payload prefix is taken without validating the offset behind it, so a
+	// row with an empty offset still names the file its batch projects onto. The
+	// row itself is dropped, exactly as the full projection drops it.
+	t.Run("a row with an empty offset names the file but is not projected", func(t *testing.T) {
+		tx := newManifestTx(payloadID)
+		for _, r := range []*block.FileChunk{chunkRow(payloadID, 0, 1, 4096), chunkRow(payloadID, 4096, 2, 4096)} {
+			require.NoError(t, tx.Put(ctx, r))
+		}
+		require.NoError(t, ProjectManifestToBlocks(ctx, tx, payloadID))
+		before := tx.file.Blocks
+
+		rows := []*block.FileChunk{{ID: payloadID + "/", Hash: testHash(9), DataSize: 4096}}
+		require.NoError(t, tx.Put(ctx, rows[0]))
+		require.Equal(t, payloadID, payloadIDFromChunks(rows))
+		require.NoError(t, ProjectCommittedChunks(ctx, tx, payloadIDFromChunks(rows), rows))
+		require.Equal(t, before, tx.file.Blocks)
+		require.Equal(t, tx.fullProjection(t, payloadID), tx.file.Blocks)
+	})
+
+	t.Run("empty payload is a no-op", func(t *testing.T) {
+		tx := newManifestTx(payloadID)
+		require.NoError(t, ProjectCommittedChunks(ctx, tx, "", nil))
+		require.Nil(t, tx.file.Blocks)
+	})
+
+	t.Run("reap and re-commit stay coherent", func(t *testing.T) {
+		tx := newManifestTx(payloadID)
+		var rows []*block.FileChunk
+		for i := range 6 {
+			rows = append(rows, chunkRow(payloadID, uint64(i)*projTestChunkSpan, i, 4096))
+		}
+		require.NoError(t, DefaultCommitBlock(ctx, tx, block.BlockRecord{BlockID: "b0"}, nil, rows))
+
+		// A run-end reap drops the rows a re-carve superseded and re-derives.
+		tx.deleteRow(chunkID(payloadID, 2*projTestChunkSpan))
+		tx.deleteRow(chunkID(payloadID, 3*projTestChunkSpan))
+		require.NoError(t, ProjectManifestToBlocks(ctx, tx, payloadID))
+		require.Equal(t, tx.fullProjection(t, payloadID), tx.file.Blocks)
+
+		// The next batch merges into the reaped projection, not the pre-reap one.
+		next := []*block.FileChunk{chunkRow(payloadID, 2*projTestChunkSpan, 42, 8192)}
+		require.NoError(t, DefaultCommitBlock(ctx, tx, block.BlockRecord{BlockID: "b1"}, nil, next))
+		require.Equal(t, tx.fullProjection(t, payloadID), tx.file.Blocks)
+	})
+}
+
+// BenchmarkManifestProjectionOnCommit measures one block object's commit against
+// an existing manifest: the full re-derivation lists and sorts every row, the
+// incremental one touches only the batch. The in-memory manifest here has no I/O
+// or row decode, so a real backend's list is dearer than this shows.
+func BenchmarkManifestProjectionOnCommit(b *testing.B) {
+	for _, manifestRows := range []int{1024, 8192, 65536} {
+		b.Run(fmt.Sprintf("rows=%d/full", manifestRows), func(b *testing.B) {
+			benchProjection(b, manifestRows, false)
+		})
+		b.Run(fmt.Sprintf("rows=%d/incremental", manifestRows), func(b *testing.B) {
+			benchProjection(b, manifestRows, true)
+		})
+	}
+}
+
+func benchProjection(b *testing.B, manifestRows int, incremental bool) {
+	const payloadID = "payload-1"
+	ctx := context.Background()
+	tx := newManifestTx(payloadID)
+	for i := range manifestRows {
+		require.NoError(b, tx.Put(ctx, chunkRow(payloadID, uint64(i)*projTestChunkSpan, i, projTestChunkSpan)))
+	}
+	require.NoError(b, ProjectManifestToBlocks(ctx, tx, payloadID))
+
+	// One carved block object's worth of rows, spread across the manifest.
+	const batchSize = 128
+	batch := make([]*block.FileChunk, 0, batchSize)
+	for i := range batchSize {
+		off := uint64(i*(manifestRows/batchSize)) * projTestChunkSpan
+		batch = append(batch, chunkRow(payloadID, off, i+1, projTestChunkSpan))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		for _, fc := range batch {
+			if err := tx.Put(ctx, fc); err != nil {
+				b.Fatal(err)
+			}
+		}
+		var err error
+		if incremental {
+			err = ProjectCommittedChunks(ctx, tx, payloadID, batch)
+		} else {
+			err = ProjectManifestToBlocks(ctx, tx, payloadID)
+		}
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## What

`DefaultCommitBlock` re-derived `File.Blocks` from scratch on every committed block object: a full `tx.ListFileChunks` of the file's entire manifest, a full `sort.Slice`, and a `PutFile{BlocksDirty:true}`. `engine.CommitBlock` calls it once per carved block object, so a file carved into K objects re-listed and re-sorted the whole growing manifest K times — quadratic in the manifest on the write/drain path.

`localBlockSink.CommitBlock` (the local-only carve path) had the identical per-batch full re-projection. Both are fixed.

`ProjectCommittedChunks` merges only the rows the caller just wrote into the already-sorted `File.Blocks`, in the same txn — so the documented same-txn coherence invariant (`File.Blocks == projection(rows)`, which the raw-row readers depend on) is preserved. Deferring to run end, the way `ReapSupersededManifest` deliberately does, would have broken it.

`ProjectManifestToBlocks` stays for the callers that don't know which rows changed: the run-end reap and `coordinator.ReprojectBlocks`.

## Why incremental == full

The merge is only valid if `File.Blocks` really is the projection of the manifest as it stood before these rows. The properties that had to be preserved, and are:

- offset ordering identical to the full projection's sort
- a row whose offset is already projected replaces that entry in place
- a batch repeating an offset keeps the last row — what the store's upsert-by-ID retains
- rows with an unparseable offset, and rows addressing another payload, are skipped exactly as `ListFileChunks` + `ManifestToChunkRefs` would skip them
- an empty `Blocks` list has no projection to merge into, so it re-derives from the manifest — which is also what makes a file's first commit correct
- a re-commit of an already-committed block object stays a no-op

`TestCommitBlockProjectionMatchesFullReprojection` drives 300 batches through `DefaultCommitBlock` with a deterministic seed — appends, out-of-order offsets within a batch, rewrites of offsets earlier batches wrote, duplicate offsets inside one batch, nil rows, unparseable IDs, foreign-payload rows — and after every batch asserts `File.Blocks` equals a full re-derivation from the whole manifest. The fake transaction returns rows in lexicographic ID order (which stops matching offset order past ten chunks) and hands back a copy of the File row, so neither list order nor in-place slice mutation can hide a divergence. `TestProjectCommittedChunksEdgeCases` pins the bootstrap, the foreign-payload no-op, and a reap-then-recommit interleaving.

Mutation-checked: dropping the supersede branch from the merge fails the test at batch 2, and flipping the equal-offset arm to first-wins fails it too.

The one path worth naming: a size-down truncate and a hole punch prune `File.Blocks` without deleting manifest rows in that txn, which would leave the merge's precondition false. The reclaim that follows (`engine.Store.Truncate` / `PunchHole` → `DecrementRefCountAndReap` → `coordinator.ReprojectBlocks`) deletes those rows and full-re-derives, so the invariant is restored — and that path still uses the full projection, unchanged here.

## Benchmark

`BenchmarkManifestProjectionOnCommit` — one block object's worth of rows (128) committed against an existing manifest, full re-derivation vs incremental. Apple M1 Max, `-benchtime 300x`:

| manifest rows | full | incremental | speedup |
|---|---|---|---|
| 1024  | 205,869 ns/op | 43,244 ns/op | 4.8x |
| 8192  | 1,680,990 ns/op | 219,045 ns/op | 7.7x |
| 65536 | 17,430,198 ns/op | 920,664 ns/op | 18.9x |

The gain grows with manifest size, as the quadratic term predicts. The benchmark's manifest is in memory with no I/O or row decode, so a real backend's `ListFileChunks` is dearer than this shows.

The commit is still O(manifest) rather than O(batch): `File.Blocks` is stored as one inline list, so `PutFile` rewrites every ref regardless. What this removes is the per-batch list + decode + sort.

## Verification

```
go build ./... && go vet ./... && gofmt -l .   # clean
go test ./pkg/metadata/... ./pkg/block/...     # all ok
go test -race ./pkg/metadata/...               # all ok
```

Relates to #1896
