### PR TITLE
fix(smb): guard the OpenFile fields WRITE mutates and coalesce its atime writes

### DIFF
--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -208,8 +208,15 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// (silent write truncation, #1267). The mapped status is recorded and
 	// applied to the response below; handle teardown still runs unconditionally
 	// so the failed flush does not leak the open-file/lease state.
+	// Snapshot the path once for the rest of CLOSE. SET_INFO rename rewrites it
+	// on a live handle, so reading it per use would let a rename landing
+	// mid-close produce log lines, a delete target and a parent path that each
+	// name a different file.
+	closePath := openFile.GetPath()
+
 	var flushFailStatus types.Status
-	if !openFile.IsDirectory && openFile.PayloadID != "" {
+	payloadID := openFile.GetPayloadID()
+	if !openFile.IsDirectory && payloadID != "" {
 		blockStore, bsErr := common.ResolveForWrite(ctx.Context, h.Registry, openFile.MetadataHandle)
 		if bsErr != nil {
 			// A ResolveForWrite failure is NOT a block-store content/durability
@@ -218,13 +225,13 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 			// etc.), mirroring READ/WRITE/FLUSH which map their resolve/handle
 			// errors via common.MapToSMB. Only the CommitBlockStore failure
 			// below is a true content error (MapContentToSMB).
-			logger.Warn("CLOSE: block store not available for handle", "path", openFile.Path, "error", bsErr)
+			logger.Warn("CLOSE: block store not available for handle", "path", closePath, "error", bsErr)
 			flushFailStatus = common.MapToSMB(bsErr)
-		} else if flushErr := common.CommitBlockStore(ctx.Context, blockStore, openFile.PayloadID); flushErr != nil {
-			logger.Warn("CLOSE: flush failed", "path", openFile.Path, "error", flushErr)
+		} else if flushErr := common.CommitBlockStore(ctx.Context, blockStore, payloadID); flushErr != nil {
+			logger.Warn("CLOSE: flush failed", "path", closePath, "error", flushErr)
 			flushFailStatus = common.MapContentToSMB(flushErr)
 		} else {
-			logger.Debug("CLOSE: flushed", "path", openFile.Path, "payloadID", openFile.PayloadID)
+			logger.Debug("CLOSE: flushed", "path", closePath, "payloadID", payloadID)
 		}
 	}
 
@@ -240,7 +247,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	if !openFile.IsDirectory && len(openFile.MetadataHandle) > 0 {
 		authCtx, authErr := BuildAuthContext(ctx)
 		if authErr != nil {
-			logger.Warn("CLOSE: failed to build auth context for metadata flush", "path", openFile.Path, "error", authErr)
+			logger.Warn("CLOSE: failed to build auth context for metadata flush", "path", closePath, "error", authErr)
 		} else {
 			metaSvc := h.Registry.GetMetadataService()
 			// STRICT (durable=true): CLOSE is a durability point (MS-SMB2 3.3.5.10,
@@ -249,7 +256,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 			// is deliberately NOT relaxed by #1687.
 			flushed, metaErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle, true)
 			if metaErr != nil {
-				logger.Warn("CLOSE: metadata flush failed", "path", openFile.Path, "error", metaErr)
+				logger.Warn("CLOSE: metadata flush failed", "path", closePath, "error", metaErr)
 				// Surface the metadata-flush failure too (#1267): if the
 				// deferred size/mtime never persisted, the client must not be
 				// told the CLOSE succeeded. Lower severity than the byte-data
@@ -260,7 +267,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 					flushFailStatus = common.MapToSMB(metaErr)
 				}
 			} else if flushed {
-				logger.Debug("CLOSE: metadata flushed", "path", openFile.Path)
+				logger.Debug("CLOSE: metadata flushed", "path", closePath)
 			}
 
 			// READ coalesces its LastAccessTime bumps, so the newest access time
@@ -278,7 +285,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 			if pending := takeSmbPendingAtime(openFile); !pending.IsZero() && !openFile.IsAtimeFrozen() {
 				if cur, curErr := metaSvc.GetFile(authCtx.Context, openFile.MetadataHandle); curErr == nil && cur.Atime.Before(pending) {
 					if _, atimeErr := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{Atime: &pending}); atimeErr != nil {
-						logger.Warn("CLOSE: LastAccessTime flush failed", "path", openFile.Path, "error", atimeErr)
+						logger.Warn("CLOSE: LastAccessTime flush failed", "path", closePath, "error", atimeErr)
 					}
 				}
 			}
@@ -299,12 +306,12 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// (1067-byte files with XSym\n header). On CLOSE, we convert these to
 	// real symlinks in the metadata store for NFS interoperability.
 
-	if !openFile.IsDirectory && openFile.PayloadID != "" && !openFile.DeletePending && !openFile.InitialDeleteOnClose {
+	if !openFile.IsDirectory && payloadID != "" && !openFile.DeletePending && !openFile.InitialDeleteOnClose {
 		// MFsymlink conversion promotes client-controlled file content to a real
 		// symlink, so it is opt-in per share (default disabled).
 		if tree, treeOK := h.GetTree(ctx.TreeID); treeOK && tree.AllowMFsymlink {
 			if converted, _ := h.checkAndConvertMFsymlink(ctx, openFile); converted {
-				logger.Debug("CLOSE: converted MFsymlink to symlink", "path", openFile.Path)
+				logger.Debug("CLOSE: converted MFsymlink to symlink", "path", closePath)
 			}
 		}
 	}
@@ -373,7 +380,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 
 		metaSvc := h.Registry.GetMetadataService()
 		if unlockErr := metaSvc.UnlockAllForOpen(ctx.Context, openFile.MetadataHandle, openFile.OpenID()); unlockErr != nil {
-			logger.Warn("CLOSE: failed to release locks", "path", openFile.Path, "error", unlockErr)
+			logger.Warn("CLOSE: failed to release locks", "path", closePath, "error", unlockErr)
 		}
 	}
 
@@ -469,7 +476,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 				return true
 			})
 			logger.Debug("CLOSE: DOC propagated to other handles (not last)",
-				"path", openFile.Path)
+				"path", closePath)
 		} else if streamHandleExists {
 			// Base file has DOC but open stream handles remain. Per MS-FSA
 			// 2.1.5.4 / 2.1.5.9.7, defer the actual deletion until all
@@ -491,7 +498,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 				return true
 			})
 			logger.Debug("CLOSE: base file DOC deferred to stream handles",
-				"path", openFile.Path)
+				"path", closePath)
 		} else {
 			// Last handle: perform the actual delete.
 			//
@@ -568,14 +575,14 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 						resp.Status = common.MapToSMB(deleteErr)
 					}
 					logger.Debug("CLOSE: failed to delete",
-						"path", openFile.Path,
+						"path", closePath,
 						"isDir", openFile.IsDirectory,
 						"deleteTarget", deleteFileName,
 						"status", resp.Status,
 						"error", deleteErr)
 				} else {
 					logger.Debug("CLOSE: deleted",
-						"path", openFile.Path,
+						"path", closePath,
 						"deleteTarget", deleteFileName,
 						"isDir", openFile.IsDirectory,
 						"isBaseFileDelete", isBaseFileDelete)
@@ -588,13 +595,13 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 							cascadeOF = &OpenFile{
 								ParentHandle: deleteParentHandle,
 								FileName:     deleteFileName,
-								Path:         openFile.Path,
+								Path:         closePath,
 							}
 						}
 						h.cascadeDeleteADSStreams(authCtx, metaSvc, cascadeOF)
 					}
 
-					h.purgeBlockStorePayload(ctx.Context, deleteTargetHandle, removedPayloadID, openFile.Path, "CLOSE")
+					h.purgeBlockStorePayload(ctx.Context, deleteTargetHandle, removedPayloadID, closePath, "CLOSE")
 					h.restoreParentDirFrozenTimestamps(authCtx, deleteParentHandle)
 
 					// Removing the entry already broke the parent directory's
@@ -609,7 +616,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 					// duplicate LEASE_BREAK for one logical change.
 
 					if h.NotifyRegistry != nil {
-						parentPath := GetParentPath(openFile.Path)
+						parentPath := GetParentPath(closePath)
 						// Use the resolved delete-target type (base file's, not
 						// the stream open's) and the actual deleteFileName.
 						// NameChangeFilterFor routes ADS names via
@@ -644,7 +651,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	if !openFile.DeletePending && !openFile.IsDirectory && smbWriteTriggered {
 		authCtx, authErr := BuildAuthContext(ctx)
 		if authErr != nil {
-			logger.Warn("CLOSE: failed to build auth context for modified-file dir-lease break", "path", openFile.Path, "error", authErr)
+			logger.Warn("CLOSE: failed to build auth context for modified-file dir-lease break", "path", closePath, "error", authErr)
 		} else {
 			PropagateOpenFileParentLeaseKey(authCtx, openFile)
 			h.breakParentDirLeasesForContentChange(ctx, authCtx, openFile)
@@ -691,14 +698,14 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 							return
 						}
 						logger.Debug("CLOSE: sent STATUS_NOTIFY_CLEANUP (post-close)",
-							"path", openFile.Path,
+							"path", closePath,
 							"messageID", n.MessageID,
 							"asyncId", n.AsyncId)
 					})
 				}
 			}
 			logger.Debug("CLOSE: unregistered pending CHANGE_NOTIFY",
-				"path", openFile.Path,
+				"path", closePath,
 				"messageID", notify.MessageID)
 		}
 	}
@@ -786,7 +793,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 
 	logger.Debug("CLOSE successful",
 		"fileID", fmt.Sprintf("%x", req.FileID),
-		"path", openFile.Path)
+		"path", closePath)
 
 	// ========================================================================
 	// Step 12: Return success response
@@ -950,7 +957,7 @@ func (h *Handler) readMFsymlinkContent(ctx *SMBHandlerContext, openFile *OpenFil
 	// plumbing lands in one place (see common/doc.go).
 	// The bytes are copied into a caller-owned slice because the MFsymlink
 	// parse path retains them past Release().
-	result, err := common.ReadFromBlockStore(ctx.Context, blockStore, openFile.PayloadID, 0, uint32(mfsymlink.Size))
+	result, err := common.ReadFromBlockStore(ctx.Context, blockStore, openFile.GetPayloadID(), 0, uint32(mfsymlink.Size))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -2180,13 +2180,18 @@ func (h *Handler) updateBaseObjectCtime(
 // Per MS-FSA / NTFS semantics, data writes to an alternate data stream propagate
 // Mtime and Ctime changes to the base object, unless the corresponding timestamp
 // is frozen on the ADS handle.
+//
+// parentHandle is passed in rather than read off openFile so it stays the same
+// directory the caller derived baseObjectName from: SET_INFO rename can move
+// the handle to another parent while the write is in flight.
 func (h *Handler) updateBaseObjectTimestampsForADSWrite(
 	authCtx *metadata.AuthContext,
 	metaSvc *metadata.Service,
 	openFile *OpenFile,
+	parentHandle metadata.FileHandle,
 	baseObjectName string,
 ) {
-	baseFile, _, _ := h.lookupCaseInsensitive(authCtx, metaSvc, openFile.ParentHandle, baseObjectName)
+	baseFile, _, _ := h.lookupCaseInsensitive(authCtx, metaSvc, parentHandle, baseObjectName)
 	if baseFile == nil {
 		return
 	}

--- a/internal/adapter/smb/handlers/durable_context.go
+++ b/internal/adapter/smb/handlers/durable_context.go
@@ -1061,6 +1061,14 @@ func buildPersistedDurableHandle(
 	leaseState uint32,
 	leaseEpoch uint16,
 ) *lock.PersistedDurableHandle {
+	// The handle lock is held across the whole snapshot rather than per field.
+	// SET_INFO rename rewrites Path, FileName and ParentHandle together, and
+	// this row is replayed on reconnect: reading them at different instants
+	// could persist one rename's name against another's parent, which no later
+	// operation would correct. Field reads and copies only, no store I/O.
+	openFile.mu.RLock()
+	defer openFile.mu.RUnlock()
+
 	// Clone MetadataHandle to avoid aliasing the live OpenFile's slice
 	metaHandle := make([]byte, len(openFile.MetadataHandle))
 	copy(metaHandle, openFile.MetadataHandle)

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -417,8 +417,14 @@ type TreeConnection struct {
 // read-modify-write region; release before any I/O to the metadata store to
 // keep the critical section bounded. Atomic-typed fields
 // (NotifyOverflowed/NotifyMaxBufferSize/NotifyCompletionFilter) and immutable
-// fields (FileID/TreeID/SessionID/Path/MetadataHandle/PayloadID/CreateOptions)
-// are safe to access without the mutex.
+// fields (FileID/TreeID/SessionID/MetadataHandle/CreateOptions) are safe to
+// access without the mutex.
+//
+// PayloadID, Path, FileName and ParentHandle are NOT immutable: the first WRITE
+// on a file created empty caches the payload the metadata store allocated,
+// SET_REPARSE_POINT and COPYCHUNK replace it, and SET_INFO rename rewrites the
+// name/path/parent triple. Reach them through GetPayloadID / SetPayloadID and
+// GetFileName, or under `mu` directly.
 type OpenFile struct {
 	// mu guards the mutable fields listed in the struct comment above. Held
 	// across QueryDirectory enumeration R-M-W, freeze/thaw bookkeeping in
@@ -583,6 +589,11 @@ type OpenFile struct {
 	// persisted at CLOSE.
 	SmbAtimeWrittenAt time.Time // when the last READ-driven atime reached the store
 	SmbPendingAtime   time.Time // newest access time not yet written to the store (zero ⇒ none)
+
+	// SmbParentAtimeWrittenAt bounds the parent-directory LastAccessTime bump a
+	// WRITE performs, the way SmbAtimeWrittenAt bounds the file's. A suppressed
+	// bump is dropped rather than deferred — see noteSmbParentAccess.
+	SmbParentAtimeWrittenAt time.Time
 
 	// Oplock state
 	// OplockLevel is the current oplock level for this handle.
@@ -843,6 +854,41 @@ func (f *OpenFile) IsAtimeFrozen() bool {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	return f.AtimeFrozen
+}
+
+// GetPayloadID returns the cached payload identifier under the read lock.
+// WRITE, SET_REPARSE_POINT and COPYCHUNK publish it on a live handle, so
+// readers on other channels must not touch the field directly.
+func (f *OpenFile) GetPayloadID() metadata.PayloadID {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.PayloadID
+}
+
+// SetPayloadID publishes a new cached payload identifier under the write lock.
+func (f *OpenFile) SetPayloadID(id metadata.PayloadID) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.PayloadID = id
+}
+
+// GetFileName returns the name within the parent directory under the read lock.
+// SET_INFO rename rewrites it on a live handle, so a caller needing the name
+// alongside Path or ParentHandle must snapshot the group under RLock instead.
+func (f *OpenFile) GetFileName() string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.FileName
+}
+
+// GetPath returns the full path under the read lock. SET_INFO rename rewrites
+// it on a live handle, so a caller needing the path alongside FileName or
+// ParentHandle must snapshot the group under RLock instead of calling this
+// once per field.
+func (f *OpenFile) GetPath() string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.Path
 }
 
 // IsMtimeFrozen returns the MtimeFrozen flag under the read lock.
@@ -1388,7 +1434,7 @@ func (h *Handler) closeFilesWithFilter(
 		}
 
 		// Flush cache if needed
-		if !openFile.IsDirectory && openFile.PayloadID != "" {
+		if !openFile.IsDirectory && openFile.GetPayloadID() != "" {
 			h.flushFileCache(ctx, openFile)
 		}
 
@@ -1905,29 +1951,33 @@ func (h *Handler) CleanupSession(ctx context.Context, sessionID uint64, isDiscon
 // flushFileCache flushes cached data for an open file.
 // This is a helper used during cleanup to ensure data durability.
 func (h *Handler) flushFileCache(ctx context.Context, openFile *OpenFile) {
-	if openFile.PayloadID == "" {
+	payloadID := openFile.GetPayloadID()
+	if payloadID == "" {
 		return
 	}
+	// Snapshot once: a rename landing mid-flush would otherwise let the three
+	// log lines below name different paths for the same operation.
+	path := openFile.GetPath()
 
 	blockStore, err := h.Registry.GetBlockStoreForShare(openFile.ShareName)
 	if err != nil {
 		logger.Warn("flushFileCache: block store not available for handle",
-			"path", openFile.Path,
+			"path", path,
 			"error", err)
 		return
 	}
 
 	// Use blocking Flush for immediate durability
-	_, flushErr := blockStore.Flush(ctx, string(openFile.PayloadID))
+	_, flushErr := blockStore.Flush(ctx, string(payloadID))
 	if flushErr != nil {
 		logger.Warn("flushFileCache: flush failed",
-			"path", openFile.Path,
-			"payloadID", openFile.PayloadID,
+			"path", path,
+			"payloadID", payloadID,
 			"error", flushErr)
 	} else {
 		logger.Debug("flushFileCache: flushed",
-			"path", openFile.Path,
-			"payloadID", openFile.PayloadID)
+			"path", path,
+			"payloadID", payloadID)
 	}
 }
 

--- a/internal/adapter/smb/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk.go
@@ -552,7 +552,7 @@ func (h *Handler) executeCopyChunks(
 
 	// Update cached PayloadID on destination (matches write.go pattern).
 	// This ensures close.go flushes block store data correctly.
-	dstOpen.PayloadID = lastWritePayloadID
+	dstOpen.SetPayloadID(lastWritePayloadID)
 
 	// Per MS-FSA 2.1.5.14.2: restore frozen timestamps after writes
 	h.restoreFrozenTimestamps(authCtx, dstOpen)

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -780,7 +780,10 @@ func (h *Handler) setFileInfoFromStore(
 				}
 			}
 
-			// Update open file state
+			// Update open file state. Ops pipelined on this handle read the
+			// name/path pair concurrently (WRITE classifies an ADS write from
+			// it), so read and republish the pair under the handle lock.
+			openFile.mu.Lock()
 			parentPath := GetParentPath(openFile.Path)
 			if parentPath == "" || parentPath == "/" || parentPath == "." {
 				openFile.Path = toName
@@ -788,6 +791,7 @@ func (h *Handler) setFileInfoFromStore(
 				openFile.Path = parentPath + "/" + toName
 			}
 			openFile.FileName = toName
+			openFile.mu.Unlock()
 			h.StoreOpenFile(openFile)
 
 			// Break parent directory leases on rename (content change)
@@ -1186,9 +1190,14 @@ func (h *Handler) setFileInfoFromStore(
 				actualNewPath = parentPath + "/" + toName
 			}
 		}
+		// Ops pipelined on this handle read the name/path/parent triple
+		// concurrently (WRITE snapshots it), so publish all three together
+		// under the handle lock.
+		openFile.mu.Lock()
 		openFile.Path = actualNewPath
 		openFile.FileName = toName
 		openFile.ParentHandle = toDir
+		openFile.mu.Unlock()
 		h.StoreOpenFile(openFile)
 
 		// Per MS-FSA 2.1.5.14.10 (smbtorture smb2.dirlease.rename):

--- a/internal/adapter/smb/handlers/timestamps.go
+++ b/internal/adapter/smb/handlers/timestamps.go
@@ -61,6 +61,29 @@ func noteSmbAccess(openFile *OpenFile, t time.Time) bool {
 	return true
 }
 
+// noteSmbParentAccess records a parent-directory access at t on the handle and
+// reports whether it has to reach the metadata store now. The first access on a
+// handle always writes.
+//
+// Unlike noteSmbAccess, a suppressed bump is dropped rather than held: the
+// parent directory has no handle here to carry it and no QUERY_INFO overlay to
+// surface it, so its LastAccessTime trails the newest write by at most
+// smbAtimeUpdateWindow instead of serializing every WRITE on the parent row.
+//
+// Takes openFile.mu (write).
+func noteSmbParentAccess(openFile *OpenFile, t time.Time) bool {
+	if openFile == nil {
+		return false
+	}
+	openFile.mu.Lock()
+	defer openFile.mu.Unlock()
+	if !openFile.SmbParentAtimeWrittenAt.IsZero() && t.Sub(openFile.SmbParentAtimeWrittenAt) < smbAtimeUpdateWindow {
+		return false
+	}
+	openFile.SmbParentAtimeWrittenAt = t
+	return true
+}
+
 // takeSmbPendingAtime removes and returns the access time held on the handle
 // since the last store write, or the zero time when there is none. Called at
 // CLOSE so a coalesced bump is not lost with the handle.

--- a/internal/adapter/smb/handlers/timestamps_test.go
+++ b/internal/adapter/smb/handlers/timestamps_test.go
@@ -949,7 +949,7 @@ func TestUpdateBaseObjectTimestampsForADSWrite_PreservesBaseCtimeWhenFrozen(t *t
 	h.StoreOpenFile(adsOpen)
 
 	// Trigger the WRITE-path base-timestamp update.
-	h.updateBaseObjectTimestampsForADSWrite(authCtx, metaSvc, adsOpen, "basedir")
+	h.updateBaseObjectTimestampsForADSWrite(authCtx, metaSvc, adsOpen, adsOpen.ParentHandle, "basedir")
 
 	// Verify the base directory's Ctime is unchanged but Mtime was advanced
 	// (because only Ctime is frozen on the ADS handle).
@@ -962,5 +962,36 @@ func TestUpdateBaseObjectTimestampsForADSWrite_PreservesBaseCtimeWhenFrozen(t *t
 	}
 	if post.Mtime.Equal(pinned) {
 		t.Errorf("base Mtime was not advanced: got %v want != %v", post.Mtime, pinned)
+	}
+}
+
+func TestNoteSmbParentAccessCoalescesWithinWindow(t *testing.T) {
+	base := time.Now()
+	openFile := &OpenFile{}
+
+	if !noteSmbParentAccess(openFile, base) {
+		t.Fatal("first parent access on a handle must write")
+	}
+	if noteSmbParentAccess(openFile, base.Add(smbAtimeUpdateWindow/2)) {
+		t.Error("a bump inside the window must be suppressed")
+	}
+	if noteSmbParentAccess(openFile, base.Add(smbAtimeUpdateWindow-time.Millisecond)) {
+		t.Error("a bump still inside the window must stay suppressed")
+	}
+	if !noteSmbParentAccess(openFile, base.Add(smbAtimeUpdateWindow)) {
+		t.Error("a bump at the window boundary must write again")
+	}
+
+	// Unlike noteSmbAccess, a suppressed parent bump is dropped rather than
+	// held: the parent has no handle here to carry it. Nothing may accumulate
+	// on the file's own pending-atime slot.
+	if !openFile.SmbPendingAtime.IsZero() {
+		t.Errorf("parent bumps leaked into the file's pending atime: %v", openFile.SmbPendingAtime)
+	}
+}
+
+func TestNoteSmbParentAccessNilHandle(t *testing.T) {
+	if noteSmbParentAccess(nil, time.Now()) {
+		t.Error("a nil handle must not report a store write")
 	}
 }

--- a/internal/adapter/smb/handlers/write.go
+++ b/internal/adapter/smb/handlers/write.go
@@ -501,42 +501,54 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	h.StoreOpenFile(openFile)
 
 	// Detect ADS writes once for timestamp propagation and change notification.
+	// A SET_INFO rename on another channel can rewrite the name, the path and
+	// the parent mid-WRITE, so snapshot all three together: re-reading would let
+	// the ADS classification, the parent-atime bump and the change notification
+	// below describe different names.
+	openFile.RLock()
+	fileName, filePath, parentHandle := openFile.FileName, openFile.Path, openFile.ParentHandle
+	openFile.RUnlock()
 	isADSWrite := false
 	var baseFileName string
-	if colonIdx := strings.Index(openFile.FileName, ":"); colonIdx > 0 {
+	if colonIdx := strings.Index(fileName, ":"); colonIdx > 0 {
 		isADSWrite = true
-		baseFileName = openFile.FileName[:colonIdx]
+		baseFileName = fileName[:colonIdx]
 	}
 
 	// Per NTFS: Writing to an ADS updates the base object's ChangeTime and
 	// LastWriteTime. Respect frozen state on the ADS handle.
 	if isADSWrite {
-		h.updateBaseObjectTimestampsForADSWrite(authCtx, metaSvc, openFile, baseFileName)
+		h.updateBaseObjectTimestampsForADSWrite(authCtx, metaSvc, openFile, parentHandle, baseFileName)
 	}
 
 	// Per MS-FSA 2.1.5.3: After a successful write, update LastAccessTime
 	// to the current system time, unless frozen via SET_INFO -1.
 	// Per MS-FSA 2.1.4.4: Parent directory's LastAccessTime is also updated.
+	// Both bumps coalesce per handle the way READ's does — see noteSmbAccess
+	// and noteSmbParentAccess.
 	now := time.Now()
 	// IsAtimeFrozen takes openFile.mu (read); see #606.
-	if !openFile.IsAtimeFrozen() {
+	if !openFile.IsAtimeFrozen() && noteSmbAccess(openFile, now) {
 		_, _ = metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{Atime: &now})
 	}
-	if len(openFile.ParentHandle) > 0 {
-		_, _ = metaSvc.SetFileAttributes(authCtx, openFile.ParentHandle, &metadata.SetAttrs{Atime: &now})
+	if len(parentHandle) > 0 && noteSmbParentAccess(openFile, now) {
+		_, _ = metaSvc.SetFileAttributes(authCtx, parentHandle, &metadata.SetAttrs{Atime: &now})
 		// Per MS-FSA 2.1.5.14.2: Restore frozen timestamps on the parent directory
 		// if any open handle has them frozen. The SetFileAttributes call above
 		// unconditionally updates atime; if a handle has atime frozen, restore it.
-		h.restoreParentDirFrozenTimestamps(authCtx, openFile.ParentHandle)
+		// Skipped along with a coalesced-away bump: nothing was written to restore.
+		h.restoreParentDirFrozenTimestamps(authCtx, parentHandle)
 	}
 
-	// Update cached PayloadID in OpenFile
-	openFile.PayloadID = writeOp.PayloadID
+	// Publish the payload the metadata store allocated for this file. A file
+	// created empty has none until its first WRITE, and CLOSE reads this to
+	// decide whether to commit block-store content.
+	openFile.SetPayloadID(writeOp.PayloadID)
 
 	if h.NotifyRegistry != nil {
-		parentDirPath := GetParentPath(openFile.Path)
+		parentDirPath := GetParentPath(filePath)
 		if isADSWrite {
-			h.NotifyRegistry.NotifyChange(openFile.ShareName, parentDirPath, notifyStreamName(openFile.FileName), FileActionModifiedStream, FileNotifyChangeStreamWrite|FileNotifyChangeStreamSize)
+			h.NotifyRegistry.NotifyChange(openFile.ShareName, parentDirPath, notifyStreamName(fileName), FileActionModifiedStream, FileNotifyChangeStreamWrite|FileNotifyChangeStreamSize)
 		} else {
 			// Mirror Samba `notify_fname(... NOTIFY_ACTION_MODIFIED, ...)` from
 			// `vfs_default_pwrite_recv`: a successful WRITE on a regular file
@@ -545,7 +557,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 			// this hook, in-memory backends never observe the kernel inotify
 			// MODIFIED event that real Samba relies on (smb2.notify.valid-req
 			// expects REMOVED + ADDED + MODIFIED for unlink → CREATE → WRITE).
-			h.NotifyRegistry.NotifyChange(openFile.ShareName, parentDirPath, openFile.FileName, FileActionModified, FileNotifyChangeSize|FileNotifyChangeLastWrite|FileNotifyChangeAttributes)
+			h.NotifyRegistry.NotifyChange(openFile.ShareName, parentDirPath, fileName, FileActionModified, FileNotifyChangeSize|FileNotifyChangeLastWrite|FileNotifyChangeAttributes)
 		}
 	}
 

--- a/internal/adapter/smb/handlers/write_race_test.go
+++ b/internal/adapter/smb/handlers/write_race_test.go
@@ -1,0 +1,61 @@
+// Concurrency coverage for the mutable OpenFile fields the WRITE path touches.
+//
+// SMB clients legitimately pipeline operations on one FileID, and a
+// multi-channel session dispatches them from different connections, so WRITE
+// runs concurrently with the cleanup-time cache flush on the same handle. The
+// test below is only meaningful under `go test -race`: it asserts nothing
+// itself and passes trivially without the detector.
+//
+// The name/path/parent triple SET_INFO rename republishes is not covered the
+// same way. Both sides of that pairing take the handle lock, which leaves the
+// detector nothing to observe; the guard there is the lock itself.
+package handlers
+
+import (
+	"sync"
+	"testing"
+)
+
+// raceIterations is high enough for the detector to observe an interleaving on
+// an unsynchronized field, low enough to stay a sub-second unit test.
+const raceIterations = 200
+
+// TestWrite_ConcurrentFlush_PayloadIDNoRace pairs the WRITE handler against
+// flushFileCache, the cleanup-path reader of the cached payload. A file created
+// empty has no payload until its first WRITE publishes the one the metadata
+// store allocated, so the field is written on the data plane while session and
+// tree teardown read it.
+func TestWrite_ConcurrentFlush_PayloadIDNoRace(t *testing.T) {
+	h, smbCtx, _, fileID := setupWriteTestShare(t, nil)
+	openFile, ok := h.GetOpenFile(fileID)
+	if !ok {
+		t.Fatal("GetOpenFile: handle missing after setup")
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for range raceIterations {
+			h.flushFileCache(smbCtx.Context, openFile)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		data := []byte("race")
+		for range raceIterations {
+			if _, err := h.Write(smbCtx, &WriteRequest{
+				FileID: fileID,
+				Length: uint32(len(data)),
+				Data:   data,
+			}); err != nil {
+				t.Errorf("Write: %v", err)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
Three MEDIUM findings from the data-plane audit, all reported against the SMB2 WRITE handler. All three were confirmed real; one sub-claim in the first was refuted (see below).

## 1. PayloadID was mutated without the handle lock (bugs)

`OpenFile`'s struct doc listed PayloadID among the "immutable fields ... safe to access without the mutex". That was false: a file created empty has no payload until its first WRITE publishes the one the metadata store allocated, and SET_REPARSE_POINT and COPYCHUNK replace it. So the doc was wrong, not the code.

Unguarded readers raced that write — CLOSE's block-store commit gate, `flushFileCache` on session/tree teardown, and the durable-handle snapshot. Added `GetPayloadID` / `SetPayloadID` accessors that take `mu`, converted every reader and writer, and corrected the struct doc to name PayloadID, Path, FileName and ParentHandle as mutable.

Refuted sub-claim: the audit also cited `set_reparse_point.go:256` as an unguarded mutation. It already mutates inside `openFile.mu.Lock()`; no change was needed there.

## 2. FileName was read without the lock while rename mutated it (bugs)

SET_INFO rename rewrites the name, path and parent on a live handle. WRITE read the name to classify an ADS write and to address the change notification, and read the parent to bump the directory's access time — none of it under the lock.

WRITE now snapshots name, path and parent once under the read lock and uses that snapshot throughout, so a rename landing mid-WRITE cannot leave the ADS classification and the change notification describing different names. Both rename publication sites in set_info.go now publish the triple under the write lock.

`updateBaseObjectTimestampsForADSWrite` took the parent off the OpenFile itself, which reintroduced the live read one call deep; it now receives the caller's snapshot, so the base-object lookup cannot target a different directory than the one its name was derived from.

## 3. Two extra unbatched metadata round trips per WRITE (perf)

Every WRITE issued a `SetFileAttributes` for the file's LastAccessTime and another for the parent directory's, on the ack path. The parent bump serialized every WRITE to any file in a directory on that one metadata row — the same read-modify-write contention shape already fixed elsewhere for mkdir nlink.

Both now coalesce per handle, reusing the mechanism the READ path already uses rather than adding a second one. The file's newest access time is held on the handle for QUERY_INFO to overlay and CLOSE to persist, so nothing observable is lost. The parent's is dropped rather than deferred, since a directory has no handle here to carry it; a parent's access time therefore trails the newest write by at most the coalescing window.

## Verification

`go build ./...`, `go vet ./...` and `gofmt -l .` are clean. `go test ./internal/adapter/smb/...` passes 2056 tests, and `go test -race ./internal/adapter/smb/...` is green across all 12 packages.

The PayloadID race was reproduced under `-race` before the fix — write in the WRITE handler against the read in `flushFileCache`. `write_race_test.go` keeps that pairing as a regression guard: it drives the real WRITE handler on one side, so the reader half is production code rather than a stand-in.

The rename race was likewise reproduced pre-fix with both sides unguarded, and showed up as three distinct races (FileName, ParentHandle, Path). It is not kept as a test: both sides of that pairing now take the handle lock, which leaves the detector nothing to observe, so the guard there is the lock itself.

Relates to #1692
