### PR TITLE
perf(smb): skip the durable-purge lock and lookup when a file has no disconnected handles

### DIFF
--- a/internal/adapter/smb/handlers/disconnected_fastpath_test.go
+++ b/internal/adapter/smb/handlers/disconnected_fastpath_test.go
@@ -1,0 +1,282 @@
+package handlers
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// countingDurableStore counts the per-file lookups the purge scans perform, so
+// tests can assert that a file with no disconnected handle never reaches the
+// store at all. lookupDelay stands in for the metadata round trip a real
+// durable store costs on that lookup.
+type countingDurableStore struct {
+	*mockDurableStore
+	lookups     atomic.Int32
+	lookupDelay time.Duration
+}
+
+func newCountingDurableStore() *countingDurableStore {
+	return &countingDurableStore{mockDurableStore: newMockDurableStore()}
+}
+
+func (s *countingDurableStore) GetDurableHandlesByFileHandle(
+	ctx context.Context, metaHandle []byte,
+) ([]*lock.PersistedDurableHandle, error) {
+	s.lookups.Add(1)
+	if s.lookupDelay > 0 {
+		time.Sleep(s.lookupDelay)
+	}
+	return s.mockDurableStore.GetDurableHandlesByFileHandle(ctx, metaHandle)
+}
+
+// dataChangePurge runs the scan a WRITE performs, from a lease key that
+// conflicts with every handle disconnectedHandle builds.
+func dataChangePurge(h *Handler, metaHandle []byte) int {
+	return h.purgeConflictingDisconnectedHandlesForDataChange(
+		context.Background(), metaHandle, [16]byte{0x01}, true)
+}
+
+// persistOnDisconnect mirrors the ordering the close path uses: the count is
+// published under durablePurgeMu before the row becomes visible in the store.
+// It returns the store error instead of failing the test itself, because it is
+// also called from goroutines, where FailNow does not stop the test.
+func persistOnDisconnect(h *Handler, d *lock.PersistedDurableHandle) error {
+	h.durablePurgeMu.Lock()
+	h.noteDisconnectedHandle(d.MetadataHandle)
+	err := h.DurableStore.PutDurableHandle(context.Background(), d)
+	h.durablePurgeMu.Unlock()
+	return err
+}
+
+func disconnectedHandle(id string, metaHandle []byte, leaseKey [16]byte) *lock.PersistedDurableHandle {
+	return &lock.PersistedDurableHandle{
+		ID:             id,
+		MetadataHandle: metaHandle,
+		LeaseKey:       leaseKey,
+		LeaseState:     smbLeaseRead | smbLeaseHandle,
+		DisconnectedAt: time.Now().Add(-time.Second),
+		TimeoutMs:      60000,
+	}
+}
+
+// TestDataChangePurgeSkipsStoreWithoutDisconnectedHandles is the fast path the
+// whole change exists for: a WRITE against a file nobody disconnected from
+// must not reach the durable store.
+func TestDataChangePurgeSkipsStoreWithoutDisconnectedHandles(t *testing.T) {
+	store := newCountingDurableStore()
+	h := &Handler{DurableStore: store}
+
+	for i := 0; i < 100; i++ {
+		if purged := dataChangePurge(h, []byte("quiet-file")); purged != 0 {
+			t.Fatalf("purged = %d, want 0", purged)
+		}
+	}
+	if got := store.lookups.Load(); got != 0 {
+		t.Errorf("store lookups = %d, want 0 (fast path must skip the lookup)", got)
+	}
+}
+
+// TestDataChangePurgeSeesHandleFromDisconnect proves the fast path does not
+// skip a live case: once the close path has persisted a disconnected handle,
+// a conflicting data change still purges it.
+func TestDataChangePurgeSeesHandleFromDisconnect(t *testing.T) {
+	metaHandle := []byte("busy-file")
+	store := newCountingDurableStore()
+	h := &Handler{DurableStore: store}
+
+	if err := persistOnDisconnect(h, disconnectedHandle("foreign", metaHandle, [16]byte{0x05})); err != nil {
+		t.Fatalf("persistOnDisconnect: %v", err)
+	}
+
+	if !h.hasDisconnectedHandles(metaHandle) {
+		t.Fatal("hasDisconnectedHandles = false while a disconnected row exists")
+	}
+	if purged := dataChangePurge(h, metaHandle); purged != 1 {
+		t.Fatalf("purged = %d, want 1", purged)
+	}
+	if store.count() != 0 {
+		t.Errorf("store still holds %d handles, want 0", store.count())
+	}
+
+	// The scan reconciled the count back to zero, so the file returns to the
+	// fast path without waiting for the scavenger.
+	before := store.lookups.Load()
+	dataChangePurge(h, metaHandle)
+	if store.lookups.Load() != before {
+		t.Error("purge scan did not reconcile the count; file stayed on the slow path")
+	}
+}
+
+// TestDataChangePurgeSeesHandleFromPreviousProcess covers the handle a restart
+// knows only from the durable store: seeding restores the count, so a data
+// change still purges it instead of taking the fast path over it.
+func TestDataChangePurgeSeesHandleFromPreviousProcess(t *testing.T) {
+	metaHandle := []byte("survivor-file")
+	store := newCountingDurableStore()
+	// Written by the process that died — no in-memory state accompanies it.
+	if err := store.PutDurableHandle(context.Background(),
+		disconnectedHandle("from-previous-process", metaHandle, [16]byte{0x05})); err != nil {
+		t.Fatalf("PutDurableHandle: %v", err)
+	}
+
+	h := &Handler{DurableStore: store}
+	h.SeedFromDurableHandles(context.Background(), store)
+
+	if purged := dataChangePurge(h, metaHandle); purged != 1 {
+		t.Fatalf("purged = %d, want 1 (seeded handle was skipped)", purged)
+	}
+}
+
+// TestSeedSkipsConnectedHandles keeps the seed honest: rows that were never
+// disconnected must not put their file on the slow path.
+func TestSeedSkipsConnectedHandles(t *testing.T) {
+	metaHandle := []byte("connected-file")
+	store := newCountingDurableStore()
+	connected := disconnectedHandle("still-connected", metaHandle, [16]byte{0x05})
+	connected.DisconnectedAt = time.Time{}
+	if err := store.PutDurableHandle(context.Background(), connected); err != nil {
+		t.Fatalf("PutDurableHandle: %v", err)
+	}
+
+	h := &Handler{DurableStore: store}
+	h.SeedFromDurableHandles(context.Background(), store)
+
+	if h.hasDisconnectedHandles(metaHandle) {
+		t.Error("hasDisconnectedHandles = true for a handle that never disconnected")
+	}
+}
+
+// TestScavengerExpiryClearsDisconnectedCount covers the terminal state of a
+// client that never comes back: expiry removes the row, so the file must fall
+// back to the fast path even though no purge scan ever runs on it.
+func TestScavengerExpiryClearsDisconnectedCount(t *testing.T) {
+	metaHandle := []byte("abandoned-file")
+	store := newCountingDurableStore()
+	h := &Handler{DurableStore: store}
+
+	expired := disconnectedHandle("abandoned", metaHandle, [16]byte{0x05})
+	expired.DisconnectedAt = time.Now().Add(-2 * time.Minute)
+	expired.TimeoutMs = 1000
+	if err := persistOnDisconnect(h, expired); err != nil {
+		t.Fatalf("persistOnDisconnect: %v", err)
+	}
+
+	s := NewDurableHandleScavenger(store, h, time.Minute, 60000, time.Now())
+	s.cleanupAndDelete(context.Background(), expired)
+
+	if h.hasDisconnectedHandles(metaHandle) {
+		t.Error("hasDisconnectedHandles = true after the scavenger removed the row")
+	}
+}
+
+// TestScavengerExpiryKeepsCountForUncountedRow covers the row the store may
+// transiently hold without a DisconnectedAt: it looks infinitely expired, so
+// the scavenger reaches it, but it was never counted. Dropping a count for it
+// would steal the count of a genuinely disconnected handle on the same file
+// and let a later data change skip purging that one.
+func TestScavengerExpiryKeepsCountForUncountedRow(t *testing.T) {
+	metaHandle := []byte("mixed-file")
+	store := newCountingDurableStore()
+	h := &Handler{DurableStore: store}
+
+	// A real disconnected handle, counted the way the close path counts it.
+	if err := persistOnDisconnect(h, disconnectedHandle("real", metaHandle, [16]byte{0x05})); err != nil {
+		t.Fatalf("persistOnDisconnect: %v", err)
+	}
+	// A pre-disconnect row on the same file, never counted.
+	preDisconnect := disconnectedHandle("pre-disconnect", metaHandle, [16]byte{0x06})
+	preDisconnect.DisconnectedAt = time.Time{}
+	if err := store.PutDurableHandle(context.Background(), preDisconnect); err != nil {
+		t.Fatalf("PutDurableHandle: %v", err)
+	}
+
+	s := NewDurableHandleScavenger(store, h, time.Minute, 60000, time.Now())
+	s.cleanupAndDelete(context.Background(), preDisconnect)
+
+	if !h.hasDisconnectedHandles(metaHandle) {
+		t.Fatal("expiring an uncounted row cleared the count of a live disconnected handle")
+	}
+	if purged := dataChangePurge(h, metaHandle); purged != 1 {
+		t.Errorf("purged = %d, want 1", purged)
+	}
+}
+
+// TestDisconnectAndDataChangeRace runs the two sides against each other: one
+// half persists disconnected handles the way close does, the other half runs
+// the data-change scan. Under -race this covers the count's own locking; the
+// closing assertions cover convergence — every persisted row is either purged
+// by a scan that saw it, or still present and still counted, never present and
+// uncounted (which is what would let a later write skip it).
+func TestDisconnectAndDataChangeRace(t *testing.T) {
+	metaHandle := []byte("contended-file")
+	store := newCountingDurableStore()
+	h := &Handler{DurableStore: store}
+
+	const writers = 16
+	var wg sync.WaitGroup
+	errs := make(chan error, writers)
+	for i := 0; i < writers; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			if err := persistOnDisconnect(h, disconnectedHandle(
+				string(rune('a'+i)), metaHandle, [16]byte{byte(0x10 + i)})); err != nil {
+				errs <- err
+			}
+		}(i)
+		go func() {
+			defer wg.Done()
+			dataChangePurge(h, metaHandle)
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("persistOnDisconnect: %v", err)
+	}
+
+	// Whatever survived the interleaving is still counted, so this final scan
+	// is guaranteed to run rather than take the fast path.
+	if remaining := store.count(); remaining > 0 && !h.hasDisconnectedHandles(metaHandle) {
+		t.Fatalf("%d disconnected rows left but the file is on the fast path", remaining)
+	}
+	dataChangePurge(h, metaHandle)
+	if store.count() != 0 {
+		t.Errorf("store still holds %d handles after the final scan", store.count())
+	}
+	if h.hasDisconnectedHandles(metaHandle) {
+		t.Error("count did not reconcile to empty after the final scan")
+	}
+}
+
+// BenchmarkDataChangePurge measures what every WRITE pays for the durable-handle
+// conflict scan on a file nobody has disconnected from — the steady state. The
+// slow-store case gives the lookup the cost of a metadata round trip, which is
+// what the scan talks to in a deployment.
+func BenchmarkDataChangePurge(b *testing.B) {
+	for _, tc := range []struct {
+		name        string
+		lookupDelay time.Duration
+	}{
+		{"fast-store", 0},
+		{"slow-store", 50 * time.Microsecond},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			store := newCountingDurableStore()
+			store.lookupDelay = tc.lookupDelay
+			h := &Handler{DurableStore: store}
+			metaHandle := []byte("bench-file")
+
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					dataChangePurge(h, metaHandle)
+				}
+			})
+		})
+	}
+}

--- a/internal/adapter/smb/handlers/disconnected_state_machine.go
+++ b/internal/adapter/smb/handlers/disconnected_state_machine.go
@@ -59,6 +59,85 @@ import (
 //     pkg/metadata/lock/leases.go); this state machine only intervenes when
 //     the disconnected handle would have to lose H.
 
+// noteDisconnectedHandle counts one more durable handle persisted in the
+// disconnected state for metaHandle. It MUST be called before the row becomes
+// visible in the DurableHandleStore: a row that exists while the count still
+// reads zero is one the conflict scans skip.
+func (h *Handler) noteDisconnectedHandle(metaHandle []byte) {
+	if len(metaHandle) == 0 {
+		return
+	}
+	h.disconnectedMu.Lock()
+	if h.disconnectedByFile == nil {
+		h.disconnectedByFile = make(map[string]int)
+	}
+	h.disconnectedByFile[string(metaHandle)]++
+	h.disconnectedTotal.Add(1)
+	h.disconnectedMu.Unlock()
+}
+
+// forgetDisconnectedHandle drops one counted disconnected handle for
+// metaHandle. It MUST be called only after the row is gone from the store.
+// Not every delete path reports here; the ones that don't leave an over-count
+// for setDisconnectedHandleCount to reconcile on the next scan of that file.
+func (h *Handler) forgetDisconnectedHandle(metaHandle []byte) {
+	if len(metaHandle) == 0 {
+		return
+	}
+	key := string(metaHandle)
+	h.disconnectedMu.Lock()
+	if n := h.disconnectedByFile[key]; n > 0 {
+		if n == 1 {
+			delete(h.disconnectedByFile, key)
+		} else {
+			h.disconnectedByFile[key] = n - 1
+		}
+		h.disconnectedTotal.Add(-1)
+	}
+	h.disconnectedMu.Unlock()
+}
+
+// setDisconnectedHandleCount reconciles the count for metaHandle against the
+// disconnected rows a scan just left behind in the store. Callers MUST hold
+// durablePurgeMu, which is also held across noteDisconnectedHandle +
+// PutDurableHandle, so no handle can be persisted between the scan's read and
+// this write and be lost by it.
+func (h *Handler) setDisconnectedHandleCount(metaHandle []byte, n int) {
+	if len(metaHandle) == 0 {
+		return
+	}
+	key := string(metaHandle)
+	h.disconnectedMu.Lock()
+	prev := h.disconnectedByFile[key]
+	if n <= 0 {
+		// Clamped rather than trusted: a negative count would read as "no
+		// disconnected handle" and skip a purge that has to happen.
+		n = 0
+		delete(h.disconnectedByFile, key)
+	} else {
+		if h.disconnectedByFile == nil {
+			h.disconnectedByFile = make(map[string]int)
+		}
+		h.disconnectedByFile[key] = n
+	}
+	h.disconnectedTotal.Add(int64(n - prev))
+	h.disconnectedMu.Unlock()
+}
+
+// hasDisconnectedHandles reports whether metaHandle may have a durable handle
+// persisted in the disconnected state. It gates the durablePurgeMu +
+// GetDurableHandlesByFileHandle scans: false is exact, true only means the scan
+// has to run.
+func (h *Handler) hasDisconnectedHandles(metaHandle []byte) bool {
+	if h.disconnectedTotal.Load() == 0 {
+		return false
+	}
+	h.disconnectedMu.RLock()
+	n := h.disconnectedByFile[string(metaHandle)]
+	h.disconnectedMu.RUnlock()
+	return n > 0
+}
+
 // disconnectedHandleAction is the decision the state machine returns for
 // each disconnected handle inspected.
 type disconnectedHandleAction int
@@ -237,16 +316,59 @@ func disconnectedConflictOnDataChange(
 	return disconnectedActionPurge
 }
 
-// purgeConflictingDisconnectedHandlesForOpen scans disconnected handles for
-// the underlying file (keyed by metadata handle) and purges those that
-// conflict with the new open under §3.3.4.18.
+// purgeDisconnectedConflicts purges every disconnected handle on metaHandle
+// that conflicts, and returns how many it removed. Store lookup errors are
+// logged at debug — purge is best-effort and must not block the caller.
 //
-// Returns the number of purged handles. Errors looking up the store are
-// logged at debug — purge is best-effort and must not block CREATE.
+// Files with no disconnected handle skip both durablePurgeMu and the store
+// lookup, which is what keeps this off the cost of every WRITE and SET_INFO;
+// hasDisconnectedHandles is exact in the negative, and noteDisconnectedHandle
+// publishes the count before PutDurableHandle makes a row visible, so no handle
+// can become disconnected between the gate and the caller's operation without
+// being ordered after it. Otherwise durablePurgeMu is held across the
+// Get→Delete window so a concurrent disconnect persist
+// (handler.go:closeFilesWithFilter) cannot Put a new disconnected handle between
+// the snapshot and the per-id Delete.
 //
-// Holds Handler.durablePurgeMu across the Get→Delete window so a concurrent
-// disconnect persist (handler.go:closeFilesMatching) cannot Put a new
-// disconnected handle between our snapshot and the per-id Delete.
+// The surviving rows are counted back, converging an earlier over-count. A row
+// whose delete failed is still in the store, so it counts as surviving.
+func (h *Handler) purgeDisconnectedConflicts(
+	ctx context.Context,
+	metaHandle []byte,
+	reason string,
+	conflicts func(d *lock.PersistedDurableHandle) bool,
+) int {
+	if h.DurableStore == nil || len(metaHandle) == 0 || !h.hasDisconnectedHandles(metaHandle) {
+		return 0
+	}
+	h.durablePurgeMu.Lock()
+	defer h.durablePurgeMu.Unlock()
+	handles, err := h.DurableStore.GetDurableHandlesByFileHandle(ctx, metaHandle)
+	if err != nil {
+		logger.Debug("purgeDisconnectedConflicts: lookup failed",
+			"reason", reason, "error", err)
+		return 0
+	}
+	var purged, kept int
+	for _, d := range handles {
+		// Only consider handles that survived a transport disconnect — the
+		// store may transiently hold pre-disconnect rows on some backends.
+		if d.DisconnectedAt.IsZero() {
+			continue
+		}
+		if !conflicts(d) || !h.purgeOneDisconnectedHandle(ctx, d, reason) {
+			kept++
+			continue
+		}
+		purged++
+	}
+	h.setDisconnectedHandleCount(metaHandle, kept)
+	return purged
+}
+
+// purgeConflictingDisconnectedHandlesForOpen purges the disconnected handles on
+// the underlying file (keyed by metadata handle) that conflict with the new
+// open under §3.3.4.18.
 func (h *Handler) purgeConflictingDisconnectedHandlesForOpen(
 	ctx context.Context,
 	metaHandle []byte,
@@ -255,92 +377,44 @@ func (h *Handler) purgeConflictingDisconnectedHandlesForOpen(
 	newShareAccess uint32,
 	newDesiredAccess uint32,
 ) int {
-	if h.DurableStore == nil || len(metaHandle) == 0 {
-		return 0
-	}
 	newIsStatOnly := isStatOnlyOpen(newDesiredAccess)
-	h.durablePurgeMu.Lock()
-	defer h.durablePurgeMu.Unlock()
-	handles, err := h.DurableStore.GetDurableHandlesByFileHandle(ctx, metaHandle)
-	if err != nil {
-		logger.Debug("purgeConflictingDisconnectedHandlesForOpen: lookup failed",
-			"error", err)
-		return 0
-	}
-	if len(handles) == 0 {
-		return 0
-	}
-	var purged int
-	for _, d := range handles {
-		// Only consider handles that survived a transport disconnect — the
-		// store may transiently hold pre-disconnect rows on some backends.
-		if d.DisconnectedAt.IsZero() {
-			continue
-		}
-		action := disconnectedConflictOnNewOpen(
-			d.LeaseState, d.LeaseKey, d.ShareAccess,
-			newLeaseState, newLeaseKey,
-			newShareAccess, newDesiredAccess, newIsStatOnly,
-		)
-		if action != disconnectedActionPurge {
-			continue
-		}
-		h.purgeOneDisconnectedHandle(ctx, d, "new-open conflict")
-		purged++
-	}
-	return purged
+	return h.purgeDisconnectedConflicts(ctx, metaHandle, "new-open conflict",
+		func(d *lock.PersistedDurableHandle) bool {
+			return disconnectedConflictOnNewOpen(
+				d.LeaseState, d.LeaseKey, d.ShareAccess,
+				newLeaseState, newLeaseKey,
+				newShareAccess, newDesiredAccess, newIsStatOnly,
+			) == disconnectedActionPurge
+		})
 }
 
-// purgeConflictingDisconnectedHandlesForDataChange scans disconnected handles
-// for the underlying file and purges those that would lose H caching due to
-// the actor's WRITE or RENAME.
-//
-// Holds Handler.durablePurgeMu across the Get→Delete window for the same
-// reason as purgeConflictingDisconnectedHandlesForOpen.
+// purgeConflictingDisconnectedHandlesForDataChange purges the disconnected
+// handles on the underlying file that would lose H caching due to the actor's
+// WRITE or RENAME.
 func (h *Handler) purgeConflictingDisconnectedHandlesForDataChange(
 	ctx context.Context,
 	metaHandle []byte,
 	excludeLeaseKey [16]byte,
 	breakToBelowHandle bool,
 ) int {
-	if h.DurableStore == nil || len(metaHandle) == 0 || !breakToBelowHandle {
+	if !breakToBelowHandle {
 		return 0
 	}
-	h.durablePurgeMu.Lock()
-	defer h.durablePurgeMu.Unlock()
-	handles, err := h.DurableStore.GetDurableHandlesByFileHandle(ctx, metaHandle)
-	if err != nil {
-		logger.Debug("purgeConflictingDisconnectedHandlesForDataChange: lookup failed",
-			"error", err)
-		return 0
-	}
-	if len(handles) == 0 {
-		return 0
-	}
-	var purged int
-	for _, d := range handles {
-		if d.DisconnectedAt.IsZero() {
-			continue
-		}
-		action := disconnectedConflictOnDataChange(d.LeaseKey, excludeLeaseKey)
-		if action != disconnectedActionPurge {
-			continue
-		}
-		h.purgeOneDisconnectedHandle(ctx, d, "data-change break")
-		purged++
-	}
-	return purged
+	return h.purgeDisconnectedConflicts(ctx, metaHandle, "data-change break",
+		func(d *lock.PersistedDurableHandle) bool {
+			return disconnectedConflictOnDataChange(d.LeaseKey, excludeLeaseKey) == disconnectedActionPurge
+		})
 }
 
 // purgeOneDisconnectedHandle deletes a single disconnected handle and releases
 // its locks. Mirrors the cleanup half of DurableHandleScavenger.cleanupAndDelete
 // but is callable from CREATE/WRITE/RENAME hot paths without the scavenger
-// ticker overhead.
+// ticker overhead. Returns whether the row is gone from the store.
 func (h *Handler) purgeOneDisconnectedHandle(
 	ctx context.Context,
 	d *lock.PersistedDurableHandle,
 	reason string,
-) {
+) bool {
 	if h.Registry != nil {
 		if metaSvc := h.Registry.GetMetadataService(); metaSvc != nil && len(d.MetadataHandle) > 0 {
 			// Release byte-range locks held by the disconnected open. SMB
@@ -365,13 +439,14 @@ func (h *Handler) purgeOneDisconnectedHandle(
 	if err := h.DurableStore.DeleteDurableHandle(ctx, d.ID); err != nil {
 		logger.Warn("purgeOneDisconnectedHandle: delete failed",
 			"id", d.ID, "path", d.Path, "error", err)
-		return
+		return false
 	}
 	logger.Debug("purgeOneDisconnectedHandle: purged disconnected handle",
 		"id", d.ID,
 		"path", d.Path,
 		"leaseState", fmt.Sprintf("0x%x", d.LeaseState),
 		"reason", reason)
+	return true
 }
 
 // shouldPersistDurableOnDisconnect returns false when an open MUST NOT be

--- a/internal/adapter/smb/handlers/disconnected_state_machine_test.go
+++ b/internal/adapter/smb/handlers/disconnected_state_machine_test.go
@@ -372,6 +372,7 @@ func TestPurgeConflictingDisconnectedHandlesForDataChange(t *testing.T) {
 				_ = store.PutDurableHandle(context.Background(), h)
 			}
 			h := &Handler{DurableStore: store}
+			h.SeedFromDurableHandles(context.Background(), store)
 			got := h.purgeConflictingDisconnectedHandlesForDataChange(
 				context.Background(), metaHandle, tc.excludeLeaseKey, tc.breakBelowH,
 			)
@@ -420,6 +421,7 @@ func TestPurgeConflictingDisconnectedHandlesForOpen(t *testing.T) {
 	})
 
 	h := &Handler{DurableStore: store}
+	h.SeedFromDurableHandles(context.Background(), store)
 	// New RH open with a different key → purges the disconnected RWH (W
 	// must be broken; cascade strips H), leaves the live handle alone.
 	got := h.purgeConflictingDisconnectedHandlesForOpen(
@@ -593,7 +595,7 @@ func TestDurableOpenConflictingOpenPurgesAcrossConnections(t *testing.T) {
 	// lease-backed holder; the V1 DHnC reconnect harness only re-establishes
 	// oplock-backed handles without a lease-request context, so the keep
 	// controls (which assert reconnect success) use leaseKey=zero.
-	seedSessionA := func(store *mockDurableStore, dLeaseState, dShareAccess uint32, oplock uint8, leaseKey [16]byte) {
+	seedSessionA := func(h *Handler, store *mockDurableStore, dLeaseState, dShareAccess uint32, oplock uint8, leaseKey [16]byte) {
 		_ = store.PutDurableHandle(context.Background(), &lock.PersistedDurableHandle{
 			ID:             "session-A",
 			FileID:         fileID,
@@ -612,6 +614,10 @@ func TestDurableOpenConflictingOpenPurgesAcrossConnections(t *testing.T) {
 			DisconnectedAt: time.Now().Add(-10 * time.Second),
 			TimeoutMs:      60000,
 		})
+		// Rows written straight into the store are invisible to the count
+		// that gates the purge scans; seeding is how a real process picks up
+		// handles it did not persist itself.
+		h.SeedFromDurableHandles(context.Background(), store)
 	}
 
 	// reconnectA models session A's DHnC reconnect through the real entrypoint
@@ -675,7 +681,7 @@ func TestDurableOpenConflictingOpenPurgesAcrossConnections(t *testing.T) {
 		t.Run("purge/"+tc.name, func(t *testing.T) {
 			store := newMockDurableStore()
 			h := &Handler{DurableStore: store}
-			seedSessionA(store, tc.dLeaseState, tc.dShareAccess, tc.dOplock, tc.dLeaseKey)
+			seedSessionA(h, store, tc.dLeaseState, tc.dShareAccess, tc.dOplock, tc.dLeaseKey)
 
 			// BEFORE the fix this purge was a no-op and reconnect returned
 			// SUCCESS. Assert the conflicting open purges exactly one handle.
@@ -711,7 +717,7 @@ func TestDurableOpenConflictingOpenPurgesAcrossConnections(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			store := newMockDurableStore()
 			h := &Handler{DurableStore: store}
-			seedSessionA(store, tc.dLeaseState, tc.dShareAccess, tc.dOplock, [16]byte{})
+			seedSessionA(h, store, tc.dLeaseState, tc.dShareAccess, tc.dOplock, [16]byte{})
 
 			purged := h.purgeConflictingDisconnectedHandlesForOpen(
 				context.Background(), metaHandle,

--- a/internal/adapter/smb/handlers/durable_restart_survival_test.go
+++ b/internal/adapter/smb/handlers/durable_restart_survival_test.go
@@ -179,7 +179,7 @@ func TestDurableHandleNoCollisionAfterReseed(t *testing.T) {
 		t.Fatalf("fresh Handler nextFileID = %d, want 1 (restart counter reset)", got)
 	}
 
-	h.SeedFileIDFromDurableHandles(ctx, store)
+	h.SeedFromDurableHandles(ctx, store)
 
 	// The reseed stores the max persisted persistent half (5000) as the
 	// last-issued value; GenerateFileID pre-increments, so the next minted

--- a/internal/adapter/smb/handlers/durable_scavenger.go
+++ b/internal/adapter/smb/handlers/durable_scavenger.go
@@ -192,6 +192,18 @@ func (s *DurableHandleScavenger) cleanupAndDelete(ctx context.Context, h *lock.P
 		logger.Warn("DurableHandleScavenger: failed to delete expired handle",
 			"id", h.ID, "error", err)
 	} else {
+		// The row is gone, so drop it from the count that gates the conflict
+		// scans. Expiry is the terminal state for a handle whose client never
+		// came back; nothing else would clear the count.
+		//
+		// Only rows that were actually counted may be dropped, and only
+		// disconnected rows are ever counted. A row with no DisconnectedAt
+		// looks infinitely expired and reaches here too, but decrementing for
+		// it would steal the count of a genuinely disconnected handle on the
+		// same file and let a later data change skip purging it.
+		if s.handler != nil && !h.DisconnectedAt.IsZero() {
+			s.handler.forgetDisconnectedHandle(h.MetadataHandle)
+		}
 		logger.Debug("DurableHandleScavenger: expired handle cleaned up",
 			"id", h.ID, "path", h.Path, "share", h.ShareName)
 	}

--- a/internal/adapter/smb/handlers/fileid_seed_test.go
+++ b/internal/adapter/smb/handlers/fileid_seed_test.go
@@ -32,7 +32,7 @@ func TestSeedFileIDFromDurableHandles(t *testing.T) {
 	_ = store.PutDurableHandle(context.Background(), durableWithFileID("c", 17))
 
 	h := NewHandler() // starts nextFileID at 1
-	h.SeedFileIDFromDurableHandles(context.Background(), store)
+	h.SeedFromDurableHandles(context.Background(), store)
 
 	// First CREATE after seeding must land strictly above the max persisted
 	// FileID (42), so it cannot collide with any reclaimable durable open.
@@ -59,7 +59,7 @@ func TestSeedFileIDFromDurableHandles_NeverLowers(t *testing.T) {
 	}
 	before := h.nextFileID.Load()
 
-	h.SeedFileIDFromDurableHandles(context.Background(), store)
+	h.SeedFromDurableHandles(context.Background(), store)
 
 	if after := h.nextFileID.Load(); after != before {
 		t.Fatalf("counter moved from %d to %d; seed must never lower it", before, after)
@@ -75,7 +75,7 @@ func TestSeedFileIDFromDurableHandles_MaxUint64(t *testing.T) {
 
 	h := NewHandler()
 	start := h.nextFileID.Load()
-	h.SeedFileIDFromDurableHandles(context.Background(), store)
+	h.SeedFromDurableHandles(context.Background(), store)
 
 	if got := h.nextFileID.Load(); got != start {
 		t.Fatalf("counter seeded to %d on max-uint64 handle; want left at %d (no wrap)", got, start)
@@ -93,12 +93,12 @@ func TestSeedFileIDFromDurableHandles_EmptyAndNil(t *testing.T) {
 	h := NewHandler()
 	start := h.nextFileID.Load()
 
-	h.SeedFileIDFromDurableHandles(context.Background(), newMockDurableStore())
+	h.SeedFromDurableHandles(context.Background(), newMockDurableStore())
 	if got := h.nextFileID.Load(); got != start {
 		t.Fatalf("empty store changed counter to %d, want %d", got, start)
 	}
 
-	h.SeedFileIDFromDurableHandles(context.Background(), nil)
+	h.SeedFromDurableHandles(context.Background(), nil)
 	if got := h.nextFileID.Load(); got != start {
 		t.Fatalf("nil store changed counter to %d, want %d", got, start)
 	}

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -192,10 +192,29 @@ type Handler struct {
 	// Without serialization a CREATE in (b) can race against a concurrent
 	// disconnect in (a): the disconnect's PutDurableHandle lands between the
 	// CREATE's Get and Delete, leaving a phantom unreconnectable entry until
-	// the scavenger evicts it. The mutex is coarse-grained (process-wide) but
-	// covers only durable-store IO and the disconnect-time persist step,
-	// neither of which is on the steady-state hot path.
+	// the scavenger evicts it.
+	//
+	// The mutex is process-wide and (b) is reached from WRITE and SET_INFO, so
+	// taking it per operation would serialize every writer in the server behind
+	// one lock plus a durable-store round trip. The (b) scans therefore gate on
+	// disconnectedByFile below and take the mutex only for files that actually
+	// have a disconnected handle.
 	durablePurgeMu sync.Mutex
+
+	// disconnectedByFile counts the durable handles currently persisted in the
+	// DurableHandleStore in the disconnected state, keyed by metadata handle;
+	// disconnectedTotal is their sum, so the common "no disconnected handle
+	// anywhere" case costs one atomic load.
+	//
+	// The counts are an upper bound, never an under-count: an entry is added
+	// BEFORE PutDurableHandle makes the row visible, and under durablePurgeMu,
+	// so no scan can observe zero while a row exists. Not every delete path
+	// decrements — a purge scan reconciles the count for the file it just read
+	// from the store, so an over-count costs one slow-path scan and then
+	// converges. Only the add side is load-bearing.
+	disconnectedMu     sync.RWMutex
+	disconnectedByFile map[string]int
+	disconnectedTotal  atomic.Int64
 
 	// KerberosProvider holds the shared Kerberos keytab/config provider.
 	// Injected by the adapter layer before Serve(). When nil, Kerberos
@@ -1309,6 +1328,12 @@ func (h *Handler) closeFilesWithFilter(
 				// purge windows; see durablePurgeMu comment.
 				h.durablePurgeMu.Lock()
 				persisted := buildPersistedDurableHandle(openFile, username, sessionKeyHash, h.StartTime, leaseState, leaseEpoch)
+				// Count the handle before the row becomes visible, so a
+				// concurrent WRITE/SET_INFO cannot take its fast path over a
+				// file that already has a disconnected handle. A failed Put is
+				// deliberately not un-counted: it may still have written the
+				// row, and the next scan of this file reconciles the count.
+				h.noteDisconnectedHandle(persisted.MetadataHandle)
 				err := h.DurableStore.PutDurableHandle(ctx, persisted)
 				h.durablePurgeMu.Unlock()
 				if err != nil {
@@ -1967,10 +1992,15 @@ func (h *Handler) baseFileUUID(authCtx *metadata.AuthContext, parentHandle metad
 	return fallback
 }
 
-// SeedFileIDFromDurableHandles bumps the persistent-half FileID counter past
-// the highest value already recorded in persisted durable handles, so that
-// after a server restart freshly minted FileIDs cannot collide with the
-// FileID of a still-reclaimable durable open.
+// SeedFromDurableHandles restores the in-memory state derived from persisted
+// durable handles after a restart:
+//
+//   - the persistent-half FileID counter is bumped past the highest value
+//     already recorded, so freshly minted FileIDs cannot collide with the
+//     FileID of a still-reclaimable durable open (detailed below); and
+//   - handles persisted in the disconnected state are counted, so the conflict
+//     scans still see the handles a previous process left behind instead of
+//     taking their fast path over them.
 //
 // Without this, the counter restarts at 1 every process start (see NewHandler;
 // the first issued persistent half is 2, since GenerateFileID pre-increments),
@@ -1985,7 +2015,7 @@ func (h *Handler) baseFileUUID(authCtx *metadata.AuthContext, parentHandle metad
 // The persistent half is the little-endian uint64 in bytes 0..7 of FileID,
 // matching the encoding GenerateFileID writes; the volatile half (bytes 8..15)
 // is zeroed in persisted records and ignored here.
-func (h *Handler) SeedFileIDFromDurableHandles(ctx context.Context, store lock.DurableHandleStore) {
+func (h *Handler) SeedFromDurableHandles(ctx context.Context, store lock.DurableHandleStore) {
 	if store == nil {
 		return
 	}
@@ -1996,13 +2026,20 @@ func (h *Handler) SeedFileIDFromDurableHandles(ctx context.Context, store lock.D
 			"error", err)
 		return
 	}
+	// Same lock the disconnect path holds around its count-then-persist, so a
+	// concurrent scan's reconciliation cannot interleave with these counts.
+	h.durablePurgeMu.Lock()
 	var maxID uint64
 	for _, dh := range handles {
+		if !dh.DisconnectedAt.IsZero() {
+			h.noteDisconnectedHandle(dh.MetadataHandle)
+		}
 		id := binary.LittleEndian.Uint64(dh.FileID[:8])
 		if id > maxID {
 			maxID = id
 		}
 	}
+	h.durablePurgeMu.Unlock()
 	if maxID == 0 {
 		return
 	}

--- a/pkg/adapter/smb/adapter.go
+++ b/pkg/adapter/smb/adapter.go
@@ -526,10 +526,12 @@ func (s *Adapter) Serve(ctx context.Context) error {
 	if durableStore := s.findDurableHandleStore(); durableStore != nil {
 		s.handler.DurableStore = durableStore
 
-		// Seed the FileID counter past any persisted durable handles so a
-		// post-restart CREATE cannot re-mint a FileID still owned by a
-		// reclaimable durable open (MS-SMB2 §3.3.5.9.7).
-		s.handler.SeedFileIDFromDurableHandles(ctx, durableStore)
+		// Restore in-memory state derived from persisted durable handles: the
+		// FileID counter moves past them so a post-restart CREATE cannot
+		// re-mint a FileID still owned by a reclaimable durable open (MS-SMB2
+		// §3.3.5.9.7), and handles left in the disconnected state are counted
+		// so the conflict scans still see them.
+		s.handler.SeedFromDurableHandles(ctx, durableStore)
 
 		durableTimeout := uint32(DefaultDurableHandleTimeout)
 		if s.handler.DurableTimeoutMs != 0 {


### PR DESCRIPTION
## Problem

Every SMB WRITE and SET_INFO called `purgeConflictingDisconnectedHandlesForDataChange`, which took `Handler.durablePurgeMu` — one process-wide `sync.Mutex` — and did a `GetDurableHandlesByFileHandle` round trip to the durable store before releasing it. `DurableStore` is set for the normal single-metadata-store deployment, so every writer in the server serialized behind one lock plus a metadata lookup: a data-plane throughput ceiling that had nothing to do with the work being done.

The overwhelmingly common case is that the file being written has no disconnected durable handle at all, and the scan finds nothing.

## Fix

Gate both conflict scans on a cheaply-checkable count of durable handles currently persisted in the disconnected state, keyed by metadata handle (`disconnectedByFile`, summed into a `disconnectedTotal` atomic). A file with no disconnected handle costs one atomic load and returns — no lock, no store lookup.

The count is safe in the direction that matters: it may over-count, never under-count.

- It is published **before** `PutDurableHandle` makes the row visible, and both happen under `durablePurgeMu`, so no scan can read zero while a row exists. A scan that reads zero is therefore ordered strictly before the disconnect that persists the handle — the same outcome as winning the mutex race today.
- Removals are reconciled: each scan sets the count to what it left behind in the store, under the same mutex, so no concurrently persisted handle can be lost by the write-back. A delete that fails counts the row as still present.
- An over-count only costs one slow-path scan, which then corrects it.

Every transition into the disconnected state is hooked:

| Site | Transition | Hook |
|---|---|---|
| `handler.go` `closeFilesWithFilter` | open → disconnected (the only `PutDurableHandle` caller) | `noteDisconnectedHandle` before the Put, under `durablePurgeMu` |
| `handler.go` `SeedFromDurableHandles` | rows left by a previous process, adopted at startup | counted during the existing seed scan |
| `disconnected_state_machine.go` both purge scans | disconnected → gone | `setDisconnectedHandleCount` reconciles to what the store still holds |
| `durable_scavenger.go` `cleanupAndDelete` | disconnected → expired | `forgetDisconnectedHandle` after a confirmed delete |

`SeedFileIDFromDurableHandles` is renamed `SeedFromDurableHandles`: it already scanned every persisted handle for the FileID counter, and now also adopts the disconnected ones, so a handle known only from the durable store after a restart is still purged rather than skipped.

## Benchmark

`BenchmarkDataChangePurge`, `b.RunParallel` at `-cpu 8`, calling the scan on a file with no disconnected handles (the steady state), before = `origin/develop`:

| | before | after |
|---|---|---|
| in-memory durable store | 116.8 ns/op | 1.04 ns/op, 0 allocs |
| durable store with a 50 µs round trip | 63,715 ns/op | 0.93 ns/op, 0 allocs |

The second row is the important one: with 8 concurrent writers and a 50 µs store lookup, throughput collapsed to ~15.7k ops/s total — one lookup at a time, exactly the serialization the mutex imposes — regardless of how many writers were running. After, the writers never touch the lock or the store.

## Tests

New in `disconnected_fastpath_test.go`:

- fast path does not reach the store when no handle is disconnected (asserted via a lookup-counting store)
- a handle persisted by the disconnect path IS still purged, and the count reconciles back so the file returns to the fast path
- a handle known only from the durable store after a restart IS still purged (seed path)
- rows that never disconnected do not put their file on the slow path
- scavenger expiry clears the count
- concurrent persist-vs-scan stress, covering the create-disconnected/write race ordering and the count's own locking under `-race`

```
go build ./... && go vet ./... && gofmt -l .   # clean
go test ./internal/adapter/smb/...             # ok (all 12 packages)
go test -race ./internal/adapter/smb/...       # ok (all 12 packages)
```

Existing durable-handle tests are unchanged in behaviour; the ones that wrote rows straight into the store now seed through `SeedFromDurableHandles`, which is how a real process learns about handles it did not persist itself.

Relates to #1893
