### PR TITLE
fix(s3): enforce the endpoint safety check on every dial, not just at config time

### DIFF
--- a/pkg/block/remote/s3/ssrf_test.go
+++ b/pkg/block/remote/s3/ssrf_test.go
@@ -2,8 +2,162 @@ package s3
 
 import (
 	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
 	"testing"
 )
+
+// localhostURL rewrites a test server's URL to reach it through the DNS name
+// "localhost" instead of the loopback literal it binds, so the dial is driven
+// by name resolution rather than by a literal address in the URL.
+func localhostURL(t *testing.T, srv *httptest.Server) string {
+	t.Helper()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse %q: %v", srv.URL, err)
+	}
+	u.Host = net.JoinHostPort("localhost", u.Port())
+	return u.String()
+}
+
+// TestDialGuard_RefusesNameResolvingToBlockedAddress covers the DNS-rebinding
+// bypass: the guard must act on the address actually being connected to, not
+// on whatever the endpoint resolved to when the config was checked. The server
+// is real and reachable, so without the dial guard this request succeeds.
+func TestDialGuard_RefusesNameResolvingToBlockedAddress(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	resp, err := newHTTPClient(false).Get(localhostURL(t, srv))
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("dial to a name resolving to loopback succeeded, want refusal")
+	}
+	if !errors.Is(err, ErrUnsafeEndpoint) {
+		t.Fatalf("want ErrUnsafeEndpoint, got %v", err)
+	}
+}
+
+// TestDialGuard_EscapeHatchAllowsPrivate verifies the allow_private_endpoint
+// opt-out still reaches a private/loopback object store (MinIO, Localstack),
+// and doubles as the proof that the guarded client can complete a real
+// connection end to end rather than refusing everything.
+func TestDialGuard_EscapeHatchAllowsPrivate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	resp, err := newHTTPClient(true).Get(localhostURL(t, srv))
+	if err != nil {
+		t.Fatalf("allow_private_endpoint dial: want success, got %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", resp.StatusCode)
+	}
+}
+
+// TestRedirect_NotFollowed covers the redirect-follow bypass. The client runs
+// with the private opt-out enabled, so the dial guard would happily connect to
+// the redirect target; only the redirect policy stops it. The target counts
+// its own hits, so the refusal is proven by the target never being contacted
+// rather than by the shape of an error.
+func TestRedirect_NotFollowed(t *testing.T) {
+	// Counted atomically: the handler runs on the server's goroutine, and a
+	// followed redirect must fail the assertion below rather than the race
+	// detector.
+	var targetHits atomic.Int64
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		targetHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	resp, err := newHTTPClient(true).Get(redirector.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if hits := targetHits.Load(); hits != 0 {
+		t.Fatalf("redirect target was contacted %d time(s), want 0", hits)
+	}
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("status: want the 302 surfaced to the caller, got %d", resp.StatusCode)
+	}
+}
+
+// TestCheckDialAddress verifies the guard's verdict on the addresses a dial can
+// present, including the IPv4-mapped IPv6 forms that report false for every
+// IPv4 classification unless they are unmapped first.
+func TestCheckDialAddress(t *testing.T) {
+	cases := []struct {
+		name         string
+		address      string
+		allowPrivate bool
+		wantErr      bool
+	}{
+		{"metadata", "169.254.169.254:80", false, true},
+		{"metadata_allow_private", "169.254.169.254:80", true, true},
+		{"metadata_v4_mapped", "[::ffff:169.254.169.254]:80", false, true},
+		{"metadata_v4_mapped_allow_private", "[::ffff:169.254.169.254]:80", true, true},
+		{"loopback_v4_mapped", "[::ffff:127.0.0.1]:9000", false, true},
+		{"private_v4_mapped", "[::ffff:10.0.0.5]:9000", false, true},
+		{"link_local_v6", "[fe80::1]:9000", false, true},
+		{"unique_local_v6", "[fc00::1]:9000", false, true},
+		{"loopback_v6", "[::1]:9000", false, true},
+		{"loopback", "127.0.0.1:9000", false, true},
+		{"private_10", "10.0.0.5:9000", false, true},
+		{"private_172", "172.16.3.4:9000", false, true},
+		{"private_192", "192.168.1.10:9000", false, true},
+		{"unspecified", "0.0.0.0:9000", false, true},
+		{"shared_address_space", "100.64.0.1:9000", false, true},
+		{"shared_address_space_upper", "100.127.255.254:9000", false, true},
+		{"shared_address_space_allow_private", "100.64.0.1:9000", true, false},
+		// 100.0.0.0/10 and 100.128.0.0/10 sit outside the shared range and
+		// stay reachable.
+		{"public_100_below", "100.63.255.255:9000", false, false},
+		{"public_100_above", "100.128.0.1:9000", false, false},
+		{"this_network", "0.1.2.3:9000", false, true},
+		{"this_network_allow_private", "0.1.2.3:9000", true, true},
+		// The escape hatch relaxes private space, never the metadata range.
+		{"loopback_allow_private", "127.0.0.1:9000", true, false},
+		{"private_allow_private", "10.0.0.5:9000", true, false},
+		{"unique_local_v6_allow_private", "[fc00::1]:9000", true, false},
+		// Public endpoints connect as before.
+		{"public_v4", "93.184.216.34:443", false, false},
+		{"public_v6", "[2606:2800:220:1:248:1893:25c8:1946]:443", false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkDialAddress(tc.address, tc.allowPrivate)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("checkDialAddress(%q, allowPrivate=%v): want error, got nil", tc.address, tc.allowPrivate)
+				}
+				if !errors.Is(err, ErrUnsafeEndpoint) {
+					t.Fatalf("checkDialAddress(%q): want ErrUnsafeEndpoint, got %v", tc.address, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("checkDialAddress(%q, allowPrivate=%v): want nil, got %v", tc.address, tc.allowPrivate, err)
+			}
+		})
+	}
+}
 
 // TestValidateEndpoint_SSRF verifies the endpoint guard rejects the cloud
 // metadata endpoint, loopback, link-local, and private/internal hosts while
@@ -20,6 +174,11 @@ func TestValidateEndpoint_SSRF(t *testing.T) {
 		// private opt-out, since 169.254.169.254 is link-local.
 		{"metadata_ip", "http://169.254.169.254/latest/meta-data", false, true},
 		{"metadata_ip_allow_private", "http://169.254.169.254/latest/meta-data", true, true},
+		// The same addresses written in IPv4-mapped IPv6 form, which classify
+		// as neither link-local nor loopback unless they are unmapped first.
+		{"metadata_ip_v4_mapped", "http://[::ffff:169.254.169.254]", false, true},
+		{"metadata_ip_v4_mapped_allow_private", "http://[::ffff:169.254.169.254]", true, true},
+		{"loopback_v4_mapped", "http://[::ffff:127.0.0.1]:9000", false, true},
 		{"link_local_v6", "http://[fe80::1]:9000", false, true},
 		{"loopback", "http://127.0.0.1:9000", false, true},
 		{"loopback_v6", "http://[::1]:9000", false, true},

--- a/pkg/block/remote/s3/store.go
+++ b/pkg/block/remote/s3/store.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -86,6 +87,12 @@ type Config struct {
 
 	// ForcePathStyle forces path-style addressing (required for Localstack/MinIO).
 	ForcePathStyle bool
+
+	// AllowPrivate permits endpoints that resolve to loopback or
+	// private/internal addresses (MinIO, Localstack, a co-located RGW). It
+	// relaxes the same set ValidateEndpoint relaxes, both at config-check time
+	// and on every dial; link-local (cloud metadata) stays refused either way.
+	AllowPrivate bool
 }
 
 // Store is an S3-backed implementation of remote.RemoteStore.
@@ -146,39 +153,7 @@ func NewFromConfig(ctx context.Context, config Config) (*Store, error) {
 		credentials.NewStaticCredentialsProvider(config.AccessKey, config.SecretKey, ""),
 	))
 
-	// Configure HTTP client for parallel uploads. The pool must not cap the
-	// syncer's upload window below its ceiling, or it becomes the hidden
-	// bottleneck: the adaptive controller ramps to engine.AdaptiveUploadCeiling
-	// (64) and downloads run concurrently on the same host, so size for both
-	// (128 conns x ~512KB buffers ≈ 64MB worst case, created on demand). A
-	// pinned --parallel-uploads above this still caps here (#1407 follow-up).
-	httpTransport := &http.Transport{
-		MaxIdleConns:        maxS3ConnsPerHost,
-		MaxIdleConnsPerHost: maxS3ConnsPerHost,
-		MaxConnsPerHost:     maxS3ConnsPerHost,
-		IdleConnTimeout:     90 * time.Second,
-		ForceAttemptHTTP2:   false,
-		TLSNextProto:        make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		TLSHandshakeTimeout: 10 * time.Second,
-		TLSClientConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
-			NextProtos: []string{"http/1.1"},
-		},
-		WriteBufferSize:       256 * 1024,
-		ReadBufferSize:        256 * 1024,
-		ExpectContinueTimeout: 0,
-		ResponseHeaderTimeout: 60 * time.Second,
-	}
-
-	httpClient := &http.Client{
-		Transport: httpTransport,
-		Timeout:   s3HTTPRequestTimeout,
-	}
-	opts = append(opts, awsconfig.WithHTTPClient(httpClient))
+	opts = append(opts, awsconfig.WithHTTPClient(newHTTPClient(config.AllowPrivate)))
 
 	maxAttempts := config.MaxRetries
 	if maxAttempts <= 0 {
@@ -231,6 +206,57 @@ func NewFromConfig(ctx context.Context, config Config) (*Store, error) {
 	client := s3.NewFromConfig(awsCfg, s3Opts...)
 
 	return New(client, config), nil
+}
+
+// newHTTPClient builds the HTTP client the S3 SDK issues every request
+// through. It sizes the connection pool for parallel uploads: the pool must
+// not cap the syncer's upload window below its ceiling, or it becomes the
+// hidden bottleneck, since the adaptive controller ramps to
+// engine.AdaptiveUploadCeiling (64) and downloads run concurrently on the same
+// host, so it is sized for both (128 conns x ~512KB buffers ≈ 64MB worst case,
+// created on demand). A pinned --parallel-uploads above this still caps here.
+//
+// It also carries the two runtime halves of the endpoint guard: a dial-time
+// address check and a refusal to follow redirects. allowPrivate relaxes the
+// same private/loopback space ValidateEndpoint relaxes; link-local stays
+// refused either way.
+func newHTTPClient(allowPrivate bool) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			MaxIdleConns:        maxS3ConnsPerHost,
+			MaxIdleConnsPerHost: maxS3ConnsPerHost,
+			MaxConnsPerHost:     maxS3ConnsPerHost,
+			IdleConnTimeout:     90 * time.Second,
+			ForceAttemptHTTP2:   false,
+			TLSNextProto:        make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+				// No proxy is configured on this transport, so every
+				// socket the SDK opens passes through this hook.
+				Control: func(_, address string, _ syscall.RawConn) error {
+					return checkDialAddress(address, allowPrivate)
+				},
+			}).DialContext,
+			TLSHandshakeTimeout: 10 * time.Second,
+			TLSClientConfig: &tls.Config{
+				MinVersion: tls.VersionTLS12,
+				NextProtos: []string{"http/1.1"},
+			},
+			WriteBufferSize:       256 * 1024,
+			ReadBufferSize:        256 * 1024,
+			ExpectContinueTimeout: 0,
+			ResponseHeaderTimeout: 60 * time.Second,
+		},
+		Timeout: s3HTTPRequestTimeout,
+		// Never follow a redirect: it would walk the client to a host no
+		// guard has vetted. Handing the 3xx back to the SDK instead of
+		// returning an error keeps a wrong-region PermanentRedirect body
+		// readable as the diagnostic it is.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 }
 
 // normalizeEndpoint prepends https:// when the endpoint does not already
@@ -312,7 +338,7 @@ func ValidateEndpoint(endpoint string, allowPrivate bool) error {
 		}
 		for _, ipa := range resolved {
 			if a, ok := netip.AddrFromSlice(ipa.IP); ok {
-				ips = append(ips, a.Unmap())
+				ips = append(ips, a)
 			}
 		}
 	}
@@ -327,11 +353,34 @@ func ValidateEndpoint(endpoint string, allowPrivate bool) error {
 	return nil
 }
 
+// checkDialAddress rejects a "host:port" the transport is about to connect to
+// when the host part is an address unsafe to dial. It is the runtime half of
+// the endpoint guard: the address here is already resolved, so a hostname that
+// answers with a safe address at config-check time and an internal one at
+// connect time is caught, and every candidate the resolver returned is
+// checked, not just the first.
+func checkDialAddress(address string, allowPrivate bool) error {
+	addrPort, err := netip.ParseAddrPort(address)
+	if err != nil {
+		return fmt.Errorf("%w: unparseable dial address %q: %v", ErrUnsafeEndpoint, address, err)
+	}
+	return checkEndpointIP(addrPort.Addr(), address, allowPrivate)
+}
+
 // checkEndpointIP rejects a single resolved address that is unsafe to dial.
 func checkEndpointIP(ip netip.Addr, host string, allowPrivate bool) error {
+	// An IPv4 address carried in 4-in-6 form (::ffff:169.254.169.254) reports
+	// false for every IPv4 classification below, so collapse it to plain IPv4
+	// before classifying. Every caller reaches the classifications through
+	// here, so this is the only place that needs to unmap.
+	ip = ip.Unmap()
 	switch {
 	case ip.IsUnspecified():
 		return fmt.Errorf("%w: host %q resolves to unspecified address", ErrUnsafeEndpoint, host)
+	case ip.Is4() && ip.As4()[0] == 0:
+		// 0.0.0.0/8 ("this network"): unroutable, and some stacks treat
+		// 0.x.y.z as an alias for loopback.
+		return fmt.Errorf("%w: host %q resolves to reserved address %s", ErrUnsafeEndpoint, host, ip)
 	case ip.IsMulticast():
 		return fmt.Errorf("%w: host %q resolves to multicast address", ErrUnsafeEndpoint, host)
 	case ip.IsLinkLocalUnicast(), ip.IsLinkLocalMulticast():
@@ -342,7 +391,13 @@ func checkEndpointIP(ip netip.Addr, host string, allowPrivate bool) error {
 	if allowPrivate {
 		return nil
 	}
-	if ip.IsLoopback() || ip.IsPrivate() || !ip.IsGlobalUnicast() {
+	// 100.64.0.0/10 (shared address space) carries cloud-internal networking
+	// and overlay VPNs. netip classifies it as ordinary global unicast and
+	// IsPrivate does not cover it, so name it here rather than let it pass as
+	// public. Operators reaching an object store over such an overlay opt in
+	// with the same flag they already use for a private endpoint.
+	sharedAddressSpace := ip.Is4() && ip.As4()[0] == 100 && ip.As4()[1]&0xc0 == 64
+	if ip.IsLoopback() || ip.IsPrivate() || sharedAddressSpace || !ip.IsGlobalUnicast() {
 		return fmt.Errorf("%w: host %q resolves to private/internal address %s (set allow_private_endpoint=true to permit)", ErrUnsafeEndpoint, host, ip)
 	}
 	return nil

--- a/pkg/controlplane/runtime/blockstoreprobe/probe.go
+++ b/pkg/controlplane/runtime/blockstoreprobe/probe.go
@@ -192,6 +192,7 @@ func probeRemote(ctx context.Context, bs *models.BlockStoreConfig) (bool, string
 	if endpoint != "" && !hasPathStyle {
 		forcePathStyle = true
 	}
+	allowPrivate, _ := config["allow_private_endpoint"].(bool)
 
 	remoteStore, err := s3.NewFromConfig(ctx, s3.Config{
 		Bucket:         bucket,
@@ -200,6 +201,7 @@ func probeRemote(ctx context.Context, bs *models.BlockStoreConfig) (bool, string
 		AccessKey:      accessKey,
 		SecretKey:      secretKey,
 		ForcePathStyle: forcePathStyle,
+		AllowPrivate:   allowPrivate,
 	})
 	if err != nil {
 		return false, "failed to initialize S3 client"

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -3288,6 +3288,7 @@ func CreateRemoteStoreFromConfig(ctx context.Context, storeType string, cfg inte
 		if endpoint != "" && !hasPathStyle {
 			forcePathStyle = true
 		}
+		allowPrivate, _ := config["allow_private_endpoint"].(bool)
 
 		store, err := remotes3.NewFromConfig(ctx, remotes3.Config{
 			Bucket:         bucket,
@@ -3297,6 +3298,7 @@ func CreateRemoteStoreFromConfig(ctx context.Context, storeType string, cfg inte
 			SecretKey:      secretKey,
 			KeyPrefix:      prefix,
 			ForcePathStyle: forcePathStyle,
+			AllowPrivate:   allowPrivate,
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
The S3 endpoint safety check validated the configured endpoint once, at
config-parse time, and was never enforced on the live connection. `ValidateEndpoint`
resolved the host and ran `checkEndpointIP` from the config path only; the transport
underneath used a bare `net.Dialer` and the `http.Client` set no `CheckRedirect`, so
Go's default follow-10 applied. Two bypasses followed:

- **DNS rebinding** — the hostname resolves to a safe address when the config is
  checked and to a link-local, loopback, or RFC1918 address when the socket is
  actually opened. The real dialer re-resolves on every later request.
- **Redirect following** — a 3xx from the validated endpoint walked the client to
  an arbitrary internal host, `169.254.169.254` included.

An operator-supplied S3 endpoint is a legitimate configuration surface, so this is
reachable wherever a user or tenant can set a remote store endpoint.

## What changed

**Enforcement moved to the dial.** `net.Dialer.Control` runs `checkDialAddress` on
every address the transport is about to connect to. `Control` fires after
resolution and once per candidate address, so rebinding cannot win the race
between validation and connect, and a multi-A-record host cannot smuggle one bad
answer through. The transport sets no proxy, so every socket the SDK opens passes
through this hook.

**Redirects are not followed.** `CheckRedirect` returns `http.ErrUseLastResponse`.
S3 operations address one bucket on one endpoint; a 3xx is either a
misconfiguration or an attempt to move the client to another host. Handing the 3xx
back to the SDK rather than returning an opaque client error preserves the
diagnostic — a wrong-region `PermanentRedirect` still surfaces its body as a usable
error instead of becoming "redirect refused". This is strictly tighter than the
SDK's own policy, which follows 307/308; that policy never applied here anyway,
since the client is injected via `WithHTTPClient` rather than built by the SDK.

**One predicate, two callers.** The dial path reuses the existing
`checkEndpointIP` rather than restating the ranges. Both hardenings landed in that
one function, so the config-time path gained them too:

- IPv4-mapped IPv6 is unmapped before classification. `::ffff:169.254.169.254`
  reports false for every IPv4 test in `net/netip`, so it previously passed both
  the config check and any dial. This was a live bypass of the config-time guard
  as well, not only of the new one.
- `0.0.0.0/8` is rejected. `IsUnspecified` only matches `0.0.0.0` exactly, and Go
  classifies `0.1.2.3` as global unicast, so the rest of the range was unblocked.
- `100.64.0.0/10` (RFC 6598 shared address space) is rejected. `netip.Addr.IsPrivate`
  implements only RFC 1918 and `fc00::/7`, and `IsGlobalUnicast` returns true for
  this range, so it was passing as an ordinary public address. It carries
  cloud-internal networking and overlay VPNs, which makes it a realistic pivot
  target. Because operators do legitimately reach an object store across such an
  overlay, this one sits behind the escape hatch rather than in the unconditional
  set.

Blocked unconditionally: `0.0.0.0/8`, unspecified, multicast, and link-local
(`169.254.0.0/16` + `fe80::/10`, covering the cloud metadata address). Blocked
unless the escape hatch is set: loopback, RFC1918, unique-local `fc00::/7`,
`100.64.0.0/10`, and anything else that is not global unicast. Every check is
applied to the unmapped address, so the IPv4-mapped spelling of each is blocked
too.

**Escape hatch: the existing flag, now honored at the dial layer.** The config
already had `allow_private_endpoint` for operators running MinIO, LocalStack, or a
co-located RGW on loopback or a private network. It was only reaching the
config-time check, so a dial-layer guard would have broken every one of those
deployments. It is now plumbed through as `Config.AllowPrivate` from both
`NewFromConfig` call sites and relaxes exactly the same set at dial time that it
relaxes at config time. The metadata range stays refused either way. No new flag,
and no behavior change for anyone already setting it — including the e2e matrix,
which runs LocalStack behind this key.

## Tests

The tests exercise the bypasses, not just the predicate. Both bypass tests were
confirmed to fail with the guard disabled and to pass with it in place:

```
--- FAIL: TestDialGuard_RefusesNameResolvingToBlockedAddress
    ssrf_test.go:39: dial to a name resolving to loopback succeeded, want refusal
--- PASS: TestDialGuard_EscapeHatchAllowsPrivate
--- FAIL: TestRedirect_NotFollowed
    ssrf_test.go:94: redirect target was contacted 1 time(s), want 0
```

The escape-hatch test passes either way, as it should — it asserts a connection
that both the old and new code must allow.

- `TestDialGuard_RefusesNameResolvingToBlockedAddress` — a real, reachable test
  server is dialed through the name `localhost`, so the connection is driven by
  name resolution and succeeds without the guard.
- `TestRedirect_NotFollowed` — runs with the private opt-out enabled so the dial
  guard would happily connect to the redirect target; only the redirect policy
  stops it. The target counts its own hits, so refusal is proven by it never being
  contacted rather than by the shape of an error.
- `TestDialGuard_EscapeHatchAllowsPrivate` — the opt-out still reaches a loopback
  store, and doubles as proof the guarded client completes a real connection end to
  end rather than refusing everything.
- `TestCheckDialAddress` — per-address verdicts including both IPv4-mapped IPv6
  forms, `fe80::`, `fc00::/7`, `0.0.0.0/8`, `100.64.0.0/10` (with the addresses
  immediately below and above the range asserted as still reachable), and public
  v4/v6 endpoints that must still connect.
- `TestValidateEndpoint_SSRF` gains the IPv4-mapped cases that bypassed the
  config-time check.

Relates to #1917
