### PR TITLE
fix(journal): skip a sealed segment that scans as zero valid records instead of panicking

### DIFF
--- a/pkg/block/journal/recovery.go
+++ b/pkg/block/journal/recovery.go
@@ -124,6 +124,21 @@ func (s *Store) recover() error {
 		// CRC-coincidence torn header from making the scanner trust a bogus length.
 		recs, validUpTo := scanValidRecords(fd, s.cfg.SegmentSize, s.cfg.SegmentSize)
 
+		if sealed && len(recs) == 0 {
+			// No write path can produce this: sealing fsyncs the records before it
+			// sets the sealed bit, and every seal is gated on the segment already
+			// holding a record. A sealed header over a record stream that scans
+			// empty therefore means the bytes under it were damaged after the fact.
+			// Skip the segment — no record names its shard, so there is nothing to
+			// attach it to — but leave the file on disk rather than sweeping it:
+			// nothing in the rebuilt index points into it, so unlinking it would
+			// destroy the only remaining copy of whatever payload is still down
+			// there.
+			_ = fd.Close()
+			logf("journal: WARN sealed segment %s scans as zero valid records (damaged first record), skipping it; left in place for inspection", path)
+			continue
+		}
+
 		m := &segmentMeta{id: id, createdAt: createdAt, fd: fd}
 		m.tail.Store(validUpTo)
 		if sealed {

--- a/pkg/block/journal/recovery_test.go
+++ b/pkg/block/journal/recovery_test.go
@@ -3,7 +3,9 @@ package journal
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -330,6 +332,72 @@ func TestOrphanSweepSparesYoung(t *testing.T) {
 	defer func() { _ = r.Close() }()
 	if _, err := os.Stat(s.segPath(orphanID)); err != nil {
 		t.Fatalf("young orphan should be spared, got: %v", err)
+	}
+}
+
+// TestSealedSegmentWithNoValidRecords builds a sealed segment whose record
+// stream is unreadable garbage and asserts recovery completes instead of
+// panicking, skips the segment, leaves its file on disk even past the orphan age
+// gate, warns about it, and serves the store's real data untouched.
+func TestSealedSegmentWithNoValidRecords(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ctx := context.Background()
+	if err := s.WriteAt(ctx, "f", 0, []byte("real-data")); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.Commit(ctx, "f"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// A valid sealed header followed by a record stream that scans as zero valid
+	// records: the damage recovery must survive rather than index into.
+	badID := uint64(7777)
+	old := time.Now().Add(-time.Hour)
+	seg := append(encodeSegHeader(badID, old, segFlagSealed), bytes.Repeat([]byte{0xAB}, 4096)...)
+	if err := os.WriteFile(s.segPath(badID), seg, 0o644); err != nil {
+		t.Fatalf("write damaged sealed seg: %v", err)
+	}
+	// Backdate past the orphan age gate so a sweep would delete it if recovery
+	// ever classified it as an orphan.
+	if err := os.Chtimes(s.segPath(badID), old, old); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	var warned []string
+	prev := logf
+	logf = func(format string, args ...any) { warned = append(warned, fmt.Sprintf(format, args...)) }
+	defer func() { logf = prev }()
+
+	r, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), fixedClock{t: time.Now()})
+	if err != nil {
+		t.Fatalf("reopen over damaged sealed segment: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	if !strings.Contains(strings.Join(warned, "\n"), "zero valid records") {
+		t.Fatalf("expected a warning naming the damaged sealed segment, got %q", warned)
+	}
+	if _, err := os.Stat(r.segPath(badID)); err != nil {
+		t.Fatalf("damaged sealed segment must be left in place, got: %v", err)
+	}
+	if got := readAll(t, r, "f", len("real-data")); string(got) != "real-data" {
+		t.Fatalf("real data lost: %q", got)
+	}
+	// The skipped segment is attached to no shard.
+	for _, sh := range r.shards {
+		if _, ok := sh.sealed[badID]; ok {
+			t.Fatalf("damaged segment %d was attached to a shard", badID)
+		}
+		if sh.active != nil && sh.active.id == badID {
+			t.Fatalf("damaged segment %d was adopted as an active segment", badID)
+		}
 	}
 }
 


### PR DESCRIPTION
Relates to #1913.

`Store.recover()` indexed `recs[0]` unconditionally to learn a segment's shard. Both
preceding guards are `!sealed`-qualified (empty active -> pool, torn tail -> truncate), so a
**sealed** segment whose record stream scans to zero valid records fell through and panicked
with `index out of range [0] with length 0` — during recovery, i.e. exactly when the process
is already coming back from a crash. A single damaged segment turned a contained,
recoverable situation into a boot loop for the share.

## How such a segment arises

Not from a crash. Every seal path is gated on the segment already holding a record:

- `appendRecord` / `appendTombstone` / `appendTruncateMarker` rotate only when
  `tail + recLen > SegmentSize`, and a record larger than `SegmentSize - segHeaderSize` is
  rejected before that check — so an empty active is never rotated.
- `sealSyncedActives` and the GC dead-active seal both require `records.Load() > 0`.
- `repackSegment` returns via `dropVictim` when there is nothing to move, so its target
  always receives at least one record before `sealInPlace`.

And `sealInPlace` fsyncs the record bytes *before* it sets the sealed bit, so a crash cannot
leave a durable sealed header over records that never landed.

A sealed header above an unreadable record stream therefore means the bytes under it were
damaged after they were made durable: media corruption, an fsync that did not reach the
device, or external truncation. That is an operator-visible inconsistency, so it is logged as
a WARN rather than at Debug.

## Behaviour chosen

Skip the segment, **leave the file on disk**, warn.

- Skipping is forced: the shard is derived from the first record, and there is no first
  record, so there is nothing to attach it to.
- Not swept as an orphan. The orphan sweep *unlinks*, and such a segment is aged, so it would
  be deleted on the first open after the damage. Nothing in the rebuilt index points into it,
  so keeping it cannot resurrect stale data — but unlinking it would destroy the only
  remaining copy of payload bytes a salvage pass could still read (a damaged record header
  does not imply damaged payloads).
- The warning names the segment's path and repeats on every open, so the inconsistency stays
  visible until an operator moves the file aside.

Leaving the file is safe because the `maxSegID` bump happens above the new `continue`: the
skipped id stays reserved, so a later `createSegment` (which opens `O_EXCL`) can never collide
with it. Its bytes are not counted in `diskBytes`, so local usage under-reports by that file's
size until an operator removes it — the right tradeoff for a damaged segment.

## Sibling index accesses on the recovery path

Audited; `recs[0]` was the only unguarded one. `decodeSegHeader` and `decodeHeader` both
length-check before slicing; `readRecordAt` bounds `PayloadLen` against the ceiling before
allocating and rejects the int64->int narrowing, and its `buf[h.FileIDLen:payloadEnd]` /
`buf[payloadEnd:]` slices are covered by `body = FileIDLen + PayloadLen + payloadCRCSize`;
`loadCold` advances by the decoder's returned length and stops at the first torn entry;
`rebuildIdx` and the ceiling replay iterate rather than index.

## Test

`TestSealedSegmentWithNoValidRecords` writes a real store, closes it, then plants a segment
file with a valid sealed header followed by garbage, backdated past the orphan age gate. It
asserts recovery completes, warns, leaves the file in place, attaches it to no shard, and
still serves the store's real data. Verified to panic at `recovery.go:152` without the fix.

## Verification

- `go build ./... && go vet ./... && gofmt -l .` — clean
- `go test ./pkg/block/...` — all packages ok
- `go test -race ./pkg/block/journal/...` — ok
