### PR TITLE
fix(nfs): correct non-regular READ errno, clamp v3 READ to rtmax

### DIFF
--- a/internal/adapter/nfs/v3/handlers/caps_cache.go
+++ b/internal/adapter/nfs/v3/handlers/caps_cache.go
@@ -4,47 +4,43 @@ import "sync/atomic"
 
 // Filesystem capability cache.
 //
-// The advertised maximum WRITE size (wtmax) is a static, store-level limit. The
-// WRITE handler needs it on every RPC to short-write over-large requests to the
-// value the client was told in FSINFO. Calling GetFilesystemCapabilities (a
-// Badger db.View on the BadgerDB backend) on every WRITE is wasteful, so the
-// value is cached here and refreshed whenever it is observed (FSINFO, or the
-// first WRITE on a cold cache).
+// wtmax and rtmax are static, store-level limits, but WRITE and READ need them
+// on every RPC to clamp over-large requests to what FSINFO told the client.
+// GetFilesystemCapabilities is a store call (a Badger db.View on the BadgerDB
+// backend), so the values are cached here and refreshed whenever they are
+// observed: in FSINFO, or by the first WRITE/READ to find a cold cache. This
+// mirrors the NFSv4 attrs package, which caches the same store capabilities in
+// atomic globals. Atomics keep concurrent handlers race-free.
 //
-// This mirrors the NFSv4 attrs package, which caches the same store
-// capabilities in atomic globals updated via SetFilesystemCapabilities.
+// Zero means "not yet observed": a caller must fall back to a store lookup and
+// must not clamp, since clamping to zero would truncate every request.
 //
-// INVARIANT (process-global is safe): wtmax is a server-wide value, not a
-// per-share one. GetFilesystemCapabilities ignores the file handle and every
+// INVARIANT (process-global is safe): both are server-wide values, not
+// per-share ones. GetFilesystemCapabilities ignores the file handle and every
 // metadata backend (memory/badger/postgres) returns the same hardcoded
-// MaxWriteSize (1 MiB). FSINFO advertises this same value to every client on
-// every share, so a single global cannot diverge from what any one client was
-// told. If a future change makes wtmax per-share (a per-share override in
-// GetFilesystemCapabilities), this cache MUST become handle-keyed to avoid
-// clamping one share's WRITE with another share's limit.
-//
-// Uses an atomic to stay race-free with concurrent WRITE/FSINFO handlers.
+// MaxWriteSize/MaxReadSize (1 MiB), and FSINFO advertises those same values to
+// every client on every share, so a single global cannot diverge from what any
+// one client was told. If a future change makes them per-share (a per-share
+// override in GetFilesystemCapabilities), this cache MUST become handle-keyed
+// to avoid clamping one share's request with another share's limit.
+var (
+	fsMaxWriteSize atomic.Uint32
+	fsMaxReadSize  atomic.Uint32
+)
 
-// fsMaxWriteSize holds the cached wtmax. Zero means "not yet observed".
-var fsMaxWriteSize atomic.Uint32
-
-// setMaxWriteSize records the advertised wtmax so subsequent WRITEs can clamp
-// without a per-RPC store lookup. A zero value is ignored (treated as unknown).
-func setMaxWriteSize(maxWriteSize uint32) {
-	if maxWriteSize > 0 {
-		fsMaxWriteSize.Store(maxWriteSize)
+// cacheMax records an advertised wtmax/rtmax so subsequent RPCs can clamp
+// without a per-RPC store lookup. Zero is ignored (treated as unknown).
+func cacheMax(cached *atomic.Uint32, size uint32) {
+	if size > 0 {
+		cached.Store(size)
 	}
-}
-
-// cachedMaxWriteSize returns the cached wtmax, or 0 if it has not been observed
-// yet. A zero result means the caller must fall back to a one-time store lookup.
-func cachedMaxWriteSize() uint32 {
-	return fsMaxWriteSize.Load()
 }
 
 // ResetCapsCacheForTest clears the process-global capability cache so a test
 // starts from a cold cache. Because the cache is process-wide, tests that set
-// different wtmax values must reset it to avoid bleed-through from earlier runs.
+// different wtmax/rtmax values must reset it to avoid bleed-through from
+// earlier runs.
 func ResetCapsCacheForTest() {
 	fsMaxWriteSize.Store(0)
+	fsMaxReadSize.Store(0)
 }

--- a/internal/adapter/nfs/v3/handlers/fsinfo.go
+++ b/internal/adapter/nfs/v3/handlers/fsinfo.go
@@ -168,9 +168,10 @@ func (h *Handler) FsInfo(
 		return &FsInfoResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
-	// Cache the advertised wtmax so WRITE can clamp over-large requests without
-	// a per-RPC GetFilesystemCapabilities lookup.
-	setMaxWriteSize(capabilities.MaxWriteSize)
+	// Cache the advertised wtmax/rtmax so WRITE and READ can clamp over-large
+	// requests without a per-RPC GetFilesystemCapabilities lookup.
+	cacheMax(&fsMaxWriteSize, capabilities.MaxWriteSize)
+	cacheMax(&fsMaxReadSize, capabilities.MaxReadSize)
 
 	// Convert metadata attributes to NFS wire format
 	nfsAttr := h.convertFileAttrToNFS(fileHandle, &file.FileAttr)

--- a/internal/adapter/nfs/v3/handlers/read.go
+++ b/internal/adapter/nfs/v3/handlers/read.go
@@ -241,8 +241,31 @@ func (h *Handler) Read(
 		}, nil
 	}
 
+	// Clamp the requested count to the rtmax advertised by FSINFO
+	// (GetFilesystemCapabilities().MaxReadSize) so the read limit can never
+	// drift from what the client was told, and so a client-supplied Count
+	// cannot size a server-side buffer beyond that limit. RFC 1813 permits a
+	// READ reply to carry fewer bytes than requested, so an over-large Count is
+	// served short (the reply Count and Eof describe the bytes actually read)
+	// rather than rejected — the same contract WRITE applies to wtmax. rtmax
+	// comes from the process-wide cache FSINFO populates; on a cold cache (READ
+	// before any FSINFO) fetch it once and populate it.
+	count := req.Count
+	maxReadSize := fsMaxReadSize.Load()
+	if maxReadSize == 0 {
+		if caps, capErr := metaSvc.GetFilesystemCapabilities(ctx.Context, fileHandle); capErr == nil && caps != nil {
+			maxReadSize = caps.MaxReadSize
+			cacheMax(&fsMaxReadSize, maxReadSize)
+		}
+	}
+	if maxReadSize > 0 && count > maxReadSize {
+		logger.DebugCtx(ctx.Context, "READ: short-read to advertised rtmax",
+			"requested", count, "rtmax", maxReadSize, "client", clientIP)
+		count = maxReadSize
+	}
+
 	// Calculate actual read length (clamped to file size)
-	readEnd := min(req.Offset+uint64(req.Count), file.Size)
+	readEnd := min(req.Offset+uint64(count), file.Size)
 	actualLength := uint32(readEnd - req.Offset)
 
 	// All reads go through BlockStore.ReadAt which reads from block store.

--- a/internal/adapter/nfs/v3/handlers/read_test.go
+++ b/internal/adapter/nfs/v3/handlers/read_test.go
@@ -452,3 +452,60 @@ func TestRead_PermissionGranted(t *testing.T) {
 	assert.EqualValues(t, types.NFS3OK, resp.Status)
 	assert.Equal(t, content, resp.Data)
 }
+
+// TestRead_ShortReadToAdvertisedRtmax verifies a READ whose Count exceeds the
+// advertised rtmax (FSINFO MaxReadSize) is served short rather than sizing a
+// buffer from the client-supplied Count. RFC 1813 Section 3.3.6 lets the server
+// return fewer bytes than requested; Eof stays false so the client re-reads the
+// remainder.
+func TestRead_ShortReadToAdvertisedRtmax(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	caps, err := fx.MetaStore.GetFilesystemCapabilities(fx.Context().Context, fx.RootHandle)
+	require.NoError(t, err)
+	const rtmax = uint32(16)
+	caps.MaxReadSize = rtmax
+	fx.MetaStore.SetFilesystemCapabilities(*caps)
+
+	content := []byte("0123456789abcdefghijklmnopqrstuv")
+	fileHandle := fx.CreateFile("big.txt", content)
+
+	resp, err := fx.Handler.Read(fx.Context(), &handlers.ReadRequest{
+		Handle: fileHandle,
+		Offset: 0,
+		Count:  1 << 20, // far beyond both rtmax and the file size
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, types.NFS3OK, resp.Status, "over-large READ should short-read, not error")
+
+	assert.EqualValues(t, rtmax, resp.Count, "Count must reflect the clamped byte total")
+	assert.Equal(t, content[:rtmax], resp.Data, "no more than rtmax bytes may be materialized")
+	assert.False(t, resp.Eof, "a clamped read that stopped short of EOF must not report EOF")
+}
+
+// TestRead_UnknownRtmaxServesUnclamped verifies the clamp fails safe when the
+// advertised rtmax is unknown (zero): the read is served in full rather than
+// clamped to zero bytes, which a client would see as data loss.
+func TestRead_UnknownRtmaxServesUnclamped(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	caps, err := fx.MetaStore.GetFilesystemCapabilities(fx.Context().Context, fx.RootHandle)
+	require.NoError(t, err)
+	caps.MaxReadSize = 0
+	fx.MetaStore.SetFilesystemCapabilities(*caps)
+
+	content := []byte("rtmax unknown, serve everything")
+	fileHandle := fx.CreateFile("unclamped.txt", content)
+
+	resp, err := fx.Handler.Read(fx.Context(), &handlers.ReadRequest{
+		Handle: fileHandle,
+		Offset: 0,
+		Count:  1 << 20, // a Count a populated rtmax would have clamped
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, types.NFS3OK, resp.Status)
+
+	assert.EqualValues(t, len(content), resp.Count, "an unknown rtmax must not clamp the read to zero")
+	assert.Equal(t, content, resp.Data)
+	assert.True(t, resp.Eof)
+}

--- a/internal/adapter/nfs/v3/handlers/write.go
+++ b/internal/adapter/nfs/v3/handlers/write.go
@@ -163,11 +163,11 @@ func (h *Handler) Write(
 	// lookup. On a cold cache (WRITE before any FSINFO) we fetch once and
 	// populate it; the common mount sequence (FSINFO precedes WRITE) keeps the
 	// store off the hot WRITE path entirely.
-	maxWriteSize := cachedMaxWriteSize()
+	maxWriteSize := fsMaxWriteSize.Load()
 	if maxWriteSize == 0 {
 		if caps, capErr := metaSvc.GetFilesystemCapabilities(ctx.Context, fileHandle); capErr == nil && caps != nil {
 			maxWriteSize = caps.MaxWriteSize
-			setMaxWriteSize(maxWriteSize)
+			cacheMax(&fsMaxWriteSize, maxWriteSize)
 		}
 	}
 	if maxWriteSize > 0 && uint32(len(req.Data)) > maxWriteSize {

--- a/internal/adapter/nfs/v3/handlers/write_codec.go
+++ b/internal/adapter/nfs/v3/handlers/write_codec.go
@@ -189,47 +189,11 @@ func (resp *WriteResponse) Encode() ([]byte, error) {
 		return nil, fmt.Errorf("failed to write status: %w", err)
 	}
 
-	// Write WCC data (Weak Cache Consistency)
-	// WCC data is included in both success and error cases to help
-	// clients maintain cache consistency.
+	// WCC (Weak Cache Consistency) data is included in both success and error
+	// cases to help clients maintain cache consistency.
 
-	// Write pre-op attributes
-	if resp.AttrBefore != nil {
-		// Present flag = TRUE (1)
-		if err := binary.Write(&buf, binary.BigEndian, uint32(1)); err != nil {
-			return nil, fmt.Errorf("failed to write pre-op present flag: %w", err)
-		}
-
-		// Write WCC attributes (size, mtime, ctime)
-		if err := binary.Write(&buf, binary.BigEndian, resp.AttrBefore.Size); err != nil {
-			return nil, fmt.Errorf("failed to write pre-op size: %w", err)
-		}
-
-		if err := binary.Write(&buf, binary.BigEndian, resp.AttrBefore.Mtime.Seconds); err != nil {
-			return nil, fmt.Errorf("failed to write pre-op mtime seconds: %w", err)
-		}
-
-		if err := binary.Write(&buf, binary.BigEndian, resp.AttrBefore.Mtime.Nseconds); err != nil {
-			return nil, fmt.Errorf("failed to write pre-op mtime nseconds: %w", err)
-		}
-
-		if err := binary.Write(&buf, binary.BigEndian, resp.AttrBefore.Ctime.Seconds); err != nil {
-			return nil, fmt.Errorf("failed to write pre-op ctime seconds: %w", err)
-		}
-
-		if err := binary.Write(&buf, binary.BigEndian, resp.AttrBefore.Ctime.Nseconds); err != nil {
-			return nil, fmt.Errorf("failed to write pre-op ctime nseconds: %w", err)
-		}
-	} else {
-		// Present flag = FALSE (0)
-		if err := binary.Write(&buf, binary.BigEndian, uint32(0)); err != nil {
-			return nil, fmt.Errorf("failed to write pre-op absent flag: %w", err)
-		}
-	}
-
-	// Write post-op attributes
-	if err := xdr.EncodeOptionalFileAttr(&buf, resp.AttrAfter); err != nil {
-		return nil, fmt.Errorf("failed to encode post-op attributes: %w", err)
+	if err := xdr.EncodeWccData(&buf, resp.AttrBefore, resp.AttrAfter); err != nil {
+		return nil, fmt.Errorf("failed to encode wcc data: %w", err)
 	}
 
 	// Error case: Return early if status is not OK

--- a/internal/adapter/nfs/v4/handlers/io_test.go
+++ b/internal/adapter/nfs/v4/handlers/io_test.go
@@ -1372,3 +1372,82 @@ func TestCommit_PermissionGranted(t *testing.T) {
 		t.Errorf("COMMIT by the file owner status = %d, want NFS4_OK", result.Status)
 	}
 }
+
+// createNonRegular creates a non-regular, non-directory object and returns its handle.
+func (fx *ioTestFixture) createNonRegular(t *testing.T, name string, fileType metadata.FileType) metadata.FileHandle {
+	t.Helper()
+
+	var uid, gid uint32
+	authCtx := &metadata.AuthContext{
+		Context:    context.Background(),
+		ClientAddr: "test:9999",
+		AuthMethod: "unix",
+		Identity:   &metadata.Identity{UID: &uid, GID: &gid},
+	}
+
+	attr := &metadata.FileAttr{Mode: 0o644}
+
+	var file *metadata.File
+	var err error
+	if fileType == metadata.FileTypeSymlink {
+		file, _, err = fx.metaSvc.CreateSymlink(authCtx, fx.rootHandle, name, "/target", attr)
+	} else {
+		file, _, err = fx.metaSvc.CreateSpecialFile(authCtx, fx.rootHandle, name, fileType, attr, 1, 3)
+	}
+	if err != nil {
+		t.Fatalf("create %q: %v", name, err)
+	}
+
+	fh, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		t.Fatalf("encode handle: %v", err)
+	}
+	return fh
+}
+
+// TestReadNonRegularType pins the per-file-type error READ and READ_PLUS owe a
+// client that reads a non-regular filehandle (see readTypeError for the RFC
+// derivation). Collapsing every non-regular type to NFS4ERR_ISDIR tells a
+// client a FIFO is a directory.
+func TestReadNonRegularType(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	// READ and READ_PLUS decode the same stateid/offset/count argument triple.
+	args := encodeReadArgs(&anonymousStateid, 0, 1024)
+
+	cases := []struct {
+		name     string
+		fileType metadata.FileType
+		want     uint32
+	}{
+		{"directory", metadata.FileTypeDirectory, types.NFS4ERR_ISDIR},
+		{"symlink", metadata.FileTypeSymlink, types.NFS4ERR_SYMLINK},
+		{"fifo", metadata.FileTypeFIFO, types.NFS4ERR_INVAL},
+		{"socket", metadata.FileTypeSocket, types.NFS4ERR_INVAL},
+		{"blockdev", metadata.FileTypeBlockDevice, types.NFS4ERR_INVAL},
+		{"chardev", metadata.FileTypeCharDevice, types.NFS4ERR_INVAL},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var handle metadata.FileHandle
+			if tc.fileType == metadata.FileTypeDirectory {
+				handle = fx.createDirectory(t, fx.rootHandle, "dir_"+tc.name)
+			} else {
+				handle = fx.createNonRegular(t, "obj_"+tc.name, tc.fileType)
+			}
+
+			ctx := newRealFSContext(0, 0)
+			ctx.CurrentFH = handle
+			if got := fx.handler.handleRead(ctx, bytes.NewReader(args)).Status; got != tc.want {
+				t.Errorf("READ status = %d, want %d", got, tc.want)
+			}
+
+			ctx = newRealFSContext(0, 0)
+			ctx.CurrentFH = handle
+			if got := fx.handler.handleReadPlus(ctx, bytes.NewReader(args)).Status; got != tc.want {
+				t.Errorf("READ_PLUS status = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/read.go
+++ b/internal/adapter/nfs/v4/handlers/read.go
@@ -144,10 +144,11 @@ func (h *Handler) handleRead(ctx *types.CompoundContext, reader io.Reader) *type
 
 	// Verify it's a regular file
 	if file.Type != metadata.FileTypeRegular {
+		status := readTypeError(file.Type)
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_ISDIR,
+			Status: status,
 			OpCode: types.OP_READ,
-			Data:   encodeStatusOnly(types.NFS4ERR_ISDIR),
+			Data:   encodeStatusOnly(status),
 		}
 	}
 
@@ -218,6 +219,27 @@ func (h *Handler) handleRead(ctx *types.CompoundContext, reader io.Reader) *type
 		"client", ctx.ClientAddr)
 
 	return encodeRead4resok(eof, readResult.Data)
+}
+
+// readTypeError maps a non-regular file type to the error READ and READ_PLUS
+// must report for it.
+//
+// RFC 7530 Section 16.23.4: a directory is NFS4ERR_ISDIR, "otherwise,
+// NFS4ERR_INVAL is returned". RFC 5661 Section 18.22.3 — which RFC 7862
+// Section 15.10.3 makes READ_PLUS inherit — splits a symbolic link out of that
+// "otherwise" case as NFS4ERR_SYMLINK, an error RFC 7530 Section 13.2 also
+// lists as valid for READ. The remaining types (block/char device, socket,
+// FIFO) stay NFS4ERR_INVAL rather than RFC 5661's NFS4ERR_WRONG_TYPE, which
+// does not exist in RFC 7530 — this handler serves v4.0 compounds as well.
+func readTypeError(fileType metadata.FileType) uint32 {
+	switch fileType {
+	case metadata.FileTypeDirectory:
+		return types.NFS4ERR_ISDIR
+	case metadata.FileTypeSymlink:
+		return types.NFS4ERR_SYMLINK
+	default:
+		return types.NFS4ERR_INVAL
+	}
 }
 
 // encodeRead4resok encodes a successful READ4 response.

--- a/internal/adapter/nfs/v4/handlers/read_plus.go
+++ b/internal/adapter/nfs/v4/handlers/read_plus.go
@@ -93,7 +93,7 @@ func (h *Handler) handleReadPlus(ctx *types.CompoundContext, reader io.Reader) *
 		return readPlusErr(common.MapToNFS4(err))
 	}
 	if file.Type != metadata.FileTypeRegular {
-		return readPlusErr(types.NFS4ERR_ISDIR)
+		return readPlusErr(readTypeError(file.Type))
 	}
 
 	// Empty file or read entirely past EOF: an empty content array with EOF set.
@@ -149,13 +149,13 @@ func (h *Handler) buildReadPlusContents(ctx *types.CompoundContext, file *metada
 	// Derive the data/hole segmentation from the block-store engine's full
 	// multi-tier data view (append-log + in-memory + persisted CAS) — the same
 	// view READ reconstructs — so READ_PLUS never reports a hole where written-
-	// but-not-yet-rolled-up data exists (RFC 7862, #1481). Resolving the engine
+	// but-not-yet-rolled-up data exists (RFC 7862). Resolving the engine
 	// here also reuses it for the data-run reads below. Fall back to the CAS
 	// block list if the engine can't be resolved or DataExtents errors, so
 	// READ_PLUS never regresses (including the all-hole/no-registry path, which
 	// must stay lazy — see the data-run guard below).
 	var blockStore *engine.Store
-	segs := block.Segments(file.Blocks, file.Size)
+	var segs []block.Segment
 	if h.Registry != nil {
 		if bs, err := common.ResolveForRead(ctx.Context, h.Registry, metadata.FileHandle(ctx.CurrentFH)); err == nil {
 			blockStore = bs
@@ -163,6 +163,9 @@ func (h *Handler) buildReadPlusContents(ctx *types.CompoundContext, file *metada
 				segs = block.SegmentsExtents(ext, file.Size)
 			}
 		}
+	}
+	if len(segs) == 0 {
+		segs = block.Segments(file.Blocks, file.Size)
 	}
 	var contents []readPlusContent
 


### PR DESCRIPTION
Four MEDIUM data-plane audit findings in the NFS adapters. Each was re-verified against the source before fixing; all four held.

## 1. READ / READ_PLUS returned NFS4ERR_ISDIR for every non-regular file type

`v4/handlers/read.go` and `v4/handlers/read_plus.go` both collapsed `file.Type != FileTypeRegular` to `NFS4ERR_ISDIR`, so a client reading a symlink, FIFO, socket, or device node was told it had hit a directory.

Spec, quoted verbatim:

- RFC 7530 Section 16.23.4 (NFSv4.0 READ): "If the current filehandle is not a regular file, an error will be returned to the client.  In the case where the current filehandle represents a directory, NFS4ERR_ISDIR is returned; otherwise, NFS4ERR_INVAL is returned."
- RFC 5661 Section 18.22.3 (NFSv4.1 READ): "In the case that the current filehandle represents an object of type NF4DIR, NFS4ERR_ISDIR is returned.  If the current filehandle designates a symbolic link, NFS4ERR_SYMLINK is returned.  In all other cases, NFS4ERR_WRONG_TYPE is returned."
- RFC 7862 Section 15.10.3 (READ_PLUS): "The READ_PLUS operation is based upon the NFSv4.1 READ operation (see Section 18.22 of [RFC5661]) and similarly reads data from the regular file identified by the current filehandle." — so READ_PLUS inherits that mapping.

Both sites now go through one helper: directory to `NFS4ERR_ISDIR`, symbolic link to `NFS4ERR_SYMLINK`, everything else to `NFS4ERR_INVAL`.

`NFS4ERR_SYMLINK` is deliberate rather than folded into RFC 7530's "otherwise": RFC 7530 Section 13.2 lists it among READ's valid errors, Section 13.1.2.8 defines it as exactly this condition ("The current filehandle designates a symbolic link when the current operation does not allow a symbolic link as the target."), and RFC 5661 requires it for v4.1+.

`NFS4ERR_INVAL` (not RFC 5661's `NFS4ERR_WRONG_TYPE`) is used for the remaining types because `WRONG_TYPE` (10083) does not exist in RFC 7530 and `handleRead` is registered in the v4.0 dispatch table, which v4.1 and v4.2 compounds fall back to. This is the same choice Linux nfsd makes in `nfsd_mode_check`: `nfserr_symlink` for a symlink on any NFSv4 minor version, `nfserr_inval` for the rest.

## 2. NFSv3 READ had no rtmax clamp

`v3/handlers/read.go` sized its read purely from the client-supplied `Count`, bounded only by a 1 GB validation ceiling. Above the buffer pool's largest size class that falls through to a bare `make()`, so a remote client could drive an unpooled allocation of up to ~1 GB per RPC against a large file, with nothing tying it to the `rtmax` the server advertises in FSINFO. WRITE already clamps to `wtmax`; READ was the asymmetric side.

READ now clamps `Count` to that advertised `rtmax`. RFC 1813 Section 3.3.6 lets the server return fewer bytes than requested, so an over-large `Count` is served short (reply `Count` and `Eof` describe the bytes actually read) rather than rejected, and the client re-reads the remainder.

The value comes from `GetFilesystemCapabilities().MaxReadSize` via the existing process-global caps cache, so the limit cannot drift from what FSINFO told the client and the hot READ path does not hit the store.

Fail-safe on a miss: a zero (unknown) `rtmax` means no clamp, never a clamp to zero. On a cold cache the value is fetched once synchronously and stored; if that fetch fails the read is served unclamped. `TestRead_UnknownRtmaxServesUnclamped` pins this, because clamping to a zero-value `rtmax` would turn every READ into a zero-length read and look like data loss to a client.

## 3. READ_PLUS computed block segments it then discarded

`buildReadPlusContents` ran `block.Segments(file.Blocks, file.Size)` unconditionally, then overwrote the result with `block.SegmentsExtents(...)` on the registry-configured path, which is the normal one. `block.Segments` sorts and merges the file's chunk refs, so a large file paid an O(n log n) sort plus two slice allocations per READ_PLUS for a value that was thrown away. It is now computed only when the block-engine extent path did not yield segments.

## 4. WRITE reply hand-rolled its wcc_data encoding

`v3/handlers/write_codec.go` open-coded the pre-op present flag plus size/mtime/ctime and then called `xdr.EncodeOptionalFileAttr` for the post-op half, which is byte-for-byte what `xdr.EncodeWccData` already does. Every other mutating v3 codec (COMMIT, SETATTR, CREATE, MKDIR, RMDIR, REMOVE, RENAME, LINK, SYMLINK, MKNOD) already reuses the helper; WRITE was the only holdout. Replaced with the helper call.

## Tests

- `TestReadNonRegularType` (v4) asserts the errno per file type for both READ and READ_PLUS across directory, symlink, FIFO, socket, block device, and char device.
- `TestRead_ShortReadToAdvertisedRtmax` (v3) asserts an oversized `Count` is served clamped: reply `Count` equals `rtmax`, the returned buffer is exactly `rtmax` bytes, and `Eof` stays false.
- `TestRead_UnknownRtmaxServesUnclamped` (v3) asserts the cache-miss path serves the full read rather than clamping to zero.

All three were confirmed to fail against the pre-fix code before being kept.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l .` all clean.
- `go test ./internal/adapter/nfs/...`: 23 packages ok, 2223 tests pass, 0 fail.

Relates to #1900

Not touched: the COMMIT authorization finding in `v3/handlers/commit.go`, which is tracked under #1918 and already landed on develop.
