### PR TITLE
fix(journal): release the segment claim when eviction's cold-log append fails

### DIFF
--- a/pkg/block/journal/cold.go
+++ b/pkg/block/journal/cold.go
@@ -155,11 +155,23 @@ func (s *Store) appendCold(entries []coldEntry) error {
 	if len(buf) == 0 {
 		return nil
 	}
+	// A write that fails part-way (ENOSPC is the likely one: eviction runs because
+	// the volume this log shares with the segments is filling up) leaves a torn
+	// entry at the tail. Replay stops at the first tear, so any entry a later
+	// append puts behind it is lost for good — silent zeros for a range the caller
+	// went on to evict. Roll the tail back to where the batch started so the log
+	// keeps its "only the tail can tear" shape and the caller's retry appends onto
+	// intact bytes.
+	st, err := s.coldFD.Stat()
+	if err != nil {
+		return fmt.Errorf("journal: stat cold log: %w", err)
+	}
+	tail := st.Size()
 	if _, err := s.coldFD.Write(buf); err != nil {
-		return fmt.Errorf("journal: append cold log: %w", err)
+		return errors.Join(fmt.Errorf("journal: append cold log: %w", err), s.coldFD.Truncate(tail))
 	}
 	if err := s.coldFD.Sync(); err != nil {
-		return fmt.Errorf("journal: fsync cold log: %w", err)
+		return errors.Join(fmt.Errorf("journal: fsync cold log: %w", err), s.coldFD.Truncate(tail))
 	}
 	return nil
 }

--- a/pkg/block/journal/evict_test.go
+++ b/pkg/block/journal/evict_test.go
@@ -145,6 +145,48 @@ func TestEvictSkipsClaimedSegment(t *testing.T) {
 	}
 }
 
+// TestEvictReleasesClaimAfterColdLogFailure: a failed cold-log append must leave
+// the segment reclaimable. Eviction's claim is exclusive, so keeping it past the
+// failure would bar that segment from every later eviction and GC pass until the
+// process restarts, stranding its bytes under the disk pressure eviction relieves.
+func TestEvictReleasesClaimAfterColdLogFailure(t *testing.T) {
+	s, _ := evictStore(t, Config{})
+	ctx := context.Background()
+
+	fillUntilSealed(t, s, "f", true, 1)
+	segs := sealedSegs(s.shardFor("f"))
+	if len(segs) == 0 {
+		t.Fatalf("want a sealed segment to evict")
+	}
+
+	// A directory in place of the cold log file fails the append's open.
+	if err := os.Mkdir(s.coldPath(), 0o755); err != nil {
+		t.Fatalf("Mkdir over cold log path: %v", err)
+	}
+	if _, err := s.Evict(ctx, 1<<30); err == nil {
+		t.Fatalf("a cold-log append failure must surface, not evict blind")
+	}
+	for _, seg := range segs {
+		if _, err := os.Stat(s.segPath(seg.id)); err != nil {
+			t.Fatalf("segment %d must survive the failed eviction, stat err=%v", seg.id, err)
+		}
+	}
+
+	// With the cold log writable again, the segments the failed pass claimed must
+	// be reclaimable.
+	if err := os.Remove(s.coldPath()); err != nil {
+		t.Fatalf("Remove cold log dir: %v", err)
+	}
+	if _, err := s.Evict(ctx, 1<<30); err != nil {
+		t.Fatalf("Evict after the cold log recovered: %v", err)
+	}
+	for _, seg := range segs {
+		if _, err := os.Stat(s.segPath(seg.id)); !os.IsNotExist(err) {
+			t.Fatalf("segment %d stayed claimed after the failed eviction: stat err=%v", seg.id, err)
+		}
+	}
+}
+
 func TestEvictSyncedGateRefusesDirty(t *testing.T) {
 	s, _ := evictStore(t, Config{})
 	ctx := context.Background()

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -204,7 +204,20 @@ func evictable(seg *segmentMeta) bool {
 // first can at worst leave a marker for bytes that are still local (the eviction
 // did not complete), which costs a needless remote fetch — the opposite order
 // would serve zeros.
-func (s *Store) evictSegment(sh *shard, seg *segmentMeta) (int64, error) {
+//
+// A failure drops the claim (as reclaimEmptied does) so a later pass can retry the
+// segment: the claim is exclusive, so keeping it would bar the segment from every
+// subsequent eviction and GC pass, stranding its bytes under the very disk pressure
+// eviction serves. Retrying is safe because the failure leaves the index and the
+// segment untouched; at worst it left markers for bytes that are still local, which
+// the persist-first order already tolerates.
+func (s *Store) evictSegment(sh *shard, seg *segmentMeta) (freed int64, err error) {
+	defer func() {
+		if err != nil {
+			seg.busy.Store(false)
+		}
+	}()
+
 	sh.mu.Lock()
 	var entries []coldEntry
 	for id, fi := range sh.index {
@@ -221,7 +234,7 @@ func (s *Store) evictSegment(sh *shard, seg *segmentMeta) (int64, error) {
 	}
 	sh.mu.Unlock()
 
-	if err := s.appendCold(entries); err != nil {
+	if err = s.appendCold(entries); err != nil {
 		// Without a durable marker the range would come back from a restart as a
 		// hole, so keep the segment (and its bytes) instead of evicting blind.
 		return 0, err


### PR DESCRIPTION
Relates to #1914.

## The leak

`evictSegment` takes an exclusive per-segment `busy` claim (CAS in `claimColdestEvictable`) and never released it when `appendCold` failed — it returned `0, err` straight through `evict()`. A stuck claim permanently excludes the segment from `evictable()`, `pickVictim`, and `reclaimEmptied`, so one cold-log I/O or ENOSPC failure strands that segment and its bytes for the life of the process, recoverable only by a restart — exactly under the disk pressure eviction exists to relieve.

Fixed with a `defer` over named returns that drops the claim on any failure, so it cannot rot when a future error path is added. Success still retains the claim, as before: `retireSegment` has already dropped the segment from `sh.sealed`, so the claim is unreachable.

## Making the retry actually safe

Releasing the claim only helps if a failed append leaves nothing half-done. It did not. `appendCold` packs the whole batch into one buffer and issues a single `Write`; Go loops the underlying syscall, so an ENOSPC part-way through returns an error *after* some bytes are already on disk — a torn entry at the tail. Nothing truncated it back and the `O_APPEND` fd stayed open, so the retry (or any later eviction sharing the fd) appended a valid batch *behind* the tear. `loadCold` stops at the first tear, so those valid, fsynced markers are dropped on every subsequent load — the segment gets unlinked and the range reads back as a zero-filled hole instead of fetching from remote.

`appendCold` now records the tail before the batch and truncates back to it when the write or fsync fails, restoring the log’s "only the tail can tear" invariant so a retry appends onto intact bytes.

## Audit of the other claim sites

Both other `busy` CAS sites were traced and are correct as-is:

- `reclaimEmptied` — releases explicitly on `retireSegment` failure; retains on success (segment already out of `sh.sealed`).
- `gcShard` — releases *unconditionally* after `repackSegment`. That is deliberate and must not be converted to the release-on-error shape: `repackSegment` has non-error paths that do not retire the victim (the defensive `remaining != 0` branch and the `testStopBeforeUnlink` seam), and those need the claim back.

## Test

`TestEvictReleasesClaimAfterColdLogFailure` forces the append to fail, asserts the segment survives, then restores the cold log and asserts the *same* segment is now reclaimable. Verified to fail before the fix on the claim assertion specifically (not merely on error propagation):

```
evict_test.go:186: segment 0 stayed claimed after the failed eviction: stat err=<nil>
--- FAIL: TestEvictReleasesClaimAfterColdLogFailure
```

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. `go test ./pkg/block/...` and `go test -race ./pkg/block/journal/...` all pass.

## Not addressed

The second (perf) finding on #1914 — `evictSegment` scanning the whole shard index once per evicted segment — is deliberately left out; it needs a restructured evict loop with a snapshotted per-segment bucket, which would enlarge this diff and its risk for no correctness gain.