### PR TITLE
fix(nfs): enforce netgroup export access on NFSv4, not only NFSv3 MOUNT

### DIFF
--- a/cmd/dfsctl/commands/netgroup/netgroup.go
+++ b/cmd/dfsctl/commands/netgroup/netgroup.go
@@ -14,6 +14,12 @@ is a named set of IP addresses, CIDR ranges, or hostnames that can be referenced
 from share security policies to allow or restrict which network endpoints can
 access a share. All subcommands require admin privileges.
 
+Netgroups are part of a share's NFS export policy: they are attached with
+"dfsctl share nfs-config set --netgroup" and are enforced on NFSv3 (at MOUNT)
+and on NFSv4 (on every operation that resolves the share). They do NOT apply to
+SMB — restrict SMB access with share permissions and user authentication
+instead.
+
 Examples:
   # List all netgroups
   dfsctl netgroup list

--- a/cmd/dfsctl/commands/share/nfs_config.go
+++ b/cmd/dfsctl/commands/share/nfs_config.go
@@ -69,6 +69,9 @@ intact. Netgroup changes take effect immediately. Changes to squash mode and
 authentication flavors (--allow-auth-sys, --require-kerberos) apply on the
 next NFS adapter restart.
 
+The netgroup allowlist is NFS export policy: it is enforced on NFSv3 mounts and
+on NFSv4 operations, and has no effect on SMB access to the same share.
+
 Examples:
   # Restrict access to a specific netgroup
   dfsctl share nfs-config set /export --netgroup office-network

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -3052,6 +3052,12 @@ is a named set of IP addresses, CIDR ranges, or hostnames that can be referenced
 from share security policies to allow or restrict which network endpoints can
 access a share. All subcommands require admin privileges.
 
+Netgroups are part of a share's NFS export policy: they are attached with
+"dfsctl share nfs-config set --netgroup" and are enforced on NFSv3 (at MOUNT)
+and on NFSv4 (on every operation that resolves the share). They do NOT apply to
+SMB — restrict SMB access with share permissions and user authentication
+instead.
+
 **Examples:**
 
 ```bash
@@ -4317,6 +4323,9 @@ Only the flags you supply are changed; omitted flags leave the existing values
 intact. Netgroup changes take effect immediately. Changes to squash mode and
 authentication flavors (--allow-auth-sys, --require-kerberos) apply on the
 next NFS adapter restart.
+
+The netgroup allowlist is NFS export policy: it is enforced on NFSv3 mounts and
+on NFSv4 operations, and has no effect on SMB access to the same share.
 
 ```
 dfsctl share nfs-config set <name> [flags]

--- a/internal/adapter/nfs/v4/handlers/helpers.go
+++ b/internal/adapter/nfs/v4/handlers/helpers.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"net"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/auth"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
@@ -87,6 +88,17 @@ func (h *Handler) buildV4AuthContext(ctx *types.CompoundContext, handle []byte) 
 			AuthMethod: authMethod,
 			Identity:   originalIdentity,
 		}, shareName, nil
+	}
+
+	// Enforce the share's netgroup client allowlist. NFSv4 has no MOUNT
+	// protocol, so the check the v3 MOUNT handler performs never runs for a v4
+	// client: without it here a netgroup-restricted share is reachable from any
+	// address over PUTROOTFH/PUTFH/LOOKUP. This gates every operation that
+	// builds an auth context, including a LOOKUP that crosses from the pseudo-fs
+	// into a share; operations that act on the current filehandle without one
+	// are gated in the PUTFH handler.
+	if err := h.checkNetgroupAccess(ctx, shareName); err != nil {
+		return nil, "", err
 	}
 
 	// Get share for the export-squash permission policy. On error GetShare
@@ -191,6 +203,40 @@ func (h *Handler) buildV4AuthContext(ctx *types.CompoundContext, handle []byte) 
 	}
 
 	return authCtx, shareName, nil
+}
+
+// checkNetgroupAccess returns NFS4ERR_ACCESS unless the compound's peer is in
+// the netgroup that shareName is restricted to.
+//
+// It fails closed the same way the v3 MOUNT handler does: a lookup error and a
+// no-match both deny. A peer address that cannot be parsed yields a nil IP,
+// which matches no netgroup member and so denies any share that has a netgroup,
+// while leaving shares without one (empty allowlist = allow all) unaffected.
+func (h *Handler) checkNetgroupAccess(ctx *types.CompoundContext, shareName string) error {
+	host := ctx.ClientAddr
+	if hostOnly, _, err := net.SplitHostPort(host); err == nil {
+		host = hostOnly
+	}
+	clientIP := net.ParseIP(host)
+
+	allowed, err := h.Registry.CheckNetgroupAccess(ctx.Context, shareName, clientIP)
+	if err != nil {
+		logger.Warn("NFSv4 netgroup access check failed, denying",
+			"share", shareName, "client", ctx.ClientAddr, "error", err)
+		return &authStatusError{
+			status: types.NFS4ERR_ACCESS,
+			err:    fmt.Errorf("netgroup access check for share %q: %w", shareName, err),
+		}
+	}
+	if !allowed {
+		logger.Warn("NFSv4 access denied: client not in the share's netgroup",
+			"share", shareName, "client", ctx.ClientAddr)
+		return &authStatusError{
+			status: types.NFS4ERR_ACCESS,
+			err:    fmt.Errorf("client %q is not in the netgroup allowed for share %q", ctx.ClientAddr, shareName),
+		}
+	}
+	return nil
 }
 
 // getMetadataServiceForCtx returns the MetadataService from the handler's registry.

--- a/internal/adapter/nfs/v4/handlers/netgroup_test.go
+++ b/internal/adapter/nfs/v4/handlers/netgroup_test.go
@@ -1,0 +1,167 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// ============================================================================
+// Netgroup (export client allowlist) enforcement on NFSv4
+// ============================================================================
+//
+// NFSv4 has no MOUNT protocol, so the netgroup allowlist the v3 MOUNT handler
+// evaluates never ran for a v4 client: a share restricted to a netgroup was
+// reachable from any address over PUTROOTFH/PUTFH/LOOKUP. buildV4AuthContext
+// now runs the same check at the point an operation resolves a share.
+//
+// Matching a client IP against netgroup members (IP, CIDR, hostname) is covered
+// by the Runtime tests in pkg/controlplane/runtime; the tests here cover the v4
+// seam: that the check runs on a real operation, and how its verdicts map onto
+// NFSv4 statuses.
+
+// fakeNetgroupRuntime satisfies nfsRuntime for the netgroup check alone. The
+// embedded nil interface panics if anything else is called, which keeps the
+// fake honest about what these tests exercise.
+type fakeNetgroupRuntime struct {
+	nfsRuntime
+
+	allowed bool
+	err     error
+
+	gotShare string
+	gotIP    net.IP
+	calls    int
+}
+
+func (f *fakeNetgroupRuntime) CheckNetgroupAccess(_ context.Context, shareName string, clientIP net.IP) (bool, error) {
+	f.calls++
+	f.gotShare = shareName
+	f.gotIP = clientIP
+	return f.allowed, f.err
+}
+
+// checkStatus runs checkNetgroupAccess against the fake and returns the NFSv4
+// status the client would see (NFS4_OK when the check passes).
+func checkStatus(t *testing.T, rt *fakeNetgroupRuntime, clientAddr string) uint32 {
+	t.Helper()
+
+	h := &Handler{Registry: rt}
+	ctx := &types.CompoundContext{Context: context.Background(), ClientAddr: clientAddr}
+
+	err := h.checkNetgroupAccess(ctx, "/export")
+	if err == nil {
+		return types.NFS4_OK
+	}
+	return nfs4StatusForAuthError(err)
+}
+
+// TestV4Netgroup_ClientOutsideNetgroupDenied covers a client the allowlist does
+// not cover: the compound must fail with NFS4ERR_ACCESS, not proceed.
+func TestV4Netgroup_ClientOutsideNetgroupDenied(t *testing.T) {
+	rt := &fakeNetgroupRuntime{allowed: false}
+
+	if status := checkStatus(t, rt, "10.0.0.5:1023"); status != types.NFS4ERR_ACCESS {
+		t.Fatalf("denied client status = %d, want NFS4ERR_ACCESS (%d)", status, types.NFS4ERR_ACCESS)
+	}
+	if !rt.gotIP.Equal(net.ParseIP("10.0.0.5")) {
+		t.Fatalf("checked IP = %v, want 10.0.0.5 (host must be split from the port)", rt.gotIP)
+	}
+	if rt.gotShare != "/export" {
+		t.Fatalf("checked share = %q, want /export", rt.gotShare)
+	}
+}
+
+// TestV4Netgroup_ClientInsideNetgroupAllowed covers the allow verdict: the
+// check must not interfere with a client the allowlist covers.
+func TestV4Netgroup_ClientInsideNetgroupAllowed(t *testing.T) {
+	rt := &fakeNetgroupRuntime{allowed: true}
+
+	if status := checkStatus(t, rt, "192.168.1.100:9999"); status != types.NFS4_OK {
+		t.Fatalf("allowed client status = %d, want NFS4_OK", status)
+	}
+	if !rt.gotIP.Equal(net.ParseIP("192.168.1.100")) {
+		t.Fatalf("checked IP = %v, want 192.168.1.100", rt.gotIP)
+	}
+}
+
+// TestV4Netgroup_LookupErrorDenies covers the fail-closed contract: a netgroup
+// lookup that errors must deny rather than fall through to the operation.
+func TestV4Netgroup_LookupErrorDenies(t *testing.T) {
+	rt := &fakeNetgroupRuntime{allowed: true, err: errors.New("netgroup store unavailable")}
+
+	if status := checkStatus(t, rt, "192.168.1.100:9999"); status != types.NFS4ERR_ACCESS {
+		t.Fatalf("lookup-error status = %d, want NFS4ERR_ACCESS (%d)", status, types.NFS4ERR_ACCESS)
+	}
+}
+
+// TestV4Netgroup_UnparseableClientAddrChecked covers a peer address the adapter
+// cannot turn into an IP: the check still runs, with a nil IP that matches no
+// netgroup member, so a restricted share denies instead of being skipped.
+func TestV4Netgroup_UnparseableClientAddrChecked(t *testing.T) {
+	rt := &fakeNetgroupRuntime{allowed: false}
+
+	if status := checkStatus(t, rt, "not-an-address"); status != types.NFS4ERR_ACCESS {
+		t.Fatalf("unparseable-addr status = %d, want NFS4ERR_ACCESS (%d)", status, types.NFS4ERR_ACCESS)
+	}
+	if rt.calls != 1 {
+		t.Fatalf("CheckNetgroupAccess calls = %d, want 1 (the check must not be skipped)", rt.calls)
+	}
+	if rt.gotIP != nil {
+		t.Fatalf("checked IP = %v, want nil for an unparseable address", rt.gotIP)
+	}
+}
+
+// TestV4Netgroup_NoNetgroupAllowsAll covers the existing empty-allowlist
+// semantics end to end: the fixture share has no netgroup, so a real GETATTR
+// succeeds.
+func TestV4Netgroup_NoNetgroupAllowsAll(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	fileHandle := fx.createTestFile(t, fx.rootHandle, "f.txt", metadata.FileTypeRegular, 0o644, 1000, 1000)
+
+	if status := getAttrStatusForFile(fx, fileHandle); status != types.NFS4_OK {
+		t.Fatalf("share without a netgroup GETATTR status = %d, want NFS4_OK", status)
+	}
+}
+
+// TestV4Netgroup_RestrictedShareDeniesOnRealOp drives a real GETATTR against a
+// share pointed at a netgroup the fixture's runtime cannot resolve. It proves
+// the check is wired into the operation path and that an unresolvable netgroup
+// fails closed rather than allowing the operation through.
+func TestV4Netgroup_RestrictedShareDeniesOnRealOp(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	fileHandle := fx.createTestFile(t, fx.rootHandle, "f.txt", metadata.FileTypeRegular, 0o644, 1000, 1000)
+
+	if err := fx.rt.SetShareNetgroup("/export", "office-ips"); err != nil {
+		t.Fatalf("SetShareNetgroup: %v", err)
+	}
+
+	if status := getAttrStatusForFile(fx, fileHandle); status != types.NFS4ERR_ACCESS {
+		t.Fatalf("restricted share GETATTR status = %d, want NFS4ERR_ACCESS (%d)", status, types.NFS4ERR_ACCESS)
+	}
+}
+
+// TestV4Netgroup_PutFHDeniesRestrictedShare covers the operations that act on
+// the current filehandle without building an auth context (LOCK, LOCKT, LOCKU,
+// GET_DIR_DELEGATION): they can only name a share handle via PUTFH, so PUTFH
+// must refuse a handle for a share whose netgroup the client is not in.
+func TestV4Netgroup_PutFHDeniesRestrictedShare(t *testing.T) {
+	h, rootHandle, rt := newPutFHTestHandler(t, "/export")
+	if err := rt.SetShareNetgroup("/export", "office-ips"); err != nil {
+		t.Fatalf("SetShareNetgroup: %v", err)
+	}
+
+	ctx := &types.CompoundContext{Context: context.Background(), ClientAddr: "10.0.0.5:1234"}
+	res := h.handlePutFH(ctx, bytes.NewReader(encodePutFHArgsBytes(t, rootHandle)))
+	if res.Status != types.NFS4ERR_ACCESS {
+		t.Fatalf("Status = %d, want NFS4ERR_ACCESS (%d)", res.Status, types.NFS4ERR_ACCESS)
+	}
+	if ctx.CurrentFH != nil {
+		t.Errorf("CurrentFH was set despite refusal: %x", ctx.CurrentFH)
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/putfh.go
+++ b/internal/adapter/nfs/v4/handlers/putfh.go
@@ -61,6 +61,20 @@ func (h *Handler) handlePutFH(ctx *types.CompoundContext, reader io.Reader) *typ
 					Data:   encodeStatusOnly(types.NFS4ERR_STALE),
 				}
 			}
+
+			// Enforce the share's netgroup client allowlist here as well as in
+			// buildV4AuthContext: operations that act on the current filehandle
+			// without building an auth context (LOCK, LOCKT, LOCKU,
+			// GET_DIR_DELEGATION) would otherwise reach a restricted share from
+			// any address. PUTFH is the only way such an operation can name a
+			// share handle, so gating it covers them all.
+			if ngErr := h.checkNetgroupAccess(ctx, shareName); ngErr != nil {
+				return &types.CompoundResult{
+					Status: nfs4StatusForAuthError(ngErr),
+					OpCode: types.OP_PUTFH,
+					Data:   encodeStatusOnly(nfs4StatusForAuthError(ngErr)),
+				}
+			}
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/runtime_iface.go
+++ b/internal/adapter/nfs/v4/handlers/runtime_iface.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"net"
 
 	"github.com/marmos91/dittofs/internal/adapter/common"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
@@ -33,6 +34,10 @@ type nfsRuntime interface {
 	// Identity / auth.
 	GetIdentityStore() models.IdentityStore
 	ApplyIdentityMapping(shareName string, ident *metadata.Identity) (*metadata.Identity, error)
+
+	// Export-level client allowlist. Reports whether clientIP is a member of the
+	// netgroup the share is restricted to; shares with no netgroup allow all.
+	CheckNetgroupAccess(ctx context.Context, shareName string, clientIP net.IP) (bool, error)
 }
 
 var _ nfsRuntime = (*runtime.Runtime)(nil)

--- a/pkg/controlplane/runtime/netgroups.go
+++ b/pkg/controlplane/runtime/netgroups.go
@@ -159,9 +159,10 @@ func (c *dnsCache) cleanExpiredLocked(now time.Time) {
 // Algorithm:
 //  1. Get share from runtime state (not DB -- use cached share config)
 //  2. If share has no NetgroupName -> return true (empty allowlist = allow all)
-//  3. Get netgroup members from store
-//  4. Match client IP against each member (IP, CIDR, or hostname)
-//  5. Return false if no member matches
+//  3. Return a cached verdict for this netgroup and client IP, if still valid
+//  4. Otherwise get netgroup members from store
+//  5. Match client IP against each member (IP, CIDR, or hostname)
+//  6. Return false if no member matches
 //
 // Per Pitfall 3 (DNS blocking): hostname matching uses cached reverse DNS with
 // 5-minute positive TTL and 1-minute negative TTL. Falls back to IP matching
@@ -193,7 +194,69 @@ func (r *Runtime) CheckNetgroupAccess(ctx context.Context, shareName string, cli
 		return true, nil
 	}
 
-	// 3. Get netgroup members from store (requires NetgroupStore interface)
+	// 3. Reuse a recent verdict. It depends only on the netgroup's members and
+	// the client IP, so those two are the whole key: re-pointing a share at a
+	// different netgroup is evaluated immediately. Errors are never cached, so a
+	// failing store keeps failing closed on every call.
+	key := netgroupName + "\x00" + clientIP.String()
+	if allowed, ok := r.cachedNetgroupDecision(key); ok {
+		return allowed, nil
+	}
+
+	allowed, err := r.evaluateNetgroupAccess(ctx, shareName, netgroupName, clientIP)
+	if err != nil {
+		return false, err
+	}
+	r.storeNetgroupDecision(key, allowed)
+	return allowed, nil
+}
+
+// netgroupDecisionTTL bounds how long a netgroup verdict is reused. It trades a
+// short window where a membership edit is not yet visible against querying the
+// netgroup store on every request of a protocol that has no mount step.
+const netgroupDecisionTTL = 30 * time.Second
+
+// netgroupDecision is a cached allow/deny verdict with its expiry.
+type netgroupDecision struct {
+	allowed   bool
+	expiresAt time.Time
+}
+
+// cachedNetgroupDecision returns a non-expired verdict for key, if one exists.
+func (r *Runtime) cachedNetgroupDecision(key string) (allowed bool, ok bool) {
+	r.netgroupDecisionsMu.Lock()
+	defer r.netgroupDecisionsMu.Unlock()
+
+	d, found := r.netgroupDecisions[key]
+	if !found || time.Now().After(d.expiresAt) {
+		return false, false
+	}
+	return d.allowed, true
+}
+
+// storeNetgroupDecision records a verdict for key and sweeps expired entries so
+// the map stays bounded by the clients seen within one TTL window.
+func (r *Runtime) storeNetgroupDecision(key string, allowed bool) {
+	now := time.Now()
+
+	r.netgroupDecisionsMu.Lock()
+	defer r.netgroupDecisionsMu.Unlock()
+
+	if r.netgroupDecisions == nil {
+		r.netgroupDecisions = make(map[string]netgroupDecision)
+	}
+	for k, d := range r.netgroupDecisions {
+		if now.After(d.expiresAt) {
+			delete(r.netgroupDecisions, k)
+		}
+	}
+	r.netgroupDecisions[key] = netgroupDecision{allowed: allowed, expiresAt: now.Add(netgroupDecisionTTL)}
+}
+
+// evaluateNetgroupAccess matches clientIP against the members of netgroupName,
+// consulting the netgroup store. shareName is used for diagnostics only.
+func (r *Runtime) evaluateNetgroupAccess(ctx context.Context, shareName, netgroupName string, clientIP net.IP) (bool, error) {
+	// Get netgroup members from store (requires NetgroupStore interface)
 	ns, ok := r.store.(store.NetgroupStore)
 	if !ok {
 		logger.Warn("Store does not implement NetgroupStore, denying access",
@@ -220,7 +283,7 @@ func (r *Runtime) CheckNetgroupAccess(ctx context.Context, shareName string, cli
 	// Initialize DNS cache lazily
 	ensureDNSCache()
 
-	// 4. Match client IP against each member
+	// Match client IP against each member
 	ipString := clientIP.String()
 	for _, member := range members {
 		switch member.Type {
@@ -243,7 +306,7 @@ func (r *Runtime) CheckNetgroupAccess(ctx context.Context, shareName string, cli
 		}
 	}
 
-	// 5. No member matches
+	// No member matches
 	return false, nil
 }
 

--- a/pkg/controlplane/runtime/netgroups_test.go
+++ b/pkg/controlplane/runtime/netgroups_test.go
@@ -644,3 +644,79 @@ func TestDNSCache_CleanExpired(t *testing.T) {
 	}
 	c.mu.Unlock()
 }
+
+// --- decision cache tests ---
+
+// TestCheckNetgroupAccess_VerdictIsMemoized documents the staleness window the
+// decision cache introduces: a membership edit is not visible until the cached
+// verdict expires. Verdicts are keyed by netgroup name and client IP only --
+// the share name is not part of the key because the verdict depends solely on
+// the netgroup's members and the client IP, so every share pointing at the same
+// netgroup shares one verdict and the staleness window is per netgroup+client,
+// not per share.
+func TestCheckNetgroupAccess_VerdictIsMemoized(t *testing.T) {
+	rt, _, ngStore := createTestRuntimeWithStore(t)
+	ctx := context.Background()
+
+	if _, err := ngStore.CreateNetgroup(ctx, &models.Netgroup{ID: uuid.New().String(), Name: "office-ips"}); err != nil {
+		t.Fatalf("CreateNetgroup failed: %v", err)
+	}
+	addShareDirect(rt, "/export", "office-ips")
+
+	// Empty netgroup denies, and that verdict is cached.
+	if allowed, err := rt.CheckNetgroupAccess(ctx, "/export", net.ParseIP("192.168.1.100")); err != nil || allowed {
+		t.Fatalf("CheckNetgroupAccess (empty netgroup) = (%v, %v), want (false, nil)", allowed, err)
+	}
+
+	if err := ngStore.AddNetgroupMember(ctx, "office-ips", &models.NetgroupMember{
+		Type:  "ip",
+		Value: "192.168.1.100",
+	}); err != nil {
+		t.Fatalf("AddNetgroupMember failed: %v", err)
+	}
+
+	allowed, err := rt.CheckNetgroupAccess(ctx, "/export", net.ParseIP("192.168.1.100"))
+	if err != nil {
+		t.Fatalf("CheckNetgroupAccess failed: %v", err)
+	}
+	if allowed {
+		t.Error("Expected the cached deny verdict to be reused within the TTL")
+	}
+}
+
+// TestCheckNetgroupAccess_RepointedShareReevaluates verifies the cache key
+// includes the netgroup name, so moving a share to another netgroup takes
+// effect immediately rather than after the TTL.
+func TestCheckNetgroupAccess_RepointedShareReevaluates(t *testing.T) {
+	rt, _, ngStore := createTestRuntimeWithStore(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"empty-group", "office-ips"} {
+		if _, err := ngStore.CreateNetgroup(ctx, &models.Netgroup{ID: uuid.New().String(), Name: name}); err != nil {
+			t.Fatalf("CreateNetgroup(%s) failed: %v", name, err)
+		}
+	}
+	if err := ngStore.AddNetgroupMember(ctx, "office-ips", &models.NetgroupMember{
+		Type:  "ip",
+		Value: "192.168.1.100",
+	}); err != nil {
+		t.Fatalf("AddNetgroupMember failed: %v", err)
+	}
+
+	addShareDirect(rt, "/export", "empty-group")
+	if allowed, err := rt.CheckNetgroupAccess(ctx, "/export", net.ParseIP("192.168.1.100")); err != nil || allowed {
+		t.Fatalf("CheckNetgroupAccess (empty-group) = (%v, %v), want (false, nil)", allowed, err)
+	}
+
+	if err := rt.SetShareNetgroup("/export", "office-ips"); err != nil {
+		t.Fatalf("SetShareNetgroup failed: %v", err)
+	}
+
+	allowed, err := rt.CheckNetgroupAccess(ctx, "/export", net.ParseIP("192.168.1.100"))
+	if err != nil {
+		t.Fatalf("CheckNetgroupAccess failed: %v", err)
+	}
+	if !allowed {
+		t.Error("Expected the new netgroup to be evaluated immediately after re-pointing the share")
+	}
+}

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -69,6 +69,13 @@ type Runtime struct {
 
 	metadataService *metadata.Service
 
+	// netgroupDecisions memoizes recent netgroup allow/deny verdicts keyed by
+	// netgroup and client IP, so a protocol with no mount step does not query the
+	// netgroup store on every request. Entries expire after netgroupDecisionTTL
+	// and expired ones are swept on insert.
+	netgroupDecisionsMu sync.Mutex
+	netgroupDecisions   map[string]netgroupDecision
+
 	adaptersSvc    *adapters.Service
 	storesSvc      *stores.Service
 	sharesSvc      *shares.Service


### PR DESCRIPTION
## Problem

`Runtime.CheckNetgroupAccess` is the only export-level client allowlist gate in the tree, and it had exactly one non-test caller: the NFSv3 MOUNT handler. NFSv4 has no MOUNT protocol, so a v4 client reaching the same share via PUTROOTFH/PUTFH/LOOKUP was never checked. A share locked to a netgroup was protected against NFSv3 clients only.

## Fix — two gates, because NFSv4 has two ways to reach a share

**1. `buildV4AuthContext`** (`internal/adapter/nfs/v4/handlers/helpers.go`) — the seam every real-FS operation goes through, and where the existing `AllowAuthSys` / `RequireKerberos` export policy is already enforced for exactly the same reason. This also covers a LOOKUP that crosses from the pseudo-fs into a share, which never touches PUTFH.

**2. `handlePutFH`** (`internal/adapter/nfs/v4/handlers/putfh.go`) — LOCK, LOCKT, LOCKU and GET_DIR_DELEGATION act on `ctx.CurrentFH` **without** building an auth context, so gate 1 alone left them bypassing the allowlist. LOCKT is the sharpest case: it takes a clientid + owner straight off the wire and needs no prior OPEN. PUTFH is the only way any of those ops can name a share handle, so one guard in the block that already resolves the share name covers all four. This was caught by the code-reviewer gate, not by the original implementation.

Both fail closed, mirroring the MOUNT handler: deny on lookup error, deny on no match. A peer address that cannot be split/parsed yields a nil IP, which matches no netgroup member, so a restricted share denies while a share with no netgroup (empty allowlist = allow all) is unaffected. Denial surfaces as `NFS4ERR_ACCESS` — not `NFS4ERR_WRONGSEC`, which would tell the client to retry with a different security flavor, and no flavor retry helps a client outside the allowlist.

## Hot-path cost

A share with no netgroup costs one lock-guarded map read — unchanged for every existing deployment. A share *with* a netgroup would otherwise query the control-plane netgroup store on every operation, so verdicts are memoized for 30s keyed by netgroup name + client IP (share name is deliberately excluded: the verdict depends only on members and IP). Errors are never cached, so a failing store keeps failing closed. Expired entries are swept on insert, bounding the map by clients seen within one TTL window. The netgroup name is in the key, so re-pointing a share applies immediately; membership edits apply within the TTL — still tighter than NFSv3, which evaluates the allowlist once per mount and never again.

## SMB scoping decision — deliberately out of scope

The issue also flags SMB TreeConnect. **Netgroups are NFS export policy by design, and this PR makes that explicit rather than bolting a half-wired check onto SMB:**

- `NetgroupID` lives under `nfsOpts` in the share config (`pkg/controlplane/runtime/init.go`), not on the share itself.
- The only way to attach one is `dfsctl share nfs-config set --netgroup`.
- The semantics — an allowlist evaluated at export access, sitting alongside `AllSquash` / `RootSquash` — are the NFS export model. SMB has its own access control: share permissions and user authentication.

Wiring an NFS-only field into SMB TreeConnect would create an access control that admins cannot see or set from the SMB surface. Instead, the NFS-only scoping is now stated in the `dfsctl netgroup` and `dfsctl share nfs-config set` help text, and therefore in the regenerated `docs/guide/cli.md`, which previously described netgroups generically as "IP-based share access control" with no protocol caveat.

## Tests

`internal/adapter/nfs/v4/handlers/netgroup_test.go`:
- client outside the allowlist denied with `NFS4ERR_ACCESS`, host correctly split from the port
- client inside the allowlist allowed
- lookup error denies (fail-closed)
- unparseable peer address still runs the check, with a nil IP
- share with no netgroup allows all — real GETATTR
- share pointed at an unresolvable netgroup denies on a real GETATTR
- PUTFH refuses a restricted share's handle and leaves `CurrentFH` unset — the LOCK/LOCKT/LOCKU/GET_DIR_DELEGATION path

`pkg/controlplane/runtime/netgroups_test.go`: verdict memoization, and immediate re-evaluation when a share is re-pointed at another netgroup.

```
go build ./... && go vet ./... && gofmt -l .        clean
go test ./internal/adapter/nfs/... ./pkg/controlplane/...   all ok
go test -race ./internal/adapter/nfs/v4/...                 all ok
go test -tags integration ./pkg/controlplane/runtime/       ok
```

Relates to #1898
