### PR TITLE
fix(authz): close three data-plane authorization gaps

### DIFF
--- a/internal/adapter/nfs/v3/handlers/commit.go
+++ b/internal/adapter/nfs/v3/handlers/commit.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
 	"github.com/marmos91/dittofs/internal/adapter/common"
@@ -78,7 +80,9 @@ type CommitResponse struct {
 // Flushes cached unstable writes to stable storage for a file byte range.
 // Delegates to BlockStore.Flush and MetadataService.FlushPendingWriteForFile.
 // Triggers cache-to-store transfer; returns WCC data and server boot-time write verifier.
-// Errors: NFS3ErrNoEnt (file not found), NFS3ErrIsDir (directory handle), NFS3ErrIO (flush failure).
+// Errors: NFS3ErrNoEnt (file not found), NFS3ErrIsDir (directory handle),
+// NFS3ErrAccess / NFS3ErrRofs (no write permission on the file or its share),
+// NFS3ErrIO (flush failure).
 func (h *Handler) Commit(
 	ctx *NFSHandlerContext,
 	req *CommitRequest,
@@ -131,6 +135,45 @@ func (h *Handler) Commit(
 			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIsDir},
 			AttrBefore:      wccBefore,
 			AttrAfter:       wccAfter,
+		}, nil
+	}
+
+	// Enforce write permission before forcing anything to stable storage.
+	// COMMIT (RFC 1813 3.3.21) is the durability half of WRITE, so it takes
+	// the same gate WRITE takes via PrepareWrite — otherwise any client
+	// holding a traversable handle could force flush + upload work on a file
+	// it may not modify. knfsd likewise verifies the handle with
+	// NFSD_MAY_WRITE for COMMIT.
+	//
+	// The gate runs against the file loaded above, which may be the
+	// pending-write cached copy — a mode change made after the writes were
+	// accepted is therefore not seen until the cache is flushed. That window
+	// is deliberate: those bytes already passed the write gate, and refusing
+	// to make accepted data durable would strand it.
+	authCtx, err := h.GetCachedAuthContext(ctx)
+	if err != nil {
+		if ctx.Context.Err() != nil {
+			return nil, ctx.Context.Err()
+		}
+		logAuthCtxError(ctx.Context, err, "COMMIT",
+			"handle", fmt.Sprintf("0x%x", req.Handle), "client", clientIP)
+		return &CommitResponse{
+			NFSResponseBase: NFSResponseBase{Status: authDenialStatus(err)},
+			AttrBefore:      wccBefore,
+			AttrAfter:       h.convertFileAttrToNFS(handle, &file.FileAttr),
+		}, nil
+	}
+
+	if err := metaSvc.CheckWritePermissionFile(authCtx, handle, file); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
+		status := common.MapToNFS3(err)
+		logger.DebugCtx(ctx.Context, "COMMIT denied", "handle", fmt.Sprintf("0x%x", req.Handle), "status", status, "client", clientIP, "error", err)
+		return &CommitResponse{
+			NFSResponseBase: NFSResponseBase{Status: status},
+			AttrBefore:      wccBefore,
+			AttrAfter:       h.convertFileAttrToNFS(handle, &file.FileAttr),
 		}, nil
 	}
 
@@ -207,20 +250,16 @@ func (h *Handler) Commit(
 		}, nil
 	}
 
-	// Build auth context for metadata flush
-	authCtx, authErr := h.GetCachedAuthContext(ctx)
-	if authErr == nil {
-		// Flush pending metadata for this specific file
-		// Relaxed metadata commit (#1687): COMMIT already forced the block data
-		// durable above; the size/mtime fsync is deferred to the background syncer,
-		// with the journal size reconcile on restart as the crash-safety net.
-		flushed, metaErr := metaSvc.FlushPendingWriteForFile(authCtx, handle, false)
-		if metaErr != nil {
-			logger.WarnCtx(ctx.Context, "COMMIT: metadata flush failed", "handle", fmt.Sprintf("0x%x", req.Handle), "error", metaErr)
-			// Continue - content is flushed, metadata will be fixed eventually
-		} else if flushed {
-			logger.DebugCtx(ctx.Context, "COMMIT: flushed pending metadata", "handle", fmt.Sprintf("0x%x", req.Handle))
-		}
+	// Flush pending metadata for this specific file.
+	// Relaxed metadata commit: COMMIT already forced the block data durable
+	// above; the size/mtime fsync is deferred to the background syncer, with
+	// the journal size reconcile on restart as the crash-safety net.
+	flushed, metaErr := metaSvc.FlushPendingWriteForFile(authCtx, handle, false)
+	if metaErr != nil {
+		logger.WarnCtx(ctx.Context, "COMMIT: metadata flush failed", "handle", fmt.Sprintf("0x%x", req.Handle), "error", metaErr)
+		// Continue - content is flushed, metadata will be fixed eventually
+	} else if flushed {
+		logger.DebugCtx(ctx.Context, "COMMIT: flushed pending metadata", "handle", fmt.Sprintf("0x%x", req.Handle))
 	}
 
 	// wccAfter is already correct: GetFileCached returned the file with pending

--- a/internal/adapter/nfs/v3/handlers/commit_test.go
+++ b/internal/adapter/nfs/v3/handlers/commit_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/nfs/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v3/handlers"
 	handlertesting "github.com/marmos91/dittofs/internal/adapter/nfs/v3/handlers/testing"
+	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -47,4 +48,55 @@ func TestCommit_InvalidHandle(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqualValues(t, types.NFS3OK, resp.Status,
 		"Invalid handle should not return NFS3OK")
+}
+
+// TestCommit_PermissionDenied verifies COMMIT is gated on write permission:
+// a non-root caller cannot force a flush of a mode-000 root-owned file.
+// Without the gate any client holding a traversable handle could drive
+// stable-storage flushes and uploads on files it may not modify.
+func TestCommit_PermissionDenied(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	rootCtx := fx.ContextWithUID(0, 0)
+
+	createResp, err := fx.Handler.Create(rootCtx, &handlers.CreateRequest{
+		DirHandle: fx.RootHandle,
+		Filename:  "rootonly.txt",
+		Mode:      types.CreateUnchecked,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, types.NFS3OK, createResp.Status)
+
+	mode := uint32(0000)
+	setattrResp, err := fx.Handler.SetAttr(rootCtx, &handlers.SetAttrRequest{
+		Handle:  createResp.FileHandle,
+		NewAttr: metadata.SetAttrs{Mode: &mode},
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, types.NFS3OK, setattrResp.Status)
+
+	resp, err := fx.Handler.Commit(fx.Context(), &handlers.CommitRequest{
+		Handle: createResp.FileHandle,
+	})
+
+	require.NoError(t, err)
+	assert.EqualValues(t, types.NFS3ErrAccess, resp.Status,
+		"COMMIT on a mode-000 root-owned file by non-root must return NFS3ErrAccess")
+}
+
+// TestCommit_PermissionGranted is the companion: the writer of a file it owns
+// still commits successfully, so the gate costs the normal write-then-commit
+// flow nothing.
+func TestCommit_PermissionGranted(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	// CreateFile makes the file mode 0644 owned by DefaultUID (1000).
+	fileHandle := fx.CreateFile("mine.txt", []byte("committed content"))
+
+	resp, err := fx.Handler.Commit(fx.Context(), &handlers.CommitRequest{
+		Handle: fileHandle,
+	})
+
+	require.NoError(t, err)
+	assert.EqualValues(t, types.NFS3OK, resp.Status)
 }

--- a/internal/adapter/nfs/v4/handlers/commit.go
+++ b/internal/adapter/nfs/v4/handlers/commit.go
@@ -94,6 +94,22 @@ func (h *Handler) handleCommit(ctx *types.CompoundContext, reader io.Reader) *ty
 		}
 	}
 
+	// Enforce write permission before forcing anything to stable storage.
+	// COMMIT (RFC 7530 16.5) is the durability half of WRITE, so it takes the
+	// same gate WRITE takes via PrepareWrite — otherwise any client holding a
+	// traversable filehandle could force flush + upload work on a file it may
+	// not modify. knfsd likewise verifies the handle with NFSD_MAY_WRITE for
+	// COMMIT.
+	if err := metaSvc.CheckWritePermissionFile(authCtx, fileHandle, file); err != nil {
+		status := common.MapToNFS4(err)
+		logger.Debug("NFSv4 COMMIT denied", "status", status, "error", err, "client", ctx.ClientAddr)
+		return &types.CompoundResult{
+			Status: status,
+			OpCode: types.OP_COMMIT,
+			Data:   encodeStatusOnly(status),
+		}
+	}
+
 	// If no content, just return success
 	if file.PayloadID == "" {
 		logger.Debug("NFSv4 COMMIT: no content to flush", "client", ctx.ClientAddr)

--- a/internal/adapter/nfs/v4/handlers/io_test.go
+++ b/internal/adapter/nfs/v4/handlers/io_test.go
@@ -1327,3 +1327,48 @@ func TestStateid4_EncodeDecode(t *testing.T) {
 		t.Errorf("other = %v, want %v", decoded.Other, original.Other)
 	}
 }
+
+// ============================================================================
+// COMMIT permission tests
+// ============================================================================
+
+// TestCommit_PermissionDenied verifies COMMIT is gated on write permission:
+// a non-root caller cannot force a flush of a mode-000 root-owned file.
+// Without the gate any client holding a traversable filehandle could drive
+// stable-storage flushes and uploads on files it may not modify.
+func TestCommit_PermissionDenied(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "rootonly.txt", 0o000, 0, 0)
+
+	ctx := newRealFSContext(1000, 1000)
+	ctx.CurrentFH = make([]byte, len(fileHandle))
+	copy(ctx.CurrentFH, fileHandle)
+
+	result := fx.handler.handleCommit(ctx, bytes.NewReader(encodeCommitArgs(0, 0)))
+
+	if result.Status != types.NFS4ERR_ACCESS {
+		t.Errorf("COMMIT on a mode-000 root-owned file by non-root status = %d, want NFS4ERR_ACCESS (%d)",
+			result.Status, types.NFS4ERR_ACCESS)
+	}
+}
+
+// TestCommit_PermissionGranted is the companion: the owner of a writable file
+// still commits successfully, so the gate costs the normal write-then-commit
+// flow nothing.
+func TestCommit_PermissionGranted(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "mine.txt", 0o644, 1000, 1000)
+	fx.writeContent(t, fileHandle, []byte("committed content"))
+
+	ctx := newRealFSContext(1000, 1000)
+	ctx.CurrentFH = make([]byte, len(fileHandle))
+	copy(ctx.CurrentFH, fileHandle)
+
+	result := fx.handler.handleCommit(ctx, bytes.NewReader(encodeCommitArgs(0, 0)))
+
+	if result.Status != types.NFS4_OK {
+		t.Errorf("COMMIT by the file owner status = %d, want NFS4_OK", result.Status)
+	}
+}

--- a/pkg/metadata/acl/evaluate.go
+++ b/pkg/metadata/acl/evaluate.go
@@ -87,6 +87,14 @@ type EvaluateContext struct {
 	// Empty when the session is POSIX-only.
 	GroupSIDs []string
 
+	// Anonymous marks the requester as carrying no identity (no UID was
+	// resolved for the session). Its UID/GID/Who fields are then Go zero
+	// values that name no principal, so only EVERYONE@ may match; without
+	// this flag the zero UID/GID collide with GROUP@ on a root-group-owned
+	// file and with an explicit "0@localdomain" ACE, handing an
+	// unauthenticated session the rights written for uid/gid 0.
+	Anonymous bool
+
 	// RequesterHasTakeOwnership indicates whether the requester holds the
 	// SeTakeOwnershipPrivilege (MS-DTYP §2.5.3.2). Only privilege holders
 	// receive WRITE_OWNER implicitly when they own the file. On Windows
@@ -378,6 +386,13 @@ func EvaluateGranted(a *ACL, evalCtx *EvaluateContext, probeMask uint32) uint32 
 // Mirrors Samba `libcli/security/access_check.c::se_access_check` handling
 // of `SID_OWNER_RIGHTS` / `SEC_RIGHTS_OWNER_RIGHTS`.
 func aceMatchesWhoWithOwnerRights(ace *ACE, evalCtx *EvaluateContext, ownerRightsPresent bool) bool {
+	// An identity-less requester matches EVERYONE@ and nothing else: its
+	// zero-valued UID/GID/Who name no principal, so every arm below must
+	// miss rather than collide with uid/gid 0.
+	if evalCtx.Anonymous {
+		return ace.Who == SpecialEveryone
+	}
+
 	requesterIsOwner := evalCtx.UID == evalCtx.FileOwnerUID
 
 	switch ace.Who {

--- a/pkg/metadata/acl/evaluate_test.go
+++ b/pkg/metadata/acl/evaluate_test.go
@@ -947,6 +947,7 @@ func TestHasTakeOwnershipPrivilege(t *testing.T) {
 // miss. See #540.
 func anonRootOwnedCtx() *EvaluateContext {
 	return &EvaluateContext{
+		Anonymous:    true,
 		UID:          0,
 		FileOwnerUID: AnonymousFileOwnerUID,
 		FileOwnerGID: 0,
@@ -1017,5 +1018,55 @@ func TestEvaluate_Anonymous_EveryoneStillMatches(t *testing.T) {
 	// But nothing beyond what EVERYONE@ grants.
 	if Evaluate(a, ctx, ACE4_WRITE_DATA) {
 		t.Error("#540: anonymous must not receive bits outside the EVERYONE@ grant")
+	}
+}
+
+// TestEvaluate_Anonymous_NoLocalDomainOrGroupMatch asserts that an
+// identity-less requester does not pick up ACEs written for uid/gid 0. Its
+// zero-valued UID/GID name no principal, so neither an explicit
+// "0@localdomain" ACE nor GROUP@ on a root-group-owned file may match.
+func TestEvaluate_Anonymous_NoLocalDomainOrGroupMatch(t *testing.T) {
+	localDomain := &ACL{
+		ACEs: []ACE{
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: "0@localdomain"},
+		},
+	}
+	if Evaluate(localDomain, anonRootOwnedCtx(), ACE4_READ_DATA) {
+		t.Error("anonymous must not match a 0@localdomain ACE via its zero-valued UID")
+	}
+
+	group := &ACL{
+		ACEs: []ACE{
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialGroup},
+		},
+	}
+	if Evaluate(group, anonRootOwnedCtx(), ACE4_READ_DATA) {
+		t.Error("anonymous must not match GROUP@ on a gid-0 owned file via its zero-valued GID")
+	}
+}
+
+// TestEvaluate_AuthenticatedRoot_MatchesLocalDomainAndGroup is the companion:
+// a real uid-0 identity still matches the very ACEs the anonymous requester is
+// denied, so confining anonymous to EVERYONE@ costs an authenticated root
+// nothing.
+func TestEvaluate_AuthenticatedRoot_MatchesLocalDomainAndGroup(t *testing.T) {
+	rootCtx := &EvaluateContext{UID: 0, GID: 0, FileOwnerUID: 500, FileOwnerGID: 0}
+
+	localDomain := &ACL{
+		ACEs: []ACE{
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: "0@localdomain"},
+		},
+	}
+	if !Evaluate(localDomain, rootCtx, ACE4_READ_DATA) {
+		t.Error("an authenticated uid-0 requester must still match its 0@localdomain ACE")
+	}
+
+	group := &ACL{
+		ACEs: []ACE{
+			{Type: ACE4_ACCESS_ALLOWED_ACE_TYPE, AccessMask: ACE4_READ_DATA, Who: SpecialGroup},
+		},
+	}
+	if !Evaluate(group, rootCtx, ACE4_READ_DATA) {
+		t.Error("an authenticated requester in the file's owning group must still match GROUP@")
 	}
 }

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -418,10 +418,11 @@ func evaluateACLPermissions(
 		// owner-implicit RC|WRITE_DAC pass by forcing FileOwnerUID to
 		// the AnonymousFileOwnerUID sentinel — without it the requester's
 		// zero-valued UID would collapse onto a root-owned file's owner.
-		// EVERYONE@ ACEs still match. GROUP@ and the "<n>@localdomain"
-		// form may still match on UID/GID-0 owned files (residuals
-		// tracked under #540).
+		// Anonymous additionally confines matching to EVERYONE@, so the
+		// zero-valued UID/GID cannot pick up GROUP@ on a root-group-owned
+		// file or an explicit "0@localdomain" ACE.
 		evalCtx := &acl.EvaluateContext{
+			Anonymous:    true,
 			FileOwnerUID: acl.AnonymousFileOwnerUID,
 			FileOwnerGID: file.GID,
 		}
@@ -576,16 +577,16 @@ func (s *Service) shareForbidsWrites(ctx *AuthContext, handle FileHandle) bool {
 // the share's default "read" permission — see the NFS share-permission
 // resolver), and such a denial is an ordinary permission denial (EACCES), not a
 // read-only filesystem.
+//
+// The share name comes from the handle, which encodes share identity — the
+// same source storeForHandle routes on — so no inode fetch is needed to learn
+// which share's options to read.
 func (s *Service) shareIsReadOnly(ctx *AuthContext, handle FileHandle) bool {
 	store, err := s.storeForHandle(handle)
 	if err != nil {
 		return false
 	}
-	file, err := store.GetFile(ctx.Context, handle)
-	if err != nil {
-		return false
-	}
-	shareOpts, err := store.GetShareOptions(ctx.Context, file.ShareName)
+	shareOpts, err := store.GetShareOptions(ctx.Context, shareNameForHandle(handle))
 	return err == nil && shareOpts != nil && shareOpts.ReadOnly
 }
 
@@ -594,11 +595,12 @@ func (s *Service) checkWritePermission(ctx *AuthContext, handle FileHandle) erro
 	return s.checkPermission(ctx, handle, PermissionWrite, "write permission denied")
 }
 
-// checkWritePermissionFile is checkWritePermission on an already-loaded file —
-// PrepareWrite holds the file (its own cache/fetch) before checking, so this
-// avoids the permission path's redundant re-fetch (store.GetFile + derivePath +
-// JSON decode) on every write.
-func (s *Service) checkWritePermissionFile(ctx *AuthContext, handle FileHandle, file *File) error {
+// CheckWritePermissionFile verifies write permission on an already-loaded file,
+// without re-fetching it — the write-side sibling of CheckReadPermissionFile.
+// PrepareWrite uses it to skip the permission path's redundant re-fetch
+// (store.GetFile + derivePath + JSON decode) on every write, and the NFS COMMIT
+// handler to gate its forced flush on the File it already loaded.
+func (s *Service) CheckWritePermissionFile(ctx *AuthContext, handle FileHandle, file *File) error {
 	return s.checkPermissionFile(ctx, handle, file, PermissionWrite, "write permission denied")
 }
 
@@ -656,7 +658,7 @@ func (s *Service) CheckParentCreateAccess(ctx *AuthContext, parentHandle FileHan
 // parent File — e.g. createEntry, which loads it once to validate the directory
 // type — passes it here so a single CreateFile no longer loads the same parent
 // handle three times. The no-ACL path routes through the file-passing
-// checkWritePermissionFile so it too avoids a re-fetch. Semantics are
+// CheckWritePermissionFile so it too avoids a re-fetch. Semantics are
 // byte-for-byte those of CheckParentCreateAccess (same NFSv4 ADD_FILE vs
 // ADD_SUBDIRECTORY mask, same read-only ordering); only the redundant reads go.
 func (s *Service) CheckParentCreateAccessFile(ctx *AuthContext, parentHandle FileHandle, file *File, isDirectory bool) error {
@@ -672,7 +674,7 @@ func (s *Service) CheckParentCreateAccessFile(ctx *AuthContext, parentHandle Fil
 	// POSIX-write check so mode bits / share-level grants apply uniformly. Reuse
 	// the already-loaded parent so the write check does not re-fetch the inode.
 	if file.ACL == nil {
-		return s.checkWritePermissionFile(ctx, parentHandle, file)
+		return s.CheckWritePermissionFile(ctx, parentHandle, file)
 	}
 
 	shareOpts, _ := store.GetShareOptions(ctx.Context, file.ShareName)
@@ -747,8 +749,15 @@ func (s *Service) CheckParentCreateAccessFile(ctx *AuthContext, parentHandle Fil
 // extensions (e.g. explicit DELETE ACE evaluation) and kept for signature
 // stability across call sites.
 func (s *Service) checkDeletePermission(ctx *AuthContext, parentHandle FileHandle, _ *File) error {
-	// Rule 1: upstream DELETE-access grant.
-	if ctx.HasDeleteAccess && !ctx.ShareReadOnly {
+	// Rule 1: upstream DELETE-access grant. shareForbidsWrites checks both
+	// read-only ceilings — the per-user one, frozen when the tree was
+	// connected, and the store-level share option, which can turn read-only
+	// while that tree connection or an open handle is still held. The
+	// store-level arm is not redundant with the per-user one and must not be
+	// dropped as an apparent duplicate: it is the only one that sees a share
+	// flipped read-only after the grant was frozen. It costs one share-options
+	// lookup, and only when the per-user ceiling is not already set.
+	if ctx.HasDeleteAccess && !s.shareForbidsWrites(ctx, parentHandle) {
 		return nil
 	}
 
@@ -1161,8 +1170,10 @@ func buildFileAccessEvalContext(file *File, authCtx *AuthContext) *acl.EvaluateC
 		// FileOwnerUID is forced to the AnonymousFileOwnerUID sentinel so
 		// the anonymous requester's zero-valued UID cannot collapse onto a
 		// root-owned file's owner and pick up OWNER@ ACEs plus the
-		// MS-DTYP §2.5.3.2 owner-implicit RC|WRITE_DAC grant. See #540.
+		// MS-DTYP §2.5.3.2 owner-implicit RC|WRITE_DAC grant. Anonymous
+		// confines the DACL walk to EVERYONE@.
 		return &acl.EvaluateContext{
+			Anonymous:    true,
 			FileOwnerUID: acl.AnonymousFileOwnerUID,
 			FileOwnerGID: file.GID,
 		}

--- a/pkg/metadata/auth_permissions_readonly_share_test.go
+++ b/pkg/metadata/auth_permissions_readonly_share_test.go
@@ -416,3 +416,53 @@ func TestLockFile_PerUserReadOnlyDeniesExclusiveLock(t *testing.T) {
 		t.Errorf("LockFile(shared) for read-only user err = %v, want nil", err)
 	}
 }
+
+// TestRemoveFile_StoreReadOnlyShareBlocksDeleteAccessBypass asserts that the
+// upstream DELETE-access grant (AuthContext.HasDeleteAccess, frozen at SMB
+// open time) does not survive the share being toggled read-only at the store
+// level. The per-user ceiling ctx.ShareReadOnly is fixed when the tree is
+// connected, so it stays false across the toggle; only the store-level check
+// closes the window.
+func TestRemoveFile_StoreReadOnlyShareBlocksDeleteAccessBypass(t *testing.T) {
+	f := newTestFixture(t)
+
+	uid, gid := uint32(1000), uint32(1000)
+
+	// Create the victim while the share is still writable.
+	_, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "doomed.txt",
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: uid, GID: gid})
+	require.NoError(t, err)
+
+	// Share flips read-only after the handle was authorized.
+	_ = f.store.CreateShare(context.Background(), &metadata.Share{Name: f.shareName})
+	require.NoError(t, f.store.UpdateShareOptions(context.Background(), f.shareName,
+		&metadata.ShareOptions{ReadOnly: true}))
+
+	authCtx := f.smbDeleteContext(uid, gid)
+	authCtx.ShareReadOnly = false // per-user ceiling frozen at connect time
+
+	_, _, err = f.service.RemoveFile(authCtx, f.rootHandle, "doomed.txt")
+	require.Error(t, err, "a read-only share must block the HasDeleteAccess fast path")
+
+	var storeErr *metadata.StoreError
+	require.True(t, errors.As(err, &storeErr))
+	require.Equal(t, metadata.ErrReadOnly, storeErr.Code,
+		"a genuinely read-only share must map the denial to EROFS/NFS3ERR_ROFS")
+}
+
+// TestRemoveFile_DeleteAccessStillSucceedsOnWritableShare is the companion:
+// the DELETE-access fast path still unlinks on a writable share, including
+// when the caller has no POSIX write bit on the parent (the SMB
+// delete-on-close case the fast path exists for).
+func TestRemoveFile_DeleteAccessStillSucceedsOnWritableShare(t *testing.T) {
+	f := newTestFixture(t)
+
+	uid, gid := uint32(1000), uint32(1000)
+
+	_, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "removable.txt",
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: uid, GID: gid})
+	require.NoError(t, err)
+
+	_, _, err = f.service.RemoveFile(f.smbDeleteContext(uid, gid), f.rootHandle, "removable.txt")
+	require.NoError(t, err, "delete on a writable share must still succeed")
+}

--- a/pkg/metadata/file_access_checker.go
+++ b/pkg/metadata/file_access_checker.go
@@ -97,8 +97,9 @@ func buildAttrEvalContext(attr *FileAttr, authCtx *AuthContext) *acl.EvaluateCon
 		// Anonymous: force FileOwnerUID to the AnonymousFileOwnerUID sentinel so
 		// the requester's zero-valued UID cannot collapse onto a root-owned
 		// entry's owner and pick up OWNER@ ACEs plus the MS-DTYP §2.5.3.2
-		// owner-implicit grant. See #540.
+		// owner-implicit grant. Anonymous confines the DACL walk to EVERYONE@.
 		return &acl.EvaluateContext{
+			Anonymous:    true,
 			FileOwnerUID: acl.AnonymousFileOwnerUID,
 			FileOwnerGID: attr.GID,
 		}

--- a/pkg/metadata/io.go
+++ b/pkg/metadata/io.go
@@ -166,7 +166,7 @@ func (s *Service) PrepareWrite(ctx *AuthContext, handle FileHandle, newSize uint
 	// possibly-stale cache (unlike the soft size/quota checks above).
 	permErr := error(nil)
 	if freshFetch {
-		permErr = s.checkWritePermissionFile(ctx, handle, file)
+		permErr = s.CheckWritePermissionFile(ctx, handle, file)
 	} else {
 		permErr = s.checkWritePermission(ctx, handle)
 	}


### PR DESCRIPTION
Relates to #1918. Three independent authorization gaps on the data plane, each verified against source before fixing, each with a denial test that fails without the fix plus a companion test for the legitimate case.

## 1. COMMIT ran no permission check (NFSv3 **and** NFSv4)

`internal/adapter/nfs/v3/handlers/commit.go` forced a stable-storage flush and block-store upload on any handle the client could reach, with no gate. RFC 1813 3.3.21 leaves the timing to the server but not the authorization; Linux knfsd verifies the handle with `NFSD_MAY_WRITE` for COMMIT. Both handlers now gate on `metaSvc.CheckWritePermissionFile` (the write-side twin of the already-exported `CheckReadPermissionFile`, unexported until now), mirroring the READ gate in `read.go`.

The audit named only the v3 handler. Review found `internal/adapter/nfs/v4/handlers/commit.go` had the identical hole — `buildV4AuthContext` resolves the identity but no per-file check followed — so it is fixed here too rather than left as the same bug one protocol version over.

- Before: any client with a traversable handle could drive forced flush + upload work on a file it may not modify.
- After: denied with NFS3ERR_ACCES / NFS4ERR_ACCESS (NFS3ERR_ROFS on a read-only share) unless the caller has write permission.

The v3 handler also fetched an auth context a second time later for the metadata flush and **silently skipped the flush** when that failed, returning NFS3_OK. The single gate now fails closed before either flush, matching `read.go`.

Deliberately not changed: the gate evaluates the file from `GetFileCached`, which may be the pending-write cached copy, so a mode change made after the writes were accepted is not seen until the cache flushes. Those bytes already passed the write gate, and refusing to make accepted data durable would strand them; a fresh store read on every COMMIT is a hot-path cost (macOS COMMITs roughly every 4 MiB). Documented in the comment.

## 2. Delete fast path skipped the store-level read-only ceiling

`checkDeletePermission`'s `ctx.HasDeleteAccess` bypass checked only `ctx.ShareReadOnly`, the per-user ceiling frozen when the tree was connected. `tree_connect.go` clamps the grant at connect time, so the reachable window is a share toggled read-only while a tree connection or an open handle is still held — the exact case `checkFilePermissionsFile` already defends against. Now uses the existing `shareForbidsWrites` helper, so both ceilings gate the fast path.

- Before: an SMB handle holding a DELETE grant could unlink on a share that had since become read-only.
- After: denied with `ErrReadOnly` (EROFS / NFS3ERR_ROFS). Ordinary deletes on writable shares, including the delete-on-close case with no POSIX write bit, are unchanged.

## 3. An identity-less requester collided with uid/gid-0 ACEs

An anonymous requester's `EvaluateContext` carried Go zero-value UID/GID. `AnonymousFileOwnerUID` already stopped `OWNER@` matching, but `GROUP@` still matched on a root-group-owned file and an explicit `0@localdomain` ACE still matched the zero UID. New `EvaluateContext.Anonymous` makes the absence of an identity explicit rather than relying on zero values being unmatchable; `aceMatchesWhoWithOwnerRights` confines such a requester to `EVERYONE@`. Set at all three in-package identity-less construction sites.

- Before: an ACE naming uid 0, or `GROUP@` on a gid-0 owned file, granted its rights to an unauthenticated session.
- After: only `EVERYONE@` matches.

## Anonymous access and squashing stay intact

- `AllSquash` / `RootSquash` produce a concrete uid (`ApplyIdentityMapping`), so `Identity.UID != nil` and squashed requests never enter the anonymous branch — `Anonymous` stays false for them.
- Anonymous/AUTH_NONE clients still match `EVERYONE@` ACEs, and the POSIX no-ACL path is untouched.
- A real authenticated uid 0 short-circuits before any `EvaluateContext` is built, and still matches its `0@localdomain` ACE and `OWNER@`/`GROUP@` at the ACL layer.

## Tests

Each denial test was confirmed to fail against the unfixed code.

- `TestCommit_PermissionDenied` / `TestCommit_PermissionGranted` (v3 and v4 handlers)
- `TestRemoveFile_StoreReadOnlyShareBlocksDeleteAccessBypass` / `TestRemoveFile_DeleteAccessStillSucceedsOnWritableShare`
- `TestEvaluate_Anonymous_NoLocalDomainOrGroupMatch` / `TestEvaluate_AuthenticatedRoot_MatchesLocalDomainAndGroup`

`go build ./...`, `go vet ./...`, `gofmt -l .` clean; `go test ./pkg/metadata/... ./internal/adapter/nfs/...` 38/38 packages pass; `go test -race ./pkg/metadata/...` green.
