### PR TITLE
fix(block): hold a cold-read hydrate to the bytes its manifest row still claims

### DIFF
--- a/pkg/block/engine/cold_read_overwrite_test.go
+++ b/pkg/block/engine/cold_read_overwrite_test.go
@@ -5,7 +5,6 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/engine"
 	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
 	"github.com/marmos91/dittofs/pkg/metadata"
@@ -108,40 +107,17 @@ func runBoundaryShiftStale(t *testing.T, ms metadata.Store) {
 // depends on.
 func assertManifestTiles(t *testing.T, ms metadata.Store, pid string, fileSize int64, label string) {
 	t.Helper()
-	fbl, ok := ms.(interface {
-		ListFileChunks(context.Context, string) ([]*block.FileChunk, error)
-	})
-	if !ok {
-		t.Fatalf("%s: store %T has no ListFileChunks", label, ms)
-	}
-	rows, err := fbl.ListFileChunks(context.Background(), pid)
-	if err != nil {
-		t.Fatalf("%s: ListFileChunks: %v", label, err)
-	}
-	type span struct{ start, end int64 }
-	spans := make([]span, 0, len(rows))
-	for _, r := range rows {
-		abs, ok := block.ParseChunkOffset(r.ID)
-		if !ok {
-			continue
-		}
-		spans = append(spans, span{int64(abs), int64(abs) + int64(r.DataSize)})
-	}
-	for i := 1; i < len(spans); i++ { // insertion sort by start (few rows)
-		for j := i; j > 0 && spans[j].start < spans[j-1].start; j-- {
-			spans[j], spans[j-1] = spans[j-1], spans[j]
-		}
-	}
 	var cursor int64
-	for _, s := range spans {
-		if s.start > cursor {
-			t.Errorf("%s: manifest GAP [%d, %d) — cold read zero-fills this range", label, cursor, s.start)
+	for _, r := range manifestRefs(t, ms, pid) {
+		start, end := int64(r.Offset), int64(r.Offset)+int64(r.Size)
+		if start > cursor {
+			t.Errorf("%s: manifest GAP [%d, %d) — cold read zero-fills this range", label, cursor, start)
 		}
-		if s.start < cursor {
-			t.Errorf("%s: manifest OVERLAP at [%d, %d) — cold read may serve stale bytes", label, s.start, cursor)
+		if start < cursor {
+			t.Errorf("%s: manifest OVERLAP at [%d, %d) — cold read may serve stale bytes", label, start, cursor)
 		}
-		if s.end > cursor {
-			cursor = s.end
+		if end > cursor {
+			cursor = end
 		}
 	}
 	if cursor < fileSize {

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -80,7 +80,21 @@ func (m *Syncer) listFileChunksSnapshot(ctx context.Context, payloadID string) (
 // evictable). The (payloadID, offset) are parsed from the row ID
 // "<payloadID>/<offset>" (split on the last '/'). A malformed ID is a hard
 // error — an inconsistent manifest, not a benign miss.
+//
+// Only the bytes the row claims are written (see FileChunk.DataSize). A remote
+// read returns the whole chunk, so on a row a shrink narrowed to its surviving
+// prefix, writing the rest would restore bytes past the file's new end, above
+// the version of the marker that moved it, and a later re-extend would serve
+// them where a zero hole is due. A row claiming nothing therefore writes
+// nothing: the clamp fails closed, since a claim of zero reaching the local tier
+// as "write the whole chunk" is that same resurrection by another route.
 func (m *Syncer) hydrateChunk(ctx context.Context, fb *block.FileChunk, data []byte) error {
+	if claimed := uint64(fb.DataSize); claimed < uint64(len(data)) {
+		data = data[:claimed]
+	}
+	if len(data) == 0 {
+		return nil
+	}
 	i := strings.LastIndexByte(fb.ID, '/')
 	off, ok := block.ParseChunkOffset(fb.ID)
 	if i <= 0 || !ok {

--- a/pkg/block/engine/fetch_test.go
+++ b/pkg/block/engine/fetch_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"sync"
@@ -228,5 +229,50 @@ func TestInlineFetchOrWait_LocalPutError_PropagatesToWaiter(t *testing.T) {
 	m.inFlightMu.Unlock()
 	if leaked {
 		t.Errorf("inFlight entry leaked for %s/0; want no entry after error return", payloadID)
+	}
+}
+
+// TestHydrateChunk_WritesOnlyWhatTheRowClaims pins the clamp at the hydrate
+// seam. A remote read returns a chunk in full, so the row's claim is the only
+// thing standing between a shrunk file and the bytes it dropped coming back.
+// The zero case has to fail closed: a row claiming nothing must write nothing,
+// because "claims nothing" arriving at the local tier as "write the whole
+// chunk" is the same resurrection, reached through a sentinel rather than a
+// length. A zero-claim row cannot be picked as a covering row, but warm walks
+// the enumerated rows directly, so one does reach here.
+func TestHydrateChunk_WritesOnlyWhatTheRowClaims(t *testing.T) {
+	ctx := context.Background()
+	const chunkLen = 4096
+	chunk := bytes.Repeat([]byte{0xAB}, chunkLen)
+
+	for _, tc := range []struct {
+		name    string
+		claims  uint32
+		written int
+	}{
+		{"row claims the whole chunk", chunkLen, chunkLen},
+		{"row narrowed to a prefix", 1024, 1024},
+		{"row claims nothing", 0, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ls := memorylocal.New()
+			m := newFetchSyncer(ls, nil, nil, nil)
+			row := &block.FileChunk{ID: "share/file/0", DataSize: tc.claims}
+			if err := m.hydrateChunk(ctx, row, chunk); err != nil {
+				t.Fatalf("hydrateChunk: %v", err)
+			}
+			got := make([]byte, chunkLen)
+			if _, _, err := ls.ReadAt(ctx, "share/file", 0, got); err != nil {
+				t.Fatalf("ReadAt: %v", err)
+			}
+			for i, b := range got {
+				if i < tc.written && b != 0xAB {
+					t.Fatalf("byte %d is %#x, want the chunk's byte — the claimed prefix was not hydrated", i, b)
+				}
+				if i >= tc.written && b != 0 {
+					t.Fatalf("byte %d is %#x, want a zero hole — hydrate wrote past the row's claim of %d", i, b, tc.claims)
+				}
+			}
+		})
 	}
 }

--- a/pkg/block/engine/hydrate_extent_test.go
+++ b/pkg/block/engine/hydrate_extent_test.go
@@ -1,0 +1,228 @@
+package engine_test
+
+import (
+	"bytes"
+	"context"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/block/local/fs"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// A hydrate writes a fetched chunk back into the local tier at the chunk's file
+// offset. These tests drive the whole sequence that makes that dangerous —
+// write, carve, upload, shrink the file, evict the local copy, read cold — and
+// assert the bytes the shrink removed stay removed. Only a real eviction reaches
+// the cold-read resolve, so every case force-evicts and fails if it did not.
+
+// hydrateFixture builds an engine over a memory metadata store and a memory
+// remote, and hands back the local tier so a test can force eviction.
+func hydrateFixture(t *testing.T, share, name string) (*engine.Store, *fs.FSStore, metadata.Store, string) {
+	t.Helper()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	bs := newEngineWithRemote(t, ms, remotememory.New())
+	root := createShare(t, ms, share)
+	pid, _ := createRealFile(t, ms, share, name, root)
+	local, ok := bs.LocalForTest().(*fs.FSStore)
+	if !ok {
+		t.Fatalf("local tier is %T, not the journal-backed store the eviction path needs", bs.LocalForTest())
+	}
+	return bs, local, ms, pid
+}
+
+// manifestRefs projects the per-file FileChunk manifest into the []ChunkRef
+// shape the engine's mutating calls take, sorted by offset.
+func manifestRefs(t *testing.T, ms metadata.Store, pid string) []block.ChunkRef {
+	t.Helper()
+	lister, ok := ms.(interface {
+		ListFileChunks(context.Context, string) ([]*block.FileChunk, error)
+	})
+	if !ok {
+		t.Fatalf("store %T has no ListFileChunks", ms)
+	}
+	rows, err := lister.ListFileChunks(context.Background(), pid)
+	if err != nil {
+		t.Fatalf("ListFileChunks: %v", err)
+	}
+	refs := make([]block.ChunkRef, 0, len(rows))
+	for _, r := range rows {
+		abs, ok := block.ParseChunkOffset(r.ID)
+		if !ok {
+			continue
+		}
+		refs = append(refs, block.ChunkRef{Hash: r.Hash, Offset: abs, Size: r.DataSize})
+	}
+	sort.Slice(refs, func(i, j int) bool { return refs[i].Offset < refs[j].Offset })
+	return refs
+}
+
+// evictAll drops every evictable local segment so the next read of those bytes
+// must resolve a manifest row and fetch from the remote.
+func evictAll(t *testing.T, local *fs.FSStore) {
+	t.Helper()
+	res, err := local.Evict(context.Background(), 1<<30)
+	if err != nil {
+		t.Fatalf("Evict: %v", err)
+	}
+	if res.SegmentsEvicted == 0 {
+		t.Fatal("nothing was evicted — the test never reaches a cold read")
+	}
+}
+
+func readAt(t *testing.T, bs *engine.Store, pid string, refs []block.ChunkRef, off uint64, n int) []byte {
+	t.Helper()
+	buf := make([]byte, n)
+	if _, err := bs.ReadAt(context.Background(), pid, refs, buf, off); err != nil {
+		t.Fatalf("ReadAt at %d: %v", off, err)
+	}
+	return buf
+}
+
+func assertZeros(t *testing.T, got []byte, what string) {
+	t.Helper()
+	for i, b := range got {
+		if b != 0 {
+			t.Fatalf("%s: byte %d is %#x, want a zero hole — removed bytes were resurrected", what, i, b)
+		}
+	}
+}
+
+// TestColdReadAfterTruncate_KeepsRemovedTailZeroed is the Truncate half: a chunk
+// straddling the new size is kept and nothing re-carves it, so reading its
+// surviving prefix cold resolves that row and a full-chunk hydrate would put the
+// removed tail back above the truncate marker's version. Re-extending the file
+// is what makes it visible — the range between the old and new end owes zeros.
+func TestColdReadAfterTruncate_KeepsRemovedTailZeroed(t *testing.T) {
+	ctx := context.Background()
+	bs, local, ms, pid := hydrateFixture(t, "truncshrink", "shrink.bin")
+
+	const fileSize = 4 << 20
+	orig := make([]byte, fileSize)
+	rand.New(rand.NewSource(0x7711)).Read(orig) //nolint:gosec // deterministic fixture
+	if _, err := bs.WriteAt(ctx, pid, nil, orig, 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	carve(t, bs, ctx, pid)
+
+	refs := manifestRefs(t, ms, pid)
+	if len(refs) == 0 {
+		t.Fatal("no manifest rows after carve")
+	}
+	// Shrink into the middle of the last chunk so exactly one row straddles.
+	last := refs[len(refs)-1]
+	if last.Size < 8192 {
+		t.Fatalf("last chunk is %d bytes, too small to straddle meaningfully", last.Size)
+	}
+	newSize := last.Offset + uint64(last.Size)/2
+
+	kept, err := bs.Truncate(ctx, pid, refs, newSize)
+	if err != nil {
+		t.Fatalf("Truncate: %v", err)
+	}
+	for _, r := range manifestRefs(t, ms, pid) {
+		if end := r.Offset + uint64(r.Size); end > newSize {
+			t.Fatalf("manifest row at %d still claims up to %d, past the new size %d", r.Offset, end, newSize)
+		}
+	}
+
+	evictAll(t, local)
+
+	// Cold read of the surviving prefix: resolves the straddling row, fetches
+	// the whole chunk from the remote, and hydrates.
+	got := readAt(t, bs, pid, kept, newSize-4096, 4096)
+	if !bytes.Equal(got, orig[newSize-4096:newSize]) {
+		t.Fatal("surviving prefix did not read back after the cold read")
+	}
+
+	// Re-extend past the truncate point, leaving a hole behind the new write.
+	const holeLen = 8192
+	tailData := bytes.Repeat([]byte{0xEE}, 4096)
+	if _, err := bs.WriteAt(ctx, pid, nil, tailData, newSize+holeLen); err != nil {
+		t.Fatalf("re-extend WriteAt: %v", err)
+	}
+	refs = manifestRefs(t, ms, pid)
+
+	assertZeros(t, readAt(t, bs, pid, refs, newSize, holeLen), "re-extended hole")
+	if !bytes.Equal(readAt(t, bs, pid, refs, newSize+holeLen, 4096), tailData) {
+		t.Fatal("re-extending write did not read back")
+	}
+}
+
+// TestColdReadAfterPunchHole_KeepsHoleZeroed is the PunchHole half: the same
+// shape at a hole boundary rather than at the end of the file. A block only
+// partially inside the punched range is kept, so a cold read inside the hole
+// must not come back with the pre-punch bytes.
+func TestColdReadAfterPunchHole_KeepsHoleZeroed(t *testing.T) {
+	ctx := context.Background()
+	bs, local, ms, pid := hydrateFixture(t, "punchhole", "punch.bin")
+
+	const fileSize = 4 << 20
+	orig := make([]byte, fileSize)
+	rand.New(rand.NewSource(0x5150)).Read(orig) //nolint:gosec // deterministic fixture
+	if _, err := bs.WriteAt(ctx, pid, nil, orig, 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	carve(t, bs, ctx, pid)
+
+	refs := manifestRefs(t, ms, pid)
+	// Punch a range that starts inside one chunk and ends inside another, so
+	// blocks on both boundaries are kept partially overlapping.
+	const holeOff, holeLen = 1 << 20, 256 << 10
+	if _, err := bs.PunchHole(ctx, pid, refs, holeOff, holeLen); err != nil {
+		t.Fatalf("PunchHole: %v", err)
+	}
+	// The zeros land through the local write path, so they must be carved and
+	// uploaded before anything can be evicted.
+	carve(t, bs, ctx, pid)
+	refs = manifestRefs(t, ms, pid)
+
+	// Structural counterpart to the read assertions: the re-carved zeros
+	// supersede the punched rows, so nothing in the manifest still covers the
+	// hole alongside them. Without that, a covering lookup could pick either row
+	// and the reads below would only be passing by luck.
+	assertManifestTiles(t, ms, pid, fileSize, "after-punch")
+
+	evictAll(t, local)
+
+	assertZeros(t, readAt(t, bs, pid, refs, holeOff, holeLen), "punched range")
+	// The bytes on either side of the hole are untouched and must still read.
+	if !bytes.Equal(readAt(t, bs, pid, refs, holeOff-4096, 4096), orig[holeOff-4096:holeOff]) {
+		t.Fatal("bytes before the hole did not survive")
+	}
+	if !bytes.Equal(readAt(t, bs, pid, refs, holeOff+holeLen, 4096), orig[holeOff+holeLen:holeOff+holeLen+4096]) {
+		t.Fatal("bytes after the hole did not survive")
+	}
+}
+
+// TestColdReadSparseFile_HydratesAtHighOffset is the other side of the clamp: a
+// genuinely sparse file must keep working. Its data lives only at a high offset
+// with no interval below it, so the hydrate has to land at that offset and the
+// untouched range in front of it has to keep reading as zeros.
+func TestColdReadSparseFile_HydratesAtHighOffset(t *testing.T) {
+	ctx := context.Background()
+	bs, local, ms, pid := hydrateFixture(t, "sparse", "sparse.bin")
+
+	const dataOff = 2 << 20
+	data := make([]byte, 256<<10)
+	rand.New(rand.NewSource(0x0FF5)).Read(data) //nolint:gosec // deterministic fixture
+	if _, err := bs.WriteAt(ctx, pid, nil, data, dataOff); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	carve(t, bs, ctx, pid)
+
+	refs := manifestRefs(t, ms, pid)
+	evictAll(t, local)
+
+	if got := readAt(t, bs, pid, refs, dataOff, len(data)); !bytes.Equal(got, data) {
+		t.Fatal("high-offset data did not hydrate back")
+	}
+	assertZeros(t, readAt(t, bs, pid, refs, 0, 4096), "leading hole")
+	assertZeros(t, readAt(t, bs, pid, refs, dataOff-4096, 4096), "hole in front of the data")
+	assertZeros(t, readAt(t, bs, pid, refs, dataOff+uint64(len(data)), 4096), "hole past the data")
+}

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -127,6 +127,35 @@ type blocksReprojector interface {
 	ReprojectBlocks(ctx context.Context, payloadID string) error
 }
 
+// narrowChunkRow shrinks a manifest row to the surviving prefix of its chunk so
+// coverage lookups stop resolving it for bytes the file no longer holds and a
+// hydrate writes back only that prefix. The remote chunk is untouched — its hash
+// still addresses the full bytes and the verified read still checks them all —
+// and RefCount is unchanged: the file still references the chunk, just less of
+// it. A row already at or below the surviving size, or already reaped, needs
+// nothing.
+func (bs *Store) narrowChunkRow(ctx context.Context, payloadID string, b block.ChunkRef) error {
+	if bs.fileChunkStore == nil {
+		return nil
+	}
+	id := fmt.Sprintf("%s/%d", payloadID, b.Offset)
+	row, err := bs.fileChunkStore.GetFileChunk(ctx, id)
+	if err != nil {
+		if errors.Is(err, block.ErrFileChunkNotFound) {
+			return nil
+		}
+		return fmt.Errorf("narrow block on truncate %s: %w", id, err)
+	}
+	if row == nil || row.DataSize <= b.Size {
+		return nil
+	}
+	row.DataSize = b.Size
+	if err := bs.fileChunkStore.Put(ctx, row); err != nil {
+		return fmt.Errorf("narrow block on truncate %s: %w", id, err)
+	}
+	return nil
+}
+
 func (bs *Store) Truncate(ctx context.Context, payloadID string, currentBlocks []block.ChunkRef, newSize uint64) ([]block.ChunkRef, error) {
 	if err := bs.enter(); err != nil {
 		return currentBlocks, err
@@ -154,8 +183,18 @@ func (bs *Store) Truncate(ctx context.Context, payloadID string, currentBlocks [
 				dropped = append(dropped, b)
 				continue
 			}
-			// Block fully or partially before newSize — keep. WriteAt will
-			// re-chunk the partial-tail block; keep it as-is.
+			if b.Offset+uint64(b.Size) > newSize {
+				// Straddles newSize: keep the surviving prefix, but stop the row
+				// claiming the rest. Nothing re-carves the chunk, so a row left
+				// covering the removed range is what a later cold read resolves,
+				// and its hydrate would write those bytes back locally. Narrowed
+				// before the reap below so the reprojection there reads a manifest
+				// that already stops at newSize.
+				b.Size = uint32(newSize - b.Offset)
+				if err := bs.narrowChunkRow(ctx, payloadID, b); err != nil {
+					return currentBlocks, err
+				}
+			}
 			kept = append(kept, b)
 		}
 

--- a/pkg/block/types.go
+++ b/pkg/block/types.go
@@ -243,7 +243,12 @@ type FileChunk struct {
 	// Hash is the BLAKE3-256 of the chunk data. Zero value means pending/incomplete.
 	Hash ContentHash
 
-	// DataSize is the actual bytes written in this chunk.
+	// DataSize is how many of the chunk's bytes belong to this file at this
+	// row's offset — the row's claim, which is what coverage lookups and a
+	// cold-read hydrate honour. It is the chunk's full length except where a
+	// shrink narrowed the row to the prefix that survived: the chunk on the
+	// remote still holds all of its bytes and is still hash-verified over all of
+	// them, the row just stops claiming the tail.
 	DataSize uint32
 
 	// RefCount is the number of files referencing this chunk.


### PR DESCRIPTION
Relates to #1911.

## Confirmed, and partly refuted

**Truncate half: confirmed.** A truncate landing inside a chunk keeps that chunk s manifest row verbatim (`readwrite.go`, drop predicate is only `b.Offset >= newSize`). journal `Store.Truncate` merely clips the local interval and never re-marks it dirty, so nothing re-carves the row and the tail segment — already fully synced — is immediately evictable. After eviction a cold read resolves the un-narrowed row and `hydrateChunk` writes the full `DataSize` at the chunk s absolute offset, restoring the removed tail above the version of the truncate marker. Re-extending then serves those stale bytes where a zero hole is due.

The new test fails on develop with:

```
re-extended hole: byte 0 is 0x3a, want a zero hole — removed bytes were resurrected
```

**PunchHole half: refuted as reported.** The punch overwrites the range with zeros through the local write path, and the carve of those zeros supersedes the punched rows, so the manifest still tiles the file exactly and the hole resolves only to the zero rows. The punch test passes both before and after this change; it is kept as a regression guard and now also asserts the tiling structurally (`assertManifestTiles`), so it is a structural refutation rather than one lucky green run.

## The fix

Two halves, both load-bearing:

1. **The shared seam** (`fetch.go` `hydrateChunk`) writes at most the bytes the row claims. Every production hydrate — the demand cold read (`inlineFetchOrWait`) and `fetchResolvedBlock`, used by both `WarmAll` and prefetch — routes through this one function, so the guard covers all of them rather than one named path.
2. **The boundary** (`readwrite.go` `Truncate`) narrows the straddling row s `DataSize` to the surviving prefix, which is what gives the clamp something to clamp to. Without it `DataSize == len(data)` and the clamp is a no-op.

Removing either half makes the truncate test fail again — the clamp alone leaves `manifest row at 3182115 still claims up to 4194304, past the new size 3688209`, the narrowing alone still resurrects `0x3a`.

The remote chunk is untouched. `readChunkVerified` reads by locator length and verifies the full bytes against the hash, so only the row s claim changes; RefCount is unchanged since the file still references the chunk, just less of it.

## Sparse files

Unaffected by construction: an unshrunk row claims its chunk in full, so the clamp is inert on every ordinary path. `TestColdReadSparseFile_HydratesAtHighOffset` pins it — a file written only at 2 MiB still hydrates there after eviction, and the leading gap, the gap in front of the data, and the range past it all still read as zeros.

## Verification

The failure needs eviction plus a cold read plus a re-extend, so each test drives the whole sequence: write, carve, upload, shrink, force-evict (`evictAll` fails the test if nothing was actually evicted, so it can never silently no-op), cold read, then re-extend and assert the hole.

```
go build ./... && go vet ./... && gofmt -l .   # clean
go test ./pkg/block/...                        # all ok (engine 34.5s, journal 31.7s)
go test -race ./pkg/block/engine/...           # ok 88.4s
```

Also folded in a small reuse win the simplifier found: `assertManifestTiles` had its own copy of the manifest projection, and now shares the new `manifestRefs` helper (−40/+8, error messages byte-identical).

## Coordination

Does not overlap PR #1929 — that adds a per-shard durable watermark and `DurableExtent` in the journal/metadata layers, which is about which bytes survive a crash. This is about which bytes a file logically still has, and touches only `pkg/block/engine`.