### PR TITLE
test(smbtorture): report timeouts and unfinished tests instead of dropping them

### DIFF
--- a/.github/workflows/smb-conformance.yml
+++ b/.github/workflows/smb-conformance.yml
@@ -132,6 +132,21 @@ jobs:
           path: test/smb-conformance/results/
           retention-days: 30
 
+  smbtorture-grading:
+    name: smbtorture grading logic
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Guards how the smbtorture job decides pass/fail (parse-results.sh). Runs
+    # on synthetic output in ~1s, no Docker and no server, so a change that
+    # would let a new conformance failure grade green is caught here instead
+    # of in a 40-minute suite run.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Test grading logic
+        run: test/smb-conformance/smbtorture/parse-results_test.sh
+
   smbtorture:
     name: smbtorture / ${{ matrix.profile }}
     runs-on: ubuntu-latest

--- a/test/smb-conformance/smbtorture/Makefile
+++ b/test/smb-conformance/smbtorture/Makefile
@@ -6,7 +6,7 @@
 
 PROFILE ?= memory
 
-.PHONY: help test test-quick test-full emit-baseline clean
+.PHONY: help test test-quick test-full test-parser emit-baseline clean
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -22,6 +22,9 @@ test-full: ## Run smbtorture with all profiles
 		echo "=== Profile: $$profile ==="; \
 		./run.sh --profile $$profile || exit 1; \
 	done
+
+test-parser: ## Unit-test parse-results.sh grading (no Docker, ~1s)
+	./parse-results_test.sh
 
 emit-baseline: ## Regenerate baseline-results.md from the latest results dir
 	@RESULTS_DIR=$$(ls -td ../results/smbtorture-*/ 2>/dev/null | head -1); \

--- a/test/smb-conformance/smbtorture/parse-results.sh
+++ b/test/smb-conformance/smbtorture/parse-results.sh
@@ -197,11 +197,34 @@ KNOWN_HITS=0
 TOTAL=0
 
 declare -a NEW_FAILURE_LIST=()
+declare -a KNOWN_STILL_FAILING=()
+declare -a NOW_PASSING_LIST=()
+declare -a INCOMPLETE_LIST=()
 declare -a ALL_RESULTS=()
+
+# Name of the test whose "test:" marker has been seen but whose verdict line
+# has not. Non-empty at the next "test:" marker (or at EOF) means the suite
+# was cut short mid-test — see the incomplete-test handling below.
+open_test=""
 
 while IFS= read -r line; do
     test_name=""
     outcome=""
+
+    # ---------- Test-start marker ----------
+    # "test: NAME" opens a test; the matching success/failure/error/skip line
+    # closes it. A name still open when the next test starts (or at EOF) never
+    # produced a verdict — the per-suite timeout killed smbtorture mid-test.
+    # Such a test is inconclusive: it is neither counted as a pass nor as a
+    # failure, and it is reported separately so a truncated suite cannot read
+    # as a clean run.
+    if [[ "$line" =~ ^test:[[:space:]]+(.*) ]]; then
+        started="${BASH_REMATCH[1]%% *}"
+        [[ "$started" != smb2.* ]] && started="smb2.${started}"
+        [[ -n "$open_test" ]] && INCOMPLETE_LIST+=("$open_test")
+        open_test="$started"
+        continue
+    fi
 
     # ---------- Keyword-prefixed format ----------
     # "success: test.name"
@@ -252,17 +275,27 @@ while IFS= read -r line; do
     # Skip lines that don't match any format
     [[ -z "$test_name" ]] && continue
 
+    # A verdict closes the currently open test.
+    [[ "$test_name" == "$open_test" ]] && open_test=""
+
     TOTAL=$((TOTAL + 1))
     ALL_RESULTS+=("${test_name}|${outcome}")
 
     case "$outcome" in
         pass)
             PASS_COUNT=$((PASS_COUNT + 1))
+            # A blacklisted test that passes is a candidate for removal from
+            # KNOWN_FAILURES.md. Never a failure, but worth surfacing — the
+            # list only shrinks if someone can see what has started passing.
+            if is_known_failure "$test_name"; then
+                NOW_PASSING_LIST+=("$test_name")
+            fi
             ;;
         fail)
             FAIL_COUNT=$((FAIL_COUNT + 1))
             if is_known_failure "$test_name"; then
                 KNOWN_HITS=$((KNOWN_HITS + 1))
+                KNOWN_STILL_FAILING+=("$test_name")
             else
                 NEW_FAILURES=$((NEW_FAILURES + 1))
                 NEW_FAILURE_LIST+=("$test_name")
@@ -273,6 +306,39 @@ while IFS= read -r line; do
             ;;
     esac
 done < "$OUTPUT_FILE"
+
+# A test left open at EOF was killed by the timeout of the last suite run.
+[[ -n "$open_test" ]] && INCOMPLETE_LIST+=("$open_test")
+
+# Reduce the "now passing" candidates to names that passed and never failed.
+# A few smbtorture suites reuse one test name across several parametrised runs
+# (smb2.charset.Testing runs three times), so the raw list carries duplicates
+# and names that both passed and failed — neither is a candidate for removal
+# from the blacklist.
+declare -A _failed_names=()
+for name in "${NEW_FAILURE_LIST[@]+"${NEW_FAILURE_LIST[@]}"}" \
+            "${KNOWN_STILL_FAILING[@]+"${KNOWN_STILL_FAILING[@]}"}"; do
+    _failed_names["$name"]=1
+done
+declare -A _seen_pass=()
+declare -a _now_passing=()
+for name in "${NOW_PASSING_LIST[@]+"${NOW_PASSING_LIST[@]}"}"; do
+    [[ -n "${_failed_names[$name]+_}" ]] && continue
+    [[ -n "${_seen_pass[$name]+_}" ]] && continue
+    _seen_pass["$name"]=1
+    _now_passing+=("$name")
+done
+NOW_PASSING_LIST=("${_now_passing[@]+"${_now_passing[@]}"}")
+
+# Suites the harness gave up on, recorded by run.sh as "filter<TAB>seconds".
+# Everything those suites had not reached is missing from the results above.
+declare -a TIMED_OUT_SUITES=()
+if [[ -n "$RESULTS_DIR" ]] && [[ -f "${RESULTS_DIR}/timeouts.txt" ]]; then
+    while IFS=$'\t' read -r to_filter to_secs; do
+        [[ -z "$to_filter" ]] && continue
+        TIMED_OUT_SUITES+=("${to_filter} (gave up after ${to_secs:-?}s)")
+    done < "${RESULTS_DIR}/timeouts.txt"
+fi
 
 # --------------------------------------------------------------------------
 # Baseline generation
@@ -482,48 +548,72 @@ for entry in "${ALL_RESULTS[@]}"; do
 done
 
 # --------------------------------------------------------------------------
-# Summary
+# Summary — written to both the terminal and summary.txt (which the CI
+# workflow pastes into the job summary). A bare pass/fail count hides the
+# things people actually need: which failures are new, which suites the
+# harness gave up on, and which blacklisted tests have started passing.
 # --------------------------------------------------------------------------
 echo ""
-echo -e "${BOLD}--- Summary ---${NC}"
-echo -e "  Passed:           ${GREEN}${PASS_COUNT}${NC}"
-echo -e "  Known failures:   ${YELLOW}${KNOWN_HITS}${NC}"
-echo -e "  New failures:     ${RED}${NEW_FAILURES}${NC}"
-echo -e "  Skipped:          ${DIM}${SKIP_COUNT}${NC}"
-echo ""
+# report_list TITLE [NAME...] — markdown section, or nothing when empty.
+report_list() {
+    local title="$1"
+    shift
+    [[ $# -eq 0 ]] && return 0
+    echo ""
+    echo "### ${title} ($#)"
+    printf -- '- %s\n' "$@"
+}
 
-# --------------------------------------------------------------------------
-# Write summary.txt for CI step summary
-# --------------------------------------------------------------------------
+report_body() {
+    echo "| Metric | Count |"
+    echo "|--------|-------|"
+    echo "| Total | ${TOTAL} |"
+    echo "| Passed | ${PASS_COUNT} |"
+    echo "| Failed | ${FAIL_COUNT} |"
+    echo "| Known | ${KNOWN_HITS} |"
+    echo "| New Failures | ${NEW_FAILURES} |"
+    echo "| Skipped | ${SKIP_COUNT} |"
+    echo "| Inconclusive | ${#INCOMPLETE_LIST[@]} |"
+    echo "| Suites cut short | ${#TIMED_OUT_SUITES[@]} |"
+
+    report_list "New failures — not in KNOWN_FAILURES.md, these fail the job" \
+        "${NEW_FAILURE_LIST[@]+"${NEW_FAILURE_LIST[@]}"}"
+    report_list "Suites cut short by timeout — everything they did not reach is ungraded" \
+        "${TIMED_OUT_SUITES[@]+"${TIMED_OUT_SUITES[@]}"}"
+    report_list "Tests with no verdict — killed mid-test, neither pass nor fail" \
+        "${INCOMPLETE_LIST[@]+"${INCOMPLETE_LIST[@]}"}"
+    report_list "Known failures that now PASS — candidates to drop from KNOWN_FAILURES.md" \
+        "${NOW_PASSING_LIST[@]+"${NOW_PASSING_LIST[@]}"}"
+    report_list "Known failures still failing" \
+        "${KNOWN_STILL_FAILING[@]+"${KNOWN_STILL_FAILING[@]}"}"
+}
+
 if [[ -n "$RESULTS_DIR" ]] && [[ -d "$RESULTS_DIR" ]]; then
-    {
-        echo "| Metric | Count |"
-        echo "|--------|-------|"
-        echo "| Total | ${TOTAL} |"
-        echo "| Passed | ${PASS_COUNT} |"
-        echo "| Failed | ${FAIL_COUNT} |"
-        echo "| Known | ${KNOWN_HITS} |"
-        echo "| New Failures | ${NEW_FAILURES} |"
-        echo "| Skipped | ${SKIP_COUNT} |"
-    } > "${RESULTS_DIR}/summary.txt"
+    report_body > "${RESULTS_DIR}/summary.txt"
 fi
+report_body
+echo ""
 
 # --------------------------------------------------------------------------
-# Report new failures
+# Verdict
+#
+# The job fails on exactly one thing: failures that are not on the
+# KNOWN_FAILURES.md blacklist. Timeouts and no-verdict tests are reported
+# above but do not move the verdict in either direction — a suite the harness
+# abandoned is evidence of nothing, and failing on it would trade one flake
+# for another.
 # --------------------------------------------------------------------------
 if [[ "$NEW_FAILURES" -gt 0 ]]; then
     echo -e "${RED}${BOLD}RESULT: ${NEW_FAILURES} new failure(s) detected!${NC}"
-    echo ""
-    echo "New failures not in KNOWN_FAILURES.md:"
-    for name in "${NEW_FAILURE_LIST[@]}"; do
-        echo "  - ${name}"
-    done
     echo ""
     echo "To add as known failures, append to KNOWN_FAILURES.md:"
     echo "  | <test-name> | <category> | <reason> | - |"
     echo ""
 else
     echo -e "${GREEN}${BOLD}RESULT: All failures are known. CI green.${NC}"
+    if [[ ${#INCOMPLETE_LIST[@]} -gt 0 || ${#TIMED_OUT_SUITES[@]} -gt 0 ]]; then
+        echo -e "${YELLOW}NOTE: coverage was incomplete — see the timeout sections above.${NC}"
+    fi
     echo ""
 fi
 

--- a/test/smb-conformance/smbtorture/parse-results_test.sh
+++ b/test/smb-conformance/smbtorture/parse-results_test.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Unit tests for parse-results.sh grading.
+#
+# The verdict must depend on exactly one thing: failures that are not on the
+# KNOWN_FAILURES.md blacklist. Timeouts, blacklisted failures, and tests the
+# harness never finished must not move it. These tests pin that down with
+# synthetic smbtorture output — no Docker, no server, runs in a second.
+#
+# Usage: ./parse-results_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PARSER="${SCRIPT_DIR}/parse-results.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+FAILURES=0
+
+cat > "${WORK}/KNOWN_FAILURES.md" <<'EOF'
+| Test Name | Category | Reason | Issue |
+|-----------|----------|--------|-------|
+| smb2.lock.lock1 | proto | expected | - |
+| smb2.oplock.* | proto | wildcard row | - |
+EOF
+
+# run_case NAME EXPECTED_EXIT <<< output
+# Writes the heredoc on stdin as a results file, runs the parser, and checks
+# the exit code. Parser output is left in $WORK/last.txt for assert_output.
+run_case() {
+    local name="$1" want="$2"
+    local dir="${WORK}/case"
+    rm -rf "$dir"
+    mkdir -p "$dir"
+    cat > "${dir}/smbtorture-output.txt"
+    [[ -f "${WORK}/timeouts.txt" ]] && cp "${WORK}/timeouts.txt" "${dir}/timeouts.txt"
+
+    "$PARSER" "${dir}/smbtorture-output.txt" "${WORK}/KNOWN_FAILURES.md" "$dir" \
+        > "${WORK}/last.txt" 2>&1
+    local got=$?
+    if [[ "$got" -ne "$want" ]]; then
+        echo "FAIL: ${name}: exit ${got}, want ${want}"
+        cat "${WORK}/last.txt"
+        FAILURES=$((FAILURES + 1))
+        return
+    fi
+    echo "ok: ${name} (exit ${got})"
+}
+
+# assert_output NAME PATTERN — the last run's output must contain PATTERN.
+assert_output() {
+    local name="$1" pattern="$2"
+    if ! grep -qF -- "$pattern" "${WORK}/last.txt"; then
+        echo "FAIL: ${name}: output missing '${pattern}'"
+        FAILURES=$((FAILURES + 1))
+        return
+    fi
+    echo "ok: ${name}"
+}
+
+# assert_not_output NAME PATTERN — the last run's output must NOT contain it.
+assert_not_output() {
+    local name="$1" pattern="$2"
+    if grep -qF -- "$pattern" "${WORK}/last.txt"; then
+        echo "FAIL: ${name}: output unexpectedly contains '${pattern}'"
+        FAILURES=$((FAILURES + 1))
+        return
+    fi
+    echo "ok: ${name}"
+}
+
+# -- Blacklisted failures alone are green, exact row and wildcard row alike. --
+run_case "known failures only" 0 <<'EOF'
+test: smb2.connect.connect1
+success: smb2.connect.connect1
+test: smb2.lock.lock1
+failure: smb2.lock.lock1 [ expected ]
+test: smb2.oplock.batch1
+failure: smb2.oplock.batch1 [ wildcard ]
+EOF
+assert_output "known failures listed" "### Known failures still failing (2)"
+
+# -- One failure off the blacklist reds the job and is named. --
+run_case "new failure fails the job" 1 <<'EOF'
+test: smb2.connect.connect1
+success: smb2.connect.connect1
+test: smb2.lock.lock1
+failure: smb2.lock.lock1 [ expected ]
+test: smb2.rename.rename1
+failure: smb2.rename.rename1 [ regression ]
+EOF
+assert_output "new failure named" "- smb2.rename.rename1"
+
+# -- Same results, different order: same verdict, same new-failure set. --
+run_case "verdict is order-independent" 1 <<'EOF'
+test: smb2.rename.rename1
+failure: smb2.rename.rename1 [ regression ]
+test: smb2.oplock.batch1
+failure: smb2.oplock.batch1 [ wildcard ]
+test: smb2.lock.lock1
+failure: smb2.lock.lock1 [ expected ]
+test: smb2.connect.connect1
+success: smb2.connect.connect1
+EOF
+assert_output "new failure named regardless of order" "- smb2.rename.rename1"
+
+# -- An unfinished test is inconclusive: reported, but not a pass or a fail. --
+run_case "unfinished test does not fail the job" 0 <<'EOF'
+test: smb2.connect.connect1
+success: smb2.connect.connect1
+test: smb2.notify.mask
+EOF
+assert_output "unfinished test counted" "| Inconclusive | 1 |"
+assert_output "unfinished test named" "- smb2.notify.mask"
+assert_output "unfinished test is not a pass" "| Passed | 1 |"
+
+# -- A timeout must not hide a new failure the suite did produce. --
+printf 'smb2.notify\t120\n' > "${WORK}/timeouts.txt"
+run_case "new failure inside a timed-out suite still fails" 1 <<'EOF'
+test: smb2.notify.dir
+failure: smb2.notify.dir [ regression ]
+test: smb2.notify.mask
+EOF
+assert_output "timed-out suite reported" "- smb2.notify (gave up after 120s)"
+assert_output "new failure inside timed-out suite named" "- smb2.notify.dir"
+rm -f "${WORK}/timeouts.txt"
+
+# -- A timeout on its own is reported but leaves the job green. --
+printf 'smb2.notify\t120\n' > "${WORK}/timeouts.txt"
+run_case "timeout alone stays green" 0 <<'EOF'
+test: smb2.connect.connect1
+success: smb2.connect.connect1
+test: smb2.notify.mask
+EOF
+assert_output "timeout counted" "| Suites cut short | 1 |"
+rm -f "${WORK}/timeouts.txt"
+
+# -- A blacklisted test that passes is surfaced as a removal candidate. --
+run_case "blacklisted test that passes" 0 <<'EOF'
+test: smb2.lock.lock1
+success: smb2.lock.lock1
+test: smb2.oplock.batch1
+failure: smb2.oplock.batch1 [ wildcard ]
+EOF
+assert_output "now-passing surfaced" "### Known failures that now PASS"
+assert_output "now-passing named" "- smb2.lock.lock1"
+
+# -- A name that both passes and fails in one run is not a removal candidate. --
+run_case "flapping blacklisted test is not a candidate" 0 <<'EOF'
+test: smb2.lock.lock1
+success: smb2.lock.lock1
+test: smb2.lock.lock1
+failure: smb2.lock.lock1 [ expected ]
+EOF
+assert_not_output "flapping name withheld" "### Known failures that now PASS"
+
+echo ""
+if [[ "$FAILURES" -eq 0 ]]; then
+    echo "PASS: all parse-results.sh grading tests passed"
+    exit 0
+fi
+echo "FAIL: ${FAILURES} assertion(s) failed"
+exit 1

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -408,7 +408,12 @@ run_smbtorture() {
             2>&1 | tee -a "${RESULTS_DIR}/smbtorture-output.txt" || rc=${PIPESTATUS[0]}
     fi
     # Classify the exit code (see _smbtorture_exit handling at end of file):
-    #   124            -> the per-suite timeout fired (a hang we DO want to fail on)
+    #   124            -> the per-suite timeout fired: the harness gave up on this
+    #                     filter. Whatever the suite had not reached yet produced
+    #                     NO result lines at all, so those tests are ungraded —
+    #                     inconclusive, not passing. Recorded in timeouts.txt so
+    #                     parse-results.sh can report the lost coverage instead of
+    #                     letting it read as a clean run.
     #   125            -> docker run/daemon error (image pull 502, OOM-killed
     #                     container, etc.) — a real infrastructure failure
     #   128+N (>=129)  -> the smbtorture CLIENT process was killed by signal N
@@ -421,7 +426,10 @@ run_smbtorture() {
     # treated as infrastructure like 125.
     if [[ $rc -ge 129 ]]; then
         log_warn "smbtorture client crashed (exit code $rc, signal $((rc - 128))) for filter: $filter — client-side bug, not failing the job on this alone"
-    elif [[ $rc -ge 124 ]]; then
+    elif [[ $rc -eq 124 ]]; then
+        log_warn "smbtorture timed out after ${per_timeout}s on filter: $filter — tests it had not reached are UNGRADED (inconclusive)"
+        printf '%s\t%s\n' "$filter" "$per_timeout" >> "${RESULTS_DIR}/timeouts.txt"
+    elif [[ $rc -ge 125 ]]; then
         log_warn "smbtorture infrastructure failure (exit code $rc) for filter: $filter"
     fi
     return $rc


### PR DESCRIPTION
Relates to #1910.

## What the verdict was, and still is

`parse-results.sh` exits with the number of `failure:`/`error:` results whose test
name does not match a row in `KNOWN_FAILURES.md`. That set-difference is unchanged
by this PR — a genuine new conformance failure still reds the job, and nothing added
here can subtract from that count.

## What was actually broken

A suite killed by the per-suite `timeout` (exit 124) emits a `test: NAME` line and
then dies. That test never gets a verdict, and every test the suite had not reached
yet emits nothing at all. Both classes simply vanished from the parsed results, so a
truncated run graded identically to a complete one — 7 suites gave up on every
badger-fs run and the job summary said nothing about it.

That is the dangerous direction: a real regression living past the cut point grades
green.

## Change

- `run.sh` records each timed-out filter and its budget in `RESULTS_DIR/timeouts.txt`.
  Exit 124 stays non-fatal, as before. The stale comment claiming 124 was "a hang we
  DO want to fail on" is corrected — it never was.
- `parse-results.sh` tracks the open `test:` marker. A name with no verdict before the
  next marker or EOF is counted and named as **inconclusive** — neither a pass nor a
  failure.
- The report written to the terminal and to `summary.txt` (which the workflow pastes
  into the job summary) now lists: new failures, suites cut short, tests with no
  verdict, blacklisted tests that now PASS, and blacklisted tests still failing.
- `parse-results_test.sh` unit-tests the grading on synthetic output (no Docker, ~1s),
  wired to a fast `smbtorture grading logic` CI job.

## Why timeouts stay non-fatal

Failing on a timeout would trade one flake for another. They are now loud instead of
silent, which is the honest state: a timed-out suite is evidence of nothing.

## Verification

Replayed against the two runs in #1910 (byte-identical `dfs`, badger-fs profile):

| | run 31011120983 (green) | run 31014070873 (red) |
|---|---|---|
| new logic verdict | exit 0 | exit 1 |
| new failures | none | `smb2.replay.channel-sequence` |
| suites cut short | 7 | 7 |
| tests with no verdict | 7 | 7 |
| known failures now passing | 2 | 2 |

Injecting one synthetic `failure:` for a non-blacklisted test into the **green**
capture flips it to exit 1 and names the test — a real new failure still fails the job.
Mutating `is_known_failure` to always return true (so every failure grades as known)
is caught by 4 assertions in the unit test.

`shellcheck --severity=warning` clean on all three scripts; workflow YAML parses.

## Follow-ups, not in this PR

- **The verdict flip in #1910 was not caused by the timeouts.** Both runs hit the same
  7 timeouts on the same suites. The single difference was
  `smb2.replay.channel-sequence`, which passed in one run and failed in the other with
  a real assertion (`replay.c:4673: failed to test CSN with replay flag`). That is an
  intermittent product/test failure and deserves its own issue; the grading correctly
  flagged it.
- **The 7 timeouts are deterministic, not load flakes.** Both runs died at the same
  point in each suite: `smb2.maxfid`, `aio_delay.aio_cancel`,
  `compound_find.compound_find_close`, `lease.v2_epoch2`, `multichannel.leases.test2`,
  `notify.dir`/`notify.mask`, `oplock.batch22b`. No "waiting for lease break timed out"
  appears in the badger-fs client output or the server log.
- **`KNOWN_FAILURES.md` looks mildly stale**, deliberately not touched here. Rows that
  matched no failure in either badger-fs run: `kernel-oplocks.kernel_oplocks4`/`8`,
  `notify.mask-change`, `twrp.openroot`, plus `maxfid` and `multichannel.leases.test2`
  which are inconclusive rather than passing (their suites timed out). Also
  `smb2.exact.test.name` at line 1120 is a documentation template row being parsed as a
  real blacklist entry — harmless, but it inflates the count.
