### PR TITLE
fix(block): verify record CRCs before copying payloads to remote or a new segment

### DIFF
--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -249,7 +249,7 @@ func (s *Store) carveFile(ctx context.Context, sh *shard, id FileID, res *CarveR
 // and flips the run's records to synced as the durable frontier advances.
 func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interval, res *CarveResult) error {
 	c := chunker.NewChunkerWithParams(s.cfg.ChunkParams)
-	rr := &runReader{s: s, sh: sh, ivs: run}
+	rr := &runReader{s: s, sh: sh, id: id, ivs: run}
 
 	fileOff := run[0].fileOff
 	flipIdx := 0
@@ -544,15 +544,27 @@ func (s *Store) maybeResetDirtyClock(sh *shard, id FileID) {
 	fi.firstDirtyNanos = 0
 }
 
-// runReader streams a contiguous run's live bytes in file-offset order by
-// preading each interval's payload. It reuses the store's positioned-read path so
-// reads race nothing (segment fds are stable once created).
+// runReader streams a contiguous run's live bytes in file-offset order, serving
+// each interval out of its owning record's CRC-verified payload. Reads race
+// nothing (segment fds are stable once created).
+//
+// The verification is load-bearing rather than defensive: carve hashes whatever
+// it reads and commits it to the remote store as content-addressed data, so a
+// raw pread here would promote latent local bit rot to the authoritative copy of
+// the file. A failed check aborts the run instead, leaving the bytes dirty and
+// local — recoverable, and loud.
 type runReader struct {
 	s   *Store
 	sh  *shard
+	id  FileID
 	ivs []interval
 	i   int   // current interval
 	off int64 // bytes already read from the current interval
+	// rec is the verified record backing the current interval, kept so a record
+	// spanning several Read calls or several intervals is read and verified once
+	// rather than per call. recSeg pairs with rec.segOff to identify it.
+	rec    *record
+	recSeg uint64
 }
 
 func (rr *runReader) Read(p []byte) (int, error) {
@@ -564,13 +576,30 @@ func (rr *runReader) Read(p []byte) (int, error) {
 			rr.off = 0
 			continue
 		}
-		n := int64(len(p))
-		if n > remain {
-			n = remain
+		if rr.rec == nil || rr.recSeg != iv.loc.SegmentID || rr.rec.segOff != iv.recOff {
+			rec, err := rr.s.readRecord(rr.sh, iv.loc.SegmentID, iv.recOff, rr.id)
+			if err != nil {
+				if errors.Is(err, errTornRecord) {
+					return 0, rr.corruptRange(iv, remain)
+				}
+				return 0, err
+			}
+			rr.rec, rr.recSeg = &rec, iv.loc.SegmentID
 		}
-		got, err := rr.s.readPayload(rr.sh, iv.loc, rr.off, p[:n])
-		rr.off += int64(got)
-		return got, err
+		n := min(int64(len(p)), remain)
+		src, ok := rr.rec.payloadRange(iv.loc.Offset+rr.off, n)
+		if !ok {
+			return 0, rr.corruptRange(iv, remain)
+		}
+		copy(p, src)
+		rr.off += n
+		return int(n), nil
 	}
 	return 0, io.EOF
+}
+
+// corruptRange names the still-unread part of iv as the corrupt file range, so
+// the carve failure points at the bytes it refused to hash.
+func (rr *runReader) corruptRange(iv interval, remain int64) error {
+	return &CorruptRangeError{FileID: rr.id, Offset: iv.fileOff + rr.off, Len: remain}
 }

--- a/pkg/block/journal/index.go
+++ b/pkg/block/journal/index.go
@@ -353,35 +353,26 @@ func (s *Store) ReadAt(ctx context.Context, id FileID, offset int64, dst []byte)
 }
 
 // verifiedRead serves a warm piece with integrity verification: it re-reads the
-// whole record that owns the piece (at p.recOff) and validates its header and
-// payload CRCs via readRecordAt, then copies the requested sub-range out of the
-// verified payload. This trades read amplification (the whole record vs the
+// whole record that owns the piece (at p.recOff) and validates it via
+// readVerifiedRecord, then copies the requested sub-range out of the verified
+// payload. This trades read amplification (the whole record vs the
 // sub-range) for detecting on-disk corruption a raw pread would return silently.
 // A CRC/torn failure — or an index/record extent that no longer agrees — returns
 // a *CorruptRangeError naming the file range so the caller heals from a remote
 // store or fails closed; it never copies unverified bytes into out.
 func (s *Store) verifiedRead(seg *segmentMeta, p piece, out []byte, id FileID, readOff int64) error {
 	corrupt := &CorruptRangeError{FileID: id, Offset: readOff + p.dstStart, Len: p.dstEnd - p.dstStart}
-	rec, _, err := readRecordAt(seg.fd, p.recOff, s.cfg.SegmentSize)
+	rec, err := readVerifiedRecord(seg.fd, p.recOff, s.cfg.SegmentSize, id)
 	if err != nil {
 		return corrupt
 	}
-	// The header and payload CRCs do not cover the FileID bytes, so a flipped
-	// FileID (or a stale recOff pointing at another file's record) would pass
-	// readRecordAt yet hand back the wrong file's bytes. Confirm the record we
-	// landed on is this file's before trusting its payload.
-	if string(rec.fileID) != string(id) {
+	// loc.Offset is the segment byte for the piece start (interval splits advance
+	// it), so the payload sub-range is addressed by absolute segment offset.
+	src, ok := rec.payloadRange(p.loc.Offset+p.subOff, int64(len(out)))
+	if !ok {
 		return corrupt
 	}
-	// Offset of the piece's first byte within the verified payload: loc.Offset is
-	// the segment byte for the piece start (interval splits advance it), so
-	// subtracting the record's payload start yields the payload-relative index.
-	payloadStart := p.recOff + recordHeaderSize + int64(len(rec.fileID))
-	within := p.loc.Offset + p.subOff - payloadStart
-	if within < 0 || within+int64(len(out)) > int64(len(rec.payload)) {
-		return corrupt
-	}
-	copy(out, rec.payload[within:within+int64(len(out))])
+	copy(out, src)
 	return nil
 }
 

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -551,6 +551,9 @@ func (s *Store) pickVictim(sh *shard, opts GCOptions) *segmentMeta {
 		if seg.busy.Load() {
 			continue // claimed by eviction or an in-flight repack
 		}
+		if seg.corrupt.Load() {
+			continue // a previous repack could not verify its records; leave it intact
+		}
 		if s.pinned(seg) {
 			// Pinned by a live snapshot: repack relocates bytes but a crash mid-move
 			// plus a rollback needs the pinned records intact at their original
@@ -596,6 +599,7 @@ type liveRec struct {
 	version uint64
 	synced  bool
 	srcOff  int64 // payload offset in the victim
+	recOff  int64 // owning record's header offset in the victim
 }
 
 // findMove returns the index of the move whose logical range fully contains
@@ -638,16 +642,29 @@ func (s *Store) repackSegment(sh *shard, victim *segmentMeta) (int64, error) {
 			}
 			moves = append(moves, liveRec{
 				id: id, fileOff: iv.fileOff, length: iv.length,
-				version: iv.version, synced: iv.synced, srcOff: iv.loc.Offset,
+				version: iv.version, synced: iv.synced,
+				srcOff: iv.loc.Offset, recOff: iv.recOff,
 			})
 		}
 	}
 	occupied := victim.liveBytes.Load()
 	sh.mu.Unlock()
 
+	// quarantine condemns the victim: it keeps its bytes (a repack that cannot
+	// verify a record must not copy it forward under a fresh CRC) and is skipped
+	// by every later pass, so one damaged segment does not stall the shard.
+	quarantine := func(err error) error {
+		victim.corrupt.Store(true)
+		logf("journal: WARN segment %d failed a repack integrity check; leaving it in place and skipping it: %v", victim.id, err)
+		return err
+	}
+
 	// 1b. Carry forward the victim's tombstones and truncate markers so deletes
 	// and size-downs stay durable until every record they fence is gone.
-	markers := victimMarkers(victim, s.cfg.SegmentSize)
+	markers, err := victimMarkers(victim, s.cfg.SegmentSize)
+	if err != nil {
+		return 0, quarantine(err)
+	}
 
 	if len(moves) == 0 && len(markers) == 0 {
 		return s.dropVictim(sh, victim, occupied)
@@ -669,12 +686,23 @@ func (s *Store) repackSegment(sh *shard, victim *segmentMeta) (int64, error) {
 		m := moves[i]
 		if m.length < 0 || m.length > maxPayloadLen {
 			cleanup()
-			return 0, fmt.Errorf("journal: repack implausible record length %d in segment %d", m.length, victim.id)
+			return 0, quarantine(fmt.Errorf("journal: repack implausible record length %d in segment %d", m.length, victim.id))
 		}
-		data := make([]byte, int(m.length)) // one interval in RAM at a time
-		if _, rerr := victim.fd.ReadAt(data, m.srcOff); rerr != nil {
+		// Verify the source record before copying it forward: writeDataRecord
+		// stamps a fresh CRC over whatever it is handed, so an unverified copy
+		// would launder on-disk bit rot into a record that passes every later
+		// integrity check. One record in RAM at a time.
+		rec, rerr := readVerifiedRecord(victim.fd, m.recOff, s.cfg.SegmentSize, m.id)
+		if rerr != nil {
 			cleanup()
-			return 0, fmt.Errorf("journal: repack read victim %d@%d: %w", victim.id, m.srcOff, rerr)
+			return 0, quarantine(fmt.Errorf("journal: repack verify victim %d record %d for %q@%d: %w",
+				victim.id, m.recOff, m.id, m.fileOff, rerr))
+		}
+		data, ok := rec.payloadRange(m.srcOff, m.length)
+		if !ok {
+			cleanup()
+			return 0, quarantine(fmt.Errorf("journal: repack victim %d record %d does not frame %q@%d+%d: %w",
+				victim.id, m.recOff, m.id, m.fileOff, m.length, errTornRecord))
 		}
 		poff, werr := writeDataRecord(target, m.id, m.fileOff, m.version, m.synced, data)
 		if werr != nil {
@@ -802,11 +830,18 @@ type markRec struct {
 
 // victimMarkers scans a sealed victim's record stream for the non-data records
 // (tombstones and truncate markers) a repack must carry forward so the deletes
-// and size-downs they encode survive the source segment's reclamation. A sealed
-// segment is trusted intact, so a torn tail (should never occur) simply yields
-// the records read so far.
-func victimMarkers(seg *segmentMeta, segSize int64) []markRec {
-	recs, _ := scanValidRecords(seg.fd, segSize, segSize)
+// and size-downs they encode survive the source segment's reclamation.
+//
+// A scan that stops short of the segment's record end means a record failed its
+// integrity check, and every marker behind it would be silently dropped — the
+// delete or size-down it encodes would come back to life once the victim is
+// reclaimed. That reports an error so the repack leaves the victim alone.
+func victimMarkers(seg *segmentMeta, segSize int64) ([]markRec, error) {
+	recs, validUpTo := scanValidRecords(seg.fd, segSize, segSize)
+	if tail := seg.tail.Load(); validUpTo < tail {
+		return nil, fmt.Errorf("journal: segment %d record stream ends at %d, want %d: %w",
+			seg.id, validUpTo, tail, errTornRecord)
+	}
 	var out []markRec
 	for _, rec := range recs {
 		switch {
@@ -821,7 +856,7 @@ func victimMarkers(seg *segmentMeta, segSize int64) []markRec {
 			})
 		}
 	}
-	return out
+	return out, nil
 }
 
 // writeDataRecord frames one data record at seg's tail, preserving the caller's

--- a/pkg/block/journal/record.go
+++ b/pkg/block/journal/record.go
@@ -199,6 +199,39 @@ func readRecordAt(r io.ReaderAt, off, maxPayload int64) (record, int64, error) {
 	}, off + recordHeaderSize + body, nil
 }
 
+// readVerifiedRecord reads the record at recOff and returns it only once its
+// header CRC, payload CRC and framed FileID all check out. Every path that
+// copies a payload forward reads through it: each one re-hashes or re-CRCs the
+// bytes it copies, so an unverified read would turn on-disk bit rot into content
+// that passes every later integrity check.
+//
+// The header and payload CRCs deliberately do not cover the FileID bytes, so a
+// flipped FileID — or a stale recOff landing on another file's record — passes
+// readRecordAt while handing back the wrong file's payload. Comparing the framed
+// FileID against the caller's closes that gap.
+func readVerifiedRecord(r io.ReaderAt, recOff, maxPayload int64, id FileID) (record, error) {
+	rec, _, err := readRecordAt(r, recOff, maxPayload)
+	if err != nil {
+		return record{}, err
+	}
+	if string(rec.fileID) != string(id) {
+		return record{}, fmt.Errorf("%w: record at %d frames %q, want %q", errTornRecord, recOff, rec.fileID, id)
+	}
+	return rec, nil
+}
+
+// payloadRange returns the sub-slice of the record's verified payload that
+// starts at segment offset segOff and runs n bytes. ok is false when that range
+// is not wholly inside the payload, meaning the caller's location no longer
+// agrees with what the record actually frames.
+func (rec record) payloadRange(segOff, n int64) (b []byte, ok bool) {
+	within := segOff - (rec.segOff + recordHeaderSize + int64(len(rec.fileID)))
+	if within < 0 || n < 0 || within+n > int64(len(rec.payload)) {
+		return nil, false
+	}
+	return rec.payload[within : within+n], true
+}
+
 // scanValidRecords walks a segment's record stream from the first record to the
 // first torn record or clean end, returning the valid records and the offset up
 // to which the segment is intact. Recovery replays the records and truncates the

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -64,9 +64,15 @@ type segmentMeta struct {
 	// busy claims the segment for an exclusive whole-segment operation (evict or
 	// GC repack). A claimer CAS-sets it true so eviction and GC never touch the
 	// same sealed segment concurrently; warm reads and carve don't claim.
-	busy  atomic.Bool
-	fd    *os.File
-	idxFD *os.File // persistent append handle for the .idx sidecar (nil if unavailable)
+	busy atomic.Bool
+	// corrupt marks a segment whose records failed an integrity check while a
+	// repack was copying them forward. GC skips it until the store is reopened, so
+	// one damaged segment cannot stall reclamation for the rest of the shard, and
+	// its bytes stay on disk untouched for the read path to report or heal from
+	// remote.
+	corrupt atomic.Bool
+	fd      *os.File
+	idxFD   *os.File // persistent append handle for the .idx sidecar (nil if unavailable)
 	// readGuard coordinates unlocked preads against a GC/eviction that unlinks the
 	// segment: readers hold it shared across a pread, the reclaimer holds it
 	// exclusive around close+unlink so no read touches a closed fd.
@@ -221,7 +227,7 @@ func (m *segmentMeta) sealInPlace() error {
 // sealSegment seals the shard's active segment, moves it into the sealed set and
 // opens a fresh active segment. The segment's existing fd stays open and serves
 // warm reads from the sealed set; GC/eviction swap it only under its readGuard,
-// so readPayload's snapshot-then-unlocked-pread never touches a closed fd.
+// so readRecord's snapshot-then-unlocked-read never touches a closed fd.
 //
 // Caller must hold sh.mu.
 func (s *Store) sealSegment(sh *shard) error {
@@ -534,22 +540,23 @@ func writeTombstoneRecord(seg *segmentMeta, id FileID, version uint64) (recStart
 	return recStart, nil
 }
 
-// readPayload preads length bytes of a record payload starting subOffset into
-// the payload identified by loc, into dst. It snapshots the segment fd under
-// the shard lock, then preads unlocked. Carve is its only caller and holds the
-// shard's carveMu, which GC/eviction also hold before closing a segment, so the
-// fd cannot close under it. (ReadAt does its own resolve-and-guard — see readAt.)
-func (s *Store) readPayload(sh *shard, loc SegmentLocation, subOffset int64, dst []byte) (int, error) {
+// readRecord resolves a segment under the shard lock, then reads and verifies
+// the record at recOff, handing the whole verified record back for the caller to
+// slice. It snapshots the segment fd under the lock and reads unlocked. Carve is
+// its only caller and holds the shard's carveMu, which GC/eviction also hold
+// before closing a segment, so the fd cannot close under it. (ReadAt does its
+// own resolve-and-guard — see readAt.)
+func (s *Store) readRecord(sh *shard, segID uint64, recOff int64, id FileID) (record, error) {
 	sh.mu.Lock()
-	seg := sh.segment(loc.SegmentID)
+	seg := sh.segment(segID)
 	sh.mu.Unlock()
 	if seg == nil {
-		return 0, fmt.Errorf("journal: unknown segment %d", loc.SegmentID)
+		return record{}, fmt.Errorf("journal: unknown segment %d", segID)
 	}
 	seg.lastAccess.Store(s.clock.Now().UnixNano())
-	n, err := seg.fd.ReadAt(dst, loc.Offset+subOffset)
+	rec, err := readVerifiedRecord(seg.fd, recOff, s.cfg.SegmentSize, id)
 	if err != nil {
-		return n, fmt.Errorf("journal: read segment %d@%d: %w", loc.SegmentID, loc.Offset+subOffset, err)
+		return record{}, fmt.Errorf("journal: read segment %d record %d: %w", segID, recOff, err)
 	}
-	return n, nil
+	return rec, nil
 }

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -853,6 +853,7 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 						length:  int64(rec.header.PayloadLen),
 						version: rec.header.Version,
 						synced:  rec.header.Flags&flagSynced != 0,
+						recOff:  rec.segOff,
 						loc: SegmentLocation{
 							SegmentID: seg.id,
 							Offset:    rec.segOff + recordHeaderSize + int64(len(rec.fileID)),
@@ -914,11 +915,19 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 			if seg == nil {
 				return fmt.Errorf("journal: restore: source segment %d gone for %q@%d", iv.loc.SegmentID, id, iv.fileOff)
 			}
-			buf := make([]byte, iv.length)
-			if _, err := seg.fd.ReadAt(buf, iv.loc.Offset); err != nil {
-				return fmt.Errorf("journal: restore: read %q@%d from segment %d: %w", id, iv.fileOff, iv.loc.SegmentID, err)
+			// Re-materializing rewrites these bytes as fresh records under a fresh
+			// CRC, so they are verified against the source record first — restoring
+			// a snapshot must not turn on-disk bit rot into trusted content.
+			rec, rerr := readVerifiedRecord(seg.fd, iv.recOff, s.cfg.SegmentSize, id)
+			if rerr != nil {
+				return fmt.Errorf("journal: restore: read %q@%d from segment %d: %w", id, iv.fileOff, iv.loc.SegmentID, rerr)
 			}
-			exts = append(exts, extent{off: iv.fileOff, data: buf})
+			src, ok := rec.payloadRange(iv.loc.Offset, iv.length)
+			if !ok {
+				return fmt.Errorf("journal: restore: segment %d record %d does not frame %q@%d+%d: %w",
+					iv.loc.SegmentID, iv.recOff, id, iv.fileOff, iv.length, errTornRecord)
+			}
+			exts = append(exts, extent{off: iv.fileOff, data: append([]byte(nil), src...)})
 		}
 		// Bury the current head (tombstone Version > head), then re-assert the
 		// V-view as fresh dirty records on top of it.

--- a/pkg/block/journal/truncate_test.go
+++ b/pkg/block/journal/truncate_test.go
@@ -251,7 +251,10 @@ func TestVictimMarkersCollectsTruncate(t *testing.T) {
 	seg := sh.active
 	sh.mu.Unlock()
 
-	markers := victimMarkers(seg, s.cfg.SegmentSize)
+	markers, err := victimMarkers(seg, s.cfg.SegmentSize)
+	if err != nil {
+		t.Fatalf("victimMarkers: %v", err)
+	}
 	var found bool
 	for _, m := range markers {
 		if m.flags&flagTruncate != 0 && m.id == "f" {

--- a/pkg/block/journal/verify_copy_test.go
+++ b/pkg/block/journal/verify_copy_test.go
@@ -1,0 +1,155 @@
+package journal
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+)
+
+// flipSegByte inverts one byte of a segment file in place, simulating on-disk
+// bit rot of an otherwise valid record. It writes through a fresh fd; the
+// store's own fd sees the change via the shared page cache.
+func flipSegByte(t *testing.T, s *Store, segID uint64, off int64) {
+	t.Helper()
+	f, err := os.OpenFile(s.segPath(segID), os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open segment %d: %v", segID, err)
+	}
+	defer func() { _ = f.Close() }()
+	var b [1]byte
+	if _, err := f.ReadAt(b[:], off); err != nil {
+		t.Fatalf("read segment byte: %v", err)
+	}
+	b[0] ^= 0xFF
+	if _, err := f.WriteAt(b[:], off); err != nil {
+		t.Fatalf("write corrupt byte: %v", err)
+	}
+}
+
+// firstInterval returns a copy of id's first live interval.
+func firstInterval(t *testing.T, s *Store, id FileID) interval {
+	t.Helper()
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	fi := sh.index[id]
+	if fi == nil || len(fi.ivs) == 0 {
+		t.Fatalf("no interval for %q", id)
+	}
+	return fi.ivs[0]
+}
+
+// segFileCount counts the .seg files currently on disk.
+func segFileCount(t *testing.T, s *Store) int {
+	t.Helper()
+	ids, err := scanSegmentIDs(s.dir)
+	if err != nil {
+		t.Fatalf("scanSegmentIDs: %v", err)
+	}
+	return len(ids)
+}
+
+// TestCarveRefusesCorruptedRecord asserts that carve fails closed on a dirty
+// record whose payload rotted on disk instead of hashing those bytes and
+// committing them to the remote store as genuine content — which would make the
+// corrupt copy the authoritative one, under a BLAKE3 hash that matches it.
+func TestCarveRefusesCorruptedRecord(t *testing.T) {
+	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 1 << 20})
+	ctx := context.Background()
+
+	data := randBytes(2<<20, 7)
+	if err := s.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	corruptFirstPayloadByte(t, s, "f")
+
+	_, err := s.Carve(ctx, CarveOptions{Force: true})
+	var cre *CorruptRangeError
+	if !errors.As(err, &cre) {
+		t.Fatalf("Carve must refuse a corrupt record, got err=%v", err)
+	}
+	if cre.FileID != "f" {
+		t.Fatalf("CorruptRangeError names wrong file: %+v", cre)
+	}
+	if got := sink.carved(); len(got) != 0 {
+		t.Fatalf("carve uploaded %d bytes from a corrupt record", len(got))
+	}
+	// The run aborted with the bytes still dirty and still local: nothing was
+	// marked durable, so the failure is recoverable rather than silently absorbed.
+	if u := s.UnsyncedBytes(); u != int64(len(data)) {
+		t.Fatalf("unsynced after refused carve = %d, want %d", u, len(data))
+	}
+	if f := recRawFlags(t, s, "f", 0); f&flagSynced != 0 {
+		t.Fatalf("refused carve still flipped the record synced: flags=%#x", f)
+	}
+}
+
+// TestRepackRefusesTruncatedRecordStream asserts that a repack whose victim
+// carries a record that fails its CRC is abandoned. Copying the survivors
+// forward would stamp a fresh CRC over rotted bytes, and the marker scan stops
+// at the bad record, so every tombstone and truncate marker behind it would be
+// dropped when the victim is reclaimed.
+func TestRepackRefusesTruncatedRecordStream(t *testing.T) {
+	s := testStore(t, Config{SegmentSize: minSegmentSize, ShardCount: 1})
+	ctx := context.Background()
+	seedRepackable(t, s)
+
+	victim := onlySealed(t, s, "keep")
+	corruptFirstPayloadByte(t, s, "keep")
+	segsBefore := segFileCount(t, s)
+
+	res, err := s.GC(ctx, GCOptions{Force: true})
+	if !errors.Is(err, errTornRecord) {
+		t.Fatalf("GC must refuse to repack a victim with a torn record, got err=%v res=%+v", err, res)
+	}
+	if res.SegmentsRepacked != 0 {
+		t.Fatalf("GC reported %d repacks despite refusing", res.SegmentsRepacked)
+	}
+	// The victim keeps its bytes and its place: nothing is dropped or rewritten,
+	// and the half-built target is cleaned up rather than left behind.
+	sh := s.shardFor("keep")
+	sh.mu.Lock()
+	_, stillSealed := sh.sealed[victim.id]
+	sh.mu.Unlock()
+	if !stillSealed {
+		t.Fatalf("refused repack dropped the victim segment")
+	}
+	if n := segFileCount(t, s); n != segsBefore {
+		t.Fatalf("segment count %d, want %d (target not cleaned up)", n, segsBefore)
+	}
+	if !victim.corrupt.Load() {
+		t.Fatalf("victim not quarantined after a failed integrity check")
+	}
+	// Quarantined: a later pass skips it, so one damaged segment cannot stall
+	// reclamation for the rest of the shard.
+	if res, err := s.GC(ctx, GCOptions{Force: true}); err != nil || res.SegmentsRepacked != 0 {
+		t.Fatalf("second GC pass: err=%v res=%+v, want a clean no-op", err, res)
+	}
+}
+
+// TestRepackRefusesRecordFramingAnotherFile asserts the repack checks which file
+// a record frames, not just its CRCs. Neither CRC covers the FileID bytes, so a
+// flipped FileID leaves the record stream fully scannable and would otherwise
+// copy one file's payload forward under another file's identity.
+func TestRepackRefusesRecordFramingAnotherFile(t *testing.T) {
+	s := testStore(t, Config{SegmentSize: minSegmentSize, ShardCount: 1})
+	ctx := context.Background()
+	seedRepackable(t, s)
+
+	victim := onlySealed(t, s, "keep")
+	iv := firstInterval(t, s, "keep")
+	flipSegByte(t, s, iv.loc.SegmentID, iv.recOff+recordHeaderSize) // first FileID byte
+	segsBefore := segFileCount(t, s)
+
+	res, err := s.GC(ctx, GCOptions{Force: true})
+	if !errors.Is(err, errTornRecord) {
+		t.Fatalf("GC must refuse a record framing another file, got err=%v res=%+v", err, res)
+	}
+	if n := segFileCount(t, s); n != segsBefore {
+		t.Fatalf("segment count %d, want %d (target not cleaned up)", n, segsBefore)
+	}
+	if !victim.corrupt.Load() {
+		t.Fatalf("victim not quarantined after a failed integrity check")
+	}
+}


### PR DESCRIPTION
Relates to #1912

## Problem

Three paths copied a journal record's payload forward with a raw, unverified pread and then re-hashed or re-CRC'd the copy. None of them *cause* corruption — they **promote already-corrupt bytes to trusted**, which is worse: the promoted copy becomes authoritative and passes every downstream integrity check.

1. **Carve upload** (`carve.go` `runReader.Read`) — BLAKE3-hashes the bytes and commits them to the remote store. Latent local bit rot becomes permanent content-addressed remote data that matches its own hash.
2. **GC repack** (`reclaim.go` `repackSegment`) — copies victim payload into a new segment, where `writeDataRecord` stamps a **fresh valid CRC** over the rotted bytes.
3. **Snapshot restore** (`store.go` `RestoreToVersion`) — re-materializes bytes as fresh records the same way. Not in the original report; found while grepping the other callers.

The store already had the right machinery and the read path already used it (`verifiedRead`, gated on `SetVerifyReads`, which production enables for non-writeback shares). So the read path failed closed while these three laundered.

`victimMarkers` had a related hole: `scanValidRecords` stops at the first bad record, so every tombstone and truncate marker behind it was silently dropped — a delete or size-down would come back to life once the victim was reclaimed.

## Fix

One shared primitive in `record.go`, reused by all four sites rather than hand-rolled per call site:

- `readVerifiedRecord` — header CRC + payload CRC + framed-FileID check. The FileID check matters because neither CRC covers those bytes, so a flipped FileID (or a stale `recOff`) otherwise passes and hands back another file's payload.
- `record.payloadRange` — bounds-checked slice of the verified payload by absolute segment offset.

`verifiedRead` was refactored onto the same primitive (identical semantics, less duplication), and `segment.go`'s unverified `readPayload` is deleted rather than left as a footgun.

## Failure policy, per site

The two sites need different answers:

- **Carve**: fail the run. The bytes stay dirty and local, nothing is uploaded, and the record's synced bit is not flipped. There is no remote copy to heal from for never-uploaded data, so loud failure is the only correct outcome — and the state stays recoverable.
- **GC repack**: keep the victim intact and abort. Silently dropping a victim's payload is unacceptable, and so is copying it forward under a fresh CRC. The victim is then quarantined via an in-memory `segmentMeta.corrupt` flag that `pickVictim` skips, so one damaged segment surfaces once instead of wedging reclamation for the whole shard (which would turn a data-integrity alarm into a disk-full outage).

## Cost

`BenchmarkCarve` (8 MiB, 6 runs, medians): **~9.9 ms/op → ~11.9 ms/op**, roughly **20% slower** carve throughput. The cost is a CRC32C pass plus one copy out of the verified record buffer instead of a pread straight into the chunker's buffer — you cannot trust any byte of a record until you have read all of it. Repack pays the same CRC pass, plus read amplification when only a fragment of a record is still live. Stated trade, not an accident: promoting corrupt bytes to authoritative is not worth 20%.

## Tests

`verify_copy_test.go` injects **real corruption** — byte flips written into the segment file through a separate fd — and asserts on the production entry points (`Carve`, `GC`), not internals:

- `TestCarveRefusesCorruptedRecord` — payload flip; asserts `*CorruptRangeError`, **zero bytes reaching the sink**, unsynced count unchanged, synced bit not flipped.
- `TestRepackRefusesTruncatedRecordStream` — payload flip; asserts GC refuses, victim survives, no orphan target segment, victim quarantined, and a second pass is a clean no-op.
- `TestRepackRefusesRecordFramingAnotherFile` — FileID flip. Distinct path: the record stream stays fully scannable (CRCs don't cover the FileID), so this exercises the move-loop check rather than the marker scan.

All three were confirmed to **fail against pre-fix source** (`SegmentsRepacked:1` and `err=<nil>` where the fix now errors), so they are not tautological.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` clean; `go test ./pkg/block/...` and `go test -race ./pkg/block/journal/...` green.
