### PR TITLE
fix(block): reclaim the legacy cas/ namespace per remote, not per share

### DIFF
--- a/pkg/block/engine/legacy_migration.go
+++ b/pkg/block/engine/legacy_migration.go
@@ -34,13 +34,17 @@ import (
 //     most one orphan block object — the same window the live carver has,
 //     reconciled by the PR5 sweep — and never a partially-pointed block
 //     record, so re-runs converge without leaks.
-//   - Phase P purges whatever is left under cas/: after Phase R nothing in
-//     that namespace is referenced (objects either had their locator rewritten
-//     or were never marked synced — the pre-flip Put-then-Mark crash orphans).
+//
+// Migration never DELETES anything under cas/. That namespace is
+// content-addressed and not scoped per share, and one remote store is shared
+// (ref-counted) by every share pointing at the same remote config, so a
+// cas/<hash> object this share just re-packed may still be the standalone
+// locator target of a share that has not migrated yet — which this share
+// cannot see, since it reads only its own metadata. Reclaiming the namespace
+// is the block GC's job: it runs per remote, across every share on it.
 //
 // Detection is state-free (no sentinel, no journal): a metadata scan for
-// standalone locators plus one remote LIST page. Re-running against a
-// migrated share is a no-op.
+// standalone locators. Re-running against a migrated share is a no-op.
 
 // migrationProgressInterval is how often a migration loop whose cost scales with
 // the data reports what it has done so far: long enough that a small store logs
@@ -79,7 +83,7 @@ func (bs *Store) localHasLogBlobSubstrate() bool {
 	return false
 }
 
-// migrateLegacyCASRemote runs Phases R and P against the share's remote store.
+// migrateLegacyCASRemote runs Phase R against the share's remote store.
 func (m *Syncer) migrateLegacyCASRemote(ctx context.Context) error {
 	m.mu.RLock()
 	rbs := m.remoteBlockStore
@@ -124,42 +128,14 @@ func (m *Syncer) migrateLegacyCASRemote(ctx context.Context) error {
 		if rbs == nil || committer == nil {
 			return fmt.Errorf("cas→blocks migration: %d standalone chunks found but the block substrate is not wired", len(standalone))
 		}
-		logger.Warn("cas→blocks migration: re-packing standalone chunks and purging the cas/ namespace — "+
+		logger.Warn("cas→blocks migration: re-packing standalone chunks — "+
 			"one-way, the previous release cannot read the result; snapshot the remote bucket before upgrading",
 			"chunks_total", len(standalone))
 		if err := m.repackStandaloneChunks(ctx, legacy, hasLegacy, sealer, committer, standalone); err != nil {
 			return err
 		}
-	}
-
-	// Phase P — purge the now-unreferenced remainder of the cas/ namespace.
-	// When nothing standalone was found and the remote is unreachable this is
-	// deliberately non-fatal: the purge is pure cleanup and retries next boot.
-	if !hasLegacy {
-		return nil
-	}
-	var purged int
-	purgeErr := legacy.WalkLegacyChunks(ctx, func(h block.ContentHash, _ int64) error {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		if err := legacy.DeleteLegacyChunk(ctx, h); err != nil {
-			return fmt.Errorf("purge cas object %s: %w", h, err)
-		}
-		purged++
-		return nil
-	})
-	if purgeErr != nil {
-		if len(standalone) == 0 {
-			logger.Warn("cas→blocks migration: cas/ purge skipped (remote unavailable?) — will retry next start",
-				"error", purgeErr)
-			return nil
-		}
-		return fmt.Errorf("cas→blocks migration: purge cas/ namespace: %w", purgeErr)
-	}
-	if purged > 0 || len(standalone) > 0 {
-		logger.Info("cas→blocks migration complete",
-			"repacked_chunks", len(standalone), "purged_objects", purged)
+		logger.Info("cas→blocks migration complete; the legacy cas/ objects stay until block GC reclaims them",
+			"repacked_chunks", len(standalone))
 	}
 	return nil
 }
@@ -196,16 +172,9 @@ func (m *Syncer) repackStandaloneChunks(
 		if err := m.packAndCommitMigrated(ctx, sealer, committer, batch); err != nil {
 			return err
 		}
-		// Locators now point at the new block: the standalone objects are
-		// unreferenced. Delete best-effort; Phase P sweeps any failure.
-		if hasLegacy {
-			for _, c := range batch {
-				if err := legacy.DeleteLegacyChunk(ctx, c.hash); err != nil {
-					logger.Warn("cas→blocks migration: standalone object delete failed (purge will retry)",
-						"hash", c.hash.String(), "error", err)
-				}
-			}
-		}
+		// The locators now point at the new block, but the standalone objects
+		// stay: the same cas/<hash> can still back another share on this
+		// remote. Block GC reclaims them (see the file header).
 		repacked += len(batch)
 		batch = batch[:0]
 		batchBytes = 0
@@ -266,8 +235,9 @@ func (m *Syncer) repackStandaloneChunks(
 }
 
 // migrationChunkBytes returns the BLAKE3-verified plaintext for hash, read from
-// the legacy remote. Verified here because migration is the last gate before the
-// standalone copy is deleted.
+// the legacy remote. Verified here because the re-packed copy inherits this
+// hash: a corrupt legacy object must fail the migration, not be sealed into a
+// block under a hash its bytes do not match.
 func (m *Syncer) migrationChunkBytes(
 	ctx context.Context,
 	legacy remote.LegacyCASStore,

--- a/pkg/block/engine/legacy_migration_test.go
+++ b/pkg/block/engine/legacy_migration_test.go
@@ -77,7 +77,9 @@ func sumLiveChunkCounts(t *testing.T, ctx context.Context, f *carveFixture) (int
 
 // TestMigrateLegacyCAS_RepacksStandaloneChunks proves the core Phase R flow
 // on a plain (undecorated) stack: standalone objects + markers in, packed
-// blocks + rewritten locators + empty cas/ namespace out.
+// blocks + rewritten locators out. The legacy objects are left in place: the
+// cas/ namespace is shared by every share on the remote, so only block GC
+// (which sees them all) may reclaim it.
 func TestMigrateLegacyCAS_RepacksStandaloneChunks(t *testing.T) {
 	ctx := context.Background()
 	base := remotememory.New()
@@ -100,8 +102,8 @@ func TestMigrateLegacyCAS_RepacksStandaloneChunks(t *testing.T) {
 		assertMigrated(t, ctx, f, h, chunks[h.String()])
 	}
 
-	if n, err := base.CountLegacyChunks(ctx); err != nil || n != 0 {
-		t.Fatalf("cas/ namespace not empty after migration: n=%d err=%v", n, err)
+	if n, err := base.CountLegacyChunks(ctx); err != nil || n != len(hashes) {
+		t.Fatalf("migration must not delete cas objects: n=%d want=%d err=%v", n, len(hashes), err)
 	}
 	records, live := sumLiveChunkCounts(t, ctx, f)
 	if live != uint32(len(hashes)) {
@@ -141,8 +143,8 @@ func TestMigrateLegacyCAS_DecoratedStack(t *testing.T) {
 		t.Fatalf("migrateLegacyCASRemote: %v", err)
 	}
 	assertMigrated(t, ctx, f, h, data)
-	if n, _ := base.CountLegacyChunks(ctx); n != 0 {
-		t.Fatalf("cas/ namespace not empty: %d", n)
+	if n, _ := base.CountLegacyChunks(ctx); n != 1 {
+		t.Fatalf("migration must not delete the legacy object: %d", n)
 	}
 }
 
@@ -171,10 +173,11 @@ func TestMigrateLegacyCAS_LostChunkDropsMarker(t *testing.T) {
 	}
 }
 
-// TestMigrateLegacyCAS_PurgesUnreferencedObjects proves Phase P: standalone
-// objects with no marker (pre-flip Put-then-Mark crash orphans) are deleted
-// even when nothing needs repacking.
-func TestMigrateLegacyCAS_PurgesUnreferencedObjects(t *testing.T) {
+// TestMigrateLegacyCAS_KeepsUnreferencedObjects proves the migration deletes
+// nothing: a standalone object with no marker in THIS share may still be the
+// locator target of another share on the same remote, so it survives (block GC
+// reclaims it once every share on the remote is migrated).
+func TestMigrateLegacyCAS_KeepsUnreferencedObjects(t *testing.T) {
 	ctx := context.Background()
 	base := remotememory.New()
 	f := newCarveFixture(t, base, 1<<20)
@@ -187,19 +190,18 @@ func TestMigrateLegacyCAS_PurgesUnreferencedObjects(t *testing.T) {
 	if err := f.syncer.migrateLegacyCASRemote(ctx); err != nil {
 		t.Fatalf("migrateLegacyCASRemote: %v", err)
 	}
-	if n, _ := base.CountLegacyChunks(ctx); n != 0 {
-		t.Fatalf("orphan cas object not purged: %d left", n)
+	if n, _ := base.CountLegacyChunks(ctx); n != 1 {
+		t.Fatalf("orphan cas object must survive the migration: %d left", n)
 	}
 	if records, _ := sumLiveChunkCounts(t, ctx, f); records != 0 {
-		t.Fatalf("purge must not mint block records, got %d", records)
+		t.Fatalf("migration must not mint block records, got %d", records)
 	}
 }
 
-// TestMigrateLegacyCAS_AlreadyRewrittenObjectPurged proves the
-// crash-after-commit-before-delete window: a chunk whose locator was already
-// rewritten but whose standalone object still exists is NOT repacked — the
-// stale object is simply purged.
-func TestMigrateLegacyCAS_AlreadyRewrittenObjectPurged(t *testing.T) {
+// TestMigrateLegacyCAS_AlreadyRewrittenObjectKept proves an already-migrated
+// chunk whose standalone object still exists is NOT repacked a second time,
+// and that the stale object is left for block GC.
+func TestMigrateLegacyCAS_AlreadyRewrittenObjectKept(t *testing.T) {
 	ctx := context.Background()
 	base := remotememory.New()
 	f := newCarveFixture(t, base, 1<<20)
@@ -221,8 +223,8 @@ func TestMigrateLegacyCAS_AlreadyRewrittenObjectPurged(t *testing.T) {
 	if err := f.syncer.migrateLegacyCASRemote(ctx); err != nil {
 		t.Fatalf("re-run: %v", err)
 	}
-	if n, _ := base.CountLegacyChunks(ctx); n != 0 {
-		t.Fatal("stale standalone object should be purged")
+	if n, _ := base.CountLegacyChunks(ctx); n != 1 {
+		t.Fatalf("stale standalone object should survive the migration: %d", n)
 	}
 	if got := countRemoteBlocks(t, ctx, base); got != blocksAfterFirst {
 		t.Fatalf("already-migrated chunk was repacked: blocks %d -> %d", blocksAfterFirst, got)
@@ -294,8 +296,8 @@ func TestMigrateLegacyCAS_ResumeAfterFailure(t *testing.T) {
 	for _, h := range hashes {
 		assertMigrated(t, ctx, f, h, chunks[h.String()])
 	}
-	if n, _ := base.CountLegacyChunks(ctx); n != 0 {
-		t.Fatalf("cas/ not empty after converged migration: %d", n)
+	if n, _ := base.CountLegacyChunks(ctx); n != len(hashes) {
+		t.Fatalf("converged migration must keep every cas object: %d want %d", n, len(hashes))
 	}
 	// Ledger check: no record leaks — every live count is backed by a chunk
 	// whose locator points at that record's block.
@@ -325,4 +327,55 @@ func TestMigrateLegacyCAS_NoRemoteIsNoOp(t *testing.T) {
 	if err := f.syncer.migrateLegacyCASRemote(ctx); err != nil {
 		t.Fatalf("local-only migration should be a no-op: %v", err)
 	}
+}
+
+// TestMigrateLegacyCAS_LeavesOtherSharesChunks proves the cross-share rule.
+// Two shares configured against ONE remote store share a single unscoped cas/
+// namespace, so a share that finishes its migration must not delete objects a
+// share that has not migrated still resolves through a standalone locator —
+// including the deduplicated object both shares point at.
+func TestMigrateLegacyCAS_LeavesOtherSharesChunks(t *testing.T) {
+	ctx := context.Background()
+	base := remotememory.New()
+	migrating := newCarveFixture(t, base, 96)
+	untouched := newCarveFixture(t, base, 96)
+
+	onlyMine := []byte("chunk only the migrating share knows ....")
+	onlyTheirs := []byte("chunk only the other share knows .......")
+	deduped := []byte("identical content stored by both shares .")
+
+	hMine := plantStandaloneChunk(t, ctx, migrating, base, base, onlyMine)
+	hTheirs := plantStandaloneChunk(t, ctx, untouched, base, base, onlyTheirs)
+	hDeduped := plantStandaloneChunk(t, ctx, migrating, base, base, deduped)
+	if got := plantStandaloneChunk(t, ctx, untouched, base, base, deduped); got != hDeduped {
+		t.Fatalf("identical content must hash identically: %s vs %s", got, hDeduped)
+	}
+
+	// One share migrates while the other has not run its migration yet.
+	if err := migrating.syncer.migrateLegacyCASRemote(ctx); err != nil {
+		t.Fatalf("migrateLegacyCASRemote: %v", err)
+	}
+	assertMigrated(t, ctx, migrating, hMine, onlyMine)
+	assertMigrated(t, ctx, migrating, hDeduped, deduped)
+
+	// The other share's chunks are still standalone and must still read.
+	for _, tc := range []struct {
+		hash block.ContentHash
+		want []byte
+	}{{hTheirs, onlyTheirs}, {hDeduped, deduped}} {
+		got, err := untouched.syncer.readStandaloneChunk(ctx, tc.hash)
+		if err != nil {
+			t.Fatalf("un-migrated share lost chunk %s: %v", tc.hash, err)
+		}
+		if !bytes.Equal(got, tc.want) {
+			t.Fatalf("un-migrated share read wrong bytes for %s", tc.hash)
+		}
+	}
+
+	// And it still migrates correctly when its own turn comes.
+	if err := untouched.syncer.migrateLegacyCASRemote(ctx); err != nil {
+		t.Fatalf("second share migrateLegacyCASRemote: %v", err)
+	}
+	assertMigrated(t, ctx, untouched, hTheirs, onlyTheirs)
+	assertMigrated(t, ctx, untouched, hDeduped, deduped)
 }

--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -157,6 +158,9 @@ func (r *Runtime) runBlockGCSweep(ctx context.Context, sharePrefix string, dryRu
 			// synced markers of past-grace dead chunks. Gated by the operator's
 			// gc.compaction_live_ratio (no-op when unset or on dry-run).
 			r.compactRemoteForEntry(ctx, entry, dryRun, gcDefaults, total)
+			// Reclaim the pre-flip cas/ namespace, gated on every share on this
+			// remote having finished the cas→blocks migration.
+			r.purgeLegacyCASForEntry(ctx, entry, dryRun, total)
 		}()
 	}
 	// Sweep the local tier too, so one `gc` invocation reclaims orphaned
@@ -372,6 +376,9 @@ func (r *Runtime) runBlockGCForShare(ctx context.Context, name string, dryRun bo
 			// Compact partially-dead blocks on this remote (#1487), under the
 			// same per-remote lock and after the sweep. See runBlockGCSweep.
 			r.compactRemoteForEntry(ctx, entry, dryRun, gcDefaults, total)
+			// Reclaim the pre-flip cas/ namespace, gated on every share on this
+			// remote having finished the cas→blocks migration.
+			r.purgeLegacyCASForEntry(ctx, entry, dryRun, total)
 		}()
 	}
 	// Sweep this share's local tier too (#1433).
@@ -632,6 +639,134 @@ func (r *Runtime) compactRemoteForEntry(ctx context.Context, entry shares.Remote
 	total.BytesReclaimed += rep.BytesReclaimed
 	total.ErrorCount += int(rep.Errors)
 	total.Errors += int(rep.Errors)
+}
+
+// errStandaloneLocator stops a synced-hash enumeration at the first standalone
+// locator. It never escapes purgeLegacyCASForEntry.
+var errStandaloneLocator = errors.New("standalone locator found")
+
+// sharesForRemote returns the share names currently registered against a
+// remote-store config, read fresh rather than from a caller's earlier snapshot.
+// Empty when no registered share references that config.
+func (r *Runtime) sharesForRemote(configID string) []string {
+	for _, e := range r.sharesSvc.DistinctRemoteStores() {
+		if e.ConfigID == configID {
+			return e.Shares
+		}
+	}
+	return nil
+}
+
+// purgeLegacyCASForEntry reclaims what is left of the pre-flip cas/ namespace
+// on one remote. The namespace is content-addressed and NOT scoped per share,
+// so a cas/<hash> object is reclaimable only once no share on this remote can
+// still resolve a chunk through it — a per-remote question the per-share
+// cas→blocks migration cannot answer, which is why the migration itself deletes
+// nothing. The gate is every share on the remote carrying zero standalone
+// (empty-BlockID) synced locators.
+//
+// Each share is enumerated on its own, NOT through the sweep's union index
+// (syncedHashStoreForShares): that index keeps a single locator per hash, so a
+// share still standalone on a hash a sibling has already re-packed would be
+// invisible to the gate.
+//
+// The share set is re-read here rather than taken from entry.Shares: the
+// caller's snapshot predates the per-remote lock, so a share that registered in
+// between would not be gated on. A share whose AddShare is still in flight is
+// not in the registry at all while its block store — and the migration that
+// block store starts — is already running, so any pending registration also
+// blocks the purge.
+//
+// It fails closed: a share whose synced index cannot be read or enumerated
+// leaves the namespace untouched, so the worst outcome is legacy objects
+// lingering until a later GC pass — never a delete of a chunk a share that was
+// merely unreadable this run still needs. Runs under the caller's
+// per-remote GC lock, and never on a dry run.
+func (r *Runtime) purgeLegacyCASForEntry(ctx context.Context, entry shares.RemoteStoreEntry, dryRun bool, total *engine.GCStats) {
+	if dryRun {
+		return
+	}
+	legacy, ok := entry.Store.(remote.LegacyCASStore)
+	if !ok {
+		return // backend has no legacy namespace
+	}
+	if pending := r.sharesSvc.PendingShareRegistrations(); pending > 0 {
+		logger.Info("GC: legacy cas/ purge skipped — a share is still registering, so the share set for this remote is not knowable",
+			"configID", entry.ConfigID, "pending_registrations", pending)
+		return
+	}
+	shareNames := r.sharesForRemote(entry.ConfigID)
+	if len(shareNames) == 0 {
+		logger.Info("GC: legacy cas/ purge skipped — no registered share claims this remote",
+			"configID", entry.ConfigID)
+		return
+	}
+	for _, shareName := range shareNames {
+		mds, err := r.GetMetadataStoreForShare(shareName)
+		if err != nil {
+			logger.Warn("GC: legacy cas/ purge skipped — metadata store unavailable for a share on this remote",
+				"configID", entry.ConfigID, "share", shareName, "err", err)
+			return
+		}
+		idx, ok := mds.(engine.SyncedHashIndex)
+		if !ok {
+			logger.Warn("GC: legacy cas/ purge skipped — share's metadata store cannot enumerate synced hashes",
+				"configID", entry.ConfigID, "share", shareName)
+			return
+		}
+		// One standalone locator answers the gate, so the scan stops there
+		// instead of counting them: while a migration is in flight this runs on
+		// every GC pass, and the enumeration is O(synced markers) per share.
+		err = idx.EnumerateSynced(ctx, func(_ block.ContentHash, loc block.ChunkLocator, _ time.Time) error {
+			if loc.BlockID == "" {
+				return errStandaloneLocator
+			}
+			return nil
+		})
+		if errors.Is(err, errStandaloneLocator) {
+			logger.Info("GC: legacy cas/ purge deferred — a share on this remote still has un-migrated standalone chunks",
+				"configID", entry.ConfigID, "share", shareName)
+			return
+		}
+		if err != nil {
+			logger.Warn("GC: legacy cas/ purge skipped — enumerating a share's synced hashes failed",
+				"configID", entry.ConfigID, "share", shareName, "err", err)
+			return
+		}
+	}
+
+	var purged int
+	var freed int64
+	walkErr := legacy.WalkLegacyChunks(ctx, func(h block.ContentHash, size int64) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := legacy.DeleteLegacyChunk(ctx, h); err != nil {
+			return fmt.Errorf("delete cas object %s: %w", h, err)
+		}
+		purged++
+		freed += size
+		return nil
+	})
+	if purged > 0 {
+		total.ObjectsSwept += int64(purged)
+		total.BytesFreed += freed
+		total.BytesReclaimed += freed
+	}
+	// A failed walk leaves part of the namespace behind, so it never reports
+	// the namespace as reclaimed — only the progress it did make.
+	if walkErr != nil {
+		logger.Warn("GC: legacy cas/ purge incomplete — will retry next pass",
+			"configID", entry.ConfigID, "purged_objects", purged, "bytesFreed", freed, "err", walkErr)
+		total.ErrorCount++
+		total.Errors++
+		return
+	}
+	if purged > 0 {
+		logger.Info("GC: legacy cas/ namespace reclaimed",
+			"configID", entry.ConfigID, "shares", shareNames,
+			"purged_objects", purged, "bytesFreed", freed)
+	}
 }
 
 // remoteGCLock returns the per-remote serializing mutex for a remote-store

--- a/pkg/controlplane/runtime/blockgc_test.go
+++ b/pkg/controlplane/runtime/blockgc_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/engine"
 	"github.com/marmos91/dittofs/pkg/block/remote"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
 	"github.com/marmos91/dittofs/pkg/health"
 	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
@@ -201,5 +202,130 @@ func TestRunBlockGC_NoRemoteShares(t *testing.T) {
 	}
 	if len(*captured) != 0 {
 		t.Fatalf("expected 0 GC calls with no remote shares, got %d", len(*captured))
+	}
+}
+
+// recordingLegacyRemote exposes a fixed legacy cas/ namespace and counts the
+// deletes a GC pass performs on it.
+type recordingLegacyRemote struct {
+	*fakeRemoteStore
+	objects []block.ContentHash
+	deleted int
+}
+
+func (r *recordingLegacyRemote) WalkLegacyChunks(_ context.Context, fn func(block.ContentHash, int64) error) error {
+	for _, h := range r.objects {
+		if err := fn(h, 16); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *recordingLegacyRemote) DeleteLegacyChunk(_ context.Context, _ block.ContentHash) error {
+	r.deleted++
+	return nil
+}
+
+// TestRunBlockGC_LegacyCASPurgeWaitsForEveryShare asserts the cas/ namespace of
+// a shared remote is reclaimed only once no share on that remote still carries
+// a standalone (un-migrated) locator — the namespace is content-addressed and
+// not scoped per share, so an early purge would delete another share's chunks.
+func TestRunBlockGC_LegacyCASPurgeWaitsForEveryShare(t *testing.T) {
+	installCollectGarbageSpy(t)
+	installCollectGarbageLocalSpy(t)
+	ctx := context.Background()
+
+	rs := &recordingLegacyRemote{
+		fakeRemoteStore: &fakeRemoteStore{name: "s3-shared"},
+		objects:         []block.ContentHash{{1}, {2}},
+	}
+	rt := newRuntimeForGC(t, map[string]remote.RemoteStore{
+		"/share-a": rs,
+		"/share-b": rs, // same remote config
+	})
+
+	mds, err := rt.GetMetadataStoreForShare("/share-a")
+	if err != nil {
+		t.Fatalf("GetMetadataStoreForShare: %v", err)
+	}
+	// A share still resolving a chunk through the legacy namespace.
+	standalone := block.ContentHash{1}
+	if err := mds.MarkSynced(ctx, standalone, block.ChunkLocator{}); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+	if _, err := rt.RunBlockGC(ctx, "", false); err != nil {
+		t.Fatalf("RunBlockGC: %v", err)
+	}
+	if rs.deleted != 0 {
+		t.Fatalf("purged %d cas objects while a share was still un-migrated", rs.deleted)
+	}
+
+	// Once every share is migrated (locator rewritten onto a packed block) the
+	// namespace is unreferenced. MarkSynced keeps the first locator, so the
+	// stale marker has to go before the migrated one can be recorded.
+	if err := mds.DeleteSynced(ctx, standalone); err != nil {
+		t.Fatalf("DeleteSynced: %v", err)
+	}
+	if err := mds.MarkSynced(ctx, standalone, block.ChunkLocator{BlockID: "blk-1"}); err != nil {
+		t.Fatalf("MarkSynced (migrated): %v", err)
+	}
+	if _, err := rt.RunBlockGC(ctx, "", false); err != nil {
+		t.Fatalf("RunBlockGC (post-migration): %v", err)
+	}
+	if rs.deleted != len(rs.objects) {
+		t.Fatalf("purged %d cas objects, want %d", rs.deleted, len(rs.objects))
+	}
+}
+
+// TestPurgeLegacyCAS_IgnoresStaleShareSnapshot asserts the gate does not trust
+// the caller's share snapshot. That snapshot is taken before the per-remote GC
+// lock, so a share that registers in the window is missing from it — and here
+// that missing share is the one still carrying un-migrated standalone chunks.
+func TestPurgeLegacyCAS_IgnoresStaleShareSnapshot(t *testing.T) {
+	ctx := context.Background()
+	rt := New(nil)
+
+	// Separate metadata stores: the stale snapshot must be unable to see the
+	// second share's markers through the first share's store.
+	stores := map[string]*metadatamemory.MemoryMetadataStore{
+		"meta-a": metadatamemory.NewMemoryMetadataStoreWithDefaults(),
+		"meta-b": metadatamemory.NewMemoryMetadataStoreWithDefaults(),
+	}
+	for name, ms := range stores {
+		if err := rt.RegisterMetadataStore(name, ms); err != nil {
+			t.Fatalf("RegisterMetadataStore(%s): %v", name, err)
+		}
+	}
+
+	rs := &recordingLegacyRemote{
+		fakeRemoteStore: &fakeRemoteStore{name: "s3-shared"},
+		objects:         []block.ContentHash{{1}, {2}},
+	}
+	for _, sh := range []struct{ share, meta string }{{"/share-a", "meta-a"}, {"/share-b", "meta-b"}} {
+		if err := rt.AddShare(ctx, &ShareConfig{Name: sh.share, MetadataStore: sh.meta, Enabled: true}); err != nil {
+			t.Fatalf("AddShare(%s): %v", sh.share, err)
+		}
+		rt.setShareRemoteForTest(sh.share, rs)
+	}
+
+	// The late-registering share has not migrated yet.
+	if err := stores["meta-b"].MarkSynced(ctx, block.ContentHash{1}, block.ChunkLocator{}); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+
+	entries := rt.sharesSvc.DistinctRemoteStores()
+	if len(entries) != 1 {
+		t.Fatalf("expected one remote entry, got %d", len(entries))
+	}
+	stale := shares.RemoteStoreEntry{
+		Store:    entries[0].Store,
+		ConfigID: entries[0].ConfigID,
+		Shares:   []string{"/share-a"}, // snapshot predating share-b's registration
+	}
+
+	rt.purgeLegacyCASForEntry(ctx, stale, false, &engine.GCStats{})
+	if rs.deleted != 0 {
+		t.Fatalf("purged %d cas objects using a stale share snapshot", rs.deleted)
 	}
 }

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -830,6 +830,18 @@ func (s *Service) reserveShareName(name string) error {
 	return nil
 }
 
+// PendingShareRegistrations reports how many AddShare calls hold a name
+// reservation they have not yet published to the registry. Such a share is
+// invisible to DistinctRemoteStores even though its block store — and the
+// background legacy migration that block store starts — is already running, so
+// callers that must reason about every share on a remote have to treat a
+// non-zero count as "the share set is not knowable right now".
+func (s *Service) PendingShareRegistrations() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.reservations)
+}
+
 // releaseShareName drops an in-flight AddShare reservation. Idempotent.
 func (s *Service) releaseShareName(name string) {
 	s.mu.Lock()


### PR DESCRIPTION
Relates to #1916.

## The bug

The cas→blocks migration (`pkg/block/engine/legacy_migration.go`) purged the entire legacy `cas/` namespace as soon as **its own** share finished re-packing, and also deleted each standalone object right after committing the block that replaced it.

That namespace is content-addressed and not scoped per share, while a remote store is ref-counted and shared by every share pointing at the same remote config (CLAUDE.md invariant 4). A share can only see its own metadata, so both deletes destroyed live data:

- the blanket purge deleted every `cas/<hash>` object, including those another share still resolved through an un-migrated (empty-BlockID) locator;
- even the "delete only what I just re-packed" per-chunk delete was unsound, because identical content in two shares is **one** `cas/<hash>` object.

The un-migrated share then read `chunk not found`, and its own migration later classified the chunk as pre-existing data loss and dropped the synced marker.

## The fix

The migration now deletes nothing — it re-packs standalone chunks and rewrites its own locators, and that is all.

Reclaiming the namespace moved to the block GC (`Runtime.purgeLegacyCASForEntry`), which already runs **per remote across every share on it**, under the existing per-remote GC lock. The purge runs only when no share on that remote carries a standalone locator, and fails closed: a share whose synced index cannot be resolved or enumerated leaves the whole namespace untouched. Leftover legacy objects therefore linger until a later GC pass, never the other way around.

Each share is enumerated on its own rather than through the sweep's union index (`syncedHashStoreForShares`): that index keeps one locator per hash, so a share still standalone on a hash a sibling already re-packed would be invisible to the gate.

**When cleanup now happens:** on the next block GC pass over that remote (scheduled GC, or `dfsctl store block gc [share]`), once every share on the remote has completed the migration.

## Second defect, found in review: the gate read a stale share set

The first version of the gate iterated `entry.Shares`, but both GC entrypoints call `sharesSvc.DistinctRemoteStores()` **before** acquiring `remoteGCLock(configID)`. `AddShare` publishes a share to the registry only in its final phase and never takes that lock, while `Store.Start` — which launches the per-share migration as a detached goroutine — runs several phases earlier. A share registering inside that window was invisible to the gate, so the purge could delete objects its still-running migration had not re-packed: the same data loss, reached through a different door.

Three fail-closed changes:

1. **Membership is re-derived under the lock.** New `Runtime.sharesForRemote(configID)` re-reads `DistinctRemoteStores()` inside `purgeLegacyCASForEntry`; `entry.Shares` is no longer used for the gate.
2. **In-flight registrations block the purge.** New `shares.Service.PendingShareRegistrations()` reports outstanding `AddShare` name reservations. A reservation is taken before the block store is built and dropped only at registry publish, so it covers exactly the interval in which a share's migration goroutine runs while the share is still invisible. Non-zero → skip.
3. **No registered claimant → skip.** If the fresh lookup finds no share on that remote, the purge does not run rather than reclaiming a namespace nobody currently claims.

### Residual window — read this before trusting the gate

This does **not** make the gate airtight. A share that reserves its name *after* the pending-registration check, and whose migration re-packs while the purge walk is running, is still not covered. Closing that requires `AddShare` to participate in `remoteGCLock`, which risks deadlocking against `Store.Start`; that was judged too large and too risky for this PR and was deliberately not attempted. What is closed is the reviewed scenario: a share that became visible between the caller's snapshot and the gate.

## From Copilot review

- The gate's enumeration now short-circuits at the first standalone locator via an `errStandaloneLocator` sentinel instead of counting them all — it previously paid an O(synced markers) scan per share on every GC pass until the last share migrated. Fail-closed ordering is preserved: the sentinel is matched with `errors.Is` before the generic error branch.
- A partially completed purge no longer logs "namespace reclaimed". The walk error returns after its warning, which now carries `purged_objects` and `bytesFreed`; stats still fold in the partial progress.

## Tests

- `TestMigrateLegacyCAS_LeavesOtherSharesChunks` — two shares over one remote store, one migrated and one not, including a deduplicated object both point at. Verified failing before the fix (`un-migrated share lost chunk …: chunk not found`).
- `TestPurgeLegacyCAS_IgnoresStaleShareSnapshot` — **deterministic**, no timing and no injected hook: two shares on one remote with separate metadata stores, the second still standalone, and a hand-built `RemoteStoreEntry` whose `Shares` lists only the first. Verified failing against the snapshot-trusting version (`purged 2 cas objects using a stale share snapshot`).
- `TestRunBlockGC_LegacyCASPurgeWaitsForEveryShare` — GC defers the purge while any share still has a standalone locator, and performs it once none do.
- Existing migration tests updated: they asserted the now-removed purge.

## Known limitation

#1930 (a configured-but-unregistered/disabled share on the same remote is not consulted by the gate) is only **partially** addressed here: the in-flight registration case is now covered by `PendingShareRegistrations()`. A share that is disabled and never registers at all is still absent from `DistinctRemoteStores()` and does not block the purge. That case remains open.

Sibling cleanup paths audited: the block reclaim / compaction / GC sweeps all delete `blocks/<id>` (per-share IDs) driven by the runtime's per-remote union reclaimers under the same lock, and the local-tier sweeps touch per-share isolated stores. The legacy CAS migration was the only path assuming single-share ownership of a shared remote namespace.
