### PR TITLE
fix(block,metadata): hold a committed file size to the durable extent

### DIFF
--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -448,6 +448,23 @@ func (bs *Store) LocalForTest() local.LocalStore { return bs.local }
 // metadata file sizes against the journal's durable high-water mark (#1687).
 func (bs *Store) Local() local.LocalStore { return bs.local }
 
+// DurableExtent reports how far a payload's bytes are on stable storage: bytes
+// below the returned offset survive an unclean shutdown, bytes above it were
+// only buffered and are gone after one. ok is false when the local tier cannot
+// answer (no local store, or one with no durability model), which callers must
+// read as "unknown", never as "nothing is durable". Callers publish file sizes
+// against it so a persisted size never describes bytes a crash would take away,
+// which would leave the range reading as a hole full of zeros.
+func (bs *Store) DurableExtent(ctx context.Context, payloadID metadata.PayloadID) (int64, bool) {
+	reporter, ok := bs.local.(interface {
+		DurableExtent(ctx context.Context, payloadID string) (int64, bool)
+	})
+	if !ok {
+		return 0, false
+	}
+	return reporter.DurableExtent(ctx, string(payloadID))
+}
+
 // LocalStore returns nil: the journal-backed local tier is a per-file byte
 // cache, not a content-addressed block.Store, so there is no hash-namespace to
 // sweep. The journal self-manages local segment reclaim (dead-byte GC +

--- a/pkg/block/journal/durable_extent_test.go
+++ b/pkg/block/journal/durable_extent_test.go
@@ -1,0 +1,217 @@
+package journal
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"testing"
+)
+
+// TestDurableExtent_PredictsWhatSurvivesDeviceLoss is the proof behind the size
+// invariant: whatever DurableExtent reports before an unclean shutdown is
+// exactly what the store still has after one. A caller that publishes a file
+// size at or below that number can never end up describing bytes the device
+// never took — bytes whose absence would read back as a hole full of zeros
+// instead of an error.
+//
+// The crash model is device loss, not process death: reopening from the same
+// tmpfiles would otherwise be served the un-fsynced tail straight out of the
+// page cache and prove nothing. So the segment is physically truncated back to
+// the length it had at the last fsync, which is precisely what a device that
+// dropped every unflushed write would have kept.
+func TestDurableExtent_PredictsWhatSurvivesDeviceLoss(t *testing.T) {
+	const rec = 4096
+	dir := t.TempDir()
+	cfg := Config{ShardCount: 1}
+	s, err := Open(dir, cfg, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ctx := context.Background()
+	id := FileID("acked.bin")
+
+	write := func(recIdx int, fill byte) {
+		t.Helper()
+		if err := s.WriteAt(ctx, id, int64(recIdx)*rec, bytes.Repeat([]byte{fill}, rec)); err != nil {
+			t.Fatalf("WriteAt rec %d: %v", recIdx, err)
+		}
+	}
+
+	// Two records the client was told are on stable storage.
+	write(0, 'a')
+	write(1, 'b')
+	if err := s.Commit(ctx, id); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	durable, ok := s.DurableExtent(ctx, id)
+	if !ok || durable != 2*rec {
+		t.Fatalf("DurableExtent after Commit = (%d, %v), want (%d, true)", durable, ok, 2*rec)
+	}
+	durableTail := s.shards[0].active.tail.Load()
+	segID := s.shards[0].active.id
+
+	// Two more the client acknowledged but nothing ever committed. They are in
+	// the page cache: readable now, gone after device loss.
+	write(2, 'c')
+	write(3, 'd')
+
+	if size, ok := s.FileSize(ctx, id); !ok || size != 4*rec {
+		t.Fatalf("FileSize = (%d, %v), want (%d, true) — the buffered records must be visible", size, ok, 4*rec)
+	}
+	if got, ok := s.DurableExtent(ctx, id); !ok || got != 2*rec {
+		t.Fatalf("DurableExtent = (%d, %v) after uncommitted writes, want (%d, true) — "+
+			"buffered bytes must never count as durable", got, ok, 2*rec)
+	}
+
+	// Device loss: everything appended after the last fsync never reached the
+	// platter. Close first so no fd is left writing behind the truncation.
+	segPath := s.segPath(segID)
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := os.Truncate(segPath, durableTail); err != nil {
+		t.Fatalf("truncate segment to the last fsync: %v", err)
+	}
+
+	r, err := Open(dir, cfg, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	// The prediction: what survived is exactly what DurableExtent promised.
+	size, ok := r.FileSize(ctx, id)
+	if !ok || size != durable {
+		t.Fatalf("post-crash FileSize = (%d, %v), want (%d, true) — DurableExtent over-promised", size, ok, durable)
+	}
+	if got, ok := r.DurableExtent(ctx, id); !ok || got != durable {
+		t.Fatalf("post-crash DurableExtent = (%d, %v), want (%d, true) — recovered data must count as durable", got, ok, durable)
+	}
+	got := make([]byte, 2*rec)
+	if _, _, err := r.ReadAt(ctx, id, 0, got); err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	want := append(bytes.Repeat([]byte{'a'}, rec), bytes.Repeat([]byte{'b'}, rec)...)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("committed bytes did not survive the crash intact")
+	}
+}
+
+// TestDurableExtent_FrozenAfterFsyncFailure covers the write-back error case the
+// group commit already treats as sticky. Once the kernel reports an fsync
+// failure it drops those pages, and the very next fsync can return success
+// without them ever having reached the device — so a later success is not
+// evidence that the earlier bytes landed. The watermark must freeze where it
+// last stood rather than sweep the failed range up with the successful one.
+func TestDurableExtent_FrozenAfterFsyncFailure(t *testing.T) {
+	const rec = 4096
+	s := testStore(t, Config{ShardCount: 1})
+	ctx := context.Background()
+	id := FileID("acked.bin")
+
+	failNext := true
+	sh := s.shardFor(id)
+	sh.segSync = func(seg *segmentMeta) error {
+		if failNext {
+			failNext = false
+			return errors.New("simulated write-back failure")
+		}
+		return seg.fd.Sync()
+	}
+
+	if err := s.WriteAt(ctx, id, 0, bytes.Repeat([]byte{'a'}, rec)); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.Commit(ctx, id); err == nil {
+		t.Fatal("Commit succeeded despite a failing fsync")
+	}
+	if got, _ := s.DurableExtent(ctx, id); got != 0 {
+		t.Fatalf("DurableExtent = %d after a failed fsync, want 0", got)
+	}
+
+	// A later fsync reports success. It says nothing about the dropped pages.
+	if err := s.WriteAt(ctx, id, rec, bytes.Repeat([]byte{'b'}, rec)); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.Commit(ctx, id); err != nil {
+		t.Fatalf("Commit after the failure: %v", err)
+	}
+	if got, _ := s.DurableExtent(ctx, id); got != 0 {
+		t.Fatalf("DurableExtent = %d after a success following a failed fsync, want 0 — "+
+			"a later success must not vouch for pages the kernel already dropped", got)
+	}
+}
+
+// TestDurableExtent_StopsAtTheFirstNonDurableRange covers writes that arrive out
+// of offset order, which is ordinary for concurrent dispatch and for any client
+// doing random writes. Durability is keyed on append order while the index is
+// keyed on offset, so a durable interval can sit ABOVE a non-durable one. The
+// extent must stop below the range that could vanish: reporting the higher one
+// would place the lost range inside the committed size, which is exactly the
+// hole-of-zeros this whole mechanism exists to prevent.
+func TestDurableExtent_StopsAtTheFirstNonDurableRange(t *testing.T) {
+	const rec = 4096
+	s := testStore(t, Config{ShardCount: 1})
+	ctx := context.Background()
+	id := FileID("acked.bin")
+
+	// A high-offset write that is committed, so its bytes are on stable storage.
+	if err := s.WriteAt(ctx, id, 100*rec, bytes.Repeat([]byte{'a'}, rec)); err != nil {
+		t.Fatalf("WriteAt high: %v", err)
+	}
+	if err := s.Commit(ctx, id); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	// A later write to an EARLIER offset that nothing commits. It sits first in
+	// the offset-ordered index but carries the higher Version.
+	if err := s.WriteAt(ctx, id, 0, bytes.Repeat([]byte{'b'}, rec)); err != nil {
+		t.Fatalf("WriteAt low: %v", err)
+	}
+
+	got, ok := s.DurableExtent(ctx, id)
+	if !ok {
+		t.Fatal("DurableExtent reported unknown for a file it has intervals for")
+	}
+	if got != 0 {
+		t.Fatalf("DurableExtent = %d, want 0 — the durable high-offset range must not be "+
+			"reported over a non-durable range beneath it, or its loss reads as zeros "+
+			"inside the committed size", got)
+	}
+}
+
+// TestDurableExtent_SpansGenuineHoles pins the other side of that rule. A gap
+// nobody ever wrote is a real sparse hole: it reads as zeros correctly and must
+// not hold the extent back, otherwise a client that writes only at a high offset
+// (thin-provisioned and random-write workloads both do) would never get a size.
+func TestDurableExtent_SpansGenuineHoles(t *testing.T) {
+	const rec = 4096
+	s := testStore(t, Config{ShardCount: 1})
+	ctx := context.Background()
+	id := FileID("sparse.bin")
+
+	if err := s.WriteAt(ctx, id, 100*rec, bytes.Repeat([]byte{'a'}, rec)); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.Commit(ctx, id); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	got, ok := s.DurableExtent(ctx, id)
+	if !ok || got != 101*rec {
+		t.Fatalf("DurableExtent = (%d, %v), want (%d, true) — a never-written gap is a "+
+			"genuine hole and must not hold the extent back", got, ok, 101*rec)
+	}
+}
+
+// TestDurableExtent_UnknownFileReportsNotOk keeps the "unknown" answer distinct
+// from "nothing is durable": a caller must be able to tell a file the local tier
+// has never heard of from one whose bytes are all still buffered, because the
+// two demand opposite handling of a size commit.
+func TestDurableExtent_UnknownFileReportsNotOk(t *testing.T) {
+	s := testStore(t, Config{})
+	if got, ok := s.DurableExtent(context.Background(), "never-written"); ok {
+		t.Fatalf("DurableExtent for an unknown file = (%d, true), want ok=false", got)
+	}
+}

--- a/pkg/block/journal/recovery.go
+++ b/pkg/block/journal/recovery.go
@@ -420,6 +420,11 @@ func (s *Store) recover() error {
 		sh := newShard(active)
 		sh.sealed = sealedByShard[i]
 		sh.index = indexByShard[i]
+		// Everything the index holds now was read back off the device and passed
+		// its CRCs, so it survived the crash by definition: the durable watermark
+		// starts at the highest replayed Version rather than at zero.
+		sh.lastVersion = maxVersion
+		sh.syncedVersion.Store(maxVersion)
 		shards[i] = sh
 	}
 

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -233,8 +233,13 @@ func (m *segmentMeta) sealInPlace() error {
 func (s *Store) sealSegment(sh *shard) error {
 	old := sh.active
 	if err := old.sealInPlace(); err != nil {
+		sh.syncFailed.Store(true)
 		return err
 	}
+	// Sealing fsyncs the segment, and every earlier segment of this shard was
+	// fsynced when it was sealed, so every record appended so far is now durable:
+	// a rotation is a durability point just like a Commit.
+	sh.markSynced(sh.lastVersion)
 	sh.sealed[old.id] = old
 
 	seg, err := s.createSegment()
@@ -319,6 +324,10 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 		return fmt.Errorf("journal: write payload CRC: %w", err)
 	}
 	seg.tail.Store(segOff + recLen)
+	// Stamped under sh.mu, after the record's writes returned: a reader holding
+	// sh.mu therefore sees a Version only once its bytes are in the page cache,
+	// which is what makes it safe for groupCommit to treat as the fsync's ceiling.
+	sh.lastVersion = version
 	seg.liveBytes.Add(int64(len(data)))
 	seg.records.Add(1)
 	seg.noteMinVersion(version)

--- a/pkg/block/journal/shard.go
+++ b/pkg/block/journal/shard.go
@@ -1,6 +1,9 @@
 package journal
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
 // FNV-1a constants (64-bit), matching fs/logshard.go so a FileID resolves to
 // the same partition as today's payloadID.
@@ -29,6 +32,19 @@ type shard struct {
 	active *segmentMeta
 	sealed map[uint64]*segmentMeta
 	index  map[FileID]*fileIndex
+	// lastVersion is the highest record Version appended to this shard, stamped
+	// under mu once the record's write() returned. syncedVersion is the highest
+	// Version a completed fsync has covered — records above it exist only in the
+	// page cache and vanish on device loss; it is atomic because groupCommit
+	// raises it after releasing mu. DurableExtent reads both.
+	lastVersion   uint64
+	syncedVersion atomic.Uint64
+	// syncFailed goes true the first time an fsync on this shard fails and never
+	// clears, freezing syncedVersion where it stood. It mirrors the stickiness of
+	// errSeq/syncErr and for the same reason: once the kernel has reported a
+	// write-back failure it drops those pages, and the next fsync can return
+	// success without them ever having reached the device.
+	syncFailed atomic.Bool
 	// carveMu serializes a shard's carve passes: the background flush and an
 	// explicit Carve() never build a block from the same records twice. It is
 	// distinct from mu, which serializes appends and index mutation — carve holds
@@ -74,6 +90,21 @@ func newShard(active *segmentMeta) *shard {
 	}
 	sh.commitCond = sync.NewCond(&sh.commitMu)
 	return sh
+}
+
+// markSynced raises the shard's durable watermark to v, which must be a Version
+// an already-completed fsync covered. Monotonic: a seal and an in-flight commit
+// finishing out of order can never walk the watermark back over durable records.
+func (sh *shard) markSynced(v uint64) {
+	if sh.syncFailed.Load() {
+		return
+	}
+	for {
+		cur := sh.syncedVersion.Load()
+		if v <= cur || sh.syncedVersion.CompareAndSwap(cur, v) {
+			return
+		}
+	}
 }
 
 // segment returns the segment with the given ID, active or sealed, or nil.

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -492,8 +492,17 @@ func (sh *shard) groupCommit() error {
 	// the whole batch durable.
 	sh.mu.Lock()
 	seg := sh.active
+	// Ceiling for this fsync: every record at or below it finished its write under
+	// the same lock, so the fsync covers all of them. Records appended after this
+	// read are simply not claimed — conservative in the only safe direction.
+	upTo := sh.lastVersion
 	sh.mu.Unlock()
 	err := sh.segSync(seg)
+	if err != nil {
+		sh.syncFailed.Store(true)
+	} else {
+		sh.markSynced(upTo)
+	}
 
 	sh.commitMu.Lock()
 	if err != nil {
@@ -621,6 +630,47 @@ func (s *Store) FileSize(_ context.Context, id FileID) (int64, bool) {
 	}
 	var size int64
 	for _, iv := range fi.ivs {
+		if e := iv.end(); e > size {
+			size = e
+		}
+	}
+	return size, true
+}
+
+// DurableExtent reports how far a file's bytes survive device loss: the maximum
+// end offset over the intervals whose bytes are already on stable storage. An
+// interval qualifies when a completed fsync covered its record (Version at or
+// below the shard's durable watermark), when it is cold (the bytes live in the
+// remote store and the marker was fsynced before it was indexed), or when it is
+// synced (carved and uploaded). Everything else was only buffered —
+// acknowledged to the client, but gone after a crash.
+//
+// It is the counterpart of FileSize, which reports every interval whether or not
+// its bytes are durable. Callers that publish a size derived from written bytes
+// use this one so the published size can never describe bytes a crash would take
+// away, which would leave the range reading as a hole full of zeros.
+func (s *Store) DurableExtent(_ context.Context, id FileID) (int64, bool) {
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	fi := sh.index[id]
+	if fi == nil {
+		return 0, false
+	}
+	synced := sh.syncedVersion.Load()
+	var size int64
+	for _, iv := range fi.ivs {
+		// Intervals are sorted by offset and non-overlapping, but durability is
+		// keyed on Version, which is append order — a later write to an earlier
+		// offset is common. So the scan stops at the first interval whose bytes
+		// could vanish rather than skipping over it: anything beyond it may be
+		// durable on its own, yet reporting it would put the lost range inside
+		// the committed size, which is the hole-of-zeros this exists to prevent.
+		// Gaps between durable intervals are a different thing entirely — never
+		// written, correctly read as zeros — so they do not stop the scan.
+		if !iv.cold && !iv.synced && iv.version > synced {
+			break
+		}
 		if e := iv.end(); e > size {
 			size = e
 		}

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -226,6 +226,10 @@ func (s *FSStore) FileSize(ctx context.Context, payloadID string) (int64, bool) 
 	return s.Store.FileSize(ctx, journal.FileID(payloadID))
 }
 
+func (s *FSStore) DurableExtent(ctx context.Context, payloadID string) (int64, bool) {
+	return s.Store.DurableExtent(ctx, journal.FileID(payloadID))
+}
+
 func (s *FSStore) DataExtents(ctx context.Context, payloadID string, fileSize int64) ([][2]uint64, error) {
 	return s.Store.DataExtents(ctx, journal.FileID(payloadID), fileSize)
 }

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -273,6 +273,15 @@ type MetadataWritebackSetter interface {
 	SetShareWriteback(shareName string, writeback bool)
 }
 
+// MetadataDurableExtentSetter gives the metadata service a way to ask how far a
+// payload's bytes are on stable storage, so a committed file size never runs
+// ahead of the data it describes. Only the control plane can answer: it owns
+// both the metadata store and the per-share block store. The concrete
+// *metadata.Service satisfies it.
+type MetadataDurableExtentSetter interface {
+	SetDurableExtentResolver(fn metadata.DurableExtentFunc)
+}
+
 // BlockStoreConfigProvider resolves block store configurations from the control plane DB.
 //
 // A share's LocalBlockStoreID/RemoteBlockStoreID normally hold the block store
@@ -722,6 +731,12 @@ func (s *Service) AddShare(
 		wb.SetShareWriteback(config.Name, share.writeback)
 	}
 
+	// Let size commits consult the block store's durable extent. The resolver is
+	// share-agnostic, so re-installing it on every AddShare is idempotent.
+	if de, ok := metadataSvc.(MetadataDurableExtentSetter); ok {
+		de.SetDurableExtentResolver(s.durableExtent)
+	}
+
 	// Phase 4: Convert the reservation into a registry entry under s.mu.
 	// Only now is the share visible to protocol handlers. The reservation has
 	// held the name exclusively since Phase 0, so registry[name] cannot already
@@ -750,6 +765,21 @@ func (s *Service) AddShare(
 	s.notifyShareChange()
 
 	return nil
+}
+
+// durableExtent reports how far a payload's bytes are on stable storage in its
+// share's block store. A share with no block store answers "unknown" (false),
+// and the caller then commits the size unclamped as before.
+//
+// It is the commit-time half of the size invariant whose restart-time half is
+// reconcileMetadataSizeFromJournal: a persisted size never runs ahead of the
+// durable data, and share start grows it back up to that data.
+func (s *Service) durableExtent(shareName string, payloadID metadata.PayloadID) (int64, bool) {
+	bs, err := s.GetBlockStoreForShare(shareName)
+	if err != nil || bs == nil {
+		return 0, false
+	}
+	return bs.DurableExtent(context.Background(), payloadID)
 }
 
 // reconcileMetadataSizeFromJournal grows each file's metadata size up to the

--- a/pkg/controlplane/runtime/size_durability_test.go
+++ b/pkg/controlplane/runtime/size_durability_test.go
@@ -1,0 +1,180 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// TestDeferredSizeCommit_NonsenseExtentWithholdsEverything covers a resolver
+// that breaks its contract and reports a negative extent. The resolver is
+// installed through exported API, so the value crossing into the clamp is not
+// fixed by the journal's construction — and widening a negative straight to
+// uint64 yields a maximal bound, which would pass every size through and turn
+// the clamp into a silent no-op. An unusable answer has to withhold everything
+// rather than everything-but-nothing.
+func TestDeferredSizeCommit_NonsenseExtentWithholdsEverything(t *testing.T) {
+	const n = 64 * 1024
+	meta, metaType := newBadgerByteVerifyBackend(t).open(t)
+	fx := newByteVerifyFixture(t, meta, metaType)
+	defer fx.close()
+
+	ctx := context.Background()
+	pid := fx.createEmptyFile(ctx, "nonsense.bin")
+	root, err := fx.meta.GetRootHandle(ctx, fx.shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+	handle, err := fx.meta.GetChild(ctx, root, "nonsense.bin")
+	if err != nil {
+		t.Fatalf("GetChild: %v", err)
+	}
+
+	metaSvc := fx.rt.GetMetadataService()
+	metaSvc.SetDurableExtentResolver(func(string, metadata.PayloadID) (int64, bool) {
+		return -1, true
+	})
+
+	authCtx := &metadata.AuthContext{
+		Context:    ctx,
+		AuthMethod: "unix",
+		Identity: &metadata.Identity{
+			UID:  metadata.Uint32Ptr(0),
+			GID:  metadata.Uint32Ptr(0),
+			GIDs: []uint32{0},
+		},
+		ClientAddr: "127.0.0.1",
+	}
+
+	writeOp, err := metaSvc.PrepareWrite(authCtx, handle, uint64(n))
+	if err != nil {
+		t.Fatalf("PrepareWrite: %v", err)
+	}
+	if err := common.WriteToBlockStore(ctx, fx.bs, pid, distinctBytes(n, 0x77), 0); err != nil {
+		t.Fatalf("WriteToBlockStore: %v", err)
+	}
+	if _, err := metaSvc.CommitWrite(authCtx, writeOp); err != nil {
+		t.Fatalf("CommitWrite: %v", err)
+	}
+	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, handle, false); err != nil {
+		t.Fatalf("FlushPendingWriteForFile: %v", err)
+	}
+
+	if got := fx.getFile(ctx, "nonsense.bin").Size; got != 0 {
+		t.Fatalf("persisted size = %d on a negative extent, want 0 — the widened "+
+			"negative became a maximal bound and disabled the clamp", got)
+	}
+}
+
+// TestDeferredSizeCommit_NeverOutrunsDurableData is the merge gate for the
+// crash-ordering half of the silent-zeros family.
+//
+// Modelled scenario: the ordinary write ack. An SMB WRITE (and an NFS UNSTABLE
+// WRITE) buffers the bytes in the journal without an fsync, then flushes the
+// pending metadata on the deferred path — and that metadata commit reaches
+// stable storage on its own schedule, within the metadata store's background
+// sync interval or immediately on a backend with no relaxed mode. If the size
+// gets there and the bytes do not, the crash leaves a file whose size covers a
+// range the block store has nothing for: an ordinary sparse hole, which every
+// read zero-fills and reports as success. The client is handed plausible zeros
+// in place of its data with no error anywhere.
+//
+// Gate property: without the commit-time clamp the persisted size is the full
+// write while the durable extent is zero, and the first assertion fails. The
+// second half then proves the clamp is a delay and not a truncation — once the
+// data is committed, the very next flush publishes the full size.
+func TestDeferredSizeCommit_NeverOutrunsDurableData(t *testing.T) {
+	const n = 256 * 1024
+	for _, bk := range byteVerifyBackends(t) {
+		bk := bk
+		t.Run(bk.name, func(t *testing.T) {
+			if bk.skip != "" {
+				t.Skip(bk.skip)
+			}
+
+			meta, metaType := bk.open(t)
+			fx := newByteVerifyFixture(t, meta, metaType)
+			defer fx.close()
+
+			ctx := context.Background()
+			data := distinctBytes(n, 0x91)
+			pid := fx.createEmptyFile(ctx, "acked.bin")
+
+			root, err := fx.meta.GetRootHandle(ctx, fx.shareName)
+			if err != nil {
+				t.Fatalf("GetRootHandle: %v", err)
+			}
+			handle, err := fx.meta.GetChild(ctx, root, "acked.bin")
+			if err != nil {
+				t.Fatalf("GetChild: %v", err)
+			}
+			authCtx := &metadata.AuthContext{
+				Context:    ctx,
+				AuthMethod: "unix",
+				Identity: &metadata.Identity{
+					UID:  metadata.Uint32Ptr(0),
+					GID:  metadata.Uint32Ptr(0),
+					GIDs: []uint32{0},
+				},
+				ClientAddr: "127.0.0.1",
+			}
+			metaSvc := fx.rt.GetMetadataService()
+
+			// The write ack, exactly as the adapters perform it: prepare, put the
+			// bytes in the block store, commit the intent, flush the metadata on
+			// the deferred path. No CommitBlockStore — nothing fsynced the data.
+			writeOp, err := metaSvc.PrepareWrite(authCtx, handle, uint64(n))
+			if err != nil {
+				t.Fatalf("PrepareWrite: %v", err)
+			}
+			if err := common.WriteToBlockStore(ctx, fx.bs, pid, data, 0); err != nil {
+				t.Fatalf("WriteToBlockStore: %v", err)
+			}
+			if _, err := metaSvc.CommitWrite(authCtx, writeOp); err != nil {
+				t.Fatalf("CommitWrite: %v", err)
+			}
+			if _, err := metaSvc.FlushPendingWriteForFile(authCtx, handle, false); err != nil {
+				t.Fatalf("FlushPendingWriteForFile: %v", err)
+			}
+
+			// Precondition: the ack really did leave the bytes non-durable.
+			durable, ok := fx.bs.DurableExtent(ctx, pid)
+			if !ok {
+				t.Fatalf("block store cannot report a durable extent — the test cannot model the bug")
+			}
+			if durable != 0 {
+				t.Fatalf("durable extent = %d after an uncommitted write, want 0 "+
+					"(the write path fsynced, so this no longer models a deferred ack)", durable)
+			}
+
+			// The gate. A persisted size above the durable extent is the bug: the
+			// size survives the crash, the bytes do not, and the gap reads as zeros.
+			if got := fx.getFile(ctx, "acked.bin").Size; got > uint64(durable) {
+				t.Fatalf("persisted size %d exceeds the durable extent %d: a crash here leaves "+
+					"the range readable as zeros with no error", got, durable)
+			}
+
+			// Readers still see the acknowledged size — it is held in the pending
+			// state, not thrown away.
+			if pending, ok := metaSvc.GetPendingSize(handle); !ok || pending != uint64(n) {
+				t.Fatalf("pending size = (%d, %v), want (%d, true) — the ACK'd size must stay visible",
+					pending, ok, n)
+			}
+
+			// And it is a delay, not a truncation: commit the data and the next
+			// flush publishes the full size.
+			if err := common.CommitBlockStore(ctx, fx.bs, pid); err != nil {
+				t.Fatalf("CommitBlockStore: %v", err)
+			}
+			if _, err := metaSvc.FlushPendingWriteForFile(authCtx, handle, false); err != nil {
+				t.Fatalf("FlushPendingWriteForFile after commit: %v", err)
+			}
+			if got := fx.getFile(ctx, "acked.bin").Size; got != uint64(n) {
+				t.Fatalf("persisted size = %d after the data was committed, want %d "+
+					"(the clamp must release the size, not drop it)", got, n)
+			}
+		})
+	}
+}

--- a/pkg/metadata/io.go
+++ b/pkg/metadata/io.go
@@ -448,10 +448,36 @@ func (s *Service) FlushPendingWriteForFile(ctx *AuthContext, handle FileHandle, 
 // but before the background fsync cannot truncate ACK'd data because
 // reconcileMetadataSizeFromJournal grows metadata.Size up to the journal's
 // durable high-water mark on share start (max-only, never shrinks).
+//
+// Whatever the commit's own durability, the size it writes is held to the block
+// store's durable extent: a size may never describe bytes the block store would
+// lose in a crash. Such a size outliving its data degrades the range into an
+// ordinary sparse hole that reads back as zeros with no error — indistinguishable
+// from real data. Holding the size back instead yields what the write path
+// already promised: uncommitted bytes are simply not there, and the file is short
+// rather than silently wrong.
 func (s *Service) flushPendingWrite(ctx *AuthContext, handle FileHandle, state *PendingWriteState, durable bool) error {
 	store, err := s.storeForHandle(handle)
 	if err != nil {
 		return err
+	}
+
+	// Bytes held back stay in the pending state, so readers still see the ACK'd
+	// size through the pending-write merge, and the first flush after the data is
+	// committed (NFS COMMIT / FILE_SYNC, SMB CLOSE / FLUSH, a segment rotation)
+	// publishes them. If the process dies before that, share start regrows the
+	// size from the journal's recovered extent — never past it.
+	size := state.MaxSize
+	if end, ok := s.durableExtentFor(shareNameForHandle(handle), state.PayloadID); ok {
+		// Floor the extent before widening it. A negative can only arrive from a
+		// resolver that breaks its contract, but converting one straight to uint64
+		// would wrap to a maximal bound, so the comparison below would pass every
+		// size through and the clamp would quietly stop clamping — the range it
+		// exists to withhold would be published and read back as zeros. Flooring
+		// makes an unusable answer withhold everything instead of nothing.
+		if durable := uint64(max(end, 0)); durable < size {
+			size = durable
+		}
 	}
 
 	commit := func(tx Transaction) error {
@@ -461,7 +487,7 @@ func (s *Service) flushPendingWrite(ctx *AuthContext, handle FileHandle, state *
 		// recorded mtime (SetCachedFile with a size but no write time) still
 		// takes the read-modify-write path below rather than stamping zero.
 		if applier, ok := tx.(DataWriteApplier); ok && !state.LastMtime.IsZero() {
-			_, err := applier.ApplyDataWrite(ctx.Context, handle, state.MaxSize, state.LastMtime, state.ClearSetuidSetgid)
+			_, err := applier.ApplyDataWrite(ctx.Context, handle, size, state.LastMtime, state.ClearSetuidSetgid)
 			return err
 		}
 
@@ -471,8 +497,8 @@ func (s *Service) flushPendingWrite(ctx *AuthContext, handle FileHandle, state *
 		}
 
 		// Apply pending changes
-		if state.MaxSize > file.Size {
-			file.Size = state.MaxSize
+		if size > file.Size {
+			file.Size = size
 		}
 		// Only update timestamps if a real write recorded a non-zero mtime.
 		// A zero LastMtime means this state was created by SetCachedFile for
@@ -490,9 +516,21 @@ func (s *Service) flushPendingWrite(ctx *AuthContext, handle FileHandle, state *
 	}
 
 	if durable {
-		return store.WithTransaction(ctx.Context, commit)
+		err = store.WithTransaction(ctx.Context, commit)
+	} else {
+		err = withRelaxedTransaction(store, ctx.Context, commit)
 	}
-	return withRelaxedTransaction(store, ctx.Context, commit)
+	if err != nil {
+		return err
+	}
+
+	// Anything held back above is still uncommitted, so put the state back: the
+	// next flush retries it once the data behind it is durable. RestorePending
+	// merges, so a write that raced in keeps the larger size.
+	if size < state.MaxSize {
+		s.pendingWrites.RestorePending(handle, state)
+	}
+	return nil
 }
 
 // GetPendingSize returns the pending size for a file if there are uncommitted writes.

--- a/pkg/metadata/pending_writes.go
+++ b/pkg/metadata/pending_writes.go
@@ -108,6 +108,11 @@ func (t *PendingWritesTracker) RecordWrite(handle FileHandle, intent *WriteOpera
 		if clearSetuid {
 			state.ClearSetuidSetgid = true
 		}
+		// A state created by SetCachedFile carries no payload, so the first real
+		// write fills in the one the flush needs to locate this file's bytes.
+		if state.PayloadID == "" {
+			state.PayloadID = intent.PayloadID
+		}
 	}
 
 	return state

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -48,6 +48,10 @@ type Service struct {
 	dirTimes           *DirTimesTracker                  // coalesced directory mtime/ctime/atime bumps (#1573)
 	writebackShares    map[string]bool                   // shareName -> writeback tier (#1757): relax FILE_SYNC metadata flush
 	deferredCommit     atomic.Bool                       // if true, use deferred commits (default: true); read lock-free on the write hot path
+	// durableExtent answers how far a payload's bytes are on stable storage in
+	// its share's block store. Installed by the control plane, which owns both
+	// tiers; nil wherever there is no block store to ask.
+	durableExtent atomic.Pointer[DurableExtentFunc]
 
 	// parentLinkShards is a fixed bank of mutexes that serialize the parent
 	// directory link-count read-modify-write (the ".." bump) done by mkdir (+1),
@@ -299,6 +303,29 @@ func (s *Service) shareWriteback(shareName string) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.writebackShares[shareName]
+}
+
+// DurableExtentFunc reports how far a payload's bytes are on stable storage in
+// the share's block store: bytes below the returned offset survive an unclean
+// shutdown, bytes above it do not. ok is false when the block store cannot
+// answer, which means "unknown" and never "nothing is durable".
+type DurableExtentFunc func(shareName string, payloadID PayloadID) (int64, bool)
+
+// SetDurableExtentResolver installs the block-store lookup flushPendingWrite
+// uses to keep a committed file size from describing bytes that are not durable
+// yet. Without it (unit tests, stores with no block tier) size commits behave as
+// they always have.
+func (s *Service) SetDurableExtentResolver(fn DurableExtentFunc) {
+	s.durableExtent.Store(&fn)
+}
+
+// durableExtentFor asks the installed resolver how far the payload is durable;
+// with no resolver the answer is "unknown".
+func (s *Service) durableExtentFor(shareName string, payloadID PayloadID) (int64, bool) {
+	if fn := s.durableExtent.Load(); fn != nil && *fn != nil {
+		return (*fn)(shareName, payloadID)
+	}
+	return 0, false
 }
 
 // RegisterStoreForShare associates a metadata store with a share.


### PR DESCRIPTION
Relates to #1909.

Under real device loss an acknowledged write came back with the correct file size and all-zero content. This is the crash-ordering sibling of #1879 / #1888 / #1894: same observable failure, different mechanism, so their fixes do not cover it.

## Diagnosed ordering

On the deferred write ack (SMB WRITE, NFS UNSTABLE WRITE):

1. `common.WriteToBlockStore` -> `engine.WriteAt` -> `journal.appendRecord`, which never fsyncs (its own doc comment says so). The bytes sit in the page cache.
2. `metadata.FlushPendingWriteForFile(..., durable=false)` -> `flushPendingWrite` -> `withRelaxedTransaction`, committing the grown `File.Size`.

That size then reaches stable storage on the metadata store's own schedule, entirely decoupled from the data:

- badger relaxed: `runDurabilitySync` fsyncs every `durabilitySyncInterval` (100ms), unconditionally.
- badger strict / sqlite / postgres: `withRelaxedTransaction` falls back to the fully durable `WithTransaction`, so the size is durable inline, at ack time.

The journal only fsyncs at an explicit commit (`Store.Commit` -> `groupCommit` -> `segSync`), a segment seal, or close. A write stream not followed by COMMIT/CLOSE therefore leaves durable size ahead of durable data permanently, not for a 100ms window. That matches the reported signature exactly, including record 0 (acked ~6s before the crash) reading as zeros: its size was fsynced within 100ms, its bytes never were.

**`reconcileMetadataSizeFromJournal` is not responsible.** It grows size only up to `localStore.FileSize`, computed from the index `recover()` rebuilds from records that physically survived and passed both header and payload CRC (`readRecord` / `errTornRecord`; the tail scan stops at the first torn record). That is the physically-present extent — a subset of what was durable. It also never shrinks, so it can neither cause the bug nor fix it.

## Fix: a committed size may never describe non-durable bytes

Clamping at commit time, which is simultaneously the ordering fix.

- **journal**: each shard tracks `lastVersion` (stamped under `sh.mu` once a record's writes return) and `syncedVersion` (raised after a completed fsync in `groupCommit`, after a segment seal, seeded to the replayed maximum at recovery). `DurableExtent` reports how far a file's bytes are on stable storage.
- **engine / metadata / shares**: `engine.Store.DurableExtent` exposes it upward, and `metadata.Service` gains a resolver installed by the shares service, which owns both tiers. A local tier that cannot answer returns "unknown", never "nothing is durable".
- **`flushPendingWrite`** holds the committed size to that extent. Held-back bytes stay in the pending-write state, so readers still see the acknowledged size through the pending merge, and the first flush after the data is committed publishes them.

Every existing durability sync point already commits the block store before flushing metadata (`flushStableWrite` for NFS FILE_SYNC, NFS COMMIT, SMB CLOSE, SMB FLUSH), so the clamp is a no-op there and none of them change behaviour. The write path stays asynchronous — no new fsync anywhere on it.

This pairs with the restart-time half that already existed: a persisted size never runs ahead of durable data, and share start grows it back up to that data.

### Two sharp edges, both covered by tests

**Out-of-order writes.** Intervals are sorted by offset but durability is keyed on Version (append order), so a durable interval can sit *above* a non-durable one. Taking the max end over qualifying intervals would jump the gap and report a size covering the range that vanishes — the original bug, relocated. The scan therefore stops at the first non-durable interval. Gaps nobody wrote are a different thing entirely: genuine sparse holes that read as zeros correctly and must not hold the extent back, or a client writing only at a high offset would never get a size.

**fsyncgate.** Once the kernel reports a write-back failure it drops those pages, and the next fsync can return success without them ever reaching the device. A shard freezes its watermark permanently on the first fsync failure, mirroring the stickiness `groupCommit` already applies to `errSeq`/`syncErr` for the same reason.

### Why not the alternatives

- **Ordering by fsyncing the journal before the ack** is #1904's write-through; it destroys the deferred write path.
- **Clamping down at reconcile time** would truncate genuine sparse files (truncate-grow legitimately leaves size above any written extent) and remote-only extents. Clamping at commit time has neither problem: truncate goes through SetAttr, not this path, and reconcile still only ever grows.
- **Distinguishability** — making the range recoverable as not-a-hole, the way `cold.log` did for evicted ranges — needs a durable marker written at ack time. `cold.log` can afford its fsync (`cold.go` fsyncs before returning) because eviction is a background event; a per-write ack marker cannot, which is write-through again. Written without an fsync it dies in the same crash as the data.

This is not silent-zeros traded for silent-truncation. An NFS UNSTABLE WRITE is explicitly *not* a durability promise (RFC 1813 — the client must COMMIT, and the reply carries `Committed: UNSTABLE`), and neither is an SMB write without write-through. Losing an uncommitted write is the contract; the shorter file is what the protocol expects, and the write verifier (`serverBootTime`) changing across a restart is exactly how the client learns to re-send. A read error would instead poison the range against that recovery path.

### Per QoS tier (`resolveDurabilityTier`)

- **local** (default): the tier the bug was measured on. Size now trails the journal's fsynced extent.
- **writeback**: downgrades per-op FILE_SYNC metadata flushes to relaxed, widening the gap. Same clamp, same invariant.
- **remote** (`require_durable_commit`): CLOSE/COMMIT block until data is durable remotely, and those paths commit the journal first, so the extent covers everything and nothing is held back.

## Tests

`pkg/block/journal/durable_extent_test.go`:
- **device loss, not process death** — records committed, then more acked but never committed, then the segment is physically truncated back to its length at the last fsync and reopened. What survives is exactly what `DurableExtent` predicted. A plain reopen proves nothing here: the page cache serves un-fsynced bytes straight back.
- out-of-order durable-above-non-durable, genuine sparse holes, and the fsync-failure freeze.

`pkg/controlplane/runtime/size_durability_test.go` — the merge gate, across memory/badger/sqlite: performs the adapter's write ack with no block commit and asserts the persisted size never exceeds the durable extent, that the acked size stays visible through the pending state, and that committing the data releases the full size (a delay, not a truncation). Without the clamp it fails on all three backends with `persisted size 262144 exceeds the durable extent 0`.

Each assertion was confirmed to fail with its guard removed.

## Also fixed

`PendingWritesTracker.RecordWrite` never filled `PayloadID` on its update branch, so the field was empty whenever `PrepareWrite`'s `SetCachedFile` had created the state first — the common case. Nothing read it before; the clamp does.

## Not covered

`CommitWrite`'s non-deferred path publishes size without routing through `flushPendingWrite`, so it is unclamped. It is unreachable in production — `SetDeferredCommit(false)` has test-only callers — so it is left alone rather than duplicating the lookup into dead code.
