### PR TITLE
fix(metadata): scope durable-handle FileID lookups to a single handle

### DIFF
--- a/pkg/metadata/store/badger/durable_fileid_index_test.go
+++ b/pkg/metadata/store/badger/durable_fileid_index_test.go
@@ -1,0 +1,150 @@
+package badger
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	badgerdb "github.com/dgraph-io/badger/v4"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+func newDurableStoreForTest(t *testing.T) *badgerDurableStore {
+	t.Helper()
+
+	db, err := badgerdb.Open(badgerdb.DefaultOptions(t.TempDir()).WithLogger(nil))
+	if err != nil {
+		t.Fatalf("open badger: %v", err)
+	}
+	t.Cleanup(func() {
+		if cErr := db.Close(); cErr != nil {
+			t.Fatalf("close badger: %v", cErr)
+		}
+	})
+
+	return newBadgerDurableStore(db)
+}
+
+func durableHandleForFile(id string, fileID [16]byte) *lock.PersistedDurableHandle {
+	var createGuid [16]byte
+	copy(createGuid[:], "cguid-"+id)
+
+	return &lock.PersistedDurableHandle{
+		ID:             id,
+		FileID:         fileID,
+		Path:           "/" + id,
+		ShareName:      "/export",
+		MetadataHandle: []byte("mh-" + id),
+		CreateGuid:     createGuid,
+	}
+}
+
+// seedLegacyFileIDIndex writes the unsuffixed FileID index entry an older store
+// would have written, alongside a primary record the store itself wrote.
+func seedLegacyFileIDIndex(t *testing.T, s *badgerDurableStore, handle *lock.PersistedDurableHandle) {
+	t.Helper()
+
+	data, err := json.Marshal(handle)
+	if err != nil {
+		t.Fatalf("marshal handle: %v", err)
+	}
+
+	err = s.db.Update(func(txn *badgerdb.Txn) error {
+		if err := txn.Set([]byte(prefixDHID+handle.ID), data); err != nil {
+			return err
+		}
+		return txn.Set(fileIDIndexScanPrefix(handle.FileID), []byte(handle.ID))
+	})
+	if err != nil {
+		t.Fatalf("seed legacy index: %v", err)
+	}
+}
+
+func legacyFileIDIndexOwner(t *testing.T, s *badgerDurableStore, fileID [16]byte) (string, bool) {
+	t.Helper()
+
+	var owner string
+	var present bool
+	err := s.db.View(func(txn *badgerdb.Txn) error {
+		item, err := txn.Get(fileIDIndexScanPrefix(fileID))
+		if err == badgerdb.ErrKeyNotFound {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		val, err := item.ValueCopy(nil)
+		if err != nil {
+			return err
+		}
+		owner, present = string(val), true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("read legacy index: %v", err)
+	}
+	return owner, present
+}
+
+// TestLegacyFileIDIndexIsReadable checks that a FileID entry written before the
+// per-handle suffix existed still resolves through the current lookup path.
+func TestLegacyFileIDIndexIsReadable(t *testing.T) {
+	s := newDurableStoreForTest(t)
+	ctx := context.Background()
+
+	var fileID [16]byte
+	copy(fileID[:], "legacy-file-0001")
+	legacy := durableHandleForFile("legacy-handle", fileID)
+	seedLegacyFileIDIndex(t, s, legacy)
+
+	got, err := s.GetDurableHandleByFileID(ctx, fileID)
+	if err != nil {
+		t.Fatalf("GetDurableHandleByFileID() error: %v", err)
+	}
+	if got == nil || got.ID != legacy.ID {
+		t.Fatalf("legacy FileID entry did not resolve, got %+v", got)
+	}
+}
+
+// TestLegacyFileIDIndexClearedWithItsOwner checks that deleting the handle a
+// legacy entry names removes the entry, while deleting an unrelated handle on
+// the same file leaves it in place.
+func TestLegacyFileIDIndexClearedWithItsOwner(t *testing.T) {
+	s := newDurableStoreForTest(t)
+	ctx := context.Background()
+
+	var fileID [16]byte
+	copy(fileID[:], "legacy-file-0002")
+
+	legacy := durableHandleForFile("legacy-owner", fileID)
+	seedLegacyFileIDIndex(t, s, legacy)
+
+	current := durableHandleForFile("current-handle", fileID)
+	if err := s.PutDurableHandle(ctx, current); err != nil {
+		t.Fatalf("PutDurableHandle() error: %v", err)
+	}
+
+	if err := s.DeleteDurableHandle(ctx, current.ID); err != nil {
+		t.Fatalf("DeleteDurableHandle(current) error: %v", err)
+	}
+	owner, present := legacyFileIDIndexOwner(t, s, fileID)
+	if !present || owner != legacy.ID {
+		t.Fatalf("legacy entry lost when an unrelated handle was deleted (present=%v owner=%q)", present, owner)
+	}
+
+	if err := s.DeleteDurableHandle(ctx, legacy.ID); err != nil {
+		t.Fatalf("DeleteDurableHandle(legacy) error: %v", err)
+	}
+	if _, present := legacyFileIDIndexOwner(t, s, fileID); present {
+		t.Fatal("legacy entry survived deletion of the handle it names")
+	}
+
+	got, err := s.GetDurableHandleByFileID(ctx, fileID)
+	if err != nil {
+		t.Fatalf("GetDurableHandleByFileID() error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("FileID lookup resolves after both handles were deleted: %+v", got)
+	}
+}

--- a/pkg/metadata/store/badger/durable_handles.go
+++ b/pkg/metadata/store/badger/durable_handles.go
@@ -23,7 +23,7 @@ const (
 	// Index by AppInstanceId: dh:appid:{hex}:{id} -> id (string)
 	prefixDHAppInstanceId = "dh:appid:"
 
-	// Index by FileID: dh:fid:{hex} -> id (string)
+	// Index by FileID: dh:fid:{hex}:{id} -> id (string)
 	prefixDHFileID = "dh:fid:"
 
 	// Index by FileHandle: dh:fh:{hex}:{id} -> id (string)
@@ -56,6 +56,21 @@ func hexEncodeBytes(b []byte) string {
 }
 
 var zeroGUID [16]byte
+
+// fileIDIndexScanPrefix returns the prefix covering every FileID index entry
+// for a file. A file can hold several durable handles at once, so entries are
+// written one per handle under a ":{id}" suffix. Stores written before the
+// suffix existed hold a single unsuffixed entry per FileID; because the hex
+// encoding is a fixed 32 characters, that entry sorts under the same prefix and
+// is picked up by the same scan.
+func fileIDIndexScanPrefix(fileID [16]byte) []byte {
+	return []byte(prefixDHFileID + hexEncode16(fileID))
+}
+
+// fileIDIndexKey returns the FileID index key owned by a single handle.
+func fileIDIndexKey(fileID [16]byte, id string) []byte {
+	return []byte(prefixDHFileID + hexEncode16(fileID) + ":" + id)
+}
 
 func (s *badgerDurableStore) PutDurableHandle(ctx context.Context, handle *lock.PersistedDurableHandle) error {
 	if err := ctx.Err(); err != nil {
@@ -96,8 +111,7 @@ func (s *badgerDurableStore) putDurableHandleTx(txn *badgerdb.Txn, handle *lock.
 		return err
 	}
 
-	fidKey := []byte(prefixDHFileID + hexEncode16(handle.FileID))
-	if err := txn.Set(fidKey, []byte(handle.ID)); err != nil {
+	if err := txn.Set(fileIDIndexKey(handle.FileID, handle.ID), []byte(handle.ID)); err != nil {
 		return err
 	}
 
@@ -131,9 +145,29 @@ func (s *badgerDurableStore) putDurableHandleTx(txn *badgerdb.Txn, handle *lock.
 }
 
 func (s *badgerDurableStore) deleteIndicesTx(txn *badgerdb.Txn, handle *lock.PersistedDurableHandle) error {
-	fidKey := []byte(prefixDHFileID + hexEncode16(handle.FileID))
-	if err := txn.Delete(fidKey); err != nil && err != badgerdb.ErrKeyNotFound {
+	if err := txn.Delete(fileIDIndexKey(handle.FileID, handle.ID)); err != nil && err != badgerdb.ErrKeyNotFound {
 		return err
+	}
+
+	// An unsuffixed FileID entry left by an older store holds one id for the
+	// whole file, so it may belong to a sibling handle that is still live.
+	// Drop it only when it names this handle; the same transaction removes the
+	// primary record, so the two never diverge.
+	legacyKey := fileIDIndexScanPrefix(handle.FileID)
+	legacyItem, err := txn.Get(legacyKey)
+	if err != nil && err != badgerdb.ErrKeyNotFound {
+		return err
+	}
+	if err == nil {
+		owner, err := legacyItem.ValueCopy(nil)
+		if err != nil {
+			return err
+		}
+		if string(owner) == handle.ID {
+			if err := txn.Delete(legacyKey); err != nil {
+				return err
+			}
+		}
 	}
 
 	if handle.CreateGuid != zeroGUID {
@@ -239,7 +273,7 @@ func (s *badgerDurableStore) GetDurableHandleByFileID(ctx context.Context, fileI
 
 	err := s.db.View(func(txn *badgerdb.Txn) error {
 		var err error
-		handle, err = s.getHandleByIndex(txn, []byte(prefixDHFileID+hexEncode16(fileID)))
+		handle, err = s.firstHandleByPrefix(txn, fileIDIndexScanPrefix(fileID))
 		return err
 	})
 
@@ -280,51 +314,69 @@ func (s *badgerDurableStore) getHandlesByPrefix(txn *badgerdb.Txn, prefix []byte
 
 	var result []*lock.PersistedDurableHandle
 	for it.Rewind(); it.Valid(); it.Next() {
-		var id string
-		err := it.Item().Value(func(val []byte) error {
-			id = string(val)
-			return nil
-		})
+		handle, err := s.resolveIndexEntry(txn, it.Item())
 		if err != nil {
 			return nil, err
 		}
-
-		primaryItem, err := txn.Get([]byte(prefixDHID + id))
-		if err == badgerdb.ErrKeyNotFound {
+		if handle == nil {
 			continue // Stale index
 		}
-		if err != nil {
-			return nil, err
-		}
-
-		var handle lock.PersistedDurableHandle
-		err = primaryItem.Value(func(val []byte) error {
-			return json.Unmarshal(val, &handle)
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		result = append(result, &handle)
+		result = append(result, handle)
 	}
 
 	return result, nil
 }
 
-// consumeByIndexTx fetches the handle referenced by indexKey, deletes the
-// primary record and all secondary indices in the same transaction, and
-// returns the previous record (or nil if no match). Used by Consume* APIs to
-// close the V1/V2 reconnect TOCTOU window.
-func (s *badgerDurableStore) consumeByIndexTx(txn *badgerdb.Txn, indexKey []byte) (*lock.PersistedDurableHandle, error) {
-	handle, err := s.getHandleByIndex(txn, indexKey)
-	if err != nil || handle == nil {
+// resolveIndexEntry loads the primary record named by a secondary index entry,
+// returning nil when the entry is stale.
+func (s *badgerDurableStore) resolveIndexEntry(txn *badgerdb.Txn, item *badgerdb.Item) (*lock.PersistedDurableHandle, error) {
+	var id string
+	if err := item.Value(func(val []byte) error {
+		id = string(val)
+		return nil
+	}); err != nil {
 		return nil, err
 	}
 
-	if err := s.deleteDurableHandleTx(txn, handle.ID); err != nil {
+	primaryItem, err := txn.Get([]byte(prefixDHID + id))
+	if err == badgerdb.ErrKeyNotFound {
+		return nil, nil
+	}
+	if err != nil {
 		return nil, err
 	}
-	return handle, nil
+
+	var handle lock.PersistedDurableHandle
+	if err := primaryItem.Value(func(val []byte) error {
+		return json.Unmarshal(val, &handle)
+	}); err != nil {
+		return nil, err
+	}
+	return &handle, nil
+}
+
+// firstHandleByPrefix returns the lowest-keyed live handle under a secondary
+// index prefix, or nil when the prefix resolves to nothing. Badger iterates in
+// key order, so the first entry that still resolves is that handle and the scan
+// stops there rather than reading the rest of the file's entries.
+func (s *badgerDurableStore) firstHandleByPrefix(txn *badgerdb.Txn, prefix []byte) (*lock.PersistedDurableHandle, error) {
+	opts := badgerdb.DefaultIteratorOptions
+	opts.Prefix = prefix
+	opts.PrefetchValues = true
+
+	it := txn.NewIterator(opts)
+	defer it.Close()
+
+	for it.Rewind(); it.Valid(); it.Next() {
+		handle, err := s.resolveIndexEntry(txn, it.Item())
+		if err != nil {
+			return nil, err
+		}
+		if handle != nil {
+			return handle, nil
+		}
+	}
+	return nil, nil
 }
 
 func (s *badgerDurableStore) ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
@@ -334,9 +386,15 @@ func (s *badgerDurableStore) ConsumeDurableHandleByFileID(ctx context.Context, f
 
 	var handle *lock.PersistedDurableHandle
 	err := s.db.Update(func(txn *badgerdb.Txn) error {
-		var err error
-		handle, err = s.consumeByIndexTx(txn, []byte(prefixDHFileID+hexEncode16(fileID)))
-		return err
+		found, err := s.firstHandleByPrefix(txn, fileIDIndexScanPrefix(fileID))
+		if err != nil || found == nil {
+			return err
+		}
+		if err := s.deleteDurableHandleTx(txn, found.ID); err != nil {
+			return err
+		}
+		handle = found
+		return nil
 	})
 	if err != nil {
 		return nil, err
@@ -351,9 +409,15 @@ func (s *badgerDurableStore) ConsumeDurableHandleByCreateGuid(ctx context.Contex
 
 	var handle *lock.PersistedDurableHandle
 	err := s.db.Update(func(txn *badgerdb.Txn) error {
-		var err error
-		handle, err = s.consumeByIndexTx(txn, []byte(prefixDHCreateGuid+hexEncode16(createGuid)))
-		return err
+		found, err := s.getHandleByIndex(txn, []byte(prefixDHCreateGuid+hexEncode16(createGuid)))
+		if err != nil || found == nil {
+			return err
+		}
+		if err := s.deleteDurableHandleTx(txn, found.ID); err != nil {
+			return err
+		}
+		handle = found
+		return nil
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/metadata/store/memory/durable_handles.go
+++ b/pkg/metadata/store/memory/durable_handles.go
@@ -64,13 +64,25 @@ func (s *memoryDurableStore) GetDurableHandleByFileID(ctx context.Context, fileI
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
+	handle := s.lowestHandleForFileID(fileID)
+	if handle == nil {
+		return nil, nil
+	}
+	return cloneDurableHandle(handle), nil
+}
+
+// lowestHandleForFileID returns the handle with the smallest ID among those
+// held on a file, or nil when the file holds none. A file can carry several
+// durable handles at once, so Get and Consume pick by ID rather than by map
+// order to agree on which one they mean. Callers hold the lock.
+func (s *memoryDurableStore) lowestHandleForFileID(fileID [16]byte) *lock.PersistedDurableHandle {
+	var lowest *lock.PersistedDurableHandle
 	for _, handle := range s.handles {
-		if handle.FileID == fileID {
-			return cloneDurableHandle(handle), nil
+		if handle.FileID == fileID && (lowest == nil || handle.ID < lowest.ID) {
+			lowest = handle
 		}
 	}
-
-	return nil, nil
+	return lowest
 }
 
 func (s *memoryDurableStore) GetDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
@@ -107,14 +119,12 @@ func (s *memoryDurableStore) ConsumeDurableHandleByFileID(ctx context.Context, f
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	for id, handle := range s.handles {
-		if handle.FileID == fileID {
-			delete(s.handles, id)
-			return cloneDurableHandle(handle), nil
-		}
+	handle := s.lowestHandleForFileID(fileID)
+	if handle == nil {
+		return nil, nil
 	}
-
-	return nil, nil
+	delete(s.handles, handle.ID)
+	return cloneDurableHandle(handle), nil
 }
 
 func (s *memoryDurableStore) ConsumeDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {

--- a/pkg/metadata/store/postgres/durable_handles.go
+++ b/pkg/metadata/store/postgres/durable_handles.go
@@ -293,7 +293,7 @@ func (s *postgresDurableStore) GetDurableHandle(ctx context.Context, id string) 
 }
 
 func (s *postgresDurableStore) GetDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
-	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE file_id = $1 LIMIT 1`
+	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE file_id = $1 ORDER BY id LIMIT 1`
 	return scanDurableHandle(s.pool.QueryRow(ctx, query, fileID[:]))
 }
 
@@ -303,9 +303,12 @@ func (s *postgresDurableStore) GetDurableHandleByCreateGuid(ctx context.Context,
 }
 
 // ConsumeDurableHandleByFileID atomically fetches and deletes via
-// `DELETE ... RETURNING`, closing the V1 reconnect TOCTOU window.
+// `DELETE ... RETURNING`, closing the V1 reconnect TOCTOU window. A file can
+// hold several durable handles at once and DELETE takes no LIMIT, so the
+// subquery pins the delete to the single row being claimed and leaves the
+// file's other handles untouched.
 func (s *postgresDurableStore) ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
-	query := `DELETE FROM durable_handles WHERE file_id = $1 RETURNING ` + durableHandleColumns
+	query := `DELETE FROM durable_handles WHERE id = (SELECT id FROM durable_handles WHERE file_id = $1 ORDER BY id LIMIT 1) RETURNING ` + durableHandleColumns
 	return scanDurableHandle(s.pool.QueryRow(ctx, query, fileID[:]))
 }
 

--- a/pkg/metadata/store/postgres/migrations/000043_durable_handle_file_id_not_unique.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000043_durable_handle_file_id_not_unique.down.sql
@@ -1,0 +1,13 @@
+-- Restore the (broken) UNIQUE constraint. DDL copied from
+-- 000005_durable_handles.up.sql.
+--
+-- WARNING: this rollback FAILS whenever a file currently holds more than one
+-- durable handle — those rows are exactly what the unique index forbids, and
+-- they are legitimate state once multiple opens per file persist. The whole
+-- file runs as one implicit transaction, so the failure is atomic and the
+-- non-unique index stays in place; the schema is left usable, but the
+-- rollback does not complete until the duplicate rows are removed.
+-- Down only intended for migration tooling completeness; do NOT run on a
+-- live deployment.
+DROP INDEX IF EXISTS idx_durable_handles_file_id;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_durable_handles_file_id ON durable_handles(file_id);

--- a/pkg/metadata/store/postgres/migrations/000043_durable_handle_file_id_not_unique.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000043_durable_handle_file_id_not_unique.up.sql
@@ -1,0 +1,13 @@
+-- Drop the UNIQUE constraint on durable_handles.file_id.
+--
+-- file_id identifies the file, not the open: the volatile half is zeroed
+-- before it is stored, so every durable handle on a file carries the same
+-- value. A file held open more than once therefore needs one row per handle,
+-- which the original 000005 UNIQUE index rejected outright — the second open
+-- failed with "duplicate key value violates unique constraint" and never
+-- persisted its durable state.
+--
+-- Replaced with a plain index: the column is still the lookup key for
+-- reconnect, it just no longer claims to identify at most one row.
+DROP INDEX IF EXISTS idx_durable_handles_file_id;
+CREATE INDEX IF NOT EXISTS idx_durable_handles_file_id ON durable_handles(file_id);

--- a/pkg/metadata/store/sqlite/durable_handles.go
+++ b/pkg/metadata/store/sqlite/durable_handles.go
@@ -292,7 +292,7 @@ func (s *sqliteDurableStore) GetDurableHandle(ctx context.Context, id string) (*
 }
 
 func (s *sqliteDurableStore) GetDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
-	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE file_id = ?1 LIMIT 1`
+	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE file_id = ?1 ORDER BY id LIMIT 1`
 	return scanDurableHandle(s.pool.QueryRow(ctx, query, fileID[:]))
 }
 
@@ -302,9 +302,12 @@ func (s *sqliteDurableStore) GetDurableHandleByCreateGuid(ctx context.Context, c
 }
 
 // ConsumeDurableHandleByFileID atomically fetches and deletes via
-// `DELETE ... RETURNING`, closing the V1 reconnect TOCTOU window.
+// `DELETE ... RETURNING`, closing the V1 reconnect TOCTOU window. A file can
+// hold several durable handles at once and DELETE takes no LIMIT, so the
+// subquery pins the delete to the single row being claimed and leaves the
+// file's other handles untouched.
 func (s *sqliteDurableStore) ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
-	query := `DELETE FROM durable_handles WHERE file_id = ?1 RETURNING ` + durableHandleColumns
+	query := `DELETE FROM durable_handles WHERE id = (SELECT id FROM durable_handles WHERE file_id = ?1 ORDER BY id LIMIT 1) RETURNING ` + durableHandleColumns
 	return scanDurableHandle(s.pool.QueryRow(ctx, query, fileID[:]))
 }
 

--- a/pkg/metadata/storetest/durable_handles.go
+++ b/pkg/metadata/storetest/durable_handles.go
@@ -57,6 +57,14 @@ func RunDurableHandleStoreTests(t *testing.T, factory StoreFactory) {
 		testDurableGetByFileID(t, factory)
 	})
 
+	t.Run("DeleteKeepsSiblingOnSameFileID", func(t *testing.T) {
+		testDurableDeleteKeepsSiblingOnSameFileID(t, factory)
+	})
+
+	t.Run("ConsumeByFileIDKeepsSibling", func(t *testing.T) {
+		testDurableConsumeByFileIDKeepsSibling(t, factory)
+	})
+
 	t.Run("GetByCreateGuid", func(t *testing.T) {
 		testDurableGetByCreateGuid(t, factory)
 	})
@@ -374,6 +382,137 @@ func testDurableGetByFileID(t *testing.T, factory StoreFactory) {
 	}
 	if got != nil {
 		t.Fatalf("expected nil for non-existent FileID, got: %+v", got)
+	}
+}
+
+// testDurableDeleteKeepsSiblingOnSameFileID covers a file held open by more
+// than one durable handle. FileID identifies the file, not the open, so the
+// two handles share it; deleting one must leave the other retrievable both by
+// its own id and by FileID.
+func testDurableDeleteKeepsSiblingOnSameFileID(t *testing.T, factory StoreFactory) {
+	ds := getDurableStore(t, factory)
+	ctx := context.Background()
+
+	first := makeDurableHandle("same-fid-first", "/export")
+	second := makeDurableHandle("same-fid-second", "/export")
+	second.FileID = first.FileID
+
+	if err := ds.PutDurableHandle(ctx, first); err != nil {
+		t.Fatalf("PutDurableHandle(first) error: %v", err)
+	}
+	if err := ds.PutDurableHandle(ctx, second); err != nil {
+		t.Fatalf("PutDurableHandle(second) error: %v", err)
+	}
+
+	if err := ds.DeleteDurableHandle(ctx, first.ID); err != nil {
+		t.Fatalf("DeleteDurableHandle(first) error: %v", err)
+	}
+
+	got, err := ds.GetDurableHandle(ctx, second.ID)
+	if err != nil {
+		t.Fatalf("GetDurableHandle(second) error: %v", err)
+	}
+	assertDurableHandleEqual(t, second, got)
+
+	got, err = ds.GetDurableHandleByFileID(ctx, second.FileID)
+	if err != nil {
+		t.Fatalf("GetDurableHandleByFileID() error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("surviving handle is unreachable by FileID after its sibling was deleted")
+	}
+	assertDurableHandleEqual(t, second, got)
+
+	// The deleted handle must not come back through the FileID index.
+	got, err = ds.GetDurableHandle(ctx, first.ID)
+	if err != nil {
+		t.Fatalf("GetDurableHandle(first) error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("deleted handle still resolves: %+v", got)
+	}
+
+	// The reconnect path reaches the survivor too, not just the plain lookup.
+	consumed, err := ds.ConsumeDurableHandleByFileID(ctx, second.FileID)
+	if err != nil {
+		t.Fatalf("ConsumeDurableHandleByFileID() error: %v", err)
+	}
+	if consumed == nil {
+		t.Fatal("consume returned nil for the surviving handle")
+	}
+	assertDurableHandleEqual(t, second, consumed)
+}
+
+// testDurableConsumeByFileIDKeepsSibling covers a reconnect against a file that
+// carries two durable handles. Consume claims exactly one of them; the other
+// must survive as a complete record, since it still backs a live open.
+func testDurableConsumeByFileIDKeepsSibling(t *testing.T, factory StoreFactory) {
+	ds := getDurableStore(t, factory)
+	ctx := context.Background()
+
+	first := makeDurableHandle("cs-a", "/export")
+	second := makeDurableHandle("cs-b", "/export")
+	second.FileID = first.FileID
+
+	if err := ds.PutDurableHandle(ctx, first); err != nil {
+		t.Fatalf("PutDurableHandle(first) error: %v", err)
+	}
+	if err := ds.PutDurableHandle(ctx, second); err != nil {
+		t.Fatalf("PutDurableHandle(second) error: %v", err)
+	}
+
+	// A reconnect validates the handle Get reports and then claims one with
+	// Consume, so the two must name the same handle while both are present.
+	peeked, err := ds.GetDurableHandleByFileID(ctx, first.FileID)
+	if err != nil {
+		t.Fatalf("GetDurableHandleByFileID() error: %v", err)
+	}
+	if peeked == nil {
+		t.Fatal("FileID lookup returned nil while two handles exist for the FileID")
+	}
+
+	consumed, err := ds.ConsumeDurableHandleByFileID(ctx, first.FileID)
+	if err != nil {
+		t.Fatalf("ConsumeDurableHandleByFileID() error: %v", err)
+	}
+	if consumed == nil {
+		t.Fatal("consume returned nil while two handles exist for the FileID")
+	}
+	if consumed.ID != peeked.ID {
+		t.Fatalf("consume claimed %q but the FileID lookup reported %q; a reconnect would validate one handle and claim another", consumed.ID, peeked.ID)
+	}
+
+	survivor := second
+	if consumed.ID == second.ID {
+		survivor = first
+	}
+
+	got, err := ds.GetDurableHandle(ctx, survivor.ID)
+	if err != nil {
+		t.Fatalf("GetDurableHandle(survivor) error: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("consuming %q also destroyed sibling %q on the same FileID", consumed.ID, survivor.ID)
+	}
+	assertDurableHandleEqual(t, survivor, got)
+
+	// The survivor is still the answer for the FileID, so a later reconnect
+	// against the same file can still claim it.
+	got, err = ds.GetDurableHandleByFileID(ctx, survivor.FileID)
+	if err != nil {
+		t.Fatalf("GetDurableHandleByFileID() error: %v", err)
+	}
+	if got == nil || got.ID != survivor.ID {
+		t.Fatalf("FileID lookup after consume returned %+v, want %q", got, survivor.ID)
+	}
+
+	// The consumed handle is gone for good.
+	got, err = ds.GetDurableHandle(ctx, consumed.ID)
+	if err != nil {
+		t.Fatalf("GetDurableHandle(consumed) error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("consumed handle still resolves: %+v", got)
 	}
 }
 


### PR DESCRIPTION
Relates to #1915.

## Problem

`FileID` identifies the **file**, not the open — the volatile half is zeroed before it is stored. So a file held open twice carries two durable handles under the same `FileID`. Every store treated that as unique per file, in three different ways:

**badger** keyed the index as `dh:fid:{hex}` — one value for the whole file. A second handle's `Put` overwrote the first's entry; either handle's delete blind-removed the shared one. A **live** handle became unreachable by `FileID` while its record survived, so the client's durable reconnect silently falls back to a fresh open.

**sqlite / postgres** consumed with an unconstrained `DELETE ... WHERE file_id = ?1 RETURNING`. Neither dialect supports `LIMIT` on `DELETE`, so this deleted **every** row for the file while `QueryRow` read only the first — destroying the sibling's record outright, unrecoverable even by the TTL sweep. Postgres additionally declared `idx_durable_handles_file_id` **UNIQUE**, rejecting a legitimate second handle at insert.

**All three SQL/memory stores** also let `Get` and `Consume` disagree about *which* handle they mean (`Get` had no `ORDER BY`; memory used map order). The reconnect path validates the handle `Get` returns, then claims via `Consume` — so it could validate one handle and destroy another.

## Fix

- **badger** — entries written per handle as `dh:fid:{hex}:{id}`, read by prefix scan, the shape `dh:appid:` / `dh:fh:` / `dh:share:` already use. `firstHandleByPrefix` stops at the first live entry instead of materializing all of them.
- **sqlite / postgres** — the consume `DELETE` pins to one row via `id = (SELECT id ... ORDER BY id LIMIT 1)`; `GetDurableHandleByFileID` gained `ORDER BY id` so Get and Consume agree.
- **memory** — both paths select the lowest ID via `lowestHandleForFileID` instead of map order.
- **postgres migration 000043** — replaces the UNIQUE FileID index with a plain one.

## Upgrade path

**badger: read through, no migration.** `hexEncode16` always emits exactly 32 characters, so the scan prefix `dh:fid:{hex}` is unambiguous per FileID and also matches the single **unsuffixed** entry an older store wrote. Existing rows resolve unchanged — no startup scan, nothing to half-finish on a crash. The legacy entry is dropped only when its value names the handle being deleted, in the **same transaction** as the primary-record delete, so cleanup is crash-safe and idempotent. The bare key is a strict byte-prefix of every suffixed key, so it sorts first and wins the scan; if stale, `getHandlesByPrefix` skips it. At most one legacy entry per FileID and none are ever written again.

*Known limit:* a pair that already collided before the upgrade cannot be repaired — that entry was destroyed by the old code. The orphan is still reclaimed by `DeleteExpiredDurableHandles`, which scans `dh:id:` directly.

**postgres migration 000043.** Safe on a live database: the UNIQUE index it replaces made duplicate `file_id` rows impossible, so none can pre-exist. Nothing else depended on the uniqueness — the only upsert conflict target on this table is `id`, and no foreign key references `file_id`. Verified on Postgres 16: applies cleanly, is idempotent (`IF NOT EXISTS`), and a fresh-database run passes the full durable-handle suite.

The **down** migration recreates the UNIQUE index and therefore **fails** once a file legitimately holds more than one handle. Verified on a live database that this failure is **atomic** — the whole file runs as one implicit transaction, so the non-unique index survives and the schema stays usable. Documented in the file with the same WARNING framing `000011_file_blocks_hash_nonunique.down.sql` uses for the identical UNIQUE-to-plain rollback.

## Tests

Two conformance cases in `pkg/metadata/storetest/`, so all four backends are covered:

- `DeleteKeepsSiblingOnSameFileID` — two handles on one FileID, delete one; the other stays reachable by id *and* by FileID.
- `ConsumeByFileIDKeepsSibling` — Get and Consume must name the same handle, consume claims exactly one, the sibling survives intact.

Each fails on exactly the broken backends pre-fix:

```
BADGER    FAIL DeleteKeepsSiblingOnSameFileID
               surviving handle is unreachable by FileID after its sibling was deleted
          FAIL (also under TestConformance_RelaxedDurability)
SQLITE    FAIL ConsumeByFileIDKeepsSibling
               consuming "cs-a" also destroyed sibling "cs-b" on the same FileID
MEMORY    FAIL ConsumeByFileIDKeepsSibling  (5/20 runs, map-order dependent)
               consume claimed X but the FileID lookup reported Y
```

Badger-level tests (`durable_fileid_index_test.go`) seed a raw legacy `dh:fid:{hex}` row and assert it still resolves, survives deletion of an unrelated handle on the same file, and is removed with the handle it names.

Post-fix:

```
go build ./... && go vet ./... && gofmt -l .        # clean
go test ./pkg/metadata/...                          # all ok
go test -race ./pkg/metadata/store/badger/...       # ok  71.0s
go test ./internal/adapter/smb/...                  # all 12 packages ok
go test -tags integration ./pkg/metadata/store/postgres/   # ok (live PG 16, fresh DB)
```

## Interaction with #1908

The disconnected-handle counter reads `GetDurableHandlesByFileHandle` (the `dh:fh:{hex}:{id}` index, already per-handle scoped) and `ListDurableHandles` — **not** the FileID index. Verified unaffected.

## Known, not addressed here

`GetDurableHandleByFileID` and `ConsumeDurableHandleByFileID` are two separate calls in the reconnect path, so they are consistent but not atomic: if a sibling handle is inserted or removed in the window between them they can still diverge. Pre-existing in the reconnect design, and only reachable at all now that multiple handles per file can persist. Worth its own issue rather than widening this one.