### PR TITLE
fix(lock): close the wait-for-graph check-then-act window and bound two lease-key sweeps

### DIFF
--- a/internal/adapter/smb/handlers/lock_async.go
+++ b/internal/adapter/smb/handlers/lock_async.go
@@ -43,19 +43,27 @@ func (h *Handler) parkLockOnConflict(
 	lockSeqEnabled bool,
 	lockSeqIndex uint32,
 	lockSeqNumber uint8,
-) (uint64, bool) {
-	// Deadlock detection: probe the conflicting holder via TestLock and
-	// check the WFG. If granting our wait would close a cycle, refuse to
-	// park — the inline-retry fallback then exits with LOCK_NOT_GRANTED.
+) (asyncId uint64, parked bool) {
+	// Deadlock detection: probe the conflicting holders via TestLock and record
+	// the wait edges in the WFG. TryAddWaiter refuses when they would close a
+	// cycle, and the inline-retry fallback then exits with LOCK_NOT_GRANTED.
+	// The edges go in before the async slot is reserved so concurrent callers
+	// see the wait immediately; the deferred unwind prunes them unless we park,
+	// where resumePendingLock prunes them on every exit path.
 	owners := h.conflictHolders(openFile.MetadataHandle, fileLock)
 	if h.LockWaitGraph != nil && len(owners) > 0 {
-		if h.LockWaitGraph.WouldCauseCycle(fileLock.OpenID, owners) {
+		if !h.LockWaitGraph.TryAddWaiter(fileLock.OpenID, owners) {
 			logger.Debug("LOCK: deadlock detected, refusing to park",
 				"waiter", fileLock.OpenID,
 				"owners", owners,
 				"messageID", ctx.MessageID)
 			return 0, false
 		}
+		defer func() {
+			if !parked {
+				h.LockWaitGraph.RemoveWaiter(fileLock.OpenID)
+			}
+		}()
 	}
 
 	if !ctx.TryReserveAsync() {
@@ -65,7 +73,7 @@ func (h *Handler) parkLockOnConflict(
 		return 0, false
 	}
 
-	asyncId := h.generateAsyncId()
+	asyncId = h.generateAsyncId()
 
 	// Wait context: independent of the request's Context (which would be
 	// torn down as soon as we return StatusPending). Cancellable by
@@ -97,13 +105,6 @@ func (h *Handler) parkLockOnConflict(
 			"messageID", ctx.MessageID,
 			"error", err)
 		return 0, false
-	}
-
-	// Add WFG edges before starting the resume goroutine so concurrent
-	// callers see the wait relationship. The resume goroutine prunes them
-	// via RemoveWaiter on every exit path.
-	if h.LockWaitGraph != nil && len(owners) > 0 {
-		h.LockWaitGraph.AddWaiter(fileLock.OpenID, owners)
 	}
 
 	go h.resumePendingLock(waitCtx, pending, openFile, fileLock)

--- a/internal/adapter/smb/handlers/lock_async_test.go
+++ b/internal/adapter/smb/handlers/lock_async_test.go
@@ -45,10 +45,12 @@ func TestLockOwnerOf(t *testing.T) {
 func TestLockWaitGraph_DeadlockDetection_Cycle(t *testing.T) {
 	wfg := lock.NewWaitForGraph()
 	// A waits for B.
-	wfg.AddWaiter("A", []string{"B"})
+	if !wfg.TryAddWaiter("A", []string{"B"}) {
+		t.Fatal("expected A->B to be recorded on an empty graph")
+	}
 	// B trying to wait for A would close a cycle.
-	if !wfg.WouldCauseCycle("B", []string{"A"}) {
-		t.Error("expected cycle (A->B->A), got no cycle")
+	if wfg.TryAddWaiter("B", []string{"A"}) {
+		t.Error("expected cycle (A->B->A) to be refused, got accepted")
 	}
 }
 
@@ -56,20 +58,22 @@ func TestLockWaitGraph_DeadlockDetection_Cycle(t *testing.T) {
 func TestLockWaitGraph_DeadlockDetection_NoCycle(t *testing.T) {
 	wfg := lock.NewWaitForGraph()
 	// A -> B is fine.
-	wfg.AddWaiter("A", []string{"B"})
+	if !wfg.TryAddWaiter("A", []string{"B"}) {
+		t.Fatal("expected A->B to be recorded on an empty graph")
+	}
 	// C -> A: no cycle.
-	if wfg.WouldCauseCycle("C", []string{"A"}) {
-		t.Error("expected no cycle for C->A->B, got cycle")
+	if !wfg.TryAddWaiter("C", []string{"A"}) {
+		t.Error("expected C->A->B to be accepted, got refused as a cycle")
 	}
 }
 
 // TestLockWaitGraph_RemoveWaiter prunes the waiter so future requests succeed.
 func TestLockWaitGraph_RemoveWaiter(t *testing.T) {
 	wfg := lock.NewWaitForGraph()
-	wfg.AddWaiter("A", []string{"B"})
+	wfg.TryAddWaiter("A", []string{"B"})
 	wfg.RemoveWaiter("A")
 	// B can now safely wait for A.
-	if wfg.WouldCauseCycle("B", []string{"A"}) {
-		t.Error("expected no cycle after RemoveWaiter, still got cycle")
+	if !wfg.TryAddWaiter("B", []string{"A"}) {
+		t.Error("expected B->A to be accepted after RemoveWaiter, got refused")
 	}
 }

--- a/pkg/adapter/nfs/nlm.go
+++ b/pkg/adapter/nfs/nlm.go
@@ -95,10 +95,11 @@ func (s *nlmService) LockFileNLM(
 	// admits reclaims so a prior owner can recover before a third party steals
 	// the range (X/Open NLMv4, RFC 7530 §9.6.2). A non-reclaim request is
 	// rejected with ErrGracePeriod, which the handler maps to NLM4_DENIED_GRACE_PERIOD.
-	allowed, graceErr := s.lockMgr.IsOperationAllowed(lock.Operation{
-		IsNew:     !reclaim,
-		IsReclaim: reclaim,
-	})
+	graceOp := lock.OpNew
+	if reclaim {
+		graceOp = lock.OpReclaim
+	}
+	allowed, graceErr := s.lockMgr.IsOperationAllowed(graceOp)
 	if !allowed {
 		return nil, graceErr
 	}
@@ -383,7 +384,7 @@ func (s *NFSAdapter) processNLMWaiters(handle metadata.FileHandle) {
 		}
 
 		// Try to add the lock
-		enhancedLock := metadata.NewUnifiedLock(
+		enhancedLock := lock.NewUnifiedLock(
 			waiter.Lock.Owner,
 			lock.FileHandle(handle),
 			waiter.Lock.Offset,

--- a/pkg/metadata/lock/connection.go
+++ b/pkg/metadata/lock/connection.go
@@ -160,10 +160,7 @@ func (ct *ConnectionTracker) RegisterClient(clientID, adapterType, remoteAddr st
 
 	currentCount := ct.adapterCounts[adapterType]
 	if currentCount >= limit {
-		return &errors.StoreError{
-			Code:    errors.ErrConnectionLimitReached,
-			Message: "connection limit reached for adapter",
-		}
+		return errors.NewConnectionLimitError(adapterType, limit)
 	}
 
 	// Create new registration

--- a/pkg/metadata/lock/cross_protocol.go
+++ b/pkg/metadata/lock/cross_protocol.go
@@ -1,7 +1,8 @@
-// Package lock provides cross-protocol translation helpers for lock visibility.
+// Cross-protocol translation helpers for lock visibility.
 //
 // Translates lock information between NLM and SMB for cross-protocol conflict
 // reporting and logging.
+
 package lock
 
 import (

--- a/pkg/metadata/lock/cross_protocol_break.go
+++ b/pkg/metadata/lock/cross_protocol_break.go
@@ -1,7 +1,8 @@
-// Package lock provides cross-protocol break coordination helpers.
+// Cross-protocol break coordination helpers.
 //
 // Coordinates break operations that span protocol boundaries (e.g., SMB write
 // breaking NFS delegation, NFS open breaking SMB lease).
+
 package lock
 
 import (

--- a/pkg/metadata/lock/deadlock.go
+++ b/pkg/metadata/lock/deadlock.go
@@ -18,10 +18,10 @@ import "sync"
 //   - Graph: A -> B -> A (cycle = deadlock)
 //
 // Usage:
-//  1. Before blocking on a lock, call WouldCauseCycle() to check for deadlock
-//  2. If no cycle, call AddWaiter() to record the wait relationship
-//  3. When lock is granted or request times out, call RemoveWaiter()
-//  4. When lock is released, call RemoveOwner() to clear all wait relationships
+//  1. Before blocking on a lock, call TryAddWaiter(): it checks for a cycle and
+//     records the wait relationship in one atomic step
+//  2. When lock is granted or request times out, call RemoveWaiter()
+//  3. When lock is released, call RemoveOwner() to clear all wait relationships
 //
 // Thread Safety:
 // WaitForGraph is safe for concurrent use by multiple goroutines.
@@ -40,52 +40,33 @@ func NewWaitForGraph() *WaitForGraph {
 	}
 }
 
-// WouldCauseCycle checks if adding edges from waiter to owners would create a cycle.
+// TryAddWaiter records that waiter is waiting for all specified owners, unless
+// doing so would close a cycle in the graph.
 //
-// This MUST be called before blocking on a lock request. If it returns true,
-// the lock request should be denied with ErrDeadlock instead of blocking.
+// The cycle check and the edge insertion happen under a single write lock, so
+// concurrent lock requests can never each observe an acyclic graph and then
+// both commit the edges that together form a cycle.
 //
 // Parameters:
 //   - waiter: The owner ID that wants to wait
 //   - owners: The owner IDs currently holding the conflicting lock(s)
 //
 // Returns:
-//   - true if adding these wait relationships would create a cycle (deadlock)
-//   - false if it's safe to proceed with waiting
-//
-// Algorithm:
-// For each owner in owners, perform DFS from that owner to see if we can
-// reach the waiter. If any path exists, adding waiter -> owner would create
-// a cycle.
-func (wfg *WaitForGraph) WouldCauseCycle(waiter string, owners []string) bool {
-	wfg.mu.RLock()
-	defer wfg.mu.RUnlock()
-
-	// For each owner, check if we can reach waiter from owner
-	for _, owner := range owners {
-		if wfg.canReach(owner, waiter, make(map[string]bool)) {
-			return true // Would create cycle
-		}
-	}
-
-	return false
-}
-
-// AddWaiter records that waiter is waiting for all specified owners.
-//
-// IMPORTANT: Caller MUST call WouldCauseCycle first to ensure this won't
-// create a deadlock. AddWaiter does NOT check for cycles.
-//
-// Parameters:
-//   - waiter: The owner ID that is now waiting
-//   - owners: The owner IDs being waited on
-func (wfg *WaitForGraph) AddWaiter(waiter string, owners []string) {
+//   - true if the edges were recorded and the caller may block; an empty
+//     owners list records nothing and also returns true
+//   - false if the edges would create a cycle (deadlock); nothing is recorded
+//     and the caller must fail the request instead of blocking
+func (wfg *WaitForGraph) TryAddWaiter(waiter string, owners []string) bool {
 	if len(owners) == 0 {
-		return
+		return true
 	}
 
 	wfg.mu.Lock()
 	defer wfg.mu.Unlock()
+
+	if wfg.wouldCauseCycleLocked(waiter, owners) {
+		return false
+	}
 
 	// Get or create the wait set for this waiter
 	waitSet, exists := wfg.edges[waiter]
@@ -98,6 +79,7 @@ func (wfg *WaitForGraph) AddWaiter(waiter string, owners []string) {
 	for _, owner := range owners {
 		waitSet[owner] = struct{}{}
 	}
+	return true
 }
 
 // RemoveWaiter removes all wait relationships where waiter is the source.
@@ -174,8 +156,20 @@ func (wfg *WaitForGraph) Size() int {
 	return len(wfg.edges)
 }
 
+// wouldCauseCycleLocked reports whether adding edges from waiter to owners
+// would close a cycle: for each owner, DFS from that owner looking for a path
+// back to waiter. Must be called with wfg.mu held (read or write).
+func (wfg *WaitForGraph) wouldCauseCycleLocked(waiter string, owners []string) bool {
+	for _, owner := range owners {
+		if wfg.canReach(owner, waiter, make(map[string]bool)) {
+			return true
+		}
+	}
+	return false
+}
+
 // canReach performs DFS to check if we can reach 'to' from 'from'.
-// Must be called with at least RLock held.
+// Must be called with wfg.mu held (read or write).
 func (wfg *WaitForGraph) canReach(from, to string, visited map[string]bool) bool {
 	// Avoid infinite loops
 	if visited[from] {

--- a/pkg/metadata/lock/deadlock_test.go
+++ b/pkg/metadata/lock/deadlock_test.go
@@ -12,6 +12,14 @@ import (
 // Wait-For Graph Tests
 // ============================================================================
 
+// wouldCauseCycle answers the same question as TryAddWaiter without recording
+// any edges, so a test can assert the predicate repeatedly against a fixed graph.
+func (wfg *WaitForGraph) wouldCauseCycle(waiter string, owners []string) bool {
+	wfg.mu.RLock()
+	defer wfg.mu.RUnlock()
+	return wfg.wouldCauseCycleLocked(waiter, owners)
+}
+
 func TestWaitForGraph_NewWaitForGraph(t *testing.T) {
 	t.Parallel()
 
@@ -29,10 +37,10 @@ func TestWaitForGraph_SimpleCycle(t *testing.T) {
 	wfg := NewWaitForGraph()
 
 	// A is waiting for B
-	wfg.AddWaiter("A", []string{"B"})
+	wfg.TryAddWaiter("A", []string{"B"})
 
 	// B wants to wait for A - this would create cycle A -> B -> A
-	cycle := wfg.WouldCauseCycle("B", []string{"A"})
+	cycle := wfg.wouldCauseCycle("B", []string{"A"})
 
 	assert.True(t, cycle, "Should detect simple A->B->A cycle")
 }
@@ -44,14 +52,14 @@ func TestWaitForGraph_Chain_NoCycle(t *testing.T) {
 	wfg := NewWaitForGraph()
 
 	// A is waiting for B
-	wfg.AddWaiter("A", []string{"B"})
+	wfg.TryAddWaiter("A", []string{"B"})
 
 	// B wants to wait for C - no cycle (A -> B -> C)
-	cycle := wfg.WouldCauseCycle("B", []string{"C"})
+	cycle := wfg.wouldCauseCycle("B", []string{"C"})
 	assert.False(t, cycle, "Chain should not be a cycle")
 
 	// Add B waiting for C
-	wfg.AddWaiter("B", []string{"C"})
+	wfg.TryAddWaiter("B", []string{"C"})
 	assert.Equal(t, 2, wfg.Size())
 }
 
@@ -61,11 +69,11 @@ func TestWaitForGraph_TriangleCycle(t *testing.T) {
 	// A -> B -> C, then C wants to wait for A (triangle cycle)
 	wfg := NewWaitForGraph()
 
-	wfg.AddWaiter("A", []string{"B"})
-	wfg.AddWaiter("B", []string{"C"})
+	wfg.TryAddWaiter("A", []string{"B"})
+	wfg.TryAddWaiter("B", []string{"C"})
 
 	// C wants to wait for A - creates A -> B -> C -> A
-	cycle := wfg.WouldCauseCycle("C", []string{"A"})
+	cycle := wfg.wouldCauseCycle("C", []string{"A"})
 
 	assert.True(t, cycle, "Should detect triangle cycle A->B->C->A")
 }
@@ -80,16 +88,16 @@ func TestWaitForGraph_ComplexGraph_NoCycle(t *testing.T) {
 	//   C -> D
 	wfg := NewWaitForGraph()
 
-	wfg.AddWaiter("A", []string{"B", "C"})
-	wfg.AddWaiter("B", []string{"D"})
-	wfg.AddWaiter("C", []string{"D"})
+	wfg.TryAddWaiter("A", []string{"B", "C"})
+	wfg.TryAddWaiter("B", []string{"D"})
+	wfg.TryAddWaiter("C", []string{"D"})
 
 	// E wants to wait for A - no cycle possible
-	cycle := wfg.WouldCauseCycle("E", []string{"A"})
+	cycle := wfg.wouldCauseCycle("E", []string{"A"})
 	assert.False(t, cycle, "DAG should not have cycle")
 
 	// D wants to wait for E - still no cycle
-	cycle = wfg.WouldCauseCycle("D", []string{"E"})
+	cycle = wfg.wouldCauseCycle("D", []string{"E"})
 	assert.False(t, cycle, "Still no cycle")
 }
 
@@ -102,12 +110,12 @@ func TestWaitForGraph_ComplexGraph_WithCycle(t *testing.T) {
 	// D -> A creates multiple cycles
 	wfg := NewWaitForGraph()
 
-	wfg.AddWaiter("A", []string{"B", "C"})
-	wfg.AddWaiter("B", []string{"D"})
-	wfg.AddWaiter("C", []string{"D"})
+	wfg.TryAddWaiter("A", []string{"B", "C"})
+	wfg.TryAddWaiter("B", []string{"D"})
+	wfg.TryAddWaiter("C", []string{"D"})
 
 	// D wants to wait for A - cycle through B and C
-	cycle := wfg.WouldCauseCycle("D", []string{"A"})
+	cycle := wfg.wouldCauseCycle("D", []string{"A"})
 	assert.True(t, cycle, "Should detect cycle through complex graph")
 }
 
@@ -117,11 +125,11 @@ func TestWaitForGraph_MultipleOwners(t *testing.T) {
 	// A wants to wait for both B and C
 	wfg := NewWaitForGraph()
 
-	wfg.AddWaiter("A", []string{"B", "C"})
+	wfg.TryAddWaiter("A", []string{"B", "C"})
 
 	// B has no other waits
 	// C wants to wait for A - creates cycle through C
-	cycle := wfg.WouldCauseCycle("C", []string{"A"})
+	cycle := wfg.wouldCauseCycle("C", []string{"A"})
 	assert.True(t, cycle, "Should detect cycle even with multiple owners")
 }
 
@@ -131,16 +139,16 @@ func TestWaitForGraph_RemoveWaiter_BreaksCycle(t *testing.T) {
 	wfg := NewWaitForGraph()
 
 	// Create potential deadlock
-	wfg.AddWaiter("A", []string{"B"})
+	wfg.TryAddWaiter("A", []string{"B"})
 
 	// Check that B->A would cause cycle
-	assert.True(t, wfg.WouldCauseCycle("B", []string{"A"}))
+	assert.True(t, wfg.wouldCauseCycle("B", []string{"A"}))
 
 	// Remove A as waiter (e.g., A's request times out)
 	wfg.RemoveWaiter("A")
 
 	// Now B->A should not cause cycle
-	assert.False(t, wfg.WouldCauseCycle("B", []string{"A"}))
+	assert.False(t, wfg.wouldCauseCycle("B", []string{"A"}))
 	assert.Equal(t, 0, wfg.Size())
 }
 
@@ -150,17 +158,17 @@ func TestWaitForGraph_RemoveOwner_BreaksCycle(t *testing.T) {
 	wfg := NewWaitForGraph()
 
 	// A -> B -> C
-	wfg.AddWaiter("A", []string{"B"})
-	wfg.AddWaiter("B", []string{"C"})
+	wfg.TryAddWaiter("A", []string{"B"})
+	wfg.TryAddWaiter("B", []string{"C"})
 
 	// C -> A would create cycle
-	assert.True(t, wfg.WouldCauseCycle("C", []string{"A"}))
+	assert.True(t, wfg.wouldCauseCycle("C", []string{"A"}))
 
 	// Remove B (e.g., B releases lock or disconnects)
 	wfg.RemoveOwner("B")
 
 	// C -> A should not cause cycle now (A is waiting for nothing)
-	assert.False(t, wfg.WouldCauseCycle("C", []string{"A"}))
+	assert.False(t, wfg.wouldCauseCycle("C", []string{"A"}))
 
 	// A's wait for B should also be gone
 	assert.Equal(t, 0, wfg.Size())
@@ -172,7 +180,7 @@ func TestWaitForGraph_RemoveOwner_PartialRemoval(t *testing.T) {
 	wfg := NewWaitForGraph()
 
 	// A waits for B and C
-	wfg.AddWaiter("A", []string{"B", "C"})
+	wfg.TryAddWaiter("A", []string{"B", "C"})
 
 	// Remove B
 	wfg.RemoveOwner("B")
@@ -181,10 +189,10 @@ func TestWaitForGraph_RemoveOwner_PartialRemoval(t *testing.T) {
 	assert.Equal(t, 1, wfg.Size())
 
 	// D -> A still no cycle (A -> C only, no path back)
-	assert.False(t, wfg.WouldCauseCycle("D", []string{"A"}))
+	assert.False(t, wfg.wouldCauseCycle("D", []string{"A"}))
 
 	// C -> A should cause cycle (A -> C -> A)
-	assert.True(t, wfg.WouldCauseCycle("C", []string{"A"}))
+	assert.True(t, wfg.wouldCauseCycle("C", []string{"A"}))
 }
 
 func TestWaitForGraph_GetWaitersFor(t *testing.T) {
@@ -193,9 +201,9 @@ func TestWaitForGraph_GetWaitersFor(t *testing.T) {
 	wfg := NewWaitForGraph()
 
 	// A, B, C all waiting for D
-	wfg.AddWaiter("A", []string{"D"})
-	wfg.AddWaiter("B", []string{"D"})
-	wfg.AddWaiter("C", []string{"D", "E"}) // C also waits for E
+	wfg.TryAddWaiter("A", []string{"D"})
+	wfg.TryAddWaiter("B", []string{"D"})
+	wfg.TryAddWaiter("C", []string{"D", "E"}) // C also waits for E
 
 	waiters := wfg.GetWaitersFor("D")
 
@@ -210,7 +218,7 @@ func TestWaitForGraph_GetWaitersFor_NoWaiters(t *testing.T) {
 
 	wfg := NewWaitForGraph()
 
-	wfg.AddWaiter("A", []string{"B"})
+	wfg.TryAddWaiter("A", []string{"B"})
 
 	waiters := wfg.GetWaitersFor("C") // No one waiting for C
 
@@ -223,9 +231,9 @@ func TestWaitForGraph_EmptyGraph(t *testing.T) {
 	wfg := NewWaitForGraph()
 
 	// No cycles in empty graph
-	assert.False(t, wfg.WouldCauseCycle("A", []string{"B"}))
-	assert.False(t, wfg.WouldCauseCycle("A", []string{}))
-	assert.False(t, wfg.WouldCauseCycle("", []string{"A"}))
+	assert.False(t, wfg.wouldCauseCycle("A", []string{"B"}))
+	assert.False(t, wfg.wouldCauseCycle("A", []string{}))
+	assert.False(t, wfg.wouldCauseCycle("", []string{"A"}))
 
 	// Safe to remove non-existent entries
 	wfg.RemoveWaiter("X")
@@ -235,14 +243,14 @@ func TestWaitForGraph_EmptyGraph(t *testing.T) {
 	assert.Equal(t, 0, wfg.Size())
 }
 
-func TestWaitForGraph_AddWaiter_EmptyOwners(t *testing.T) {
+func TestWaitForGraph_TryAddWaiter_EmptyOwners(t *testing.T) {
 	t.Parallel()
 
 	wfg := NewWaitForGraph()
 
 	// Adding with empty owners should be no-op
-	wfg.AddWaiter("A", []string{})
-	wfg.AddWaiter("A", nil)
+	wfg.TryAddWaiter("A", []string{})
+	wfg.TryAddWaiter("A", nil)
 
 	assert.Equal(t, 0, wfg.Size())
 }
@@ -253,7 +261,7 @@ func TestWaitForGraph_SelfCycle(t *testing.T) {
 	wfg := NewWaitForGraph()
 
 	// A wants to wait for A (immediate cycle)
-	cycle := wfg.WouldCauseCycle("A", []string{"A"})
+	cycle := wfg.wouldCauseCycle("A", []string{"A"})
 
 	// This isn't detected by our DFS because A has no edges yet
 	// This is a degenerate case - in practice, A shouldn't wait for itself
@@ -261,9 +269,9 @@ func TestWaitForGraph_SelfCycle(t *testing.T) {
 	assert.False(t, cycle, "Self-cycle check depends on existing edges")
 
 	// But if A is already waiting for B...
-	wfg.AddWaiter("A", []string{"B"})
+	wfg.TryAddWaiter("A", []string{"B"})
 	// ...and B tries to wait for A
-	cycle = wfg.WouldCauseCycle("B", []string{"A"})
+	cycle = wfg.wouldCauseCycle("B", []string{"A"})
 	assert.True(t, cycle)
 }
 
@@ -275,17 +283,17 @@ func TestWaitForGraph_LongChain(t *testing.T) {
 	// Create long chain: owner0 -> owner1 -> owner2 -> ... -> owner99
 	// Use numeric IDs to avoid character overflow
 	for i := 0; i < 99; i++ {
-		wfg.AddWaiter(
+		wfg.TryAddWaiter(
 			string(rune('0'+i/10))+string(rune('0'+i%10)),                     // "00", "01", ..., "98"
 			[]string{string(rune('0'+(i+1)/10)) + string(rune('0'+(i+1)%10))}, // "01", "02", ..., "99"
 		)
 	}
 
 	// Check that a non-participant doesn't create a cycle
-	assert.False(t, wfg.WouldCauseCycle("XX", []string{"00"}))
+	assert.False(t, wfg.wouldCauseCycle("XX", []string{"00"}))
 
 	// Creating cycle at the end: "99" -> "00" would create cycle
-	cycle := wfg.WouldCauseCycle("99", []string{"00"})
+	cycle := wfg.wouldCauseCycle("99", []string{"00"})
 	assert.True(t, cycle, "Should detect cycle in long chain")
 }
 
@@ -314,9 +322,9 @@ func TestWaitForGraph_ConcurrentAccess(t *testing.T) {
 				// Mix of operations
 				switch j % 5 {
 				case 0:
-					wfg.WouldCauseCycle(ownerID, []string{targetID})
+					wfg.wouldCauseCycle(ownerID, []string{targetID})
 				case 1:
-					wfg.AddWaiter(ownerID, []string{targetID})
+					wfg.TryAddWaiter(ownerID, []string{targetID})
 				case 2:
 					wfg.RemoveWaiter(ownerID)
 				case 3:
@@ -340,7 +348,7 @@ func TestWaitForGraph_ConcurrentCycleDetection(t *testing.T) {
 		wfg := NewWaitForGraph()
 
 		// Set up A -> B
-		wfg.AddWaiter("A", []string{"B"})
+		wfg.TryAddWaiter("A", []string{"B"})
 
 		var wg sync.WaitGroup
 		results := make(chan bool, 10)
@@ -350,7 +358,7 @@ func TestWaitForGraph_ConcurrentCycleDetection(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				results <- wfg.WouldCauseCycle("B", []string{"A"})
+				results <- wfg.wouldCauseCycle("B", []string{"A"})
 			}()
 		}
 
@@ -361,5 +369,95 @@ func TestWaitForGraph_ConcurrentCycleDetection(t *testing.T) {
 		for result := range results {
 			assert.True(t, result, "All goroutines should detect cycle")
 		}
+	}
+}
+
+// TestWaitForGraph_TryAddWaiter_ConcurrentRingCannotCloseCycle fires a full ring
+// of wait edges (owner i waits on owner i+1, the last on the first) at once.
+// Every edge is cycle-free against the empty graph, so a separate check call
+// followed by a separate add call could admit all of them and leave a closed
+// ring behind. TryAddWaiter holds one write lock across check and insert, so
+// whichever request the mutex orders last sees a path back to itself and is
+// refused. The assertions are exact, so the test never flakes on correct code;
+// the iterations only raise the odds of catching a regression.
+func TestWaitForGraph_TryAddWaiter_ConcurrentRingCannotCloseCycle(t *testing.T) {
+	t.Parallel()
+
+	const ringSize = 8
+	owners := make([]string, ringSize)
+	for i := range owners {
+		owners[i] = string(rune('A' + i))
+	}
+
+	for iteration := 0; iteration < 300; iteration++ {
+		wfg := NewWaitForGraph()
+
+		start := make(chan struct{})
+		results := make([]bool, ringSize)
+		var wg sync.WaitGroup
+		for i := 0; i < ringSize; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				<-start
+				results[i] = wfg.TryAddWaiter(owners[i], []string{owners[(i+1)%ringSize]})
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+
+		refused := 0
+		for _, granted := range results {
+			if !granted {
+				refused++
+			}
+		}
+		require.GreaterOrEqual(t, refused, 1,
+			"a full ring of wait edges is a deadlock; at least one request must be refused")
+
+		// The surviving graph must be acyclic: no owner can reach itself.
+		for _, owner := range owners {
+			assert.False(t, wfg.wouldCauseCycle(owner, []string{owner}),
+				"owner %s is waiting on itself transitively — a cycle was committed", owner)
+		}
+	}
+}
+
+// The ring test above asserts acyclicity with wouldCauseCycle(x, []string{x}).
+// That reads like it only catches a self-edge, because canReach has no
+// from == to base case. It does catch a multi-node ring: canReach checks
+// waitSet[to] directly at each hop, so the check fires when the DFS reaches
+// the node whose edge points back at the origin. visited only stops a node
+// being expanded twice, it does not stop that node matching as a target.
+// Pinned here so the assertion is not later weakened into a self-edge check.
+func TestWouldCauseCycleDetectsRingWithoutSelfEdge(t *testing.T) {
+	wfg := NewWaitForGraph()
+
+	// Build A->B->C->A directly, bypassing the entry point that refuses
+	// cycles, so the graph genuinely holds one.
+	wfg.mu.Lock()
+	for _, e := range [][2]string{{"A", "B"}, {"B", "C"}, {"C", "A"}} {
+		if wfg.edges[e[0]] == nil {
+			wfg.edges[e[0]] = make(map[string]struct{})
+		}
+		wfg.edges[e[0]][e[1]] = struct{}{}
+	}
+	wfg.mu.Unlock()
+
+	for _, owner := range []string{"A", "B", "C"} {
+		assert.True(t, wfg.wouldCauseCycle(owner, []string{owner}),
+			"ring member %s must be reported as reaching itself", owner)
+	}
+
+	// An acyclic chain must not report a cycle.
+	chain := NewWaitForGraph()
+	chain.mu.Lock()
+	chain.edges["X"] = map[string]struct{}{"Y": {}}
+	chain.edges["Y"] = map[string]struct{}{"Z": {}}
+	chain.mu.Unlock()
+
+	for _, owner := range []string{"X", "Y", "Z"} {
+		assert.False(t, chain.wouldCauseCycle(owner, []string{owner}),
+			"acyclic chain member %s must not be reported as cyclic", owner)
 	}
 }

--- a/pkg/metadata/lock/delegation.go
+++ b/pkg/metadata/lock/delegation.go
@@ -1,4 +1,4 @@
-// Package lock provides delegation management for cross-protocol caching.
+// Delegation management for cross-protocol caching.
 //
 // Delegations are the protocol-neutral equivalent of NFS delegations and
 // SMB leases, representing caching permissions granted to a client. Unlike
@@ -9,6 +9,7 @@
 // with leases, and helper functions.
 //
 // Reference: RFC 8881 Section 10 (NFS Delegations)
+
 package lock
 
 import (

--- a/pkg/metadata/lock/directory.go
+++ b/pkg/metadata/lock/directory.go
@@ -1,4 +1,4 @@
-// Package lock provides directory lease management and change notification.
+// Directory lease management and change notification.
 //
 // This file implements the DirChangeNotifier interface and the recently-broken
 // cache that prevents lease grant storms on frequently-changed directories.
@@ -9,6 +9,7 @@
 // TTL window to prevent immediate re-grant followed by another break.
 //
 // Reference: MS-SMB2 3.3.4.7 Object Store Indicates a Lease Break
+
 package lock
 
 import (

--- a/pkg/metadata/lock/errors.go
+++ b/pkg/metadata/lock/errors.go
@@ -2,6 +2,8 @@ package lock
 
 import (
 	stderrors "errors"
+	"fmt"
+	"strings"
 
 	"github.com/marmos91/dittofs/pkg/metadata/errors"
 )
@@ -66,7 +68,7 @@ func NewLockConflictError(path string, conflict *UnifiedLockConflict) *errors.St
 func NewDeadlockError(waiter string, blockedBy []string) *errors.StoreError {
 	return &errors.StoreError{
 		Code:    errors.ErrDeadlock,
-		Message: "deadlock detected",
+		Message: fmt.Sprintf("deadlock detected: waiting on %s", strings.Join(blockedBy, ", ")),
 		Path:    waiter,
 	}
 }
@@ -75,7 +77,7 @@ func NewDeadlockError(waiter string, blockedBy []string) *errors.StoreError {
 func NewGracePeriodError(remainingSeconds int) *errors.StoreError {
 	return &errors.StoreError{
 		Code:    errors.ErrGracePeriod,
-		Message: "grace period active, new locks blocked",
+		Message: fmt.Sprintf("grace period active, new locks blocked (%ds remaining)", remainingSeconds),
 	}
 }
 
@@ -83,6 +85,6 @@ func NewGracePeriodError(remainingSeconds int) *errors.StoreError {
 func NewLockLimitExceededError(limitType string, current, max int) *errors.StoreError {
 	return &errors.StoreError{
 		Code:    errors.ErrLockLimitExceeded,
-		Message: limitType + " lock limit exceeded",
+		Message: fmt.Sprintf("%s lock limit exceeded (%d/%d)", limitType, current, max),
 	}
 }

--- a/pkg/metadata/lock/errors_test.go
+++ b/pkg/metadata/lock/errors_test.go
@@ -1,0 +1,60 @@
+package lock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/marmos91/dittofs/pkg/metadata/errors"
+)
+
+// TestErrorConstructorsCarryDiagnostics pins that the diagnostic parameters each
+// constructor accepts actually reach the returned error's message.
+func TestErrorConstructorsCarryDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	t.Run("deadlock names the blocking owners", func(t *testing.T) {
+		err := NewDeadlockError("smb:open:42", []string{"smb:open:7", "nlm:host-b"})
+		require.Equal(t, errors.ErrDeadlock, err.Code)
+		assert.Equal(t, "smb:open:42", err.Path)
+		assert.Contains(t, err.Message, "smb:open:7")
+		assert.Contains(t, err.Message, "nlm:host-b")
+	})
+
+	t.Run("grace period names the remaining seconds", func(t *testing.T) {
+		err := NewGracePeriodError(45)
+		require.Equal(t, errors.ErrGracePeriod, err.Code)
+		assert.Contains(t, err.Message, "45")
+	})
+
+	t.Run("lock limit names the counts", func(t *testing.T) {
+		err := NewLockLimitExceededError("per-file", 1024, 1024)
+		require.Equal(t, errors.ErrLockLimitExceeded, err.Code)
+		assert.Contains(t, err.Message, "per-file")
+		assert.Contains(t, err.Message, "1024/1024")
+	})
+}
+
+// TestRegisterClientReportsAdapterAndLimit pins that the connection-limit
+// rejection identifies which adapter hit which limit.
+func TestRegisterClientReportsAdapterAndLimit(t *testing.T) {
+	t.Parallel()
+
+	config := DefaultConnectionTrackerConfig()
+	config.MaxConnectionsPerAdapter = map[string]int{"smb": 3}
+	ct := NewConnectionTracker(config)
+
+	for _, clientID := range []string{"client1", "client2", "client3"} {
+		require.NoError(t, ct.RegisterClient(clientID, "smb", "10.0.0.1:445", 0))
+	}
+
+	err := ct.RegisterClient("client4", "smb", "10.0.0.2:445", 0)
+	require.Error(t, err)
+
+	var se *errors.StoreError
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, errors.ErrConnectionLimitReached, se.Code)
+	assert.Contains(t, se.Message, "smb")
+	assert.Contains(t, se.Message, "3")
+}

--- a/pkg/metadata/lock/grace.go
+++ b/pkg/metadata/lock/grace.go
@@ -35,16 +35,18 @@ func (gs GraceState) String() string {
 }
 
 // Operation describes the type of lock operation for grace period checking.
-type Operation struct {
-	// IsReclaim indicates this is a lock reclaim during grace period.
-	IsReclaim bool
+type Operation int
 
-	// IsTest indicates this is a lock test (query) operation.
-	IsTest bool
+const (
+	// OpNew is a new lock request - denied while the grace period is active.
+	OpNew Operation = iota
 
-	// IsNew indicates this is a new lock request (not reclaim or test).
-	IsNew bool
-}
+	// OpReclaim is a reclaim of a lock held before restart - always allowed.
+	OpReclaim
+
+	// OpTest is a lock test (query) - always allowed.
+	OpTest
+)
 
 // GracePeriodManager manages the grace period state machine.
 //
@@ -231,7 +233,7 @@ func (gpm *GracePeriodManager) IsOperationAllowed(op Operation) (bool, error) {
 	}
 
 	// Active state - check operation type
-	if op.IsReclaim || op.IsTest {
+	if op == OpReclaim || op == OpTest {
 		return true, nil
 	}
 

--- a/pkg/metadata/lock/grace_test.go
+++ b/pkg/metadata/lock/grace_test.go
@@ -34,7 +34,7 @@ func TestEnterGracePeriod_BlocksNewLocks(t *testing.T) {
 	}
 
 	// New lock should be blocked
-	newLockOp := Operation{IsNew: true}
+	newLockOp := OpNew
 	allowed, err := gpm.IsOperationAllowed(newLockOp)
 	if allowed {
 		t.Error("expected new lock to be blocked during grace period")
@@ -61,7 +61,7 @@ func TestEnterGracePeriod_AllowsReclaims(t *testing.T) {
 	gpm.EnterGracePeriod([]string{"client1"})
 
 	// Reclaim operation should be allowed
-	reclaimOp := Operation{IsReclaim: true}
+	reclaimOp := OpReclaim
 	allowed, err := gpm.IsOperationAllowed(reclaimOp)
 	if !allowed {
 		t.Error("expected reclaim to be allowed during grace period")
@@ -79,7 +79,7 @@ func TestEnterGracePeriod_AllowsTests(t *testing.T) {
 	gpm.EnterGracePeriod([]string{"client1"})
 
 	// Test operation should be allowed
-	testOp := Operation{IsTest: true}
+	testOp := OpTest
 	allowed, err := gpm.IsOperationAllowed(testOp)
 	if !allowed {
 		t.Error("expected test operation to be allowed during grace period")
@@ -103,9 +103,9 @@ func TestExitGracePeriod_AllowsAllOperations(t *testing.T) {
 
 	// All operations should be allowed
 	ops := []Operation{
-		{IsNew: true},
-		{IsReclaim: true},
-		{IsTest: true},
+		OpNew,
+		OpReclaim,
+		OpTest,
 	}
 
 	for _, op := range ops {
@@ -232,8 +232,8 @@ func TestGracePeriod_ThreadSafety(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < iterations; i++ {
-			_, _ = gpm.IsOperationAllowed(Operation{IsNew: true})
-			_, _ = gpm.IsOperationAllowed(Operation{IsReclaim: true})
+			_, _ = gpm.IsOperationAllowed(OpNew)
+			_, _ = gpm.IsOperationAllowed(OpReclaim)
 		}
 	}()
 

--- a/pkg/metadata/lock/indexes_test.go
+++ b/pkg/metadata/lock/indexes_test.go
@@ -287,3 +287,154 @@ func TestIndex_ReclaimAddsToIndex(t *testing.T) {
 	assert.Equal(t, "fileR", hk)
 	require.NotNil(t, lk, "restored lease must be resolvable via the index")
 }
+
+// ============================================================================
+// Index lookup vs full scan equivalence
+// ============================================================================
+
+// scanLeaseKeyMatches is the reference implementation SetLeaseEpoch used before
+// it consulted leaseKeyIndex: a full sweep of every handleKey bucket collecting
+// every record bound to leaseKey.
+func scanLeaseKeyMatches(lm *Manager, leaseKey [16]byte) map[string]bool {
+	out := make(map[string]bool)
+	for _, locks := range lm.unifiedLocks {
+		for _, l := range locks {
+			if l.Lease != nil && l.Lease.LeaseKey == leaseKey {
+				out[l.ID] = true
+			}
+		}
+	}
+	return out
+}
+
+// scanHasLeaseKeyOnOtherFile is the reference implementation
+// hasLeaseKeyOnOtherFile used before it consulted leaseKeyIndex.
+func scanHasLeaseKeyOnOtherFile(lm *Manager, leaseKey [16]byte, excludeHandleKey, clientID string) bool {
+	for handleKey, locks := range lm.unifiedLocks {
+		if handleKey == excludeHandleKey {
+			continue
+		}
+		for _, l := range locks {
+			if l.Lease == nil || l.Lease.LeaseKey != leaseKey {
+				continue
+			}
+			if l.Owner.ClientID != clientID {
+				continue
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// buildMixedLockSet populates a Manager with a realistic mix: the same numeric
+// lease key bound on several files by different clients, distinct keys, a
+// directory lease, byte-range (non-lease) records, and a released record — so
+// the index-vs-scan comparison covers empty buckets and shared keys rather than
+// just the happy path. Returns the lease keys and handle keys in play.
+func buildMixedLockSet(t *testing.T, mgr *Manager) (keys [][16]byte, handleKeys []string) {
+	t.Helper()
+	ctx := context.Background()
+
+	keyA := [16]byte{0xA}
+	keyB := [16]byte{0xB}
+	keyC := [16]byte{0xC}
+	// keyD is never granted: probes for it must come back empty from both paths.
+	keyD := [16]byte{0xD}
+
+	grants := []struct {
+		file     string
+		key      [16]byte
+		client   string
+		isDir    bool
+		newState uint32
+	}{
+		{"file1", keyA, "client1", false, LeaseStateRead},
+		{"file2", keyA, "client2", false, LeaseStateRead},
+		{"file3", keyA, "client3", false, LeaseStateRead | LeaseStateHandle},
+		{"file1", keyB, "client2", false, LeaseStateRead},
+		{"dir1", keyC, "client1", true, LeaseStateRead | LeaseStateHandle},
+	}
+	for _, g := range grants {
+		_, _, err := mgr.RequestLease(ctx, FileHandle(g.file), g.key, [16]byte{},
+			"owner-"+g.file+"-"+g.client, g.client, "/share", g.newState, g.isDir)
+		require.NoError(t, err)
+	}
+
+	// Byte-range records on a file with no lease at all, plus one on a file that
+	// does hold a lease — both must be invisible to every lease-key probe.
+	for _, br := range []struct{ file, client string }{{"file4", "client1"}, {"file2", "client1"}} {
+		err := mgr.AddUnifiedLock(br.file, NewUnifiedLock(
+			LockOwner{OwnerID: "nlm:" + br.file + ":" + br.client, ClientID: br.client, ShareName: "/share"},
+			FileHandle(br.file), 0, 4096, LockTypeExclusive))
+		require.NoError(t, err)
+	}
+
+	// Release one holder of the shared key so a bucket drops out of the index.
+	require.NoError(t, mgr.ReleaseLeaseForHandle(ctx, "file3", keyA))
+
+	return [][16]byte{keyA, keyB, keyC, keyD},
+		[]string{"file1", "file2", "file3", "file4", "dir1", "absent"}
+}
+
+// TestSetLeaseEpoch_IndexMatchesFullScan proves the leaseKeyIndex-driven record
+// selection in SetLeaseEpoch reaches the same records a full unifiedLocks sweep
+// would, and converges every one of them.
+func TestSetLeaseEpoch_IndexMatchesFullScan(t *testing.T) {
+	t.Parallel()
+	mgr := NewManager()
+	keys, _ := buildMixedLockSet(t, mgr)
+	assertIndexesConsistent(t, mgr)
+
+	for _, key := range keys {
+		mgr.mu.RLock()
+		want := scanLeaseKeyMatches(mgr, key)
+		mgr.mu.RUnlock()
+
+		// SetLeaseEpoch reports found iff the scan found records, and lifts
+		// every matching record to the same epoch.
+		ok := mgr.SetLeaseEpoch(key, 7)
+		assert.Equal(t, len(want) > 0, ok, "SetLeaseEpoch found-flag must match the scan for key %x", key)
+
+		mgr.mu.RLock()
+		for _, locks := range mgr.unifiedLocks {
+			for _, l := range locks {
+				if l.Lease != nil && l.Lease.LeaseKey == key {
+					assert.Equal(t, uint16(7), l.Lease.Epoch,
+						"every record for key %x must converge to the target epoch", key)
+				}
+			}
+		}
+		mgr.mu.RUnlock()
+	}
+}
+
+// TestHasLeaseKeyOnOtherFile_IndexMatchesFullScan proves the index-driven
+// uniqueness probe answers identically to the full scan it replaced, across
+// every (key, excluded bucket, client) triple the fixture can produce.
+func TestHasLeaseKeyOnOtherFile_IndexMatchesFullScan(t *testing.T) {
+	t.Parallel()
+	mgr := NewManager()
+	keys, handleKeys := buildMixedLockSet(t, mgr)
+	assertIndexesConsistent(t, mgr)
+
+	clients := []string{"client1", "client2", "client3", "client4", ""}
+
+	mgr.mu.RLock()
+	defer mgr.mu.RUnlock()
+
+	checked := 0
+	for _, key := range keys {
+		for _, exclude := range handleKeys {
+			for _, client := range clients {
+				want := scanHasLeaseKeyOnOtherFile(mgr, key, exclude, client)
+				got := mgr.hasLeaseKeyOnOtherFile(key, exclude, client)
+				assert.Equal(t, want, got,
+					"key=%x exclude=%s client=%s", key, exclude, client)
+				checked++
+			}
+		}
+	}
+	// Guard against the fixture silently collapsing to a trivial case.
+	require.Greater(t, checked, 50, "expected a broad triple sweep")
+}

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -1,4 +1,4 @@
-// Package lock provides lease CRUD operations on the Manager.
+// Lease CRUD operations on the Manager.
 //
 // This file implements RequestLease, AcknowledgeLeaseBreak, ReleaseLease,
 // and GetLeaseState methods on the Manager struct. These are the core lease
@@ -7,6 +7,7 @@
 // All lease state changes go through advanceEpoch to ensure epoch monotonicity.
 //
 // Reference: MS-SMB2 3.3.5.9 Processing an SMB2 CREATE Request
+
 package lock
 
 import (
@@ -158,13 +159,16 @@ func (lm *Manager) findLeaseByKey(leaseKey [16]byte) (string, *UnifiedLock, int)
 // multichannel work (#361) where ClientGuid threading is needed
 // for cross-channel break fan-out anyway.
 //
+// Probes only the buckets leaseKeyIndex names for leaseKey; the ones it omits
+// hold no record for the key and could never have matched.
+//
 // Must be called with lm.mu held (read or write).
 func (lm *Manager) hasLeaseKeyOnOtherFile(leaseKey [16]byte, excludeHandleKey, clientID string) bool {
-	for handleKey, locks := range lm.unifiedLocks {
+	for handleKey := range lm.leaseKeyIndex[leaseKey] {
 		if handleKey == excludeHandleKey {
 			continue
 		}
-		for _, lock := range locks {
+		for _, lock := range lm.unifiedLocks[handleKey] {
 			if lock.Lease == nil || lock.Lease.LeaseKey != leaseKey {
 				continue
 			}

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -119,7 +119,7 @@ type LockManager interface {
 
 	// RequestLease requests a new or upgraded lease on a file or directory.
 	// Returns the granted state (may be less than requested), epoch, and error.
-	// isDirectory=true restricts to ValidDirectoryLeaseStates.
+	// isDirectory=true restricts to validDirectoryLeaseStates.
 	RequestLease(ctx context.Context, fileHandle FileHandle, leaseKey [16]byte,
 		parentLeaseKey [16]byte, ownerID string, clientID string, shareName string,
 		requestedState uint32, isDirectory bool) (grantedState uint32, epoch uint16, err error)
@@ -1489,10 +1489,13 @@ func (lm *Manager) SetLeaseEpoch(leaseKey [16]byte, epoch uint16) bool {
 	// notifications (the break_twice / v2_breaking3 regression class). Compute
 	// the max of the requested epoch and every matching record's current epoch,
 	// then assign that single max to all of them so the lease has one epoch.
+	//
+	// Probes only the buckets leaseKeyIndex names for leaseKey; the ones it
+	// omits hold no record for the key and could never have matched.
 	target := epoch
 	var matches []*UnifiedLock
-	for _, locks := range lm.unifiedLocks {
-		for _, lock := range locks {
+	for handleKey := range lm.leaseKeyIndex[leaseKey] {
+		for _, lock := range lm.unifiedLocks[handleKey] {
 			if lock.Lease == nil || lock.Lease.LeaseKey != leaseKey {
 				continue
 			}

--- a/pkg/metadata/lock/manager_test.go
+++ b/pkg/metadata/lock/manager_test.go
@@ -1043,7 +1043,7 @@ func TestManager_GracePeriod_Delegation(t *testing.T) {
 	}
 
 	// New locks should be denied
-	allowed, err := lm.IsOperationAllowed(Operation{IsNew: true})
+	allowed, err := lm.IsOperationAllowed(OpNew)
 	if allowed {
 		t.Fatal("Expected new lock to be denied during grace period")
 	}
@@ -1052,7 +1052,7 @@ func TestManager_GracePeriod_Delegation(t *testing.T) {
 	}
 
 	// Reclaims should be allowed
-	allowed, err = lm.IsOperationAllowed(Operation{IsReclaim: true})
+	allowed, err = lm.IsOperationAllowed(OpReclaim)
 	if !allowed {
 		t.Fatal("Expected reclaim to be allowed during grace period")
 	}
@@ -1081,7 +1081,7 @@ func TestManager_GracePeriod_NilManager(t *testing.T) {
 		t.Fatal("Expected not in grace period without manager")
 	}
 
-	allowed, err := lm.IsOperationAllowed(Operation{IsNew: true})
+	allowed, err := lm.IsOperationAllowed(OpNew)
 	if !allowed || err != nil {
 		t.Fatal("Expected all operations allowed without grace period manager")
 	}
@@ -1279,13 +1279,18 @@ func TestSetLeaseEpoch_UpdatesAllMatchingRecords(t *testing.T) {
 	lm := NewManager()
 	leaseKey := [16]byte{0xaa, 0xbb, 0xcc}
 
+	// Seeding unifiedLocks directly skips the mutation paths that maintain the
+	// reverse indexes, so reconcile each bucket the way those paths do —
+	// lease-key lookups resolve through leaseKeyIndex.
 	lm.mu.Lock()
 	lm.unifiedLocks["/share:fileA"] = []*UnifiedLock{
 		{Owner: LockOwner{OwnerID: "oA"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 1}},
 	}
+	lm.reindexHandleLocked("/share:fileA", nil)
 	lm.unifiedLocks["/share:fileB"] = []*UnifiedLock{
 		{Owner: LockOwner{OwnerID: "oB"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 1}},
 	}
+	lm.reindexHandleLocked("/share:fileB", nil)
 	lm.mu.Unlock()
 
 	if !lm.SetLeaseEpoch(leaseKey, 7) {
@@ -1330,9 +1335,11 @@ func TestSetLeaseEpoch_ConvergesDivergentRecords(t *testing.T) {
 	lm.unifiedLocks["/share:fileA"] = []*UnifiedLock{
 		{Owner: LockOwner{OwnerID: "oA"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 5}},
 	}
+	lm.reindexHandleLocked("/share:fileA", nil)
 	lm.unifiedLocks["/share:fileB"] = []*UnifiedLock{
 		{Owner: LockOwner{OwnerID: "oB"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 1}},
 	}
+	lm.reindexHandleLocked("/share:fileB", nil)
 	lm.mu.Unlock()
 
 	// Request a lower epoch (4) than the highest existing record (5). All
@@ -1365,6 +1372,7 @@ func TestSetLeaseEpoch_Persists(t *testing.T) {
 	lm.unifiedLocks["/share:fileA"] = []*UnifiedLock{
 		{ID: "lease-1", Owner: LockOwner{OwnerID: "oA"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 1}},
 	}
+	lm.reindexHandleLocked("/share:fileA", nil)
 	lm.mu.Unlock()
 
 	if !lm.SetLeaseEpoch(leaseKey, 9) {

--- a/pkg/metadata/lock/notification_queue.go
+++ b/pkg/metadata/lock/notification_queue.go
@@ -1,4 +1,4 @@
-// Package lock provides a bounded notification queue for directory change events.
+// Bounded notification queue for directory change events.
 //
 // The NotificationQueue collects directory change notifications for clients
 // holding directory delegations. When the queue reaches its capacity, it
@@ -9,6 +9,7 @@
 // This is used by directory delegation holders to receive fine-grained
 // change notifications (add, remove, rename) or, on overflow, a signal
 // that a full directory rescan is required.
+
 package lock
 
 import (

--- a/pkg/metadata/lock/oplock.go
+++ b/pkg/metadata/lock/oplock.go
@@ -1,11 +1,11 @@
-// Package lock provides lock management types and operations for the metadata package.
-// This file contains SMB2/3 lease types integrated with the unified lock manager.
+// SMB2/3 lease types integrated with the unified lock manager.
 //
 // SMB2.1+ leases provide client caching permissions using Read/Write/Handle flags.
 // Leases are whole-file (not byte-range) and use a 128-bit client-generated key
 // to group multiple file handles into a single caching unit.
 //
 // Reference: MS-SMB2 2.2.13.2.8 SMB2_CREATE_REQUEST_LEASE_V2
+
 package lock
 
 import (
@@ -113,10 +113,10 @@ func breakSentinelForReason(reason BreakReason) uint32 {
 	}
 }
 
-// ValidFileLeaseStates contains all valid lease state combinations for files.
+// validFileLeaseStates contains all valid lease state combinations for files.
 // Per MS-SMB2: Write and Handle alone are not valid; they require Read.
 // Valid combinations: None, R, RH, RW, RWH
-var ValidFileLeaseStates = []uint32{
+var validFileLeaseStates = []uint32{
 	LeaseStateNone,                                      // 0x00 - No caching
 	LeaseStateRead,                                      // 0x01 - Read only
 	LeaseStateRead | LeaseStateHandle,                   // 0x03 - Read + Handle
@@ -124,14 +124,14 @@ var ValidFileLeaseStates = []uint32{
 	LeaseStateRead | LeaseStateWrite | LeaseStateHandle, // 0x07 - Full (RWH)
 }
 
-// ValidDirectoryLeaseStates contains valid lease state combinations for directories.
+// validDirectoryLeaseStates contains valid lease state combinations for directories.
 // Per MS-SMB2 3.3.5.9: directories support Read and Handle caching but NOT
 // Write caching. Write caching requires exclusive access semantics that don't
 // apply to directory opens.
 // When RWH is requested, bestGrantableState will downgrade to RH.
 // When RW is requested, bestGrantableState will downgrade to R.
 // Valid combinations: None, R, RH
-var ValidDirectoryLeaseStates = []uint32{
+var validDirectoryLeaseStates = []uint32{
 	LeaseStateNone,                    // 0x00 - No caching
 	LeaseStateRead,                    // 0x01 - Read only
 	LeaseStateRead | LeaseStateHandle, // 0x03 - Read + Handle
@@ -210,7 +210,7 @@ type OpLock struct {
 	ParentLeaseKey [16]byte
 
 	// IsDirectory indicates this lease is on a directory.
-	// When true, valid lease states are restricted to ValidDirectoryLeaseStates
+	// When true, valid lease states are restricted to validDirectoryLeaseStates
 	// (None, R, RH).
 	IsDirectory bool
 
@@ -315,7 +315,7 @@ func LeaseStateToString(state uint32) string {
 // Valid file states: None, R, RW, RH, RWH
 // Invalid states: W alone, H alone, WH (Write/Handle without Read)
 func IsValidFileLeaseState(state uint32) bool {
-	return slices.Contains(ValidFileLeaseStates, state)
+	return slices.Contains(validFileLeaseStates, state)
 }
 
 // IsValidDirectoryLeaseState returns true if the state is a valid lease combination for directories.
@@ -323,7 +323,7 @@ func IsValidFileLeaseState(state uint32) bool {
 // Valid directory states: None, R, RH
 // Invalid: W alone, H alone, WH, RW, RWH (Write not valid for directories)
 func IsValidDirectoryLeaseState(state uint32) bool {
-	return slices.Contains(ValidDirectoryLeaseStates, state)
+	return slices.Contains(validDirectoryLeaseStates, state)
 }
 
 // Clone creates a deep copy of the OpLock.

--- a/pkg/metadata/lock/oplock_break.go
+++ b/pkg/metadata/lock/oplock_break.go
@@ -1,9 +1,9 @@
-// Package lock provides lock management types and operations for the metadata package.
-// This file implements the lease break timeout scanner.
+// Lease break timeout scanner.
 //
 // The OpLockBreakScanner monitors breaking leases and force-revokes them on timeout.
 // Per MS-SMB2 and CONTEXT.md: "Force revoke on timeout - don't retry, just revoke
 // and allow conflicting operation"
+
 package lock
 
 import (

--- a/pkg/metadata/lock/reclaim.go
+++ b/pkg/metadata/lock/reclaim.go
@@ -1,4 +1,4 @@
-// Package lock provides unified lease reclaim for both SMB and NFS protocols.
+// Unified lease reclaim for both SMB and NFS protocols.
 //
 // Lease reclaim is used during grace period after server restart. Clients
 // that held leases before the restart can reclaim them during the grace window.
@@ -7,6 +7,7 @@
 // exists (via HandleChecker) since deleted directories cannot have leases reclaimed.
 //
 // Reference: MS-SMB2 3.3.5.9 Processing an SMB2 CREATE Request (Lease Reclaim)
+
 package lock
 
 import (

--- a/pkg/metadata/lock_exports.go
+++ b/pkg/metadata/lock_exports.go
@@ -116,10 +116,6 @@ const (
 // Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type GracePeriodManager = lock.GracePeriodManager
 
-// NewGracePeriodManager creates a new grace period manager.
-// Deprecated: Use lock.NewGracePeriodManager() directly.
-var NewGracePeriodManager = lock.NewGracePeriodManager
-
 // LockOperation is re-exported from the lock package as Operation.
 // Deprecated: Import Operation from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type LockOperation = lock.Operation
@@ -132,17 +128,9 @@ type LockOperation = lock.Operation
 // Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type ConnectionTracker = lock.ConnectionTracker
 
-// NewConnectionTracker creates a new connection tracker.
-// Deprecated: Use lock.NewConnectionTracker() directly.
-var NewConnectionTracker = lock.NewConnectionTracker
-
 // ConnectionTrackerConfig is re-exported from the lock package.
 // Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type ConnectionTrackerConfig = lock.ConnectionTrackerConfig
-
-// DefaultConnectionTrackerConfig returns default connection tracker config.
-// Deprecated: Use lock.DefaultConnectionTrackerConfig() directly.
-var DefaultConnectionTrackerConfig = lock.DefaultConnectionTrackerConfig
 
 // ClientRegistration is re-exported from the lock package.
 // Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
@@ -155,10 +143,6 @@ type ClientRegistration = lock.ClientRegistration
 // WaitForGraph is re-exported from the lock package.
 // Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type WaitForGraph = lock.WaitForGraph
-
-// NewWaitForGraph creates a new wait-for graph.
-// Deprecated: Use lock.NewWaitForGraph() directly.
-var NewWaitForGraph = lock.NewWaitForGraph
 
 // ============================================================================
 // Persistence Types
@@ -176,45 +160,9 @@ type PersistedLock = lock.PersistedLock
 // Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type LockQuery = lock.LockQuery
 
-// ToPersistedLock converts an UnifiedLock to a PersistedLock.
-// Deprecated: Use lock.ToPersistedLock() directly.
-var ToPersistedLock = lock.ToPersistedLock
-
-// FromPersistedLock converts a PersistedLock to an UnifiedLock.
-// Deprecated: Use lock.FromPersistedLock() directly.
-var FromPersistedLock = lock.FromPersistedLock
-
 // ============================================================================
 // Utility Functions
 // ============================================================================
-
-// RangesOverlap checks if two byte ranges overlap.
-// Deprecated: Use lock.RangesOverlap() directly.
-var RangesOverlap = lock.RangesOverlap
-
-// IsLockConflicting checks if two locks conflict.
-// Deprecated: Use lock.IsLockConflicting() directly.
-var IsLockConflicting = lock.IsLockConflicting
-
-// IsUnifiedLockConflicting checks if two unified locks conflict.
-// Deprecated: Use lock.IsUnifiedLockConflicting() directly.
-var IsUnifiedLockConflicting = lock.IsUnifiedLockConflicting
-
-// CheckIOConflict checks if an I/O operation conflicts with a lock.
-// Deprecated: Use lock.CheckIOConflict() directly.
-var CheckIOConflict = lock.CheckIOConflict
-
-// SplitLock splits an existing lock when a portion is unlocked.
-// Deprecated: Use lock.SplitLock() directly.
-var SplitLock = lock.SplitLock
-
-// MergeLocks coalesces adjacent or overlapping locks.
-// Deprecated: Use lock.MergeLocks() directly.
-var MergeLocks = lock.MergeLocks
-
-// NewUnifiedLock creates a new UnifiedLock with a generated UUID.
-// Deprecated: Use lock.NewUnifiedLock() directly.
-var NewUnifiedLock = lock.NewUnifiedLock
 
 // OpLock is re-exported from the lock package.
 // Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
@@ -228,14 +176,6 @@ type OpLockBreakScanner = lock.OpLockBreakScanner
 // Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type OpLockBreakCallback = lock.OpLockBreakCallback
 
-// OpLocksConflict checks if two OpLock leases conflict.
-// Deprecated: Use lock.OpLocksConflict() directly.
-var OpLocksConflict = lock.OpLocksConflict
-
 // NLMHolderInfo is re-exported from the lock package.
 // Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type NLMHolderInfo = lock.NLMHolderInfo
-
-// TranslateToNLMHolder translates an SMB lease to NLM holder format.
-// Deprecated: Use lock.TranslateToNLMHolder() directly.
-var TranslateToNLMHolder = lock.TranslateToNLMHolder


### PR DESCRIPTION
Fixes the MEDIUM findings the data-plane audit raised against `pkg/metadata/lock/`.

## Correctness

**Wait-for-graph check-then-act.** `WouldCauseCycle` (RLock) and `AddWaiter` (separate Lock) were a check-then-act pair, and the only production caller — `parkLockOnConflict` — did real work between them (`TryReserveAsync`, `generateAsyncId`, `context.WithTimeout`, `PendingLockRegistry.Register`). Two SMB LOCK requests racing to park could each observe an acyclic graph and then together commit the edges that close a cycle. They are now one `TryAddWaiter(waiter, owners) bool` holding a single write lock across the check and the insert; on refusal nothing is recorded. The park path inserts the edges before reserving the async slot so concurrent callers see the wait immediately, and a deferred `RemoveWaiter` unwinds them on every path that does not end up parking. On the parked path `resumePendingLock` owns them and already defers `RemoveWaiter` at entry, so timeout, cancellation, success and error all prune.

The undetected cycle was never a permanent wedge — every parked lock is bounded by `asyncBlockingLockTimeout` — so this converts a late `LOCK_NOT_GRANTED` into an immediate, correct one.

`TestWaitForGraph_TryAddWaiter_ConcurrentRingCannotCloseCycle` fires a full ring of wait edges at once; every edge is individually cycle-free against the empty graph, so the old pair could admit all of them.

## Performance

**Two full-manager sweeps replaced by the existing reverse index.** `hasLeaseKeyOnOtherFile` (called under `lm.mu` on every lease-granting SMB CREATE) and `SetLeaseEpoch` both ranged all of `lm.unifiedLocks` to find records for a single lease key. Both now probe `leaseKeyIndex[leaseKey]`, which is derived state reconciled from the authoritative slice on every mutation and already used by `findLeaseByKey` for exactly this lookup. It ref-counts every bucket holding the key, so it is a complete candidate set — `SetLeaseEpoch` still reaches every matching record, not just the first. Work now scales with the files actually bound to that key instead of with every lock on the share.

`TestSetLeaseEpoch_IndexMatchesFullScan` and `TestHasLeaseKeyOnOtherFile_IndexMatchesFullScan` assert the index-driven answer equals the full-sweep answer across a mixed fixture, and `indexes_test.go` asserts index/`unifiedLocks` consistency across the whole lease lifecycle.

## Clarity

- Grace-period `Operation` was a struct of three independent bools (`IsNew`/`IsTest`/`IsReclaim`) that admitted contradictory combinations; it is now an enum. The sole production caller sets it explicitly, so the `OpNew`-as-zero-value change is inert.
- `NewDeadlockError`, `NewGracePeriodError` and `NewLockLimitExceededError` accepted diagnostic values and dropped them on the floor; they now appear in the message. `RegisterClient` builds its error via the existing `errors.NewConnectionLimitError` instead of an inline literal.
- `ValidFileLeaseStates`/`ValidDirectoryLeaseStates` unexported (no external users), unused deprecated re-export vars deleted from `lock_exports.go`, and eight duplicated `// Package lock ...` headers detached from the `package` clause so `types.go` is the only package doc.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. `pkg/metadata/lock` 451 tests pass and pass under `-race`; `internal/adapter/smb/...` + `pkg/adapter/nfs/...` 803 tests pass. No behaviour change outside the lock scope.

Relates to #1900